### PR TITLE
Fix missing crawler example in doc navigation

### DIFF
--- a/docs/source/examples/README.rst
+++ b/docs/source/examples/README.rst
@@ -19,6 +19,7 @@ These examples are formatted for sphinx-gallery and will be automatically conver
    :hidden:
 
    ping_pong
+   crawler
    spmd_ddp
    grpo_actor
    distributed_tensors


### PR DESCRIPTION
Summary:
D83214162 added a new example but it's hidden from the navigation bar

 {F1982411267}

Differential Revision: D83751831


