### PR TITLE
log improvement

### DIFF
--- a/hyperactor/src/mailbox.rs
+++ b/hyperactor/src/mailbox.rs
@@ -1509,7 +1509,14 @@ impl MailboxSender for Mailbox {
 
         match self.inner.ports.entry(envelope.dest().index()) {
             Entry::Vacant(_) => {
-                let err = DeliveryError::Unroutable("port not bound in mailbox".to_string());
+                let err = DeliveryError::Unroutable(format!(
+                    "port not bound in mailbox; port id: {}; message type: {}",
+                    envelope.dest().index(),
+                    envelope.data().typename().map_or_else(
+                        || format!("unregistered type hash {}", envelope.data().typehash()),
+                        |s| s.to_string(),
+                    )
+                ));
 
                 envelope.undeliverable(err, return_handle);
             }

--- a/hyperactor_mesh/src/v1/host_mesh.rs
+++ b/hyperactor_mesh/src/v1/host_mesh.rs
@@ -854,7 +854,10 @@ impl HostMeshRef {
             } else {
                 // Timeout error, stop reading from the receiver and send back what we have so far,
                 // padding with failed states.
-                tracing::warn!("Timeout waiting for response from host mesh agent for proc_states");
+                tracing::warn!(
+                    "Timeout waiting for response from host mesh agent for proc_states after {:?}",
+                    timeout
+                );
                 let all_ranks = (0..num_ranks).collect::<HashSet<_>>();
                 let completed_ranks = states.iter().map(|(rank, _)| *rank).collect::<HashSet<_>>();
                 let mut leftover_ranks = all_ranks.difference(&completed_ranks).collect::<Vec<_>>();

--- a/hyperactor_mesh/src/v1/proc_mesh.rs
+++ b/hyperactor_mesh/src/v1/proc_mesh.rs
@@ -646,7 +646,8 @@ impl ProcMeshRef {
                 }
             } else {
                 tracing::error!(
-                    "timeout waiting for a message from proc mesh agent in mesh: {}",
+                    "timeout waiting for a message after {:?} from proc mesh agent in mesh {}",
+                    timeout,
                     agent_mesh
                 );
                 // Timeout error, stop reading from the receiver and send back what we have so far,


### PR DESCRIPTION
Summary:
Two changes:

1. Include the timeout value in the log.
2. Include port id and message type name, or hash if not registered, in the undelivered message error. It it will look like the following in a returned message log:

> metatls:twshared13737.02.gtn2.facebook.com:46155,service,agent[0]: actor failure: serving metatls:twshared13737.02.gtn2.facebook.com:46155,service,agent[0]: processing error: a message from metatls:twshared13737.02.gtn2.facebook.com:46155,service,agent[0] to metatls:twshared13736.02.gtn2.facebook.com:40835,mesh_root_client_proc,client[0][430914] was undeliverable and returned: Some(**"address not routable: port not bound in mailbox; port id: 430914; message type: unregistered type hash 16038717096654025819**; broken link: message was undeliverable")

Reviewed By: shayne-fletcher

Differential Revision: D85537948


