### PR TITLE
Should not restrict RdmaController on RDMA instance

### DIFF
--- a/monarch_rdma/examples/cuda_ping_pong/src/cuda_ping_pong.rs
+++ b/monarch_rdma/examples/cuda_ping_pong/src/cuda_ping_pong.rs
@@ -705,12 +705,12 @@ pub async fn run() -> Result<(), anyhow::Error> {
 
     // Create RDMA manager for the first device
     let device_1_rdma_manager: RootActorMesh<'_, RdmaManagerActor> = device_1_proc_mesh
-        .spawn("device_1_rdma_manager", &device_1_ibv_config)
+        .spawn("device_1_rdma_manager", &Some(device_1_ibv_config))
         .await?;
 
     // Create RDMA manager for the second device
     let device_2_rdma_manager: RootActorMesh<'_, RdmaManagerActor> = device_2_proc_mesh
-        .spawn("device_2_rdma_manager", &device_2_ibv_config)
+        .spawn("device_2_rdma_manager", &Some(device_2_ibv_config))
         .await?;
 
     // Get the RDMA manager actor references

--- a/monarch_rdma/examples/parameter_server/src/parameter_server.rs
+++ b/monarch_rdma/examples/parameter_server/src/parameter_server.rs
@@ -495,7 +495,7 @@ pub async fn run(num_workers: usize, num_steps: usize) -> Result<(), anyhow::Err
     // We spin this up manually here, but in Python-land we assume this will
     // be spun up with the PyProcMesh.
     let ps_rdma_manager: RootActorMesh<'_, RdmaManagerActor> = ps_proc_mesh
-        .spawn("ps_rdma_manager", &ps_ibv_config)
+        .spawn("ps_rdma_manager", &Some(ps_ibv_config))
         .await
         .unwrap();
 
@@ -518,7 +518,7 @@ pub async fn run(num_workers: usize, num_steps: usize) -> Result<(), anyhow::Err
     );
     // Similarly, create an RdmaManagerActor corresponding to each worker.
     let worker_rdma_manager_mesh: RootActorMesh<'_, RdmaManagerActor> = worker_proc_mesh
-        .spawn("ps_rdma_manager", &worker_ibv_config)
+        .spawn("ps_rdma_manager", &Some(worker_ibv_config))
         .await
         .unwrap();
 

--- a/monarch_rdma/src/test_utils.rs
+++ b/monarch_rdma/src/test_utils.rs
@@ -345,8 +345,10 @@ pub mod test_utils {
                 .unwrap();
 
             let proc_mesh_1 = Box::leak(Box::new(ProcMesh::allocate(alloc_1).await.unwrap()));
-            let actor_mesh_1: RootActorMesh<'_, RdmaManagerActor> =
-                proc_mesh_1.spawn("rdma_manager", &(config1)).await.unwrap();
+            let actor_mesh_1: RootActorMesh<'_, RdmaManagerActor> = proc_mesh_1
+                .spawn("rdma_manager", &Some(config1))
+                .await
+                .unwrap();
 
             let alloc_2 = LocalAllocator
                 .allocate(AllocSpec {
@@ -358,8 +360,10 @@ pub mod test_utils {
                 .unwrap();
 
             let proc_mesh_2 = Box::leak(Box::new(ProcMesh::allocate(alloc_2).await.unwrap()));
-            let actor_mesh_2: RootActorMesh<'_, RdmaManagerActor> =
-                proc_mesh_2.spawn("rdma_manager", &(config2)).await.unwrap();
+            let actor_mesh_2: RootActorMesh<'_, RdmaManagerActor> = proc_mesh_2
+                .spawn("rdma_manager", &Some(config2))
+                .await
+                .unwrap();
 
             let mut buf_vec = Vec::new();
             let mut cuda_contexts = Vec::new();

--- a/python/monarch/_src/tensor_engine/rdma.py
+++ b/python/monarch/_src/tensor_engine/rdma.py
@@ -119,10 +119,8 @@ class RdmaController(Actor):
 
     @endpoint
     async def init_rdma_on_mesh(self, proc_mesh: ProcMesh) -> None:
-        if not _RdmaBuffer.rdma_supported():
-            raise RuntimeError(
-                "Cannot spawn _RdmaManager because RDMA is not supported on this machine"
-            )
+        # Note: RdmaController acts as coordinator and can run on any node
+        # The RDMA support check should happen on the target proc_mesh nodes, not on RdmaController's node
 
         if proc_mesh in self._managers:
             return

--- a/python/tests/test_rdma_unsupported.py
+++ b/python/tests/test_rdma_unsupported.py
@@ -1,0 +1,54 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-unsafe
+"""
+Tests for RDMA functionality when RDMA is not supported.
+
+This file contains tests that are specifically designed to run on systems
+where RDMA is NOT available. These tests verify error handling and fallback
+behavior when RDMA support is missing.
+"""
+
+import pytest
+from monarch.tensor_engine import is_available as rdma_available
+
+needs_no_rdma = pytest.mark.skipif(
+    rdma_available(),
+    reason="RDMA is available, test only runs on systems without RDMA support",
+)
+
+
+@needs_no_rdma
+@pytest.mark.asyncio
+async def test_rdma_manager_creation_fails_when_unsupported():
+    """Test that RdmaManagerActor creation fails with correct error when RDMA is not supported.
+
+    This test only runs on systems where RDMA is not available.
+    If RDMA is available, the test is skipped since we cannot test the unsupported path.
+
+    Note: We don't use mock here because the error originates from a cross-language call
+    chain (Python → Rust → C ibverbs library). Python mocks cannot intercept the native
+    ibverbs_supported() function that calls ibv_get_device_list() in the C library.
+    """
+    from monarch._rust_bindings.rdma import _RdmaManager
+    from monarch._src.actor.future import Future
+    from monarch.actor import this_host
+
+    proc_mesh = this_host().spawn_procs(per_host={"cpus": 1})
+
+    with pytest.raises(Exception) as exc_info:
+        await Future(
+            coro=_RdmaManager.create_rdma_manager_nonblocking(
+                await Future(coro=proc_mesh._proc_mesh.task())
+            )
+        )
+
+    error_message = str(exc_info.value)
+    assert (
+        "Cannot create RdmaManagerActor because RDMA is not supported on this machine"
+        in error_message
+    ), f"Expected specific error message not found. Actual error: {error_message}"


### PR DESCRIPTION
Summary:
Currently, the system will fail if the RdmaController runs on an instance that does not support RDMA. For example, if you launch a MAST job with RDMA-enabled instances, your local environment is still required to support RDMA, because that is where the RdmaController runs by default. (Sidenote: It is not trivial to change the RdmaController to run on the MAST mesh either, because it is a singleton, whereas MAST mesh jobs run as multiple actors, and slicing a mesh is not supported yet.)
However, there is no reason for the RdmaController to require running on instances that support RDMA. This diff contains the changes to remove that restriction.

Differential Revision: D82124576


