### PR TITLE
Add GPU-affinity device selection for CPU RDMA

### DIFF
--- a/monarch_rdma/src/ibverbs_primitives.rs
+++ b/monarch_rdma/src/ibverbs_primitives.rs
@@ -422,6 +422,18 @@ pub struct RdmaPort {
     gid_tbl_len: i32,
 }
 
+impl RdmaPort {
+    /// Returns the port number.
+    pub fn port_num(&self) -> u8 {
+        self.port_num
+    }
+
+    /// Returns the link layer type of the port (e.g., "InfiniBand", "Ethernet").
+    pub fn link_layer(&self) -> &str {
+        &self.link_layer
+    }
+}
+
 impl fmt::Display for RdmaDevice {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         writeln!(f, "{}", self.name)?;


### PR DESCRIPTION
Summary:
The current RDMA implementation does not distinguish between NIC capabilities, i.e. Ethernet vs RoCE, front-end vs back-end, etc.

A concrete challenge I was facing was that the current device inference would lead to e.g. a front-end NIC and a back-end NIC trying to communicate with each other. Specifically, CPU devices would fallback to mlx5_0, which is a backend NIC on our dev GPUs but could be a front-end NIC on other deployments.

Unfortunately deducing by capability is not something that is provided by the ibverbs APIs, and seems like it's specific to each deployment.

So assuming that GPU<>RDMA deduction works consistently, we're shifting the CPU device mapping based on the set of devices that have an affinity with GPU devices.

Specifically:
  - `get_gpu_affinity_devices()`: Returns RDMA devices used by GPUs (assumed to
    be backend/high-speed network)
  - `devices_share_link_layer()`: Validates link layer consistency with clear
    documentation of its limitations
  - Separate CPU and CUDA device selection logic: CPU now calculates PCI distances
    ONLY among GPU-affinity devices, ensuring CPU and GPU operations use the same
    high-speed network fabric

Differential Revision: D86802863


