### PR TITLE
add endpoint message size metric

### DIFF
--- a/python/monarch/_src/actor/endpoint.py
+++ b/python/monarch/_src/actor/endpoint.py
@@ -128,9 +128,12 @@ class Endpoint(ABC, Generic[P, R]):
             The method name, or "unknown" if not available
         """
         method_specifier = self._call_name()
-        if hasattr(method_specifier, "name"):
-            # pyre-ignore[16]: MethodSpecifier subclasses ReturnsResponse and ExplicitPort have .name
-            return method_specifier.name
+        match method_specifier:
+            case MethodSpecifier.Init():
+                return "__init__"
+            case MethodSpecifier.ReturnsResponse() | MethodSpecifier.ExplicitPort():
+                # pyre-ignore[16]: MethodSpecifier subclasses ReturnsResponse and ExplicitPort have .name
+                return method_specifier.name
         return "unknown"
 
     def _with_telemetry(

--- a/python/monarch/_src/actor/metrics.py
+++ b/python/monarch/_src/actor/metrics.py
@@ -40,6 +40,12 @@ endpoint_choose_latency_histogram: Histogram = METER.create_histogram(
     description="Latency of endpoint choose operations in microseconds",
 )
 
+# Histogram for measuring endpoint message size
+endpoint_message_size_histogram: Histogram = METER.create_histogram(
+    name="endpoint_message_size",
+    description="Size of endpoint messages",
+)
+
 # Counters for measuring endpoint errors
 endpoint_call_error_counter: Counter = METER.create_counter(
     name="endpoint_call_error.count",


### PR DESCRIPTION
Summary: We don't have a client side message size metric for endpoint call, need this to for better monitoring endpoint calls.

Differential Revision: D88828482


