### PR TITLE
Back out "Allow CommActor 0 to handle ForwardMessage directly instead of self messaging"

### DIFF
--- a/hyperactor_mesh/src/comm.rs
+++ b/hyperactor_mesh/src/comm.rs
@@ -353,23 +353,18 @@ impl Handler<CastMessage> for CommActor {
             .or_default();
         let last_seq = *seq;
         *seq += 1;
-
-        let fwd_message = ForwardMessage {
-            dests: vec![frame],
-            sender: cx.self_id().clone(),
-            message: cast_message.message,
-            seq: *seq,
-            last_seq,
-        };
-
-        // Optimization: if forwarding to ourselves, handle inline instead of
-        // going through the message queue
-        let self_rank = self.mode.self_rank(cx.self_id())?;
-        if rank == self_rank {
-            Handler::<ForwardMessage>::handle(self, cx, fwd_message).await?;
-        } else {
-            Self::forward(cx, &self.mode, rank, fwd_message)?;
-        }
+        Self::forward(
+            cx,
+            &self.mode,
+            rank,
+            ForwardMessage {
+                dests: vec![frame],
+                sender: cx.self_id().clone(),
+                message: cast_message.message,
+                seq: *seq,
+                last_seq,
+            },
+        )?;
         Ok(())
     }
 }

--- a/python/monarch/__init__.py
+++ b/python/monarch/__init__.py
@@ -36,6 +36,11 @@ except ImportError:
 
 if TYPE_CHECKING:
     from monarch import timer
+    from monarch._rust_bindings.monarch_hyperactor.alloc import (
+        AllocConstraints,
+        AllocSpec,
+    )
+    from monarch._src.actor.allocator import LocalAllocator, ProcessAllocator
     from monarch._src.actor.shape import Extent, NDSlice, Shape
     from monarch.common._coalescing import coalescing
 
@@ -75,6 +80,11 @@ if TYPE_CHECKING:
 
 
 _public_api = {
+    "AllocConstraints": (
+        "monarch._rust_bindings.monarch_hyperactor.alloc",
+        "AllocConstraints",
+    ),
+    "AllocSpec": ("monarch._rust_bindings.monarch_hyperactor.alloc", "AllocSpec"),
     "coalescing": ("monarch.common._coalescing", "coalescing"),
     "remote": ("monarch.common.remote", "remote"),
     "DeviceMesh": ("monarch.common.device_mesh", "DeviceMesh"),
@@ -118,6 +128,9 @@ _public_api = {
     "Simulator": ("monarch.simulator.interface", "Simulator"),
     "world_mesh": ("monarch.world_mesh", "world_mesh"),
     "timer": ("monarch.timer", "timer"),
+    "ProcessAllocator": ("monarch._src.actor.allocator", "ProcessAllocator"),
+    "LocalAllocator": ("monarch._src.actor.allocator", "LocalAllocator"),
+    "SimAllocator": ("monarch._src_actor.allocator", "SimAllocator"),
     "ActorFuture": ("monarch.future", "ActorFuture"),
     "builtins": ("monarch.builtins", "builtins"),
 }
@@ -143,6 +156,8 @@ except ImportError:
 # we have to explicitly list this rather than just take the keys of the _public_api
 # otherwise tools think the imports are unused
 __all__ = [
+    "AllocConstraints",
+    "AllocSpec",
     "coalescing",
     "DeviceMesh",
     "get_active_mesh",
@@ -186,6 +201,9 @@ __all__ = [
     "Simulator",
     "world_mesh",
     "timer",
+    "ProcessAllocator",
+    "LocalAllocator",
+    "SimAllocator",
     "ActorFuture",
     "builtins",
 ]

--- a/python/tests/_monarch/test_actor_mesh.py
+++ b/python/tests/_monarch/test_actor_mesh.py
@@ -26,9 +26,7 @@ from monarch._rust_bindings.monarch_hyperactor.alloc import (  # @manual=//monar
     AllocSpec,
 )
 from monarch._rust_bindings.monarch_hyperactor.shape import Extent, Region, Slice
-from monarch._src.actor.allocator import LocalAllocator
 from monarch._src.actor.proc_mesh import _get_bootstrap_args, ProcessAllocator
-
 
 if TYPE_CHECKING:
     from monarch._rust_bindings.monarch_hyperactor.actor import PortProtocol
@@ -58,7 +56,7 @@ def run_on_tokio(
 
 async def alloc() -> Alloc:
     spec = AllocSpec(AllocConstraints(), replicas=3, hosts=8, gpus=8)
-    allocator = LocalAllocator()
+    allocator = monarch.LocalAllocator()
     return await allocator.allocate_nonblocking(spec)
 
 

--- a/python/tests/_monarch/test_hyperactor.py
+++ b/python/tests/_monarch/test_hyperactor.py
@@ -12,6 +12,8 @@ import signal
 import time
 from typing import Any, Callable, Coroutine
 
+import monarch
+
 from monarch._rust_bindings.monarch_hyperactor.alloc import (  # @manual=//monarch/monarch_extension:monarch_extension_no_torch
     AllocConstraints,
     AllocSpec,
@@ -20,8 +22,6 @@ from monarch._rust_bindings.monarch_hyperactor.buffers import Buffer
 from monarch._rust_bindings.monarch_hyperactor.proc import ActorId
 from monarch._rust_bindings.monarch_hyperactor.proc_mesh import ProcMesh
 from monarch._rust_bindings.monarch_hyperactor.pytokio import PythonTask
-
-from monarch._src.actor.allocator import LocalAllocator
 from monarch._src.actor.pickle import flatten, unflatten
 
 
@@ -64,7 +64,7 @@ def test_no_hang_on_shutdown() -> None:
 
 async def test_allocator() -> None:
     spec = AllocSpec(AllocConstraints(), replica=2)
-    allocator = LocalAllocator()
+    allocator = monarch.LocalAllocator()
     _ = allocator.allocate(spec)
 
 
@@ -81,7 +81,7 @@ def _python_task_test(
 @_python_task_test
 async def test_proc_mesh() -> None:
     spec = AllocSpec(AllocConstraints(), replica=2)
-    allocator = LocalAllocator()
+    allocator = monarch.LocalAllocator()
     alloc = await allocator.allocate_nonblocking(spec)
     proc_mesh = await ProcMesh.allocate_nonblocking(alloc)
     assert str(proc_mesh) == "<ProcMesh { shape: {replica=2} }>"
@@ -90,7 +90,7 @@ async def test_proc_mesh() -> None:
 @_python_task_test
 async def test_actor_mesh() -> None:
     spec = AllocSpec(AllocConstraints(), replica=2)
-    allocator = LocalAllocator()
+    allocator = monarch.LocalAllocator()
     alloc = await allocator.allocate_nonblocking(spec)
     proc_mesh = await ProcMesh.allocate_nonblocking(alloc)
     actor_mesh = await proc_mesh.spawn_nonblocking("test", MyActor)

--- a/python/tests/_monarch/test_mailbox.py
+++ b/python/tests/_monarch/test_mailbox.py
@@ -19,6 +19,8 @@ from typing import (
     TypeVar,
 )
 
+import monarch
+
 from monarch._rust_bindings.monarch_hyperactor.actor import (
     MethodSpecifier,
     PanicFlag,
@@ -26,8 +28,6 @@ from monarch._rust_bindings.monarch_hyperactor.actor import (
     PythonMessageKind,
 )
 from monarch._rust_bindings.monarch_hyperactor.pytokio import PythonTask
-
-from monarch._src.actor.allocator import LocalAllocator
 
 if TYPE_CHECKING:
     from monarch._rust_bindings.monarch_hyperactor.actor import PortProtocol
@@ -100,7 +100,7 @@ class Accumulator(Generic[S, U]):
 
 async def allocate() -> ProcMesh:
     spec = AllocSpec(AllocConstraints(), replica=1)
-    allocator = LocalAllocator()
+    allocator = monarch.LocalAllocator()
     alloc = await allocator.allocate_nonblocking(spec)
     return await ProcMesh.allocate_nonblocking(alloc)
 

--- a/python/tests/test_alloc.py
+++ b/python/tests/test_alloc.py
@@ -8,11 +8,11 @@
 
 from unittest import IsolatedAsyncioTestCase
 
+from monarch import ProcessAllocator
 from monarch._rust_bindings.monarch_hyperactor.alloc import (  # @manual=//monarch/monarch_extension:monarch_extension
     AllocConstraints,
     AllocSpec,
 )
-from monarch._src.actor.allocator import ProcessAllocator
 
 
 class TestAlloc(IsolatedAsyncioTestCase):


### PR DESCRIPTION
Summary:
Original commit changeset: 68ddf6a71c85

Original Phabricator Diff: D84639620

Differential Revision: D84885182


