### PR TITLE
[monarch] Reenable non-mock-cuda tests in github CI

### DIFF
--- a/.github/workflows/test-cuda.yml
+++ b/.github/workflows/test-cuda.yml
@@ -56,8 +56,8 @@ jobs:
         # pyre currently does not check these assertions
         pyright python/tests/test_python_actors.py
 
+        # Run CUDA tests
+        LC_ALL=C pytest python/tests/ -s -v -m "not oss_skip"
         # TODO(meriksen): temporarily disabled to unblock lands while debugging
         # mock CUDA issues on the OSS setup
-        # Run CUDA tests
-        # LC_ALL=C pytest python/tests/ -s -v -m "not oss_skip"
         # python python/tests/test_mock_cuda.py


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #1162
* __->__ #1160
* #1153

D82058473 disabled all tests in github CI instead of just the mock cuda test. This diff reeenables all of the other tests.

Differential Revision: [D82124618](https://our.internmc.facebook.com/intern/diff/D82124618/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D82124618/)!