### PR TITLE
Add occurred_at timestamp for ActorSupervisionEvent

### DIFF
--- a/hyperactor/Cargo.toml
+++ b/hyperactor/Cargo.toml
@@ -42,6 +42,7 @@ async-trait = "0.1.86"
 backoff = { version = "0.4.0", features = ["futures", "tokio"] }
 bincode = "1.3.3"
 bytes = { version = "1.10", features = ["serde"] }
+chrono = { version = "0.4.41", features = ["clock", "serde", "std"], default-features = false }
 cityhasher = "0.1.0"
 clap = { version = "4.5.42", features = ["derive", "env", "string", "unicode", "wrap_help"] }
 crc32fast = "1.4"

--- a/hyperactor/src/mailbox/undeliverable.rs
+++ b/hyperactor/src/mailbox/undeliverable.rs
@@ -173,15 +173,12 @@ pub fn supervise_undeliverable_messages_with<R, F>(
                     let actor_id = env.dest().actor_id().clone();
                     let headers = env.headers().clone();
 
-                    if let Err(e) = sink.send(ActorSupervisionEvent {
+                    if let Err(e) = sink.send(ActorSupervisionEvent::new(
                         actor_id,
-                        actor_status: ActorStatus::Failed(format!(
-                            "message not delivered: {}",
-                            env
-                        )),
-                        message_headers: Some(headers),
-                        caused_by: None,
-                    }) {
+                        ActorStatus::Failed(format!("message not delivered: {}", env)),
+                        Some(headers),
+                        None,
+                    )) {
                         tracing::warn!(
                             %e,
                             actor=%env.dest().actor_id(),

--- a/hyperactor/src/supervision.rs
+++ b/hyperactor/src/supervision.rs
@@ -10,8 +10,13 @@
 
 use std::fmt;
 use std::fmt::Debug;
+use std::time::SystemTime;
 
+use chrono::DateTime;
+use chrono::offset::Local;
 use derivative::Derivative;
+use hyperactor::clock::Clock;
+use hyperactor::clock::RealClock;
 use serde::Deserialize;
 use serde::Serialize;
 
@@ -27,6 +32,9 @@ use crate::reference::ActorId;
 pub struct ActorSupervisionEvent {
     /// The actor id of the child actor where the event is triggered.
     pub actor_id: ActorId,
+    /// The time when the event is triggered.
+    #[derivative(PartialEq = "ignore")]
+    pub occurred_at: SystemTime,
     /// Status of the child actor.
     pub actor_status: ActorStatus,
     /// If this event is associated with a message, the message headers.
@@ -37,6 +45,21 @@ pub struct ActorSupervisionEvent {
 }
 
 impl ActorSupervisionEvent {
+    /// Create a new supervision event. Timestamp is set to the current time.
+    pub fn new(
+        actor_id: ActorId,
+        actor_status: ActorStatus,
+        message_headers: Option<Attrs>,
+        caused_by: Option<Box<ActorSupervisionEvent>>,
+    ) -> Self {
+        Self {
+            actor_id,
+            occurred_at: RealClock.system_time_now(),
+            actor_status,
+            message_headers,
+            caused_by,
+        }
+    }
     /// Compute an actor status from this event, ensuring that "caused-by"
     /// events are included in failure states. This should be used as the
     /// actor status when reporting events to users.
@@ -52,14 +75,20 @@ impl std::error::Error for ActorSupervisionEvent {}
 
 impl fmt::Display for ActorSupervisionEvent {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}: {}", self.actor_id, self.actor_status)?;
+        write!(
+            f,
+            "{}: {} at {}",
+            self.actor_id,
+            self.actor_status,
+            DateTime::<Local>::from(self.occurred_at),
+        )?;
         if let Some(message_headers) = &self.message_headers {
             let headers = serde_json::to_string(&message_headers)
                 .expect("could not serialize message headers");
             write!(f, " (headers: {})", headers)?;
         }
         if let Some(caused_by) = &self.caused_by {
-            write!(f, ": caused by: {})", caused_by)?;
+            write!(f, ": (caused by: {})", caused_by)?;
         }
         Ok(())
     }

--- a/hyperactor_mesh/src/proc_mesh.rs
+++ b/hyperactor_mesh/src/proc_mesh.rs
@@ -30,6 +30,8 @@ use hyperactor::actor::RemoteActor;
 use hyperactor::actor::remote::Remote;
 use hyperactor::channel;
 use hyperactor::channel::ChannelAddr;
+use hyperactor::clock::Clock;
+use hyperactor::clock::RealClock;
 use hyperactor::context;
 use hyperactor::mailbox;
 use hyperactor::mailbox::BoxableMailboxSender;
@@ -712,12 +714,12 @@ impl ProcEvents {
                     for entry in self.actor_event_router.iter() {
                         // Make a dummy actor supervision event, all actors on the proc are affected if a proc stops.
                         // TODO(T231868026): find a better way to represent all actors in a proc for supervision event
-                        let event = ActorSupervisionEvent {
-                            actor_id: proc_id.actor_id("any", 0),
-                            actor_status: ActorStatus::Failed(format!("proc {} is stopped", proc_id)),
-                            message_headers: None,
-                            caused_by: None,
-                        };
+                        let event = ActorSupervisionEvent::new(
+                            proc_id.actor_id("any", 0),
+                            ActorStatus::Failed(format!("proc {} is stopped", proc_id)),
+                            None,
+                            None,
+                        );
                         tracing::debug!(name = "ActorSupervisionEventDelivery", event = ?event);
                         if entry.value().send(event.clone()).is_err() {
                             tracing::warn!(


### PR DESCRIPTION
Summary:
Adding the time at which an ActorSupervisionEvent occurred, which will be useful for investigations
and logs after-the-fact.

Reviewed By: mariusae

Differential Revision: D82683937


