### PR TITLE
Maybe fix partially imported torch

### DIFF
--- a/python/monarch/_src/actor/pickle.py
+++ b/python/monarch/_src/actor/pickle.py
@@ -23,7 +23,18 @@ def maybe_torch():
     """
     Returns the torch module if it has been loaded, otherwise None.
     """
-    return sys.modules.get("torch")
+    if "torch" in sys.modules:
+        # we avoid eagerly loading torch because it
+        # takes a long time to import and slows down startup
+        # for programs that do not use it.
+
+        # But once it has been loaded, we know we might need it.
+        # We have to explicitly import now because torch
+        # might now be completely loaded yet.
+        import torch
+
+        return torch
+    return None
 
 
 _orig_function_getstate = cloudpickle.cloudpickle._function_getstate


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #1567

I believe there is a race condition where simply checking for torch in `sys.modules` does not ensure it is completely finished importing. So instead if we see it in `sys.modules` we call import directly to wait for the import to finish.

Differential Revision: [D84836798](https://our.internmc.facebook.com/intern/diff/D84836798/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D84836798/)!