### PR TITLE
: python/tests/test_actors.py: more contextmgr improvements

### DIFF
--- a/python/monarch/_rust_bindings/monarch_hyperactor/config.pyi
+++ b/python/monarch/_rust_bindings/monarch_hyperactor/config.pyi
@@ -38,8 +38,42 @@ def configure(
     tail_log_lines: int = ...,
     **kwargs: object,
 ) -> None:
-    """Change a configuration value in the global configuration. If called with
-    no arguments, makes no changes. Does not reset any configuration"""
+    """Configure Hyperactor runtime defaults for this process.
+
+    This updates the **runtime** configuration layer from Python,
+    setting the default channel transport and optional logging
+    behaviour (forwarding, file capture, and how many lines to tail).
+    """
     ...
 
-def get_configuration() -> Dict[str, Any]: ...
+def get_configuration() -> Dict[str, Any]:
+    """Return a snapshot of the current Hyperactor configuration.
+
+    The result is a plain dictionary view of the merged configuration
+    (defaults plus any overrides from environment or Python), useful
+    for debugging and tests.
+    """
+    ...
+
+def get_runtime_configuration() -> Dict[str, Any]:
+    """Return a snapshot of the Runtime layer configuration.
+
+    The Runtime layer contains only configuration values set from
+    Python via configure(). This returns only those Python-exposed
+    keys currently in the Runtime layer (not merged across all layers
+    like get_configuration).
+
+    This can be used to snapshot/restore Runtime state.
+    """
+    ...
+
+def clear_runtime_configuration() -> None:
+    """Clear all Runtime layer configuration overrides.
+
+    Safely removes all entries from the Runtime config layer. Since
+    the Runtime layer is exclusively populated via Python's
+    configure(), this will not affect configuration from environment
+    variables, config files, or built-in defaults.
+    """
+
+    ...


### PR DESCRIPTION
Summary: this refactors the python-side config helpers to make Runtime-layer overrides explicit and reversible, replaces the previous "restore from snapshot" approach with a clearer model that writes into the Runtime layer on entry and clears it on exit, and exposes a Rust-backed `clear()` to support that. the main functional change is adding `configured_with_redirected_stdio()`, which composes configuration overrides with stdio redirection in a single context manager so the tests don't need nested with blocks. all affected tests are updated to use the combined form, but the underlying logging behaviour is unchanged.

Differential Revision: D87795973


