### PR TITLE
notebook example: 'await' on call to make sure reply port remains alive

### DIFF
--- a/examples/notebooks/ping_pong.ipynb
+++ b/examples/notebooks/ping_pong.ipynb
@@ -21,10 +21,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "id": "057bdd93-f218-4192-b71c-16045ad77ffe",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "I0529 17:04:38.195836 2830017 hyperactor_mesh/src/proc_mesh/mod.rs:114] proc _128tEcETi5FK[0] rank 0: created\n",
+      "I0529 17:04:38.196293 2830017 hyperactor_mesh/src/proc_mesh/mod.rs:114] proc _128tEcETi5FK[1] rank 1: created\n",
+      "I0529 17:04:38.196709 2830017 hyperactor_mesh/src/proc_mesh/mod.rs:114] proc _128tEcETi5FK[2] rank 2: created\n",
+      "I0529 17:04:38.197093 2830017 hyperactor_mesh/src/proc_mesh/mod.rs:114] proc _128tEcETi5FK[3] rank 3: created\n",
+      "I0529 17:04:39.233129 2830017 hyperactor_mesh/src/proc_mesh/mod.rs:133] proc _128tEcETi5FK[1] rank 1: running at addr:unix!@choXYEwnmQspRu9iZUgKvF6Q mesh_agent:_128tEcETi5FK[1].mesh[0]<hyperactor_mesh::proc_mesh::mesh_agent::MeshAgent>\n",
+      "I0529 17:04:39.234619 2830017 hyperactor_mesh/src/proc_mesh/mod.rs:133] proc _128tEcETi5FK[3] rank 3: running at addr:unix!@aztljBHYamc5fQB8oKyUptrm mesh_agent:_128tEcETi5FK[3].mesh[0]<hyperactor_mesh::proc_mesh::mesh_agent::MeshAgent>\n",
+      "I0529 17:04:39.238444 2830017 hyperactor_mesh/src/proc_mesh/mod.rs:133] proc _128tEcETi5FK[2] rank 2: running at addr:unix!@8qAmI2Ex2gj3sUNjfm4RkaL3 mesh_agent:_128tEcETi5FK[2].mesh[0]<hyperactor_mesh::proc_mesh::mesh_agent::MeshAgent>\n",
+      "I0529 17:04:39.238497 2830017 hyperactor_mesh/src/proc_mesh/mod.rs:133] proc _128tEcETi5FK[0] rank 0: running at addr:unix!@yXDQEYcGLQnPmb8Un5FX8rpY mesh_agent:_128tEcETi5FK[0].mesh[0]<hyperactor_mesh::proc_mesh::mesh_agent::MeshAgent>\n"
+     ]
+    }
+   ],
    "source": [
     "import asyncio\n",
     "\n",
@@ -49,21 +64,66 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "id": "53bfe107-b4d9-4e33-80b2-dbea14cc4df2",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Identity: 3, msg='hey there, from jupyter!!'\n",
+      "Identity: 2, msg='hey there, from jupyter!!'\n",
+      "Identity: 0, msg='hey there, from jupyter!!'\n",
+      "Identity: 1, msg='hey there, from jupyter!!'\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<monarch.service.ValueMesh at 0x7f98a012b850>"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
-    "# Once actors are spawned, we can call all of them simultaneiously with `Actor.endpoint.call` as below\n",
+    "# Once actors are spawned, we can call all of them simultaneously with `Actor.endpoint.call` as below\n",
     "await toy_actor.hello_world.call(\"hey there, from jupyter!!\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "id": "a1327cdd-45c6-423b-a05c-e0565555109a",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Identity: 0, msg=\"Here's an arbitrary unique value: 0\"\n",
+      "Identity: 0, msg=\"Here's an arbitrary unique value: 1\"\n",
+      "Identity: 0, msg=\"Here's an arbitrary unique value: 2\"\n",
+      "Identity: 0, msg=\"Here's an arbitrary unique value: 3\"\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "[<monarch.service.ValueMesh at 0x7f98a012b8e0>,\n",
+       " <monarch.service.ValueMesh at 0x7f9863baeb60>,\n",
+       " <monarch.service.ValueMesh at 0x7f988af23280>,\n",
+       " <monarch.service.ValueMesh at 0x7f98a012b310>]"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "# We can also specify a single actor using the 'slice' API\n",
     "futures = []\n",
@@ -86,10 +146,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 20,
    "id": "2c9d37c7-e6d9-452d-bde0-589b8757c9e8",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "I0529 17:05:37.904476 2830017 hyperactor_mesh/src/proc_mesh/mod.rs:114] proc _14wENoic4WQM[0] rank 0: created\n",
+      "I0529 17:05:37.904983 2830017 hyperactor_mesh/src/proc_mesh/mod.rs:114] proc _14wENoic4WQM[1] rank 1: created\n",
+      "I0529 17:05:39.065343 2830017 hyperactor_mesh/src/proc_mesh/mod.rs:133] proc _14wENoic4WQM[0] rank 0: running at addr:unix!@tjxHFPUc2tv5w8RYZDOjVTFN mesh_agent:_14wENoic4WQM[0].mesh[0]<hyperactor_mesh::proc_mesh::mesh_agent::MeshAgent>\n",
+      "I0529 17:05:39.070276 2830017 hyperactor_mesh/src/proc_mesh/mod.rs:133] proc _14wENoic4WQM[1] rank 1: running at addr:unix!@yHbPlBV7H43hbCq73DsCoPTQ mesh_agent:_14wENoic4WQM[1].mesh[0]<hyperactor_mesh::proc_mesh::mesh_agent::MeshAgent>\n",
+      "I0529 17:05:39.289522 2830017 hyperactor_mesh/src/proc_mesh/mod.rs:114] proc _1xtVcyVB4hVH[0] rank 0: created\n",
+      "I0529 17:05:39.290061 2830017 hyperactor_mesh/src/proc_mesh/mod.rs:114] proc _1xtVcyVB4hVH[1] rank 1: created\n",
+      "I0529 17:05:40.331259 2830017 hyperactor_mesh/src/proc_mesh/mod.rs:133] proc _1xtVcyVB4hVH[1] rank 1: running at addr:unix!@I3py42AbzUiSqiEEijRbDzjC mesh_agent:_1xtVcyVB4hVH[1].mesh[0]<hyperactor_mesh::proc_mesh::mesh_agent::MeshAgent>\n",
+      "I0529 17:05:40.339197 2830017 hyperactor_mesh/src/proc_mesh/mod.rs:133] proc _1xtVcyVB4hVH[0] rank 0: running at addr:unix!@xXjtJso3xmY5X2gXQ64Ey0fZ mesh_agent:_1xtVcyVB4hVH[0].mesh[0]<hyperactor_mesh::proc_mesh::mesh_agent::MeshAgent>\n"
+     ]
+    }
+   ],
    "source": [
     "import asyncio\n",
     "\n",
@@ -108,7 +183,7 @@
     "    \n",
     "    @endpoint\n",
     "    async def send(self, msg):\n",
-    "        self.other_actor_pair.recv.call(f\"Sender ({self.actor_name}:{self.identity}) {msg=}\")\n",
+    "         await self.other_actor_pair.recv.call(f\"Sender ({self.actor_name}:{self.identity}) {msg=}\")\n",
     "        \n",
     "    @endpoint\n",
     "    async def recv(self, msg):\n",
@@ -132,13 +207,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 25,
    "id": "9b1fcb84-83b2-4465-9ff4-141e5b0c4a16",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[<monarch.service.ValueMesh at 0x7f936a64b220>,\n",
+       " <monarch.service.ValueMesh at 0x7f936a64a8f0>]"
+      ]
+     },
+     "execution_count": 25,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "# Initialize each actor with references to each other\n",
-    "asyncio.gather(\n",
+    "await asyncio.gather(\n",
     "    actor_0.init.call(actor_1),\n",
     "    actor_1.init.call(actor_0),\n",
     ")"
@@ -146,20 +233,58 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 26,
    "id": "1f44a9fb-9ba4-44cd-af29-e32e3a4c7c65",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Pong!, Receiver (actor_1:0) received msg Sender (actor_0:0) msg='Ping'\n",
+      "Pong!, Receiver (actor_1:1) received msg Sender (actor_0:1) msg='Ping'\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<monarch.service.ValueMesh at 0x7f988af22560>"
+      ]
+     },
+     "execution_count": 26,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "await actor_0.send.call(\"Ping\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 27,
    "id": "282b36b6-9348-48a0-92f5-f29d3401009d",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Pong!, Receiver (actor_0:0) received msg Sender (actor_1:0) msg='Ping'\n",
+      "Pong!, Receiver (actor_0:1) received msg Sender (actor_1:1) msg='Ping'\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<monarch.service.ValueMesh at 0x7f936a6497b0>"
+      ]
+     },
+     "execution_count": 27,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "await actor_1.send.call(\"Ping\")"
    ]


### PR DESCRIPTION
Summary:
Without this, we get an 'unroutable' error because the source port no longer exists.

(This is harmless, but not great to have an unexplained error like this in the output of an example.)

Differential Revision: D75648307


