### PR TITLE
[monarch] Fix mock cuda test in github CI

### DIFF
--- a/.github/workflows/test-cuda.yml
+++ b/.github/workflows/test-cuda.yml
@@ -58,6 +58,4 @@ jobs:
 
         # Run CUDA tests
         LC_ALL=C pytest python/tests/ -s -v -m "not oss_skip"
-        # TODO(meriksen): temporarily disabled to unblock lands while debugging
-        # mock CUDA issues on the OSS setup
-        # python python/tests/test_mock_cuda.py
+        python python/tests/test_mock_cuda.py

--- a/python/monarch/common/mock_cuda.cpp
+++ b/python/monarch/common/mock_cuda.cpp
@@ -53,7 +53,9 @@ std::optional<void*> extractJumpTarget(const uint8_t* functionBytes) {
   // push %rbp       # 0x55
   // mov %rsp, %rbp  # 0x48 0x89 0xe5
   // push %rsp       # 0x65 0x54
-  const uint8_t framePointerPrelude[] = {0x55, 0x48, 0x89, 0xe5, 0x65, 0x54};
+  // sub $0x8, %rsp  # 0x48 0x83 0xec 0x8
+  const uint8_t framePointerPrelude[] = {
+      0x55, 0x48, 0x89, 0xe5, 0x65, 0x54, 0x48, 0x83, 0xec, 0x8};
   uint8_t* functionBytesStart = (uint8_t*)functionBytes;
   if (std::memcmp(
           functionBytes, framePointerPrelude, sizeof(framePointerPrelude)) ==

--- a/python/monarch/common/mock_cuda.cpp
+++ b/python/monarch/common/mock_cuda.cpp
@@ -48,28 +48,43 @@ namespace {
 // This function extracts the address of the table entry for a function (e.g.
 // 0x7ffff7d0f150 above)
 std::optional<void*> extractJumpTarget(const uint8_t* functionBytes) {
+  // If the library was compiled without -fomit-frame-pointer, the first
+  // instructions will be:
+  // push %rbp       # 0x55
+  // mov %rsp, %rbp  # 0x48 0x89 0xe5
+  // push %rsp       # 0x65 0x54
+  const uint8_t framePointerPrelude[] = {0x55, 0x48, 0x89, 0xe5, 0x65, 0x54};
+  uint8_t* functionBytesStart = (uint8_t*)functionBytes;
+  if (std::memcmp(
+          functionBytes, framePointerPrelude, sizeof(framePointerPrelude)) ==
+      0) {
+    functionBytesStart = (uint8_t*)functionBytes + sizeof(framePointerPrelude);
+  }
+
   const uint8_t expectedOpcode[] = {0x81, 0x3D};
   const uint8_t expectedImmediateValue[] = {0x00, 0xBA, 0x1C, 0x32};
   const uint8_t jmpq[] = {0xFF, 0x25};
   const uint8_t movzbl_sil_esi[] = {0x40, 0x0f, 0xb6, 0xf6};
-  if (std::memcmp(functionBytes, expectedOpcode, sizeof(expectedOpcode)) != 0) {
+  if (std::memcmp(functionBytesStart, expectedOpcode, sizeof(expectedOpcode)) !=
+      0) {
     return std::nullopt;
   }
   if (std::memcmp(
-          functionBytes + 6,
+          functionBytesStart + 6,
           expectedImmediateValue,
           sizeof(expectedImmediateValue)) != 0) {
     return std::nullopt;
   }
 
   size_t jmpqOffset = 12;
-  if (std::memcmp(functionBytes + 12, jmpq, sizeof(jmpq)) != 0) {
+  if (std::memcmp(functionBytesStart + 12, jmpq, sizeof(jmpq)) != 0) {
     // The only exception to the pattern is cuMemsetD8Async which does a
     // ubyte -> uint promotion of its second argument. We just
     // skip that here. Our own function will redo the promotion,
     // but the operation is idempotent.
     if (std::memcmp(
-            functionBytes + 12, movzbl_sil_esi, sizeof(movzbl_sil_esi)) != 0) {
+            functionBytesStart + 12, movzbl_sil_esi, sizeof(movzbl_sil_esi)) !=
+        0) {
       return std::nullopt;
     }
     jmpqOffset += sizeof(movzbl_sil_esi);
@@ -78,10 +93,10 @@ std::optional<void*> extractJumpTarget(const uint8_t* functionBytes) {
   int32_t ripRelativeOffset;
   std::memcpy(
       &ripRelativeOffset,
-      functionBytes + jmpqOffset + 2,
+      functionBytesStart + jmpqOffset + 2,
       sizeof(ripRelativeOffset));
   uintptr_t jmpqInstructionAddress =
-      reinterpret_cast<uintptr_t>(functionBytes) + jmpqOffset;
+      reinterpret_cast<uintptr_t>(functionBytesStart) + jmpqOffset;
   uintptr_t targetAddress = jmpqInstructionAddress + 6 + ripRelativeOffset;
   return reinterpret_cast<void*>(targetAddress);
 }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #1158
* __->__ #1162
* #1160
* #1153

Mocking cuda relies on matching against an expected sequence of bytes at the start of each cuda driver function. If `libcuda.so.1` was compiled without the `-fomit-frame-pointer` flag, then there will be additional bytes at the start to deal with the frame pointer. `mock_cuda.cpp` now takes into account this case as well.

Differential Revision: [D82129347](https://our.internmc.facebook.com/intern/diff/D82129347/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D82129347/)!