### PR TITLE
[hyperactor] Message, Actor, etc. does not require `Debug`

### DIFF
--- a/hyperactor/src/actor.rs
+++ b/hyperactor/src/actor.rs
@@ -67,7 +67,7 @@ pub mod remote;
 /// Actors are assumed to be _deterministic_: that is, the state of an
 /// actor is determined by the set (and order) of messages it receives.
 #[async_trait]
-pub trait Actor: Sized + Send + Debug + 'static {
+pub trait Actor: Sized + Send + 'static {
     /// Initialize the actor, after the runtime has been fully initialized.
     /// Init thus provides a mechanism by which an actor can reliably and always
     /// receive some initial event that can be used to kick off further

--- a/hyperactor/src/channel.rs
+++ b/hyperactor/src/channel.rs
@@ -107,7 +107,7 @@ pub enum TxStatus {
 
 /// The transmit end of an M-typed channel.
 #[async_trait]
-pub trait Tx<M: RemoteMessage>: std::fmt::Debug {
+pub trait Tx<M: RemoteMessage> {
     /// Post a message; returning failed deliveries on the return channel, if provided.
     /// If provided, the sender is dropped when the message has been
     /// enqueued at the channel endpoint.
@@ -154,7 +154,7 @@ pub trait Tx<M: RemoteMessage>: std::fmt::Debug {
 
 /// The receive end of an M-typed channel.
 #[async_trait]
-pub trait Rx<M: RemoteMessage>: std::fmt::Debug {
+pub trait Rx<M: RemoteMessage> {
     /// Receive the next message from the channel. If the channel returns
     /// an error it is considered broken and should be discarded.
     async fn recv(&mut self) -> Result<M, ChannelError>;
@@ -163,7 +163,6 @@ pub trait Rx<M: RemoteMessage>: std::fmt::Debug {
     fn addr(&self) -> ChannelAddr;
 }
 
-#[derive(Debug)]
 struct MpscTx<M: RemoteMessage> {
     tx: mpsc::UnboundedSender<M>,
     addr: ChannelAddr,
@@ -205,7 +204,6 @@ impl<M: RemoteMessage> Tx<M> for MpscTx<M> {
     }
 }
 
-#[derive(Debug)]
 struct MpscRx<M: RemoteMessage> {
     rx: mpsc::UnboundedReceiver<M>,
     addr: ChannelAddr,
@@ -739,13 +737,19 @@ impl ChannelAddr {
 }
 
 /// Universal channel transmitter.
-#[derive(Debug)]
 pub struct ChannelTx<M: RemoteMessage> {
     inner: ChannelTxKind<M>,
 }
 
+impl<M: RemoteMessage> fmt::Debug for ChannelTx<M> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ChannelTx")
+            .field("addr", &self.addr())
+            .finish()
+    }
+}
+
 /// Universal channel transmitter.
-#[derive(Debug)]
 enum ChannelTxKind<M: RemoteMessage> {
     Local(local::LocalTx<M>),
     Tcp(net::NetTx<M>),
@@ -788,13 +792,19 @@ impl<M: RemoteMessage> Tx<M> for ChannelTx<M> {
 }
 
 /// Universal channel receiver.
-#[derive(Debug)]
 pub struct ChannelRx<M: RemoteMessage> {
     inner: ChannelRxKind<M>,
 }
 
+impl<M: RemoteMessage> fmt::Debug for ChannelRx<M> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ChannelRx")
+            .field("addr", &self.addr())
+            .finish()
+    }
+}
+
 /// Universal channel receiver.
-#[derive(Debug)]
 enum ChannelRxKind<M: RemoteMessage> {
     Local(local::LocalRx<M>),
     Tcp(net::NetRx<M>),

--- a/hyperactor/src/channel/local.rs
+++ b/hyperactor/src/channel/local.rs
@@ -62,7 +62,6 @@ impl Default for Ports {
 
 static PORTS: LazyLock<Mutex<Ports>> = LazyLock::new(|| Mutex::new(Ports::default()));
 
-#[derive(Debug)]
 pub struct LocalTx<M: RemoteMessage> {
     tx: mpsc::UnboundedSender<Data>,
     port: u64,
@@ -102,7 +101,6 @@ impl<M: RemoteMessage> Tx<M> for LocalTx<M> {
     }
 }
 
-#[derive(Debug)]
 pub struct LocalRx<M: RemoteMessage> {
     data_rx: mpsc::UnboundedReceiver<Data>,
     status_tx: watch::Sender<TxStatus>,

--- a/hyperactor/src/channel/sim.rs
+++ b/hyperactor/src/channel/sim.rs
@@ -222,7 +222,6 @@ impl<M: RemoteMessage> Drop for SimRx<M> {
 }
 
 /// Primarily used for dispatching messages to the correct sender.
-#[derive(Debug)]
 pub struct SimDispatcher {
     dispatchers: DashMap<ChannelAddr, mpsc::Sender<Serialized>>,
     sender_cache: DashMap<ChannelAddr, Arc<dyn Tx<MessageEnvelope> + Send + Sync>>,
@@ -258,7 +257,6 @@ impl Default for SimDispatcher {
     }
 }
 
-#[derive(Debug)]
 pub(crate) struct SimTx<M: RemoteMessage> {
     src_addr: Option<ChannelAddr>,
     dst_addr: ChannelAddr,
@@ -267,7 +265,6 @@ pub(crate) struct SimTx<M: RemoteMessage> {
     _phantom: PhantomData<M>,
 }
 
-#[derive(Debug)]
 pub(crate) struct SimRx<M: RemoteMessage> {
     /// The destination address, not the full SimAddr.
     addr: ChannelAddr,

--- a/hyperactor/src/host.rs
+++ b/hyperactor/src/host.rs
@@ -120,7 +120,6 @@ pub enum HostError {
 
 /// A host, managing the lifecycle of several procs, and their backend
 /// routing, as described in this module's documentation.
-#[derive(Debug)]
 pub struct Host<M> {
     procs: HashSet<String>,
     frontend_addr: ChannelAddr,
@@ -266,7 +265,7 @@ impl<M: ProcManager> Host<M> {
 
 /// A router used to route to the system proc, or else fall back to
 /// the dial mailbox router.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 struct ProcOrDial {
     proc: Proc,
     dialer: DialMailboxRouter,
@@ -749,7 +748,6 @@ where
 ///
 /// **Type parameter:** `A` is constrained by the `ProcHandle::Agent`
 /// bound (`Actor + Referable`).
-#[derive(Debug)]
 pub struct LocalHandle<A: Actor + Referable> {
     proc_id: ProcId,
     addr: ChannelAddr,

--- a/hyperactor/src/mailbox/durable_mailbox_sender.rs
+++ b/hyperactor/src/mailbox/durable_mailbox_sender.rs
@@ -13,7 +13,6 @@ use super::*;
 /// A [`DurableMailboxSender`] is a [`MailboxSender`] that writes messages to a write-ahead log
 /// before the receiver consume any of them. It allows the receiver to recover from crashes by
 /// replaying the log. It supports any implementation of [`MailboxSender`].
-#[derive(Debug)]
 struct DurableMailboxSender(Buffer<MessageEnvelope>);
 
 impl DurableMailboxSender {
@@ -133,7 +132,7 @@ pub mod log {
     /// crash without requesting resending the messages. The log is append-only and the messages are
     /// persisted in order with sequence ids.
     #[async_trait]
-    pub trait MessageLog<M: RemoteMessage>: Sync + Send + Debug {
+    pub trait MessageLog<M: RemoteMessage>: Sync + Send {
         /// The type of the stream returned from read operations on this log.
         type Stream<'a>: Stream<Item = Result<(SeqId, M), MessageLogError>> + Send
         where
@@ -177,7 +176,7 @@ pub mod test_utils {
     use super::*;
 
     /// An in-memory log for testing.
-    #[derive(Debug, Clone)]
+    #[derive(Clone)]
     pub struct TestLog<M: RemoteMessage> {
         queue: Arc<Mutex<VecDeque<(SeqId, M)>>>,
         current_seq_id: Arc<Mutex<SeqId>>,

--- a/hyperactor/src/proc.rs
+++ b/hyperactor/src/proc.rs
@@ -117,12 +117,19 @@ static NEXT_LOCAL_RANK: AtomicUsize = AtomicUsize::new(0);
 /// procs.
 ///
 /// Procs are also responsible for maintaining the local supervision hierarchy.
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub struct Proc {
     inner: Arc<ProcState>,
 }
 
-#[derive(Debug)]
+impl fmt::Debug for Proc {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Proc")
+            .field("proc_id", &self.inner.proc_id)
+            .finish()
+    }
+}
+
 struct ProcState {
     /// The proc's id. This should be globally unique, but is not (yet)
     /// for local-only procs.
@@ -1701,12 +1708,20 @@ impl ActorType {
 /// to access the underlying instance.
 ///
 /// InstanceCell is reference counted and cloneable.
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub struct InstanceCell {
     inner: Arc<InstanceCellState>,
 }
 
-#[derive(Debug)]
+impl fmt::Debug for InstanceCell {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("InstanceCell")
+            .field("actor_id", &self.inner.actor_id)
+            .field("actor_type", &self.inner.actor_type)
+            .finish()
+    }
+}
+
 struct InstanceCellState {
     /// The actor's id.
     actor_id: ActorId,

--- a/hyperactor/src/reference.rs
+++ b/hyperactor/src/reference.rs
@@ -738,7 +738,7 @@ impl FromStr for ActorId {
 }
 
 /// ActorRefs are typed references to actors.
-#[derive(Debug, Named)]
+#[derive(Named)]
 pub struct ActorRef<A: Referable> {
     pub(crate) actor_id: ActorId,
     // fn() -> A so that the struct remains Send
@@ -834,6 +834,16 @@ impl<'de, A: Referable> Deserialize<'de> for ActorRef<A> {
             actor_id,
             phantom: PhantomData,
         })
+    }
+}
+
+// Implement Debug manually, without requiring A: Debug
+impl<A: Referable> fmt::Debug for ActorRef<A> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ActorRef")
+            .field("actor_id", &self.actor_id)
+            .field("type", &std::any::type_name::<A>())
+            .finish()
     }
 }
 

--- a/hyperactor_mesh/src/logging.rs
+++ b/hyperactor_mesh/src/logging.rs
@@ -983,7 +983,6 @@ pub enum LogForwardMessage {
 }
 
 /// A log forwarder that receives the log from its parent process and forward it back to the client
-#[derive(Debug)]
 #[hyperactor::export(
     spawn = true,
     handlers = [LogForwardMessage {cast = true}],

--- a/hyperactor_mesh/src/proc_mesh.rs
+++ b/hyperactor_mesh/src/proc_mesh.rs
@@ -1064,7 +1064,7 @@ impl fmt::Debug for ProcMesh {
                 .debug_struct("ProcMesh::V0")
                 .field("shape", shape)
                 .field("ranks", ranks)
-                .field("client_proc", client_proc)
+                .field("client_proc", &"<Proc>")
                 .field("client", &"<Instance>")
                 // Skip the alloc field since it doesn't implement Debug
                 .finish(),

--- a/hyperactor_mesh/src/proc_mesh/mesh_agent.rs
+++ b/hyperactor_mesh/src/proc_mesh/mesh_agent.rs
@@ -213,7 +213,6 @@ pub(crate) fn update_event_actor_id(mut event: ActorSupervisionEvent) -> ActorSu
 }
 
 /// A mesh agent is responsible for managing procs in a [`ProcMesh`].
-#[derive(Debug)]
 #[hyperactor::export(
     handlers=[
         MeshAgentMessage,

--- a/monarch_hyperactor/src/proc.rs
+++ b/monarch_hyperactor/src/proc.rs
@@ -283,8 +283,9 @@ impl PySerialized {
         Ok(Self {
             inner: Serialized::serialize(message).map_err(|err| {
                 PyRuntimeError::new_err(format!(
-                    "failed to serialize message ({:?}) to Serialized: {}",
-                    message, err
+                    "failed to serialize message of type {} to Serialized: {}",
+                    std::any::type_name::<M>(),
+                    err
                 ))
             })?,
             port: M::port(),


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #2135

We should in general not overconstrain traits, but rather be precise about their requirements. Instead, let the consumer of the trait add constraints as needed.

Differential Revision: [D89057664](https://our.internmc.facebook.com/intern/diff/D89057664/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D89057664/)!