### PR TITLE
Disable execution time display in Example docs

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -49,6 +49,7 @@ sphinx_gallery_conf = {
     "ignore_pattern": r"__init__\.py",  # Exclude __init__.py files
     "plot_gallery": "False",
     "only_warn_on_example_error": "True",
+    "show_time": False,  # Disable execution time display
 }
 
 


### PR DESCRIPTION
Summary:
At the end of each Sphinx-Gallery generated examples doc page (e.g. https://meta-pytorch.org/monarch/generated/examples/getting_started.html , https://meta-pytorch.org/monarch/generated/examples/ping_pong.html),  there is a line saying
```
Total running time of the script: (0 minutes 0.000 seconds)
```
which isn't helpful. Disable that to avoid confusions.

<img width="2082" height="760" alt="image" src="https://github.com/user-attachments/assets/d9e10a68-a7f4-47ba-84e9-70d57d5ecf8f" />

Differential Revision: D81746218


