### PR TITLE
separate out fb specific deps when building cargo.toml for OSS (2nd try)

### DIFF
--- a/hyperactor_telemetry/Cargo.toml
+++ b/hyperactor_telemetry/Cargo.toml
@@ -28,7 +28,6 @@ tracing-subscriber = { version = "0.3.18", features = ["chrono", "env-filter", "
 
 [features]
 default = []
-fbcode_build = ["fbinit", "scuba"]
 
 [lints]
 rust = { unexpected_cfgs = { check-cfg = ["cfg(fbcode_build)"], level = "warn" } }


### PR DESCRIPTION
Summary: try to avoid cargo trying to resolve meta libraries.

Differential Revision: D74767959
