### PR TITLE
[monarch] Fix infinite recursion in python actor undeliverable message handling

### DIFF
--- a/hyperactor/src/actor.rs
+++ b/hyperactor/src/actor.rs
@@ -127,12 +127,22 @@ pub trait Actor: Sized + Send + Debug + 'static {
     async fn handle_undeliverable_message(
         &mut self,
         cx: &Instance<Self>,
-        Undeliverable(envelope): Undeliverable<MessageEnvelope>,
+        envelope: Undeliverable<MessageEnvelope>,
     ) -> Result<(), anyhow::Error> {
-        assert_eq!(envelope.sender(), cx.self_id());
-
-        anyhow::bail!(UndeliverableMessageError::delivery_failure(&envelope));
+        handle_undeliverable_message(cx, envelope)
     }
+}
+
+/// Default implementation of [`Actor::handle_undeliverable_message`]. Defined
+/// as a free function so that `Actor` implementations that override
+/// [`Actor::handle_undeliverable_message`] can fallback to this default.
+pub fn handle_undeliverable_message<A: Actor>(
+    cx: &Instance<A>,
+    Undeliverable(envelope): Undeliverable<MessageEnvelope>,
+) -> Result<(), anyhow::Error> {
+    assert_eq!(envelope.sender(), cx.self_id());
+
+    anyhow::bail!(UndeliverableMessageError::delivery_failure(&envelope));
 }
 
 /// An actor that does nothing. It is used to represent "client only" actors,

--- a/monarch_hyperactor/src/actor.rs
+++ b/monarch_hyperactor/src/actor.rs
@@ -536,7 +536,7 @@ impl Actor for PythonActor {
         })?;
 
         if !handled {
-            <Self as Actor>::handle_undeliverable_message(self, cx, envelope).await
+            hyperactor::actor::handle_undeliverable_message(cx, envelope)
         } else {
             Ok(())
         }

--- a/python/tests/test_python_actors.py
+++ b/python/tests/test_python_actors.py
@@ -520,6 +520,16 @@ class Printer(Actor):
         sys.stdout.flush()
         sys.stderr.flush()
 
+    def _handle_undeliverable_message(
+        self, message: UndeliverableMessageEnvelope
+    ) -> bool:
+        # Don't throw an error on undeliverable messages. This actor is used in a test for
+        # stopping actor meshes, and if we throw an error here then there is a race between
+        # the asserted error that the mesh was stopped and the supervision error that a message
+        # wasn't delivered.
+        self._logger.error(f"Ignoring undeliverable message: {message}")
+        return True
+
 
 @pytest.mark.timeout(60)
 async def test_actor_log_streaming() -> None:
@@ -1298,9 +1308,6 @@ class UndeliverableMessageReceiver(Actor):
 
 
 class UndeliverableMessageSender(Actor):
-    def __init__(self, receiver: UndeliverableMessageReceiver):
-        self._receiver = receiver
-
     @endpoint
     def send_undeliverable(self) -> None:
         mailbox = context().actor_instance._mailbox
@@ -1316,6 +1323,11 @@ class UndeliverableMessageSender(Actor):
             PythonMessage(PythonMessageKind.Result(None), b"123"),
         )
 
+
+class UndeliverableMessageSenderWithOverride(UndeliverableMessageSender):
+    def __init__(self, receiver: UndeliverableMessageReceiver):
+        self._receiver = receiver
+
     def _handle_undeliverable_message(
         self, message: UndeliverableMessageEnvelope
     ) -> bool:
@@ -1326,15 +1338,28 @@ class UndeliverableMessageSender(Actor):
 
 
 @pytest.mark.timeout(60)
-async def test_undeliverable_message() -> None:
+async def test_undeliverable_message_with_override() -> None:
     pm = this_host().spawn_procs(per_host={"gpus": 1})
     receiver = pm.spawn("undeliverable_receiver", UndeliverableMessageReceiver)
-    sender = pm.spawn("undeliverable_sender", UndeliverableMessageSender, receiver)
+    sender = pm.spawn(
+        "undeliverable_sender", UndeliverableMessageSenderWithOverride, receiver
+    )
     sender.send_undeliverable.call().get()
     sender, dest, error_msg = receiver.get_messages.call_one().get()
     assert sender.actor_name == "undeliverable_sender"
     assert dest.actor_id.actor_name == "bogus"
     assert error_msg is not None
+    pm.stop().get()
+
+
+@pytest.mark.timeout(60)
+async def test_undeliverable_message_without_override() -> None:
+    pm = this_host().spawn_procs(per_host={"gpus": 1})
+    sender = pm.spawn("undeliverable_sender", UndeliverableMessageSender)
+    sender.send_undeliverable.call().get()
+    # Wait a few seconds to ensure that the undeliverable message is processed
+    # without crashing anything
+    await asyncio.sleep(5)
     pm.stop().get()
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #1070

This diff fixes an infinite recursion issue in python actors that don't override `_handle_undeliverable_message`. `PythonActor::handle_undeliverable_message` had an implementation that attempted to fallback to the default `Actor::handle_undeliverable_message` implementation, but it turns out this isn't possible. Fixed by defining the default `handle_undeliverable_message` as a free function.

Differential Revision: [D81524563](https://our.internmc.facebook.com/intern/diff/D81524563/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D81524563/)!