### PR TITLE
Remove unused def undeliverable_receiver from PyMailbox

### DIFF
--- a/python/monarch/_rust_bindings/monarch_hyperactor/mailbox.pyi
+++ b/python/monarch/_rust_bindings/monarch_hyperactor/mailbox.pyi
@@ -160,15 +160,6 @@ class Mailbox:
         """
         ...
 
-    def undeliverable_receiver(self) -> UndeliverablePortReceiver:
-        """
-        Open a port to receive undeliverable messages.
-
-        This may only be called at most once per mailbox. Calling it
-        more than once may panic due to the port already being bound.
-        """
-        ...
-
     @property
     def actor_id(self) -> ActorId: ...
 


### PR DESCRIPTION
Summary: Originally added in D77456497 2 months ago but it was never used. Remove it to reduce unnecessary maintenance burden. We can add it back when we need it again.

Reviewed By: mariusae

Differential Revision: D83912653


