### PR TITLE
(monarch_hyperactor) Create python binding for a RemoteAllocator that takes a list of remote channel addresses

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,6 +54,9 @@ jobs:
         # Install test dependencies
         pip install -r python/tests/requirements.txt
 
+        # Install remote process_allocator binary (some tests use it)
+        cargo install --path monarch_hyperactor
+
         # Build and install monarch
         # NB: monarch is currently can't be built in isolated builds (e.g not PEP519 compatible)
         # because 'torch-sys' needs to be compiled against 'torch' in the main python environment

--- a/monarch_extension/src/lib.rs
+++ b/monarch_extension/src/lib.rs
@@ -142,6 +142,10 @@ pub fn mod_init(module: &Bound<'_, PyModule>) -> PyResult<()> {
         module,
         "monarch_hyperactor.alloc",
     )?)?;
+    monarch_hyperactor::channel::register_python_bindings(&get_or_add_new_module(
+        module,
+        "monarch_hyperactor.channel",
+    )?)?;
     monarch_hyperactor::actor_mesh::register_python_bindings(&get_or_add_new_module(
         module,
         "monarch_hyperactor.actor_mesh",

--- a/monarch_hyperactor/src/bin/process_allocator/main.rs
+++ b/monarch_hyperactor/src/bin/process_allocator/main.rs
@@ -8,6 +8,8 @@
 
 mod common;
 
+use std::str::FromStr;
+
 use clap::Parser;
 use common::Args;
 use common::main_impl;
@@ -18,9 +20,11 @@ async fn main() {
     let args = Args::parse();
     hyperactor::initialize();
 
-    let bind = format!("{}:{}", args.addr, args.port);
-    let socket_addr: std::net::SocketAddr = bind.parse().unwrap();
-    let serve_address = ChannelAddr::Tcp(socket_addr);
+    let bind = args
+        .addr
+        .unwrap_or_else(|| format!("tcp![::]:{}", args.port));
+
+    let serve_address = ChannelAddr::from_str(&bind).unwrap();
 
     let _ = main_impl(serve_address, args.program).await.unwrap();
 }

--- a/monarch_hyperactor/src/channel.rs
+++ b/monarch_hyperactor/src/channel.rs
@@ -1,0 +1,176 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+use std::str::FromStr;
+
+use hyperactor::channel::ChannelAddr;
+use hyperactor::channel::ChannelTransport;
+use pyo3::exceptions::PyRuntimeError;
+use pyo3::prelude::*;
+
+/// Python binding for [`hyperactor::channel::ChannelTransport`]
+#[pyclass(
+    name = "ChannelTransport",
+    module = "monarch._rust_bindings.monarch_hyperactor.channel",
+    eq
+)]
+#[derive(PartialEq, Clone, Copy, Debug)]
+pub enum PyChannelTransport {
+    Tcp,
+    MetaTls,
+    Local,
+    Unix,
+    // Sim(/*proxy address:*/ ChannelAddr), TODO kiuk@ add support
+}
+
+#[pyclass(
+    name = "ChannelAddr",
+    module = "monarch._rust_bindings.monarch_hyperactor.channel"
+)]
+pub struct PyChannelAddr {
+    inner: ChannelAddr,
+}
+
+impl FromStr for PyChannelAddr {
+    type Err = anyhow::Error;
+    fn from_str(addr: &str) -> anyhow::Result<Self> {
+        let inner = ChannelAddr::from_str(addr)?;
+        Ok(Self { inner })
+    }
+}
+
+#[pymethods]
+impl PyChannelAddr {
+    /// Returns an "any" address for the given transport type.
+    /// Primarily used to bind servers. Returned string form of the address
+    /// is of the format `{transport}!{address}`. For example:
+    /// `tcp![::]:0`, `unix!@a0b1c2d3`, `metatls!devgpu001.pci.facebook.com:0`
+    #[staticmethod]
+    pub fn any(transport: PyChannelTransport) -> PyResult<String> {
+        Ok(ChannelAddr::any(transport.into()).to_string())
+    }
+
+    #[staticmethod]
+    pub fn parse(addr: &str) -> PyResult<Self> {
+        Ok(PyChannelAddr::from_str(addr)?)
+    }
+
+    /// Returns the port number (if any) of this channel address,
+    /// `0` for transports for which unix ports do not apply (e.g. `unix`, `local`)
+    pub fn get_port(&self) -> PyResult<u16> {
+        match self.inner {
+            ChannelAddr::Tcp(socket_addr) => Ok(socket_addr.port()),
+            ChannelAddr::MetaTls(_, port) => Ok(port),
+            ChannelAddr::Unix(_) | ChannelAddr::Local(_) => Ok(0),
+            _ => Err(PyRuntimeError::new_err(format!(
+                "unsupported transport: `{:?}` for channel address: `{}`",
+                self.inner.transport(),
+                self.inner
+            ))),
+        }
+    }
+
+    /// Returns the channel transport of this channel address.
+    pub fn get_transport(&self) -> PyResult<PyChannelTransport> {
+        let transport = self.inner.transport();
+        match transport {
+            ChannelTransport::Tcp => Ok(PyChannelTransport::Tcp),
+            ChannelTransport::MetaTls => Ok(PyChannelTransport::MetaTls),
+            ChannelTransport::Local => Ok(PyChannelTransport::Local),
+            ChannelTransport::Unix => Ok(PyChannelTransport::Unix),
+            _ => Err(PyRuntimeError::new_err(format!(
+                "unsupported transport: `{:?}` for address: `{}`",
+                self.inner.transport(),
+                self.inner
+            ))),
+        }
+    }
+}
+
+impl From<PyChannelTransport> for ChannelTransport {
+    fn from(val: PyChannelTransport) -> Self {
+        match val {
+            PyChannelTransport::Tcp => ChannelTransport::Tcp,
+            PyChannelTransport::MetaTls => ChannelTransport::MetaTls,
+            PyChannelTransport::Local => ChannelTransport::Local,
+            PyChannelTransport::Unix => ChannelTransport::Unix,
+        }
+    }
+}
+
+#[pymodule]
+pub fn register_python_bindings(hyperactor_mod: &Bound<'_, PyModule>) -> PyResult<()> {
+    hyperactor_mod.add_class::<PyChannelTransport>()?;
+    hyperactor_mod.add_class::<PyChannelAddr>()?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_channel_any_and_parse() -> PyResult<()> {
+        // just make sure any() and parse() calls work for all transports
+        for transport in [
+            PyChannelTransport::Tcp,
+            PyChannelTransport::Unix,
+            PyChannelTransport::MetaTls,
+            PyChannelTransport::Local,
+        ] {
+            let address = PyChannelAddr::any(transport)?;
+            let _ = PyChannelAddr::parse(&address)?;
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn test_channel_unsupported_transport() -> PyResult<()> {
+        let sim_addr = ChannelAddr::any(ChannelTransport::Sim(ChannelAddr::any(
+            ChannelTransport::Unix,
+        )));
+        let addr = PyChannelAddr { inner: sim_addr };
+
+        assert!(addr.get_port().is_err());
+        assert!(addr.get_transport().is_err());
+        Ok(())
+    }
+
+    #[test]
+    fn test_channel_addr_get_port() -> PyResult<()> {
+        assert_eq!(PyChannelAddr::parse("tcp![::]:26600")?.get_port()?, 26600);
+        assert_eq!(
+            PyChannelAddr::parse("metatls!devgpu1.pci.facebook.com:26600")?.get_port()?,
+            26600
+        );
+        assert_eq!(PyChannelAddr::parse("local!12345")?.get_port()?, 0);
+        assert_eq!(PyChannelAddr::parse("unix!@1a2b3c")?.get_port()?, 0);
+        Ok(())
+    }
+
+    #[test]
+    fn test_channel_addr_get_transport() -> PyResult<()> {
+        assert_eq!(
+            PyChannelAddr::parse("tcp![::]:26600")?.get_transport()?,
+            PyChannelTransport::Tcp
+        );
+        assert_eq!(
+            PyChannelAddr::parse("metatls!devgpu001.pci.facebook.com:26600")?.get_transport()?,
+            PyChannelTransport::MetaTls
+        );
+        assert_eq!(
+            PyChannelAddr::parse("local!12345")?.get_transport()?,
+            PyChannelTransport::Local
+        );
+        assert_eq!(
+            PyChannelAddr::parse("unix!@1a2b3c")?.get_transport()?,
+            PyChannelTransport::Unix
+        );
+        Ok(())
+    }
+}

--- a/monarch_hyperactor/src/lib.rs
+++ b/monarch_hyperactor/src/lib.rs
@@ -12,6 +12,7 @@ pub mod actor;
 pub mod actor_mesh;
 pub mod alloc;
 pub mod bootstrap;
+pub mod channel;
 pub mod mailbox;
 pub mod ndslice;
 pub mod proc;

--- a/python/monarch/_rust_bindings/monarch_hyperactor/alloc.pyi
+++ b/python/monarch/_rust_bindings/monarch_hyperactor/alloc.pyi
@@ -6,9 +6,11 @@
 
 # pyre-strict
 
+from datetime import timedelta
 from typing import Optional
 
 from monarch._rust_bindings.hyperactor_extension.alloc import Alloc, AllocSpec
+from typing_extensions import Self
 
 class ProcessAllocatorBase:
     def __init__(
@@ -48,6 +50,43 @@ class ProcessAllocatorBase:
         ...
 
 class LocalAllocatorBase:
+    async def allocate_nonblocking(self, spec: AllocSpec) -> Alloc:
+        """
+        Allocate a process according to the provided spec.
+
+        Arguments:
+        - `spec`: The spec to allocate according to.
+        """
+        ...
+
+    def allocate_blocking(self, spec: AllocSpec) -> Alloc:
+        """
+        Allocate a process according to the provided spec, blocking until an
+        alloc is returned.
+
+        Arguments:
+        - `spec`: The spec to allocate according to.
+        """
+        ...
+
+class RemoteAllocatorBase:
+    def __new__(
+        cls,
+        world_id: str,
+        initializer: "monarch.allocator.RemoteAllocInitializer",  # pyre-ignore[11] defined in monarch/python/monarch/allocator.py
+        heartbeat_interval: timedelta = timedelta(seconds=5),
+    ) -> Self:
+        """
+        Create a new (client-side) allocator instance that submits allocation requests to
+        remote hosts that are running hyperactor's RemoteProcessAllocator.
+
+        Arguments:
+        - `world_id`: The world id to use for the remote allocator.
+        - `initializer`: Returns the server addresses to send allocation requests to.
+        - `heartbeat_interval`: Heartbeat interval used to maintain health status of remote hosts.
+        """
+        ...
+
     async def allocate_nonblocking(self, spec: AllocSpec) -> Alloc:
         """
         Allocate a process according to the provided spec.

--- a/python/monarch/_rust_bindings/monarch_hyperactor/channel.pyi
+++ b/python/monarch/_rust_bindings/monarch_hyperactor/channel.pyi
@@ -1,0 +1,27 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from enum import Enum
+
+class ChannelTransport(Enum):
+    Tcp = "tcp"
+    MetaTls = "metatls"
+    Local = "local"
+    Unix = "unix"
+    # Sim  # TODO add support
+
+class ChannelAddr:
+    @staticmethod
+    def any(transport: ChannelTransport) -> str:
+        """Returns an "any" address for the given transport type.
+
+        Primarily used to bind servers. The returned string can be
+        converted into `hyperactor::channel::ChannelAddr` (in Rust) by
+        calling `hyperactor::channel::ChannelAddr::from_str()`.
+        """
+        ...

--- a/python/monarch/allocator.py
+++ b/python/monarch/allocator.py
@@ -4,6 +4,9 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+# pyre-strict
+
+import abc
 from typing import final
 
 from monarch import ActorFuture as Future
@@ -15,6 +18,7 @@ from monarch._rust_bindings.hyperactor_extension.alloc import (  # @manual=//mon
 from monarch._rust_bindings.monarch_hyperactor.alloc import (  # @manual=//monarch/monarch_extension:monarch_extension
     LocalAllocatorBase,
     ProcessAllocatorBase,
+    RemoteAllocatorBase,
 )
 
 
@@ -44,6 +48,69 @@ class ProcessAllocator(ProcessAllocatorBase):
 class LocalAllocator(LocalAllocatorBase):
     """
     An allocator that allocates by spawning actors into the current process.
+    """
+
+    def allocate(self, spec: AllocSpec) -> Future[Alloc]:
+        """
+        Allocate a process according to the provided spec.
+
+        Arguments:
+        - `spec`: The spec to allocate according to.
+
+        Returns:
+        - A future that will be fulfilled when the requested allocation is fulfilled.
+        """
+        return Future(
+            lambda: self.allocate_nonblocking(spec),
+            lambda: self.allocate_blocking(spec),
+        )
+
+
+class RemoteAllocInitializer(abc.ABC):
+    """Subclass-able Python interface for `hyperactor_mesh::alloc::remoteprocess:RemoteProcessAllocInitializer`.
+
+    NOTE: changes to method signatures of this class must be made to the call-site at
+    `PyRemoteProcessAllocInitializer.py_initialize_alloc()` in `monarch/monarch_hyperactor/src/alloc.rs`
+    """
+
+    @abc.abstractmethod
+    async def initialize_alloc(self) -> list[str]:
+        """
+        Return the addresses of the servers that should be used to allocate processes
+        for the proc mesh. The addresses should be running hyperactor's RemoteProcessAllocator.
+
+        Each address is of the form `{transport}!{addr}(:{port})`.
+        This is the string form of `hyperactor::channel::ChannelAddr` (Rust).
+        For example, `tcp!127.0.0.1:1234`.
+
+        NOTE: Currently, all the addresses must have the same transport type and port
+        NOTE: Although this method is currently called once at the initialization of the Allocator,
+            in the future this method can be called multiple times and should return the current set of
+            addresses that are eligible to handle allocation requests.
+
+        """
+        ...
+
+
+class StaticRemoteAllocInitializer(RemoteAllocInitializer):
+    """
+    Returns the static list of server addresses that this initializer
+    was constructed with on each `initialize_alloc()` call.
+    """
+
+    def __init__(self, *addrs: str) -> None:
+        super().__init__()
+        self.addrs: list[str] = list(addrs)
+
+    async def initialize_alloc(self) -> list[str]:
+        return list(self.addrs)
+
+
+@final
+class RemoteAllocator(RemoteAllocatorBase):
+    """
+    An allocator that allocates by spawning actors on a remote host.
+    The remote host must be running hyperactor's remote-process-allocator.
     """
 
     def allocate(self, spec: AllocSpec) -> Future[Alloc]:

--- a/python/tests/test_allocator.py
+++ b/python/tests/test_allocator.py
@@ -1,0 +1,216 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import contextlib
+import importlib.resources
+import math
+import os
+import subprocess
+import sys
+import unittest
+from datetime import timedelta
+from typing import Generator
+
+import cloudpickle
+
+import torch
+import torch.distributed as dist
+import torch.nn.functional as F
+
+from monarch._rust_bindings.hyperactor_extension.alloc import (
+    AllocConstraints,
+    AllocSpec,
+)
+
+from monarch._rust_bindings.monarch_hyperactor.channel import (
+    ChannelAddr,
+    ChannelTransport,
+)
+from monarch.actor_mesh import Actor, current_rank, current_size, endpoint, ValueMesh
+
+from monarch.allocator import RemoteAllocator, StaticRemoteAllocInitializer
+from monarch.proc_mesh import ProcMesh
+
+from torch.distributed.elastic.utils.distributed import get_free_port
+
+_100_MILLISECONDS = timedelta(milliseconds=100)
+
+
+class TestActor(Actor):
+    """Silly actor that computes the world size by all-reducing rank-hot tensors"""
+
+    def __init__(self) -> None:
+        self.rank: int = current_rank().rank
+        self.world_size: int = math.prod(current_size().values())
+
+    @endpoint
+    async def compute_world_size(self, master_addr: str, master_port: int) -> int:
+        os.environ["MASTER_ADDR"] = master_addr
+        os.environ["MASTER_PORT"] = str(master_port)
+        dist.init_process_group("gloo", rank=self.rank, world_size=self.world_size)
+
+        try:
+            t = F.one_hot(torch.tensor(self.rank), num_classes=dist.get_world_size())
+            dist.all_reduce(t)
+            return int(torch.sum(t).item())
+        finally:
+            dist.destroy_process_group()
+
+
+@contextlib.contextmanager
+def remote_process_allocator() -> Generator[str, None, None]:
+    with importlib.resources.path(__package__, "") as package_path:
+        addr = ChannelAddr.any(ChannelTransport.Unix)
+
+        process_allocator = subprocess.Popen(
+            args=[
+                "process_allocator",
+                f"--addr={addr}",
+            ],
+            env={
+                # prefix PATH with this test module's directory to
+                # give 'process_allocator' and 'monarch_bootstrap' binary resources
+                # in this test module's directory precedence over the installed ones
+                # useful in BUCK where these binaries are added as 'resources' of this test target
+                "PATH": f"{package_path}:{os.getenv('PATH', '')}",
+                "RUST_LOG": "debug",
+            },
+        )
+        try:
+            yield addr
+        finally:
+            process_allocator.terminate()
+            try:
+                five_seconds = 5
+                process_allocator.wait(timeout=five_seconds)
+            except subprocess.TimeoutExpired:
+                process_allocator.kill()
+
+
+class TestRemoteAllocator(unittest.IsolatedAsyncioTestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cloudpickle.register_pickle_by_value(sys.modules[TestActor.__module__])
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        cloudpickle.unregister_pickle_by_value(sys.modules[TestActor.__module__])
+
+    def assert_computed_world_size(
+        self, computed: ValueMesh[int], expected_world_size: int
+    ) -> None:
+        expected_world_sizes = {
+            rank: expected_world_size for rank in range(0, expected_world_size)
+        }
+        computed_world_sizes = {p.rank: v for p, v in list(computed.flatten("rank"))}
+        self.assertDictEqual(expected_world_sizes, computed_world_sizes)
+
+    async def test_call_allocate_twice(self) -> None:
+        class DeletingAllocInitializer(StaticRemoteAllocInitializer):
+            """test initializer that removes the last address from the list each time initialize_alloc() is called
+            used to test that the state of the initializer is preserved across calls to allocate()
+            """
+
+            async def initialize_alloc(self) -> list[str]:
+                alloc = await super().initialize_alloc()
+                self.addrs.pop(-1)
+                return alloc
+
+        with remote_process_allocator() as host1, remote_process_allocator() as host2:
+            initializer = DeletingAllocInitializer(host1, host2)
+
+            allocator = RemoteAllocator(
+                world_id="test_remote_allocator",
+                initializer=initializer,
+                heartbeat_interval=_100_MILLISECONDS,
+            )
+
+            spec = AllocSpec(AllocConstraints(), host=1, gpu=1)
+
+            await allocator.allocate(spec)
+            self.assertEqual([host1], initializer.addrs)
+
+            await allocator.allocate(spec)
+            self.assertEqual([], initializer.addrs)
+
+    async def test_throws_when_initializer_returns_empty_addrs(self) -> None:
+        class EmptyAllocInitializer(StaticRemoteAllocInitializer):
+            """test initializer that returns an empty list of addresses"""
+
+            async def initialize_alloc(self) -> list[str]:
+                return []
+
+        empty_initializer = EmptyAllocInitializer()
+        with self.assertRaisesRegex(
+            RuntimeError, r"initializer must return non-empty list of addresses"
+        ):
+            allocator = RemoteAllocator(
+                world_id="test_remote_allocator",
+                initializer=empty_initializer,
+                heartbeat_interval=_100_MILLISECONDS,
+            )
+            await allocator.allocate(AllocSpec(AllocConstraints(), host=1, gpu=1))
+
+    async def test_allocate_2d_mesh(self) -> None:
+        hosts = 2
+        gpus = 4
+        world_size = hosts * gpus
+        spec = AllocSpec(AllocConstraints(), host=hosts, gpu=gpus)
+
+        # create 2x process-allocators (on their own bind addresses) to simulate 2 hosts
+        with remote_process_allocator() as host1, remote_process_allocator() as host2:
+            allocator = RemoteAllocator(
+                world_id="test_remote_allocator",
+                initializer=StaticRemoteAllocInitializer(host1, host2),
+                heartbeat_interval=_100_MILLISECONDS,
+            )
+            alloc = await allocator.allocate(spec)
+            proc_mesh = await ProcMesh.from_alloc(alloc)
+            actor = await proc_mesh.spawn("test_actor", TestActor)
+
+            values = await actor.compute_world_size.call(
+                master_addr="::",
+                master_port=get_free_port(),
+            )
+
+            self.assert_computed_world_size(values, world_size)
+
+    async def test_stacked_1d_meshes(self) -> None:
+        # create two stacked actor meshes on the same host
+        # each actor mesh running on separate process-allocators
+
+        with remote_process_allocator() as host1_a, remote_process_allocator() as host1_b:
+            allocator_a = RemoteAllocator(
+                world_id="a",
+                initializer=StaticRemoteAllocInitializer(host1_a),
+                heartbeat_interval=_100_MILLISECONDS,
+            )
+            allocator_b = RemoteAllocator(
+                world_id="b",
+                initializer=StaticRemoteAllocInitializer(host1_b),
+                heartbeat_interval=_100_MILLISECONDS,
+            )
+
+            spec_a = AllocSpec(AllocConstraints(), host=1, gpu=2)
+            spec_b = AllocSpec(AllocConstraints(), host=1, gpu=6)
+
+            proc_mesh_a = await ProcMesh.from_alloc(await allocator_a.allocate(spec_a))
+            proc_mesh_b = await ProcMesh.from_alloc(await allocator_b.allocate(spec_b))
+
+            actor_a = await proc_mesh_a.spawn("actor_a", TestActor)
+            actor_b = await proc_mesh_b.spawn("actor_b", TestActor)
+
+            results_a = await actor_a.compute_world_size.call(
+                master_addr="::", master_port=get_free_port()
+            )
+            results_b = await actor_b.compute_world_size.call(
+                master_addr="::", master_port=get_free_port()
+            )
+
+            self.assert_computed_world_size(results_a, 2)  # a is a 1x2 mesh
+            self.assert_computed_world_size(results_b, 6)  # b is a 1x6 mesh


### PR DESCRIPTION
Summary:
To support multi-node actor meshes in OSS without having to write a custom allocator for each scheduler (e.g. `SlurmAllocator`, `KubernetesAllocator`) we take advantage of the infrastructure we already have in TorchX and TorchElastic.

This Diff creates Python bindings for `RemoteAllocatorBase` that takes a list of server addresses (in channel_addr format - e.g. `metatls!devgpu032.nha1.facebook.com:26600` or `tcp!devgpu032.nha1.facebook.com:26601`) of remote-process-allocator server and connects to it.

The internals reuse existing `RemoteProcessAlloc` with a custom `PyRemoteProcessAllocInitializer` that simply returns a `Vec<RemoteProcessAllocHost>` given the user provided list of server addresses.

Recommended to start the review at `monarch‎/python‎/tests‎/test_allocator.py‎` to get a sense of what the API/Usage looks like.

The next diff will provide a function that gets the list of server addresses given a job-id (more specifically a monarch server handle of the form `{scheduler}://{namespace}/{job_id}` e.g. `slurm://default/monarch-kiuk-123`) and returns an Allocator that can be used to create a `ProcMesh` as usual.

NOTE: WIP fixing type-checking failures so ignore those...

Differential Revision: D75928565
