### PR TITLE
: mailbox: implement ttl for MessageEnvelope

### DIFF
--- a/hyperactor/src/config.rs
+++ b/hyperactor/src/config.rs
@@ -42,6 +42,9 @@ declare_attrs! {
     /// Number of messages after which to send an acknowledgment
     pub attr MESSAGE_ACK_EVERY_N_MESSAGES: u64 = 1000;
 
+    /// Default hop Time-To-Live for message envelopes.
+    pub attr MESSAGE_TTL_DEFAULT : u8 = 64;
+
     /// Maximum buffer size for split port messages
     pub attr SPLIT_MAX_BUFFER_SIZE: usize = 5;
 
@@ -86,6 +89,14 @@ pub fn from_env() -> Attrs {
         if let Ok(parsed) = val.parse::<u64>() {
             tracing::info!("overriding MESSAGE_ACK_TIME_INTERVAL to {}", parsed);
             config[MESSAGE_ACK_TIME_INTERVAL] = Duration::from_millis(parsed);
+        }
+    }
+
+    // Load message ttl default
+    if let Ok(val) = env::var("HYPERACTOR_MESSAGE_TTL_DEFAULT") {
+        if let Ok(parsed) = val.parse::<u8>() {
+            tracing::info!("overriding MESSAGE_TTL_DEFAULT to {}", parsed);
+            config[MESSAGE_TTL_DEFAULT] = parsed;
         }
     }
 
@@ -163,6 +174,9 @@ pub fn merge(config: &mut Attrs, other: &Attrs) {
     }
     if other.contains_key(MESSAGE_ACK_EVERY_N_MESSAGES) {
         config[MESSAGE_ACK_EVERY_N_MESSAGES] = other[MESSAGE_ACK_EVERY_N_MESSAGES];
+    }
+    if other.contains_key(MESSAGE_TTL_DEFAULT) {
+        config[MESSAGE_TTL_DEFAULT] = other[MESSAGE_TTL_DEFAULT];
     }
     if other.contains_key(SPLIT_MAX_BUFFER_SIZE) {
         config[SPLIT_MAX_BUFFER_SIZE] = other[SPLIT_MAX_BUFFER_SIZE];

--- a/hyperactor/src/host.rs
+++ b/hyperactor/src/host.rs
@@ -193,15 +193,15 @@ struct ProcOrDial {
 }
 
 impl MailboxSender for ProcOrDial {
-    fn post(
+    fn post_unchecked(
         &self,
         envelope: MessageEnvelope,
         return_handle: PortHandle<Undeliverable<MessageEnvelope>>,
     ) {
         if envelope.dest().actor_id().proc_id() == self.proc.proc_id() {
-            self.proc.post(envelope, return_handle);
+            self.proc.post_unchecked(envelope, return_handle);
         } else {
-            self.router.post(envelope, return_handle)
+            self.router.post_unchecked(envelope, return_handle)
         }
     }
 }

--- a/hyperactor/src/mailbox/durable_mailbox_sender.rs
+++ b/hyperactor/src/mailbox/durable_mailbox_sender.rs
@@ -70,7 +70,7 @@ impl DurableMailboxSender {
 
 #[async_trait]
 impl MailboxSender for DurableMailboxSender {
-    fn post(
+    fn post_unchecked(
         &self,
         envelope: MessageEnvelope,
         return_handle: PortHandle<Undeliverable<MessageEnvelope>>,

--- a/hyperactor/src/proc.rs
+++ b/hyperactor/src/proc.rs
@@ -739,7 +739,7 @@ impl Proc {
 
 #[async_trait]
 impl MailboxSender for Proc {
-    fn post(
+    fn post_unchecked(
         &self,
         envelope: MessageEnvelope,
         return_handle: PortHandle<Undeliverable<MessageEnvelope>>,
@@ -767,7 +767,7 @@ impl WeakProc {
 
 #[async_trait]
 impl MailboxSender for WeakProc {
-    fn post(
+    fn post_unchecked(
         &self,
         envelope: MessageEnvelope,
         return_handle: PortHandle<Undeliverable<MessageEnvelope>>,

--- a/hyperactor_mesh/src/actor_mesh.rs
+++ b/hyperactor_mesh/src/actor_mesh.rs
@@ -1352,7 +1352,7 @@ mod tests {
 
             // Message sized to exactly max frame length.
             let payload = Payload {
-                part: Part::from(Bytes::from(vec![0u8; 764])),
+                part: Part::from(Bytes::from(vec![0u8; 763])),
                 reply_port: reply_handle.bind(),
             };
             let frame_len = frame_length(
@@ -1372,7 +1372,7 @@ mod tests {
 
             // Message sized to max frame length + 1.
             let payload = Payload {
-                part: Part::from(Bytes::from(vec![0u8; 765])),
+                part: Part::from(Bytes::from(vec![0u8; 764])),
                 reply_port: reply_handle.bind(),
             };
             let frame_len = frame_length(

--- a/hyperactor_mesh/src/proc_mesh/mesh_agent.rs
+++ b/hyperactor_mesh/src/proc_mesh/mesh_agent.rs
@@ -380,6 +380,21 @@ impl MailboxSender for ReconfigurableMailboxSender {
             }
         }
     }
+
+    fn post_unchecked(
+        &self,
+        envelope: MessageEnvelope,
+        return_handle: PortHandle<Undeliverable<MessageEnvelope>>,
+    ) {
+        match *self.state.read().unwrap() {
+            ReconfigurableMailboxSenderState::Queueing(ref queue) => {
+                queue.lock().unwrap().push((envelope, return_handle));
+            }
+            ReconfigurableMailboxSenderState::Configured(ref sender) => {
+                sender.post_unchecked(envelope, return_handle);
+            }
+        }
+    }
 }
 
 #[cfg(test)]
@@ -416,7 +431,7 @@ mod tests {
     }
 
     impl MailboxSender for QueueingMailboxSender {
-        fn post(
+        fn post_unchecked(
             &self,
             envelope: MessageEnvelope,
             _return_handle: PortHandle<Undeliverable<MessageEnvelope>>,

--- a/hyperactor_multiprocess/src/system_actor.rs
+++ b/hyperactor_multiprocess/src/system_actor.rs
@@ -722,14 +722,14 @@ pub struct ReportingRouter {
 }
 
 impl MailboxSender for ReportingRouter {
-    fn post(
+    fn post_unchecked(
         &self,
         envelope: MessageEnvelope,
         return_handle: PortHandle<Undeliverable<MessageEnvelope>>,
     ) {
         let ReportingRouter { router, .. } = self;
         self.post_update_address(&envelope);
-        router.post(envelope, return_handle);
+        router.post_unchecked(envelope, return_handle);
     }
 }
 


### PR DESCRIPTION
Summary: added TTL support to message envelopes. seeded from `MESSAGE_TTL_DEFAULT` (`u8`, default 64) and decremented at every hop via a new `hop_or_undeliverable` helper. undeliverables get `DeliveryError::TtlExpired`. tests cover a loopback-until-expire case and a normal local delivery case. adjusted frame size tests in actor_mesh to account for the extra byte.

Differential Revision: D82337893


