### PR TITLE
Change ActorStatus to Stopping and Stopped only once

### DIFF
--- a/hyperactor_mesh/src/proc_mesh/mesh_agent.rs
+++ b/hyperactor_mesh/src/proc_mesh/mesh_agent.rs
@@ -401,7 +401,7 @@ impl MeshAgentMessageHandler for ProcMeshAgent {
             match RealClock
                 .timeout(
                     tokio::time::Duration::from_millis(timeout_ms),
-                    status.wait_for(|state: &ActorStatus| matches!(*state, ActorStatus::Stopped)),
+                    status.wait_for(|state: &ActorStatus| state.is_terminal()),
                 )
                 .await
             {


### PR DESCRIPTION
Summary:
Minor change: before the "Instance::run" and "Instance::run_actor_tree" would both
try to change the ActorStatus to Stopping and Stopped. Going back and forth from a terminal
state could introduce timing errors on status watchers, which watch for Stopped or Failed.

Just do this once in run_actor_tree once all child actors are stopped and cleanup has run.

Reviewed By: mariusae

Differential Revision: D87082404


