### PR TITLE
order async messages, provide workaround flag

### DIFF
--- a/monarch_hyperactor/src/config.rs
+++ b/monarch_hyperactor/src/config.rs
@@ -35,6 +35,9 @@ use crate::channel::PyChannelTransport;
 declare_attrs! {
     /// Use a single asyncio runtime for all Python actors, rather than one per actor
     pub attr SHARED_ASYNCIO_RUNTIME: bool = false;
+
+    /// Use old async workaround that spawns Python handler methods in tokio tasks
+    pub attr MONARCH_OLD_ASYNC_WORKAROUND: bool = false;
 }
 
 /// Python API for configuration management

--- a/python/monarch/_src/actor/actor_mesh.py
+++ b/python/monarch/_src/actor/actor_mesh.py
@@ -13,10 +13,12 @@ import functools
 import inspect
 import itertools
 import logging
+
+import os
 import threading
 from abc import abstractproperty
-
 from dataclasses import dataclass
+from functools import cache
 from pprint import pformat
 from textwrap import indent
 from traceback import TracebackException
@@ -211,6 +213,11 @@ _context: contextvars.ContextVar[Context] = contextvars.ContextVar(
 )
 
 T = TypeVar("T")
+
+
+@cache
+def _old_async_workaround():
+    return os.environ.get("MONARCH_OLD_ASYNC_WORKAROUND", "0") != "0"
 
 
 class _Lazy(Generic[T]):
@@ -1141,7 +1148,7 @@ class ActorMesh(MeshTrait, Generic[T]):
                 else:
                     sync_endpoints.append(attr_name)
 
-        if sync_endpoints and async_endpoints:
+        if (sync_endpoints and async_endpoints) and not _old_async_workaround():
             raise ValueError(
                 f"{self._class} mixes both async and sync endpoints."
                 "Synchronous endpoints cannot be mixed with async endpoints because they can cause the asyncio loop to deadlock if they wait."


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #1636
* #1626

Having async messages run in parallel by default is confusing. It used to be the fact that there would be no way to delay a message response without async behaving out of order. We now have the ability, via explicit_response_port=True, to choose to defer when to respond to a message. This lets you just create_task to parallelize message handling. This adds a workaround flag just in case we need to keep someone internally on the old behavior.

Differential Revision: [D85172238](https://our.internmc.facebook.com/intern/diff/D85172238/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D85172238/)!