### PR TITLE
Turn on tokio time features for monarch_tensor_worker::stream tests

### DIFF
--- a/monarch_tensor_worker/src/stream.rs
+++ b/monarch_tensor_worker/src/stream.rs
@@ -560,7 +560,7 @@ impl Actor for StreamActor {
             // use `block_in_place` for nested async-to-sync-to-async flows.
             let rt = tokio::runtime::Builder::new_multi_thread()
                 .worker_threads(1)
-                .enable_io()
+                .enable_all()
                 .build()
                 .unwrap();
             let result = rt.block_on(async {


### PR DESCRIPTION
Summary:
Fixing test breakages like:
```
thread 'worker-stream' panicked at fbcode/monarch/hyperactor/src/clock.rs:293:9:
A Tokio 1.x context was found, but timers are disabled. Call `enable_time` on the runtime builder to enable timers.
```
in stream.rs

Differential Revision: D87099251


