### PR TITLE
[hyperactor] `Referable` is just `Named`

### DIFF
--- a/hyperactor/src/actor.rs
+++ b/hyperactor/src/actor.rs
@@ -693,16 +693,13 @@ impl<A: Actor> Clone for ActorHandle<A> {
 /// `Referable` so that you can hand out restricted or stable APIs
 /// while still using the same remote messaging machinery.
 ///
-/// Implementing this trait means the type:
-/// - can be identified (`Named`) so the runtime knows what it is,
-/// - is safe to pass across threads (`Send + Sync`),
-/// - and can be carried in [`ActorRef<T>`] values across process
-///   boundaries.
+/// Implementing this trait means the type can be identified (`Named`)
+/// so the runtime knows what it is.
 ///
-/// In contrast, [`RemoteSpawn`] is the trait that marks *actors*
+///  In contrast, [`RemoteSpawn`] is the trait that marks *actors*
 /// that can actually be **spawned remotely**. A behavior may be a
 /// `Referable` but is never a `RemoteSpawn`.
-pub trait Referable: Named + Send + Sync {}
+pub trait Referable: Named {}
 
 /// Binds determines how an actor's ports are bound to a specific
 /// reference type.

--- a/hyperactor/src/host.rs
+++ b/hyperactor/src/host.rs
@@ -1042,7 +1042,7 @@ impl<A> ProcManager for ProcessProcManager<A>
 where
     // Agent actor runs in the proc (`Actor`) and must be
     // referenceable (`Referable`).
-    A: Actor + Referable,
+    A: Actor + Referable + Sync,
 {
     type Handle = ProcessHandle<A>;
 

--- a/hyperactor_mesh/src/v1/mesh_controller.rs
+++ b/hyperactor_mesh/src/v1/mesh_controller.rs
@@ -24,19 +24,19 @@ use crate::v1::proc_mesh::ProcMeshRef;
 #[hyperactor::export]
 pub(crate) struct ActorMeshController<A>
 where
-    A: Referable,
+    A: Referable + Send,
 {
     mesh: ActorMeshRef<A>,
 }
 
-impl<A: Referable> ActorMeshController<A> {
+impl<A: Referable + Send> ActorMeshController<A> {
     /// Create a new mesh controller based on the provided reference.
     pub(crate) fn new(mesh: ActorMeshRef<A>) -> Self {
         Self { mesh }
     }
 }
 
-impl<A: Referable> Debug for ActorMeshController<A> {
+impl<A: Referable + Send> Debug for ActorMeshController<A> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("MeshController")
             .field("mesh", &self.mesh)
@@ -45,7 +45,7 @@ impl<A: Referable> Debug for ActorMeshController<A> {
 }
 
 #[async_trait]
-impl<A: Referable> Actor for ActorMeshController<A> {
+impl<A: Referable + Send> Actor for ActorMeshController<A> {
     async fn cleanup(
         &mut self,
         this: &Instance<Self>,

--- a/monarch_hyperactor/src/proc_mesh.rs
+++ b/monarch_hyperactor/src/proc_mesh.rs
@@ -86,7 +86,7 @@ impl From<ProcMesh> for TrackedProcMesh {
 }
 
 impl TrackedProcMesh {
-    pub async fn spawn<A: RemoteSpawn>(
+    pub async fn spawn<A: RemoteSpawn + Sync>(
         &self,
         cx: &impl context::Actor,
         actor_name: &str,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #2135
* __->__ #2132

Referable should not require `Send + Sync` since Referable applies to the referand, not the reference itself -- it is perfectly ok for the referand to be neither of those.

Differential Revision: [D89052077](https://our.internmc.facebook.com/intern/diff/D89052077/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D89052077/)!