### PR TITLE
Make test_actor_ledger more reliable

### DIFF
--- a/hyperactor/src/proc.rs
+++ b/hyperactor/src/proc.rs
@@ -2731,6 +2731,8 @@ mod tests {
         // Stop root_1. This should remove it, and its child, from snapshot.
         root_1.drain_and_stop().unwrap();
         root_1.await;
+        // root also needs to stop processing messages to get a reliable number.
+        wait_until_idle(&root).await;
         {
             let snapshot = proc.state().ledger.snapshot();
             assert_eq!(


### PR DESCRIPTION
Summary:
Fixing this error:
```
    running 1 test
    test proc::tests::test_actor_ledger ... FAILED

    failures:

    failures:
        proc::tests::test_actor_ledger

    test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 217 filtered out; finished in 0.01s
    
  stderr ───

    thread '<unnamed>' panicked at hyperactor/src/proc.rs:2745:13:
    assertion `left == right` failed
      left: {ActorId(Ranked(WorldId("local"), 0), "root", 0): ActorTreeSnapshot { pid: 0, type_name: "hyperactor::proc::tests::TestActor", status: Idle, stats: ActorStats { num_processed_messages: 2 }, handlers: {}, children: {3: ActorTreeSnapshot { pid: 3, type_name: "hyperactor::proc::tests::TestActor", status: Idle, stats: ActorStats { num_processed_messages: 0 }, handlers: {}, children: {}, events: [], spans: [] }}, events: [], spans: [] }}
     right: {ActorId(Ranked(WorldId("local"), 0), "root", 0): ActorTreeSnapshot { pid: 0, type_name: "hyperactor::proc::tests::TestActor", status: Idle, stats: ActorStats { num_processed_messages: 3 }, handlers: {}, children: {3: ActorTreeSnapshot { pid: 3, type_name: "hyperactor::proc::tests::TestActor", status: Idle, stats: ActorStats { num_processed_messages: 0 }, handlers: {}, children: {}, events: [], spans: [] }}, events: [], spans: [] }}
    note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

The num_processed_messages might still increase until the root is idle (as it processes
signals as well as messages).

Differential Revision: D87499544


