### PR TITLE
Do not capture logger logs in Monarch tracing

### DIFF
--- a/python/monarch/_src/actor/actor_mesh.py
+++ b/python/monarch/_src/actor/actor_mesh.py
@@ -87,7 +87,7 @@ from monarch._src.actor.pickle import flatten, unflatten
 from monarch._src.actor.python_extension_methods import rust_struct
 from monarch._src.actor.shape import MeshTrait, NDSlice
 from monarch._src.actor.sync_state import fake_sync_state
-from monarch._src.actor.telemetry import METER, TracingForwarder
+from monarch._src.actor.telemetry import METER
 from monarch._src.actor.tensor_engine_shim import actor_rref, actor_send
 from typing_extensions import Self
 
@@ -105,7 +105,6 @@ from monarch._src.actor.telemetry import get_monarch_tracer
 CallMethod = PythonMessageKind.CallMethod
 
 logger: logging.Logger = logging.getLogger(__name__)
-logging.root.addHandler(TracingForwarder(level=logging.DEBUG))
 
 TRACER = get_monarch_tracer()
 


### PR DESCRIPTION
Summary:
Reverting from D82748854, this is not needed to propagate actors ids which was the goal of D82748854.

This line is causing user logs captured via logger.log() to be added to Monarch logs (monarch_logs.log ) and also telemetry dashboards

Reviewed By: hirenapatel1109

Differential Revision: D84215137


