### PR TITLE
Fix enum math in verbs.h for CUDA C++20 upgrade via reversions and casts

### DIFF
--- a/rdmaxcel-sys/src/lib.rs
+++ b/rdmaxcel-sys/src/lib.rs
@@ -15,67 +15,13 @@ mod inner {
     #![allow(non_snake_case)]
     #![allow(unused_attributes)]
     #[cfg(not(cargo))]
+    use crate::ibv_wc_flags;
+    #[cfg(not(cargo))]
     use crate::ibv_wc_opcode;
     #[cfg(not(cargo))]
     use crate::ibv_wc_status;
     #[cfg(cargo)]
     include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
-
-    // Manually define ibv_wc_flags as a bitfield (bindgen can't generate it from static const)
-    // Only needed in fbcode builds - OSS/cargo builds have bindgen generate these from enums
-    #[cfg(not(cargo))]
-    #[repr(transparent)]
-    #[derive(Debug, Copy, Clone, PartialEq, Eq, Default)]
-    pub struct ibv_wc_flags(pub u32);
-
-    #[cfg(not(cargo))]
-    impl ibv_wc_flags {
-        pub const IBV_WC_GRH: Self = Self(1 << 0);
-        pub const IBV_WC_WITH_IMM: Self = Self(1 << 1);
-        pub const IBV_WC_IP_CSUM_OK: Self = Self(1 << 2);
-        pub const IBV_WC_WITH_INV: Self = Self(1 << 3);
-        pub const IBV_WC_TM_SYNC_REQ: Self = Self(1 << 4);
-        pub const IBV_WC_TM_MATCH: Self = Self(1 << 5);
-        pub const IBV_WC_TM_DATA_VALID: Self = Self(1 << 6);
-    }
-
-    #[cfg(not(cargo))]
-    impl std::ops::BitAnd for ibv_wc_flags {
-        type Output = Self;
-        fn bitand(self, rhs: Self) -> Self {
-            Self(self.0 & rhs.0)
-        }
-    }
-
-    // Manually define ibv_access_flags as a bitfield (bindgen can't generate it from static const)
-    // Only needed in fbcode builds - OSS/cargo builds have bindgen generate these from enums
-    #[cfg(not(cargo))]
-    #[repr(transparent)]
-    #[derive(Debug, Copy, Clone, PartialEq, Eq, Default)]
-    pub struct ibv_access_flags(pub u32);
-
-    #[cfg(not(cargo))]
-    impl ibv_access_flags {
-        pub const IBV_ACCESS_LOCAL_WRITE: Self = Self(1 << 0);
-        pub const IBV_ACCESS_REMOTE_WRITE: Self = Self(1 << 1);
-        pub const IBV_ACCESS_REMOTE_READ: Self = Self(1 << 2);
-        pub const IBV_ACCESS_REMOTE_ATOMIC: Self = Self(1 << 3);
-        pub const IBV_ACCESS_MW_BIND: Self = Self(1 << 4);
-        pub const IBV_ACCESS_ZERO_BASED: Self = Self(1 << 5);
-        pub const IBV_ACCESS_ON_DEMAND: Self = Self(1 << 6);
-        pub const IBV_ACCESS_HUGETLB: Self = Self(1 << 7);
-        pub const IBV_ACCESS_RELAXED_ORDERING: Self = Self(1 << 8);
-        pub const IBV_ACCESS_FLUSH_GLOBAL: Self = Self(1 << 9);
-        pub const IBV_ACCESS_FLUSH_PERSISTENT: Self = Self(1 << 10);
-    }
-
-    #[cfg(not(cargo))]
-    impl std::ops::BitOr for ibv_access_flags {
-        type Output = Self;
-        fn bitor(self, rhs: Self) -> Self {
-            Self(self.0 | rhs.0)
-        }
-    }
 
     #[repr(C, packed(1))]
     #[derive(Debug, Default, Clone, Copy)]


### PR DESCRIPTION
Summary:
Generated by running
```
hg backout D88882181
hg backout D89083275
hg backout D88911049
```
and then adding explicit casts.

`infiniband/verbs.h` caused C++20 compilation failures due to enum-enum math which could not simply be suppressed because it's a header file.

D88882181 converted `enum` to constants to allow the math to work and because the enums themselves seemed suspect. This caused compilation to succeed with C++20 and unblock a number of broken tests.

But it broke Rust! D89083275 and D88911049 fix Rust by artificially restoring the `enum` values. But that's a mess.

Here we back out both D88882181 and D89083275 and D88911049. Doing so brings us back to a state where the following compilation error would arise:
```
buck-out/v2/gen/fbsource/third-party/rdma-core/stablev60/__ibverbs__/c01e142197f8fe04/buck-headers/infiniband/verbs.h:573:59: error: bitwise operation between different enumeration types ('(unnamed enum at buck-out/v2/gen/fbsource/third-party/rdma-core/stablev60/__ibverbs__/c01e142197f8fe04/buck-headers/infiniband/verbs.h:562:1)' and 'ibv_create_cq_wc_flags') is deprecated [-Werror,-Wdeprecated-anon-enum-enum-conversion]
  573 | IBV_CREATE_CQ_SUP_WC_FLAGS = ((((((IBV_WC_STANDARD_FLAGS) | (IBV_WC_EX_WITH_COMPLETION_TIMESTAMP)) | (IBV_WC_EX_WITH_CVLAN)) | (IBV_WC_EX_WITH_FLOW_TAG)) | (IBV_WC_EX_WITH_TM_INFO)) | (IBV_WC_EX_WITH_COMPLETION_TIMESTAMP_WALLCLOCK))
      |                                   ~~~~~~~~~~~~~~~~~~~~~~~ ^ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
This time we fix the error by adding explicit `(int)` casts to the affected Line 573.

The result is code that:
* Compiles with C++20 by explicitly suppressing the issue causing the compilation failure
* Retains the enums so that builds with Rust work.

Upstream PR: https://github.com/linux-rdma/rdma-core/pull/1671

See discussion [here](https://fb.workplace.com/groups/rust.language/permalink/30268407786114448/).

Reviewed By: peterdelevoryas

Differential Revision: D89088011


