### PR TITLE
Make sure cuda is not initialized by us on proc start.

### DIFF
--- a/python/monarch/_src/actor/proc_mesh.py
+++ b/python/monarch/_src/actor/proc_mesh.py
@@ -72,18 +72,20 @@ from monarch.tools.config import Workspace
 from monarch.tools.utils import conda as conda_utils
 
 
-HAS_TENSOR_ENGINE = False
-try:
-    # Torch is needed for tensor engine
-    import torch  # @manual
+@cache
+def _has_tensor_engine() -> bool:
+    try:
+        # Torch is needed for tensor engine
+        import torch  # @manual
 
-    # Confirm that rust bindings were built with tensor engine enabled
-    from monarch._rust_bindings.rdma import _RdmaManager  # noqa
+        # Confirm that rust bindings were built with tensor engine enabled
+        from monarch._rust_bindings.rdma import _RdmaManager  # noqa
 
-    # type: ignore[16]
-    HAS_TENSOR_ENGINE = torch.cuda.is_available()
-except ImportError:
-    logging.warning("Tensor engine is not available on this platform")
+        # type: ignore[16]
+        return torch.cuda.is_available()
+    except ImportError:
+        logging.warning("Tensor engine is not available on this platform")
+        return False
 
 
 if TYPE_CHECKING:
@@ -364,6 +366,9 @@ class ProcMesh(MeshTrait, DeprecatedNotAFuture):
     ) -> T:
         return self._spawn_nonblocking_on(self._proc_mesh, name, Class, *args, **kwargs)
 
+    def to_table(self) -> str:
+        return self._device_mesh.to_table()
+
     def _spawn_nonblocking_on(
         self,
         pm: "Shared[HyProcMesh]",
@@ -394,7 +399,7 @@ class ProcMesh(MeshTrait, DeprecatedNotAFuture):
 
     @property
     def _device_mesh(self) -> "DeviceMesh":
-        if not HAS_TENSOR_ENGINE:
+        if not _has_tensor_engine():
             raise RuntimeError(
                 "DeviceMesh is not available because tensor_engine was not compiled (USE_TENSOR_ENGINE=0)"
             )

--- a/python/tests/test_python_actors.py
+++ b/python/tests/test_python_actors.py
@@ -1355,3 +1355,24 @@ async def test_things_survive_losing_python_reference() -> None:
     receptor = receptor.slice(gpus=0)
 
     await receptor.status.call()
+
+
+class IsInit(Actor):
+    @endpoint
+    def is_cuda_initialized(self) -> bool:
+        import ctypes
+
+        cuda = ctypes.CDLL("libcuda.so")
+        CUresult = ctypes.c_int
+        cuDeviceGetCount = cuda.cuDeviceGetCount
+        cuDeviceGetCount.argtypes = [ctypes.POINTER(ctypes.c_int)]
+        cuDeviceGetCount.restype = CUresult
+        count = ctypes.c_int()
+        result = cuDeviceGetCount(ctypes.byref(count))
+        CUDA_ERROR_NOT_INITIALIZED = 3
+        return result == CUDA_ERROR_NOT_INITIALIZED
+
+
+def test_cuda_is_not_initialized_in_a_new_proc():
+    proc = this_host().spawn_procs().spawn("is_init", IsInit)
+    assert not proc.is_cuda_initialized.call_one().get()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #1011

Previously querying HAS_TENSOR_ENGINE eagerly slowed now init, and made it impossible to set CUDA_VISIBLE_DEVICES before an actor started running.

Differential Revision: [D81172530](https://our.internmc.facebook.com/intern/diff/D81172530/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D81172530/)!