### PR TITLE
Move supervision monitor to controller actor

### DIFF
--- a/hyperactor_mesh/src/comm.rs
+++ b/hyperactor_mesh/src/comm.rs
@@ -1084,8 +1084,11 @@ mod tests {
             forward_port: tx.bind(),
         };
         let actor_name = v1::Name::new("test").expect("valid test name");
+        // Make this actor a "system" actor to avoid spawning a controller actor.
+        // This test is verifying the whole comm tree, so we want fewer actors
+        // involved.
         let actor_mesh = proc_mesh
-            .spawn_with_name(&instance, actor_name, &params)
+            .spawn_with_name(&instance, actor_name, &params, None, true)
             .await
             .unwrap();
         let actor_mesh_ref = actor_mesh.deref().clone();

--- a/hyperactor_mesh/src/resource/mesh.rs
+++ b/hyperactor_mesh/src/resource/mesh.rs
@@ -8,12 +8,15 @@
 
 #![allow(dead_code)]
 
-/// This module defines common types for mesh resources. Meshes are managed as
-/// resources, usually by a controller actor implementing the [`crate::resource`]
-/// behavior.
-///
-/// The mesh controller manages all aspects of the mesh lifecycle, and the owning
-/// actor uses the resource behavior directly to query the state of the mesh.
+//! This module defines common types for mesh resources. Meshes are managed as
+//! resources, usually by a controller actor implementing the [`crate::resource`]
+//! behavior.
+//!
+//! The mesh controller manages all aspects of the mesh lifecycle, and the owning
+//! actor uses the resource behavior directly to query the state of the mesh.
+
+use hyperactor::Bind;
+use hyperactor::Unbind;
 use ndslice::Extent;
 use serde::Deserialize;
 use serde::Serialize;
@@ -34,12 +37,12 @@ pub struct Spec<S> {
 }
 
 /// Mesh states
-#[derive(Debug, Named, Serialize, Deserialize)]
+#[derive(Debug, Named, Bind, Unbind, Serialize, Deserialize)]
 pub struct State<S> {
     /// The current status for each rank in the mesh.
-    statuses: ValueMesh<Status>,
+    pub statuses: ValueMesh<Status>,
     /// Mesh-specific state.
-    state: S,
+    pub state: S,
 }
 
 /// A mesh trait bundles a set of types that together define a mesh resource.

--- a/hyperactor_mesh/src/supervision.rs
+++ b/hyperactor_mesh/src/supervision.rs
@@ -59,3 +59,10 @@ impl std::fmt::Display for SupervisionFailureMessage {
         )
     }
 }
+
+// Shared between mesh types.
+#[derive(Debug, Clone)]
+pub(crate) enum Unhealthy {
+    StreamClosed(SupervisionFailureMessage), // Event stream closed
+    Crashed(SupervisionFailureMessage),      // Bad health event received
+}

--- a/hyperactor_mesh/src/v1/host_mesh.rs
+++ b/hyperactor_mesh/src/v1/host_mesh.rs
@@ -410,11 +410,15 @@ impl HostMesh {
         // sub-host dimension of size 1.
 
         let (mesh_agents, mut mesh_agents_rx) = cx.mailbox().open_port();
+        let trampoline_name = Name::new("host_mesh_trampoline").unwrap();
         let _trampoline_actor_mesh = proc_mesh
-            .spawn::<HostMeshAgentProcMeshTrampoline, C>(
+            .spawn_with_name::<HostMeshAgentProcMeshTrampoline, C>(
                 cx,
-                "host_mesh_trampoline",
+                trampoline_name,
                 &(transport, mesh_agents.bind(), bootstrap_params, is_local),
+                None,
+                // The trampoline is a system actor and does not need a controller.
+                true,
             )
             .await?;
 

--- a/hyperactor_mesh/src/v1/mesh_controller.rs
+++ b/hyperactor_mesh/src/v1/mesh_controller.rs
@@ -6,57 +6,759 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+use std::collections::HashMap;
+use std::collections::HashSet;
 use std::fmt::Debug;
 
 use async_trait::async_trait;
 use hyperactor::Actor;
+use hyperactor::Bind;
+use hyperactor::Context;
+use hyperactor::Handler;
 use hyperactor::Instance;
+use hyperactor::PortRef;
 use hyperactor::ProcId;
+use hyperactor::Unbind;
 use hyperactor::actor::ActorError;
+use hyperactor::actor::ActorErrorKind;
+use hyperactor::actor::ActorStatus;
 use hyperactor::actor::Referable;
+use hyperactor::actor::handle_undeliverable_message;
+use hyperactor::context;
+use hyperactor::mailbox::MessageEnvelope;
+use hyperactor::mailbox::Undeliverable;
+use hyperactor::supervision::ActorSupervisionEvent;
+use hyperactor_config::CONFIG;
+use hyperactor_config::ConfigAttr;
+use hyperactor_config::attrs::declare_attrs;
 use ndslice::ViewExt;
+use ndslice::view::CollectMeshExt;
 use ndslice::view::Ranked;
+use serde::Deserialize;
+use serde::Serialize;
+use tokio::time::Duration;
+use typeuri::Named;
 
+use crate::actor_mesh::update_undeliverable_envelope_for_casting;
+use crate::bootstrap::ProcStatus;
+use crate::proc_mesh::mesh_agent::ActorState;
+use crate::resource;
+use crate::supervision::SupervisionFailureMessage;
+use crate::supervision::Unhealthy;
+use crate::v1;
+use crate::v1::Name;
+use crate::v1::ValueMesh;
 use crate::v1::actor_mesh::ActorMeshRef;
 use crate::v1::host_mesh::HostMeshRef;
 use crate::v1::proc_mesh::ProcMeshRef;
+use crate::v1::view::Point;
 
-#[hyperactor::export]
-pub(crate) struct ActorMeshController<A>
-where
-    A: Referable + Send,
-{
-    mesh: ActorMeshRef<A>,
+declare_attrs! {
+    /// Time between checks of actor states to create supervision events for
+    /// owners. Default of 3 seconds is chosen to not penalize short-lived actors,
+    /// while still able to catch issues before they look like a hang or timeout.
+    /// This also controls how frequently the healthy heartbeat is sent out to
+    /// subscribers.
+    @meta(CONFIG = ConfigAttr {
+        env_name: Some("HYPERACTOR_MESH_SUPERVISION_POLL_FREQUENCY".to_string()),
+        py_name: None,
+    })
+    pub attr SUPERVISION_POLL_FREQUENCY: Duration = Duration::from_secs(3);
 }
 
-impl<A: Referable + Send> ActorMeshController<A> {
-    /// Create a new mesh controller based on the provided reference.
-    pub(crate) fn new(mesh: ActorMeshRef<A>) -> Self {
-        Self { mesh }
+#[derive(Debug)]
+struct HealthState {
+    /// The status of each actor in the controlled mesh.
+    /// TODO: replace with ValueMesh?
+    statuses: HashMap<Point, resource::Status>,
+    unhealthy_event: Option<Unhealthy>,
+    crashed_ranks: HashMap<usize, ActorSupervisionEvent>,
+    // The unique owner of this actor.
+    owner: Option<PortRef<SupervisionFailureMessage>>,
+    /// A set of subscribers to send messages to when events are encountered.
+    subscribers: HashSet<PortRef<Option<SupervisionFailureMessage>>>,
+    /// A set of subscribers that are known to be undeliverable to. This is used
+    /// to avoid causing errors in handle_undeliverable_message, and is cleared
+    /// before a the set of subscribers is sent to.
+    /// This should only be queried by handle_undeliverable_message, and not used
+    /// to prevent sending messages. A port id may be reused later.
+    undeliverable_subscribers: HashSet<PortRef<Option<SupervisionFailureMessage>>>,
+}
+
+impl HealthState {
+    fn new(
+        statuses: HashMap<Point, resource::Status>,
+        owner: Option<PortRef<SupervisionFailureMessage>>,
+    ) -> Self {
+        Self {
+            statuses,
+            unhealthy_event: None,
+            crashed_ranks: HashMap::new(),
+            owner,
+            subscribers: HashSet::new(),
+            undeliverable_subscribers: HashSet::new(),
+        }
     }
 }
 
-impl<A: Referable + Send> Debug for ActorMeshController<A> {
+/// Subscribe me to updates about a mesh. If a duplicate is subscribed, only a single
+/// message is sent.
+/// Will send None if there are no failures on the mesh periodically. This guarantees
+/// the listener that the controller is still alive. Make sure to filter such events
+/// out as not useful.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Named, Bind, Unbind)]
+pub struct Subscribe(pub PortRef<Option<SupervisionFailureMessage>>);
+
+/// Unsubscribe me to future updates about a mesh. Should be the same port used in
+/// the Subscribe message.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Named, Bind, Unbind)]
+pub struct Unsubscribe(pub PortRef<Option<SupervisionFailureMessage>>);
+
+/// Check state of the actors in the mesh. This is used as a self message to
+/// periodically check.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Named, Bind, Unbind)]
+pub struct CheckState();
+
+/// The implementation of monitoring works as follows:
+/// * ActorMesh and ActorMeshRef subscribe for updates from this controller,
+///   which aggregates events from all owned actors.
+/// * The monitor continuously polls for new events. When new events are
+///   found, it sends messages to all subscribers
+/// * In addition to sending to subscribers, the owner is an automatic subscriber
+///   that also has to handle the events.
+#[hyperactor::export(handlers = [
+    Subscribe,
+    Unsubscribe,
+    resource::CreateOrUpdate<resource::mesh::Spec<()>> { cast = true },
+    resource::GetState<resource::mesh::State<()>> { cast = true },
+    resource::Stop { cast = true },
+])]
+pub struct ActorMeshController<A>
+where
+    A: Referable,
+{
+    mesh: ActorMeshRef<A>,
+    supervision_display_name: String,
+    // Shared health state for the monitor and responding to queries.
+    health_state: HealthState,
+    // The monitor which continuously runs in the background to refresh the state
+    // of actors.
+    // If None, the actor it monitors has already stopped.
+    monitor: Option<()>,
+}
+
+impl<A: Referable> resource::mesh::Mesh for ActorMeshController<A> {
+    type Spec = ();
+    type State = ();
+}
+
+impl<A: Referable> ActorMeshController<A> {
+    /// Create a new mesh controller based on the provided reference.
+    pub(crate) fn new(
+        mesh: ActorMeshRef<A>,
+        supervision_display_name: Option<String>,
+        port: Option<PortRef<SupervisionFailureMessage>>,
+        initial_statuses: ValueMesh<resource::Status>,
+    ) -> Self {
+        let supervision_display_name =
+            supervision_display_name.unwrap_or_else(|| mesh.name().to_string());
+        Self {
+            mesh,
+            supervision_display_name,
+            health_state: HealthState::new(initial_statuses.iter().collect(), port),
+            monitor: None,
+        }
+    }
+
+    async fn stop(&self, cx: &impl context::Actor) -> v1::Result<ValueMesh<resource::Status>> {
+        // Cannot use "ActorMesh::stop" as it tries to message the controller, which is this actor.
+        self.mesh
+            .proc_mesh()
+            .stop_actor_by_name(cx, self.mesh.name().clone())
+            .await
+    }
+
+    fn self_check_state_message(&self, cx: &Instance<Self>) -> Result<(), ActorError> {
+        // Only schedule a self message if the monitor has not been dropped.
+        if self.monitor.is_some() {
+            cx.self_message_with_delay(
+                CheckState {},
+                hyperactor_config::global::get(SUPERVISION_POLL_FREQUENCY),
+            )
+        } else {
+            Ok(())
+        }
+    }
+}
+
+fn send_subscriber_message(
+    cx: &impl context::Actor,
+    subscriber: &PortRef<Option<SupervisionFailureMessage>>,
+    message: SupervisionFailureMessage,
+) {
+    if let Err(error) = subscriber.send(cx, Some(message.clone())) {
+        tracing::warn!(
+            event = %message,
+            "failed to send supervision event to subscriber {}: {}",
+            subscriber.port_id(),
+            error
+        );
+    } else {
+        tracing::info!(event = %message, "sent supervision failure message to subscriber {}", subscriber.port_id());
+    }
+}
+
+impl<A: Referable> Debug for ActorMeshController<A> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("MeshController")
             .field("mesh", &self.mesh)
+            .field("health_state", &self.health_state)
+            .field("monitor", &self.monitor)
             .finish()
     }
 }
 
 #[async_trait]
-impl<A: Referable + Send> Actor for ActorMeshController<A> {
+impl<A: Referable> Actor for ActorMeshController<A> {
+    async fn init(&mut self, this: &Instance<Self>) -> Result<(), anyhow::Error> {
+        // Start the monitor task.
+        // There's a shared monitor for all whole mesh ref. Note that slices do
+        // not share the health state. This is fine because requerying a slice
+        // of a mesh will still return any failed state.
+        self.monitor = Some(());
+        self.self_check_state_message(this)?;
+        tracing::info!(actor = %this.self_id(), "started mesh controller for {}", self.mesh.name());
+        Ok(())
+    }
+
     async fn cleanup(
         &mut self,
         this: &Instance<Self>,
         _err: Option<&ActorError>,
     ) -> Result<(), anyhow::Error> {
-        // Cannot use "ActorMesh::stop" as it's only defined on ActorMesh, not ActorMeshRef.
-        self.mesh
-            .proc_mesh()
-            .stop_actor_by_name(this, self.mesh.name().clone())
-            .await?;
+        // If the monitor hasn't been dropped yet, send a stop message to the
+        // proc mesh.
+        if self.monitor.take().is_some() {
+            self.stop(this).await?;
+        }
         Ok(())
+    }
+
+    async fn handle_undeliverable_message(
+        &mut self,
+        cx: &Instance<Self>,
+        envelope: Undeliverable<MessageEnvelope>,
+    ) -> Result<(), anyhow::Error> {
+        // The only part of the port that is used for equality checks is the port id,
+        // so create a new one just for the comparison.
+        let dest_port_id = envelope.clone().into_inner().dest().clone();
+        let port = PortRef::<Option<SupervisionFailureMessage>>::attest(dest_port_id);
+        // If we sent a message to a subscriber that could not receive it, remove
+        // it from the subscriber set instead of generating an error.
+        let did_exist = self.health_state.subscribers.remove(&port);
+        if did_exist {
+            tracing::debug!(
+                actor = %cx.self_id(),
+                "ActorMeshController: handle_undeliverable_message: removed subscriber {} from mesh controller",
+                port.port_id()
+            );
+            // Add this to a set of ports that we know are undeliverable.
+            self.health_state.undeliverable_subscribers.insert(port);
+            Ok(())
+        } else if self.health_state.undeliverable_subscribers.contains(&port) {
+            // If this was already removed from the subscriber set, don't cause an
+            // error. We may have sent multiple messages to the same subscriber,
+            // and they all come back as undeliverable.
+            // This set is cleared periodically to avoid growing too large.
+            Ok(())
+        } else {
+            // If the destination was a cast message, update the sender to avoid
+            // an assert from handle_undeliverable_message.
+            handle_undeliverable_message(cx, update_undeliverable_envelope_for_casting(envelope))
+        }
+    }
+}
+
+#[async_trait]
+impl<A: Referable> Handler<Subscribe> for ActorMeshController<A> {
+    async fn handle(&mut self, cx: &Context<Self>, message: Subscribe) -> anyhow::Result<()> {
+        // If we can't send a message to a subscriber, the subscriber might be gone.
+        // That shouldn't cause this actor to exit.
+        // This is handled by the handle_undeliverable_message method.
+        match &self.health_state.unhealthy_event {
+            None => {}
+            // For an adverse event like stopped or crashed, send a notification
+            // immediately. This represents an initial bad state, if subscribing
+            // to an already-dead mesh.
+            Some(Unhealthy::StreamClosed(msg)) => {
+                send_subscriber_message(cx, &message.0, msg.clone());
+            }
+            Some(Unhealthy::Crashed(msg)) => {
+                send_subscriber_message(cx, &message.0, msg.clone());
+            }
+        }
+        self.health_state.subscribers.insert(message.0);
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl<A: Referable> Handler<Unsubscribe> for ActorMeshController<A> {
+    async fn handle(&mut self, _cx: &Context<Self>, message: Unsubscribe) -> anyhow::Result<()> {
+        self.health_state.subscribers.remove(&message.0);
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl<A: Referable> Handler<resource::CreateOrUpdate<resource::mesh::Spec<()>>>
+    for ActorMeshController<A>
+{
+    /// Currently a no-op as there's nothing to create or update, but allows
+    /// ActorMeshController to implement the resource mesh behavior.
+    async fn handle(
+        &mut self,
+        _cx: &Context<Self>,
+        _message: resource::CreateOrUpdate<resource::mesh::Spec<()>>,
+    ) -> anyhow::Result<()> {
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl<A: Referable> Handler<resource::GetState<resource::mesh::State<()>>>
+    for ActorMeshController<A>
+{
+    async fn handle(
+        &mut self,
+        cx: &Context<Self>,
+        message: resource::GetState<resource::mesh::State<()>>,
+    ) -> anyhow::Result<()> {
+        let status = if let Some(Unhealthy::Crashed(e)) = &self.health_state.unhealthy_event {
+            resource::Status::Failed(e.to_string())
+        } else if let Some(Unhealthy::StreamClosed(_)) = &self.health_state.unhealthy_event {
+            resource::Status::Stopped
+        } else {
+            resource::Status::Running
+        };
+        let statuses = &self.health_state.statuses;
+        let mut statuses = statuses.clone().into_iter().collect::<Vec<_>>();
+        statuses.sort_by_key(|(p, _)| p.rank());
+        let statuses: ValueMesh<resource::Status> =
+            statuses
+                .into_iter()
+                .map(|(_, s)| s)
+                .collect_mesh::<ValueMesh<_>>(self.mesh.region().clone())?;
+        let state = resource::mesh::State {
+            statuses,
+            state: (),
+        };
+        message.reply.send(
+            cx,
+            resource::State {
+                name: message.name,
+                status,
+                state: Some(state),
+            },
+        )?;
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl<A: Referable> Handler<resource::Stop> for ActorMeshController<A> {
+    async fn handle(&mut self, cx: &Context<Self>, _message: resource::Stop) -> anyhow::Result<()> {
+        let mesh = &self.mesh;
+        let mesh_name = mesh.name();
+        // Run the drop on the monitor loop. The actors will not change state
+        // after this point, because they will be stopped.
+        // This message is idempotent because multiple stops only send out one
+        // set of messages to subscribers.
+        if self.monitor.take().is_none() {
+            tracing::debug!(actor = %cx.self_id(), %mesh_name, "duplicate stop request, actor mesh is already stopped");
+            return Ok(());
+        }
+        // See comment in GetState, we want to keep this set pruned to be able
+        // to detect real errors.
+        self.health_state.undeliverable_subscribers.clear();
+
+        // Let the client know that the controller has stopped. Since the monitor
+        // is cancelled, it will not alert the owner or the subscribers.
+        // We use a placeholder rank to get an actor id, but really there should
+        // be a stop event for every rank in the mesh. Since every rank has the
+        // same owner, we assume the rank doesn't matter, and the owner can just
+        // assume the stop happened on all actors.
+        let rank = 0usize;
+        let event = ActorSupervisionEvent::new(
+            // Use an actor id from the mesh.
+            mesh.get(rank).unwrap().actor_id().clone(),
+            None,
+            ActorStatus::Stopped,
+            None,
+        );
+        let message = SupervisionFailureMessage {
+            actor_mesh_name: Some(mesh_name.to_string()),
+            // Rank = none means it affects the whole mesh.
+            rank: None,
+            event,
+        };
+        self.health_state.unhealthy_event = Some(Unhealthy::StreamClosed(message.clone()));
+        // We don't send a message to the owner on stops, because only the owner
+        // can request a stop. We just send to subscribers instead, as they did
+        // not request the stop themselves.
+        for subscriber in self.health_state.subscribers.iter() {
+            send_subscriber_message(cx, subscriber, message.clone());
+        }
+
+        // max_rank and extent are only needed for the deprecated RankedValues.
+        // TODO: add cmp::Ord to Point for a max() impl.
+        let max_rank = self.health_state.statuses.keys().map(|p| p.rank()).max();
+        let extent = self
+            .health_state
+            .statuses
+            .keys()
+            .next()
+            .map(|p| p.extent().clone());
+        // Send a stop message to the ProcMeshAgent for these actors.
+        match self.stop(cx).await {
+            Ok(statuses) => {
+                // All stops successful, set actor status on health state.
+                for (rank, status) in statuses.iter() {
+                    self.health_state
+                        .statuses
+                        .entry(rank)
+                        .and_modify(move |s| *s = status);
+                }
+            }
+            // An ActorStopError means some actors didn't reach the stopped state.
+            Err(v1::Error::ActorStopError { statuses }) => {
+                // If there are no states yet, nothing to update.
+                if let Some(max_rank) = max_rank {
+                    let extent = extent.expect("no actors in mesh");
+                    for (rank, status) in statuses.materialized_iter(max_rank).enumerate() {
+                        *self
+                            .health_state
+                            .statuses
+                            .get_mut(&extent.point_of_rank(rank).expect("illegal rank"))
+                            .unwrap() = status.clone();
+                    }
+                }
+            }
+            // Other error types should be reported as supervision errors.
+            Err(e) => {
+                return Err(e.into());
+            }
+        }
+
+        tracing::info!(actor = %cx.self_id(), %mesh_name, "stopped mesh");
+        Ok(())
+    }
+}
+
+/// Like send_state_change, but when there was no state change that occurred.
+/// Will send a None message to subscribers, and there is no state to change.
+/// Is not sent to the owner, because the owner is only watching for failures.
+/// Should be called once every so often so subscribers can discern the difference
+/// between "no messages because no errors" and "no messages because controller died".
+/// Without sending these hearbeats, subscribers will assume the mesh is dead.
+fn send_heartbeat(cx: &impl context::Actor, health_state: &HealthState) {
+    tracing::debug!("sending heartbeat to subscribers");
+
+    for subscriber in health_state.subscribers.iter() {
+        if let Err(e) = subscriber.send(cx, None) {
+            tracing::warn!(subscriber = %subscriber.port_id(), "error sending heartbeat message: {:?}", e);
+        }
+    }
+}
+
+/// Sends a SupervisionFailureMessage to the owner and subscribers of this mesh,
+/// and changes the health state stored unhealthy_event.
+/// Owners are sent a message only for Failure events, not for Stopped events.
+/// Subscribers are sent both Stopped and Failure events.
+fn send_state_change(
+    cx: &impl context::Actor,
+    rank: usize,
+    event: ActorSupervisionEvent,
+    mesh_name: &Name,
+    is_proc_stopped: bool,
+    health_state: &mut HealthState,
+) {
+    // This does not include the Stopped status, which is a state that occurs when the
+    // user calls stop() on a proc or actor mesh.
+    let is_failed = event.is_error();
+    if is_failed {
+        tracing::warn!(
+            name = "SupervisionEvent",
+            %mesh_name,
+            %event,
+            "detected supervision error on monitored mesh: name={mesh_name}",
+        );
+    } else {
+        tracing::debug!(
+            name = "SupervisionEvent",
+            %mesh_name,
+            %event,
+            "detected non-error supervision event on monitored mesh: name={mesh_name}",
+        );
+    }
+
+    let failure_message = SupervisionFailureMessage {
+        actor_mesh_name: Some(mesh_name.to_string()),
+        rank: Some(rank),
+        event: event.clone(),
+    };
+    health_state.crashed_ranks.insert(rank, event.clone());
+    health_state.unhealthy_event = Some(if is_proc_stopped {
+        Unhealthy::StreamClosed(failure_message.clone())
+    } else {
+        Unhealthy::Crashed(failure_message.clone())
+    });
+    // Send a notification to the owning actor of this mesh, if there is one.
+    // Don't send a message to the owner for non-failure events such as "stopped".
+    // Those events are always initiated by the owner, who don't need to be
+    // told that they were stopped.
+    if is_failed {
+        if let Some(owner) = &health_state.owner {
+            if let Err(error) = owner.send(cx, failure_message.clone()) {
+                tracing::warn!(
+                    name = "SupervisionEvent",
+                    %mesh_name,
+                    %event,
+                    %error,
+                    "failed to send supervision event to owner {}: {}. dropping event",
+                    owner.port_id(),
+                    error
+                );
+            } else {
+                tracing::info!(%mesh_name, %event, "sent supervision failure message to owner {}", owner.port_id());
+            }
+        }
+    }
+    // Subscribers get all messages, even for non-failures like Stopped, because
+    // they need to know if the owner stopped the mesh.
+    for subscriber in health_state.subscribers.iter() {
+        send_subscriber_message(cx, subscriber, failure_message.clone());
+    }
+}
+
+fn actor_state_to_supervision_events(
+    state: resource::State<ActorState>,
+) -> (usize, Vec<ActorSupervisionEvent>) {
+    let (rank, actor_id, events) = match state.state {
+        Some(inner) => (
+            inner.create_rank,
+            Some(inner.actor_id),
+            inner.supervision_events.clone(),
+        ),
+        None => (0, None, vec![]),
+    };
+    let events = match state.status {
+        // If the actor was killed, it might not have a Failed status
+        // or supervision events, and it can't tell us which rank
+        resource::Status::NotExist | resource::Status::Stopped | resource::Status::Timeout(_) => {
+            // it was.
+            if !events.is_empty() {
+                events
+            } else {
+                vec![ActorSupervisionEvent::new(
+                    actor_id.expect("actor_id is None"),
+                    None,
+                    ActorStatus::Stopped,
+                    None,
+                )]
+            }
+        }
+        resource::Status::Failed(_) => events,
+        // All other states are successful.
+        _ => vec![],
+    };
+    (rank, events)
+}
+
+#[async_trait]
+impl<A: Referable> Handler<CheckState> for ActorMeshController<A> {
+    /// Checks actor states and reschedules as a self-message.
+    ///
+    /// When any actor in this mesh changes state,
+    /// including once for the initial state of all actors, send a message to the
+    /// owners and subscribers of this mesh.
+    /// The receivers will get a SupervisionFailureMessage. The created rank is
+    /// the original rank of the actor on the mesh, not the rank after
+    /// slicing.
+    ///
+    /// * SUPERVISION_POLL_FREQUENCY controls how frequently to poll.
+    /// * self-messaging stops when self.monitor is set to None.
+    async fn handle(&mut self, cx: &Context<Self>, _: CheckState) -> Result<(), anyhow::Error> {
+        // This implementation polls every "time_between_checks" duration, checking
+        // for changes in the actor states. It can be improved in two ways:
+        // 1. Use accumulation, to get *any* actor with a change in state, not *all*
+        //    actors.
+        // 2. Use a push-based mode instead of polling.
+        // Wait in between checking to avoid using too much network.
+        let mesh = &self.mesh;
+        let supervision_display_name = &self.supervision_display_name;
+        // Before sending any new messages to subscribers, purge the set of undeliverable.
+        // We are guaranteed if a subscriber is in undeliverable, it will not be in subscribers.
+        // This way we can still get some errors if we send to an actor that isn't
+        // listening.
+        self.health_state.undeliverable_subscribers.clear();
+        // First check if the proc mesh is dead before trying to query their agents.
+        let proc_states = mesh.proc_mesh().proc_states(cx).await;
+        if let Err(e) = proc_states {
+            send_state_change(
+                cx,
+                0,
+                ActorSupervisionEvent::new(
+                    cx.self_id().clone(),
+                    None,
+                    ActorStatus::generic_failure(format!(
+                        "unable to query for proc states: {:?}",
+                        e
+                    )),
+                    None,
+                ),
+                mesh.name(),
+                false,
+                &mut self.health_state,
+            );
+            self.self_check_state_message(cx)?;
+            return Ok(());
+        }
+        if let Some(proc_states) = proc_states.unwrap() {
+            // Check if the proc mesh is still alive.
+            if let Some((point, state)) = proc_states
+                .iter()
+                .find(|(_rank, state)| state.status.is_terminating())
+            {
+                // TODO: allow "actor supervision event" to be general, and
+                // make the proc failure the cause. It is a hack to try to determine
+                // the correct status based on process exit status.
+                let actor_status = match state.state.and_then(|s| s.proc_status) {
+                    Some(ProcStatus::Stopped { .. })
+                    // SIGTERM
+                    | Some(ProcStatus::Killed { signal: 15, .. })
+                    // Conservatively treat lack of status as stopped
+                    | None => ActorStatus::Stopped,
+
+                    Some(status) => ActorStatus::Failed(ActorErrorKind::Generic(format!(
+                        "process failure: {}",
+                        status
+                    ))),
+                };
+                let display_name = if !point.is_empty() {
+                    let coords_display = point.format_as_dict();
+                    if let Some(pos) = supervision_display_name.rfind('>') {
+                        format!(
+                            "{}{}{}",
+                            &supervision_display_name[..pos],
+                            coords_display,
+                            &supervision_display_name[pos..]
+                        )
+                    } else {
+                        format!("{}{}", supervision_display_name, coords_display)
+                    }
+                } else {
+                    supervision_display_name.clone()
+                };
+                send_state_change(
+                    cx,
+                    point.rank(),
+                    ActorSupervisionEvent::new(
+                        // Attribute this to the monitored actor, even if the underlying
+                        // cause is a proc_failure. We propagate the cause explicitly.
+                        mesh.get(point.rank()).unwrap().actor_id().clone(),
+                        Some(format!("{} was running on a process which", display_name)),
+                        actor_status,
+                        None,
+                    ),
+                    mesh.name(),
+                    true,
+                    &mut self.health_state,
+                );
+                self.self_check_state_message(cx)?;
+                return Ok(());
+            }
+        }
+
+        // Now that we know the proc mesh is alive, check for actor state changes.
+        let events = mesh.actor_states(cx).await;
+        if let Err(e) = events {
+            send_state_change(
+                cx,
+                0,
+                ActorSupervisionEvent::new(
+                    cx.self_id().clone(),
+                    Some(supervision_display_name.clone()),
+                    ActorStatus::generic_failure(format!(
+                        "unable to query for actor states: {:?}",
+                        e
+                    )),
+                    None,
+                ),
+                mesh.name(),
+                false,
+                &mut self.health_state,
+            );
+            self.self_check_state_message(cx)?;
+            return Ok(());
+        }
+        // This returned point is the created rank, *not* the rank of
+        // the possibly sliced input mesh.
+        for (point, state) in events.unwrap().iter() {
+            let mut is_new = false;
+            let entry = self
+                .health_state
+                .statuses
+                .entry(point.clone())
+                .or_insert_with(|| {
+                    tracing::debug!(
+                        "PythonActorMeshImpl: received initial state: point={:?}, state={:?}",
+                        point,
+                        state
+                    );
+                    let (_rank, events) = actor_state_to_supervision_events(state.clone());
+                    // Wait for next event if the change in state produced no supervision events.
+                    if !events.is_empty() {
+                        is_new = true;
+                    }
+                    state.status.clone()
+                });
+            // If this actor is new, or the state changed, send a message to the owner.
+            let (rank, event) = if is_new {
+                let (rank, events) = actor_state_to_supervision_events(state.clone());
+                if events.is_empty() {
+                    continue;
+                }
+                (rank, events[0].clone())
+            } else if *entry != state.status {
+                tracing::debug!(
+                    "PythonActorMeshImpl: received state change event: point={:?}, old_state={:?}, new_state={:?}",
+                    point,
+                    entry,
+                    state
+                );
+                let (rank, events) = actor_state_to_supervision_events(state.clone());
+                if events.is_empty() {
+                    continue;
+                }
+                *entry = state.status;
+                (rank, events[0].clone())
+            } else {
+                // No state change, but subscribers need to be sent a message
+                // every so often so they know the controller is still alive.
+                // Send a "no state change" message.
+                // Only if the last state for this actor is not a terminal state.
+                if !entry.is_terminating() {
+                    send_heartbeat(cx, &self.health_state);
+                }
+                continue;
+            };
+            send_state_change(cx, rank, event, mesh.name(), false, &mut self.health_state);
+        }
+
+        // Reschedule a self send after a waiting period.
+        self.self_check_state_message(cx)?;
+        return Ok(());
     }
 }
 

--- a/monarch_hyperactor/Cargo.toml
+++ b/monarch_hyperactor/Cargo.toml
@@ -52,7 +52,6 @@ serde = { version = "1.0.219", features = ["derive", "rc"] }
 serde_multipart = { version = "0.0.0", path = "../serde_multipart" }
 tempfile = "3.22"
 tokio = { version = "1.47.1", features = ["full", "test-util", "tracing"] }
-tokio-util = { version = "0.7.15", features = ["full"] }
 tracing = { version = "0.1.41", features = ["attributes", "valuable"] }
 typeuri = { version = "0.0.0", path = "../typeuri" }
 

--- a/monarch_hyperactor/src/v1/actor_mesh.rs
+++ b/monarch_hyperactor/src/v1/actor_mesh.rs
@@ -7,36 +7,14 @@
  */
 
 use std::clone::Clone;
-use std::collections::HashMap;
 use std::ops::Deref;
-use std::sync::Arc;
-use std::sync::Mutex;
 
-use hyperactor::Actor;
-use hyperactor::ActorHandle;
 use hyperactor::ActorRef;
-use hyperactor::RemoteMessage;
-use hyperactor::actor::ActorErrorKind;
-use hyperactor::actor::ActorStatus;
-use hyperactor::actor::Referable;
-use hyperactor::actor::RemoteSpawn;
-use hyperactor::clock::Clock;
-use hyperactor::clock::RealClock;
-use hyperactor::context;
-use hyperactor::supervision::ActorSupervisionEvent;
-use hyperactor_mesh::bootstrap::ProcStatus;
-use hyperactor_mesh::dashmap::DashMap;
-use hyperactor_mesh::proc_mesh::mesh_agent::ActorState;
-use hyperactor_mesh::resource;
-use hyperactor_mesh::supervision::SupervisionFailureMessage;
-use hyperactor_mesh::v1::Name;
 use hyperactor_mesh::v1::actor_mesh::ActorMesh;
 use hyperactor_mesh::v1::actor_mesh::ActorMeshRef;
-use ndslice::Point;
 use ndslice::Region;
 use ndslice::Selection;
 use ndslice::Slice;
-use ndslice::ViewExt;
 use ndslice::selection::structurally_equal;
 use ndslice::view::Ranked;
 use ndslice::view::RankedSliceable;
@@ -47,59 +25,17 @@ use pyo3::exceptions::PyRuntimeError;
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use pyo3::types::PyBytes;
-use tokio::sync::watch;
-use tokio_util::sync::CancellationToken;
 
 use crate::actor::PythonActor;
 use crate::actor::PythonMessage;
 use crate::actor_mesh::ActorMeshProtocol;
-use crate::actor_mesh::PyActorSupervisionEvent;
 use crate::actor_mesh::PythonActorMesh;
 use crate::context::PyInstance;
 use crate::proc::PyActorId;
 use crate::pytokio::PyPythonTask;
 use crate::pytokio::PyShared;
-use crate::runtime::get_tokio_runtime;
 use crate::shape::PyRegion;
 use crate::supervision::SupervisionError;
-use crate::supervision::Unhealthy;
-
-struct RootHealthState {
-    unhealthy_event: std::sync::Mutex<Unhealthy<ActorSupervisionEvent>>,
-    crashed_ranks: DashMap<usize, ActorSupervisionEvent>,
-}
-
-impl std::fmt::Debug for RootHealthState {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("RootHealthState")
-            .field("unhealthy_event", &self.unhealthy_event)
-            .field("crashed_ranks", &self.crashed_ranks)
-            .finish()
-    }
-}
-
-impl RootHealthState {
-    fn new() -> Self {
-        Self {
-            unhealthy_event: std::sync::Mutex::new(Unhealthy::SoFarSoGood),
-            crashed_ranks: DashMap::new(),
-        }
-    }
-}
-
-#[derive(Debug)]
-struct SupervisionMonitor {
-    cancel: CancellationToken,
-    receiver: watch::Receiver<Option<PyErr>>,
-}
-
-impl Drop for SupervisionMonitor {
-    fn drop(&mut self) {
-        // The task is continuously polling for events on this mesh, but when
-        // the mesh is no longer available we can stop querying it.
-        self.cancel.cancel();
-    }
-}
 
 #[derive(Debug, Clone)]
 #[pyclass(
@@ -108,8 +44,6 @@ impl Drop for SupervisionMonitor {
 )]
 pub(crate) struct PyActorMesh {
     mesh: ActorMesh<PythonActor>,
-    health_state: Arc<RootHealthState>,
-    monitor: Arc<Mutex<Option<SupervisionMonitor>>>,
 }
 
 #[derive(Debug, Clone)]
@@ -119,8 +53,6 @@ pub(crate) struct PyActorMesh {
 )]
 pub(crate) struct PyActorMeshRef {
     mesh: ActorMeshRef<PythonActor>,
-    health_state: Arc<RootHealthState>,
-    monitor: Arc<Mutex<Option<SupervisionMonitor>>>,
 }
 
 #[derive(Debug, Clone)]
@@ -136,420 +68,18 @@ pub(crate) enum PythonActorMeshImpl {
 impl PythonActorMeshImpl {
     /// Get a new owned [`PythonActorMeshImpl`].
     pub(crate) fn new_owned(inner: ActorMesh<PythonActor>) -> Self {
-        let health_state = Arc::new(RootHealthState::new());
-        PythonActorMeshImpl::Owned(PyActorMesh {
-            mesh: inner,
-            health_state,
-            monitor: Arc::new(Mutex::new(None)),
-        })
+        PythonActorMeshImpl::Owned(PyActorMesh { mesh: inner })
     }
 
     /// Get a new ref-based [`PythonActorMeshImpl`].
     pub(crate) fn new_ref(inner: ActorMeshRef<PythonActor>) -> Self {
-        let health_state = Arc::new(RootHealthState::new());
-        PythonActorMeshImpl::Ref(PyActorMeshRef {
-            mesh: inner,
-            health_state,
-            monitor: Arc::new(Mutex::new(None)),
-        })
+        PythonActorMeshImpl::Ref(PyActorMeshRef { mesh: inner })
     }
 
     fn mesh_ref(&self) -> ActorMeshRef<PythonActor> {
         match self {
             PythonActorMeshImpl::Owned(inner) => (*inner.mesh).clone(),
             PythonActorMeshImpl::Ref(inner) => inner.mesh.clone(),
-        }
-    }
-
-    fn health_state(&self) -> &Arc<RootHealthState> {
-        match self {
-            PythonActorMeshImpl::Owned(inner) => &inner.health_state,
-            PythonActorMeshImpl::Ref(inner) => &inner.health_state,
-        }
-    }
-
-    fn monitor(&self) -> &Arc<Mutex<Option<SupervisionMonitor>>> {
-        match self {
-            PythonActorMeshImpl::Owned(inner) => &inner.monitor,
-            PythonActorMeshImpl::Ref(inner) => &inner.monitor,
-        }
-    }
-
-    fn make_monitor(
-        &self,
-        instance: PyInstance,
-        supervision_display_name: String,
-    ) -> SupervisionMonitor {
-        match self {
-            // Owned meshes send a local message to themselves for the failures.
-            PythonActorMeshImpl::Owned(inner) => Self::create_monitor(
-                instance,
-                (*inner.mesh).clone(),
-                inner.health_state.clone(),
-                true,
-                supervision_display_name,
-            ),
-            // Ref meshes send no message, they are only used to generate
-            // the v0 style exception.
-            PythonActorMeshImpl::Ref(inner) => Self::create_monitor(
-                instance,
-                inner.mesh.clone(),
-                inner.health_state.clone(),
-                false,
-                supervision_display_name,
-            ),
-        }
-    }
-
-    /// Get a supervision receiver for this mesh. The passed in monitor object
-    /// must outlive the returned receiver, or else the sender may be dropped
-    /// and the receiver will get a closed channel.
-    fn supervision_receiver(
-        &self,
-        instance: &PyInstance,
-        monitor: &Arc<Mutex<Option<SupervisionMonitor>>>,
-        supervision_display_name: Option<String>,
-    ) -> watch::Receiver<Option<PyErr>> {
-        let mut guard = monitor.lock().unwrap();
-        guard.get_or_insert_with(move || {
-            let instance = Python::with_gil(|_py| instance.clone());
-            self.make_monitor(instance, supervision_display_name.unwrap_or_default())
-        });
-        let monitor = guard.as_ref().unwrap();
-        monitor.receiver.clone()
-    }
-
-    fn create_monitor(
-        instance: PyInstance,
-        mesh: ActorMeshRef<PythonActor>,
-        health_state: Arc<RootHealthState>,
-        is_owned: bool,
-        supervision_display_name: String,
-    ) -> SupervisionMonitor {
-        // There's a shared monitor for all whole mesh ref. Note that slices do
-        // not share the health state. This is fine because requerying a slice
-        // of a mesh will still return any failed state.
-        let (sender, receiver) = watch::channel(None);
-        let cancel = CancellationToken::new();
-        let canceled = cancel.clone();
-        let _task = get_tokio_runtime().spawn(async move {
-            // 3 seconds is chosen to not penalize short-lived successful calls,
-            // while still able to catch issues before they look like a hang or timeout.
-            let time_between_checks = tokio::time::Duration::from_secs(3);
-            // Only make a handle if is_owned is true, we don't want
-            // to send messages to the ref holder.
-            let owner = if is_owned {
-                Some(instance.handle())
-            } else {
-                None
-            };
-            actor_states_monitor(
-                instance.deref(),
-                mesh,
-                owner,
-                health_state,
-                time_between_checks,
-                sender,
-                canceled,
-                supervision_display_name,
-            )
-            .await;
-        });
-        SupervisionMonitor { cancel, receiver }
-    }
-}
-
-fn actor_state_to_supervision_events(
-    state: resource::State<ActorState>,
-) -> (usize, Vec<ActorSupervisionEvent>) {
-    let (rank, actor_id, events) = match state.state {
-        Some(inner) => (
-            inner.create_rank,
-            Some(inner.actor_id),
-            inner.supervision_events.clone(),
-        ),
-        None => (0, None, vec![]),
-    };
-    let events = match state.status {
-        // If the actor was killed, it might not have a Failed status
-        // or supervision events, and it can't tell us which rank
-        resource::Status::NotExist | resource::Status::Stopped | resource::Status::Timeout(_) => {
-            // it was.
-            if !events.is_empty() {
-                events
-            } else {
-                vec![ActorSupervisionEvent::new(
-                    actor_id.expect("actor_id is None"),
-                    None,
-                    ActorStatus::Stopped,
-                    None,
-                )]
-            }
-        }
-        resource::Status::Failed(_) => events,
-        // All other states are successful.
-        _ => vec![],
-    };
-    (rank, events)
-}
-
-fn send_state_change(
-    rank: usize,
-    event: ActorSupervisionEvent,
-    actor_mesh_name: &Name,
-    owner: &Option<ActorHandle<PythonActor>>,
-    health_state: &Arc<RootHealthState>,
-    sender: &watch::Sender<Option<PyErr>>,
-) {
-    // Any supervision event that is not a failure should not generate
-    // call "unhandled".
-    // This includes the Stopped status, which is a state that occurs when the
-    // user calls stop() on a proc or actor mesh.
-    // It is not being terminated due to a failure. In this state, new messages
-    // should not be sent, but we don't call unhandled when it is detected.
-    let is_failed = event.is_error();
-    if is_failed {
-        tracing::warn!(
-            name = "ActorMeshStatus",
-            status = "SupervisionError",
-            %event,
-            "detected supervision error on monitored mesh: name={actor_mesh_name}",
-        );
-    } else {
-        tracing::debug!(
-            name = "ActorMeshStatus",
-            status = "SupervisionEvent",
-            %event,
-            "detected non-error supervision event on monitored mesh: name={actor_mesh_name}",
-        );
-    }
-
-    // Send a notification to the owning actor of this mesh, if there is one, but only if
-    // the supervision event is a failure.
-    if let Some(owner) = owner {
-        if is_failed {
-            if let Err(error) = owner.send(SupervisionFailureMessage {
-                actor_mesh_name: Some(actor_mesh_name.to_string()),
-                rank: Some(rank),
-                event: event.clone(),
-            }) {
-                tracing::warn!(
-                    name = "ActorMeshStatus",
-                    status = "SupervisionError",
-                    %event,
-                    %error,
-                    "failed to send supervision event to owner {}: {}. dropping event",
-                    owner.actor_id(),
-                    error
-                );
-            }
-        }
-    }
-
-    let mut inner_unhealthy_event = health_state
-        .unhealthy_event
-        .lock()
-        .expect("unhealthy_event lock poisoned");
-    health_state.crashed_ranks.insert(rank, event.clone());
-    *inner_unhealthy_event = if is_failed {
-        Unhealthy::Crashed(event.clone())
-    } else {
-        Unhealthy::StreamClosed
-    };
-    let event_actor_id = event.actor_id.clone();
-    let py_event = PyActorSupervisionEvent::from(event.clone());
-    let pyerr = SupervisionError::new_err(format!(
-        "Actor {} exited because of the following reason: {}",
-        event_actor_id,
-        py_event
-            .__repr__()
-            .expect("repr failed on PyActorSupervisionEvent")
-    ));
-    sender.send(Some(pyerr)).expect("receiver closed");
-}
-
-/// Returns a watchable receiver for actor states.
-///
-/// The receiver will be notified when any actor in this mesh changes state,
-/// including once for the initial state of all actors.
-/// The caller can filter the state transition notifications themselves.
-/// The receiver will get a tuple of (created rank, old state, new state). The
-/// created rank is the original rank of the actor on the mesh, not the rank after
-/// slicing.
-///
-/// * time_between_tasks 1trols how frequently to poll.
-#[hyperactor::instrument_infallible(fields(
-    host_mesh=actor_mesh.proc_mesh().host_mesh_name().map(|n| n.to_string()),
-    proc_mesh=actor_mesh.proc_mesh().name().to_string(),
-    actor_name=actor_mesh.name().to_string(),
-))]
-async fn actor_states_monitor<A>(
-    cx: &impl context::Actor,
-    actor_mesh: ActorMeshRef<A>,
-    owner: Option<ActorHandle<PythonActor>>,
-    health_state: Arc<RootHealthState>,
-    time_between_checks: tokio::time::Duration,
-    sender: watch::Sender<Option<PyErr>>,
-    canceled: CancellationToken,
-    supervision_display_name: String,
-) where
-    A: Actor + RemoteSpawn + Referable,
-    A::Params: RemoteMessage,
-{
-    // This implementation polls every "time_between_checks" duration, checking
-    // for changes in the actor states. It can be improved in two ways:
-    // 1. Use accumulation, to get *any* actor with a change in state, not *all*
-    //    actors.
-    // 2. Use a push-based mode instead of polling.
-    let mut existing_states: HashMap<Point, resource::State<ActorState>> = HashMap::new();
-    loop {
-        // Wait in between checking to avoid using too much network.
-        tokio::select! {
-            _ = RealClock.sleep(time_between_checks) => (),
-            _ = canceled.cancelled() => break,
-        }
-        // First check if the proc mesh is dead before trying to query their agents.
-        let proc_states = actor_mesh.proc_mesh().proc_states(cx).await;
-        if let Err(e) = proc_states {
-            send_state_change(
-                0,
-                ActorSupervisionEvent::new(
-                    cx.instance().self_id().clone(),
-                    None,
-                    ActorStatus::generic_failure(format!(
-                        "unable to query for proc states: {:?}",
-                        e
-                    )),
-                    None,
-                ),
-                actor_mesh.name(),
-                &owner,
-                &health_state,
-                &sender,
-            );
-            continue;
-        }
-        if let Some(proc_states) = proc_states.unwrap() {
-            // Check if the proc mesh is still alive.
-            if let Some((point, state)) = proc_states
-                .iter()
-                .find(|(_rank, state)| state.status.is_terminating())
-            {
-                // TODO: allow "actor supervision event" to be general, and
-                // make the proc failure the cause. It is a hack to try to determine
-                // the correct status based on process exit status.
-                let actor_status = match state.state.and_then(|s| s.proc_status) {
-                    Some(ProcStatus::Stopped { .. })
-                    // SIGTERM
-                    | Some(ProcStatus::Killed { signal: 15, .. })
-                    // Conservatively treat lack of status as stopped
-                    | None => ActorStatus::Stopped,
-                    Some(status) => ActorStatus::Failed(ActorErrorKind::Generic(format!(
-                        "process failure: {}",
-                        status
-                    ))),
-                };
-                let display_name = if !point.is_empty() {
-                    let coords_display = point.format_as_dict();
-                    if let Some(pos) = supervision_display_name.rfind('>') {
-                        format!(
-                            "{}{}{}",
-                            &supervision_display_name[..pos],
-                            coords_display,
-                            &supervision_display_name[pos..]
-                        )
-                    } else {
-                        format!("{}{}", supervision_display_name, coords_display)
-                    }
-                } else {
-                    supervision_display_name.clone()
-                };
-                send_state_change(
-                    point.rank(),
-                    ActorSupervisionEvent::new(
-                        // Attribute this to the monitored actor, even if the underlying
-                        // cause is a proc_failure. We propagate the cause explicitly.
-                        actor_mesh.get(point.rank()).unwrap().actor_id().clone(),
-                        Some(display_name),
-                        actor_status,
-                        None,
-                    ),
-                    actor_mesh.name(),
-                    &owner,
-                    &health_state,
-                    &sender,
-                );
-                continue;
-            }
-        }
-
-        // Now that we know the proc mesh is alive, check for actor state changes.
-        let events = actor_mesh.actor_states(cx).await;
-        if let Err(e) = events {
-            send_state_change(
-                0,
-                ActorSupervisionEvent::new(
-                    cx.instance().self_id().clone(),
-                    Some(supervision_display_name.clone()),
-                    ActorStatus::generic_failure(format!(
-                        "unable to query for actor states: {:?}",
-                        e
-                    )),
-                    None,
-                ),
-                actor_mesh.name(),
-                &owner,
-                &health_state,
-                &sender,
-            );
-            continue;
-        }
-        // This returned point is the created rank, *not* the rank of
-        // the possibly sliced input mesh.
-        for (point, state) in events.unwrap().iter() {
-            let entry = existing_states.entry(point.clone()).or_insert_with(|| {
-                tracing::debug!(
-                    "PythonActorMeshImpl: received initial state: point={:?}, state={:?}",
-                    point,
-                    state
-                );
-                let (rank, events) = actor_state_to_supervision_events(state.clone());
-                // Wait for next event if the change in state produced no supervision events.
-                if events.is_empty() {
-                    return state.clone();
-                }
-                // If this actor is new, send a message to the owner.
-                send_state_change(
-                    rank,
-                    events[0].clone(),
-                    actor_mesh.name(),
-                    &owner,
-                    &health_state,
-                    &sender,
-                );
-                state.clone()
-            });
-            if entry.status != state.status {
-                tracing::debug!(
-                    "PythonActorMeshImpl: received state change event: point={:?}, old_state={:?}, new_state={:?}",
-                    point,
-                    entry,
-                    state
-                );
-                let (rank, events) = actor_state_to_supervision_events(state.clone());
-                if events.is_empty() {
-                    continue;
-                }
-                send_state_change(
-                    rank,
-                    events[0].clone(),
-                    actor_mesh.name(),
-                    &owner,
-                    &health_state,
-                    &sender,
-                );
-                *entry = state;
-            }
         }
     }
 }
@@ -561,89 +91,43 @@ impl ActorMeshProtocol for PythonActorMeshImpl {
         selection: Selection,
         instance: &PyInstance,
     ) -> PyResult<()> {
-        // First check if the mesh is already dead before sending out any messages
-        // to a possibly undeliverable actor.
         let mesh_ref = self.mesh_ref();
 
-        let health_state = self.health_state();
-        let region = Ranked::region(&mesh_ref);
-        match &*health_state
-            .unhealthy_event
-            .lock()
-            .unwrap_or_else(|e| e.into_inner())
-        {
-            Unhealthy::StreamClosed => {
-                return Err(SupervisionError::new_err(
-                    "actor mesh is stopped due to proc mesh shutdown".to_string(),
-                ));
-            }
-            Unhealthy::Crashed(event) => {
-                return Err(SupervisionError::new_err(format!(
-                    "Actor {} is unhealthy with reason: {}",
-                    event.actor_id, event.actor_status
-                )));
-            }
-            Unhealthy::SoFarSoGood => {
-                // Further check crashed ranks in case those were updated from another
-                // slice of the same mesh.
-                if let Some(event) = region.slice().iter().find_map(|rank| {
-                    health_state
-                        .crashed_ranks
-                        .get(&rank)
-                        .map(|entry| entry.value().clone())
-                }) {
-                    return Err(SupervisionError::new_err(format!(
-                        "Actor {} is unhealthy with reason: {}",
-                        event.actor_id, event.actor_status
-                    )));
-                }
-            }
-        }
         <ActorMeshRef<PythonActor> as ActorMeshProtocol>::cast(
             &mesh_ref, message, selection, instance,
         )
     }
 
     fn supervision_event(&self, instance: &PyInstance) -> PyResult<Option<PyShared>> {
-        // Make a clone so each endpoint can get the same supervision events.
-        let monitor = self.monitor().clone();
-        let mut receiver = self.supervision_receiver(instance, &monitor, None);
-        PyPythonTask::new(async move {
-            receiver.changed().await.map_err(|e| {
-                PyValueError::new_err(format!("Waiting for supervision event change: {}", e))
-            })?;
-            let event = receiver.borrow();
-            let result = if let Some(pyerr) = event.as_ref() {
-                Err(Python::with_gil(move |py| pyerr.clone_ref(py)))
-            } else {
-                tracing::error!("Received None on watch channel for supervision events");
-                Ok(())
-            };
-            // Make sure the task is kept alive until after the receiver has been
-            // read from. If it is dropped too early the sender will close before
-            // the receiver is read.
-            // The &self is not sufficient to keep the task alive, because this
-            // future may outlive the PythonActorMeshImpl!
-            drop(monitor);
-            result
+        let mesh = self.mesh_ref();
+        let instance = Python::with_gil(|_py| instance.clone());
+        let shared = PyPythonTask::new::<_, ()>(async move {
+            let supervision_failure = mesh
+                .next_supervision_event(instance.deref())
+                .await
+                .map_err(|e| PyValueError::new_err(e.to_string()))?;
+            let event = supervision_failure.event;
+            let pyerr = SupervisionError::new_err(format!(
+                "Actor {} exited because of the following reason: {}",
+                event.actor_id, event,
+            ));
+            Err(pyerr)
         })?
-        .spawn_abortable()
-        .map(Some)
+        .spawn_abortable()?;
+        Ok(Some(shared))
     }
 
     fn start_supervision(
         &self,
-        instance: &PyInstance,
-        supervision_display_name: String,
+        _instance: &PyInstance,
+        _supervision_display_name: String,
     ) -> PyResult<()> {
-        // Fetch the receiver once, this will initialize the monitor task.
-        let monitor = self.monitor().clone();
-        self.supervision_receiver(instance, &monitor, Some(supervision_display_name));
+        // This function is a no-op since moving the monitor loop to ActorMeshController.
+        // Initializing the receiver changes no received events.
         Ok(())
     }
 
     fn new_with_region(&self, region: &PyRegion) -> PyResult<Box<dyn ActorMeshProtocol>> {
-        // The sliced mesh will not share the health state as the original mesh.
         assert!(region.as_inner().is_subset(self.mesh_ref().region()));
         Ok(Box::new(PythonActorMeshImpl::new_ref(
             self.mesh_ref().sliced(region.as_inner().clone()),
@@ -653,7 +137,7 @@ impl ActorMeshProtocol for PythonActorMeshImpl {
     fn stop(&self, instance: &PyInstance) -> PyResult<PyPythonTask> {
         let (slf, instance) = Python::with_gil(|_py| (self.clone(), instance.clone()));
         match slf {
-            PythonActorMeshImpl::Owned(mesh) => PyPythonTask::new(async move {
+            PythonActorMeshImpl::Owned(mut mesh) => PyPythonTask::new(async move {
                 mesh.mesh
                     .stop(instance.deref())
                     .await

--- a/python/monarch/_rust_bindings/monarch_hyperactor/v1/proc_mesh.pyi
+++ b/python/monarch/_rust_bindings/monarch_hyperactor/v1/proc_mesh.pyi
@@ -41,6 +41,7 @@ class ProcMesh:
         instance: Instance,
         name: str,
         actor: Any,
+        supervision_display_name: str | None = None,
     ) -> PythonTask[PythonActorMesh]:
         """
         Spawn a new actor on this mesh.
@@ -49,6 +50,8 @@ class ProcMesh:
         - `instance`: The actor instance that will own the returned actor mesh.
         - `name`: Name of the actor.
         - `actor`: The type of the actor that will be spawned.
+        - `supervision_display_name`: The name of the actor to display in supervision. If not None, this
+            will be used instead of the fully qualified name of the actor.
         """
         ...
 
@@ -59,6 +62,7 @@ class ProcMesh:
         name: str,
         actor: Type["Actor"],
         emulated: bool,
+        supervision_display_name: str | None = None,
     ) -> PythonActorMesh: ...
     async def monitor(self) -> ProcMeshMonitor:
         """

--- a/python/monarch/_src/actor/actor_mesh.py
+++ b/python/monarch/_src/actor/actor_mesh.py
@@ -1599,10 +1599,8 @@ class ActorMesh(MeshTrait, Generic[T]):
         # supervision_event, which needs an Instance. Initialize here so events
         # can be collected even without any endpoints being awaited.
         instance = context().actor_instance
-        supervision_display_name = (
-            f"{str(instance)}.<{Class.__module__}.{Class.__name__} {name}>"
-        )
-        mesh._inner.start_supervision(instance._as_rust(), supervision_display_name)
+        # Supervision display name is unused here now, it is set in ProcMesh::spawn.
+        mesh._inner.start_supervision(instance._as_rust(), "")
 
         async def null_func(*_args: Iterable[Any], **_kwargs: Dict[str, Any]) -> None:
             return None

--- a/python/monarch/_src/actor/proc_mesh.py
+++ b/python/monarch/_src/actor/proc_mesh.py
@@ -452,8 +452,18 @@ class ProcMesh(MeshTrait):
             )
 
         instance = context().actor_instance
+        # The default name used has a UUID appended to it that is not useful for debugging.
+        # Replace with this more descriptive name.
+        supervision_display_name = (
+            f"{str(instance)}.<{Class.__module__}.{Class.__name__} {name}>"
+        )
         actor_mesh = HyProcMesh.spawn_async(
-            pm, instance._as_rust(), name, _Actor, emulated=False
+            pm,
+            instance._as_rust(),
+            name,
+            _Actor,
+            emulated=False,
+            supervision_display_name=supervision_display_name,
         )
         # Inlined ActorMesh._create implementation
         mesh = ActorMesh(Class, name, actor_mesh, self._region.as_shape(), self)

--- a/python/tests/test_python_actors.py
+++ b/python/tests/test_python_actors.py
@@ -1240,6 +1240,15 @@ def test_mesh_len():
     assert 12 == len(s)
 
 
+def test_long_endpoint_completes() -> None:
+    """Tests that a mesh with endpoints that take a long time to complete still
+    complete and don't hit supervision errors"""
+    pm = this_host().spawn_procs(per_host={"gpus": 1})
+    sleeper = pm.spawn("sleep", SleepActor)
+    # Sleep for 60 seconds and then complete without an exception.
+    sleeper.sleep.call(60).get()
+
+
 class UndeliverableMessageReceiver(Actor):
     def __init__(self):
         self._messages = asyncio.Queue()

--- a/python/tests/test_supervision_hierarchy.py
+++ b/python/tests/test_supervision_hierarchy.py
@@ -4,14 +4,15 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-import os
+# pyre-unsafe
 
+import os
+import re
 from threading import Event
 from typing import Callable, Optional, TypeVar
 
 import monarch.actor
 from monarch._rust_bindings.monarch_hyperactor.supervision import MeshFailure
-
 from monarch.actor import Actor, endpoint, this_host
 
 
@@ -85,15 +86,15 @@ class FaultCapture:
         self.captured_failure = failure
         self.failure_happened.set()
 
-    def assert_fault_occurred(self, expected_substring: Optional[str] = None):
+    def assert_fault_occurred(self, pattern: Optional[str] = None):
         """Assert that a fault was captured, optionally checking the message."""
         assert (
             self.captured_failure is not None
         ), "Expected a fault to be captured, but none occurred"
-        if expected_substring:
+        if pattern:
             report = self.captured_failure.report()
-            assert expected_substring in report, (
-                f"Expected fault message to contain '{expected_substring}', "
+            assert re.search(pattern, report), (
+                f"Expected fault message to contain pattern '{pattern}', "
                 f"but got: {report}"
             )
 
@@ -106,7 +107,7 @@ def test_actor_failure():
         actor = this_host().spawn_procs().spawn("actor", Lambda)
         actor.run.broadcast(error)
 
-    capture.assert_fault_occurred("This occurred because the actor itself failed.")
+    capture.assert_fault_occurred("This occurred because the actor itself failed\\.")
 
 
 def test_proc_failure():
@@ -117,7 +118,10 @@ def test_proc_failure():
         actor = this_host().spawn_procs().spawn("top", Nest)
         actor.kill_nest.call_one().get()
 
-    capture.assert_fault_occurred("nested{'a_dim': 0/1}")
+    # Any actors on the proc mesh can report the proc failure, so it might be
+    # "nested" or it might be other broken actors such as "logger".
+    capture.assert_fault_occurred("(nested|logger-.*)\\{'a_dim': 0/1\\}")
+    capture.assert_fault_occurred("process failure: Killed\\(sig=9\\)")
 
 
 def test_nested_mesh_kills_actor_actor_error():
@@ -131,5 +135,5 @@ def test_nested_mesh_kills_actor_actor_error():
         actor.nested.call_one(error).get()
         print("ERRORED THE ACTOR")
     capture.assert_fault_occurred(
-        "actor <root>.<tests.test_supervision_hierarchy.Nest actor>.<tests.test_supervision_hierarchy.Lambda nested{'a_dim': 0/1}> failed"
+        "actor <root>\\.<.*tests\\.test_supervision_hierarchy\\.Nest actor>\\.<.*tests\\.test_supervision_hierarchy\\.Lambda nested\\{'a_dim': 0/1\\}> failed"
     )

--- a/scripts/common-setup.sh
+++ b/scripts/common-setup.sh
@@ -182,6 +182,7 @@ run_test_groups() {
   # Backtraces help with debugging remotely.
   export RUST_BACKTRACE=1
   local FAILED_GROUPS=()
+  local TEST_EXIT_CODE=0
   for GROUP in $(seq 1 10); do
     echo "Running test group $GROUP of 10..."
     # Kill any existing Python processes to ensure clean state
@@ -205,12 +206,13 @@ run_test_groups() {
             --junit-xml="$test_results_dir/test-results-$GROUP.xml" \
             --splits=10
     fi
+    TEST_EXIT_CODE=$?
     # Check result and record failures
-    if [[ $? -eq 0 ]]; then
+    if [[ $TEST_EXIT_CODE -eq 0 ]]; then
         echo "✓ Test group $GROUP completed successfully"
     else
-        FAILED_GROUPS+=($GROUP)
-        echo "✗ Test group $GROUP failed with exit code $?"
+        FAILED_GROUPS+=("$GROUP")
+        echo "✗ Test group $GROUP failed with exit code $TEST_EXIT_CODE"
     fi
   done
   # Final cleanup after all groups


### PR DESCRIPTION
Summary:
Part of: https://github.com/meta-pytorch/monarch/issues/2027

Before this change, the actor_states_monitor tokio task was only running on PyActorMesh, and
only monitored PythonActors. Plus it only forwarded the SupervisionFailureMessage to other
PythonActors. This means that rust-based actors have none of this error propagation working.

This change moves the monitor task into the ActorMeshController, which will allow every actor,
regardless of type, to monitor the mesh it owns for failures. Each Ref will subscribe to messages
from the controller to alert it to changes in state. This will also scale better, as instead of each
Mesh and Ref object having a monitor, there is only one per mesh globally. So there should be
fewer messages going around.
This also gives more implementation flexibility because the details are inside the controller,
and users only need the `Subscribe` message.
The subscribers are guaranteed to also get a None message, which means that the owner
is still alive, and the actors have not changed their state. This can be used to detect cases
where the controller is unreachable.

To do the forwarding, we require the spawning context of ProcMesh::spawn to
have an impl Handler<SupervisionFailureMessage>.
This message represents when an actor on a mesh your actor (or client) owns fails.
PythonActor uses this message to call its `__supervise__` callback, and rust actors have
no default implementation. The TestRootClient and GlobalRootClient both get implementations
that just panic. In the future we may want something like `unhandled_fault_hook` for Rust
actors.

The new method is `next_supervision_event`, a future that resolves if an event occurs. This
can be awaited simultaneously via tokio::select with a reply from a casted message to re-create
the Python behavior.

Differential Revision: D87491033


