### PR TITLE
: view: RankedSliceable

### DIFF
--- a/hyperactor_mesh/src/v1/actor_mesh.rs
+++ b/hyperactor_mesh/src/v1/actor_mesh.rs
@@ -92,10 +92,7 @@ impl<A: RemoteActor> view::Ranked for ActorMeshRef<A> {
         Some(proc_ref.attest(&self.name.clone()))
     }
 
-    // TODO: adjust this to include a compaction hint, rather than the nodes themselves,
-    // as the current interface forces refs like ActorRef, which does not materialize its
-    // ranks, to needlessly materialize.
-    fn sliced(&self, region: Region, _nodes: impl Iterator<Item = ActorRef<A>>) -> Self {
+    fn sliced(&self, region: Region) -> Self {
         Self {
             // This is safe because by the time `sliced` has been called, the subsetting
             // has been validated.

--- a/hyperactor_mesh/src/v1/host_mesh.rs
+++ b/hyperactor_mesh/src/v1/host_mesh.rs
@@ -78,8 +78,13 @@ impl view::Ranked for HostMeshRef {
         self.ranks.get(rank).cloned()
     }
 
-    fn sliced(&self, region: Region, nodes: impl Iterator<Item = HostRef>) -> Self {
-        Self::new(region, nodes.collect()).unwrap()
+    fn sliced(&self, region: Region) -> Self {
+        let ranks = self
+            .region()
+            .remap(&region)
+            .unwrap()
+            .map(|index| self.get(index).unwrap());
+        Self::new(region, ranks.collect()).unwrap()
     }
 }
 

--- a/hyperactor_mesh/src/v1/host_mesh.rs
+++ b/hyperactor_mesh/src/v1/host_mesh.rs
@@ -13,6 +13,7 @@ use hyperactor::Named;
 use hyperactor::channel::ChannelAddr;
 use ndslice::Region;
 use ndslice::view;
+use ndslice::view::Ranked;
 use ndslice::view::RegionParseError;
 use serde::Deserialize;
 use serde::Serialize;
@@ -74,16 +75,18 @@ impl view::Ranked for HostMeshRef {
         &self.region
     }
 
-    fn get(&self, rank: usize) -> Option<HostRef> {
-        self.ranks.get(rank).cloned()
+    fn get(&self, rank: usize) -> Option<&Self::Item> {
+        self.ranks.get(rank)
     }
+}
 
+impl view::RankedSliceable for HostMeshRef {
     fn sliced(&self, region: Region) -> Self {
         let ranks = self
             .region()
             .remap(&region)
             .unwrap()
-            .map(|index| self.get(index).unwrap());
+            .map(|index| self.get(index).unwrap().clone());
         Self::new(region, ranks.collect()).unwrap()
     }
 }

--- a/hyperactor_mesh/src/v1/proc_mesh.rs
+++ b/hyperactor_mesh/src/v1/proc_mesh.rs
@@ -341,8 +341,13 @@ impl view::Ranked for ProcMeshRef {
         self.ranks.get(rank).cloned()
     }
 
-    fn sliced(&self, region: Region, nodes: impl Iterator<Item = ProcRef>) -> Self {
-        Self::new(self.name.clone(), region, Arc::new(nodes.collect())).unwrap()
+    fn sliced(&self, region: Region) -> Self {
+        let ranks = self
+            .region()
+            .remap(&region)
+            .unwrap()
+            .map(|index| self.get(index).unwrap());
+        Self::new(self.name.clone(), region, Arc::new(ranks.collect())).unwrap()
     }
 }
 

--- a/hyperactor_mesh/src/v1/value_mesh.rs
+++ b/hyperactor_mesh/src/v1/value_mesh.rs
@@ -88,9 +88,14 @@ impl<T: Clone + 'static> view::Ranked for ValueMesh<T> {
         self.ranks.get(rank).cloned()
     }
 
-    fn sliced(&self, region: Region, nodes: impl Iterator<Item = T>) -> Self {
+    fn sliced(&self, region: Region) -> Self {
         debug_assert!(region.is_subset(self.region()), "sliced: not a subset");
-        let ranks: Vec<T> = nodes.collect();
+        let ranks: Vec<T> = self
+            .region()
+            .remap(&region)
+            .unwrap()
+            .map(|index| self.get(index).unwrap())
+            .collect();
         debug_assert_eq!(
             region.num_ranks(),
             ranks.len(),

--- a/monarch_hyperactor/src/value_mesh.rs
+++ b/monarch_hyperactor/src/value_mesh.rs
@@ -70,7 +70,7 @@ impl PyValueMesh {
         // ValueMesh<T: Clone>: get() returns owned T; we clone the
         // Py<PyAny>. `unwrap` is safe because the bounds have been
         // checked.
-        let v: Py<PyAny> = self.inner.get(rank).unwrap();
+        let v: Py<PyAny> = self.inner.get(rank).unwrap().clone();
         Ok(v.into())
     }
 


### PR DESCRIPTION
Summary:
switch `Ranked` to reference-based API

- drop `Clone` bound from `Ranked::Item`, `get()` now returns `&Self::Item`
- add `RankedSliceable` for types that can materialize a new owned view
- drop` RankedRef` and `MapIntoRefExt`
- update `ValueMesh`, `ProcMeshRef`, `HostMeshRef`, `ActorMeshRef` accordingly
- fix call sites and tests to use `map_into`/`try_map_into` with `&Self::Item`

after this:
- `Ranked` is minimal (`region` + `get`)
- `RankedSliceable` covers slice construction
- `View` has a blanket impl for `RankedSliceable<Item: Clone>`
- `MapIntoExt` works for any`Ranked`

Differential Revision: D82599998


