### PR TITLE
[hyperactor] macros: allow PortRefs and PortHandles in the reply position

### DIFF
--- a/hyperactor/example/derive.rs
+++ b/hyperactor/example/derive.rs
@@ -16,6 +16,7 @@ use hyperactor::HandleClient;
 use hyperactor::Handler;
 use hyperactor::Named;
 use hyperactor::OncePortRef;
+use hyperactor::PortRef;
 use hyperactor::RefClient;
 use hyperactor::proc::Proc;
 use serde::Deserialize;
@@ -31,7 +32,7 @@ enum ShoppingList {
     // provided port, which must be in the last position.
     Exists(String, #[reply] OncePortRef<bool>),
 
-    List(#[reply] OncePortRef<Vec<String>>),
+    List(#[reply] PortRef<Vec<String>>),
 }
 
 // Struct message types. These generate a single method.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #1234
* #1233
* #1228
* #1227
* __->__ #1226
* #1225
* #1217

There's no real reason we can't allow this. This also allows us to unify different calling styles and generate handlers across.

Differential Revision: [D82534106](https://our.internmc.facebook.com/intern/diff/D82534106/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D82534106/)!