### PR TITLE
Update futures 0.3.30 -> 0.3.31

### DIFF
--- a/hyperactor/Cargo.toml
+++ b/hyperactor/Cargo.toml
@@ -31,7 +31,7 @@ derivative = "2.2"
 dns-lookup = "1.0"
 enum-as-inner = "0.6.0"
 erased-serde = "0.3.27"
-futures = { version = "0.3.30", features = ["async-await", "compat"] }
+futures = { version = "0.3.31", features = ["async-await", "compat"] }
 hostname = "0.3"
 hyperactor_macros = { version = "0.0.0", path = "../hyperactor_macros" }
 hyperactor_telemetry = { version = "0.0.0", path = "../hyperactor_telemetry" }

--- a/hyperactor_mesh/Cargo.toml
+++ b/hyperactor_mesh/Cargo.toml
@@ -42,7 +42,7 @@ clap = { version = "4.5.41", features = ["derive", "env", "string", "unicode", "
 dashmap = { version = "5.5.3", features = ["rayon", "serde"] }
 enum-as-inner = "0.6.0"
 erased-serde = "0.3.27"
-futures = { version = "0.3.30", features = ["async-await", "compat"] }
+futures = { version = "0.3.31", features = ["async-await", "compat"] }
 hostname = "0.3"
 hyperactor = { version = "0.0.0", path = "../hyperactor" }
 hyperactor_mesh_macros = { version = "0.0.0", path = "../hyperactor_mesh_macros" }

--- a/hyperactor_multiprocess/Cargo.toml
+++ b/hyperactor_multiprocess/Cargo.toml
@@ -13,7 +13,7 @@ async-trait = "0.1.86"
 bincode = "1.3.3"
 dashmap = { version = "5.5.3", features = ["rayon", "serde"] }
 enum-as-inner = "0.6.0"
-futures = { version = "0.3.30", features = ["async-await", "compat"] }
+futures = { version = "0.3.31", features = ["async-await", "compat"] }
 hyperactor = { version = "0.0.0", path = "../hyperactor" }
 hyperactor_mesh = { version = "0.0.0", path = "../hyperactor_mesh" }
 hyperactor_telemetry = { version = "0.0.0", path = "../hyperactor_telemetry" }

--- a/monarch_extension/Cargo.toml
+++ b/monarch_extension/Cargo.toml
@@ -19,7 +19,7 @@ async-trait = "0.1.86"
 bincode = "1.3.3"
 clap = { version = "4.5.41", features = ["derive", "env", "string", "unicode", "wrap_help"] }
 controller = { version = "0.0.0", path = "../controller", optional = true }
-futures = { version = "0.3.30", features = ["async-await", "compat"] }
+futures = { version = "0.3.31", features = ["async-await", "compat"] }
 hyperactor = { version = "0.0.0", path = "../hyperactor" }
 hyperactor_mesh = { version = "0.0.0", path = "../hyperactor_mesh" }
 hyperactor_multiprocess = { version = "0.0.0", path = "../hyperactor_multiprocess" }

--- a/monarch_hyperactor/Cargo.toml
+++ b/monarch_hyperactor/Cargo.toml
@@ -19,7 +19,7 @@ bincode = "1.3.3"
 clap = { version = "4.5.41", features = ["derive", "env", "string", "unicode", "wrap_help"] }
 erased-serde = "0.3.27"
 fbinit = { version = "0.2.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main" }
-futures = { version = "0.3.30", features = ["async-await", "compat"] }
+futures = { version = "0.3.31", features = ["async-await", "compat"] }
 hyperactor = { version = "0.0.0", path = "../hyperactor" }
 hyperactor_mesh = { version = "0.0.0", path = "../hyperactor_mesh" }
 hyperactor_multiprocess = { version = "0.0.0", path = "../hyperactor_multiprocess" }

--- a/monarch_simulator/Cargo.toml
+++ b/monarch_simulator/Cargo.toml
@@ -12,7 +12,7 @@ anyhow = "1.0.98"
 async-trait = "0.1.86"
 controller = { version = "0.0.0", path = "../controller" }
 dashmap = { version = "5.5.3", features = ["rayon", "serde"] }
-futures = { version = "0.3.30", features = ["async-await", "compat"] }
+futures = { version = "0.3.31", features = ["async-await", "compat"] }
 hyperactor = { version = "0.0.0", path = "../hyperactor" }
 hyperactor_multiprocess = { version = "0.0.0", path = "../hyperactor_multiprocess" }
 lazy_static = "1.5"

--- a/monarch_tensor_worker/Cargo.toml
+++ b/monarch_tensor_worker/Cargo.toml
@@ -14,7 +14,7 @@ bincode = "1.3.3"
 clap = { version = "4.5.41", features = ["derive", "env", "string", "unicode", "wrap_help"] }
 cxx = "1.0.119"
 derive_more = { version = "1.0.0", features = ["full"] }
-futures = { version = "0.3.30", features = ["async-await", "compat"] }
+futures = { version = "0.3.31", features = ["async-await", "compat"] }
 hyperactor = { version = "0.0.0", path = "../hyperactor" }
 hyperactor_mesh = { version = "0.0.0", path = "../hyperactor_mesh" }
 hyperactor_multiprocess = { version = "0.0.0", path = "../hyperactor_multiprocess" }

--- a/preempt_rwlock/Cargo.toml
+++ b/preempt_rwlock/Cargo.toml
@@ -12,4 +12,4 @@ tokio = { version = "1.46.1", features = ["full", "test-util", "tracing"] }
 
 [dev-dependencies]
 anyhow = "1.0.98"
-futures = { version = "0.3.30", features = ["async-await", "compat"] }
+futures = { version = "0.3.31", features = ["async-await", "compat"] }


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebook/fb303/pull/70

0.3.31 - 2024-10-05

Fix use after free of task in FuturesUnordered when dropped future panics (#2886)
Fix soundness bug in task::waker_ref (#2830) This is a breaking change but allowed because it is soundness bug fix.
Fix bugs in AsyncBufRead::read_line and AsyncBufReadExt::lines (#2884)
Fix parsing issue in select!/select_biased! (#2832) This is technically a breaking change as it will now reject a very odd undocumented syntax that was previously accidentally accepted.
Work around issue due to upstream Waker::will_wake change (#2865)
Add stream::Iter::{get_ref,get_mut,into_inner} (#2875)
Add future::AlwaysReady (#2825)
Relax trait bound on non-constructor methods of io::{BufReader,BufWriter} (#2848)

Reviewed By: cjlongoria

Differential Revision: D78949285


