### PR TITLE
[14/n] tensor engine {handle_cast, handle} -> handle

### DIFF
--- a/hyperactor_mesh/src/actor_mesh.rs
+++ b/hyperactor_mesh/src/actor_mesh.rs
@@ -451,7 +451,7 @@ pub(crate) mod test_util {
             cx: &Context<Self>,
             GetRank(ok, reply): GetRank,
         ) -> Result<(), anyhow::Error> {
-            let (rank, _) = cx.cast_info()?;
+            let (rank, _) = cx.cast_info();
             reply.send(cx, rank)?;
             anyhow::ensure!(ok, "intentional error!"); // If `!ok` exit with `Err()`.
             Ok(())

--- a/hyperactor_mesh/src/comm/multicast.rs
+++ b/hyperactor_mesh/src/comm/multicast.rs
@@ -196,32 +196,20 @@ pub fn set_cast_info_on_headers(headers: &mut Attrs, rank: usize, shape: Shape, 
 }
 
 pub trait CastInfo {
-    /// Get the cast rank and cast shape, returning an error
-    /// if the relevant info isn't available.
-    fn cast_info(&self) -> anyhow::Result<(usize, Shape)>;
-
-    /// Get the cast rank and cast shape, returning None
-    /// if the relevant info isn't available.
-    fn maybe_cast_info(&self) -> Option<(usize, Shape)>;
+    /// Get the cast rank and cast shape.
+    /// If something wasn't explicitly sent via a cast, then
+    /// we represent it as the only member of a 0-dimensonal cast shape,
+    /// which is the same as a singleton.
+    fn cast_info(&self) -> (usize, Shape);
 }
 
 impl<A: Actor> CastInfo for Context<'_, A> {
-    fn cast_info(&self) -> anyhow::Result<(usize, Shape)> {
+    fn cast_info(&self) -> (usize, Shape) {
         let headers = self.headers();
-        let rank = headers
-            .get(CAST_RANK)
-            .ok_or_else(|| anyhow::anyhow!("{} not found in headers", CAST_RANK.name()))?;
-        let shape = headers
-            .get(CAST_SHAPE)
-            .ok_or_else(|| anyhow::anyhow!("{} not found in headers", CAST_SHAPE.name()))?
-            .clone();
-        Ok((*rank, shape))
-    }
-
-    fn maybe_cast_info(&self) -> Option<(usize, Shape)> {
-        let headers = self.headers();
-        headers
-            .get(CAST_RANK)
-            .map(|rank| headers.get(CAST_SHAPE).map(|shape| (*rank, shape.clone())))?
+        match (headers.get(CAST_RANK), headers.get(CAST_SHAPE)) {
+            (Some(rank), Some(shape)) => (*rank, shape.clone()),
+            (None, None) => (0, Shape::unity()),
+            _ => panic!("Expected either both rank and shape or neither"),
+        }
     }
 }

--- a/monarch_tensor_worker/src/lib.rs
+++ b/monarch_tensor_worker/src/lib.rs
@@ -266,7 +266,7 @@ impl Handler<AssignRankMessage> for WorkerActor {
         cx: &hyperactor::Context<Self>,
         _: AssignRankMessage,
     ) -> anyhow::Result<()> {
-        let (rank, shape) = cx.cast_info()?;
+        let (rank, shape) = cx.cast_info();
         self.rank = rank;
         self.respond_with_python_message = true;
         Python::with_gil(|py| {

--- a/python/monarch/_rust_bindings/monarch_hyperactor/actor.pyi
+++ b/python/monarch/_rust_bindings/monarch_hyperactor/actor.pyi
@@ -179,9 +179,6 @@ class PanicFlag:
 
 class Actor(Protocol):
     async def handle(
-        self, mailbox: Mailbox, message: PythonMessage, panic_flag: PanicFlag
-    ) -> None: ...
-    async def handle_cast(
         self,
         mailbox: Mailbox,
         rank: int,

--- a/python/monarch/_src/actor/actor_mesh.py
+++ b/python/monarch/_src/actor/actor_mesh.py
@@ -571,11 +571,6 @@ class _Actor:
         self.instance: object | None = None
 
     async def handle(
-        self, mailbox: Mailbox, message: PythonMessage, panic_flag: PanicFlag
-    ) -> None:
-        return await self.handle_cast(mailbox, 0, singleton_shape, message, panic_flag)
-
-    async def handle_cast(
         self,
         mailbox: Mailbox,
         rank: int,

--- a/python/tests/_monarch/test_hyperactor.py
+++ b/python/tests/_monarch/test_hyperactor.py
@@ -27,11 +27,6 @@ from monarch._rust_bindings.monarch_hyperactor.shape import Shape
 
 class MyActor:
     async def handle(
-        self, mailbox: Mailbox, message: PythonMessage, panic_flag: PanicFlag
-    ) -> None:
-        raise NotImplementedError()
-
-    async def handle_cast(
         self,
         mailbox: Mailbox,
         rank: int,

--- a/python/tests/_monarch/test_mailbox.py
+++ b/python/tests/_monarch/test_mailbox.py
@@ -121,11 +121,6 @@ async def test_accumulator() -> None:
 
 class MyActor:
     async def handle(
-        self, mailbox: Mailbox, message: PythonMessage, panic_flag: PanicFlag
-    ) -> None:
-        return None
-
-    async def handle_cast(
         self,
         mailbox: Mailbox,
         rank: int,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #484
* #478

We unified the message handling logic in rust, so we can keep that unification for the python bindings. We keep the handle_cast variant, rename it handle.

We provide a definition for cast coordinates even when a message wasn't cast: the message is considered to be the  rank of a zero dimension shape.

Differential Revision: [D78061501](https://our.internmc.facebook.com/intern/diff/D78061501/)