### PR TITLE
(monarch/tools) introduce a proper Workspace abstraction to support multiple project directories

### DIFF
--- a/monarch_extension/src/code_sync.rs
+++ b/monarch_extension/src/code_sync.rs
@@ -41,14 +41,16 @@ use serde::Serialize;
 #[derive(Clone, Debug, Serialize, Deserialize)]
 enum PyWorkspaceLocation {
     Constant(PathBuf),
-    FromEnvVar(String),
+    FromEnvVar { env: String, relpath: PathBuf },
 }
 
 impl From<PyWorkspaceLocation> for WorkspaceLocation {
     fn from(workspace: PyWorkspaceLocation) -> WorkspaceLocation {
         match workspace {
             PyWorkspaceLocation::Constant(v) => WorkspaceLocation::Constant(v),
-            PyWorkspaceLocation::FromEnvVar(v) => WorkspaceLocation::FromEnvVar(v),
+            PyWorkspaceLocation::FromEnvVar { env, relpath } => {
+                WorkspaceLocation::FromEnvVar { env, relpath }
+            }
         }
     }
 }

--- a/monarch_hyperactor/src/code_sync/workspace.rs
+++ b/monarch_hyperactor/src/code_sync/workspace.rs
@@ -15,17 +15,87 @@ use serde::Serialize;
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum WorkspaceLocation {
+    //// Workspace directory specified by the given path.
     Constant(PathBuf),
-    FromEnvVar(String),
+
+    /// Workspace directory specified by dereferencing the value of the environment variable
+    /// and appending the relative path to it.
+    ///
+    /// Example: `WorkspaceLocation::FromEnvVar{ env:"WORKSPACE_DIR", relpath: PathBuf::from("github/torchtitan) }`
+    /// points to `$WORKSPACE_DIR/github/torchtitan`.
+    FromEnvVar {
+        env: String,
+        relpath: PathBuf,
+    },
 }
 
 impl WorkspaceLocation {
     pub fn resolve(&self) -> Result<PathBuf> {
         Ok(match self {
             WorkspaceLocation::Constant(p) => p.clone(),
-            WorkspaceLocation::FromEnvVar(v) => PathBuf::from(
-                std::env::var_os(v).with_context(|| format!("workspace env var not set: {}", v))?,
-            ),
+            WorkspaceLocation::FromEnvVar { env, relpath } => PathBuf::from(
+                std::env::var_os(env)
+                    .with_context(|| format!("workspace env var not set: {}", env))?,
+            )
+            .join(relpath),
         })
+    }
+}
+#[cfg(test)]
+mod tests {
+    use std::env;
+
+    use tempfile::tempdir;
+
+    use super::*;
+
+    #[test]
+    fn test_constant_workspace_location_constant() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().to_path_buf();
+        let loc = WorkspaceLocation::Constant(path.clone());
+        let resolved = loc.resolve().unwrap();
+        assert_eq!(resolved, path);
+    }
+
+    #[test]
+    fn test_from_env_var_workspace_location() {
+        let tmpdir = tempdir().unwrap();
+
+        // SAFETY: ok for single threaded test case
+        unsafe { env::set_var("WORKSPACE_DIR", tmpdir.path()) }
+
+        assert_eq!(
+            tmpdir.path().join("github/torchtitan"),
+            WorkspaceLocation::FromEnvVar {
+                env: "WORKSPACE_DIR".to_string(),
+                relpath: PathBuf::from("github/torchtitan")
+            }
+            .resolve()
+            .unwrap(),
+        );
+
+        assert_eq!(
+            tmpdir.path().to_path_buf(),
+            WorkspaceLocation::FromEnvVar {
+                env: "WORKSPACE_DIR".to_string(),
+                relpath: PathBuf::new()
+            }
+            .resolve()
+            .unwrap(),
+        );
+
+        // SAFETY: ok for single threaded test case
+        unsafe { env::remove_var("WORKSPACE_DIR") }
+    }
+
+    #[test]
+    fn test_from_env_var_missing_env() {
+        let loc = WorkspaceLocation::FromEnvVar {
+            env: "__NON_EXISTENT__".to_string(),
+            relpath: PathBuf::from("foo"),
+        };
+        let err = loc.resolve().unwrap_err();
+        assert!(format!("{:?}", err).contains("__NON_EXISTENT__"));
     }
 }

--- a/python/monarch/_rust_bindings/monarch_extension/code_sync.pyi
+++ b/python/monarch/_rust_bindings/monarch_extension/code_sync.pyi
@@ -17,11 +17,11 @@ class WorkspaceLocation:
     """
     @final
     class Constant(WorkspaceLocation):
-        def __init__(self, path) -> None: ...
+        def __init__(self, path: str | Path) -> None: ...
 
     @final
     class FromEnvVar(WorkspaceLocation):
-        def __init__(self, var) -> None: ...
+        def __init__(self, env: str, relpath: str | Path) -> None: ...
 
     def resolve(self) -> Path:
         """

--- a/python/monarch/tools/config/__init__.py
+++ b/python/monarch/tools/config/__init__.py
@@ -5,8 +5,11 @@
 # LICENSE file in the root directory of this source tree.
 
 # pyre-strict
+import warnings
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, TYPE_CHECKING
+
+from monarch.tools.config.workspace import Workspace
 
 # Defer the import of Role to avoid requiring torchx at import time
 if TYPE_CHECKING:
@@ -26,14 +29,6 @@ class UnnamedAppDef:
     metadata: Dict[str, str] = field(default_factory=dict)
 
 
-# TODO: provide a proper Workspace class to support
-#  - multiple workspaces
-#  - empty workspaces
-#  - no workspace
-#  - experimental directories
-Workspace = str | None
-
-
 @dataclass
 class Config:
     """
@@ -42,6 +37,24 @@ class Config:
 
     scheduler: str = NOT_SET
     scheduler_args: dict[str, Any] = field(default_factory=dict)
-    workspace: Workspace = None
+    workspace: Workspace = field(default_factory=Workspace.null)
     dryrun: bool = False
     appdef: UnnamedAppDef = field(default_factory=UnnamedAppDef)
+
+    def __post_init__(self) -> None:
+        # workspace used to be Optional[str]
+        # while we type it as class Workspace now, handle workspace=None and str for BC
+        if self.workspace is None:
+            deprecation_msg = "Setting `workspace=None` is deprecated."
+            " Use `workspace=monarch.tools.config.workspace.Workspace(env=None)` instead."
+            warnings.warn(deprecation_msg, FutureWarning, stacklevel=2)
+            self.workspace = Workspace.null()
+        elif isinstance(self.workspace, str):
+            deprecation_msg = f"Setting `workspace='{self.workspace}'` is deprecated."
+            f" Use `workspace=monarch.tools.config.workspace.Workspace(dirs=['{self.workspace}'])` instead."
+            warnings.warn(deprecation_msg, FutureWarning, stacklevel=2)
+            # previous behavior (when workspace was a str pointing to the local project dir)
+            # was to copy the local dir into $WORKSPACE_DIR. For example:
+            # ~/github/torch/** (local) -> $WORKSPACE_DIR/** (remote)
+            # so we map it to "".
+            self.workspace = Workspace(dirs={self.workspace: ""})

--- a/python/monarch/tools/config/defaults.py
+++ b/python/monarch/tools/config/defaults.py
@@ -8,10 +8,12 @@
 
 """Defines defaults for ``monarch.tools``"""
 
+import warnings
 from typing import Callable
 
 from monarch.tools.components import hyperactor
-from monarch.tools.config import Config, UnnamedAppDef, Workspace
+from monarch.tools.config import Config, UnnamedAppDef
+from monarch.tools.config.workspace import Workspace
 
 from torchx import specs
 from torchx.schedulers import (
@@ -40,9 +42,17 @@ def scheduler_factories() -> dict[str, SchedulerFactory]:
     }
 
 
-def config(scheduler: str, workspace: Workspace = None) -> Config:
+def config(scheduler: str, workspace: str | None = None) -> Config:
     """The default :py:class:`~monarch.tools.config.Config` to use when submitting to the provided ``scheduler``."""
-    return Config(scheduler=scheduler, workspace=workspace)
+    warnings.warn(
+        "`defaults.config()` is deprecated, prefer instantiating `Config()` directly",
+        FutureWarning,
+        stacklevel=2,
+    )
+    return Config(
+        scheduler=scheduler,
+        workspace=Workspace(dirs={workspace: ""}) if workspace else Workspace.null(),
+    )
 
 
 def dryrun_info_formatter(dryrun_info: specs.AppDryRunInfo) -> Callable[..., str]:

--- a/python/monarch/tools/config/environment.py
+++ b/python/monarch/tools/config/environment.py
@@ -1,0 +1,45 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from monarch.tools import utils
+
+
+class Environment:
+    """An environment holds the necessary dependencies for the projects (directories)
+    in a `monarch.tools.workspace.Workspace`. When specified as part of a Workspace,
+    the local environment is packed into an ephemeral "image" (e.g. Docker) to mirror
+    the locally installed packages on the remote job.
+    """
+
+    pass
+
+
+class CondaEnvironment(Environment):
+    """Reference to a conda environment.
+    If no `conda_prefix` is specified, then defaults to the currently active conda environment.
+    """
+
+    def __init__(self, conda_prefix: str | None = None) -> None:
+        self._conda_prefix = conda_prefix
+
+    @property
+    def conda_prefix(self) -> str:
+        """Returns the `conda_prefix` this object was instantiated with or the currently active conda environment
+        if no `conda_prefix` was specified in the constructor."""
+        if not self._conda_prefix:
+            active_conda_prefix = utils.conda.active_env_dir()
+            assert active_conda_prefix, "No currently active conda environment. Either specify a `conda_prefix` or activate one."
+            return active_conda_prefix
+        else:
+            return self._conda_prefix
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, CondaEnvironment):
+            return False
+
+        return self._conda_prefix == other._conda_prefix

--- a/python/monarch/tools/config/workspace.py
+++ b/python/monarch/tools/config/workspace.py
@@ -1,0 +1,165 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import shutil
+from pathlib import Path
+
+from monarch.tools.config.environment import CondaEnvironment, Environment
+
+ACTIVE_CONDA_ENV = CondaEnvironment()
+
+
+class Workspace:
+    """
+    A workspace is one or more local directories that contains your project(s).
+    Workspaces can specify an "environment" on which projects are developed and run locally.
+    A currently active conda environment is an example of such environment.
+
+    At the time of job submission an ephemeral version of the "image" is built and the
+    new job is configured to run on this image. The "image" is the one specified by
+    `Role.image` attribute in the job's `AppDef`
+    (see `monarch.tools.components.hyperactor.host_mesh()`).
+
+    For example when launching onto Kubernetes, "image" is interpreted as a Docker image (e.g. "name:tag")
+
+    Specifically the ephemeral image contains:
+
+    1. A copy of the workspace directories
+    2. (If Applicable) A copy of the currently active environment
+
+    This effectively one-time mirrors the local codebase and environment on the remote machines.
+
+    Workspaces can also be sync'ed interactively on-demand (post job launch) by using
+    `monarch.actor.proc_mesh.ProcMesh.syncWorkspace(Workspace)`.
+
+    Usage:
+
+    .. doc-test::
+
+        import pathlib
+        from monarch.tools.config import Workspace
+        from monarch.tools.config import Config
+
+        HOME = pathlib.Path().home()
+
+        # 1. single project workspace
+        config = Config(
+            workspace=Workspace(dirs=[HOME / "github" / "torchtitan"]),
+        )
+
+        # 2. multiple projects (useful for cross-project development)
+        config = Config(
+            workspace=Workspace(
+                dirs=[
+                    # $HOME/torch             (local) -> $WORKSPACE_DIR/torch      (remote)
+                    # $HOME/github/torchtitan (local) -> $WORKSPACE_DIR/torchtitan (remote)
+                    HOME() / "torch",
+                    HOME() / "github" / "torchtitan",
+                ]
+            ),
+        )
+
+        # 3. with explicit local -> remote mappings
+        config = Config(
+            workspace=Workspace(
+                dirs={
+                    # $HOME/torch             (local) -> $WORKSPACE_DIR/github/pytorch    (remote)
+                    # $HOME/github/torchtitan (local) -> $WORKSPACE_DIR/github/torchtitan (remote)
+                    HOME() / "torch" : "github/pytorch"
+                    HOME() / "github" / "torchtitan" : "github/torchtitan"
+                }
+            )
+        )
+        # -- or flat into WORKSPACE_DIR
+        config = Config(
+            workspace=Workspace(
+                # $HOME/github/torchtitan  (local) -> $WORKSPACE_DIR/  (remote)
+                dirs={HOME() / "github" / "torchtitan": ""},
+            )
+        )
+
+        # 3. no project, everything is installed in my environment (but sync my env)
+        config = Config(
+            workspace=Workspace(),
+        )
+
+        # 4. disable project and environment sync
+        config = Config(
+            workspace=Workspace(env=None),
+        )
+    """
+
+    def __init__(
+        self,
+        dirs: list[Path | str] | dict[Path | str, str] | None = None,
+        env: Environment | None = ACTIVE_CONDA_ENV,
+    ) -> None:
+        self.env = env
+        self.dirs: dict[Path, str] = {}  # src -> dst
+
+        if dirs is None:
+            pass
+        elif isinstance(dirs, list):
+            for d in dirs:
+                d = Path(d)
+                self.dirs[d] = d.name
+        else:  # dict
+            for src, dst in dirs.items():
+                self.dirs[Path(src)] = dst
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, Workspace):
+            return False
+
+        return self.env == other.env and self.dirs == other.dirs
+
+    def merge(self, outdir: str | Path) -> None:
+        """Merges the dirs of this workspace into the given outdir."""
+
+        outdir = Path(outdir)
+        outdir.mkdir(parents=True, exist_ok=True)
+
+        for src, dst in self.dirs.items():
+            shutil.copytree(src, outdir / dst, dirs_exist_ok=True)
+
+    # pyre-ignore[2] skip type-hint to avoid torchx dep
+    def set_env_vars(self, appdef) -> None:
+        """For each role in the appdef, sets the following env vars (if not already set):
+
+        1. `WORKSPACE_DIR`: the root directory of the remote workspace
+        2. `PYTHONPATH`: include all the remote workspace dirs for all the roles in the appdef
+                (dedups and appends to existing `PYTHONPATH`)
+        3. `CONDA_DIR`: (if env is conda) the remote path to the conda env to activate
+        """
+
+        # typically this macro comes from torchx.specs.macros.img_root
+        # but we use the str repr instead to avoid taking a dep to torchx from this module
+        # unittest (test_workspace.py) asserts against torchx.specs.macros.img_root
+        # guarding against changes to the macro value
+        img_root_macro = "${img_root}"
+
+        for role in appdef.roles:
+            remote_workspace_root = role.env.setdefault(
+                "WORKSPACE_DIR",
+                f"{img_root_macro}/workspace",
+            )
+
+            PYTHONPATH = [p for p in role.env.get("PYTHONPATH", "").split(":") if p]
+            for dst in self.dirs.values():
+                remote_dir = f"{remote_workspace_root}/{dst}"
+                if remote_dir not in PYTHONPATH:
+                    PYTHONPATH.append(remote_dir)
+            role.env["PYTHONPATH"] = ":".join(PYTHONPATH)
+
+            if isinstance(self.env, CondaEnvironment):
+                role.env.setdefault("CONDA_DIR", f"{img_root_macro}/conda")
+
+    @staticmethod
+    def null() -> "Workspace":
+        """Returns a "null" workspace; a workspace with no project dirs and no environment."""
+        return Workspace(env=None)

--- a/python/tests/_monarch/test_proc_mesh.py
+++ b/python/tests/_monarch/test_proc_mesh.py
@@ -1,0 +1,108 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import contextlib
+import importlib.resources
+import os
+import shutil
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+from typing import Generator
+
+import pytest
+
+from monarch._rust_bindings.monarch_hyperactor.alloc import AllocConstraints, AllocSpec
+from monarch._rust_bindings.monarch_hyperactor.channel import (
+    ChannelAddr,
+    ChannelTransport,
+)
+from monarch._src.actor.allocator import RemoteAllocator, StaticRemoteAllocInitializer
+
+from monarch.actor import ProcMesh
+from monarch.tools.config.workspace import Workspace
+
+
+@contextlib.contextmanager
+def remote_process_allocator(env: dict[str, str]) -> Generator[str, None, None]:
+    if __package__:
+        cm = importlib.resources.as_file(importlib.resources.files(__package__))
+    else:  # running as script (e.g. pytest test_proc_mesh.py)
+        cm = contextlib.nullcontext()
+
+    with cm as package_path:
+        if package_path is None:
+            package_path = ""
+
+        addr = ChannelAddr.any(ChannelTransport.Unix)
+        args = ["process_allocator", f"--addr={addr}"]
+
+        env = {
+            # prefix PATH with this test module's directory to
+            # give 'process_allocator' and 'monarch_bootstrap' binary resources
+            # in this test module's directory precedence over the installed ones
+            # useful in BUCK where these binaries are added as 'resources' of this test target
+            "PATH": f"{package_path}:{os.getenv('PATH', '')}",
+            "RUST_LOG": "debug",
+        } | env
+
+        process_allocator = subprocess.Popen(
+            args=args,
+            env=env,
+        )
+        try:
+            yield addr
+        finally:
+            process_allocator.terminate()
+            try:
+                five_seconds = 5
+                process_allocator.wait(timeout=five_seconds)
+            except subprocess.TimeoutExpired:
+                process_allocator.kill()
+
+
+class TestSyncWorkspace(unittest.IsolatedAsyncioTestCase):
+    def setUp(self) -> None:
+        self.tmpdir = Path(tempfile.mkdtemp())
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self.tmpdir)
+
+    # oss_skip: TODO kiuk@ fails in CI due to rsync binary not found
+    @pytest.mark.oss_skip  # pyre-ignore[56]
+    async def test_sync_workspace(self) -> None:
+        local_workspace_dir = self.tmpdir / "local" / "github" / "torch"
+        local_workspace_dir.mkdir(parents=True)
+
+        remote_workspace_root = self.tmpdir / "remote" / "workspace"
+        remote_workspace_dir = remote_workspace_root / "torch"
+        workspace = Workspace(dirs=[local_workspace_dir])
+
+        with remote_process_allocator(
+            env={"WORKSPACE_DIR": str(remote_workspace_root)}
+        ) as host:
+            allocator = RemoteAllocator(
+                world_id="test_sync_workspace",
+                initializer=StaticRemoteAllocInitializer(host),
+            )
+            spec = AllocSpec(AllocConstraints(), hosts=1, gpus=1)
+            proc_mesh = ProcMesh.from_alloc(allocator.allocate(spec))
+
+            # local workspace dir is empty & remote workspace dir hasn't been primed yet
+            self.assertFalse(remote_workspace_dir.is_dir())
+
+            # create a README file locally and sync workspace
+            with open(local_workspace_dir / "README.md", mode="w") as f:
+                f.write("hello world")
+
+            await proc_mesh.sync_workspace(workspace)
+
+            # validate README has been created remotely
+            with open(remote_workspace_dir / "README.md", mode="r") as f:
+                self.assertListEqual(["hello world"], f.readlines())

--- a/python/tests/test_allocator.py
+++ b/python/tests/test_allocator.py
@@ -15,7 +15,6 @@ import os
 import subprocess
 import sys
 import unittest
-from datetime import timedelta
 from time import sleep
 from typing import Generator, Optional
 from unittest import mock
@@ -54,8 +53,6 @@ from monarch.tools.network import get_sockaddr
 
 from torch.distributed.elastic.utils.distributed import get_free_port
 from torchx.specs import AppState
-
-_100_MILLISECONDS = timedelta(milliseconds=100)
 
 SERVER_READY = "monarch.tools.commands.server_ready"
 UNUSED = "__UNUSED__"

--- a/python/tests/test_python_actors.py
+++ b/python/tests/test_python_actors.py
@@ -1167,7 +1167,7 @@ class LsActor(Actor):
         return os.listdir(self.workspace)
 
 
-# oss_skip: TODO kiuk@ investigate why this fails in CI with FileNotFound error on rust-side
+# oss_skip: TODO kiuk@ fails in CI due to rsync binary not found
 @pytest.mark.oss_skip
 async def test_sync_workspace() -> None:
     # create two workspaces: one for local and one for remote

--- a/python/tests/tools/config/test_config.py
+++ b/python/tests/tools/config/test_config.py
@@ -1,0 +1,35 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+
+from monarch.tools.config import Config
+
+
+class TestConfig(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmpdir = Path(tempfile.mkdtemp(prefix="TestConfig_"))
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self.tmpdir)
+
+    def test_workspace_is_None(self) -> None:
+        with self.assertWarns(FutureWarning):
+            config = Config(workspace=None)  # pyre-ignore[6] BC testing
+        self.assertDictEqual({}, config.workspace.dirs)
+        self.assertIsNone(config.workspace.env)
+
+    def test_workspace_is_str(self) -> None:
+        with self.assertWarns(FutureWarning):
+            # pyre-ignore[6] BC testing
+            config = Config(workspace=str(self.tmpdir / "torch"))
+
+        self.assertDictEqual({self.tmpdir / "torch": ""}, config.workspace.dirs)

--- a/python/tests/tools/config/test_defaults.py
+++ b/python/tests/tools/config/test_defaults.py
@@ -34,14 +34,6 @@ class TestDefaults(unittest.TestCase):
                 config.scheduler_args["foo"] = "bar"
                 self.assertNotIn("foo", defaults.config(scheduler).scheduler_args)
 
-    def test_default_config_workspace(self) -> None:
-        current_working_dir = str(Path.cwd())
-        config = defaults.config(
-            "local_cwd",
-            current_working_dir,
-        )
-        self.assertEqual(current_working_dir, config.workspace)
-
     def test_default_config_appdef(self) -> None:
         for scheduler, _ in {
             "mast": {"image": "_DUMMY_FBPKG_:0"},

--- a/python/tests/tools/config/test_environment.py
+++ b/python/tests/tools/config/test_environment.py
@@ -1,0 +1,52 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import os
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from monarch.tools.config.environment import CondaEnvironment
+
+
+class TestCondaEnvironment(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmpdir = Path(tempfile.mkdtemp(prefix="TestEnvironment_"))
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self.tmpdir)
+
+    def test_no_prefix_no_active_env_throws(self) -> None:
+        # clears any CONDA_PREFIX env vars
+        with mock.patch.dict(os.environ, {}, clear=True):
+            with self.assertRaises(AssertionError):
+                CondaEnvironment().conda_prefix
+
+    def test_no_prefix_active_env(self) -> None:
+        mock_conda_prefix = str(self.tmpdir / ".conda" / "testenv")
+        with mock.patch.dict(os.environ, {"CONDA_PREFIX": mock_conda_prefix}):
+            self.assertEqual(mock_conda_prefix, CondaEnvironment().conda_prefix)
+
+    def test_conda_prefix(self) -> None:
+        current_active = str(self.tmpdir / ".conda" / "foo")
+        override = str(self.tmpdir / ".conda" / "bar")
+        with mock.patch.dict(os.environ, {"CONDA_PREFIX": current_active}):
+            self.assertEqual(override, CondaEnvironment(override).conda_prefix)
+
+    def test_currently_active_env(self) -> None:
+        mock_conda_prefix = str(self.tmpdir / ".conda" / "testenv")
+        env = CondaEnvironment()
+
+        with mock.patch.dict(os.environ, {"CONDA_PREFIX": mock_conda_prefix}):
+            self.assertEqual(str(self.tmpdir / ".conda" / "testenv"), env.conda_prefix)
+
+        with mock.patch.dict(os.environ, {}, clear=True):
+            with self.assertRaises(AssertionError):
+                env.conda_prefix

--- a/python/tests/tools/config/test_workspace.py
+++ b/python/tests/tools/config/test_workspace.py
@@ -1,0 +1,193 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import os
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+
+from monarch.tools.config.environment import CondaEnvironment
+
+from monarch.tools.config.workspace import Workspace
+from torchx import specs
+
+
+class TestWorkspace(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmpdir = Path(tempfile.mkdtemp(prefix="TestWorkspace_"))
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self.tmpdir)
+
+    def touch(self, *path: str) -> Path:
+        f = Path(os.path.join(self.tmpdir, *path))
+        f.parent.mkdir(parents=True, exist_ok=True)
+        f.touch()
+        return f
+
+    def test_workspace_dir_list(self) -> None:
+        w = Workspace(
+            dirs=[
+                self.tmpdir / "foo",
+                self.tmpdir / "github" / "bar",
+            ]
+        )
+        self.assertDictEqual(
+            {
+                self.tmpdir / "foo": "foo",
+                self.tmpdir / "github" / "bar": "bar",
+            },
+            w.dirs,
+        )
+
+    def test_workspace_dir_map(self) -> None:
+        w = Workspace(
+            dirs={
+                self.tmpdir / "foo": "github/foo",
+                self.tmpdir / "github" / "bar": "github/bar",
+                self.tmpdir / "github" / "torchx": "",
+            }
+        )
+        self.assertDictEqual(
+            {
+                self.tmpdir / "foo": "github/foo",
+                self.tmpdir / "github" / "bar": "github/bar",
+                self.tmpdir / "github" / "torchx": "",
+            },
+            w.dirs,
+        )
+
+    def test_merge(self) -> None:
+        def assert_exists(outdir: Path, *path: str) -> None:
+            f = outdir / os.path.join(*path)
+            self.assertTrue(f.exists())
+            self.assertTrue(f.is_file())
+
+        self.touch("github", "torch", "pyproject.toml")
+        self.touch("github", "torch", "torch", "__init__.py")
+
+        self.touch("torchtitan", "pyproject.toml")
+        self.touch("torchtitan", "torchtitan", "__init__.py")
+
+        self.touch("github", "torchx", "README.md")
+        self.touch("github", "torchx", "torchx", "__init__.py")
+
+        outdir = self.tmpdir / "out"
+
+        Workspace(
+            dirs={
+                self.tmpdir / "github" / "torch": "torch",
+                self.tmpdir / "torchtitan": "torchtitan",
+                self.tmpdir / "github" / "torchx": "",
+            }
+        ).merge(outdir)
+
+        assert_exists(outdir, "torch", "pyproject.toml")
+        assert_exists(outdir, "torch", "torch", "__init__.py")
+
+        assert_exists(outdir, "torchtitan", "pyproject.toml")
+        assert_exists(outdir, "torchtitan", "torchtitan", "__init__.py")
+
+        assert_exists(outdir, "README.md")
+        assert_exists(outdir, "torchx", "__init__.py")
+
+    def test_null(self) -> None:
+        self.assertDictEqual({}, Workspace.null().dirs)
+        self.assertIsNone(Workspace.null().env)
+
+    def test_set_env_vars(self) -> None:
+        w = Workspace(
+            dirs={
+                self.tmpdir / "github" / "torch": "torch",
+                self.tmpdir / "torchtitan": "torchtitan",
+                self.tmpdir / "github" / "torchx": "",
+            },
+            env=None,
+        )
+
+        appdef = specs.AppDef(
+            name="test",
+            roles=[
+                specs.Role("0", "N/A", env={}),
+                specs.Role("1", "N/A", env={"WORKSPACE_DIR": "/tmp/workspace"}),
+                specs.Role("2", "N/A", env={"PYTHONPATH": "/do/not:/overwrite"}),
+                specs.Role(
+                    "3",
+                    "N/A",
+                    env={
+                        "PYTHONPATH": f"{specs.macros.img_root}/workspace/torch:/tmp/workspace"
+                    },
+                ),
+            ],
+        )
+
+        w.set_env_vars(appdef)
+
+        PYTHONPATH = ":".join(
+            [
+                f"{specs.macros.img_root}/workspace/torch",
+                f"{specs.macros.img_root}/workspace/torchtitan",
+                f"{specs.macros.img_root}/workspace/",
+            ]
+        )
+        WORKSPACE_DIR = f"{specs.macros.img_root}/workspace"
+
+        # -- check role0
+        role0 = appdef.roles[0]
+        self.assertEqual(WORKSPACE_DIR, role0.env["WORKSPACE_DIR"])
+        self.assertEqual(PYTHONPATH, role0.env["PYTHONPATH"])
+        self.assertNotIn("CONDA_DIR", role0.env)
+
+        # -- check role1
+        role1 = appdef.roles[1]
+        self.assertEqual("/tmp/workspace", role1.env["WORKSPACE_DIR"])
+        self.assertEqual(
+            "/tmp/workspace/torch:/tmp/workspace/torchtitan:/tmp/workspace/",
+            role1.env["PYTHONPATH"],
+        )
+        self.assertNotIn("CONDA_DIR", role1.env)
+
+        # -- check role2
+        role2 = appdef.roles[2]
+        self.assertEqual(WORKSPACE_DIR, role2.env["WORKSPACE_DIR"])
+        self.assertEqual(f"/do/not:/overwrite:{PYTHONPATH}", role2.env["PYTHONPATH"])
+        self.assertNotIn("CONDA_DIR", role2.env)
+
+        # -- check role3
+        role3 = appdef.roles[3]
+        self.assertEqual(WORKSPACE_DIR, role3.env["WORKSPACE_DIR"])
+        self.assertEqual(
+            ":".join(
+                [
+                    f"{specs.macros.img_root}/workspace/torch",
+                    "/tmp/workspace",
+                    f"{specs.macros.img_root}/workspace/torchtitan",
+                    f"{specs.macros.img_root}/workspace/",
+                ]
+            ),
+            role3.env["PYTHONPATH"],
+        )
+        self.assertNotIn("CONDA_DIR", role2.env)
+
+    def test_set_CONDA_DIR(self) -> None:
+        w = Workspace(env=CondaEnvironment(conda_prefix="_IGNORED_"))
+        appdef = specs.AppDef(
+            name="test",
+            roles=[
+                specs.Role("0", "N/A", env={}),
+                specs.Role("1", "N/A", env={"CONDA_DIR": "/do/not/overwrite"}),
+            ],
+        )
+
+        w.set_env_vars(appdef)
+
+        self.assertEqual(
+            f"{specs.macros.img_root}/conda", appdef.roles[0].env["CONDA_DIR"]
+        )
+        self.assertEqual("/do/not/overwrite", appdef.roles[1].env["CONDA_DIR"])

--- a/python/tests/tools/test_cli.py
+++ b/python/tests/tools/test_cli.py
@@ -12,7 +12,7 @@ import unittest
 from unittest import mock
 
 from monarch.tools.cli import config_from_cli_args, get_parser, main
-from monarch.tools.config import Config
+from monarch.tools.config import Config, Workspace
 from monarch.tools.mesh_spec import MeshSpec, ServerSpec
 
 from tests.tools.utils import capture_stdout
@@ -117,7 +117,7 @@ class TestCli(unittest.TestCase):
                     "mail-type": "FAIL",
                 },
                 dryrun=True,
-                workspace="/mnt/users/foo",
+                workspace=Workspace(dirs={"/mnt/users/foo": ""}),
             ),
             config,
         )


### PR DESCRIPTION
Summary:
Adds `Workspace` class in `monarch.tools.config.workspace` to use to define workspace configurations.

### Usage:

```
config = Config(...
  workspace=Workspace(...)
)
```
where `Workspace` can be defined as:

### single dir workspace
```
Workspace(dirs=["/home/kiuk/github/torchtitan"])
Workspace(dirs=[Path().home()/"github"/"torchtitan"]) # same thing using pathlib.Path
```

### multi-dir workspace
```
Workspace(dirs=[
  HOME/"github"/"torch",
  HOME/"github"/"torchtitan",
])
```

### multi-dir workspace with custom mapping
```
Workspace(dirs={
  HOME/"github"/"torch": "pytorch",
  HOME/"github"/"torchtitan": "github/torchtitan",
})
```

### flat-mapping into $WORKSPACE_DIR
```
Workspace(dirs={
  HOME/"github"/"torch": "",
})
```

### turn-off conda env sync
```
Workspace(dirs=[...] env=None)
```

### use role.image directly (no sync workspace, no sync env)
```
Workspace(env=None)
```

## NOTE:
1. We use `WORKSPACE_DIR` env var as the remote workspace directory root. Since `WORKSPACE_DIR` doesn't actually get resolved until job launch time, we query the env var from the running job description and set it as `workspace.remote_workspace_root`)

2. TODO set `PYTHONPATH` to include all workspace directories remotely

Reviewed By: highker

Differential Revision: D80752051
