### PR TITLE
Make Test GPU Rust fail fast if stuck

### DIFF
--- a/.github/workflows/test-gpu-rust.yml
+++ b/.github/workflows/test-gpu-rust.yml
@@ -63,7 +63,7 @@ jobs:
         # * monarch_messages: monarch/target/debug/deps/monarch_messages-...:
         #   /lib64/libm.so.6: version `GLIBC_2.29' not found
         #   (required by /meta-pytorch/monarch/libtorch/lib/libtorch_cpu.so)
-        cargo nextest run --workspace --profile ci \
+        timeout 12m cargo nextest run --workspace --profile ci \
           --exclude monarch_messages \
           --exclude monarch_tensor_worker \
           --exclude monarch_simulator_lib \


### PR DESCRIPTION
Summary: This is currently timing out after 2 hours on github actions. Of all the successful runs I've seen, cargo test completes in around 9 minutes, so if its taking anything even a few minutes more than this its almost guaranteed to be stuck and we are better off retrying

Differential Revision: D86904785


