### PR TITLE
Allow procs to skip forwarder when talking to peers

### DIFF
--- a/hyperactor_mesh/src/alloc/local.rs
+++ b/hyperactor_mesh/src/alloc/local.rs
@@ -215,7 +215,8 @@ impl Alloc for LocalAlloc {
                         create_key,
                         proc_id,
                         mesh_agent: mesh_agent.bind(),
-                        addr,
+                        addr: addr.clone(),
+                        local_addr: addr,
                     });
                     break Some(created);
                 }

--- a/hyperactor_mesh/src/alloc/process.rs
+++ b/hyperactor_mesh/src/alloc/process.rs
@@ -521,7 +521,8 @@ impl Alloc for ProcessAlloc {
                                 create_key: self.created[index].clone(),
                                 proc_id,
                                 mesh_agent,
-                                addr,
+                                addr: addr.clone(),
+                                local_addr: addr,
                             });
                         }
                         Process2AllocatorMessage::Heartbeat => {

--- a/hyperactor_mesh/src/alloc/remoteprocess.rs
+++ b/hyperactor_mesh/src/alloc/remoteprocess.rs
@@ -431,12 +431,12 @@ impl RemoteProcessAllocator {
                             tracing::debug!(name = event.as_ref(), "got event: {:?}", event);
                             let event = match event {
                                 ProcState::Created { .. } => event,
-                                ProcState::Running { create_key, proc_id, mesh_agent, addr } => {
+                                ProcState::Running { create_key, proc_id, mesh_agent, addr, local_addr  } => {
                                     // TODO(meriksen, direct addressing): disable remapping in direct addressing mode
                                     tracing::debug!("remapping mesh_agent {}: addr {} -> {}", mesh_agent, addr, forward_addr);
                                     mesh_agents_by_create_key.insert(create_key.clone(), mesh_agent.clone());
                                     router.bind(mesh_agent.actor_id().proc_id().clone().into(), addr);
-                                    ProcState::Running { create_key, proc_id, mesh_agent, addr: forward_addr.clone() }
+                                    ProcState::Running { create_key, proc_id, mesh_agent, addr: forward_addr.clone(), local_addr }
                                 },
                                 ProcState::Stopped { create_key, reason } => {
                                     match mesh_agents_by_create_key.remove(&create_key) {
@@ -1272,6 +1272,7 @@ mod test {
                     create_key,
                     proc_id,
                     addr: ChannelAddr::Unix("/proc0".parse().unwrap()),
+                    local_addr: ChannelAddr::Unix("/proc0".parse().unwrap()),
                     mesh_agent,
                 })
             });


### PR DESCRIPTION
Summary:
ProcState::Running will now store 2 fields for addresses. `addr` is just any address that can be used to reach this Proc meaning it may be a proxy while `local_addr` is the true address in which it is running. When building address books during ProcMesh initialization, what we will do is for every MeshAgent, we will pass in a slightly modified address book where the address for every one of it's peers that share the same forwarding proxy is pointed towards the true direct address, while every other proc id is bound to that proc's forwarder address, so inter-host communication will still be through a proxy.

That is for proc 2a, instead of being passed:
```
{
  "1a" => "1_proxy"
  "1b" => "1_proxy",
  "1c" => "1_proxy",
  "1d" => "1_proxy",
  "2b" => "2_proxy",
  "2c" => "2_proxy",
  "2d" => "2_proxy"
}
```
It will receive
```:
{
  "1a" => "1_proxy"
  "1b" => "1_proxy",
  "1c" => "1_proxy",
  "1d" => "1_proxy",
  "2b" => "2b_addr",
  "2c" => "2c_addr",
  "2d" => "2d_addr"
}
```


The reason why we want to do this is because without it, the forwarder acts as a bottleneck within the host, and causes all communication to be serial instead of parallel.

Some example data points for perf improvement include:
- call 1 host x 8 gpu @ 1GB 12.5s => 2.99s
- call 8 host x 8 gpu @ 1GB 20.0s => 5.84s
- call 64 host x 8 gpu @ 1GB 23.6s => 12.26s

Proof of parallelism (VPN needed): https://interncache-all.fbcdn.net/manifold/perfetto-artifacts/tree/ui/index.html#!/?url=https://interncache-all.fbcdn.net/manifold/perfetto_internal_traces%2Ftree%2Fshared_trace%2Fthomasywang_2070d1f3-3b42-48cd-bde1-20460b3850cf_tmpt17nblpf.json

Differential Revision: D84032776


