### PR TITLE
[hyperactor] factor `net` into modules

### DIFF
--- a/hyperactor/src/channel/net.rs
+++ b/hyperactor/src/channel/net.rs
@@ -47,48 +47,18 @@
 //!   when EOF occurs exactly on a frame boundary. If EOF happens
 //!   mid-frame, it returns `Err(io::ErrorKind::UnexpectedEof)`.
 
-use std::any::type_name;
-use std::collections::VecDeque;
 use std::fmt;
 use std::fmt::Debug;
-use std::future::Future;
-use std::io;
-use std::mem::replace;
-use std::mem::take;
 use std::net::ToSocketAddrs;
-use std::ops::Deref;
-use std::ops::DerefMut;
-use std::pin::Pin;
-use std::sync::Arc;
-use std::task::Poll;
 
 use anyhow::Context;
-use backoff::ExponentialBackoffBuilder;
-use backoff::backoff::Backoff;
-use bytes::Buf;
 use bytes::Bytes;
-use dashmap::DashMap;
-use dashmap::mapref::entry::Entry;
 use enum_as_inner::EnumAsInner;
 use serde::de::Error;
 use tokio::io::AsyncRead;
 use tokio::io::AsyncWrite;
-use tokio::io::AsyncWriteExt;
-use tokio::io::ReadHalf;
-use tokio::io::WriteHalf;
-use tokio::sync::Mutex;
-use tokio::sync::MutexGuard;
 use tokio::sync::watch;
-use tokio::task::JoinError;
-use tokio::task::JoinHandle;
-use tokio::task::JoinSet;
-use tokio::time::Duration;
 use tokio::time::Instant;
-use tokio_util::net::Listener;
-use tokio_util::sync::CancellationToken;
-use tracing::Instrument;
-use tracing::Level;
-use tracing::Span;
 
 use super::*;
 use crate::RemoteMessage;
@@ -96,27 +66,13 @@ use crate::clock::Clock;
 use crate::clock::RealClock;
 use crate::config;
 use crate::config::CHANNEL_MULTIPART;
-use crate::metrics;
 
+mod client;
 mod framed;
-use framed::FrameReader;
-use framed::FrameWrite;
-
-/// Use to prevent [futures::Stream] objects using the wrong next() method by
-/// accident. Bascially, we want to use [tokio_stream::StreamExt::next] since it
-/// is cancel safe. However, there is another trait, [futures::StreamExt::next],
-/// which has the same method name and similar functionality, except it is not
-/// cancel safe. It is quite easy to import the wrong trait and use the wrong
-/// method by doing `stream.next()`. Adding this trait would prevent this
-/// from happening in this file. The callsite would have to `StreamExt::next()`
-/// to disambiguate.
-trait UnimplementedStreamExt {
-    fn next(&mut self) {
-        unimplemented!()
-    }
-}
-
-impl<T: futures::Stream> UnimplementedStreamExt for T {}
+use client::dial;
+mod server;
+pub use server::ServerHandle;
+use server::serve;
 
 pub(crate) trait Stream:
     AsyncRead + AsyncWrite + Unpin + Send + Sync + Debug + 'static
@@ -175,460 +131,6 @@ fn serialize_bincode<S: ?Sized + serde::Serialize>(
     }
 }
 
-struct QueuedMessage<M: RemoteMessage> {
-    seq: u64,
-    message: serde_multipart::Message,
-    received_at: Instant,
-    // When this message was written to the stream. None means it is not
-    // written yet.
-    sent_at: Option<Instant>,
-    return_channel: oneshot::Sender<SendError<M>>,
-}
-
-impl<M: RemoteMessage> fmt::Display for QueuedMessage<M> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let rcv_secs = self.received_at.elapsed().as_secs();
-        match self.sent_at {
-            Some(s) => {
-                write!(
-                    f,
-                    "(seq={}, since_rcv={}sec, since_sent={}sec)",
-                    self.seq,
-                    rcv_secs,
-                    s.elapsed().as_secs()
-                )
-            }
-            None => {
-                write!(f, "(seq={}, since_rcv={}sec)", self.seq, rcv_secs)
-            }
-        }
-    }
-}
-
-// A new type to provide custom Debug impl.
-struct MessageDeque<M: RemoteMessage>(VecDeque<QueuedMessage<M>>);
-
-impl<M: RemoteMessage> MessageDeque<M> {
-    fn len(&self) -> usize {
-        self.0.len()
-    }
-
-    fn is_empty(&self) -> bool {
-        self.0.is_empty()
-    }
-
-    fn front(&self) -> Option<&QueuedMessage<M>> {
-        self.0.front()
-    }
-
-    fn back(&self) -> Option<&QueuedMessage<M>> {
-        self.0.back()
-    }
-
-    fn num_bytes_queued(&self) -> usize {
-        self.0.iter().map(|m| m.message.len()).sum()
-    }
-}
-
-impl<M: RemoteMessage> Deref for MessageDeque<M> {
-    type Target = VecDeque<QueuedMessage<M>>;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-impl<M: RemoteMessage> DerefMut for MessageDeque<M> {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
-    }
-}
-
-// only show the first and last N messages, and display how many are
-// omitted in the middle.
-impl<M: RemoteMessage> fmt::Display for MessageDeque<M> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fn write_msg<M: RemoteMessage>(
-            f: &mut fmt::Formatter<'_>,
-            i: usize,
-            msg: &QueuedMessage<M>,
-        ) -> fmt::Result {
-            if i > 0 {
-                write!(f, ", ")?;
-            }
-            write!(f, "{}", msg)
-        }
-
-        let len = self.0.len();
-        let n: usize = 3;
-
-        write!(f, "[")?;
-
-        if len <= n * 2 {
-            for (i, msg) in self.0.iter().enumerate() {
-                write_msg(f, i, msg)?;
-            }
-        } else {
-            // first N
-            for (i, msg) in self.0.iter().take(n).enumerate() {
-                write_msg(f, i, msg)?;
-            }
-            // middle
-            write!(f, ", ... omit {} messages ..., ", len - 2 * n)?;
-            // last N
-            for (i, msg) in self.0.iter().skip(len - n).enumerate() {
-                write_msg(f, i, msg)?;
-            }
-        }
-
-        write!(f, "]")
-    }
-}
-
-impl<M: RemoteMessage> QueuedMessage<M> {
-    /// Attempt to deserialize this queued frame as a
-    /// `Frame::Message<M>` and return it to the original
-    /// sender. Falls back to logging if the frame is not a
-    /// message or deserialization fails.
-    pub(crate) fn try_return(self) {
-        match serde_multipart::deserialize_bincode::<Frame<M>>(self.message) {
-            Ok(Frame::Message(_, msg)) => {
-                let _ = self
-                    .return_channel
-                    .send(SendError(ChannelError::Closed, msg));
-            }
-            Ok(_) => {
-                tracing::debug!("queued frame was not a Frame::Message; dropping without return");
-            }
-            Err(e) => {
-                tracing::warn!("failed to deserialize queued frame for return: {e}");
-            }
-        }
-    }
-}
-
-struct Outbox<'a, M: RemoteMessage> {
-    // The seq number of the next new message put into outbox. Requeued
-    // unacked messages should still use their already assigned seq
-    // numbers.
-    next_seq: u64,
-    deque: MessageDeque<M>,
-    log_id: &'a str,
-}
-
-impl<'a, M: RemoteMessage> Outbox<'a, M> {
-    fn new(log_id: &'a str) -> Self {
-        Self {
-            next_seq: 0,
-            deque: MessageDeque(VecDeque::new()),
-            log_id,
-        }
-    }
-
-    fn is_expired(&self) -> bool {
-        match self.deque.front() {
-            None => false,
-            Some(msg) => {
-                msg.received_at.elapsed() > config::global::get(config::MESSAGE_DELIVERY_TIMEOUT)
-            }
-        }
-    }
-
-    fn is_empty(&self) -> bool {
-        self.deque.is_empty()
-    }
-
-    fn front_message(&self) -> Option<serde_multipart::Message> {
-        self.deque.front().map(|msg| msg.message.clone())
-    }
-
-    fn front_size(&self) -> Option<usize> {
-        self.deque.front().map(|msg| msg.message.frame_len())
-    }
-
-    fn pop_front(&mut self) -> Option<QueuedMessage<M>> {
-        self.deque.pop_front()
-    }
-
-    fn push_back(
-        &mut self,
-        (message, return_channel, received_at): (M, oneshot::Sender<SendError<M>>, Instant),
-    ) -> Result<(), String> {
-        assert!(
-            self.deque.back().is_none_or(|msg| msg.seq < self.next_seq),
-            "{}: unexpected: seq should be in ascending order, but got {} vs {}",
-            self.log_id,
-            self.deque
-                .back()
-                .map_or("None".to_string(), |m| m.to_string()),
-            self.next_seq
-        );
-
-        let frame = Frame::Message(self.next_seq, message);
-        let message = serialize_bincode(&frame).map_err(|e| format!("serialization error: {e}"))?;
-        metrics::REMOTE_MESSAGE_SEND_SIZE.record(message.frame_len() as f64, &[]);
-
-        self.deque.push_back(QueuedMessage {
-            seq: self.next_seq,
-            message,
-            received_at,
-            sent_at: None,
-            return_channel,
-        });
-        self.next_seq += 1;
-        Ok(())
-    }
-
-    fn requeue_unacked(&mut self, unacked: MessageDeque<M>) {
-        if let (Some(last), Some(first)) = (unacked.back(), self.deque.front()) {
-            assert!(
-                last.seq < first.seq,
-                "{}: seq should be in ascending order, but got {} vs {}",
-                self.log_id,
-                last.seq,
-                first.seq,
-            );
-        }
-
-        let mut outbox = unacked;
-        outbox.append(&mut self.deque);
-        self.deque = outbox;
-    }
-}
-
-impl<'a, M: RemoteMessage> fmt::Display for Outbox<'a, M> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "(next_seq: {}, deque: {})", self.next_seq, self.deque)
-    }
-}
-
-// A tuple of acked seq and when it was acked.
-#[derive(Debug, Clone)]
-struct AckedSeq(u64, Instant);
-
-impl fmt::Display for AckedSeq {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let acked_secs = self.1.elapsed().as_secs();
-        write!(f, "(seq={}, since_acked={}sec)", self.0, acked_secs)
-    }
-}
-
-struct Unacked<'a, M: RemoteMessage> {
-    deque: MessageDeque<M>,
-    largest_acked: Option<AckedSeq>,
-    log_id: &'a str,
-}
-
-impl<'a, M: RemoteMessage> Unacked<'a, M> {
-    fn new(largest_acked: Option<AckedSeq>, log_id: &'a str) -> Self {
-        Self {
-            deque: MessageDeque(VecDeque::new()),
-            largest_acked,
-            log_id,
-        }
-    }
-
-    fn push_back(&mut self, message: QueuedMessage<M>) {
-        assert!(
-            self.deque.back().is_none_or(|msg| msg.seq < message.seq),
-            "{}: seq should be in ascending order, but got {} vs {}",
-            self.log_id,
-            self.deque
-                .back()
-                .map_or("None".to_string(), |m| m.to_string()),
-            message.seq
-        );
-
-        if let Some(AckedSeq(largest, _)) = self.largest_acked {
-            // Note: some scenarios of why this if branch could happen:
-            //
-            // message.0 <= largest could happen in the following scenario:
-            //
-            // 1. NetTx sent seq=2 and seq=3.
-            // 2. NetRx received messages and put them on its mpsc channel.
-            //    But before NetRx acked, the connection was broken.
-            // 3. NetTx reconnected. In this case, NetTx will put unacked
-            //    messages, i.e. 2 and 3, back to outbox.
-            // 2. At the beginning of the new connection. NetRx acked 2
-            //    and 3 immediately.
-            // 3. Before sending messages, NetTx received the acks first
-            //    with the new connection. NetTx Stored 3 as largest_acked.
-            // 4. Now NetRx finally got the chance to resend 2 and 3.
-            //    When it resent 2, 2 < largest_acked, which is 3.
-            //    * similarly, if there was only one message, seq=3
-            //      involved, we would have 3 == largest_acked.
-            //
-            // message.0 == largest could also happen in the following
-            // scenario:
-            //
-            // The message was delivered, but the send branch did not push
-            // it into unacked queue. This chould happen when:
-            //   1. `outbox.send_message` future was canceled by tokio::select.
-            //   2. `outbox.send_message` returns an error, which makes
-            //      the deliver result unknown to Tx.
-            // When this happens, Tx will resend the same message. However,
-            // since Rx already received the message, it might ack before
-            // Tx resends. As a result, this message's ack would be
-            // recorded already by `largest_acked` before it is put into
-            // unacked queue.
-            if message.seq <= largest {
-                // since the message is already delivered and acked, it
-                // does need to be put in the queue again.
-                return;
-            }
-        }
-
-        self.deque.push_back(message);
-    }
-
-    /// Remove acked messages from the deque.
-    fn prune(&mut self, acked: u64, acked_at: Instant) {
-        assert!(
-            self.largest_acked.as_ref().map_or(0, |i| i.0) <= acked,
-            "{}: received out-of-order ack; received: {}; stored largest: {}",
-            self.log_id,
-            acked,
-            self.largest_acked
-                .as_ref()
-                .map_or("None".to_string(), |l| l.to_string()),
-        );
-
-        self.largest_acked = Some(AckedSeq(acked, acked_at));
-        let deque = &mut self.deque;
-        while let Some(msg) = deque.front() {
-            if msg.seq <= acked {
-                deque.pop_front();
-            } else {
-                // Messages in the deque are orderd by seq in ascending
-                // order. So we could return early once we encounter
-                // a message that is not acked.
-                break;
-            }
-        }
-    }
-
-    fn is_expired(&self) -> bool {
-        matches!(
-            self.deque.front(),
-            Some(msg) if msg.received_at.elapsed() > config::global::get(config::MESSAGE_DELIVERY_TIMEOUT)
-        )
-    }
-
-    /// Return when the oldest message has not been acked within the
-    /// timeout limit. This method is used in tokio::select with other
-    /// branches.
-    async fn wait_for_timeout(&self) {
-        match self.deque.front() {
-            Some(msg) => {
-                RealClock
-                    .sleep_until(
-                        msg.received_at + config::global::get(config::MESSAGE_DELIVERY_TIMEOUT),
-                    )
-                    .await
-            }
-            None => std::future::pending::<()>().await,
-        }
-    }
-
-    fn is_empty(&self) -> bool {
-        self.deque.is_empty()
-    }
-}
-
-impl<'a, M: RemoteMessage> fmt::Display for Unacked<'a, M> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "(deque: {}, largest_acked: {})",
-            self.deque,
-            self.largest_acked
-                .as_ref()
-                .map_or("None".to_string(), |l| l.to_string())
-        )
-    }
-}
-
-struct Deliveries<'a, M: RemoteMessage> {
-    outbox: Outbox<'a, M>,
-    unacked: Unacked<'a, M>,
-}
-
-impl<'a, M: RemoteMessage> fmt::Display for Deliveries<'a, M> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "(outbox: {}, unacked: {})", self.outbox, self.unacked)
-    }
-}
-
-#[derive(EnumAsInner)]
-enum State<'a, M: RemoteMessage> {
-    /// Channel is running.
-    Running(Deliveries<'a, M>),
-    /// Message delivery not possible.
-    Closing {
-        deliveries: Deliveries<'a, M>,
-        /// why closing
-        reason: String,
-    },
-}
-
-impl<'a, M: RemoteMessage> State<'a, M> {
-    fn init(log_id: &'a str) -> Self {
-        Self::Running(Deliveries {
-            outbox: Outbox::new(log_id),
-            unacked: Unacked::new(None, log_id),
-        })
-    }
-
-    fn deliveries(&self) -> &Deliveries<'a, M> {
-        match self {
-            Self::Running(deliveries) => deliveries,
-            Self::Closing { deliveries, .. } => deliveries,
-        }
-    }
-}
-
-impl<'a, M: RemoteMessage> fmt::Display for State<'a, M> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            State::Running(deliveries) => {
-                write!(f, "Running(deliveries: {})", deliveries)
-            }
-            State::Closing { deliveries, reason } => {
-                write!(f, "Running(deliveries: {}, reason: {})", deliveries, reason)
-            }
-        }
-    }
-}
-
-#[derive(EnumAsInner)]
-enum Conn<S: Stream> {
-    /// Disconnected.
-    Disconnected(Box<dyn Backoff + Send>),
-    /// Connected and ready to go.
-    Connected {
-        reader: FrameReader<ReadHalf<S>>,
-        write_state: WriteState<WriteHalf<S>, serde_multipart::Frame, ()>,
-    },
-}
-
-impl<S: Stream> Conn<S> {
-    fn reconnect_with_default() -> Self {
-        Self::Disconnected(Box::new(
-            ExponentialBackoffBuilder::new()
-                .with_initial_interval(Duration::from_millis(50))
-                .with_multiplier(2.0)
-                .with_randomization_factor(0.1)
-                .with_max_interval(Duration::from_millis(1000))
-                .with_max_elapsed_time(None) // Allow infinite retries
-                .build(),
-        ))
-    }
-
-    fn reconnect(backoff: impl Backoff + Send + 'static) -> Self {
-        Self::Disconnected(Box::new(backoff))
-    }
-}
-
 /// A Tx implemented on top of a Link. The Tx manages the link state,
 /// reconnections, etc.
 #[derive(Debug)]
@@ -636,569 +138,6 @@ pub(crate) struct NetTx<M: RemoteMessage> {
     sender: mpsc::UnboundedSender<(M, oneshot::Sender<SendError<M>>, Instant)>,
     dest: ChannelAddr,
     status: watch::Receiver<TxStatus>,
-}
-
-impl<M: RemoteMessage> NetTx<M> {
-    /// Creates a new session, and assigns it a guid.
-    fn new(link: impl Link + 'static) -> Self {
-        let (sender, receiver) = mpsc::unbounded_channel();
-        let dest = link.dest();
-        let (notify, status) = watch::channel(TxStatus::Active);
-
-        let tx = Self {
-            sender,
-            dest,
-            status,
-        };
-        crate::init::get_runtime().spawn(Self::run(link, receiver, notify));
-        tx
-    }
-
-    async fn run(
-        link: impl Link,
-        mut receiver: mpsc::UnboundedReceiver<(M, oneshot::Sender<SendError<M>>, Instant)>,
-        notify: watch::Sender<TxStatus>,
-    ) {
-        // If we can't deliver a message within this limit consider
-        // `link` broken and return.
-
-        let session_id = rand::random();
-        let log_id = format!("session {}.{}", link.dest(), session_id);
-        let mut state = State::init(&log_id);
-        let mut conn = Conn::reconnect_with_default();
-
-        let (state, conn) = loop {
-            let span = Self::state_span(&state, &conn, session_id, &link);
-
-            (state, conn) = Self::step(state, conn, session_id, &log_id, &link, &mut receiver)
-                .instrument(span)
-                .await;
-
-            if state.is_closing() {
-                break (state, conn);
-            }
-
-            if let Conn::Disconnected(ref mut backoff) = conn {
-                RealClock.sleep(backoff.next_backoff().unwrap()).await;
-            }
-        }; // loop
-
-        let span = Self::state_span(&state, &conn, session_id, &link);
-
-        tracing::debug!(parent: &span, "{log_id}: NetTx exited its loop with state: {state}");
-
-        match state {
-            State::Closing {
-                deliveries:
-                    Deliveries {
-                        mut outbox,
-                        mut unacked,
-                    },
-                // TODO(T233029051): Return reason through return_channel too.
-                reason: _,
-            } => {
-                // Return in order from oldest to newest, messages
-                // either not acknowledged or not sent.
-                unacked
-                    .deque
-                    .drain(..)
-                    .chain(outbox.deque.drain(..))
-                    .for_each(|queued| queued.try_return());
-                while let Ok((msg, return_channel, _)) = receiver.try_recv() {
-                    if let Err(m) = return_channel.send(SendError(ChannelError::Closed, msg)) {
-                        tracing::warn!("failed to deliver SendError: {}", m);
-                    }
-                }
-            }
-            _ => (),
-        }
-
-        // Notify senders that this link is no longer usable
-        if let Err(err) = notify.send(TxStatus::Closed) {
-            tracing::debug!(parent: &span, "{log_id}: tx status update error: {err}");
-        }
-
-        if let Conn::Connected {
-            write_state: WriteState::Writing(mut frame_writer, ()),
-            ..
-        } = conn
-        {
-            if let Err(err) = frame_writer.send().await {
-                tracing::info!(parent: &span, "{log_id}: write error: {err}",);
-            } else if let Err(err) = frame_writer.complete().flush().await {
-                tracing::info!(parent: &span, "{log_id}: flush error: {err}",);
-            }
-        }
-
-        tracing::debug!(parent: &span, "{log_id}: NetTx::run exits");
-    }
-
-    fn state_span<'a, L, S>(state: &State<'a, M>, conn: &Conn<S>, session_id: u64, link: &L) -> Span
-    where
-        S: Stream,
-        L: Link<Stream = S>,
-    {
-        let deliveries = state.deliveries();
-
-        use valuable::NamedField;
-        use valuable::Structable;
-        use valuable::Tuplable;
-        use valuable::Valuable;
-        use valuable::Value;
-
-        struct TimestampValue(Instant);
-
-        impl From<Instant> for TimestampValue {
-            fn from(timestamp: Instant) -> TimestampValue {
-                TimestampValue(timestamp)
-            }
-        }
-
-        impl Valuable for TimestampValue {
-            fn as_value(&self) -> Value<'_> {
-                Value::Tuplable(self)
-            }
-
-            fn visit(&self, visit: &mut dyn valuable::Visit) {
-                let elapsed = humantime::format_duration(self.0.elapsed()).to_string();
-                visit.visit_unnamed_fields(&[Value::String(&elapsed)]);
-            }
-        }
-
-        impl Tuplable for TimestampValue {
-            fn definition(&self) -> valuable::TupleDef {
-                valuable::TupleDef::new_static(1)
-            }
-        }
-
-        #[derive(Valuable)]
-        struct QueueEntryValue {
-            seq: u64,
-            since_received: TimestampValue,
-            since_sent: Option<TimestampValue>,
-        }
-
-        impl<M: RemoteMessage> From<&QueuedMessage<M>> for QueueEntryValue {
-            fn from(m: &QueuedMessage<M>) -> QueueEntryValue {
-                QueueEntryValue {
-                    seq: m.seq,
-                    since_received: m.received_at.into(),
-                    since_sent: m.sent_at.map(TimestampValue::from),
-                }
-            }
-        }
-
-        #[derive(Valuable)]
-        enum QueueValue {
-            Empty,
-            NonEmpty {
-                len: usize,
-                num_bytes_queued: usize,
-                front: QueueEntryValue,
-                back: QueueEntryValue,
-            },
-        }
-
-        impl<M: RemoteMessage> From<&MessageDeque<M>> for QueueValue {
-            fn from(q: &MessageDeque<M>) -> QueueValue {
-                if q.is_empty() {
-                    return QueueValue::Empty;
-                }
-
-                QueueValue::NonEmpty {
-                    len: q.len(),
-                    num_bytes_queued: q.num_bytes_queued(),
-                    front: q.front().unwrap().into(),
-                    back: q.back().unwrap().into(),
-                }
-            }
-        }
-
-        struct AckedSeqValue(AckedSeq);
-
-        static ACKED_SEQ_FIELDS: &[NamedField<'static>] =
-            &[NamedField::new("seq"), NamedField::new("timestamp")];
-
-        impl Valuable for AckedSeqValue {
-            fn as_value(&self) -> Value<'_> {
-                Value::Structable(self)
-            }
-
-            fn visit(&self, visit: &mut dyn valuable::Visit) {
-                let AckedSeq(seq, timestamp) = &self.0;
-                visit.visit_named_fields(&valuable::NamedValues::new(
-                    ACKED_SEQ_FIELDS,
-                    &[
-                        seq.as_value(),
-                        Value::String(&humantime::format_duration(timestamp.elapsed()).to_string()),
-                    ],
-                ));
-            }
-        }
-
-        impl Structable for AckedSeqValue {
-            fn definition(&self) -> valuable::StructDef<'_> {
-                valuable::StructDef::new_static(
-                    "AckedSeq",
-                    valuable::Fields::Named(ACKED_SEQ_FIELDS),
-                )
-            }
-        }
-
-        let largest_acked = deliveries
-            .unacked
-            .largest_acked
-            .as_ref()
-            .map(|acked_seq| AckedSeqValue(acked_seq.clone()));
-
-        tracing::span!(
-            Level::ERROR,
-            "net i/o loop",
-            session = format!("{}.{}", link.dest(), session_id),
-            connected = conn.is_connected(),
-            next_seq = deliveries.outbox.next_seq,
-            largest_acked = largest_acked.as_value(),
-            outbox = QueueValue::from(&deliveries.outbox.deque).as_value(),
-            unacked = QueueValue::from(&deliveries.unacked.deque).as_value(),
-        )
-    }
-
-    async fn step<'a, L, S>(
-        state: State<'a, M>,
-        conn: Conn<S>,
-        session_id: u64,
-        log_id: &'a str,
-        link: &L,
-        receiver: &mut mpsc::UnboundedReceiver<(M, oneshot::Sender<SendError<M>>, Instant)>,
-    ) -> (State<'a, M>, Conn<S>)
-    where
-        S: Stream,
-        L: Link<Stream = S>,
-    {
-        match (state, conn) {
-            // This branch is to provide lazy connection creation. It can be removed after
-            // we move to eager creation.
-            (
-                State::Running(Deliveries {
-                    mut outbox,
-                    unacked,
-                }),
-                conn,
-            ) if outbox.is_empty() && unacked.is_empty() => match receiver.recv().await {
-                Some(msg) => match outbox.push_back(msg) {
-                    Ok(()) => {
-                        let running = State::Running(Deliveries { outbox, unacked });
-                        (running, conn)
-                    }
-                    Err(err) => {
-                        let error_msg =
-                            format!("{log_id}: failed to push message to outbox: {err}");
-                        tracing::error!(error_msg);
-                        (
-                            State::Closing {
-                                deliveries: Deliveries { outbox, unacked },
-                                reason: error_msg,
-                            },
-                            conn,
-                        )
-                    }
-                },
-                None => (
-                    State::Closing {
-                        deliveries: Deliveries { outbox, unacked },
-                        reason: "NetTx is dropped".to_string(),
-                    },
-                    conn,
-                ),
-            },
-            (
-                State::Running(Deliveries {
-                    mut outbox,
-                    unacked,
-                }),
-                Conn::Connected {
-                    reader,
-                    write_state: WriteState::Idle(writer),
-                    ..
-                },
-            ) if !outbox.is_empty() => {
-                let max = config::global::get(config::CODEC_MAX_FRAME_LENGTH);
-                let len = outbox.front_size().expect("not empty");
-                let message = outbox.front_message().expect("not empty");
-
-                match FrameWrite::new(writer, message.framed(), max) {
-                    Ok(fw) => (
-                        State::Running(Deliveries { outbox, unacked }),
-                        Conn::Connected {
-                            reader,
-                            write_state: WriteState::Writing(fw, ()),
-                        },
-                    ),
-                    Err((writer, e)) => {
-                        debug_assert_eq!(e.kind(), io::ErrorKind::InvalidData);
-                        tracing::error!(
-                            "rejecting oversize frame: len={} > max={}. \
-                                ack will not arrive before timeout; increase CODEC_MAX_FRAME_LENGTH to allow.",
-                            len,
-                            max
-                        );
-                        // Reject and return.
-                        outbox.pop_front().expect("not empty").try_return();
-                        let error_msg =
-                            format!("{log_id}: oversized frame was rejected. closing channel");
-                        tracing::error!(error_msg);
-                        // Close the channel (avoid sequence
-                        // violations).
-                        (
-                            State::Closing {
-                                deliveries: Deliveries { outbox, unacked },
-                                reason: error_msg,
-                            },
-                            Conn::Connected {
-                                reader,
-                                write_state: WriteState::Idle(writer),
-                            },
-                        )
-                    }
-                }
-            }
-            (
-                State::Running(Deliveries {
-                    mut outbox,
-                    mut unacked,
-                }),
-                Conn::Connected {
-                    mut reader,
-                    mut write_state,
-                },
-            ) => {
-                tokio::select! {
-                    biased;
-
-                    ack_result = reader.next() => {
-                        match ack_result {
-                            Ok(Some(buffer)) => {
-                                match deserialize_response(buffer) {
-                                    Ok(response) => {
-                                        match response {
-                                            NetRxResponse::Ack(ack) => {
-                                                unacked.prune(ack, RealClock.now());
-                                                (State::Running(Deliveries { outbox, unacked }), Conn::Connected { reader, write_state })
-                                            }
-                                            NetRxResponse::Reject => {
-                                                let error_msg = format!(
-                                                    "{log_id}: server rejected connection.",
-                                                );
-                                                tracing::error!(error_msg);
-                                                (State::Closing {
-                                                    deliveries: Deliveries{outbox, unacked},
-                                                    reason: error_msg,
-                                                }, Conn::reconnect_with_default())
-                                            }
-                                        }
-                                    }
-                                    Err(err) => {
-                                        let error_msg = format!(
-                                            "{log_id}: failed deserializing response: {err}",
-                                        );
-                                        tracing::error!(error_msg);
-                                        // Similar to the message flow, we always close the
-                                        // channel when encountering ser/deser errors.
-                                        (State::Closing {
-                                            deliveries: Deliveries{outbox, unacked},
-                                            reason: error_msg,
-                                        }, Conn::Connected { reader, write_state })
-                                    }
-                                }
-                            }
-                            Ok(None) => {
-                                // Graceful of stream: reconnect
-                                (State::Running(Deliveries { outbox, unacked }), Conn::reconnect_with_default())
-                            }
-                            Err(err) => {
-                                    tracing::error!(
-                                        "{log_id}: failed while receiving ack: {err}",
-                                    );
-                                    // Reconnect and wish the error will go away.
-                                    (State::Running(Deliveries { outbox, unacked }), Conn::reconnect_with_default())
-                            }
-                        }
-                    },
-
-                    // If acking message takes too long, consider the link broken.
-                    _ = unacked.wait_for_timeout(), if !unacked.is_empty() => {
-                        let error_msg = format!(
-                            "{log_id}: failed to receive ack within timeout {} secs; link is currently connected",
-                            config::global::get(config::MESSAGE_DELIVERY_TIMEOUT).as_secs(),
-                        );
-                        tracing::error!(error_msg);
-                        (State::Closing {
-                            deliveries: Deliveries{outbox, unacked},
-                            reason: error_msg,
-                        }, Conn::Connected { reader, write_state })
-                    }
-
-
-                    // We have to be careful to manage outgoing write states, so that we never write
-                    // partial frames in the presence cancellation.
-                    send_result = write_state.send() => {
-                        match send_result {
-                            Ok(()) => {
-                                let mut message = outbox.pop_front().expect("outbox should not be empty");
-                                // If this message was re-put into `outbox` from `unacked` due to reconnection,
-                                // its `sent_at` field would be set in the last attempt. In that case, we simply
-                                // overwrite the old one here.
-                                message.sent_at = Some(RealClock.now());
-                                unacked.push_back(message);
-                                (State::Running(Deliveries { outbox, unacked }), Conn::Connected { reader, write_state })
-                            }
-                            Err(err) => {
-                                tracing::info!(
-                                    "{log_id}: outbox send error: {err}; message size: {}",
-                                    outbox.front_size().expect("outbox should not be empty"),
-                                );
-                                (State::Running(Deliveries { outbox, unacked }), Conn::reconnect_with_default())
-                            }
-                        }
-                    }
-                    // UnboundedReceiver::recv() is cancel safe.
-                    // Only checking mpsc channel when outbox is empty. In this way, we prioritize
-                    // sending messages already in outbox.
-                    work_result = receiver.recv(), if outbox.is_empty() => {
-                        match work_result {
-                            Some(msg) => {
-                                match outbox.push_back(msg) {
-                                    Ok(()) => {
-                                        let running = State::Running (Deliveries{
-                                            outbox,
-                                            unacked,
-                                        });
-                                        (running, Conn::Connected { reader, write_state })
-                                    }
-                                    Err(err) => {
-                                        let error_msg = format!(
-                                            "{log_id}: failed to push message to outbox: {err}",
-                                        );
-                                        tracing::error!(error_msg);
-                                        (State::Closing {
-                                            deliveries: Deliveries {outbox, unacked},
-                                            reason: error_msg,
-                                        }, Conn::Connected { reader, write_state })
-                                    }
-                                }
-                            }
-                            None => (State::Closing {
-                                deliveries: Deliveries{outbox, unacked},
-                                reason: "NetTx is dropped".to_string(),
-                            }, Conn::Connected { reader, write_state }),
-                        }
-                    },
-                }
-            }
-
-            // We have a message to send, but not an active link.
-            (
-                State::Running(Deliveries {
-                    mut outbox,
-                    unacked,
-                }),
-                Conn::Disconnected(mut backoff),
-            ) => {
-                // If delivering this message is taking too long,
-                // consider the link broken.
-                if outbox.is_expired() {
-                    let error_msg = format!("{log_id}: failed to deliver message within timeout");
-                    tracing::error!(error_msg);
-                    (
-                        State::Closing {
-                            deliveries: Deliveries { outbox, unacked },
-                            reason: error_msg,
-                        },
-                        Conn::reconnect_with_default(),
-                    )
-                } else if unacked.is_expired() {
-                    let error_msg = format!(
-                        "{log_id}: failed to receive ack within timeout {} secs; link is currently broken",
-                        config::global::get(config::MESSAGE_DELIVERY_TIMEOUT).as_secs(),
-                    );
-                    tracing::error!(error_msg);
-                    (
-                        State::Closing {
-                            deliveries: Deliveries { outbox, unacked },
-                            reason: error_msg,
-                        },
-                        Conn::reconnect_with_default(),
-                    )
-                } else {
-                    match link.connect().await {
-                        Ok(stream) => {
-                            let message = serialize_bincode(&Frame::<M>::Init(session_id)).unwrap();
-
-                            let mut write = FrameWrite::new(
-                                stream,
-                                message.framed(),
-                                config::global::get(config::CODEC_MAX_FRAME_LENGTH),
-                            )
-                            .expect("enough length");
-                            let initialized = write.send().await.is_ok();
-                            let stream = write.complete();
-
-                            metrics::CHANNEL_CONNECTIONS.add(
-                                1,
-                                hyperactor_telemetry::kv_pairs!(
-                                    "transport" => link.dest().transport().to_string(),
-                                    "reason" => "link connected",
-                                ),
-                            );
-
-                            // Need to resend unacked after reconnecting.
-                            let largest_acked = unacked.largest_acked;
-                            outbox.requeue_unacked(unacked.deque);
-                            (
-                                State::Running(Deliveries {
-                                    outbox,
-                                    // unacked messages are put back to outbox. So they are not
-                                    // considered as "sent yet unacked" message anymore. But
-                                    // we still want to keep `largest_acked` to known Rx's watermark.
-                                    unacked: Unacked::new(largest_acked, log_id),
-                                }),
-                                if initialized {
-                                    backoff.reset();
-                                    let (reader, writer) = tokio::io::split(stream);
-                                    Conn::Connected {
-                                        reader: FrameReader::new(
-                                            reader,
-                                            config::global::get(config::CODEC_MAX_FRAME_LENGTH),
-                                        ),
-                                        write_state: WriteState::Idle(writer),
-                                    }
-                                } else {
-                                    Conn::reconnect(backoff)
-                                },
-                            )
-                        }
-                        Err(err) => {
-                            tracing::debug!(
-                                "session {}.{}: failed to connect: {}",
-                                link.dest(),
-                                session_id,
-                                err
-                            );
-                            (
-                                State::Running(Deliveries { outbox, unacked }),
-                                Conn::reconnect(backoff),
-                            )
-                        }
-                    }
-                }
-            }
-
-            // The link is no longer viable.
-            (State::Closing { deliveries, reason }, stream) => {
-                (State::Closing { deliveries, reason }, stream)
-            }
-        }
-    }
 }
 
 #[async_trait]
@@ -1223,15 +162,6 @@ impl<M: RemoteMessage> Tx<M> for NetTx<M> {
     }
 }
 
-fn is_closed_error(err: &std::io::Error) -> bool {
-    matches!(
-        err.kind(),
-        std::io::ErrorKind::ConnectionReset
-            | std::io::ErrorKind::ConnectionAborted
-            | std::io::ErrorKind::BrokenPipe
-    )
-}
-
 #[derive(Debug)]
 pub struct NetRx<M: RemoteMessage>(mpsc::Receiver<M>, ChannelAddr, ServerHandle);
 
@@ -1254,53 +184,6 @@ impl<M: RemoteMessage> Drop for NetRx<M> {
     }
 }
 
-/// Handle to an underlying server that is actively listening.
-#[derive(Debug)]
-pub struct ServerHandle {
-    /// Join handle of the listening task.
-    join_handle: JoinHandle<Result<(), ServerError>>,
-
-    /// A cancellation token used to indicate that a stop has been
-    /// initiated.
-    cancel_token: CancellationToken,
-
-    /// Address of the channel that was used to create the listener. This can be used to dial the that listener.
-    channel_addr: ChannelAddr,
-}
-
-impl fmt::Display for ServerHandle {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.channel_addr)
-    }
-}
-
-impl ServerHandle {
-    /// Signal the server to stop. This will stop accepting new
-    /// incoming connection requests, and drain pending operations
-    /// on active connections. After draining is completed, the
-    /// connections are closed.
-    fn stop(&self, reason: &str) {
-        tracing::info!("stopping server: {}; reason: {}", self, reason);
-        self.cancel_token.cancel();
-    }
-
-    /// Reference to the channel that was used to start the server.
-    fn local_channel_addr(&self) -> &ChannelAddr {
-        &self.channel_addr
-    }
-}
-
-impl Future for ServerHandle {
-    type Output = <JoinHandle<Result<(), ServerError>> as Future>::Output;
-
-    fn poll(self: Pin<&mut Self>, cx: &mut std::task::Context<'_>) -> Poll<Self::Output> {
-        // SAFETY: This is safe to do because self is pinned.
-        let join_handle_pinned =
-            unsafe { self.map_unchecked_mut(|container| &mut container.join_handle) };
-        join_handle_pinned.poll(cx)
-    }
-}
-
 /// Error returned during server operations.
 #[derive(Debug, thiserror::Error)]
 pub enum ServerError {
@@ -1312,45 +195,6 @@ pub enum ServerError {
     Resolve(ChannelAddr, #[source] std::io::Error),
     #[error("internal: {0} {1}")]
     Internal(ChannelAddr, #[source] anyhow::Error),
-}
-
-/// serve new connections that are accepted from the given listener.
-pub fn serve<M: RemoteMessage, L: Listener + Send + Unpin + 'static>(
-    listener: L,
-    channel_addr: ChannelAddr,
-    is_tls: bool,
-) -> Result<(ChannelAddr, NetRx<M>), ServerError>
-where
-    L::Addr: Sync + Send + fmt::Debug + Into<ChannelAddr>,
-    L::Io: Sync + Send + Unpin + fmt::Debug,
-{
-    metrics::CHANNEL_CONNECTIONS.add(
-        1,
-        hyperactor_telemetry::kv_pairs!(
-            "transport" => channel_addr.transport().to_string(),
-            "operation" => "serve"
-        ),
-    );
-
-    let (tx, rx) = mpsc::channel::<M>(1024);
-    let cancel_token = CancellationToken::new();
-    let join_handle = tokio::spawn(listen(
-        listener,
-        channel_addr.clone(),
-        tx,
-        cancel_token.child_token(),
-        is_tls,
-    ));
-    let server_handle = ServerHandle {
-        join_handle,
-        cancel_token,
-        channel_addr: channel_addr.clone(),
-    };
-
-    Ok((
-        server_handle.local_channel_addr().clone(),
-        NetRx(rx, channel_addr, server_handle),
-    ))
 }
 
 #[derive(thiserror::Error, Debug)]
@@ -1367,641 +211,9 @@ pub enum ClientError {
     InvalidAddress(String),
 }
 
-#[derive(EnumAsInner)]
-enum WriteState<W, F, T> {
-    /// No frame being written.
-    Idle(W),
-    /// Currently writing a frame, with associated T-typed value.
-    Writing(FrameWrite<W, F>, T),
-
-    /// Internal state to manage completions.
-    Broken,
-}
-
-impl<W, F: bytes::Buf, T> fmt::Debug for WriteState<W, F, T> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            WriteState::Idle(_) => f.debug_tuple("Idle").finish(),
-            WriteState::Writing(frame_write, _) => {
-                f.debug_tuple("Writing").field(frame_write).finish()
-            }
-            WriteState::Broken => f.debug_tuple("Broken").finish(),
-        }
-    }
-}
-
-impl<W, F, T> WriteState<W, F, T> {
-    fn value(&self) -> Option<&T> {
-        match self {
-            Self::Writing(_, v) => Some(v),
-            Self::Idle(_) | Self::Broken => None,
-        }
-    }
-}
-
-impl<W: AsyncWrite + Unpin, F: Buf, T> WriteState<W, F, T> {
-    async fn send(&mut self) -> io::Result<T> {
-        match self {
-            Self::Idle(_) => futures::future::pending().await,
-            Self::Writing(fw, _value) => {
-                fw.send().await?;
-                let Ok((fw, value)) = replace(self, Self::Broken).into_writing() else {
-                    panic!("illegal state");
-                };
-                *self = Self::Idle(fw.complete());
-                Ok(value)
-            }
-            Self::Broken => panic!("illegal state"),
-        }
-    }
-}
-
-struct ServerConn<S> {
-    reader: FrameReader<ReadHalf<S>>,
-    write_state: WriteState<WriteHalf<S>, Bytes, u64>,
-    source: ChannelAddr,
-    dest: ChannelAddr,
-}
-
-impl<S: AsyncRead + AsyncWrite> ServerConn<S> {
-    fn new(stream: S, source: ChannelAddr, dest: ChannelAddr) -> Self {
-        let (reader, writer) = tokio::io::split(stream);
-        Self {
-            reader: FrameReader::new(reader, config::global::get(config::CODEC_MAX_FRAME_LENGTH)),
-            write_state: WriteState::Idle(writer),
-            source,
-            dest,
-        }
-    }
-}
-
-impl<S: AsyncRead + AsyncWrite + Send + 'static + Unpin> ServerConn<S> {
-    async fn handshake<M: RemoteMessage>(&mut self) -> Result<u64, anyhow::Error> {
-        let Some(frame) = self.reader.next().await? else {
-            anyhow::bail!("end of stream before first frame from {}", self.source);
-        };
-        let message = serde_multipart::Message::from_framed(frame)?;
-        let Frame::Init(session_id) = serde_multipart::deserialize_bincode::<Frame<M>>(message)?
-        else {
-            anyhow::bail!("unexpected initial frame from {}", self.source);
-        };
-        Ok(session_id)
-    }
-
-    /// Handles a server side stream created during the `listen` loop.
-    async fn process<M: RemoteMessage>(
-        &mut self,
-        session_id: u64,
-        tx: mpsc::Sender<M>,
-        cancel_token: CancellationToken,
-        mut next: Next,
-    ) -> (Next, Result<(), anyhow::Error>) {
-        let log_id = format!("session {}.{}<-{}", self.dest, session_id, self.source);
-        let initial_next: Next = next.clone();
-        let mut rcv_raw_frame_count = 0u64;
-        let mut last_ack_time = RealClock.now();
-
-        let ack_time_interval = config::global::get(config::MESSAGE_ACK_TIME_INTERVAL);
-        let ack_msg_interval = config::global::get(config::MESSAGE_ACK_EVERY_N_MESSAGES);
-
-        let (mut final_next, final_result, reject_conn) = loop {
-            if self.write_state.is_idle()
-                && (next.ack + ack_msg_interval <= next.seq
-                    || (next.ack < next.seq && last_ack_time.elapsed() > ack_time_interval))
-            {
-                let Ok(writer) = replace(&mut self.write_state, WriteState::Broken).into_idle()
-                else {
-                    panic!("illegal state");
-                };
-                let ack = match serialize_response(NetRxResponse::Ack(next.seq - 1)) {
-                    Ok(ack) => ack,
-                    Err(err) => {
-                        break (
-                            next,
-                            Err::<(), anyhow::Error>(err.into())
-                                .context(format!("{log_id}: serializing ack")),
-                            false,
-                        );
-                    }
-                };
-                match FrameWrite::new(
-                    writer,
-                    ack,
-                    config::global::get(config::CODEC_MAX_FRAME_LENGTH),
-                ) {
-                    Ok(fw) => {
-                        self.write_state = WriteState::Writing(fw, next.seq);
-                    }
-                    Err((writer, e)) => {
-                        debug_assert_eq!(e.kind(), io::ErrorKind::InvalidData);
-                        tracing::error!("failed to create ack frame (should be tiny): {e}");
-                        self.write_state = WriteState::Idle(writer);
-                    }
-                }
-            }
-
-            tokio::select! {
-                // Prioritize ack, and then shutdown. Leave read last because
-                // there could be a large volume of messages to read, which
-                // subsequently starves the other select! branches.
-                biased;
-                // We have to be careful to manage the ack write state here, so that we do not
-                // write partial acks in the presence of cancellation.
-                ack_result = self.write_state.send() => {
-                    match ack_result {
-                        Ok(acked_seq) => {
-                            last_ack_time = RealClock.now();
-                            next.ack = acked_seq;
-                        }
-                        Err(err) => {
-                            let v = self.write_state.value();
-                            break (
-                                next,
-                                Err::<(), anyhow::Error>(err.into())
-                                    .context(format!("{log_id}: acking peer message: {v:?}")),
-                                false
-                            );
-                        }
-                    }
-                },
-                // Have a tick to abort select! call to make sure the ack for the last message can get the chance
-                // to be sent as a result of time interval being reached.
-                _ = RealClock.sleep_until(last_ack_time + ack_time_interval), if next.ack < next.seq => {},
-                _ = cancel_token.cancelled() => break (next, Ok(()), false),
-                bytes_result = self.reader.next() => {
-                    rcv_raw_frame_count += 1;
-                    // First handle transport-level I/O errors, and EOFs.
-                    let bytes = match bytes_result {
-                        Ok(Some(bytes)) => bytes,
-                        Ok(None) => {
-                            tracing::debug!("{log_id}: EOF");
-                            break (next, Ok(()), false);
-                        }
-                        Err(err) => break (
-                            next,
-                            Err::<(), anyhow::Error>(err.into()).context(
-                                format!(
-                                    "{log_id}: reading into Frame with M = {}",
-                                    type_name::<M>(),
-                                )
-                            ),
-                            false
-                        ),
-                    };
-
-                    // De-frame the multi-part message.
-                    let message = match serde_multipart::Message::from_framed(bytes) {
-                        Ok(message) => message,
-                        Err(err) => break (
-                            next,
-                            Err::<(), anyhow::Error>(err.into()).context(
-                                format!(
-                                    "{log_id}: de-frame message with M = {}",
-                                    type_name::<M>(),
-                                )
-                            ),
-                            false
-                        ),
-                    };
-
-                    // Finally decode the message. This assembles the M-typed message
-                    // from its constituent parts.
-                    match serde_multipart::deserialize_bincode(message) {
-                        Ok(Frame::Init(_)) => {
-                            break (next, Err(anyhow::anyhow!("{log_id}: unexpected init frame")), true)
-                        },
-                        // Ignore retransmits.
-                        Ok(Frame::Message(seq, _)) if seq < next.seq => {
-                            tracing::debug!(
-                                "{log_id}: ignoring retransmit; retransmit seq: {}; expected next seq: {}",
-                                seq,
-                                next.seq,
-                            );
-                        },
-                        // The following segment ensures exactly-once semantics.
-                        // That means No out-of-order delivery and no duplicate delivery.
-                        Ok(Frame::Message(seq, message)) => {
-                            // received seq should be equal to next seq. Else error out!
-                            if seq > next.seq {
-                                let msg = format!("{log_id}: out-of-sequence message, expected seq {}, got {}", next.seq, seq);
-                                tracing::error!(msg);
-                                break (next, Err(anyhow::anyhow!(msg)), true)
-                            }
-                            match self.send_with_buffer_metric(&log_id, &tx, message).await {
-                                Ok(()) => {
-                                    // In channel's contract, "delivered" means the message
-                                    // is sent to the NetRx object. Therefore, we could bump
-                                    // `next_seq` as far as the message is put on the mpsc
-                                    // channel.
-                                    //
-                                    // Note that when/how the messages in NetRx are processed
-                                    // is not covered by channel's contract. For example,
-                                    // the message might never be taken out of netRx, but
-                                    // channel still considers those messages delivered.
-                                    next.seq = seq+1;
-                                }
-                                Err(err) => {
-                                    break (next, Err::<(), anyhow::Error>(err).context(format!("{log_id}: relaying message to mpsc channel")), false)
-                                }
-                            }
-                        },
-                        Err(err) => break (
-                            next,
-                            Err::<(), anyhow::Error>(err.into()).context(
-                                format!(
-                                    "{log_id}: deserialize message with M = {}",
-                                    type_name::<M>(),
-                                )
-                            ),
-                            false
-                        ),
-                    }
-                },
-            }
-        };
-
-        // Note:
-        //   1. processed seq/ack is Next-1;
-        //   2. rcv_raw_frame_count contains the last frame which might not be
-        //      desrializable, e.g. EOF, error, etc.
-        tracing::debug!(
-            "{log_id}: NetRx::process exited its loop with states: initial Next \
-            was {initial_next}; final Next is {final_next}; since acked: {}sec; \
-            rcv raw frame count is {rcv_raw_frame_count}; final result: {:?}",
-            last_ack_time.elapsed().as_secs(),
-            final_result,
-        );
-
-        let mut final_ack = final_next.ack;
-        // Flush any ongoing write.
-        if self.write_state.is_writing() {
-            if let Ok(acked_seq) = self.write_state.send().await {
-                if acked_seq > final_ack {
-                    final_ack = acked_seq;
-                }
-            };
-        }
-        // best effort: "flush" any remaining ack before closing this session
-        if self.write_state.is_idle() && final_ack < final_next.seq {
-            let Ok(writer) = replace(&mut self.write_state, WriteState::Broken).into_idle() else {
-                panic!("illegal state");
-            };
-            let result = async {
-                let ack = serialize_response(NetRxResponse::Ack(final_next.seq - 1))
-                    .map_err(anyhow::Error::from)?;
-
-                let max = config::global::get(config::CODEC_MAX_FRAME_LENGTH);
-                let fw =
-                    FrameWrite::new(writer, ack, max).map_err(|(_, e)| anyhow::Error::from(e))?;
-                self.write_state = WriteState::Writing(fw, final_next.seq);
-                self.write_state.send().await.map_err(anyhow::Error::from)
-            };
-
-            match result.await {
-                Ok(acked_seq) => {
-                    final_next.ack = acked_seq;
-                }
-                Err(e) => {
-                    tracing::debug!(
-                        "{log_id}: failed to flush acks due to error : {e}. \
-                        Normally, this is okay because Tx will reconnect, and \
-                        acks will be resent in the next connection. However, if \
-                        either Tx or Rx is dropped, the reconnection will not \
-                        happen, and subsequently the pending ack will never be sent out.",
-                    );
-                }
-            }
-        }
-
-        if self.write_state.is_idle() && reject_conn {
-            let Ok(writer) = replace(&mut self.write_state, WriteState::Broken).into_idle() else {
-                panic!("illegal state");
-            };
-            if let Ok(data) = serialize_response(NetRxResponse::Reject) {
-                match FrameWrite::new(
-                    writer,
-                    data,
-                    config::global::get(config::CODEC_MAX_FRAME_LENGTH),
-                ) {
-                    Ok(fw) => {
-                        self.write_state = WriteState::Writing(fw, 0);
-                        let _ = self.write_state.send().await;
-                    }
-                    Err((w, e)) => {
-                        debug_assert_eq!(e.kind(), io::ErrorKind::InvalidData);
-                        tracing::debug!("failed to create reject frame (should be tiny): {e}");
-                        self.write_state = WriteState::Idle(w);
-                        // drop the reject; we're closing anyway
-                    }
-                }
-            };
-        }
-
-        (final_next, final_result)
-    }
-
-    // NetRx's buffer, i.e. the mpsc channel between NetRx and its
-    // client, should rarely be full for long. But when it is full, it
-    // will block NetRx from taking more messages, sending back ack,
-    // and subsequently lead to uncommon behaviors such as ack
-    // timeout, backpressure on NetTx, etc. In order to aid debugging,
-    // it is important to add a metric measuring full buffer
-    // occurences.
-    async fn send_with_buffer_metric<M: RemoteMessage>(
-        &mut self,
-        log_id: &str,
-        tx: &mpsc::Sender<M>,
-        message: M,
-    ) -> anyhow::Result<()> {
-        let start = RealClock.now();
-        loop {
-            tokio::select! {
-                biased;
-                permit_result = tx.reserve() => {
-                    permit_result?.send(message);
-                    return Ok(())
-                }
-                _ = RealClock.sleep(config::global::get(config::CHANNEL_NET_RX_BUFFER_FULL_CHECK_INTERVAL)) => {
-                    // When buffer is full too long, we log it.
-                    metrics::CHANNEL_NET_RX_BUFFER_FULL.add(
-                        1,
-                        hyperactor_telemetry::kv_pairs!(
-                            "dest" => self.dest.to_string(),
-                            "source" => self.source.to_string(),
-                        ),
-                    );
-                    // Full buffer should happen rarely. So we also add a log
-                    // here to make debugging easy.
-                    tracing::debug!(
-                        "{log_id}: encountered full mpsc channel for {} secs",
-                        start.elapsed().as_secs(),
-                    );
-                }
-            }
-        }
-    }
-}
-
-/// An MVar is a primitive that combines synchronization and the exchange
-/// of a value. Its semantics are analogous to a synchronous channel of
-/// size 1: if the MVar is full, then `put` blocks until it is emptied;
-/// if the MVar is empty, then `take` blocks until it is filled.
-///
-/// MVars, first introduced in "[Concurrent Haskell](https://www.microsoft.com/en-us/research/wp-content/uploads/1996/01/concurrent-haskell.pdf)"
-/// are surprisingly versatile in use. They can be used as:
-/// - a communication channel (with `put` and `take` corresponding to `send` and `recv`);
-/// - a semaphore (with `put` and `take` corresponding to `signal` and `wait`);
-/// - a mutex (with `put` and `take` corresponding to `lock` and `unlock`);
-#[derive(Clone, Debug)]
-struct MVar<T> {
-    seq: watch::Sender<usize>,
-    value: Arc<Mutex<Option<T>>>,
-}
-
-impl<T> MVar<T> {
-    fn new(init: Option<T>) -> Self {
-        let (seq, _) = watch::channel(0);
-        Self {
-            seq,
-            value: Arc::new(Mutex::new(init)),
-        }
-    }
-
-    fn full(value: T) -> Self {
-        Self::new(Some(value))
-    }
-
-    fn empty() -> Self {
-        Self::new(None)
-    }
-
-    async fn waitseq(&self, seq: usize) -> (MutexGuard<'_, Option<T>>, usize) {
-        let mut sub = self.seq.subscribe();
-        while *sub.borrow_and_update() < seq {
-            sub.changed().await.unwrap();
-        }
-        let locked = self.value.lock().await;
-        let seq = *sub.borrow_and_update();
-        (locked, seq + 1)
-    }
-
-    fn notify(&self, seq: usize) {
-        self.seq.send_replace(seq);
-    }
-
-    async fn take(&self) -> T {
-        let mut seq = 0;
-        loop {
-            let mut value;
-            (value, seq) = self.waitseq(seq).await;
-
-            if let Some(current_value) = take(&mut *value) {
-                self.notify(seq);
-                break current_value;
-            }
-            drop(value);
-        }
-    }
-
-    async fn put(&self, new_value: T) {
-        let mut seq = 0;
-        loop {
-            let mut value;
-            (value, seq) = self.waitseq(seq).await;
-
-            if value.is_none() {
-                *value = Some(new_value);
-                self.notify(seq);
-                break;
-            }
-            drop(value);
-        }
-    }
-}
-
-/// Used to bookkeep message processing states.
-#[derive(Clone)]
-struct Next {
-    // The last received message's seq number + 1.
-    seq: u64,
-    // The last acked seq number + 1.
-    ack: u64,
-}
-
-impl fmt::Display for Next {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "(seq: {}, ack: {})", self.seq, self.ack)
-    }
-}
-
-/// Manages persistent sessions, ensuring that only one connection can own
-/// a session at a time, and arranging for session handover.
-#[derive(Clone)]
-struct SessionManager {
-    sessions: Arc<DashMap<u64, MVar<Next>>>,
-}
-
-impl SessionManager {
-    fn new() -> Self {
-        Self {
-            sessions: Arc::new(DashMap::new()),
-        }
-    }
-
-    async fn serve<S, M>(
-        &self,
-        mut conn: ServerConn<S>,
-        tx: mpsc::Sender<M>,
-        cancel_token: CancellationToken,
-    ) -> Result<(), anyhow::Error>
-    where
-        S: AsyncRead + AsyncWrite + Send + 'static + Unpin,
-        M: RemoteMessage,
-    {
-        let session_id = conn
-            .handshake::<M>()
-            .await
-            .context("while serving handshake")?;
-
-        let session_var = match self.sessions.entry(session_id) {
-            Entry::Occupied(entry) => entry.get().clone(),
-            Entry::Vacant(entry) => {
-                // We haven't seen this session before. We begin with seq=0 and ack=0.
-                let var = MVar::full(Next { seq: 0, ack: 0 });
-                entry.insert(var.clone());
-                var
-            }
-        };
-
-        let next = session_var.take().await;
-        let (next, res) = conn.process(session_id, tx, cancel_token, next).await;
-        session_var.put(next).await;
-
-        if let Err(ref err) = res {
-            tracing::info!("process encountered an error: {:#}", err);
-        }
-
-        res
-    }
-}
-
-/// Main listen loop that actually runs the server. The loop will exit when `parent_cancel_token` is
-/// canceled.
-async fn listen<M: RemoteMessage, L: Listener>(
-    mut listener: L,
-    listener_channel_addr: ChannelAddr,
-    tx: mpsc::Sender<M>,
-    parent_cancel_token: CancellationToken,
-    is_tls: bool,
-) -> Result<(), ServerError>
-where
-    L::Addr: Send + Sync + fmt::Debug + 'static + Into<ChannelAddr>,
-    L::Io: Send + Unpin + fmt::Debug + 'static,
-{
-    let mut connections: JoinSet<Result<(), anyhow::Error>> = JoinSet::new();
-
-    // Cancellation token used to cancel our children only.
-    let child_cancel_token = CancellationToken::new();
-
-    let manager = SessionManager::new();
-    let result: Result<(), ServerError> = loop {
-        let _ = tracing::info_span!("channel_listen_accept_loop");
-        tokio::select! {
-            result = listener.accept() => {
-                match result {
-                    Ok((stream, addr)) => {
-                        let source : ChannelAddr = addr.into();
-                        tracing::debug!("listen {}: new connection from {}", listener_channel_addr, source);
-                        metrics::CHANNEL_CONNECTIONS.add(
-                            1,
-                            hyperactor_telemetry::kv_pairs!(
-                                "transport" => listener_channel_addr.transport().to_string(),
-                                "operation" => "accept"
-                            ),
-                        );
-
-                        let tx = tx.clone();
-                        let child_cancel_token = child_cancel_token.child_token();
-                        let dest  = listener_channel_addr.clone();
-                        let manager = manager.clone();
-                        connections.spawn(async move {
-                            let res = if is_tls {
-                                let conn = ServerConn::new(meta::tls_acceptor(true)?
-                                    .accept(stream)
-                                    .await?, source.clone(), dest.clone());
-                                manager.serve(conn, tx, child_cancel_token).await
-                            } else {
-                                let conn = ServerConn::new(stream, source.clone(), dest.clone());
-                                manager.serve(conn, tx, child_cancel_token).await
-                            };
-
-                            if let Err(ref err) = res {
-                                metrics::CHANNEL_CONNECTION_ERRORS.add(
-                                    1,
-                                    hyperactor_telemetry::kv_pairs!(
-                                        "transport" => dest.transport().to_string(),
-                                        "error" => err.to_string(),
-                                    ),
-                                );
-
-                                // we don't want the health probe TCP connections to be counted as an error.
-                                match source {
-                                    ChannelAddr::Tcp(source_addr) if source_addr.ip().is_loopback() => {},
-                                    _ => {
-                                        tracing::info!(
-                                            "serve: error processing peer connection {} <- {}: {:?}",
-                                            dest, source, err
-                                            );
-                                    }
-                                }
-                            }
-                            res
-                    });
-                    }
-                    Err(err) => {
-                        metrics::CHANNEL_CONNECTION_ERRORS.add(
-                            1,
-                            hyperactor_telemetry::kv_pairs!(
-                                "transport" => listener_channel_addr.transport().to_string(),
-                                "operation" => "accept",
-                                "error" => err.to_string(),
-                            ),
-                        );
-
-                        tracing::info!("serve {}: accept error: {}", listener_channel_addr, err)
-                    }
-                }
-            }
-
-            _ = parent_cancel_token.cancelled() => {
-                tracing::info!("serve {}: received parent token cancellation", listener_channel_addr);
-                break Ok(());
-            }
-
-            result = join_nonempty(&mut connections) => {
-                if let Err(err) = result {
-                    tracing::info!("connection error: {}: {}", listener_channel_addr, err);
-                }
-            }
-        }
-    };
-
-    child_cancel_token.cancel();
-    while connections.join_next().await.is_some() {}
-
-    result
-}
-
-async fn join_nonempty<T: 'static>(set: &mut JoinSet<T>) -> Result<T, JoinError> {
-    match set.join_next().await {
-        None => std::future::pending::<Result<T, JoinError>>().await,
-        Some(result) => result,
-    }
-}
-
 /// Tells whether the address is a 'net' address. These currently have different semantics
 /// from local transports.
-pub fn is_net_addr(addr: &ChannelAddr) -> bool {
+pub(super) fn is_net_addr(addr: &ChannelAddr) -> bool {
     match addr.transport() {
         // TODO Metatls?
         ChannelTransport::Tcp(_) => true,
@@ -2061,7 +273,7 @@ pub(crate) mod unix {
 
     /// Dial the given unix socket.
     pub fn dial<M: RemoteMessage>(addr: SocketAddr) -> NetTx<M> {
-        NetTx::new(UnixLink(addr))
+        super::dial(UnixLink(addr))
     }
 
     /// Listen and serve connections on this socket address.
@@ -2323,7 +535,7 @@ pub(crate) mod tcp {
     }
 
     pub fn dial<M: RemoteMessage>(addr: SocketAddr) -> NetTx<M> {
-        NetTx::new(TcpLink(addr))
+        super::dial(TcpLink(addr))
     }
 
     /// Serve the given address. Supports both v4 and v6 address. If port 0 is provided as
@@ -2568,7 +780,7 @@ pub(crate) mod meta {
 
     pub fn dial<M: RemoteMessage>(addr: MetaTlsAddr) -> Result<NetTx<M>, ClientError> {
         match addr {
-            MetaTlsAddr::Host { hostname, port } => Ok(NetTx::new(MetaLink { hostname, port })),
+            MetaTlsAddr::Host { hostname, port } => Ok(super::dial(MetaLink { hostname, port })),
             MetaTlsAddr::Socket(_) => Err(ClientError::InvalidAddress(
                 "MetaTls clients require hostname/port for host identity, not socket addresses"
                     .to_string(),
@@ -2659,11 +871,16 @@ pub(crate) mod meta {
 #[cfg(test)]
 mod tests {
     use std::assert_matches::assert_matches;
+    use std::collections::VecDeque;
     use std::marker::PhantomData;
+    use std::pin::Pin;
+    use std::sync::Arc;
     use std::sync::RwLock;
     use std::sync::atomic::AtomicBool;
     use std::sync::atomic::AtomicU64;
     use std::sync::atomic::Ordering;
+    use std::task::Poll;
+    use std::time::Duration;
     #[cfg(target_os = "linux")] // uses abstract names
     use std::time::UNIX_EPOCH;
 
@@ -2676,8 +893,20 @@ mod tests {
     use timed_test::async_timed_test;
     use tokio::io::AsyncWrite;
     use tokio::io::DuplexStream;
+    use tokio::io::ReadHalf;
+    use tokio::io::WriteHalf;
+    use tokio::task::JoinHandle;
+    use tokio_util::net::Listener;
+    use tokio_util::sync::CancellationToken;
 
     use super::*;
+    use crate::channel;
+    use crate::channel::net::framed::FrameReader;
+    use crate::channel::net::framed::FrameWrite;
+    use crate::channel::net::server::ServerConn;
+    use crate::channel::net::server::SessionManager;
+    use crate::metrics;
+    use crate::sync::mvar::MVar;
 
     #[cfg(target_os = "linux")] // uses abstract names
     #[tracing_test::traced_test]
@@ -2701,13 +930,13 @@ mod tests {
         // out of the buffer because NetRx could not ack through the closed
         // channel.
         {
-            let tx: ChannelTx<u64> = crate::channel::dial::<u64>(addr.clone()).unwrap();
+            let tx: ChannelTx<u64> = channel::dial::<u64>(addr.clone()).unwrap();
             tx.post(123);
             assert_eq!(rx.recv().await.unwrap(), 123);
         }
 
         {
-            let tx = dial::<u64>(addr.clone()).unwrap();
+            let tx = channel::dial::<u64>(addr.clone()).unwrap();
             tx.post(321);
             tx.post(111);
             tx.post(444);
@@ -2718,7 +947,7 @@ mod tests {
         }
 
         {
-            let tx = dial::<u64>(addr).unwrap();
+            let tx = channel::dial::<u64>(addr).unwrap();
             drop(rx);
 
             let (return_tx, return_rx) = oneshot::channel();
@@ -2769,13 +998,13 @@ mod tests {
     async fn test_tcp_basic() {
         let (addr, mut rx) = tcp::serve::<u64>("[::1]:0".parse().unwrap()).unwrap();
         {
-            let tx = dial::<u64>(addr.clone()).unwrap();
+            let tx = channel::dial::<u64>(addr.clone()).unwrap();
             tx.post(123);
             assert_eq!(rx.recv().await.unwrap(), 123);
         }
 
         {
-            let tx = dial::<u64>(addr.clone()).unwrap();
+            let tx = channel::dial::<u64>(addr.clone()).unwrap();
             tx.post(321);
             tx.post(111);
             tx.post(444);
@@ -2786,7 +1015,7 @@ mod tests {
         }
 
         {
-            let tx = dial::<u64>(addr).unwrap();
+            let tx = channel::dial::<u64>(addr).unwrap();
             drop(rx);
 
             let (return_tx, return_rx) = oneshot::channel();
@@ -2808,7 +1037,7 @@ mod tests {
 
         let (addr, mut rx) = tcp::serve::<String>("[::1]:0".parse().unwrap()).unwrap();
 
-        let tx = dial::<String>(addr.clone()).unwrap();
+        let tx = channel::dial::<String>(addr.clone()).unwrap();
         // Default size is okay
         {
             // Leave some headroom because Tx will wrap the payload in Frame::Message.
@@ -2839,7 +1068,7 @@ mod tests {
             config.override_key(config::MESSAGE_DELIVERY_TIMEOUT, Duration::from_secs(5));
 
         let (addr, mut net_rx) = tcp::serve::<u64>("[::1]:0".parse().unwrap()).unwrap();
-        let net_tx = dial::<u64>(addr.clone()).unwrap();
+        let net_tx = channel::dial::<u64>(addr.clone()).unwrap();
         let (tx, rx) = oneshot::channel();
         net_tx.try_post(1, tx);
         assert_eq!(net_rx.recv().await.unwrap(), 1);
@@ -2861,13 +1090,13 @@ mod tests {
         };
         let (local_addr, mut rx) = net::meta::serve::<u64>(meta_addr).unwrap();
         {
-            let tx = dial::<u64>(local_addr.clone()).unwrap();
+            let tx = channel::dial::<u64>(local_addr.clone()).unwrap();
             tx.post(123);
         }
         assert_eq!(rx.recv().await.unwrap(), 123);
 
         {
-            let tx = dial::<u64>(local_addr.clone()).unwrap();
+            let tx = channel::dial::<u64>(local_addr.clone()).unwrap();
             tx.post(321);
             tx.post(111);
             tx.post(444);
@@ -2877,30 +1106,13 @@ mod tests {
         }
 
         {
-            let tx = dial::<u64>(local_addr).unwrap();
+            let tx = channel::dial::<u64>(local_addr).unwrap();
             drop(rx);
 
             let (return_tx, return_rx) = oneshot::channel();
             tx.try_post(123, return_tx);
             assert_matches!(return_rx.await, Ok(SendError(ChannelError::Closed, 123)));
         }
-    }
-
-    #[tokio::test]
-    async fn test_mvar() {
-        let mv0 = MVar::full(0);
-        let mv1 = MVar::empty();
-
-        assert_eq!(mv0.take().await, 0);
-
-        tokio::spawn({
-            let mv0 = mv0.clone();
-            let mv1 = mv1.clone();
-            async move { mv1.put(mv0.take().await).await }
-        });
-
-        mv0.put(1).await;
-        assert_eq!(mv1.take().await, 1);
     }
 
     #[derive(Clone, Debug, Default)]
@@ -3470,7 +1682,7 @@ mod tests {
     async fn test_tcp_tx_delivery_timeout() {
         // This link always fails to connect.
         let link = MockLink::<u64>::fail_connects();
-        let tx = NetTx::<u64>::new(link);
+        let tx = super::dial::<u64>(link);
         // Override the default (1m) for the purposes of this test.
         let config = config::global::lock();
         let _guard = config.override_key(config::MESSAGE_DELIVERY_TIMEOUT, Duration::from_secs(1));
@@ -3540,7 +1752,7 @@ mod tests {
     async fn test_ack_in_net_tx_basic() {
         let link = MockLink::<u64>::new();
         let receiver_storage = link.receiver_storage();
-        let tx = NetTx::<u64>::new(link);
+        let tx = super::dial::<u64>(link);
 
         // Send some messages, but not acking any of them.
         net_tx_send(&tx, &[100, 101, 102, 103, 104]).await;
@@ -3594,7 +1806,7 @@ mod tests {
         let link = MockLink::<u64>::new();
         let receiver_storage = link.receiver_storage();
 
-        let tx = NetTx::<u64>::new(link);
+        let tx = super::dial::<u64>(link);
         let mut session_id = None;
 
         // Send some messages, but not acking any of them.
@@ -3789,7 +2001,7 @@ mod tests {
     async fn test_ack_before_redelivery_in_net_tx() {
         let link = MockLink::<u64>::new();
         let receiver_storage = link.receiver_storage();
-        let net_tx = NetTx::<u64>::new(link);
+        let net_tx = super::dial::<u64>(link);
 
         // Verify sent-and-ack a message. This is necessary for the test to
         // trigger a connection.
@@ -3847,7 +2059,7 @@ mod tests {
         let disconnect_signal = link.disconnect_signal().clone();
         let fail_connect_switch = link.fail_connects_switch();
         let receiver_storage = link.receiver_storage();
-        let tx = NetTx::<u64>::new(link);
+        let tx = super::dial::<u64>(link);
         let mut tx_status = tx.status().clone();
         // send a message
         tx.post(100);
@@ -3925,7 +2137,7 @@ mod tests {
         let local_addr = listener.local_addr().unwrap();
         let (_, mut nx): (ChannelAddr, NetRx<u64>) =
             super::serve(listener, local_addr, false).unwrap();
-        let tx = NetTx::<u64>::new(link);
+        let tx = super::dial::<u64>(link);
         let messages: Vec<_> = (0..10001).collect();
         let messages_clone = messages.clone();
         // Put the sender side in a separate task so we can start the receiver
@@ -4004,7 +2216,7 @@ mod tests {
         let local_addr = listener.local_addr().unwrap();
         let (_, mut nx): (ChannelAddr, NetRx<u64>) =
             super::serve(listener, local_addr, false).unwrap();
-        let tx = NetTx::<u64>::new(link);
+        let tx = super::dial::<u64>(link);
         let messages: Vec<_> = (0..20001).collect();
         let messages_clone = messages.clone();
         // Put the sender side in a separate task so we can start the receiver
@@ -4101,7 +2313,7 @@ mod tests {
         let mut txs = vec![];
         for _ in 0..10 {
             let server_addr = local_addr.clone();
-            let tx = Arc::new(dial::<String>(server_addr).unwrap());
+            let tx = Arc::new(channel::dial::<String>(server_addr).unwrap());
             let tx2 = Arc::clone(&tx);
             txs.push(tx);
             tx_handles.push(tokio::spawn(async move {
@@ -4129,7 +2341,7 @@ mod tests {
     async fn test_net_tx_closed_on_server_reject() {
         let link = MockLink::<u64>::new();
         let receiver_storage = link.receiver_storage();
-        let mut tx = NetTx::<u64>::new(link);
+        let mut tx = super::dial::<u64>(link);
         net_tx_send(&tx, &[100]).await;
 
         {

--- a/hyperactor/src/channel/net/client.rs
+++ b/hyperactor/src/channel/net/client.rs
@@ -1,0 +1,1078 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+//! TODO
+
+use std::collections::VecDeque;
+use std::fmt;
+use std::io;
+use std::ops::Deref;
+use std::ops::DerefMut;
+
+use backoff::ExponentialBackoffBuilder;
+use backoff::backoff::Backoff;
+use enum_as_inner::EnumAsInner;
+use tokio::io::AsyncWriteExt;
+use tokio::io::ReadHalf;
+use tokio::io::WriteHalf;
+use tokio::sync::mpsc;
+use tokio::sync::oneshot;
+use tokio::sync::watch;
+use tokio::time::Duration;
+use tokio::time::Instant;
+use tracing::Instrument;
+use tracing::Level;
+use tracing::Span;
+
+use super::framed::FrameReader;
+use super::framed::FrameWrite;
+use super::framed::WriteState;
+use crate::RemoteMessage;
+use crate::channel::ChannelError;
+use crate::channel::SendError;
+use crate::channel::TxStatus;
+use crate::channel::net::Frame;
+use crate::channel::net::Link;
+use crate::channel::net::NetRxResponse;
+use crate::channel::net::NetTx;
+use crate::channel::net::Stream;
+use crate::channel::net::deserialize_response;
+use crate::channel::net::serialize_bincode;
+use crate::clock::Clock;
+use crate::clock::RealClock;
+use crate::config;
+use crate::metrics;
+
+/// Use to prevent [futures::Stream] objects using the wrong next() method by
+/// accident. Bascially, we want to use [tokio_stream::StreamExt::next] since it
+/// is cancel safe. However, there is another trait, [futures::StreamExt::next],
+/// which has the same method name and similar functionality, except it is not
+/// cancel safe. It is quite easy to import the wrong trait and use the wrong
+/// method by doing `stream.next()`. Adding this trait would prevent this
+/// from happening in this file. The callsite would have to `StreamExt::next()`
+/// to disambiguate.
+trait UnimplementedStreamExt {
+    fn next(&mut self) {
+        unimplemented!()
+    }
+}
+
+impl<T: futures::Stream> UnimplementedStreamExt for T {}
+
+struct QueuedMessage<M: RemoteMessage> {
+    seq: u64,
+    message: serde_multipart::Message,
+    received_at: Instant,
+    // When this message was written to the stream. None means it is not
+    // written yet.
+    sent_at: Option<Instant>,
+    return_channel: oneshot::Sender<SendError<M>>,
+}
+
+impl<M: RemoteMessage> fmt::Display for QueuedMessage<M> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let rcv_secs = self.received_at.elapsed().as_secs();
+        match self.sent_at {
+            Some(s) => {
+                write!(
+                    f,
+                    "(seq={}, since_rcv={}sec, since_sent={}sec)",
+                    self.seq,
+                    rcv_secs,
+                    s.elapsed().as_secs()
+                )
+            }
+            None => {
+                write!(f, "(seq={}, since_rcv={}sec)", self.seq, rcv_secs)
+            }
+        }
+    }
+}
+
+// A new type to provide custom Debug impl.
+struct MessageDeque<M: RemoteMessage>(VecDeque<QueuedMessage<M>>);
+
+impl<M: RemoteMessage> MessageDeque<M> {
+    fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    fn front(&self) -> Option<&QueuedMessage<M>> {
+        self.0.front()
+    }
+
+    fn back(&self) -> Option<&QueuedMessage<M>> {
+        self.0.back()
+    }
+
+    fn num_bytes_queued(&self) -> usize {
+        self.0.iter().map(|m| m.message.len()).sum()
+    }
+}
+
+impl<M: RemoteMessage> Deref for MessageDeque<M> {
+    type Target = VecDeque<QueuedMessage<M>>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<M: RemoteMessage> DerefMut for MessageDeque<M> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+// only show the first and last N messages, and display how many are
+// omitted in the middle.
+impl<M: RemoteMessage> fmt::Display for MessageDeque<M> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fn write_msg<M: RemoteMessage>(
+            f: &mut fmt::Formatter<'_>,
+            i: usize,
+            msg: &QueuedMessage<M>,
+        ) -> fmt::Result {
+            if i > 0 {
+                write!(f, ", ")?;
+            }
+            write!(f, "{}", msg)
+        }
+
+        let len = self.0.len();
+        let n: usize = 3;
+
+        write!(f, "[")?;
+
+        if len <= n * 2 {
+            for (i, msg) in self.0.iter().enumerate() {
+                write_msg(f, i, msg)?;
+            }
+        } else {
+            // first N
+            for (i, msg) in self.0.iter().take(n).enumerate() {
+                write_msg(f, i, msg)?;
+            }
+            // middle
+            write!(f, ", ... omit {} messages ..., ", len - 2 * n)?;
+            // last N
+            for (i, msg) in self.0.iter().skip(len - n).enumerate() {
+                write_msg(f, i, msg)?;
+            }
+        }
+
+        write!(f, "]")
+    }
+}
+
+impl<M: RemoteMessage> QueuedMessage<M> {
+    /// Attempt to deserialize this queued frame as a
+    /// `Frame::Message<M>` and return it to the original
+    /// sender. Falls back to logging if the frame is not a
+    /// message or deserialization fails.
+    pub(crate) fn try_return(self) {
+        match serde_multipart::deserialize_bincode::<Frame<M>>(self.message) {
+            Ok(Frame::Message(_, msg)) => {
+                let _ = self
+                    .return_channel
+                    .send(SendError(ChannelError::Closed, msg));
+            }
+            Ok(_) => {
+                tracing::debug!("queued frame was not a Frame::Message; dropping without return");
+            }
+            Err(e) => {
+                tracing::warn!("failed to deserialize queued frame for return: {e}");
+            }
+        }
+    }
+}
+
+struct Outbox<'a, M: RemoteMessage> {
+    // The seq number of the next new message put into outbox. Requeued
+    // unacked messages should still use their already assigned seq
+    // numbers.
+    next_seq: u64,
+    deque: MessageDeque<M>,
+    log_id: &'a str,
+}
+
+impl<'a, M: RemoteMessage> Outbox<'a, M> {
+    fn new(log_id: &'a str) -> Self {
+        Self {
+            next_seq: 0,
+            deque: MessageDeque(VecDeque::new()),
+            log_id,
+        }
+    }
+
+    fn is_expired(&self) -> bool {
+        match self.deque.front() {
+            None => false,
+            Some(msg) => {
+                msg.received_at.elapsed() > config::global::get(config::MESSAGE_DELIVERY_TIMEOUT)
+            }
+        }
+    }
+
+    fn is_empty(&self) -> bool {
+        self.deque.is_empty()
+    }
+
+    fn front_message(&self) -> Option<serde_multipart::Message> {
+        self.deque.front().map(|msg| msg.message.clone())
+    }
+
+    fn front_size(&self) -> Option<usize> {
+        self.deque.front().map(|msg| msg.message.frame_len())
+    }
+
+    fn pop_front(&mut self) -> Option<QueuedMessage<M>> {
+        self.deque.pop_front()
+    }
+
+    fn push_back(
+        &mut self,
+        (message, return_channel, received_at): (M, oneshot::Sender<SendError<M>>, Instant),
+    ) -> Result<(), String> {
+        assert!(
+            self.deque.back().is_none_or(|msg| msg.seq < self.next_seq),
+            "{}: unexpected: seq should be in ascending order, but got {} vs {}",
+            self.log_id,
+            self.deque
+                .back()
+                .map_or("None".to_string(), |m| m.to_string()),
+            self.next_seq
+        );
+
+        let frame = Frame::Message(self.next_seq, message);
+        let message = serialize_bincode(&frame).map_err(|e| format!("serialization error: {e}"))?;
+        metrics::REMOTE_MESSAGE_SEND_SIZE.record(message.frame_len() as f64, &[]);
+
+        self.deque.push_back(QueuedMessage {
+            seq: self.next_seq,
+            message,
+            received_at,
+            sent_at: None,
+            return_channel,
+        });
+        self.next_seq += 1;
+        Ok(())
+    }
+
+    fn requeue_unacked(&mut self, unacked: MessageDeque<M>) {
+        if let (Some(last), Some(first)) = (unacked.back(), self.deque.front()) {
+            assert!(
+                last.seq < first.seq,
+                "{}: seq should be in ascending order, but got {} vs {}",
+                self.log_id,
+                last.seq,
+                first.seq,
+            );
+        }
+
+        let mut outbox = unacked;
+        outbox.append(&mut self.deque);
+        self.deque = outbox;
+    }
+}
+
+impl<'a, M: RemoteMessage> fmt::Display for Outbox<'a, M> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "(next_seq: {}, deque: {})", self.next_seq, self.deque)
+    }
+}
+
+// A tuple of acked seq and when it was acked.
+#[derive(Debug, Clone)]
+struct AckedSeq(u64, Instant);
+
+impl fmt::Display for AckedSeq {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let acked_secs = self.1.elapsed().as_secs();
+        write!(f, "(seq={}, since_acked={}sec)", self.0, acked_secs)
+    }
+}
+
+struct Unacked<'a, M: RemoteMessage> {
+    deque: MessageDeque<M>,
+    largest_acked: Option<AckedSeq>,
+    log_id: &'a str,
+}
+
+impl<'a, M: RemoteMessage> Unacked<'a, M> {
+    fn new(largest_acked: Option<AckedSeq>, log_id: &'a str) -> Self {
+        Self {
+            deque: MessageDeque(VecDeque::new()),
+            largest_acked,
+            log_id,
+        }
+    }
+
+    fn push_back(&mut self, message: QueuedMessage<M>) {
+        assert!(
+            self.deque.back().is_none_or(|msg| msg.seq < message.seq),
+            "{}: seq should be in ascending order, but got {} vs {}",
+            self.log_id,
+            self.deque
+                .back()
+                .map_or("None".to_string(), |m| m.to_string()),
+            message.seq
+        );
+
+        if let Some(AckedSeq(largest, _)) = self.largest_acked {
+            // Note: some scenarios of why this if branch could happen:
+            //
+            // message.0 <= largest could happen in the following scenario:
+            //
+            // 1. NetTx sent seq=2 and seq=3.
+            // 2. NetRx received messages and put them on its mpsc channel.
+            //    But before NetRx acked, the connection was broken.
+            // 3. NetTx reconnected. In this case, NetTx will put unacked
+            //    messages, i.e. 2 and 3, back to outbox.
+            // 2. At the beginning of the new connection. NetRx acked 2
+            //    and 3 immediately.
+            // 3. Before sending messages, NetTx received the acks first
+            //    with the new connection. NetTx Stored 3 as largest_acked.
+            // 4. Now NetRx finally got the chance to resend 2 and 3.
+            //    When it resent 2, 2 < largest_acked, which is 3.
+            //    * similarly, if there was only one message, seq=3
+            //      involved, we would have 3 == largest_acked.
+            //
+            // message.0 == largest could also happen in the following
+            // scenario:
+            //
+            // The message was delivered, but the send branch did not push
+            // it into unacked queue. This chould happen when:
+            //   1. `outbox.send_message` future was canceled by tokio::select.
+            //   2. `outbox.send_message` returns an error, which makes
+            //      the deliver result unknown to Tx.
+            // When this happens, Tx will resend the same message. However,
+            // since Rx already received the message, it might ack before
+            // Tx resends. As a result, this message's ack would be
+            // recorded already by `largest_acked` before it is put into
+            // unacked queue.
+            if message.seq <= largest {
+                // since the message is already delivered and acked, it
+                // does need to be put in the queue again.
+                return;
+            }
+        }
+
+        self.deque.push_back(message);
+    }
+
+    /// Remove acked messages from the deque.
+    fn prune(&mut self, acked: u64, acked_at: Instant) {
+        assert!(
+            self.largest_acked.as_ref().map_or(0, |i| i.0) <= acked,
+            "{}: received out-of-order ack; received: {}; stored largest: {}",
+            self.log_id,
+            acked,
+            self.largest_acked
+                .as_ref()
+                .map_or("None".to_string(), |l| l.to_string()),
+        );
+
+        self.largest_acked = Some(AckedSeq(acked, acked_at));
+        let deque = &mut self.deque;
+        while let Some(msg) = deque.front() {
+            if msg.seq <= acked {
+                deque.pop_front();
+            } else {
+                // Messages in the deque are orderd by seq in ascending
+                // order. So we could return early once we encounter
+                // a message that is not acked.
+                break;
+            }
+        }
+    }
+
+    fn is_expired(&self) -> bool {
+        matches!(
+            self.deque.front(),
+            Some(msg) if msg.received_at.elapsed() > config::global::get(config::MESSAGE_DELIVERY_TIMEOUT)
+        )
+    }
+
+    /// Return when the oldest message has not been acked within the
+    /// timeout limit. This method is used in tokio::select with other
+    /// branches.
+    async fn wait_for_timeout(&self) {
+        match self.deque.front() {
+            Some(msg) => {
+                RealClock
+                    .sleep_until(
+                        msg.received_at + config::global::get(config::MESSAGE_DELIVERY_TIMEOUT),
+                    )
+                    .await
+            }
+            None => std::future::pending::<()>().await,
+        }
+    }
+
+    fn is_empty(&self) -> bool {
+        self.deque.is_empty()
+    }
+}
+
+impl<'a, M: RemoteMessage> fmt::Display for Unacked<'a, M> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "(deque: {}, largest_acked: {})",
+            self.deque,
+            self.largest_acked
+                .as_ref()
+                .map_or("None".to_string(), |l| l.to_string())
+        )
+    }
+}
+
+struct Deliveries<'a, M: RemoteMessage> {
+    outbox: Outbox<'a, M>,
+    unacked: Unacked<'a, M>,
+}
+
+impl<'a, M: RemoteMessage> fmt::Display for Deliveries<'a, M> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "(outbox: {}, unacked: {})", self.outbox, self.unacked)
+    }
+}
+
+#[derive(EnumAsInner)]
+enum State<'a, M: RemoteMessage> {
+    /// Channel is running.
+    Running(Deliveries<'a, M>),
+    /// Message delivery not possible.
+    Closing {
+        deliveries: Deliveries<'a, M>,
+        /// why closing
+        reason: String,
+    },
+}
+
+impl<'a, M: RemoteMessage> State<'a, M> {
+    fn init(log_id: &'a str) -> Self {
+        Self::Running(Deliveries {
+            outbox: Outbox::new(log_id),
+            unacked: Unacked::new(None, log_id),
+        })
+    }
+
+    fn deliveries(&self) -> &Deliveries<'a, M> {
+        match self {
+            Self::Running(deliveries) => deliveries,
+            Self::Closing { deliveries, .. } => deliveries,
+        }
+    }
+}
+
+impl<'a, M: RemoteMessage> fmt::Display for State<'a, M> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            State::Running(deliveries) => {
+                write!(f, "Running(deliveries: {})", deliveries)
+            }
+            State::Closing { deliveries, reason } => {
+                write!(f, "Running(deliveries: {}, reason: {})", deliveries, reason)
+            }
+        }
+    }
+}
+
+#[derive(EnumAsInner)]
+enum Conn<S: Stream> {
+    /// Disconnected.
+    Disconnected(Box<dyn Backoff + Send>),
+    /// Connected and ready to go.
+    Connected {
+        reader: FrameReader<ReadHalf<S>>,
+        write_state: WriteState<WriteHalf<S>, serde_multipart::Frame, ()>,
+    },
+}
+
+impl<S: Stream> Conn<S> {
+    fn reconnect_with_default() -> Self {
+        Self::Disconnected(Box::new(
+            ExponentialBackoffBuilder::new()
+                .with_initial_interval(Duration::from_millis(50))
+                .with_multiplier(2.0)
+                .with_randomization_factor(0.1)
+                .with_max_interval(Duration::from_millis(1000))
+                .with_max_elapsed_time(None) // Allow infinite retries
+                .build(),
+        ))
+    }
+
+    fn reconnect(backoff: impl Backoff + Send + 'static) -> Self {
+        Self::Disconnected(Box::new(backoff))
+    }
+}
+
+/// Creates a new session, and assigns it a guid.
+pub(super) fn dial<M: RemoteMessage>(link: impl Link + 'static) -> NetTx<M> {
+    let (sender, receiver) = mpsc::unbounded_channel();
+    let dest = link.dest();
+    let (notify, status) = watch::channel(TxStatus::Active);
+
+    let tx = NetTx {
+        sender,
+        dest,
+        status,
+    };
+    crate::init::get_runtime().spawn(run(link, receiver, notify));
+    tx
+}
+
+async fn run<M: RemoteMessage>(
+    link: impl Link,
+    mut receiver: mpsc::UnboundedReceiver<(M, oneshot::Sender<SendError<M>>, Instant)>,
+    notify: watch::Sender<TxStatus>,
+) {
+    // If we can't deliver a message within this limit consider
+    // `link` broken and return.
+
+    let session_id = rand::random();
+    let log_id = format!("session {}.{}", link.dest(), session_id);
+    let mut state = State::init(&log_id);
+    let mut conn = Conn::reconnect_with_default();
+
+    let (state, conn) = loop {
+        let span = state_span(&state, &conn, session_id, &link);
+
+        (state, conn) = step(state, conn, session_id, &log_id, &link, &mut receiver)
+            .instrument(span)
+            .await;
+
+        if state.is_closing() {
+            break (state, conn);
+        }
+
+        if let Conn::Disconnected(ref mut backoff) = conn {
+            RealClock.sleep(backoff.next_backoff().unwrap()).await;
+        }
+    }; // loop
+
+    let span = state_span(&state, &conn, session_id, &link);
+
+    tracing::debug!(parent: &span, "{log_id}: NetTx exited its loop with state: {state}");
+
+    match state {
+        State::Closing {
+            deliveries:
+                Deliveries {
+                    mut outbox,
+                    mut unacked,
+                },
+            // TODO(T233029051): Return reason through return_channel too.
+            reason: _,
+        } => {
+            // Return in order from oldest to newest, messages
+            // either not acknowledged or not sent.
+            unacked
+                .deque
+                .drain(..)
+                .chain(outbox.deque.drain(..))
+                .for_each(|queued| queued.try_return());
+            while let Ok((msg, return_channel, _)) = receiver.try_recv() {
+                if let Err(m) = return_channel.send(SendError(ChannelError::Closed, msg)) {
+                    tracing::warn!("failed to deliver SendError: {}", m);
+                }
+            }
+        }
+        _ => (),
+    }
+
+    // Notify senders that this link is no longer usable
+    if let Err(err) = notify.send(TxStatus::Closed) {
+        tracing::debug!(parent: &span, "{log_id}: tx status update error: {err}");
+    }
+
+    if let Conn::Connected {
+        write_state: WriteState::Writing(mut frame_writer, ()),
+        ..
+    } = conn
+    {
+        if let Err(err) = frame_writer.send().await {
+            tracing::info!(parent: &span, "{log_id}: write error: {err}",);
+        } else if let Err(err) = frame_writer.complete().flush().await {
+            tracing::info!(parent: &span, "{log_id}: flush error: {err}",);
+        }
+    }
+
+    tracing::debug!(parent: &span, "{log_id}: NetTx::run exits");
+}
+
+fn state_span<'a, L, S, M>(state: &State<'a, M>, conn: &Conn<S>, session_id: u64, link: &L) -> Span
+where
+    S: Stream,
+    L: Link<Stream = S>,
+    M: RemoteMessage,
+{
+    let deliveries = state.deliveries();
+
+    use valuable::NamedField;
+    use valuable::Structable;
+    use valuable::Tuplable;
+    use valuable::Valuable;
+    use valuable::Value;
+
+    struct TimestampValue(Instant);
+
+    impl From<Instant> for TimestampValue {
+        fn from(timestamp: Instant) -> TimestampValue {
+            TimestampValue(timestamp)
+        }
+    }
+
+    impl Valuable for TimestampValue {
+        fn as_value(&self) -> Value<'_> {
+            Value::Tuplable(self)
+        }
+
+        fn visit(&self, visit: &mut dyn valuable::Visit) {
+            let elapsed = humantime::format_duration(self.0.elapsed()).to_string();
+            visit.visit_unnamed_fields(&[Value::String(&elapsed)]);
+        }
+    }
+
+    impl Tuplable for TimestampValue {
+        fn definition(&self) -> valuable::TupleDef {
+            valuable::TupleDef::new_static(1)
+        }
+    }
+
+    #[derive(Valuable)]
+    struct QueueEntryValue {
+        seq: u64,
+        since_received: TimestampValue,
+        since_sent: Option<TimestampValue>,
+    }
+
+    impl<M: RemoteMessage> From<&QueuedMessage<M>> for QueueEntryValue {
+        fn from(m: &QueuedMessage<M>) -> QueueEntryValue {
+            QueueEntryValue {
+                seq: m.seq,
+                since_received: m.received_at.into(),
+                since_sent: m.sent_at.map(TimestampValue::from),
+            }
+        }
+    }
+
+    #[derive(Valuable)]
+    enum QueueValue {
+        Empty,
+        NonEmpty {
+            len: usize,
+            num_bytes_queued: usize,
+            front: QueueEntryValue,
+            back: QueueEntryValue,
+        },
+    }
+
+    impl<M: RemoteMessage> From<&MessageDeque<M>> for QueueValue {
+        fn from(q: &MessageDeque<M>) -> QueueValue {
+            if q.is_empty() {
+                return QueueValue::Empty;
+            }
+
+            QueueValue::NonEmpty {
+                len: q.len(),
+                num_bytes_queued: q.num_bytes_queued(),
+                front: q.front().unwrap().into(),
+                back: q.back().unwrap().into(),
+            }
+        }
+    }
+
+    struct AckedSeqValue(AckedSeq);
+
+    static ACKED_SEQ_FIELDS: &[NamedField<'static>] =
+        &[NamedField::new("seq"), NamedField::new("timestamp")];
+
+    impl Valuable for AckedSeqValue {
+        fn as_value(&self) -> Value<'_> {
+            Value::Structable(self)
+        }
+
+        fn visit(&self, visit: &mut dyn valuable::Visit) {
+            let AckedSeq(seq, timestamp) = &self.0;
+            visit.visit_named_fields(&valuable::NamedValues::new(
+                ACKED_SEQ_FIELDS,
+                &[
+                    seq.as_value(),
+                    Value::String(&humantime::format_duration(timestamp.elapsed()).to_string()),
+                ],
+            ));
+        }
+    }
+
+    impl Structable for AckedSeqValue {
+        fn definition(&self) -> valuable::StructDef<'_> {
+            valuable::StructDef::new_static("AckedSeq", valuable::Fields::Named(ACKED_SEQ_FIELDS))
+        }
+    }
+
+    let largest_acked = deliveries
+        .unacked
+        .largest_acked
+        .as_ref()
+        .map(|acked_seq| AckedSeqValue(acked_seq.clone()));
+
+    tracing::span!(
+        Level::ERROR,
+        "net i/o loop",
+        session = format!("{}.{}", link.dest(), session_id),
+        connected = conn.is_connected(),
+        next_seq = deliveries.outbox.next_seq,
+        largest_acked = largest_acked.as_value(),
+        outbox = QueueValue::from(&deliveries.outbox.deque).as_value(),
+        unacked = QueueValue::from(&deliveries.unacked.deque).as_value(),
+    )
+}
+
+async fn step<'a, L, S, M>(
+    state: State<'a, M>,
+    conn: Conn<S>,
+    session_id: u64,
+    log_id: &'a str,
+    link: &L,
+    receiver: &mut mpsc::UnboundedReceiver<(M, oneshot::Sender<SendError<M>>, Instant)>,
+) -> (State<'a, M>, Conn<S>)
+where
+    S: Stream,
+    L: Link<Stream = S>,
+    M: RemoteMessage,
+{
+    match (state, conn) {
+        // This branch is to provide lazy connection creation. It can be removed after
+        // we move to eager creation.
+        (
+            State::Running(Deliveries {
+                mut outbox,
+                unacked,
+            }),
+            conn,
+        ) if outbox.is_empty() && unacked.is_empty() => match receiver.recv().await {
+            Some(msg) => match outbox.push_back(msg) {
+                Ok(()) => {
+                    let running = State::Running(Deliveries { outbox, unacked });
+                    (running, conn)
+                }
+                Err(err) => {
+                    let error_msg = format!("{log_id}: failed to push message to outbox: {err}");
+                    tracing::error!(error_msg);
+                    (
+                        State::Closing {
+                            deliveries: Deliveries { outbox, unacked },
+                            reason: error_msg,
+                        },
+                        conn,
+                    )
+                }
+            },
+            None => (
+                State::Closing {
+                    deliveries: Deliveries { outbox, unacked },
+                    reason: "NetTx is dropped".to_string(),
+                },
+                conn,
+            ),
+        },
+        (
+            State::Running(Deliveries {
+                mut outbox,
+                unacked,
+            }),
+            Conn::Connected {
+                reader,
+                write_state: WriteState::Idle(writer),
+                ..
+            },
+        ) if !outbox.is_empty() => {
+            let max = config::global::get(config::CODEC_MAX_FRAME_LENGTH);
+            let len = outbox.front_size().expect("not empty");
+            let message = outbox.front_message().expect("not empty");
+
+            match FrameWrite::new(writer, message.framed(), max) {
+                Ok(fw) => (
+                    State::Running(Deliveries { outbox, unacked }),
+                    Conn::Connected {
+                        reader,
+                        write_state: WriteState::Writing(fw, ()),
+                    },
+                ),
+                Err((writer, e)) => {
+                    debug_assert_eq!(e.kind(), io::ErrorKind::InvalidData);
+                    tracing::error!(
+                        "rejecting oversize frame: len={} > max={}. \
+                                ack will not arrive before timeout; increase CODEC_MAX_FRAME_LENGTH to allow.",
+                        len,
+                        max
+                    );
+                    // Reject and return.
+                    outbox.pop_front().expect("not empty").try_return();
+                    let error_msg =
+                        format!("{log_id}: oversized frame was rejected. closing channel");
+                    tracing::error!(error_msg);
+                    // Close the channel (avoid sequence
+                    // violations).
+                    (
+                        State::Closing {
+                            deliveries: Deliveries { outbox, unacked },
+                            reason: error_msg,
+                        },
+                        Conn::Connected {
+                            reader,
+                            write_state: WriteState::Idle(writer),
+                        },
+                    )
+                }
+            }
+        }
+        (
+            State::Running(Deliveries {
+                mut outbox,
+                mut unacked,
+            }),
+            Conn::Connected {
+                mut reader,
+                mut write_state,
+            },
+        ) => {
+            tokio::select! {
+                biased;
+
+                ack_result = reader.next() => {
+                    match ack_result {
+                        Ok(Some(buffer)) => {
+                            match deserialize_response(buffer) {
+                                Ok(response) => {
+                                    match response {
+                                        NetRxResponse::Ack(ack) => {
+                                            unacked.prune(ack, RealClock.now());
+                                            (State::Running(Deliveries { outbox, unacked }), Conn::Connected { reader, write_state })
+                                        }
+                                        NetRxResponse::Reject => {
+                                            let error_msg = format!(
+                                                "{log_id}: server rejected connection.",
+                                            );
+                                            tracing::error!(error_msg);
+                                            (State::Closing {
+                                                deliveries: Deliveries{outbox, unacked},
+                                                reason: error_msg,
+                                            }, Conn::reconnect_with_default())
+                                        }
+                                    }
+                                }
+                                Err(err) => {
+                                    let error_msg = format!(
+                                        "{log_id}: failed deserializing response: {err}",
+                                    );
+                                    tracing::error!(error_msg);
+                                    // Similar to the message flow, we always close the
+                                    // channel when encountering ser/deser errors.
+                                    (State::Closing {
+                                        deliveries: Deliveries{outbox, unacked},
+                                        reason: error_msg,
+                                    }, Conn::Connected { reader, write_state })
+                                }
+                            }
+                        }
+                        Ok(None) => {
+                            // Graceful of stream: reconnect
+                            (State::Running(Deliveries { outbox, unacked }), Conn::reconnect_with_default())
+                        }
+                        Err(err) => {
+                                tracing::error!(
+                                    "{log_id}: failed while receiving ack: {err}",
+                                );
+                                // Reconnect and wish the error will go away.
+                                (State::Running(Deliveries { outbox, unacked }), Conn::reconnect_with_default())
+                        }
+                    }
+                },
+
+                // If acking message takes too long, consider the link broken.
+                _ = unacked.wait_for_timeout(), if !unacked.is_empty() => {
+                    let error_msg = format!(
+                        "{log_id}: failed to receive ack within timeout {} secs; link is currently connected",
+                        config::global::get(config::MESSAGE_DELIVERY_TIMEOUT).as_secs(),
+                    );
+                    tracing::error!(error_msg);
+                    (State::Closing {
+                        deliveries: Deliveries{outbox, unacked},
+                        reason: error_msg,
+                    }, Conn::Connected { reader, write_state })
+                }
+
+
+                // We have to be careful to manage outgoing write states, so that we never write
+                // partial frames in the presence cancellation.
+                send_result = write_state.send() => {
+                    match send_result {
+                        Ok(()) => {
+                            let mut message = outbox.pop_front().expect("outbox should not be empty");
+                            // If this message was re-put into `outbox` from `unacked` due to reconnection,
+                            // its `sent_at` field would be set in the last attempt. In that case, we simply
+                            // overwrite the old one here.
+                            message.sent_at = Some(RealClock.now());
+                            unacked.push_back(message);
+                            (State::Running(Deliveries { outbox, unacked }), Conn::Connected { reader, write_state })
+                        }
+                        Err(err) => {
+                            tracing::info!(
+                                "{log_id}: outbox send error: {err}; message size: {}",
+                                outbox.front_size().expect("outbox should not be empty"),
+                            );
+                            (State::Running(Deliveries { outbox, unacked }), Conn::reconnect_with_default())
+                        }
+                    }
+                }
+                // UnboundedReceiver::recv() is cancel safe.
+                // Only checking mpsc channel when outbox is empty. In this way, we prioritize
+                // sending messages already in outbox.
+                work_result = receiver.recv(), if outbox.is_empty() => {
+                    match work_result {
+                        Some(msg) => {
+                            match outbox.push_back(msg) {
+                                Ok(()) => {
+                                    let running = State::Running (Deliveries{
+                                        outbox,
+                                        unacked,
+                                    });
+                                    (running, Conn::Connected { reader, write_state })
+                                }
+                                Err(err) => {
+                                    let error_msg = format!(
+                                        "{log_id}: failed to push message to outbox: {err}",
+                                    );
+                                    tracing::error!(error_msg);
+                                    (State::Closing {
+                                        deliveries: Deliveries {outbox, unacked},
+                                        reason: error_msg,
+                                    }, Conn::Connected { reader, write_state })
+                                }
+                            }
+                        }
+                        None => (State::Closing {
+                            deliveries: Deliveries{outbox, unacked},
+                            reason: "NetTx is dropped".to_string(),
+                        }, Conn::Connected { reader, write_state }),
+                    }
+                },
+            }
+        }
+
+        // We have a message to send, but not an active link.
+        (
+            State::Running(Deliveries {
+                mut outbox,
+                unacked,
+            }),
+            Conn::Disconnected(mut backoff),
+        ) => {
+            // If delivering this message is taking too long,
+            // consider the link broken.
+            if outbox.is_expired() {
+                let error_msg = format!("{log_id}: failed to deliver message within timeout");
+                tracing::error!(error_msg);
+                (
+                    State::Closing {
+                        deliveries: Deliveries { outbox, unacked },
+                        reason: error_msg,
+                    },
+                    Conn::reconnect_with_default(),
+                )
+            } else if unacked.is_expired() {
+                let error_msg = format!(
+                    "{log_id}: failed to receive ack within timeout {} secs; link is currently broken",
+                    config::global::get(config::MESSAGE_DELIVERY_TIMEOUT).as_secs(),
+                );
+                tracing::error!(error_msg);
+                (
+                    State::Closing {
+                        deliveries: Deliveries { outbox, unacked },
+                        reason: error_msg,
+                    },
+                    Conn::reconnect_with_default(),
+                )
+            } else {
+                match link.connect().await {
+                    Ok(stream) => {
+                        let message = serialize_bincode(&Frame::<M>::Init(session_id)).unwrap();
+
+                        let mut write = FrameWrite::new(
+                            stream,
+                            message.framed(),
+                            config::global::get(config::CODEC_MAX_FRAME_LENGTH),
+                        )
+                        .expect("enough length");
+                        let initialized = write.send().await.is_ok();
+                        let stream = write.complete();
+
+                        metrics::CHANNEL_CONNECTIONS.add(
+                            1,
+                            hyperactor_telemetry::kv_pairs!(
+                                "transport" => link.dest().transport().to_string(),
+                                "reason" => "link connected",
+                            ),
+                        );
+
+                        // Need to resend unacked after reconnecting.
+                        let largest_acked = unacked.largest_acked;
+                        outbox.requeue_unacked(unacked.deque);
+                        (
+                            State::Running(Deliveries {
+                                outbox,
+                                // unacked messages are put back to outbox. So they are not
+                                // considered as "sent yet unacked" message anymore. But
+                                // we still want to keep `largest_acked` to known Rx's watermark.
+                                unacked: Unacked::new(largest_acked, log_id),
+                            }),
+                            if initialized {
+                                backoff.reset();
+                                let (reader, writer) = tokio::io::split(stream);
+                                Conn::Connected {
+                                    reader: FrameReader::new(
+                                        reader,
+                                        config::global::get(config::CODEC_MAX_FRAME_LENGTH),
+                                    ),
+                                    write_state: WriteState::Idle(writer),
+                                }
+                            } else {
+                                Conn::reconnect(backoff)
+                            },
+                        )
+                    }
+                    Err(err) => {
+                        tracing::debug!(
+                            "session {}.{}: failed to connect: {}",
+                            link.dest(),
+                            session_id,
+                            err
+                        );
+                        (
+                            State::Running(Deliveries { outbox, unacked }),
+                            Conn::reconnect(backoff),
+                        )
+                    }
+                }
+            }
+        }
+
+        // The link is no longer viable.
+        (State::Closing { deliveries, reason }, stream) => {
+            (State::Closing { deliveries, reason }, stream)
+        }
+    }
+}

--- a/hyperactor/src/channel/net/framed.rs
+++ b/hyperactor/src/channel/net/framed.rs
@@ -18,6 +18,7 @@ use bytes::Buf;
 use bytes::BufMut;
 use bytes::Bytes;
 use bytes::BytesMut;
+use enum_as_inner::EnumAsInner;
 use futures::future::poll_fn;
 use tokio::io::AsyncRead;
 use tokio::io::AsyncReadExt;
@@ -310,6 +311,66 @@ impl<W: AsyncWrite + Unpin, B: Buf> FrameWrite<W, B> {
         match res {
             Ok(()) => Ok(writer),
             Err(e) => Err((writer, e)),
+        }
+    }
+}
+
+/// A state machine to manage cancellable writes. Notably, writes have
+/// values associated with them in order to maintain additional state
+/// for bookeeping purposes. WriteState ensures that an underlying
+/// `W`-typed writer is correctly owned by a [`FrameWrite`], or else
+/// is Idled.
+#[derive(EnumAsInner)]
+pub enum WriteState<W, F, T> {
+    /// No frame being written; the writer `W` is idle.
+    Idle(W),
+
+    /// Currently writing a frame, with associated T-typed bookeeping value.
+    /// The writer is owned by the [`FrameWrite`].
+    Writing(FrameWrite<W, F>, T),
+
+    /// Internal state to manage completions.
+    Broken,
+}
+
+impl<W, F: bytes::Buf, T> fmt::Debug for WriteState<W, F, T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            WriteState::Idle(_) => f.debug_tuple("Idle").finish(),
+            WriteState::Writing(frame_write, _) => {
+                f.debug_tuple("Writing").field(frame_write).finish()
+            }
+            WriteState::Broken => f.debug_tuple("Broken").finish(),
+        }
+    }
+}
+
+impl<W, F, T> WriteState<W, F, T> {
+    /// Current bookeeping value, if it exists.
+    pub fn value(&self) -> Option<&T> {
+        match self {
+            Self::Writing(_, v) => Some(v),
+            Self::Idle(_) | Self::Broken => None,
+        }
+    }
+}
+
+impl<W: AsyncWrite + Unpin, F: Buf, T> WriteState<W, F, T> {
+    /// Drive the send operation. (Cancellation safe.) This is a no-op
+    /// if the write state isn't sending anything; in this case, the operations
+    /// never returns, but may be canceled.
+    pub async fn send(&mut self) -> io::Result<T> {
+        match self {
+            Self::Idle(_) => futures::future::pending().await,
+            Self::Writing(fw, _value) => {
+                fw.send().await?;
+                let Ok((fw, value)) = std::mem::replace(self, Self::Broken).into_writing() else {
+                    panic!("illegal state");
+                };
+                *self = Self::Idle(fw.complete());
+                Ok(value)
+            }
+            Self::Broken => panic!("illegal state"),
         }
     }
 }

--- a/hyperactor/src/channel/net/server.rs
+++ b/hyperactor/src/channel/net/server.rs
@@ -1,0 +1,640 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+//! TODO
+
+use std::any::type_name;
+use std::fmt;
+use std::mem::replace;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::Poll;
+
+use anyhow::Context;
+use bytes::Bytes;
+use dashmap::DashMap;
+use dashmap::mapref::entry::Entry;
+use tokio::io::AsyncRead;
+use tokio::io::AsyncWrite;
+use tokio::io::ReadHalf;
+use tokio::io::WriteHalf;
+use tokio::sync::mpsc;
+use tokio::task::JoinError;
+use tokio::task::JoinHandle;
+use tokio::task::JoinSet;
+use tokio_util::net::Listener;
+use tokio_util::sync::CancellationToken;
+
+use super::serialize_response;
+use crate::RemoteMessage;
+use crate::channel::ChannelAddr;
+use crate::channel::net::Frame;
+use crate::channel::net::NetRx;
+use crate::channel::net::NetRxResponse;
+use crate::channel::net::ServerError;
+use crate::channel::net::framed::FrameReader;
+use crate::channel::net::framed::FrameWrite;
+use crate::channel::net::framed::WriteState;
+use crate::channel::net::meta;
+use crate::clock::Clock;
+use crate::clock::RealClock;
+use crate::config;
+use crate::metrics;
+use crate::sync::mvar::MVar;
+pub(super) struct ServerConn<S> {
+    reader: FrameReader<ReadHalf<S>>,
+    write_state: WriteState<WriteHalf<S>, Bytes, u64>,
+    source: ChannelAddr,
+    dest: ChannelAddr,
+}
+
+impl<S: AsyncRead + AsyncWrite> ServerConn<S> {
+    pub(super) fn new(stream: S, source: ChannelAddr, dest: ChannelAddr) -> Self {
+        let (reader, writer) = tokio::io::split(stream);
+        Self {
+            reader: FrameReader::new(reader, config::global::get(config::CODEC_MAX_FRAME_LENGTH)),
+            write_state: WriteState::Idle(writer),
+            source,
+            dest,
+        }
+    }
+}
+
+impl<S: AsyncRead + AsyncWrite + Send + 'static + Unpin> ServerConn<S> {
+    async fn handshake<M: RemoteMessage>(&mut self) -> Result<u64, anyhow::Error> {
+        let Some(frame) = self.reader.next().await? else {
+            anyhow::bail!("end of stream before first frame from {}", self.source);
+        };
+        let message = serde_multipart::Message::from_framed(frame)?;
+        let Frame::Init(session_id) = serde_multipart::deserialize_bincode::<Frame<M>>(message)?
+        else {
+            anyhow::bail!("unexpected initial frame from {}", self.source);
+        };
+        Ok(session_id)
+    }
+
+    /// Handles a server side stream created during the `listen` loop.
+    async fn process<M: RemoteMessage>(
+        &mut self,
+        session_id: u64,
+        tx: mpsc::Sender<M>,
+        cancel_token: CancellationToken,
+        mut next: Next,
+    ) -> (Next, Result<(), anyhow::Error>) {
+        let log_id = format!("session {}.{}<-{}", self.dest, session_id, self.source);
+        let initial_next: Next = next.clone();
+        let mut rcv_raw_frame_count = 0u64;
+        let mut last_ack_time = RealClock.now();
+
+        let ack_time_interval = config::global::get(config::MESSAGE_ACK_TIME_INTERVAL);
+        let ack_msg_interval = config::global::get(config::MESSAGE_ACK_EVERY_N_MESSAGES);
+
+        let (mut final_next, final_result, reject_conn) = loop {
+            if self.write_state.is_idle()
+                && (next.ack + ack_msg_interval <= next.seq
+                    || (next.ack < next.seq && last_ack_time.elapsed() > ack_time_interval))
+            {
+                let Ok(writer) = replace(&mut self.write_state, WriteState::Broken).into_idle()
+                else {
+                    panic!("illegal state");
+                };
+                let ack = match serialize_response(NetRxResponse::Ack(next.seq - 1)) {
+                    Ok(ack) => ack,
+                    Err(err) => {
+                        break (
+                            next,
+                            Err::<(), anyhow::Error>(err.into())
+                                .context(format!("{log_id}: serializing ack")),
+                            false,
+                        );
+                    }
+                };
+                match FrameWrite::new(
+                    writer,
+                    ack,
+                    config::global::get(config::CODEC_MAX_FRAME_LENGTH),
+                ) {
+                    Ok(fw) => {
+                        self.write_state = WriteState::Writing(fw, next.seq);
+                    }
+                    Err((writer, e)) => {
+                        debug_assert_eq!(e.kind(), std::io::ErrorKind::InvalidData);
+                        tracing::error!("failed to create ack frame (should be tiny): {e}");
+                        self.write_state = WriteState::Idle(writer);
+                    }
+                }
+            }
+
+            tokio::select! {
+                // Prioritize ack, and then shutdown. Leave read last because
+                // there could be a large volume of messages to read, which
+                // subsequently starves the other select! branches.
+                biased;
+
+                // We have to be careful to manage the ack write state here, so that we do not
+                // write partial acks in the presence of cancellation.
+                ack_result = self.write_state.send() => {
+                    match ack_result {
+                        Ok(acked_seq) => {
+                            last_ack_time = RealClock.now();
+                            next.ack = acked_seq;
+                        }
+                        Err(err) => {
+                            let v = self.write_state.value();
+                            break (
+                                next,
+                                Err::<(), anyhow::Error>(err.into())
+                                    .context(format!("{log_id}: acking peer message: {v:?}")),
+                                false
+                            );
+                        }
+                    }
+                },
+                // Have a tick to abort select! call to make sure the ack for the last message can get the chance
+                // to be sent as a result of time interval being reached.
+                _ = RealClock.sleep_until(last_ack_time + ack_time_interval), if next.ack < next.seq => {},
+                _ = cancel_token.cancelled() => break (next, Ok(()), false),
+                bytes_result = self.reader.next() => {
+                    rcv_raw_frame_count += 1;
+                    // First handle transport-level I/O errors, and EOFs.
+                    let bytes = match bytes_result {
+                        Ok(Some(bytes)) => bytes,
+                        Ok(None) => {
+                            tracing::debug!("{log_id}: EOF");
+                            break (next, Ok(()), false);
+                        }
+                        Err(err) => break (
+                            next,
+                            Err::<(), anyhow::Error>(err.into()).context(
+                                format!(
+                                    "{log_id}: reading into Frame with M = {}",
+                                    type_name::<M>(),
+                                )
+                            ),
+                            false
+                        ),
+                    };
+
+                    // De-frame the multi-part message.
+                    let message = match serde_multipart::Message::from_framed(bytes) {
+                        Ok(message) => message,
+                        Err(err) => break (
+                            next,
+                            Err::<(), anyhow::Error>(err.into()).context(
+                                format!(
+                                    "{log_id}: de-frame message with M = {}",
+                                    type_name::<M>(),
+                                )
+                            ),
+                            false
+                        ),
+                    };
+
+                    // Finally decode the message. This assembles the M-typed message
+                    // from its constituent parts.
+                    match serde_multipart::deserialize_bincode(message) {
+                        Ok(Frame::Init(_)) => {
+                            break (next, Err(anyhow::anyhow!("{log_id}: unexpected init frame")), true)
+                        },
+                        // Ignore retransmits.
+                        Ok(Frame::Message(seq, _)) if seq < next.seq => {
+                            tracing::debug!(
+                                "{log_id}: ignoring retransmit; retransmit seq: {}; expected next seq: {}",
+                                seq,
+                                next.seq,
+                            );
+                        },
+                        // The following segment ensures exactly-once semantics.
+                        // That means No out-of-order delivery and no duplicate delivery.
+                        Ok(Frame::Message(seq, message)) => {
+                            // received seq should be equal to next seq. Else error out!
+                            if seq > next.seq {
+                                let msg = format!("{log_id}: out-of-sequence message, expected seq {}, got {}", next.seq, seq);
+                                tracing::error!(msg);
+                                break (next, Err(anyhow::anyhow!(msg)), true)
+                            }
+                            match self.send_with_buffer_metric(&log_id, &tx, message).await {
+                                Ok(()) => {
+                                    // In channel's contract, "delivered" means the message
+                                    // is sent to the NetRx object. Therefore, we could bump
+                                    // `next_seq` as far as the message is put on the mpsc
+                                    // channel.
+                                    //
+                                    // Note that when/how the messages in NetRx are processed
+                                    // is not covered by channel's contract. For example,
+                                    // the message might never be taken out of netRx, but
+                                    // channel still considers those messages delivered.
+                                    next.seq = seq+1;
+                                }
+                                Err(err) => {
+                                    break (next, Err::<(), anyhow::Error>(err).context(format!("{log_id}: relaying message to mpsc channel")), false)
+                                }
+                            }
+                        },
+                        Err(err) => break (
+                            next,
+                            Err::<(), anyhow::Error>(err.into()).context(
+                                format!(
+                                    "{log_id}: deserialize message with M = {}",
+                                    type_name::<M>(),
+                                )
+                            ),
+                            false
+                        ),
+                    }
+                },
+            }
+        };
+
+        // Note:
+        //   1. processed seq/ack is Next-1;
+        //   2. rcv_raw_frame_count contains the last frame which might not be
+        //      desrializable, e.g. EOF, error, etc.
+        tracing::debug!(
+            "{log_id}: NetRx::process exited its loop with states: initial Next \
+            was {initial_next}; final Next is {final_next}; since acked: {}sec; \
+            rcv raw frame count is {rcv_raw_frame_count}; final result: {:?}",
+            last_ack_time.elapsed().as_secs(),
+            final_result,
+        );
+
+        let mut final_ack = final_next.ack;
+        // Flush any ongoing write.
+        if self.write_state.is_writing() {
+            if let Ok(acked_seq) = self.write_state.send().await {
+                if acked_seq > final_ack {
+                    final_ack = acked_seq;
+                }
+            };
+        }
+        // best effort: "flush" any remaining ack before closing this session
+        if self.write_state.is_idle() && final_ack < final_next.seq {
+            let Ok(writer) = replace(&mut self.write_state, WriteState::Broken).into_idle() else {
+                panic!("illegal state");
+            };
+            let result = async {
+                let ack = serialize_response(NetRxResponse::Ack(final_next.seq - 1))
+                    .map_err(anyhow::Error::from)?;
+
+                let max = config::global::get(config::CODEC_MAX_FRAME_LENGTH);
+                let fw =
+                    FrameWrite::new(writer, ack, max).map_err(|(_, e)| anyhow::Error::from(e))?;
+                self.write_state = WriteState::Writing(fw, final_next.seq);
+                self.write_state.send().await.map_err(anyhow::Error::from)
+            };
+
+            match result.await {
+                Ok(acked_seq) => {
+                    final_next.ack = acked_seq;
+                }
+                Err(e) => {
+                    tracing::debug!(
+                        "{log_id}: failed to flush acks due to error : {e}. \
+                        Normally, this is okay because Tx will reconnect, and \
+                        acks will be resent in the next connection. However, if \
+                        either Tx or Rx is dropped, the reconnection will not \
+                        happen, and subsequently the pending ack will never be sent out.",
+                    );
+                }
+            }
+        }
+
+        if self.write_state.is_idle() && reject_conn {
+            let Ok(writer) = replace(&mut self.write_state, WriteState::Broken).into_idle() else {
+                panic!("illegal state");
+            };
+            if let Ok(data) = serialize_response(NetRxResponse::Reject) {
+                match FrameWrite::new(
+                    writer,
+                    data,
+                    config::global::get(config::CODEC_MAX_FRAME_LENGTH),
+                ) {
+                    Ok(fw) => {
+                        self.write_state = WriteState::Writing(fw, 0);
+                        let _ = self.write_state.send().await;
+                    }
+                    Err((w, e)) => {
+                        debug_assert_eq!(e.kind(), std::io::ErrorKind::InvalidData);
+                        tracing::debug!("failed to create reject frame (should be tiny): {e}");
+                        self.write_state = WriteState::Idle(w);
+                        // drop the reject; we're closing anyway
+                    }
+                }
+            };
+        }
+
+        (final_next, final_result)
+    }
+
+    // NetRx's buffer, i.e. the mpsc channel between NetRx and its
+    // client, should rarely be full for long. But when it is full, it
+    // will block NetRx from taking more messages, sending back ack,
+    // and subsequently lead to uncommon behaviors such as ack
+    // timeout, backpressure on NetTx, etc. In order to aid debugging,
+    // it is important to add a metric measuring full buffer
+    // occurences.
+    async fn send_with_buffer_metric<M: RemoteMessage>(
+        &mut self,
+        log_id: &str,
+        tx: &mpsc::Sender<M>,
+        message: M,
+    ) -> anyhow::Result<()> {
+        let start = RealClock.now();
+        loop {
+            tokio::select! {
+                biased;
+                permit_result = tx.reserve() => {
+                    permit_result?.send(message);
+                    return Ok(())
+                }
+                _ = RealClock.sleep(config::global::get(config::CHANNEL_NET_RX_BUFFER_FULL_CHECK_INTERVAL)) => {
+                    // When buffer is full too long, we log it.
+                    metrics::CHANNEL_NET_RX_BUFFER_FULL.add(
+                        1,
+                        hyperactor_telemetry::kv_pairs!(
+                            "dest" => self.dest.to_string(),
+                            "source" => self.source.to_string(),
+                        ),
+                    );
+                    // Full buffer should happen rarely. So we also add a log
+                    // here to make debugging easy.
+                    tracing::debug!(
+                        "{log_id}: encountered full mpsc channel for {} secs",
+                        start.elapsed().as_secs(),
+                    );
+                }
+            }
+        }
+    }
+}
+
+/// Used to bookkeep message processing states.
+#[derive(Clone)]
+struct Next {
+    // The last received message's seq number + 1.
+    seq: u64,
+    // The last acked seq number + 1.
+    ack: u64,
+}
+
+impl fmt::Display for Next {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "(seq: {}, ack: {})", self.seq, self.ack)
+    }
+}
+
+/// Manages persistent sessions, ensuring that only one connection can own
+/// a session at a time, and arranging for session handover.
+#[derive(Clone)]
+pub(super) struct SessionManager {
+    sessions: Arc<DashMap<u64, MVar<Next>>>,
+}
+
+impl SessionManager {
+    pub(super) fn new() -> Self {
+        Self {
+            sessions: Arc::new(DashMap::new()),
+        }
+    }
+
+    pub(super) async fn serve<S, M>(
+        &self,
+        mut conn: ServerConn<S>,
+        tx: mpsc::Sender<M>,
+        cancel_token: CancellationToken,
+    ) -> Result<(), anyhow::Error>
+    where
+        S: AsyncRead + AsyncWrite + Send + 'static + Unpin,
+        M: RemoteMessage,
+    {
+        let session_id = conn
+            .handshake::<M>()
+            .await
+            .context("while serving handshake")?;
+
+        let session_var = match self.sessions.entry(session_id) {
+            Entry::Occupied(entry) => entry.get().clone(),
+            Entry::Vacant(entry) => {
+                // We haven't seen this session before. We begin with seq=0 and ack=0.
+                let var = MVar::full(Next { seq: 0, ack: 0 });
+                entry.insert(var.clone());
+                var
+            }
+        };
+
+        let next = session_var.take().await;
+        let (next, res) = conn.process(session_id, tx, cancel_token, next).await;
+        session_var.put(next).await;
+
+        if let Err(ref err) = res {
+            tracing::info!("process encountered an error: {:#}", err);
+        }
+
+        res
+    }
+}
+
+/// Main listen loop that actually runs the server. The loop will exit when `parent_cancel_token` is
+/// canceled.
+async fn listen<M: RemoteMessage, L: Listener>(
+    mut listener: L,
+    listener_channel_addr: ChannelAddr,
+    tx: mpsc::Sender<M>,
+    parent_cancel_token: CancellationToken,
+    is_tls: bool,
+) -> Result<(), ServerError>
+where
+    L::Addr: Send + Sync + fmt::Debug + 'static + Into<ChannelAddr>,
+    L::Io: Send + Unpin + fmt::Debug + 'static,
+{
+    let mut connections: JoinSet<Result<(), anyhow::Error>> = JoinSet::new();
+
+    // Cancellation token used to cancel our children only.
+    let child_cancel_token = CancellationToken::new();
+
+    let manager = SessionManager::new();
+    let result: Result<(), ServerError> = loop {
+        let _ = tracing::info_span!("channel_listen_accept_loop");
+        tokio::select! {
+            result = listener.accept() => {
+                match result {
+                    Ok((stream, addr)) => {
+                        let source : ChannelAddr = addr.into();
+                        tracing::debug!("listen {}: new connection from {}", listener_channel_addr, source);
+                        metrics::CHANNEL_CONNECTIONS.add(
+                            1,
+                            hyperactor_telemetry::kv_pairs!(
+                                "transport" => listener_channel_addr.transport().to_string(),
+                                "operation" => "accept"
+                            ),
+                        );
+
+                        let tx = tx.clone();
+                        let child_cancel_token = child_cancel_token.child_token();
+                        let dest  = listener_channel_addr.clone();
+                        let manager = manager.clone();
+                        connections.spawn(async move {
+                            let res = if is_tls {
+                                let conn = ServerConn::new(meta::tls_acceptor(true)?
+                                    .accept(stream)
+                                    .await?, source.clone(), dest.clone());
+                                manager.serve(conn, tx, child_cancel_token).await
+                            } else {
+                                let conn = ServerConn::new(stream, source.clone(), dest.clone());
+                                manager.serve(conn, tx, child_cancel_token).await
+                            };
+
+                            if let Err(ref err) = res {
+                                metrics::CHANNEL_CONNECTION_ERRORS.add(
+                                    1,
+                                    hyperactor_telemetry::kv_pairs!(
+                                        "transport" => dest.transport().to_string(),
+                                        "error" => err.to_string(),
+                                    ),
+                                );
+
+                                // we don't want the health probe TCP connections to be counted as an error.
+                                match source {
+                                    ChannelAddr::Tcp(source_addr) if source_addr.ip().is_loopback() => {},
+                                    _ => {
+                                        tracing::info!(
+                                            "serve: error processing peer connection {} <- {}: {:?}",
+                                            dest, source, err
+                                            );
+                                    }
+                                }
+                            }
+                            res
+                    });
+                    }
+                    Err(err) => {
+                        metrics::CHANNEL_CONNECTION_ERRORS.add(
+                            1,
+                            hyperactor_telemetry::kv_pairs!(
+                                "transport" => listener_channel_addr.transport().to_string(),
+                                "operation" => "accept",
+                                "error" => err.to_string(),
+                            ),
+                        );
+
+                        tracing::info!("serve {}: accept error: {}", listener_channel_addr, err)
+                    }
+                }
+            }
+
+            _ = parent_cancel_token.cancelled() => {
+                tracing::info!("serve {}: received parent token cancellation", listener_channel_addr);
+                break Ok(());
+            }
+
+            result = join_nonempty(&mut connections) => {
+                if let Err(err) = result {
+                    tracing::info!("connection error: {}: {}", listener_channel_addr, err);
+                }
+            }
+        }
+    };
+
+    child_cancel_token.cancel();
+    while connections.join_next().await.is_some() {}
+
+    result
+}
+
+async fn join_nonempty<T: 'static>(set: &mut JoinSet<T>) -> Result<T, JoinError> {
+    match set.join_next().await {
+        None => std::future::pending::<Result<T, JoinError>>().await,
+        Some(result) => result,
+    }
+}
+
+/// Handle to an underlying server that is actively listening.
+#[derive(Debug)]
+pub struct ServerHandle {
+    /// Join handle of the listening task.
+    join_handle: JoinHandle<Result<(), ServerError>>,
+
+    /// A cancellation token used to indicate that a stop has been
+    /// initiated.
+    cancel_token: CancellationToken,
+
+    /// Address of the channel that was used to create the listener. This can be used to dial the that listener.
+    channel_addr: ChannelAddr,
+}
+
+impl fmt::Display for ServerHandle {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.channel_addr)
+    }
+}
+
+impl ServerHandle {
+    /// Signal the server to stop. This will stop accepting new
+    /// incoming connection requests, and drain pending operations
+    /// on active connections. After draining is completed, the
+    /// connections are closed.
+    pub(crate) fn stop(&self, reason: &str) {
+        tracing::info!("stopping server: {}; reason: {}", self, reason);
+        self.cancel_token.cancel();
+    }
+
+    /// Reference to the channel that was used to start the server.
+    fn local_channel_addr(&self) -> &ChannelAddr {
+        &self.channel_addr
+    }
+}
+
+impl Future for ServerHandle {
+    type Output = <JoinHandle<Result<(), ServerError>> as Future>::Output;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut std::task::Context<'_>) -> Poll<Self::Output> {
+        // SAFETY: This is safe to do because self is pinned.
+        let join_handle_pinned =
+            unsafe { self.map_unchecked_mut(|container| &mut container.join_handle) };
+        join_handle_pinned.poll(cx)
+    }
+}
+
+/// serve new connections that are accepted from the given listener.
+pub(super) fn serve<M: RemoteMessage, L: Listener + Send + Unpin + 'static>(
+    listener: L,
+    channel_addr: ChannelAddr,
+    is_tls: bool,
+) -> Result<(ChannelAddr, NetRx<M>), ServerError>
+where
+    L::Addr: Sync + Send + fmt::Debug + Into<ChannelAddr>,
+    L::Io: Sync + Send + Unpin + fmt::Debug,
+{
+    metrics::CHANNEL_CONNECTIONS.add(
+        1,
+        hyperactor_telemetry::kv_pairs!(
+            "transport" => channel_addr.transport().to_string(),
+            "operation" => "serve"
+        ),
+    );
+
+    let (tx, rx) = mpsc::channel::<M>(1024);
+    let cancel_token = CancellationToken::new();
+    let join_handle = tokio::spawn(listen(
+        listener,
+        channel_addr.clone(),
+        tx,
+        cancel_token.child_token(),
+        is_tls,
+    ));
+    let server_handle = ServerHandle {
+        join_handle,
+        cancel_token,
+        channel_addr: channel_addr.clone(),
+    };
+
+    Ok((
+        server_handle.local_channel_addr().clone(),
+        NetRx(rx, channel_addr, server_handle),
+    ))
+}

--- a/hyperactor/src/sync.rs
+++ b/hyperactor/src/sync.rs
@@ -14,3 +14,4 @@
 
 pub mod flag;
 pub mod monitor;
+pub mod mvar;

--- a/hyperactor/src/sync/mvar.rs
+++ b/hyperactor/src/sync/mvar.rs
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+//! This module contains an implementation of the MVar synchronization
+//! primitive.
+
+use std::mem::take;
+use std::sync::Arc;
+
+use tokio::sync::Mutex;
+use tokio::sync::MutexGuard;
+use tokio::sync::watch;
+
+/// An MVar is a primitive that combines synchronization and the exchange
+/// of a value. Its semantics are analogous to a synchronous channel of
+/// size 1: if the MVar is full, then `put` blocks until it is emptied;
+/// if the MVar is empty, then `take` blocks until it is filled.
+///
+/// MVars, first introduced in "[Concurrent Haskell](https://www.microsoft.com/en-us/research/wp-content/uploads/1996/01/concurrent-haskell.pdf)"
+/// are surprisingly versatile in use. They can be used as:
+/// - a communication channel (with `put` and `take` corresponding to `send` and `recv`);
+/// - a semaphore (with `put` and `take` corresponding to `signal` and `wait`);
+/// - a mutex (with `put` and `take` corresponding to `lock` and `unlock`);
+#[derive(Clone, Debug)]
+pub struct MVar<T> {
+    seq: watch::Sender<usize>,
+    value: Arc<Mutex<Option<T>>>,
+}
+
+impl<T> MVar<T> {
+    /// Create a new MVar with an optional initial value; if no value is
+    /// provided the MVar starts empty.
+    fn new(init: Option<T>) -> Self {
+        let (seq, _) = watch::channel(0);
+        Self {
+            seq,
+            value: Arc::new(Mutex::new(init)),
+        }
+    }
+
+    /// Create a new full MVar with the provided value.
+    pub fn full(value: T) -> Self {
+        Self::new(Some(value))
+    }
+
+    /// Create a new empty MVar.
+    pub fn empty() -> Self {
+        Self::new(None)
+    }
+
+    async fn waitseq(&self, seq: usize) -> (MutexGuard<'_, Option<T>>, usize) {
+        let mut sub = self.seq.subscribe();
+        while *sub.borrow_and_update() < seq {
+            sub.changed().await.unwrap();
+        }
+        let locked = self.value.lock().await;
+        let seq = *sub.borrow_and_update();
+        (locked, seq + 1)
+    }
+
+    fn notify(&self, seq: usize) {
+        self.seq.send_replace(seq);
+    }
+
+    /// Wait until the MVar is full and take its value.
+    /// This method is cancellation safe.
+    pub async fn take(&self) -> T {
+        let mut seq = 0;
+        loop {
+            let mut value;
+            (value, seq) = self.waitseq(seq).await;
+
+            if let Some(current_value) = take(&mut *value) {
+                self.notify(seq);
+                break current_value;
+            }
+            drop(value);
+        }
+    }
+
+    /// Wait until the MVar is empty and put a new value.
+    /// This method is cancellation safe.
+    pub async fn put(&self, new_value: T) {
+        let mut seq = 0;
+        loop {
+            let mut value;
+            (value, seq) = self.waitseq(seq).await;
+
+            if value.is_none() {
+                *value = Some(new_value);
+                self.notify(seq);
+                break;
+            }
+            drop(value);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_mvar() {
+        let mv0 = MVar::full(0);
+        let mv1 = MVar::empty();
+
+        assert_eq!(mv0.take().await, 0);
+
+        tokio::spawn({
+            let mv0 = mv0.clone();
+            let mv1 = mv1.clone();
+            async move { mv1.put(mv0.take().await).await }
+        });
+
+        mv0.put(1).await;
+        assert_eq!(mv1.take().await, 1);
+    }
+}


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #1831
* #1824
* #1823

This is a straightforward refactor of `net` into `net::server` and `net::client`. More to come.

Differential Revision: [D86800094](https://our.internmc.facebook.com/intern/diff/D86800094/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D86800094/)!