### PR TITLE
Add typing_extensions to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ pyzmq
 requests
 numpy
 pyre-extensions
+typing-extensions>=4.12
 cloudpickle
 torchx-nightly
 lark


### PR DESCRIPTION
Summary:
We use `typing_extensions` in a few places, but it wasn't listed on our dependencies.
Add it to ensure it's installed.
4.12 is the last version with a change to an API we used, so anything newer than that is
fine.

Differential Revision: D84078256


