### PR TITLE
mitigate the python proc mesh bug for KD controller service

### DIFF
--- a/hyperactor_mesh/src/proc_mesh.rs
+++ b/hyperactor_mesh/src/proc_mesh.rs
@@ -184,6 +184,7 @@ impl ProcMesh {
         let (router_channel_addr, router_rx) = channel::serve(ChannelAddr::any(alloc.transport()))
             .await
             .map_err(|err| AllocatorError::Other(err.into()))?;
+        tracing::info!("router channel started listening on addr: {router_channel_addr}");
         let router = DialMailboxRouter::new_with_default(global_router().boxed());
         for (rank, (addr, _agent)) in running.iter().enumerate() {
             let proc_id = proc_ids.get(rank).unwrap().clone();
@@ -202,6 +203,7 @@ impl ProcMesh {
         let (client_proc_addr, client_rx) = channel::serve(ChannelAddr::any(alloc.transport()))
             .await
             .map_err(|err| AllocatorError::Other(err.into()))?;
+        tracing::info!("client proc started listening on addr: {client_proc_addr}");
         let client_proc = Proc::new(
             client_proc_id.clone(),
             BoxedMailboxSender::new(router.clone()),


### PR DESCRIPTION
Summary:
A bug introduced by D77250211, which messed up the lifecycle management of python proc mesh. The Alloc of the proc mesh can be destroyed earlier than expected, resulting in connection disconnecting.

This diff is a workaround, it keeps the proc meshes around, the same as the actor mesh.

Differential Revision: D78111736


