### PR TITLE
Client trace id for connecting events on backend and frontend

### DIFF
--- a/hyperactor_mesh/src/alloc/process.rs
+++ b/hyperactor_mesh/src/alloc/process.rs
@@ -33,6 +33,8 @@ use hyperactor::sync::monitor;
 use ndslice::view::Extent;
 use nix::sys::signal;
 use nix::unistd::Pid;
+use serde::Deserialize;
+use serde::Serialize;
 use tokio::io;
 use tokio::process::Command;
 use tokio::sync::Mutex;
@@ -55,6 +57,8 @@ use crate::shortuuid::ShortUuid;
 
 /// The maximum number of log lines to tail keep for managed processes.
 const MAX_TAIL_LOG_LINES: usize = 100;
+
+pub const CLIENT_TRACE_ID_LABEL: &str = "CLIENT_TRACE_ID";
 
 /// An allocator that allocates procs by executing managed (local)
 /// processes. ProcessAllocator is configured with a [`Command`] (template)
@@ -102,8 +106,24 @@ impl Allocator for ProcessAllocator {
             children: JoinSet::new(),
             running: true,
             failed: false,
+            client_context: ClientContext {
+                trace_id: spec
+                    .constraints
+                    .match_labels
+                    .get(CLIENT_TRACE_ID_LABEL)
+                    .cloned()
+                    .unwrap_or_else(|| "".to_string()),
+            },
         })
     }
+}
+
+// Client Context is saved in ProcessAlloc, and is also passed in
+// the RemoteProcessAllocator's Allocate method
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ClientContext {
+    /// Trace ID for correlating logs across client and worker processes
+    pub trace_id: String,
 }
 
 /// An allocation produced by [`ProcessAllocator`].
@@ -121,6 +141,7 @@ pub struct ProcessAlloc {
     children: JoinSet<(usize, ProcStopReason)>,
     running: bool,
     failed: bool,
+    client_context: ClientContext,
 }
 
 #[derive(EnumAsInner)]
@@ -388,6 +409,10 @@ impl ProcessAlloc {
         cmd.env(
             bootstrap::BOOTSTRAP_ADDR_ENV,
             self.bootstrap_addr.to_string(),
+        );
+        cmd.env(
+            bootstrap::CLIENT_TRACE_ID_ENV,
+            self.client_context.trace_id.as_str(),
         );
         cmd.env(bootstrap::BOOTSTRAP_INDEX_ENV, index.to_string());
         cmd.env(bootstrap::BOOTSTRAP_LOG_CHANNEL, log_channel.to_string());

--- a/hyperactor_mesh/src/bootstrap.rs
+++ b/hyperactor_mesh/src/bootstrap.rs
@@ -29,6 +29,7 @@ use crate::proc_mesh::mesh_agent::MeshAgent;
 
 pub const BOOTSTRAP_ADDR_ENV: &str = "HYPERACTOR_MESH_BOOTSTRAP_ADDR";
 pub const BOOTSTRAP_INDEX_ENV: &str = "HYPERACTOR_MESH_INDEX";
+pub const CLIENT_TRACE_ID_ENV: &str = "MONARCH_CLIENT_TRACE_ID";
 /// A channel used by each process to receive its own stdout and stderr
 /// Because stdout and stderr can only be obtained by the parent process,
 /// they need to be streamed back to the process.

--- a/hyperactor_telemetry/src/lib.rs
+++ b/hyperactor_telemetry/src/lib.rs
@@ -34,6 +34,7 @@ mod pool;
 pub mod recorder;
 mod spool;
 pub mod sqlite;
+pub mod trace;
 use std::io::IsTerminal;
 use std::io::Write;
 use std::str::FromStr;

--- a/hyperactor_telemetry/src/trace.rs
+++ b/hyperactor_telemetry/src/trace.rs
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+use std::env;
+
+use crate::env::execution_id;
+
+const MONARCH_CLIENT_TRACE_ID: &str = "MONARCH_CLIENT_TRACE_ID";
+
+/// Returns the current trace ID if it exists, or None if it doesn't.
+/// This function does not create a new trace ID if one doesn't exist.
+/// Todo: Eventually use Message Headers to relay this traceid instead of
+/// env vars
+pub fn get_trace_id() -> Option<String> {
+    if let Ok(env_id) = env::var(MONARCH_CLIENT_TRACE_ID) {
+        if !env_id.is_empty() {
+            return Some(env_id);
+        }
+    }
+
+    // No trace ID found
+    None
+}
+
+/// Returns the current trace ID, if none exists, set the current execution id as the trace id.
+/// This ensures that the client trace id and execution id is the same.
+/// The trace ID remains the same as long as it is in the same process.
+/// Use this method only on the client side.
+pub fn get_or_create_trace_id() -> String {
+    if let Ok(existing_trace_id) = std::env::var(MONARCH_CLIENT_TRACE_ID) {
+        if !existing_trace_id.is_empty() {
+            return existing_trace_id;
+        }
+    }
+
+    let trace_id = execution_id().clone();
+    // Safety: Can be unsound if there are multiple threads
+    // reading and writing the environment.
+    unsafe {
+        std::env::set_var(MONARCH_CLIENT_TRACE_ID, trace_id.clone());
+    }
+
+    trace_id
+}

--- a/monarch_extension/Cargo.toml
+++ b/monarch_extension/Cargo.toml
@@ -23,6 +23,7 @@ futures = { version = "0.3.31", features = ["async-await", "compat"] }
 hyperactor = { version = "0.0.0", path = "../hyperactor" }
 hyperactor_mesh = { version = "0.0.0", path = "../hyperactor_mesh" }
 hyperactor_multiprocess = { version = "0.0.0", path = "../hyperactor_multiprocess" }
+hyperactor_telemetry = { version = "0.0.0", path = "../hyperactor_telemetry" }
 libc = "0.2.139"
 monarch_hyperactor = { version = "0.0.0", path = "../monarch_hyperactor" }
 monarch_messages = { version = "0.0.0", path = "../monarch_messages", optional = true }

--- a/monarch_extension/src/lib.rs
+++ b/monarch_extension/src/lib.rs
@@ -27,6 +27,7 @@ mod tensor_worker;
 
 mod blocking;
 mod panic;
+mod trace;
 use pyo3::prelude::*;
 
 #[pyfunction]
@@ -65,6 +66,7 @@ fn get_or_add_new_module<'py>(
 #[pymodule]
 #[pyo3(name = "_rust_bindings")]
 pub fn mod_init(module: &Bound<'_, PyModule>) -> PyResult<()> {
+    hyperactor_telemetry::trace::get_or_create_trace_id();
     monarch_hyperactor::runtime::initialize(module.py())?;
     let runtime = monarch_hyperactor::runtime::get_tokio_runtime();
     ::hyperactor::initialize_with_log_prefix(
@@ -203,6 +205,11 @@ pub fn mod_init(module: &Bound<'_, PyModule>) -> PyResult<()> {
     crate::logging::register_python_bindings(&get_or_add_new_module(
         module,
         "monarch_extension.logging",
+    )?)?;
+
+    crate::trace::register_python_bindings(&get_or_add_new_module(
+        module,
+        "monarch_extension.trace",
     )?)?;
 
     #[cfg(fbcode_build)]

--- a/monarch_extension/src/trace.rs
+++ b/monarch_extension/src/trace.rs
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+use pyo3::prelude::*;
+use pyo3::types::PyModule;
+
+#[pyfunction]
+fn get_or_create_trace_id() -> String {
+    hyperactor_telemetry::trace::get_or_create_trace_id()
+}
+
+pub fn register_python_bindings(module: &Bound<'_, PyModule>) -> PyResult<()> {
+    let f = wrap_pyfunction!(get_or_create_trace_id, module)?;
+    f.setattr(
+        "__module__",
+        "monarch._rust_bindings.monarch_extension.trace",
+    )?;
+    module.add_function(f)?;
+    Ok(())
+}

--- a/python/monarch/_rust_bindings/monarch_extension/trace.pyi
+++ b/python/monarch/_rust_bindings/monarch_extension/trace.pyi
@@ -1,0 +1,11 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+def get_or_create_trace_id() -> str:
+    """
+    Get the trace id or create a new one if it doesn't exist.
+    """
+    ...

--- a/python/monarch/tools/commands.py
+++ b/python/monarch/tools/commands.py
@@ -297,7 +297,6 @@ async def get_or_create(
 
     server_handle = f"{config.scheduler}:///{name}"
     server_info = await server_ready(server_handle, check_interval)
-
     if not server_info or not server_info.is_running:  # then create one
         logger.info(
             "no existing RUNNING server `%s` creating new one...", server_handle


### PR DESCRIPTION
Summary:
Introducing a client context, which currently only contains a trace id, which can be used to connect events on the client and worker side. The trace id will be logged to scuba, and is saved as an env var on the process. 

get_trace_id_or_create_new is first called when we initialize the rust bindings and the trace_id itself is first assigned to be the same as the execution id. 

Then, as part of the alloc we also pass this trace id along. For RemoteProcessAllocator, the Allocate message will take the client context, and on receiving it, set it in the AllocSpec before allocating the new processes. 

The ProcessAlloc will set the env var after reading the trace_id from the match_labels of the AllocSpec. It is only set when the client has set it and passed it with the RemoteAlloc. It will default to "".

Differential Revision: D79537187


