### PR TITLE
Error repro for tensor engine related errors (#56)

### DIFF
--- a/monarch_extension/src/convert.rs
+++ b/monarch_extension/src/convert.rs
@@ -140,9 +140,8 @@ impl<'a> MessageParser<'a> {
             .try_iter()?
             .map(|x| {
                 let v = x?;
-                let vr: PyResult<u64> = v.extract();
-                if let Ok(v) = vr {
-                    Ok(v.into())
+                if v.is_instance_of::<pyo3::types::PyInt>() {
+                    Ok(v.extract::<u64>()?.into())
                 } else {
                     create_ref(v)
                 }

--- a/python/monarch/worker/_testing_function.py
+++ b/python/monarch/worker/_testing_function.py
@@ -479,3 +479,13 @@ def test_pdb_actor():
     pdb_actor.send(DebuggerAction.Write(b"5678"))
     assert isinstance(pdb_actor.receive(), DebuggerAction.Detach)
     return torch.zeros(1)
+
+
+def throw_python_exception():
+    d = {"a": torch.tensor(1)}
+    x = d["b"]
+    return x
+
+
+def returns_a_string():
+    return "hello"

--- a/python/monarch/worker/_testing_throws_on_import.py
+++ b/python/monarch/worker/_testing_throws_on_import.py
@@ -1,0 +1,13 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import torch
+
+raise ImportError("could not import file")
+
+
+def _an_unusable_function():
+    return torch.tensor([1, 2, 3])


### PR DESCRIPTION
Summary:

Add a script that repros various categories of error for observing error propagation behavior in the tensor engine.

Differential Revision: D75566269


