### PR TITLE
Add WatermarkAccumulator

### DIFF
--- a/hyperactor/src/mailbox/mod.rs
+++ b/hyperactor/src/mailbox/mod.rs
@@ -1075,7 +1075,7 @@ impl Mailbox {
         let reducer_typehash = accum.reducer_typehash();
         let enqueue = move |update: A::Update| {
             let mut state = state.lock().unwrap();
-            accum.accumulate(&mut state, &update);
+            accum.accumulate(&mut state, update);
             let _ = sender.send(state.clone());
             Ok(())
         };

--- a/hyperactor_mesh/src/comm/mod.rs
+++ b/hyperactor_mesh/src/comm/mod.rs
@@ -762,7 +762,7 @@ mod tests {
         type Update = u64;
         type Reducer = NonReducer;
 
-        fn accumulate(&self, _state: &mut Self::State, _update: &Self::Update) {
+        fn accumulate(&self, _state: &mut Self::State, _update: Self::Update) {
             unimplemented!()
         }
     }


### PR DESCRIPTION
Summary:
We need an accumulator to track the lowest value among ranks. In order to distinguish from regular min accumulator, we call it low watermark accumulator. This diff introduces this accumulator.

This implementation does not do any optimization, and uses a HashMap to store the states. The main focus of this diff is to get the API correct. We will do the optimization in followups.

Reviewed By: mariusae

Differential Revision: D75166323


