### PR TITLE
Replace &Instance<A> with &Context<'_, A> in the Handler trait

### DIFF
--- a/controller/src/lib.rs
+++ b/controller/src/lib.rs
@@ -22,6 +22,7 @@ use async_trait::async_trait;
 use hyperactor::Actor;
 use hyperactor::ActorId;
 use hyperactor::ActorRef;
+use hyperactor::Context;
 use hyperactor::GangId;
 use hyperactor::Handler;
 use hyperactor::Named;
@@ -212,7 +213,7 @@ impl ControllerActor {
     // M = self.worker_progress_check_interval
     async fn request_status_if_needed(
         &mut self,
-        this: &hyperactor::Instance<Self>,
+        this: &Context<'_, Self>,
     ) -> Result<(), anyhow::Error> {
         if let Some((expected_seq, ..)) = self.history.deadline(
             self.operations_per_worker_progress_request,
@@ -259,7 +260,7 @@ struct CheckWorkerProgress;
 impl Handler<CheckWorkerProgress> for ControllerActor {
     async fn handle(
         &mut self,
-        this: &hyperactor::Instance<Self>,
+        this: &Context<Self>,
         _check_worker_progress: CheckWorkerProgress,
     ) -> Result<(), anyhow::Error> {
         let client = self.client()?;
@@ -359,7 +360,7 @@ fn slice_to_selection(slice: Slice) -> Selection {
 impl ControllerMessageHandler for ControllerActor {
     async fn attach(
         &mut self,
-        this: &hyperactor::Instance<Self>,
+        this: &Context<Self>,
         client_actor: ActorRef<ClientActor>,
     ) -> Result<(), anyhow::Error> {
         tracing::debug!("attaching client actor {}", client_actor);
@@ -378,7 +379,7 @@ impl ControllerMessageHandler for ControllerActor {
 
     async fn node(
         &mut self,
-        this: &hyperactor::Instance<Self>,
+        this: &Context<Self>,
         seq: Seq,
         defs: Vec<Ref>,
         uses: Vec<Ref>,
@@ -395,7 +396,7 @@ impl ControllerMessageHandler for ControllerActor {
 
     async fn drop_refs(
         &mut self,
-        _this: &hyperactor::Instance<Self>,
+        _this: &Context<Self>,
         refs: Vec<Ref>,
     ) -> Result<(), anyhow::Error> {
         self.history.delete_invocations_for_refs(refs);
@@ -404,7 +405,7 @@ impl ControllerMessageHandler for ControllerActor {
 
     async fn send(
         &mut self,
-        this: &hyperactor::Instance<Self>,
+        this: &Context<Self>,
         ranks: Ranks,
         message: Serialized,
     ) -> Result<(), anyhow::Error> {
@@ -456,7 +457,7 @@ impl ControllerMessageHandler for ControllerActor {
 
     async fn remote_function_failed(
         &mut self,
-        this: &hyperactor::Instance<Self>,
+        this: &Context<Self>,
         seq: Seq,
         error: WorkerError,
     ) -> Result<(), anyhow::Error> {
@@ -469,7 +470,7 @@ impl ControllerMessageHandler for ControllerActor {
 
     async fn status(
         &mut self,
-        _this: &hyperactor::Instance<Self>,
+        _this: &Context<Self>,
         seq: Seq,
         worker_actor_id: ActorId,
         controller: bool,
@@ -486,7 +487,7 @@ impl ControllerMessageHandler for ControllerActor {
 
     async fn fetch_result(
         &mut self,
-        _this: &hyperactor::Instance<Self>,
+        _this: &Context<Self>,
         seq: Seq,
         result: Result<Serialized, WorkerError>,
     ) -> Result<(), anyhow::Error> {
@@ -494,10 +495,7 @@ impl ControllerMessageHandler for ControllerActor {
         Ok(())
     }
 
-    async fn check_supervision(
-        &mut self,
-        this: &hyperactor::Instance<Self>,
-    ) -> Result<(), anyhow::Error> {
+    async fn check_supervision(&mut self, this: &Context<Self>) -> Result<(), anyhow::Error> {
         let gang_id: GangId = self.worker_gang_ref.clone().into();
         let world_state = self
             .system_supervision_actor_ref
@@ -565,7 +563,7 @@ impl ControllerMessageHandler for ControllerActor {
 
     async fn debugger_message(
         &mut self,
-        this: &hyperactor::Instance<Self>,
+        this: &Context<Self>,
         debugger_actor_id: ActorId,
         action: DebuggerAction,
     ) -> Result<(), anyhow::Error> {
@@ -577,7 +575,7 @@ impl ControllerMessageHandler for ControllerActor {
     #[cfg(test)]
     async fn get_first_incomplete_seqs_unit_tests_only(
         &mut self,
-        _this: &hyperactor::Instance<Self>,
+        _this: &Context<Self>,
     ) -> Result<Vec<Seq>, anyhow::Error> {
         Ok(self.history.first_incomplete_seqs().to_vec())
     }
@@ -585,7 +583,7 @@ impl ControllerMessageHandler for ControllerActor {
     #[cfg(not(test))]
     async fn get_first_incomplete_seqs_unit_tests_only(
         &mut self,
-        _this: &hyperactor::Instance<Self>,
+        _this: &Context<Self>,
     ) -> Result<Vec<Seq>, anyhow::Error> {
         unimplemented!("get_first_incomplete_seqs_unit_tests_only is only for unit tests")
     }
@@ -616,7 +614,6 @@ mod tests {
 
     use hyperactor::HandleClient;
     use hyperactor::Handler;
-    use hyperactor::Instance;
     use hyperactor::RefClient;
     use hyperactor::channel;
     use hyperactor::channel::ChannelTransport;
@@ -1801,7 +1798,7 @@ mod tests {
     impl PanickingMessageHandler for PanickingActor {
         async fn panic(
             &mut self,
-            _this: &Instance<Self>,
+            _this: &Context<Self>,
             err_msg: String,
         ) -> Result<(), anyhow::Error> {
             panic!("{}", err_msg);

--- a/hyper/src/commands/demo.rs
+++ b/hyper/src/commands/demo.rs
@@ -12,6 +12,7 @@ use std::time::Duration;
 use async_trait::async_trait;
 use clap::Subcommand;
 use hyperactor::Actor;
+use hyperactor::Context;
 use hyperactor::HandleClient;
 use hyperactor::Handler;
 use hyperactor::Named;
@@ -229,40 +230,29 @@ impl Actor for DemoActor {
 impl DemoMessageHandler for DemoActor {
     async fn echo(
         &mut self,
-        _this: &hyperactor::Instance<Self>,
+        _this: &Context<Self>,
         message: String,
     ) -> Result<String, anyhow::Error> {
         tracing::info!("demo: message: {}", message);
         Ok(message)
     }
 
-    async fn increment(
-        &mut self,
-        _this: &hyperactor::Instance<Self>,
-        num: u64,
-    ) -> Result<u64, anyhow::Error> {
+    async fn increment(&mut self, _this: &Context<Self>, num: u64) -> Result<u64, anyhow::Error> {
         tracing::info!("demo: increment: {}", num);
         Ok(num + 1)
     }
 
-    async fn panic(&mut self, _this: &hyperactor::Instance<Self>) -> Result<(), anyhow::Error> {
+    async fn panic(&mut self, _this: &Context<Self>) -> Result<(), anyhow::Error> {
         tracing::info!("demo: panic!");
         panic!()
     }
 
-    async fn spawn_child(
-        &mut self,
-        this: &hyperactor::Instance<Self>,
-    ) -> Result<ActorRef<Self>, anyhow::Error> {
+    async fn spawn_child(&mut self, this: &Context<Self>) -> Result<ActorRef<Self>, anyhow::Error> {
         tracing::info!("demo: spawn child");
         Ok(Self::spawn(this, ()).await?.bind())
     }
 
-    async fn error(
-        &mut self,
-        _this: &hyperactor::Instance<Self>,
-        message: String,
-    ) -> Result<(), anyhow::Error> {
+    async fn error(&mut self, _this: &Context<Self>, message: String) -> Result<(), anyhow::Error> {
         tracing::info!("demo: message: {}", message);
         anyhow::bail!("{}", message)
     }

--- a/hyperactor/example/derive.rs
+++ b/hyperactor/example/derive.rs
@@ -11,9 +11,9 @@ use std::time::Duration;
 
 use async_trait::async_trait;
 use hyperactor::Actor;
+use hyperactor::Context;
 use hyperactor::HandleClient;
 use hyperactor::Handler;
-use hyperactor::Instance;
 use hyperactor::Named;
 use hyperactor::OncePortRef;
 use hyperactor::RefClient;
@@ -68,27 +68,23 @@ impl Actor for ShoppingListActor {
 #[async_trait]
 #[hyperactor::forward(ShoppingList)]
 impl ShoppingListHandler for ShoppingListActor {
-    async fn add(&mut self, _this: &Instance<Self>, item: String) -> Result<(), anyhow::Error> {
+    async fn add(&mut self, _this: &Context<Self>, item: String) -> Result<(), anyhow::Error> {
         eprintln!("insert {}", item);
         self.0.insert(item);
         Ok(())
     }
 
-    async fn remove(&mut self, _this: &Instance<Self>, item: String) -> Result<(), anyhow::Error> {
+    async fn remove(&mut self, _this: &Context<Self>, item: String) -> Result<(), anyhow::Error> {
         eprintln!("remove {}", item);
         self.0.remove(&item);
         Ok(())
     }
 
-    async fn exists(
-        &mut self,
-        _this: &Instance<Self>,
-        item: String,
-    ) -> Result<bool, anyhow::Error> {
+    async fn exists(&mut self, _this: &Context<Self>, item: String) -> Result<bool, anyhow::Error> {
         Ok(self.0.contains(&item))
     }
 
-    async fn list(&mut self, _this: &Instance<Self>) -> Result<Vec<String>, anyhow::Error> {
+    async fn list(&mut self, _this: &Context<Self>) -> Result<Vec<String>, anyhow::Error> {
         Ok(self.0.iter().cloned().collect())
     }
 }

--- a/hyperactor/src/actor/remote.rs
+++ b/hyperactor/src/actor/remote.rs
@@ -139,8 +139,8 @@ mod tests {
 
     use super::*;
     use crate as hyperactor; // for macros
+    use crate::Context;
     use crate::Handler;
-    use crate::Instance;
 
     #[derive(Debug)]
     #[hyperactor::export(handlers = [()])]
@@ -161,7 +161,7 @@ mod tests {
 
     #[async_trait]
     impl Handler<()> for MyActor {
-        async fn handle(&mut self, _this: &Instance<Self>, _message: ()) -> anyhow::Result<()> {
+        async fn handle(&mut self, _this: &Context<Self>, _message: ()) -> anyhow::Result<()> {
             unimplemented!()
         }
     }

--- a/hyperactor/src/lib.rs
+++ b/hyperactor/src/lib.rs
@@ -149,6 +149,7 @@ pub use mailbox::RemoteMessage;
 pub use opentelemetry;
 #[doc(hidden)]
 pub use paste::paste;
+pub use proc::Context;
 pub use proc::Instance;
 pub use reference::ActorId;
 pub use reference::ActorRef;

--- a/hyperactor/src/test_utils/pingpong.rs
+++ b/hyperactor/src/test_utils/pingpong.rs
@@ -15,6 +15,7 @@ use serde::Serialize;
 use crate as hyperactor; // for macros
 use crate::Actor;
 use crate::ActorRef;
+use crate::Context;
 use crate::Handler;
 use crate::Instance;
 use crate::Named;
@@ -107,7 +108,7 @@ impl Handler<PingPongMessage> for PingPongActor {
     /// It also panics if TTL == 66 for testing purpose.
     async fn handle(
         &mut self,
-        this: &Instance<Self>,
+        this: &Context<Self>,
         PingPongMessage(ttl, pong_actor, done_port): PingPongMessage,
     ) -> anyhow::Result<()> {
         // PingPongActor sends the messages back and forth. When it's ttl = 0, it will stop.

--- a/hyperactor/src/test_utils/proc_supervison.rs
+++ b/hyperactor/src/test_utils/proc_supervison.rs
@@ -12,8 +12,8 @@ use std::sync::Mutex;
 use async_trait::async_trait;
 
 use crate::Actor;
+use crate::Context;
 use crate::Handler;
-use crate::Instance;
 use crate::proc::Proc;
 use crate::supervision::ActorSupervisionEvent;
 
@@ -81,7 +81,7 @@ impl Actor for ProcSupervisionCoordinator {
 impl Handler<ActorSupervisionEvent> for ProcSupervisionCoordinator {
     async fn handle(
         &mut self,
-        _this: &Instance<Self>,
+        _this: &Context<Self>,
         msg: ActorSupervisionEvent,
     ) -> anyhow::Result<()> {
         tracing::debug!("in handler, handling supervision event");

--- a/hyperactor_macros/src/lib.rs
+++ b/hyperactor_macros/src/lib.rs
@@ -485,7 +485,7 @@ fn parse_message_enum(input: DeriveInput) -> Result<Vec<Message>, syn::Error> {
 /// #[async_trait]
 /// #[hyperactor::forward(ShoppingList)]
 /// impl ShoppingListHandler for ShoppingListActor {
-///     async fn add(&mut self, _this: &Instance<Self>, item: String) -> Result<(), anyhow::Error> {
+///     async fn add(&mut self, _this: &Context<Self>, item: String) -> Result<(), anyhow::Error> {
 ///         eprintln!("insert {}", item);
 ///         self.0.insert(item);
 ///         Ok(())
@@ -493,7 +493,7 @@ fn parse_message_enum(input: DeriveInput) -> Result<Vec<Message>, syn::Error> {
 ///
 ///     async fn remove(
 ///         &mut self,
-///         _this: &Instance<Self>,
+///         _this: &Context<Self>,
 ///         item: String,
 ///     ) -> Result<(), anyhow::Error> {
 ///         eprintln!("remove {}", item);
@@ -503,13 +503,13 @@ fn parse_message_enum(input: DeriveInput) -> Result<Vec<Message>, syn::Error> {
 ///
 ///     async fn exists(
 ///         &mut self,
-///         _this: &Instance<Self>,
+///         _this: &Context<Self>,
 ///         item: String,
 ///     ) -> Result<bool, anyhow::Error> {
 ///         Ok(self.0.contains(&item))
 ///     }
 ///
-///     async fn list(&mut self, _this: &Instance<Self>) -> Result<Vec<String>, anyhow::Error> {
+///     async fn list(&mut self, _this: &Context<Self>) -> Result<Vec<String>, anyhow::Error> {
 ///         Ok(self.0.iter().cloned().collect())
 ///     }
 /// }
@@ -621,7 +621,7 @@ pub fn derive_handler(input: TokenStream) -> TokenStream {
                     #[doc = "The generated handler method for this enum variant."]
                     async fn #variant_name_snake(
                         &mut self,
-                        this: &hyperactor::Instance<Self>,
+                        this: &hyperactor::Context<Self>,
                         #(#arg_names: #arg_types),*)
                         -> Result<#return_type, hyperactor::anyhow::Error>;
                 });
@@ -689,7 +689,7 @@ pub fn derive_handler(input: TokenStream) -> TokenStream {
                     #[doc = "The generated handler method for this enum variant."]
                     async fn #variant_name_snake(
                         &mut self,
-                        this: &hyperactor::Instance<Self>,
+                        this: &hyperactor::Context<Self>,
                         #(#arg_names: #arg_types),*)
                         -> Result<(), hyperactor::anyhow::Error>;
                 });
@@ -727,7 +727,7 @@ pub fn derive_handler(input: TokenStream) -> TokenStream {
             #[doc = "Handle the next message."]
             async fn handle(
                 &mut self,
-                this: &hyperactor::Instance<Self>,
+                this: &hyperactor::Context<Self>,
                 message: #name #ty_generics,
             ) -> hyperactor::anyhow::Result<()>  {
                  // Dispatch based on message type.
@@ -990,7 +990,7 @@ pub fn forward(attr: TokenStream, item: TokenStream) -> TokenStream {
         impl hyperactor::Handler<#message_type> for #self_type {
             async fn handle(
                 &mut self,
-                this: &hyperactor::Instance<Self>,
+                this: &hyperactor::Context<Self>,
                 message: #message_type,
             ) -> hyperactor::anyhow::Result<()> {
                 <Self as #trait_name>::handle(self, this, message).await

--- a/hyperactor_macros/tests/basic.rs
+++ b/hyperactor_macros/tests/basic.rs
@@ -15,9 +15,9 @@ use std::fmt::Debug;
 use anyhow::Result;
 use async_trait::async_trait;
 use hyperactor::Actor;
+use hyperactor::Context;
 use hyperactor::HandleClient;
 use hyperactor::Handler;
-use hyperactor::Instance;
 use hyperactor::Named;
 use hyperactor::OncePortRef;
 use hyperactor::RefClient;
@@ -108,7 +108,7 @@ impl Actor for GenericArgActor {
 #[async_trait]
 #[forward(GenericArgMessage<usize>)]
 impl GenericArgMessageHandler<usize> for GenericArgActor {
-    async fn variant(&mut self, _this: &Instance<Self>, _val: usize) -> Result<()> {
+    async fn variant(&mut self, _this: &Context<Self>, _val: usize) -> Result<()> {
         Ok(())
     }
 }

--- a/hyperactor_macros/tests/export.rs
+++ b/hyperactor_macros/tests/export.rs
@@ -9,8 +9,8 @@
 use async_trait::async_trait;
 use hyperactor::Actor;
 use hyperactor::Bind;
+use hyperactor::Context;
 use hyperactor::Handler;
-use hyperactor::Instance;
 use hyperactor::Named;
 use hyperactor::PortRef;
 use hyperactor::Unbind;
@@ -54,7 +54,7 @@ struct TestMessage(String);
 
 #[async_trait]
 impl Handler<TestMessage> for TestActor {
-    async fn handle(&mut self, this: &Instance<Self>, msg: TestMessage) -> anyhow::Result<()> {
+    async fn handle(&mut self, this: &Context<Self>, msg: TestMessage) -> anyhow::Result<()> {
         self.forward_port.send(this, msg.0)?;
         Ok(())
     }
@@ -71,7 +71,7 @@ impl<T: Named> Named for MyGeneric<T> {
 
 #[async_trait]
 impl Handler<()> for TestActor {
-    async fn handle(&mut self, this: &Instance<Self>, _msg: ()) -> anyhow::Result<()> {
+    async fn handle(&mut self, this: &Context<Self>, _msg: ()) -> anyhow::Result<()> {
         self.forward_port.send(this, "()".to_string())?;
         Ok(())
     }
@@ -79,7 +79,7 @@ impl Handler<()> for TestActor {
 
 #[async_trait]
 impl Handler<MyGeneric<()>> for TestActor {
-    async fn handle(&mut self, this: &Instance<Self>, _msg: MyGeneric<()>) -> anyhow::Result<()> {
+    async fn handle(&mut self, this: &Context<Self>, _msg: MyGeneric<()>) -> anyhow::Result<()> {
         self.forward_port.send(this, "MyGeneric<()>".to_string())?;
         Ok(())
     }
@@ -87,7 +87,7 @@ impl Handler<MyGeneric<()>> for TestActor {
 
 #[async_trait]
 impl Handler<u64> for TestActor {
-    async fn handle(&mut self, this: &Instance<Self>, msg: u64) -> anyhow::Result<()> {
+    async fn handle(&mut self, this: &Context<Self>, msg: u64) -> anyhow::Result<()> {
         self.forward_port.send(this, format!("u64: {msg}"))?;
         Ok(())
     }

--- a/hyperactor_mesh/examples/dining_philosophers.rs
+++ b/hyperactor_mesh/examples/dining_philosophers.rs
@@ -15,6 +15,7 @@ use anyhow::Result;
 use async_trait::async_trait;
 use hyperactor::Actor;
 use hyperactor::Bind;
+use hyperactor::Context;
 use hyperactor::Handler;
 use hyperactor::Instance;
 use hyperactor::Named;
@@ -25,7 +26,7 @@ use hyperactor_mesh::actor_mesh::ActorMesh;
 use hyperactor_mesh::alloc::AllocSpec;
 use hyperactor_mesh::alloc::Allocator;
 use hyperactor_mesh::alloc::LocalAllocator;
-use hyperactor_mesh::comm::multicast::get_cast_info_from_headers_or_err;
+use hyperactor_mesh::comm::multicast::CastInfo;
 use hyperactor_mesh::selection::dsl::all;
 use hyperactor_mesh::selection::dsl::true_;
 use hyperactor_mesh::shape;
@@ -138,11 +139,10 @@ impl PhilosopherActor {
 impl Handler<PhilosopherMessage> for PhilosopherActor {
     async fn handle(
         &mut self,
-        this: &Instance<Self>,
+        this: &Context<Self>,
         message: PhilosopherMessage,
     ) -> Result<(), anyhow::Error> {
-        // Instance::ctx() should always return a value when inside a handler.
-        let (rank, _) = get_cast_info_from_headers_or_err(this.ctx().unwrap().headers())?;
+        let (rank, _) = this.cast_info()?;
         self.rank = rank;
         match message {
             PhilosopherMessage::Start(waiter) => {

--- a/hyperactor_mesh/examples/sieve.rs
+++ b/hyperactor_mesh/examples/sieve.rs
@@ -18,8 +18,8 @@ use anyhow::Result;
 use async_trait::async_trait;
 use hyperactor::Actor;
 use hyperactor::ActorRef;
+use hyperactor::Context;
 use hyperactor::Handler;
-use hyperactor::Instance;
 use hyperactor::Named;
 use hyperactor::PortRef;
 use hyperactor_mesh::Mesh;
@@ -72,7 +72,7 @@ pub struct SieveActor {
 
 #[async_trait]
 impl Handler<NextNumber> for SieveActor {
-    async fn handle(&mut self, this: &Instance<Self>, msg: NextNumber) -> Result<()> {
+    async fn handle(&mut self, this: &Context<Self>, msg: NextNumber) -> Result<()> {
         if msg.number % self.prime != 0 {
             match &self.next {
                 Some(next) => {

--- a/hyperactor_mesh/src/code_sync/rsync.rs
+++ b/hyperactor_mesh/src/code_sync/rsync.rs
@@ -21,7 +21,6 @@ use async_trait::async_trait;
 use futures::try_join;
 use hyperactor::Actor;
 use hyperactor::Handler;
-use hyperactor::Instance;
 use hyperactor::Named;
 use hyperactor::clock::Clock;
 use hyperactor::clock::RealClock;
@@ -194,7 +193,7 @@ impl Actor for RsyncActor {
 impl Handler<Connect> for RsyncActor {
     async fn handle(
         &mut self,
-        this: &Instance<Self>,
+        this: &hyperactor::Context<Self>,
         message: Connect,
     ) -> Result<(), anyhow::Error> {
         let (mut local, mut stream) = try_join!(

--- a/hyperactor_mesh/src/connect.rs
+++ b/hyperactor_mesh/src/connect.rs
@@ -252,8 +252,8 @@ mod tests {
     use async_trait::async_trait;
     use futures::try_join;
     use hyperactor::Actor;
+    use hyperactor::Context;
     use hyperactor::Handler;
-    use hyperactor::Instance;
     use hyperactor::proc::Proc;
     use tokio::io::AsyncReadExt;
     use tokio::io::AsyncWriteExt;
@@ -276,7 +276,7 @@ mod tests {
     impl Handler<Connect> for EchoActor {
         async fn handle(
             &mut self,
-            this: &Instance<Self>,
+            this: &Context<Self>,
             message: Connect,
         ) -> Result<(), anyhow::Error> {
             let (mut rd, mut wr) = accept(this, message).await?;

--- a/hyperactor_mesh/src/proc_mesh/mesh_agent.rs
+++ b/hyperactor_mesh/src/proc_mesh/mesh_agent.rs
@@ -19,6 +19,7 @@ use enum_as_inner::EnumAsInner;
 use hyperactor::Actor;
 use hyperactor::ActorHandle;
 use hyperactor::ActorId;
+use hyperactor::Context;
 use hyperactor::Data;
 use hyperactor::HandleClient;
 use hyperactor::Handler;
@@ -161,7 +162,7 @@ impl Actor for MeshAgent {
 impl MeshAgentMessageHandler for MeshAgent {
     async fn configure(
         &mut self,
-        this: &Instance<Self>,
+        this: &Context<Self>,
         rank: usize,
         forwarder: ChannelAddr,
         supervisor: PortRef<ActorSupervisionEvent>,
@@ -189,7 +190,7 @@ impl MeshAgentMessageHandler for MeshAgent {
 
     async fn gspawn(
         &mut self,
-        this: &Instance<Self>,
+        this: &Context<Self>,
         actor_type: String,
         actor_name: String,
         params_data: Data,
@@ -211,7 +212,7 @@ impl MeshAgentMessageHandler for MeshAgent {
 impl Handler<ActorSupervisionEvent> for MeshAgent {
     async fn handle(
         &mut self,
-        this: &hyperactor::Instance<Self>,
+        this: &Context<Self>,
         event: ActorSupervisionEvent,
     ) -> anyhow::Result<()> {
         if let Some(supervisor) = &self.supervisor {

--- a/hyperactor_mesh/src/reference.rs
+++ b/hyperactor_mesh/src/reference.rs
@@ -168,8 +168,8 @@ impl<A: RemoteActor> Eq for ActorMeshRef<A> {}
 mod tests {
     use async_trait::async_trait;
     use hyperactor::Actor;
+    use hyperactor::Context;
     use hyperactor::Handler;
-    use hyperactor::Instance;
     use hyperactor::PortRef;
     use hyperactor::message::Bind;
     use hyperactor::message::Bindings;
@@ -232,7 +232,7 @@ mod tests {
     impl Handler<MeshPingPongMessage> for MeshPingPongActor {
         async fn handle(
             &mut self,
-            this: &Instance<Self>,
+            this: &Context<Self>,
             MeshPingPongMessage(ttl, sender_mesh, done_tx): MeshPingPongMessage,
         ) -> Result<(), anyhow::Error> {
             if ttl == 0 {

--- a/hyperactor_mesh/src/test_utils.rs
+++ b/hyperactor_mesh/src/test_utils.rs
@@ -9,8 +9,8 @@
 use async_trait::async_trait;
 use hyperactor::Actor;
 use hyperactor::Bind;
+use hyperactor::Context;
 use hyperactor::Handler;
-use hyperactor::Instance;
 use hyperactor::Named;
 use hyperactor::Unbind;
 use serde::Deserialize;
@@ -40,7 +40,7 @@ impl Actor for EmptyActor {
 
 #[async_trait]
 impl Handler<EmptyMessage> for EmptyActor {
-    async fn handle(&mut self, _: &Instance<Self>, _: EmptyMessage) -> Result<(), anyhow::Error> {
+    async fn handle(&mut self, _: &Context<Self>, _: EmptyMessage) -> Result<(), anyhow::Error> {
         Ok(())
     }
 }

--- a/hyperactor_multiprocess/src/system_actor.rs
+++ b/hyperactor_multiprocess/src/system_actor.rs
@@ -26,6 +26,7 @@ use hyperactor::Actor;
 use hyperactor::ActorHandle;
 use hyperactor::ActorId;
 use hyperactor::ActorRef;
+use hyperactor::Context;
 use hyperactor::HandleClient;
 use hyperactor::Instance;
 use hyperactor::Named;
@@ -1254,7 +1255,7 @@ impl Actor for SystemActor {
 impl SystemMessageHandler for SystemActor {
     async fn join(
         &mut self,
-        this: &Instance<Self>,
+        this: &Context<Self>,
         world_id: WorldId,
         proc_id: ProcId,
         proc_message_port: PortRef<ProcMessage>,
@@ -1341,7 +1342,7 @@ impl SystemMessageHandler for SystemActor {
 
     async fn upsert_world(
         &mut self,
-        this: &Instance<Self>,
+        this: &Context<Self>,
         world_id: WorldId,
         shape: Shape,
         num_procs_per_host: usize,
@@ -1412,7 +1413,7 @@ impl SystemMessageHandler for SystemActor {
 
     async fn snapshot(
         &mut self,
-        _this: &Instance<Self>,
+        _this: &Context<Self>,
         filter: SystemSnapshotFilter,
     ) -> Result<SystemSnapshot, anyhow::Error> {
         let world_snapshots = self
@@ -1434,7 +1435,7 @@ impl SystemMessageHandler for SystemActor {
 
     async fn stop(
         &mut self,
-        this: &Instance<Self>,
+        this: &Context<Self>,
         worlds: Option<Vec<WorldId>>,
         proc_timeout: Duration,
         reply_port: OncePortRef<()>,
@@ -1556,11 +1557,7 @@ impl SystemMessageHandler for SystemActor {
 
 #[async_trait]
 impl Handler<MaintainWorldHealth> for SystemActor {
-    async fn handle(
-        &mut self,
-        this: &hyperactor::Instance<Self>,
-        _: MaintainWorldHealth,
-    ) -> anyhow::Result<()> {
+    async fn handle(&mut self, this: &Context<Self>, _: MaintainWorldHealth) -> anyhow::Result<()> {
         // TODO: this needn't be async
 
         // Find the world with the oldest unhealthy time so we can schedule the next check.
@@ -1674,7 +1671,7 @@ impl Handler<MaintainWorldHealth> for SystemActor {
 impl Handler<ProcSupervisionMessage> for SystemActor {
     async fn handle(
         &mut self,
-        this: &hyperactor::Instance<Self>,
+        this: &Context<Self>,
         msg: ProcSupervisionMessage,
     ) -> anyhow::Result<()> {
         match msg {
@@ -1691,7 +1688,7 @@ impl Handler<ProcSupervisionMessage> for SystemActor {
 impl Handler<WorldSupervisionMessage> for SystemActor {
     async fn handle(
         &mut self,
-        this: &hyperactor::Instance<Self>,
+        this: &Context<Self>,
         msg: WorldSupervisionMessage,
     ) -> anyhow::Result<()> {
         match msg {
@@ -1711,11 +1708,7 @@ impl Handler<WorldSupervisionMessage> for SystemActor {
 // messages. Can be remove after T214365263 is implemented.
 #[async_trait]
 impl Handler<ProcStopResult> for SystemActor {
-    async fn handle(
-        &mut self,
-        this: &hyperactor::Instance<Self>,
-        msg: ProcStopResult,
-    ) -> anyhow::Result<()> {
+    async fn handle(&mut self, this: &Context<Self>, msg: ProcStopResult) -> anyhow::Result<()> {
         fn stopping_proc_msg<'a>(sprocs: impl Iterator<Item = &'a ProcId>) -> String {
             let sprocs = sprocs.collect::<Vec<_>>();
             if sprocs.is_empty() {
@@ -1774,7 +1767,7 @@ impl Handler<ProcStopResult> for SystemActor {
 impl Handler<SystemStopMessage> for SystemActor {
     async fn handle(
         &mut self,
-        this: &hyperactor::Instance<Self>,
+        this: &Context<Self>,
         message: SystemStopMessage,
     ) -> anyhow::Result<()> {
         match message {

--- a/hyperactor_state/src/client.rs
+++ b/hyperactor_state/src/client.rs
@@ -9,8 +9,8 @@
 use anyhow::Result;
 use async_trait::async_trait;
 use hyperactor::Actor;
+use hyperactor::Context;
 use hyperactor::Handler;
-use hyperactor::Instance;
 use hyperactor::Named;
 use hyperactor_macros::HandleClient;
 use hyperactor_macros::RefClient;
@@ -54,7 +54,7 @@ impl Actor for ClientActor {
 impl ClientMessageHandler for ClientActor {
     async fn push_logs(
         &mut self,
-        _this: &Instance<Self>,
+        _this: &Context<Self>,
         logs: Vec<GenericStateObject>,
     ) -> Result<(), anyhow::Error> {
         self.sender.send(logs).await?;

--- a/hyperactor_state/src/state_actor.rs
+++ b/hyperactor_state/src/state_actor.rs
@@ -12,9 +12,9 @@ use anyhow::Result;
 use async_trait::async_trait;
 use hyperactor::Actor;
 use hyperactor::ActorRef;
+use hyperactor::Context;
 use hyperactor::HandleClient;
 use hyperactor::Handler;
-use hyperactor::Instance;
 use hyperactor::Mailbox;
 use hyperactor::Named;
 use hyperactor::RefClient;
@@ -65,7 +65,7 @@ impl Actor for StateActor {
 impl StateMessageHandler for StateActor {
     async fn push_logs(
         &mut self,
-        _this: &Instance<Self>,
+        _this: &Context<Self>,
         logs: Vec<GenericStateObject>,
     ) -> Result<(), anyhow::Error> {
         for (subscriber, (_, remote_client)) in self.subscribers.iter() {
@@ -76,7 +76,7 @@ impl StateMessageHandler for StateActor {
 
     async fn subscribe_logs(
         &mut self,
-        _this: &Instance<Self>,
+        _this: &Context<Self>,
         addr: ChannelAddr,
         client_actor_ref: ActorRef<ClientActor>,
     ) -> Result<(), anyhow::Error> {

--- a/monarch_rdma/src/rdma_manager_actor.rs
+++ b/monarch_rdma/src/rdma_manager_actor.rs
@@ -33,6 +33,7 @@ use async_trait::async_trait;
 use hyperactor::Actor;
 use hyperactor::ActorId;
 use hyperactor::ActorRef;
+use hyperactor::Context;
 use hyperactor::HandleClient;
 use hyperactor::Handler;
 use hyperactor::Instance;
@@ -166,7 +167,7 @@ impl RdmaManagerMessageHandler for RdmaManagerActor {
     ///   the registered memory region's details. On failure, returns an error.
     async fn request_buffer(
         &mut self,
-        this: &Instance<Self>,
+        this: &Context<Self>,
         addr: usize,
         size: usize,
     ) -> Result<RdmaBuffer, anyhow::Error> {
@@ -197,7 +198,7 @@ impl RdmaManagerMessageHandler for RdmaManagerActor {
     ///   On failure, returns an error.
     async fn request_queue_pair(
         &mut self,
-        this: &Instance<Self>,
+        this: &Context<Self>,
         remote: ActorRef<RdmaManagerActor>,
     ) -> Result<RdmaQueuePair, anyhow::Error> {
         if !self.is_connected(this, remote.clone()).await? {
@@ -230,7 +231,7 @@ impl RdmaManagerMessageHandler for RdmaManagerActor {
     /// * `other` - The ActorRef of the remote actor to connect with
     async fn initialize_qp(
         &mut self,
-        _this: &Instance<Self>,
+        _this: &Context<Self>,
         other: ActorRef<RdmaManagerActor>,
     ) -> Result<bool, anyhow::Error> {
         let key = other.actor_id().clone();
@@ -253,7 +254,7 @@ impl RdmaManagerMessageHandler for RdmaManagerActor {
     /// * `bool` - True if connected, false otherwise
     async fn is_connected(
         &mut self,
-        _this: &Instance<Self>,
+        _this: &Context<Self>,
         other: ActorRef<RdmaManagerActor>,
     ) -> Result<bool, anyhow::Error> {
         tracing::debug!("checking if connected with {:?}", other);
@@ -275,7 +276,7 @@ impl RdmaManagerMessageHandler for RdmaManagerActor {
     /// * `endpoint` - Connection information needed to establish the RDMA connection
     async fn connect(
         &mut self,
-        _this: &Instance<Self>,
+        _this: &Context<Self>,
         other: ActorRef<RdmaManagerActor>,
         endpoint: RdmaQpInfo,
     ) -> Result<(), anyhow::Error> {
@@ -300,7 +301,7 @@ impl RdmaManagerMessageHandler for RdmaManagerActor {
     /// * `RdmaQpInfo` - Connection information needed for the RDMA connection
     async fn connection_info(
         &mut self,
-        _this: &Instance<Self>,
+        _this: &Context<Self>,
         other: ActorRef<RdmaManagerActor>,
     ) -> Result<RdmaQpInfo, anyhow::Error> {
         tracing::debug!("getting connection info with {:?}", other);

--- a/monarch_simulator/src/controller.rs
+++ b/monarch_simulator/src/controller.rs
@@ -15,6 +15,7 @@ use async_trait::async_trait;
 use hyperactor::Actor;
 use hyperactor::ActorId;
 use hyperactor::ActorRef;
+use hyperactor::Context;
 use hyperactor::Named;
 use hyperactor::actor::ActorHandle;
 use hyperactor::attrs::Attrs;
@@ -84,7 +85,7 @@ impl Actor for SimControllerActor {
 impl ControllerMessageHandler for SimControllerActor {
     async fn attach(
         &mut self,
-        _this: &hyperactor::Instance<Self>,
+        _this: &Context<Self>,
         client_actor: ActorRef<ClientActor>,
     ) -> Result<(), anyhow::Error> {
         self.client_actor_ref
@@ -94,7 +95,7 @@ impl ControllerMessageHandler for SimControllerActor {
 
     async fn node(
         &mut self,
-        _this: &hyperactor::Instance<Self>,
+        _this: &Context<Self>,
         _seq: Seq,
         _uses: Vec<Ref>,
         _defs: Vec<Ref>,
@@ -105,7 +106,7 @@ impl ControllerMessageHandler for SimControllerActor {
 
     async fn send(
         &mut self,
-        this: &hyperactor::Instance<Self>,
+        this: &Context<Self>,
         ranks: Ranks,
         message: Serialized,
     ) -> Result<(), anyhow::Error> {
@@ -118,7 +119,7 @@ impl ControllerMessageHandler for SimControllerActor {
 
     async fn remote_function_failed(
         &mut self,
-        _this: &hyperactor::Instance<Self>,
+        _this: &Context<Self>,
         _seq: Seq,
         _error: WorkerError,
     ) -> Result<(), anyhow::Error> {
@@ -127,7 +128,7 @@ impl ControllerMessageHandler for SimControllerActor {
 
     async fn status(
         &mut self,
-        this: &hyperactor::Instance<Self>,
+        this: &Context<Self>,
         seq: Seq,
         _worker_actor_id: ActorId,
         controller: bool,
@@ -152,7 +153,7 @@ impl ControllerMessageHandler for SimControllerActor {
 
     async fn fetch_result(
         &mut self,
-        _this: &hyperactor::Instance<Self>,
+        _this: &Context<Self>,
         seq: Seq,
         result: Result<Serialized, WorkerError>,
     ) -> Result<(), anyhow::Error> {
@@ -166,16 +167,13 @@ impl ControllerMessageHandler for SimControllerActor {
         Ok(())
     }
 
-    async fn check_supervision(
-        &mut self,
-        _this: &hyperactor::Instance<Self>,
-    ) -> Result<(), anyhow::Error> {
+    async fn check_supervision(&mut self, _this: &Context<Self>) -> Result<(), anyhow::Error> {
         Ok(())
     }
 
     async fn drop_refs(
         &mut self,
-        _this: &hyperactor::Instance<Self>,
+        _this: &Context<Self>,
         _refs: Vec<Ref>,
     ) -> Result<(), anyhow::Error> {
         Ok(())
@@ -183,7 +181,7 @@ impl ControllerMessageHandler for SimControllerActor {
 
     async fn debugger_message(
         &mut self,
-        _this: &hyperactor::Instance<Self>,
+        _this: &Context<Self>,
         _debugger_actor_id: ActorId,
         _action: DebuggerAction,
     ) -> Result<(), anyhow::Error> {
@@ -193,7 +191,7 @@ impl ControllerMessageHandler for SimControllerActor {
     #[cfg(test)]
     async fn get_first_incomplete_seqs_unit_tests_only(
         &mut self,
-        _this: &hyperactor::Instance<Self>,
+        _this: &Context<Self>,
     ) -> Result<Vec<Seq>, anyhow::Error> {
         Ok(vec![])
     }
@@ -201,7 +199,7 @@ impl ControllerMessageHandler for SimControllerActor {
     #[cfg(not(test))]
     async fn get_first_incomplete_seqs_unit_tests_only(
         &mut self,
-        _this: &hyperactor::Instance<Self>,
+        _this: &Context<Self>,
     ) -> Result<Vec<Seq>, anyhow::Error> {
         unimplemented!("get_first_incomplete_seqs_unit_tests_only is only for unit tests")
     }

--- a/monarch_simulator/src/worker.rs
+++ b/monarch_simulator/src/worker.rs
@@ -235,7 +235,7 @@ impl Actor for WorkerActor {
 impl WorkerMessageHandler for WorkerActor {
     async fn backend_network_init(
         &mut self,
-        _this: &Instance<Self>,
+        _this: &hyperactor::Context<Self>,
         _unique_id: UniqueId,
     ) -> Result<()> {
         Ok(())
@@ -243,7 +243,7 @@ impl WorkerMessageHandler for WorkerActor {
 
     async fn backend_network_point_to_point_init(
         &mut self,
-        _this: &Instance<Self>,
+        _this: &hyperactor::Context<Self>,
         _from_stream: StreamRef,
         _to_stream: StreamRef,
     ) -> Result<()> {
@@ -252,7 +252,7 @@ impl WorkerMessageHandler for WorkerActor {
 
     async fn call_function(
         &mut self,
-        this: &Instance<Self>,
+        this: &hyperactor::Context<Self>,
         params: CallFunctionParams,
     ) -> Result<()> {
         tracing::info!("worker received call_function: {:#?}", &params);
@@ -314,7 +314,7 @@ impl WorkerMessageHandler for WorkerActor {
 
     async fn command_group(
         &mut self,
-        this: &Instance<Self>,
+        this: &hyperactor::Context<Self>,
         params: Vec<WorkerMessage>,
     ) -> Result<()> {
         for msg in params {
@@ -325,7 +325,7 @@ impl WorkerMessageHandler for WorkerActor {
 
     async fn create_stream(
         &mut self,
-        _this: &Instance<Self>,
+        _this: &hyperactor::Context<Self>,
         _result: StreamRef,
         _creation_mode: StreamCreationMode,
     ) -> Result<()> {
@@ -334,7 +334,7 @@ impl WorkerMessageHandler for WorkerActor {
 
     async fn create_device_mesh(
         &mut self,
-        _this: &Instance<Self>,
+        _this: &hyperactor::Context<Self>,
         result: Ref,
         names: Vec<String>,
         ranks: Slice,
@@ -346,7 +346,7 @@ impl WorkerMessageHandler for WorkerActor {
 
     async fn create_remote_process_group(
         &mut self,
-        _this: &Instance<Self>,
+        _this: &hyperactor::Context<Self>,
         _result: Ref,
         _device_mesh: Ref,
         _dims: Vec<String>,
@@ -356,7 +356,7 @@ impl WorkerMessageHandler for WorkerActor {
 
     async fn borrow_create(
         &mut self,
-        _this: &Instance<Self>,
+        _this: &hyperactor::Context<Self>,
         _result: Ref,
         _borrow_id: u64,
         _tensor_ref: Ref,
@@ -366,25 +366,41 @@ impl WorkerMessageHandler for WorkerActor {
         bail!("unimplemented: borrow_create")
     }
 
-    async fn borrow_first_use(&mut self, _this: &Instance<Self>, _borrow: u64) -> Result<()> {
+    async fn borrow_first_use(
+        &mut self,
+        _this: &hyperactor::Context<Self>,
+        _borrow: u64,
+    ) -> Result<()> {
         bail!("unimplemented: borrow_first_use")
     }
 
-    async fn borrow_last_use(&mut self, _this: &Instance<Self>, _borrow: u64) -> Result<()> {
+    async fn borrow_last_use(
+        &mut self,
+        _this: &hyperactor::Context<Self>,
+        _borrow: u64,
+    ) -> Result<()> {
         bail!("unimplemented: borrow_last_use")
     }
 
-    async fn borrow_drop(&mut self, _this: &Instance<Self>, _borrow_id: u64) -> Result<()> {
+    async fn borrow_drop(
+        &mut self,
+        _this: &hyperactor::Context<Self>,
+        _borrow_id: u64,
+    ) -> Result<()> {
         bail!("unimplemented: borrow_drop")
     }
 
-    async fn delete_refs(&mut self, _this: &Instance<Self>, _refs: Vec<Ref>) -> Result<()> {
+    async fn delete_refs(
+        &mut self,
+        _this: &hyperactor::Context<Self>,
+        _refs: Vec<Ref>,
+    ) -> Result<()> {
         Ok(())
     }
 
     async fn request_status(
         &mut self,
-        this: &Instance<Self>,
+        this: &hyperactor::Context<Self>,
         seq: Seq,
         controller: bool,
     ) -> Result<()> {
@@ -401,7 +417,7 @@ impl WorkerMessageHandler for WorkerActor {
 
     async fn reduce(
         &mut self,
-        _this: &Instance<Self>,
+        _this: &hyperactor::Context<Self>,
         result: Ref,
         local_tensor: Ref,
         factory: Factory,
@@ -490,7 +506,7 @@ impl WorkerMessageHandler for WorkerActor {
 
     async fn create_pipe(
         &mut self,
-        _this: &Instance<Self>,
+        _this: &hyperactor::Context<Self>,
         result: Ref,
         _key: String,
         _function: ResolvableFunction,
@@ -505,7 +521,7 @@ impl WorkerMessageHandler for WorkerActor {
 
     async fn send_tensor(
         &mut self,
-        _this: &Instance<Self>,
+        _this: &hyperactor::Context<Self>,
         _result: Ref,
         _from_ranks: Slice,
         _to_ranks: Slice,
@@ -519,7 +535,7 @@ impl WorkerMessageHandler for WorkerActor {
 
     async fn exit(
         &mut self,
-        _this: &Instance<Self>,
+        _this: &hyperactor::Context<Self>,
         _error: Option<(Option<ActorId>, String)>,
     ) -> Result<()> {
         Ok(())
@@ -527,7 +543,7 @@ impl WorkerMessageHandler for WorkerActor {
 
     async fn send_value(
         &mut self,
-        this: &Instance<Self>,
+        this: &hyperactor::Context<Self>,
         seq: Seq,
         _destination: Option<Ref>,
         _mutates: Vec<Ref>,
@@ -561,7 +577,7 @@ impl WorkerMessageHandler for WorkerActor {
 
     async fn split_comm(
         &mut self,
-        _this: &Instance<Self>,
+        _this: &hyperactor::Context<Self>,
         _dims: Vec<String>,
         _device_mesh: Ref,
         _stream_ref: StreamRef,
@@ -572,7 +588,7 @@ impl WorkerMessageHandler for WorkerActor {
 
     async fn split_comm_for_process_group(
         &mut self,
-        _this: &Instance<Self>,
+        _this: &hyperactor::Context<Self>,
         _remote_process_group_ref: Ref,
         _stream_ref: StreamRef,
         _config: Option<NcclConfig>,
@@ -582,7 +598,7 @@ impl WorkerMessageHandler for WorkerActor {
 
     async fn pipe_recv(
         &mut self,
-        _this: &Instance<Self>,
+        _this: &hyperactor::Context<Self>,
         _seq: Seq,
         results: Vec<Option<Ref>>,
         pipe: Ref,
@@ -603,7 +619,7 @@ impl WorkerMessageHandler for WorkerActor {
 
     async fn set_ref_unit_tests_only(
         &mut self,
-        _this: &Instance<Self>,
+        _this: &hyperactor::Context<Self>,
         _reference: Ref,
         _value: WireValue,
         _stream: StreamRef,
@@ -613,7 +629,7 @@ impl WorkerMessageHandler for WorkerActor {
 
     async fn get_ref_unit_tests_only(
         &mut self,
-        _this: &Instance<Self>,
+        _this: &hyperactor::Context<Self>,
         _ref_id: Ref,
         _stream: StreamRef,
     ) -> Result<Option<Result<WireValue, ValueError>>> {
@@ -622,7 +638,7 @@ impl WorkerMessageHandler for WorkerActor {
 
     async fn define_recording(
         &mut self,
-        _this: &Instance<Self>,
+        _this: &hyperactor::Context<Self>,
         _result: Ref,
         _nresults: usize,
         _nformals: usize,
@@ -635,7 +651,7 @@ impl WorkerMessageHandler for WorkerActor {
 
     async fn recording_formal(
         &mut self,
-        _this: &Instance<Self>,
+        _this: &hyperactor::Context<Self>,
         _result: Ref,
         _argument_index: usize,
         _stream: StreamRef,
@@ -645,7 +661,7 @@ impl WorkerMessageHandler for WorkerActor {
 
     async fn recording_result(
         &mut self,
-        _this: &Instance<Self>,
+        _this: &hyperactor::Context<Self>,
         _result: Ref,
         _output_index: usize,
         _stream: StreamRef,
@@ -655,7 +671,7 @@ impl WorkerMessageHandler for WorkerActor {
 
     async fn call_recording(
         &mut self,
-        _this: &Instance<Self>,
+        _this: &hyperactor::Context<Self>,
         _seq: Seq,
         _recording: Ref,
         _results: Vec<Ref>,

--- a/monarch_tensor_worker/src/comm.rs
+++ b/monarch_tensor_worker/src/comm.rs
@@ -18,7 +18,6 @@ use cxx::CxxVector;
 use hyperactor::Actor;
 use hyperactor::HandleClient;
 use hyperactor::Handler;
-use hyperactor::Instance;
 use hyperactor::Named;
 use hyperactor::actor::ActorHandle;
 use hyperactor::forward;
@@ -216,7 +215,7 @@ impl Actor for NcclCommActor {
 impl CommMessageHandler for NcclCommActor {
     async fn all_reduce(
         &mut self,
-        _this: &Instance<Self>,
+        _this: &hyperactor::Context<Self>,
         tensor: TensorCell,
         op: ReduceOp,
         stream: Stream,
@@ -229,7 +228,7 @@ impl CommMessageHandler for NcclCommActor {
 
     async fn all_to_all_single(
         &mut self,
-        _this: &Instance<Self>,
+        _this: &hyperactor::Context<Self>,
         output: TensorCell,
         input: TensorCell,
         stream: Stream,
@@ -242,7 +241,7 @@ impl CommMessageHandler for NcclCommActor {
 
     async fn split_all(
         &mut self,
-        this: &Instance<Self>,
+        this: &hyperactor::Context<Self>,
         nccl_config: Option<NcclConfig>,
     ) -> Result<ActorHandle<NcclCommActor>> {
         let comm = self.comm.clone();
@@ -256,7 +255,7 @@ impl CommMessageHandler for NcclCommActor {
 
     async fn split_from(
         &mut self,
-        this: &Instance<Self>,
+        this: &hyperactor::Context<Self>,
         ranks: Vec<i32>,
         nccl_config: Option<NcclConfig>,
     ) -> Result<Option<ActorHandle<NcclCommActor>>> {
@@ -277,7 +276,7 @@ impl CommMessageHandler for NcclCommActor {
 
     async fn broadcast(
         &mut self,
-        _this: &Instance<Self>,
+        _this: &hyperactor::Context<Self>,
         tensor: TensorCell,
         root: i32,
         stream: Stream,
@@ -288,7 +287,11 @@ impl CommMessageHandler for NcclCommActor {
         .await
     }
 
-    async fn barrier(&mut self, _this: &Instance<Self>, stream: Stream) -> Result<Event> {
+    async fn barrier(
+        &mut self,
+        _this: &hyperactor::Context<Self>,
+        stream: Stream,
+    ) -> Result<Event> {
         self.collective("barrier".into(), stream.clone(), move |comm| {
             comm.lock().barrier(&stream)
         })
@@ -297,7 +300,7 @@ impl CommMessageHandler for NcclCommActor {
 
     async fn reduce(
         &mut self,
-        _this: &Instance<Self>,
+        _this: &hyperactor::Context<Self>,
         tensor: TensorCell,
         op: ReduceOp,
         root: i32,
@@ -311,7 +314,7 @@ impl CommMessageHandler for NcclCommActor {
 
     async fn all_gather(
         &mut self,
-        _this: &Instance<Self>,
+        _this: &hyperactor::Context<Self>,
         output: Vec<TensorCell>,
         input: TensorCell,
         stream: Stream,
@@ -324,7 +327,7 @@ impl CommMessageHandler for NcclCommActor {
 
     async fn all_gather_into_tensor(
         &mut self,
-        _this: &Instance<Self>,
+        _this: &hyperactor::Context<Self>,
         output: TensorCell,
         input: TensorCell,
         stream: Stream,
@@ -339,7 +342,7 @@ impl CommMessageHandler for NcclCommActor {
 
     async fn reduce_scatter_tensor(
         &mut self,
-        _this: &Instance<Self>,
+        _this: &hyperactor::Context<Self>,
         output: TensorCell,
         input: TensorCell,
         op: ReduceOp,
@@ -358,7 +361,7 @@ impl CommMessageHandler for NcclCommActor {
 
     async fn send(
         &mut self,
-        _this: &Instance<Self>,
+        _this: &hyperactor::Context<Self>,
         tensor: TensorCell,
         dst: i32,
         stream: Stream,
@@ -372,7 +375,7 @@ impl CommMessageHandler for NcclCommActor {
 
     async fn recv(
         &mut self,
-        _this: &Instance<Self>,
+        _this: &hyperactor::Context<Self>,
         tensor: TensorCell,
         src: i32,
         stream: Stream,
@@ -386,7 +389,7 @@ impl CommMessageHandler for NcclCommActor {
 
     async fn group(
         &mut self,
-        _this: &Instance<Self>,
+        _this: &hyperactor::Context<Self>,
         messages: Vec<CommMessage>,
         stream: Stream,
     ) -> Result<Event> {

--- a/monarch_tensor_worker/src/lib.rs
+++ b/monarch_tensor_worker/src/lib.rs
@@ -58,14 +58,13 @@ use hyperactor::Actor;
 use hyperactor::ActorRef;
 use hyperactor::Bind;
 use hyperactor::Handler;
-use hyperactor::Instance;
 use hyperactor::Named;
 use hyperactor::Unbind;
 use hyperactor::actor::ActorHandle;
 use hyperactor::cap;
 use hyperactor::forward;
 use hyperactor::reference::ActorId;
-use hyperactor_mesh::comm::multicast::get_cast_info_from_headers_or_err;
+use hyperactor_mesh::comm::multicast::CastInfo;
 use itertools::Itertools;
 use monarch_hyperactor::shape::PyPoint;
 use monarch_hyperactor::shape::PyShape;
@@ -260,9 +259,12 @@ impl Actor for WorkerActor {
 
 #[async_trait]
 impl Handler<AssignRankMessage> for WorkerActor {
-    async fn handle(&mut self, this: &Instance<Self>, _: AssignRankMessage) -> anyhow::Result<()> {
-        // Instance::ctx() should always return a value when inside a handler.
-        let (rank, shape) = get_cast_info_from_headers_or_err(this.ctx().unwrap().headers())?;
+    async fn handle(
+        &mut self,
+        this: &hyperactor::Context<Self>,
+        _: AssignRankMessage,
+    ) -> anyhow::Result<()> {
+        let (rank, shape) = this.cast_info()?;
         self.rank = rank;
         Python::with_gil(|py| {
             let mesh_controller = py.import("monarch.mesh_controller").unwrap();
@@ -289,7 +291,7 @@ pub enum AssignRankMessage {
 impl WorkerMessageHandler for WorkerActor {
     async fn backend_network_init(
         &mut self,
-        this: &Instance<Self>,
+        this: &hyperactor::Context<Self>,
         unique_id: UniqueId,
     ) -> Result<()> {
         let device = self
@@ -352,7 +354,7 @@ impl WorkerMessageHandler for WorkerActor {
 
     async fn backend_network_point_to_point_init(
         &mut self,
-        this: &Instance<Self>,
+        this: &hyperactor::Context<Self>,
         from_stream: StreamRef,
         to_stream: StreamRef,
     ) -> Result<()> {
@@ -374,7 +376,7 @@ impl WorkerMessageHandler for WorkerActor {
 
     async fn call_function(
         &mut self,
-        this: &Instance<Self>,
+        this: &hyperactor::Context<Self>,
         params: CallFunctionParams,
     ) -> Result<()> {
         let stream = self.try_get_stream(params.stream)?.clone();
@@ -423,7 +425,7 @@ impl WorkerMessageHandler for WorkerActor {
 
     async fn command_group(
         &mut self,
-        this: &Instance<Self>,
+        this: &hyperactor::Context<Self>,
         params: Vec<WorkerMessage>,
     ) -> Result<()> {
         for msg in params {
@@ -434,7 +436,7 @@ impl WorkerMessageHandler for WorkerActor {
 
     async fn create_stream(
         &mut self,
-        this: &Instance<Self>,
+        this: &hyperactor::Context<Self>,
         result: StreamRef,
         creation_mode: StreamCreationMode,
     ) -> Result<()> {
@@ -456,7 +458,7 @@ impl WorkerMessageHandler for WorkerActor {
 
     async fn create_device_mesh(
         &mut self,
-        _this: &Instance<Self>,
+        _this: &hyperactor::Context<Self>,
         result: Ref,
         names: Vec<String>,
         ranks: Slice,
@@ -470,7 +472,7 @@ impl WorkerMessageHandler for WorkerActor {
 
     async fn create_remote_process_group(
         &mut self,
-        _this: &Instance<Self>,
+        _this: &hyperactor::Context<Self>,
         result: Ref,
         device_mesh: Ref,
         dims: Vec<String>,
@@ -490,7 +492,7 @@ impl WorkerMessageHandler for WorkerActor {
 
     async fn borrow_create(
         &mut self,
-        this: &Instance<Self>,
+        this: &hyperactor::Context<Self>,
         result: Ref,
         borrow_id: u64,
         tensor_ref: Ref,
@@ -509,7 +511,11 @@ impl WorkerMessageHandler for WorkerActor {
         Ok(())
     }
 
-    async fn borrow_first_use(&mut self, this: &Instance<Self>, borrow: u64) -> Result<()> {
+    async fn borrow_first_use(
+        &mut self,
+        this: &hyperactor::Context<Self>,
+        borrow: u64,
+    ) -> Result<()> {
         let borrow = self
             .borrows
             .get_mut(&borrow)
@@ -519,7 +525,11 @@ impl WorkerMessageHandler for WorkerActor {
         Ok(())
     }
 
-    async fn borrow_last_use(&mut self, this: &Instance<Self>, borrow: u64) -> Result<()> {
+    async fn borrow_last_use(
+        &mut self,
+        this: &hyperactor::Context<Self>,
+        borrow: u64,
+    ) -> Result<()> {
         let borrow = self
             .borrows
             .get_mut(&borrow)
@@ -529,7 +539,11 @@ impl WorkerMessageHandler for WorkerActor {
         Ok(())
     }
 
-    async fn borrow_drop(&mut self, this: &Instance<Self>, borrow_id: u64) -> Result<()> {
+    async fn borrow_drop(
+        &mut self,
+        this: &hyperactor::Context<Self>,
+        borrow_id: u64,
+    ) -> Result<()> {
         let borrow = self
             .borrows
             .get_mut(&borrow_id)
@@ -540,7 +554,11 @@ impl WorkerMessageHandler for WorkerActor {
         Ok(())
     }
 
-    async fn delete_refs(&mut self, this: &Instance<Self>, refs: Vec<Ref>) -> Result<()> {
+    async fn delete_refs(
+        &mut self,
+        this: &hyperactor::Context<Self>,
+        refs: Vec<Ref>,
+    ) -> Result<()> {
         // Fan the delete message to all streams.
         // Check for errors.
         // TODO: this blocks forward progress of the the actor loop while we
@@ -558,7 +576,7 @@ impl WorkerMessageHandler for WorkerActor {
 
     async fn request_status(
         &mut self,
-        this: &Instance<Self>,
+        this: &hyperactor::Context<Self>,
         seq: Seq,
         controller: bool,
     ) -> Result<()> {
@@ -586,7 +604,7 @@ impl WorkerMessageHandler for WorkerActor {
 
     async fn reduce(
         &mut self,
-        this: &Instance<Self>,
+        this: &hyperactor::Context<Self>,
         result: Ref,
         local_tensor: Ref,
         factory: Factory,
@@ -634,7 +652,7 @@ impl WorkerMessageHandler for WorkerActor {
 
     async fn create_pipe(
         &mut self,
-        this: &Instance<Self>,
+        this: &hyperactor::Context<Self>,
         result: Ref,
         // TODO(agallagher): This is used in the python impl to name the socket
         // path to use for comms, but we don't currently use a named socket.
@@ -686,7 +704,7 @@ impl WorkerMessageHandler for WorkerActor {
 
     async fn send_tensor(
         &mut self,
-        this: &Instance<Self>,
+        this: &hyperactor::Context<Self>,
         result: Ref,
         from_ranks: Slice,
         to_ranks: Slice,
@@ -740,7 +758,7 @@ impl WorkerMessageHandler for WorkerActor {
 
     async fn exit(
         &mut self,
-        this: &Instance<Self>,
+        this: &hyperactor::Context<Self>,
         error: Option<(Option<ActorId>, String)>,
     ) -> Result<()> {
         for (_, stream) in self.streams.drain() {
@@ -790,7 +808,7 @@ impl WorkerMessageHandler for WorkerActor {
 
     async fn send_value(
         &mut self,
-        this: &Instance<Self>,
+        this: &hyperactor::Context<Self>,
         seq: Seq,
         destination: Option<Ref>,
         mutates: Vec<Ref>,
@@ -843,7 +861,7 @@ impl WorkerMessageHandler for WorkerActor {
 
     async fn split_comm(
         &mut self,
-        this: &Instance<Self>,
+        this: &hyperactor::Context<Self>,
         dims: Vec<String>,
         device_mesh: Ref,
         stream_ref: StreamRef,
@@ -894,7 +912,7 @@ impl WorkerMessageHandler for WorkerActor {
 
     async fn split_comm_for_process_group(
         &mut self,
-        this: &Instance<Self>,
+        this: &hyperactor::Context<Self>,
         remote_process_group_ref: Ref,
         stream_ref: StreamRef,
         config: Option<NcclConfig>,
@@ -949,7 +967,7 @@ impl WorkerMessageHandler for WorkerActor {
 
     async fn pipe_recv(
         &mut self,
-        this: &Instance<Self>,
+        this: &hyperactor::Context<Self>,
         _seq: Seq,
         results: Vec<Option<Ref>>,
         pipe: Ref,
@@ -975,7 +993,7 @@ impl WorkerMessageHandler for WorkerActor {
 
     async fn set_ref_unit_tests_only(
         &mut self,
-        this: &Instance<Self>,
+        this: &hyperactor::Context<Self>,
         reference: Ref,
         value: WireValue,
         stream: StreamRef,
@@ -987,7 +1005,7 @@ impl WorkerMessageHandler for WorkerActor {
 
     async fn get_ref_unit_tests_only(
         &mut self,
-        this: &Instance<Self>,
+        this: &hyperactor::Context<Self>,
         ref_id: Ref,
         stream: StreamRef,
     ) -> Result<Option<Result<WireValue, ValueError>>> {
@@ -1000,7 +1018,7 @@ impl WorkerMessageHandler for WorkerActor {
 
     async fn define_recording(
         &mut self,
-        this: &Instance<Self>,
+        this: &hyperactor::Context<Self>,
         result: Ref,
         _nresults: usize,
         _nformals: usize,
@@ -1083,7 +1101,7 @@ impl WorkerMessageHandler for WorkerActor {
 
     async fn recording_formal(
         &mut self,
-        this: &Instance<Self>,
+        this: &hyperactor::Context<Self>,
         result: Ref,
         argument_index: usize,
         stream: StreamRef,
@@ -1097,7 +1115,7 @@ impl WorkerMessageHandler for WorkerActor {
 
     async fn recording_result(
         &mut self,
-        this: &Instance<Self>,
+        this: &hyperactor::Context<Self>,
         result: Ref,
         output_index: usize,
         stream: StreamRef,
@@ -1111,7 +1129,7 @@ impl WorkerMessageHandler for WorkerActor {
 
     async fn call_recording(
         &mut self,
-        this: &Instance<Self>,
+        this: &hyperactor::Context<Self>,
         seq: Seq,
         recording: Ref,
         results: Vec<Ref>,

--- a/monarch_tensor_worker/src/pipe.rs
+++ b/monarch_tensor_worker/src/pipe.rs
@@ -21,7 +21,6 @@ use async_trait::async_trait;
 use hyperactor::Actor;
 use hyperactor::HandleClient;
 use hyperactor::Handler;
-use hyperactor::Instance;
 use hyperactor::forward;
 use hyperactor::mailbox::OncePortHandle;
 use monarch_messages::controller::WorkerError;
@@ -364,7 +363,7 @@ impl Drop for PipeActor {
 impl PipeMessageHandler for PipeActor {
     async fn send_value(
         &mut self,
-        _this: &Instance<Self>,
+        _this: &hyperactor::Context<Self>,
         val: Result<PyTree<RValue>, WorkerError>,
     ) -> Result<()> {
         // TODO(agallagher): Propagate failures and use a timeout and handle worker errors?
@@ -376,7 +375,7 @@ impl PipeMessageHandler for PipeActor {
         Ok(())
     }
 
-    async fn recv_value(&mut self, _this: &Instance<Self>) -> Result<PyTree<RValue>> {
+    async fn recv_value(&mut self, _this: &hyperactor::Context<Self>) -> Result<PyTree<RValue>> {
         // TODO(agallagher): Propagate failures and use a timeout?
         tokio::select! {
             res = self.handle.wait() => bail!("pipe server exited: {:?}", res),

--- a/monarch_tensor_worker/src/stream.rs
+++ b/monarch_tensor_worker/src/stream.rs
@@ -23,6 +23,7 @@ use async_trait::async_trait;
 use hyperactor::Actor;
 use hyperactor::ActorId;
 use hyperactor::ActorRef;
+use hyperactor::Context;
 use hyperactor::HandleClient;
 use hyperactor::Handler;
 use hyperactor::Instance;
@@ -925,7 +926,7 @@ impl StreamActor {
 impl StreamMessageHandler for StreamActor {
     async fn call_function(
         &mut self,
-        this: &Instance<Self>,
+        this: &Context<Self>,
         params: CallFunctionParams,
         device_meshes: HashMap<Ref, DeviceMesh>,
         remote_process_groups: HashMap<
@@ -1005,7 +1006,7 @@ impl StreamMessageHandler for StreamActor {
 
     async fn borrow_create(
         &mut self,
-        _this: &Instance<Self>,
+        _this: &Context<Self>,
         borrow: u64,
         tensor: Ref,
         first_use_sender: PortHandle<(Option<Event>, TensorCellResult)>,
@@ -1045,7 +1046,7 @@ impl StreamMessageHandler for StreamActor {
 
     async fn borrow_first_use(
         &mut self,
-        _this: &Instance<Self>,
+        _this: &Context<Self>,
         borrow: u64,
         result: Ref,
         first_use_receiver: Arc<Mutex<PortReceiver<(Option<Event>, TensorCellResult)>>>,
@@ -1096,7 +1097,7 @@ impl StreamMessageHandler for StreamActor {
 
     async fn borrow_last_use(
         &mut self,
-        _this: &Instance<Self>,
+        _this: &Context<Self>,
         borrow: u64,
         result: Ref,
         last_use_sender: PortHandle<(Option<Event>, TensorCellResult)>,
@@ -1131,7 +1132,7 @@ impl StreamMessageHandler for StreamActor {
 
     async fn borrow_drop(
         &mut self,
-        _this: &Instance<Self>,
+        _this: &Context<Self>,
         borrow: u64,
         last_use_receiver: Arc<Mutex<PortReceiver<(Option<Event>, TensorCellResult)>>>,
     ) -> Result<()> {
@@ -1168,7 +1169,7 @@ impl StreamMessageHandler for StreamActor {
         Ok(())
     }
 
-    async fn delete_refs(&mut self, _this: &Instance<Self>, refs: Vec<Ref>) -> Result<()> {
+    async fn delete_refs(&mut self, _this: &Context<Self>, refs: Vec<Ref>) -> Result<()> {
         if let Some((recording, _)) = self.get_defining_recording() {
             recording.messages.push(StreamMessage::DeleteRefs(refs));
             return Ok(());
@@ -1180,7 +1181,7 @@ impl StreamMessageHandler for StreamActor {
         Ok(())
     }
 
-    async fn request_status(&mut self, _this: &Instance<Self>) -> Result<()> {
+    async fn request_status(&mut self, _this: &Context<Self>) -> Result<()> {
         if self.get_defining_recording().is_some() {
             bail!("request_status not allowed in recording");
         }
@@ -1190,7 +1191,7 @@ impl StreamMessageHandler for StreamActor {
 
     async fn init_comm(
         &mut self,
-        _this: &Instance<Self>,
+        _this: &Context<Self>,
         comm: ActorHandle<NcclCommActor>,
     ) -> Result<()> {
         if self.get_defining_recording().is_some() {
@@ -1203,7 +1204,7 @@ impl StreamMessageHandler for StreamActor {
 
     async fn reduce(
         &mut self,
-        this: &Instance<Self>,
+        this: &Context<Self>,
         comm: Arc<ActorHandle<NcclCommActor>>,
         dim_size: i64,
         result: Ref,
@@ -1323,7 +1324,7 @@ impl StreamMessageHandler for StreamActor {
 
     async fn send_tensor(
         &mut self,
-        this: &Instance<Self>,
+        this: &Context<Self>,
         result: Ref,
         from_rank: Option<usize>,
         to_rank: Option<usize>,
@@ -1417,7 +1418,7 @@ impl StreamMessageHandler for StreamActor {
 
     async fn send_value(
         &mut self,
-        this: &Instance<Self>,
+        this: &Context<Self>,
         seq: Seq,
         worker_actor_id: ActorId,
         mutates: Vec<Ref>,
@@ -1553,7 +1554,7 @@ impl StreamMessageHandler for StreamActor {
 
     async fn set_value(
         &mut self,
-        this: &Instance<Self>,
+        this: &Context<Self>,
         results: Vec<Option<Ref>>,
         pipe: Result<PortHandle<PipeMessage>, Arc<CallFunctionError>>,
     ) -> Result<()> {
@@ -1595,7 +1596,7 @@ impl StreamMessageHandler for StreamActor {
         Ok(())
     }
 
-    async fn define_recording(&mut self, _this: &Instance<Self>, recording: Ref) -> Result<()> {
+    async fn define_recording(&mut self, _this: &Context<Self>, recording: Ref) -> Result<()> {
         if self.active_recording.is_some() {
             bail!("different recording already active");
         }
@@ -1610,7 +1611,7 @@ impl StreamMessageHandler for StreamActor {
         Ok(())
     }
 
-    async fn finalize_recording(&mut self, _this: &Instance<Self>, recording: Ref) -> Result<()> {
+    async fn finalize_recording(&mut self, _this: &Context<Self>, recording: Ref) -> Result<()> {
         match self.active_recording {
             Some(RecordingState::Defining {
                 recording: active_recording,
@@ -1629,7 +1630,7 @@ impl StreamMessageHandler for StreamActor {
 
     async fn recording_formal(
         &mut self,
-        _this: &Instance<Self>,
+        _this: &Context<Self>,
         result: Ref,
         argument_index: usize,
     ) -> Result<()> {
@@ -1647,7 +1648,7 @@ impl StreamMessageHandler for StreamActor {
 
     async fn recording_result(
         &mut self,
-        _this: &Instance<Self>,
+        _this: &Context<Self>,
         result: Ref,
         output_index: usize,
     ) -> Result<()> {
@@ -1665,7 +1666,7 @@ impl StreamMessageHandler for StreamActor {
 
     async fn call_recording(
         &mut self,
-        this: &Instance<Self>,
+        this: &Context<Self>,
         seq: Seq,
         recording: Ref,
         results: Vec<Ref>,
@@ -1888,7 +1889,7 @@ impl StreamMessageHandler for StreamActor {
 
     async fn set_ref_unit_tests_only(
         &mut self,
-        _this: &Instance<Self>,
+        _this: &Context<Self>,
         reference: Ref,
         value: WireValue,
     ) -> Result<()> {
@@ -1899,7 +1900,7 @@ impl StreamMessageHandler for StreamActor {
 
     async fn set_tensor_ref_unit_tests_only(
         &mut self,
-        _this: &Instance<Self>,
+        _this: &Context<Self>,
         reference: Ref,
         tensor_result: TensorCellResult,
     ) -> Result<()> {
@@ -1916,7 +1917,7 @@ impl StreamMessageHandler for StreamActor {
 
     async fn get_ref_unit_tests_only(
         &mut self,
-        _this: &Instance<Self>,
+        _this: &Context<Self>,
         reference: Ref,
     ) -> Result<Option<Result<WireValue, Arc<CallFunctionError>>>> {
         /// For testing only, doesn't support Tensor or TensorList.
@@ -1945,7 +1946,7 @@ impl StreamMessageHandler for StreamActor {
 
     async fn get_tensor_ref_unit_tests_only(
         &mut self,
-        _this: &Instance<Self>,
+        _this: &Context<Self>,
         reference: Ref,
     ) -> Result<Option<TensorCellResult>> {
         match self.env.get(&reference) {


### PR DESCRIPTION
Summary:
In order to make the headers accessible to message handlers in a cleaner way, this diff introduces a new struct `Context<'_, A>` which contains a `&Instance<A>` and the headers associated with the current message. As per T228176204, the `Handler` trait now takes a `&Context<Self>` for the `this` parameter. `Context` has the same capabilities as the contained `Instance`. Moreover, I have implemented `Deref` for `Context` to return `&Instance` -- with deref coercion, this means that no code has to change except for inside the method signatures (this deref coercion is also why the `Handler` takes `&Context` instead of `&Instance`.

Disclaimer: many of these changes were made by devmate.

Reviewed By: shayne-fletcher, mariusae

Differential Revision: D77341169
