### PR TITLE
Use edition 2024 rust

### DIFF
--- a/controller/Cargo.toml
+++ b/controller/Cargo.toml
@@ -7,9 +7,13 @@ authors = ["Meta"]
 edition = "2021"
 license = "BSD-3-Clause"
 
+[lib]
+edition = "2024"
+
 [[bin]]
 name = "controller_bin"
 path = "src/main.rs"
+edition = "2024"
 
 [dependencies]
 anyhow = "1.0.98"

--- a/erased_lifetime/Cargo.toml
+++ b/erased_lifetime/Cargo.toml
@@ -8,3 +8,6 @@ edition = "2021"
 description = "dynamic, lifetime-erased refcell"
 repository = "https://github.com/meta-pytorch/monarch/"
 license = "BSD-3-Clause"
+
+[lib]
+edition = "2024"

--- a/hyperactor/Cargo.toml
+++ b/hyperactor/Cargo.toml
@@ -9,6 +9,9 @@ description = "a high-performance, scalable actor framework for cluster computin
 repository = "https://github.com/meta-pytorch/monarch/"
 license = "BSD-3-Clause"
 
+[lib]
+edition = "2024"
+
 [[bin]]
 name = "channel_benchmarks"
 path = "benches/main.rs"
@@ -16,18 +19,22 @@ path = "benches/main.rs"
 [[bin]]
 name = "hyperactor_example_channel"
 path = "example/channel.rs"
+edition = "2024"
 
 [[bin]]
 name = "hyperactor_example_derive"
 path = "example/derive.rs"
+edition = "2024"
 
 [[bin]]
 name = "hyperactor_example_stream"
 path = "example/stream.rs"
+edition = "2024"
 
 [[bin]]
 name = "hyperactor_host_test_bootstrap"
 path = "test/host_bootstrap.rs"
+edition = "2024"
 
 [dependencies]
 anyhow = "1.0.98"

--- a/hyperactor_macros/Cargo.toml
+++ b/hyperactor_macros/Cargo.toml
@@ -13,6 +13,7 @@ license = "BSD-3-Clause"
 test = false
 doctest = false
 proc-macro = true
+edition = "2024"
 
 [[test]]
 name = "hyperactor_macros_test"

--- a/hyperactor_mesh/Cargo.toml
+++ b/hyperactor_mesh/Cargo.toml
@@ -7,6 +7,9 @@ authors = ["Meta"]
 edition = "2021"
 license = "BSD-3-Clause"
 
+[lib]
+edition = "2024"
+
 [[bin]]
 name = "actor_mesh_benchmarks"
 path = "benches/main.rs"
@@ -14,22 +17,27 @@ path = "benches/main.rs"
 [[bin]]
 name = "hyperactor_mesh_test_bootstrap"
 path = "test/bootstrap.rs"
+edition = "2024"
 
 [[bin]]
 name = "hyperactor_mesh_test_remote_process_alloc"
 path = "test/remote_process_alloc.rs"
+edition = "2024"
 
 [[bin]]
 name = "hyperactor_mesh_test_remote_process_allocator"
 path = "test/remote_process_allocator.rs"
+edition = "2024"
 
 [[bin]]
 name = "process_allocator_test_bin"
 path = "test/process_allocator_cleanup/process_allocator_test_bin.rs"
+edition = "2024"
 
 [[bin]]
 name = "process_allocator_test_bootstrap"
 path = "test/process_allocator_cleanup/process_allocator_test_bootstrap.rs"
+edition = "2024"
 
 [[test]]
 name = "process_allocator_cleanup"

--- a/hyperactor_mesh_macros/Cargo.toml
+++ b/hyperactor_mesh_macros/Cargo.toml
@@ -11,6 +11,7 @@ license = "BSD-3-Clause"
 test = false
 doctest = false
 proc-macro = true
+edition = "2024"
 
 [dependencies]
 ndslice = { version = "0.0.0", path = "../ndslice" }

--- a/hyperactor_multiprocess/Cargo.toml
+++ b/hyperactor_multiprocess/Cargo.toml
@@ -7,6 +7,9 @@ authors = ["Meta"]
 edition = "2021"
 license = "BSD-3-Clause"
 
+[lib]
+edition = "2024"
+
 [dependencies]
 anyhow = "1.0.98"
 async-trait = "0.1.86"

--- a/hyperactor_telemetry/Cargo.toml
+++ b/hyperactor_telemetry/Cargo.toml
@@ -7,6 +7,9 @@ authors = ["Meta"]
 edition = "2021"
 license = "BSD-3-Clause"
 
+[lib]
+edition = "2024"
+
 [dependencies]
 anyhow = "1.0.98"
 chrono = { version = "0.4.41", features = ["clock", "serde", "std"], default-features = false }

--- a/hyperactor_telemetry/tester/Cargo.toml
+++ b/hyperactor_telemetry/tester/Cargo.toml
@@ -10,6 +10,7 @@ license = "BSD-3-Clause"
 [[bin]]
 name = "tester"
 path = "main.rs"
+edition = "2024"
 
 [dependencies]
 hyperactor_telemetry = { version = "0.0.0", path = ".." }

--- a/monarch_conda/Cargo.toml
+++ b/monarch_conda/Cargo.toml
@@ -7,9 +7,13 @@ authors = ["Meta"]
 edition = "2021"
 license = "BSD-3-Clause"
 
+[lib]
+edition = "2024"
+
 [[bin]]
 name = "conda_sync_cli"
 path = "src/main.rs"
+edition = "2024"
 
 [dependencies]
 aho-corasick = "1.1.3"

--- a/monarch_hyperactor/Cargo.toml
+++ b/monarch_hyperactor/Cargo.toml
@@ -7,6 +7,10 @@ authors = ["Meta"]
 edition = "2021"
 license = "BSD-3-Clause"
 
+[[bin]]
+name = "process_allocator"
+edition = "2024"
+
 [[test]]
 name = "test_monarch_hyperactor"
 path = "tests/lib.rs"

--- a/monarch_perfetto_trace/Cargo.toml
+++ b/monarch_perfetto_trace/Cargo.toml
@@ -7,6 +7,9 @@ authors = ["Meta"]
 edition = "2021"
 license = "BSD-3-Clause"
 
+[lib]
+edition = "2024"
+
 [dependencies]
 serde = { version = "1.0.219", features = ["derive", "rc"] }
 serde_json = { version = "1.0.140", features = ["alloc", "float_roundtrip", "raw_value", "unbounded_depth"] }

--- a/monarch_rdma/Cargo.toml
+++ b/monarch_rdma/Cargo.toml
@@ -7,6 +7,9 @@ authors = ["Meta"]
 edition = "2021"
 license = "BSD-3-Clause"
 
+[lib]
+edition = "2024"
+
 [dependencies]
 anyhow = "1.0.98"
 async-trait = "0.1.86"

--- a/monarch_rdma/examples/cuda_ping_pong/Cargo.toml
+++ b/monarch_rdma/examples/cuda_ping_pong/Cargo.toml
@@ -11,16 +11,19 @@ license = "BSD-3-Clause"
 path = "cuda_ping_pong.rs"
 test = false
 doctest = false
+edition = "2024"
 
 [[bin]]
 name = "cuda_ping_pong_bootstrap"
 path = "bootstrap.rs"
 test = false
+edition = "2024"
 
 [[bin]]
 name = "cuda_ping_pong_example"
 path = "main.rs"
 test = false
+edition = "2024"
 
 [dependencies]
 anyhow = "1.0.98"

--- a/monarch_rdma/examples/parameter_server/Cargo.toml
+++ b/monarch_rdma/examples/parameter_server/Cargo.toml
@@ -9,16 +9,19 @@ license = "BSD-3-Clause"
 
 [lib]
 path = "parameter_server.rs"
+edition = "2024"
 
 [[bin]]
 name = "parameter_server_bootstrap"
 path = "bootstrap.rs"
 test = false
+edition = "2024"
 
 [[bin]]
 name = "parameter_server_example"
 path = "main.rs"
 test = false
+edition = "2024"
 
 [dependencies]
 anyhow = "1.0.98"

--- a/monarch_rdma/extension/Cargo.toml
+++ b/monarch_rdma/extension/Cargo.toml
@@ -11,6 +11,7 @@ license = "BSD-3-Clause"
 path = "lib.rs"
 test = false
 doctest = false
+edition = "2024"
 
 [dependencies]
 hyperactor = { version = "0.0.0", path = "../../hyperactor" }

--- a/monarch_simulator/Cargo.toml
+++ b/monarch_simulator/Cargo.toml
@@ -7,6 +7,9 @@ authors = ["Meta"]
 edition = "2021"
 license = "BSD-3-Clause"
 
+[lib]
+edition = "2024"
+
 [dependencies]
 anyhow = "1.0.98"
 async-trait = "0.1.86"

--- a/ndslice/Cargo.toml
+++ b/ndslice/Cargo.toml
@@ -9,6 +9,9 @@ description = "data structures to support n-d arrays of ranks"
 repository = "https://github.com/meta-pytorch/monarch/"
 license = "BSD-3-Clause"
 
+[lib]
+edition = "2024"
+
 [dependencies]
 anyhow = "1.0.98"
 enum-as-inner = "0.6.0"

--- a/preempt_rwlock/Cargo.toml
+++ b/preempt_rwlock/Cargo.toml
@@ -7,6 +7,9 @@ authors = ["Meta"]
 edition = "2021"
 license = "BSD-3-Clause"
 
+[lib]
+edition = "2024"
+
 [dependencies]
 tokio = { version = "1.47.1", features = ["full", "test-util", "tracing"] }
 

--- a/serde_multipart/Cargo.toml
+++ b/serde_multipart/Cargo.toml
@@ -9,6 +9,9 @@ description = "multipart encoding for serde"
 repository = "https://github.com/meta-pytorch/monarch/"
 license = "BSD-3-Clause"
 
+[lib]
+edition = "2024"
+
 [dependencies]
 bincode = "1.3.3"
 bytes = { version = "1.10", features = ["serde"] }

--- a/timed_test/Cargo.toml
+++ b/timed_test/Cargo.toml
@@ -11,6 +11,7 @@ license = "BSD-3-Clause"
 test = false
 doctest = false
 proc-macro = true
+edition = "2024"
 
 [[test]]
 name = "timed_test_test"


### PR DESCRIPTION
Summary: Use edition 2024 rust for monarch

Differential Revision: D82724601


