### PR TITLE
(1/n torchx-allocator)(monarch/cli) pretty print json in `info` subcommand

### DIFF
--- a/python/monarch/tools/cli.py
+++ b/python/monarch/tools/cli.py
@@ -112,7 +112,7 @@ class InfoCmd:
                 file=sys.stderr,
             )
         else:
-            json.dump(server_spec.to_json(), fp=sys.stdout)
+            json.dump(server_spec.to_json(), indent=2, fp=sys.stdout)
 
 
 class KillCmd:


### PR DESCRIPTION
Summary: pretty print json for `monarch info` subcommand

Reviewed By: ahmadsharif1

Differential Revision: D76845620


