### PR TITLE
add optional dependencies to setup.py; add examples for requirements.txt in examples

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -158,6 +158,12 @@ setup(
     package_dir={"": "python"},
     python_requires=">= 3.10",
     install_requires=reqs.strip().split("\n"),
+    extras_require={
+        "examples": [
+            "bs4",
+            "ipython",
+        ],
+    },
     license="BSD-3-Clause",
     author="Meta",
     author_email="oncall+monarch@xmail.facebook.com",


### PR DESCRIPTION
Summary:
we want to introduce (long term) optional deps for rdma, tensor_engine.
short term, we should put deps on exmaples. 

This adds to setup.py

Differential Revision: D83884709


