### PR TITLE
[EZ] Replace `pytorch-labs` with `meta-pytorch`

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ pytest python/tests/ -v -m "not oss_skip"
 
 ```sh
 # Clone the repository and navigate to it
-git clone https://github.com/pytorch-labs/monarch.git
+git clone https://github.com/meta-pytorch/monarch.git
 cd monarch
 
 # Install nightly rust toolchain

--- a/docs/source/books/hyperactor-book/book.toml
+++ b/docs/source/books/hyperactor-book/book.toml
@@ -5,5 +5,5 @@ src = "src"
 title = "Hyperactor Book"
 
 [output.html]
-git-repository-url = "https://github.com/pytorch-labs/monarch"
-edit-url-template = "https://github.com/pytorch-labs/monarch/edit/main/books/hyperactor-book/src/{path}"
+git-repository-url = "https://github.com/meta-pytorch/monarch"
+edit-url-template = "https://github.com/meta-pytorch/monarch/edit/main/books/hyperactor-book/src/{path}"

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -84,7 +84,7 @@ html_theme_options = {
         },
         {
             "name": "GitHub",
-            "url": "https://github.com/pytorch-labs/monarch",
+            "url": "https://github.com/meta-pytorch/monarch",
             "icon": "fa-brands fa-github",
         },
         {
@@ -112,9 +112,9 @@ html_context = {
     "theme_variables": theme_variables,
     "display_github": True,
     "github_url": "https://github.com",
-    "github_user": "pytorch-labs",
+    "github_user": "meta-pytorch",
     "github_repo": "monarch",
-    "feedback_url": "https://github.com/pytorch-labs/monarch",
+    "feedback_url": "https://github.com/meta-pytorch/monarch",
     "github_version": "main",
     "doc_path": "docs/source",
     "library_links": theme_variables.get("library_links", []),

--- a/docs/source/get_started.md
+++ b/docs/source/get_started.md
@@ -187,6 +187,6 @@ If you encounter issues:
 - Make sure your CUDA environment is properly set up
 - Check that you're using a compatible version of PyTorch
 - Verify that all dependencies are installed correctly
-- Consult the [GitHub repository](https://github.com/pytorch-labs/monarch) for known issues
+- Consult the [GitHub repository](https://github.com/meta-pytorch/monarch) for known issues
 
 Remember that Monarch is currently in an experimental stage, so you may encounter bugs or incomplete features. Contributions and bug reports are welcome!

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -48,13 +48,13 @@ rust-api
 
 ## License
 
-Monarch is BSD-3 licensed, as found in the [LICENSE](https://github.com/pytorch-labs/monarch/blob/main/LICENSE) file.
+Monarch is BSD-3 licensed, as found in the [LICENSE](https://github.com/meta-pytorch/monarch/blob/main/LICENSE) file.
 
 ## Community
 
 We welcome contributions from the community! If you're interested in contributing, please:
 
-1. Check the [GitHub repository](https://github.com/pytorch-labs/monarch)
+1. Check the [GitHub repository](https://github.com/meta-pytorch/monarch)
 2. Review existing issues or create a new one
 3. Discuss your proposed changes before starting work
 4. Submit a pull request with your changes

--- a/hyperactor/Cargo.toml
+++ b/hyperactor/Cargo.toml
@@ -6,7 +6,7 @@ version = "0.0.0"
 authors = ["Facebook <opensource+crates-hyperactor@fb.com>"]
 edition = "2021"
 description = "a high-performance, scalable actor framework for cluster computing"
-repository = "https://github.com/pytorch-labs/monarch/"
+repository = "https://github.com/meta-pytorch/monarch/"
 license = "BSD-3-Clause"
 
 [[bin]]

--- a/hyperactor_macros/Cargo.toml
+++ b/hyperactor_macros/Cargo.toml
@@ -6,7 +6,7 @@ version = "0.0.0"
 authors = ["Facebook <opensource+crates-hyperactor-macros@fb.com>"]
 edition = "2021"
 description = "macros to support the Hyperactor actors and data exchange"
-repository = "https://github.com/pytorch-labs/monarch/"
+repository = "https://github.com/meta-pytorch/monarch/"
 license = "BSD-3-Clause"
 
 [lib]

--- a/ndslice/Cargo.toml
+++ b/ndslice/Cargo.toml
@@ -6,7 +6,7 @@ version = "0.0.0"
 authors = ["Facebook <opensource+crates-ndslice@fb.com>"]
 edition = "2021"
 description = "data structures to support n-d arrays of ranks"
-repository = "https://github.com/pytorch-labs/monarch/"
+repository = "https://github.com/meta-pytorch/monarch/"
 license = "BSD-3-Clause"
 
 [dependencies]

--- a/python/monarch/tools/components/hyperactor.py
+++ b/python/monarch/tools/components/hyperactor.py
@@ -23,7 +23,7 @@ __version__ = "latest"  # TODO get version from monarch.__version_
 
 
 def host_mesh(
-    image: str = f"ghcr.io/pytorch-labs/monarch:{__version__}",  # TODO docker needs to be built and pushed to ghcr
+    image: str = f"ghcr.io/meta-pytorch/monarch:{__version__}",  # TODO docker needs to be built and pushed to ghcr
     meshes: list[str] = _DEFAULT_MESHES,
     env: Optional[dict[str, str]] = None,
     port: int = mesh_spec.DEFAULT_REMOTE_ALLOCATOR_PORT,

--- a/serde_multipart/Cargo.toml
+++ b/serde_multipart/Cargo.toml
@@ -6,7 +6,7 @@ version = "0.0.0"
 authors = ["Facebook <opensource+crates-serde_multipart@fb.com>"]
 edition = "2021"
 description = "multipart encoding for serde"
-repository = "https://github.com/pytorch-labs/monarch/"
+repository = "https://github.com/meta-pytorch/monarch/"
 license = "BSD-3-Clause"
 
 [dependencies]


### PR DESCRIPTION
This PR replaces all instances of `pytorch-labs` with `meta-pytorch` in this repository now that the `pytorch-labs` org has been renamed to `meta-pytorch`

## Changes Made
- Replaced all occurrences of `pytorch-labs` with `meta-pytorch`
- Skipped binary files and files larger than 1MB due to GitHub api payload limits in the script to cover all repos in this org. Will do a more manual second pass later to cover any larger files

## Files Modified
This PR updates files that contained the target text.

Generated by automated script on 2025-08-22T23:43:52.462970+00:00Z