### PR TITLE
[monarch] monarch.enable_transport(), and v1 controllers

### DIFF
--- a/python/monarch/_src/actor/debugger/debug_controller.py
+++ b/python/monarch/_src/actor/debugger/debug_controller.py
@@ -9,7 +9,7 @@ import asyncio
 import functools
 from typing import Dict, List, Optional, Tuple
 
-from monarch._src.actor.actor_mesh import Actor
+from monarch._src.actor.actor_mesh import Actor, context
 from monarch._src.actor.debugger.debug_command import (
     Attach,
     Cast,
@@ -33,8 +33,11 @@ from monarch._src.actor.debugger.debug_session import (
 )
 from monarch._src.actor.debugger.pdb_wrapper import DebuggerWrite
 from monarch._src.actor.endpoint import endpoint
-from monarch._src.actor.proc_mesh import get_or_spawn_controller
+from monarch._src.actor.proc_mesh import (
+    get_or_spawn_controller as get_or_spawn_controller_v0,
+)
 from monarch._src.actor.sync_state import fake_sync_state
+from monarch._src.actor.v1.proc_mesh import get_or_spawn_controller, ProcMesh
 from monarch.tools.debug_env import (
     _get_debug_server_host,
     _get_debug_server_port,
@@ -243,4 +246,7 @@ class DebugController(Actor):
 @functools.cache
 def debug_controller() -> DebugController:
     with fake_sync_state():
-        return get_or_spawn_controller("debug_controller", DebugController).get()
+        if isinstance(context().actor_instance.proc_mesh, ProcMesh):
+            return get_or_spawn_controller("debug_controller", DebugController).get()
+        else:
+            return get_or_spawn_controller_v0("debug_controller", DebugController).get()

--- a/python/monarch/_src/actor/source_loader.py
+++ b/python/monarch/_src/actor/source_loader.py
@@ -10,10 +10,13 @@ import importlib
 import importlib.abc
 import linecache
 
-from monarch._src.actor.actor_mesh import _context, Actor
+from monarch._src.actor.actor_mesh import _context, Actor, context
 from monarch._src.actor.endpoint import endpoint
-from monarch._src.actor.proc_mesh import get_or_spawn_controller
+from monarch._src.actor.proc_mesh import (
+    get_or_spawn_controller as get_or_spawn_controller_v0,
+)
 from monarch._src.actor.sync_state import fake_sync_state
+from monarch._src.actor.v1.proc_mesh import get_or_spawn_controller, ProcMesh
 
 
 class SourceLoaderController(Actor):
@@ -25,7 +28,14 @@ class SourceLoaderController(Actor):
 @functools.cache
 def source_loader_controller() -> SourceLoaderController:
     with fake_sync_state():
-        return get_or_spawn_controller("source_loader", SourceLoaderController).get()
+        if isinstance(context().actor_instance.proc_mesh, ProcMesh):
+            return get_or_spawn_controller(
+                "source_loader", SourceLoaderController
+            ).get()
+        else:
+            return get_or_spawn_controller_v0(
+                "source_loader", SourceLoaderController
+            ).get()
 
 
 @functools.cache

--- a/python/monarch/_src/actor/telemetry/__init__.py
+++ b/python/monarch/_src/actor/telemetry/__init__.py
@@ -30,12 +30,14 @@ class TracingForwarder(logging.Handler):
     def emit(self, record: logging.LogRecord) -> None:
         # Try to add actor_id from the current context to the logging record
         try:
-            from monarch._src.actor.actor_mesh import context
+            from monarch._src.actor.actor_mesh import _context, context
 
-            ctx = context()
-            if ctx and ctx.actor_instance and ctx.actor_instance.actor_id:
-                # Add actor_id as an attribute to the logging record
-                setattr(record, "actor_id", str(ctx.actor_instance.actor_id))
+            # Don't initialize the context if it hasn't been initialized yet.
+            if _context.get(None) is not None:
+                ctx = context()
+                if ctx and ctx.actor_instance and ctx.actor_instance.actor_id:
+                    # Add actor_id as an attribute to the logging record
+                    setattr(record, "actor_id", str(ctx.actor_instance.actor_id))
         except Exception:
             # If we can't get the context or actor_id for any reason, just continue
             # without adding the actor_id field

--- a/python/monarch/_src/actor/v1/host_mesh.py
+++ b/python/monarch/_src/actor/v1/host_mesh.py
@@ -142,7 +142,7 @@ class HostMesh(MeshTrait):
             name = ""
 
         return self._spawn_nonblocking(
-            name, Extent(list(per_host.keys()), list(per_host.values())), setup, False
+            name, Extent(list(per_host.keys()), list(per_host.values())), setup, True
         )
 
     def _spawn_nonblocking(

--- a/python/monarch/actor/__init__.py
+++ b/python/monarch/actor/__init__.py
@@ -9,6 +9,7 @@
 Monarch Actor API - Public interface for actor functionality.
 """
 
+from monarch._rust_bindings.monarch_hyperactor.channel import ChannelTransport
 from monarch._rust_bindings.monarch_hyperactor.shape import Extent
 from monarch._src.actor.actor_mesh import (
     Accumulator,
@@ -20,6 +21,7 @@ from monarch._src.actor.actor_mesh import (
     current_actor_name,
     current_rank,
     current_size,
+    enable_transport,
     Endpoint,
     Point,
     Port,
@@ -77,4 +79,5 @@ __all__ = [
     "Extent",
     "run_worker_loop_forever",
     "attach_to_workers",
+    "enable_transport",
 ]


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #1462
* #1459

This diff does two things:
- Introduce `monarch.enable_transport(...)`, which enables the user to set the transport of the root client. For now, only one transport is allowed. It must be called before any other monarch APIs, and it will throw if called multiple times with different transports.
- Enable controllers in v1

Differential Revision: [D84100520](https://our.internmc.facebook.com/intern/diff/D84100520/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D84100520/)!