### PR TITLE
[hyperactor] parse direct procs / actors

### DIFF
--- a/hyperactor/src/parse.rs
+++ b/hyperactor/src/parse.rs
@@ -38,6 +38,8 @@ pub enum Token<'a> {
     Colon,
     /// "."
     Dot,
+    /// ","
+    Comma,
 
     // Special token to denote an invalid element. It is used to poison
     // the parser.
@@ -56,7 +58,7 @@ impl<'a> Lexer<'a> {
         Self {
             // TODO: compose iterators directly; would be simpler with
             // existential type support.
-            tokens: chop(input, &["[", "]", ".", "@"]).collect(),
+            tokens: chop(input, &["[", "]", ".", "@", ","]).collect(),
         }
     }
 }
@@ -72,6 +74,7 @@ impl<'a> Iterator for Lexer<'a> {
             Some("@") => Some(Token::At),
             Some(":") => Some(Token::Colon),
             Some(".") => Some(Token::Dot),
+            Some(",") => Some(Token::Comma),
             Some(elem) => Some({
                 if let Ok(uint) = elem.parse::<usize>() {
                     Token::Uint(uint)
@@ -180,7 +183,7 @@ mod tests {
 
     #[test]
     fn test_lexer() {
-        let tokens = Lexer::new("foo.bar[123]");
+        let tokens = Lexer::new("foo.bar[123],baz");
         assert_eq!(
             tokens.collect::<Vec<Token>>(),
             vec![
@@ -189,7 +192,9 @@ mod tests {
                 Token::Elem("bar"),
                 Token::LeftBracket,
                 Token::Uint(123),
-                Token::RightBracket
+                Token::RightBracket,
+                Token::Comma,
+                Token::Elem("baz"),
             ]
         )
     }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #800
* #799
* #798
* #796
* #786
* #787
* #784

This change introduces a new kind of identifier used to parse direct procs.

As we plan to phase out ranked procs, this will become the only kind of identifier in the system.


```
# The proc "proc-name" at tcp:[::1]:1234
tcp:[::1]:1234,proc-name

# The root actor "actor-name" at the above proc
tcp:[::1]:1234,proc-name,actor-name

# ... equivalent to:
tcp:[::1]:1234,proc-name,actor-name[0]

# A child actor of the above actor:
tcp:[::1]:1234,proc-name,actor-name[123]
```

## Alternatives considered

The central challenge with this syntax is satisfying the following simultaneously:

1) Unambiguous parsing: all while mixing channel addresses and procs, actor names, and PIDs
2) A shell-friendly syntax: we do not want to have to impose quoting or escaping in typical cases
3) Make it simple, drawing on only a few lexemes

For example, the first requirement precludes a straightforward URL syntax, consider:

```
tcp://[::1]:1234/proc-name/actor-name/pid
```

but what happens when you introduce unix sockets?

```
unix:///path/to/socket/proc-name/actor-name/pid
```

How do you delimit the socket address from the proc name?

One alternative is to introduce another delimiter, e.g.:

```
unix:///path/to/socket//proc-name/actor-name/pid
```

but now this looks rather like line noise! And it's hard to parse!

One alternative I liked is to quote the channel address: this sets it apart, and signifies a separate syntax.

```
"tcp:[::1]:1234".proc-name.actor-name[pid]
```

but the shell parses the quotes!

Similar issues exist for other alternatives, which can be parsed unambiguously, but would make the grammar more complicated:

```
# Brackets compete with IPv6 addresses, requiring recursive descent parsing
unix[/foo/bar].proc-name.actor-name[pid]

# "::" clash with IPv6 addresses, requiring additional context to parse correctly
unix:/foo/bar::proc-name::actor-name[pid]
```

And so on.

All of this being said: if you find a clearly superior alternative, I am all ears.

Differential Revision: [D79856404](https://our.internmc.facebook.com/intern/diff/D79856404/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D79856404/)!