### PR TITLE
[monarch] remove our custom signal handlers

### DIFF
--- a/monarch_hyperactor/Cargo.toml
+++ b/monarch_hyperactor/Cargo.toml
@@ -12,6 +12,7 @@ anyhow = "1.0.98"
 async-trait = "0.1.86"
 bincode = "1.3.3"
 clap = { version = "4.5.38", features = ["derive", "env", "string", "unicode", "wrap_help"] }
+fbinit = { version = "0.2.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main" }
 hyperactor = { version = "0.0.0", path = "../hyperactor" }
 hyperactor_extension = { version = "0.0.0", path = "../hyperactor_extension" }
 hyperactor_mesh = { version = "0.0.0", path = "../hyperactor_mesh" }

--- a/monarch_hyperactor/src/bootstrap.rs
+++ b/monarch_hyperactor/src/bootstrap.rs
@@ -20,6 +20,16 @@ use pyo3::wrap_pyfunction;
 #[pyfunction]
 #[pyo3(signature = ())]
 pub fn bootstrap_main(py: Python) -> PyResult<Bound<PyAny>> {
+    // SAFETY: this is a correct use of this function.
+    let _ = unsafe {
+        fbinit::perform_init();
+    };
+    // SAFETY:
+    // - Only one of these is every created.
+    // - This is the entry point of this program, so this will be dropped when
+    // no more FB C++ code is running.
+    let destroy_guard = unsafe { fbinit::DestroyGuard::new() };
+
     hyperactor::tracing::debug!("entering async bootstrap");
     pyo3_async_runtimes::tokio::future_into_py::<_, ()>(py, async move {
         bootstrap_or_die().await;

--- a/monarch_hyperactor/src/bootstrap.rs
+++ b/monarch_hyperactor/src/bootstrap.rs
@@ -28,7 +28,7 @@ pub fn bootstrap_main(py: Python) -> PyResult<Bound<PyAny>> {
     // - Only one of these is every created.
     // - This is the entry point of this program, so this will be dropped when
     // no more FB C++ code is running.
-    let destroy_guard = unsafe { fbinit::DestroyGuard::new() };
+    let _destroy_guard = unsafe { fbinit::DestroyGuard::new() };
 
     hyperactor::tracing::debug!("entering async bootstrap");
     pyo3_async_runtimes::tokio::future_into_py::<_, ()>(py, async move {

--- a/python/monarch/bootstrap_main.py
+++ b/python/monarch/bootstrap_main.py
@@ -34,13 +34,6 @@ def invoke_main():
     # TODO: figure out what from worker_main.py we should reproduce here.
     from monarch.telemetry import TracingForwarder
 
-    try:
-        from libfb.py import pyinit
-
-        pyinit.initFacebook()
-    except ImportError:
-        logging.warning("pyinit not found, fatal signal handlers will not be installed")
-
     if os.environ.get("MONARCH_ERROR_DURING_BOOTSTRAP_FOR_TESTING") == "1":
         raise RuntimeError("Error during bootstrap for testing")
 

--- a/python/monarch/bootstrap_main.py
+++ b/python/monarch/bootstrap_main.py
@@ -34,6 +34,13 @@ def invoke_main():
     # TODO: figure out what from worker_main.py we should reproduce here.
     from monarch.telemetry import TracingForwarder
 
+    try:
+        from libfb.py import pyinit
+
+        pyinit.initFacebook()
+    except ImportError:
+        logging.warning("pyinit not found, fatal signal handlers will not be installed")
+
     if os.environ.get("MONARCH_ERROR_DURING_BOOTSTRAP_FOR_TESTING") == "1":
         raise RuntimeError("Error during bootstrap for testing")
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #385
* #406

These need to be written quite carefully as they need to be async-signal-safe (no log, no printf, no malloc). Let's just not even try, and instead rely on the standard fb implementation which has been worked over forever.

Normally `#[fbinit]` will do this on the main entry point, but because bootstrap_main is a Python entry point that we spawn via the ProcessAllocator we need to call `initFacebook` there as well.

Differential Revision: [D77565855](https://our.internmc.facebook.com/intern/diff/D77565855/)