### PR TITLE
Hook up pytest results for publishing on each Github Action

### DIFF
--- a/scripts/common-setup.sh
+++ b/scripts/common-setup.sh
@@ -167,6 +167,7 @@ setup_test_environment() {
 # between runs.
 run_test_groups() {
   set +e
+  local test_results_dir="${RUNNER_TEST_RESULTS_DIR:-test-results}"
   local enable_actor_error_test="${2:-0}"
   # Validate argument enable_actor_error_test
   if [[ "$enable_actor_error_test" != "0" && "$enable_actor_error_test" != "1" ]]; then
@@ -186,6 +187,7 @@ run_test_groups() {
             --ignore-glob="**/meta/**" \
             --dist=no \
             --group="$GROUP" \
+            --junit-xml="$test_results_dir/test-results-$GROUP.xml" \
             --splits=10
     else
         LC_ALL=C pytest python/tests/ -s -v -m "not oss_skip" \
@@ -193,6 +195,7 @@ run_test_groups() {
             --dist=no \
             --ignore=python/tests/test_actor_error.py \
             --group="$GROUP" \
+            --junit-xml="$test_results_dir/test-results-$GROUP.xml" \
             --splits=10
     fi
     # Check result and record failures


### PR DESCRIPTION
Summary:
The pytorch test-infra jobs already support submitting test reports for display on a job.
This can improve the user experience when there's a problem with the CI.

Right now this is just for python tests, but cargo also supports the JUnit xml format, so we
can add that later too.

Differential Revision: D85294258


