### PR TITLE
(bugfix)(monarch/tools) make sure server_info.host0() returns node 0's hostname

### DIFF
--- a/python/monarch/tools/commands.py
+++ b/python/monarch/tools/commands.py
@@ -188,7 +188,11 @@ def info(server_handle: str) -> Optional[ServerSpec]:
 
         # null-guard since some schedulers do not fill replica_status
         if host_status := replica_status.get(role.name):
-            spec.hostnames = [h.hostname for h in host_status]
+            # make sure the hostnames are sorted by their respective node indexes
+            # this makes ServerSpec.host0 return hostname of node 0
+            spec.hostnames = [
+                h.hostname for h in sorted(host_status, key=lambda h: h.id)
+            ]
             # the mesh status is based on the "least progressive" replica status
             spec.state = min(h.state for h in host_status)
 


### PR DESCRIPTION
Summary:
Makes sure that `server_info.host0("mesh_name")` returns the hostname of machine 0 where 0 is the scheduler assigned index of the machine within the job/task-group.

In short, makes this possible:

```
 
server_info = get_or_create(...)
# ... create alloc (code omitted for brevity) ...
proc_mesh = ProcMesh.from_alloc(alloc)

master_addr = server_info.host0(mesh_name)
master_port = 29950

proc_mesh.spawn("PTD", SPMDStyleActor).fn(master_addr, master_port)

# where SPMDStyleActor#fn() is:

def fn(master_addr, master_port):
  import os
  os.environ["MASTER_ADDR"] = master_addr
  os.environ["MASTER_PORT"] = str(master_port)
  os.environ["RANK"] = current_rank().rank
  os.environ["WORLD_SIZE"] = math.prod(math.prod(current_size().values())

  dist.init_process_group(backend="nccl/gloo") 
```

This ensures that `server_info.host0` can be used to set `MASTER_ADDR` since `RANK` is typically set to `current_rank().rank` (which is node-idx-stable - that is, rank0 runs on node 0) and PTD's `init_process_group()` creates a c10d store on rank0 and  on non-rank0 tries to connect to the c10d store server on `MASTER_ADDR` therefore MASTER_ADDR should be the machine that is running rank0

Does this by simply sorting the hostnames by their respective `id` (e.g. node index) when adding the hostnames from the `ReplicaStatus` struct into `MeshSpec.hostnames` list.

Reviewed By: moonli

Differential Revision: D81266709


