### PR TITLE
v1: remove mapped from ProcMeshRef (again)

### DIFF
--- a/hyperactor_mesh/src/v1/proc_mesh.rs
+++ b/hyperactor_mesh/src/v1/proc_mesh.rs
@@ -357,6 +357,12 @@ impl view::Ranked for ProcMeshRef {
 }
 
 impl view::RankedRef for ProcMeshRef {
+    type Item = ProcRef;
+
+    fn region(&self) -> &Region {
+        &self.region
+    }
+
     fn get_ref(&self, rank: usize) -> Option<&Self::Item> {
         self.ranks.get(rank)
     }

--- a/hyperactor_mesh/src/v1/proc_mesh.rs
+++ b/hyperactor_mesh/src/v1/proc_mesh.rs
@@ -254,16 +254,6 @@ impl ProcMeshRef {
         })
     }
 
-    /// Maps over all of the ProcRefs in the mesh, returning a new
-    /// ValueMesh with the mapped values. This is infallible because
-    /// the mapping is 1:1 with the ranks.
-    fn mapped<F, R>(&self, f: F) -> ValueMesh<R>
-    where
-        F: Fn(&ProcRef) -> R,
-    {
-        ValueMesh::new_unchecked(self.region.clone(), self.ranks.iter().map(f).collect())
-    }
-
     /// The current statuses of procs in this mesh.
     #[allow(dead_code)]
     async fn status(&self, cx: &impl context::Actor) -> v1::Result<ValueMesh<bool>> {

--- a/ndslice/src/view.rs
+++ b/ndslice/src/view.rs
@@ -1269,7 +1269,7 @@ impl<T: Ranked> MapIntoExt for T {}
 
 /// Map-by-reference into any mesh `M` (no clone required).
 pub trait MapIntoRefExt: RankedRef {
-    fn map_into_ref<M, U>(&self, f: impl Fn(&Self::Item) -> U) -> M
+    fn map_into_ref<M, U>(&self, f: impl Fn(&<Self as RankedRef>::Item) -> U) -> M
     where
         M: BuildFromRegion<U>,
     {
@@ -1279,7 +1279,10 @@ pub trait MapIntoRefExt: RankedRef {
         M::build_dense_unchecked(region, values)
     }
 
-    fn try_map_into_ref<M, U, E>(&self, f: impl Fn(&Self::Item) -> Result<U, E>) -> Result<M, E>
+    fn try_map_into_ref<M, U, E>(
+        &self,
+        f: impl Fn(&<Self as RankedRef>::Item) -> Result<U, E>,
+    ) -> Result<M, E>
     where
         M: BuildFromRegion<U>,
     {
@@ -1392,13 +1395,29 @@ pub trait Ranked: Sized {
     /// Construct a new Ranked containing the ranks in this view that are
     /// part of region. The caller guarantees that
     /// `ranks.len() == region.num_ranks()` and that
-    /// `region.is_subset(self.region())`.`
+    /// `region.is_subset(self.region())`.
     fn sliced(&self, region: Region, ranks: impl Iterator<Item = Self::Item>) -> Self;
 }
 
-/// Access items by reference (no clone). Types that can expose
-/// internal storage implement this.
-pub trait RankedRef: Ranked {
+/// Borrowed (by-reference) access to items in a ranked view.
+///
+/// This trait is the counterpart to [`Ranked`], which provides owned
+/// access (`get` ->`Self::Item`). `RankedRef` instead allows
+/// implementors that can expose their internal storage to let callers
+/// borrow items directly without requiring `Clone` on the element
+/// type.
+///
+/// A type may implement `RankedRef` even if it cannot implement
+/// [`Ranked`], for example when its items are not `Clone`. This
+/// enables APIs like [`MapIntoRefExt`] that can transform meshes by
+/// reference only.
+pub trait RankedRef {
+    type Item;
+
+    /// The ranks contained in this view.
+    fn region(&self) -> &Region;
+
+    /// Return the item at `rank`
     fn get_ref(&self, rank: usize) -> Option<&Self::Item>;
 }
 


### PR DESCRIPTION
Summary: D82235779 removed `ProcMesh::mapped` (since `.map_into_ref()`  now exists) but D82035308 ("[hyperactor] introduce (owned) ProcMesh, and test multiple allocators") put it back. this diff removes it again.

Differential Revision: D82539609
