### PR TITLE
: CI: oss skip flaky test_split_port_id_no_reducer

### DIFF
--- a/hyperactor/src/mailbox.rs
+++ b/hyperactor/src/mailbox.rs
@@ -3349,6 +3349,8 @@ mod tests {
     }
 
     #[async_timed_test(timeout_secs = 30)]
+    // TODO: OSS: this test is flaky in OSS. Need to repo and fix it.
+    #[cfg_attr(not(feature = "fb"), ignore)]
     async fn test_split_port_id_no_reducer() {
         let Setup {
             mut receiver,


### PR DESCRIPTION
Summary: this test has been seend to be flaky in oss e.g. https://github.com/meta-pytorch/monarch/actions/runs/18542437069/job/52856326758

Differential Revision: D84762700


