### PR TITLE
Quick fix for T246995730

### DIFF
--- a/hyperactor_mesh/src/v1/host_mesh/mesh_agent.rs
+++ b/hyperactor_mesh/src/v1/host_mesh/mesh_agent.rs
@@ -131,15 +131,12 @@ impl Actor for HostMeshAgent {
                 None,
             )
             .unwrap();
+            // TODO: include execution_url here
             eprintln!(
-                "Monarch internal logs are being written to {}/{}.log; execution id {}{}",
+                "Monarch internal logs are being written to {}/{}.log; execution id {}",
                 directory,
                 file,
                 hyperactor_telemetry::env::execution_id(),
-                hyperactor_telemetry::env::execution_url()
-                    .await
-                    .unwrap_or_else(|e| Some(format!(": <error generating URL: {}>", e)))
-                    .map_or_else(|| "".to_string(), |url| format!(": {}", url))
             );
         }
         Ok(Self {


### PR DESCRIPTION
Summary: Calling `hyperactor_telemetry::env::execution_url()` in unit tests is causing hangs. A line-by-line bisection shows that its this downstream graphql call that causes this https://fburl.com/code/b99kgut6. The simplest fix is to just not print it for now so we don't need to fully back out of D87273699 and make it easy to forward fix the full functionality

Reviewed By: dulinriley

Differential Revision: D88190271


