### PR TITLE
Document a multipart SocketAddr-in-map bug

### DIFF
--- a/serde_multipart/src/de/bincode.rs
+++ b/serde_multipart/src/de/bincode.rs
@@ -84,6 +84,12 @@ where
 {
     type Error = Error;
 
+    fn is_human_readable(&self) -> bool {
+        // Same as Deserializer's default implementation. Duplicate here to
+        // be explicit.
+        true
+    }
+
     fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
     where
         V: serde::de::Visitor<'de>,

--- a/serde_multipart/src/ser/bincode.rs
+++ b/serde_multipart/src/ser/bincode.rs
@@ -56,6 +56,12 @@ impl<'a, W: Write, O: Options> ser::Serializer for &'a mut Serializer<W, O> {
     type SerializeStruct = Compound<'a, W, O>;
     type SerializeStructVariant = Compound<'a, W, O>;
 
+    fn is_human_readable(&self) -> bool {
+        // Same as Serializer's default implementation. Duplicate here to
+        // be explicit.
+        true
+    }
+
     fn serialize_bool(self, v: bool) -> Result<Self::Ok, Self::Error> {
         self.ser.serialize_bool(v)
     }


### PR DESCRIPTION
Summary: See the unit test for the bug.

Differential Revision: D82029195


