### PR TITLE
[hyperactor]: reference: attest_message_port

### DIFF
--- a/hyperactor/src/reference.rs
+++ b/hyperactor/src/reference.rs
@@ -765,6 +765,7 @@ pub struct PortRef<M: RemoteMessage> {
 }
 
 impl<M: RemoteMessage> PortRef<M> {
+
     /// The caller attests that the provided PortId can be
     /// converted to a reachable, typed port reference.
     pub fn attest(port_id: PortId) -> Self {
@@ -773,6 +774,12 @@ impl<M: RemoteMessage> PortRef<M> {
             reducer_typehash: None,
             phantom: PhantomData,
         }
+    }
+
+    /// The caller attests that the provided PortId can be
+    /// converted to a reachable, typed port reference.
+    pub fn attest_message_port(actor: &ActorId) -> Self {
+        PortRef::<M>::attest(actor.port_id(<M as Named>::port()))
     }
 
     /// The caller attests that the provided PortId can be

--- a/hyperactor/src/reference.rs
+++ b/hyperactor/src/reference.rs
@@ -765,7 +765,6 @@ pub struct PortRef<M: RemoteMessage> {
 }
 
 impl<M: RemoteMessage> PortRef<M> {
-
     /// The caller attests that the provided PortId can be
     /// converted to a reachable, typed port reference.
     pub fn attest(port_id: PortId) -> Self {
@@ -778,18 +777,18 @@ impl<M: RemoteMessage> PortRef<M> {
 
     /// The caller attests that the provided PortId can be
     /// converted to a reachable, typed port reference.
-    pub fn attest_message_port(actor: &ActorId) -> Self {
-        PortRef::<M>::attest(actor.port_id(<M as Named>::port()))
-    }
-
-    /// The caller attests that the provided PortId can be
-    /// converted to a reachable, typed port reference.
     pub(crate) fn attest_reducible(port_id: PortId, reducer_typehash: Option<u64>) -> Self {
         Self {
             port_id,
             reducer_typehash,
             phantom: PhantomData,
         }
+    }
+
+    /// The caller attests that the provided PortId can be
+    /// converted to a reachable, typed port reference.
+    pub fn attest_message_port(actor: &ActorId) -> Self {
+        PortRef::<M>::attest(actor.port_id(<M as Named>::port()))
     }
 
     /// The typehash of this port's reducer, if any. Reducers


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #221
* __->__ #253
* #247
* #246

Differential Revision: [D76516843](https://our.internmc.facebook.com/intern/diff/D76516843/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D76516843/)!