### PR TITLE
[monarch] fix race conditions in port splitting tests

### DIFF
--- a/hyperactor/src/cap.rs
+++ b/hyperactor/src/cap.rs
@@ -47,7 +47,12 @@ pub(crate) mod sealed {
     }
 
     pub trait CanSplitPort: Send + Sync {
-        fn split(&self, port_id: PortId, reducer: Option<u64>) -> PortId;
+        fn split(
+            &self,
+            port_id: PortId,
+            reducer: Option<u64>,
+            buffer_size: Option<usize>,
+        ) -> PortId;
     }
 
     #[async_trait]

--- a/hyperactor/src/proc.rs
+++ b/hyperactor/src/proc.rs
@@ -1162,8 +1162,13 @@ impl<A: Actor> cap::sealed::CanOpenPort for Instance<A> {
 }
 
 impl<A: Actor> cap::sealed::CanSplitPort for Instance<A> {
-    fn split(&self, port_id: PortId, reducer_typehash: Option<u64>) -> PortId {
-        self.mailbox.split(port_id, reducer_typehash)
+    fn split(
+        &self,
+        port_id: PortId,
+        reducer_typehash: Option<u64>,
+        buffer_size: Option<usize>,
+    ) -> PortId {
+        self.mailbox.split(port_id, reducer_typehash, buffer_size)
     }
 }
 

--- a/hyperactor/src/reference.rs
+++ b/hyperactor/src/reference.rs
@@ -726,7 +726,18 @@ impl PortId {
     /// Split this port, returning a new port that relays messages to the port
     /// through a local proxy, which may coalesce messages.
     pub fn split(&self, caps: &impl cap::CanSplitPort, reducer_typehash: Option<u64>) -> PortId {
-        caps.split(self.clone(), reducer_typehash)
+        self.split_with_buffer_size(caps, reducer_typehash, None)
+    }
+
+    /// Split this port with a custom buffer size, returning a new port that relays messages to the port
+    /// through a local proxy, which may coalesce messages based on the specified buffer size.
+    pub fn split_with_buffer_size(
+        &self,
+        caps: &impl cap::CanSplitPort,
+        reducer_typehash: Option<u64>,
+        buffer_size: Option<usize>,
+    ) -> PortId {
+        caps.split(self.clone(), reducer_typehash, buffer_size)
     }
 }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #197

Two issues, both exposed when running in a one-process-multi-thread test setup:
1. Using env var to configure buffer size led to races.
2. setting log level will panic if you do it twice in the same process.

For the env var one, I threaded buffer size as an optional argument, with the default still initialized through the env var. Happy to do whatever though.

Differential Revision: [D76240322](https://our.internmc.facebook.com/intern/diff/D76240322/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D76240322/)!