### PR TITLE
Add controller actor for meshes

### DIFF
--- a/hyperactor_mesh/src/v1.rs
+++ b/hyperactor_mesh/src/v1.rs
@@ -12,6 +12,7 @@
 
 pub mod actor_mesh;
 pub mod host_mesh;
+pub mod mesh_controller;
 pub mod proc_mesh;
 pub mod testactor;
 pub mod testing;
@@ -142,6 +143,9 @@ pub enum Error {
 
     #[error("error spawning actor: {0}")]
     SingletonActorSpawnError(anyhow::Error),
+
+    #[error("error spawning controller actor for mesh {0}: {1}")]
+    ControllerActorSpawnError(Name, anyhow::Error),
 
     #[error("error: {0} does not exist")]
     NotExist(Name),

--- a/hyperactor_mesh/src/v1/mesh_controller.rs
+++ b/hyperactor_mesh/src/v1/mesh_controller.rs
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+use std::fmt::Debug;
+
+use async_trait::async_trait;
+use hyperactor::Actor;
+use hyperactor::Instance;
+use hyperactor::ProcId;
+use hyperactor::actor::ActorError;
+use hyperactor::actor::Referable;
+use ndslice::ViewExt;
+use ndslice::view::Ranked;
+
+use crate::v1::actor_mesh::ActorMeshRef;
+use crate::v1::host_mesh::HostMeshRef;
+use crate::v1::proc_mesh::ProcMeshRef;
+
+#[hyperactor::export(spawn = false)]
+pub(crate) struct ActorMeshController<A>
+where
+    A: Referable,
+{
+    mesh: ActorMeshRef<A>,
+}
+
+impl<A: Referable> Debug for ActorMeshController<A> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("MeshController")
+            .field("mesh", &self.mesh)
+            .finish()
+    }
+}
+
+#[async_trait]
+impl<A: Referable> Actor for ActorMeshController<A> {
+    type Params = ActorMeshRef<A>;
+    async fn new(params: Self::Params) -> Result<Self, anyhow::Error> {
+        Ok(Self { mesh: params })
+    }
+
+    async fn cleanup(
+        &mut self,
+        this: &Instance<Self>,
+        _err: Option<&ActorError>,
+    ) -> Result<(), anyhow::Error> {
+        // Cannot use "ActorMesh::stop" as it's only defined on ActorMesh, not ActorMeshRef.
+        self.mesh
+            .proc_mesh()
+            .stop_actor_by_name(this, self.mesh.name().clone())
+            .await?;
+        Ok(())
+    }
+}
+
+#[derive(Debug)]
+#[hyperactor::export(spawn = true)]
+pub(crate) struct ProcMeshController {
+    mesh: ProcMeshRef,
+}
+
+#[async_trait]
+impl Actor for ProcMeshController {
+    type Params = ProcMeshRef;
+    async fn new(params: Self::Params) -> Result<Self, anyhow::Error> {
+        Ok(Self { mesh: params })
+    }
+
+    async fn cleanup(
+        &mut self,
+        this: &Instance<Self>,
+        _err: Option<&ActorError>,
+    ) -> Result<(), anyhow::Error> {
+        // Cannot use "ProcMesh::stop" as it's only defined on ProcMesh, not ProcMeshRef.
+        let names = self.mesh.proc_ids().collect::<Vec<ProcId>>();
+        let region = self.mesh.region().clone();
+        if let Some(hosts) = self.mesh.hosts() {
+            hosts
+                .stop_proc_mesh(this, self.mesh.name(), names, region)
+                .await
+        } else {
+            Ok(())
+        }
+    }
+}
+
+#[derive(Debug)]
+#[hyperactor::export(spawn = true)]
+pub(crate) struct HostMeshController {
+    mesh: HostMeshRef,
+}
+
+#[async_trait]
+impl Actor for HostMeshController {
+    type Params = HostMeshRef;
+    async fn new(params: Self::Params) -> Result<Self, anyhow::Error> {
+        Ok(Self { mesh: params })
+    }
+
+    async fn cleanup(
+        &mut self,
+        this: &Instance<Self>,
+        _err: Option<&ActorError>,
+    ) -> Result<(), anyhow::Error> {
+        // Cannot use "HostMesh::shutdown" as it's only defined on HostMesh, not HostMeshRef.
+        for host in self.mesh.values() {
+            if let Err(e) = host.shutdown(this).await {
+                tracing::warn!(host = %host, error = %e, "host shutdown failed");
+            }
+        }
+        Ok(())
+    }
+}


### PR DESCRIPTION
Summary:
Fixes https://github.com/meta-pytorch/monarch/issues/1848

We want to support an important ownership axiom of Actors, that every actor which
is alive has a single alive owner.
If that owner is stopped (either voluntarily or via a crash), we want the child actors to
stop as well.

To this end, whenever we spawn a normal actor on a ProcMesh, we also spawn a "controller"
actor on the owner. This controller's only job at the moment is to ensure during cleanup
it calls "stop" on the actor it owns.
This should mean as long as your actor stops on its own, all of its children will recursively
stop.

This mechanism doesn't handle an unclean exit on the owner, in which case we wouldn't
be able to run the cleanup hook. That will need to be fixed separately.
It is an important case for when the client might just exit for some reason, or get Ctrl-C'd.

Had to enhance the `hyperactor::export` macro to handle generics. "hyperactor::remote"
still doesn't, but luckily we don't even need to do a remote spawn of this actor.

Reviewed By: mariusae

Differential Revision: D86917010


