### PR TITLE
: host: add terminate() and kill() to ProcHandle

### DIFF
--- a/hyperactor_mesh/src/v1.rs
+++ b/hyperactor_mesh/src/v1.rs
@@ -13,8 +13,8 @@
 pub mod actor_mesh;
 pub mod host_mesh;
 pub mod proc_mesh;
-mod testactor;
-mod testing;
+pub mod testactor;
+pub mod testing;
 pub mod value_mesh;
 
 use std::str::FromStr;

--- a/hyperactor_mesh/src/v1/host_mesh.rs
+++ b/hyperactor_mesh/src/v1/host_mesh.rs
@@ -33,7 +33,7 @@ use crate::v1;
 use crate::v1::Name;
 use crate::v1::ProcMesh;
 use crate::v1::ProcMeshRef;
-use crate::v1::host_mesh::mesh_agent::HostMeshAgent;
+pub use crate::v1::host_mesh::mesh_agent::HostMeshAgent;
 use crate::v1::host_mesh::mesh_agent::HostMeshAgentProcMeshTrampoline;
 use crate::v1::proc_mesh::ProcRef;
 
@@ -73,6 +73,7 @@ impl FromStr for HostRef {
 }
 
 /// An owned mesh of hosts.
+#[allow(dead_code)]
 pub struct HostMesh {
     name: Name,
     extent: Extent,
@@ -80,6 +81,7 @@ pub struct HostMesh {
     current_ref: HostMeshRef,
 }
 
+#[allow(dead_code)]
 enum HostMeshAllocation {
     /// The host mesh was bootstrapped from a proc mesh.
     /// This is to support providing host meshes through Allocs.
@@ -104,29 +106,29 @@ impl HostMesh {
     /// channel, established by the host.
     ///
     /// ```text
-    ///                        ┌ ─ ─┌────────────────────┐                   
-    ///                             │allocated Proc:     │                   
-    ///                        │    │ ┌─────────────────┐│                   
-    ///                             │ │TrampolineActor  ││                   
-    ///                        │    │ │ ┌──────────────┐││                   
-    ///                             │ │ │Host          │││                   
-    ///               ┌────┬ ─ ┘    │ │ │ ┌──────────┐ │││                   
-    ///            ┌─▶│Proc│        │ │ │ │HostAgent │ │││                   
-    ///            │  └────┴ ─ ┐    │ │ │ └──────────┘ │││                   
-    ///            │  ┌────┐        │ │ │             ██████                 
-    /// ┌────────┐ ├─▶│Proc│   │    │ │ └──────────────┘││ ▲                 
+    ///                        ┌ ─ ─┌────────────────────┐
+    ///                             │allocated Proc:     │
+    ///                        │    │ ┌─────────────────┐│
+    ///                             │ │TrampolineActor  ││
+    ///                        │    │ │ ┌──────────────┐││
+    ///                             │ │ │Host          │││
+    ///               ┌────┬ ─ ┘    │ │ │ ┌──────────┐ │││
+    ///            ┌─▶│Proc│        │ │ │ │HostAgent │ │││
+    ///            │  └────┴ ─ ┐    │ │ │ └──────────┘ │││
+    ///            │  ┌────┐        │ │ │             ██████
+    /// ┌────────┐ ├─▶│Proc│   │    │ │ └──────────────┘││ ▲
     /// │ Client │─┤  └────┘        │ └─────────────────┘│ listening channel
-    /// └────────┘ │  ┌────┐   └ ─ ─└────────────────────┘                   
-    ///            ├─▶│Proc│                                                 
-    ///            │  └────┘                                                 
-    ///            │  ┌────┐                                                 
-    ///            └─▶│Proc│                                                 
-    ///               └────┘                                                 
-    ///                 ▲                                                    
-    ///                                                                     
-    ///          `Alloc`-provided                                            
-    ///                procs               
-    /// ```                                  
+    /// └────────┘ │  ┌────┐   └ ─ ─└────────────────────┘
+    ///            ├─▶│Proc│
+    ///            │  └────┘
+    ///            │  ┌────┐
+    ///            └─▶│Proc│
+    ///               └────┘
+    ///                 ▲
+    ///
+    ///          `Alloc`-provided
+    ///                procs
+    /// ```
     pub async fn allocate(
         cx: &impl context::Actor,
         alloc: Box<dyn Alloc + Send + Sync>,

--- a/hyperactor_mesh/src/v1/proc_mesh.rs
+++ b/hyperactor_mesh/src/v1/proc_mesh.rs
@@ -76,8 +76,7 @@ impl ProcRef {
 
     /// Pings the proc, returning whether it is alive. This will be replaced by a
     /// finer-grained lifecycle status in the near future.
-    #[allow(dead_code)]
-    async fn status(&self, cx: &impl context::Actor) -> v1::Result<bool> {
+    pub(crate) async fn status(&self, cx: &impl context::Actor) -> v1::Result<bool> {
         let (port, mut rx) = cx.mailbox().open_port();
         self.agent
             .status(cx, port.bind())
@@ -148,6 +147,7 @@ impl ProcRef {
 }
 
 /// A mesh of processes.
+#[allow(dead_code)]
 #[derive(Debug)]
 pub struct ProcMesh {
     name: Name,
@@ -648,7 +648,6 @@ mod tests {
     use ndslice::extent;
     use timed_test::async_timed_test;
 
-    use crate::v1::ActorMesh;
     use crate::v1::testactor;
     use crate::v1::testing;
 

--- a/hyperactor_mesh/test/bootstrap.rs
+++ b/hyperactor_mesh/test/bootstrap.rs
@@ -10,6 +10,15 @@
 /// simply invoking [`hyperactor_mesh::bootstrap_or_die`].
 #[tokio::main]
 async fn main() {
+    // This causes folly to intercept SIGTERM. When run in
+    // '@fbcode//mode/dev-nosan' that translates into SEGFAULTs.
     hyperactor::initialize_with_current_runtime();
+    // SAFETY: Does not derefrence pointers or rely on undefined
+    // memory. No other threads are likely to be modifying it
+    // concurrently.
+    unsafe {
+        libc::signal(libc::SIGTERM, libc::SIG_DFL);
+    }
+
     hyperactor_mesh::bootstrap_or_die().await;
 }


### PR DESCRIPTION
Summary: this change extends the `ProcHandle` surface with `terminate(timeout)` and `kill()`, introduces `TerminateError`, and clarifies proc- vs process-lifecycle semantics. `LocalProcManager` now implements proc-level shutdown via `Proc::destroy_and_wait`, while the toy `ProcessProcManager` leaves signaling unsupported. on the bootstrap side, `ProcStatus::Stopping` now carries `{ pid, started_at }`, and the handle implements graceful `SIGTERM `with a deadline (falling back to `SIGKILL`) plus a direct `kill()`. new tests cover graceful terminate, forced kill, status transitions, and the canonical v1 flow; docs/comments were tightened accordingly.  in addition, helper methods like `signalable_pid` and send_signal encapsulate POSIX signaling, and a new bootstrap test suite validates integration from allocator → host mesh → proc mesh → actor mesh, asserting correct ID round-trips and message delivery in the canonical flow.

Differential Revision: D83299896


