### PR TITLE
[hyperactor] fix bug in maybe_unlink_parent

### DIFF
--- a/hyperactor/src/proc.rs
+++ b/hyperactor/src/proc.rs
@@ -1345,17 +1345,15 @@ impl InstanceState {
     /// Unlink this instance from its parent, if it has one. If it was unlinked,
     /// the parent is returned.
     fn maybe_unlink_parent(&self) -> Option<InstanceCell> {
-        let result = self.parent.upgrade();
-        if let Some(parent) = &result {
-            parent.inner.unlink(self);
-        }
-        result
+        self.parent
+            .upgrade()
+            .filter(|parent| parent.inner.unlink(self))
     }
 
     /// Unlink this instance from a child.
-    fn unlink(&self, child: &InstanceState) {
+    fn unlink(&self, child: &InstanceState) -> bool {
         assert_eq!(self.actor_id.proc_id(), child.actor_id.proc_id());
-        self.children.remove(&child.actor_id.pid());
+        self.children.remove(&child.actor_id.pid()).is_some()
     }
 }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #420

It was meant to return the parent only when it was actually unlinked.

Happily, the net effect of this bug was that we printed spurious "instances was dropped while parent was linked".

Differential Revision: [D77705185](https://our.internmc.facebook.com/intern/diff/D77705185/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D77705185/)!