### PR TITLE
Bug in telemetry doesn't collect metrics

### DIFF
--- a/hyperactor_telemetry/src/lib.rs
+++ b/hyperactor_telemetry/src/lib.rs
@@ -649,7 +649,7 @@ pub fn initialize_logging_with_log_prefix(
             "logging_initialized"
         );
 
-        if is_layer_enabled(DISABLE_OTEL_METRICS) {
+        if !is_layer_disabled(DISABLE_OTEL_METRICS) {
             otel::init_metrics();
         }
     }


### PR DESCRIPTION
Summary: D87234372 missed a change in OTEL_METRICS disabling.

Reviewed By: dulinriley

Differential Revision: D87595448


