### PR TITLE
workspace sync fix for empty dir

### DIFF
--- a/python/monarch/tools/config/__init__.py
+++ b/python/monarch/tools/config/__init__.py
@@ -40,7 +40,7 @@ class Config:
     def __post_init__(self) -> None:
         # workspace used to be Optional[str]
         # while we type it as class Workspace now, handle workspace=None and str for BC
-        if self.workspace is None:
+        if self.workspace is None or self.workspace == "":
             deprecation_msg = (
                 "Setting `workspace=None` is deprecated."
                 " Use `workspace=monarch.tools.config.workspace.Workspace(env=None)` instead."

--- a/python/monarch/tools/config/workspace.py
+++ b/python/monarch/tools/config/workspace.py
@@ -106,10 +106,16 @@ class Workspace:
             pass
         elif isinstance(dirs, list):
             for d in dirs:
+                assert (
+                    d
+                ), f"{d} must note be empty as this may have unintended consequences"
                 d = Path(d)
                 self.dirs[d] = d.name
         else:  # dict
             for src, dst in dirs.items():
+                assert (
+                    src
+                ), f"{src} must note be empty as this may have unintended consequences"
                 self.dirs[Path(src)] = dst
 
     def __eq__(self, other: object) -> bool:


### PR DESCRIPTION
Summary:
In the current state, we recommend users set 'Workspace(dirs=[''])' which hangs (likely from trying to crawl my home directory or some other nonesense).

This diff:
-- updates deprecation warning
-- Fixes for workspace_dir = "" + asserts

Reviewed By: vidhyav, amirafzali

Differential Revision: D82573182


