### PR TITLE
Increase timeout for host mesh spawning procs

### DIFF
--- a/hyperactor/src/config.rs
+++ b/hyperactor/src/config.rs
@@ -196,13 +196,13 @@ declare_attrs! {
 
     /// Timeout for [`Host::spawn`] to await proc readiness.
     ///
-    /// Default: 10 seconds. If set to zero, disables the timeout and
+    /// Default: 30 seconds. If set to zero, disables the timeout and
     /// waits indefinitely.
     @meta(CONFIG = ConfigAttr {
         env_name: Some("HYPERACTOR_HOST_SPAWN_READY_TIMEOUT".to_string()),
         py_name: None,
     })
-    pub attr HOST_SPAWN_READY_TIMEOUT: Duration = Duration::from_secs(10);
+    pub attr HOST_SPAWN_READY_TIMEOUT: Duration = Duration::from_secs(30);
 }
 
 /// Load configuration from environment variables

--- a/monarch_hyperactor/src/v1/actor_mesh.rs
+++ b/monarch_hyperactor/src/v1/actor_mesh.rs
@@ -220,7 +220,9 @@ where
         let pyerr = PyErr::new::<SupervisionError, _>(format!(
             "Actor {} exited because of the following reason: {}",
             event_actor_id,
-            py_event.__repr__().expect("foo")
+            py_event
+                .__repr__()
+                .expect("repr failed on PyActorSupervisionEvent")
         ));
         Some(pyerr)
     };

--- a/python/tests/test_actor_error.py
+++ b/python/tests/test_actor_error.py
@@ -643,7 +643,10 @@ async def test_actor_mesh_supervision_handling_chained_error(mesh) -> None:
         await intermediate_actor.forward_error.call()
 
     # calling success endpoint should fail with ActorError, but with supervision msg.
-    with pytest.raises(ActorError, match="Actor .* is unhealthy with reason"):
+    with pytest.raises(
+        ActorError,
+        match="Actor .* (is unhealthy with reason|exited because of the following reason)",
+    ):
         await intermediate_actor.forward_success.call()
 
     # healthy actor should still be working
@@ -741,9 +744,15 @@ async def test_supervision_with_sending_error() -> None:
         await actor_mesh.check_with_payload.call(payload="a" * 55000000)
 
     # new call should fail with check of health state of actor mesh
-    with pytest.raises(SupervisionError, match="Actor .* is unhealthy with reason"):
+    with pytest.raises(
+        SupervisionError,
+        match="Actor .* (is unhealthy with reason|exited because of the following reason)",
+    ):
         await actor_mesh.check.call()
-    with pytest.raises(SupervisionError, match="Actor .* is unhealthy with reason"):
+    with pytest.raises(
+        SupervisionError,
+        match="Actor .* (is unhealthy with reason|exited because of the following reason)",
+    ):
         await actor_mesh.check_with_payload.call(payload="a")
 
 


### PR DESCRIPTION
Summary:
When stress testing unit tests in test_actor_error.py,
I ran into occasional failures due to host mesh timing out to spawn procs.

Bumped that timeout until the error wasn't happening in over 1k tests.

Also fixed some other race conditions, like the error message changing slightly
based on how fast the monitoring messages came back on an endpoint.

Differential Revision: D84621674


