### PR TITLE
Fix infinite wait in actor mesh stop

### DIFF
--- a/python/tests/test_python_actors.py
+++ b/python/tests/test_python_actors.py
@@ -1348,9 +1348,7 @@ async def test_actor_mesh_stop() -> None:
     await pm.stop()
 
 
-# FIXME: Flaky on v1
-@pytest.mark.oss_skip
-@pytest.mark.timeout(60)
+@pytest.mark.timeout(120)
 async def test_proc_mesh_stop_after_actor_mesh_stop() -> None:
     pm = this_host().spawn_procs(per_host={"gpus": 2})
     am = pm.spawn("printer", Printer)


### PR DESCRIPTION
Summary:
In v1::ActorMesh::stop, there was occasionally an infinite wait for an actor to transition
to the "Stopped" state. I determined that sometimes an actor would get hung waiting
for a child actor to signal their parent that they had stopped.

Add a timeout for this check, so that in the case where the children are unresponsive,
the parent can still stop themselves. In that case the child actor becomes orphaned and might
never stop, but at least the parent can stop successfully and isn't left hanging.

Reviewed By: shayne-fletcher

Differential Revision: D84861696


