### PR TITLE
: bootstrap: add optional config snapshot to Bootstrap variants with logging and tests

### DIFF
--- a/hyperactor_mesh/src/v1/host_mesh.rs
+++ b/hyperactor_mesh/src/v1/host_mesh.rs
@@ -767,7 +767,10 @@ mod tests {
         let mut children = Vec::new();
         for host in hosts.iter() {
             let mut cmd = Command::new(program.clone());
-            let boot = Bootstrap::Host { addr: host.clone() };
+            let boot = Bootstrap::Host {
+                addr: host.clone(),
+                config: None,
+            };
             boot.to_env(&mut cmd);
             cmd.kill_on_drop(true);
             children.push(cmd.spawn().unwrap());


### PR DESCRIPTION
Summary: this diff adds producer-side support for embedding an optional config snapshot in `Bootstrap::Proc` and `Bootstrap::Host`. the snapshot is serialized as JSON, base64-encoded, and carried through the bootstrap payload. when present, the child process currently just logs the snapshot length (or a warning on decode failure) but does not apply it yet; that will follow in a later change. tests exercise round-trips with and without config, invalid base64, opaque payloads, and large payloads. call sites that construct `Bootstrap` were updated to set config: None.

Differential Revision: D83667836


