### PR TITLE
[monarch] Only use precomputed bootstrap command for ProcessAllocator

### DIFF
--- a/python/monarch/_src/actor/v1/host_mesh.py
+++ b/python/monarch/_src/actor/v1/host_mesh.py
@@ -135,12 +135,17 @@ class HostMesh(MeshTrait):
         spec = AllocSpec(alloc_constraints or AllocConstraints(), **extent)
         alloc: AllocHandle = allocator.allocate(spec)
 
+        # Local runs that use ProcessAllocator need to use the precomputed
+        # bootstrap command.
+        if bootstrap_cmd is None and isinstance(allocator, ProcessAllocator):
+            bootstrap_cmd = _bootstrap_cmd()
+
         async def task() -> HyHostMesh:
             return await HyHostMesh.allocate_nonblocking(
                 context().actor_instance._as_rust(),
                 await alloc._hy_alloc,
                 name,
-                bootstrap_cmd if bootstrap_cmd else _bootstrap_cmd(),
+                bootstrap_cmd,
             )
 
         hm = cls(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #1539

Remote allocators should use the current exe for their bootstrap command, but trying to do so for local ProcessAllocator causes issues.

Differential Revision: [D84639781](https://our.internmc.facebook.com/intern/diff/D84639781/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D84639781/)!