### PR TITLE
Don't rely on hardcoded address to tell if message is from client

### DIFF
--- a/python/monarch/sim_mesh.py
+++ b/python/monarch/sim_mesh.py
@@ -201,9 +201,11 @@ class Bootstrap:
 
         proxy_addr = proxy_addr or f"unix!@{_random_id()}-proxy"
         self.bootstrap_addr: str = f"sim!unix!@system,{proxy_addr}"
-        self.client_listen_addr: str = f"sim!unix!@client,{proxy_addr}"
+
+        client_proxy_addr = f"unix!@{_random_id()}-proxy"
+        self.client_listen_addr: str = f"sim!unix!@client,{client_proxy_addr}"
         self.client_bootstrap_addr: str = (
-            f"sim!unix!@client,{proxy_addr},unix!@system,{proxy_addr}"
+            f"sim!unix!@client,{client_proxy_addr},unix!@system,{proxy_addr}"
         )
         bootstrap_simulator_backend(self.bootstrap_addr, proxy_addr, world_size)
 


### PR DESCRIPTION
Summary:
Previously we relied on matching a hardcoded abstract name for a unix socket to determine if the message was sent by the client. This does not work in non-linux. What we will do instead is determine if a message was sent by the client based on whether or not the src proxy address is different than the local proxy address.

To make this work we do need to remove our logic for using an egress sender (which is currently unused) to send a forward message to the other proxy which then forwards it to the actual recipient and will just send directly to the recipient. That is if the controller is sending the client a message instead of going from controller -> client_proxy -> client we will go directly from controller -> client. This is because client doesn't actually run in a separate process anymore and doesn't actually have a separate proxy, and if we were to set this up this would require more work because we would also need some way to configure it such that only one proxy sends events to the event loop whereas all other proxy forwards messages to that proxy. We can file a follow up task if need be but in the meantime this diff solves our problems very simply without creating any new problems

Differential Revision: D76526071
