### PR TITLE
Set LocalAlloc's transport to be Local

### DIFF
--- a/hyperactor_mesh/src/alloc/local.rs
+++ b/hyperactor_mesh/src/alloc/local.rs
@@ -19,6 +19,7 @@ use hyperactor::ProcId;
 use hyperactor::WorldId;
 use hyperactor::channel;
 use hyperactor::channel::ChannelAddr;
+use hyperactor::channel::ChannelTransport;
 use hyperactor::mailbox::MailboxServer;
 use hyperactor::mailbox::MailboxServerHandle;
 use hyperactor::proc::Proc;
@@ -254,6 +255,10 @@ impl Alloc for LocalAlloc {
 
     fn spec(&self) -> &AllocSpec {
         &self.spec
+    }
+
+    fn transport(&self) -> ChannelTransport {
+        ChannelTransport::Local
     }
 
     fn extent(&self) -> &Extent {


### PR DESCRIPTION
Summary:
I notice channels served from `LocalAlloc` is using metatls. I guess that is because by default it gets the transport from the input spec, which contains metatls:

https://www.internalfb.com/code/fbsource/[056940bb1cd57f5dc7702498a081c26f58c1e7ba]/fbcode/monarch/hyperactor_mesh/src/alloc/local.rs?lines=132-133%2C150

This diffs explicitly set `LocalAlloc`'s transport to be `Local`, so it would not use the default impl, i.e. the spec's transport instead:

https://www.internalfb.com/code/fbsource/[f46af006d39e28c30ccd00afb81e576c995a831f]/fbcode/monarch/hyperactor_mesh/src/alloc.rs?lines=327%2C349-352

Differential Revision: D84851977


