### PR TITLE
Trace id for mailbox message posts

### DIFF
--- a/hyperactor_telemetry/src/lib.rs
+++ b/hyperactor_telemetry/src/lib.rs
@@ -645,6 +645,7 @@ pub mod env {
     pub const MAST_HPC_JOB_NAME_ENV: &str = "MAST_HPC_JOB_NAME";
     pub const OTEL_EXPORTER: &str = "HYPERACTOR_OTEL_EXPORTER";
     pub const MAST_ENVIRONMENT: &str = "MAST_ENVIRONMENT";
+    pub const HYPERACTOR_MESSAGE_TRACE_ENABLED: &str = "HYPERACTOR_MESSAGE_TRACE_ENABLED";
 
     /// Forward or generate a uuid for this execution. When running in production on mast, this is provided to
     /// us via the MAST_HPC_JOB_NAME env var. Subprocesses should either forward the MAST_HPC_JOB_NAME

--- a/hyperactor_telemetry/src/trace.rs
+++ b/hyperactor_telemetry/src/trace.rs
@@ -8,9 +8,32 @@
 
 use std::env;
 
+use rand::Rng;
+use rand::distributions::Alphanumeric;
+
 use crate::env::execution_id;
 
 const MONARCH_CLIENT_TRACE_ID: &str = "MONARCH_CLIENT_TRACE_ID";
+pub const HYPERACTOR_MESSAGE_TRACE_ENABLED: &str = "HYPERACTOR_MESSAGE_TRACE_ENABLED";
+
+pub fn is_message_tracing_enabled() -> bool {
+    if let Ok(val) = env::var(HYPERACTOR_MESSAGE_TRACE_ENABLED) {
+        if val == "1" || val.to_lowercase() == "true" {
+            return true;
+        }
+    }
+
+    false
+}
+
+pub fn generate_new_message_trace() -> String {
+    let new_trace_id: String = rand::thread_rng()
+        .sample_iter(&Alphanumeric)
+        .take(24)
+        .map(char::from)
+        .collect();
+    new_trace_id
+}
 
 /// Returns the current trace ID if it exists, or None if it doesn't.
 /// This function does not create a new trace ID if one doesn't exist.


### PR DESCRIPTION
Summary:
1. Moved around some counters for mailbox posts, and added a field which can log what kind of Mailbox the post was in 
2. Moved around counters for Undeliverable messages 
3. Based on an environment variable, added a trace id to the messages to be able to track which one did not make it all the way through

Differential Revision: D81202328


