### PR TITLE
: config: straighten out naming

### DIFF
--- a/python/monarch/_rust_bindings/monarch_hyperactor/config.pyi
+++ b/python/monarch/_rust_bindings/monarch_hyperactor/config.pyi
@@ -42,11 +42,15 @@ def configure(
 
     This updates the **runtime** configuration layer from Python,
     setting the default channel transport and optional logging
-    behaviour (forwarding, file capture, and how many lines to tail).
+    behaviour (forwarding, file capture, and how many lines to tail),
+    plus any additional CONFIG-marked keys passed via **kwargs.
+
+    Historically this API is named ``configure(...)``; conceptually it
+    acts as "set runtime config for this process".
     """
     ...
 
-def get_configuration() -> Dict[str, Any]:
+def get_global_config() -> Dict[str, Any]:
     """Return a snapshot of the current Hyperactor configuration.
 
     The result is a plain dictionary view of the merged configuration
@@ -55,24 +59,24 @@ def get_configuration() -> Dict[str, Any]:
     """
     ...
 
-def get_runtime_configuration() -> Dict[str, Any]:
+def get_runtime_config() -> Dict[str, Any]:
     """Return a snapshot of the Runtime layer configuration.
 
     The Runtime layer contains only configuration values set from
     Python via configure(). This returns only those Python-exposed
     keys currently in the Runtime layer (not merged across all layers
-    like get_configuration).
+    like `get_global_config()`).
 
     This can be used to snapshot/restore Runtime state.
     """
     ...
 
-def clear_runtime_configuration() -> None:
+def clear_runtime_config() -> None:
     """Clear all Runtime layer configuration overrides.
 
     Safely removes all entries from the Runtime config layer. Since
     the Runtime layer is exclusively populated via Python's
-    configure(), this will not affect configuration from environment
+    `configure()`, this will not affect configuration from environment
     variables, config files, or built-in defaults.
     """
 


### PR DESCRIPTION
Summary:
this diff follows up on mariusae's [comment in D87795973](https://www.internalfb.com/diff/D87795973?dst_version_fbid=861202266855169&transaction_fbid=1244851620803763) and completes the cleanup he hinted at. the main change is to make the Python-owned "Runtime" layer an explicit, coherent concept throughout the module. the Rust helpers are renamed (`*_py`, `configure_kwarg`, etc.) so their roles are unambiguous, and the documentation now reflects the actual data flow: `configure(**kwargs)` writes only into `Source::Runtime`, while `get_global_config` and `get_runtime_config` clearly separate merged vs. layer-local views.

on the Python side, the API surface is aligned with these semantics. the `configured(...)` context manager (the 'test_config.py' version) is rewritten to snapshot and restore only the Runtime layer instead of resetting global config, which makes overrides composable while continuing to prevent state leakage across tests. the .pyi file is updated to document the layered model and the historical naming of `configure(...)`.

this diff further formalizes the contract implied by the earlier code: Python exclusively owns the Runtime layer, and all read/write paths now reflect that consistently in naming, behavior, and documentation.

Differential Revision: D87866946


