### PR TITLE
remove date version from publish_release.yml GHA

### DIFF
--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -38,7 +38,6 @@ jobs:
 
         # Build wheel
         export MONARCH_PACKAGE_NAME="torchmonarch"
-        export MONARCH_VERSION=$(date +'%Y.%m.%d')
         export CUDA_LIB_DIR=/usr/lib64
 
         python setup.py bdist_wheel


### PR DESCRIPTION
Summary:
for versioned releases, we want named versions.
deletes the date version names from the GHA

Reviewed By: shayne-fletcher

Differential Revision: D81630849


