### PR TITLE
Avoid unnecessary clones

### DIFF
--- a/monarch_hyperactor/src/actor_mesh.rs
+++ b/monarch_hyperactor/src/actor_mesh.rs
@@ -286,7 +286,7 @@ impl ActorMeshProtocol for PythonActorMeshImpl {
 
         instance_dispatch!(instance, |cx_instance| {
             self.try_inner()?
-                .cast(cx_instance, selection, message.clone())
+                .cast(cx_instance, selection, message)
                 .map_err(|err| PyException::new_err(err.to_string()))?;
         });
         Ok(())
@@ -453,7 +453,7 @@ impl ActorMeshProtocol for PythonActorMeshRef {
 
         instance_dispatch!(instance, |cx_instance| {
             self.inner
-                .cast(cx_instance, selection, message.clone())
+                .cast(cx_instance, selection, message)
                 .map_err(|err| PyException::new_err(err.to_string()))?;
         });
         Ok(())


### PR DESCRIPTION
Summary:
Remove unecessary clone calls which account for ~30% of cast time for 100mb messages (https://fburl.com/strobelight/um4q3zlb) and 10% for 100KB (https://fburl.com/strobelight/5xz5ngj5).

Before
 {F1982174448} 

After
 {F1982174440}

Differential Revision: D82990000


