### PR TITLE
Startup benchmark

### DIFF
--- a/python/benches/startup.py
+++ b/python/benches/startup.py
@@ -1,0 +1,17 @@
+import time
+
+begin = time.time()
+from monarch.actor import Actor, endpoint, this_host
+
+
+class Noop(Actor):
+    @endpoint
+    def run(self) -> None:
+        return None
+
+
+h = this_host().spawn_procs().spawn("actor", Noop)
+h.run.call_one().get()
+end = time.time()
+
+print(end - begin)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #1248

Round trip time for startup.

Goal is 2 seconds, current is 3.5 seconds on my devgpu.  We should be able to hit this goal by re-landing lazy torch import, but this benchmark emphasizes why we need to land import torch.

Differential Revision: [D82666750](https://our.internmc.facebook.com/intern/diff/D82666750/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D82666750/)!