### PR TITLE
Moves a few i8 to c_char for ARM compatible tensor engine builds

### DIFF
--- a/monarch_rdma/src/macros.rs
+++ b/monarch_rdma/src/macros.rs
@@ -10,7 +10,7 @@
 macro_rules! cu_check {
     ($result:expr) => {
         if $result != cuda_sys::CUresult::CUDA_SUCCESS {
-            let mut error_string: *const i8 = std::ptr::null();
+            let mut error_string: *const std::os::raw::c_char = std::ptr::null();
             cuda_sys::cuGetErrorString($result, &mut error_string);
             panic!(
                 "cuda failure {}:{} {:?} '{}'",

--- a/monarch_rdma/src/rdma_manager_actor.rs
+++ b/monarch_rdma/src/rdma_manager_actor.rs
@@ -378,7 +378,7 @@ impl RdmaManagerActor {
 
             if is_cuda {
                 // Use rdmaxcel utility to get PCI address from CUDA pointer
-                let mut pci_addr_buf = [0i8; 16]; // Enough space for "ffff:ff:ff.0\0"
+                let mut pci_addr_buf: [std::os::raw::c_char; 16] = [0; 16]; // Enough space for "ffff:ff:ff.0\0"
                 let err = rdmaxcel_sys::get_cuda_pci_address_from_ptr(
                     addr as u64,
                     pci_addr_buf.as_mut_ptr(),

--- a/nccl-sys/src/lib.rs
+++ b/nccl-sys/src/lib.rs
@@ -56,17 +56,20 @@ mod inner {
         pub internal: [::std::os::raw::c_char; 128usize],
     }
 
-    fn deserialize_array<'de, D>(deserializer: D) -> Result<[i8; 128], D::Error>
+    fn deserialize_array<'de, D>(deserializer: D) -> Result<[::std::os::raw::c_char; 128], D::Error>
     where
         D: Deserializer<'de>,
     {
-        let vec: Vec<i8> = Deserialize::deserialize(deserializer)?;
-        vec.try_into().map_err(|v: Vec<i8>| {
+        let vec: Vec<::std::os::raw::c_char> = Deserialize::deserialize(deserializer)?;
+        vec.try_into().map_err(|v: Vec<::std::os::raw::c_char>| {
             serde::de::Error::invalid_length(v.len(), &"expected an array of length 128")
         })
     }
 
-    fn serialize_array<S>(array: &[i8; 128], serializer: S) -> Result<S::Ok, S::Error>
+    fn serialize_array<S>(
+        array: &[::std::os::raw::c_char; 128],
+        serializer: S,
+    ) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
     {


### PR DESCRIPTION
Summary:
As title. For the interested, Claude mentions that the C standard says `char` signedness is implementation-defined.

x86_64 for instance has `char` be signed - therefore all of our usage of char as i8 was correct.

But on aarch64, it's unsigned by default.

Without this change, you see a lot of errors like this:

```
      error[E0308]: mismatched types
         --> monarch_rdma/src/rdma_manager_actor.rs:398:57
          |
      398 |                 let pci_addr = std::ffi::CStr::from_ptr(pci_addr_buf.as_ptr())
          |                                ------------------------ ^^^^^^^^^^^^^^^^^^^^^ expected `*const u8`, found `*const i8`
          |                                |
          |                                arguments to this function are incorrect
          |
          = note: expected raw pointer `*const u8`
                     found raw pointer `*const i8`
      note: associated function defined here
```

Differential Revision: D86711698


