### PR TITLE
Rename supervision_events to actor_states

### DIFF
--- a/hyperactor_mesh/src/proc_mesh/mesh_agent.rs
+++ b/hyperactor_mesh/src/proc_mesh/mesh_agent.rs
@@ -183,7 +183,7 @@ pub struct ProcMeshAgent {
     record_supervision_events: bool,
     /// If record_supervision_events is true, then this will contain the list
     /// of all events that were received.
-    supervision_events: Vec<ActorSupervisionEvent>,
+    supervision_events: HashMap<ActorId, Vec<ActorSupervisionEvent>>,
 }
 
 impl ProcMeshAgent {
@@ -204,7 +204,7 @@ impl ProcMeshAgent {
             state: State::UnconfiguredV0 { sender },
             created: HashMap::new(),
             record_supervision_events: false,
-            supervision_events: Vec::new(),
+            supervision_events: HashMap::new(),
         };
         let handle = proc.spawn::<Self>("mesh", agent).await?;
         Ok((proc, handle))
@@ -236,7 +236,7 @@ impl ProcMeshAgent {
             state: State::V1,
             created: HashMap::new(),
             record_supervision_events: true,
-            supervision_events: Vec::new(),
+            supervision_events: HashMap::new(),
         };
         proc.spawn::<Self>("agent", agent).await
     }
@@ -393,7 +393,10 @@ impl Handler<ActorSupervisionEvent> for ProcMeshAgent {
     ) -> anyhow::Result<()> {
         if self.record_supervision_events {
             tracing::info!("Received supervision event: {:?}, recording", event);
-            self.supervision_events.push(event.clone());
+            self.supervision_events
+                .entry(event.actor_id.clone())
+                .or_insert_with(Vec::new)
+                .push(event.clone());
         }
         if let Some(supervisor) = self.state.supervisor() {
             supervisor.send(cx, event)?;
@@ -482,15 +485,29 @@ impl Handler<resource::GetState<ActorState>> for ProcMeshAgent {
             .rank()
             .ok_or_else(|| anyhow::anyhow!("tried to get status of unconfigured proc"))?;
         let state = match self.created.get(&get_state.name) {
-            Some(Ok(actor_id)) => resource::State {
-                name: get_state.name.clone(),
-                status: resource::Status::Running,
-                state: Some(ActorState {
-                    actor_id: actor_id.clone(),
-                    create_rank: rank,
-                    supervision_events: self.supervision_events.clone(),
-                }),
-            },
+            Some(Ok(actor_id)) => {
+                let supervision_events = self
+                    .supervision_events
+                    .get(actor_id)
+                    .map_or_else(Vec::new, |a| a.clone());
+                let status = if supervision_events.is_empty() {
+                    resource::Status::Running
+                } else {
+                    resource::Status::Failed(format!(
+                        "because of supervision events: {:?}",
+                        supervision_events
+                    ))
+                };
+                resource::State {
+                    name: get_state.name.clone(),
+                    status,
+                    state: Some(ActorState {
+                        actor_id: actor_id.clone(),
+                        create_rank: rank,
+                        supervision_events,
+                    }),
+                }
+            }
             Some(Err(e)) => resource::State {
                 name: get_state.name.clone(),
                 status: resource::Status::Failed(e.to_string()),

--- a/hyperactor_mesh/src/resource.rs
+++ b/hyperactor_mesh/src/resource.rs
@@ -26,7 +26,17 @@ use serde::Serialize;
 use crate::v1::Name;
 
 /// The current lifecycle status of a resource.
-#[derive(Debug, Serialize, Deserialize, Named, PartialOrd, Ord, PartialEq, Eq)]
+#[derive(
+    Clone,
+    Debug,
+    Serialize,
+    Deserialize,
+    Named,
+    PartialOrd,
+    Ord,
+    PartialEq,
+    Eq
+)]
 pub enum Status {
     /// The resource does not exist.
     NotExist,
@@ -43,7 +53,7 @@ pub enum Status {
 }
 
 /// The state of a resource.
-#[derive(Debug, Serialize, Deserialize, Named, PartialEq, Eq)]
+#[derive(Clone, Debug, Serialize, Deserialize, Named, PartialEq, Eq)]
 pub struct State<S> {
     /// The name of the resource.
     pub name: Name,

--- a/hyperactor_mesh/src/v1/proc_mesh.rs
+++ b/hyperactor_mesh/src/v1/proc_mesh.rs
@@ -25,7 +25,6 @@ use hyperactor::channel::ChannelAddr;
 use hyperactor::context;
 use hyperactor::mailbox::DialMailboxRouter;
 use hyperactor::mailbox::MailboxServer;
-use hyperactor::supervision::ActorSupervisionEvent;
 use ndslice::Extent;
 use ndslice::ViewExt as _;
 use ndslice::view;
@@ -96,11 +95,11 @@ impl ProcRef {
 
     /// Get the supervision events for one actor with the given name.
     #[allow(dead_code)]
-    async fn supervision_events(
+    async fn actor_state(
         &self,
         cx: &impl context::Actor,
         name: Name,
-    ) -> v1::Result<Vec<ActorSupervisionEvent>> {
+    ) -> v1::Result<resource::State<ActorState>> {
         let (port, mut rx) = cx.mailbox().open_port::<resource::State<ActorState>>();
         self.agent
             .send(
@@ -115,11 +114,10 @@ impl ProcRef {
             .recv()
             .await
             .map_err(|e| Error::CallError(self.agent.actor_id().clone(), e.into()))?;
-        if let Some(state) = state.state {
-            let rank = state.create_rank;
-            let events = state.supervision_events;
+        if let Some(ref inner) = state.state {
+            let rank = inner.create_rank;
             if rank == self.create_rank {
-                Ok(events)
+                Ok(state)
             } else {
                 Err(Error::CallError(
                     self.agent.actor_id().clone(),
@@ -463,11 +461,11 @@ impl ProcMeshRef {
     }
 
     /// The supervision events of procs in this mesh.
-    pub async fn supervision_events(
+    pub async fn actor_states(
         &self,
         cx: &impl context::Actor,
         name: Name,
-    ) -> v1::Result<ValueMesh<Vec<ActorSupervisionEvent>>> {
+    ) -> v1::Result<ValueMesh<resource::State<ActorState>>> {
         let agent_mesh = self.agent_mesh();
         let (port, mut rx) = cx.mailbox().open_port::<resource::State<ActorState>>();
         // TODO: Use accumulation to get back a single value (representing whether
@@ -496,15 +494,8 @@ impl ProcMeshRef {
         states.sort_by_key(|(rank, _)| *rank);
         let vm = states
             .into_iter()
-            .map(|(_, state)| {
-                if let Some(state) = state.state {
-                    state.supervision_events
-                } else {
-                    // Empty vec for ranks with no supervision events.
-                    Vec::new()
-                }
-            })
-            .collect_mesh::<ValueMesh<Vec<_>>>(self.region.clone())?;
+            .map(|(_, state)| state)
+            .collect_mesh::<ValueMesh<_>>(self.region.clone())?;
         Ok(vm)
     }
 


### PR DESCRIPTION
Summary:
Part of: https://github.com/meta-pytorch/monarch/issues/1209

Rename from supervision_events to actor_states, and return the whole State object.
This is more in line with what we want, which is an API that can accumulate statuses across the whole
mesh to continuously monitor when a member transitions to unhealthy.

Reviewed By: shayne-fletcher, mariusae

Differential Revision: D82761485


