### PR TITLE
Change proc mesh stop to exit the process instead of SIGTERM

### DIFF
--- a/hyperactor_mesh/src/resource.rs
+++ b/hyperactor_mesh/src/resource.rs
@@ -217,26 +217,6 @@ impl GetRankStatus {
     }
 }
 
-/// Get the status of all resources across the mesh.
-#[derive(
-    Clone,
-    Debug,
-    Serialize,
-    Deserialize,
-    Named,
-    Handler,
-    HandleClient,
-    RefClient,
-    Bind,
-    Unbind
-)]
-pub struct GetAllRankStatus {
-    /// Returns the status and rank of all resources.
-    /// TODO: migrate to a ValueOverlay.
-    #[binding(include)]
-    pub reply: PortRef<Vec<(usize, Status)>>,
-}
-
 /// The state of a resource.
 #[derive(Clone, Debug, Serialize, Deserialize, Named, PartialEq, Eq)]
 pub struct State<S> {


### PR DESCRIPTION
Summary:
Instead of relying on sending SIGTERM, give the process a chance to clean itself up
gracefully.
Have the StopAll message on ProcMeshAgent call exit(0) if it is able to clean up all
actors successfully, or exit(1) if there's an issue.

Then, instead of awaiting a reply from the actor, use the `wait()` functionality of
ProcHandle to wait for it to exit. This way we don't get the SIGTERM stack dump,
and gives the user process a chance to run atexit handlers such as static C++
object destructors (SIGTERM bypasses atexit handlers).

This also means nothing uses GetAllRankStatus anymore, and we can delete it!
We may also want to rename StopAll to StopSelf or something that implies it'll
stop itself as well.

Reviewed By: shayne-fletcher

Differential Revision: D87108568


