### PR TITLE
Implement __str__ for Point struct py binding

### DIFF
--- a/ndslice/src/view.rs
+++ b/ndslice/src/view.rs
@@ -370,7 +370,13 @@ impl std::fmt::Display for Point {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let n = self.coords.len();
         for i in 0..n {
-            write!(f, "{}={}", self.extent.labels()[i], self.coords[i])?;
+            write!(
+                f,
+                "{}={}/{}",
+                self.extent.labels()[i],
+                self.coords[i],
+                self.extent.sizes()[i]
+            )?;
             if i != n - 1 {
                 write!(f, ",")?;
             }
@@ -851,7 +857,7 @@ mod test {
     fn test_point_display() {
         let extent = Extent::new(vec!["x".into(), "y".into(), "z".into()], vec![4, 5, 6]).unwrap();
         let point = extent.point(vec![1, 2, 3]).unwrap();
-        assert_eq!(format!("{}", point), "x=1,y=2,z=3");
+        assert_eq!(format!("{}", point), "x=1/4,y=2/5,z=3/6");
 
         assert!(extent.point(vec![]).is_err());
 

--- a/python/monarch/_rust_bindings/monarch_hyperactor/shape.pyi
+++ b/python/monarch/_rust_bindings/monarch_hyperactor/shape.pyi
@@ -106,7 +106,7 @@ class Shape:
 
     Arguments:
     - `labels`: A list of strings representing the labels for each dimension.
-    - `slice`: An Slice object representing the shape.
+    - `slice`: A Slice object representing the shape.
     """
     def __new__(cls, labels: Sequence[str], slice: Slice) -> "Shape": ...
     @property

--- a/python/tests/_monarch/test_ndslice.py
+++ b/python/tests/_monarch/test_ndslice.py
@@ -12,7 +12,7 @@ from unittest import TestCase
 
 from monarch._rust_bindings.monarch_hyperactor.selection import Selection
 
-from monarch._rust_bindings.monarch_hyperactor.shape import Shape, Slice
+from monarch._rust_bindings.monarch_hyperactor.shape import Point, Shape, Slice
 
 
 class TestNdslice(TestCase):
@@ -189,6 +189,23 @@ class TestShape(TestCase):
             repr(shape),
             'Shape { labels: ["label0", "label1"], slice: Slice { offset: 0, sizes: [2, 3], strides: [3, 1] } }',
         )
+
+
+class TestPoint(TestCase):
+    def test_point_str_simple(self) -> None:
+        """Test __str__ method for Point with simple 2D shape."""
+        s = Slice(offset=0, sizes=[3, 4], strides=[4, 1])
+        shape = Shape(["label0", "label1"], s)
+
+        # Test different ranks and their string representations
+        point_0 = Point(0, shape)
+        self.assertEqual(str(point_0), "rank=0/12 coords={label0=0/3,label1=0/4}")
+
+        point_3 = Point(3, shape)
+        self.assertEqual(str(point_3), "rank=3/12 coords={label0=0/3,label1=3/4}")
+
+        point_11 = Point(11, shape)
+        self.assertEqual(str(point_11), "rank=11/12 coords={label0=2/3,label1=3/4}")
 
 
 class TestSelection(TestCase):


### PR DESCRIPTION
Summary:
Implement `__str__` method for the `Point` struct in the `monarch_hyperactor` library. The `__str__` method returns a string representation of the `Point` struct, which includes the labels and coordinates of the point.

Also, added a unit test for the same.

Related github issue https://github.com/meta-pytorch/monarch/issues/935

TODO: Plan to audit other structs with missing __str__. If there are missing ones, then those shall be sent via separate diff.



