### PR TITLE
: channel/proc/mailbox/reference/simnet: fix remaining 1.87.0 enabled lints (#89)

### DIFF
--- a/hyperactor/src/actor/mod.rs
+++ b/hyperactor/src/actor/mod.rs
@@ -544,6 +544,7 @@ impl<A: Actor> ActorHandle<A> {
     }
 
     /// Signal the actor to drain its current messages and then stop.
+    #[allow(clippy::result_large_err)] // TODO: Consider reducing the size of `ActorError`.
     pub fn drain_and_stop(&self) -> Result<(), ActorError> {
         self.cell.signal(Signal::DrainAndStop)
     }
@@ -555,6 +556,7 @@ impl<A: Actor> ActorHandle<A> {
 
     /// Send a message to the actor. Messages sent through the handle
     /// are always queued in process, and do not require serialization.
+    #[allow(clippy::result_large_err)] // TODO: Consider reducing the size of `MailboxSenderError`.
     pub fn send<M: Message>(&self, message: M) -> Result<(), MailboxSenderError>
     where
         A: Handler<M>,

--- a/hyperactor/src/channel/local.rs
+++ b/hyperactor/src/channel/local.rs
@@ -123,6 +123,7 @@ impl<M: RemoteMessage> Drop for LocalRx<M> {
 }
 
 /// Dial a local port, returning a Tx for it.
+#[allow(clippy::result_large_err)] // TODO: Consider reducing the size of `ChannelError`.
 pub fn dial<M: RemoteMessage>(port: u64) -> Result<LocalTx<M>, ChannelError> {
     let ports = PORTS.lock().unwrap();
     let result = ports.get(port);

--- a/hyperactor/src/channel/mod.rs
+++ b/hyperactor/src/channel/mod.rs
@@ -98,6 +98,7 @@ pub trait Tx<M: RemoteMessage>: std::fmt::Debug {
     /// the channel has failed and it will be sent back on `return_handle`.
     // TODO: the return channel should be SendError<M> directly, and we should drop
     // the returned result.
+    #[allow(clippy::result_large_err)] // TODO: Consider reducing the size of `SendError`.
     fn try_post(&self, message: M, return_channel: oneshot::Sender<M>) -> Result<(), SendError<M>>;
 
     /// Enqueue a message to be sent on the channel. The caller is expected to monitor
@@ -513,6 +514,7 @@ impl<M: RemoteMessage> Rx<M> for ChannelRx<M> {
 /// Dial the provided address, returning the corresponding Tx, or error
 /// if the channel cannot be established. The underlying connection is
 /// dropped whenever the returned Tx is dropped.
+#[allow(clippy::result_large_err)] // TODO: Consider reducing the size of `ChannelError`.
 pub fn dial<M: RemoteMessage>(addr: ChannelAddr) -> Result<ChannelTx<M>, ChannelError> {
     dial_impl(addr, None)
 }
@@ -520,6 +522,7 @@ pub fn dial<M: RemoteMessage>(addr: ChannelAddr) -> Result<ChannelTx<M>, Channel
 /// Dial the provided address, providing the address of the dialer, returning
 /// the corresponding Tx, or error if the channel cannot be established.
 /// The underlying connection is dropped whenever the returned Tx is dropped.
+#[allow(clippy::result_large_err)] // TODO: Consider reducing the size of `ChannelError`.
 pub fn dial_from_address<M: RemoteMessage>(
     addr: ChannelAddr,
     dialer: ChannelAddr,

--- a/hyperactor/src/channel/net.rs
+++ b/hyperactor/src/channel/net.rs
@@ -1549,6 +1549,7 @@ pub(crate) mod meta {
     const THRIFT_TLS_CL_KEY_PATH_ENV: &str = "THRIFT_TLS_CL_KEY_PATH";
     const DEFAULT_SERVER_PEM_PATH: &str = "/var/facebook/x509_identities/server.pem";
 
+    #[allow(clippy::result_large_err)] // TODO: Consider reducing the size of `ChannelError`.
     pub(crate) fn parse(addr_string: &str) -> Result<ChannelAddr, ChannelError> {
         // use right split to allow for ipv6 addresses where ":" is expected.
         let parts = addr_string.rsplit_once(":");
@@ -1711,7 +1712,7 @@ pub(crate) mod meta {
             let (connector, domain_name) = tls_connector_config(&self.hostname).map_err(|err| {
                 ClientError::Connect(
                     self.dest(),
-                    io::Error::new(io::ErrorKind::Other, err.to_string()),
+                    io::Error::other(err.to_string()),
                     format!("cannot config tls connector for addr {}", addr),
                 )
             })?;
@@ -1743,7 +1744,7 @@ pub(crate) mod meta {
         })?;
         let addr = addrs.next().ok_or(ServerError::Resolve(
             ChannelAddr::MetaTls(hostname.clone(), port),
-            io::Error::new(io::ErrorKind::Other, "no available socket addr"),
+            io::Error::other("no available socket addr"),
         ))?;
         let channel_addr = ChannelAddr::MetaTls(hostname.clone(), port);
         let listener = TcpListener::bind(addr)

--- a/hyperactor/src/channel/sim.rs
+++ b/hyperactor/src/channel/sim.rs
@@ -71,6 +71,7 @@ pub struct SimAddr {
 
 impl SimAddr {
     /// Creates a new SimAddr.
+    #[allow(clippy::result_large_err)] // TODO: Consider reducing the size of `SimNetError`.
     pub fn new(addr: ChannelAddr, proxy: ChannelAddr) -> Result<Self, SimNetError> {
         if let ChannelAddr::Sim(_) = &addr {
             return Err(SimNetError::InvalidArg(format!(
@@ -209,6 +210,7 @@ pub(crate) fn any(proxy: ChannelAddr) -> ChannelAddr {
 }
 
 /// Parse the sim channel address. It should have two non-sim channel addresses separated by a comma.
+#[allow(clippy::result_large_err)] // TODO: Consider reducing the size of `ChannelError`.
 pub fn parse(addr_string: &str) -> Result<ChannelAddr, ChannelError> {
     let re = Regex::new(r"^([^,]+),([^,]+)$").map_err(|err| {
         ChannelError::InvalidAddress(format!("invalid sim address regex: {}", err))
@@ -370,6 +372,7 @@ impl<M: RemoteMessage> Tx<M> for SimTx<M> {
 
 /// Dial a peer and return a transmitter. The transmitter can retrieve from the
 /// network the link latency.
+#[allow(clippy::result_large_err)] // TODO: Consider reducing the size of `ChannelError`.
 pub(crate) fn dial<M: RemoteMessage>(
     addr: SimAddr,
     dialer: Option<ChannelAddr>,

--- a/hyperactor/src/mailbox/mod.rs
+++ b/hyperactor/src/mailbox/mod.rs
@@ -627,6 +627,7 @@ pub trait MailboxSender: Send + Sync + Debug + Any {
 /// for sending messages over ports.
 pub trait PortSender: MailboxSender {
     /// Deliver a message to the provided port.
+    #[allow(clippy::result_large_err)] // TODO: Consider reducing the size of `MailboxSenderError`.
     fn serialize_and_send<M: RemoteMessage>(
         &self,
         port: &PortRef<M>,
@@ -649,6 +650,7 @@ pub trait PortSender: MailboxSender {
 
     /// Deliver a message to a one-shot port, consuming the provided port,
     /// which is not reusable.
+    #[allow(clippy::result_large_err)] // TODO: Consider reducing the size of `MailboxSenderError`.
     fn serialize_and_send_once<M: RemoteMessage>(
         &self,
         once_port: OncePortRef<M>,
@@ -1404,6 +1406,7 @@ impl<M: Message> PortHandle<M> {
     }
 
     /// Send a message to this port.
+    #[allow(clippy::result_large_err)] // TODO: Consider reducing the size of `MailboxSenderError`.
     pub fn send(&self, message: M) -> Result<(), MailboxSenderError> {
         self.sender.send(message).map_err(|err| {
             MailboxSenderError::new_unbound::<M>(
@@ -1468,6 +1471,7 @@ impl<M: Message> OncePortHandle<M> {
 
     /// Send a message to this port. The send operation will consume the
     /// port handle, as the port accepts at most one message.
+    #[allow(clippy::result_large_err)] // TODO: Consider reducing the size of `MailboxSenderError`.
     pub fn send(self, message: M) -> Result<(), MailboxSenderError> {
         let actor_id = self.mailbox.actor_id().clone();
         self.sender.send(message).map_err(|_| {
@@ -1531,6 +1535,7 @@ impl<M> PortReceiver<M> {
     /// Tries to receive the next value for this receiver.
     /// This function returns `Ok(None)` if the receiver is empty
     /// and returns a MailboxError if the receiver is disconnected.
+    #[allow(clippy::result_large_err)] // TODO: Consider reducing the size of `MailboxError`.
     pub fn try_recv(&mut self) -> Result<Option<M>, MailboxError> {
         let mut next = self.receiver.try_recv();
         // To coalesce, drain the mpsc queue and only keep the last one.
@@ -1660,6 +1665,7 @@ trait SerializedSender: Send + Sync {
     ///
     /// Send_serialized returns true whenever the port remains valid
     /// after the send operation.
+    #[allow(clippy::result_large_err)] // TODO: Consider reducing the size of `SerializedSender`.
     fn send_serialized(&self, serialized: Serialized) -> Result<bool, SerializedSenderError>;
 }
 
@@ -1715,6 +1721,7 @@ impl<M: Message> UnboundedSender<M> {
         Self { sender, port_id }
     }
 
+    #[allow(clippy::result_large_err)] // TODO: Consider reducing the size of `MailboxSenderError`.
     fn send(&self, message: M) -> Result<(), MailboxSenderError> {
         self.sender.send(message).map_err(|err| {
             MailboxSenderError::new_bound(self.port_id.clone(), MailboxSenderErrorKind::Other(err))
@@ -1779,6 +1786,7 @@ impl<M: Message> OnceSender<M> {
         }
     }
 
+    #[allow(clippy::result_large_err)] // TODO: Consider reducing the size of `MailboxSenderError`.
     fn send_once(&self, message: M) -> Result<bool, MailboxSenderError> {
         // TODO: we should replace the sender on error
         match self.sender.lock().unwrap().take() {
@@ -2160,6 +2168,7 @@ impl DialMailboxRouter {
             })
     }
 
+    #[allow(clippy::result_large_err)] // TODO: Consider reducing the size of `MailboxSenderError`.
     fn dial(
         &self,
         addr: &ChannelAddr,

--- a/hyperactor/src/proc.rs
+++ b/hyperactor/src/proc.rs
@@ -800,6 +800,7 @@ impl<A: Actor> Instance<A> {
     }
 
     /// Signal the actor to stop.
+    #[allow(clippy::result_large_err)] // TODO: Consider reducing the size of `ActorError`.
     pub fn stop(&self) -> Result<(), ActorError> {
         self.cell.signal(Signal::DrainAndStop)
     }
@@ -825,6 +826,7 @@ impl<A: Actor> Instance<A> {
     }
 
     /// Send a message to the actor itself with a delay usually to trigger some event.
+    #[allow(clippy::result_large_err)] // TODO: Consider reducing the size of `ActorError`.
     pub fn self_message_with_delay<M>(&self, message: M, delay: Duration) -> Result<(), ActorError>
     where
         M: Message,
@@ -1268,6 +1270,7 @@ impl InstanceCell {
     }
 
     /// Send a signal to the actor.
+    #[allow(clippy::result_large_err)] // TODO: Consider reducing the size of `ActorError`.
     pub fn signal(&self, signal: Signal) -> Result<(), ActorError> {
         self.state.signal.send(signal).map_err(ActorError::from)
     }

--- a/hyperactor/src/reference.rs
+++ b/hyperactor/src/reference.rs
@@ -599,6 +599,7 @@ impl<A: RemoteActor> ActorRef<A> {
     }
 
     /// Send an [`M`]-typed message to the referenced actor.
+    #[allow(clippy::result_large_err)] // TODO: Consider reducing the size of `MailboxSenderError`.
     pub fn send<M: RemoteMessage>(
         &self,
         cap: &impl cap::CanSend,
@@ -813,6 +814,7 @@ impl<M: RemoteMessage> PortRef<M> {
 
     /// Send a message to this port, provided a sending capability, such as
     /// [`crate::actor::Instance`].
+    #[allow(clippy::result_large_err)] // TODO: Consider reducing the size of `MailboxSenderError`.
     pub fn send(&self, caps: &impl cap::CanSend, message: M) -> Result<(), MailboxSenderError> {
         let serialized = Serialized::serialize(&message).map_err(|err| {
             MailboxSenderError::new_bound(
@@ -882,6 +884,7 @@ impl<M: RemoteMessage> OncePortRef<M> {
 
     /// Send a message to this port, provided a sending capability, such as
     /// [`crate::actor::Instance`].
+    #[allow(clippy::result_large_err)] // TODO: Consider reducing the size of `MailboxSenderError`.
     pub fn send(self, caps: &impl cap::CanSend, message: M) -> Result<(), MailboxSenderError> {
         let serialized = Serialized::serialize(&message).map_err(|err| {
             MailboxSenderError::new_bound(

--- a/hyperactor/src/simnet.rs
+++ b/hyperactor/src/simnet.rs
@@ -347,6 +347,7 @@ pub struct SimNetHandle {
 
 impl SimNetHandle {
     /// Sends an event to be scheduled onto the simnet's event loop
+    #[allow(clippy::result_large_err)] // TODO: Consider reducing the size of `SimNetError`.
     pub fn send_event(&self, event: Box<dyn Event>) -> Result<(), SimNetError> {
         self.pending_event_count
             .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
@@ -356,6 +357,7 @@ impl SimNetHandle {
     }
 
     /// Sends an event that already has a scheduled time onto the simnet's event loop
+    #[allow(clippy::result_large_err)] // TODO: Consider reducing the size of `SimNetError`.
     pub(crate) fn send_scheduled_event(
         &self,
         scheduled_event: ScheduledEvent,
@@ -374,6 +376,7 @@ impl SimNetHandle {
     }
 
     /// Bind the given address to this simulator instance.
+    #[allow(clippy::result_large_err)] // TODO: Consider reducing the size of `SimNetError`.
     pub fn bind(&self, address: ChannelAddr) -> Result<(), SimNetError> {
         self.pending_event_count
             .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
@@ -986,6 +989,7 @@ pub struct EdgeConfig {
 
 impl NetworkConfig {
     /// Create a new configuration from a YAML string.
+    #[allow(clippy::result_large_err)] // TODO: Consider reducing the size of `SimNetError`.
     pub fn from_yaml(yaml: &str) -> Result<Self, SimNetError> {
         let config: NetworkConfig = serde_yaml::from_str(yaml)
             .map_err(|err| SimNetError::InvalidArg(format!("failed to parse config: {}", err)))?;


### PR DESCRIPTION
Summary:

fix remaining 1.87.0 enabled clippy lint warnings in `hyperactor`

Reviewed By: mariusae

Differential Revision: D75704083


