### PR TITLE
Add send timestamp to the message headers with sampling to track e2e latency

### DIFF
--- a/hyperactor/Cargo.toml
+++ b/hyperactor/Cargo.toml
@@ -44,6 +44,7 @@ derivative = "2.2"
 dns-lookup = "1.0"
 enum-as-inner = "0.6.0"
 erased-serde = "0.3.27"
+fastrand = "2.1.1"
 futures = { version = "0.3.31", features = ["async-await", "compat"] }
 hostname = "0.3"
 hyperactor_macros = { version = "0.0.0", path = "../hyperactor_macros" }

--- a/hyperactor/src/config.rs
+++ b/hyperactor/src/config.rs
@@ -62,6 +62,10 @@ declare_attrs! {
 
     /// How often to check for full MSPC channel on NetRx.
     pub attr CHANNEL_NET_RX_BUFFER_FULL_CHECK_INTERVAL: Duration = Duration::from_secs(5);
+
+    /// Sampling rate for logging message latency
+    /// Set to 0.01 for 1% sampling, 0.1 for 10% sampling, 0.90 for 90% sampling, etc.
+    pub attr MESSAGE_LATENCY_SAMPLING_RATE: f32 = 0.01;
 }
 
 /// Load configuration from environment variables

--- a/hyperactor/src/data.rs
+++ b/hyperactor/src/data.rs
@@ -120,6 +120,12 @@ impl Named for std::time::Duration {
     }
 }
 
+impl Named for std::time::SystemTime {
+    fn typename() -> &'static str {
+        "std::time::SystemTime"
+    }
+}
+
 impl Named for bytes::Bytes {
     fn typename() -> &'static str {
         "bytes::Bytes"

--- a/hyperactor/src/mailbox/headers.rs
+++ b/hyperactor/src/mailbox/headers.rs
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+//! Message headers and latency tracking functionality for the mailbox system.
+//!
+//! This module provides header attributes and utilities for message metadata,
+//! including latency tracking timestamps used to measure message processing times.
+
+use std::time::SystemTime;
+
+use crate::attrs::Attrs;
+use crate::attrs::declare_attrs;
+use crate::clock::Clock;
+use crate::clock::RealClock;
+use crate::config::global;
+use crate::metrics::MESSAGE_LATENCY_MICROS;
+
+declare_attrs! {
+    /// Send timestamp for message latency tracking
+    pub attr SEND_TIMESTAMP: SystemTime;
+}
+
+/// Set the send timestamp for latency tracking if timestamp not already set.
+pub fn set_send_timestamp(headers: &mut Attrs) {
+    if !headers.contains_key(SEND_TIMESTAMP) {
+        let time = RealClock.system_time_now();
+        headers.set(SEND_TIMESTAMP, time);
+    }
+}
+
+/// This function checks the configured sampling rate and, if the random sample passes,
+/// calculates the latency between the send timestamp and the current time, then records
+/// the latency metric with the associated actor ID.
+pub fn log_message_latency_if_sampling(headers: &Attrs, actor_id: String) {
+    if fastrand::f32() > global::get(crate::config::MESSAGE_LATENCY_SAMPLING_RATE) {
+        return;
+    }
+    let metric_pairs = hyperactor_telemetry::kv_pairs!(
+        "actor_id" => actor_id
+    );
+    let send_timestamp = headers.get(SEND_TIMESTAMP).unwrap();
+    let now = RealClock.system_time_now();
+    let latency = now.duration_since(*send_timestamp).unwrap();
+    MESSAGE_LATENCY_MICROS.record(latency.as_micros() as f64, metric_pairs);
+}

--- a/hyperactor/src/metrics.rs
+++ b/hyperactor/src/metrics.rs
@@ -61,3 +61,7 @@ declare_static_counter!(PROC_MESH_ALLOCATION, "proc_mesh.active_procs");
 declare_static_counter!(PROC_MESH_PROC_STOPPED, "proc_mesh.proc_failures");
 // Tracks the number of actor failures within the process mesh
 declare_static_counter!(PROC_MESH_ACTOR_FAILURES, "proc_mesh.actor_failures");
+
+// MESSAGE LATENCY
+// Tracks end-to-end message latency in microseconds (sampled at 1% by default)
+declare_static_histogram!(MESSAGE_LATENCY_MICROS, "message.e2e_latency.us");

--- a/hyperactor/src/proc.rs
+++ b/hyperactor/src/proc.rs
@@ -1284,6 +1284,10 @@ impl<A: Actor> Instance<A> {
             self.clock().system_time_now(),
             handler,
         ));
+        crate::mailbox::headers::log_message_latency_if_sampling(
+            &headers,
+            self.self_id().to_string(),
+        );
         let span = tracing::debug_span!(
             "actor_status",
             actor_id = self.self_id().to_string(),

--- a/hyperactor_mesh/src/actor_mesh.rs
+++ b/hyperactor_mesh/src/actor_mesh.rs
@@ -1314,8 +1314,9 @@ mod tests {
             // Calculate the frame length for the given message.
             fn frame_length(src: &ActorId, dst: &PortId, pay: &Payload) -> usize {
                 let serialized = Serialized::serialize(pay).unwrap();
-                let envelope =
-                    MessageEnvelope::new(src.clone(), dst.clone(), serialized, Attrs::new());
+                let mut headers = Attrs::new();
+                hyperactor::mailbox::headers::set_send_timestamp(&mut headers);
+                let envelope = MessageEnvelope::new(src.clone(), dst.clone(), serialized, headers);
                 let frame = Frame::Message(0u64, envelope);
                 let message = serde_multipart::serialize_illegal_bincode(&frame).unwrap();
                 message.frame_len()
@@ -1352,7 +1353,7 @@ mod tests {
 
             // Message sized to exactly max frame length.
             let payload = Payload {
-                part: Part::from(Bytes::from(vec![0u8; 763])),
+                part: Part::from(Bytes::from(vec![0u8; 699])),
                 reply_port: reply_handle.bind(),
             };
             let frame_len = frame_length(
@@ -1372,7 +1373,7 @@ mod tests {
 
             // Message sized to max frame length + 1.
             let payload = Payload {
-                part: Part::from(Bytes::from(vec![0u8; 764])),
+                part: Part::from(Bytes::from(vec![0u8; 700])),
                 reply_port: reply_handle.bind(),
             };
             let frame_len = frame_length(


### PR DESCRIPTION
Summary:
Added a config which can contain sampling rate, defaults to 1%. The send timesamp is added in a couple of places (I couldn't find one common place for message sending - and please let me know if I missed something). 

Then when the message is finished handling we log the latency.

Differential Revision: D82178843


