### PR TITLE
increase timeout limit for test-cuda GH workflow

### DIFF
--- a/.github/workflows/test-cuda.yml
+++ b/.github/workflows/test-cuda.yml
@@ -26,7 +26,7 @@ jobs:
             gpu-arch-type: "cuda"
             gpu-arch-version: "12.6"
     with:
-      timeout: 60
+      timeout: 120
       runner: ${{ matrix.runs-on }}
       gpu-arch-type: ${{ matrix.gpu-arch-type }}
       gpu-arch-version: ${{ matrix.gpu-arch-version }}


### PR DESCRIPTION
Summary: https://fb.workplace.com/groups/4571909969591489/permalink/24026214373734425/ indicates that the `test-cuda` workflow timed out. So this diff tries to increase the timeout limit.

Reviewed By: suo

Differential Revision: D78024763


