### PR TITLE
Update TORCH_VERSION_NEWER_THAN condition

### DIFF
--- a/python/monarch/gradient/_gradient_generator.cpp
+++ b/python/monarch/gradient/_gradient_generator.cpp
@@ -426,7 +426,7 @@ struct GradientGenerator {
     DEBUG_PRINT(
         "// add: " << node->node->name()
                    << ", input_nr=" << static_cast<int>(input_nr) << "\n");
-#if TORCH_VERSION_NEWER_THAN(2, 8, 0)
+#if TORCH_VERSION_NEWER_THAN(2, 9, 1)
     realInputBuffer(node).add(
         input_nr,
         check_and_reduce(node->node, input_nr, std::move(t)),


### PR DESCRIPTION
Even PyTorch 2.9.1 has the 4-argument version of this API: https://github.com/pytorch/pytorch/blob/d38164a545b4a4e4e0cf73ce67173f70574890b6/torch/csrc/autograd/input_buffer.h#L31

Relates to https://github.com/meta-pytorch/monarch/pull/1768/files#r2561710699 

Not sure if the #if block was tested on PyTorch2.9.