### PR TITLE
Fix rdma failures

### DIFF
--- a/rdmaxcel-sys/src/driver_api.cpp
+++ b/rdmaxcel-sys/src/driver_api.cpp
@@ -7,6 +7,7 @@
  */
 
 #include "driver_api.h"
+#include <cuda_runtime.h>
 #include <dlfcn.h>
 #include <iostream>
 #include <stdexcept>
@@ -79,6 +80,8 @@ DriverAPI create_driver_api() {
 } // namespace
 
 DriverAPI* DriverAPI::get() {
+  // Ensure we have a valid CUDA context for this thread
+  cudaFree(0);
   static DriverAPI singleton = create_driver_api();
   return &singleton;
 }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #2085
* #2088
* __->__ #2089
* #2086
* #2077

One of the recent changes has now made it possible for the tokio thread running the rdma manager to not have an active cuda context before making cuda API calls. This changes ensures we cause the context to exist if we are about to use a driver call.

Differential Revision: [D88692378](https://our.internmc.facebook.com/intern/diff/D88692378/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D88692378/)!