### PR TITLE
[monarch] ActorStatus::Failed(String) -> Failed(ActorErrorKind)

### DIFF
--- a/controller/src/lib.rs
+++ b/controller/src/lib.rs
@@ -544,7 +544,7 @@ impl ControllerMessageHandler for ControllerActor {
                             (
                                 actor.clone(),
                                 match status {
-                                    ActorStatus::Failed(msg) => msg.clone(),
+                                    ActorStatus::Failed(msg) => msg.to_string(),
                                     _ => format!("unexpected actor status {status}"),
                                 },
                             )

--- a/docs/source/books/hyperactor-book/src/actors/actor_handle.md
+++ b/docs/source/books/hyperactor-book/src/actors/actor_handle.md
@@ -162,7 +162,7 @@ impl<A: Actor> IntoFuture for ActorHandle<A> {
             let result = status_receiver.wait_for(ActorStatus::is_terminal).await;
             match result {
                 Err(_) => ActorStatus::Unknown,
-                Ok(status) => status.passthrough(),
+                Ok(status) => status.clone(),
             }
         };
         future.boxed()

--- a/hyperactor/src/mailbox.rs
+++ b/hyperactor/src/mailbox.rs
@@ -3116,8 +3116,8 @@ mod tests {
         let ActorStatus::Failed(ref msg) = *foo_status.borrow() else {
             unreachable!()
         };
-        assert!(msg.as_str().contains(
-            "serving quux[0].foo[0]: processing error: a message from \
+        assert!(msg.to_string().contains(
+            "processing error: a message from \
                 quux[0].foo[0] to corge[0].bar[0][9999] was undeliverable and returned"
         ));
 

--- a/hyperactor/src/mailbox/undeliverable.rs
+++ b/hyperactor/src/mailbox/undeliverable.rs
@@ -109,7 +109,7 @@ pub(crate) fn return_undeliverable(
 pub enum UndeliverableMessageError {
     /// Delivery of a message to its destination failed.
     #[error(
-        "a message from {} to {} was undeliverable and returned: {:?}: {envelope}", 
+        "a message from {} to {} was undeliverable and returned: {:?}: {envelope}",
         .envelope.sender(),
         .envelope.dest(),
         .envelope.error_msg()
@@ -163,7 +163,7 @@ pub fn supervise_undeliverable_messages_with<R, F>(
 
                     if let Err(e) = sink.send(ActorSupervisionEvent::new(
                         actor_id,
-                        ActorStatus::Failed(format!("message not delivered: {}", env)),
+                        ActorStatus::generic_failure(format!("message not delivered: {}", env)),
                         Some(headers),
                         None,
                     )) {

--- a/hyperactor/src/proc.rs
+++ b/hyperactor/src/proc.rs
@@ -1106,7 +1106,7 @@ impl<A: Actor> Instance<A> {
                 ..
             }) => (event.actor_status.clone(), Some(event)),
             Err(err) => {
-                let error_kind = ActorErrorKind::Generic(err.to_string());
+                let error_kind = ActorErrorKind::Generic(err.kind.to_string());
                 (
                     ActorStatus::Failed(error_kind.clone()),
                     Some(ActorSupervisionEvent::new(

--- a/hyperactor/src/proc.rs
+++ b/hyperactor/src/proc.rs
@@ -1102,18 +1102,21 @@ impl<A: Actor> Instance<A> {
         let (actor_status, event) = match result {
             Ok(_) => (ActorStatus::Stopped, None),
             Err(ActorError {
-                kind: box ActorErrorKind::UnhandledSupervisionEvent(event),
+                kind: box ActorErrorKind::UnhandledSupervisionEvent(box event),
                 ..
             }) => (event.actor_status.clone(), Some(event)),
-            Err(err) => (
-                ActorStatus::Failed(err.to_string()),
-                Some(ActorSupervisionEvent::new(
-                    self.cell.actor_id().clone(),
-                    ActorStatus::Failed(err.to_string()),
-                    None,
-                    None,
-                )),
-            ),
+            Err(err) => {
+                let error_kind = ActorErrorKind::Generic(err.to_string());
+                (
+                    ActorStatus::Failed(error_kind.clone()),
+                    Some(ActorSupervisionEvent::new(
+                        self.cell.actor_id().clone(),
+                        ActorStatus::Failed(error_kind),
+                        None,
+                        None,
+                    )),
+                )
+            }
         };
 
         if let Some(parent) = self.cell.maybe_unlink_parent() {
@@ -1174,7 +1177,10 @@ impl<A: Actor> Instance<A> {
                     .unwrap_or_else(|e| format!("Cannot take backtrace due to: {:?}", e));
                 Err(ActorError::new(
                     self.self_id(),
-                    ActorErrorKind::Panic(anyhow::anyhow!("{}\n{}", err_msg, backtrace)),
+                    ActorErrorKind::panic(anyhow::anyhow!(
+                        "{}
+{}", err_msg, backtrace
+                    )),
                 ))
             }
         };
@@ -1244,7 +1250,7 @@ impl<A: Actor> Instance<A> {
         actor
             .init(self)
             .await
-            .map_err(|err| ActorError::new(self.self_id(), ActorErrorKind::Init(err)))?;
+            .map_err(|err| ActorError::new(self.self_id(), ActorErrorKind::init(err)))?;
         let need_drain;
         'messages: loop {
             self.change_status(ActorStatus::Idle);
@@ -1260,7 +1266,7 @@ impl<A: Actor> Instance<A> {
                         for supervision_event in supervision_event_receiver.drain() {
                             self.handle_supervision_event(actor, supervision_event).await?;
                         }
-                        return Err(ActorError::new(self.self_id(), ActorErrorKind::Processing(err)));
+                        return Err(ActorError::new(self.self_id(), ActorErrorKind::processing(err)));
                     }
                 }
                 signal = signal_receiver.recv() => {
@@ -1293,7 +1299,7 @@ impl<A: Actor> Instance<A> {
                 if let Err(err) = work.handle(actor, self).await {
                     return Err(ActorError::new(
                         self.self_id(),
-                        ActorErrorKind::Processing(err),
+                        ActorErrorKind::processing(err),
                     ));
                 }
                 n += 1;
@@ -1323,7 +1329,7 @@ impl<A: Actor> Instance<A> {
                 // The supervision event wasn't handled by this actor, chain it and bubble it up.
                 let supervision_event = ActorSupervisionEvent::new(
                     self.self_id().clone(),
-                    ActorStatus::Failed("did not handle supervision event".to_string()),
+                    ActorStatus::generic_failure("did not handle supervision event"),
                     None,
                     Some(Box::new(supervision_event)),
                 );
@@ -1334,7 +1340,10 @@ impl<A: Actor> Instance<A> {
                 // Create a new supervision event for this failure and propagate it.
                 let supervision_event = ActorSupervisionEvent::new(
                     self.self_id().clone(),
-                    ActorStatus::Failed(format!("failed to handle supervision event: {}", err)),
+                    ActorStatus::generic_failure(format!(
+                        "failed to handle supervision event: {}",
+                        err
+                    )),
                     None,
                     Some(Box::new(supervision_event)),
                 );
@@ -2388,17 +2397,17 @@ mod tests {
                 "some random failure"
             )))
             .unwrap();
-        let root_2_actor_id = root_2.actor_id().clone();
+        let _root_2_actor_id = root_2.actor_id().clone();
         assert_matches!(
             root_2.await,
-            ActorStatus::Failed(err) if err == format!("serving {}: processing error: some random failure", root_2_actor_id)
+            ActorStatus::Failed(err) if err.to_string() == "processing error: some random failure"
         );
 
         // TODO: should we provide finer-grained stop reasons, e.g., to indicate it was
         // stopped by a parent failure?
-        assert_eq!(
+        assert_matches!(
             root.await,
-            ActorStatus::Failed("did not handle supervision event".to_string())
+            ActorStatus::Failed(ActorErrorKind::Generic(msg)) if msg == "did not handle supervision event"
         );
         assert_eq!(root_2_1.await, ActorStatus::Stopped);
         assert_eq!(root_1.await, ActorStatus::Stopped);
@@ -2913,16 +2922,13 @@ mod tests {
             // The time field is ignored for Eq and PartialEq.
             ActorSupervisionEvent::new(
                 child_actor_id,
-                ActorStatus::Failed(
+                ActorStatus::generic_failure(
                     "failed to handle supervision event: failed to handle supervision event!"
-                        .to_string(),
                 ),
                 None,
                 Some(Box::new(ActorSupervisionEvent::new(
                     grandchild_actor_id,
-                    ActorStatus::Failed(
-                        "serving local[0].parent[2]: processing error: trigger failure".to_string()
-                    ),
+                    ActorStatus::generic_failure("processing error: trigger failure"),
                     None,
                     None,
                 ))),

--- a/hyperactor/src/supervision.rs
+++ b/hyperactor/src/supervision.rs
@@ -22,6 +22,7 @@ use serde::Serialize;
 
 use crate as hyperactor; // for macros
 use crate::Named;
+use crate::actor::ActorErrorKind;
 use crate::actor::ActorStatus;
 use crate::attrs::Attrs;
 use crate::reference::ActorId;
@@ -63,10 +64,12 @@ impl ActorSupervisionEvent {
     /// Compute an actor status from this event, ensuring that "caused-by"
     /// events are included in failure states. This should be used as the
     /// actor status when reporting events to users.
-    pub fn status(&self) -> ActorStatus {
-        match &self.actor_status {
-            ActorStatus::Failed(msg) => ActorStatus::Failed(format!("{}: {}", self, msg)),
-            status => status.clone(),
+    pub fn status(self) -> ActorStatus {
+        match self.actor_status {
+            ActorStatus::Failed(_) => {
+                ActorStatus::Failed(ActorErrorKind::UnhandledSupervisionEvent(Box::new(self)))
+            }
+            status => status,
         }
     }
 }

--- a/hyperactor_mesh/src/proc_mesh.rs
+++ b/hyperactor_mesh/src/proc_mesh.rs
@@ -842,7 +842,7 @@ impl ProcEvents {
                         // TODO(T231868026): find a better way to represent all actors in a proc for supervision event
                         let event = ActorSupervisionEvent::new(
                             proc_id.actor_id("any", 0),
-                            ActorStatus::Failed(format!("proc {} is stopped", proc_id)),
+                            ActorStatus::generic_failure(format!("proc {} is stopped", proc_id)),
                             None,
                             None,
                         );

--- a/hyperactor_multiprocess/src/proc_actor.rs
+++ b/hyperactor_multiprocess/src/proc_actor.rs
@@ -814,13 +814,14 @@ impl Handler<ActorSupervisionEvent> for ProcActor {
         cx: &Context<Self>,
         event: ActorSupervisionEvent,
     ) -> anyhow::Result<()> {
+        let actor_id = event.actor_id.clone();
         let status = event.status();
         let message = ProcSupervisionState {
             world_id: self.params.world_id.clone(),
             proc_id: self.params.proc.proc_id().clone(),
             proc_addr: self.params.local_addr.clone(),
             proc_health: ProcStatus::Alive,
-            failed_actors: Vec::from([(event.actor_id, status)]),
+            failed_actors: Vec::from([(actor_id, status)]),
         };
         self.params.supervisor_actor_ref.update(cx, message).await?;
         Ok(())

--- a/hyperactor_multiprocess/src/proc_actor.rs
+++ b/hyperactor_multiprocess/src/proc_actor.rs
@@ -1278,7 +1278,7 @@ mod tests {
             .await;
         assert_matches!(
             result.unwrap().unwrap(),
-            ActorStatus::Failed(msg) if msg.contains("test actor is erroring out")
+            ActorStatus::Failed(msg) if msg.to_string().contains("test actor is erroring out")
         );
 
         server_handle.stop().await.unwrap();

--- a/hyperactor_multiprocess/src/system_actor.rs
+++ b/hyperactor_multiprocess/src/system_actor.rs
@@ -1961,8 +1961,11 @@ mod tests {
                 proc_addr: ChannelAddr::any(ChannelTransport::Local),
                 proc_id: proc_id_1.clone(),
                 proc_health: ProcStatus::Alive,
-                failed_actors: [(actor_id.clone(), ActorStatus::Failed("Actor failed".into()))]
-                    .to_vec(),
+                failed_actors: [(
+                    actor_id.clone(),
+                    ActorStatus::generic_failure("Actor failed"),
+                )]
+                .to_vec(),
             },
             &clock,
         );

--- a/monarch_hyperactor/src/actor_mesh.rs
+++ b/monarch_hyperactor/src/actor_mesh.rs
@@ -315,7 +315,7 @@ impl ActorMeshProtocol for PythonActorMeshImpl {
                     // Dummy actor as placeholder to indicate the whole mesh is stopped
                     // TODO(albertli): remove this when pushing all supervision logic to rust.
                     id!(default[0].actor[0]),
-                    ActorStatus::Failed("actor mesh is stopped due to proc mesh shutdown".into()),
+                    ActorStatus::generic_failure("actor mesh is stopped due to proc mesh shutdown"),
                     None,
                     None,
                 )),
@@ -372,8 +372,8 @@ impl PythonActorMeshImpl {
                         // Dummy actor as placeholder to indicate the whole mesh is stopped
                         // TODO(albertli): remove this when pushing all supervision logic to rust.
                         id!(default[0].actor[0]),
-                        ActorStatus::Failed(
-                            "actor mesh is stopped due to proc mesh shutdown".into(),
+                        ActorStatus::generic_failure(
+                            "actor mesh is stopped due to proc mesh shutdown",
                         ),
                         None,
                         None,

--- a/monarch_hyperactor/src/v1/actor_mesh.rs
+++ b/monarch_hyperactor/src/v1/actor_mesh.rs
@@ -501,7 +501,10 @@ async fn actor_states_monitor<A, F>(
                 0,
                 ActorSupervisionEvent::new(
                     cx.instance().self_id().clone(),
-                    ActorStatus::Failed(format!("Unable to query for proc states: {:?}", e)),
+                    ActorStatus::generic_failure(format!(
+                        "Unable to query for proc states: {:?}",
+                        e
+                    )),
                     None,
                     None,
                 ),
@@ -551,7 +554,10 @@ async fn actor_states_monitor<A, F>(
                 0,
                 ActorSupervisionEvent::new(
                     cx.instance().self_id().clone(),
-                    ActorStatus::Failed(format!("Unable to query for actor states: {:?}", e)),
+                    ActorStatus::generic_failure(format!(
+                        "Unable to query for actor states: {:?}",
+                        e
+                    )),
                     None,
                     None,
                 ),

--- a/monarch_tensor_worker/src/stream.rs
+++ b/monarch_tensor_worker/src/stream.rs
@@ -2222,7 +2222,7 @@ mod tests {
                 .status
                 .clone();
             if let ActorStatus::Failed(msg) = status {
-                assert!(msg.contains(&expected_msg));
+                assert!(msg.to_string().contains(&expected_msg));
                 break;
             } else {
                 tokio::task::yield_now().await;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #1815

Refactor to get a more structured error to ActorStatus. This deletes the unused structure in ActorErrorKind to make it cloneable/serializable so that we can put it in ActorStatus.

Now that we can represent an ActorStatus that is an SupervisionEvent of a child, we can start to chain/collapse the supervision chain as it bubbles up.

Differential Revision: [D86723978](https://our.internmc.facebook.com/intern/diff/D86723978/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D86723978/)!