### PR TITLE
Update tokio 1.46-1 -> 1.47.1 and tokio-openssl 1.6.1 -> 1.6.5

### DIFF
--- a/controller/Cargo.toml
+++ b/controller/Cargo.toml
@@ -26,7 +26,7 @@ ndslice = { version = "0.0.0", path = "../ndslice" }
 pyo3 = { version = "0.24", features = ["anyhow", "multiple-pymethods"] }
 serde = { version = "1.0.219", features = ["derive", "rc"] }
 serde_json = { version = "1.0.140", features = ["alloc", "float_roundtrip", "raw_value", "unbounded_depth"] }
-tokio = { version = "1.46.1", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.47.1", features = ["full", "test-util", "tracing"] }
 torch-sys = { path = "../torch-sys" }
 tracing = { version = "0.1.41", features = ["attributes", "valuable"] }
 

--- a/hyperactor/Cargo.toml
+++ b/hyperactor/Cargo.toml
@@ -63,7 +63,7 @@ serde_yaml = "0.9.25"
 signal-hook-tokio = { version = "0.3", features = ["futures-v0_3"] }
 strum = { version = "0.27.1", features = ["derive"] }
 thiserror = "2.0.12"
-tokio = { version = "1.46.1", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.47.1", features = ["full", "test-util", "tracing"] }
 tokio-rustls = "0.26.2"
 tokio-stream = { version = "0.1.17", features = ["fs", "io-util", "net", "signal", "sync", "time"] }
 tokio-util = { version = "0.7.15", features = ["full"] }

--- a/hyperactor_mesh/Cargo.toml
+++ b/hyperactor_mesh/Cargo.toml
@@ -63,7 +63,7 @@ serde = { version = "1.0.219", features = ["derive", "rc"] }
 serde_bytes = "0.11"
 serde_json = { version = "1.0.140", features = ["alloc", "float_roundtrip", "raw_value", "unbounded_depth"] }
 thiserror = "2.0.12"
-tokio = { version = "1.46.1", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.47.1", features = ["full", "test-util", "tracing"] }
 tokio-stream = { version = "0.1.17", features = ["fs", "io-util", "net", "signal", "sync", "time"] }
 tokio-util = { version = "0.7.15", features = ["full"] }
 tracing = { version = "0.1.41", features = ["attributes", "valuable"] }

--- a/hyperactor_multiprocess/Cargo.toml
+++ b/hyperactor_multiprocess/Cargo.toml
@@ -20,7 +20,7 @@ hyperactor_telemetry = { version = "0.0.0", path = "../hyperactor_telemetry" }
 remoteprocess = { git = "https://github.com/technicianted/remoteprocess", rev = "72505594a19d80c07df6f1dc4a80556b7e462148" }
 serde = { version = "1.0.219", features = ["derive", "rc"] }
 thiserror = "2.0.12"
-tokio = { version = "1.46.1", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.47.1", features = ["full", "test-util", "tracing"] }
 tokio-retry = "0.3"
 tracing = { version = "0.1.41", features = ["attributes", "valuable"] }
 

--- a/hyperactor_telemetry/Cargo.toml
+++ b/hyperactor_telemetry/Cargo.toml
@@ -25,7 +25,7 @@ scuba = { version = "0.1.0", git = "https://github.com/facebookexperimental/rust
 serde = { version = "1.0.219", features = ["derive", "rc"] }
 serde_json = { version = "1.0.140", features = ["alloc", "float_roundtrip", "raw_value", "unbounded_depth"] }
 serde_rusqlite = "0.39.3"
-tokio = { version = "1.46.1", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.47.1", features = ["full", "test-util", "tracing"] }
 tracing = { version = "0.1.41", features = ["attributes", "valuable"] }
 tracing-appender = "0.2.3"
 tracing-core = { version = "0.1.33", features = ["valuable"] }

--- a/monarch_conda/Cargo.toml
+++ b/monarch_conda/Cargo.toml
@@ -29,7 +29,7 @@ rattler_conda_types = "0.28.3"
 serde = { version = "1.0.219", features = ["derive", "rc"] }
 serde_json = { version = "1.0.140", features = ["alloc", "float_roundtrip", "raw_value", "unbounded_depth"] }
 sha2 = "0.10.6"
-tokio = { version = "1.46.1", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.47.1", features = ["full", "test-util", "tracing"] }
 tokio-util = { version = "0.7.15", features = ["full"] }
 walkdir = "2.3"
 

--- a/monarch_extension/Cargo.toml
+++ b/monarch_extension/Cargo.toml
@@ -36,7 +36,7 @@ ndslice = { version = "0.0.0", path = "../ndslice" }
 pyo3 = { version = "0.24", features = ["anyhow", "multiple-pymethods"] }
 rdmaxcel-sys = { path = "../rdmaxcel-sys", optional = true }
 serde = { version = "1.0.219", features = ["derive", "rc"] }
-tokio = { version = "1.46.1", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.47.1", features = ["full", "test-util", "tracing"] }
 torch-sys = { version = "0.0.0", path = "../torch-sys", optional = true }
 torch-sys-cuda = { version = "0.0.0", path = "../torch-sys-cuda", optional = true }
 tracing = { version = "0.1.41", features = ["attributes", "valuable"] }

--- a/monarch_hyperactor/Cargo.toml
+++ b/monarch_hyperactor/Cargo.toml
@@ -40,7 +40,7 @@ serde = { version = "1.0.219", features = ["derive", "rc"] }
 serde_bytes = "0.11"
 tempfile = "3.15"
 thiserror = "2.0.12"
-tokio = { version = "1.46.1", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.47.1", features = ["full", "test-util", "tracing"] }
 tracing = { version = "0.1.41", features = ["attributes", "valuable"] }
 
 [dev-dependencies]

--- a/monarch_rdma/Cargo.toml
+++ b/monarch_rdma/Cargo.toml
@@ -21,7 +21,7 @@ tracing = { version = "0.1.41", features = ["attributes", "valuable"] }
 hyperactor_mesh = { version = "0.0.0", path = "../hyperactor_mesh" }
 ndslice = { version = "0.0.0", path = "../ndslice" }
 timed_test = { version = "0.0.0", path = "../timed_test" }
-tokio = { version = "1.46.1", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.47.1", features = ["full", "test-util", "tracing"] }
 
 [features]
 cuda = []

--- a/monarch_rdma/examples/parameter_server/Cargo.toml
+++ b/monarch_rdma/examples/parameter_server/Cargo.toml
@@ -29,7 +29,7 @@ hyperactor_mesh = { version = "0.0.0", path = "../../../hyperactor_mesh" }
 monarch_rdma = { version = "0.0.0", path = "../.." }
 ndslice = { version = "0.0.0", path = "../../../ndslice" }
 serde = { version = "1.0.219", features = ["derive", "rc"] }
-tokio = { version = "1.46.1", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.47.1", features = ["full", "test-util", "tracing"] }
 tracing = { version = "0.1.41", features = ["attributes", "valuable"] }
 tracing-subscriber = { version = "0.3.19", features = ["chrono", "env-filter", "json", "local-time", "parking_lot", "registry"] }
 

--- a/monarch_simulator/Cargo.toml
+++ b/monarch_simulator/Cargo.toml
@@ -23,7 +23,7 @@ ndslice = { version = "0.0.0", path = "../ndslice" }
 serde = { version = "1.0.219", features = ["derive", "rc"] }
 serde_json = { version = "1.0.140", features = ["alloc", "float_roundtrip", "raw_value", "unbounded_depth"] }
 thiserror = "2.0.12"
-tokio = { version = "1.46.1", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.47.1", features = ["full", "test-util", "tracing"] }
 torch-sys = { version = "0.0.0", path = "../torch-sys" }
 torch-sys-cuda = { version = "0.0.0", path = "../torch-sys-cuda" }
 tracing = { version = "0.1.41", features = ["attributes", "valuable"] }

--- a/monarch_tensor_worker/Cargo.toml
+++ b/monarch_tensor_worker/Cargo.toml
@@ -29,7 +29,7 @@ pyo3 = { version = "0.24", features = ["anyhow", "multiple-pymethods"] }
 serde = { version = "1.0.219", features = ["derive", "rc"] }
 serde_json = { version = "1.0.140", features = ["alloc", "float_roundtrip", "raw_value", "unbounded_depth"] }
 sorted-vec = "0.8.3"
-tokio = { version = "1.46.1", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.47.1", features = ["full", "test-util", "tracing"] }
 torch-sys = { version = "0.0.0", path = "../torch-sys" }
 torch-sys-cuda = { version = "0.0.0", path = "../torch-sys-cuda" }
 tracing = { version = "0.1.41", features = ["attributes", "valuable"] }

--- a/monarch_types/Cargo.toml
+++ b/monarch_types/Cargo.toml
@@ -17,4 +17,4 @@ serde_bytes = "0.11"
 [dev-dependencies]
 anyhow = "1.0.98"
 timed_test = { version = "0.0.0", path = "../timed_test" }
-tokio = { version = "1.46.1", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.47.1", features = ["full", "test-util", "tracing"] }

--- a/preempt_rwlock/Cargo.toml
+++ b/preempt_rwlock/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 license = "BSD-3-Clause"
 
 [dependencies]
-tokio = { version = "1.46.1", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.47.1", features = ["full", "test-util", "tracing"] }
 
 [dev-dependencies]
 anyhow = "1.0.98"

--- a/timed_test/Cargo.toml
+++ b/timed_test/Cargo.toml
@@ -21,4 +21,4 @@ quote = "1.0.29"
 syn = { version = "2.0.101", features = ["extra-traits", "fold", "full", "visit", "visit-mut"] }
 
 [dev-dependencies]
-tokio = { version = "1.46.1", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.47.1", features = ["full", "test-util", "tracing"] }

--- a/torch-sys/Cargo.toml
+++ b/torch-sys/Cargo.toml
@@ -22,7 +22,7 @@ pyo3 = { version = "0.24", features = ["anyhow", "multiple-pymethods"] }
 regex = "1.11.1"
 serde = { version = "1.0.219", features = ["derive", "rc"] }
 thiserror = "2.0.12"
-tokio = { version = "1.46.1", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.47.1", features = ["full", "test-util", "tracing"] }
 tracing = { version = "0.1.41", features = ["attributes", "valuable"] }
 
 [build-dependencies]


### PR DESCRIPTION
Summary:
1.47.1 (August 1st, 2025)
Fixed
process: fix panic from spurious pidfd wakeup (#7494)
sync: fix broken link of Python asyncio.Event in SetOnce docs (#7485)

1.47.0 (July 25th, 2025)
This release adds poll_proceed and cooperative to the coop module for
cooperative scheduling, adds SetOnce to the sync module which provides
similar functionality to [std::sync::OnceLock], and adds a new method
sync::Notify::notified_owned() which returns an OwnedNotified without
a lifetime parameter.

Added
coop: add cooperative and poll_proceed (#7405)
sync: add SetOnce (#7418)
sync: add sync::Notify::notified_owned() (#7465)
Changed
deps: upgrade windows-sys 0.52 → 0.59 ([#7117])
deps: update to socket2 v0.6 ([#7443])
sync: improve AtomicWaker::wake performance (#7450)
Documented
metrics: fix listed feature requirements for some metrics (#7449)
runtime: improve safety comments of Readiness<'_> (#7415)

Differential Revision: D80726365
