### PR TITLE
Add more context in NameParseError::InvalidName error message

### DIFF
--- a/hyperactor_mesh/src/v1.rs
+++ b/hyperactor_mesh/src/v1.rs
@@ -322,7 +322,13 @@ pub enum NameParseError {
     #[error("invalid name: missing uuid")]
     MissingUuid,
 
-    #[error("invalid name '{0}'")]
+    /// Strictly speaking Monarch identifier also supports other characters. But
+    /// to avoid confusion for the user, we only state intuitive characters here
+    /// so the error message is more actionable.
+    #[error(
+        "invalid name '{0}': names must contain only alphanumeric characters \
+        and underscores, and must start with a letter or underscore"
+    )]
     InvalidName(String),
 
     #[error(transparent)]


### PR DESCRIPTION
Summary: We want to make the error message actionable, because otherwise the user do not know want to do after hitting this error (context: D88403520).

Reviewed By: mariusae

Differential Revision: D88638502


