### PR TITLE
Migrate telemetry over to hyperactor_config

### DIFF
--- a/hyperactor_telemetry/Cargo.toml
+++ b/hyperactor_telemetry/Cargo.toml
@@ -14,8 +14,10 @@ edition = "2024"
 anyhow = "1.0.98"
 chrono = { version = "0.4.41", features = ["clock", "serde", "std"], default-features = false }
 dashmap = { version = "5.5.3", features = ["rayon", "serde"] }
+erased-serde = "0.4.9"
 fbinit = { version = "0.2.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main" }
 hdrhistogram = "7.5"
+hyperactor_config = { version = "0.0.0", path = "../hyperactor_config" }
 lazy_static = "1.5"
 opentelemetry = "0.29"
 opentelemetry_sdk = { version = "0.29.0", features = ["rt-tokio"] }

--- a/hyperactor_telemetry/src/config.rs
+++ b/hyperactor_telemetry/src/config.rs
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+//! Configuration keys for hyperactor telemetry.
+//!
+//! This module defines configuration attributes for telemetry features including
+//! OpenTelemetry tracing/metrics, recorder output, SQLite tracing, and file logging.
+
+use std::time::Duration;
+
+use hyperactor_config::CONFIG;
+use hyperactor_config::ConfigAttr;
+use hyperactor_config::attrs::declare_attrs;
+
+declare_attrs! {
+    /// Enable the OpenTelemetry tracing layer.
+    /// When true (default), OpenTelemetry tracing is enabled.
+    @meta(CONFIG = ConfigAttr {
+        env_name: Some("ENABLE_OTEL_TRACING".to_string()),
+        py_name: Some("enable_otel_tracing".to_string()),
+    })
+    pub attr ENABLE_OTEL_TRACING: bool = true;
+
+    /// Enable the OpenTelemetry metrics layer.
+    /// When true (default), OpenTelemetry metrics are enabled.
+    @meta(CONFIG = ConfigAttr {
+        env_name: Some("ENABLE_OTEL_METRICS".to_string()),
+        py_name: Some("enable_otel_metrics".to_string()),
+    })
+    pub attr ENABLE_OTEL_METRICS: bool = true;
+
+    /// Enable the recorder tracing layer.
+    /// When true (default), recorder output is enabled.
+    @meta(CONFIG = ConfigAttr {
+        env_name: Some("ENABLE_RECORDER_TRACING".to_string()),
+        py_name: Some("enable_recorder_tracing".to_string()),
+    })
+    pub attr ENABLE_RECORDER_TRACING: bool = true;
+
+    /// Enable the SQLite tracing layer.
+    /// When true, SQLite tracing is enabled.
+    @meta(CONFIG = ConfigAttr {
+        env_name: Some("ENABLE_SQLITE_TRACING".to_string()),
+        py_name: Some("enable_sqlite_tracing".to_string()),
+    })
+    pub attr ENABLE_SQLITE_TRACING: bool = false;
+
+    /// Log level for Monarch file logging.
+    /// Valid values: "debug", "info", "warn", "error"
+    /// Defaults to "info" when not set via environment variable.
+    @meta(CONFIG = ConfigAttr {
+        env_name: Some("MONARCH_FILE_LOG".to_string()),
+        py_name: Some("file_log_level".to_string()),
+    })
+    pub attr MONARCH_FILE_LOG_LEVEL: String;
+
+    /// OpenTelemetry metric export interval.
+    @meta(CONFIG = ConfigAttr {
+        env_name: Some("OTEL_METRIC_EXPORT_INTERVAL".to_string()),
+        py_name: Some("otel_metric_export_interval".to_string()),
+    })
+    pub attr OTEL_METRIC_EXPORT_INTERVAL: Duration = Duration::from_secs(10);
+
+    /// Enable logging of span enter/exit events to Scuba.
+    @meta(CONFIG = ConfigAttr {
+        env_name: Some("SCUBA_LOG_ENTER_EXIT".to_string()),
+        py_name: Some("scuba_log_enter_exit".to_string()),
+    })
+    pub attr SCUBA_LOG_ENTER_EXIT: bool = false;
+}

--- a/hyperactor_telemetry/src/lib.rs
+++ b/hyperactor_telemetry/src/lib.rs
@@ -15,27 +15,7 @@
 #![feature(formatting_options)]
 #![recursion_limit = "256"]
 
-// TODO:ehedeman Remove or replace with better config once telemetry perf issues are solved
-/// Environment variable to disable the OpenTelemetry logging layer.
-/// Set to "1" to disable OpenTelemetry  tracing.
-pub const DISABLE_OTEL_TRACING: &str = "DISABLE_OTEL_TRACING";
-
-/// Environment variable to disable the OpenTelemetry logging layer.
-/// Set to "1" to disable OpenTelemetry metrics.
-pub const DISABLE_OTEL_METRICS: &str = "DISABLE_OTEL_METRICS";
-
-/// Environment variable to disable the recorder logging layer.
-/// Set to "1" to disable the recorder output.
-pub const DISABLE_RECORDER_TRACING: &str = "DISABLE_RECORDER_TRACING";
-
-/// Environment variable to enable the sqlite logging layer.
-/// Set to "1" to enable the sqlite tracing.
-pub const ENABLE_SQLITE_TRACING: &str = "ENABLE_SQLITE_TRACING";
-
-/// Environment variable constants
-// Log level (debug, info, warn, error, critical) to capture for Monarch traces on dedicated log file (changes based on environment, see `log_file_path`).
-const MONARCH_FILE_LOG_ENV: &str = "MONARCH_FILE_LOG";
-
+// Environment variable for job name (used for environment detection)
 pub const MAST_HPC_JOB_NAME_ENV: &str = "MAST_HPC_JOB_NAME";
 
 // Log level constants
@@ -70,6 +50,7 @@ const ENV_VALUE_LOCAL_MAST_SIMULATOR: &str = "local_mast_simulator";
 // pub const skip_record: tracing::field::Empty = tracing::field::Empty;
 pub const skip_record: bool = true;
 
+mod config;
 pub mod in_memory_reader;
 #[cfg(fbcode_build)]
 mod meta;
@@ -109,6 +90,11 @@ use tracing_subscriber::fmt::FormatFields;
 use tracing_subscriber::fmt::format::Writer;
 use tracing_subscriber::registry::LookupSpan;
 
+use crate::config::ENABLE_OTEL_METRICS;
+use crate::config::ENABLE_OTEL_TRACING;
+use crate::config::ENABLE_RECORDER_TRACING;
+use crate::config::ENABLE_SQLITE_TRACING;
+use crate::config::MONARCH_FILE_LOG_LEVEL;
 use crate::recorder::Recorder;
 use crate::sqlite::get_reloadable_sqlite_layer;
 
@@ -604,12 +590,14 @@ pub fn initialize_logging_with_log_prefix(
         .with_ansi(false)
         .with_filter(
             Targets::new()
-                .with_default(LevelFilter::from_level(
-                    tracing::Level::from_str(
-                        &std::env::var(MONARCH_FILE_LOG_ENV).unwrap_or(file_log_level.to_string()),
-                    )
-                    .expect("Invalid log level"),
-                ))
+                .with_default(LevelFilter::from_level({
+                    let log_level_str =
+                        hyperactor_config::global::try_get_cloned(MONARCH_FILE_LOG_LEVEL)
+                            .unwrap_or_else(|| file_log_level.to_string());
+                    tracing::Level::from_str(&log_level_str).unwrap_or_else(|_| {
+                        tracing::Level::from_str(file_log_level).expect("Invalid default log level")
+                    })
+                }))
                 .with_target("opentelemetry", LevelFilter::OFF), // otel has some log span under debug that we don't care about
         );
 
@@ -619,28 +607,21 @@ pub fn initialize_logging_with_log_prefix(
 
     #[cfg(fbcode_build)]
     {
-        use crate::env::Env;
-        fn is_layer_enabled(env_var: &str) -> bool {
-            std::env::var(env_var).unwrap_or_default() == "1"
-        }
-        fn is_layer_disabled(env_var: &str) -> bool {
-            std::env::var(env_var).unwrap_or_default() == "1"
-        }
         if let Err(err) = Registry::default()
-            .with(if is_layer_enabled(ENABLE_SQLITE_TRACING) {
+            .with(if hyperactor_config::global::get(ENABLE_SQLITE_TRACING) {
                 // TODO: get_reloadable_sqlite_layer currently still returns None,
                 // and some additional work is required to make it work.
                 Some(get_reloadable_sqlite_layer().expect("failed to create sqlite layer"))
             } else {
                 None
             })
-            .with(if !is_layer_disabled(DISABLE_OTEL_TRACING) {
+            .with(if hyperactor_config::global::get(ENABLE_OTEL_TRACING) {
                 Some(otel::tracing_layer())
             } else {
                 None
             })
             .with(file_layer)
-            .with(if !is_layer_disabled(DISABLE_RECORDER_TRACING) {
+            .with(if hyperactor_config::global::get(ENABLE_RECORDER_TRACING) {
                 Some(recorder().layer())
             } else {
                 None
@@ -654,7 +635,7 @@ pub fn initialize_logging_with_log_prefix(
         tracing::info!(
             target: "execution",
             execution_id = exec_id,
-            environment = %Env::current(),
+            environment = %env::Env::current(),
             args = ?std::env::args(),
             build_mode = build_info::BuildInfo::get_build_mode(),
             compiler = build_info::BuildInfo::get_compiler(),
@@ -669,7 +650,7 @@ pub fn initialize_logging_with_log_prefix(
         // here we have the monarch_executions scuba client log
         meta::log_execution_event(
             &exec_id,
-            &Env::current().to_string(),
+            &env::Env::current().to_string(),
             std::env::args().collect(),
             build_info::BuildInfo::get_build_mode(),
             build_info::BuildInfo::get_compiler(),
@@ -681,7 +662,7 @@ pub fn initialize_logging_with_log_prefix(
             build_info::BuildInfo::get_revision(),
         );
 
-        if !is_layer_disabled(DISABLE_OTEL_METRICS) {
+        if hyperactor_config::global::get(ENABLE_OTEL_METRICS) {
             otel::init_metrics();
         }
     }
@@ -689,13 +670,11 @@ pub fn initialize_logging_with_log_prefix(
     {
         if let Err(err) = Registry::default()
             .with(file_layer)
-            .with(
-                if std::env::var(DISABLE_RECORDER_TRACING).unwrap_or_default() != "1" {
-                    Some(recorder().layer())
-                } else {
-                    None
-                },
-            )
+            .with(if hyperactor_config::global::get(ENABLE_RECORDER_TRACING) {
+                Some(recorder().layer())
+            } else {
+                None
+            })
             .try_init()
         {
             tracing::debug!("logging already initialized for this process: {}", err);


### PR DESCRIPTION
Summary:
We've long wanted to use `Config`/`attrs` for configuring `hyperactor_telemetry` but we could not due to a circular dependency `hyperactor` -> `hyperactor_telemetry` -> `hyperactor`.

Earlier in the stack we refactor `Config` into it's own crate `hyperactor_config` that is free of `hyperactor`

Differential Revision: D87941211
