### PR TITLE
Add conda lib to static linker search path for builds

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -154,6 +154,10 @@ if sys.platform.startswith("linux"):
         "link-arg=-Wl,-rpath,$ORIGIN/../../..",
         "-C",
         "link-arg=-Wl,-rpath," + conda_lib,
+        # Add the conda lib to the search path for the linker, as libraries like
+        # libunwind may be installed there.
+        "-L",
+        conda_lib,
     ]
     if py_lib:
         flags += ["-C", "link-arg=-Wl,-rpath," + py_lib]


### PR DESCRIPTION
Summary:
Our install instructions say to use `conda install libunwind`, but the rust compiler
is unable to locate it.
Add a `-L` flag when building from within python to add the conda environment libraries.
This should help rust locate the libraries it needs.

Differential Revision: D87665225


