### PR TITLE
make supervision timeout message more user friendly

### DIFF
--- a/python/tests/test_actor_error.py
+++ b/python/tests/test_actor_error.py
@@ -692,7 +692,7 @@ async def test_supervision_with_proc_mesh_stopped(mesh) -> None:
     # new call should fail with check of health state of actor mesh
     with pytest.raises(
         SupervisionError,
-        match="actor mesh is stopped due to proc mesh shutdown|Actor .* exited because of the following reason.*stopped",
+        match="actor mesh is stopped due to proc mesh shutdown|.* is not reacheable, check the log on the host for details",
     ):
         await actor_mesh.check.call()
 


### PR DESCRIPTION
Summary:
right now, when anything related to mesh agent happens, e.g. connection down, proc stopped, we print supervision error message like

```
monarch._rust_bindings.monarch_hyperactor.supervision.SupervisionError: Actor metatls:twshared12411.02.gtn2.facebook.com:36037,anon_0_15HL6RLpNvRw,agent[0] exited because of the following reason: <PyActorSupervisionEvent: metatls:twshared12411.02.gtn2.facebook.com:36037,anon_0_15HL6RLpNvRw,agent[0]: stopped at 2025-11-11 17:31:58.907237439 -08:00>
```

This message contains the actor mesh agent, which is monarch internal actor, should not be exposed to customers. This message would confuse users, thinking it is always something related to monarch internal.

This diff changes the message to be more explicit for user what the next step is for investigation. New log for agent related error will look like

```
twshared234234.gtn3:23232 is not reacheable, check the log on the host for details
```

A followup diff will include a scuba link as part of the message, the scuba will show monarch error log and stderr error logs.

Differential Revision: D86984496


