### PR TITLE
[monarch] ez: add Extent to public API

### DIFF
--- a/python/monarch/__init__.py
+++ b/python/monarch/__init__.py
@@ -37,7 +37,7 @@ except ImportError:
 if TYPE_CHECKING:
     from monarch import timer
     from monarch._src.actor.allocator import LocalAllocator, ProcessAllocator
-    from monarch._src.actor.shape import NDSlice, Shape
+    from monarch._src.actor.shape import Extent, NDSlice, Shape
     from monarch.common._coalescing import coalescing
 
     from monarch.common.device_mesh import (

--- a/python/monarch/__init__.py
+++ b/python/monarch/__init__.py
@@ -154,6 +154,7 @@ __all__ = [
     "remote",
     "RemoteProcessGroup",
     "function_resolvers",
+    "Extent",
     "Future",
     "RemoteException",
     "Shape",

--- a/python/monarch/__init__.py
+++ b/python/monarch/__init__.py
@@ -83,6 +83,7 @@ _public_api = {
     "no_mesh": ("monarch.common.device_mesh", "no_mesh"),
     "RemoteProcessGroup": ("monarch.common.device_mesh", "RemoteProcessGroup"),
     "function_resolvers": ("monarch.common.function", "resolvers"),
+    "Extent": ("monarch._src.actor.shape", "Extent"),
     "Future": ("monarch.common.future", "Future"),
     "RemoteException": ("monarch.common.invocation", "RemoteException"),
     "Shape": ("monarch._src.actor.shape", "Shape"),


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #1527
* #1531
* #1520

This was missing from the public API.

Differential Revision: [D84633650](https://our.internmc.facebook.com/intern/diff/D84633650/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D84633650/)!