### PR TITLE
Toggle between v0 and v1 in private API using `MONARCH_HOST_MESH_V1_REMOVE_ME_BEFORE_RELEASE`

### DIFF
--- a/.github/workflows/test-gpu-python.yml
+++ b/.github/workflows/test-gpu-python.yml
@@ -55,46 +55,13 @@ jobs:
         # Run GPU Python tests split into 10 groups sequentially
         # Each group runs separately with process cleanup in between
         pip install pytest-split
-        FAILED_GROUPS=()
 
-        for GROUP in {1..10}; do
-          echo "Running test group $GROUP of 10..."
+        # Run tests with the v0 API
+        run_test_groups 0
 
-          # Kill any existing Python processes to ensure clean state
-          echo "Cleaning up Python processes before group $GROUP..."
-          pkill -9 python || true
-          pkill -9 pytest || true
+        # Run tests with the v1 API
+        run_test_groups 1
 
-          # Wait a moment for processes to terminate
-          sleep 2
-
-          # Run tests for this group
-          if LC_ALL=C pytest python/tests/ -s -v -m "not oss_skip" \
-            --ignore-glob="**/meta/**" \
-            --dist=no \
-            --group=$GROUP \
-            --splits=10; then
-            echo "✓ Test group $GROUP completed successfully"
-          else
-            FAILED_GROUPS+=($GROUP)
-            echo "✗ Test group $GROUP failed with exit code $?"
-          fi
-
-        done
-
-        # Final cleanup after all groups
-        echo "Final cleanup of Python processes..."
-        pkill -9 python || true
-        pkill -9 pytest || true
-
-        # Check if any groups failed and exit with appropriate code
-        if [ ${#FAILED_GROUPS[@]} -eq 0 ]; then
-          echo "✓ All test groups completed successfully!"
-        else
-          echo "✗ The following test groups failed: ${FAILED_GROUPS[*]}"
-          echo "Failed groups count: ${#FAILED_GROUPS[@]}/10"
-          exit 1
-        fi
         # TODO(meriksen): temporarily disabled to unblock lands while debugging
         # mock CUDA issues on the OSS setup
         # python python/tests/test_mock_cuda.py

--- a/python/monarch/_src/actor/bootstrap.py
+++ b/python/monarch/_src/actor/bootstrap.py
@@ -21,7 +21,7 @@ from monarch._rust_bindings.monarch_hyperactor.v1.host_mesh import (
 )
 
 from monarch._src.actor.future import _Unawaited, Future
-from monarch._src.actor.v1.host_mesh import HostMesh
+from monarch._src.actor.host_mesh import HostMesh
 
 PrivateKey = Union[bytes, Path, None]
 CA = Union[bytes, Path, Literal["trust_all_connections"]]

--- a/python/monarch/_src/actor/debugger/debug_controller.py
+++ b/python/monarch/_src/actor/debugger/debug_controller.py
@@ -9,7 +9,7 @@ import asyncio
 import functools
 from typing import Dict, List, Optional, Tuple
 
-from monarch._src.actor.actor_mesh import Actor, context
+from monarch._src.actor.actor_mesh import Actor
 from monarch._src.actor.debugger.debug_command import (
     Attach,
     Cast,
@@ -33,11 +33,8 @@ from monarch._src.actor.debugger.debug_session import (
 )
 from monarch._src.actor.debugger.pdb_wrapper import DebuggerWrite
 from monarch._src.actor.endpoint import endpoint
-from monarch._src.actor.proc_mesh import (
-    get_or_spawn_controller as get_or_spawn_controller_v0,
-)
+from monarch._src.actor.proc_mesh import get_or_spawn_controller
 from monarch._src.actor.sync_state import fake_sync_state
-from monarch._src.actor.v1.proc_mesh import get_or_spawn_controller, ProcMesh
 from monarch.tools.debug_env import (
     _get_debug_server_host,
     _get_debug_server_port,
@@ -246,7 +243,4 @@ class DebugController(Actor):
 @functools.cache
 def debug_controller() -> DebugController:
     with fake_sync_state():
-        if isinstance(context().actor_instance.proc_mesh, ProcMesh):
-            return get_or_spawn_controller("debug_controller", DebugController).get()
-        else:
-            return get_or_spawn_controller_v0("debug_controller", DebugController).get()
+        return get_or_spawn_controller("debug_controller", DebugController).get()

--- a/python/monarch/_src/actor/host_mesh.py
+++ b/python/monarch/_src/actor/host_mesh.py
@@ -9,38 +9,53 @@
 import warnings
 from math import prod
 
-from typing import Callable, Dict, Optional, Tuple
+from typing import Callable, Dict, Optional, Tuple, TYPE_CHECKING
 
 from monarch._rust_bindings.monarch_hyperactor.alloc import AllocConstraints, AllocSpec
+from monarch._rust_bindings.monarch_hyperactor.shape import Extent, Slice
 
 from monarch._src.actor.actor_mesh import context
 from monarch._src.actor.allocator import AllocateMixin, AllocHandle, LocalAllocator
-from monarch._src.actor.proc_mesh import _get_bootstrap_args, ProcessAllocator, ProcMesh
+from monarch._src.actor.proc_mesh import (
+    _get_bootstrap_args,
+    ProcessAllocator,
+    ProcMeshV0,
+)
 from monarch._src.actor.shape import MeshTrait, NDSlice, Shape
+from monarch._src.actor.v1 import enabled as v1_enabled
+from monarch._src.actor.v1.host_mesh import (
+    create_local_host_mesh as create_local_host_mesh_v1,
+    fake_in_process_host as fake_in_process_host_v1,
+    host_mesh_from_alloc as host_mesh_from_alloc_v1,
+    HostMesh as HostMeshV1,
+    hosts_from_config as hosts_from_config_v1,
+    this_host as this_host_v1,
+    this_proc as this_proc_v1,
+)
 
 
-def this_host() -> "HostMesh":
+def this_host_v0() -> "HostMeshV0":
     """
     The current machine.
 
     This is just shorthand for looking it up via the context
     """
     host_mesh = context().actor_instance.proc.host_mesh
-    assert isinstance(host_mesh, HostMesh), "expected v0 HostMesh, got v1 HostMesh"
+    assert isinstance(host_mesh, HostMeshV0), "expected v0 HostMesh, got v1 HostMesh"
     return host_mesh
 
 
-def this_proc() -> "ProcMesh":
+def this_proc_v0() -> "ProcMeshV0":
     """
     The current singleton process that this specific actor is
     running on
     """
     proc = context().actor_instance.proc
-    assert isinstance(proc, ProcMesh), "expected v1 ProcMesh, got v0 ProcMesh"
+    assert isinstance(proc, ProcMeshV0), "expected v1 ProcMesh, got v0 ProcMesh"
     return proc
 
 
-def create_local_host_mesh() -> "HostMesh":
+def create_local_host_mesh_v0() -> "HostMeshV0":
     """
     Create a local host mesh for the current machine.
 
@@ -48,10 +63,10 @@ def create_local_host_mesh() -> "HostMesh":
         HostMesh: A single-host mesh configured for local process allocation.
     """
     cmd, args, env = _get_bootstrap_args()
-    return HostMesh(Shape.unity(), ProcessAllocator(cmd, args, env))
+    return HostMeshV0(Shape.unity(), ProcessAllocator(cmd, args, env))
 
 
-class HostMesh(MeshTrait):
+class HostMeshV0(MeshTrait):
     """
     HostMesh represents a collection of compute hosts that can be used to spawn
     processes and actors. The class requires you to provide your AllocateMixin that
@@ -79,7 +94,7 @@ class HostMesh(MeshTrait):
         self,
         per_host: Optional[Dict[str, int]] = None,
         bootstrap: Optional[Callable[[], None]] = None,
-    ) -> "ProcMesh":
+    ) -> "ProcMeshV0":
         """
         Start new processes on this host mesh. By default this starts one proc
         on each host in the mesh. Additional procs can be started using `per_host` to
@@ -113,7 +128,7 @@ class HostMesh(MeshTrait):
             )
 
         new_extent.update(per_host)
-        return ProcMesh.from_alloc(alloc_handle.reshape(new_extent), bootstrap)
+        return ProcMeshV0.from_alloc(alloc_handle.reshape(new_extent), bootstrap)
 
     @property
     def _ndslice(self) -> NDSlice:
@@ -123,28 +138,28 @@ class HostMesh(MeshTrait):
     def _labels(self) -> Tuple[str, ...]:
         return tuple(self._shape.labels)
 
-    def _new_with_shape(self, shape: Shape) -> "HostMesh":
+    def _new_with_shape(self, shape: Shape) -> "HostMeshV0":
         warnings.warn(
             "Slicing a host mesh is kinda fake at the moment, there is no guarentee that procs in the slice will end up on the corresponding hosts",
             stacklevel=2,
         )
-        return HostMesh(
+        return HostMeshV0(
             Shape(self._labels, NDSlice.new_row_major(self._ndslice.sizes)),
             self._allocator,
         )
 
 
-def fake_in_process_host() -> "HostMesh":
+def fake_in_process_host_v0() -> "HostMeshV0":
     """
     Create a host mesh for testing and development using a local allocator.
 
     Returns:
         HostMesh: A host mesh configured with local allocation for in-process use.
     """
-    return HostMesh(Shape.unity(), LocalAllocator())
+    return HostMeshV0(Shape.unity(), LocalAllocator())
 
 
-def hosts_from_config(name: str):
+def hosts_from_config_v0(name: str):
     """
     Get the host mesh 'name' from the monarch configuration for the project.
 
@@ -156,4 +171,32 @@ def hosts_from_config(name: str):
     """
 
     shape = Shape(["hosts"], NDSlice.new_row_major([2]))
-    return HostMesh(shape, ProcessAllocator(*_get_bootstrap_args()))
+    return HostMeshV0(shape, ProcessAllocator(*_get_bootstrap_args()))
+
+
+def host_mesh_from_alloc_v0(
+    name: str, extent: Extent, allocator: AllocateMixin, constraints: AllocConstraints
+) -> HostMeshV0:
+    return HostMeshV0(
+        Shape(extent.labels, Slice.new_row_major(extent.sizes)),
+        allocator,
+        constraints,
+    )
+
+
+if v1_enabled or TYPE_CHECKING:
+    this_host = this_host_v1
+    this_proc = this_proc_v1
+    create_local_host_mesh = create_local_host_mesh_v1
+    fake_in_process_host = fake_in_process_host_v1
+    HostMesh = HostMeshV1
+    hosts_from_config = hosts_from_config_v1
+    host_mesh_from_alloc = host_mesh_from_alloc_v1
+else:
+    this_host = this_host_v0
+    this_proc = this_proc_v0
+    create_local_host_mesh = create_local_host_mesh_v0
+    fake_in_process_host = fake_in_process_host_v0
+    HostMesh = HostMeshV0
+    hosts_from_config = hosts_from_config_v0
+    host_mesh_from_alloc = host_mesh_from_alloc_v0

--- a/python/monarch/_src/actor/logging.py
+++ b/python/monarch/_src/actor/logging.py
@@ -45,11 +45,7 @@ FD_READ_CHUNK_SIZE = 4096
 
 def flush_all_proc_mesh_logs(v1: bool = False) -> None:
     """Flush logs from all active ProcMesh instances."""
-    if not v1:
-        # import `get_active_proc_meshes` here to avoid circular import dependency
-        from monarch._src.actor.proc_mesh import get_active_proc_meshes
-    else:
-        from monarch._src.actor.v1.proc_mesh import get_active_proc_meshes
+    from monarch._src.actor.proc_mesh import get_active_proc_meshes
 
     for pm in get_active_proc_meshes():
         if pm._logging_manager._logging_mesh_client is not None:

--- a/python/monarch/_src/actor/proc_mesh.py
+++ b/python/monarch/_src/actor/proc_mesh.py
@@ -37,13 +37,12 @@ from urllib.parse import urlparse
 from weakref import WeakValueDictionary
 
 from monarch._rust_bindings.monarch_hyperactor.alloc import (  # @manual=//monarch/monarch_extension:monarch_extension
-    Alloc,
     AllocConstraints,
     AllocSpec,
 )
 
 from monarch._rust_bindings.monarch_hyperactor.proc_mesh import (
-    ProcMesh as HyProcMesh,
+    ProcMesh as HyProcMeshV0,
     ProcMeshMonitor,
 )
 from monarch._rust_bindings.monarch_hyperactor.pytokio import PythonTask, Shared
@@ -70,6 +69,14 @@ from monarch._src.actor.endpoint import endpoint
 from monarch._src.actor.future import Future
 from monarch._src.actor.logging import LoggingManager
 from monarch._src.actor.shape import MeshTrait
+from monarch._src.actor.v1 import enabled as v1_enabled
+from monarch._src.actor.v1.proc_mesh import (
+    _ControllerController as _ControllerControllerV1,
+    _get_controller_controller as _get_controller_controller_v1,
+    get_active_proc_meshes as get_active_proc_meshes_v1,
+    get_or_spawn_controller as get_or_spawn_controller_v1,
+    ProcMesh as ProcMeshV1,
+)
 from monarch.tools.config.environment import CondaEnvironment
 from monarch.tools.config.workspace import Workspace
 from monarch.tools.utils import conda as conda_utils
@@ -93,7 +100,7 @@ def _has_tensor_engine() -> bool:
 if TYPE_CHECKING:
     Tensor = Any
     DeviceMesh = Any
-    from monarch._src.actor.host_mesh import HostMesh
+    from monarch._src.actor.host_mesh import HostMeshV0
 
 
 class SetupActor(Actor):
@@ -129,11 +136,11 @@ class ProcMeshRef:
 
     def __init__(self, proc_mesh_id: int) -> None:
         self._proc_mesh_id = proc_mesh_id
-        self._host_mesh: Optional["HostMesh"] = None
+        self._host_mesh: Optional["HostMeshV0"] = None
 
     @classmethod
-    def _fake_proc_mesh(cls, proc_mesh_id: int) -> "ProcMesh":
-        return cast(ProcMesh, cls(proc_mesh_id))
+    def _fake_proc_mesh(cls, proc_mesh_id: int) -> "ProcMeshV0":
+        return cast(ProcMeshV0, cls(proc_mesh_id))
 
     def __getattr__(self, attr: str) -> Any:
         # AttributeError instead of NotImplementedError so that any hasattr calls
@@ -151,23 +158,23 @@ class ProcMeshRef:
         return self._proc_mesh_id == other._proc_mesh_id
 
     @property
-    def _proc_mesh(self) -> Shared["HyProcMesh"]:
+    def _proc_mesh(self) -> Shared["HyProcMeshV0"]:
         return _deref_proc_mesh(self)._proc_mesh
 
 
 _proc_mesh_lock: threading.Lock = threading.Lock()
 _proc_mesh_key: int = 0
-_proc_mesh_registry: WeakValueDictionary[ProcMeshRef, "ProcMesh"] = (
+_proc_mesh_registry: WeakValueDictionary[ProcMeshRef, "ProcMeshV0"] = (
     WeakValueDictionary()
 )
 
 
-def get_active_proc_meshes() -> List["ProcMesh"]:
+def get_active_proc_meshes_v0() -> List["ProcMeshV0"]:
     """Get a list of all active ProcMesh instances."""
     return list(_proc_mesh_registry.values())
 
 
-def _deref_proc_mesh(proc_mesh: ProcMeshRef) -> "ProcMesh":
+def _deref_proc_mesh(proc_mesh: ProcMeshRef) -> "ProcMeshV0":
     if proc_mesh not in _proc_mesh_registry:
         raise ValueError(
             f"ProcMesh with id {proc_mesh._proc_mesh_id} does not exist on host."
@@ -175,7 +182,7 @@ def _deref_proc_mesh(proc_mesh: ProcMeshRef) -> "ProcMesh":
     return _proc_mesh_registry[proc_mesh]
 
 
-class ProcMesh(MeshTrait):
+class ProcMeshV0(MeshTrait):
     """
     A distributed mesh of processes for actor computation.
 
@@ -189,7 +196,7 @@ class ProcMesh(MeshTrait):
 
     def __init__(
         self,
-        hy_proc_mesh: "Shared[HyProcMesh]",
+        hy_proc_mesh: "Shared[HyProcMeshV0]",
         shape: Shape,
         _device_mesh: Optional["DeviceMesh"] = None,
     ) -> None:
@@ -206,9 +213,9 @@ class ProcMesh(MeshTrait):
         self._logging_manager: LoggingManager = LoggingManager()
         self._maybe_device_mesh: Optional["DeviceMesh"] = _device_mesh
         self._stopped = False
-        self._controller_controller: Optional["_ControllerController"] = None
+        self._controller_controller: Optional["_ControllerControllerV0"] = None
         # current set only for context()'s proc_mesh to be a local host mesh.
-        self._host_mesh: Optional["HostMesh"] = None
+        self._host_mesh: Optional["HostMeshV0"] = None
 
     @property
     def initialized(self) -> Future[Literal[True]]:
@@ -217,7 +224,7 @@ class ProcMesh(MeshTrait):
         Because ProcMesh are remote objects, there is no guarentee that the ProcMesh is
         still usable after this completes, only that at some point in the past it was usable.
         """
-        pm: Shared[HyProcMesh] = self._proc_mesh
+        pm: Shared[HyProcMeshV0] = self._proc_mesh
 
         async def task() -> Literal[True]:
             await pm
@@ -226,7 +233,7 @@ class ProcMesh(MeshTrait):
         return Future(coro=task())
 
     @property
-    def host_mesh(self) -> "HostMesh":
+    def host_mesh(self) -> "HostMeshV0":
         if self._host_mesh is None:
             raise NotImplementedError(
                 "NYI complete for release 0.1 (ProcMeshRef knowing its host mesh)"
@@ -241,7 +248,7 @@ class ProcMesh(MeshTrait):
     def _labels(self) -> List[str]:
         return self._shape.labels
 
-    def _new_with_shape(self, shape: Shape) -> "ProcMesh":
+    def _new_with_shape(self, shape: Shape) -> "ProcMeshV0":
         # make sure that if we slice something with unity,
         # we do not lose the ability to spawn on it.
         # remote when spawn is implemented.
@@ -252,7 +259,7 @@ class ProcMesh(MeshTrait):
             if self._maybe_device_mesh is None
             else self._device_mesh._new_with_shape(shape)
         )
-        pm = ProcMesh(self._proc_mesh, shape, _device_mesh=device_mesh)
+        pm = ProcMeshV0(self._proc_mesh, shape, _device_mesh=device_mesh)
         pm._slice = True
         return pm
 
@@ -278,7 +285,7 @@ class ProcMesh(MeshTrait):
         return self._spawn_nonblocking(name, Class, *args, **kwargs)
 
     @property
-    async def _proc_mesh_for_asyncio_fixme(self) -> HyProcMesh:
+    async def _proc_mesh_for_asyncio_fixme(self) -> HyProcMeshV0:
         """
         Get ProcMesh on the asyncio event stream.
         We should redo this functionality to work on the tokio stream.
@@ -313,7 +320,7 @@ class ProcMesh(MeshTrait):
         alloc: AllocHandle,
         setup: Callable[[], None] | None = None,
         _attach_controller_controller: bool = True,
-    ) -> "ProcMesh":
+    ) -> "ProcMeshV0":
         """
         Allocate a process mesh according to the provided alloc.
         Returns when the mesh is fully allocated.
@@ -323,8 +330,8 @@ class ProcMesh(MeshTrait):
         - `setup`: An optional lambda function to configure environment variables on the allocated mesh.
         """
 
-        async def task() -> HyProcMesh:
-            return await HyProcMesh.allocate_nonblocking(await alloc._hy_alloc)
+        async def task() -> HyProcMeshV0:
+            return await HyProcMeshV0.allocate_nonblocking(await alloc._hy_alloc)
 
         shape = Shape(
             list(alloc._extent.keys()),
@@ -333,30 +340,30 @@ class ProcMesh(MeshTrait):
 
         hy_proc_mesh = PythonTask.from_coroutine(task()).spawn()
 
-        pm = ProcMesh(hy_proc_mesh, shape)
+        pm = ProcMeshV0(hy_proc_mesh, shape)
         if _attach_controller_controller:
             instance = context().actor_instance
             assert (
                 instance._controller_controller is None
                 or cast(
-                    ActorMesh[_ControllerController], instance._controller_controller
+                    ActorMesh[_ControllerControllerV0], instance._controller_controller
                 )._class
-                is _ControllerController
+                is _ControllerControllerV0
             ), "Expected v0 _ControllerController, got v1 _ControllerController"
             if instance._controller_controller is None:
-                pm._controller_controller = _get_controller_controller()[1]
+                pm._controller_controller = _get_controller_controller_v0()[1]
             else:
                 pm._controller_controller = cast(
-                    _ControllerController, instance._controller_controller
+                    _ControllerControllerV0, instance._controller_controller
                 )
-            instance._add_child(pm)
+            instance._add_child(pm)  # type: ignore
 
         async def task(
-            pm: "ProcMesh",
-            hy_proc_mesh_task: "Shared[HyProcMesh]",
+            pm: "ProcMeshV0",
+            hy_proc_mesh_task: "Shared[HyProcMeshV0]",
             setup_actor: Optional[SetupActor],
             stream_log_to_client: bool,
-        ) -> HyProcMesh:
+        ) -> HyProcMeshV0:
             hy_proc_mesh = await hy_proc_mesh_task
 
             await pm._logging_manager.init(hy_proc_mesh, stream_log_to_client)
@@ -397,7 +404,7 @@ class ProcMesh(MeshTrait):
 
     def _spawn_nonblocking_on(
         self,
-        pm: "Shared[HyProcMesh]",
+        pm: "Shared[HyProcMeshV0]",
         name: str,
         Class: Type[T],
         *args: Any,
@@ -408,7 +415,7 @@ class ProcMesh(MeshTrait):
                 f"{Class} must subclass monarch.service.Actor to spawn it."
             )
 
-        actor_mesh = HyProcMesh.spawn_async(pm, name, _Actor)
+        actor_mesh = HyProcMeshV0.spawn_async(pm, name, _Actor)
         service = ActorMesh._create(
             Class,
             actor_mesh,
@@ -610,7 +617,7 @@ class ProcMesh(MeshTrait):
             level=level,
         )
 
-    async def __aenter__(self) -> "ProcMesh":
+    async def __aenter__(self) -> "ProcMeshV0":
         if self._stopped:
             raise RuntimeError("`ProcMesh` has already been stopped")
         return self
@@ -656,7 +663,7 @@ class ProcMesh(MeshTrait):
         return (ProcMeshRef._fake_proc_mesh, (self._proc_mesh_id,))
 
     @staticmethod
-    def _from_ref(proc_mesh_ref: ProcMeshRef) -> "ProcMesh":
+    def _from_ref(proc_mesh_ref: ProcMeshRef) -> "ProcMeshV0":
         maybe_proc_mesh = _proc_mesh_registry.get(proc_mesh_ref, None)
         if maybe_proc_mesh is None:
             raise RuntimeError(
@@ -665,7 +672,7 @@ class ProcMesh(MeshTrait):
         return maybe_proc_mesh
 
 
-def local_proc_mesh(*, gpus: Optional[int] = None, hosts: int = 1) -> ProcMesh:
+def local_proc_mesh(*, gpus: Optional[int] = None, hosts: int = 1) -> ProcMeshV0:
     """
     Create a local process mesh for testing and development.
 
@@ -704,7 +711,7 @@ def sim_proc_mesh(
     zones: int = 1,
     dcs: int = 1,
     regions: int = 1,
-) -> ProcMesh:
+) -> ProcMeshV0:
     """Create a simulated process mesh for testing distributed scenarios.
 
     This function creates a process mesh using simulation allocation to test
@@ -731,7 +738,7 @@ def sim_proc_mesh(
         regions=regions,
     )
     alloc = SimAllocator().allocate(spec)
-    return ProcMesh.from_alloc(alloc, None, True)
+    return ProcMeshV0.from_alloc(alloc, None, True)
 
 
 _BOOTSTRAP_MAIN = "monarch._src.actor.bootstrap_main"
@@ -752,12 +759,6 @@ def _get_bootstrap_args() -> tuple[str, Optional[list[str]], dict[str, str]]:
     return cmd, args, env
 
 
-async def _hy_proc_mesh_from_alloc_coro(
-    alloc: "Shared[Alloc] | PythonTask[Alloc]",
-) -> HyProcMesh:
-    return await HyProcMesh.allocate_nonblocking(await alloc)
-
-
 def _proc_mesh_from_allocator(
     *,
     allocator: AllocateMixin,
@@ -765,7 +766,7 @@ def _proc_mesh_from_allocator(
     hosts: int,
     setup: Callable[[], None] | None = None,
     _attach_controller_controller: bool = True,
-) -> ProcMesh:
+) -> ProcMeshV0:
     if gpus is None:
         gpus = _local_device_count()
     # gpus must come last in this order because
@@ -773,7 +774,7 @@ def _proc_mesh_from_allocator(
     # in the order of the dimensions.
     spec: AllocSpec = AllocSpec(AllocConstraints(), hosts=hosts, gpus=gpus)
     alloc = allocator.allocate(spec)
-    return ProcMesh.from_alloc(alloc, setup, _attach_controller_controller)
+    return ProcMeshV0.from_alloc(alloc, setup, _attach_controller_controller)
 
 
 def proc_mesh(
@@ -782,7 +783,7 @@ def proc_mesh(
     hosts: int = 1,
     env: dict[str, str] | None = None,
     setup: Callable[[], None] | None = None,
-) -> ProcMesh:
+) -> ProcMeshV0:
     """
     Create a distributed process mesh across hosts.
 
@@ -827,7 +828,7 @@ def proc_mesh(
 _ActorType = TypeVar("_ActorType", bound=Actor)
 
 
-class _ControllerController(Actor):
+class _ControllerControllerV0(Actor):
     def __init__(self) -> None:
         self._controllers: Dict[str, Actor] = {}
 
@@ -847,8 +848,8 @@ class _ControllerController(Actor):
 
 
 _cc_init = threading.Lock()
-_cc_proc_mesh: Optional["ProcMesh"] = None
-_controller_controller: Optional["_ControllerController"] = None
+_cc_proc_mesh: Optional["ProcMeshV0"] = None
+_controller_controller: Optional["_ControllerControllerV0"] = None
 
 
 # Lazy init so that the controller_controller and proc do not produce logs when they aren't used.
@@ -856,22 +857,22 @@ _controller_controller: Optional["_ControllerController"] = None
 # otherwise two initializing procs will both try to init resulting in duplicates. The critical
 # region is not blocking: it spawns a separate task to do the init, assigns the
 # Shared[_ControllerController] from that task to the global and releases the lock.
-def _get_controller_controller() -> "Tuple[ProcMesh, _ControllerController]":
+def _get_controller_controller_v0() -> "Tuple[ProcMeshV0, _ControllerControllerV0]":
     global _controller_controller, _cc_proc_mesh
     with _cc_init:
         if _controller_controller is None:
             alloc = LocalAllocator().allocate(AllocSpec(AllocConstraints()))
-            _cc_proc_mesh = ProcMesh.from_alloc(
+            _cc_proc_mesh = ProcMeshV0.from_alloc(
                 alloc, _attach_controller_controller=False
             )
             _controller_controller = _cc_proc_mesh.spawn(
-                "controller_controller", _ControllerController
+                "controller_controller", _ControllerControllerV0
             )
     assert _cc_proc_mesh is not None
     return _cc_proc_mesh, _controller_controller
 
 
-def get_or_spawn_controller(
+def get_or_spawn_controller_v0(
     name: str, Class: Type["_ActorType"], *args: Any, **kwargs: Any
 ) -> Future["_ActorType"]:
     """
@@ -890,3 +891,17 @@ def get_or_spawn_controller(
     return context().actor_instance._controller_controller.get_or_spawn.call_one(
         name, Class, *args, **kwargs
     )
+
+
+if v1_enabled or TYPE_CHECKING:
+    ProcMesh = ProcMeshV1
+    get_or_spawn_controller = get_or_spawn_controller_v1  # type: ignore
+    _get_controller_controller = _get_controller_controller_v1
+    get_active_proc_meshes = get_active_proc_meshes_v1
+    _ControllerController = _ControllerControllerV1
+else:
+    ProcMesh = ProcMeshV0
+    get_or_spawn_controller = get_or_spawn_controller_v0
+    _get_controller_controller = _get_controller_controller_v0
+    get_active_proc_meshes = get_active_proc_meshes_v0
+    _ControllerController = _ControllerControllerV0

--- a/python/monarch/_src/actor/source_loader.py
+++ b/python/monarch/_src/actor/source_loader.py
@@ -10,13 +10,10 @@ import importlib
 import importlib.abc
 import linecache
 
-from monarch._src.actor.actor_mesh import _context, Actor, context
+from monarch._src.actor.actor_mesh import _context, Actor
 from monarch._src.actor.endpoint import endpoint
-from monarch._src.actor.proc_mesh import (
-    get_or_spawn_controller as get_or_spawn_controller_v0,
-)
+from monarch._src.actor.proc_mesh import get_or_spawn_controller
 from monarch._src.actor.sync_state import fake_sync_state
-from monarch._src.actor.v1.proc_mesh import get_or_spawn_controller, ProcMesh
 
 
 class SourceLoaderController(Actor):
@@ -28,14 +25,7 @@ class SourceLoaderController(Actor):
 @functools.cache
 def source_loader_controller() -> SourceLoaderController:
     with fake_sync_state():
-        if isinstance(context().actor_instance.proc_mesh, ProcMesh):
-            return get_or_spawn_controller(
-                "source_loader", SourceLoaderController
-            ).get()
-        else:
-            return get_or_spawn_controller_v0(
-                "source_loader", SourceLoaderController
-            ).get()
+        return get_or_spawn_controller("source_loader", SourceLoaderController).get()
 
 
 @functools.cache

--- a/python/monarch/_src/actor/v1/__init__.py
+++ b/python/monarch/_src/actor/v1/__init__.py
@@ -6,45 +6,5 @@
 
 # pyre-unsafe
 import os
-from typing import TYPE_CHECKING
-
-from monarch._rust_bindings.monarch_hyperactor.alloc import AllocConstraints
-from monarch._rust_bindings.monarch_hyperactor.shape import Shape, Slice
-
-from monarch._src.actor.allocator import AllocateMixin
-
-from monarch._src.actor.endpoint import Extent
-from monarch._src.actor.host_mesh import HostMesh as HostMeshV0
-from monarch._src.actor.v1.host_mesh import HostMesh as HostMeshV1
 
 enabled = os.environ.get("MONARCH_HOST_MESH_V1_REMOVE_ME_BEFORE_RELEASE", "0") != "0"
-
-if TYPE_CHECKING or not enabled:
-    from monarch._src.actor.host_mesh import HostMesh, this_host, this_proc
-    from monarch._src.actor.proc_mesh import get_or_spawn_controller, ProcMesh
-else:
-    from monarch._src.actor.v1.host_mesh import HostMesh, this_host, this_proc
-    from monarch._src.actor.v1.proc_mesh import get_or_spawn_controller, ProcMesh
-
-
-def host_mesh_from_alloc(
-    name: str, extent: Extent, allocator: AllocateMixin, constraints: AllocConstraints
-) -> "HostMeshV0 | HostMeshV1":
-    if enabled:
-        return HostMeshV1.allocate_nonblocking(name, extent, allocator, constraints)
-    else:
-        return HostMeshV0(
-            Shape(extent.labels, Slice.new_row_major(extent.sizes)),
-            allocator,
-            constraints,
-        )
-
-
-__all__ = [
-    "HostMesh",
-    "this_host",
-    "this_proc",
-    "get_or_spawn_controller",
-    "ProcMesh",
-    "host_mesh_from_alloc",
-]

--- a/python/monarch/_src/job/meta.py
+++ b/python/monarch/_src/job/meta.py
@@ -4,7 +4,6 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-import os
 import tempfile
 import uuid
 from contextlib import ExitStack
@@ -21,12 +20,12 @@ from monarch._rust_bindings.monarch_hyperactor.alloc import (
 from monarch._rust_bindings.monarch_hyperactor.pytokio import PythonTask, Shared
 from monarch._rust_bindings.monarch_hyperactor.shape import Extent
 from monarch._src.actor.allocator import AllocateMixin
+from monarch._src.actor.host_mesh import host_mesh_from_alloc
 from monarch._src.actor.meta.allocator import (
     MastAllocator,
     MastAllocatorBase,
     MastAllocatorConfig,
 )
-from monarch._src.actor.v1 import host_mesh_from_alloc
 
 from monarch._src.job.job import BatchJob, JobState, JobTrait
 

--- a/python/monarch/actor/__init__.py
+++ b/python/monarch/actor/__init__.py
@@ -9,6 +9,8 @@
 Monarch Actor API - Public interface for actor functionality.
 """
 
+from typing import TYPE_CHECKING
+
 from monarch._rust_bindings.monarch_hyperactor.shape import Extent
 from monarch._src.actor.actor_mesh import (
     Accumulator,
@@ -34,16 +36,29 @@ from monarch._src.actor.debugger.debug_controller import debug_controller
 from monarch._src.actor.endpoint import endpoint
 from monarch._src.actor.future import Future
 
-from monarch._src.actor.host_mesh import hosts_from_config
 from monarch._src.actor.proc_mesh import local_proc_mesh, proc_mesh, sim_proc_mesh
 
-from monarch._src.actor.v1 import (
-    get_or_spawn_controller,
-    HostMesh,
-    ProcMesh,
-    this_host,
-    this_proc,
-)
+from monarch._src.actor.v1 import enabled as v1_enabled
+
+if not v1_enabled or TYPE_CHECKING:
+    from monarch._src.actor.host_mesh import (
+        HostMeshV0 as HostMesh,
+        hosts_from_config_v0 as hosts_from_config,
+        this_host_v0 as this_host,
+        this_proc_v0 as this_proc,
+    )
+    from monarch._src.actor.proc_mesh import (
+        get_or_spawn_controller_v0 as get_or_spawn_controller,
+        ProcMeshV0 as ProcMesh,
+    )
+else:
+    from monarch._src.actor.v1.host_mesh import (
+        HostMesh,
+        hosts_from_config,
+        this_host,
+        this_proc,
+    )
+    from monarch._src.actor.v1.proc_mesh import get_or_spawn_controller, ProcMesh
 
 
 __all__ = [
@@ -79,4 +94,5 @@ __all__ = [
     "attach_to_workers",
     "enable_transport",
     "Context",
+    "ChannelTransport",
 ]

--- a/python/tests/_monarch/test_actor_mesh.py
+++ b/python/tests/_monarch/test_actor_mesh.py
@@ -42,6 +42,10 @@ from monarch._rust_bindings.monarch_hyperactor.v1.proc_mesh import (
     ProcMesh as ProcMeshV1,
 )
 from monarch._src.actor.actor_mesh import Context, context, Instance
+from monarch._src.actor.v1 import enabled as v1_enabled
+
+
+pytestmark = pytest.mark.skipif(not v1_enabled, reason="v0 tested even when v1 enabled")
 
 
 def run_on_tokio(

--- a/python/tests/_monarch/test_client.py
+++ b/python/tests/_monarch/test_client.py
@@ -8,11 +8,18 @@
 
 from unittest import TestCase
 
+import pytest
+
 import torch
 from monarch._rust_bindings.monarch_extension import client
 
 from monarch._rust_bindings.monarch_hyperactor.proc import ActorId
+from monarch._src.actor.v1 import enabled as v1_enabled
 from pyre_extensions import none_throws
+
+pytestmark: pytest.MarkDecorator = pytest.mark.skipif(
+    not v1_enabled, reason="no dep on v0/v1, so only run on v1"
+)
 
 
 class TestClient(TestCase):

--- a/python/tests/_monarch/test_controller.py
+++ b/python/tests/_monarch/test_controller.py
@@ -8,11 +8,18 @@
 
 from unittest import TestCase
 
+import pytest
+
 from monarch._rust_bindings.monarch_extension import (  # @manual=//monarch/monarch_extension:monarch_extension
     controller,
     tensor_worker,
 )
 from monarch._rust_bindings.monarch_hyperactor import shape
+from monarch._src.actor.v1 import enabled as v1_enabled
+
+pytestmark: pytest.MarkDecorator = pytest.mark.skipif(
+    not v1_enabled, reason="no dep on v0/v1, so only run on v1"
+)
 
 
 class TestController(TestCase):

--- a/python/tests/_monarch/test_hyperactor.py
+++ b/python/tests/_monarch/test_hyperactor.py
@@ -6,29 +6,30 @@
 
 # pyre-strict
 
-import datetime
 import multiprocessing
 import os
-import pickle
 import signal
 import time
 from typing import Any, Callable, Coroutine
 
 import monarch
-
-from monarch._rust_bindings.monarch_hyperactor.actor import PanicFlag, PythonMessage
+import pytest
 
 from monarch._rust_bindings.monarch_hyperactor.alloc import (  # @manual=//monarch/monarch_extension:monarch_extension_no_torch
     AllocConstraints,
     AllocSpec,
 )
 from monarch._rust_bindings.monarch_hyperactor.buffers import Buffer
-from monarch._rust_bindings.monarch_hyperactor.mailbox import Mailbox
 from monarch._rust_bindings.monarch_hyperactor.proc import ActorId
 from monarch._rust_bindings.monarch_hyperactor.proc_mesh import ProcMesh
 from monarch._rust_bindings.monarch_hyperactor.pytokio import PythonTask
-from monarch._rust_bindings.monarch_hyperactor.shape import Shape
 from monarch._src.actor.pickle import flatten, unflatten
+from monarch._src.actor.v1 import enabled as v1_enabled
+
+
+pytestmark: pytest.MarkDecorator = pytest.mark.skipif(
+    not v1_enabled, reason="v0 tested even when v1 enabled"
+)
 
 
 class MyActor:

--- a/python/tests/_monarch/test_mailbox.py
+++ b/python/tests/_monarch/test_mailbox.py
@@ -33,6 +33,7 @@ if TYPE_CHECKING:
     from monarch._rust_bindings.monarch_hyperactor.actor import PortProtocol
 
 
+import pytest
 from monarch._rust_bindings.monarch_hyperactor.alloc import AllocConstraints, AllocSpec
 
 from monarch._rust_bindings.monarch_hyperactor.mailbox import (
@@ -42,6 +43,13 @@ from monarch._rust_bindings.monarch_hyperactor.mailbox import (
 )
 from monarch._rust_bindings.monarch_hyperactor.proc_mesh import ProcMesh
 from monarch._src.actor.actor_mesh import Instance
+from monarch._src.actor.v1 import enabled as v1_enabled
+
+
+pytestmark: pytest.MarkDecorator = pytest.mark.skipif(
+    not v1_enabled, reason="v0 tested even when v1 enabled"
+)
+
 
 S = TypeVar("S")
 U = TypeVar("U")

--- a/python/tests/_monarch/test_ndslice.py
+++ b/python/tests/_monarch/test_ndslice.py
@@ -10,9 +10,16 @@ import math
 import random
 from unittest import TestCase
 
+import pytest
+
 from monarch._rust_bindings.monarch_hyperactor.selection import Selection
 
 from monarch._rust_bindings.monarch_hyperactor.shape import Extent, Point, Shape, Slice
+from monarch._src.actor.v1 import enabled as v1_enabled
+
+pytestmark: pytest.MarkDecorator = pytest.mark.skipif(
+    not v1_enabled, reason="no dep on v0/v1, so only run on v1"
+)
 
 
 class TestNdslice(TestCase):

--- a/python/tests/_monarch/test_proc_mesh.py
+++ b/python/tests/_monarch/test_proc_mesh.py
@@ -16,15 +16,22 @@ import unittest
 from pathlib import Path
 from typing import Generator
 
+import pytest
+
 from monarch._rust_bindings.monarch_hyperactor.alloc import AllocConstraints, AllocSpec
 from monarch._rust_bindings.monarch_hyperactor.channel import (
     ChannelAddr,
     ChannelTransport,
 )
 from monarch._src.actor.allocator import RemoteAllocator, StaticRemoteAllocInitializer
+from monarch._src.actor.v1 import enabled as v1_enabled
 
 from monarch.actor import ProcMesh
 from monarch.tools.config.workspace import Workspace
+
+pytestmark: pytest.MarkDecorator = pytest.mark.skipif(
+    v1_enabled, reason="ENABLE ASAP ONCE V1 CODE SYNC LANDS"
+)
 
 
 @contextlib.contextmanager

--- a/python/tests/_monarch/test_value_mesh.py
+++ b/python/tests/_monarch/test_value_mesh.py
@@ -8,8 +8,15 @@
 
 from unittest import TestCase
 
+import pytest
+
 from monarch._rust_bindings.monarch_hyperactor.shape import Shape, Slice
 from monarch._rust_bindings.monarch_hyperactor.value_mesh import ValueMesh
+from monarch._src.actor.v1 import enabled as v1_enabled
+
+pytestmark: pytest.MarkDecorator = pytest.mark.skipif(
+    not v1_enabled, reason="no dep on v0/v1, so only run on v1"
+)
 
 
 class TestValueMesh(TestCase):

--- a/python/tests/_monarch/test_worker.py
+++ b/python/tests/_monarch/test_worker.py
@@ -11,10 +11,16 @@ from typing import cast
 from unittest import TestCase
 
 import cloudpickle
+import pytest
 
 from monarch._rust_bindings.monarch_extension import tensor_worker
 from monarch._rust_bindings.monarch_hyperactor import shape
+from monarch._src.actor.v1 import enabled as v1_enabled
 from pyre_extensions import none_throws
+
+pytestmark: pytest.MarkDecorator = pytest.mark.skipif(
+    not v1_enabled, reason="no dep on v0/v1, so only run on v1"
+)
 
 
 def is_nan(val: int) -> bool:

--- a/python/tests/job_train.py
+++ b/python/tests/job_train.py
@@ -6,6 +6,7 @@
 
 # Directly import to avoid import issues in Buck
 from monarch._src.job.job import LocalJob
+from monarch.actor import this_proc
 
 if __name__ == "__main__":
     job = LocalJob()
@@ -13,6 +14,11 @@ if __name__ == "__main__":
 
     # Check which hosts are available in the state
     print(f"hosts {getattr(state, 'hosts', None) is not None}")
+
+    # Wait until we know the hosts have finished initializing to avoid
+    # fatal GIL release error.
+    this_proc().initialized.get()
+
     print(
         f"batch_launched_hosts {getattr(state, 'batch_launched_hosts', None) is not None}"
     )

--- a/python/tests/python_actor_test_binary.py
+++ b/python/tests/python_actor_test_binary.py
@@ -11,7 +11,7 @@ import logging
 
 import click
 
-from monarch.actor import Actor, endpoint, proc_mesh
+from monarch.actor import Actor, endpoint, this_host
 
 
 @click.group()
@@ -30,7 +30,7 @@ class Printer(Actor):
 
 async def _flush_logs() -> None:
     # Create a lot of processes to stress test the logging
-    pm = proc_mesh(gpus=32)
+    pm = this_host().spawn_procs(per_host={"gpus": 32})
 
     # never flush
     await pm.logging_option(aggregate_window_sec=1000)

--- a/python/tests/rdma_load_test.py
+++ b/python/tests/rdma_load_test.py
@@ -11,6 +11,8 @@ import random
 import statistics
 import time
 
+import pytest
+
 # parse up front to extract env variables.
 args = None
 if __name__ == "__main__":
@@ -61,8 +63,14 @@ else:
 
 # pyre-ignore
 import torch
+from monarch._src.actor.v1 import enabled as v1_enabled
 from monarch.actor import Actor, endpoint, this_host
 from monarch.rdma import RDMABuffer
+
+
+pytestmark: pytest.MarkDecorator = pytest.mark.skipif(
+    v1_enabled, reason="ENABLE ME ASAP ONCE V1 RDMA LANDS"
+)
 
 
 class RDMATest(Actor):

--- a/python/tests/test_actor_shape.py
+++ b/python/tests/test_actor_shape.py
@@ -8,8 +8,16 @@
 
 from unittest import TestCase
 
+import pytest
+
 from monarch._rust_bindings.monarch_hyperactor.shape import Shape, Slice
 from monarch._src.actor.shape import ShapeExt
+from monarch._src.actor.v1 import enabled as v1_enabled
+
+
+pytestmark: pytest.MarkDecorator = pytest.mark.skipif(
+    not v1_enabled, reason="no v0/v1 dependency, so only run with v1"
+)
 
 
 class TestShapeSlicing(TestCase):

--- a/python/tests/test_actor_value_mesh.py
+++ b/python/tests/test_actor_value_mesh.py
@@ -18,6 +18,15 @@ if TYPE_CHECKING:
     # import the Rust type at runtime.
     from monarch._rust_bindings.monarch_hyperactor.shape import Shape as HyShape
 
+
+from monarch._src.actor.v1 import enabled as v1_enabled
+
+
+pytestmark: pytest.MarkDecorator = pytest.mark.skipif(
+    not v1_enabled, reason="no v0/v1 dependency, so only run with v1"
+)
+
+
 # These tests target ValueMesh._new_with_shape. The goal is to verify the
 # remapping logic:
 #

--- a/python/tests/test_alloc.py
+++ b/python/tests/test_alloc.py
@@ -8,10 +8,18 @@
 
 from unittest import IsolatedAsyncioTestCase
 
+import pytest
+
 from monarch import ProcessAllocator
 from monarch._rust_bindings.monarch_hyperactor.alloc import (  # @manual=//monarch/monarch_extension:monarch_extension
     AllocConstraints,
     AllocSpec,
+)
+from monarch._src.actor.v1 import enabled as v1_enabled
+
+
+pytestmark: pytest.MarkDecorator = pytest.mark.skipif(
+    not v1_enabled, reason="no v0/v1 dependency, so only run with v1"
 )
 
 

--- a/python/tests/test_coalescing.py
+++ b/python/tests/test_coalescing.py
@@ -27,10 +27,16 @@ from monarch import (
     remote,
     Stream,
 )
+from monarch._src.actor.v1 import enabled as v1_enabled
 from monarch._testing import TestingContext
 from monarch.common._coalescing import _record_and_define, compile
 from monarch.common.function_caching import AliasOf, Storage, TensorGroup
 from monarch.common.tensor import Tensor
+
+
+pytestmark = pytest.mark.skipif(
+    not v1_enabled, reason="no dep on tensor engine, so might as well only run on v1"
+)
 
 
 def _do_bogus_tensor_work(x, y, fail_rank=None):

--- a/python/tests/test_config.py
+++ b/python/tests/test_config.py
@@ -12,6 +12,11 @@ from monarch._rust_bindings.monarch_hyperactor.config import (
     configure,
     get_configuration,
 )
+from monarch._src.actor.v1 import enabled as v1_enabled
+
+pytestmark = pytest.mark.skipif(
+    not v1_enabled, reason="no v0/v1 dependency, so only run with v1"
+)
 
 
 def test_get_set_transport() -> None:

--- a/python/tests/test_controller.py
+++ b/python/tests/test_controller.py
@@ -27,6 +27,7 @@ from monarch import (
     Stream,
     Tensor,
 )
+from monarch._src.actor.v1 import enabled as v1_enabled
 
 from monarch._testing import BackendType, TestingContext
 from monarch.common.controller_api import LogMessage
@@ -42,6 +43,12 @@ from monarch.rust_local_mesh import (
     SupervisionParams,
 )
 from monarch_supervisor.logging import fix_exception_lines
+
+
+# FIXME(slurye)
+pytestmark = pytest.mark.skipif(
+    v1_enabled, reason="ENABLE ME ASAP ONCE V1 TENSOR ENGINE LANDS"
+)
 
 
 def custom_excepthook(exc_type, exc_value, exc_traceback):

--- a/python/tests/test_device_mesh.py
+++ b/python/tests/test_device_mesh.py
@@ -8,8 +8,14 @@
 import pytest
 
 from monarch import DeviceMesh, NDSlice
+from monarch._src.actor.v1 import enabled as v1_enabled
 from monarch.common.client import Client
 from monarch.simulator.mock_controller import MockController
+
+
+pytestmark: pytest.MarkDecorator = pytest.mark.skipif(
+    not v1_enabled, reason="no v0/v1 dependency, so only run with v1"
+)
 
 
 class TestDeviceMesh:

--- a/python/tests/test_env_before_cuda.py
+++ b/python/tests/test_env_before_cuda.py
@@ -16,8 +16,10 @@ import cloudpickle
 import torch
 from monarch._rust_bindings.monarch_hyperactor.alloc import AllocConstraints, AllocSpec
 from monarch._src.actor.allocator import LocalAllocator
-from monarch._src.actor.proc_mesh import proc_mesh
-from monarch.actor import Actor, endpoint, ProcMesh
+from monarch._src.actor.host_mesh import create_local_host_mesh, fake_in_process_host
+from monarch._src.actor.proc_mesh import proc_mesh as proc_mesh_v0, ProcMesh
+from monarch._src.actor.v1 import enabled as v1_enabled
+from monarch.actor import Actor, endpoint
 
 
 class CudaInitTestActor(Actor):
@@ -73,11 +75,14 @@ class TestEnvBeforeCuda(unittest.IsolatedAsyncioTestCase):
             for name, value in cuda_env_vars.items():
                 os.environ[name] = value
 
-        spec = AllocSpec(AllocConstraints(), gpus=1, hosts=1)
-        allocator = LocalAllocator()
-        alloc = allocator.allocate(spec)
+        if not v1_enabled:
+            spec = AllocSpec(AllocConstraints(), gpus=1, hosts=1)
+            allocator = LocalAllocator()
+            alloc = allocator.allocate(spec)
 
-        proc_mesh = ProcMesh.from_alloc(alloc, setup=setup_cuda_env)
+            proc_mesh = ProcMesh.from_alloc(alloc, setup=setup_cuda_env)
+        else:
+            proc_mesh = fake_in_process_host().spawn_procs(bootstrap=setup_cuda_env)
 
         try:
             actor = proc_mesh.spawn("cuda_init", CudaInitTestActor)
@@ -110,7 +115,12 @@ class TestEnvBeforeCuda(unittest.IsolatedAsyncioTestCase):
             for name, value in cuda_env_vars.items():
                 os.environ[name] = value
 
-        proc_mesh_instance = proc_mesh(gpus=1, hosts=1, setup=setup_cuda_env)
+        if not v1_enabled:
+            proc_mesh_instance = proc_mesh_v0(gpus=1, hosts=1, setup=setup_cuda_env)
+        else:
+            proc_mesh_instance = create_local_host_mesh().spawn_procs(
+                bootstrap=setup_cuda_env
+            )
 
         try:
             actor = proc_mesh_instance.spawn("cuda_init", CudaInitTestActor)
@@ -136,7 +146,10 @@ class TestEnvBeforeCuda(unittest.IsolatedAsyncioTestCase):
             "CUDA_DEVICE_MAX_CONNECTIONS": "1",
         }
 
-        proc_mesh_instance = proc_mesh(gpus=1, hosts=1, env=cuda_env_vars)
+        if not v1_enabled:
+            proc_mesh_instance = proc_mesh_v0(gpus=1, hosts=1, env=cuda_env_vars)
+        else:
+            proc_mesh_instance = create_local_host_mesh(env=cuda_env_vars).spawn_procs()
 
         try:
             actor = proc_mesh_instance.spawn("cuda_init", CudaInitTestActor)

--- a/python/tests/test_fault_tolerance.py
+++ b/python/tests/test_fault_tolerance.py
@@ -8,7 +8,7 @@
 
 import random
 import time
-from typing import List, Optional
+from typing import Optional
 
 import pytest
 import torch
@@ -19,6 +19,7 @@ except ModuleNotFoundError:
     from unittest import TestCase
 
 from monarch import fetch_shard, no_mesh, remote
+from monarch._src.actor.v1 import enabled as v1_enabled
 from monarch.common.device_mesh import DeviceMesh, DeviceMeshStatus
 from monarch.common.invocation import DeviceException, RemoteException
 from monarch.rust_backend_mesh import MeshWorld, PoolDeviceMeshProvider
@@ -29,6 +30,12 @@ from monarch.rust_local_mesh import (
     LoggingLocation,
     SocketType,
     SupervisionParams,
+)
+
+
+pytestmark = pytest.mark.skipif(
+    not v1_enabled,
+    reason="uses deprecated system actor, so might as well only run on v1",
 )
 
 

--- a/python/tests/test_future.py
+++ b/python/tests/test_future.py
@@ -13,8 +13,14 @@ from monarch import Future, RemoteException
 from monarch._rust_bindings.monarch_hyperactor.proc import (  # @manual=//monarch/monarch_extension:monarch_extension
     ActorId,
 )
+from monarch._src.actor.v1 import enabled as v1_enabled
 from monarch.common import future
 from monarch.common.client import Client
+
+
+pytestmark: pytest.MarkDecorator = pytest.mark.skipif(
+    not v1_enabled, reason="no v0/v1 dependency, so only run with v1"
+)
 
 
 class TestFuture:

--- a/python/tests/test_grad_generator.py
+++ b/python/tests/test_grad_generator.py
@@ -7,9 +7,17 @@
 # pyre-unsafe
 from unittest import main, TestCase
 
+import pytest
+
 import torch
+from monarch._src.actor.v1 import enabled as v1_enabled
 from monarch.gradient._gradient_generator import GradientGenerator
 from monarch.gradient_generator import gradient_execution_order
+
+
+pytestmark: pytest.MarkDecorator = pytest.mark.skipif(
+    not v1_enabled, reason="no v0/v1 dependency, so only run with v1"
+)
 
 
 class TestGradIter(TestCase):

--- a/python/tests/test_host_mesh.py
+++ b/python/tests/test_host_mesh.py
@@ -8,17 +8,21 @@
 
 import pytest
 from monarch._rust_bindings.monarch_hyperactor.shape import Extent, Shape, Slice
-from monarch._src.actor.pickle import flatten, unflatten
-from monarch._src.actor.v1.host_mesh import (
+from monarch._src.actor.host_mesh import (
     create_local_host_mesh,
     fake_in_process_host,
     HostMesh,
 )
+from monarch._src.actor.pickle import flatten, unflatten
+from monarch._src.actor.v1 import enabled as v1_enabled
+
+
+pytestmark = pytest.mark.skipif(not v1_enabled, reason="v1 not enabled")
 
 
 @pytest.mark.timeout(60)
 def test_fake_in_process_host() -> None:
-    host = fake_in_process_host("fake")
+    host = fake_in_process_host()
     assert host.extent.labels == ["hosts"]
     assert host.extent.sizes == [1]
     assert not host.stream_logs
@@ -29,7 +33,7 @@ def test_fake_in_process_host() -> None:
 
 @pytest.mark.timeout(60)
 def test_create_local_host_mesh() -> None:
-    host = create_local_host_mesh("fake")
+    host = create_local_host_mesh()
     assert host.extent.labels == ["hosts"]
     assert host.extent.sizes == [1]
     assert not host.stream_logs
@@ -41,7 +45,6 @@ def test_create_local_host_mesh() -> None:
 @pytest.mark.timeout(60)
 def test_multi_dim_host_mesh() -> None:
     host = create_local_host_mesh(
-        "host",
         Extent(["replicas", "hosts"], [2, 4]),
     )
     assert host.extent.labels == ["replicas", "hosts"]
@@ -70,7 +73,6 @@ def test_multi_dim_host_mesh() -> None:
 @pytest.mark.timeout(120)
 def test_spawn_proc_mesh() -> None:
     host = create_local_host_mesh(
-        "host",
         Extent(["replicas", "hosts"], [2, 4]),
     )
     proc_mesh = host.spawn_procs(name="proc")
@@ -99,7 +101,6 @@ def test_spawn_proc_mesh() -> None:
 @pytest.mark.timeout(60)
 def test_pickle() -> None:
     host = create_local_host_mesh(
-        "host",
         Extent(["replicas", "hosts"], [2, 4]),
     )
     _unused, pickled = flatten(host, lambda _: False)

--- a/python/tests/test_job.py
+++ b/python/tests/test_job.py
@@ -11,11 +11,15 @@ import tempfile
 from typing import cast, Dict, Optional, Sequence
 
 import pytest
+from monarch._src.actor.v1 import enabled as v1_enabled
 
 # Import directly from _src since job module isn't properly exposed
 from monarch._src.job.job import job_load, job_loads, JobState, JobTrait, LocalJob
 
 from monarch.actor import HostMesh
+
+
+pytestmark = pytest.mark.skipif(not v1_enabled, reason="not relevant for v0")
 
 
 class MockJobTrait(JobTrait):

--- a/python/tests/test_mesh_trait.py
+++ b/python/tests/test_mesh_trait.py
@@ -8,7 +8,14 @@
 
 from typing import Iterable
 
+import pytest
+
 from monarch._src.actor.shape import MeshTrait, NDSlice, Shape, Slice
+from monarch._src.actor.v1 import enabled as v1_enabled
+
+pytestmark = pytest.mark.skipif(
+    not v1_enabled, reason="no dep on v0/v1, so only run with v1"
+)
 
 
 class Mesh(MeshTrait):

--- a/python/tests/test_mock_cuda.py
+++ b/python/tests/test_mock_cuda.py
@@ -9,6 +9,11 @@ from unittest import main, TestCase
 
 import pytest
 import torch
+from monarch._src.actor.v1 import enabled as v1_enabled
+
+pytestmark = pytest.mark.skipif(
+    not v1_enabled, reason="no dep on v0/v1, so only run with v1"
+)
 
 
 # Avoid importing if the test is not run.

--- a/python/tests/test_pdb_actor.py
+++ b/python/tests/test_pdb_actor.py
@@ -25,8 +25,14 @@ from monarch._rust_bindings.monarch_extension.debugger import (
     get_bytes_from_write_action,
 )
 from monarch._rust_bindings.monarch_messages.debugger import DebuggerAction
+from monarch._src.actor.v1 import enabled as v1_enabled
 from monarch.rust_local_mesh import LoggingLocation, SocketType
 from monarch_supervisor.logging import fix_exception_lines
+
+
+pytestmark = pytest.mark.skipif(
+    not v1_enabled, reason="uses deprecated system actor, might as well only run on v1"
+)
 
 
 def custom_excepthook(exc_type, exc_value, exc_traceback):

--- a/python/tests/test_rdma.py
+++ b/python/tests/test_rdma.py
@@ -12,8 +12,12 @@ os.environ["PYTORCH_CUDA_ALLOC_CONF"] = "expandable_segments:True"
 
 import pytest
 import torch
+from monarch._src.actor.v1 import enabled as v1_enabled
 from monarch.actor import Actor, current_rank, endpoint, this_host
 from monarch.rdma import is_rdma_available, RDMAAction, RDMABuffer
+
+
+pytestmark = pytest.mark.skipif(v1_enabled, reason="ENABLE ASAP ONCE V1 RDMA LANDS")
 
 
 needs_cuda = pytest.mark.skipif(

--- a/python/tests/test_rdma_unit.py
+++ b/python/tests/test_rdma_unit.py
@@ -86,8 +86,13 @@ import numpy as np
 import pytest
 
 import torch
+from monarch._src.actor.v1 import enabled as v1_enabled
 from monarch.actor import Actor, endpoint, this_host
 from monarch.rdma import is_rdma_available, RDMABuffer
+
+
+pytestmark = pytest.mark.skipif(v1_enabled, reason="ENABLE ASAP ONCE V1 RDMA LANDS")
+
 
 TIMEOUT = 60  # 60 seconds
 

--- a/python/tests/test_rdma_unsupported.py
+++ b/python/tests/test_rdma_unsupported.py
@@ -14,7 +14,12 @@ behavior when RDMA support is missing.
 """
 
 import pytest
+from monarch._src.actor.v1 import enabled as v1_enabled
 from monarch.rdma import is_rdma_available
+
+
+pytestmark = pytest.mark.skipif(v1_enabled, reason="ENABLE ASAP ONCE V1 RDMA LANDS")
+
 
 needs_no_rdma = pytest.mark.skipif(
     is_rdma_available(),

--- a/python/tests/test_remote_functions.py
+++ b/python/tests/test_remote_functions.py
@@ -27,6 +27,7 @@ from monarch import (
     RemoteException as OldRemoteException,
     Stream,
 )
+from monarch._src.actor.v1 import enabled as v1_enabled
 
 from monarch._testing import BackendType, TestingContext
 from monarch.builtins.log import log_remote
@@ -57,6 +58,12 @@ from monarch.worker._testing_function import (
 )
 from monarch_supervisor.logging import fix_exception_lines
 from torch.distributed import ReduceOp
+
+
+pytestmark = pytest.mark.skipif(
+    v1_enabled, reason="ENABLE ASAP ONCE V1 TENSOR ENGINE LANDS"
+)
+
 
 RemoteException = (NewRemoteException, OldRemoteException)
 

--- a/python/tests/test_rust_backend.py
+++ b/python/tests/test_rust_backend.py
@@ -16,11 +16,17 @@ import pytest
 import torch
 import torch.utils._python_dispatch
 from monarch import fetch_shard, no_mesh, remote, Stream
+from monarch._src.actor.v1 import enabled as v1_enabled
 from monarch.common.device_mesh import DeviceMesh
 from monarch.common.remote import call_on_shard_and_fetch
 from monarch.rust_local_mesh import local_meshes, LoggingLocation, SocketType
 from torch.nn.attention import sdpa_kernel, SDPBackend
 from torch.nn.functional import scaled_dot_product_attention
+
+
+pytestmark = pytest.mark.skipif(
+    not v1_enabled, reason="uses deprecated system actor, might as well only run on v1"
+)
 
 
 def simple_all_reduce(*args, **kwargs):

--- a/python/tests/test_signal_safe_block_on.py
+++ b/python/tests/test_signal_safe_block_on.py
@@ -23,6 +23,12 @@ import time
 import unittest
 
 import pytest
+from monarch._src.actor.v1 import enabled as v1_enabled
+
+
+pytestmark: pytest.MarkDecorator = pytest.mark.skipif(
+    not v1_enabled, reason="no dep on v0/v1, so only run on v1"
+)
 
 
 # oss_skip: importlib not pulling resource correctly in git CI, needs to be revisited

--- a/python/tests/test_sim_backend.py
+++ b/python/tests/test_sim_backend.py
@@ -7,15 +7,22 @@
 # pyre-unsafe
 
 from contextlib import contextmanager
-from typing import Generator, Optional
+from typing import Generator
 from unittest import TestCase
 
 import pytest
 
 import torch
 from monarch import fetch_shard
+from monarch._src.actor.v1 import enabled as v1_enabled
 from monarch.common.device_mesh import DeviceMesh
 from monarch.sim_mesh import sim_mesh
+
+
+pytestmark = pytest.mark.skipif(
+    not v1_enabled,
+    reason="uses deprecated system actor, so might as well only run on v1",
+)
 
 
 @contextmanager

--- a/python/tests/test_tensor_engine.py
+++ b/python/tests/test_tensor_engine.py
@@ -10,8 +10,14 @@ import monarch
 import pytest
 import torch
 from monarch import remote
+from monarch._src.actor.v1 import enabled as v1_enabled
 from monarch.actor import Actor, as_endpoint, endpoint, proc_mesh, this_host
 from monarch.mesh_controller import spawn_tensor_engine
+
+
+pytestmark = pytest.mark.skipif(
+    v1_enabled, reason="ENABLE ASAP ONCE V1 TENSOR ENGINE LANDS"
+)
 
 
 two_gpu = pytest.mark.skipif(

--- a/python/tests/test_value_mesh_compression_scheme.py
+++ b/python/tests/test_value_mesh_compression_scheme.py
@@ -1,6 +1,19 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
 import math
 from dataclasses import dataclass
 from typing import Iterator, List, Sequence
+
+import pytest
+from monarch._src.actor.v1 import enabled as v1_enabled
+
+pytestmark = pytest.mark.skipif(
+    not v1_enabled, reason="no dep on v0/v1, so only run on v1"
+)
 
 
 @dataclass


### PR DESCRIPTION
Summary:
Instead of just toggling the public API, the `MONARCH_HOST_MESH_V1_REMOVE_ME_BEFORE_RELEASE` env var now toggles both the public and private APIs. That means there should be minimal instances left of, e.g. `if v1 then get_or_spawn_controller_v1() else get_or_spawn_controller_v0()` and similar usages.

Unfortunately, it *also* means we now have to do two separate test runs for v0 and v1 instead of just parametrizing on the API version. This diff therefore:
- Goes through all the tests that had previously been parametrized on API version and undoes the parametrization
- Goes through all tests that only need to be enabled for v1 and marks them as such (this is mostly done at the file level)
- Goes through all tests that only need to be enabled for v0 and marks them as such (this is mostly done at the file level)
- Adds separate v0 and v1 test runs to github CI

Reviewed By: zdevito, mariusae

Differential Revision: D84296391
