### PR TITLE
Move casting protocol into rust

### DIFF
--- a/monarch_hyperactor/src/actor_mesh.rs
+++ b/monarch_hyperactor/src/actor_mesh.rs
@@ -6,9 +6,15 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+use std::error::Error;
+use std::future::Future;
+use std::pin::Pin;
 use std::sync::Arc;
 
+use futures::future::FutureExt;
+use futures::future::Shared;
 use hyperactor::ActorRef;
+use hyperactor::Mailbox;
 use hyperactor::id;
 use hyperactor::supervision::ActorSupervisionEvent;
 use hyperactor_mesh::Mesh;
@@ -16,8 +22,11 @@ use hyperactor_mesh::RootActorMesh;
 use hyperactor_mesh::actor_mesh::ActorMesh;
 use hyperactor_mesh::actor_mesh::ActorSupervisionEvents;
 use hyperactor_mesh::reference::ActorMeshRef;
+use hyperactor_mesh::sel;
 use hyperactor_mesh::shared_cell::SharedCell;
 use hyperactor_mesh::shared_cell::SharedCellRef;
+use ndslice::Selection;
+use pyo3::IntoPyObjectExt;
 use pyo3::exceptions::PyException;
 use pyo3::exceptions::PyNotImplementedError;
 use pyo3::exceptions::PyRuntimeError;
@@ -28,23 +37,133 @@ use pyo3::types::PyDict;
 use pyo3::types::PySlice;
 use serde::Deserialize;
 use serde::Serialize;
+use tokio::pin;
+use tokio::sync::mpsc::Sender;
+use tokio::sync::mpsc::channel;
+use tokio::sync::oneshot;
 
 use crate::actor::PythonActor;
 use crate::actor::PythonMessage;
+use crate::actor::PythonMessageKind;
+use crate::mailbox::EitherPortRef;
 use crate::mailbox::PyMailbox;
 use crate::proc::PyActorId;
 use crate::proc_mesh::Keepalive;
 use crate::pytokio::PyPythonTask;
-use crate::selection::PySelection;
+use crate::pytokio::PyShared;
+use crate::runtime::get_tokio_runtime;
 use crate::shape::PyShape;
 use crate::supervision::SupervisionError;
 use crate::supervision::Unhealthy;
 
+/// Trait defining the common interface for actor mesh, mesh ref and actor mesh implementations.
+/// This corresponds to the Python ActorMeshProtocol ABC.
+trait ActorMeshProtocol: Send + Sync {
+    /// Cast a message to actors selected by the given selection using the specified mailbox.
+    fn cast(&self, message: PythonMessage, selection: Selection, mailbox: Mailbox) -> PyResult<()>;
+
+    /// Create a new actor mesh with the specified shape.
+    fn new_with_shape(&self, shape: PyShape) -> PyResult<Box<dyn ActorMeshProtocol>>;
+
+    fn __reduce__<'py>(&self, py: Python<'py>) -> PyResult<(Bound<'py, PyAny>, Bound<'py, PyAny>)>;
+
+    /// Get supervision events for this actor mesh.
+    /// Returns None by default for implementations that don't support supervision events.
+    fn supervision_event(&self) -> PyResult<Option<PyShared>> {
+        Ok(None)
+    }
+
+    /// Stop the actor mesh asynchronously.
+    /// Default implementation raises NotImplementedError for types that don't support stopping.
+    fn stop(&self) -> PyResult<PyPythonTask> {
+        Err(PyNotImplementedError::new_err(format!(
+            "stop() is not supported for {}",
+            std::any::type_name::<Self>()
+        )))
+    }
+
+    /// Initialize the actor mesh asynchronously.
+    /// Default implementation returns None (no initialization needed).
+    fn initialized<'py>(&self) -> PyResult<PyPythonTask> {
+        PyPythonTask::new(async { Ok(None::<()>) })
+    }
+}
+
+/// This just forwards to the rust trait that can implement these bindings
 #[pyclass(
     name = "PythonActorMesh",
     module = "monarch._rust_bindings.monarch_hyperactor.actor_mesh"
 )]
-pub struct PythonActorMesh {
+pub(crate) struct PythonActorMesh {
+    inner: Box<dyn ActorMeshProtocol>,
+}
+
+impl PythonActorMesh {
+    pub(crate) fn new<F>(f: F) -> Self
+    where
+        F: Future<Output = PyResult<PythonActorMeshImpl>> + Send + 'static,
+    {
+        PythonActorMesh {
+            inner: Box::new(AsyncActorMesh::new_queue(async {
+                let b: Box<dyn ActorMeshProtocol> = Box::new(f.await?);
+                Ok(b)
+            })),
+        }
+    }
+}
+
+fn to_hy_sel(selection: &str) -> PyResult<Selection> {
+    match selection {
+        "choose" => Ok(sel!(?)),
+        "all" => Ok(sel!(*)),
+        _ => Err(PyErr::new::<PyValueError, _>(format!(
+            "Invalid selection: {}",
+            selection
+        ))),
+    }
+}
+
+#[pymethods]
+impl PythonActorMesh {
+    fn cast(&self, message: &PythonMessage, selection: &str, mailbox: &PyMailbox) -> PyResult<()> {
+        let sel = to_hy_sel(selection)?;
+        self.inner.cast(message.clone(), sel, mailbox.inner.clone())
+    }
+
+    fn new_with_shape(&self, shape: PyShape) -> PyResult<PythonActorMesh> {
+        let inner = self.inner.new_with_shape(shape)?;
+        Ok(PythonActorMesh { inner })
+    }
+
+    fn supervision_event(&self) -> PyResult<Option<PyShared>> {
+        self.inner.supervision_event()
+    }
+
+    fn stop(&self) -> PyResult<PyPythonTask> {
+        self.inner.stop()
+    }
+
+    fn initialized(&self) -> PyResult<PyPythonTask> {
+        self.inner.initialized()
+    }
+
+    fn __reduce__<'py>(&self, py: Python<'py>) -> PyResult<(Bound<'py, PyAny>, Bound<'py, PyAny>)> {
+        self.inner.__reduce__(py)
+    }
+
+    #[staticmethod]
+    fn from_bytes(bytes: &Bound<'_, PyBytes>) -> PyResult<PythonActorMesh> {
+        let r: PyResult<PythonActorMeshRef> = bincode::deserialize(bytes.as_bytes())
+            .map_err(|e| PyErr::new::<PyValueError, _>(e.to_string()));
+        r.map(|r| PythonActorMesh { inner: Box::new(r) })
+    }
+}
+
+#[pyclass(
+    name = "PythonActorMeshImpl",
+    module = "monarch._rust_bindings.monarch_hyperactor.actor_mesh"
+)]
+pub(crate) struct PythonActorMeshImpl {
     inner: SharedCell<RootActorMesh<'static, PythonActor>>,
     client: PyMailbox,
     _keepalive: Keepalive,
@@ -53,10 +172,10 @@ pub struct PythonActorMesh {
     monitor: tokio::task::JoinHandle<()>,
 }
 
-impl PythonActorMesh {
+impl PythonActorMeshImpl {
     /// Create a new [`PythonActorMesh`] with a monitor that will observe supervision
     /// errors for this mesh, and update its state properly.
-    pub(crate) fn monitored(
+    pub(crate) fn new(
         inner: SharedCell<RootActorMesh<'static, PythonActor>>,
         client: PyMailbox,
         keepalive: Keepalive,
@@ -65,12 +184,12 @@ impl PythonActorMesh {
         let (user_monitor_sender, _) =
             tokio::sync::broadcast::channel::<Option<ActorSupervisionEvent>>(1);
         let unhealthy_event = Arc::new(std::sync::Mutex::new(Unhealthy::SoFarSoGood));
-        let monitor = tokio::spawn(Self::actor_mesh_monitor(
+        let monitor = tokio::spawn(PythonActorMeshImpl::actor_mesh_monitor(
             events,
             user_monitor_sender.clone(),
             Arc::clone(&unhealthy_event),
         ));
-        Self {
+        PythonActorMeshImpl {
             inner,
             client,
             _keepalive: keepalive,
@@ -79,7 +198,6 @@ impl PythonActorMesh {
             monitor,
         }
     }
-
     /// Monitor of the actor mesh. It processes supervision errors for the mesh, and keeps mesh
     /// health state up to date.
     async fn actor_mesh_monitor(
@@ -115,23 +233,14 @@ impl PythonActorMesh {
         })
     }
 
-    fn pickling_err(&self) -> PyErr {
-        PyErr::new::<PyNotImplementedError, _>(
-            "PythonActorMesh cannot be pickled. If applicable, use bind() \
-            to get a PythonActorMeshRef, and use that instead."
-                .to_string(),
-        )
+    fn bind(&self) -> PyResult<PythonActorMeshRef> {
+        let mesh = self.try_inner()?;
+        Ok(PythonActorMeshRef { inner: mesh.bind() })
     }
 }
 
-#[pymethods]
-impl PythonActorMesh {
-    fn cast(
-        &self,
-        mailbox: &PyMailbox,
-        selection: &PySelection,
-        message: &PythonMessage,
-    ) -> PyResult<()> {
+impl ActorMeshProtocol for PythonActorMeshImpl {
+    fn cast(&self, message: PythonMessage, selection: Selection, mailbox: Mailbox) -> PyResult<()> {
         let unhealthy_event = self
             .unhealthy_event
             .lock()
@@ -153,16 +262,54 @@ impl PythonActorMesh {
         }
 
         self.try_inner()?
-            .cast(&mailbox.inner, selection.inner().clone(), message.clone())
+            .cast(&mailbox, selection, message.clone())
             .map_err(|err| PyException::new_err(err.to_string()))?;
         Ok(())
     }
-
-    fn bind(&self) -> PyResult<PythonActorMeshRef> {
-        let mesh = self.try_inner()?;
-        Ok(PythonActorMeshRef { inner: mesh.bind() })
+    fn supervision_event(&self) -> PyResult<Option<PyShared>> {
+        let mut receiver = self.user_monitor_sender.subscribe();
+        PyPythonTask::new(async move {
+            let event = receiver.recv().await;
+            let event = match event {
+                Ok(Some(event)) => PyActorSupervisionEvent::from(event.clone()),
+                Ok(None) | Err(_) => PyActorSupervisionEvent {
+                    // Dummy actor as placeholder to indicate the whole mesh is stopped
+                    // TODO(albertli): remove this when pushing all supervision logic to rust.
+                    actor_id: id!(default[0].actor[0]).into(),
+                    actor_status: "actor mesh is stopped due to proc mesh shutdown".to_string(),
+                },
+            };
+            Ok(PyErr::new::<SupervisionError, _>(format!(
+                "Actor {:?} exited because of the following reason: {}",
+                event.actor_id, event.actor_status
+            )))
+        })
+        .map(|mut x| x.spawn().map(Some))?
+    }
+    fn new_with_shape(&self, shape: PyShape) -> PyResult<Box<dyn ActorMeshProtocol>> {
+        self.bind()?.new_with_shape(shape)
     }
 
+    fn stop<'py>(&self) -> PyResult<PyPythonTask> {
+        let actor_mesh = self.inner.clone();
+        PyPythonTask::new(async move {
+            let actor_mesh = actor_mesh
+                .take()
+                .await
+                .map_err(|_| PyRuntimeError::new_err("`ActorMesh` has already been stopped"))?;
+            actor_mesh.stop().await.map_err(|err| {
+                PyException::new_err(format!("Failed to stop actor mesh: {}", err))
+            })?;
+            Ok(())
+        })
+    }
+    fn __reduce__<'py>(&self, py: Python<'py>) -> PyResult<(Bound<'py, PyAny>, Bound<'py, PyAny>)> {
+        self.bind()?.__reduce__(py)
+    }
+}
+
+#[pymethods]
+impl PythonActorMeshImpl {
     fn get_supervision_event(&self) -> PyResult<Option<PyActorSupervisionEvent>> {
         let unhealthy_event = self
             .unhealthy_event
@@ -181,6 +328,12 @@ impl PythonActorMesh {
         }
     }
 
+    fn supervision_event(&self) -> PyResult<Option<PyShared>> {
+        ActorMeshProtocol::supervision_event(self)
+    }
+    fn stop(&self) -> PyResult<PyPythonTask> {
+        ActorMeshProtocol::stop(self)
+    }
     // Consider defining a "PythonActorRef", which carries specifically
     // a reference to python message actors.
     fn get(&self, rank: usize) -> PyResult<Option<PyActorId>> {
@@ -190,67 +343,6 @@ impl PythonActorMesh {
             .map(ActorRef::into_actor_id)
             .map(PyActorId::from))
     }
-    fn supervision_event(&self) -> PyResult<PyPythonTask> {
-        let mut receiver = self.user_monitor_sender.subscribe();
-        PyPythonTask::new(async move {
-            let event = receiver.recv().await;
-            let event = match event {
-                Ok(Some(event)) => PyActorSupervisionEvent::from(event.clone()),
-                Ok(None) | Err(_) => PyActorSupervisionEvent {
-                    // Dummy actor as placeholder to indicate the whole mesh is stopped
-                    // TODO(albertli): remove this when pushing all supervision logic to rust.
-                    actor_id: id!(default[0].actor[0]).into(),
-                    actor_status: "actor mesh is stopped due to proc mesh shutdown".to_string(),
-                },
-            };
-            Ok(PyErr::new::<SupervisionError, _>(format!(
-                "Actor {:?} exited because of the following reason: {}",
-                event.actor_id, event.actor_status
-            )))
-        })
-    }
-
-    #[pyo3(signature = (**kwargs))]
-    fn slice(&self, kwargs: Option<&Bound<'_, PyDict>>) -> PyResult<PythonActorMeshRef> {
-        self.bind()?.slice(kwargs)
-    }
-
-    fn new_with_shape(&self, shape: PyShape) -> PyResult<PythonActorMeshRef> {
-        self.bind()?.new_with_shape(shape)
-    }
-
-    #[getter]
-    pub fn client(&self) -> PyMailbox {
-        self.client.clone()
-    }
-
-    #[getter]
-    fn shape(&self) -> PyResult<PyShape> {
-        Ok(PyShape::from(self.try_inner()?.shape().clone()))
-    }
-
-    // Override the pickling methods to provide a meaningful error message.
-    fn __reduce__(&self) -> PyResult<()> {
-        Err(self.pickling_err())
-    }
-
-    fn __reduce_ex__(&self, _proto: u8) -> PyResult<()> {
-        Err(self.pickling_err())
-    }
-
-    fn stop<'py>(&self) -> PyResult<PyPythonTask> {
-        let actor_mesh = self.inner.clone();
-        PyPythonTask::new(async move {
-            let actor_mesh = actor_mesh
-                .take()
-                .await
-                .map_err(|_| PyRuntimeError::new_err("`ActorMesh` has already been stopped"))?;
-            actor_mesh.stop().await.map_err(|err| {
-                PyException::new_err(format!("Failed to stop actor mesh: {}", err))
-            })?;
-            Ok(())
-        })
-    }
 
     #[getter]
     fn stopped(&self) -> PyResult<bool> {
@@ -258,133 +350,44 @@ impl PythonActorMesh {
     }
 }
 
-#[pyclass(
-    frozen,
-    name = "PythonActorMeshRef",
-    module = "monarch._rust_bindings.monarch_hyperactor.actor_mesh"
-)]
 #[derive(Debug, Serialize, Deserialize)]
-pub(super) struct PythonActorMeshRef {
+struct PythonActorMeshRef {
     inner: ActorMeshRef<PythonActor>,
 }
 
-#[pymethods]
-impl PythonActorMeshRef {
-    fn cast(
-        &self,
-        client: &PyMailbox,
-        selection: &PySelection,
-        message: &PythonMessage,
-    ) -> PyResult<()> {
+impl ActorMeshProtocol for PythonActorMeshRef {
+    fn cast(&self, message: PythonMessage, selection: Selection, client: Mailbox) -> PyResult<()> {
         self.inner
-            .cast(&client.inner, selection.inner().clone(), message.clone())
+            .cast(&client, selection, message.clone())
             .map_err(|err| PyException::new_err(err.to_string()))?;
         Ok(())
     }
 
-    #[pyo3(signature = (**kwargs))]
-    fn slice(&self, kwargs: Option<&Bound<'_, PyDict>>) -> PyResult<Self> {
-        // When the input type is `int`, convert it into `ndslice::Range`.
-        fn convert_int(index: isize) -> PyResult<ndslice::Range> {
-            if index < 0 {
-                return Err(PyException::new_err(format!(
-                    "does not support negative index in selection: {}",
-                    index
-                )));
-            }
-            Ok(ndslice::Range::from(index as usize))
-        }
-
-        // When the input type is `slice`, convert it into `ndslice::Range`.
-        fn convert_py_slice<'py>(s: &Bound<'py, PySlice>) -> PyResult<ndslice::Range> {
-            fn get_attr<'py>(s: &Bound<'py, PySlice>, attr: &str) -> PyResult<Option<isize>> {
-                let v = s.getattr(attr)?.extract::<Option<isize>>()?;
-                if v.is_some() && v.unwrap() < 0 {
-                    return Err(PyException::new_err(format!(
-                        "does not support negative {} in slice: {}",
-                        attr,
-                        v.unwrap(),
-                    )));
-                }
-                Ok(v)
-            }
-
-            let start = get_attr(s, "start")?.unwrap_or(0);
-            let stop: Option<isize> = get_attr(s, "stop")?;
-            let step = get_attr(s, "step")?.unwrap_or(1);
-            Ok(ndslice::Range(
-                start as usize,
-                stop.map(|s| s as usize),
-                step as usize,
-            ))
-        }
-
-        if kwargs.is_none() || kwargs.unwrap().is_empty() {
-            return Err(PyException::new_err("selection cannot be empty"));
-        }
-
-        let mut sliced = self.inner.clone();
-
-        for entry in kwargs.unwrap().items() {
-            let label = entry.get_item(0)?.str()?;
-            let label_str = label.to_str()?;
-
-            let value = entry.get_item(1)?;
-
-            let range = if let Ok(index) = value.extract::<isize>() {
-                convert_int(index)?
-            } else if let Ok(s) = value.downcast::<PySlice>() {
-                convert_py_slice(s)?
-            } else {
-                return Err(PyException::new_err(
-                    "selection only supports type int or slice",
-                ));
-            };
-            sliced = sliced.select(label_str, range).map_err(|err| {
-                PyException::new_err(format!(
-                    "failed to select label {}; error is: {}",
-                    label_str, err
-                ))
-            })?;
-        }
-
-        Ok(Self { inner: sliced })
-    }
-
-    fn new_with_shape(&self, shape: PyShape) -> PyResult<PythonActorMeshRef> {
+    fn new_with_shape(&self, shape: PyShape) -> PyResult<Box<dyn ActorMeshProtocol>> {
         let sliced = self
             .inner
             .new_with_shape(shape.get_inner().clone())
             .map_err(|e| PyErr::new::<PyValueError, _>(e.to_string()))?;
-        Ok(Self { inner: sliced })
+        Ok(Box::new(Self { inner: sliced }))
     }
 
-    #[getter]
-    fn shape(&self) -> PyShape {
-        PyShape::from(self.inner.shape().clone())
-    }
-
-    #[staticmethod]
-    fn from_bytes(bytes: &Bound<'_, PyBytes>) -> PyResult<Self> {
-        bincode::deserialize(bytes.as_bytes())
-            .map_err(|e| PyErr::new::<PyValueError, _>(e.to_string()))
-    }
-
-    fn __reduce__<'py>(
-        slf: &Bound<'py, Self>,
-    ) -> PyResult<(Bound<'py, PyAny>, (Bound<'py, PyBytes>,))> {
-        let bytes = bincode::serialize(&*slf.borrow())
-            .map_err(|e| PyErr::new::<PyValueError, _>(e.to_string()))?;
-        let py_bytes = PyBytes::new(slf.py(), &bytes);
-        Ok((slf.as_any().getattr("from_bytes")?, (py_bytes,)))
-    }
-
-    fn __repr__(&self) -> String {
-        format!("{:?}", self)
+    fn __reduce__<'py>(&self, py: Python<'py>) -> PyResult<(Bound<'py, PyAny>, Bound<'py, PyAny>)> {
+        let bytes =
+            bincode::serialize(self).map_err(|e| PyErr::new::<PyValueError, _>(e.to_string()))?;
+        let py_bytes = (PyBytes::new(py, &bytes),).into_bound_py_any(py).unwrap();
+        let module = py
+            .import("monarch._rust_bindings.monarch_hyperactor.actor_mesh")
+            .unwrap();
+        let from_bytes = module
+            .getattr("PythonActorMesh")
+            .unwrap()
+            .getattr("from_bytes")
+            .unwrap();
+        Ok((from_bytes, py_bytes))
     }
 }
 
-impl Drop for PythonActorMesh {
+impl Drop for PythonActorMeshImpl {
     fn drop(&mut self) {
         if let Ok(mesh) = self.inner.borrow() {
             tracing::debug!("Dropping PythonActorMesh: {}", mesh.name());
@@ -394,6 +397,149 @@ impl Drop for PythonActorMesh {
             );
         }
         self.monitor.abort();
+    }
+}
+struct ClonePyErr {
+    inner: PyErr,
+}
+
+impl From<ClonePyErr> for PyErr {
+    fn from(value: ClonePyErr) -> PyErr {
+        value.inner
+    }
+}
+impl From<PyErr> for ClonePyErr {
+    fn from(inner: PyErr) -> ClonePyErr {
+        ClonePyErr { inner }
+    }
+}
+
+impl Clone for ClonePyErr {
+    fn clone(&self) -> Self {
+        Python::with_gil(|py| self.inner.clone_ref(py).into())
+    }
+}
+
+type ActorMeshResult = Result<Arc<dyn ActorMeshProtocol>, ClonePyErr>;
+struct AsyncActorMesh {
+    mesh: Shared<Pin<Box<dyn Future<Output = ActorMeshResult> + Send>>>,
+    queue: Sender<Pin<Box<dyn Future<Output = ()> + Send + 'static>>>,
+    supervised: bool,
+}
+
+impl AsyncActorMesh {
+    fn new_queue<F>(f: F) -> AsyncActorMesh
+    where
+        F: Future<Output = PyResult<Box<dyn ActorMeshProtocol>>> + Send + 'static,
+    {
+        let (queue, mut recv) = channel(128);
+
+        get_tokio_runtime().spawn(async move {
+            loop {
+                let r = recv.recv().await;
+                if let Some(r) = r {
+                    r.await;
+                } else {
+                    return;
+                }
+            }
+        });
+        AsyncActorMesh::new(queue, true, f)
+    }
+    fn new<F>(
+        queue: Sender<Pin<Box<dyn Future<Output = ()> + Send + 'static>>>,
+        supervised: bool,
+        f: F,
+    ) -> AsyncActorMesh
+    where
+        F: Future<Output = PyResult<Box<dyn ActorMeshProtocol>>> + Send + 'static,
+    {
+        let mesh = async { Ok(Arc::from(f.await?)) }.boxed().shared();
+        AsyncActorMesh {
+            mesh,
+            queue,
+            supervised,
+        }
+    }
+
+    fn push<F>(&self, f: F)
+    where
+        F: Future<Output = ()> + Send + 'static,
+    {
+        self.queue.blocking_send(f.boxed()).unwrap();
+    }
+}
+
+impl ActorMeshProtocol for AsyncActorMesh {
+    fn cast(&self, message: PythonMessage, selection: Selection, client: Mailbox) -> PyResult<()> {
+        let mesh = self.mesh.clone();
+        self.push(async {
+            let port = match &message.kind {
+                PythonMessageKind::CallMethod { response_port, .. } => response_port.clone(),
+                _ => None,
+            };
+            let result = async { mesh.await?.cast(message, selection, client.clone()) }.await;
+            match (port, result) {
+                (Some(p), Err(pyerr)) => Python::with_gil(|py: Python<'_>| {
+                    let port_ref = match p {
+                        EitherPortRef::Once(p) => p.into_bound_py_any(py),
+                        EitherPortRef::Unbounded(p) => p.into_bound_py_any(py),
+                    }
+                    .unwrap();
+                    let port = py
+                        .import("monarch._src.actor.actor_mesh")
+                        .unwrap()
+                        .call_method1("Port", (port_ref, PyMailbox { inner: client }, 0))
+                        .unwrap();
+                    port.call_method1("exception", (pyerr.value(py),)).unwrap();
+                }),
+                _ => (),
+            }
+        });
+        Ok(())
+    }
+
+    fn new_with_shape(&self, shape: PyShape) -> PyResult<Box<dyn ActorMeshProtocol>> {
+        let mesh = self.mesh.clone();
+        Ok(Box::new(AsyncActorMesh::new(
+            self.queue.clone(),
+            false,
+            async { Ok(mesh.await?.new_with_shape(shape)?) },
+        )))
+    }
+
+    fn __reduce__<'py>(&self, py: Python<'py>) -> PyResult<(Bound<'py, PyAny>, Bound<'py, PyAny>)> {
+        let mesh = self.mesh.clone();
+        let mesh = py.allow_threads(|| get_tokio_runtime().block_on(mesh));
+        mesh?.__reduce__(py)
+    }
+
+    fn supervision_event(&self) -> PyResult<Option<PyShared>> {
+        if !self.supervised {
+            return Ok(None);
+        }
+        let mesh = self.mesh.clone();
+        PyPythonTask::new(async {
+            let mut event = mesh.await?.supervision_event()?.unwrap();
+            event.task()?.take_task()?.await
+        })
+        .map(|mut x| x.spawn().map(Some))?
+    }
+
+    fn stop(&self) -> PyResult<PyPythonTask> {
+        let mesh = self.mesh.clone();
+        PyPythonTask::new(async {
+            let task = mesh.await?.stop()?.take_task()?;
+            task.await
+        })
+    }
+
+    fn initialized<'py>(&self) -> PyResult<PyPythonTask> {
+        let mesh = self.mesh.clone();
+        PyPythonTask::new(async {
+            mesh.await?;
+            Ok(None::<()>)
+        })
     }
 }
 
@@ -433,7 +579,7 @@ impl From<ActorSupervisionEvent> for PyActorSupervisionEvent {
 
 pub fn register_python_bindings(hyperactor_mod: &Bound<'_, PyModule>) -> PyResult<()> {
     hyperactor_mod.add_class::<PythonActorMesh>()?;
-    hyperactor_mod.add_class::<PythonActorMeshRef>()?;
+    hyperactor_mod.add_class::<PythonActorMeshImpl>()?;
     hyperactor_mod.add_class::<PyActorSupervisionEvent>()?;
     Ok(())
 }

--- a/monarch_hyperactor/src/proc_mesh.rs
+++ b/monarch_hyperactor/src/proc_mesh.rs
@@ -29,6 +29,7 @@ use hyperactor_mesh::shared_cell::SharedCellPool;
 use hyperactor_mesh::shared_cell::SharedCellRef;
 use monarch_types::PickledPyObject;
 use ndslice::Shape;
+use pyo3::IntoPyObjectExt;
 use pyo3::exceptions::PyException;
 use pyo3::exceptions::PyRuntimeError;
 use pyo3::prelude::*;
@@ -38,10 +39,13 @@ use tokio::sync::Mutex;
 use tokio::sync::mpsc;
 
 use crate::actor_mesh::PythonActorMesh;
+use crate::actor_mesh::PythonActorMeshImpl;
 use crate::alloc::PyAlloc;
 use crate::mailbox::PyMailbox;
 use crate::pytokio::PyPythonTask;
+use crate::pytokio::PyShared;
 use crate::pytokio::PythonTask;
+use crate::runtime::get_tokio_runtime;
 use crate::shape::PyShape;
 use crate::supervision::SupervisionError;
 use crate::supervision::Unhealthy;
@@ -273,26 +277,76 @@ impl PyProcMesh {
         &self,
         name: String,
         actor: &Bound<'py, PyType>,
-    ) -> PyResult<PyPythonTask> {
+        emulated: bool,
+    ) -> PyResult<PyObject> {
         let unhealthy_event = Arc::clone(&self.unhealthy_event);
         let pickled_type = PickledPyObject::pickle(actor.as_any())?;
         let proc_mesh = self.try_inner()?;
         let keepalive = self.keepalive.clone();
-        PyPythonTask::new(async move {
+        let meshimpl = async move {
             ensure_mesh_healthy(&unhealthy_event).await?;
-
             let mailbox = proc_mesh.client().clone();
             let actor_mesh = proc_mesh.spawn(&name, &pickled_type).await?;
             let actor_events = actor_mesh.with_mut(|a| a.events()).await.unwrap().unwrap();
-            Ok(PythonActorMesh::monitored(
+            Ok(PythonActorMeshImpl::new(
                 actor_mesh,
                 PyMailbox { inner: mailbox },
                 keepalive,
                 actor_events,
             ))
-        })
+        };
+        if emulated {
+            // we give up on doing mesh spawn async for the emulated old version
+            // it is too complicated to make both work.
+            let r = get_tokio_runtime().block_on(meshimpl)?;
+            Python::with_gil(|py| r.into_py_any(py))
+        } else {
+            let r = PythonActorMesh::new(meshimpl);
+            Python::with_gil(|py| r.into_py_any(py))
+        }
     }
 
+    #[staticmethod]
+    fn spawn_async(
+        proc_mesh: &mut PyShared,
+        name: String,
+        actor: Py<PyType>,
+        emulated: bool,
+    ) -> PyResult<PyObject> {
+        let task = proc_mesh.task()?.take_task()?;
+        let meshimpl = async move {
+            let proc_mesh = task.await?;
+            let (proc_mesh, pickled_type, unhealthy_event, keepalive) =
+                Python::with_gil(|py| -> PyResult<_> {
+                    let slf: Bound<PyProcMesh> = proc_mesh.extract(py)?;
+                    let slf = slf.borrow();
+                    let unhealthy_event = Arc::clone(&slf.unhealthy_event);
+                    let pickled_type = PickledPyObject::pickle(actor.bind(py).as_any())?;
+                    let proc_mesh = slf.try_inner()?;
+                    let keepalive = slf.keepalive.clone();
+                    Ok((proc_mesh, pickled_type, unhealthy_event, keepalive))
+                })?;
+            ensure_mesh_healthy(&unhealthy_event).await?;
+            let mailbox = proc_mesh.client().clone();
+            let actor_mesh = proc_mesh.spawn(&name, &pickled_type).await?;
+            let actor_events = actor_mesh.with_mut(|a| a.events()).await.unwrap().unwrap();
+            Ok(PythonActorMeshImpl::new(
+                actor_mesh,
+                PyMailbox { inner: mailbox },
+                keepalive,
+                actor_events,
+            ))
+        };
+        if emulated {
+            // we give up on doing mesh spawn async for the emulated old version
+            // it is too complicated to make both work.
+            let r = get_tokio_runtime().block_on(meshimpl)?;
+            Python::with_gil(|py| r.into_py_any(py))
+        } else {
+            let r = PythonActorMesh::new(meshimpl);
+            Python::with_gil(|py| r.into_py_any(py))
+        }
+    }
     // User can call this to monitor the proc mesh events. This will override
     // the default monitor that exits the client on process crash, so user can
     // handle the process crash in their own way.

--- a/monarch_hyperactor/src/pytokio.rs
+++ b/monarch_hyperactor/src/pytokio.rs
@@ -8,6 +8,7 @@
 
 use std::error::Error;
 use std::future::Future;
+use std::ops::Deref;
 use std::pin::Pin;
 
 use hyperactor::clock::Clock;
@@ -119,7 +120,7 @@ where
 }
 
 impl PyPythonTask {
-    fn take_task(
+    pub(crate) fn take_task(
         &mut self,
     ) -> PyResult<Pin<Box<dyn Future<Output = Result<Py<PyAny>, PyErr>> + Send + 'static>>> {
         self.inner
@@ -158,7 +159,7 @@ impl PyPythonTask {
         signal_safe_block_on(py, task)?
     }
 
-    fn spawn(&mut self) -> PyResult<PyShared> {
+    pub(crate) fn spawn(&mut self) -> PyResult<PyShared> {
         let (tx, rx) = watch::channel(None);
         let task = self.take_task()?;
         get_tokio_runtime().spawn(async move {
@@ -277,7 +278,7 @@ pub struct PyShared {
 }
 #[pymethods]
 impl PyShared {
-    fn task(&mut self) -> PyResult<PyPythonTask> {
+    pub(crate) fn task(&mut self) -> PyResult<PyPythonTask> {
         // watch channels start unchanged, and when a value is sent to them signal
         // the receivers `changed` future.
         // By cloning the rx before awaiting it,

--- a/python/monarch/_rust_bindings/monarch_hyperactor/actor_mesh.pyi
+++ b/python/monarch/_rust_bindings/monarch_hyperactor/actor_mesh.pyi
@@ -6,7 +6,7 @@
 
 # pyre-strict
 
-from typing import AsyncIterator, final, NoReturn
+from typing import AsyncIterator, final, NoReturn, Optional, Protocol
 
 from monarch._rust_bindings.monarch_hyperactor.actor import PythonMessage
 from monarch._rust_bindings.monarch_hyperactor.mailbox import (
@@ -15,93 +15,35 @@ from monarch._rust_bindings.monarch_hyperactor.mailbox import (
     PortReceiver,
 )
 from monarch._rust_bindings.monarch_hyperactor.proc import ActorId
-from monarch._rust_bindings.monarch_hyperactor.pytokio import PythonTask
+from monarch._rust_bindings.monarch_hyperactor.pytokio import PythonTask, Shared
 from monarch._rust_bindings.monarch_hyperactor.selection import Selection
 from monarch._rust_bindings.monarch_hyperactor.shape import Shape
 from typing_extensions import Self
 
-@final
-class PythonActorMeshRef:
+class ActorMeshProtocol(Protocol):
     """
-    A reference to a remote actor mesh over which PythonMessages can be sent.
+    Protocol defining the common interface for actor mesh, mesh ref and _ActorMeshRefImpl.
     """
 
     def cast(
-        self, mailbox: Mailbox, selection: Selection, message: PythonMessage
-    ) -> None:
-        """Cast a message to the selected actors in the mesh."""
-        ...
-
-    def slice(self, **kwargs: int | slice[int | None, int | None, int | None]) -> Self:
-        """
-        See PythonActorMeshRef.slice for documentation.
-        """
-        ...
-
-    def new_with_shape(self, shape: Shape) -> PythonActorMeshRef:
-        """
-        Return a new mesh ref with the given sliced shape. If the provided shape
-        is not a valid slice of the current shape, an exception will be raised.
-        """
-        ...
-
-    @property
-    def shape(self) -> Shape:
-        """
-        The Shape object that describes how the rank of an actor
-        retrieved with get corresponds to coordinates in the
-        mesh.
-        """
-        ...
+        self,
+        message: PythonMessage,
+        selection: str,
+        mailbox: Mailbox,
+    ) -> None: ...
+    def new_with_shape(self, shape: Shape) -> Self: ...
+    def supervision_event(self) -> "Optional[Shared[Exception]]": ...
+    def stop(self) -> PythonTask[None]: ...
+    def initialized(self) -> PythonTask[None]: ...
 
 @final
-class PythonActorMesh:
-    def bind(self) -> PythonActorMeshRef:
-        """
-        Bind this actor mesh. The returned mesh ref can be used to reach the
-        mesh remotely.
-        """
-        ...
+class PythonActorMesh(ActorMeshProtocol):
+    pass
 
-    def cast(
-        self, mailbox: Mailbox, selection: Selection, message: PythonMessage
-    ) -> None:
-        """
-        Cast a message to the selected actors in the mesh.
-        """
-        ...
-
-    def slice(
-        self, **kwargs: int | slice[int | None, int | None, int | None]
-    ) -> PythonActorMeshRef:
-        """
-        Slice the mesh into a new mesh ref with the given selection. The reason
-        it returns a mesh ref, rather than the mesh object itself, is because
-        sliced mesh is a view of the original mesh, and does not own the mesh's
-        resources.
-
-        Arguments:
-        - `kwargs`: argument name is the label, and argument value is how to
-          slice the mesh along the dimension of that label.
-        """
-        ...
-
-    def new_with_shape(self, shape: Shape) -> PythonActorMeshRef:
-        """
-        Return a new mesh ref with the given sliced shape. If the provided shape
-        is not a valid slice of the current shape, an exception will be raised.
-        """
-        ...
-
+class PythonActorMeshImpl:
     def get_supervision_event(self) -> ActorSupervisionEvent | None:
         """
         Returns supervision event if there is any.
-        """
-        ...
-
-    def supervision_event(self) -> PythonTask[Exception]:
-        """
-        Completes with an exception when there is a supervision error.
         """
         ...
 
@@ -111,31 +53,14 @@ class PythonActorMesh:
         """
         ...
 
-    @property
-    def client(self) -> Mailbox:
-        """
-        A client that can be used to communicate with individual
-        actors in the mesh, and also to create ports that can be
-        broadcast across the mesh)
-        """
-        ...
-
-    @property
-    def shape(self) -> Shape:
-        """
-        The Shape object that describes how the rank of an actor
-        retrieved with get corresponds to coordinates in the
-        mesh.
-        """
-        ...
-
-    async def stop(self) -> None:
+    def stop(self) -> PythonTask[None]:
         """
         Stop all actors that are part of this mesh.
         Using this mesh after stop() is called will raise an Exception.
         """
         ...
 
+    def supervision_event(self) -> "Optional[Shared[Exception]]": ...
     @property
     def stopped(self) -> bool:
         """

--- a/python/monarch/_rust_bindings/monarch_hyperactor/proc_mesh.pyi
+++ b/python/monarch/_rust_bindings/monarch_hyperactor/proc_mesh.pyi
@@ -6,14 +6,17 @@
 
 # pyre-strict
 
-from typing import AsyncIterator, final, Type
+from typing import AsyncIterator, final, Literal, overload, Type
 
 from monarch._rust_bindings.monarch_hyperactor.actor import Actor
-from monarch._rust_bindings.monarch_hyperactor.actor_mesh import PythonActorMesh
+from monarch._rust_bindings.monarch_hyperactor.actor_mesh import (
+    PythonActorMesh,
+    PythonActorMeshImpl,
+)
 
 from monarch._rust_bindings.monarch_hyperactor.alloc import Alloc
 from monarch._rust_bindings.monarch_hyperactor.mailbox import Mailbox
-from monarch._rust_bindings.monarch_hyperactor.pytokio import PythonTask
+from monarch._rust_bindings.monarch_hyperactor.pytokio import PythonTask, Shared
 
 from monarch._rust_bindings.monarch_hyperactor.shape import Shape
 
@@ -42,6 +45,10 @@ class ProcMesh:
         """
         ...
 
+    @staticmethod
+    def spawn_async(
+        proc_mesh: Shared[ProcMesh], name: str, actor: Type[Actor], emulated: bool
+    ) -> PythonActorMesh: ...
     async def monitor(self) -> ProcMeshMonitor:
         """
         Returns a supervision monitor for this mesh.

--- a/python/monarch/_src/actor/actor_mesh.py
+++ b/python/monarch/_src/actor/actor_mesh.py
@@ -50,7 +50,7 @@ from monarch._rust_bindings.monarch_hyperactor.actor import (
 
 from monarch._rust_bindings.monarch_hyperactor.actor_mesh import (
     PythonActorMesh,
-    PythonActorMeshRef,
+    PythonActorMeshImpl,
 )
 from monarch._rust_bindings.monarch_hyperactor.mailbox import (
     Mailbox,
@@ -96,6 +96,7 @@ from typing_extensions import Self
 
 if TYPE_CHECKING:
     from monarch._rust_bindings.monarch_hyperactor.actor import PortProtocol
+    from monarch._rust_bindings.monarch_hyperactor.actor_mesh import ActorMeshProtocol
     from monarch._rust_bindings.monarch_hyperactor.mailbox import PortReceiverBase
     from monarch._src.actor.proc_mesh import ProcMesh
 
@@ -170,147 +171,17 @@ A = TypeVar("A")
 _load_balancing_seed = random.Random(4)
 
 
-def to_hy_sel(selection: Selection) -> HySelection:
-    if selection == "choose":
-        return HySelection.any()
-    elif selection == "all":
-        return HySelection.all()
-    else:
-        raise ValueError(f"invalid selection: {selection}")
-
-
-# A temporary gate used by the PythonActorMesh/PythonActorMeshRef migration.
-# We can use this gate to quickly roll back to using _ActorMeshRefImpl, if we
-# encounter any issues with the migration.
-#
-# This should be removed once we confirm PythonActorMesh/PythonActorMeshRef is
-# working correctly in production.
-def _use_standin_mesh() -> bool:
-    return bool(os.getenv("USE_STANDIN_ACTOR_MESH", default=False))
-
-
-class ActorMeshProtocol(ABC):
-    """
-    Protocol defining the common interface for actor mesh, mesh ref and _ActorMeshRefImpl.
-    """
-
-    @abstractmethod
-    def cast(
-        self,
-        message: PythonMessage,
-        selection: Selection,
-        mailbox: Mailbox,
-    ) -> None: ...
-
-    @abstractmethod
-    def new_with_shape(self, shape: Shape) -> Self: ...
-
-    def supervision_event(self) -> "Optional[Shared[Exception]]":
-        return None
-
-    async def stop(self) -> None:
-        raise NotImplementedError(f"stop() is not supported for {type(self)}")
-
-    async def initialized(self):
-        return None
-
-
-class _PythonActorMeshAdapter(ActorMeshProtocol):
-    """
-    Adapter for PythonActorMesh to implement the normalized ActorMeshProtocol
-    interface. This adapter also provides a convenient way to add states to
-    the mesh on the python side, without changing the rust side implementation.
-
-    Since PythonActorMesh cannot be pickled, this adapter also provides a
-    custom pickling logic which bind the mesh to PythonActorMeshRef during
-    pickling.
-    """
-
-    def __init__(self, inner: PythonActorMesh) -> None:
-        if _use_standin_mesh():
-            raise ValueError(
-                "_PythonActorMeshAdapter should only be used when USE_STANDIN_ACTOR_MESH is not set"
-            )
-        self._inner = inner
-
-    def cast(
-        self,
-        message: PythonMessage,
-        selection: Selection,
-        mailbox: Mailbox,
-    ) -> None:
-        self._inner.cast(mailbox, to_hy_sel(selection), message)
-
-    def new_with_shape(self, shape: Shape) -> "ActorMeshProtocol":
-        sliced: PythonActorMeshRef = self._inner.new_with_shape(shape)
-        return _PythonActorMeshRefAdapter(sliced)
-
-    def supervision_event(self) -> "Optional[Shared[Exception]]":
-        return self._inner.supervision_event().spawn()
-
-    async def stop(self) -> None:
-        await self._inner.stop()
-
-    def __reduce_ex__(self, protocol: ...) -> Tuple[Any, Tuple[Any, ...]]:
-        """
-        Automatically pickle as a PythonActorMeshRef by binding the mesh.
-        Unpicklable states such as proc_mesh are dropped as well.
-        """
-        mesh_ref = self._inner.bind()
-        return _PythonActorMeshRefAdapter, (mesh_ref,)
-
-
-class _PythonActorMeshRefAdapter(ActorMeshProtocol):
-    """
-    Adapter for PythonActorMeshRef to implement the normalized ActorMeshProtocol interface. It is
-    also used to store unpickable states such as proc_mesh.
-    """
-
-    def __init__(self, inner: PythonActorMeshRef) -> None:
-        if _use_standin_mesh():
-            raise ValueError(
-                "_PythonActorMeshRefAdapter should only be used when USE_STANDIN_ACTOR_MESH is not set"
-            )
-        self._inner = inner
-
-    def cast(
-        self,
-        message: PythonMessage,
-        selection: Selection,
-        mailbox: Mailbox,
-    ) -> None:
-        self._inner.cast(mailbox, to_hy_sel(selection), message)
-
-    def new_with_shape(self, shape: Shape) -> "ActorMeshProtocol":
-        sliced: PythonActorMeshRef = self._inner.new_with_shape(shape)
-        return _PythonActorMeshRefAdapter(sliced)
-
-    def __reduce_ex__(self, protocol: ...) -> Tuple[Any, Tuple[Any, ...]]:
-        """
-        Dropping all unpickable states.
-        """
-        return _PythonActorMeshRefAdapter, (self._inner,)
-
-
-class _SingletonActorAdapator(ActorMeshProtocol):
+class _SingletonActorAdapator:
     def __init__(self, inner: ActorId, shape: Optional[Shape] = None) -> None:
         self._inner: ActorId = inner
         if shape is None:
             shape = singleton_shape
         self._shape = shape
 
-    @property
-    def shape(self) -> Shape:
-        return singleton_shape
-
-    @property
-    def proc_mesh(self) -> Optional["ProcMesh"]:
-        return None
-
     def cast(
         self,
         message: PythonMessage,
-        selection: Selection,
+        selection: str,
         mailbox: Mailbox,
     ) -> None:
         mailbox.post(self._inner, message)
@@ -318,23 +189,31 @@ class _SingletonActorAdapator(ActorMeshProtocol):
     def new_with_shape(self, shape: Shape) -> "ActorMeshProtocol":
         return _SingletonActorAdapator(self._inner, self._shape)
 
+    def supervision_event(self) -> "Optional[Shared[Exception]]":
+        return None
+
+    def stop(self) -> "PythonTask[None]":
+        raise NotImplementedError("stop()")
+
+    def initialized(self) -> "PythonTask[None]":
+        async def empty():
+            pass
+
+        return PythonTask.from_coroutine(empty())
+
 
 # standin class for whatever is the serializable python object we use
 # to name an actor mesh. Hacked up today because ActorMesh
 # isn't plumbed to non-clients
-class _ActorMeshRefImpl(ActorMeshProtocol):
+class _ActorMeshRefImpl:
     def __init__(
         self,
         mailbox: Mailbox,
-        hy_actor_mesh: Optional[PythonActorMesh],
+        hy_actor_mesh: Optional[PythonActorMeshImpl],
         proc_mesh: "Optional[ProcMesh]",
         shape: Shape,
         actor_ids: List[ActorId],
     ) -> None:
-        if not _use_standin_mesh():
-            raise ValueError(
-                "ActorMeshRefImpl should only be used when USE_STANDIN_ACTOR_MESH is set"
-            )
         self._mailbox = mailbox
         self._actor_mesh = hy_actor_mesh
         # actor meshes do not have a way to look this up at the moment,
@@ -345,14 +224,16 @@ class _ActorMeshRefImpl(ActorMeshProtocol):
 
     @staticmethod
     def from_hyperactor_mesh(
-        mailbox: Mailbox, hy_actor_mesh: PythonActorMesh, proc_mesh: "ProcMesh"
+        mailbox: Mailbox,
+        shape: Shape,
+        hy_actor_mesh: PythonActorMeshImpl,
+        proc_mesh: "ProcMesh",
     ) -> "_ActorMeshRefImpl":
-        shape: Shape = hy_actor_mesh.shape
         return _ActorMeshRefImpl(
             mailbox,
             hy_actor_mesh,
             proc_mesh,
-            hy_actor_mesh.shape,
+            shape,
             [cast(ActorId, hy_actor_mesh.get(i)) for i in range(len(shape))],
         )
 
@@ -387,7 +268,7 @@ class _ActorMeshRefImpl(ActorMeshProtocol):
     def cast(
         self,
         message: PythonMessage,
-        selection: Selection,
+        selection: str,
         mailbox: Mailbox,
     ) -> None:
         self._check_state()
@@ -454,13 +335,23 @@ class _ActorMeshRefImpl(ActorMeshProtocol):
     def supervision_event(self) -> "Optional[Shared[Exception]]":
         if self._actor_mesh is None:
             return None
-        return self._actor_mesh.supervision_event().spawn()
+        return self._actor_mesh.supervision_event()
 
-    async def stop(self):
-        await self._actor_mesh.stop()
+    def stop(self) -> PythonTask[None]:
+        async def task():
+            if self._actor_mesh is not None:
+                self._actor_mesh.stop()
+
+        return PythonTask.from_coroutine(task())
+
+    def initialized(self) -> PythonTask[None]:
+        async def task():
+            pass
+
+        return PythonTask.from_coroutine(task())
 
 
-class SharedProtocolAdapter(ActorMeshProtocol):
+class SharedProtocolAdapter:
     def __init__(self, inner: "Shared[ActorMeshProtocol]", supervise: bool):
         self._inner = inner
         self._supervise = supervise
@@ -468,7 +359,7 @@ class SharedProtocolAdapter(ActorMeshProtocol):
     def cast(
         self,
         message: PythonMessage,
-        selection: Selection,
+        selection: str,
         mailbox: Mailbox,
     ) -> None:
         ctx = MonarchContext.get()
@@ -505,11 +396,14 @@ class SharedProtocolAdapter(ActorMeshProtocol):
 
         return PythonTask.from_coroutine(task()).spawn()
 
-    async def stop(self) -> None:
-        await (await self._inner).stop()
+    def stop(self) -> "PythonTask[None]":
+        async def task():
+            await (await self._inner).stop()
+
+        return PythonTask.from_coroutine(task())
 
     @staticmethod
-    def _restore(inner: ActorMeshProtocol) -> ActorMeshProtocol:
+    def _restore(inner: "ActorMeshProtocol") -> "ActorMeshProtocol":
         return inner
 
     def __reduce_ex__(self, protocol):
@@ -530,7 +424,7 @@ class SharedProtocolAdapter(ActorMeshProtocol):
 class ActorEndpoint(Endpoint[P, R]):
     def __init__(
         self,
-        actor_mesh: ActorMeshProtocol,
+        actor_mesh: "ActorMeshProtocol",
         shape: Shape,
         proc_mesh: "Optional[ProcMesh]",
         name: MethodSpecifier,
@@ -1062,14 +956,14 @@ class ActorMesh(MeshTrait, Generic[T], DeprecatedNotAFuture):
     def __init__(
         self,
         Class: Type[T],
-        inner: ActorMeshProtocol,
+        inner: "ActorMeshProtocol",
         mailbox: Mailbox,
         shape: Shape,
         proc_mesh: "Optional[ProcMesh]",
     ) -> None:
         self.__name__: str = Class.__name__
         self._class: Type[T] = Class
-        self._inner: ActorMeshProtocol = inner
+        self._inner: "ActorMeshProtocol" = inner
         self._mailbox: Mailbox = mailbox
         self._shape = shape
         self._proc_mesh = proc_mesh
@@ -1120,7 +1014,7 @@ class ActorMesh(MeshTrait, Generic[T], DeprecatedNotAFuture):
     def _create(
         cls,
         Class: Type[T],
-        actor_mesh: "PythonTask[PythonActorMesh]",
+        actor_mesh: "PythonActorMesh | PythonActorMeshImpl",
         mailbox: Mailbox,
         shape: Shape,
         proc_mesh: "ProcMesh",
@@ -1129,17 +1023,12 @@ class ActorMesh(MeshTrait, Generic[T], DeprecatedNotAFuture):
         *args: Any,
         **kwargs: Any,
     ) -> "ActorMesh[T]":
-        async def task():
-            if _use_standin_mesh():
-                return _ActorMeshRefImpl.from_hyperactor_mesh(
-                    mailbox, await actor_mesh, proc_mesh
-                )
-            else:
-                return _PythonActorMeshAdapter(await actor_mesh)
+        if isinstance(actor_mesh, PythonActorMeshImpl):
+            actor_mesh = _ActorMeshRefImpl.from_hyperactor_mesh(
+                mailbox, shape, actor_mesh, proc_mesh
+            )
 
-        shared = PythonTask.from_coroutine(task()).spawn()
-        inner = SharedProtocolAdapter(shared, True)
-        mesh = cls(Class, inner, mailbox, shape, proc_mesh)
+        mesh = cls(Class, actor_mesh, mailbox, shape, proc_mesh)
 
         async def null_func(*_args: Iterable[Any], **_kwargs: Dict[str, Any]) -> None:
             return None

--- a/python/monarch/_src/actor/endpoint.py
+++ b/python/monarch/_src/actor/endpoint.py
@@ -46,7 +46,7 @@ if TYPE_CHECKING:
 P = ParamSpec("P")
 R = TypeVar("R")
 
-Selection = Literal["all", "choose"] | int
+Selection = Literal["all", "choose"]
 
 
 class Extent:

--- a/python/monarch/mesh_controller.py
+++ b/python/monarch/mesh_controller.py
@@ -277,7 +277,7 @@ class RemoteException(Exception):
 
 def _cast_call_method_indirect(
     endpoint: ActorEndpoint,
-    selection: Selection,
+    selection: str,
     client: MeshClient,
     seq: Seq,
     args_kwargs_tuple: bytes,
@@ -303,7 +303,7 @@ def actor_send(
     args_kwargs_tuple: bytes,
     refs: Sequence[Any],
     port: Optional[Port[Any]],
-    selection: Selection,
+    selection: str,
 ):
     tensors = [ref for ref in refs if isinstance(ref, Tensor)]
     # we have some monarch references, we need to ensure their
@@ -352,7 +352,7 @@ def _actor_send(
     args_kwargs_tuple: bytes,
     refs: Sequence[Any],
     port: Optional[Port[Any]],
-    selection: Selection,
+    selection: str,
     client: MeshClient,
     mesh: DeviceMesh,
     tensors: List[Tensor],

--- a/python/tests/_monarch/test_hyperactor.py
+++ b/python/tests/_monarch/test_hyperactor.py
@@ -97,8 +97,4 @@ async def test_actor_mesh() -> None:
     proc_mesh = await ProcMesh.allocate_nonblocking(alloc)
     actor_mesh = await proc_mesh.spawn_nonblocking("test", MyActor)
 
-    assert actor_mesh.get(0) is not None
-    assert actor_mesh.get(1) is not None
-    assert actor_mesh.get(2) is None
-
-    assert isinstance(actor_mesh.client, Mailbox)
+    await actor_mesh.initialized()

--- a/python/tests/_monarch/test_mailbox.py
+++ b/python/tests/_monarch/test_mailbox.py
@@ -188,14 +188,14 @@ async def test_reducer() -> None:
     port_ref = handle.bind()
 
     actor_mesh.cast(
-        proc_mesh.client,
-        Selection.from_string("*"),
         PythonMessage(
             PythonMessageKind.CallMethod(
                 MethodSpecifier.ReturnsResponse("echo"), port_ref
             ),
             pickle.dumps("start"),
         ),
+        "all",
+        proc_mesh.client,
     )
 
     messge = await receiver.recv_task().with_timeout(seconds=5)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)

This moves the logic for deferring sends into Rust to avoid slowing down actor sends. Increases send throughput ~30% from the python approach. It is just a little faster than what came before the python approach because this also eliminates a layer of python wrappers for dispatching sends. I suspect there is tons more to to be gained removing more layers of python between the user calling an endpoint and issuing a send.

Differential Revision: [D80037834](https://our.internmc.facebook.com/intern/diff/D80037834/)