### PR TITLE
: channel: remove #[pymodule], its wrong

### DIFF
--- a/monarch_hyperactor/src/channel.rs
+++ b/monarch_hyperactor/src/channel.rs
@@ -146,7 +146,6 @@ impl From<PyChannelTransport> for ChannelTransport {
     }
 }
 
-#[pymodule]
 pub fn register_python_bindings(hyperactor_mod: &Bound<'_, PyModule>) -> PyResult<()> {
     hyperactor_mod.add_class::<PyChannelTransport>()?;
     hyperactor_mod.add_class::<PyChannelAddr>()?;


### PR DESCRIPTION
Summary: `#[pymodule]` in channel.rs is wrong. monarch_hyperactor is a rust library. monarch_extension is a rust python extension that calls the code in monarch_hyperactor. monarch_extension is where the`#[pymodule]` is.

Differential Revision: D89314522


