### PR TITLE
Lift the `send-to-actor` logic from  `_ActorMeshRefImpl` to `ActorIdRef`

### DIFF
--- a/python/monarch/_src/actor/actor_mesh.py
+++ b/python/monarch/_src/actor/actor_mesh.py
@@ -177,9 +177,12 @@ class _ActorMeshRefImpl(MeshTrait):
             [cast(ActorId, hy_actor_mesh.get(i)) for i in range(len(shape))],
         )
 
-    @staticmethod
-    def from_actor_id(mailbox: Mailbox, actor_id: ActorId) -> "_ActorMeshRefImpl":
-        return _ActorMeshRefImpl(mailbox, None, None, singleton_shape, [actor_id])
+    def monitor(self) -> Optional[ActorMeshMonitor]:
+        return self._actor_mesh.monitor() if self._actor_mesh is not None else None
+
+    @property
+    def shape(self) -> Shape:
+        return self._shape
 
     @property
     def _ndslice(self) -> NDSlice:
@@ -273,6 +276,35 @@ class _ActorMeshRefImpl(MeshTrait):
     def _name_pid(self):
         actor_id0 = self._please_replace_me_actor_ids[0]
         return actor_id0.actor_name, actor_id0.pid
+
+
+class ActorIdFakeMesh:
+    """
+    Fake mesh that represents a single actor. This is used to allow sending a
+    message to a single actor through the mesh API.
+    """
+
+    def __init__(
+        self,
+        actor_id: ActorId,
+        mailbox: Mailbox,
+    ) -> None:
+        self._actor_id = actor_id
+        self._mailbox = mailbox
+
+    def cast(
+        self,
+        message: PythonMessage,
+        selection: Selection,
+    ) -> None:
+        self._mailbox.post(self._actor_id, message)
+
+    @property
+    def shape(self) -> Shape:
+        return singleton_shape
+
+    def monitor(self) -> Optional[ActorMeshMonitor]:
+        return None
 
 
 class Extent(NamedTuple):
@@ -394,7 +426,7 @@ class Endpoint(ABC, Generic[P, R]):
 class ActorEndpoint(Endpoint[P, R]):
     def __init__(
         self,
-        actor_mesh_ref: _ActorMeshRefImpl,
+        actor_mesh_ref: _ActorMeshRefImpl | ActorIdFakeMesh,
         name: str,
         impl: Callable[Concatenate[Any, P], Awaitable[R]],
         mailbox: Mailbox,
@@ -431,15 +463,11 @@ class ActorEndpoint(Endpoint[P, R]):
             importlib.import_module("monarch." + "mesh_controller").actor_send(
                 self, bytes, refs, port, selection
             )
-        shape = self._actor_mesh._shape
+        shape = self._actor_mesh.shape
         return Extent(shape.labels, shape.ndslice.sizes)
 
     def _port(self, once: bool = False) -> "PortTuple[R]":
-        monitor = (
-            None
-            if self._actor_mesh._actor_mesh is None
-            else self._actor_mesh._actor_mesh.monitor()
-        )
+        monitor = self._actor_mesh.monitor()
         return PortTuple.create(self._mailbox, monitor, once)
 
 
@@ -885,13 +913,16 @@ class Actor(MeshTrait):
         )
 
 
-class ActorMeshRef(MeshTrait):
+class _ActorMeshTrait(MeshTrait):
     def __init__(
-        self, Class: Type[T], actor_mesh_ref: _ActorMeshRefImpl, mailbox: Mailbox
+        self,
+        Class: Type[T],
+        actor_mesh_ref: _ActorMeshRefImpl | ActorIdFakeMesh,
+        mailbox: Mailbox,
     ) -> None:
         self.__name__: str = Class.__name__
         self._class: Type[T] = Class
-        self._actor_mesh_ref: _ActorMeshRefImpl = actor_mesh_ref
+        self._actor_mesh_ref: _ActorMeshRefImpl | ActorIdFakeMesh = actor_mesh_ref
         self._mailbox: Mailbox = mailbox
         for attr_name in dir(self._class):
             attr_value = getattr(self._class, attr_name, None)
@@ -933,6 +964,40 @@ class ActorMeshRef(MeshTrait):
             f"'{self.__class__.__name__}' object has no attribute '{name}'"
         )
 
+    @property
+    def _ndslice(self) -> NDSlice:
+        raise NotImplementedError(
+            "should not be called because def slice is overridden"
+        )
+
+    @property
+    def _labels(self) -> Iterable[str]:
+        raise NotImplementedError(
+            "should not be called because def slice is overridden"
+        )
+
+    def _new_with_shape(self, shape: Shape) -> "ActorMeshRef":
+        raise NotImplementedError(
+            "should not be called because def slice is overridden"
+        )
+
+
+class ActorMeshRef(_ActorMeshTrait, Generic[T]):
+    def __init__(
+        self,
+        Class: Type[T],
+        actor_mesh: _ActorMeshRefImpl,
+        mailbox: Mailbox,
+    ) -> None:
+        super().__init__(Class, actor_mesh, mailbox)
+
+    def _inner(self) -> "_ActorMeshRefImpl":
+        mesh = self._actor_mesh_ref
+        assert isinstance(
+            mesh, _ActorMeshRefImpl
+        ), f"mesh type is {mesh.__class__.__name__}"
+        return mesh
+
     def _create(
         self,
         args: Iterable[Any],
@@ -958,29 +1023,35 @@ class ActorMeshRef(MeshTrait):
             self._mailbox,
         )
 
-    @property
-    def _ndslice(self) -> NDSlice:
-        raise NotImplementedError(
-            "should not be called because def slice is overridden"
-        )
-
-    @property
-    def _labels(self) -> Iterable[str]:
-        raise NotImplementedError(
-            "should not be called because def slice is overridden"
-        )
-
-    def _new_with_shape(self, shape: Shape) -> "ActorMeshRef":
-        raise NotImplementedError(
-            "should not be called because def slice is overridden"
-        )
-
     def slice(self, **kwargs) -> "ActorMeshRef":
-        sliced = self._actor_mesh_ref.slice(**kwargs)
+        sliced = self._inner().slice(**kwargs)
         return ActorMeshRef(self._class, sliced, self._mailbox)
 
     def __repr__(self) -> str:
-        return f"ActorMeshRef(class={self._class}, shape={self._actor_mesh_ref._shape})"
+        return f"ActorMeshRef(class={self._class}, shape={self._inner().shape})"
+
+
+class ActorIdRef(_ActorMeshTrait, Generic[T]):
+    def __init__(
+        self,
+        Class: Type[T],
+        actor_id: ActorId,
+        mailbox: Mailbox,
+    ) -> None:
+        super().__init__(Class, ActorIdFakeMesh(actor_id, mailbox), mailbox)
+
+    def _inner(self) -> "ActorId":
+        mesh = self._actor_mesh_ref
+        assert isinstance(
+            mesh, ActorIdFakeMesh
+        ), f"mesh type is {mesh.__class__.__name__}"
+        return mesh._actor_id
+
+    def slice(self, **kwargs) -> "ActorIdRef":
+        raise NotImplementedError("ActorIdRef does not support slicing")
+
+    def __repr__(self) -> str:
+        return f"ActorIdRef(class={self._class}, actor_id={self._inner()})"
 
 
 class ActorError(Exception):

--- a/python/monarch/_src/actor/debugger.py
+++ b/python/monarch/_src/actor/debugger.py
@@ -16,9 +16,8 @@ from typing import cast, Dict, Generator, List, Tuple, Union
 
 from monarch._rust_bindings.monarch_hyperactor.proc import ActorId
 from monarch._src.actor.actor_mesh import (
-    _ActorMeshRefImpl,
     Actor,
-    ActorMeshRef,
+    ActorIdRef,
     DebugContext,
     endpoint,
     MonarchContext,
@@ -511,14 +510,9 @@ class DebugManager(Actor):
         ctx = MonarchContext.get()
         return cast(
             DebugManager,
-            ActorMeshRef(
+            ActorIdRef(
                 DebugManager,
-                _ActorMeshRefImpl.from_actor_id(
-                    ctx.mailbox,
-                    ActorId.from_string(
-                        f"{ctx.proc_id}.{_DEBUG_MANAGER_ACTOR_NAME}[0]"
-                    ),
-                ),
+                ActorId.from_string(f"{ctx.proc_id}.{_DEBUG_MANAGER_ACTOR_NAME}[0]"),
                 ctx.mailbox,
             ),
         )

--- a/python/monarch/rdma.py
+++ b/python/monarch/rdma.py
@@ -14,13 +14,7 @@ from typing import cast, Dict, Optional, Tuple
 import torch
 
 from monarch._rust_bindings.monarch_hyperactor.proc import ActorId
-from monarch._src.actor.actor_mesh import (
-    _ActorMeshRefImpl,
-    Actor,
-    ActorMeshRef,
-    endpoint,
-    MonarchContext,
-)
+from monarch._src.actor.actor_mesh import Actor, ActorIdRef, endpoint, MonarchContext
 
 
 @dataclass
@@ -56,12 +50,9 @@ class RDMAManager(Actor):
         ctx = MonarchContext.get()
         return cast(
             RDMAManager,
-            ActorMeshRef(
+            ActorIdRef(
                 RDMAManager,
-                _ActorMeshRefImpl.from_actor_id(
-                    ctx.mailbox,
-                    ActorId.from_string(f"{proc_id}.rdma_manager[0]"),
-                ),
+                ActorId.from_string(f"{proc_id}.rdma_manager[0]"),
                 ctx.mailbox,
             ),
         )

--- a/python/monarch/rdma.py
+++ b/python/monarch/rdma.py
@@ -4,6 +4,8 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+# pyre-strict
+
 import ctypes
 
 from dataclasses import dataclass


### PR DESCRIPTION
Summary:
`RDMAManger` and `DebugManager` have use cases that need to send messages directly to an actor based on its actor id, instead of to a mesh. Currently the "send-to-actor" function is piggybacking `_ActorMeshRefImpl`'s implementation. This is blocking the migration from `_ActorMeshRefImpl` to `PythonActorMesh`, because we cannot create a mesh solely based on its actor ID. 

To unblock, this diff lifts the `send-to-actor` logic from  `_ActorMeshRefImpl` to `ActorIdRef`, so it is decoupled from `_ActorMeshRefImpl` and `ActorMeshRef`.

Differential Revision: D78302352


