### PR TITLE
(8/n - non-xlformers conda-on-mast mvp)(monarch/tools) Implement commands.get_or_create function

### DIFF
--- a/python/monarch/tools/cli.py
+++ b/python/monarch/tools/cli.py
@@ -86,7 +86,9 @@ class CreateCmd:
             else defaults.component_fn(config.scheduler)
         )
         component_args = component_args_from_cli(component_fn, args.component_args)
-        handle = create(config, component_fn)(**component_args)
+        appdef = component_fn(**component_args)
+
+        handle = create(config, appdef)
         print(handle)
 
 

--- a/python/monarch/tools/mesh_spec.py
+++ b/python/monarch/tools/mesh_spec.py
@@ -122,6 +122,12 @@ class ServerSpec:
     name: str
     state: specs.AppState
     meshes: list[MeshSpec]
+    scheduler: str
+    namespace: str = ""
+
+    @property
+    def server_handle(self) -> str:
+        return f"{self.scheduler}://{self.namespace}/{self.name}"
 
     @property
     def is_running(self) -> bool:
@@ -152,6 +158,7 @@ class ServerSpec:
 
         return {
             "name": self.name,
+            "server_handle": self.server_handle,
             "state": self.state.name,
             "meshes": {
                 mesh.name: {

--- a/python/tests/test_allocator.py
+++ b/python/tests/test_allocator.py
@@ -49,6 +49,7 @@ from torchx.specs import AppState
 _100_MILLISECONDS = timedelta(milliseconds=100)
 
 SERVER_READY = "monarch.tools.commands.server_ready"
+UNUSED = "__UNUSED__"
 
 
 class TestActor(Actor):
@@ -244,7 +245,8 @@ class TestRemoteAllocator(unittest.IsolatedAsyncioTestCase):
         # but there are more than 1 mesh (hence ambiguous which mesh to allocate on)
 
         server = ServerSpec(
-            name="__UNUSED__",
+            name=UNUSED,
+            scheduler=UNUSED,
             state=AppState.RUNNING,
             meshes=[MeshSpec(name="x", num_hosts=1), MeshSpec(name="y", num_hosts=1)],
         )
@@ -262,7 +264,8 @@ class TestRemoteAllocator(unittest.IsolatedAsyncioTestCase):
     @pytest.mark.oss_skip  # pyre-ignore[56] TODO T228752279
     async def test_torchx_remote_alloc_initializer_no_match_label_1_mesh(self) -> None:
         server = ServerSpec(
-            name="__UNUSED__",
+            name=UNUSED,
+            scheduler=UNUSED,
             state=AppState.RUNNING,
             meshes=[
                 MeshSpec(
@@ -295,7 +298,8 @@ class TestRemoteAllocator(unittest.IsolatedAsyncioTestCase):
     @pytest.mark.oss_skip  # pyre-ignore[56] TODO T228752279
     async def test_torchx_remote_alloc_initializer_with_match_label(self) -> None:
         server = ServerSpec(
-            name="__UNUSED__",
+            name=UNUSED,
+            scheduler=UNUSED,
             state=AppState.RUNNING,
             meshes=[
                 MeshSpec(
@@ -338,6 +342,7 @@ class TestRemoteAllocator(unittest.IsolatedAsyncioTestCase):
 
         server = ServerSpec(
             name="test",
+            scheduler=UNUSED,
             state=AppState.RUNNING,
             meshes=[
                 MeshSpec(

--- a/python/tests/tools/test_cli.py
+++ b/python/tests/tools/test_cli.py
@@ -48,6 +48,7 @@ class TestCli(unittest.TestCase):
         job_name = "imaginary-test-job"
         mock_cmd_info.return_value = ServerSpec(
             name=job_name,
+            scheduler="slurm",
             state=AppState.RUNNING,
             meshes=[
                 MeshSpec(name="trainer", num_hosts=4, host_type="gpu.medium", gpus=2),
@@ -63,6 +64,7 @@ class TestCli(unittest.TestCase):
             expected = """
 {
   "name": "imaginary-test-job",
+  "server_handle": "slurm:///imaginary-test-job",
   "state": "RUNNING",
   "meshes": {
     "trainer": {

--- a/python/tests/tools/test_commands.py
+++ b/python/tests/tools/test_commands.py
@@ -9,15 +9,20 @@
 import unittest
 from datetime import timedelta
 from unittest import mock
+from unittest.mock import MagicMock
 
 from monarch.tools import commands
 from monarch.tools.commands import component_args_from_cli, server_ready
 
 from monarch.tools.config import (  # @manual=//monarch/python/monarch/tools/config/meta:defaults
+    Config,
     defaults,
 )
 from monarch.tools.mesh_spec import MeshSpec, ServerSpec
 from torchx.specs import AppDef, AppDryRunInfo, AppState, AppStatus, Role
+
+CMD_INFO = "monarch.tools.commands.info"
+CMD_CREATE = "monarch.tools.commands.create"
 
 
 class TestCommands(unittest.TestCase):
@@ -32,10 +37,12 @@ class TestCommands(unittest.TestCase):
         self.assertDictEqual({"h": "gpu.medium", "num_hosts": 4}, args)
 
     def test_create_dryrun(self) -> None:
-        config = defaults.config("slurm")
+        scheduler = "slurm"
+        config = defaults.config(scheduler)
         config.dryrun = True
+        appdef = defaults.component_fn(scheduler)()
 
-        dryrun_info = commands.create(config)()
+        dryrun_info = commands.create(config, appdef)
         # need only assert that the return type of dryrun is a dryrun info object
         # since we delegate to torchx for job submission
         self.assertIsInstance(dryrun_info, AppDryRunInfo)
@@ -45,8 +52,10 @@ class TestCommands(unittest.TestCase):
         return_value="test_job_id",
     )
     def test_create(self, mock_schedule: mock.MagicMock) -> None:
-        config = defaults.config("slurm")
-        server_handle = commands.create(config)()
+        scheduler = "slurm"
+        config = defaults.config(scheduler)
+        appdef = defaults.component_fn(scheduler)()
+        server_handle = commands.create(config, appdef)
 
         mock_schedule.assert_called_once()
         self.assertEqual(server_handle, "slurm:///test_job_id")
@@ -89,6 +98,7 @@ class TestCommands(unittest.TestCase):
         self.assertEqual(
             ServerSpec(
                 name="monarch_test_123",
+                scheduler="slurm",
                 state=appstatus.state,
                 meshes=[
                     MeshSpec(
@@ -108,7 +118,7 @@ UNUSED = "__UNUSED__"
 _5_MS = timedelta(milliseconds=5)
 
 
-def server(state: AppState) -> ServerSpec:
+def server(state: AppState, name: str = UNUSED) -> ServerSpec:
     mesh_x = MeshSpec(name="x", num_hosts=2, host_type=UNUSED, gpus=-1)
     mesh_y = MeshSpec(name="y", num_hosts=4, host_type=UNUSED, gpus=-1)
     meshes = [mesh_x, mesh_y]
@@ -117,13 +127,13 @@ def server(state: AppState) -> ServerSpec:
         for mesh in meshes:
             mesh.hostnames = [f"node{i}" for i in range(mesh.num_hosts)]
 
-    return ServerSpec(name=UNUSED, state=state, meshes=meshes)
+    return ServerSpec(name=name, scheduler="slurm", state=state, meshes=meshes)
 
 
 class TestCommandsAsync(unittest.IsolatedAsyncioTestCase):
     async def test_server_ready_server_does_not_exist(self) -> None:
         with mock.patch(
-            "monarch.tools.commands.info",
+            CMD_INFO,
             return_value=None,
         ):
             server_info = await server_ready("slurm:///123", check_interval=_5_MS)
@@ -131,7 +141,7 @@ class TestCommandsAsync(unittest.IsolatedAsyncioTestCase):
 
     async def test_server_ready_pending_to_running(self) -> None:
         with mock.patch(
-            "monarch.tools.commands.info",
+            CMD_INFO,
             side_effect=[
                 server(AppState.UNSUBMITTED),
                 server(AppState.SUBMITTED),
@@ -160,7 +170,7 @@ class TestCommandsAsync(unittest.IsolatedAsyncioTestCase):
         for terminal_state in [AppState.SUCCEEDED, AppState.FAILED, AppState.CANCELLED]:
             with self.subTest(terminal_state=terminal_state):
                 with mock.patch(
-                    "monarch.tools.commands.info",
+                    CMD_INFO,
                     side_effect=[
                         server(AppState.SUBMITTED),
                         server(AppState.PENDING),
@@ -177,3 +187,113 @@ class TestCommandsAsync(unittest.IsolatedAsyncioTestCase):
                     self.assertEqual(server_info.state, terminal_state)
                     mock_info.assert_called()
                     self.assertEqual(mock_info.call_count, 4)
+
+    @mock.patch(CMD_INFO, side_effect=[server(AppState.RUNNING, name="123")])
+    async def test_get_or_create_existing(self, mock_info: MagicMock) -> None:
+        config = Config(
+            scheduler="slurm",
+            scheduler_args={},
+        )
+        appdef = defaults.component_fn(config.scheduler)()
+        server_info = await commands.get_or_create("123", config, appdef)
+        self.assertEqual(server_info.server_handle, "slurm:///123")
+        mock_info.assert_called_once_with("slurm:///123")
+
+    async def test_get_or_create(self) -> None:
+        for existing_state in [
+            None,
+            server(AppState.FAILED, name="123"),
+            server(AppState.SUCCEEDED, name="123"),
+        ]:
+            with self.subTest(existing_state=existing_state):
+                with mock.patch(
+                    CMD_INFO,
+                    side_effect=[
+                        # -- state for slurm:///123
+                        existing_state,
+                        # -- states for (new) slurm:///456
+                        server(AppState.PENDING, name="456"),
+                        server(AppState.RUNNING, name="456"),
+                    ],
+                ) as mock_info, mock.patch(
+                    CMD_CREATE, return_value="slurm:///456"
+                ) as mock_create:
+                    config = Config(
+                        scheduler="slurm",
+                        scheduler_args={},
+                    )
+                    appdef = defaults.component_fn(config.scheduler)()
+                    server_info = await commands.get_or_create(
+                        "123",
+                        config,
+                        appdef,
+                        check_interval=_5_MS,
+                    )
+
+                    mock_create.called_once_with(config, appdef)
+                    self.assertEqual(server_info.server_handle, "slurm:///456")
+                    self.assertListEqual(
+                        mock_info.call_args_list,
+                        [
+                            mock.call("slurm:///123"),
+                            mock.call("slurm:///456"),
+                            mock.call("slurm:///456"),
+                        ],
+                    )
+
+    @mock.patch(
+        CMD_INFO,
+        side_effect=[
+            # -- slurm:///123 not found
+            None,
+            # -- states for (new) slurm:///456
+            server(AppState.PENDING, name="456"),
+            server(AppState.FAILED, name="456"),
+        ],
+    )
+    @mock.patch(CMD_CREATE, return_value="slurm:///456")
+    async def test_get_or_create_new_server_failed(
+        self,
+        _1: MagicMock,
+        _2: MagicMock,
+    ) -> None:
+        config = Config(
+            scheduler="slurm",
+            scheduler_args={},
+        )
+        appdef = defaults.component_fn(config.scheduler)()
+        with self.assertRaises(RuntimeError):
+            _ = await commands.get_or_create(
+                "123",
+                config,
+                appdef,
+                check_interval=_5_MS,
+            )
+
+    @mock.patch(
+        CMD_INFO,
+        side_effect=[
+            # -- slurm:///123 not found
+            None,
+            # -- (new) slurm:///456 goes missing
+            None,
+        ],
+    )
+    @mock.patch(CMD_CREATE, return_value="slurm:///456")
+    async def test_get_or_create_new_server_missing(
+        self,
+        _1: MagicMock,
+        _2: MagicMock,
+    ) -> None:
+        config = Config(
+            scheduler="slurm",
+            scheduler_args={},
+        )
+        appdef = defaults.component_fn(config.scheduler)()
+        with self.assertRaises(RuntimeError):
+            _ = await commands.get_or_create(
+                "123",
+                config,
+                appdef,
+                check_interval=_5_MS,
+            )

--- a/python/tests/tools/test_mesh_spec.py
+++ b/python/tests/tools/test_mesh_spec.py
@@ -172,6 +172,7 @@ class ServerSpecTest(unittest.TestCase):
     def get_test_server_spec(self) -> ServerSpec:
         return ServerSpec(
             name="monarch-foo-1a2b3c",
+            scheduler="slurm",
             state=specs.AppState.RUNNING,
             meshes=[
                 MeshSpec(name="trainer", num_hosts=4, host_type="gpu.medium", gpus=2),


### PR DESCRIPTION
Summary:
Implements `monarch.tools.commands.get_or_create("monarch-kiuk", config, appdef)`, which will:

1. check if a job called `monarch-kiuk` exists on the scheduler specified in `config.scheduler`
2. if it does waits for it to be in `RUNNING` state and return the server_spec (information about the server) struct.
3. if it does not, then create a new one using `config` (has scheduler and workspace configs) and `appdef` (aka the job definition)
4. waits for the new job to be in `RUNNING` state and return the new server_spec

Reviewed By: suo

Differential Revision: D77560753


