### PR TITLE
More Python Stack Retention

### DIFF
--- a/monarch_tensor_worker/src/stream.rs
+++ b/monarch_tensor_worker/src/stream.rs
@@ -726,7 +726,8 @@ impl StreamActor {
             let function = function.resolve(py).map_err(|e| {
                 CallFunctionError::InvalidRemoteFunction(format!(
                     "failed to resolve function {}: {}",
-                    function, e
+                    function,
+                    SerializablePyErr::from(py, &e)
                 ))
             })?;
 

--- a/monarch_types/src/python.rs
+++ b/monarch_types/src/python.rs
@@ -127,7 +127,7 @@ impl SerializablePyErr {
         let mut f = inspect
             .call_method0("currentframe")
             .unwrap_or(PyNone::get_bound(py).to_owned().into_any());
-        let mut tb: Bound<'_, PyAny> = err.traceback_bound(py).unwrap().as_any().clone();
+        let mut tb: Bound<'_, PyAny> = err.traceback_bound(py).to_object(py).into_bound(py);
         while !f.is_none() {
             let lasti = f.getattr("f_lasti").unwrap();
             let lineno = f.getattr("f_lineno").unwrap();


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #237

Fix a couple more places where we lose python stack traces by converting between error types.

Differential Revision: [D76356209](https://our.internmc.facebook.com/intern/diff/D76356209/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D76356209/)!