### PR TITLE
bump ruff packages

### DIFF
--- a/hyperactor/Cargo.toml
+++ b/hyperactor/Cargo.toml
@@ -58,7 +58,7 @@ humantime = "2.1"
 hyperactor_macros = { version = "0.0.0", path = "../hyperactor_macros" }
 hyperactor_telemetry = { version = "0.0.0", path = "../hyperactor_telemetry" }
 indenter = "0.3.3"
-inventory = "0.3.8"
+inventory = "0.3.21"
 lazy_static = "1.5"
 local-ip-address = "0.5.3"
 ndslice = { version = "0.0.0", path = "../ndslice" }

--- a/monarch_hyperactor/Cargo.toml
+++ b/monarch_hyperactor/Cargo.toml
@@ -35,7 +35,7 @@ hyperactor = { version = "0.0.0", path = "../hyperactor" }
 hyperactor_mesh = { version = "0.0.0", path = "../hyperactor_mesh" }
 hyperactor_multiprocess = { version = "0.0.0", path = "../hyperactor_multiprocess" }
 hyperactor_telemetry = { version = "0.0.0", path = "../hyperactor_telemetry" }
-inventory = "0.3.8"
+inventory = "0.3.21"
 lazy_errors = "0.10.1"
 lazy_static = "1.5"
 libc = "0.2.139"


### PR DESCRIPTION
Summary:
Need to pull in a ruff parser change to fix https://github.com/facebook/pyrefly/issues/1559

This requires a bump for the `inventory` crate, since ruff requires 0.3.20/0.3.21. That version is semver compatible with 0.3.8, so we can't keep both versions around.

Reviewed By: dtolnay

Differential Revision: D87817697
