### PR TITLE
: selection: handle dim mismatch in reify_view (refinement)

### DIFF
--- a/ndslice/src/selection.rs
+++ b/ndslice/src/selection.rs
@@ -1047,7 +1047,9 @@ impl ReifyView for Slice {
             return Ok(dsl::false_());
         }
 
-        if view.num_dim() != self.num_dim() {
+        if view.num_dim() != self.num_dim()
+            || view.sizes().iter().zip(self.sizes()).any(|(&v, &s)| v > s)
+        {
             return Selection::of_ranks(self, &view.iter().collect::<BTreeSet<usize>>());
         }
 


### PR DESCRIPTION
Summary:
if the view matches the base in dimensionality but not extents, fall back on `of_ranks`.

addresses comment in D78035345: https://www.internalfb.com/diff/D78035345?dst_version_fbid=1811944813013520&transaction_fbid=1009940194342925.

Reviewed By: mariusae

Differential Revision: D78111264


