### PR TITLE
don't panic when there are concurrent requests

### DIFF
--- a/monarch_rdma/src/rdma_manager_actor.rs
+++ b/monarch_rdma/src/rdma_manager_actor.rs
@@ -28,6 +28,7 @@
 //!
 //! See test examples: `test_rdma_write_loopback` and `test_rdma_read_loopback`.
 use std::collections::HashMap;
+use std::sync::Arc;
 
 use async_trait::async_trait;
 use hyperactor::Actor;
@@ -40,26 +41,42 @@ use hyperactor::Instance;
 use hyperactor::Named;
 use hyperactor::OncePortRef;
 use hyperactor::RefClient;
+use hyperactor::clock::Clock;
+use hyperactor::clock::RealClock;
 use hyperactor::supervision::ActorSupervisionEvent;
 use serde::Deserialize;
 use serde::Serialize;
+use tokio::sync::Notify;
+use tokio::sync::Semaphore;
 
 use crate::ibverbs_primitives::IbverbsConfig;
 use crate::ibverbs_primitives::RdmaMemoryRegionView;
 use crate::ibverbs_primitives::RdmaQpInfo;
 use crate::ibverbs_primitives::ibverbs_supported;
 use crate::ibverbs_primitives::resolve_qp_type;
+use crate::rdma_components::PollTarget;
 use crate::rdma_components::RdmaBuffer;
 use crate::rdma_components::RdmaDomain;
 use crate::rdma_components::RdmaQueuePair;
 use crate::rdma_components::get_registered_cuda_segments;
 use crate::validate_execution_context;
 
-/// Represents the state of a queue pair in the manager, either available or checked out.
+/// Wrapper for a queue pair with a semaphore for fair access control.
+#[derive(Debug, Clone)]
+pub struct QueuePairEntry {
+    pub qp: RdmaQueuePair,
+    pub semaphore: Arc<Semaphore>,
+}
+
+/// Represents the state of a queue pair in the manager.
 #[derive(Debug, Clone)]
 pub enum QueuePairState {
-    Available(RdmaQueuePair),
-    CheckedOut,
+    /// Connection establishment in progress. Waiters will be notified when ready or on error.
+    Connecting(Arc<tokio::sync::Notify>),
+    /// Queue pair is ready and available for use.
+    Ready(QueuePairEntry),
+    /// Connection failed. Error is persisted for all current and future requesters.
+    ConnectionError(Arc<anyhow::Error>),
 }
 
 /// Helper function to get detailed error messages from RDMAXCEL error codes
@@ -127,6 +144,20 @@ pub enum RdmaManagerMessage {
         other_device: String,
         /// `qp` - The queue pair to return (ownership transferred back)
         qp: RdmaQueuePair,
+    },
+    ReadInto {
+        local: RdmaBuffer,
+        remote: RdmaBuffer,
+        timeout: tokio::time::Duration,
+        #[reply]
+        reply: OncePortRef<()>,
+    },
+    WriteFrom {
+        local: RdmaBuffer,
+        remote: RdmaBuffer,
+        timeout: tokio::time::Duration,
+        #[reply]
+        reply: OncePortRef<()>,
     },
 }
 
@@ -209,12 +240,20 @@ impl Drop for RdmaManagerActor {
         for (device_name, device_map) in self.device_qps.drain() {
             for ((actor_id, remote_device), qp_state) in device_map {
                 match qp_state {
-                    QueuePairState::Available(qp) => {
-                        destroy_queue_pair(&qp, &format!("actor {:?}", actor_id));
+                    QueuePairState::Ready(entry) => {
+                        destroy_queue_pair(&entry.qp, &format!("actor {:?}", actor_id));
                     }
-                    QueuePairState::CheckedOut => {
+                    QueuePairState::Connecting(_) => {
                         tracing::warn!(
-                            "QP for actor {:?} (device {} -> {}) was checked out during cleanup",
+                            "QP for actor {:?} (device {} -> {}) was still connecting during cleanup",
+                            actor_id,
+                            device_name,
+                            remote_device
+                        );
+                    }
+                    QueuePairState::ConnectionError(_) => {
+                        tracing::warn!(
+                            "QP for actor {:?} (device {} -> {}) had connection error during cleanup",
                             actor_id,
                             device_name,
                             remote_device
@@ -515,6 +554,107 @@ impl RdmaManagerActor {
         }
         Ok(())
     }
+
+    /// Establishes a connection between this actor and another remote actor.
+    /// Handles both loopback (same actor, same device) and remote connections.
+    async fn establish_connection(
+        &mut self,
+        cx: &Context<'_, Self>,
+        other: ActorRef<RdmaManagerActor>,
+        self_device: String,
+        other_device: String,
+    ) -> Result<RdmaQueuePair, anyhow::Error> {
+        let is_loopback = other.actor_id() == cx.bind::<RdmaManagerActor>().actor_id()
+            && self_device == other_device;
+
+        if is_loopback {
+            // Loopback connection setup
+            self.initialize_qp(cx, other.clone(), self_device.clone(), other_device.clone())
+                .await?;
+            let endpoint = self
+                .connection_info(cx, other.clone(), other_device.clone(), self_device.clone())
+                .await?;
+            self.connect(
+                cx,
+                other.clone(),
+                self_device.clone(),
+                other_device.clone(),
+                endpoint,
+            )
+            .await?;
+        } else {
+            // Remote connection setup
+            self.initialize_qp(cx, other.clone(), self_device.clone(), other_device.clone())
+                .await?;
+            other
+                .initialize_qp(
+                    cx,
+                    cx.bind().clone(),
+                    other_device.clone(),
+                    self_device.clone(),
+                )
+                .await?;
+            let other_endpoint: RdmaQpInfo = other
+                .connection_info(
+                    cx,
+                    cx.bind().clone(),
+                    other_device.clone(),
+                    self_device.clone(),
+                )
+                .await?;
+            self.connect(
+                cx,
+                other.clone(),
+                self_device.clone(),
+                other_device.clone(),
+                other_endpoint,
+            )
+            .await?;
+            let local_endpoint = self
+                .connection_info(cx, other.clone(), self_device.clone(), other_device.clone())
+                .await?;
+            other
+                .connect(
+                    cx,
+                    cx.bind().clone(),
+                    other_device.clone(),
+                    self_device.clone(),
+                    local_endpoint,
+                )
+                .await?;
+        }
+
+        // Hardware init delay. apply_first_op_delay no longer works for mysterious reasons.
+        // FIXME(yuxuanh): refactor & make this behave like apply_first_op_delay
+        RealClock.sleep(tokio::time::Duration::from_millis(2)).await;
+
+        // Retrieve the connected queue pair
+        let inner_key = (other.actor_id().clone(), other_device.clone());
+        if let Some(device_map) = self.device_qps.get(&self_device) {
+            if let Some(qp_state) = device_map.get(&inner_key) {
+                match qp_state {
+                    QueuePairState::Ready(entry) => Ok(entry.qp.clone()),
+                    QueuePairState::Connecting(_) => Err(anyhow::anyhow!(
+                        "Unexpected Connecting state after connection establishment"
+                    )),
+                    QueuePairState::ConnectionError(err) => {
+                        Err(anyhow::anyhow!("Connection failed: {}", err))
+                    }
+                }
+            } else {
+                Err(anyhow::anyhow!(
+                    "Failed to find connection for actor {} on device {}",
+                    other.actor_id(),
+                    other_device
+                ))
+            }
+        } else {
+            Err(anyhow::anyhow!(
+                "Failed to find device map for device {} after connection",
+                self_device
+            ))
+        }
+    }
 }
 
 #[async_trait]
@@ -649,12 +789,15 @@ impl RdmaManagerMessageHandler for RdmaManagerActor {
 
     /// Requests a queue pair for communication with a remote RDMA manager actor.
     ///
-    /// Basic logic: if queue pair exists in map, return it; if None, create connection first.
+    /// This method uses a fair semaphore-based approach that allows multiple concurrent
+    /// requesters to wait for queue pair availability without failing.
     ///
     /// # Arguments
     ///
     /// * `cx` - The context of the actor requesting the queue pair.
-    /// * `remote` - The ActorRef of the remote RDMA manager actor to communicate with.
+    /// * `other` - The ActorRef of the remote RDMA manager actor to communicate with.
+    /// * `self_device` - The local device name.
+    /// * `other_device` - The remote device name.
     ///
     /// # Returns
     ///
@@ -664,121 +807,105 @@ impl RdmaManagerMessageHandler for RdmaManagerActor {
         &mut self,
         cx: &Context<Self>,
         other: ActorRef<RdmaManagerActor>,
-
         self_device: String,
         other_device: String,
     ) -> Result<RdmaQueuePair, anyhow::Error> {
-        let other_id = other.actor_id().clone();
+        let inner_key = (other.actor_id().clone(), other_device.clone());
+        // Phase 1: Get or create the QueuePairEntry
+        let entry = loop {
+            let qp_state = self
+                .device_qps
+                .get(&self_device)
+                .and_then(|map| map.get(&inner_key))
+                .cloned();
 
-        // Use the nested map structure: local_device -> (actor_id, remote_device) -> QueuePairState
-        let inner_key = (other_id.clone(), other_device.clone());
+            match qp_state {
+                Some(QueuePairState::Ready(entry)) => {
+                    // Queue pair is ready
+                    break entry;
+                }
+                Some(QueuePairState::ConnectionError(err)) => {
+                    // Connection previously failed, propagate error
+                    return Err(anyhow::anyhow!("Connection previously failed: {}", err));
+                }
+                Some(QueuePairState::Connecting(ref notify)) => {
+                    // Another task is connecting, wait for notification
+                    let notify = notify.clone();
+                    drop(qp_state); // Release borrows before awaiting
 
-        // Check if queue pair exists in map
-        if let Some(device_map) = self.device_qps.get(&self_device) {
-            if let Some(qp_state) = device_map.get(&inner_key).cloned() {
-                match qp_state {
-                    QueuePairState::Available(qp) => {
-                        // Queue pair exists and is available - return it
-                        self.device_qps
-                            .get_mut(&self_device)
-                            .unwrap()
-                            .insert(inner_key, QueuePairState::CheckedOut);
-                        return Ok(qp);
-                    }
-                    QueuePairState::CheckedOut => {
-                        return Err(anyhow::anyhow!(
-                            "queue pair for actor {} on device {} is already checked out",
-                            other_id,
-                            other_device
-                        ));
+                    notify.notified().await;
+                    // Loop back to re-check state (could be Ready or ConnectionError now)
+                    continue;
+                }
+                None => {
+                    // No connection exists, we need to establish it
+                    let notify = Arc::new(Notify::new());
+
+                    // Insert Connecting state
+                    self.device_qps
+                        .entry(self_device.clone())
+                        .or_insert_with(HashMap::new)
+                        .insert(
+                            inner_key.clone(),
+                            QueuePairState::Connecting(notify.clone()),
+                        );
+
+                    // Establish the connection
+                    let result = self
+                        .establish_connection(
+                            cx,
+                            other.clone(),
+                            self_device.clone(),
+                            other_device.clone(),
+                        )
+                        .await;
+
+                    match result {
+                        Ok(qp) => {
+                            let entry = QueuePairEntry {
+                                qp,
+                                semaphore: Arc::new(Semaphore::new(1)),
+                            };
+
+                            // Update state to Ready
+                            self.device_qps
+                                .get_mut(&self_device)
+                                .unwrap()
+                                .insert(inner_key.clone(), QueuePairState::Ready(entry.clone()));
+
+                            // Notify all waiters
+                            notify.notify_waiters();
+                            break entry;
+                        }
+                        Err(e) => {
+                            let arc_err = Arc::new(e);
+
+                            // Insert ConnectionError state for all current and future requesters
+                            self.device_qps.get_mut(&self_device).unwrap().insert(
+                                inner_key.clone(),
+                                QueuePairState::ConnectionError(arc_err.clone()),
+                            );
+
+                            // Notify all waiters to fail
+                            notify.notify_waiters();
+                            return Err(anyhow::anyhow!("Connection failed: {}", arc_err));
+                        }
                     }
                 }
             }
-        }
+        };
 
-        // Queue pair doesn't exist - need to create connection
-        let is_loopback = other_id == cx.bind::<RdmaManagerActor>().actor_id().clone()
-            && self_device == other_device;
+        // Phase 2: Acquire semaphore permit (fair FIFO waiting)
+        let permit = entry
+            .semaphore
+            .acquire()
+            .await
+            .map_err(|e| anyhow::anyhow!("Failed to acquire semaphore: {}", e))?;
 
-        if is_loopback {
-            // Loopback connection setup
-            self.initialize_qp(cx, other.clone(), self_device.clone(), other_device.clone())
-                .await?;
-            let endpoint = self
-                .connection_info(cx, other.clone(), other_device.clone(), self_device.clone())
-                .await?;
-            self.connect(
-                cx,
-                other.clone(),
-                self_device.clone(),
-                other_device.clone(),
-                endpoint,
-            )
-            .await?;
-        } else {
-            // Remote connection setup
-            self.initialize_qp(cx, other.clone(), self_device.clone(), other_device.clone())
-                .await?;
-            other
-                .initialize_qp(
-                    cx,
-                    cx.bind().clone(),
-                    other_device.clone(),
-                    self_device.clone(),
-                )
-                .await?;
-            let other_endpoint: RdmaQpInfo = other
-                .connection_info(
-                    cx,
-                    cx.bind().clone(),
-                    other_device.clone(),
-                    self_device.clone(),
-                )
-                .await?;
-            self.connect(
-                cx,
-                other.clone(),
-                self_device.clone(),
-                other_device.clone(),
-                other_endpoint,
-            )
-            .await?;
-            let local_endpoint = self
-                .connection_info(cx, other.clone(), self_device.clone(), other_device.clone())
-                .await?;
-            other
-                .connect(
-                    cx,
-                    cx.bind().clone(),
-                    other_device.clone(),
-                    self_device.clone(),
-                    local_endpoint,
-                )
-                .await?;
-        }
+        // Forget the permit so it doesn't auto-release on drop
+        permit.forget();
 
-        // Now that connection is established, get the queue pair
-        if let Some(device_map) = self.device_qps.get(&self_device) {
-            if let Some(QueuePairState::Available(qp)) = device_map.get(&inner_key).cloned() {
-                self.device_qps
-                    .get_mut(&self_device)
-                    .unwrap()
-                    .insert(inner_key, QueuePairState::CheckedOut);
-                Ok(qp)
-            } else {
-                Err(anyhow::anyhow!(
-                    "Failed to create connection for actor {} on device {}",
-                    other_id,
-                    other_device
-                ))
-            }
-        } else {
-            Err(anyhow::anyhow!(
-                "Failed to create connection for actor {} on device {} - no device map",
-                other_id,
-                other_device
-            ))
-        }
+        Ok(entry.qp.clone())
     }
 
     async fn initialize_qp(
@@ -791,9 +918,9 @@ impl RdmaManagerMessageHandler for RdmaManagerActor {
         let other_id = other.actor_id().clone();
         let inner_key = (other_id.clone(), other_device.clone());
 
-        // Check if QP already exists in nested structure
+        // Check if QP already exists and is Ready
         if let Some(device_map) = self.device_qps.get(&self_device) {
-            if device_map.contains_key(&inner_key) {
+            if let Some(QueuePairState::Ready(_)) = device_map.get(&inner_key) {
                 return Ok(true);
             }
         }
@@ -826,11 +953,17 @@ impl RdmaManagerMessageHandler for RdmaManagerActor {
         let qp = RdmaQueuePair::new(domain_context, domain_pd, self.config.clone())
             .map_err(|e| anyhow::anyhow!("could not create RdmaQueuePair: {}", e))?;
 
+        // Wrap in QueuePairEntry with semaphore
+        let entry = QueuePairEntry {
+            qp,
+            semaphore: Arc::new(Semaphore::new(1)),
+        };
+
         // Insert the QP into the nested map structure
         self.device_qps
             .entry(self_device.clone())
             .or_insert_with(HashMap::new)
-            .insert(inner_key, QueuePairState::Available(qp));
+            .insert(inner_key, QueuePairState::Ready(entry));
 
         tracing::debug!(
             "successfully created a connection with {:?} for local device {} -> remote device {}",
@@ -857,21 +990,27 @@ impl RdmaManagerMessageHandler for RdmaManagerActor {
     ) -> Result<(), anyhow::Error> {
         tracing::debug!("connecting with {:?}", other);
         let other_id = other.actor_id().clone();
-
-        // For backward compatibility, use default device
         let inner_key = (other_id.clone(), other_device.clone());
 
         if let Some(device_map) = self.device_qps.get_mut(&self_device) {
             match device_map.get_mut(&inner_key) {
-                Some(QueuePairState::Available(qp)) => {
+                Some(QueuePairState::Ready(entry)) => {
+                    // Access the QP from the entry and connect
+                    // Note: We need to mutate the QP, but entry is behind Arc/Clone semantics
+                    // So we get a mutable reference to the QP directly from the map
+                    let qp = &mut entry.qp;
                     qp.connect(&endpoint).map_err(|e| {
                         anyhow::anyhow!("could not connect to RDMA endpoint: {}", e)
                     })?;
                     Ok(())
                 }
-                Some(QueuePairState::CheckedOut) => Err(anyhow::anyhow!(
-                    "Cannot connect: queue pair for actor {} is checked out",
+                Some(QueuePairState::Connecting(_)) => Err(anyhow::anyhow!(
+                    "Cannot connect: queue pair for actor {} is still being initialized",
                     other_id
+                )),
+                Some(QueuePairState::ConnectionError(err)) => Err(anyhow::anyhow!(
+                    "Cannot connect: connection failed: {}",
+                    err
                 )),
                 None => Err(anyhow::anyhow!(
                     "No connection found for actor {}",
@@ -902,18 +1041,21 @@ impl RdmaManagerMessageHandler for RdmaManagerActor {
     ) -> Result<RdmaQpInfo, anyhow::Error> {
         tracing::debug!("getting connection info with {:?}", other);
         let other_id = other.actor_id().clone();
-
         let inner_key = (other_id.clone(), other_device.clone());
 
         if let Some(device_map) = self.device_qps.get_mut(&self_device) {
             match device_map.get_mut(&inner_key) {
-                Some(QueuePairState::Available(qp)) => {
-                    let connection_info = qp.get_qp_info()?;
+                Some(QueuePairState::Ready(entry)) => {
+                    let connection_info = entry.qp.get_qp_info()?;
                     Ok(connection_info)
                 }
-                Some(QueuePairState::CheckedOut) => Err(anyhow::anyhow!(
-                    "Cannot get connection info: queue pair for actor {} is checked out",
+                Some(QueuePairState::Connecting(_)) => Err(anyhow::anyhow!(
+                    "Cannot get connection info: queue pair for actor {} is still being initialized",
                     other_id
+                )),
+                Some(QueuePairState::ConnectionError(err)) => Err(anyhow::anyhow!(
+                    "Cannot get connection info: connection failed: {}",
+                    err
                 )),
                 None => Err(anyhow::anyhow!(
                     "No connection found for actor {}",
@@ -928,49 +1070,119 @@ impl RdmaManagerMessageHandler for RdmaManagerActor {
         }
     }
 
-    /// Releases a queue pair back to the HashMap
+    /// Releases a queue pair back to the pool.
     ///
-    /// This method returns a queue pair to the HashMap after the caller has finished
-    /// using it. This completes the request/release cycle, similar to RdmaBuffer.
+    /// This method releases a semaphore permit, allowing the next waiting requester
+    /// to acquire the queue pair. This completes the request/release cycle.
     ///
     /// # Arguments
-    /// * `remote` - The ActorRef of the remote actor to return the queue pair for
-    /// * `qp` - The queue pair to release
+    /// * `other` - The ActorRef of the remote actor
+    /// * `self_device` - The local device name
+    /// * `other_device` - The remote device name
+    /// * `qp` - The queue pair to release (unused but kept for API compatibility)
     async fn release_queue_pair(
         &mut self,
         _cx: &Context<Self>,
         other: ActorRef<RdmaManagerActor>,
         self_device: String,
         other_device: String,
-        qp: RdmaQueuePair,
+        _qp: RdmaQueuePair,
     ) -> Result<(), anyhow::Error> {
         let inner_key = (other.actor_id().clone(), other_device.clone());
 
-        match self
+        // Get the entry from the map
+        let entry = self
             .device_qps
-            .get_mut(&self_device)
-            .unwrap()
-            .get_mut(&inner_key)
-        {
-            Some(QueuePairState::CheckedOut) => {
-                self.device_qps
-                    .get_mut(&self_device)
-                    .unwrap()
-                    .insert(inner_key, QueuePairState::Available(qp));
+            .get(&self_device)
+            .and_then(|map| map.get(&inner_key))
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "No queue pair found for actor {}, between devices {} and {}",
+                    other.actor_id(),
+                    self_device,
+                    other_device,
+                )
+            })?;
+
+        match entry {
+            QueuePairState::Ready(entry) => {
+                // Release the semaphore permit, allowing next waiter to acquire
+                entry.semaphore.add_permits(1);
                 Ok(())
             }
-            Some(QueuePairState::Available(_)) => Err(anyhow::anyhow!(
-                "Cannot release queue pair: queue pair for actor {} is already available between devices {} and {}",
+            QueuePairState::Connecting(_) => Err(anyhow::anyhow!(
+                "Cannot release queue pair: connection still in progress for actor {} between devices {} and {}",
                 other.actor_id(),
                 self_device,
                 other_device,
             )),
-            None => Err(anyhow::anyhow!(
-                "No queue pair found for actor {}, between devices {} and {}",
-                other.actor_id(),
-                self_device,
-                other_device,
+            QueuePairState::ConnectionError(err) => Err(anyhow::anyhow!(
+                "Cannot release queue pair: connection failed: {}",
+                err
             )),
         }
+    }
+    async fn read_into(
+        &mut self,
+        cx: &Context<Self>,
+        local: RdmaBuffer,
+        remote: RdmaBuffer,
+        timeout: tokio::time::Duration,
+    ) -> Result<(), anyhow::Error> {
+        let remote_owner = remote.owner.clone();
+
+        let local_device = local.device_name.clone();
+        let remote_device = remote.device_name.clone();
+        let mut qp = self
+            .request_queue_pair(
+                cx,
+                remote_owner.clone(),
+                local_device.clone(),
+                remote_device.clone(),
+            )
+            .await?;
+        qp.put(local.clone(), remote)?;
+        let result = local
+            .wait_for_completion(&mut qp, PollTarget::Send, timeout)
+            .await;
+
+        // Release the queue pair back to the actor
+        self.release_queue_pair(cx, remote_owner, local_device, remote_device, qp)
+            .await?;
+
+        result?;
+        Ok(())
+    }
+    async fn write_from(
+        &mut self,
+        cx: &Context<Self>,
+        local: RdmaBuffer,
+        remote: RdmaBuffer,
+        timeout: tokio::time::Duration,
+    ) -> Result<(), anyhow::Error> {
+        let remote_owner = remote.owner.clone();
+
+        let local_device = local.device_name.clone();
+        let remote_device = remote.device_name.clone();
+        let mut qp = self
+            .request_queue_pair(
+                cx,
+                remote_owner.clone(),
+                local_device.clone(),
+                remote_device.clone(),
+            )
+            .await?;
+
+        qp.get(local.clone(), remote)?;
+        let result = local
+            .wait_for_completion(&mut qp, PollTarget::Send, timeout)
+            .await;
+
+        // Release the queue pair back to the actor
+        self.release_queue_pair(cx, remote_owner, local_device, remote_device, qp)
+            .await?;
+
+        result?;
+        Ok(())
     }
 }

--- a/monarch_rdma/src/rdma_manager_actor_tests.rs
+++ b/monarch_rdma/src/rdma_manager_actor_tests.rs
@@ -56,7 +56,7 @@ mod tests {
             )
             .await?;
 
-        env.verify_buffers(BSIZE).await?;
+        env.verify_buffers().await?;
         Ok(())
     }
 
@@ -93,7 +93,7 @@ mod tests {
             )
             .await?;
 
-        env.verify_buffers(BSIZE).await?;
+        env.verify_buffers().await?;
         Ok(())
     }
 
@@ -123,7 +123,7 @@ mod tests {
         // Poll for completion
         wait_for_completion(&mut qp_1, PollTarget::Send, 2).await?;
 
-        env.verify_buffers(BSIZE).await?;
+        env.verify_buffers().await?;
         Ok(())
     }
 
@@ -151,7 +151,7 @@ mod tests {
         qp_1.put(env.rdma_handle_1.clone(), env.rdma_handle_2.clone())?;
         wait_for_completion(&mut qp_1, PollTarget::Send, 2).await?;
 
-        env.verify_buffers(BSIZE).await?;
+        env.verify_buffers().await?;
         env.cleanup().await?;
         Ok(())
     }
@@ -188,7 +188,7 @@ mod tests {
         qp_2.put_with_recv(env.rdma_handle_2.clone(), env.rdma_handle_1.clone())?;
         qp_1.recv(env.rdma_handle_1.clone(), env.rdma_handle_2.clone())?;
         wait_for_completion(&mut qp_2, PollTarget::Send, 5).await?;
-        env.verify_buffers(BSIZE).await?;
+        env.verify_buffers().await?;
         env.cleanup().await?;
         Ok(())
     }
@@ -219,7 +219,7 @@ mod tests {
         // Poll for completion
         wait_for_completion(&mut qp_1, PollTarget::Send, 5).await?;
 
-        env.verify_buffers(BSIZE).await?;
+        env.verify_buffers().await?;
         Ok(())
     }
 
@@ -249,7 +249,7 @@ mod tests {
         // Poll for completion
         wait_for_completion(&mut qp_2, PollTarget::Send, 5).await?;
 
-        env.verify_buffers(BSIZE).await?;
+        env.verify_buffers().await?;
         Ok(())
     }
 
@@ -270,7 +270,7 @@ mod tests {
             .read_into(env.client_1, env.rdma_handle_2.clone(), 2)
             .await?;
 
-        env.verify_buffers(BSIZE).await?;
+        env.verify_buffers().await?;
         env.cleanup().await?;
         Ok(())
     }
@@ -292,7 +292,7 @@ mod tests {
             .write_from(env.client_1, env.rdma_handle_2.clone(), 2)
             .await?;
 
-        env.verify_buffers(BSIZE).await?;
+        env.verify_buffers().await?;
         Ok(())
     }
 
@@ -342,7 +342,7 @@ mod tests {
         // Poll for completion
         wait_for_completion_gpu(&mut qp_1, PollTarget::Send, 5).await?;
 
-        env.verify_buffers(BSIZE).await?;
+        env.verify_buffers().await?;
         Ok(())
     }
 
@@ -381,7 +381,7 @@ mod tests {
         // Poll for completion
         wait_for_completion_gpu(&mut qp_1, PollTarget::Send, 5).await?;
 
-        env.verify_buffers(BSIZE).await?;
+        env.verify_buffers().await?;
         Ok(())
     }
 
@@ -440,7 +440,7 @@ mod tests {
         ring_db_gpu(&mut qp_2).await?;
         wait_for_completion_gpu(&mut qp_1, PollTarget::Recv, 10).await?;
         wait_for_completion_gpu(&mut qp_2, PollTarget::Send, 10).await?;
-        env.verify_buffers(BSIZE).await?;
+        env.verify_buffers().await?;
         env.cleanup().await?;
         Ok(())
     }
@@ -475,7 +475,7 @@ mod tests {
 
         wait_for_completion(&mut qp_1, PollTarget::Send, 5).await?;
 
-        env.verify_buffers(BSIZE).await?;
+        env.verify_buffers().await?;
         env.cleanup().await?;
         Ok(())
     }
@@ -510,7 +510,7 @@ mod tests {
 
         wait_for_completion(&mut qp_1, PollTarget::Send, 5).await?;
 
-        env.verify_buffers(BSIZE).await?;
+        env.verify_buffers().await?;
         env.cleanup().await?;
         Ok(())
     }
@@ -538,7 +538,7 @@ mod tests {
             .read_into(env.client_1, env.rdma_handle_2.clone(), 5)
             .await?;
 
-        env.verify_buffers(BSIZE).await?;
+        env.verify_buffers().await?;
         env.cleanup().await?;
         Ok(())
     }
@@ -564,7 +564,7 @@ mod tests {
             .read_into(env.client_1, env.rdma_handle_2.clone(), 5)
             .await?;
 
-        env.verify_buffers(BSIZE).await?;
+        env.verify_buffers().await?;
         env.cleanup().await?;
         Ok(())
     }
@@ -590,7 +590,7 @@ mod tests {
             .read_into(env.client_1, env.rdma_handle_2.clone(), 5)
             .await?;
 
-        env.verify_buffers(BSIZE).await?;
+        env.verify_buffers().await?;
         env.cleanup().await?;
         Ok(())
     }
@@ -616,7 +616,7 @@ mod tests {
             .write_from(env.client_1, env.rdma_handle_2.clone(), 5)
             .await?;
 
-        env.verify_buffers(BSIZE).await?;
+        env.verify_buffers().await?;
         env.cleanup().await?;
         Ok(())
     }
@@ -644,7 +644,7 @@ mod tests {
             .read_into(env.client_1, env.rdma_handle_2.clone(), 2)
             .await?;
 
-        env.verify_buffers(BSIZE).await?;
+        env.verify_buffers().await?;
         env.cleanup().await?;
         Ok(())
     }
@@ -672,7 +672,7 @@ mod tests {
             .write_from(env.client_1, env.rdma_handle_2.clone(), 2)
             .await?;
 
-        env.verify_buffers(BSIZE).await?;
+        env.verify_buffers().await?;
         env.cleanup().await?;
         Ok(())
     }
@@ -704,7 +704,7 @@ mod tests {
             .read_into(env.client_1, env.rdma_handle_2.clone(), 5)
             .await?;
 
-        env.verify_buffers(BSIZE).await?;
+        env.verify_buffers().await?;
         env.cleanup().await?;
         Ok(())
     }
@@ -736,7 +736,70 @@ mod tests {
             .write_from(env.client_1, env.rdma_handle_2.clone(), 5)
             .await?;
 
-        env.verify_buffers(BSIZE).await?;
+        env.verify_buffers().await?;
+        env.cleanup().await?;
+        Ok(())
+    }
+
+    #[timed_test::async_timed_test(timeout_secs = 60)]
+    async fn test_concurrent_read_into() -> Result<(), anyhow::Error> {
+        const BSIZE: usize = 32;
+        let devices = get_all_devices();
+        if devices.len() < 5 {
+            println!(
+                "skipping this test as it is only configured on H100 nodes with backend network"
+            );
+            return Ok(());
+        }
+
+        let mut env = RdmaManagerTestEnv::setup(BSIZE, "cpu:0", "cpu:1").await?;
+
+        // Create three distinct buffer pairs that share the same actors
+        let (h1_a, h2_a) = env.create_buffer_pair(BSIZE).await?;
+        let (h1_b, h2_b) = env.create_buffer_pair(BSIZE).await?;
+        let (h1_c, h2_c) = env.create_buffer_pair(BSIZE).await?;
+
+        // Launch 3 concurrent read_into operations, each with its own buffer pair
+        // All operations share the same queue pair connection and should wait fairly
+        let task1 = h1_a.read_into(env.client_1, h2_a.clone(), 2);
+        let task2 = h1_b.read_into(env.client_1, h2_b.clone(), 2);
+        let task3 = h1_c.read_into(env.client_1, h2_c.clone(), 2);
+
+        tokio::try_join!(task1, task2, task3)?;
+        env.verify_all_buffer_pairs().await?;
+
+        env.cleanup().await?;
+        Ok(())
+    }
+
+    #[timed_test::async_timed_test(timeout_secs = 60)]
+    async fn test_concurrent_write_from() -> Result<(), anyhow::Error> {
+        const BSIZE: usize = 32;
+        let devices = get_all_devices();
+        if devices.len() < 5 {
+            println!(
+                "skipping this test as it is only configured on H100 nodes with backend network"
+            );
+            return Ok(());
+        }
+
+        let mut env = RdmaManagerTestEnv::setup(BSIZE, "cpu:0", "cpu:1").await?;
+
+        // Create three distinct buffer pairs that share the same actors
+        let (h1_a, h2_a) = env.create_buffer_pair(BSIZE).await?;
+        let (h1_b, h2_b) = env.create_buffer_pair(BSIZE).await?;
+        let (h1_c, h2_c) = env.create_buffer_pair(BSIZE).await?;
+
+        // Launch 3 concurrent write_from operations, each with its own buffer pair
+        // All operations share the same queue pair connection and should wait fairly
+        let task1 = h1_a.write_from(env.client_1, h2_a.clone(), 2);
+        let task2 = h1_b.write_from(env.client_1, h2_b.clone(), 2);
+        let task3 = h1_c.write_from(env.client_1, h2_c.clone(), 2);
+
+        tokio::try_join!(task1, task2, task3)?;
+
+        env.verify_all_buffer_pairs().await?;
+
         env.cleanup().await?;
         Ok(())
     }


### PR DESCRIPTION
Summary:
This diff adds a FIFO waiting mechanism for acquiring the queue pair.

**True concurrency support will come in follow-up diff**: this will require we track wr_id and create a polling task for each queue pair, which will need further refactoring.

**Limitations**
- No true concurrency support: only one request can be in-flight at a time per queue pair connection. However, subsequent requests now wait fairly (FIFO) instead of panicking with "already checked out" errors.
- request_queue_pair/release_queue_pair is still not cancel safe (if an operation times out, the queue pair might not be returned and subsequent requests will fail)

Core changes:
1. **Fair Waiting via Semaphore**: Replaced Available/CheckedOut states with Connecting/Ready/ConnectionError. Added QueuePairEntry wrapping RdmaQueuePair + Arc<Semaphore>. request_queue_pair uses two-phase approach (get/create QP, then acquire semaphore permit for FIFO fairness).

2. **Refactor - Moved read_into/write_from to RdmaManagerActor**: Prevents deadlock in actor message queue. Old design had RdmaBuffer call request_queue_pair RPC → perform operation → call release_queue_pair RPC, causing release messages to queue behind waiting requests. Now entire operation (request → use → release) happens within single actor message handler.

3. **Refactored Connection Logic**: Extracted establish_connection helper handling both loopback and remote connections.

5. **Test**: Added create_buffer_pair method and concurrent tests.

Differential Revision: D85627877
