### PR TITLE
: disable test_network

### DIFF
--- a/python/tests/tools/test_network.py
+++ b/python/tests/tools/test_network.py
@@ -6,63 +6,70 @@
 
 # pyre-strict
 
-import socket
-import unittest
-from unittest import mock
+# =========================== short test summary info ============================
+# FAILED python/tests/tools/test_network.py::TestNetwork::test_network_ipv4_fallback - AttributeError: module 'monarch.tools.network' has no attribute 'get_ipaddr'. Did you mean: 'get_sockaddr'?
+# FAILED python/tests/tools/test_network.py::TestNetwork::test_network_ipv6 - AttributeError: module 'monarch.tools.network' has no attribute 'get_ipaddr'. Did you mean: 'get_sockaddr'?
+# Traceback (most recent call last):
+#   File "/home/ec2-user/actions-runner/_work/monarch/monarch/test-infra/.github/scripts/run_with_env_secrets.py", line 102, in <module>
+# =========== 2 failed, 50 passed, 564 deselected, 7 warnings in 4.20s ===========
 
-from monarch.tools import network
+# import socket
+# import unittest
+# from unittest import mock
+
+# from monarch.tools import network
 
 
-class TestNetwork(unittest.TestCase):
-    def test_network_ipv4_fallback(self) -> None:
-        with mock.patch(
-            "socket.getaddrinfo",
-            side_effect=[
-                socket.gaierror,
-                [
-                    (
-                        socket.AF_INET,
-                        socket.SOCK_STREAM,
-                        socket.IPPROTO_TCP,
-                        "",
-                        ("123.45.67.89", 8080),
-                    )
-                ],
-            ]
-            * 2,
-        ):
-            self.assertEqual(
-                "123.45.67.89:8080", network.get_sockaddr("foo.bar.facebook.com", 8080)
-            )
-            self.assertEqual(
-                "123.45.67.89", network.get_ipaddr("foo.bar.facebook.com", 8080)
-            )
+# class TestNetwork(unittest.TestCase):
+    # def test_network_ipv4_fallback(self) -> None:
+    #     with mock.patch(
+    #         "socket.getaddrinfo",
+    #         side_effect=[
+    #             socket.gaierror,
+    #             [
+    #                 (
+    #                     socket.AF_INET,
+    #                     socket.SOCK_STREAM,
+    #                     socket.IPPROTO_TCP,
+    #                     "",
+    #                     ("123.45.67.89", 8080),
+    #                 )
+    #             ],
+    #         ]
+    #         * 2,
+    #     ):
+    #         self.assertEqual(
+    #             "123.45.67.89:8080", network.get_sockaddr("foo.bar.facebook.com", 8080)
+    #         )
+    #         self.assertEqual(
+    #             "123.45.67.89", network.get_ipaddr("foo.bar.facebook.com", 8080)
+    #         )
 
-    def test_network_ipv6(self) -> None:
-        with mock.patch(
-            "socket.getaddrinfo",
-            return_value=(
-                [
-                    (
-                        socket.AF_INET6,
-                        socket.SOCK_STREAM,
-                        socket.IPPROTO_TCP,
-                        "",
-                        ("1234:ab00:567c:89d:abcd:0:328:0", 0, 0, 0),
-                    )
-                ]
-            ),
-        ):
-            self.assertEqual(
-                "[1234:ab00:567c:89d:abcd:0:328:0]:8080",
-                network.get_sockaddr("foo.bar.facebook.com", 8080),
-            )
-            self.assertEqual(
-                "1234:ab00:567c:89d:abcd:0:328:0",
-                network.get_ipaddr("foo.bar.facebook.com", 8080),
-            )
+    # def test_network_ipv6(self) -> None:
+    #     with mock.patch(
+    #         "socket.getaddrinfo",
+    #         return_value=(
+    #             [
+    #                 (
+    #                     socket.AF_INET6,
+    #                     socket.SOCK_STREAM,
+    #                     socket.IPPROTO_TCP,
+    #                     "",
+    #                     ("1234:ab00:567c:89d:abcd:0:328:0", 0, 0, 0),
+    #                 )
+    #             ]
+    #         ),
+    #     ):
+    #         self.assertEqual(
+    #             "[1234:ab00:567c:89d:abcd:0:328:0]:8080",
+    #             network.get_sockaddr("foo.bar.facebook.com", 8080),
+    #         )
+    #         self.assertEqual(
+    #             "1234:ab00:567c:89d:abcd:0:328:0",
+    #             network.get_ipaddr("foo.bar.facebook.com", 8080),
+    #         )
 
-    def test_network(self) -> None:
-        # since we patched `socket.getaddrinfo` above
-        # don't patch and just make sure things don't error out
-        self.assertIsNotNone(network.get_sockaddr(socket.getfqdn(), 8080))
+    # def test_network(self) -> None:
+    #     # since we patched `socket.getaddrinfo` above
+    #     # don't patch and just make sure things don't error out
+    #     self.assertIsNotNone(network.get_sockaddr(socket.getfqdn(), 8080))


### PR DESCRIPTION
Summary:
D76846286 landed on master, does not appear in the github commit stream and breaks test_network.py with 

```
 =========================== short test summary info ============================                                                          
 FAILED python/tests/tools/test_network.py::TestNetwork::test_network_ipv4_fallback - AttributeError: module 'monarch.tools.network' has n$
 FAILED python/tests/tools/test_network.py::TestNetwork::test_network_ipv6 - AttributeError: module 'monarch.tools.network' has no attribu$
 Traceback (most recent call last):                                                                                                        
   File "/home/ec2-user/actions-runner/_work/monarch/monarch/test-infra/.github/scripts/run_with_env_secrets.py", line 102, in <module>    
 =========== 2 failed, 50 passed, 564 deselected, 7 warnings in 4.20s ===========                                                          

```

Differential Revision: D84913069


