### PR TITLE
[monarch] Fix some broken tests

### DIFF
--- a/monarch_hyperactor/src/v1/logging.rs
+++ b/monarch_hyperactor/src/v1/logging.rs
@@ -98,8 +98,6 @@ impl LoggingMeshClient {
             })
             .map_err(anyhow::Error::from)?;
 
-            // FIXME: Flush on proc mesh stop.
-
             Ok(Self {
                 forwarder_mesh,
                 logger_mesh,

--- a/python/monarch/_src/actor/host_mesh.py
+++ b/python/monarch/_src/actor/host_mesh.py
@@ -24,6 +24,7 @@ from monarch._src.actor.proc_mesh import (
 from monarch._src.actor.shape import MeshTrait, NDSlice, Shape
 from monarch._src.actor.v1 import enabled as v1_enabled
 from monarch._src.actor.v1.host_mesh import (
+    _bootstrap_cmd,  # noqa
     create_local_host_mesh as create_local_host_mesh_v1,
     fake_in_process_host as fake_in_process_host_v1,
     host_mesh_from_alloc as host_mesh_from_alloc_v1,

--- a/python/monarch/_src/actor/v1/proc_mesh.py
+++ b/python/monarch/_src/actor/v1/proc_mesh.py
@@ -392,6 +392,7 @@ class ProcMesh(MeshTrait):
         instance = context().actor_instance._as_rust()
 
         async def _stop_nonblocking(instance: HyInstance) -> None:
+            await PythonTask.spawn_blocking(lambda: self._logging_manager.flush())
             await (await self._proc_mesh).stop_nonblocking(instance)
             self._stopped = True
 

--- a/python/tests/_monarch/test_sync_workspace.py
+++ b/python/tests/_monarch/test_sync_workspace.py
@@ -27,7 +27,7 @@ from monarch._src.actor.allocator import (
     RemoteAllocator,
     StaticRemoteAllocInitializer,
 )
-from monarch._src.actor.host_mesh import HostMesh
+from monarch._src.actor.host_mesh import _bootstrap_cmd, HostMesh
 
 from monarch._src.actor.proc_mesh import ProcMesh
 from monarch.tools.config.workspace import Workspace
@@ -108,6 +108,7 @@ class TestSyncWorkspace(unittest.IsolatedAsyncioTestCase):
                 Extent(["hosts", "gpus"], [1, 1]),
                 allocator,
                 AllocConstraints(),
+                _bootstrap_cmd(),
             )
 
             # local workspace dir is empty & remote workspace dir hasn't been primed yet


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #1627

Fix some tests that are broken internally due to various issues related to the v1 migration.

The only change that could impact other code is that there is now an explicit log flush on proc mesh stop.

Differential Revision: [D85108767](https://our.internmc.facebook.com/intern/diff/D85108767/)