### PR TITLE
alloc-based log stream to client

### DIFF
--- a/python/monarch/_src/actor/logging.py
+++ b/python/monarch/_src/actor/logging.py
@@ -35,14 +35,14 @@ class LoggingManager:
         self._logging_mesh_client: LoggingMeshClient | None = None
         self._ipython_flush_logs_handler: Callable[..., None] | None = None
 
-    async def init(self, proc_mesh: HyProcMesh) -> None:
+    async def init(self, proc_mesh: HyProcMesh, stream_to_client: bool) -> None:
         if self._logging_mesh_client is not None:
             return
 
         self._logging_mesh_client = await LoggingMeshClient.spawn(proc_mesh=proc_mesh)
         self._logging_mesh_client.set_mode(
-            stream_to_client=True,
-            aggregate_window_sec=3,
+            stream_to_client=stream_to_client,
+            aggregate_window_sec=3 if stream_to_client else None,
             level=logging.INFO,
         )
 

--- a/python/monarch/_src/actor/proc_mesh.py
+++ b/python/monarch/_src/actor/proc_mesh.py
@@ -329,10 +329,11 @@ class ProcMesh(MeshTrait, DeprecatedNotAFuture):
             pm: "ProcMesh",
             hy_proc_mesh_task: "Shared[HyProcMesh]",
             setup_actor: Optional[SetupActor],
+            stream_log_to_client: bool,
         ) -> HyProcMesh:
             hy_proc_mesh = await hy_proc_mesh_task
 
-            await pm._logging_manager.init(hy_proc_mesh)
+            await pm._logging_manager.init(hy_proc_mesh, stream_log_to_client)
 
             if setup_actor is not None:
                 await setup_actor.setup.call()
@@ -349,7 +350,7 @@ class ProcMesh(MeshTrait, DeprecatedNotAFuture):
             )
 
         pm._proc_mesh = PythonTask.from_coroutine(
-            task(pm, hy_proc_mesh, setup_actor)
+            task(pm, hy_proc_mesh, setup_actor, alloc.stream_logs)
         ).spawn()
 
         return pm
@@ -579,7 +580,11 @@ def local_proc_mesh(*, gpus: Optional[int] = None, hosts: int = 1) -> ProcMesh:
         stacklevel=2,
     )
 
-    return _proc_mesh_from_allocator(allocator=LocalAllocator(), gpus=gpus, hosts=hosts)
+    return _proc_mesh_from_allocator(
+        allocator=LocalAllocator(),
+        gpus=gpus,
+        hosts=hosts,
+    )
 
 
 def sim_proc_mesh(


### PR DESCRIPTION
Summary:
we only stream logs back for remote processes; for local runs, no log
streaming is needed

Differential Revision: D81295234


