### PR TITLE
: bootstrap: proc handle, proc status

### DIFF
--- a/hyperactor_mesh/src/proc_mesh/mesh_agent.rs
+++ b/hyperactor_mesh/src/proc_mesh/mesh_agent.rs
@@ -209,6 +209,25 @@ impl ProcMeshAgent {
     }
 
     pub(crate) async fn boot_v1(proc: Proc) -> Result<ActorHandle<Self>, anyhow::Error> {
+        // Spawn a LogClientActor in this proc. It aggregates and
+        // prints logs coming from our stdout/stderr (via the parent's
+        // log writers). This is the sink for all forwarded LogMessage
+        // traffic.
+        let log_client_ref = proc
+            .spawn("log_client", ())
+            .await?
+            .bind::<crate::logging::LogClientActor>();
+
+        // Spawn a LogForwardActor. It serves BOOTSTRAP_LOG_CHANNEL
+        // (set by the parent ProcManager) and forwards any LogMessage
+        // it receives there into the above LogClientActor. Together
+        // these give us structured log forwarding without blocking
+        // pipes.
+        let _log_fwd_ref = proc
+            .spawn("log_forwarder", log_client_ref.clone())
+            .await?
+            .bind::<crate::logging::LogForwardActor>();
+
         let agent = ProcMeshAgent {
             proc: proc.clone(),
             remote: Remote::collect(),


### PR DESCRIPTION
Summary:
this diff lands `ProcStatus` and `ProcHandle` as the lifecycle surface for procs launched under bootstrap. the handle pairs a `ProcId` with the `Child` and tracks status through controlled `mark_*` transitions (starting → running → stopping → stopped/killed/failed). transitions are checked, illegal moves leave the state unchanged, and return values make that explicit in tests.

this establishes the basic lifecycle API; the next step is to integrate these handles into `BootstrapProcManager` so that callers can observe and control proc lifecycles directly.

Differential Revision: D82827662


