### PR TITLE
Fix test utils in cuda path

### DIFF
--- a/monarch_rdma/src/rdma_manager_actor_tests.rs
+++ b/monarch_rdma/src/rdma_manager_actor_tests.rs
@@ -405,7 +405,7 @@ mod tests {
             println!("Skipping test: GPU P2P not supported");
             return Ok(());
         }
-        const BSIZE: usize = 1024 * 1024;
+        const BSIZE: usize = 2 * 1024 * 1024;
         let devices = get_all_devices();
         if devices.len() < 5 {
             println!(
@@ -711,7 +711,7 @@ mod tests {
             println!("Skipping test: GPU P2P not supported");
             return Ok(());
         }
-        const BSIZE: usize = 32;
+        const BSIZE: usize = 2 * 1024 * 1024; // minimum size for cuda
         let devices = get_all_devices();
         if devices.len() < 5 {
             println!(


### PR DESCRIPTION
Summary: During prior refactor, cuda testing path was mapped to cpu path, so tests accidentally longer covered cuda case.  This fixes issue; no changes to rdma internals (all tests passed before and after fix).

Differential Revision: D82172473


