### PR TITLE
: bootstrap: address some snagging issues

### DIFF
--- a/hyperactor_mesh/Cargo.toml
+++ b/hyperactor_mesh/Cargo.toml
@@ -58,6 +58,7 @@ enum-as-inner = "0.6.0"
 erased-serde = "0.3.27"
 futures = { version = "0.3.31", features = ["async-await", "compat"] }
 hostname = "0.3"
+humantime = "2.1"
 hyperactor = { version = "0.0.0", path = "../hyperactor" }
 hyperactor_mesh_macros = { version = "0.0.0", path = "../hyperactor_mesh_macros" }
 hyperactor_telemetry = { version = "0.0.0", path = "../hyperactor_telemetry" }


### PR DESCRIPTION
Summary: this diff removes the `Agent` associated type from `ProcManager` and replaces it with a `ManagerAgent<M>` type alias via `ProcHandle::Agent`. `Host::spawn` now returns an `ActorRef<ManagerAgent<M>> `and the redundant `type Agent = …` lines in the local and bootstrap managers are dropped. a `Display` implementation is added for `ProcStatus` that prints pid and uptime using humantime, and corresponding display tests are introduced. documentation and error text are updated to refer to `Ready` rather than `Running`. humantime is added as a dependency in BUCK and Cargo. cleanups include dropping an unused variable and trimming some test imports.

Differential Revision: D83110957


