### PR TITLE
: python: actor: skip this_host() shutdown

### DIFF
--- a/python/monarch/_src/actor/actor_mesh.py
+++ b/python/monarch/_src/actor/actor_mesh.py
@@ -381,10 +381,14 @@ def shutdown_context() -> "Future[None]":
     """
     from monarch._src.actor.future import Future
 
-    client_host_ctx = _client_context.try_get()
-    if client_host_ctx is not None:
-        host_mesh = client_host_ctx.actor_instance.proc_mesh.host_mesh
-        return host_mesh.shutdown()
+    # TODO(shayne,2025-12-18): Since D89089836 we can't call shutdown
+    # like this and doing so is causing runtime errors. This avoids
+    # the error while I work out a better fix.
+
+    # client_host_ctx = _client_context.try_get()
+    # if client_host_ctx is not None:
+    #     host_mesh = client_host_ctx.actor_instance.proc_mesh.host_mesh
+    #     return host_mesh.shutdown()
 
     # Nothing to shutdown - return a completed future
     async def noop() -> None:


### PR DESCRIPTION
Summary: D89052078 changed the implementation of `shutdown_context()` but unfortunately as written it can't work and generates a runtime error: "cannot shut down `HostMesh` that is a reference instead of owned". skip the explicit shutdown while we work out a better fix.

Differential Revision: D89478006


