### PR TITLE
boost message serder perf

### DIFF
--- a/monarch_hyperactor/src/actor.rs
+++ b/monarch_hyperactor/src/actor.rs
@@ -235,6 +235,7 @@ fn mailbox<'py, T: Actor>(py: Python<'py>, cx: &Context<'_, T>) -> Bound<'py, Py
 #[derive(Clone, Serialize, Deserialize, Named, PartialEq, Default)]
 pub struct PythonMessage {
     pub kind: PythonMessageKind,
+    #[serde(with = "serde_bytes")]
     pub message: Vec<u8>,
 }
 


### PR DESCRIPTION
Summary: In a [test](https://docs.google.com/document/d/11wE6PC4o_YOBFlRkG7pbvPE0c2iU3UnteJq3XmN0dEo/edit?tab=t.0) with 500MB message sending, this change cuts the e2e latency from 4.1s to 2.3s.

Reviewed By: dulinriley

Differential Revision: D79204285


