### PR TITLE
[monarch] [1/n] jobs api: adding trait and local

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ monarch.egg-info/*
 python/monarch/monarch_controller
 
 .ipynb_checkpoints
+.monarch
 
 # Rust stuff
 target/

--- a/python/monarch/_src/job/job.py
+++ b/python/monarch/_src/job/job.py
@@ -1,0 +1,292 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import os
+import pickle
+import subprocess
+import sys
+import tempfile
+from abc import ABC, abstractmethod
+from typing import Dict, Optional, Sequence
+
+# note: the jobs api is intended as a library so it should
+# only be importing _public_ monarch API functions.
+from monarch._src.actor.host_mesh import HostMesh, this_host
+
+
+class JobState:
+    """
+    Job State
+
+    Currently this just has a property for each HostMesh.
+    """
+
+    def __init__(self, hosts: Dict[str, HostMesh]):
+        self._hosts = hosts
+
+    def __getattr__(self, attr: str) -> HostMesh:
+        try:
+            return self._hosts[attr]
+        except KeyError:
+            raise AttributeError(attr)
+
+
+class JobTrait(ABC):
+    def __init__(self):
+        super().__init__()
+        self._created = False
+
+    """
+    A job object represents a specification and set of machines that can be
+    used to create monarch HostMeshes and run actors on them.
+
+    A job object comprises a declarative specification for the job and
+    optionally the job's *state*. The `apply()` operation applies the job's
+    specification to the scheduler, creating or updating the job as
+    required. If the job exists and there are no changes in its
+    specification, `apply()` is a no-op. Once applied, we can query the
+    job's *state*. The state of the job contains the set of hosts currently
+    allocated, arranged into the requested host meshes. Conceptually, the
+    state can be retrieved directly from the scheduler, but we may also
+    cache snapshots of the state locally.
+
+    The state is the interface to the job consumed by Monarch: Monarch
+    bootstraps host meshes from the state alone, and is not concerned with
+    any other aspect of the job.
+
+    Conceptually, dynamic jobs (e.g., to enable consistently fast restarts,
+    elasticity, etc.), Monarch can simply poll the state for changes. In
+    practice we'd develop notification mechanisms so that polling isn't
+    jobs can also be "templates". But the model also supports having the job
+    job's *specification* is. The model allows for late resolution of some
+    parts of the specification. For example, a job that does not specify a
+    name may instead resolve the name on the first `apply()`. In this way,
+    jobs can also be "templates". But the model also supports having the job
+    refer to a *specific instance* by including the resolved job name in the
+    specification itself.
+    """
+
+    def apply(self, client_script: Optional[str] = None):
+        """
+        Request the job as specified is brought into existence or modified to the current specification/
+        The worker machines launched in the job should call run_worker_forever to join the job.
+
+        Calling apply when the job as specified has already been applied is a no-op.
+
+        If client_script is not None, then creating the job arranges for the job to run train.py as the client.
+
+        Implementation note: To batch launch the job, we will first write .monarch/job_state.pkl with a Job
+        that instructs the client to connect to the job that it is running in.
+        Then we will schedule the job including that .monarch/job_state.pkl.
+        When the client calls `.state()`, it will find the .monarch/job_state.pkl and connect to it.
+        """
+        if not self._created:
+            self._create(client_script)
+            self._created = True
+
+    def state(self, cached_path: Optional[str] = ".monarch/job_state.pkl") -> JobState:
+        """
+        Get the current state of this job, containing the host mesh objects of its requires that were requested
+            host_meshes = self.state()
+            # properties of state hold the requested host meshes:
+
+            host_meshes.trainers
+            host_meshes.dataloaders
+            This is a dictionary so that meshes can hold different machine types.
+
+            cached_path: if cached_path is not None and the job has yet to be applied,
+            we will first check `cached_path` for an existing created job state.
+            If it exists  and `saved_job.can_run(self)`, we will connect to the cached job.
+            Otherwise, we will apply this job and connect to it, saving the job in `cached_path` if it is not None.
+
+
+        Raises: JobExpiredException - when the job has finished and this connection cannot be made.
+        """
+        # this is implemented uniquely for each scheduler, but it will ultimately make
+        # calls to attach_to_workers and return the HostMeshes
+        if self._created:
+            job = self
+        else:
+            job = self._load_cached(cached_path)
+            if job is None:
+                job = self
+                self.apply()
+                if cached_path is not None:
+                    # Create the directory for cached_path if it doesn't exist
+                    cache_dir = os.path.dirname(cached_path)
+                    if cache_dir:  # Only create if there's a directory component
+                        os.makedirs(cache_dir, exist_ok=True)
+                    self.dump(cached_path)
+
+        return job._state()
+
+    def _load_cached(self, cached_path: Optional[str]) -> "Optional[JobTrait]":
+        if cached_path is None:
+            return None
+        try:
+            job = job_load(cached_path)
+        except FileNotFoundError:
+            return None
+        if not job.can_run(self):
+            return None
+        return job
+
+    def dump(self, filename: str):
+        """
+            Save job to a file. Helper to make it more apparent
+        Jobs are serializable across processes.
+        """
+        # Ensure the directory exists
+        directory = os.path.dirname(filename)
+        if directory:  # Only create if there's a directory component
+            os.makedirs(directory, exist_ok=True)
+
+        with open(filename, "wb") as file:
+            # @lint-ignore PYTHONPICKLEISBAD
+            pickle.dump(self, file)
+
+    def dumps(self) -> bytes:
+        # @lint-ignore PYTHONPICKLEISBAD
+        return pickle.dumps(self)
+
+    @abstractmethod
+    def _state(self) -> JobState: ...
+
+    @abstractmethod
+    def _create(self, client_script: Optional[str]): ...
+
+    @abstractmethod
+    def can_run(self, spec: "JobTrait") -> bool:
+        """
+        Is this job capable of running the job spec? This is used to check if a
+        cached job can be used to run `spec` instead of creating a new reserveration.
+
+        It is also used by the batch run infrastructure to indicate that the batch job can certainly run itself.
+        """
+
+        ...
+
+    @abstractmethod
+    def kill(self):
+        """
+        Stop the job/reservation.
+        """
+        ...
+
+
+def job_loads(data: bytes) -> JobTrait:
+    # @lint-ignore PYTHONPICKLEISBAD
+    return pickle.loads(data)
+
+
+def job_load(filename: str) -> JobTrait:
+    with open(filename, "rb") as file:
+        # @lint-ignore PYTHONPICKLEISBAD
+        job: "JobTrait" = pickle.load(file)
+        return job
+
+
+class LocalJob(JobTrait):
+    def __init__(self, hosts: Sequence["str"] = ("hosts",)):
+        """
+        Job that is just running on the local host.
+        This job will just call this_host() for each host mesh requested.
+        It is used as standin in config so a job can be configured to either use
+        a remote or local job just by changing the job configuration.
+        """
+        self._host_names = hosts
+        # if launched with client_script, the proc corresponding to the
+        # locally running client, and the log_dir it is writing to.
+        self._proc: Optional[subprocess.Popen] = None
+        self._log_dir: Optional[str] = None
+        super().__init__()
+
+    def kill(self):
+        pass
+
+    def can_run(self, spec: "JobTrait"):
+        """
+        Local jobs are the same regardless of what was saved, so just
+        use the spec, which has the correct 'hosts' sequence.
+        """
+        return False
+
+    def _state(self) -> JobState:
+        return JobState({k: this_host() for k in self._host_names})
+
+    def _create(self, client_script: Optional[str]):
+        if client_script is None:
+            return  # noop, because LocalJob always 'exists'
+
+        b = _BatchLocalJob(self._host_names)
+        b.dump(".monarch/job_state.pkl")
+
+        log_dir = self._setup_log_directory()
+        self._run_client_as_daemon(client_script, log_dir)
+
+        print(f"Started client script {client_script} with PID: {self.process.pid}")
+        print(f"Logs available at: {log_dir}")
+
+    def _setup_log_directory(self) -> str:
+        """Create a log directory for the batch job."""
+        log_base_dir = ".monarch/logs"
+        os.makedirs(log_base_dir, exist_ok=True)
+        # Create a unique subdirectory for this job run
+        self._log_dir = tempfile.mkdtemp(prefix="job_", dir=log_base_dir)
+        return self._log_dir
+
+    def _run_client_as_daemon(self, client_script: str, log_dir: str) -> None:
+        """
+        Run the client script as a daemon process.
+
+        Args:
+            client_script: Path to the client script to run
+            log_dir: Directory to store log files
+
+        Returns:
+            The process ID of the daemon
+        """
+        # Prepare log files
+        stdout_log = os.path.join(log_dir, "stdout.log")
+        stderr_log = os.path.join(log_dir, "stderr.log")
+
+        # Create environment with MONARCH_BATCH_JOB=1
+        env = os.environ.copy()
+        env["MONARCH_BATCH_JOB"] = "1"
+
+        # Open log files
+        with open(stdout_log, "w") as stdout_file, open(stderr_log, "w") as stderr_file:
+            # Start the process with Python interpreter
+            self._proc = subprocess.Popen(
+                [sys.executable, client_script],
+                env=env,
+                stdout=stdout_file,
+                stderr=stderr_file,
+                # Detach the process from parent (daemonize)
+                start_new_session=True,
+            )
+
+    @property
+    def process(self):
+        if self._proc is None:
+            raise ValueError("no local batch job")
+        return self._proc
+
+
+class _BatchTrait:
+    """
+    Mixin that can be written to .monarch/job_state.pkl so that a batch job
+    always load its connection information from job_state.pkl.
+    """
+
+    def can_run(self, spec: JobTrait):
+        if os.environ.get("MONARCH_BATCH_JOB", None) == "1":
+            return True
+        return False
+
+
+class _BatchLocalJob(_BatchTrait, LocalJob):
+    pass

--- a/python/monarch/job.py
+++ b/python/monarch/job.py
@@ -1,0 +1,11 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Re-export the job module directly
+from monarch._src.job.job import job_load, job_loads, JobState, JobTrait, LocalJob
+
+# Define exports
+__all__ = ["JobTrait", "job_load", "job_loads", "JobState", "LocalJob"]

--- a/python/tests/job_train.py
+++ b/python/tests/job_train.py
@@ -1,0 +1,18 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Directly import to avoid import issues in Buck
+from monarch._src.job.job import LocalJob
+
+if __name__ == "__main__":
+    job = LocalJob()
+    state = job.state()
+
+    # Check which hosts are available in the state
+    print(f"hosts {getattr(state, 'hosts', None) is not None}")
+    print(
+        f"batch_launched_hosts {getattr(state, 'batch_launched_hosts', None) is not None}"
+    )

--- a/python/tests/test_job.py
+++ b/python/tests/test_job.py
@@ -1,0 +1,405 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import os
+import subprocess
+import sys
+import tempfile
+from typing import cast, Dict, Optional, Sequence
+
+import pytest
+
+# Import directly from _src since job module isn't properly exposed
+from monarch._src.job.job import job_load, job_loads, JobState, JobTrait, LocalJob
+
+from monarch.actor import HostMesh
+
+
+class MockJobTrait(JobTrait):
+    """
+    Mock implementation of JobTrait for testing purposes.
+    """
+
+    def __init__(self, host_names: Sequence[str] = ("default",), compatible_specs=None):
+        """
+        Initialize a mock job trait.
+
+        Args:
+            host_names: Names of host meshes to create in the state
+            compatible_specs: List of specs this job is compatible with, or None if compatible with all
+        """
+        super().__init__()
+        self._host_names = host_names
+        self._compatible_specs = compatible_specs
+        # Track mock state for testing
+        self.create_called = False
+        self.create_args = None
+        self.kill_called = False
+
+    def _state(self) -> JobState:
+        """Return a mock job state with fake host meshes."""
+        # Create a mock host mesh for each host name
+        mock_hosts: Dict[str, HostMesh] = {}
+        for name in self._host_names:
+            # Using a simple object that mimics HostMesh for testing
+            class MockHostMesh:
+                def __init__(self, name):
+                    self.name = name
+
+                def __repr__(self):
+                    return f"MockHostMesh({self.name})"
+
+            mock_hosts[name] = cast("HostMesh", MockHostMesh(name))
+
+        return JobState(mock_hosts)
+
+    def _create(self, client_script: Optional[str] = None):
+        """Mock implementation that tracks the creation call."""
+        self.create_called = True
+        self.create_args = client_script
+
+    def can_run(self, spec: "JobTrait") -> bool:
+        """
+        Check if this mock job can run the given spec.
+
+        If compatible_specs was provided, check if the spec is in the list.
+        Otherwise, just return True.
+        """
+        if self._compatible_specs is None:
+            return True
+        return spec in self._compatible_specs
+
+    def kill(self):
+        """Mock implementation that tracks the kill call."""
+        self.kill_called = True
+
+
+def test_apply():
+    """Test applying a job."""
+    job = MockJobTrait()
+
+    # Initial state - create_called should be False
+    assert not job.create_called
+
+    # Apply the job
+    job.apply()
+
+    # After apply(), create_called should be True
+    assert job.create_called
+
+    # Applying again shouldn't call _create again
+    job.create_called = False
+    job.apply()
+    assert not job.create_called
+
+
+def test_state_after_apply():
+    """Test getting state from an already applied job."""
+    job = MockJobTrait(host_names=["trainers", "dataloaders"])
+
+    # Apply the job first
+    job.apply()
+
+    # Get the state
+    state = job.state()
+
+    # Check that the state has the expected host meshes
+    assert hasattr(state, "trainers")
+    assert hasattr(state, "dataloaders")
+
+
+def test_state_from_cache():
+    """Test loading job state from a compatible cached job."""
+    # Create a job that will be saved to the cache
+    original_job = MockJobTrait(host_names=["trainers", "evaluators"])
+    original_job.apply()
+
+    # Create a temp file for caching
+    with tempfile.NamedTemporaryFile(delete=False) as tmp:
+        cache_path = tmp.name
+
+    try:
+        # Save the original job to the cache
+        original_job.dump(cache_path)
+
+        # Create a new job that should use the cached job
+        new_job = MockJobTrait()
+
+        # Get state using the cache
+        state = new_job.state(cached_path=cache_path)
+
+        # Check that state has the host meshes from the cached job
+        assert hasattr(state, "trainers")
+        assert hasattr(state, "evaluators")
+
+        # Since we used the cached job, _create should not have been called
+        assert not new_job.create_called
+
+    finally:
+        # Clean up the temp file
+        if os.path.exists(cache_path):
+            os.unlink(cache_path)
+
+
+def test_incompatible_cache():
+    """Test behavior when cache contains an incompatible job."""
+    # Create a job that will be saved to the cache
+    # This job is compatible with nothing (empty compatible_specs list)
+    cached_job = MockJobTrait(compatible_specs=[])
+    cached_job.apply()
+
+    # Create a temp file for caching
+    with tempfile.NamedTemporaryFile(delete=False) as tmp:
+        cache_path = tmp.name
+
+    try:
+        # Save the cached job
+        cached_job.dump(cache_path)
+
+        # Create a new job that should NOT use the cached job
+        new_job = MockJobTrait(host_names=["workers"])
+
+        # Get state using the cache - this should not use the cached job
+        state = new_job.state(cached_path=cache_path)
+
+        # The new job should have been applied
+        assert new_job.create_called
+
+        # State should have the host meshes from the new job, not the cached one
+        assert hasattr(state, "workers")
+
+        # Try accessing the attributes - they shouldn't exist
+        try:
+            state.trainers
+            raise AssertionError("state should not have trainers attribute")
+        except (KeyError, AttributeError):
+            pass
+
+        try:
+            state.evaluators
+            raise AssertionError("state should not have evaluators attribute")
+        except (KeyError, AttributeError):
+            pass
+
+    finally:
+        # Clean up the temp file
+        if os.path.exists(cache_path):
+            os.unlink(cache_path)
+
+
+def test_state_no_cache():
+    """Test getting state when no cache path is provided."""
+    job = MockJobTrait()
+
+    # Get state without providing a cache path
+    state = job.state(cached_path=None)
+
+    # The job should have been applied
+    assert job.create_called
+
+    # State should have the default host mesh
+    assert hasattr(state, "default")
+
+
+def test_dump_load():
+    """Test saving a job to a file and loading it back."""
+    # Create and apply a job
+    original_job = MockJobTrait(host_names=["gpu_nodes"])
+    original_job.apply()
+
+    # Create a temp file for saving the job
+    with tempfile.NamedTemporaryFile(delete=False) as tmp:
+        job_path = tmp.name
+
+    try:
+        # Save the job to a file
+        original_job.dump(job_path)
+
+        # Load the job directly from the file
+        loaded_job = job_load(job_path)
+
+        # Get state from the loaded job
+        state = loaded_job.state()
+
+        # Check that the state has the expected host mesh
+        assert hasattr(state, "gpu_nodes")
+
+    finally:
+        # Clean up the temp file
+        if os.path.exists(job_path):
+            os.unlink(job_path)
+
+
+def test_dumps_loads():
+    """Test serializing and deserializing a job using dumps/loads."""
+    original_job = MockJobTrait(host_names=["trainers", "parameter_servers"])
+    original_job.apply()
+
+    # Serialize the job to bytes
+    serialized = original_job.dumps()
+
+    # Deserialize the job
+    loaded_job = job_loads(serialized)
+
+    # Get state from the loaded job
+    state = loaded_job.state()
+
+    # Check that the state has the expected host meshes
+    assert hasattr(state, "trainers")
+    assert hasattr(state, "parameter_servers")
+
+
+def test_cache_write():
+    """Test that job is written to cache when state is called with a cache path."""
+    job = MockJobTrait()
+
+    # Create a temp file for caching
+    with tempfile.NamedTemporaryFile(delete=False) as tmp:
+        cache_path = tmp.name
+        # Delete it so we can check if it gets created
+        os.unlink(cache_path)
+
+    try:
+        # Get state with a cache path - this should apply the job and write to cache
+        job.state(cached_path=cache_path)
+
+        # Check that the cache file was created
+        assert os.path.exists(cache_path)
+
+        # Load the job from the cache
+        cached_job = job_load(cache_path)
+
+        # Get state from the loaded job
+        cached_state = cached_job.state()
+
+        # Check that it has the expected host mesh
+        assert hasattr(cached_state, "default")
+
+    finally:
+        # Clean up the temp file
+        if os.path.exists(cache_path):
+            os.unlink(cache_path)
+
+
+def test_kill():
+    """Test the kill method."""
+    job = MockJobTrait()
+
+    # Kill shouldn't have been called yet
+    assert not job.kill_called
+
+    # Call kill
+    job.kill()
+
+    # kill_called should now be True
+    assert job.kill_called
+
+
+# Tests for LocalJob implementation
+
+
+def test_local_job():
+    """Test LocalJob initialization and state access."""
+    # Create a job
+    job = LocalJob(hosts=["trainers", "workers", "parameter_servers"])
+
+    # Apply the job
+    job.apply()
+
+    # Get the state
+    state = job.state()
+
+    # Check that the state has all the host meshes
+    assert hasattr(state, "trainers")
+    assert hasattr(state, "workers")
+    assert hasattr(state, "parameter_servers")
+
+
+def test_local_job_default_hosts():
+    """Test that LocalJob works with default host names."""
+    # Create a job with default hosts
+    job = LocalJob()
+
+    # Apply the job
+    job.apply()
+
+    # Get the state
+    state = job.state()
+
+    # Check that the state has the default "hosts" mesh
+    assert hasattr(state, "hosts")
+
+
+def test_local_job_compatibility():
+    """Test the can_run method of LocalJob."""
+    # LocalJob.can_run always returns False as per implementation
+    job = LocalJob()
+    mock_job = MockJobTrait()
+
+    # LocalJob should not be able to run any spec
+    assert job.can_run(mock_job) is False
+
+
+train_script = os.path.join(os.path.dirname(__file__), "job_train.py")
+
+
+def test_train_script_job_state_regular():
+    """
+    Test that the train.py script picks up the default 'hosts' in regular mode.
+    """
+    # Path to train.py
+    if "FB_XAR_INVOKED_NAME" in os.environ:
+        pytest.skip("buck")
+
+    with tempfile.TemporaryDirectory():
+        # Run train.py directly (no batch mode) in the temp directory
+        env = os.environ.copy()
+        if "MONARCH_BATCH_JOB" in env:
+            del env["MONARCH_BATCH_JOB"]  # Ensure batch mode is off
+
+        # Set the working directory to the temp directory
+        # Execute train.py
+        result = subprocess.run(
+            [sys.executable, train_script],
+            env=env,
+            capture_output=True,
+            text=True,
+        )
+
+        # Print any error output for debugging
+        if result.returncode != 0:
+            print(f"Script failed with stderr: {result.stderr}")
+            print(f"Script stdout: {result.stdout}")
+
+        # Check that the script executed successfully
+        assert result.returncode == 0
+
+        # Check output for hosts mesh existence
+        assert "hosts True" in result.stdout
+        # In non-batch mode, batch_launched_hosts shouldn't be available
+        assert "batch_launched_hosts False" in result.stdout
+
+
+def test_train_script_job_state_batch():
+    """
+    Test that the train.py script picks up the 'batch_launched_hosts' in batch mode.
+    """
+    if "FB_XAR_INVOKED_NAME" in os.environ:
+        pytest.skip("buck")
+
+    try:
+        job = LocalJob(("batch_launched_hosts",))
+        job.apply(client_script=train_script)
+        assert 0 == job.process.wait()
+        assert (
+            "batch_launched_hosts True"
+            in open(os.path.join(job._log_dir, "stdout.log"), "r").read()
+        )
+        # look in job._log_dir for the stdout file which will have the batch_lauched_hosts True
+    finally:
+        # Clean up
+        if os.path.exists(".monarch/job_state.pkl"):
+            os.unlink(".monarch/job_state.pkl")


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #1301

Beginning the implementation of RFC: https://docs.google.com/document/d/1QJ1WeRYjDElJ_bySgekWVMujdCXc3oIJRB0Cvkjj-UI/edit?tab=t.0

This diff adds:

* The Jobs Trait
* LocalJob

The LocalJob can schedule as if it were a batch job with .apply taking a client_script. This is useful for testing and for consistency with remote batch scheduling but probably won't get much use.

Next up is to pull in the code from monarch.tools so that we can use the Jobs api with the torchx launchers we already support.

Differential Revision: [D83015058](https://our.internmc.facebook.com/intern/diff/D83015058/)