### PR TITLE
Distance based latency

### DIFF
--- a/hyperactor/Cargo.toml
+++ b/hyperactor/Cargo.toml
@@ -50,6 +50,7 @@ nix = { version = "0.30.1", features = ["dir", "event", "hostname", "inotify", "
 opentelemetry = "0.29"
 paste = "1.0.14"
 rand = { version = "0.8", features = ["small_rng"] }
+rand_distr = "0.4"
 regex = "1.11.1"
 rustls-pemfile = "1.0.0"
 serde = { version = "1.0.219", features = ["derive", "rc"] }

--- a/hyperactor/src/channel/sim.rs
+++ b/hyperactor/src/channel/sim.rs
@@ -145,7 +145,7 @@ impl MessageDeliveryEvent {
 
 #[async_trait]
 impl Event for MessageDeliveryEvent {
-    async fn handle(&self) -> Result<(), SimNetError> {
+    async fn handle(&mut self) -> Result<(), SimNetError> {
         // Send the message to the correct receiver.
         SENDER
             .send(

--- a/hyperactor/src/clock.rs
+++ b/hyperactor/src/clock.rs
@@ -12,25 +12,17 @@ use std::error::Error;
 use std::fmt;
 use std::sync::LazyLock;
 use std::sync::Mutex;
-use std::sync::OnceLock;
 use std::time::SystemTime;
 
+use async_trait::async_trait;
 use futures::pin_mut;
 use hyperactor_telemetry::TelemetryClock;
 use serde::Deserialize;
 use serde::Serialize;
 
-use crate::Mailbox;
 use crate::channel::ChannelAddr;
-use crate::data::Named;
-use crate::id;
-use crate::mailbox::DeliveryError;
-use crate::mailbox::MailboxSender;
-use crate::mailbox::MessageEnvelope;
-use crate::mailbox::Undeliverable;
-use crate::mailbox::UndeliverableMailboxSender;
-use crate::mailbox::monitored_return_handle;
-use crate::simnet::SleepEvent;
+use crate::simnet::Event;
+use crate::simnet::SimNetError;
 use crate::simnet::simnet_handle;
 
 struct SimTime {
@@ -183,6 +175,45 @@ impl ClockKind {
     }
 }
 
+#[derive(Debug)]
+struct SleepEvent {
+    done_tx: Option<tokio::sync::oneshot::Sender<()>>,
+    duration: tokio::time::Duration,
+}
+
+impl SleepEvent {
+    pub(crate) fn new(
+        done_tx: tokio::sync::oneshot::Sender<()>,
+        duration: tokio::time::Duration,
+    ) -> Box<Self> {
+        Box::new(Self {
+            done_tx: Some(done_tx),
+            duration,
+        })
+    }
+}
+
+#[async_trait]
+impl Event for SleepEvent {
+    async fn handle(&mut self) -> Result<(), SimNetError> {
+        self.done_tx
+            .take()
+            .unwrap()
+            .send(())
+            .map_err(|_| SimNetError::PanickedTask)?;
+
+        Ok(())
+    }
+
+    fn duration(&self) -> tokio::time::Duration {
+        self.duration
+    }
+
+    fn summary(&self) -> String {
+        format!("Sleeping for {} ms", self.duration.as_millis())
+    }
+}
+
 /// Clock to be used in simulator runs that allows the simnet to create a scheduled event for.
 /// When the wakeup event becomes the next earliest scheduled event, the simnet will advance it's
 /// time to the wakeup time and use the transmitter to wake up this green thread
@@ -192,25 +223,25 @@ pub struct SimClock;
 impl Clock for SimClock {
     /// Tell the simnet to wake up this green thread after the specified duration has pass on the simnet
     async fn sleep(&self, duration: tokio::time::Duration) {
-        let mailbox = SimClock::mailbox().clone();
-        let (tx, rx) = mailbox.open_once_port::<()>();
+        let (tx, rx) = tokio::sync::oneshot::channel::<()>();
 
         simnet_handle()
             .unwrap()
-            .send_event(SleepEvent::new(tx.bind(), mailbox, duration))
+            .send_event(SleepEvent::new(tx, duration))
             .unwrap();
-        rx.recv().await.unwrap();
+
+        rx.await.unwrap();
     }
 
     async fn non_advancing_sleep(&self, duration: tokio::time::Duration) {
-        let mailbox = SimClock::mailbox().clone();
-        let (tx, rx) = mailbox.open_once_port::<()>();
+        let (tx, rx) = tokio::sync::oneshot::channel::<()>();
 
         simnet_handle()
             .unwrap()
-            .send_nonadvanceable_event(SleepEvent::new(tx.bind(), mailbox, duration))
+            .send_nonadvanceable_event(SleepEvent::new(tx, duration))
             .unwrap();
-        rx.recv().await.unwrap();
+
+        rx.await.unwrap();
     }
 
     async fn sleep_until(&self, deadline: tokio::time::Instant) {
@@ -234,19 +265,18 @@ impl Clock for SimClock {
     where
         F: std::future::Future<Output = T>,
     {
-        let mailbox = SimClock::mailbox().clone();
-        let (tx, deadline_rx) = mailbox.open_once_port::<()>();
+        let (tx, deadline_rx) = tokio::sync::oneshot::channel::<()>();
 
         simnet_handle()
             .unwrap()
-            .send_event(SleepEvent::new(tx.bind(), mailbox, duration))
+            .send_event(SleepEvent::new(tx, duration))
             .unwrap();
 
         let fut = f;
         pin_mut!(fut);
 
         tokio::select! {
-            _ = deadline_rx.recv() => {
+            _ = deadline_rx => {
                 Err(TimeoutError)
             }
             res = &mut fut => Ok(res)
@@ -255,28 +285,6 @@ impl Clock for SimClock {
 }
 
 impl SimClock {
-    // TODO (SF, 2025-07-11): Remove this global, thread through a mailbox
-    // from upstack and handle undeliverable messages properly.
-    fn mailbox() -> &'static Mailbox {
-        static SIMCLOCK_MAILBOX: OnceLock<Mailbox> = OnceLock::new();
-        SIMCLOCK_MAILBOX.get_or_init(|| {
-            let mailbox = Mailbox::new_detached(id!(proc[0].proc).clone());
-            let (undeliverable_messages, mut rx) =
-                mailbox.open_port::<Undeliverable<MessageEnvelope>>();
-            undeliverable_messages.bind_to(Undeliverable::<MessageEnvelope>::port());
-            tokio::spawn(async move {
-                while let Ok(Undeliverable(mut envelope)) = rx.recv().await {
-                    envelope.try_set_error(DeliveryError::BrokenLink(
-                        "message returned to undeliverable port".to_string(),
-                    ));
-                    UndeliverableMailboxSender
-                        .post(envelope, /*unused */ monitored_return_handle())
-                }
-            });
-            mailbox
-        })
-    }
-
     /// Advance the sumulator's time to the specified instant
     pub fn advance_to(&self, time: tokio::time::Instant) {
         let mut guard = SIM_TIME.now.lock().unwrap();

--- a/hyperactor/src/simnet.rs
+++ b/hyperactor/src/simnet.rs
@@ -26,6 +26,7 @@ use async_trait::async_trait;
 use dashmap::DashMap;
 use dashmap::DashSet;
 use enum_as_inner::EnumAsInner;
+use ndslice::view::Point;
 use serde::Deserialize;
 use serde::Deserializer;
 use serde::Serialize;
@@ -43,6 +44,7 @@ use tokio::time::interval;
 use crate::ActorId;
 use crate::Mailbox;
 use crate::OncePortRef;
+use crate::ProcId;
 use crate::channel::ChannelAddr;
 use crate::clock::Clock;
 use crate::clock::RealClock;
@@ -299,6 +301,7 @@ pub struct SimNetHandle {
     training_script_state_tx: tokio::sync::watch::Sender<TrainingScriptState>,
     /// Signal to stop the simnet loop
     stop_signal: Arc<AtomicBool>,
+    resources: DashMap<ProcId, Point>,
 }
 
 impl SimNetHandle {
@@ -409,6 +412,11 @@ impl SimNetHandle {
             "timeout waiting for received events to be scheduled".to_string(),
         ))
     }
+
+    /// Register the location in resource space for a Proc
+    pub fn register_proc(&self, proc_id: ProcId, point: Point) {
+        self.resources.insert(proc_id, point);
+    }
 }
 
 pub(crate) type Topology = DashMap<SimNetEdge, SimNetEdgeInfo>;
@@ -482,6 +490,7 @@ pub fn start() {
         pending_event_count,
         training_script_state_tx,
         stop_signal,
+        resources: DashMap::new(),
     });
 }
 

--- a/hyperactor_mesh/src/alloc/sim.rs
+++ b/hyperactor_mesh/src/alloc/sim.rs
@@ -130,11 +130,76 @@ impl Alloc for SimAlloc {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
+
+    use hyperactor::simnet::BetaDistribution;
+    use hyperactor::simnet::LatencyConfig;
+    use hyperactor::simnet::LatencyDistribution;
+    use ndslice::extent;
+
     use super::*;
+    use crate::ProcMesh;
+    use crate::RootActorMesh;
+    use crate::actor_mesh::ActorMesh;
+    use crate::alloc::AllocConstraints;
+    use crate::alloc::test_utils::TestActor;
 
     #[tokio::test]
     async fn test_allocator_basic() {
         hyperactor::simnet::start();
         crate::alloc::testing::test_allocator_basic(SimAllocator).await;
+    }
+
+    #[tokio::test]
+    async fn test_allocator_registers_resources() {
+        hyperactor::simnet::start_with_config(LatencyConfig {
+            inter_zone_distribution: LatencyDistribution::Beta(
+                BetaDistribution::new(
+                    tokio::time::Duration::from_millis(999),
+                    tokio::time::Duration::from_millis(999),
+                    1.0,
+                    1.0,
+                )
+                .unwrap(),
+            ),
+            ..Default::default()
+        });
+
+        let alloc = SimAllocator
+            .allocate(AllocSpec {
+                extent: extent!(region = 1, dc = 1, zone = 10, rack = 1, host = 1, gpu = 1),
+                constraints: AllocConstraints {
+                    match_labels: HashMap::new(),
+                },
+            })
+            .await
+            .unwrap();
+
+        let proc_mesh = ProcMesh::allocate(alloc).await.unwrap();
+
+        let handle = hyperactor::simnet::simnet_handle().unwrap();
+        let actor_mesh: RootActorMesh<TestActor> = proc_mesh.spawn("echo", &()).await.unwrap();
+        let actors = actor_mesh.iter_actor_refs().collect::<Vec<_>>();
+        assert_eq!(
+            handle.sample_latency(
+                actors[0].actor_id().proc_id(),
+                actors[1].actor_id().proc_id()
+            ),
+            tokio::time::Duration::from_millis(999)
+        );
+        assert_eq!(
+            handle.sample_latency(
+                actors[2].actor_id().proc_id(),
+                actors[9].actor_id().proc_id()
+            ),
+            tokio::time::Duration::from_millis(999)
+        );
+        assert_eq!(
+            handle.sample_latency(
+                proc_mesh.client().actor_id().proc_id(),
+                actors[1].actor_id().proc_id()
+            ),
+            tokio::time::Duration::from_millis(999)
+        );
     }
 }

--- a/hyperactor_multiprocess/src/ping_pong.rs
+++ b/hyperactor_multiprocess/src/ping_pong.rs
@@ -14,13 +14,11 @@ mod tests {
     use hyperactor::ActorRef;
     use hyperactor::Mailbox;
     use hyperactor::channel::ChannelAddr;
-    use hyperactor::channel::sim;
     use hyperactor::channel::sim::SimAddr;
     use hyperactor::id;
     use hyperactor::reference::Index;
     use hyperactor::reference::WorldId;
     use hyperactor::simnet;
-    use hyperactor::simnet::NetworkConfig;
     use hyperactor::test_utils::pingpong::PingPongActor;
     use hyperactor::test_utils::pingpong::PingPongActorParams;
     use hyperactor::test_utils::pingpong::PingPongMessage;
@@ -64,29 +62,6 @@ mod tests {
 
         let pong_actor_ref =
             spawn_proc_actor(3, system_sim_addr, sys_mailbox.clone(), world_id.clone()).await;
-
-        // Configure the simulation network.
-        let simnet_config_yaml = r#"
-edges:
-  - src: local!1
-    dst: local!2
-    metadata:
-      latency: 1
-  - src: local!2
-    dst: local!1
-    metadata:
-      latency: 1
-  - src: local!1
-    dst: local!3
-    metadata:
-      latency: 2
-  - src: local!3
-    dst: local!1
-    metadata:
-      latency: 2
-"#;
-        let simnet_config = NetworkConfig::from_yaml(simnet_config_yaml).unwrap();
-        sim::update_config(simnet_config).await.unwrap();
 
         // Kick start the ping pong game by sending a message to the ping actor. The message will ask the
         // ping actor to deliver a message to the pong actor with TTL - 1. The pong actor will then

--- a/python/monarch/_src/actor/proc_mesh.py
+++ b/python/monarch/_src/actor/proc_mesh.py
@@ -548,8 +548,26 @@ def local_proc_mesh(*, gpus: Optional[int] = None, hosts: int = 1) -> ProcMesh:
     return _proc_mesh_from_allocator(allocator=LocalAllocator(), gpus=gpus, hosts=hosts)
 
 
-def sim_proc_mesh(*, gpus: Optional[int] = None, hosts: int = 1) -> ProcMesh:
-    return _proc_mesh_from_allocator(allocator=SimAllocator(), gpus=gpus, hosts=hosts)
+def sim_proc_mesh(
+    *,
+    gpus: int = 1,
+    hosts: int = 1,
+    racks: int = 1,
+    zones: int = 1,
+    dcs: int = 1,
+    regions: int = 1,
+) -> ProcMesh:
+    spec: AllocSpec = AllocSpec(
+        AllocConstraints(),
+        hosts=hosts,
+        gpus=gpus,
+        racks=racks,
+        zones=zones,
+        dcs=dcs,
+        regions=regions,
+    )
+    alloc = SimAllocator().allocate(spec)
+    return ProcMesh.from_alloc(alloc, None, True)
 
 
 _BOOTSTRAP_MAIN = "monarch._src.actor.bootstrap_main"


### PR DESCRIPTION
Summary:
Now that the simnet has awareness of which compute resource each ProcId maps to, when messages are being sent we can simply look at the sender and destination ProcIds and compute the distance the message is being sent in order to determine the latency.

Latency is randomly sample from a beta distribution where the min and max for each distance is configured

Implementation details (follow along numbers in comments):
1. In the previous diff when Procs were allocated, their coordinates (region, dc, zone, rack, host, gpu) were registered to the Simnet
2. When SimTx posts a message, we can safely assume that it is a MessageEnvelope. MessageEnvelopes contain information about the sender and receiver so we can determine which ProcIds the message is being sent between, which in turn means we can identify which coordinates they are being sent between
3. We determine distance between 2 coordinates by identifying the most major dimension in which they differ
4. We create a struct called LatencyConfig which holds a distribution for sampling, as well as minimum and maximum values for each distance.
5. We use the identified distance to get a sample for what the latency should be for that send
6. We pass in that latency to the MessageDeliveryEvent to use as its duration
7. The old network configuration which was an all-to-all map of edges with latencies between nodes has been removed along with all related structs
8. Unit tests have been refactored such that when we need a particular message to be sent with a particular latency, we register the ProcIds with the appropriate coordinates, and configure the interdistance latency

test_allocator_registers_resources in alloc/sim.rs demonstrates that when we allocate a ProcMesh using the sim allocator, our Procs are registered as compute resources and the latencies are computed based on distance

Differential Revision: D80141665


