### PR TITLE
[monarch][hyperactor] fix panic handler test

### DIFF
--- a/hyperactor/src/panic_handler.rs
+++ b/hyperactor/src/panic_handler.rs
@@ -169,7 +169,11 @@ mod tests {
             assert!(result.is_ok());
 
             // Verify the outer task can get its own backtrace.
-            assert!(take_panic_backtrace().unwrap().contains("execute_panic"));
+            assert!(
+                take_panic_backtrace()
+                    .unwrap()
+                    .contains("test_nested_tasks")
+            );
         })
         .await;
     }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #212

this test is somewhat questionable, it asserts on a particular item in the stack trace, which may get optimized out. Seems that D76315082 jittered the compiler enough that it indeed gets optimized out; dev mode still works but opt mode fails.


Change the assertion to check something less likely to get optimized out.

Differential Revision: [D76348108](https://our.internmc.facebook.com/intern/diff/D76348108/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D76348108/)!