### PR TITLE
[monarch] split tensor engine tests into their own file

### DIFF
--- a/python/tests/test_python_actors.py
+++ b/python/tests/test_python_actors.py
@@ -6,7 +6,6 @@
 
 import asyncio
 import operator
-import os
 import re
 import threading
 import time
@@ -30,8 +29,6 @@ from monarch.actor_mesh import (
 )
 from monarch.debugger import init_debugging
 from monarch.future import ActorFuture
-
-from monarch.mesh_controller import spawn_tensor_engine
 
 from monarch.proc_mesh import local_proc_mesh, proc_mesh
 from monarch.rdma import RDMABuffer
@@ -403,30 +400,6 @@ def test_proc_mesh_liveness() -> None:
     counter.value.call().get()
 
 
-two_gpu = pytest.mark.skipif(
-    torch.cuda.device_count() < 2,
-    reason="Not enough GPUs, this test requires at least 2 GPUs",
-)
-
-
-@two_gpu
-def test_tensor_engine() -> None:
-    pm = proc_mesh(gpus=2).get()
-
-    dm = spawn_tensor_engine(pm)
-    with dm.activate():
-        r = monarch.inspect(2 * torch.zeros(3, 4))
-
-    fm = dm.flatten("all")
-    with fm.activate():
-        f = monarch.inspect(2 * torch.zeros(3, 4), all=1)
-
-    assert torch.allclose(torch.zeros(3, 4), r)
-    assert torch.allclose(torch.zeros(3, 4), f)
-
-    dm.exit()
-
-
 def _debugee_actor_internal(rank):
     if rank == 0:
         breakpoint()  # noqa
@@ -630,23 +603,6 @@ async def test_actor_tls_full_sync() -> None:
     await am.increment.call_one()
 
     assert 4 == await am.get.call_one()
-
-
-@two_gpu
-def test_proc_mesh_tensor_engine() -> None:
-    pm = proc_mesh(gpus=2).get()
-    with pm.activate():
-        f = 10 * pm.rank_tensor("gpus").cuda()
-        a = monarch.inspect(f, hosts=0, gpus=0)
-        b = monarch.inspect(f, hosts=0, gpus=1)
-
-    one = pm.slice(gpus=1)
-    with one.activate():
-        sliced_b = monarch.slice_mesh(f, gpus=1).to_mesh(one)
-        c = monarch.inspect(sliced_b * 10)
-    assert a == 0
-    assert b == 10
-    assert c == 100
 
 
 class AsyncActor(Actor):

--- a/python/tests/test_tensor_engine.py
+++ b/python/tests/test_tensor_engine.py
@@ -1,0 +1,52 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import monarch
+import pytest
+import torch
+from monarch.mesh_controller import spawn_tensor_engine
+from monarch.proc_mesh import proc_mesh
+
+
+two_gpu = pytest.mark.skipif(
+    torch.cuda.device_count() < 2,
+    reason="Not enough GPUs, this test requires at least 2 GPUs",
+)
+
+
+@two_gpu
+def test_tensor_engine() -> None:
+    pm = proc_mesh(gpus=2).get()
+
+    dm = spawn_tensor_engine(pm)
+    with dm.activate():
+        r = monarch.inspect(2 * torch.zeros(3, 4))
+
+    fm = dm.flatten("all")
+    with fm.activate():
+        f = monarch.inspect(2 * torch.zeros(3, 4), all=1)
+
+    assert torch.allclose(torch.zeros(3, 4), r)
+    assert torch.allclose(torch.zeros(3, 4), f)
+
+    dm.exit()
+
+
+@two_gpu
+def test_proc_mesh_tensor_engine() -> None:
+    pm = proc_mesh(gpus=2).get()
+    with pm.activate():
+        f = 10 * pm.rank_tensor("gpus").cuda()
+        a = monarch.inspect(f, hosts=0, gpus=0)
+        b = monarch.inspect(f, hosts=0, gpus=1)
+
+    one = pm.slice(gpus=1)
+    with one.activate():
+        sliced_b = monarch.slice_mesh(f, gpus=1).to_mesh(one)
+        c = monarch.inspect(sliced_b * 10)
+    assert a == 0
+    assert b == 10
+    assert c == 100


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #313

as title. This is to distinguish things thare are testing the actor_mesh layer from things that are testing the tensor_engine layer (as well as make it easier to run `test_python_actors.py` on platforms that the tensor engine doesn't support yet, e.g. mac)

Differential Revision: [D76995688](https://our.internmc.facebook.com/intern/diff/D76995688/)