### PR TITLE
hg mv rdma.py to monarch/rdma

### DIFF
--- a/docs/source/examples/getting_started.py
+++ b/docs/source/examples/getting_started.py
@@ -293,7 +293,7 @@ class SupervisorActor(Actor):
 # once an actor has a handle to a buffer, it can read or write to the buffer without the owner of the buffer.
 
 import torch
-from monarch.tensor_engine import RDMABuffer
+from monarch.rdma import RDMABuffer
 
 
 class ParameterServer(Actor):
@@ -346,8 +346,6 @@ worker.sync_weights.call_one(server).get()
 # This lets a single actor directly compute with tensors distributed across a mesh of processes.
 #
 # We can use distributed features by 'activating' a ProcMesh:
-
-import torch
 
 with trainer_procs.activate():
     t = torch.rand(3, 4)

--- a/docs/source/rdma.py
+++ b/docs/source/rdma.py
@@ -15,7 +15,7 @@ This is meant to be merged with the getting_started guide.
 
 import torch
 from monarch.actor import Actor, endpoint, this_host
-from monarch.tensor_engine import RDMABuffer
+from monarch.rdma import RDMABuffer
 
 # %%
 # Point-to-Point RDMA

--- a/python/monarch/_src/rdma/__init__.py
+++ b/python/monarch/_src/rdma/__init__.py
@@ -5,8 +5,3 @@
 # LICENSE file in the root directory of this source tree.
 
 # pyre-unsafe
-
-# Currently empty - RDMA has moved to monarch.rdma
-# Future tensor engine functionality will be added here
-
-__all__ = []

--- a/python/monarch/_src/rdma/rdma.py
+++ b/python/monarch/_src/rdma/rdma.py
@@ -43,7 +43,7 @@ warnings.simplefilter("once", RDMAReadTransferWarning)
 warnings.simplefilter("once", RDMAWriteTransferWarning)
 
 
-def is_available():
+def is_rdma_available():
     return _RdmaBuffer.rdma_supported()
 
 
@@ -218,7 +218,7 @@ class RDMABuffer:
             _check_cuda_expandable_segments_enabled()
 
         assert (
-            is_available()
+            is_rdma_available()
         ), "Tried to create an RDMABuffer, but RDMA is not available on this platform."
 
         # We need to ensure that _RdmaManager is initialized at this point, because under the hood

--- a/python/monarch/rdma/__init__.py
+++ b/python/monarch/rdma/__init__.py
@@ -1,0 +1,25 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-unsafe
+
+"""
+Monarch RDMA API - Public interface for RDMA functionality.
+"""
+
+from monarch._src.rdma.rdma import (
+    is_rdma_available,
+    RDMABuffer,
+    RDMAReadTransferWarning,
+    RDMAWriteTransferWarning,
+)
+
+__all__ = [
+    "is_rdma_available",
+    "RDMABuffer",
+    "RDMAReadTransferWarning",
+    "RDMAWriteTransferWarning",
+]

--- a/python/tests/rdma_load_test.py
+++ b/python/tests/rdma_load_test.py
@@ -61,7 +61,7 @@ else:
 # pyre-ignore
 import torch
 from monarch.actor import Actor, endpoint, this_host
-from monarch.tensor_engine import RDMABuffer
+from monarch.rdma import RDMABuffer
 
 
 class RDMATest(Actor):

--- a/python/tests/test_rdma.py
+++ b/python/tests/test_rdma.py
@@ -13,7 +13,7 @@ os.environ["PYTORCH_CUDA_ALLOC_CONF"] = "expandable_segments:True"
 import pytest
 import torch
 from monarch.actor import Actor, current_rank, endpoint, this_host
-from monarch.tensor_engine import is_available as rdma_available, RDMABuffer
+from monarch.rdma import is_rdma_available, RDMABuffer
 
 
 needs_cuda = pytest.mark.skipif(
@@ -21,7 +21,7 @@ needs_cuda = pytest.mark.skipif(
     reason="CUDA not available",
 )
 needs_rdma = pytest.mark.skipif(
-    not rdma_available(),
+    not is_rdma_available(),
     reason="RDMA not available",
 )
 

--- a/python/tests/test_rdma_unit.py
+++ b/python/tests/test_rdma_unit.py
@@ -6,7 +6,7 @@
 
 # pyre-unsafe
 """
-Unit tests for python/monarch/_src/tensor_engine/rdma.py
+Unit tests for python/monarch/_src/rdma/rdma.py
 
 RDMA Testing Architecture - Dataflow Summary
 ===========================================
@@ -87,7 +87,7 @@ import pytest
 
 import torch
 from monarch.actor import Actor, endpoint, this_host
-from monarch.tensor_engine import is_available as rdma_available, RDMABuffer
+from monarch.rdma import is_rdma_available, RDMABuffer
 
 TIMEOUT = 60  # 60 seconds
 
@@ -110,7 +110,7 @@ needs_cuda = pytest.mark.skipif(
     reason="CUDA not available",
 )
 needs_rdma = pytest.mark.skipif(
-    not rdma_available(),
+    not is_rdma_available(),
     reason="RDMA not available",
 )
 

--- a/python/tests/test_rdma_unsupported.py
+++ b/python/tests/test_rdma_unsupported.py
@@ -14,10 +14,10 @@ behavior when RDMA support is missing.
 """
 
 import pytest
-from monarch.tensor_engine import is_available as rdma_available
+from monarch.rdma import is_rdma_available
 
 needs_no_rdma = pytest.mark.skipif(
-    rdma_available(),
+    is_rdma_available(),
     reason="RDMA is available, test only runs on systems without RDMA support",
 )
 


### PR DESCRIPTION
Summary:
As per user discussions, the import path is confusing.   Move of import path from monarch/tensor_engine to monarch/rdma.  Resubmit of prior diff w/ proper edit history mechanics.

Additional minor changes
rename is_available() to is_rdma_available()
some linter fixes
update reference example (grpo_actor) to use updated spawn behavior.

Differential Revision: D83583220
