### PR TITLE
add image field to MeshSpec

### DIFF
--- a/python/monarch/tools/mesh_spec.py
+++ b/python/monarch/tools/mesh_spec.py
@@ -40,6 +40,7 @@ class MeshSpec:
     port: int = DEFAULT_REMOTE_ALLOCATOR_PORT
     hostnames: list[str] = field(default_factory=list)
     state: specs.AppState = specs.AppState.UNSUBMITTED
+    image: str = _UNSET_STR
 
     def server_addrs(
         self, transport: Optional[str] = None, port: Optional[int] = None
@@ -81,6 +82,7 @@ def mesh_spec_from_metadata(appdef: specs.AppDef, mesh_name: str) -> Optional[Me
         if role.name == mesh_name:
             return MeshSpec(
                 name=mesh_name,
+                image=role.image,
                 num_hosts=role.num_replicas,
                 host_type=appdef.metadata.get(
                     _tag(mesh_name, _TAG_HOST_TYPE), _UNSET_STR

--- a/python/tests/tools/test_commands.py
+++ b/python/tests/tools/test_commands.py
@@ -172,6 +172,7 @@ class TestCommands(unittest.TestCase):
                         host_type="gpu.medium",
                         gpus=2,
                         port=26501,
+                        image="__unused__",
                     )
                 ],
             ),

--- a/python/tests/tools/test_mesh_spec.py
+++ b/python/tests/tools/test_mesh_spec.py
@@ -91,6 +91,7 @@ class TestMeshSpec(unittest.TestCase):
             host_type="gpu.medium",
             gpus=2,
             hostnames=["n0", "n1", "n2", "n3"],
+            image="test_pkg:123",
         )
         expected = """
 {
@@ -106,7 +107,8 @@ class TestMeshSpec(unittest.TestCase):
     "n2",
     "n3"
   ],
-  "state": 0
+  "state": 0,
+  "image": "test_pkg:123"
 }
 """
         self.assertEqual(expected.strip("\n"), json.dumps(asdict(mesh_spec), indent=2))


### PR DESCRIPTION
Summary: Add image field to MeshSpec to tell the package and version the mesh is running with.

Differential Revision: D82049412


