### PR TITLE
[monarch] Fix broken tests

### DIFF
--- a/python/monarch/_src/actor/actor_mesh.py
+++ b/python/monarch/_src/actor/actor_mesh.py
@@ -134,7 +134,7 @@ class Instance:
         """
         The proc_id of the current actor.
         """
-        ...
+        return self.actor_id.proc_id
 
     @property
     def actor_id(self) -> ActorId:
@@ -775,6 +775,18 @@ class _Actor:
             match method:
                 case MethodSpecifier.Init():
                     Class, self._proc_mesh, self._controller_controller, *args = args
+                    # Happens when initializing the _ControllerController singleton
+                    if self._controller_controller is None:
+                        from monarch._src.actor.proc_mesh import (
+                            _get_controller_controller,
+                        )
+
+                        self._controller_controller = _get_controller_controller()
+                    ctx.actor_instance._controller_controller = (
+                        self._controller_controller
+                    )
+                    assert self._proc_mesh is not None
+                    ctx.actor_instance.proc_mesh = self._proc_mesh
                     try:
                         self.instance = Class(*args, **kwargs)
                     except Exception as e:

--- a/python/monarch/_src/actor/actor_mesh.py
+++ b/python/monarch/_src/actor/actor_mesh.py
@@ -775,16 +775,10 @@ class _Actor:
             match method:
                 case MethodSpecifier.Init():
                     Class, self._proc_mesh, self._controller_controller, *args = args
-                    # Happens when initializing the _ControllerController singleton
-                    if self._controller_controller is None:
-                        from monarch._src.actor.proc_mesh import (
-                            _get_controller_controller,
+                    if self._controller_controller is not None:
+                        ctx.actor_instance._controller_controller = (
+                            self._controller_controller
                         )
-
-                        self._controller_controller = _get_controller_controller()
-                    ctx.actor_instance._controller_controller = (
-                        self._controller_controller
-                    )
                     assert self._proc_mesh is not None
                     ctx.actor_instance.proc_mesh = self._proc_mesh
                     try:
@@ -820,8 +814,8 @@ class _Actor:
                         f" This is likely due to an earlier error: {self._saved_error}"
                     )
                 raise AssertionError(error_message)
-            assert self._controller_controller is not None
-            ctx.actor_instance._controller_controller = self._controller_controller
+            if self._controller_controller is not None:
+                ctx.actor_instance._controller_controller = self._controller_controller
             assert self._proc_mesh is not None
             ctx.actor_instance.proc_mesh = self._proc_mesh
             the_method = getattr(self.instance, method_name)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #951

D80505166 broke some tests. We need to provide a python implementation for `Instance.proc_id`. Additionally, there was a bad assert about `_controller_controller` not being none; we need to handle the case where the `_Actor` being initialized is `_ControllerController`.

Differential Revision: [D80725768](https://our.internmc.facebook.com/intern/diff/D80725768/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D80725768/)!