### PR TITLE
Use Clock.timeout

### DIFF
--- a/hyper/src/commands/show.rs
+++ b/hyper/src/commands/show.rs
@@ -16,6 +16,8 @@ use chrono::Local;
 use hyper::utils::system_address::SystemAddr;
 use hyperactor::ActorId;
 use hyperactor::ActorRef;
+use hyperactor::clock::Clock;
+use hyperactor::clock::RealClock;
 use hyperactor::proc::ActorTreeSnapshot;
 use hyperactor::reference::Index;
 use hyperactor::reference::Reference;
@@ -202,11 +204,12 @@ impl ShowCommand {
                                 ActorRef::attest(proc_id.actor_id("proc", 0));
                             (
                                 proc_id,
-                                tokio::time::timeout(
-                                    std::time::Duration::from_secs(5),
-                                    proc_ref.snapshot(&client.clone()),
-                                )
-                                .await,
+                                RealClock
+                                    .timeout(
+                                        std::time::Duration::from_secs(5),
+                                        proc_ref.snapshot(&client.clone()),
+                                    )
+                                    .await,
                             )
                         }
                     })

--- a/hyperactor/src/channel/net.rs
+++ b/hyperactor/src/channel/net.rs
@@ -2517,7 +2517,10 @@ mod tests {
 
     #[tracing_test::traced_test]
     async fn verify_tx_closed(tx_status: &mut watch::Receiver<TxStatus>, expected_log: &str) {
-        match tokio::time::timeout(Duration::from_secs(5), tx_status.changed()).await {
+        match RealClock
+            .timeout(Duration::from_secs(5), tx_status.changed())
+            .await
+        {
             Ok(Ok(())) => {
                 let current_status = *tx_status.borrow();
                 assert_eq!(current_status, TxStatus::Closed);

--- a/hyperactor/src/clock.rs
+++ b/hyperactor/src/clock.rs
@@ -229,6 +229,7 @@ impl Clock for SimClock {
         SIM_TIME.system_start.clone() + self.now().duration_since(SIM_TIME.start)
     }
 
+    #[allow(clippy::disallowed_methods)]
     async fn timeout<F, T>(&self, duration: tokio::time::Duration, f: F) -> Result<T, TimeoutError>
     where
         F: std::future::Future<Output = T>,
@@ -295,6 +296,7 @@ impl Clock for RealClock {
     fn system_time_now(&self) -> SystemTime {
         SystemTime::now()
     }
+    #[allow(clippy::disallowed_methods)]
     async fn timeout<F, T>(&self, duration: tokio::time::Duration, f: F) -> Result<T, TimeoutError>
     where
         F: std::future::Future<Output = T>,

--- a/hyperactor/src/mailbox.rs
+++ b/hyperactor/src/mailbox.rs
@@ -2763,7 +2763,8 @@ mod tests {
         return_handle.send(Undeliverable(envelope.clone())).unwrap();
         // Check we receive the undelivered message.
         assert!(
-            tokio::time::timeout(tokio::time::Duration::from_secs(1), return_receiver.recv())
+            RealClock
+                .timeout(tokio::time::Duration::from_secs(1), return_receiver.recv())
                 .await
                 .is_ok()
         );
@@ -2780,7 +2781,8 @@ mod tests {
         });
         drop(return_handle);
         assert!(
-            tokio::time::timeout(tokio::time::Duration::from_secs(1), monitor_handle)
+            RealClock
+                .timeout(tokio::time::Duration::from_secs(1), monitor_handle)
                 .await
                 .is_ok()
         );
@@ -2873,7 +2875,8 @@ mod tests {
         {
             let (sender, mut receiver) = create_receiver::<u64>(coalesce);
             assert!(
-                tokio::time::timeout(tokio::time::Duration::from_secs(1), receiver.recv())
+                RealClock
+                    .timeout(tokio::time::Duration::from_secs(1), receiver.recv())
                     .await
                     .is_err()
             );
@@ -2905,7 +2908,8 @@ mod tests {
                 );
             } else {
                 assert!(
-                    tokio::time::timeout(tokio::time::Duration::from_secs(1), receiver.recv())
+                    RealClock
+                        .timeout(tokio::time::Duration::from_secs(1), receiver.recv())
                         .await
                         .is_err()
                 );
@@ -3013,16 +3017,17 @@ mod tests {
     ) -> anyhow::Result<Vec<u64>> {
         let mut messeges = vec![];
 
-        tokio::time::timeout(timeout_duration, async {
-            loop {
-                let msg = receiver.recv().await.unwrap();
-                messeges.push(msg);
-                if messeges.len() == expected_size {
-                    break;
+        RealClock
+            .timeout(timeout_duration, async {
+                loop {
+                    let msg = receiver.recv().await.unwrap();
+                    messeges.push(msg);
+                    if messeges.len() == expected_size {
+                        break;
+                    }
                 }
-            }
-        })
-        .await?;
+            })
+            .await?;
         Ok(messeges)
     }
 

--- a/hyperactor/src/proc.rs
+++ b/hyperactor/src/proc.rs
@@ -66,6 +66,7 @@ use crate::attrs::Attrs;
 use crate::cap;
 use crate::clock::Clock;
 use crate::clock::ClockKind;
+use crate::clock::RealClock;
 use crate::data::Serialized;
 use crate::data::TypeInfo;
 use crate::mailbox::BoxedMailboxSender;
@@ -558,13 +559,16 @@ impl Proc {
             .map(|(actor_id, root)| {
                 let actor_id = actor_id.clone();
                 async move {
-                    tokio::time::timeout(
-                        timeout,
-                        root.wait_for(|state: &ActorStatus| matches!(*state, ActorStatus::Stopped)),
-                    )
-                    .await
-                    .ok()
-                    .map(|_| actor_id)
+                    RealClock
+                        .timeout(
+                            timeout,
+                            root.wait_for(|state: &ActorStatus| {
+                                matches!(*state, ActorStatus::Stopped)
+                            }),
+                        )
+                        .await
+                        .ok()
+                        .map(|_| actor_id)
                 }
             })
             .collect();

--- a/hyperactor/src/simnet.rs
+++ b/hyperactor/src/simnet.rs
@@ -902,8 +902,9 @@ impl SimNet {
                 break 'outer self.records.clone();
             }
 
-            while let Ok(Some((event, advanceable, time))) =
-                tokio::time::timeout(tokio::time::Duration::from_millis(1), event_rx.recv()).await
+            while let Ok(Some((event, advanceable, time))) = RealClock
+                .timeout(tokio::time::Duration::from_millis(1), event_rx.recv())
+                .await
             {
                 let scheduled_event = match time {
                     Some(time) => ScheduledEvent {

--- a/hyperactor_mesh/src/comm.rs
+++ b/hyperactor_mesh/src/comm.rs
@@ -856,15 +856,16 @@ mod tests {
         dur: Duration,
     ) -> anyhow::Result<()> {
         // timeout wraps the entire async block
-        tokio::time::timeout(dur, async {
-            loop {
-                let msg = receiver.recv().await.unwrap();
-                if msg == expected {
-                    break;
+        RealClock
+            .timeout(dur, async {
+                loop {
+                    let msg = receiver.recv().await.unwrap();
+                    if msg == expected {
+                        break;
+                    }
                 }
-            }
-        })
-        .await?;
+            })
+            .await?;
         Ok(())
     }
 

--- a/hyperactor_mesh/src/connect.rs
+++ b/hyperactor_mesh/src/connect.rs
@@ -187,7 +187,7 @@ pub async fn accept<'a, C: CanOpenPort + CanSend>(
             return_conn: r_tx.bind(),
         },
     )?;
-    let wr = tokio::time::timeout(CONNECT_TIMEOUT, r_rx.recv()).await??;
+    let wr = RealClock.timeout(CONNECT_TIMEOUT, r_rx.recv()).await??;
     Ok((IoMsgRead::new(rx), IoMsgWrite::new(caps, wr)))
 }
 
@@ -200,7 +200,7 @@ pub async fn connect<C: CanOpenPort + CanSend>(
     let (tx, mut rx) = open_port::<Accept>(caps);
     port.send(caps, Connect { port: tx.bind() })?;
 
-    let connection = tokio::time::timeout(CONNECT_TIMEOUT, rx.recv()).await??;
+    let connection = RealClock.timeout(CONNECT_TIMEOUT, rx.recv()).await??;
     let (tx, rx) = open_port::<Io>(caps);
     connection.return_conn.send(caps, tx.bind())?;
 

--- a/hyperactor_multiprocess/src/system_actor.rs
+++ b/hyperactor_multiprocess/src/system_actor.rs
@@ -2748,7 +2748,8 @@ mod tests {
         // We expect message delivery failure prevents the game from
         // ending within the timeout.
         assert!(
-            tokio::time::timeout(tokio::time::Duration::from_secs(4), on_game_over.recv())
+            RealClock
+                .timeout(tokio::time::Duration::from_secs(4), on_game_over.recv())
                 .await
                 .is_err()
         );

--- a/monarch_extension/src/client.rs
+++ b/monarch_extension/src/client.rs
@@ -11,6 +11,8 @@ use std::sync::Arc;
 
 use hyperactor::ActorRef;
 use hyperactor::WorldId;
+use hyperactor::clock::Clock;
+use hyperactor::clock::RealClock;
 use hyperactor::data::Serialized;
 use hyperactor_multiprocess::system_actor::SYSTEM_ACTOR_REF;
 use hyperactor_multiprocess::system_actor::SystemMessageClient;
@@ -546,7 +548,7 @@ impl ClientActor {
                 .stop(&mailbox, worlds_ids, timeout, tx.bind())
                 .await?;
             let timeout = tokio::time::Duration::from_secs(10);
-            match tokio::time::timeout(timeout, rx.recv()).await {
+            match RealClock.timeout(timeout, rx.recv()).await {
                 Ok(result) => result.map_err(|e| PyRuntimeError::new_err(e.to_string()))?,
                 Err(_) => {
                     tracing::info!(

--- a/tools/rust/ossconfigs/clippy.toml
+++ b/tools/rust/ossconfigs/clippy.toml
@@ -3,4 +3,5 @@ disallowed-methods = [
     { path = "std::thread::sleep", reason = "use `hyperactor::clock::Clock::sleep` instead." },
     { path = "tokio::time::Instant::now", reason = "use `hyperactor::clock::Clock::now` instead." },
     { path = "std::time::SystemTime::now", reason = "use `hyperactor::clock::Clock::system_time_now` instead." },
+    { path = "tokio::time::timeout", reason = "use `hyperactor::clock::Clock::timeout` instead." },
 ]


### PR DESCRIPTION
Summary: Replace all instances of `tokio::time::timeout` with the corresponding Clock.timeout

Reviewed By: pablorfb-meta

Differential Revision: D77263418


