### PR TITLE
Add requirement for Handler<SupervisionFailureMessage> to ProcMesh::spawn

### DIFF
--- a/hyperactor_mesh/benches/main.rs
+++ b/hyperactor_mesh/benches/main.rs
@@ -13,7 +13,6 @@ use criterion::Criterion;
 use criterion::Throughput;
 use criterion::criterion_group;
 use criterion::criterion_main;
-use hyperactor::Proc;
 use hyperactor::channel::ChannelTransport;
 use hyperactor_mesh::ProcMesh;
 use hyperactor_mesh::actor_mesh::ActorMesh;
@@ -22,6 +21,7 @@ use hyperactor_mesh::alloc::AllocSpec;
 use hyperactor_mesh::alloc::Allocator;
 use hyperactor_mesh::alloc::LocalAllocator;
 use hyperactor_mesh::extent;
+use hyperactor_mesh::proc_mesh::global_root_client;
 use hyperactor_mesh::selection::dsl::all;
 use hyperactor_mesh::selection::dsl::true_;
 use tokio::time::Duration;
@@ -53,7 +53,7 @@ fn bench_actor_scaling(c: &mut Criterion) {
                     .await
                     .unwrap();
 
-                let (bootstrap_instance, _) = Proc::local().instance("bench").unwrap();
+                let bootstrap_instance = global_root_client();
                 let mut proc_mesh = ProcMesh::allocate(alloc).await.unwrap();
                 let actor_mesh: RootActorMesh<BenchActor> = proc_mesh
                     .spawn(&bootstrap_instance, "bench", &(Duration::from_millis(0)))
@@ -153,7 +153,7 @@ fn bench_actor_mesh_message_sizes(c: &mut Criterion) {
                             .await
                             .unwrap();
 
-                        let (bootstrap_instance, _) = Proc::local().instance("bench").unwrap();
+                        let bootstrap_instance = global_root_client();
                         let mut proc_mesh = ProcMesh::allocate(alloc).await.unwrap();
                         let actor_mesh: RootActorMesh<BenchActor> = proc_mesh
                             .spawn(&bootstrap_instance, "bench", &(Duration::from_millis(0)))

--- a/hyperactor_mesh/examples/dining_philosophers.rs
+++ b/hyperactor_mesh/examples/dining_philosophers.rs
@@ -27,6 +27,7 @@ use hyperactor::context;
 use hyperactor_mesh::comm::multicast::CastInfo;
 use hyperactor_mesh::extent;
 use hyperactor_mesh::proc_mesh::global_root_client;
+use hyperactor_mesh::v1::ActorMesh;
 use hyperactor_mesh::v1::ActorMeshRef;
 use hyperactor_mesh::v1::host_mesh::HostMesh;
 use ndslice::ViewExt;
@@ -251,9 +252,8 @@ async fn main() -> Result<ExitCode> {
         .await?;
 
     let params = PhilosopherActorParams { size: group_size };
-    let actor_mesh = proc_mesh
-        .spawn::<PhilosopherActor>(&instance, "philosopher", &params)
-        .await?;
+    let actor_mesh: ActorMesh<PhilosopherActor> =
+        proc_mesh.spawn(&instance, "philosopher", &params).await?;
     let (dining_message_handle, mut dining_message_rx) = instance.open_port();
     actor_mesh
         .cast(

--- a/hyperactor_mesh/examples/sieve.rs
+++ b/hyperactor_mesh/examples/sieve.rs
@@ -22,15 +22,16 @@ use hyperactor::Context;
 use hyperactor::Handler;
 use hyperactor::Named;
 use hyperactor::PortRef;
-use hyperactor::Proc;
 use hyperactor::RemoteSpawn;
 use hyperactor::channel::ChannelTransport;
 use hyperactor_mesh::Mesh;
 use hyperactor_mesh::ProcMesh;
+use hyperactor_mesh::RootActorMesh;
 use hyperactor_mesh::alloc::AllocSpec;
 use hyperactor_mesh::alloc::Allocator;
 use hyperactor_mesh::alloc::LocalAllocator;
 use hyperactor_mesh::extent;
+use hyperactor_mesh::proc_mesh::global_root_client;
 use serde::Deserialize;
 use serde::Serialize;
 
@@ -125,12 +126,11 @@ async fn main() -> Result<ExitCode> {
 
     let mesh = ProcMesh::allocate(alloc).await?;
 
-    let (instance, _) = Proc::local().instance("client").unwrap();
+    let instance = global_root_client();
 
     let sieve_params = SieveParams { prime: 2 };
-    let sieve_mesh = mesh
-        .spawn::<SieveActor>(&instance, "sieve", &sieve_params)
-        .await?;
+    let sieve_mesh: RootActorMesh<SieveActor> =
+        mesh.spawn(&instance, "sieve", &sieve_params).await?;
     let sieve_head = sieve_mesh.get(0).unwrap();
 
     let mut primes = vec![2];

--- a/hyperactor_mesh/examples/test_bench.rs
+++ b/hyperactor_mesh/examples/test_bench.rs
@@ -27,6 +27,7 @@ use hyperactor::clock::RealClock;
 use hyperactor_mesh::bootstrap::BootstrapCommand;
 use hyperactor_mesh::comm::multicast::CastInfo;
 use hyperactor_mesh::proc_mesh::global_root_client;
+use hyperactor_mesh::v1::actor_mesh::ActorMesh;
 use hyperactor_mesh::v1::host_mesh::HostMesh;
 use ndslice::Point;
 use ndslice::ViewExt;
@@ -79,10 +80,7 @@ async fn main() {
         .await
         .unwrap();
 
-    let actor_mesh = proc_mesh
-        .spawn::<TestActor>(instance, "test", &())
-        .await
-        .unwrap();
+    let actor_mesh: ActorMesh<TestActor> = proc_mesh.spawn(instance, "test", &()).await.unwrap();
 
     loop {
         let mut received = HashSet::new();

--- a/hyperactor_mesh/src/bootstrap.rs
+++ b/hyperactor_mesh/src/bootstrap.rs
@@ -2402,6 +2402,7 @@ mod tests {
     use crate::v1::ActorMesh;
     use crate::v1::host_mesh::HostMesh;
     use crate::v1::testactor;
+    use crate::v1::testing;
 
     // Helper: Avoid repeating
     // `ChannelAddr::any(ChannelTransport::Unix)`.
@@ -3603,13 +3604,9 @@ mod tests {
         unsafe {
             std::env::set_var("HYPERACTOR_MESH_BOOTSTRAP_ENABLE_PDEATHSIG", "false");
         }
-        // Create a "root" direct addressed proc.
-        let proc = Proc::direct(ChannelTransport::Unix.any(), "root".to_string())
-            .await
-            .unwrap();
         // Create an actor instance we'll use to send and receive
         // messages.
-        let (instance, _handle) = proc.instance("client").unwrap();
+        let instance = testing::instance().await;
 
         // Configure a ProcessAllocator with the bootstrap binary.
         let mut allocator = ProcessAllocator::new(Command::new(crate::testresource::get(

--- a/hyperactor_mesh/src/lib.rs
+++ b/hyperactor_mesh/src/lib.rs
@@ -32,6 +32,7 @@ pub mod resource;
 pub mod router;
 pub mod shared_cell;
 pub mod shortuuid;
+pub mod supervision;
 #[cfg(target_os = "linux")]
 mod systemd;
 pub mod test_utils;

--- a/hyperactor_mesh/src/supervision.rs
+++ b/hyperactor_mesh/src/supervision.rs
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+//! Messages used in supervision of actor meshes.
+
+use hyperactor::Bind;
+use hyperactor::Named;
+use hyperactor::Unbind;
+use hyperactor::actor::ActorErrorKind;
+use hyperactor::actor::ActorStatus;
+use hyperactor::context;
+use hyperactor::supervision::ActorSupervisionEvent;
+use serde::Deserialize;
+use serde::Serialize;
+
+/// Message about a supervision failure on a mesh of actors instead of a single
+/// actor.
+#[derive(Clone, Debug, Serialize, Deserialize, Named, PartialEq, Bind, Unbind)]
+pub struct SupervisionFailureMessage {
+    /// Name of the mesh which the event originated from.
+    pub actor_mesh_name: Option<String>,
+    /// Rank of the mesh from which the event originated.
+    /// TODO: Point instead?
+    pub rank: Option<usize>,
+    /// The supervision event on an actor located at mesh + rank.
+    pub event: ActorSupervisionEvent,
+}
+
+impl SupervisionFailureMessage {
+    /// Helper function to handle a message to an actor that just wants to forward
+    /// it to the next owner.
+    pub fn default_handler(&self, cx: &impl context::Actor) -> Result<(), anyhow::Error> {
+        // If an actor spawned by this one fails, we can't handle it. We fail
+        // ourselves with a chained error and bubble up to the next owner.
+        let err = ActorErrorKind::UnhandledSupervisionEvent(Box::new(ActorSupervisionEvent::new(
+            cx.instance().self_id().clone(),
+            None,
+            ActorStatus::Failed(ActorErrorKind::UnhandledSupervisionEvent(Box::new(
+                self.event.clone(),
+            ))),
+            None,
+        )));
+        Err(anyhow::Error::new(err))
+    }
+}
+
+impl std::fmt::Display for SupervisionFailureMessage {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "Supervision failure on mesh {:?} at rank {:?} with event: {}",
+            self.actor_mesh_name, self.rank, self.event
+        )
+    }
+}

--- a/hyperactor_mesh/src/v1/actor_mesh.rs
+++ b/hyperactor_mesh/src/v1/actor_mesh.rs
@@ -589,8 +589,8 @@ mod tests {
         let proc_mesh = &meshes[1];
         let child_name = Name::new("child").unwrap();
 
-        let actor_mesh = proc_mesh
-            .spawn_with_name::<testactor::TestActor>(instance, child_name.clone(), &())
+        let actor_mesh: ActorMesh<testactor::TestActor> = proc_mesh
+            .spawn_with_name(instance, child_name.clone(), &())
             .await
             .unwrap();
 
@@ -659,8 +659,8 @@ mod tests {
         let proc_mesh = &meshes[1];
         let child_name = Name::new("child").unwrap();
 
-        let actor_mesh = proc_mesh
-            .spawn_with_name::<testactor::TestActor>(instance, child_name.clone(), &())
+        let actor_mesh: ActorMesh<testactor::TestActor> = proc_mesh
+            .spawn_with_name(instance, child_name.clone(), &())
             .await
             .unwrap();
 
@@ -724,8 +724,8 @@ mod tests {
         let proc_mesh = &meshes[1];
         let child_name = Name::new("child").unwrap();
 
-        let actor_mesh = proc_mesh
-            .spawn_with_name::<testactor::TestActor>(instance, child_name.clone(), &())
+        let actor_mesh: ActorMesh<testactor::TestActor> = proc_mesh
+            .spawn_with_name(instance, child_name.clone(), &())
             .await
             .unwrap();
         let sliced = actor_mesh
@@ -795,10 +795,8 @@ mod tests {
             .spawn(instance, "test", Extent::unity())
             .await
             .unwrap();
-        let actor_mesh = proc_mesh
-            .spawn::<testactor::TestActor>(instance, "test", &())
-            .await
-            .unwrap();
+        let actor_mesh: ActorMesh<testactor::TestActor> =
+            proc_mesh.spawn(instance, "test", &()).await.unwrap();
 
         let (cast_info, mut cast_info_rx) = instance.mailbox().open_port();
         actor_mesh
@@ -862,8 +860,8 @@ mod tests {
         let ping_proc_mesh = proc_mesh.range("replicas", 0..1).unwrap();
         let pong_proc_mesh = proc_mesh.range("replicas", 1..2).unwrap();
 
-        let ping_mesh = ping_proc_mesh
-            .spawn::<PingPongActor>(
+        let ping_mesh: ActorMesh<PingPongActor> = ping_proc_mesh
+            .spawn(
                 instance,
                 "ping",
                 &(Some(undeliverable_port.bind()), None, None),
@@ -871,8 +869,8 @@ mod tests {
             .await
             .unwrap();
 
-        let pong_mesh = pong_proc_mesh
-            .spawn::<PingPongActor>(instance, "pong", &(None, None, None))
+        let pong_mesh: ActorMesh<PingPongActor> = pong_proc_mesh
+            .spawn(instance, "pong", &(None, None, None))
             .await
             .unwrap();
 
@@ -966,10 +964,8 @@ mod tests {
 
         // Spawn SleepActors across the mesh that will block longer
         // than timeout
-        let sleep_mesh = proc_mesh
-            .spawn::<testactor::SleepActor>(instance, "sleepers", &())
-            .await
-            .unwrap();
+        let sleep_mesh: ActorMesh<testactor::SleepActor> =
+            proc_mesh.spawn(instance, "sleepers", &()).await.unwrap();
 
         // Send each actor a message to sleep for 5 seconds (longer
         // than 1-second timeout)
@@ -1049,10 +1045,8 @@ mod tests {
 
         // Spawn TestActors - these stop cleanly (no blocking
         // operations)
-        let actor_mesh = proc_mesh
-            .spawn::<testactor::TestActor>(instance, "test_actors", &())
-            .await
-            .unwrap();
+        let actor_mesh: ActorMesh<testactor::TestActor> =
+            proc_mesh.spawn(instance, "test_actors", &()).await.unwrap();
 
         let expected_actors = actor_mesh.values().count();
         assert!(expected_actors > 0, "Should have spawned some actors");

--- a/hyperactor_mesh/src/v1/testactor.rs
+++ b/hyperactor_mesh/src/v1/testactor.rs
@@ -32,6 +32,8 @@ use hyperactor::Unbind;
 use hyperactor::clock::Clock as _;
 use hyperactor::clock::RealClock;
 #[cfg(test)]
+use hyperactor::context;
+#[cfg(test)]
 use hyperactor::mailbox;
 use hyperactor::supervision::ActorSupervisionEvent;
 use hyperactor_config::global::Source;
@@ -306,7 +308,7 @@ pub async fn assert_mesh_shape(actor_mesh: ActorMesh<TestActor>) {
 /// Cast to the actor mesh, and verify that all actors are reached.
 pub async fn assert_casting_correctness(
     actor_mesh: &ActorMeshRef<TestActor>,
-    instance: &Instance<()>,
+    instance: &impl context::Actor,
 ) {
     let (port, mut rx) = mailbox::open_port(instance);
     actor_mesh.cast(instance, GetActorId(port.bind())).unwrap();

--- a/monarch_hyperactor/src/actor.rs
+++ b/monarch_hyperactor/src/actor.rs
@@ -43,6 +43,7 @@ use hyperactor_mesh::comm::multicast::CastInfo;
 use hyperactor_mesh::proc_mesh::default_transport;
 use hyperactor_mesh::reference::ActorMeshId;
 use hyperactor_mesh::router;
+use hyperactor_mesh::supervision::SupervisionFailureMessage;
 use monarch_types::PickledPyObject;
 use monarch_types::SerializablePyErr;
 use pyo3::IntoPyObjectExt;
@@ -83,7 +84,6 @@ use crate::pytokio::PythonTask;
 use crate::runtime::get_tokio_runtime;
 use crate::runtime::signal_safe_block_on;
 use crate::supervision::MeshFailure;
-use crate::supervision::SupervisionFailureMessage;
 
 #[pyclass(frozen, module = "monarch._rust_bindings.monarch_hyperactor.actor")]
 #[derive(Serialize, Deserialize, Named)]

--- a/monarch_hyperactor/src/code_sync/manager.rs
+++ b/monarch_hyperactor/src/code_sync/manager.rs
@@ -666,8 +666,8 @@ mod tests {
         let instance = global_root_client();
 
         // Spawn actor mesh with CodeSyncManager actors
-        let actor_mesh = proc_mesh
-            .spawn::<CodeSyncManager>(&instance, "code_sync_test", &params)
+        let actor_mesh: RootActorMesh<CodeSyncManager> = proc_mesh
+            .spawn(&instance, "code_sync_test", &params)
             .await?;
 
         // Create workspace configuration

--- a/monarch_hyperactor/src/code_sync/rsync.rs
+++ b/monarch_hyperactor/src/code_sync/rsync.rs
@@ -457,6 +457,7 @@ mod tests {
     use anyhow::Result;
     use anyhow::anyhow;
     use hyperactor::channel::ChannelTransport;
+    use hyperactor_mesh::actor_mesh::RootActorMesh;
     use hyperactor_mesh::alloc::AllocSpec;
     use hyperactor_mesh::alloc::Allocator;
     use hyperactor_mesh::alloc::local::LocalAllocator;
@@ -522,9 +523,8 @@ mod tests {
         let instance = global_root_client();
 
         // Spawn actor mesh with RsyncActors
-        let actor_mesh = proc_mesh
-            .spawn::<RsyncActor>(&instance, "rsync_test", &())
-            .await?;
+        let actor_mesh: RootActorMesh<RsyncActor> =
+            proc_mesh.spawn(&instance, "rsync_test", &()).await?;
 
         // Test rsync_mesh function - this coordinates rsync operations across the mesh
         let results = rsync_mesh(

--- a/monarch_hyperactor/src/supervision.rs
+++ b/monarch_hyperactor/src/supervision.rs
@@ -6,14 +6,10 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-use hyperactor::Bind;
-use hyperactor::Named;
-use hyperactor::Unbind;
 use hyperactor::supervision::ActorSupervisionEvent;
+use hyperactor_mesh::supervision::SupervisionFailureMessage;
 use pyo3::exceptions::PyRuntimeError;
 use pyo3::prelude::*;
-use serde::Deserialize;
-use serde::Serialize;
 
 #[pyclass(
     name = "SupervisionError",
@@ -60,13 +56,6 @@ impl SupervisionError {
             format!("SupervisionError('{}')", self.message)
         }
     }
-}
-
-#[derive(Clone, Debug, Serialize, Deserialize, Named, PartialEq, Bind, Unbind)]
-pub struct SupervisionFailureMessage {
-    pub actor_mesh_name: Option<String>,
-    pub rank: Option<usize>,
-    pub event: ActorSupervisionEvent,
 }
 
 // TODO: find out how to extend a Python exception and have internal data.

--- a/monarch_hyperactor/src/v1/actor_mesh.rs
+++ b/monarch_hyperactor/src/v1/actor_mesh.rs
@@ -28,6 +28,7 @@ use hyperactor_mesh::bootstrap::ProcStatus;
 use hyperactor_mesh::dashmap::DashMap;
 use hyperactor_mesh::proc_mesh::mesh_agent::ActorState;
 use hyperactor_mesh::resource;
+use hyperactor_mesh::supervision::SupervisionFailureMessage;
 use hyperactor_mesh::v1::Name;
 use hyperactor_mesh::v1::actor_mesh::ActorMesh;
 use hyperactor_mesh::v1::actor_mesh::ActorMeshRef;
@@ -61,7 +62,6 @@ use crate::pytokio::PyShared;
 use crate::runtime::get_tokio_runtime;
 use crate::shape::PyRegion;
 use crate::supervision::SupervisionError;
-use crate::supervision::SupervisionFailureMessage;
 use crate::supervision::Unhealthy;
 
 struct RootHealthState {

--- a/monarch_hyperactor/tests/code_sync/auto_reload.rs
+++ b/monarch_hyperactor/tests/code_sync/auto_reload.rs
@@ -8,14 +8,15 @@
 
 use anyhow::Result;
 use anyhow::anyhow;
-use hyperactor::Proc;
 use hyperactor::channel::ChannelTransport;
 use hyperactor_mesh::actor_mesh::ActorMesh;
+use hyperactor_mesh::actor_mesh::RootActorMesh;
 use hyperactor_mesh::alloc::AllocSpec;
 use hyperactor_mesh::alloc::Allocator;
 use hyperactor_mesh::alloc::local::LocalAllocator;
 use hyperactor_mesh::mesh::Mesh;
 use hyperactor_mesh::proc_mesh::ProcMesh;
+use hyperactor_mesh::proc_mesh::global_root_client;
 use monarch_hyperactor::code_sync::auto_reload::AutoReloadActor;
 use monarch_hyperactor::code_sync::auto_reload::AutoReloadMessage;
 use monarch_hyperactor::code_sync::auto_reload::AutoReloadParams;
@@ -57,12 +58,12 @@ CONSTANT = "initial_constant"
         })
         .await?;
 
-    let (instance, _) = Proc::local().instance("client").unwrap();
+    let instance = global_root_client();
 
     let proc_mesh = ProcMesh::allocate(alloc).await?;
     let params = AutoReloadParams {};
-    let actor_mesh = proc_mesh
-        .spawn::<AutoReloadActor>(&instance, "auto_reload_test", &params)
+    let actor_mesh: RootActorMesh<AutoReloadActor> = proc_mesh
+        .spawn(&instance, "auto_reload_test", &params)
         .await?;
 
     // Get a reference to the single actor

--- a/monarch_rdma/examples/cuda_ping_pong/src/cuda_ping_pong.rs
+++ b/monarch_rdma/examples/cuda_ping_pong/src/cuda_ping_pong.rs
@@ -66,7 +66,6 @@ use hyperactor::Handler;
 use hyperactor::Instance;
 use hyperactor::Named;
 use hyperactor::OncePortRef;
-use hyperactor::Proc;
 use hyperactor::RemoteSpawn;
 use hyperactor::Unbind;
 use hyperactor::channel::ChannelTransport;
@@ -78,6 +77,7 @@ use hyperactor_mesh::alloc::AllocSpec;
 use hyperactor_mesh::alloc::Allocator;
 use hyperactor_mesh::alloc::ProcessAllocator;
 use hyperactor_mesh::extent;
+use hyperactor_mesh::proc_mesh::global_root_client;
 use monarch_rdma::IbverbsConfig;
 use monarch_rdma::RdmaBuffer;
 use monarch_rdma::RdmaManagerActor;
@@ -697,7 +697,7 @@ pub async fn run() -> Result<(), anyhow::Error> {
         device_2_ibv_config = IbverbsConfig::default();
     }
 
-    let (instance, _) = Proc::local().instance("test").unwrap();
+    let instance = global_root_client();
 
     // Create process allocator for spawning actors
     let mut alloc = ProcessAllocator::new(Command::new(

--- a/monarch_rdma/examples/parameter_server/src/parameter_server.rs
+++ b/monarch_rdma/examples/parameter_server/src/parameter_server.rs
@@ -65,7 +65,6 @@ use hyperactor::Instance;
 use hyperactor::Named;
 use hyperactor::OncePortRef;
 use hyperactor::PortRef;
-use hyperactor::Proc;
 use hyperactor::RemoteSpawn;
 use hyperactor::Unbind;
 use hyperactor::channel::ChannelTransport;
@@ -79,6 +78,7 @@ use hyperactor_mesh::alloc::AllocSpec;
 use hyperactor_mesh::alloc::Allocator;
 use hyperactor_mesh::alloc::ProcessAllocator;
 use hyperactor_mesh::comm::multicast::CastInfo;
+use hyperactor_mesh::proc_mesh::global_root_client;
 use monarch_rdma::IbverbsConfig;
 use monarch_rdma::RdmaBuffer;
 use monarch_rdma::RdmaManagerActor;
@@ -475,7 +475,7 @@ pub async fn run(num_workers: usize, num_steps: usize) -> Result<(), anyhow::Err
     // As normal, create a proc mesh for the parameter server.
     tracing::info!("creating parameter server proc mesh...");
 
-    let (instance, _) = Proc::local().instance("client").unwrap();
+    let instance = global_root_client();
 
     let mut alloc = ProcessAllocator::new(Command::new(
         buck_resources::get("monarch/monarch_rdma/examples/parameter_server/bootstrap").unwrap(),

--- a/monarch_rdma/extension/lib.rs
+++ b/monarch_rdma/extension/lib.rs
@@ -357,10 +357,10 @@ impl PyRdmaManager {
             PyPythonTask::new(async move {
                 // Spawns the `RdmaManagerActor` on the target proc_mesh.
                 // This allows the `RdmaController` to run on any node while real RDMA operations occur on appropriate hardware.
-                let actor_mesh = tracked_proc_mesh
+                let actor_mesh: SharedCell<RootActorMesh<RdmaManagerActor>> = tracked_proc_mesh
                     // Pass None to use default config - RdmaManagerActor will use default IbverbsConfig
                     // TODO - make IbverbsConfig configurable
-                    .spawn::<RdmaManagerActor>(client.deref(), "rdma_manager", &None)
+                    .spawn(client.deref(), "rdma_manager", &None)
                     .await
                     .map_err(|err| PyException::new_err(err.to_string()))?;
 
@@ -373,10 +373,10 @@ impl PyRdmaManager {
         } else {
             let proc_mesh = proc_mesh.downcast::<PyProcMeshV1>()?.borrow().mesh_ref()?;
             PyPythonTask::new(async move {
-                let actor_mesh = proc_mesh
+                let actor_mesh: hyperactor_mesh::v1::ActorMesh<RdmaManagerActor> = proc_mesh
                     // Pass None to use default config - RdmaManagerActor will use default IbverbsConfig
                     // TODO - make IbverbsConfig configurable
-                    .spawn_service::<RdmaManagerActor>(client.deref(), "rdma_manager", &None)
+                    .spawn_service(client.deref(), "rdma_manager", &None)
                     .await
                     .map_err(|err| PyException::new_err(err.to_string()))?;
 

--- a/monarch_rdma/src/test_utils.rs
+++ b/monarch_rdma/src/test_utils.rs
@@ -83,7 +83,6 @@ pub mod test_utils {
     use hyperactor::HandleClient;
     use hyperactor::Handler;
     use hyperactor::Instance;
-    use hyperactor::Proc;
     use hyperactor::RefClient;
     use hyperactor::RemoteSpawn;
     use hyperactor::channel::ChannelTransport;
@@ -95,6 +94,7 @@ pub mod test_utils {
     use hyperactor_mesh::alloc::AllocSpec;
     use hyperactor_mesh::alloc::Allocator;
     use hyperactor_mesh::alloc::LocalAllocator;
+    use hyperactor_mesh::proc_mesh::global_root_client;
     use ndslice::extent;
 
     use crate::IbverbsConfig;
@@ -589,7 +589,7 @@ pub mod test_utils {
                 .await
                 .unwrap();
 
-            let (instance, _) = Proc::local().instance("test").unwrap();
+            let instance = global_root_client();
 
             let proc_mesh_1 = Box::leak(Box::new(ProcMesh::allocate(alloc_1).await.unwrap()));
             let actor_mesh_1: RootActorMesh<'_, RdmaManagerActor> = proc_mesh_1


### PR DESCRIPTION
Summary:
Part of: https://github.com/meta-pytorch/monarch/issues/2027

In order for all actor types to support supervising the actors they own, we need to add
a capability to spawn, which requires the context to handle supervision messages.

Add this trait bound to ProcMesh::spawn, and further that to all callers.
A lot of tests used `Instance<()>` to spawn actors, so this was changed to 
`Instance<TestRootClient>` to support these messages. The root client just
panics if it actually receives one of these messages.

The `global_root_client` used for non-tests now supports this message via its type,
but it doesn't actually have a message handling loop for the message. That should be ok,
as this is only used for v0.

Differential Revision: D88877061


