### PR TITLE
(monarch/ci) refactor python test dependencies into python/tests/requirements.txt

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,18 +48,17 @@ jobs:
         rustup toolchain install nightly
         rustup default nightly
 
-        # Install torch
-        pip install torch
+        # Install build dependencies
+        pip install -r build-requirements.txt
 
-        # Install Python dependencies
-        pip install setuptools-rust
-        pip install pyzmq requests numpy pyre-extensions
-
-        # Test dependencies
-        pip install pytest cloudpickle pytest-timeout pytest-asyncio
+        # Install test dependencies
+        pip install -r python/tests/requirements.txt
 
         # Build and install monarch
-        python setup.py install
+        # NB: monarch is currently can't be built in isolated builds (e.g not PEP519 compatible)
+        # because 'torch-sys' needs to be compiled against 'torch' in the main python environment
+        # so that libtorch is linked correctly at runtime.
+        pip install --no-build-isolation .
 
         # Run tests
         LC_ALL=C pytest python/tests/ -s -v -m "not oss_skip"

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,16 +36,11 @@ RUN apt-get update -y && \
 ENV PATH="/root/.cargo/bin:${PATH}"
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 
-# Install Python build deps
-RUN pip install --no-cache-dir setuptools-rust
-
 # Install Python deps as a separate layer to avoid rebuilding if deps do not change
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
 # Install monarch
 COPY . .
-# currently monarch/pyproject.toml uses meta-internal build-backend, just use setup.py
-RUN rm pyproject.toml
 RUN cargo install --path monarch_hyperactor
 RUN pip install .

--- a/build-requirements.txt
+++ b/build-requirements.txt
@@ -1,0 +1,4 @@
+torch
+setuptools
+setuptools-rust
+wheel

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,36 +1,3 @@
-[build-system]
-requires = [
-    "torch",
-    "setuptools",
-    "setuptools-rust",
-    "wheel"
-]
-build-backend = "setuptools.build_meta"
-
-[project]
-name = "monarch"
-authors = [
-    {email = "oncall+monarch@xmail.facebook.com"},
-]
-version = "1.0"
-readme = "README.md"
-description = "Monarch: Single controller library"
-dependencies = [
-    "torch",
-    "pyzmq",
-    "requests",
-    "numpy",
-    "pyre-extensions",
-    "pytest-timeout",
-    "cloudpickle",
-    "pytest-asyncio"
-]
-requires-python = ">= 3.10"
-dynamic = [
-    "scripts", # tells pip to use console scripts defined in setup.py
-]
-
-
 [tool.pytest.ini_options]
 
 markers = [

--- a/python/tests/requirements.txt
+++ b/python/tests/requirements.txt
@@ -1,0 +1,3 @@
+pytest
+pytest-timeout
+pytest-asyncio

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,4 @@ pyzmq
 requests
 numpy
 pyre-extensions
-pytest-timeout
 cloudpickle

--- a/setup.py
+++ b/setup.py
@@ -103,6 +103,9 @@ class Clean(Command):
 with open("requirements.txt") as f:
     reqs = f.read()
 
+with open("README.md", encoding="utf8") as f:
+    readme = f.read()
+
 setup(
     name="monarch",
     version="1.0",
@@ -111,9 +114,13 @@ setup(
         exclude=["python/tests.*", "python/tests"],
     ),
     package_dir={"": "python"},
+    python_requires=">= 3.10",
     install_requires=reqs.strip().split("\n"),
     author="Meta",
+    author_email="oncall+monarch@xmail.facebook.com",
     description="Monarch: Single controller library",
+    long_description=readme,
+    long_description_content_type="text/markdown",
     ext_modules=[
         controller_C,
         common_C,


### PR DESCRIPTION
Summary:
Makes it easier to run tests outside of github CI (e.g. on a developer desktop) by running:

```
$ pip install -r python/tests/requirements.txt
$ pytest python/tests -s -v -m "not oss_skip"
```

versus having to install the test deps manually (by copying the command from `.github/workflows/test.yaml`)

```
$ pip install pytest cloudpickle pytest-timeout pytest-asyncio
$ pytest python/tests -s -v -m "not oss_skip"
```

Reviewed By: amirafzali, dcci

Differential Revision: D75629443
