### PR TITLE
improve logs

### DIFF
--- a/hyperactor/src/channel/net.rs
+++ b/hyperactor/src/channel/net.rs
@@ -2093,9 +2093,9 @@ mod tests {
 
         // Verify the channel is closed due to ack timeout based on the log.
         let expected_log: &str = if disconnect_before_ack {
-            "failed to receive ack within timeout 2 secs; link is currently broken"
+            "failed to receive ack within timeout 2s; link is currently broken"
         } else {
-            "failed to receive ack within timeout 2 secs; link is currently connected"
+            "failed to receive ack within timeout 2s; link is currently connected"
         };
 
         verify_tx_closed(&mut tx_status, expected_log).await;

--- a/hyperactor/src/channel/net/client.rs
+++ b/hyperactor/src/channel/net/client.rs
@@ -905,8 +905,8 @@ where
                 // If acking message takes too long, consider the link broken.
                 _ = unacked.wait_for_timeout(), if !unacked.is_empty() => {
                     let error_msg = format!(
-                        "{log_id}: failed to receive ack within timeout {} secs; link is currently connected",
-                        config::global::get(config::MESSAGE_DELIVERY_TIMEOUT).as_secs(),
+                        "{log_id}: failed to receive ack within timeout {:?}; link is currently connected",
+                        config::global::get(config::MESSAGE_DELIVERY_TIMEOUT),
                     );
                     tracing::error!(error_msg);
                     (State::Closing {
@@ -984,7 +984,10 @@ where
             // If delivering this message is taking too long,
             // consider the link broken.
             if outbox.is_expired() {
-                let error_msg = format!("{log_id}: failed to deliver message within timeout");
+                let error_msg = format!(
+                    "{log_id}: failed to deliver message within timeout {:?}",
+                    config::global::get(config::MESSAGE_DELIVERY_TIMEOUT)
+                );
                 tracing::error!(error_msg);
                 (
                     State::Closing {
@@ -995,8 +998,8 @@ where
                 )
             } else if unacked.is_expired() {
                 let error_msg = format!(
-                    "{log_id}: failed to receive ack within timeout {} secs; link is currently broken",
-                    config::global::get(config::MESSAGE_DELIVERY_TIMEOUT).as_secs(),
+                    "{log_id}: failed to receive ack within timeout {:?}; link is currently broken",
+                    config::global::get(config::MESSAGE_DELIVERY_TIMEOUT),
                 );
                 tracing::error!(error_msg);
                 (

--- a/hyperactor_mesh/src/alloc/process.rs
+++ b/hyperactor_mesh/src/alloc/process.rs
@@ -454,7 +454,7 @@ impl ProcessAlloc {
 
         // We don't support FileAppender in this v0 allocator path; warn if asked.
         if enable_file_capture {
-            tracing::warn!(
+            tracing::info!(
                 "MESH_ENABLE_FILE_CAPTURE=true, but ProcessAllocator (v0) has no FileAppender; \
                  files will NOT be written in this path"
             );


### PR DESCRIPTION
Summary:
This diff does 2 changes:

1. downgrade a `warn` to `info` since that message is more a fyi, rather than asking the user to do something.
2. include `MESSAGE_DELIVERY_TIMEOUT` value in the error message.

Differential Revision: D86974138


