### PR TITLE
[hyperactor] mesh: fix up instrumentation

### DIFF
--- a/hyperactor_mesh/src/proc_mesh.rs
+++ b/hyperactor_mesh/src/proc_mesh.rs
@@ -50,6 +50,9 @@ use ndslice::Shape;
 use ndslice::ShapeError;
 use strum::AsRefStr;
 use tokio::sync::mpsc;
+use tracing::Instrument;
+use tracing::Level;
+use tracing::span;
 
 use crate::CommActor;
 use crate::Mesh;
@@ -243,7 +246,14 @@ impl ProcMesh {
         );
 
         // 1. Initialize the alloc, producing the initial set of ranked procs:
-        let running = alloc.initialize().await?;
+        let running = alloc
+            .initialize()
+            .instrument(span!(
+                Level::INFO,
+                "ProcMesh::Allocate::Initialize",
+                alloc_id
+            ))
+            .await?;
 
         // 2. Set up routing to the initialized procs; these require dialing.
         let router = DialMailboxRouter::new();


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #1117
* #1095
* #1087
* #1086
* #1079
* #1078
* #1075
* #1030
* #1027
* #1026

The HostMesh stack did some refactoring which accidenntally removed some recent instrumentation changes. (Big merge, sorry.)

This restores those changes, but since the code has been refactored, we use spans to identify the name. However, this seems like the correct design? Should we build a span to propagate the alloc id, instead of stuffing it in every event?

Differential Revision: [D81809068](https://our.internmc.facebook.com/intern/diff/D81809068/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D81809068/)!