### PR TITLE
After Stop and StopAll messages, use GetRankStatus to query for success

### DIFF
--- a/hyperactor_mesh/src/v1/actor_mesh.rs
+++ b/hyperactor_mesh/src/v1/actor_mesh.rs
@@ -368,9 +368,6 @@ impl<A: Referable> fmt::Display for ActorMeshRef<A> {
     }
 }
 
-// proc_mesh: ProcMeshRef,
-// name: Name,
-
 impl<A: Referable> PartialEq for ActorMeshRef<A> {
     fn eq(&self, other: &Self) -> bool {
         self.proc_mesh == other.proc_mesh && self.name == other.name


### PR DESCRIPTION
Summary:
The StopAll message didn't have a reply, so there could be a race between asking
all actors to stop and sending a SIGTERM to kill them.
Avoid this by adding a new GetAllRankStatus message, a parallel of GetRankStatus without
a particular name.
In order to cut down on the proliferation of rank replies, removed the reply from Stop. The
pre-existing GetRankStatus is used now to fetch whether the actor did successfully stop.

In order for a second message to work, we need to *not* destroy the agent actor on the proc, so we
add a new argument to `destroy_and_wait`. This way you can send a StopAll, and then actually
spawn new actors after that point, making the system a bit more flexible.

Reviewed By: mariusae

Differential Revision: D86137850


