### PR TITLE
[monarch] add monarch_no_torch wheel and fbpkg

### DIFF
--- a/python/monarch/__init__.py
+++ b/python/monarch/__init__.py
@@ -11,7 +11,10 @@ from typing import TYPE_CHECKING
 
 # Import before monarch to pre-load torch DSOs as, in exploded wheel flows,
 # our RPATHs won't correctly find them.
-import torch  # noqa: F401
+try:
+    import torch  # noqa: F401
+except ImportError:
+    pass
 
 # submodules of monarch should not be imported in this
 # top-level file because it will cause them to get

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ pyre-extensions
 cloudpickle
 torchx-nightly
 lark
+tabulate


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #502

It's extremely useful to have have a version of monarch that does not require linking against torch.

torch's ABI is not stable. This means that we need to build a wheel for each torch version that we plan to link against and match them up correctly, which is not always convenient when we are trying monarch against all sorts of random envs.

So we add a monarch_no_torch wheel and fbpkg, to have a portable wheel we can install (pretty much) anywhere.

Differential Revision: [D78168948](https://our.internmc.facebook.com/intern/diff/D78168948/)