### PR TITLE
[monarch] Tensor engine on v1

### DIFF
--- a/hyperactor_mesh/src/actor_mesh.rs
+++ b/hyperactor_mesh/src/actor_mesh.rs
@@ -358,7 +358,7 @@ impl<'a, A: Referable> RootActorMesh<'a, A> {
         }
     }
 
-    pub(crate) fn new_v1(actor_mesh: v1::ActorMeshRef<A>) -> Self {
+    pub fn new_v1(actor_mesh: v1::ActorMeshRef<A>) -> Self {
         Self {
             inner: ActorMeshKind::V1(actor_mesh),
             shape: OnceLock::new(),
@@ -831,7 +831,7 @@ pub(crate) mod test_util {
                 use tokio::time::Duration;
                 use tokio::time::timeout;
                 #[allow(clippy::disallowed_methods)]
-                if let Ok(_) = timeout(Duration::from_secs(1), rx.recv()).await {
+                if timeout(Duration::from_secs(1), rx.recv()).await.is_ok() {
                     message
                         .1
                         .send(cx, "the impossible happened".to_owned())

--- a/hyperactor_mesh/src/proc_mesh.rs
+++ b/hyperactor_mesh/src/proc_mesh.rs
@@ -175,6 +175,18 @@ pub fn global_root_client() -> &'static Instance<()> {
             .instance("client")
             .expect("root instance create");
 
+        let (supervision_tx, mut supervision_rx) = client.open_port();
+        client_proc.set_supervision_coordinator(supervision_tx).unwrap();
+
+        // TODO: Come up with a better way to handle supervision events from actors spawned
+        // on the root client proc. Unfortunately, for now, detached instances can't handle
+        // supervision events, and its proc would just crash if it received one.
+        tokio::spawn(async move {
+            while let Ok(event) = supervision_rx.recv().await {
+                tracing::error!("root client received superivision event from child actor: {}", event);
+            }
+        });
+
         // Bind the global root client's undeliverable port and
         // forward any undeliverable messages to the currently active
         // supervision sink.
@@ -992,7 +1004,9 @@ impl<D: Deref<Target = ProcMesh> + Send + Sync + 'static> SharedSpawnable for D 
                     ranks,
                 ))
             }
-            ProcMeshKind::V1(proc_mesh) => todo!(),
+            ProcMeshKind::V1(proc_mesh) => Ok(RootActorMesh::from(
+                proc_mesh.spawn_service(cx, actor_name, params).await?,
+            )),
         }
     }
 }

--- a/hyperactor_mesh/src/v1/actor_mesh.rs
+++ b/hyperactor_mesh/src/v1/actor_mesh.rs
@@ -13,7 +13,6 @@ use std::marker::PhantomData;
 use std::ops::Deref;
 use std::sync::OnceLock as OnceCell;
 
-use hyperactor::Actor;
 use hyperactor::ActorRef;
 use hyperactor::RemoteHandles;
 use hyperactor::RemoteMessage;
@@ -145,14 +144,44 @@ pub struct ActorMeshRef<A: Referable> {
 }
 
 impl<A: Referable> ActorMeshRef<A> {
-    /// Cast a message to all actors in this mesh.
+    /// Cast a message to all the actors in this mesh
     pub fn cast<M>(&self, cx: &impl context::Actor, message: M) -> v1::Result<()>
     where
         A: RemoteHandles<M> + RemoteHandles<IndexedErasedUnbound<M>>,
         M: Castable + RemoteMessage + Clone, // Clone is required until we are fully onto comm actor
     {
+        self.cast_with_selection(cx, sel!(*), message)
+    }
+
+    /// Cast a message to the actors in this mesh according to the provided selection.
+    /// This should *only* be used for temporary support for selections in the tensor
+    /// engine. If you use this for anything else, you will be fired (you too, OSS
+    /// contributor).
+    pub fn cast_for_tensor_engine_only_do_not_use<M>(
+        &self,
+        cx: &impl context::Actor,
+        sel: Selection,
+        message: M,
+    ) -> v1::Result<()>
+    where
+        A: RemoteHandles<M> + RemoteHandles<IndexedErasedUnbound<M>>,
+        M: Castable + RemoteMessage + Clone, // Clone is required until we are fully onto comm actor
+    {
+        self.cast_with_selection(cx, sel, message)
+    }
+
+    fn cast_with_selection<M>(
+        &self,
+        cx: &impl context::Actor,
+        sel: Selection,
+        message: M,
+    ) -> v1::Result<()>
+    where
+        A: RemoteHandles<M> + RemoteHandles<IndexedErasedUnbound<M>>,
+        M: Castable + RemoteMessage + Clone, // Clone is required until we are fully onto comm actor
+    {
         if let Some(root_comm_actor) = self.proc_mesh.root_comm_actor() {
-            self.cast_v0(cx, message, root_comm_actor)
+            self.cast_v0(cx, message, sel, root_comm_actor)
         } else {
             for (point, actor) in self.iter() {
                 let create_rank = point.rank();
@@ -188,6 +217,7 @@ impl<A: Referable> ActorMeshRef<A> {
         &self,
         cx: &impl context::Actor,
         message: M,
+        sel: Selection,
         root_comm_actor: &ActorRef<CommActor>,
     ) -> v1::Result<()>
     where
@@ -203,7 +233,7 @@ impl<A: Referable> ActorMeshRef<A> {
                     cx,
                     actor_mesh_id,
                     root_comm_actor,
-                    &sel!(*),
+                    &sel,
                     message,
                     &cast_mesh_shape,
                     &root_mesh_shape,
@@ -214,7 +244,7 @@ impl<A: Referable> ActorMeshRef<A> {
                 cx,
                 actor_mesh_id,
                 root_comm_actor,
-                sel!(*),
+                sel,
                 &cast_mesh_shape,
                 &cast_mesh_shape,
                 message,

--- a/hyperactor_mesh/src/v1/proc_mesh.rs
+++ b/hyperactor_mesh/src/v1/proc_mesh.rs
@@ -167,7 +167,7 @@ impl ProcRef {
         }
     }
 
-    pub(crate) fn proc_id(&self) -> &ProcId {
+    pub fn proc_id(&self) -> &ProcId {
         &self.proc_id
     }
 

--- a/monarch_extension/Cargo.toml
+++ b/monarch_extension/Cargo.toml
@@ -22,6 +22,7 @@ controller = { version = "0.0.0", path = "../controller", optional = true }
 futures = { version = "0.3.31", features = ["async-await", "compat"] }
 hyperactor = { version = "0.0.0", path = "../hyperactor" }
 hyperactor_mesh = { version = "0.0.0", path = "../hyperactor_mesh" }
+hyperactor_mesh_macros = { version = "0.0.0", path = "../hyperactor_mesh_macros" }
 hyperactor_multiprocess = { version = "0.0.0", path = "../hyperactor_multiprocess" }
 hyperactor_telemetry = { version = "0.0.0", path = "../hyperactor_telemetry" }
 libc = "0.2.139"

--- a/monarch_extension/src/mesh_controller.rs
+++ b/monarch_extension/src/mesh_controller.rs
@@ -29,22 +29,31 @@ use hyperactor::HandleClient;
 use hyperactor::Handler;
 use hyperactor::Instance;
 use hyperactor::PortRef;
+use hyperactor::ProcId;
+use hyperactor::actor::ActorStatus;
 use hyperactor::context;
 use hyperactor::mailbox::MailboxSenderError;
 use hyperactor_mesh::Mesh;
+use hyperactor_mesh::ProcMesh;
 use hyperactor_mesh::actor_mesh::ActorMesh;
 use hyperactor_mesh::actor_mesh::RootActorMesh;
+use hyperactor_mesh::selection::Selection;
 use hyperactor_mesh::shared_cell::SharedCell;
 use hyperactor_mesh::shared_cell::SharedCellRef;
+use hyperactor_mesh::v1::Name;
+use hyperactor_mesh_macros::sel;
 use monarch_hyperactor::actor::PythonMessage;
 use monarch_hyperactor::actor::PythonMessageKind;
 use monarch_hyperactor::buffers::FrozenBuffer;
+use monarch_hyperactor::context::PyInstance;
+use monarch_hyperactor::instance_dispatch;
 use monarch_hyperactor::local_state_broker::LocalStateBrokerActor;
 use monarch_hyperactor::mailbox::PyPortId;
 use monarch_hyperactor::ndslice::PySlice;
 use monarch_hyperactor::proc_mesh::PyProcMesh;
 use monarch_hyperactor::proc_mesh::TrackedProcMesh;
 use monarch_hyperactor::runtime::signal_safe_block_on;
+use monarch_hyperactor::v1::proc_mesh::PyProcMesh as PyProcMeshV1;
 use monarch_messages::controller::ControllerActor;
 use monarch_messages::controller::ControllerMessage;
 use monarch_messages::controller::Seq;
@@ -58,8 +67,9 @@ use monarch_messages::worker::WorkerParams;
 use monarch_tensor_worker::AssignRankMessage;
 use monarch_tensor_worker::WorkerActor;
 use ndslice::Slice;
-use ndslice::selection;
+use ndslice::ViewExt;
 use ndslice::selection::ReifySlice;
+use pyo3::exceptions::PyRuntimeError;
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use tokio::sync::Mutex;
@@ -95,8 +105,30 @@ where
 #[pymethods]
 impl _Controller {
     #[new]
-    fn new(py: Python, py_proc_mesh: &PyProcMesh) -> PyResult<Self> {
-        let proc_mesh: SharedCell<TrackedProcMesh> = py_proc_mesh.inner.clone();
+    fn new(py: Python, client: PyInstance, py_proc_mesh: &Bound<'_, PyAny>) -> PyResult<Self> {
+        let (proc_mesh, rank_map) = if let Ok(v0) = py_proc_mesh.downcast::<PyProcMesh>() {
+            (v0.borrow().inner.clone(), None)
+        } else {
+            // Here, also extract a rank map. We have to look
+            // up which ids correspond with which ranks.
+            //
+            // This should be fixed up for the true v1 support,
+            // possibly by having the workers send back their ranks
+            // directly.
+            let proc_mesh = py_proc_mesh
+                .downcast::<PyProcMeshV1>()?
+                .borrow()
+                .mesh_ref()?;
+            let rank_map = proc_mesh
+                .iter()
+                .map(|(point, proc)| (proc.proc_id().clone(), point.rank()))
+                .collect();
+            (
+                SharedCell::from(TrackedProcMesh::from(ProcMesh::from(proc_mesh))),
+                Some(rank_map),
+            )
+        };
+
         let proc_mesh_ref = proc_mesh.borrow().unwrap();
         let shape = proc_mesh_ref.shape();
         let slice = shape.slice();
@@ -106,21 +138,24 @@ impl _Controller {
                 "NYI: proc mesh for workers must be contiguous and start at offset 0",
             ));
         }
+
         let id = NEXT_ID.fetch_add(1, atomic::Ordering::Relaxed);
         let controller_handle: Arc<Mutex<ActorHandle<MeshControllerActor>>> =
             signal_safe_block_on(py, async move {
-                let controller_handle = proc_mesh
-                    .borrow()
-                    .unwrap()
-                    .client_proc()
-                    .spawn(
-                        &format!("tensor_engine_controller_{}", id),
-                        MeshControllerActorParams { proc_mesh, id },
-                    )
-                    .await?;
-                let r: Result<Arc<Mutex<ActorHandle<MeshControllerActor>>>, anyhow::Error> =
-                    Ok(Arc::new(Mutex::new(controller_handle)));
-                r
+                let controller_handle = instance_dispatch!(client, |instance| {
+                    instance
+                        .proc()
+                        .spawn(
+                            &Name::new("mesh_controller").to_string(),
+                            MeshControllerActorParams {
+                                proc_mesh,
+                                id,
+                                rank_map,
+                            },
+                        )
+                        .await?
+                });
+                Ok::<_, anyhow::Error>(Arc::new(Mutex::new(controller_handle)))
             })??;
 
         Ok(Self {
@@ -128,6 +163,7 @@ impl _Controller {
             all_ranks,
             // note that 0 is the _pid_ of the broker, which will be 0 for
             // top-level spawned actors.
+            // todo: plumb these through as proper actor mesh refs
             broker_id: (format!("tensor_engine_brokers_{}", id), 0),
         })
     }
@@ -194,10 +230,10 @@ impl _Controller {
         };
         let message: WorkerMessage = convert(message)?;
         self.controller_handle
-            .blocking_lock()
             .send(ClientToControllerMessage::Send { slices, message })
             .map_err(to_py_error)
     }
+
     fn _drain_and_stop(&mut self) -> PyResult<()> {
         self.controller_handle
             .blocking_lock()
@@ -506,10 +542,9 @@ impl History {
         sender: &impl context::Actor,
         seq: Seq,
         exception: WorkerError,
+        rank: usize,
     ) -> Result<(), MailboxSenderError> {
         // TODO: supplement PythonMessage with the stack trace we have in invocation
-        let rank = exception.worker_actor_id.rank();
-
         let invocation = self.inflight_invocations.get(&seq).unwrap().clone();
 
         let python_message = Arc::new(Python::with_gil(|py| {
@@ -639,6 +674,7 @@ struct MeshControllerActor {
     id: usize,
     debugger_active: Option<ActorRef<DebuggerActor>>,
     debugger_paused: VecDeque<ActorRef<DebuggerActor>>,
+    rank_map: Option<HashMap<ProcId, usize>>,
 }
 
 impl MeshControllerActor {
@@ -727,30 +763,36 @@ impl Debug for MeshControllerActor {
 struct MeshControllerActorParams {
     proc_mesh: SharedCell<TrackedProcMesh>,
     id: usize,
+    rank_map: Option<HashMap<ProcId, usize>>,
 }
 
 #[async_trait]
 impl Actor for MeshControllerActor {
     type Params = MeshControllerActorParams;
     async fn new(
-        MeshControllerActorParams { proc_mesh, id }: Self::Params,
+        MeshControllerActorParams {
+            proc_mesh,
+            id,
+            rank_map,
+        }: Self::Params,
     ) -> Result<Self, anyhow::Error> {
         let world_size = proc_mesh.borrow().unwrap().shape().slice().len();
         Ok(MeshControllerActor {
-            proc_mesh: proc_mesh.clone(),
+            proc_mesh,
             workers: None,
             brokers: None,
             history: History::new(world_size),
             id,
             debugger_active: None,
             debugger_paused: VecDeque::new(),
+            rank_map,
         })
     }
+
     async fn init(&mut self, this: &Instance<Self>) -> Result<(), anyhow::Error> {
         let controller_actor_ref: ActorRef<ControllerActor> = this.bind();
         let proc_mesh = self.proc_mesh.borrow().unwrap();
-        let slice = proc_mesh.shape().slice();
-        let world_size = slice.len();
+        let world_size = proc_mesh.shape().slice().len();
         let param = WorkerParams {
             world_size,
             // Rank assignment is consistent with proc indices.
@@ -762,11 +804,10 @@ impl Actor for MeshControllerActor {
         let workers = proc_mesh
             .spawn(this, &format!("tensor_engine_workers_{}", self.id), &param)
             .await?;
-        workers.borrow().unwrap().cast(
-            this,
-            selection::dsl::true_(),
-            AssignRankMessage::AssignRank(),
-        )?;
+        workers
+            .borrow()
+            .unwrap()
+            .cast(this, sel!(*), AssignRankMessage::AssignRank())?;
 
         self.workers = Some(workers);
         let brokers = proc_mesh
@@ -774,6 +815,21 @@ impl Actor for MeshControllerActor {
             .await?;
         self.brokers = Some(brokers);
         Ok(())
+    }
+}
+
+impl MeshControllerActor {
+    fn rank_of_worker(&self, actor_id: &ActorId) -> usize {
+        if actor_id.proc_id().is_ranked() {
+            actor_id.rank()
+        } else {
+            self.rank_map
+                .as_ref()
+                .expect("direct-addressed workers should have a rank map")
+                .get(actor_id.proc_id())
+                .expect("rank map should contain worker")
+                .clone()
+        }
     }
 }
 
@@ -796,8 +852,8 @@ impl Handler<ControllerMessage> for MeshControllerActor {
                 worker_actor_id,
                 controller: false,
             } => {
-                let rank = worker_actor_id.rank();
-                self.history.rank_completed(this, rank, seq)?;
+                self.history
+                    .rank_completed(this, self.rank_of_worker(&worker_actor_id), seq)?;
             }
             ControllerMessage::FetchResult {
                 seq,
@@ -807,7 +863,8 @@ impl Handler<ControllerMessage> for MeshControllerActor {
                 self.history.set_result(seq, msg);
             }
             ControllerMessage::RemoteFunctionFailed { seq, error } => {
-                self.history.propagate_exception(this, seq, error)?;
+                let rank = self.rank_of_worker(&error.worker_actor_id);
+                self.history.propagate_exception(this, seq, error, rank)?;
             }
             message => {
                 panic!("unexpected message: {:?}", message);
@@ -826,8 +883,13 @@ impl Handler<ClientToControllerMessage> for MeshControllerActor {
     ) -> anyhow::Result<()> {
         match message {
             ClientToControllerMessage::Send { slices, message } => {
-                let sel = self.workers().shape().slice().reify_slices(slices)?;
-                self.workers().cast(this, sel, message)?;
+                let workers = self.workers();
+                let sel = workers.shape().slice().reify_slices(slices)?;
+                if let Some(workers) = workers.v1() {
+                    workers.cast_for_tensor_engine_only_do_not_use(this, sel, message)?;
+                } else {
+                    workers.cast(this, sel, message)?;
+                }
             }
             ClientToControllerMessage::Node {
                 seq,
@@ -845,7 +907,7 @@ impl Handler<ClientToControllerMessage> for MeshControllerActor {
             ClientToControllerMessage::SyncAtExit { port } => {
                 self.workers().cast(
                     this,
-                    selection::dsl::true_(),
+                    sel!(*),
                     WorkerMessage::RequestStatus {
                         seq: self.history.seq_lower_bound,
                         controller: false,

--- a/monarch_tensor_worker/src/lib.rs
+++ b/monarch_tensor_worker/src/lib.rs
@@ -852,9 +852,7 @@ impl WorkerMessageHandler for WorkerActor {
         params: ActorCallParams,
     ) -> Result<()> {
         let stream = self.try_get_stream(params.stream)?;
-        stream
-            .send_result_of_actor_call(cx, cx.self_id().clone(), params)
-            .await?;
+        stream.send_result_of_actor_call(cx, params).await?;
         Ok(())
     }
     async fn call_actor_method(

--- a/python/monarch/_rust_bindings/monarch_extension/mesh_controller.pyi
+++ b/python/monarch/_rust_bindings/monarch_extension/mesh_controller.pyi
@@ -12,12 +12,15 @@ from typing import List, NamedTuple, Sequence, Tuple, Union
 from monarch._rust_bindings.monarch_extension import client
 from monarch._rust_bindings.monarch_hyperactor.mailbox import PortId
 from monarch._rust_bindings.monarch_hyperactor.proc import ActorId
-from monarch._rust_bindings.monarch_hyperactor.proc_mesh import ProcMesh
+from monarch._rust_bindings.monarch_hyperactor.proc_mesh import ProcMesh as ProcMeshV0
 
 from monarch._rust_bindings.monarch_hyperactor.shape import Slice as NDSlice
+from monarch._rust_bindings.monarch_hyperactor.v1.proc_mesh import (
+    ProcMesh as ProcMeshV1,
+)
 
 class _Controller:
-    def __init__(self) -> None: ...
+    def __new__(self, proc_mesh: Union[ProcMeshV0, ProcMeshV1]) -> None: ...
     def node(
         self,
         seq: int,

--- a/python/monarch/_src/actor/proc_mesh.py
+++ b/python/monarch/_src/actor/proc_mesh.py
@@ -75,6 +75,7 @@ from monarch._src.actor.v1.proc_mesh import (
     _get_controller_controller as _get_controller_controller_v1,
     get_active_proc_meshes as get_active_proc_meshes_v1,
     get_or_spawn_controller as get_or_spawn_controller_v1,
+    HyProcMesh as HyProcMeshV1,
     ProcMesh as ProcMeshV1,
 )
 from monarch.tools.config.environment import CondaEnvironment
@@ -906,9 +907,11 @@ if v1_enabled or TYPE_CHECKING:
     _get_controller_controller = _get_controller_controller_v1
     get_active_proc_meshes = get_active_proc_meshes_v1
     _ControllerController = _ControllerControllerV1
+    HyProcMesh = HyProcMeshV1
 else:
     ProcMesh = ProcMeshV0
     get_or_spawn_controller = get_or_spawn_controller_v0
     _get_controller_controller = _get_controller_controller_v0
     get_active_proc_meshes = get_active_proc_meshes_v0
     _ControllerController = _ControllerControllerV0
+    HyProcMesh = HyProcMeshV0

--- a/python/monarch/_src/actor/v1/proc_mesh.py
+++ b/python/monarch/_src/actor/v1/proc_mesh.py
@@ -322,7 +322,7 @@ class ProcMesh(MeshTrait):
 
     # pyre-ignore
     def activate(self) -> AbstractContextManager:
-        return self._maybe_device_mesh.activate()
+        return self._device_mesh.activate()
 
     def rank_tensor(self, dim: str | Sequence[str]) -> "Tensor":
         return self._maybe_device_mesh.rank(dim)

--- a/python/monarch/mesh_controller.py
+++ b/python/monarch/mesh_controller.py
@@ -28,7 +28,7 @@ from typing import (
 )
 
 import torch.utils._python_dispatch
-from monarch._rust_bindings.monarch_extension import client
+from monarch._rust_bindings.monarch_extension import client, tensor_worker
 from monarch._rust_bindings.monarch_extension.client import (  # @manual=//monarch/monarch_extension:monarch_extension
     WorldState,
 )
@@ -47,26 +47,22 @@ from monarch._rust_bindings.monarch_hyperactor.proc import (  # @manual=//monarc
 )
 from monarch._rust_bindings.monarch_hyperactor.pytokio import PythonTask
 from monarch._src.actor.actor_mesh import ActorEndpoint, Channel, Port
-from monarch._src.actor.endpoint import Selection
 from monarch._src.actor.shape import NDSlice
 from monarch.common import device_mesh, messages, stream
 from monarch.common.controller_api import TController
 from monarch.common.function import ResolvableFunction
 from monarch.common.invocation import Seq
-from monarch.common.messages import Referenceable, SendResultOfActorCall
+from monarch.common.messages import SendResultOfActorCall
 from monarch.common.stream import Stream, StreamRef
 from monarch.common.tensor import dtensor_check, InputChecker, Tensor
 from monarch.common.tree import flatten
 from monarch.tensor_worker_main import _set_trace
 
 if TYPE_CHECKING:
-    from monarch._rust_bindings.monarch_hyperactor.proc_mesh import (
-        ProcMesh as HyProcMesh,
-    )
-    from monarch.actor import ProcMesh
+    from monarch._src.actor.proc_mesh import HyProcMesh, ProcMesh
 
 from monarch._rust_bindings.monarch_hyperactor.shape import Point
-from monarch._src.actor.actor_mesh import context, Context, Instance
+from monarch._src.actor.actor_mesh import context, Instance
 from monarch._src.actor.device_utils import _local_device_count
 
 from monarch.common.client import Client
@@ -80,9 +76,9 @@ logger: Logger = logging.getLogger(__name__)
 
 
 class Controller(_Controller):
-    def __init__(self, workers: "HyProcMesh") -> None:
+    def __init__(self, instance: Instance, workers: "HyProcMesh") -> None:
         super().__init__()
-        self._mailbox: Mailbox = Instance._as_py(workers.client)._mailbox
+        self._mailbox: Mailbox = Instance._mailbox
         # Buffer for messages unrelated to debugging that are received while a
         # debugger session is active.
         self._non_debugger_pending_messages: deque[
@@ -234,6 +230,10 @@ class MeshClient(Client):
         tracebacks: List[List[traceback.FrameSummary]],
     ) -> Seq:
         seq = self._next_seq()
+        # .ref can be None if the tensor is an intermediate result
+        # inside a recording
+        defs = cast(Sequence["Tensor"], [t for t in defs if t.ref is not None])
+        uses = cast(Sequence["Tensor"], [t for t in uses if t.ref is not None])
         for d in defs:
             d._seq = seq
         response_port = None
@@ -259,7 +259,7 @@ def spawn_tensor_engine(proc_mesh: "ProcMesh") -> DeviceMesh:
     gpus = proc_mesh.sizes.get("gpus", 1)
 
     # we currently block on the creation of the proc mesh, but conceivably we could init concurrently here.
-    backend_ctrl = Controller(proc_mesh._proc_mesh.block_on())
+    backend_ctrl = Controller(context().actor_instance, proc_mesh._proc_mesh.block_on())
     client = MeshClient(cast("TController", backend_ctrl), proc_mesh.size(), gpus)
     dm = DeviceMesh(
         client,

--- a/python/tests/test_coalescing.py
+++ b/python/tests/test_coalescing.py
@@ -63,13 +63,16 @@ def testing_context():
 class BackendType(Enum):
     PY = "py"
     RS = "rs"
+    MESH = "mesh"
 
 
 @pytest.mark.skipif(
     torch.cuda.device_count() < 2,
     reason="Not enough GPUs, this test requires at least 2 GPUs",
 )
-@pytest.mark.parametrize("backend_type", [BackendType.PY, BackendType.RS])
+@pytest.mark.parametrize(
+    "backend_type", [BackendType.PY, BackendType.RS, BackendType.MESH]
+)
 class TestCoalescing:
     @classmethod
     def local_device_mesh(

--- a/python/tests/test_controller.py
+++ b/python/tests/test_controller.py
@@ -27,7 +27,6 @@ from monarch import (
     Stream,
     Tensor,
 )
-from monarch._src.actor.v1 import enabled as v1_enabled
 
 from monarch._testing import BackendType, TestingContext
 from monarch.common.controller_api import LogMessage
@@ -43,12 +42,6 @@ from monarch.rust_local_mesh import (
     SupervisionParams,
 )
 from monarch_supervisor.logging import fix_exception_lines
-
-
-# FIXME(slurye)
-pytestmark = pytest.mark.skipif(
-    v1_enabled, reason="ENABLE ME ASAP ONCE V1 TENSOR ENGINE LANDS"
-)
 
 
 def custom_excepthook(exc_type, exc_value, exc_traceback):

--- a/python/tests/test_remote_functions.py
+++ b/python/tests/test_remote_functions.py
@@ -27,7 +27,6 @@ from monarch import (
     RemoteException as OldRemoteException,
     Stream,
 )
-from monarch._src.actor.v1 import enabled as v1_enabled
 
 from monarch._testing import BackendType, TestingContext
 from monarch.builtins.log import log_remote
@@ -58,11 +57,6 @@ from monarch.worker._testing_function import (
 )
 from monarch_supervisor.logging import fix_exception_lines
 from torch.distributed import ReduceOp
-
-
-pytestmark = pytest.mark.skipif(
-    v1_enabled, reason="ENABLE ASAP ONCE V1 TENSOR ENGINE LANDS"
-)
 
 
 RemoteException = (NewRemoteException, OldRemoteException)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #1521
* __->__ #1510

Add support for tensor engine on v1, and enable the respective tests. Working on this revealed a few holes **that already existed in v0**:
- test_coalescing and test_remote_functions were never enabled for tensor engine v0. This diff enables it.
  - There was a bug in the tensor engine implementation of coalescing that didn't remove intermediate result tensors from the controller node, causing an error during conversion from python to rust.
- If `MeshControllerActor` (which is spawned on the root client proc) fails, the experience is quite bad:
  - In both v0/v1 the supervision event would just bubble up to the root client proc and crash the user process. After this diff, the root client proc now simply prints a message with `tracing::error!` and ignores the supervision event. This needs to be revisited.
  - In both v0/v1, the `_Controller` python class is isolated from errors in `MeshControllerActor`. If the latter fails, future `_Controller` calls will fail silently, and the user will eventually just see "connection timed out" or whatever. We need a way to propagate these failures back to `_Controller` so that it can raise them to the user.
  - In a similar vein, there is no supervision whatsoever of the tensor workers in either v0/v1, so we can't (a) raise tensor worker failures to the user, or (b) fail any outstanding `fetch_shard` futures when a tensor worker fails.

Differential Revision: [D84434760](https://our.internmc.facebook.com/intern/diff/D84434760/)