### PR TITLE
Add error handling counters

### DIFF
--- a/hyperactor/src/channel.rs
+++ b/hyperactor/src/channel.rs
@@ -242,6 +242,18 @@ pub enum ChannelTransport {
     Unix,
 }
 
+impl fmt::Display for ChannelTransport {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Tcp => write!(f, "tcp"),
+            Self::MetaTls => write!(f, "metatls"),
+            Self::Local => write!(f, "local"),
+            Self::Sim(transport) => write!(f, "sim({})", transport),
+            Self::Unix => write!(f, "unix"),
+        }
+    }
+}
+
 impl ChannelTransport {
     /// All known channel transports.
     pub fn all() -> [ChannelTransport; 3] {

--- a/hyperactor/src/metrics.rs
+++ b/hyperactor/src/metrics.rs
@@ -6,26 +6,53 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-//! A bunch of statily defined metrics. Defined here because they are used in
-//! both macros and handwritten code.
+//! Hyperactor metrics.
+//!
+//! This module contains metrics definitions for various components of hyperactor.
 
 use hyperactor_telemetry::declare_static_counter;
+use hyperactor_telemetry::declare_static_histogram;
 use hyperactor_telemetry::declare_static_timer;
 use hyperactor_telemetry::declare_static_up_down_counter;
 
-declare_static_counter!(MESSAGES_SENT, "messages_sent");
-declare_static_counter!(MESSAGES_RECEIVED, "messages_received");
-declare_static_counter!(MESSAGE_HANDLE_ERRORS, "message_handle_errors");
-declare_static_counter!(MESSAGE_RECEIVE_ERRORS, "message_receive_errors");
-declare_static_up_down_counter!(MESSAGE_QUEUE_SIZE, "message_queue_size");
+// MAILBOX
+// Tracks messages that couldn't be delivered to their destination and were returned as undeliverable
+declare_static_counter!(
+    MAILBOX_UNDELIVERABLE_MESSAGES,
+    "mailbox.undeliverable_messages"
+);
+// Tracks the number of messages that were posted.
+hyperactor_telemetry::declare_static_counter!(MAILBOX_POSTS, "mailbox.posts");
+
+// ACTOR
+// Tracks the current size of the message queue for actors (increases when messages are queued, decreases when processed)
+declare_static_up_down_counter!(ACTOR_MESSAGE_QUEUE_SIZE, "actor.message_queue_size");
+// Tracks the total number of messages sent by actors
+declare_static_counter!(ACTOR_MESSAGES_SENT, "actor.messages_sent");
+// Tracks the total number of messages received by actors
+declare_static_counter!(ACTOR_MESSAGES_RECEIVED, "actor.messages_received");
+// Tracks errors that occur when receiving messages
+declare_static_counter!(ACTOR_MESSAGE_RECEIVE_ERRORS, "actor.message_receive_errors");
+// Measures the time taken to handle messages by actors
 declare_static_timer!(
-    MESSAGE_HANDLER_DURATION,
-    "message_handler_duration",
+    ACTOR_MESSAGE_HANDLER_DURATION,
+    "actor.message_handler_duration",
     hyperactor_telemetry::TimeUnit::Nanos
 );
 
-declare_static_timer!(
-    ACTOR_STATUS,
-    "actor.status",
-    hyperactor_telemetry::TimeUnit::Nanos
-);
+// CHANNEL
+declare_static_histogram!(REMOTE_MESSAGE_SEND_SIZE, "channel.remote_message_send_size");
+// Tracks the number of new channel connections established (client and server)
+declare_static_counter!(CHANNEL_CONNECTIONS, "channel.connections");
+// Tracks errors that occur when establishing channel connections
+declare_static_counter!(CHANNEL_CONNECTION_ERRORS, "channel.connection_errors");
+// Tracks the number of channel reconnection attempts
+declare_static_counter!(CHANNEL_RECONNECTIONS, "channel.reconnections");
+
+// PROC MESH
+// Tracks the number of active processes in the process mesh
+declare_static_counter!(PROC_MESH_ALLOCATION, "proc_mesh.active_procs");
+// Tracks the number of process failures in the process mesh
+declare_static_counter!(PROC_MESH_PROC_STOPPED, "proc_mesh.proc_failures");
+// Tracks the number of actor failures within the process mesh
+declare_static_counter!(PROC_MESH_ACTOR_FAILURES, "proc_mesh.actor_failures");

--- a/hyperactor_macros/src/lib.rs
+++ b/hyperactor_macros/src/lib.rs
@@ -605,7 +605,7 @@ pub fn derive_handler(input: TokenStream) -> TokenStream {
                     }
                 };
                 let log_message = quote! {
-                        hyperactor::metrics::MESSAGES_RECEIVED.add(1, hyperactor::kv_pairs!(
+                        hyperactor::metrics::ACTOR_MESSAGES_RECEIVED.add(1, hyperactor::kv_pairs!(
                             "rpc" => "call",
                             "actor_id" => cx.self_id().to_string(),
                             "message_type" => stringify!(#enum_name),
@@ -672,7 +672,7 @@ pub fn derive_handler(input: TokenStream) -> TokenStream {
                     tracing::Level::#log_level
                 };
                 let log_message = quote! {
-                        hyperactor::metrics::MESSAGES_RECEIVED.add(1, hyperactor::kv_pairs!(
+                        hyperactor::metrics::ACTOR_MESSAGES_RECEIVED.add(1, hyperactor::kv_pairs!(
                             "rpc" => "call",
                             "actor_id" => cx.self_id().to_string(),
                             "message_type" => stringify!(#enum_name),
@@ -804,7 +804,7 @@ fn derive_client(input: TokenStream, is_handle: bool) -> TokenStream {
                     }
                 };
                 let log_message = quote! {
-                        hyperactor::metrics::MESSAGES_SENT.add(1, hyperactor::kv_pairs!(
+                        hyperactor::metrics::ACTOR_MESSAGES_SENT.add(1, hyperactor::kv_pairs!(
                             "rpc" => "call",
                             "actor_id" => self.actor_id().to_string(),
                             "message_type" => stringify!(#enum_name),
@@ -870,7 +870,7 @@ fn derive_client(input: TokenStream, is_handle: bool) -> TokenStream {
                     }
                 };
                 let log_message = quote! {
-                    hyperactor::metrics::MESSAGES_SENT.add(1, hyperactor::kv_pairs!(
+                    hyperactor::metrics::ACTOR_MESSAGES_SENT.add(1, hyperactor::kv_pairs!(
                         "rpc" => "oneway",
                         "actor_id" => self.actor_id().to_string(),
                         "message_type" => stringify!(#enum_name),

--- a/monarch_hyperactor/src/proc.rs
+++ b/monarch_hyperactor/src/proc.rs
@@ -594,11 +594,11 @@ impl<M: RemoteMessage> InstanceWrapper<M> {
         }
         .map_err(|err| err.into())
         .inspect_err(|err| {
-            hyperactor::metrics::MESSAGE_RECEIVE_ERRORS.add(1, hyperactor::kv_pairs!("actor_id" => self.actor_id().to_string()));
+            hyperactor::metrics::ACTOR_MESSAGE_RECEIVE_ERRORS.add(1, hyperactor::kv_pairs!("actor_id" => self.actor_id().to_string()));
             tracing::error!(err=?err, actor_id=%self.actor_id(), "unable to receive next py message");
         })
         .inspect(|_|{
-            hyperactor::metrics::MESSAGES_RECEIVED.add(1, hyperactor::kv_pairs!("actor_id" => self.actor_id().to_string()));
+            hyperactor::metrics::ACTOR_MESSAGES_RECEIVED.add(1, hyperactor::kv_pairs!("actor_id" => self.actor_id().to_string()));
         })
     }
 


### PR DESCRIPTION
Summary:
Added metrics will shed light on any recovered failures seen during stress test

- Add new metrics
- Consolidate metrics in one place

Differential Revision: D79266667


