### PR TITLE
Define blocking variants of everything in terms of non-blocking variant.

### DIFF
--- a/monarch_rdma/extension/lib.rs
+++ b/monarch_rdma/extension/lib.rs
@@ -13,6 +13,7 @@ use hyperactor::Named;
 use hyperactor::ProcId;
 use hyperactor_mesh::RootActorMesh;
 use hyperactor_mesh::shared_cell::SharedCell;
+use monarch_hyperactor::actor::PyPythonTask;
 use monarch_hyperactor::mailbox::PyMailbox;
 use monarch_hyperactor::proc_mesh::PyProcMesh;
 use monarch_hyperactor::runtime::signal_safe_block_on;
@@ -66,26 +67,6 @@ async fn create_rdma_buffer(
 #[pymethods]
 impl PyRdmaBuffer {
     #[classmethod]
-    fn create_rdma_buffer_blocking<'py>(
-        _cls: &Bound<'_, PyType>,
-        py: Python<'py>,
-        addr: usize,
-        size: usize,
-        proc_id: String,
-        client: PyMailbox,
-    ) -> PyResult<PyRdmaBuffer> {
-        if !ibverbs_supported() {
-            return Err(PyException::new_err(
-                "ibverbs is not supported on this system",
-            ));
-        }
-        signal_safe_block_on(
-            py,
-            create_rdma_buffer(addr, size, proc_id.parse().unwrap(), client),
-        )?
-    }
-
-    #[classmethod]
     fn create_rdma_buffer_nonblocking<'py>(
         _cls: &Bound<'_, PyType>,
         py: Python<'py>,
@@ -93,16 +74,18 @@ impl PyRdmaBuffer {
         size: usize,
         proc_id: String,
         client: PyMailbox,
-    ) -> PyResult<Bound<'py, PyAny>> {
+    ) -> PyResult<PyPythonTask> {
         if !ibverbs_supported() {
             return Err(PyException::new_err(
                 "ibverbs is not supported on this system",
             ));
         }
-        pyo3_async_runtimes::tokio::future_into_py(
-            py,
-            create_rdma_buffer(addr, size, proc_id.parse().unwrap(), client),
-        )
+        PyPythonTask::new(create_rdma_buffer(
+            addr,
+            size,
+            proc_id.parse().unwrap(),
+            client,
+        ))
     }
 
     #[classmethod]
@@ -136,9 +119,9 @@ impl PyRdmaBuffer {
         local_proc_id: String,
         client: PyMailbox,
         timeout: u64,
-    ) -> PyResult<Bound<'py, PyAny>> {
+    ) -> PyResult<PyPythonTask> {
         let (local_owner_ref, buffer) = setup_rdma_context(self, local_proc_id);
-        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+        PyPythonTask::new(async move {
             let caps = client.get_inner();
             let local_buffer = local_owner_ref.request_buffer(caps, addr, size).await?;
             let _result_ = local_buffer
@@ -147,41 +130,6 @@ impl PyRdmaBuffer {
                 .map_err(|e| PyException::new_err(format!("failed to read into buffer: {}", e)))?;
             Ok(())
         })
-    }
-
-    /// Reads data from the local buffer and places it into this remote RDMA buffer.
-    ///
-    /// This operation appears as "read_into" from the caller's perspective (reading from local memory
-    /// into the remote buffer), but internally it's implemented as a "write_from" operation on the
-    /// local buffer since the data flows from the local buffer to the remote one.
-    ///
-    /// This is the blocking version of `read_into`, compatible with non asyncio Python code.
-    ///
-    /// # Arguments
-    /// * `addr` - The address of the local buffer to read from
-    /// * `size` - The size of the data to transfer
-    /// * `local_proc_id` - The process ID where the local buffer resides
-    /// * `client` - The mailbox for communication
-    /// * `timeout` - Maximum time in milliseconds to wait for the operation
-    #[pyo3(signature = (addr, size, local_proc_id, client, timeout))]
-    fn read_into_blocking<'py>(
-        &self,
-        py: Python<'py>,
-        addr: usize,
-        size: usize,
-        local_proc_id: String,
-        client: PyMailbox,
-        timeout: u64,
-    ) -> PyResult<bool> {
-        let (local_owner_ref, buffer) = setup_rdma_context(self, local_proc_id);
-        signal_safe_block_on(py, async move {
-            let caps = client.get_inner();
-            let local_buffer = local_owner_ref.request_buffer(caps, addr, size).await?;
-            local_buffer
-                .write_from(caps, buffer, timeout)
-                .await
-                .map_err(|e| PyException::new_err(format!("failed to read into buffer: {}", e)))
-        })?
     }
 
     /// Writes data from this remote RDMA buffer into a local buffer.
@@ -205,9 +153,9 @@ impl PyRdmaBuffer {
         local_proc_id: String,
         client: PyMailbox,
         timeout: u64,
-    ) -> PyResult<Bound<'py, PyAny>> {
+    ) -> PyResult<PyPythonTask> {
         let (local_owner_ref, buffer) = setup_rdma_context(self, local_proc_id);
-        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+        PyPythonTask::new(async move {
             let caps = client.get_inner();
             let local_buffer = local_owner_ref.request_buffer(caps, addr, size).await?;
             let _result_ = local_buffer
@@ -216,41 +164,6 @@ impl PyRdmaBuffer {
                 .map_err(|e| PyException::new_err(format!("failed to write from buffer: {}", e)))?;
             Ok(())
         })
-    }
-
-    /// Writes data from this remote RDMA buffer into a local buffer.
-    ///
-    /// This operation appears as "write_from" from the caller's perspective (writing from the remote
-    /// buffer into local memory), but internally it's implemented as a "read_into" operation on the
-    /// local buffer since the data flows from the remote buffer to the local one.
-    ///
-    /// This is the blocking version of `write_from`, compatible with non asyncio Python code.
-    ///
-    /// # Arguments
-    /// * `addr` - The address of the local buffer to write to
-    /// * `size` - The size of the data to transfer
-    /// * `local_proc_id` - The process ID where the local buffer resides
-    /// * `client` - The mailbox for communication
-    /// * `timeout` - Maximum time in milliseconds to wait for the operation
-    #[pyo3(signature = (addr, size, local_proc_id, client, timeout))]
-    fn write_from_blocking<'py>(
-        &self,
-        py: Python<'py>,
-        addr: usize,
-        size: usize,
-        local_proc_id: String,
-        client: PyMailbox,
-        timeout: u64,
-    ) -> PyResult<bool> {
-        let (local_owner_ref, buffer) = setup_rdma_context(self, local_proc_id);
-        signal_safe_block_on(py, async move {
-            let caps = client.get_inner();
-            let local_buffer = local_owner_ref.request_buffer(caps, addr, size).await?;
-            local_buffer
-                .read_into(caps, buffer, timeout)
-                .await
-                .map_err(|e| PyException::new_err(format!("failed to write from buffer: {}", e)))
-        })?
     }
 
     fn __reduce__(&self) -> PyResult<(PyObject, PyObject)> {
@@ -272,18 +185,10 @@ impl PyRdmaBuffer {
         Ok(deserialized)
     }
 
-    fn drop<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+    fn drop<'py>(&self) -> PyResult<PyPythonTask> {
         // no op with CPUs, currently a stub.
         // TODO - replace with correct GPU behavior.
-        pyo3_async_runtimes::tokio::future_into_py(py, async move { Ok(()) })
-    }
-
-    fn drop_blocking<'py>(&self, py: Python<'py>) -> PyResult<()> {
-        signal_safe_block_on(py, async move {
-            // no op with CPUs, currently a stub.
-            // TODO - replace with correct GPU behavior.
-            Ok(())
-        })?
+        PyPythonTask::new(async move { Ok(()) })
     }
 }
 

--- a/python/monarch/_rust_bindings/monarch_hyperactor/alloc.pyi
+++ b/python/monarch/_rust_bindings/monarch_hyperactor/alloc.pyi
@@ -10,6 +10,8 @@ from datetime import timedelta
 from typing import final, Optional
 
 from monarch._rust_bindings.monarch_hyperactor.alloc import Alloc, AllocSpec
+from monarch._rust_bindings.monarch_hyperactor.mailbox import Mailbox, PythonTask
+
 from typing_extensions import Self
 
 class Alloc:
@@ -61,19 +63,9 @@ class ProcessAllocatorBase:
         """
         ...
 
-    async def allocate_nonblocking(self, spec: AllocSpec) -> Alloc:
+    def allocate_nonblocking(self, spec: AllocSpec) -> PythonTask[Alloc]:
         """
         Allocate a process according to the provided spec.
-
-        Arguments:
-        - `spec`: The spec to allocate according to.
-        """
-        ...
-
-    def allocate_blocking(self, spec: AllocSpec) -> Alloc:
-        """
-        Allocate a process according to the provided spec, blocking until an
-        alloc is returned.
 
         Arguments:
         - `spec`: The spec to allocate according to.
@@ -81,19 +73,9 @@ class ProcessAllocatorBase:
         ...
 
 class LocalAllocatorBase:
-    async def allocate_nonblocking(self, spec: AllocSpec) -> Alloc:
+    def allocate_nonblocking(self, spec: AllocSpec) -> PythonTask[Alloc]:
         """
         Allocate a process according to the provided spec.
-
-        Arguments:
-        - `spec`: The spec to allocate according to.
-        """
-        ...
-
-    def allocate_blocking(self, spec: AllocSpec) -> Alloc:
-        """
-        Allocate a process according to the provided spec, blocking until an
-        alloc is returned.
 
         Arguments:
         - `spec`: The spec to allocate according to.
@@ -101,19 +83,9 @@ class LocalAllocatorBase:
         ...
 
 class SimAllocatorBase:
-    async def allocate_nonblocking(self, spec: AllocSpec) -> Alloc:
+    def allocate_nonblocking(self, spec: AllocSpec) -> PythonTask[Alloc]:
         """
         Allocate a process according to the provided spec.
-
-        Arguments:
-        - `spec`: The spec to allocate according to.
-        """
-        ...
-
-    def allocate_blocking(self, spec: AllocSpec) -> Alloc:
-        """
-        Allocate a process according to the provided spec, blocking until an
-        alloc is returned.
 
         Arguments:
         - `spec`: The spec to allocate according to.
@@ -138,19 +110,9 @@ class RemoteAllocatorBase:
         """
         ...
 
-    async def allocate_nonblocking(self, spec: AllocSpec) -> Alloc:
+    def allocate_nonblocking(self, spec: AllocSpec) -> PythonTask[Alloc]:
         """
         Allocate a process according to the provided spec.
-
-        Arguments:
-        - `spec`: The spec to allocate according to.
-        """
-        ...
-
-    def allocate_blocking(self, spec: AllocSpec) -> Alloc:
-        """
-        Allocate a process according to the provided spec, blocking until an
-        alloc is returned.
 
         Arguments:
         - `spec`: The spec to allocate according to.

--- a/python/monarch/_rust_bindings/monarch_hyperactor/proc_mesh.pyi
+++ b/python/monarch/_rust_bindings/monarch_hyperactor/proc_mesh.pyi
@@ -12,13 +12,13 @@ from monarch._rust_bindings.monarch_hyperactor.actor import Actor
 from monarch._rust_bindings.monarch_hyperactor.actor_mesh import PythonActorMesh
 
 from monarch._rust_bindings.monarch_hyperactor.alloc import Alloc
-from monarch._rust_bindings.monarch_hyperactor.mailbox import Mailbox
+from monarch._rust_bindings.monarch_hyperactor.mailbox import Mailbox, PythonTask
 from monarch._rust_bindings.monarch_hyperactor.shape import Shape
 
 @final
 class ProcMesh:
     @classmethod
-    async def allocate_nonblocking(self, alloc: Alloc) -> ProcMesh:
+    def allocate_nonblocking(self, alloc: Alloc) -> PythonTask[ProcMesh]:
         """
         Allocate a process mesh according to the provided alloc.
         Returns when the mesh is fully allocated.
@@ -28,30 +28,11 @@ class ProcMesh:
         """
         ...
 
-    @classmethod
-    def allocate_blocking(self, alloc: Alloc) -> ProcMesh:
-        """
-        Allocate a process mesh according to the provided alloc.
-        Blocks until the mesh is fully allocated.
-
-        Arguments:
-        - `alloc`: The alloc to allocate according to.
-        """
-        ...
-
-    async def spawn_nonblocking(self, name: str, actor: Type[Actor]) -> PythonActorMesh:
+    def spawn_nonblocking(
+        self, name: str, actor: Type[Actor]
+    ) -> PythonTask[PythonActorMesh]:
         """
         Spawn a new actor on this mesh.
-
-        Arguments:
-        - `name`: Name of the actor.
-        - `actor`: The type of the actor that will be spawned.
-        """
-        ...
-
-    async def spawn_blocking(self, name: str, actor: Type[Actor]) -> PythonActorMesh:
-        """
-        Spawn a new actor on this mesh. Blocks until the actor is fully spawned.
 
         Arguments:
         - `name`: Name of the actor.
@@ -81,15 +62,9 @@ class ProcMesh:
         """
         ...
 
-    async def stop_nonblocking(self) -> None:
+    def stop_nonblocking(self) -> PythonTask[None]:
         """
         Stop the proc mesh.
-        """
-        ...
-
-    def stop_blocking(self) -> None:
-        """
-        Stop the proc mesh. Blocks until the mesh is fully stopped.
         """
         ...
 

--- a/python/monarch/_rust_bindings/rdma/__init__.pyi
+++ b/python/monarch/_rust_bindings/rdma/__init__.pyi
@@ -6,6 +6,8 @@
 
 from typing import Any, final, Optional
 
+from monarch._rust_bindings.monarch_hyperactor.mailbox import PythonTask
+
 @final
 class _RdmaMemoryRegionView:
     def __init__(self, addr: int, size_in_bytes: int) -> None: ...
@@ -22,47 +24,26 @@ class _RdmaBuffer:
     name: str
 
     @classmethod
-    def create_rdma_buffer_blocking(
+    def create_rdma_buffer_nonblocking(
         cls, addr: int, size: int, proc_id: str, client: Any
-    ) -> _RdmaBuffer: ...
-    @classmethod
-    async def create_rdma_buffer_nonblocking(
-        cls, addr: int, size: int, proc_id: str, client: Any
-    ) -> Any: ...
-    async def drop(self, client: Any): ...
-    def drop_blocking(self, client: Any): ...
-    async def read_into(
+    ) -> PythonTask[Any]: ...
+    def drop(self, client: Any) -> PythonTask[None]: ...
+    def read_into(
         self,
         addr: int,
         size: int,
         local_proc_id: str,
         client: Any,
         timeout: int,
-    ) -> Any: ...
-    def read_into_blocking(
+    ) -> PythonTask[Any]: ...
+    def write_from(
         self,
         addr: int,
         size: int,
         local_proc_id: str,
         client: Any,
         timeout: int,
-    ) -> Any: ...
-    async def write_from(
-        self,
-        addr: int,
-        size: int,
-        local_proc_id: str,
-        client: Any,
-        timeout: int,
-    ) -> Any: ...
-    def write_from_blocking(
-        self,
-        addr: int,
-        size: int,
-        local_proc_id: str,
-        client: Any,
-        timeout: int,
-    ) -> Any: ...
+    ) -> PythonTask[Any]: ...
     def __reduce__(self) -> tuple: ...
     def __repr__(self) -> str: ...
     @staticmethod

--- a/python/monarch/_src/actor/allocator.py
+++ b/python/monarch/_src/actor/allocator.py
@@ -42,10 +42,7 @@ class ProcessAllocator(ProcessAllocatorBase):
         Returns:
         - A future that will be fulfilled when the requested allocation is fulfilled.
         """
-        return Future(
-            lambda: self.allocate_nonblocking(spec),
-            lambda: self.allocate_blocking(spec),
-        )
+        return Future(impl=lambda: self.allocate_nonblocking(spec), requires_loop=False)
 
 
 @final
@@ -64,10 +61,7 @@ class LocalAllocator(LocalAllocatorBase):
         Returns:
         - A future that will be fulfilled when the requested allocation is fulfilled.
         """
-        return Future(
-            lambda: self.allocate_nonblocking(spec),
-            lambda: self.allocate_blocking(spec),
-        )
+        return Future(impl=lambda: self.allocate_nonblocking(spec), requires_loop=False)
 
 
 @final
@@ -86,10 +80,7 @@ class SimAllocator(SimAllocatorBase):
         Returns:
         - A future that will be fulfilled when the requested allocation is fulfilled.
         """
-        return Future(
-            lambda: self.allocate_nonblocking(spec),
-            lambda: self.allocate_blocking(spec),
-        )
+        return Future(impl=lambda: self.allocate_nonblocking(spec), requires_loop=False)
 
 
 class RemoteAllocInitializer(abc.ABC):
@@ -235,7 +226,4 @@ class RemoteAllocator(RemoteAllocatorBase):
         Returns:
         - A future that will be fulfilled when the requested allocation is fulfilled.
         """
-        return Future(
-            lambda: self.allocate_nonblocking(spec),
-            lambda: self.allocate_blocking(spec),
-        )
+        return Future(impl=lambda: self.allocate_nonblocking(spec), requires_loop=False)

--- a/python/tests/test_allocator.py
+++ b/python/tests/test_allocator.py
@@ -204,7 +204,7 @@ class TestRemoteAllocator(unittest.IsolatedAsyncioTestCase):
 
             self.assert_computed_world_size(values, world_size)
 
-    async def test_stop_proc_mesh_blocking(self) -> None:
+    def test_stop_proc_mesh_blocking(self) -> None:
         spec = AllocSpec(AllocConstraints(), host=2, gpu=4)
         with remote_process_allocator() as host1, remote_process_allocator() as host2:
             allocator = RemoteAllocator(
@@ -212,8 +212,8 @@ class TestRemoteAllocator(unittest.IsolatedAsyncioTestCase):
                 initializer=StaticRemoteAllocInitializer(host1, host2),
                 heartbeat_interval=_100_MILLISECONDS,
             )
-            alloc = await allocator.allocate(spec)
-            proc_mesh = await ProcMesh.from_alloc(alloc)
+            alloc = allocator.allocate(spec).get()
+            proc_mesh = ProcMesh.from_alloc(alloc).get()
             actor = proc_mesh.spawn("test_actor", TestActor).get()
             proc_mesh.stop().get()
             with self.assertRaises(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #585
* #565

This uses the PyPythonTask functionality developed in the last diff to delete all the _blocking variants of exposing tokio async work to Python.

The new approach is to define the entire thing in async and then wrap it in a future:

`Future(async_impl, requires_loop=False)`.

If async_impl only awaits on (1) PythonTask objects, and (2) other coroutine functions, then it is correct to pass `requires_loop=False`, which keeps execution speed the same as the blocking version. Otherwise, pass requires_loop=True and the code will work correctly in both async and sync contexts.

Differential Revision: [D78585722](https://our.internmc.facebook.com/intern/diff/D78585722/)