### PR TITLE
User mode

### DIFF
--- a/monarch_hyperactor/src/telemetry.rs
+++ b/monarch_hyperactor/src/telemetry.rs
@@ -108,6 +108,12 @@ pub fn get_execution_id() -> PyResult<String> {
     Ok(hyperactor_telemetry::env::execution_id())
 }
 
+#[pyfunction]
+pub fn instant_event(message: &str) -> PyResult<()> {
+    tracing::info!(message);
+    Ok(())
+}
+
 // opentelemetry requires that the names of counters etc are static for the lifetime of the program.
 // Since we are binding these classes from python to rust, we have to leak these strings in order to
 // ensure they live forever. This is fine, as these classes aren't dynamically created.
@@ -341,6 +347,13 @@ pub fn register_python_bindings(module: &Bound<'_, PyModule>) -> PyResult<()> {
         "monarch._rust_bindings.monarch_hyperactor.telemetry",
     )?;
     module.add_function(get_execution_id_fn)?;
+
+    let instant_event_fn = wrap_pyfunction!(instant_event, module)?;
+    instant_event_fn.setattr(
+        "__module__",
+        "monarch._rust_bindings.monarch_hyperactor.telemetry",
+    )?;
+    module.add_function(instant_event_fn)?;
 
     module.add_class::<PySpan>()?;
     module.add_class::<PyCounter>()?;

--- a/python/monarch/_rust_bindings/monarch_hyperactor/telemetry.pyi
+++ b/python/monarch/_rust_bindings/monarch_hyperactor/telemetry.pyi
@@ -72,6 +72,12 @@ def get_execution_id() -> str:
     """
     ...
 
+def instant_event(message: str) -> None:
+    """
+    Emit an instant event. This is a binding for tracing::info!(message)
+    """
+    ...
+
 class PySpan:
     def __init__(self, name: str, actor_id: str | None = None) -> None:
         """

--- a/python/monarch/_src/actor/actor_mesh.py
+++ b/python/monarch/_src/actor/actor_mesh.py
@@ -76,6 +76,7 @@ from monarch._rust_bindings.monarch_hyperactor.supervision import (
     MeshFailure,
     SupervisionError,
 )
+from monarch._rust_bindings.monarch_hyperactor.telemetry import instant_event
 from monarch._rust_bindings.monarch_hyperactor.v1.logging import log_endpoint_exception
 from monarch._rust_bindings.monarch_hyperactor.value_mesh import (
     ValueMesh as HyValueMesh,
@@ -563,6 +564,7 @@ class ActorEndpoint(Endpoint[P, R]):
                 ),
                 buffer,
             )
+            instant_event(f"sending {self._method_name()} message")
             self._actor_mesh.cast(
                 message, selection, context().actor_instance._as_rust()
             )
@@ -572,6 +574,9 @@ class ActorEndpoint(Endpoint[P, R]):
         return Extent(shape.labels, shape.ndslice.sizes)
 
     def _full_name(self) -> str:
+        return f"{self._mesh_name}.{self._method_name()}()"
+
+    def _method_name(self) -> str:
         method_name = "unknown"
         match self._name:
             case MethodSpecifier.Init():
@@ -580,7 +585,7 @@ class ActorEndpoint(Endpoint[P, R]):
                 pass
             case MethodSpecifier.ExplicitPort(name=method_name):
                 pass
-        return f"{self._mesh_name}.{method_name}()"
+        return method_name
 
     def _port(self, once: bool = False) -> "Tuple[Port[R], PortReceiver[R]]":
         p, r = super()._port(once=once)

--- a/python/monarch/_src/actor/endpoint.py
+++ b/python/monarch/_src/actor/endpoint.py
@@ -32,6 +32,7 @@ from typing import (
 
 from monarch._rust_bindings.monarch_hyperactor.actor import MethodSpecifier
 from monarch._rust_bindings.monarch_hyperactor.shape import Extent
+from monarch._rust_bindings.monarch_hyperactor.telemetry import instant_event
 
 from monarch._src.actor.future import Future
 from monarch._src.actor.metrics import (
@@ -295,6 +296,8 @@ class Endpoint(ABC, Generic[P, R]):
                 extent.labels,
                 NDSlice.new_row_major(extent.sizes),
             )
+            instant_event(f"{method_name} response received")
+
             return ValueMesh(call_shape, results)
 
         return Future(coro=process())


### PR DESCRIPTION
Summary:
We will create a simplied view for users to only show when messages are sent, response are received, and python spans created using `get_monarch_tracer()`

We also create a Python binding to `tracing::info` so we can create instant events from Python

Reviewed By: moonli

Differential Revision: D88797016


