### PR TITLE
mitigate PyGILState_Release in test

### DIFF
--- a/python/tests/python_actor_test_binary.py
+++ b/python/tests/python_actor_test_binary.py
@@ -46,6 +46,9 @@ async def _flush_logs() -> None:
     assert log_mesh is not None
     Future(coro=log_mesh.flush().spawn().task()).get()
 
+    # TODO: without stop, we will have PyGILState_Release error under stress test
+    await pm.stop()
+
 
 @main.command("flush-logs")
 def flush_logs() -> None:

--- a/python/tests/test_python_actors.py
+++ b/python/tests/test_python_actors.py
@@ -775,7 +775,9 @@ async def test_flush_logs_fast_exit() -> None:
 
     # Check if the process ended without error
     if process.returncode != 0:
-        raise RuntimeError(f"{cmd} ended with error code {process.returncode}. ")
+        raise RuntimeError(
+            f"{cmd} ended with error code {process.returncode}. {process.stderr}"
+        )
 
     # Assertions on the captured output, 160 = 32 procs * 5 logs per proc
     # 32 and 5 are specified in the test_bin flush-logs.


### PR DESCRIPTION
Summary: somehow it only happens during stress tests

Differential Revision: D80870026


