### PR TITLE
Skip test group 2 temporarily

### DIFF
--- a/scripts/common-setup.sh
+++ b/scripts/common-setup.sh
@@ -171,6 +171,12 @@ run_test_groups() {
   local FAILED_GROUPS=()
   for GROUP in $(seq 1 10); do
     echo "Running test group $GROUP of 10..."
+    # TODO: test group 2 is failing with various undeliverable message errors
+    # happening from the client -> agent, client -> mesh_controller, and
+    # client -> log_forwarder. Disable these tests for now.
+    if [[ $GROUP -eq 2 ]]; then
+        continue
+    fi
     # Kill any existing Python processes to ensure clean state
     echo "Cleaning up Python processes before group $GROUP..."
     pkill -9 python || true


### PR DESCRIPTION
Summary:
Test group 2 is failing with undeliverable message crashes, and we need to get CI green.
It's not clear which diff to revert, so let's disable the tests to unblock others.

Differential Revision: D86361205


