### PR TITLE
Allow disallowed time methods

### DIFF
--- a/hyperactor_telemetry/src/lib.rs
+++ b/hyperactor_telemetry/src/lib.rs
@@ -7,6 +7,7 @@
  */
 
 #![allow(internal_features)]
+#![allow(clippy::disallowed_methods)] // hyperactor_telemetry can't use hyperactor::clock::Clock (circular dependency)
 #![feature(assert_matches)]
 #![feature(sync_unsafe_cell)]
 #![feature(mpmc_channel)]


### PR DESCRIPTION
Summary: We disallow methods relating to time to ensure that we use `hyperactor::clock`, but need to make an exception for this for telemetry because we would create a circular dependency if we tried to use `hyperactor::clock`

Differential Revision: D87664116


