### PR TITLE
Add Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+.git
+.github
+.pyre
+docs
+*_meta/**
+**/*_meta/**
+**/*_meta.rs
+**/meta/**

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,51 @@
+# Pre-reqs:
+#  1. podman (shown below) or just docker
+#     $ dnf install -y podman podman-docker
+#  2. NVIDIA container toolkit
+#     $ dnf install -y nvidia-container-toolkit
+#
+# Build:
+#  $ cd ~/monarch
+#  $ export TAG_NAME=$USER-dev
+#  $ docker build --network=host \
+#     -t monarch:$TAG_NAME \
+#     -f Dockerfile .
+#
+# Build (with http proxy):
+#  $ docker build --network=host \
+#     --build-arg=http_proxy=$http_proxy \
+#     --build-arg=https_proxy=$https_proxy \
+#     -t monarch:$TAG_NAME \
+#     -f Dockerfile .
+#
+ARG http_proxy
+ARG https_proxy
+
+FROM pytorch/pytorch:2.7.0-cuda12.6-cudnn9-devel
+WORKDIR /monarch
+
+# export http proxy env vars if build-args are provided
+RUN if [ -n "${http_proxy}" ]; then export http_proxy=${http_proxy}; fi && \
+    if [ -n "${https_proxy}" ]; then export https_proxy=${https_proxy}; fi
+
+# Install native dependencies
+RUN apt-get update -y && \
+    apt-get -y install curl clang liblzma-dev libunwind-dev
+
+# Install Rust
+ENV PATH="/root/.cargo/bin:${PATH}"
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+
+# Install Python build deps
+RUN pip install --no-cache-dir setuptools-rust
+
+# Install Python deps as a separate layer to avoid rebuilding if deps do not change
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Install monarch
+COPY . .
+# currently monarch/pyproject.toml uses meta-internal build-backend, just use setup.py
+RUN rm pyproject.toml
+RUN cargo install --path monarch_hyperactor
+RUN pip install .

--- a/controller/build.rs
+++ b/controller/build.rs
@@ -20,4 +20,6 @@ fn main() {
 
     // Disable new dtags, as conda envs generally use `RPATH` over `RUNPATH`.
     println!("cargo::rustc-link-arg=-Wl,--disable-new-dtags");
+
+    println!("cargo:rustc-link-lib=lzma");
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,10 @@
 [build-system]
-requires = ["setuptools", "torch", "setuptools-rust", "wheel"]
+requires = [
+    "torch",
+    "setuptools",
+    "setuptools-rust",
+    "wheel"
+]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -10,8 +15,21 @@ authors = [
 version = "1.0"
 readme = "README.md"
 description = "Monarch: Single controller library"
-dependencies = ["torch", "pyzmq", "requests", "numpy", "pyre-extensions", "pytest-timeout", "cloudpickle", "pytest-asyncio"]
+dependencies = [
+    "torch",
+    "pyzmq",
+    "requests",
+    "numpy",
+    "pyre-extensions",
+    "pytest-timeout",
+    "cloudpickle",
+    "pytest-asyncio"
+]
 requires-python = ">= 3.10"
+dynamic = [
+    "scripts", # tells pip to use console scripts defined in setup.py
+]
+
 
 [tool.pytest.ini_options]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+torch
+pyzmq
+requests
+numpy
+pyre-extensions
+pytest-timeout
+cloudpickle

--- a/setup.py
+++ b/setup.py
@@ -100,6 +100,9 @@ class Clean(Command):
         subprocess.run(["cargo", "clean"])
 
 
+with open("requirements.txt") as f:
+    reqs = f.read()
+
 setup(
     name="monarch",
     version="1.0",
@@ -108,15 +111,7 @@ setup(
         exclude=["python/tests.*", "python/tests"],
     ),
     package_dir={"": "python"},
-    install_requires=[
-        "torch",
-        "pyzmq",
-        "requests",
-        "numpy",
-        "pyre-extensions",
-        "pytest-timeout",
-        "cloudpickle",
-    ],
+    install_requires=reqs.strip().split("\n"),
     author="Meta",
     description="Monarch: Single controller library",
     ext_modules=[

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -1,0 +1,7 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict

--- a/tools/components/__init__.py
+++ b/tools/components/__init__.py
@@ -1,0 +1,7 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict


### PR DESCRIPTION
Summary:
Adds a Dockerfile that builds and installs monarch (wheel) and any monarch rust binary crates (e.g. monarch_hyperactor)

For better docker layer caching also extracted `requirements.txt` from `install_dependencies` in `setup.py`

NOTE: I had to add `-llzma` to `controller/build.rs` because compiling the controller crate under ubuntu (pytorch base image) failed due to a linker error on `libzma`. Not sure how this wasn't a problem in `test.yml` in CI.

Reviewed By: colin2328

Differential Revision: D75559660


