### PR TITLE
[monarch] make py-spy unwind feature target-dependent

### DIFF
--- a/hyperactor_multiprocess/Cargo.toml
+++ b/hyperactor_multiprocess/Cargo.toml
@@ -17,7 +17,6 @@ futures = { version = "0.3.30", features = ["async-await", "compat"] }
 hyperactor = { version = "0.0.0", path = "../hyperactor" }
 hyperactor_mesh = { version = "0.0.0", path = "../hyperactor_mesh" }
 hyperactor_telemetry = { version = "0.0.0", path = "../hyperactor_telemetry" }
-py-spy = { git = "https://github.com/technicianted/py-spy", rev = "8f74f3e4f955fee57f0d4a8103511ee788348a2a", features = ["unwind"] }
 remoteprocess = { git = "https://github.com/technicianted/remoteprocess", rev = "72505594a19d80c07df6f1dc4a80556b7e462148" }
 serde = { version = "1.0.185", features = ["derive", "rc"] }
 thiserror = "2.0.12"
@@ -32,3 +31,9 @@ regex = "1.11.1"
 serde_json = { version = "1.0.140", features = ["float_roundtrip", "unbounded_depth"] }
 timed_test = { version = "0.0.0", path = "../timed_test" }
 tracing-test = { version = "0.2.3", features = ["no-env-filter"] }
+
+[target.'cfg(not(target_os = "linux"))'.dependencies]
+py-spy = { git = "https://github.com/technicianted/py-spy", rev = "8f74f3e4f955fee57f0d4a8103511ee788348a2a" }
+
+[target.'cfg(target_os = "linux")'.dependencies]
+py-spy = { git = "https://github.com/technicianted/py-spy", rev = "8f74f3e4f955fee57f0d4a8103511ee788348a2a", features = ["unwind"] }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #196
* __->__ #195
* #194
* #192

libunwind doesn't exist on macos, so don't rely on this feature if we are building on mac

Differential Revision: [D76232591](https://our.internmc.facebook.com/intern/diff/D76232591/)