### PR TITLE
Log the client error as a debug instead of an error

### DIFF
--- a/hyperactor/src/channel/net.rs
+++ b/hyperactor/src/channel/net.rs
@@ -772,7 +772,7 @@ impl<M: RemoteMessage> NetTx<M> {
                                 )
                             }
                             Err(err) => {
-                                tracing::error!(
+                                tracing::debug!(
                                     "session {}.{}: failed to connect: {}",
                                     link.dest(),
                                     session_id,


### PR DESCRIPTION
Summary: Todo is to add sampling and log it back as error / warning.

Differential Revision: D81061595


