### PR TITLE
fix a flaky test

### DIFF
--- a/python/tests/_monarch/test_mailbox.py
+++ b/python/tests/_monarch/test_mailbox.py
@@ -6,7 +6,6 @@
 
 # pyre-strict
 
-import asyncio
 import pickle
 from typing import (
     Any,
@@ -29,10 +28,9 @@ from monarch._rust_bindings.monarch_hyperactor.actor import (
     PythonMessageKind,
 )
 from monarch._rust_bindings.monarch_hyperactor.pytokio import PythonTask
-from monarch._src.actor.future import Future
 
 if TYPE_CHECKING:
-    from monarch._rust_bindings.monarch_hyperactor.actor import CallMethod, PortProtocol
+    from monarch._rust_bindings.monarch_hyperactor.actor import PortProtocol
 
 
 from monarch._rust_bindings.monarch_hyperactor.alloc import AllocConstraints, AllocSpec
@@ -202,3 +200,6 @@ async def test_reducer() -> None:
     messge = await receiver.recv_task().with_timeout(seconds=5)
     value = pickle.loads(messge.message)
     assert "[reduced](start+msg0)" in value
+
+    #  Note: occasionally test would hang without this stop
+    await proc_mesh.stop_nonblocking()


### PR DESCRIPTION
Summary:
Currently the test could hang on exit (also repro locally): https://www.internalfb.com/intern/test/562950174062842?ref_report_id=0

Confirm this diff's change works locally. Land it to see if it would work in sandcastle as well.

I am not sure why the test hang though. Probably the background rust process prevent the test from finishing?

Reviewed By: shayne-fletcher

Differential Revision: D79222654


