### PR TITLE
Fix warnings in test_controller.py

### DIFF
--- a/python/monarch/_testing.py
+++ b/python/monarch/_testing.py
@@ -98,6 +98,7 @@ class TestingContext:
         num_hosts,
         gpu_per_host,
         activate: bool = True,
+        controller_params=None,
     ) -> Generator[DeviceMesh, None, None]:
         # Create a new system and mesh for test.
         with local_mesh(
@@ -111,6 +112,7 @@ class TestingContext:
                 num_worker_procs=num_hosts * gpu_per_host,
                 gpus_per_host=gpu_per_host,
             ),
+            controller_params=controller_params,
         ) as dm:
             try:
                 if activate:
@@ -129,11 +131,13 @@ class TestingContext:
 
     @contextmanager
     def local_device_mesh(
-        self, num_hosts, gpu_per_host, activate=True, rust=False
+        self, num_hosts, gpu_per_host, activate=True, rust=False, controller_params=None
     ) -> Generator[DeviceMesh, None, None]:
         start = time.time()
         if rust:
-            generator = self.local_rust_device_mesh(num_hosts, gpu_per_host, activate)
+            generator = self.local_rust_device_mesh(
+                num_hosts, gpu_per_host, activate, controller_params=controller_params
+            )
         else:
             generator = self.local_py_device_mesh(num_hosts, gpu_per_host, activate)
         with generator as dm:

--- a/python/monarch/common/tensor.py
+++ b/python/monarch/common/tensor.py
@@ -349,7 +349,7 @@ class Tensor(Referenceable, BaseTensor):
         # because a device mesh also has caches for doing collectives.
         # but this is an easy way to create a MeshSliceTensor until we optimize
         # how we represent mesh slices.
-        slicing = self.mesh(**kwargs)
+        slicing = self.mesh.slice(**kwargs)
         return MeshSliceTensor(self, slicing)
 
     def delete_ref(self, ref: int):
@@ -432,7 +432,7 @@ class MeshSliceTensor:
                 for dim in broadcast_dims
             ]
             destinations = [
-                mesh(**dict(dim_settings)).processes
+                mesh.slice(**dict(dim_settings)).processes
                 for dim_settings in itertools.product(*dim_sequences)
             ]
         else:


### PR DESCRIPTION
Summary: Fix warnings related to mesh slicing in `test_controller.py`, and update the file to use `TestingContext` in order to deal with device mesh shutdown warnings.

Reviewed By: colin2328

Differential Revision: D75106997


