### PR TITLE
[hyperactor] mesh: add a bootstrapping debug facility

### DIFF
--- a/hyperactor_mesh/src/bootstrap.rs
+++ b/hyperactor_mesh/src/bootstrap.rs
@@ -9,11 +9,16 @@
 use std::collections::HashMap;
 use std::collections::VecDeque;
 use std::env::VarError;
+use std::fs::OpenOptions;
 use std::future;
 use std::io;
+use std::io::Write;
 use std::os::unix::process::ExitStatusExt;
+use std::path::Path;
 use std::process::Stdio;
 use std::sync::Arc;
+use std::sync::Mutex;
+use std::sync::OnceLock;
 use std::time::Duration;
 use std::time::SystemTime;
 
@@ -42,6 +47,7 @@ use tokio::process::Child;
 use tokio::process::Command;
 use tokio::sync::oneshot;
 use tokio::sync::watch;
+use tracing::field::debug;
 
 use crate::logging::create_log_writers;
 use crate::proc_mesh::mesh_agent::ProcMeshAgent;
@@ -217,6 +223,31 @@ impl Bootstrap {
             "bootstrapping mesh process: {}",
             serde_json::to_string(&self).unwrap()
         );
+
+        if Debug::is_active() {
+            let mut buf = Vec::new();
+            writeln!(&mut buf, "bootstrapping {}:", std::process::id()).unwrap();
+            writeln!(
+                &mut buf,
+                "\tconfig: {}",
+                serde_json::to_string(&self).unwrap()
+            )
+            .unwrap();
+            match std::env::current_exe() {
+                Ok(path) => writeln!(&mut buf, "\tcurrent_exe: {}", path.display()).unwrap(),
+                Err(e) => writeln!(&mut buf, "\tcurrent_exe: error<{}>", e).unwrap(),
+            }
+            writeln!(&mut buf, "\targs:").unwrap();
+            for arg in std::env::args() {
+                writeln!(&mut buf, "\t\t{}", arg).unwrap();
+            }
+            writeln!(&mut buf, "\tenv:").unwrap();
+            for (key, val) in std::env::vars() {
+                writeln!(&mut buf, "\t\t{}={}", key, val).unwrap();
+            }
+            let _ = Debug.write(&buf);
+        }
+
         match self {
             Bootstrap::Proc {
                 proc_id,
@@ -1320,8 +1351,83 @@ async fn bootstrap_v0_proc_mesh() -> anyhow::Error {
 /// if bootstrapping fails.
 pub async fn bootstrap_or_die() -> ! {
     let err = bootstrap().await;
+    let _ = writeln!(Debug, "failed to bootstrap mesh process: {}", err);
     tracing::error!("failed to bootstrap mesh process: {}", err);
     std::process::exit(1)
+}
+
+#[derive(enum_as_inner::EnumAsInner)]
+enum DebugSink {
+    File(std::fs::File),
+    Sink,
+}
+
+impl DebugSink {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        match self {
+            DebugSink::File(f) => f.write(buf),
+            DebugSink::Sink => Ok(buf.len()),
+        }
+    }
+    fn flush(&mut self) -> io::Result<()> {
+        match self {
+            DebugSink::File(f) => f.flush(),
+            DebugSink::Sink => Ok(()),
+        }
+    }
+}
+
+fn debug_sink() -> &'static Mutex<DebugSink> {
+    static DEBUG_SINK: OnceLock<Mutex<DebugSink>> = OnceLock::new();
+    DEBUG_SINK.get_or_init(|| {
+        let debug_path = {
+            let mut p = std::env::temp_dir();
+            if let Ok(user) = std::env::var("USER") {
+                p.push(user);
+            }
+            std::fs::create_dir_all(&p).ok();
+            p.push("monarch-bootstrap-debug.log");
+            p
+        };
+        let sink = if debug_path.exists() {
+            match OpenOptions::new()
+                .append(true)
+                .create(true)
+                .open(debug_path.clone())
+            {
+                Ok(f) => DebugSink::File(f),
+                Err(e) => {
+                    eprintln!(
+                        "failed to open {} for bootstrap debug logging",
+                        debug_path.display()
+                    );
+                    DebugSink::Sink
+                }
+            }
+        } else {
+            DebugSink::Sink
+        };
+        Mutex::new(sink)
+    })
+}
+
+/// A bootstrap specific debug writer. If the file /tmp/monarch-bootstrap-debug.log
+/// exists, then the writer's destination is that file; otherwise it discards all writes.
+struct Debug;
+
+impl Debug {
+    fn is_active() -> bool {
+        debug_sink().lock().unwrap().is_file()
+    }
+}
+
+impl Write for Debug {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        debug_sink().lock().unwrap().write(buf)
+    }
+    fn flush(&mut self) -> io::Result<()> {
+        debug_sink().lock().unwrap().flush()
+    }
 }
 
 #[cfg(test)]

--- a/hyperactor_mesh/src/v1/host_mesh.rs
+++ b/hyperactor_mesh/src/v1/host_mesh.rs
@@ -352,7 +352,6 @@ mod tests {
 
     use super::*;
     use crate::Bootstrap;
-    use crate::alloc::Allocator;
     use crate::v1::ActorMesh;
     use crate::v1::testactor;
     use crate::v1::testing;
@@ -392,7 +391,9 @@ mod tests {
         let instance = testing::instance().await;
 
         for alloc in testing::allocs(extent!(replicas = 4)).await {
-            let host_mesh = HostMesh::allocate(instance, alloc, "test").await.unwrap();
+            let host_mesh = HostMesh::allocate(instance, alloc, "test", None)
+                .await
+                .unwrap();
             let proc_mesh1 = host_mesh.spawn(instance, "test_1").await.unwrap();
             let actor_mesh1: ActorMesh<testactor::TestActor> =
                 proc_mesh1.spawn(instance, "test", &()).await.unwrap();

--- a/hyperactor_mesh/src/v1/host_mesh/mesh_agent.rs
+++ b/hyperactor_mesh/src/v1/host_mesh/mesh_agent.rs
@@ -199,7 +199,7 @@ impl Actor for HostMeshAgentProcMeshTrampoline {
             HostAgentMode::Local(host)
         } else {
             let manager = if let Some(params) = bootstrap_params {
-                BootstrapProcManager::from_params(bootstrap_params.unwrap())
+                BootstrapProcManager::from_params(params)
             } else {
                 BootstrapProcManager::new_current_exe()?
             };


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #1338
* #1330
* __->__ #1329
* #1326

Bootstrapping problems can be especially difficult to debug. We add a specific debug facility that bypasses all other logging, stdio redirection, etc.

This provides the `io::Writer` `bootstrap::Debug`, with the following behavior: if the file "/tmp/monarch-bootstrap-debug.log" exists, then writes are directed to this file; otherwise all writes are discarded. The existence of the file is checked on the first write.

Thus, you can debug bootstrapping problems:

```
$ touch /tmp/monarch-bootstrap-debug.log; tail -f /tmp/monarch-bootstrap-debug.log
...
```

Differential Revision: [D83212851](https://our.internmc.facebook.com/intern/diff/D83212851/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D83212851/)!