### PR TITLE
[monarch/telemetry] fall back to /tmp/ if /logs/ doesn't exist

### DIFF
--- a/hyperactor_telemetry/src/lib.rs
+++ b/hyperactor_telemetry/src/lib.rs
@@ -77,19 +77,46 @@ impl TelemetryClock for DefaultTelemetryClock {
     }
 }
 
+fn try_create_appender(
+    path: &str,
+    create_dir: bool,
+) -> Result<RollingFileAppender, Box<dyn std::error::Error>> {
+    if create_dir {
+        std::fs::create_dir_all(path)?;
+    }
+    Ok(RollingFileAppender::builder()
+        .rotation(Rotation::DAILY)
+        .filename_prefix("dedicated_log_monarch")
+        .filename_suffix("log")
+        .build(path)?)
+}
+
 // Need to keep this around so that the tracing subscriber doesn't drop the writer.
 lazy_static! {
     static ref FILE_WRITER_GUARD: Arc<(NonBlocking, WorkerGuard)> = {
-        let writer: Box<dyn Write + Send> = match RollingFileAppender::builder()
-            .rotation(Rotation::DAILY)
-            .filename_prefix("dedicated_log_monarch")
-            .filename_suffix("log")
-            .build("/logs/")
-        {
-            Ok(file) => Box::new(file),
-            Err(e) => {
-                tracing::warn!("unable to create custom log file: {}", e);
-                Box::new(std::io::stderr())
+        let writer: Box<dyn Write + Send> = {
+            let logs_dir_exists = std::fs::metadata("/logs/").map(|m| m.is_dir()).unwrap_or(false);
+
+            // First try /logs/ if it exists and is a directory
+            let logs_result = if logs_dir_exists {
+                try_create_appender("/logs/", false)
+            } else {
+                Err("logs directory not available".into())
+            };
+
+            // Fall back to /tmp/monarch_log if not.
+            match logs_result {
+                Ok(file_appender) => Box::new(file_appender),
+                Err(_) => {
+                    match try_create_appender("/tmp/monarch_log/", true) {
+                        Ok(file_appender) => Box::new(file_appender),
+                        // Fall back to stderr as a last resort
+                        Err(e) => {
+                            eprintln!("unable to create log file in /tmp/monarch_log/: {}. Falling back to stderr", e);
+                            Box::new(std::io::stderr())
+                        }
+                    }
+                }
             }
         };
         return Arc::new(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #526

as title, `/logs/` is not always available on all machines (notably devservers). Try falling back to a more conventionally writeable location before falling back to stderr

Differential Revision: [D78245838](https://our.internmc.facebook.com/intern/diff/D78245838/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D78245838/)!