### PR TITLE
: bootstrap: child registry + kill_on_drop

### DIFF
--- a/hyperactor/src/channel.rs
+++ b/hyperactor/src/channel.rs
@@ -256,7 +256,7 @@ pub enum TlsMode {
 }
 
 /// Types of channel transports.
-#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize, Named)]
 pub enum ChannelTransport {
     /// Transport over a TCP connection.
     Tcp,

--- a/hyperactor_mesh/Cargo.toml
+++ b/hyperactor_mesh/Cargo.toml
@@ -83,6 +83,7 @@ tracing-subscriber = { version = "0.3.20", features = ["chrono", "env-filter", "
 
 [dev-dependencies]
 bytes = { version = "1.10", features = ["serde"] }
+itertools = "0.14.0"
 maplit = "1.0"
 proptest = "1.5"
 timed_test = { version = "0.0.0", path = "../timed_test" }

--- a/hyperactor_mesh/src/bootstrap.rs
+++ b/hyperactor_mesh/src/bootstrap.rs
@@ -8,6 +8,7 @@
 
 use std::env::VarError;
 use std::future;
+use std::io;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -155,6 +156,7 @@ impl BootstrapMode {
 }
 
 /// A proc manager that launches procs using the [`bootstrap`] function as an entry point.
+#[derive(Debug)]
 pub struct BootstrapProcManager {
     program: std::path::PathBuf,
 }
@@ -163,6 +165,10 @@ impl BootstrapProcManager {
     #[allow(dead_code)]
     pub(crate) fn new(program: std::path::PathBuf) -> Self {
         Self { program }
+    }
+
+    pub(crate) fn new_current_exe() -> io::Result<Self> {
+        Ok(Self::new(std::env::current_exe()?))
     }
 
     #[cfg(test)]
@@ -178,6 +184,7 @@ impl ProcManager for BootstrapProcManager {
     fn transport(&self) -> ChannelTransport {
         ChannelTransport::Unix
     }
+
     async fn spawn(
         &self,
         proc_id: ProcId,

--- a/hyperactor_mesh/src/v1.rs
+++ b/hyperactor_mesh/src/v1.rs
@@ -80,6 +80,9 @@ pub enum Error {
 
     #[error("error while casting message to {0}: {1}")]
     CastingError(Name, anyhow::Error),
+
+    #[error("error configuring host mesh agent {0}: {1}")]
+    HostMeshAgentConfigurationError(ActorId, String),
 }
 
 /// Errors that occur during serialization and deserialization.

--- a/hyperactor_mesh/src/v1/host_mesh.rs
+++ b/hyperactor_mesh/src/v1/host_mesh.rs
@@ -11,8 +11,12 @@ pub mod mesh_agent;
 use std::str::FromStr;
 use std::sync::Arc;
 
+use hyperactor::ActorRef;
 use hyperactor::Named;
+use hyperactor::ProcId;
 use hyperactor::channel::ChannelAddr;
+use hyperactor::context;
+use ndslice::Extent;
 use ndslice::Region;
 use ndslice::view;
 use ndslice::view::Ranked;
@@ -20,11 +24,36 @@ use ndslice::view::RegionParseError;
 use serde::Deserialize;
 use serde::Serialize;
 
+use crate::alloc::Alloc;
+use crate::resource::CreateOrUpdateClient;
 use crate::v1;
+use crate::v1::Name;
+use crate::v1::ProcMesh;
+use crate::v1::ProcMeshRef;
+use crate::v1::host_mesh::mesh_agent::HostMeshAgent;
+use crate::v1::host_mesh::mesh_agent::HostMeshAgentProcMeshTrampoline;
+use crate::v1::proc_mesh::ProcRef;
 
 /// A reference to a single host.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Named, Serialize, Deserialize)]
 pub struct HostRef(ChannelAddr);
+
+impl HostRef {
+    /// The host mesh agent associated with this host.
+    fn mesh_agent(&self) -> ActorRef<HostMeshAgent> {
+        ActorRef::attest(self.service_proc().actor_id("agent", 0))
+    }
+
+    /// The ProcId for the proc with name `name` on this host.
+    fn named_proc(&self, name: &Name) -> ProcId {
+        ProcId::Direct(self.0.clone(), name.to_string())
+    }
+
+    /// The service proc on this host.
+    fn service_proc(&self) -> ProcId {
+        ProcId::Direct(self.0.clone(), "service".to_string())
+    }
+}
 
 impl std::fmt::Display for HostRef {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -37,6 +66,129 @@ impl FromStr for HostRef {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         Ok(HostRef(ChannelAddr::from_str(s)?))
+    }
+}
+
+/// An owned mesh of hosts.
+pub struct HostMesh {
+    name: Name,
+    extent: Extent,
+    allocation: HostMeshAllocation,
+}
+
+enum HostMeshAllocation {
+    /// The host mesh was bootstrapped from a proc mesh.
+    /// This is to support providing host meshes through Allocs.
+    ProcMesh {
+        proc_mesh: ProcMesh,
+        proc_mesh_ref: ProcMeshRef,
+        hosts: Vec<HostRef>,
+    },
+}
+
+impl HostMesh {
+    /// Allocate a host mesh from an [`Alloc`]. This creates a HostMesh with the same extent
+    /// as the provided alloc. Allocs generate procs, and thus we define and run a Host for each
+    /// proc allocated by it.
+    ///
+    /// ## Allocation strategy
+    ///
+    /// Because HostMeshes use direct-addressed procs, and must fully control the procs they are
+    /// managing, `HostMesh::allocate` uses a trampoline actor to launch the host, which in turn
+    /// runs a [`crate::v1::host_mesh::mesh_agent::HostMeshAgent`] actor to manage the host itself.
+    /// The host (and thus all of its procs) are exposed directly through a separate listening
+    /// channel, established by the host.
+    ///
+    /// ```text
+    ///                        ┌ ─ ─┌────────────────────┐                   
+    ///                             │allocated Proc:     │                   
+    ///                        │    │ ┌─────────────────┐│                   
+    ///                             │ │TrampolineActor  ││                   
+    ///                        │    │ │ ┌──────────────┐││                   
+    ///                             │ │ │Host          │││                   
+    ///               ┌────┬ ─ ┘    │ │ │ ┌──────────┐ │││                   
+    ///            ┌─▶│Proc│        │ │ │ │HostAgent │ │││                   
+    ///            │  └────┴ ─ ┐    │ │ │ └──────────┘ │││                   
+    ///            │  ┌────┐        │ │ │             ██████                 
+    /// ┌────────┐ ├─▶│Proc│   │    │ │ └──────────────┘││ ▲                 
+    /// │ Client │─┤  └────┘        │ └─────────────────┘│ listening channel
+    /// └────────┘ │  ┌────┐   └ ─ ─└────────────────────┘                   
+    ///            ├─▶│Proc│                                                 
+    ///            │  └────┘                                                 
+    ///            │  ┌────┐                                                 
+    ///            └─▶│Proc│                                                 
+    ///               └────┘                                                 
+    ///                 ▲                                                    
+    ///                                                                     
+    ///          `Alloc`-provided                                            
+    ///                procs               
+    /// ```                                  
+    pub async fn allocate(
+        cx: &impl context::Actor,
+        alloc: impl Alloc + Send + Sync + 'static,
+        name: &str,
+    ) -> v1::Result<Self> {
+        let transport = alloc.transport();
+        let extent = alloc.extent().clone();
+        let proc_mesh = ProcMesh::allocate(cx, alloc, name).await?;
+        let proc_mesh_ref = proc_mesh.freeze();
+        let name = Name::new(name);
+
+        // TODO: figure out how to deal with MAST allocs. It requires an extra dimension,
+        // into which it launches multiple procs, so we need to always specify an additional
+        // sub-host dimension of size 1.
+
+        let (mesh_agents, mut mesh_agents_rx) = cx.mailbox().open_port();
+        let _trampoline_actor_mesh = proc_mesh_ref
+            .spawn::<HostMeshAgentProcMeshTrampoline>(
+                cx,
+                "host_mesh_trampoline",
+                &(transport, mesh_agents.bind()),
+            )
+            .await?;
+
+        // TODO: don't re-rank the hosts
+        let mut hosts = Vec::new();
+        for _rank in 0..extent.num_ranks() {
+            let mesh_agent = mesh_agents_rx.recv().await?;
+
+            let Some((addr, _)) = mesh_agent.actor_id().proc_id().as_direct() else {
+                return Err(v1::Error::HostMeshAgentConfigurationError(
+                    mesh_agent.actor_id().clone(),
+                    "host mesh agent must be a direct actor".to_string(),
+                ));
+            };
+
+            let host_ref = HostRef(addr.clone());
+            if host_ref.mesh_agent() != mesh_agent {
+                return Err(v1::Error::HostMeshAgentConfigurationError(
+                    mesh_agent.actor_id().clone(),
+                    format!(
+                        "expected mesh agent actor id to be {}",
+                        host_ref.mesh_agent().actor_id()
+                    ),
+                ));
+            }
+            hosts.push(host_ref);
+        }
+
+        Ok(Self {
+            name,
+            extent,
+            allocation: HostMeshAllocation::ProcMesh {
+                proc_mesh,
+                proc_mesh_ref,
+                hosts,
+            },
+        })
+    }
+
+    pub fn freeze(&self) -> HostMeshRef {
+        match &self.allocation {
+            HostMeshAllocation::ProcMesh { hosts, .. } => {
+                HostMeshRef::new(self.extent.clone().into(), hosts.clone()).unwrap()
+            }
+        }
     }
 }
 
@@ -67,6 +219,33 @@ impl HostMeshRef {
             region,
             ranks: Arc::new(ranks),
         })
+    }
+
+    /// Spawn a ProcMesh onto this host mesh.
+    // TODO: add an "additional dims" API
+    pub async fn spawn(&self, cx: &impl context::Actor, name: &str) -> v1::Result<ProcMesh> {
+        let name = Name::new(name);
+        let mut procs = Vec::new();
+        for (rank, host) in self.ranks.iter().enumerate() {
+            let ok = host
+                .mesh_agent()
+                .create_or_update(cx, name.clone(), ())
+                .await
+                .map_err(|e| {
+                    v1::Error::HostMeshAgentConfigurationError(
+                        host.mesh_agent().actor_id().clone(),
+                        format!("failed while creating proc: {}", e),
+                    )
+                })?;
+            procs.push(ProcRef::new(
+                host.named_proc(&name),
+                rank,
+                // TODO: specify or retrieve from state instead, to avoid attestation.
+                ActorRef::attest(host.named_proc(&name).actor_id("agent", 0)),
+            ));
+        }
+
+        ProcMesh::create_owned_unchecked(cx, name, self.clone(), procs).await
     }
 }
 
@@ -146,10 +325,23 @@ impl FromStr for HostMeshRef {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashSet;
+    use std::collections::VecDeque;
+
+    use hyperactor::PortRef;
+    use hyperactor::context::Mailbox as _;
+    use itertools::Itertools;
     use ndslice::ViewExt;
     use ndslice::extent;
+    use tokio::process::Command;
 
     use super::*;
+    use crate::alloc::AllocSpec;
+    use crate::alloc::Allocator;
+    use crate::alloc::ProcessAllocator;
+    use crate::v1::ActorMeshRef;
+    use crate::v1::testactor;
+    use crate::v1::testing;
 
     #[test]
     fn test_host_mesh_subset() {
@@ -179,5 +371,92 @@ mod tests {
             host_mesh_ref.to_string().parse::<HostMeshRef>().unwrap(),
             host_mesh_ref
         );
+    }
+
+    #[tokio::test]
+    async fn test_allocate() {
+        // This only works with the process allocator since we assume a working
+        // bootstrap binary.
+        //
+        // TODO: have multiple trampoline modes (self_exe, etc.)
+
+        let instance = testing::instance().await;
+
+        let mut allocator = ProcessAllocator::new(Command::new(
+            buck_resources::get("monarch/hyperactor_mesh/bootstrap").unwrap(),
+        ));
+        let alloc = allocator
+            .allocate(AllocSpec {
+                extent: extent!(replicas = 4),
+                constraints: Default::default(),
+                proc_name: None,
+            })
+            .await
+            .unwrap();
+
+        let host_mesh = HostMesh::allocate(&instance, alloc, "test").await.unwrap();
+        let proc_mesh1 = host_mesh.freeze().spawn(&instance, "test_1").await.unwrap();
+        let actor_mesh1: ActorMeshRef<testactor::TestActor> = proc_mesh1
+            .freeze()
+            .spawn(&instance, "test", &())
+            .await
+            .unwrap()
+            .freeze();
+        let proc_mesh2 = host_mesh.freeze().spawn(&instance, "test_2").await.unwrap();
+        let actor_mesh2: ActorMeshRef<testactor::TestActor> = proc_mesh2
+            .freeze()
+            .spawn(&instance, "test", &())
+            .await
+            .unwrap()
+            .freeze();
+
+        // Validate we can cast:
+
+        let (port, mut rx) = instance.mailbox().open_port();
+        actor_mesh1
+            .cast(&instance, testactor::GetActorId(port.bind()))
+            .unwrap();
+
+        let mut expected_actor_ids: HashSet<_> = actor_mesh1
+            .values()
+            .map(|actor_ref| actor_ref.actor_id().clone())
+            .collect();
+
+        while !expected_actor_ids.is_empty() {
+            let actor_id = rx.recv().await.unwrap();
+            assert!(
+                expected_actor_ids.remove(&actor_id),
+                "got {actor_id}, expect {expected_actor_ids:?}"
+            );
+        }
+
+        // Now forward a message through all directed edges across the two meshes.
+        // This tests the full connectivity of all the hosts, procs, and actors
+        // involved in these two meshes.
+        let mut to_visit: VecDeque<_> = actor_mesh1
+            .values()
+            .chain(actor_mesh2.values())
+            .map(|actor_ref| actor_ref.port())
+            // Each ordered pair of ports
+            .permutations(2)
+            // Flatten them to create a path:
+            .flatten()
+            .collect();
+
+        let expect_visited: Vec<_> = to_visit.clone().into();
+
+        // We are going to send to the first, and then set up a port to receive the last.
+        let (last, mut last_rx) = instance.mailbox().open_port();
+        to_visit.push_back(last.bind());
+
+        let forward = testactor::Forward {
+            to_visit,
+            visited: Vec::new(),
+        };
+        let first = forward.to_visit.front().unwrap().clone();
+        first.send(&instance, forward).unwrap();
+
+        let forward = last_rx.recv().await.unwrap();
+        assert_eq!(forward.visited, expect_visited);
     }
 }

--- a/hyperactor_mesh/src/v1/testactor.rs
+++ b/hyperactor_mesh/src/v1/testactor.rs
@@ -11,6 +11,8 @@
 //! the bootstrap binary, which is not built in test mode (and anyway, test mode
 //! does not work across crate boundaries)
 
+use std::collections::VecDeque;
+
 use async_trait::async_trait;
 use hyperactor::Actor;
 use hyperactor::ActorId;
@@ -32,6 +34,7 @@ use serde::Serialize;
     handlers = [
         GetActorId { cast = true },
         CauseSupervisionEvent { cast = true },
+        Forward,
     ]
 )]
 pub struct TestActor;
@@ -122,6 +125,36 @@ impl Handler<ActorSupervisionEvent> for TestActorWithSupervisionHandling {
         _cx: &Context<Self>,
         _msg: ActorSupervisionEvent,
     ) -> Result<(), anyhow::Error> {
+        Ok(())
+    }
+}
+
+/// A message to forward to a visit list of ports.
+/// Each port removes the next entry, and adds it to the
+/// 'visited' list.
+#[derive(Debug, Clone, Named, Bind, Unbind, Serialize, Deserialize)]
+pub struct Forward {
+    pub to_visit: VecDeque<PortRef<Forward>>,
+    pub visited: Vec<PortRef<Forward>>,
+}
+
+#[async_trait]
+impl Handler<Forward> for TestActor {
+    async fn handle(
+        &mut self,
+        cx: &Context<Self>,
+        Forward {
+            mut to_visit,
+            mut visited,
+        }: Forward,
+    ) -> Result<(), anyhow::Error> {
+        let Some(this) = to_visit.pop_front() else {
+            anyhow::bail!("unexpected forward chain termination");
+        };
+        visited.push(this);
+        let next = to_visit.front().cloned();
+        anyhow::ensure!(next.is_some(), "unexpected forward chain termination");
+        next.unwrap().send(cx, Forward { to_visit, visited })?;
         Ok(())
     }
 }

--- a/hyperactor_mesh/src/v1/testing.rs
+++ b/hyperactor_mesh/src/v1/testing.rs
@@ -12,6 +12,7 @@
 
 use hyperactor::Instance;
 use hyperactor::Proc;
+use hyperactor::channel::ChannelTransport;
 use hyperactor::context;
 use hyperactor::id;
 use hyperactor::mailbox::BoxableMailboxSender;
@@ -25,8 +26,10 @@ use crate::alloc::LocalAllocator;
 use crate::alloc::ProcessAllocator;
 use crate::v1::ProcMesh;
 
-pub fn instance() -> Instance<()> {
-    let proc = Proc::new(id!(test[0]), DialMailboxRouter::new().boxed());
+pub async fn instance() -> Instance<()> {
+    let proc = Proc::direct(ChannelTransport::Unix.any(), "testproc".to_string())
+        .await
+        .unwrap();
     let (actor, _handle) = proc.instance("testclient").unwrap();
     actor
 }


### PR DESCRIPTION
Summary: this wires `BootstrapProcManager `up to retain child process handles and drain stdout/stderr so processes don’t block on full pipes. output is sent into tracing for now; we’ll come back to structured log forwarding (like v0) in a later diff. a simple test confirms that dropping the manager tears down its children correctly (`kill_on_drop(true)`), with a /proc check on linux. this gives us safe baseline lifecycle management, with graceful shutdown and other improvements to follow.

Differential Revision: D82753182


