### PR TITLE
Fix logging client and mailbox routing for v1 actor mesh

### DIFF
--- a/monarch_extension/src/lib.rs
+++ b/monarch_extension/src/lib.rs
@@ -236,6 +236,11 @@ pub fn mod_init(module: &Bound<'_, PyModule>) -> PyResult<()> {
         "monarch_extension.logging",
     )?)?;
 
+    monarch_hyperactor::v1::logging::register_python_bindings(&get_or_add_new_module(
+        module,
+        "monarch_hyperactor.v1.logging",
+    )?)?;
+
     crate::trace::register_python_bindings(&get_or_add_new_module(
         module,
         "monarch_extension.trace",

--- a/monarch_extension/src/logging.rs
+++ b/monarch_extension/src/logging.rs
@@ -21,6 +21,7 @@ use hyperactor_mesh::logging::LogForwardActor;
 use hyperactor_mesh::logging::LogForwardMessage;
 use hyperactor_mesh::selection::Selection;
 use hyperactor_mesh::shared_cell::SharedCell;
+use monarch_hyperactor::context::PyInstance;
 use monarch_hyperactor::logging::LoggerRuntimeActor;
 use monarch_hyperactor::logging::LoggerRuntimeMessage;
 use monarch_hyperactor::proc_mesh::PyProcMesh;
@@ -85,7 +86,7 @@ impl LoggingMeshClient {
 #[pymethods]
 impl LoggingMeshClient {
     #[staticmethod]
-    fn spawn(proc_mesh: &PyProcMesh) -> PyResult<PyPythonTask> {
+    fn spawn(_instance: &PyInstance, proc_mesh: &PyProcMesh) -> PyResult<PyPythonTask> {
         let proc_mesh = proc_mesh.try_inner()?;
         PyPythonTask::new(async move {
             let client_actor = proc_mesh.client_proc().spawn("log_client", ()).await?;
@@ -135,6 +136,7 @@ impl LoggingMeshClient {
     fn set_mode<'py>(
         &self,
         _py: Python<'py>,
+        _instance: &PyInstance,
         stream_to_client: bool,
         aggregate_window_sec: Option<u64>,
         level: u8,
@@ -175,7 +177,7 @@ impl LoggingMeshClient {
     }
 
     // A sync flush mechanism for the client make sure all the stdout/stderr are streamed back and flushed.
-    fn flush(&self) -> PyResult<PyPythonTask> {
+    fn flush(&self, _instance: &PyInstance) -> PyResult<PyPythonTask> {
         let forwarder_mesh = self.forwarder_mesh.clone();
         let client_actor = self.client_actor.clone();
 

--- a/monarch_hyperactor/src/actor_mesh.rs
+++ b/monarch_hyperactor/src/actor_mesh.rs
@@ -102,12 +102,12 @@ pub(crate) struct PythonActorMesh {
 }
 
 impl PythonActorMesh {
-    pub(crate) fn new<F>(f: F) -> Self
+    pub(crate) fn new<F>(f: F, supervised: bool) -> Self
     where
         F: Future<Output = PyResult<Box<dyn ActorMeshProtocol>>> + Send + 'static,
     {
         PythonActorMesh {
-            inner: Box::new(AsyncActorMesh::new_queue(f)),
+            inner: Box::new(AsyncActorMesh::new_queue(f, supervised)),
         }
     }
     pub(crate) fn from_impl(inner: Box<dyn ActorMeshProtocol>) -> Self {
@@ -551,7 +551,7 @@ pub(crate) struct AsyncActorMesh {
 }
 
 impl AsyncActorMesh {
-    pub(crate) fn new_queue<F>(f: F) -> AsyncActorMesh
+    pub(crate) fn new_queue<F>(f: F, supervised: bool) -> AsyncActorMesh
     where
         F: Future<Output = PyResult<Box<dyn ActorMeshProtocol>>> + Send + 'static,
     {
@@ -567,7 +567,7 @@ impl AsyncActorMesh {
                 }
             }
         });
-        AsyncActorMesh::new(queue, true, f)
+        AsyncActorMesh::new(queue, supervised, f)
     }
     fn new<F>(
         queue: UnboundedSender<Pin<Box<dyn Future<Output = ()> + Send + 'static>>>,

--- a/monarch_hyperactor/src/context.rs
+++ b/monarch_hyperactor/src/context.rs
@@ -56,17 +56,23 @@ macro_rules! instance_dispatch {
             $crate::context::ContextInstance::PythonActor($cx) => $code,
         }
     };
+    ($ins:expr, async |$cx:ident| $code:block) => {
+        match $ins.context_instance() {
+            $crate::context::ContextInstance::Client($cx) => async $code.await,
+            $crate::context::ContextInstance::PythonActor($cx) => async $code.await,
+        }
+    };
     ($ins:expr, async move |$cx:ident| $code:block) => {
         match $ins.context_instance() {
             $crate::context::ContextInstance::Client($cx) => async move $code.await,
             $crate::context::ContextInstance::PythonActor($cx) => async move $code.await,
         }
-    }
+    };
 }
 
 #[derive(Clone)]
 #[pyclass(name = "Instance", module = "monarch._src.actor.actor_mesh")]
-pub(crate) struct PyInstance {
+pub struct PyInstance {
     inner: ContextInstance,
     #[pyo3(get, set)]
     proc_mesh: Option<PyObject>,

--- a/monarch_hyperactor/src/proc_mesh.rs
+++ b/monarch_hyperactor/src/proc_mesh.rs
@@ -366,10 +366,13 @@ impl PyProcMesh {
                 actor_events,
             )))
         };
-        let r = PythonActorMesh::new(async move {
-            let meshimpl: Box<dyn ActorMeshProtocol> = meshimpl.await?;
-            Ok(meshimpl)
-        });
+        let r = PythonActorMesh::new(
+            async move {
+                let meshimpl: Box<dyn ActorMeshProtocol> = meshimpl.await?;
+                Ok(meshimpl)
+            },
+            true,
+        );
         Python::with_gil(|py| r.into_py_any(py))
     }
 

--- a/monarch_hyperactor/src/v1.rs
+++ b/monarch_hyperactor/src/v1.rs
@@ -10,4 +10,5 @@
 
 pub mod actor_mesh;
 pub mod host_mesh;
+pub mod logging;
 pub mod proc_mesh;

--- a/monarch_hyperactor/src/v1/logging.rs
+++ b/monarch_hyperactor/src/v1/logging.rs
@@ -1,0 +1,171 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#![allow(unsafe_op_in_unsafe_fn)]
+
+use std::ops::Deref;
+
+use hyperactor::ActorHandle;
+use hyperactor::context;
+use hyperactor_mesh::logging::LogClientActor;
+use hyperactor_mesh::logging::LogClientMessage;
+use hyperactor_mesh::logging::LogForwardActor;
+use hyperactor_mesh::logging::LogForwardMessage;
+use hyperactor_mesh::v1::ActorMesh;
+use hyperactor_mesh::v1::actor_mesh::ActorMeshRef;
+use ndslice::View;
+use pyo3::Bound;
+use pyo3::prelude::*;
+use pyo3::types::PyModule;
+
+use crate::context::PyInstance;
+use crate::instance_dispatch;
+use crate::logging::LoggerRuntimeActor;
+use crate::logging::LoggerRuntimeMessage;
+use crate::pytokio::PyPythonTask;
+use crate::v1::proc_mesh::PyProcMesh;
+
+#[pyclass(
+    frozen,
+    name = "LoggingMeshClient",
+    module = "monarch._rust_bindings.monarch_hyperactor.v1.logging"
+)]
+pub struct LoggingMeshClient {
+    // handles remote process log forwarding; no python runtime
+    forwarder_mesh: ActorMesh<LogForwardActor>,
+    // handles python logger; has python runtime
+    logger_mesh: ActorMesh<LoggerRuntimeActor>,
+    client_actor: ActorHandle<LogClientActor>,
+}
+
+impl LoggingMeshClient {
+    async fn flush_internal(
+        cx: &impl context::Actor,
+        client_actor: ActorHandle<LogClientActor>,
+        forwarder_mesh: ActorMeshRef<LogForwardActor>,
+    ) -> Result<(), anyhow::Error> {
+        let (reply_tx, reply_rx) = cx.instance().open_once_port::<()>();
+        let (version_tx, version_rx) = cx.instance().open_once_port::<u64>();
+
+        // First initialize a sync flush.
+        client_actor.send(LogClientMessage::StartSyncFlush {
+            expected_procs: forwarder_mesh.region().num_ranks(),
+            reply: reply_tx.bind(),
+            version: version_tx.bind(),
+        })?;
+
+        let version = version_rx.recv().await?;
+
+        // Then ask all the flushers to ask the log forwarders to sync flush
+        forwarder_mesh.cast(cx, LogForwardMessage::ForceSyncFlush { version })?;
+
+        // Finally the forwarder will send sync point back to the client, flush, and return.
+        reply_rx.recv().await?;
+
+        Ok(())
+    }
+}
+
+#[pymethods]
+impl LoggingMeshClient {
+    #[staticmethod]
+    fn spawn(instance: &PyInstance, proc_mesh: &PyProcMesh) -> PyResult<PyPythonTask> {
+        let proc_mesh = proc_mesh.mesh_ref()?;
+        let instance = instance.clone();
+        PyPythonTask::new(async move {
+            let client_actor: ActorHandle<LogClientActor> =
+                instance_dispatch!(instance, async move |cx_instance| {
+                    cx_instance.proc().spawn("log_client", ()).await
+                })?;
+            let client_actor_ref = client_actor.bind();
+            let forwarder_mesh = instance_dispatch!(instance, async |cx_instance| {
+                proc_mesh
+                    .spawn(cx_instance, "log_forwarder", &client_actor_ref)
+                    .await
+            })
+            .map_err(anyhow::Error::from)?;
+            let logger_mesh = instance_dispatch!(instance, async |cx_instance| {
+                proc_mesh.spawn(cx_instance, "logger", &()).await
+            })
+            .map_err(anyhow::Error::from)?;
+
+            // FIXME: Flush on proc mesh stop.
+
+            Ok(Self {
+                forwarder_mesh,
+                logger_mesh,
+                client_actor,
+            })
+        })
+    }
+
+    fn set_mode(
+        &self,
+        instance: &PyInstance,
+        stream_to_client: bool,
+        aggregate_window_sec: Option<u64>,
+        level: u8,
+    ) -> PyResult<()> {
+        if aggregate_window_sec.is_some() && !stream_to_client {
+            return Err(PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(
+                "cannot set aggregate window without streaming to client".to_string(),
+            ));
+        }
+
+        instance_dispatch!(instance, |cx_instance| {
+            self.forwarder_mesh
+                .cast(cx_instance, LogForwardMessage::SetMode { stream_to_client })
+        })
+        .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(e.to_string()))?;
+
+        instance_dispatch!(instance, |cx_instance| {
+            self.logger_mesh
+                .cast(cx_instance, LoggerRuntimeMessage::SetLogging { level })
+        })
+        .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(e.to_string()))?;
+
+        self.client_actor
+            .send(LogClientMessage::SetAggregate {
+                aggregate_window_sec,
+            })
+            .map_err(anyhow::Error::msg)?;
+
+        Ok(())
+    }
+
+    // A sync flush mechanism for the client make sure all the stdout/stderr are streamed back and flushed.
+    fn flush(&self, instance: &PyInstance) -> PyResult<PyPythonTask> {
+        let forwarder_mesh = self.forwarder_mesh.deref().clone();
+        let client_actor = self.client_actor.clone();
+        let instance = instance.clone();
+
+        PyPythonTask::new(async move {
+            instance_dispatch!(instance, async move |cx_instance| {
+                Self::flush_internal(cx_instance, client_actor, forwarder_mesh).await
+            })
+            .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(e.to_string()))
+        })
+    }
+}
+
+impl Drop for LoggingMeshClient {
+    fn drop(&mut self) {
+        match self.client_actor.drain_and_stop() {
+            Ok(_) => {}
+            Err(e) => {
+                // it is ok as during shutdown, the channel might already be closed
+                tracing::debug!("error draining logging client actor during shutdown: {}", e);
+            }
+        }
+    }
+}
+
+pub fn register_python_bindings(module: &Bound<'_, PyModule>) -> PyResult<()> {
+    module.add_class::<LoggingMeshClient>()?;
+    Ok(())
+}

--- a/python/monarch/_rust_bindings/monarch_hyperactor/v1/logging.pyi
+++ b/python/monarch/_rust_bindings/monarch_hyperactor/v1/logging.pyi
@@ -6,12 +6,14 @@
 
 # pyre-strict
 
-from typing import final
+from typing import final, TYPE_CHECKING
 
-from monarch._rust_bindings.monarch_hyperactor.context import Instance
-
-from monarch._rust_bindings.monarch_hyperactor.proc_mesh import ProcMesh
 from monarch._rust_bindings.monarch_hyperactor.pytokio import PythonTask
+
+from monarch._rust_bindings.monarch_hyperactor.v1.proc_mesh import ProcMesh
+
+if TYPE_CHECKING:
+    from monarch._rust_bindings.monarch_hyperactor.context import Instance
 
 @final
 class LoggingMeshClient:

--- a/python/tests/test_python_actors.py
+++ b/python/tests/test_python_actors.py
@@ -1146,7 +1146,11 @@ async def test_multiple_ongoing_flushes_no_deadlock() -> None:
     for _ in range(5):
         # FIXME: the order of futures doesn't necessarily mean the order of flushes due to the async nature.
         await asyncio.sleep(0.1)
-        futures.append(Future(coro=log_mesh.flush().spawn().task()))
+        futures.append(
+            Future(
+                coro=log_mesh.flush(context().actor_instance._as_rust()).spawn().task()
+            )
+        )
 
     # The last flush should not block
     futures[-1].get()


### PR DESCRIPTION
Summary:
Part of: https://github.com/meta-pytorch/monarch/issues/1212

To bring parity between v0 ProcMesh and v1 ProcMesh, we need to revamp the logging
client to take an Instance.

Also, v0 vs v1 proc meshes use a different router depending on who allocated them.
If the root client proc allocates, they have a `DialMailboxRouter`; whereas if the mesh agent
allocates them, they have a `ReconfigurableMailboxSender`.

Handle both of these in the proc mesh agent for now.

Differential Revision: D83104015


