### PR TITLE
Support single asyncio runtime for python actors

### DIFF
--- a/monarch_hyperactor/Cargo.toml
+++ b/monarch_hyperactor/Cargo.toml
@@ -12,6 +12,7 @@ anyhow = "1.0.98"
 async-trait = "0.1.86"
 bincode = "1.3.3"
 clap = { version = "4.5.38", features = ["derive", "env", "string", "unicode", "wrap_help"] }
+erased-serde = "0.3.27"
 fbinit = { version = "0.2.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main" }
 hyperactor = { version = "0.0.0", path = "../hyperactor" }
 hyperactor_extension = { version = "0.0.0", path = "../hyperactor_extension" }

--- a/monarch_hyperactor/src/config.rs
+++ b/monarch_hyperactor/src/config.rs
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+//! Configuration for Monarch Hyperactor.
+//!
+//! This module provides monarch-specific configuration attributes that extend
+//! the base hyperactor configuration system.
+
+use hyperactor::attrs::declare_attrs;
+
+// Declare monarch-specific configuration keys
+declare_attrs! {
+    /// Use a single asyncio runtime for all Python actors, rather than one per actor
+    pub attr SHARED_ASYNCIO_RUNTIME: bool = false;
+}

--- a/monarch_hyperactor/src/lib.rs
+++ b/monarch_hyperactor/src/lib.rs
@@ -13,6 +13,7 @@ pub mod actor_mesh;
 pub mod alloc;
 pub mod bootstrap;
 pub mod channel;
+pub mod config;
 pub mod mailbox;
 pub mod ndslice;
 pub mod proc;


### PR DESCRIPTION
Summary:
Support two asyncio runtime modes in monarch-hyperactor:
* shared asyncio event loop
* per-actor async event loop (default)

This lets us scale past ~1000 Python actors with the LocalAllocator since each actor can run on a shared thread.
exported-using-ghexport

Differential Revision: D77636974
