### PR TITLE
Fix redundant information in doc

### DIFF
--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -29,7 +29,7 @@ Here are some suggested steps to get started with Monarch:
 
 1. **Learn the Basics**: Check out the [Getting Started](get_started) guide to learn the basics of Monarch
 2. **Explore Examples**: Review the [Examples](./generated/examples/index) to see Monarch in action
-3. **Dive Deeper**: Explore the API Documentation(rust-api) for more detailed information:
+3. **Dive Deeper**: Explore the API Documentation for more detailed information:
     - [Python API](api/index)
     - [Rust API](rust-api)
 


### PR DESCRIPTION
Summary:
The line was supposed to introduce the bulleted list below, which already includes separate links for both Python API and Rust API documentation.


(I'm tring to use this PR to get myself familiar with Monarch OSS dev workflow)

Reviewed By: highker

Differential Revision: D81254564


