### PR TITLE
[monarch] Fix broken github CI due to no ipython

### DIFF
--- a/python/tests/_monarch/test_logging.py
+++ b/python/tests/_monarch/test_logging.py
@@ -11,6 +11,8 @@ from typing import Any
 from unittest import IsolatedAsyncioTestCase, TestCase
 from unittest.mock import Mock, patch
 
+import pytest
+
 from monarch._rust_bindings.monarch_hyperactor.v1.proc_mesh import (
     ProcMesh as HyProcMeshV1,
 )
@@ -29,6 +31,7 @@ class LoggingManagerTest(TestCase):
         # Assert: confirm that _logging_mesh_client is initialized to None
         self.assertIsNone(manager._logging_mesh_client)
 
+    @pytest.mark.oss_skip  # type: ignore: monarch._src.actor.logging.get_ipython doesn't exist in OSS CI
     @patch("monarch._src.actor.logging.IN_IPYTHON", True)
     @patch("monarch._src.actor.logging.get_ipython")
     @patch("monarch._src.actor.logging._global_flush_registered", False)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #1504

Someone landed a test that references the `get_ipython` function that doesn't exist in github CI. This diff skips the test in github CI so it should get us back to green.

Differential Revision: [D84401486](https://our.internmc.facebook.com/intern/diff/D84401486/)