### PR TITLE
new module 'config' for mesh attributes

### DIFF
--- a/hyperactor_mesh/src/config.rs
+++ b/hyperactor_mesh/src/config.rs
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+use hyperactor::attrs::declare_attrs;
+
+declare_attrs! {
+    pub attr ROUTER_CONFIG_NO_GLOBAL_FALLBACK: bool = false;
+}
+
+/// Extend hyperactor global config with mesh-specific settings.
+pub fn init_global_from_env() {
+    hyperactor::config::global::init_from_env();
+
+    let config_lock = hyperactor::config::global::lock();
+
+    if std::env::var("HYPERACTOR_ROUTER_CONFIG_NO_GLOBAL_FALLBACK").is_ok() {
+        let guard = config_lock.override_key(ROUTER_CONFIG_NO_GLOBAL_FALLBACK, true);
+        std::mem::forget(guard);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use hyperactor::config;
+
+    use super::*;
+
+    #[test]
+    fn test_init_global_from_env() {
+        config::global::reset_to_defaults();
+        assert_eq!(
+            config::global::get(hyperactor::config::MESSAGE_DELIVERY_TIMEOUT),
+            std::time::Duration::from_secs(30)
+        );
+        assert!(!config::global::get(ROUTER_CONFIG_NO_GLOBAL_FALLBACK));
+
+        // SAFETY: We rely on no concurrent access here.
+        unsafe {
+            std::env::set_var("HYPERACTOR_ROUTER_CONFIG_NO_GLOBAL_FALLBACK", "1");
+        }
+        init_global_from_env();
+        assert!(config::global::get(ROUTER_CONFIG_NO_GLOBAL_FALLBACK));
+
+        // SAFETY: We rely on no concurrent access here.
+        unsafe {
+            std::env::remove_var("HYPERACTOR_ROUTER_CONFIG_NO_GLOBAL_FALLBACK");
+        }
+        config::global::reset_to_defaults();
+    }
+}

--- a/hyperactor_mesh/src/lib.rs
+++ b/hyperactor_mesh/src/lib.rs
@@ -18,6 +18,7 @@ pub mod alloc;
 mod assign;
 pub mod bootstrap;
 pub mod comm;
+pub mod config;
 pub mod connect;
 pub mod logging;
 pub mod mesh;

--- a/hyperactor_mesh/test/bootstrap.rs
+++ b/hyperactor_mesh/test/bootstrap.rs
@@ -16,5 +16,8 @@ async fn main() {
         .finish();
     tracing::subscriber::set_global_default(subscriber).expect("failed to set subscriber");
 
+    // Load hyperactor and mesh settings from env into global config.
+    hyperactor_mesh::config::init_global_from_env();
+
     hyperactor_mesh::bootstrap_or_die().await;
 }


### PR DESCRIPTION
Summary:
add mesh-specific configuration support

extends hyperactor's config system to support mesh-specific settings. adds flag `ROUTER_CONFIG_NO_GLOBAL_FALLBACK` (intended for use in tests upstack).

`hyperactor_mesh_test_bootstrap` now initializes both base and mesh configs from environment on startup.

Differential Revision: D79725191
