### PR TITLE
telemetry: fix build

### DIFF
--- a/hyperactor_extension/src/telemetry.rs
+++ b/hyperactor_extension/src/telemetry.rs
@@ -11,10 +11,7 @@
 use pyo3::prelude::*;
 
 /// Log a message with the given metadata
-#[pyfunction(
-    name = "forward_o_tracing",
-    module = "monarch._rust_bindings.hyperactor_extension.alloc"
-)]
+#[pyfunction]
 pub fn forward_to_tracing(message: &str, file: &str, lineno: i64, level: i32) {
     // Map level number to level name
     match level {


### PR DESCRIPTION
Summary:
```
devgpu014=/d/u/m/fbsource% buck2 build --config fbcode.enable_gpu_sections=true --config fbcode.nvcc_arch=a100,h100a --config hpc_comms.use_nccl=2.18.3 --flagfile fbcode//mode/dev-nosan fbcode//monarch/monarch_hyperactor:monarch_hyperactor                                                                             (base)
Starting new buck2 daemon...
Connected to new buck2 daemon.
Watchman fresh instance: new mergebase, cleared graph state, cleared dep files
Action failed: fbcode//monarch/hyperactor_extension:hyperactor_extension (rustc check)
Local command returned non-zero exit code 1
Reproduce locally: `env -- 'BUCK_SCRATCH_PATH=buck-out/v2/tmp/fbcode/54309b42e50aedc2/rustc/check' /usr/local/fbcode/pla ...<omitted>... arch/hyperactor_extension/__hyperactor_extension__/LPPM/hyperactor_extension-metadata-fast-diag.args (run `buck2 log what-failed` to get the full command)`
stdout:
stderr:
error: expected one of: `name`, `pass_module`, `signature`, `text_signature`, `crate`
  --> fbcode/monarch/hyperactor_extension/src/telemetry.rs:16:5
   |
16 |     module = "monarch._rust_bindings.hyperactor_extension.alloc"
   |     ^^^^^^


error[E0432]: unresolved import `forward_to_tracing`
  --> third-party/rust/vendor/pyo3-0.22.6/src/macros.rs:136:1
   |
   = note: in this expansion of `wrap_pyfunction!`
  ::: third-party/rust/vendor/pyo3-0.22.6/src/macros.rs:147:13
   |
   = note: no external crate `forward_to_tracing`
   |
  ::: fbcode/monarch/hyperactor_extension/src/telemetry.rs:33:13
   |
33 |     let f = wrap_pyfunction!(forward_to_tracing, module)?;
   |             -------------------------------------------- in this macro invocation


Target `fbcode//monarch/hyperactor_extension:hyperactor_extension` has unused dependencies:
    fbsource//third-party/rust:tracing: tracing
error: aborting due to 2 previous errors
```

Reviewed By: colin2328

Differential Revision: D75556789


