### PR TITLE
FragmentedPart

### DIFF
--- a/hyperactor/src/data.rs
+++ b/hyperactor/src/data.rs
@@ -382,9 +382,13 @@ impl Encoded {
             Encoded::Json(data) => crc32fast::hash(data),
             Encoded::Multipart(message) => {
                 let mut hasher = crc32fast::Hasher::new();
-                hasher.update(message.body().as_ref());
+                for fragment in message.body().iter() {
+                    hasher.update(fragment);
+                }
                 for part in message.parts() {
-                    hasher.update(part.as_ref());
+                    for fragment in part.iter() {
+                        hasher.update(fragment);
+                    }
                 }
                 hasher.finalize()
             }
@@ -398,9 +402,13 @@ impl std::fmt::Debug for Encoded {
             Encoded::Bincode(data) => write!(f, "Encoded::Bincode({})", HexFmt(data)),
             Encoded::Json(data) => write!(f, "Encoded::Json({})", HexFmt(data)),
             Encoded::Multipart(message) => {
-                write!(f, "Encoded::Multipart(body={}", HexFmt(message.body()))?;
+                write!(
+                    f,
+                    "Encoded::Multipart(body={}",
+                    HexFmt(&message.body().to_bytes())
+                )?;
                 for (index, part) in message.parts().iter().enumerate() {
-                    write!(f, ", part[{}]={}", index, HexFmt(part))?;
+                    write!(f, ", part[{}]={}", index, HexFmt(&part.to_bytes()))?;
                 }
                 write!(f, ")")
             }

--- a/monarch_hyperactor/src/actor.rs
+++ b/monarch_hyperactor/src/actor.rs
@@ -341,7 +341,7 @@ impl PythonMessage {
                     Ok(ResolvedCallMethod {
                         method: name,
                         bytes: FrozenBuffer {
-                            inner: self.message.into_inner(),
+                            inner: self.message.into_bytes(),
                         },
                         local_state,
                         response_port,
@@ -380,7 +380,7 @@ impl PythonMessage {
                 Ok(ResolvedCallMethod {
                     method: name,
                     bytes: FrozenBuffer {
-                        inner: self.message.into_inner(),
+                        inner: self.message.into_bytes(),
                     },
                     local_state,
                     response_port,
@@ -399,7 +399,7 @@ impl std::fmt::Debug for PythonMessage {
             .field("kind", &self.kind)
             .field(
                 "message",
-                &hyperactor::data::HexFmt(&(*self.message)[..]).to_string(),
+                &hyperactor::data::HexFmt(&(*self.message.to_bytes())[..]).to_string(),
             )
             .finish()
     }
@@ -451,7 +451,7 @@ impl PythonMessage {
     #[getter]
     fn message(&self) -> FrozenBuffer {
         FrozenBuffer {
-            inner: self.message.clone().into_inner(),
+            inner: self.message.to_bytes(),
         }
     }
 }


### PR DESCRIPTION
Summary:
This sets us up for the next diff by creating `FragmentedPart` 

Currently our pickle is still not truly zero copy because the Pickler calls `Buffer::write()` which is copying bytes from `PyBytes` to `BytesMut` via `extend_from_slice()`. 

This is especially problematic for large messages (100KB+) as we are spending a lot of CPU cycles handling page faults. For a 1MB message pickling can take as long as 600us

To avoid copies, we can just make `Buffer` backed by a `Vec<PyBytes>` with each call to `Buffer::write()` pushing the PyBytes to the Vec. As a result of this, the PyBytes are physically fragmented despite being logically contiguous. 

To make this work, we will have a NewType with called `FragmentedPart` with a `::Fragmented` variant wrapping `Vec<Part>` and a `::Contiguous` variant wrapping `Part`. Similar to `Part`, `FragmentedPart` also just collects during serialization. When we receive the frame on the other end of the wire, we reconstruct it contiguously in the `FragmentedPart::Contiguous` variant so that we can easily consume it to create a single contiguous `bytes::Bytes`

Differential Revision: D86696390


