### PR TITLE
Hint about static linking on libpython import error

### DIFF
--- a/python/monarch/__init__.py
+++ b/python/monarch/__init__.py
@@ -13,7 +13,14 @@ from typing import TYPE_CHECKING
 # our RPATHs won't correctly find them.
 try:
     import monarch._rust_bindings  # @manual  # noqa: F401
-except ImportError:
+except ImportError as e:
+    if "libpython" in str(e) and "cannot open shared object file" in str(e):
+        print(
+            f"\nERROR: {e}",
+            "\nHint: Please statically link the library.",
+            "\nIf you're using conda: export LD_LIBRARY_PATH=${CONDA_PREFIX}/lib:${LD_LIBRARY_PATH}",
+        )
+        raise
     try:
         import torch  # @manual  # noqa: F401
     except ImportError:


### PR DESCRIPTION
Summary:
When you import Monarch from PyPI you often see an error message like this:

```
$ python -c "from monarch import actor"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/home/allencwang/.conda/envs/monarch_dev/lib/python3.10/site-packages/monarch/actor/__init__.py", line 12, in <module>
    from monarch._src.actor.actor_mesh import (
  File "/home/allencwang/.conda/envs/monarch_dev/lib/python3.10/site-packages/monarch/_src/actor/actor_mesh.py", line 46, in <module>
    from monarch._rust_bindings.monarch_hyperactor.actor import (
ImportError: libpython3.10.so.1.0: cannot open shared object file: No such file or directory
```

The solution most have been using has been to

```
export LD_LIBRARY_PATH=${CONDA_PREFIX}/lib:LD_LIBRARY_PATH
```

which is frustrating to discover. This PR will print a hint on the failure to at least suggest this to end users.

Differential Revision: D84940190


