### PR TITLE
Extend RemoteActor trait to use Actor too

### DIFF
--- a/docs/source/books/hyperactor-book/src/actors/remotable_actor.md
+++ b/docs/source/books/hyperactor-book/src/actors/remotable_actor.md
@@ -56,7 +56,7 @@ This allows `A` to be remotely registered and instantiated from serialized data,
 ```rust
 impl<A> RemotableActor for A
 where
-    A: Actor + RemoteActor,
+    A: RemoteActor,
     A: Binds<A>,
     A::Params: RemoteMessage,
 {

--- a/docs/source/books/hyperactor-book/src/actors/remote_actor.md
+++ b/docs/source/books/hyperactor-book/src/actors/remote_actor.md
@@ -6,5 +6,6 @@ pub trait RemoteActor: Named + Send + Sync {}
 This is a marker trait indicating that a type is eligible to serve as a reference to a remote actor (i.e., an actor that may reside on a different proc).
 
 It requires:
+- `Actor`: the type must implement the Actor trait.
 - `Named`: the type must provide a static name.
 - `Send + Sync`: the type must be safely transferable and shareable across threads.

--- a/docs/source/books/hyperactor-book/src/macros/alias.md
+++ b/docs/source/books/hyperactor-book/src/macros/alias.md
@@ -87,6 +87,12 @@ pub struct ShoppingApi;
 
 impl hyperactor::actor::RemoteActor for ShoppingApi {}
 
+#[hyperactor::async_trait::async_trait]
+impl hyperactor::Actor for ShoppingApi {
+    type Params = ();
+    async fn new(_: ()) -> Result<Self, hyperactor::anyhow::Error> { panic!("RemoteActor instances should not be created!") }
+}
+
 impl<A> hyperactor::actor::Binds<A> for ShoppingApi
 where
     A: Actor

--- a/hyperactor/src/actor.rs
+++ b/hyperactor/src/actor.rs
@@ -234,7 +234,7 @@ where
 
 impl<A> RemotableActor for A
 where
-    A: Actor + RemoteActor,
+    A: RemoteActor,
     A: Binds<A>,
     A::Params: RemoteMessage,
 {
@@ -655,7 +655,7 @@ impl<A: Actor> Clone for ActorHandle<A> {
 /// remote actor references. All [`Actor`]s are thus referencable;
 /// but other types may also implement this in order to separately
 /// specify actor interfaces.
-pub trait RemoteActor: Named + Send + Sync {}
+pub trait RemoteActor: Actor + Named + Send + Sync {}
 
 /// Binds determines how an actor's ports are bound to a specific
 /// reference type.

--- a/hyperactor/src/cap.rs
+++ b/hyperactor/src/cap.rs
@@ -79,7 +79,7 @@ pub(crate) mod sealed {
     }
 
     pub trait CanResolveActorRef: Send + Sync {
-        fn resolve_actor_ref<A: RemoteActor + Actor>(
+        fn resolve_actor_ref<A: RemoteActor>(
             &self,
             actor_ref: &ActorRef<A>,
         ) -> Option<ActorHandle<A>>;

--- a/hyperactor/src/host.rs
+++ b/hyperactor/src/host.rs
@@ -266,7 +266,7 @@ impl MailboxSender for ProcOrDial {
 pub trait ProcHandle: Clone + Send + Sync + 'static {
     /// The type of the agent actor installed in ths proc by the
     /// manager.
-    type Agent: Actor + RemoteActor;
+    type Agent: RemoteActor;
 
     /// The proc's logical identity on this host.
     fn proc_id(&self) -> &ProcId;
@@ -354,14 +354,14 @@ impl<A: Actor> LocalProcManager<A> {
 /// host code can treat local and external procs through the same
 /// trait.
 #[derive(Debug)]
-pub struct LocalHandle<A: Actor + RemoteActor> {
+pub struct LocalHandle<A: RemoteActor> {
     proc_id: ProcId,
     addr: ChannelAddr,
     agent_ref: ActorRef<A>,
 }
 
 // Manual `Clone` to avoid requiring `A: Clone`.
-impl<A: Actor + RemoteActor> Clone for LocalHandle<A> {
+impl<A: RemoteActor> Clone for LocalHandle<A> {
     fn clone(&self) -> Self {
         Self {
             proc_id: self.proc_id.clone(),
@@ -371,7 +371,7 @@ impl<A: Actor + RemoteActor> Clone for LocalHandle<A> {
     }
 }
 
-impl<A: Actor + RemoteActor> ProcHandle for LocalHandle<A> {
+impl<A: RemoteActor> ProcHandle for LocalHandle<A> {
     type Agent = A;
 
     fn proc_id(&self) -> &ProcId {
@@ -388,7 +388,7 @@ impl<A: Actor + RemoteActor> ProcHandle for LocalHandle<A> {
 #[async_trait]
 impl<A> ProcManager for LocalProcManager<A>
 where
-    A: Actor + RemoteActor + Binds<A>,
+    A: RemoteActor + Binds<A>,
     A::Params: Sync + Clone,
 {
     type Handle = LocalHandle<A>;
@@ -482,14 +482,14 @@ impl<A> Drop for ProcessProcManager<A> {
 /// and agent reference so host code can interact uniformly with local
 /// and external procs.
 #[derive(Debug)]
-pub struct ProcessHandle<A: Actor + RemoteActor> {
+pub struct ProcessHandle<A: RemoteActor> {
     proc_id: ProcId,
     addr: ChannelAddr,
     agent_ref: ActorRef<A>,
 }
 
 // Manual `Clone` to avoid requiring `A: Clone`.
-impl<A: Actor + RemoteActor> Clone for ProcessHandle<A> {
+impl<A: RemoteActor> Clone for ProcessHandle<A> {
     fn clone(&self) -> Self {
         Self {
             proc_id: self.proc_id.clone(),
@@ -499,7 +499,7 @@ impl<A: Actor + RemoteActor> Clone for ProcessHandle<A> {
     }
 }
 
-impl<A: Actor + RemoteActor> ProcHandle for ProcessHandle<A> {
+impl<A: RemoteActor> ProcHandle for ProcessHandle<A> {
     type Agent = A;
 
     fn proc_id(&self) -> &ProcId {
@@ -516,7 +516,7 @@ impl<A: Actor + RemoteActor> ProcHandle for ProcessHandle<A> {
 #[async_trait]
 impl<A> ProcManager for ProcessProcManager<A>
 where
-    A: Actor + RemoteActor,
+    A: RemoteActor,
 {
     type Handle = ProcessHandle<A>;
 
@@ -573,7 +573,7 @@ where
 
 impl<A> ProcessProcManager<A>
 where
-    A: Actor + RemoteActor + Binds<A>,
+    A: RemoteActor + Binds<A>,
 {
     /// Boot a process in a ProcessProcManager<A>. Should be called from processes spawned
     /// by the process manager. `boot_proc` will spawn the provided actor type (with parameters)
@@ -613,7 +613,7 @@ pub async fn spawn_proc<A, S, F>(
     spawn: S,
 ) -> Result<Proc, HostError>
 where
-    A: Actor + RemoteActor + Binds<A>,
+    A: RemoteActor + Binds<A>,
     S: FnOnce(Proc) -> F,
     F: Future<Output = Result<ActorHandle<A>, anyhow::Error>>,
 {

--- a/hyperactor/src/proc.rs
+++ b/hyperactor/src/proc.rs
@@ -743,7 +743,7 @@ impl Proc {
 
     /// Resolve an actor reference to an actor residing on this proc.
     /// Returns None if the actor is not found on this proc.
-    pub fn resolve_actor_ref<R: RemoteActor + Actor>(
+    pub fn resolve_actor_ref<R: RemoteActor>(
         &self,
         actor_ref: &ActorRef<R>,
     ) -> Option<ActorHandle<R>> {

--- a/hyperactor_macros/src/lib.rs
+++ b/hyperactor_macros/src/lib.rs
@@ -1643,7 +1643,11 @@ pub fn alias(input: TokenStream) -> TokenStream {
         #[derive(Debug, hyperactor::Named, serde::Serialize, serde::Deserialize)]
         pub struct #alias;
         impl hyperactor::actor::RemoteActor for #alias {}
-
+        #[hyperactor::async_trait::async_trait]
+        impl hyperactor::Actor for #alias {
+            type Params = ();
+            async fn new(_: ()) -> Result<Self, hyperactor::anyhow::Error> { panic!("RemoteActor instances should not be created!") }
+        }
         impl<A> hyperactor::actor::Binds<A> for #alias
         where
             A: hyperactor::Actor #(+ hyperactor::Handler<#tys>)* {

--- a/hyperactor_mesh/src/proc_mesh.rs
+++ b/hyperactor_mesh/src/proc_mesh.rs
@@ -460,7 +460,7 @@ impl ProcMesh {
         })
     }
 
-    async fn spawn_on_procs<A: Actor + RemoteActor>(
+    async fn spawn_on_procs<A: RemoteActor>(
         cx: &impl context::Actor,
         agents: impl IntoIterator<Item = ActorRef<ProcMeshAgent>> + '_,
         actor_name: &str,
@@ -537,7 +537,7 @@ impl ProcMesh {
     /// - `actor_name`: Name for all spawned actors.
     /// - `params`: Reference to the parameter struct, reused for all
     ///   actors.
-    pub async fn spawn<A: Actor + RemoteActor>(
+    pub async fn spawn<A: RemoteActor>(
         &self,
         actor_name: &str,
         params: &A::Params,
@@ -857,7 +857,7 @@ impl ProcEvents {
 /// static lifetimes.
 #[async_trait]
 pub trait SharedSpawnable {
-    async fn spawn<A: Actor + RemoteActor>(
+    async fn spawn<A: RemoteActor>(
         self,
         actor_name: &str,
         params: &A::Params,
@@ -868,7 +868,7 @@ pub trait SharedSpawnable {
 
 #[async_trait]
 impl<D: Deref<Target = ProcMesh> + Send + Sync + 'static> SharedSpawnable for D {
-    async fn spawn<A: Actor + RemoteActor>(
+    async fn spawn<A: RemoteActor>(
         self,
         actor_name: &str,
         params: &A::Params,

--- a/hyperactor_mesh/src/v1/actor_mesh.rs
+++ b/hyperactor_mesh/src/v1/actor_mesh.rs
@@ -127,7 +127,7 @@ pub struct ActorMeshRef<A: RemoteActor> {
     _phantom: PhantomData<A>,
 }
 
-impl<A: Actor + RemoteActor> ActorMeshRef<A> {
+impl<A: RemoteActor> ActorMeshRef<A> {
     /// Cast a message to all actors in this mesh.
     pub fn cast<M>(&self, cx: &impl context::Actor, message: M) -> v1::Result<()>
     where

--- a/hyperactor_mesh/src/v1/proc_mesh.rs
+++ b/hyperactor_mesh/src/v1/proc_mesh.rs
@@ -509,7 +509,7 @@ impl ProcMeshRef {
     }
 
     /// Spawn an actor on all of the procs in this mesh, returning a new ActorMesh.
-    pub async fn spawn<A: Actor + RemoteActor>(
+    pub async fn spawn<A: RemoteActor>(
         &self,
         cx: &impl context::Actor,
         name: &str,
@@ -521,7 +521,7 @@ impl ProcMeshRef {
         self.spawn_with_name(cx, Name::new(name), params).await
     }
 
-    pub async fn spawn_with_name<A: Actor + RemoteActor>(
+    pub async fn spawn_with_name<A: RemoteActor>(
         &self,
         cx: &impl context::Actor,
         name: Name,

--- a/hyperactor_multiprocess/src/proc_actor.rs
+++ b/hyperactor_multiprocess/src/proc_actor.rs
@@ -829,7 +829,7 @@ impl Handler<ActorSupervisionEvent> for ProcActor {
 
 /// Convenience utility to spawn an actor on a proc. Spawn returns
 /// with the new ActorRef on success.
-pub async fn spawn<A: Actor + RemoteActor>(
+pub async fn spawn<A: RemoteActor>(
     cx: &impl context::Actor,
     proc_actor: &ActorRef<ProcActor>,
     actor_name: &str,

--- a/monarch_hyperactor/src/proc_mesh.rs
+++ b/monarch_hyperactor/src/proc_mesh.rs
@@ -87,7 +87,7 @@ impl From<ProcMesh> for TrackedProcMesh {
 }
 
 impl TrackedProcMesh {
-    pub async fn spawn<A: Actor + RemoteActor>(
+    pub async fn spawn<A: RemoteActor>(
         &self,
         actor_name: &str,
         params: &A::Params,


### PR DESCRIPTION
Summary:
Usually RemoteActor is used alongside Actor as `RemoteActor + Actor`. The goal here is to add Actor to RemoteActor trait bound so we can avoid using them both in all these places. 

Looking at some standalone instances for just RemoteActor (instead of both), 
Some of them seem to be related to the `hyperactor::alias!();` macro. See docs for more info on alias macro: https://meta-pytorch.org/monarch/books/hyperactor-book/src/macros/alias.html

So when we go from `RemoteActor: Named + Send + Sync` to `RemoteActor: Actor + Named + Send + Sync`, we will also need to make sure Actor has an impl for alias. So adding new() for this.


Differential Revision: D82558304


