### PR TITLE
Adding Actor Id to Exceptions in Monarch Tracing Scuba

### DIFF
--- a/python/monarch/_src/actor/actor_mesh.py
+++ b/python/monarch/_src/actor/actor_mesh.py
@@ -91,7 +91,7 @@ from monarch._src.actor.pickle import flatten, unflatten
 from monarch._src.actor.python_extension_methods import rust_struct
 from monarch._src.actor.shape import MeshTrait, NDSlice
 from monarch._src.actor.sync_state import fake_sync_state
-from monarch._src.actor.telemetry import METER
+from monarch._src.actor.telemetry import METER, TracingForwarder
 from monarch._src.actor.tensor_engine_shim import actor_rref, actor_send
 from typing_extensions import Self
 
@@ -105,6 +105,7 @@ from monarch._src.actor.telemetry import get_monarch_tracer
 CallMethod = PythonMessageKind.CallMethod
 
 logger: logging.Logger = logging.getLogger(__name__)
+logging.root.addHandler(TracingForwarder(level=logging.DEBUG))
 
 TRACER = get_monarch_tracer()
 

--- a/python/monarch/_src/actor/telemetry/__init__.py
+++ b/python/monarch/_src/actor/telemetry/__init__.py
@@ -28,6 +28,19 @@ from opentelemetry.util.types import Attributes
 
 class TracingForwarder(logging.Handler):
     def emit(self, record: logging.LogRecord) -> None:
+        # Try to add actor_id from the current context to the logging record
+        try:
+            from monarch._src.actor.actor_mesh import context
+
+            ctx = context()
+            if ctx and ctx.actor_instance and ctx.actor_instance.actor_id:
+                # Add actor_id as an attribute to the logging record
+                setattr(record, "actor_id", str(ctx.actor_instance.actor_id))
+        except Exception:
+            # If we can't get the context or actor_id for any reason, just continue
+            # without adding the actor_id field
+            pass
+
         forward_to_tracing(record)
 
 


### PR DESCRIPTION
Summary:
The Actor Id column used to be null for Exceptions:
{F1982094709}
https://fburl.com/scuba/monarch_tracing/13hx70aj

Actor Id would show up for spans:
{F1982094744}
https://fburl.com/scuba/monarch_tracing/s2f6glbu

This change allows Exceptions to have Actor Id column populated as well:
{F1982094856}
https://fburl.com/scuba/monarch_tracing/757k16xp

Differential Revision: D82748854


