### PR TITLE
Restore Port objects as argument to send

### DIFF
--- a/monarch_hyperactor/src/actor.rs
+++ b/monarch_hyperactor/src/actor.rs
@@ -172,7 +172,7 @@ pub struct PythonMessage {
     method: String,
     message: ByteBuf,
     response_port: Option<PortId>,
-    rank_in_response: bool,
+    rank: Option<usize>,
 }
 
 impl std::fmt::Debug for PythonMessage {
@@ -209,18 +209,18 @@ impl Bind for PythonMessage {
 #[pymethods]
 impl PythonMessage {
     #[new]
-    #[pyo3(signature = (method, message, response_port = None, rank_in_response = false))]
+    #[pyo3(signature = (method, message, response_port, rank))]
     fn new(
         method: String,
         message: Vec<u8>,
         response_port: Option<crate::mailbox::PyPortId>,
-        rank_in_response: bool,
+        rank: Option<usize>,
     ) -> Self {
         Self {
             method,
             message: ByteBuf::from(message),
             response_port: response_port.map(Into::into),
-            rank_in_response,
+            rank,
         }
     }
 
@@ -240,8 +240,8 @@ impl PythonMessage {
     }
 
     #[getter]
-    fn rank_in_response(&self) -> bool {
-        self.rank_in_response
+    fn rank(&self) -> Option<usize> {
+        return self.rank;
     }
 }
 
@@ -521,7 +521,7 @@ mod tests {
             method: "test".to_string(),
             message: ByteBuf::from(vec![1, 2, 3]),
             response_port: Some(id!(world[0].client[0][123])),
-            rank_in_response: false,
+            rank: None,
         };
         {
             let unbound = message.clone().unbind().unwrap();

--- a/python/monarch/_rust_bindings/monarch_hyperactor/actor.pyi
+++ b/python/monarch/_rust_bindings/monarch_hyperactor/actor.pyi
@@ -8,7 +8,7 @@
 
 import abc
 
-from typing import final, List, Protocol
+from typing import final, List, Optional, Protocol
 
 from monarch._rust_bindings.monarch_hyperactor.mailbox import Mailbox, PortId
 from monarch._rust_bindings.monarch_hyperactor.proc import ActorId, Proc, Serialized
@@ -103,8 +103,8 @@ class PythonMessage:
         self,
         method: str,
         message: bytes,
-        response_port: PortId | None = None,
-        rank_in_response: bool = False,
+        response_port: Optional[PortId],
+        rank: int | None,
     ) -> None: ...
     @property
     def method(self) -> str:
@@ -122,8 +122,8 @@ class PythonMessage:
         ...
 
     @property
-    def rank_in_response(self) -> bool:
-        """Whether or not to include the rank of the handling actor in the response."""
+    def rank(self) -> Optional[int]:
+        """If this message is a response, the rank of the actor in the original broadcast that send the request."""
         ...
 
 @final


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #264
* __->__ #265

Moving around the rank logic so that the `send` API is still clean.

Now every PythonMessage has a "rank: Optional[usize]" which is set for any message that is a response from a PythonActor that identifies the returning rank. The python PortReceiver object is the one that decides whether to expose the rank in the message or just return the message.

Differential Revision: [D76617694](https://our.internmc.facebook.com/intern/diff/D76617694/)