### PR TITLE
Use IP addr for torch.distributed MASTER_ADDR

### DIFF
--- a/python/monarch/tools/network.py
+++ b/python/monarch/tools/network.py
@@ -25,45 +25,74 @@ def get_sockaddr(hostname: str, port: int) -> str:
     """
 
     def resolve_sockaddr(family: socket.AddressFamily) -> Optional[str]:
-        try:
-            # patternlint-disable-next-line python-dns-deps (only used for oss)
-            addrs = socket.getaddrinfo(hostname, port, family, type=socket.SOCK_STREAM)
-            if addrs:
-                family, _, _, _, sockaddr = addrs[0]  # use the first address
+        if ipaddr := _resolve_ipaddr(hostname, port, family):
+            if family == socket.AF_INET6:
+                socket_address = f"[{ipaddr}]:{port}"
+            else:  # socket.AF_INET
+                socket_address = f"{ipaddr}:{port}"
 
-                # sockaddr is a tuple (ipv4) or a 4-tuple (ipv6)
-                # in both cases the first element is the ip addr
-                ipaddr = str(sockaddr[0])
-
-                if family == socket.AF_INET6:
-                    socket_address = f"[{ipaddr}]:{port}"
-                else:  # socket.AF_INET
-                    socket_address = f"{ipaddr}:{port}"
-
-                logger.info(
-                    "resolved %s address `%s` for `%s:%d`",
-                    family.name,
-                    socket_address,
-                    hostname,
-                    port,
-                )
-
-                return socket_address
-        except socket.gaierror as e:
             logger.info(
-                "no %s address that can bind TCP sockets for `%s:%d` (error: %s)",
+                "resolved %s address `%s` for `%s:%d`",
                 family.name,
+                socket_address,
                 hostname,
                 port,
-                e,
             )
+            return socket_address
+
         return None
 
     for family in [socket.AF_INET6, socket.AF_INET]:
-        if ipaddr := resolve_sockaddr(family):
+        if sockaddr := resolve_sockaddr(family):
+            return sockaddr
+
+    raise RuntimeError(
+        f"Unable to resolve `{hostname}` to ipv6 or ipv4 address that can bind TCP socket."
+        " Check the network configuration on the host."
+    )
+
+
+def get_ipaddr(hostname: str, port: int) -> str:
+    """Similar to `get_sockaddr` but returns only the ip address instead of the socket address.
+    The return IP address is of the form:
+      1. `{ipv4.address}` (e.g. `127.0.0.1`)
+      2. `[{ipv6:address}]` (e.g. `[::1]`)
+    """
+    for family in [socket.AF_INET6, socket.AF_INET]:
+        if ipaddr := _resolve_ipaddr(hostname, port, family):
+            logger.info(
+                "resolved %s address `%s` for `%s:%d`",
+                family.name,
+                ipaddr,
+                hostname,
+                port,
+            )
             return ipaddr
 
     raise RuntimeError(
         f"Unable to resolve `{hostname}` to ipv6 or ipv4 address that can bind TCP socket."
         " Check the network configuration on the host."
     )
+
+
+def _resolve_ipaddr(
+    hostname: str, port: int, family: socket.AddressFamily
+) -> Optional[str]:
+    try:
+        # patternlint-disable-next-line python-dns-deps (only used for oss)
+        addrs = socket.getaddrinfo(hostname, port, family, type=socket.SOCK_STREAM)
+        if addrs:
+            family, _, _, _, sockaddr = addrs[0]  # use the first address
+
+            # sockaddr is a tuple (ipv4) or a 4-tuple (ipv6)
+            # in both cases the first element is the ip addr
+            return str(sockaddr[0])
+    except socket.gaierror as e:
+        logger.info(
+            "no %s address that can bind TCP sockets for `%s:%d` (error: %s)",
+            family.name,
+            hostname,
+            port,
+            e,
+        )
+    return None

--- a/python/monarch/utils/utils.py
+++ b/python/monarch/utils/utils.py
@@ -10,6 +10,7 @@ import os
 import socket
 
 from monarch.actor import Actor, current_rank, endpoint, ProcMesh
+from monarch.tools.network import get_ipaddr
 
 
 def _find_free_port() -> int:
@@ -26,7 +27,9 @@ class _TorchDistributedInitActor(Actor):
 
     @endpoint
     def get_host_port(self) -> tuple[str, int]:
-        return (socket.gethostname(), _find_free_port())
+        port = _find_free_port()
+        ipaddr = get_ipaddr(socket.gethostname(), port)
+        return (ipaddr, port)
 
     @endpoint
     def setup_env(self, master_addr: str, master_port: int) -> None:

--- a/python/tests/tools/test_network.py
+++ b/python/tests/tools/test_network.py
@@ -28,10 +28,14 @@ class TestNetwork(unittest.TestCase):
                         ("123.45.67.89", 8080),
                     )
                 ],
-            ],
+            ]
+            * 2,
         ):
             self.assertEqual(
                 "123.45.67.89:8080", network.get_sockaddr("foo.bar.facebook.com", 8080)
+            )
+            self.assertEqual(
+                "123.45.67.89", network.get_ipaddr("foo.bar.facebook.com", 8080)
             )
 
     def test_network_ipv6(self) -> None:
@@ -52,6 +56,10 @@ class TestNetwork(unittest.TestCase):
             self.assertEqual(
                 "[1234:ab00:567c:89d:abcd:0:328:0]:8080",
                 network.get_sockaddr("foo.bar.facebook.com", 8080),
+            )
+            self.assertEqual(
+                "1234:ab00:567c:89d:abcd:0:328:0",
+                network.get_ipaddr("foo.bar.facebook.com", 8080),
             )
 
     def test_network(self) -> None:


### PR DESCRIPTION
Summary:
Lightning uses GCP for its worker hosts. `socket.gethostname()` will return a host name like `job-01k72wn5f8waqw7d81mfggagn4.internal`, which can not be resolved by its DNS, and lead to errors like:

> [7 similar log lines] [W1008 23:40:22.836678340 socket.cpp:767] [c10d] The client socket has failed to connect to [job-01k72wn5f8waqw7d81mfggagn4.internal]:50745 (errno: 22 - Invalid argument).
> [24 similar log lines] [W1008 23:40:22.781961348 socket.cpp:767] [c10d] The IPv6 network addresses of (job-01k72wn5f8waqw7d81mfggagn4.internal, 50745) cannot be retrieved (gai error: -2 - Name or service not known).

We tried with IP address, and it worked.

Therefore, using the IP address as the `MASTER_ADDR`, instead of hostname

Differential Revision: D84827696


