### PR TITLE
Add labels to channels

### DIFF
--- a/hyper/src/utils/system_address.rs
+++ b/hyper/src/utils/system_address.rs
@@ -63,10 +63,13 @@ async fn parse_system_address_or_mast_job(address: &str) -> Result<ChannelAddr, 
             let (host, port) = SMCClient::new(fbinit::expect_init(), smc_tier)?
                 .get_system_address()
                 .await?;
-            let channel_address = ChannelAddr::MetaTls(MetaTlsAddr::Host {
-                hostname: canonicalize_hostname(&host),
-                port,
-            });
+            let channel_address = ChannelAddr::MetaTls {
+                addr: MetaTlsAddr::Host {
+                    hostname: canonicalize_hostname(&host),
+                    port,
+                },
+                label: None,
+            };
             Ok(channel_address)
         }
     }

--- a/hyperactor/benches/main.rs
+++ b/hyperactor/benches/main.rs
@@ -83,7 +83,10 @@ fn bench_message_sizes(c: &mut Criterion) {
                 let tt = &transport;
                 b.iter_custom(|iters| async move {
                     let addr = ChannelAddr::any(tt.clone());
-                    if let ChannelAddr::Tcp(socket_addr) = addr {
+                    if let ChannelAddr::Tcp {
+                        addr: socket_addr, ..
+                    } = addr
+                    {
                         assert!(!socket_addr.ip().is_loopback());
                     }
 

--- a/hyperactor/src/channel/local.rs
+++ b/hyperactor/src/channel/local.rs
@@ -18,8 +18,8 @@ use crate::Data;
 /// Create a new local channel, returning its two ends.
 pub fn new<M: RemoteMessage>() -> (impl Tx<M>, impl Rx<M>) {
     let (tx, rx) = mpsc::unbounded_channel::<M>();
-    let (mpsc_tx, status_sender) = MpscTx::new(tx, ChannelAddr::Local(0));
-    let mpsc_rx = MpscRx::new(rx, ChannelAddr::Local(0), status_sender);
+    let (mpsc_tx, status_sender) = MpscTx::new(tx, ChannelAddr::Local { id: 0, label: None });
+    let mpsc_rx = MpscRx::new(rx, ChannelAddr::Local { id: 0, label: None }, status_sender);
     (mpsc_tx, mpsc_rx)
 }
 
@@ -87,7 +87,10 @@ impl<M: RemoteMessage> Tx<M> for LocalTx<M> {
     }
 
     fn addr(&self) -> ChannelAddr {
-        ChannelAddr::Local(self.port)
+        ChannelAddr::Local {
+            id: self.port,
+            label: None,
+        }
     }
 
     fn status(&self) -> &watch::Receiver<TxStatus> {
@@ -111,7 +114,10 @@ impl<M: RemoteMessage> Rx<M> for LocalRx<M> {
     }
 
     fn addr(&self) -> ChannelAddr {
-        ChannelAddr::Local(self.port)
+        ChannelAddr::Local {
+            id: self.port,
+            label: None,
+        }
     }
 }
 

--- a/hyperactor/src/clock.rs
+++ b/hyperactor/src/clock.rs
@@ -168,7 +168,7 @@ impl ClockKind {
     /// a proc is being served on
     pub fn for_channel_addr(channel_addr: &ChannelAddr) -> Self {
         match channel_addr {
-            ChannelAddr::Sim(_) => Self::Sim(SimClock),
+            ChannelAddr::Sim { .. } => Self::Sim(SimClock),
             _ => Self::Real(RealClock),
         }
     }

--- a/hyperactor/src/mailbox.rs
+++ b/hyperactor/src/mailbox.rs
@@ -2841,15 +2841,20 @@ mod tests {
     async fn test_sim_client_server() {
         simnet::start();
         let dst_addr = SimAddr::new("local:1".parse::<ChannelAddr>().unwrap()).unwrap();
-        let src_to_dst = ChannelAddr::Sim(
-            SimAddr::new_with_src(
+        let src_to_dst = ChannelAddr::Sim {
+            addr: SimAddr::new_with_src(
                 "local:0".parse::<ChannelAddr>().unwrap(),
                 dst_addr.addr().clone(),
             )
             .unwrap(),
-        );
+            label: None,
+        };
 
-        let (_, rx) = serve::<MessageEnvelope>(ChannelAddr::Sim(dst_addr.clone())).unwrap();
+        let (_, rx) = serve::<MessageEnvelope>(ChannelAddr::Sim {
+            addr: dst_addr.clone(),
+            label: None,
+        })
+        .unwrap();
         let tx = dial::<MessageEnvelope>(src_to_dst).unwrap();
         let mbox = Mailbox::new_detached(id!(test[0].actor0));
         let serve_handle = mbox.clone().serve(rx);

--- a/hyperactor_mesh/src/alloc.rs
+++ b/hyperactor_mesh/src/alloc.rs
@@ -494,22 +494,35 @@ impl AllocAssignedAddr {
     /// for other types of addr, return "any" address.
     pub(crate) fn with_unspecified_port_or_any(addr: &ChannelAddr) -> AllocAssignedAddr {
         let new_addr = match addr {
-            ChannelAddr::Tcp(socket) => {
+            ChannelAddr::Tcp { addr: socket, .. } => {
                 let mut new_socket = socket.clone();
                 new_socket.set_port(0);
-                ChannelAddr::Tcp(new_socket)
+                ChannelAddr::Tcp {
+                    addr: new_socket,
+                    label: None,
+                }
             }
-            ChannelAddr::MetaTls(MetaTlsAddr::Socket(socket)) => {
+            ChannelAddr::MetaTls {
+                addr: MetaTlsAddr::Socket(socket),
+                ..
+            } => {
                 let mut new_socket = socket.clone();
                 new_socket.set_port(0);
-                ChannelAddr::MetaTls(MetaTlsAddr::Socket(new_socket))
+                ChannelAddr::MetaTls {
+                    addr: MetaTlsAddr::Socket(new_socket),
+                    label: None,
+                }
             }
-            ChannelAddr::MetaTls(MetaTlsAddr::Host { hostname, port: _ }) => {
-                ChannelAddr::MetaTls(MetaTlsAddr::Host {
+            ChannelAddr::MetaTls {
+                addr: MetaTlsAddr::Host { hostname, port: _ },
+                ..
+            } => ChannelAddr::MetaTls {
+                addr: MetaTlsAddr::Host {
                     hostname: hostname.clone(),
                     port: 0,
-                })
-            }
+                },
+                label: None,
+            },
             _ => addr.transport().any(),
         };
         AllocAssignedAddr(new_addr)
@@ -530,7 +543,7 @@ impl AllocAssignedAddr {
         let mut bind_to = self.0;
         let mut original_ip: Option<IpAddr> = None;
         match &mut bind_to {
-            ChannelAddr::Tcp(socket) => {
+            ChannelAddr::Tcp { addr: socket, .. } => {
                 original_ip = Some(socket.ip().clone());
                 if use_inaddr_any {
                     set_as_inaddr_any(socket);
@@ -555,7 +568,7 @@ impl AllocAssignedAddr {
 
         // Restore the original IP address if we used INADDR_ANY.
         match &mut bound {
-            ChannelAddr::Tcp(socket) => {
+            ChannelAddr::Tcp { addr: socket, .. } => {
                 if use_inaddr_any {
                     socket.set_ip(original_ip.unwrap());
                 }

--- a/hyperactor_mesh/src/alloc/remoteprocess.rs
+++ b/hyperactor_mesh/src/alloc/remoteprocess.rs
@@ -10,7 +10,6 @@ use std::collections::HashMap;
 use std::collections::HashSet;
 use std::collections::VecDeque;
 use std::net::IpAddr;
-use std::net::Ipv4Addr;
 use std::net::Ipv6Addr;
 use std::sync::Arc;
 use std::time::Duration;
@@ -1303,7 +1302,10 @@ mod test {
                 Some(ProcState::Running {
                     create_key,
                     proc_id,
-                    addr: ChannelAddr::Unix("/proc0".parse().unwrap()),
+                    addr: ChannelAddr::Unix {
+                        addr: "/proc0".parse().unwrap(),
+                        label: None,
+                    },
                     mesh_agent,
                 })
             });

--- a/hyperactor_mesh/src/v1/host_mesh.rs
+++ b/hyperactor_mesh/src/v1/host_mesh.rs
@@ -1135,7 +1135,10 @@ mod tests {
     /// Even so, this is racy.
     fn free_localhost_addr() -> ChannelAddr {
         let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
-        ChannelAddr::Tcp(listener.local_addr().unwrap())
+        ChannelAddr::Tcp {
+            addr: listener.local_addr().unwrap(),
+            label: None,
+        }
     }
 
     #[tokio::test]

--- a/hyperactor_multiprocess/src/ping_pong.rs
+++ b/hyperactor_multiprocess/src/ping_pong.rs
@@ -38,7 +38,10 @@ mod tests {
 
         let system_sim_addr = SimAddr::new(system_addr.clone()).unwrap();
         let server_handle = System::serve(
-            ChannelAddr::Sim(system_sim_addr.clone()),
+            ChannelAddr::Sim {
+                addr: system_sim_addr.clone(),
+                label: None,
+            },
             Duration::from_secs(10),
             Duration::from_secs(10),
         )
@@ -87,11 +90,15 @@ mod tests {
             .unwrap();
 
         let proc_sim_addr = SimAddr::new(proc_addr.clone()).unwrap();
-        let proc_listen_addr = ChannelAddr::Sim(proc_sim_addr);
+        let proc_listen_addr = ChannelAddr::Sim {
+            addr: proc_sim_addr,
+            label: None,
+        };
         let proc_id = world_id.proc_id(actor_index);
-        let proc_to_system = ChannelAddr::Sim(
-            SimAddr::new_with_src(proc_addr.clone(), system_addr.addr().clone()).unwrap(),
-        );
+        let proc_to_system = ChannelAddr::Sim {
+            addr: SimAddr::new_with_src(proc_addr.clone(), system_addr.addr().clone()).unwrap(),
+            label: None,
+        };
         let bootstrap = ProcActor::bootstrap(
             proc_id,
             world_id.clone(),

--- a/monarch_hyperactor/src/alloc.rs
+++ b/monarch_hyperactor/src/alloc.rs
@@ -425,8 +425,11 @@ impl RemoteProcessAllocInitializer for PyRemoteProcessAllocInitializer {
             .map(|channel_addr| {
                 let addr = ChannelAddr::from_str(channel_addr)?;
                 let (id, hostname) = match addr {
-                    ChannelAddr::Tcp(socket)
-                    | ChannelAddr::MetaTls(MetaTlsAddr::Socket(socket)) => {
+                    ChannelAddr::Tcp { addr: socket, .. }
+                    | ChannelAddr::MetaTls {
+                        addr: MetaTlsAddr::Socket(socket),
+                        ..
+                    } => {
                         if socket.is_ipv6() {
                             // ipv6 addresses need to be wrapped in square-brackets [ipv6_addr]
                             // since the return value here gets concatenated with 'port' to make up a sockaddr
@@ -437,10 +440,11 @@ impl RemoteProcessAllocInitializer for PyRemoteProcessAllocInitializer {
                             (ipv4_addr.clone(), ipv4_addr.clone())
                         }
                     }
-                    ChannelAddr::MetaTls(MetaTlsAddr::Host { hostname, .. }) => {
-                        (hostname.clone(), hostname.clone())
-                    }
-                    ChannelAddr::Unix(_) => (addr.to_string(), addr.to_string()),
+                    ChannelAddr::MetaTls {
+                        addr: MetaTlsAddr::Host { hostname, .. },
+                        ..
+                    } => (hostname.clone(), hostname.clone()),
+                    ChannelAddr::Unix { .. } => (addr.to_string(), addr.to_string()),
                     _ => anyhow::bail!("unsupported transport for channel address: `{addr}`"),
                 };
                 Ok(RemoteProcessAllocHost { id, hostname })

--- a/monarch_hyperactor/src/channel.rs
+++ b/monarch_hyperactor/src/channel.rs
@@ -98,10 +98,18 @@ impl PyChannelAddr {
     /// `0` for transports for which unix ports do not apply (e.g. `unix`, `local`)
     pub fn get_port(&self) -> PyResult<u16> {
         match self.inner {
-            ChannelAddr::Tcp(socket_addr)
-            | ChannelAddr::MetaTls(MetaTlsAddr::Socket(socket_addr)) => Ok(socket_addr.port()),
-            ChannelAddr::MetaTls(MetaTlsAddr::Host { port, .. }) => Ok(port),
-            ChannelAddr::Unix(_) | ChannelAddr::Local(_) => Ok(0),
+            ChannelAddr::Tcp {
+                addr: socket_addr, ..
+            }
+            | ChannelAddr::MetaTls {
+                addr: MetaTlsAddr::Socket(socket_addr),
+                ..
+            } => Ok(socket_addr.port()),
+            ChannelAddr::MetaTls {
+                addr: MetaTlsAddr::Host { port, .. },
+                ..
+            } => Ok(port),
+            ChannelAddr::Unix { .. } | ChannelAddr::Local { .. } => Ok(0),
             _ => Err(PyRuntimeError::new_err(format!(
                 "unsupported transport: `{:?}` for channel address: `{}`",
                 self.inner.transport(),

--- a/monarch_simulator/src/bootstrap.rs
+++ b/monarch_simulator/src/bootstrap.rs
@@ -57,12 +57,18 @@ pub async fn spawn_controller(
     world_size: usize,
 ) -> anyhow::Result<ActorHandle<ProcActor>> {
     let listen_addr = ChannelAddr::any(bootstrap_addr.transport());
-    let ChannelAddr::Sim(bootstrap_addr) = bootstrap_addr else {
+    let ChannelAddr::Sim {
+        addr: bootstrap_sim_addr,
+        ..
+    } = bootstrap_addr
+    else {
         panic!("bootstrap_addr must be a SimAddr");
     };
-    let bootstrap_addr = ChannelAddr::Sim(
-        SimAddr::new_with_src(listen_addr.clone(), bootstrap_addr.addr().clone()).unwrap(),
-    );
+    let bootstrap_addr = ChannelAddr::Sim {
+        addr: SimAddr::new_with_src(listen_addr.clone(), bootstrap_sim_addr.addr().clone())
+            .unwrap(),
+        label: None,
+    };
     tracing::info!(
         "controller listen addr: {}, bootstrap addr: {}",
         &listen_addr,
@@ -108,12 +114,18 @@ pub async fn spawn_sim_worker(
     let worker_proc_id = ProcId::Ranked(worker_world_id.clone(), rank);
     let worker_actor_id = ActorId(worker_proc_id.clone(), "worker".into(), 0);
 
-    let ChannelAddr::Sim(bootstrap_addr) = bootstrap_addr else {
+    let ChannelAddr::Sim {
+        addr: bootstrap_sim_addr,
+        ..
+    } = bootstrap_addr
+    else {
         panic!("bootstrap_addr must be a SimAddr");
     };
-    let bootstrap_addr = ChannelAddr::Sim(
-        SimAddr::new_with_src(listen_addr.clone(), bootstrap_addr.addr().clone()).unwrap(),
-    );
+    let bootstrap_addr = ChannelAddr::Sim {
+        addr: SimAddr::new_with_src(listen_addr.clone(), bootstrap_sim_addr.addr().clone())
+            .unwrap(),
+        label: None,
+    };
     tracing::info!(
         "worker {} listen addr: {}, bootstrap addr: {}",
         &worker_actor_id,


### PR DESCRIPTION
Summary:
Add optional string labels to both `ChannelAddr` and `ChannelTransport` enum types to enable user-friendly identification and debugging of channels.

### Changes to ChannelAddr

Converted all `ChannelAddr` variants from tuple-style to struct-style with named fields and added an optional `label: Option<String>` field to each variant (local, sim, meta_tls).

Added helper methods:

*   `with_label(label: impl Into<String>) -> Self` - Sets a label on an existing address
*   `label() -> Option<&str>` - Returns the label if present

Updated `Display` implementation to show labels in brackets when present:

*   Without label: `tcp:127.0.0.1:8080`
*   With label: `tcp:127.0.0.1:8080[my-service]`

Differential Revision: D84656187


