### PR TITLE
[monarch, quick rfc] Less surprising actor lifetimes

### DIFF
--- a/monarch_hyperactor/src/mailbox.rs
+++ b/monarch_hyperactor/src/mailbox.rs
@@ -763,6 +763,8 @@ pub(crate) struct Instance {
     controller_controller: Option<PyObject>,
     #[pyo3(get, set)]
     rank: PyPoint,
+    #[pyo3(get, set, name = "_children")]
+    children: Option<PyObject>,
 }
 #[pymethods]
 impl Instance {
@@ -786,6 +788,7 @@ impl<A: hyperactor::Actor> From<&hyperactor::proc::Instance<A>> for Instance {
             proc_mesh: None,
             controller_controller: None,
             rank: PyPoint::new(0, Extent::unity().into()),
+            children: None,
         }
     }
 }
@@ -798,6 +801,7 @@ impl<A: hyperactor::Actor> From<&hyperactor::proc::Context<'_, A>> for Instance 
             proc_mesh: None,
             controller_controller: None,
             rank: cx.cast_info().into(),
+            children: None,
         }
     }
 }

--- a/python/monarch/_src/actor/actor_mesh.py
+++ b/python/monarch/_src/actor/actor_mesh.py
@@ -6,6 +6,7 @@
 
 # pyre-unsafe
 
+import abc
 import collections
 import contextvars
 import functools
@@ -14,6 +15,7 @@ import itertools
 import logging
 import random
 import traceback
+from abc import abstractmethod, abstractproperty
 from dataclasses import dataclass
 from traceback import TracebackException
 from typing import (
@@ -122,8 +124,8 @@ class Point(HyPoint, collections.abc.Mapping):
 
 
 @rust_struct("monarch_hyperactor::mailbox::Instance")
-class Instance:
-    @property
+class Instance(abc.ABC):
+    @abstractproperty
     def _mailbox(self) -> Mailbox:
         """
         This can be removed once we fix all the uses of mailbox to just use context instead.
@@ -137,37 +139,12 @@ class Instance:
         """
         return self.actor_id.proc_id
 
-    @property
+    @abstractproperty
     def actor_id(self) -> ActorId:
         """
         The actor_id of the current actor.
         """
         ...
-
-    @property
-    def rank(self) -> Point:
-        """
-        Every actor is spawned over some mesh of processes. This identifies the point in that mesh where
-        the current actor was spawned. In other words, it is the `monarch.current_rank()` of
-        The actors __init__ message.
-        """
-        ...
-
-    @rank.setter
-    def rank(self, value: Point) -> Point: ...
-
-    @property
-    def proc_mesh(self) -> "ProcMesh":
-        """
-        The proc mesh over which all actors in this mesh were launched.
-        """
-        ...
-
-    @proc_mesh.setter
-    def proc_mesh(self, value: "ProcMesh") -> None: ...
-
-    @proc_mesh.setter
-    def proc_mesh(self, value: "ProcMesh") -> None: ...
 
     @property
     def proc(self) -> "ProcMesh":
@@ -177,13 +154,24 @@ class Instance:
 
         return self.proc_mesh.slice(**self.rank)
 
-    @property
-    def _controller_controller(self) -> "_ControllerController": ...
+    """
+    Every actor is spawned over some mesh of processes. This identifies the point in that mesh where
+    the current actor was spawned. In other words, it is the `monarch.current_rank()` of
+    The actors __init__ message.
+    """
+    rank: Point
+    proc_mesh: "ProcMesh"
+    _controller_controller: "_ControllerController"
 
-    @_controller_controller.setter
-    def _controller_controller(
-        self, value: "Optional[_ControllerController]"
-    ) -> None: ...
+    # this property is used to hold the handles to actors and processes launched by this actor
+    # in order to keep them alive until this actor exits.
+    _children: "Optional[List[ActorMesh | ProcMesh]]"
+
+    def _add_child(self, child: "ActorMesh | ProcMesh") -> None:
+        if self._children is None:
+            self._children = [child]
+        else:
+            self._children.append(child)
 
 
 @rust_struct("monarch_hyperactor::mailbox::Context")

--- a/python/monarch/_src/actor/proc_mesh.py
+++ b/python/monarch/_src/actor/proc_mesh.py
@@ -320,7 +320,9 @@ class ProcMesh(MeshTrait, DeprecatedNotAFuture):
 
         pm = ProcMesh(hy_proc_mesh, shape)
         if _attach_controller_controller:
-            pm._controller_controller = context().actor_instance._controller_controller
+            instance = context().actor_instance
+            pm._controller_controller = instance._controller_controller
+            instance._add_child(pm)
 
         async def task(
             pm: "ProcMesh",
@@ -376,16 +378,18 @@ class ProcMesh(MeshTrait, DeprecatedNotAFuture):
             )
 
         actor_mesh = HyProcMesh.spawn_async(pm, name, _Actor, _use_standin_mesh())
+        instance = context().actor_instance
         service = ActorMesh._create(
             Class,
             actor_mesh,
-            context().actor_instance._mailbox,
+            instance._mailbox,
             self._shape,
             self,
             self._controller_controller,
             *args,
             **kwargs,
         )
+        instance._add_child(service)
         return cast(T, service)
 
     @property

--- a/python/tests/test_python_actors.py
+++ b/python/tests/test_python_actors.py
@@ -1333,3 +1333,25 @@ async def test_undeliverable_message() -> None:
 def test_this_and_that():
     counter = this_proc().spawn("counter", Counter, 7)
     assert 7 == counter.value.call_one().get()
+
+
+class ReceptorActor(Actor):
+    @endpoint
+    def status(self):
+        return 1
+
+
+async def test_things_survive_losing_python_reference() -> None:
+    """Test the slice_receptor_mesh function in LOCAL mode, verifying that setup methods are called."""
+
+    receptor = (
+        this_host()
+        .spawn_procs(per_host={"gpus": 1})
+        .spawn(
+            "receptor",
+            ReceptorActor,
+        )
+    )
+    receptor = receptor.slice(gpus=0)
+
+    await receptor.status.call()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #1013
* #1011
* __->__ #1006

This establishes that the lifetime of an actor or proc mesh is initially bound to the lifetime of the actor that spawned it.

In particular, an actor mesh or proc mesh will stop running when (1) its parent stops, or (2) its parent explicitly calls stop on it.

This replaces the previous surprising behavior where an actor_mesh/proc_mesh would stop once there was no remaining external reference to it.  This led to errors where renaming dimensions, slicing, or creating a proc with only one actor on it caused the thing to stop immediately.

Differential Revision: [D81141365](https://our.internmc.facebook.com/intern/diff/D81141365/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D81141365/)!