### PR TITLE
(exclusively) Back out "[monarch][perf]Allow CommActor 0 to handle ForwardMessage directly instead of self messaging"

### DIFF
--- a/hyperactor_mesh/src/comm.rs
+++ b/hyperactor_mesh/src/comm.rs
@@ -353,23 +353,18 @@ impl Handler<CastMessage> for CommActor {
             .or_default();
         let last_seq = *seq;
         *seq += 1;
-
-        let fwd_message = ForwardMessage {
-            dests: vec![frame],
-            sender: cx.self_id().clone(),
-            message: cast_message.message,
-            seq: *seq,
-            last_seq,
-        };
-
-        // Optimization: if forwarding to ourselves, handle inline instead of
-        // going through the message queue
-        let self_rank = self.mode.self_rank(cx.self_id())?;
-        if rank == self_rank {
-            Handler::<ForwardMessage>::handle(self, cx, fwd_message).await?;
-        } else {
-            Self::forward(cx, &self.mode, rank, fwd_message)?;
-        }
+        Self::forward(
+            cx,
+            &self.mode,
+            rank,
+            ForwardMessage {
+                dests: vec![frame],
+                sender: cx.self_id().clone(),
+                message: cast_message.message,
+                seq: *seq,
+                last_seq,
+            },
+        )?;
         Ok(())
     }
 }


### PR DESCRIPTION
Summary:
Original commit changeset: 68ddf6a71c85

Original Phabricator Diff: D84639620

Differential Revision: D84888047


