### PR TITLE
(10/n - non-xlformers conda-on-mast mvp)(monarch-fb/BUCK) Include torchx-fb as part of monarch.whl

### DIFF
--- a/python/monarch/__init__.py
+++ b/python/monarch/__init__.py
@@ -135,7 +135,7 @@ def __getattr__(name):
 try:
     from __manifest__ import fbmake  # noqa
 
-    IN_PAR = True
+    IN_PAR = bool(fbmake.get("par_style"))
 except ImportError:
     IN_PAR = False
 

--- a/python/monarch/_src/actor/actor_mesh.py
+++ b/python/monarch/_src/actor/actor_mesh.py
@@ -86,7 +86,7 @@ Allocator = ProcessAllocator | LocalAllocator
 try:
     from __manifest__ import fbmake  # noqa
 
-    IN_PAR = True
+    IN_PAR = bool(fbmake.get("par_style"))
 except ImportError:
     IN_PAR = False
 

--- a/python/monarch/_src/actor/proc_mesh.py
+++ b/python/monarch/_src/actor/proc_mesh.py
@@ -76,7 +76,7 @@ T = TypeVar("T")
 try:
     from __manifest__ import fbmake  # noqa
 
-    IN_PAR = True
+    IN_PAR = bool(fbmake.get("par_style"))
 except ImportError:
     IN_PAR = False
 

--- a/python/monarch/rust_local_mesh.py
+++ b/python/monarch/rust_local_mesh.py
@@ -71,7 +71,7 @@ _MONARCH_TENSOR_WORKER_MAIN = "monarch.tensor_worker_main"
 try:
     from __manifest__ import fbmake  # noqa
 
-    IN_PAR = True
+    IN_PAR = bool(fbmake.get("par_style"))
 except ImportError:
     IN_PAR = False
 

--- a/python/monarch/tools/commands.py
+++ b/python/monarch/tools/commands.py
@@ -7,7 +7,6 @@
 # pyre-strict
 
 import argparse
-import functools
 import inspect
 import logging
 import os
@@ -21,7 +20,7 @@ from monarch.tools.config import (  # @manual=//monarch/python/monarch/tools/con
 )
 
 from monarch.tools.mesh_spec import mesh_spec_from_metadata, ServerSpec
-from torchx.runner import Runner
+from torchx.runner import Runner  # @manual=//torchx/runner:lib_core
 from torchx.specs import AppDef, AppDryRunInfo, AppState, CfgVal, parse_app_handle
 from torchx.specs.builders import parse_args
 from torchx.util.types import decode, decode_optional

--- a/python/monarch_supervisor/python_executable.py
+++ b/python/monarch_supervisor/python_executable.py
@@ -11,7 +11,10 @@ import sys
 try:
     from __manifest__ import fbmake  # noqa
 
-    IN_PAR = True
+    # simply checking for the existence of __manifest__ is not enough to tell if we are in a PAR
+    # because monarch wheels include a dummy __manifest__ (see fbcode//monarch/python/monarch/session/meta/__manifest__.py)
+    # so that we can use libfb programmatically. Hence additionally check if the `par_style` key is not null/empty
+    IN_PAR = bool(fbmake.get("par_style"))
 except ImportError:
     IN_PAR = False
 


### PR DESCRIPTION
Summary:
To bundle torchx-fb (with internal plugins such as being able to launch on MAST) build the wheel with:

```
buck build @//mode/opt --show-full-simple-output --config monarch_whl.include=torchx //monarch/python/monarch:monarch.whl
```

To install:

```
pip install --force-reinstall --no-deps $(BUILD_CMD_ABOVE)
```

WARNING: monarch + torchx doesn't work yet! this is why it is behind the `--config monarch_whl.include=torchx`! I'm landing this so that others can repro the error and I can get help fixing it.

## Repro Instructions:

```
$ $HOME/fbsource/genai/xlformers/dev/xl_conda.sh xlformers_finetune_conda:stable

$ cd ~/fbsource/fbcode

$ pip install --force-reinstall --no-deps $(buck build @//mode/opt --show-full-simple-output --config monarch_whl.include=torchx //monarch/python/monarch:monarch.whl)

$ cd ~/fbsource/fbcode/scripts/kiuk/examples/monarch_conda
$ python main.py 
```

should fail with 

```
import monarch._rust_bindings
ImportError: /home/kiuk/.fbpkg_conda_envs/xlformers_finetune_conda-9648802/lib/python3.10/site-packages/monarch/../monarch/lib/libomnibus.so: undefined symbol: __kmpc_fork_call
```

Reviewed By: highker

Differential Revision: D77411375


