### PR TITLE
(5/n torchx-allocator)(monarch/allocator) Implement TorchXRemoteAllocInitializer

### DIFF
--- a/python/monarch/tools/network.py
+++ b/python/monarch/tools/network.py
@@ -12,51 +12,58 @@ from typing import Optional
 logger: logging.Logger = logging.getLogger(__name__)
 
 
-def get_ip_addr(hostname: str) -> str:
-    """Resolves and returns the ip address of the given hostname.
+def get_sockaddr(hostname: str, port: int) -> str:
+    """Returns either an IPv6 or IPv4 socket address (that supports TCP) of the given hostname and port.
+    The socket address is of the form:
+      1. `{ipv4.address}:{port}` (e.g. `127.0.0.1:8080`)
+      2. `[{ipv6:address}]:{port}` (e.g. `[::1]:8080`)
 
-    This function will return an ipv6 address if one that can bind
-    `SOCK_STREAM` (TCP) socket is found. Otherwise it will fall-back
-    to resolving an ipv4 `SOCK_STREAM` address.
+    The hostname is resolved to an IPv6 (or IPv4 if IPv6 is not available on the host) address that
+    supports `SOCK_STREAM` (TCP).
 
     Raises a `RuntimeError` if neither ipv6 or ipv4 ip can be resolved from hostname.
     """
 
-    def get_sockaddr(family: socket.AddressFamily) -> Optional[str]:
+    def resolve_sockaddr(family: socket.AddressFamily) -> Optional[str]:
         try:
             # patternlint-disable-next-line python-dns-deps (only used for oss)
-            addrs = socket.getaddrinfo(
-                hostname, port=None, family=family, type=socket.SOCK_STREAM
-            )  # tcp
+            addrs = socket.getaddrinfo(hostname, port, family, type=socket.SOCK_STREAM)
             if addrs:
-                # socket.getaddrinfo return a list of addr 5-tuple addr infos
-                _, _, _, _, sockaddr = addrs[0]  # use the first address
+                family, _, _, _, sockaddr = addrs[0]  # use the first address
 
-                # sockaddr is a tuple (ipv4) or a 4-tuple (ipv6) where the first element is the ip addr
+                # sockaddr is a tuple (ipv4) or a 4-tuple (ipv6)
+                # in both cases the first element is the ip addr
                 ipaddr = str(sockaddr[0])
 
+                if family == socket.AF_INET6:
+                    socket_address = f"[{ipaddr}]:{port}"
+                else:  # socket.AF_INET
+                    socket_address = f"{ipaddr}:{port}"
+
                 logger.info(
-                    "Resolved %s address: `%s` for host: `%s`",
+                    "resolved %s address `%s` for `%s:%d`",
                     family.name,
-                    ipaddr,
+                    socket_address,
                     hostname,
+                    port,
                 )
-                return str(ipaddr)
-            else:
-                return None
+
+                return socket_address
         except socket.gaierror as e:
             logger.info(
-                "No %s address that can bind TCP sockets for host: %s. %s",
+                "no %s address that can bind TCP sockets for `%s:%d` (error: %s)",
                 family.name,
                 hostname,
+                port,
                 e,
             )
-            return None
+        return None
 
-    ipaddr = get_sockaddr(socket.AF_INET6) or get_sockaddr(socket.AF_INET)
-    if not ipaddr:
-        raise RuntimeError(
-            f"Unable to resolve `{hostname}` to ipv6 or ipv4 address that can bind TCP socket."
-            " Check the network configuration on the host."
-        )
-    return ipaddr
+    for family in [socket.AF_INET6, socket.AF_INET]:
+        if ipaddr := resolve_sockaddr(family):
+            return ipaddr
+
+    raise RuntimeError(
+        f"Unable to resolve `{hostname}` to ipv6 or ipv4 address that can bind TCP socket."
+        " Check the network configuration on the host."
+    )

--- a/python/tests/tools/test_network.py
+++ b/python/tests/tools/test_network.py
@@ -25,13 +25,13 @@ class TestNetwork(unittest.TestCase):
                         socket.SOCK_STREAM,
                         socket.IPPROTO_TCP,
                         "",
-                        ("123.45.67.89", 80),
+                        ("123.45.67.89", 8080),
                     )
                 ],
             ],
         ):
             self.assertEqual(
-                "123.45.67.89", network.get_ip_addr("foo.bar.facebook.com")
+                "123.45.67.89:8080", network.get_sockaddr("foo.bar.facebook.com", 8080)
             )
 
     def test_network_ipv6(self) -> None:
@@ -50,11 +50,11 @@ class TestNetwork(unittest.TestCase):
             ),
         ):
             self.assertEqual(
-                "1234:ab00:567c:89d:abcd:0:328:0",
-                network.get_ip_addr("foo.bar.facebook.com"),
+                "[1234:ab00:567c:89d:abcd:0:328:0]:8080",
+                network.get_sockaddr("foo.bar.facebook.com", 8080),
             )
 
     def test_network(self) -> None:
         # since we patched `socket.getaddrinfo` above
         # don't patch and just make sure things don't error out
-        self.assertIsNotNone(network.get_ip_addr(socket.getfqdn()))
+        self.assertIsNotNone(network.get_sockaddr(socket.getfqdn(), 8080))


### PR DESCRIPTION
Summary:
TorchX allocator can be created by:

```
RemoteAllocator(
  world_id = "foo",
  initializer = TorchXRemoteAllocInitializer("mast:///job_name")
)
```

when multiple task groups exist, you need to provide it a match label:

```
spec = AllocSpec(
  AllocConstraints(match_label={ALLOC_LABEL_PROC_MESH_NAME: "trainer"},
  hosts=1, gpus=2)

allocator.allocate(spec)
```

but on a single task group, no explicit match label needs to be specified.

Differential Revision: D76845657


