### PR TITLE
Back out "Don't pre-import torch"

### DIFF
--- a/python/monarch/__init__.py
+++ b/python/monarch/__init__.py
@@ -9,6 +9,13 @@
 from importlib import import_module as _import_module
 from typing import TYPE_CHECKING
 
+# Import before monarch to pre-load torch DSOs as, in exploded wheel flows,
+# our RPATHs won't correctly find them.
+try:
+    import torch  # noqa: F401
+except ImportError:
+    pass
+
 # submodules of monarch should not be imported in this
 # top-level file because it will cause them to get
 # loaded even if they are not actually being used.

--- a/python/monarch/_src/actor/bootstrap_main.py
+++ b/python/monarch/_src/actor/bootstrap_main.py
@@ -17,6 +17,12 @@ import multiprocessing
 import os
 import sys
 
+# Import torch to avoid import-time races if a spawned actor tries to import torch.
+try:
+    import torch  # @manual  # noqa: F401
+except ImportError:
+    pass
+
 
 async def main():
     from monarch._rust_bindings.monarch_hyperactor.bootstrap import bootstrap_main
@@ -32,7 +38,6 @@ def invoke_main():
     global bootstrap_main
 
     # TODO: figure out what from worker_main.py we should reproduce here.
-
     from monarch._src.actor.telemetry import TracingForwarder  # noqa
 
     if os.environ.get("MONARCH_ERROR_DURING_BOOTSTRAP_FOR_TESTING") == "1":

--- a/python/monarch/_src/actor/pickle.py
+++ b/python/monarch/_src/actor/pickle.py
@@ -8,18 +8,15 @@
 
 import io
 import pickle
-import sys
 from contextlib import contextmanager, ExitStack
 from typing import Any, Callable, Iterable, List, Tuple
 
 import cloudpickle
 
-
-def maybe_torch():
-    """
-    We have to do some special pickling if torch is loaded but not if it isn't loaded?
-    """
-    return sys.modules.get("torch")
+try:
+    import torch  # @manual
+except ImportError:
+    torch = None
 
 
 _orig_function_getstate = cloudpickle.cloudpickle._function_getstate
@@ -79,7 +76,6 @@ def flatten(obj: Any, filter: Callable[[Any], bool]) -> Tuple[List[Any], bytes]:
 
 def unflatten(data: bytes, values: Iterable[Any]) -> Any:
     with ExitStack() as stack:
-        torch = maybe_torch()
         if torch is not None:
             stack.enter_context(load_tensors_on_cpu())
             stack.enter_context(torch.utils._python_dispatch._disable_current_modes())
@@ -91,8 +87,6 @@ def unflatten(data: bytes, values: Iterable[Any]) -> Any:
 def load_tensors_on_cpu():
     # Ensure that any tensors load from CPU via monkeypatching how Storages are
     # loaded.
-    import torch
-
     old = torch.storage._load_from_bytes
     try:
         torch.storage._load_from_bytes = lambda b: torch.load(


### PR DESCRIPTION
Summary:
https://github.com/meta-pytorch/monarch/pull/1112 broke a workflow used internally,
where the monarch python library is prepended to PYTHONPATH instead of installing
the wheel. For now, revert to avoid breakages. We'll find a better fix soon so we don't
need this import.

Differential Revision: D81980772


