### PR TITLE
[monarch] make test_python_actors.py work without torch

### DIFF
--- a/python/monarch/__init__.py
+++ b/python/monarch/__init__.py
@@ -9,9 +9,13 @@
 from importlib import import_module as _import_module
 from typing import TYPE_CHECKING
 
-# Import before monarch to pre-load torch DSOs as, in exploded wheel flows,
-# our RPATHs won't correctly find them.
-import torch  # noqa: F401
+# Import torch conditionally based on tensor engine availability
+from monarch._rust_bindings import has_tensor_engine
+
+if has_tensor_engine():
+    # Import before monarch to pre-load torch DSOs as, in exploded wheel flows,
+    # our RPATHs won't correctly find them.
+    import torch  # noqa: F401
 
 # submodules of monarch should not be imported in this
 # top-level file because it will cause them to get

--- a/python/monarch/bootstrap_main.py
+++ b/python/monarch/bootstrap_main.py
@@ -14,8 +14,11 @@ import logging
 import os
 import sys
 
-# Import torch to avoid import-time races if a spawned actor tries to import torch.
-import torch  # noqa[F401]
+from monarch._rust_bindings import has_tensor_engine
+
+if has_tensor_engine():
+    # Import torch to avoid import-time races if a spawned actor tries to import torch.
+    import torch  # noqa: F401
 
 
 async def main():

--- a/python/monarch/mesh_controller.py
+++ b/python/monarch/mesh_controller.py
@@ -13,6 +13,11 @@ from collections import deque
 from logging import Logger
 from typing import List, NamedTuple, Optional, Union
 
+from monarch._rust_bindings import has_tensor_engine
+
+if not has_tensor_engine():
+    raise ImportError("Tensor engine is not enabled, this module requires it.")
+
 import torch.utils._python_dispatch
 
 from monarch import NDSlice

--- a/python/monarch/proc_mesh.py
+++ b/python/monarch/proc_mesh.py
@@ -25,7 +25,10 @@ from monarch.actor_mesh import _Actor, _ActorMeshRefImpl, Actor, ActorMeshRef
 
 from monarch.common._device_utils import _local_device_count
 from monarch.common.shape import MeshTrait
-from monarch.rdma import RDMAManager
+from monarch._rust_bindings import has_tensor_engine
+
+if has_tensor_engine():
+    from monarch.rdma import RDMAManager
 
 T = TypeVar("T")
 try:
@@ -48,9 +51,10 @@ class ProcMesh(MeshTrait):
     def __init__(self, hy_proc_mesh: HyProcMesh) -> None:
         self._proc_mesh = hy_proc_mesh
         self._mailbox: Mailbox = self._proc_mesh.client
-        self._rdma_manager: RDMAManager = self._spawn_blocking(
-            "rdma_manager", RDMAManager
-        )
+        if has_tensor_engine():
+            self._rdma_manager: RDMAManager = self._spawn_blocking(
+                "rdma_manager", RDMAManager
+            )
 
     @property
     def _ndslice(self) -> Slice:

--- a/python/monarch/rdma.py
+++ b/python/monarch/rdma.py
@@ -9,6 +9,11 @@ import ctypes
 from dataclasses import dataclass
 from typing import cast, Dict, Optional, Tuple
 
+from monarch._rust_bindings import has_tensor_engine
+
+if not has_tensor_engine():
+    raise ImportError("Tensor engine is not enabled, this module requires it.")
+
 import torch
 
 from monarch._rust_bindings.monarch_hyperactor.proc import ActorId


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #273
* #269

Make it so that if I pass `USE_TENSOR_ENGINE=0`, we can still run
(or skip) all the tests test_python_actors.py, even without a torch
dependency.

This is accomplished by gating relevant imports under a
`has_tensor_engine()` check. In the future, we will refactor the physical
layout of the library so that it's not so random where these checks are,
but this will get us started.

Tested by:
```
pip uninstall torch
USE_TENSOR_ENGINE=0 pip install --no-build-isolation -e .
pytest python/tests/test_python_actors.py
```