### PR TITLE
[hyperactor_mesh] bootstrapped local host

### DIFF
--- a/hyperactor/src/proc.rs
+++ b/hyperactor/src/proc.rs
@@ -966,6 +966,12 @@ pub struct Instance<A: Actor> {
     inner: Arc<InstanceState<A>>,
 }
 
+impl<A: Actor> fmt::Debug for Instance<A> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Instance").field("inner", &"..").finish()
+    }
+}
+
 struct InstanceState<A: Actor> {
     /// The proc that owns this instance.
     proc: Proc,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #2133
* #2132

Add `bootstrap::host()`, providing a way to bootstrap an in-process host. The host, in turn, provides an in-process proc. We add handlers to the agents along the way that allows the local process to bootstrap a client side actor on the host-managed local proc.

The upshot is that we can now fully bootstrap a *valid* host/proc/actor hierarchy locally, out of which we can construct singleton host/proc/actor meshes.

With this, we can remove the distinction between a 'client' and a 'worker'. The only difference is that a client bundles the host and client proc in a single physical process.

This means: 1) we can push down the fake implementations in today's python implementation down to rust -- the root client now has a correct proc/host mesh associated with it; and 2) since we manage the process as a host, we require binding only a single frontend address, which is managed by the host, as with any other host/process in the system.

Differential Revision: [D89052078](https://our.internmc.facebook.com/intern/diff/D89052078/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D89052078/)!