### PR TITLE
do not unwrap during shutdown

### DIFF
--- a/monarch_extension/src/logging.rs
+++ b/monarch_extension/src/logging.rs
@@ -94,7 +94,13 @@ impl LoggingMeshClient {
 
 impl Drop for LoggingMeshClient {
     fn drop(&mut self) {
-        let _ = self.client_actor.drain_and_stop().unwrap();
+        match self.client_actor.drain_and_stop() {
+            Ok(_) => {}
+            Err(e) => {
+                // it is ok as during shutdown, the channel might already be closed
+                tracing::debug!("error draining logging client actor during shutdown: {}", e);
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Summary: the actor might be gone already; no need to unwrap if it errors out

Reviewed By: vidhyav, amirafzali

Differential Revision: D79904856


