### PR TITLE
: remove controller health monitoring

### DIFF
--- a/monarch_extension/src/client.rs
+++ b/monarch_extension/src/client.rs
@@ -21,7 +21,6 @@ use hyperactor_multiprocess::system_actor::SystemSnapshotFilter;
 use hyperactor_multiprocess::system_actor::WorldSnapshot;
 use hyperactor_multiprocess::system_actor::WorldSnapshotProcInfo;
 use monarch_hyperactor::ndslice::PySlice;
-use monarch_hyperactor::proc::ControllerError;
 use monarch_hyperactor::proc::InstanceWrapper;
 use monarch_hyperactor::proc::PyActorId;
 use monarch_hyperactor::proc::PyProc;
@@ -630,8 +629,7 @@ impl ClientActor {
 
     /// Attach the client to a controller actor. This will block until the controller responds.
     fn attach(&mut self, py: Python, controller_id: PyActorId) -> PyResult<()> {
-        let mut instance_wrapper = self.instance.blocking_lock();
-        instance_wrapper.set_controller((&controller_id).into());
+        let instance_wrapper = self.instance.blocking_lock();
         let actor_id = instance_wrapper.actor_id().clone();
         let (instance, _handler) = instance_wrapper
             .instance()
@@ -675,44 +673,25 @@ impl ClientActor {
             instance.lock().await.next_message(timeout_msec).await
         })?;
 
-        Python::with_gil(|py| {
-            match result {
-                Ok(Some(ClientMessage::Result { seq, result })) => {
-                    WorkerResponse { seq, result }.into_py_any(py)
-                }
-                Ok(Some(ClientMessage::Log { level, message })) => LogMessage {
-                    level: PyLogLevel::from(level),
-                    message,
-                }
-                .into_py_any(py),
-                Ok(Some(ClientMessage::DebuggerMessage {
-                    debugger_actor_id,
-                    action,
-                })) => DebuggerMessage {
-                    debugger_actor_id: debugger_actor_id.into(),
-                    action,
-                }
-                .into_py_any(py),
-                Ok(None) => PyNone::get(py).into_py_any(py),
-                Err(err) => {
-                    if let Some(ControllerError::Failed(controller_id, err_msg)) =
-                        err.downcast_ref::<ControllerError>()
-                    {
-                        let failure = DeviceFailure {
-                            actor_id: controller_id.clone(),
-                            address: "".to_string(), // Controller is always task 0 for now.
-                            backtrace: err_msg.clone(),
-                        };
-                        WorkerResponse {
-                            seq: Seq::default(),
-                            result: Some(Err(Exception::Failure(failure))),
-                        }
-                        .into_py_any(py)
-                    } else {
-                        Err(PyRuntimeError::new_err(err.to_string()))
-                    }
-                }
+        Python::with_gil(|py| match result {
+            Ok(Some(ClientMessage::Result { seq, result })) => {
+                WorkerResponse { seq, result }.into_py_any(py)
             }
+            Ok(Some(ClientMessage::Log { level, message })) => LogMessage {
+                level: PyLogLevel::from(level),
+                message,
+            }
+            .into_py_any(py),
+            Ok(Some(ClientMessage::DebuggerMessage {
+                debugger_actor_id,
+                action,
+            })) => DebuggerMessage {
+                debugger_actor_id: debugger_actor_id.into(),
+                action,
+            }
+            .into_py_any(py),
+            Ok(None) => PyNone::get(py).into_py_any(py),
+            Err(err) => Err(PyRuntimeError::new_err(err.to_string())),
         })
     }
 

--- a/monarch_extension/src/lib.rs
+++ b/monarch_extension/src/lib.rs
@@ -18,6 +18,7 @@ mod debugger;
 mod logging;
 #[cfg(feature = "tensor_engine")]
 mod mesh_controller;
+mod proc;
 mod simulation_tools;
 #[cfg(feature = "tensor_engine")]
 mod tensor_worker;
@@ -230,6 +231,9 @@ pub fn mod_init(module: &Bound<'_, PyModule>) -> PyResult<()> {
         module,
         "monarch_extension.trace",
     )?)?;
+
+    // Register proc module with multiprocess-dependent functions (init_proc, world_status)
+    crate::proc::register_python_bindings(&get_or_add_new_module(module, "proc")?)?;
 
     #[cfg(fbcode_build)]
     {

--- a/monarch_extension/src/proc.rs
+++ b/monarch_extension/src/proc.rs
@@ -1,0 +1,171 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+//! Proc-related functionality that requires hyperactor_multiprocess.
+//!
+//! This module provides the Python-facing `init_proc` function and `world_status`
+//! which need hyperactor_multiprocess for system actor integration. This is separated
+//! from monarch_hyperactor to avoid that dependency in the core library.
+
+use std::collections::HashMap;
+use std::time::Duration;
+
+use anyhow::Result;
+use hyperactor::ActorRef;
+use hyperactor::channel;
+use hyperactor::channel::ChannelAddr;
+use hyperactor::clock::ClockKind;
+use hyperactor::mailbox::BoxedMailboxSender;
+use hyperactor::mailbox::DialMailboxRouter;
+use hyperactor::mailbox::MailboxClient;
+use hyperactor::proc::Proc;
+use hyperactor::reference::ProcId;
+use hyperactor::reference::WorldId;
+use hyperactor_multiprocess::proc_actor::ProcActor;
+use hyperactor_multiprocess::supervision::ProcSupervisor;
+use hyperactor_multiprocess::system_actor::ProcLifecycleMode;
+use hyperactor_multiprocess::system_actor::SYSTEM_ACTOR_REF;
+use hyperactor_multiprocess::system_actor::SystemMessageClient;
+use hyperactor_multiprocess::system_actor::SystemSnapshotFilter;
+use hyperactor_multiprocess::system_actor::WorldStatus;
+use monarch_hyperactor::actor::PickledMessageClientActor;
+use monarch_hyperactor::proc::PyProc;
+use monarch_hyperactor::runtime::signal_safe_block_on;
+use pyo3::exceptions::PyRuntimeError;
+use pyo3::prelude::*;
+use pyo3::types::PyDict;
+use pyo3::types::PyModule;
+
+/// Bootstrap a proc into the system at the provided bootstrap address.
+/// The proc will report to the system actor every
+/// [`supervision_update_interval_in_sec`] seconds.
+async fn bootstrap_proc(
+    proc_id: &str,
+    bootstrap_addr: &str,
+    supervision_update_interval_in_sec: u64,
+    listen_addr: Option<String>,
+) -> Result<PyProc> {
+    let proc_id: ProcId = proc_id.parse()?;
+    let bootstrap_addr: ChannelAddr = bootstrap_addr.parse()?;
+    let listen_addr = if let Some(listen_addr) = listen_addr {
+        listen_addr.parse()?
+    } else {
+        ChannelAddr::any(bootstrap_addr.transport())
+    };
+    let chan = channel::dial(bootstrap_addr.clone())?;
+    let system_sender = BoxedMailboxSender::new(MailboxClient::new(chan));
+    let proc_forwarder =
+        BoxedMailboxSender::new(DialMailboxRouter::new_with_default(system_sender));
+    let proc = Proc::new_with_clock(
+        proc_id.clone(),
+        proc_forwarder,
+        ClockKind::for_channel_addr(&bootstrap_addr),
+    );
+
+    let system_supervision_ref: ActorRef<ProcSupervisor> =
+        ActorRef::attest(SYSTEM_ACTOR_REF.actor_id().clone());
+
+    let bootstrap = ProcActor::bootstrap_for_proc(
+        proc.clone().clone(),
+        proc.clone()
+            .proc_id()
+            .world_id()
+            .expect("proc must be ranked for world id")
+            .clone(), // REFACTOR(marius): factor out world id
+        listen_addr,
+        bootstrap_addr.clone(),
+        system_supervision_ref,
+        Duration::from_secs(supervision_update_interval_in_sec),
+        HashMap::new(),
+        ProcLifecycleMode::Detached,
+    )
+    .await
+    .inspect_err(|err| {
+        tracing::error!("could not spawn proc actor for {}: {}", proc.proc_id(), err,);
+    })?;
+
+    tokio::spawn(async move {
+        tracing::info!(
+            "proc actor for {} exited with status {}",
+            proc_id,
+            bootstrap.proc_actor.await
+        );
+    });
+
+    Ok(PyProc::new_from_proc(proc))
+}
+
+#[pyfunction]
+#[pyo3(signature = (*, proc_id, bootstrap_addr, timeout = 5, supervision_update_interval = 0, listen_addr = None))]
+pub fn init_proc(
+    py: Python<'_>,
+    proc_id: &str,
+    bootstrap_addr: &str,
+    #[allow(unused_variables)] // pyo3 will complain if we name this _timeout
+    timeout: u64,
+    supervision_update_interval: u64,
+    listen_addr: Option<String>,
+) -> PyResult<PyProc> {
+    // TODO: support configuring supervision_update_interval in Python binding.
+    let proc_id = proc_id.to_owned();
+    let bootstrap_addr = bootstrap_addr.to_owned();
+    signal_safe_block_on(py, async move {
+        bootstrap_proc(
+            &proc_id,
+            &bootstrap_addr,
+            supervision_update_interval,
+            listen_addr,
+        )
+        .await
+        .map_err(|e| PyRuntimeError::new_err(e.to_string()))
+    })?
+}
+
+#[pyfunction]
+pub fn world_status<'py>(
+    py: Python<'py>,
+    actor: &PickledMessageClientActor,
+) -> PyResult<Bound<'py, PyDict>> {
+    let instance = actor.instance_arc().clone();
+
+    let worlds = signal_safe_block_on(py, async move {
+        let instance = instance.lock().await;
+        let filter: SystemSnapshotFilter = Default::default();
+        let snapshot = SYSTEM_ACTOR_REF
+            .snapshot(instance.instance(), filter)
+            .await?;
+
+        // TODO: pulling snapshot is expensive as it contains all proc details
+        // We do not need those extra information.
+        let result: HashMap<WorldId, WorldStatus> = snapshot
+            .worlds
+            .into_iter()
+            .map(|(k, v)| (k, v.status))
+            .collect();
+        Ok::<_, anyhow::Error>(result)
+    })
+    .map_err(|e| PyRuntimeError::new_err(format!("{:?}", e)))??;
+
+    let py_dict = PyDict::new(py);
+    for (world, status) in worlds {
+        py_dict.set_item(world.to_string(), status.to_string())?;
+    }
+    Ok(py_dict)
+}
+
+pub fn register_python_bindings(module: &Bound<'_, PyModule>) -> PyResult<()> {
+    let f = wrap_pyfunction!(init_proc, module)?;
+    f.setattr("__module__", "monarch._rust_bindings.proc")?;
+    module.add_function(f)?;
+
+    let f = wrap_pyfunction!(world_status, module)?;
+    f.setattr("__module__", "monarch._rust_bindings.proc")?;
+    module.add_function(f)?;
+
+    Ok(())
+}

--- a/monarch_hyperactor/Cargo.toml
+++ b/monarch_hyperactor/Cargo.toml
@@ -34,7 +34,6 @@ futures = { version = "0.3.31", features = ["async-await", "compat"] }
 hyperactor = { version = "0.0.0", path = "../hyperactor" }
 hyperactor_config = { version = "0.0.0", path = "../hyperactor_config" }
 hyperactor_mesh = { version = "0.0.0", path = "../hyperactor_mesh" }
-hyperactor_multiprocess = { version = "0.0.0", path = "../hyperactor_multiprocess" }
 hyperactor_telemetry = { version = "0.0.0", path = "../hyperactor_telemetry" }
 inventory = "0.3.21"
 lazy_errors = "0.10.1"

--- a/monarch_hyperactor/Cargo.toml
+++ b/monarch_hyperactor/Cargo.toml
@@ -51,7 +51,6 @@ serde = { version = "1.0.219", features = ["derive", "rc"] }
 serde_bytes = "0.11"
 serde_multipart = { version = "0.0.0", path = "../serde_multipart" }
 tempfile = "3.22"
-thiserror = "2.0.12"
 tokio = { version = "1.47.1", features = ["full", "test-util", "tracing"] }
 tokio-util = { version = "0.7.15", features = ["full"] }
 tracing = { version = "0.1.41", features = ["attributes", "valuable"] }

--- a/python/monarch/_rust_bindings/monarch_hyperactor/proc.pyi
+++ b/python/monarch/_rust_bindings/monarch_hyperactor/proc.pyi
@@ -11,27 +11,6 @@ from typing import final, Optional, Type
 from monarch._rust_bindings.monarch_hyperactor.actor import Actor, PythonActorHandle
 from monarch._rust_bindings.monarch_hyperactor.mailbox import Mailbox
 
-def init_proc(
-    *,
-    proc_id: str,
-    bootstrap_addr: str,
-    timeout: int = 5,
-    supervision_update_interval: int = 0,
-    listen_addr: Optional[str] = None,
-) -> Proc:
-    """
-    Helper function to bootstrap a new Proc.
-
-    Arguments:
-    - `proc_id`: String representation of the ProcId eg. `"world_name[0]"`
-    - `bootstrap_addr`: String representation of the channel address of the system
-        actor. eg. `"tcp![::1]:2345"`
-    - `timeout`: Number of seconds to wait to successfully connect to the system.
-    - `supervision_update_interval`: Number of seconds between supervision updates.
-    - `listen_addr`: String representation of the channel address of the proc
-        actor. eg. `"tcp![::1]:2345"`
-    """
-    ...
 @final
 class Serialized:
     """

--- a/python/monarch/_rust_bindings/proc.pyi
+++ b/python/monarch/_rust_bindings/proc.pyi
@@ -1,0 +1,46 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from typing import Optional
+
+from monarch._rust_bindings.monarch_hyperactor.actor import PickledMessageClientActor
+from monarch._rust_bindings.monarch_hyperactor.proc import Proc
+
+def init_proc(
+    *,
+    proc_id: str,
+    bootstrap_addr: str,
+    timeout: int = 5,
+    supervision_update_interval: int = 0,
+    listen_addr: Optional[str] = None,
+) -> Proc:
+    """
+    Helper function to bootstrap a new Proc with multiprocess supervision.
+
+    Arguments:
+    - `proc_id`: String representation of the ProcId eg. `"world_name[0]"`
+    - `bootstrap_addr`: String representation of the channel address of the system
+        actor. eg. `"tcp![::1]:2345"`
+    - `timeout`: Number of seconds to wait to successfully connect to the system.
+    - `supervision_update_interval`: Number of seconds between supervision updates.
+    - `listen_addr`: String representation of the channel address of the proc
+        actor. eg. `"tcp![::1]:2345"`
+    """
+    ...
+
+def world_status(actor: PickledMessageClientActor) -> dict[str, str]:
+    """
+    Get the status of all worlds from the system actor.
+
+    Arguments:
+    - `actor`: A client actor to use for querying the system.
+
+    Returns:
+    - A dictionary mapping world IDs to their status strings.
+    """
+    ...

--- a/python/monarch/rust_backend_mesh.py
+++ b/python/monarch/rust_backend_mesh.py
@@ -17,8 +17,11 @@ from monarch._rust_bindings.monarch_extension.client import (  # @manual=//monar
 
 from monarch._rust_bindings.monarch_hyperactor.proc import (  # @manual=//monarch/monarch_extension:monarch_extension
     ActorId,
-    init_proc,
     Proc,
+)
+
+from monarch._rust_bindings.proc import (  # @manual=//monarch/monarch_extension:monarch_extension
+    init_proc,
 )
 
 from monarch._src.actor.shape import NDSlice
@@ -115,8 +118,8 @@ class PoolDeviceMeshProvider:
         while timeout_in_sec is None or time.time() - now < timeout_in_sec:
             # Pull the fresh world status
             self._refresh_worlds()
-            world_status = self._root_client.world_status()
-            self._remove_evicted_worlds(world_status)
+            ws = self._root_client.world_status()
+            self._remove_evicted_worlds(ws)
 
             # Find the next available world
             for mesh_world, mesh in self._mesh_map.items():
@@ -127,8 +130,8 @@ class PoolDeviceMeshProvider:
                 worker_world, controller_id = mesh_world
                 controller_world = controller_id.world_name
 
-                if (not _is_world_healthy(world_status, worker_world)) or (
-                    not _is_world_healthy(world_status, controller_world)
+                if (not _is_world_healthy(ws, worker_world)) or (
+                    not _is_world_healthy(ws, controller_world)
                 ):
                     # Either controller world is not ready or worker world is not ready
                     continue


### PR DESCRIPTION
Summary:
the entire controller health monitoring system is now dead code. in monarch_hyperactor/src/proc.rs, the supervision check loop was already stubbed out to just log and do nothing. the struct fields `controller_id`, `last_controller_status_check`, `controller_error_sender`, and `controller_error_receiver` were initialized but never meaningfully used. the `set_controller()` method was only called from the deprecated `ClientActor::attach()` code path. the `ControllerError` enum was never actually raised since the only code path that could raise it was inside the stubbed-out supervision check.

in monarch_extension/src/client.rs, the error handling for `ControllerError` was unreachable code since that error was never raised. the `set_controller()` call in `ClientActor::attach()` was part of this deprecated flow.

this diff deletes all of this supervision code. the `ensure_detached_and_alive()` method is simplified to only check signals. all controller-related struct fields are removed along with the `ControllerError` enum definition.

Differential Revision: D88441603


