### PR TITLE
: move comm actor tests 1/2

### DIFF
--- a/hyperactor_mesh/src/proc_mesh/mod.rs
+++ b/hyperactor_mesh/src/proc_mesh/mod.rs
@@ -339,6 +339,13 @@ impl ProcMesh {
         &self.comm_actors[0]
     }
 
+    /// Spawn an `ActorMesh` by launching the same actor type on all
+    /// agents, using the **same** parameters instance for every
+    /// actor.
+    ///
+    /// - `actor_name`: Name for all spawned actors.
+    /// - `params`: Reference to the parameter struct, reused for all
+    ///   actors.
     pub async fn spawn<A: Actor + RemoteActor>(
         &self,
         actor_name: &str,
@@ -535,7 +542,6 @@ mod tests {
     use super::*;
     use crate::actor_mesh::test_util::Error;
     use crate::actor_mesh::test_util::TestActor;
-    use crate::alloc::AllocConstraints;
     use crate::alloc::AllocSpec;
     use crate::alloc::Allocator;
     use crate::alloc::local::LocalAllocator;


### PR DESCRIPTION
Summary:
port `hyperactor_multiprocess` broadcast test to `hyperactor_mesh`, ~~add `spawn_with_params` for per-actor param support~~
	- ~~add `spawn_with_params()` to `ProcMesh` for per-actor parameter spawning~~
	- ~~expose `comm_actors()` (`pub crate`) for access to all comm actors in the mesh~~
	- ~~port~~ rewrite (use `ActorMesh<>::cast`) the full broadcast mesh test (`test_comm_actor_cast_system` -> `test_actor_mesh_cast`) from the old multiprocess crate to the new mesh, and remove the legacy version

Reviewed By: mariusae

Differential Revision: D75095504


