### PR TITLE
Implement hyperactor configuration with an attribute dictionary. This makes the configuration extensible -- downstream crates can define their own keys -- and provides a uniform way to define, access, store, and load hyperactor related configuration.

### DIFF
--- a/hyperactor/src/attrs.rs
+++ b/hyperactor/src/attrs.rs
@@ -206,7 +206,7 @@ impl Attrs {
     }
 
     /// Get a value for the given key, returning None if not present.
-    pub fn get<T: Send + Sync + Serialize + DeserializeOwned + Named + Clone + 'static>(
+    pub fn get<T: Send + Sync + Serialize + DeserializeOwned + Named + 'static>(
         &self,
         key: Key<T>,
     ) -> Option<&T> {
@@ -234,7 +234,7 @@ impl Attrs {
         self.values.remove(key.name).is_some()
     }
 
-    /// Returns true if the dictionary contains a value for the given key.
+    /// Checks if the given key exists in the dictionary.
     pub fn contains_key<T: Send + Sync + Serialize + DeserializeOwned + Named + 'static>(
         &self,
         key: Key<T>,
@@ -255,6 +255,22 @@ impl Attrs {
     /// Clear all key-value pairs from the dictionary.
     pub fn clear(&mut self) {
         self.values.clear();
+    }
+
+    // Internal methods for config guard support
+    /// Take a value by key name, returning the boxed value if present
+    pub(crate) fn take_value<T>(&mut self, key: Key<T>) -> Option<Box<dyn SerializableValue>> {
+        self.values.remove(key.name)
+    }
+
+    /// Restore a value by key name
+    pub(crate) fn restore_value<T>(&mut self, key: Key<T>, value: Box<dyn SerializableValue>) {
+        self.values.insert(key.name, value);
+    }
+
+    /// Remove a value by key name
+    pub(crate) fn remove_value<T>(&mut self, key: &Key<T>) -> bool {
+        self.values.remove(key.name).is_some()
     }
 }
 
@@ -530,7 +546,7 @@ mod tests {
         attrs.set(TEST_COUNT, 42u32);
 
         let removed = attrs.remove(TEST_COUNT);
-        assert_eq!(removed, Some(42u32));
+        assert!(removed);
         assert_eq!(attrs.get(TEST_COUNT), None);
         assert!(!attrs.contains_key(TEST_COUNT));
     }

--- a/hyperactor/src/channel/mod.rs
+++ b/hyperactor/src/channel/mod.rs
@@ -757,12 +757,11 @@ mod tests {
 
     #[tokio::test]
     async fn test_send() {
+        let config = crate::config::global::lock();
+        
         // Use temporary config for this test
-        let _guard = crate::config::global::set_temp_config(crate::config::Config {
-            message_delivery_timeout: Duration::from_secs(1),
-            message_ack_every_n_messages: 1,
-            ..Default::default()
-        });
+        let _guard1 = config.override_key(crate::config::MESSAGE_DELIVERY_TIMEOUT, Duration::from_secs(1));
+        let _guard2 = config.override_key(crate::config::MESSAGE_ACK_EVERY_N_MESSAGES, 1);
         for addr in addrs() {
             let (listen_addr, mut rx) = crate::channel::serve::<i32>(addr).await.unwrap();
             let tx = crate::channel::dial(listen_addr).unwrap();

--- a/hyperactor/src/channel/net.rs
+++ b/hyperactor/src/channel/net.rs
@@ -1915,11 +1915,9 @@ mod tests {
     async fn test_tcp_message_size() {
         let default_size_in_bytes = 100 * 1024 * 1024;
         // Use temporary config for this test
-        let _guard = config::global::set_temp_config(crate::Config {
-            message_delivery_timeout: Duration::from_secs(1),
-            codec_max_frame_length: default_size_in_bytes,
-            ..Default::default()
-        });
+        let config = config::global::lock();
+        let _guard1 = config.override_key(crate::config::MESSAGE_DELIVERY_TIMEOUT, Duration::from_secs(1));
+        let _guard2 = config.override_key(crate::config::CODEC_MAX_FRAME_LENGTH, default_size_in_bytes);
 
         set_tracing_env_filter(Level::DEBUG);
         let (addr, mut rx) = tcp::serve::<String>("[::1]:0".parse().unwrap())
@@ -1949,10 +1947,8 @@ mod tests {
     #[async_timed_test(timeout_secs = 30)]
     async fn test_tcp_reconnect() {
         // Use temporary config for this test
-        let _guard = config::global::set_temp_config(Config {
-            message_ack_every_n_messages: 1,
-            ..Default::default()
-        });
+        let config = config::global::lock();
+        let _guard = config.override_key(crate::config::MESSAGE_ACK_EVERY_N_MESSAGES, 1);
         let socket_addr: SocketAddr = "[::1]:0".parse().unwrap();
         let (local_addr, mut rx1) = tcp::serve::<u64>(socket_addr).await.unwrap();
         let local_socket = match local_addr {
@@ -2390,10 +2386,8 @@ mod tests {
     #[async_timed_test(timeout_secs = 30)]
     async fn test_persistent_server_session() {
         // Use temporary config for this test
-        let _guard = config::global::set_temp_config(Config {
-            message_ack_every_n_messages: 1,
-            ..Default::default()
-        });
+        let config = config::global::lock();
+        let _guard = config.override_key(crate::config::MESSAGE_ACK_EVERY_N_MESSAGES, 1);
         async fn verify_ack(
             framed: &mut Framed<DuplexStream, LengthDelimitedCodec>,
             expected_last: u64,
@@ -2487,10 +2481,8 @@ mod tests {
     #[async_timed_test(timeout_secs = 60)]
     async fn test_ack_from_server_sesssion() {
         // Use temporary config for this test
-        let _guard = config::global::set_temp_config(Config {
-            message_ack_every_n_messages: 1,
-            ..Default::default()
-        });
+        let config = config::global::lock();
+        let _guard = config.override_key(crate::config::MESSAGE_ACK_EVERY_N_MESSAGES, 1);
         hyperactor::test_utils::tracing::set_tracing_env_filter(tracing::Level::DEBUG);
         let manager = SessionManager::new();
         let session_id = 123;
@@ -2552,10 +2544,8 @@ mod tests {
         let link = MockLink::<u64>::fail_connects();
         let tx = NetTx::<u64>::new(link);
         // Override the default (1m) for the purposes of this test.
-        let _guard = config::global::set_temp_config(Config {
-            message_delivery_timeout: Duration::from_secs(1),
-            ..Default::default()
-        });
+        let config = config::global::lock();
+        let _guard = config.override_key(crate::config::MESSAGE_DELIVERY_TIMEOUT, Duration::from_secs(1));
         let mut tx_receiver = tx.status().clone();
         let (return_channel, _return_receiver) = oneshot::channel();
         tx.try_post(123, return_channel).unwrap();
@@ -2807,10 +2797,8 @@ mod tests {
 
     async fn verify_ack_exceeded_limit(disconnect_before_ack: bool) {
         // Use temporary config for this test
-        let _guard = config::global::set_temp_config(Config {
-            message_delivery_timeout: Duration::from_secs(2),
-            ..Default::default()
-        });
+        let config = config::global::lock();
+        let _guard = config.override_key(crate::config::MESSAGE_DELIVERY_TIMEOUT, Duration::from_secs(2));
 
         let link: MockLink<u64> = MockLink::<u64>::new();
         let disconnect_signal = link.disconnect_signal().clone();
@@ -2933,22 +2921,18 @@ mod tests {
     #[async_timed_test(timeout_secs = 30)]
     async fn test_ack_every_n_messages() {
         // Use temporary config for this test
-        let _guard = config::global::set_temp_config(Config {
-            message_ack_every_n_messages: 600,
-            message_ack_time_interval: Duration::from_millis(1000000),
-            ..Default::default()
-        });
+        let config = config::global::lock();
+        let _guard1 = config.override_key(crate::config::MESSAGE_ACK_EVERY_N_MESSAGES, 600);
+        let _guard2 = config.override_key(crate::config::MESSAGE_ACK_TIME_INTERVAL, Duration::from_millis(1000000));
         sparse_ack().await;
     }
 
     #[async_timed_test(timeout_secs = 30)]
     async fn test_ack_every_time_interval() {
         // Use temporary config for this test
-        let _guard = config::global::set_temp_config(Config {
-            message_ack_every_n_messages: 100000000,
-            message_ack_time_interval: Duration::from_millis(500),
-            ..Default::default()
-        });
+        let config = config::global::lock();
+        let _guard1 = config.override_key(crate::config::MESSAGE_ACK_EVERY_N_MESSAGES, 100000000);
+        let _guard2 = config.override_key(crate::config::MESSAGE_ACK_TIME_INTERVAL, Duration::from_millis(500));
         sparse_ack().await;
     }
 
@@ -3015,10 +2999,8 @@ mod tests {
     #[async_timed_test(timeout_secs = 300)]
     async fn test_tcp_throughput() {
         // Use temporary config for this test
-        let _guard = config::global::set_temp_config(Config {
-            message_delivery_timeout: Duration::from_secs(300),
-            ..Default::default()
-        });
+        let config = config::global::lock();
+        let _guard = config.override_key(crate::config::MESSAGE_DELIVERY_TIMEOUT, Duration::from_secs(300));
         set_tracing_env_filter(Level::DEBUG);
         let socket_addr: SocketAddr = "[::1]:0".parse().unwrap();
         let (local_addr, mut rx) = tcp::serve::<String>(socket_addr).await.unwrap();

--- a/hyperactor/src/config.rs
+++ b/hyperactor/src/config.rs
@@ -9,9 +9,8 @@
 //! Configuration for Hyperactor.
 //!
 //! This module provides a centralized way to manage configuration settings for Hyperactor.
-//! It abstracts away environment variables and allows configuration to be sourced from
-//! different places (environment variables, YAML files, command line flags).
-//! It also supports temporary modifications for tests.
+//! It uses the attrs system for type-safe, flexible configuration management that supports
+//! environment variables, YAML files, and temporary modifications for tests.
 
 use std::env;
 use std::fs::File;
@@ -22,45 +21,74 @@ use std::sync::LazyLock;
 use std::sync::RwLock;
 use std::time::Duration;
 
-use serde::Deserialize;
-use serde::Serialize;
+use crate::attrs::Attrs;
+use crate::attrs::declare_attr_key;
 
-/// Configuration for Hyperactor.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+// Declare configuration keys using the attrs system
+declare_attr_key!(
+    CODEC_MAX_FRAME_LENGTH,
+    usize,
+    "Maximum frame length for codec"
+);
+
+declare_attr_key!(
+    MESSAGE_DELIVERY_TIMEOUT,
+    Duration,
+    "Message delivery timeout"
+);
+
+declare_attr_key!(
+    MESSAGE_ACK_TIME_INTERVAL,
+    Duration,
+    "Message acknowledgment interval"
+);
+
+declare_attr_key!(
+    MESSAGE_ACK_EVERY_N_MESSAGES,
+    u64,
+    "Number of messages after which to send an acknowledgment"
+);
+
+declare_attr_key!(
+    SPLIT_MAX_BUFFER_SIZE,
+    usize,
+    "Maximum buffer size for split port messages"
+);
+
+declare_attr_key!(
+    IS_MANAGED_SUBPROCESS,
+    bool,
+    "Flag indicating if this is a managed subprocess"
+);
+
+/// Configuration builder for Hyperactor.
+#[derive(Debug, Clone)]
 pub struct Config {
-    /// Maximum frame length for codec
-    pub codec_max_frame_length: usize,
-
-    /// Message delivery timeout
-    pub message_delivery_timeout: Duration,
-
-    /// Message acknowledgment interval
-    pub message_ack_time_interval: Duration,
-
-    /// Number of messages after which to send an acknowledgment
-    pub message_ack_every_n_messages: u64,
-
-    /// Maximum buffer size for split port messages
-    pub split_max_buffer_size: usize,
-
-    /// Flag indicating if this is a managed subprocess
-    pub is_managed_subprocess: bool,
+    attrs: Attrs,
 }
 
 impl Default for Config {
     fn default() -> Self {
-        Self {
-            codec_max_frame_length: 8 * 1024 * 1024, // 8 MB
-            message_delivery_timeout: Duration::from_secs(30),
-            message_ack_time_interval: Duration::from_millis(500),
-            message_ack_every_n_messages: 1000,
-            split_max_buffer_size: 5,
-            is_managed_subprocess: false,
-        }
+        let mut attrs = Attrs::new();
+
+        // Set default values
+        attrs.set(CODEC_MAX_FRAME_LENGTH, 8 * 1024 * 1024); // 8 MB
+        attrs.set(MESSAGE_DELIVERY_TIMEOUT, Duration::from_secs(30));
+        attrs.set(MESSAGE_ACK_TIME_INTERVAL, Duration::from_millis(500));
+        attrs.set(MESSAGE_ACK_EVERY_N_MESSAGES, 1000u64);
+        attrs.set(SPLIT_MAX_BUFFER_SIZE, 5usize);
+        attrs.set(IS_MANAGED_SUBPROCESS, false);
+
+        Self { attrs }
     }
 }
 
 impl Config {
+    /// Create a new configuration with default values
+    pub fn new() -> Self {
+        Self::default()
+    }
+
     /// Load configuration from environment variables
     pub fn from_env() -> Self {
         let mut config = Self::default();
@@ -68,40 +96,47 @@ impl Config {
         // Load codec max frame length
         if let Ok(val) = env::var("HYPERACTOR_CODEC_MAX_FRAME_LENGTH") {
             if let Ok(parsed) = val.parse::<usize>() {
-                config.codec_max_frame_length = parsed;
+                config.attrs.set(CODEC_MAX_FRAME_LENGTH, parsed);
             }
         }
 
         // Load message delivery timeout
         if let Ok(val) = env::var("HYPERACTOR_MESSAGE_DELIVERY_TIMEOUT_SECS") {
             if let Ok(parsed) = val.parse::<u64>() {
-                config.message_delivery_timeout = Duration::from_secs(parsed);
+                config
+                    .attrs
+                    .set(MESSAGE_DELIVERY_TIMEOUT, Duration::from_secs(parsed));
             }
         }
 
         // Load message ack time interval
         if let Ok(val) = env::var("HYPERACTOR_MESSAGE_ACK_TIME_INTERVAL_MS") {
             if let Ok(parsed) = val.parse::<u64>() {
-                config.message_ack_time_interval = Duration::from_millis(parsed);
+                config
+                    .attrs
+                    .set(MESSAGE_ACK_TIME_INTERVAL, Duration::from_millis(parsed));
             }
         }
 
         // Load message ack every n messages
         if let Ok(val) = env::var("HYPERACTOR_MESSAGE_ACK_EVERY_N_MESSAGES") {
             if let Ok(parsed) = val.parse::<u64>() {
-                config.message_ack_every_n_messages = parsed;
+                config.attrs.set(MESSAGE_ACK_EVERY_N_MESSAGES, parsed);
             }
         }
 
         // Load split max buffer size
         if let Ok(val) = env::var("HYPERACTOR_SPLIT_MAX_BUFFER_SIZE") {
             if let Ok(parsed) = val.parse::<usize>() {
-                config.split_max_buffer_size = parsed;
+                config.attrs.set(SPLIT_MAX_BUFFER_SIZE, parsed);
             }
         }
 
         // Check if this is a managed subprocess
-        config.is_managed_subprocess = env::var("HYPERACTOR_MANAGED_SUBPROCESS").is_ok();
+        config.attrs.set(
+            IS_MANAGED_SUBPROCESS,
+            env::var("HYPERACTOR_MANAGED_SUBPROCESS").is_ok(),
+        );
 
         config
     }
@@ -112,36 +147,242 @@ impl Config {
         let mut contents = String::new();
         file.read_to_string(&mut contents)?;
 
-        let config = serde_yaml::from_str(&contents)?;
-        Ok(config)
+        let attrs: Attrs = serde_yaml::from_str(&contents)?;
+        Ok(Self { attrs })
     }
 
     /// Merge with another configuration, with the other taking precedence
     pub fn merge(&mut self, other: &Self) {
-        self.codec_max_frame_length = other.codec_max_frame_length;
-        self.message_delivery_timeout = other.message_delivery_timeout;
-        self.message_ack_time_interval = other.message_ack_time_interval;
-        self.message_ack_every_n_messages = other.message_ack_every_n_messages;
-        self.split_max_buffer_size = other.split_max_buffer_size;
-
-        self.is_managed_subprocess = other.is_managed_subprocess;
+        // For each key in the other config, copy it to this config
+        if let Some(value) = other.attrs.get(CODEC_MAX_FRAME_LENGTH) {
+            self.attrs.set(CODEC_MAX_FRAME_LENGTH, *value);
+        }
+        if let Some(value) = other.attrs.get(MESSAGE_DELIVERY_TIMEOUT) {
+            self.attrs.set(MESSAGE_DELIVERY_TIMEOUT, *value);
+        }
+        if let Some(value) = other.attrs.get(MESSAGE_ACK_TIME_INTERVAL) {
+            self.attrs.set(MESSAGE_ACK_TIME_INTERVAL, *value);
+        }
+        if let Some(value) = other.attrs.get(MESSAGE_ACK_EVERY_N_MESSAGES) {
+            self.attrs.set(MESSAGE_ACK_EVERY_N_MESSAGES, *value);
+        }
+        if let Some(value) = other.attrs.get(SPLIT_MAX_BUFFER_SIZE) {
+            self.attrs.set(SPLIT_MAX_BUFFER_SIZE, *value);
+        }
+        if let Some(value) = other.attrs.get(IS_MANAGED_SUBPROCESS) {
+            self.attrs.set(IS_MANAGED_SUBPROCESS, *value);
+        }
     }
 
     /// Save configuration to a YAML file
     pub fn to_yaml<P: AsRef<Path>>(&self, path: P) -> Result<(), anyhow::Error> {
-        let yaml = serde_yaml::to_string(self)?;
+        let yaml = serde_yaml::to_string(&self.attrs)?;
         std::fs::write(path, yaml)?;
         Ok(())
+    }
+
+    /// Get the underlying attrs
+    pub fn attrs(&self) -> &Attrs {
+        &self.attrs
+    }
+
+    /// Get a mutable reference to the underlying attrs
+    pub fn attrs_mut(&mut self) -> &mut Attrs {
+        &mut self.attrs
+    }
+
+    // Convenience getter methods
+    /// Get the codec max frame length
+    pub fn codec_max_frame_length(&self) -> usize {
+        *self
+            .attrs
+            .get(CODEC_MAX_FRAME_LENGTH)
+            .unwrap_or(&(8 * 1024 * 1024))
+    }
+
+    /// Get the message delivery timeout
+    pub fn message_delivery_timeout(&self) -> Duration {
+        *self
+            .attrs
+            .get(MESSAGE_DELIVERY_TIMEOUT)
+            .unwrap_or(&Duration::from_secs(30))
+    }
+
+    /// Get the message acknowledgment time interval
+    pub fn message_ack_time_interval(&self) -> Duration {
+        *self
+            .attrs
+            .get(MESSAGE_ACK_TIME_INTERVAL)
+            .unwrap_or(&Duration::from_millis(500))
+    }
+
+    /// Get the number of messages after which to send an acknowledgment
+    pub fn message_ack_every_n_messages(&self) -> u64 {
+        *self
+            .attrs
+            .get(MESSAGE_ACK_EVERY_N_MESSAGES)
+            .unwrap_or(&1000)
+    }
+
+    /// Get the maximum buffer size for split port messages
+    pub fn split_max_buffer_size(&self) -> usize {
+        *self.attrs.get(SPLIT_MAX_BUFFER_SIZE).unwrap_or(&5)
+    }
+
+    /// Check if this is a managed subprocess
+    pub fn is_managed_subprocess(&self) -> bool {
+        *self.attrs.get(IS_MANAGED_SUBPROCESS).unwrap_or(&false)
+    }
+
+    // Convenience setter methods
+    /// Set the codec max frame length
+    pub fn set_codec_max_frame_length(&mut self, value: usize) {
+        self.attrs.set(CODEC_MAX_FRAME_LENGTH, value);
+    }
+
+    /// Set the message delivery timeout
+    pub fn set_message_delivery_timeout(&mut self, value: Duration) {
+        self.attrs.set(MESSAGE_DELIVERY_TIMEOUT, value);
+    }
+
+    /// Set the message acknowledgment time interval
+    pub fn set_message_ack_time_interval(&mut self, value: Duration) {
+        self.attrs.set(MESSAGE_ACK_TIME_INTERVAL, value);
+    }
+
+    /// Set the number of messages after which to send an acknowledgment
+    pub fn set_message_ack_every_n_messages(&mut self, value: u64) {
+        self.attrs.set(MESSAGE_ACK_EVERY_N_MESSAGES, value);
+    }
+
+    /// Set the maximum buffer size for split port messages
+    pub fn set_split_max_buffer_size(&mut self, value: usize) {
+        self.attrs.set(SPLIT_MAX_BUFFER_SIZE, value);
+    }
+
+    /// Set whether this is a managed subprocess
+    pub fn set_is_managed_subprocess(&mut self, value: bool) {
+        self.attrs.set(IS_MANAGED_SUBPROCESS, value);
     }
 }
 
 /// Global configuration functions
+///
+/// This module provides global configuration access and testing utilities.
+///
+/// # Testing with Global Configuration
+///
+/// When writing tests that manipulate global configuration using `override_key()`,
+/// you MUST ensure test serialization to prevent race conditions between concurrent tests.
+///
+/// **Important:** These functions are available in all builds (not just test builds)
+/// to support tests in other crates that depend on hyperactor.
+///
+/// ## Using the `test_lock` Attribute Macro (Recommended)
+///
+/// The easiest way to ensure test serialization is to use the `#[test_lock]` attribute macro:
+///
+/// ```rust
+/// use hyperactor::test_lock;
+///
+/// #[test]
+/// #[test_lock]
+/// fn test_my_feature() {
+///     let _guard = hyperactor::config::global::override_key(SOME_CONFIG_KEY, test_value);
+///     // ... test logic here ...
+/// }
+///
+/// #[tokio::test]
+/// #[test_lock]
+/// async fn test_my_async_feature() {
+///     let _guard = hyperactor::config::global::override_key(SOME_CONFIG_KEY, test_value);
+///     // ... async test logic here ...
+/// }
+/// ```
+///
+/// For tests within the hyperactor crate itself, use `#[test_lock(crate)]`:
+///
+/// ```rust
+/// #[test]
+/// #[test_lock(crate)]
+/// fn test_internal_feature() {
+///     let _guard = global::override_key(SOME_CONFIG_KEY, test_value);
+///     // ... test logic here ...
+/// }
+/// ```
+///
+/// ## Manual Test Synchronization (Advanced)
+///
+/// You can also manually wrap tests using the synchronization functions:
+///
+/// ### Synchronous Tests
+/// ```rust
+/// #[test]
+/// fn test_my_feature() {
+///     hyperactor::config::global::with_test_lock(|| {
+///         let _guard = hyperactor::config::global::override_key(SOME_CONFIG_KEY, test_value);
+///         // ... test logic here ...
+///     });
+/// }
+/// ```
+///
+/// ### Async Tests
+/// ```rust
+/// #[tokio::test]
+/// async fn test_my_async_feature() {
+///     hyperactor::config::global::with_test_lock_async(|| async {
+///         let _guard = hyperactor::config::global::override_key(SOME_CONFIG_KEY, test_value);
+///         // ... async test logic here ...
+///     })
+///     .await;
+/// }
+/// ```
+///
+/// ## Cross-Crate Usage
+///
+/// For tests in other crates (like `hyperactor_multiprocess`, `hyperactor_mesh`, etc.):
+///
+/// ```rust
+/// use hyperactor::config::global;
+/// use hyperactor::test_lock;
+///
+/// #[tokio::test]
+/// #[test_lock]
+/// async fn test_in_other_crate() {
+///     let _guard = global::override_key(
+///         hyperactor::config::MESSAGE_DELIVERY_TIMEOUT,
+///         Duration::from_secs(1),
+///     );
+///     // ... test logic here ...
+/// }
+/// ```
+///
+/// The `test_lock` macro and `with_test_lock*` functions ensure that only one test at a time can modify
+/// global configuration, preventing race conditions that could cause flaky tests.
 pub mod global {
     use super::*;
 
     /// Global configuration instance, initialized from environment variables.
     static CONFIG: LazyLock<Arc<RwLock<Config>>> =
         LazyLock::new(|| Arc::new(RwLock::new(Config::from_env())));
+
+    /// Acquire the global configuration lock for testing.
+    ///
+    /// This function returns a ConfigLock that acts as both a write lock guard (preventing
+    /// other tests from modifying global config concurrently) and as the only way to
+    /// create configuration overrides.
+    ///
+    /// Example usage:
+    /// ```rust
+    /// let config = hyperactor::config::global::lock();
+    /// let _guard = config.override_key(CONFIG_KEY, "value");
+    /// // ... test code using the overridden config ...
+    /// ```
+    pub fn lock() -> ConfigLock {
+        static MUTEX: LazyLock<std::sync::Mutex<()>> = LazyLock::new(|| std::sync::Mutex::new(()));
+        let guard = MUTEX.lock().unwrap();
+        ConfigLock { _guard: guard }
+    }
 
     /// Initialize the global configuration from environment variables
     pub fn init_from_env() {
@@ -163,29 +404,89 @@ pub mod global {
         CONFIG.clone()
     }
 
+    /// Get the global attrs
+    pub fn attrs() -> Attrs {
+        CONFIG.read().unwrap().attrs.clone()
+    }
+
     /// Get the codec max frame length
     pub fn codec_max_frame_length() -> usize {
-        CONFIG.read().unwrap().codec_max_frame_length
+        CONFIG.read().unwrap().codec_max_frame_length()
     }
 
     /// Get the message delivery timeout
     pub fn message_delivery_timeout() -> Duration {
-        CONFIG.read().unwrap().message_delivery_timeout
+        CONFIG.read().unwrap().message_delivery_timeout()
     }
 
     /// Get the message acknowledgment time interval
     pub fn message_ack_time_interval() -> Duration {
-        CONFIG.read().unwrap().message_ack_time_interval
+        CONFIG.read().unwrap().message_ack_time_interval()
     }
 
     /// Get the number of messages after which to send an acknowledgment
     pub fn message_ack_every_n_messages() -> u64 {
-        CONFIG.read().unwrap().message_ack_every_n_messages
+        CONFIG.read().unwrap().message_ack_every_n_messages()
     }
 
     /// Get the maximum buffer size for split port messages
     pub fn split_max_buffer_size() -> usize {
-        CONFIG.read().unwrap().split_max_buffer_size
+        CONFIG.read().unwrap().split_max_buffer_size()
+    }
+
+    /// Check if this is a managed subprocess
+    pub fn is_managed_subprocess() -> bool {
+        CONFIG.read().unwrap().is_managed_subprocess()
+    }
+
+    /// Reset the global configuration to defaults (for testing only)
+    ///
+    /// Note: This should be called from within with_test_lock() to ensure thread safety.
+    /// Available in all builds to support tests in other crates.
+    pub fn reset_to_defaults() {
+        let mut config = CONFIG.write().unwrap();
+        *config = Config::default();
+    }
+
+    /// A guard that holds the global configuration lock and provides override functionality.
+    ///
+    /// This struct acts as both a lock guard (preventing other tests from modifying global config)
+    /// and as the only way to create configuration overrides. Override guards cannot outlive
+    /// this ConfigLock, ensuring proper synchronization.
+    pub struct ConfigLock {
+        // We'll use a simpler approach with a dedicated test mutex
+        _guard: std::sync::MutexGuard<'static, ()>,
+    }
+
+    impl ConfigLock {
+        /// Create a configuration override that will be restored when the guard is dropped.
+        ///
+        /// The returned guard must not outlive this ConfigLock.
+        pub fn override_key<
+            T: Send
+                + Sync
+                + serde::Serialize
+                + serde::de::DeserializeOwned
+                + crate::data::Named
+                + Clone
+                + 'static,
+        >(
+            &self,
+            key: crate::attrs::Key<T>,
+            value: T,
+        ) -> ConfigValueGuard<T> {
+            let original_value = {
+                let mut config = CONFIG.write().unwrap();
+                let original = config.attrs.take_value(key);
+                config.attrs.set(key, value);
+                original
+            };
+
+            ConfigValueGuard {
+                key,
+                orig: original_value,
+            }
+        }
     }
 
     /// A guard that restores the original configuration when dropped
@@ -197,6 +498,23 @@ pub mod global {
         fn drop(&mut self) {
             let mut config = CONFIG.write().unwrap();
             *config = self.original_config.clone();
+        }
+    }
+
+    /// A guard that restores a single configuration value when dropped
+    pub struct ConfigValueGuard<T> {
+        key: crate::attrs::Key<T>,
+        orig: Option<Box<dyn crate::attrs::SerializableValue>>,
+    }
+
+    impl<T> Drop for ConfigValueGuard<T> {
+        fn drop(&mut self) {
+            let mut config = CONFIG.write().unwrap();
+            if let Some(orig) = self.orig.take() {
+                config.attrs.restore_value(self.key, orig);
+            } else {
+                config.attrs.remove_value(&self.key);
+            }
         }
     }
 
@@ -212,6 +530,19 @@ pub mod global {
 
         ConfigGuard { original_config }
     }
+
+    /// Temporarily modify the global attrs for testing
+    ///
+    /// Returns a guard that will restore the original configuration when dropped
+    pub fn set_temp_attrs(temp_attrs: Attrs) -> ConfigGuard {
+        let original_config = CONFIG.read().unwrap().clone();
+        {
+            let mut config = CONFIG.write().unwrap();
+            config.attrs = temp_attrs;
+        }
+
+        ConfigGuard { original_config }
+    }
 }
 
 #[cfg(test)]
@@ -221,10 +552,15 @@ mod tests {
     #[test]
     fn test_default_config() {
         let config = Config::default();
-        assert_eq!(config.codec_max_frame_length, 8 * 1024 * 1024);
-        assert_eq!(config.message_delivery_timeout, Duration::from_secs(30));
-        assert_eq!(config.message_ack_time_interval, Duration::from_millis(500));
-        assert_eq!(config.message_ack_every_n_messages, 1000);
+        assert_eq!(config.codec_max_frame_length(), 8 * 1024 * 1024);
+        assert_eq!(config.message_delivery_timeout(), Duration::from_secs(30));
+        assert_eq!(
+            config.message_ack_time_interval(),
+            Duration::from_millis(500)
+        );
+        assert_eq!(config.message_ack_every_n_messages(), 1000);
+        assert_eq!(config.split_max_buffer_size(), 5);
+        assert!(!config.is_managed_subprocess());
     }
 
     #[test]
@@ -237,9 +573,12 @@ mod tests {
 
         let config = Config::from_env();
 
-        assert_eq!(config.codec_max_frame_length, 1024);
-        assert_eq!(config.message_delivery_timeout, Duration::from_secs(60));
-        assert_eq!(config.message_ack_time_interval, Duration::from_millis(500)); // Default value
+        assert_eq!(config.codec_max_frame_length(), 1024);
+        assert_eq!(config.message_delivery_timeout(), Duration::from_secs(60));
+        assert_eq!(
+            config.message_ack_time_interval(),
+            Duration::from_millis(500)
+        ); // Default value
 
         // Clean up
         // SAFETY: TODO: Audit that the environment access only happens in single-threaded code.
@@ -251,29 +590,28 @@ mod tests {
     #[test]
     fn test_merge() {
         let mut config1 = Config::default();
-        let config2 = Config {
-            codec_max_frame_length: 1024,
-            message_delivery_timeout: Duration::from_secs(60),
-            ..Config::default()
-        };
+        let mut config2 = Config::default();
+        config2.set_codec_max_frame_length(1024);
+        config2.set_message_delivery_timeout(Duration::from_secs(60));
 
         config1.merge(&config2);
 
-        assert_eq!(config1.codec_max_frame_length, 1024);
-        assert_eq!(config1.message_delivery_timeout, Duration::from_secs(60));
+        assert_eq!(config1.codec_max_frame_length(), 1024);
+        assert_eq!(config1.message_delivery_timeout(), Duration::from_secs(60));
     }
 
     #[test]
     fn test_global_config() {
+        let config = global::lock();
+
+        // Reset global config to defaults to avoid interference from other tests
+        global::reset_to_defaults();
+
         assert_eq!(global::codec_max_frame_length(), 8 * 1024 * 1024);
 
-        // Temporarily modify the configuration using the legacy function
-        let temp_config = Config {
-            codec_max_frame_length: 1024,
-            ..Config::default()
-        };
+        // Temporarily modify the configuration using the new lock/override API
         {
-            let _guard = global::set_temp_config(temp_config.clone());
+            let _guard = config.override_key(CODEC_MAX_FRAME_LENGTH, 1024);
             assert_eq!(global::codec_max_frame_length(), 1024);
         }
 
@@ -282,7 +620,7 @@ mod tests {
 
         // Temporarily modify the configuration using the RAII pattern
         {
-            let _guard = global::set_temp_config(temp_config);
+            let _guard = config.override_key(CODEC_MAX_FRAME_LENGTH, 1024);
             assert_eq!(global::codec_max_frame_length(), 1024);
 
             // The configuration will be automatically restored when _guard goes out of scope
@@ -290,5 +628,70 @@ mod tests {
 
         // Check that the original configuration is restored
         assert_eq!(global::codec_max_frame_length(), 8 * 1024 * 1024);
+    }
+
+    #[test]
+    fn test_attrs_integration() {
+        let mut config = Config::new();
+
+        // Test direct attrs access
+        config.attrs_mut().set(CODEC_MAX_FRAME_LENGTH, 2048);
+        assert_eq!(config.codec_max_frame_length(), 2048);
+
+        // Test serialization
+        let serialized = serde_json::to_string(config.attrs()).unwrap();
+        assert!(serialized.contains("hyperactor::config::codec_max_frame_length"));
+
+        // Test that we can deserialize back
+        let attrs: Attrs = serde_json::from_str(&serialized).unwrap();
+        assert_eq!(attrs.get(CODEC_MAX_FRAME_LENGTH), Some(&2048));
+    }
+
+    #[test]
+    fn test_convenience_setters() {
+        let mut config = Config::new();
+
+        config.set_codec_max_frame_length(4096);
+        config.set_message_delivery_timeout(Duration::from_secs(120));
+        config.set_is_managed_subprocess(true);
+
+        assert_eq!(config.codec_max_frame_length(), 4096);
+        assert_eq!(config.message_delivery_timeout(), Duration::from_secs(120));
+        assert!(config.is_managed_subprocess());
+    }
+
+    #[test]
+    fn test_override_api() {
+        let config = global::lock();
+
+        // Reset global config to defaults to avoid interference from other tests
+        global::reset_to_defaults();
+
+        // Test the new lock/override API for individual config values
+        assert_eq!(global::codec_max_frame_length(), 8 * 1024 * 1024);
+        assert_eq!(global::message_delivery_timeout(), Duration::from_secs(30));
+
+        // Test single value override
+        {
+            let _guard = config.override_key(CODEC_MAX_FRAME_LENGTH, 2048);
+            assert_eq!(global::codec_max_frame_length(), 2048);
+            assert_eq!(global::message_delivery_timeout(), Duration::from_secs(30)); // Unchanged
+        }
+
+        // Values should be restored after guard is dropped
+        assert_eq!(global::codec_max_frame_length(), 8 * 1024 * 1024);
+
+        // Test multiple overrides
+        {
+            let _guard1 = config.override_key(CODEC_MAX_FRAME_LENGTH, 4096);
+            let _guard2 = config.override_key(MESSAGE_DELIVERY_TIMEOUT, Duration::from_secs(60));
+
+            assert_eq!(global::codec_max_frame_length(), 4096);
+            assert_eq!(global::message_delivery_timeout(), Duration::from_secs(60));
+        }
+
+        // All values should be restored
+        assert_eq!(global::codec_max_frame_length(), 8 * 1024 * 1024);
+        assert_eq!(global::message_delivery_timeout(), Duration::from_secs(30));
     }
 }

--- a/hyperactor/src/mailbox/mod.rs
+++ b/hyperactor/src/mailbox/mod.rs
@@ -2966,10 +2966,8 @@ mod tests {
 
     #[async_timed_test(timeout_secs = 30)]
     async fn test_split_port_id_sum_reducer() {
-        let _config_guard = crate::config::global::set_temp_config(crate::config::Config {
-            split_max_buffer_size: 1,
-            ..crate::config::Config::default()
-        });
+        let config = crate::config::global::lock();
+        let _config_guard = config.override_key(crate::config::SPLIT_MAX_BUFFER_SIZE, 1);
 
         let sum_accumulator = accum::sum::<u64>();
         let reducer_typehash = sum_accumulator.reducer_typehash();

--- a/hyperactor_macros/src/lib.rs
+++ b/hyperactor_macros/src/lib.rs
@@ -1208,3 +1208,4 @@ fn export_impl(which: &'static str, attr: TokenStream, input: &DeriveInput) -> T
 
     TokenStream::from(expanded)
 }
+

--- a/hyperactor_mesh/src/alloc/remoteprocess.rs
+++ b/hyperactor_mesh/src/alloc/remoteprocess.rs
@@ -1406,10 +1406,8 @@ mod test {
     #[timed_test::async_timed_test(timeout_secs = 15)]
     async fn test_upstream_closed() {
         // Use temporary config for this test
-        let _guard = hyperactor::config::global::set_temp_config(hyperactor::config::Config {
-            message_delivery_timeout: Duration::from_secs(1),
-            ..Default::default()
-        });
+        let config = hyperactor::config::global::lock();
+        let _guard = config.override_key(hyperactor::config::MESSAGE_DELIVERY_TIMEOUT, Duration::from_secs(1));
 
         hyperactor_telemetry::initialize_logging();
         let serve_addr = ChannelAddr::any(ChannelTransport::Unix);
@@ -1583,10 +1581,8 @@ mod test_alloc {
     #[async_timed_test(timeout_secs = 60)]
     async fn test_alloc_simple() {
         // Use temporary config for this test
-        let _guard = hyperactor::config::global::set_temp_config(hyperactor::config::Config {
-            message_delivery_timeout: Duration::from_secs(1),
-            ..Default::default()
-        });
+        let config = hyperactor::config::global::lock();
+        let _guard = config.override_key(hyperactor::config::MESSAGE_DELIVERY_TIMEOUT, Duration::from_secs(1));
         hyperactor_telemetry::initialize_logging();
 
         let spec = AllocSpec {
@@ -1703,10 +1699,8 @@ mod test_alloc {
     #[async_timed_test(timeout_secs = 60)]
     async fn test_alloc_host_failure() {
         // Use temporary config for this test
-        let _guard = hyperactor::config::global::set_temp_config(hyperactor::config::Config {
-            message_delivery_timeout: Duration::from_secs(1),
-            ..Default::default()
-        });
+        let config = hyperactor::config::global::lock();
+        let _guard = config.override_key(hyperactor::config::MESSAGE_DELIVERY_TIMEOUT, Duration::from_secs(1));
         hyperactor_telemetry::initialize_logging();
 
         let spec = AllocSpec {

--- a/hyperactor_multiprocess/src/proc_actor.rs
+++ b/hyperactor_multiprocess/src/proc_actor.rs
@@ -1347,10 +1347,8 @@ mod tests {
         use hyperactor::test_utils::pingpong::PingPongMessage;
 
         // Use temporary config for this test
-        let _guard = hyperactor::config::global::set_temp_config(hyperactor::config::Config {
-            message_delivery_timeout: Duration::from_secs(1),
-            ..Default::default()
-        });
+        let config = hyperactor::config::global::lock();
+        let _guard = config.override_key(hyperactor::config::MESSAGE_DELIVERY_TIMEOUT, Duration::from_secs(1));
 
         // Serve a system.
         let server_handle = System::serve(

--- a/hyperactor_multiprocess/src/system_actor.rs
+++ b/hyperactor_multiprocess/src/system_actor.rs
@@ -2608,10 +2608,8 @@ mod tests {
         use crate::supervision::ProcSupervisor;
 
         // Use temporary config for this test
-        let _guard = hyperactor::config::global::set_temp_config(hyperactor::config::Config {
-            message_delivery_timeout: Duration::from_secs(1),
-            ..Default::default()
-        });
+        let config = hyperactor::config::global::lock();
+        let _guard = config.override_key(hyperactor::config::MESSAGE_DELIVERY_TIMEOUT, Duration::from_secs(1));
 
         // Serve a system. Undeliverable messages encountered by the
         // mailbox server are returned to the system actor.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #227
* #226
* #225

The base hyperactor configuration is defined in terms of a set of keys in the config crate. The config crate also implements defaults for these. (As a future change, we should consider including defaults in the base attribute dictionary implementation.)

We also provide an improved overloading API for tests, wherein individual keys can be directly overriden, e.g.:

```
let _guard = config::global::override_key(crate::config::MESSAGE_ACK_EVERY_N_MESSAGES, 1);
```