### PR TITLE
Migrator monarch/python/monarch/_src/actor to pyre-strict

### DIFF
--- a/python/monarch/_src/actor/__init__.py
+++ b/python/monarch/_src/actor/__init__.py
@@ -4,7 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-# pyre-unsafe
+# pyre-strict
 
 """
 Monarch Actor API

--- a/python/monarch/_src/actor/bootstrap.py
+++ b/python/monarch/_src/actor/bootstrap.py
@@ -4,7 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-# pyre-unsafe
+# pyre-strict
 
 
 from pathlib import Path
@@ -28,11 +28,12 @@ PrivateKey = Union[bytes, Path, None]
 CA = Union[bytes, Path, Literal["trust_all_connections"]]
 
 
-def _as_python_task(s: str | Future[str]) -> PythonTask:
+def _as_python_task(s: str | Future[str]) -> "PythonTask[str]":
     if isinstance(s, str):
+        s_str: str = s
 
-        async def just():
-            return s
+        async def just() -> str:
+            return s_str
 
         return PythonTask.from_coroutine(just())
     else:

--- a/python/monarch/_src/actor/bootstrap_main.py
+++ b/python/monarch/_src/actor/bootstrap_main.py
@@ -4,7 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-# pyre-unsafe
+# pyre-strict
 
 """
 This is the main function for the boostrapping a new process using a ProcessAllocator.
@@ -29,13 +29,14 @@ except ImportError:
     import monarch._rust_bindings  # @manual  # noqa: F401
 
 
-async def main():
+async def main() -> None:
     from monarch._rust_bindings.monarch_hyperactor.bootstrap import bootstrap_main
 
+    # pyre-ignore[12]: bootstrap_main is async but imported from Rust bindings
     await bootstrap_main()
 
 
-def invoke_main():
+def invoke_main() -> None:
     # if this is invoked with the stdout piped somewhere, then print
     # changes its buffering behavior. So we default to the standard
     # behavior of std out as if it were a terminal.

--- a/python/monarch/_src/actor/code_sync/__init__.py
+++ b/python/monarch/_src/actor/code_sync/__init__.py
@@ -4,7 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-# pyre-unsafe
+# pyre-strict
 
 from monarch._rust_bindings.monarch_extension.code_sync import (  # noqa: F401
     CodeSyncMeshClient,

--- a/python/monarch/_src/actor/debugger/__init__.py
+++ b/python/monarch/_src/actor/debugger/__init__.py
@@ -4,4 +4,4 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-# pyre-unsafe
+# pyre-strict

--- a/python/monarch/_src/actor/debugger/breakpoint.py
+++ b/python/monarch/_src/actor/debugger/breakpoint.py
@@ -4,7 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-# pyre-unsafe
+# pyre-strict
 import inspect
 
 from monarch._src.actor.actor_mesh import context, DebugContext

--- a/python/monarch/_src/actor/debugger/debug_command.py
+++ b/python/monarch/_src/actor/debugger/debug_command.py
@@ -4,21 +4,24 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-# pyre-unsafe
+# pyre-strict
 import sys
 from dataclasses import dataclass
-from typing import cast, Dict, List, Tuple, Union
+from typing import cast, Dict, List, Optional, Tuple, TYPE_CHECKING, Union
+
+if TYPE_CHECKING:
+    from lark import Lark, Transformer
 
 from monarch._src.actor.debugger.debug_io import DebugIO
 
 RanksType = Union[int, List[int], range, Dict[str, Union[range, List[int], int]]]
 
-_debug_input_parser = None
+_debug_input_parser: "Optional[Lark]" = None
 
 
 # Wrap the parser in a function so that jobs don't have to import lark
 # unless they want to use the debugger.
-def _get_debug_input_parser():
+def _get_debug_input_parser() -> "Lark":
     global _debug_input_parser
     if _debug_input_parser is None:
         from lark import Lark
@@ -55,12 +58,12 @@ def _get_debug_input_parser():
     return _debug_input_parser
 
 
-_debug_input_transformer = None
+_debug_input_transformer: "Optional[Transformer]" = None
 
 
 # Wrap the transformer in a function so that jobs don't have to import lark
 # unless they want to use the debugger.
-def _get_debug_input_transformer():
+def _get_debug_input_transformer() -> "Transformer":
     global _debug_input_transformer
     if _debug_input_transformer is None:
         from lark import Transformer

--- a/python/monarch/_src/actor/debugger/debug_controller.py
+++ b/python/monarch/_src/actor/debugger/debug_controller.py
@@ -4,7 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-# pyre-unsafe
+# pyre-strict
 import asyncio
 import functools
 from typing import Dict, List, Optional, Tuple
@@ -54,10 +54,10 @@ class DebugController(Actor):
     def __init__(self) -> None:
         self.sessions = DebugSessions()
         self._task_lock = asyncio.Lock()
-        self._task: asyncio.Task | None = None
+        self._task: Optional[asyncio.Task[None]] = None
         self._debug_io: DebugIO = DebugStdIO()
-        self._server = asyncio.Future()
-        self._server_task = asyncio.create_task(self._serve())
+        self._server: asyncio.Future[asyncio.Server] = asyncio.Future()
+        self._server_task: asyncio.Task[None] = asyncio.create_task(self._serve())
 
     async def _serve(self) -> None:
         try:
@@ -98,12 +98,12 @@ class DebugController(Actor):
             self._task = asyncio.create_task(self._enter())
 
     @endpoint
-    async def wait_pending_session(self):
+    async def wait_pending_session(self) -> None:
         while len(self.sessions) == 0:
             await asyncio.sleep(1)
 
     @endpoint
-    async def list(self, print_output=True) -> List[DebugSessionInfo]:
+    async def list(self, print_output: bool = True) -> List[DebugSessionInfo]:
         session_info = sorted(self.sessions.info())
         if print_output:
             await self._debug_io.output(

--- a/python/monarch/_src/actor/debugger/debug_io.py
+++ b/python/monarch/_src/actor/debugger/debug_io.py
@@ -4,7 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-# pyre-unsafe
+# pyre-strict
 import asyncio
 import sys
 from abc import abstractmethod
@@ -34,12 +34,14 @@ class DebugStdIO(DebugIO):
 
 
 class DebugIOError(RuntimeError):
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__("Error encountered during debugger I/O operation.")
 
 
 class DebugCliIO(DebugIO):
-    def __init__(self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter):
+    def __init__(
+        self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter
+    ) -> None:
         self._reader = reader
         self._writer = writer
 

--- a/python/monarch/_src/actor/device_utils.py
+++ b/python/monarch/_src/actor/device_utils.py
@@ -4,14 +4,14 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-# pyre-unsafe
+# pyre-strict
 
 import os
 import re
 from pathlib import Path
 
 
-def _local_device_count():
+def _local_device_count() -> int:
     if "CUDA_VISIBLE_DEVICES" in os.environ:
         return len(os.environ["CUDA_VISIBLE_DEVICES"].split(","))
     dev_path = Path("/dev")

--- a/python/monarch/_src/actor/event_loop.py
+++ b/python/monarch/_src/actor/event_loop.py
@@ -4,7 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-# pyre-unsafe
+# pyre-strict
 
 """
 Module for managing the event loop used by Monarch Python actors.
@@ -18,7 +18,7 @@ from typing import Optional
 
 from pyre_extensions import none_throws
 
-logger = logging.getLogger(__name__)
+logger: logging.Logger = logging.getLogger(__name__)
 
 _event_loop: Optional[asyncio.AbstractEventLoop] = None
 _lock = threading.Lock()
@@ -35,7 +35,7 @@ def _initialize_event_loop() -> None:
         return
 
     # Create a new thread that will host our event loop
-    def event_loop_thread():
+    def event_loop_thread() -> None:
         """Target function for the event loop thread."""
         global _event_loop, _ready
         try:

--- a/python/monarch/_src/actor/host_mesh.py
+++ b/python/monarch/_src/actor/host_mesh.py
@@ -4,7 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-# pyre-unsafe
+# pyre-strict
 
 import warnings
 from math import prod
@@ -80,7 +80,7 @@ class HostMeshV0(MeshTrait):
         shape: Shape,
         allocator: AllocateMixin,
         alloc_constraints: Optional[AllocConstraints] = None,
-    ):
+    ) -> None:
         warnings.warn(
             (
                 "DEPRECATION WARNING: using a deprecated version of HostMesh. This is going be removed imminently. "
@@ -186,7 +186,7 @@ def fake_in_process_host_v0() -> "HostMeshV0":
     return HostMeshV0(Shape.unity(), LocalAllocator())
 
 
-def hosts_from_config_v0(name: str):
+def hosts_from_config_v0(name: str) -> HostMeshV0:
     """
     Get the host mesh 'name' from the monarch configuration for the project.
 

--- a/python/monarch/_src/actor/python_extension_methods.py
+++ b/python/monarch/_src/actor/python_extension_methods.py
@@ -4,7 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-# pyre-unsafe
+# pyre-strict
 
 import importlib
 
@@ -15,7 +15,7 @@ T = TypeVar("T")
 
 
 class PatchRustClass:
-    def __init__(self, rust_class: Type):
+    def __init__(self, rust_class: Type[T]) -> None:
         self.rust_class = rust_class
 
     def __call__(self, python_class: Type[T]) -> Type[T]:

--- a/python/monarch/_src/actor/shape.py
+++ b/python/monarch/_src/actor/shape.py
@@ -4,13 +4,13 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-# pyre-unsafe
+# pyre-strict
 
 import itertools
 import operator
 from abc import ABC, abstractmethod
 
-from typing import Dict, Generator, Sequence, Tuple, Union
+from typing import Any, Dict, Generator, Sequence, Tuple, Union
 
 from monarch._rust_bindings.monarch_hyperactor.shape import Extent, Shape, Slice
 
@@ -38,7 +38,7 @@ class ShapeExt:
     functionality."""
 
     @staticmethod
-    def slice(shape: Shape, **kwargs) -> Shape:
+    def slice(shape: Shape, **kwargs: Any) -> Shape:
         """Select along named dimensions. Integer values remove
         dimensions, slice objects keep dimensions but restrict them.
 
@@ -78,7 +78,7 @@ class MeshTrait(ABC):
     @abstractmethod
     def _new_with_shape(self, shape: Shape) -> Self: ...
 
-    def slice(self, **kwargs) -> Self:
+    def slice(self, **kwargs: Any) -> Self:
         """Select along named dimensions. Integer values remove
         dimensions, slice objects keep dimensions but restrict them.
 
@@ -87,7 +87,7 @@ class MeshTrait(ABC):
         shape = Shape(list(self._labels), self._ndslice)
         return self._new_with_shape(ShapeExt.slice(shape, **kwargs))
 
-    def split(self, **kwargs) -> Self:
+    def split(self, **kwargs: Any) -> Self:
         """
         Returns a new device mesh with some dimensions of this mesh split.
         For instance, this call splits the host dimension into dp and pp dimensions,
@@ -195,7 +195,7 @@ class MeshTrait(ABC):
             )
         )
 
-    def rename(self, **kwargs) -> Self:
+    def rename(self, **kwargs: Any) -> Self:
         """
         Returns a new device mesh with some of dimensions renamed.
         Dimensions not mentioned are retained:

--- a/python/monarch/_src/actor/source_loader.py
+++ b/python/monarch/_src/actor/source_loader.py
@@ -4,7 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-# pyre-unsafe
+# pyre-strict
 import functools
 import importlib
 import importlib.abc
@@ -35,7 +35,7 @@ def load_remote_source(filename: str) -> str:
 
 
 class RemoteImportLoader(importlib.abc.Loader):
-    def __init__(self, filename: str):
+    def __init__(self, filename: str) -> None:
         self._filename = filename
 
     def get_source(self, _module_name: str) -> str:

--- a/python/monarch/_src/actor/sync_state.py
+++ b/python/monarch/_src/actor/sync_state.py
@@ -4,14 +4,15 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-# pyre-unsafe
+# pyre-strict
 
 import asyncio
 from contextlib import contextmanager
+from typing import Any, Generator
 
 
 @contextmanager
-def fake_sync_state():
+def fake_sync_state() -> Generator[None, None, None]:
     prev_loop = asyncio.events._get_running_loop()
     asyncio._set_running_loop(None)
     try:

--- a/python/monarch/_src/actor/tensor_engine_shim.py
+++ b/python/monarch/_src/actor/tensor_engine_shim.py
@@ -4,11 +4,20 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-# pyre-unsafe
+# pyre-strict
 
 import importlib
 from functools import partial
-from typing import Any, Optional, Sequence, TYPE_CHECKING
+from typing import (
+    Any,
+    Callable,
+    Optional,
+    overload,
+    ParamSpec,
+    Sequence,
+    TYPE_CHECKING,
+    TypeVar,
+)
 
 """
 This file provides a type annoated shim for using tensor engine functions
@@ -24,17 +33,34 @@ if TYPE_CHECKING:
 
 from monarch._rust_bindings.monarch_hyperactor.buffers import FrozenBuffer
 
+P = ParamSpec("P")
+F = TypeVar("F", bound=Callable[..., Any])
 
-def shim(fn=None, *, module=None):
+
+@overload
+def shim(fn: F, *, module: Optional[str] = None) -> F: ...
+
+
+@overload
+def shim(
+    fn: None = None, *, module: Optional[str] = None
+) -> Callable[[Callable[..., Any]], Callable[..., Any]]: ...
+
+
+def shim(
+    fn: Optional[Callable[..., Any]] = None, *, module: Optional[str] = None
+) -> Any:
     if fn is None:
         return partial(shim, module=module)
 
-    impl = None
-    name = fn.__name__
+    impl: Optional[Callable[..., Any]] = None
+    name: str = fn.__name__
 
-    def wrap(*args, **kwargs):
+    def wrap(*args: Any, **kwargs: Any) -> Any:
         nonlocal impl
         if impl is None:
+            # TODO: See if there's a reasonable way to assert that the module name is not none
+            # pyre-ignore Incompatible parameter type [6]: In call `importlib.import_module`, for 1st positional argument, expected `str` but got `Optional[str]`
             impl = getattr(importlib.import_module(module), name)
         return impl(*args, **kwargs)
 
@@ -43,7 +69,7 @@ def shim(fn=None, *, module=None):
 
 @shim(module="monarch.mesh_controller")
 def actor_send(
-    endpoint: "ActorEndpoint",
+    endpoint: "ActorEndpoint[..., ...]",
     args_kwargs_tuple: bytes,
     refs: "Sequence[Any]",
     port: "Optional[Port[Any]]",
@@ -52,12 +78,16 @@ def actor_send(
 
 
 @shim(module="monarch.mesh_controller")
-def actor_rref(endpoint, args_kwargs_tuple: FrozenBuffer, refs: Sequence[Any]): ...
+def actor_rref(
+    endpoint: Any,
+    args_kwargs_tuple: FrozenBuffer,
+    refs: Sequence[Any],
+) -> Any: ...
 
 
 @shim(module="monarch.common.remote")
-def _cached_propagation(_cache, rfunction, args, kwargs) -> Any: ...
+def _cached_propagation(_cache: Any, rfunction: Any, args: Any, kwargs: Any) -> Any: ...
 
 
 @shim(module="monarch.common.fake")
-def fake_call(fn, *args, **kwargs): ...
+def fake_call(fn: Any, *args: Any, **kwargs: Any) -> Any: ...

--- a/python/monarch/_src/actor/v1/__init__.py
+++ b/python/monarch/_src/actor/v1/__init__.py
@@ -4,7 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-# pyre-unsafe
+# pyre-strict
 import os
 
-enabled = os.environ.get("MONARCH_V0_WORKAROUND_DO_NOT_USE", "0") != "1"
+enabled: bool = os.environ.get("MONARCH_V0_WORKAROUND_DO_NOT_USE", "0") != "1"


### PR DESCRIPTION
Summary:
pyre had a couple of gaps for how we handled endpoints that interfered with full turning typing on that are mostly addressed with pyrefly. 

This is part 1 of a series of diffs to turn on pyre-strict, leaning someone generously on Any's for now, which then will be followed up by enabling pyrefly.

Differential Revision: D85356082


