### PR TITLE
abort log tailer for proc during proc shutdown

### DIFF
--- a/hyperactor_mesh/src/alloc/process.rs
+++ b/hyperactor_mesh/src/alloc/process.rs
@@ -466,6 +466,8 @@ impl Alloc for ProcessAlloc {
 
                 Some(Ok((index, mut reason))) = self.children.join_next() => {
                     let stderr_content = if let Some(Child { stdout, stderr, ..} ) = self.remove(index) {
+                        stdout.abort();
+                        stderr.abort();
                         let (_stdout, _) = stdout.join().await;
                         let (stderr_lines, _) = stderr.join().await;
                         stderr_lines.join("\n")


### PR DESCRIPTION
Summary:
When proc stops, we shutdown all actors and exit the process. We also join the
log tailers. We need to explicitly abort the log tailers to make sure joining
won't be stuck.

Reviewed By: vidhyav

Differential Revision: D79932041


