### PR TITLE
__exit__ in Actors for user defined cleanup

### DIFF
--- a/python/monarch/_src/actor/actor_mesh.py
+++ b/python/monarch/_src/actor/actor_mesh.py
@@ -752,6 +752,7 @@ class _Actor:
         self._saved_error: ActorError | None = None
         self._proc_mesh: Optional[ProcMesh] = None
         self._controller_controller: Optional["_ControllerController"] = None
+        self._cleanup_called = False
 
     async def handle(
         self,
@@ -849,10 +850,12 @@ class _Actor:
 
             response_port.send(result)
         except Exception as e:
+            self._run_user_defined_cleanup(e)
             self._post_mortem_debug(e.__traceback__)
             traceback.print_exc()
             response_port.exception(ActorError(e))
         except BaseException as e:
+            self._run_user_defined_cleanup(e)
             self._post_mortem_debug(e.__traceback__)
             # A BaseException can be thrown in the case of a Rust panic.
             # In this case, we need a way to signal the panic to the Rust side.
@@ -888,6 +891,22 @@ class _Actor:
                 DebugContext.set(DebugContext(pdb_wrapper))
                 pdb_wrapper.post_mortem(exc_tb)
                 self._maybe_exit_debugger(do_continue=False)
+
+    def _run_user_defined_cleanup(self, exc: Exception | BaseException | None) -> None:
+        if self._cleanup_called or self.instance is None:
+            return
+
+        cleanup = getattr(self.instance, "__exit__", None)
+        if cleanup is None:
+            return
+
+        if exc is None:
+            cleanup(None, None, None)
+        else:
+            cleanup(type(exc), exc, exc.__traceback__)
+
+        # ensure idempotency
+        self._cleanup_called = True
 
 
 def _is_mailbox(x: object) -> bool:


### PR DESCRIPTION
Summary:
There is an open papercut https://github.com/meta-pytorch/monarch/issues/839 where NCCL watchdog causes a segfault on ProcMesh.stop().

This issue can reliably be stopped by making sure `torch.distributed.destroy_process_groups()` is called on exit.

We want to provide users with a convenient way of being able to define a cleanup function for an actor that is automatically invoked on exception or shutdown, and this is a location in which users can add in the call to `destroy_process_groups()`

Because this may not be safe to call (on abnormal exit), we want to be able to also thread through exception details to define different cleanup procedures for normal vs abnormal exit.

When an Actor throws an `Exception` while handling a message, `__exit__` is invoked with the `Exception`. Otherwise, when the Actor exits gracefully it will invoke `__exit__` passing in None as all its arguments

Differential Revision: D80719752


