### PR TITLE
rustfmt update

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,6 +1,6 @@
 # Get help on options with `rustfmt --help=config`
 # Please keep these in alphabetical order.
-edition = "2021"
+edition = "2024"
 format_code_in_doc_comments = true
 group_imports = "StdExternalCrate"
 imports_granularity = "Item"


### PR DESCRIPTION
Summary:
update rustfmt to match 1.90.0 cut.

Fixed formatting issues by updating project's rustfmt.toml or updating code.

Reviewed By: dtolnay

Differential Revision: D84213462
