### PR TITLE
: config: introduce ConfigAttr and CONFIG meta attr

### DIFF
--- a/hyperactor_mesh/src/bootstrap.rs
+++ b/hyperactor_mesh/src/bootstrap.rs
@@ -39,7 +39,8 @@ use hyperactor::channel::Rx;
 use hyperactor::channel::Tx;
 use hyperactor::clock::Clock;
 use hyperactor::clock::RealClock;
-use hyperactor::config::CONFIG_ENV_VAR;
+use hyperactor::config::CONFIG;
+use hyperactor::config::ConfigAttr;
 use hyperactor::config::global as config;
 use hyperactor::declare_attrs;
 use hyperactor::host;
@@ -71,26 +72,38 @@ declare_attrs! {
     /// against leaked children; tests usually disable it via
     /// `std::env::set_var("HYPERACTOR_MESH_BOOTSTRAP_ENABLE_PDEATHSIG",
     /// "false")`.
-    @meta(CONFIG_ENV_VAR = "HYPERACTOR_MESH_BOOTSTRAP_ENABLE_PDEATHSIG".to_string())
+    @meta(CONFIG = ConfigAttr {
+        env_name: Some("HYPERACTOR_MESH_BOOTSTRAP_ENABLE_PDEATHSIG".to_string()),
+        py_name: None,
+    })
     pub attr MESH_BOOTSTRAP_ENABLE_PDEATHSIG: bool = true;
 
     /// Maximum number of log lines retained in a proc's stderr/stdout
     /// tail buffer. Used by [`LogTailer::tee`] when wiring child
     /// pipes. Default: 100
-    @meta(CONFIG_ENV_VAR = "HYPERACTOR_MESH_TAIL_LOG_LINES".to_string())
+    @meta(CONFIG = ConfigAttr {
+        env_name: Some("HYPERACTOR_MESH_TAIL_LOG_LINES".to_string()),
+        py_name: None,
+    })
     pub attr MESH_TAIL_LOG_LINES: usize = 100;
 
     /// Maximum number of child terminations to run concurrently
     /// during bulk shutdown. Prevents unbounded spawning of
     /// termination tasks (which could otherwise spike CPU, I/O, or
     /// file descriptor load).
-    @meta(CONFIG_ENV_VAR = "HYPERACTOR_MESH_TERMINATE_CONCURRENCY".to_string())
+    @meta(CONFIG = ConfigAttr {
+        env_name: Some("HYPERACTOR_MESH_TERMINATE_CONCURRENCY".to_string()),
+        py_name: None,
+    })
     pub attr MESH_TERMINATE_CONCURRENCY: usize = 16;
 
     /// Per-child grace window for termination. When a shutdown is
     /// requested, the manager sends SIGTERM and waits this long for
     /// the child to exit before escalating to SIGKILL.
-    @meta(CONFIG_ENV_VAR = "HYPERACTOR_MESH_TERMINATE_TIMEOUT".to_string())
+    @meta(CONFIG = ConfigAttr {
+        env_name: Some("HYPERACTOR_MESH_TERMINATE_TIMEOUT".to_string()),
+        py_name: None,
+    })
     pub attr MESH_TERMINATE_TIMEOUT: Duration = Duration::from_secs(10);
 }
 

--- a/hyperactor_mesh/src/config.rs
+++ b/hyperactor_mesh/src/config.rs
@@ -12,7 +12,8 @@
 //! the base hyperactor configuration system.
 
 use hyperactor::attrs::declare_attrs;
-use hyperactor::config::CONFIG_ENV_VAR;
+use hyperactor::config::CONFIG;
+use hyperactor::config::ConfigAttr;
 
 // Declare hyperactor_mesh-specific configuration keys
 declare_attrs! {
@@ -20,6 +21,9 @@ declare_attrs! {
     /// when reshaping during casting to limit fanout.
     /// usize::MAX means no reshaping as any shape will always be below
     /// the limit so no dimension needs to be folded.
-    @meta(CONFIG_ENV_VAR = "HYPERACTOR_MESH_MAX_CAST_DIMENSION_SIZE".to_string())
+    @meta(CONFIG = ConfigAttr {
+        env_name: Some("HYPERACTOR_MESH_MAX_CAST_DIMENSION_SIZE".to_string()),
+        py_name: None,
+    })
     pub attr MAX_CAST_DIMENSION_SIZE: usize = usize::MAX;
 }

--- a/hyperactor_mesh/src/proc_mesh.rs
+++ b/hyperactor_mesh/src/proc_mesh.rs
@@ -31,8 +31,8 @@ use hyperactor::channel;
 use hyperactor::channel::ChannelAddr;
 use hyperactor::channel::ChannelTransport;
 use hyperactor::config;
-use hyperactor::config::CONFIG_ENV_VAR;
-use hyperactor::config::PYTHON_CONFIG_KEY;
+use hyperactor::config::CONFIG;
+use hyperactor::config::ConfigAttr;
 use hyperactor::context;
 use hyperactor::declare_attrs;
 use hyperactor::mailbox;
@@ -87,10 +87,10 @@ use std::sync::RwLock;
 
 declare_attrs! {
     /// Default transport type to use across the application.
-    @meta(
-        CONFIG_ENV_VAR = "HYPERACTOR_MESH_DEFAULT_TRANSPORT".to_string(),
-        PYTHON_CONFIG_KEY = "default_transport".to_string(),
-    )
+    @meta(CONFIG = ConfigAttr {
+        env_name: Some("HYPERACTOR_MESH_DEFAULT_TRANSPORT".to_string()),
+        py_name: Some("default_transport".to_string()),
+    })
     pub attr DEFAULT_TRANSPORT: ChannelTransport = ChannelTransport::Unix;
 }
 /// Get the default transport type to use across the application.

--- a/hyperactor_mesh/src/v1/host_mesh.rs
+++ b/hyperactor_mesh/src/v1/host_mesh.rs
@@ -11,7 +11,8 @@ use hyperactor::channel::ChannelTransport;
 use hyperactor::clock::Clock;
 use hyperactor::clock::RealClock;
 use hyperactor::config;
-use hyperactor::config::CONFIG_ENV_VAR;
+use hyperactor::config::CONFIG;
+use hyperactor::config::ConfigAttr;
 use hyperactor::declare_attrs;
 pub mod mesh_agent;
 
@@ -54,8 +55,12 @@ use crate::v1::host_mesh::mesh_agent::ShutdownHostClient;
 use crate::v1::proc_mesh::ProcRef;
 
 declare_attrs! {
-    /// The maximum idle time between updates while spawning proc meshes.
-    @meta(CONFIG_ENV_VAR = "HYPERACTOR_MESH_PROC_SPAWN_MAX_IDLE".to_string())
+    /// The maximum idle time between updates while spawning proc
+    /// meshes.
+    @meta(CONFIG = ConfigAttr {
+        env_name: Some("HYPERACTOR_MESH_PROC_SPAWN_MAX_IDLE".to_string()),
+        py_name: None,
+    })
     pub attr PROC_SPAWN_MAX_IDLE: Duration = Duration::from_secs(30);
 }
 

--- a/hyperactor_mesh/src/v1/proc_mesh.rs
+++ b/hyperactor_mesh/src/v1/proc_mesh.rs
@@ -29,7 +29,8 @@ use hyperactor::channel::ChannelAddr;
 use hyperactor::clock::Clock;
 use hyperactor::clock::RealClock;
 use hyperactor::config;
-use hyperactor::config::CONFIG_ENV_VAR;
+use hyperactor::config::CONFIG;
+use hyperactor::config::ConfigAttr;
 use hyperactor::context;
 use hyperactor::declare_attrs;
 use hyperactor::mailbox::DialMailboxRouter;
@@ -69,8 +70,12 @@ use crate::v1::Name;
 use crate::v1::ValueMesh;
 
 declare_attrs! {
-    /// The maximum idle time between updates while spawning actor meshes.
-    @meta(CONFIG_ENV_VAR = "HYPERACTOR_MESH_ACTOR_SPAWN_MAX_IDLE".to_string())
+    /// The maximum idle time between updates while spawning actor
+    /// meshes.
+    @meta(CONFIG = ConfigAttr {
+        env_name: Some("HYPERACTOR_MESH_ACTOR_SPAWN_MAX_IDLE".to_string()),
+        py_name: None,
+    })
     pub attr ACTOR_SPAWN_MAX_IDLE: Duration = Duration::from_secs(30);
 }
 


### PR DESCRIPTION
Summary: this diff follows on from the discussions in D83778023 and lands `ConfigAttr` and the unified `CONFIG` meta-attribute for marking configuration keys, replaces all previous `CONFIG_ENV_VAR`/`PYTHON_CONFIG_KEY` usage, and narrows `attrs()` and `init_from_env()` to include only keys carrying this meta. it updates monarch python bindings to read `py_name` from `ConfigAttr`, rewrites affected documentation accordingly, and adds a unit test verifying that non-`CONFIG` keys are excluded from `attrs()`. all existing keys in hyperactor and hyperactor\_mesh have been migrated to the new form.

Differential Revision: D83997813


