### PR TITLE
Proper flushing on shutdown

### DIFF
--- a/monarch_hyperactor/src/runtime.rs
+++ b/monarch_hyperactor/src/runtime.rs
@@ -68,6 +68,8 @@ pub fn get_tokio_runtime<'l>() -> std::sync::MappedRwLockReadGuard<'l, tokio::ru
 
 #[pyfunction]
 pub fn shutdown_tokio_runtime() {
+    hyperactor_telemetry::shutdown_telemetry();
+
     // It is important to not hold the GIL while calling this function.
     // Other runtime threads may be waiting to acquire it and we will never get to shutdown.
     if let Some(x) = INSTANCE.write().unwrap().take() {


### PR DESCRIPTION
Summary: We were previously relying on `Drop` in some places to invoke flushing but this will not work reliably from Python. What we should do instead is invoke a shutdown function in `shutdown_tokio_runtime`

Differential Revision: D89674332


