### PR TITLE
Context and Instance python APIs

### DIFF
--- a/monarch_hyperactor/src/actor.rs
+++ b/monarch_hyperactor/src/actor.rs
@@ -625,15 +625,11 @@ impl Handler<PythonMessage> for PythonActor {
         let (sender, receiver) = oneshot::channel();
 
         let future = Python::with_gil(|py| -> Result<_, SerializablePyErr> {
-            let mailbox = mailbox(py, cx);
-            let (rank, shape) = cx.cast_info();
             let awaitable = self.actor.call_method(
                 py,
                 "handle",
                 (
-                    mailbox,
-                    rank,
-                    PyShape::from(shape),
+                    crate::mailbox::Context::new(cx),
                     resolved.method,
                     resolved.bytes,
                     PanicFlag {

--- a/monarch_hyperactor/src/mailbox.rs
+++ b/monarch_hyperactor/src/mailbox.rs
@@ -9,8 +9,10 @@
 use std::hash::DefaultHasher;
 use std::hash::Hash;
 use std::hash::Hasher;
+use std::ops::Deref;
 use std::sync::Arc;
 
+use hyperactor::ActorId;
 use hyperactor::Mailbox;
 use hyperactor::Named;
 use hyperactor::OncePortHandle;
@@ -33,8 +35,12 @@ use hyperactor::mailbox::monitored_return_handle;
 use hyperactor::message::Bind;
 use hyperactor::message::Bindings;
 use hyperactor::message::Unbind;
+use hyperactor_mesh::comm::multicast::CastInfo;
 use hyperactor_mesh::comm::multicast::set_cast_info_on_headers;
+use hyperactor_mesh::proc_mesh::global_root_client;
 use monarch_types::PickledPyObject;
+use monarch_types::py_global;
+use ndslice::shape::Shape;
 use pyo3::IntoPyObjectExt;
 use pyo3::exceptions::PyEOFError;
 use pyo3::exceptions::PyRuntimeError;
@@ -51,6 +57,7 @@ use crate::proc::PyActorId;
 use crate::pytokio::PyPythonTask;
 use crate::pytokio::PythonTask;
 use crate::runtime::signal_safe_block_on;
+use crate::shape::PyPoint;
 use crate::shape::PyShape;
 #[derive(Clone, Debug)]
 #[pyclass(
@@ -69,12 +76,6 @@ impl PyMailbox {
 
 #[pymethods]
 impl PyMailbox {
-    #[staticmethod]
-    fn root_client_mailbox() -> PyMailbox {
-        PyMailbox {
-            inner: hyperactor_mesh::proc_mesh::global_mailbox(),
-        }
-    }
     fn open_port<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyTuple>> {
         let (handle, receiver) = self.inner.open_port();
         let handle = Py::new(py, PythonPortHandle { inner: handle })?;
@@ -702,6 +703,77 @@ inventory::submit! {
     }
 }
 
+#[derive(Clone)]
+#[pyclass(name = "Instance", module = "monarch._src.actor.actor_mesh")]
+struct Instance {
+    mailbox: Mailbox,
+    actor_id: ActorId,
+}
+#[pymethods]
+impl Instance {
+    #[getter]
+    fn _mailbox(&self) -> PyMailbox {
+        PyMailbox {
+            inner: self.mailbox.clone(),
+        }
+    }
+    #[getter]
+    fn actor_id(&self) -> PyActorId {
+        self.actor_id.clone().into()
+    }
+}
+
+#[pyclass(name = "Context", module = "monarch._src.actor.actor_mesh")]
+pub(crate) struct Context {
+    instance: Instance,
+    rank: usize,
+    shape: Shape,
+}
+
+py_global!(point, "monarch._src.actor.actor_mesh", "Point");
+
+#[pymethods]
+impl Context {
+    #[getter]
+    fn actor_instance(&self) -> Instance {
+        self.instance.clone()
+    }
+    #[getter]
+    fn message_rank<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        let shape = PyShape::from(self.shape.clone());
+        point(py).call1((self.rank, shape.into_pyobject(py).unwrap().unbind()))
+    }
+    #[staticmethod]
+    fn _root_client_context() -> Context {
+        let instance = global_root_client();
+        let instance = Instance {
+            mailbox: instance.mailbox_for_py().clone(),
+            actor_id: instance.self_id().clone(),
+        };
+        Context {
+            instance,
+            rank: 0,
+            shape: Shape::unity(),
+        }
+    }
+}
+
+impl Context {
+    pub(crate) fn new<T: hyperactor::actor::Actor>(cx: &hyperactor::proc::Context<T>) -> Context {
+        let ins = cx.deref();
+        let instance = Instance {
+            mailbox: ins.mailbox_for_py().clone(),
+            actor_id: ins.self_id().clone(),
+        };
+        let (rank, shape) = cx.cast_info();
+        Context {
+            instance,
+            rank,
+            shape,
+        }
+    }
+}
+
 pub fn register_python_bindings(hyperactor_mod: &Bound<'_, PyModule>) -> PyResult<()> {
     hyperactor_mod.add_class::<PyMailbox>()?;
     hyperactor_mod.add_class::<PyPortId>()?;
@@ -713,5 +785,7 @@ pub fn register_python_bindings(hyperactor_mod: &Bound<'_, PyModule>) -> PyResul
     hyperactor_mod.add_class::<PythonOncePortHandle>()?;
     hyperactor_mod.add_class::<PythonOncePortRef>()?;
     hyperactor_mod.add_class::<PythonOncePortReceiver>()?;
+    hyperactor_mod.add_class::<Instance>()?;
+    hyperactor_mod.add_class::<Context>()?;
     Ok(())
 }

--- a/python/monarch/_rust_bindings/monarch_hyperactor/actor.pyi
+++ b/python/monarch/_rust_bindings/monarch_hyperactor/actor.pyi
@@ -266,9 +266,7 @@ class PortProtocol(Generic[R], Protocol):
 class Actor(Protocol):
     async def handle(
         self,
-        mailbox: Mailbox,
-        rank: int,
-        shape: Shape,
+        context: Any,
         method: MethodSpecifier,
         message: bytes,
         panic_flag: PanicFlag,

--- a/python/monarch/_rust_bindings/monarch_hyperactor/mailbox.pyi
+++ b/python/monarch/_rust_bindings/monarch_hyperactor/mailbox.pyi
@@ -137,8 +137,6 @@ class Mailbox:
     """
     A mailbox from that can receive messages.
     """
-    @staticmethod
-    def root_client_mailbox() -> "Mailbox": ...
     def open_port(self) -> tuple[PortHandle, PortReceiver]:
         """Open a port to receive `PythonMessage` messages."""
         ...

--- a/python/monarch/_rust_bindings/monarch_hyperactor/proc_mesh.pyi
+++ b/python/monarch/_rust_bindings/monarch_hyperactor/proc_mesh.pyi
@@ -6,9 +6,10 @@
 
 # pyre-strict
 
-from typing import AsyncIterator, final, Literal, overload, Type
+from typing import Any, AsyncIterator, final, Literal, overload, Type, TYPE_CHECKING
 
-from monarch._rust_bindings.monarch_hyperactor.actor import Actor
+if TYPE_CHECKING:
+    from monarch._rust_bindings.monarch_hyperactor.actor import Actor
 from monarch._rust_bindings.monarch_hyperactor.actor_mesh import (
     PythonActorMesh,
     PythonActorMeshImpl,
@@ -23,7 +24,7 @@ from monarch._rust_bindings.monarch_hyperactor.shape import Shape
 @final
 class ProcMesh:
     @classmethod
-    def allocate_nonblocking(self, alloc: Alloc) -> PythonTask[ProcMesh]:
+    def allocate_nonblocking(self, alloc: Alloc) -> PythonTask["ProcMesh"]:
         """
         Allocate a process mesh according to the provided alloc.
         Returns when the mesh is fully allocated.
@@ -34,7 +35,9 @@ class ProcMesh:
         ...
 
     def spawn_nonblocking(
-        self, name: str, actor: Type[Actor]
+        self,
+        name: str,
+        actor: Any,
     ) -> PythonTask[PythonActorMesh]:
         """
         Spawn a new actor on this mesh.
@@ -47,7 +50,7 @@ class ProcMesh:
 
     @staticmethod
     def spawn_async(
-        proc_mesh: Shared[ProcMesh], name: str, actor: Type[Actor], emulated: bool
+        proc_mesh: Shared["ProcMesh"], name: str, actor: Type["Actor"], emulated: bool
     ) -> PythonActorMesh: ...
     async def monitor(self) -> ProcMeshMonitor:
         """

--- a/python/monarch/_src/actor/proc_mesh.py
+++ b/python/monarch/_src/actor/proc_mesh.py
@@ -45,7 +45,7 @@ from monarch._rust_bindings.monarch_hyperactor.proc_mesh import (
 )
 from monarch._rust_bindings.monarch_hyperactor.pytokio import PythonTask, Shared
 from monarch._rust_bindings.monarch_hyperactor.shape import Shape, Slice
-from monarch._src.actor.actor_mesh import _Actor, Actor, ActorMesh, MonarchContext
+from monarch._src.actor.actor_mesh import _Actor, Actor, ActorMesh, context
 
 from monarch._src.actor.allocator import (
     AllocateMixin,
@@ -343,7 +343,7 @@ class ProcMesh(MeshTrait, DeprecatedNotAFuture):
         service = ActorMesh._create(
             Class,
             actor_mesh,
-            MonarchContext.get().mailbox,
+            context().actor_instance._mailbox,
             self._shape,
             self,
             *args,

--- a/python/tests/_monarch/test_actor_mesh.py
+++ b/python/tests/_monarch/test_actor_mesh.py
@@ -31,7 +31,7 @@ if TYPE_CHECKING:
 from monarch._rust_bindings.monarch_hyperactor.mailbox import Mailbox, PortReceiver
 from monarch._rust_bindings.monarch_hyperactor.proc_mesh import ProcMesh
 from monarch._rust_bindings.monarch_hyperactor.pytokio import PythonTask
-from monarch._rust_bindings.monarch_hyperactor.shape import Shape
+from monarch._src.actor.actor_mesh import Context
 
 
 def run_on_tokio(
@@ -61,9 +61,7 @@ class MyActor:
 
     async def handle(
         self,
-        mailbox: Mailbox,
-        rank: int,
-        shape: Shape,
+        ctx: Context,
         method: MethodSpecifier,
         message: bytes,
         panic_flag: PanicFlag,
@@ -74,7 +72,7 @@ class MyActor:
             case MethodSpecifier.Init():
                 # Since this actor is spawn from the root proc mesh, the rank
                 # passed from init should be the rank on the root mesh.
-                self._rank_on_root_mesh = rank
+                self._rank_on_root_mesh = ctx.message_rank.rank
                 response_port.send(None)
                 return None
             case MethodSpecifier.ReturnsResponse(name=_):

--- a/python/tests/_monarch/test_mailbox.py
+++ b/python/tests/_monarch/test_mailbox.py
@@ -157,9 +157,7 @@ async def test_accumulator() -> None:
 class MyActor:
     async def handle(
         self,
-        mailbox: Mailbox,
-        rank: int,
-        shape: Shape,
+        ctx: Any,
         method: MethodSpecifier,
         message: bytes,
         panic_flag: PanicFlag,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #937
* __->__ #918
* #917
* #913

Adding Context/Instance objects as proposed in https://docs.google.com/document/d/11ohUVih8yPmT1lZaV-OpL-Lawj49-RhJJ6tqxlW94S0/edit?tab=t.0 .

This also replaces our global root mailbox with a global root client instance object.

Context is created from the rust Context<Self> object, though it cannot directly contain Context because the lifetime of the rust thing is limited. (Is there some way to store a limited lifetime thing with a longer lifetime and dynamically assert it is still alvie)?

Differential Revision: [D80505166](https://our.internmc.facebook.com/intern/diff/D80505166/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D80505166/)!