### PR TITLE
Fix up failing tests by adding Tcp::Localhost mode

### DIFF
--- a/hyper/src/commands/serve.rs
+++ b/hyper/src/commands/serve.rs
@@ -10,6 +10,7 @@ use std::time::Duration;
 
 use hyperactor::channel::ChannelAddr;
 use hyperactor::channel::ChannelTransport;
+use hyperactor::channel::TcpMode;
 use hyperactor_multiprocess::system::System;
 
 // The commands in the demo spawn temporary actors the join a system.
@@ -27,7 +28,9 @@ pub struct ServeCommand {
 
 impl ServeCommand {
     pub async fn run(self) -> anyhow::Result<()> {
-        let addr = self.addr.unwrap_or(ChannelAddr::any(ChannelTransport::Tcp));
+        let addr = self
+            .addr
+            .unwrap_or(ChannelAddr::any(ChannelTransport::Tcp(TcpMode::Hostname)));
         let handle = System::serve(addr, LONG_DURATION, LONG_DURATION).await?;
         eprintln!("serve: {}", handle.local_addr());
         handle.await;

--- a/hyperactor/benches/main.rs
+++ b/hyperactor/benches/main.rs
@@ -22,6 +22,7 @@ use hyperactor::channel;
 use hyperactor::channel::ChannelAddr;
 use hyperactor::channel::ChannelTransport;
 use hyperactor::channel::Rx;
+use hyperactor::channel::TcpMode;
 use hyperactor::channel::Tx;
 use hyperactor::channel::dial;
 use hyperactor::channel::serve;
@@ -66,7 +67,7 @@ impl Message {
 fn bench_message_sizes(c: &mut Criterion) {
     let transports = vec![
         ("local", ChannelTransport::Local),
-        ("tcp", ChannelTransport::Tcp),
+        ("tcp", ChannelTransport::Tcp(TcpMode::Hostname)),
         ("unix", ChannelTransport::Unix),
     ];
 
@@ -108,7 +109,7 @@ fn bench_message_rates(c: &mut Criterion) {
 
     let transports = vec![
         ("local", ChannelTransport::Local),
-        ("tcp", ChannelTransport::Tcp),
+        ("tcp", ChannelTransport::Tcp(TcpMode::Hostname)),
         ("unix", ChannelTransport::Unix),
         //TODO Add TLS once it is able to run in Sandcastle
     ];

--- a/hyperactor/src/channel.rs
+++ b/hyperactor/src/channel.rs
@@ -14,6 +14,8 @@
 use core::net::SocketAddr;
 use std::fmt;
 use std::net::IpAddr;
+use std::net::Ipv4Addr;
+use std::net::Ipv6Addr;
 #[cfg(target_os = "linux")]
 use std::os::linux::net::SocketAddrExt;
 use std::str::FromStr;
@@ -33,6 +35,7 @@ use crate::Named;
 use crate::RemoteMessage;
 use crate::attrs::AttrValue;
 use crate::channel::sim::SimAddr;
+use crate::config;
 use crate::simnet::SimNetError;
 
 pub(crate) mod local;
@@ -249,6 +252,26 @@ impl<M: RemoteMessage> Rx<M> for MpscRx<M> {
     strum::Display,
     strum::EnumString
 )]
+pub enum TcpMode {
+    /// Use localhost/loopback for the connection.
+    Localhost,
+    /// Use host domain name for the connection.
+    Hostname,
+}
+
+/// The hostname to use for TLS connections.
+#[derive(
+    Clone,
+    Debug,
+    PartialEq,
+    Eq,
+    Hash,
+    Serialize,
+    Deserialize,
+    strum::EnumIter,
+    strum::Display,
+    strum::EnumString
+)]
 pub enum TlsMode {
     /// Use IpV6 address for TLS connections.
     IpV6,
@@ -315,7 +338,7 @@ impl fmt::Display for MetaTlsAddr {
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize, Named)]
 pub enum ChannelTransport {
     /// Transport over a TCP connection.
-    Tcp,
+    Tcp(TcpMode),
 
     /// Transport over a TCP connection with TLS support within Meta
     MetaTls(TlsMode),
@@ -333,7 +356,7 @@ pub enum ChannelTransport {
 impl fmt::Display for ChannelTransport {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::Tcp => write!(f, "tcp"),
+            Self::Tcp(mode) => write!(f, "tcp({:?})", mode),
             Self::MetaTls(mode) => write!(f, "metatls({:?})", mode),
             Self::Local => write!(f, "local"),
             Self::Sim(transport) => write!(f, "sim({})", transport),
@@ -358,7 +381,13 @@ impl FromStr for ChannelTransport {
         }
 
         match s {
-            "tcp" => Ok(ChannelTransport::Tcp),
+            // Default to TcpMode::Hostname, if the mode isn't set
+            "tcp" => Ok(ChannelTransport::Tcp(TcpMode::Hostname)),
+            s if s.starts_with("tcp(") => {
+                let inner = &s["tcp(".len()..s.len() - 1];
+                let mode = inner.parse()?;
+                Ok(ChannelTransport::Tcp(mode))
+            }
             "local" => Ok(ChannelTransport::Local),
             "unix" => Ok(ChannelTransport::Unix),
             s if s.starts_with("metatls(") && s.ends_with(")") => {
@@ -375,7 +404,9 @@ impl ChannelTransport {
     /// All known channel transports.
     pub fn all() -> [ChannelTransport; 3] {
         [
-            ChannelTransport::Tcp,
+            // TODO: @rusch add back once figuring out unspecified override for OSS CI
+            // ChannelTransport::Tcp(TcpMode::Localhost),
+            ChannelTransport::Tcp(TcpMode::Hostname),
             ChannelTransport::Local,
             ChannelTransport::Unix,
             // TODO add MetaTls (T208303369)
@@ -392,7 +423,7 @@ impl ChannelTransport {
     /// Returns true if this transport type represents a remote channel.
     pub fn is_remote(&self) -> bool {
         match self {
-            ChannelTransport::Tcp => true,
+            ChannelTransport::Tcp(_) => true,
             ChannelTransport::MetaTls(_) => true,
             ChannelTransport::Local => false,
             ChannelTransport::Sim(_) => false,
@@ -502,18 +533,23 @@ impl ChannelAddr {
     /// servers to "any" address.
     pub fn any(transport: ChannelTransport) -> Self {
         match transport {
-            ChannelTransport::Tcp => {
-                let ip = hostname::get()
-                    .ok()
-                    .and_then(|hostname| {
-                        // TODO: Avoid using DNS directly once we figure out a good extensibility story here
-                        hostname.to_str().and_then(|hostname_str| {
-                            dns_lookup::lookup_host(hostname_str)
-                                .ok()
-                                .and_then(|addresses| addresses.first().cloned())
-                        })
-                    })
-                    .unwrap_or_else(|| IpAddr::from_str("::1").unwrap());
+            ChannelTransport::Tcp(mode) => {
+                let ip = match mode {
+                    TcpMode::Localhost => IpAddr::V6(Ipv6Addr::LOCALHOST),
+                    TcpMode::Hostname => {
+                        hostname::get()
+                            .ok()
+                            .and_then(|hostname| {
+                                // TODO: Avoid using DNS directly once we figure out a good extensibility story here
+                                hostname.to_str().and_then(|hostname_str| {
+                                    dns_lookup::lookup_host(hostname_str)
+                                        .ok()
+                                        .and_then(|addresses| addresses.first().cloned())
+                                })
+                            })
+                            .expect("failed to resolve hostname to ip address")
+                    }
+                };
                 Self::Tcp(SocketAddr::new(ip, 0))
             }
             ChannelTransport::MetaTls(mode) => {
@@ -542,7 +578,13 @@ impl ChannelAddr {
     /// The transport used by this address.
     pub fn transport(&self) -> ChannelTransport {
         match self {
-            Self::Tcp(_) => ChannelTransport::Tcp,
+            Self::Tcp(addr) => {
+                if addr.ip().is_loopback() {
+                    ChannelTransport::Tcp(TcpMode::Localhost)
+                } else {
+                    ChannelTransport::Tcp(TcpMode::Hostname)
+                }
+            }
             Self::MetaTls(addr) => match addr {
                 MetaTlsAddr::Host { hostname, .. } => match hostname.parse::<IpAddr>() {
                     Ok(IpAddr::V6(_)) => ChannelTransport::MetaTls(TlsMode::IpV6),

--- a/hyperactor/src/channel/net.rs
+++ b/hyperactor/src/channel/net.rs
@@ -1799,7 +1799,12 @@ async fn join_nonempty<T: 'static>(set: &mut JoinSet<T>) -> Result<T, JoinError>
 /// Tells whether the address is a 'net' address. These currently have different semantics
 /// from local transports.
 pub fn is_net_addr(addr: &ChannelAddr) -> bool {
-    [ChannelTransport::Tcp, ChannelTransport::Unix].contains(&addr.transport())
+    match addr.transport() {
+        // TODO Metatls?
+        ChannelTransport::Tcp(_) => true,
+        ChannelTransport::Unix => true,
+        _ => false,
+    }
 }
 
 pub(crate) mod unix {

--- a/hyperactor_mesh/src/alloc/remoteprocess.rs
+++ b/hyperactor_mesh/src/alloc/remoteprocess.rs
@@ -9,6 +9,9 @@
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::collections::VecDeque;
+use std::net::IpAddr;
+use std::net::Ipv4Addr;
+use std::net::Ipv6Addr;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -26,6 +29,7 @@ use hyperactor::channel::ChannelRx;
 use hyperactor::channel::ChannelTransport;
 use hyperactor::channel::ChannelTx;
 use hyperactor::channel::Rx;
+use hyperactor::channel::TcpMode;
 use hyperactor::channel::Tx;
 use hyperactor::channel::TxStatus;
 use hyperactor::clock;
@@ -768,7 +772,12 @@ impl RemoteProcessAlloc {
                 ChannelTransport::MetaTls(_) => {
                     format!("metatls!{}:{}", host.hostname, self.remote_allocator_port)
                 }
-                ChannelTransport::Tcp => {
+                ChannelTransport::Tcp(TcpMode::Localhost) => {
+                    // TODO: @rusch see about moving over to config for this
+                    let ip = IpAddr::V6(Ipv6Addr::LOCALHOST);
+                    format!("tcp!{}:{}", ip, self.remote_allocator_port)
+                }
+                ChannelTransport::Tcp(TcpMode::Hostname) => {
                     format!("tcp!{}:{}", host.hostname, self.remote_allocator_port)
                 }
                 // Used only for testing.

--- a/hyperactor_mesh/src/bootstrap.rs
+++ b/hyperactor_mesh/src/bootstrap.rs
@@ -2053,6 +2053,7 @@ mod tests {
     use hyperactor::WorldId;
     use hyperactor::channel::ChannelAddr;
     use hyperactor::channel::ChannelTransport;
+    use hyperactor::channel::TcpMode;
     use hyperactor::clock::RealClock;
     use hyperactor::context::Mailbox as _;
     use hyperactor::host::ProcHandle;
@@ -2083,7 +2084,7 @@ mod tests {
             Bootstrap::default(),
             Bootstrap::Proc {
                 proc_id: id!(foo[0]),
-                backend_addr: ChannelAddr::any(ChannelTransport::Tcp),
+                backend_addr: ChannelAddr::any(ChannelTransport::Tcp(TcpMode::Hostname)),
                 callback_addr: ChannelAddr::any(ChannelTransport::Unix),
                 config: None,
             },

--- a/hyperactor_multiprocess/src/proc_actor.rs
+++ b/hyperactor_multiprocess/src/proc_actor.rs
@@ -34,6 +34,7 @@ use hyperactor::actor::Referable;
 use hyperactor::actor::remote::Remote;
 use hyperactor::channel;
 use hyperactor::channel::ChannelAddr;
+use hyperactor::channel::TcpMode;
 use hyperactor::clock::Clock;
 use hyperactor::clock::ClockKind;
 use hyperactor::context;
@@ -1376,7 +1377,7 @@ mod tests {
 
         // Serve a system.
         let server_handle = System::serve(
-            ChannelAddr::any(ChannelTransport::Tcp),
+            ChannelAddr::any(ChannelTransport::Tcp(TcpMode::Hostname)),
             Duration::from_secs(120),
             Duration::from_secs(120),
         )
@@ -1395,7 +1396,7 @@ mod tests {
         ));
 
         // Construct a proc forwarder in terms of the system sender.
-        let listen_addr = ChannelAddr::any(ChannelTransport::Tcp);
+        let listen_addr = ChannelAddr::any(ChannelTransport::Tcp(TcpMode::Hostname));
         let proc_forwarder =
             BoxedMailboxSender::new(DialMailboxRouter::new_with_default(system_sender));
 
@@ -1422,7 +1423,7 @@ mod tests {
         let _proc_actor_1 = ProcActor::bootstrap_for_proc(
             proc_1.clone(),
             world_id.clone(),
-            ChannelAddr::any(ChannelTransport::Tcp),
+            ChannelAddr::any(ChannelTransport::Tcp(TcpMode::Hostname)),
             server_handle.local_addr().clone(),
             sup_ref.clone(),
             Duration::from_secs(120),
@@ -1497,7 +1498,7 @@ mod tests {
 
         // Serve a system.
         let server_handle = System::serve(
-            ChannelAddr::any(ChannelTransport::Tcp),
+            ChannelAddr::any(ChannelTransport::Tcp(TcpMode::Hostname)),
             Duration::from_secs(120),
             Duration::from_secs(120),
         )
@@ -1518,7 +1519,7 @@ mod tests {
         ));
 
         // Construct a proc forwarder in terms of the system sender.
-        let listen_addr = ChannelAddr::any(ChannelTransport::Tcp);
+        let listen_addr = ChannelAddr::any(ChannelTransport::Tcp(TcpMode::Hostname));
         let proc_forwarder =
             BoxedMailboxSender::new(DialMailboxRouter::new_with_default(system_sender));
 
@@ -1545,7 +1546,7 @@ mod tests {
         let _proc_actor_1 = ProcActor::bootstrap_for_proc(
             proc_1.clone(),
             world_id.clone(),
-            ChannelAddr::any(ChannelTransport::Tcp),
+            ChannelAddr::any(ChannelTransport::Tcp(TcpMode::Hostname)),
             server_handle.local_addr().clone(),
             sup_ref.clone(),
             Duration::from_secs(120),
@@ -1651,7 +1652,7 @@ mod tests {
     #[tokio::test]
     async fn test_update_address_book_cache() {
         let server_handle = System::serve(
-            ChannelAddr::any(ChannelTransport::Tcp),
+            ChannelAddr::any(ChannelTransport::Tcp(TcpMode::Hostname)),
             Duration::from_secs(2), // supervision update timeout
             Duration::from_secs(2), // duration to evict an unhealthy world
         )
@@ -1705,7 +1706,7 @@ mod tests {
         actor_id: &ActorId,
         system_addr: &ChannelAddr,
     ) -> (ActorRef<PingPongActor>, ActorRef<ProcActor>) {
-        let listen_addr = ChannelAddr::any(ChannelTransport::Tcp);
+        let listen_addr = ChannelAddr::any(ChannelTransport::Tcp(TcpMode::Hostname));
         let bootstrap = ProcActor::bootstrap(
             actor_id.proc_id().clone(),
             actor_id

--- a/hyperactor_multiprocess/src/system.rs
+++ b/hyperactor_multiprocess/src/system.rs
@@ -176,6 +176,7 @@ mod tests {
     use hyperactor::WorldId;
     use hyperactor::channel::ChannelAddr;
     use hyperactor::channel::ChannelTransport;
+    use hyperactor::channel::TcpMode;
     use hyperactor::clock::Clock;
     use hyperactor::clock::RealClock;
     use hyperactor_telemetry::env::execution_id;
@@ -825,7 +826,7 @@ mod tests {
     #[tokio::test]
     async fn test_channel_dial_count() {
         let system_handle = System::serve(
-            ChannelAddr::any(ChannelTransport::Tcp),
+            ChannelAddr::any(ChannelTransport::Tcp(TcpMode::Hostname)),
             Duration::from_secs(10),
             Duration::from_secs(10),
         )

--- a/hyperactor_multiprocess/src/system_actor.rs
+++ b/hyperactor_multiprocess/src/system_actor.rs
@@ -1849,6 +1849,7 @@ mod tests {
     use hyperactor::channel;
     use hyperactor::channel::ChannelTransport;
     use hyperactor::channel::Rx;
+    use hyperactor::channel::TcpMode;
     use hyperactor::clock::Clock;
     use hyperactor::clock::RealClock;
     use hyperactor::data::Serialized;
@@ -2194,7 +2195,7 @@ mod tests {
         // Serve a system. Undeliverable messages encountered by the
         // mailbox server are returned to the system actor.
         let server_handle = System::serve(
-            ChannelAddr::any(ChannelTransport::Tcp),
+            ChannelAddr::any(ChannelTransport::Tcp(TcpMode::Hostname)),
             Duration::from_secs(2), // supervision update timeout
             Duration::from_secs(2), // duration to evict an unhealthy world
         )
@@ -2255,7 +2256,7 @@ mod tests {
         let _proc_actor_0 = ProcActor::bootstrap_for_proc(
             proc_0.clone(),
             world_id.clone(),
-            ChannelAddr::any(ChannelTransport::Tcp),
+            ChannelAddr::any(ChannelTransport::Tcp(TcpMode::Hostname)),
             server_handle.local_addr().clone(),
             sup_ref.clone(),
             Duration::from_millis(300), // supervision update interval
@@ -2272,7 +2273,7 @@ mod tests {
         let proc_actor_1 = ProcActor::bootstrap_for_proc(
             proc_1.clone(),
             world_id.clone(),
-            ChannelAddr::any(ChannelTransport::Tcp),
+            ChannelAddr::any(ChannelTransport::Tcp(TcpMode::Hostname)),
             server_handle.local_addr().clone(),
             sup_ref.clone(),
             Duration::from_millis(300), // supervision update interval
@@ -2348,7 +2349,7 @@ mod tests {
     #[tokio::test]
     async fn test_stop_fast() -> Result<()> {
         let server_handle = System::serve(
-            ChannelAddr::any(ChannelTransport::Tcp),
+            ChannelAddr::any(ChannelTransport::Tcp(TcpMode::Hostname)),
             Duration::from_secs(2), // supervision update timeout
             Duration::from_secs(2), // duration to evict an unhealthy world
         )

--- a/python/monarch/_rust_bindings/monarch_hyperactor/channel.pyi
+++ b/python/monarch/_rust_bindings/monarch_hyperactor/channel.pyi
@@ -9,7 +9,8 @@
 from enum import Enum
 
 class ChannelTransport(Enum):
-    Tcp = "tcp"
+    TcpWithLocalhost = "tcp(localhost)"
+    TcpWithHostname = "tcp(hostname)"
     MetaTlsWithHostname = "metatls(hostname)"
     MetaTlsWithIpV6 = "metatls(ipv6)"
     Local = "local"

--- a/python/monarch/_src/actor/actor_mesh.py
+++ b/python/monarch/_src/actor/actor_mesh.py
@@ -248,7 +248,7 @@ def enable_transport(transport: "ChannelTransport | str") -> None:
     """
     if isinstance(transport, str):
         transport = {
-            "tcp": ChannelTransport.Tcp,
+            "tcp": ChannelTransport.TcpWithHostname,
             "ipc": ChannelTransport.Unix,
             "metatls": ChannelTransport.MetaTlsWithIpV6,
         }.get(transport)

--- a/python/monarch/_src/job/slurm.py
+++ b/python/monarch/_src/job/slurm.py
@@ -72,7 +72,7 @@ class SlurmJob(JobTrait):
                       but may increase queue times and waste resources if nodes are underutilized.
             gpus_per_node: Number of GPUs to request per node. If None, no GPU resources are requested.
         """
-        configure(default_transport=ChannelTransport.Tcp)
+        configure(default_transport=ChannelTransport.TcpWithHostname)
         self._meshes = meshes
         self._python_exe = python_exe
         self._slurm_args = slurm_args

--- a/python/tests/test_allocator.py
+++ b/python/tests/test_allocator.py
@@ -607,7 +607,6 @@ class TestRemoteAllocator(unittest.IsolatedAsyncioTestCase):
 
     # Skipping test temporarily due to blocking OSS CI TODO: @rusch T232884876
     @pytest.mark.oss_skip  # pyre-ignore[56]: Pyre cannot infer the type of this pytest marker
-    @pytest.mark.skip("broken")
     async def test_torchx_remote_alloc_initializer_no_match_label_1_mesh(self) -> None:
         server = ServerSpec(
             name=UNUSED,
@@ -623,7 +622,10 @@ class TestRemoteAllocator(unittest.IsolatedAsyncioTestCase):
             ],
         )
         port = get_free_port()
-        with remote_process_allocator(addr=f"tcp!{get_sockaddr('localhost', port)}"):
+
+        with remote_process_allocator(
+            addr=f"tcp!{get_sockaddr('localhost', port)}",
+        ):
             with mock.patch(SERVER_READY, return_value=server):
                 initializer = TorchXRemoteAllocInitializer("local:///test", port=port)
                 allocator = RemoteAllocator(
@@ -640,7 +642,6 @@ class TestRemoteAllocator(unittest.IsolatedAsyncioTestCase):
 
     # Skipping test temporarily due to blocking OSS CI TODO: @rusch T232884876
     @pytest.mark.oss_skip  # pyre-ignore[56]: Pyre cannot infer the type of this pytest marker
-    @pytest.mark.skip("broken")
     async def test_torchx_remote_alloc_initializer_with_match_label(self) -> None:
         server = ServerSpec(
             name=UNUSED,
@@ -656,7 +657,10 @@ class TestRemoteAllocator(unittest.IsolatedAsyncioTestCase):
             ],
         )
         port = get_free_port()
-        with remote_process_allocator(addr=f"tcp!{get_sockaddr('localhost', port)}"):
+
+        with remote_process_allocator(
+            addr=f"tcp!{get_sockaddr('localhost', port)}",
+        ):
             with mock.patch(SERVER_READY, return_value=server):
                 initializer = TorchXRemoteAllocInitializer("local:///test", port=port)
                 allocator = RemoteAllocator(

--- a/python/tests/test_config.py
+++ b/python/tests/test_config.py
@@ -17,7 +17,8 @@ from monarch._rust_bindings.monarch_hyperactor.config import (
 def test_get_set_transport() -> None:
     for transport in (
         ChannelTransport.Unix,
-        ChannelTransport.Tcp,
+        ChannelTransport.TcpWithLocalhost,
+        ChannelTransport.TcpWithHostname,
         ChannelTransport.MetaTlsWithHostname,
     ):
         configure(default_transport=transport)


### PR DESCRIPTION
Summary:
This diff adds support for tls localhost to fix T232884876. I go into detail in https://fb.workplace.com/groups/1434680487636162/posts/1441470780290466/, but basically, the hostname can't be bound to for certain environments. This generally takes the approach discussed with mariusae, though I ended up doing localhost instead of unspecified. This is because the tests were already set up with localhost; it was just being ignored. 

This is a bit of a short term fix, as I hope to follow up by allowing the hostname to get sent to workers while using unspecified locally. DNS is "more correctly" resolved on the worker machines, due to proxying and load balancing questions, but that's a bigger lift.

Differential Revision: D84094699


