### PR TITLE
Fix serialize and deserialize of ValueMesh with bincode

### DIFF
--- a/hyperactor_mesh/src/resource/mesh.rs
+++ b/hyperactor_mesh/src/resource/mesh.rs
@@ -115,4 +115,18 @@ mod test {
     }
 
     hyperactor::assert_behaves!(TestMeshController as Controller<TestMesh>);
+
+    #[test]
+    fn test_state_serialize_and_deserialize_with_bincode() {
+        let region: ndslice::Region = ndslice::extent!(x = 5).into();
+        let num_ranks = region.num_ranks();
+        let data = State {
+            statuses: ValueMesh::new(region, vec![Status::Running; num_ranks]).unwrap(),
+            state: 0,
+        };
+        let encoded = bincode::serialize(&data).expect("serialization failed");
+        let decoded: State<i32> = bincode::deserialize(&encoded).expect("deserialization failed");
+        assert_eq!(decoded.state, data.state);
+        assert_eq!(decoded.statuses, data.statuses);
+    }
 }


### PR DESCRIPTION
Summary:
ValueMesh was not serializable with bincode because it tried to use a self-describing format
with a serde tag, and bincode doesn't work with deserialize_any.

Remove this tag, and add tests that bincode serialization works. This is the serialization
we use with Mailbox, so it's important that it is supported.

While the JSON size may increase by a little bit, bincode is much smaller and the only format
we really use seriously, so I think this is worthwhile.

Reviewed By: shayne-fletcher

Differential Revision: D89214898


