### PR TITLE
two workaround to build from the source on Ubuntu

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,9 @@ sudo apt install -y ninja-build
 sudo apt install -y libunwind-dev
 sudo apt install -y clang
 
+# Install the libunwind package on conda
+conda install -c conda-forge libunwind
+
 # Set clang as the default C/C++ compiler
 export CC=clang
 export CXX=clang++
@@ -157,8 +160,12 @@ USE_TENSOR_ENGINE=0 pip install --no-build-isolation .
 # or setup for development
 pip install --no-build-isolation -e .
 
+# Preload libgcc_s.so.1 from the current Conda environment to ensure correct GCC runtime linking,
+export LD_PRELOAD="$CONDA_PREFIX/lib/libgcc_s.so.1:$LD_PRELOAD"
+
 # Verify installation
 pip list | grep monarch
+python -c 'import monarch; print("monarch ok")'
 ```
 
 #### On non-CUDA machines


### PR DESCRIPTION
This PR addresses these two issues (installing monarch from source on Ubuntu and importing monarch):

[1773](https://github.com/meta-pytorch/monarch/issues/1773) 
and
[1774](https://github.com/meta-pytorch/monarch/issues/1774)

There might be another better way to handle these two issues.

### Install libunwind in Conda
To ensure proper stack unwinding and compatibility with certain native libraries, install libunwind from conda-forge:
```bash
# Install the libunwind package from conda-forge
conda install -c conda-forge libunwind
```

### Preload libgcc_s.so.1 from Conda Environment
Some binaries require a specific version of the GCC runtime library (libgcc_s.so.1). To avoid conflicts with system libraries and ensure the correct version is used, preload the library from your active Conda environment:
```bash
# Preload libgcc_s.so.1 from the current Conda environment to ensure correct GCC runtime linking.
# This helps prevent issues with mismatched or missing GCC runtime libraries when running binaries.
export LD_PRELOAD="$CONDA_PREFIX/lib/libgcc_s.so.1:$LD_PRELOAD"
```