### PR TITLE
remove unnecessary unsafe block

### DIFF
--- a/hyperactor/src/mailbox/mod.rs
+++ b/hyperactor/src/mailbox/mod.rs
@@ -1287,15 +1287,12 @@ impl SplitPortBuffer {
     /// be flushed.
     fn push(&mut self, serialized: Serialized) -> Option<Vec<Serialized>> {
         static HYPERACTOR_SPLIT_MAX_BUFFER_SIZE: OnceLock<usize> = OnceLock::new();
-        #[allow(clippy::undocumented_unsafe_blocks)]
-        let limit = HYPERACTOR_SPLIT_MAX_BUFFER_SIZE.get_or_init(||
-            // TODO: Audit that the environment access only happens in single-threaded code.
-            unsafe {
-                std::env::var("HYPERACTOR_SPLIT_MAX_BUFFER_SIZE")
-                    .ok()
-                    .and_then(|val| val.parse::<usize>().ok())
-                    .unwrap_or(5)
-            });
+        let limit = HYPERACTOR_SPLIT_MAX_BUFFER_SIZE.get_or_init(|| {
+            std::env::var("HYPERACTOR_SPLIT_MAX_BUFFER_SIZE")
+                .ok()
+                .and_then(|val| val.parse::<usize>().ok())
+                .unwrap_or(5)
+        });
 
         self.0.push(serialized);
         if &self.0.len() >= limit {


### PR DESCRIPTION
Summary:
I got a bit carried away using sed with the edition update. [This function doesn't need to be unsafe](https://doc.rust-lang.org/std/env/fn.var.html).

Setting and removing env vars is unsafe. Checking an env var value is not.

Reviewed By: shayne-fletcher

Differential Revision: D75876552
