### PR TITLE
Use RejectConn enum instead of bool

### DIFF
--- a/hyperactor/src/channel/net.rs
+++ b/hyperactor/src/channel/net.rs
@@ -108,7 +108,8 @@ enum Frame<M> {
 #[derive(Debug, Serialize, Deserialize, EnumAsInner)]
 enum NetRxResponse {
     Ack(u64),
-    Reject,
+    /// This channel is closed with the given reason. NetTx should stop reconnecting.
+    Reject(String),
 }
 
 fn serialize_response(response: NetRxResponse) -> Result<Bytes, bincode::Error> {
@@ -2357,7 +2358,7 @@ mod tests {
             let (_reader, writer) = take_receiver(&receiver_storage).await;
             let _ = FrameWrite::write_frame(
                 writer,
-                serialize_response(NetRxResponse::Reject).unwrap(),
+                serialize_response(NetRxResponse::Reject("testing".to_string())).unwrap(),
                 1024,
             )
             .await

--- a/hyperactor/src/channel/net/client.rs
+++ b/hyperactor/src/channel/net/client.rs
@@ -941,8 +941,8 @@ where
                                             unacked.prune(ack, RealClock.now(), &link.dest(), session_id);
                                             (State::Running(Deliveries { outbox, unacked }), Conn::Connected { reader, write_state })
                                         }
-                                        NetRxResponse::Reject => {
-                                            let error_msg = "server rejected connection";
+                                        NetRxResponse::Reject(reason) => {
+                                            let error_msg = format!("server rejected connection due to: {reason}");
                                             tracing::error!(
                                                         dest = %link.dest(),
                                                         session_id = session_id,


### PR DESCRIPTION
Summary: `bool` makes it difficult to find where do we return `true`. Using a enum would solve this problem.

Differential Revision: D87867373


