### PR TITLE
remove spammy log when log forwarder is disabled

### DIFF
--- a/hyperactor_mesh/src/logging.rs
+++ b/hyperactor_mesh/src/logging.rs
@@ -401,11 +401,6 @@ impl LogSender for LocalLogSender {
                 output_target: target,
                 payload: Serialized::serialize(&payload)?,
             });
-        } else {
-            tracing::debug!(
-                "log sender {} is not active, skip sending log",
-                self.tx.addr()
-            )
         }
 
         Ok(())
@@ -416,11 +411,6 @@ impl LogSender for LocalLogSender {
         if TxStatus::Active == *self.status.borrow() {
             // Do not use tx.send, it will block the allocator as the child process state is unknown.
             self.tx.post(LogMessage::Flush { sync_version: None });
-        } else {
-            tracing::debug!(
-                "log sender {} is not active, skip sending flush message",
-                self.tx.addr()
-            );
         }
         Ok(())
     }


### PR DESCRIPTION
Summary:
We could see a lot of such logs in agent tune job, they are not very meaningful, instead it adds noise to the debugging. Simply remove them.


```
D1028 13:41:14.902225  2072 fbcode/monarch/hyperactor_mesh/src/logging.rs:405] log sender unix:DXQZoTDccbIdARnDeVUKh0hf is not active, skip sending log
```

Reviewed By: pzhan9

Differential Revision: D85712862


