### PR TITLE
Introduces `MonarchSession` and `connect`

### DIFF
--- a/python/monarch/session/__init__.py
+++ b/python/monarch/session/__init__.py
@@ -1,0 +1,150 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-unsafe
+"""Monarch Sessions for resource management on multiple hosts."""
+
+import json
+import logging
+
+from monarch._src.actor.allocator import RemoteAllocator, TorchXRemoteAllocInitializer
+from monarch._src.actor.future import Future
+from monarch._src.actor.shape import NDSlice, Shape
+from monarch.actor import HostMesh
+from monarch.tools import commands
+from monarch.tools.config import Config
+from monarch.tools.mesh_spec import ServerSpec
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+
+class MonarchSession:
+    """A Monarch session provides high-level APIs for creating and managing Monarch resources.
+
+    A MonarchSession is obtained by calling `connect()` and represents an active connection
+    to a monarch cluster. The session provides APIs to create resources like HostMesh.
+
+    Usage:
+
+    .. code-block:: python
+
+        from monarch.session import connect
+        from monarch.tools.config import defaults
+
+        config = defaults.config(scheduler="slurm")
+        session = await connect("my_session", config)
+
+        # Create a mesh of 4 hosts
+        host_mesh = session.host_mesh(num_hosts=4)
+
+        # Spawn procs on the Mesh
+
+
+    Attributes:
+        _alloc: The underlying RemoteAllocator that manages resource allocation
+
+    """
+
+    def __init__(self, allocator: RemoteAllocator):
+        """Initialize a MonarchSession with the given allocator.
+
+        Args:
+            allocator: RemoteAllocator instance that handles resource allocation
+        """
+        self._alloc = allocator
+
+    def host_mesh(self, num_hosts: int) -> HostMesh:
+        """Create a HostMesh with the specified number of hosts.
+
+        A HostMesh represents a collection of compute hosts that can be used
+        for distributed workloads. Each host in the mesh can run multiple
+        processes and is suitable for multi-host distributed training or
+        computation tasks.
+
+        Args:
+            num_hosts: Number of hosts to include in the mesh
+
+        Returns:
+            HostMesh: A mesh containing the requested number of hosts
+
+        Example:
+
+        .. code-block:: python
+
+            # Create a mesh with 8 hosts
+            mesh = session.host_mesh(num_hosts=8)
+
+            with mesh:
+                # Each host can run distributed training processes
+                pass
+        """
+        shape = Shape(["hosts"], NDSlice.new_row_major([num_hosts]))
+        return HostMesh(
+            shape=shape,
+            allocator=self._alloc,
+        )
+
+
+def connect(name: str, config: Config, force_restart: bool = False) -> MonarchSession:
+    """Connect to a Monarch server and return a session.
+
+    This establishes a connection to a monarch server by finding an existing
+    server with the given name or creating a new one according to the
+    provided config. Once connected, it returns a MonarchSession that can
+    be used to create and manage distributed compute meshes.
+
+    Usage:
+
+    .. code-block:: python
+
+        from monarch.session import connect
+        from monarch.tools.config import defaults
+
+        # Connect to a server on SLURM
+        config = defaults.config(scheduler="slurm")
+        config.appdef = defaults.component_fn(config.scheduler)()
+
+        session = await connect("my_training_job", config)
+        host_mesh = session.host_mesh(num_hosts=4)
+        procs = host_mesh.spawn_procs(per_host={"procs": 8})
+        # procs is shape {"hosts": 4, "procs": 8}
+
+    Args:
+        name: Unique identifier for the monarch server/job. This is used to
+            find existing servers or as the job name when creating new ones.
+        config: Configuration object containing scheduler settings, workspace
+            configuration, and application definition for the server.
+        force_restart: If True, restarts the server even if one already exists.
+
+    Returns:
+        MonarchSession: An active session connected to the monarch server that
+            can be used to create distributed compute meshes.
+
+    Raises:
+        RuntimeError: If the server fails to start or becomes unreachable.
+        AssertionError: If config.dryrun is True (dryrun not supported for connections).
+
+    Note:
+        This function is asynchronous and must be awaited. The underlying server
+        creation and readiness checking may take some time depending on the
+        scheduler and resource availability.
+    """
+
+    async def task() -> ServerSpec:
+        return await commands.get_or_create(
+            name=name,
+            config=config,
+            force_restart=force_restart,
+        )
+
+    # Allows this to run in both sync/async contexts
+    server_info: ServerSpec = Future(coro=task()).get()
+    logger.debug("\n=== Server Info ===%s", json.dumps(server_info.to_json(), indent=2))
+    allocator = RemoteAllocator(
+        world_id=name,
+        initializer=TorchXRemoteAllocInitializer(server_info.server_handle),
+    )
+    return MonarchSession(allocator)

--- a/python/tests/test_session.py
+++ b/python/tests/test_session.py
@@ -1,0 +1,106 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+import json
+from typing import Any
+from unittest import mock
+
+from monarch._src.actor.allocator import LocalAllocator
+from monarch.actor import Actor, current_rank, endpoint, HostMesh, ValueMesh
+from monarch.session import connect, MonarchSession
+from monarch.tools.components import hyperactor
+from monarch.tools.config import Config
+from monarch.tools.config.workspace import Workspace
+
+
+def mock_slurm_subprocess_run(*args: Any, **kwargs: Any) -> mock.MagicMock:
+    """Mock subprocess.run for SLURM commands."""
+    cmd = args[0] if args else []
+    result = mock.MagicMock()
+    result.returncode = 0
+    result.stderr = b""
+
+    if isinstance(cmd, list) and len(cmd) > 0:
+        command = cmd[0]
+        if command == "sbatch":
+            result.stdout = b"Submitted batch job 1234567\n"
+        elif command == "sinfo":
+            # Mock sinfo output for partition memory info
+            result.stdout = b"PARTITION,MEMORY\ndefault,65536\ngpu_h,131072\n"
+        else:
+            result.stdout = b""
+    else:
+        result.stdout = b""
+
+    return result
+
+
+def mock_slurm_subprocess_check_output(*args: Any, **kwargs: Any) -> bytes:
+    """Mock subprocess.check_output for SLURM commands."""
+    slurm_json = {
+        "jobs": [
+            {
+                "job_id": "1234567",
+                "name": "test-0",
+                "command": "process_allocator",
+                "current_working_directory": "/tmp/workspace",
+                "job_state": ["RUNNING"],
+                "job_resources": {
+                    "allocated_nodes": [
+                        {
+                            "nodename": "node001",
+                            "cpus_used": 32,
+                            "memory_allocated": 65536,
+                            "state": "RUNNING",
+                        },
+                    ],
+                },
+            }
+        ]
+    }
+
+    return json.dumps(slurm_json).encode("utf-8")
+
+
+def mock_remote_allocator(*args: Any, **kwargs: Any) -> LocalAllocator:
+    """Mock RemoteAllocator to return LocalAllocator instead."""
+    return LocalAllocator()
+
+
+class MockActor(Actor):
+    @endpoint
+    def test(self) -> int:
+        return current_rank()["procs"]
+
+
+@mock.patch("subprocess.run", side_effect=mock_slurm_subprocess_run)
+@mock.patch("subprocess.check_output", side_effect=mock_slurm_subprocess_check_output)
+@mock.patch("monarch.session.RemoteAllocator", side_effect=mock_remote_allocator)
+def test_connect(
+    mock_remote_allocator: Any, mock_check_output: Any, mock_run: Any
+) -> None:
+    # This mostly just tests the APIs with a mock SLURM call and local allocator
+    # We choose a mocked SLURM vs something like local for simplicity.
+    # Local would attempt to spin up process_allocator which is not included
+    # on all Monarch builds.
+    num_hosts = 1
+    appdef = hyperactor.host_mesh(
+        image="test",
+        meshes=[f"mesh_0:{num_hosts}:NULL"],
+    )
+    config = Config(scheduler="slurm", appdef=appdef, workspace=Workspace(env=None))
+    ms = connect(name="test", config=config)
+    assert isinstance(ms, MonarchSession)
+    host_mesh = ms.host_mesh(num_hosts=num_hosts)
+    assert isinstance(host_mesh, HostMesh)
+
+    procs = host_mesh.spawn_procs(per_host={"procs": 8})
+    actors = procs.spawn("test", MockActor)
+    results = actors.test.call().get()
+    assert isinstance(results, ValueMesh)
+    extent = results.extent
+    assert extent["procs"] == 8


### PR DESCRIPTION
Summary:
Context - current multi-node APIs require the user to manually handle allocators etc. This diff is one step towards simplification:

```
from monarch import session

config = Config(...)
ms: MonarchSession = session.connect(
  "trainer", config)

host_mesh = ms.host_mesh(num_hosts=4)
proc_mesh = host_mesh.spawn_procs(per_host={"procs": 8})
```

These APIs are chosen specifically as they align closer with e.g. Spark APIs and their `SparkSession`

Next step is to create configs from file.

Rollback Plan:

Differential Revision: D81960261


