### PR TITLE
Fix issues with two allocator tests

### DIFF
--- a/hyperactor_mesh/src/alloc/remoteprocess.rs
+++ b/hyperactor_mesh/src/alloc/remoteprocess.rs
@@ -9,9 +9,6 @@
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::collections::VecDeque;
-use std::net::IpAddr;
-use std::net::Ipv4Addr;
-use std::net::Ipv6Addr;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -779,8 +776,7 @@ impl RemoteProcessAlloc {
                 }
                 ChannelTransport::Tcp(TcpMode::Localhost) => {
                     // TODO: @rusch see about moving over to config for this
-                    let ip = IpAddr::V6(Ipv6Addr::LOCALHOST);
-                    format!("tcp!{}:{}", ip, self.remote_allocator_port)
+                    format!("tcp![::1]:{}", self.remote_allocator_port)
                 }
                 ChannelTransport::Tcp(TcpMode::Hostname) => {
                     format!("tcp!{}:{}", host.hostname, self.remote_allocator_port)

--- a/python/monarch/_src/actor/host_mesh.py
+++ b/python/monarch/_src/actor/host_mesh.py
@@ -24,6 +24,7 @@ from monarch._src.actor.proc_mesh import (
 from monarch._src.actor.shape import MeshTrait, NDSlice, Shape
 from monarch._src.actor.v1 import enabled as v1_enabled
 from monarch._src.actor.v1.host_mesh import (
+    _bootstrap_cmd,
     create_local_host_mesh as create_local_host_mesh_v1,
     fake_in_process_host as fake_in_process_host_v1,
     host_mesh_from_alloc as host_mesh_from_alloc_v1,

--- a/python/tests/test_allocator.py
+++ b/python/tests/test_allocator.py
@@ -42,7 +42,7 @@ from monarch._src.actor.allocator import (
     StaticRemoteAllocInitializer,
     TorchXRemoteAllocInitializer,
 )
-from monarch._src.actor.host_mesh import HostMesh
+from monarch._src.actor.host_mesh import _bootstrap_cmd, HostMesh
 from monarch._src.actor.proc_mesh import ProcMesh
 from monarch._src.actor.sync_state import fake_sync_state
 from monarch.actor import Actor, current_rank, current_size, endpoint, ValueMesh
@@ -63,7 +63,11 @@ def proc_mesh_from_alloc(
     constraints: Optional[AllocConstraints] = None,
 ) -> ProcMesh:
     return HostMesh.allocate_nonblocking(
-        "hosts", Extent(*zip(*list(spec.extent.items()))), allocator, constraints
+        "hosts",
+        Extent(*zip(*list(spec.extent.items()))),
+        allocator,
+        constraints,
+        bootstrap_cmd=_bootstrap_cmd(),
     ).spawn_procs(bootstrap=setup)
 
 


### PR DESCRIPTION
Summary:
Didn't get around to re-enabling CI for these two tests yet, so a change in bootstrap behavior had broken them. This fixes that. 

Additionally, one of the late stage refactors broke the remoteprocess invocation, where instead of `tcp!::1:0` it needed to be `tcp![::1]:0`

Fixing the tests for the Github CI tests in a follow up, as it needs both setting an ipv4 binding fallback, as well as using the new attribute for setting binding to unspecified.

Differential Revision: D85049463


