### PR TITLE
Allow manual trigger for Github CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch: # Allows manual triggering
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.run_number || github.ref }}


### PR DESCRIPTION
Summary:
Allow triggering a Github CI job manually instead of only on pull requests + push.
This way we can retry at any given commit easily.

Differential Revision: D88086665


