### PR TITLE
eagerly import torch in actor bootstrap

### DIFF
--- a/python/monarch/bootstrap_main.py
+++ b/python/monarch/bootstrap_main.py
@@ -14,6 +14,9 @@ import logging
 import os
 import sys
 
+# Import torch to avoid import-time races if a spawned actor tries to import torch.
+import torch  # noqa[F401]
+
 
 async def main():
     from monarch._rust_bindings.monarch_hyperactor.bootstrap import bootstrap_main


### PR DESCRIPTION
Summary:
T225878580, there seems to be a race where under some conditions we don't fully initialize the torch module before attempting to access it. I suspect this has something to do with the different way that pickle imports globals vs. just normal import statements, but need to confirm.

I will try to root cause it further, but one thing that is certain to work is importing torch before entering into the actor runtime.

Reviewed By: mariusae

Differential Revision: D75645067


