### PR TITLE
[hyperactor] mesh: key streams off of sender only

### DIFF
--- a/hyperactor_mesh/src/comm.rs
+++ b/hyperactor_mesh/src/comm.rs
@@ -83,8 +83,8 @@ struct ReceiveState {
 pub struct CommActor {
     /// Each world will use its own seq num from this caster.
     send_seq: HashMap<Slice, usize>,
-    /// Each world/caster uses its own stream.
-    recv_state: HashMap<(Slice, ActorId), ReceiveState>,
+    /// Each sender is a unique stream.
+    recv_state: HashMap<ActorId, ReceiveState>,
 
     /// The comm actor's mode.
     mode: CommActorMode,
@@ -346,7 +346,7 @@ impl Handler<ForwardMessage> for CommActor {
                 panic!("Choice encountered in CommActor routing")
             })?;
 
-        let recv_state = self.recv_state.entry((slice, sender.clone())).or_default();
+        let recv_state = self.recv_state.entry(sender.clone()).or_default();
         match recv_state.seq.cmp(&last_seq) {
             // We got the expected next message to deliver to this host.
             Ordering::Equal => {

--- a/ndslice/src/selection/routing.rs
+++ b/ndslice/src/selection/routing.rs
@@ -421,7 +421,7 @@ impl RoutingFrame {
                 }
 
                 use rand::Rng;
-                let mut rng = rand::thread_rng();
+                let mut rng: rand::prelude::ThreadRng = rand::thread_rng();
                 let i = rng.gen_range(0..size);
                 let mut coord = self.here.clone();
                 coord[self.dim] = i;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #397

Each stream was previously associated with `(sender, <shape of mesh>)`, the shape being a stand-in for the mesh itself. In practice, each proc is reachable through exactly one mesh, so this is unnecessary.

This change simplifies this to just the sender.

In the future, we'll likely want to support multiple sessions per sender (e.g., for persistent meshes), but that is a straightforward addition we can make as needed.

Differential Revision: [D77609169](https://our.internmc.facebook.com/intern/diff/D77609169/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D77609169/)!