### PR TITLE
Fix too many tasks with supervision

### DIFF
--- a/monarch_hyperactor/src/context.rs
+++ b/monarch_hyperactor/src/context.rs
@@ -76,6 +76,8 @@ macro_rules! instance_dispatch {
     };
 }
 
+/// Similar to `instance_dispatch!`, but moves the PyInstance into an Instance<T>
+/// instead of a borrow.
 #[macro_export]
 macro_rules! instance_into_dispatch {
     ($ins:expr, |$cx:ident| $code:block) => {

--- a/monarch_hyperactor/src/v1/proc_mesh.rs
+++ b/monarch_hyperactor/src/v1/proc_mesh.rs
@@ -143,8 +143,7 @@ impl PyProcMesh {
                     let mesh_impl: Box<dyn ActorMeshProtocol> = mesh_impl.await?;
                     Ok(mesh_impl)
                 },
-                // Not supervised, supervision_event not implemented yet.
-                false,
+                true,
             );
             Python::with_gil(|py| r.into_py_any(py))
         }

--- a/python/tests/test_actor_error.py
+++ b/python/tests/test_actor_error.py
@@ -551,7 +551,10 @@ async def test_actor_mesh_supervision_handling(mesh) -> None:
         await e.fail_with_supervision_error.call_one()
 
     # new call should fail with check of health state of actor mesh
-    with pytest.raises(SupervisionError, match="Actor .* is unhealthy with reason"):
+    with pytest.raises(
+        SupervisionError,
+        match="Actor .* (is unhealthy with reason|exited because of the following reason)",
+    ):
         await e.check.call()
 
     # should not be able to spawn actors anymore as proc mesh is unhealthy
@@ -678,7 +681,10 @@ async def test_base_exception_handling(mesh, method_name) -> None:
         await method.call_one()
 
     # Subsequent calls should fail with a health state error
-    with pytest.raises(RuntimeError, match="Actor .* is unhealthy with reason"):
+    with pytest.raises(
+        RuntimeError,
+        match="Actor .* (is unhealthy with reason|exited because of the following reason)",
+    ):
         await error_actor.check.call()
 
 

--- a/scripts/common-setup.sh
+++ b/scripts/common-setup.sh
@@ -176,7 +176,6 @@ run_test_groups() {
       MONARCH_HOST_MESH_V1_REMOVE_ME_BEFORE_RELEASE=1 \
       LC_ALL=C pytest python/tests/ -s -v -m "not oss_skip" \
         --ignore-glob="**/meta/**" \
-        --ignore=python/tests/test_actor_error.py \
         --dist=no \
         --group=$GROUP \
         --splits=10


### PR DESCRIPTION
Summary:
Part of: https://github.com/meta-pytorch/monarch/issues/1209

There was a performance issue with a polling-based supervision events, where the
periodic timer loop would run forever, even if the endpoint which generated it
had been deleted.

The cause was my misunderstanding of how PyShared worked, it is a way to turn a one-off
task into a continuous task.
It does this:
```lang=rs
get_tokio_runtime().spawn(async move {
  send_result(tx, task.await);
});
```
The problem was that this tokio task lived until the `.await` completed. In the case of
supervision on a healthy endpoint, that await would never complete.
For v1, this meant that the polling loop would never get dropped.

This problem affects v0 supervision as well, where the number of alive tokio tasks grew without bound;
however, in v0 the individual tasks didn't use any CPU or memory resources, they just
waited on a channel. In v1 they now send out periodic "cast" messages to collect state, so
we don't want them hanging around forever.

To this end, add a `PyPythonTask::spawn_abortable` to turn a task that is safe to cancel
into a PyShared. When the PyShared is dropped, it aborts the task.
This change allows the supervision monitors to be dropped as soon as the endpoint
completes in a healthy manner.

Differential Revision: D84400989


