### PR TITLE
[hyperactor] mesh: enable local allocs to run as host meshes

### DIFF
--- a/hyperactor/src/host.rs
+++ b/hyperactor/src/host.rs
@@ -47,6 +47,8 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use futures::Future;
+use nix::sys::signal::Signal::SIGTERM;
+use nix::sys::signal::Signal::SIGTTOU;
 use tokio::process::Child;
 use tokio::process::Command;
 use tokio::sync::Mutex;
@@ -309,18 +311,18 @@ pub trait ProcManager {
 
 /// A ProcManager that spawns into local (in-process) procs. Used for
 /// testing.
-pub struct LocalProcManager<A: Actor> {
+pub struct LocalProcManager<S> {
     procs: Arc<Mutex<HashMap<ProcId, Proc>>>,
-    params: A::Params,
+    spawn: S,
 }
 
-impl<A: Actor> LocalProcManager<A> {
+impl<S> LocalProcManager<S> {
     /// Create a new in-process proc manager with the given agent
     /// params.
-    pub fn new(params: A::Params) -> Self {
+    pub fn new(spawn: S) -> Self {
         Self {
             procs: Arc::new(Mutex::new(HashMap::new())),
-            params,
+            spawn,
         }
     }
 }
@@ -372,10 +374,11 @@ impl<A: Actor + RemoteActor> ProcHandle for LocalHandle<A> {
 }
 
 #[async_trait]
-impl<A> ProcManager for LocalProcManager<A>
+impl<A, S, F> ProcManager for LocalProcManager<S>
 where
     A: Actor + RemoteActor + Binds<A>,
-    A::Params: Sync + Clone,
+    F: Future<Output = anyhow::Result<ActorHandle<A>>> + Send,
+    S: Fn(Proc) -> F + Sync,
 {
     type Agent = A;
     type Handle = LocalHandle<A>;
@@ -400,8 +403,7 @@ where
             .await
             .insert(proc_id.clone(), proc.clone());
         let _handle = proc.clone().serve(rx);
-        let agent_handle = proc
-            .spawn("agent", self.params.clone())
+        let agent_handle = (self.spawn)(proc)
             .await
             .map_err(|e| HostError::AgentSpawnFailure(proc_id.clone(), e))?;
 
@@ -669,7 +671,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_basic() {
-        let proc_manager = LocalProcManager::<()>::new(());
+        let proc_manager =
+            LocalProcManager::new(|proc: Proc| async move { proc.spawn::<()>("agent", ()).await });
         let procs = Arc::clone(&proc_manager.procs);
         let (mut host, _handle) =
             Host::serve(proc_manager, ChannelAddr::any(ChannelTransport::Local))

--- a/hyperactor/src/reference.rs
+++ b/hyperactor/src/reference.rs
@@ -702,7 +702,8 @@ impl FromStr for ActorId {
 #[derive(Debug, Named)]
 pub struct ActorRef<A: RemoteActor> {
     pub(crate) actor_id: ActorId,
-    phantom: PhantomData<A>,
+    // fn() -> A so that the struct remains Send
+    phantom: PhantomData<fn() -> A>,
 }
 
 impl<A: RemoteActor> ActorRef<A> {

--- a/hyperactor_macros/src/lib.rs
+++ b/hyperactor_macros/src/lib.rs
@@ -1594,7 +1594,6 @@ pub fn export(attr: TokenStream, item: TokenStream) -> TokenStream {
 
     if spawn {
         expanded.extend(quote! {
-
             hyperactor::remote!(#data_type_name);
         });
     }

--- a/hyperactor_mesh/src/alloc.rs
+++ b/hyperactor_mesh/src/alloc.rs
@@ -265,6 +265,12 @@ pub trait Alloc {
         }
         Ok(())
     }
+
+    /// Returns whether the alloc is a local alloc: that is, its procs are
+    /// not independent processes, but just threads in the selfsame process.
+    fn is_local(&self) -> bool {
+        return false;
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]

--- a/hyperactor_mesh/src/alloc/local.rs
+++ b/hyperactor_mesh/src/alloc/local.rs
@@ -278,6 +278,10 @@ impl Alloc for LocalAlloc {
         self.todo_tx.send(Action::Stopped).unwrap();
         Ok(())
     }
+
+    fn is_local(&self) -> bool {
+        true
+    }
 }
 
 impl Drop for LocalAlloc {

--- a/hyperactor_mesh/src/bootstrap.rs
+++ b/hyperactor_mesh/src/bootstrap.rs
@@ -45,6 +45,7 @@ use tokio::sync::watch;
 use crate::logging::create_log_writers;
 use crate::proc_mesh::mesh_agent::ProcMeshAgent;
 use crate::v1;
+use crate::v1::host_mesh::mesh_agent::HostAgentHost;
 use crate::v1::host_mesh::mesh_agent::HostMeshAgent;
 
 pub const BOOTSTRAP_ADDR_ENV: &str = "HYPERACTOR_MESH_BOOTSTRAP_ADDR";
@@ -238,7 +239,7 @@ impl Bootstrap {
                 let host_mesh_agent = ok!(host
                     .system_proc()
                     .clone()
-                    .spawn::<HostMeshAgent>("agent", host)
+                    .spawn::<HostMeshAgent>("agent", HostAgentHost::Process(host))
                     .await);
 
                 tracing::info!(

--- a/hyperactor_mesh/src/v1/host_mesh.rs
+++ b/hyperactor_mesh/src/v1/host_mesh.rs
@@ -128,12 +128,13 @@ impl HostMesh {
     /// ```                                  
     pub async fn allocate(
         cx: &impl context::Actor,
-        alloc: impl Alloc + Send + Sync + 'static,
+        alloc: Box<dyn Alloc + Send + Sync + 'static>,
         name: &str,
     ) -> v1::Result<Self> {
         let transport = alloc.transport();
         let extent = alloc.extent().clone();
-        let proc_mesh = ProcMesh::allocate(cx, Box::new(alloc), name).await?;
+        let is_local = alloc.is_local();
+        let proc_mesh = ProcMesh::allocate(cx, alloc, name).await?;
         let name = Name::new(name);
 
         // TODO: figure out how to deal with MAST allocs. It requires an extra dimension,
@@ -145,7 +146,7 @@ impl HostMesh {
             .spawn::<HostMeshAgentProcMeshTrampoline>(
                 cx,
                 "host_mesh_trampoline",
-                &(transport, mesh_agents.bind()),
+                &(transport, mesh_agents.bind(), is_local),
             )
             .await?;
 
@@ -390,89 +391,74 @@ mod tests {
 
     #[tokio::test]
     async fn test_allocate() {
-        // This only works with the process allocator since we assume a working
-        // bootstrap binary.
-        //
-        // TODO: have multiple trampoline modes (self_exe, etc.)
-
         let instance = testing::instance().await;
 
-        let mut allocator = ProcessAllocator::new(Command::new(
-            buck_resources::get("monarch/hyperactor_mesh/bootstrap").unwrap(),
-        ));
-        let alloc = allocator
-            .allocate(AllocSpec {
-                extent: extent!(replicas = 4),
-                constraints: Default::default(),
-                proc_name: None,
-            })
-            .await
-            .unwrap();
+        for alloc in testing::allocs(extent!(replicas = 4)).await {
+            let host_mesh = HostMesh::allocate(instance, alloc, "test").await.unwrap();
+            let proc_mesh1 = host_mesh.spawn(instance, "test_1").await.unwrap();
+            let actor_mesh1: ActorMesh<testactor::TestActor> =
+                proc_mesh1.spawn(instance, "test", &()).await.unwrap();
+            let proc_mesh2 = host_mesh.spawn(instance, "test_2").await.unwrap();
+            let actor_mesh2: ActorMesh<testactor::TestActor> =
+                proc_mesh2.spawn(instance, "test", &()).await.unwrap();
 
-        let host_mesh = HostMesh::allocate(instance, alloc, "test").await.unwrap();
-        let proc_mesh1 = host_mesh.spawn(instance, "test_1").await.unwrap();
-        let actor_mesh1: ActorMesh<testactor::TestActor> =
-            proc_mesh1.spawn(instance, "test", &()).await.unwrap();
-        let proc_mesh2 = host_mesh.spawn(instance, "test_2").await.unwrap();
-        let actor_mesh2: ActorMesh<testactor::TestActor> =
-            proc_mesh2.spawn(instance, "test", &()).await.unwrap();
-
-        // Host meshes can be dereferenced to produce a concrete ref.
-        let host_mesh_ref: HostMeshRef = host_mesh.clone();
-        // Here, the underlying host mesh does not change:
-        assert_eq!(
-            host_mesh_ref.iter().collect::<Vec<_>>(),
-            host_mesh.iter().collect::<Vec<_>>(),
-        );
-
-        // Validate we can cast:
-
-        let (port, mut rx) = instance.mailbox().open_port();
-        actor_mesh1
-            .cast(instance, testactor::GetActorId(port.bind()))
-            .unwrap();
-
-        let mut expected_actor_ids: HashSet<_> = actor_mesh1
-            .values()
-            .map(|actor_ref| actor_ref.actor_id().clone())
-            .collect();
-
-        while !expected_actor_ids.is_empty() {
-            let actor_id = rx.recv().await.unwrap();
-            assert!(
-                expected_actor_ids.remove(&actor_id),
-                "got {actor_id}, expect {expected_actor_ids:?}"
+            // Host meshes can be dereferenced to produce a concrete ref.
+            let host_mesh_ref: HostMeshRef = host_mesh.clone();
+            // Here, the underlying host mesh does not change:
+            assert_eq!(
+                host_mesh_ref.iter().collect::<Vec<_>>(),
+                host_mesh.iter().collect::<Vec<_>>(),
             );
+
+            // Validate we can cast:
+
+            let (port, mut rx) = instance.mailbox().open_port();
+            actor_mesh1
+                .cast(instance, testactor::GetActorId(port.bind()))
+                .unwrap();
+
+            let mut expected_actor_ids: HashSet<_> = actor_mesh1
+                .values()
+                .map(|actor_ref| actor_ref.actor_id().clone())
+                .collect();
+
+            while !expected_actor_ids.is_empty() {
+                let actor_id = rx.recv().await.unwrap();
+                assert!(
+                    expected_actor_ids.remove(&actor_id),
+                    "got {actor_id}, expect {expected_actor_ids:?}"
+                );
+            }
+
+            // Now forward a message through all directed edges across the two meshes.
+            // This tests the full connectivity of all the hosts, procs, and actors
+            // involved in these two meshes.
+            let mut to_visit: VecDeque<_> = actor_mesh1
+                .values()
+                .chain(actor_mesh2.values())
+                .map(|actor_ref| actor_ref.port())
+                // Each ordered pair of ports
+                .permutations(2)
+                // Flatten them to create a path:
+                .flatten()
+                .collect();
+
+            let expect_visited: Vec<_> = to_visit.clone().into();
+
+            // We are going to send to the first, and then set up a port to receive the last.
+            let (last, mut last_rx) = instance.mailbox().open_port();
+            to_visit.push_back(last.bind());
+
+            let forward = testactor::Forward {
+                to_visit,
+                visited: Vec::new(),
+            };
+            let first = forward.to_visit.front().unwrap().clone();
+            first.send(instance, forward).unwrap();
+
+            let forward = last_rx.recv().await.unwrap();
+            assert_eq!(forward.visited, expect_visited);
         }
-
-        // Now forward a message through all directed edges across the two meshes.
-        // This tests the full connectivity of all the hosts, procs, and actors
-        // involved in these two meshes.
-        let mut to_visit: VecDeque<_> = actor_mesh1
-            .values()
-            .chain(actor_mesh2.values())
-            .map(|actor_ref| actor_ref.port())
-            // Each ordered pair of ports
-            .permutations(2)
-            // Flatten them to create a path:
-            .flatten()
-            .collect();
-
-        let expect_visited: Vec<_> = to_visit.clone().into();
-
-        // We are going to send to the first, and then set up a port to receive the last.
-        let (last, mut last_rx) = instance.mailbox().open_port();
-        to_visit.push_back(last.bind());
-
-        let forward = testactor::Forward {
-            to_visit,
-            visited: Vec::new(),
-        };
-        let first = forward.to_visit.front().unwrap().clone();
-        first.send(instance, forward).unwrap();
-
-        let forward = last_rx.recv().await.unwrap();
-        assert_eq!(forward.visited, expect_visited);
     }
 
     /// Allocate a new port on localhost. This drops the listener, releasing the socket,

--- a/hyperactor_mesh/src/v1/testing.rs
+++ b/hyperactor_mesh/src/v1/testing.rs
@@ -21,6 +21,7 @@ use ndslice::Extent;
 use tokio::process::Command;
 use tokio::sync::OnceCell;
 
+use crate::alloc::Alloc;
 use crate::alloc::AllocSpec;
 use crate::alloc::Allocator;
 use crate::alloc::LocalAllocator;
@@ -82,6 +83,27 @@ pub async fn proc_meshes(cx: &impl context::Actor, extent: Extent) -> Vec<ProcMe
     meshes
 }
 
+/// Return different alloc implementations with the provided extent.
+pub async fn allocs(extent: Extent) -> Vec<Box<dyn Alloc + Send + Sync>> {
+    let spec = AllocSpec {
+        extent: extent.clone(),
+        constraints: Default::default(),
+        proc_name: None,
+    };
+
+    vec![
+        Box::new(LocalAllocator.allocate(spec.clone()).await.unwrap()),
+        Box::new(
+            ProcessAllocator::new(Command::new(
+                buck_resources::get("monarch/hyperactor_mesh/bootstrap").unwrap(),
+            ))
+            .allocate(spec.clone())
+            .await
+            .unwrap(),
+        ),
+    ]
+}
+
 /// Create a local proc mesh with the provided extent, returning the
 /// mesh itself, the controller actor, and the router.
 pub async fn local_proc_mesh(extent: Extent) -> (ProcMesh, Instance<()>, DialMailboxRouter) {
@@ -120,7 +142,7 @@ pub async fn host_mesh(extent: Extent) -> HostMesh {
         .await
         .unwrap();
 
-    HostMesh::allocate(instance().await, alloc, "test")
+    HostMesh::allocate(instance().await, Box::new(alloc), "test")
         .await
         .unwrap()
 }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #1338
* #1330
* #1329
* __->__ #1326

Useful for testing.

This required introducing a "local" trampoline mode, where we use a LocalProcManager to manage processes. The ProcMeshAgent is now made polymorphic in managers.

Differential Revision: [D83210277](https://our.internmc.facebook.com/intern/diff/D83210277/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D83210277/)!