### PR TITLE
[monarch] Fix error tests in test_remote_functions

### DIFF
--- a/python/tests/test_remote_functions.py
+++ b/python/tests/test_remote_functions.py
@@ -24,9 +24,9 @@ from monarch.builtins.random import set_manual_seed_remote
 from monarch.cached_remote_function import remote_autograd_function
 from monarch.common import remote as remote_module
 from monarch.common.device_mesh import DeviceMesh, no_mesh
-from monarch.common.invocation import RemoteException
 from monarch.common.pipe import Pipe, remote_generator
 from monarch.common.remote import call_on_shard_and_fetch, Remote
+from monarch.mesh_controller import RemoteException
 
 from monarch.opaque_module import OpaqueModule
 from monarch.opaque_object import opaque_method, OpaqueObject


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #1607
* #1588
* #1572

D81635254 removed a line from `test_remote_functions` that ensured we were checking for the right type of remote exception, and subsequently broke several tests. This diff fixes that.

Differential Revision: [D84960018](https://our.internmc.facebook.com/intern/diff/D84960018/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D84960018/)!