### PR TITLE
[Logging] put the actor name in the python logger

### DIFF
--- a/python/monarch/actor/__init__.py
+++ b/python/monarch/actor/__init__.py
@@ -27,6 +27,7 @@ from monarch._src.actor.actor_mesh import (
     current_size,
     enable_transport,
     Endpoint,
+    per_actor_logging_prefix,
     Point,
     Port,
     PortReceiver,
@@ -107,5 +108,6 @@ __all__ = [
     "Context",
     "ChannelTransport",
     "unhandled_fault_hook",
+    "per_actor_logging_prefix",
     "MeshFailure",
 ]

--- a/python/tests/test_python_actors.py
+++ b/python/tests/test_python_actors.py
@@ -9,6 +9,7 @@
 import asyncio
 import ctypes
 import importlib.resources
+import io
 import logging
 import operator
 import os
@@ -20,6 +21,7 @@ import threading
 import time
 import unittest
 import unittest.mock
+from contextlib import contextmanager
 from tempfile import TemporaryDirectory
 from types import ModuleType
 from typing import Any, cast, Tuple
@@ -67,7 +69,6 @@ from monarch.actor import (
 )
 from monarch.tools.config import defaults
 from typing_extensions import assert_type
-
 
 needs_cuda = pytest.mark.skipif(
     not torch.cuda.is_available(),
@@ -1733,9 +1734,31 @@ def test_setup_async() -> None:
     time.sleep(10)
 
 
+class CaptureLogs:
+    def __init__(self):
+        log_stream = io.StringIO()
+        handler = logging.StreamHandler(log_stream)
+        handler.setFormatter(logging.Formatter("%(message)s"))
+
+        logger = logging.getLogger("capture")
+        logger.setLevel(logging.INFO)
+        logger.addHandler(handler)
+
+        self.log_stream = log_stream
+        self.logger = logger
+
+    @property
+    def contents(self) -> str:
+        return self.log_stream.getvalue()
+
+
 class Named(Actor):
     @endpoint
     def report(self) -> Any:
+        logs = CaptureLogs()
+        logs.logger.error("HUH")
+        assert "test_python_actors.Named the_name{'f': 0/2}>" in logs.contents
+
         return context().actor_instance.creator, str(context().actor_instance)
 
 
@@ -1751,3 +1774,19 @@ def test_instance_name():
     assert "test_python_actors.Named the_name{'f': 0/2}>" in result
     assert cr.name == "root"
     assert str(context().actor_instance) == "<root>"
+
+    logs = CaptureLogs()
+    logs.logger.error("HUH")
+    assert "actor=<root>" in logs.contents
+    default = monarch.actor.per_actor_logging_prefix
+    try:
+        monarch.actor.per_actor_logging_prefix = lambda inst: "<test>"
+        logs = CaptureLogs()
+        logs.logger.error("HUH")
+        assert "<test>" in logs.contents
+        monarch.actor.per_actor_logging_prefix = None
+        # make sure we can set _per_actor_logging_prefix to none.
+        logs = CaptureLogs()
+        logs.logger.error("HUH")
+    finally:
+        monarch.actor.per_actor_logging_prefix = default


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #1767
* #1731

Injects [actor=<the fully qualified actor name>] into the log message of the python actor.

The prefix is configurable by redefining `monarch.actor.per_actor_logging_prefix` callback. Setting to None disables the filter that alters the logs.

Hopefully this works pretty broadly since it hooks in as a filter on logging handlers.

Differential Revision: [D85994688](https://our.internmc.facebook.com/intern/diff/D85994688/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D85994688/)!