### PR TITLE
[monarch] extension: make CodeSyncMeshClient ActorMesh version polymorphic

### DIFF
--- a/python/monarch/_rust_bindings/monarch_extension/code_sync.pyi
+++ b/python/monarch/_rust_bindings/monarch_extension/code_sync.pyi
@@ -9,9 +9,12 @@
 from pathlib import Path
 from typing import Any, Dict, final
 
-from monarch._rust_bindings.monarch_hyperactor.proc_mesh import ProcMesh
+from monarch._rust_bindings.monarch_hyperactor.proc_mesh import ProcMesh as ProcMeshV0
 
 from monarch._rust_bindings.monarch_hyperactor.shape import Shape
+from monarch._rust_bindings.monarch_hyperactor.v1.proc_mesh import (
+    ProcMesh as ProcMeshV1,
+)
 
 class WorkspaceLocation:
     """
@@ -84,7 +87,7 @@ class CodeSyncMeshClient:
     @staticmethod
     def spawn_blocking(
         client: Any,
-        proc_mesh: ProcMesh,
+        proc_mesh: ProcMeshV0 | ProcMeshV1,
     ) -> CodeSyncMeshClient: ...
     async def sync_workspace(
         self,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #1482

This uses shimming to accept both v0 and v1 proc meshes when constructing a codesync client.

Differential Revision: [D84284336](https://our.internmc.facebook.com/intern/diff/D84284336/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D84284336/)!