### PR TITLE
(monarch/code_sync) re-enable sync_workspace tests in CI after fixing rsync bin path

### DIFF
--- a/python/tests/_monarch/test_proc_mesh.py
+++ b/python/tests/_monarch/test_proc_mesh.py
@@ -16,8 +16,6 @@ import unittest
 from pathlib import Path
 from typing import Generator
 
-import pytest
-
 from monarch._rust_bindings.monarch_hyperactor.alloc import AllocConstraints, AllocSpec
 from monarch._rust_bindings.monarch_hyperactor.channel import (
     ChannelAddr,
@@ -74,8 +72,6 @@ class TestSyncWorkspace(unittest.IsolatedAsyncioTestCase):
     def tearDown(self) -> None:
         shutil.rmtree(self.tmpdir)
 
-    # oss_skip: TODO kiuk@ fails in CI due to rsync binary not found
-    @pytest.mark.oss_skip  # pyre-ignore[56]
     async def test_sync_workspace(self) -> None:
         local_workspace_dir = self.tmpdir / "local" / "github" / "torch"
         local_workspace_dir.mkdir(parents=True)

--- a/python/tests/test_python_actors.py
+++ b/python/tests/test_python_actors.py
@@ -1167,8 +1167,6 @@ class LsActor(Actor):
         return os.listdir(self.workspace)
 
 
-# oss_skip: TODO kiuk@ fails in CI due to rsync binary not found
-@pytest.mark.oss_skip
 async def test_sync_workspace() -> None:
     # create two workspaces: one for local and one for remote
     with tempfile.TemporaryDirectory() as workspace_src, tempfile.TemporaryDirectory() as workspace_dst:

--- a/scripts/common-setup.sh
+++ b/scripts/common-setup.sh
@@ -44,6 +44,7 @@ install_build_dependencies() {
 install_python_test_dependencies() {
     echo "Installing test dependencies..."
     pip install -r python/tests/requirements.txt
+    dnf install -y rsync # required for code sync tests
 }
 
 # Install wheel from artifact directory


### PR DESCRIPTION
Differential Revision: D81244554
