### PR TITLE
: selection: add NormalizedSelection and expose selection::normal module (#105)

### DIFF
--- a/ndslice/src/selection/mod.rs
+++ b/ndslice/src/selection/mod.rs
@@ -93,6 +93,9 @@ pub mod token_parser;
 /// Shape navigation guided by [`Selection`] expressions.
 pub mod routing;
 
+/// Normalization logic for `Selection`.
+pub mod normal;
+
 pub mod test_utils;
 
 use std::collections::BTreeSet;
@@ -236,7 +239,20 @@ impl fmt::Display for Selection {
 /// For example, a selection like `sel!(["A100"]*)` matches only
 /// indices at the current dimension whose associated label value is
 /// `"A100"`.
-#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+///
+/// `Ord` is derived to allow deterministic sorting and set membership,
+/// based on lexicographic ordering of label strings.
+#[derive(
+    Clone,
+    Debug,
+    PartialEq,
+    Eq,
+    Hash,
+    Serialize,
+    Deserialize,
+    PartialOrd,
+    Ord
+)]
 pub enum LabelKey {
     /// A plain string label value.
     Value(String),

--- a/ndslice/src/selection/normal.rs
+++ b/ndslice/src/selection/normal.rs
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+use std::collections::BTreeSet;
+
+use crate::selection::LabelKey;
+use crate::shape;
+
+/// A normalized form of `Selection`, used during canonicalization.
+///
+/// This structure uses `BTreeSet` for `Union` and `Intersection` to
+/// enable flattening, deduplication, and deterministic ordering.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub enum NormalizedSelection {
+    False,
+    True,
+    All(Box<NormalizedSelection>),
+    First(Box<NormalizedSelection>),
+    Range(shape::Range, Box<NormalizedSelection>),
+    Label(Vec<LabelKey>, Box<NormalizedSelection>),
+    Any(Box<NormalizedSelection>),
+    Union(BTreeSet<NormalizedSelection>),
+    Intersection(BTreeSet<NormalizedSelection>),
+}

--- a/ndslice/src/shape.rs
+++ b/ndslice/src/shape.rs
@@ -359,7 +359,21 @@ macro_rules! select {
 
 /// A range of indices, with a stride. Ranges are convertible from
 /// native Rust ranges.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+///
+/// Deriving `Eq`, `Ord` and `Hash` is sound because all fields are
+/// `Ord` and comparison is purely structural over `(start, end,
+/// step)`.
+#[derive(
+    Debug,
+    Clone,
+    Eq,
+    Hash,
+    PartialEq,
+    Serialize,
+    Deserialize,
+    PartialOrd,
+    Ord
+)]
 pub struct Range(pub usize, pub Option<usize>, pub usize);
 
 impl Range {


### PR DESCRIPTION
Summary:

- define `NormalizedSelection`, a canonical representation of `Selection` used during normalization
  - use `BTreeSet` for `Union` and `Intersection` to enable flattening, deduplication, and ordering

- expose `selection::normal` module

- derive `Ord` for `LabelKey` and `Range`, enabling use in `BTreeSet` and ensuring deterministic comparisons
  - include documentation justifying structural ordering

Differential Revision: D75742872


