### PR TITLE
[monarch][debugger] Enable external debug CLI

### DIFF
--- a/python/monarch/_src/actor/debugger.py
+++ b/python/monarch/_src/actor/debugger.py
@@ -11,6 +11,7 @@ import inspect
 import logging
 import os
 import sys
+from abc import abstractmethod
 from dataclasses import dataclass
 from typing import cast, Dict, Generator, List, Optional, Tuple, Union
 
@@ -19,19 +20,94 @@ from monarch._src.actor.endpoint import endpoint
 from monarch._src.actor.pdb_wrapper import DebuggerWrite, PdbWrapper
 from monarch._src.actor.proc_mesh import get_or_spawn_controller
 from monarch._src.actor.sync_state import fake_sync_state
+from pyre_extensions import none_throws
 from tabulate import tabulate
 
 
 logger = logging.getLogger(__name__)
 
+_MONARCH_DEBUG_SERVER_HOST_ENV_VAR = "MONARCH_DEBUG_SERVER_HOST"
+_MONARCH_DEBUG_SERVER_HOST_DEFAULT = "::1"
+_MONARCH_DEBUG_SERVER_PORT_ENV_VAR = "MONARCH_DEBUG_SERVER_PORT"
+_MONARCH_DEBUG_SERVER_PORT_DEFAULT = "27000"
+_MONARCH_DEBUG_SERVER_PROTOCOL_ENV_VAR = "MONARCH_DEBUG_SERVER_PROTOCOL"
+_MONARCH_DEBUG_SERVER_PROTOCOL_DEFAULT = "tcp"
 
-async def _debugger_input(prompt=""):
-    return await asyncio.to_thread(input, prompt)
+
+def _get_debug_server_host():
+    return os.environ.get(
+        _MONARCH_DEBUG_SERVER_HOST_ENV_VAR, _MONARCH_DEBUG_SERVER_HOST_DEFAULT
+    )
 
 
-def _debugger_output(msg):
-    sys.stdout.write(msg)
-    sys.stdout.flush()
+def _get_debug_server_port():
+    return os.environ.get(
+        _MONARCH_DEBUG_SERVER_PORT_ENV_VAR, _MONARCH_DEBUG_SERVER_PORT_DEFAULT
+    )
+
+
+def _get_debug_server_protocol():
+    return os.environ.get(
+        _MONARCH_DEBUG_SERVER_PROTOCOL_ENV_VAR, _MONARCH_DEBUG_SERVER_PROTOCOL_DEFAULT
+    )
+
+
+class DebugIO:
+    @abstractmethod
+    async def input(self, prompt: str = "") -> str: ...
+
+    @abstractmethod
+    async def output(self, msg: str) -> None: ...
+
+    @abstractmethod
+    async def quit(self) -> None: ...
+
+
+class DebugStdIO(DebugIO):
+    async def input(self, prompt: str = "") -> str:
+        return await asyncio.to_thread(input, prompt)
+
+    async def output(self, msg: str) -> None:
+        sys.stdout.write(msg)
+        sys.stdout.flush()
+
+    async def quit(self) -> None:
+        pass
+
+
+class DebugIOError(RuntimeError):
+    def __init__(self):
+        super().__init__("Error encountered during debugger I/O operation.")
+
+
+class DebugCliIO(DebugIO):
+    def __init__(self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter):
+        self._reader = reader
+        self._writer = writer
+
+    async def input(self, prompt: str = "") -> str:
+        try:
+            await self.output(prompt)
+            msg = (await self._reader.readline()).decode()
+            # Incomplete read due to EOF
+            if not msg.endswith("\n"):
+                raise RuntimeError("Unexpected end of input.")
+            # Strip the newline to be consistent with the behavior of input()
+            return msg.strip("\n")
+        except Exception as e:
+            raise DebugIOError() from e
+
+    async def output(self, msg: str) -> None:
+        try:
+            self._writer.write(msg.encode())
+            await self._writer.drain()
+        except Exception as e:
+            raise DebugIOError() from e
+
+    async def quit(self) -> None:
+        await self.output("Quitting debug session...\n")
+        self._writer.close()
+        await self._writer.wait_closed()
 
 
 @dataclass
@@ -70,15 +146,19 @@ class DebugSession:
         self._function_lineno = None
         self._need_read = False
 
-    async def _event_loop(self, line=None, suppress_output=False):
+    async def _event_loop(self, debug_io: DebugIO, line=None, suppress_output=False):
         if not suppress_output:
             # If the user had previously attached to this debug session,
             # then it would have printed various messages from the
             # message queue. When the user re-attaches, we want to
             # print out all of the output that was printed since the
             # last command sent to this session.
+            if len(self._outputs_since_last_input) > 0:
+                await debug_io.output(
+                    f"<last pdb output for {self.actor_name} {self.rank} follows>\n"
+                )
             for output in self._outputs_since_last_input:
-                _debugger_output(output.payload.decode())
+                await debug_io.output(output.payload.decode())
 
         while True:
             # When the user inputs "detach", it uses up a "read" message
@@ -95,20 +175,29 @@ class DebugSession:
                 # Return to the main outer debug loop.
                 break
             elif message == "read":
-                break_after = False
-                if line is not None:
-                    break_after = True
-                else:
-                    line = await _debugger_input()
-                if line.strip("\n") == "detach":
-                    self._need_read = True
-                    break
-                else:
-                    self._outputs_since_last_input = []
-                    await self._pending_send_to_actor.put((line + "\n").encode())
-                    line = None
-                    if break_after:
+                try:
+                    break_after = False
+                    if line is not None:
+                        break_after = True
+                    else:
+                        line = await debug_io.input()
+                    if line == "detach":
+                        self._need_read = True
                         break
+                    else:
+                        await self._pending_send_to_actor.put((line + "\n").encode())
+                        # Cancel safety: don't clear the previous outputs until we know
+                        # the actor will receive the input.
+                        self._outputs_since_last_input = []
+                        line = None
+                        if break_after:
+                            break
+                except (DebugIOError, asyncio.CancelledError):
+                    # See earlier comment about this flag. If either of the awaits inside
+                    # the try block is cancelled, we need to redo the read without actually
+                    # reinserting "read" into the message queue.
+                    self._need_read = True
+                    raise
             elif message[0] == "write":
                 output = message[1]
                 # If the user sees this output but then detaches from the session,
@@ -116,11 +205,11 @@ class DebugSession:
                 # they can be printed again when the user re-attaches.
                 self._outputs_since_last_input.append(output)
                 if not suppress_output:
-                    _debugger_output(output.payload.decode())
+                    await debug_io.output(output.payload.decode())
 
         if not suppress_output:
-            print(
-                f"Detaching from debug session for rank {self.rank} ({self.hostname})"
+            await debug_io.output(
+                f"Detaching from debug session for {self.actor_name} {self.rank} ({self.hostname})\n"
             )
 
     def get_info(self):
@@ -131,14 +220,20 @@ class DebugSession:
             self.actor_name, self.rank, self.coords, self.hostname, function, lineno
         )
 
-    async def attach(self, line=None, suppress_output=False):
+    async def attach(self, debug_io: DebugIO, line=None, suppress_output=False):
         self._active = True
         if not suppress_output:
-            print(f"Attached to debug session for rank {self.rank} ({self.hostname})")
-        self._task = asyncio.create_task(self._event_loop(line, suppress_output))
+            await debug_io.output(
+                f"Attached to debug session for {self.actor_name} {self.rank} ({self.hostname})\n"
+            )
+        self._task = asyncio.create_task(
+            self._event_loop(debug_io, line, suppress_output)
+        )
         await self._task
         if not suppress_output:
-            print(f"Detached from debug session for rank {self.rank} ({self.hostname})")
+            await debug_io.output(
+                f"Detached from debug session for {self.actor_name} {self.rank} ({self.hostname})\n"
+            )
         self._active = False
 
     async def detach(self):
@@ -380,12 +475,12 @@ def _get_debug_input_transformer():
 
 class DebugCommand:
     @staticmethod
-    def parse(line: str) -> Union["DebugCommand", None]:
+    async def parse(debug_io: DebugIO, line: str) -> Union["DebugCommand", None]:
         try:
             tree = _get_debug_input_parser().parse(line)
             return _get_debug_input_transformer().transform(tree)
         except Exception as e:
-            print(f"Error parsing input: {e}")
+            await debug_io.output(f"Error parsing input: {e}\n")
             return None
 
 
@@ -431,6 +526,49 @@ class DebugController(Actor):
 
     def __init__(self) -> None:
         self.sessions = DebugSessions()
+        self._task_lock = asyncio.Lock()
+        self._task: asyncio.Task | None = None
+        self._debug_io: DebugIO = DebugStdIO()
+        self._server_started = asyncio.Future()
+        self._server = asyncio.create_task(self._serve())
+
+    async def _serve(self) -> None:
+        try:
+            if (proto := _get_debug_server_protocol()) != "tcp":
+                raise NotImplementedError(
+                    f"Network protocol {proto} not yet supported."
+                )
+            server = await asyncio.start_server(
+                self._handle_client,
+                _get_debug_server_host(),
+                _get_debug_server_port(),
+            )
+            async with server:
+                self._server_started.set_result(True)
+                await server.serve_forever()
+        except Exception as e:
+            if self._server_started.done():
+                self._server_started = asyncio.Future()
+            self._server_started.set_exception(e)
+            raise
+
+    async def _handle_client(
+        self,
+        reader: asyncio.StreamReader,
+        writer: asyncio.StreamWriter,
+    ) -> None:
+        # Make sure only one external debug process can
+        # be attached at a time. If a new request is
+        # received, the current task is cancelled.
+        async with self._task_lock:
+            if self._task is not None:
+                self._task.cancel()
+                try:
+                    await none_throws(self._task)
+                except (DebugIOError, asyncio.CancelledError):
+                    pass
+            self._debug_io = DebugCliIO(reader, writer)
+            self._task = asyncio.create_task(self._enter())
 
     @endpoint
     async def wait_pending_session(self):
@@ -438,85 +576,90 @@ class DebugController(Actor):
             await asyncio.sleep(1)
 
     @endpoint
-    async def list(self) -> List[DebugSessionInfo]:
+    async def list(self, print_output=True) -> List[DebugSessionInfo]:
         session_info = sorted(self.sessions.info())
-        print(
-            tabulate(
-                (
+        if print_output:
+            await self._debug_io.output(
+                tabulate(
                     (
-                        info.actor_name,
-                        info.rank,
-                        info.coords,
-                        info.hostname,
-                        info.function,
-                        info.lineno,
-                    )
-                    for info in session_info
-                ),
-                headers=[
-                    "Actor Name",
-                    "Rank",
-                    "Coords",
-                    "Hostname",
-                    "Function",
-                    "Line No.",
-                ],
-                tablefmt="grid",
+                        (
+                            info.actor_name,
+                            info.rank,
+                            info.coords,
+                            info.hostname,
+                            info.function,
+                            info.lineno,
+                        )
+                        for info in session_info
+                    ),
+                    headers=[
+                        "Actor Name",
+                        "Rank",
+                        "Coords",
+                        "Hostname",
+                        "Function",
+                        "Line No.",
+                    ],
+                    tablefmt="grid",
+                )
+                + "\n"
             )
-        )
         return session_info
 
-    @endpoint
-    async def enter(self) -> None:
+    async def _enter(self) -> None:
         await asyncio.sleep(0.5)
-        logger.info("Remote breakpoint hit. Entering monarch debugger...")
-        print("\n\n************************ MONARCH DEBUGGER ************************")
-        print("Enter 'help' for a list of commands.")
-        print("Enter 'list' to show all active breakpoints.\n")
+        await self._debug_io.output(
+            "\n\n************************ MONARCH DEBUGGER ************************\n"
+        )
+        await self._debug_io.output("Enter 'help' for a list of commands.\n")
+        await self._debug_io.output("Enter 'list' to show all active breakpoints.\n\n")
 
         while True:
             try:
-                user_input = await _debugger_input("monarch_dbg> ")
+                user_input = await self._debug_io.input("monarch_dbg> ")
                 if not user_input.strip():
                     continue
-                command = DebugCommand.parse(user_input)
+                command = await DebugCommand.parse(self._debug_io, user_input)
                 if isinstance(command, Help):
-                    print("monarch_dbg commands:")
-                    print("\tattach <actor_name> <rank> - attach to a debug session")
-                    print("\tlist - list all debug sessions")
-                    print("\tquit - exit the debugger, leaving all sessions in place")
-                    print(
+                    await self._debug_io.output("monarch_dbg commands:\n")
+                    await self._debug_io.output(
+                        "\tattach <actor_name> <rank> - attach to a debug session\n"
+                    )
+                    await self._debug_io.output("\tlist - list all debug sessions\n")
+                    await self._debug_io.output(
+                        "\tquit - exit the debugger, leaving all sessions in place\n"
+                    )
+                    await self._debug_io.output(
                         "\tcast <actor_name> ranks(...) <command> - send a command to a set of ranks on the specified actor mesh.\n"
                         "\t\tThe value inside ranks(...) can be a single rank (ranks(1)),\n"
                         "\t\ta list of ranks (ranks(1,4,6)), a range of ranks (ranks(start?:stop?:step?)),\n"
-                        "\t\tor a dict of dimensions (ranks(dim1=1:5:2,dim2=3, dim4=(3,6)))."
+                        "\t\tor a dict of dimensions (ranks(dim1=1:5:2,dim2=3, dim4=(3,6))).\n"
                     )
-                    print(
-                        "\tcontinue - tell all ranks to continue execution, then exit the debugger"
+                    await self._debug_io.output(
+                        "\tcontinue - clear all breakpoints and tell all ranks to continue\n"
                     )
-                    print("\thelp - print this help message")
+                    await self._debug_io.output("\thelp - print this help message\n")
                 elif isinstance(command, Attach):
-                    await self.sessions.get(command.actor_name, command.rank).attach()
+                    await self.sessions.get(command.actor_name, command.rank).attach(
+                        self._debug_io
+                    )
                 elif isinstance(command, ListCommand):
                     # pyre-ignore
                     await self.list._method(self)
                 elif isinstance(command, Continue):
-                    # Clear all breakpoints and make sure all ranks have
-                    # exited their debug sessions. If we sent "quit", it
-                    # would raise BdbQuit, crashing the process, which
-                    # probably isn't what we want.
                     await self._cast_input_and_wait("clear")
-                    while len(self.sessions) > 0:
-                        await self._cast_input_and_wait("c")
-                    return
+                    await self._cast_input_and_wait("c")
                 elif isinstance(command, Quit):
+                    await self._debug_io.quit()
                     return
                 elif isinstance(command, Cast):
                     await self._cast_input_and_wait(
                         command.command, (command.actor_name, command.ranks)
                     )
+            except (DebugIOError, asyncio.CancelledError):
+                raise
             except Exception as e:
-                print(f"Error processing command: {e}")
+                await self._debug_io.output(f"Error processing command: {e}\n")
 
     async def _cast_input_and_wait(
         self,
@@ -525,7 +668,7 @@ class DebugController(Actor):
     ) -> None:
         tasks = []
         for session in self.sessions.iter(selection):
-            tasks.append(session.attach(command, suppress_output=True))
+            tasks.append(session.attach(self._debug_io, command, suppress_output=True))
         await asyncio.gather(*tasks)
 
     ##########################################################################
@@ -537,6 +680,13 @@ class DebugController(Actor):
     async def debugger_session_start(
         self, rank: int, coords: Dict[str, int], hostname: str, actor_name: str
     ) -> None:
+        # Good enough for now to ensure that if the server for processing
+        # user interactions never starts, then the rank being debugged will
+        # fail instead of hanging indefinitely with no way to send it commands.
+        # Of course this isn't sufficient to handle the case where the server
+        # fails after the rank's debug session has successfully started.
+        # TODO: implement a heartbeat to prevent pdb sessions from hanging.
+        await self._server_started
         # Create a session if it doesn't exist
         if (actor_name, rank) not in self.sessions:
             self.sessions.insert(DebugSession(rank, coords, hostname, actor_name))

--- a/python/monarch/_src/actor/pdb_wrapper.py
+++ b/python/monarch/_src/actor/pdb_wrapper.py
@@ -11,6 +11,7 @@ import io
 import pdb  # noqa
 import socket
 import sys
+from contextlib import contextmanager
 from dataclasses import dataclass
 
 from typing import Dict, TYPE_CHECKING
@@ -29,31 +30,41 @@ class DebuggerWrite:
     lineno: int | None
 
 
+@contextmanager
+def _debug_controller_request_ctx():
+    try:
+        with fake_sync_state():
+            yield
+    except Exception as e:
+        raise bdb.BdbQuit from e
+
+
 class PdbWrapper(pdb.Pdb):
     def __init__(
         self,
         rank: int,
         coords: Dict[str, int],
         actor_id: ActorId,
-        client_ref: "DebugController",
+        controller: "DebugController",
         header: str | None = None,
     ):
         self.rank = rank
         self.coords = coords
         self.header = header
         self.actor_id = actor_id
-        self.client_ref = client_ref
+        self.controller = controller
         # pyre-ignore
         super().__init__(stdout=WriteWrapper(self), stdin=ReadWrapper.create(self))
         self._first = True
 
     def set_trace(self, frame=None):
-        self.client_ref.debugger_session_start.broadcast(
-            self.rank,
-            self.coords,
-            socket.getfqdn(socket.gethostname()),
-            self.actor_id.actor_name,
-        )
+        with _debug_controller_request_ctx():
+            self.controller.debugger_session_start.call_one(
+                self.rank,
+                self.coords,
+                socket.getfqdn(socket.gethostname()),
+                self.actor_id.actor_name,
+            ).get()
         if self.header:
             self.message(self.header)
         super().set_trace(frame)
@@ -70,9 +81,10 @@ class PdbWrapper(pdb.Pdb):
             super().do_clear(arg)
 
     def end_debug_session(self):
-        self.client_ref.debugger_session_end.broadcast(
-            self.actor_id.actor_name, self.rank
-        )
+        with _debug_controller_request_ctx():
+            self.controller.debugger_session_end.call_one(
+                self.actor_id.actor_name, self.rank
+            ).get()
         # Once the debug client actor is notified of the session being over,
         # we need to prevent any additional requests being sent for the session
         # by redirecting stdin and stdout.
@@ -91,8 +103,8 @@ class ReadWrapper(io.RawIOBase):
         self.session = session
 
     def readinto(self, b):
-        with fake_sync_state():
-            response = self.session.client_ref.debugger_read.call_one(
+        with _debug_controller_request_ctx():
+            response = self.session.controller.debugger_read.call_one(
                 self.session.actor_id.actor_name, self.session.rank, len(b)
             ).get()
             if response == "detach":
@@ -128,15 +140,16 @@ class WriteWrapper:
             function = f"{inspect.getmodulename(self.session.curframe.f_code.co_filename)}.{self.session.curframe.f_code.co_name}"
             # pyre-ignore
             lineno = self.session.curframe.f_lineno
-        self.session.client_ref.debugger_write.broadcast(
-            self.session.actor_id.actor_name,
-            self.session.rank,
-            DebuggerWrite(
-                s.encode(),
-                function,
-                lineno,
-            ),
-        )
+        with _debug_controller_request_ctx():
+            self.session.controller.debugger_write.call_one(
+                self.session.actor_id.actor_name,
+                self.session.rank,
+                DebuggerWrite(
+                    s.encode(),
+                    function,
+                    lineno,
+                ),
+            ).get()
 
     def flush(self):
         pass

--- a/python/monarch/_src/debug_cli/__init__.py
+++ b/python/monarch/_src/debug_cli/__init__.py
@@ -1,0 +1,7 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-unsafe

--- a/python/monarch/_src/debug_cli/debug_cli.py
+++ b/python/monarch/_src/debug_cli/debug_cli.py
@@ -1,0 +1,30 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-unsafe
+import argparse
+import subprocess
+
+from monarch._src.actor.debugger import _get_debug_server_host, _get_debug_server_port
+
+
+def run():
+    parser = argparse.ArgumentParser(description="Monarch Debug CLI")
+    parser.add_argument(
+        "--host",
+        type=str,
+        default=_get_debug_server_host(),
+        help="Hostname where the debug server is running",
+    )
+    parser.add_argument(
+        "--port",
+        type=str,
+        default=_get_debug_server_port(),
+        help="Port that the debug server is listening on",
+    )
+    args = parser.parse_args()
+
+    subprocess.run(["nc", f"{args.host}", f"{args.port}"], check=True)

--- a/python/monarch/debug_cli/__init__.py
+++ b/python/monarch/debug_cli/__init__.py
@@ -1,0 +1,7 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-unsafe

--- a/python/monarch/debug_cli/__main__.py
+++ b/python/monarch/debug_cli/__main__.py
@@ -1,0 +1,12 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-unsafe
+from monarch._src.debug_cli import debug_cli
+
+
+if __name__ == "__main__":
+    debug_cli.run()

--- a/python/tests/test_debugger.py
+++ b/python/tests/test_debugger.py
@@ -6,9 +6,14 @@
 
 # pyre-unsafe
 import asyncio
+import functools
+import importlib.resources
+import os
 import re
+import signal
+import subprocess
 import sys
-from typing import cast, List
+from typing import cast, List, Tuple
 from unittest.mock import AsyncMock, patch
 
 import monarch
@@ -17,27 +22,97 @@ import monarch.actor as actor
 import pytest
 
 import torch
-
-from monarch._src.actor.actor_mesh import Actor, ActorError, current_rank
+from monarch._src.actor.actor_mesh import Actor, ActorError, current_rank, IN_PAR
 from monarch._src.actor.debugger import (
     Attach,
     Cast,
     Continue,
     DebugCommand,
+    DebugController,
     DebugSession,
     DebugSessionInfo,
     DebugSessions,
+    DebugStdIO,
     Help,
     ListCommand,
     Quit,
 )
 from monarch._src.actor.endpoint import endpoint
-
 from monarch._src.actor.proc_mesh import proc_mesh
+
+from pyre_extensions import none_throws
 
 needs_cuda = pytest.mark.skipif(
     not torch.cuda.is_available(),
     reason="CUDA not available",
+)
+
+
+def _debug_port():
+    for i in range(100):
+        yield {
+            "MONARCH_DEBUG_SERVER_PORT": f"270{i:02d}",
+        }
+
+
+debug_port = _debug_port()
+
+
+def isolate_in_subprocess(test_fn=None, *, env=None):
+    if test_fn is None:
+        return functools.partial(isolate_in_subprocess, env=env)
+
+    if env is None:
+        env = {}
+
+    def sync_test_fn():
+        asyncio.run(test_fn())
+
+    sync_test_fn_name = f"sync_{test_fn.__name__}"
+    setattr(sys.modules[__name__], sync_test_fn_name, sync_test_fn)
+
+    env.update(os.environ.copy())
+
+    def wrapper():
+        if IN_PAR:
+            assert (
+                subprocess.call(
+                    [
+                        str(
+                            importlib.resources.files("monarch.python.tests").joinpath(
+                                "run_test_bin"
+                            )
+                        ),
+                        sync_test_fn_name,
+                    ],
+                    env=env,
+                )
+                == 0
+            )
+        else:
+            assert (
+                subprocess.call(
+                    [
+                        sys.executable,
+                        "-c",
+                        f"import tests.test_debugger; tests.test_debugger.{sync_test_fn_name}()",
+                    ],
+                    env=env,
+                )
+                == 0
+            )
+
+    return wrapper
+
+
+def run_test_from_name():
+    getattr(sys.modules[__name__], sys.argv[1])()
+
+
+debug_cli_bin = (
+    str(importlib.resources.files("monarch.python.tests").joinpath("debug_cli_bin"))
+    if IN_PAR
+    else ""
 )
 
 
@@ -75,24 +150,41 @@ class DebugeeActor(Actor):
         return _debugee_actor_internal(rank)
 
 
+class DebugControllerForTesting(DebugController):
+    def __init__(self):
+        super().__init__()
+        self._debug_io = DebugStdIO()
+
+    @endpoint
+    async def blocking_enter(self):
+        async with self._task_lock:
+            assert self._task is None
+            await self._enter()
+
+
 async def _wait_for_breakpoints(
     debug_controller, n_breakpoints
 ) -> List[DebugSessionInfo]:
     breakpoints: List[DebugSessionInfo] = []
-    for i in range(10):
-        breakpoints = await debug_controller.list.call_one()
+    for i in range(20):
+        breakpoints = await debug_controller.list.call_one(print_output=False)
         if len(breakpoints) == n_breakpoints:
             break
         await asyncio.sleep(1)
-        if i == 9:
+        if i == 20:
             raise RuntimeError("timed out waiting for breakpoints")
     return breakpoints
 
 
+# We have to run this test in a separate process because there is only one
+# debug controller per process, and we don't want this to interfere with
+# the other two tests that access the debug controller.
+@isolate_in_subprocess(env=next(debug_port))
 @pytest.mark.skipif(
     torch.cuda.device_count() < 2,
     reason="Not enough GPUs, this test requires at least 2 GPUs",
 )
+@pytest.mark.timeout(180)
 async def test_debug() -> None:
     input_mock = AsyncMock()
     input_mock.side_effect = [
@@ -124,6 +216,7 @@ async def test_debug() -> None:
         "c",
         "quit",
         "continue",
+        "quit",
     ]
 
     outputs = []
@@ -132,12 +225,17 @@ async def test_debug() -> None:
         nonlocal outputs
         outputs.append(msg)
 
-    with patch(
-        "monarch._src.actor.debugger._debugger_input", side_effect=input_mock
-    ), patch("monarch._src.actor.debugger._debugger_output", new=_patch_output):
+    output_mock = AsyncMock()
+    output_mock.side_effect = _patch_output
+
+    with patch("monarch._src.actor.debugger.DebugStdIO.input", new=input_mock), patch(
+        "monarch._src.actor.debugger.DebugStdIO.output", new=output_mock
+    ):
         proc = proc_mesh(hosts=2, gpus=2)
         debugee = await proc.spawn("debugee", DebugeeActor)
-        debug_controller = actor.debug_controller()
+        debug_controller = actor.get_or_spawn_controller(
+            "debug_controller", DebugControllerForTesting
+        ).get()
 
         fut = debugee.to_debug.call()
         await debug_controller.wait_pending_session.call_one()
@@ -152,7 +250,7 @@ async def test_debug() -> None:
             assert info.function == "test_debugger._debugee_actor_internal"
             assert info.lineno == cast(int, breakpoints[0].lineno) + 5 * info.rank
 
-        await debug_controller.enter.call_one()
+        await debug_controller.blocking_enter.call_one()
 
         # Check that when detaching and re-attaching to a session, the last portion of the output is repeated
         expected_last_output = [
@@ -163,13 +261,22 @@ async def test_debug() -> None:
             r"\(Pdb\) ",
         ]
         output_len = len(expected_last_output)
-        assert outputs[-2 * output_len : -output_len] == outputs[-output_len:]
+        rev_outputs = outputs[::-1]
+        last_return = rev_outputs.index("--Return--")
+        second_to_last_return = rev_outputs.index("--Return--", last_return + 1)
+        last_return = len(rev_outputs) - last_return - 1
+        second_to_last_return = len(rev_outputs) - second_to_last_return - 1
+        assert (
+            outputs[second_to_last_return : second_to_last_return + output_len]  # noqa
+            == outputs[last_return : last_return + output_len]  # noqa
+        )
         for real_output, expected_output in zip(
-            outputs[-output_len:], expected_last_output
+            outputs[last_return : last_return + output_len],  # noqa
+            expected_last_output,
         ):
             assert re.match(expected_output, real_output) is not None
 
-        breakpoints = await debug_controller.list.call_one()
+        breakpoints = await debug_controller.list.call_one(print_output=False)
         for i in range(len(breakpoints)):
             if i == 1:
                 assert breakpoints[i].function == "test_debugger.to_debug"
@@ -179,9 +286,9 @@ async def test_debug() -> None:
                 )
                 assert breakpoints[i].lineno == initial_linenos[i]
 
-        await debug_controller.enter.call_one()
+        await debug_controller.blocking_enter.call_one()
 
-        breakpoints = await debug_controller.list.call_one()
+        breakpoints = await debug_controller.list.call_one(print_output=False)
         for i in range(len(breakpoints)):
             if i == 1:
                 assert breakpoints[i].function == "test_debugger.to_debug"
@@ -196,14 +303,14 @@ async def test_debug() -> None:
                 )
                 assert breakpoints[i].lineno == initial_linenos[i]
 
-        await debug_controller.enter.call_one()
+        await debug_controller.blocking_enter.call_one()
 
-        breakpoints = await debug_controller.list.call_one()
+        breakpoints = await debug_controller.list.call_one(print_output=False)
         assert len(breakpoints) == 4
         # Expect post-mortem debugging for rank 2
         assert breakpoints[2].function == "test_debugger._bad_rank"
 
-        await debug_controller.enter.call_one()
+        await debug_controller.blocking_enter.call_one()
 
         expected_last_output = [
             r"\s*(/.*/)+test_debugger.py\(\d+\)_debugee_actor_internal\(\)\n-> _bad_rank\(\)",
@@ -213,18 +320,24 @@ async def test_debug() -> None:
             r"\(Pdb\) ",
         ]
 
+        rev_outputs = outputs[::-1]
+        output_index = len(outputs) - (
+            rev_outputs.index("(Pdb) ") + len(expected_last_output)
+        )
+
         for output, expected_output in zip(
-            outputs[-len(expected_last_output) :], expected_last_output
+            outputs[output_index : output_index + len(expected_last_output)],  # noqa
+            expected_last_output,
         ):
             assert re.match(expected_output, output) is not None
 
-        breakpoints = await debug_controller.list.call_one()
+        breakpoints = await debug_controller.list.call_one(print_output=False)
         assert len(breakpoints) == 3
         for i, rank in enumerate((0, 1, 3)):
             assert breakpoints[i].rank == rank
 
-        await debug_controller.enter.call_one()
-        breakpoints = await debug_controller.list.call_one()
+        await debug_controller.blocking_enter.call_one()
+        breakpoints = await debug_controller.list.call_one(print_output=False)
         assert len(breakpoints) == 0
 
         with pytest.raises(
@@ -233,10 +346,13 @@ async def test_debug() -> None:
             await fut
 
 
+# See earlier comment
+@isolate_in_subprocess(env=next(debug_port))
 @pytest.mark.skipif(
     torch.cuda.device_count() < 2,
     reason="Not enough GPUs, this test requires at least 2 GPUs",
 )
+@pytest.mark.timeout(180)
 async def test_debug_multi_actor() -> None:
     input_mock = AsyncMock()
     input_mock.side_effect = [
@@ -253,13 +369,16 @@ async def test_debug_multi_actor() -> None:
         "c",
         "quit",
         "continue",
+        "quit",
     ]
 
-    with patch("monarch._src.actor.debugger._debugger_input", side_effect=input_mock):
+    with patch("monarch._src.actor.debugger.DebugStdIO.input", side_effect=input_mock):
         proc = await proc_mesh(hosts=2, gpus=2)
         debugee_1 = await proc.spawn("debugee_1", DebugeeActor)
         debugee_2 = await proc.spawn("debugee_2", DebugeeActor)
-        debug_controller = actor.debug_controller()
+        debug_controller = actor.get_or_spawn_controller(
+            "debug_controller", DebugControllerForTesting
+        ).get()
 
         fut_1 = debugee_1.to_debug.call()
         fut_2 = debugee_2.to_debug.call()
@@ -277,7 +396,7 @@ async def test_debug_multi_actor() -> None:
             assert info.function == "test_debugger._debugee_actor_internal"
             assert info.lineno == cast(int, breakpoints[0].lineno) + 5 * info.rank
 
-        await debug_controller.enter.call_one()
+        await debug_controller.blocking_enter.call_one()
 
         breakpoints = await _wait_for_breakpoints(debug_controller, 8)
         for i in range(len(breakpoints)):
@@ -296,7 +415,7 @@ async def test_debug_multi_actor() -> None:
                 assert breakpoints[i].rank == i % 4
                 assert breakpoints[i].lineno == initial_linenos[breakpoints[i].rank]
 
-        await debug_controller.enter.call_one()
+        await debug_controller.blocking_enter.call_one()
 
         breakpoints = await _wait_for_breakpoints(debug_controller, 1)
         with pytest.raises(ActorError, match="ValueError: bad rank"):
@@ -305,7 +424,7 @@ async def test_debug_multi_actor() -> None:
         assert breakpoints[0].rank == 2
         assert breakpoints[0].function == "test_debugger._bad_rank"
 
-        await debug_controller.enter.call_one()
+        await debug_controller.blocking_enter.call_one()
 
         breakpoints = await _wait_for_breakpoints(debug_controller, 0)
         with pytest.raises(ActorError, match="ValueError: bad rank"):
@@ -602,7 +721,7 @@ async def test_debug_sessions_iter() -> None:
     ],
 )
 async def test_debug_command_parser_valid_inputs(user_input, expected_output):
-    assert DebugCommand.parse(user_input) == expected_output
+    assert await DebugCommand.parse(DebugStdIO(), user_input) == expected_output
 
 
 @pytest.mark.parametrize(
@@ -643,4 +762,201 @@ async def test_debug_command_parser_valid_inputs(user_input, expected_output):
     ],
 )
 async def test_debug_command_parser_invalid_inputs(invalid_input):
-    assert DebugCommand.parse(invalid_input) is None
+    assert await DebugCommand.parse(DebugStdIO(), invalid_input) is None
+
+
+# See earlier comment
+@isolate_in_subprocess(env={"MONARCH_DEBUG_CLI_BIN": debug_cli_bin, **next(debug_port)})
+@pytest.mark.skipif(
+    torch.cuda.device_count() < 2,
+    reason="Not enough GPUs, this test requires at least 2 GPUs",
+)
+@pytest.mark.timeout(180)
+async def test_debug_cli():
+    proc = proc_mesh(hosts=2, gpus=2)
+    debugee = await proc.spawn("debugee", DebugeeActor)
+    debug_controller = actor.debug_controller()
+
+    fut = debugee.to_debug.call()
+    breakpoints = await _wait_for_breakpoints(debug_controller, 4)
+
+    initial_linenos = {}
+    for i in range(len(breakpoints)):
+        info = breakpoints[i]
+        initial_linenos[info.rank] = info.lineno
+        assert info.rank == i
+        assert info.coords == {"hosts": info.rank // 2, "gpus": info.rank % 2}
+        assert info.function == "test_debugger._debugee_actor_internal"
+        assert info.lineno == cast(int, breakpoints[0].lineno) + 5 * info.rank
+
+    async def create_debug_cli_proc() -> (
+        Tuple[asyncio.subprocess.Process, asyncio.StreamWriter, asyncio.StreamReader]
+    ):
+        if IN_PAR:
+            cmd = [os.environ["MONARCH_DEBUG_CLI_BIN"]]
+        else:
+            cmd = [sys.executable, "-m", "monarch.debug_cli"]
+        debug_cli_proc = await asyncio.create_subprocess_exec(
+            *cmd,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+        )
+        debug_cli_stdin = none_throws(debug_cli_proc.stdin)
+        debug_cli_stdout = none_throws(debug_cli_proc.stdout)
+        return debug_cli_proc, debug_cli_stdin, debug_cli_stdout
+
+    (
+        debug_cli_proc,
+        debug_cli_stdin,
+        debug_cli_stdout,
+    ) = await create_debug_cli_proc()
+
+    debug_cli_stdin.writelines(
+        [
+            b"attach debugee 1\n",
+            b"n\n",
+            b"n\n",
+            b"n\n",
+            b"n\n",
+            b"detach\n",
+            b"attach debugee 1\n",
+            b"print('test separator')\n",
+            b"detach\n",
+        ]
+    )
+    await debug_cli_stdin.drain()
+
+    # Check that when detaching and re-attaching to a session, the last portion of the output is repeated
+    expected_last_output = (
+        r"--Return--\n"
+        r"> (?:/.*/)+test_debugger.py\(\d+\)to_debug\(\)->5\n"
+        r"-> return _debugee_actor_internal\(rank\)\n"
+        r"\(Pdb\) "
+    )
+
+    outputs = (await debug_cli_stdout.readuntil(b"test separator")).decode()
+    assert len(re.findall(expected_last_output, outputs)) == 2
+    assert outputs[0] == outputs[1]
+
+    breakpoints = await debug_controller.list.call_one(print_output=False)
+    for i in range(len(breakpoints)):
+        if i == 1:
+            assert breakpoints[i].function == "test_debugger.to_debug"
+        else:
+            assert breakpoints[i].function == "test_debugger._debugee_actor_internal"
+            assert breakpoints[i].lineno == initial_linenos[i]
+
+    debug_cli_stdin.write(b"quit\n")
+    await debug_cli_stdin.drain()
+    debug_cli_stdin.close()
+    await debug_cli_stdin.wait_closed()
+    assert await debug_cli_proc.wait() == 0
+
+    (
+        debug_cli_proc,
+        debug_cli_stdin,
+        debug_cli_stdout,
+    ) = await create_debug_cli_proc()
+
+    debug_cli_stdin.writelines(
+        [
+            b"cast debugee ranks(0,3) n\n",
+            b"cast debugee ranks(0,3) n\n",
+            # Attaching to 0 and 3 ensures that when we call "list"
+            # the next time, their function/lineno info will be
+            # up-to-date.
+            b"attach debugee 0\n",
+            b"detach\n",
+            b"attach debugee 3\n",
+            b"detach\n",
+        ]
+    )
+    await debug_cli_stdin.drain()
+
+    # Make sure we have run all the commands before killing the CLI, otherwise
+    # the commands may not actually be sent to the debug controller.
+    await debug_cli_stdout.readuntil(b"Detached from debug session for debugee 3")
+    # Even if we kill the proc using a signal, we should be able to reconnect
+    # without issue.
+    debug_cli_proc.send_signal(signal.SIGINT)
+    assert await debug_cli_proc.wait() != 0
+
+    breakpoints = await debug_controller.list.call_one(print_output=False)
+    for i in range(len(breakpoints)):
+        if i == 1:
+            assert breakpoints[i].function == "test_debugger.to_debug"
+        elif i in (0, 3):
+            assert breakpoints[i].function == "test_debugger._debugee_actor_internal"
+            assert breakpoints[i].lineno == initial_linenos[i] + 2
+        else:
+            assert breakpoints[i].function == "test_debugger._debugee_actor_internal"
+            assert breakpoints[i].lineno == initial_linenos[i]
+
+    (
+        debug_cli_proc,
+        debug_cli_stdin,
+        debug_cli_stdout,
+    ) = await create_debug_cli_proc()
+
+    debug_cli_stdin.writelines([b"attach debugee 2\n", b"c\n"])
+    await debug_cli_stdin.drain()
+
+    # Make sure we have run all the commands before killing the CLI, otherwise
+    # the commands may not actually be sent to the debug controller.
+    await debug_cli_stdout.readuntil(b"raise ValueError")
+    # Even if we kill the proc using a signal while the debugger is attached to
+    # a specific rank, we should be able to reconnect to that rank later without
+    # issue.
+    debug_cli_proc.send_signal(signal.SIGINT)
+    assert await debug_cli_proc.wait() != 0
+
+    breakpoints = await debug_controller.list.call_one(print_output=False)
+    assert len(breakpoints) == 4
+    # Expect post-mortem debugging for rank 2
+    assert breakpoints[2].function == "test_debugger._bad_rank"
+
+    (
+        debug_cli_proc,
+        debug_cli_stdin,
+        debug_cli_stdout,
+    ) = await create_debug_cli_proc()
+
+    debug_cli_stdin.writelines([b"attach debugee 2\n", b"bt\n", b"c\n"])
+    await debug_cli_stdin.drain()
+
+    expected_output = (
+        r"(?:/.*/)+test_debugger.py\(\d+\)_debugee_actor_internal\(\)\n-> _bad_rank\(\)\n"
+        r'> (?:/.*/)+test_debugger.py\(\d+\)_bad_rank\(\)\n-> raise ValueError\("bad rank"\)\n'
+        r"\(Pdb\)"
+    )
+
+    output = (
+        await debug_cli_stdout.readuntil(b"Detached from debug session for debugee 2")
+    ).decode()
+    assert len(re.findall(expected_output, output)) == 1
+
+    debug_cli_stdin.writelines([b"quit\n"])
+    await debug_cli_stdin.drain()
+    debug_cli_stdin.close()
+    await debug_cli_stdin.wait_closed()
+    assert await debug_cli_proc.wait() == 0
+
+    breakpoints = await debug_controller.list.call_one(print_output=False)
+    assert len(breakpoints) == 3
+    for i, rank in enumerate((0, 1, 3)):
+        assert breakpoints[i].rank == rank
+
+    debug_cli_proc, debug_cli_stdin, _ = await create_debug_cli_proc()
+    debug_cli_stdin.writelines([b"continue\n", b"quit\n"])
+    await debug_cli_stdin.drain()
+    debug_cli_stdin.close()
+    await debug_cli_stdin.wait_closed()
+    assert await debug_cli_proc.wait() == 0
+
+    breakpoints = await debug_controller.list.call_one(print_output=False)
+    assert len(breakpoints) == 0
+
+    with pytest.raises(
+        monarch._src.actor.actor_mesh.ActorError, match="ValueError: bad rank"
+    ):
+        await fut

--- a/python/tests/test_python_actors.py
+++ b/python/tests/test_python_actors.py
@@ -392,7 +392,7 @@ class AsyncActor(Actor):
         self.should_exit = True
 
 
-@pytest.mark.timeout(15)
+@pytest.mark.timeout(30)
 async def test_async_concurrency():
     """Test that async endpoints will be processed concurrently."""
     pm = await this_host().spawn_procs()
@@ -1144,7 +1144,7 @@ def test_port_as_argument() -> None:
         assert i == recv.recv().get()
 
 
-@pytest.mark.timeout(15)
+@pytest.mark.timeout(30)
 async def test_same_actor_twice() -> None:
     pm = this_host().spawn_procs(per_host={"gpus": 1})
     await pm.spawn("dup", Counter, 0).initialized


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #1040
* #1038
* __->__ #1037

This diff replaces the previous way of doing debugging, which required inserting `monarch.actor.debug_controller().enter.call_one().get()` in the script you wanted to debug after the endpoint call you wanted to debug. Now, you simply run your script, then connect from a separate terminal window by running:
```
python -m monarch.debug_cli
```
This will enter the same debugging experience as what currently exists. The debug CLI exchanges messages with the debugee script using hyperactor's channel abstraction. By default, the debugee script listens for messages via `tcp![::1]:29700`, but this can be configured using the env vars`MONARCH_DEBUG_SERVER_ADDR`.

This diff also slightly changes the `continue` command to just clear all breakpoints and tell all ranks to continue once, instead of repeatedly telling them to continue until there are no sessions left. The prior implementation didn't properly account for manually-inserted-but-not-yet-encountered `breakpoint()`'s, or post-mortem debugging. It will be worth doing this eventually but actually getting it right is non-trivial and subtle, so I'm leaving it for future work.


Differential Revision: [D79757568](https://our.internmc.facebook.com/intern/diff/D79757568/)