### PR TITLE
Use assert_type to check for type inference failures for actor endpoints

### DIFF
--- a/.github/workflows/test-cuda.yml
+++ b/.github/workflows/test-cuda.yml
@@ -47,6 +47,10 @@ jobs:
         # Install the built wheel from artifact
         install_wheel_from_artifact
 
+        # tests the type_assert statements in test_python_actor are correct
+        # pyre currently does not check these assertions
+        pyright python/tests/test_python_actors.py
+
         # Run CUDA tests
         LC_ALL=C pytest python/tests/ -s -v -m "not oss_skip"
         python python/tests/test_mock_cuda.py

--- a/python/tests/requirements.txt
+++ b/python/tests/requirements.txt
@@ -2,3 +2,4 @@ pytest
 pytest-timeout
 pytest-asyncio
 pytest-xdist
+pyright

--- a/python/tests/test_python_actors.py
+++ b/python/tests/test_python_actors.py
@@ -4,6 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+# pyre-unsafe
 import asyncio
 import operator
 import threading


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #518
* __->__ #515
* #510
* #504

This requires running pyright on the file in the oss test because pyre doesn't seem to care about the assert_type statement.

Differential Revision: [D78185660](https://our.internmc.facebook.com/intern/diff/D78185660/)