### PR TITLE
Fix assert with undeliverable message from comm actor

### DIFF
--- a/hyperactor/src/mailbox.rs
+++ b/hyperactor/src/mailbox.rs
@@ -324,6 +324,13 @@ impl MessageEnvelope {
         self.errors.push(error)
     }
 
+    /// Change the sender on the envelope in case it was set incorrectly. This
+    /// should only be used by CommActor since it is forwarding from another
+    /// sender.
+    pub fn update_sender(&mut self, sender: ActorId) {
+        self.sender = sender;
+    }
+
     /// The message has been determined to be undeliverable with the
     /// provided error. Mark the envelope with the error and return to
     /// sender.


### PR DESCRIPTION
Summary:
This panic is very common due to the CommActor message forwarding which obscures
the return address.

When this happens, have a better message that also includes what the destination was
so people aren't confused.

Reviewed By: pablorfb-meta

Differential Revision: D84952942


