### PR TITLE
Use PyBytes as backing for Buffer

### DIFF
--- a/monarch_extension/src/mesh_controller.rs
+++ b/monarch_extension/src/mesh_controller.rs
@@ -47,7 +47,7 @@ use hyperactor_mesh::supervision::SupervisionFailureMessage;
 use hyperactor_mesh_macros::sel;
 use monarch_hyperactor::actor::PythonMessage;
 use monarch_hyperactor::actor::PythonMessageKind;
-use monarch_hyperactor::buffers::FrozenBuffer;
+use monarch_hyperactor::buffers::Buffer;
 use monarch_hyperactor::context::PyInstance;
 use monarch_hyperactor::local_state_broker::LocalStateBrokerActor;
 use monarch_hyperactor::mailbox::PyPortId;
@@ -567,10 +567,10 @@ impl History {
             let exe = remote_exception
                 .call1((exception.backtrace, traceback, rank))
                 .unwrap();
-            let data: FrozenBuffer = pickle.call1((exe,)).unwrap().extract().unwrap();
+            let mut data: Buffer = pickle.call1((exe,)).unwrap().extract().unwrap();
             PythonMessage::new_from_buf(
                 PythonMessageKind::Exception { rank: Some(rank) },
-                data.inner,
+                data.take_part(),
             )
         }));
 

--- a/monarch_tensor_worker/src/stream.rs
+++ b/monarch_tensor_worker/src/stream.rs
@@ -37,7 +37,7 @@ use hyperactor::mailbox::PortReceiver;
 use hyperactor::proc::Proc;
 use monarch_hyperactor::actor::PythonMessage;
 use monarch_hyperactor::actor::PythonMessageKind;
-use monarch_hyperactor::buffers::FrozenBuffer;
+use monarch_hyperactor::buffers::Buffer;
 use monarch_hyperactor::local_state_broker::BrokerId;
 use monarch_hyperactor::local_state_broker::LocalState;
 use monarch_hyperactor::local_state_broker::LocalStateBrokerMessage;
@@ -99,7 +99,7 @@ fn pickle_python_result(
         .unwrap()
         .getattr("_pickle")
         .unwrap();
-    let data: FrozenBuffer = pickle
+    let mut data: Buffer = pickle
         .call1((result,))
         .map_err(|pyerr| anyhow::Error::from(SerializablePyErr::from(py, &pyerr)))?
         .extract()
@@ -108,7 +108,7 @@ fn pickle_python_result(
         PythonMessageKind::Result {
             rank: Some(worker_rank),
         },
-        data.inner,
+        data.take_part(),
     ))
 }
 

--- a/python/monarch/_rust_bindings/monarch_hyperactor/actor.pyi
+++ b/python/monarch/_rust_bindings/monarch_hyperactor/actor.pyi
@@ -23,7 +23,7 @@ from typing import (
     Union,
 )
 
-from monarch._rust_bindings.monarch_hyperactor.buffers import FrozenBuffer
+from monarch._rust_bindings.monarch_hyperactor.buffers import Buffer, FrozenBuffer
 
 from monarch._rust_bindings.monarch_hyperactor.mailbox import (
     Mailbox,
@@ -204,7 +204,7 @@ class PythonMessage:
     def __init__(
         self,
         kind: PythonMessageKind,
-        message: Union[FrozenBuffer, bytes],
+        message: Union[Buffer, bytes],
     ) -> None: ...
     @property
     def message(self) -> FrozenBuffer:

--- a/python/monarch/_src/actor/actor_mesh.py
+++ b/python/monarch/_src/actor/actor_mesh.py
@@ -52,7 +52,7 @@ from monarch._rust_bindings.monarch_hyperactor.actor import (
     PythonMessageKind,
 )
 from monarch._rust_bindings.monarch_hyperactor.actor_mesh import PythonActorMesh
-from monarch._rust_bindings.monarch_hyperactor.buffers import FrozenBuffer
+from monarch._rust_bindings.monarch_hyperactor.buffers import Buffer, FrozenBuffer
 from monarch._rust_bindings.monarch_hyperactor.channel import ChannelTransport
 from monarch._rust_bindings.monarch_hyperactor.config import configure
 from monarch._rust_bindings.monarch_hyperactor.context import Instance as HyInstance
@@ -1355,7 +1355,7 @@ def _is_ref_or_mailbox(x: object) -> bool:
     return hasattr(x, "__monarch_ref__") or isinstance(x, Mailbox)
 
 
-def _pickle(obj: object) -> bytes | FrozenBuffer:
+def _pickle(obj: object) -> Buffer:
     _, buff = flatten(obj, _is_mailbox)
     return buff
 
@@ -1649,7 +1649,7 @@ class RootClientActor(Actor):
         return True
 
     @staticmethod
-    def _pickled_init_args() -> FrozenBuffer:
+    def _pickled_init_args() -> Buffer:
         args = (
             ActorInitArgs(RootClientActor, None, None, RootClientActor.name, None, ()),
         )

--- a/python/monarch/_src/actor/pickle.py
+++ b/python/monarch/_src/actor/pickle.py
@@ -135,12 +135,12 @@ class _Unpickler(pickle.Unpickler):
         return self._values[pid]
 
 
-def flatten(obj: Any, filter: Callable[[Any], bool]) -> Tuple[List[Any], FrozenBuffer]:
+def flatten(obj: Any, filter: Callable[[Any], bool]) -> Tuple[List[Any], Buffer]:
     buffer = Buffer()
     pickler = _Pickler(filter, buffer)
     pickler.dump(obj)
 
-    return pickler._saved, buffer.freeze()
+    return pickler._saved, buffer
 
 
 def unflatten(data: FrozenBuffer | bytes, values: Iterable[Any]) -> Any:

--- a/python/monarch/_src/actor/tensor_engine_shim.py
+++ b/python/monarch/_src/actor/tensor_engine_shim.py
@@ -31,7 +31,7 @@ time it is used.
 if TYPE_CHECKING:
     from monarch._src.actor.actor_mesh import ActorEndpoint, Port, Selection
 
-from monarch._rust_bindings.monarch_hyperactor.buffers import FrozenBuffer
+from monarch._rust_bindings.monarch_hyperactor.buffers import Buffer
 
 P = ParamSpec("P")
 F = TypeVar("F", bound=Callable[..., Any])
@@ -70,7 +70,7 @@ def shim(
 @shim(module="monarch.mesh_controller")
 def actor_send(
     endpoint: "ActorEndpoint[..., ...]",
-    args_kwargs_tuple: bytes,
+    args_kwargs_tuple: Buffer,
     refs: "Sequence[Any]",
     port: "Optional[Port[Any]]",
     selection: "Selection",
@@ -80,7 +80,7 @@ def actor_send(
 @shim(module="monarch.mesh_controller")
 def actor_rref(
     endpoint: Any,
-    args_kwargs_tuple: FrozenBuffer,
+    args_kwargs_tuple: Buffer,
     refs: Sequence[Any],
 ) -> Any: ...
 

--- a/python/monarch/mesh_controller.py
+++ b/python/monarch/mesh_controller.py
@@ -37,7 +37,7 @@ from monarch._rust_bindings.monarch_hyperactor.actor import (
     PythonMessageKind,
     UnflattenArg,
 )
-from monarch._rust_bindings.monarch_hyperactor.buffers import FrozenBuffer
+from monarch._rust_bindings.monarch_hyperactor.buffers import Buffer
 from monarch._rust_bindings.monarch_hyperactor.mailbox import Mailbox
 from monarch._rust_bindings.monarch_hyperactor.proc import (  # @manual=//monarch/monarch_extension:monarch_extension
     ActorId,
@@ -407,7 +407,7 @@ def _cast_call_method_indirect(
     selection: str,
     client: MeshClient,
     seq: Seq,
-    args_kwargs_tuple: FrozenBuffer,
+    args_kwargs_tuple: Buffer,
     refs: Sequence[Any],
 ) -> Tuple[str, int]:
     unflatten_args = [
@@ -427,7 +427,7 @@ def _cast_call_method_indirect(
 
 def actor_send(
     endpoint: ActorEndpoint,
-    args_kwargs_tuple: FrozenBuffer,
+    args_kwargs_tuple: Buffer,
     refs: Sequence[Any],
     port: Optional[Port[Any]],
     selection: str,
@@ -469,7 +469,7 @@ def actor_send(
 
 def _actor_send(
     endpoint: ActorEndpoint,
-    args_kwargs_tuple: FrozenBuffer,
+    args_kwargs_tuple: Buffer,
     refs: Sequence[Any],
     port: Optional[Port[Any]],
     selection: str,
@@ -503,7 +503,7 @@ def _actor_send(
     client._request_status()
 
 
-def actor_rref(endpoint, args_kwargs_tuple: FrozenBuffer, refs: Sequence[Any]):
+def actor_rref(endpoint, args_kwargs_tuple: Buffer, refs: Sequence[Any]):
     chosen_stream = stream._active
     fake_result, dtensors, mutates, mesh = dtensor_check(
         endpoint._propagate,

--- a/python/tests/_monarch/test_hyperactor.py
+++ b/python/tests/_monarch/test_hyperactor.py
@@ -108,7 +108,6 @@ def test_buffer_read_write() -> None:
 
 def test_pickle_to_buffer() -> None:
     x = [bytes(100000)]
-    b = Buffer()
     args, b = flatten(x, lambda x: False)
-    y = unflatten(b, args)
+    y = unflatten(b.freeze(), args)
     assert x == y

--- a/python/tests/test_host_mesh.py
+++ b/python/tests/test_host_mesh.py
@@ -115,7 +115,7 @@ def test_pickle() -> None:
         Extent(["replicas", "hosts"], [2, 4]),
     )
     _unused, pickled = flatten(host, lambda _: False)
-    unpickled = unflatten(pickled, _unused)
+    unpickled = unflatten(pickled.freeze(), _unused)
     assert isinstance(unpickled, HostMesh)
     assert host.extent.labels == ["replicas", "hosts"]
     assert host.extent.sizes == [2, 4]

--- a/serde_multipart/src/part.rs
+++ b/serde_multipart/src/part.rs
@@ -79,6 +79,10 @@ impl Part {
     pub fn is_empty(&self) -> bool {
         self.0.iter().all(|b| b.is_empty())
     }
+
+    pub fn from_fragments(fragments: Vec<Bytes>) -> Self {
+        Self(fragments)
+    }
 }
 
 impl<T: Into<Bytes>> From<T> for Part {


### PR DESCRIPTION
Summary:
Currently our pickle is still not truly zero copy because the Pickler calls `Buffer::write()` which is copying bytes from `PyBytes` to `BytesMut` via `extend_from_slice()`. 

To avoid copies, we can just make `Buffer` backed by a `Vec<PyBytes>` with each call to `Buffer::write()` pushing the PyBytes to the Vec.

The following figures show a round trip produced from
```
await am.echo.call(b"x" * 1024 * 1024)
```
Before: 
Send path: 600us pickle (purple), write frames (dark green), receive frames (light green), 130 us unpickle, 
Reply path: 600us pickle, write frames, receive frames, 130us unpickle
 {F1983399784}



After:
Send path: 20us pickle (purple), write frames (dark green), receive frames (light green), 200us unpickle, 
Reply path: 20us pickle, write frames, receive frames, 150us unpickle
{F1983399596}

Differential Revision: D86696391


