### PR TITLE
Add labels to links

### DIFF
--- a/controller/src/lib.rs
+++ b/controller/src/lib.rs
@@ -1131,7 +1131,7 @@ mod tests {
 
         // Construct a system sender.
         let system_sender = BoxedMailboxSender::new(MailboxClient::new(
-            channel::dial(server_handle.local_addr().clone()).unwrap(),
+            channel::dial(server_handle.local_addr().clone(), "test".to_string()).unwrap(),
         ));
 
         // Construct a proc forwarder in terms of the system sender.
@@ -1360,7 +1360,7 @@ mod tests {
 
         // Construct a system sender.
         let system_sender = BoxedMailboxSender::new(MailboxClient::new(
-            channel::dial(server_handle.local_addr().clone()).unwrap(),
+            channel::dial(server_handle.local_addr().clone(), "test".to_string()).unwrap(),
         ));
 
         // Construct a proc forwarder in terms of the system sender.
@@ -1572,8 +1572,11 @@ mod tests {
         let world_id = id!(world);
         // Set up a local actor.
         let local_proc_id = world_id.proc_id(rank);
-        let (local_proc_addr, local_proc_rx) =
-            channel::serve(ChannelAddr::any(ChannelTransport::Local)).unwrap();
+        let (local_proc_addr, local_proc_rx) = channel::serve(
+            ChannelAddr::any(ChannelTransport::Local),
+            "test".to_string(),
+        )
+        .unwrap();
         let local_proc_mbox = Mailbox::new_detached(
             local_proc_id.actor_id(format!("test_dummy_proc{}", idx).to_string(), 0),
         );

--- a/hyperactor/benches/main.rs
+++ b/hyperactor/benches/main.rs
@@ -87,8 +87,8 @@ fn bench_message_sizes(c: &mut Criterion) {
                         assert!(!socket_addr.ip().is_loopback());
                     }
 
-                    let (listen_addr, mut rx) = serve::<Message>(addr).unwrap();
-                    let tx = dial::<Message>(listen_addr).unwrap();
+                    let (listen_addr, mut rx) = serve::<Message>(addr, "".to_string()).unwrap();
+                    let tx = dial::<Message>(listen_addr, "".to_string()).unwrap();
                     let msg = Message::new(0, size);
                     let start = Instant::now();
                     for _ in 0..iters {
@@ -127,7 +127,8 @@ fn bench_message_rates(c: &mut Criterion) {
                 b.iter_custom(|iters| async move {
                     let total_msgs = iters * rate;
                     let addr = ChannelAddr::any(transport.clone());
-                    let (listen_addr, mut rx) = serve::<Message>(addr).unwrap();
+                    let (listen_addr, mut rx) =
+                        serve::<Message>(addr, "bench".to_string()).unwrap();
                     tokio::spawn(async move {
                         let mut received_count = 0;
 
@@ -141,7 +142,7 @@ fn bench_message_rates(c: &mut Criterion) {
                         }
                     });
 
-                    let tx = dial::<Message>(listen_addr).unwrap();
+                    let tx = dial::<Message>(listen_addr, "".to_string()).unwrap();
                     let message = Message::new(0, payload_size);
                     let start = Instant::now();
 
@@ -212,13 +213,15 @@ async fn channel_ping_pong(
     struct Message(Part);
 
     let (client_addr, mut client_rx) =
-        channel::serve::<Message>(ChannelAddr::any(transport.clone())).unwrap();
+        channel::serve::<Message>(ChannelAddr::any(transport.clone()), "client".to_string())
+            .unwrap();
     let (server_addr, mut server_rx) =
-        channel::serve::<Message>(ChannelAddr::any(transport.clone())).unwrap();
+        channel::serve::<Message>(ChannelAddr::any(transport.clone()), "server".to_string())
+            .unwrap();
 
     let _server_handle: tokio::task::JoinHandle<Result<(), anyhow::Error>> =
         tokio::spawn(async move {
-            let client_tx = channel::dial(client_addr)?;
+            let client_tx = channel::dial(client_addr, "client".to_string())?;
             loop {
                 let message = server_rx.recv().await?;
                 client_tx.post(message);
@@ -227,7 +230,7 @@ async fn channel_ping_pong(
 
     let client_handle: tokio::task::JoinHandle<Result<(), anyhow::Error>> =
         tokio::spawn(async move {
-            let server_tx = channel::dial(server_addr)?;
+            let server_tx = channel::dial(server_addr, "server".to_string())?;
             let message = Message(Part::from(vec![0u8; message_size]));
             for _ in 0..num_iter {
                 server_tx.post(message.clone() /*cheap */);

--- a/hyperactor/src/channel/sim.rs
+++ b/hyperactor/src/channel/sim.rs
@@ -231,7 +231,7 @@ pub struct SimDispatcher {
 fn create_egress_sender(
     addr: ChannelAddr,
 ) -> anyhow::Result<Arc<dyn Tx<MessageEnvelope> + Send + Sync>> {
-    let tx = channel::dial(addr)?;
+    let tx = channel::dial(addr, "sim-egress".to_string())?;
     Ok(Arc::new(tx))
 }
 

--- a/hyperactor/src/host.rs
+++ b/hyperactor/src/host.rs
@@ -135,7 +135,7 @@ impl<M: ProcManager> Host<M> {
         manager: M,
         addr: ChannelAddr,
     ) -> Result<(Self, MailboxServerHandle), HostError> {
-        let (frontend_addr, frontend_rx) = channel::serve(addr)?;
+        let (frontend_addr, frontend_rx) = channel::serve(addr, "host-frontend".to_string())?;
 
         // We set up a cascade of routers: first, the outer router supports
         // sending to the the system proc, while the dial router manages dialed
@@ -144,7 +144,10 @@ impl<M: ProcManager> Host<M> {
 
         // Establish a backend channel on the preferred transport. We currently simply
         // serve the same router on both.
-        let (backend_addr, backend_rx) = channel::serve(ChannelAddr::any(manager.transport()))?;
+        let (backend_addr, backend_rx) = channel::serve(
+            ChannelAddr::any(manager.transport()),
+            "host-backend".to_string(),
+        )?;
 
         // Set up a system proc. This is often used to manage the host itself.
         let service_proc_id = ProcId::Direct(frontend_addr.clone(), "service".to_string());
@@ -865,7 +868,10 @@ where
             proc_id.clone(),
             MailboxClient::dial(forwarder_addr)?.into_boxed(),
         );
-        let (proc_addr, rx) = channel::serve(ChannelAddr::any(transport))?;
+        let (proc_addr, rx) = channel::serve(
+            ChannelAddr::any(transport),
+            format!("local-proc-{}", proc_id),
+        )?;
         self.procs
             .lock()
             .await
@@ -1036,8 +1042,10 @@ where
         forwarder_addr: ChannelAddr,
         _config: (),
     ) -> Result<Self::Handle, HostError> {
-        let (callback_addr, mut callback_rx) =
-            channel::serve(ChannelAddr::any(ChannelTransport::Unix))?;
+        let (callback_addr, mut callback_rx) = channel::serve(
+            ChannelAddr::any(ChannelTransport::Unix),
+            format!("proc-spawn-callback-{}", proc_id),
+        )?;
 
         let mut cmd = Command::new(&self.program);
         cmd.env("HYPERACTOR_HOST_PROC_ID", proc_id.to_string());
@@ -1144,13 +1152,16 @@ where
 
     let agent_handle = spawn(proc.clone())
         .await
-        .map_err(|e| HostError::AgentSpawnFailure(proc_id, e))?;
+        .map_err(|e| HostError::AgentSpawnFailure(proc_id.clone(), e))?;
 
     // Finally serve the proc on the same transport as the backend address,
     // and call back.
-    let (proc_addr, proc_rx) = channel::serve(ChannelAddr::any(backend_transport))?;
+    let (proc_addr, proc_rx) = channel::serve(
+        ChannelAddr::any(backend_transport),
+        format!("proc-backend-{}", proc_id),
+    )?;
     proc.clone().serve(proc_rx);
-    channel::dial(callback_addr)?
+    channel::dial(callback_addr, "proc-callback".to_string())?
         .send((proc_addr, agent_handle.bind::<A>()))
         .await
         .map_err(ChannelError::from)?;

--- a/hyperactor/src/proc.rs
+++ b/hyperactor/src/proc.rs
@@ -334,7 +334,7 @@ impl Proc {
 
     /// Create a new direct-addressed proc.
     pub async fn direct(addr: ChannelAddr, name: String) -> Result<Self, ChannelError> {
-        let (addr, rx) = channel::serve(addr)?;
+        let (addr, rx) = channel::serve(addr, "proc-direct".to_string())?;
         let proc_id = ProcId::Direct(addr, name);
         let proc = Self::new(proc_id, DialMailboxRouter::new().into_boxed());
         proc.clone().serve(rx);
@@ -347,7 +347,7 @@ impl Proc {
         name: String,
         default: BoxedMailboxSender,
     ) -> Result<Self, ChannelError> {
-        let (addr, rx) = channel::serve(addr)?;
+        let (addr, rx) = channel::serve(addr, "proc-direct-default".to_string())?;
         let proc_id = ProcId::Direct(addr, name);
         let proc = Self::new(
             proc_id,

--- a/hyperactor_mesh/src/actor_mesh.rs
+++ b/hyperactor_mesh/src/actor_mesh.rs
@@ -1702,7 +1702,7 @@ mod tests {
             type Params = ChannelAddr;
 
             async fn new(params: ChannelAddr) -> Result<Self, anyhow::Error> {
-                Ok(Self(dial::<usize>(params)?))
+                Ok(Self(dial::<usize>(params, "test".to_string())?))
             }
         }
 
@@ -1730,7 +1730,7 @@ mod tests {
             let config = hyperactor::config::global::lock();
             let _guard = config.override_key(MAX_CAST_DIMENSION_SIZE, 2);
 
-            let (_, mut rx) = serve::<usize>(addr).unwrap();
+            let (_, mut rx) = serve::<usize>(addr, "test".to_string()).unwrap();
 
             let expected_ranks = selection
                 .eval(

--- a/hyperactor_mesh/src/alloc.rs
+++ b/hyperactor_mesh/src/alloc.rs
@@ -551,7 +551,7 @@ impl AllocAssignedAddr {
             }
         };
 
-        let (mut bound, rx) = channel::serve(bind_to)?;
+        let (mut bound, rx) = channel::serve(bind_to, "alloc-assigned-addr".to_string())?;
 
         // Restore the original IP address if we used INADDR_ANY.
         match &mut bound {
@@ -836,13 +836,14 @@ pub(crate) mod testing {
         transport: ChannelTransport,
     ) -> (DialMailboxRouter, Instance<()>, Proc, ChannelAddr) {
         let (router_channel_addr, router_rx) =
-            channel::serve(ChannelAddr::any(transport.clone())).unwrap();
+            channel::serve(ChannelAddr::any(transport.clone()), "test".to_string()).unwrap();
         let router =
             DialMailboxRouter::new_with_default((UndeliverableMailboxSender {}).into_boxed());
         router.clone().serve(router_rx);
 
         let client_proc_id = ProcId::Ranked(WorldId("test_stuck".to_string()), 0);
-        let (client_proc_addr, client_rx) = channel::serve(ChannelAddr::any(transport)).unwrap();
+        let (client_proc_addr, client_rx) =
+            channel::serve(ChannelAddr::any(transport), "test".to_string()).unwrap();
         let client_proc = Proc::new(
             client_proc_id.clone(),
             BoxedMailboxSender::new(router.clone()),

--- a/hyperactor_mesh/src/alloc/local.rs
+++ b/hyperactor_mesh/src/alloc/local.rs
@@ -147,7 +147,10 @@ impl Alloc for LocalAlloc {
             match self.todo_rx.recv().await? {
                 Action::Start(rank) => {
                     let (addr, proc_rx) = loop {
-                        match channel::serve(ChannelAddr::any(self.transport())) {
+                        match channel::serve(
+                            ChannelAddr::any(self.transport()),
+                            "local-alloc".to_string(),
+                        ) {
                             Ok(addr_and_proc_rx) => break addr_and_proc_rx,
                             Err(err) => {
                                 tracing::error!(

--- a/hyperactor_mesh/src/alloc/process.rs
+++ b/hyperactor_mesh/src/alloc/process.rs
@@ -89,8 +89,11 @@ impl Allocator for ProcessAllocator {
 
     #[hyperactor::instrument(fields(name = "process_allocate", monarch_client_trace_id = spec.constraints.match_labels.get(CLIENT_TRACE_ID_LABEL).cloned().unwrap_or_else(|| "".to_string())))]
     async fn allocate(&mut self, spec: AllocSpec) -> Result<ProcessAlloc, AllocatorError> {
-        let (bootstrap_addr, rx) = channel::serve(ChannelAddr::any(ChannelTransport::Unix))
-            .map_err(anyhow::Error::from)?;
+        let (bootstrap_addr, rx) = channel::serve(
+            ChannelAddr::any(ChannelTransport::Unix),
+            "process-alloc".to_string(),
+        )
+        .map_err(anyhow::Error::from)?;
 
         if spec.transport == ChannelTransport::Local {
             return Err(AllocatorError::Other(anyhow::anyhow!(
@@ -292,7 +295,7 @@ impl Child {
             return false;
         }
 
-        match channel::dial(addr) {
+        match channel::dial(addr, "process-alloc".to_string()) {
             Ok(channel) => {
                 let mut status = channel.status().clone();
                 self.channel = ChannelState::Connected(channel);

--- a/hyperactor_mesh/src/proc_mesh.rs
+++ b/hyperactor_mesh/src/proc_mesh.rs
@@ -314,8 +314,11 @@ impl ProcMesh {
         //    everything else, so now the whole mesh should be able to communicate.
         let client_proc_id =
             ProcId::Ranked(WorldId(format!("{}_client", alloc.world_id().name())), 0);
-        let (client_proc_addr, client_rx) = channel::serve(ChannelAddr::any(alloc.transport()))
-            .map_err(|err| AllocatorError::Other(err.into()))?;
+        let (client_proc_addr, client_rx) = channel::serve(
+            ChannelAddr::any(alloc.transport()),
+            "proc-mesh-client".to_string(),
+        )
+        .map_err(|err| AllocatorError::Other(err.into()))?;
         tracing::info!(
             name = "ProcMesh::Allocate::ChannelServe",
             alloc_id = alloc_id,

--- a/hyperactor_mesh/src/proc_mesh/mesh_agent.rs
+++ b/hyperactor_mesh/src/proc_mesh/mesh_agent.rs
@@ -309,7 +309,7 @@ impl MeshAgentMessageHandler for ProcMeshAgent {
 
         // Wire up the local proc to the global (process) router. This ensures that child
         // meshes are reachable from any actor created by this mesh.
-        let client = MailboxClient::new(channel::dial(forwarder)?);
+        let client = MailboxClient::new(channel::dial(forwarder, "mesh-agent".to_string())?);
 
         // `HYPERACTOR_MESH_ROUTER_CONFIG_NO_GLOBAL_FALLBACK` may be
         // set as a means of failure injection in the testing of

--- a/hyperactor_mesh/src/router.rs
+++ b/hyperactor_mesh/src/router.rs
@@ -63,7 +63,7 @@ impl Router {
             return Ok(addr.clone());
         }
 
-        let (addr, rx) = channel::serve(ChannelAddr::any(transport.clone()))?;
+        let (addr, rx) = channel::serve(ChannelAddr::any(transport.clone()), "router".to_string())?;
         self.router.clone().serve(rx);
         servers.insert(transport.clone(), addr.clone());
         Ok(addr)

--- a/hyperactor_mesh/src/v1/proc_mesh.rs
+++ b/hyperactor_mesh/src/v1/proc_mesh.rs
@@ -296,7 +296,8 @@ impl ProcMesh {
         let proc = cx.instance().proc();
 
         // First make sure we can serve the proc:
-        let (proc_channel_addr, rx) = channel::serve(ChannelAddr::any(alloc.transport()))?;
+        let (proc_channel_addr, rx) =
+            channel::serve(ChannelAddr::any(alloc.transport()), "proc-mesh".to_string())?;
         proc.clone().serve(rx);
 
         let bind_allocated_procs = |router: &DialMailboxRouter| {

--- a/hyperactor_mesh/test/remote_process_alloc.rs
+++ b/hyperactor_mesh/test/remote_process_alloc.rs
@@ -72,7 +72,7 @@ async fn main() {
     );
     let mut allocs = Vec::new();
 
-    let pid_tx = channel::dial(args.pid_addr.parse().unwrap()).unwrap();
+    let pid_tx = channel::dial(args.pid_addr.parse().unwrap(), "test".to_string()).unwrap();
     for proc_num in 0..num_proc_meshes {
         let mut initializer = MockRemoteProcessAllocInitializer::new();
 
@@ -116,9 +116,12 @@ async fn main() {
         allocs.push(alloc);
     }
 
-    channel::dial(args.done_allocating_addr.parse().unwrap())
-        .unwrap()
-        .post(());
+    channel::dial(
+        args.done_allocating_addr.parse().unwrap(),
+        "test".to_string(),
+    )
+    .unwrap()
+    .post(());
 
     RealClock.sleep(Duration::from_secs(100)).await;
 }

--- a/hyperactor_multiprocess/src/proc_actor.rs
+++ b/hyperactor_multiprocess/src/proc_actor.rs
@@ -384,8 +384,10 @@ impl ProcActor {
         labels: HashMap<String, String>,
         lifecycle_mode: ProcLifecycleMode,
     ) -> Result<BootstrappedProc, anyhow::Error> {
-        let system_sender =
-            BoxedMailboxSender::new(MailboxClient::new(channel::dial(bootstrap_addr.clone())?));
+        let system_sender = BoxedMailboxSender::new(MailboxClient::new(channel::dial(
+            bootstrap_addr.clone(),
+            "proc-bootstrap".to_string(),
+        )?));
         let clock = ClockKind::for_channel_addr(&listen_addr);
 
         let proc_forwarder =
@@ -418,7 +420,7 @@ impl ProcActor {
         labels: HashMap<String, String>,
         lifecycle_mode: ProcLifecycleMode,
     ) -> Result<BootstrappedProc, anyhow::Error> {
-        let (local_addr, rx) = channel::serve(listen_addr)?;
+        let (local_addr, rx) = channel::serve(listen_addr, "proc-bootstrap".to_string())?;
         let mailbox_handle = proc.clone().serve(rx);
         let (state_tx, mut state_rx) = watch::channel(ProcState::AwaitingJoin);
 
@@ -1392,7 +1394,11 @@ mod tests {
 
         // Construct a system sender.
         let system_sender = BoxedMailboxSender::new(MailboxClient::new(
-            channel::dial(server_handle.local_addr().clone()).unwrap(),
+            channel::dial(
+                server_handle.local_addr().clone(),
+                "proc-bootstrap".to_string(),
+            )
+            .unwrap(),
         ));
 
         // Construct a proc forwarder in terms of the system sender.
@@ -1515,7 +1521,7 @@ mod tests {
 
         // Construct a system sender.
         let system_sender = BoxedMailboxSender::new(MailboxClient::new(
-            channel::dial(server_handle.local_addr().clone()).unwrap(),
+            channel::dial(server_handle.local_addr().clone(), "".to_string()).unwrap(),
         ));
 
         // Construct a proc forwarder in terms of the system sender.

--- a/hyperactor_multiprocess/src/system_actor.rs
+++ b/hyperactor_multiprocess/src/system_actor.rs
@@ -1877,8 +1877,11 @@ mod tests {
             WorldId(format!("{}{}", SHADOW_PREFIX, proc_world_id.name())),
             host_id,
         );
-        let (local_proc_addr, local_proc_rx) =
-            channel::serve::<MessageEnvelope>(ChannelAddr::any(ChannelTransport::Local)).unwrap();
+        let (local_proc_addr, local_proc_rx) = channel::serve::<MessageEnvelope>(
+            ChannelAddr::any(ChannelTransport::Local),
+            "".to_string(),
+        )
+        .unwrap();
         let local_proc_mbox = Mailbox::new_detached(local_proc_id.actor_id("test".to_string(), 0));
         let (local_proc_message_port, local_proc_message_receiver) = local_proc_mbox.open_port();
         let _local_proc_serve_handle = local_proc_mbox.clone().serve(local_proc_rx);
@@ -2245,7 +2248,7 @@ mod tests {
 
         // Construct a system sender.
         let system_sender = BoxedMailboxSender::new(MailboxClient::new(
-            channel::dial(server_handle.local_addr().clone()).unwrap(),
+            channel::dial(server_handle.local_addr().clone(), "test".to_string()).unwrap(),
         ));
         // Construct a proc forwarder in terms of the system sender.
         let proc_forwarder =
@@ -2384,7 +2387,8 @@ mod tests {
         let src_id = id!(proc[0].actor);
         let src_addr = ChannelAddr::Sim(SimAddr::new("unix!@src".parse().unwrap()).unwrap());
         let dst_addr = ChannelAddr::Sim(SimAddr::new("unix!@dst".parse().unwrap()).unwrap());
-        let (_, mut rx) = channel::serve::<MessageEnvelope>(src_addr.clone()).unwrap();
+        let (_, mut rx) =
+            channel::serve::<MessageEnvelope>(src_addr.clone(), "".to_string()).unwrap();
 
         let router = ReportingRouter::new();
 

--- a/monarch_hyperactor/src/proc.rs
+++ b/monarch_hyperactor/src/proc.rs
@@ -192,7 +192,7 @@ impl PyProc {
         } else {
             ChannelAddr::any(bootstrap_addr.transport())
         };
-        let chan = channel::dial(bootstrap_addr.clone())?;
+        let chan = channel::dial(bootstrap_addr.clone(), format!("py-bootstrap-{}", proc_id))?;
         let system_sender = BoxedMailboxSender::new(MailboxClient::new(chan));
         let proc_forwarder =
             BoxedMailboxSender::new(DialMailboxRouter::new_with_default(system_sender));


### PR DESCRIPTION
Summary:
Changes the signature of `ChannelAddr::serve` and `ChannelAddr::dial` to include a label.

Label is marked as a required argument, hence the changes in so many files, but main change is in `net.rs` and `channel.rs`

Logs sample:

```
[1] listen host-frontend-unix:CIP0z4kzu05gPBSlpQ2dxh3D: new connection from unix:(unnamed)
[0] listen bootstrap-spawn-unix:AE7MIE3IMaJGgpOIFkpFGcdw: new connection from unix:(unnamed)
[0] stopping server: [bootstrap-spawn]unix:AE7MIE3IMaJGgpOIFkpFGcdw; reason: NetRx dropped; channel address: unix:AE7MIE3IMaJGgpOIFkpFGcdw
[0] serve unix:AE7MIE3IMaJGgpOIFkpFGcdw-bootstrap-spawn: received parent token cancellation
[0]: session unix:AE7MIE3IMaJGgpOIFkpFGcdw[bootstrap-spawn].12230889822276986604<-unix:(unnamed): NetRx::process exited its loop with states: initial Next was (seq: 0, ack: 0); final Next is (seq: 1, ack: 0); since acked: 0sec; rcv raw frame count is 1; final result: Ok(())
[0]: session [proc-callback]unix:AE7MIE3IMaJGgpOIFkpFGcdw.12230889822276986604: NetTx exited its loop with state: Running(deliveries: (outbox: (next_seq: 1, deque: []), unacked: (deque: [], largest_acked: (seq=0, since_acked=0sec))), reason: NetTx is dropped)
```

Differential Revision: D85192987


