### PR TITLE
[monarch] OSS CI: re-enable "not oss_skip" tests

### DIFF
--- a/.github/workflows/test-cuda.yml
+++ b/.github/workflows/test-cuda.yml
@@ -56,8 +56,8 @@ jobs:
         # pyre currently does not check these assertions
         pyright python/tests/test_python_actors.py
 
+        # Run CUDA tests
+        LC_ALL=C pytest python/tests/ -s -v -m "not oss_skip"
         # TODO(meriksen): temporarily disabled to unblock lands while debugging
         # mock CUDA issues on the OSS setup
-        # Run CUDA tests
-        # LC_ALL=C pytest python/tests/ -s -v -m "not oss_skip"
         # python python/tests/test_mock_cuda.py


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #1161
* #1153

This was an oversight from D82058473

Differential Revision: [D82126294](https://our.internmc.facebook.com/intern/diff/D82126294/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D82126294/)!