### PR TITLE
Improve Python Stack retention

### DIFF
--- a/monarch_hyperactor/src/actor.rs
+++ b/monarch_hyperactor/src/actor.rs
@@ -25,6 +25,7 @@ use hyperactor::message::IndexedErasedUnbound;
 use hyperactor::message::Unbind;
 use hyperactor_mesh::actor_mesh::Cast;
 use monarch_types::PickledPyObject;
+use monarch_types::SerializablePyErr;
 use pyo3::exceptions::PyBaseException;
 use pyo3::exceptions::PyRuntimeError;
 use pyo3::prelude::*;
@@ -268,7 +269,7 @@ impl Actor for PythonActor {
     type Params = PickledPyObject;
 
     async fn new(actor_type: PickledPyObject) -> Result<Self, anyhow::Error> {
-        Ok(Python::with_gil(|py| -> PyResult<Self> {
+        Ok(Python::with_gil(|py| -> Result<Self, SerializablePyErr> {
             let unpickled = actor_type.unpickle(py)?;
             let class_type: &Bound<'_, PyType> = unpickled.downcast()?;
             let actor: PyObject = class_type.call0()?.to_object(py);
@@ -403,7 +404,7 @@ impl Handler<PythonMessage> for PythonActor {
         // See [Panics in async endpoints].
         let (sender, receiver) = oneshot::channel();
 
-        let future = Python::with_gil(|py| -> PyResult<_> {
+        let future = Python::with_gil(|py| -> Result<_, SerializablePyErr> {
             let mailbox = PyMailbox {
                 inner: this.mailbox_for_py().clone(),
             };
@@ -430,6 +431,7 @@ impl Handler<PythonMessage> for PythonActor {
                 awaitable.into_bound(py),
             )
             .map(Some)
+            .map_err(|err| err.into())
         })?;
 
         if let Some(future) = future {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #213

This makes SerializedPyError match the exact formatting of python exceptions by using TracebackException to format it. It also ensures that it prepends any current members of the python stack to the Exceptions traceback before formatting. Normally exceptions are only reported after being completely unwound to the root of the python stack. But in most cases when we are capturing a Python exception it is because we are going to move it across the network. We might not have competely unwound the stack at the point we do the serialization, but this unwound stack is still potentially useful. So we also include these frames by adding them to the traceback object.

This also updates two places in PythonActor where exceptions would lose stack traces by going from PyErr -> anyhow::Error. By changing the result type to Result<_, SerialiablePyErr> we force it to capture the stack trace.

Differential Revision: [D76316820](https://our.internmc.facebook.com/intern/diff/D76316820/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D76316820/)!