### PR TITLE
run autocargo

### DIFF
--- a/monarch_rdma/examples/cuda_ping_pong/Cargo.toml
+++ b/monarch_rdma/examples/cuda_ping_pong/Cargo.toml
@@ -31,6 +31,6 @@ hyperactor = { version = "0.0.0", path = "../../../hyperactor" }
 hyperactor_mesh = { version = "0.0.0", path = "../../../hyperactor_mesh" }
 monarch_rdma = { version = "0.0.0", path = "../.." }
 serde = { version = "1.0.219", features = ["derive", "rc"] }
-tokio = { version = "1.46.1", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.47.1", features = ["full", "test-util", "tracing"] }
 tracing = { version = "0.1.41", features = ["attributes", "valuable"] }
 tracing-subscriber = { version = "0.3.19", features = ["chrono", "env-filter", "json", "local-time", "parking_lot", "registry"] }


### PR DESCRIPTION
Summary:
Fixing this issue:

```
`arc autocargo` resulted in changed files.

This happens because an autocargo enrolled project had changes to
relevant TARGETS (or related files) and `arc autocargo` was not run
to sync them to their `Cargo.toml`s.

Note: Enrollment in autocargo is something deliberately done by project
owners. If this is unexpected, consider unenrolling or partially excluding
your project. See https://fburl.com/autocargo

See the missing changes at
https://www.internalfb.com/.../3289ac7e82fc635870fddd47ba...

Or locally with:
hg up 3289ac7e82fc635870fddd47ba31bb302d1a213f
```

Reviewed By: fanzeyi

Differential Revision: D81003072


