### PR TITLE
Endpoint call latency measurements

### DIFF
--- a/monarch_hyperactor/src/telemetry.rs
+++ b/monarch_hyperactor/src/telemetry.rs
@@ -136,8 +136,19 @@ impl PyHistogram {
         }
     }
 
-    fn record(&mut self, value: f64) {
-        self.inner.record(value, &[]);
+    fn record(
+        &mut self,
+        value: f64,
+        attributes: Option<std::collections::HashMap<String, String>>,
+    ) {
+        let kv_attributes: Vec<opentelemetry::KeyValue> = match attributes {
+            Some(attrs) => attrs
+                .into_iter()
+                .map(|(k, v)| opentelemetry::KeyValue::new(k, v))
+                .collect(),
+            None => vec![],
+        };
+        self.inner.record(value, &kv_attributes);
     }
 }
 

--- a/python/monarch/_rust_bindings/monarch_hyperactor/telemetry.pyi
+++ b/python/monarch/_rust_bindings/monarch_hyperactor/telemetry.pyi
@@ -119,12 +119,13 @@ class PyHistogram:
         """
         ...
 
-    def record(self, value: float) -> None:
+    def record(self, value: float, *, attributes: dict[str, str] | None = None) -> None:
         """
         Record a value in the histogram.
 
         Args:
         - value (float): The value to record in the histogram.
+        - attributes (dict[str, str] | None): Optional attributes to associate with the measurement.
         """
         ...
 

--- a/python/monarch/_src/actor/telemetry/__init__.py
+++ b/python/monarch/_src/actor/telemetry/__init__.py
@@ -76,7 +76,10 @@ class Histogram(metrics.Histogram):
         attributes: Optional[Attributes] = None,
         context: Optional[Context] = None,
     ) -> None:
-        self.inner.record(amount)
+        rust_attributes = None
+        if attributes:
+            rust_attributes = {str(k): str(v) for k, v in attributes.items()}
+        self.inner.record(amount, attributes=rust_attributes)
 
 
 class Meter(metrics.Meter):


### PR DESCRIPTION
Summary:
Instrumenting the endpoint calls. This gives us latency measurements, along with the number of actors and name of the method. 

Also fixing the python histogram record method to account for attributes.

Differential Revision: D82492042


