### PR TITLE
[hyperactor] channel: allow ":" as a channel-type delimiter

### DIFF
--- a/hyperactor/src/channel/sim.rs
+++ b/hyperactor/src/channel/sim.rs
@@ -419,8 +419,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_sim_basic() {
-        let dst_ok = vec!["tcp![::1]:1234", "tcp!127.0.0.1:8080", "local!123"];
-        let srcs_ok = vec!["tcp![::2]:1234", "tcp!127.0.0.2:8080", "local!124"];
+        let dst_ok = vec!["tcp:[::1]:1234", "tcp:127.0.0.1:8080", "local:123"];
+        let srcs_ok = vec!["tcp:[::2]:1234", "tcp:127.0.0.2:8080", "local:124"];
 
         start();
 
@@ -460,23 +460,23 @@ mod tests {
 
     #[tokio::test]
     async fn test_parse_sim_addr() {
-        let sim_addr = "sim!unix!@dst";
+        let sim_addr = "sim!unix:@dst";
         let result = sim_addr.parse();
         assert!(result.is_ok());
         let ChannelAddr::Sim(sim_addr) = result.unwrap() else {
             panic!("Expected a sim address");
         };
         assert!(sim_addr.src().is_none());
-        assert_eq!(sim_addr.addr().to_string(), "unix!@dst");
+        assert_eq!(sim_addr.addr().to_string(), "unix:@dst");
 
-        let sim_addr = "sim!unix!@src,unix!@dst";
+        let sim_addr = "sim!unix:@src,unix:@dst";
         let result = sim_addr.parse();
         assert!(result.is_ok());
         let ChannelAddr::Sim(sim_addr) = result.unwrap() else {
             panic!("Expected a sim address");
         };
         assert!(sim_addr.src().is_some());
-        assert_eq!(sim_addr.addr().to_string(), "unix!@dst");
+        assert_eq!(sim_addr.addr().to_string(), "unix:@dst");
     }
 
     #[tokio::test]
@@ -484,18 +484,18 @@ mod tests {
         start();
 
         tokio::time::pause();
-        let sim_addr = SimAddr::new("unix!@dst".parse::<ChannelAddr>().unwrap()).unwrap();
+        let sim_addr = SimAddr::new("unix:@dst".parse::<ChannelAddr>().unwrap()).unwrap();
         let sim_addr_with_src = SimAddr::new_with_src(
-            "unix!@src".parse::<ChannelAddr>().unwrap(),
-            "unix!@dst".parse::<ChannelAddr>().unwrap(),
+            "unix:@src".parse::<ChannelAddr>().unwrap(),
+            "unix:@dst".parse::<ChannelAddr>().unwrap(),
         )
         .unwrap();
         let (_, mut rx) = sim::serve::<()>(sim_addr.clone()).unwrap();
         let tx = sim::dial::<()>(sim_addr_with_src).unwrap();
         let simnet_config_yaml = r#"
         edges:
-        - src: unix!@src
-          dst: unix!@dst
+        - src: unix:@src
+          dst: unix:@dst
           metadata:
             latency: 100
         "#;
@@ -526,15 +526,15 @@ mod tests {
         tokio::time::pause();
         start();
         let controller_to_dst = SimAddr::new_with_src(
-            "unix!@controller".parse::<ChannelAddr>().unwrap(),
-            "unix!@dst".parse::<ChannelAddr>().unwrap(),
+            "unix:@controller".parse::<ChannelAddr>().unwrap(),
+            "unix:@dst".parse::<ChannelAddr>().unwrap(),
         )
         .unwrap();
         let controller_tx = sim::dial::<()>(controller_to_dst.clone()).unwrap();
 
         let client_to_dst = SimAddr::new_with_client_src(
-            "unix!@client".parse::<ChannelAddr>().unwrap(),
-            "unix!@dst".parse::<ChannelAddr>().unwrap(),
+            "unix:@client".parse::<ChannelAddr>().unwrap(),
+            "unix:@dst".parse::<ChannelAddr>().unwrap(),
         )
         .unwrap();
         let client_tx = sim::dial::<()>(client_to_dst).unwrap();
@@ -542,8 +542,8 @@ mod tests {
         // 1 second of latency
         let simnet_config_yaml = r#"
         edges:
-        - src: unix!@controller
-          dst: unix!@dst
+        - src: unix:@controller
+          dst: unix:@dst
           metadata:
             latency: 1
         "#;

--- a/hyperactor/src/mailbox.rs
+++ b/hyperactor/src/mailbox.rs
@@ -2639,10 +2639,10 @@ mod tests {
     #[tokio::test]
     async fn test_sim_client_server() {
         simnet::start();
-        let dst_addr = SimAddr::new("local!1".parse::<ChannelAddr>().unwrap()).unwrap();
+        let dst_addr = SimAddr::new("local:1".parse::<ChannelAddr>().unwrap()).unwrap();
         let src_to_dst = ChannelAddr::Sim(
             SimAddr::new_with_src(
-                "local!0".parse::<ChannelAddr>().unwrap(),
+                "local:0".parse::<ChannelAddr>().unwrap(),
                 dst_addr.addr().clone(),
             )
             .unwrap(),

--- a/hyperactor/src/simnet.rs
+++ b/hyperactor/src/simnet.rs
@@ -917,8 +917,8 @@ mod tests {
         // Tests that we can create a simnet, config latency between two node and deliver
         // the message with configured latency.
         start();
-        let alice = "local!1".parse::<simnet::ChannelAddr>().unwrap();
-        let bob = "local!2".parse::<simnet::ChannelAddr>().unwrap();
+        let alice = "local:1".parse::<simnet::ChannelAddr>().unwrap();
+        let bob = "local:2".parse::<simnet::ChannelAddr>().unwrap();
         let latency = Duration::from_millis(1000);
         let config = NetworkConfig {
             edges: vec![EdgeConfig {
@@ -949,7 +949,7 @@ mod tests {
             .unwrap();
         let records = simnet_handle().unwrap().close().await;
         let expected_record = SimulatorEventRecord {
-            summary: "Sending message from local!1 to local!2".to_string(),
+            summary: "Sending message from local:1 to local:2".to_string(),
             start_at: 0,
             end_at: latency.as_millis() as u64,
         };
@@ -960,8 +960,8 @@ mod tests {
     #[tokio::test]
     async fn test_simnet_debounce() {
         start();
-        let alice = "local!1".parse::<simnet::ChannelAddr>().unwrap();
-        let bob = "local!2".parse::<simnet::ChannelAddr>().unwrap();
+        let alice = "local:1".parse::<simnet::ChannelAddr>().unwrap();
+        let bob = "local:2".parse::<simnet::ChannelAddr>().unwrap();
 
         let latency = Duration::from_millis(10000);
         simnet_handle()
@@ -1020,7 +1020,7 @@ mod tests {
         // // Create a simple network of 4 nodes.
         for i in 0..4 {
             addresses.push(
-                format!("local!{}", i)
+                format!("local:{}", i)
                     .parse::<simnet::ChannelAddr>()
                     .unwrap(),
             );
@@ -1083,16 +1083,16 @@ mod tests {
     async fn test_read_config_from_yaml() {
         let yaml = r#"
  edges:
-   - src: local!0
-     dst: local!1
+   - src: local:0
+     dst: local:1
      metadata:
        latency: 1
-   - src: local!0
-     dst: local!2
+   - src: local:0
+     dst: local:2
      metadata:
        latency: 2
-   - src: local!1
-     dst: local!2
+   - src: local:1
+     dst: local:2
      metadata:
        latency: 3
  "#;
@@ -1100,29 +1100,29 @@ mod tests {
         assert_eq!(config.edges.len(), 3);
         assert_eq!(
             config.edges[0].src,
-            "local!0".parse::<simnet::ChannelAddr>().unwrap()
+            "local:0".parse::<simnet::ChannelAddr>().unwrap()
         );
         assert_eq!(
             config.edges[0].dst,
-            "local!1".parse::<simnet::ChannelAddr>().unwrap()
+            "local:1".parse::<simnet::ChannelAddr>().unwrap()
         );
         assert_eq!(config.edges[0].metadata.latency, Duration::from_secs(1));
         assert_eq!(
             config.edges[1].src,
-            "local!0".parse::<simnet::ChannelAddr>().unwrap()
+            "local:0".parse::<simnet::ChannelAddr>().unwrap()
         );
         assert_eq!(
             config.edges[1].dst,
-            "local!2".parse::<simnet::ChannelAddr>().unwrap()
+            "local:2".parse::<simnet::ChannelAddr>().unwrap()
         );
         assert_eq!(config.edges[1].metadata.latency, Duration::from_secs(2));
         assert_eq!(
             config.edges[2].src,
-            "local!1".parse::<simnet::ChannelAddr>().unwrap()
+            "local:1".parse::<simnet::ChannelAddr>().unwrap()
         );
         assert_eq!(
             config.edges[2].dst,
-            "local!2".parse::<simnet::ChannelAddr>().unwrap()
+            "local:2".parse::<simnet::ChannelAddr>().unwrap()
         );
         assert_eq!(config.edges[2].metadata.latency, Duration::from_secs(3));
     }

--- a/hyperactor_multiprocess/src/ping_pong.rs
+++ b/hyperactor_multiprocess/src/ping_pong.rs
@@ -33,7 +33,7 @@ mod tests {
     #[tracing_test::traced_test]
     #[tokio::test]
     async fn test_sim_ping_pong() {
-        let system_addr = "local!1".parse::<ChannelAddr>().unwrap();
+        let system_addr = "local:1".parse::<ChannelAddr>().unwrap();
 
         simnet::start();
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #800
* #799
* __->__ #798
* #796
* #786
* #787
* #784

We currently use "!" to delimit between channel type and its address. The main issue with "!" is that it is not shell-friendly, as Bourne shells will expand "!" into a history entry.

With this change, we allow ":" to be used instead. With the previous change (requiring channel types to be specified), we can parse these two cases unambiguously.

The ChannelAddr `Display` implementation is adjusted to emit ":"-delimited channel addresses, too. It is the new preferred syntax.

Differential Revision: [D79846852](https://our.internmc.facebook.com/intern/diff/D79846852/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D79846852/)!