### PR TITLE
(4/n torchx-allocator)(monarch/hyperactor) pass alloc spec match label to python initializer

### DIFF
--- a/python/monarch/allocator.py
+++ b/python/monarch/allocator.py
@@ -74,7 +74,7 @@ class RemoteAllocInitializer(abc.ABC):
     """
 
     @abc.abstractmethod
-    async def initialize_alloc(self) -> list[str]:
+    async def initialize_alloc(self, match_labels: dict[str, str]) -> list[str]:
         """
         Return the addresses of the servers that should be used to allocate processes
         for the proc mesh. The addresses should be running hyperactor's RemoteProcessAllocator.
@@ -87,6 +87,10 @@ class RemoteAllocInitializer(abc.ABC):
         NOTE: Although this method is currently called once at the initialization of the Allocator,
             in the future this method can be called multiple times and should return the current set of
             addresses that are eligible to handle allocation requests.
+
+        Arguments:
+        - `match_labels`: The match labels specified in `AllocSpec.AllocConstraints`. Initializer implementations
+            can read specific labels for matching a set of hosts that will service `allocate()` requests.
 
         """
         ...
@@ -102,7 +106,8 @@ class StaticRemoteAllocInitializer(RemoteAllocInitializer):
         super().__init__()
         self.addrs: list[str] = list(addrs)
 
-    async def initialize_alloc(self) -> list[str]:
+    async def initialize_alloc(self, match_labels: dict[str, str]) -> list[str]:
+        _ = match_labels  # Suppress unused variable warning
         return list(self.addrs)
 
 

--- a/python/tests/test_allocator.py
+++ b/python/tests/test_allocator.py
@@ -116,8 +116,8 @@ class TestRemoteAllocator(unittest.IsolatedAsyncioTestCase):
             used to test that the state of the initializer is preserved across calls to allocate()
             """
 
-            async def initialize_alloc(self) -> list[str]:
-                alloc = await super().initialize_alloc()
+            async def initialize_alloc(self, match_labels: dict[str, str]) -> list[str]:
+                alloc = await super().initialize_alloc(match_labels)
                 self.addrs.pop(-1)
                 return alloc
 
@@ -142,7 +142,8 @@ class TestRemoteAllocator(unittest.IsolatedAsyncioTestCase):
         class EmptyAllocInitializer(StaticRemoteAllocInitializer):
             """test initializer that returns an empty list of addresses"""
 
-            async def initialize_alloc(self) -> list[str]:
+            async def initialize_alloc(self, match_labels: dict[str, str]) -> list[str]:
+                _ = match_labels  # Suppress unused variable warning
                 return []
 
         empty_initializer = EmptyAllocInitializer()


### PR DESCRIPTION
Summary: Makes it possible for `RemoteAllocInitializer` implementations in Python has access to the `alloc_spec`'s allocation constraints - particularly the `match_labels`. This is so that the initializer can apply the match labels to potentially filter the list of hosts that will service a particular `allocate(alloc_spec)` request.

Differential Revision: D76854490


