### PR TITLE
[18/n] tensor engine: Simplify CallFunctionError

### DIFF
--- a/monarch_simulator/src/worker.rs
+++ b/monarch_simulator/src/worker.rs
@@ -639,7 +639,7 @@ impl WorkerMessageHandler for WorkerActor {
         _cx: &hyperactor::Context<Self>,
         _ref_id: Ref,
         _stream: StreamRef,
-    ) -> Result<Option<Result<WireValue, ValueError>>> {
+    ) -> Result<Option<Result<WireValue, String>>> {
         bail!("unimplemented: get_ref_unit_tests_only")
     }
 

--- a/monarch_tensor_worker/src/borrow.rs
+++ b/monarch_tensor_worker/src/borrow.rs
@@ -422,10 +422,9 @@ mod tests {
         let error = result
             .context("no such ref")?
             .err()
-            .context("expected error")?
-            .into_call_function_error()?;
+            .context("expected error")?;
         assert!(
-            error.starts_with("DependentError"),
+            error.contains("Computation depended on an input that failed"),
             "If a borrowed value contains an error, downstream calls should propagate that error (unexpected error string: {})",
             error,
         );


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #552
* #539
* #547

The only case we every 'catch' is DependentError. Everything else is just a textural description. So this collapses those cases into just the two cases.

This retains the enum variants as function calls so that we can also reify them again if we need to catch them but having them obscures the places where DependentError needs to be handled differently.

Differential Revision: [D78363663](https://our.internmc.facebook.com/intern/diff/D78363663/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D78363663/)!