### PR TITLE
[monarch] test failure during bootstrap

### DIFF
--- a/hyperactor_mesh/src/proc_mesh/mod.rs
+++ b/hyperactor_mesh/src/proc_mesh/mod.rs
@@ -136,11 +136,12 @@ impl ProcMesh {
                         rank
                     );
                 }
+                // TODO: We should push responsibility to the allocator, which
+                // can choose to either provide a new proc or emit a
+                // ProcState::Failed to fail the whole allocation.
                 ProcState::Stopped { proc_id, reason } => {
-                    if let Some(rank) = proc_ids.unassign(proc_id.clone()) {
-                        let _ = running.remove(rank);
-                        tracing::info!("proc {} rank {}: stopped: {}", proc_id, rank, reason);
-                    }
+                    tracing::error!("allocation failed for proc_id {}: {}", proc_id, reason);
+                    return Err(AllocatorError::Other(anyhow::Error::msg(reason)));
                 }
                 ProcState::Failed {
                     world_id,

--- a/python/monarch/bootstrap_main.py
+++ b/python/monarch/bootstrap_main.py
@@ -53,6 +53,9 @@ def invoke_main():
                     record.levelno,
                 )
 
+    if os.environ.get("MONARCH_ERROR_DURING_BOOTSTRAP_FOR_TESTING") == "1":
+        raise RuntimeError("Error during bootstrap for testing")
+
     # forward logs to rust tracing. Defaults to on.
     if os.environ.get("MONARCH_PYTHON_LOG_TRACING", "1") == "1":
         logging.root.addHandler(TracingForwarder())

--- a/python/tests/error_test_binary.py
+++ b/python/tests/error_test_binary.py
@@ -138,5 +138,13 @@ def error_endpoint(num_procs, sync_test_impl, sync_endpoint, endpoint_name):
         _run_error_test(num_procs, sync_endpoint, endpoint_name)
 
 
+@main.command("error-bootstrap")
+def error_bootstrap():
+    print("I actually ran")
+    sys.stdout.flush()
+
+    proc_mesh(gpus=4, env={"MONARCH_ERROR_DURING_BOOTSTRAP_FOR_TESTING": "1"}).get()
+
+
 if __name__ == "__main__":
     main()

--- a/python/tests/test_actor_error.py
+++ b/python/tests/test_actor_error.py
@@ -106,3 +106,32 @@ def test_actor_supervision(num_procs, sync_endpoint, sync_test_impl, endpoint_na
     assert (
         process.returncode != 0
     ), f"Expected non-zero exit code, got {process.returncode}"
+
+
+# oss_skip: importlib not pulling resource correctly in git CI, needs to be revisited
+@pytest.mark.oss_skip
+def test_proc_mesh_bootstrap_error():
+    """
+    Test that attempts to spawn a ProcMesh with a failure during bootstrap.
+    """
+    # Run the segfault test in a subprocess
+    test_bin = importlib.resources.files("monarch.python.tests").joinpath("test_bin")
+    cmd = [
+        str(test_bin),
+        "error-bootstrap",
+    ]
+    try:
+        process = subprocess.run(cmd, capture_output=True, timeout=180)
+    except subprocess.TimeoutExpired as e:
+        print("timeout expired")
+        if e.stdout is not None:
+            print(e.stdout.decode())
+        if e.stderr is not None:
+            print(e.stderr.decode())
+        raise
+
+    # Assert that the subprocess exited with a non-zero code
+    assert "I actually ran" in process.stdout.decode()
+    assert (
+        process.returncode != 0
+    ), f"Expected non-zero exit code, got {process.returncode}"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #182
* #181
* #180

Currently, a failure in the bootstrap process leads to an infinite loop in `ProcMesh::allocate`, as we would keep retrying indefinitely.

This diff treats stopped procs during the initial allocation process as a reason to fail the whole allocation.

Since that initial allocation process doesn't run any use code (it only runs our bootstrapping code) I think it makes sense to be highly suspicious of any process stoppage there.

Differential Revision: [D75975259](https://our.internmc.facebook.com/intern/diff/D75975259/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D75975259/)!