### PR TITLE
Add attachable simulator to PaftManager tests with sqlite db assertions

### DIFF
--- a/monarch_extension/src/simulation_tools.rs
+++ b/monarch_extension/src/simulation_tools.rs
@@ -31,6 +31,13 @@ pub fn py_sim_sleep<'py>(py: Python<'py>, seconds: f64) -> PyResult<Bound<'py, P
     })
 }
 
+#[pyfunction]
+#[pyo3(name = "is_simulator_active")]
+pub fn is_simulator_active() -> PyResult<bool> {
+    // Use the existing simnet_handle() function to check if SimNet is active
+    Ok(hyperactor::simnet::simnet_handle().is_ok())
+}
+
 pub(crate) fn register_python_bindings(simulation_tools_mod: &Bound<'_, PyModule>) -> PyResult<()> {
     {
         let f = wrap_pyfunction!(py_sim_sleep, simulation_tools_mod)?;
@@ -42,6 +49,14 @@ pub(crate) fn register_python_bindings(simulation_tools_mod: &Bound<'_, PyModule
     }
     {
         let f = wrap_pyfunction!(start_simnet_event_loop, simulation_tools_mod)?;
+        f.setattr(
+            "__module__",
+            "monarch._rust_bindings.monarch_extension.simulation_tools",
+        )?;
+        simulation_tools_mod.add_function(f)?;
+    }
+    {
+        let f = wrap_pyfunction!(is_simulator_active, simulation_tools_mod)?;
         f.setattr(
             "__module__",
             "monarch._rust_bindings.monarch_extension.simulation_tools",

--- a/python/monarch/_rust_bindings/monarch_extension/simulation_tools.pyi
+++ b/python/monarch/_rust_bindings/monarch_extension/simulation_tools.pyi
@@ -15,3 +15,12 @@ async def start_event_loop() -> None:
     Starts the simulator event loop
     """
     ...
+
+def is_simulator_active() -> bool:
+    """
+    Check if the simulation network is currently active.
+
+    Returns True if SimNet has been started (typically after calling
+    start_event_loop()), False otherwise.
+    """
+    ...


### PR DESCRIPTION
Summary:
This diff:
* exposes paft_manager.py's main so we can attach the simulator to it
* Allows test_paft_manager.py to write log assertions using sqlite db
* Add `is_simulator_active()` so we can decide whether to real/sim sleep in the actor

Differential Revision: D80271648


