### PR TITLE
Fix broken sim tests

### DIFF
--- a/hyperactor/src/channel/sim.rs
+++ b/hyperactor/src/channel/sim.rs
@@ -140,7 +140,7 @@ impl MessageDeliveryEvent {
 
 #[async_trait]
 impl Event for MessageDeliveryEvent {
-    async fn handle(&mut self) -> Result<(), SimNetError> {
+    async fn handle(&self) -> Result<(), SimNetError> {
         // Send the message to the correct receiver.
         SENDER
             .send(self.dest_addr.clone(), self.data.clone())

--- a/hyperactor/src/simnet.rs
+++ b/hyperactor/src/simnet.rs
@@ -93,12 +93,12 @@ pub trait Event: Send + Sync + Debug {
     /// For a proc spawn, it will be creating the proc object and instantiating it.
     /// For any event that manipulates the network (like adding/removing nodes etc.)
     /// implement handle_network().
-    async fn handle(&mut self) -> Result<(), SimNetError>;
+    async fn handle(&self) -> Result<(), SimNetError>;
 
     /// This is the method that will be called when the simulator fires the event
     /// Unless you need to make changes to the network, you do not have to implement this.
     /// Only implement handle() method for all non-simnet requirements.
-    async fn handle_network(&mut self, _phantom: &SimNet) -> Result<(), SimNetError> {
+    async fn handle_network(&self, _phantom: &SimNet) -> Result<(), SimNetError> {
         self.handle().await
     }
 
@@ -119,11 +119,11 @@ struct NodeJoinEvent {
 
 #[async_trait]
 impl Event for NodeJoinEvent {
-    async fn handle(&mut self) -> Result<(), SimNetError> {
+    async fn handle(&self) -> Result<(), SimNetError> {
         Ok(())
     }
 
-    async fn handle_network(&mut self, _simnet: &SimNet) -> Result<(), SimNetError> {
+    async fn handle_network(&self, _simnet: &SimNet) -> Result<(), SimNetError> {
         self.handle().await
     }
 
@@ -149,11 +149,11 @@ pub struct TorchOpEvent {
 
 #[async_trait]
 impl Event for TorchOpEvent {
-    async fn handle(&mut self) -> Result<(), SimNetError> {
+    async fn handle(&self) -> Result<(), SimNetError> {
         Ok(())
     }
 
-    async fn handle_network(&mut self, _simnet: &SimNet) -> Result<(), SimNetError> {
+    async fn handle_network(&self, _simnet: &SimNet) -> Result<(), SimNetError> {
         self.done_tx
             .clone()
             .send(&self.mailbox, ())
@@ -196,6 +196,50 @@ impl TorchOpEvent {
             kwargs_string,
             worker_actor_id,
         })
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct SleepEvent {
+    done_tx: OncePortRef<()>,
+    mailbox: Mailbox,
+    duration: tokio::time::Duration,
+}
+
+impl SleepEvent {
+    pub(crate) fn new(
+        done_tx: OncePortRef<()>,
+        mailbox: Mailbox,
+        duration: tokio::time::Duration,
+    ) -> Box<Self> {
+        Box::new(Self {
+            done_tx,
+            mailbox,
+            duration,
+        })
+    }
+}
+
+#[async_trait]
+impl Event for SleepEvent {
+    async fn handle(&self) -> Result<(), SimNetError> {
+        Ok(())
+    }
+
+    async fn handle_network(&self, _simnet: &SimNet) -> Result<(), SimNetError> {
+        self.done_tx
+            .clone()
+            .send(&self.mailbox, ())
+            .map_err(|_err| SimNetError::Closed("TODO".to_string()))?;
+        Ok(())
+    }
+
+    fn duration(&self) -> tokio::time::Duration {
+        self.duration
+    }
+
+    fn summary(&self) -> String {
+        format!("Sleeping for {} ms", self.duration.as_millis())
     }
 }
 
@@ -251,10 +295,6 @@ pub enum SimNetError {
     /// SimnetHandle being accessed without starting simnet
     #[error("simnet not started")]
     NotStarted,
-
-    /// A task has panicked.
-    #[error("panicked task")]
-    PanickedTask,
 }
 
 struct State {
@@ -768,7 +808,7 @@ impl SimNet {
                     training_script_waiting_time += advanced_time;
                 }
                 SimClock.advance_to(scheduled_time);
-                for mut scheduled_event in scheduled_events {
+                for scheduled_event in scheduled_events {
                     self.pending_event_count
                         .fetch_sub(1, std::sync::atomic::Ordering::SeqCst);
                     if scheduled_event.event.handle_network(self).await.is_err() {
@@ -844,7 +884,7 @@ mod tests {
 
     #[async_trait]
     impl Event for MessageDeliveryEvent {
-        async fn handle(&mut self) -> Result<(), simnet::SimNetError> {
+        async fn handle(&self) -> Result<(), simnet::SimNetError> {
             if let Some(dispatcher) = &self.dispatcher {
                 dispatcher
                     .send(self.dest_addr.clone(), self.data.clone())


### PR DESCRIPTION
Summary:
Revert of D80029571  which broke simulator tests.

Panicking on `rx.recv().await.unwrap();`
```
 async fn non_advancing_sleep(&self, duration: tokio::time::Duration) {
        let mailbox = SimClock::mailbox().clone();
        let (tx, rx) = mailbox.open_once_port::<()>();

        simnet_handle()
            .unwrap()
            .send_nonadvanceable_event(SleepEvent::new(tx.bind(), mailbox, duration))
            .unwrap();
        rx.recv().await.unwrap();
    }
```



Reverting for now until Thomas is back, cannot simply unland since diff is part of a stack

Differential Revision: D81265952


