### PR TITLE
[monarch] mesh: include full state of proc on spawn failure if available

### DIFF
--- a/hyperactor_mesh/src/resource.rs
+++ b/hyperactor_mesh/src/resource.rs
@@ -182,6 +182,16 @@ pub struct State<S> {
     pub state: Option<S>,
 }
 
+impl<S: Serialize> fmt::Display for State<S> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // Use serde_json to serialize the struct to a compact JSON string
+        match serde_json::to_string(self) {
+            Ok(json) => write!(f, "{}", json),
+            Err(e) => write!(f, "<state: serde_json error: {}>", e),
+        }
+    }
+}
+
 /// Create or update a resource according to a spec.
 #[derive(
     Debug,

--- a/hyperactor_mesh/src/v1.rs
+++ b/hyperactor_mesh/src/v1.rs
@@ -43,6 +43,7 @@ use crate::resource::ValuesByRank;
 use crate::shortuuid::ShortUuid;
 use crate::v1::host_mesh::HostMeshAgent;
 use crate::v1::host_mesh::HostMeshRefParseError;
+use crate::v1::host_mesh::mesh_agent::ProcState;
 
 /// Errors that occur during mesh operations.
 #[derive(Debug, EnumAsInner, thiserror::Error)]
@@ -95,12 +96,13 @@ pub enum Error {
     #[error("error configuring host mesh agent {0}: {1}")]
     HostMeshAgentConfigurationError(ActorId, String),
 
-    #[error("error creating {proc_name} (host rank {host_rank}) on host mesh agent {mesh_agent}")]
+    #[error(
+        "error creating proc (host rank {host_rank}) on host mesh agent {mesh_agent}, state: {state}"
+    )]
     ProcCreationError {
-        proc_name: Name,
-        mesh_agent: ActorRef<HostMeshAgent>,
+        state: resource::State<ProcState>,
         host_rank: usize,
-        status: resource::Status,
+        mesh_agent: ActorRef<HostMeshAgent>,
     },
 
     #[error(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #1527
* #1531
* __->__ #1520

This should be very useful in debugging proc spawning issues.

Differential Revision: [D84568579](https://our.internmc.facebook.com/intern/diff/D84568579/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D84568579/)!