### PR TITLE
[monarch] hyperactor: make sure that mock MAST jobs are unique

### DIFF
--- a/hyperactor_mesh/src/proc_mesh/mesh_agent.rs
+++ b/hyperactor_mesh/src/proc_mesh/mesh_agent.rs
@@ -210,6 +210,7 @@ impl MeshAgentMessageHandler for MeshAgent {
         let client = MailboxClient::new(channel::dial(forwarder)?);
         let default = super::global_router().fallback(client.into_boxed());
         let router = DialMailboxRouter::new_with_default(default.into_boxed());
+        // let router = DialMailboxRouter::new_with_default(client.into_boxed());
         for (proc_id, addr) in address_book {
             router.bind(proc_id.into(), addr);
         }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #756

Without this, we cannot guarantee that the various world/proc names are unique.

This was not a problem before D79478197 because each mesh was private -- the underlying agents were not wired together.

However, since the mock MAST allocator uses the LocalAllocator to allocate host-local procs, they are now all wired together, and messages, and subsequently, we have overlapping routing entries.

Differential Revision: [D79596215](https://our.internmc.facebook.com/intern/diff/D79596215/)