### PR TITLE
Switch to Packed vs Aligned mlx5 WQE ctrl

### DIFF
--- a/rdmacore-sys/src/lib.rs
+++ b/rdmacore-sys/src/lib.rs
@@ -9,7 +9,7 @@
 // sections of code adapted from https://github.com/jonhoo/rust-ibverbs
 // Copyright (c) 2016 Jon Gjengset under MIT License (MIT)
 
-#[repr(C, align(4))]
+#[repr(C, packed(1))]
 #[derive(Debug, Default, Clone, Copy)]
 pub struct mlx5_wqe_ctrl_seg {
     pub opmod_idx_opcode: u32,


### PR DESCRIPTION
Summary:
Fix bug in alignment, C definition is: 
  struct mlx5_wqe_ctrl_seg {
	__be32		opmod_idx_opcode;
	__be32		qpn_ds;
	uint8_t		signature;
	__be16		dci_stream_channel_id;
	uint8_t		fm_ce_se;
	__be32		imm;
  } __attribute__((__packed__)) __attribute__((__aligned__(4)));

LSS: we want to use packed / packed(1) with binding (drop align, works fine).

Differential Revision: D78362878


