### PR TITLE
Have proc_mesh.stop try to cleanly exit actors

### DIFF
--- a/hyperactor_mesh/src/resource.rs
+++ b/hyperactor_mesh/src/resource.rs
@@ -273,6 +273,22 @@ pub struct Stop {
     pub reply: PortRef<StatusOverlay>,
 }
 
+/// Stop all resources owned by the receiver of this message.
+/// No reply, this is meant to force a stop without waiting for acknowledgement.
+#[derive(
+    Debug,
+    Clone,
+    Serialize,
+    Deserialize,
+    Named,
+    Handler,
+    HandleClient,
+    RefClient,
+    Bind,
+    Unbind
+)]
+pub struct StopAll {}
+
 /// Retrieve the current state of the resource.
 #[derive(Debug, Serialize, Deserialize, Named, Handler, HandleClient, RefClient)]
 pub struct GetState<S> {

--- a/python/tests/test_actor_error.py
+++ b/python/tests/test_actor_error.py
@@ -749,13 +749,13 @@ async def test_slice_supervision() -> None:
     slice_2 = error_mesh.slice(gpus=2)
     slice_3 = error_mesh.slice(gpus=3)
 
-    # Trigger supervision error on gpus=3
-    with pytest.raises(SupervisionError, match="did not handle supervision event"):
-        await slice_3.fail_with_supervision_error.call()
-
     match = (
         "Actor .* (is unhealthy with reason:|exited because of the following reason:)"
     )
+    # Trigger supervision error on gpus=3
+    with pytest.raises(SupervisionError, match=match):
+        await slice_3.fail_with_supervision_error.call()
+
     # Mesh containing all gpus is unhealthy
     with pytest.raises(SupervisionError, match=match):
         await error_mesh.check.call()


### PR DESCRIPTION
Summary:
Non-local processes that are being stopped with v1 `proc_mesh.stop()` go right
to SIGTERM, and don't give actors a chance to stop themselves. LocalHandle processes use
"destroy_and_wait" already.
That didn't matter a lot before, but we'd like for Actors to have a chance to run cleanups
in Drop, and in the future the `Actor::cleanup` trait function.

This change asks the ProcMeshAgent to stop the actors on the proc before sending a
SIGTERM, which gives a chance for more cooperative cleanup. Note that the process still
gets SIGTERM, as "destroy_and_wait" (and by extension, the StopAll message) does not exit
the process. We make sure to `await` the StopAll message response, so that we don't
try to SIGTERM actors that are already stopping.

Reviewed By: shayne-fletcher

Differential Revision: D85795859


