### PR TITLE
Setting the client trace id for process allocate

### DIFF
--- a/hyperactor_mesh/src/alloc/process.rs
+++ b/hyperactor_mesh/src/alloc/process.rs
@@ -87,7 +87,7 @@ impl ProcessAllocator {
 impl Allocator for ProcessAllocator {
     type Alloc = ProcessAlloc;
 
-    #[hyperactor::instrument(fields(name = "process_allocate"))]
+    #[hyperactor::instrument(fields(name = "process_allocate", monarch_client_trace_id = spec.constraints.match_labels.get(CLIENT_TRACE_ID_LABEL).cloned().unwrap_or_else(|| "".to_string())))]
     async fn allocate(&mut self, spec: AllocSpec) -> Result<ProcessAlloc, AllocatorError> {
         let (bootstrap_addr, rx) = channel::serve(ChannelAddr::any(ChannelTransport::Unix))
             .await

--- a/hyperactor_mesh/src/alloc/remoteprocess.rs
+++ b/hyperactor_mesh/src/alloc/remoteprocess.rs
@@ -40,7 +40,6 @@ use hyperactor::reference::Reference;
 use hyperactor::serde_json;
 use mockall::automock;
 use ndslice::Region;
-use ndslice::View;
 use ndslice::ViewExt;
 use ndslice::view::Extent;
 use ndslice::view::Point;
@@ -229,6 +228,8 @@ impl RemoteProcessAllocator {
                                     "allocating...",
                                 );
                             }
+
+
                             let spec = AllocSpec {
                                 extent: view.extent(),
                                 constraints,


### PR DESCRIPTION
Summary: Logging the client trace id with the process_allocate span.

Differential Revision: D81470056


