### PR TITLE
Support configurable heartbeat timeout

### DIFF
--- a/hyperactor/src/config.rs
+++ b/hyperactor/src/config.rs
@@ -46,6 +46,9 @@ declare_attrs! {
 
     /// Timeout used by proc mesh for stopping an actor.
     pub attr STOP_ACTOR_TIMEOUT: Duration = Duration::from_secs(1);
+
+    /// Heartbeat interval for remote allocator
+    pub attr REMOTE_ALLOCATOR_HEARTBEAT_INTERVAL: Duration = Duration::from_secs(5);
 }
 
 /// Load configuration from environment variables
@@ -87,6 +90,13 @@ pub fn from_env() -> Attrs {
         }
     }
 
+    // Load remote allocator heartbeat interval
+    if let Ok(val) = env::var("HYPERACTOR_REMOTE_ALLOCATOR_HEARTBEAT_INTERVAL_SECS") {
+        if let Ok(parsed) = val.parse::<u64>() {
+            config[REMOTE_ALLOCATOR_HEARTBEAT_INTERVAL] = Duration::from_secs(parsed);
+        }
+    }
+
     config
 }
 
@@ -121,6 +131,9 @@ pub fn merge(config: &mut Attrs, other: &Attrs) {
     }
     if other.contains_key(SPLIT_MAX_BUFFER_SIZE) {
         config[SPLIT_MAX_BUFFER_SIZE] = other[SPLIT_MAX_BUFFER_SIZE];
+    }
+    if other.contains_key(REMOTE_ALLOCATOR_HEARTBEAT_INTERVAL) {
+        config[REMOTE_ALLOCATOR_HEARTBEAT_INTERVAL] = other[REMOTE_ALLOCATOR_HEARTBEAT_INTERVAL];
     }
 }
 
@@ -292,6 +305,10 @@ mod tests {
         );
         assert_eq!(config[MESSAGE_ACK_EVERY_N_MESSAGES], 1000);
         assert_eq!(config[SPLIT_MAX_BUFFER_SIZE], 5);
+        assert_eq!(
+            config[REMOTE_ALLOCATOR_HEARTBEAT_INTERVAL],
+            Duration::from_secs(5)
+        );
     }
 
     #[test]

--- a/hyperactor_mesh/test/remote_process_alloc.rs
+++ b/hyperactor_mesh/test/remote_process_alloc.rs
@@ -95,7 +95,6 @@ async fn main() {
             WorldId("test_world_id".to_string()),
             ChannelTransport::Unix,
             0,
-            Duration::from_millis(100),
             initializer,
         )
         .await

--- a/monarch_hyperactor/src/alloc.rs
+++ b/monarch_hyperactor/src/alloc.rs
@@ -10,7 +10,6 @@ use std::collections::HashMap;
 use std::str::FromStr;
 use std::sync::Arc;
 use std::sync::Mutex;
-use std::time::Duration;
 
 use anyhow::anyhow;
 use async_trait::async_trait;
@@ -389,7 +388,6 @@ impl RemoteProcessAllocInitializer for PyRemoteProcessAllocInitializer {
 pub struct PyRemoteAllocator {
     world_id: String,
     initializer: Py<PyAny>,
-    heartbeat_interval: Duration,
 }
 
 impl Clone for PyRemoteAllocator {
@@ -397,7 +395,6 @@ impl Clone for PyRemoteAllocator {
         Self {
             world_id: self.world_id.clone(),
             initializer: Python::with_gil(|py| Py::clone_ref(&self.initializer, py)),
-            heartbeat_interval: self.heartbeat_interval.clone(),
         }
     }
 }
@@ -423,7 +420,6 @@ impl Allocator for PyRemoteAllocator {
             WorldId(self.world_id.clone()),
             transport,
             port,
-            self.heartbeat_interval,
             initializer,
         )
         .await?;
@@ -437,17 +433,11 @@ impl PyRemoteAllocator {
     #[pyo3(signature = (
         world_id,
         initializer,
-        heartbeat_interval = Duration::from_secs(5),
     ))]
-    fn new(
-        world_id: String,
-        initializer: Py<PyAny>,
-        heartbeat_interval: Duration,
-    ) -> PyResult<Self> {
+    fn new(world_id: String, initializer: Py<PyAny>) -> PyResult<Self> {
         Ok(Self {
             world_id,
             initializer,
-            heartbeat_interval,
         })
     }
 

--- a/monarch_hyperactor/src/bin/process_allocator/common.rs
+++ b/monarch_hyperactor/src/bin/process_allocator/common.rs
@@ -127,7 +127,6 @@ mod tests {
             }])
         });
 
-        let heartbeat = std::time::Duration::from_millis(100);
         let world_id = WorldId("__unused__".to_string());
 
         let mut alloc = remoteprocess::RemoteProcessAlloc::new(
@@ -135,7 +134,6 @@ mod tests {
             world_id,
             ChannelTransport::Unix,
             0,
-            heartbeat,
             initializer,
         )
         .await
@@ -195,7 +193,6 @@ mod tests {
             }])
         });
 
-        let heartbeat = std::time::Duration::from_millis(100);
         let world_id = WorldId("__unused__".to_string());
 
         // Wait at least as long as the timeout before sending any messages.
@@ -207,7 +204,6 @@ mod tests {
             world_id.clone(),
             ChannelTransport::Unix,
             0,
-            heartbeat,
             initializer,
         )
         .await
@@ -257,7 +253,6 @@ mod tests {
             .expect_initialize_alloc()
             .return_once(move || Ok(vec![alloc_host_clone]));
 
-        let heartbeat = std::time::Duration::from_millis(100);
         let world_id = WorldId("__unused__".to_string());
 
         // Attempt to allocate, it should succeed because a timeout happens before
@@ -266,7 +261,6 @@ mod tests {
             world_id.clone(),
             ChannelTransport::Unix,
             0,
-            heartbeat,
             initializer,
         )
         .await
@@ -289,7 +283,6 @@ mod tests {
             world_id.clone(),
             ChannelTransport::Unix,
             0,
-            heartbeat,
             initializer,
         )
         .await
@@ -338,7 +331,6 @@ mod tests {
             .expect_initialize_alloc()
             .return_once(move || Ok(vec![alloc_host]));
 
-        let heartbeat = std::time::Duration::from_millis(100);
         let world_id = WorldId("__unused__".to_string());
 
         // Attempt to allocate, it should succeed because a timeout happens before
@@ -347,7 +339,6 @@ mod tests {
             world_id.clone(),
             ChannelTransport::Unix,
             0,
-            heartbeat,
             initializer,
         )
         .await

--- a/python/tests/test_allocator.py
+++ b/python/tests/test_allocator.py
@@ -252,7 +252,6 @@ class TestRemoteAllocator(unittest.IsolatedAsyncioTestCase):
                 allocator = RemoteAllocator(
                     world_id="test_remote_allocator",
                     initializer=StaticRemoteAllocInitializer(host1, host2),
-                    heartbeat_interval=_100_MILLISECONDS,
                 )
                 alloc = allocator.allocate(spec)
                 await alloc.initialized
@@ -276,7 +275,6 @@ class TestRemoteAllocator(unittest.IsolatedAsyncioTestCase):
             allocator = RemoteAllocator(
                 world_id="test_remote_allocator",
                 initializer=initializer,
-                heartbeat_interval=_100_MILLISECONDS,
             )
 
             spec = AllocSpec(AllocConstraints(), host=1, gpu=1)
@@ -305,7 +303,6 @@ class TestRemoteAllocator(unittest.IsolatedAsyncioTestCase):
             allocator = RemoteAllocator(
                 world_id="test_remote_allocator",
                 initializer=empty_initializer,
-                heartbeat_interval=_100_MILLISECONDS,
             )
             await allocator.allocate(
                 AllocSpec(AllocConstraints(), host=1, gpu=1)
@@ -322,7 +319,6 @@ class TestRemoteAllocator(unittest.IsolatedAsyncioTestCase):
             allocator = RemoteAllocator(
                 world_id="test_remote_allocator",
                 initializer=StaticRemoteAllocInitializer(host1, host2),
-                heartbeat_interval=_100_MILLISECONDS,
             )
             alloc = allocator.allocate(spec)
             proc_mesh = ProcMesh.from_alloc(alloc)
@@ -341,7 +337,6 @@ class TestRemoteAllocator(unittest.IsolatedAsyncioTestCase):
             allocator = RemoteAllocator(
                 world_id="test_remote_allocator",
                 initializer=StaticRemoteAllocInitializer(host1, host2),
-                heartbeat_interval=_100_MILLISECONDS,
             )
 
             alloc = allocator.allocate(spec)
@@ -368,7 +363,6 @@ class TestRemoteAllocator(unittest.IsolatedAsyncioTestCase):
             allocator = RemoteAllocator(
                 world_id="test_remote_allocator",
                 initializer=StaticRemoteAllocInitializer(wrong_host),
-                heartbeat_interval=_100_MILLISECONDS,
             )
             alloc = allocator.allocate(spec)
             await alloc.initialized
@@ -392,7 +386,6 @@ class TestRemoteAllocator(unittest.IsolatedAsyncioTestCase):
             allocator = RemoteAllocator(
                 world_id="helloworld",
                 initializer=StaticRemoteAllocInitializer(host1, host2),
-                heartbeat_interval=_100_MILLISECONDS,
             )
             spec = AllocSpec(AllocConstraints(), host=2, gpu=2)
             proc_mesh = ProcMesh.from_alloc(allocator.allocate(spec))
@@ -412,7 +405,6 @@ class TestRemoteAllocator(unittest.IsolatedAsyncioTestCase):
             allocator = RemoteAllocator(
                 world_id="test_remote_allocator",
                 initializer=StaticRemoteAllocInitializer(host1, host2),
-                heartbeat_interval=_100_MILLISECONDS,
             )
             alloc = allocator.allocate(spec)
             proc_mesh = ProcMesh.from_alloc(alloc)
@@ -438,7 +430,6 @@ class TestRemoteAllocator(unittest.IsolatedAsyncioTestCase):
             allocator = RemoteAllocator(
                 world_id="test_remote_allocator",
                 initializer=StaticRemoteAllocInitializer(host1, host2),
-                heartbeat_interval=_100_MILLISECONDS,
             )
             alloc = allocator.allocate(spec)
             proc_mesh = ProcMesh.from_alloc(alloc)
@@ -474,7 +465,6 @@ class TestRemoteAllocator(unittest.IsolatedAsyncioTestCase):
             allocator = RemoteAllocator(
                 world_id="test_remote_allocator",
                 initializer=StaticRemoteAllocInitializer(host1, host2),
-                heartbeat_interval=_100_MILLISECONDS,
             )
             alloc = allocator.allocate(spec)
             proc_mesh = ProcMesh.from_alloc(alloc, setup=setup_env_vars)
@@ -501,7 +491,6 @@ class TestRemoteAllocator(unittest.IsolatedAsyncioTestCase):
             allocator = RemoteAllocator(
                 world_id="test_remote_allocator",
                 initializer=StaticRemoteAllocInitializer(host1, host2),
-                heartbeat_interval=_100_MILLISECONDS,
             )
             alloc = allocator.allocate(spec)
             proc_mesh = ProcMesh.from_alloc(alloc)
@@ -531,7 +520,6 @@ class TestRemoteAllocator(unittest.IsolatedAsyncioTestCase):
             allocator = RemoteAllocator(
                 world_id="test_remote_allocator",
                 initializer=StaticRemoteAllocInitializer(host1),
-                heartbeat_interval=_100_MILLISECONDS,
             )
             with self.assertRaisesRegex(
                 Exception, "no process has ever been allocated on"
@@ -547,12 +535,10 @@ class TestRemoteAllocator(unittest.IsolatedAsyncioTestCase):
             allocator_a = RemoteAllocator(
                 world_id="a",
                 initializer=StaticRemoteAllocInitializer(host1_a),
-                heartbeat_interval=_100_MILLISECONDS,
             )
             allocator_b = RemoteAllocator(
                 world_id="b",
                 initializer=StaticRemoteAllocInitializer(host1_b),
-                heartbeat_interval=_100_MILLISECONDS,
             )
 
             spec_a = AllocSpec(AllocConstraints(), host=1, gpu=2)
@@ -634,7 +620,6 @@ class TestRemoteAllocator(unittest.IsolatedAsyncioTestCase):
                 allocator = RemoteAllocator(
                     world_id="test",
                     initializer=initializer,
-                    heartbeat_interval=_100_MILLISECONDS,
                 )
                 alloc = allocator.allocate(AllocSpec(AllocConstraints(), host=1, gpu=4))
                 proc_mesh = ProcMesh.from_alloc(alloc)
@@ -666,7 +651,6 @@ class TestRemoteAllocator(unittest.IsolatedAsyncioTestCase):
                 allocator = RemoteAllocator(
                     world_id="test",
                     initializer=initializer,
-                    heartbeat_interval=_100_MILLISECONDS,
                 )
                 alloc = allocator.allocate(
                     AllocSpec(
@@ -726,7 +710,6 @@ class TestRemoteAllocator(unittest.IsolatedAsyncioTestCase):
             allocator = RemoteAllocator(
                 world_id="test_actor_logger",
                 initializer=StaticRemoteAllocInitializer(host),
-                heartbeat_interval=_100_MILLISECONDS,
             )
 
             spec = AllocSpec(AllocConstraints(), host=1, gpu=2)


### PR DESCRIPTION
Summary:
Move RemoteAlloc HB timeout as part of configs

Monarch runs with 1k+ workers timeout on allocation with the default heartbeat setting (1s).

This is not a fix but simply extending configurability to Python side.

Differential Revision: D79064585


