### PR TITLE
[monarch] HostMesh.shutdown()

### DIFF
--- a/python/monarch/_rust_bindings/monarch_hyperactor/v1/host_mesh.pyi
+++ b/python/monarch/_rust_bindings/monarch_hyperactor/v1/host_mesh.pyi
@@ -70,6 +70,15 @@ class HostMesh:
 
     def __reduce__(self) -> Any: ...
     def __eq__(self, other: "HostMesh") -> bool: ...
+    def shutdown(self, instance: Instance) -> PythonTask[None]:
+        """
+        Shutdown the hosts in this mesh. This will throw an exception if this object
+        is backed by a reference to a mesh rather than an owned mesh.
+
+        Arguments:
+        - `instance`: The instance to use to shutdown the mesh.
+        """
+        ...
 
 @final
 class BootstrapCommand:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #1507
* __->__ #1506

Integrate `HostMesh.shutdown()` into python. It's a blocking call and it throws if it's a reference to a host mesh instead of an owned host mesh.

Differential Revision: [D84323613](https://our.internmc.facebook.com/intern/diff/D84323613/)