### PR TITLE
Fix errant cuda stream syncs and tensor serializations in remote function impl

### DIFF
--- a/monarch_worker/src/stream.rs
+++ b/monarch_worker/src/stream.rs
@@ -822,9 +822,6 @@ impl StreamActor {
             // Execute the borrow.
             let _borrow = multiborrow.borrow()?;
 
-            tracing::debug!(
-                "calling python function: {function:?} with args: {py_args:?} and kwargs: {py_kwargs:?}"
-            );
             // Call function.
             // Use custom subscriber to route Worker messages to stdout.
             let scoped_subscriber = Subscriber::builder().with_writer(std::io::stdout).finish();
@@ -850,7 +847,6 @@ impl StreamActor {
                         )
                         .map_err(SerializablePyErr::from_fn(py))
                 })?;
-            tracing::debug!("python function: {function:?} result: {result:?}");
 
             // Parse the python result as an `Object`, which should preserve the
             // original Python object structure, while providing access to the

--- a/torch-sys/src/bridge.h
+++ b/torch-sys/src/bridge.h
@@ -86,6 +86,7 @@ rust::Vec<int32_t> sizes(const Tensor& tensor);
 
 FFIPyObject arbitrary_ivalue_to_py_object(IValue val);
 IValue ivalue_from_arbitrary_py_object(FFIPyObject obj);
+bool py_object_is_ivalue(FFIPyObject obj);
 
 inline IValue ivalue_from_py_object_with_type(
     FFIPyObject obj,
@@ -105,12 +106,15 @@ FFIPyObject device_to_py_object(c10::Device device);
 
 c10::ScalarType scalar_type_from_py_object(FFIPyObject obj);
 FFIPyObject scalar_type_to_py_object(c10::ScalarType scalar_type);
+bool py_object_is_scalar_type(FFIPyObject obj);
 
 c10::Layout layout_from_py_object(FFIPyObject obj);
 FFIPyObject layout_to_py_object(c10::Layout layout);
+bool py_object_is_layout(FFIPyObject obj);
 
 c10::MemoryFormat memory_format_from_py_object(FFIPyObject obj);
 FFIPyObject memory_format_to_py_object(c10::MemoryFormat memory_format);
+bool py_object_is_memory_format(FFIPyObject obj);
 
 FFIPyObject tensor_to_py_object(Tensor tensor);
 Tensor tensor_from_py_object(FFIPyObject obj);

--- a/torch-sys/src/bridge.rs
+++ b/torch-sys/src/bridge.rs
@@ -209,10 +209,12 @@ pub(crate) mod ffi {
         // Layout
         fn layout_from_py_object(obj: FFIPyObject) -> Result<Layout>;
         fn layout_to_py_object(layout: Layout) -> FFIPyObject;
+        fn py_object_is_layout(obj: FFIPyObject) -> bool;
 
         // MemoryFormat
         fn memory_format_from_py_object(obj: FFIPyObject) -> Result<MemoryFormat>;
         fn memory_format_to_py_object(memory_format: MemoryFormat) -> FFIPyObject;
+        fn py_object_is_memory_format(obj: FFIPyObject) -> bool;
 
         // Tensor
         fn tensor_from_py_object(obj: FFIPyObject) -> Result<Tensor>;
@@ -273,6 +275,7 @@ pub(crate) mod ffi {
         // Convert to Python object.
         fn scalar_type_from_py_object(obj: FFIPyObject) -> Result<ScalarType>;
         fn scalar_type_to_py_object(scalar_type: ScalarType) -> FFIPyObject;
+        fn py_object_is_scalar_type(obj: FFIPyObject) -> bool;
 
         /// # Safety
         /// - **Mutability**:
@@ -322,6 +325,7 @@ pub(crate) mod ffi {
         // Interop with Python object.
         fn arbitrary_ivalue_to_py_object(val: IValue) -> Result<FFIPyObject>;
         fn ivalue_from_arbitrary_py_object(obj: FFIPyObject) -> Result<IValue>;
+        fn py_object_is_ivalue(obj: FFIPyObject) -> bool;
         /// Converts the provided Python object to an `IValue` with the provided
         /// type. If the object is not convertible to the provided type, an
         /// exception will be thrown.

--- a/torch-sys/src/ivalue.rs
+++ b/torch-sys/src/ivalue.rs
@@ -301,6 +301,11 @@ impl IValue {
                 ))
             })
     }
+
+    pub(crate) fn from_py_object_or_none(obj: &Bound<'_, PyAny>) -> Option<IValue> {
+        ffi::py_object_is_ivalue(obj.clone().into())
+            .then(|| ffi::ivalue_from_arbitrary_py_object(obj.into()).unwrap())
+    }
 }
 
 // impl `From` for all IValue kinds.

--- a/torch-sys/src/layout.rs
+++ b/torch-sys/src/layout.rs
@@ -14,6 +14,13 @@ unsafe impl ExternType for Layout {
     type Kind = cxx::kind::Trivial;
 }
 
+impl Layout {
+    pub(crate) fn from_py_object_or_none(obj: &Bound<'_, PyAny>) -> Option<Self> {
+        ffi::py_object_is_layout(obj.clone().into())
+            .then(|| ffi::layout_from_py_object(obj.into()).unwrap())
+    }
+}
+
 impl FromPyObject<'_> for Layout {
     fn extract_bound(obj: &Bound<'_, PyAny>) -> PyResult<Self> {
         ffi::layout_from_py_object(obj.into()).map_err(|e| {

--- a/torch-sys/src/memory_format.rs
+++ b/torch-sys/src/memory_format.rs
@@ -14,6 +14,13 @@ unsafe impl ExternType for MemoryFormat {
     type Kind = cxx::kind::Trivial;
 }
 
+impl MemoryFormat {
+    pub(crate) fn from_py_object_or_none(obj: &Bound<'_, PyAny>) -> Option<Self> {
+        ffi::py_object_is_memory_format(obj.clone().into())
+            .then(|| ffi::memory_format_from_py_object(obj.into()).unwrap())
+    }
+}
+
 impl FromPyObject<'_> for MemoryFormat {
     fn extract_bound(obj: &Bound<'_, PyAny>) -> PyResult<Self> {
         ffi::memory_format_from_py_object(obj.into()).map_err(|e| {

--- a/torch-sys/src/scalar_type.rs
+++ b/torch-sys/src/scalar_type.rs
@@ -15,6 +15,13 @@ unsafe impl ExternType for ScalarType {
     type Kind = cxx::kind::Trivial;
 }
 
+impl ScalarType {
+    pub(crate) fn from_py_object_or_none(obj: &Bound<'_, PyAny>) -> Option<Self> {
+        ffi::py_object_is_scalar_type(obj.clone().into())
+            .then(|| ffi::scalar_type_from_py_object(obj.into()).unwrap())
+    }
+}
+
 impl FromPyObject<'_> for ScalarType {
     fn extract_bound(obj: &Bound<'_, PyAny>) -> PyResult<Self> {
         ffi::scalar_type_from_py_object(obj.into()).map_err(|e| {


### PR DESCRIPTION
Summary:
This diff fixes two issues related to the remote function implementation inside `StreamActor`:
1. There were two calls to `tracing::debug!` that use the function inputs and outputs as arguments. Even if the log level was set such that the message wasn't printed to the console, this still incurred the overhead of serialization (and therefore, when tensors were involved, synchronizing the host with the cuda stream).
2. The code to extract an `RValue` from a `PyObject` worked by attempting to do a conversion in C++, and if that failed, handling the exception via rust and trying the next `RValue` variant. Each time the conversion failed, the code created a `PyValueError` that serialized the `PyObject` as part of its message. Importantly, the case for tensors was only handled after the cases for `ScalarType`, `Layout`, and `MemoryFormat`. So if the `RValue` was a tensor, we would incur 3 C++ exceptions, 3 cuda stream syncs, and 3 tensor serializations. And this would happen for every tensor in the output of a remote function.

The fixes in this diff are:
1. Remove the `tracing::debug!` calls.
2. Instead of trying an unchecked type conversion and handling the exception, actually check the type before trying to do the conversion.

Differential Revision: D75035191


