### PR TITLE
(9/n - non-xlformers conda-on-mast mvp)(monarch/tools) add conda util functions in monarch.tools.utils

### DIFF
--- a/python/monarch/tools/utils.py
+++ b/python/monarch/tools/utils.py
@@ -1,0 +1,38 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+import os
+from typing import Optional
+
+
+class conda:
+    """Conda related util functions."""
+
+    @staticmethod
+    def active_env_dir() -> Optional[str]:
+        """
+        Returns the currently active conda environment's directory.
+        `None` if run outside of a conda environment.
+        """
+        return os.getenv("CONDA_PREFIX")
+
+    @staticmethod
+    def active_env_name() -> Optional[str]:
+        """
+        Returns the currently active conda environment name.
+        `None` if run outside of a conda environment.
+        """
+        env_name = os.getenv("CONDA_DEFAULT_ENV")
+
+        if not env_name:
+            # conda envs activated with metaconda doesn't set CODNA_DEFAULT_ENV so
+            # fallback to CONDA_PREFIX which points to the path of the currently active conda environment
+            # e.g./home/$USER/.conda/envs/{env_name}
+            if env_dir := conda.active_env_dir():
+                env_name = os.path.basename(env_dir)
+
+        return env_name

--- a/python/tests/tools/test_utils.py
+++ b/python/tests/tools/test_utils.py
@@ -1,0 +1,35 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+import os
+import unittest
+from unittest import mock
+
+from monarch.tools.utils import conda
+
+
+class TestCondaUtils(unittest.TestCase):
+    def test_conda_active_env_name(self) -> None:
+        with mock.patch.dict(os.environ, {"CONDA_DEFAULT_ENV": "foo-py3"}, clear=True):
+            self.assertEqual(conda.active_env_name(), "foo-py3")
+
+        with mock.patch.dict(
+            os.environ, {"CONDA_PREFIX": "/home/USER/.conda/envs/bar-py3"}, clear=True
+        ):
+            self.assertEqual(conda.active_env_name(), "bar-py3")
+
+        with mock.patch.dict(os.environ, {}, clear=True):
+            self.assertIsNone(conda.active_env_name())
+
+    def test_conda_active_env_dir(self) -> None:
+        with mock.patch.dict(
+            os.environ, {"CONDA_PREFIX": "/home/USER/.conda/envs/foo"}, clear=True
+        ):
+            self.assertEqual(conda.active_env_dir(), "/home/USER/.conda/envs/foo")
+
+        with mock.patch.dict(os.environ, {}, clear=True):
+            self.assertIsNone(conda.active_env_dir())


### PR DESCRIPTION
Summary: adds `conda.active_env_name()` and `conda.active_env_dir()` util functions to `monarch.tools.utils`

Differential Revision: D77615227


