### PR TITLE
Change builds-doc.yaml torch install order, remove rdma-core-dev from instructions

### DIFF
--- a/.github/workflows/doc_build.yml
+++ b/.github/workflows/doc_build.yml
@@ -30,6 +30,9 @@ jobs:
         # docs build will use 3.13
         setup_build_environment 3.13
 
+        # Install PyTorch with CUDA support (matching build-cuda.yml)
+        pip install --pre torch --index-url https://download.pytorch.org/whl/nightly/cu126
+
         # Setup Tensor Engine
         setup_tensor_engine
 
@@ -37,9 +40,6 @@ jobs:
         python -m pip install --upgrade pip
         pip install -r build-requirements.txt
         pip install -r docs/requirements.txt
-
-        # Install PyTorch with CUDA support (matching build-cuda.yml)
-        pip install --pre torch --index-url https://download.pytorch.org/whl/nightly/cu126
 
         # Set environment variables for CUDA build
         export USE_CUDA=1

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Stable and nightly distributions require libmxl and libibverbs (runtime).
 `sudo dnf install -y libibverbs rdma-core libmlx5 libibverbs-devel rdma-core-devel`
 
 ## Ubuntu
-`sudo apt install -y rdma-core libibverbs1 libmlx5-1 libibverbs-dev rdma-core-dev`
+`sudo apt install -y rdma-core libibverbs1 libmlx5-1 libibverbs-dev`
 
 ### Stable
 


### PR DESCRIPTION
Summary:
This diff tries to fix the discrepancy between build-*.yaml and the doc+build.yaml workflows by installing torch nightly first. 

Also removes an incorrect instruction in the README.

Differential Revision: D86119065


