### PR TITLE
fix test_realtime_frontier stress runs

### DIFF
--- a/hyperactor/src/channel/sim.rs
+++ b/hyperactor/src/channel/sim.rs
@@ -558,7 +558,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_realtime_frontier() {
-        let proxy: ChannelAddr = "unix!@proxy".parse().unwrap();
+        let proxy: ChannelAddr = ChannelAddr::any(ChannelTransport::Unix);
         start(
             ChannelAddr::any(ChannelTransport::Unix),
             proxy.clone(),


### PR DESCRIPTION
Summary: Use ChannelAddr::any() instead of hardcoded address to prevent error about proxy already being served on that address when we are doing stress runs

Reviewed By: ahmadsharif1, vidhyav

Differential Revision: D76902727
