### PR TITLE
Refactor actor init message

### DIFF
--- a/python/monarch/_src/actor/tensor_engine_shim.py
+++ b/python/monarch/_src/actor/tensor_engine_shim.py
@@ -30,6 +30,7 @@ time it is used.
 
 if TYPE_CHECKING:
     from monarch._src.actor.actor_mesh import ActorEndpoint, Port, Selection
+    from monarch._rust_bindings.monarch_hyperactor.actor import MethodSpecifier
 
 from monarch._rust_bindings.monarch_hyperactor.buffers import Buffer
 
@@ -68,13 +69,13 @@ def shim(
 
 
 @shim(module="monarch.mesh_controller")
-def actor_send(
-    endpoint: "ActorEndpoint[..., ...]",
+def create_actor_message(
+    method_name: "MethodSpecifier",
+    proc_mesh: "Optional[Any]",
     args_kwargs_tuple: Buffer,
     refs: "Sequence[Any]",
     port: "Optional[Port[Any]]",
-    selection: "Selection",
-) -> None: ...
+) -> "Any": ...
 
 
 @shim(module="monarch.mesh_controller")


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #2205
* #2203
* #2200

This makes it more clear that the actor init message can be creating at the same time as the call to allocate the python actor by refactoring ActorMesh._create. It gets inlined into the ProcMesh spawn code, and calls a method that returns the PythonMessage that is the init message.

However, we currently _cannot_ remove the actual cast of the init message. This is because actor init itself uses the context of the init message to initialize its rank. This information is not available to the rust actor's init method so we cannot handle our init method from within it.

Nevertheless, this change makes it clearer how to merge the init when it is possible.

Differential Revision: [D89700862](https://our.internmc.facebook.com/intern/diff/D89700862/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D89700862/)!