### PR TITLE
Clean up type annoation

### DIFF
--- a/python/monarch/_monarch/hyperactor/__init__.py
+++ b/python/monarch/_monarch/hyperactor/__init__.py
@@ -5,7 +5,6 @@
 # LICENSE file in the root directory of this source tree.
 
 # pyre-strict
-import abc
 
 from monarch._rust_bindings.monarch_hyperactor.actor import PythonMessage
 
@@ -28,21 +27,6 @@ from monarch._rust_bindings.monarch_hyperactor.proc import (  # @manual=//monarc
 from monarch._rust_bindings.monarch_hyperactor.shape import (  # @manual=//monarch/monarch_extension:monarch_extension
     Shape,
 )
-
-
-class Actor(abc.ABC):
-    @abc.abstractmethod
-    async def handle(self, mailbox: Mailbox, message: PythonMessage) -> None: ...
-
-    async def handle_cast(
-        self,
-        mailbox: Mailbox,
-        rank: int,
-        coordinates: list[tuple[str, int]],
-        message: PythonMessage,
-    ) -> None:
-        await self.handle(mailbox, message)
-
 
 __all__ = [
     "init_proc",

--- a/python/monarch/_rust_bindings/monarch_hyperactor/actor.pyi
+++ b/python/monarch/_rust_bindings/monarch_hyperactor/actor.pyi
@@ -6,11 +6,13 @@
 
 # pyre-strict
 
+import abc
+
 from typing import final, List, Protocol
 
 from monarch._rust_bindings.monarch_hyperactor.mailbox import Mailbox, PortId
-
 from monarch._rust_bindings.monarch_hyperactor.proc import ActorId, Proc, Serialized
+from monarch._rust_bindings.monarch_hyperactor.shape import Shape
 
 @final
 class PickledMessage:
@@ -149,17 +151,6 @@ class PythonActorHandle:
         """
         ...
 
-class Actor(Protocol):
-    async def handle(self, mailbox: Mailbox, message: PythonMessage) -> None: ...
-    async def handle_cast(
-        self,
-        mailbox: Mailbox,
-        rank: int,
-        coordinates: list[tuple[str, int]],
-        message: PythonMessage,
-    ) -> None:
-        await self.handle(mailbox, message)
-
 @final
 class PanicFlag:
     """
@@ -172,3 +163,16 @@ class PanicFlag:
         Signal that a panic has occurred in an asynchronous Python task.
         """
         ...
+
+class Actor(Protocol):
+    async def handle(
+        self, mailbox: Mailbox, message: PythonMessage, panic_flag: PanicFlag
+    ) -> None: ...
+    async def handle_cast(
+        self,
+        mailbox: Mailbox,
+        rank: int,
+        shape: Shape,
+        message: PythonMessage,
+        panic_flag: PanicFlag,
+    ) -> None: ...

--- a/python/monarch/_rust_bindings/monarch_hyperactor/proc.pyi
+++ b/python/monarch/_rust_bindings/monarch_hyperactor/proc.pyi
@@ -6,12 +6,9 @@
 
 # pyre-strict
 
-from typing import final, Optional, Protocol, Type
+from typing import final, Optional, Type
 
-from monarch._rust_bindings.monarch_hyperactor.actor import (
-    PythonActorHandle,
-    PythonMessage,
-)
+from monarch._rust_bindings.monarch_hyperactor.actor import Actor, PythonActorHandle
 from monarch._rust_bindings.monarch_hyperactor.mailbox import Mailbox
 
 def init_proc(
@@ -95,36 +92,6 @@ class ActorId:
 
         Arguments:
         - `actor_id_str`: String representation of the actor id.
-        """
-        ...
-
-class Actor(Protocol):
-    async def handle(self, mailbox: Mailbox, message: PythonMessage) -> None:
-        """
-        Handle a message from the mailbox.
-
-        Arguments:
-        - `mailbox`: The actor's mailbox.
-        - `message`: The message to handle.
-        """
-        ...
-
-    async def handle_cast(
-        self,
-        mailbox: Mailbox,
-        rank: int,
-        coordinates: list[tuple[str, int]],
-        message: PythonMessage,
-    ) -> None:
-        """
-        Handle a message casted to this actor, on a mesh in which this actor
-        has the given rank and coordinates.
-
-        Arguments:
-        - `mailbox`: The actor's mailbox.
-        - `rank`: The rank of the actor in the mesh.
-        - `coordinates`: The labeled coordinates of the actor in the mesh.
-        - `message`: The message to handle.
         """
         ...
 

--- a/python/monarch/_rust_bindings/monarch_hyperactor/proc_mesh.pyi
+++ b/python/monarch/_rust_bindings/monarch_hyperactor/proc_mesh.pyi
@@ -9,9 +9,9 @@
 from typing import final, Type
 
 from monarch._rust_bindings.hyperactor_extension.alloc import Alloc
+from monarch._rust_bindings.monarch_hyperactor.actor import Actor
 from monarch._rust_bindings.monarch_hyperactor.actor_mesh import PythonActorMesh
 from monarch._rust_bindings.monarch_hyperactor.mailbox import Mailbox
-from monarch._rust_bindings.monarch_hyperactor.proc import Actor
 from monarch._rust_bindings.monarch_hyperactor.shape import Shape
 
 @final

--- a/python/monarch/proc_mesh.py
+++ b/python/monarch/proc_mesh.py
@@ -4,9 +4,11 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+# pyre-strict
+
 import sys
 
-from typing import Any, cast, Optional, Type, TypeVar
+from typing import Any, cast, List, Optional, Type, TypeVar
 
 import monarch
 from monarch import ActorFuture as Future
@@ -18,7 +20,7 @@ from monarch._rust_bindings.hyperactor_extension.alloc import (  # @manual=//mon
 )
 from monarch._rust_bindings.monarch_hyperactor.mailbox import Mailbox
 from monarch._rust_bindings.monarch_hyperactor.proc_mesh import ProcMesh as HyProcMesh
-from monarch._rust_bindings.monarch_hyperactor.shape import Shape
+from monarch._rust_bindings.monarch_hyperactor.shape import Shape, Slice
 from monarch.actor_mesh import _Actor, _ActorMeshRefImpl, Actor, ActorMeshRef
 
 from monarch.common._device_utils import _local_device_count
@@ -46,14 +48,16 @@ class ProcMesh(MeshTrait):
     def __init__(self, hy_proc_mesh: HyProcMesh) -> None:
         self._proc_mesh = hy_proc_mesh
         self._mailbox: Mailbox = self._proc_mesh.client
-        self._rdma_manager = self._spawn_blocking("rdma_manager", RDMAManager)
+        self._rdma_manager: RDMAManager = self._spawn_blocking(
+            "rdma_manager", RDMAManager
+        )
 
     @property
-    def _ndslice(self):
+    def _ndslice(self) -> Slice:
         return self._proc_mesh.shape.ndslice
 
     @property
-    def _labels(self):
+    def _labels(self) -> List[str]:
         return self._proc_mesh.shape.labels
 
     def _new_with_shape(self, shape: Shape) -> "ProcMesh":

--- a/python/tests/_monarch/test_hyperactor.py
+++ b/python/tests/_monarch/test_hyperactor.py
@@ -8,39 +8,38 @@
 
 import multiprocessing
 import os
-import pickle
 import signal
-import sys
 import time
 
 import monarch
-import pytest
 
 from monarch._rust_bindings.hyperactor_extension.alloc import (  # @manual=//monarch/monarch_extension:monarch_extension
     AllocConstraints,
     AllocSpec,
 )
 
-from monarch._rust_bindings.monarch_hyperactor.actor import PythonMessage
-
+from monarch._rust_bindings.monarch_hyperactor.actor import PanicFlag, PythonMessage
 from monarch._rust_bindings.monarch_hyperactor.mailbox import Mailbox
 from monarch._rust_bindings.monarch_hyperactor.proc import ActorId
 from monarch._rust_bindings.monarch_hyperactor.proc_mesh import ProcMesh
+from monarch._rust_bindings.monarch_hyperactor.shape import Shape
 
 
 class MyActor:
-    async def handle(self, mailbox: Mailbox, message: PythonMessage) -> None:
-        return None
+    async def handle(
+        self, mailbox: Mailbox, message: PythonMessage, panic_flag: PanicFlag
+    ) -> None:
+        raise NotImplementedError()
 
     async def handle_cast(
         self,
         mailbox: Mailbox,
         rank: int,
-        coordinates: list[tuple[str, int]],
+        shape: Shape,
         message: PythonMessage,
+        panic_flag: PanicFlag,
     ) -> None:
-        reply_port = pickle.loads(message.message)
-        mailbox.post(reply_port, PythonMessage("echo", pickle.dumps(coordinates)))
+        raise NotImplementedError()
 
 
 def test_import() -> None:


### PR DESCRIPTION
Summary: `class Actor` is meant to define the interface of the container python actor, which is run from [the Rust side](https://www.internalfb.com/code/fbsource/[152e131ff52a790441618c0f8cbb18ac812a746c]/fbcode/monarch/monarch_hyperactor/src/actor.rs?lines=472-485). But there are too many copies of them, and all of them are out of sync. This diff is to clean that up by reducing them into 1 copy, and update the method parameter list.

Differential Revision: D76382282
