### PR TITLE
[monarch][hyperactor] pyo3 integration for v1 proc/actor mesh implementations

### DIFF
--- a/hyperactor/src/proc.rs
+++ b/hyperactor/src/proc.rs
@@ -333,6 +333,22 @@ impl Proc {
         Ok(proc)
     }
 
+    /// Create a new direct-addressed proc with a default sender for the forwarder.
+    pub async fn direct_with_default(
+        addr: ChannelAddr,
+        name: String,
+        default: BoxedMailboxSender,
+    ) -> Result<Self, ChannelError> {
+        let (addr, rx) = channel::serve(addr).await?;
+        let proc_id = ProcId::Direct(addr, name);
+        let proc = Self::new(
+            proc_id,
+            DialMailboxRouter::new_with_default(default).into_boxed(),
+        );
+        proc.clone().serve(rx);
+        Ok(proc)
+    }
+
     /// Create a new proc with the given proc id, forwarder and clock kind.
     pub fn new_with_clock(
         proc_id: ProcId,

--- a/hyperactor_mesh/src/v1/actor_mesh.rs
+++ b/hyperactor_mesh/src/v1/actor_mesh.rs
@@ -23,12 +23,13 @@ use hyperactor::message::IndexedErasedUnbound;
 use hyperactor::supervision::ActorSupervisionEvent;
 use hyperactor_mesh_macros::sel;
 use ndslice::Selection;
-use ndslice::Shape;
 use ndslice::view;
 use ndslice::view::Region;
 use ndslice::view::View;
 use serde::Deserialize;
+use serde::Deserializer;
 use serde::Serialize;
+use serde::Serializer;
 
 use crate::CommActor;
 use crate::actor_mesh as v0_actor_mesh;
@@ -70,6 +71,18 @@ impl<A: RemoteActor> ActorMesh<A> {
     }
 }
 
+/// Manual implementation of Clone because `A` doesn't need to implement Clone
+/// but we still want to be able to clone the ActorMesh.
+impl<A: RemoteActor> Clone for ActorMesh<A> {
+    fn clone(&self) -> Self {
+        Self {
+            proc_mesh: self.proc_mesh.clone(),
+            name: self.name.clone(),
+            _phantom: PhantomData,
+        }
+    }
+}
+
 /// Influences paging behavior for the lazy cache. Smaller pages
 /// reduce over-allocation for sparse access; larger pages reduce the
 /// number of heap allocations for contiguous scans.
@@ -93,7 +106,6 @@ impl<A: RemoteActor> Page<A> {
 }
 
 /// A reference to a stable snapshot of an [`ActorMesh`].
-#[derive(Serialize, Deserialize)]
 pub struct ActorMeshRef<A: RemoteActor> {
     proc_mesh: ProcMeshRef,
     name: Name,
@@ -107,10 +119,8 @@ pub struct ActorMeshRef<A: RemoteActor> {
     /// - A `Page<A>` is a boxed slice of `OnceCell<ActorRef<A>>`,
     ///   i.e. the actual storage for actor references within that
     ///   page.
-    #[serde(skip, default)]
     pages: OnceCell<Vec<OnceCell<Box<Page<A>>>>>,
     // Page size knob (not serialize; defaults after deserialize).
-    #[serde(skip, default)]
     page_size: usize,
 
     _phantom: PhantomData<A>,
@@ -123,7 +133,7 @@ impl<A: Actor + RemoteActor> ActorMeshRef<A> {
         A: RemoteHandles<M> + RemoteHandles<IndexedErasedUnbound<M>>,
         M: Castable + RemoteMessage,
     {
-        let cast_mesh_shape = to_shape(view::Ranked::region(self));
+        let cast_mesh_shape = view::Ranked::region(self).into();
         let comm_actor_ref = self
             .proc_mesh
             .root_mesh_rank_0
@@ -131,7 +141,7 @@ impl<A: Actor + RemoteActor> ActorMeshRef<A> {
         let actor_mesh_id = ActorMeshId::V1(self.name.clone());
         match &self.proc_mesh.root_region {
             Some(root_region) => {
-                let root_mesh_shape = to_shape(root_region);
+                let root_mesh_shape = root_region.into();
                 v0_actor_mesh::cast_to_sliced_mesh::<A, M>(
                     cx,
                     actor_mesh_id,
@@ -264,6 +274,28 @@ impl<A: RemoteActor> fmt::Debug for ActorMeshRef<A> {
     }
 }
 
+// Implement Serialize manually, without requiring A: Serialize
+impl<A: RemoteActor> Serialize for ActorMeshRef<A> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        // Serialize only the fields that don't depend on A
+        (&self.proc_mesh, &self.name).serialize(serializer)
+    }
+}
+
+// Implement Deserialize manually, without requiring A: Deserialize
+impl<'de, A: RemoteActor> Deserialize<'de> for ActorMeshRef<A> {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let (proc_mesh, name) = <(ProcMeshRef, Name)>::deserialize(deserializer)?;
+        Ok(ActorMeshRef::with_page_size(name, proc_mesh, DEFAULT_PAGE))
+    }
+}
+
 impl<A: RemoteActor> view::Ranked for ActorMeshRef<A> {
     type Item = ActorRef<A>;
 
@@ -284,11 +316,6 @@ impl<A: RemoteActor> view::RankedSliceable for ActorMeshRef<A> {
         let proc_mesh = self.proc_mesh.subset(region).unwrap();
         Self::with_page_size(self.name.clone(), proc_mesh, self.page_size)
     }
-}
-
-fn to_shape(region: &Region) -> Shape {
-    Shape::new(region.labels().to_vec(), region.slice().clone())
-        .expect("Shape::new should not fail because a Region by definition is a valid Shape")
 }
 
 #[cfg(test)]

--- a/hyperactor_mesh/src/v1/proc_mesh.rs
+++ b/hyperactor_mesh/src/v1/proc_mesh.rs
@@ -134,7 +134,7 @@ impl ProcRef {
 }
 
 /// A mesh of processes.
-#[derive(Named)]
+#[derive(Debug, Named)]
 pub struct ProcMesh {
     name: Name,
     allocation: ProcMeshAllocation,
@@ -167,7 +167,7 @@ impl ProcMesh {
     /// Allocate a new ProcMesh from the provided alloc.
     pub async fn allocate(
         cx: &impl context::Actor,
-        mut alloc: impl Alloc + Send + Sync + 'static,
+        mut alloc: Box<dyn Alloc + Send + Sync + 'static>,
         name: &str,
     ) -> v1::Result<Self> {
         let running = alloc.initialize().await?;
@@ -245,7 +245,7 @@ impl ProcMesh {
         let proc_mesh = Self {
             name: Name::new(name),
             allocation: ProcMeshAllocation::Allocated {
-                alloc: Box::new(alloc),
+                alloc,
                 ranks: Arc::new(ranks),
             },
             comm_actor_name: Name::new("comm"),
@@ -372,8 +372,7 @@ impl ProcMeshRef {
     }
 
     /// Spawn an actor on all of the procs in this mesh, returning a new ActorMesh.
-    #[allow(dead_code)]
-    pub(crate) async fn spawn<A: Actor + RemoteActor>(
+    pub async fn spawn<A: Actor + RemoteActor>(
         &self,
         cx: &impl context::Actor,
         name: &str,

--- a/hyperactor_mesh/src/v1/testing.rs
+++ b/hyperactor_mesh/src/v1/testing.rs
@@ -44,7 +44,9 @@ pub async fn proc_meshes(cx: &impl context::Actor, extent: Extent) -> Vec<ProcMe
             .await
             .unwrap();
 
-        ProcMesh::allocate(cx, alloc, "test.local").await.unwrap()
+        ProcMesh::allocate(cx, Box::new(alloc), "test.local")
+            .await
+            .unwrap()
     });
 
     meshes.push({
@@ -60,7 +62,9 @@ pub async fn proc_meshes(cx: &impl context::Actor, extent: Extent) -> Vec<ProcMe
             .await
             .unwrap();
 
-        ProcMesh::allocate(cx, alloc, "test.process").await.unwrap()
+        ProcMesh::allocate(cx, Box::new(alloc), "test.process")
+            .await
+            .unwrap()
     });
 
     meshes
@@ -82,7 +86,9 @@ pub async fn local_proc_mesh(extent: Extent) -> (ProcMesh, Instance<()>, DialMai
         .await
         .unwrap();
     (
-        ProcMesh::allocate(&actor, alloc, "test").await.unwrap(),
+        ProcMesh::allocate(&actor, Box::new(alloc), "test")
+            .await
+            .unwrap(),
         actor,
         router,
     )

--- a/monarch_extension/src/lib.rs
+++ b/monarch_extension/src/lib.rs
@@ -195,6 +195,15 @@ pub fn mod_init(module: &Bound<'_, PyModule>) -> PyResult<()> {
         "monarch_hyperactor.proc_mesh",
     )?)?;
 
+    monarch_hyperactor::v1::actor_mesh::register_python_bindings(&get_or_add_new_module(
+        module,
+        "monarch_hyperactor.v1.actor_mesh",
+    )?)?;
+    monarch_hyperactor::v1::proc_mesh::register_python_bindings(&get_or_add_new_module(
+        module,
+        "monarch_hyperactor.v1.proc_mesh",
+    )?)?;
+
     monarch_hyperactor::runtime::register_python_bindings(&get_or_add_new_module(
         module,
         "monarch_hyperactor.runtime",

--- a/monarch_hyperactor/src/actor_mesh.rs
+++ b/monarch_hyperactor/src/actor_mesh.rs
@@ -14,7 +14,7 @@ use std::sync::Weak;
 use futures::future::FutureExt;
 use futures::future::Shared;
 use hyperactor::ActorRef;
-use hyperactor::Mailbox;
+use hyperactor::actor::ActorStatus;
 use hyperactor::id;
 use hyperactor::supervision::ActorSupervisionEvent;
 use hyperactor_mesh::Mesh;
@@ -42,6 +42,8 @@ use tokio::sync::mpsc::unbounded_channel;
 use crate::actor::PythonActor;
 use crate::actor::PythonMessage;
 use crate::actor::PythonMessageKind;
+use crate::context::PyInstance;
+use crate::instance_dispatch;
 use crate::mailbox::EitherPortRef;
 use crate::mailbox::PyMailbox;
 use crate::proc::PyActorId;
@@ -49,18 +51,20 @@ use crate::proc_mesh::Keepalive;
 use crate::pytokio::PyPythonTask;
 use crate::pytokio::PyShared;
 use crate::runtime::get_tokio_runtime;
-use crate::shape::PyShape;
+use crate::shape::PyRegion;
 use crate::supervision::SupervisionError;
 use crate::supervision::Unhealthy;
 
 /// Trait defining the common interface for actor mesh, mesh ref and actor mesh implementations.
 /// This corresponds to the Python ActorMeshProtocol ABC.
-trait ActorMeshProtocol: Send + Sync {
+pub(crate) trait ActorMeshProtocol: Send + Sync {
     /// Cast a message to actors selected by the given selection using the specified mailbox.
-    fn cast(&self, message: PythonMessage, selection: Selection, mailbox: Mailbox) -> PyResult<()>;
-
-    /// Create a new actor mesh with the specified shape.
-    fn new_with_shape(&self, shape: PyShape) -> PyResult<Box<dyn ActorMeshProtocol>>;
+    fn cast(
+        &self,
+        message: PythonMessage,
+        selection: Selection,
+        instance: &PyInstance,
+    ) -> PyResult<()>;
 
     fn __reduce__<'py>(&self, py: Python<'py>) -> PyResult<(Bound<'py, PyAny>, Bound<'py, PyAny>)>;
 
@@ -81,9 +85,11 @@ trait ActorMeshProtocol: Send + Sync {
 
     /// Initialize the actor mesh asynchronously.
     /// Default implementation returns None (no initialization needed).
-    fn initialized<'py>(&self) -> PyResult<PyPythonTask> {
+    fn initialized(&self) -> PyResult<PyPythonTask> {
         PyPythonTask::new(async { Ok(None::<()>) })
     }
+
+    fn new_with_region(&self, region: &PyRegion) -> PyResult<Box<dyn ActorMeshProtocol>>;
 }
 
 /// This just forwards to the rust trait that can implement these bindings
@@ -98,23 +104,18 @@ pub(crate) struct PythonActorMesh {
 impl PythonActorMesh {
     pub(crate) fn new<F>(f: F) -> Self
     where
-        F: Future<Output = PyResult<PythonActorMeshImpl>> + Send + 'static,
+        F: Future<Output = PyResult<Box<dyn ActorMeshProtocol>>> + Send + 'static,
     {
         PythonActorMesh {
-            inner: Box::new(AsyncActorMesh::new_queue(async {
-                let b: Box<dyn ActorMeshProtocol> = Box::new(f.await?);
-                Ok(b)
-            })),
+            inner: Box::new(AsyncActorMesh::new_queue(f)),
         }
     }
-    pub(crate) fn from_impl(im: PythonActorMeshImpl) -> Self {
-        PythonActorMesh {
-            inner: Box::new(im),
-        }
+    pub(crate) fn from_impl(inner: Box<dyn ActorMeshProtocol>) -> Self {
+        PythonActorMesh { inner }
     }
 }
 
-fn to_hy_sel(selection: &str) -> PyResult<Selection> {
+pub(crate) fn to_hy_sel(selection: &str) -> PyResult<Selection> {
     match selection {
         "choose" => Ok(sel!(?)),
         "all" => Ok(sel!(*)),
@@ -127,13 +128,18 @@ fn to_hy_sel(selection: &str) -> PyResult<Selection> {
 
 #[pymethods]
 impl PythonActorMesh {
-    fn cast(&self, message: &PythonMessage, selection: &str, mailbox: &PyMailbox) -> PyResult<()> {
+    fn cast(
+        &self,
+        message: &PythonMessage,
+        selection: &str,
+        instance: &PyInstance,
+    ) -> PyResult<()> {
         let sel = to_hy_sel(selection)?;
-        self.inner.cast(message.clone(), sel, mailbox.inner.clone())
+        self.inner.cast(message.clone(), sel, instance)
     }
 
-    fn new_with_shape(&self, shape: PyShape) -> PyResult<PythonActorMesh> {
-        let inner = self.inner.new_with_shape(shape)?;
+    fn new_with_region(&self, region: &PyRegion) -> PyResult<PythonActorMesh> {
+        let inner = self.inner.new_with_region(region)?;
         Ok(PythonActorMesh { inner })
     }
 
@@ -251,7 +257,12 @@ impl PythonActorMeshImpl {
 }
 
 impl ActorMeshProtocol for PythonActorMeshImpl {
-    fn cast(&self, message: PythonMessage, selection: Selection, mailbox: Mailbox) -> PyResult<()> {
+    fn cast(
+        &self,
+        message: PythonMessage,
+        selection: Selection,
+        instance: &PyInstance,
+    ) -> PyResult<()> {
         let unhealthy_event = self
             .health_state
             .unhealthy_event
@@ -273,33 +284,42 @@ impl ActorMeshProtocol for PythonActorMeshImpl {
             }
         }
 
-        self.try_inner()?
-            .cast(&mailbox, selection, message.clone())
-            .map_err(|err| PyException::new_err(err.to_string()))?;
+        instance_dispatch!(instance, |cx_instance| {
+            self.try_inner()?
+                .cast(cx_instance, selection, message.clone())
+                .map_err(|err| PyException::new_err(err.to_string()))?;
+        });
         Ok(())
     }
+
     fn supervision_event(&self) -> PyResult<Option<PyShared>> {
         let mut receiver = self.health_state.user_monitor_sender.subscribe();
         PyPythonTask::new(async move {
             let event = receiver.recv().await;
             let event = match event {
                 Ok(Some(event)) => PyActorSupervisionEvent::from(event.clone()),
-                Ok(None) | Err(_) => PyActorSupervisionEvent {
+                Ok(None) | Err(_) => PyActorSupervisionEvent::from(ActorSupervisionEvent {
                     // Dummy actor as placeholder to indicate the whole mesh is stopped
                     // TODO(albertli): remove this when pushing all supervision logic to rust.
-                    actor_id: id!(default[0].actor[0]).into(),
-                    actor_status: "actor mesh is stopped due to proc mesh shutdown".to_string(),
-                },
+                    actor_id: id!(default[0].actor[0]),
+                    actor_status: ActorStatus::Failed(
+                        "actor mesh is stopped due to proc mesh shutdown".into(),
+                    ),
+                    message_headers: None,
+                    caused_by: None,
+                }),
             };
             Ok(PyErr::new::<SupervisionError, _>(format!(
                 "Actor {:?} exited because of the following reason: {}",
-                event.actor_id, event.actor_status
+                event.actor_id(),
+                event.__repr__()?
             )))
         })
         .map(|mut x| x.spawn().map(Some))?
     }
-    fn new_with_shape(&self, shape: PyShape) -> PyResult<Box<dyn ActorMeshProtocol>> {
-        self.bind()?.new_with_shape(shape)
+
+    fn new_with_region(&self, region: &PyRegion) -> PyResult<Box<dyn ActorMeshProtocol>> {
+        self.bind()?.new_with_region(region)
     }
 
     fn stop<'py>(&self) -> PyResult<PyPythonTask> {
@@ -331,12 +351,18 @@ impl PythonActorMeshImpl {
 
         match &*unhealthy_event {
             Unhealthy::SoFarSoGood => Ok(None),
-            Unhealthy::StreamClosed => Ok(Some(PyActorSupervisionEvent {
-                // Dummy actor as place holder to indicate the whole mesh is stopped
-                // TODO(albertli): remove this when pushing all supervision logic to rust.
-                actor_id: id!(default[0].actor[0]).into(),
-                actor_status: "actor mesh is stopped due to proc mesh shutdown".to_string(),
-            })),
+            Unhealthy::StreamClosed => {
+                Ok(Some(PyActorSupervisionEvent::from(ActorSupervisionEvent {
+                    // Dummy actor as placeholder to indicate the whole mesh is stopped
+                    // TODO(albertli): remove this when pushing all supervision logic to rust.
+                    actor_id: id!(default[0].actor[0]),
+                    actor_status: ActorStatus::Failed(
+                        "actor mesh is stopped due to proc mesh shutdown".into(),
+                    ),
+                    message_headers: None,
+                    caused_by: None,
+                })))
+            }
             Unhealthy::Crashed(event) => Ok(Some(PyActorSupervisionEvent::from(event.clone()))),
         }
     }
@@ -380,7 +406,12 @@ struct PythonActorMeshRef {
 }
 
 impl ActorMeshProtocol for PythonActorMeshRef {
-    fn cast(&self, message: PythonMessage, selection: Selection, client: Mailbox) -> PyResult<()> {
+    fn cast(
+        &self,
+        message: PythonMessage,
+        selection: Selection,
+        instance: &PyInstance,
+    ) -> PyResult<()> {
         if let Some(root_health_state) = &self.root_health_state {
             // MeshRef has not been serialized and sent over the wire so we can actually validate
             // if the underlying mesh still exists
@@ -419,16 +450,19 @@ impl ActorMeshProtocol for PythonActorMeshRef {
                 ));
             }
         }
-        self.inner
-            .cast(&client, selection, message.clone())
-            .map_err(|err| PyException::new_err(err.to_string()))?;
+
+        instance_dispatch!(instance, |cx_instance| {
+            self.inner
+                .cast(cx_instance, selection, message.clone())
+                .map_err(|err| PyException::new_err(err.to_string()))?;
+        });
         Ok(())
     }
 
-    fn new_with_shape(&self, shape: PyShape) -> PyResult<Box<dyn ActorMeshProtocol>> {
+    fn new_with_region(&self, region: &PyRegion) -> PyResult<Box<dyn ActorMeshProtocol>> {
         let sliced = self
             .inner
-            .new_with_shape(shape.get_inner().clone())
+            .new_with_shape(region.as_inner().into())
             .map_err(|e| PyErr::new::<PyValueError, _>(e.to_string()))?;
         Ok(Box::new(Self {
             inner: sliced,
@@ -510,14 +544,14 @@ impl Clone for ClonePyErr {
 }
 
 type ActorMeshResult = Result<Arc<dyn ActorMeshProtocol>, ClonePyErr>;
-struct AsyncActorMesh {
+pub(crate) struct AsyncActorMesh {
     mesh: Shared<Pin<Box<dyn Future<Output = ActorMeshResult> + Send>>>,
     queue: UnboundedSender<Pin<Box<dyn Future<Output = ()> + Send + 'static>>>,
     supervised: bool,
 }
 
 impl AsyncActorMesh {
-    fn new_queue<F>(f: F) -> AsyncActorMesh
+    pub(crate) fn new_queue<F>(f: F) -> AsyncActorMesh
     where
         F: Future<Output = PyResult<Box<dyn ActorMeshProtocol>>> + Send + 'static,
     {
@@ -560,14 +594,20 @@ impl AsyncActorMesh {
 }
 
 impl ActorMeshProtocol for AsyncActorMesh {
-    fn cast(&self, message: PythonMessage, selection: Selection, client: Mailbox) -> PyResult<()> {
+    fn cast(
+        &self,
+        message: PythonMessage,
+        selection: Selection,
+        instance: &PyInstance,
+    ) -> PyResult<()> {
         let mesh = self.mesh.clone();
-        self.push(async {
+        let instance = instance.clone();
+        self.push(async move {
             let port = match &message.kind {
                 PythonMessageKind::CallMethod { response_port, .. } => response_port.clone(),
                 _ => None,
             };
-            let result = async { mesh.await?.cast(message, selection, client.clone()) }.await;
+            let result = async { mesh.await?.cast(message, selection, &instance) }.await;
             match (port, result) {
                 (Some(p), Err(pyerr)) => Python::with_gil(|py: Python<'_>| {
                     let port_ref = match p {
@@ -578,7 +618,7 @@ impl ActorMeshProtocol for AsyncActorMesh {
                     let port = py
                         .import("monarch._src.actor.actor_mesh")
                         .unwrap()
-                        .call_method1("Port", (port_ref, PyMailbox { inner: client }, 0))
+                        .call_method1("Port", (port_ref, instance._mailbox(), 0))
                         .unwrap();
                     port.call_method1("exception", (pyerr.value(py),)).unwrap();
                 }),
@@ -588,12 +628,13 @@ impl ActorMeshProtocol for AsyncActorMesh {
         Ok(())
     }
 
-    fn new_with_shape(&self, shape: PyShape) -> PyResult<Box<dyn ActorMeshProtocol>> {
+    fn new_with_region(&self, region: &PyRegion) -> PyResult<Box<dyn ActorMeshProtocol>> {
         let mesh = self.mesh.clone();
+        let region = region.clone();
         Ok(Box::new(AsyncActorMesh::new(
             self.queue.clone(),
             self.supervised,
-            async { Ok(mesh.await?.new_with_shape(shape)?) },
+            async move { mesh.await?.new_with_region(&region) },
         )))
     }
 
@@ -638,31 +679,29 @@ impl ActorMeshProtocol for AsyncActorMesh {
 )]
 #[derive(Debug)]
 pub struct PyActorSupervisionEvent {
-    /// Actor ID of the actor where supervision event originates from.
-    #[pyo3(get)]
-    actor_id: PyActorId,
-    /// String representation of the actor status.
-    /// TODO(T230628951): make it an enum or a struct for easier consumption.
-    #[pyo3(get)]
-    actor_status: String,
+    inner: ActorSupervisionEvent,
 }
 
 #[pymethods]
 impl PyActorSupervisionEvent {
     fn __repr__(&self) -> PyResult<String> {
-        Ok(format!(
-            "<PyActorSupervisionEvent: actor_id: {:?}, status: {}>",
-            self.actor_id, self.actor_status
-        ))
+        Ok(format!("<PyActorSupervisionEvent: {}>", self.inner))
+    }
+
+    #[getter]
+    fn actor_id(&self) -> PyResult<PyActorId> {
+        Ok(PyActorId::from(self.inner.actor_id.clone()))
+    }
+
+    #[getter]
+    fn actor_status(&self) -> PyResult<String> {
+        Ok(self.inner.actor_status.to_string())
     }
 }
 
 impl From<ActorSupervisionEvent> for PyActorSupervisionEvent {
     fn from(event: ActorSupervisionEvent) -> Self {
-        PyActorSupervisionEvent {
-            actor_id: event.actor_id.clone().into(),
-            actor_status: event.actor_status.to_string(),
-        }
+        PyActorSupervisionEvent { inner: event }
     }
 }
 

--- a/monarch_hyperactor/src/lib.rs
+++ b/monarch_hyperactor/src/lib.rs
@@ -31,6 +31,7 @@ pub mod selection;
 pub mod shape;
 pub mod supervision;
 pub mod telemetry;
+pub mod v1;
 pub mod value_mesh;
 
 #[cfg(fbcode_build)]

--- a/monarch_hyperactor/src/proc_mesh.rs
+++ b/monarch_hyperactor/src/proc_mesh.rs
@@ -12,7 +12,6 @@ use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
 
 use hyperactor::Actor;
-use hyperactor::Mailbox;
 use hyperactor::RemoteMessage;
 use hyperactor::WorldId;
 use hyperactor::actor::RemoteActor;
@@ -41,15 +40,17 @@ use tokio::sync::mpsc;
 
 type OnStopCallback = Box<dyn FnOnce() -> Box<dyn std::future::Future<Output = ()> + Send> + Send>;
 
+use crate::actor_mesh::ActorMeshProtocol;
 use crate::actor_mesh::PythonActorMesh;
 use crate::actor_mesh::PythonActorMeshImpl;
 use crate::alloc::PyAlloc;
+use crate::context::PyInstance;
 use crate::mailbox::PyMailbox;
 use crate::pytokio::PyPythonTask;
 use crate::pytokio::PyShared;
 use crate::pytokio::PythonTask;
 use crate::runtime::get_tokio_runtime;
-use crate::shape::PyShape;
+use crate::shape::PyRegion;
 use crate::supervision::SupervisionError;
 use crate::supervision::Unhealthy;
 
@@ -329,7 +330,7 @@ impl PyProcMesh {
                 keepalive,
                 actor_events,
             );
-            Ok(PythonActorMesh::from_impl(im))
+            Ok(PythonActorMesh::from_impl(Box::new(im)))
         };
         PyPythonTask::new(meshimpl)
     }
@@ -358,14 +359,14 @@ impl PyProcMesh {
             let instance = proc_mesh.client();
             let actor_mesh = proc_mesh.spawn(&name, &pickled_type).await?;
             let actor_events = actor_mesh.with_mut(|a| a.events()).await.unwrap().unwrap();
-            Ok(PythonActorMeshImpl::new(
+            Ok::<_, PyErr>(Box::new(PythonActorMeshImpl::new(
                 actor_mesh,
                 PyMailbox {
                     inner: instance.mailbox().clone(),
                 },
                 keepalive,
                 actor_events,
-            ))
+            )))
         };
         if emulated {
             // we give up on doing mesh spawn async for the emulated old version
@@ -373,10 +374,14 @@ impl PyProcMesh {
             let r = get_tokio_runtime().block_on(meshimpl)?;
             Python::with_gil(|py| r.into_py_any(py))
         } else {
-            let r = PythonActorMesh::new(meshimpl);
+            let r = PythonActorMesh::new(async move {
+                let meshimpl: Box<dyn ActorMeshProtocol> = meshimpl.await?;
+                Ok(meshimpl)
+            });
             Python::with_gil(|py| r.into_py_any(py))
         }
     }
+
     // User can call this to monitor the proc mesh events. This will override
     // the default monitor that exits the client on process crash, so user can
     // handle the process crash in their own way.
@@ -399,10 +404,8 @@ impl PyProcMesh {
     }
 
     #[getter]
-    fn client(&self) -> PyResult<PyMailbox> {
-        Ok(PyMailbox {
-            inner: self.try_inner()?.client().mailbox().clone(),
-        })
+    fn client(&self) -> PyResult<PyInstance> {
+        Ok(self.try_inner()?.client().into())
     }
 
     fn __repr__(&self) -> PyResult<String> {
@@ -410,8 +413,10 @@ impl PyProcMesh {
     }
 
     #[getter]
-    fn shape(&self) -> PyResult<PyShape> {
-        Ok(self.try_inner()?.shape().clone().into())
+    fn region(&self) -> PyResult<PyRegion> {
+        Ok(PyRegion {
+            inner: self.try_inner()?.shape().into(),
+        })
     }
 
     fn stop_nonblocking(&self) -> PyResult<PyPythonTask> {

--- a/monarch_hyperactor/src/shape.rs
+++ b/monarch_hyperactor/src/shape.rs
@@ -9,6 +9,7 @@
 use monarch_types::MapPyErr;
 use ndslice::Extent;
 use ndslice::Point;
+use ndslice::Region;
 use ndslice::Shape;
 use ndslice::Slice;
 use pyo3::IntoPyObjectExt;
@@ -98,6 +99,37 @@ impl PyExtent {
 impl From<Extent> for PyExtent {
     fn from(inner: Extent) -> Self {
         PyExtent { inner }
+    }
+}
+
+#[derive(Serialize, Deserialize, Clone)]
+#[pyclass(
+    name = "Region",
+    module = "monarch._rust_bindings.monarch_hyperactor.shape",
+    frozen
+)]
+pub struct PyRegion {
+    pub(crate) inner: Region,
+}
+
+impl PyRegion {
+    pub(crate) fn as_inner(&self) -> &Region {
+        &self.inner
+    }
+}
+
+#[pymethods]
+impl PyRegion {
+    fn as_shape(&self) -> PyShape {
+        PyShape {
+            inner: (&self.inner).into(),
+        }
+    }
+}
+
+impl From<Region> for PyRegion {
+    fn from(inner: Region) -> Self {
+        PyRegion { inner }
     }
 }
 
@@ -245,6 +277,13 @@ impl PyShape {
     fn extent(&self) -> PyExtent {
         self.inner.extent().into()
     }
+
+    #[getter]
+    fn region(&self) -> PyRegion {
+        PyRegion {
+            inner: self.inner.region(),
+        }
+    }
 }
 
 impl From<Shape> for PyShape {
@@ -368,5 +407,6 @@ pub fn register_python_bindings(module: &Bound<'_, PyModule>) -> PyResult<()> {
     PyMapping::register::<PyPoint>(py)?;
     module.add_class::<PyExtent>()?;
     PyMapping::register::<PyExtent>(py)?;
+    module.add_class::<PyRegion>()?;
     Ok(())
 }

--- a/monarch_hyperactor/src/v1.rs
+++ b/monarch_hyperactor/src/v1.rs
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+//! V1 API implementation for monarch_hyperactor using hyperactor_mesh::v1
+
+pub mod actor_mesh;
+mod borrow;
+pub mod proc_mesh;

--- a/monarch_hyperactor/src/v1/actor_mesh.rs
+++ b/monarch_hyperactor/src/v1/actor_mesh.rs
@@ -1,0 +1,176 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+use hyperactor::ActorRef;
+use hyperactor_mesh::v1::actor_mesh::ActorMesh;
+use hyperactor_mesh::v1::actor_mesh::ActorMeshRef;
+use ndslice::Selection;
+use ndslice::view::Ranked;
+use ndslice::view::RankedSliceable;
+use pyo3::IntoPyObjectExt;
+use pyo3::exceptions::PyException;
+use pyo3::exceptions::PyNotImplementedError;
+use pyo3::exceptions::PyValueError;
+use pyo3::prelude::*;
+use pyo3::types::PyBytes;
+
+use crate::actor::PythonActor;
+use crate::actor::PythonMessage;
+use crate::actor_mesh::ActorMeshProtocol;
+use crate::actor_mesh::PythonActorMesh;
+use crate::context::PyInstance;
+use crate::instance_dispatch;
+use crate::proc::PyActorId;
+use crate::pytokio::PyPythonTask;
+use crate::pytokio::PyShared;
+use crate::shape::PyRegion;
+use crate::v1::borrow::BorrowMeshRef;
+use crate::v1::borrow::MeshRefBorrow;
+
+#[derive(Debug, Clone)]
+#[pyclass(
+    name = "PyActorMesh",
+    module = "monarch._rust_bindings.monarch_hyperactor.v1.actor_mesh"
+)]
+pub(crate) struct PyActorMesh(ActorMesh<PythonActor>);
+
+#[derive(Debug, Clone)]
+#[pyclass(
+    name = "PyActorMeshRef",
+    module = "monarch._rust_bindings.monarch_hyperactor.v1.actor_mesh"
+)]
+pub(crate) struct PyActorMeshRef(ActorMeshRef<PythonActor>);
+
+#[derive(Debug, Clone)]
+#[pyclass(
+    name = "PythonActorMeshImpl",
+    module = "monarch._rust_bindings.monarch_hyperactor.v1.actor_mesh"
+)]
+pub(crate) enum PythonActorMeshImpl {
+    Owned(PyActorMesh),
+    Ref(PyActorMeshRef),
+}
+
+impl PythonActorMeshImpl {
+    /// Get a new owned [`PythonActorMeshImpl`].
+    pub(crate) fn new_owned(inner: ActorMesh<PythonActor>) -> Self {
+        PythonActorMeshImpl::Owned(PyActorMesh(inner))
+    }
+
+    /// Get a new ref-based [`PythonActorMeshImpl`].
+    pub(crate) fn new_ref(inner: ActorMeshRef<PythonActor>) -> Self {
+        PythonActorMeshImpl::Ref(PyActorMeshRef(inner))
+    }
+}
+
+impl ActorMeshProtocol for PythonActorMeshImpl {
+    fn cast(
+        &self,
+        message: PythonMessage,
+        selection: Selection,
+        instance: &PyInstance,
+    ) -> PyResult<()> {
+        <ActorMeshRef<PythonActor> as ActorMeshProtocol>::cast(
+            &self.borrow(),
+            message,
+            selection,
+            instance,
+        )
+    }
+
+    fn supervision_event(&self) -> PyResult<Option<PyShared>> {
+        Err(PyErr::new::<PyNotImplementedError, _>(
+            "supervision_event is not implemented yet for v1::PythonActorMeshImpl",
+        ))
+    }
+
+    fn new_with_region(&self, region: &PyRegion) -> PyResult<Box<dyn ActorMeshProtocol>> {
+        self.borrow().new_with_region(region)
+    }
+
+    fn stop<'py>(&self) -> PyResult<PyPythonTask> {
+        Err(PyErr::new::<PyNotImplementedError, _>(
+            "stop is not implemented yet for v1::PythonActorMeshImpl",
+        ))
+    }
+
+    fn __reduce__<'py>(&self, py: Python<'py>) -> PyResult<(Bound<'py, PyAny>, Bound<'py, PyAny>)> {
+        self.borrow().__reduce__(py)
+    }
+}
+
+impl ActorMeshProtocol for ActorMeshRef<PythonActor> {
+    fn cast(
+        &self,
+        message: PythonMessage,
+        _selection: Selection,
+        instance: &PyInstance,
+    ) -> PyResult<()> {
+        instance_dispatch!(instance, |cx_instance| {
+            self.cast(cx_instance, message.clone())
+                .map_err(|err| PyException::new_err(err.to_string()))?;
+        });
+        Ok(())
+    }
+
+    fn new_with_region(&self, region: &PyRegion) -> PyResult<Box<dyn ActorMeshProtocol>> {
+        let sliced = self.sliced(region.as_inner().clone());
+        Ok(Box::new(sliced))
+    }
+
+    fn __reduce__<'py>(&self, py: Python<'py>) -> PyResult<(Bound<'py, PyAny>, Bound<'py, PyAny>)> {
+        let bytes =
+            bincode::serialize(self).map_err(|e| PyErr::new::<PyValueError, _>(e.to_string()))?;
+        let py_bytes = (PyBytes::new(py, &bytes),).into_bound_py_any(py).unwrap();
+        let module = py
+            .import("monarch._rust_bindings.monarch_hyperactor.v1.actor_mesh")
+            .unwrap();
+        let from_bytes = module.getattr("py_actor_mesh_from_bytes").unwrap();
+        Ok((from_bytes, py_bytes))
+    }
+}
+
+#[pymethods]
+impl PythonActorMeshImpl {
+    fn get(&self, rank: usize) -> PyResult<Option<PyActorId>> {
+        Ok(self
+            .borrow()
+            .get(rank)
+            .map(|r| ActorRef::into_actor_id(r.clone()))
+            .map(PyActorId::from))
+    }
+}
+
+impl BorrowMeshRef<'_> for PythonActorMeshImpl {
+    type Borrowed = ActorMeshRef<PythonActor>;
+
+    fn try_borrow(&self) -> Result<MeshRefBorrow<'_, Self::Borrowed>, anyhow::Error> {
+        match self {
+            PythonActorMeshImpl::Owned(inner) => Ok(MeshRefBorrow::Owned(inner.0.freeze())),
+            PythonActorMeshImpl::Ref(inner) => Ok(MeshRefBorrow::Ref(&inner.0)),
+        }
+    }
+}
+
+#[pyfunction]
+fn py_actor_mesh_from_bytes(bytes: &Bound<'_, PyBytes>) -> PyResult<PythonActorMesh> {
+    let r: PyResult<ActorMeshRef<PythonActor>> = bincode::deserialize(bytes.as_bytes())
+        .map_err(|e| PyErr::new::<PyValueError, _>(e.to_string()));
+    r.map(|r| PythonActorMesh::from_impl(Box::new(PythonActorMeshImpl::new_ref(r))))
+}
+
+pub fn register_python_bindings(hyperactor_mod: &Bound<'_, PyModule>) -> PyResult<()> {
+    hyperactor_mod.add_class::<PythonActorMeshImpl>()?;
+    let f = wrap_pyfunction!(py_actor_mesh_from_bytes, hyperactor_mod)?;
+    f.setattr(
+        "__module__",
+        "monarch._rust_bindings.monarch_hyperactor.v1.actor_mesh",
+    )?;
+    hyperactor_mod.add_function(f)?;
+    Ok(())
+}

--- a/monarch_hyperactor/src/v1/borrow.rs
+++ b/monarch_hyperactor/src/v1/borrow.rs
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+use std::ops::Deref;
+
+pub(crate) trait BorrowMeshRef<'a> {
+    type Borrowed;
+
+    fn borrow(&'a self) -> MeshRefBorrow<'a, Self::Borrowed> {
+        self.try_borrow().unwrap()
+    }
+
+    fn try_borrow(&'a self) -> Result<MeshRefBorrow<'a, Self::Borrowed>, anyhow::Error>;
+}
+
+/// Multiple mesh types have two underlying implementations, one that is an owned mesh
+/// and one that is a mesh ref. This enum (together with the BorrowMeshRef trait and
+/// Deref impl) provides a unified way to get &MeshRef from either and owned mesh
+/// or a mesh ref.
+pub(crate) enum MeshRefBorrow<'a, M> {
+    Owned(M),
+    Ref(&'a M),
+}
+
+impl<M> MeshRefBorrow<'_, M> {
+    fn borrow(&self) -> &M {
+        match self {
+            MeshRefBorrow::Owned(ref_) => ref_,
+            MeshRefBorrow::Ref(ref_) => ref_,
+        }
+    }
+}
+
+impl<M> Deref for MeshRefBorrow<'_, M> {
+    type Target = M;
+
+    fn deref(&self) -> &Self::Target {
+        self.borrow()
+    }
+}

--- a/monarch_hyperactor/src/v1/proc_mesh.rs
+++ b/monarch_hyperactor/src/v1/proc_mesh.rs
@@ -1,0 +1,231 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+use hyperactor_mesh::shared_cell::SharedCell;
+use hyperactor_mesh::v1::proc_mesh::ProcMesh;
+use hyperactor_mesh::v1::proc_mesh::ProcMeshRef;
+use monarch_types::PickledPyObject;
+use ndslice::View;
+use pyo3::IntoPyObjectExt;
+use pyo3::exceptions::PyException;
+use pyo3::exceptions::PyNotImplementedError;
+use pyo3::exceptions::PyValueError;
+use pyo3::prelude::*;
+use pyo3::types::PyBytes;
+use pyo3::types::PyType;
+
+use crate::actor::to_py_error;
+use crate::actor_mesh::ActorMeshProtocol;
+use crate::actor_mesh::PythonActorMesh;
+use crate::alloc::PyAlloc;
+use crate::context::PyInstance;
+use crate::instance_dispatch;
+use crate::pytokio::PyPythonTask;
+use crate::pytokio::PyShared;
+use crate::runtime::get_tokio_runtime;
+use crate::shape::PyRegion;
+use crate::v1::actor_mesh::PythonActorMeshImpl;
+use crate::v1::borrow::BorrowMeshRef;
+use crate::v1::borrow::MeshRefBorrow;
+
+#[pyclass(
+    name = "ProcMesh",
+    module = "monarch._rust_bindings.monarch_hyperactor.v1.proc_mesh"
+)]
+enum PyProcMesh {
+    Owned(PyProcMeshImpl),
+    Ref(PyProcMeshRefImpl),
+}
+
+impl PyProcMesh {
+    fn new_owned(inner: ProcMesh) -> Self {
+        Self::Owned(PyProcMeshImpl(inner.into()))
+    }
+
+    fn new_ref(inner: ProcMeshRef) -> Self {
+        Self::Ref(PyProcMeshRefImpl(inner))
+    }
+}
+
+#[pymethods]
+impl PyProcMesh {
+    #[classmethod]
+    fn allocate_nonblocking<'py>(
+        _cls: &Bound<'_, PyType>,
+        _py: Python<'py>,
+        instance: &PyInstance,
+        alloc: &mut PyAlloc,
+        name: String,
+    ) -> PyResult<PyPythonTask> {
+        let alloc = match alloc.take() {
+            Some(alloc) => alloc,
+            None => {
+                return Err(PyException::new_err(
+                    "Alloc object already used".to_string(),
+                ));
+            }
+        };
+        let instance = instance.clone();
+        PyPythonTask::new(async move {
+            let mesh = instance_dispatch!(instance, async move |cx_instance| {
+                ProcMesh::allocate(cx_instance, alloc, &name).await
+            })
+            .map_err(|err| PyException::new_err(err.to_string()))?;
+            Ok(Self::new_owned(mesh))
+        })
+    }
+
+    fn spawn_nonblocking<'py>(
+        &self,
+        instance: &PyInstance,
+        name: String,
+        actor: &Bound<'py, PyType>,
+    ) -> PyResult<PyPythonTask> {
+        let pickled_type = PickledPyObject::pickle(actor.as_any())?;
+        let proc_mesh = self.try_borrow()?.clone();
+        let instance = instance.clone();
+        let mesh_impl = async move {
+            let actor_mesh = instance_dispatch!(instance, async move |cx_instance| {
+                proc_mesh.spawn(cx_instance, &name, &pickled_type).await
+            })
+            .map_err(to_py_error)?;
+            Ok(PythonActorMesh::from_impl(Box::new(
+                PythonActorMeshImpl::new_owned(actor_mesh),
+            )))
+        };
+        PyPythonTask::new(mesh_impl)
+    }
+
+    #[staticmethod]
+    fn spawn_async(
+        proc_mesh: &mut PyShared,
+        instance: &PyInstance,
+        name: String,
+        actor: Py<PyType>,
+        emulated: bool,
+    ) -> PyResult<PyObject> {
+        let task = proc_mesh.task()?.take_task()?;
+        let instance = instance.clone();
+        let mesh_impl = async move {
+            let proc_mesh = task.await?;
+            let (proc_mesh, pickled_type) = Python::with_gil(|py| -> PyResult<_> {
+                let slf: Bound<PyProcMesh> = proc_mesh.extract(py)?;
+                let slf = slf.borrow();
+                let pickled_type = PickledPyObject::pickle(actor.bind(py).as_any())?;
+                Ok((slf.try_borrow()?.clone(), pickled_type))
+            })?;
+
+            let actor_mesh = instance_dispatch!(instance, async move |cx_instance| {
+                proc_mesh.spawn(cx_instance, &name, &pickled_type).await
+            })
+            .map_err(anyhow::Error::from)?;
+            Ok::<_, PyErr>(Box::new(PythonActorMeshImpl::new_owned(actor_mesh)))
+        };
+        if emulated {
+            // we give up on doing mesh spawn async for the emulated old version
+            // it is too complicated to make both work.
+            let r = get_tokio_runtime().block_on(mesh_impl)?;
+            Python::with_gil(|py| r.into_py_any(py))
+        } else {
+            let r = PythonActorMesh::new(async move {
+                let mesh_impl: Box<dyn ActorMeshProtocol> = mesh_impl.await?;
+                Ok(mesh_impl)
+            });
+            Python::with_gil(|py| r.into_py_any(py))
+        }
+    }
+
+    fn __repr__(&self) -> PyResult<String> {
+        match self {
+            PyProcMesh::Owned(inner) => Ok(format!("<ProcMesh: {:?}>", inner.__repr__()?)),
+            PyProcMesh::Ref(inner) => Ok(format!("<ProcMesh: {:?}>", inner.__repr__()?)),
+        }
+    }
+
+    fn __reduce__<'py>(&self, py: Python<'py>) -> PyResult<(Bound<'py, PyAny>, Bound<'py, PyAny>)> {
+        let bytes = bincode::serialize(&*self.try_borrow()?)
+            .map_err(|e| PyErr::new::<PyValueError, _>(e.to_string()))?;
+        let py_bytes = (PyBytes::new(py, &bytes),).into_bound_py_any(py).unwrap();
+        let from_bytes = wrap_pyfunction!(py_proc_mesh_from_bytes, py)?.into_any();
+        Ok((from_bytes, py_bytes))
+    }
+
+    fn monitor(&self) -> PyResult<PyObject> {
+        Err(PyNotImplementedError::new_err(
+            "v1::PyProcMesh::monitor not implemented",
+        ))
+    }
+
+    #[getter]
+    fn region(&self) -> PyResult<PyRegion> {
+        Ok(self.try_borrow()?.region().into())
+    }
+
+    fn stop_nonblocking(&self) -> PyResult<PyPythonTask> {
+        Err(PyNotImplementedError::new_err(
+            "v1::PyProcMesh::stop not implemented",
+        ))
+    }
+}
+
+impl BorrowMeshRef<'_> for PyProcMesh {
+    type Borrowed = ProcMeshRef;
+
+    fn try_borrow(&self) -> Result<MeshRefBorrow<'_, Self::Borrowed>, anyhow::Error> {
+        match self {
+            PyProcMesh::Owned(inner) => Ok(MeshRefBorrow::Owned(inner.0.borrow()?.freeze())),
+            PyProcMesh::Ref(inner) => Ok(MeshRefBorrow::Ref(&inner.0)),
+        }
+    }
+}
+
+#[derive(Clone)]
+#[pyclass(
+    name = "ProcMeshImpl",
+    module = "monarch._rust_bindings.monarch_hyperactor.v1.proc_mesh"
+)]
+struct PyProcMeshImpl(SharedCell<ProcMesh>);
+
+impl PyProcMeshImpl {
+    fn __repr__(&self) -> PyResult<String> {
+        Ok(format!(
+            "<ProcMeshImpl {:?}>",
+            *self.0.borrow().map_err(anyhow::Error::from)?
+        ))
+    }
+}
+
+#[derive(Debug, Clone)]
+#[pyclass(
+    name = "ProcMeshRefImpl",
+    module = "monarch._rust_bindings.monarch_hyperactor.v1.proc_mesh"
+)]
+struct PyProcMeshRefImpl(ProcMeshRef);
+
+impl PyProcMeshRefImpl {
+    fn __repr__(&self) -> PyResult<String> {
+        Ok(format!("<ProcMeshRefImpl {:?}>", self.0))
+    }
+}
+
+#[pyfunction]
+fn py_proc_mesh_from_bytes(bytes: &Bound<'_, PyBytes>) -> PyResult<PyProcMesh> {
+    let r: PyResult<ProcMeshRef> = bincode::deserialize(bytes.as_bytes())
+        .map_err(|e| PyErr::new::<PyValueError, _>(e.to_string()));
+    r.map(PyProcMesh::new_ref)
+}
+
+pub fn register_python_bindings(hyperactor_mod: &Bound<'_, PyModule>) -> PyResult<()> {
+    let f = wrap_pyfunction!(py_proc_mesh_from_bytes, hyperactor_mod)?;
+    f.setattr(
+        "__module__",
+        "monarch._rust_bindings.monarch_hyperactor.v1.proc_mesh",
+    )?;
+    hyperactor_mod.add_class::<PyProcMesh>()?;
+    Ok(())
+}

--- a/ndslice/src/shape.rs
+++ b/ndslice/src/shape.rs
@@ -12,6 +12,7 @@ use serde::Deserialize;
 use serde::Serialize;
 
 use crate::DimSliceIterator;
+use crate::Region;
 use crate::Slice;
 use crate::SliceError;
 use crate::selection::Selection;
@@ -201,6 +202,17 @@ impl Shape {
     /// The extent corresponding to this shape.
     pub fn extent(&self) -> Extent {
         Extent::new(self.labels.clone(), self.slice.sizes().to_vec()).unwrap()
+    }
+
+    /// The region corresponding to this shape.
+    pub fn region(&self) -> Region {
+        self.into()
+    }
+}
+
+impl From<&Region> for Shape {
+    fn from(region: &Region) -> Self {
+        Shape::new(region.labels().to_vec(), region.slice().clone()).unwrap()
     }
 }
 

--- a/ndslice/src/view.rs
+++ b/ndslice/src/view.rs
@@ -943,6 +943,21 @@ impl From<Extent> for Region {
     }
 }
 
+impl From<&Shape> for Region {
+    fn from(s: &Shape) -> Self {
+        Region {
+            labels: s.labels().to_vec(),
+            slice: s.slice().clone(),
+        }
+    }
+}
+
+impl From<Shape> for Region {
+    fn from(s: Shape) -> Self {
+        Region::from(&s)
+    }
+}
+
 /// Formats a `Region` in a compact rectangular syntax:
 /// ```text
 /// [offset+]label=size/stride[,label=size/stride,...]

--- a/python/monarch/_rust_bindings/monarch_hyperactor/actor_mesh.pyi
+++ b/python/monarch/_rust_bindings/monarch_hyperactor/actor_mesh.pyi
@@ -6,18 +6,13 @@
 
 # pyre-strict
 
-from typing import AsyncIterator, final, NoReturn, Optional, Protocol
+from typing import final, Optional, Protocol
 
 from monarch._rust_bindings.monarch_hyperactor.actor import PythonMessage
-from monarch._rust_bindings.monarch_hyperactor.mailbox import (
-    Mailbox,
-    OncePortReceiver,
-    PortReceiver,
-)
+from monarch._rust_bindings.monarch_hyperactor.context import Instance
 from monarch._rust_bindings.monarch_hyperactor.proc import ActorId
 from monarch._rust_bindings.monarch_hyperactor.pytokio import PythonTask, Shared
-from monarch._rust_bindings.monarch_hyperactor.selection import Selection
-from monarch._rust_bindings.monarch_hyperactor.shape import Shape
+from monarch._rust_bindings.monarch_hyperactor.shape import Region
 from typing_extensions import Self
 
 class ActorMeshProtocol(Protocol):
@@ -29,9 +24,9 @@ class ActorMeshProtocol(Protocol):
         self,
         message: PythonMessage,
         selection: str,
-        mailbox: Mailbox,
+        instance: Instance,
     ) -> None: ...
-    def new_with_shape(self, shape: Shape) -> Self: ...
+    def new_with_region(self, region: Region) -> Self: ...
     def supervision_event(self) -> "Optional[Shared[Exception]]": ...
     def stop(self) -> PythonTask[None]: ...
     def initialized(self) -> PythonTask[None]: ...

--- a/python/monarch/_rust_bindings/monarch_hyperactor/context.pyi
+++ b/python/monarch/_rust_bindings/monarch_hyperactor/context.pyi
@@ -1,0 +1,12 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+# This class is stubbed out in monarch._src.actor.actor_mesh, but
+# it's useful to have this here for type-checking in other rust
+# bindings.
+class Instance: ...

--- a/python/monarch/_rust_bindings/monarch_hyperactor/shape.pyi
+++ b/python/monarch/_rust_bindings/monarch_hyperactor/shape.pyi
@@ -157,6 +157,8 @@ class Shape:
     def unity() -> "Shape": ...
     @property
     def extent(self) -> "Extent": ...
+    @property
+    def region(self) -> "Region": ...
 
 # TODO: should be an abc.Mapping similar to Point so it can be used a dictionary.
 class Extent(collections.abc.Mapping):
@@ -190,3 +192,14 @@ class Point(collections.abc.Mapping):
     @property
     def extent(self) -> "Extent": ...
     def __iter__(self) -> "Iterator[str]": ...
+
+class Region:
+    """
+    `Region` describes a region of a possibly-larger space of ranks, organized into
+    a hyper rectangle.
+
+    Internally, region consist of a set of labels and a [`Slice`], as it allows for
+    a compact but useful representation of the ranks. However, this representation
+    may change in the future.
+    """
+    def as_shape(self) -> "Shape": ...

--- a/python/monarch/_rust_bindings/monarch_hyperactor/v1/proc_mesh.pyi
+++ b/python/monarch/_rust_bindings/monarch_hyperactor/v1/proc_mesh.pyi
@@ -6,17 +6,15 @@
 
 # pyre-strict
 
-from typing import Any, AsyncIterator, final, Literal, overload, Type, TYPE_CHECKING
+from typing import Any, final, Type, TYPE_CHECKING
 
 if TYPE_CHECKING:
     from monarch._rust_bindings.monarch_hyperactor.actor import Actor
-from monarch._rust_bindings.monarch_hyperactor.actor_mesh import (
-    PythonActorMesh,
-    PythonActorMeshImpl,
-)
+from monarch._rust_bindings.monarch_hyperactor.actor_mesh import PythonActorMesh
 
 from monarch._rust_bindings.monarch_hyperactor.alloc import Alloc
 from monarch._rust_bindings.monarch_hyperactor.context import Instance
+from monarch._rust_bindings.monarch_hyperactor.proc_mesh import ProcMeshMonitor
 from monarch._rust_bindings.monarch_hyperactor.pytokio import PythonTask, Shared
 
 from monarch._rust_bindings.monarch_hyperactor.shape import Region
@@ -24,18 +22,23 @@ from monarch._rust_bindings.monarch_hyperactor.shape import Region
 @final
 class ProcMesh:
     @classmethod
-    def allocate_nonblocking(self, alloc: Alloc) -> PythonTask["ProcMesh"]:
+    def allocate_nonblocking(
+        self, instance: Instance, alloc: Alloc, name: str
+    ) -> PythonTask["ProcMesh"]:
         """
         Allocate a process mesh according to the provided alloc.
         Returns when the mesh is fully allocated.
 
         Arguments:
+        - `instance`: The actor instance used to allocate the mesh.
         - `alloc`: The alloc to allocate according to.
+        - `name`: Name of the mesh.
         """
         ...
 
     def spawn_nonblocking(
         self,
+        instance: Instance,
         name: str,
         actor: Any,
     ) -> PythonTask[PythonActorMesh]:
@@ -43,6 +46,7 @@ class ProcMesh:
         Spawn a new actor on this mesh.
 
         Arguments:
+        - `instance`: The actor instance that will own the returned actor mesh.
         - `name`: Name of the actor.
         - `actor`: The type of the actor that will be spawned.
         """
@@ -50,20 +54,15 @@ class ProcMesh:
 
     @staticmethod
     def spawn_async(
-        proc_mesh: Shared["ProcMesh"], name: str, actor: Type["Actor"], emulated: bool
+        proc_mesh: Shared["ProcMesh"],
+        instance: Instance,
+        name: str,
+        actor: Type["Actor"],
+        emulated: bool,
     ) -> PythonActorMesh: ...
     async def monitor(self) -> ProcMeshMonitor:
         """
         Returns a supervision monitor for this mesh.
-        """
-        ...
-
-    @property
-    def client(self) -> Instance:
-        """
-        A client that can be used to communicate with individual
-        actors in the mesh, and also to create ports that can be
-        broadcast across the mesh)
         """
         ...
 
@@ -81,35 +80,3 @@ class ProcMesh:
         ...
 
     def __repr__(self) -> str: ...
-
-@final
-class ProcMeshMonitor:
-    def __aiter__(self) -> AsyncIterator["ProcEvent"]:
-        """
-        Returns an async iterator for this monitor.
-        """
-        ...
-
-    async def __anext__(self) -> "ProcEvent":
-        """
-        Returns the next proc event in the proc mesh.
-        """
-        ...
-
-@final
-class ProcEvent:
-    @final
-    class Stopped:
-        """
-        A Stopped event.
-        """
-
-        ...
-
-    @final
-    class Crashed:
-        """
-        A Crashed event.
-        """
-
-        ...

--- a/python/monarch/mesh_controller.py
+++ b/python/monarch/mesh_controller.py
@@ -65,6 +65,7 @@ if TYPE_CHECKING:
     from monarch.actor import ProcMesh
 
 from monarch._rust_bindings.monarch_hyperactor.shape import Point
+from monarch._src.actor.actor_mesh import context, Instance
 from monarch._src.actor.device_utils import _local_device_count
 
 from monarch.common.client import Client
@@ -80,7 +81,7 @@ logger: Logger = logging.getLogger(__name__)
 class Controller(_Controller):
     def __init__(self, workers: "HyProcMesh") -> None:
         super().__init__()
-        self._mailbox: Mailbox = workers.client
+        self._mailbox: Mailbox = Instance._as_py(workers.client)._mailbox
         # Buffer for messages unrelated to debugging that are received while a
         # debugger session is active.
         self._non_debugger_pending_messages: deque[
@@ -312,7 +313,7 @@ def _cast_call_method_indirect(
         ),
         args_kwargs_tuple,
     )
-    endpoint._actor_mesh.cast(actor_msg, selection, endpoint._mailbox)
+    endpoint._actor_mesh.cast(actor_msg, selection, context().actor_instance._as_rust())
     return broker_id
 
 

--- a/python/tests/_monarch/test_mailbox.py
+++ b/python/tests/_monarch/test_mailbox.py
@@ -41,8 +41,7 @@ from monarch._rust_bindings.monarch_hyperactor.mailbox import (
     PortRef,
 )
 from monarch._rust_bindings.monarch_hyperactor.proc_mesh import ProcMesh
-from monarch._rust_bindings.monarch_hyperactor.selection import Selection
-from monarch._rust_bindings.monarch_hyperactor.shape import Shape
+from monarch._src.actor.actor_mesh import Instance
 
 S = TypeVar("S")
 U = TypeVar("U")
@@ -117,7 +116,7 @@ def _python_task_test(
 @_python_task_test
 async def test_accumulator() -> None:
     proc_mesh = await allocate()
-    mailbox: Mailbox = proc_mesh.client
+    mailbox: Mailbox = Instance._as_py(proc_mesh.client)._mailbox
 
     def my_accumulate(state: str, update: int) -> str:
         return f"{state}+{update}"
@@ -182,7 +181,9 @@ async def test_reducer() -> None:
 
     accumulator = Accumulator("", my_accumulate, my_reduce)
     receiver: PortReceiver
-    handle, receiver = proc_mesh.client.open_accum_port(accumulator)
+    handle, receiver = Instance._as_py(proc_mesh.client)._mailbox.open_accum_port(
+        accumulator
+    )
     port_ref = handle.bind()
 
     actor_mesh.cast(

--- a/python/tests/test_allocator.py
+++ b/python/tests/test_allocator.py
@@ -389,7 +389,7 @@ class TestRemoteAllocator(unittest.IsolatedAsyncioTestCase):
 
             with self.assertRaisesRegex(
                 Exception,
-                r"(?s)fail on init",
+                r"(?s)fail on init(?s)",
             ):
                 await actor_mesh.dummy.call()
 

--- a/python/tests/test_python_actors.py
+++ b/python/tests/test_python_actors.py
@@ -931,7 +931,7 @@ async def test_flush_logs_ipython() -> None:
                     lambda: mock_ipython,
                 ), unittest.mock.patch("monarch._src.actor.logging.IN_IPYTHON", True):
                     # Make sure we can register and unregister callbacks
-                    for i in range(3):
+                    for _ in range(3):
                         pm1 = await this_host().spawn_procs(per_host={"gpus": 2})
                         pm2 = await this_host().spawn_procs(per_host={"gpus": 2})
                         am1 = await pm1.spawn("printer", Printer)
@@ -1426,9 +1426,11 @@ class UndeliverableMessageSenderWithOverride(UndeliverableMessageSender):
     def _handle_undeliverable_message(
         self, message: UndeliverableMessageEnvelope
     ) -> bool:
-        self._receiver.receive_undeliverable.call_one(
-            message.sender(), message.dest(), message.error_msg()
-        ).get()
+        PythonTask.spawn_blocking(
+            self._receiver.receive_undeliverable.call_one(
+                message.sender(), message.dest(), message.error_msg()
+            ).get
+        )
         return True
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #1272

Implement basic `pyo3` integration (and python bindings when necessary) for v1 proc/actor mesh implementations. `v1::ActorMesh` and `v1::ActorMeshRef` actually don't need direct python bindings -- we can just have them implement `ActorMeshProtocol` and then wire them into the existing `PythonActorMesh`. `ActorMeshProtocol` has now also been updated to replace `new_with_shape` with `new_with_region`, though shapes are still used in many places in python for now. The only actually new python bindings required were for `Region` and `v1::PyProcMesh`. The latter has a similar, but not identical, interface as the existing `PyProcMesh`.

Some fun gotchas:
- To be compatible with v1, the root client now has to be a direct-addressed `Proc`, which means the `global_root_client()` function has to be async.
  - This also uncovered an issue with undeliverable message override in python actors where the context wasn't being set properly.
- There was a bug in the `Reference` parsing code for direct-addressed procs that had to be fixed.
- There was a race condition in `test_allocator` that had to be fixed. As a consequence, supervision events in python now provide more useful information.

Differential Revision: [D81949169](https://our.internmc.facebook.com/intern/diff/D81949169/)