### PR TITLE
: supervision: new enum Unhealthy

### DIFF
--- a/monarch_hyperactor/src/supervision.rs
+++ b/monarch_hyperactor/src/supervision.rs
@@ -23,3 +23,23 @@ pub fn register_python_bindings(module: &Bound<'_, PyModule>) -> PyResult<()> {
     module.add("SupervisionError", py.get_type::<SupervisionError>())?;
     Ok(())
 }
+
+// Shared between mesh types.
+#[derive(Debug, Clone)]
+pub(crate) enum Unhealthy<Event> {
+    SoFarSoGood,    // Still healthy
+    StreamClosed,   // Event stream closed
+    Crashed(Event), // Bad health event received
+}
+
+impl<Event> Unhealthy<Event> {
+    #[allow(dead_code)] // No uses yet.
+    pub(crate) fn is_healthy(&self) -> bool {
+        matches!(self, Unhealthy::SoFarSoGood)
+    }
+
+    #[allow(dead_code)] // No uses yet.
+    pub(crate) fn is_crashed(&self) -> bool {
+        matches!(self, Unhealthy::Crashed(_))
+    }
+}


### PR DESCRIPTION
Summary:
- introduced new type `supervision::Unhealthy`
```rust
 #[derive(Debug, Clone)]
 pub(crate) enum Unhealthy<Event> {
     SoFarSoGood,    // Still healthy
     StreamClosed,   // Event stream closed
     Crashed(Event), // Bad health event received
 }
```
- in `PyProcMesh`
  - replace:
    -  from`Arc<Mutex<Option<Option<ProcEvent>>>>` 
    - to `Arc<Mutex<Unhealthy<ProcEvent>>>`
- in `PythonActorMesh`
  - replace:
    - from: `Arc<Mutex<Option<Option<ActorSupervisionEvent>>>>`
    - to: `Arc<Mutex<Unhealthy<ActorSupervisionEvent>>`

Differential Revision: D78498195


