### PR TITLE
: bootstrap: no auto-spawn log actors in v1

### DIFF
--- a/hyperactor_mesh/src/proc_mesh/mesh_agent.rs
+++ b/hyperactor_mesh/src/proc_mesh/mesh_agent.rs
@@ -212,25 +212,6 @@ impl ProcMeshAgent {
     }
 
     pub(crate) async fn boot_v1(proc: Proc) -> Result<ActorHandle<Self>, anyhow::Error> {
-        // Spawn a LogClientActor in this proc. It aggregates and
-        // prints logs coming from our stdout/stderr (via the parent's
-        // log writers). This is the sink for all forwarded LogMessage
-        // traffic.
-        let log_client_ref = proc
-            .spawn("log_client", ())
-            .await?
-            .bind::<crate::logging::LogClientActor>();
-
-        // Spawn a LogForwardActor. It serves BOOTSTRAP_LOG_CHANNEL
-        // (set by the parent ProcManager) and forwards any LogMessage
-        // it receives there into the above LogClientActor. Together
-        // these give us structured log forwarding without blocking
-        // pipes.
-        let _log_fwd_ref = proc
-            .spawn("log_forwarder", log_client_ref.clone())
-            .await?
-            .bind::<crate::logging::LogForwardActor>();
-
         let agent = ProcMeshAgent {
             proc: proc.clone(),
             remote: Remote::collect(),


### PR DESCRIPTION
Summary:
samlurye reported: "I keep seeing this error:
```
[3] [0] [1 similar log lines] [3]E0925 17:01:40.760842 4028178 hyperactor/src/channel.rs:642] error:listen: unix:gCmMugVT3dGiorTwR42K6O4D Address already in use (os error 98)
[3] [0] [1 similar log lines] [3]E0925 17:01:40.760854 4028178 hyperactor_mesh/src/logging.rs:634] log forwarder actor failed to bootstrap on given channel unix:gCmMugVT3dGiorTwR42K6O4D: listen: unix:gCmMugVT3dGiorTwR42K6O4D Address already in use (os error 98)"
```
and later,

"I figured it out. ProcMeshAgent::boot_v1 spawns its own LogForwardActor, which isn't compatible with LoggingManager: https://fburl.com/code/xw2u7ts8. Because LoggingManager also spawns LogForwardActor across the proc mesh."

this makes sense. in v0 we never auto-spawned log actors; the parent just wired writers at spawn and left it up to higher-level managers to decide if/when to drain logs. by contrast, v1's `ProcMeshAgent::boot_v1` was eagerly spawning `LogForwardActor`s and `LogClientActor`s  (and not tracking their existence in the proc's `created` resource registry), which conflicted with `LoggingManager`  - `LoggingManager` also wants to spawn those across the proc mesh. that double spawning is what led to the "address already in use" errors.

with this diff we drop the eager auto-spawn and instead make tests explicitly create the forwarder/client if they need structured log forwarding. that restores parity with v0:
- parent always sets `BOOTSTRAP_LOG_CHANNEL` and wires the writers,
- `dial` returns a `Tx` immediately but it only goes `Active` once someone serves the channel,
- until then we just drain to local stdout/stderr, so no backpressure and no double-serve errors.

so this is the right direction: we're back to v0 semantics, and higher-level managers (e.g. `LoggingManager`) can layer in forwarding without clashing.

Differential Revision: D83489725


