### PR TITLE
(monarch/CI) remove redundant build_process_allocator in CI jobs

### DIFF
--- a/.github/workflows/build-cuda.yml
+++ b/.github/workflows/build-cuda.yml
@@ -37,9 +37,6 @@ jobs:
         # Setup Tensor Engine
         setup_tensor_engine
 
-        # Build the process allocator binary
-        build_process_allocator
-
         export CUDA_LIB_DIR=/usr/lib64
 
         # Build monarch (CUDA version)

--- a/.github/workflows/doc_build.yml
+++ b/.github/workflows/doc_build.yml
@@ -33,9 +33,6 @@ jobs:
         # Setup Tensor Engine
         setup_tensor_engine
 
-        # Build the process allocator binary
-        build_process_allocator
-
         # Setup Python dependencies
         python -m pip install --upgrade pip
         pip install -r build-requirements.txt

--- a/.github/workflows/test-cuda.yml
+++ b/.github/workflows/test-cuda.yml
@@ -39,11 +39,6 @@ jobs:
         # Setup test environment
         setup_test_environment
 
-        # Install cargo binaries
-        mkdir cargo_bin && mv ${RUNNER_ARTIFACT_DIR}/cargo_bin/* cargo_bin
-        chmod +x cargo_bin/process_allocator
-        export PATH=$(pwd)/cargo_bin:$PATH
-
         # Setup Tensor Engine dependencies
         setup_tensor_engine
 

--- a/scripts/common-setup.sh
+++ b/scripts/common-setup.sh
@@ -59,15 +59,6 @@ setup_tensor_engine() {
     dnf install -y libibverbs rdma-core libmlx5 libibverbs-devel rdma-core-devel
 }
 
-# Build process allocator binary
-build_process_allocator() {
-    echo "Building process allocator binary..."
-    cargo build --manifest-path monarch_hyperactor/Cargo.toml --release
-    mkdir -p "${RUNNER_ARTIFACT_DIR}"/cargo_bin
-    mv target/release/process_allocator "${RUNNER_ARTIFACT_DIR}"/cargo_bin
-}
-
-
 # Common setup for build workflows (environment + system deps + rust)
 setup_build_environment() {
     local python_version=${1:-3.10}


### PR DESCRIPTION
Summary: Manually building and copying `process_allocator` binary to `cargo_bin/**` is no longer needed since https://github.com/meta-pytorch/monarch/pull/1163 includes `process_allocator` as part of the monarch wheel.

Differential Revision: D82138033
