### PR TITLE
rust macro to capture latency and success metrics for async methods (#961)

### DIFF
--- a/hyperactor/src/lib.rs
+++ b/hyperactor/src/lib.rs
@@ -131,6 +131,7 @@ pub use hyperactor_macros::forward;
 pub use hyperactor_macros::instrument;
 #[doc(inline)]
 pub use hyperactor_macros::instrument_infallible;
+pub use hyperactor_macros::observe;
 pub use hyperactor_telemetry::declare_static_counter;
 pub use hyperactor_telemetry::declare_static_gauge;
 pub use hyperactor_telemetry::declare_static_histogram;

--- a/hyperactor/src/proc.rs
+++ b/hyperactor/src/proc.rs
@@ -448,6 +448,7 @@ impl Proc {
 
     /// Spawn a named (root) actor on this proc. The name of the actor must be
     /// unique.
+    #[hyperactor::observe("proc")]
     pub async fn spawn<A: Actor>(
         &self,
         name: &str,

--- a/hyperactor_macros/Cargo.toml
+++ b/hyperactor_macros/Cargo.toml
@@ -29,6 +29,8 @@ syn = { version = "2.0.101", features = ["extra-traits", "fold", "full", "visit"
 anyhow = "1.0.98"
 async-trait = "0.1.86"
 hyperactor = { version = "0.0.0", path = "../hyperactor" }
+hyperactor_telemetry = { version = "0.0.0", path = "../hyperactor_telemetry" }
+opentelemetry = "0.29"
 serde = { version = "1.0.185", features = ["derive", "rc"] }
 static_assertions = "1.1.0"
 timed_test = { version = "0.0.0", path = "../timed_test" }

--- a/hyperactor_macros/tests/basic.rs
+++ b/hyperactor_macros/tests/basic.rs
@@ -24,6 +24,7 @@ use hyperactor::RefClient;
 use hyperactor::forward;
 use hyperactor::instrument;
 use hyperactor::instrument_infallible;
+use hyperactor::observe;
 use serde::Deserialize;
 use serde::Serialize;
 

--- a/hyperactor_mesh/Cargo.toml
+++ b/hyperactor_mesh/Cargo.toml
@@ -56,6 +56,7 @@ libc = "0.2.139"
 mockall = "0.13.1"
 ndslice = { version = "0.0.0", path = "../ndslice" }
 nix = { version = "0.30.1", features = ["dir", "event", "hostname", "inotify", "ioctl", "mman", "mount", "net", "poll", "ptrace", "reboot", "resource", "sched", "signal", "term", "time", "user", "zerocopy"] }
+opentelemetry = "0.29"
 pin-project = "1.1.10"
 preempt_rwlock = { version = "0.0.0", path = "../preempt_rwlock" }
 rand = { version = "0.8", features = ["small_rng"] }

--- a/hyperactor_mesh/src/alloc/remoteprocess.rs
+++ b/hyperactor_mesh/src/alloc/remoteprocess.rs
@@ -35,6 +35,7 @@ use hyperactor::clock::RealClock;
 use hyperactor::config;
 use hyperactor::mailbox::DialMailboxRouter;
 use hyperactor::mailbox::MailboxServer;
+use hyperactor::observe;
 use hyperactor::reference::Reference;
 use hyperactor::serde_json;
 use mockall::automock;
@@ -180,6 +181,7 @@ impl RemoteProcessAllocator {
             handle: JoinHandle<()>,
             cancel_token: CancellationToken,
         }
+        #[observe("remote_process")]
         async fn ensure_previous_alloc_stopped(active_allocation: &mut Option<ActiveAllocation>) {
             if let Some(active_allocation) = active_allocation.take() {
                 tracing::info!("previous alloc found, stopping");
@@ -291,6 +293,7 @@ impl RemoteProcessAllocator {
         Ok(())
     }
 
+    #[observe("remote_process")]
     async fn handle_allocation_request(
         alloc: Box<dyn Alloc + Send + Sync>,
         view: Region,
@@ -597,6 +600,7 @@ impl RemoteProcessAlloc {
     /// to obtain a list of allocate hosts. Then Allocate message will be sent to all
     /// RemoteProcessAllocator on all hosts. Heartbeats will be used to maintain health
     /// status of remote hosts.
+    #[observe("remote_process")]
     pub async fn new(
         spec: AllocSpec,
         world_id: WorldId,

--- a/hyperactor_mesh/src/proc_mesh/mesh_agent.rs
+++ b/hyperactor_mesh/src/proc_mesh/mesh_agent.rs
@@ -43,6 +43,7 @@ use hyperactor::mailbox::MailboxClient;
 use hyperactor::mailbox::MailboxSender;
 use hyperactor::mailbox::MessageEnvelope;
 use hyperactor::mailbox::Undeliverable;
+use hyperactor::observe;
 use hyperactor::proc::Proc;
 use hyperactor::supervision::ActorSupervisionEvent;
 use serde::Deserialize;
@@ -124,7 +125,7 @@ pub struct MeshAgent {
 }
 
 impl MeshAgent {
-    #[hyperactor::instrument]
+    #[hyperactor::observe("mesh_agent")]
     pub(crate) async fn bootstrap(
         proc_id: ProcId,
     ) -> Result<(Proc, ActorHandle<Self>), anyhow::Error> {
@@ -143,7 +144,6 @@ impl MeshAgent {
             supervisor: None, // not yet assigned
         };
         let handle = proc.spawn::<Self>("mesh", agent).await?;
-        tracing::info!("bootstrap_end");
         Ok((proc, handle))
     }
 }


### PR DESCRIPTION
Summary:

Adding a new macro called "observe", which adds latency, success and error metrics to the annotated methods. It only works on async methods for now. Will follow up and also include tracing as part of these.


Differential Revision: D80296789
