### PR TITLE
Revert supervision_event from v1 API due to performance

### DIFF
--- a/monarch_hyperactor/src/v1/proc_mesh.rs
+++ b/monarch_hyperactor/src/v1/proc_mesh.rs
@@ -143,7 +143,8 @@ impl PyProcMesh {
                     let mesh_impl: Box<dyn ActorMeshProtocol> = mesh_impl.await?;
                     Ok(mesh_impl)
                 },
-                true,
+                // Not supervised, supervision_event not implemented yet.
+                false,
             );
             Python::with_gil(|py| r.into_py_any(py))
         }

--- a/python/tests/test_actor_error.py
+++ b/python/tests/test_actor_error.py
@@ -9,7 +9,6 @@
 import importlib.resources
 import os
 import subprocess
-from enum import auto, Enum
 
 import pytest
 from monarch._rust_bindings.monarch_hyperactor.proc_mesh import ProcEvent
@@ -18,11 +17,6 @@ from monarch._src.actor.host_mesh import fake_in_process_host, this_host
 from monarch._src.actor.proc_mesh import proc_mesh, ProcMesh
 from monarch._src.actor.v1 import enabled as v1_enabled
 from monarch.actor import Actor, ActorError, endpoint
-
-
-class ApiVersion(Enum):
-    V0 = auto()
-    V1 = auto()
 
 
 class ExceptionActor(Actor):

--- a/scripts/common-setup.sh
+++ b/scripts/common-setup.sh
@@ -176,6 +176,7 @@ run_test_groups() {
       MONARCH_HOST_MESH_V1_REMOVE_ME_BEFORE_RELEASE=1 \
       LC_ALL=C pytest python/tests/ -s -v -m "not oss_skip" \
         --ignore-glob="**/meta/**" \
+        --ignore=python/tests/test_actor_error.py \
         --dist=no \
         --group=$GROUP \
         --splits=10


### PR DESCRIPTION
Summary:
Part of: https://github.com/meta-pytorch/monarch/issues/1209

I discovered a pretty bad performance regression in basic endpoints during investigating
a multiprocessing benchmark.
It turns out the cause was the supervision event polling loop introduced in
https://github.com/meta-pytorch/monarch/pull/1454.
There were many copies that weren't getting dropped even after the endpoint was no longer being awaited.

Since benchmarking performance is critical right now, revert this until I can get a proper fix.

Most of the implementation is still there, just dead code.

Differential Revision: D84398334
