### PR TITLE
Dedicated Actors for Cuda Init in test infra

### DIFF
--- a/monarch_rdma/src/rdma_manager_actor_tests.rs
+++ b/monarch_rdma/src/rdma_manager_actor_tests.rs
@@ -569,7 +569,7 @@ mod tests {
         Ok(())
     }
 
-    #[timed_test::async_timed_test(timeout_secs = 60)]
+    #[timed_test::async_timed_test(timeout_secs = 30)]
     async fn test_rdma_read_into_cuda_vs_cuda() -> Result<(), anyhow::Error> {
         if is_cpu_only_mode() {
             println!("Skipping CUDA test in CPU-only mode");

--- a/rdmaxcel-sys/src/driver_api.cpp
+++ b/rdmaxcel-sys/src/driver_api.cpp
@@ -24,6 +24,7 @@
   _(cuMemRelease)                   \
   _(cuMemcpyHtoD_v2)                \
   _(cuMemcpyDtoH_v2)                \
+  _(cuMemsetD8_v2)                  \
   _(cuPointerGetAttribute)          \
   _(cuInit)                         \
   _(cuDeviceGet)                    \
@@ -167,6 +168,11 @@ CUresult rdmaxcel_cuMemcpyDtoH_v2(
     size_t ByteCount) {
   return rdmaxcel::DriverAPI::get()->cuMemcpyDtoH_v2_(
       dstHost, srcDevice, ByteCount);
+}
+
+CUresult
+rdmaxcel_cuMemsetD8_v2(CUdeviceptr dstDevice, unsigned char uc, size_t N) {
+  return rdmaxcel::DriverAPI::get()->cuMemsetD8_v2_(dstDevice, uc, N);
 }
 
 // Pointer queries

--- a/rdmaxcel-sys/src/driver_api.h
+++ b/rdmaxcel-sys/src/driver_api.h
@@ -71,6 +71,9 @@ CUresult rdmaxcel_cuMemcpyDtoH_v2(
     CUdeviceptr srcDevice,
     size_t ByteCount);
 
+CUresult
+rdmaxcel_cuMemsetD8_v2(CUdeviceptr dstDevice, unsigned char uc, size_t N);
+
 // Pointer queries
 CUresult rdmaxcel_cuPointerGetAttribute(
     void* data,


### PR DESCRIPTION
Summary:
Basically we need to create cuda logic within same process as a given rdma manager - which test fixtures did not do prior; resulting in sporadic test failures (common under stress runs).

This resolves that issue:
  buck2 test fbcode//mode/dev-nosan //monarch/monarch_rdma\:monarch_rdma -- --stress-runs 10
  Tests finished: Pass 270. Fail 0. Fatal 0. Skip 35. Infra Failure 0. Build failure 0

Differential Revision: D87385796


