### PR TITLE
Add cleanup function to Actor trait and use it from PythonActor

### DIFF
--- a/hyperactor/src/config.rs
+++ b/hyperactor/src/config.rs
@@ -155,6 +155,14 @@ declare_attrs! {
     })
     pub attr STOP_ACTOR_TIMEOUT: Duration = Duration::from_secs(10);
 
+    /// Timeout used by proc for running the cleanup callback on an actor.
+    /// Should be less than the timeout for STOP_ACTOR_TIMEOUT.
+    @meta(CONFIG = ConfigAttr {
+        env_name: Some("HYPERACTOR_CLEANUP_TIMEOUT".to_string()),
+        py_name: None,
+    })
+    pub attr CLEANUP_TIMEOUT: Duration = Duration::from_secs(3);
+
     /// Heartbeat interval for remote allocator
     @meta(CONFIG = ConfigAttr {
         env_name: Some("HYPERACTOR_REMOTE_ALLOCATOR_HEARTBEAT_INTERVAL".to_string()),


### PR DESCRIPTION
Summary:
RFC: Add a "cleanup" for actors to run on stop.

This method is invoked after all child actors are stopped, but before the current actor
exits.
If an exception is thrown, it will become an error at shutdown which will propagate.
The cleanup method in python can be sync or async, and must match the syncness of
endpoints. It takes one argument, which is an `Optional[Exception]`. If this was an abnormal exit,
that exception is not None, specifically to the result of `ActorError::to_string` (wrapped
in an exception object).
Later on we may be able to preserve the original exception, if there is one.

The motivation is from actors that want to call `dist.destroy_process_group()`,
as that is one of the most frequent cleanup action in users of monarch. Actors should
*not* call `stop()` on any actor or proc meshes they own. This will be handled automatically
in the future, and they will have already been stopped by the time cleanup
is invoked.

This cleanup is per-actor, not per-proc. So if the cleanup is destroying process-wide resources
(as does "destroy_process_group"), then the actor shouldn't be colocated with any other
actors on the same proc using the same resource.
If the cleanup takes too long, ignore the result and continue with stopping.

ProcMesh::stop() already does a graceful stop of all actors, so this cleanup will be run
automatically when proc meshes are stopped.

Reviewed By: mariusae

Differential Revision: D85624518
