### PR TITLE
bug fix: write_from doesn't propogate result to caller

### DIFF
--- a/monarch_rdma/src/rdma_components.rs
+++ b/monarch_rdma/src/rdma_components.rs
@@ -207,8 +207,7 @@ impl RdmaBuffer {
             .release_queue_pair(client, remote_owner, local_device, remote_device, qp)
             .await?;
 
-        result?;
-        Ok(true)
+        result
     }
     /// Waits for the completion of an RDMA operation.
     ///


### PR DESCRIPTION
Summary: Clear bug, we swallow possible errors from write_from operations.

Differential Revision: D87037246


