### PR TITLE
[hyperactor] framer: don't rely on capacity for buffer lengths

### DIFF
--- a/hyperactor/proptest-regressions/channel/net/framed.txt
+++ b/hyperactor/proptest-regressions/channel/net/framed.txt
@@ -1,0 +1,9 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 87af2864d7673cb85da5e9bfbe7cbff7f6c43f5c2453457795ae3e728d140850 # shrinks to drips = [1]
+cc fd0ba176124ae2db3523693c9f44c40fd8971b80e049a5144def4a1db0855b07 # shrinks to msg = Message { body: Part(b""), parts: [Part(b"")], is_illegal: false }, drips = [1]
+cc 9fdba9bf99e30c0846ea7e6bf3da36811a59ab59aa1011698452db65b9811375 # shrinks to msg = Message { body: Part(b""), parts: [], is_illegal: false }, drips = [1]

--- a/hyperactor/proptest-regressions/channel/net/framed.txt
+++ b/hyperactor/proptest-regressions/channel/net/framed.txt
@@ -1,9 +1,0 @@
-# Seeds for failure cases proptest has generated in the past. It is
-# automatically read and these particular cases re-run before any
-# novel cases are generated.
-#
-# It is recommended to check this file in to source control so that
-# everyone who runs the test benefits from these saved cases.
-cc 87af2864d7673cb85da5e9bfbe7cbff7f6c43f5c2453457795ae3e728d140850 # shrinks to drips = [1]
-cc fd0ba176124ae2db3523693c9f44c40fd8971b80e049a5144def4a1db0855b07 # shrinks to msg = Message { body: Part(b""), parts: [Part(b"")], is_illegal: false }, drips = [1]
-cc 9fdba9bf99e30c0846ea7e6bf3da36811a59ab59aa1011698452db65b9811375 # shrinks to msg = Message { body: Part(b""), parts: [], is_illegal: false }, drips = [1]

--- a/hyperactor/src/channel/net/framed.rs
+++ b/hyperactor/src/channel/net/framed.rs
@@ -72,7 +72,6 @@ impl<R: AsyncRead + Unpin> FrameReader<R> {
             match &mut self.state {
                 FrameReaderState::ReadLen { buf, off } if *off < 8 => {
                     let n = self.reader.read(&mut buf[*off..]).await?;
-                    // Print the address of self as a pointer
                     *off += n;
                     assert!(*off <= 8);
 
@@ -112,7 +111,7 @@ impl<R: AsyncRead + Unpin> FrameReader<R> {
                         return Err(io::ErrorKind::UnexpectedEof.into());
                     }
                     *off += n;
-                    assert!(*off <= *len,)
+                    assert!(*off <= *len)
                 }
 
                 FrameReaderState::ReadBody { buf, off, len } => {

--- a/hyperactor/src/channel/net/framed.rs
+++ b/hyperactor/src/channel/net/framed.rs
@@ -30,9 +30,13 @@ pub struct FrameReader<R> {
 
 enum FrameReaderState {
     /// Accumulating 8-byte length prefix.
-    ReadLen { buf: BytesMut }, // buf.len() <= 8
+    ReadLen { buf: [u8; 8], off: usize },
     /// Accumulating body of exactly `len` bytes.
-    ReadBody { len: usize, buf: BytesMut }, // buf.len() <= len
+    ReadBody {
+        buf: Vec<u8>,
+        off: usize,
+        len: usize,
+    }, // off <= len
 }
 
 impl<R: AsyncRead + Unpin> FrameReader<R> {
@@ -43,7 +47,8 @@ impl<R: AsyncRead + Unpin> FrameReader<R> {
             reader,
             max_frame_length,
             state: FrameReaderState::ReadLen {
-                buf: BytesMut::with_capacity(8),
+                buf: [0; 8],
+                off: 0,
             },
         }
     }
@@ -65,17 +70,20 @@ impl<R: AsyncRead + Unpin> FrameReader<R> {
     pub async fn next(&mut self) -> io::Result<Option<Bytes>> {
         loop {
             match &mut self.state {
-                FrameReaderState::ReadLen { buf } if buf.len() < 8 => {
-                    let n = self.reader.read_buf(buf).await?;
+                FrameReaderState::ReadLen { buf, off } if *off < 8 => {
+                    let n = self.reader.read(&mut buf[*off..]).await?;
+                    // Print the address of self as a pointer
+                    *off += n;
+                    assert!(*off <= 8);
 
-                    // https://docs.rs/tokio/latest/tokio/io/trait.AsyncReadExt.html#method.read_buf
+                    // https://docs.rs/tokio/latest/tokio/io/trait.AsyncReadExt.html#method.read
                     // "This reader has reached its "end of file" and will likely no longer
                     // be able to produce bytes. Note that this does not mean that the reader
                     // will always no longer be able to produce bytes."
                     //
                     // In practice, this means EOF.
                     if n == 0 {
-                        if buf.is_empty() {
+                        if *off == 0 {
                             // We ended on a frame boundary. End of stream:
                             return Ok(None);
                         } else {
@@ -84,28 +92,35 @@ impl<R: AsyncRead + Unpin> FrameReader<R> {
                     }
                 }
 
-                FrameReaderState::ReadLen { buf } => {
-                    let len = buf.get_u64() as usize;
+                FrameReaderState::ReadLen { buf, off } => {
+                    assert_eq!(*off, 8);
+                    let len = (&buf[..]).get_u64() as usize;
                     if len > self.max_frame_length {
                         return Err(io::ErrorKind::InvalidData.into());
                     }
                     self.state = FrameReaderState::ReadBody {
+                        // TODO: allow for uninitialized fills
+                        buf: vec![0; len],
+                        off: 0,
                         len,
-                        buf: BytesMut::with_capacity(len),
                     };
                 }
 
-                FrameReaderState::ReadBody { len, buf } if buf.len() < *len => {
-                    let n = self.reader.read_buf(buf).await?;
+                FrameReaderState::ReadBody { buf, off, len } if *off < *len => {
+                    let n = self.reader.read(&mut buf[*off..*len]).await?;
                     if n == 0 {
                         return Err(io::ErrorKind::UnexpectedEof.into());
                     }
+                    *off += n;
+                    assert!(*off <= *len,)
                 }
 
-                FrameReaderState::ReadBody { len, buf } if buf.len() == *len => {
-                    let frame = take(buf).freeze();
+                FrameReaderState::ReadBody { buf, off, len } => {
+                    assert_eq!(*off, *len);
+                    let frame = take(buf).into();
                     self.state = FrameReaderState::ReadLen {
-                        buf: BytesMut::with_capacity(8),
+                        buf: [0; 8],
+                        off: 0,
                     };
                     return Ok(Some(frame));
                 }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #999
* #986
* #968

The contract for BytesMut::with_capacity (and also Vec::with_capacity) is that it returns a buffer of *at least* the requested length. The framer was relying on the capacity to denote the end of the buffer it was reading into.

Switch to explicitly managing both buffer limits.

Differential Revision: [D81089871](https://our.internmc.facebook.com/intern/diff/D81089871/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D81089871/)!