### PR TITLE
Fix Python auto-reloader bug

### DIFF
--- a/python/monarch/_src/actor/code_sync/auto_reload.py
+++ b/python/monarch/_src/actor/code_sync/auto_reload.py
@@ -120,7 +120,7 @@ class SysAuditImportHook:
             module = sys.modules.get(module_name)
             if module is None:
                 return
-            if module.__file__ is None:
+            if getattr(module, "__file__", None) is None:
                 return
             (code_obj,) = args
             if code_obj.co_filename is None:

--- a/python/tests/code_sync/test_auto_reload.py
+++ b/python/tests/code_sync/test_auto_reload.py
@@ -67,6 +67,18 @@ class TestAutoReloader(unittest.TestCase):
                 )
                 self.assertEqual(test_module.foo, 2)
 
+    def test_builtin_module_no_file_attribute(self):
+        """Test that modules without __file__ attribute don't cause AttributeError."""
+        reloader = AutoReloader()
+        with SysAuditImportHook.install(reloader.import_callback):
+            # C extensions don't have a `__file__` attr and won't trigger an "exec"
+            # event, so we're verifying that an unrelated "exec" (via `eval`) won't
+            # cause issues.
+            assert "_tracemalloc" not in sys.modules
+            import _tracemalloc  # noqa
+
+            eval("5")  # trigger `exec` event in the reloader
+
     def test_pyc_only_change(self):
         with importable_workspace() as workspace:
             reloader = AutoReloader()


### PR DESCRIPTION
Summary:
Our reloader hook needs to combine info from two separate, successive
audit events -- an "import" followed by "exec".  There was a bug where
an "import" of a C extension (which doesn't trigger "exec"s), followed by
an arbitrary `exec`/`eval` would confuse the hook and cause it to crash.

Add a test for this case and fix.

Reviewed By: highker, suo

Differential Revision: D78623922


