### PR TITLE
Change ProcMeshAgent timeout from Stopped to Failed

### DIFF
--- a/hyperactor_mesh/src/v1/actor_mesh.rs
+++ b/hyperactor_mesh/src/v1/actor_mesh.rs
@@ -705,7 +705,7 @@ mod tests {
                 .expect("state should be present")
                 .supervision_events;
             assert_eq!(events.len(), 1);
-            assert_eq!(events[0].actor_status, ActorStatus::Stopped);
+            assert_matches!(events[0].actor_status, ActorStatus::Failed(_));
         }
     }
 

--- a/hyperactor_mesh/src/v1/host_mesh.rs
+++ b/hyperactor_mesh/src/v1/host_mesh.rs
@@ -7,7 +7,6 @@
  */
 
 use hyperactor::Actor;
-use hyperactor::ActorHandle;
 use hyperactor::accum::ReducerOpts;
 use hyperactor::channel::ChannelTransport;
 use hyperactor::clock::Clock;
@@ -1082,6 +1081,8 @@ impl HostMeshRef {
 
     /// Get the state of all procs with Name in this host mesh.
     /// The procs iterator must be in rank order.
+    /// The returned ValueMesh will have a non-empty inner state unless there
+    /// was a timeout reaching the host mesh agent.
     #[allow(clippy::result_large_err)]
     pub(crate) async fn proc_states(
         &self,

--- a/hyperactor_mesh/src/v1/proc_mesh.rs
+++ b/hyperactor_mesh/src/v1/proc_mesh.rs
@@ -19,7 +19,6 @@ use std::sync::atomic::Ordering;
 use std::time::Duration;
 
 use hyperactor::Actor;
-use hyperactor::ActorHandle;
 use hyperactor::ActorId;
 use hyperactor::ActorRef;
 use hyperactor::Named;
@@ -784,7 +783,10 @@ impl ProcMeshRef {
                                 supervision_events: vec![ActorSupervisionEvent::new(
                                     agent_id,
                                     None,
-                                    ActorStatus::Stopped,
+                                    ActorStatus::generic_failure(format!(
+                                        "timeout waiting for message from proc mesh agent while querying for \"{}\". The process likely crashed",
+                                        name,
+                                    )),
                                     None,
                                 )],
                             }),

--- a/monarch_hyperactor/src/v1/actor_mesh.rs
+++ b/monarch_hyperactor/src/v1/actor_mesh.rs
@@ -444,7 +444,6 @@ async fn actor_states_monitor<A>(
                     | Some(ProcStatus::Killed { signal: 15, .. })
                     // Conservatively treat lack of status as stopped
                     | None => ActorStatus::Stopped,
-
                     Some(status) => ActorStatus::Failed(ActorErrorKind::Generic(format!(
                         "process failure: {}",
                         status


### PR DESCRIPTION
Summary:
Part of: https://github.com/meta-pytorch/monarch/issues/2027

When a process goes down and we cannot reach the ProcMeshAgent, we used to use
the "Stopped" actor status. But Stopped is handled differently than Failed, Stopped is considered
a user-requested stop, and that the actor stopped cleanly. A process exit is not that, and
should follow the error propagation path up to the client.

Also, with Failed we can include a more helpful message saying the process was
crashed, which should help troubleshooting.

Same thing goes for HostMeshAgent being unreachable as well.

Differential Revision: D88529146


