### PR TITLE
Explicilty list .a paths for rdma

### DIFF
--- a/monarch_cpp_static_libs/build.rs
+++ b/monarch_cpp_static_libs/build.rs
@@ -247,27 +247,32 @@ fn emit_link_directives(rdma_build_dir: &Path) {
     let rdma_static_dir = rdma_build_dir.join("lib/statics");
     let rdma_util_dir = rdma_build_dir.join("util");
 
-    // Emit search paths
-    println!(
-        "cargo:rustc-link-search=native={}",
-        rdma_static_dir.display()
-    );
-    println!("cargo:rustc-link-search=native={}", rdma_util_dir.display());
+    // Link directly to the specific .a files we built, rather than using search paths.
+    // This avoids any path ordering issues where the linker might find system libraries
+    // or libraries built with different flags (e.g., ENABLE_RESOLVE_NEIGH=1).
+    let libmlx5_path = rdma_static_dir.join("libmlx5.a");
+    let libibverbs_path = rdma_static_dir.join("libibverbs.a");
+    let librdma_util_path = rdma_util_dir.join("librdma_util.a");
 
-    println!("cargo:rustc-link-lib=static=mlx5");
-    println!("cargo:rustc-link-lib=static=ibverbs");
-
-    // rdma_util helper library
-    println!("cargo:rustc-link-lib=static=rdma_util");
+    println!("cargo:rustc-link-arg={}", libmlx5_path.display());
+    println!("cargo:rustc-link-arg={}", libibverbs_path.display());
+    println!("cargo:rustc-link-arg={}", librdma_util_path.display());
 
     // Export metadata for dependent crates
     // Use cargo:: (double colon) format for proper DEP_<LINKS>_<KEY> env vars
     println!(
-        "cargo::metadata=RDMA_INCLUDE={}",
+        "cargo::metadata=RDMA_INCLUDE_DIR={}",
         rdma_build_dir.join("include").display()
     );
-    println!("cargo::metadata=RDMA_LIB_DIR={}", rdma_static_dir.display());
-    println!("cargo::metadata=RDMA_UTIL_DIR={}", rdma_util_dir.display());
+
+    // Export library paths as a semicolon-separated list
+    let lib_paths = format!(
+        "{};{};{}",
+        libmlx5_path.display(),
+        libibverbs_path.display(),
+        librdma_util_path.display()
+    );
+    println!("cargo::metadata=RDMA_STATIC_LIBRARIES={}", lib_paths);
 
     // Re-run if build scripts change
     println!("cargo:rerun-if-changed=build.rs");

--- a/rdmaxcel-sys/build.rs
+++ b/rdmaxcel-sys/build.rs
@@ -17,7 +17,7 @@ fn main() {}
 fn main() {
     // Get rdma-core config from cpp_static_libs (includes are used, links emitted by monarch_extension)
     let cpp_static_libs_config = build_utils::CppStaticLibsConfig::from_env();
-    let rdma_include = &cpp_static_libs_config.rdma_include;
+    let rdma_include = &cpp_static_libs_config.rdma_include_dir;
 
     // Link against dl for dynamic loading
     println!("cargo:rustc-link-lib=dl");


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #2193
* #2192

Make sure we link to the rdma libraries we built. Ensure we do not pick up something with additional library requiements (libnl).

Differential Revision: [D89575917](https://our.internmc.facebook.com/intern/diff/D89575917/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D89575917/)!