### PR TITLE
Remove torch-op special call path in tensor engine

### DIFF
--- a/monarch_extension/src/convert.rs
+++ b/monarch_extension/src/convert.rs
@@ -330,21 +330,6 @@ fn create_map(py: Python) -> HashMap<u64, FnType> {
             to_stream: p.parseStreamRef("to_stream")?,
         })
     });
-    m.insert(key("CreatePipe"), |p| {
-        let function = p.parseFunction("function")?;
-        let args = p.parse("args")?;
-        let kwargs = p.parse("kwargs")?;
-        let (args, kwargs) = func_call_args_to_wire_values(Some(&function), &args, &kwargs)?;
-        Ok(WorkerMessage::CreatePipe {
-            result: p.parseRef("result")?,
-            key: p.parse("key")?,
-            function,
-            max_messages: p.parse("max_messages")?,
-            mesh: p.parseRef("device_mesh")?,
-            args,
-            kwargs,
-        })
-    });
     m.insert(key("SendValue"), |p|  {
             let function = p.parseOptionalFunction("function")?;
             let args: Bound<'_, PyTuple> = p.parse("args")?;

--- a/monarch_messages/src/wire_value.rs
+++ b/monarch_messages/src/wire_value.rs
@@ -171,110 +171,12 @@ impl From<PyObject> for WireValue {
     }
 }
 
-impl WireValue {
-    fn from_pyobject_with_torch_op_arg_type(
-        obj: Bound<'_, PyAny>,
-        type_: &torch_sys::call_op::TypePtr,
-        num_elements: i32,
-        allow_nums_as_tensors: bool,
-    ) -> PyResult<Self> {
-        if type_.is_tensor() || type_.is_optional_tensor() {
-            if type_.is_optional_tensor() && obj.is_none() {
-                return Ok(WireValue::None(()));
-            } else if let Ok(ref_) = Ref::from_py_object(&obj) {
-                return Ok(WireValue::Ref(ref_));
-            }
-        }
-        if type_.is_tensor_list() || type_.is_optional_tensor_list() {
-            if type_.is_optional_tensor_list() && obj.is_none() {
-                return Ok(WireValue::None(()));
-            }
-            let list = obj.downcast::<PyList>()?;
-            let len = list.len();
-            if len == 0 {
-                return Ok(WireValue::RefList(vec![]));
-            }
-            // SAFETY: We know it is within bounds
-            let item = unsafe { list.get_item_unchecked(0) };
-            if let Ok(ref_) = Ref::from_py_object(&item) {
-                let mut ref_list = Vec::with_capacity(len);
-                ref_list.push(ref_);
-                for item in list.iter().skip(1) {
-                    ref_list.push(Ref::from_py_object(&item).map_err(|_| {
-                        PyValueError::new_err(format!(
-                            "Expected homogeneous list of refs got: {:?}",
-                            list
-                        ))
-                    })?);
-                }
-                return Ok(WireValue::RefList(ref_list));
-            }
-        }
-        OpaqueIValue::from_py_object_with_type(obj, type_, num_elements, allow_nums_as_tensors)
-            .map(WireValue::IValue)
-    }
-}
-
 pub fn func_call_args_to_wire_values(
-    func: Option<&ResolvableFunction>,
+    _func: Option<&ResolvableFunction>,
     args: &Bound<'_, PyTuple>,
     kwargs: &Bound<'_, PyDict>,
 ) -> PyResult<(Vec<WireValue>, HashMap<String, WireValue>)> {
-    if let Some((op, overload)) = func.and_then(|func| func.as_torch_op()) {
-        torch_op_args_to_wire_values(&op, &overload, args, kwargs)
-    } else {
-        python_func_args_to_wire_value(args, kwargs)
-    }
-}
-
-fn torch_op_args_to_wire_values(
-    op: &str,
-    overload: &str,
-    args: &Bound<'_, PyTuple>,
-    kwargs: &Bound<'_, PyDict>,
-) -> PyResult<(Vec<WireValue>, HashMap<String, WireValue>)> {
-    let args_info = torch_sys::call_op::get_schema_args_info(op, overload).map_err(|err| {
-        PyValueError::new_err(format!(
-            "Failed to get the operator schema for {}::{}: {}",
-            op, overload, err
-        ))
-    })?;
-
-    let args = args
-        .iter()
-        .zip(&args_info)
-        .map(|(arg, arg_info)| {
-            WireValue::from_pyobject_with_torch_op_arg_type(
-                arg,
-                arg_info.type_,
-                arg_info.num_elements,
-                arg_info.allows_number_as_tensor,
-            )
-        })
-        .collect::<Result<Vec<_>, _>>()?;
-    let kwargs = kwargs
-        .iter()
-        .map(|(k, v)| {
-            let key = k.extract::<String>()?;
-            let arg_info = args_info
-                .iter()
-                .find(|arg_info| arg_info.name == key)
-                .ok_or_else(|| {
-                    PyValueError::new_err(format!(
-                        "Torch op {}::{} does not support kwarg {}",
-                        op, overload, key
-                    ))
-                })?;
-            let val = WireValue::from_pyobject_with_torch_op_arg_type(
-                v,
-                arg_info.type_,
-                arg_info.num_elements,
-                arg_info.allows_number_as_tensor,
-            )?;
-            Ok((key, val))
-        })
-        .collect::<Result<HashMap<_, _>, PyErr>>()?;
-    Ok((args, kwargs))
+    python_func_args_to_wire_value(args, kwargs)
 }
 
 fn python_func_args_to_wire_value(

--- a/monarch_messages/src/worker.rs
+++ b/monarch_messages/src/worker.rs
@@ -340,21 +340,6 @@ impl ResolvableFunction {
         }
     }
 
-    pub fn as_torch_op<'a>(&'a self) -> Option<(String, String)> {
-        match self {
-            Self::FunctionPath(func) => match func.path.split(".").collect::<Vec<_>>().as_slice() {
-                ["torch", "ops", namespace, op_name, "default"] => {
-                    Some((format!("{}::{}", namespace, op_name), String::new()))
-                }
-                ["torch", "ops", namespace, op_name, overload] => {
-                    Some((format!("{}::{}", namespace, op_name), overload.to_string()))
-                }
-                _ => None,
-            },
-            _ => None,
-        }
-    }
-
     /// For testing: this is a special remote function path that induces a panic
     /// when called.
     pub fn panic_if_requested(&self) {
@@ -365,13 +350,6 @@ impl ResolvableFunction {
                 }
             }
             _ => (),
-        }
-    }
-
-    pub fn supports_pytree_args(&self) -> bool {
-        match self {
-            Self::Cloudpickle(_) => true,
-            Self::FunctionPath(_) => self.as_torch_op().is_none(),
         }
     }
 }
@@ -798,16 +776,6 @@ pub enum WorkerMessage {
         factory: Factory,
         from_stream: StreamRef,
         to_stream: StreamRef,
-    },
-
-    CreatePipe {
-        result: Ref,
-        key: String,
-        function: ResolvableFunction,
-        max_messages: i64,
-        mesh: Ref,
-        args: Vec<WireValue>,
-        kwargs: HashMap<String, WireValue>,
     },
 
     SendValue {

--- a/monarch_tensor_worker/src/lib.rs
+++ b/monarch_tensor_worker/src/lib.rs
@@ -79,7 +79,6 @@ use monarch_messages::worker::StreamRef;
 use monarch_messages::worker::WorkerMessage;
 use monarch_messages::worker::WorkerMessageHandler;
 use monarch_messages::worker::WorkerParams;
-use monarch_types::PyTree;
 use ndslice::Slice;
 use pyo3::Python;
 use pyo3::types::PyAnyMethods;
@@ -92,7 +91,6 @@ use stream::StreamParams;
 use torch_sys::CudaDevice;
 use torch_sys::DeviceIndex;
 use torch_sys::Layout;
-use torch_sys::RValue;
 use torch_sys::ScalarType;
 use torch_sys::TensorCell;
 use torch_sys::factory_zeros;
@@ -383,14 +381,10 @@ impl WorkerMessageHandler for WorkerActor {
         self.maybe_add_stream_to_recording(cx, params.stream)
             .await?;
 
-        let device_meshes = if params.function.as_torch_op().is_some() {
-            HashMap::new()
-        } else {
-            self.device_meshes
-                .iter()
-                .map(|(k, v)| (k.clone(), v.0.clone()))
-                .collect()
-        };
+        let device_meshes = self.device_meshes
+            .iter()
+            .map(|(k, v)| (k.clone(), v.0.clone()))
+            .collect();
 
         let mut remote_process_groups = HashMap::new();
         for remote_process_group_ref in &params.remote_process_groups {
@@ -638,22 +632,6 @@ impl WorkerMessageHandler for WorkerActor {
         Ok(())
     }
 
-    async fn create_pipe(
-        &mut self,
-        _cx: &hyperactor::Context<Self>,
-        _result: Ref,
-        // TODO(agallagher): This is used in the python impl to name the socket
-        // path to use for comms, but we don't currently use a named socket.
-        _key: String,
-        _function: ResolvableFunction,
-        _max_messages: i64,
-        _device_mesh: Ref,
-        _args: Vec<WireValue>,
-        _kwargs: HashMap<String, WireValue>,
-    ) -> Result<()> {
-        panic!("create_pipe is no longer implemented")
-    }
-
     async fn send_tensor(
         &mut self,
         cx: &hyperactor::Context<Self>,
@@ -772,7 +750,7 @@ impl WorkerMessageHandler for WorkerActor {
         // Resolve the stream.
         let stream = self.try_get_stream(stream)?;
 
-        let device_meshes = if function.as_ref().is_none_or(|f| f.as_torch_op().is_some()) {
+        let device_meshes = if function.is_none() {
             HashMap::new()
         } else {
             self.device_meshes


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #1986
* #1975

This is part of the work to remove a direct libtorch dependency. We now just route through python. A few months ago we tested that this is not slower because of so much wrapping/unwrapping to python objects anyway. We can re-enable faster execution in the future if needed.

Differential Revision: [D87807456](https://our.internmc.facebook.com/intern/diff/D87807456/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D87807456/)!