### PR TITLE
[hyperactor] define a way to configure managed procs

### DIFF
--- a/hyperactor/src/host.rs
+++ b/hyperactor/src/host.rs
@@ -197,7 +197,7 @@ impl<M: ProcManager> Host<M> {
     pub async fn spawn(
         &mut self,
         name: String,
-        rank: Option<usize>,
+        config: M::Config,
     ) -> Result<(ProcId, ActorRef<ManagerAgent<M>>), HostError> {
         if self.procs.contains_key(&name) {
             return Err(HostError::ProcExists(name));
@@ -206,7 +206,7 @@ impl<M: ProcManager> Host<M> {
         let proc_id = ProcId::Direct(self.frontend_addr.clone(), name.clone());
         let handle = self
             .manager
-            .spawn(proc_id.clone(), self.backend_addr.clone(), rank)
+            .spawn(proc_id.clone(), self.backend_addr.clone(), config)
             .await?;
 
         // Await readiness (config-driven; 0s disables timeout).
@@ -542,6 +542,9 @@ pub trait ProcManager {
     /// Concrete handle type this manager returns.
     type Handle: ProcHandle;
 
+    /// Additional configuration for the proc, supported by this manager.
+    type Config = ();
+
     /// The preferred transport for this ProcManager.
     /// In practice this will be [`ChannelTransport::Local`]
     /// for testing, and [`ChannelTransport::Unix`] for external
@@ -559,7 +562,7 @@ pub trait ProcManager {
         &self,
         proc_id: ProcId,
         forwarder_addr: ChannelAddr,
-        rank: Option<usize>,
+        config: Self::Config,
     ) -> Result<Self::Handle, HostError>;
 }
 
@@ -790,7 +793,7 @@ where
         &self,
         proc_id: ProcId,
         forwarder_addr: ChannelAddr,
-        _rank: Option<usize>,
+        _config: (),
     ) -> Result<Self::Handle, HostError> {
         let transport = forwarder_addr.transport();
         let proc = Proc::new(
@@ -966,7 +969,7 @@ where
         &self,
         proc_id: ProcId,
         forwarder_addr: ChannelAddr,
-        _rank: Option<usize>,
+        _config: (),
     ) -> Result<Self::Handle, HostError> {
         let (callback_addr, mut callback_rx) =
             channel::serve(ChannelAddr::any(ChannelTransport::Unix))?;
@@ -1143,14 +1146,14 @@ mod tests {
                 .await
                 .unwrap();
 
-        let (proc_id1, _ref) = host.spawn("proc1".to_string(), None).await.unwrap();
+        let (proc_id1, _ref) = host.spawn("proc1".to_string(), ()).await.unwrap();
         assert_eq!(
             proc_id1,
             ProcId::Direct(host.addr().clone(), "proc1".to_string())
         );
         assert!(procs.lock().await.contains_key(&proc_id1));
 
-        let (proc_id2, _ref) = host.spawn("proc2".to_string(), None).await.unwrap();
+        let (proc_id2, _ref) = host.spawn("proc2".to_string(), ()).await.unwrap();
         assert!(procs.lock().await.contains_key(&proc_id2));
 
         let proc1 = procs.lock().await.get(&proc_id1).unwrap().clone();
@@ -1214,13 +1217,13 @@ mod tests {
 
         // (1) Spawn and check invariants.
         assert!(matches!(host.addr().transport(), ChannelTransport::Unix));
-        let (proc1, echo1) = host.spawn("proc1".to_string(), None).await.unwrap();
-        let (proc2, echo2) = host.spawn("proc2".to_string(), None).await.unwrap();
+        let (proc1, echo1) = host.spawn("proc1".to_string(), ()).await.unwrap();
+        let (proc2, echo2) = host.spawn("proc2".to_string(), ()).await.unwrap();
         assert_eq!(echo1.actor_id().proc_id(), &proc1);
         assert_eq!(echo2.actor_id().proc_id(), &proc2);
 
         // (2) Duplicate name rejection.
-        let dup = host.spawn("proc1".to_string(), None).await;
+        let dup = host.spawn("proc1".to_string(), ()).await;
         assert!(matches!(dup, Err(HostError::ProcExists(_))));
 
         // (3) Create a standalone client proc and verify echo1 agent responds.
@@ -1409,7 +1412,7 @@ mod tests {
             &self,
             proc_id: ProcId,
             forwarder_addr: ChannelAddr,
-            _rank: Option<usize>,
+            _config: (),
         ) -> Result<Self::Handle, HostError> {
             let agent = ActorRef::<()>::attest(proc_id.actor_id("agent", 0));
             Ok(TestHandle {
@@ -1438,10 +1441,7 @@ mod tests {
         .await
         .unwrap();
 
-        let err = host
-            .spawn("t".into(), None)
-            .await
-            .expect_err("must time out");
+        let err = host.spawn("t".into(), ()).await.expect_err("must time out");
         assert!(matches!(err, HostError::ProcessConfigurationFailure(_, _)));
     }
 
@@ -1460,7 +1460,7 @@ mod tests {
         .await
         .unwrap();
 
-        let (pid, agent) = host.spawn("ok".into(), None).await.expect("must succeed");
+        let (pid, agent) = host.spawn("ok".into(), ()).await.expect("must succeed");
         assert_eq!(agent.actor_id().proc_id(), &pid);
         assert!(host.procs.contains_key("ok"));
     }
@@ -1474,7 +1474,7 @@ mod tests {
         .await
         .unwrap();
 
-        let err = host.spawn("p".into(), None).await.expect_err("must fail");
+        let err = host.spawn("p".into(), ()).await.expect_err("must fail");
         assert!(matches!(err, HostError::ProcessConfigurationFailure(_, _)));
     }
 
@@ -1487,7 +1487,7 @@ mod tests {
         .await
         .unwrap();
 
-        let err = host.spawn("p".into(), None).await.expect_err("must fail");
+        let err = host.spawn("p".into(), ()).await.expect_err("must fail");
         assert!(matches!(err, HostError::ProcessConfigurationFailure(_, _)));
     }
 
@@ -1501,7 +1501,7 @@ mod tests {
         .unwrap();
 
         let err = host
-            .spawn("no-addr".into(), None)
+            .spawn("no-addr".into(), ())
             .await
             .expect_err("must fail");
         assert!(matches!(err, HostError::ProcessConfigurationFailure(_, _)));
@@ -1517,7 +1517,7 @@ mod tests {
         .unwrap();
 
         let err = host
-            .spawn("no-agent".into(), None)
+            .spawn("no-agent".into(), ())
             .await
             .expect_err("must fail");
         assert!(matches!(err, HostError::ProcessConfigurationFailure(_, _)));

--- a/hyperactor_mesh/src/v1/host_mesh/mesh_agent.rs
+++ b/hyperactor_mesh/src/v1/host_mesh/mesh_agent.rs
@@ -34,6 +34,7 @@ use serde::Serialize;
 
 use crate::bootstrap;
 use crate::bootstrap::BootstrapCommand;
+use crate::bootstrap::BootstrapProcConfig;
 use crate::bootstrap::BootstrapProcManager;
 use crate::proc_mesh::mesh_agent::ProcMeshAgent;
 use crate::resource;
@@ -123,16 +124,15 @@ impl Handler<resource::CreateOrUpdate<()>> for HostMeshAgent {
             HostAgentMode::Process(host) => {
                 host.spawn(
                     create_or_update.name.clone().to_string(),
-                    create_or_update.rank.0,
+                    BootstrapProcConfig {
+                        create_rank: create_or_update.rank.unwrap(),
+                    },
                 )
                 .await
             }
             HostAgentMode::Local(host) => {
-                host.spawn(
-                    create_or_update.name.clone().to_string(),
-                    create_or_update.rank.0,
-                )
-                .await
+                host.spawn(create_or_update.name.clone().to_string(), ())
+                    .await
             }
         };
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #1551

This adds a `Config` type to `ProcManager`, and plumbs it through `Host`.

The mesh bootstrap proc manager defines a config that includes the create rank of the proc that is spawned, which is then used to pass to logs, etc.

This replaces the 'rank' passthrough added in D84657553.

Differential Revision: [D84713972](https://our.internmc.facebook.com/intern/diff/D84713972/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D84713972/)!