### PR TITLE
Fix in Proc Mesh Allocation Metric

### DIFF
--- a/hyperactor_mesh/src/proc_mesh.rs
+++ b/hyperactor_mesh/src/proc_mesh.rs
@@ -415,7 +415,10 @@ impl ProcMesh {
 
         let shape = alloc.shape().clone();
         let world_id = alloc.world_id().clone();
-        metrics::PROC_MESH_ALLOCATION.add(1, hyperactor_telemetry::kv_pairs!());
+        metrics::PROC_MESH_ALLOCATION.add(
+            running.len() as u64,
+            hyperactor_telemetry::kv_pairs!("alloc_id" => alloc_id.to_string()),
+        );
 
         Ok(Self {
             event_state: Some(EventState {


### PR DESCRIPTION
Summary:
See T238032743

We should be seeing the number o factive procs in the proc mesh but we are seeing just 5 in https://fburl.com/scuba/monarch_metrics/bv4ywrj5

Also adding alloc_id to help differentiate it.

Differential Revision: D82473916


