### PR TITLE
: view: remove iterator from sliced

### DIFF
--- a/hyperactor_mesh/src/v1/actor_mesh.rs
+++ b/hyperactor_mesh/src/v1/actor_mesh.rs
@@ -92,10 +92,7 @@ impl<A: RemoteActor> view::Ranked for ActorMeshRef<A> {
         Some(proc_ref.attest(&self.name.clone()))
     }
 
-    // TODO: adjust this to include a compaction hint, rather than the nodes themselves,
-    // as the current interface forces refs like ActorRef, which does not materialize its
-    // ranks, to needlessly materialize.
-    fn sliced(&self, region: Region, _nodes: impl Iterator<Item = ActorRef<A>>) -> Self {
+    fn sliced(&self, region: Region) -> Self {
         Self {
             // This is safe because by the time `sliced` has been called, the subsetting
             // has been validated.

--- a/hyperactor_mesh/src/v1/host_mesh.rs
+++ b/hyperactor_mesh/src/v1/host_mesh.rs
@@ -78,8 +78,13 @@ impl view::Ranked for HostMeshRef {
         self.ranks.get(rank).cloned()
     }
 
-    fn sliced(&self, region: Region, nodes: impl Iterator<Item = HostRef>) -> Self {
-        Self::new(region, nodes.collect()).unwrap()
+    fn sliced(&self, region: Region) -> Self {
+        let ranks = self
+            .region()
+            .remap(&region)
+            .unwrap()
+            .map(|index| self.get(index).unwrap());
+        Self::new(region, ranks.collect()).unwrap()
     }
 }
 

--- a/hyperactor_mesh/src/v1/proc_mesh.rs
+++ b/hyperactor_mesh/src/v1/proc_mesh.rs
@@ -341,8 +341,13 @@ impl view::Ranked for ProcMeshRef {
         self.ranks.get(rank).cloned()
     }
 
-    fn sliced(&self, region: Region, nodes: impl Iterator<Item = ProcRef>) -> Self {
-        Self::new(self.name.clone(), region, Arc::new(nodes.collect())).unwrap()
+    fn sliced(&self, region: Region) -> Self {
+        let ranks = self
+            .region()
+            .remap(&region)
+            .unwrap()
+            .map(|index| self.get(index).unwrap());
+        Self::new(self.name.clone(), region, Arc::new(ranks.collect())).unwrap()
     }
 }
 

--- a/hyperactor_mesh/src/v1/value_mesh.rs
+++ b/hyperactor_mesh/src/v1/value_mesh.rs
@@ -88,9 +88,14 @@ impl<T: Clone + 'static> view::Ranked for ValueMesh<T> {
         self.ranks.get(rank).cloned()
     }
 
-    fn sliced(&self, region: Region, nodes: impl Iterator<Item = T>) -> Self {
+    fn sliced(&self, region: Region) -> Self {
         debug_assert!(region.is_subset(self.region()), "sliced: not a subset");
-        let ranks: Vec<T> = nodes.collect();
+        let ranks: Vec<T> = self
+            .region()
+            .remap(&region)
+            .unwrap()
+            .map(|index| self.get(index).unwrap())
+            .collect();
         debug_assert_eq!(
             region.num_ranks(),
             ranks.len(),


### PR DESCRIPTION
Summary:
simplify `Ranked::sliced()` to remove redundant iterator parameter

the current signature forces callers to materialize and pass item collections that implementations must recreate anyway. this inhibits upcoming changes where `get()` will return `&Self::Item` instead of owned values  and `RankedRef` will be eliminated.

the fix: `sliced()` takes only the region geometry and implementations handle their own item extraction.

Differential Revision: D82585400


