### PR TITLE
Replace Duration::from_secs(60) to Duration::from_mins(1)

### DIFF
--- a/hyperactor/src/config.rs
+++ b/hyperactor/src/config.rs
@@ -182,7 +182,7 @@ mod tests {
         let config = from_env();
 
         assert_eq!(config[CODEC_MAX_FRAME_LENGTH], 1024);
-        assert_eq!(config[MESSAGE_DELIVERY_TIMEOUT], Duration::from_secs(60));
+        assert_eq!(config[MESSAGE_DELIVERY_TIMEOUT], Duration::from_mins(1));
         assert_eq!(
             config[MESSAGE_ACK_TIME_INTERVAL],
             Duration::from_millis(500)

--- a/hyperactor_config/src/global.rs
+++ b/hyperactor_config/src/global.rs
@@ -957,10 +957,10 @@ mod tests {
         let orig_value = std::env::var("HYPERACTOR_MESSAGE_DELIVERY_TIMEOUT").ok();
         {
             let _guard1 = config.override_key(CODEC_MAX_FRAME_LENGTH, 4096);
-            let _guard2 = config.override_key(MESSAGE_DELIVERY_TIMEOUT, Duration::from_secs(60));
+            let _guard2 = config.override_key(MESSAGE_DELIVERY_TIMEOUT, Duration::from_mins(1));
 
             assert_eq!(get(CODEC_MAX_FRAME_LENGTH), 4096);
-            assert_eq!(get(MESSAGE_DELIVERY_TIMEOUT), Duration::from_secs(60));
+            assert_eq!(get(MESSAGE_DELIVERY_TIMEOUT), Duration::from_mins(1));
             // This was overridden:
             assert_eq!(
                 std::env::var("HYPERACTOR_MESSAGE_DELIVERY_TIMEOUT").unwrap(),

--- a/hyperactor_config/src/lib.rs
+++ b/hyperactor_config/src/lib.rs
@@ -284,7 +284,7 @@ mod tests {
             env_name: Some("TEST_DURATION_KEY".to_string()),
             py_name: None,
         })
-        pub attr DURATION_KEY: std::time::Duration = std::time::Duration::from_secs(60);
+        pub attr DURATION_KEY: std::time::Duration = std::time::Duration::from_mins(1);
 
         @meta(CONFIG = ConfigAttr {
             env_name: Some("TEST_MODE_KEY".to_string()),

--- a/hyperactor_mesh/src/alloc.rs
+++ b/hyperactor_mesh/src/alloc.rs
@@ -681,7 +681,7 @@ pub mod test_utils {
     extern "C" fn exit_handler() {
         loop {
             #[allow(clippy::disallowed_methods)]
-            std::thread::sleep(Duration::from_secs(60));
+            std::thread::sleep(Duration::from_mins(1));
         }
     }
 

--- a/hyperactor_mesh/src/alloc/remoteprocess.rs
+++ b/hyperactor_mesh/src/alloc/remoteprocess.rs
@@ -1927,7 +1927,7 @@ mod test {
         let config = hyperactor_config::global::lock();
         let _guard = config.override_key(
             hyperactor::config::REMOTE_ALLOCATOR_HEARTBEAT_INTERVAL,
-            Duration::from_secs(60),
+            Duration::from_mins(1),
         );
         hyperactor_telemetry::initialize_logging_for_test();
         let serve_addr = ChannelAddr::any(ChannelTransport::Unix);
@@ -2029,7 +2029,7 @@ mod test {
         let config = hyperactor_config::global::lock();
         let _guard = config.override_key(
             hyperactor::config::REMOTE_ALLOCATOR_HEARTBEAT_INTERVAL,
-            Duration::from_secs(60),
+            Duration::from_mins(1),
         );
         hyperactor_telemetry::initialize_logging(ClockKind::default());
         let serve_addr = ChannelAddr::any(ChannelTransport::Unix);
@@ -2110,7 +2110,7 @@ mod test {
         let config = hyperactor_config::global::lock();
         let _guard = config.override_key(
             hyperactor::config::REMOTE_ALLOCATOR_HEARTBEAT_INTERVAL,
-            Duration::from_secs(60),
+            Duration::from_mins(1),
         );
         hyperactor_telemetry::initialize_logging(ClockKind::default());
         let serve_addr = ChannelAddr::any(ChannelTransport::Unix);

--- a/hyperactor_mesh/src/v1/host_mesh.rs
+++ b/hyperactor_mesh/src/v1/host_mesh.rs
@@ -88,7 +88,7 @@ declare_attrs! {
         env_name: Some("HYPERACTOR_MESH_GET_PROC_STATE_MAX_IDLE".to_string()),
         py_name: None,
     })
-    pub attr GET_PROC_STATE_MAX_IDLE: Duration = Duration::from_secs(60);
+    pub attr GET_PROC_STATE_MAX_IDLE: Duration = Duration::from_mins(1);
 }
 
 /// A reference to a single host.
@@ -1574,7 +1574,7 @@ mod tests {
         );
         let _guard3 = config.override_key(
             hyperactor::config::MESSAGE_DELIVERY_TIMEOUT,
-            Duration::from_secs(60),
+            Duration::from_mins(1),
         );
 
         let instance = testing::instance().await;
@@ -1614,7 +1614,7 @@ mod tests {
             *actual_attrs
                 .get(hyperactor::config::MESSAGE_DELIVERY_TIMEOUT)
                 .unwrap(),
-            Duration::from_secs(60)
+            Duration::from_mins(1)
         );
     }
 }

--- a/hyperactor_mesh/src/v1/proc_mesh.rs
+++ b/hyperactor_mesh/src/v1/proc_mesh.rs
@@ -91,7 +91,7 @@ declare_attrs! {
         env_name: Some("HYPERACTOR_MESH_GET_ACTOR_STATE_MAX_IDLE".to_string()),
         py_name: None,
     })
-    pub attr GET_ACTOR_STATE_MAX_IDLE: Duration = Duration::from_secs(60);
+    pub attr GET_ACTOR_STATE_MAX_IDLE: Duration = Duration::from_mins(1);
 }
 
 /// A reference to a single [`hyperactor::Proc`].

--- a/hyperactor_mesh/test/process_allocator_cleanup/process_allocator_cleanup.rs
+++ b/hyperactor_mesh/test/process_allocator_cleanup/process_allocator_cleanup.rs
@@ -130,7 +130,7 @@ async fn test_process_allocator_child_cleanup() {
     }
 
     eprintln!("Waiting longer to see if children eventually exit due to channel hangup...");
-    let timeout = Duration::from_secs(60);
+    let timeout = Duration::from_mins(1);
     let start = Instant::now();
 
     loop {

--- a/monarch_extension/src/blocking.rs
+++ b/monarch_extension/src/blocking.rs
@@ -13,7 +13,7 @@ use tokio::time::Duration;
 extern "C" fn exit_handler() {
     loop {
         #[allow(clippy::disallowed_methods)]
-        std::thread::sleep(Duration::from_secs(60));
+        std::thread::sleep(Duration::from_mins(1));
     }
 }
 


### PR DESCRIPTION
Summary:
Rust 1.91 introduced `Duration::from_mins`.

This diff replaces some instances of `Duration::from_secs` with the corresponding `Duration::from_mins`.

Differential Revision: D88434166


