### PR TITLE
: channel example: fix docs issue

### DIFF
--- a/hyperactor/example/channel.rs
+++ b/hyperactor/example/channel.rs
@@ -87,9 +87,7 @@ async fn client(
     #[allow(clippy::disallowed_methods)]
     let start = Instant::now();
     for i in 0usize.. {
-        if let Some(num_iter) = num_iter
-            && i >= num_iter
-        {
+        if num_iter.is_some_and(|n| i >= n) {
             break;
         }
 


### PR DESCRIPTION
Summary:
the docs deployment job broke since D81099840 landed (example https://github.com/meta-pytorch/monarch/actions/runs/17279785335). 

the error log showed
```
error[E0658]: 'let' expressions in this position are unstable at hyperactor/example/channel.rs:90:12, with the hint to enable #![feature(let_chains)] (which you can’t on stable). 
```
followed by 
```
error: could not document 'hyperactor'
```
that is, this pattern,
```rust
for i in 0usize.. {
    if let Some(num_iter) = num_iter
        && i >= num_iter
    {
        break;
    }
    // ...
}
```
which is a let-chain and apparently nightly-only - the rustdoc step runs on stable.

i rewrote the relevant code to not use a let-chain.

Differential Revision: D81178946


