### PR TITLE
[3/n tensor engine] hello tensor engine

### DIFF
--- a/controller/src/history.rs
+++ b/controller/src/history.rs
@@ -115,7 +115,7 @@ enum RefStatus {
 /// borrows, drops etc. directly.
 #[derive(Debug)]
 #[allow(dead_code)]
-pub(crate) struct History {
+pub struct History {
     /// The first incomplete Seq for each rank. This is used to determine which
     /// Seqs are no longer relevant and can be purged from the history.
     first_incomplete_seqs: MinVector<Seq>,
@@ -198,7 +198,7 @@ where
 }
 
 impl History {
-    pub(crate) fn new(world_size: usize) -> Self {
+    pub fn new(world_size: usize) -> Self {
         Self {
             first_incomplete_seqs: MinVector::new(vec![Seq::default(); world_size]),
             min_incomplete_seq: Seq::default(),
@@ -213,23 +213,23 @@ impl History {
     }
 
     #[cfg(test)]
-    pub(crate) fn first_incomplete_seqs(&self) -> &[Seq] {
+    pub fn first_incomplete_seqs(&self) -> &[Seq] {
         self.first_incomplete_seqs.vec()
     }
 
-    pub(crate) fn first_incomplete_seqs_controller(&self) -> &[Seq] {
+    pub fn first_incomplete_seqs_controller(&self) -> &[Seq] {
         self.first_incomplete_seqs_controller.vec()
     }
 
-    pub(crate) fn min_incomplete_seq_reported(&self) -> Seq {
+    pub fn min_incomplete_seq_reported(&self) -> Seq {
         self.min_incompleted_seq_controller
     }
 
-    pub(crate) fn world_size(&self) -> usize {
+    pub fn world_size(&self) -> usize {
         self.first_incomplete_seqs.len()
     }
 
-    pub(crate) fn delete_invocations_for_refs(&mut self, refs: Vec<Ref>) {
+    pub fn delete_invocations_for_refs(&mut self, refs: Vec<Ref>) {
         self.marked_for_deletion.extend(refs);
 
         self.marked_for_deletion
@@ -251,7 +251,7 @@ impl History {
     }
 
     /// Add an invocation to the history.
-    pub(crate) fn add_invocation(
+    pub fn add_invocation(
         &mut self,
         seq: Seq,
         uses: Vec<Ref>,
@@ -306,7 +306,7 @@ impl History {
 
     /// Propagate worker error to the invocation with the given Seq. This will also propagate
     /// to all seqs that depend on this seq directly or indirectly.
-    pub(crate) fn propagate_exception(&mut self, seq: Seq, exception: Exception) {
+    pub fn propagate_exception(&mut self, seq: Seq, exception: Exception) {
         let mut queue = vec![seq];
         let mut visited = HashSet::new();
 
@@ -364,13 +364,13 @@ impl History {
         results
     }
 
-    pub(crate) fn report_deadline_missed(&mut self) {
+    pub fn report_deadline_missed(&mut self) {
         if let Some((seq, time, _)) = self.deadline {
             self.deadline = Some((seq, time, true));
         }
     }
 
-    pub(crate) fn deadline(
+    pub fn deadline(
         &mut self,
         expected_progress: u64,
         timeout: tokio::time::Duration,
@@ -397,7 +397,7 @@ impl History {
         self.deadline
     }
 
-    pub(crate) fn update_deadline_tracking(&mut self, rank: usize, seq: Seq) {
+    pub fn update_deadline_tracking(&mut self, rank: usize, seq: Seq) {
         // rank_completed also calls this so that we stay up to date with client request_status messages.
         // However, controller request_status messages may be ahead of the client as the client may retain invocations
         // past the time completed so we should take the max
@@ -411,7 +411,7 @@ impl History {
 
     /// Mark the given rank as completed up to but excluding the given Seq. This will also purge history for
     /// any Seqs that are no longer relevant (completed on all ranks).
-    pub(crate) fn rank_completed(
+    pub fn rank_completed(
         &mut self,
         rank: usize,
         seq: Seq,

--- a/controller/src/lib.rs
+++ b/controller/src/lib.rs
@@ -12,7 +12,7 @@
 #![allow(unsafe_op_in_unsafe_fn)]
 
 pub mod bootstrap;
-mod history;
+pub mod history;
 
 use std::collections::HashMap;
 use std::collections::HashSet;

--- a/hyperactor_mesh/src/proc_mesh/mod.rs
+++ b/hyperactor_mesh/src/proc_mesh/mod.rs
@@ -371,6 +371,14 @@ impl ProcMesh {
         &self.client
     }
 
+    pub fn client_proc(&self) -> &Proc {
+        &self.client_proc
+    }
+
+    pub fn proc_id(&self) -> &ProcId {
+        self.client_proc.proc_id()
+    }
+
     /// An event stream of proc events. Each ProcMesh can produce only one such
     /// stream, returning None after the first call.
     pub fn events(&mut self) -> Option<ProcEvents> {

--- a/monarch_extension/Cargo.toml
+++ b/monarch_extension/Cargo.toml
@@ -19,6 +19,7 @@ clap = { version = "4.5.38", features = ["derive", "env", "string", "unicode", "
 controller = { version = "0.0.0", path = "../controller" }
 hyperactor = { version = "0.0.0", path = "../hyperactor" }
 hyperactor_extension = { version = "0.0.0", path = "../hyperactor_extension" }
+hyperactor_mesh = { version = "0.0.0", path = "../hyperactor_mesh" }
 hyperactor_multiprocess = { version = "0.0.0", path = "../hyperactor_multiprocess" }
 monarch_hyperactor = { version = "0.0.0", path = "../monarch_hyperactor" }
 monarch_messages = { version = "0.0.0", path = "../monarch_messages" }

--- a/monarch_extension/src/client.rs
+++ b/monarch_extension/src/client.rs
@@ -51,9 +51,15 @@ use crate::controller::PyRanks;
 use crate::convert::convert;
 
 #[pyclass(frozen, module = "monarch._rust_bindings.monarch_extension.client")]
-struct WorkerResponse {
+pub struct WorkerResponse {
     seq: Seq,
     result: Option<Result<Serialized, Exception>>,
+}
+
+impl WorkerResponse {
+    pub fn new(seq: Seq, result: Option<Result<Serialized, Exception>>) -> Self {
+        Self { seq, result }
+    }
 }
 
 #[pymethods]
@@ -510,7 +516,7 @@ pub struct DebuggerMessage {
 impl DebuggerMessage {
     #[new]
     #[pyo3(signature = (*, debugger_actor_id, action))]
-    fn new(debugger_actor_id: PyActorId, action: DebuggerAction) -> PyResult<Self> {
+    pub fn new(debugger_actor_id: PyActorId, action: DebuggerAction) -> PyResult<Self> {
         Ok(Self {
             debugger_actor_id,
             action,

--- a/monarch_extension/src/lib.rs
+++ b/monarch_extension/src/lib.rs
@@ -12,6 +12,7 @@ mod client;
 mod controller;
 pub mod convert;
 mod debugger;
+mod mesh_controller;
 mod panic;
 mod simulator_client;
 mod tensor_worker;
@@ -148,6 +149,11 @@ pub fn mod_init(module: &Bound<'_, PyModule>) -> PyResult<()> {
     crate::panic::register_python_bindings(&get_or_add_new_module(
         module,
         "monarch_extension.panic",
+    )?)?;
+
+    crate::mesh_controller::register_python_bindings(&get_or_add_new_module(
+        module,
+        "monarch_extension.mesh_controller",
     )?)?;
 
     Ok(())

--- a/monarch_extension/src/mesh_controller.rs
+++ b/monarch_extension/src/mesh_controller.rs
@@ -1,0 +1,253 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+use std::sync::Arc;
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering;
+
+use controller::history;
+use hyperactor::ActorRef;
+use hyperactor_mesh::actor_mesh::ActorMesh;
+use hyperactor_mesh::proc_mesh::SharedSpawnable;
+use monarch_hyperactor::ndslice::PySlice;
+use monarch_hyperactor::proc::InstanceWrapper;
+use monarch_hyperactor::proc::PyActorId;
+use monarch_hyperactor::proc::PyProc;
+use monarch_hyperactor::proc_mesh::PyProcMesh;
+use monarch_hyperactor::runtime::signal_safe_block_on;
+use monarch_messages::client::Exception;
+use monarch_messages::controller::ControllerActor;
+use monarch_messages::controller::ControllerMessage;
+use monarch_messages::debugger::DebuggerAction;
+use monarch_messages::debugger::DebuggerActor;
+use monarch_messages::debugger::DebuggerMessage;
+use monarch_messages::worker::Ref;
+use monarch_messages::worker::WorkerMessage;
+use monarch_messages::worker::WorkerParams;
+use monarch_tensor_worker::AssignRankMessage;
+use monarch_tensor_worker::WorkerActor;
+use ndslice::Slice;
+use pyo3::exceptions::PyValueError;
+use pyo3::prelude::*;
+use tokio::sync::Mutex;
+
+use crate::convert::convert;
+
+#[pyclass(
+    subclass,
+    module = "monarch._rust_bindings.monarch_extension.mesh_controller"
+)]
+struct _Controller {
+    controller_instance: Arc<Mutex<InstanceWrapper<ControllerMessage>>>,
+    workers: ActorMesh<'static, WorkerActor>,
+    pending_messages: Vec<PyObject>,
+    history: history::History,
+}
+
+impl _Controller {
+    fn add_responses(
+        &mut self,
+        py: Python<'_>,
+        responses: Vec<(
+            monarch_messages::controller::Seq,
+            Option<Result<hyperactor::data::Serialized, monarch_messages::client::Exception>>,
+        )>,
+    ) -> PyResult<()> {
+        for (seq, response) in responses {
+            let message = crate::client::WorkerResponse::new(seq, response);
+            self.pending_messages.push(message.into_py(py));
+        }
+        Ok(())
+    }
+    fn fill_messages<'py>(&mut self, py: Python<'py>, timeout_msec: Option<u64>) -> PyResult<()> {
+        let instance = self.controller_instance.clone();
+        let result = signal_safe_block_on(py, async move {
+            instance.lock().await.next_message(timeout_msec).await
+        })??;
+        result.map(|m| self.add_message(m)).transpose()?;
+        Ok(())
+    }
+
+    fn add_message(&mut self, message: ControllerMessage) -> PyResult<()> {
+        Python::with_gil(|py| -> PyResult<()> {
+            match message {
+                ControllerMessage::DebuggerMessage {
+                    debugger_actor_id,
+                    action,
+                } => {
+                    let dm = crate::client::DebuggerMessage::new(debugger_actor_id.into(), action)?
+                        .into_py(py);
+                    self.pending_messages.push(dm);
+                }
+                ControllerMessage::Status {
+                    seq,
+                    worker_actor_id,
+                    controller: false,
+                } => {
+                    let rank = worker_actor_id.rank();
+                    let responses = self.history.rank_completed(rank, seq);
+                    self.add_responses(py, responses)?;
+                }
+                ControllerMessage::RemoteFunctionFailed { seq, error } => {
+                    self.history
+                        .propagate_exception(seq, Exception::Error(seq, seq, error));
+                }
+                ControllerMessage::FetchResult { seq, value } => {
+                    self.history.set_result(seq, value);
+                }
+                message => {
+                    panic!("unexpected message: {:?}", message);
+                }
+            };
+            Ok(())
+        })
+    }
+}
+
+static NEXT_ID: AtomicUsize = AtomicUsize::new(0);
+
+#[pymethods]
+impl _Controller {
+    #[new]
+    fn new(py: Python, py_proc_mesh: &PyProcMesh) -> PyResult<Self> {
+        let proc_mesh = py_proc_mesh.inner.as_ref();
+        let id = NEXT_ID.fetch_add(1, Ordering::Relaxed);
+        let controller_instance: InstanceWrapper<ControllerMessage> = InstanceWrapper::new(
+            &PyProc::new_from_proc(proc_mesh.client_proc().clone()),
+            &format!("tensor_engine_controller_{}", id),
+        )?;
+
+        let controller_actor_ref =
+            ActorRef::<ControllerActor>::attest(controller_instance.actor_id().clone());
+
+        let slice = proc_mesh.shape().slice();
+        if !slice.is_contiguous() || slice.offset() != 0 {
+            return Err(PyValueError::new_err(
+                "NYI: proc mesh for workers must be contiguous and start at offset 0",
+            ));
+        }
+        let world_size = slice.len();
+        let param = WorkerParams {
+            world_size,
+            // Rank assignment is consistent with proc indices.
+            rank: 0,
+            device_index: Some(0),
+            controller_actor: controller_actor_ref,
+        };
+
+        let py_proc_mesh = Arc::clone(&py_proc_mesh.inner);
+        let workers: anyhow::Result<ActorMesh<'_, WorkerActor>> =
+            signal_safe_block_on(py, async move {
+                let workers = py_proc_mesh
+                    .spawn(&format!("tensor_engine_workers_{}", id), &param)
+                    .await?;
+                let all_slices = vec![Slice::new_row_major(vec![world_size])];
+                workers.cast_slices(all_slices, AssignRankMessage::AssignRank())?;
+                Ok(workers)
+            })?;
+        Ok(Self {
+            workers: workers?,
+            controller_instance: Arc::new(Mutex::new(controller_instance)),
+            pending_messages: Vec::new(),
+            history: history::History::new(world_size),
+        })
+    }
+
+    fn node<'py>(
+        &mut self,
+        seq: u64,
+        defs: Bound<'py, PyAny>,
+        uses: Bound<'py, PyAny>,
+    ) -> PyResult<()> {
+        let failures = self.history.add_invocation(
+            seq.into(),
+            uses.iter()?
+                .map(|x| Ref::from_py_object(&x?))
+                .collect::<PyResult<Vec<Ref>>>()?,
+            defs.iter()?
+                .map(|x| Ref::from_py_object(&x?))
+                .collect::<PyResult<Vec<Ref>>>()?,
+        );
+        self.add_responses(defs.py(), failures)?;
+        Ok(())
+    }
+
+    fn drop_refs(&mut self, refs: Vec<Ref>) -> Result<(), anyhow::Error> {
+        self.history.delete_invocations_for_refs(refs);
+        Ok(())
+    }
+
+    fn send<'py>(&mut self, ranks: Bound<'py, PyAny>, message: Bound<'py, PyAny>) -> PyResult<()> {
+        let slices: Vec<Slice> = if let Ok(slice) = ranks.extract::<PySlice>() {
+            vec![slice.into()]
+        } else {
+            ranks
+                .extract::<Vec<PySlice>>()?
+                .iter()
+                .map(|x| x.into())
+                .collect()
+        };
+        let message: WorkerMessage = convert(message)?;
+
+        self.workers
+            .cast_slices(slices, message)
+            .map_err(|err| PyErr::new::<PyValueError, _>(err.to_string()))
+    }
+
+    #[pyo3(signature = (*, timeout_msec = None))]
+    fn _get_next_message<'py>(
+        &mut self,
+        py: Python<'py>,
+        timeout_msec: Option<u64>,
+    ) -> PyResult<Option<PyObject>> {
+        if self.pending_messages.is_empty() {
+            self.fill_messages(py, timeout_msec)?;
+        }
+        Ok(self.pending_messages.pop())
+    }
+
+    fn _debugger_attach(&mut self, pdb_actor: PyActorId) -> PyResult<()> {
+        let pdb_actor: ActorRef<DebuggerActor> = ActorRef::attest(pdb_actor.into());
+        pdb_actor
+            .send(
+                self.controller_instance.blocking_lock().mailbox(),
+                DebuggerMessage::Action {
+                    action: DebuggerAction::Attach(),
+                },
+            )
+            .map_err(|err| PyErr::new::<PyValueError, _>(err.to_string()))?;
+        Ok(())
+    }
+
+    fn _debugger_write(&mut self, pdb_actor: PyActorId, bytes: Vec<u8>) -> PyResult<()> {
+        let pdb_actor: ActorRef<DebuggerActor> = ActorRef::attest(pdb_actor.into());
+        pdb_actor
+            .send(
+                self.controller_instance.blocking_lock().mailbox(),
+                DebuggerMessage::Action {
+                    action: DebuggerAction::Write { bytes },
+                },
+            )
+            .map_err(|err| PyErr::new::<PyValueError, _>(err.to_string()))?;
+        Ok(())
+    }
+    fn _drain_and_stop(&mut self, py: Python<'_>) -> PyResult<Vec<PyObject>> {
+        let instance = self.controller_instance.clone();
+        let result =
+            signal_safe_block_on(py, async move { instance.lock().await.drain_and_stop() })??;
+        for r in result {
+            self.add_message(r)?;
+        }
+        Ok(std::mem::take(&mut self.pending_messages))
+    }
+}
+
+pub(crate) fn register_python_bindings(module: &Bound<'_, PyModule>) -> PyResult<()> {
+    module.add_class::<_Controller>()?;
+    Ok(())
+}

--- a/monarch_extension/src/tensor_worker.rs
+++ b/monarch_extension/src/tensor_worker.rs
@@ -48,7 +48,7 @@ use torch_sys::nccl::UniqueId;
     module = "monarch._rust_bindings.monarch_extension.tensor_worker"
 )]
 pub(crate) struct PyWorkerMessage {
-    message: WorkerMessage,
+    pub message: WorkerMessage,
 }
 
 impl PyWorkerMessage {
@@ -1448,3 +1448,27 @@ pub(crate) fn register_python_bindings(worker_mod: &Bound<'_, PyModule>) -> PyRe
 
     Ok(())
 }
+
+// #[pymethods]
+// impl CreateStream {
+//     #[new]
+//     #[pyo3(signature = (id, stream_creation))]
+//     fn new(id: StreamRef, stream_creation: StreamCreationMode) -> PyResult<WorkerMessage> {
+//         Ok(WorkerMessage::CreateStream {
+//             id,
+//             stream_creation,
+//         })
+//     }
+// }
+
+// class CreateStream(NamedTuple):
+//     result: StreamRef
+//     default: bool
+//     def to_rust_message(self) -> worker.WorkerMessage:
+//         return worker.CreateStream(
+//             id=worker.StreamRef(id=self.result.ref),
+//             stream_creation=(
+//                 worker.StreamCreationMode.UseDefaultStream
+//                 if self.default
+//                 else worker.StreamCreationMode.CreateNewStream
+//             ),

--- a/monarch_hyperactor/src/proc_mesh.rs
+++ b/monarch_hyperactor/src/proc_mesh.rs
@@ -31,10 +31,9 @@ use crate::shape::PyShape;
     module = "monarch._rust_bindings.monarch_hyperactor.proc_mesh"
 )]
 pub struct PyProcMesh {
-    pub(super) inner: Arc<ProcMesh>,
+    pub inner: Arc<ProcMesh>,
     monitor: tokio::task::JoinHandle<()>,
 }
-
 fn allocate_proc_mesh<'py>(py: Python<'py>, alloc: &PyAlloc) -> PyResult<Bound<'py, PyAny>> {
     let alloc = match alloc.take() {
         Some(alloc) => alloc,

--- a/monarch_messages/src/debugger.rs
+++ b/monarch_messages/src/debugger.rs
@@ -11,7 +11,9 @@
 #![allow(unsafe_op_in_unsafe_fn)]
 
 use derive_more::From;
+use hyperactor::Handler;
 use hyperactor::Named;
+use hyperactor::message::IndexedErasedUnbound;
 use pyo3::Bound;
 use pyo3::PyResult;
 use pyo3::types::PyModule;
@@ -49,7 +51,13 @@ pub enum DebuggerAction {
     Read { requested_size: usize },
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, Named, From)]
+#[derive(Serialize, Deserialize, Debug, Clone, Named, From, Handler)]
 pub enum DebuggerMessage {
     Action { action: DebuggerAction },
 }
+
+hyperactor::alias!(
+    DebuggerActor,
+    DebuggerMessage,
+    IndexedErasedUnbound<DebuggerMessage>
+);

--- a/monarch_tensor_worker/Cargo.toml
+++ b/monarch_tensor_worker/Cargo.toml
@@ -16,6 +16,7 @@ cxx = "1.0.119"
 derive_more = { version = "1.0.0", features = ["full"] }
 futures = { version = "0.3.30", features = ["async-await", "compat"] }
 hyperactor = { version = "0.0.0", path = "../hyperactor" }
+hyperactor_mesh = { version = "0.0.0", path = "../hyperactor_mesh" }
 hyperactor_multiprocess = { version = "0.0.0", path = "../hyperactor_multiprocess" }
 itertools = "0.14.0"
 monarch_messages = { version = "0.0.0", path = "../monarch_messages" }

--- a/monarch_tensor_worker/src/lib.rs
+++ b/monarch_tensor_worker/src/lib.rs
@@ -56,12 +56,16 @@ use device_mesh::DeviceMesh;
 use futures::future::try_join_all;
 use hyperactor::Actor;
 use hyperactor::ActorRef;
+use hyperactor::Handler;
 use hyperactor::Instance;
+use hyperactor::Named;
 use hyperactor::actor::ActorHandle;
 use hyperactor::cap;
 use hyperactor::forward;
 use hyperactor::message::IndexedErasedUnbound;
 use hyperactor::reference::ActorId;
+
+use hyperactor_mesh::actor_mesh::Cast;
 use itertools::Itertools;
 use monarch_messages::controller::ControllerActor;
 use monarch_messages::controller::ControllerMessageClient;
@@ -83,6 +87,8 @@ use monarch_types::PyTree;
 use ndslice::Slice;
 use pipe::PipeActor;
 use pipe::PipeParams;
+use serde::Deserialize;
+use serde::Serialize;
 use sorted_vec::SortedVec;
 use stream::StreamActor;
 use stream::StreamMessageClient;
@@ -141,7 +147,7 @@ enum Recording {
 ///
 /// See [`WorkerMessage`] for what it can do!
 #[derive(Debug)]
-#[hyperactor::export_spawn(WorkerMessage, IndexedErasedUnbound<WorkerMessage>)]
+#[hyperactor::export_spawn(WorkerMessage, IndexedErasedUnbound<WorkerMessage>, Cast<AssignRankMessage>, Cast<WorkerMessage>, IndexedErasedUnbound<Cast<AssignRankMessage>>, IndexedErasedUnbound<Cast<WorkerMessage>>)]
 pub struct WorkerActor {
     device: Option<CudaDevice>,
     streams: HashMap<StreamRef, Arc<ActorHandle<StreamActor>>>,
@@ -239,6 +245,36 @@ impl Actor for WorkerActor {
     }
 
     // TODO: Exit the worker directly on any worker actor errors, with error exit code.
+}
+
+#[async_trait]
+impl Handler<Cast<AssignRankMessage>> for WorkerActor {
+    async fn handle(
+        &mut self,
+        _this: &Instance<Self>,
+        message: Cast<AssignRankMessage>,
+    ) -> anyhow::Result<()> {
+        self.rank = message.rank.0;
+        Ok(())
+    }
+}
+
+/// Worker messages. These define the observable behavior of the worker, so the
+/// documentations here
+#[derive(Handler, Clone, Serialize, Deserialize, Debug, Named)]
+pub enum AssignRankMessage {
+    AssignRank(),
+}
+
+#[async_trait]
+impl Handler<Cast<WorkerMessage>> for WorkerActor {
+    async fn handle(
+        &mut self,
+        this: &Instance<Self>,
+        message: Cast<WorkerMessage>,
+    ) -> anyhow::Result<()> {
+        WorkerMessageHandler::handle(self, this, message.message).await
+    }
 }
 
 #[async_trait]
@@ -741,6 +777,7 @@ impl WorkerMessageHandler for WorkerActor {
             tracing::info!("stopping the worker process, exit code: {}", exit_code);
             std::process::exit(exit_code);
         }
+        this.stop()?;
         Ok(())
     }
 

--- a/ndslice/src/shape.rs
+++ b/ndslice/src/shape.rs
@@ -234,7 +234,7 @@ impl Shape {
             .collect())
     }
 
-    fn dim(&self, label: &str) -> Result<usize, ShapeError> {
+    pub fn dim(&self, label: &str) -> Result<usize, ShapeError> {
         self.labels
             .iter()
             .position(|l| l == label)

--- a/ndslice/src/slice.rs
+++ b/ndslice/src/slice.rs
@@ -6,6 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+use std::iter::zip;
+
 use serde::Deserialize;
 use serde::Serialize;
 
@@ -168,6 +170,17 @@ impl Slice {
     /// element at a given index in the underlying array.
     pub fn strides(&self) -> &[usize] {
         &self.strides
+    }
+
+    pub fn is_contiguous(&self) -> bool {
+        let mut expected_stride = 1;
+        for (stride, size) in zip(self.strides.iter(), self.sizes.iter()).rev() {
+            if *stride != expected_stride {
+                return false;
+            }
+            expected_stride *= *size
+        }
+        true
     }
 
     /// Return the location of the provided coordinates.

--- a/python/monarch/_rust_bindings/monarch_extension/client.pyi
+++ b/python/monarch/_rust_bindings/monarch_extension/client.pyi
@@ -46,7 +46,7 @@ class Error(Exception):
         ...
 
     @staticmethod
-    def new_for_unit_test(
+    def new(
         seq: int, caused_by_seq: int, actor_id: ActorId, backtrace: str
     ) -> "Error": ...
 
@@ -74,7 +74,7 @@ class Failure(Exception):
         ...
 
     @staticmethod
-    def new_for_unit_test(actor_id: ActorId) -> "Failure": ...
+    def new(actor_id: ActorId) -> "Failure": ...
 
 @final
 class WorkerResponse:
@@ -109,7 +109,7 @@ class WorkerResponse:
         ...
 
     @staticmethod
-    def new_for_unit_test(*, seq: int, response: Any) -> "WorkerResponse": ...
+    def new(*, seq: int, response: Any) -> "WorkerResponse": ...
 
 @final
 class LogLevel:

--- a/python/monarch/_rust_bindings/monarch_extension/mesh_controller.pyi
+++ b/python/monarch/_rust_bindings/monarch_extension/mesh_controller.pyi
@@ -1,0 +1,33 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import List, NamedTuple, Sequence, Union
+
+from monarch._rust_bindings.monarch_extension import client
+from monarch._rust_bindings.monarch_hyperactor.proc import ActorId
+from monarch._rust_bindings.monarch_hyperactor.proc_mesh import ProcMesh
+
+from monarch._rust_bindings.monarch_hyperactor.shape import Slice as NDSlice
+
+class _Controller:
+    def __init__(self) -> None: ...
+    def node(
+        self, seq: int, defs: Sequence[object], uses: Sequence[object]
+    ) -> None: ...
+    def drop_refs(self, refs: Sequence[object]) -> None: ...
+    def send(
+        self,
+        ranks: Union[NDSlice, List[NDSlice]],
+        msg: NamedTuple,
+    ) -> None: ...
+    def _get_next_message(
+        self, *, timeout_msec: int | None = None
+    ) -> client.WorkerResponse | client.DebuggerMessage | None: ...
+    def _debugger_attach(self, debugger_actor_id: ActorId) -> None: ...
+    def _debugger_write(self, debugger_actor_id: ActorId, data: bytes) -> None: ...
+    def _drain_and_stop(
+        self,
+    ) -> List[client.LogMessage | client.WorkerResponse | client.DebuggerMessage]: ...

--- a/python/monarch/mesh_controller.py
+++ b/python/monarch/mesh_controller.py
@@ -1,0 +1,209 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import logging
+import traceback
+from collections import deque
+from logging import Logger
+from typing import List, NamedTuple, Optional, Union
+
+import torch.utils._python_dispatch
+
+from monarch import DeviceMesh, NDSlice
+from monarch._rust_bindings.monarch_extension import client, debugger
+from monarch._rust_bindings.monarch_extension.client import (  # @manual=//monarch/monarch_extension:monarch_extension
+    WorldState,
+)
+from monarch._rust_bindings.monarch_extension.mesh_controller import _Controller
+from monarch._rust_bindings.monarch_hyperactor.proc import (  # @manual=//monarch/monarch_extension:monarch_extension
+    ActorId,
+)
+from monarch._rust_bindings.monarch_hyperactor.proc_mesh import ProcMesh as HyProcMesh
+from monarch._rust_bindings.monarch_messages.debugger import DebuggerAction
+from monarch.common.client import Client
+from monarch.common.controller_api import LogMessage, MessageResult
+from monarch.common.device_mesh import DeviceMesh, no_mesh
+from monarch.common.invocation import DeviceException, RemoteException
+from monarch.controller.debugger import read as debugger_read, write as debugger_write
+from monarch.proc_mesh import ProcMesh
+from pyre_extensions import none_throws
+
+logger: Logger = logging.getLogger(__name__)
+
+
+class Controller(_Controller):
+    def __init__(self, workers: HyProcMesh) -> None:
+        super().__init__()
+        # Buffer for messages unrelated to debugging that are received while a
+        # debugger session is active.
+        self._non_debugger_pending_messages: deque[
+            Optional[client.LogMessage | client.WorkerResponse]
+        ] = deque()
+        self._pending_debugger_sessions: deque[ActorId] = deque()
+
+    def next_message(
+        self, timeout: Optional[float]
+    ) -> Optional[LogMessage | MessageResult]:
+        if self._non_debugger_pending_messages:
+            msg = self._non_debugger_pending_messages.popleft()
+        else:
+            msg = self._get_next_message(timeout_msec=int((timeout or 0.0) * 1000.0))
+        if msg is None:
+            return None
+
+        if isinstance(msg, client.WorkerResponse):
+            return _worker_response_to_result(msg)
+        elif isinstance(msg, client.LogMessage):
+            return LogMessage(msg.level, msg.message)
+        elif isinstance(msg, client.DebuggerMessage):
+            self._run_debugger_loop(msg)
+
+    def send(
+        self,
+        ranks: Union[NDSlice, List[NDSlice]],
+        msg: NamedTuple,
+    ) -> None:
+        with torch.utils._python_dispatch._disable_current_modes():
+            return super().send(ranks, msg)
+
+    def drain_and_stop(
+        self,
+    ) -> List[LogMessage | MessageResult | client.DebuggerMessage]:
+        logger.info("rust controller shutting down")
+        results = []
+        for msg in self._drain_and_stop():
+            if isinstance(msg, client.WorkerResponse):
+                results.append(_worker_response_to_result(msg))
+            elif isinstance(msg, client.LogMessage):
+                results.append(LogMessage(msg.level, msg.message))
+            elif isinstance(msg, client.DebuggerMessage):
+                results.append(msg)
+            else:
+                raise RuntimeError(f"Unexpected message type {type(msg)}")
+        return results
+
+    def _run_debugger_loop(self, message: client.DebuggerMessage) -> None:
+        if not isinstance(message.action, DebuggerAction.Paused):
+            raise RuntimeError(
+                f"Unexpected debugger message {message} when no debugger session is running"
+            )
+
+        self._pending_debugger_sessions.append(message.debugger_actor_id)
+        while self._pending_debugger_sessions:
+            debugger_actor_id = self._pending_debugger_sessions.popleft()
+            rank = debugger_actor_id.rank
+            proc_id = debugger_actor_id.proc_id
+            debugger_write(
+                f"pdb attached to proc {proc_id} with rank {rank}, debugger actor {debugger_actor_id} \n"
+            )
+
+            self._debugger_attach(debugger_actor_id)
+            while True:
+                # TODO: Add appropriate timeout.
+                msg = self._get_next_message(timeout_msec=None)
+
+                if not isinstance(msg, client.DebuggerMessage):
+                    self._non_debugger_pending_messages.append(msg)
+                    continue
+
+                if msg.debugger_actor_id != debugger_actor_id:
+                    if isinstance(msg.action, DebuggerAction.Paused):
+                        self._pending_debugger_sessions.append(msg.debugger_actor_id)
+                        continue
+                    else:
+                        raise RuntimeError(
+                            f"unexpected debugger message {msg} from rank {msg.debugger_actor_id.rank} "
+                            f"when debugging rank {debugger_actor_id.rank}"
+                        )
+
+                action = msg.action
+                if isinstance(action, DebuggerAction.Detach):
+                    break
+                elif isinstance(action, DebuggerAction.Read):
+                    self._debugger_write(
+                        debugger_actor_id, debugger_read(action.requested_size)
+                    )
+                elif isinstance(action, DebuggerAction.Write):
+                    debugger_write(
+                        debugger.get_bytes_from_write_action(action).decode()
+                    )
+                else:
+                    raise RuntimeError(
+                        f"unexpected debugger message {msg} when debugging rank {debugger_actor_id.rank}"
+                    )
+
+    def worker_world_state(self) -> WorldState:
+        raise NotImplementedError("worker world state")
+
+    def stop_mesh(self):
+        # I think this is a noop?
+
+        pass
+
+
+# TODO: Handling conversion of the response can move to a separate module over time
+# especially as we have structured error messages.
+def _worker_response_to_result(result: client.WorkerResponse) -> MessageResult:
+    if not result.is_exception():
+        # The result of the message needs to be unwrapped on a real device.
+        # Staying as a fake tensor will fail the tensor deserialization.
+        with no_mesh.activate():
+            return MessageResult(result.seq, result.result(), None)
+    exc = none_throws(result.exception())
+    if isinstance(exc, client.Error):
+        worker_frames = [
+            traceback.FrameSummary("<unknown>", None, frame)
+            for frame in exc.backtrace.split("\\n")
+        ]
+        logger.error(f"Worker {exc.actor_id} failed")
+        return MessageResult(
+            seq=result.seq,
+            result=None,
+            error=RemoteException(
+                seq=exc.caused_by_seq,
+                exception=RuntimeError(exc.backtrace),
+                controller_frame_index=0,  # TODO: T225205291 fix this once we have recording support in rust
+                controller_frames=None,
+                worker_frames=worker_frames,
+                source_actor_id=exc.actor_id,
+                message=f"Worker {exc.actor_id} failed",
+            ),
+        )
+    elif isinstance(exc, client.Failure):
+        frames = [
+            traceback.FrameSummary("<unknown>", None, frame)
+            for frame in exc.backtrace.split("\n")
+        ]
+        reason = f"Actor {exc.actor_id} crashed on {exc.address}, check the host log for details"
+        logger.error(reason)
+        return MessageResult(
+            seq=0,  # seq is not consumed for DeviceException; it will be directly thrown by the client
+            result=None,
+            error=DeviceException(
+                exception=RuntimeError(reason),
+                frames=frames,
+                source_actor_id=exc.actor_id,
+                message=reason,
+            ),
+        )
+    else:
+        raise RuntimeError(f"Unknown exception type: {type(exc)}")
+
+
+def spawn_tensor_engine(proc_mesh: ProcMesh) -> DeviceMesh:
+    # This argument to Controller
+    # is currently only used for debug printing. It should be fixed to
+    # report the proc ID instead of the rank it currently does.
+    gpus = proc_mesh.sizes.get("gpus", 1)
+    backend_ctrl = Controller(proc_mesh._proc_mesh)
+    client = Client(backend_ctrl, proc_mesh.size(), gpus)
+    dm = DeviceMesh(
+        client,
+        NDSlice.new_row_major(list(proc_mesh.sizes.values())),
+        tuple(proc_mesh.sizes.keys()),
+    )
+    dm.exit = lambda: client.shutdown()
+    return dm


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #187
* #147

Add the initialize controller class `mesh_controller` that can implement the tensor engine on top of the ProcMesh/ProcActor API.

The only example is currently a "hello world" that allocates and fetches a tensor.

Follow up PRs will integrate creating meshes this way into the testing code more deeply and fix the issues that come up with it.


This design assumes that supervision of stuff is going to be handled by the actor system and that tensor compute can just rely on that for monitoring and stuckness detection stuff.

This design has no ClientActor, and the ControllerActor only exists as a Instance handle for reading messages from the workers (which send some controller messages).

This does not attempt to clean up the existing RustController system yet, since it isn't feature equivalent or tested with it.

Differential Revision: [D75909313](https://our.internmc.facebook.com/intern/diff/D75909313/)