### PR TITLE
: bootstrap: fix missing config propagation to v0 proc mesh bootstrap processes

### DIFF
--- a/hyperactor_mesh/src/alloc/process.rs
+++ b/hyperactor_mesh/src/alloc/process.rs
@@ -482,6 +482,13 @@ impl ProcessAlloc {
         self.created.push(ShortUuid::generate());
         let create_key = &self.created[index];
 
+        // Capture config and pass to child via Bootstrap::V0ProcMesh
+        let client_config = hyperactor_config::global::attrs();
+        let bootstrap = bootstrap::Bootstrap::V0ProcMesh {
+            config: Some(client_config),
+        };
+        bootstrap.to_env(&mut cmd);
+
         cmd.env(
             bootstrap::BOOTSTRAP_ADDR_ENV,
             self.bootstrap_addr.to_string(),


### PR DESCRIPTION
Summary:
host mesh processes spawned by `ProcessAllocator` weren't getting client config. this has been harmless so far - child procs spawned by the hosts correctly get their config direct from the client.

this fix ensures consistency - host processes now also run with the client's intended config, not just the worker procs.

so, this closes a gap that existed but didn't cause problems in practice - good to fix even if we'll soon remove this code path entirely.

Differential Revision: D88983141


