### PR TITLE
[monarch] heartbeat in child processes to ensure cleanup

### DIFF
--- a/hyperactor_mesh/src/alloc/process.rs
+++ b/hyperactor_mesh/src/alloc/process.rs
@@ -331,12 +331,6 @@ impl ProcessAlloc {
         cmd.stdout(Stdio::piped());
         cmd.stderr(Stdio::piped());
 
-        // Opt-in to signal handling (`PR_SET_PDEATHSIG`) so that the
-        // spawned subprocess will automatically exit when the parent
-        // process dies.
-        // TODO: Use hyperactor::config::global::MANAGED_SUBPROCESS_ENV once it's defined
-        cmd.env("HYPERACTOR_MANAGED_SUBPROCESS", "1");
-
         let proc_id = ProcId(WorldId(self.name.to_string()), index);
         tracing::debug!("Spawning process {:?}", cmd);
         match cmd.spawn() {
@@ -429,6 +423,9 @@ impl Alloc for ProcessAlloc {
                                 mesh_agent,
                                 addr,
                             });
+                        }
+                        Process2AllocatorMessage::Heartbeat => {
+                            tracing::debug!("recv heartbeat from {index}");
                         }
                     }
                 },

--- a/hyperactor_mesh/src/bootstrap.rs
+++ b/hyperactor_mesh/src/bootstrap.rs
@@ -16,6 +16,8 @@ use hyperactor::channel::ChannelAddr;
 use hyperactor::channel::ChannelTransport;
 use hyperactor::channel::Rx;
 use hyperactor::channel::Tx;
+use hyperactor::clock::Clock;
+use hyperactor::clock::RealClock;
 use hyperactor::mailbox::MailboxServer;
 use serde::Deserialize;
 use serde::Serialize;
@@ -44,6 +46,8 @@ pub(crate) enum Process2AllocatorMessage {
     /// after instruction by the allocator through the corresponding
     /// [`Allocator2Process`] message.
     StartedProc(ProcId, ActorRef<MeshAgent>, ChannelAddr),
+
+    Heartbeat,
 }
 
 /// Messages sent from the allocator to a process.
@@ -60,6 +64,43 @@ pub(crate) enum Allocator2Process {
     /// A request for the process to immediately exit with the provided
     /// exit code
     Exit(i32),
+}
+
+async fn heartbeat_task(bootstrap_index: usize, bootstrap_addr: ChannelAddr) {
+    let tx = match channel::dial(bootstrap_addr.clone()) {
+        Ok(tx) => tx,
+
+        Err(err) => {
+            tracing::error!(
+                "Failed to establish heartbeat connection to allocator, exiting! (addr: {:?}): {}",
+                bootstrap_addr,
+                err
+            );
+            std::process::exit(1);
+        }
+    };
+    tracing::info!(
+        "Heartbeat connection established to allocator (idx: {bootstrap_index}, addr: {bootstrap_addr:?})",
+    );
+    loop {
+        RealClock.sleep(Duration::from_secs(5)).await;
+
+        let result = tx
+            .send(Process2Allocator(
+                bootstrap_index,
+                Process2AllocatorMessage::Heartbeat,
+            ))
+            .await;
+
+        if let Err(err) = result {
+            tracing::error!(
+                "Heartbeat failed to allocator, exiting! (addr: {:?}): {}",
+                bootstrap_addr,
+                err
+            );
+            std::process::exit(1);
+        }
+    }
 }
 
 /// Entry point to processes managed by hyperactor_mesh. This advertises the process
@@ -86,15 +127,15 @@ pub async fn bootstrap() -> anyhow::Error {
             .parse()?;
         let listen_addr = ChannelAddr::any(bootstrap_addr.transport());
         let (serve_addr, mut rx) = channel::serve(listen_addr).await?;
-        let tx = channel::dial(bootstrap_addr)?;
+        let tx = channel::dial(bootstrap_addr.clone())?;
 
-        {
-            tx.send(Process2Allocator(
-                bootstrap_index,
-                Process2AllocatorMessage::Hello(serve_addr),
-            ))
-            .await?;
-        }
+        tx.send(Process2Allocator(
+            bootstrap_index,
+            Process2AllocatorMessage::Hello(serve_addr),
+        ))
+        .await?;
+
+        tokio::spawn(heartbeat_task(bootstrap_index, bootstrap_addr));
 
         let mut procs = Vec::new();
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #435

In D77392241, I removed the signal-based cleanup mechanism. The assumption there was that the `rx.recv()` in `bootstrap.rs` would throw an error if the other side hung up, and the error would bubble up and eventually abort the child process.

This assumption is wrong; `rx.recv()` has server-like semantics, not channel-like (which makes sense; there could be many senders, so any individual one disappearing should not abort the receiver!).

But as a result, we were not cleaning up properly if the parent process exited, child processes would just hang around forever. The test added in D77348271 *happened* to pass, because we sent `SIGKILL` to the parent process, triggering unclean shutdown which *will* cause a error on the receiver side . However, a *graceful* shutdown (e.g. from an uncaught Python exception) will not.

A quick solution is to add a simple heartbeat task and kill the process if it fails.

Differential Revision: [D77802426](https://our.internmc.facebook.com/intern/diff/D77802426/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D77802426/)!