### PR TITLE
: fix up the select_! fiasco

### DIFF
--- a/hyperactor_mesh/src/actor_mesh.rs
+++ b/hyperactor_mesh/src/actor_mesh.rs
@@ -365,28 +365,6 @@ mod tests {
 
     use super::*;
 
-    // Prototype. Replicated from hyperactor_mesh_core for the moment.
-    #[macro_export] // ok since this is only enabled in tests
-    macro_rules! select_ {
-        ($shape:expr_2021, $label:ident = $range:expr_2021) => {
-            ndslice::selection::selection_from_one($shape, stringify!($label), $range).unwrap()
-        };
-
-        ($shape:expr_2021, $($label:ident = $val:literal),* $(,)?) => {
-            ndslice::selection::selection_from($shape,
-                           &[
-                               $((stringify!($label), $val..$val+1)),*
-                           ]).unwrap()
-        };
-
-        ($shape:expr_2021, $($label:ident = $range:expr_2021),* $(,)?) => {
-            ndslice::selection::selection_from($shape, &[
-                $((stringify!($label), $range)),*
-
-            ]).unwrap()
-        };
-    }
-
     // These tests are parametric over allocators.
     #[macro_export]
     macro_rules! actor_mesh_test_suite {
@@ -397,6 +375,7 @@ mod tests {
             use $crate::alloc::AllocSpec;
             use $crate::alloc::Allocator;
             use $crate::assign::Ranks;
+            use $crate::sel_from_shape;
             use ndslice::selection::dsl::*;
             use $crate::proc_mesh::SharedSpawnable;
             use std::collections::VecDeque;
@@ -451,7 +430,7 @@ mod tests {
                 let (reply_handle, mut reply_receiver) = actor_mesh.open_port();
                 actor_mesh
                     .cast(
-                        select_!(actor_mesh.shape(), replica = 0, host = 0),
+                        sel_from_shape!(actor_mesh.shape(), replica = 0, host = 0),
                         GetRank(reply_handle.bind()),
                     )
                     .unwrap();

--- a/hyperactor_mesh/src/lib.rs
+++ b/hyperactor_mesh/src/lib.rs
@@ -31,6 +31,7 @@ pub use bootstrap::bootstrap_or_die;
 pub use comm::CommActor;
 pub use hyperactor_mesh_macros::sel;
 pub use mesh::Mesh;
+pub use ndslice::sel_from_shape;
 pub use ndslice::selection;
 pub use ndslice::shape;
 pub use proc_mesh::ProcMesh;

--- a/hyperactor_mesh/src/proc_mesh/mod.rs
+++ b/hyperactor_mesh/src/proc_mesh/mod.rs
@@ -545,7 +545,7 @@ mod tests {
     use crate::alloc::AllocSpec;
     use crate::alloc::Allocator;
     use crate::alloc::local::LocalAllocator;
-    use crate::select_;
+    use crate::sel_from_shape;
 
     #[tokio::test]
     async fn test_basic() {
@@ -613,7 +613,7 @@ mod tests {
 
         actors
             .cast(
-                select_!(actors.shape(), replica = 0),
+                sel_from_shape!(actors.shape(), replica = 0),
                 Error("failmonkey".to_string()),
             )
             .unwrap();

--- a/ndslice/src/shape.rs
+++ b/ndslice/src/shape.rs
@@ -335,7 +335,10 @@ macro_rules! shape {
     };
 }
 
-/// Perform a sub-selection on the provided shaped object (a `[Shape]`, or a [`crate::Mesh`].
+/// Perform a sub-selection on the provided [`Shape`] object.
+///
+/// This macro chains `.select()` calls to apply multiple labeled
+/// dimension restrictions in a fluent way.
 ///
 /// ```
 /// let s = ndslice::shape!(host = 2, gpu = 8);


### PR DESCRIPTION
Summary: replace the internal `select_!` test macro(s) with a public, documented `sel_from_shape!` macro in `ndslice`, re-exported via `hyperactor_mesh`. it wraps `selection_from[_one]` to construct `Selection`s from labeled shapes. all usages updated accordingly. clean up redundant macro definitions and improve doc-comments.

Reviewed By: mariusae

Differential Revision: D75686684


