### PR TITLE
Add torch-requirements file for the nightly version

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,8 +102,7 @@ conda update -n monarchenv --all -c conda-forge -y
 sudo dnf install -y libibverbs rdma-core libmlx5 libibverbs-devel rdma-core-devel
 
 # Install build dependencies
-pip install --pre torch --index-url https://download.pytorch.org/whl/nightly/cu128
-pip install -r build-requirements.txt
+pip install -r torch-requirements.txt -r build-requirements.txt
 # Install test dependencies
 pip install -r python/tests/requirements.txt
 
@@ -142,8 +141,7 @@ export CXX=clang++
 sudo apt install -y cuda-toolkit-12-8 cuda-12-8
 
 # Install build dependencies
-pip install --pre torch --index-url https://download.pytorch.org/whl/nightly/cu128
-pip install -r build-requirements.txt
+pip install -r torch-requirements.txt -r build-requirements.txt
 # Install test dependencies
 pip install -r python/tests/requirements.txt
 

--- a/build-requirements.txt
+++ b/build-requirements.txt
@@ -1,4 +1,3 @@
-torch
 setuptools
 setuptools-rust
 wheel

--- a/torch-requirements.txt
+++ b/torch-requirements.txt
@@ -1,0 +1,2 @@
+--index-url https://download.pytorch.org/whl/nightly/cu128
+torch --pre


### PR DESCRIPTION
Summary:
Fixes https://github.com/meta-pytorch/monarch/issues/1978

Separate out the torch requirement into a different file, since it requires a different
index. We don't want `build-requirements.txt` to overwrite it.

It is not used in CI because we use "matrix.torch-spec" to change the torch version we
download. We should ensure the requirements file always matches the tested version.

Differential Revision: D87802441


