### PR TITLE
[14/n] tensor engine {handle_cast, handle} -> handle

### DIFF
--- a/hyperactor_mesh/examples/dining_philosophers.rs
+++ b/hyperactor_mesh/examples/dining_philosophers.rs
@@ -142,7 +142,7 @@ impl Handler<PhilosopherMessage> for PhilosopherActor {
         cx: &Context<Self>,
         message: PhilosopherMessage,
     ) -> Result<(), anyhow::Error> {
-        let (rank, _) = cx.cast_info()?;
+        let (rank, _) = cx.cast_info();
         self.rank = rank;
         match message {
             PhilosopherMessage::Start(waiter) => {

--- a/hyperactor_mesh/src/actor_mesh.rs
+++ b/hyperactor_mesh/src/actor_mesh.rs
@@ -441,7 +441,7 @@ pub(crate) mod test_util {
             cx: &Context<Self>,
             GetRank(ok, reply): GetRank,
         ) -> Result<(), anyhow::Error> {
-            let (rank, _) = cx.cast_info()?;
+            let (rank, _) = cx.cast_info();
             reply.send(cx, rank)?;
             anyhow::ensure!(ok, "intentional error!"); // If `!ok` exit with `Err()`.
             Ok(())

--- a/monarch_rdma/examples/parameter_server.rs
+++ b/monarch_rdma/examples/parameter_server.rs
@@ -303,7 +303,7 @@ impl Handler<WorkerInit> for WorkerActor {
         cx: &Context<Self>,
         WorkerInit(ps_ref, rdma_managers): WorkerInit,
     ) -> Result<(), anyhow::Error> {
-        let (rank, _) = cx.cast_info()?;
+        let (rank, _) = cx.cast_info();
 
         println!("[worker_actor_{}] initializing", rank);
 
@@ -336,7 +336,7 @@ impl Handler<WorkerStep> for WorkerActor {
         cx: &Context<Self>,
         WorkerStep(reply): WorkerStep,
     ) -> Result<(), anyhow::Error> {
-        let (rank, _) = cx.cast_info()?;
+        let (rank, _) = cx.cast_info();
 
         for (grad_value, weight) in self
             .local_gradients
@@ -385,7 +385,7 @@ impl Handler<WorkerUpdate> for WorkerActor {
         cx: &Context<Self>,
         WorkerUpdate(reply): WorkerUpdate,
     ) -> Result<(), anyhow::Error> {
-        let (rank, _) = cx.cast_info()?;
+        let (rank, _) = cx.cast_info();
 
         println!(
             "[worker_actor_{}] pulling new weights from parameter server (before: {:?})",
@@ -418,7 +418,7 @@ impl Handler<WorkerUpdate> for WorkerActor {
 impl Handler<Log> for WorkerActor {
     /// Logs the worker's weights
     async fn handle(&mut self, cx: &Context<Self>, _: Log) -> Result<(), anyhow::Error> {
-        let (rank, _) = cx.cast_info()?;
+        let (rank, _) = cx.cast_info();
         println!("[worker_actor_{}] weights: {:?}", rank, self.weights_data);
         Ok(())
     }

--- a/monarch_tensor_worker/src/lib.rs
+++ b/monarch_tensor_worker/src/lib.rs
@@ -266,7 +266,7 @@ impl Handler<AssignRankMessage> for WorkerActor {
         cx: &hyperactor::Context<Self>,
         _: AssignRankMessage,
     ) -> anyhow::Result<()> {
-        let (rank, shape) = cx.cast_info()?;
+        let (rank, shape) = cx.cast_info();
         self.rank = rank;
         self.respond_with_python_message = true;
         Python::with_gil(|py| {

--- a/python/monarch/_rust_bindings/monarch_hyperactor/actor.pyi
+++ b/python/monarch/_rust_bindings/monarch_hyperactor/actor.pyi
@@ -179,9 +179,6 @@ class PanicFlag:
 
 class Actor(Protocol):
     async def handle(
-        self, mailbox: Mailbox, message: PythonMessage, panic_flag: PanicFlag
-    ) -> None: ...
-    async def handle_cast(
         self,
         mailbox: Mailbox,
         rank: int,

--- a/python/monarch/_src/actor/actor_mesh.py
+++ b/python/monarch/_src/actor/actor_mesh.py
@@ -580,11 +580,6 @@ class _Actor:
         self.instance: object | None = None
 
     async def handle(
-        self, mailbox: Mailbox, message: PythonMessage, panic_flag: PanicFlag
-    ) -> None:
-        return await self.handle_cast(mailbox, 0, singleton_shape, message, panic_flag)
-
-    async def handle_cast(
         self,
         mailbox: Mailbox,
         rank: int,

--- a/python/tests/_monarch/test_hyperactor.py
+++ b/python/tests/_monarch/test_hyperactor.py
@@ -27,11 +27,6 @@ from monarch._rust_bindings.monarch_hyperactor.shape import Shape
 
 class MyActor:
     async def handle(
-        self, mailbox: Mailbox, message: PythonMessage, panic_flag: PanicFlag
-    ) -> None:
-        raise NotImplementedError()
-
-    async def handle_cast(
         self,
         mailbox: Mailbox,
         rank: int,

--- a/python/tests/_monarch/test_mailbox.py
+++ b/python/tests/_monarch/test_mailbox.py
@@ -118,11 +118,6 @@ async def test_accumulator() -> None:
 
 class MyActor:
     async def handle(
-        self, mailbox: Mailbox, message: PythonMessage, panic_flag: PanicFlag
-    ) -> None:
-        return None
-
-    async def handle_cast(
         self,
         mailbox: Mailbox,
         rank: int,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #497
* #496

We unified the message handling logic in rust, so we can keep that unification for the python bindings. We keep the handle_cast variant, rename it handle.

We provide a definition for cast coordinates even when a message wasn't cast: the message is considered to be the  rank of a zero dimension shape.

Differential Revision: [D78061501](https://our.internmc.facebook.com/intern/diff/D78061501/)