### PR TITLE
v1 by default

### DIFF
--- a/.github/workflows/test-gpu-python.yml
+++ b/.github/workflows/test-gpu-python.yml
@@ -56,11 +56,8 @@ jobs:
         # Each group runs separately with process cleanup in between
         pip install pytest-split
 
-        # Run tests with the v0 API
-        run_test_groups 0 0
-
-        # Run tests with the v1 API
-        run_test_groups 1 0
+        # Run tests with test_actor_error disabled
+        run_test_groups 0
 
         # TODO(meriksen): temporarily disabled to unblock lands while debugging
         # mock CUDA issues on the OSS setup

--- a/monarch_hyperactor/src/alloc.rs
+++ b/monarch_hyperactor/src/alloc.rs
@@ -164,6 +164,11 @@ impl PyAllocConstraints {
 
         Ok(Self { inner: constraints })
     }
+
+    #[getter]
+    fn match_labels(&self) -> PyResult<HashMap<String, String>> {
+        Ok(self.inner.match_labels.clone())
+    }
 }
 
 #[pyclass(
@@ -217,6 +222,7 @@ impl PyAllocSpec {
             transport: None,
         })
     }
+
     #[getter]
     fn extent<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyDict>> {
         let d = PyDict::new(py);
@@ -224,6 +230,13 @@ impl PyAllocSpec {
             d.set_item(name, size)?;
         }
         Ok(d)
+    }
+
+    #[getter]
+    fn constraints(&self) -> PyResult<PyAllocConstraints> {
+        Ok(PyAllocConstraints {
+            inner: self.inner.constraints.clone(),
+        })
     }
 }
 

--- a/python/monarch/_rust_bindings/monarch_hyperactor/alloc.pyi
+++ b/python/monarch/_rust_bindings/monarch_hyperactor/alloc.pyi
@@ -40,6 +40,13 @@ class AllocConstraints:
         """
         ...
 
+    @property
+    def match_labels(self) -> dict[str, str]:
+        """
+        The labels to match.
+        """
+        ...
+
 @final
 class AllocSpec:
     def __init__(self, constraints: AllocConstraints, **kwargs: int) -> None:
@@ -55,6 +62,13 @@ class AllocSpec:
     def extent(self) -> Dict[str, int]:
         """
         Size of requested alloc.
+        """
+        ...
+
+    @property
+    def constraints(self) -> AllocConstraints:
+        """
+        The AllocConstraints used to create this AllocSpec.
         """
         ...
 

--- a/python/monarch/_src/actor/host_mesh.py
+++ b/python/monarch/_src/actor/host_mesh.py
@@ -80,6 +80,15 @@ class HostMeshV0(MeshTrait):
         allocator: AllocateMixin,
         alloc_constraints: Optional[AllocConstraints] = None,
     ):
+        warnings.warn(
+            (
+                "DEPRECATION WARNING: using a deprecated version of HostMesh. This is going be removed imminently. "
+                "Make sure you aren't running with `MONARCH_V0_WORKAROUND_DO_NOT_USE=1` to get the new version of "
+                "HostMesh."
+            ),
+            DeprecationWarning,
+            stacklevel=2,
+        )
         self._allocator = allocator
         self._alloc_constraints = alloc_constraints
         self._shape = shape

--- a/python/monarch/_src/actor/proc_mesh.py
+++ b/python/monarch/_src/actor/proc_mesh.py
@@ -76,7 +76,10 @@ from monarch._src.actor.v1.proc_mesh import (
     get_active_proc_meshes as get_active_proc_meshes_v1,
     get_or_spawn_controller as get_or_spawn_controller_v1,
     HyProcMesh as HyProcMeshV1,
+    local_proc_mesh as local_proc_mesh_v1,
+    proc_mesh as proc_mesh_v1,
     ProcMesh as ProcMeshV1,
+    sim_proc_mesh as sim_proc_mesh_v1,
 )
 from monarch.tools.config.environment import CondaEnvironment
 from monarch.tools.config.workspace import Workspace
@@ -208,6 +211,16 @@ class ProcMeshV0(MeshTrait):
         shape: Shape,
         _device_mesh: Optional["DeviceMesh"] = None,
     ) -> None:
+        warnings.warn(
+            (
+                "DEPRECATION WARNING: using a deprecated version of ProcMesh. This is going be removed imminently. "
+                "Make sure you aren't running with `MONARCH_V0_WORKAROUND_DO_NOT_USE=1` to get the new version of "
+                "ProcMesh."
+            ),
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
         self._proc_mesh = hy_proc_mesh
         global _proc_mesh_lock, _proc_mesh_key
         with _proc_mesh_lock:
@@ -681,7 +694,7 @@ class ProcMeshV0(MeshTrait):
         return maybe_proc_mesh
 
 
-def local_proc_mesh(*, gpus: Optional[int] = None, hosts: int = 1) -> ProcMeshV0:
+def local_proc_mesh_v0(*, gpus: Optional[int] = None, hosts: int = 1) -> ProcMeshV0:
     """
     Create a local process mesh for testing and development.
 
@@ -712,7 +725,7 @@ def local_proc_mesh(*, gpus: Optional[int] = None, hosts: int = 1) -> ProcMeshV0
     )
 
 
-def sim_proc_mesh(
+def sim_proc_mesh_v0(
     *,
     gpus: int = 1,
     hosts: int = 1,
@@ -786,7 +799,7 @@ def _proc_mesh_from_allocator(
     return ProcMeshV0.from_alloc(alloc, setup, _attach_controller_controller)
 
 
-def proc_mesh(
+def proc_mesh_v0(
     *,
     gpus: Optional[int] = None,
     hosts: int = 1,
@@ -909,6 +922,9 @@ if v1_enabled or TYPE_CHECKING:
     get_active_proc_meshes = get_active_proc_meshes_v1
     _ControllerController = _ControllerControllerV1
     HyProcMesh = HyProcMeshV1
+    proc_mesh = proc_mesh_v1
+    local_proc_mesh = local_proc_mesh_v1
+    sim_proc_mesh = sim_proc_mesh_v1
 else:
     ProcMesh = ProcMeshV0
     get_or_spawn_controller = get_or_spawn_controller_v0
@@ -916,3 +932,6 @@ else:
     get_active_proc_meshes = get_active_proc_meshes_v0
     _ControllerController = _ControllerControllerV0
     HyProcMesh = HyProcMeshV0
+    proc_mesh = proc_mesh_v0
+    local_proc_mesh = local_proc_mesh_v0
+    sim_proc_mesh = sim_proc_mesh_v0

--- a/python/monarch/_src/actor/v1/__init__.py
+++ b/python/monarch/_src/actor/v1/__init__.py
@@ -7,4 +7,4 @@
 # pyre-unsafe
 import os
 
-enabled = os.environ.get("MONARCH_HOST_MESH_V1_REMOVE_ME_BEFORE_RELEASE", "0") != "0"
+enabled = os.environ.get("MONARCH_V0_WORKAROUND_DO_NOT_USE", "0") != "1"

--- a/python/monarch/_src/actor/v1/host_mesh.py
+++ b/python/monarch/_src/actor/v1/host_mesh.py
@@ -73,7 +73,7 @@ def create_local_host_mesh(
     Args:
         name: The name of the host mesh.
         extent: Optional extent describing the shape of the host mesh.
-                If not provided, `Extent(labels=["hosts"], sizes=[1])` is used.
+                If not provided, `Extent(labels=[], sizes=[])` is used.
                 Other extents allow for local host meshes where each "host" is
                 actually just a local process.
 
@@ -87,7 +87,7 @@ def create_local_host_mesh(
 
     return HostMesh.allocate_nonblocking(
         "local_host",
-        extent if extent is not None else Extent(labels=["hosts"], sizes=[1]),
+        extent if extent is not None else Extent([], []),
         ProcessAllocator(cmd, args, bootstrap_env),
         bootstrap_cmd=_bootstrap_cmd(),
     )
@@ -350,7 +350,7 @@ def fake_in_process_host() -> "HostMesh":
     """
     return HostMesh.allocate_nonblocking(
         "fake_host",
-        Extent(labels=["hosts"], sizes=[1]),
+        Extent([], []),
         LocalAllocator(),
         bootstrap_cmd=_bootstrap_cmd(),
     )

--- a/python/monarch/_src/job/job.py
+++ b/python/monarch/_src/job/job.py
@@ -4,6 +4,8 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+# pyre-unsafe
+
 import logging
 import os
 import pickle
@@ -13,9 +15,7 @@ import subprocess
 import sys
 import tempfile
 from abc import ABC, abstractmethod
-from typing import cast, Dict, List, Literal, NamedTuple, Optional, Sequence
-
-from monarch._rust_bindings.monarch_hyperactor.channel import ChannelTransport
+from typing import Dict, List, Literal, NamedTuple, Optional, Sequence
 
 from monarch._src.actor.bootstrap import attach_to_workers
 
@@ -382,13 +382,10 @@ class LoginJob(JobTrait):
         if not self._pids_active():
             raise RuntimeError("lost connection")
         hosts = {
-            name: cast(
-                "HostMesh",
-                attach_to_workers(
-                    name=name,
-                    ca="trust_all_connections",
-                    workers=[self._host_to_pid[v].channel for v in values],
-                ),
+            name: attach_to_workers(
+                name=name,
+                ca="trust_all_connections",
+                workers=[self._host_to_pid[v].channel for v in values],
             )
             for name, values in self._meshes.items()
         }

--- a/python/monarch/actor/__init__.py
+++ b/python/monarch/actor/__init__.py
@@ -11,6 +11,8 @@ Monarch Actor API - Public interface for actor functionality.
 
 from typing import TYPE_CHECKING
 
+from monarch._rust_bindings.monarch_hyperactor.channel import ChannelTransport
+
 from monarch._rust_bindings.monarch_hyperactor.shape import Extent
 from monarch._src.actor.actor_mesh import (
     Accumulator,
@@ -36,11 +38,24 @@ from monarch._src.actor.debugger.debug_controller import debug_controller
 from monarch._src.actor.endpoint import endpoint
 from monarch._src.actor.future import Future
 
-from monarch._src.actor.proc_mesh import local_proc_mesh, proc_mesh, sim_proc_mesh
-
 from monarch._src.actor.v1 import enabled as v1_enabled
 
-if not v1_enabled or TYPE_CHECKING:
+
+if v1_enabled or TYPE_CHECKING:
+    from monarch._src.actor.v1.host_mesh import (
+        HostMesh,
+        hosts_from_config,
+        this_host,
+        this_proc,
+    )
+    from monarch._src.actor.v1.proc_mesh import (
+        get_or_spawn_controller,
+        local_proc_mesh,
+        proc_mesh,
+        ProcMesh,
+        sim_proc_mesh,
+    )
+else:
     from monarch._src.actor.host_mesh import (
         HostMeshV0 as HostMesh,
         hosts_from_config_v0 as hosts_from_config,
@@ -49,16 +64,11 @@ if not v1_enabled or TYPE_CHECKING:
     )
     from monarch._src.actor.proc_mesh import (
         get_or_spawn_controller_v0 as get_or_spawn_controller,
+        local_proc_mesh_v0 as local_proc_mesh,
+        proc_mesh_v0 as proc_mesh,
         ProcMeshV0 as ProcMesh,
+        sim_proc_mesh_v0 as sim_proc_mesh,
     )
-else:
-    from monarch._src.actor.v1.host_mesh import (
-        HostMesh,
-        hosts_from_config,
-        this_host,
-        this_proc,
-    )
-    from monarch._src.actor.v1.proc_mesh import get_or_spawn_controller, ProcMesh
 
 
 __all__ = [

--- a/python/tests/_monarch/test_actor_mesh.py
+++ b/python/tests/_monarch/test_actor_mesh.py
@@ -42,10 +42,6 @@ from monarch._rust_bindings.monarch_hyperactor.v1.proc_mesh import (
     ProcMesh as ProcMeshV1,
 )
 from monarch._src.actor.actor_mesh import Context, context, Instance
-from monarch._src.actor.v1 import enabled as v1_enabled
-
-
-pytestmark = pytest.mark.skipif(not v1_enabled, reason="v0 tested even when v1 enabled")
 
 
 def run_on_tokio(

--- a/python/tests/_monarch/test_client.py
+++ b/python/tests/_monarch/test_client.py
@@ -14,12 +14,7 @@ import torch
 from monarch._rust_bindings.monarch_extension import client
 
 from monarch._rust_bindings.monarch_hyperactor.proc import ActorId
-from monarch._src.actor.v1 import enabled as v1_enabled
 from pyre_extensions import none_throws
-
-pytestmark: pytest.MarkDecorator = pytest.mark.skipif(
-    not v1_enabled, reason="no dep on v0/v1, so only run on v1"
-)
 
 
 class TestClient(TestCase):

--- a/python/tests/_monarch/test_controller.py
+++ b/python/tests/_monarch/test_controller.py
@@ -15,11 +15,6 @@ from monarch._rust_bindings.monarch_extension import (  # @manual=//monarch/mona
     tensor_worker,
 )
 from monarch._rust_bindings.monarch_hyperactor import shape
-from monarch._src.actor.v1 import enabled as v1_enabled
-
-pytestmark: pytest.MarkDecorator = pytest.mark.skipif(
-    not v1_enabled, reason="no dep on v0/v1, so only run on v1"
-)
 
 
 class TestController(TestCase):

--- a/python/tests/_monarch/test_hyperactor.py
+++ b/python/tests/_monarch/test_hyperactor.py
@@ -13,7 +13,6 @@ import time
 from typing import Any, Callable, Coroutine
 
 import monarch
-import pytest
 
 from monarch._rust_bindings.monarch_hyperactor.alloc import (  # @manual=//monarch/monarch_extension:monarch_extension_no_torch
     AllocConstraints,
@@ -24,12 +23,6 @@ from monarch._rust_bindings.monarch_hyperactor.proc import ActorId
 from monarch._rust_bindings.monarch_hyperactor.proc_mesh import ProcMesh
 from monarch._rust_bindings.monarch_hyperactor.pytokio import PythonTask
 from monarch._src.actor.pickle import flatten, unflatten
-from monarch._src.actor.v1 import enabled as v1_enabled
-
-
-pytestmark: pytest.MarkDecorator = pytest.mark.skipif(
-    not v1_enabled, reason="v0 tested even when v1 enabled"
-)
 
 
 class MyActor:

--- a/python/tests/_monarch/test_mailbox.py
+++ b/python/tests/_monarch/test_mailbox.py
@@ -43,12 +43,6 @@ from monarch._rust_bindings.monarch_hyperactor.mailbox import (
 )
 from monarch._rust_bindings.monarch_hyperactor.proc_mesh import ProcMesh
 from monarch._src.actor.actor_mesh import Instance
-from monarch._src.actor.v1 import enabled as v1_enabled
-
-
-pytestmark: pytest.MarkDecorator = pytest.mark.skipif(
-    not v1_enabled, reason="v0 tested even when v1 enabled"
-)
 
 
 S = TypeVar("S")

--- a/python/tests/_monarch/test_ndslice.py
+++ b/python/tests/_monarch/test_ndslice.py
@@ -15,11 +15,6 @@ import pytest
 from monarch._rust_bindings.monarch_hyperactor.selection import Selection
 
 from monarch._rust_bindings.monarch_hyperactor.shape import Extent, Point, Shape, Slice
-from monarch._src.actor.v1 import enabled as v1_enabled
-
-pytestmark: pytest.MarkDecorator = pytest.mark.skipif(
-    not v1_enabled, reason="no dep on v0/v1, so only run on v1"
-)
 
 
 class TestNdslice(TestCase):

--- a/python/tests/_monarch/test_value_mesh.py
+++ b/python/tests/_monarch/test_value_mesh.py
@@ -8,15 +8,8 @@
 
 from unittest import TestCase
 
-import pytest
-
 from monarch._rust_bindings.monarch_hyperactor.shape import Shape, Slice
 from monarch._rust_bindings.monarch_hyperactor.value_mesh import ValueMesh
-from monarch._src.actor.v1 import enabled as v1_enabled
-
-pytestmark: pytest.MarkDecorator = pytest.mark.skipif(
-    not v1_enabled, reason="no dep on v0/v1, so only run on v1"
-)
 
 
 class TestValueMesh(TestCase):

--- a/python/tests/_monarch/test_worker.py
+++ b/python/tests/_monarch/test_worker.py
@@ -11,16 +11,10 @@ from typing import cast
 from unittest import TestCase
 
 import cloudpickle
-import pytest
 
 from monarch._rust_bindings.monarch_extension import tensor_worker
 from monarch._rust_bindings.monarch_hyperactor import shape
-from monarch._src.actor.v1 import enabled as v1_enabled
 from pyre_extensions import none_throws
-
-pytestmark: pytest.MarkDecorator = pytest.mark.skipif(
-    not v1_enabled, reason="no dep on v0/v1, so only run on v1"
-)
 
 
 def is_nan(val: int) -> bool:

--- a/python/tests/test_actor_shape.py
+++ b/python/tests/test_actor_shape.py
@@ -12,12 +12,6 @@ import pytest
 
 from monarch._rust_bindings.monarch_hyperactor.shape import Shape, Slice
 from monarch._src.actor.shape import ShapeExt
-from monarch._src.actor.v1 import enabled as v1_enabled
-
-
-pytestmark: pytest.MarkDecorator = pytest.mark.skipif(
-    not v1_enabled, reason="no v0/v1 dependency, so only run with v1"
-)
 
 
 class TestShapeSlicing(TestCase):

--- a/python/tests/test_actor_value_mesh.py
+++ b/python/tests/test_actor_value_mesh.py
@@ -19,14 +19,6 @@ if TYPE_CHECKING:
     from monarch._rust_bindings.monarch_hyperactor.shape import Shape as HyShape
 
 
-from monarch._src.actor.v1 import enabled as v1_enabled
-
-
-pytestmark: pytest.MarkDecorator = pytest.mark.skipif(
-    not v1_enabled, reason="no v0/v1 dependency, so only run with v1"
-)
-
-
 # These tests target ValueMesh._new_with_shape. The goal is to verify the
 # remapping logic:
 #

--- a/python/tests/test_alloc.py
+++ b/python/tests/test_alloc.py
@@ -8,18 +8,10 @@
 
 from unittest import IsolatedAsyncioTestCase
 
-import pytest
-
 from monarch import ProcessAllocator
 from monarch._rust_bindings.monarch_hyperactor.alloc import (  # @manual=//monarch/monarch_extension:monarch_extension
     AllocConstraints,
     AllocSpec,
-)
-from monarch._src.actor.v1 import enabled as v1_enabled
-
-
-pytestmark: pytest.MarkDecorator = pytest.mark.skipif(
-    not v1_enabled, reason="no v0/v1 dependency, so only run with v1"
 )
 
 

--- a/python/tests/test_coalescing.py
+++ b/python/tests/test_coalescing.py
@@ -27,16 +27,10 @@ from monarch import (
     remote,
     Stream,
 )
-from monarch._src.actor.v1 import enabled as v1_enabled
 from monarch._testing import TestingContext
 from monarch.common._coalescing import _record_and_define, compile
 from monarch.common.function_caching import AliasOf, Storage, TensorGroup
 from monarch.common.tensor import Tensor
-
-
-pytestmark = pytest.mark.skipif(
-    not v1_enabled, reason="no dep on tensor engine, so might as well only run on v1"
-)
 
 
 def _do_bogus_tensor_work(x, y, fail_rank=None):

--- a/python/tests/test_config.py
+++ b/python/tests/test_config.py
@@ -12,11 +12,6 @@ from monarch._rust_bindings.monarch_hyperactor.config import (
     configure,
     get_configuration,
 )
-from monarch._src.actor.v1 import enabled as v1_enabled
-
-pytestmark = pytest.mark.skipif(
-    not v1_enabled, reason="no v0/v1 dependency, so only run with v1"
-)
 
 
 def test_get_set_transport() -> None:

--- a/python/tests/test_debugger.py
+++ b/python/tests/test_debugger.py
@@ -55,7 +55,6 @@ from monarch._src.actor.proc_mesh import (
     ProcMesh,
 )
 from monarch._src.actor.source_loader import SourceLoaderController
-from monarch._src.actor.v1 import enabled as v1_enabled
 from monarch.tools.debug_env import (
     _MONARCH_DEBUG_SERVER_HOST_ENV_VAR,
     _MONARCH_DEBUG_SERVER_PORT_ENV_VAR,
@@ -71,12 +70,9 @@ def proc_mesh(
     gpus: int = 1,
     hosts: int = 1,
 ) -> ProcMesh:
-    if v1_enabled:
-        return create_local_host_mesh(extent=Extent(["hosts"], [hosts])).spawn_procs(
-            per_host={"gpus": gpus}
-        )
-    else:
-        return proc_mesh_v0(gpus=gpus, hosts=hosts)  # type: ignore
+    return create_local_host_mesh(extent=Extent(["hosts"], [hosts])).spawn_procs(
+        per_host={"gpus": gpus}
+    )
 
 
 needs_cuda = pytest.mark.skipif(
@@ -229,9 +225,6 @@ async def _test_debug(nested: bool) -> None:
     if not nested:
         proc = proc_mesh(hosts=2, gpus=2)
         debugee = proc.spawn("debugee", DebugeeActor)
-    elif not v1_enabled:
-        # Nested debugging is not supported in v0
-        return
     else:
         proc = create_local_host_mesh(extent=Extent(["hosts"], [1])).spawn_procs()
         debugee = proc.spawn("debugee", DebugeeActor).nested.choose().get()

--- a/python/tests/test_device_mesh.py
+++ b/python/tests/test_device_mesh.py
@@ -8,14 +8,8 @@
 import pytest
 
 from monarch import DeviceMesh, NDSlice
-from monarch._src.actor.v1 import enabled as v1_enabled
 from monarch.common.client import Client
 from monarch.simulator.mock_controller import MockController
-
-
-pytestmark: pytest.MarkDecorator = pytest.mark.skipif(
-    not v1_enabled, reason="no v0/v1 dependency, so only run with v1"
-)
 
 
 class TestDeviceMesh:

--- a/python/tests/test_fault_tolerance.py
+++ b/python/tests/test_fault_tolerance.py
@@ -19,7 +19,6 @@ except ModuleNotFoundError:
     from unittest import TestCase
 
 from monarch import fetch_shard, no_mesh, remote
-from monarch._src.actor.v1 import enabled as v1_enabled
 from monarch.common.device_mesh import DeviceMesh, DeviceMeshStatus
 from monarch.common.invocation import DeviceException, RemoteException
 from monarch.rust_backend_mesh import MeshWorld, PoolDeviceMeshProvider
@@ -30,12 +29,6 @@ from monarch.rust_local_mesh import (
     LoggingLocation,
     SocketType,
     SupervisionParams,
-)
-
-
-pytestmark = pytest.mark.skipif(
-    not v1_enabled,
-    reason="uses deprecated system actor, so might as well only run on v1",
 )
 
 

--- a/python/tests/test_future.py
+++ b/python/tests/test_future.py
@@ -13,14 +13,8 @@ from monarch import Future, RemoteException
 from monarch._rust_bindings.monarch_hyperactor.proc import (  # @manual=//monarch/monarch_extension:monarch_extension
     ActorId,
 )
-from monarch._src.actor.v1 import enabled as v1_enabled
 from monarch.common import future
 from monarch.common.client import Client
-
-
-pytestmark: pytest.MarkDecorator = pytest.mark.skipif(
-    not v1_enabled, reason="no v0/v1 dependency, so only run with v1"
-)
 
 
 class TestFuture:

--- a/python/tests/test_grad_generator.py
+++ b/python/tests/test_grad_generator.py
@@ -7,17 +7,9 @@
 # pyre-unsafe
 from unittest import main, TestCase
 
-import pytest
-
 import torch
-from monarch._src.actor.v1 import enabled as v1_enabled
 from monarch.gradient._gradient_generator import GradientGenerator
 from monarch.gradient_generator import gradient_execution_order
-
-
-pytestmark: pytest.MarkDecorator = pytest.mark.skipif(
-    not v1_enabled, reason="no v0/v1 dependency, so only run with v1"
-)
 
 
 class TestGradIter(TestCase):

--- a/python/tests/test_host_mesh.py
+++ b/python/tests/test_host_mesh.py
@@ -17,17 +17,13 @@ from monarch._src.actor.host_mesh import (
     HostMesh,
 )
 from monarch._src.actor.pickle import flatten, unflatten
-from monarch._src.actor.v1 import enabled as v1_enabled
-
-
-pytestmark = pytest.mark.skipif(not v1_enabled, reason="v1 not enabled")
 
 
 @pytest.mark.timeout(60)
 def test_fake_in_process_host() -> None:
     host = fake_in_process_host()
-    assert host.extent.labels == ["hosts"]
-    assert host.extent.sizes == [1]
+    assert host.extent.labels == []
+    assert host.extent.sizes == []
     assert not host.stream_logs
     hy_host = host._hy_host_mesh.block_on()
     assert hy_host.region.labels == host.region.labels
@@ -37,8 +33,8 @@ def test_fake_in_process_host() -> None:
 @pytest.mark.timeout(60)
 def test_create_local_host_mesh() -> None:
     host = create_local_host_mesh()
-    assert host.extent.labels == ["hosts"]
-    assert host.extent.sizes == [1]
+    assert host.extent.labels == []
+    assert host.extent.sizes == []
     assert not host.stream_logs
     hy_host = host._hy_host_mesh.block_on()
     assert hy_host.region.labels == host.region.labels

--- a/python/tests/test_job.py
+++ b/python/tests/test_job.py
@@ -4,6 +4,8 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+# pyre-unsafe
+
 import os
 import subprocess
 import sys
@@ -11,15 +13,11 @@ import tempfile
 from typing import cast, Dict, Optional, Sequence
 
 import pytest
-from monarch._src.actor.v1 import enabled as v1_enabled
 
 # Import directly from _src since job module isn't properly exposed
 from monarch._src.job.job import job_load, job_loads, JobState, JobTrait, LocalJob
 
 from monarch.actor import HostMesh
-
-
-pytestmark = pytest.mark.skipif(not v1_enabled, reason="not relevant for v0")
 
 
 class MockJobTrait(JobTrait):

--- a/python/tests/test_mesh_trait.py
+++ b/python/tests/test_mesh_trait.py
@@ -8,14 +8,7 @@
 
 from typing import Iterable
 
-import pytest
-
 from monarch._src.actor.shape import MeshTrait, NDSlice, Shape, Slice
-from monarch._src.actor.v1 import enabled as v1_enabled
-
-pytestmark = pytest.mark.skipif(
-    not v1_enabled, reason="no dep on v0/v1, so only run with v1"
-)
 
 
 class Mesh(MeshTrait):

--- a/python/tests/test_mock_cuda.py
+++ b/python/tests/test_mock_cuda.py
@@ -9,11 +9,6 @@ from unittest import main, TestCase
 
 import pytest
 import torch
-from monarch._src.actor.v1 import enabled as v1_enabled
-
-pytestmark = pytest.mark.skipif(
-    not v1_enabled, reason="no dep on v0/v1, so only run with v1"
-)
 
 
 # Avoid importing if the test is not run.

--- a/python/tests/test_pdb_actor.py
+++ b/python/tests/test_pdb_actor.py
@@ -25,14 +25,8 @@ from monarch._rust_bindings.monarch_extension.debugger import (
     get_bytes_from_write_action,
 )
 from monarch._rust_bindings.monarch_messages.debugger import DebuggerAction
-from monarch._src.actor.v1 import enabled as v1_enabled
 from monarch.rust_local_mesh import LoggingLocation, SocketType
 from monarch_supervisor.logging import fix_exception_lines
-
-
-pytestmark = pytest.mark.skipif(
-    not v1_enabled, reason="uses deprecated system actor, might as well only run on v1"
-)
 
 
 def custom_excepthook(exc_type, exc_value, exc_traceback):

--- a/python/tests/test_proc_mesh.py
+++ b/python/tests/test_proc_mesh.py
@@ -7,20 +7,19 @@
 # pyre-unsafe
 
 from typing import cast
+from unittest.mock import MagicMock, patch
 
 import cloudpickle
 
 import pytest
+from monarch._rust_bindings.monarch_hyperactor.alloc import AllocConstraints, AllocSpec
 from monarch._rust_bindings.monarch_hyperactor.pytokio import PythonTask
 from monarch._rust_bindings.monarch_hyperactor.shape import Extent, Shape, Slice
 from monarch._src.actor.actor_mesh import Actor, ActorMesh, context, ValueMesh
+from monarch._src.actor.allocator import LocalAllocator, ProcessAllocator
 from monarch._src.actor.endpoint import endpoint
-from monarch._src.actor.host_mesh import create_local_host_mesh, this_host
-from monarch._src.actor.proc_mesh import ProcMesh
-from monarch._src.actor.v1 import enabled as v1_enabled
-
-
-pytestmark = pytest.mark.skipif(not v1_enabled, reason="v1 not enabled")
+from monarch._src.actor.host_mesh import create_local_host_mesh, HostMesh, this_host
+from monarch._src.actor.proc_mesh import _get_bootstrap_args, ProcMesh
 
 
 _proc_rank = -1
@@ -162,3 +161,57 @@ async def test_pickle_initialized_proc_mesh_in_tokio_thread() -> None:
         cloudpickle.dumps(proc.slice(gpus=0, hosts=0))
 
     PythonTask.from_coroutine(task()).block_on()
+
+
+@pytest.mark.timeout(60)
+async def test_deprecated_proc_mesh_from_alloc_mock() -> None:
+    num_hosts = 2
+    num_gpus = 8
+
+    def test_setup() -> None:
+        import os
+
+        os.environ["TEST_VAR"] = "test_value"
+
+    constraints = AllocConstraints(match_labels={"test_label": "test_value"})
+    allocator = LocalAllocator()
+    spec = AllocSpec(
+        constraints,
+        hosts=num_hosts,
+        gpus=num_gpus,
+    )
+
+    with patch.object(HostMesh, "allocate_nonblocking") as mock_host_alloc:
+        mock_host_mesh = MagicMock()
+        mock_host_mesh.spawn_procs = MagicMock()
+        mock_host_alloc.return_value = mock_host_mesh
+
+        alloc_handle = allocator.allocate(spec)
+        ProcMesh.from_alloc(alloc_handle, test_setup)
+
+        mock_host_alloc.assert_called_once()
+        (name, extent, allocator, constraints) = mock_host_alloc.call_args.args
+
+        assert name == "host_mesh_from_alloc"
+        assert extent == Extent(["hosts", "gpus"], [num_hosts, num_gpus])
+        assert isinstance(allocator, LocalAllocator)
+        assert constraints.match_labels == {"test_label": "test_value"}
+
+        mock_host_mesh.spawn_procs.assert_called_once_with(bootstrap=test_setup)
+
+
+@pytest.mark.timeout(60)
+def test_deprecated_proc_mesh_from_alloc_multi_actor() -> None:
+    allocator = ProcessAllocator(*_get_bootstrap_args())
+    spec = AllocSpec(AllocConstraints(), replicas=2, hosts=2, gpus=3)
+    alloc_handle = allocator.allocate(spec)
+    proc_mesh = ProcMesh.from_alloc(alloc_handle)
+
+    actor = proc_mesh.spawn("test_actor", TestActor, 42)
+
+    proc_ranks = actor.get_proc_rank.call().get()
+    assert proc_ranks.extent.labels == ["replicas", "hosts", "gpus"]
+    assert proc_ranks.extent.sizes == [2, 2, 3]
+    for i, (point, rank) in enumerate(proc_ranks.items()):
+        assert rank == i
+        assert point.rank == i

--- a/python/tests/test_rust_backend.py
+++ b/python/tests/test_rust_backend.py
@@ -16,17 +16,11 @@ import pytest
 import torch
 import torch.utils._python_dispatch
 from monarch import fetch_shard, no_mesh, remote, Stream
-from monarch._src.actor.v1 import enabled as v1_enabled
 from monarch.common.device_mesh import DeviceMesh
 from monarch.common.remote import call_on_shard_and_fetch
 from monarch.rust_local_mesh import local_meshes, LoggingLocation, SocketType
 from torch.nn.attention import sdpa_kernel, SDPBackend
 from torch.nn.functional import scaled_dot_product_attention
-
-
-pytestmark = pytest.mark.skipif(
-    not v1_enabled, reason="uses deprecated system actor, might as well only run on v1"
-)
 
 
 def simple_all_reduce(*args, **kwargs):

--- a/python/tests/test_signal_safe_block_on.py
+++ b/python/tests/test_signal_safe_block_on.py
@@ -23,12 +23,6 @@ import time
 import unittest
 
 import pytest
-from monarch._src.actor.v1 import enabled as v1_enabled
-
-
-pytestmark: pytest.MarkDecorator = pytest.mark.skipif(
-    not v1_enabled, reason="no dep on v0/v1, so only run on v1"
-)
 
 
 # oss_skip: importlib not pulling resource correctly in git CI, needs to be revisited

--- a/python/tests/test_sim_backend.py
+++ b/python/tests/test_sim_backend.py
@@ -14,15 +14,8 @@ import pytest
 
 import torch
 from monarch import fetch_shard
-from monarch._src.actor.v1 import enabled as v1_enabled
 from monarch.common.device_mesh import DeviceMesh
 from monarch.sim_mesh import sim_mesh
-
-
-pytestmark = pytest.mark.skipif(
-    not v1_enabled,
-    reason="uses deprecated system actor, so might as well only run on v1",
-)
 
 
 @contextmanager

--- a/python/tests/test_value_mesh_compression_scheme.py
+++ b/python/tests/test_value_mesh_compression_scheme.py
@@ -4,16 +4,11 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+# pyre-unsafe
+
 import math
 from dataclasses import dataclass
 from typing import Iterator, List, Sequence
-
-import pytest
-from monarch._src.actor.v1 import enabled as v1_enabled
-
-pytestmark = pytest.mark.skipif(
-    not v1_enabled, reason="no dep on v0/v1, so only run on v1"
-)
 
 
 @dataclass

--- a/scripts/common-setup.sh
+++ b/scripts/common-setup.sh
@@ -156,12 +156,9 @@ setup_test_environment() {
 }
 
 # Run Python test groups for Monarch.
-# Usage: run_test_groups <enable_v1: 0|1> <enable_actor_error_test: 0|1>
+# Usage: run_test_groups <enable_actor_error_test: 0|1>
 #
 # Arguments:
-#   enable_v1:
-#       0 → run tests with the v0 API
-#       1 → run tests with the v1 API (sets MONARCH_HOST_MESH_V1_REMOVE_ME_BEFORE_RELEASE)
 #   enable_actor_error_test:
 #       0 → skip python/tests/test_actor_error.py
 #       1 → include python/tests/test_actor_error.py
@@ -170,13 +167,7 @@ setup_test_environment() {
 # between runs.
 run_test_groups() {
   set +e
-  local enable_v1="$1"
   local enable_actor_error_test="${2:-0}"
-  # Validate argument enable_v1
-  if [[ "$enable_v1" != "0" && "$enable_v1" != "1" ]]; then
-    echo "Usage: run_test_groups <enable_v1: 0|1>"
-    return 2
-  fi
   # Validate argument enable_actor_error_test
   if [[ "$enable_actor_error_test" != "0" && "$enable_actor_error_test" != "1" ]]; then
     echo "Usage: run_test_groups <enable_actor_error_test: 0|1>"
@@ -190,30 +181,19 @@ run_test_groups() {
     pkill -9 python || true
     pkill -9 pytest || true
     sleep 2
-    # Conditionally set environment variables for pytest
-    if [[ "$enable_v1" == "1" ]]; then
-        if [[ "$enable_actor_error_test" == "1" ]]; then
-            MONARCH_HOST_MESH_V1_REMOVE_ME_BEFORE_RELEASE=1 \
-                LC_ALL=C pytest python/tests/ -s -v -m "not oss_skip" \
-                --ignore-glob="**/meta/**" \
-                --dist=no \
-                --group="$GROUP" \
-                --splits=10
-        else
-            MONARCH_HOST_MESH_V1_REMOVE_ME_BEFORE_RELEASE=1 \
-                LC_ALL=C pytest python/tests/ -s -v -m "not oss_skip" \
-                --ignore-glob="**/meta/**" \
-                --dist=no \
-                --ignore=python/tests/test_actor_error.py \
-                --group="$GROUP" \
-                --splits=10
-        fi
+    if [[ "$enable_actor_error_test" == "1" ]]; then
+        LC_ALL=C pytest python/tests/ -s -v -m "not oss_skip" \
+            --ignore-glob="**/meta/**" \
+            --dist=no \
+            --group="$GROUP" \
+            --splits=10
     else
         LC_ALL=C pytest python/tests/ -s -v -m "not oss_skip" \
-                 --ignore-glob="**/meta/**" \
-                 --dist=no \
-                 --group="$GROUP" \
-                 --splits=10
+            --ignore-glob="**/meta/**" \
+            --dist=no \
+            --ignore=python/tests/test_actor_error.py \
+            --group="$GROUP" \
+            --splits=10
     fi
     # Check result and record failures
     if [[ $? -eq 0 ]]; then


### PR DESCRIPTION
Summary: Make v1 the default. Also, rename `MONARCH_HOST_MESH_V1_REMOVE_ME_BEFORE_RELEASE` to `MONARCH_V0_WORKAROUND_DO_NOT_USE`; remove all the v0 tests; and add a temporary implementation of the `proc_mesh(...)` function in v1 for backward compatibility.

Reviewed By: mariusae

Differential Revision: D84649645
