### PR TITLE
[hyperactor] implement Nagle's algorithm for port reducers

### DIFF
--- a/hyperactor/src/accum.rs
+++ b/hyperactor/src/accum.rs
@@ -11,6 +11,7 @@
 use std::collections::HashMap;
 use std::marker::PhantomData;
 use std::sync::OnceLock;
+use std::time::Duration;
 
 use serde::Deserialize;
 use serde::Serialize;
@@ -18,6 +19,7 @@ use serde::de::DeserializeOwned;
 
 use crate as hyperactor; // for macros
 use crate::Named;
+use crate::config;
 use crate::data::Serialized;
 use crate::reference::Index;
 
@@ -43,6 +45,21 @@ pub struct ReducerSpec {
     pub typehash: u64,
     /// The parameters used to build the reducer.
     pub builder_params: Option<Serialized>,
+}
+
+/// Runtime behavior of reducers.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Named, Default)]
+pub struct ReducerOpts {
+    /// The maximum interval between updates. When unspecified, a default
+    /// interval is used.
+    pub max_update_interval: Option<Duration>,
+}
+
+impl ReducerOpts {
+    pub(crate) fn max_update_interval(&self) -> Duration {
+        self.max_update_interval
+            .unwrap_or(config::global::get(config::SPLIT_MAX_BUFFER_AGE))
+    }
 }
 
 /// Commutative reducer for an accumulator. This is used to coallesce updates.

--- a/hyperactor/src/config.rs
+++ b/hyperactor/src/config.rs
@@ -63,6 +63,10 @@ declare_attrs! {
     @meta(CONFIG_ENV_VAR = "HYPERACTOR_SPLIT_MAX_BUFFER_SIZE".to_string())
     pub attr SPLIT_MAX_BUFFER_SIZE: usize = 5;
 
+    /// The maximum time an update can be buffered before being reduced.
+    @meta(CONFIG_ENV_VAR = "HYPERACTOR_SPLIT_MAX_BUFFER_AGE".to_string())
+    pub attr SPLIT_MAX_BUFFER_AGE: Duration = Duration::from_millis(50);
+
     /// Timeout used by proc mesh for stopping an actor.
     @meta(CONFIG_ENV_VAR = "HYPERACTOR_STOP_ACTOR_TIMEOUT".to_string())
     pub attr STOP_ACTOR_TIMEOUT: Duration = Duration::from_secs(1);

--- a/hyperactor/src/reference.rs
+++ b/hyperactor/src/reference.rs
@@ -47,6 +47,7 @@ use crate::ActorHandle;
 use crate::Named;
 use crate::RemoteHandles;
 use crate::RemoteMessage;
+use crate::accum::ReducerOpts;
 use crate::accum::ReducerSpec;
 use crate::actor::RemoteActor;
 use crate::attrs::Attrs;
@@ -907,8 +908,9 @@ impl PortId {
         &self,
         cx: &impl context::Mailbox,
         reducer_spec: Option<ReducerSpec>,
+        reducer_opts: Option<ReducerOpts>,
     ) -> anyhow::Result<PortId> {
-        cx.split(self.clone(), reducer_spec)
+        cx.split(self.clone(), reducer_spec, reducer_opts)
     }
 }
 
@@ -949,6 +951,13 @@ pub struct PortRef<M> {
         Hash = "ignore"
     )]
     reducer_spec: Option<ReducerSpec>,
+    #[derivative(
+        PartialEq = "ignore",
+        PartialOrd = "ignore",
+        Ord = "ignore",
+        Hash = "ignore"
+    )]
+    reducer_opts: Option<ReducerOpts>,
     phantom: PhantomData<M>,
 }
 
@@ -959,6 +968,7 @@ impl<M: RemoteMessage> PortRef<M> {
         Self {
             port_id,
             reducer_spec: None,
+            reducer_opts: None,
             phantom: PhantomData,
         }
     }
@@ -969,6 +979,7 @@ impl<M: RemoteMessage> PortRef<M> {
         Self {
             port_id,
             reducer_spec,
+            reducer_opts: None, // TODO: provide attest_reducible_opts
             phantom: PhantomData,
         }
     }
@@ -1049,6 +1060,7 @@ impl<M: RemoteMessage> Clone for PortRef<M> {
         Self {
             port_id: self.port_id.clone(),
             reducer_spec: self.reducer_spec.clone(),
+            reducer_opts: self.reducer_opts.clone(),
             phantom: PhantomData,
         }
     }
@@ -1062,7 +1074,7 @@ impl<M: RemoteMessage> fmt::Display for PortRef<M> {
 
 /// The parameters extracted from [`PortRef`] to [`Bindings`].
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Named)]
-pub struct UnboundPort(pub PortId, pub Option<ReducerSpec>);
+pub struct UnboundPort(pub PortId, pub Option<ReducerSpec>, pub Option<ReducerOpts>);
 
 impl UnboundPort {
     /// Update the port id of this binding.
@@ -1073,7 +1085,11 @@ impl UnboundPort {
 
 impl<M: RemoteMessage> From<&PortRef<M>> for UnboundPort {
     fn from(port_ref: &PortRef<M>) -> Self {
-        UnboundPort(port_ref.port_id.clone(), port_ref.reducer_spec.clone())
+        UnboundPort(
+            port_ref.port_id.clone(),
+            port_ref.reducer_spec.clone(),
+            port_ref.reducer_opts.clone(),
+        )
     }
 }
 
@@ -1088,6 +1104,7 @@ impl<M: RemoteMessage> Bind for PortRef<M> {
         let bound = bindings.try_pop_front::<UnboundPort>()?;
         self.port_id = bound.0;
         self.reducer_spec = bound.1;
+        self.reducer_opts = bound.2;
         Ok(())
     }
 }

--- a/hyperactor/src/time.rs
+++ b/hyperactor/src/time.rs
@@ -6,8 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#![allow(dead_code)] // until next diff..
-
 //! This module contains various utilities for dealing with time.
 
 use std::sync::Arc;

--- a/hyperactor_mesh/src/actor_mesh.rs
+++ b/hyperactor_mesh/src/actor_mesh.rs
@@ -1391,7 +1391,7 @@ mod tests {
                 dest.port::<Payload>().port_id(),
                 &payload,
             );
-            assert_eq!(frame_len, 1024);
+            assert_eq!(frame_len, 1025);
 
             // Send direct. A cast message is > 1024 bytes.
             dest.send(proc_mesh.client(), payload).unwrap();

--- a/hyperactor_mesh/src/comm.rs
+++ b/hyperactor_mesh/src/comm.rs
@@ -263,17 +263,17 @@ impl CommActor {
         // Split ports, if any, and update message with new ports. In this
         // way, children actors will reply to this comm actor's ports, instead
         // of to the original ports provided by parent.
-        message
-            .data_mut()
-            .visit_mut::<UnboundPort>(|UnboundPort(port_id, reducer_spec)| {
-                let split = port_id.split(cx, reducer_spec.clone())?;
+        message.data_mut().visit_mut::<UnboundPort>(
+            |UnboundPort(port_id, reducer_spec, reducer_opts)| {
+                let split = port_id.split(cx, reducer_spec.clone(), reducer_opts.clone())?;
 
                 #[cfg(test)]
                 tests::collect_split_port(port_id, &split, deliver_here);
 
                 *port_id = split;
                 Ok(())
-            })?;
+            },
+        )?;
 
         // Deliver message here, if necessary.
         if deliver_here {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #1405
* #1404

This implements a timed flush for port reducers. It introduces a new struct, `ReducerOpts`, which specifies the interval used; otherwise a new global configuration variable (default 50ms) is used.

This will enable timely streaming updates through cast/accumulate.

In the near future we should strive to do even better: for value meshes specifically, we know the number of responses expected. We can introduce an 'n-shot' port which keeps track of the number of updates expected at each split. This will also allow us to implement proper lifecycle management of these ports.

Differential Revision: [D83768514](https://our.internmc.facebook.com/intern/diff/D83768514/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D83768514/)!