### PR TITLE
Update crate pin-project 0.4.30 -> 1.1.10

### DIFF
--- a/hyperactor_mesh/Cargo.toml
+++ b/hyperactor_mesh/Cargo.toml
@@ -51,7 +51,7 @@ libc = "0.2.139"
 mockall = "0.13.1"
 ndslice = { version = "0.0.0", path = "../ndslice" }
 nix = { version = "0.29.0", features = ["dir", "event", "hostname", "inotify", "ioctl", "mman", "mount", "net", "poll", "ptrace", "reboot", "resource", "sched", "signal", "term", "time", "user", "zerocopy"] }
-pin-project = "0.4.30"
+pin-project = "1.1.10"
 preempt_rwlock = { version = "0.0.0", path = "../preempt_rwlock" }
 rand = { version = "0.8", features = ["small_rng"] }
 regex = "1.11.1"


### PR DESCRIPTION
Summary:
## [1.1.10] - 2025-03-03

- Suppress `clippy::elidable_lifetime_names` lint in generated code.

## [1.1.9] - 2025-02-03

- Suppress `clippy::missing_const_for_fn` lint in generated code.

## [1.1.8] - 2025-01-06

- Suppress `unnameable_types`, `clippy::absolute_paths`, `clippy::min_ident_chars`, `clippy::pub_with_shorthand`, `clippy::single_call_fn`, `clippy::single_char_lifetime_names` lints in generated code.

## [1.1.7] - 2024-10-24

- Work around an issue on negative_impls that allows unsound overlapping `Unpin` implementations. ([#357](https://github.com/taiki-e/pin-project/pull/357))

## [1.1.6] - 2024-10-05

- Suppress `clippy::needless_lifetimes` lint in generated code.

- Disable `derive` feature of `syn` dependency.

## [1.1.5] - 2024-03-05

- Suppress `unused_qualifications` lint in generated code.

## [1.1.4] - 2024-01-25

- Suppress `clippy::missing_docs_in_private_items` and `clippy::missing_inline_in_public_items` lints in generated code. ([#356](https://github.com/taiki-e/pin-project/pull/356), thanks daxpedda)

## [1.1.3] - 2023-08-06

- Hide documentation of the `Unpin` implementation for `!Unpin` option to work around [rustdoc issue](https://github.com/rust-lang/rust/issues/80481). ([#355](https://github.com/taiki-e/pin-project/pull/355), thanks matheus-consoli)

## [1.1.2] - 2023-07-02

- Inline project methods.

## [1.1.1] - 2023-06-29

- Fix build error from dependency when built with `-Z minimal-versions`.

## [1.1.0] - 2023-05-13

- Update `syn` dependency to 2. This increase the minimum supported Rust version from Rust 1.37 to Rust 1.56. ([#352](https://github.com/taiki-e/pin-project/pull/352), [#354](https://github.com/taiki-e/pin-project/pull/354), thanks maurer and daxpedda)

## [1.0.12] - 2022-08-15

- Suppress `unused_tuple_struct_fields` lint in generated code.

## [1.0.11] - 2022-07-02

- [Suppress `dead_code` lint in generated code.](https://github.com/taiki-e/pin-project/pull/346)

## [1.0.10] - 2021-12-31

- Revert the increase of the minimal version of `syn` that was done in 1.0.9.

## [1.0.9] - 2021-12-26

- [Prevent abuse of private module.](https://github.com/taiki-e/pin-project/pull/336)

- Update minimal version of `syn` to 1.0.84.

## [1.0.8] - 2021-07-21

- [Suppress `clippy::use_self` and `clippy::type_repetition_in_bounds` lints in generated code.](https://github.com/taiki-e/pin-project/pull/331)

## [1.0.7] - 2021-04-16

- [Fix compile error when using `self::` as prefix of path inside `#[pinned_drop]` impl.](https://github.com/taiki-e/pin-project/pull/326)

## [1.0.6] - 2021-03-25

- [Suppress `clippy::semicolon_if_nothing_returned` lint in generated code.](https://github.com/taiki-e/pin-project/pull/318)

## [1.0.5] - 2021-02-03

- [Suppress `deprecated` lint in generated code.](https://github.com/taiki-e/pin-project/pull/313)

## [1.0.4] - 2021-01-09

- [Suppress `clippy::ref_option_ref` lint in generated code.](https://github.com/taiki-e/pin-project/pull/308)

## [1.0.3] - 2021-01-05

- Exclude unneeded files from crates.io.

## [1.0.2] - 2020-11-18

- [Suppress `clippy::unknown_clippy_lints` lint in generated code.](https://github.com/taiki-e/pin-project/pull/303)

## [1.0.1] - 2020-10-15

**Note:** This release has been yanked because it [failed to compile with syn 1.0.84 and later](https://github.com/taiki-e/pin-project/commit/ddcd88079ba2d82857c365f2a3543ad146ade54c).

- [Fix warnings when `#[pin_project]` attribute used within `macro_rules!` macros.](https://github.com/taiki-e/pin-project/pull/298)

## [1.0.0] - 2020-10-13

**Note:** This release has been yanked because it [failed to compile with syn 1.0.84 and later](https://github.com/taiki-e/pin-project/commit/ddcd88079ba2d82857c365f2a3543ad146ade54c).

- [Remove deprecated `#[project]`, `#[project_ref]`, and `#[project_replace]` attributes.](https://github.com/taiki-e/pin-project/pull/265)

  Name the projected type by passing an argument with the same name as the method to the `#[pin_project]` attribute instead:

  ```diff
  - #[pin_project]
  + #[pin_project(project = EnumProj)]
    enum Enum<T> {
        Variant(#[pin] T),
    }

  - #[project]
    fn func<T>(x: Pin<&mut Enum<T>>) {
  -     #[project]
        match x.project() {
  -         Enum::Variant(_) => { /* ... */ }
  +         EnumProj::Variant(_) => { /* ... */ }
        }
    }
  ```

- [Remove deprecated `Replace` argument from `#[pin_project]` attribute.](https://github.com/taiki-e/pin-project/pull/266) Use `project_replace` argument instead.

- [Optimize code generation when used on enums.](https://github.com/taiki-e/pin-project/pull/270)

- [Raise the minimum supported Rust version of this crate from Rust 1.34 to Rust 1.37.](https://github.com/taiki-e/pin-project/pull/292)

- Suppress `explicit_outlives_requirements`, `box_pointers`, `clippy::large_enum_variant`, `clippy::pattern_type_mismatch`, `clippy::implicit_return`, and `clippy::redundant_pub_crate` lints in generated code. ([#276](https://github.com/taiki-e/pin-project/pull/276), [#277](https://github.com/taiki-e/pin-project/pull/277), [#284](https://github.com/taiki-e/pin-project/pull/284))

- Diagnostic improvements.

Changes since the 1.0.0-alpha.1 release:

- [Fix drop order of pinned fields in `project_replace`.](https://github.com/taiki-e/pin-``project/pull/287)

- Update minimal version of `syn` to 1.0.44.

## [1.0.0-alpha.1] - 2020-09-22

- [Remove deprecated `#[project]`, `#[project_ref]`, and `#[project_replace]` attributes.](https://github.com/taiki-e/pin-project/pull/265)

  Name the projected type by passing an argument with the same name as the method to the `#[pin_project]` attribute instead:

  ```diff
  - #[pin_project]
  + #[pin_project(project = EnumProj)]
    enum Enum<T> {
        Variant(#[pin] T),
    }

  - #[project]
    fn func<T>(x: Pin<&mut Enum<T>>) {
  -     #[project]
        match x.project() {
  -         Enum::Variant(_) => { /* ... */ }
  +         EnumProj::Variant(_) => { /* ... */ }
        }
    }
  ```

- [Remove deprecated `Replace` argument from `#[pin_project]` attribute.](https://github.com/taiki-e/pin-project/pull/266) Use `project_replace` argument instead.

- [Optimize code generation when used on enums.](https://github.com/taiki-e/pin-project/pull/270)

- Suppress `explicit_outlives_requirements`, `box_pointers`, `clippy::large_enum_variant`, `clippy::pattern_type_mismatch`, and `clippy::implicit_return` lints in generated code. ([#276](https://github.com/taiki-e/pin-project/pull/276), [#277](https://github.com/taiki-e/pin-project/pull/277))

- Diagnostic improvements.

See also [tracking issue for 1.0 release](https://github.com/taiki-e/pin-project/issues/264).

Reviewed By: dtolnay, capickett

Differential Revision: D79015865
