### PR TITLE
[ROCm][CI] Add ciflow/rocm tag

### DIFF
--- a/.github/pytorch-probot.yml
+++ b/.github/pytorch-probot.yml
@@ -1,3 +1,2 @@
-ciflow_tracking_issue: 64124
 ciflow_push_tags:
 - ciflow/rocm


### PR DESCRIPTION
This file enables the mechanism of adding a ciflow label on any PR, and the bot creates a corresponding tag on the repo, which can be used as a trigger for a workflow.