### PR TITLE
ignore sigpipe

### DIFF
--- a/monarch_hyperactor/Cargo.toml
+++ b/monarch_hyperactor/Cargo.toml
@@ -26,6 +26,7 @@ hyperactor_multiprocess = { version = "0.0.0", path = "../hyperactor_multiproces
 hyperactor_telemetry = { version = "0.0.0", path = "../hyperactor_telemetry" }
 inventory = "0.3.8"
 lazy_static = "1.5"
+libc = "0.2.139"
 monarch_types = { version = "0.0.0", path = "../monarch_types" }
 ndslice = { version = "0.0.0", path = "../ndslice" }
 nix = { version = "0.30.1", features = ["dir", "event", "hostname", "inotify", "ioctl", "mman", "mount", "net", "poll", "ptrace", "reboot", "resource", "sched", "signal", "term", "time", "user", "zerocopy"] }


### PR DESCRIPTION
Summary:
SAFETY: ignore SIGPIPE as hyperactor tx/rx channels have the following issue:
When tx tries to send a message, it can either do try_post/post or send.
try_post/post is async and send is sync. However, both methods do not have a
way to tell the receiver's state.
For try_post/post, it will send messages in the background. However, if the
receiver process gets killed,
try_post/post will continue sending messages leading to SIGPIPE and crash the
parent process.
For send, it is a sync call. It waits on the receiver to ack. However, if the
receiver is dead or not started yet,
the send will be blocked.


We need to fix the above issues but before that, ignore SIGPIPE as a
mitigation.


As a specific victim of this, the log sender streams the log to the log
forwarder. However, it doesn't know the state of the log forwarder. It could
have not started yet or being killed. If we use tx.send, it will be blocked
leading to stuck allocator. If we use tx.post, it will get back sigpipe on
child process shutdown.

Reviewed By: LucasLLC

Differential Revision: D80131609


