### PR TITLE
[hyperactor] channel: remove fallback channel type parsing

### DIFF
--- a/hyperactor/src/channel/sim.rs
+++ b/hyperactor/src/channel/sim.rs
@@ -419,8 +419,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_sim_basic() {
-        let dst_ok = vec!["[::1]:1234", "tcp!127.0.0.1:8080", "local!123"];
-        let srcs_ok = vec!["[::2]:1234", "tcp!127.0.0.2:8080", "local!124"];
+        let dst_ok = vec!["tcp![::1]:1234", "tcp!127.0.0.1:8080", "local!123"];
+        let srcs_ok = vec!["tcp![::2]:1234", "tcp!127.0.0.2:8080", "local!124"];
 
         start();
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #800
* #799
* #798
* __->__ #796
* #786
* #787
* #784

When a channel type was not specified in a channel address, we fell back to tcp. This creates icky ambiguties in the channel address syntax -- which I plan on evolving.

The first step is to remove this ambiguity, which is the purpose of this diff.

Differential Revision: [D79839031](https://our.internmc.facebook.com/intern/diff/D79839031/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D79839031/)!