### PR TITLE
/[hyperactor_mesh]: apply producer-supplied config snapshots during bootstrap and freeze global re-init

### DIFF
--- a/hyperactor/Cargo.toml
+++ b/hyperactor/Cargo.toml
@@ -40,6 +40,7 @@ edition = "2024"
 anyhow = "1.0.98"
 async-trait = "0.1.86"
 backoff = { version = "0.4.0", features = ["futures", "tokio"] }
+base64 = { version = "0.22.1", features = ["alloc"] }
 bincode = "1.3.3"
 bytes = { version = "1.10", features = ["serde"] }
 chrono = { version = "0.4.41", features = ["clock", "serde", "std"], default-features = false }

--- a/hyperactor/src/config.rs
+++ b/hyperactor/src/config.rs
@@ -8,9 +8,19 @@
 
 //! Configuration for Hyperactor.
 //!
-//! This module provides a centralized way to manage configuration settings for Hyperactor.
-//! It uses the attrs system for type-safe, flexible configuration management that supports
-//! environment variables, YAML files, and temporary modifications for tests.
+//! This module provides a centralized way to manage configuration
+//! settings for Hyperactor. It uses the attrs system for type-safe,
+//! flexible configuration management. Sources include built-in
+//! defaults, environment variables, YAML files, explicit snapshots,
+//! and temporary overrides for tests.
+//!
+//! **Precedence summary (first match wins):**
+//! 1) `install_snapshot` (frozen snapshot, if present)
+//! 2) `init_from_yaml` / `init_from_env` (when not frozen)
+//! 3) Built-in defaults on each key
+//!
+//! Test-only overrides (`global::lock().override_key(...)`) layer on
+//! top for the lifetime of their guards.
 
 use std::env;
 use std::fs::File;
@@ -19,6 +29,8 @@ use std::path::Path;
 use std::sync::Arc;
 use std::sync::LazyLock;
 use std::sync::RwLock;
+use std::sync::atomic::AtomicBool;
+use std::sync::atomic::Ordering;
 use std::time::Duration;
 
 use shell_quote::QuoteRefExt;
@@ -176,7 +188,7 @@ pub fn to_yaml<P: AsRef<Path>>(attrs: &Attrs, path: P) -> Result<(), anyhow::Err
 /// Tests can override global configuration using [`global::lock`]. This ensures that
 /// such tests are serialized (and cannot clobber each other's overrides).
 ///
-/// ```ignore rust
+/// ```rust,ignore
 /// #[test]
 /// fn test_my_feature() {
 ///     let config = hyperactor::config::global::lock();
@@ -187,19 +199,41 @@ pub fn to_yaml<P: AsRef<Path>>(attrs: &Attrs, path: P) -> Result<(), anyhow::Err
 pub mod global {
     use std::marker::PhantomData;
 
+    use base64::prelude::*;
+
     use super::*;
     use crate::attrs::AttrValue;
     use crate::attrs::Key;
 
-    /// Global configuration instance, initialized from environment variables.
+    /// Global configuration instance.
+    ///
+    /// At process startup this is initialized from environment
+    /// variables via [`from_env`], overlaying values on top of each
+    /// key’s built-in defaults. In this normal mode, the config may
+    /// later be reinitialized (e.g., from YAML). However, once
+    /// [`install_snapshot`] is called, the current values are
+    /// replaced wholesale with the provided snapshot and [`FROZEN`]
+    /// is set.
+    ///
+    /// "Frozen" means re-initialization paths (env/yaml loaders) are
+    /// disabled for the rest of the process lifetime. It does *not*
+    /// prevent explicit, programmatic overrides (e.g. in tests with
+    /// `override_key`) or later snapshots via another call to
+    /// [`install_snapshot`]. Defaults continue to apply for any keys
+    /// not set in the snapshot.
     static CONFIG: LazyLock<Arc<RwLock<Attrs>>> =
         LazyLock::new(|| Arc::new(RwLock::new(from_env())));
 
-    /// Acquire the global configuration lock for testing.
+    // When true, global config is "frozen" by a snapshot and may not be
+    // reinitialized.
+    static FROZEN: AtomicBool = AtomicBool::new(false);
+
+    /// Acquire the global configuration lock.
     ///
-    /// This function returns a ConfigLock that acts as both a write lock guard (preventing
-    /// other tests from modifying global config concurrently) and as the only way to
-    /// create configuration overrides.
+    /// The returned [`ConfigLock`] serializes all mutations of the global config,
+    /// ensuring they don't clobber each other. In practice this is most often used
+    /// in tests to apply temporary overrides, but it can be used anywhere mutation
+    /// is required.
     ///
     /// Example usage:
     /// ```ignore rust
@@ -214,19 +248,124 @@ pub mod global {
         }
     }
 
-    /// Initialize the global configuration from environment variables
+    /// Apply a base64-encoded JSON snapshot of `Attrs` as the global
+    /// config.
+    ///
+    /// `kind` is a short label for the caller/context (e.g., "Proc",
+    /// "Host"). On success installs the snapshot and freezes further
+    /// re-init. On failure (decode or JSON), logs and leaves the
+    /// current config unchanged.
+    ///
+    /// The JSON must be the standard `Attrs` serialization
+    /// (`serde_json` for `hyperactor::attrs::Attrs`).
+    pub fn maybe_apply_snapshot_from_b64(kind: &'static str, cfg_b64: &Option<String>) {
+        if let Some(s) = cfg_b64 {
+            match BASE64_STANDARD.decode(s) {
+                Ok(bytes) => {
+                    tracing::debug!(
+                        config_b64_len = s.len(),
+                        config_decoded_len = bytes.len(),
+                        "config: applying snapshot ({kind})"
+                    );
+                    match serde_json::from_slice::<Attrs>(&bytes) {
+                        Ok(attrs) => {
+                            install_snapshot(attrs);
+                            tracing::debug!("config: applied snapshot and froze ({kind})");
+                        }
+                        Err(e) => {
+                            tracing::warn!(error=%e, "config: invalid snapshot JSON ({kind}); ignoring");
+                        }
+                    }
+                }
+                Err(e) => {
+                    tracing::warn!(error=%e, "config: base64 decode failed ({kind}); ignoring");
+                }
+            }
+        } else {
+            tracing::debug!("config: no snapshot provided ({kind})");
+        }
+    }
+
+    /// Install an explicit config snapshot and freeze further
+    /// re-initialization.
+    ///
+    /// Replaces the current global values with the provided [`Attrs`]
+    /// and sets [`FROZEN`]. This disables environment- and YAML-based
+    /// re-init paths for the rest of the process lifetime, ensuring
+    /// the snapshot remains the authoritative source of truth.
+    ///
+    /// "Frozen" means re-initialization paths (env/yaml loaders) are
+    /// disabled for the rest of the process lifetime. This does *not*
+    /// prevent other snapshots being installed explicitly with
+    /// [`install_snapshot`], nor does it block programmatic overrides
+    /// taken under the global config lock (e.g.,
+    /// `global::lock().override_key(...)`). Defaults always apply for
+    /// any keys not set in the snapshot.
+    ///
+    /// Note: this updates only the in-process global configuration;
+    /// it does not set or clear any process environment variables.
+    pub fn install_snapshot(attrs: Attrs) {
+        let mut global = CONFIG.write().unwrap();
+        *global = attrs;
+        FROZEN.store(true, Ordering::SeqCst);
+        tracing::debug!("global config: installed snapshot and froze further re-init");
+    }
+
+    /// Has the global config been frozen by a snapshot?
+    pub fn is_frozen() -> bool {
+        FROZEN.load(Ordering::SeqCst)
+    }
+
+    /// Initialize the global configuration from environment
+    /// variables.
+    ///
+    /// Loads values from environment (overlaying defaults). No effect
+    /// if [`FROZEN`] has been set via [`install_snapshot`].
     pub fn init_from_env() {
+        if FROZEN.load(Ordering::SeqCst) {
+            tracing::debug!("global config frozen; ignoring init_from_env()");
+            return;
+        }
         let config = from_env();
         let mut global_config = CONFIG.write().unwrap();
         *global_config = config;
     }
 
-    /// Initialize the global configuration from a YAML file
+    /// Initialize the global configuration from a YAML file.
+    ///
+    /// Loads values from a YAML file (overlaying defaults). No effect
+    /// if [`FROZEN`] has been set via [`install_snapshot`].
     pub fn init_from_yaml<P: AsRef<Path>>(path: P) -> Result<(), anyhow::Error> {
+        if FROZEN.load(Ordering::SeqCst) {
+            tracing::debug!("global config frozen; ignoring init_from_yaml()");
+            return Ok(());
+        }
         let config = from_yaml(path)?;
         let mut global_config = CONFIG.write().unwrap();
         *global_config = config;
         Ok(())
+    }
+
+    /// Reset the global configuration to defaults (for testing only).
+    ///
+    /// This clears all explicit values and restores each key to its
+    /// built-in default. Unlike other initialization paths, this call
+    /// ignores the [`FROZEN`] flag: it will reset even if a snapshot
+    /// has been installed. It also clears the frozen state so future
+    /// `init_from_env` / `init_from_yaml` calls become effective
+    /// again.
+    ///
+    /// Intended solely for tests. Call only while holding the global
+    /// config lock to avoid race conditions.
+    ///
+    /// ```rust,ignore
+    /// let _guard = hyperactor::config::global::lock();
+    /// hyperactor::config::global::reset_to_defaults();
+    /// ```
+    pub fn reset_to_defaults() {
+        let mut config = CONFIG.write().unwrap();
+        *config = Attrs::new();
+        FROZEN.store(false, Ordering::SeqCst);
     }
 
     /// Get a key from the global configuration. Currently only available for Copy types.
@@ -240,18 +379,14 @@ pub mod global {
         CONFIG.read().unwrap().get(key).unwrap().clone()
     }
 
-    /// Get the global attrs
+    /// Get a snapshot (`Attrs`) of the global configuration by value.
+    ///
+    /// This returns a **clone** of the current global config.
+    /// Mutating the returned value does **not** affect the global
+    /// configuration unless you pass it back via an API (e.g.,
+    /// `install_snapshot`).
     pub fn attrs() -> Attrs {
         CONFIG.read().unwrap().clone()
-    }
-
-    /// Reset the global configuration to defaults (for testing only)
-    ///
-    /// Note: This should be called from within with_test_lock() to ensure thread safety.
-    /// Available in all builds to support tests in other crates.
-    pub fn reset_to_defaults() {
-        let mut config = CONFIG.write().unwrap();
-        *config = Attrs::new();
     }
 
     /// A guard that holds the global configuration lock and provides override functionality.
@@ -264,9 +399,13 @@ pub mod global {
     }
 
     impl ConfigLock {
-        /// Create a configuration override that will be restored when the guard is dropped.
+        /// Create a configuration override that is reverted when the
+        /// guard drops.
         ///
-        /// The returned guard must not outlive this ConfigLock.
+        /// If the key declares a `CONFIG_ENV_VAR`, this also updates
+        /// the corresponding process environment variable for the
+        /// duration of the guard and restores it on drop. The
+        /// returned guard must not outlive this `ConfigLock`.
         pub fn override_key<'a, T: AttrValue>(
             &'a self,
             key: crate::attrs::Key<T>,
@@ -337,6 +476,7 @@ pub mod global {
 mod tests {
     use std::collections::HashSet;
 
+    use base64::prelude::*;
     use indoc::indoc;
 
     use super::*;
@@ -584,5 +724,46 @@ mod tests {
             global::get(MESSAGE_DELIVERY_TIMEOUT),
             Duration::from_secs(30)
         );
+    }
+
+    #[test]
+    fn test_snapshot_apply_and_freeze() {
+        // Serialize a tiny snapshot that overrides a known key. Start
+        // from a clean slate.
+        let _guard = global::lock();
+        global::reset_to_defaults();
+        assert!(!global::is_frozen(), "sanity: not frozen yet");
+
+        // Build a snapshot: set MESSAGE_DELIVERY_TIMEOUT = 1500ms.
+        let mut attrs = Attrs::new();
+        attrs[MESSAGE_DELIVERY_TIMEOUT] = Duration::from_millis(1500);
+
+        let json = serde_json::to_vec(&attrs).expect("serialize attrs");
+        let b64 = BASE64_STANDARD.encode(json);
+
+        // Apply via the same path bootstrap uses.
+        global::maybe_apply_snapshot_from_b64("Test", &Some(b64));
+
+        // Value took effect.
+        assert_eq!(
+            global::get(MESSAGE_DELIVERY_TIMEOUT),
+            Duration::from_millis(1500)
+        );
+        // Frozen.
+        assert!(global::is_frozen());
+
+        // Try (and fail) to change it via env re-init: freeze must
+        // win. SAFETY: this test runs single-threaded.
+        unsafe { std::env::set_var("HYPERACTOR_MESSAGE_DELIVERY_TIMEOUT", "1s") };
+        global::init_from_env(); // should NO-OP due to freeze
+        assert_eq!(
+            global::get(MESSAGE_DELIVERY_TIMEOUT),
+            Duration::from_millis(1500),
+            "frozen snapshot must remain authoritative"
+        );
+
+        // Clean up env var to avoid bleeding state. SAFETY: this test
+        // runs single-threaded.
+        unsafe { std::env::remove_var("HYPERACTOR_MESSAGE_DELIVERY_TIMEOUT") };
     }
 }

--- a/hyperactor_mesh/src/bootstrap.rs
+++ b/hyperactor_mesh/src/bootstrap.rs
@@ -176,6 +176,13 @@ async fn halt<R>() -> R {
 }
 
 /// Bootstrap configures the bootstrap behavior of a binary.
+///
+/// Both `Proc` and `Host` variants may carry an optional config
+/// snapshot. This is a base64-encoded JSON serialization of
+/// `hyperactor::config::Attrs`. Base64 is used to enable safe
+/// transport through env vars and CLI args. If present, the child
+/// installs it as its global config at startup; otherwise it falls
+/// back to environment variables and defaults.
 #[derive(Clone, Default, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum Bootstrap {
     /// "v1" proc bootstrap
@@ -187,6 +194,8 @@ pub enum Bootstrap {
         backend_addr: ChannelAddr,
         /// The callback address used to indicate successful spawning.
         callback_addr: ChannelAddr,
+        /// Config snapshot for the child.
+        config: Option<String>,
     },
 
     /// Host bootstrap. This sets up a new `Host`, managed by a
@@ -194,6 +203,9 @@ pub enum Bootstrap {
     Host {
         /// The address on which to serve the host.
         addr: ChannelAddr,
+
+        /// Config snapshot for the child.
+        config: Option<String>,
     },
 
     #[default]
@@ -274,7 +286,31 @@ impl Bootstrap {
                 proc_id,
                 backend_addr,
                 callback_addr,
+                config,
             } => {
+                if let Some(cfg_b64) = &config {
+                    match BASE64_STANDARD.decode(cfg_b64) {
+                        Ok(bytes) => {
+                            tracing::debug!(
+                                config_b64_len = cfg_b64.len(),
+                                config_decoded_len = bytes.len(),
+                                "bootstrap: received config snapshot (Proc)"
+                            );
+                            // TODO: Apply decoded config snapshot as
+                            // global config before proc init.
+                        }
+                        Err(e) => {
+                            tracing::warn!(
+                                config_b64_len = cfg_b64.len(),
+                                error = %e,
+                                "bootstrap: config snapshot base64 decode failed (Proc); ignoring"
+                            );
+                        }
+                    }
+                } else {
+                    tracing::debug!("bootstrap: no config snapshot provided (Proc)");
+                }
+
                 if hyperactor::config::global::get(MESH_BOOTSTRAP_ENABLE_PDEATHSIG) {
                     // Safety net: normal shutdown is via
                     // `host_mesh.shutdown(&instance)`; PR_SET_PDEATHSIG
@@ -295,7 +331,30 @@ impl Bootstrap {
                     Err(e) => e.into(),
                 }
             }
-            Bootstrap::Host { addr } => {
+            Bootstrap::Host { addr, config } => {
+                if let Some(cfg_b64) = &config {
+                    match BASE64_STANDARD.decode(cfg_b64) {
+                        Ok(bytes) => {
+                            tracing::debug!(
+                                config_b64_len = cfg_b64.len(),
+                                config_decoded_len = bytes.len(),
+                                "bootstrap: received config snapshot (Host)"
+                            );
+                            // TODO: Apply decoded config snapshot as
+                            // global config before proc init.
+                        }
+                        Err(e) => {
+                            tracing::warn!(
+                                config_b64_len = cfg_b64.len(),
+                                error = %e,
+                                "bootstrap: config snapshot base64 decode failed (Host); ignoring"
+                            );
+                        }
+                    }
+                } else {
+                    tracing::debug!("bootstrap: no config snapshot provided (Host)");
+                }
+
                 let command = ok!(BootstrapCommand::current());
                 let manager = BootstrapProcManager::new(command);
                 let (host, _handle) = ok!(Host::serve(manager, addr).await);
@@ -1453,9 +1512,13 @@ impl ProcManager for BootstrapProcManager {
     /// Launch a new proc under this [`BootstrapProcManager`].
     ///
     /// Spawns the configured bootstrap binary (`self.program`) in a
-    /// fresh child process, passing environment variables that
-    /// describe the [`BootstrapMode::Proc`] (proc ID, backend
-    /// address, callback address).
+    /// fresh child process. The environment is populated with
+    /// variables that describe the bootstrap context — most
+    /// importantly `HYPERACTOR_MESH_BOOTSTRAP_MODE`, which carries a
+    /// base64-encoded JSON [`Bootstrap::Proc`] payload (proc id,
+    /// backend addr, callback addr, optional config snapshot).
+    /// Additional variables like `BOOTSTRAP_LOG_CHANNEL` are also set
+    /// up for logging and control.
     ///
     /// Responsibilities performed here:
     /// - Create a one-shot callback channel so the child can confirm
@@ -1483,10 +1546,15 @@ impl ProcManager for BootstrapProcManager {
         let (callback_addr, mut callback_rx) =
             channel::serve(ChannelAddr::any(ChannelTransport::Unix))?;
 
+        let cfg = hyperactor::config::global::attrs();
+        let cfg_json = serde_json::to_vec(&cfg).unwrap();
+        let cfg_json_b64 = BASE64_STANDARD.encode(cfg_json);
+
         let mode = Bootstrap::Proc {
             proc_id: proc_id.clone(),
             backend_addr,
             callback_addr,
+            config: Some(cfg_json_b64),
         };
         let mut cmd = Command::new(&self.command.program);
         if let Some(arg0) = &self.command.arg0 {
@@ -1842,13 +1910,14 @@ mod tests {
     }
 
     #[test]
-    fn test_bootstrap_mode_env_string() {
+    fn test_bootstrap_mode_env_string_none_config_proc() {
         let values = [
             Bootstrap::default(),
             Bootstrap::Proc {
                 proc_id: id!(foo[0]),
                 backend_addr: ChannelAddr::any(ChannelTransport::Tcp),
                 callback_addr: ChannelAddr::any(ChannelTransport::Unix),
+                config: None,
             },
         ];
 
@@ -1856,6 +1925,105 @@ mod tests {
             let safe = value.to_env_safe_string().unwrap();
             assert_eq!(value, Bootstrap::from_env_safe_string(&safe).unwrap());
         }
+    }
+
+    #[test]
+    fn test_bootstrap_mode_env_string_none_config_host() {
+        let value = Bootstrap::Host {
+            addr: ChannelAddr::any(ChannelTransport::Unix),
+            config: None,
+        };
+        let safe = value.to_env_safe_string().unwrap();
+        assert_eq!(value, Bootstrap::from_env_safe_string(&safe).unwrap());
+    }
+
+    #[test]
+    fn test_bootstrap_mode_env_string_invalid() {
+        // Not valid base64
+        assert!(Bootstrap::from_env_safe_string("!!!").is_err());
+    }
+
+    #[test]
+    fn test_bootstrap_env_roundtrip_with_config_proc_and_host() {
+        let cfg_json = r#"{"hyperactor::config::message_delivery_timeout":"1500ms"}"#;
+        let cfg_b64 = BASE64_STANDARD.encode(cfg_json.as_bytes());
+
+        let cases = [
+            Bootstrap::Proc {
+                proc_id: id!(foo[42]),
+                backend_addr: ChannelAddr::any(ChannelTransport::Unix),
+                callback_addr: ChannelAddr::any(ChannelTransport::Unix),
+                config: Some(cfg_b64.clone()),
+            },
+            Bootstrap::Host {
+                addr: ChannelAddr::any(ChannelTransport::Unix),
+                config: Some(cfg_b64.clone()),
+            },
+        ];
+
+        for value in cases {
+            let safe = value.to_env_safe_string().unwrap();
+            let decoded = Bootstrap::from_env_safe_string(&safe).unwrap();
+            assert_eq!(decoded, value, "config payload must survive exactly");
+        }
+    }
+
+    // "Opaque string" guarantee: inner payload can be arbitrary bytes
+    // (we don’t validate here).
+    #[test]
+    fn test_bootstrap_env_config_is_opaque_string() {
+        // Arbitrary binary blob -> base64. This simulates non-UTF8
+        // JSON (in a possible future) or compressed payloads.
+        let raw: Vec<u8> = (0..=255).collect();
+        let cfg_b64 = BASE64_STANDARD.encode(&raw);
+
+        let value = Bootstrap::Proc {
+            proc_id: id!(bar[0]),
+            backend_addr: ChannelAddr::any(ChannelTransport::Unix),
+            callback_addr: ChannelAddr::any(ChannelTransport::Unix),
+            config: Some(cfg_b64.clone()),
+        };
+
+        let safe = value.to_env_safe_string().unwrap();
+        let decoded = Bootstrap::from_env_safe_string(&safe).unwrap();
+        match decoded {
+            Bootstrap::Proc { config, .. } => assert_eq!(config, Some(cfg_b64)),
+            _ => panic!("decoded variant mismatch"),
+        }
+    }
+
+    // Size/regression guard: large-ish config payload doesn't break
+    // env encoding.
+    #[test]
+    fn test_bootstrap_env_config_large_payload() {
+        // ~64KB of JSON-ish text; env-encoding must still succeed.
+        let big_json = "{\"k\":\"v\"}\n".repeat(4 * 1024); // ~44KB
+        let cfg_b64 = BASE64_STANDARD.encode(big_json.as_bytes());
+
+        // Guard: the base64 snapshot itself should be big.
+        assert!(
+            cfg_b64.len() > 50_000,
+            "expected large base64 config, got {} bytes",
+            cfg_b64.len()
+        );
+
+        let v = Bootstrap::Host {
+            addr: ChannelAddr::any(ChannelTransport::Unix),
+            config: Some(cfg_b64),
+        };
+
+        // Should encode and decode without error.
+        let safe = v.to_env_safe_string().unwrap();
+
+        // Guard: the wrapped env string must also remain large.
+        assert!(
+            safe.len() > 50_000,
+            "expected large env-encoded bootstrap, got {} bytes",
+            safe.len()
+        );
+
+        let back = Bootstrap::from_env_safe_string(&safe).unwrap();
+        assert_eq!(back, v);
     }
 
     #[tokio::test]

--- a/hyperactor_mesh/src/v1/host_mesh.rs
+++ b/hyperactor_mesh/src/v1/host_mesh.rs
@@ -767,7 +767,10 @@ mod tests {
         let mut children = Vec::new();
         for host in hosts.iter() {
             let mut cmd = Command::new(program.clone());
-            let boot = Bootstrap::Host { addr: host.clone() };
+            let boot = Bootstrap::Host {
+                addr: host.clone(),
+                config: None,
+            };
             boot.to_env(&mut cmd);
             cmd.kill_on_drop(true);
             children.push(cmd.spawn().unwrap());


### PR DESCRIPTION
Differential Revision: D83683389


