### PR TITLE
make client this_proc() real

### DIFF
--- a/hyperactor/src/channel.rs
+++ b/hyperactor/src/channel.rs
@@ -505,6 +505,27 @@ pub enum ChannelAddr {
     /// A unix domain socket address. Supports both absolute path names as
     ///  well as "abstract" names per https://manpages.debian.org/unstable/manpages/unix.7.en.html#Abstract_sockets
     Unix(net::unix::SocketAddr),
+
+    /// A pair of addresses, one for the client and one for the server:
+    ///   - The client should dial to the `dial_to` address.
+    ///   - The server should bind to the `bind_to` address.
+    ///
+    /// The user is responsible for ensuring the traffic to the `dial_to` address
+    /// is routed to the `bind_to` address.
+    ///
+    /// This is useful for scenarios where the network is configured in a way,
+    /// that the bound address is not directly accessible from the client.
+    ///
+    /// For example, in AWS, the client could be provided with the public IP
+    /// address, yet the server is bound to a private IP address or simply
+    /// INADDR_ANY. Traffic to the public IP address is mapped to the private
+    /// IP address through network address translation (NAT).
+    Alias {
+        /// The address to which the client should dial to.
+        dial_to: Box<ChannelAddr>,
+        /// The address to which the server should bind to.
+        bind_to: Box<ChannelAddr>,
+    },
 }
 
 impl From<SocketAddr> for ChannelAddr {
@@ -602,6 +623,9 @@ impl ChannelAddr {
             Self::Local(_) => ChannelTransport::Local,
             Self::Sim(addr) => ChannelTransport::Sim(Box::new(addr.transport())),
             Self::Unix(_) => ChannelTransport::Unix,
+            // bind_to's transport is what is actually used in communication.
+            // Therefore we use its transport to represent the Alias.
+            Self::Alias { bind_to, .. } => bind_to.transport(),
         }
     }
 }
@@ -614,6 +638,9 @@ impl fmt::Display for ChannelAddr {
             Self::Local(index) => write!(f, "local:{}", index),
             Self::Sim(sim_addr) => write!(f, "sim:{}", sim_addr),
             Self::Unix(addr) => write!(f, "unix:{}", addr),
+            Self::Alias { dial_to, bind_to } => {
+                write!(f, "alias:dial_to={};bind_to={}", dial_to, bind_to)
+            }
         }
     }
 }
@@ -634,6 +661,11 @@ impl FromStr for ChannelAddr {
             Some(("metatls", rest)) => net::meta::parse(rest).map_err(|e| e.into()),
             Some(("sim", rest)) => sim::parse(rest).map_err(|e| e.into()),
             Some(("unix", rest)) => Ok(Self::Unix(net::unix::SocketAddr::from_str(rest)?)),
+            Some(("alias", _)) => Err(anyhow::anyhow!(
+                "detect possible alias address, but we currently do not support \
+                parsing alias' string representation since we only want to \
+                support parsing its zmq url format."
+            )),
             Some((r#type, _)) => Err(anyhow::anyhow!("no such channel type: {type}")),
             None => Err(anyhow::anyhow!("no channel type specified")),
         }
@@ -647,7 +679,38 @@ impl ChannelAddr {
     /// - inproc://endpoint-name (equivalent to local)
     /// - ipc://path (equivalent to unix)
     /// - metatls://hostname:port or metatls://*:port
+    /// - Alias format: dial_to_url@bind_to_url (e.g., tcp://host:port@tcp://host:port)
+    ///   Note: Alias format is currently only supported for TCP addresses
     pub fn from_zmq_url(address: &str) -> Result<Self, anyhow::Error> {
+        // Check for Alias format: dial_to_url@bind_to_url
+        // The @ character separates two valid ZMQ URLs
+        if let Some(at_pos) = address.find('@') {
+            let dial_to_str = &address[..at_pos];
+            let bind_to_str = &address[at_pos + 1..];
+
+            // Validate that both addresses use TCP scheme
+            if !dial_to_str.starts_with("tcp://") {
+                return Err(anyhow::anyhow!(
+                    "alias format is only supported for TCP addresses, got dial_to: {}",
+                    dial_to_str
+                ));
+            }
+            if !bind_to_str.starts_with("tcp://") {
+                return Err(anyhow::anyhow!(
+                    "alias format is only supported for TCP addresses, got bind_to: {}",
+                    bind_to_str
+                ));
+            }
+
+            let dial_to = Self::from_zmq_url(dial_to_str)?;
+            let bind_to = Self::from_zmq_url(bind_to_str)?;
+
+            return Ok(Self::Alias {
+                dial_to: Box::new(dial_to),
+                bind_to: Box::new(bind_to),
+            });
+        }
+
         // Try ZMQ-style URL format first (scheme://...)
         let (scheme, address) = address.split_once("://").ok_or_else(|| {
             anyhow::anyhow!("address must be in url form scheme://endppoint {}", address)
@@ -850,6 +913,7 @@ pub fn dial<M: RemoteMessage>(addr: ChannelAddr) -> Result<ChannelTx<M>, Channel
         ChannelAddr::MetaTls(meta_addr) => ChannelTxKind::MetaTls(net::meta::dial(meta_addr)?),
         ChannelAddr::Sim(sim_addr) => ChannelTxKind::Sim(sim::dial::<M>(sim_addr)?),
         ChannelAddr::Unix(path) => ChannelTxKind::Unix(net::unix::dial(path)),
+        ChannelAddr::Alias { dial_to, .. } => dial(*dial_to)?.inner,
     };
     Ok(ChannelTx { inner })
 }
@@ -862,6 +926,19 @@ pub fn serve<M: RemoteMessage>(
     addr: ChannelAddr,
 ) -> Result<(ChannelAddr, ChannelRx<M>), ChannelError> {
     let caller = Location::caller();
+    serve_inner(addr).map(|(addr, inner)| {
+        tracing::debug!(
+            name = "serve",
+            %addr,
+            %caller,
+        );
+        (addr, ChannelRx { inner })
+    })
+}
+
+fn serve_inner<M: RemoteMessage>(
+    addr: ChannelAddr,
+) -> Result<(ChannelAddr, ChannelRxKind<M>), ChannelError> {
     match addr {
         ChannelAddr::Tcp(addr) => {
             let (addr, rx) = net::tcp::serve::<M>(addr)?;
@@ -887,15 +964,15 @@ pub fn serve<M: RemoteMessage>(
             "invalid local addr: {}",
             a
         ))),
+        ChannelAddr::Alias { dial_to, bind_to } => {
+            let (bound_addr, rx) = serve_inner::<M>(*bind_to)?;
+            let alias_addr = ChannelAddr::Alias {
+                dial_to,
+                bind_to: Box::new(bound_addr),
+            };
+            Ok((alias_addr, rx))
+        }
     }
-    .map(|(addr, inner)| {
-        tracing::debug!(
-            name = "serve",
-            %addr,
-            %caller,
-        );
-        (addr, ChannelRx { inner })
-    })
 }
 
 /// Serve on the local address. The server is turned down
@@ -1064,6 +1141,48 @@ mod tests {
         assert!(ChannelAddr::from_zmq_url("tcp://invalid-port").is_err());
         assert!(ChannelAddr::from_zmq_url("metatls://no-port").is_err());
         assert!(ChannelAddr::from_zmq_url("inproc://not-a-number").is_err());
+    }
+
+    #[test]
+    fn test_zmq_style_alias_channel_addr() {
+        // Test Alias format: dial_to_url@bind_to_url
+        // The format is: dial_to_url@bind_to_url where both are valid ZMQ URLs
+        // Note: Alias format is only supported for TCP addresses
+
+        // Test Alias with tcp on both sides
+        let alias_addr = ChannelAddr::from_zmq_url("tcp://127.0.0.1:9000@tcp://[::]:8800").unwrap();
+        match alias_addr {
+            ChannelAddr::Alias { dial_to, bind_to } => {
+                assert_eq!(
+                    *dial_to,
+                    ChannelAddr::Tcp("127.0.0.1:9000".parse().unwrap())
+                );
+                assert_eq!(*bind_to, ChannelAddr::Tcp("[::]:8800".parse().unwrap()));
+            }
+            _ => panic!("Expected Alias"),
+        }
+
+        // Test error: alias with non-tcp dial_to (not supported)
+        assert!(
+            ChannelAddr::from_zmq_url("metatls://example.com:443@tcp://127.0.0.1:8080").is_err()
+        );
+
+        // Test error: alias with non-tcp bind_to (not supported)
+        assert!(
+            ChannelAddr::from_zmq_url("tcp://127.0.0.1:8080@metatls://example.com:443").is_err()
+        );
+
+        // Test error: invalid dial_to URL in Alias
+        assert!(ChannelAddr::from_zmq_url("invalid://scheme@tcp://127.0.0.1:8080").is_err());
+
+        // Test error: invalid bind_to URL in Alias
+        assert!(ChannelAddr::from_zmq_url("tcp://127.0.0.1:8080@invalid://scheme").is_err());
+
+        // Test error: missing port in dial_to
+        assert!(ChannelAddr::from_zmq_url("tcp://host@tcp://127.0.0.1:8080").is_err());
+
+        // Test error: missing port in bind_to
+        assert!(ChannelAddr::from_zmq_url("tcp://127.0.0.1:8080@tcp://example.com").is_err());
     }
 
     #[tokio::test]

--- a/hyperactor_mesh/proptest-regressions/actor_mesh.txt
+++ b/hyperactor_mesh/proptest-regressions/actor_mesh.txt
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 7da0353e3138258986cf2598af0836656a1f7c3399a9ffa18ca93cf983b3e64c # shrinks to extent = Extent { inner: ExtentData { labels: ["d/0"], sizes: [1] } }

--- a/hyperactor_mesh/src/bootstrap.rs
+++ b/hyperactor_mesh/src/bootstrap.rs
@@ -266,7 +266,10 @@ async fn halt<R>() -> R {
     unreachable!()
 }
 
-/// Bootstrap a host in this process, returning a handle to the mesh agent:
+/// Bootstrap a host in this process, returning a handle to the mesh agent.
+///
+/// To obtain the local proc, use `GetLocalProc` on the returned host mesh agent,
+/// then use `GetProc` on the returned proc mesh agent.
 ///
 /// - `addr`: the listening address of the host; this is used to bind the frontend address;
 /// - `command`: optional bootstrap command to spawn procs, otherwise [`BootstrapProcManager::current`];

--- a/hyperactor_mesh/src/proc_mesh.rs
+++ b/hyperactor_mesh/src/proc_mesh.rs
@@ -30,6 +30,7 @@ use hyperactor::WorldId;
 use hyperactor::actor::ActorStatus;
 use hyperactor::actor::remote::Remote;
 use hyperactor::channel;
+use hyperactor::channel::BindSpec;
 use hyperactor::channel::ChannelAddr;
 use hyperactor::channel::ChannelTransport;
 use hyperactor::context;
@@ -96,11 +97,24 @@ declare_attrs! {
         env_name: Some("HYPERACTOR_MESH_DEFAULT_TRANSPORT".to_string()),
         py_name: Some("default_transport".to_string()),
     })
-    pub attr DEFAULT_TRANSPORT: ChannelTransport = ChannelTransport::Unix;
+    pub attr DEFAULT_TRANSPORT: BindSpec = BindSpec::Any(ChannelTransport::Unix);
 }
 
-/// Get the default transport type to use across the application.
+/// Temporary: used to support the legacy allocator-based V1 bootstrap. Should
+/// be removed once we fully migrate to simple bootstrap.
+///
+/// Get the default transport to use across the application. Panic if BindSpec::Addr
+/// is set as default transport. Since we expect BindSpec::Addr to be used only
+/// with simple bootstrap, we should not see this panic in production.
 pub fn default_transport() -> ChannelTransport {
+    match default_bind_spec() {
+        BindSpec::Any(transport) => transport,
+        BindSpec::Addr(addr) => panic!("default_bind_spec() returned BindSpec::Addr({addr})"),
+    }
+}
+
+/// Get the default bind spec to use across the application.
+pub fn default_bind_spec() -> BindSpec {
     global::get_cloned(DEFAULT_TRANSPORT)
 }
 
@@ -187,7 +201,7 @@ pub fn global_root_client() -> &'static Instance<GlobalClientActor> {
     )> = OnceLock::new();
     &GLOBAL_INSTANCE.get_or_init(|| {
         let client_proc = Proc::direct_with_default(
-            ChannelAddr::any(default_transport()),
+            default_bind_spec().any(),
             "mesh_root_client_proc".into(),
             router::global().clone().boxed(),
         )

--- a/hyperactor_mesh/src/proc_mesh/mesh_agent.rs
+++ b/hyperactor_mesh/src/proc_mesh/mesh_agent.rs
@@ -795,6 +795,26 @@ impl Handler<NewClientInstance> for ProcMeshAgent {
     }
 }
 
+/// A handler to get a clone of the proc managed by this agent.
+/// This is used to obtain the local proc from a host mesh.
+#[derive(Debug, hyperactor::Handler, hyperactor::HandleClient)]
+pub struct GetProc {
+    #[reply]
+    pub proc: PortHandle<Proc>,
+}
+
+#[async_trait]
+impl Handler<GetProc> for ProcMeshAgent {
+    async fn handle(
+        &mut self,
+        _cx: &Context<Self>,
+        GetProc { proc }: GetProc,
+    ) -> anyhow::Result<()> {
+        proc.send(self.proc.clone())?;
+        Ok(())
+    }
+}
+
 /// A mailbox sender that initially queues messages, and then relays them to
 /// an underlying sender once configured.
 #[derive(Clone)]

--- a/hyperactor_mesh/src/v1.rs
+++ b/hyperactor_mesh/src/v1.rs
@@ -28,6 +28,7 @@ pub use host_mesh::HostMeshRef;
 use hyperactor::ActorId;
 use hyperactor::ActorRef;
 use hyperactor::Named;
+use hyperactor::ProcId;
 use hyperactor::host::HostError;
 use hyperactor::mailbox::MailboxSenderError;
 use hyperactor::reference;
@@ -149,6 +150,9 @@ pub enum Error {
     #[error("error spawning controller actor for mesh {0}: {1}")]
     ControllerActorSpawnError(Name, anyhow::Error),
 
+    #[error("proc {0} must be direct-addressable")]
+    RankedProc(ProcId),
+
     #[error("error: {0} does not exist")]
     NotExist(Name),
 
@@ -253,7 +257,7 @@ impl Name {
     }
 
     /// Create a Reserved `Name` with no uuid. Only for use by system actors.
-    pub(crate) fn new_reserved(name: impl Into<String>) -> Result<Self> {
+    pub fn new_reserved(name: impl Into<String>) -> Result<Self> {
         Ok(Self::new_with_uuid(name, None)?)
     }
 

--- a/hyperactor_mesh/src/v1/host_mesh.rs
+++ b/hyperactor_mesh/src/v1/host_mesh.rs
@@ -147,6 +147,18 @@ impl HostRef {
     }
 }
 
+impl TryFrom<ActorRef<HostMeshAgent>> for HostRef {
+    type Error = v1::Error;
+
+    fn try_from(value: ActorRef<HostMeshAgent>) -> Result<Self, v1::Error> {
+        let proc_id = value.actor_id().proc_id();
+        match proc_id.as_direct() {
+            Some((addr, _)) => Ok(HostRef(addr.clone())),
+            None => Err(v1::Error::RankedProc(proc_id.clone())),
+        }
+    }
+}
+
 impl std::fmt::Display for HostRef {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         self.0.fmt(f)
@@ -732,6 +744,20 @@ impl HostMeshRef {
             region: extent!(hosts = hosts.len()).into(),
             ranks: Arc::new(hosts.into_iter().map(HostRef).collect()),
         }
+    }
+
+    /// Create a new HostMeshRef from an arbitrary set of host mesh agents.
+    pub fn from_host_agents(name: Name, agents: Vec<ActorRef<HostMeshAgent>>) -> v1::Result<Self> {
+        Ok(Self {
+            name,
+            region: extent!(hosts = agents.len()).into(),
+            ranks: Arc::new(
+                agents
+                    .into_iter()
+                    .map(HostRef::try_from)
+                    .collect::<v1::Result<_>>()?,
+            ),
+        })
     }
 
     /// Spawn a ProcMesh onto this host mesh. The per_host extent specifies the shape

--- a/hyperactor_mesh/src/v1/proc_mesh.rs
+++ b/hyperactor_mesh/src/v1/proc_mesh.rs
@@ -106,7 +106,8 @@ pub struct ProcRef {
 }
 
 impl ProcRef {
-    pub(crate) fn new(proc_id: ProcId, create_rank: usize, agent: ActorRef<ProcMeshAgent>) -> Self {
+    /// Create a new proc ref from the provided id, create rank and agent.
+    pub fn new(proc_id: ProcId, create_rank: usize, agent: ActorRef<ProcMeshAgent>) -> Self {
         Self {
             proc_id,
             create_rank,
@@ -711,6 +712,20 @@ impl ProcMeshRef {
             root_region,
             root_comm_actor,
         })
+    }
+
+    /// Create a singleton ProcMeshRef, given the provided ProcRef and name.
+    /// This is used to support creating local singleton proc meshes to support `this_proc()`
+    /// in python client actors.
+    pub fn new_singleton(name: Name, proc_ref: ProcRef) -> Self {
+        Self {
+            name,
+            region: Extent::unity().into(),
+            ranks: Arc::new(vec![proc_ref]),
+            host_mesh: None,
+            root_region: None,
+            root_comm_actor: None,
+        }
     }
 
     pub(crate) fn root_comm_actor(&self) -> Option<&ActorRef<CommActor>> {

--- a/monarch_hyperactor/src/actor.rs
+++ b/monarch_hyperactor/src/actor.rs
@@ -27,7 +27,6 @@ use hyperactor::RemoteSpawn;
 use hyperactor::actor::ActorError;
 use hyperactor::actor::ActorErrorKind;
 use hyperactor::actor::ActorStatus;
-use hyperactor::channel::ChannelAddr;
 use hyperactor::mailbox::BoxableMailboxSender;
 use hyperactor::mailbox::MessageEnvelope;
 use hyperactor::mailbox::Undeliverable;
@@ -40,7 +39,7 @@ use hyperactor_config::Attrs;
 use hyperactor_mesh::actor_mesh::CAST_ACTOR_MESH_ID;
 use hyperactor_mesh::comm::multicast::CAST_ORIGINATING_SENDER;
 use hyperactor_mesh::comm::multicast::CastInfo;
-use hyperactor_mesh::proc_mesh::default_transport;
+use hyperactor_mesh::proc_mesh::default_bind_spec;
 use hyperactor_mesh::reference::ActorMeshId;
 use hyperactor_mesh::router;
 use hyperactor_mesh::supervision::SupervisionFailureMessage;
@@ -525,7 +524,7 @@ impl PythonActor {
         static ROOT_CLIENT_INSTANCE: OnceLock<Instance<PythonActor>> = OnceLock::new();
 
         let client_proc = Proc::direct_with_default(
-            ChannelAddr::any(default_transport()),
+            default_bind_spec().any(),
             "mesh_root_client_proc".into(),
             router::global().clone().boxed(),
         )

--- a/monarch_hyperactor/src/channel.rs
+++ b/monarch_hyperactor/src/channel.rs
@@ -8,16 +8,21 @@
 
 use std::str::FromStr;
 
+use hyperactor::channel::BindSpec;
 use hyperactor::channel::ChannelAddr;
 use hyperactor::channel::ChannelTransport;
 use hyperactor::channel::MetaTlsAddr;
 use hyperactor::channel::TcpMode;
 use hyperactor::channel::TlsMode;
 use pyo3::exceptions::PyRuntimeError;
+use pyo3::exceptions::PyTypeError;
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 
 /// Python binding for [`hyperactor::channel::ChannelTransport`]
+///
+/// This enum represents the basic transport types that can be represented
+/// as simple enum variants. For explicit addresses, use `PyBindSpec`.
 #[pyclass(
     name = "ChannelTransport",
     module = "monarch._rust_bindings.monarch_hyperactor.channel",
@@ -59,6 +64,83 @@ impl TryFrom<ChannelTransport> for PyChannelTransport {
                 transport
             ))),
         }
+    }
+}
+
+/// Python binding for [`hyperactor::channel::BindSpec`]
+#[pyclass(
+    name = "BindSpec",
+    module = "monarch._rust_bindings.monarch_hyperactor.channel"
+)]
+#[derive(Clone, Debug, PartialEq)]
+pub struct PyBindSpec {
+    inner: BindSpec,
+}
+
+#[pymethods]
+impl PyBindSpec {
+    /// Create a new PyBindSpec from a ChannelTransport enum, a string representation,
+    /// or another PyBindSpec object.
+    ///
+    /// Examples:
+    ///     PyBindSpec(ChannelTransport.Unix)
+    ///     PyBindSpec("tcp://127.0.0.1:8080")
+    ///     PyBindSpec(PyBindSpec(ChannelTransport.Unix))
+    #[new]
+    pub fn new(spec: &Bound<'_, PyAny>) -> PyResult<Self> {
+        // First try to extract as PyBindSpec (for when passing an existing spec)
+        if let Ok(bind_spec) = spec.extract::<PyBindSpec>() {
+            return Ok(bind_spec);
+        }
+
+        // Then try to extract as PyChannelTransport enum
+        if let Ok(py_transport) = spec.extract::<PyChannelTransport>() {
+            let transport: ChannelTransport = py_transport.into();
+            return Ok(PyBindSpec {
+                inner: BindSpec::Any(transport),
+            });
+        }
+
+        // Then try to extract as a string and parse it as a ZMQ URL
+        if let Ok(spec_str) = spec.extract::<String>() {
+            let addr = ChannelAddr::from_zmq_url(&spec_str).map_err(|e| {
+                PyValueError::new_err(format!(
+                    "invalid ZMQ URL for address binding '{}': {}",
+                    spec_str, e
+                ))
+            })?;
+            return Ok(PyBindSpec {
+                inner: BindSpec::Addr(addr),
+            });
+        }
+
+        Err(PyTypeError::new_err(
+            "expected ChannelTransport enum, BindSpec, or str",
+        ))
+    }
+
+    fn __str__(&self) -> String {
+        self.inner.to_string()
+    }
+
+    fn __repr__(&self) -> String {
+        format!("PyBindSpec({:?})", self.inner)
+    }
+
+    fn __eq__(&self, other: &Self) -> bool {
+        self.inner == other.inner
+    }
+}
+
+impl From<PyBindSpec> for BindSpec {
+    fn from(spec: PyBindSpec) -> Self {
+        spec.inner
+    }
+}
+
+impl From<BindSpec> for PyBindSpec {
+    fn from(spec: BindSpec) -> Self {
+        PyBindSpec { inner: spec }
     }
 }
 
@@ -149,6 +231,7 @@ impl From<PyChannelTransport> for ChannelTransport {
 #[pymodule]
 pub fn register_python_bindings(hyperactor_mod: &Bound<'_, PyModule>) -> PyResult<()> {
     hyperactor_mod.add_class::<PyChannelTransport>()?;
+    hyperactor_mod.add_class::<PyBindSpec>()?;
     hyperactor_mod.add_class::<PyChannelAddr>()?;
     Ok(())
 }

--- a/monarch_hyperactor/src/config.rs
+++ b/monarch_hyperactor/src/config.rs
@@ -21,7 +21,7 @@ use std::fmt::Debug;
 use std::time::Duration;
 
 use hyperactor::Named;
-use hyperactor::channel::ChannelTransport;
+use hyperactor::channel::BindSpec;
 use hyperactor_config::AttrValue;
 use hyperactor_config::CONFIG;
 use hyperactor_config::ConfigAttr;
@@ -30,12 +30,13 @@ use hyperactor_config::attrs::Attrs;
 use hyperactor_config::attrs::ErasedKey;
 use hyperactor_config::attrs::declare_attrs;
 use hyperactor_config::global::Source;
+use pyo3::conversion::IntoPyObject;
 use pyo3::conversion::IntoPyObjectExt;
 use pyo3::exceptions::PyTypeError;
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 
-use crate::channel::PyChannelTransport;
+use crate::channel::PyBindSpec;
 
 /// Python wrapper for Duration, using humantime format strings.
 ///
@@ -289,9 +290,9 @@ inventory::collect!(PythonConfigTypeInfo);
 /// like `String` that are convertible directly to/from PyObjects,
 /// you can just use `declare_py_config_type!(String)`. For types
 /// that must first be converted to/from a rust python wrapper
-/// (e.g., keys with type `ChannelTransport` must use `PyChannelTransport`
+/// (e.g., keys with type `BindSpec` must use `PyBindSpec`
 /// as an intermediate step), the usage is
-/// `declare_py_config_type!(PyChannelTransport as ChannelTransport)`.
+/// `declare_py_config_type!(PyBindSpec as BindSpec)`.
 macro_rules! declare_py_config_type {
     ($($ty:ty),+ $(,)?) => {
         hyperactor::paste! {
@@ -341,7 +342,7 @@ macro_rules! declare_py_config_type {
     };
 }
 
-declare_py_config_type!(PyChannelTransport as ChannelTransport);
+declare_py_config_type!(PyBindSpec as BindSpec);
 declare_py_config_type!(PyDuration as Duration);
 declare_py_config_type!(
     i8, i16, i32, i64, u8, u16, u32, u64, usize, f32, f64, bool, String
@@ -367,9 +368,19 @@ declare_py_config_type!(
 fn configure(py: Python<'_>, kwargs: Option<HashMap<String, PyObject>>) -> PyResult<()> {
     kwargs
         .map(|kwargs| {
-            kwargs
-                .into_iter()
-                .try_for_each(|(key, val)| configure_kwarg(py, &key, val))
+            kwargs.into_iter().try_for_each(|(key, val)| {
+                // Special handling for default_transport: convert ChannelTransport
+                // enum or string to PyBindSpec before processing
+                let val = if key == "default_transport" {
+                    PyBindSpec::new(val.bind(py))?
+                        .into_pyobject(py)?
+                        .into_any()
+                        .unbind()
+                } else {
+                    val
+                };
+                configure_kwarg(py, &key, val)
+            })
         })
         .transpose()?;
     Ok(())

--- a/monarch_hyperactor/src/context.rs
+++ b/monarch_hyperactor/src/context.rs
@@ -126,6 +126,17 @@ impl PyContext {
             rank: Extent::unity().point_of_rank(0).unwrap(),
         })
     }
+
+    /// Create a context from an existing instance.
+    /// This is used when the root client was bootstrapped via bootstrap_host()
+    /// instead of the default bootstrap_client().
+    #[staticmethod]
+    fn _from_instance(py: Python<'_>, instance: PyInstance) -> PyResult<PyContext> {
+        Ok(PyContext {
+            instance: instance.into_pyobject(py)?.into(),
+            rank: Extent::unity().point_of_rank(0).unwrap(),
+        })
+    }
 }
 
 impl PyContext {

--- a/monarch_hyperactor/src/v1/host_mesh.rs
+++ b/monarch_hyperactor/src/v1/host_mesh.rs
@@ -9,11 +9,20 @@
 use std::collections::HashMap;
 use std::ops::Deref;
 use std::path::PathBuf;
+use std::sync::OnceLock;
 
+use hyperactor::Instance;
+use hyperactor::Proc;
 use hyperactor_mesh::bootstrap::BootstrapCommand;
+use hyperactor_mesh::bootstrap::host;
+use hyperactor_mesh::proc_mesh::default_transport;
+use hyperactor_mesh::proc_mesh::mesh_agent::GetProcClient;
 use hyperactor_mesh::shared_cell::SharedCell;
+use hyperactor_mesh::v1::ProcMeshRef;
 use hyperactor_mesh::v1::host_mesh::HostMesh;
 use hyperactor_mesh::v1::host_mesh::HostMeshRef;
+use hyperactor_mesh::v1::host_mesh::mesh_agent::GetLocalProcClient;
+use hyperactor_mesh::v1::proc_mesh::ProcRef;
 use ndslice::View;
 use ndslice::view::RankedSliceable;
 use pyo3::IntoPyObjectExt;
@@ -24,6 +33,7 @@ use pyo3::prelude::*;
 use pyo3::types::PyBytes;
 use pyo3::types::PyType;
 
+use crate::actor::PythonActor;
 use crate::actor::to_py_error;
 use crate::alloc::PyAlloc;
 use crate::context::PyInstance;
@@ -240,6 +250,76 @@ impl PyHostMeshRefImpl {
     }
 }
 
+/// Static storage for the root client instance when using host-based bootstrap.
+static ROOT_CLIENT_INSTANCE_FOR_HOST: OnceLock<Instance<PythonActor>> = OnceLock::new();
+
+/// Bootstrap the client host and root client actor.
+///
+/// This creates a proper Host with BootstrapProcManager, spawns the root client
+/// actor on the Host's local_proc.
+///
+/// Returns a tuple of (HostMesh, ProcMesh, PyInstance) where:
+/// - PyHostMesh: the bootstrapped (local) host mesh; and
+/// - PyProcMesh: the local ProcMesh on this HostMesh; and
+/// - PyInstance: the root client actor instance, on the ProcMesh.
+///
+/// The HostMesh is served on the default transport.
+///
+/// This should be called only once, at process initialization
+#[pyfunction]
+fn bootstrap_host(bootstrap_cmd: Option<PyBootstrapCommand>) -> PyResult<PyPythonTask> {
+    let bootstrap_cmd = match bootstrap_cmd {
+        Some(cmd) => cmd.to_rust(),
+        None => BootstrapCommand::current().map_err(|e| PyException::new_err(e.to_string()))?,
+    };
+
+    PyPythonTask::new(async move {
+        let host_mesh_agent = host(default_transport().any(), Some(bootstrap_cmd), None)
+            .await
+            .map_err(|e| PyException::new_err(e.to_string()))?;
+
+        let host_mesh_name = hyperactor_mesh::v1::Name::new_reserved("local").unwrap();
+        let host_mesh = HostMeshRef::from_host_agents(host_mesh_name, vec![host_mesh_agent.bind()])
+            .map_err(|e| PyException::new_err(e.to_string()))?;
+
+        // We require a temporary instance to make a call to the host/proc agent.
+        let temp_proc = Proc::local();
+        let (temp_instance, _) = temp_proc
+            .instance("temp")
+            .map_err(|e| PyException::new_err(e.to_string()))?;
+
+        let local_proc_agent = host_mesh_agent
+            .get_local_proc(&temp_instance)
+            .await
+            .map_err(|e| PyException::new_err(e.to_string()))?;
+
+        let proc_mesh_name = hyperactor_mesh::v1::Name::new_reserved("local").unwrap();
+        let proc_mesh = ProcMeshRef::new_singleton(
+            proc_mesh_name,
+            ProcRef::new(
+                local_proc_agent.actor_id().proc_id().clone(),
+                0,
+                local_proc_agent.bind(),
+            ),
+        );
+
+        let local_proc = local_proc_agent
+            .get_proc(&temp_instance)
+            .await
+            .map_err(|e| PyException::new_err(e.to_string()))?;
+
+        let (instance, _handle) = Python::with_gil(|py| {
+            PythonActor::bootstrap_client_inner(py, local_proc, &ROOT_CLIENT_INSTANCE_FOR_HOST)
+        });
+
+        Ok((
+            PyHostMesh::new_ref(host_mesh),
+            PyProcMesh::new_ref(proc_mesh),
+            PyInstance::from(instance),
+        ))
+    })
+}
+
 #[pyfunction]
 fn py_host_mesh_from_bytes(bytes: &Bound<'_, PyBytes>) -> PyResult<PyHostMesh> {
     let r: PyResult<HostMeshRef> = bincode::deserialize(bytes.as_bytes())
@@ -254,6 +334,14 @@ pub fn register_python_bindings(hyperactor_mod: &Bound<'_, PyModule>) -> PyResul
         "monarch._rust_bindings.monarch_hyperactor.v1.host_mesh",
     )?;
     hyperactor_mod.add_function(f)?;
+
+    let f2 = wrap_pyfunction!(bootstrap_host, hyperactor_mod)?;
+    f2.setattr(
+        "__module__",
+        "monarch._rust_bindings.monarch_hyperactor.v1.host_mesh",
+    )?;
+    hyperactor_mod.add_function(f2)?;
+
     hyperactor_mod.add_class::<PyHostMesh>()?;
     hyperactor_mod.add_class::<PyBootstrapCommand>()?;
     Ok(())

--- a/python/monarch/_rust_bindings/monarch_hyperactor/channel.pyi
+++ b/python/monarch/_rust_bindings/monarch_hyperactor/channel.pyi
@@ -9,6 +9,11 @@
 from enum import Enum
 
 class ChannelTransport(Enum):
+    """
+    Enum representing basic transport types for channels.
+    For explicit address binding, use BindSpec instead.
+    """
+
     TcpWithLocalhost = "tcp(localhost)"
     TcpWithHostname = "tcp(hostname)"
     MetaTlsWithHostname = "metatls(hostname)"
@@ -16,6 +21,27 @@ class ChannelTransport(Enum):
     Local = "local"
     Unix = "unix"
     # Sim  # TODO add support
+
+class BindSpec:
+    """
+    Specify how to bind a channel server.
+
+    Can be created from either a ChannelTransport enum for "any" binding,
+    or a ZMQ-style URL string for explicit address.
+
+    Note: This class is for internal use only. Users should pass ChannelTransport
+    enum directly or use the ZMQ-style URL string for explicit address.
+    """
+
+    def __init__(self, spec: ChannelTransport | str) -> None: ...
+    """
+        Basic transport types supported by ChannelTransport should be used directly as enum values.
+        For explicit address binding, use a ZMQ-style URL string. e.g.:
+        - "tcp://127.0.0.1:8080"
+    """
+    def __str__(self) -> str: ...
+    def __repr__(self) -> str: ...
+    def __eq__(self, other: object) -> bool: ...
 
 class ChannelAddr:
     @staticmethod

--- a/python/monarch/_rust_bindings/monarch_hyperactor/config.pyi
+++ b/python/monarch/_rust_bindings/monarch_hyperactor/config.pyi
@@ -32,7 +32,7 @@ def reset_config_to_defaults() -> None:
     ...
 
 def configure(
-    default_transport: ChannelTransport = ...,
+    default_transport: ChannelTransport | str = ...,
     enable_log_forwarding: bool = ...,
     enable_file_capture: bool = ...,
     tail_log_lines: int = ...,
@@ -50,7 +50,9 @@ def configure(
     plus any additional CONFIG-marked keys passed via **kwargs.
 
     Args:
-        default_transport: Default channel transport for communication
+        default_transport: Default channel transport for communication. Can be:
+            - A ChannelTransport enum value (e.g., ChannelTransport.Unix)
+            - A explicit address string in the ZMQ-style URL format (e.g., "tcp://127.0.0.1:8080")
         enable_log_forwarding: Whether to forward logs from actors
         enable_file_capture: Whether to capture file output
         tail_log_lines: Number of log lines to tail

--- a/python/monarch/_rust_bindings/monarch_hyperactor/v1/host_mesh.pyi
+++ b/python/monarch/_rust_bindings/monarch_hyperactor/v1/host_mesh.pyi
@@ -101,3 +101,15 @@ class BootstrapCommand:
         ...
 
     def __repr__(self) -> str: ...
+
+def bootstrap_host(
+    bootstrap_cmd: BootstrapCommand | None,
+) -> PythonTask[(HostMesh, ProcMesh, Instance)]:
+    """
+    Bootstrap a host mesh in this process, returning the host mesh,
+    proc mesh, and client instance.
+
+    Arguments:
+    - `bootstrap_cmd`: The bootstrap command to use to bootstrap the host.
+    """
+    ...

--- a/python/monarch/_src/actor/actor_mesh.py
+++ b/python/monarch/_src/actor/actor_mesh.py
@@ -53,7 +53,7 @@ from monarch._rust_bindings.monarch_hyperactor.actor import (
 )
 from monarch._rust_bindings.monarch_hyperactor.actor_mesh import PythonActorMesh
 from monarch._rust_bindings.monarch_hyperactor.buffers import FrozenBuffer
-from monarch._rust_bindings.monarch_hyperactor.channel import ChannelTransport
+from monarch._rust_bindings.monarch_hyperactor.channel import BindSpec, ChannelTransport
 from monarch._rust_bindings.monarch_hyperactor.config import configure
 from monarch._rust_bindings.monarch_hyperactor.context import Instance as HyInstance
 from monarch._rust_bindings.monarch_hyperactor.mailbox import (
@@ -410,7 +410,7 @@ def context() -> Context:
     return c
 
 
-_transport: Optional[ChannelTransport] = None
+_transport: Optional[BindSpec] = None
 _transport_lock = threading.Lock()
 
 
@@ -424,17 +424,33 @@ def enable_transport(transport: "ChannelTransport | str") -> None:
     Currently only one transport type may be enabled at one time.
     In the future we may allow multiple to be enabled.
 
+    Supported transport values:
+        - ChannelTransport enum: ChannelTransport.Unix, ChannelTransport.TcpWithHostname, etc.
+        - string short cuts for the ChannelTransport enum:
+            - "tcp": ChannelTransport.TcpWithHostname
+            - "ipc": ChannelTransport.Unix
+            - "metatls": ChannelTransport.MetaTlsWithIpV6
+            - "metatls-hostname": ChannelTransport.MetaTlsWithHostname
+        - ZMQ-style URL format string for explicit address, e.g.:
+            - "tcp://127.0.0.1:8080"
+
     For Meta usage, use metatls-hostname
     """
     if isinstance(transport, str):
-        transport = {
+        # Handle string shortcuts for the ChannelTransport enum,
+        resolved = {
             "tcp": ChannelTransport.TcpWithHostname,
             "ipc": ChannelTransport.Unix,
             "metatls": ChannelTransport.MetaTlsWithIpV6,
             "metatls-hostname": ChannelTransport.MetaTlsWithHostname,
         }.get(transport)
-        if transport is None:
-            raise ValueError(f"unknown transport: {transport}")
+        if resolved is not None:
+            transport_config = BindSpec(resolved)
+        else:
+            transport_config = BindSpec(transport)
+    else:
+        # ChannelTransport enum
+        transport_config = BindSpec(transport)
 
     if _context.get(None) is not None:
         raise RuntimeError(
@@ -445,14 +461,16 @@ def enable_transport(transport: "ChannelTransport | str") -> None:
 
     global _transport
     with _transport_lock:
-        if _transport is not None and _transport != transport:
+        if _transport is not None and _transport != transport_config:
             raise RuntimeError(
                 f"Only one transport type may be enabled at one time. "
                 f"Currently enabled transport type is `{_transport}`. "
-                f"Attempted to enable transport type `{transport}`."
+                f"Attempted to enable transport type `{transport_config}`."
             )
-        _transport = transport
-    configure(default_transport=transport)
+        _transport = transport_config
+    # pyre-ignore[6]: BindSpec is accepted by configure. We just do not expose
+    # it in the method's signature since BindSpec is not a public type.
+    configure(default_transport=transport_config)
 
 
 @dataclass

--- a/python/monarch/_src/actor/actor_mesh.py
+++ b/python/monarch/_src/actor/actor_mesh.py
@@ -264,6 +264,9 @@ class Context:
     @staticmethod
     def _root_client_context() -> "Context": ...
 
+    @staticmethod
+    def _from_instance(instance: Instance) -> "Context": ...
+
 
 _context: contextvars.ContextVar[Context] = contextvars.ContextVar(
     "monarch.actor_mesh._context"
@@ -307,9 +310,12 @@ def _init_context_log_handler() -> None:
     logging.Logger.addHandler = _patched_addHandler
 
 
-def _set_context(c: Context) -> None:
+def _set_context(c: Context) -> contextvars.Token[Context]:
     _init_context_log_handler()
-    _context.set(c)
+    return _context.set(c)
+
+def _reset_context(c: contextvars.Token[Context]):
+    _context.reset(c)
 
 
 T = TypeVar("T")
@@ -331,15 +337,34 @@ class _Lazy(Generic[T]):
         return self._val
 
 
-def _init_this_host_for_fake_in_process_host() -> "HostMesh":
-    from monarch._src.actor.host_mesh import create_local_host_mesh
+def _init_client_context() -> Context:
+    """
+    Create a client context that bootstraps an actor instance running on a real
+    local proc mesh on a real local host mesh.
+    """
+    from monarch._rust_bindings.monarch_hyperactor.v1.host_mesh import bootstrap_host
+    from monarch._src.actor.host_mesh import HostMesh
+    from monarch._src.actor.proc_mesh import ProcMesh
+    from monarch._src.actor.v1.host_mesh import _bootstrap_cmd
 
-    return create_local_host_mesh()
+    rust_host_mesh, rust_proc_mesh, py_instance = bootstrap_host(
+        _bootstrap_cmd()
+    ).block_on()
+
+    ctx = Context._from_instance(py_instance)
+    # Set the context here to avoid recursive context creation:
+    token = _set_context(ctx)
+    try:
+        py_host_mesh = HostMesh._from_rust(rust_host_mesh)
+        py_proc_mesh = ProcMesh._from_rust(rust_proc_mesh, py_host_mesh)
+    finally:
+        _reset_context(token)
+
+    ctx.actor_instance.proc_mesh = py_proc_mesh
+    return ctx
 
 
-_this_host_for_fake_in_process_host: _Lazy["HostMesh"] = _Lazy(
-    _init_this_host_for_fake_in_process_host
-)
+_client_context: _Lazy[Context] = _Lazy(_init_client_context)
 
 
 def shutdown_context() -> "Future[None]":
@@ -355,9 +380,10 @@ def shutdown_context() -> "Future[None]":
     """
     from monarch._src.actor.future import Future
 
-    local_host = _this_host_for_fake_in_process_host.try_get()
-    if local_host is not None:
-        return local_host.shutdown()
+    client_host_ctx = _client_context.try_get()
+    if client_host_ctx is not None:
+        host_mesh = client_host_ctx.actor_instance.proc_mesh.host_mesh
+        return host_mesh.shutdown()
 
     # Nothing to shutdown - return a completed future
     async def noop() -> None:
@@ -366,47 +392,26 @@ def shutdown_context() -> "Future[None]":
     return Future(coro=noop())
 
 
-def _init_root_proc_mesh() -> "ProcMesh":
-    from monarch._src.actor.host_mesh import fake_in_process_host
-
-    return fake_in_process_host()._spawn_nonblocking(
-        name="root_client_proc_mesh",
-        per_host=Extent([], []),
-        setup=None,
-        _attach_controller_controller=False,  # can't attach the controller controller because it doesn't exist yet
-    )
-
-
-_root_proc_mesh: _Lazy["ProcMesh"] = _Lazy(_init_root_proc_mesh)
-
-
 def context() -> Context:
     c = _context.get(None)
     if c is None:
-        c = Context._root_client_context()
-        _set_context(c)
-
-        from monarch._src.actor.host_mesh import create_local_host_mesh
         from monarch._src.actor.proc_mesh import _get_controller_controller
         from monarch._src.actor.v1 import enabled as v1_enabled
 
         if not v1_enabled:
+            from monarch._src.actor.host_mesh import create_local_host_mesh
+
+            c = Context._root_client_context()
+            _set_context(c)
             c.actor_instance.proc_mesh, c.actor_instance._controller_controller = (
                 _get_controller_controller()
             )
 
             c.actor_instance.proc_mesh._host_mesh = create_local_host_mesh()  # type: ignore
         else:
-            c.actor_instance.proc_mesh = _root_proc_mesh.get()
-
-            # This needs to be initialized when the root client context is initialized.
-            # Otherwise, it will be initialized inside an actor endpoint running inside
-            # a fake in-process host. That will fail with an "unroutable mesh" error,
-            # because the hyperactor Proc being used to spawn the local host mesh
-            # won't have the correct type of forwarder.
-            _this_host_for_fake_in_process_host.get()
-
-            c.actor_instance._controller_controller = _get_controller_controller()[1]
+            c = _client_context.get()
+            _set_context(c)
+            _, c.actor_instance._controller_controller = _get_controller_controller()
     return c
 
 

--- a/python/monarch/_src/actor/host_mesh.py
+++ b/python/monarch/_src/actor/host_mesh.py
@@ -26,7 +26,6 @@ from monarch._src.actor.v1 import enabled as v1_enabled
 from monarch._src.actor.v1.host_mesh import (
     _bootstrap_cmd,  # noqa: F401
     create_local_host_mesh as create_local_host_mesh_v1,
-    fake_in_process_host as fake_in_process_host_v1,
     host_mesh_from_alloc as host_mesh_from_alloc_v1,
     HostMesh as HostMeshV1,
     hosts_from_config as hosts_from_config_v1,
@@ -215,7 +214,7 @@ if v1_enabled or TYPE_CHECKING:
     this_host = this_host_v1
     this_proc = this_proc_v1
     create_local_host_mesh = create_local_host_mesh_v1
-    fake_in_process_host = fake_in_process_host_v1
+    fake_in_process_host = this_host_v1
     HostMesh = HostMeshV1
     hosts_from_config = hosts_from_config_v1
     host_mesh_from_alloc = host_mesh_from_alloc_v1

--- a/python/tests/test_config.py
+++ b/python/tests/test_config.py
@@ -10,7 +10,8 @@ import contextlib
 
 import monarch
 import pytest
-from monarch._rust_bindings.monarch_hyperactor.channel import ChannelTransport
+
+from monarch._rust_bindings.monarch_hyperactor.channel import BindSpec, ChannelTransport
 from monarch._rust_bindings.monarch_hyperactor.supervision import SupervisionError
 from monarch.actor import Actor, endpoint, this_proc
 from monarch.config import configured, get_global_config
@@ -34,12 +35,12 @@ def test_get_set_transport() -> None:
         ChannelTransport.MetaTlsWithHostname,
     ):
         with configured(default_transport=transport) as config:
-            assert config["default_transport"] == transport
+            assert config["default_transport"] == BindSpec(transport)
     # Succeed even if we don't specify the transport, but does not change the
     # previous value.
     with configured() as config:
-        assert config["default_transport"] == ChannelTransport.Unix
-    with pytest.raises(TypeError):
+        assert config["default_transport"] == BindSpec(ChannelTransport.Unix)
+    with pytest.raises(ValueError):
         with configured(default_transport="unix"):  # type: ignore
             pass
     with pytest.raises(TypeError):
@@ -47,6 +48,22 @@ def test_get_set_transport() -> None:
             pass
     with pytest.raises(TypeError):
         with configured(default_transport={}):  # type: ignore
+            pass
+
+
+def test_get_set_explicit_transport() -> None:
+    # Test explicit transport with a TCP address
+    with configured(default_transport="tcp://127.0.0.1:8080") as config:
+        assert config["default_transport"] == BindSpec("tcp://127.0.0.1:8080")
+
+    # Test that invalid explicit transport strings raise an error
+    with pytest.raises(ValueError):
+        with configured(default_transport="invalid://scheme"):
+            pass
+
+    # Test that random strings (not ZMQ URL format) raise an error
+    with pytest.raises(ValueError):
+        with configured(default_transport="random_string"):
             pass
 
 
@@ -64,13 +81,15 @@ def test_get_set_multiple() -> None:
             assert config["enable_log_forwarding"]
             assert config["enable_file_capture"]
             assert config["tail_log_lines"] == 100
-            assert config["default_transport"] == ChannelTransport.TcpWithLocalhost
+            assert config["default_transport"] == BindSpec(
+                ChannelTransport.TcpWithLocalhost
+            )
     # Make sure the previous values are restored.
     config = get_global_config()
     assert not config["enable_log_forwarding"]
     assert not config["enable_file_capture"]
     assert config["tail_log_lines"] == 0
-    assert config["default_transport"] == ChannelTransport.Unix
+    assert config["default_transport"] == BindSpec(ChannelTransport.Unix)
 
 
 # This test tries to allocate too much memory for the GitHub actions
@@ -219,7 +238,9 @@ def test_duration_config_multiple() -> None:
         enable_log_forwarding=True,
         tail_log_lines=100,
     ) as config:
-        assert config["default_transport"] == ChannelTransport.TcpWithLocalhost
+        assert config["default_transport"] == BindSpec(
+            ChannelTransport.TcpWithLocalhost
+        )
         assert config["host_spawn_ready_timeout"] == "10m"
         assert config["message_delivery_timeout"] == "5m"
         assert config["mesh_proc_spawn_max_idle"] == "2m"
@@ -228,7 +249,7 @@ def test_duration_config_multiple() -> None:
 
     # Verify all values are restored
     config = get_global_config()
-    assert config["default_transport"] == ChannelTransport.Unix
+    assert config["default_transport"] == BindSpec(ChannelTransport.Unix)
     assert config["host_spawn_ready_timeout"] == "30s"
     assert config["message_delivery_timeout"] == "30s"
     assert config["mesh_proc_spawn_max_idle"] == "30s"

--- a/python/tests/test_proc_mesh.py
+++ b/python/tests/test_proc_mesh.py
@@ -20,7 +20,7 @@ from monarch._rust_bindings.monarch_hyperactor.alloc import AllocConstraints, Al
 from monarch._rust_bindings.monarch_hyperactor.pytokio import PythonTask
 from monarch._rust_bindings.monarch_hyperactor.shape import Extent, Shape, Slice
 from monarch._src.actor.actor_mesh import (
-    _root_proc_mesh,
+    _client_context,
     Actor,
     ActorMesh,
     context,
@@ -297,11 +297,11 @@ def test_context_proc_mesh_in_controller_spawns_actor_in_client_os_process() -> 
 
 @pytest.mark.timeout(60)
 def test_root_client_does_not_leak_proc_meshes() -> None:
-    orig_get_root_proc_mesh = _root_proc_mesh.get
-    with patch.object(_root_proc_mesh, "get") as mock_get_root_proc_mesh, patch.object(
+    orig_get_client_context = _client_context.get
+    with patch.object(_client_context, "get") as mock_get_client_context, patch.object(
         monarch._src.actor.host_mesh, "fake_in_process_host"
     ) as mock_fake_in_process_host:
-        mock_get_root_proc_mesh.side_effect = orig_get_root_proc_mesh
+        mock_get_client_context.side_effect = orig_get_client_context
 
         def sync_sleep_then_context():
             time.sleep(0.1)
@@ -316,7 +316,7 @@ def test_root_client_does_not_leak_proc_meshes() -> None:
         for t in threads:
             t.join()
 
-        assert mock_get_root_proc_mesh.call_count == 100
+        assert mock_get_client_context.call_count == 100
         # If this test is run in isolation, the local host mesh will
         # be created once. But if it runs with other tests, the host mesh
         # will have already been initialized and the function never gets


### PR DESCRIPTION
Summary:
This builds on the previous change to implement a *real* in-process host and local proc mesh. Thus, nothing is fake anymore in the v1 path: this_proc() behaves the same everywhere, and is managed in precisely the same way.

This also means that we can do things like hand out references to the local host (or proc), and have remove actors spawn (procs, actors) on it!

It will also simplify integration: since the client proc is now a host, it has a single front-end address that multiplexes all its procs (including the local one).

We keep around the old codepaths for the benefit of v0; this can be significantly simplified again once we drop v0 support.

Differential Revision: D89196041


