### PR TITLE
: v1: improve RankedRef

### DIFF
--- a/hyperactor_mesh/src/v1/proc_mesh.rs
+++ b/hyperactor_mesh/src/v1/proc_mesh.rs
@@ -357,6 +357,12 @@ impl view::Ranked for ProcMeshRef {
 }
 
 impl view::RankedRef for ProcMeshRef {
+    type Item = ProcRef;
+
+    fn region(&self) -> &Region {
+        &self.region
+    }
+
     fn get_ref(&self, rank: usize) -> Option<&Self::Item> {
         self.ranks.get(rank)
     }

--- a/ndslice/src/view.rs
+++ b/ndslice/src/view.rs
@@ -1269,7 +1269,7 @@ impl<T: Ranked> MapIntoExt for T {}
 
 /// Map-by-reference into any mesh `M` (no clone required).
 pub trait MapIntoRefExt: RankedRef {
-    fn map_into_ref<M, U>(&self, f: impl Fn(&Self::Item) -> U) -> M
+    fn map_into_ref<M, U>(&self, f: impl Fn(&<Self as RankedRef>::Item) -> U) -> M
     where
         M: BuildFromRegion<U>,
     {
@@ -1279,7 +1279,10 @@ pub trait MapIntoRefExt: RankedRef {
         M::build_dense_unchecked(region, values)
     }
 
-    fn try_map_into_ref<M, U, E>(&self, f: impl Fn(&Self::Item) -> Result<U, E>) -> Result<M, E>
+    fn try_map_into_ref<M, U, E>(
+        &self,
+        f: impl Fn(&<Self as RankedRef>::Item) -> Result<U, E>,
+    ) -> Result<M, E>
     where
         M: BuildFromRegion<U>,
     {
@@ -1392,13 +1395,29 @@ pub trait Ranked: Sized {
     /// Construct a new Ranked containing the ranks in this view that are
     /// part of region. The caller guarantees that
     /// `ranks.len() == region.num_ranks()` and that
-    /// `region.is_subset(self.region())`.`
+    /// `region.is_subset(self.region())`.
     fn sliced(&self, region: Region, ranks: impl Iterator<Item = Self::Item>) -> Self;
 }
 
-/// Access items by reference (no clone). Types that can expose
-/// internal storage implement this.
-pub trait RankedRef: Ranked {
+/// Borrowed (by-reference) access to items in a ranked view.
+///
+/// This trait is the counterpart to [`Ranked`], which provides owned
+/// access (`get` ->`Self::Item`). `RankedRef` instead allows
+/// implementors that can expose their internal storage to let callers
+/// borrow items directly without requiring `Clone` on the element
+/// type.
+///
+/// A type may implement `RankedRef` even if it cannot implement
+/// [`Ranked`], for example when its items are not `Clone`. This
+/// enables APIs like [`MapIntoRefExt`] that can transform meshes by
+/// reference only.
+pub trait RankedRef {
+    type Item;
+
+    /// The ranks contained in this view.
+    fn region(&self) -> &Region;
+
+    /// Return the item at `rank`
     fn get_ref(&self, rank: usize) -> Option<&Self::Item>;
 }
 


### PR DESCRIPTION
Summary:
fix `RankedRef` so `map_into_ref` works on `ValueMesh<T>` when `T: !Clone`

- make `RankedRef` independent of `Ranked`
- add `region()` to `RankedRef`
- implement for `ProcMeshRef` and `ValueMesh<T>`
- disambiguate `<Self as RankedRef>::Item` in `MapIntoRefExt`
- add test with `(i32, NotClone)` tuple
- doc cleanup (remove stray backtick, expand RankedRef comment)

Differential Revision: D82535815


