### PR TITLE
[nightly] Don't build allocator in the wheel for now

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -39,9 +39,6 @@ jobs:
         # Setup Tensor Engine dependencies
         setup_tensor_engine
 
-        # Build the process allocator binary
-        build_process_allocator
-
         cargo install --path monarch_hyperactor
 
         # Build wheel


### PR DESCRIPTION
It's incompatible with the pypi distribution model

Checking dist/cargo_bin: ERROR    InvalidDistribution: Unknown distribution format: 'cargo_bin'