### PR TITLE
[hyperactor] mesh: concurrent spawns, aggregated statuses

### DIFF
--- a/hyperactor/src/message.rs
+++ b/hyperactor/src/message.rs
@@ -136,6 +136,15 @@ impl<M> Unbound<M> {
     pub fn new(message: M, bindings: Bindings) -> Self {
         Self { message, bindings }
     }
+
+    /// Use the provided function to update values inside bindings in the same
+    /// order as they were pushed into bindings.
+    pub fn visit_mut<T: Serialize + DeserializeOwned + Named>(
+        &mut self,
+        f: impl FnMut(&mut T) -> anyhow::Result<()>,
+    ) -> anyhow::Result<()> {
+        self.bindings.visit_mut(f)
+    }
 }
 
 impl<M: Bind> Unbound<M> {

--- a/hyperactor_mesh/src/comm.rs
+++ b/hyperactor_mesh/src/comm.rs
@@ -8,6 +8,7 @@
 
 use crate::comm::multicast::CAST_ORIGINATING_SENDER;
 use crate::reference::ActorMeshId;
+use crate::resource;
 pub mod multicast;
 
 use std::cmp::Ordering;
@@ -279,6 +280,13 @@ impl CommActor {
         if deliver_here {
             let rank_on_root_mesh = mode.self_rank(cx.self_id())?;
             let cast_rank = message.relative_rank(rank_on_root_mesh)?;
+            // Replace ranks with self ranks.
+            message
+                .data_mut()
+                .visit_mut::<resource::Rank>(|resource::Rank(rank)| {
+                    *rank = Some(cast_rank);
+                    Ok(())
+                })?;
             let cast_shape = message.shape();
             let point = cast_shape
                 .extent()

--- a/hyperactor_mesh/src/lib.rs
+++ b/hyperactor_mesh/src/lib.rs
@@ -12,6 +12,8 @@
 #![feature(exit_status_error)]
 #![feature(impl_trait_in_bindings)]
 #![feature(let_chains)]
+#![feature(get_disjoint_mut_helpers)]
+#![feature(exact_size_is_empty)]
 
 pub mod actor_mesh;
 pub mod alloc;

--- a/hyperactor_mesh/src/proc_mesh/mesh_agent.rs
+++ b/hyperactor_mesh/src/proc_mesh/mesh_agent.rs
@@ -54,7 +54,6 @@ use serde::Serialize;
 
 use crate::proc_mesh::SupervisionEventState;
 use crate::resource;
-use crate::resource::RankStatus;
 use crate::v1::Name;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Named)]

--- a/hyperactor_mesh/src/proc_mesh/mesh_agent.rs
+++ b/hyperactor_mesh/src/proc_mesh/mesh_agent.rs
@@ -54,6 +54,7 @@ use serde::Serialize;
 
 use crate::proc_mesh::SupervisionEventState;
 use crate::resource;
+use crate::resource::RankStatus;
 use crate::v1::Name;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Named)]
@@ -164,13 +165,21 @@ impl State {
     }
 }
 
+/// Actor state used for v1 API.
+#[derive(Debug)]
+struct ActorInstanceState {
+    create_rank: usize,
+    spawn: Result<ActorId, anyhow::Error>,
+}
+
 /// A mesh agent is responsible for managing procs in a [`ProcMesh`].
 #[derive(Debug)]
 #[hyperactor::export(
     handlers=[
         MeshAgentMessage,
-        resource::CreateOrUpdate<ActorSpec>,
+        resource::CreateOrUpdate<ActorSpec> { cast = true },
         resource::GetState<ActorState> { cast = true },
+        resource::GetRankStatus { cast = true },
     ]
 )]
 pub struct ProcMeshAgent {
@@ -178,7 +187,7 @@ pub struct ProcMeshAgent {
     remote: Remote,
     state: State,
     /// Actors created and tracked through the resource behavior.
-    created: HashMap<Name, Result<ActorId, anyhow::Error>>,
+    actor_states: HashMap<Name, ActorInstanceState>,
     /// If true, and supervisor is None, record supervision events to be reported
     /// to owning actors later.
     record_supervision_events: bool,
@@ -203,7 +212,7 @@ impl ProcMeshAgent {
             proc: proc.clone(),
             remote: Remote::collect(),
             state: State::UnconfiguredV0 { sender },
-            created: HashMap::new(),
+            actor_states: HashMap::new(),
             record_supervision_events: false,
             supervision_events: HashMap::new(),
         };
@@ -216,7 +225,7 @@ impl ProcMeshAgent {
             proc: proc.clone(),
             remote: Remote::collect(),
             state: State::V1,
-            created: HashMap::new(),
+            actor_states: HashMap::new(),
             record_supervision_events: true,
             supervision_events: HashMap::new(),
         };
@@ -442,10 +451,10 @@ pub struct ActorState {
 impl Handler<resource::CreateOrUpdate<ActorSpec>> for ProcMeshAgent {
     async fn handle(
         &mut self,
-        cx: &Context<Self>,
+        _cx: &Context<Self>,
         create_or_update: resource::CreateOrUpdate<ActorSpec>,
     ) -> anyhow::Result<()> {
-        if self.created.contains_key(&create_or_update.name) {
+        if self.actor_states.contains_key(&create_or_update.name) {
             // There is no update.
             return Ok(());
         }
@@ -454,19 +463,63 @@ impl Handler<resource::CreateOrUpdate<ActorSpec>> for ProcMeshAgent {
             actor_type,
             params_data,
         } = create_or_update.spec;
-        self.created.insert(
+        self.actor_states.insert(
             create_or_update.name.clone(),
-            self.remote
-                .gspawn(
-                    &self.proc,
-                    &actor_type,
-                    &create_or_update.name.to_string(),
-                    params_data,
-                )
-                .await,
+            ActorInstanceState {
+                create_rank: create_or_update.rank.unwrap(),
+                spawn: self
+                    .remote
+                    .gspawn(
+                        &self.proc,
+                        &actor_type,
+                        &create_or_update.name.to_string(),
+                        params_data,
+                    )
+                    .await,
+            },
         );
 
-        create_or_update.reply.send(cx, true)?;
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl Handler<resource::GetRankStatus> for ProcMeshAgent {
+    async fn handle(
+        &mut self,
+        cx: &Context<Self>,
+        get_rank_status: resource::GetRankStatus,
+    ) -> anyhow::Result<()> {
+        let (rank, status) = match self.actor_states.get(&get_rank_status.name) {
+            Some(ActorInstanceState {
+                spawn: Ok(actor_id),
+                create_rank,
+            }) => {
+                let supervision_events = self
+                    .supervision_events
+                    .get(actor_id)
+                    .map_or_else(Vec::new, |a| a.clone());
+                (
+                    *create_rank,
+                    if supervision_events.is_empty() {
+                        resource::Status::Running
+                    } else {
+                        resource::Status::Failed(format!(
+                            "because of supervision events: {:?}",
+                            supervision_events
+                        ))
+                    },
+                )
+            }
+            Some(ActorInstanceState {
+                spawn: Err(e),
+                create_rank,
+            }) => (*create_rank, resource::Status::Failed(e.to_string())),
+            // TODO: represent unknown rank
+            None => (usize::MAX, resource::Status::NotExist),
+        };
+
+        get_rank_status.reply.send(cx, (rank, status).into())?;
         Ok(())
     }
 }
@@ -478,12 +531,11 @@ impl Handler<resource::GetState<ActorState>> for ProcMeshAgent {
         cx: &Context<Self>,
         get_state: resource::GetState<ActorState>,
     ) -> anyhow::Result<()> {
-        let rank = self
-            .state
-            .rank()
-            .ok_or_else(|| anyhow::anyhow!("tried to get status of unconfigured proc"))?;
-        let state = match self.created.get(&get_state.name) {
-            Some(Ok(actor_id)) => {
+        let state = match self.actor_states.get(&get_state.name) {
+            Some(ActorInstanceState {
+                create_rank,
+                spawn: Ok(actor_id),
+            }) => {
                 let supervision_events = self
                     .supervision_events
                     .get(actor_id)
@@ -501,12 +553,12 @@ impl Handler<resource::GetState<ActorState>> for ProcMeshAgent {
                     status,
                     state: Some(ActorState {
                         actor_id: actor_id.clone(),
-                        create_rank: rank,
+                        create_rank: *create_rank,
                         supervision_events,
                     }),
                 }
             }
-            Some(Err(e)) => resource::State {
+            Some(ActorInstanceState { spawn: Err(e), .. }) => resource::State {
                 name: get_state.name.clone(),
                 status: resource::Status::Failed(e.to_string()),
                 state: None,

--- a/hyperactor_mesh/src/resource.rs
+++ b/hyperactor_mesh/src/resource.rs
@@ -9,14 +9,27 @@
 //! This modules defines a set of common message types used for managing resources
 //! in hyperactor meshes.
 
+use core::slice::GetDisjointMutIndex as _;
 use std::fmt::Debug;
+use std::hash::Hash;
+use std::marker::PhantomData;
+use std::mem::replace;
+use std::mem::take;
+use std::ops::Range;
 
+use enum_as_inner::EnumAsInner;
+use hyperactor::Bind;
 use hyperactor::HandleClient;
 use hyperactor::Handler;
 use hyperactor::Named;
 use hyperactor::PortRef;
 use hyperactor::RefClient;
 use hyperactor::RemoteMessage;
+use hyperactor::Unbind;
+use hyperactor::accum::Accumulator;
+use hyperactor::accum::CommReducer;
+use hyperactor::accum::ReducerFactory;
+use hyperactor::accum::ReducerSpec;
 use hyperactor::message::Bind;
 use hyperactor::message::Bindings;
 use hyperactor::message::Unbind;
@@ -35,7 +48,9 @@ use crate::v1::Name;
     PartialOrd,
     Ord,
     PartialEq,
-    Eq
+    Eq,
+    Hash,
+    EnumAsInner
 )]
 pub enum Status {
     /// The resource does not exist.
@@ -52,6 +67,67 @@ pub enum Status {
     Failed(String),
 }
 
+impl Status {
+    /// Returns whether the status is a terminating status.
+    pub fn is_terminating(&self) -> bool {
+        matches!(self, Status::Stopping | Status::Stopped | Status::Failed(_))
+    }
+}
+
+/// Data type used to communicate ranks.
+/// Implements [`Bind`] and [`Unbind`]; the comm actor replaces
+/// instances with the delivered rank.
+#[derive(Clone, Debug, Serialize, Deserialize, Named, PartialEq, Eq, Default)]
+pub struct Rank(pub Option<usize>);
+
+impl Rank {
+    /// Create a new rank with the provided value.
+    pub fn new(rank: usize) -> Self {
+        Self(Some(rank))
+    }
+
+    /// Unwrap the rank; panics if not set.
+    pub fn unwrap(&self) -> usize {
+        self.0.unwrap()
+    }
+}
+
+impl Unbind for Rank {
+    fn unbind(&self, bindings: &mut Bindings) -> anyhow::Result<()> {
+        bindings.push_back(self)
+    }
+}
+
+impl Bind for Rank {
+    fn bind(&mut self, bindings: &mut Bindings) -> anyhow::Result<()> {
+        let bound = bindings.try_pop_front::<Rank>()?;
+        self.0 = bound.0;
+        Ok(())
+    }
+}
+
+/// Get the status of a resource at a rank. This message is designed to be
+/// cast and efficiently accumulated.
+#[derive(
+    Clone,
+    Debug,
+    Serialize,
+    Deserialize,
+    Named,
+    Handler,
+    HandleClient,
+    RefClient,
+    Bind,
+    Unbind
+)]
+pub struct GetRankStatus {
+    /// The name of the resource.
+    pub name: Name,
+    /// The status of the rank.
+    #[binding(include)]
+    pub reply: PortRef<RankedValues<Status>>,
+}
+
 /// The state of a resource.
 #[derive(Clone, Debug, Serialize, Deserialize, Named, PartialEq, Eq)]
 pub struct State<S> {
@@ -64,15 +140,26 @@ pub struct State<S> {
 }
 
 /// Create or update a resource according to a spec.
-#[derive(Debug, Serialize, Deserialize, Named, Handler, HandleClient, RefClient)]
+#[derive(
+    Debug,
+    Clone,
+    Serialize,
+    Deserialize,
+    Named,
+    Handler,
+    HandleClient,
+    RefClient,
+    Bind,
+    Unbind
+)]
 pub struct CreateOrUpdate<S> {
     /// The name of the resource to create or update.
     pub name: Name,
+    /// The rank of the resource, when available.
+    #[binding(include)]
+    pub rank: Rank,
     /// The specification of the resource.
     pub spec: S,
-    /// Whether the operation succeeded.
-    #[reply]
-    pub reply: PortRef<bool>,
 }
 
 /// Retrieve the current state of the resource.
@@ -115,5 +202,227 @@ where
             name: self.name.clone(),
             reply: self.reply.clone(),
         }
+    }
+}
+
+/// RankedValues compactly represents rank-indexed values of type T.
+/// It stores contiguous values in a set of intervals; thus it is
+/// efficient and compact when the cardinality of T-typed values is
+/// low.
+#[derive(Debug, Clone, Named, Serialize, Deserialize)]
+pub struct RankedValues<T> {
+    intervals: Vec<(Range<usize>, T)>,
+}
+
+impl<T> Default for RankedValues<T> {
+    fn default() -> Self {
+        Self {
+            intervals: Vec::new(),
+        }
+    }
+}
+
+impl<T> RankedValues<T> {
+    /// Iterate over contiguous rank intervals of values.
+    pub fn iter(&self) -> impl Iterator<Item = &(Range<usize>, T)> + '_ {
+        self.intervals.iter()
+    }
+
+    /// The (set) rank of the RankedValues is the number of values stored with
+    /// rank less than `value`.
+    pub fn rank(&self, value: usize) -> usize {
+        self.iter()
+            .take_while(|(ranks, _)| ranks.start <= value)
+            .map(|(ranks, _)| ranks.end.min(value) - ranks.start)
+            .sum()
+    }
+}
+
+impl<T: Eq + Clone> RankedValues<T> {
+    /// Merge `other` into this set of ranked values. Values in `other` that overlap
+    /// with `self` take prededence.
+    ///
+    /// This currently uses a simple algorithm that merges the full set of RankedValues.
+    /// This remains efficient when the cardinality of T-typed values is low. However,
+    /// it does not efficiently merge high cardinality value sets. Consider using interval
+    /// trees or bitmap techniques like Roaring Bitmaps in these cases.
+    pub fn merge_from(&mut self, other: Self) {
+        let mut left_iter = take(&mut self.intervals).into_iter();
+        let mut right_iter = other.intervals.into_iter();
+
+        let mut left = left_iter.next();
+        let mut right = right_iter.next();
+
+        while left.is_some() && right.is_some() {
+            let (left_ranks, left_value) = left.as_mut().unwrap();
+            let (right_ranks, right_value) = right.as_mut().unwrap();
+
+            if left_ranks.is_overlapping(right_ranks) {
+                if left_value == right_value {
+                    let ranks = left_ranks.start.min(right_ranks.start)..right_ranks.end;
+                    let (_, value) = replace(&mut right, right_iter.next()).unwrap();
+                    left_ranks.start = ranks.end;
+                    if left_ranks.is_empty() {
+                        left = left_iter.next();
+                    }
+                    self.append(ranks, value);
+                } else if left_ranks.start < right_ranks.start {
+                    let ranks = left_ranks.start..right_ranks.start;
+                    left_ranks.start = ranks.end;
+                    // TODO: get rid of clone
+                    self.append(ranks, left_value.clone());
+                } else {
+                    let (ranks, value) = replace(&mut right, right_iter.next()).unwrap();
+                    left_ranks.start = ranks.end;
+                    if left_ranks.is_empty() {
+                        left = left_iter.next();
+                    }
+                    self.append(ranks, value);
+                }
+            } else if left_ranks.start < right_ranks.start {
+                let (ranks, value) = replace(&mut left, left_iter.next()).unwrap();
+                self.append(ranks, value);
+            } else {
+                let (ranks, value) = replace(&mut right, right_iter.next()).unwrap();
+                self.append(ranks, value);
+            }
+        }
+
+        while let Some((left_ranks, left_value)) = left {
+            self.append(left_ranks, left_value);
+            left = left_iter.next();
+        }
+        while let Some((right_ranks, right_value)) = right {
+            self.append(right_ranks, right_value);
+            right = right_iter.next();
+        }
+    }
+
+    fn append(&mut self, range: Range<usize>, value: T) {
+        if let Some(last) = self.intervals.last_mut()
+            && last.0.end == range.start
+            && last.1 == value
+        {
+            last.0.end = range.end;
+        } else {
+            self.intervals.push((range, value));
+        }
+    }
+}
+
+impl<T> From<(usize, T)> for RankedValues<T> {
+    fn from((rank, value): (usize, T)) -> Self {
+        Self {
+            intervals: vec![(rank..rank + 1, value)],
+        }
+    }
+}
+
+/// Enabled for test only because we have to guarantee that the input
+/// iterator is well-formed.
+#[cfg(test)]
+impl<T> FromIterator<(Range<usize>, T)> for RankedValues<T> {
+    fn from_iter<I: IntoIterator<Item = (Range<usize>, T)>>(iter: I) -> Self {
+        Self {
+            intervals: iter.into_iter().collect(),
+        }
+    }
+}
+
+impl<T: Eq + Clone + Named> Accumulator for RankedValues<T> {
+    type State = Self;
+    type Update = Self;
+
+    fn accumulate(&self, state: &mut Self::State, update: Self::Update) -> anyhow::Result<()> {
+        state.merge_from(update);
+        Ok(())
+    }
+
+    fn reducer_spec(&self) -> Option<ReducerSpec> {
+        None
+        // TODO: make this work. When it is enabled, the comm actor simply halts.
+        // Some(ReducerSpec {
+        //     typehash: <RankedValuesReducer<T> as Named>::typehash(),
+        //     builder_params: None,
+        // })
+    }
+}
+
+#[derive(Named)]
+struct RankedValuesReducer<T>(std::marker::PhantomData<T>);
+
+impl<T: Hash + Eq + Ord + Clone> CommReducer for RankedValuesReducer<T> {
+    type Update = RankedValues<T>;
+
+    fn reduce(&self, mut left: Self::Update, right: Self::Update) -> anyhow::Result<Self::Update> {
+        left.merge_from(right);
+        Ok(left)
+    }
+}
+
+// register for concrete types:
+
+hyperactor::submit! {
+    ReducerFactory {
+        typehash_f: <RankedValuesReducer<Status> as Named>::typehash,
+        builder_f: |_| Ok(Box::new(RankedValuesReducer::<Status>(PhantomData))),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_ranked_values_merge() {
+        #[derive(PartialEq, Debug, Eq, Clone)]
+        enum Side {
+            Left,
+            Right,
+            Both,
+        }
+        use Side::Both;
+        use Side::Left;
+        use Side::Right;
+
+        let mut left: RankedValues<Side> = [
+            (0..10, Left),
+            (15..20, Left),
+            (30..50, Both),
+            (60..70, Both),
+        ]
+        .into_iter()
+        .collect();
+
+        let right: RankedValues<Side> = [
+            (9..12, Right),
+            (25..30, Right),
+            (30..40, Both),
+            (40..50, Right),
+            (50..60, Both),
+        ]
+        .into_iter()
+        .collect();
+
+        left.merge_from(right);
+        assert_eq!(
+            left.iter().cloned().collect::<Vec<_>>(),
+            vec![
+                (0..9, Left),
+                (9..12, Right),
+                (15..20, Left),
+                (25..30, Right),
+                (30..40, Both),
+                (40..50, Right),
+                // Merge consecutive:
+                (50..70, Both)
+            ]
+        );
+
+        assert_eq!(left.rank(5), 5);
+        assert_eq!(left.rank(10), 10);
+        assert_eq!(left.rank(16), 13);
+        assert_eq!(left.rank(70), 62);
+        assert_eq!(left.rank(100), 62);
     }
 }

--- a/hyperactor_mesh/src/v1.rs
+++ b/hyperactor_mesh/src/v1.rs
@@ -32,6 +32,7 @@ use serde::Deserialize;
 use serde::Serialize;
 pub use value_mesh::ValueMesh;
 
+use crate::resource;
 use crate::shortuuid::ShortUuid;
 use crate::v1::host_mesh::HostMeshAgent;
 use crate::v1::host_mesh::HostMeshRefParseError;
@@ -74,6 +75,7 @@ pub enum Error {
     #[error("actor not registered for type {0}")]
     ActorTypeNotRegistered(String),
 
+    // TODO: this should be a valuemesh of statuses
     #[error("error while spawning actor {0}: {1}")]
     GspawnError(Name, String),
 
@@ -91,6 +93,7 @@ pub enum Error {
         proc_name: Name,
         mesh_agent: ActorRef<HostMeshAgent>,
         host_rank: usize,
+        status: resource::Status,
     },
 
     #[error("error: {0} does not exist")]

--- a/hyperactor_mesh/src/v1/actor_mesh.rs
+++ b/hyperactor_mesh/src/v1/actor_mesh.rs
@@ -21,7 +21,7 @@ use hyperactor::actor::RemoteActor;
 use hyperactor::attrs::Attrs;
 use hyperactor::context;
 use hyperactor::message::Castable;
-use hyperactor::message::ErasedUnbound;
+
 use hyperactor::message::IndexedErasedUnbound;
 use hyperactor::message::Unbound;
 use hyperactor_mesh_macros::sel;
@@ -153,16 +153,16 @@ impl<A: Actor + RemoteActor> ActorMeshRef<A> {
                 // Make sure that we re-bind ranks, as these may be used for
                 // bootstrapping comm actors.
                 let mut unbound = Unbound::try_from_message(message.clone())
-                    .map_err(|e| Error::CastingError(self.name.clone(), e.into()))?;
+                    .map_err(|e| Error::CastingError(self.name.clone(), e))?;
                 unbound
                     .visit_mut::<resource::Rank>(|resource::Rank(rank)| {
                         *rank = Some(create_rank);
                         Ok(())
                     })
-                    .map_err(|e| Error::CastingError(self.name.clone(), e.into()))?;
+                    .map_err(|e| Error::CastingError(self.name.clone(), e))?;
                 let rebound_message = unbound
                     .bind()
-                    .map_err(|e| Error::CastingError(self.name.clone(), e.into()))?;
+                    .map_err(|e| Error::CastingError(self.name.clone(), e))?;
                 actor
                     .send_with_headers(cx, headers, rebound_message)
                     .map_err(|e| Error::SendingError(actor.actor_id().clone(), Box::new(e)))?;

--- a/hyperactor_mesh/src/v1/actor_mesh.rs
+++ b/hyperactor_mesh/src/v1/actor_mesh.rs
@@ -21,7 +21,9 @@ use hyperactor::actor::RemoteActor;
 use hyperactor::attrs::Attrs;
 use hyperactor::context;
 use hyperactor::message::Castable;
+use hyperactor::message::ErasedUnbound;
 use hyperactor::message::IndexedErasedUnbound;
+use hyperactor::message::Unbound;
 use hyperactor_mesh_macros::sel;
 use ndslice::Selection;
 use ndslice::ViewExt as _;
@@ -140,6 +142,7 @@ impl<A: Actor + RemoteActor> ActorMeshRef<A> {
             self.cast_v0(cx, message, root_comm_actor)
         } else {
             for (point, actor) in self.iter() {
+                let create_rank = point.rank();
                 let mut headers = Attrs::new();
                 headers.set(
                     multicast::CAST_ORIGINATING_SENDER,
@@ -147,8 +150,21 @@ impl<A: Actor + RemoteActor> ActorMeshRef<A> {
                 );
                 headers.set(multicast::CAST_POINT, point);
 
+                // Make sure that we re-bind ranks, as these may be used for
+                // bootstrapping comm actors.
+                let mut unbound = Unbound::try_from_message(message.clone())
+                    .map_err(|e| Error::CastingError(self.name.clone(), e.into()))?;
+                unbound
+                    .visit_mut::<resource::Rank>(|resource::Rank(rank)| {
+                        *rank = Some(create_rank);
+                        Ok(())
+                    })
+                    .map_err(|e| Error::CastingError(self.name.clone(), e.into()))?;
+                let rebound_message = unbound
+                    .bind()
+                    .map_err(|e| Error::CastingError(self.name.clone(), e.into()))?;
                 actor
-                    .send_with_headers(cx, headers, message.clone())
+                    .send_with_headers(cx, headers, rebound_message)
                     .map_err(|e| Error::SendingError(actor.actor_id().clone(), Box::new(e)))?;
             }
             Ok(())

--- a/hyperactor_mesh/src/v1/host_mesh.rs
+++ b/hyperactor_mesh/src/v1/host_mesh.rs
@@ -31,7 +31,10 @@ use serde::Serialize;
 
 use crate::alloc::Alloc;
 use crate::bootstrap::BootstrapCommand;
+use crate::resource;
 use crate::resource::CreateOrUpdateClient;
+use crate::resource::GetRankStatusClient;
+use crate::resource::RankedValues;
 use crate::v1;
 use crate::v1::Name;
 use crate::v1::ProcMesh;
@@ -463,6 +466,9 @@ impl HostMeshRef {
 
     /// Spawn a ProcMesh onto this host mesh. The per_host extent specifies the shape
     /// of the procs to spawn on each host.
+    ///
+    /// Currently, spawn issues direct calls to each host agent. This will be fixed by
+    /// maintaining a comm actor on the host service procs themselves.
     pub async fn spawn(
         &self,
         cx: &impl context::Actor,
@@ -501,12 +507,19 @@ impl HostMeshRef {
 
         let mesh_name = Name::new(name);
         let mut procs = Vec::new();
+        let num_ranks = self.region().num_ranks() * per_host.num_ranks();
+        let (port, mut rx) = cx.mailbox().open_accum_port(RankedValues::default());
+        // We CreateOrUpdate each proc, and then fence on getting statuses back.
+        // This is currently necessary because otherwise there is a race between
+        // the procs being created, and subsequent messages becoming unroutable
+        // (the agent actor manages the local muxer). We can solve this by allowing
+        // buffering in the host-level muxer.
         for (host_rank, host) in self.ranks.iter().enumerate() {
             for per_host_rank in 0..per_host.num_ranks() {
+                let create_rank = per_host.num_ranks() * host_rank + per_host_rank;
                 let proc_name = Name::new(format!("{}-{}", name, per_host_rank));
-                let ok = host
-                    .mesh_agent()
-                    .create_or_update(cx, proc_name.clone(), ())
+                host.mesh_agent()
+                    .create_or_update(cx, proc_name.clone(), resource::Rank::new(create_rank), ())
                     .await
                     .map_err(|e| {
                         v1::Error::HostMeshAgentConfigurationError(
@@ -514,20 +527,42 @@ impl HostMeshRef {
                             format!("failed while creating proc: {}", e),
                         )
                     })?;
-                if !ok {
-                    // TODO: clean up the rest of the procs
-                    return Err(v1::Error::ProcCreationError {
-                        proc_name,
-                        mesh_agent: host.mesh_agent(),
-                        host_rank,
-                    });
-                }
+                host.mesh_agent()
+                    .get_rank_status(cx, proc_name.clone(), port.bind())
+                    .await
+                    .map_err(|e| {
+                        v1::Error::HostMeshAgentConfigurationError(
+                            host.mesh_agent().actor_id().clone(),
+                            format!("failed while querying proc status: {}", e),
+                        )
+                    })?;
                 procs.push(ProcRef::new(
                     host.named_proc(&proc_name),
-                    per_host.num_ranks() * host_rank + per_host_rank,
+                    create_rank,
                     // TODO: specify or retrieve from state instead, to avoid attestation.
                     ActorRef::attest(host.named_proc(&proc_name).actor_id("agent", 0)),
                 ));
+            }
+        }
+
+        // fence: wait for everyone to report back.
+        loop {
+            let statuses = rx.recv().await?;
+            if let Some((ranks, status)) =
+                statuses.iter().find(|(_, status)| status.is_terminating())
+            {
+                let rank = ranks.start;
+                let proc_name = Name::new(format!("{}-{}", name, rank % per_host.num_ranks()));
+                return Err(v1::Error::ProcCreationError {
+                    proc_name,
+                    mesh_agent: self.ranks[rank].mesh_agent(),
+                    host_rank: rank / per_host.num_ranks(),
+                    status: status.clone(),
+                });
+            }
+
+            if statuses.rank(num_ranks) == num_ranks {
+                break;
             }
         }
 
@@ -611,6 +646,7 @@ impl FromStr for HostMeshRef {
 
 #[cfg(test)]
 mod tests {
+    use std::assert_matches::assert_matches;
     use std::collections::HashSet;
     use std::collections::VecDeque;
 
@@ -672,8 +708,10 @@ mod tests {
                 .spawn(instance, "test_1", Extent::unity())
                 .await
                 .unwrap();
+
             let actor_mesh1: ActorMesh<testactor::TestActor> =
                 proc_mesh1.spawn(instance, "test", &()).await.unwrap();
+
             let proc_mesh2 = host_mesh
                 .spawn(instance, "test_2", extent!(gpus = 3, extra = 2))
                 .await
@@ -683,6 +721,7 @@ mod tests {
                 extent!(replicas = 4, gpus = 3, extra = 2)
             );
             assert_eq!(proc_mesh2.values().count(), 24);
+
             let actor_mesh2: ActorMesh<testactor::TestActor> =
                 proc_mesh2.spawn(instance, "test", &()).await.unwrap();
             assert_eq!(
@@ -775,7 +814,10 @@ mod tests {
         let mut children = Vec::new();
         for host in hosts.iter() {
             let mut cmd = Command::new(program.clone());
-            let boot = Bootstrap::Host { addr: host.clone() };
+            let boot = Bootstrap::Host {
+                addr: host.clone(),
+                command: None, // use current binary
+            };
             boot.to_env(&mut cmd);
             cmd.kill_on_drop(true);
             children.push(cmd.spawn().unwrap());
@@ -783,10 +825,12 @@ mod tests {
 
         let instance = testing::instance().await;
         let host_mesh = HostMeshRef::from_hosts(hosts);
+
         let proc_mesh = host_mesh
             .spawn(&testing::instance().await, "test", Extent::unity())
             .await
             .unwrap();
+
         let actor_mesh: ActorMesh<testactor::TestActor> = proc_mesh
             .spawn(&testing::instance().await, "test", &())
             .await
@@ -798,5 +842,37 @@ mod tests {
             .shutdown(&instance)
             .await
             .expect("hosts shutdown");
+    }
+
+    #[tokio::test]
+    async fn test_failing_proc_allocation() {
+        let program = buck_resources::get("monarch/hyperactor_mesh/bootstrap").unwrap();
+
+        let hosts = vec![free_localhost_addr(), free_localhost_addr()];
+
+        let mut children = Vec::new();
+        for host in hosts.iter() {
+            let mut cmd = Command::new(program.clone());
+            let boot = Bootstrap::Host {
+                addr: host.clone(),
+                // The entire purpose of this is to fail:
+                command: Some(BootstrapCommand::from("/bin/false")),
+            };
+            boot.to_env(&mut cmd);
+            cmd.kill_on_drop(true);
+            children.push(cmd.spawn().unwrap());
+        }
+        let host_mesh = HostMeshRef::from_hosts(hosts);
+
+        let instance = testing::instance().await;
+
+        let err = host_mesh
+            .spawn(&instance, "test", Extent::unity())
+            .await
+            .unwrap_err();
+        assert_matches!(
+            err, v1::Error::ProcCreationError { status: resource::Status::Failed(msg), .. }
+            if msg.contains("failed to configure process: Terminal(Stopped { exit_code: 1 })")
+        );
     }
 }

--- a/hyperactor_mesh/src/v1/host_mesh/mesh_agent.rs
+++ b/hyperactor_mesh/src/v1/host_mesh/mesh_agent.rs
@@ -37,6 +37,7 @@ use crate::bootstrap::BootstrapCommand;
 use crate::bootstrap::BootstrapProcManager;
 use crate::proc_mesh::mesh_agent::ProcMeshAgent;
 use crate::resource;
+use crate::resource::RankStatus;
 use crate::v1::Name;
 
 type ProcManagerSpawnFuture =
@@ -71,10 +72,17 @@ impl HostAgentMode {
 
 /// A mesh agent is responsible for managing a host iny a [`HostMesh`],
 /// through the resource behaviors defined in [`crate::resource`].
-#[hyperactor::export(handlers=[resource::CreateOrUpdate<()>, resource::GetState<ProcState>, ShutdownHost])]
+#[hyperactor::export(
+    handlers=[
+        resource::CreateOrUpdate<()>, 
+        resource::GetState<ProcState>,
+        resource::GetRankStatus,
+        ShutdownHost
+    ]
+)]
 pub struct HostMeshAgent {
     host: Option<HostAgentMode>,
-    created: HashMap<Name, Result<(ProcId, ActorRef<ProcMeshAgent>), HostError>>,
+    created: HashMap<Name, (usize, Result<(ProcId, ActorRef<ProcMeshAgent>), HostError>)>,
 }
 
 impl fmt::Debug for HostMeshAgent {
@@ -103,11 +111,11 @@ impl Handler<resource::CreateOrUpdate<()>> for HostMeshAgent {
     #[tracing::instrument("HostMeshAgent::CreateOrUpdate", level = "info", skip_all, fields(name=%create_or_update.name))]
     async fn handle(
         &mut self,
-        cx: &Context<Self>,
+        _cx: &Context<Self>,
         create_or_update: resource::CreateOrUpdate<()>,
     ) -> anyhow::Result<()> {
         if self.created.contains_key(&create_or_update.name) {
-            // There is no update.
+            // Already created: there is no update.
             return Ok(());
         }
 
@@ -120,13 +128,35 @@ impl Handler<resource::CreateOrUpdate<()>> for HostMeshAgent {
                 host.spawn(create_or_update.name.clone().to_string()).await
             }
         };
-        let ok = created.is_ok();
+
         if let Err(e) = &created {
             tracing::error!("failed to spawn proc {}: {}", create_or_update.name, e);
         }
-        self.created.insert(create_or_update.name.clone(), created);
-        create_or_update.reply.send(cx, ok)?;
+        self.created.insert(create_or_update.name.clone(), (create_or_update.rank.unwrap(), created));
 
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl Handler<resource::GetRankStatus> for HostMeshAgent {
+    async fn handle(
+        &mut self,
+        cx: &Context<Self>,
+        get_rank_status: resource::GetRankStatus,
+    ) -> anyhow::Result<()> {
+        let Some(created) = self.created.get(&get_rank_status.name) else {
+            // TODO: how can we get the host's rank here? we should model its absence explicitly.
+            get_rank_status.reply.send(cx, (usize::MAX, resource::Status::NotExist).into())?;
+            return Ok(());
+        };
+        
+        let rank_status = match created {
+            (rank, Ok(_)) => (*rank, resource::Status::Running),
+            (rank, Err(e)) => (*rank, resource::Status::Failed(e.to_string())),
+        };
+        get_rank_status.reply.send(cx, rank_status.into())?;
+        
         Ok(())
     }
 }
@@ -176,7 +206,7 @@ impl Handler<resource::GetState<ProcState>> for HostMeshAgent {
             .as_process()
             .map(Host::manager);
         let state = match self.created.get(&get_state.name) {
-            Some(Ok((proc_id, mesh_agent))) => resource::State {
+            Some((_rank, Ok((proc_id, mesh_agent)))) => resource::State {
                 name: get_state.name.clone(),
                 status: resource::Status::Running,
                 state: Some(ProcState {
@@ -189,7 +219,7 @@ impl Handler<resource::GetState<ProcState>> for HostMeshAgent {
                     },
                 }),
             },
-            Some(Err(e)) => resource::State {
+            Some((_rank, Err(e))) => resource::State {
                 name: get_state.name.clone(),
                 status: resource::Status::Failed(e.to_string()),
                 state: None,
@@ -321,12 +351,10 @@ mod tests {
 
         // First, create the proc, then query its state:
 
-        assert!(
-            host_agent
-                .create_or_update(&client, name.clone(), ())
-                .await
-                .unwrap()
-        );
+        host_agent
+            .create_or_update(&client, name.clone(), resource::Rank::new(0), ())
+            .await
+            .unwrap();
         assert_matches!(
             host_agent.get_state(&client, name.clone()).await.unwrap(),
             resource::State {

--- a/hyperactor_mesh/src/v1/proc_mesh.rs
+++ b/hyperactor_mesh/src/v1/proc_mesh.rs
@@ -17,6 +17,7 @@ use hyperactor::ActorId;
 use hyperactor::ActorRef;
 use hyperactor::Named;
 use hyperactor::ProcId;
+use hyperactor::RemoteHandles;
 use hyperactor::RemoteMessage;
 use hyperactor::actor::RemoteActor;
 use hyperactor::actor::remote::Remote;
@@ -25,6 +26,8 @@ use hyperactor::channel::ChannelAddr;
 use hyperactor::context;
 use hyperactor::mailbox::DialMailboxRouter;
 use hyperactor::mailbox::MailboxServer;
+use hyperactor::message::Castable;
+use hyperactor::message::IndexedErasedUnbound;
 use ndslice::Extent;
 use ndslice::ViewExt as _;
 use ndslice::view;
@@ -47,6 +50,7 @@ use crate::proc_mesh::mesh_agent::MeshAgentMessageClient;
 use crate::proc_mesh::mesh_agent::ProcMeshAgent;
 use crate::proc_mesh::mesh_agent::ReconfigurableMailboxSender;
 use crate::resource;
+use crate::resource::RankedValues;
 use crate::v1;
 use crate::v1::ActorMesh;
 use crate::v1::ActorMeshRef;
@@ -184,11 +188,11 @@ impl ProcMesh {
             region,
             ranks,
             None, // this is the root mesh
-            root_comm_actor,
+            None, // comm actor is not alive yet
         )
         .unwrap();
 
-        let proc_mesh = Self {
+        let mut proc_mesh = Self {
             name,
             allocation,
             comm_actor_name: comm_actor_name.clone(),
@@ -210,7 +214,11 @@ impl ProcMesh {
                     .send(cx, CommActorMode::Mesh(*rank, address_book.clone()))
                     .map_err(|e| Error::SendingError(comm_actor.actor_id().clone(), Box::new(e)))?
             }
+
+            // The comm actor is now set up and ready to go.
+            proc_mesh.current_ref.root_comm_actor = root_comm_actor;
         }
+
         Ok(proc_mesh)
     }
 
@@ -534,7 +542,7 @@ impl ProcMeshRef {
         self.spawn_with_name(cx, Name::new(name), params).await
     }
 
-    pub async fn spawn_with_name<A: Actor + RemoteActor>(
+    pub(crate) async fn spawn_with_name<A: Actor + RemoteActor>(
         &self,
         cx: &impl context::Actor,
         name: Name,
@@ -551,58 +559,52 @@ impl ProcMeshRef {
 
         let serialized_params = bincode::serialize(params)?;
 
-        let (completed_handle, mut completed_receiver) = cx.mailbox().open_port();
-        for (rank, proc_ref) in self.ranks.iter().enumerate() {
-            proc_ref
-                .agent
-                .send(
-                    cx,
-                    resource::CreateOrUpdate::<mesh_agent::ActorSpec> {
-                        name: name.clone(),
-                        spec: mesh_agent::ActorSpec {
-                            actor_type: actor_type.clone(),
-                            params_data: serialized_params.clone(),
-                        },
-                        reply: completed_handle.contramap(move |ok| (rank, ok)).bind(),
-                    },
-                )
-                .map_err(|e| Error::SendingError(proc_ref.agent.actor_id().clone(), Box::new(e)))?;
-        }
+        self.agent_mesh().cast(
+            cx,
+            resource::CreateOrUpdate::<mesh_agent::ActorSpec> {
+                name: name.clone(),
+                rank: Default::default(),
+                spec: mesh_agent::ActorSpec {
+                    actor_type: actor_type.clone(),
+                    params_data: serialized_params.clone(),
+                },
+            },
+        )?;
 
-        let mut completed = Ranks::new(self.ranks.len());
-        while !completed.is_full() {
-            let (rank, ok) = completed_receiver.recv().await?;
-            if rank >= self.ranks.len() {
-                tracing::error!("ignoring invalid rank {}", rank);
-                continue;
+        let (port, mut rx) = cx.mailbox().open_accum_port(RankedValues::default());
+
+        self.agent_mesh().cast(
+            cx,
+            resource::GetRankStatus {
+                name: name.clone(),
+                reply: port.bind(),
+            },
+        )?;
+
+        // Wait for everyone to report back.
+        // TODO: move out of critical path
+        let statuses = loop {
+            let statuses = rx.recv().await?;
+            if statuses.rank(self.ranks.len()) == self.ranks.len() {
+                break statuses;
             }
+        };
 
-            if completed.insert(rank, (rank, ok)).is_some() {
-                tracing::error!("multiple completions received for rank {}", rank);
-            }
-        }
-
-        // TODO: at this point, we know that non-failed ranks have been created.
-        // This is good enough for mailbox setup: the actors are now routable.
-        //
-        // However, we should retrieve detailed failure information from failed spawns.
-
-        let failed: Vec<_> = completed
-            .into_iter()
-            .filter_map(|rank| {
-                if let Some((rank, ok)) = rank
-                    && !ok
-                {
-                    Some(rank)
+        let failed: Vec<_> = statuses
+            .iter()
+            .filter_map(|(ranks, status)| {
+                if status.is_terminating() {
+                    Some(ranks.clone())
                 } else {
                     None
                 }
             })
+            .flatten()
             .collect();
         if !failed.is_empty() {
             return Err(Error::GspawnError(
                 name,
-                format!("failed ranks: {:?}", failed),
+                format!("failed ranks: {:?}", failed,),
             ));
         }
 
@@ -644,10 +646,13 @@ impl view::RankedSliceable for ProcMeshRef {
 
 #[cfg(test)]
 mod tests {
+    use std::assert_matches::assert_matches;
+
     use ndslice::ViewExt;
     use ndslice::extent;
     use timed_test::async_timed_test;
 
+    use crate::v1;
     use crate::v1::testactor;
     use crate::v1::testing;
 
@@ -682,6 +687,21 @@ mod tests {
         for proc_mesh in testing::proc_meshes(&instance, extent!(replicas = 4, hosts = 2)).await {
             testactor::assert_mesh_shape(proc_mesh.spawn(instance, "test", &()).await.unwrap())
                 .await;
+        }
+    }
+
+    #[tokio::test]
+    async fn test_failing_spawn_actor() {
+        hyperactor_telemetry::initialize_logging(hyperactor::clock::ClockKind::default());
+
+        let instance = testing::instance().await;
+
+        for proc_mesh in testing::proc_meshes(&instance, extent!(replicas = 4, hosts = 2)).await {
+            let err = proc_mesh
+                .spawn::<testactor::FailingCreateTestActor>(instance, "testfail", &())
+                .await
+                .unwrap_err();
+            assert_matches!(err, v1::Error::GspawnError(_, _))
         }
     }
 }

--- a/hyperactor_mesh/src/v1/proc_mesh.rs
+++ b/hyperactor_mesh/src/v1/proc_mesh.rs
@@ -17,7 +17,7 @@ use hyperactor::ActorId;
 use hyperactor::ActorRef;
 use hyperactor::Named;
 use hyperactor::ProcId;
-use hyperactor::RemoteHandles;
+
 use hyperactor::RemoteMessage;
 use hyperactor::actor::RemoteActor;
 use hyperactor::actor::remote::Remote;
@@ -26,8 +26,8 @@ use hyperactor::channel::ChannelAddr;
 use hyperactor::context;
 use hyperactor::mailbox::DialMailboxRouter;
 use hyperactor::mailbox::MailboxServer;
-use hyperactor::message::Castable;
-use hyperactor::message::IndexedErasedUnbound;
+
+
 use ndslice::Extent;
 use ndslice::ViewExt as _;
 use ndslice::view;

--- a/hyperactor_mesh/src/v1/testactor.rs
+++ b/hyperactor_mesh/src/v1/testactor.rs
@@ -213,6 +213,19 @@ impl Handler<GetCastInfo> for TestActor {
     }
 }
 
+#[derive(Default, Debug)]
+#[hyperactor::export(spawn = true)]
+pub struct FailingCreateTestActor;
+
+#[async_trait]
+impl Actor for FailingCreateTestActor {
+    type Params = ();
+
+    async fn new(params: Self::Params) -> Result<Self, hyperactor::anyhow::Error> {
+        Err(anyhow::anyhow!("test failure"))
+    }
+}
+
 #[cfg(test)]
 /// Asserts that the provided actor mesh has the expected shape,
 /// and all actors are assigned the correct ranks. We also test

--- a/hyperactor_mesh/src/v1/testing.rs
+++ b/hyperactor_mesh/src/v1/testing.rs
@@ -92,7 +92,7 @@ pub async fn allocs(extent: Extent) -> Vec<Box<dyn Alloc + Send + Sync>> {
     };
 
     vec![
-        Box::new(LocalAllocator.allocate(spec.clone()).await.unwrap()),
+        // Box::new(LocalAllocator.allocate(spec.clone()).await.unwrap()),
         Box::new(
             ProcessAllocator::new(Command::new(
                 buck_resources::get("monarch/hyperactor_mesh/bootstrap").unwrap(),


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #1394
* #1379
* #1378
* #1373
* #1372

This adds concurrent spawning for procs, and introduces a principled cast/accumulate status aggregation.

The latter lets us efficiently determine the status of a mesh, and apply whatever policy makes sense in context (e.g., early exit).

We will use GetRankStatus also to apply liveness checks for actors, as we can support this efficiently.

This change also introduces an RLE-encoded data structure, RankedValues, which works well for low-cardinality contexts (e.g., statuses); but to use it more generally for value meshes will require that the merge operation be optimized.

Differential Revision: [D83678884](https://our.internmc.facebook.com/intern/diff/D83678884/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D83678884/)!