### PR TITLE
Make SupervisionError::new_err return the correct error type

### DIFF
--- a/monarch_hyperactor/src/actor_mesh.rs
+++ b/monarch_hyperactor/src/actor_mesh.rs
@@ -328,7 +328,7 @@ impl ActorMeshProtocol for PythonActorMeshImpl {
                     None,
                 )),
             };
-            Ok(PyErr::new::<SupervisionError, _>(format!(
+            Ok(SupervisionError::new_err(format!(
                 "Actor {:?} exited because of the following reason: {}",
                 event.actor_id(),
                 event.__repr__()?
@@ -507,13 +507,13 @@ impl ActorMeshProtocol for PythonActorMeshRef {
                 PyPythonTask::new(async move {
                     while let Ok(Some(event)) =  receiver.recv().await {
                         if slice.iter().any(|rank| rank == event.actor_id.rank()) {
-                            return Ok(PyErr::new::<SupervisionError, _>(format!(
+                            return Ok(SupervisionError::new_err(format!(
                                 "Actor {:?} exited because of the following reason: {}",
                                 event.actor_id, event.actor_status
                             )));
                         }
                     }
-                    Ok(PyErr::new::<SupervisionError, _>(format!(
+                    Ok(SupervisionError::new_err(format!(
                         "Actor {:?} exited because of the following reason: actor mesh is stopped due to proc mesh shutdown",
                         id!(default[0].actor[0])
                     )))

--- a/monarch_hyperactor/src/supervision.rs
+++ b/monarch_hyperactor/src/supervision.rs
@@ -37,7 +37,12 @@ impl SupervisionError {
 
     #[staticmethod]
     pub fn new_err(message: String) -> PyErr {
-        PyRuntimeError::new_err(message)
+        PyErr::new::<Self, _>(message)
+    }
+
+    #[staticmethod]
+    pub fn new_err_from_endpoint(message: String, endpoint: String) -> PyErr {
+        PyErr::new::<Self, _>((message, Some(endpoint)))
     }
 
     fn __str__(&self) -> String {


### PR DESCRIPTION
Summary:
The `new_err` method is supposed to create a new PyErr with the same type.
This was accidentally set to the supertype RuntimeError. This should be `SupervisionError`
instead. Else `PyErr::new` and `SupervisionError::new_err` give slightly different exceptions.

Also follow this pattern for other exceptions in the same file to avoid accidental copy-paste.

Fixed and changed to use this shorthand method wherever we can.

Reviewed By: mariusae

Differential Revision: D88436495


