### PR TITLE
Add Cargo support to  `cuda-sys` and `rdmacore-sys`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 resolver = "2"
 members = [
     "controller",
+    "cuda-sys",
     "hyper",
     "hyperactor",
     "hyperactor_macros",
@@ -12,5 +13,6 @@ members = [
     "monarch_extension",
     "monarch_tensor_worker",
     "nccl-sys",
+    "rdmacore-sys",
     "torch-sys",
 ]

--- a/cuda-sys/build.rs
+++ b/cuda-sys/build.rs
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+use std::env;
+use std::path::Path;
+use std::path::PathBuf;
+
+use glob::glob;
+use which::which;
+
+// Translated from torch/utils/cpp_extension.py
+fn find_cuda_home() -> Option<String> {
+    // Guess #1
+    let mut cuda_home = env::var("CUDA_HOME")
+        .ok()
+        .or_else(|| env::var("CUDA_PATH").ok());
+
+    if cuda_home.is_none() {
+        // Guess #2
+        if let Ok(nvcc_path) = which("nvcc") {
+            // Get parent directory twice
+            if let Some(cuda_dir) = nvcc_path.parent().and_then(|p| p.parent()) {
+                cuda_home = Some(cuda_dir.to_string_lossy().into_owned());
+            }
+        } else {
+            // Guess #3
+            if cfg!(windows) {
+                // Windows code
+                let pattern = r"C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v*.*";
+                let cuda_homes: Vec<_> = glob(pattern).unwrap().filter_map(Result::ok).collect();
+                if !cuda_homes.is_empty() {
+                    cuda_home = Some(cuda_homes[0].to_string_lossy().into_owned());
+                } else {
+                    cuda_home = None;
+                }
+            } else {
+                // Not Windows
+                let cuda_candidate = "/usr/local/cuda";
+                if Path::new(cuda_candidate).exists() {
+                    cuda_home = Some(cuda_candidate.to_string());
+                } else {
+                    cuda_home = None;
+                }
+            }
+        }
+    }
+    cuda_home
+}
+
+fn main() {
+    let cuda_home = find_cuda_home().expect("Could not find CUDA installation");
+
+    // Tell cargo to look for shared libraries in the CUDA directory
+    println!("cargo:rustc-link-search={}/lib64", cuda_home);
+    println!("cargo:rustc-link-search={}/lib", cuda_home);
+
+    // Link against the CUDA libraries
+    println!("cargo:rustc-link-lib=cuda");
+    println!("cargo:rustc-link-lib=cudart");
+
+    // Tell cargo to invalidate the built crate whenever the wrapper changes
+    println!("cargo:rerun-if-changed=src/wrapper.h");
+
+    // Add cargo metadata
+    println!("cargo:rustc-cfg=cargo");
+    println!("cargo:rustc-check-cfg=cfg(cargo)");
+
+    // The bindgen::Builder is the main entry point to bindgen
+    let bindings = bindgen::Builder::default()
+        // The input header we would like to generate bindings for
+        .header("src/wrapper.h")
+        // Add the CUDA include directory
+        .clang_arg(format!("-I{}/include", cuda_home))
+        // Parse as C++
+        .clang_arg("-x")
+        .clang_arg("c++")
+        .clang_arg("-std=gnu++20")
+        // Allow the specified functions and types
+        .allowlist_function("cu.*")
+        .allowlist_function("CU.*")
+        .allowlist_type("cu.*")
+        .allowlist_type("CU.*")
+        // Use newtype enum style
+        .default_enum_style(bindgen::EnumVariation::NewType {
+            is_bitfield: false,
+            is_global: false,
+        })
+        // Finish the builder and generate the bindings
+        .parse_callbacks(Box::new(bindgen::CargoCallbacks::new()))
+        .generate()
+        // Unwrap the Result and panic on failure
+        .expect("Unable to generate bindings");
+
+    // Write the bindings to the $OUT_DIR/bindings.rs file
+    let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
+    bindings
+        .write_to_file(out_path.join("bindings.rs"))
+        .expect("Couldn't write bindings!");
+}

--- a/cuda-sys/src/lib.rs
+++ b/cuda-sys/src/lib.rs
@@ -5,3 +5,49 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
  */
+
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+use cxx::ExternType;
+use cxx::type_id;
+
+/// SAFETY: bindings
+unsafe impl ExternType for CUstream_st {
+    type Id = type_id!("CUstream_st");
+    type Kind = cxx::kind::Opaque;
+}
+
+// When building with cargo, this is actually the lib.rs file for a crate.
+// Include the generated bindings.rs and suppress lints.
+#[allow(non_camel_case_types)]
+#[allow(non_upper_case_globals)]
+#[allow(non_snake_case)]
+mod inner {
+    #[cfg(cargo)]
+    include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
+}
+
+pub use inner::*;
+
+#[cfg(test)]
+mod tests {
+    use std::mem::MaybeUninit;
+
+    use super::*;
+
+    #[test]
+    fn sanity() {
+        // SAFETY: testing bindings
+        unsafe {
+            let mut version = MaybeUninit::<i32>::uninit();
+            let result = cuDriverGetVersion(version.as_mut_ptr());
+            assert_eq!(result, cudaError_enum(0));
+        }
+    }
+}

--- a/monarch_rdma/Cargo.toml
+++ b/monarch_rdma/Cargo.toml
@@ -10,8 +10,10 @@ license = "BSD-3-Clause"
 [dependencies]
 anyhow = "1.0.98"
 async-trait = "0.1.86"
+cuda-sys = { path = "../cuda-sys" }
 hyperactor = { version = "0.0.0", path = "../hyperactor" }
 rand = { version = "0.8", features = ["small_rng"] }
+rdmacore-sys = { path = "../rdmacore-sys" }
 serde = { version = "1.0.185", features = ["derive", "rc"] }
 tracing = { version = "0.1.41", features = ["attributes", "valuable"] }
 

--- a/rdmacore-sys/build.rs
+++ b/rdmacore-sys/build.rs
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+use std::env;
+use std::path::PathBuf;
+
+fn main() {
+    // Tell cargo to look for shared libraries in the specified directory
+    println!("cargo:rustc-link-search=/usr/lib");
+    println!("cargo:rustc-link-search=/usr/lib64");
+
+    // Link against the ibverbs library
+    println!("cargo:rustc-link-lib=ibverbs");
+
+    // Link against the mlx5 library
+    println!("cargo:rustc-link-lib=mlx5");
+
+    // Tell cargo to invalidate the built crate whenever the wrapper changes
+    println!("cargo:rerun-if-changed=src/wrapper.h");
+
+    // Add cargo metadata
+    println!("cargo:rustc-cfg=cargo");
+    println!("cargo:rustc-check-cfg=cfg(cargo)");
+
+    // The bindgen::Builder is the main entry point to bindgen
+    let bindings = bindgen::Builder::default()
+        // The input header we would like to generate bindings for
+        .header("src/wrapper.h")
+        // Allow the specified functions, types, and variables
+        .allowlist_function("ibv_.*")
+        .allowlist_function("mlx5dv_.*")
+        .allowlist_function("mlx5_wqe_.*")
+        .allowlist_type("ibv_.*")
+        .allowlist_type("mlx5dv_.*")
+        .allowlist_type("mlx5_wqe_.*")
+        .allowlist_var("MLX5_.*")
+        // Block specific types that are manually defined in lib.rs
+        .blocklist_type("ibv_wc")
+        .blocklist_type("mlx5_wqe_ctrl_seg")
+        // Apply the same bindgen flags as in the BUCK file
+        .bitfield_enum("ibv_access_flags")
+        .bitfield_enum("ibv_qp_attr_mask")
+        .bitfield_enum("ibv_wc_flags")
+        .bitfield_enum("ibv_send_flags")
+        .bitfield_enum("ibv_port_cap_flags")
+        .constified_enum_module("ibv_qp_type")
+        .constified_enum_module("ibv_qp_state")
+        .constified_enum_module("ibv_port_state")
+        .constified_enum_module("ibv_wc_opcode")
+        .constified_enum_module("ibv_wr_opcode")
+        .constified_enum_module("ibv_wc_status")
+        .derive_default(true)
+        .prepend_enum_name(false)
+        // Finish the builder and generate the bindings
+        .generate()
+        // Unwrap the Result and panic on failure
+        .expect("Unable to generate bindings");
+
+    // Write the bindings to the $OUT_DIR/bindings.rs file
+    let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
+    bindings
+        .write_to_file(out_path.join("bindings.rs"))
+        .expect("Couldn't write bindings!");
+}

--- a/rdmacore-sys/src/lib.rs
+++ b/rdmacore-sys/src/lib.rs
@@ -9,214 +9,227 @@
 // sections of code adapted from https://github.com/jonhoo/rust-ibverbs
 // Copyright (c) 2016 Jon Gjengset under MIT License (MIT)
 
-#[repr(C, packed(1))]
-#[derive(Debug, Default, Clone, Copy)]
-pub struct mlx5_wqe_ctrl_seg {
-    pub opmod_idx_opcode: u32,
-    pub qpn_ds: u32,
-    pub signature: u8,
-    pub dci_stream_channel_id: u16,
-    pub fm_ce_se: u8,
-    pub imm: u32,
-}
+mod inner {
+    #[cfg(not(cargo))]
+    use crate::ibv_wc_flags;
+    #[cfg(not(cargo))]
+    use crate::ibv_wc_opcode;
+    #[cfg(not(cargo))]
+    use crate::ibv_wc_status;
+    #[cfg(cargo)]
+    include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
 
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct ibv_wc {
-    wr_id: u64,
-    status: ibv_wc_status::Type,
-    opcode: ibv_wc_opcode::Type,
-    vendor_err: u32,
-    byte_len: u32,
-
-    /// Immediate data OR the local RKey that was invalidated depending on `wc_flags`.
-    /// See `man ibv_poll_cq` for details.
-    pub imm_data: u32,
-    /// Local QP number of completed WR.
-    ///
-    /// Relevant for Receive Work Completions that are associated with an SRQ.
-    pub qp_num: u32,
-    /// Source QP number (remote QP number) of completed WR.
-    ///
-    /// Relevant for Receive Work Completions of a UD QP.
-    pub src_qp: u32,
-    /// Flags of the Work Completion. It is either 0 or the bitwise OR of one or more of the
-    /// following flags:
-    ///
-    ///  - `IBV_WC_GRH`: Indicator that GRH is present for a Receive Work Completions of a UD QP.
-    ///    If this bit is set, the first 40 bytes of the buffered that were referred to in the
-    ///    Receive request will contain the GRH of the incoming message. If this bit is cleared,
-    ///    the content of those first 40 bytes is undefined
-    ///  - `IBV_WC_WITH_IMM`: Indicator that imm_data is valid. Relevant for Receive Work
-    ///    Completions
-    pub wc_flags: ibv_wc_flags,
-    /// P_Key index (valid only for GSI QPs).
-    pub pkey_index: u16,
-    /// Source LID (the base LID that this message was sent from).
-    ///
-    /// Relevant for Receive Work Completions of a UD QP.
-    pub slid: u16,
-    /// Service Level (the SL LID that this message was sent with).
-    ///
-    /// Relevant for Receive Work Completions of a UD QP.
-    pub sl: u8,
-    /// Destination LID path bits.
-    ///
-    /// Relevant for Receive Work Completions of a UD QP (not applicable for multicast messages).
-    pub dlid_path_bits: u8,
-}
-
-#[allow(clippy::len_without_is_empty)]
-impl ibv_wc {
-    /// Returns the 64 bit value that was associated with the corresponding Work Request.
-    pub fn wr_id(&self) -> u64 {
-        self.wr_id
+    #[repr(C, packed(1))]
+    #[derive(Debug, Default, Clone, Copy)]
+    pub struct mlx5_wqe_ctrl_seg {
+        pub opmod_idx_opcode: u32,
+        pub qpn_ds: u32,
+        pub signature: u8,
+        pub dci_stream_channel_id: u16,
+        pub fm_ce_se: u8,
+        pub imm: u32,
     }
 
-    /// Returns the number of bytes transferred.
-    ///
-    /// Relevant if the Receive Queue for incoming Send or RDMA Write with immediate operations.
-    /// This value doesn't include the length of the immediate data, if such exists. Relevant in
-    /// the Send Queue for RDMA Read and Atomic operations.
-    ///
-    /// For the Receive Queue of a UD QP that is not associated with an SRQ or for an SRQ that is
-    /// associated with a UD QP this value equals to the payload of the message plus the 40 bytes
-    /// reserved for the GRH. The number of bytes transferred is the payload of the message plus
-    /// the 40 bytes reserved for the GRH, whether or not the GRH is present
-    pub fn len(&self) -> usize {
-        self.byte_len as usize
+    #[repr(C)]
+    #[derive(Debug, Copy, Clone)]
+    pub struct ibv_wc {
+        wr_id: u64,
+        status: ibv_wc_status::Type,
+        opcode: ibv_wc_opcode::Type,
+        vendor_err: u32,
+        byte_len: u32,
+
+        /// Immediate data OR the local RKey that was invalidated depending on `wc_flags`.
+        /// See `man ibv_poll_cq` for details.
+        pub imm_data: u32,
+        /// Local QP number of completed WR.
+        ///
+        /// Relevant for Receive Work Completions that are associated with an SRQ.
+        pub qp_num: u32,
+        /// Source QP number (remote QP number) of completed WR.
+        ///
+        /// Relevant for Receive Work Completions of a UD QP.
+        pub src_qp: u32,
+        /// Flags of the Work Completion. It is either 0 or the bitwise OR of one or more of the
+        /// following flags:
+        ///
+        ///  - `IBV_WC_GRH`: Indicator that GRH is present for a Receive Work Completions of a UD QP.
+        ///    If this bit is set, the first 40 bytes of the buffered that were referred to in the
+        ///    Receive request will contain the GRH of the incoming message. If this bit is cleared,
+        ///    the content of those first 40 bytes is undefined
+        ///  - `IBV_WC_WITH_IMM`: Indicator that imm_data is valid. Relevant for Receive Work
+        ///    Completions
+        pub wc_flags: ibv_wc_flags,
+        /// P_Key index (valid only for GSI QPs).
+        pub pkey_index: u16,
+        /// Source LID (the base LID that this message was sent from).
+        ///
+        /// Relevant for Receive Work Completions of a UD QP.
+        pub slid: u16,
+        /// Service Level (the SL LID that this message was sent with).
+        ///
+        /// Relevant for Receive Work Completions of a UD QP.
+        pub sl: u8,
+        /// Destination LID path bits.
+        ///
+        /// Relevant for Receive Work Completions of a UD QP (not applicable for multicast messages).
+        pub dlid_path_bits: u8,
     }
 
-    /// Check if this work requested completed successfully.
-    ///
-    /// A successful work completion (`IBV_WC_SUCCESS`) means that the corresponding Work Request
-    /// (and all of the unsignaled Work Requests that were posted previous to it) ended, and the
-    /// memory buffers that this Work Request refers to are ready to be (re)used.
-    pub fn is_valid(&self) -> bool {
-        self.status == ibv_wc_status::IBV_WC_SUCCESS
-    }
+    #[allow(clippy::len_without_is_empty)]
+    impl ibv_wc {
+        /// Returns the 64 bit value that was associated with the corresponding Work Request.
+        pub fn wr_id(&self) -> u64 {
+            self.wr_id
+        }
 
-    /// Returns the work completion status and vendor error syndrome (`vendor_err`) if the work
-    /// request did not completed successfully.
-    ///
-    /// Possible statuses include:
-    ///
-    ///  - `IBV_WC_LOC_LEN_ERR`: Local Length Error: this happens if a Work Request that was posted
-    ///    in a local Send Queue contains a message that is greater than the maximum message size
-    ///    that is supported by the RDMA device port that should send the message or an Atomic
-    ///    operation which its size is different than 8 bytes was sent. This also may happen if a
-    ///    Work Request that was posted in a local Receive Queue isn't big enough for holding the
-    ///    incoming message or if the incoming message size if greater the maximum message size
-    ///    supported by the RDMA device port that received the message.
-    ///  - `IBV_WC_LOC_QP_OP_ERR`: Local QP Operation Error: an internal QP consistency error was
-    ///    detected while processing this Work Request: this happens if a Work Request that was
-    ///    posted in a local Send Queue of a UD QP contains an Address Handle that is associated
-    ///    with a Protection Domain to a QP which is associated with a different Protection Domain
-    ///    or an opcode which isn't supported by the transport type of the QP isn't supported (for
-    ///    example:
-    ///    RDMA Write over a UD QP).
-    ///  - `IBV_WC_LOC_EEC_OP_ERR`: Local EE Context Operation Error: an internal EE Context
-    ///    consistency error was detected while processing this Work Request (unused, since its
-    ///    relevant only to RD QPs or EE Context, which aren’t supported).
-    ///  - `IBV_WC_LOC_PROT_ERR`: Local Protection Error: the locally posted Work Request’s buffers
-    ///    in the scatter/gather list does not reference a Memory Region that is valid for the
-    ///    requested operation.
-    ///  - `IBV_WC_WR_FLUSH_ERR`: Work Request Flushed Error: A Work Request was in process or
-    ///    outstanding when the QP transitioned into the Error State.
-    ///  - `IBV_WC_MW_BIND_ERR`: Memory Window Binding Error: A failure happened when tried to bind
-    ///    a MW to a MR.
-    ///  - `IBV_WC_BAD_RESP_ERR`: Bad Response Error: an unexpected transport layer opcode was
-    ///    returned by the responder. Relevant for RC QPs.
-    ///  - `IBV_WC_LOC_ACCESS_ERR`: Local Access Error: a protection error occurred on a local data
-    ///    buffer during the processing of a RDMA Write with Immediate operation sent from the
-    ///    remote node. Relevant for RC QPs.
-    ///  - `IBV_WC_REM_INV_REQ_ERR`: Remote Invalid Request Error: The responder detected an
-    ///    invalid message on the channel. Possible causes include the operation is not supported
-    ///    by this receive queue (qp_access_flags in remote QP wasn't configured to support this
-    ///    operation), insufficient buffering to receive a new RDMA or Atomic Operation request, or
-    ///    the length specified in a RDMA request is greater than 2^{31} bytes. Relevant for RC
-    ///    QPs.
-    ///  - `IBV_WC_REM_ACCESS_ERR`: Remote Access Error: a protection error occurred on a remote
-    ///    data buffer to be read by an RDMA Read, written by an RDMA Write or accessed by an
-    ///    atomic operation. This error is reported only on RDMA operations or atomic operations.
-    ///    Relevant for RC QPs.
-    ///  - `IBV_WC_REM_OP_ERR`: Remote Operation Error: the operation could not be completed
-    ///    successfully by the responder. Possible causes include a responder QP related error that
-    ///    prevented the responder from completing the request or a malformed WQE on the Receive
-    ///    Queue. Relevant for RC QPs.
-    ///  - `IBV_WC_RETRY_EXC_ERR`: Transport Retry Counter Exceeded: The local transport timeout
-    ///    retry counter was exceeded while trying to send this message. This means that the remote
-    ///    side didn't send any Ack or Nack. If this happens when sending the first message,
-    ///    usually this mean that the connection attributes are wrong or the remote side isn't in a
-    ///    state that it can respond to messages. If this happens after sending the first message,
-    ///    usually it means that the remote QP isn't available anymore. Relevant for RC QPs.
-    ///  - `IBV_WC_RNR_RETRY_EXC_ERR`: RNR Retry Counter Exceeded: The RNR NAK retry count was
-    ///    exceeded. This usually means that the remote side didn't post any WR to its Receive
-    ///    Queue. Relevant for RC QPs.
-    ///  - `IBV_WC_LOC_RDD_VIOL_ERR`: Local RDD Violation Error: The RDD associated with the QP
-    ///    does not match the RDD associated with the EE Context (unused, since its relevant only
-    ///    to RD QPs or EE Context, which aren't supported).
-    ///  - `IBV_WC_REM_INV_RD_REQ_ERR`: Remote Invalid RD Request: The responder detected an
-    ///    invalid incoming RD message. Causes include a Q_Key or RDD violation (unused, since its
-    ///    relevant only to RD QPs or EE Context, which aren't supported)
-    ///  - `IBV_WC_REM_ABORT_ERR`: Remote Aborted Error: For UD or UC QPs associated with a SRQ,
-    ///    the responder aborted the operation.
-    ///  - `IBV_WC_INV_EECN_ERR`: Invalid EE Context Number: An invalid EE Context number was
-    ///    detected (unused, since its relevant only to RD QPs or EE Context, which aren't
-    ///    supported).
-    ///  - `IBV_WC_INV_EEC_STATE_ERR`: Invalid EE Context State Error: Operation is not legal for
-    ///    the specified EE Context state (unused, since its relevant only to RD QPs or EE Context,
-    ///    which aren't supported).
-    ///  - `IBV_WC_FATAL_ERR`: Fatal Error.
-    ///  - `IBV_WC_RESP_TIMEOUT_ERR`: Response Timeout Error.
-    ///  - `IBV_WC_GENERAL_ERR`: General Error: other error which isn't one of the above errors.
-    pub fn error(&self) -> Option<(ibv_wc_status::Type, u32)> {
-        match self.status {
-            ibv_wc_status::IBV_WC_SUCCESS => None,
-            status => Some((status, self.vendor_err)),
+        /// Returns the number of bytes transferred.
+        ///
+        /// Relevant if the Receive Queue for incoming Send or RDMA Write with immediate operations.
+        /// This value doesn't include the length of the immediate data, if such exists. Relevant in
+        /// the Send Queue for RDMA Read and Atomic operations.
+        ///
+        /// For the Receive Queue of a UD QP that is not associated with an SRQ or for an SRQ that is
+        /// associated with a UD QP this value equals to the payload of the message plus the 40 bytes
+        /// reserved for the GRH. The number of bytes transferred is the payload of the message plus
+        /// the 40 bytes reserved for the GRH, whether or not the GRH is present
+        pub fn len(&self) -> usize {
+            self.byte_len as usize
+        }
+
+        /// Check if this work requested completed successfully.
+        ///
+        /// A successful work completion (`IBV_WC_SUCCESS`) means that the corresponding Work Request
+        /// (and all of the unsignaled Work Requests that were posted previous to it) ended, and the
+        /// memory buffers that this Work Request refers to are ready to be (re)used.
+        pub fn is_valid(&self) -> bool {
+            self.status == ibv_wc_status::IBV_WC_SUCCESS
+        }
+
+        /// Returns the work completion status and vendor error syndrome (`vendor_err`) if the work
+        /// request did not completed successfully.
+        ///
+        /// Possible statuses include:
+        ///
+        ///  - `IBV_WC_LOC_LEN_ERR`: Local Length Error: this happens if a Work Request that was posted
+        ///    in a local Send Queue contains a message that is greater than the maximum message size
+        ///    that is supported by the RDMA device port that should send the message or an Atomic
+        ///    operation which its size is different than 8 bytes was sent. This also may happen if a
+        ///    Work Request that was posted in a local Receive Queue isn't big enough for holding the
+        ///    incoming message or if the incoming message size if greater the maximum message size
+        ///    supported by the RDMA device port that received the message.
+        ///  - `IBV_WC_LOC_QP_OP_ERR`: Local QP Operation Error: an internal QP consistency error was
+        ///    detected while processing this Work Request: this happens if a Work Request that was
+        ///    posted in a local Send Queue of a UD QP contains an Address Handle that is associated
+        ///    with a Protection Domain to a QP which is associated with a different Protection Domain
+        ///    or an opcode which isn't supported by the transport type of the QP isn't supported (for
+        ///    example:
+        ///    RDMA Write over a UD QP).
+        ///  - `IBV_WC_LOC_EEC_OP_ERR`: Local EE Context Operation Error: an internal EE Context
+        ///    consistency error was detected while processing this Work Request (unused, since its
+        ///    relevant only to RD QPs or EE Context, which aren’t supported).
+        ///  - `IBV_WC_LOC_PROT_ERR`: Local Protection Error: the locally posted Work Request’s buffers
+        ///    in the scatter/gather list does not reference a Memory Region that is valid for the
+        ///    requested operation.
+        ///  - `IBV_WC_WR_FLUSH_ERR`: Work Request Flushed Error: A Work Request was in process or
+        ///    outstanding when the QP transitioned into the Error State.
+        ///  - `IBV_WC_MW_BIND_ERR`: Memory Window Binding Error: A failure happened when tried to bind
+        ///    a MW to a MR.
+        ///  - `IBV_WC_BAD_RESP_ERR`: Bad Response Error: an unexpected transport layer opcode was
+        ///    returned by the responder. Relevant for RC QPs.
+        ///  - `IBV_WC_LOC_ACCESS_ERR`: Local Access Error: a protection error occurred on a local data
+        ///    buffer during the processing of a RDMA Write with Immediate operation sent from the
+        ///    remote node. Relevant for RC QPs.
+        ///  - `IBV_WC_REM_INV_REQ_ERR`: Remote Invalid Request Error: The responder detected an
+        ///    invalid message on the channel. Possible causes include the operation is not supported
+        ///    by this receive queue (qp_access_flags in remote QP wasn't configured to support this
+        ///    operation), insufficient buffering to receive a new RDMA or Atomic Operation request, or
+        ///    the length specified in a RDMA request is greater than 2^{31} bytes. Relevant for RC
+        ///    QPs.
+        ///  - `IBV_WC_REM_ACCESS_ERR`: Remote Access Error: a protection error occurred on a remote
+        ///    data buffer to be read by an RDMA Read, written by an RDMA Write or accessed by an
+        ///    atomic operation. This error is reported only on RDMA operations or atomic operations.
+        ///    Relevant for RC QPs.
+        ///  - `IBV_WC_REM_OP_ERR`: Remote Operation Error: the operation could not be completed
+        ///    successfully by the responder. Possible causes include a responder QP related error that
+        ///    prevented the responder from completing the request or a malformed WQE on the Receive
+        ///    Queue. Relevant for RC QPs.
+        ///  - `IBV_WC_RETRY_EXC_ERR`: Transport Retry Counter Exceeded: The local transport timeout
+        ///    retry counter was exceeded while trying to send this message. This means that the remote
+        ///    side didn't send any Ack or Nack. If this happens when sending the first message,
+        ///    usually this mean that the connection attributes are wrong or the remote side isn't in a
+        ///    state that it can respond to messages. If this happens after sending the first message,
+        ///    usually it means that the remote QP isn't available anymore. Relevant for RC QPs.
+        ///  - `IBV_WC_RNR_RETRY_EXC_ERR`: RNR Retry Counter Exceeded: The RNR NAK retry count was
+        ///    exceeded. This usually means that the remote side didn't post any WR to its Receive
+        ///    Queue. Relevant for RC QPs.
+        ///  - `IBV_WC_LOC_RDD_VIOL_ERR`: Local RDD Violation Error: The RDD associated with the QP
+        ///    does not match the RDD associated with the EE Context (unused, since its relevant only
+        ///    to RD QPs or EE Context, which aren't supported).
+        ///  - `IBV_WC_REM_INV_RD_REQ_ERR`: Remote Invalid RD Request: The responder detected an
+        ///    invalid incoming RD message. Causes include a Q_Key or RDD violation (unused, since its
+        ///    relevant only to RD QPs or EE Context, which aren't supported)
+        ///  - `IBV_WC_REM_ABORT_ERR`: Remote Aborted Error: For UD or UC QPs associated with a SRQ,
+        ///    the responder aborted the operation.
+        ///  - `IBV_WC_INV_EECN_ERR`: Invalid EE Context Number: An invalid EE Context number was
+        ///    detected (unused, since its relevant only to RD QPs or EE Context, which aren't
+        ///    supported).
+        ///  - `IBV_WC_INV_EEC_STATE_ERR`: Invalid EE Context State Error: Operation is not legal for
+        ///    the specified EE Context state (unused, since its relevant only to RD QPs or EE Context,
+        ///    which aren't supported).
+        ///  - `IBV_WC_FATAL_ERR`: Fatal Error.
+        ///  - `IBV_WC_RESP_TIMEOUT_ERR`: Response Timeout Error.
+        ///  - `IBV_WC_GENERAL_ERR`: General Error: other error which isn't one of the above errors.
+        pub fn error(&self) -> Option<(ibv_wc_status::Type, u32)> {
+            match self.status {
+                ibv_wc_status::IBV_WC_SUCCESS => None,
+                status => Some((status, self.vendor_err)),
+            }
+        }
+
+        /// Returns the operation that the corresponding Work Request performed.
+        ///
+        /// This value controls the way that data was sent, the direction of the data flow and the
+        /// valid attributes in the Work Completion.
+        pub fn opcode(&self) -> ibv_wc_opcode::Type {
+            self.opcode
+        }
+
+        /// Returns a 32 bits number, in network order, in an SEND or RDMA WRITE opcodes that is being
+        /// sent along with the payload to the remote side and placed in a Receive Work Completion and
+        /// not in a remote memory buffer
+        ///
+        /// Note that IMM is only returned if `IBV_WC_WITH_IMM` is set in `wc_flags`. If this is not
+        /// the case, no immediate value was provided, and `imm_data` should be interpreted
+        /// differently. See `man ibv_poll_cq` for details.
+        pub fn imm_data(&self) -> Option<u32> {
+            if self.is_valid() && ((self.wc_flags & ibv_wc_flags::IBV_WC_WITH_IMM).0 != 0) {
+                Some(self.imm_data)
+            } else {
+                None
+            }
         }
     }
 
-    /// Returns the operation that the corresponding Work Request performed.
-    ///
-    /// This value controls the way that data was sent, the direction of the data flow and the
-    /// valid attributes in the Work Completion.
-    pub fn opcode(&self) -> ibv_wc_opcode::Type {
-        self.opcode
-    }
-
-    /// Returns a 32 bits number, in network order, in an SEND or RDMA WRITE opcodes that is being
-    /// sent along with the payload to the remote side and placed in a Receive Work Completion and
-    /// not in a remote memory buffer
-    ///
-    /// Note that IMM is only returned if `IBV_WC_WITH_IMM` is set in `wc_flags`. If this is not
-    /// the case, no immediate value was provided, and `imm_data` should be interpreted
-    /// differently. See `man ibv_poll_cq` for details.
-    pub fn imm_data(&self) -> Option<u32> {
-        if self.is_valid() && ((self.wc_flags & ibv_wc_flags::IBV_WC_WITH_IMM).0 != 0) {
-            Some(self.imm_data)
-        } else {
-            None
+    impl Default for ibv_wc {
+        fn default() -> Self {
+            ibv_wc {
+                wr_id: 0,
+                status: ibv_wc_status::IBV_WC_GENERAL_ERR,
+                opcode: ibv_wc_opcode::IBV_WC_LOCAL_INV,
+                vendor_err: 0,
+                byte_len: 0,
+                imm_data: 0,
+                qp_num: 0,
+                src_qp: 0,
+                wc_flags: ibv_wc_flags(0),
+                pkey_index: 0,
+                slid: 0,
+                sl: 0,
+                dlid_path_bits: 0,
+            }
         }
     }
 }
 
-impl Default for ibv_wc {
-    fn default() -> Self {
-        ibv_wc {
-            wr_id: 0,
-            status: ibv_wc_status::IBV_WC_GENERAL_ERR,
-            opcode: ibv_wc_opcode::IBV_WC_LOCAL_INV,
-            vendor_err: 0,
-            byte_len: 0,
-            imm_data: 0,
-            qp_num: 0,
-            src_qp: 0,
-            wc_flags: ibv_wc_flags(0),
-            pkey_index: 0,
-            slid: 0,
-            sl: 0,
-            dlid_path_bits: 0,
-        }
-    }
-}
+pub use inner::*;


### PR DESCRIPTION
Summary:
This diff adds Cargo support for `cuda-sys` and `rdmacore-sys`, which will be necessary for the open source build.

Note - I found that `arc autocargo` does not support `rust_bindgen_library` so these Cargo.tomls were created manually.

Differential Revision: D78414608


