### PR TITLE
Update cranelift / yara-x / aho-corasick crates (fixes RUSTSEC-2025-0118)

### DIFF
--- a/monarch_conda/Cargo.toml
+++ b/monarch_conda/Cargo.toml
@@ -16,7 +16,7 @@ path = "src/main.rs"
 edition = "2024"
 
 [dependencies]
-aho-corasick = "1.1.3"
+aho-corasick = "1.1.4"
 anyhow = "1.0.98"
 async-tempfile = "0.7.0"
 bincode = "1.3.3"


### PR DESCRIPTION
Summary: The goal of this diff is get rid of old versions os wasmtime for which open RUSTSECs exists. We do this transitively by updating the crates that depend on those versions.

Reviewed By: dtolnay

Differential Revision: D87987008
