### PR TITLE
python: tests: test_config - codec max frame length tests

### DIFF
--- a/hyperactor/src/config.rs
+++ b/hyperactor/src/config.rs
@@ -23,7 +23,7 @@ declare_attrs! {
     /// Maximum frame length for codec
     @meta(CONFIG = ConfigAttr {
         env_name: Some("HYPERACTOR_CODEC_MAX_FRAME_LENGTH".to_string()),
-        py_name: None,
+        py_name: Some("codec_max_frame_length".to_string()),
     })
     pub attr CODEC_MAX_FRAME_LENGTH: usize = 10 * 1024 * 1024 * 1024; // 10 GiB
 

--- a/python/tests/test_config.py
+++ b/python/tests/test_config.py
@@ -7,9 +7,11 @@
 # pyre-unsafe
 
 import pytest
+
 from monarch._rust_bindings.monarch_hyperactor.channel import ChannelTransport
-from monarch._rust_bindings.monarch_hyperactor.config import get_global_config
-from monarch.config import configured
+from monarch._rust_bindings.monarch_hyperactor.supervision import SupervisionError
+from monarch.actor import Actor, endpoint, this_proc
+from monarch.config import configured, get_global_config
 
 
 def test_get_set_transport() -> None:
@@ -57,3 +59,77 @@ def test_get_set_multiple() -> None:
     assert not config["enable_file_capture"]
     assert config["tail_log_lines"] == 0
     assert config["default_transport"] == ChannelTransport.Unix
+
+
+# This test tries to allocate too much memory for the GitHub actions
+# environment.
+@pytest.mark.oss_skip
+def test_codec_max_frame_length_exceeds_default() -> None:
+    """Test that sending 10 chunks of 1GiB fails with default 10 GiB
+    limit."""
+
+    class Chunker(Actor):
+        def __init__(self):
+            self.chunks = []
+
+        @endpoint
+        def process_chunks(self, chunks):
+            self.chunks = chunks
+            return len(chunks)
+
+    oneGiB = 1024 * 1024 * 1024
+    tenGiB = 10 * oneGiB
+
+    # Verify default is 10 GiB
+    config = get_global_config()
+    assert config["codec_max_frame_length"] == tenGiB
+
+    # Try to send 10 chunks of 1GiB each with default 10 GiB limit
+    # This should fail due to serialization overhead
+    proc = this_proc()
+
+    # Create 10 chunks, 1GiB each (total 10GiB)
+    chunks = [bytes(oneGiB) for _ in range(10)]
+
+    # Spawn actor and send chunks - should fail with SupervisionError
+    chunker = proc.spawn("chunker", Chunker)
+    with pytest.raises(SupervisionError):
+        chunker.process_chunks.call_one(chunks).get()
+
+
+# This test tries to allocate too much memory for the GitHub actions
+# environment.
+@pytest.mark.oss_skip
+def test_codec_max_frame_length_with_increased_limit() -> None:
+    """Test that we can successfully send 10 chunks of 1GiB each with
+    100 GiB limit."""
+
+    class Chunker(Actor):
+        def __init__(self):
+            self.chunks = []
+
+        @endpoint
+        def process_chunks(self, chunks):
+            self.chunks = chunks
+            return len(chunks)
+
+    oneGiB = 1024 * 1024 * 1024
+    tenGiB = 10 * oneGiB
+    oneHundredGiB = 10 * tenGiB
+
+    # Verify default is 10 GiB
+    config = get_global_config()
+    assert config["codec_max_frame_length"] == tenGiB
+
+    # Set the frame limit to confidently handle 10GiB
+    with configured(codec_max_frame_length=oneHundredGiB):
+        proc = this_proc()
+
+        # Create 10 chunks, 1GiB each (total 10GiB)
+        chunks = [bytes(oneGiB) for _ in range(10)]
+
+        # Spawn actor and send chunks - should succeed
+        chunker = proc.spawn("chunker", Chunker)
+        result = chunker.process_chunks.call_one(chunks).get()
+
+        assert result == 10


### PR DESCRIPTION
Summary: expose the `CODEC_MAX_FRAME_LENGTH` config key to Python as `codec_max_frame_length` and add end-to-end tests around it. by default the codec limit is 10 GiB; the tests show that sending 10×1 GiB chunks fails with `SupervisionError`, and that raising `codec_max_frame_length` to 100 GiB via `configured(...)` allows the same call to succeed. see https://fburl.com/workplace/du1l5nvm for background.

Differential Revision: D88294720


