### PR TITLE
Let alloc to use IP addresses consistently

### DIFF
--- a/hyperactor_mesh/src/proc_mesh.rs
+++ b/hyperactor_mesh/src/proc_mesh.rs
@@ -378,8 +378,10 @@ impl ProcMesh {
         );
 
         // Ensure that the router is served so that agents may reach us.
-        let (router_channel_addr, router_rx) = channel::serve(ChannelAddr::any(alloc.transport()))
-            .map_err(|err| AllocatorError::Other(err.into()))?;
+        let (router_channel_addr, router_rx) = alloc
+            .client_router_addr()
+            .serve()
+            .map_err(AllocatorError::Other)?;
         router.serve(router_rx);
         tracing::info!("router channel started listening on addr: {router_channel_addr}");
 

--- a/monarch_hyperactor/src/alloc.rs
+++ b/monarch_hyperactor/src/alloc.rs
@@ -496,7 +496,11 @@ impl Allocator for PyRemoteAllocator {
 
         let alloc =
             RemoteProcessAlloc::new(spec, WorldId(self.world_id.clone()), port, initializer)
-                .await?;
+                .await
+                .map_err(|e| {
+                    tracing::error!("failed to allocate: {e:?}");
+                    e
+                })?;
         Ok(alloc)
     }
 }


### PR DESCRIPTION
Summary:
In v0, there are 4 ports are "frontend" ports, which would be accessed by other hosts:

* on the client host,
    * alloc serve port
    * proc mesh' router port.
* on the worker host,
   * allocator serve port
    * forwarder port

We want these port's `ChannelAddr`s to use consistent IP addresses, i.e.

* on the client host, router port should use the same IP address as alloc serve port
* on the worker host, forwarder port should use the same IP address as allocator serve port, which was known to client host.

This is important because otherwise the IP address will be generated through `channel::any`, which would get the private IP address. In some environments, e.g. in aws, we could have:

* client host and worker host are on different subnets, and they can only talk to each other through the public address.

Using the same IP address consistently would make it easy to guarantee the correct address type is used throughout the hosts.

Differential Revision: D84614744


