### PR TITLE
link launch and sync conda/workspace locations

### DIFF
--- a/python/monarch/tools/config/__init__.py
+++ b/python/monarch/tools/config/__init__.py
@@ -6,9 +6,11 @@
 
 # pyre-strict
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, TYPE_CHECKING
 
-from torchx.specs import Role
+# Defer the import of Role to avoid requiring torchx at import time
+if TYPE_CHECKING:
+    from torchx.specs import Role
 
 
 NOT_SET: str = "__NOT_SET__"
@@ -20,8 +22,16 @@ class UnnamedAppDef:
     A TorchX AppDef without a name.
     """
 
-    roles: List[Role] = field(default_factory=list)
+    roles: List["Role"] = field(default_factory=list)
     metadata: Dict[str, str] = field(default_factory=dict)
+
+
+# TODO: provide a proper Workspace class to support
+#  - multiple workspaces
+#  - empty workspaces
+#  - no workspace
+#  - experimental directories
+Workspace = str | None
 
 
 @dataclass
@@ -32,6 +42,6 @@ class Config:
 
     scheduler: str = NOT_SET
     scheduler_args: dict[str, Any] = field(default_factory=dict)
-    workspace: Optional[str] = None
+    workspace: Workspace = None
     dryrun: bool = False
     appdef: UnnamedAppDef = field(default_factory=UnnamedAppDef)

--- a/python/monarch/tools/config/defaults.py
+++ b/python/monarch/tools/config/defaults.py
@@ -8,10 +8,10 @@
 
 """Defines defaults for ``monarch.tools``"""
 
-from typing import Callable, Optional
+from typing import Callable
 
 from monarch.tools.components import hyperactor
-from monarch.tools.config import Config, UnnamedAppDef
+from monarch.tools.config import Config, UnnamedAppDef, Workspace
 
 from torchx import specs
 from torchx.schedulers import (
@@ -40,7 +40,7 @@ def scheduler_factories() -> dict[str, SchedulerFactory]:
     }
 
 
-def config(scheduler: str, workspace: Optional[str] = None) -> Config:
+def config(scheduler: str, workspace: Workspace = None) -> Config:
     """The default :py:class:`~monarch.tools.config.Config` to use when submitting to the provided ``scheduler``."""
     return Config(scheduler=scheduler, workspace=workspace)
 


### PR DESCRIPTION
Summary:
Make sure the conda/workspace locations during launch map with the
locations when we sync.

Differential Revision: D79516268
