### PR TITLE
[monarch] Fix deadlock in root_client_actor initialization

### DIFF
--- a/monarch_hyperactor/src/context.rs
+++ b/monarch_hyperactor/src/context.rs
@@ -120,7 +120,7 @@ impl PyContext {
     #[staticmethod]
     fn _root_client_context(py: Python<'_>) -> PyResult<PyContext> {
         let _guard = runtime::get_tokio_runtime().enter();
-        let instance: PyInstance = root_client_actor().into();
+        let instance: PyInstance = root_client_actor(py).into();
         Ok(PyContext {
             instance: instance.into_pyobject(py)?.into(),
             rank: Extent::unity().point_of_rank(0).unwrap(),


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #2091

This is a fix for T247454046. Initializing the root client actor could deadlock in a multithreaded context because one thread could hold the GIL while waiting for the OnceLock, while another thread that holds the OnceLock could be waiting for the GIL.

Differential Revision: [D88700403](https://our.internmc.facebook.com/intern/diff/D88700403/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D88700403/)!