### PR TITLE
Add simulator context manager and execution summary

### DIFF
--- a/monarch_extension/src/simulation_tools.rs
+++ b/monarch_extension/src/simulation_tools.rs
@@ -31,6 +31,13 @@ pub fn py_sim_sleep<'py>(py: Python<'py>, seconds: f64) -> PyResult<Bound<'py, P
     })
 }
 
+#[pyfunction]
+#[pyo3(name = "is_simulator_active")]
+pub fn is_simulator_active() -> PyResult<bool> {
+    // Use the existing simnet_handle() function to check if SimNet is active
+    Ok(hyperactor::simnet::simnet_handle().is_ok())
+}
+
 pub(crate) fn register_python_bindings(simulation_tools_mod: &Bound<'_, PyModule>) -> PyResult<()> {
     {
         let f = wrap_pyfunction!(py_sim_sleep, simulation_tools_mod)?;
@@ -42,6 +49,14 @@ pub(crate) fn register_python_bindings(simulation_tools_mod: &Bound<'_, PyModule
     }
     {
         let f = wrap_pyfunction!(start_simnet_event_loop, simulation_tools_mod)?;
+        f.setattr(
+            "__module__",
+            "monarch._rust_bindings.monarch_extension.simulation_tools",
+        )?;
+        simulation_tools_mod.add_function(f)?;
+    }
+    {
+        let f = wrap_pyfunction!(is_simulator_active, simulation_tools_mod)?;
         f.setattr(
             "__module__",
             "monarch._rust_bindings.monarch_extension.simulation_tools",

--- a/monarch_hyperactor/src/telemetry.rs
+++ b/monarch_hyperactor/src/telemetry.rs
@@ -113,6 +113,12 @@ pub fn use_sim_clock() -> PyResult<()> {
     Ok(())
 }
 
+/// Get the current execution ID
+#[pyfunction]
+pub fn get_execution_id() -> PyResult<String> {
+    Ok(hyperactor_telemetry::env::execution_id())
+}
+
 // opentelemetry requires that the names of counters etc are static for the lifetime of the program.
 // Since we are binding these classes from python to rust, we have to leak these strings in order to
 // ensure they live forever. This is fine, as these classes aren't dynamically created.
@@ -319,6 +325,13 @@ pub fn register_python_bindings(module: &Bound<'_, PyModule>) -> PyResult<()> {
         "monarch._rust_bindings.monarch_hyperactor.telemetry",
     )?;
     module.add_function(use_sim_clock_fn)?;
+
+    let get_execution_id_fn = wrap_pyfunction!(get_execution_id, module)?;
+    get_execution_id_fn.setattr(
+        "__module__",
+        "monarch._rust_bindings.monarch_hyperactor.telemetry",
+    )?;
+    module.add_function(get_execution_id_fn)?;
 
     module.add_class::<PySpan>()?;
     module.add_class::<PyCounter>()?;

--- a/python/monarch/_rust_bindings/monarch_extension/simulation_tools.pyi
+++ b/python/monarch/_rust_bindings/monarch_extension/simulation_tools.pyi
@@ -15,3 +15,12 @@ async def start_event_loop() -> None:
     Starts the simulator event loop
     """
     ...
+
+def is_simulator_active() -> bool:
+    """
+    Check if the simulation network is currently active.
+
+    Returns True if SimNet has been started (typically after calling
+    start_event_loop()), False otherwise.
+    """
+    ...

--- a/python/monarch/_rust_bindings/monarch_hyperactor/telemetry.pyi
+++ b/python/monarch/_rust_bindings/monarch_hyperactor/telemetry.pyi
@@ -87,6 +87,20 @@ def use_sim_clock() -> None:
     """
     ...
 
+def get_execution_id() -> str:
+    """
+    Get the current execution ID.
+
+    Returns the execution ID that is set by the telemetry system. This ID is either:
+    - Set from the HYPERACTOR_EXECUTION_ID environment variable
+    - Set from the MAST_HPC_JOB_NAME environment variable (in MAST environments)
+    - Generated as a random string if neither environment variable is available
+
+    Returns:
+        str: The current execution ID
+    """
+    ...
+
 class PySpan:
     def __init__(self, name: str) -> None:
         """


### PR DESCRIPTION
Summary:
To make the simulator a bit easier to use for monarch test workloads:
* Add context manager to set up logging, tracing, sim event loop
* print execution details after run including execution ID, scuba links to tracing/metrics table

Reviewed By: eliothedeman

Differential Revision: D80366675


