### PR TITLE
: add generated build info module with commit hash and metadata

### DIFF
--- a/hyperactor_mesh/src/lib.rs
+++ b/hyperactor_mesh/src/lib.rs
@@ -35,11 +35,25 @@ pub mod test_utils;
 mod testresource;
 pub mod v1;
 
+// Generated build information module
+#[cfg(fbcode_build)]
+#[path = "../build_info.rs"]
+pub mod build_info;
+
 pub use actor_mesh::RootActorMesh;
 pub use actor_mesh::SlicedActorMesh;
 pub use bootstrap::Bootstrap;
 pub use bootstrap::bootstrap;
 pub use bootstrap::bootstrap_or_die;
+// Re-export build info attributes for easy access
+#[cfg(fbcode_build)]
+pub use build_info::BUILD_COMMIT;
+#[cfg(fbcode_build)]
+pub use build_info::BUILD_HOST;
+#[cfg(fbcode_build)]
+pub use build_info::BUILD_TIMESTAMP;
+#[cfg(fbcode_build)]
+pub use build_info::BUILD_USER;
 pub use comm::CommActor;
 pub use dashmap;
 pub use hyperactor_mesh_macros::sel;

--- a/python/monarch/gradient/_gradient_generator.cpp
+++ b/python/monarch/gradient/_gradient_generator.cpp
@@ -420,12 +420,20 @@ struct GradientGenerator {
     DEBUG_PRINT(
         "// add: " << node->node->name()
                    << ", input_nr=" << static_cast<int>(input_nr) << "\n");
+#if !defined(FBCODE_BUILD)
+    realInputBuffer(node).add(
+        input_nr,
+        check_and_reduce(node->node, input_nr, std::move(t)),
+        std::nullopt,
+        std::nullopt);
+#else
     realInputBuffer(node).add(
         input_nr,
         check_and_reduce(node->node, input_nr, std::move(t)),
         std::nullopt,
         std::nullopt,
         node->node);
+#endif
   }
 
   InputBuffer& realInputBuffer(NodeState* state) {


### PR DESCRIPTION
Summary:
this diff adds an experimental build identity module to hyperactor_mesh.

at buck build time we generate a rust module ("build_info.rs") with four values: sapling changeset hash, build timestamp, user, and host. the file is not checked in; it is produced in buck-out and added to the crate via `mapped_srcs`. cargo / oss builds do not see it. fbcode builds get a new `hyperactor_mesh::build_info` module (behind `#[cfg(fbcode_build)]`) that exposes `commit()`, `timestamp()`, `user()`, and `host()`. each of those returns a `&'static str` baked in at build time. no syscalls or runtime i/o.

the module can also register these values into the global config/attrs registry. calling `init()` installs `BUILD_COMMIT`, `BUILD_TIMESTAMP`, `BUILD_USER`, and `BUILD_HOST` into process-wide `Attrs` via `hyperactor::config::global`. callsites that only need to compare versions (e.g. host/proc handshake) can read `commit()` directly. code that wants to surface this via logs or admin endpoints can call `init()` once and query the global config.

this is buck-only. we do not add a `build.rs`, we do not write into the source tree, and cargo builds are unchanged.

rfc: host/child handshake will start comparing `commit()` at startup and warn or fail on mismatch.

Differential Revision: D86009410


