### PR TITLE
Enable two tests in OSS again

### DIFF
--- a/hyperactor_mesh/src/alloc/remoteprocess.rs
+++ b/hyperactor_mesh/src/alloc/remoteprocess.rs
@@ -779,8 +779,7 @@ impl RemoteProcessAlloc {
                 }
                 ChannelTransport::Tcp(TcpMode::Localhost) => {
                     // TODO: @rusch see about moving over to config for this
-                    let ip = IpAddr::V6(Ipv6Addr::LOCALHOST);
-                    format!("tcp!{}:{}", ip, self.remote_allocator_port)
+                    format!("tcp![::1]:{}", self.remote_allocator_port)
                 }
                 ChannelTransport::Tcp(TcpMode::Hostname) => {
                     format!("tcp!{}:{}", host.hostname, self.remote_allocator_port)

--- a/python/tests/test_allocator.py
+++ b/python/tests/test_allocator.py
@@ -606,8 +606,6 @@ class TestRemoteAllocator(unittest.IsolatedAsyncioTestCase):
                     AllocSpec(AllocConstraints(), host=1, gpu=1)
                 ).initialized
 
-    # Skipping test temporarily due to blocking OSS CI TODO: @rusch T232884876
-    @pytest.mark.oss_skip  # pyre-ignore[56]: Pyre cannot infer the type of this pytest marker
     async def test_torchx_remote_alloc_initializer_no_match_label_1_mesh(self) -> None:
         server = ServerSpec(
             name=UNUSED,
@@ -623,9 +621,11 @@ class TestRemoteAllocator(unittest.IsolatedAsyncioTestCase):
             ],
         )
         port = get_free_port()
+        os.environ["HYPERACTOR_REMOTE_ALLOC_BIND_TO_INADDR_ANY"] = "true"
 
         with remote_process_allocator(
             addr=f"tcp!{get_sockaddr('localhost', port)}",
+            envs={"HYPERACTOR_REMOTE_ALLOC_BIND_TO_INADDR_ANY": "true"},
         ):
             with mock.patch(SERVER_READY, return_value=server):
                 initializer = TorchXRemoteAllocInitializer("local:///test", port=port)
@@ -641,8 +641,6 @@ class TestRemoteAllocator(unittest.IsolatedAsyncioTestCase):
                 )
                 self.assert_computed_world_size(results, 4)  # 1x4 mesh
 
-    # Skipping test temporarily due to blocking OSS CI TODO: @rusch T232884876
-    @pytest.mark.oss_skip  # pyre-ignore[56]: Pyre cannot infer the type of this pytest marker
     async def test_torchx_remote_alloc_initializer_with_match_label(self) -> None:
         server = ServerSpec(
             name=UNUSED,
@@ -658,9 +656,11 @@ class TestRemoteAllocator(unittest.IsolatedAsyncioTestCase):
             ],
         )
         port = get_free_port()
+        os.environ["HYPERACTOR_REMOTE_ALLOC_BIND_TO_INADDR_ANY"] = "true"
 
         with remote_process_allocator(
             addr=f"tcp!{get_sockaddr('localhost', port)}",
+            envs={"HYPERACTOR_REMOTE_ALLOC_BIND_TO_INADDR_ANY": "true"},
         ):
             with mock.patch(SERVER_READY, return_value=server):
                 initializer = TorchXRemoteAllocInitializer("local:///test", port=port)


### PR DESCRIPTION
Summary:
This diff builds on the previous TcpMode::Localhost for fixing up these two tests by:
1) Use HYPERACTOR_REMOTE_ALLOC_BIND_TO_INADDR_ANY to handle CI not allowing binding to ::1
2) Fixing a rebase issue where I accidentally did tcp!::1:0 instead of tcp![::1]:0
3) Fixing an issue where allocate_nonblocking doesn't do a default bootstrap_cmd, which broke the tests before I could re-enable them internally

Differential Revision: D85018600


