### PR TITLE
Disable test_actor_ledger in Github

### DIFF
--- a/hyperactor/src/proc.rs
+++ b/hyperactor/src/proc.rs
@@ -2574,6 +2574,9 @@ mod tests {
     }
 
     #[async_timed_test(timeout_secs = 30)]
+    // TODO: The snapshot has a flaky num_messages_processed count after stopping
+    // root_1, but only on Github. The test expects 3, sometimes the result is 2.
+    #[cfg_attr(not(fbcode_build), ignore)]
     async fn test_actor_ledger() {
         async fn wait_until_idle(actor_handle: &ActorHandle<TestActor>) {
             actor_handle


### PR DESCRIPTION
Summary:
This test is flaky on Github, but in local runs, even when stress testing 100 times, it is
always passing.
Disable it for now to help keep CI reliable.

Differential Revision: D88868555


