### PR TITLE
[monarch] don't abort in-progress proc state checks

### DIFF
--- a/monarch_hyperactor/Cargo.toml
+++ b/monarch_hyperactor/Cargo.toml
@@ -48,6 +48,7 @@ serde_multipart = { version = "0.0.0", path = "../serde_multipart" }
 tempfile = "3.22"
 thiserror = "2.0.12"
 tokio = { version = "1.47.1", features = ["full", "test-util", "tracing"] }
+tokio-util = { version = "0.7.15", features = ["full"] }
 tracing = { version = "0.1.41", features = ["attributes", "valuable"] }
 
 [dev-dependencies]


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #1670
* #1669

These are not currently cancellation safe because dropping the rx will cause messages to be undelivered, supervision to kick in, and the job to fail.

Instead, we thread through a cancellation token so that we can safely cancel these tasks, resolving the race.

Differential Revision: [D85577198](https://our.internmc.facebook.com/intern/diff/D85577198/)