### PR TITLE
Add a link to the rust docs for all the hyperactor macros

### DIFF
--- a/docs/source/books/hyperactor-book/src/macros/index.md
+++ b/docs/source/books/hyperactor-book/src/macros/index.md
@@ -11,6 +11,9 @@ These macros support a complete message-passing workflow: from defining message 
 - [`#[export]`](export.md) — make an actor remotely spawnable and routable by registering its type, handlers, and and optionally spawnable from outside the current runtime
 - [`#[forward]`](forward.md) — route messages to a user-defined handler trait implementation
 
+
+<a id="link-hyperactor_macros" href="https://meta-pytorch.org/monarch/rust-api/hyperactor_macros/index.html">**hyperactor_macros**</a><span id="desc-hyperactor_macros"> - See rust API link for all the macros including the ones above. </span>
+
 ## Macro Summary
 
 - **`#[derive(Handler)]`**


### PR DESCRIPTION
Summary: Looks like https://meta-pytorch.org/monarch/rust-api/hyperactor_macros/index.html has more of the macros. Lets try to link that page from within the mdbook for hyperactor-book(https://meta-pytorch.org/monarch/books/hyperactor-book/src/macros/index.html).

Differential Revision: D82634301


