### PR TITLE
[monarch] delete extra runtime

### DIFF
--- a/books/hyperactor-book/src/mailboxes/mailbox_client.md
+++ b/books/hyperactor-book/src/mailboxes/mailbox_client.md
@@ -38,7 +38,7 @@ impl<T: Message> Buffer<T> {
     {
         let (queue, mut next) = mpsc::unbounded_channel();
         let (last_processed, processed) = watch::channel(0);
-        crate::init::RUNTIME.spawn(async move {
+        tokio::spawn(async move {
             let mut seq = 0;
             while let Some((msg, return_handle)) = next.recv().await {
                 process(msg, return_handle).await;

--- a/hyperactor/src/channel/net.rs
+++ b/hyperactor/src/channel/net.rs
@@ -190,7 +190,7 @@ impl<M: RemoteMessage> NetTx<M> {
             dest,
             status,
         };
-        crate::init::RUNTIME.spawn(Self::run(link, receiver, notify));
+        tokio::spawn(Self::run(link, receiver, notify));
         tx
     }
 

--- a/hyperactor/src/init.rs
+++ b/hyperactor/src/init.rs
@@ -8,16 +8,10 @@
 
 //! Utilities for launching hyperactor processes.
 
-use std::sync::LazyLock;
 use std::sync::OnceLock;
 
 use crate::clock::ClockKind;
 use crate::panic_handler;
-
-/// A global runtime used in binding async and sync code. Do not use for executing long running or
-/// compute intensive tasks.
-pub(crate) static RUNTIME: LazyLock<tokio::runtime::Runtime> =
-    LazyLock::new(|| tokio::runtime::Runtime::new().expect("failed to create global runtime"));
 
 /// Initialize the Hyperactor runtime. Specifically:
 /// - Set up panic handling, so that we get consistent panic stack traces in Actors.

--- a/hyperactor/src/mailbox.rs
+++ b/hyperactor/src/mailbox.rs
@@ -678,7 +678,7 @@ impl<T: Message> Buffer<T> {
     {
         let (queue, mut next) = mpsc::unbounded_channel();
         let (last_processed, processed) = watch::channel(0);
-        crate::init::RUNTIME.spawn(async move {
+        tokio::spawn(async move {
             let mut seq = 0;
             while let Some((msg, return_handle)) = next.recv().await {
                 process(msg, return_handle).await;
@@ -925,7 +925,7 @@ impl MailboxClient {
         cancel_token: CancellationToken,
         addr: ChannelAddr,
     ) {
-        crate::init::RUNTIME.spawn(async move {
+        tokio::spawn(async move {
             loop {
                 tokio::select! {
                     changed = rx.changed() => {

--- a/hyperactor/src/mailbox/undeliverable.rs
+++ b/hyperactor/src/mailbox/undeliverable.rs
@@ -61,7 +61,7 @@ pub fn monitored_return_handle() -> PortHandle<Undeliverable<MessageEnvelope>> {
         // Don't reuse `return_handle` for `h`: else it will never get
         // dropped and the task will never return.
         let (h, _) = new_undeliverable_port();
-        crate::init::RUNTIME.spawn(async move {
+        tokio::spawn(async move {
             while let Ok(Undeliverable(mut envelope)) = rx.recv().await {
                 envelope.try_set_error(DeliveryError::BrokenLink(
                     "message returned to undeliverable port".to_string(),
@@ -80,7 +80,7 @@ pub(crate) fn return_undeliverable(
     return_handle: PortHandle<Undeliverable<MessageEnvelope>>,
     envelope: MessageEnvelope,
 ) {
-    crate::init::RUNTIME.spawn(async move {
+    tokio::spawn(async move {
         let envelope_copy = envelope.clone();
         if (return_handle.send(Undeliverable(envelope))).is_err() {
             UndeliverableMailboxSender.post(envelope_copy, /*unsued*/ return_handle)

--- a/monarch_tensor_worker/src/stream.rs
+++ b/monarch_tensor_worker/src/stream.rs
@@ -517,7 +517,7 @@ impl Actor for StreamActor {
             // use `block_in_place` for nested async-to-sync-to-async flows.
             let rt = tokio::runtime::Builder::new_multi_thread()
                 .worker_threads(1)
-                .enable_io()
+                .enable_all()
                 .build()
                 .unwrap();
             let result = rt.block_on(async {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #363

Libraries should never create tokio runtimes; that should be up to the caller to manage.

Seems that we were doing this because pyo3 threads did not have the runtime context properly set. So just fix that and zap this runtime. This cuts the number of threads we spawn in the PythonActor by a lot.

Differential Revision: [D77422927](https://our.internmc.facebook.com/intern/diff/D77422927/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D77422927/)!