### PR TITLE
(monarch/tools) print UI URL of job in get_or_create

### DIFF
--- a/python/monarch/tools/commands.py
+++ b/python/monarch/tools/commands.py
@@ -182,12 +182,14 @@ def info(server_handle: str) -> Optional[ServerSpec]:
         mesh_specs.append(spec)
 
     scheduler, namespace, _ = parse_app_handle(server_handle)
+
     return ServerSpec(
         name=appdef.name,
         state=status.state,
         meshes=mesh_specs,
         scheduler=scheduler,
         namespace=namespace,
+        ui_url=status.ui_url,
     )
 
 
@@ -320,7 +322,6 @@ async def get_or_create(
             )
 
         print(f"{CYAN}New job `{new_server_handle}` is ready to serve.{ENDC}")
-        return server_info
     else:
         print(f"{CYAN}Found existing job `{server_handle}` ready to serve.{ENDC}")
 
@@ -329,7 +330,10 @@ async def get_or_create(
             kill(server_handle)
             server_info = await get_or_create(name, config, check_interval)
 
-        return server_info
+    if server_info.ui_url:  # not all schedulers have a UI URL
+        print(f"{CYAN}Job URL: {server_info.ui_url}{ENDC}")
+
+    return server_info
 
 
 def kill(server_handle: str) -> None:

--- a/python/monarch/tools/mesh_spec.py
+++ b/python/monarch/tools/mesh_spec.py
@@ -128,6 +128,7 @@ class ServerSpec:
     meshes: list[MeshSpec]
     scheduler: str
     namespace: str = ""
+    ui_url: Optional[str] = None
 
     @property
     def server_handle(self) -> str:
@@ -210,6 +211,7 @@ class ServerSpec:
         return {
             "name": self.name,
             "server_handle": self.server_handle,
+            **({"ui_url": self.ui_url} if self.ui_url else {}),
             "state": self.state.name,
             "meshes": {
                 mesh.name: {


### PR DESCRIPTION
Summary: Prints the job's UI URL in `monarch.tools.commands.get_or_create()` if one is available. Note that not all schedulers have a UI.

Differential Revision: D81175222


