### PR TITLE
Fix debugger test

### DIFF
--- a/python/monarch/_src/actor/actor_mesh.py
+++ b/python/monarch/_src/actor/actor_mesh.py
@@ -18,7 +18,6 @@ import random
 import traceback
 
 from abc import ABC, abstractmethod
-from contextlib import contextmanager
 
 from dataclasses import dataclass
 from operator import mul
@@ -80,6 +79,7 @@ from monarch._src.actor.pdb_wrapper import PdbWrapper
 from monarch._src.actor.pickle import flatten, unflatten
 
 from monarch._src.actor.shape import MeshTrait, NDSlice
+from monarch._src.actor.sync_state import fake_sync_state
 
 if TYPE_CHECKING:
     from monarch._src.actor.proc_mesh import ProcMesh
@@ -686,16 +686,6 @@ singleton_shape = Shape([], NDSlice(offset=0, sizes=[], strides=[]))
 # We do this by blanking out the running event loop during the call to the synchronous actor function.
 
 
-@contextmanager
-def fake_sync_state():
-    prev_loop = asyncio.events._get_running_loop()
-    asyncio._set_running_loop(None)
-    try:
-        yield
-    finally:
-        asyncio._set_running_loop(prev_loop)
-
-
 class _Actor:
     """
     This is the message handling implementation of a Python actor.
@@ -828,16 +818,17 @@ class _Actor:
         from monarch._src.actor.debugger import DebugManager
 
         if (pdb_wrapper := DebugContext.get().pdb_wrapper) is not None:
-            ctx = MonarchContext.get()
-            pdb_wrapper = PdbWrapper(
-                ctx.point.rank,
-                ctx.point.shape.coordinates(ctx.point.rank),
-                ctx.mailbox.actor_id,
-                DebugManager.ref().get_debug_client.call_one().get(),
-            )
-            DebugContext.set(DebugContext(pdb_wrapper))
-            pdb_wrapper.post_mortem(exc_tb)
-            self._maybe_exit_debugger(do_continue=False)
+            with fake_sync_state():
+                ctx = MonarchContext.get()
+                pdb_wrapper = PdbWrapper(
+                    ctx.point.rank,
+                    ctx.point.shape.coordinates(ctx.point.rank),
+                    ctx.mailbox.actor_id,
+                    DebugManager.ref().get_debug_client.call_one().get(),
+                )
+                DebugContext.set(DebugContext(pdb_wrapper))
+                pdb_wrapper.post_mortem(exc_tb)
+                self._maybe_exit_debugger(do_continue=False)
 
 
 def _is_mailbox(x: object) -> bool:

--- a/python/monarch/_src/actor/debugger.py
+++ b/python/monarch/_src/actor/debugger.py
@@ -24,6 +24,7 @@ from monarch._src.actor.actor_mesh import (
     MonarchContext,
 )
 from monarch._src.actor.pdb_wrapper import DebuggerWrite, PdbWrapper
+from monarch._src.actor.sync_state import fake_sync_state
 from tabulate import tabulate
 
 
@@ -549,12 +550,14 @@ def remote_breakpointhook():
             "exists on both your client and worker processes."
         )
 
+    with fake_sync_state():
+        manager = DebugManager.ref().get_debug_client.call_one().get()
     ctx = MonarchContext.get()
     pdb_wrapper = PdbWrapper(
         ctx.point.rank,
         ctx.point.shape.coordinates(ctx.point.rank),
         ctx.mailbox.actor_id,
-        DebugManager.ref().get_debug_client.call_one().get(),
+        manager,
     )
     DebugContext.set(DebugContext(pdb_wrapper))
     pdb_wrapper.set_trace(frame)

--- a/python/monarch/_src/actor/sync_state.py
+++ b/python/monarch/_src/actor/sync_state.py
@@ -1,0 +1,18 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import asyncio
+from contextlib import contextmanager
+
+
+@contextmanager
+def fake_sync_state():
+    prev_loop = asyncio.events._get_running_loop()
+    asyncio._set_running_loop(None)
+    try:
+        yield
+    finally:
+        asyncio._set_running_loop(prev_loop)

--- a/python/tests/test_allocator.py
+++ b/python/tests/test_allocator.py
@@ -33,14 +33,13 @@ from monarch._rust_bindings.monarch_hyperactor.channel import (
     ChannelTransport,
 )
 
-from monarch._src.actor.actor_mesh import fake_sync_state
-
 from monarch._src.actor.allocator import (
     ALLOC_LABEL_PROC_MESH_NAME,
     RemoteAllocator,
     StaticRemoteAllocInitializer,
     TorchXRemoteAllocInitializer,
 )
+from monarch._src.actor.sync_state import fake_sync_state
 from monarch.actor import (
     Actor,
     current_rank,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #590

D78585722  broke test_debug and somehow the tests don't run on diffs.

This adds the necessary annotations to make it ok for the  debugger code to block the existing event loop while it is doing debugging stuff.

Differential Revision: [D78634155](https://our.internmc.facebook.com/intern/diff/D78634155/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D78634155/)!