### PR TITLE
: 'configure' should merge to global config not set

### DIFF
--- a/hyperactor/src/attrs.rs
+++ b/hyperactor/src/attrs.rs
@@ -556,6 +556,15 @@ impl Attrs {
     pub(crate) fn get_value_by_name(&self, name: &'static str) -> Option<&dyn SerializableValue> {
         self.values.get(name).map(|b| b.as_ref())
     }
+
+    /// Merge all attributes from `other` into this set, consuming
+    /// `other`.
+    ///
+    /// For each key in `other`, moves its value into `self`,
+    /// overwriting any existing value for the same key.
+    pub(crate) fn merge(&mut self, other: Attrs) {
+        self.values.extend(other.values);
+    }
 }
 
 impl Clone for Attrs {

--- a/hyperactor_mesh/src/bootstrap.rs
+++ b/hyperactor_mesh/src/bootstrap.rs
@@ -96,7 +96,7 @@ declare_attrs! {
     /// piping) or via [`StreamFwder`] when piping is active.
     @meta(CONFIG = ConfigAttr {
         env_name: Some("HYPERACTOR_MESH_ENABLE_LOG_FORWARDING".to_string()),
-        py_name: None,
+        py_name: Some("enable_log_forwarding".to_string()),
     })
     pub attr MESH_ENABLE_LOG_FORWARDING: bool = false;
 
@@ -121,7 +121,7 @@ declare_attrs! {
     ///   buffer used for peeking—independent of file capture.
     @meta(CONFIG = ConfigAttr {
         env_name: Some("HYPERACTOR_MESH_ENABLE_FILE_CAPTURE".to_string()),
-        py_name: None,
+        py_name: Some("enable_file_capture".to_string()),
     })
     pub attr MESH_ENABLE_FILE_CAPTURE: bool = false;
 
@@ -130,7 +130,7 @@ declare_attrs! {
     /// pipes. Default: 100
     @meta(CONFIG = ConfigAttr {
         env_name: Some("HYPERACTOR_MESH_TAIL_LOG_LINES".to_string()),
-        py_name: None,
+        py_name: Some("tail_log_lines".to_string()),
     })
     pub attr MESH_TAIL_LOG_LINES: usize = 0;
 

--- a/monarch_hyperactor/src/config.rs
+++ b/monarch_hyperactor/src/config.rs
@@ -97,7 +97,7 @@ fn set_global_config<T: AttrValue + Debug>(key: &'static dyn ErasedKey, value: T
     let key = key.downcast_ref().expect("cannot fail");
     let mut attrs = Attrs::new();
     attrs.set(key.clone(), value);
-    hyperactor::config::global::set(Source::Runtime, attrs);
+    hyperactor::config::global::create_or_merge(Source::Runtime, attrs);
     Ok(())
 }
 

--- a/python/monarch/_rust_bindings/monarch_hyperactor/config.pyi
+++ b/python/monarch/_rust_bindings/monarch_hyperactor/config.pyi
@@ -25,5 +25,8 @@ def reload_config_from_env() -> None:
 
 def configure(
     default_transport: ChannelTransport = ChannelTransport.Unix,
+    enable_log_forwarding: bool = False,
+    enable_file_capture: bool = False,
+    tail_log_lines: int = 0,
 ) -> None: ...
 def get_configuration() -> Dict[str, Any]: ...

--- a/python/tests/test_config.py
+++ b/python/tests/test_config.py
@@ -39,3 +39,14 @@ def test_get_set_transport() -> None:
 def test_nonexistent_config_key() -> None:
     with pytest.raises(ValueError):
         configure(does_not_exist=42)  # type: ignore
+
+
+def test_get_set_multiple() -> None:
+    configure(default_transport=ChannelTransport.TcpWithLocalhost)
+    configure(enable_log_forwarding=True, enable_file_capture=True, tail_log_lines=100)
+    config = get_configuration()
+
+    assert config["enable_log_forwarding"]
+    assert config["enable_file_capture"]
+    assert config["tail_log_lines"] == 100
+    assert config["default_transport"] == ChannelTransport.TcpWithLocalhost


### PR DESCRIPTION
Summary:
this diff fixes incorrect overwrite semantics in the python configuration path. previously, each kwarg passed to `configure()` called `global::set(Source::Runtime, …)`, which replaces the entire `Runtime` layer. as a result, setting multiple keys in separate calls-or even within a single call-would drop previously set `Runtime` values.

the fix introduces `Attrs::absorb` and `global::create_or_update`, which perform an in‑place update of an existing layer while preserving keys not mentioned in the update. the python bridge now uses `create_or_update` instead of `set`, giving `Runtime` the incremental semantics expected by the python API. a shared `make_layer` helper removes duplicated construction logic.

python‑exposed config keys for log forwarding and capture are enabled, and new tests in the python layer exercise both single and multi-key configuration.

Differential Revision: D87339094


