### PR TITLE
Add casting support to resource::GetState messages

### DIFF
--- a/hyperactor_mesh/src/proc_mesh/mesh_agent.rs
+++ b/hyperactor_mesh/src/proc_mesh/mesh_agent.rs
@@ -20,6 +20,7 @@ use enum_as_inner::EnumAsInner;
 use hyperactor::Actor;
 use hyperactor::ActorHandle;
 use hyperactor::ActorId;
+use hyperactor::Bind;
 use hyperactor::Context;
 use hyperactor::Data;
 use hyperactor::HandleClient;
@@ -31,6 +32,7 @@ use hyperactor::PortHandle;
 use hyperactor::PortRef;
 use hyperactor::ProcId;
 use hyperactor::RefClient;
+use hyperactor::Unbind;
 use hyperactor::actor::ActorStatus;
 use hyperactor::actor::remote::Remote;
 use hyperactor::channel;
@@ -167,7 +169,7 @@ impl State {
     handlers=[
         MeshAgentMessage,
         resource::CreateOrUpdate<ActorSpec>,
-        resource::GetState<ActorState>
+        resource::GetState<ActorState> { cast = true },
     ]
 )]
 pub struct ProcMeshAgent {
@@ -425,7 +427,7 @@ pub struct ActorSpec {
 }
 
 /// Actor state.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Named)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Named, Bind, Unbind)]
 pub struct ActorState {
     /// The actor's ID.
     pub actor_id: ActorId,

--- a/hyperactor_mesh/src/resource.rs
+++ b/hyperactor_mesh/src/resource.rs
@@ -16,6 +16,10 @@ use hyperactor::Handler;
 use hyperactor::Named;
 use hyperactor::PortRef;
 use hyperactor::RefClient;
+use hyperactor::RemoteMessage;
+use hyperactor::message::Bind;
+use hyperactor::message::Bindings;
+use hyperactor::message::Unbind;
 use serde::Deserialize;
 use serde::Serialize;
 
@@ -69,4 +73,37 @@ pub struct GetState<S> {
     /// A reply containing the state.
     #[reply]
     pub reply: PortRef<State<S>>,
+}
+
+// Cannot derive Bind and Unbind for this generic, implement manually.
+impl<S> Unbind for GetState<S>
+where
+    S: RemoteMessage,
+    S: Unbind,
+{
+    fn unbind(&self, bindings: &mut Bindings) -> anyhow::Result<()> {
+        self.reply.unbind(bindings)
+    }
+}
+
+impl<S> Bind for GetState<S>
+where
+    S: RemoteMessage,
+    S: Bind,
+{
+    fn bind(&mut self, bindings: &mut Bindings) -> anyhow::Result<()> {
+        self.reply.bind(bindings)
+    }
+}
+
+impl<S> Clone for GetState<S>
+where
+    S: RemoteMessage,
+{
+    fn clone(&self) -> Self {
+        Self {
+            name: self.name.clone(),
+            reply: self.reply.clone(),
+        }
+    }
 }


### PR DESCRIPTION
Summary:
Part of: https://github.com/meta-pytorch/monarch/issues/1209

Use casting to implement the `supervision_events` API instead of iterating over all
ProcMeshAgents. This will scale better as the size of the ProcMesh increases.
This requires making some trait bound changes to `resource::GetState` so that it can be casted with.

Unfortunately, the Actor name for the mesh agent is not compatible with the v1::Name struct
due to the missing uuid. Make `v1::Name` an enum to allow reserved names to be used for
things like ActorMeshes.

Also, minor improvement: make ActorMeshRef::supervision_events not take a Name, we can assume
it is for the current mesh's name.

Differential Revision: D82687236


