### PR TITLE
: job: hack env into MastJob

### DIFF
--- a/python/monarch/_src/job/meta.py
+++ b/python/monarch/_src/job/meta.py
@@ -49,6 +49,7 @@ class _MASTSpec(NamedTuple):
     timeout_sec: int
     meshes: List[Tuple[str, int, str]]
     workspace: Dict[Union[Path, str], str]
+    env: Dict[str, str]
 
 
 MONARCH_PORT: int = 26600
@@ -80,6 +81,7 @@ class MASTJob(JobTrait):
         hpcClusterUuid: str = "MastProdCluster",
         packages: Sequence[str] = (),
         timeout_sec=3600,
+        env: Optional[Dict[str, str]] = None,
     ):
         super().__init__()
         self._name: Optional[str] = None
@@ -92,6 +94,7 @@ class MASTJob(JobTrait):
             timeout_sec,
             [],
             {},
+            env or {},
         )
         self._handle: Optional[str] = None
 
@@ -115,6 +118,7 @@ class MASTJob(JobTrait):
             ],
             additional_packages=packages,
             timeout_sec=self._spec.timeout_sec,
+            env=self._spec.env,
         )
         with ExitStack() as stack:
             workspace = Workspace(self._spec.workspace)


### PR DESCRIPTION
Summary: allow passing environment variables into Mast jobs. the `JobSpec` now carries an `env` dictionary, the `MetaJob` constructor accepts an optional `env` argument, and the value is forwarded when constructing the underlying HPC job. the example `hello_mast_job.py` is updated to to disable OilFS via `DISABLE_OILFS=1`. these two things together mean the bento notebook N8762221 and `hello_mast_job.py` are both shown to work (without `DISABLE_OILFS=1` neither do)

Reviewed By: AbishekS

Differential Revision: D88701511


