### PR TITLE
Wait for send message to be queued before exiting

### DIFF
--- a/hyperactor_mesh/src/alloc/remoteprocess.rs
+++ b/hyperactor_mesh/src/alloc/remoteprocess.rs
@@ -459,10 +459,17 @@ impl RemoteProcessAllocator {
                             tx.post(RemoteProcessProcStateMessage::Update(alloc_key.clone(), event));
                         }
                         None => {
-                            tracing::debug!("sending done");
-                            tx.post(RemoteProcessProcStateMessage::Done(alloc_key.clone()));
-                            running = false;
-                            break;
+                            let done_message = RemoteProcessProcStateMessage::Done(alloc_key.clone());
+                            tracing::debug!("{:?}", done_message);
+                            match tx.send(done_message).await {
+                                Ok(_) => {
+                                    running = false;
+                                    break;
+                                }
+                                Err(e) => {
+                                    tracing::error!("Failed to send done message: {}", e);
+                                }
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
Summary:
The proc mesh stop stress tests have been failing intermittently. It gets stuck here https://www.internalfb.com/code/fbsource/[f57ffe8d4469f825bd6f7cc2c8ebbe94702ffcca]/fbcode/monarch/monarch_hyperactor/src/proc_mesh.rs?lines=279

I could confirm that the alloc stops, but we get stuck waiting in the next() loop here. https://www.internalfb.com/code/fbsource/[f57ffe8d4469f825bd6f7cc2c8ebbe94702ffcca]/fbcode/monarch/hyperactor_mesh/src/alloc.rs?lines=263 

Based on some logs, I believe that the issue happens when the remote process allocator is sending the "Done" message, however that message is not received on the other end, because of which we don't exit the loop. 

Currently we're sending the message with a post, which doesn't capture any errors.in this diff we change it to a proper send. If it is a failure then we do not break out of the loop.

Differential Revision: D83312094


