### PR TITLE
[hyperactor] mesh: HostMesh::process, test_bench

### DIFF
--- a/hyperactor_mesh/examples/dining_philosophers.rs
+++ b/hyperactor_mesh/examples/dining_philosophers.rs
@@ -23,6 +23,7 @@ use hyperactor::Named;
 use hyperactor::PortRef;
 use hyperactor::Unbind;
 use hyperactor::context;
+use hyperactor_mesh::bootstrap::BootstrapCommand;
 use hyperactor_mesh::comm::multicast::CastInfo;
 use hyperactor_mesh::extent;
 use hyperactor_mesh::proc_mesh::global_root_client;
@@ -233,6 +234,12 @@ impl Waiter {
 #[tokio::main]
 async fn main() -> Result<ExitCode> {
     hyperactor_telemetry::initialize_logging_for_test();
+
+    // Option: run as a local process mesh
+    // let host_mesh = HostMesh::process(extent!(hosts = 1), BootstrapCommand::current().unwrap())
+    //     .await
+    //     .unwrap();
+
     let host_mesh = HostMesh::local().await?;
 
     let group_size = 5;

--- a/hyperactor_mesh/examples/test_bench.rs
+++ b/hyperactor_mesh/examples/test_bench.rs
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/// This program is meant as a test bed for exercising the various
+/// (v1) mesh APIs.
+///
+/// It can also be used as the basis for benchmarks, functionality testing,
+/// etc.
+use std::collections::HashSet;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use hyperactor::Actor;
+use hyperactor::Bind;
+use hyperactor::Context;
+use hyperactor::Handler;
+use hyperactor::Named;
+use hyperactor::PortRef;
+use hyperactor::Unbind;
+use hyperactor_mesh::bootstrap::BootstrapCommand;
+use hyperactor_mesh::comm::multicast::CastInfo;
+use hyperactor_mesh::proc_mesh::global_root_client;
+use hyperactor_mesh::v1::host_mesh::HostMesh;
+use ndslice::Point;
+use ndslice::ViewExt;
+use ndslice::extent;
+use serde::Deserialize;
+use serde::Serialize;
+use tokio::time::Instant;
+
+#[derive(Actor, Default, Debug)]
+#[hyperactor::export(
+    spawn = true,
+    handlers = [
+        TestMessage { cast = true },
+    ],
+)]
+struct TestActor {}
+
+#[derive(Debug, Serialize, Deserialize, Named, Clone, Bind, Unbind)]
+enum TestMessage {
+    Ping(#[binding(include)] PortRef<Point>),
+}
+
+#[async_trait]
+impl Handler<TestMessage> for TestActor {
+    async fn handle(
+        &mut self,
+        cx: &Context<Self>,
+        message: TestMessage,
+    ) -> Result<(), anyhow::Error> {
+        match message {
+            TestMessage::Ping(reply) => reply.send(cx, cx.cast_point())?,
+        }
+        Ok(())
+    }
+}
+
+#[tokio::main]
+async fn main() {
+    hyperactor_telemetry::initialize_logging_for_test();
+
+    let host_mesh = HostMesh::process(extent!(hosts = 8), BootstrapCommand::current().unwrap())
+        .await
+        .unwrap();
+
+    let instance = global_root_client();
+
+    let proc_mesh = host_mesh
+        .spawn(instance, "test", extent!(procs = 2))
+        .await
+        .unwrap();
+
+    let actor_mesh = proc_mesh
+        .spawn::<TestActor>(instance, "test", &())
+        .await
+        .unwrap();
+
+    loop {
+        let mut received = HashSet::new();
+        let (port, mut rx) = instance.open_port();
+        let begin = Instant::now();
+        actor_mesh
+            .cast(instance, TestMessage::Ping(port.bind()))
+            .unwrap();
+        while received.len() < actor_mesh.extent().num_ranks() {
+            received.insert(rx.recv().await.unwrap());
+        }
+
+        eprintln!("ping {}ms", begin.elapsed().as_millis());
+        tokio::time::sleep(Duration::from_secs(1)).await;
+    }
+}

--- a/hyperactor_mesh/src/bootstrap.rs
+++ b/hyperactor_mesh/src/bootstrap.rs
@@ -1357,6 +1357,22 @@ impl BootstrapCommand {
         })
     }
 
+    /// Create a new `Command` reflecting this bootstrap command
+    /// configuration.
+    pub fn new(&self) -> Command {
+        let mut cmd = Command::new(&self.program);
+        if let Some(arg0) = &self.arg0 {
+            cmd.arg0(arg0);
+        }
+        for arg in &self.args {
+            cmd.arg(arg);
+        }
+        for (k, v) in &self.env {
+            cmd.env(k, v);
+        }
+        cmd
+    }
+
     /// Bootstrap command used for testing, invoking the Buck-built
     /// `monarch/hyperactor_mesh/bootstrap` binary.
     ///
@@ -1672,16 +1688,7 @@ impl ProcManager for BootstrapProcManager {
             callback_addr,
             config: Some(config.client_config_override),
         };
-        let mut cmd = Command::new(&self.command.program);
-        if let Some(arg0) = &self.command.arg0 {
-            cmd.arg0(arg0);
-        }
-        for arg in &self.command.args {
-            cmd.arg(arg);
-        }
-        for (k, v) in &self.command.env {
-            cmd.env(k, v);
-        }
+        let mut cmd = self.command.new();
         cmd.env(
             "HYPERACTOR_MESH_BOOTSTRAP_MODE",
             mode.to_env_safe_string()

--- a/monarch_hyperactor/src/v1/actor_mesh.rs
+++ b/monarch_hyperactor/src/v1/actor_mesh.rs
@@ -366,8 +366,8 @@ fn actor_state_to_supervision_events(
     let events = match state.status {
         // If the actor was killed, it might not have a Failed status
         // or supervision events, and it can't tell us which rank
-        // it was.
         resource::Status::NotExist | resource::Status::Stopped | resource::Status::Timeout(_) => {
+        // it was.
             if !events.is_empty() {
                 events
             } else {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #1661
* #1660

HostMesh::process constructs a host mesh by forking a process for each host in the mesh. It can be used to bootstrap a large host mesh from a single binary on a single host. The intent is to use for testing, benchmarking, tool development, etc.

test_bench is meant as a template "test bench" for purposes of testing, development, and benchmarking.

Differential Revision: [D85476028](https://our.internmc.facebook.com/intern/diff/D85476028/)