### PR TITLE
v1: value_mesh: property tests for try_collect_indexed

### DIFF
--- a/hyperactor_mesh/Cargo.toml
+++ b/hyperactor_mesh/Cargo.toml
@@ -75,6 +75,7 @@ tracing-subscriber = { version = "0.3.20", features = ["chrono", "env-filter", "
 [dev-dependencies]
 bytes = { version = "1.10", features = ["serde"] }
 maplit = "1.0"
+proptest = "1.5"
 timed_test = { version = "0.0.0", path = "../timed_test" }
 tracing-test = { version = "0.2.3", features = ["no-env-filter"] }
 

--- a/ndslice/Cargo.toml
+++ b/ndslice/Cargo.toml
@@ -15,10 +15,8 @@ enum-as-inner = "0.6.0"
 itertools = "0.14.0"
 nom = "8"
 proc-macro2 = { version = "1.0.70", features = ["span-locations"] }
+proptest = "1.5"
 quote = "1.0.29"
 rand = { version = "0.8", features = ["small_rng"] }
 serde = { version = "1.0.219", features = ["derive", "rc"] }
 thiserror = "2.0.12"
-
-[dev-dependencies]
-proptest = "1.5"

--- a/ndslice/src/lib.rs
+++ b/ndslice/src/lib.rs
@@ -47,8 +47,9 @@ pub use shape::Shape;
 /// Errors that can occur during shape construction or validation.
 pub use shape::ShapeError;
 
-/// Property-based generators for randomized test input.
-#[cfg(test)]
+/// Property-based generators for randomized test input. TODO: Move
+/// into dedicated crate and access via
+// `test_deps`.
 pub mod strategy;
 
 /// Utilities.

--- a/ndslice/src/strategy.rs
+++ b/ndslice/src/strategy.rs
@@ -20,9 +20,8 @@
 //! Example usage:
 //!
 //! ```
+//! use ndslice::strategy::gen_selection;
 //! use proptest::prelude::*;
-//!
-//! use crate::selection::strategy::gen_selection;
 //!
 //! proptest! {
 //!     #[test]
@@ -31,8 +30,6 @@
 //!     }
 //! }
 //! ```
-//!
-//! This module is only included in test builds (`#[cfg(test)]`).
 
 use proptest::prelude::*;
 
@@ -63,9 +60,8 @@ use crate::view::Region;
 /// # Example
 ///
 /// ```
+/// use ndslice::strategy::gen_slice;
 /// use proptest::prelude::*;
-///
-/// use crate::selection::strategy::gen_slice;
 ///
 /// proptest! {
 ///     #[test]
@@ -348,6 +344,7 @@ pub fn gen_selection(depth: u32, shape: Vec<usize>, dim: usize) -> BoxedStrategy
     .boxed()
 }
 
+#[cfg(test)]
 mod tests {
     use std::collections::HashMap;
     use std::collections::HashSet;


### PR DESCRIPTION
Summary: added property tests to cross-check `try_collect_indexed_opt` against the reference implementation. this involved introducing a deterministic shuffle based on SplitMix64 so we can vary input order without relying on global RNG and still observe last-write-wins semantics. tests now cover equivalence on complete inputs, as well as matching error behavior for missing and out-of-bounds ranks. to support this, I promoted `ndslice::strategy` out of `#[cfg(test)]` so that generators like `gen_region` are available in downstream tests. that required moving proptest into regular deps. local test modules stay behind `#[cfg(test)]` as before. at some point will split strategy into its own `ndslice_strategy` crate so it can remain test-only.

Differential Revision: D81957511
