### PR TITLE
Update workspace bootstrapping docs and comments

### DIFF
--- a/python/monarch/tools/config/workspace.py
+++ b/python/monarch/tools/config/workspace.py
@@ -35,7 +35,7 @@ class Workspace:
     This effectively one-time mirrors the local codebase and environment on the remote machines.
 
     Workspaces can also be sync'ed interactively on-demand (post job launch) by using
-    `monarch.actor.proc_mesh.ProcMesh.syncWorkspace(Workspace)`.
+    `monarch.actor.HostMesh.sync_workspace(Workspace)`.
 
     Usage:
 
@@ -90,7 +90,7 @@ class Workspace:
 
         # 4. disable project and environment sync
         config = Config(
-            workspace=Workspace(env=None),
+            workspace=Workspace.null(),
         )
     """
 


### PR DESCRIPTION
Summary:
* From V1, we provide HostMesh.sync_workspace
* Use the `Workspace` class instead of `str` in the bootstrap documentaiton

Reviewed By: jayasi

Differential Revision: D87802663


