### PR TITLE
: fix 1.87.0 lints

### DIFF
--- a/hyperactor_mesh/src/actor_mesh.rs
+++ b/hyperactor_mesh/src/actor_mesh.rs
@@ -101,6 +101,7 @@ impl<'a, A: RemoteActor> ActorMesh<'a, A> {
 
     /// Cast an [`M`]-typed message to the ranks selected by `sel`
     /// in this ActorMesh.
+    #[allow(clippy::result_large_err)] // TODO: Consider reducing the size of `CastError`.
     pub fn cast<M: RemoteMessage + Clone>(
         &self,
         selection: Selection,

--- a/hyperactor_mesh/src/assign.rs
+++ b/hyperactor_mesh/src/assign.rs
@@ -12,7 +12,6 @@
 
 use std::cmp::min;
 use std::collections::HashMap;
-use std::mem::replace;
 use std::rc::Rc;
 
 use bitmaps::Bitmap;
@@ -88,7 +87,7 @@ where
     /// that previously occupied the rank, if any.
     pub(crate) fn insert(&mut self, rank: usize, value: T) -> Option<T> {
         let value = Rc::new(value);
-        let prev = replace(&mut self.forward[rank], Some(Rc::clone(&value))).map(|prev| {
+        let prev = self.forward[rank].replace(Rc::clone(&value)).map(|prev| {
             // There was a previous value at this rank.
             // Clean up the reverse, and take unwrap the
             // value.
@@ -99,7 +98,7 @@ where
         if let Some(prev_rank) = self.reverse.insert(value, rank) {
             // The value was assigned to another rank, which must
             // now be unassigned.
-            self.forward[prev_rank].take().unwrap(); // must exist in forward            
+            self.forward[prev_rank].take().unwrap(); // must exist in forward
             self.set(prev_rank, false);
         }
         self.set(rank, true);

--- a/hyperactor_mesh/src/proc_mesh/mesh_agent.rs
+++ b/hyperactor_mesh/src/proc_mesh/mesh_agent.rs
@@ -10,7 +10,6 @@
 
 use std::collections::HashMap;
 use std::mem::replace;
-use std::ops::Add;
 use std::sync::Arc;
 use std::sync::Mutex;
 use std::sync::RwLock;


### PR DESCRIPTION
Summary: rust 1.87.0 landed earlier this week and brings with it new clippy lints. fix the `hyperactor_mesh` ones.

Differential Revision: D75680870


