### PR TITLE
Don't wait 1/2 second every time we launch a new proc

### DIFF
--- a/hyperactor_mesh/src/bootstrap.rs
+++ b/hyperactor_mesh/src/bootstrap.rs
@@ -24,6 +24,7 @@ use hyperactor::proc::Proc;
 use serde::Deserialize;
 use serde::Serialize;
 use tokio::sync::Mutex;
+use tokio::sync::oneshot;
 
 use crate::proc_mesh::mesh_agent::MeshAgent;
 
@@ -154,56 +155,72 @@ pub async fn bootstrap() -> anyhow::Error {
         let (serve_addr, mut rx) = channel::serve(listen_addr).await?;
         let tx = channel::dial(bootstrap_addr.clone())?;
 
-        tx.send(Process2Allocator(
-            bootstrap_index,
-            Process2AllocatorMessage::Hello(serve_addr),
-        ))
-        .await?;
-
+        let (rtx, return_channel) = oneshot::channel();
+        let mut return_channel = Some(return_channel);
+        tx.try_post(
+            Process2Allocator(bootstrap_index, Process2AllocatorMessage::Hello(serve_addr)),
+            rtx,
+        )?;
         tokio::spawn(exit_if_missed_heartbeat(bootstrap_index, bootstrap_addr));
 
         loop {
             let _ = hyperactor::tracing::info_span!("wait_for_next_message_from_mesh_agent");
-            match rx.recv().await? {
-                Allocator2Process::StartProc(proc_id, listen_transport) => {
-                    let (proc, mesh_agent) = MeshAgent::bootstrap(proc_id.clone()).await?;
-                    let (proc_addr, proc_rx) =
-                        channel::serve(ChannelAddr::any(listen_transport)).await?;
-                    let handle = proc.clone().serve(proc_rx);
-                    drop(handle); // linter appeasement; it is safe to drop this future
-                    tx.send(Process2Allocator(
-                        bootstrap_index,
-                        Process2AllocatorMessage::StartedProc(
-                            proc_id.clone(),
-                            mesh_agent.bind(),
-                            proc_addr,
-                        ),
-                    ))
-                    .await?;
-                    procs.lock().await.push(proc);
-                }
-                Allocator2Process::StopAndExit(code) => {
-                    tracing::info!("stopping procs with code {code}");
-                    {
-                        for proc_to_stop in procs.lock().await.iter_mut() {
-                            if let Err(err) = proc_to_stop
-                                .destroy_and_wait(Duration::from_millis(10), None)
-                                .await
+            tokio::select! {
+                msg = rx.recv() => {
+                    match msg? {
+                        Allocator2Process::StartProc(proc_id, listen_transport) => {
+                            let (proc, mesh_agent) = MeshAgent::bootstrap(proc_id.clone()).await?;
+                            let (proc_addr, proc_rx) =
+                                channel::serve(ChannelAddr::any(listen_transport)).await?;
+                            let handle = proc.clone().serve(proc_rx);
+                            drop(handle); // linter appeasement; it is safe to drop this future
+                            tx.send(Process2Allocator(
+                                bootstrap_index,
+                                Process2AllocatorMessage::StartedProc(
+                                    proc_id.clone(),
+                                    mesh_agent.bind(),
+                                    proc_addr,
+                                ),
+                            ))
+                            .await?;
+                            procs.lock().await.push(proc);
+                        }
+                        Allocator2Process::StopAndExit(code) => {
+                            tracing::info!("stopping procs with code {code}");
                             {
-                                tracing::error!(
-                                    "error while stopping proc {}: {}",
-                                    proc_to_stop.proc_id(),
-                                    err
-                                );
+                                for proc_to_stop in procs.lock().await.iter_mut() {
+                                    if let Err(err) = proc_to_stop
+                                        .destroy_and_wait(Duration::from_millis(10), None)
+                                        .await
+                                    {
+                                        tracing::error!(
+                                            "error while stopping proc {}: {}",
+                                            proc_to_stop.proc_id(),
+                                            err
+                                        );
+                                    }
+                                }
                             }
+                            tracing::info!("exiting with {code}");
+                            std::process::exit(code);
+                        }
+                        Allocator2Process::Exit(code) => {
+                            tracing::info!("exiting with {code}");
+                            std::process::exit(code);
                         }
                     }
-                    tracing::info!("exiting with {code}");
-                    std::process::exit(code);
                 }
-                Allocator2Process::Exit(code) => {
-                    tracing::info!("exiting with {code}");
-                    std::process::exit(code);
+                returned_msg = &mut return_channel.as_mut().unwrap(), if return_channel.is_some() => {
+                    match returned_msg {
+                        Ok(msg) => {
+                            return Err(anyhow::anyhow!("Hello message was not delivered:{:?}", msg));
+                        }
+                        Err(_) => {
+                            // Channel was closed normally, which is expected behavior
+                            // Continue with the loop
+                            return_channel = None;
+                        }
+                    }
                 }
             }
         }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #1104
* #1088
* #1085

tx.send waits for a response that the send was received. That response seems to only be sent at MESSAGE_ACK_TIME_INTERVAL (.5 seconds). This means that pretty much every launch of a process has a sleep(.5) seconds in it.

This changes it to simulatenously monitor for a send error or the response, eliminating the sleep.

Gaze at the hideous tokio::select invocation needed to do the right thing here and question whether the efficiency of rust is never achieved because doing the right thing is just too hard.

Differential Revision: [D81709502](https://our.internmc.facebook.com/intern/diff/D81709502/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D81709502/)!