### PR TITLE
Fallback when mlx5dv is not supported.

### DIFF
--- a/monarch_rdma/src/rdma_manager_actor_tests.rs
+++ b/monarch_rdma/src/rdma_manager_actor_tests.rs
@@ -620,4 +620,124 @@ mod tests {
         env.cleanup().await?;
         Ok(())
     }
+
+    #[timed_test::async_timed_test(timeout_secs = 60)]
+    async fn test_rdma_read_into_standard_qp() -> Result<(), anyhow::Error> {
+        const BSIZE: usize = 32;
+        // Skip test if RDMA devices are not available
+        let devices = get_all_devices();
+        if devices.is_empty() {
+            println!("Skipping test: RDMA devices not available");
+            return Ok(());
+        }
+
+        let env = RdmaManagerTestEnv::setup_with_qp_type(
+            BSIZE,
+            "cpu:0",
+            "cpu:0",
+            crate::ibverbs_primitives::RdmaQpType::Standard,
+        )
+        .await?;
+
+        let rdma_handle_1 = env.rdma_handle_1.clone();
+        rdma_handle_1
+            .read_into(env.client_1, env.rdma_handle_2.clone(), 2)
+            .await?;
+
+        env.verify_buffers(BSIZE).await?;
+        env.cleanup().await?;
+        Ok(())
+    }
+
+    #[timed_test::async_timed_test(timeout_secs = 60)]
+    async fn test_rdma_write_from_standard_qp() -> Result<(), anyhow::Error> {
+        const BSIZE: usize = 32;
+        // Skip test if RDMA devices are not available
+        let devices = get_all_devices();
+        if devices.is_empty() {
+            println!("Skipping test: RDMA devices not available");
+            return Ok(());
+        }
+
+        let env = RdmaManagerTestEnv::setup_with_qp_type(
+            BSIZE,
+            "cpu:0",
+            "cpu:0",
+            crate::ibverbs_primitives::RdmaQpType::Standard,
+        )
+        .await?;
+
+        let rdma_handle_1 = env.rdma_handle_1.clone();
+        rdma_handle_1
+            .write_from(env.client_1, env.rdma_handle_2.clone(), 2)
+            .await?;
+
+        env.verify_buffers(BSIZE).await?;
+        env.cleanup().await?;
+        Ok(())
+    }
+
+    #[timed_test::async_timed_test(timeout_secs = 60)]
+    async fn test_rdma_read_into_standard_qp_cuda() -> Result<(), anyhow::Error> {
+        if is_cpu_only_mode() {
+            println!("Skipping CUDA test in CPU-only mode");
+            return Ok(());
+        }
+        const BSIZE: usize = 16 * 1024 * 1024;
+        // Skip test if RDMA devices are not available
+        let devices = get_all_devices();
+        if devices.is_empty() {
+            println!("Skipping test: RDMA devices not available");
+            return Ok(());
+        }
+
+        let env = RdmaManagerTestEnv::setup_with_qp_type(
+            BSIZE,
+            "cuda:0",
+            "cuda:1",
+            crate::ibverbs_primitives::RdmaQpType::Standard,
+        )
+        .await?;
+
+        let rdma_handle_1 = env.rdma_handle_1.clone();
+        rdma_handle_1
+            .read_into(env.client_1, env.rdma_handle_2.clone(), 5)
+            .await?;
+
+        env.verify_buffers(BSIZE).await?;
+        env.cleanup().await?;
+        Ok(())
+    }
+
+    #[timed_test::async_timed_test(timeout_secs = 60)]
+    async fn test_rdma_write_from_standard_qp_cuda() -> Result<(), anyhow::Error> {
+        if is_cpu_only_mode() {
+            println!("Skipping CUDA test in CPU-only mode");
+            return Ok(());
+        }
+        const BSIZE: usize = 16 * 1024 * 1024;
+        // Skip test if RDMA devices are not available
+        let devices = get_all_devices();
+        if devices.is_empty() {
+            println!("Skipping test: RDMA devices not available");
+            return Ok(());
+        }
+
+        let env = RdmaManagerTestEnv::setup_with_qp_type(
+            BSIZE,
+            "cuda:0",
+            "cuda:1",
+            crate::ibverbs_primitives::RdmaQpType::Standard,
+        )
+        .await?;
+
+        let rdma_handle_1 = env.rdma_handle_1.clone();
+        rdma_handle_1
+            .write_from(env.client_1, env.rdma_handle_2.clone(), 5)
+            .await?;
+
+        env.verify_buffers(BSIZE).await?;
+        env.cleanup().await?;
+        Ok(())
+    }
 }

--- a/rdmaxcel-sys/src/rdmaxcel.h
+++ b/rdmaxcel-sys/src/rdmaxcel.h
@@ -24,6 +24,12 @@ typedef enum {
   CQE_POLL_TRUE = 1
 } cqe_poll_result_t;
 
+// RDMA queue pair type selection
+typedef enum {
+  RDMA_QP_TYPE_STANDARD = 1, // Standard ibverbs queue pair
+  RDMA_QP_TYPE_MLX5DV = 2 // mlx5dv extended queue pair
+} rdma_qp_type_t;
+
 // C-compatible structure for CUDA segment information
 typedef struct {
   size_t phys_address; // Physical memory address of the segment
@@ -69,7 +75,8 @@ struct ibv_qp* create_qp(
     int max_send_wr,
     int max_recv_wr,
     int max_send_sge,
-    int max_recv_sge);
+    int max_recv_sge,
+    rdma_qp_type_t qp_type);
 
 struct mlx5dv_qp* create_mlx5dv_qp(struct ibv_qp* qp);
 


### PR DESCRIPTION
Summary:
This change adds fallback support when mlx5dv (Mellanox device-specific extensions) is not available for RDMA operations. It modifies the queue pair creation logic to conditionally use either extended mlx5dv-based queue pairs (when supported) or standard ibverbs queue pairs (as fallback). The pt_cuda_alloc flag is updated to require mlx5dv support since it's necessary for merging memory segments when using PyTorch's CUDA allocator. The change adds a new `is_extended` parameter to control whether to create extended or standard queue pairs at runtime.

Adds an env variable `MONARCH_RDMA_MLX5DV_DISABLED` to test the new code path on dev machine.
## Changes in Latest Revision

Based on reviewer feedback, the implementation has been updated with a cleaner, configuration-based approach:

**API Changes:**
  - Replaced `uint8_t is_extended` parameter with `rdma_qp_type_t` enum in C API
  - Added `RdmaQpType` enum to Rust with three variants:
    - `Auto`: Auto-detect based on device capabilities (default)
    - `Standard`: Force standard ibverbs queue pairs
    - `Mlx5dv`: Force mlx5dv extended queue pairs
  - Added `qp_type` field to `IbverbsConfig` for explicit QP type control
  - C code uses switch statement with proper default case for unknown types

**Architecture:**
  - Rust resolves `Auto` mode before calling C (single source of truth for detection)
  - C function becomes a pure executor - no capability detection logic
  - Removed environment variable approach in favor of configuration

**Testing:**
  - Added `setup_with_qp_type()` helper function in test utilities
  - Added 4 new unit tests to verify standard QP fallback path:
    - `test_rdma_read_into_standard_qp` (CPU-to-CPU)
    - `test_rdma_write_from_standard_qp` (CPU-to-CPU)
    - `test_rdma_read_into_standard_qp_cuda` (GPU-to-GPU)
    - `test_rdma_write_from_standard_qp_cuda` (GPU-to-GPU)


Differential Revision: D85504061


