### PR TITLE
Back out "don't pass in "reason" to channel::serve; instead rely on span contexts"

### DIFF
--- a/controller/src/lib.rs
+++ b/controller/src/lib.rs
@@ -1573,7 +1573,7 @@ mod tests {
         // Set up a local actor.
         let local_proc_id = world_id.proc_id(rank);
         let (local_proc_addr, local_proc_rx) =
-            channel::serve(ChannelAddr::any(ChannelTransport::Local)).unwrap();
+            channel::serve(ChannelAddr::any(ChannelTransport::Local), "mock_proc_actor").unwrap();
         let local_proc_mbox = Mailbox::new_detached(
             local_proc_id.actor_id(format!("test_dummy_proc{}", idx).to_string(), 0),
         );

--- a/hyperactor/benches/main.rs
+++ b/hyperactor/benches/main.rs
@@ -87,7 +87,7 @@ fn bench_message_sizes(c: &mut Criterion) {
                         assert!(!socket_addr.ip().is_loopback());
                     }
 
-                    let (listen_addr, mut rx) = serve::<Message>(addr).unwrap();
+                    let (listen_addr, mut rx) = serve::<Message>(addr, "bench").unwrap();
                     let tx = dial::<Message>(listen_addr).unwrap();
                     let msg = Message::new(0, size);
                     let start = Instant::now();
@@ -127,7 +127,7 @@ fn bench_message_rates(c: &mut Criterion) {
                 b.iter_custom(|iters| async move {
                     let total_msgs = iters * rate;
                     let addr = ChannelAddr::any(transport.clone());
-                    let (listen_addr, mut rx) = serve::<Message>(addr).unwrap();
+                    let (listen_addr, mut rx) = serve::<Message>(addr, "bench").unwrap();
                     tokio::spawn(async move {
                         let mut received_count = 0;
 
@@ -212,9 +212,9 @@ async fn channel_ping_pong(
     struct Message(Part);
 
     let (client_addr, mut client_rx) =
-        channel::serve::<Message>(ChannelAddr::any(transport.clone())).unwrap();
+        channel::serve::<Message>(ChannelAddr::any(transport.clone()), "ping_pong_client").unwrap();
     let (server_addr, mut server_rx) =
-        channel::serve::<Message>(ChannelAddr::any(transport.clone())).unwrap();
+        channel::serve::<Message>(ChannelAddr::any(transport.clone()), "ping_pong_server").unwrap();
 
     let _server_handle: tokio::task::JoinHandle<Result<(), anyhow::Error>> =
         tokio::spawn(async move {

--- a/hyperactor/example/channel.rs
+++ b/hyperactor/example/channel.rs
@@ -64,8 +64,11 @@ async fn client(
 ) -> anyhow::Result<()> {
     let server_tx = channel::dial(server_addr)?;
 
-    let (client_addr, mut client_rx) =
-        channel::serve::<Message>(ChannelAddr::any(server_tx.addr().transport().clone())).unwrap();
+    let (client_addr, mut client_rx) = channel::serve::<Message>(
+        ChannelAddr::any(server_tx.addr().transport().clone()),
+        "example",
+    )
+    .unwrap();
 
     server_tx.post(Message::Hello(client_addr));
 
@@ -164,7 +167,8 @@ async fn main() -> Result<(), anyhow::Error> {
     match args.command {
         Some(Commands::Server) => {
             let (server_addr, server_rx) =
-                channel::serve::<Message>(ChannelAddr::any(args.transport.clone())).unwrap();
+                channel::serve::<Message>(ChannelAddr::any(args.transport.clone()), "example")
+                    .unwrap();
             eprintln!("server listening on {}", server_addr);
             server(server_rx).await?;
         }
@@ -176,7 +180,8 @@ async fn main() -> Result<(), anyhow::Error> {
         // No command: run a self-contained benchmark.
         None => {
             let (server_addr, server_rx) =
-                channel::serve::<Message>(ChannelAddr::any(args.transport.clone())).unwrap();
+                channel::serve::<Message>(ChannelAddr::any(args.transport.clone()), "example")
+                    .unwrap();
             let _server_handle = tokio::spawn(server(server_rx));
             let client_handle = tokio::spawn(client(server_addr, args.message_size, args.num_iter));
 

--- a/hyperactor/src/host.rs
+++ b/hyperactor/src/host.rs
@@ -131,12 +131,11 @@ impl<M: ProcManager> Host<M> {
     /// Serve a host using the provided ProcManager, on the provided `addr`.
     /// On success, the host will multiplex messages for procs on the host
     /// on the address of the host.
-    #[tracing::instrument(skip(manager))]
     pub async fn serve(
         manager: M,
         addr: ChannelAddr,
     ) -> Result<(Self, MailboxServerHandle), HostError> {
-        let (frontend_addr, frontend_rx) = channel::serve(addr)?;
+        let (frontend_addr, frontend_rx) = channel::serve(addr, "host frontend")?;
 
         // We set up a cascade of routers: first, the outer router supports
         // sending to the the system proc, while the dial router manages dialed
@@ -145,7 +144,8 @@ impl<M: ProcManager> Host<M> {
 
         // Establish a backend channel on the preferred transport. We currently simply
         // serve the same router on both.
-        let (backend_addr, backend_rx) = channel::serve(ChannelAddr::any(manager.transport()))?;
+        let (backend_addr, backend_rx) =
+            channel::serve(ChannelAddr::any(manager.transport()), "host backend")?;
 
         // Set up a system proc. This is often used to manage the host itself.
         let service_proc_id = ProcId::Direct(frontend_addr.clone(), "service".to_string());
@@ -863,7 +863,6 @@ where
         ChannelTransport::Local
     }
 
-    #[tracing::instrument(skip(self, _config))]
     async fn spawn(
         &self,
         proc_id: ProcId,
@@ -875,7 +874,10 @@ where
             proc_id.clone(),
             MailboxClient::dial(forwarder_addr)?.into_boxed(),
         );
-        let (proc_addr, rx) = channel::serve(ChannelAddr::any(transport))?;
+        let (proc_addr, rx) = channel::serve(
+            ChannelAddr::any(transport),
+            &format!("LocalProcManager spawning: {}", &proc_id),
+        )?;
         self.procs
             .lock()
             .await
@@ -1041,15 +1043,16 @@ where
         ChannelTransport::Unix
     }
 
-    #[tracing::instrument(skip(self, _config))]
     async fn spawn(
         &self,
         proc_id: ProcId,
         forwarder_addr: ChannelAddr,
         _config: (),
     ) -> Result<Self::Handle, HostError> {
-        let (callback_addr, mut callback_rx) =
-            channel::serve(ChannelAddr::any(ChannelTransport::Unix))?;
+        let (callback_addr, mut callback_rx) = channel::serve(
+            ChannelAddr::any(ChannelTransport::Unix),
+            &format!("ProcessProcManager spawning: {}", &proc_id),
+        )?;
 
         let mut cmd = Command::new(&self.program);
         cmd.env("HYPERACTOR_HOST_PROC_ID", proc_id.to_string());
@@ -1135,7 +1138,6 @@ where
 /// forwarding messages to the provided `backend_addr`,
 /// and returning the proc's address and agent actor on
 /// the provided `callback_addr`.
-#[tracing::instrument(skip(spawn))]
 pub async fn spawn_proc<A, S, F>(
     proc_id: ProcId,
     backend_addr: ChannelAddr,
@@ -1161,7 +1163,10 @@ where
 
     // Finally serve the proc on the same transport as the backend address,
     // and call back.
-    let (proc_addr, proc_rx) = channel::serve(ChannelAddr::any(backend_transport))?;
+    let (proc_addr, proc_rx) = channel::serve(
+        ChannelAddr::any(backend_transport),
+        &format!("proc addr of: {}", &proc_id),
+    )?;
     proc.clone().serve(proc_rx);
     channel::dial(callback_addr)?
         .send((proc_addr, agent_handle.bind::<A>()))

--- a/hyperactor/src/mailbox.rs
+++ b/hyperactor/src/mailbox.rs
@@ -2868,7 +2868,7 @@ mod tests {
             .unwrap(),
         );
 
-        let (_, rx) = serve::<MessageEnvelope>(ChannelAddr::Sim(dst_addr.clone())).unwrap();
+        let (_, rx) = serve::<MessageEnvelope>(ChannelAddr::Sim(dst_addr.clone()), "test").unwrap();
         let tx = dial::<MessageEnvelope>(src_to_dst).unwrap();
         let mbox = Mailbox::new_detached(id!(test[0].actor0));
         let serve_handle = mbox.clone().serve(rx);
@@ -2997,7 +2997,8 @@ mod tests {
 
         let mut handles = Vec::new(); // hold on to handles, or channels get closed
         for mbox in mailboxes.iter() {
-            let (addr, rx) = channel::serve(ChannelAddr::any(ChannelTransport::Local)).unwrap();
+            let (addr, rx) =
+                channel::serve(ChannelAddr::any(ChannelTransport::Local), "test").unwrap();
             let handle = (*mbox).clone().serve(rx);
             handles.push(handle);
 

--- a/hyperactor_mesh/src/actor_mesh.rs
+++ b/hyperactor_mesh/src/actor_mesh.rs
@@ -1731,7 +1731,7 @@ mod tests {
             let config = hyperactor::config::global::lock();
             let _guard = config.override_key(MAX_CAST_DIMENSION_SIZE, 2);
 
-            let (_, mut rx) = serve::<usize>(addr).unwrap();
+            let (_, mut rx) = serve::<usize>(addr, "test").unwrap();
 
             let expected_ranks = selection
                 .eval(

--- a/hyperactor_mesh/src/alloc/local.rs
+++ b/hyperactor_mesh/src/alloc/local.rs
@@ -147,7 +147,10 @@ impl Alloc for LocalAlloc {
             match self.todo_rx.recv().await? {
                 Action::Start(rank) => {
                     let (addr, proc_rx) = loop {
-                        match channel::serve(ChannelAddr::any(self.transport())) {
+                        match channel::serve(
+                            ChannelAddr::any(self.transport()),
+                            "LocalAlloc next proc addr",
+                        ) {
                             Ok(addr_and_proc_rx) => break addr_and_proc_rx,
                             Err(err) => {
                                 tracing::error!(

--- a/hyperactor_mesh/src/alloc/process.rs
+++ b/hyperactor_mesh/src/alloc/process.rs
@@ -89,8 +89,11 @@ impl Allocator for ProcessAllocator {
 
     #[hyperactor::instrument(fields(name = "process_allocate", monarch_client_trace_id = spec.constraints.match_labels.get(CLIENT_TRACE_ID_LABEL).cloned().unwrap_or_else(|| "".to_string())))]
     async fn allocate(&mut self, spec: AllocSpec) -> Result<ProcessAlloc, AllocatorError> {
-        let (bootstrap_addr, rx) = channel::serve(ChannelAddr::any(ChannelTransport::Unix))
-            .map_err(anyhow::Error::from)?;
+        let (bootstrap_addr, rx) = channel::serve(
+            ChannelAddr::any(ChannelTransport::Unix),
+            "ProcessAllocator allocate bootstrap_addr",
+        )
+        .map_err(anyhow::Error::from)?;
 
         if spec.transport == ChannelTransport::Local {
             return Err(AllocatorError::Other(anyhow::anyhow!(

--- a/hyperactor_mesh/src/alloc/remoteprocess.rs
+++ b/hyperactor_mesh/src/alloc/remoteprocess.rs
@@ -173,7 +173,6 @@ impl RemoteProcessAllocator {
     /// Start a remote process allocator with given allocator listening for
     /// RemoteProcessAllocatorMessage on serve_addr.
     /// Used for testing.
-    #[tracing::instrument(skip(self, process_allocator))]
     pub async fn start_with_allocator<A: Allocator + Send + Sync + 'static>(
         &self,
         serve_addr: ChannelAddr,
@@ -185,7 +184,8 @@ impl RemoteProcessAllocator {
         <A as Allocator>::Alloc: Sync,
     {
         tracing::info!("starting remote allocator on: {}", serve_addr);
-        let (_, mut rx) = channel::serve(serve_addr.clone()).map_err(anyhow::Error::from)?;
+        let (_, mut rx) = channel::serve(serve_addr.clone(), "RemoteProcessAllocator serve addr")
+            .map_err(anyhow::Error::from)?;
 
         struct ActiveAllocation {
             handle: JoinHandle<()>,
@@ -309,7 +309,6 @@ impl RemoteProcessAllocator {
         Ok(())
     }
 
-    #[tracing::instrument(skip(alloc, cancel_token))]
     #[observe_async("RemoteProcessAllocator")]
     async fn handle_allocation_request(
         alloc: Box<dyn Alloc + Send + Sync>,
@@ -321,13 +320,14 @@ impl RemoteProcessAllocator {
     ) {
         tracing::info!("handle allocation request, bootstrap_addr: {bootstrap_addr}");
         // start proc message forwarder
-        let (forwarder_addr, forwarder_rx) = match forwarder_addr.serve_with_config() {
-            Ok(v) => v,
-            Err(e) => {
-                tracing::error!("failed to to bootstrap forwarder actor: {}", e);
-                return;
-            }
-        };
+        let (forwarder_addr, forwarder_rx) =
+            match forwarder_addr.serve_with_config("handle_allocation_request: forwarder_addr") {
+                Ok(v) => v,
+                Err(e) => {
+                    tracing::error!("failed to to bootstrap forwarder actor: {}", e);
+                    return;
+                }
+            };
         let router = DialMailboxRouter::new();
         let mailbox_handle = router.clone().serve(forwarder_rx);
         tracing::info!("started forwarder on: {}", forwarder_addr);
@@ -617,7 +617,6 @@ impl RemoteProcessAlloc {
     /// to obtain a list of allocate hosts. Then Allocate message will be sent to all
     /// RemoteProcessAllocator on all hosts. Heartbeats will be used to maintain health
     /// status of remote hosts.
-    #[tracing::instrument(skip(initializer))]
     #[observe_result("RemoteProcessAlloc")]
     pub async fn new(
         spec: AllocSpec,
@@ -630,7 +629,7 @@ impl RemoteProcessAlloc {
             None => AllocAssignedAddr::new(ChannelAddr::any(spec.transport.clone())),
         };
 
-        let (bootstrap_addr, rx) = alloc_serve_addr.serve_with_config()?;
+        let (bootstrap_addr, rx) = alloc_serve_addr.serve_with_config("alloc bootstrap_addr")?;
 
         tracing::info!(
             "starting alloc for {} on: {}",
@@ -1327,7 +1326,7 @@ mod test {
         hyperactor_telemetry::initialize_logging_for_test();
         let serve_addr = ChannelAddr::any(ChannelTransport::Unix);
         let bootstrap_addr = ChannelAddr::any(ChannelTransport::Unix);
-        let (_, mut rx) = channel::serve(bootstrap_addr.clone()).unwrap();
+        let (_, mut rx) = channel::serve(bootstrap_addr.clone(), "test").unwrap();
 
         let extent = extent!(host = 1, gpu = 2);
         let tx = channel::dial(serve_addr.clone()).unwrap();
@@ -1483,7 +1482,7 @@ mod test {
         hyperactor_telemetry::initialize_logging_for_test();
         let serve_addr = ChannelAddr::any(ChannelTransport::Unix);
         let bootstrap_addr = ChannelAddr::any(ChannelTransport::Unix);
-        let (_, mut rx) = channel::serve(bootstrap_addr.clone()).unwrap();
+        let (_, mut rx) = channel::serve(bootstrap_addr.clone(), "test").unwrap();
 
         let extent = extent!(host = 1, gpu = 2);
         let tx = channel::dial(serve_addr.clone()).unwrap();
@@ -1564,7 +1563,7 @@ mod test {
         hyperactor_telemetry::initialize_logging_for_test();
         let serve_addr = ChannelAddr::any(ChannelTransport::Unix);
         let bootstrap_addr = ChannelAddr::any(ChannelTransport::Unix);
-        let (_, mut rx) = channel::serve(bootstrap_addr.clone()).unwrap();
+        let (_, mut rx) = channel::serve(bootstrap_addr.clone(), "test").unwrap();
 
         let extent = extent!(host = 1, gpu = 2);
 
@@ -1703,7 +1702,7 @@ mod test {
         hyperactor_telemetry::initialize_logging_for_test();
         let serve_addr = ChannelAddr::any(ChannelTransport::Unix);
         let bootstrap_addr = ChannelAddr::any(ChannelTransport::Unix);
-        let (_, mut rx) = channel::serve(bootstrap_addr.clone()).unwrap();
+        let (_, mut rx) = channel::serve(bootstrap_addr.clone(), "test").unwrap();
 
         let extent = extent!(host = 1, gpu = 2);
 
@@ -1793,7 +1792,7 @@ mod test {
         hyperactor_telemetry::initialize_logging_for_test();
         let serve_addr = ChannelAddr::any(ChannelTransport::Unix);
         let bootstrap_addr = ChannelAddr::any(ChannelTransport::Unix);
-        let (_, mut rx) = channel::serve(bootstrap_addr.clone()).unwrap();
+        let (_, mut rx) = channel::serve(bootstrap_addr.clone(), "test").unwrap();
 
         let extent = extent!(host = 1, gpu = 2);
 
@@ -1895,7 +1894,7 @@ mod test {
         hyperactor_telemetry::initialize_logging(ClockKind::default());
         let serve_addr = ChannelAddr::any(ChannelTransport::Unix);
         let bootstrap_addr = ChannelAddr::any(ChannelTransport::Unix);
-        let (_, mut rx) = channel::serve(bootstrap_addr.clone()).unwrap();
+        let (_, mut rx) = channel::serve(bootstrap_addr.clone(), "test").unwrap();
 
         let extent = extent!(host = 1, gpu = 1);
         let tx = channel::dial(serve_addr.clone()).unwrap();
@@ -1976,7 +1975,7 @@ mod test {
         hyperactor_telemetry::initialize_logging(ClockKind::default());
         let serve_addr = ChannelAddr::any(ChannelTransport::Unix);
         let bootstrap_addr = ChannelAddr::any(ChannelTransport::Unix);
-        let (_, mut rx) = channel::serve(bootstrap_addr.clone()).unwrap();
+        let (_, mut rx) = channel::serve(bootstrap_addr.clone(), "test").unwrap();
 
         let extent = extent!(host = 1, gpu = 1);
         let tx = channel::dial(serve_addr.clone()).unwrap();
@@ -2456,7 +2455,7 @@ mod test_alloc {
         let hosts_per_proc_mesh = 5;
 
         let pid_addr = ChannelAddr::any(ChannelTransport::Unix);
-        let (pid_addr, mut pid_rx) = channel::serve::<u32>(pid_addr).unwrap();
+        let (pid_addr, mut pid_rx) = channel::serve::<u32>(pid_addr, "test").unwrap();
 
         let addresses = (0..(num_proc_meshes * hosts_per_proc_mesh))
             .map(|_| ChannelAddr::any(ChannelTransport::Unix).to_string())
@@ -2478,7 +2477,7 @@ mod test_alloc {
 
         let done_allocating_addr = ChannelAddr::any(ChannelTransport::Unix);
         let (done_allocating_addr, mut done_allocating_rx) =
-            channel::serve::<()>(done_allocating_addr).unwrap();
+            channel::serve::<()>(done_allocating_addr, "test").unwrap();
         let mut remote_process_alloc = Command::new(crate::testresource::get(
             "monarch/hyperactor_mesh/remote_process_alloc",
         ))

--- a/hyperactor_mesh/src/bootstrap.rs
+++ b/hyperactor_mesh/src/bootstrap.rs
@@ -66,8 +66,6 @@ use tokio::process::ChildStdout;
 use tokio::process::Command;
 use tokio::sync::oneshot;
 use tokio::sync::watch;
-use tracing::Instrument;
-use tracing::Level;
 
 use crate::logging::OutputTarget;
 use crate::logging::StreamFwder;
@@ -406,15 +404,6 @@ impl Bootstrap {
                 socket_dir_path,
                 config,
             } => {
-                let entered = tracing::span!(
-                    Level::INFO,
-                    "proc_bootstrap",
-                    %proc_id,
-                    %backend_addr,
-                    %callback_addr,
-                    socket_dir_path = %socket_dir_path.display(),
-                )
-                .entered();
                 if let Some(attrs) = config {
                     config::set(config::Source::ClientOverride, attrs);
                     tracing::debug!("bootstrap: installed ClientOverride config snapshot (Proc)");
@@ -451,20 +440,16 @@ impl Bootstrap {
 
                 let proc = Proc::new(proc_id.clone(), proc_sender.into_boxed());
 
-                let span = entered.exit();
-
                 let agent_handle = ok!(ProcMeshAgent::boot_v1(proc.clone())
-                    .instrument(span.clone())
                     .await
                     .map_err(|e| HostError::AgentSpawnFailure(proc_id, e)));
 
                 // Finally serve the proc on the same transport as the backend address,
                 // and call back.
-                let (proc_addr, proc_rx) = ok!(channel::serve(serve_addr));
+                let (proc_addr, proc_rx) = ok!(channel::serve(serve_addr, "proc_backend"));
                 proc.clone().serve(proc_rx);
                 ok!(ok!(channel::dial(callback_addr))
                     .send((proc_addr, agent_handle.bind::<ProcMeshAgent>()))
-                    .instrument(span)
                     .await
                     .map_err(ChannelError::from));
 
@@ -1815,15 +1800,16 @@ impl ProcManager for BootstrapProcManager {
     /// Returns a [`BootstrapProcHandle`] that exposes the child
     /// process's lifecycle (status, wait/ready, termination). Errors
     /// are surfaced as [`HostError`].
-    #[tracing::instrument(skip(self, config))]
     async fn spawn(
         &self,
         proc_id: ProcId,
         backend_addr: ChannelAddr,
         config: BootstrapProcConfig,
     ) -> Result<Self::Handle, HostError> {
-        let (callback_addr, mut callback_rx) =
-            channel::serve(ChannelAddr::any(ChannelTransport::Unix))?;
+        let (callback_addr, mut callback_rx) = channel::serve(
+            ChannelAddr::any(ChannelTransport::Unix),
+            &format!("BootstrapProcManager::spawn callback_addr: {}", &proc_id),
+        )?;
 
         let mode = Bootstrap::Proc {
             proc_id: proc_id.clone(),
@@ -2110,17 +2096,8 @@ async fn bootstrap_v0_proc_mesh() -> anyhow::Error {
             .map_err(|err| anyhow::anyhow!("read `{}`: {}", BOOTSTRAP_INDEX_ENV, err))?
             .parse()?;
         let listen_addr = ChannelAddr::any(bootstrap_addr.transport());
-
-        let entered = tracing::span!(
-            Level::INFO,
-            "bootstrap_v0_proc_mesh",
-            %bootstrap_addr,
-            %bootstrap_index,
-            %listen_addr,
-        )
-        .entered();
-
-        let (serve_addr, mut rx) = channel::serve(listen_addr)?;
+        let (serve_addr, mut rx) =
+            channel::serve(listen_addr, "bootstrap_v0_proc_mesh listen_addr")?;
         let tx = channel::dial(bootstrap_addr.clone())?;
 
         let (rtx, mut return_channel) = oneshot::channel();
@@ -2129,8 +2106,6 @@ async fn bootstrap_v0_proc_mesh() -> anyhow::Error {
             rtx,
         )?;
         tokio::spawn(exit_if_missed_heartbeat(bootstrap_index, bootstrap_addr));
-
-        let _ = entered.exit();
 
         let mut the_msg;
 
@@ -2150,17 +2125,16 @@ async fn bootstrap_v0_proc_mesh() -> anyhow::Error {
             }
         }
         loop {
+            let _ = hyperactor::tracing::info_span!("wait_for_next_message_from_mesh_agent");
             match the_msg? {
                 Allocator2Process::StartProc(proc_id, listen_transport) => {
-                    let span = tracing::span!(Level::INFO, "Allocator2Process::StartProc", %proc_id, %listen_transport);
-                    let (proc, mesh_agent) = ProcMeshAgent::bootstrap(proc_id.clone())
-                        .instrument(span.clone())
-                        .await?;
-                    let entered = span.entered();
-                    let (proc_addr, proc_rx) = channel::serve(ChannelAddr::any(listen_transport))?;
+                    let (proc, mesh_agent) = ProcMeshAgent::bootstrap(proc_id.clone()).await?;
+                    let (proc_addr, proc_rx) = channel::serve(
+                        ChannelAddr::any(listen_transport),
+                        &format!("bootstrap_v0_proc_mesh proc_addr: {}", &proc_id,),
+                    )?;
                     let handle = proc.clone().serve(proc_rx);
                     drop(handle); // linter appeasement; it is safe to drop this future
-                    let span = entered.exit();
                     tx.send(Process2Allocator(
                         bootstrap_index,
                         Process2AllocatorMessage::StartedProc(
@@ -2169,7 +2143,6 @@ async fn bootstrap_v0_proc_mesh() -> anyhow::Error {
                             proc_addr,
                         ),
                     ))
-                    .instrument(span)
                     .await?;
                     procs.lock().await.push(proc);
                 }
@@ -2568,7 +2541,7 @@ mod tests {
 
         let router = DialMailboxRouter::new();
         let (proc_addr, proc_rx) =
-            channel::serve(ChannelAddr::any(ChannelTransport::Unix)).unwrap();
+            channel::serve(ChannelAddr::any(ChannelTransport::Unix), "test").unwrap();
         let proc = Proc::new(id!(client[0]), BoxedMailboxSender::new(router.clone()));
         proc.clone().serve(proc_rx);
         router.bind(id!(client[0]).into(), proc_addr.clone());
@@ -3409,7 +3382,8 @@ mod tests {
     ) -> (ProcId, ChannelAddr) {
         // Serve a Unix channel as the "backend_addr" and hook it into
         // this test proc.
-        let (backend_addr, rx) = channel::serve(ChannelAddr::any(ChannelTransport::Unix)).unwrap();
+        let (backend_addr, rx) =
+            channel::serve(ChannelAddr::any(ChannelTransport::Unix), "test").unwrap();
 
         // Route messages arriving on backend_addr into this test
         // proc's mailbox so the bootstrap child can reach the host

--- a/hyperactor_mesh/src/bootstrap/mailbox.rs
+++ b/hyperactor_mesh/src/bootstrap/mailbox.rs
@@ -130,16 +130,18 @@ mod tests {
             format!("unix:{}/{}", dir.path().display(), first)
                 .parse()
                 .unwrap(),
+            "test",
         )
         .unwrap();
         let (second_addr, mut second_rx) = channel::serve::<MessageEnvelope>(
             format!("unix:{}/{}", dir.path().display(), second)
                 .parse()
                 .unwrap(),
+            "test",
         )
         .unwrap();
         let (backend_addr, mut backend_rx) =
-            channel::serve::<MessageEnvelope>(ChannelTransport::Unix.any()).unwrap();
+            channel::serve::<MessageEnvelope>(ChannelTransport::Unix.any(), "test").unwrap();
 
         let local_addr: ChannelAddr = "tcp:3.4.5.6:123".parse().unwrap();
         let first_actor_id = ActorId(

--- a/hyperactor_mesh/src/logging.rs
+++ b/hyperactor_mesh/src/logging.rs
@@ -58,7 +58,6 @@ use tokio::sync::Notify;
 use tokio::sync::RwLock;
 use tokio::sync::watch::Receiver;
 use tokio::task::JoinHandle;
-use tracing::Level;
 
 use crate::bootstrap::BOOTSTRAP_LOG_CHANNEL;
 use crate::shortuuid::ShortUuid;
@@ -458,14 +457,14 @@ impl FileAppender {
                     return None;
                 }
             };
-        let (stdout_addr, stdout_rx) = {
-            let _guard = tracing::span!(Level::INFO, "appender", file = "stdout").entered();
-            match channel::serve(ChannelAddr::any(ChannelTransport::Unix)) {
-                Ok((addr, rx)) => (addr, rx),
-                Err(e) => {
-                    tracing::warn!("failed to serve stdout channel: {}", e);
-                    return None;
-                }
+        let (stdout_addr, stdout_rx) = match channel::serve(
+            ChannelAddr::any(ChannelTransport::Unix),
+            "FileAppender stdout_addr",
+        ) {
+            Ok((addr, rx)) => (addr, rx),
+            Err(e) => {
+                tracing::warn!("failed to serve stdout channel: {}", e);
+                return None;
             }
         };
         let stdout_stop = stop.clone();
@@ -485,14 +484,14 @@ impl FileAppender {
                     return None;
                 }
             };
-        let (stderr_addr, stderr_rx) = {
-            let _guard = tracing::span!(Level::INFO, "appender", file = "stderr").entered();
-            match channel::serve(ChannelAddr::any(ChannelTransport::Unix)) {
-                Ok((addr, rx)) => (addr, rx),
-                Err(e) => {
-                    tracing::warn!("failed to serve stderr channel: {}", e);
-                    return None;
-                }
+        let (stderr_addr, stderr_rx) = match channel::serve(
+            ChannelAddr::any(ChannelTransport::Unix),
+            "FileAppender stderr_addr",
+        ) {
+            Ok((addr, rx)) => (addr, rx),
+            Err(e) => {
+                tracing::warn!("failed to serve stderr channel: {}", e);
+                return None;
             }
         };
         let stderr_stop = stop.clone();
@@ -1008,7 +1007,7 @@ impl Actor for LogForwardActor {
             log_channel
         );
 
-        let rx = match channel::serve(log_channel.clone()) {
+        let rx = match channel::serve(log_channel.clone(), "LogForwardActor") {
             Ok((_, rx)) => rx,
             Err(err) => {
                 // This can happen if we are not spanwed on a separate process like local.
@@ -1018,7 +1017,11 @@ impl Actor for LogForwardActor {
                     log_channel,
                     err
                 );
-                channel::serve(ChannelAddr::any(ChannelTransport::Unix))?.1
+                channel::serve(
+                    ChannelAddr::any(ChannelTransport::Unix),
+                    "LogForwardActor Unix fallback",
+                )?
+                .1
             }
         };
 
@@ -1576,7 +1579,7 @@ mod tests {
         // Setup the basics
         let router = DialMailboxRouter::new();
         let (proc_addr, client_rx) =
-            channel::serve(ChannelAddr::any(ChannelTransport::Unix)).unwrap();
+            channel::serve(ChannelAddr::any(ChannelTransport::Unix), "test").unwrap();
         let proc = Proc::new(id!(client[0]), BoxedMailboxSender::new(router.clone()));
         proc.clone().serve(client_rx);
         router.bind(id!(client[0]).into(), proc_addr.clone());
@@ -1792,7 +1795,7 @@ mod tests {
 
         let (mut writer, reader) = tokio::io::duplex(1024);
         let (log_channel, mut rx) =
-            channel::serve::<LogMessage>(ChannelAddr::any(ChannelTransport::Unix)).unwrap();
+            channel::serve::<LogMessage>(ChannelAddr::any(ChannelTransport::Unix), "test").unwrap();
 
         // Create a temporary file for testing the writer
         let temp_file = tempfile::NamedTempFile::new().unwrap();
@@ -1925,7 +1928,7 @@ mod tests {
     #[tokio::test]
     async fn test_local_log_sender_inactive_status() {
         let (log_channel, _) =
-            channel::serve::<LogMessage>(ChannelAddr::any(ChannelTransport::Unix)).unwrap();
+            channel::serve::<LogMessage>(ChannelAddr::any(ChannelTransport::Unix), "test").unwrap();
         let mut sender = LocalLogSender::new(log_channel, 12345).unwrap();
 
         // This test verifies that the sender handles inactive status gracefully

--- a/hyperactor_mesh/src/proc_mesh.rs
+++ b/hyperactor_mesh/src/proc_mesh.rs
@@ -273,7 +273,6 @@ impl ProcMesh {
         C.get_or_init(|| AtomicUsize::new(0))
     }
 
-    #[tracing::instrument(skip_all)]
     #[hyperactor::observe_result("ProcMesh")]
     async fn allocate_boxed_inner(
         mut alloc: Box<dyn Alloc + Send + Sync>,
@@ -315,8 +314,11 @@ impl ProcMesh {
         //    everything else, so now the whole mesh should be able to communicate.
         let client_proc_id =
             ProcId::Ranked(WorldId(format!("{}_client", alloc.world_id().name())), 0);
-        let (client_proc_addr, client_rx) = channel::serve(ChannelAddr::any(alloc.transport()))
-            .map_err(|err| AllocatorError::Other(err.into()))?;
+        let (client_proc_addr, client_rx) = channel::serve(
+            ChannelAddr::any(alloc.transport()),
+            &format!("client_proc_addr: {}", &client_proc_id),
+        )
+        .map_err(|err| AllocatorError::Other(err.into()))?;
         tracing::info!(
             name = "ProcMesh::Allocate::ChannelServe",
             alloc_id = alloc_id,
@@ -381,7 +383,7 @@ impl ProcMesh {
         // Ensure that the router is served so that agents may reach us.
         let (router_channel_addr, router_rx) = alloc
             .client_router_addr()
-            .serve_with_config()
+            .serve_with_config("client_router_addr")
             .map_err(AllocatorError::Other)?;
         router.serve(router_rx);
         tracing::info!("router channel started listening on addr: {router_channel_addr}");

--- a/hyperactor_mesh/src/router.rs
+++ b/hyperactor_mesh/src/router.rs
@@ -57,14 +57,13 @@ impl Router {
     /// Servers are memoized, and we maintain only one per transport; thus
     /// subsequent calls using the same transport will return the same address.
     #[allow(dead_code)]
-    #[tracing::instrument(skip(self))]
     pub async fn serve(&self, transport: &ChannelTransport) -> Result<ChannelAddr, ChannelError> {
         let mut servers = self.servers.lock().await;
         if let Some(addr) = servers.get(transport) {
             return Ok(addr.clone());
         }
 
-        let (addr, rx) = channel::serve(ChannelAddr::any(transport.clone()))?;
+        let (addr, rx) = channel::serve(ChannelAddr::any(transport.clone()), "Router::serve")?;
         self.router.clone().serve(rx);
         servers.insert(transport.clone(), addr.clone());
         Ok(addr)

--- a/hyperactor_mesh/src/v1/proc_mesh.rs
+++ b/hyperactor_mesh/src/v1/proc_mesh.rs
@@ -46,7 +46,6 @@ use ndslice::view::Region;
 use serde::Deserialize;
 use serde::Serialize;
 use tokio::sync::Notify;
-use tracing::Level;
 
 use crate::CommActor;
 use crate::alloc::Alloc;
@@ -284,7 +283,6 @@ impl ProcMesh {
 
     /// Allocate a new ProcMesh from the provided alloc.
     /// Allocate does not require an owning actor because references are not owned.
-    #[tracing::instrument(skip_all)]
     pub async fn allocate(
         cx: &impl context::Actor,
         mut alloc: Box<dyn Alloc + Send + Sync + 'static>,
@@ -300,14 +298,11 @@ impl ProcMesh {
         let proc = cx.instance().proc();
 
         // First make sure we can serve the proc:
-        let proc_channel_addr = {
-            let _guard =
-                tracing::span!(Level::INFO, "allocate_serve_proc", proc_id = %proc.proc_id())
-                    .entered();
-            let (addr, rx) = channel::serve(ChannelAddr::any(alloc.transport()))?;
-            proc.clone().serve(rx);
-            addr
-        };
+        let (proc_channel_addr, rx) = channel::serve(
+            ChannelAddr::any(alloc.transport()),
+            &format!("proc_channel_addr for {}", proc.proc_id()),
+        )?;
+        proc.clone().serve(rx);
 
         let bind_allocated_procs = |router: &DialMailboxRouter| {
             // Route all of the allocated procs:

--- a/hyperactor_multiprocess/src/proc_actor.rs
+++ b/hyperactor_multiprocess/src/proc_actor.rs
@@ -417,7 +417,7 @@ impl ProcActor {
         labels: HashMap<String, String>,
         lifecycle_mode: ProcLifecycleMode,
     ) -> Result<BootstrappedProc, anyhow::Error> {
-        let (local_addr, rx) = channel::serve(listen_addr)?;
+        let (local_addr, rx) = channel::serve(listen_addr, "bootstrap_for_proc")?;
         let mailbox_handle = proc.clone().serve(rx);
         let (state_tx, mut state_rx) = watch::channel(ProcState::AwaitingJoin);
 

--- a/hyperactor_multiprocess/src/system.rs
+++ b/hyperactor_multiprocess/src/system.rs
@@ -45,7 +45,6 @@ impl System {
     /// Spawns a system actor and serves it at the provided channel
     /// address. This becomes a well-known address with which procs
     /// can bootstrap.
-    #[tracing::instrument]
     pub async fn serve(
         addr: ChannelAddr,
         supervision_update_timeout: tokio::time::Duration,
@@ -56,7 +55,7 @@ impl System {
         let (actor_handle, system_proc) = SystemActor::bootstrap_with_clock(params, clock).await?;
         actor_handle.bind::<SystemActor>();
 
-        let (local_addr, rx) = channel::serve(addr)?;
+        let (local_addr, rx) = channel::serve(addr, "System::serve")?;
         let mailbox_handle = system_proc.clone().serve(rx);
 
         Ok(ServerHandle {
@@ -91,7 +90,8 @@ impl System {
             BoxedMailboxSender::new(self.sender().await?),
         );
 
-        let (proc_addr, proc_rx) = channel::serve(ChannelAddr::any(self.addr.transport())).unwrap();
+        let (proc_addr, proc_rx) =
+            channel::serve(ChannelAddr::any(self.addr.transport()), "system").unwrap();
 
         let _proc_serve_handle: MailboxServerHandle = proc.clone().serve(proc_rx);
 

--- a/hyperactor_multiprocess/src/system_actor.rs
+++ b/hyperactor_multiprocess/src/system_actor.rs
@@ -1878,7 +1878,8 @@ mod tests {
             host_id,
         );
         let (local_proc_addr, local_proc_rx) =
-            channel::serve::<MessageEnvelope>(ChannelAddr::any(ChannelTransport::Local)).unwrap();
+            channel::serve::<MessageEnvelope>(ChannelAddr::any(ChannelTransport::Local), "test")
+                .unwrap();
         let local_proc_mbox = Mailbox::new_detached(local_proc_id.actor_id("test".to_string(), 0));
         let (local_proc_message_port, local_proc_message_receiver) = local_proc_mbox.open_port();
         let _local_proc_serve_handle = local_proc_mbox.clone().serve(local_proc_rx);
@@ -2384,7 +2385,7 @@ mod tests {
         let src_id = id!(proc[0].actor);
         let src_addr = ChannelAddr::Sim(SimAddr::new("unix!@src".parse().unwrap()).unwrap());
         let dst_addr = ChannelAddr::Sim(SimAddr::new("unix!@dst".parse().unwrap()).unwrap());
-        let (_, mut rx) = channel::serve::<MessageEnvelope>(src_addr.clone()).unwrap();
+        let (_, mut rx) = channel::serve::<MessageEnvelope>(src_addr.clone(), "test").unwrap();
 
         let router = ReportingRouter::new();
 


### PR DESCRIPTION
Summary:
Original commit changeset: 22561577f8ca

Original Phabricator Diff: D85727450

D85727450 breaks the debugging flow due to [gaps described in this comment](https://www.internalfb.com/diff/D85727450?dst_version_fbid=834705232344304&transaction_fbid=1160000608954528). While I agree we want contextual logging, but let us keep the current debug flow working while working on that in parallel.

Reviewed By: vidhyav

Differential Revision: D86051287


