### PR TITLE
Various improvements

### DIFF
--- a/monarch_perfetto_trace/src/lib.rs
+++ b/monarch_perfetto_trace/src/lib.rs
@@ -274,7 +274,8 @@ impl<'a, T: Sink> Instant<'a, T> {
     }
 
     pub fn consume(self) {
-        let event = self.event;
+        let mut event = self.event;
+        event.r#type = Some(TrackEventType::Instant as i32);
         let tp = TracePacket {
             timestamp: self.ts.into(),
             data: Some(Data::TrackEvent(event)),


### PR DESCRIPTION
Summary:
- Only care about SpanEnter, SpanExit, and InstantEvents. Span creation and destruction is irrelevant.
- Fix a bug where we called .consume on events twice causing bad output
- Only query for above categories.
- Remove the old build_trace.
- Enum for event types
- Fix instant events not showing up
- skip hostname field in additional info for each event

Reviewed By: moonli

Differential Revision: D88765753


