### PR TITLE
Fix broken test

### DIFF
--- a/python/monarch/_src/actor/proc_mesh.py
+++ b/python/monarch/_src/actor/proc_mesh.py
@@ -103,7 +103,7 @@ class ProcMesh(MeshTrait):
         if _mock_shape is None and HAS_TENSOR_ENGINE:
             # type: ignore[21]
             self._rdma_manager = self._spawn_blocking("rdma_manager", RDMAManager)
-        if not _is_initializing_debugger:
+        if not _is_initializing_debugger and _mock_shape is None:
             self._debug_manager = self._spawn_blocking(
                 _DEBUG_MANAGER_ACTOR_NAME, DebugManager, debug_client()
             )


### PR DESCRIPTION
Summary: Fix broken test for T230654436. `DebugManager` should only be spawned when the proc mesh is first created, similar to `RDMAManager`. If `_mock_shape` isn't None, it means we're creating a proc mesh by slicing an existing one, so DebugManager will already exist.

Reviewed By: colin2328, dcci

Differential Revision: D78171244


