### PR TITLE
Enhance exceptions in process allocation and setup

### DIFF
--- a/hyperactor_mesh/src/alloc/remoteprocess.rs
+++ b/hyperactor_mesh/src/alloc/remoteprocess.rs
@@ -794,7 +794,7 @@ impl Alloc for RemoteProcessAlloc {
             if let Err(e) = self.ensure_started().await {
                 break Some(ProcState::Failed {
                     world_id: self.world_id.clone(),
-                    description: format!("failed to ensure started: {}", e),
+                    description: format!("failed to ensure started: {:#}", e),
                 });
             }
 

--- a/python/monarch/actor_mesh.py
+++ b/python/monarch/actor_mesh.py
@@ -520,6 +520,10 @@ class _Actor:
                 self.instance = Class(*args, **kwargs)
                 return None
 
+            if self.instance is None:
+                raise AssertionError(
+                    "__init__ failed earlier and no Actor object is available"
+                )
             the_method = getattr(self.instance, message.method)._method
 
             if inspect.iscoroutinefunction(the_method):


### PR DESCRIPTION
Summary:
When working on pretraining on CPU models, I ran into a couple issues that were made
easier by these changes:
* When task group allocation fails, the error message was too terse, and didn't include all the  context. Use `{:#}` to select the more-context print of anyhow::Error
* Add one layer of context to narrow down the path better along mast process allocation
* Add an exception that will catch when the `__init__` of an actor fails and doesn't instantiate the instance correctly

Differential Revision: D77322952


