### PR TITLE
[monarch] make tensor_engine a crate feature of monarch_extension

### DIFF
--- a/monarch_extension/Cargo.toml
+++ b/monarch_extension/Cargo.toml
@@ -20,10 +20,9 @@ controller = { version = "0.0.0", path = "../controller", optional = true }
 hyperactor = { version = "0.0.0", path = "../hyperactor" }
 hyperactor_extension = { version = "0.0.0", path = "../hyperactor_extension" }
 hyperactor_multiprocess = { version = "0.0.0", path = "../hyperactor_multiprocess" }
-monarch-simulator-lib = { path = "../monarch-simulator", optional = true }
 monarch_hyperactor = { version = "0.0.0", path = "../monarch_hyperactor" }
 monarch_messages = { version = "0.0.0", path = "../monarch_messages", optional = true }
-monarch_simulator_lib = { version = "0.0.0", path = "../monarch_simulator" }
+monarch_simulator_lib = { version = "0.0.0", path = "../monarch_simulator", optional = true }
 monarch_tensor_worker = { version = "0.0.0", path = "../monarch_tensor_worker", optional = true }
 monarch_types = { version = "0.0.0", path = "../monarch_types" }
 nccl-sys = { path = "../nccl-sys", optional = true }

--- a/monarch_extension/Cargo.toml
+++ b/monarch_extension/Cargo.toml
@@ -16,19 +16,24 @@ crate-type = ["cdylib"]
 [dependencies]
 anyhow = "1.0.95"
 clap = { version = "4.5.38", features = ["derive", "env", "string", "unicode", "wrap_help"] }
-controller = { version = "0.0.0", path = "../controller" }
+controller = { version = "0.0.0", path = "../controller", optional = true }
 hyperactor = { version = "0.0.0", path = "../hyperactor" }
 hyperactor_extension = { version = "0.0.0", path = "../hyperactor_extension" }
 hyperactor_multiprocess = { version = "0.0.0", path = "../hyperactor_multiprocess" }
+monarch-simulator-lib = { path = "../monarch-simulator", optional = true }
 monarch_hyperactor = { version = "0.0.0", path = "../monarch_hyperactor" }
-monarch_messages = { version = "0.0.0", path = "../monarch_messages" }
+monarch_messages = { version = "0.0.0", path = "../monarch_messages", optional = true }
 monarch_simulator_lib = { version = "0.0.0", path = "../monarch_simulator" }
-monarch_tensor_worker = { version = "0.0.0", path = "../monarch_tensor_worker" }
+monarch_tensor_worker = { version = "0.0.0", path = "../monarch_tensor_worker", optional = true }
 monarch_types = { version = "0.0.0", path = "../monarch_types" }
-nccl-sys = { path = "../nccl-sys" }
+nccl-sys = { path = "../nccl-sys", optional = true }
 ndslice = { version = "0.0.0", path = "../ndslice" }
 pyo3 = { version = "0.22.6", features = ["anyhow"] }
 tokio = { version = "1.45.0", features = ["full", "test-util", "tracing"] }
-torch-sys = { version = "0.0.0", path = "../torch-sys" }
-torch-sys-cuda = { version = "0.0.0", path = "../torch-sys-cuda" }
+torch-sys = { version = "0.0.0", path = "../torch-sys", optional = true }
+torch-sys-cuda = { version = "0.0.0", path = "../torch-sys-cuda", optional = true }
 tracing = { version = "0.1.41", features = ["attributes", "valuable"] }
+
+[features]
+default = ["tensor_engine"]
+tensor_engine = ["dep:controller", "dep:monarch_messages", "dep:monarch_simulator_lib", "dep:monarch_tensor_worker", "dep:nccl-sys", "dep:torch-sys", "dep:torch-sys-cuda"]

--- a/monarch_extension/build.rs
+++ b/monarch_extension/build.rs
@@ -7,12 +7,16 @@
  */
 
 fn main() {
-    // `torch-sys` will set this env var through Cargo `links` metadata.
-    let lib_path = std::env::var("DEP_TORCH_LIB_PATH").expect("DEP_TORCH_LIB_PATH to be set");
-    // Set the rpath so that the dynamic linker can find libtorch and friends.
-    println!("cargo::rustc-link-arg=-Wl,-rpath,{lib_path}");
+    // Only set torch-related rpaths if tensor_engine feature is enabled
+    #[cfg(feature = "tensor_engine")]
+    {
+        // `torch-sys` will set this env var through Cargo `links` metadata.
+        let lib_path = std::env::var("DEP_TORCH_LIB_PATH").expect("DEP_TORCH_LIB_PATH to be set");
+        // Set the rpath so that the dynamic linker can find libtorch and friends.
+        println!("cargo::rustc-link-arg=-Wl,-rpath,{lib_path}");
 
-    if let Ok(path) = std::env::var("DEP_NCCL_LIB_PATH") {
-        println!("cargo::rustc-link-arg=-Wl,-rpath,{path}");
+        if let Ok(path) = std::env::var("DEP_NCCL_LIB_PATH") {
+            println!("cargo::rustc-link-arg=-Wl,-rpath,{path}");
+        }
     }
 }

--- a/monarch_extension/src/client.rs
+++ b/monarch_extension/src/client.rs
@@ -6,6 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#![cfg(feature = "tensor_engine")]
+
 use std::collections::HashMap;
 use std::sync::Arc;
 

--- a/monarch_extension/src/controller.rs
+++ b/monarch_extension/src/controller.rs
@@ -6,6 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#![cfg(feature = "tensor_engine")]
+
 /// These the controller messages that are exposed to python to allow the client to construct and
 /// send messages to the controller. For more details of the definitions take a look at
 /// [`monarch_messages::controller::ControllerMessage`].

--- a/monarch_extension/src/convert.rs
+++ b/monarch_extension/src/convert.rs
@@ -6,6 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#![cfg(feature = "tensor_engine")]
+
 use std::collections::HashMap;
 use std::sync::OnceLock;
 

--- a/monarch_extension/src/debugger.rs
+++ b/monarch_extension/src/debugger.rs
@@ -6,6 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#![cfg(feature = "tensor_engine")]
+
 use std::sync::Arc;
 
 use hyperactor::ActorRef;

--- a/monarch_extension/src/simulator_client.rs
+++ b/monarch_extension/src/simulator_client.rs
@@ -6,6 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#![cfg(feature = "tensor_engine")]
+
 use anyhow::anyhow;
 use hyperactor::PortId;
 use hyperactor::channel::ChannelAddr;

--- a/monarch_extension/src/tensor_worker.rs
+++ b/monarch_extension/src/tensor_worker.rs
@@ -6,6 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#![cfg(feature = "tensor_engine")]
+
 /// These are the worker messages exposed through pyo3 to python.
 /// The actual documentation of the messages can be found in [`monarch_messages::worker::WorkerMessage`]
 /// This split is currently needed to customize the constructors for the messages and due to the


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #196
* #195
* __->__ #194
* #192

Allow for conditional compilation of `tensor_engine`-related code.

This is a pre-cursor to a more substantive separation in layering of these two components.

In the end-state, `hyperactor` and `actor_mesh` shouldn't know about the tensor-engine (or torch) at all. This will help with testing, make it eeasier on environments without CUDA, etc.

This is just a convenient way to start, because it means we can turn the feature off and run Python tests to prove to ourselves there is actually no dependency, before we start a disruptive code migration.

Differential Revision: [D76232031](https://our.internmc.facebook.com/intern/diff/D76232031/)