### PR TITLE
[hyperactor] Add reducer_opts parameter to attest_reducible

### DIFF
--- a/docs/source/books/hyperactor-book/src/mailboxes/mailbox.md
+++ b/docs/source/books/hyperactor-book/src/mailboxes/mailbox.md
@@ -94,7 +94,8 @@ impl<M: RemoteMessage> PortHandle<M> {
             self.bound
                 .get_or_init(|| self.mailbox.bind(self).port_id().clone())
                 .clone(),
-            self.reducer_typehash.clone(),
+            self.reducer_spec.clone(),
+            self.reducer_opts.clone(),
         )
     }
 }

--- a/hyperactor/src/mailbox.rs
+++ b/hyperactor/src/mailbox.rs
@@ -1687,6 +1687,7 @@ impl<M: RemoteMessage> PortHandle<M> {
                 .get_or_init(|| self.mailbox.bind(self).port_id().clone())
                 .clone(),
             self.reducer_spec.clone(),
+            self.reducer_opts.clone(),
         )
     }
 

--- a/hyperactor/src/message.rs
+++ b/hyperactor/src/message.rs
@@ -351,6 +351,7 @@ mod tests {
                 typehash: 123,
                 builder_params: None,
             }),
+            None,
         );
         let my_message = MyMessage {
             arg0: true,
@@ -406,6 +407,7 @@ mod tests {
                 typehash: 123,
                 builder_params: None,
             }),
+            None,
         );
         let new_bindings = Bindings(
             [

--- a/hyperactor/src/reference.rs
+++ b/hyperactor/src/reference.rs
@@ -1017,11 +1017,15 @@ impl<M: RemoteMessage> PortRef<M> {
 
     /// The caller attests that the provided PortId can be
     /// converted to a reachable, typed port reference.
-    pub fn attest_reducible(port_id: PortId, reducer_spec: Option<ReducerSpec>) -> Self {
+    pub fn attest_reducible(
+        port_id: PortId,
+        reducer_spec: Option<ReducerSpec>,
+        reducer_opts: Option<ReducerOpts>,
+    ) -> Self {
         Self {
             port_id,
             reducer_spec,
-            reducer_opts: None, // TODO: provide attest_reducible_opts
+            reducer_opts,
             phantom: PhantomData,
             return_undeliverable: true,
         }

--- a/monarch_hyperactor/src/actor.rs
+++ b/monarch_hyperactor/src/actor.rs
@@ -1265,6 +1265,7 @@ mod tests {
         let port_ref = PortRef::<PythonMessage>::attest_reducible(
             id!(world[0].client[0][123]),
             Some(reducer_spec),
+            None,
         );
         let message = PythonMessage {
             kind: PythonMessageKind::CallMethod {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #2120

The attest_reducible function was hardcoding reducer_opts to None
with a TODO comment, preventing callers from specifying custom reducer
options when creating reducible port references. This change adds
reducer_opts as a required parameter to attest_reducible and threads it
through all call sites, enabling proper configuration of reducer behavior.

Differential Revision: [D88922470](https://our.internmc.facebook.com/intern/diff/D88922470/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D88922470/)!