### PR TITLE
Set max_elapsed_time to None for ExponentialBackoffBuilder in net.rs

### DIFF
--- a/hyperactor/src/channel/net.rs
+++ b/hyperactor/src/channel/net.rs
@@ -481,6 +481,7 @@ impl<M: RemoteMessage> NetTx<M> {
                         .with_multiplier(2.0)
                         .with_randomization_factor(0.1)
                         .with_max_interval(Duration::from_millis(1000))
+                        .with_max_elapsed_time(None) // Allow infinite retries
                         .build(),
                 ))
             }


### PR DESCRIPTION
Summary:
This value defaults to 15 minutes if do not set it explicitly:

https://www.internalfb.com/code/fbsource/[d2654f57d7bc358c5296e7c410d9aee32949d171]/third-party/rust/vendor/backoff-0.4.0/src/exponential.rs?lines=163%2C169
https://www.internalfb.com/code/fbsource/[d2654f57d7bc358c5296e7c410d9aee32949d171]/third-party/rust/vendor/backoff-0.4.0/src/default.rs?lines=12-13

This value set [the upper bound](https://docs.rs/backoff/latest/backoff/type.ExponentialBackoff.html#structfield.max_elapsed_time) of the accumulated backoff time:

> The maximum elapsed time after instantiating ExponentialBackfff or calling reset after which next_backoff returns None.

When that happens, this `unwrap` would panic:
https://www.internalfb.com/code/fbsource/[d2654f57d7bc358c5296e7c410d9aee32949d171]/fbcode/monarch/hyperactor/src/channel/net.rs?lines=795

We have seen this in perf test: P1932537411

Rollback Plan:

Differential Revision: D81775257


