### PR TITLE
Clean up of monarch_rdma/extension

### DIFF
--- a/monarch_hyperactor/src/mailbox.rs
+++ b/monarch_hyperactor/src/mailbox.rs
@@ -53,7 +53,13 @@ use crate::shape::PyShape;
     module = "monarch._rust_bindings.monarch_hyperactor.mailbox"
 )]
 pub struct PyMailbox {
-    pub inner: Mailbox,
+    pub(super) inner: Mailbox,
+}
+
+impl PyMailbox {
+    pub fn get_inner(&self) -> &Mailbox {
+        &self.inner
+    }
 }
 
 #[pymethods]


### PR DESCRIPTION
Summary:
Follow up to D76937776

- Reverts some objects back to `pub(super)`, exposing the relevant needed APIs
- Cleanups of monarch_rdma/extension/lib.rs

Differential Revision: D78276671


