### PR TITLE
: oss: install rpath that _rust_bindings.so dynamic link searches for libpython3.10.so.1.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ import os
 
 import shutil
 import subprocess
+import sys
 import sysconfig
 
 import torch
@@ -118,6 +119,42 @@ with open("requirements.txt") as f:
 
 with open("README.md", encoding="utf8") as f:
     readme = f.read()
+
+if sys.platform.startswith("linux"):
+    # Always include the active env's lib (Conda-safe)
+    conda_lib = os.path.join(sys.prefix, "lib")
+
+    ldlib = sysconfig.get_config_var("LDLIBRARY") or ""
+    libdir = sysconfig.get_config_var("LIBDIR") or ""
+    py_lib = ""
+    if libdir and ldlib:
+        cand = os.path.join(libdir, ldlib)
+        if os.path.exists(cand) and os.path.realpath(libdir) != os.path.realpath(
+            conda_lib
+        ):
+            py_lib = libdir
+
+    # Prefer sidecar .so next to the extension; then the conda env;
+    # then (optionally) py_lib
+    flags = [
+        "-C",
+        "link-arg=-Wl,--enable-new-dtags",
+        "-C",
+        "link-arg=-Wl,-z,origin",
+        "-C",
+        "link-arg=-Wl,-rpath,$ORIGIN",
+        "-C",
+        "link-arg=-Wl,-rpath,$ORIGIN/..",
+        "-C",
+        "link-arg=-Wl,-rpath,$ORIGIN/../../..",
+        "-C",
+        "link-arg=-Wl,-rpath," + conda_lib,
+    ]
+    if py_lib:
+        flags += ["-C", "link-arg=-Wl,-rpath," + py_lib]
+
+    cur = os.environ.get("RUSTFLAGS", "")
+    os.environ["RUSTFLAGS"] = (cur + " " + " ".join(flags)).strip()
 
 rust_extensions = [
     RustBin(


### PR DESCRIPTION
Summary: the goal is to inject an rpath into the `_rust_bindings.so`. we put `-C link-args=-Wl,-rpath,<dir>` into `RUST_FLAGS`.

Differential Revision: D84991141


