### PR TITLE
Use pytest-isolate to make tests more reliable

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,4 +5,4 @@ markers = [
 ]
 asyncio_mode = "auto"
 # Default timeout of 5 minutes
-timeout = 300
+isolate_timeout = 300

--- a/python/tests/requirements.txt
+++ b/python/tests/requirements.txt
@@ -1,5 +1,5 @@
 pytest
-pytest-timeout
 pytest-asyncio
+pytest-isolate
 pytest-xdist
 pyright

--- a/scripts/common-setup.sh
+++ b/scripts/common-setup.sh
@@ -182,15 +182,16 @@ run_test_groups() {
     pkill -9 python || true
     pkill -9 pytest || true
     sleep 2
+    # Isolate runs each test in a separate forked process which enhances reliability.
     if [[ "$enable_actor_error_test" == "1" ]]; then
-        LC_ALL=C pytest python/tests/ -s -v -m "not oss_skip" \
+        LC_ALL=C pytest --isolate python/tests/ -s -v -m "not oss_skip" \
             --ignore-glob="**/meta/**" \
             --dist=no \
             --group="$GROUP" \
             --junit-xml="$test_results_dir/test-results-$GROUP.xml" \
             --splits=10
     else
-        LC_ALL=C pytest python/tests/ -s -v -m "not oss_skip" \
+        LC_ALL=C pytest --isolate python/tests/ -s -v -m "not oss_skip" \
             --ignore-glob="**/meta/**" \
             --dist=no \
             --ignore=python/tests/test_actor_error.py \


### PR DESCRIPTION
Summary:
The pytest-isolate package can support both pytest-timeout and pytest-forked,
to run each test in a separate process.
This should help prevent cross-contamination (one test affects a second test), as well
as preventing tests with fatal signals from taking down the whole test run.

Differential Revision: D84636534


