### PR TITLE
Graceful shutdown for proc_mesh

### DIFF
--- a/hyperactor/src/proc.rs
+++ b/hyperactor/src/proc.rs
@@ -517,11 +517,9 @@ impl Proc {
             .next()
     }
 
-    // Iterating over a proc's root actors signaling each to stop.
-    // Return the root actor IDs and status observers.
-    async fn destroy(
-        &mut self,
-    ) -> Result<HashMap<ActorId, watch::Receiver<ActorStatus>>, anyhow::Error> {
+    /// Iterating over a proc's root actors signaling each to stop.
+    /// Return the root actor IDs and status observers.
+    pub fn destroy(&self) -> Result<HashMap<ActorId, watch::Receiver<ActorStatus>>, anyhow::Error> {
         tracing::debug!("{}: proc stopping", self.proc_id());
 
         let mut statuses = HashMap::new();
@@ -558,7 +556,7 @@ impl Proc {
         timeout: Duration,
         skip_waiting: Option<&ActorId>,
     ) -> Result<(Vec<ActorId>, Vec<ActorId>), anyhow::Error> {
-        let mut statuses = self.destroy().await?;
+        let mut statuses = self.destroy()?;
         let waits: Vec<_> = statuses
             .iter_mut()
             .filter(|(actor_id, _)| Some(*actor_id) != skip_waiting)

--- a/python/monarch/_rust_bindings/monarch_hyperactor/proc_mesh.pyi
+++ b/python/monarch/_rust_bindings/monarch_hyperactor/proc_mesh.pyi
@@ -74,4 +74,20 @@ class ProcMesh:
         """
         ...
 
+    def stop(self) -> None:
+        """
+        Signals the `alloc` to stop all `Proc`s and the
+        `client`'s `Proc` to stop.
+        This returns immediately after the signal is sent.
+
+        Call `await wait_for_stop()` to wait until all the `Proc`s have completed stopping.
+        """
+        ...
+
+    async def wait_for_stop(self) -> None:
+        """
+        Wait for all `Proc`s in the `alloc` and the `client`'s `Proc` to stop.
+        """
+        ...
+
     def __repr__(self) -> str: ...

--- a/python/monarch/proc_mesh.py
+++ b/python/monarch/proc_mesh.py
@@ -14,6 +14,7 @@ from typing import (
     Any,
     cast,
     Dict,
+    Generator,
     List,
     Optional,
     Sequence,
@@ -213,6 +214,12 @@ class ProcMesh(MeshTrait):
                 remote_workspace=RemoteWorkspace.FromEnvVar("WORKSPACE_DIR"),
             )
         await self._rsync_mesh_client.sync_workspace()
+
+    def stop(self) -> None:
+        self._proc_mesh.stop()
+
+    def __await__(self) -> Generator[None, None, None]:
+        return self._proc_mesh.wait_for_stop().__await__()
 
 
 async def local_proc_mesh_nonblocking(


### PR DESCRIPTION
Summary: We perform graceful shutdown for proc_meshes by stopping all procs and their actors on the allocator before finally stopping the client proc

Differential Revision: D76908301


