### PR TITLE
Implement __supervise__ callback on PythonActor

### DIFF
--- a/monarch_hyperactor/src/supervision.rs
+++ b/monarch_hyperactor/src/supervision.rs
@@ -6,9 +6,15 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+use hyperactor::Bind;
+use hyperactor::Named;
+use hyperactor::Unbind;
+use hyperactor::supervision::ActorSupervisionEvent;
 use pyo3::create_exception;
 use pyo3::exceptions::PyRuntimeError;
 use pyo3::prelude::*;
+use serde::Deserialize;
+use serde::Serialize;
 
 create_exception!(
     monarch._rust_bindings.monarch_hyperactor.supervision,
@@ -16,11 +22,55 @@ create_exception!(
     PyRuntimeError
 );
 
+#[derive(Clone, Debug, Serialize, Deserialize, Named, PartialEq, Bind, Unbind)]
+pub struct SupervisionFailureMessage {
+    pub rank: usize,
+    pub event: ActorSupervisionEvent,
+}
+
+// TODO: find out how to extend a Python exception and have internal data.
+#[derive(Clone, Debug)]
+#[pyclass(
+    name = "MeshFailure",
+    module = "monarch._rust_bindings.monarch_hyperactor.supervision"
+)]
+pub struct MeshFailure {
+    pub rank: usize,
+    pub event: ActorSupervisionEvent,
+}
+
+impl MeshFailure {
+    pub fn new(rank: usize, event: ActorSupervisionEvent) -> Self {
+        Self { rank, event }
+    }
+}
+
+impl From<SupervisionFailureMessage> for MeshFailure {
+    fn from(message: SupervisionFailureMessage) -> Self {
+        Self {
+            rank: message.rank,
+            event: message.event,
+        }
+    }
+}
+
+#[pymethods]
+impl MeshFailure {
+    // TODO: store and return the mesh object.
+    #[getter]
+    fn mesh(&self) {}
+
+    fn __repr__(&self) -> String {
+        format!("{:?}", self)
+    }
+}
+
 pub fn register_python_bindings(module: &Bound<'_, PyModule>) -> PyResult<()> {
     // Get the Python interpreter instance from the module
     let py = module.py();
     // Add the exception to the module using its type object
     module.add("SupervisionError", py.get_type::<SupervisionError>())?;
+    module.add("MeshFailure", py.get_type::<MeshFailure>())?;
     Ok(())
 }
 

--- a/python/monarch/_rust_bindings/monarch_hyperactor/supervision.pyi
+++ b/python/monarch/_rust_bindings/monarch_hyperactor/supervision.pyi
@@ -15,3 +15,13 @@ class SupervisionError(RuntimeError):
     """
 
     ...
+
+# TODO: Make this an exception subclass
+@final
+class MeshFailure:
+    """
+    Raise this if you cannot handle the supervision event and you want
+    to propagate it to the parent actor.
+    """
+    @property
+    def mesh(self) -> object: ...


### PR DESCRIPTION
Summary:
Part of https://github.com/meta-pytorch/monarch/issues/1209

The goal of the v1 supervision API is to give owning PythonActors a chance to recover
from a failure on a mesh they own.
To this end, we want to invoke a `__supervise__` function on the PythonActor whenever
an actor it "owns" changes state. For now we're mostly interested in state changes to "Failed"
or "Stopped".

To do so, we reuse the continuous polling we did for the port monitoring for v0 supervision
events, and additionally send a message to an owning PythonActor.
If the owner is a root client actor (the unit actor `()`), we don't send this message for now. 

We provide a `Failure` exception object with the mesh that failed. It's `__str__` will include
the rank, actorid, and as much information as we have. For now those properties are not
directly exposed to allow us flexibility in evolving the API.

The `__supervise__` return API is similar to `__exit__` for context managers:
Truthy return value suppresses original supervision error (handled), Falsey return value allows it to bubble (unhandled). Exceptions raised from the callback become their own supervision event,
whose cause is the previous supervision event.

Some limitations of this implementation:
1. Currently the "owning" actor is fetched via the context at the time of the endpoint call. This means that if a ref is passed to another actor, that actor will receive the `__supervise__`, and not the original creator. This is not the intended long term behavior, as refs should only get the "instantaneous" exceptions and not a notification.
2. Bubbling up to the next owning actor is not possible because it's not reachable from an Instance.
We need to have a way to get an ActorRef to the original owner. Solving (1) should make this solvable too.
3. Client-owned meshes don't get these events delivered, because there is no `__supervise__` to call. In the future, we may want to give users a way to provide a callback function to spawn

Reviewed By: mariusae

Differential Revision: D84020973


