### PR TITLE
[hyperactor] BootstrapProcManagerParams -> BootstrapCommand

### DIFF
--- a/hyperactor_mesh/src/bootstrap.rs
+++ b/hyperactor_mesh/src/bootstrap.rs
@@ -265,7 +265,8 @@ impl Bootstrap {
                 }
             }
             Bootstrap::Host { addr } => {
-                let manager = ok!(BootstrapProcManager::new_current_exe());
+                let command = ok!(BootstrapCommand::current());
+                let manager = BootstrapProcManager::new(command);
                 let (host, _handle) = ok!(Host::serve(manager, addr).await);
                 let addr = host.addr().clone();
                 let host_mesh_agent = ok!(host
@@ -844,11 +845,45 @@ impl hyperactor::host::ProcHandle for BootstrapProcHandle {
     }
 }
 
-#[derive(Debug, Named, Serialize, Deserialize, Clone)]
-pub struct BootstrapProcManagerParams {
+/// A specification of the command used to bootstrap procs.
+#[derive(Debug, Named, Serialize, Deserialize, Clone, Default)]
+pub struct BootstrapCommand {
     pub program: std::path::PathBuf,
+    pub arg0: Option<String>,
     pub args: Vec<String>,
     pub env: HashMap<String, String>,
+}
+
+impl BootstrapCommand {
+    /// Creates a bootstrap command specification to replicate the
+    /// invocation of the currently running process.
+    pub fn current() -> io::Result<Self> {
+        let mut args: VecDeque<String> = std::env::args().collect();
+        let arg0 = args.pop_front();
+
+        Ok(Self {
+            program: std::env::current_exe()?,
+            arg0,
+            args: args.into(),
+            env: std::env::vars().collect(),
+        })
+    }
+
+    /// Bootstrap command used for testing, invokking the Buck-built
+    /// `monarch/hyperactor_mesh/bootstrap` binary.
+    ///
+    /// Intended for integration tests where we need to spawn real
+    /// bootstrap processes under proc manager control. Not available
+    /// outside of test builds.
+    #[cfg(test)]
+    pub(crate) fn test() -> Self {
+        Self {
+            program: buck_resources::get("monarch/hyperactor_mesh/bootstrap").unwrap(),
+            arg0: None,
+            args: vec![],
+            env: HashMap::new(),
+        }
+    }
 }
 
 /// A process manager for launching and supervising **bootstrap
@@ -873,13 +908,8 @@ pub struct BootstrapProcManagerParams {
 /// orphaned if the manager itself is dropped.
 #[derive(Debug)]
 pub struct BootstrapProcManager {
-    /// Path to the bootstrap binary that this manager will launch for
-    /// each proc.
-    program: std::path::PathBuf,
-    /// argv[0], if specified
-    arg0: Option<String>,
-    /// argv[1..]
-    args: Vec<String>,
+    /// The command specification used to bootstrap new processes.
+    command: BootstrapCommand,
     /// Async registry of running children, keyed by [`ProcId`]. Holds
     /// [`BootstrapProcHandle`]s so callers can query or monitor
     /// status.
@@ -888,7 +918,6 @@ pub struct BootstrapProcManager {
     /// exclusively in the [`Drop`] impl to send `SIGKILL` without
     /// needing async context.
     pid_table: Arc<std::sync::Mutex<HashMap<ProcId, u32>>>,
-    env: HashMap<String, String>,
 }
 
 impl Drop for BootstrapProcManager {
@@ -933,66 +962,17 @@ impl Drop for BootstrapProcManager {
 
 impl BootstrapProcManager {
     /// Construct a new [`BootstrapProcManager`] that will launch
-    /// procs using the given program binary.
+    /// procs using the given bootstrap command specification.
     ///
     /// This is the general entry point when you want to manage procs
     /// backed by a specific binary path (e.g. a bootstrap
     /// trampoline).
-    #[allow(dead_code)]
-    pub(crate) fn new(program: std::path::PathBuf) -> Self {
+    pub(crate) fn new(command: BootstrapCommand) -> Self {
         Self {
-            program,
-            arg0: None,
-            args: Vec::new(),
+            command,
             children: Arc::new(tokio::sync::Mutex::new(HashMap::new())),
             pid_table: Arc::new(std::sync::Mutex::new(HashMap::new())),
-            env: HashMap::new(),
         }
-    }
-
-    /// Convenience constructor that resolves the current executable
-    /// (`std::env::current_exe`) and uses that as the bootstrap
-    /// binary. The program arguments are also captured and used to
-    /// configure child processes.
-    ///
-    /// Useful when the proc manager should re-exec itself as the
-    /// child program. Returns an `io::Result` since querying the
-    /// current executable path can fail.
-    pub(crate) fn new_current_exe() -> io::Result<Self> {
-        // Ok(Self::new(std::env::current_exe()?))
-        let mut args: VecDeque<String> = std::env::args().collect();
-        let arg0 = args.pop_front();
-
-        Ok(Self {
-            program: std::env::current_exe()?,
-            arg0,
-            args: args.into(),
-            children: Arc::new(tokio::sync::Mutex::new(HashMap::new())),
-            pid_table: Arc::new(std::sync::Mutex::new(HashMap::new())),
-            env: HashMap::new(),
-        })
-    }
-
-    pub(crate) fn from_params(params: BootstrapProcManagerParams) -> Self {
-        Self {
-            program: params.program,
-            arg0: None,
-            args: params.args,
-            children: Arc::new(tokio::sync::Mutex::new(HashMap::new())),
-            pid_table: Arc::new(std::sync::Mutex::new(HashMap::new())),
-            env: params.env,
-        }
-    }
-
-    /// Test-only constructor that uses the Buck-built
-    /// `monarch/hyperactor_mesh/bootstrap` binary.
-    ///
-    /// Intended for integration tests where we need to spawn real
-    /// bootstrap processes under proc manager control. Not available
-    /// outside of test builds.
-    #[cfg(test)]
-    pub(crate) fn new_for_test() -> Self {
-        Self::new(buck_resources::get("monarch/hyperactor_mesh/bootstrap").unwrap())
     }
 
     /// Return the current [`ProcStatus`] for the given [`ProcId`], if
@@ -1115,14 +1095,14 @@ impl ProcManager for BootstrapProcManager {
             backend_addr,
             callback_addr,
         };
-        let mut cmd = Command::new(&self.program);
-        if let Some(arg0) = &self.arg0 {
+        let mut cmd = Command::new(&self.command.program);
+        if let Some(arg0) = &self.command.arg0 {
             cmd.arg0(arg0);
         }
-        for arg in &self.args {
+        for arg in &self.command.args {
             cmd.arg(arg);
         }
-        for (k, v) in &self.env {
+        for (k, v) in &self.command.env {
             cmd.env(k, v);
         }
         cmd.env(
@@ -1479,7 +1459,11 @@ mod tests {
         use tokio::time::Duration;
 
         // Manager; program path is irrelevant for this test.
-        let manager = BootstrapProcManager::new(PathBuf::from("/bin/true"));
+        let command = BootstrapCommand {
+            program: PathBuf::from("/bin/true"),
+            ..Default::default()
+        };
+        let manager = BootstrapProcManager::new(command);
 
         // Spawn a long-running child process (sleep 30) with
         // kill_on_drop(true).
@@ -1779,7 +1763,11 @@ mod tests {
 
     #[tokio::test]
     async fn test_exit_monitor_updates_status_on_clean_exit() {
-        let manager = BootstrapProcManager::new(PathBuf::from("/bin/true"));
+        let command = BootstrapCommand {
+            program: PathBuf::from("/bin/true"),
+            ..Default::default()
+        };
+        let manager = BootstrapProcManager::new(command);
 
         // Spawn a fast-exiting child.
         let mut cmd = Command::new("/bin/true");
@@ -1809,7 +1797,11 @@ mod tests {
 
     #[tokio::test]
     async fn test_exit_monitor_updates_status_on_kill() {
-        let manager = BootstrapProcManager::new(PathBuf::from("/bin/sleep"));
+        let command = BootstrapCommand {
+            program: PathBuf::from("/bin/sleep"),
+            ..Default::default()
+        };
+        let manager = BootstrapProcManager::new(command);
 
         // Spawn a process that will live long enough to kill.
         let mut cmd = Command::new("/bin/sleep");
@@ -1923,14 +1915,20 @@ mod tests {
 
     #[tokio::test]
     async fn status_unknown_proc_is_none() {
-        let manager = BootstrapProcManager::new(PathBuf::from("/bin/true"));
+        let manager = BootstrapProcManager::new(BootstrapCommand {
+            program: PathBuf::from("/bin/true"),
+            ..Default::default()
+        });
         let unknown = ProcId::Direct(ChannelAddr::any(ChannelTransport::Unix), "nope".into());
         assert!(manager.status(&unknown).await.is_none());
     }
 
     #[tokio::test]
     async fn exit_monitor_child_already_taken_leaves_status_unchanged() {
-        let manager = BootstrapProcManager::new(PathBuf::from("/bin/sleep"));
+        let manager = BootstrapProcManager::new(BootstrapCommand {
+            program: PathBuf::from("/bin/sleep"),
+            ..Default::default()
+        });
 
         // Long-ish child so it's alive while we "steal" it.
         let mut cmd = Command::new("/bin/sleep");
@@ -1966,7 +1964,10 @@ mod tests {
 
     #[tokio::test]
     async fn pid_none_after_exit_monitor_takes_child() {
-        let manager = BootstrapProcManager::new(PathBuf::from("/bin/sleep"));
+        let manager = BootstrapProcManager::new(BootstrapCommand {
+            program: PathBuf::from("/bin/sleep"),
+            ..Default::default()
+        });
 
         let mut cmd = Command::new("/bin/sleep");
         cmd.arg("5").stdout(Stdio::null()).stderr(Stdio::null());

--- a/hyperactor_mesh/src/v1/host_mesh.rs
+++ b/hyperactor_mesh/src/v1/host_mesh.rs
@@ -27,7 +27,7 @@ use serde::Deserialize;
 use serde::Serialize;
 
 use crate::alloc::Alloc;
-use crate::bootstrap::BootstrapProcManagerParams;
+use crate::bootstrap::BootstrapCommand;
 use crate::resource::CreateOrUpdateClient;
 use crate::v1;
 use crate::v1::Name;
@@ -131,7 +131,7 @@ impl HostMesh {
         cx: &impl context::Actor,
         alloc: Box<dyn Alloc + Send + Sync>,
         name: &str,
-        bootstrap_params: Option<BootstrapProcManagerParams>,
+        bootstrap_params: Option<BootstrapCommand>,
     ) -> v1::Result<Self> {
         let transport = alloc.transport();
         let extent = alloc.extent().clone();

--- a/hyperactor_mesh/src/v1/host_mesh/mesh_agent.rs
+++ b/hyperactor_mesh/src/v1/host_mesh/mesh_agent.rs
@@ -31,8 +31,8 @@ use hyperactor::host::LocalProcManager;
 use serde::Deserialize;
 use serde::Serialize;
 
+use crate::bootstrap::BootstrapCommand;
 use crate::bootstrap::BootstrapProcManager;
-use crate::bootstrap::BootstrapProcManagerParams;
 use crate::proc_mesh::mesh_agent::ProcMeshAgent;
 use crate::resource;
 use crate::v1::Name;
@@ -185,24 +185,22 @@ impl Actor for HostMeshAgentProcMeshTrampoline {
     type Params = (
         ChannelTransport,
         PortRef<ActorRef<HostMeshAgent>>,
-        Option<BootstrapProcManagerParams>,
+        Option<BootstrapCommand>,
         bool, /* local? */
     );
 
-    async fn new(
-        (transport, reply_port, bootstrap_params, local): Self::Params,
-    ) -> anyhow::Result<Self> {
+    async fn new((transport, reply_port, command, local): Self::Params) -> anyhow::Result<Self> {
         let host = if local {
             let spawn: ProcManagerSpawnFn = Box::new(|proc| Box::pin(ProcMeshAgent::boot_v1(proc)));
             let manager = LocalProcManager::new(spawn);
             let (host, _) = Host::serve(manager, transport.any()).await?;
             HostAgentMode::Local(host)
         } else {
-            let manager = if let Some(params) = bootstrap_params {
-                BootstrapProcManager::from_params(params)
-            } else {
-                BootstrapProcManager::new_current_exe()?
+            let command = match command {
+                Some(command) => command,
+                None => BootstrapCommand::current()?,
             };
+            let manager = BootstrapProcManager::new(command);
             let (host, _) = Host::serve(manager, transport.any()).await?;
             HostAgentMode::Process(host)
         };
@@ -257,7 +255,7 @@ mod tests {
     #[tokio::test]
     async fn test_basic() {
         let (host, _handle) = Host::serve(
-            BootstrapProcManager::new_for_test(),
+            BootstrapProcManager::new(BootstrapCommand::test()),
             ChannelTransport::Unix.any(),
         )
         .await

--- a/monarch_hyperactor/src/v1/host_mesh.rs
+++ b/monarch_hyperactor/src/v1/host_mesh.rs
@@ -9,7 +9,7 @@
 use std::collections::HashMap;
 use std::path::PathBuf;
 
-use hyperactor_mesh::bootstrap::BootstrapProcManagerParams;
+use hyperactor_mesh::bootstrap::BootstrapCommand;
 use hyperactor_mesh::shared_cell::SharedCell;
 use hyperactor_mesh::v1::host_mesh::HostMesh;
 use hyperactor_mesh::v1::host_mesh::HostMeshRef;
@@ -31,13 +31,15 @@ use crate::shape::PyRegion;
 use crate::v1::proc_mesh::PyProcMesh;
 
 #[pyclass(
-    name = "BootstrapProcManagerParams",
+    name = "BootstrapCommand",
     module = "monarch._rust_bindings.monarch_hyperactor.v1.host_mesh"
 )]
 #[derive(Clone)]
-pub struct PyBootstrapProcManagerParams {
+pub struct PyBootstrapCommand {
     #[pyo3(get, set)]
     pub program: String,
+    #[pyo3(get, set)]
+    pub argv0: Option<String>,
     #[pyo3(get, set)]
     pub args: Vec<String>,
     #[pyo3(get, set)]
@@ -45,24 +47,35 @@ pub struct PyBootstrapProcManagerParams {
 }
 
 #[pymethods]
-impl PyBootstrapProcManagerParams {
+impl PyBootstrapCommand {
     #[new]
-    fn new(program: String, args: Vec<String>, env: HashMap<String, String>) -> Self {
-        Self { program, args, env }
+    fn new(
+        program: String,
+        argv0: Option<String>,
+        args: Vec<String>,
+        env: HashMap<String, String>,
+    ) -> Self {
+        Self {
+            program,
+            argv0,
+            args,
+            env,
+        }
     }
 
     fn __repr__(&self) -> String {
         format!(
-            "BootstrapProcManagerParams(program='{}', args={:?}, env={:?})",
+            "BootstrapCommand(program='{}', args={:?}, env={:?})",
             self.program, self.args, self.env
         )
     }
 }
 
-impl PyBootstrapProcManagerParams {
-    pub fn to_rust(&self) -> BootstrapProcManagerParams {
-        BootstrapProcManagerParams {
+impl PyBootstrapCommand {
+    pub fn to_rust(&self) -> BootstrapCommand {
+        BootstrapCommand {
             program: PathBuf::from(&self.program),
+            argv0: self.argv0.clone(),
             args: self.args.clone(),
             env: self.env.clone(),
         }
@@ -103,7 +116,7 @@ impl PyHostMesh {
         instance: &PyInstance,
         alloc: &mut PyAlloc,
         name: String,
-        bootstrap_params: Option<PyBootstrapProcManagerParams>,
+        bootstrap_params: Option<PyBootstrapCommand>,
     ) -> PyResult<PyPythonTask> {
         let alloc = match alloc.take() {
             Some(alloc) => alloc,
@@ -197,6 +210,6 @@ pub fn register_python_bindings(hyperactor_mod: &Bound<'_, PyModule>) -> PyResul
     )?;
     hyperactor_mod.add_function(f)?;
     hyperactor_mod.add_class::<PyHostMesh>()?;
-    hyperactor_mod.add_class::<PyBootstrapProcManagerParams>()?;
+    hyperactor_mod.add_class::<PyBootstrapCommand>()?;
     Ok(())
 }

--- a/python/monarch/_rust_bindings/monarch_hyperactor/v1/host_mesh.pyi
+++ b/python/monarch/_rust_bindings/monarch_hyperactor/v1/host_mesh.pyi
@@ -23,7 +23,7 @@ class HostMesh:
         instance: Instance,
         alloc: Alloc,
         name: str,
-        bootstrap_params: BootstrapProcManagerParams | None,
+        bootstrap_command: BootstrapCommand | None,
     ) -> PythonTask["HostMesh"]:
         """
         Allocate a host mesh according to the provided alloc.
@@ -32,7 +32,7 @@ class HostMesh:
         - `instance`: The actor instance used to allocate the mesh.
         - `alloc`: The alloc to allocate according to.
         - `name`: Name of the mesh.
-        - `bootstrap_params`: Parameters to pass to the BootstrapProcManager constructor.
+        - `bootstrap_command`: Override the bootstrap command used to bootstrap procs.
         """
         ...
 
@@ -69,15 +69,16 @@ class HostMesh:
     def __reduce__(self) -> Any: ...
 
 @final
-class BootstrapProcManagerParams:
+class BootstrapCommand:
     def __init__(
         self,
         program: str,
+        argv0: str | None,
         args: list[str],
         env: dict[str, str],
     ) -> None:
         """
-        Parameters to pass to the BootstrapProcManager constructor.
+        Bootstrap command specification.
 
         Arguments:
         - `program`: The program to execute.

--- a/python/tests/_monarch/test_actor_mesh.py
+++ b/python/tests/_monarch/test_actor_mesh.py
@@ -35,7 +35,7 @@ from monarch._rust_bindings.monarch_hyperactor.mailbox import PortReceiver
 from monarch._rust_bindings.monarch_hyperactor.proc_mesh import ProcMesh
 from monarch._rust_bindings.monarch_hyperactor.pytokio import PythonTask
 from monarch._rust_bindings.monarch_hyperactor.v1.host_mesh import (
-    BootstrapProcManagerParams,
+    BootstrapCommand,
     HostMesh,
 )
 from monarch._rust_bindings.monarch_hyperactor.v1.proc_mesh import (
@@ -263,8 +263,9 @@ async def test_host_mesh() -> None:
             context().actor_instance._as_rust(),
             await alloc._hy_alloc,
             "host_mesh",
-            BootstrapProcManagerParams(
+            BootstrapCommand(
                 cmd,
+                None,
                 args if args else [],
                 bootstrap_env,
             ),


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #1338
* __->__ #1330
* #1329
* #1326

This change redefines the proc manager params into a first-class BootstrapCommand, which is then used uniformly throughout the proc manager. Thus, instead of constructing special test modes, we can simply specify different bootstrap command to use. This homogenizes the API, makes its intent clearer, and simplifies how bootstrap processes are configured.

Differential Revision: [D83253114](https://our.internmc.facebook.com/intern/diff/D83253114/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D83253114/)!