### PR TITLE
remove bad sphinx_gallery_conf option

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -49,7 +49,6 @@ sphinx_gallery_conf = {
     "ignore_pattern": r"__init__\.py",  # Exclude __init__.py files
     "plot_gallery": "False",
     "only_warn_on_example_error": "True",
-    "show_time": False,  # Disable execution time display
 }
 
 


### PR DESCRIPTION
Summary:
Reverting D81746218.

There is `write_computation_times` option supported in v0.19.0. We are using v0.14.0, where isn't not supported.

Reviewed By: keyan

Differential Revision: D81804009


