### PR TITLE
Shutdown NetTx stream when it exits

### DIFF
--- a/hyperactor/src/channel/net.rs
+++ b/hyperactor/src/channel/net.rs
@@ -1086,11 +1086,12 @@ mod tests {
         assert!(rx.await.is_err());
     }
 
-    #[tracing_test::traced_test]
-    #[tokio::test]
+    #[async_timed_test(timeout_secs = 60)]
     // TODO: OSS: failed to retrieve ipv6 address
     #[cfg_attr(not(fbcode_build), ignore)]
     async fn test_meta_tls_basic() {
+        hyperactor_telemetry::initialize_logging_for_test();
+
         let addr = ChannelAddr::any(ChannelTransport::MetaTls(TlsMode::IpV6));
         let meta_addr = match addr {
             ChannelAddr::MetaTls(meta_addr) => meta_addr,


### PR DESCRIPTION
Summary:
We currently do not explicitly close `NetTx`'s write stream when it exits, as a result, we will see the following log on the `NetRx` side when using `MetaTls`:

```
[-]I1124 14:09:27.934423 629996 fbcode/monarch/hyperactor/src/channel/net/server.rs:592] error processing peer connection, source:tcp:[2401:db00:eef0:1120:3520:0:6c09:3cba]:57588, dest:metatls:devvm16922.vll0.facebook.com:35865, error:session metatls:devvm16922.vll0.facebook.com:35865.18243036951658569703<-tcp:[2401:db00:eef0:1120:3520:0:6c09:3cba]:57588: reading into Frame with M = u64

Caused by:
    peer closed connection without sending TLS close_notify: https://docs.rs/rustls/latest/rustls/manual/_03_howto/index.html#unexpected-eof
```

This diff fixes that.

Differential Revision: D87823699


