### PR TITLE
Do not log CRC

### DIFF
--- a/hyperactor/src/mailbox.rs
+++ b/hyperactor/src/mailbox.rs
@@ -1153,8 +1153,7 @@ impl MailboxSender for MailboxClient {
         envelope: MessageEnvelope,
         return_handle: PortHandle<Undeliverable<MessageEnvelope>>,
     ) {
-        // tracing::trace!(name = "post", "posting message to {}", envelope.dest);
-        tracing::event!(target:"messages", tracing::Level::DEBUG, "crc"=envelope.data.crc(), "size"=envelope.data.len(), "sender"= %envelope.sender, "dest" = %envelope.dest.0, "port"= envelope.dest.1, "message_type" = envelope.data.typename().unwrap_or("unknown"), "send_message");
+        tracing::event!(target:"messages", tracing::Level::DEBUG,  "size"=envelope.data.len(), "sender"= %envelope.sender, "dest" = %envelope.dest.0, "port"= envelope.dest.1, "message_type" = envelope.data.typename().unwrap_or("unknown"), "send_message");
         if let Err(mpsc::error::SendError((envelope, return_handle))) =
             self.buffer.send((envelope, return_handle))
         {


### PR DESCRIPTION
Summary:
Getting CRC of a messages is a costly operation, and cost scales with message size. 

e.g. With a 100Mb payload, crc represents 10% of execution time
 {F1982206757} 

Bench with 1Mb
```
start = time.time()
    with TRACER.start_as_current_span("scheduling", METER):
        while len(futs) < 10000:
            with TRACER.start_as_current_span("call", METER):
                fut = await actor_mesh.sleep.call(payload)
            futs.append(fut)

    elapsed = time.time() - start
    print(f"scheduled: {elapsed}")
```

Before: 21.569
After: 19.955 (5% improvement)

Differential Revision: D83083775


