### PR TITLE
Support uuid "rng-getrandom" feature

### DIFF
--- a/hyperactor/Cargo.toml
+++ b/hyperactor/Cargo.toml
@@ -82,7 +82,7 @@ tokio-stream = { version = "0.1.17", features = ["fs", "io-util", "net", "signal
 tokio-util = { version = "0.7.15", features = ["full"] }
 tracing = { version = "0.1.41", features = ["attributes", "valuable"] }
 unicode-ident = "1.0.12"
-uuid = { version = "1.17", features = ["serde", "v4", "v5", "v6", "v7", "v8"] }
+uuid = { version = "1.17", features = ["rng-getrandom", "serde", "v4", "v5", "v6", "v7", "v8"] }
 
 [dev-dependencies]
 buck-resources = "1"


### PR DESCRIPTION
Summary:
Required in D85438479, which contains a handwritten Cargo.toml (fbcode/pyrefly/pyrefly_wasm/Cargo.toml) that gets incorporated into an Autocargo-generated Cargo.lock (fbcode/pyrefly/Cargo.lock).

In order for the handwritten Cargo.toml to be able to use uuid with "rng-getrandom", the Cargo.lock generation needs to have offline access to all the transitive dependencies pulled by this feature.

https://www.internalfb.com/code/fbsource/[0cc72b95913a155b4ae4b660196a25e4c23cd6b1]/fbcode/pyrefly/pyrefly_wasm/Cargo.toml?lines=17%2C26

Reviewed By: diliop

Differential Revision: D85680730


