### PR TITLE
Serve actors in their own thread

### DIFF
--- a/hyperactor/src/actor.rs
+++ b/hyperactor/src/actor.rs
@@ -110,7 +110,8 @@ pub trait Actor: Sized + Send + Debug + 'static {
         F: Future + Send + 'static,
         F::Output: Send + 'static,
     {
-        tokio::spawn(future)
+        let handle = tokio::runtime::Handle::current();
+        tokio::task::spawn_blocking(move || handle.block_on(future))
     }
 
     /// Handle actor supervision event. Return `Ok(true)`` if the event is handled here.

--- a/hyperactor_mesh/src/comm.rs
+++ b/hyperactor_mesh/src/comm.rs
@@ -353,18 +353,23 @@ impl Handler<CastMessage> for CommActor {
             .or_default();
         let last_seq = *seq;
         *seq += 1;
-        Self::forward(
-            cx,
-            &self.mode,
-            rank,
-            ForwardMessage {
-                dests: vec![frame],
-                sender: cx.self_id().clone(),
-                message: cast_message.message,
-                seq: *seq,
-                last_seq,
-            },
-        )?;
+
+        let fwd_message = ForwardMessage {
+            dests: vec![frame],
+            sender: cx.self_id().clone(),
+            message: cast_message.message,
+            seq: *seq,
+            last_seq,
+        };
+
+        // Optimization: if forwarding to ourselves, handle inline instead of
+        // going through the message queue
+        let self_rank = self.mode.self_rank(cx.self_id())?;
+        if rank == self_rank {
+            Handler::<ForwardMessage>::handle(self, cx, fwd_message).await?;
+        } else {
+            Self::forward(cx, &self.mode, rank, fwd_message)?;
+        }
         Ok(())
     }
 }

--- a/monarch_hyperactor/src/context.rs
+++ b/monarch_hyperactor/src/context.rs
@@ -24,7 +24,7 @@ pub enum ContextInstance {
 }
 
 impl ContextInstance {
-    fn mailbox_for_py(&self) -> &hyperactor::Mailbox {
+    pub(crate) fn mailbox_for_py(&self) -> &hyperactor::Mailbox {
         match self {
             ContextInstance::Client(ins) => ins.mailbox_for_py(),
             ContextInstance::PythonActor(ins) => ins.mailbox_for_py(),
@@ -213,6 +213,10 @@ impl PyContext {
             instance,
             rank: cx.cast_point(),
         }
+    }
+
+    pub(crate) fn from_instance_and_rank(instance: Py<PyInstance>, rank: Point) -> PyContext {
+        PyContext { instance, rank }
     }
 }
 


### PR DESCRIPTION
Summary:
In theory, workers in the tokio multithreaded runtime will steal work from others when their queue builds up but this doesn't always happen as aggressively as we want. When we leave scheduling at the liberty of the runtime, sometimes it does what we want:

(Pink spans are PythonActor, spans on top are CommActor)
 {F1982726496} 
[https://interncache-all.fbcdn.net/manifold/perfetto-artifacts/tree/ui/index.html#!/?url=https://interncache-all.fbcdn.net/manifold/perfetto_internal_traces%2Ftree%2Fshared_trace%2Fthomasywang_2c012b23-0bd4-4dbb-9205-df5e45b8cd41_tmpnqcutxjm.json](https://interncache-all.fbcdn.net/manifold/perfetto-artifacts/tree/ui/index.html#!/?url=https://interncache-all.fbcdn.net/manifold/perfetto_internal_traces%2Ftree%2Fshared_trace%2Fthomasywang_2c012b23-0bd4-4dbb-9205-df5e45b8cd41_tmpnqcutxjm.json) (Needs VPN)


And sometimes it doesnt:
 {F1982725822} 
[https://interncache-all.fbcdn.net/manifold/perfetto-artifacts/tree/ui/index.html#!/?url=https://interncache-all.fbcdn.net/manifold/perfetto_internal_traces%2Ftree%2Fshared_trace%2Fthomasywang_3476e8be-3939-4bdb-8cf4-da363dad4617_tmprzs1qzws.json](https://interncache-all.fbcdn.net/manifold/perfetto-artifacts/tree/ui/index.html#!/?url=https://interncache-all.fbcdn.net/manifold/perfetto_internal_traces%2Ftree%2Fshared_trace%2Fthomasywang_3476e8be-3939-4bdb-8cf4-da363dad4617_tmprzs1qzws.json)

Actor serve loops can run quite hot and we are able to drive progress quickest when we allow message handlers to just run as soon as they can instead of potentially waiting in the same queue as handlers for other actors. 

There are many ways we can dedicate a thread to serving an actor. We can spawn a std::thread, we can create another runtime (with fewer threads), or we can call spawn_blocking.

In the meantime I chose `spawn_blocking()` because on any given process, I don't anticipate we will spawn an absurd number of actors so it is okay to permanently take a thread from the pool, and it is simple to implement.

I am open to discussion on how we implement this, but some form of this is one of the most effective optimizations we can make when it comes to small message broadcast throughput

Differential Revision: D84653571


