### PR TITLE
update regex crate: 1.11.1 -> 1.12.2

### DIFF
--- a/hyperactor/Cargo.toml
+++ b/hyperactor/Cargo.toml
@@ -67,7 +67,7 @@ opentelemetry = "0.29"
 paste = "1.0.14"
 rand = { version = "0.8", features = ["small_rng"] }
 rand_distr = "0.4"
-regex = "1.11.1"
+regex = "1.12.2"
 rustls-pemfile = "1.0.0"
 serde = { version = "1.0.219", features = ["derive", "rc"] }
 serde_json = { version = "1.0.140", features = ["alloc", "float_roundtrip", "raw_value", "unbounded_depth"] }

--- a/hyperactor_multiprocess/Cargo.toml
+++ b/hyperactor_multiprocess/Cargo.toml
@@ -30,7 +30,7 @@ tracing = { version = "0.1.41", features = ["attributes", "valuable"] }
 [dev-dependencies]
 maplit = "1.0"
 rand = { version = "0.8", features = ["small_rng"] }
-regex = "1.11.1"
+regex = "1.12.2"
 serde_json = { version = "1.0.140", features = ["alloc", "float_roundtrip", "raw_value", "unbounded_depth"] }
 timed_test = { version = "0.0.0", path = "../timed_test" }
 tracing-test = { version = "0.2.3", features = ["no-env-filter"] }

--- a/monarch_rdma/Cargo.toml
+++ b/monarch_rdma/Cargo.toml
@@ -18,7 +18,7 @@ futures = { version = "0.3.31", features = ["async-await", "compat"] }
 hyperactor = { version = "0.0.0", path = "../hyperactor" }
 rand = { version = "0.8", features = ["small_rng"] }
 rdmaxcel-sys = { path = "../rdmaxcel-sys" }
-regex = "1.11.1"
+regex = "1.12.2"
 serde = { version = "1.0.219", features = ["derive", "rc"] }
 tracing = { version = "0.1.41", features = ["attributes", "valuable"] }
 

--- a/torch-sys/Cargo.toml
+++ b/torch-sys/Cargo.toml
@@ -20,7 +20,7 @@ monarch_types = { version = "0.0.0", path = "../monarch_types" }
 nccl-sys = { path = "../nccl-sys", optional = true }
 paste = "1.0.14"
 pyo3 = { version = "0.24", features = ["anyhow", "multiple-pymethods", "py-clone"] }
-regex = "1.11.1"
+regex = "1.12.2"
 serde = { version = "1.0.219", features = ["derive", "rc"] }
 thiserror = "2.0.12"
 tokio = { version = "1.47.1", features = ["full", "test-util", "tracing"] }


### PR DESCRIPTION
Summary:
Primarily updating for https://docs.rs/regex/latest/regex/struct.Captures.html#method.get_match to avoid explicit `unwrap()` in production code

https://github.com/rust-lang/regex/blob/master/CHANGELOG.md

Differential Revision: D87950658


