### PR TITLE
[monarch] improve error behavior during pickle/unpickling

### DIFF
--- a/monarch_hyperactor/src/mailbox.rs
+++ b/monarch_hyperactor/src/mailbox.rs
@@ -160,6 +160,12 @@ impl From<PortId> for PyPortId {
     }
 }
 
+impl From<PyPortId> for PortId {
+    fn from(port_id: PyPortId) -> Self {
+        port_id.inner
+    }
+}
+
 #[pymethods]
 impl PyPortId {
     #[new]

--- a/python/monarch/_rust_bindings/monarch_hyperactor/actor.pyi
+++ b/python/monarch/_rust_bindings/monarch_hyperactor/actor.pyi
@@ -8,7 +8,7 @@
 
 from typing import final, List, Protocol
 
-from monarch._rust_bindings.monarch_hyperactor.mailbox import Mailbox
+from monarch._rust_bindings.monarch_hyperactor.mailbox import Mailbox, PortId
 
 from monarch._rust_bindings.monarch_hyperactor.proc import ActorId, Proc, Serialized
 
@@ -97,7 +97,13 @@ class PythonMessage:
     the arguments to the method.
     """
 
-    def __init__(self, method: str, message: bytes) -> None: ...
+    def __init__(
+        self,
+        method: str,
+        message: bytes,
+        response_port: PortId | None = None,
+        rank_in_response: bool = False,
+    ) -> None: ...
     @property
     def method(self) -> str:
         """The method of the message."""
@@ -106,6 +112,16 @@ class PythonMessage:
     @property
     def message(self) -> bytes:
         """The pickled arguments."""
+        ...
+
+    @property
+    def response_port(self) -> PortId | None:
+        """The response port."""
+        ...
+
+    @property
+    def rank_in_response(self) -> bool:
+        """Whether or not to include the rank of the handling actor in the response."""
         ...
 
 @final


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #189

Today, if there is an error in unpickling the message content, it will kill the actor and generate a supervision event. We cannot respond on the port to generate an ActorError that the client can handle.

This is because the response Port itself we get from unpickling, so if there is an error during unpickling we don't have anywhere to send a response.

This diff moves the response port into the `PythonMessage` itself so that it can be unconditionally deserialized. I also had to remove `RankedPort` (since we can no longer rely on pickle to preserve that behavior), and make `rank_in_response` another first-class thing in `PythonMessage`.

I think this plus a few other changes should also be able to allow us to remove the mailbox serialization hack from `_pickle` and `_unpickle`, but I will address that in a forthcoming diff

Differential Revision: [D76171937](https://our.internmc.facebook.com/intern/diff/D76171937/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D76171937/)!