### PR TITLE
Add unhandled supervision error hook to crash the client

### DIFF
--- a/python/monarch/_src/actor/supervision.py
+++ b/python/monarch/_src/actor/supervision.py
@@ -1,0 +1,27 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import logging
+import sys
+
+from monarch._rust_bindings.monarch_hyperactor.supervision import MeshFailure
+
+_logger: logging.Logger = logging.getLogger(__name__)
+
+
+def unhandled_fault_hook(failure: MeshFailure) -> None:
+    """When a supervision event is unhandled and is propagated back to the client,
+    this hook is called.
+    The default implementation is to exit the process after logging
+    the event.
+    Assign to this function to change the behavior.
+    Single argument is the SupervisionEvent
+    """
+
+    _logger.error(f"Unhandled mesh failure, crashing! {failure}")
+    sys.exit(1)

--- a/python/monarch/actor/__init__.py
+++ b/python/monarch/actor/__init__.py
@@ -12,8 +12,8 @@ Monarch Actor API - Public interface for actor functionality.
 from typing import TYPE_CHECKING
 
 from monarch._rust_bindings.monarch_hyperactor.channel import ChannelTransport
-
 from monarch._rust_bindings.monarch_hyperactor.shape import Extent
+from monarch._rust_bindings.monarch_hyperactor.supervision import MeshFailure
 from monarch._src.actor.actor_mesh import (
     Accumulator,
     Actor,
@@ -37,6 +37,7 @@ from monarch._src.actor.bootstrap import attach_to_workers, run_worker_loop_fore
 from monarch._src.actor.debugger.debug_controller import debug_controller
 from monarch._src.actor.endpoint import endpoint
 from monarch._src.actor.future import Future
+from monarch._src.actor.supervision import unhandled_fault_hook
 
 from monarch._src.actor.v1 import enabled as v1_enabled
 
@@ -105,4 +106,6 @@ __all__ = [
     "enable_transport",
     "Context",
     "ChannelTransport",
+    "unhandled_fault_hook",
+    "MeshFailure",
 ]

--- a/python/tests/test_allocator.py
+++ b/python/tests/test_allocator.py
@@ -21,8 +21,8 @@ from typing import Generator, Optional
 from unittest import mock
 
 import cloudpickle
+import monarch.actor
 import pytest
-
 import torch
 import torch.distributed as dist
 import torch.nn.functional as F
@@ -246,6 +246,9 @@ class TestRemoteAllocator(unittest.IsolatedAsyncioTestCase):
         self.assertDictEqual(expected_world_sizes, computed_world_sizes)
 
     async def test_allocate_failure_message(self) -> None:
+        # This will generate a supervision failure, and we don't want to crash
+        # the test process.
+        monarch.actor.unhandled_fault_hook = lambda failure: None
         spec = AllocSpec(AllocConstraints(), host=2, gpu=4)
 
         with self.assertRaisesRegex(

--- a/python/tests/test_env_before_cuda.py
+++ b/python/tests/test_env_before_cuda.py
@@ -12,7 +12,7 @@ import unittest
 from typing import Dict, List
 
 import cloudpickle
-
+import monarch.actor
 import torch
 from monarch._src.actor.host_mesh import create_local_host_mesh, fake_in_process_host
 from monarch.actor import Actor, endpoint
@@ -132,6 +132,7 @@ class TestEnvBeforeCuda(unittest.IsolatedAsyncioTestCase):
             "CUDA_DEVICE_MAX_CONNECTIONS": "1",
         }
 
+        monarch.actor.unhandled_fault_hook = lambda failure: None
         proc_mesh_instance = create_local_host_mesh(env=cuda_env_vars).spawn_procs()
 
         try:

--- a/python/tests/test_proc_mesh.py
+++ b/python/tests/test_proc_mesh.py
@@ -14,7 +14,7 @@ from unittest.mock import MagicMock, patch
 
 import cloudpickle
 import monarch._src.actor.host_mesh
-
+import monarch.actor
 import pytest
 from monarch._rust_bindings.monarch_hyperactor.alloc import AllocConstraints, AllocSpec
 from monarch._rust_bindings.monarch_hyperactor.pytokio import PythonTask
@@ -167,6 +167,7 @@ def test_nested_meshes() -> None:
 
 @pytest.mark.timeout(60)
 async def test_pickle_initialized_proc_mesh_in_tokio_thread() -> None:
+    monarch.actor.unhandled_fault_hook = lambda failure: None
     host = create_local_host_mesh(Extent(["hosts"], [2]))
     proc = host.spawn_procs(per_host={"gpus": 2})
 


### PR DESCRIPTION
Summary:
Part of https://github.com/meta-pytorch/monarch/issues/1209

Make two variants of the "actor_states_monitor" watchdog. One version for Owned ActorMesh,
which will send a message to the owner if it exists, and one version for Ref ActorMesh which will
not. This way, Ref actor meshes will generate liveness exceptions without propagation, and Owned
actor meshes will send a SupervisionFailureMessage to its owning actor. Since every Owned mesh
is also doing this, events will always reach the client if they aren't handled.

Add a `monarch.actor.unhandled_fault_hook` function which is called when an unhandled supervision
error reaches the client. It takes one argument, a SupervisionError exception object, and is expected
to somehow halt the process. By default it calls `sys.exit(1)` after logging the error.
Raising an exception is not sufficient, as it is called outside of a Python thread (by a tokio task).

Note that propagation will not happen if an ActorMesh and all endpoints are unreachable and garbage
collected, but the actors are still running something that generates an error. We'll want to fix this
eventually.

Reviewed By: mariusae

Differential Revision: D85163744


