### PR TITLE
no whole archive

### DIFF
--- a/build_utils/src/lib.rs
+++ b/build_utils/src/lib.rs
@@ -385,11 +385,8 @@ impl CppStaticLibsConfig {
         println!("cargo::rustc-link-search=native={}", self.rdma_lib_dir);
         println!("cargo::rustc-link-search=native={}", self.rdma_util_dir);
 
-        // Use whole-archive for rdma-core static libraries
-        println!("cargo::rustc-link-arg=-Wl,--whole-archive");
         println!("cargo::rustc-link-lib=static=mlx5");
         println!("cargo::rustc-link-lib=static=ibverbs");
-        println!("cargo::rustc-link-arg=-Wl,--no-whole-archive");
 
         // rdma_util helper library
         println!("cargo::rustc-link-lib=static=rdma_util");

--- a/monarch_cpp_static_libs/build.rs
+++ b/monarch_cpp_static_libs/build.rs
@@ -254,11 +254,8 @@ fn emit_link_directives(rdma_build_dir: &Path) {
     );
     println!("cargo:rustc-link-search=native={}", rdma_util_dir.display());
 
-    // Static libraries - use whole-archive for rdma-core static libraries
-    println!("cargo:rustc-link-arg=-Wl,--whole-archive");
     println!("cargo:rustc-link-lib=static=mlx5");
     println!("cargo:rustc-link-lib=static=ibverbs");
-    println!("cargo:rustc-link-arg=-Wl,--no-whole-archive");
 
     // rdma_util helper library
     println!("cargo:rustc-link-lib=static=rdma_util");


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #2193
* __->__ #2192

Added when we redid bulid but it isn't necessary -- doesn't  build shared libraries of intermediate crates, and I don't think things use dynamic lookup of symbols within our rust crate. Lets see if CI passes.

Differential Revision: [D89570908](https://our.internmc.facebook.com/intern/diff/D89570908/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D89570908/)!