### PR TITLE
[monarch] .gitignore: ignore Cargo.lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ python/monarch/monarch_controller
 
 # Rust stuff
 target/
+Cargo.lock


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #234

Resolves a papercut when developing from Github.

Differential Revision: [D76424222](https://our.internmc.facebook.com/intern/diff/D76424222/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D76424222/)!