### PR TITLE
fix docs build to use more updated python version

### DIFF
--- a/.github/workflows/doc_build.yml
+++ b/.github/workflows/doc_build.yml
@@ -27,7 +27,8 @@ jobs:
         source scripts/common-setup.sh
 
         # Setup build environment (conda + system deps + rust + build deps)
-        setup_build_environment
+        # docs build will use 3.13
+        setup_build_environment 3.13
 
         # Setup Tensor Engine
         setup_tensor_engine


### PR DESCRIPTION
Summary:
docs are failing due to https://github.com/meta-pytorch/monarch/actions/runs/17456083732/job/49569880859
try building with more up to date python version

Differential Revision: D81692538


