### PR TITLE
v1: value_mesh: collect_mesh_exact + tests

### DIFF
--- a/hyperactor/src/cap.rs
+++ b/hyperactor/src/cap.rs
@@ -34,6 +34,14 @@ impl<T: sealed::CanSpawn> CanSpawn for T {}
 pub trait CanResolveActorRef: sealed::CanResolveActorRef {}
 impl<T: sealed::CanResolveActorRef> CanResolveActorRef for T {}
 
+/// HasProc is a capability that returns the Proc associated with the caller.
+/// Full access to the proc is quite powerful: we should consider some kind of
+/// "read only" proc trait.
+pub trait HasProc {
+    /// The proc associated with the caller.
+    fn proc(&self) -> &crate::Proc;
+}
+
 pub(crate) mod sealed {
     use async_trait::async_trait;
 

--- a/hyperactor/src/channel.rs
+++ b/hyperactor/src/channel.rs
@@ -234,6 +234,7 @@ impl<M: RemoteMessage> Rx<M> for MpscRx<M> {
     Debug,
     PartialEq,
     Eq,
+    Hash,
     Serialize,
     Deserialize,
     strum::EnumIter,
@@ -249,7 +250,7 @@ pub enum TlsMode {
 }
 
 /// Types of channel transports.
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum ChannelTransport {
     /// Transport over a TCP connection.
     Tcp,

--- a/hyperactor/src/lib.rs
+++ b/hyperactor/src/lib.rs
@@ -65,6 +65,7 @@
 #![feature(panic_update_hook)]
 #![feature(type_alias_impl_trait)]
 #![feature(trait_alias)]
+#![feature(let_chains)]
 #![deny(missing_docs)]
 
 pub mod accum;

--- a/hyperactor/src/lib.rs
+++ b/hyperactor/src/lib.rs
@@ -162,6 +162,7 @@ pub use opentelemetry;
 pub use paste::paste;
 pub use proc::Context;
 pub use proc::Instance;
+pub use proc::Proc;
 pub use reference::ActorId;
 pub use reference::ActorRef;
 pub use reference::GangId;

--- a/hyperactor/src/mailbox.rs
+++ b/hyperactor/src/mailbox.rs
@@ -67,6 +67,7 @@
 
 use std::any::Any;
 use std::collections::BTreeMap;
+use std::collections::BTreeSet;
 use std::fmt;
 use std::fmt::Debug;
 use std::future::Future;
@@ -285,16 +286,15 @@ impl MessageEnvelope {
     ) {
         tracing::error!(
             name = "undelivered_message_attempt",
-            actor_id = self.sender.to_string(),
-            "message not delivered to {}, {}",
-            self.dest.actor_id().name(),
-            error.to_string(),
+            sender = self.sender.to_string(),
+            dest = self.dest.actor_id().to_string(),
+            error = error.to_string(),
         );
         metrics::MAILBOX_UNDELIVERABLE_MESSAGES.add(
             1,
             hyperactor_telemetry::kv_pairs!(
-                "actor_id" => self.sender.to_string(),
-                "dest_actor_id" => self.dest.0.to_string(),
+                "sender_actor_id" => self.sender.to_string(),
+                "dest_actor_id" => self.dest.to_string(),
                 "message_type" => self.data.typename().unwrap_or("unknown"),
                 "error_type" =>  error.to_string(),
             ),
@@ -2469,6 +2469,23 @@ impl DialMailboxRouter {
         }
     }
 
+    /// Return all covering prefixes of this router. That is, all references that are not
+    /// prefixed by another reference in the routing table
+    pub fn prefixes(&self) -> BTreeSet<Reference> {
+        let addrs = self.address_book.read().unwrap();
+        let mut prefixes: BTreeSet<Reference> = BTreeSet::new();
+        for (reference, _) in addrs.iter() {
+            match prefixes.lower_bound(Excluded(reference)).peek_prev() {
+                Some(candidate) if candidate.is_prefix_of(reference) => (),
+                _ => {
+                    prefixes.insert(reference.clone());
+                }
+            }
+        }
+
+        prefixes
+    }
+
     #[allow(clippy::result_large_err)] // TODO: Consider reducing the size of `MailboxSenderError`.
     fn dial(
         &self,
@@ -3377,5 +3394,104 @@ mod tests {
         RealClock.sleep(Duration::from_secs(2)).await;
         let msg = receiver.try_recv().unwrap();
         assert_eq!(msg, None);
+    }
+
+    #[test]
+    fn test_dial_mailbox_router_prefixes_empty() {
+        assert_eq!(DialMailboxRouter::new().prefixes().len(), 0);
+    }
+
+    #[test]
+    fn test_dial_mailbox_router_prefixes_single_entry() {
+        let router = DialMailboxRouter::new();
+        router.bind(id!(world0).into(), "unix!@1".parse().unwrap());
+
+        let prefixes: Vec<Reference> = router.prefixes().into_iter().collect();
+        assert_eq!(prefixes.len(), 1);
+        assert_eq!(prefixes[0], id!(world0).into());
+    }
+
+    #[test]
+    fn test_dial_mailbox_router_prefixes_no_overlap() {
+        let router = DialMailboxRouter::new();
+        router.bind(id!(world0).into(), "unix!@1".parse().unwrap());
+        router.bind(id!(world1).into(), "unix!@2".parse().unwrap());
+        router.bind(id!(world2).into(), "unix!@3".parse().unwrap());
+
+        let mut prefixes: Vec<Reference> = router.prefixes().into_iter().collect();
+        prefixes.sort();
+
+        let mut expected = vec![id!(world0).into(), id!(world1).into(), id!(world2).into()];
+        expected.sort();
+
+        assert_eq!(prefixes, expected);
+    }
+
+    #[test]
+    fn test_dial_mailbox_router_prefixes_with_overlaps() {
+        let router = DialMailboxRouter::new();
+        router.bind(id!(world0).into(), "unix!@1".parse().unwrap());
+        router.bind(id!(world0[0]).into(), "unix!@2".parse().unwrap());
+        router.bind(id!(world0[1]).into(), "unix!@3".parse().unwrap());
+        router.bind(id!(world1).into(), "unix!@4".parse().unwrap());
+        router.bind(id!(world1[0]).into(), "unix!@5".parse().unwrap());
+
+        let mut prefixes: Vec<Reference> = router.prefixes().into_iter().collect();
+        prefixes.sort();
+
+        // Only world0 and world1 should be covering prefixes since they cover their children
+        let mut expected = vec![id!(world0).into(), id!(world1).into()];
+        expected.sort();
+
+        assert_eq!(prefixes, expected);
+    }
+
+    #[test]
+    fn test_dial_mailbox_router_prefixes_complex_hierarchy() {
+        let router = DialMailboxRouter::new();
+        router.bind(id!(world0).into(), "unix!@1".parse().unwrap());
+        router.bind(id!(world0[0]).into(), "unix!@2".parse().unwrap());
+        router.bind(id!(world0[0].actor1).into(), "unix!@3".parse().unwrap());
+        router.bind(id!(world1[0]).into(), "unix!@4".parse().unwrap());
+        router.bind(id!(world1[1]).into(), "unix!@5".parse().unwrap());
+        router.bind(id!(world2[0].actor0).into(), "unix!@6".parse().unwrap());
+
+        let mut prefixes: Vec<Reference> = router.prefixes().into_iter().collect();
+        prefixes.sort();
+
+        // Covering prefixes should be:
+        // - world0 (covers world0[0] and world0[0].actor1)
+        // - world1[0] (not covered by anything else)
+        // - world1[1] (not covered by anything else)
+        // - world2[0].actor0 (not covered by anything else)
+        let expected = vec![
+            id!(world0).into(),
+            id!(world1[0]).into(),
+            id!(world1[1]).into(),
+            id!(world2[0].actor0).into(),
+        ];
+
+        assert_eq!(prefixes, expected);
+    }
+
+    #[test]
+    fn test_dial_mailbox_router_prefixes_same_level() {
+        let router = DialMailboxRouter::new();
+        router.bind(id!(world0[0]).into(), "unix!@1".parse().unwrap());
+        router.bind(id!(world0[1]).into(), "unix!@2".parse().unwrap());
+        router.bind(id!(world0[2]).into(), "unix!@3".parse().unwrap());
+
+        let mut prefixes: Vec<Reference> = router.prefixes().into_iter().collect();
+        prefixes.sort();
+
+        // All should be covering prefixes since none is a prefix of another
+        let mut expected = vec![
+            id!(world0[0]).into(),
+            id!(world0[1]).into(),
+            id!(world0[2]).into(),
+        ];
+        expected.sort();
+
+        assert_eq!(prefixes, expected);
     }
 }

--- a/hyperactor/src/proc.rs
+++ b/hyperactor/src/proc.rs
@@ -1335,6 +1335,12 @@ impl<A: Actor> cap::sealed::CanResolveActorRef for Instance<A> {
     }
 }
 
+impl<A: Actor> cap::HasProc for Instance<A> {
+    fn proc(&self) -> &Proc {
+        &self.proc
+    }
+}
+
 impl<A: Actor> cap::sealed::CanSend for Context<'_, A> {
     fn post(&self, dest: PortId, headers: Attrs, data: Serialized) {
         <Instance<A> as cap::sealed::CanSend>::post(self, dest, headers, data)
@@ -1384,6 +1390,12 @@ impl<A: Actor> cap::sealed::CanResolveActorRef for Context<'_, A> {
         actor_ref: &ActorRef<R>,
     ) -> Option<ActorHandle<R>> {
         <Instance<A> as cap::sealed::CanResolveActorRef>::resolve_actor_ref(self, actor_ref)
+    }
+}
+
+impl<A: Actor> cap::HasProc for Context<'_, A> {
+    fn proc(&self) -> &Proc {
+        <Instance<A> as cap::HasProc>::proc(self)
     }
 }
 

--- a/hyperactor/src/reference.rs
+++ b/hyperactor/src/reference.rs
@@ -77,7 +77,17 @@ use crate::parse::parse;
 /// ordered lexicographically with the hierarchy implied by world, proc,
 /// actor. This allows reference ordering to be used to implement prefix
 /// based routing.
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, Hash, Named)]
+#[derive(
+    Debug,
+    Serialize,
+    Deserialize,
+    Clone,
+    PartialEq,
+    Eq,
+    Hash,
+    Named,
+    EnumAsInner
+)]
 pub enum Reference {
     /// A reference to a world.
     World(WorldId),

--- a/hyperactor_mesh/benches/main.rs
+++ b/hyperactor_mesh/benches/main.rs
@@ -46,6 +46,7 @@ fn bench_actor_scaling(c: &mut Criterion) {
                     .allocate(AllocSpec {
                         extent: extent!(hosts = host_count, gpus = gpus),
                         constraints: Default::default(),
+                        proc_name: None,
                     })
                     .await
                     .unwrap();
@@ -142,6 +143,7 @@ fn bench_actor_mesh_message_sizes(c: &mut Criterion) {
                             .allocate(AllocSpec {
                                 extent: extent!(gpus = actor_count),
                                 constraints: Default::default(),
+                                proc_name: None,
                             })
                             .await
                             .unwrap();

--- a/hyperactor_mesh/examples/dining_philosophers.rs
+++ b/hyperactor_mesh/examples/dining_philosophers.rs
@@ -231,6 +231,7 @@ async fn main() -> Result<ExitCode> {
         .allocate(AllocSpec {
             extent: extent! {replica = group_size},
             constraints: Default::default(),
+            proc_name: None,
         })
         .await?;
 

--- a/hyperactor_mesh/examples/sieve.rs
+++ b/hyperactor_mesh/examples/sieve.rs
@@ -108,6 +108,7 @@ async fn main() -> Result<ExitCode> {
         .allocate(AllocSpec {
             extent: extent! { replica = 1 },
             constraints: Default::default(),
+            proc_name: None,
         })
         .await?;
 

--- a/hyperactor_mesh/src/actor_mesh.rs
+++ b/hyperactor_mesh/src/actor_mesh.rs
@@ -619,6 +619,7 @@ pub(crate) mod test_util {
                 .allocate(AllocSpec {
                     extent: extent! { replica = 1 },
                     constraints: Default::default(),
+                    proc_name: None,
                 })
                 .await
                 .unwrap();
@@ -719,6 +720,7 @@ mod tests {
                     .allocate(AllocSpec {
                         extent: extent! { replica = 1 },
                         constraints: Default::default(),
+                        proc_name: None,
                     })
                     .await
                     .unwrap();
@@ -741,6 +743,7 @@ mod tests {
                     .allocate(AllocSpec {
                         extent: extent!(replica = 4),
                         constraints: Default::default(),
+                        proc_name: None,
                     })
                     .await
                     .unwrap();
@@ -766,6 +769,7 @@ mod tests {
                     .allocate(AllocSpec {
                         extent: extent!(replica = 2),
                         constraints: Default::default(),
+                        proc_name: None,
                     })
                     .await
                     .unwrap();
@@ -801,6 +805,7 @@ mod tests {
                     .allocate(AllocSpec {
                         extent: extent!(x = X, y = Y, z = Z),
                         constraints: Default::default(),
+                        proc_name: None,
                     })
                     .await
                     .unwrap();
@@ -844,6 +849,7 @@ mod tests {
                     .allocate(AllocSpec {
                         extent: extent!(replica = 2, host = 2, gpu = 8),
                         constraints: Default::default(),
+                        proc_name: None,
                     })
                     .await
                     .unwrap();
@@ -885,6 +891,7 @@ mod tests {
                         // reasonable (< 60s).
                         extent: extent!(replica = 2, host = 2, gpu = 8),
                         constraints: Default::default(),
+                        proc_name: None,
                     })
                     .await
                     .unwrap();
@@ -915,6 +922,7 @@ mod tests {
                         .allocate(AllocSpec {
                             extent: extent!(replica = 1),
                             constraints: Default::default(),
+                            proc_name: None,
                         })
                         .await
                         .unwrap();
@@ -962,6 +970,7 @@ mod tests {
                     .allocate(AllocSpec {
                         extent,
                         constraints: Default::default(),
+                        proc_name: None,
                     })
                     .await
                     .unwrap();
@@ -991,6 +1000,7 @@ mod tests {
                     .allocate(AllocSpec {
                         extent: extent!(replica = 1 ),
                         constraints: Default::default(),
+                        proc_name: None,
                     })
                     .await
                     .unwrap();
@@ -1020,6 +1030,7 @@ mod tests {
                     .allocate(AllocSpec {
                         extent: extent.clone(),
                         constraints: Default::default(),
+                        proc_name: None,
                     })
                     .await
                     .unwrap();
@@ -1083,6 +1094,7 @@ mod tests {
                 .allocate(AllocSpec {
                     extent: extent!(replica = 2),
                     constraints: Default::default(),
+                    proc_name: None,
                 })
                 .await
                 .unwrap();
@@ -1150,6 +1162,7 @@ mod tests {
                 .allocate(AllocSpec {
                     extent: extent!(replica = 1),
                     constraints: Default::default(),
+                    proc_name: None,
                 })
                 .await
                 .unwrap();
@@ -1216,6 +1229,7 @@ mod tests {
                 .allocate(AllocSpec {
                     extent: extent!(replica = 2),
                     constraints: Default::default(),
+                    proc_name: None,
                 })
                 .await
                 .unwrap();
@@ -1319,6 +1333,7 @@ mod tests {
                 .allocate(AllocSpec {
                     extent: extent!(replica = 1),
                     constraints: Default::default(),
+                    proc_name: None,
                 })
                 .await
                 .unwrap();
@@ -1402,6 +1417,7 @@ mod tests {
                 .allocate(AllocSpec {
                     extent: extent! { replica = 1 },
                     constraints: Default::default(),
+                    proc_name: None,
                 })
                 .await
                 .unwrap();

--- a/hyperactor_mesh/src/alloc.rs
+++ b/hyperactor_mesh/src/alloc.rs
@@ -628,7 +628,7 @@ pub(crate) mod testing {
                 client,
                 rank,
                 router_channel_addr,
-                supervison_port.bind(),
+                Some(supervison_port.bind()),
                 HashMap::new(),
                 config_handle.bind(),
             )

--- a/hyperactor_mesh/src/alloc.rs
+++ b/hyperactor_mesh/src/alloc.rs
@@ -41,7 +41,7 @@ use strum::AsRefStr;
 
 use crate::alloc::test_utils::MockAllocWrapper;
 use crate::assign::Ranks;
-use crate::proc_mesh::mesh_agent::MeshAgent;
+use crate::proc_mesh::mesh_agent::ProcMeshAgent;
 use crate::shortuuid::ShortUuid;
 
 /// Errors that occur during allocation operations.
@@ -120,7 +120,7 @@ pub enum ProcState {
         proc_id: ProcId,
         /// Reference to this proc's mesh agent. In the future, we'll reserve a
         /// 'well known' PID (0) for this purpose.
-        mesh_agent: ActorRef<MeshAgent>,
+        mesh_agent: ActorRef<ProcMeshAgent>,
         /// The address of this proc. The endpoint of this address is
         /// the proc's mailbox, which accepts [`hyperactor::mailbox::MessageEnvelope`]s.
         addr: ChannelAddr,
@@ -262,7 +262,7 @@ pub(crate) struct AllocatedProc {
     pub create_key: ShortUuid,
     pub proc_id: ProcId,
     pub addr: ChannelAddr,
-    pub mesh_agent: ActorRef<MeshAgent>,
+    pub mesh_agent: ActorRef<ProcMeshAgent>,
 }
 
 impl fmt::Display for AllocatedProc {
@@ -618,7 +618,7 @@ pub(crate) mod testing {
         client_proc: &Proc,
         client: &Mailbox,
         router_channel_addr: ChannelAddr,
-        mesh_agent: ActorRef<MeshAgent>,
+        mesh_agent: ActorRef<ProcMeshAgent>,
     ) -> ActorRef<TestActor> {
         let supervisor = client_proc.attach("supervisor").unwrap();
         let (supervison_port, _) = supervisor.open_port();

--- a/hyperactor_mesh/src/alloc/local.rs
+++ b/hyperactor_mesh/src/alloc/local.rs
@@ -33,7 +33,7 @@ use crate::alloc::AllocSpec;
 use crate::alloc::Allocator;
 use crate::alloc::AllocatorError;
 use crate::alloc::ProcState;
-use crate::proc_mesh::mesh_agent::MeshAgent;
+use crate::proc_mesh::mesh_agent::ProcMeshAgent;
 use crate::shortuuid::ShortUuid;
 
 enum Action {
@@ -175,7 +175,7 @@ impl Alloc for LocalAlloc {
                     };
 
                     let bspan = tracing::info_span!("mesh_agent_bootstrap");
-                    let (proc, mesh_agent) = match MeshAgent::bootstrap(proc_id.clone()).await {
+                    let (proc, mesh_agent) = match ProcMeshAgent::bootstrap(proc_id.clone()).await {
                         Ok(proc_and_agent) => proc_and_agent,
                         Err(err) => {
                             let message = format!("failed spawn mesh agent for {}: {}", rank, err);

--- a/hyperactor_mesh/src/alloc/remoteprocess.rs
+++ b/hyperactor_mesh/src/alloc/remoteprocess.rs
@@ -1215,7 +1215,7 @@ mod test {
     use crate::alloc::MockAllocWrapper;
     use crate::alloc::MockAllocator;
     use crate::alloc::ProcStopReason;
-    use crate::proc_mesh::mesh_agent::MeshAgent;
+    use crate::proc_mesh::mesh_agent::ProcMeshAgent;
 
     async fn read_all_created(rx: &mut ChannelRx<RemoteProcessProcStateMessage>, alloc_len: usize) {
         let mut i: usize = 0;
@@ -1269,7 +1269,7 @@ mod test {
         }
         for i in 0..extent.num_ranks() {
             let proc_id = format!("test[{}]", i).parse().unwrap();
-            let mesh_agent = ActorRef::<MeshAgent>::attest(
+            let mesh_agent = ActorRef::<ProcMeshAgent>::attest(
                 format!("test[{}].mesh_agent[{}]", i, i).parse().unwrap(),
             );
             let create_key = create_keys[i].clone();
@@ -1398,7 +1398,7 @@ mod test {
                     assert_eq!(got_alloc_key, alloc_key);
                     assert_eq!(create_key, create_keys[rank]);
                     let expected_proc_id = format!("test[{}]", rank).parse().unwrap();
-                    let expected_mesh_agent = ActorRef::<MeshAgent>::attest(
+                    let expected_mesh_agent = ActorRef::<ProcMeshAgent>::attest(
                         format!("test[{}].mesh_agent[{}]", rank, rank)
                             .parse()
                             .unwrap(),

--- a/hyperactor_mesh/src/bootstrap.rs
+++ b/hyperactor_mesh/src/bootstrap.rs
@@ -26,7 +26,7 @@ use serde::Serialize;
 use tokio::sync::Mutex;
 use tokio::sync::oneshot;
 
-use crate::proc_mesh::mesh_agent::MeshAgent;
+use crate::proc_mesh::mesh_agent::ProcMeshAgent;
 
 pub const BOOTSTRAP_ADDR_ENV: &str = "HYPERACTOR_MESH_BOOTSTRAP_ADDR";
 pub const BOOTSTRAP_INDEX_ENV: &str = "HYPERACTOR_MESH_INDEX";
@@ -54,7 +54,7 @@ pub(crate) enum Process2AllocatorMessage {
     /// served at the provided channel address. Procs are started
     /// after instruction by the allocator through the corresponding
     /// [`Allocator2Process`] message.
-    StartedProc(ProcId, ActorRef<MeshAgent>, ChannelAddr),
+    StartedProc(ProcId, ActorRef<ProcMeshAgent>, ChannelAddr),
 
     Heartbeat,
 }
@@ -183,7 +183,7 @@ pub async fn bootstrap() -> anyhow::Error {
             let _ = hyperactor::tracing::info_span!("wait_for_next_message_from_mesh_agent");
             match the_msg? {
                 Allocator2Process::StartProc(proc_id, listen_transport) => {
-                    let (proc, mesh_agent) = MeshAgent::bootstrap(proc_id.clone()).await?;
+                    let (proc, mesh_agent) = ProcMeshAgent::bootstrap(proc_id.clone()).await?;
                     let (proc_addr, proc_rx) =
                         channel::serve(ChannelAddr::any(listen_transport)).await?;
                     let handle = proc.clone().serve(proc_rx);

--- a/hyperactor_mesh/src/comm.rs
+++ b/hyperactor_mesh/src/comm.rs
@@ -761,6 +761,7 @@ mod tests {
             .allocate(AllocSpec {
                 extent: extent.clone(),
                 constraints: Default::default(),
+                proc_name: None,
             })
             .await
             .unwrap();

--- a/hyperactor_mesh/src/lib.rs
+++ b/hyperactor_mesh/src/lib.rs
@@ -29,6 +29,7 @@ mod router;
 pub mod shared_cell;
 pub mod shortuuid;
 pub mod test_utils;
+pub mod v1;
 
 pub use actor_mesh::RootActorMesh;
 pub use actor_mesh::SlicedActorMesh;

--- a/hyperactor_mesh/src/lib.rs
+++ b/hyperactor_mesh/src/lib.rs
@@ -25,6 +25,7 @@ pub mod mesh_selection;
 mod metrics;
 pub mod proc_mesh;
 pub mod reference;
+mod router;
 pub mod shared_cell;
 pub mod shortuuid;
 pub mod test_utils;

--- a/hyperactor_mesh/src/proc_mesh.rs
+++ b/hyperactor_mesh/src/proc_mesh.rs
@@ -350,7 +350,7 @@ impl ProcMesh {
                     &client,
                     rank,
                     router_channel_addr.clone(),
-                    supervision_port.bind(),
+                    Some(supervision_port.bind()),
                     address_book.clone(),
                     config_handle.bind(),
                 )

--- a/hyperactor_mesh/src/proc_mesh.rs
+++ b/hyperactor_mesh/src/proc_mesh.rs
@@ -64,8 +64,8 @@ use crate::alloc::ProcStopReason;
 use crate::assign::Ranks;
 use crate::comm::CommActorMode;
 use crate::proc_mesh::mesh_agent::GspawnResult;
-use crate::proc_mesh::mesh_agent::MeshAgent;
 use crate::proc_mesh::mesh_agent::MeshAgentMessageClient;
+use crate::proc_mesh::mesh_agent::ProcMeshAgent;
 use crate::proc_mesh::mesh_agent::StopActorResult;
 use crate::reference::ProcMeshId;
 use crate::router;
@@ -190,7 +190,7 @@ pub struct ProcMesh {
     event_state: Option<EventState>,
     actor_event_router: ActorEventRouter,
     shape: Shape,
-    ranks: Vec<(ShortUuid, ProcId, ChannelAddr, ActorRef<MeshAgent>)>,
+    ranks: Vec<(ShortUuid, ProcId, ChannelAddr, ActorRef<ProcMeshAgent>)>,
     #[allow(dead_code)] // will be used in subsequent diff
     client_proc: Proc,
     client: Mailbox,
@@ -334,7 +334,6 @@ impl ProcMesh {
 
         // 6. Configure the mesh agents. This transmits the address book to all agents,
         //    so that they can resolve and route traffic to all nodes in the mesh.
-
         let address_book: HashMap<_, _> = running
             .iter()
             .map(
@@ -381,7 +380,7 @@ impl ProcMesh {
         // unification!
         //
         // Baffling and unsettling.
-        fn project_mesh_agent_ref(allocated_proc: &AllocatedProc) -> ActorRef<MeshAgent> {
+        fn project_mesh_agent_ref(allocated_proc: &AllocatedProc) -> ActorRef<ProcMeshAgent> {
             allocated_proc.mesh_agent.clone()
         }
 
@@ -436,7 +435,7 @@ impl ProcMesh {
 
     async fn spawn_on_procs<A: Actor + RemoteActor>(
         cx: &(impl cap::CanSend + cap::CanOpenPort),
-        agents: impl IntoIterator<Item = ActorRef<MeshAgent>> + '_,
+        agents: impl IntoIterator<Item = ActorRef<ProcMeshAgent>> + '_,
         actor_name: &str,
         params: &A::Params,
     ) -> Result<Vec<ActorRef<A>>, anyhow::Error>
@@ -495,7 +494,7 @@ impl ProcMesh {
             .collect())
     }
 
-    fn agents(&self) -> impl Iterator<Item = ActorRef<MeshAgent>> + '_ {
+    fn agents(&self) -> impl Iterator<Item = ActorRef<ProcMeshAgent>> + '_ {
         self.ranks.iter().map(|(_, _, _, agent)| agent.clone())
     }
 

--- a/hyperactor_mesh/src/proc_mesh/mesh_agent.rs
+++ b/hyperactor_mesh/src/proc_mesh/mesh_agent.rs
@@ -117,7 +117,7 @@ pub(crate) enum MeshAgentMessage {
 /// A mesh agent is responsible for managing procs in a [`ProcMesh`].
 #[derive(Debug)]
 #[hyperactor::export(handlers=[MeshAgentMessage])]
-pub struct MeshAgent {
+pub struct ProcMeshAgent {
     proc: Proc,
     remote: Remote,
     sender: ReconfigurableMailboxSender,
@@ -125,7 +125,7 @@ pub struct MeshAgent {
     supervisor: Option<PortRef<ActorSupervisionEvent>>,
 }
 
-impl MeshAgent {
+impl ProcMeshAgent {
     #[hyperactor::observe_result("MeshAgent")]
     pub(crate) async fn bootstrap(
         proc_id: ProcId,
@@ -137,7 +137,7 @@ impl MeshAgent {
         // this process can reach actors in this proc.
         super::router::global().bind(proc_id.into(), proc.clone());
 
-        let agent = MeshAgent {
+        let agent = ProcMeshAgent {
             proc: proc.clone(),
             remote: Remote::collect(),
             sender,
@@ -150,7 +150,7 @@ impl MeshAgent {
 }
 
 #[async_trait]
-impl Actor for MeshAgent {
+impl Actor for ProcMeshAgent {
     type Params = Self;
 
     async fn new(params: Self::Params) -> Result<Self, anyhow::Error> {
@@ -165,7 +165,7 @@ impl Actor for MeshAgent {
 
 #[async_trait]
 #[hyperactor::forward(MeshAgentMessage)]
-impl MeshAgentMessageHandler for MeshAgent {
+impl MeshAgentMessageHandler for ProcMeshAgent {
     async fn configure(
         &mut self,
         cx: &Context<Self>,
@@ -268,7 +268,7 @@ impl MeshAgentMessageHandler for MeshAgent {
 }
 
 #[async_trait]
-impl Handler<ActorSupervisionEvent> for MeshAgent {
+impl Handler<ActorSupervisionEvent> for ProcMeshAgent {
     async fn handle(
         &mut self,
         cx: &Context<Self>,

--- a/hyperactor_mesh/src/proc_mesh/mesh_agent.rs
+++ b/hyperactor_mesh/src/proc_mesh/mesh_agent.rs
@@ -135,7 +135,7 @@ impl MeshAgent {
 
         // Wire up this proc to the global router so that any meshes managed by
         // this process can reach actors in this proc.
-        super::global_router().bind(proc_id.into(), proc.clone());
+        super::router::global().bind(proc_id.into(), proc.clone());
 
         let agent = MeshAgent {
             proc: proc.clone(),
@@ -188,7 +188,7 @@ impl MeshAgentMessageHandler for MeshAgent {
         // set as a means of failure injection in the testing of
         // supervision codepaths.
         let router = if std::env::var("HYPERACTOR_MESH_ROUTER_NO_GLOBAL_FALLBACK").is_err() {
-            let default = super::global_router().fallback(client.into_boxed());
+            let default = super::router::global().fallback(client.into_boxed());
             DialMailboxRouter::new_with_default(default.into_boxed())
         } else {
             DialMailboxRouter::new_with_default(client.into_boxed())

--- a/hyperactor_mesh/src/reference.rs
+++ b/hyperactor_mesh/src/reference.rs
@@ -278,6 +278,7 @@ mod tests {
             .allocate(AllocSpec {
                 extent: extent(),
                 constraints: Default::default(),
+                proc_name: None,
             })
             .await
             .unwrap();
@@ -285,6 +286,7 @@ mod tests {
             .allocate(AllocSpec {
                 extent: extent(),
                 constraints: Default::default(),
+                proc_name: None,
             })
             .await
             .unwrap();

--- a/hyperactor_mesh/src/router.rs
+++ b/hyperactor_mesh/src/router.rs
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+//! This module supports (in-process) global routing in hyperactor meshes.
+
+use std::collections::HashMap;
+use std::ops::Deref;
+use std::sync::OnceLock;
+
+use hyperactor::channel;
+use hyperactor::channel::ChannelAddr;
+use hyperactor::channel::ChannelError;
+use hyperactor::channel::ChannelTransport;
+use hyperactor::mailbox::DialMailboxRouter;
+use hyperactor::mailbox::MailboxRouter;
+use hyperactor::mailbox::MailboxServer;
+use tokio::sync::Mutex;
+
+/// The shared, global router for this process.
+pub fn global() -> &'static Router {
+    static GLOBAL_ROUTER: OnceLock<Router> = OnceLock::new();
+    GLOBAL_ROUTER.get_or_init(Router::new)
+}
+
+/// Router augments [`MailboxRouter`] with additional APIs and
+/// bookeeping relevant to meshes.
+pub struct Router {
+    router: MailboxRouter,
+    servers: Mutex<HashMap<ChannelTransport, ChannelAddr>>,
+}
+
+/// Deref so that we can use the [`MailboxRouter`] APIs directly.
+impl Deref for Router {
+    type Target = MailboxRouter;
+
+    fn deref(&self) -> &Self::Target {
+        &self.router
+    }
+}
+
+impl Router {
+    /// Create a new router.
+    fn new() -> Self {
+        Self {
+            router: MailboxRouter::new(),
+            servers: Mutex::new(HashMap::new()),
+        }
+    }
+
+    /// Serve this router on the provided transport, returning the address.
+    /// Servers are memoized, and we maintain only one per transport; thus
+    /// subsequent calls using the same transport will return the same address.
+    pub async fn serve(&self, transport: &ChannelTransport) -> Result<ChannelAddr, ChannelError> {
+        let mut servers = self.servers.lock().await;
+        if let Some(addr) = servers.get(transport) {
+            return Ok(addr.clone());
+        }
+
+        let (addr, rx) = channel::serve(ChannelAddr::any(transport.clone())).await?;
+        self.router.clone().serve(rx);
+        servers.insert(transport.clone(), addr.clone());
+        Ok(addr)
+    }
+
+    /// Binds a [`DialMailboxRouter`] directly into this router. Specifically, each
+    /// prefix served by `router` is bound directly into this [`MailboxRouter`].
+    pub fn bind_dial_router(&self, router: &DialMailboxRouter) {
+        for prefix in router.prefixes() {
+            self.router.bind(prefix, router.clone());
+        }
+    }
+}

--- a/hyperactor_mesh/src/shortuuid.rs
+++ b/hyperactor_mesh/src/shortuuid.rs
@@ -52,9 +52,8 @@ impl ShortUuid {
     pub fn generate() -> ShortUuid {
         ShortUuid(rand::thread_rng().next_u64())
     }
-}
-impl std::fmt::Display for ShortUuid {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+
+    pub(crate) fn format(&self, f: &mut std::fmt::Formatter<'_>, raw: bool) -> std::fmt::Result {
         let mut num = self.0;
         let base = FLICKR_BASE_58.len() as u64;
         let mut result = String::with_capacity(12);
@@ -65,7 +64,7 @@ impl std::fmt::Display for ShortUuid {
             let c = FLICKR_BASE_58.chars().nth(remainder).unwrap();
             result.push(c);
             // Make sure the first position is never a digit.
-            if pos == 11 && c >= '0' && c <= '9' {
+            if !raw && pos == 11 && c >= '0' && c <= '9' {
                 result.push('_');
             }
         }
@@ -73,6 +72,11 @@ impl std::fmt::Display for ShortUuid {
 
         let result = result.chars().rev().collect::<String>();
         write!(f, "{}", result)
+    }
+}
+impl std::fmt::Display for ShortUuid {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.format(f, false /*raw*/)
     }
 }
 

--- a/hyperactor_mesh/src/shortuuid.rs
+++ b/hyperactor_mesh/src/shortuuid.rs
@@ -13,6 +13,8 @@ use std::str::FromStr;
 use std::sync::LazyLock;
 
 use rand::RngCore;
+use serde::Deserialize;
+use serde::Serialize;
 
 /// So-called ["Flickr base 58"](https://www.flickr.com/groups/api/discuss/72157616713786392/)
 /// as this alphabet was used in Flickr URLs. It has nice properties: 1) characters are all
@@ -42,7 +44,7 @@ static FLICKR_BASE_58_ORD: LazyLock<[Option<usize>; 256]> = LazyLock::new(|| {
 /// The characters "_" and "-" are ignored when decoding, and may be
 /// safely interspersed. By default, rendered UUIDs that begin with a
 /// numeric character is prefixed with "_".
-#[derive(PartialEq, Eq, Debug, Clone)]
+#[derive(PartialEq, Eq, Hash, Debug, Clone, Serialize, Deserialize)]
 pub struct ShortUuid(u64);
 
 impl ShortUuid {

--- a/hyperactor_mesh/src/v1.rs
+++ b/hyperactor_mesh/src/v1.rs
@@ -12,12 +12,16 @@
 
 pub mod host_mesh;
 pub mod proc_mesh;
+pub mod value_mesh;
 
 use std::str::FromStr;
 
+pub use host_mesh::HostMeshRef;
 use hyperactor::ActorId;
+pub use proc_mesh::ProcMeshRef;
 use serde::Deserialize;
 use serde::Serialize;
+pub use value_mesh::ValueMesh;
 
 use crate::shortuuid::ShortUuid;
 use crate::v1::host_mesh::HostMeshRefParseError;

--- a/hyperactor_mesh/src/v1.rs
+++ b/hyperactor_mesh/src/v1.rs
@@ -10,14 +10,18 @@
 //! This will be moved down to the base module when we graduate
 //! the APIs and fully deprecate the "v0" APIs.
 
+pub mod actor_mesh;
 pub mod host_mesh;
 pub mod proc_mesh;
 pub mod value_mesh;
 
 use std::str::FromStr;
 
+pub use actor_mesh::ActorMesh;
+pub use actor_mesh::ActorMeshRef;
 pub use host_mesh::HostMeshRef;
 use hyperactor::ActorId;
+use hyperactor::mailbox::MailboxSenderError;
 pub use proc_mesh::ProcMeshRef;
 use serde::Deserialize;
 use serde::Serialize;
@@ -44,6 +48,12 @@ pub enum Error {
     #[error(transparent)]
     ChannelError(#[from] hyperactor::channel::ChannelError),
 
+    #[error(transparent)]
+    MailboxError(#[from] hyperactor::mailbox::MailboxError),
+
+    #[error(transparent)]
+    BincodeError(#[from] bincode::Error),
+
     #[error("error during mesh configuration: {0}")]
     ConfigurationError(anyhow::Error),
 
@@ -53,6 +63,15 @@ pub enum Error {
 
     #[error("error while calling actor {0}: {1}")]
     CallError(ActorId, anyhow::Error),
+
+    #[error("actor not registered for type {0}")]
+    ActorTypeNotRegistered(String),
+
+    #[error("error while spawning actor {0}: {1}")]
+    GspawnError(Name, String),
+
+    #[error("error while sending message to actor {0}: {1}")]
+    SendingError(ActorId, MailboxSenderError),
 }
 
 /// The type of result used in `hyperactor_mesh::v1`.

--- a/hyperactor_mesh/src/v1.rs
+++ b/hyperactor_mesh/src/v1.rs
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+//! A temporary holding space for APIv1 of the Hyperactor Mesh.
+//! This will be moved down to the base module when we graduate
+//! the APIs and fully deprecate the "v0" APIs.
+
+pub mod host_mesh;
+pub mod proc_mesh;
+
+use std::str::FromStr;
+
+use serde::Deserialize;
+use serde::Serialize;
+
+use crate::shortuuid::ShortUuid;
+use crate::v1::host_mesh::HostMeshRefParseError;
+
+/// Errors that occur during mesh operations.
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("invalid mesh ref: expected {expected} ranks, but contains {actual} ranks")]
+    InvalidRankCardinality { expected: usize, actual: usize },
+
+    #[error(transparent)]
+    NameParseError(#[from] NameParseError),
+
+    #[error(transparent)]
+    HostMeshRefParseError(#[from] HostMeshRefParseError),
+}
+
+/// The type of result used in `hyperactor_mesh::v1`.
+pub type Result<T> = std::result::Result<T, Error>;
+
+/// Names are used to identify objects in the system. They have a user-provided name,
+/// and a unique UUID.
+///
+/// Names have a concrete syntax--`{name}-{uuid}`--printed by `Display` and parsed by `FromStr`.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct Name(pub String, pub ShortUuid);
+
+impl Name {
+    /// Create a new `Name` from a user-provided base name.
+    pub fn new(name: impl Into<String>) -> Self {
+        let mut name = name.into();
+        if name.is_empty() {
+            name = "unnamed".to_string();
+        }
+        let uuid = ShortUuid::generate();
+        Self(name, uuid)
+    }
+
+    /// The name portion of this `Name`.
+    pub fn name(&self) -> &str {
+        &self.0
+    }
+
+    /// The UUID portion of this `Name`.
+    pub fn uuid(&self) -> &ShortUuid {
+        &self.1
+    }
+}
+
+/// Errors that occur when parsing names.
+#[derive(thiserror::Error, Debug)]
+pub enum NameParseError {
+    #[error("invalid name: missing name")]
+    MissingName,
+
+    #[error("invalid name: missing uuid")]
+    MissingUuid,
+
+    #[error(transparent)]
+    InvalidUuid(#[from] <ShortUuid as FromStr>::Err),
+
+    #[error("invalid name: missing separator")]
+    MissingSeparator,
+}
+
+impl FromStr for Name {
+    type Err = NameParseError;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        let (name, uuid) = s.split_once('-').ok_or(NameParseError::MissingSeparator)?;
+        if name.is_empty() {
+            return Err(NameParseError::MissingName);
+        }
+        if uuid.is_empty() {
+            return Err(NameParseError::MissingName);
+        }
+
+        let name = name.to_string();
+        let uuid = uuid.parse()?;
+        Ok(Name(name, uuid))
+    }
+}
+
+impl std::fmt::Display for Name {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}-", self.name())?;
+        self.uuid().format(f, true /*raw*/)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_name_unique() {
+        assert_ne!(Name::new("foo"), Name::new("foo"));
+        let name = Name::new("foo");
+        assert_eq!(name, name);
+    }
+
+    #[test]
+    fn test_name_roundtrip() {
+        let name = Name::new("foo");
+        assert_eq!(name, Name::from_str(&name.to_string()).unwrap());
+    }
+}

--- a/hyperactor_mesh/src/v1.rs
+++ b/hyperactor_mesh/src/v1.rs
@@ -15,6 +15,7 @@ pub mod proc_mesh;
 
 use std::str::FromStr;
 
+use hyperactor::ActorId;
 use serde::Deserialize;
 use serde::Serialize;
 
@@ -32,6 +33,22 @@ pub enum Error {
 
     #[error(transparent)]
     HostMeshRefParseError(#[from] HostMeshRefParseError),
+
+    #[error(transparent)]
+    AllocatorError(#[from] crate::alloc::AllocatorError),
+
+    #[error(transparent)]
+    ChannelError(#[from] hyperactor::channel::ChannelError),
+
+    #[error("error during mesh configuration: {0}")]
+    ConfigurationError(anyhow::Error),
+
+    // This is a temporary error to ensure we don't create unroutable meshes.
+    #[error("configuration error: mesh is unroutable")]
+    UnroutableMesh(),
+
+    #[error("error while calling actor {0}: {1}")]
+    CallError(ActorId, anyhow::Error),
 }
 
 /// The type of result used in `hyperactor_mesh::v1`.

--- a/hyperactor_mesh/src/v1.rs
+++ b/hyperactor_mesh/src/v1.rs
@@ -43,21 +43,22 @@ pub enum Error {
     HostMeshRefParseError(#[from] HostMeshRefParseError),
 
     #[error(transparent)]
-    AllocatorError(#[from] crate::alloc::AllocatorError),
+    AllocatorError(#[from] Box<crate::alloc::AllocatorError>),
 
     #[error(transparent)]
-    ChannelError(#[from] hyperactor::channel::ChannelError),
+    ChannelError(#[from] Box<hyperactor::channel::ChannelError>),
 
     #[error(transparent)]
-    MailboxError(#[from] hyperactor::mailbox::MailboxError),
+    MailboxError(#[from] Box<hyperactor::mailbox::MailboxError>),
 
     #[error(transparent)]
-    BincodeError(#[from] bincode::Error),
+    BincodeError(#[from] Box<bincode::Error>),
 
     #[error("error during mesh configuration: {0}")]
     ConfigurationError(anyhow::Error),
 
-    // This is a temporary error to ensure we don't create unroutable meshes.
+    // This is a temporary error to ensure we don't create unroutable
+    // meshes.
     #[error("configuration error: mesh is unroutable")]
     UnroutableMesh(),
 
@@ -71,7 +72,31 @@ pub enum Error {
     GspawnError(Name, String),
 
     #[error("error while sending message to actor {0}: {1}")]
-    SendingError(ActorId, MailboxSenderError),
+    SendingError(ActorId, Box<MailboxSenderError>),
+}
+
+impl From<crate::alloc::AllocatorError> for Error {
+    fn from(e: crate::alloc::AllocatorError) -> Self {
+        Error::AllocatorError(Box::new(e))
+    }
+}
+
+impl From<hyperactor::channel::ChannelError> for Error {
+    fn from(e: hyperactor::channel::ChannelError) -> Self {
+        Error::ChannelError(Box::new(e))
+    }
+}
+
+impl From<hyperactor::mailbox::MailboxError> for Error {
+    fn from(e: hyperactor::mailbox::MailboxError) -> Self {
+        Error::MailboxError(Box::new(e))
+    }
+}
+
+impl From<bincode::Error> for Error {
+    fn from(e: bincode::Error) -> Self {
+        Error::BincodeError(Box::new(e))
+    }
 }
 
 /// The type of result used in `hyperactor_mesh::v1`.

--- a/hyperactor_mesh/src/v1/actor_mesh.rs
+++ b/hyperactor_mesh/src/v1/actor_mesh.rs
@@ -1,0 +1,99 @@
+use std::marker::PhantomData;
+
+use hyperactor::Actor;
+use hyperactor::ActorRef;
+use hyperactor::RemoteHandles;
+use hyperactor::RemoteMessage;
+use hyperactor::actor::RemoteActor;
+use hyperactor::cap;
+use hyperactor::message::Castable;
+use ndslice::view;
+use ndslice::view::Region;
+use ndslice::view::View;
+use ndslice::view::ViewExt;
+use serde::Deserialize;
+use serde::Serialize;
+
+use crate::v1;
+use crate::v1::Error;
+use crate::v1::Name;
+use crate::v1::ProcMeshRef;
+
+/// An ActorMesh is a collection of ranked A-typed actors.
+#[derive(Debug)]
+pub struct ActorMesh<A> {
+    proc_mesh: ProcMeshRef,
+    name: Name,
+    _phantom: PhantomData<A>,
+}
+
+impl<A> ActorMesh<A> {
+    pub(crate) fn new(proc_mesh: ProcMeshRef, name: Name) -> Self {
+        Self {
+            proc_mesh,
+            name,
+            _phantom: PhantomData,
+        }
+    }
+
+    /// Freeze this actor mesh in its current state, returning a stable
+    /// reference that may be serialized.
+    pub fn freeze(&self) -> ActorMeshRef<A> {
+        ActorMeshRef {
+            proc_mesh: self.proc_mesh.clone(),
+            name: self.name.clone(),
+            _phantom: PhantomData,
+        }
+    }
+}
+
+/// A reference to a stable snapshot of an [`ActorMesh`].
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct ActorMeshRef<A> {
+    proc_mesh: ProcMeshRef,
+    name: Name,
+    _phantom: PhantomData<A>,
+}
+
+impl<A: Actor + RemoteActor> ActorMeshRef<A> {
+    /// Cast a message to all actors in this mesh.
+    pub fn cast<M>(&self, caps: &impl cap::CanSend, message: M) -> v1::Result<()>
+    where
+        M: Castable + RemoteMessage + Clone,
+        A: RemoteHandles<M>,
+    {
+        // todo: headers, binding/unbinding/accumulation
+        for actor_ref in self.values() {
+            actor_ref
+                .send(caps, message.clone())
+                .map_err(|e| Error::SendingError(actor_ref.actor_id().clone(), e))?;
+        }
+        Ok(())
+    }
+}
+
+impl<A: RemoteActor> view::Ranked for ActorMeshRef<A> {
+    type Item = ActorRef<A>;
+
+    fn region(&self) -> &Region {
+        view::Ranked::region(&self.proc_mesh)
+    }
+
+    fn get(&self, rank: usize) -> Option<ActorRef<A>> {
+        let proc_ref = view::Ranked::get(&self.proc_mesh, rank)?;
+        Some(proc_ref.attest(&self.name.clone()))
+    }
+
+    // TODO: adjust this to include a compaction hint, rather than the nodes themselves,
+    // as the current interface forces refs like ActorRef, which does not materialize its
+    // ranks, to needlessly materialize.
+    fn sliced(&self, region: Region, _nodes: impl Iterator<Item = ActorRef<A>>) -> Self {
+        Self {
+            // This is safe because by the time `sliced` has been called, the subsetting
+            // has been validated.
+            proc_mesh: self.proc_mesh.subset(region).unwrap(),
+            name: self.name.clone(),
+            _phantom: PhantomData,
+        }
+    }
+}

--- a/hyperactor_mesh/src/v1/actor_mesh.rs
+++ b/hyperactor_mesh/src/v1/actor_mesh.rs
@@ -1,3 +1,11 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 use std::marker::PhantomData;
 
 use hyperactor::Actor;
@@ -66,7 +74,7 @@ impl<A: Actor + RemoteActor> ActorMeshRef<A> {
         for actor_ref in self.values() {
             actor_ref
                 .send(caps, message.clone())
-                .map_err(|e| Error::SendingError(actor_ref.actor_id().clone(), e))?;
+                .map_err(|e| Error::SendingError(actor_ref.actor_id().clone(), Box::new(e)))?;
         }
         Ok(())
     }

--- a/hyperactor_mesh/src/v1/host_mesh.rs
+++ b/hyperactor_mesh/src/v1/host_mesh.rs
@@ -1,0 +1,173 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+use std::str::FromStr;
+use std::sync::Arc;
+
+use hyperactor::Named;
+use hyperactor::channel::ChannelAddr;
+use ndslice::Region;
+use ndslice::view;
+use ndslice::view::RegionParseError;
+use serde::Deserialize;
+use serde::Serialize;
+
+use crate::v1;
+
+/// A reference to a single host.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Named, Serialize, Deserialize)]
+pub struct HostRef(ChannelAddr);
+
+impl std::fmt::Display for HostRef {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl FromStr for HostRef {
+    type Err = <ChannelAddr as FromStr>::Err;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(HostRef(ChannelAddr::from_str(s)?))
+    }
+}
+
+/// A reference to a mesh of hosts. Logically this is a data structure that
+/// contains a set of ranked hosts organized into a [`Region`]. HostMeshRefs
+/// can be sliced to produce new HostMeshRefs that contain a subset of the
+/// hosts in the original mesh.
+///
+/// HostMeshRefs have a concrete syntax, implemented by its `Display` and `FromStr`
+/// implementations.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Named, Serialize, Deserialize)]
+pub struct HostMeshRef {
+    region: Region,
+    ranks: Arc<Vec<HostRef>>,
+}
+
+impl HostMeshRef {
+    /// Create a new (raw) HostMeshRef from the provided region and associated
+    /// ranks, which must match in cardinality.
+    fn new(region: Region, ranks: Vec<HostRef>) -> v1::Result<Self> {
+        if region.num_ranks() != ranks.len() {
+            return Err(v1::Error::InvalidRankCardinality {
+                expected: region.num_ranks(),
+                actual: ranks.len(),
+            });
+        }
+        Ok(Self {
+            region,
+            ranks: Arc::new(ranks),
+        })
+    }
+}
+
+impl view::Ranked for HostMeshRef {
+    type Item = HostRef;
+
+    fn region(&self) -> &Region {
+        &self.region
+    }
+
+    fn ranks(&self) -> &[HostRef] {
+        &self.ranks
+    }
+
+    fn sliced<'a>(&self, region: Region, nodes: impl Iterator<Item = &'a HostRef>) -> Self {
+        Self::new(region, nodes.cloned().collect()).unwrap()
+    }
+}
+
+impl std::fmt::Display for HostMeshRef {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        for (rank, host) in self.ranks.iter().enumerate() {
+            if rank > 0 {
+                write!(f, ",")?;
+            }
+            write!(f, "{}", host)?;
+        }
+        write!(f, "@{}", self.region)
+    }
+}
+
+/// The type of error occuring during `HostMeshRef` parsing.
+#[derive(thiserror::Error, Debug)]
+pub enum HostMeshRefParseError {
+    #[error(transparent)]
+    RegionParseError(#[from] RegionParseError),
+
+    #[error("invalid host mesh ref: missing region")]
+    MissingRegion,
+
+    #[error(transparent)]
+    InvalidHostMeshRef(#[from] Box<v1::Error>),
+
+    #[error(transparent)]
+    Other(#[from] anyhow::Error),
+}
+
+impl From<v1::Error> for HostMeshRefParseError {
+    fn from(err: v1::Error) -> Self {
+        Self::InvalidHostMeshRef(Box::new(err))
+    }
+}
+
+impl FromStr for HostMeshRef {
+    type Err = HostMeshRefParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let (hosts, region) = s
+            .split_once('@')
+            .ok_or(HostMeshRefParseError::MissingRegion)?;
+        let hosts = hosts
+            .split(',')
+            .map(|host| host.trim())
+            .map(|host| host.parse::<HostRef>())
+            .collect::<Result<Vec<_>, _>>()?;
+        let region = region.parse()?;
+        Ok(HostMeshRef::new(region, hosts)?)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use ndslice::ViewExt;
+    use ndslice::extent;
+
+    use super::*;
+
+    #[test]
+    fn test_host_mesh_subset() {
+        let hosts: HostMeshRef = "local:1,local:2,local:3,local:4@replica=2/2,host=2/1"
+            .parse()
+            .unwrap();
+        assert_eq!(
+            hosts.range("replica", 1).unwrap().to_string(),
+            "local:3,local:4@2+replica=1/2,host=2/1"
+        );
+    }
+
+    #[test]
+    fn test_host_mesh_ref_parse_roundtrip() {
+        let host_mesh_ref = HostMeshRef::new(
+            extent!(replica = 2, host = 2).into(),
+            vec![
+                "tcp:127.0.0.1:123".parse().unwrap(),
+                "tcp:127.0.0.1:123".parse().unwrap(),
+                "tcp:127.0.0.1:123".parse().unwrap(),
+                "tcp:127.0.0.1:123".parse().unwrap(),
+            ],
+        )
+        .unwrap();
+
+        assert_eq!(
+            host_mesh_ref.to_string().parse::<HostMeshRef>().unwrap(),
+            host_mesh_ref
+        );
+    }
+}

--- a/hyperactor_mesh/src/v1/host_mesh.rs
+++ b/hyperactor_mesh/src/v1/host_mesh.rs
@@ -74,12 +74,12 @@ impl view::Ranked for HostMeshRef {
         &self.region
     }
 
-    fn ranks(&self) -> &[HostRef] {
-        &self.ranks
+    fn get(&self, rank: usize) -> Option<HostRef> {
+        self.ranks.get(rank).cloned()
     }
 
-    fn sliced<'a>(&self, region: Region, nodes: impl Iterator<Item = &'a HostRef>) -> Self {
-        Self::new(region, nodes.cloned().collect()).unwrap()
+    fn sliced(&self, region: Region, nodes: impl Iterator<Item = HostRef>) -> Self {
+        Self::new(region, nodes.collect()).unwrap()
     }
 }
 

--- a/hyperactor_mesh/src/v1/proc_mesh.rs
+++ b/hyperactor_mesh/src/v1/proc_mesh.rs
@@ -6,22 +6,62 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+use std::collections::HashMap;
 use std::sync::Arc;
 
+use hyperactor::ActorRef;
 use hyperactor::Named;
 use hyperactor::ProcId;
+use hyperactor::cap;
+use hyperactor::channel;
+use hyperactor::channel::ChannelAddr;
+use hyperactor::mailbox;
+use hyperactor::mailbox::DialMailboxRouter;
+use hyperactor::mailbox::MailboxServer;
 use ndslice::view;
 use ndslice::view::Region;
 use serde::Deserialize;
 use serde::Serialize;
 
+use crate::alloc::Alloc;
+use crate::alloc::AllocExt;
+use crate::alloc::AllocatedProc;
+use crate::assign::Ranks;
+use crate::proc_mesh::mesh_agent::MeshAgentMessageClient;
+use crate::proc_mesh::mesh_agent::ProcMeshAgent;
 use crate::v1;
+use crate::v1::Error;
 use crate::v1::Name;
 
 /// A reference to a single [`hyperactor::Proc`].
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct ProcRef {
     proc_id: ProcId,
+    /// The rank of this proc at creation.
+    create_rank: usize,
+    /// The agent managing this proc.
+    agent: ActorRef<ProcMeshAgent>,
+}
+
+impl ProcRef {
+    /// Pings the proc, returning whether it is alive. This will be replaced by a
+    /// finer-grained lifecycle status in the near future.
+    async fn status(&self, caps: &(impl cap::CanSend + cap::CanOpenPort)) -> v1::Result<bool> {
+        let (port, mut rx) = mailbox::open_port(caps);
+        self.agent
+            .status(caps, port.bind())
+            .await
+            .map_err(|e| Error::CallError(self.agent.actor_id().clone(), e))?;
+        loop {
+            let (rank, status) = rx
+                .recv()
+                .await
+                .map_err(|e| Error::CallError(self.agent.actor_id().clone(), e.into()))?;
+            if rank == self.create_rank {
+                break Ok(status);
+            }
+        }
+    }
 }
 
 /// A reference to a ProcMesh, consisting of a set of ranked [`ProcRef`]s,
@@ -52,6 +92,90 @@ impl ProcMeshRef {
             ranks: Arc::new(ranks),
         })
     }
+
+    /// Allocate a new ProcMeshRef from the provided alloc.
+    /// Allocate does not require an owning actor because references are not owned.
+    async fn allocate(
+        caps: &(impl cap::CanOpenPort + cap::CanSend + cap::HasProc),
+        mut alloc: impl Alloc + Send + Sync + 'static,
+        name: &str,
+    ) -> v1::Result<Self> {
+        let running = alloc.initialize().await?;
+
+        // Wire the newly created mesh into the proc, so that it is routable.
+        // We route all of the relevant prefixes into the proc's forwarder,
+        // and serve it on the alloc's transport.
+        //
+        // This will be removed with direct addressing.
+        let proc = caps.proc();
+        // First make sure we can serve the proc:
+        let (proc_channel_addr, rx) = channel::serve(ChannelAddr::any(alloc.transport())).await?;
+        proc.clone().serve(rx);
+
+        let router = proc
+            .forwarder()
+            .downcast_ref::<DialMailboxRouter>()
+            .ok_or(Error::UnroutableMesh())?;
+        // Route all of the allocated procs:
+        for AllocatedProc { proc_id, addr, .. } in running.iter() {
+            if proc_id.is_direct() {
+                continue;
+            }
+            router.bind(proc_id.clone().into(), addr.clone());
+        }
+
+        // Set up the mesh agents. Since references are not owned, we don't supervise it.
+        // Instead, we just let procs die when they have unhandled supervision events.
+        let address_book: HashMap<_, _> = running
+            .iter()
+            .map(
+                |AllocatedProc {
+                     addr, mesh_agent, ..
+                 }| { (mesh_agent.actor_id().proc_id().clone(), addr.clone()) },
+            )
+            .collect();
+
+        let (config_handle, mut config_receiver) = mailbox::open_port(caps);
+        for (rank, AllocatedProc { mesh_agent, .. }) in running.iter().enumerate() {
+            mesh_agent
+                .configure(
+                    caps,
+                    rank,
+                    proc_channel_addr.clone(),
+                    None, // no supervisor; we just crash
+                    address_book.clone(),
+                    config_handle.bind(),
+                )
+                .await
+                .map_err(Error::ConfigurationError)?;
+        }
+        let mut completed = Ranks::new(running.len());
+        while !completed.is_full() {
+            let rank = config_receiver
+                .recv()
+                .await
+                .map_err(|err| Error::ConfigurationError(err.into()))?;
+            if completed.insert(rank, rank).is_some() {
+                tracing::warn!("multiple completions received for rank {}", rank);
+            }
+        }
+
+        let ranks = running
+            .into_iter()
+            .enumerate()
+            .map(|(create_rank, allocated)| ProcRef {
+                proc_id: allocated.proc_id,
+                create_rank,
+                agent: allocated.mesh_agent,
+            })
+            .collect();
+
+        Ok(Self {
+            name: Name::new(name),
+            region: alloc.extent().clone().into(),
+            ranks: Arc::new(ranks),
+        })
+    }
 }
 
 impl view::Ranked for ProcMeshRef {
@@ -67,5 +191,45 @@ impl view::Ranked for ProcMeshRef {
 
     fn sliced<'a>(&self, region: Region, nodes: impl Iterator<Item = &'a ProcRef>) -> Self {
         Self::new(self.name.clone(), region, nodes.cloned().collect()).unwrap()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use hyperactor::Proc;
+    use hyperactor::id;
+    use hyperactor::mailbox::BoxableMailboxSender;
+    use ndslice::ViewExt;
+    use ndslice::extent;
+
+    use super::*;
+    use crate::alloc::AllocSpec;
+    use crate::alloc::Allocator;
+    use crate::alloc::LocalAllocator;
+
+    #[tokio::test]
+    async fn test_proc_mesh_allocate() {
+        let router = DialMailboxRouter::new();
+        let proc = Proc::new(id!(test[0]), router.boxed());
+        let (actor, _handle) = proc.instance("controller").unwrap();
+
+        let alloc = LocalAllocator
+            .allocate(AllocSpec {
+                extent: extent!(replica = 4),
+                constraints: Default::default(),
+                proc_name: None,
+            })
+            .await
+            .unwrap();
+
+        let mesh = ProcMeshRef::allocate(&actor, alloc, "test").await.unwrap();
+        assert_eq!(mesh.extent(), extent!(replica = 4));
+        assert_eq!(mesh.ranks.len(), 4);
+        assert!(!router.prefixes().is_empty());
+
+        // All of the agents are alive, and reachable (both ways).
+        for proc_ref in mesh.values() {
+            assert!(proc_ref.status(&actor).await.unwrap());
+        }
     }
 }

--- a/hyperactor_mesh/src/v1/proc_mesh.rs
+++ b/hyperactor_mesh/src/v1/proc_mesh.rs
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+use std::sync::Arc;
+
+use hyperactor::Named;
+use hyperactor::ProcId;
+use ndslice::view;
+use ndslice::view::Region;
+use serde::Deserialize;
+use serde::Serialize;
+
+use crate::v1;
+use crate::v1::Name;
+
+/// A reference to a single [`hyperactor::Proc`].
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct ProcRef {
+    proc_id: ProcId,
+}
+
+/// A reference to a ProcMesh, consisting of a set of ranked [`ProcRef`]s,
+/// arranged into a region. ProcMeshes named, uniquely identifying the
+/// ProcMesh from which the reference was derived.
+///
+/// ProcMeshes can be sliced to create new ProcMeshes with a subset of the
+/// original ranks.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Named, Serialize, Deserialize)]
+pub struct ProcMeshRef {
+    name: Name,
+    region: Region,
+    ranks: Arc<Vec<ProcRef>>,
+}
+
+impl ProcMeshRef {
+    /// Create a new ProcMeshRef from the given name, region, and ranks.
+    fn new(name: Name, region: Region, ranks: Vec<ProcRef>) -> v1::Result<Self> {
+        if region.num_ranks() != ranks.len() {
+            return Err(v1::Error::InvalidRankCardinality {
+                expected: region.num_ranks(),
+                actual: ranks.len(),
+            });
+        }
+        Ok(Self {
+            name,
+            region,
+            ranks: Arc::new(ranks),
+        })
+    }
+}
+
+impl view::Ranked for ProcMeshRef {
+    type Item = ProcRef;
+
+    fn region(&self) -> &Region {
+        &self.region
+    }
+
+    fn ranks(&self) -> &[ProcRef] {
+        &self.ranks
+    }
+
+    fn sliced<'a>(&self, region: Region, nodes: impl Iterator<Item = &'a ProcRef>) -> Self {
+        Self::new(self.name.clone(), region, nodes.cloned().collect()).unwrap()
+    }
+}

--- a/hyperactor_mesh/src/v1/value_mesh.rs
+++ b/hyperactor_mesh/src/v1/value_mesh.rs
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+use futures::Future;
+use futures::future;
+use ndslice::view;
+use ndslice::view::Region;
+
+/// A mesh of values, where each value is associated with a rank.
+pub struct ValueMesh<T> {
+    region: Region,
+    ranks: Vec<T>,
+}
+
+impl<T> ValueMesh<T> {
+    /// Creates a new value mesh with the given region and ranks.
+    pub(crate) fn new(region: Region, ranks: Vec<T>) -> Self {
+        Self { region, ranks }
+    }
+}
+
+impl<F: Future> ValueMesh<F> {
+    /// Waits for all futures to complete, producing a mesh with their results.
+    pub async fn join(self) -> ValueMesh<F::Output> {
+        let ValueMesh { region, ranks } = self;
+        ValueMesh {
+            region,
+            ranks: future::join_all(ranks.into_iter()).await,
+        }
+    }
+}
+
+impl<T, E> ValueMesh<Result<T, E>> {
+    /// Promotes a ValueMesh of results to a Result of ValueMesh.
+    pub fn promote_result(self) -> Result<ValueMesh<T>, E> {
+        let ValueMesh { region, ranks } = self;
+        let ranks = ranks.into_iter().collect::<Result<Vec<T>, E>>()?;
+        Ok(ValueMesh { region, ranks })
+    }
+}
+
+impl<T: Clone + 'static> view::Ranked for ValueMesh<T> {
+    type Item = T;
+
+    fn region(&self) -> &Region {
+        &self.region
+    }
+
+    fn ranks(&self) -> &[T] {
+        &self.ranks
+    }
+
+    fn sliced<'a>(&self, region: Region, nodes: impl Iterator<Item = &'a T>) -> Self {
+        Self {
+            region,
+            ranks: nodes.cloned().collect(),
+        }
+    }
+}

--- a/hyperactor_mesh/src/v1/value_mesh.rs
+++ b/hyperactor_mesh/src/v1/value_mesh.rs
@@ -51,14 +51,14 @@ impl<T: Clone + 'static> view::Ranked for ValueMesh<T> {
         &self.region
     }
 
-    fn ranks(&self) -> &[T] {
-        &self.ranks
+    fn get(&self, rank: usize) -> Option<T> {
+        self.ranks.get(rank).cloned()
     }
 
-    fn sliced<'a>(&self, region: Region, nodes: impl Iterator<Item = &'a T>) -> Self {
+    fn sliced(&self, region: Region, nodes: impl Iterator<Item = T>) -> Self {
         Self {
             region,
-            ranks: nodes.cloned().collect(),
+            ranks: nodes.collect(),
         }
     }
 }

--- a/hyperactor_mesh/src/v1/value_mesh.rs
+++ b/hyperactor_mesh/src/v1/value_mesh.rs
@@ -7,40 +7,68 @@
  */
 
 use futures::Future;
-use futures::future;
 use ndslice::view;
 use ndslice::view::Region;
 
 /// A mesh of values, where each value is associated with a rank.
+///
+/// # Invariant
+/// The mesh is *complete*: `ranks.len()` always equals
+/// `region.num_ranks()`. Every rank in the region has exactly one
+/// associated value.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)] // only if T implements
 pub struct ValueMesh<T> {
     region: Region,
     ranks: Vec<T>,
 }
 
 impl<T> ValueMesh<T> {
-    /// Creates a new value mesh with the given region and ranks.
-    pub(crate) fn new(region: Region, ranks: Vec<T>) -> Self {
+    /// Creates a new `ValueMesh` for `region` with exactly one value
+    /// per rank.
+    ///
+    /// # Invariants
+    /// This constructor validates that the number of provided values
+    /// (`ranks.len()`) matches the region’s cardinality
+    /// (`region.num_ranks()`). A value mesh must be complete: every
+    /// rank in `region` has a corresponding `T`.
+    ///
+    /// # Errors
+    /// Returns [`Error::InvalidRankCardinality`] if `ranks.len() !=
+    /// region.num_ranks()`.
+    /// ```
+    pub(crate) fn new(region: Region, ranks: Vec<T>) -> crate::v1::Result<Self> {
+        let (actual, expected) = (ranks.len(), region.num_ranks());
+        if actual != expected {
+            return Err(crate::v1::Error::InvalidRankCardinality { expected, actual });
+        }
+        Ok(Self { region, ranks })
+    }
+
+    /// Constructs a ValueMesh without checking cardinality. Caller
+    /// must ensure `ranks.len() == region.num_ranks()`.
+    #[inline]
+    pub(crate) fn new_unchecked(region: Region, ranks: Vec<T>) -> Self {
+        debug_assert_eq!(region.num_ranks(), ranks.len());
         Self { region, ranks }
     }
 }
 
 impl<F: Future> ValueMesh<F> {
-    /// Waits for all futures to complete, producing a mesh with their results.
+    /// Await all futures in the mesh, yielding a `ValueMesh` of their
+    /// outputs.
     pub async fn join(self) -> ValueMesh<F::Output> {
         let ValueMesh { region, ranks } = self;
-        ValueMesh {
-            region,
-            ranks: future::join_all(ranks.into_iter()).await,
-        }
+        ValueMesh::new_unchecked(region, futures::future::join_all(ranks).await)
     }
 }
 
 impl<T, E> ValueMesh<Result<T, E>> {
-    /// Promotes a ValueMesh of results to a Result of ValueMesh.
-    pub fn promote_result(self) -> Result<ValueMesh<T>, E> {
+    /// Transposes a `ValueMesh<Result<T, E>>` into a
+    /// `Result<ValueMesh<T>, E>`.
+    pub fn transpose(self) -> Result<ValueMesh<T>, E> {
         let ValueMesh { region, ranks } = self;
         let ranks = ranks.into_iter().collect::<Result<Vec<T>, E>>()?;
-        Ok(ValueMesh { region, ranks })
+        Ok(ValueMesh::new_unchecked(region, ranks))
     }
 }
 
@@ -59,6 +87,37 @@ impl<T: Clone + 'static> view::Ranked for ValueMesh<T> {
         Self {
             region,
             ranks: nodes.collect(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use ndslice::extent;
+    use ndslice::view::Ranked;
+    use ndslice::view::ViewExt;
+
+    use super::*;
+
+    #[test]
+    fn value_mesh_new_ok() {
+        let region: Region = extent!(replica = 2, gpu = 3).into();
+        let mesh = ValueMesh::new(region.clone(), (0..6).collect()).expect("new should succeed");
+        assert_eq!(mesh.region().num_ranks(), 6);
+        assert_eq!(mesh.values().count(), 6);
+        assert_eq!(mesh.values().collect::<Vec<_>>(), vec![0, 1, 2, 3, 4, 5]);
+    }
+
+    #[test]
+    fn value_mesh_new_len_mismatch_is_error() {
+        let region: Region = extent!(replica = 2, gpu = 3).into();
+        let err = ValueMesh::new(region, vec![0_i32; 5]).unwrap_err();
+        match err {
+            crate::v1::Error::InvalidRankCardinality { expected, actual } => {
+                assert_eq!(expected, 6);
+                assert_eq!(actual, 5);
+            }
+            other => panic!("unexpected error: {other:?}"),
         }
     }
 }

--- a/hyperactor_mesh/test/hyperactor_mesh_proxy_test.rs
+++ b/hyperactor_mesh/test/hyperactor_mesh_proxy_test.rs
@@ -118,6 +118,7 @@ impl Actor for ProxyActor {
             .allocate(AllocSpec {
                 extent: extent! { replica = 1 },
                 constraints: Default::default(),
+                proc_name: None,
             })
             .await
             .unwrap();
@@ -154,6 +155,7 @@ async fn run_client(exe_path: PathBuf, keep_alive: bool) -> Result<(), anyhow::E
         .allocate(AllocSpec {
             extent: extent! { replica = 1 },
             constraints: Default::default(),
+            proc_name: None,
         })
         .await
         .unwrap();

--- a/hyperactor_mesh/test/process_allocator_cleanup/process_allocator_test_bin.rs
+++ b/hyperactor_mesh/test/process_allocator_cleanup/process_allocator_test_bin.rs
@@ -46,6 +46,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .allocate(AllocSpec {
             extent: extent! { replica = 4 },
             constraints: AllocConstraints::default(),
+            proc_name: None,
         })
         .await?;
 

--- a/hyperactor_mesh/test/remote_process_alloc.rs
+++ b/hyperactor_mesh/test/remote_process_alloc.rs
@@ -91,6 +91,7 @@ async fn main() {
             AllocSpec {
                 extent: extent!(host = hosts_per_proc_mesh, gpu = 1),
                 constraints: Default::default(),
+                proc_name: None,
             },
             WorldId("test_world_id".to_string()),
             ChannelTransport::Unix,

--- a/monarch_hyperactor/src/bin/process_allocator/common.rs
+++ b/monarch_hyperactor/src/bin/process_allocator/common.rs
@@ -134,6 +134,7 @@ mod tests {
             // NOTE: x cannot be more than 1 since we created a single process-allocator server instance!
             extent: extent! { x=1, y=4 },
             constraints: Default::default(),
+            proc_name: None,
         };
 
         let mut initializer = remoteprocess::MockRemoteProcessAllocInitializer::new();
@@ -158,37 +159,26 @@ mod tests {
 
         // make sure we accounted for `world_size` number of Created and Stopped proc states
         let world_size = spec.extent.num_ranks();
-        let mut created_ranks: HashSet<usize> = HashSet::new();
-        let mut stopped_ranks: HashSet<usize> = HashSet::new();
+        let mut created = HashSet::new();
+        let mut stopped = HashSet::new();
 
-        while created_ranks.len() < world_size || stopped_ranks.len() < world_size {
+        while stopped.len() < world_size {
             let proc_state = alloc.next().await.unwrap();
             match proc_state {
-                alloc::ProcState::Created { proc_id, .. } => {
+                alloc::ProcState::Created { create_key, .. } => {
                     // alloc.next() will keep creating procs and incrementing rank id
                     // so we mod the rank by world_size to map it to its logical rank
-                    created_ranks.insert(
-                        proc_id
-                            .rank()
-                            .expect("process allocator currently supports only ranked procs")
-                            % world_size,
-                    );
+                    eprintln!("created: {}", create_key);
+                    created.insert(create_key);
                 }
-                alloc::ProcState::Stopped { proc_id, .. } => {
-                    stopped_ranks.insert(
-                        proc_id
-                            .rank()
-                            .expect("process allocator currently supports only ranked procs")
-                            % world_size,
-                    );
+                alloc::ProcState::Stopped { create_key, .. } => {
+                    eprintln!("stopped: {}", create_key);
+                    assert!(created.remove(&create_key));
+                    stopped.insert(create_key);
                 }
                 _ => {}
             }
         }
-
-        let expected_ranks: HashSet<usize> = (0..world_size).collect();
-        assert_eq!(created_ranks, expected_ranks);
-        assert_eq!(stopped_ranks, expected_ranks);
 
         server_handle.abort();
         Ok(())
@@ -210,6 +200,7 @@ mod tests {
             // NOTE: x cannot be more than 1 since we created a single process-allocator server instance!
             extent: extent! { x=1, y=4 },
             constraints: Default::default(),
+            proc_name: None,
         };
 
         let mut initializer = remoteprocess::MockRemoteProcessAllocInitializer::new();
@@ -268,6 +259,7 @@ mod tests {
             // NOTE: x cannot be more than 1 since we created a single process-allocator server instance!
             extent: extent! { x=1, y=4 },
             constraints: Default::default(),
+            proc_name: None,
         };
 
         let mut initializer = remoteprocess::MockRemoteProcessAllocInitializer::new();
@@ -347,6 +339,7 @@ mod tests {
             // NOTE: x cannot be more than 1 since we created a single process-allocator server instance!
             extent: extent! { x=1, y=4 },
             constraints: Default::default(),
+            proc_name: None,
         };
 
         let mut initializer = remoteprocess::MockRemoteProcessAllocInitializer::new();
@@ -374,17 +367,13 @@ mod tests {
         // start without stopping.
         // make sure we accounted for `world_size` number of Created and Stopped proc states
         let world_size = spec.extent.num_ranks();
-        let mut created_ranks: HashSet<usize> = HashSet::new();
+        let mut created = HashSet::new();
 
-        while created_ranks.len() < world_size {
+        while created.len() < world_size {
             let proc_state = alloc.next().await.unwrap();
             match proc_state {
-                alloc::ProcState::Created { proc_id, .. } => {
-                    created_ranks.insert(
-                        proc_id
-                            .rank()
-                            .expect("process allocator currently supports only ranked procs"),
-                    );
+                alloc::ProcState::Created { create_key, .. } => {
+                    created.insert(create_key);
                 }
                 _ => {
                     panic!("Unexpected message: {:?}", proc_state)
@@ -396,26 +385,21 @@ mod tests {
         // stays alive as long as the child processes stay alive.
         RealClock.sleep(timeout * 2).await;
         // Now wait for more events and ensure they are ProcState::Stopped
-        let mut stopped_ranks: HashSet<usize> = HashSet::new();
-        while stopped_ranks.len() < world_size {
+        while !created.is_empty() {
             let proc_state = alloc.next().await.unwrap();
             match proc_state {
-                alloc::ProcState::Created { .. } => {
-                    // ignore
+                alloc::ProcState::Created { create_key, .. } => {
+                    // created.insert(create_key);
                 }
-                alloc::ProcState::Stopped { proc_id, .. } => {
-                    stopped_ranks.insert(
-                        proc_id
-                            .rank()
-                            .expect("process allocator currently supports only ranked procs")
-                            % world_size,
-                    );
+                alloc::ProcState::Stopped { create_key, .. } => {
+                    created.remove(&create_key);
                 }
                 _ => {
                     panic!("Unexpected message: {:?}", proc_state)
                 }
             }
         }
+        assert!(created.is_empty());
         server_handle.abort();
         Ok(())
     }

--- a/monarch_hyperactor/src/code_sync/manager.rs
+++ b/monarch_hyperactor/src/code_sync/manager.rs
@@ -559,6 +559,7 @@ mod tests {
             .allocate(AllocSpec {
                 extent: extent! { replica = 2 },
                 constraints: Default::default(),
+                proc_name: None,
             })
             .await?;
 

--- a/monarch_hyperactor/src/code_sync/rsync.rs
+++ b/monarch_hyperactor/src/code_sync/rsync.rs
@@ -501,6 +501,7 @@ mod tests {
             .allocate(AllocSpec {
                 extent: extent! { replica = 1 },
                 constraints: Default::default(),
+                proc_name: None,
             })
             .await?;
 

--- a/monarch_hyperactor/src/proc_mesh.rs
+++ b/monarch_hyperactor/src/proc_mesh.rs
@@ -543,6 +543,7 @@ mod tests {
             .allocate(AllocSpec {
                 extent: extent! { replica = 1 },
                 constraints: Default::default(),
+                proc_name: None,
             })
             .await?;
 
@@ -590,6 +591,7 @@ mod tests {
             .allocate(AllocSpec {
                 extent: extent! { replica = 1 },
                 constraints: Default::default(),
+                proc_name: None,
             })
             .await?;
 
@@ -653,6 +655,7 @@ mod tests {
             .allocate(AllocSpec {
                 extent: extent! { replica = 1 },
                 constraints: Default::default(),
+                proc_name: None,
             })
             .await?;
 

--- a/monarch_hyperactor/tests/code_sync/auto_reload.rs
+++ b/monarch_hyperactor/tests/code_sync/auto_reload.rs
@@ -47,6 +47,7 @@ CONSTANT = "initial_constant"
         .allocate(AllocSpec {
             extent: extent! { replica = 1 },
             constraints: Default::default(),
+            proc_name: None,
         })
         .await?;
 

--- a/monarch_rdma/examples/cuda_ping_pong/cuda_ping_pong.rs
+++ b/monarch_rdma/examples/cuda_ping_pong/cuda_ping_pong.rs
@@ -636,6 +636,7 @@ pub async fn run() -> Result<(), anyhow::Error> {
             .allocate(AllocSpec {
                 extent: extent! {replica=1, host=1, gpu=1},
                 constraints: Default::default(),
+                proc_name: None,
             })
             .await?,
     )
@@ -647,6 +648,7 @@ pub async fn run() -> Result<(), anyhow::Error> {
             .allocate(AllocSpec {
                 extent: extent! {replica=1, host=1, gpu=1},
                 constraints: Default::default(),
+                proc_name: None,
             })
             .await?,
     )

--- a/monarch_rdma/examples/parameter_server/parameter_server.rs
+++ b/monarch_rdma/examples/parameter_server/parameter_server.rs
@@ -479,6 +479,7 @@ pub async fn run(num_workers: usize, num_steps: usize) -> Result<(), anyhow::Err
             .allocate(AllocSpec {
                 extent: extent! {replica=1, host=1, gpu=1},
                 constraints: Default::default(),
+                proc_name: None,
             })
             .await?,
     )
@@ -505,6 +506,7 @@ pub async fn run(num_workers: usize, num_steps: usize) -> Result<(), anyhow::Err
             .allocate(AllocSpec {
                 extent: extent! {replica=1, host=1, gpu=num_workers},
                 constraints: Default::default(),
+                proc_name: None,
             })
             .await?,
     )

--- a/monarch_rdma/src/test_utils.rs
+++ b/monarch_rdma/src/test_utils.rs
@@ -334,6 +334,7 @@ pub mod test_utils {
                 .allocate(AllocSpec {
                     extent: extent! { proc = 1 },
                     constraints: Default::default(),
+                    proc_name: None,
                 })
                 .await
                 .unwrap();
@@ -346,6 +347,7 @@ pub mod test_utils {
                 .allocate(AllocSpec {
                     extent: extent! { proc = 1 },
                     constraints: Default::default(),
+                    proc_name: None,
                 })
                 .await
                 .unwrap();

--- a/ndslice/src/view.rs
+++ b/ndslice/src/view.rs
@@ -962,14 +962,14 @@ pub trait Ranked: Sized {
     /// The ranks contained in this view.
     fn region(&self) -> &Region;
 
-    /// Return the raw slice of ranks in this collection.
-    fn ranks(&self) -> &[Self::Item];
+    /// Return the item at `rank`
+    fn get(&self, rank: usize) -> Option<Self::Item>;
 
     /// Construct a new Ranked containing the ranks in this view that are
     /// part of region. The caller guarantees that
     /// `ranks.len() == region.num_ranks()` and that
     /// `region.is_subset(self.region())`.`
-    fn sliced<'a>(&self, region: Region, ranks: impl Iterator<Item = &'a Self::Item>) -> Self;
+    fn sliced(&self, region: Region, ranks: impl Iterator<Item = Self::Item>) -> Self;
 }
 
 impl<T: Ranked> View for T {
@@ -981,7 +981,7 @@ impl<T: Ranked> View for T {
     }
 
     fn get(&self, rank: usize) -> Option<Self::Item> {
-        self.ranks().get(rank).cloned()
+        self.get(rank)
     }
 
     fn subset(&self, region: Region) -> Result<Self, ViewError> {
@@ -995,7 +995,7 @@ impl<T: Ranked> View for T {
                 base: self.region().clone(),
                 selected: region.clone(),
             })?
-            .map(|index| &self.ranks()[index]);
+            .map(|index| self.get(index).unwrap());
 
         Ok(self.sliced(region, ranks))
     }

--- a/ndslice/src/view.rs
+++ b/ndslice/src/view.rs
@@ -683,7 +683,10 @@ pub enum ViewError {
     ExtentError(#[from] ExtentError),
 
     #[error("invalid range: selected ranks {selected} not a subset of base {base} ")]
-    InvalidRange { base: Region, selected: Region },
+    InvalidRange {
+        base: Box<Region>,
+        selected: Box<Region>,
+    },
 }
 
 /// `Region` describes a region of a possibly-larger space of ranks, organized into
@@ -913,8 +916,8 @@ impl View for Region {
             Ok(region)
         } else {
             Err(ViewError::InvalidRange {
-                base: self.clone(),
-                selected: region,
+                base: Box::new(self.clone()),
+                selected: Box::new(region),
             })
         }
     }
@@ -992,8 +995,8 @@ impl<T: Ranked> View for T {
             .region()
             .remap(&region)
             .ok_or_else(|| ViewError::InvalidRange {
-                base: self.region().clone(),
-                selected: region.clone(),
+                base: Box::new(self.region().clone()),
+                selected: Box::new(region.clone()),
             })?
             .map(|index| self.get(index).unwrap());
 


### PR DESCRIPTION
Summary: add `CollectExactMesh` trait as a “mesh-aware collect” (exact-size-iterator + region → ValueMesh), since `FromIterator` can’t carry `Region` or validate length. pre-checks with `.len()` to fail fast with no allocations on a length mismatch.

Differential Revision: D81804781
