### PR TITLE
: port v0 multi-process test to v1

### DIFF
--- a/hyperactor_multiprocess/src/proc_actor.rs
+++ b/hyperactor_multiprocess/src/proc_actor.rs
@@ -1002,13 +1002,15 @@ mod tests {
         }
     }
 
-    // V0 test - V1 needs equivalent coverage. Tests graceful stop
+    // V0 test - V1 has equivalent coverage. Tests graceful stop
     // behavior where responsive actors stop cleanly within timeout.
     // Spawns 4 TestActors, calls stop() with 1-second timeout,
     // verifies all actors stop gracefully (5 stopped, 1 aborted). V1
-    // uses the same underlying mechanism (Proc::destroy_and_wait) but
-    // ActorMesh::stop() currently has no test coverage verifying stop
-    // succeeds and actors reach terminal state.
+    // equivalent:
+    // hyperactor_mesh/src/v1/actor_mesh.rs::test_actor_mesh_stop_graceful.
+    // Both use the same underlying mechanism (Proc::destroy_and_wait),
+    // but V1 returns Ok() for clean stop vs V0's ProcStopResult with
+    // counts.
     #[tokio::test]
     async fn test_stop() {
         // Show here that the proc actors are stopped when the proc


### PR DESCRIPTION
Summary: port graceful-stop coverage from hyperactor_multiprocess into the v1 mesh layer. this adds `actor_mesh::test_actor_mesh_stop_graceful`, which spawns responsive `TestActor`s across a proc mesh, calls `stop()`, and verifies that the operation completes quickly and returns `Ok` — the V1 analogue of V0's test_stop. both paths use the same underlying mechanism (`Proc::destroy_and_wait`), but V1 reports a simple success instead of V0's structured `ProcStopResult`, so the V0 test is re-documented to point at the new V1 coverage and note the API difference.

Differential Revision: D87933475


