### PR TITLE
[hyperactor] macros: fix hygiene of 'result'

### DIFF
--- a/hyperactor_macros/tests/basic.rs
+++ b/hyperactor_macros/tests/basic.rs
@@ -31,11 +31,20 @@ use serde::Serialize;
 enum ShoppingList {
     // Oneway messages dispatch messages asynchronously, with no reply.
     Add(String),
-    Remove { item: String }, // both tuple and struct variants are supported.
+    Remove {
+        item: String,
+    }, // both tuple and struct variants are supported.
 
     // Call messages dispatch a request, expecting a reply to the
     // provided port, which must be in the last position.
     Exists(String, #[reply] OncePortRef<bool>),
+
+    // Tests macro hygience. We use 'result' as a keyword in the implementation.
+    Clobber {
+        arg: String,
+        #[reply]
+        result: OncePortRef<bool>,
+    },
 }
 
 #[derive(Handler, HandleClient, RefClient, Debug, Serialize, Deserialize, Named)]


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #800
* #799
* #798
* #796
* __->__ #786
* #787
* #784

This caused struct members named 'result' to clash with our internal let binding.

The other bindings are in client code, which we fully control, and so should not be an issue.

Differential Revision: [D79767017](https://our.internmc.facebook.com/intern/diff/D79767017/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D79767017/)!