### PR TITLE
[monarch] generally propagate naming in meshes

### DIFF
--- a/hyperactor_mesh/src/v1/actor_mesh.rs
+++ b/hyperactor_mesh/src/v1/actor_mesh.rs
@@ -87,6 +87,12 @@ impl<A: Referable> ActorMesh<A> {
     }
 }
 
+impl<A: Referable> fmt::Display for ActorMesh<A> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.current_ref)
+    }
+}
+
 impl<A: Referable> Deref for ActorMesh<A> {
     type Target = ActorMeshRef<A>;
 
@@ -350,6 +356,15 @@ impl<A: Referable> Clone for ActorMeshRef<A> {
         }
     }
 }
+
+impl<A: Referable> fmt::Display for ActorMeshRef<A> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}:{}@{}", self.name, A::typename(), self.proc_mesh)
+    }
+}
+
+// proc_mesh: ProcMeshRef,
+// name: Name,
 
 impl<A: Referable> PartialEq for ActorMeshRef<A> {
     fn eq(&self, other: &Self) -> bool {

--- a/hyperactor_mesh/src/v1/proc_mesh.rs
+++ b/hyperactor_mesh/src/v1/proc_mesh.rs
@@ -393,6 +393,12 @@ impl ProcMesh {
     }
 }
 
+impl fmt::Display for ProcMesh {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.current_ref)
+    }
+}
+
 impl Deref for ProcMesh {
     type Target = ProcMeshRef;
 
@@ -463,7 +469,7 @@ impl fmt::Debug for ProcMeshAllocation {
 }
 
 /// A reference to a ProcMesh, consisting of a set of ranked [`ProcRef`]s,
-/// arranged into a region. ProcMeshes named, uniquely identifying the
+/// arranged into a region. ProcMeshes are named, uniquely identifying the
 /// ProcMesh from which the reference was derived.
 ///
 /// ProcMeshes can be sliced to create new ProcMeshes with a subset of the
@@ -572,7 +578,7 @@ impl ProcMeshRef {
                 }
             } else {
                 tracing::error!(
-                    "Timeout waiting for a message from proc mesh agent in mesh: {:?}",
+                    "timeout waiting for a message from proc mesh agent in mesh: {}",
                     agent_mesh
                 );
                 // Timeout error, stop reading from the receiver and send back what we have so far,
@@ -891,6 +897,12 @@ impl ProcMeshRef {
                 Err(Error::ActorStopError { statuses: legacy })
             }
         }
+    }
+}
+
+impl fmt::Display for ProcMeshRef {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}{{{}}}", self.name, self.region)
     }
 }
 

--- a/hyperactor_mesh/src/v1/testing.rs
+++ b/hyperactor_mesh/src/v1/testing.rs
@@ -96,7 +96,7 @@ pub async fn allocs(extent: Extent) -> Vec<Box<dyn Alloc + Send + Sync>> {
     };
 
     vec![
-        // Box::new(LocalAllocator.allocate(spec.clone()).await.unwrap()),
+        Box::new(LocalAllocator.allocate(spec.clone()).await.unwrap()),
         Box::new(
             ProcessAllocator::new(Command::new(crate::testresource::get(
                 "monarch/hyperactor_mesh/bootstrap",

--- a/monarch_hyperactor/src/bootstrap.rs
+++ b/monarch_hyperactor/src/bootstrap.rs
@@ -129,7 +129,7 @@ pub fn attach_to_workers<'py>(
         });
         let addresses = addresses?;
 
-        let host_mesh = HostMesh::take(name, HostMeshRef::from_hosts(addresses));
+        let host_mesh = HostMesh::take(HostMeshRef::from_hosts(name, addresses));
         Ok(PyHostMesh::new_owned(host_mesh))
     })
 }

--- a/python/monarch/_src/actor/actor_mesh.py
+++ b/python/monarch/_src/actor/actor_mesh.py
@@ -228,7 +228,9 @@ def context() -> Context:
             c.actor_instance.proc_mesh._host_mesh = create_local_host_mesh()  # type: ignore
         else:
             c.actor_instance._controller_controller = _get_controller_controller()[1]
-            c.actor_instance.proc_mesh = create_local_host_mesh().spawn_procs()
+            c.actor_instance.proc_mesh = create_local_host_mesh().spawn_procs(
+                name="controller_controller"
+            )
     return c
 
 

--- a/python/monarch/_src/actor/v1/host_mesh.py
+++ b/python/monarch/_src/actor/v1/host_mesh.py
@@ -157,7 +157,7 @@ class HostMesh(MeshTrait):
             None,
         )
 
-        hm._code_sync_proc_mesh = hm.spawn_procs()
+        hm._code_sync_proc_mesh = hm.spawn_procs(name="code_sync")
         return hm
 
     def spawn_procs(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #1599
* __->__ #1597

The aim is to provide better diagnostic messages and `Display` implementations for meshes to be used in log messages.

* Retain names in HostMeshRefs
* Label internal proc meshes
* Implement `Display` for ActorMesh[Ref] and ProcMesh[Ref]
* Use Display in log message

Differential Revision: [D84923001](https://our.internmc.facebook.com/intern/diff/D84923001/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D84923001/)!