### PR TITLE
flush logs in the end no matter what

### DIFF
--- a/monarch_extension/Cargo.toml
+++ b/monarch_extension/Cargo.toml
@@ -33,7 +33,6 @@ monarch_types = { version = "0.0.0", path = "../monarch_types" }
 nccl-sys = { path = "../nccl-sys", optional = true }
 ndslice = { version = "0.0.0", path = "../ndslice" }
 pyo3 = { version = "0.24", features = ["anyhow", "multiple-pymethods"] }
-pyo3-async-runtimes = { version = "0.24", features = ["attributes", "tokio-runtime"] }
 rdmaxcel-sys = { path = "../rdmaxcel-sys", optional = true }
 serde = { version = "1.0.219", features = ["derive", "rc"] }
 tokio = { version = "1.46.1", features = ["full", "test-util", "tracing"] }

--- a/monarch_extension/src/logging.rs
+++ b/monarch_extension/src/logging.rs
@@ -92,6 +92,12 @@ impl LoggingMeshClient {
     }
 }
 
+impl Drop for LoggingMeshClient {
+    fn drop(&mut self) {
+        let _ = self.client_actor.drain_and_stop().unwrap();
+    }
+}
+
 pub fn register_python_bindings(module: &Bound<'_, PyModule>) -> PyResult<()> {
     module.add_class::<LoggingMeshClient>()?;
     Ok(())

--- a/python/tests/error_test_binary.py
+++ b/python/tests/error_test_binary.py
@@ -4,9 +4,10 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+# pyre-unsafe
+
 import asyncio
 import ctypes
-import sys
 
 import click
 from monarch._rust_bindings.monarch_extension.blocking import blocking_function

--- a/python/tests/python_actor_test_binary.py
+++ b/python/tests/python_actor_test_binary.py
@@ -1,0 +1,54 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import asyncio
+import logging
+import sys
+
+import click
+
+from monarch.actor import Actor, endpoint, proc_mesh
+
+
+@click.group()
+def main() -> None:
+    pass
+
+
+class Printer(Actor):
+    def __init__(self) -> None:
+        self.logger: logging.Logger = logging.getLogger()
+
+    @endpoint
+    async def print(self, content: str) -> None:
+        print(f"{content}", flush=True)
+        sys.stdout.flush()
+        sys.stderr.flush()
+
+
+async def _flush_logs() -> None:
+    pm = await proc_mesh(gpus=2)
+    # never flush
+    await pm.logging_option(aggregate_window_sec=1000)
+    am = await pm.spawn("printer", Printer)
+
+    # These should be streamed to client
+    for _ in range(5):
+        await am.print.call("has print streaming")
+
+    # Sleep a tiny so we allow the logs to stream back to the client
+    await asyncio.sleep(1)
+
+
+@main.command("flush-logs")
+def flush_logs() -> None:
+    asyncio.run(_flush_logs())
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Summary:
make sure we are able to flush whatever remaining when program ends.
However, we could still miss logs as log through channel is not always
guaranteed to be streamed back when a program ends.

Differential Revision: D79620358
