### PR TITLE
Fix broken test_allocator::test_setup_lambda_with_multiple_env_vars

### DIFF
--- a/python/tests/test_allocator.py
+++ b/python/tests/test_allocator.py
@@ -173,6 +173,8 @@ class TestSetupActorInAllocator(unittest.IsolatedAsyncioTestCase):
             "TEST_ENV_VAR_2": "value_2",
             "TEST_ENV_VAR_3": "value_3",
         }
+        # If the proc mesh is stopped, don't crash the process.
+        monarch.actor.unhandled_fault_hook = lambda failure: None
 
         def setup_multiple_env_vars() -> None:
             for name, value in env_vars.items():
@@ -326,6 +328,7 @@ class TestRemoteAllocator(unittest.IsolatedAsyncioTestCase):
 
     @pytest.mark.oss_skip  # pyre-ignore[56]: Pyre cannot infer the type of this pytest marker
     async def test_allocate_2d_mesh(self) -> None:
+        monarch.actor.unhandled_fault_hook = lambda failure: None
         hosts = 2
         gpus = 4
         world_size = hosts * gpus
@@ -347,8 +350,8 @@ class TestRemoteAllocator(unittest.IsolatedAsyncioTestCase):
 
             self.assert_computed_world_size(values, world_size)
 
-    @pytest.mark.skip("stop proc mesh not supported yet in v1")
     async def test_stop_proc_mesh_blocking(self) -> None:
+        monarch.actor.unhandled_fault_hook = lambda failure: None
         spec = AllocSpec(AllocConstraints(), host=2, gpu=4)
         with remote_process_allocator() as host1, remote_process_allocator() as host2:
             allocator = RemoteAllocator(
@@ -543,6 +546,7 @@ class TestRemoteAllocator(unittest.IsolatedAsyncioTestCase):
 
     @pytest.mark.oss_skip  # pyre-ignore[56]: Pyre cannot infer the type of this pytest marker
     async def test_stacked_1d_meshes(self) -> None:
+        monarch.actor.unhandled_fault_hook = lambda failure: None
         # create two stacked actor meshes on the same host
         # each actor mesh running on separate process-allocators
 


### PR DESCRIPTION
Summary:
This test fails flakily every so often with a process crash because the proc mesh fails and
the failure reaches the client.
It's not relevant to the test, so turn off the process crash

Differential Revision: D85255590


