### PR TITLE
Add supervision_events polling API to v1::ActorMeshRef

### DIFF
--- a/hyperactor/src/data.rs
+++ b/hyperactor/src/data.rs
@@ -184,6 +184,12 @@ impl<T: Named + 'static> Named for Vec<T> {
     }
 }
 
+impl<K: Named + 'static, V: Named + 'static> Named for HashMap<K, V> {
+    fn typename() -> &'static str {
+        intern_typename!(Self, "HashMap<{}, {}>", K, V)
+    }
+}
+
 impl<T: Named + 'static, E: Named + 'static> Named for Result<T, E> {
     fn typename() -> &'static str {
         intern_typename!(Self, "Result<{}, {}>", T, E)

--- a/hyperactor_mesh/src/alloc.rs
+++ b/hyperactor_mesh/src/alloc.rs
@@ -660,6 +660,7 @@ pub(crate) mod testing {
                 Some(supervison_port.bind()),
                 HashMap::new(),
                 config_handle.bind(),
+                false,
             )
             .await
             .unwrap();

--- a/hyperactor_mesh/src/proc_mesh.rs
+++ b/hyperactor_mesh/src/proc_mesh.rs
@@ -363,6 +363,7 @@ impl ProcMesh {
                     Some(supervision_port.bind()),
                     address_book.clone(),
                     config_handle.bind(),
+                    false,
                 )
                 .await?;
         }

--- a/hyperactor_mesh/src/v1/testactor.rs
+++ b/hyperactor_mesh/src/v1/testactor.rs
@@ -17,9 +17,11 @@ use hyperactor::ActorId;
 use hyperactor::Bind;
 use hyperactor::Context;
 use hyperactor::Handler;
+use hyperactor::Instance;
 use hyperactor::Named;
 use hyperactor::PortRef;
 use hyperactor::Unbind;
+use hyperactor::supervision::ActorSupervisionEvent;
 use serde::Deserialize;
 use serde::Serialize;
 
@@ -29,6 +31,7 @@ use serde::Serialize;
     spawn = true,
     handlers = [
         GetActorId { cast = true },
+        CauseSupervisionEvent { cast = true },
     ]
 )]
 pub struct TestActor;
@@ -36,6 +39,18 @@ pub struct TestActor;
 /// A message that returns the recipient actor's id.
 #[derive(Debug, Clone, Named, Bind, Unbind, Serialize, Deserialize)]
 pub struct GetActorId(#[binding(include)] pub PortRef<ActorId>);
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum SupervisionEventType {
+    Panic,
+    SigSEGV,
+    ProcessExit(i32),
+}
+
+/// A message that causes a supervision event. The one argument determines what
+/// kind of supervision event it'll be.
+#[derive(Debug, Clone, Named, Bind, Unbind, Serialize, Deserialize)]
+pub struct CauseSupervisionEvent(pub SupervisionEventType);
 
 #[async_trait]
 impl Handler<GetActorId> for TestActor {
@@ -45,6 +60,68 @@ impl Handler<GetActorId> for TestActor {
         GetActorId(reply): GetActorId,
     ) -> Result<(), anyhow::Error> {
         reply.send(cx, cx.self_id().clone())?;
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl Handler<CauseSupervisionEvent> for TestActor {
+    async fn handle(
+        &mut self,
+        _cx: &Context<Self>,
+        msg: CauseSupervisionEvent,
+    ) -> Result<(), anyhow::Error> {
+        match msg.0 {
+            SupervisionEventType::Panic => {
+                panic!("for testing");
+            }
+            SupervisionEventType::SigSEGV => {
+                // SAFETY: This is for testing code that explicitly causes a SIGSEGV.
+                unsafe { std::ptr::null_mut::<i32>().write(42) };
+            }
+            SupervisionEventType::ProcessExit(code) => {
+                std::process::exit(code);
+            }
+        }
+        Ok(())
+    }
+}
+
+/// A test actor that handles supervision events.
+/// It should be the parent of TestActor who can panic or cause a SIGSEGV.
+#[derive(Default, Debug)]
+#[hyperactor::export(
+    spawn = true,
+    handlers = [ActorSupervisionEvent],
+)]
+pub struct TestActorWithSupervisionHandling;
+
+#[async_trait]
+impl Actor for TestActorWithSupervisionHandling {
+    type Params = ();
+
+    async fn new(_params: Self::Params) -> Result<Self, hyperactor::anyhow::Error> {
+        Ok(Self {})
+    }
+
+    async fn handle_supervision_event(
+        &mut self,
+        _this: &Instance<Self>,
+        event: &ActorSupervisionEvent,
+    ) -> Result<bool, anyhow::Error> {
+        tracing::error!("supervision event: {:?}", event);
+        // Swallow the supervision error to avoid crashing the process.
+        Ok(true)
+    }
+}
+
+#[async_trait]
+impl Handler<ActorSupervisionEvent> for TestActorWithSupervisionHandling {
+    async fn handle(
+        &mut self,
+        _cx: &Context<Self>,
+        _msg: ActorSupervisionEvent,
+    ) -> Result<(), anyhow::Error> {
         Ok(())
     }
 }


### PR DESCRIPTION
Summary:
Part of https://github.com/meta-pytorch/monarch/issues/1209

Add a `supervision_events` API for v1::ProcMeshRef and v1::ActorMeshRef to get the
list of supervision events that have accumulated on the ProcMeshAgent.

This needs to be configured so that supervision events don't crash the proc, and instead
are buffered into the mesh agent.

Reviewed By: mariusae

Differential Revision: D82131957


