### PR TITLE
Add stop for v1::ProcMesh

### DIFF
--- a/hyperactor/src/reference.rs
+++ b/hyperactor/src/reference.rs
@@ -587,6 +587,14 @@ impl ProcId {
             ProcId::Direct(_, _) => None,
         }
     }
+
+    /// The proc's name, if this is a direct proc.
+    pub fn name(&self) -> Option<&String> {
+        match self {
+            ProcId::Ranked(_, _) => None,
+            ProcId::Direct(_, name) => Some(name),
+        }
+    }
 }
 
 impl fmt::Display for ProcId {

--- a/hyperactor_mesh/src/v1.rs
+++ b/hyperactor_mesh/src/v1.rs
@@ -297,7 +297,8 @@ impl FromStr for Name {
     type Err = NameParseError;
 
     fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
-        if let Some((name, uuid)) = s.split_once(NAME_SUFFIX_DELIMITER) {
+        // Split from the last in case the name has underscores in it.
+        if let Some((name, uuid)) = s.rsplit_once(NAME_SUFFIX_DELIMITER) {
             if name.is_empty() {
                 return Err(NameParseError::MissingName);
             }
@@ -375,9 +376,9 @@ mod tests {
 
     #[test]
     fn test_name_parse() {
-        // Multiple underscores are allowed in the name, as ShortUuid will discard
-        // them.
-        let name = Name::from_str("foo__1a2b3c4_d5e6f").unwrap();
-        assert_eq!(format!("{}", name), "foo_1a2b3c4d5e6f");
+        // Multiple underscores are allowed in the name, as ShortUuid will choose
+        // the part after the last underscore.
+        let name = Name::from_str("foo_bar_1a2b3c4d5e6f").unwrap();
+        assert_eq!(format!("{}", name), "foo_bar_1a2b3c4d5e6f");
     }
 }

--- a/hyperactor_mesh/src/v1/actor_mesh.rs
+++ b/hyperactor_mesh/src/v1/actor_mesh.rs
@@ -293,7 +293,7 @@ impl<A: Referable> ActorMeshRef<A> {
         }
     }
 
-    pub(crate) fn proc_mesh(&self) -> &ProcMeshRef {
+    pub fn proc_mesh(&self) -> &ProcMeshRef {
         &self.proc_mesh
     }
 
@@ -683,7 +683,7 @@ mod tests {
                 .await
                 .expect("timeout")
                 .unwrap();
-            assert_matches!(state.status, resource::Status::Stopped);
+            assert_matches!(state.status, resource::Status::Timeout(_));
             let events = state
                 .state
                 .expect("state should be present")

--- a/hyperactor_mesh/src/v1/host_mesh.rs
+++ b/hyperactor_mesh/src/v1/host_mesh.rs
@@ -14,6 +14,7 @@ use hyperactor::config;
 use hyperactor::config::CONFIG;
 use hyperactor::config::ConfigAttr;
 use hyperactor::declare_attrs;
+use ndslice::view::CollectMeshExt;
 use tokio::time::timeout;
 
 pub mod mesh_agent;
@@ -52,8 +53,11 @@ use crate::v1;
 use crate::v1::Name;
 use crate::v1::ProcMesh;
 use crate::v1::ProcMeshRef;
+use crate::v1::StatusMesh;
+use crate::v1::ValueMesh;
 pub use crate::v1::host_mesh::mesh_agent::HostMeshAgent;
 use crate::v1::host_mesh::mesh_agent::HostMeshAgentProcMeshTrampoline;
+use crate::v1::host_mesh::mesh_agent::ProcState;
 use crate::v1::host_mesh::mesh_agent::ShutdownHostClient;
 use crate::v1::proc_mesh::ProcRef;
 
@@ -65,6 +69,20 @@ declare_attrs! {
         py_name: None,
     })
     pub attr PROC_SPAWN_MAX_IDLE: Duration = Duration::from_secs(30);
+
+    /// The maximum idle time between updates while stopping proc
+    /// meshes.
+    @meta(CONFIG = ConfigAttr {
+        env_name: Some("HYPERACTOR_MESH_PROC_STOP_MAX_IDLE".to_string()),
+        py_name: None,
+    })
+    pub attr PROC_STOP_MAX_IDLE: Duration = Duration::from_secs(30);
+
+    @meta(CONFIG = ConfigAttr {
+        env_name: Some("HYPERACTOR_MESH_GET_PROC_STATE_MAX_IDLE".to_string()),
+        py_name: None,
+    })
+    pub attr GET_PROC_STATE_MAX_IDLE: Duration = Duration::from_secs(60);
 }
 
 /// A reference to a single host.
@@ -461,6 +479,25 @@ impl Drop for HostMesh {
     }
 }
 
+/// Helper: legacy shim for error types that still require
+/// RankedValues<Status>. TODO(shayne-fletcher): Delete this
+/// shim once Error::ActorSpawnError carries a StatusMesh
+/// (ValueMesh<Status>) directly. At that point, use the mesh
+/// as-is and remove `mesh_to_rankedvalues_*` calls below.
+pub(crate) fn mesh_to_rankedvalues_with_default(
+    mesh: &StatusMesh,
+    default: Status,
+    len: usize,
+) -> RankedValues<Status> {
+    let mut out = RankedValues::from((0..len, default));
+    for (i, s) in mesh.values().enumerate() {
+        if !matches!(s, Status::NotExist) {
+            out.merge_from(RankedValues::from((i..i + 1, s.clone())));
+        }
+    }
+    out
+}
+
 /// A non-owning reference to a mesh of hosts.
 ///
 /// Logically, this is a data structure that contains a set of ranked
@@ -544,25 +581,6 @@ impl HostMeshRef {
 
         let region: Region = extent.clone().into();
         let mesh_name = Name::new(name);
-
-        // Helper: legacy shim for error types that still require
-        // RankedValues<Status>. TODO(shayne-fletcher): Delete this
-        // shim once Error::ActorSpawnError carries a StatusMesh
-        // (ValueMesh<Status>) directly. At that point, use the mesh
-        // as-is and remove `mesh_to_rankedvalues_*` calls below.
-        fn mesh_to_rankedvalues_with_default(
-            mesh: &crate::v1::StatusMesh,
-            default_fill: Status,
-            len: usize,
-        ) -> RankedValues<Status> {
-            let mut out = RankedValues::from((0..len, default_fill));
-            for (i, s) in mesh.values().enumerate() {
-                if !matches!(s, Status::NotExist) {
-                    out.merge_from(RankedValues::from((i..i + 1, s.clone())));
-                }
-            }
-            out
-        }
 
         let mut procs = Vec::new();
         let num_ranks = region.num_ranks();
@@ -651,7 +669,6 @@ impl HostMeshRef {
                         },
                     };
 
-                    let proc_name = Name::new(format!("{}-{}", name, rank % per_host.num_ranks()));
                     return Err(v1::Error::ProcCreationError {
                         state,
                         host_rank,
@@ -677,6 +694,190 @@ impl HostMeshRef {
     /// The name of the referenced host mesh.
     pub fn name(&self) -> &Name {
         &self.name
+    }
+
+    pub(crate) async fn stop_proc_mesh(
+        &self,
+        cx: &impl hyperactor::context::Actor,
+        procs: impl IntoIterator<Item = ProcId>,
+        region: Region,
+    ) -> anyhow::Result<()> {
+        // Accumulator outputs full StatusMesh snapshots; seed with
+        // NotExist.
+        let (tx, rx) = cx.mailbox().open_accum_port_opts(
+            crate::v1::StatusMesh::from_single(region.clone(), Status::NotExist),
+            Some(ReducerOpts {
+                max_update_interval: Some(Duration::from_millis(50)),
+            }),
+        );
+        let mut num_ranks = 0;
+        let mut proc_names = Vec::new();
+        for proc_id in procs.into_iter() {
+            num_ranks += 1;
+            let Some((addr, proc_name)) = proc_id.as_direct() else {
+                return Err(anyhow::anyhow!(
+                    "host mesh proc {} must be direct addressed",
+                    proc_id,
+                ));
+            };
+            // The name stored in HostMeshAgent is not the same as the
+            // one stored in the ProcMesh. We instead take each proc id
+            // and map it to that particular agent.
+            let proc_name = proc_name.parse::<Name>()?;
+            proc_names.push(proc_name.clone());
+
+            // Note that we don't send 1 message per host agent, we send 1 message
+            // per proc.
+            let host = HostRef(addr.clone());
+            host.mesh_agent().send(
+                cx,
+                resource::Stop {
+                    name: proc_name,
+                    reply: tx.bind(),
+                },
+            )?;
+        }
+        tracing::info!(
+            "Sending Stop to host mesh {} for {:?} procs",
+            self.name,
+            proc_names
+        );
+
+        let start_time = RealClock.now();
+
+        match GetRankStatus::wait(
+            rx,
+            num_ranks,
+            config::global::get(PROC_STOP_MAX_IDLE),
+            region,
+        )
+        .await
+        {
+            Ok(statuses) => {
+                let failed = statuses.values().any(|s| {
+                    matches!(
+                        s,
+                        resource::Status::Failed(_) | resource::Status::Timeout(_)
+                    )
+                });
+                if failed {
+                    return Err(anyhow::anyhow!(
+                        "failed to terminate proc mesh: {:?}",
+                        statuses,
+                    ));
+                }
+            }
+            Err(complete) => {
+                // Fill remaining ranks with a timeout status via the
+                // legacy shim.
+                let legacy = mesh_to_rankedvalues_with_default(
+                    &complete,
+                    Status::Timeout(start_time.elapsed()),
+                    num_ranks,
+                );
+                return Err(anyhow::anyhow!(
+                    "failed to terminate proc mesh: {:?}",
+                    legacy
+                ));
+            }
+        }
+        Ok(())
+    }
+
+    /// Get the state of all procs with Name in this host mesh.
+    /// The procs iterator must be in rank order.
+    pub(crate) async fn proc_states(
+        &self,
+        cx: &impl context::Actor,
+        procs: impl IntoIterator<Item = ProcId>,
+        region: Region,
+    ) -> v1::Result<ValueMesh<resource::State<ProcState>>> {
+        let (tx, mut rx) = cx.mailbox().open_port();
+
+        let mut num_ranks = 0;
+        let procs: Vec<ProcId> = procs.into_iter().collect();
+        let mut proc_names = Vec::new();
+        for proc_id in procs.iter() {
+            num_ranks += 1;
+            let Some((addr, proc_name)) = proc_id.as_direct() else {
+                return Err(v1::Error::ConfigurationError(anyhow::anyhow!(
+                    "host mesh proc {} must be direct addressed",
+                    proc_id,
+                )));
+            };
+
+            // Note that we don't send 1 message per host agent, we send 1 message
+            // per proc.
+            let host = HostRef(addr.clone());
+            let proc_name = proc_name.parse::<Name>()?;
+            proc_names.push(proc_name.clone());
+            host.mesh_agent()
+                .send(
+                    cx,
+                    resource::GetState {
+                        name: proc_name,
+                        reply: tx.bind(),
+                    },
+                )
+                .map_err(|e| {
+                    v1::Error::CallError(host.mesh_agent().actor_id().clone(), e.into())
+                })?;
+        }
+
+        let mut states = Vec::with_capacity(num_ranks);
+        let timeout = config::global::get(GET_PROC_STATE_MAX_IDLE);
+        for _ in 0..num_ranks {
+            // The agent runs on the same process as the running actor, so if some
+            // fatal event caused the process to crash (e.g. OOM, signal, process exit),
+            // the agent will be unresponsive.
+            // We handle this by setting a timeout on the recv, and if we don't get a
+            // message we assume the agent is dead and return a failed state.
+            let state = RealClock.timeout(timeout, rx.recv()).await;
+            if let Ok(state) = state {
+                // Handle non-timeout receiver error.
+                let state = state?;
+                match state.state {
+                    Some(ref inner) => {
+                        states.push((inner.create_rank, state));
+                    }
+                    None => {
+                        return Err(v1::Error::NotExist(state.name));
+                    }
+                }
+            } else {
+                // Timeout error, stop reading from the receiver and send back what we have so far,
+                // padding with failed states.
+                tracing::warn!("Timeout waiting for response from host mesh agent for proc_states");
+                let all_ranks = (0..num_ranks).collect::<HashSet<_>>();
+                let completed_ranks = states.iter().map(|(rank, _)| *rank).collect::<HashSet<_>>();
+                let mut leftover_ranks = all_ranks.difference(&completed_ranks).collect::<Vec<_>>();
+                assert_eq!(leftover_ranks.len(), num_ranks - states.len());
+                while states.len() < num_ranks {
+                    let rank = *leftover_ranks
+                        .pop()
+                        .expect("leftover ranks should not be empty");
+                    states.push((
+                        // We populate with any ranks leftover at the time of the timeout.
+                        rank,
+                        resource::State {
+                            name: proc_names[rank].clone(),
+                            status: resource::Status::Timeout(timeout),
+                            state: None,
+                        },
+                    ));
+                }
+                break;
+            }
+        }
+        // Ensure that all ranks have replied. Note that if the mesh is sliced,
+        // not all create_ranks may be in the mesh.
+        // Sort by rank, so that the resulting mesh is ordered.
+        states.sort_by_key(|(rank, _)| *rank);
+        let vm = states
+            .into_iter()
+            .map(|(_, state)| state)
+            .collect_mesh::<ValueMesh<_>>(region)?;
+        Ok(vm)
     }
 }
 

--- a/python/monarch/_rust_bindings/monarch_hyperactor/v1/proc_mesh.pyi
+++ b/python/monarch/_rust_bindings/monarch_hyperactor/v1/proc_mesh.pyi
@@ -73,7 +73,7 @@ class ProcMesh:
         """
         ...
 
-    def stop_nonblocking(self) -> PythonTask[None]:
+    def stop_nonblocking(self, instance: Instance) -> PythonTask[None]:
         """
         Stop the proc mesh.
         """

--- a/python/tests/_monarch/test_actor_mesh.py
+++ b/python/tests/_monarch/test_actor_mesh.py
@@ -128,8 +128,12 @@ async def test_bind_and_pickling(use_v1: bool) -> None:
         obj = pickle.dumps(actor_mesh_ref)
         pickle.loads(obj)
         if not use_v1:
-            # TODO: proc mesh stop not yet supported for v1
+            assert isinstance(proc_mesh, ProcMesh)
             await proc_mesh.stop_nonblocking()
+        else:
+            assert isinstance(proc_mesh, ProcMeshV1)
+            instance = context().actor_instance._as_rust()
+            await proc_mesh.stop_nonblocking(instance)
 
     run()
 
@@ -223,7 +227,12 @@ async def test_cast_handle(use_v1: bool) -> None:
         )
 
         if not use_v1:
+            assert isinstance(proc_mesh, ProcMesh)
             await proc_mesh.stop_nonblocking()
+        else:
+            assert isinstance(proc_mesh, ProcMeshV1)
+            instance = context().actor_instance._as_rust()
+            await proc_mesh.stop_nonblocking(instance)
 
     run()
 
@@ -245,7 +254,12 @@ async def test_cast_ref(use_v1: bool) -> None:
             actor_mesh_ref, context().actor_instance, list(range(3 * 8 * 8))
         )
         if not use_v1:
+            assert isinstance(proc_mesh, ProcMesh)
             await proc_mesh.stop_nonblocking()
+        else:
+            assert isinstance(proc_mesh, ProcMeshV1)
+            instance = context().actor_instance._as_rust()
+            await proc_mesh.stop_nonblocking(instance)
 
     run()
 


### PR DESCRIPTION
Summary:
Add in support for ProcMesh::stop for v1 proc meshes.
This sends a Destroy message to the HostMeshAgent that owns this proc mesh.

This only works for owned ProcMeshes, they cannot be stopped from a reference.
The Name for HostMesh procs contained an underscore and required a change to Name parsing,
that only the last underscore separates the uuid

Reviewed By: mariusae

Differential Revision: D84556616


