### PR TITLE
Fix Reference::from_str v1::Name::Suffixed

### DIFF
--- a/hyperactor/src/reference.rs
+++ b/hyperactor/src/reference.rs
@@ -1386,6 +1386,16 @@ mod tests {
                 )
                 .into(),
             ),
+            (
+                // References with v1::Name::Suffixed for actor names are parseable
+                "test[234].testactor_12345[6]",
+                ActorId(
+                    ProcId::Ranked(WorldId("test".into()), 234),
+                    "testactor_12345".into(),
+                    6,
+                )
+                .into(),
+            ),
         ];
 
         for (s, expected) in cases {
@@ -1395,7 +1405,12 @@ mod tests {
 
     #[test]
     fn test_reference_parse_error() {
-        let cases: Vec<&str> = vec!["(blah)", "world(1, 2, 3)"];
+        let cases: Vec<&str> = vec![
+            "(blah)",
+            "world(1, 2, 3)",
+            // hyphen is not allowed in actor name
+            "test[234].testactor-12345[6]",
+        ];
 
         for s in cases {
             let result: Result<Reference, ReferenceParsingError> = s.parse();


### PR DESCRIPTION
Summary:
Fixes https://github.com/meta-pytorch/monarch/issues/1352

The v1::Name format with a random uuid included a hyphen character that wasn't
parseable as a rust identifier. This is used by the "Reference" parsing logic for a fully
qualified world + proc + actor name.

Change to underscore to fix this, as I don't think the choice of hyphen has any other
special meaning.

Differential Revision: D83495465


