### PR TITLE
perf fix for channel over MetaTls

### DIFF
--- a/hyperactor/src/channel/net.rs
+++ b/hyperactor/src/channel/net.rs
@@ -3186,8 +3186,7 @@ mod tests {
             let (local_addr, mut rx) = crate::channel::serve::<String>(addr).await.unwrap();
             tracing::info!("local_addr: {:?}", local_addr);
             {
-
-                let size  = 200 * 1000 * 1000;
+                let size = 200 * 1000 * 1000;
                 let msg = "x".repeat(size);
                 let tx = dial::<String>(local_addr).unwrap();
                 let now: Instant = Instant::now();
@@ -3204,8 +3203,8 @@ mod tests {
             tracing::info!("testing with metatls");
             let addr = ChannelAddr::any(ChannelTransport::MetaTls);
             let elapsed = send_message(addr).await;
-            // e.g. elapsed: 26.743396697s
-            assert!(elapsed.as_secs() > 20);
+            // e.g. elapsed: 650ms
+            assert!(elapsed.as_secs() < 2);
         }
 
         {
@@ -3218,7 +3217,7 @@ mod tests {
                 _ => panic!("unexpected addr: {:?}", addr),
             }
             let elapsed = send_message(addr).await;
-            // e.g elapsed: 653.70663ms
+            // e.g elapsed: 350ms
             assert!(elapsed.as_secs() < 2);
         }
     }


### PR DESCRIPTION
Summary:
Throughput of channel on MetaTls is surprisingly low, it is much lower than regular TCP without TLS.

Profiling shows most of the time is spent in memset of buffer: https://fburl.com/strobelight/bxxdyloh,
Hot stack: P1879123816

Root cause:

TLS record size is 16KB, so every poll will get 16KB of data, but we use a buf of total message size to
receive the record, in my test, it is 70MB. The worst thing is, TLS lib will zero-out the whole 70MB
every time: e.g. P1879474802. As a result, the larger the message, the worse the perf.


This diff propose a mitigate to the problem, but it makes changes to rustls.

* In monarch, we can get around of this problem but implementing our own framing, making sure size of
each fame is fairly small.
* But this is also a real problem in rust TLS lib, its API doesn't tell user about such a perf trap. It should
either fix the perf issue, or explicitly asking users to always use small buffer (which I don't think it
is desible behavior), so I still think it should be fixed in Rust TLS.

Differential Revision: D78875272


