### PR TITLE
Make MessageEnvelope takes a vec of errors

### DIFF
--- a/hyperactor/src/mailbox.rs
+++ b/hyperactor/src/mailbox.rs
@@ -177,6 +177,10 @@ pub enum DeliveryError {
     /// A (local) mailbox delivery error.
     #[error("mailbox error: {0}")]
     Mailbox(String),
+
+    /// A multicast related delivery error.
+    #[error("multicast error: {0}")]
+    Multicast(String),
 }
 
 /// An envelope that carries a message destined to a remote actor.
@@ -194,7 +198,7 @@ pub struct MessageEnvelope {
     data: Serialized,
 
     /// Error contains a delivery error when message delivery failed.
-    error: Option<DeliveryError>,
+    errors: Vec<DeliveryError>,
 
     /// Additional context for this message.
     headers: Attrs,
@@ -208,7 +212,7 @@ impl MessageEnvelope {
             sender,
             dest,
             data,
-            error: None,
+            errors: Vec::new(),
             headers,
         }
     }
@@ -230,7 +234,7 @@ impl MessageEnvelope {
             data: Serialized::serialize(value)?,
             sender: source,
             dest,
-            error: None,
+            errors: Vec::new(),
         })
     }
 
@@ -264,12 +268,10 @@ impl MessageEnvelope {
         self.dest.index() == Signal::port()
     }
 
-    /// Tries to sets a delivery error for the message. If the error is already
-    /// set, nothing is updated.
-    pub fn try_set_error(&mut self, error: DeliveryError) {
-        if self.error.is_none() {
-            self.error = Some(error);
-        }
+    /// Set a delivery error for the message. If errors are already set, append
+    /// it to the existing errors.
+    pub fn set_error(&mut self, error: DeliveryError) {
+        self.errors.push(error)
     }
 
     /// The message has been determined to be undeliverable with the
@@ -290,14 +292,31 @@ impl MessageEnvelope {
             ),
         );
 
-        self.try_set_error(error);
+        self.set_error(error);
         undeliverable::return_undeliverable(return_handle, self);
     }
 
-    /// Get the error of why this message was undeliverable. None means this
+    /// Get the errors of why this message was undeliverable. Empty means this
     /// message was not determined as undeliverable.
-    pub fn error(&self) -> Option<&DeliveryError> {
-        self.error.as_ref()
+    pub fn errors(&self) -> &Vec<DeliveryError> {
+        &self.errors
+    }
+
+    /// Get the string representation of the errors of this message was
+    /// undeliverable. None means this message was not determined as
+    /// undeliverable.
+    pub fn error_msg(&self) -> Option<String> {
+        if self.errors.is_empty() {
+            None
+        } else {
+            Some(
+                self.errors
+                    .iter()
+                    .map(|e| e.to_string())
+                    .collect::<Vec<_>>()
+                    .join("; "),
+            )
+        }
     }
 
     fn open(self) -> (MessageMetadata, Serialized) {
@@ -305,7 +324,7 @@ impl MessageEnvelope {
             sender,
             dest,
             data,
-            error,
+            errors,
             headers,
         } = self;
 
@@ -313,7 +332,7 @@ impl MessageEnvelope {
             MessageMetadata {
                 sender,
                 dest,
-                error,
+                errors,
                 headers,
             },
             data,
@@ -324,7 +343,7 @@ impl MessageEnvelope {
         let MessageMetadata {
             sender,
             dest,
-            error,
+            errors,
             headers,
         } = metadata;
 
@@ -332,7 +351,7 @@ impl MessageEnvelope {
             sender,
             dest,
             data,
-            error,
+            errors,
             headers,
         }
     }
@@ -340,7 +359,7 @@ impl MessageEnvelope {
 
 impl fmt::Display for MessageEnvelope {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match &self.error {
+        match &self.error_msg() {
             None => write!(f, "{} > {}: {}", self.sender, self.dest, self.data),
             Some(err) => write!(
                 f,
@@ -356,7 +375,7 @@ impl fmt::Display for MessageEnvelope {
 pub struct MessageMetadata {
     sender: ActorId,
     dest: PortId,
-    error: Option<DeliveryError>,
+    errors: Vec<DeliveryError>,
     headers: Attrs,
 }
 
@@ -853,7 +872,7 @@ fn server_return_handle<T: MailboxServer>(server: T) -> PortHandle<Undeliverable
                 UndeliverableMailboxSender.post(e, monitored_return_handle());
                 continue;
             }
-            envelope.try_set_error(DeliveryError::BrokenLink(
+            envelope.set_error(DeliveryError::BrokenLink(
                 "message was undeliverable".to_owned(),
             ));
             server.post(
@@ -900,7 +919,7 @@ pub trait MailboxServer: MailboxSender + Clone + Sized + 'static {
                     UndeliverableMailboxSender.post(e, monitored_return_handle());
                     continue;
                 }
-                envelope.try_set_error(DeliveryError::BrokenLink(
+                envelope.set_error(DeliveryError::BrokenLink(
                     "message was undeliverable".to_owned(),
                 ));
                 server.post(
@@ -1364,7 +1383,7 @@ impl MailboxSender for Mailbox {
                     headers,
                     sender,
                     dest,
-                    error: metadata_error,
+                    errors: metadata_errors,
                 } = metadata;
 
                 // We use the entry API here so that we can remove the
@@ -1400,7 +1419,7 @@ impl MailboxSender for Mailbox {
                                 headers,
                                 sender,
                                 dest,
-                                error: metadata_error,
+                                errors: metadata_errors,
                             },
                             data,
                         )
@@ -2995,7 +3014,7 @@ mod tests {
         // no outstanding return handles it terminates.
         let monitor_handle = tokio::spawn(async move {
             while let Ok(Undeliverable(mut envelope)) = return_receiver.recv().await {
-                envelope.try_set_error(DeliveryError::BrokenLink(
+                envelope.set_error(DeliveryError::BrokenLink(
                     "returned in unit test".to_string(),
                 ));
                 UndeliverableMailboxSender

--- a/monarch_hyperactor/src/mailbox.rs
+++ b/monarch_hyperactor/src/mailbox.rs
@@ -465,8 +465,8 @@ impl PythonUndeliverableMessageEnvelope {
         Ok(self
             .inner()?
             .0
-            .error()
-            .map_or("None".to_string(), |e| e.to_string()))
+            .error_msg()
+            .unwrap_or_else(|| "None".to_string()))
     }
 }
 


### PR DESCRIPTION
Summary:
Right now, `MessageEnvelope` only allows up to 1 undelivered error. But very often the message could be associated with a series of errors. We want to log all of them in order to get the full picture of why it was not delievered.

This diff makes this change. It also improves some callsites with this new capability

Differential Revision: D80846618


