### PR TITLE
[5/n tensor engine] ProcMesh activate() / mock slicing

### DIFF
--- a/python/monarch/common/shape.py
+++ b/python/monarch/common/shape.py
@@ -44,6 +44,9 @@ class MeshTrait(ABC):
     @abstractmethod
     def _labels(self) -> Tuple[str, ...]: ...
 
+    # mesh trait guarentees that its own calls to _new_with_shape
+    # will only ever select a shape that is a subspace of the
+    # current _ndslice.
     @abstractmethod
     def _new_with_shape(self, shape: Shape) -> Self: ...
 

--- a/python/monarch/mesh_controller.py
+++ b/python/monarch/mesh_controller.py
@@ -11,7 +11,7 @@ import time
 import traceback
 from collections import deque
 from logging import Logger
-from typing import List, NamedTuple, Optional, Union
+from typing import List, NamedTuple, Optional, TYPE_CHECKING, Union
 
 import torch.utils._python_dispatch
 
@@ -24,7 +24,13 @@ from monarch._rust_bindings.monarch_extension.mesh_controller import _Controller
 from monarch._rust_bindings.monarch_hyperactor.proc import (  # @manual=//monarch/monarch_extension:monarch_extension
     ActorId,
 )
-from monarch._rust_bindings.monarch_hyperactor.proc_mesh import ProcMesh as HyProcMesh
+
+if TYPE_CHECKING:
+    from monarch._rust_bindings.monarch_hyperactor.proc_mesh import (
+        ProcMesh as HyProcMesh,
+    )
+    from monarch.proc_mesh import ProcMesh
+
 from monarch._rust_bindings.monarch_hyperactor.shape import Point
 
 from monarch._rust_bindings.monarch_messages.debugger import DebuggerAction
@@ -33,7 +39,6 @@ from monarch.common.controller_api import LogMessage, MessageResult
 from monarch.common.device_mesh import DeviceMesh, no_mesh
 from monarch.common.invocation import DeviceException, RemoteException
 from monarch.controller.debugger import read as debugger_read, write as debugger_write
-from monarch.proc_mesh import ProcMesh
 from monarch.rust_local_mesh import _get_worker_exec_info
 from pyre_extensions import none_throws
 
@@ -41,7 +46,7 @@ logger: Logger = logging.getLogger(__name__)
 
 
 class Controller(_Controller):
-    def __init__(self, workers: HyProcMesh) -> None:
+    def __init__(self, workers: "HyProcMesh") -> None:
         super().__init__()
         # Buffer for messages unrelated to debugging that are received while a
         # debugger session is active.
@@ -250,7 +255,7 @@ class MeshClient(Client):
         self.inner.drain_and_stop()
 
 
-def spawn_tensor_engine(proc_mesh: ProcMesh) -> DeviceMesh:
+def spawn_tensor_engine(proc_mesh: "ProcMesh") -> DeviceMesh:
     # This argument to Controller
     # is currently only used for debug printing. It should be fixed to
     # report the proc ID instead of the rank it currently does.

--- a/python/monarch/proc_mesh.py
+++ b/python/monarch/proc_mesh.py
@@ -7,8 +7,22 @@
 # pyre-strict
 
 import sys
+from contextlib import AbstractContextManager
 
-from typing import Any, cast, List, Optional, Type, TypeVar
+from typing import (
+    Any,
+    cast,
+    Dict,
+    List,
+    Optional,
+    Sequence,
+    Type,
+    TYPE_CHECKING,
+    TypeVar,
+)
+
+if TYPE_CHECKING:
+    import torch
 
 import monarch
 from monarch import ActorFuture as Future
@@ -24,7 +38,9 @@ from monarch._rust_bindings.monarch_hyperactor.shape import Shape, Slice
 from monarch.actor_mesh import _Actor, _ActorMeshRefImpl, Actor, ActorMeshRef
 
 from monarch.common._device_utils import _local_device_count
+from monarch.common.device_mesh import DeviceMesh
 from monarch.common.shape import MeshTrait
+from monarch.mesh_controller import spawn_tensor_engine
 from monarch.rdma import RDMAManager
 
 T = TypeVar("T")
@@ -45,25 +61,43 @@ def _allocate_blocking(alloc: Alloc) -> "ProcMesh":
 
 
 class ProcMesh(MeshTrait):
-    def __init__(self, hy_proc_mesh: HyProcMesh) -> None:
+    def __init__(
+        self,
+        hy_proc_mesh: HyProcMesh,
+        _mock_shape: Optional[Shape] = None,
+        _device_mesh: Optional[DeviceMesh] = None,
+    ) -> None:
         self._proc_mesh = hy_proc_mesh
+        self._mock_shape: Optional[Shape] = None
         self._mailbox: Mailbox = self._proc_mesh.client
-        self._rdma_manager: RDMAManager = self._spawn_blocking(
-            "rdma_manager", RDMAManager
-        )
+        self._rdma_manager: Optional[RDMAManager] = None
+        self._maybe_device_mesh: Optional[DeviceMesh] = _device_mesh
+        if _mock_shape is None:
+            self._rdma_manager = self._spawn_blocking("rdma_manager", RDMAManager)
+
+    @property
+    def _shape(self) -> Shape:
+        return self._proc_mesh.shape if self._mock_shape is None else self._mock_shape
 
     @property
     def _ndslice(self) -> Slice:
-        return self._proc_mesh.shape.ndslice
+        return self._shape.ndslice
 
     @property
     def _labels(self) -> List[str]:
-        return self._proc_mesh.shape.labels
+        return self._shape.labels
 
     def _new_with_shape(self, shape: Shape) -> "ProcMesh":
-        raise NotImplementedError("ProcMesh slicing is not implemeted yet.")
+        device_mesh = (
+            None
+            if self._device_mesh is None
+            else self._device_mesh._new_with_shape(shape)
+        )
+        return ProcMesh(self._proc_mesh, _mock_shape=shape, _device_mesh=device_mesh)
 
     def spawn(self, name: str, Class: Type[T], *args: Any, **kwargs: Any) -> Future[T]:
+        if self._mock_shape is not None:
+            raise NotImplementedError("NYI: spawn on slice of a proc mesh.")
         return Future(
             lambda: self._spawn_nonblocking(name, Class, *args, **kwargs),
             lambda: self._spawn_blocking(name, Class, *args, **kwargs),
@@ -119,6 +153,26 @@ class ProcMesh(MeshTrait):
         # doing `ActorMeshRef(Class, actor_handle)` but not calling _create.
         service._create(args, kwargs)
         return cast(T, service)
+
+    @property
+    def _device_mesh(self) -> "DeviceMesh":
+        if self._maybe_device_mesh is None:
+            if self._mock_shape is not None:
+                raise NotImplementedError(
+                    "NYI: activating a proc mesh must first happen on the root proc_mesh until we fix spawning on submeshes."
+                )
+            self._maybe_device_mesh = spawn_tensor_engine(self)
+        return self._maybe_device_mesh
+
+    # pyre-ignore
+    def activate(self) -> AbstractContextManager:
+        return self._device_mesh.activate()
+
+    def rank_tensor(self, dim: str | Sequence[str]) -> "torch.Tensor":
+        return self._device_mesh.rank(dim)
+
+    def rank_tensors(self) -> Dict[str, "torch.Tensor"]:
+        return self._device_mesh.ranks
 
 
 async def local_proc_mesh_nonblocking(

--- a/python/tests/test_python_actors.py
+++ b/python/tests/test_python_actors.py
@@ -390,10 +390,13 @@ def test_rust_binding_modules_correct() -> None:
     check(bindings, "monarch._rust_bindings")
 
 
-@pytest.mark.skipif(
+two_gpu = pytest.mark.skipif(
     torch.cuda.device_count() < 2,
     reason="Not enough GPUs, this test requires at least 2 GPUs",
 )
+
+
+@two_gpu
 def test_tensor_engine() -> None:
     pm = proc_mesh(gpus=2).get()
 
@@ -549,3 +552,20 @@ async def test_debug() -> None:
 
         with pytest.raises(monarch.actor_mesh.ActorError, match="ValueError: bad rank"):
             await fut
+
+
+@two_gpu
+def test_proc_mesh_tensor_engine() -> None:
+    pm = proc_mesh(gpus=2).get()
+    with pm.activate():
+        f = 10 * pm.rank_tensor("gpus").cuda()
+        a = monarch.inspect(f, hosts=0, gpus=0)
+        b = monarch.inspect(f, hosts=0, gpus=1)
+
+    one = pm.slice(gpus=1)
+    with one.activate():
+        sliced_b = monarch.slice_mesh(f, gpus=1).to_mesh(one)
+        c = monarch.inspect(sliced_b * 10)
+    assert a == 0
+    assert b == 10
+    assert c == 100


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #264

See test_python_actor.py for an example.

DeviceMesh is hidden inside of ProcMesh wrapper, so that you can use ProcMesh as the way to tell the tensor engine what to do.

Currently we cannot spawn sliced proc meshes so we have to fake the slicing behavior for ProcMesh to allow it to stil be used as a sliced mesh for the purpose of the tensor engine.

Differential Revision: [D76556227](https://our.internmc.facebook.com/intern/diff/D76556227/)