### PR TITLE
[ROCm][CI] First draft of ROCm build workflow

### DIFF
--- a/.github/workflows/build-rocm.yml
+++ b/.github/workflows/build-rocm.yml
@@ -18,7 +18,7 @@ permissions:
 jobs:
   build-rocm:
     name: Build ROCm (rocm6.4-py3.10)
-    uses: jithunnair-amd/test-infra/.github/workflows/linux_job_v2.yml@patch-5
+    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
     strategy:
       fail-fast: true
       matrix:


### PR DESCRIPTION
This PR introduces a new build workflow for ROCm

* Uses ROCm6.4 PyTorch 2.9.1 wheels to match the bare metal environment on ROCm runners (will switch to PyTorch nightly wheels in a follow-up PR)
* ROCm6.4 almalinux image has devtoolset-14, so need the PATH setting for that since rust needs a new enough compiler
* Set `USE_TENSOR_ENGINE=0` to disable rust errors when building cuda-sys, nccl-sys etc.
* The eventual goal is to invoke this from `ci.yml`. We also enabled the `ciflow/rocm` label-based trigger mechanism for this repo (similar to how we do on pytorch/pytorch), so that we can test this workflow on the PR itself (a `pull_request` trigger will not work to test on the PR because the AWS OIDC step will fail on a forked repo branch).

Depends on https://github.com/meta-pytorch/monarch/pull/2000, https://github.com/meta-pytorch/monarch/pull/2032, and https://github.com/pytorch/test-infra/pull/7650