### PR TITLE
[monarch] make tracing initialization log to debug

### DIFF
--- a/hyperactor_telemetry/src/lib.rs
+++ b/hyperactor_telemetry/src/lib.rs
@@ -453,7 +453,7 @@ pub fn initialize_logging() {
             tracing::debug!("logging already initialized for this process: {}", err);
         }
         let exec_id = env::execution_id();
-        tracing::info!(
+        tracing::debug!(
             target: "execution",
             execution_id = exec_id,
             environment = %Env::current(),


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #283

Slowly trying to eliminate library-generated noise from monarch output.

My principle is that in default mode (INFO): we should intend for any logs generated to be directly consumed by the user.

If it's relevant mostly for us as monarch developers, it should go to DEBUG.

Differential Revision: [D76771090](https://our.internmc.facebook.com/intern/diff/D76771090/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D76771090/)!