### PR TITLE
applying rustfix to remaining fbcode targets

### DIFF
--- a/hyperactor_mesh/src/alloc/remoteprocess.rs
+++ b/hyperactor_mesh/src/alloc/remoteprocess.rs
@@ -1458,7 +1458,8 @@ mod test_alloc {
 
     #[async_timed_test(timeout_secs = 15)]
     async fn test_alloc_simple() {
-        std::env::set_var("MONARCH_MESSAGE_DELIVERY_TIMEOUT_SECS", "1");
+        // TODO: Audit that the environment access only happens in single-threaded code.
+        unsafe { std::env::set_var("MONARCH_MESSAGE_DELIVERY_TIMEOUT_SECS", "1") };
         hyperactor_telemetry::initialize_logging();
 
         let spec = AllocSpec {
@@ -1574,7 +1575,8 @@ mod test_alloc {
 
     #[async_timed_test(timeout_secs = 15)]
     async fn test_alloc_host_failure() {
-        std::env::set_var("MONARCH_MESSAGE_DELIVERY_TIMEOUT_SECS", "1");
+        // TODO: Audit that the environment access only happens in single-threaded code.
+        unsafe { std::env::set_var("MONARCH_MESSAGE_DELIVERY_TIMEOUT_SECS", "1") };
         hyperactor_telemetry::initialize_logging();
 
         let spec = AllocSpec {


### PR DESCRIPTION
Summary: applying changes to the remaining fbcode targets to make them compatible with both 2021 and 2024 rust editions

Reviewed By: dtolnay

Differential Revision: D75525276
