### PR TITLE
[hyperactor] channel example: make it into a flexible stress test

### DIFF
--- a/hyperactor/Cargo.toml
+++ b/hyperactor/Cargo.toml
@@ -32,6 +32,7 @@ backoff = { version = "0.4.0", features = ["futures", "tokio"] }
 bincode = "1.3.3"
 bytes = { version = "1.10", features = ["serde"] }
 cityhasher = "0.1.0"
+clap = { version = "4.5.42", features = ["derive", "env", "string", "unicode", "wrap_help"] }
 crc32fast = "1.4"
 criterion = { version = "0.5.1", features = ["async_tokio", "csv_output"] }
 dashmap = { version = "5.5.3", features = ["rayon", "serde"] }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #1002

With this change, we can stress channels better by running the server and client independently (and potentially on separate machines). By default, it runs in "infinite" mode, reporting stats every 1000 messages.

The idea is that we can use this as a test bench to try to replicate issues we see in production with channels.

Differential Revision: [D81099840](https://our.internmc.facebook.com/intern/diff/D81099840/)