### PR TITLE
Fix tensor engine unit test failures

### DIFF
--- a/monarch_messages/src/worker.rs
+++ b/monarch_messages/src/worker.rs
@@ -513,7 +513,7 @@ pub enum StreamCreationMode {
 pub enum CallFunctionError {
     #[error("{0}")]
     Error(#[from] anyhow::Error),
-    #[error("Computation depended on an input that failed with errror: {0}")]
+    #[error("Computation depended on an input that failed with error: {0}")]
     DependentError(Arc<CallFunctionError>),
 }
 

--- a/monarch_tensor_worker/src/lib.rs
+++ b/monarch_tensor_worker/src/lib.rs
@@ -1441,7 +1441,7 @@ mod tests {
             .context("no such ref")?
             .err()
             .context("expected error")?;
-        assert!(mutated_ref.contains("InvalidRemoteFunction"));
+        assert!(mutated_ref.contains("failed to resolve function"));
 
         let responses = controller_rx.drain();
         assert_eq!(
@@ -2185,7 +2185,7 @@ mod tests {
                     value
                         .unwrap_err()
                         .backtrace
-                        .contains("InvalidRemoteFunction")
+                        .contains("failed to resolve function")
                 );
             }
             _ => panic!("unexpected response {:#?}", responses),
@@ -2198,7 +2198,7 @@ mod tests {
                     value
                         .unwrap_err()
                         .backtrace
-                        .contains("InvalidRemoteFunction")
+                        .contains("failed to resolve function")
                 );
             }
             _ => panic!("unexpected response {:#?}", responses),

--- a/monarch_tensor_worker/src/stream.rs
+++ b/monarch_tensor_worker/src/stream.rs
@@ -2736,7 +2736,7 @@ mod tests {
             let error = result.unwrap().unwrap_err();
 
             // Check that the error contains the expected strings
-            let error_str = format!("{:?}", error);
+            let error_str = error.to_string();
             assert!(
                 error_str.contains("recording failed"),
                 "Error should contain 'recording failed': {}",
@@ -3034,14 +3034,14 @@ mod tests {
                 .unwrap()
                 .unwrap_err();
             // Check that the error contains the expected strings
-            let error_str = format!("{:?}", result_error);
+            let error_str = result_error.to_string();
             assert!(
                 error_str.contains("recording failed"),
                 "Error should contain 'recording failed': {}",
                 error_str
             );
             assert!(
-                error_str.contains("torch operator failed"),
+                error_str.contains("torch operator error"),
                 "Error should contain 'torch operator failed': {}",
                 error_str
             );
@@ -3096,7 +3096,7 @@ mod tests {
                 .unwrap()
                 .unwrap_err();
             // Check that the error contains the expected strings
-            let error_str = format!("{:?}", result_error);
+            let error_str = result_error.to_string();
             assert!(
                 error_str.contains("Computation depended on an input that failed"),
                 "Error should contain dependency message: {}",
@@ -3118,7 +3118,7 @@ mod tests {
             3.into(),
             captured_ref,
             &mut test_setup.controller_rx,
-            "RecordingFailed",
+            "recording failed",
         )
         .await;
 
@@ -3477,7 +3477,7 @@ mod tests {
             .unwrap_err();
 
         // Check that the error contains the expected strings
-        let error_str = format!("{:?}", result_error);
+        let error_str = result_error.to_string();
         assert!(
             error_str.contains("Computation depended on an input that failed"),
             "Error should contain dependency message: {}",
@@ -3486,7 +3486,7 @@ mod tests {
 
         // Since we're checking for pointer equality in the original code, we need to ensure
         // the error is propagated correctly. We can check that the original error message is contained.
-        let input_error_str = format!("{:?}", input_error);
+        let input_error_str = input_error.to_string();
         assert!(
             error_str.contains(&input_error_str),
             "Error should contain the original error: {}",
@@ -4232,7 +4232,7 @@ mod tests {
             .unwrap()
             .unwrap_err();
         // Check that the error contains the expected string
-        let error_str = format!("{:?}", real_result_err);
+        let error_str = real_result_err.to_string();
         assert!(
             error_str.contains("recording failed"),
             "Error should contain 'recording failed': {}",
@@ -4309,7 +4309,7 @@ mod tests {
             .unwrap()
             .unwrap_err();
         // Check that the error contains the expected strings
-        let error_str = format!("{:?}", real_result_err);
+        let error_str = real_result_err.to_string();
         assert!(
             error_str.contains("Computation depended on an input that failed"),
             "Error should contain dependency message: {}",


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #565
* __->__ #571

Fixes errors like T231366522 which were due to strings not matching correctly when simplifying the error messages. For some reason those tests were not run on the diff.

Differential Revision: [D78509944](https://our.internmc.facebook.com/intern/diff/D78509944/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D78509944/)!