### PR TITLE
Bind the undeliverable port on the global PythonActor

### DIFF
--- a/python/tests/test_job.py
+++ b/python/tests/test_job.py
@@ -395,8 +395,11 @@ def test_train_script_job_state_batch():
     try:
         job = LocalJob(("batch_launched_hosts",))
         job.apply(client_script=train_script)
-        assert 0 == job.process.wait()
         stdout = open(os.path.join(job._log_dir, "stdout.log"), "r").read()
+        stderr = open(os.path.join(job._log_dir, "stderr.log"), "r").read()
+        assert (
+            0 == job.process.wait()
+        ), f"Job failed\nstdout:\n{stdout}\nstderr:\n{stderr}"
         assert "batch_launched_hosts True" in stdout
         # look in job._log_dir for the stdout file which will have the batch_lauched_hosts True
     finally:

--- a/python/tests/test_python_actors.py
+++ b/python/tests/test_python_actors.py
@@ -1176,28 +1176,6 @@ async def test_sync_workspace() -> None:
 
 
 @pytest.mark.timeout(120)
-async def test_actor_mesh_stop() -> None:
-    # This test doesn't want the client process to crash during testing.
-    pm = this_host().spawn_procs(per_host={"gpus": 2})
-    am_1 = pm.spawn("printer", Printer)
-    am_2 = pm.spawn("printer2", Printer)
-    await am_1.print.call("hello 1")
-    await am_1.log.call("hello 2")
-    await cast(ActorMesh, am_1).stop()
-
-    with pytest.raises(
-        SupervisionError,
-        match=r"(?s)Actor .*printer-.* exited because of the following reason:.*stopped",
-    ):
-        await am_1.print.call("hello 1")
-
-    await am_2.print.call("hello 3")
-    await am_2.log.call("hello 4")
-
-    await pm.stop()
-
-
-@pytest.mark.timeout(120)
 async def test_proc_mesh_stop_after_actor_mesh_stop() -> None:
     pm = this_host().spawn_procs(per_host={"gpus": 2})
     am = pm.spawn("printer", Printer)


### PR DESCRIPTION
Summary:
Fixes: https://github.com/meta-pytorch/monarch/issues/2041

Undeliverable messages sent from the root python client were not making it back to that
client, and were getting silently abandoned. This was because the handler for undeliverable
wasn't bound. Use a `.bind()` on the ActorHandle<PythonActor> to get the port bound.

Furthermore, there were some issues with how handle_supervision_event worked on the global
client. It wasn't called for immediate errors in its own message handlers, only for child supervision
events. This prevented us from calling `__supervise__` after an undeliverable message resulted
in an error.
Secondly, if a supervision event is not handled by the global client PythonActor, it was going
to ProcMeshAgent, which by default records events without crashing if it has a coordinator port
present.
For the global root client, we want to fail fast and loud, so we use process::exit after logging instead.
This in general should never happen, because `__supervise__` always either (a)
handles the event, or (b) causes a crash anyways. But to be defensive we never want to
silently drop these events.

Reviewed By: shayne-fletcher

Differential Revision: D89562504


