### PR TITLE
Add message envelope header for no return

### DIFF
--- a/hyperactor/src/mailbox/undeliverable.rs
+++ b/hyperactor/src/mailbox/undeliverable.rs
@@ -98,9 +98,11 @@ pub(crate) fn return_undeliverable(
     return_handle: PortHandle<Undeliverable<MessageEnvelope>>,
     envelope: MessageEnvelope,
 ) {
-    let envelope_copy = envelope.clone();
-    if (return_handle.send(Undeliverable(envelope))).is_err() {
-        UndeliverableMailboxSender.post(envelope_copy, /*unsued*/ return_handle)
+    if envelope.return_undeliverable() {
+        let envelope_copy = envelope.clone();
+        if (return_handle.send(Undeliverable(envelope))).is_err() {
+            UndeliverableMailboxSender.post(envelope_copy, /*unused*/ return_handle)
+        }
     }
 }
 
@@ -109,7 +111,7 @@ pub(crate) fn return_undeliverable(
 pub enum UndeliverableMessageError {
     /// Delivery of a message to its destination failed.
     #[error(
-        "a message from {} to {} was undeliverable and returned: {:?}: {envelope}", 
+        "a message from {} to {} was undeliverable and returned: {:?}: {envelope}",
         .envelope.sender(),
         .envelope.dest(),
         .envelope.error_msg()

--- a/hyperactor/src/proc.rs
+++ b/hyperactor/src/proc.rs
@@ -1036,7 +1036,7 @@ impl<A: Actor> Instance<A> {
 
     /// Send a message to the actor running on the proc.
     pub fn post(&self, port_id: PortId, headers: Attrs, message: Serialized) {
-        <Self as context::MailboxExt>::post(self, port_id, headers, message)
+        <Self as context::MailboxExt>::post(self, port_id, headers, message, true)
     }
 
     /// Send a message to the actor itself with a delay usually to trigger some event.

--- a/hyperactor_mesh/src/actor_mesh.rs
+++ b/hyperactor_mesh/src/actor_mesh.rs
@@ -141,7 +141,7 @@ where
 
     comm_actor_ref
         .port()
-        .send_with_headers(cx, headers, cast_message)?;
+        .send_with_headers(cx, headers, cast_message, true)?;
 
     Ok(())
 }

--- a/hyperactor_mesh/src/bootstrap.rs
+++ b/hyperactor_mesh/src/bootstrap.rs
@@ -56,6 +56,7 @@ use hyperactor::host::TerminateSummary;
 use hyperactor::mailbox::IntoBoxedMailboxSender;
 use hyperactor::mailbox::MailboxClient;
 use hyperactor::mailbox::MailboxServer;
+use hyperactor::mailbox::headers;
 use hyperactor::proc::Proc;
 use serde::Deserialize;
 use serde::Serialize;
@@ -72,7 +73,7 @@ use tracing::Level;
 use crate::logging::OutputTarget;
 use crate::logging::StreamFwder;
 use crate::proc_mesh::mesh_agent::ProcMeshAgent;
-use crate::resource::StopAllClient;
+use crate::resource;
 use crate::v1;
 use crate::v1::host_mesh::mesh_agent::HostAgentMode;
 use crate::v1::host_mesh::mesh_agent::HostMeshAgent;
@@ -1324,20 +1325,13 @@ impl hyperactor::host::ProcHandle for BootstrapProcHandle {
         // they are in the Ready state and have an Agent we can message.
         let agent = self.agent_ref();
         if let Some(agent) = agent {
-            let mailbox_result = RealClock.timeout(timeout, agent.stop_all(cx)).await;
-            if let Err(timeout_err) = mailbox_result {
-                // Agent didn't respond in time, proceed with SIGTERM.
+            // TODO: add a reply to StopAll and wait for it.
+            if let Err(e) = agent.send_no_return(cx, resource::StopAll {}) {
+                // Cannot send to agent, proceed with SIGTERM.
                 tracing::warn!(
                     "ProcMeshAgent {} didn't respond in time to stop proc: {}",
                     agent.actor_id(),
-                    timeout_err,
-                );
-            } else if let Ok(Err(e)) = mailbox_result {
-                // Other mailbox error, proceed with SIGTERM.
-                tracing::warn!(
-                    "ProcMeshAgent {} did not successfully stop all actors: {}",
-                    agent.actor_id(),
-                    e
+                    e,
                 );
             }
         }

--- a/monarch_simulator/src/controller.rs
+++ b/monarch_simulator/src/controller.rs
@@ -113,7 +113,7 @@ impl ControllerMessageHandler for SimControllerActor {
         tracing::info!("controller send to ranks {:?}: {}", ranks, message);
         self.worker_actor_ref
             .port::<WorkerMessage>()
-            .send_serialized(cx, Attrs::new(), message);
+            .send_serialized(cx, Attrs::new(), message, true);
         Ok(())
     }
 


### PR DESCRIPTION
Summary:
Sometimes when we send a message, we want it to be fully fire-and-forget,
including if the destination is not even reachable. This is typically only used in
scenarios like:
* When shutting down the system, we try to ask a process to nicely shut itself down
before ungracefully killing it. If the message is undeliverable, we can just proceed with
killing the process (it's probably already dead anyways)
* Replying to a message. If the sender is down, there's nothing the current actor can do about it

This should be used sparingly as it could hide real errors, like your messages not getting sent.

Add a header to MessageEnvelope for this use case, which avoids posting the Undelivered
message back to the sender.
Use it with a send of the StopAll message.

Differential Revision: D86315780


