### PR TITLE
CreateRemoteProcessGroup placeholder

### DIFF
--- a/python/monarch/simulator/simulator.py
+++ b/python/monarch/simulator/simulator.py
@@ -754,6 +754,11 @@ class Simulator:
     ):
         return
 
+    def CreateRemoteProcessGroup(
+        self, ranks: List[NDSlice], msg: messages.CreateRemoteProcessGroup
+    ):
+        return
+
 
 class SimulatorController(MockController):
     """


### PR DESCRIPTION
Summary: This Diff creates a placeholder `CreateRemoteProcessGroup` message for the Simulator in order to remove the `"Simulator doesn't implement..."` error.

Reviewed By: zdevito

Differential Revision: D72756564


