### PR TITLE
Fix owned read guard bug

### DIFF
--- a/preempt_rwlock/Cargo.toml
+++ b/preempt_rwlock/Cargo.toml
@@ -12,3 +12,4 @@ tokio = { version = "1.45.0", features = ["full", "test-util", "tracing"] }
 
 [dev-dependencies]
 anyhow = "1.0.98"
+futures = { version = "0.3.30", features = ["async-await", "compat"] }


### PR DESCRIPTION
Summary:
Make sure `OwnedPreemptibleRwLockReadGuard` holds a reference
to the original lock, to prevent it from prematurely getting dropped
(just as `OwnedRwLockReadGuard` does).

Differential Revision: D77910522


