### PR TITLE
Add rust macro for instrumentation.

### DIFF
--- a/hyperactor/src/lib.rs
+++ b/hyperactor/src/lib.rs
@@ -130,6 +130,7 @@ pub use hyperactor_macros::forward;
 pub use hyperactor_macros::instrument;
 #[doc(inline)]
 pub use hyperactor_macros::instrument_infallible;
+pub use hyperactor_macros::observe;
 pub use hyperactor_telemetry::declare_static_counter;
 pub use hyperactor_telemetry::declare_static_gauge;
 pub use hyperactor_telemetry::declare_static_histogram;

--- a/hyperactor_macros/Cargo.toml
+++ b/hyperactor_macros/Cargo.toml
@@ -29,6 +29,8 @@ syn = { version = "2.0.101", features = ["extra-traits", "fold", "full", "visit"
 anyhow = "1.0.98"
 async-trait = "0.1.86"
 hyperactor = { version = "0.0.0", path = "../hyperactor" }
+hyperactor_telemetry = { version = "0.0.0", path = "../hyperactor_telemetry" }
+opentelemetry = "0.29"
 serde = { version = "1.0.185", features = ["derive", "rc"] }
 static_assertions = "1.1.0"
 timed_test = { version = "0.0.0", path = "../timed_test" }

--- a/hyperactor_macros/src/lib.rs
+++ b/hyperactor_macros/src/lib.rs
@@ -37,6 +37,7 @@ use syn::ItemImpl;
 use syn::Lit;
 use syn::Meta;
 use syn::MetaNameValue;
+use syn::ReturnType;
 use syn::Token;
 use syn::Type;
 use syn::bracketed;
@@ -1878,4 +1879,181 @@ pub fn derive_actor(input: TokenStream) -> TokenStream {
     };
 
     TokenStream::from(expanded)
+}
+
+/// A procedural macro that automatically injects telemetry code into async functions.
+///
+/// This macro wraps tokio::async functions and adds instrumentation to measure:
+/// 1. Latency - how long the function takes to execute
+/// 2. Error throughput - whether the function returns an error or success
+///
+/// # Example
+///
+/// ```rust
+/// use hyperactor_actor::observe;
+///
+/// #[observe("my_module")]
+/// async fn process_request(user_id: &str) -> Result<String, Error> {
+///     // Function implementation
+///     // Telemetry will be automatically collected
+/// }
+/// ```
+///
+/// The macro will generate code equivalent to:
+///
+/// ```rust
+/// async fn process_request(user_id: &str) -> Result<String, Error> {
+///     let _timer = hyperactor_telemetry::FUNCTION_LATENCY.start(
+///         hyperactor_telemetry::kv_pairs!("function" => "process_request")
+///     );
+///     
+///     let result = async {
+///         // Original function body
+///     }.await;
+///     
+///     match &result {
+///         Ok(_) => {
+///             hyperactor_telemetry::FUNCTION_SUCCESS.add(
+///                 1,
+///                 hyperactor_telemetry::kv_pairs!("function" => "process_request")
+///             );
+///         }
+///         Err(_) => {
+///             hyperactor_telemetry::FUNCTION_ERROR.add(
+///                 1,
+///                 hyperactor_telemetry::kv_pairs!("function" => "process_request")
+///             );
+///         }
+///     }
+///     
+///     result
+/// }
+/// ```
+#[proc_macro_attribute]
+pub fn observe(attr: TokenStream, item: TokenStream) -> TokenStream {
+    // Parse the input function
+    let input = parse_macro_input!(item as ItemFn);
+
+    // Check if the function is async
+    if !input.sig.asyncness.is_some() {
+        return syn::Error::new(
+            input.sig.span(),
+            "the #[instrument] macro can only be applied to async functions",
+        )
+        .to_compile_error()
+        .into();
+    }
+
+    // Extract function name
+    let fn_name = &input.sig.ident;
+    let fn_name_str = fn_name.to_string();
+    // Parse attr if present into a string variable named module_name_str
+    let module_name_str = parse_macro_input!(attr as syn::LitStr).value();
+
+    // Extract function visibility, arguments, return type, and body
+    let vis = &input.vis;
+    let args = &input.sig.inputs;
+    let return_type = &input.sig.output;
+    let body = &input.block;
+    let attrs = &input.attrs;
+    let generics = &input.sig.generics;
+
+    let module_and_fn = format!("{}_{}", module_name_str, fn_name_str);
+
+    let latency_ident = Ident::new(
+        format!("{}_LATENCY", module_and_fn).as_str(),
+        Span::call_site(),
+    );
+
+    let success_ident = Ident::new(
+        format!("{}_SUCCESS", module_and_fn).as_str(),
+        Span::call_site(),
+    );
+
+    let error_ident = Ident::new(
+        format!("{}_ERROR", module_and_fn).as_str(),
+        Span::call_site(),
+    );
+
+    // Determine if the function returns a Result
+    let returns_result = match return_type {
+        ReturnType::Type(_, ty) => {
+            if let Type::Path(type_path) = ty.as_ref() {
+                if let Some(segment) = type_path.path.segments.first() {
+                    segment.ident == "Result"
+                } else {
+                    false
+                }
+            } else {
+                false
+            }
+        }
+        _ => false,
+    };
+
+    // Generate the instrumented function
+    let expanded = if returns_result {
+        quote! {
+            #(#attrs)*
+            #vis async fn #fn_name #generics(#args) #return_type {
+                use hyperactor_telemetry;
+                // Create the static counters and timer if they don't exist yet
+                hyperactor_telemetry::declare_static_timer!(#latency_ident, concat!(stringify!(attr as LitStr), "_", stringify!(#fn_name), ".latency"), hyperactor_telemetry::TimeUnit::Micros);
+                hyperactor_telemetry::declare_static_counter!(#success_ident, concat!(stringify!(attr as LitStr), "_", stringify!(#fn_name), ".success"));
+                hyperactor_telemetry::declare_static_counter!(#error_ident, concat!(stringify!(attr as LitStr), "_", stringify!(#fn_name), ".error"));
+
+                let kv_pairs = hyperactor_telemetry::kv_pairs!("function" => #fn_name_str.clone());
+                // Start timing the function execution
+                let _timer = #latency_ident.start(kv_pairs);
+
+                // Execute the original function body
+                let result = async #body.await;
+
+                // Record success or error based on the result
+                match &result {
+                    Ok(_) => {
+                        #success_ident.add(
+                            1,
+                            hyperactor_telemetry::kv_pairs!("function" => #fn_name_str.clone())
+                        );
+                    }
+                    Err(_) => {
+                        #error_ident.add(
+                            1,
+                            hyperactor_telemetry::kv_pairs!("function" => #fn_name_str.clone())
+                        );
+                    }
+                }
+
+                result
+            }
+        }
+    } else {
+        // For functions that don't return Result, we still measure both latency and errors
+        quote! {
+            #(#attrs)*
+            #vis async fn #fn_name #generics(#args) #return_type {
+                use hyperactor_telemetry;
+
+                hyperactor_telemetry::declare_static_timer!(#latency_ident, concat!(stringify!(attr as LitStr), "_", stringify!(#fn_name), ".latency"), hyperactor_telemetry::TimeUnit::Micros);
+                hyperactor_telemetry::declare_static_counter!(#success_ident, concat!(stringify!(attr as LitStr), "_", stringify!(#fn_name), ".success"));
+                hyperactor_telemetry::declare_static_counter!(#error_ident, concat!(stringify!(attr as LitStr), "_", stringify!(#fn_name), ".error"));
+
+                let kv_pairs = hyperactor_telemetry::kv_pairs!("function" => #fn_name_str.clone());
+                // Start timing the function execution
+                let _timer = #latency_ident.start(kv_pairs);
+
+                let ret = async #body.await;
+
+                #success_ident.add(
+                    1,
+                    hyperactor_telemetry::kv_pairs!("function" => #fn_name_str.clone())
+                );
+                ret
+            }
+        }
+    };
+
+    // Return the expanded code
+    expanded.into()
 }

--- a/hyperactor_macros/tests/basic.rs
+++ b/hyperactor_macros/tests/basic.rs
@@ -24,6 +24,7 @@ use hyperactor::RefClient;
 use hyperactor::forward;
 use hyperactor::instrument;
 use hyperactor::instrument_infallible;
+use hyperactor::observe;
 use serde::Deserialize;
 use serde::Serialize;
 
@@ -139,3 +140,149 @@ static_assertions::assert_type_eq_all!(
     <PassthroughActorTest as hyperactor::Actor>::Params,
     PassthroughActorTest
 );
+
+#[cfg(test)]
+mod tests {
+    use std::error::Error;
+    use std::fmt;
+    use std::sync::Arc;
+    use std::sync::atomic::AtomicBool;
+    use std::sync::atomic::Ordering;
+
+    use super::*;
+
+    // Define a custom error type for testing
+    #[derive(Debug)]
+    struct CustomError {
+        message: String,
+    }
+
+    impl CustomError {
+        fn new(message: &str) -> Self {
+            Self {
+                message: message.to_string(),
+            }
+        }
+    }
+
+    impl fmt::Display for CustomError {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            write!(f, "{}", self.message)
+        }
+    }
+
+    impl Error for CustomError {}
+
+    // Example using the basic instrument macro
+    #[observe("custom_module")]
+    async fn process_data(data: &str) -> Result<String, CustomError> {
+        // Simulate some processing time
+        tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;
+
+        if data.contains("error") {
+            return Err(CustomError::new("Data contains error"));
+        }
+
+        Ok(format!("Processed: {}", data))
+    }
+
+    // Example using the instrument_with macro with custom metric names and attributes
+    #[observe("custom_module")]
+    async fn handle_api_request(
+        endpoint: &str,
+        method: &str,
+        payload: &str,
+    ) -> Result<String, CustomError> {
+        // Simulate API processing time
+        tokio::time::sleep(tokio::time::Duration::from_millis(20)).await;
+
+        if endpoint.contains("invalid") {
+            return Err(CustomError::new("Invalid endpoint"));
+        }
+
+        if method == "POST" && payload.is_empty() {
+            return Err(CustomError::new("Empty payload for POST request"));
+        }
+
+        Ok(format!("Response from {} {}", method, endpoint))
+    }
+
+    // Example of a function that doesn't return a Result but might throw exceptions
+    #[observe("custom_module")]
+    async fn log_activity(activity: &str) {
+        // Simulate logging activity
+        tokio::time::sleep(tokio::time::Duration::from_millis(5)).await;
+    }
+
+    // Example of a function that will panic
+    #[observe("custom_module")]
+    async fn risky_operation(should_panic: bool) {
+        // Simulate operation
+        tokio::time::sleep(tokio::time::Duration::from_millis(3)).await;
+
+        if should_panic {
+            panic!("Something went wrong!");
+        }
+    }
+
+    #[tokio::test]
+    async fn test_process_data_success() {
+        let result = process_data("normal data").await;
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), "Processed: normal data");
+    }
+
+    #[tokio::test]
+    async fn test_process_data_error() {
+        let result = process_data("data with error").await;
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err().to_string(), "Data contains error");
+    }
+
+    #[tokio::test]
+    async fn test_handle_api_request_success() {
+        // Test GET request
+        let result = handle_api_request("/users", "GET", "").await;
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), "Response from GET /users");
+
+        // Test POST request with payload
+        let result = handle_api_request("/posts", "POST", "content").await;
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), "Response from POST /posts");
+    }
+
+    #[tokio::test]
+    async fn test_handle_api_request_errors() {
+        // Test invalid endpoint
+        let result = handle_api_request("/invalid/path", "GET", "").await;
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err().to_string(), "Invalid endpoint");
+
+        // Test empty payload for POST
+        let result = handle_api_request("/posts", "POST", "").await;
+        assert!(result.is_err());
+        assert_eq!(
+            result.unwrap_err().to_string(),
+            "Empty payload for POST request"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_log_activity() {
+        // This should complete without errors
+        log_activity("User login").await;
+    }
+
+    #[tokio::test]
+    async fn test_risky_operation_success() {
+        // This should complete without errors
+        risky_operation(false).await;
+    }
+
+    #[tokio::test]
+    #[should_panic(expected = "Something went wrong!")]
+    async fn test_risky_operation_panic() {
+        risky_operation(true).await;
+    }
+}

--- a/hyperactor_telemetry/Cargo.toml
+++ b/hyperactor_telemetry/Cargo.toml
@@ -19,12 +19,14 @@ hdrhistogram = "7.5"
 lazy_static = "1.5"
 opentelemetry = "0.29"
 opentelemetry_sdk = { version = "0.29.0", features = ["rt-tokio"] }
+quote = "1.0.29"
 rand = { version = "0.8", features = ["small_rng"] }
 rusqlite = { version = "0.36.0", features = ["backup", "blob", "bundled", "column_decltype", "functions", "limits", "modern_sqlite", "serde_json"] }
 scuba = { version = "0.1.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main", optional = true }
 serde = { version = "1.0.219", features = ["derive", "rc"] }
 serde_json = { version = "1.0.140", features = ["alloc", "float_roundtrip", "raw_value", "unbounded_depth"] }
 serde_rusqlite = "0.39.3"
+syn = { version = "2.0.101", features = ["extra-traits", "fold", "full", "visit", "visit-mut"] }
 tokio = { version = "1.46.1", features = ["full", "test-util", "tracing"] }
 tracing = { version = "0.1.41", features = ["attributes", "valuable"] }
 tracing-appender = "0.2.3"


### PR DESCRIPTION
Summary:
This may be integrated with instrument
but for now, keeping it separated out. You just need to add the decorator on the api method if you need to add basic telemetry and tracing as well.

Differential Revision: D80296789


