### PR TITLE
Adding README link to hosted documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ PyTorch, but at cluster scale.
 
 Note: Monarch is currently only supported on Linux systems
 
+## 📖 Documentation
+
+View Monarch's hosted documentation [at this link](https://meta-pytorch.org/monarch/).
+
 ## Installation
 
 ### On Fedora distributions


### PR DESCRIPTION
Summary: We have nice hosted docs at https://meta-pytorch.org/monarch/; but there is no obvious way for a user to find them from the repo/README.  So, this just adds a section link to make it obvious.

Differential Revision: D80671899


