### PR TITLE
Fix Python code sync test

### DIFF
--- a/monarch_hyperactor/src/code_sync/manager.rs
+++ b/monarch_hyperactor/src/code_sync/manager.rs
@@ -416,7 +416,7 @@ pub async fn code_sync_mesh(
         }
     };
 
-    let (res1, res2) = futures::future::join(
+    let ((), ()) = try_join!(
         method_fut,
         // This async task will cast the code sync message to workspace owners, and process any errors.
         async move {
@@ -450,15 +450,9 @@ pub async fn code_sync_mesh(
                 .try_collect_or_stash::<()>(&mut errs);
             Ok(errs.into_result()?)
         },
-    )
-    .await;
+    )?;
 
-    // Combine code sync handler and cast errors into one.
-    let mut errs = ErrorStash::<_, _, anyhow::Error>::new(|| "code sync failed");
-    [res1, res2]
-        .into_iter()
-        .try_collect_or_stash::<()>(&mut errs);
-    Ok(errs.into_result()?)
+    Ok(())
 }
 
 #[cfg(test)]

--- a/monarch_hyperactor/src/code_sync/rsync.rs
+++ b/monarch_hyperactor/src/code_sync/rsync.rs
@@ -358,7 +358,9 @@ impl Handler<RsyncMessage> for RsyncActor {
         }: RsyncMessage,
     ) -> Result<(), anyhow::Error> {
         let res = async {
-            let workspace = workspace.resolve()?;
+            let workspace = workspace
+                .resolve()
+                .context("resolving workspace location")?;
             let (connect_msg, completer) = Connect::allocate(cx.self_id().clone(), cx);
             connect.send(cx, connect_msg)?;
             let (listener, mut stream) = try_join!(

--- a/monarch_hyperactor/src/code_sync/workspace.rs
+++ b/monarch_hyperactor/src/code_sync/workspace.rs
@@ -8,6 +8,7 @@
 
 use std::path::PathBuf;
 
+use anyhow::Context;
 use anyhow::Result;
 use serde::Deserialize;
 use serde::Serialize;
@@ -22,7 +23,9 @@ impl WorkspaceLocation {
     pub fn resolve(&self) -> Result<PathBuf> {
         Ok(match self {
             WorkspaceLocation::Constant(p) => p.clone(),
-            WorkspaceLocation::FromEnvVar(v) => PathBuf::from(std::env::var(v)?),
+            WorkspaceLocation::FromEnvVar(v) => PathBuf::from(
+                std::env::var_os(v).with_context(|| format!("workspace env var not set: {}", v))?,
+            ),
         })
     }
 }

--- a/python/tests/test_python_actors.py
+++ b/python/tests/test_python_actors.py
@@ -959,12 +959,12 @@ class LsActor(Actor):
 
 
 async def test_sync_workspace() -> None:
-    pm = await proc_mesh(gpus=1)
-
     # create two workspaces: one for local and one for remote
     with tempfile.TemporaryDirectory() as workspace_src, tempfile.TemporaryDirectory() as workspace_dst, unittest.mock.patch.dict(
         os.environ, {"WORKSPACE_DIR": workspace_dst}
     ):
+        pm = await proc_mesh(gpus=1)
+
         os.environ["WORKSPACE_DIR"] = workspace_dst
         config = defaults.config("slurm", workspace_src)
         await pm.sync_workspace(


### PR DESCRIPTION
Summary:
Make sure we spawn child procs after setting the workspace env
var, so that they inherit it.

Reviewed By: highker

Differential Revision: D80267335


