### PR TITLE
Add a reason to channel send error

### DIFF
--- a/docs/source/books/hyperactor-book/src/mailboxes/mailbox_client.md
+++ b/docs/source/books/hyperactor-book/src/mailboxes/mailbox_client.md
@@ -124,7 +124,7 @@ impl MailboxClient {
             let return_handle_0 = return_handle.clone();
             tokio::spawn(async move {
                 let result = return_receiver.await;
-                if let Ok(SendError(e, message)) = result {
+                if let Ok(SendError{error: e, message, ..}) = result {
                     message.undeliverable(
                         DeliveryError::BrokenLink(format!(
                             "failed to enqueue in MailboxClient when processing buffer: {e}"

--- a/hyperactor/src/channel/net.rs
+++ b/hyperactor/src/channel/net.rs
@@ -149,7 +149,11 @@ impl<M: RemoteMessage> Tx<M> for NetTx<M> {
         if let Err(mpsc::error::SendError((message, return_channel, _))) =
             self.sender.send((message, return_channel, RealClock.now()))
         {
-            let _ = return_channel.send(SendError(ChannelError::Closed, message));
+            let _ = return_channel.send(SendError {
+                error: ChannelError::Closed,
+                message,
+                reason: None,
+            });
         }
     }
 }
@@ -948,7 +952,14 @@ mod tests {
 
             let (return_tx, return_rx) = oneshot::channel();
             tx.try_post(123, return_tx);
-            assert_matches!(return_rx.await, Ok(SendError(ChannelError::Closed, 123)));
+            assert_matches!(
+                return_rx.await,
+                Ok(SendError {
+                    error: ChannelError::Closed,
+                    message: 123,
+                    ..
+                })
+            );
         }
 
         Ok(())
@@ -1016,7 +1027,14 @@ mod tests {
 
             let (return_tx, return_rx) = oneshot::channel();
             tx.try_post(123, return_tx);
-            assert_matches!(return_rx.await, Ok(SendError(ChannelError::Closed, 123)));
+            assert_matches!(
+                return_rx.await,
+                Ok(SendError {
+                    error: ChannelError::Closed,
+                    message: 123,
+                    ..
+                })
+            );
         }
     }
 
@@ -1047,7 +1065,7 @@ mod tests {
             let message = "a".repeat(default_size_in_bytes + 1024);
             tx.try_post(message.clone(), return_channel);
             let returned = return_receiver.await.unwrap();
-            assert_eq!(message, returned.1);
+            assert_eq!(message, returned.message);
         }
     }
 
@@ -1108,7 +1126,14 @@ mod tests {
 
             let (return_tx, return_rx) = oneshot::channel();
             tx.try_post(123, return_tx);
-            assert_matches!(return_rx.await, Ok(SendError(ChannelError::Closed, 123)));
+            assert_matches!(
+                return_rx.await,
+                Ok(SendError {
+                    error: ChannelError::Closed,
+                    message: 123,
+                    ..
+                })
+            );
         }
     }
 

--- a/hyperactor/src/channel/sim.rs
+++ b/hyperactor/src/channel/sim.rs
@@ -280,7 +280,11 @@ impl<M: RemoteMessage + Any> Tx<M> for SimTx<M> {
             Err(err) => {
                 if let Some(return_channel) = return_channel {
                     return_channel
-                        .send(SendError(err.into(), message))
+                        .send(SendError {
+                            error: err.into(),
+                            message,
+                            reason: None,
+                        })
                         .unwrap_or_else(|m| tracing::warn!("failed to deliver SendError: {}", m));
                 }
 
@@ -312,7 +316,11 @@ impl<M: RemoteMessage + Any> Tx<M> for SimTx<M> {
                 if let Err(err) = result {
                     if let Some(return_channel) = return_channel {
                         return_channel
-                            .send(SendError(err.into(), message))
+                            .send(SendError {
+                                error: err.into(),
+                                message,
+                                reason: None,
+                            })
                             .unwrap_or_else(|m| {
                                 tracing::warn!("failed to deliver SendError: {}", m)
                             });
@@ -322,7 +330,11 @@ impl<M: RemoteMessage + Any> Tx<M> for SimTx<M> {
             Err(err) => {
                 if let Some(return_channel) = return_channel {
                     return_channel
-                        .send(SendError(err.into(), message))
+                        .send(SendError {
+                            error: err.into(),
+                            message,
+                            reason: None,
+                        })
                         .unwrap_or_else(|m| tracing::warn!("failed to deliver SendError: {}", m));
                 }
             }


### PR DESCRIPTION
Summary:
Part of: https://github.com/meta-pytorch/monarch/issues/2041

On the NetTx sending pathway, there are some errors that would cause the channel to close,
and they mostly have an explainable reason for doing so. This wasn't making it back to the
errors stored in the envelope though.

Add the reason to SendError, and include this information in the whole set of queued messages
that are returned. Note that a reason for a single message is put on all the returned messages,
because all of them will fail for a reason possibly unrelated to themselves.

Reviewed By: shayne-fletcher

Differential Revision: D89562505


