### PR TITLE
: actor_mesh: fix test

### DIFF
--- a/hyperactor_mesh/src/actor_mesh.rs
+++ b/hyperactor_mesh/src/actor_mesh.rs
@@ -993,13 +993,18 @@ mod tests {
 
             #[tokio::test]
             async fn test_send_with_headers() {
+                let extent = extent!(replica = 3);
                 let alloc = $allocator
                     .allocate(AllocSpec {
-                        extent: extent!(replica = 1 ),
+                        extent: extent.clone(),
                         constraints: Default::default(),
                     })
                     .await
                     .unwrap();
+                // TODO: Replace `Shape` with `Extent` in
+                // `set_cast_info_on_headers` (and wherever else - it
+                // is to be retired).
+                let shape = Shape::new(extent.labels().to_vec(), extent.to_slice()).unwrap();
 
                 let mesh = ProcMesh::allocate(alloc).await.unwrap();
                 let (reply_port_handle, mut reply_port_receiver) = mesh.client().open_port::<usize>();
@@ -1008,17 +1013,17 @@ mod tests {
                 let actor_mesh: RootActorMesh<TestActor> = mesh.spawn("test", &()).await.unwrap();
                 let actor_ref = actor_mesh.get(0).unwrap();
                 let mut headers = Attrs::new();
-                set_cast_info_on_headers(&mut headers, 0, Shape::unity(), mesh.client().actor_id().clone());
+                set_cast_info_on_headers(&mut headers, 0, shape.clone(), mesh.client().actor_id().clone());
                 actor_ref.send_with_headers(mesh.client(), headers.clone(), GetRank(true, reply_port.clone())).unwrap();
                 assert_eq!(0, reply_port_receiver.recv().await.unwrap());
 
-                set_cast_info_on_headers(&mut headers, 1, Shape::unity(), mesh.client().actor_id().clone());
+                set_cast_info_on_headers(&mut headers, 1, shape.clone(), mesh.client().actor_id().clone());
                 actor_ref.port()
                     .send_with_headers(mesh.client(), headers.clone(), GetRank(true, reply_port.clone()))
                     .unwrap();
                 assert_eq!(1, reply_port_receiver.recv().await.unwrap());
 
-                set_cast_info_on_headers(&mut headers, 2, Shape::unity(), mesh.client().actor_id().clone());
+                set_cast_info_on_headers(&mut headers, 2, shape.clone(), mesh.client().actor_id().clone());
                 actor_ref.actor_id()
                     .port_id(GetRank::port())
                     .send_with_headers(

--- a/ndslice/src/view.rs
+++ b/ndslice/src/view.rs
@@ -202,7 +202,7 @@ impl Extent {
         Slice::new_row_major(self.sizes())
     }
 
-    /// Iterate over this extens labels and sizes.
+    /// Iterate over this extent's labels and sizes.
     pub fn iter(&self) -> impl Iterator<Item = (String, usize)> + use<'_> {
         self.labels()
             .iter()
@@ -441,7 +441,7 @@ pub enum ViewError {
 }
 
 /// `Region` describes a region of a possibly-larger space of ranks, organized into
-/// a hyperrect.  
+/// a hyperrect.
 ///
 /// Internally, region consist of a set of labels and a [`Slice`], as it allows for
 /// a compact but useful representation of the ranks. However, this representation


### PR DESCRIPTION
Summary: this diff fixes `test_send_with_headers`, which previously "worked by accident" even while passing inconsistent `(rank, Shape::unity())` pairs. with rank validation added in D80664909 the bug was exposed; we now use a valid 3-replica `Extent`. also fixes a doc typo in view.rs.

Differential Revision: D81229528


