### PR TITLE
[monarch] Add bootstrap command hint when proc bootstrap fails

### DIFF
--- a/python/monarch/_src/actor/bootstrap_main.py
+++ b/python/monarch/_src/actor/bootstrap_main.py
@@ -36,40 +36,48 @@ async def main():
 
 
 def invoke_main():
-    # if this is invoked with the stdout piped somewhere, then print
-    # changes its buffering behavior. So we default to the standard
-    # behavior of std out as if it were a terminal.
-    sys.stdout.reconfigure(line_buffering=True)
-    global bootstrap_main
-
-    # TODO: figure out what from worker_main.py we should reproduce here.
-
-    from monarch._src.actor.telemetry import TracingForwarder  # noqa
-
-    if os.environ.get("MONARCH_ERROR_DURING_BOOTSTRAP_FOR_TESTING") == "1":
-        raise RuntimeError("Error during bootstrap for testing")
-
-    # forward logs to rust tracing. Defaults to on.
-    if os.environ.get("MONARCH_PYTHON_LOG_TRACING", "1") == "1":
-        # we can stream python logs now; no need to forward them to rust processes
-        pass
-        # install opentelemetry tracing
-
     try:
-        with (
-            importlib.resources.as_file(
-                importlib.resources.files("monarch") / "py-spy"
-            ) as pyspy,
-        ):
-            if pyspy.exists():
-                os.environ["PYSPY_BIN"] = str(pyspy)
-            # fallback to using local py-spy
+        # if this is invoked with the stdout piped somewhere, then print
+        # changes its buffering behavior. So we default to the standard
+        # behavior of std out as if it were a terminal.
+        sys.stdout.reconfigure(line_buffering=True)
+        global bootstrap_main
+
+        # TODO: figure out what from worker_main.py we should reproduce here.
+
+        from monarch._src.actor.telemetry import TracingForwarder  # noqa
+
+        if os.environ.get("MONARCH_ERROR_DURING_BOOTSTRAP_FOR_TESTING") == "1":
+            raise RuntimeError("Error during bootstrap for testing")
+
+        # forward logs to rust tracing. Defaults to on.
+        if os.environ.get("MONARCH_PYTHON_LOG_TRACING", "1") == "1":
+            # we can stream python logs now; no need to forward them to rust processes
+            pass
+            # install opentelemetry tracing
+
+        try:
+            with (
+                importlib.resources.as_file(
+                    importlib.resources.files("monarch") / "py-spy"
+                ) as pyspy,
+            ):
+                if pyspy.exists():
+                    os.environ["PYSPY_BIN"] = str(pyspy)
+                # fallback to using local py-spy
+        except Exception as e:
+            logging.warning(f"Failed to set up py-spy: {e}")
+
+        from monarch._src.actor.debugger.breakpoint import remote_breakpointhook
+
+        sys.breakpointhook = remote_breakpointhook
     except Exception as e:
-        logging.warning(f"Failed to set up py-spy: {e}")
-
-    from monarch._src.actor.debugger.breakpoint import remote_breakpointhook
-
-    sys.breakpointhook = remote_breakpointhook
+        bootstrap_err = RuntimeError(
+            f"Failed to bootstrap proc due to: {e}\nMake sure your proc bootstrap command is correct. "
+            f"Provided command:\n{' '.join([sys.executable, *sys.argv])}\nTo specify your proc bootstrap command, use the "
+            f"`bootstrap_cmd` kwarg in `monarch.actor.host_mesh.HostMesh.allocate_nonblocking(...)`."
+        )
+        raise bootstrap_err from e
 
     # Start an event loop for PythonActors to use.
     asyncio.run(main())


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #1719
* #1718

If proc bootstrap (e.g., `monarch/_src/actor/bootstrap_main.py`) fails, provide both the original error message and a hint that indicates that the user might need to look at their proc bootstrap command, and points them to the correct API.

Differential Revision: [D85903691](https://our.internmc.facebook.com/intern/diff/D85903691/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D85903691/)!