### PR TITLE
[13/n] tensor engine, free functions implement call/broadcast/stream/etc., temp

### DIFF
--- a/python/monarch/_rust_bindings/monarch_hyperactor/shape.pyi
+++ b/python/monarch/_rust_bindings/monarch_hyperactor/shape.pyi
@@ -5,7 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import collections.abc
-from typing import Dict, final, Iterator, List, overload
+from typing import Dict, final, Iterator, List, overload, Sequence
 
 @final
 class Slice:
@@ -90,7 +90,7 @@ class Slice:
         ...
 
     @staticmethod
-    def new_row_major(ranks: list[int]) -> "Slice":
+    def new_row_major(ranks: Sequence[int]) -> "Slice":
         """Returns a contiguous slice composed of ranks"""
         ...
 
@@ -106,7 +106,7 @@ class Shape:
     - `labels`: A list of strings representing the labels for each dimension.
     - `slice`: An Slice object representing the shape.
     """
-    def __new__(cls, labels: List[str], slice: Slice) -> "Shape": ...
+    def __new__(cls, labels: Sequence[str], slice: Slice) -> "Shape": ...
     @property
     def ndslice(self) -> Slice: ...
     @property

--- a/python/monarch/_src/actor/actor_mesh.py
+++ b/python/monarch/_src/actor/actor_mesh.py
@@ -15,7 +15,10 @@ import random
 import sys
 import traceback
 
+from abc import ABC, abstractmethod
+
 from dataclasses import dataclass
+from operator import mul
 from traceback import extract_tb, StackSummary
 from typing import (
     Any,
@@ -27,11 +30,13 @@ from typing import (
     Dict,
     Generic,
     Iterable,
+    Iterator,
     List,
     Literal,
     NamedTuple,
     Optional,
     ParamSpec,
+    Sequence,
     Tuple,
     Type,
     TYPE_CHECKING,
@@ -204,18 +209,41 @@ class _ActorMeshRefImpl:
         return len(self._shape)
 
 
-class Endpoint(Generic[P, R]):
-    def __init__(
+class Extent(NamedTuple):
+    labels: Sequence[str]
+    sizes: Sequence[int]
+
+    @property
+    def nelements(self) -> int:
+        return functools.reduce(mul, self.sizes, 1)
+
+    def __str__(self) -> str:
+        return str(dict(zip(self.labels, self.sizes)))
+
+
+class Endpoint(ABC, Generic[P, R]):
+    @abstractmethod
+    def _send(
         self,
-        actor_mesh_ref: _ActorMeshRefImpl,
-        name: str,
-        impl: Callable[Concatenate[Any, P], Awaitable[R]],
-        mailbox: Mailbox,
-    ) -> None:
-        self._actor_mesh = actor_mesh_ref
-        self._name = name
-        self._signature: inspect.Signature = inspect.signature(impl)
-        self._mailbox = mailbox
+        args: Tuple[Any, ...],
+        kwargs: Dict[str, Any],
+        port: "Optional[Port]" = None,
+        selection: Selection = "all",
+    ) -> Extent:
+        """
+        Implements sending a message to the endpoint. The return value of the endpoint will
+        be sent to port if provided. If port is not provided, the return will be dropped,
+        and any exception will cause the actor to fail.
+
+        The return value is the (multi-dimension) size of the actors that were sent a message.
+        For ActorEndpoints this will be the actor_meshes size. For free-function endpoints,
+        this will be the size of the currently active proc_mesh.
+        """
+        pass
+
+    @abstractmethod
+    def _port(self, once: bool = False) -> "PortTuple[R]":
+        pass
 
     # the following are all 'adverbs' or different ways to handle the
     # return values of this endpoint. Adverbs should only ever take *args, **kwargs
@@ -228,46 +256,47 @@ class Endpoint(Generic[P, R]):
 
         Load balanced RPC-style entrypoint for request/response messaging.
         """
-        p: Port[R]
-        r: PortReceiver[R]
         p, r = port(self, once=True)
         # pyre-ignore
-        send(self, args, kwargs, port=p, selection="choose")
+        self._send(args, kwargs, port=p, selection="choose")
         return r.recv()
 
     def call_one(self, *args: P.args, **kwargs: P.kwargs) -> Future[R]:
-        if len(self._actor_mesh) != 1:
+        p, r = port(self, once=True)
+        # pyre-ignore
+        extent = self._send(args, kwargs, port=p, selection="choose")
+        if extent.nelements != 1:
             raise ValueError(
-                f"Can only use 'call_one' on a single Actor but this actor has shape {self._actor_mesh._shape}"
+                f"Can only use 'call_one' on a single Actor but this actor has shape {extent}"
             )
-        return self.choose(*args, **kwargs)
+        return r.recv()
 
     def call(self, *args: P.args, **kwargs: P.kwargs) -> "Future[ValueMesh[R]]":
         p: Port[R]
         r: RankedPortReceiver[R]
         p, r = ranked_port(self)
         # pyre-ignore
-        send(self, args, kwargs, port=p)
+        extent = self._send(args, kwargs, port=p)
 
         async def process() -> ValueMesh[R]:
-            results: List[R] = [None] * len(self._actor_mesh)  # pyre-fixme[9]
-            for _ in range(len(self._actor_mesh)):
+            results: List[R] = [None] * extent.nelements  # pyre-fixme[9]
+            for _ in range(extent.nelements):
                 rank, value = await r.recv()
                 results[rank] = value
             call_shape = Shape(
-                self._actor_mesh._shape.labels,
-                NDSlice.new_row_major(self._actor_mesh._shape.ndslice.sizes),
+                extent.labels,
+                NDSlice.new_row_major(extent.sizes),
             )
             return ValueMesh(call_shape, results)
 
         def process_blocking() -> ValueMesh[R]:
-            results: List[R] = [None] * len(self._actor_mesh)  # pyre-fixme[9]
-            for _ in range(len(self._actor_mesh)):
+            results: List[R] = [None] * extent.nelements  # pyre-fixme[9]
+            for _ in range(extent.nelements):
                 rank, value = r.recv().get()
                 results[rank] = value
             call_shape = Shape(
-                self._actor_mesh._shape.labels,
-                NDSlice.new_row_major(self._actor_mesh._shape.ndslice.sizes),
+                extent.labels,
+                NDSlice.new_row_major(extent.sizes),
             )
             return ValueMesh(call_shape, results)
 
@@ -282,8 +311,8 @@ class Endpoint(Generic[P, R]):
         """
         p, r = port(self)
         # pyre-ignore
-        send(self, args, kwargs, port=p)
-        for _ in range(len(self._actor_mesh)):
+        extent = self._send(args, kwargs, port=p)
+        for _ in range(extent.nelements):
             yield await r.recv()
 
     def broadcast(self, *args: P.args, **kwargs: P.kwargs) -> None:
@@ -296,6 +325,46 @@ class Endpoint(Generic[P, R]):
         """
         # pyre-ignore
         send(self, args, kwargs)
+
+
+class ActorEndpoint(Endpoint[P, R]):
+    def __init__(
+        self,
+        actor_mesh_ref: _ActorMeshRefImpl,
+        name: str,
+        impl: Callable[Concatenate[Any, P], Awaitable[R]],
+        mailbox: Mailbox,
+    ) -> None:
+        self._actor_mesh = actor_mesh_ref
+        self._name = name
+        self._signature: inspect.Signature = inspect.signature(impl)
+        self._mailbox = mailbox
+
+    def _send(
+        self,
+        args: Tuple[Any, ...],
+        kwargs: Dict[str, Any],
+        port: "Optional[Port]" = None,
+        selection: Selection = "all",
+    ) -> Extent:
+        """
+        Fire-and-forget broadcast invocation of the endpoint across all actors in the mesh.
+
+        This sends the message to all actors but does not wait for any result.
+        """
+        self._signature.bind(None, *args, **kwargs)
+        message = PythonMessage(
+            self._name,
+            _pickle((args, kwargs)),
+            None if port is None else port._port_ref,
+            None,
+        )
+        self._actor_mesh.cast(message, selection)
+        shape = self._actor_mesh._shape
+        return Extent(shape.labels, shape.ndslice.sizes)
+
+    def _port(self, once: bool = False) -> "PortTuple[R]":
+        return PortTuple.create(self._mailbox, once)
 
 
 class Accumulator(Generic[P, R, A]):
@@ -337,9 +406,12 @@ class ValueMesh(MeshTrait, Generic[R]):
 
         return self._values[self._ndslice.nditem(coordinates)]
 
-    def __iter__(self):
+    def items(self) -> Iterable[Tuple[Point, R]]:
         for rank in self._shape.ranks():
             yield Point(rank, self._shape), self._values[rank]
+
+    def __iter__(self) -> Iterator[Tuple[Point, R]]:
+        return iter(self.items())
 
     def __len__(self) -> int:
         return len(self._shape)
@@ -368,14 +440,7 @@ def send(
 
     This sends the message to all actors but does not wait for any result.
     """
-    endpoint._signature.bind(None, *args, **kwargs)
-    message = PythonMessage(
-        endpoint._name,
-        _pickle((args, kwargs)),
-        None if port is None else port._port_ref,
-        None,
-    )
-    endpoint._actor_mesh.cast(message, selection)
+    endpoint._send(args, kwargs, port, selection)
 
 
 class EndpointProperty(Generic[P, R]):
@@ -447,7 +512,7 @@ else:
 # not part of the Endpoint API because they way it accepts arguments
 # and handles concerns is different.
 def port(endpoint: Endpoint[P, R], once: bool = False) -> "PortTuple[R]":
-    return PortTuple.create(endpoint._mailbox, once)
+    return endpoint._port(once)
 
 
 def ranked_port(
@@ -676,7 +741,7 @@ class ActorMeshRef(MeshTrait, Generic[T]):
                 setattr(
                     self,
                     attr_name,
-                    Endpoint(
+                    ActorEndpoint(
                         self._actor_mesh_ref,
                         attr_name,
                         attr_value._method,
@@ -695,7 +760,7 @@ class ActorMeshRef(MeshTrait, Generic[T]):
             attr = getattr(self._class, name)
             if isinstance(attr, EndpointProperty):
                 # Dynamically create the endpoint
-                endpoint = Endpoint(
+                endpoint = ActorEndpoint(
                     self._actor_mesh_ref,
                     name,
                     attr._method,
@@ -718,7 +783,7 @@ class ActorMeshRef(MeshTrait, Generic[T]):
         async def null_func(*_args: Iterable[Any], **_kwargs: Dict[str, Any]) -> None:
             return None
 
-        ep = Endpoint(
+        ep = ActorEndpoint(
             self._actor_mesh_ref,
             "__init__",
             null_func,

--- a/python/monarch/fetch.py
+++ b/python/monarch/fetch.py
@@ -9,7 +9,7 @@
 This is a utility file for fetching a shard of a tensor from remote.
 """
 
-from typing import TypeVar
+from typing import cast, TypeVar
 
 from monarch.common.device_mesh import no_mesh
 
@@ -37,7 +37,7 @@ def fetch_shard(
             shard = {}
         shard.update(kwargs)
 
-    return call_on_shard_and_fetch(remote_identity, obj, shard=shard)
+    return cast("Future[T]", call_on_shard_and_fetch(remote_identity, obj, shard=shard))
 
 
 def show(obj: T, shard: dict[str, int] | None = None, **kwargs: int) -> object:

--- a/python/monarch/mesh_controller.py
+++ b/python/monarch/mesh_controller.py
@@ -204,8 +204,7 @@ class MeshClient(Client):
         response_port = None
         if future is not None:
             # method annotation is a lie to make Client happy
-            port = cast("Port[Any]", future)
-            slice = NDSlice.new_row_major([])
+            port, slice = cast("Tuple[Port[Any], NDSlice]", future)
             response_port = (port._port_ref.port_id, slice)
         self._mesh_controller.node(seq, defs, uses, response_port, tracebacks)
         return seq

--- a/python/tests/test_remote_functions.py
+++ b/python/tests/test_remote_functions.py
@@ -9,7 +9,6 @@ import itertools
 import math
 import sys
 import traceback
-from enum import Enum
 from typing import Callable, ContextManager, Tuple
 from unittest.mock import patch
 
@@ -1277,3 +1276,24 @@ def a_function_called_by_a_live_function(x):
 
 def a_live_function_call_by_a_live_function(x):
     return 3 * x
+
+
+@remote
+def return_them(x: torch.Tensor, y: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
+    return (x, y)
+
+
+@pytest.mark.skipif(
+    torch.cuda.device_count() < 2,
+    reason="Not enough GPUs, this test requires at least 2 GPUs",
+)
+class TestMeshSpecific(RemoteFunctionsTestBase):
+    def test_value_mesh(self):
+        with self.local_device_mesh(2, 2, "mesh") as device_mesh:
+            x = device_mesh.rank("host")
+            y = device_mesh.rank("gpu")
+            r = return_them.call(x, y).get()
+
+            for p, (h, g) in r:
+                assert p["host"] == h.item()
+                assert p["gpu"] == g.item()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #499
* __->__ #498

This unifies call_on_shard_and_fetch with actor endpoints. It is now possible to issue a `.call` on a free-function remote and get a ValueMesh back. `call_on_shard_and_fetch` along with `fetch_shard` and `inspect` are implemented in terms of `call_one` now.

Differential Revision: [D77978317](https://our.internmc.facebook.com/intern/diff/D77978317/)