### PR TITLE
Fix log file suffix

### DIFF
--- a/hyperactor_telemetry/src/lib.rs
+++ b/hyperactor_telemetry/src/lib.rs
@@ -199,7 +199,15 @@ pub fn log_file_path(
     env: env::Env,
     suffix: Option<&str>,
 ) -> Result<(String, String), anyhow::Error> {
-    let suffix = suffix.map(|s| format!("_{}", s)).unwrap_or_default();
+    let suffix = suffix
+        .map(|s| {
+            if s.is_empty() {
+                String::new()
+            } else {
+                format!("_{}", s)
+            }
+        })
+        .unwrap_or_default();
     match env {
         env::Env::Local | env::Env::MastEmulator => {
             let username = if whoami::username().is_empty() {


### PR DESCRIPTION
Summary: This has been manifesting as "monarch_log_.log" when we intend an empty suffix to just be "monarch_log.log"

Reviewed By: zdevito

Differential Revision: D89216922


