### PR TITLE
update README for Ubuntu dist. installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,47 @@ pip install --no-build-isolation -e .
 pytest python/tests/ -v -m "not oss_skip"
 ```
 
+### On Ubuntu distributions
+
+```sh
+# Clone the repository and navigate to it
+git clone https://github.com/pytorch-labs/monarch.git
+cd monarch
+
+# Install nightly rust toolchain
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+source $HOME/.cargo/env
+rustup toolchain install nightly
+rustup default nightly
+
+# Install Ubuntu-specific system dependencies
+sudo apt install -y ninja-build
+sudo apt install -y libunwind-dev
+sudo apt install -y clang
+
+# Set clang as the default C/C++ compiler
+export CC=clang
+export CXX=clang++
+
+# Install build dependencies
+pip install -r build-requirements.txt
+# Install test dependencies
+pip install -r python/tests/requirements.txt
+
+# Build and install Monarch (with tensor engine support)
+pip install --no-build-isolation .
+
+# or
+# Build and install Monarch (without tensor engine support)
+USE_TENSOR_ENGINE=0 pip install --no-build-isolation .
+
+# or setup for development
+pip install --no-build-isolation -e .
+
+# Verify installation
+pip list | grep monarch
+```
+
 ### On MacOS
 
 You can also build Monarch to run locally on a MacOS system.


### PR DESCRIPTION
This PR addresses this issue ([682](https://github.com/meta-pytorch/monarch/issues/682)).

The lightning studio runs on Ubuntu distribution. So I tried the setup that works on multi node training for Lightning (MMT). 
It seems working fine and stable. 

The main differences between Fedora and Ubuntu installation is the `ninja-build` and `clang` as the C/C++ compiler.

This PR is tested w/o tensor engine support for now.