### PR TITLE
Create separate events for sending & receiving messages

### DIFF
--- a/hyperactor/src/channel/sim.rs
+++ b/hyperactor/src/channel/sim.rs
@@ -19,18 +19,15 @@ use regex::Regex;
 use tokio::sync::Mutex;
 
 use super::*;
-use crate::PortId;
 use crate::channel;
 use crate::clock::Clock;
 use crate::clock::RealClock;
 use crate::clock::SimClock;
 use crate::data::Serialized;
-use crate::id;
 use crate::mailbox::MessageEnvelope;
 use crate::simnet;
 use crate::simnet::Dispatcher;
 use crate::simnet::Event;
-use crate::simnet::ProxyMessage;
 use crate::simnet::ScheduledEvent;
 use crate::simnet::SimNetConfig;
 use crate::simnet::SimNetEdge;
@@ -41,7 +38,6 @@ lazy_static! {
     static ref SENDER: SimDispatcher = SimDispatcher::default();
 }
 static SIM_LINK_BUF_SIZE: usize = 256;
-static CLIENT_ADDRESS: &str = "unix!@client";
 
 #[derive(
     Clone,
@@ -324,31 +320,10 @@ fn is_external_addr(addr: &AddressProxyPair) -> anyhow::Result<bool, SimNetError
 impl Dispatcher<AddressProxyPair> for SimDispatcher {
     async fn send(
         &self,
-        src_addr: Option<AddressProxyPair>,
+        _src_addr: Option<AddressProxyPair>,
         addr: AddressProxyPair,
         data: Serialized,
     ) -> Result<(), SimNetError> {
-        if is_external_addr(&addr)? {
-            let dst_proxy = addr.proxy.clone();
-            let sender = self
-                .sender_cache
-                .entry(dst_proxy.clone())
-                .or_insert_with(|| create_egress_sender(dst_proxy.clone()).unwrap());
-            let forward_message = ProxyMessage::new(src_addr.clone(), Some(addr.clone()), data);
-            let serialized_forward_message = match Serialized::serialize(&forward_message) {
-                Ok(data) => data,
-                Err(err) => return Err(SimNetError::InvalidArg(err.to_string())),
-            };
-            // Here we use mailbox to deliver the ForwardMessage. But it's higher level than
-            // the simnet. So there are unused placeholder here which is not ideal.
-            let port_id_placeholder = PortId(id!(unused_world[0].unused_actor), 0);
-            let message =
-                MessageEnvelope::new_unknown(port_id_placeholder, serialized_forward_message);
-            return sender
-                .try_post(message, oneshot::channel().0)
-                .map_err(|err| SimNetError::InvalidNode(addr.address.to_string(), err.into()));
-        }
-
         self.dispatchers
             .get(&addr.address)
             .ok_or_else(|| {
@@ -397,7 +372,7 @@ impl<M: RemoteMessage> Tx<M> for SimTx<M> {
         };
         match simnet_handle() {
             Ok(handle) => match &self.src_addr {
-                Some(src_addr) if src_addr.address.to_string() == CLIENT_ADDRESS => handle
+                Some(src_addr) if src_addr.proxy != *handle.proxy_addr() => handle
                     .send_scheduled_event(ScheduledEvent {
                         event: Box::new(MessageDeliveryEvent::new(
                             self.src_addr.clone(),
@@ -488,10 +463,13 @@ mod tests {
     use std::iter::zip;
 
     use super::*;
+    use crate::PortId;
     use crate::clock::Clock;
     use crate::clock::RealClock;
     use crate::clock::SimClock;
+    use crate::id;
     use crate::simnet::NetworkConfig;
+    use crate::simnet::ProxyMessage;
     use crate::simnet::start;
 
     #[tokio::test]
@@ -536,80 +514,6 @@ mod tests {
 
         let records = sim::simnet_handle().unwrap().close().await.unwrap();
         eprintln!("records: {:#?}", records);
-    }
-
-    #[tokio::test]
-    async fn test_send_egress_message() {
-        let proxy = ChannelAddr::any(ChannelTransport::Unix);
-        start(
-            ChannelAddr::any(ChannelTransport::Unix),
-            proxy.clone(),
-            1000,
-        )
-        .unwrap();
-
-        // Serve an external proxy channel to receive the egress message.
-        let egress_addr = ChannelAddr::any(ChannelTransport::Unix);
-        let dispatcher = SimDispatcher::default();
-        let (_, mut rx) = channel::serve::<MessageEnvelope>(egress_addr.clone())
-            .await
-            .unwrap();
-        // just a random port ID
-        let port_id = PortId(id!(test[0].actor0), 0);
-        let msg = MessageEnvelope::new_unknown(
-            port_id.clone(),
-            Serialized::serialize(&"hola".to_string()).unwrap(),
-        );
-        // The sim addr we want simnet to send message to, it should have the egress_addr
-        // as the proxy address of dst.
-        let src_addr = AddressProxyPair {
-            address: "unix!@src".parse::<ChannelAddr>().unwrap(),
-            proxy: "unix!@proxy".parse::<ChannelAddr>().unwrap(),
-        };
-        let egress_addr = AddressProxyPair {
-            address: "unix!@dst".parse::<ChannelAddr>().unwrap(),
-            proxy: egress_addr,
-        };
-        let serialized_msg = Serialized::serialize(&msg).unwrap();
-        dispatcher
-            .send(
-                Some(src_addr.clone()),
-                egress_addr.clone(),
-                serialized_msg.clone(),
-            )
-            .await
-            .unwrap();
-        let received_msg = rx.recv().await.unwrap();
-        let actual_forward_msg: ProxyMessage = received_msg.deserialized().unwrap();
-        let expected_forward_msg = ProxyMessage::new(
-            Some(src_addr.clone()),
-            Some(egress_addr.clone()),
-            serialized_msg,
-        );
-
-        assert_eq!(actual_forward_msg, expected_forward_msg);
-
-        // Sending the message again should work by using the cached sender.
-        // But it's impl detail, not verified here. We just verify that it
-        // can send a different message.
-        let msg = MessageEnvelope::new_unknown(
-            port_id,
-            Serialized::serialize(&"ciao".to_string()).unwrap(),
-        );
-        let serialized_msg = Serialized::serialize(&msg).unwrap();
-        dispatcher
-            .send(
-                Some(src_addr.clone()),
-                egress_addr.clone(),
-                serialized_msg.clone(),
-            )
-            .await
-            .unwrap();
-        let received_msg = rx.recv().await.unwrap();
-        let actual_forward_msg: ProxyMessage = received_msg.deserialized().unwrap();
-        let expected_forward_msg =
-            ProxyMessage::new(Some(src_addr), Some(egress_addr), serialized_msg);
-        assert_eq!(actual_forward_msg, expected_forward_msg);
     }
 
     #[tokio::test]
@@ -731,8 +635,8 @@ mod tests {
 
         let client_to_dst = SimAddr::new_with_src(
             AddressProxyPair {
-                address: "unix!@client".parse::<ChannelAddr>().unwrap(),
-                proxy: proxy_addr.clone(),
+                address: ChannelAddr::any(ChannelTransport::Unix),
+                proxy: ChannelAddr::any(ChannelTransport::Unix),
             },
             "unix!@dst".parse::<ChannelAddr>().unwrap(),
             proxy_addr.clone(),

--- a/python/monarch/sim_mesh.py
+++ b/python/monarch/sim_mesh.py
@@ -201,9 +201,11 @@ class Bootstrap:
 
         proxy_addr = proxy_addr or f"unix!@{_random_id()}-proxy"
         self.bootstrap_addr: str = f"sim!unix!@system,{proxy_addr}"
-        self.client_listen_addr: str = f"sim!unix!@client,{proxy_addr}"
+
+        client_proxy_addr = f"unix!@{_random_id()}-proxy"
+        self.client_listen_addr: str = f"sim!unix!@client,{client_proxy_addr}"
         self.client_bootstrap_addr: str = (
-            f"sim!unix!@client,{proxy_addr},unix!@system,{proxy_addr}"
+            f"sim!unix!@client,{client_proxy_addr},unix!@system,{proxy_addr}"
         )
         bootstrap_simulator_backend(self.bootstrap_addr, proxy_addr, world_size)
 


### PR DESCRIPTION
Summary: We have been treating the entire message send & recv as a single event but this doesn't really make sense since each of these should have their own duration (sending -> in flight -> receiving), and they happen on different processes (This will matter in the next diff when we render our events onto Perfetto).

Differential Revision: D76433477
