### PR TITLE
(monarch/tools) Add force_restart argument to get_or_create command

### DIFF
--- a/python/monarch/tools/colors.py
+++ b/python/monarch/tools/colors.py
@@ -1,0 +1,25 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import sys
+
+# only print colors if outputting directly to a terminal
+if not sys.stdout.closed and sys.stdout.isatty():
+    GREEN = "\033[32m"
+    BLUE = "\033[34m"
+    ORANGE = "\033[38:2:238:76:44m"
+    GRAY = "\033[2m"
+    CYAN = "\033[36m"
+    ENDC = "\033[0m"
+else:
+    GREEN = ""
+    ORANGE = ""
+    BLUE = ""
+    GRAY = ""
+    CYAN = ""
+    ENDC = ""

--- a/python/monarch/tools/commands.py
+++ b/python/monarch/tools/commands.py
@@ -265,6 +265,7 @@ async def get_or_create(
     name: str,
     config: Config,
     check_interval: timedelta = _5_SECONDS,
+    force_restart: bool = False,
 ) -> ServerSpec:
     """Waits for the server based on identity `name` in the scheduler specified in the `config`
     to be ready (e.g. RUNNING). If the server is not found then this function creates one
@@ -286,6 +287,7 @@ async def get_or_create(
         name: the name of the server (job) to get or create
         config: configs used to create the job if one does not exist
         check_interval: how often to poll the status of the job when waiting for it to be ready
+        force_restart: if True kills and re-creates the job even if one exists
 
     Returns: A `ServerSpec` containing information about either the existing or the newly
         created server.
@@ -322,6 +324,12 @@ async def get_or_create(
         return server_info
     else:
         print(f"{CYAN}Found existing job `{server_handle}` ready to serve.{ENDC}")
+
+        if force_restart:
+            print(f"{CYAN}force_restart=True, restarting `{server_handle}`.{ENDC}")
+            kill(server_handle)
+            server_info = await get_or_create(name, config, check_interval)
+
         return server_info
 
 

--- a/python/monarch/tools/commands.py
+++ b/python/monarch/tools/commands.py
@@ -14,6 +14,8 @@ import os
 from datetime import datetime, timedelta
 from typing import Any, Callable, Mapping, Optional, Union
 
+from monarch.tools.colors import CYAN, ENDC
+
 from monarch.tools.components.hyperactor import DEFAULT_NAME
 
 from monarch.tools.config import (  # @manual=//monarch/python/monarch/tools/config/meta:defaults
@@ -280,6 +282,11 @@ async def get_or_create(
         server_handle = get_or_create(name="my_job_name", config)
         server_info = info(server_handle)
 
+    Args:
+        name: the name of the server (job) to get or create
+        config: configs used to create the job if one does not exist
+        check_interval: how often to poll the status of the job when waiting for it to be ready
+
     Returns: A `ServerSpec` containing information about either the existing or the newly
         created server.
 
@@ -311,10 +318,10 @@ async def get_or_create(
                 f"the new server `{new_server_handle}` has {server_info.state}"
             )
 
-        print(f"\x1b[36mNew job `{new_server_handle}` is ready to serve. \x1b[0m")
+        print(f"{CYAN}New job `{new_server_handle}` is ready to serve.{ENDC}")
         return server_info
     else:
-        print(f"\x1b[36mFound existing job `{server_handle}` ready to serve. \x1b[0m")
+        print(f"{CYAN}Found existing job `{server_handle}` ready to serve.{ENDC}")
         return server_info
 
 


### PR DESCRIPTION
Summary:
`force_restart=True` will kill the existing job and force it to create again. Useful when we want to redeploy the server to reflect any changes in the local conda/workspace that are not eligible for CodeSync.

NOTE: this is tangential to setting `workspace=None` which disables local conda AND workspace building into an ephemeral image.

Reviewed By: ahmadsharif1

Differential Revision: D79754696


