### PR TITLE
fix test_torchx_remote_alloc_initializer_with_match_label

### DIFF
--- a/python/tests/test_allocator.py
+++ b/python/tests/test_allocator.py
@@ -321,7 +321,7 @@ class TestRemoteAllocator(unittest.IsolatedAsyncioTestCase):
             actor = proc_mesh.spawn("test_actor", TestActor)
 
             values = await actor.compute_world_size.call(
-                master_addr="0.0.0.0",
+                master_addr="localhost",
                 master_port=get_free_port(),
             )
 
@@ -547,10 +547,10 @@ class TestRemoteAllocator(unittest.IsolatedAsyncioTestCase):
             actor_b = proc_mesh_b.spawn("actor_b", TestActor)
 
             results_a = await actor_a.compute_world_size.call(
-                master_addr="0.0.0.0", master_port=get_free_port()
+                master_addr="localhost", master_port=get_free_port()
             )
             results_b = await actor_b.compute_world_size.call(
-                master_addr="0.0.0.0", master_port=get_free_port()
+                master_addr="localhost", master_port=get_free_port()
             )
 
             self.assert_computed_world_size(results_a, 2)  # a is a 1x2 mesh
@@ -604,12 +604,12 @@ class TestRemoteAllocator(unittest.IsolatedAsyncioTestCase):
                     name="x",
                     num_hosts=1,
                     transport="tcp",
-                    hostnames=["0.0.0.0"],
+                    hostnames=["localhost"],
                 )
             ],
         )
         port = get_free_port()
-        with remote_process_allocator(addr=f"tcp!{get_sockaddr('0.0.0.0', port)}"):
+        with remote_process_allocator(addr=f"tcp!{get_sockaddr('localhost', port)}"):
             with mock.patch(SERVER_READY, return_value=server):
                 initializer = TorchXRemoteAllocInitializer("local:///test", port=port)
                 allocator = RemoteAllocator(
@@ -620,7 +620,7 @@ class TestRemoteAllocator(unittest.IsolatedAsyncioTestCase):
                 proc_mesh = ProcMesh.from_alloc(alloc)
                 actor = proc_mesh.spawn("test_actor", TestActor)
                 results = await actor.compute_world_size.call(
-                    master_addr="0.0.0.0", master_port=get_free_port()
+                    master_addr="localhost", master_port=get_free_port()
                 )
                 self.assert_computed_world_size(results, 4)  # 1x4 mesh
 
@@ -634,12 +634,12 @@ class TestRemoteAllocator(unittest.IsolatedAsyncioTestCase):
                     name="x",
                     num_hosts=1,
                     transport="tcp",
-                    hostnames=["0.0.0.0"],
+                    hostnames=["localhost"],
                 )
             ],
         )
         port = get_free_port()
-        with remote_process_allocator(addr=f"tcp!{get_sockaddr('0.0.0.0', port)}"):
+        with remote_process_allocator(addr=f"tcp!{get_sockaddr('localhost', port)}"):
             with mock.patch(SERVER_READY, return_value=server):
                 initializer = TorchXRemoteAllocInitializer("local:///test", port=port)
                 allocator = RemoteAllocator(
@@ -658,7 +658,7 @@ class TestRemoteAllocator(unittest.IsolatedAsyncioTestCase):
                 proc_mesh = ProcMesh.from_alloc(alloc)
                 actor = proc_mesh.spawn("test_actor", TestActor)
                 results = await actor.compute_world_size.call(
-                    master_addr="0.0.0.0", master_port=get_free_port()
+                    master_addr="localhost", master_port=get_free_port()
                 )
                 self.assert_computed_world_size(results, 3)  # 1x3 mesh
 


### PR DESCRIPTION
Summary:
Some hosts may not have ipv4 addresses enabled, so following error could happen
```
/re_cwd/buck-out/v2/gen/fbcode/8e752ec50d5ee6f3/monarch/python/tests/__test_allocator__/test_allocator#link-tree/monarch/tools/network.py:43: resolved AF_INET address `0.0.0.0:36915` for `0.0.0.0:36915`
/re_cwd/buck-out/v2/gen/fbcode/8e752ec50d5ee6f3/monarch/python/tests/__test_allocator__/test_allocator#link-tree/monarch/tools/network.py:53: no AF_INET6 address that can bind TCP sockets for `0.0.0.0:36915` (error: [Errno -9] Address family for hostname not supported)
/re_cwd/buck-out/v2/gen/fbcode/8e752ec50d5ee6f3/monarch/python/tests/__test_allocator__/test_allocator#link-tree/monarch/tools/network.py:43: resolved AF_INET address `0.0.0.0:36915` for `0.0.0.0:36915`
/re_cwd/buck-out/v2/gen/fbcode/8e752ec50d5ee6f3/monarch/python/tests/__test_allocator__/test_allocator#link-tree/monarch/_src/actor/allocator.py:255: initializing alloc on remote allocator addresses: ['tcp!0.0.0.0:36915']
[-]E0924 09:15:29.915414 373140 fbcode/monarch/hyperactor/src/channel.rs:620] error:listen: tcp:[2401:db00:256c:806:face:0:247:0]:0 Cannot assign requested address (os error 99)
```

Move away from hardcoded ipv4 addresses.

Reviewed By: pablorfb-meta

Differential Revision: D83172163


