### PR TITLE
add ipv6 option for metatls

### DIFF
--- a/hyperactor/Cargo.toml
+++ b/hyperactor/Cargo.toml
@@ -45,6 +45,7 @@ hyperactor_macros = { version = "0.0.0", path = "../hyperactor_macros" }
 hyperactor_telemetry = { version = "0.0.0", path = "../hyperactor_telemetry" }
 inventory = "0.3.8"
 lazy_static = "1.5"
+local-ip-address = "0.5.3"
 ndslice = { version = "0.0.0", path = "../ndslice" }
 nix = { version = "0.30.1", features = ["dir", "event", "hostname", "inotify", "ioctl", "mman", "mount", "net", "poll", "ptrace", "reboot", "resource", "sched", "signal", "term", "time", "user", "zerocopy"] }
 opentelemetry = "0.29"

--- a/hyperactor/src/channel/net.rs
+++ b/hyperactor/src/channel/net.rs
@@ -2196,11 +2196,10 @@ mod tests {
         assert!(rx.await.is_err());
     }
 
-    #[ignore = "fix problem in Sandcastle T208303369"]
     #[tracing_test::traced_test]
     #[tokio::test]
     async fn test_meta_tls_basic() {
-        let addr = ChannelAddr::any(ChannelTransport::MetaTls);
+        let addr = ChannelAddr::any(ChannelTransport::MetaTls(TlsMode::IpV6));
         let (hostname, port) = match addr {
             ChannelAddr::MetaTls(hostname, port) => (hostname, port),
             _ => ("".to_string(), 0),

--- a/hyperactor_mesh/src/alloc/remoteprocess.rs
+++ b/hyperactor_mesh/src/alloc/remoteprocess.rs
@@ -739,7 +739,7 @@ impl RemoteProcessAlloc {
             tracing::debug!("allocating: {} for host: {}", view, host.id);
 
             let remote_addr = match self.transport {
-                ChannelTransport::MetaTls => {
+                ChannelTransport::MetaTls(_) => {
                     format!("metatls!{}:{}", host.hostname, self.remote_allocator_port)
                 }
                 ChannelTransport::Tcp => {


### PR DESCRIPTION
Summary: TLS cannot work with ip-per-task containers. To support such containers, we need to use IP addresses instead of hostnames. For non-ip-per-task containers, we need to do the opposite. Adding ipv6 support for metatls to get ready for such support.

Differential Revision: D80654404


