### PR TITLE
Add missing init that breaks oss ci

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,5 +61,5 @@ jobs:
         python setup.py install
 
         # Run tests
-        pytest python/tests/ -v -m "not oss_skip"
+        pytest python/tests/ -s -v -m "not oss_skip"
         python python/tests/test_mock_cuda.py


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #15

Differential Revision: [D75088703](https://our.internmc.facebook.com/intern/diff/D75088703/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D75088703/)!