### PR TITLE
[monarch/Dockerfile] Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,50 @@
+# Build Command:
+#  $ cd ~/monarch
+#  $ export TAG_NAME=$USER-dev
+#  $ docker build --network=host -t monarch:$TAG_NAME -f Dockerfile .
+FROM pytorch/pytorch:2.7.0-cuda12.6-cudnn9-runtime
+
+# Configure Rust to use http proxy
+RUN mkdir -p /root/.cargo && \
+    cat <<EOF > /root/.cargo/config
+[http]
+proxy = "${http_proxy}"
+[https]
+proxy = "${https_proxy}"
+EOF
+
+# Install native dependencies
+RUN apt-get update -y && \
+    apt-get -y install curl clang libunwind-dev
+
+# Install Rust
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+ENV PATH="/root/.cargo/bin:${PATH}"
+
+WORKDIR /monarch
+
+# Install Python deps as a separate layer to avoid rebuilding if deps do not change
+# TODO extract deps (currently in pyproject.toml and setup.py) into requirements.txt
+# and uncomment the line below in favor of generating requirements.txt
+# COPY requirements.txt .
+RUN cat <<EOF > requirements.txt
+# project-deps (from pyproject.toml and setup.py)
+torch
+pyzmq
+requests
+numpy
+pyre-extensions
+pytest-timeout
+cloudpickle
+pytest-asyncio
+# build-system deps (from pyproject.toml)
+setuptools
+setuptools-rust
+EOF
+
+RUN pip install -r requirements.txt
+
+# Build and install monarch
+COPY . /monarch
+RUN cargo install --path monarch_hyperactor
+RUN python setup.py install


### PR DESCRIPTION
Adds a Dockerfile for monarch. Primarily to be used to run `RemoteProcessAllocator` on jobs running on OSS schedulers.

Testing
---------
0. **Meta-only (on devserver we use podman-docker instead of docker directly)**
     ```
     $ dnf install podman podman-docker
     $ docker context create podman --docker "host=unix://$(podman info --format '{{.Host.RemoteSocket.Path}}')"
     $ systemctl --user enable podman.socket
     $ systemctl --user start podman.socket
     ```
2. Build the docker:
     ```
     $ cd ~/monarch
     $  docker build --network=host -t monarch:$USER-dev -f Dockerfile .
     ```
     This creates a `monarch:kiuk-dev` local docker image (note `--network-host` required in devserver due to fwdproxy)

3. Validate `process-allocator` can be run:
     ```shell
     $ docker run -p 26600:26600 monarch:kiuk-dev process_allocator
     I0527 23:47:34.469562     1 monarch_hyperactor/src/bin/process_allocator/common.rs:45] bind address is: tcp![::]:29500
     I0527 23:47:34.469626     1 monarch_hyperactor/src/bin/process_allocator/common.rs:46] program to spawn on allocation request: [monarch_bootstrap]
     I0527 23:47:34.469695     1 hyperactor_mesh/src/alloc/remoteprocess.rs:146] starting remote allocator on: tcp![::]:29500
     ```

NOTE: the last line `python setup.py install` doesn't work right now and fails with:
```
STEP 11/11: RUN python setup.py install
Traceback (most recent call last):
  File "/monarch/setup.py", line 54, in <module>
    os.environ.update(
  File "<frozen _collections_abc>", line 949, in update
  File "<frozen os>", line 684, in __setitem__
  File "<frozen os>", line 758, in encode
TypeError: str expected, not NoneType
Error: building at STEP "RUN python setup.py install": while running runtime: exit status 1
```
I need to fix this but the main functionality of this docker image is to be able to run the remote process allocator on k8s/slurm