### PR TITLE
[nightly] Setup the correct CUDA_LIB_DIR.

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -39,11 +39,15 @@ jobs:
         # Setup Tensor Engine dependencies
         setup_tensor_engine
 
+        # Build the process allocator binary
+        build_process_allocator
+
         cargo install --path monarch_hyperactor
 
         # Build wheel
         export MONARCH_PACKAGE_NAME="torchmonarch-nightly"
         export MONARCH_VERSION=$(date +'%Y.%m.%d')
+        export CUDA_LIB_DIR=/usr/lib64
 
         python setup.py bdist_wheel
 


### PR DESCRIPTION
After https://github.com/meta-pytorch/monarch/pull/720 we expect the CUDA_LIB_DIR to find the correct library. Also, make sure that the process allocator is built.