### PR TITLE
Enhance logging message when supervision events are not handled

### DIFF
--- a/hyperactor/src/proc.rs
+++ b/hyperactor/src/proc.rs
@@ -394,16 +394,17 @@ impl Proc {
 
     fn handle_supervision_event(&self, event: ActorSupervisionEvent) {
         let result = match self.state().supervision_coordinator_port.get() {
-            Some(port) => port.send(event).map_err(anyhow::Error::from),
+            Some(port) => port.send(event.clone()).map_err(anyhow::Error::from),
             None => Err(anyhow::anyhow!(
                 "coordinator port is not set for proc {}",
-                self.proc_id()
+                self.proc_id(),
             )),
         };
         if let Err(err) = result {
             tracing::error!(
-                "proc {}: could not propagate supervision event: {:?}: crashing",
+                "proc {}: could not propagate supervision event {} due to error: {:?}: crashing",
                 self.proc_id(),
+                event,
                 err
             );
 


### PR DESCRIPTION
Summary:
In cases where a supervision event happens very early in a proc lifecycle, before the
ProcMeshAgent sets the coordinator port, we end up dropping the event details.
Add these to logs so they are seen.

Before we would see:
```
proc tcp:hostname:port,service: could not propagate supervision event: coordinator port is not set for proc tcp:hostname:port,service: crashing
```

Now we will also see the original supervision event which caused that crash.

Differential Revision: D85676924


