### PR TITLE
Stop the proc mesh from the alloc in HostMesh::shutdown

### DIFF
--- a/hyperactor_mesh/src/bootstrap.rs
+++ b/hyperactor_mesh/src/bootstrap.rs
@@ -3622,7 +3622,7 @@ mod tests {
         // stored `BootstrapProcManager`, which does a
         // `Command::spawn()` to launch a new OS child process for
         // that proc.
-        let host_mesh = HostMesh::allocate(&instance, Box::new(alloc), "test", None)
+        let mut host_mesh = HostMesh::allocate(&instance, Box::new(alloc), "test", None)
             .await
             .unwrap();
 

--- a/hyperactor_mesh/src/v1/actor_mesh.rs
+++ b/hyperactor_mesh/src/v1/actor_mesh.rs
@@ -789,7 +789,7 @@ mod tests {
         let _guard = config.override_key(crate::bootstrap::MESH_BOOTSTRAP_ENABLE_PDEATHSIG, false);
 
         let instance = testing::instance().await;
-        let host_mesh = testing::host_mesh(extent!(host = 4)).await;
+        let mut host_mesh = testing::host_mesh(extent!(host = 4)).await;
         let proc_mesh = host_mesh
             .spawn(instance, "test", Extent::unity())
             .await

--- a/monarch_hyperactor/src/v1/logging.rs
+++ b/monarch_hyperactor/src/v1/logging.rs
@@ -511,7 +511,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_world_smoke() {
-        let (proc, instance, host_mesh, proc_mesh) = test_world().await.expect("world failed");
+        let (proc, instance, mut host_mesh, proc_mesh) = test_world().await.expect("world failed");
 
         assert_eq!(
             host_mesh.region().num_ranks(),
@@ -534,7 +534,7 @@ mod tests {
 
     #[tokio::test]
     async fn spawn_respects_forwarding_flag() {
-        let (_, instance, host_mesh, proc_mesh) = test_world().await.expect("world failed");
+        let (_, instance, mut host_mesh, proc_mesh) = test_world().await.expect("world failed");
 
         let py_instance = PyInstance::from(&instance);
         let py_proc_mesh = PyProcMesh::new_owned(proc_mesh);
@@ -591,7 +591,7 @@ mod tests {
 
     #[tokio::test]
     async fn set_mode_behaviors() {
-        let (_proc, instance, host_mesh, proc_mesh) = test_world().await.expect("world failed");
+        let (_proc, instance, mut host_mesh, proc_mesh) = test_world().await.expect("world failed");
 
         let py_instance = PyInstance::from(&instance);
         let py_proc_mesh = PyProcMesh::new_owned(proc_mesh);
@@ -706,7 +706,7 @@ mod tests {
 
     #[tokio::test]
     async fn flush_behaviors() {
-        let (_proc, instance, host_mesh, proc_mesh) = test_world().await.expect("world failed");
+        let (_proc, instance, mut host_mesh, proc_mesh) = test_world().await.expect("world failed");
 
         let py_instance = PyInstance::from(&instance);
         let py_proc_mesh = PyProcMesh::new_owned(proc_mesh);


### PR DESCRIPTION
Summary:
In order to stop the remote process allocation, we need to call `Alloc::stop`, which is
done when the ProcMesh created from the allocation is itself stopped.
This should ensure jobs finish entirely.

Note that the Drop for ProcMesh and Drop for RemoteProcessAlloc both do not try to stop
the underlying allocation, which is why this is necessary.

Differential Revision: D87264086


