### PR TITLE
[monarch] Clean future cancellation handling

### DIFF
--- a/python/monarch/_src/actor/future.py
+++ b/python/monarch/_src/actor/future.py
@@ -139,11 +139,11 @@ class Future(Generic[R]):
                     self._status = _Asyncio(fut)
 
                     def set_result(fut, value):
-                        if not fut.done():
+                        if not fut.cancelled():
                             fut.set_result(value)
 
                     def set_exception(fut, e):
-                        if not fut.done():
+                        if not fut.cancelled():
                             fut.set_exception(e)
 
                     async def mark_complete():

--- a/python/monarch/_src/actor/future.py
+++ b/python/monarch/_src/actor/future.py
@@ -138,12 +138,20 @@ class Future(Generic[R]):
                     fut = loop.create_future()
                     self._status = _Asyncio(fut)
 
+                    def set_result(fut, value):
+                        if not fut.done():
+                            fut.set_result(value)
+
+                    def set_exception(fut, e):
+                        if not fut.done():
+                            fut.set_exception(e)
+
                     async def mark_complete():
                         try:
-                            func, value = fut.set_result, await coro
+                            func, value = set_result, await coro
                         except Exception as e:
-                            func, value = fut.set_exception, e
-                        loop.call_soon_threadsafe(func, value)
+                            func, value = set_exception, e
+                        loop.call_soon_threadsafe(func, fut, value)
 
                     PythonTask.from_coroutine(mark_complete()).spawn()
                     return fut.__await__()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #1687

The implementation of `monarch.actor.Future` uses `loop.call_soon_threadsafe` to set a value/exception on an underlying asyncio future. But if the caller cancelled the asyncio future before `call_soon_threadsafe` executes the callback, then `asyncio.exceptions.InvalidStateError` will be logged, which is noisy and misleading.

This diff solves the issue by checking whether the future is already resolved/cancelled from inside the callback.

Differential Revision: [D85693875](https://our.internmc.facebook.com/intern/diff/D85693875/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D85693875/)!