### PR TITLE
[monarch] expose specific-rank selection

### DIFF
--- a/python/monarch/actor/__init__.py
+++ b/python/monarch/actor/__init__.py
@@ -19,6 +19,7 @@ from monarch._src.actor.actor_mesh import (
     endpoint,
     MonarchContext,
     Point,
+    port,
     send,
     ValueMesh,
 )
@@ -46,6 +47,7 @@ __all__ = [
     "Point",
     "proc_mesh",
     "ProcMesh",
+    "port",
     "send",
     "ValueMesh",
     "debug_client",


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #506
* #502

only exposed via the low-level `send` API, not a first-class adverb on the endpoints (since I don't know how to make a good API for it).

Differential Revision: [D78172884](https://our.internmc.facebook.com/intern/diff/D78172884/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D78172884/)!