### PR TITLE
[logging] prefix logging round 2

### DIFF
--- a/python/monarch/_src/actor/config.py
+++ b/python/monarch/_src/actor/config.py
@@ -1,0 +1,7 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+prefix_python_logs_with_actor = True

--- a/python/monarch/actor/__init__.py
+++ b/python/monarch/actor/__init__.py
@@ -14,6 +14,8 @@ from typing import TYPE_CHECKING
 from monarch._rust_bindings.monarch_hyperactor.channel import ChannelTransport
 from monarch._rust_bindings.monarch_hyperactor.shape import Extent
 from monarch._rust_bindings.monarch_hyperactor.supervision import MeshFailure
+
+from monarch._src.actor import config
 from monarch._src.actor.actor_mesh import (
     Accumulator,
     Actor,
@@ -40,7 +42,6 @@ from monarch._src.actor.future import Future
 from monarch._src.actor.supervision import unhandled_fault_hook
 
 from monarch._src.actor.v1 import enabled as v1_enabled
-
 
 if v1_enabled or TYPE_CHECKING:
     from monarch._src.actor.v1.host_mesh import (
@@ -108,4 +109,5 @@ __all__ = [
     "ChannelTransport",
     "unhandled_fault_hook",
     "MeshFailure",
+    "config",
 ]


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #1808

Redid how conifg works so that it is less likely to break given weird packaging.

Ensure that failure to prefix the log results in a warning rather than failing the whole job.

Differential Revision: [D86685629](https://our.internmc.facebook.com/intern/diff/D86685629/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D86685629/)!