### PR TITLE
no stdout/stderr redirect for local runs

### DIFF
--- a/hyperactor_mesh/src/logging.rs
+++ b/hyperactor_mesh/src/logging.rs
@@ -426,11 +426,11 @@ fn get_local_log_destination(
 ) -> Result<Box<dyn io::AsyncWrite + Send + Unpin>> {
     let env: env::Env = env::Env::current();
     Ok(match env {
-        env::Env::Test => match output_target {
+        env::Env::Test | env::Env::Local => match output_target {
             OutputTarget::Stdout => Box::new(LinePrefixingWriter::new(local_rank, io::stdout())),
             OutputTarget::Stderr => Box::new(LinePrefixingWriter::new(local_rank, io::stderr())),
         },
-        env::Env::Local | env::Env::MastEmulator | env::Env::Mast => {
+        env::Env::MastEmulator | env::Env::Mast => {
             create_file_writer(local_rank, output_target, env)?
         }
     })

--- a/python/tests/test_python_actors.py
+++ b/python/tests/test_python_actors.py
@@ -1007,7 +1007,9 @@ async def test_flush_on_disable_aggregation() -> None:
         ), stdout_content
 
         # 10 = 5 log lines * 2 procs
-        assert len(re.findall(r"single log line", stdout_content)) == 10, stdout_content
+        assert (
+            len(re.findall(r"\[.* [0-9]+\] single log line", stdout_content)) == 10
+        ), stdout_content
 
     finally:
         # Ensure file descriptors are restored even if something goes wrong


### PR DESCRIPTION
Summary:
just print stdout/stderr to wherever the system decides to for local
runs.

Reviewed By: zdevito, mariusae

Differential Revision: D81262726


