### PR TITLE
[hyperactor] py: ensure that proc mesh lifetimes are tied to actor mesh lifetimes

### DIFF
--- a/hyperactor/src/channel/net.rs
+++ b/hyperactor/src/channel/net.rs
@@ -1186,7 +1186,7 @@ where
             }
 
             _ = parent_cancel_token.cancelled() => {
-                tracing::info!("recieved parent token cancellation");
+                tracing::info!("received parent token cancellation");
                 break Ok(());
             }
 

--- a/monarch_hyperactor/src/actor_mesh.rs
+++ b/monarch_hyperactor/src/actor_mesh.rs
@@ -19,6 +19,7 @@ use crate::actor::PythonActor;
 use crate::actor::PythonMessage;
 use crate::mailbox::PyMailbox;
 use crate::proc::PyActorId;
+use crate::proc_mesh::Keepalive;
 use crate::shape::PyShape;
 
 #[pyclass(
@@ -28,6 +29,7 @@ use crate::shape::PyShape;
 pub struct PythonActorMesh {
     pub(super) inner: Arc<RootActorMesh<'static, PythonActor>>,
     pub(super) client: PyMailbox,
+    pub(super) keepalive: Keepalive,
 }
 
 #[pymethods]

--- a/monarch_hyperactor/src/proc_mesh.rs
+++ b/monarch_hyperactor/src/proc_mesh.rs
@@ -32,7 +32,7 @@ use crate::shape::PyShape;
 )]
 pub struct PyProcMesh {
     pub inner: Arc<ProcMesh>,
-    monitor: tokio::task::JoinHandle<()>,
+    keepalive: Keepalive,
 }
 fn allocate_proc_mesh<'py>(py: Python<'py>, alloc: &PyAlloc) -> PyResult<Bound<'py, PyAny>> {
     let alloc = match alloc.take() {
@@ -80,7 +80,7 @@ impl PyProcMesh {
         ));
         Self {
             inner: Arc::new(proc_mesh),
-            monitor,
+            keepalive: Keepalive::new(monitor),
         }
     }
 
@@ -98,12 +98,6 @@ impl PyProcMesh {
                 }
             }
         }
-    }
-}
-
-impl Drop for PyProcMesh {
-    fn drop(&mut self) {
-        self.monitor.abort();
     }
 }
 
@@ -135,6 +129,7 @@ impl PyProcMesh {
     ) -> PyResult<Bound<'py, PyAny>> {
         let pickled_type = PickledPyObject::pickle(actor.as_any())?;
         let proc_mesh = Arc::clone(&self.inner);
+        let keepalive = self.keepalive.clone();
         pyo3_async_runtimes::tokio::future_into_py(py, async move {
             let actor_mesh = proc_mesh.spawn(&name, &pickled_type).await?;
             let python_actor_mesh = PythonActorMesh {
@@ -142,6 +137,7 @@ impl PyProcMesh {
                 client: PyMailbox {
                     inner: proc_mesh.client().clone(),
                 },
+                keepalive,
             };
             Ok(Python::with_gil(|py| python_actor_mesh.into_py(py)))
         })
@@ -155,6 +151,7 @@ impl PyProcMesh {
     ) -> PyResult<PyObject> {
         let pickled_type = PickledPyObject::pickle(actor.as_any())?;
         let proc_mesh = Arc::clone(&self.inner);
+        let keepalive = self.keepalive.clone();
         signal_safe_block_on(py, async move {
             let actor_mesh = proc_mesh.spawn(&name, &pickled_type).await?;
             let python_actor_mesh = PythonActorMesh {
@@ -162,6 +159,7 @@ impl PyProcMesh {
                 client: PyMailbox {
                     inner: proc_mesh.client().clone(),
                 },
+                keepalive,
             };
             Ok(Python::with_gil(|py| python_actor_mesh.into_py(py)))
         })?
@@ -181,6 +179,32 @@ impl PyProcMesh {
     #[getter]
     fn shape(&self) -> PyShape {
         self.inner.shape().clone().into()
+    }
+}
+
+/// A keepalive token that aborts a task only after the last clone
+/// of the token is dropped.
+#[derive(Clone, Debug)]
+pub(crate) struct Keepalive {
+    /// The function of this field is to maintain a reference to the
+    /// state.
+    _state: Arc<KeepaliveState>,
+}
+
+impl Keepalive {
+    fn new(handle: tokio::task::JoinHandle<()>) -> Self {
+        Self {
+            _state: Arc::new(KeepaliveState(handle)),
+        }
+    }
+}
+
+#[derive(Debug)]
+struct KeepaliveState(tokio::task::JoinHandle<()>);
+
+impl Drop for KeepaliveState {
+    fn drop(&mut self) {
+        self.0.abort();
     }
 }
 

--- a/python/tests/test_python_actors.py
+++ b/python/tests/test_python_actors.py
@@ -9,6 +9,7 @@ import operator
 import os
 import re
 import threading
+import time
 from types import ModuleType
 from unittest.mock import AsyncMock, patch
 
@@ -389,6 +390,16 @@ def test_rust_binding_modules_correct() -> None:
                 assert value.__module__ == path
 
     check(bindings, "monarch._rust_bindings")
+
+
+def test_proc_mesh_liveness() -> None:
+    mesh = proc_mesh(gpus=2).get()
+    counter = mesh.spawn("counter", Counter, 1).get()
+    del mesh
+    # Give some time for the mesh to have been shut down.
+    # (It only would if there were a bug.)
+    time.sleep(0.5)
+    counter.value.call().get()
 
 
 two_gpu = pytest.mark.skipif(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #299

In Python, a ProcMesh may outlive its alloc. This is because the monitoring loop of the ProcMesh—which owns the alloc—is tied to its Python object, which may be dropped while there are extant actor mesh references.

---

The EventState owns the underlying alloc, because this is how we're driving all changes to the proc.

```
struct EventState {
    alloc: Box<dyn Alloc + Send + Sync>,
    supervision_events: PortReceiver<ActorSupervisionEvent>,
}
```

We transfer ownership to whomever is listening to events.

```
    /// An event stream of proc events. Each ProcMesh can produce only one such
    /// stream, returning None after the first call.
    pub fn events(&mut self) -> Option<ProcEvents> {
        self.event_state.take().map(|event_state| ProcEvents {
            event_state,
            ranks: self
                .ranks
                .iter()
                .enumerate()
                .map(|(rank, (proc_id, _))| (proc_id.clone(), rank))
                .collect(),
        })
    }
```

In PyProcMesh, we take over the event stream to perform monitoring. When PyProcMesh is then dropped, we abort the task, the closure, and thus the event stream. This causes the alloc to be dropped. It's the alloc that maintains the server.

---

We fix this by ensuring that the monitoring loop is kept alive as long as there are any Python proc mesh or actor mesh objects.

In the more medium term, this will be fixed by decoupling these lifetimes in the underlying APIs.

Differential Revision: [D76873976](https://our.internmc.facebook.com/intern/diff/D76873976/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D76873976/)!