### PR TITLE
(monarch/tools) define ANSI colors in monarch.tools.colors and use them in commands.py

### DIFF
--- a/python/monarch/tools/colors.py
+++ b/python/monarch/tools/colors.py
@@ -1,0 +1,25 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import sys
+
+# only print colors if outputting directly to a terminal
+if not sys.stdout.closed and sys.stdout.isatty():
+    GREEN = "\033[32m"
+    BLUE = "\033[34m"
+    ORANGE = "\033[38:2:238:76:44m"
+    GRAY = "\033[2m"
+    CYAN = "\033[36m"
+    ENDC = "\033[0m"
+else:
+    GREEN = ""
+    ORANGE = ""
+    BLUE = ""
+    GRAY = ""
+    CYAN = ""
+    ENDC = ""

--- a/python/monarch/tools/commands.py
+++ b/python/monarch/tools/commands.py
@@ -14,6 +14,8 @@ import os
 from datetime import datetime, timedelta
 from typing import Any, Callable, Mapping, Optional, Union
 
+from monarch.tools.colors import CYAN, ENDC
+
 from monarch.tools.components.hyperactor import DEFAULT_NAME
 
 from monarch.tools.config import (  # @manual=//monarch/python/monarch/tools/config/meta:defaults
@@ -280,6 +282,11 @@ async def get_or_create(
         server_handle = get_or_create(name="my_job_name", config)
         server_info = info(server_handle)
 
+    Args:
+        name: the name of the server (job) to get or create
+        config: configs used to create the job if one does not exist
+        check_interval: how often to poll the status of the job when waiting for it to be ready
+
     Returns: A `ServerSpec` containing information about either the existing or the newly
         created server.
 
@@ -311,10 +318,10 @@ async def get_or_create(
                 f"the new server `{new_server_handle}` has {server_info.state}"
             )
 
-        print(f"\x1b[36mNew job `{new_server_handle}` is ready to serve. \x1b[0m")
+        print(f"{CYAN}New job `{new_server_handle}` is ready to serve.{ENDC}")
         return server_info
     else:
-        print(f"\x1b[36mFound existing job `{server_handle}` ready to serve. \x1b[0m")
+        print(f"{CYAN}Found existing job `{server_handle}` ready to serve.{ENDC}")
         return server_info
 
 


### PR DESCRIPTION
Summary: Extracts ANSI colors into constants in `monarch.tools.colors` for better code-readability.

Differential Revision: D79685004


