### PR TITLE
Limit cast fanout

### DIFF
--- a/hyperactor_mesh/src/config.rs
+++ b/hyperactor_mesh/src/config.rs
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+//! Configuration for Hyperactor Mesh.
+//!
+//! This module provides hyperactor_mesh-specific configuration attributes that extend
+//! the base hyperactor configuration system.
+
+use hyperactor::attrs::declare_attrs;
+use hyperactor::config::CONFIG_ENV_VAR;
+
+// Declare hyperactor_mesh-specific configuration keys
+declare_attrs! {
+    /// The maximium for a dimension size allowed for a folded shape
+    /// when reshaping during casting to limit fanout.
+    /// usize::MAX means no reshaping as any shape will always be below
+    /// the limit so no dimension needs to be folded.
+    @meta(CONFIG_ENV_VAR = "HYPERACTOR_MESH_MAX_CAST_DIMENSION_SIZE".to_string())
+    pub attr MAX_CAST_DIMENSION_SIZE: usize = usize::MAX;
+}

--- a/hyperactor_mesh/src/lib.rs
+++ b/hyperactor_mesh/src/lib.rs
@@ -18,6 +18,7 @@ pub mod alloc;
 mod assign;
 pub mod bootstrap;
 pub mod comm;
+pub mod config;
 pub mod connect;
 pub mod logging;
 pub mod mesh;


### PR DESCRIPTION
Summary:
ActorMesh's shape might have large extents on some dimensions. Those dimensions would cause large fanout in our comm actor
implementation. To avoid that, we reshape it by increasing dimensionality and limiting the extent of each dimension. Note: the reshape is only visibility to the internal algorithom. Theshape that user sees maintains intact.

For example, a typical shape is [hosts=1024, gpus=8]. By using limit 8, it becomes [8, 8, 8, 2, 8] during casting. In other words, it adds 3 extra layers to the comm actor tree, while keeping the fanout in each layer at 8 or smaller.

The limit for cast fanouts will be configured by the key `CASTING_FANOUT_SIZE` which is currently set to 0 as default disabling the feature.

Differential Revision: D82320948


