### PR TITLE
(monarch/tools) add utils.MONARCH_HOME() to get or create a ~/.monarch dot-directory

### DIFF
--- a/python/monarch/tools/components/hyperactor.py
+++ b/python/monarch/tools/components/hyperactor.py
@@ -22,7 +22,7 @@ DEFAULT_NAME: str = f"monarch-{_USER}"
 __version__ = "latest"  # TODO get version from monarch.__version_
 
 
-def proc_mesh(
+def host_mesh(
     image: str = f"ghcr.io/pytorch-labs/monarch:{__version__}",  # TODO docker needs to be built and pushed to ghcr
     meshes: list[str] = _DEFAULT_MESHES,
     env: Optional[dict[str, str]] = None,

--- a/python/monarch/tools/config/defaults.py
+++ b/python/monarch/tools/config/defaults.py
@@ -25,7 +25,7 @@ from torchx.schedulers import (
 
 def component_fn(scheduler: str) -> Callable[..., UnnamedAppDef]:
     """The default TorchX component function for the scheduler"""
-    return hyperactor.proc_mesh
+    return hyperactor.host_mesh
 
 
 def scheduler_factories() -> dict[str, SchedulerFactory]:

--- a/python/monarch/tools/utils.py
+++ b/python/monarch/tools/utils.py
@@ -6,7 +6,34 @@
 
 # pyre-strict
 import os
+import pathlib
 from typing import Optional
+
+
+def MONARCH_HOME(*subdir_paths: str) -> pathlib.Path:
+    """
+    Path to the "dot-directory" for monarch.
+    Defaults to `~/.monarch` and is overridable via the `MONARCH_HOME` environment variable.
+
+    Usage:
+
+    .. doc-test::
+
+        from pathlib import Path
+        from monarch.tools.utils import MONARCH_HOME
+
+        assert MONARCH_HOME() == Path.home() / ".monarch"
+        assert MONARCH_HOME("conda-pack-out") ==  Path.home() / ".monarch" / "conda-pack-out"
+    ```
+    """
+
+    default_dir = str(pathlib.Path.home() / ".monarch")
+    monarch_home = pathlib.Path(os.getenv("MONARCH_HOME", default_dir))
+
+    monarch_home_subdir = monarch_home / os.path.sep.join(subdir_paths)
+    monarch_home_subdir.mkdir(parents=True, exist_ok=True)
+
+    return monarch_home_subdir
 
 
 class conda:

--- a/python/tests/tools/test_utils.py
+++ b/python/tests/tools/test_utils.py
@@ -6,10 +6,39 @@
 
 # pyre-strict
 import os
+import tempfile
 import unittest
+from pathlib import Path
 from unittest import mock
 
-from monarch.tools.utils import conda
+from monarch.tools.utils import conda, MONARCH_HOME
+
+
+class TestUtils(unittest.TestCase):
+    # guard against MONARCH_HOME set outside the test
+    @mock.patch.dict(os.environ, {}, clear=True)
+    def test_MONARCH_HOME_default(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            user_home = Path(tmpdir) / "sally"
+            with mock.patch("pathlib.Path.home", return_value=user_home):
+                monarch_home = MONARCH_HOME()
+                self.assertEqual(monarch_home, user_home / ".monarch")
+                self.assertTrue(monarch_home.exists())
+
+    def test_MONARCH_HOME_override(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            override_monarch_home = Path(tmpdir) / "test" / ".monarch"
+            with mock.patch.dict(
+                os.environ, {"MONARCH_HOME": str(override_monarch_home)}
+            ):
+                monarch_home = MONARCH_HOME()
+                conda_pack_out = MONARCH_HOME("conda-pack", "out")
+
+                self.assertEqual(override_monarch_home, monarch_home)
+                self.assertEqual(monarch_home / "conda-pack" / "out", conda_pack_out)
+
+                self.assertTrue(monarch_home.is_dir())
+                self.assertTrue(conda_pack_out.is_dir())
 
 
 class TestCondaUtils(unittest.TestCase):


### PR DESCRIPTION
Summary:
`~/.monarch` directory is useful to put all the configs/temp files that we generate.

One concrete use-case is to use it to create a temporary output build directory for conda-pack and CAF so that we can add options to "keep_build_dir" for debugging.

Differential Revision: D78998140
