### PR TITLE
Resolve top-level symlinks when configuring conda code sync

### DIFF
--- a/python/monarch/_src/actor/proc_mesh.py
+++ b/python/monarch/_src/actor/proc_mesh.py
@@ -413,9 +413,15 @@ class ProcMesh(MeshTrait, DeprecatedNotAFuture):
         # If `conda` is set, also sync the currently activated conda env.
         conda_prefix = conda_utils.active_env_dir()
         if conda and conda_prefix is not None:
+            conda_prefix = Path(conda_prefix)
+
+            # Resolve top-level symlinks for rsync/conda-sync.
+            while conda_prefix.is_symlink():
+                conda_prefix = conda_prefix.parent / conda_prefix.readlink()
+
             workspaces.append(
                 WorkspaceConfig(
-                    local=Path(conda_prefix),
+                    local=conda_prefix,
                     remote=RemoteWorkspace(
                         location=WorkspaceLocation.FromEnvVar("CONDA_PREFIX"),
                         shape=WorkspaceShape.shared("gpus"),


### PR DESCRIPTION
Summary:
When configuring the conda env as a workspace, resolve any top-level
symlinks before handing off to the sync tool (so that it doesn't copy the
symlink itself).

Reviewed By: highker

Differential Revision: D80467880


