### PR TITLE
[monarch] make tensor engine mesh version polymorphic

### DIFF
--- a/hyperactor/src/proc.rs
+++ b/hyperactor/src/proc.rs
@@ -1361,11 +1361,10 @@ impl<A: Actor> Instance<A> {
         actor.handle(&context, message).instrument(span).await
     }
 
-    // Spawn on child on this instance. Currently used only by cap::CanSpawn.
-    pub(crate) async fn spawn<C: Actor>(
-        &self,
-        params: C::Params,
-    ) -> anyhow::Result<ActorHandle<C>> {
+    /// Spawn on child on this instance. This method should only be used
+    /// when the holder has a concrete Instance. Generally, prefer to use
+    /// the context-passing methods on [`Actor`].
+    pub async fn spawn<C: Actor>(&self, params: C::Params) -> anyhow::Result<ActorHandle<C>> {
         self.proc.spawn_child(self.cell.clone(), params).await
     }
 

--- a/hyperactor_mesh/src/proc_mesh.rs
+++ b/hyperactor_mesh/src/proc_mesh.rs
@@ -992,7 +992,9 @@ impl<D: Deref<Target = ProcMesh> + Send + Sync + 'static> SharedSpawnable for D 
                     ranks,
                 ))
             }
-            ProcMeshKind::V1(proc_mesh) => todo!(),
+            ProcMeshKind::V1(proc_mesh) => Ok(RootActorMesh::from(
+                proc_mesh.spawn(cx, actor_name, params).await?,
+            )),
         }
     }
 }

--- a/hyperactor_mesh/src/v1/actor_mesh.rs
+++ b/hyperactor_mesh/src/v1/actor_mesh.rs
@@ -155,7 +155,7 @@ impl<A: Referable> ActorMeshRef<A> {
             self.cast_v0(cx, message, root_comm_actor)
         } else {
             for (point, actor) in self.iter() {
-                let create_rank = point.rank();
+                let rank = point.rank();
                 let mut headers = Attrs::new();
                 headers.set(
                     multicast::CAST_ORIGINATING_SENDER,
@@ -168,8 +168,8 @@ impl<A: Referable> ActorMeshRef<A> {
                 let mut unbound = Unbound::try_from_message(message.clone())
                     .map_err(|e| Error::CastingError(self.name.clone(), e))?;
                 unbound
-                    .visit_mut::<resource::Rank>(|resource::Rank(rank)| {
-                        *rank = Some(create_rank);
+                    .visit_mut::<resource::Rank>(|resource::Rank(r)| {
+                        *r = Some(rank);
                         Ok(())
                     })
                     .map_err(|e| Error::CastingError(self.name.clone(), e))?;
@@ -195,7 +195,7 @@ impl<A: Referable> ActorMeshRef<A> {
         M: Castable + RemoteMessage + Clone, // Clone is required until we are fully onto comm actor
     {
         let cast_mesh_shape = view::Ranked::region(self).into();
-        let actor_mesh_id = ActorMeshId::V1(self.name.clone());
+        let actor_mesh_id: ActorMeshId = ActorMeshId::V1(self.name.clone());
         match &self.proc_mesh.root_region {
             Some(root_region) => {
                 let root_mesh_shape = root_region.into();

--- a/hyperactor_mesh/src/v1/proc_mesh.rs
+++ b/hyperactor_mesh/src/v1/proc_mesh.rs
@@ -167,7 +167,8 @@ impl ProcRef {
         }
     }
 
-    pub(crate) fn proc_id(&self) -> &ProcId {
+    /// The proc's ProcId.
+    pub fn proc_id(&self) -> &ProcId {
         &self.proc_id
     }
 

--- a/monarch_tensor_worker/src/lib.rs
+++ b/monarch_tensor_worker/src/lib.rs
@@ -835,7 +835,7 @@ impl WorkerMessageHandler for WorkerActor {
             .send_value(
                 cx,
                 seq,
-                cx.self_id().clone(),
+                self.rank,
                 mutates,
                 function,
                 args,
@@ -852,8 +852,9 @@ impl WorkerMessageHandler for WorkerActor {
         params: ActorCallParams,
     ) -> Result<()> {
         let stream = self.try_get_stream(params.stream)?;
+        // MARIUS: wrong!
         stream
-            .send_result_of_actor_call(cx, cx.self_id().clone(), params)
+            .send_result_of_actor_call(cx, self.rank, params)
             .await?;
         Ok(())
     }

--- a/ndslice/src/slice.rs
+++ b/ndslice/src/slice.rs
@@ -138,6 +138,14 @@ impl Slice {
         })
     }
 
+    pub(crate) fn new_singleton(rank: usize) -> Self {
+        Self {
+            offset: rank,
+            sizes: vec![1],
+            strides: vec![1],
+        }
+    }
+
     /// Deconstruct the slice into its offset, sizes, and strides.
     pub fn into_inner(self) -> (usize, Vec<usize>, Vec<usize>) {
         let Slice {

--- a/python/monarch/_rust_bindings/monarch_extension/mesh_controller.pyi
+++ b/python/monarch/_rust_bindings/monarch_extension/mesh_controller.pyi
@@ -7,7 +7,7 @@
 # pyre-unsafe
 
 from traceback import FrameSummary
-from typing import List, NamedTuple, Sequence, Tuple, Union
+from typing import Any, List, NamedTuple, Sequence, Tuple, Union
 
 from monarch._rust_bindings.monarch_extension import client
 from monarch._rust_bindings.monarch_hyperactor.mailbox import PortId


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #1508

With this change, the tensor engine supports both v0 and v1 meshes. (See test plan.)

Same deal as the rest, and also:

- support for casting to arbitrary selections
- some additional adjustments to avoid using ranked proc ids.

Differential Revision: [D84434467](https://our.internmc.facebook.com/intern/diff/D84434467/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D84434467/)!