### PR TITLE
(5/N) Extend monarch_extension with RDMA

### DIFF
--- a/.github/workflows/build-cuda.yml
+++ b/.github/workflows/build-cuda.yml
@@ -34,6 +34,9 @@ jobs:
         # Setup build environment (conda + system deps + rust + build deps)
         setup_build_environment
 
+        # Setup Tensor Engine
+        setup_tensor_engine
+
         # Build the process allocator binary
         build_process_allocator
 

--- a/.github/workflows/test-cuda.yml
+++ b/.github/workflows/test-cuda.yml
@@ -44,6 +44,9 @@ jobs:
         chmod +x cargo_bin/process_allocator
         export PATH=$(pwd)/cargo_bin:$PATH
 
+        # Setup Tensor Engine dependencies
+        setup_tensor_engine
+
         # Install the built wheel from artifact
         install_wheel_from_artifact
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,10 @@ members = [
     "ndslice",
     "monarch_extension",
     "monarch_tensor_worker",
+    "monarch_rdma",
     "nccl-sys",
     "rdmacore-sys",
     "torch-sys",
+    "rdmacore-sys",
+    "cuda-sys",
 ]

--- a/monarch_extension/Cargo.toml
+++ b/monarch_extension/Cargo.toml
@@ -25,6 +25,7 @@ hyperactor_multiprocess = { version = "0.0.0", path = "../hyperactor_multiproces
 libc = "0.2.139"
 monarch_hyperactor = { version = "0.0.0", path = "../monarch_hyperactor" }
 monarch_messages = { version = "0.0.0", path = "../monarch_messages", optional = true }
+monarch_rdma_extension = { version = "0.0.0", path = "../monarch_rdma/extension", optional = true }
 monarch_simulator_lib = { version = "0.0.0", path = "../monarch_simulator", optional = true }
 monarch_tensor_worker = { version = "0.0.0", path = "../monarch_tensor_worker", optional = true }
 monarch_types = { version = "0.0.0", path = "../monarch_types" }
@@ -40,4 +41,4 @@ tracing = { version = "0.1.41", features = ["attributes", "valuable"] }
 
 [features]
 default = ["tensor_engine"]
-tensor_engine = ["dep:controller", "dep:monarch_messages", "dep:monarch_simulator_lib", "dep:monarch_tensor_worker", "dep:nccl-sys", "dep:torch-sys", "dep:torch-sys-cuda"]
+tensor_engine = ["dep:controller", "dep:monarch_messages", "dep:monarch_rdma_extension", "dep:monarch_simulator_lib", "dep:monarch_tensor_worker", "dep:nccl-sys", "dep:torch-sys", "dep:torch-sys-cuda"]

--- a/monarch_extension/src/lib.rs
+++ b/monarch_extension/src/lib.rs
@@ -129,6 +129,7 @@ pub fn mod_init(module: &Bound<'_, PyModule>) -> PyResult<()> {
             module,
             "monarch_extension.mesh_controller",
         )?)?;
+        monarch_rdma_extension::register_python_bindings(&get_or_add_new_module(module, "rdma")?)?;
     }
     simulation_tools::register_python_bindings(&get_or_add_new_module(
         module,

--- a/python/tests/_monarch/test_hyperactor.py
+++ b/python/tests/_monarch/test_hyperactor.py
@@ -16,7 +16,7 @@ import monarch
 
 from monarch._rust_bindings.monarch_hyperactor.actor import PanicFlag, PythonMessage
 
-from monarch._rust_bindings.monarch_hyperactor.alloc import (  # @manual=//monarch/monarch_extension:monarch_extension
+from monarch._rust_bindings.monarch_hyperactor.alloc import (  # @manual=//monarch/monarch_extension:monarch_extension_no_torch
     AllocConstraints,
     AllocSpec,
 )

--- a/scripts/common-setup.sh
+++ b/scripts/common-setup.sh
@@ -52,6 +52,12 @@ install_wheel_from_artifact() {
     pip install "${RUNNER_ARTIFACT_DIR}"/*.whl
 }
 
+# Setup and install dependencies for Tensor Engine
+setup_tensor_engine() {
+    echo "Installing Tensor Engine dependencies..."
+    dnf install -y libibverbs rdma-core libmlx5 libibverbs-devel rdma-core-devel
+}
+
 # Build process allocator binary
 build_process_allocator() {
     echo "Building process allocator binary..."


### PR DESCRIPTION
Summary:
This diff:
1. Adds `monarch_rdma` to `monarch_extension`
2. Changes several tests to use `*_no_torch` build.

Tests / targets that don't use the `_no_torch` build should be run with GPUs from here.

Differential Revision: D78290956


