### PR TITLE
fix the build revision parameter name

### DIFF
--- a/hyperactor_telemetry/src/lib.rs
+++ b/hyperactor_telemetry/src/lib.rs
@@ -665,7 +665,8 @@ pub fn initialize_logging_with_log_prefix(
             buck_rule = build_info::BuildInfo::get_rule(),
             package_name = build_info::BuildInfo::get_package_name(),
             package_release = build_info::BuildInfo::get_package_release(),
-            upstream_revision = build_info::BuildInfo::get_revision(),
+            upstream_revision = build_info::BuildInfo::get_upstream_revision(),
+            revision = build_info::BuildInfo::get_revision(),
             "logging_initialized"
         );
 


### PR DESCRIPTION
Summary:
Right now we log `BuildInfo::get_revision` as `upstream_revision`. This is wrong since there is another method `BuildInfo::get_upstream_revision`.

This diff corrects this.

Differential Revision: D85166428


