### PR TITLE
make test_actor_mesh_stop more robust by allowing for failure to deliver RuntimeError; fix flaky OSS

### DIFF
--- a/python/tests/test_python_actors.py
+++ b/python/tests/test_python_actors.py
@@ -8,7 +8,6 @@
 
 import asyncio
 import ctypes
-import gc
 import importlib.resources
 import logging
 import operator
@@ -1326,7 +1325,8 @@ class TestActorMeshStop(unittest.IsolatedAsyncioTestCase):
         await cast(ActorMesh, am_1).stop()
 
         with self.assertRaisesRegex(
-            RuntimeError, expected_regex="`PythonActorMesh` has already been stopped"
+            RuntimeError,
+            r"(?:`PythonActorMesh` has already been stopped|delivery error: broken link)",
         ):
             await am_1.print.call("hello 1")
 


### PR DESCRIPTION
Summary:
in OSS, test_actor_mesh_stop is flaky as it can fail with two different regexes
e.g https://github.com/meta-pytorch/monarch/actions/runs/17628571027/job/50092263340

this should fix

Differential Revision: D82319426


