### PR TITLE
add monarch.torchrun module; replicate torchrun using monarch as a proc manager

### DIFF
--- a/python/monarch/actor/torchrun.py
+++ b/python/monarch/actor/torchrun.py
@@ -1,0 +1,22 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+"""
+Public interface for monarch torchrun launcher.
+
+This module provides command-line entry points for both single-node worker
+and multi-node client modes.
+
+Use `python -m monarch.actor.torchrun` for single-node training (worker mode).
+Use `python -m monarch.actor.torchrun.client` for multi-node orchestration (client mode).
+"""
+
+from monarch._src.actor.torchrun.worker import main
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Differential Revision: D86152013

python -m monarch.actor.torchrun train.py
NCCL version 2.27.5+cuda12.9
[Rank 0] Step 0 loss=-3.3797261714935303
[Rank 1] Step 0 loss=-2.670731544494629
[Rank 0] Step 1 loss=0.08844298124313354
[Rank 1] Step 1 loss=-1.594184398651123
[Rank 0] Step 2 loss=-2.7455830574035645
[Rank 1] Step 2 loss=-0.4763872027397156
[Rank 0] Step 3 loss=-2.7619757652282715
[Rank 1] Step 3 loss=-2.6958324909210205
[Rank 0] Step 4 loss=-1.0318412780761719
[Rank 1] Step 4 loss=-3.984520673751831




