### PR TITLE
Move PythonActor endpoint handling outside of handle(PythonMessage)

### DIFF
--- a/monarch_hyperactor/src/context.rs
+++ b/monarch_hyperactor/src/context.rs
@@ -24,7 +24,7 @@ pub enum ContextInstance {
 }
 
 impl ContextInstance {
-    fn mailbox_for_py(&self) -> &hyperactor::Mailbox {
+    pub(crate) fn mailbox_for_py(&self) -> &hyperactor::Mailbox {
         match self {
             ContextInstance::Client(ins) => ins.mailbox_for_py(),
             ContextInstance::PythonActor(ins) => ins.mailbox_for_py(),
@@ -213,6 +213,10 @@ impl PyContext {
             instance,
             rank: cx.cast_point(),
         }
+    }
+
+    pub(crate) fn from_instance_and_rank(instance: Py<PyInstance>, rank: Point) -> PyContext {
+        PyContext { instance, rank }
     }
 }
 


### PR DESCRIPTION
Summary:
The implementation for PythonActor is rather convoluted but the essence of what it needs to do is rather simple:

1. Convert the PythonMessage into a set of arguments to pass to `_Actor.handle`
2. poll/await the completion of `_Actor.handle`
3. Surface any `BaseExceptions` caught in `_Actor.handle` as a supervision event.

The problem with the current implementation is that 1 happens inside of PythonActor::handle(PythonMessage), causing the message handler to take ~80us just to handle a noop. When we look at traces (needs VPN): 

https://interncache-all.fbcdn.net/manifold/perfetto-artifacts/tree/ui/index.html#!/?url=https://interncache-all.fbcdn.net/manifold/perfetto_internal_traces%2Ftree%2Fshared_trace%2Fthomasywang_f73a485d-30f8-4194-9d6d-73c2ff65c1e1_tmpe8gvkyio.json

We can see that this is our processing bottleneck.

The idea of how we will optimize this is by spawning a single loop for taking care of driving Python work, holding the GIL as little as possible. When PythonActor::handle receives a PythonMessage, it will simply convert it to a structure capable of capturing all information needed to invoke the endpoint, and dispatch it to the loop, allowing it to make forward progress. 

The loop will manage 2 queues responsible for 1 and 2. 1 will grab the GIL to create a coroutine and send this into the coroutine queue, 2 will poll for coroutines.

`_Actor.handle` is able to directly send `BaseException`s in the form of `SerializablePyErr`s to `EndpointPanic2SupervisionEvent`.

It may be easier to understand this diff by just understanding how the new version achieves 1, 2, and 3 than trying to understand the old implementation

Differential Revision: D84639622


