### PR TITLE
reduce otel metric flush interval from 10s to 1s

### DIFF
--- a/hyperactor_telemetry/src/config.rs
+++ b/hyperactor_telemetry/src/config.rs
@@ -64,7 +64,7 @@ declare_attrs! {
         env_name: Some("OTEL_METRIC_EXPORT_INTERVAL".to_string()),
         py_name: Some("otel_metric_export_interval".to_string()),
     })
-    pub attr OTEL_METRIC_EXPORT_INTERVAL: Duration = Duration::from_secs(10);
+    pub attr OTEL_METRIC_EXPORT_INTERVAL: Duration = Duration::from_secs(1);
 
     /// Enable logging of span enter/exit events to Scuba.
     @meta(CONFIG = ConfigAttr {


### PR DESCRIPTION
Summary:
Reduce the interval so metrics can get a higher chance to be flushed when proc exits.

1s shouldn't push too much load on scuba.

Reviewed By: vidhyav

Differential Revision: D88533524


