### PR TITLE
[logging] monarch logs do not go to stderr

### DIFF
--- a/hyperactor_mesh/src/v1/host_mesh/mesh_agent.rs
+++ b/hyperactor_mesh/src/v1/host_mesh/mesh_agent.rs
@@ -125,6 +125,17 @@ impl Actor for HostMeshAgent {
     type Params = HostAgentMode;
 
     async fn new(host: HostAgentMode) -> anyhow::Result<Self> {
+        if let HostAgentMode::Process(_) = host {
+            let (directory, file) = hyperactor_telemetry::log_file_path(
+                hyperactor_telemetry::env::Env::current(),
+                None,
+            )
+            .unwrap();
+            eprintln!(
+                "Monarch internal logs are being written to {}/{}.log",
+                directory, file
+            );
+        }
         Ok(Self {
             host: Some(host),
             created: HashMap::new(),


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #1769

Updating our logging behavior to reflect our 'logging axioms'.

This removes the forwarding of monarch logs to stderr.

"Monarch Logs" are logs lines which relate to the internal operation of monarch and are used for debugging bugs in the monarch system.
"User logs" are the logs and any output to stderr/out that actors running within monarch make.
Monarch itself should never produce "User logs" except in the following limited circumstances:
* warning about deprecated APIs and other functionality limitations
the output of the default 'unhandled_fault_hook' reporting the serialization of an ActorFailure message.
* a single log line on startup of the client or a host worker (but not a proc!) that describes where the "monarch logs" are being written.

Differential Revision: [D86456839](https://our.internmc.facebook.com/intern/diff/D86456839/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D86456839/)!