### PR TITLE
disable cuda on macos

### DIFF
--- a/cuda-sys/build.rs
+++ b/cuda-sys/build.rs
@@ -132,6 +132,10 @@ fn validate_cuda_installation() -> String {
     cuda_home
 }
 
+#[cfg(target_os = "macos")]
+fn main() {}
+
+#[cfg(not(target_os = "macos"))]
 fn main() {
     // Validate CUDA installation and get CUDA home path
     let cuda_home = validate_cuda_installation();

--- a/nccl-sys/build.rs
+++ b/nccl-sys/build.rs
@@ -77,7 +77,10 @@ fn python_env_dirs() -> (Option<String>, Option<String>) {
     }
     (include_dir, lib_dir)
 }
+#[cfg(target_os = "macos")]
+fn main() {}
 
+#[cfg(not(target_os = "macos"))]
 fn main() {
     let mut builder = bindgen::Builder::default()
         // Parse nccl.h as C++ with -std=gnu++20.

--- a/rdmaxcel-sys/build.rs
+++ b/rdmaxcel-sys/build.rs
@@ -132,6 +132,10 @@ fn validate_cuda_installation() -> String {
     cuda_home
 }
 
+#[cfg(target_os = "macos")]
+fn main() {}
+
+#[cfg(not(target_os = "macos"))]
 fn main() {
     // Tell cargo to look for shared libraries in the specified directory
     println!("cargo:rustc-link-search=/usr/lib");

--- a/torch-sys-cuda/build.rs
+++ b/torch-sys-cuda/build.rs
@@ -42,6 +42,10 @@ fn get_env_var_with_rerun(name: &str) -> Result<String, std::env::VarError> {
     std::env::var(name)
 }
 
+#[cfg(target_os = "macos")]
+fn main() {}
+
+#[cfg(not(target_os = "macos"))]
 fn main() {
     let mut libtorch_include_dirs: Vec<PathBuf> = vec![];
     let mut libtorch_lib_dir: Option<PathBuf> = None;


### PR DESCRIPTION
Summary: This diff disables CUDA on MacOS by modifying the build.rs files of the Monarch library. The changes include adding a main function that does nothing for MacOS and modifying the build.rs files for nccl-sys, rdmaxcel-sys, and torch-sys-cuda to exclude MacOS. The changes are necessary because CUDA is not supported on MacOS.

Reviewed By: shayne-fletcher

Differential Revision: D80573844


