### PR TITLE
Data DAG mesh_ref

### DIFF
--- a/python/monarch/common/tensor.py
+++ b/python/monarch/common/tensor.py
@@ -446,6 +446,8 @@ class MeshSliceTensor:
         from_ranks = NDSlice(
             offset=self.slicing.processes.offset, sizes=sizes, strides=strides
         )
+        # Ensure the destination mesh is defined remotely so it has a proper ref
+        mesh.define_remotely()
         r = Tensor(fake_call(self.tensor._fake.clone), mesh, stream)
         assert r.ref is not None
         client = self.tensor.mesh.client

--- a/python/monarch/simulator/tensor.py
+++ b/python/monarch/simulator/tensor.py
@@ -38,6 +38,11 @@ class DTensorRef:
         self._fake: Optional[torch._subclasses.FakeTensor] = getattr(
             tensor, "_fake", None
         )
+        # Capture mesh reference from tensor if available
+        self._mesh_ref: Optional[int] = None
+        if hasattr(tensor, "mesh") and tensor.mesh is not None:
+            self._mesh_ref = getattr(tensor.mesh, "ref", None)
+
         if self._fake is not None:
             self._storage_id: Optional[torch.types._int] = id(
                 self._fake.untyped_storage()


### PR DESCRIPTION
Summary:
Implement proper mesh reference tracking in simulator IR system.

Previously, the system used device sets to identify meshes, which failed to distinguish between different logical meshes that use the same physical devices but have different topologies. This change implements mesh reference (mesh.ref) based tracking.

This ensures that tensors with the same physical devices but different mesh topologies are correctly tracked as separate logical meshes in the IR system.

Reviewed By: zdevito

Differential Revision: D72696103


