### PR TITLE
(3/n torchx-allocator)(monarch/tools) add commands.server_ready function and hostnames to mesh_spec

### DIFF
--- a/python/monarch/tools/mesh_spec.py
+++ b/python/monarch/tools/mesh_spec.py
@@ -6,7 +6,7 @@
 
 # pyre-strict
 import string
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, Optional
 
 from torchx import specs
@@ -29,6 +29,7 @@ class MeshSpec:
     host_type: str
     gpus: int
     port: int = DEFAULT_REMOTE_ALLOCATOR_PORT
+    hostnames: list[str] = field(default_factory=list)
 
 
 def _tag(mesh_name: str, tag_template: str) -> str:
@@ -84,6 +85,10 @@ class ServerSpec:
     state: specs.AppState
     meshes: list[MeshSpec]
 
+    @property
+    def is_running(self) -> bool:
+        return self.state == specs.AppState.RUNNING
+
     def get_mesh_spec(self, mesh_name: str) -> MeshSpec:
         for mesh_spec in self.meshes:
             if mesh_spec.name == mesh_name:
@@ -115,6 +120,7 @@ class ServerSpec:
                     "host_type": mesh.host_type,
                     "hosts": mesh.num_hosts,
                     "gpus": mesh.gpus,
+                    "hostnames": mesh.hostnames,
                 }
                 for mesh in self.meshes
             },

--- a/python/tests/tools/test_cli.py
+++ b/python/tests/tools/test_cli.py
@@ -68,12 +68,14 @@ class TestCli(unittest.TestCase):
     "trainer": {
       "host_type": "gpu.medium",
       "hosts": 4,
-      "gpus": 2
+      "gpus": 2,
+      "hostnames": []
     },
     "generator": {
       "host_type": "gpu.small",
       "hosts": 16,
-      "gpus": 1
+      "gpus": 1,
+      "hostnames": []
     }
   }
 }

--- a/python/tests/tools/test_mesh_spec.py
+++ b/python/tests/tools/test_mesh_spec.py
@@ -82,7 +82,11 @@ class TestMeshSpec(unittest.TestCase):
 
     def test_mesh_spec_can_dump_as_json(self) -> None:
         mesh_spec = MeshSpec(
-            name="trainer", num_hosts=4, host_type="gpu.medium", gpus=2
+            name="trainer",
+            num_hosts=4,
+            host_type="gpu.medium",
+            gpus=2,
+            hostnames=["n0", "n1", "n2", "n3"],
         )
         expected = """
 {
@@ -90,7 +94,13 @@ class TestMeshSpec(unittest.TestCase):
   "num_hosts": 4,
   "host_type": "gpu.medium",
   "gpus": 2,
-  "port": 26600
+  "port": 26600,
+  "hostnames": [
+    "n0",
+    "n1",
+    "n2",
+    "n3"
+  ]
 }
 """
         self.assertEqual(expected.strip("\n"), json.dumps(asdict(mesh_spec), indent=2))


### PR DESCRIPTION
Summary:
TorchX's `status` API returns a struct that has `replica.hostname` field. However it is not always filled for all schedulers. https://github.com/pytorch/torchx/pull/1080 makes it such that the slurm scheduler in TorchX fills out the hostname information.

This PR adds a `hostnames` field to `monarch.tools.mesh_sepc.MeshSpec` and fills it up with the hostnames returned by TorchX.

This information will be used in PR (5/n) to implement a `TorchXAllocator`

Differential Revision: D76847192


