### PR TITLE
Close NetRx write stream on exit

### DIFF
--- a/hyperactor/src/channel/net/framed.rs
+++ b/hyperactor/src/channel/net/framed.rs
@@ -373,6 +373,21 @@ impl<W: AsyncWrite + Unpin, F: Buf, T> WriteState<W, F, T> {
             Self::Broken => panic!("illegal state"),
         }
     }
+
+    /// Consume the state and return the underlying writer, if the
+    /// stream is not broken.
+    ///
+    /// For `Idle`, this returns the stored writer. For `Writing`,
+    /// this assumes no more frames will be sent and calls
+    /// `complete()` to recover the writer. For `Broken`, this returns
+    /// `None`.
+    pub fn into_writer(self) -> Option<W> {
+        match self {
+            Self::Idle(w) => Some(w),
+            Self::Writing(w, _) => Some(w.complete()),
+            Self::Broken => None,
+        }
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Summary:
Currently, when `NetRx` exits, it does not close the write stream gracefully. Since `NetTx` is listening to this write stream for the ack messages, NetTx will see an `close_notify` error, and generate a log like this:

> [-]E1125 06:50:46.476994 518989 fbcode/monarch/hyperactor/src/channel/net/client.rs:988] [net i/o loop{session:metatls:2401:db00:eef0:1120:3520:0:6c09:3cba:44243.17588939158573269181, connected:true, next_seq:2, largest_acked:AckedSeq { seq: 0, timestamp: "2s 805us 589ns" }, outbox:QueueValue::NonEmpty { len: 1, num_bytes_queued: 20, front: QueueEntryValue { seq: 1, since_received: ("817us 855ns",), since_sent: () }, back: QueueEntryValue { seq: 1, since_received: ("821us 911ns",), since_sent: () } }, unacked:QueueValue::Empty}] failed while receiving ack, dest:metatls:2401:db00:eef0:1120:3520:0:6c09:3cba:44243, session_id:17588939158573269181, error:peer closed connection without sending TLS close_notify: https://docs.rs/rustls/latest/rustls/manual/_03_howto/index.html#unexpected-eof

This diff fixes that.

Differential Revision: D87863524


