### PR TITLE
Add metric and mesarue full occourances on NetRx's mspc channel

### DIFF
--- a/hyperactor/src/config.rs
+++ b/hyperactor/src/config.rs
@@ -56,6 +56,9 @@ declare_attrs! {
 
     /// Whether to use multipart encoding for network channel communications.
     pub attr CHANNEL_MULTIPART: bool = false;
+
+    /// How often to check for full MSPC channel on NetRx.
+    pub attr CHANNEL_NET_RX_BUFFER_FULL_CHECK_INTERVAL: Duration = Duration::from_secs(5);
 }
 
 /// Load configuration from environment variables

--- a/hyperactor/src/metrics.rs
+++ b/hyperactor/src/metrics.rs
@@ -48,6 +48,11 @@ declare_static_counter!(CHANNEL_CONNECTIONS, "channel.connections");
 declare_static_counter!(CHANNEL_CONNECTION_ERRORS, "channel.connection_errors");
 // Tracks the number of channel reconnection attempts
 declare_static_counter!(CHANNEL_RECONNECTIONS, "channel.reconnections");
+// Tracks the number of NetRx encountering full buffer, i.e. its mspc channel.
+
+// This metric counts how often the NetRx→client mpsc channel remains full,
+// incrementing once per CHANNEL_NET_RX_BUFFER_FULL_CHECK_INTERVAL while blocked.
+declare_static_counter!(CHANNEL_NET_RX_BUFFER_FULL, "channel.net_rx_buffer_full");
 
 // PROC MESH
 // Tracks the number of active processes in the process mesh


### PR DESCRIPTION
Summary:
We currently do not have any observability when NetRx is blocked on its mspc::channel

https://www.internalfb.com/code/fbsource/[6b9c4478772d18bc091c432b4dd87d679935546f]/fbcode/monarch/hyperactor/src/channel/net.rs?lines=1185

This diff adds a metric for that.

Reviewed By: shayne-fletcher

Differential Revision: D81133714


