### PR TITLE
Add libstdc++-static to Fedora build dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,8 +92,8 @@ conda install libunwind -y
 # Install the correct cuda and cuda-toolkit versions for your machine
 sudo dnf install cuda-toolkit-12-8 cuda-12-8
 
-# Install clang-dev and nccl-dev
-sudo dnf install clang-devel libnccl-devel
+# Install clang-devel, nccl-devel, and libstdc++-static
+sudo dnf install clang-devel libnccl-devel libstdc++-static
 # Or, in some environments, the following may be necessary instead
 conda install -c conda-forge clangdev nccl
 conda update -n monarchenv --all -c conda-forge -y


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #2113
* #2085

The libstdc++-static package is required for building Monarch on Fedora systems. Without this package, the build fails during linking. This adds it to the installation instructions for Fedora distributions.

Differential Revision: [D88899581](https://our.internmc.facebook.com/intern/diff/D88899581/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D88899581/)!