### PR TITLE
(monarch/tools) Remove UnnamedAppDef in favor of using AppDef(name=__NOT_SET__) with a placeholder name

### DIFF
--- a/python/monarch/tools/components/hyperactor.py
+++ b/python/monarch/tools/components/hyperactor.py
@@ -9,7 +9,8 @@ import getpass
 from typing import Optional
 
 from monarch.tools import mesh_spec
-from monarch.tools.config import UnnamedAppDef
+
+from monarch.tools.config import NOT_SET
 from monarch.tools.mesh_spec import mesh_spec_from_str
 from torchx import specs
 
@@ -18,6 +19,7 @@ _DEFAULT_MESHES = ["mesh_0:1:gpu.small"]
 _USER: str = getpass.getuser()
 
 DEFAULT_NAME: str = f"monarch-{_USER}"
+
 
 __version__ = "latest"  # TODO get version from monarch.__version_
 
@@ -28,7 +30,7 @@ def host_mesh(
     env: Optional[dict[str, str]] = None,
     port: int = mesh_spec.DEFAULT_REMOTE_ALLOCATOR_PORT,
     program: str = "monarch_bootstrap",  # installed with monarch wheel (as console script)
-) -> UnnamedAppDef:
+) -> specs.AppDef:
     """
     Args:
         name: the name of the monarch server job
@@ -39,7 +41,7 @@ def host_mesh(
         program: path to the binary that the remote process allocator spawns on an allocation request
     """
 
-    appdef = UnnamedAppDef()
+    appdef = specs.AppDef(name=NOT_SET)
 
     for mesh in [mesh_spec_from_str(mesh) for mesh in meshes]:
         mesh_role = specs.Role(

--- a/python/monarch/tools/config/__init__.py
+++ b/python/monarch/tools/config/__init__.py
@@ -7,26 +7,22 @@
 # pyre-strict
 import warnings
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, TYPE_CHECKING
+from typing import Any
 
 from monarch.tools.config.workspace import Workspace
 
-# Defer the import of Role to avoid requiring torchx at import time
-if TYPE_CHECKING:
-    from torchx.specs import Role
-
+# Gracefully handle cases where torchx might not be installed
+# NOTE: this can be removed once torchx.specs moves to monarch.session
+try:
+    from torchx import specs
+except ImportError:
+    pass
 
 NOT_SET: str = "__NOT_SET__"
 
 
-@dataclass
-class UnnamedAppDef:
-    """
-    A TorchX AppDef without a name.
-    """
-
-    roles: List["Role"] = field(default_factory=list)
-    metadata: Dict[str, str] = field(default_factory=dict)
+def _empty_appdef() -> "specs.AppDef":
+    return specs.AppDef(name=NOT_SET)
 
 
 @dataclass
@@ -39,7 +35,7 @@ class Config:
     scheduler_args: dict[str, Any] = field(default_factory=dict)
     workspace: Workspace = field(default_factory=Workspace.null)
     dryrun: bool = False
-    appdef: UnnamedAppDef = field(default_factory=UnnamedAppDef)
+    appdef: "specs.AppDef" = field(default_factory=_empty_appdef)
 
     def __post_init__(self) -> None:
         # workspace used to be Optional[str]

--- a/python/monarch/tools/config/defaults.py
+++ b/python/monarch/tools/config/defaults.py
@@ -12,7 +12,7 @@ import warnings
 from typing import Callable
 
 from monarch.tools.components import hyperactor
-from monarch.tools.config import Config, UnnamedAppDef
+from monarch.tools.config import Config
 from monarch.tools.config.workspace import Workspace
 
 from torchx import specs
@@ -25,7 +25,7 @@ from torchx.schedulers import (
 )
 
 
-def component_fn(scheduler: str) -> Callable[..., UnnamedAppDef]:
+def component_fn(scheduler: str) -> Callable[..., specs.AppDef]:
     """The default TorchX component function for the scheduler"""
     return hyperactor.host_mesh
 

--- a/python/monarch/tools/mesh_spec.py
+++ b/python/monarch/tools/mesh_spec.py
@@ -9,8 +9,6 @@ import string
 from dataclasses import dataclass, field
 from typing import Any, Optional
 
-from monarch.tools.config import UnnamedAppDef
-
 from monarch.tools.network import get_sockaddr
 from torchx import specs
 from torchx.specs.api import is_terminal
@@ -72,7 +70,7 @@ def _tag(mesh_name: str, tag_template: str) -> str:
     return string.Template(tag_template).substitute(mesh_name=mesh_name)
 
 
-def tag_as_metadata(mesh_spec: MeshSpec, appdef: UnnamedAppDef) -> None:
+def tag_as_metadata(mesh_spec: MeshSpec, appdef: specs.AppDef) -> None:
     appdef.metadata[_tag(mesh_spec.name, _TAG_HOST_TYPE)] = mesh_spec.host_type
     appdef.metadata[_tag(mesh_spec.name, _TAG_GPUS)] = str(mesh_spec.gpus)
     appdef.metadata[_tag(mesh_spec.name, _TAG_TRANSPORT)] = mesh_spec.transport

--- a/python/tests/tools/test_mesh_spec.py
+++ b/python/tests/tools/test_mesh_spec.py
@@ -9,8 +9,6 @@ import json
 import unittest
 from dataclasses import asdict
 
-from monarch.tools.config import UnnamedAppDef
-
 from monarch.tools.mesh_spec import (
     mesh_spec_from_metadata,
     mesh_spec_from_str,
@@ -30,7 +28,7 @@ class TestMeshSpec(unittest.TestCase):
         mesh_spec = MeshSpec(
             name="trainer", num_hosts=2, host_type="gpu.medium", gpus=2
         )
-        appdef = UnnamedAppDef()
+        appdef = specs.AppDef(name=UNUSED)
         tag_as_metadata(mesh_spec, appdef)
 
         self.assertDictEqual(


### PR DESCRIPTION
Summary: Remove `UnnamedAppDef` in favor of just setting a placeholder (`NOT_SET`) value for `AppDef(name)` until we set it in `tools.commands.get_or_create(name, config)`.

Differential Revision: D81522879


