### PR TITLE
No torch requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,3 @@
-torch
-torchshow
 pyzmq
 requests
 numpy


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #2114
* #2099
* #2085

We now only require torch to build, not installed to run monarch. (Though you need it if you want to use tensors in the tensor worker).

Differential Revision: [D88912346](https://our.internmc.facebook.com/intern/diff/D88912346/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D88912346/)!