### PR TITLE
Add AddrType parameter to setup_env_for_distributed

### DIFF
--- a/python/monarch/utils/utils.py
+++ b/python/monarch/utils/utils.py
@@ -9,8 +9,10 @@
 import os
 import socket
 
+from typing import Optional
+
 from monarch.actor import Actor, current_rank, endpoint, ProcMesh
-from monarch.tools.network import get_ipaddr
+from monarch.tools.network import AddrType, get_ipaddr
 
 
 def _find_free_port() -> int:
@@ -26,9 +28,13 @@ class _TorchDistributedInitActor(Actor):
         self.rank: int = current_rank().rank
 
     @endpoint
-    def get_host_port(self) -> tuple[str, int]:
+    def get_host_port(self, use_ipaddr: Optional[AddrType]) -> tuple[str, int]:
+        hostname = socket.gethostname()
         port = _find_free_port()
-        ipaddr = get_ipaddr(socket.gethostname(), port)
+        if use_ipaddr is None:
+            return (hostname, port)
+
+        ipaddr = get_ipaddr(hostname, port, use_ipaddr)
         return (ipaddr, port)
 
     @endpoint
@@ -62,6 +68,7 @@ async def setup_env_for_distributed(
     proc_mesh: ProcMesh,
     master_addr: str | None = None,
     master_port: int | None = None,
+    use_ipaddr: Optional[AddrType] = None,
 ) -> None:
     """
     Sets up environment variables for pytorch distributed.
@@ -75,7 +82,7 @@ async def setup_env_for_distributed(
     am = proc_mesh.spawn("_TorchDistributedInitActor", _TorchDistributedInitActor)
     if master_addr is None:
         # We use call instead of call_one because call_one can't handle tuple return types.
-        vm = await am.flatten("rank").slice(rank=0).get_host_port.call()
+        vm = await am.flatten("rank").slice(rank=0).get_host_port.call(use_ipaddr)
         master_addr, master_port = vm.item()
     assert master_port is not None, "master_port should not be None here."
     await am.setup_env.call(master_addr, master_port)

--- a/python/tests/tools/test_network.py
+++ b/python/tests/tools/test_network.py
@@ -38,6 +38,26 @@ class TestNetwork(unittest.TestCase):
                 "123.45.67.89", network.get_ipaddr("foo.bar.facebook.com", 8080)
             )
 
+    def test_network_ipv4(self) -> None:
+        with mock.patch(
+            "socket.getaddrinfo",
+            return_value=(
+                [
+                    (
+                        socket.AF_INET,
+                        socket.SOCK_STREAM,
+                        socket.IPPROTO_TCP,
+                        "",
+                        ("123.45.67.89", 8080),
+                    )
+                ]
+            ),
+        ):
+            self.assertEqual(
+                "123.45.67.89",
+                network.get_ipaddr("foo.bar.facebook.com", 8080, network.AddrType.IPv4),
+            )
+
     def test_network_ipv6(self) -> None:
         with mock.patch(
             "socket.getaddrinfo",
@@ -60,6 +80,10 @@ class TestNetwork(unittest.TestCase):
             self.assertEqual(
                 "1234:ab00:567c:89d:abcd:0:328:0",
                 network.get_ipaddr("foo.bar.facebook.com", 8080),
+            )
+            self.assertEqual(
+                "1234:ab00:567c:89d:abcd:0:328:0",
+                network.get_ipaddr("foo.bar.facebook.com", 8080, network.AddrType.IPv6),
             )
 
     def test_network(self) -> None:


### PR DESCRIPTION
Summary: lightning want a parameter so they can explicitly setup IPv4 address, rather than the current behavior, which is IPv6 first, and fallback on IPv4.

Differential Revision: D84949050


