### PR TITLE
Propagating errors is not an error.

### DIFF
--- a/monarch_tensor_worker/src/stream.rs
+++ b/monarch_tensor_worker/src/stream.rs
@@ -986,7 +986,9 @@ impl StreamMessageHandler for StreamActor {
                             backtrace: format!("{err}"),
                             worker_actor_id: this.self_id().clone(),
                         };
-                        tracing::error!("{worker_error}");
+                        tracing::info!(
+                            "Propagating remote function error to client: {worker_error}"
+                        );
                         self.controller_actor
                             .remote_function_failed(this, params.seq, worker_error)
                             .await?;

--- a/python/monarch/common/client.py
+++ b/python/monarch/common/client.py
@@ -302,7 +302,7 @@ class Client:
         self.last_processed_seq = max(self.last_processed_seq, seq)
 
         if error is not None:
-            logging.error("Received error for seq %s: %s", seq, error)
+            logging.info("Received error for seq %s: %s", seq, error)
             # We should not have set result if we have an error.
             assert result is None
             if not isinstance(error, RemoteException):
@@ -332,9 +332,7 @@ class Client:
         elif error is not None:
             # errors get reported as results even if they
             # do not have futures attached.
-            logger.warning(
-                f"Error encountered for this instruction {seq}. Proceeding forward because error is unused and unhandled. Error details:\n{error}."
-            )
+            pass
 
         # We can safely delete the seq as tracebacks have been saved to the remote failure itself.
         del self.pending_results[seq]

--- a/python/monarch/common/stream.py
+++ b/python/monarch/common/stream.py
@@ -82,6 +82,9 @@ class StreamRef(Referenceable):
             messages.CreateStream(self, self.default),
         )
 
+    def __repr__(self):
+        return f"<StreamRef {repr(self.name)} {self.ref}>"
+
     def delete_ref(self, ref):
         client = self.client()
         if client is not None and not client._shutdown:

--- a/python/monarch/mesh_controller.py
+++ b/python/monarch/mesh_controller.py
@@ -158,7 +158,6 @@ def _worker_response_to_result(result: client.WorkerResponse) -> MessageResult:
             traceback.FrameSummary("<unknown>", None, frame)
             for frame in exc.backtrace.split("\\n")
         ]
-        logger.error(f"Worker {exc.actor_id} failed")
         return MessageResult(
             seq=result.seq,
             result=None,
@@ -169,7 +168,7 @@ def _worker_response_to_result(result: client.WorkerResponse) -> MessageResult:
                 controller_frames=None,
                 worker_frames=worker_frames,
                 source_actor_id=exc.actor_id,
-                message=f"Worker {exc.actor_id} failed",
+                message=f"Remote function in {exc.actor_id} errored.",
             ),
         )
     elif isinstance(exc, client.Failure):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #199
* __->__ #219
* #218

Log spew when something goes wrong makes it hard to see which part is actually broken.

Reducing the severity of logging when we just propagate an error message along the chain of reporting. Errors that are user generated are not a sign that the monarch components that move the errors around are working sub-optiminally so anything over an `info` at this level is probably not right.

Removed at least one redundant log where we get two messages.

Ultimately, we should be checking errors in the global context on client script exit, and logging to the user console until that point.

Differential Revision: [D76377545](https://our.internmc.facebook.com/intern/diff/D76377545/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D76377545/)!