### PR TITLE
Log to monarch_executions directly

### DIFF
--- a/hyperactor_telemetry/src/lib.rs
+++ b/hyperactor_telemetry/src/lib.rs
@@ -650,6 +650,7 @@ pub fn initialize_logging_with_log_prefix(
             tracing::debug!("logging already initialized for this process: {}", err);
         }
         let exec_id = env::execution_id();
+        // setting target to "execution" will prevent the monarch_tracing scuba client from logging this
         tracing::info!(
             target: "execution",
             execution_id = exec_id,
@@ -664,6 +665,20 @@ pub fn initialize_logging_with_log_prefix(
             upstream_revision = build_info::BuildInfo::get_upstream_revision(),
             revision = build_info::BuildInfo::get_revision(),
             "logging_initialized"
+        );
+        // here we have the monarch_executions scuba client log
+        meta::log_execution_event(
+            &exec_id,
+            &Env::current().to_string(),
+            std::env::args().collect(),
+            build_info::BuildInfo::get_build_mode(),
+            build_info::BuildInfo::get_compiler(),
+            build_info::BuildInfo::get_compiler_version(),
+            build_info::BuildInfo::get_rule(),
+            build_info::BuildInfo::get_package_name(),
+            build_info::BuildInfo::get_package_release(),
+            build_info::BuildInfo::get_upstream_revision(),
+            build_info::BuildInfo::get_revision(),
         );
 
         if !is_layer_disabled(DISABLE_OTEL_METRICS) {


### PR DESCRIPTION
Summary: Each process only logs to monarch_executions once at the beginning of the  execution so there is no need to add a scuba client that logs to this table into our tracing subscriber

Reviewed By: vidhyav

Differential Revision: D87664117
