### PR TITLE
fix some oss build issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ PyTorch, but at cluster scale.
 > work. It's recommended that you signal your intention to contribute in the
 > issue tracker, either by filing a new issue or by claiming an existing one.
 
+Note: Monarch is currently only supported on Linux systems
+
 ## Installation
 
 `pip install torchmonarch`
@@ -31,8 +33,14 @@ rustup default nightly
 # Install non-python dependencies
 conda install libunwind -y
 
-# Install the correct cuda and cuda-toolkit versions for your machine
-sudo dnf install cuda-toolkit-12-0 cuda-12-0 libnccl-devel clang-devel
+# Install the correct cuda and cuda-toolkit versions for your machine, as well as NCCL-dev
+sudo dnf install cuda-toolkit-12-0 cuda-12-0 libnccl-devel
+
+# Install clang dev
+sudo dnf install clang-devel
+# In some envrionments, the following may be necessary instead
+conda install conda-forge::clangdev
+conda update -n monarchenv --all -c conda-forge -y
 
 # Install build dependencies
 pip install -r build-requirements.txt

--- a/build-requirements.txt
+++ b/build-requirements.txt
@@ -2,3 +2,4 @@ torch
 setuptools
 setuptools-rust
 wheel
+numpy

--- a/python/monarch/common/mock_cuda.cpp
+++ b/python/monarch/common/mock_cuda.cpp
@@ -26,6 +26,7 @@
 #include <cstring>
 #include <mutex>
 #include <random>
+#include <stdexcept>
 #include <string>
 #include <unordered_map>
 


### PR DESCRIPTION
Summary:
1. `conda install conda-forge::clangdev` followed by `conda update -n monarchenv --all -c conda-forge -y` seems to be necessary for linking to succeed on at least two different machines / distributions i tried (without system level build lib)
2.  numpy is a build requirement
3. include \<stdexcept> for std::runtime_error

Differential Revision: D75888019


