### PR TITLE
Improve ProcMesh.spawn's doc string

### DIFF
--- a/python/monarch/_src/actor/v1/proc_mesh.py
+++ b/python/monarch/_src/actor/v1/proc_mesh.py
@@ -217,7 +217,22 @@ class ProcMesh(MeshTrait):
         - `kwargs`: Keyword arguments to pass to the actor's constructor.
 
         Returns:
-        - The actor instance.
+        - The actor mesh reference typed as T.
+
+        Note:
+
+        The method returns immediately, initializing the underlying actor instances
+        asynchronously. Thus, return of this method does not guarantee the actor's
+        __init__ has be executed; but rather that __init__ will be executed before the
+        first call to the actor's endpoints.
+
+        Nonblocking enhances composition, permitting the user to easily pipeline mesh
+        creation, for exmaple to construct complex mesh object graphs without introducing
+        additional latency.
+
+
+        If __init__ fails, the actor will be stopped and a supervision event will
+        be raised.
         """
         return self._spawn_nonblocking(name, Class, *args, **kwargs)
 


### PR DESCRIPTION
Summary:
As title.

More context regarding why __init__ needs to be executed in a fire-and-forget way can be found in [this thread](https://chat.google.com/room/AAQA8ub_cFI/Y9v6KGyJzOs/Y9v6KGyJzOs?cls=10).

Reviewed By: mariusae

Differential Revision: D88786867


