### PR TITLE
Allow CommActor 0 to handle ForwardMessage directly instead of self messaging

### DIFF
--- a/hyperactor_mesh/src/comm.rs
+++ b/hyperactor_mesh/src/comm.rs
@@ -353,18 +353,23 @@ impl Handler<CastMessage> for CommActor {
             .or_default();
         let last_seq = *seq;
         *seq += 1;
-        Self::forward(
-            cx,
-            &self.mode,
-            rank,
-            ForwardMessage {
-                dests: vec![frame],
-                sender: cx.self_id().clone(),
-                message: cast_message.message,
-                seq: *seq,
-                last_seq,
-            },
-        )?;
+
+        let fwd_message = ForwardMessage {
+            dests: vec![frame],
+            sender: cx.self_id().clone(),
+            message: cast_message.message,
+            seq: *seq,
+            last_seq,
+        };
+
+        // Optimization: if forwarding to ourselves, handle inline instead of
+        // going through the message queue
+        let self_rank = self.mode.self_rank(cx.self_id())?;
+        if rank == self_rank {
+            Handler::<ForwardMessage>::handle(self, cx, fwd_message).await?;
+        } else {
+            Self::forward(cx, &self.mode, rank, fwd_message)?;
+        }
         Ok(())
     }
 }


### PR DESCRIPTION
Summary: Comm Actor 0 will always send an extra unneeded message to itself in order to trigger the handler for `ForwardMessage` we should be able to just move the handler logic for `ForwardMessage` into it's own function and invoke it directly to avoid an extra message hop

Differential Revision: D84639620


