### PR TITLE
[monarch] Make test_python_actor.py work if cuda is not available

### DIFF
--- a/python/tests/test_python_actors.py
+++ b/python/tests/test_python_actors.py
@@ -36,6 +36,11 @@ from monarch.mesh_controller import spawn_tensor_engine
 from monarch.proc_mesh import local_proc_mesh, proc_mesh
 from monarch.rdma import RDMABuffer
 
+needs_cuda = pytest.mark.skipif(
+    not torch.cuda.is_available(),
+    reason="CUDA not available",
+)
+
 
 class Counter(Actor):
     def __init__(self, v: int):
@@ -116,6 +121,7 @@ class ParameterClient(Actor):
         return self.buffer
 
 
+@needs_cuda
 async def test_proc_mesh_rdma():
     proc = await proc_mesh(gpus=1)
     server = await proc.spawn("server", ParameterServer)
@@ -284,6 +290,7 @@ class GeneratorActor(Actor):
         ), f"{torch.sum(self.generator.weight.data)=}, {self.step=}"
 
 
+@needs_cuda
 async def test_gpu_trainer_generator():
     trainer_proc = await proc_mesh(gpus=1)
     gen_proc = await proc_mesh(gpus=1)
@@ -313,6 +320,7 @@ async def test_sync_actor():
     assert r == 5
 
 
+@needs_cuda
 def test_gpu_trainer_generator_sync() -> None:
     trainer_proc = proc_mesh(gpus=1).get()
     gen_proc = proc_mesh(gpus=1).get()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #314

skips tests as necessary

Differential Revision: [D77054935](https://our.internmc.facebook.com/intern/diff/D77054935/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D77054935/)!