### PR TITLE
Fix non-async endpoint type checking

### DIFF
--- a/python/monarch/_src/actor/actor_mesh.py
+++ b/python/monarch/_src/actor/actor_mesh.py
@@ -34,6 +34,7 @@ from typing import (
     Literal,
     NamedTuple,
     Optional,
+    overload,
     ParamSpec,
     Sequence,
     Tuple,
@@ -457,7 +458,13 @@ def send(
 
 
 class EndpointProperty(Generic[P, R]):
-    def __init__(self, method: Callable[Concatenate[Any, P], Awaitable[R]]) -> None:
+    @overload
+    def __init__(self, method: Callable[Concatenate[Any, P], Awaitable[R]]) -> None: ...
+
+    @overload
+    def __init__(self, method: Callable[Concatenate[Any, P], R]) -> None: ...
+
+    def __init__(self, method: Any) -> None:
         self._method = method
 
     def __get__(self, instance, owner) -> Endpoint[P, R]:
@@ -467,9 +474,19 @@ class EndpointProperty(Generic[P, R]):
         return cast(Endpoint[P, R], self)
 
 
+@overload
 def endpoint(
     method: Callable[Concatenate[Any, P], Awaitable[R]],
-) -> EndpointProperty[P, R]:
+) -> EndpointProperty[P, R]: ...
+
+
+@overload
+def endpoint(
+    method: Callable[Concatenate[Any, P], R],
+) -> EndpointProperty[P, R]: ...
+
+
+def endpoint(method):
     return EndpointProperty(method)
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #515
* __->__ #510
* #504

It wasn't working correctly if the function didn't return an Awaitable.

Differential Revision: [D78181976](https://our.internmc.facebook.com/intern/diff/D78181976/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D78181976/)!