### PR TITLE
Drop requirement around nv_permeem for cpu triggered gpu <> gpu

### DIFF
--- a/monarch_rdma/src/ibverbs_primitives.rs
+++ b/monarch_rdma/src/ibverbs_primitives.rs
@@ -154,7 +154,7 @@ impl Default for IbverbsConfig {
             max_rd_atomic: 1,
             pkey_index: 0,
             psn: rand::random::<u32>() & 0xffffff,
-            use_gpu_direct: true,
+            use_gpu_direct: false, // nv_peermem enabled for cuda
         }
     }
 }

--- a/monarch_rdma/src/rdma_manager_actor_tests.rs
+++ b/monarch_rdma/src/rdma_manager_actor_tests.rs
@@ -16,14 +16,15 @@
 #[cfg(test)]
 mod tests {
 
+    use hyperactor::clock::Clock;
+    use hyperactor::clock::RealClock;
+
     use crate::PollTarget;
     use crate::ibverbs_primitives::get_all_devices;
     use crate::rdma_components::validate_execution_context;
     use crate::rdma_manager_actor::RdmaManagerMessageClient;
     use crate::test_utils::test_utils::RdmaManagerTestEnv;
     use crate::test_utils::test_utils::*;
-
-    // CPU-only tests
 
     #[timed_test::async_timed_test(timeout_secs = 60)]
     async fn test_rdma_read_loopback() -> Result<(), anyhow::Error> {
@@ -581,10 +582,6 @@ mod tests {
             println!("Skipping CUDA test in CPU-only mode");
             return Ok(());
         }
-        if !does_gpu_support_p2p().await {
-            println!("Skipping test: GPU P2P not supported");
-            return Ok(());
-        }
         const BSIZE: usize = 2 * 1024 * 1024; // minimum size for cuda
         let devices = get_all_devices();
         if devices.len() < 5 {
@@ -594,10 +591,12 @@ mod tests {
             return Ok(());
         }
         let env = RdmaManagerTestEnv::setup(BSIZE, ("mlx5_0", "mlx5_4"), ("cuda:0", "cpu")).await?;
+        // Pre-initialize comms, and wait for hardware to transition to send state
         let mut qp_1 = env
             .actor_1
             .request_queue_pair(&env.client_1.clone(), env.actor_2.clone())
             .await?;
+        RealClock.sleep(std::time::Duration::from_millis(50)).await;
         qp_1.put(env.rdma_handle_1.clone(), env.rdma_handle_2.clone())?;
 
         wait_for_completion(&mut qp_1, PollTarget::Send, 5).await?;
@@ -614,10 +613,6 @@ mod tests {
             println!("Skipping CUDA test in CPU-only mode");
             return Ok(());
         }
-        if !does_gpu_support_p2p().await {
-            println!("Skipping test: GPU P2P not supported");
-            return Ok(());
-        }
         const BSIZE: usize = 2 * 1024 * 1024; // minimum size for cuda
         let devices = get_all_devices();
         if devices.len() < 5 {
@@ -628,10 +623,12 @@ mod tests {
         }
         let env =
             RdmaManagerTestEnv::setup(BSIZE, ("mlx5_0", "mlx5_4"), ("cuda:0", "cuda:1")).await?;
+        // Pre-initialize comms, and wait for hardware to transition to send state
         let mut qp_1 = env
             .actor_1
             .request_queue_pair(&env.client_1.clone(), env.actor_2.clone())
             .await?;
+        RealClock.sleep(std::time::Duration::from_millis(50)).await;
         qp_1.put(env.rdma_handle_1.clone(), env.rdma_handle_2.clone())?;
 
         wait_for_completion(&mut qp_1, PollTarget::Send, 5).await?;
@@ -647,10 +644,6 @@ mod tests {
             println!("Skipping CUDA test in CPU-only mode");
             return Ok(());
         }
-        if !does_gpu_support_p2p().await {
-            println!("Skipping test: GPU P2P not supported");
-            return Ok(());
-        }
         const BSIZE: usize = 2 * 1024 * 1024; // minimum size for cuda
         let devices = get_all_devices();
         if devices.len() < 5 {
@@ -661,6 +654,14 @@ mod tests {
         }
         let env = RdmaManagerTestEnv::setup(BSIZE, ("mlx5_0", "mlx5_4"), ("cuda:0", "cpu")).await?;
         let /*mut*/ rdma_handle_1 = env.rdma_handle_1.clone();
+
+        // Pre-initialize comms, and wait for hardware to transition to send state
+        let mut _qp_1 = env
+            .actor_1
+            .request_queue_pair(&env.client_1.clone(), env.actor_2.clone())
+            .await?;
+        RealClock.sleep(std::time::Duration::from_millis(50)).await;
+
         rdma_handle_1
             .read_into(&env.client_1.clone(), env.rdma_handle_2.clone(), 2)
             .await?;
@@ -676,8 +677,37 @@ mod tests {
             println!("Skipping CUDA test in CPU-only mode");
             return Ok(());
         }
-        if !does_gpu_support_p2p().await {
-            println!("Skipping test: GPU P2P not supported");
+        const BSIZE: usize = 2 * 1024 * 1024; // minimum size for cuda
+        let devices = get_all_devices();
+        if devices.len() < 5 {
+            println!(
+                "skipping this test as it is only configured on H100 nodes with backend network"
+            );
+            return Ok(());
+        }
+        let env =
+            RdmaManagerTestEnv::setup(BSIZE, ("mlx5_0", "mlx5_4"), ("cuda:0", "cuda:1")).await?;
+        // Pre-initialize comms, and wait for hardware to transition to send state
+        let mut _qp_1 = env
+            .actor_1
+            .request_queue_pair(&env.client_1.clone(), env.actor_2.clone())
+            .await?;
+        RealClock.sleep(std::time::Duration::from_millis(50)).await;
+
+        let /*mut*/ rdma_handle_1 = env.rdma_handle_1.clone();
+        rdma_handle_1
+            .read_into(&env.client_1.clone(), env.rdma_handle_2.clone(), 2)
+            .await?;
+
+        env.verify_buffers(BSIZE).await?;
+        env.cleanup().await?;
+        Ok(())
+    }
+
+    #[timed_test::async_timed_test(timeout_secs = 60)]
+    async fn test_rdma_write_from_cuda_vs_cuda() -> Result<(), anyhow::Error> {
+        if is_cpu_only_mode() {
+            println!("Skipping CUDA test in CPU-only mode");
             return Ok(());
         }
         const BSIZE: usize = 2 * 1024 * 1024; // minimum size for cuda
@@ -690,42 +720,19 @@ mod tests {
         }
         let env =
             RdmaManagerTestEnv::setup(BSIZE, ("mlx5_0", "mlx5_4"), ("cuda:0", "cuda:1")).await?;
+        // Pre-initialize comms, and wait for hardware to transition to send state
+        let mut _qp_1 = env
+            .actor_1
+            .request_queue_pair(&env.client_1.clone(), env.actor_2.clone())
+            .await?;
+        RealClock.sleep(std::time::Duration::from_millis(50)).await;
         let /*mut*/ rdma_handle_1 = env.rdma_handle_1.clone();
         rdma_handle_1
-            .read_into(&env.client_1.clone(), env.rdma_handle_2.clone(), 2)
+            .write_from(&env.client_1.clone(), env.rdma_handle_2.clone(), 2)
             .await?;
 
         env.verify_buffers(BSIZE).await?;
         env.cleanup().await?;
-        Ok(())
-    }
-
-    // Tests RdmaBufer's `read_into` API
-    #[timed_test::async_timed_test(timeout_secs = 60)]
-    async fn test_rdma_read_into_cuda() -> Result<(), anyhow::Error> {
-        if is_cpu_only_mode() {
-            println!("Skipping CUDA test in CPU-only mode");
-            return Ok(());
-        }
-        if !does_gpu_support_p2p().await {
-            println!("Skipping test: GPU P2P not supported");
-            return Ok(());
-        }
-        const BSIZE: usize = 2 * 1024 * 1024; // minimum size for cuda
-        let devices = get_all_devices();
-        if devices.len() < 5 {
-            println!(
-                "skipping this test as it is only configured on H100 nodes with backend network"
-            );
-            return Ok(());
-        }
-        let env = RdmaManagerTestEnv::setup(BSIZE, ("mlx5_0", "mlx5_4"), ("cuda:0", "cpu")).await?;
-        let /*mut*/ rdma_handle_1 = env.rdma_handle_1.clone();
-        rdma_handle_1
-            .read_into(&env.client_1.clone(), env.rdma_handle_2.clone(), 2)
-            .await?;
-
-        env.verify_buffers(BSIZE).await?;
         Ok(())
     }
 }

--- a/monarch_rdma/src/test_utils.rs
+++ b/monarch_rdma/src/test_utils.rs
@@ -97,6 +97,7 @@ pub mod test_utils {
     use crate::rdma_components::RdmaQueuePair;
     use crate::rdma_manager_actor::RdmaManagerActor;
     use crate::rdma_manager_actor::RdmaManagerMessageClient;
+    use crate::validate_execution_context;
     // Waits for the completion of an RDMA operation.
 
     // This function polls for the completion of an RDMA operation by repeatedly
@@ -316,9 +317,9 @@ pub mod test_utils {
                     .parse::<usize>()
                     .expect("Device index is not a valid integer");
                 accel1 = (backend.to_string(), parsed_idx);
+                config1.use_gpu_direct = validate_execution_context().await.is_ok();
             } else {
                 assert!(accels.0 == "cpu");
-                config1.use_gpu_direct = false;
                 accel1 = ("cpu".to_string(), 0);
             }
 
@@ -328,9 +329,9 @@ pub mod test_utils {
                     .parse::<usize>()
                     .expect("Device index is not a valid integer");
                 accel2 = (backend.to_string(), parsed_idx);
+                config2.use_gpu_direct = validate_execution_context().await.is_ok();
             } else {
                 assert!(accels.1 == "cpu");
-                config2.use_gpu_direct = false;
                 accel2 = ("cpu".to_string(), 0);
             }
 


### PR DESCRIPTION
Summary: GPU <> GPU RDMA only needs NV PERMEEM kernels IFF we are doing device comms; if its cpu initiated, its fine to use standard IBV DMABUF Registration.     One subtly is at least in internal test infra, it appears the software can be Ready-To-Send before hardware has caught up.  the short-term fix is after setting up all QPs introduce a small delay (10's ms) to allow hardware to catch up.  In theory we can do this once or with high level apis, the natural overhead will provide enough time to resolve.

Reviewed By: allenwang28

Differential Revision: D82270311


