### PR TITLE
: wait for alloc completion in ProcMesh::stop()

### DIFF
--- a/hyperactor_mesh/src/v1/proc_mesh.rs
+++ b/hyperactor_mesh/src/v1/proc_mesh.rs
@@ -439,7 +439,7 @@ impl ProcMesh {
         let extent = alloc.extent().clone();
         let alloc_name = alloc.world_id().to_string();
 
-        {
+        let alloc_task = {
             let stop = Arc::clone(&stop);
 
             tokio::spawn(
@@ -475,8 +475,8 @@ impl ProcMesh {
                     }
                 }
                 .instrument(tracing::info_span!("alloc_monitor")),
-            );
-        }
+            )
+        };
 
         let mesh = Self::create(
             cx,
@@ -486,6 +486,7 @@ impl ProcMesh {
                 stop,
                 extent,
                 ranks: Arc::new(ranks),
+                alloc_task: Some(alloc_task),
             },
             true, // alloc-based meshes support comm actors
         )
@@ -511,15 +512,31 @@ impl ProcMesh {
         let region = self.region.clone();
         match &mut self.allocation {
             ProcMeshAllocation::Allocated {
-                stop, alloc_name, ..
+                stop,
+                alloc_task,
+                alloc_name,
+                ..
             } => {
                 stop.notify_one();
+                // Wait for the alloc monitor task to complete, ensuring the
+                // alloc has fully stopped before we drop it.
+                if let Some(handle) = alloc_task.take() {
+                    if let Err(e) = handle.await {
+                        tracing::warn!(
+                            name = "ProcMeshStatus",
+                            proc_mesh = %self.name,
+                            alloc_name,
+                            %e,
+                            "alloc monitor task failed"
+                        );
+                    }
+                }
                 tracing::info!(
                     name = "ProcMeshStatus",
                     proc_mesh = %self.name,
                     alloc_name,
                     status = "StoppingAlloc",
-                    "sending stop to alloc {alloc_name}; check its log for stop status",
+                    "alloc {alloc_name} has stopped",
                 );
                 Ok(())
             }
@@ -571,6 +588,9 @@ enum ProcMeshAllocation {
 
         // The allocated ranks.
         ranks: Arc<Vec<ProcRef>>,
+
+        // The task handle for the alloc monitor. Used to wait for clean shutdown.
+        alloc_task: Option<tokio::task::JoinHandle<()>>,
     },
 
     /// An owned allocation: this ProcMesh fully owns the set of ranks.

--- a/python/monarch/_src/actor/actor_mesh.py
+++ b/python/monarch/_src/actor/actor_mesh.py
@@ -340,6 +340,30 @@ _this_host_for_fake_in_process_host: _Lazy["HostMesh"] = _Lazy(
 )
 
 
+def shutdown_context() -> "Future[None]":
+    """Shutdown global actor context resources.
+
+    This should be called at the end of scripts that use the actor
+    system to ensure clean shutdown of background processes.
+
+    Returns:
+        Future[None]: A future that completes when shutdown is
+                      finished. Call with .get() to wait for
+                      completion.
+    """
+    from monarch._src.actor.future import Future
+
+    local_host = _this_host_for_fake_in_process_host.try_get()
+    if local_host is not None:
+        return local_host.shutdown()
+
+    # Nothing to shutdown - return a completed future
+    async def noop() -> None:
+        pass
+
+    return Future(coro=noop())
+
+
 def _init_root_proc_mesh() -> "ProcMesh":
     from monarch._src.actor.host_mesh import fake_in_process_host
 

--- a/python/monarch/actor/__init__.py
+++ b/python/monarch/actor/__init__.py
@@ -33,6 +33,7 @@ from monarch._src.actor.actor_mesh import (
     Port,
     PortReceiver,
     send,
+    shutdown_context,
     ValueMesh,
 )
 from monarch._src.actor.bootstrap import attach_to_workers, run_worker_loop_forever
@@ -89,6 +90,7 @@ __all__ = [
     "ProcMesh",
     "Channel",
     "send",
+    "shutdown_context",
     "sim_proc_mesh",
     "ValueMesh",
     "debug_controller",


### PR DESCRIPTION
Summary:
`ProcMesh::stop()` was signaling the alloc monitor task to stop but returning immediately without waiting for the task to complete. this created a shutdown race where `HostMesh::shutdown()` calls `proc_mesh.stop()` (which signals stop and returns), then `HostMesh` drops, which causes `ProcMesh` and `ProcMeshAllocation` to drop, which in turn drops `ProcessAlloc`, `Child`, and finally `monitor::Group`. dropping `monitor::Group` completes the handle future and sends `SIGTERM` just as the bootstrap process is still exiting cleanly from the earlier stop signal, and the folly handler prints a backtrace on that signal.

the fix is to add `alloc_task: Option<JoinHandle<()>>` to `ProcMeshAllocation::Allocated`, capture the alloc monitor task handle when it is spawned, and have `ProcMesh::stop()` await that handle before returning. this ensures the bootstrap process exits via `std::process::exit(0)` before any of the drops occur and removes the `SIGTERM` race.

on the Python side, `actor_mesh.py` now registers an `atexit` handler that shuts down the global `local_host` `HostMesh` before interpreter exit, providing automatic cleanup without requiring manual shutdown calls.

Differential Revision: D88796970


