### PR TITLE
: channels: framing

### DIFF
--- a/docs/source/books/hyperactor-book/src/SUMMARY.md
+++ b/docs/source/books/hyperactor-book/src/SUMMARY.md
@@ -42,3 +42,5 @@
   - [`#[derive(Named)]`](macros/named.md)
   - [`#[export]`](macros/export.md)
   - [`#[forward]`](macros/forward.md)
+- [Appendix](appendix/index.md)
+  - [Typed Message Lifecycle](appendix/lifecycle.md)

--- a/docs/source/books/hyperactor-book/src/appendix/index.md
+++ b/docs/source/books/hyperactor-book/src/appendix/index.md
@@ -1,0 +1,4 @@
+# Appendix
+
+- [Appendix](index.md)
+  - [Typed Message Lifecycle](lifecycle.md)

--- a/docs/source/books/hyperactor-book/src/appendix/lifecycle.md
+++ b/docs/source/books/hyperactor-book/src/appendix/lifecycle.md
@@ -1,0 +1,61 @@
+# Typed Message Lifecycle: Zero-Copy Serialization, Framing, and Cancel-Safe I/O
+
+## Serialization (Typed → Logical Wire Format)
+- Input: A typed message `M` (struct, enum, etc.) which may include `Part` fields for large binary blobs.
+- Process:
+  - Walk `M` with a custom `Serialize` impl.
+    - Run `serde_multipart::serialize_bincode(&M)`, using a custom Serde+bincode serializer.
+  - Emit the "body" as compact bincode into a contiguous `BytesMut` buffer.
+  - For each `Part`, don’t write anything into the body; just push its backing `Bytes` into parts in visitation order. The body remains compact bincode without placeholders.
+- Output: A `Message { body: Bytes, parts: Vec<Bytes> }`.
+
+This is the heart of our zero-copy story: large payloads (`Part`) stay in their original `Bytes` allocations, and the body just carries lightweight references.
+
+## Framing (Logical Message → Transport Frame)
+
+- Input: Message from serialization.
+- Process:
+  - Wrap with length prefix (`u64`, big-endian): total byte length of serialized body + all parts.
+  - Build a `Buf` that is multipart:
+    - Slice #0: 8-byte length prefix.
+    - Slice #1: body (compact metadata + placeholders).
+    - Slice #2+: each part as-is.
+- Key Property: Zero-copy – `Bytes` is reference-counted, no data copying when building the frame
+  -  Representation: The framed value is a multipart `Buf`, not a single contiguous buffer. Internally it's a small deque of `Bytes` slices — `[len-prefix][body][part₀]…[partₙ]` — which implements `chunks_vectored()`. That means `FrameWrite` can hand the OS a vector of slices (`writev`) without coalescing, preserving zero-copy semantics end-to-end.
+
+*Note: "Zero-copy" here refers to user-space: we still incur one unavoidable kernel copy on send (`writev`) and one on receive (`read` into `BytesMut`), but avoid any additional user-space coalescing/copying.*
+
+## I/O (FrameWrite / FrameReader)
+
+- Send (`FrameWrite`):
+  - Accepts any `Buf` implementation.
+    - Uses `poll_write_vectored` under the hood:
+    - The OS sees multiple `IoSlice`S: `prefix`, `body`, `parts`.
+    - Calls `writev` to push them in one syscall.
+    - Benefit: No gather-buffering in userland; fully vectored writes.
+- Receive (`FrameReader`):
+    - Reads the length prefix.
+    - Reads exactly that many bytes.
+    - Returns a contiguous `Bytes` slice of the frame payload to the caller.
+
+## Deframing & Deserialization (Transport → Typed)
+
+- Input: Contiguous frame payload.
+  - Process:
+    - Split payload into body bytes + any parts (zero-copy): this is just slicing a shared buffer into smaller pieces (creating lightweight metadata views, not copying data).
+    - Run custom `Deserialize`:
+    - Reconstruct `M` by deserializing the compact bincode body and, whenever a `Part` field is visited, take the next entry from parts (same visitation order).
+- Output: A fully-typed message `M`.
+
+## Highlights
+
+- **Zero-copy**: `Part`s (`Bytes`) are never copied—only referenced.
+- **Vectorized I/O:** OS-level `writev` (send) and read (`recv`) avoid extra user-space copies
+- **Extensible**: Supports unipart and multipart seamlessly.
+- **Cancel-safe**: `FrameRead`/`FrameWrite` can be canceled mid-poll and resumed without corrupting state.
+
+
+## TL;DR
+
+- **Send:** `serde_multipart::serialize_bincode(M) -> Message → Message::framed() -> impl Buf`
+- **Recv:** `FrameReader::next() -> Bytes → Message::from_framed(Bytes) -> Message → serde_multipart::deserialize_bincode::<M>(Message) -> M`

--- a/docs/source/books/hyperactor-book/src/channels/frames.md
+++ b/docs/source/books/hyperactor-book/src/channels/frames.md
@@ -1,3 +1,165 @@
 # Frames
 
-Frames define the wire format. A length-prefixed protocol carries serialized messages and acknowledgements. `FrameReader` and `FrameWrite` ensure cancellation safety.
+Frames define the wire format for channel messages: a single-stream, length-prefixed protocol that carries a serialized, multipart message per frame. Each frame is:
+```text
+[length: u64 big-endian][payload bytes …]
+```
+where the 8-byte prefix declares exactly how many payload bytes follow.
+
+This section describes:
+- The **frame format** (u64 length + payload) used by channels
+- **`FrameReader`**: a cancel-safe reader that yields whole frames as `Bytes`
+- **`FrameWrite`**: a cancel-safe writer that emits a frame from any `Buf`, using vectored I/O
+- **Safety and limits**: `EOF` behavior and a configurable max frame size
+
+**Multipart by default**. Channel messages are serialized as `serde_multipart::Message`. On the send path, we frame the message's bytes (body + parts) and write them without coalescing: `FrameWrite` accepts a multipart `Buf` (via `Message::framed()`), then uses `write_vectored` to hand the kernel multiple `IoSlice`s at once. On the receive path, `FrameReader` reads the length, then reads exactly that many bytes and returns a contiguous `Bytes` payload; higher layers split that payload back into body/parts.
+
+Key properties:
+- **Zero-copy friendly (user space)**: large `Bytes` parts are never copied for framing; vectored writes avoid gather buffers.
+- **Cancellation-safe**: both read and write can be used in `tokio::select!` without risking dropped or partial frames. Progress is preserved across cancellations.
+- **Bounded**: frames exceeding `max_frame_length` are rejected early.
+- Clear `EOF` semantics: `Ok(None)` only when `EOF` happens on a frame boundary; mid-frame `EOF` is `UnexpectedEof`.
+
+That's the overview. Next we'll spell out the exact format and walk through `FrameReader` and `FrameWrite` in detail.
+
+## Frame format
+
+Frames carry a single serialized **multipart** message per frame.
+```text
+[length: u64 big-endian][payload bytes …]
+```
+- **Length prefix (8 bytes)**: total number of bytes in the payload that follows.
+- **Payload**: the bytes of a `serde_multipart::Message::framed()` value. This is logically multipart (body + parts), but appears on the wire as a single contiguous length-sized region.
+
+### Invariants
+
+- The length is the exact payload size (`payload.len() == length`).
+- Zero-length frames are valid.
+- Receivers **must** reject frames whose length exceeds a configured maximum.
+- `EOF` semantics:
+  - `EOF` on a frame boundary => end of stream (no error).
+  - `EOF` mid-prefix or mid-payload => `UnexpectedEof` (error).
+
+### Why multipart matters (even on one stream)
+
+`Message::framed()` implements `Buf` with vectored slices (`chunks_vectored`). `FrameWrite` uses `write_vectored` to hand the OS multiple `IoSlice`s (prefix, body, parts) without coalescing in user-space. This preserves zero-copy characteristics for large parts while still producing a single length-delimited frame on the wire.
+
+## `FrameReader`
+
+`FrameReader<R: AsyncRead + Unpin>` yields whole frames as `Bytes` and is cancellation-safe (safe to use in `tokio::select!` without losing frames).
+
+```rust
+/// A FrameReader reads frames from an underlying [`AsyncRead`].
+pub struct FrameReader<R> {
+    reader: R,
+    max_frame_length: usize,
+    state: FrameReaderState,
+}
+
+enum FrameReaderState {
+    /// Accumulating 8-byte length prefix.
+    ReadLen { buf: [u8; 8], off: usize },
+    /// Accumulating body of exactly `len` bytes.
+    ReadBody {
+        buf: Vec<u8>,
+        off: usize,
+        len: usize,
+    }, // off <= len
+}
+```
+- `new(reader, max_frame_length)` initializes `state = ReadLen { buf: [0;8], off: 0 }`.
+- `next()` drives a small state machine:
+  - `ReadLen`: fill 8 bytes; on `EOF` with `off == 0` → `Ok(None)`; with `off > 0` → `UnexpectedEof`.
+  - Parse `u64` length (big-endian); `if len > max_frame_length` → `InvalidData` (fatal).
+  - `ReadBody`: read exactly `len` bytes; `EOF` mid-body → `UnexpectedEof`.
+  - On completion, `take(buf).into()` returns a `Bytes` payload and state resets to `ReadLen`.
+
+**Cancellation-safe**: If polled inside `tokio::select!` and cancelled at any `Pending`, progress is not lost and no partial frame is surfaced; the next `next()` call resumes from state.
+
+## `FrameWrite`
+
+```rust
+
+/// A Writer for message frames. `FrameWrite` requires the user to
+/// drive the underlying state machines through (possibly) successive
+/// calls to `send`, retaining cancellation safety. The `FrameWrite`
+/// owns the underlying writer until the frame has been written to
+/// completion.
+pub struct FrameWrite<W, B> {
+    writer: W,
+    len_buf: Bytes,
+    body: B,
+}
+
+impl<W: AsyncWrite + Unpin, B: Buf> FrameWrite<W, B> {
+    /// Create a new frame writer, writing `body` to `writer`.
+    pub fn new(writer: W, body: B) -> Self { /* builds 8-byte BE prefix */ }
+
+    /// Drive the underlying state machine. The frame is written when this
+    /// returns `Ok(())`.
+    pub async fn send(&mut self) -> io::Result<()> { /* length → body → flush */ }
+
+    /// Return ownership of the underlying writer (call after success).
+    pub fn complete(self) -> W { /* … */ }
+
+    /// Convenience: write a single frame and return the writer.
+    pub async fn write_frame(writer: W, buf: B) -> io::Result<W> { /* … */ }
+}
+```
+
+### What it does
+
+- Length-prefix first. `new()` precomputes an 8-byte big-endian prefix with `body.remaining()` and freezes it (`BytesMut::put_u64(..).freeze()`).
+- Then the body. `send()` writes the prefix, then the body:
+  - Uses **vectored I/O** when possible: builds up to 4 `IoSlice`s from `B: Buf` via `chunks_vectored`, then calls `write_vectored`.
+  - Falls back to scalar writes if the underlying writer isn't vectored.
+  - Flush at the end. Not all transports auto-flush (e.g., rustls); `send()` calls `flush()` before returning `Ok(())`.
+  - Hand back the writer. `complete(self)` returns the inner `AsyncWrite` so you can reuse it.
+
+### Cancellation safety
+
+`send()` is designed to be used inside `tokio::select!` and safely cancelled:
+- If cancelled while writing the length prefix, no body bytes are written yet; a subsequent `send()` call resumes and finishes the prefix before writing body bytes.
+- If cancelled during the body, progress is preserved. On each poll, `write_vectored` (per Tokio docs) guarantees that if a different `select!` branch wins, no data was written in that poll. Short writes are handled by advancing the `Buf` (monotonic progress).
+- Because the reader consumes exactly one `[len][payload]` pair, the receiver either sees a complete frame or nothing—not a "split" frame.
+
+## Atomicity (frame granularity)
+
+Guarantee: A receiver observes either the entire frame body exactly once, or it observes nothing for that frame.
+This flows from:
+
+- length-prefix protocol + `FrameReader`'s "read exactly len bytes" contract, and
+- writer's monotonic progress (no user-space reordering) + vectored writes.
+
+## Errors & state
+
+- `send()` returns an `io::Result<()>`. Any error means the underlying stream is in an unknown state; higher layers typically reconnect.
+- Call `complete()` only after a successful `send()`. Calling it early yields an undefined stream state (by design).
+
+## Multipart friendly
+
+Pass a multipart buffer to `new()`:
+```rust
+use serde_multipart::Message;
+let msg: Message = // serialized typed message
+let body = msg.framed(); // impl Buf with chunks_vectored()
+let mut fw = FrameWrite::new(writer, body);
+fw.send().await?; // writes [len][body][part0]...[partN] via writev
+let writer = fw.complete(); // reuse for the next frame
+```
+
+## Oneshot convenience
+
+```rust
+// Send exactly one frame, then get the writer back.
+let writer = FrameWrite::write_frame(writer, msg.framed()).await?;
+```
+
+## TL;DR
+
+- **Send**:
+`serde_multipart::serialize_bincode(M) -> Message → Message::framed() -> impl Buf`
+- **Recv**:
+- `FrameReader::next() -> Bytes → Message::from_framed(Bytes) -> Message → serde_multipart::deserialize_bincode::<M>(Message) -> M`
+
+See [Typed Message Lifecycle](../appendix/lifecycle.md) for the full end-to-end walkthrough, including serialization, framing, cancel-safe I/O, and deserialization.

--- a/docs/source/books/hyperactor-book/src/introduction.md
+++ b/docs/source/books/hyperactor-book/src/introduction.md
@@ -15,5 +15,6 @@ We hope this becomes the book we wish we had when we started working with Monarc
 ./channels/index
 ./mailboxes/index
 ./references/index
+./appendix/index
 ./SUMMARY.md
 ```


### PR DESCRIPTION
Summary: fleshed out frames chapter (format, `FrameReader`, `FrameWrite`, cancel-safety, examples) and added appendix with full typed message lifecycle walkthrough; cross-linked from frames.md

Differential Revision: D81341320


