### PR TITLE
Remove unnecessary async from Proc::direct

### DIFF
--- a/hyperactor/src/channel/net.rs
+++ b/hyperactor/src/channel/net.rs
@@ -276,6 +276,7 @@ pub(crate) mod unix {
     }
 
     /// Listen and serve connections on this socket address.
+    /// This function panics if thread-local tokio runtime is not set.
     pub fn serve<M: RemoteMessage>(
         addr: SocketAddr,
     ) -> Result<(ChannelAddr, NetRx<M>), ServerError> {

--- a/hyperactor/src/host.rs
+++ b/hyperactor/src/host.rs
@@ -1356,7 +1356,6 @@ mod tests {
             ChannelAddr::any(host.addr().transport()),
             "test".to_string(),
         )
-        .await
         .unwrap();
         let (client_inst, _h) = client.instance("test").unwrap();
         let (port, rx) = client_inst.mailbox().open_once_port();

--- a/hyperactor/src/proc.rs
+++ b/hyperactor/src/proc.rs
@@ -357,7 +357,7 @@ impl Proc {
     }
 
     /// Create a new direct-addressed proc.
-    pub async fn direct(addr: ChannelAddr, name: String) -> Result<Self, ChannelError> {
+    pub fn direct(addr: ChannelAddr, name: String) -> Result<Self, ChannelError> {
         let (addr, rx) = channel::serve(addr)?;
         let proc_id = ProcId::Direct(addr, name);
         let proc = Self::new(proc_id, DialMailboxRouter::new().into_boxed());

--- a/hyperactor_mesh/src/actor_mesh.rs
+++ b/hyperactor_mesh/src/actor_mesh.rs
@@ -911,7 +911,7 @@ mod tests {
                     })
                     .await
                     .unwrap();
-                let instance = $crate::v1::testing::instance().await;
+                let instance = $crate::v1::testing::instance();
                 let proc_mesh = ProcMesh::allocate(alloc).await.unwrap();
                 let actor_mesh: RootActorMesh<'_, ProxyActor> = proc_mesh.spawn(&instance, "proxy", &()).await.unwrap();
                 let proxy_actor = actor_mesh.get(0).unwrap();
@@ -938,7 +938,7 @@ mod tests {
                     .await
                     .unwrap();
 
-                let instance = $crate::v1::testing::instance().await;
+                let instance = $crate::v1::testing::instance();
                 let proc_mesh = ProcMesh::allocate(alloc).await.unwrap();
                 let actor_mesh: RootActorMesh<TestActor> = proc_mesh.spawn(&instance, "echo", &()).await.unwrap();
                 let (reply_handle, mut reply_receiver) = actor_mesh.open_port();
@@ -965,7 +965,7 @@ mod tests {
                     })
                     .await
                     .unwrap();
-                let instance = $crate::v1::testing::instance().await;
+                let instance = $crate::v1::testing::instance();
                 let mesh = ProcMesh::allocate(alloc).await.unwrap();
 
                 let (undeliverable_msg_tx, _) = mesh.client().open_port();
@@ -1003,7 +1003,7 @@ mod tests {
                     .await
                     .unwrap();
 
-                let instance = $crate::v1::testing::instance().await;
+                let instance = $crate::v1::testing::instance();
                 let proc_mesh = ProcMesh::allocate(alloc).await.unwrap();
                 let (undeliverable_tx, _undeliverable_rx) = proc_mesh.client().open_port();
                 let actor_mesh: RootActorMesh<PingPongActor> = proc_mesh.spawn(&instance, "pingpong", &(Some(undeliverable_tx.bind()), None, None)).await.unwrap();
@@ -1049,7 +1049,7 @@ mod tests {
                     .await
                     .unwrap();
 
-                let instance = $crate::v1::testing::instance().await;
+                let instance = $crate::v1::testing::instance();
                 let proc_mesh = ProcMesh::allocate(alloc).await.unwrap();
                 let actor_mesh: RootActorMesh<TestActor> = proc_mesh.spawn(&instance, "echo", &()).await.unwrap();
                 let dont_simulate_error = true;
@@ -1094,7 +1094,7 @@ mod tests {
                     .await
                     .unwrap();
 
-                let instance = $crate::v1::testing::instance().await;
+                let instance = $crate::v1::testing::instance();
                 let proc_mesh = ProcMesh::allocate(alloc).await.unwrap();
                 let actor_mesh: RootActorMesh<TestActor> = proc_mesh.spawn(&instance, "echo", &()).await.unwrap();
 
@@ -1116,7 +1116,7 @@ mod tests {
             #[tokio::test]
             async fn test_inter_proc_mesh_comms() {
                 let mut meshes = Vec::new();
-                let instance = $crate::v1::testing::instance().await;
+                let instance = $crate::v1::testing::instance();
                 for _ in 0..2 {
                     let alloc = $allocator
                         .allocate(AllocSpec {
@@ -1179,7 +1179,7 @@ mod tests {
                     .await
                     .unwrap();
 
-                let instance = $crate::v1::testing::instance().await;
+                let instance = $crate::v1::testing::instance();
                 let mut proc_mesh = ProcMesh::allocate(alloc).await.unwrap();
 
                 let (tx, mut rx) = hyperactor::mailbox::open_port(proc_mesh.client());
@@ -1244,7 +1244,7 @@ mod tests {
                     .await
                     .unwrap();
 
-                let instance = $crate::v1::testing::instance().await;
+                let instance = $crate::v1::testing::instance();
                 let mesh = ProcMesh::allocate(alloc).await.unwrap();
                 let (reply_port_handle, mut reply_port_receiver) = mesh.client().open_port::<usize>();
                 let reply_port = reply_port_handle.bind();
@@ -1309,7 +1309,7 @@ mod tests {
                 })
                 .await
                 .unwrap();
-            let instance = crate::v1::testing::instance().await;
+            let instance = crate::v1::testing::instance();
             let monkey = alloc.chaos_monkey();
             let mut mesh = ProcMesh::allocate(alloc).await.unwrap();
             let mut events = mesh.events().unwrap();
@@ -1384,7 +1384,7 @@ mod tests {
                 })
                 .await
                 .unwrap();
-            let instance = crate::v1::testing::instance().await;
+            let instance = crate::v1::testing::instance();
 
             let stop = alloc.stopper();
             let mut mesh = ProcMesh::allocate(alloc).await.unwrap();
@@ -1451,7 +1451,7 @@ mod tests {
                 })
                 .await
                 .unwrap();
-            let instance = crate::v1::testing::instance().await;
+            let instance = crate::v1::testing::instance();
             let mesh = ProcMesh::allocate(alloc).await.unwrap();
 
             let mesh_one: RootActorMesh<PingPongActor> = mesh
@@ -1578,7 +1578,7 @@ mod tests {
                 })
                 .await
                 .unwrap();
-            let instance = crate::v1::testing::instance().await;
+            let instance = crate::v1::testing::instance();
             let mut proc_mesh = ProcMesh::allocate(alloc).await.unwrap();
             let mut proc_events = proc_mesh.events().unwrap();
             let actor_mesh: RootActorMesh<TestActor> =
@@ -1668,7 +1668,7 @@ mod tests {
             // SAFETY: Not multithread safe.
             unsafe { std::env::set_var("HYPERACTOR_MESH_ROUTER_NO_GLOBAL_FALLBACK", "1") };
 
-            let instance = crate::v1::testing::instance().await;
+            let instance = crate::v1::testing::instance();
             let mut proc_mesh = ProcMesh::allocate(alloc).await.unwrap();
             let mut proc_events = proc_mesh.events().unwrap();
             let mut actor_mesh: RootActorMesh<'_, ProxyActor> =
@@ -1722,6 +1722,7 @@ mod tests {
         use hyperactor::channel::serve;
         use hyperactor::clock::Clock;
         use hyperactor::clock::RealClock;
+        use ndslice::Extent;
         use ndslice::Selection;
 
         use crate::Mesh;
@@ -1823,30 +1824,29 @@ mod tests {
             #[test]
             fn test_reshaped_actor_mesh_cast(extent in gen_extent(1..=4, 8)) {
                 let runtime = make_tokio_runtime();
-                let alloc = runtime.block_on(LocalAllocator
-                    .allocate(AllocSpec {
-                        extent,
-                        constraints: Default::default(),
-                        proc_name: None,
-                        transport: ChannelTransport::Local,
-                        proc_allocation_mode: Default::default(),
-                    }))
-                    .unwrap();
-                let instance = runtime.block_on(crate::v1::testing::instance());
-                let proc_mesh = runtime.block_on(ProcMesh::allocate(alloc)).unwrap();
-
-                let addr = ChannelAddr::any(ChannelTransport::Unix);
-
-                let actor_mesh: RootActorMesh<EchoActor> =
-                    runtime.block_on(proc_mesh.spawn(&instance, "echo", &addr)).unwrap();
-
-                let mut runner = TestRunner::default();
-                let selection = gen_selection(4, actor_mesh.shape().slice().sizes().to_vec(), 0)
-                    .new_tree(&mut runner)
-                    .unwrap()
-                    .current();
-
-                runtime.block_on(validate_cast(&actor_mesh, actor_mesh.proc_mesh().client(), addr, selection));
+                async fn inner(extent: Extent) {
+                    let alloc = LocalAllocator
+                        .allocate(AllocSpec {
+                            extent,
+                            constraints: Default::default(),
+                            proc_name: None,
+                            transport: ChannelTransport::Local,
+                            proc_allocation_mode: Default::default(),
+                        }).await
+                        .unwrap();
+                    let instance = crate::v1::testing::instance();
+                    let proc_mesh = ProcMesh::allocate(alloc).await.unwrap();
+                    let addr = ChannelAddr::any(ChannelTransport::Unix);
+                    let actor_mesh: RootActorMesh<EchoActor> =
+                        proc_mesh.spawn(&instance, "echo", &addr).await.unwrap();
+                    let mut runner = TestRunner::default();
+                    let selection = gen_selection(4, actor_mesh.shape().slice().sizes().to_vec(), 0)
+                        .new_tree(&mut runner)
+                        .unwrap()
+                        .current();
+                    validate_cast(&actor_mesh, actor_mesh.proc_mesh().client(), addr, selection).await;
+                }
+                runtime.block_on(inner(extent));
             }
         }
 
@@ -1857,71 +1857,74 @@ mod tests {
             #[test]
             fn test_reshaped_actor_mesh_slice_cast(extent in gen_extent(1..=4, 8)) {
                 let runtime = make_tokio_runtime();
-                let alloc = runtime.block_on(LocalAllocator
-                    .allocate(AllocSpec {
-                        extent: extent.clone(),
-                        constraints: Default::default(),
-                        proc_name: None,
-                        transport: ChannelTransport::Local,
-                        proc_allocation_mode: Default::default(),
-                    }))
-                    .unwrap();
-                let instance = runtime.block_on(crate::v1::testing::instance());
-                let proc_mesh = runtime.block_on(ProcMesh::allocate(alloc)).unwrap();
+                async fn inner(extent: Extent) {
+                    let alloc = LocalAllocator
+                        .allocate(AllocSpec {
+                            extent: extent.clone(),
+                            constraints: Default::default(),
+                            proc_name: None,
+                            transport: ChannelTransport::Local,
+                            proc_allocation_mode: Default::default(),
+                        }).await
+                        .unwrap();
+                    let instance = crate::v1::testing::instance();
+                    let proc_mesh = ProcMesh::allocate(alloc).await.unwrap();
 
-                let addr = ChannelAddr::any(ChannelTransport::Unix);
+                    let addr = ChannelAddr::any(ChannelTransport::Unix);
 
-                let actor_mesh: RootActorMesh<EchoActor> =
-                    runtime.block_on(proc_mesh.spawn(&instance, "echo", &addr)).unwrap();
-
-
-                let first_label = extent.labels().first().unwrap();
-                let slice = actor_mesh.select(first_label, 0..extent.size(first_label).unwrap()).unwrap();
-
-                // Unfortunately we must do things this way due to borrow checker reasons
-                let slice = if extent.len() >= 2 {
-                    let label = &extent.labels()[1];
-                    let size = extent.size(label).unwrap();
-                    let start = if size > 1 { 1 } else { 0 };
-                    let end = (if size > 1 { size - 1 } else { 1 }).max(start + 1);
-                    slice.select(label, start..end).unwrap()
-                } else {
-                    slice
-                };
-
-                let slice = if extent.len() >= 3 {
-                    let label = &extent.labels()[2];
-                    let size = extent.size(label).unwrap();
-                    let start = if size > 1 { 1 } else { 0 };
-                    let end = (if size > 1 { size - 1 } else { 1 }).max(start + 1);
-                    slice.select(label, start..end).unwrap()
-                } else {
-                    slice
-                };
-
-                let slice = if extent.len() >= 4 {
-                    let label = &extent.labels()[3];
-                    let size = extent.size(label).unwrap();
-                    let start = if size > 1 { 1 } else { 0 };
-                    let end = (if size > 1 { size - 1 } else { 1 }).max(start + 1);
-                    slice.select(label, start..end).unwrap()
-                } else {
-                    slice
-                };
+                    let actor_mesh: RootActorMesh<EchoActor> =
+                        proc_mesh.spawn(&instance, "echo", &addr).await.unwrap();
 
 
-                let mut runner = TestRunner::default();
-                let selection = gen_selection(4, slice.shape().slice().sizes().to_vec(), 0)
-                    .new_tree(&mut runner)
-                    .unwrap()
-                    .current();
+                    let first_label = extent.labels().first().unwrap();
+                    let slice = actor_mesh.select(first_label, 0..extent.size(first_label).unwrap()).unwrap();
 
-                runtime.block_on(validate_cast(
-                    &slice,
-                    actor_mesh.proc_mesh().client(),
-                    addr,
-                    selection
-                ));
+                    // Unfortunately we must do things this way due to borrow checker reasons
+                    let slice = if extent.len() >= 2 {
+                        let label = &extent.labels()[1];
+                        let size = extent.size(label).unwrap();
+                        let start = if size > 1 { 1 } else { 0 };
+                        let end = (if size > 1 { size - 1 } else { 1 }).max(start + 1);
+                        slice.select(label, start..end).unwrap()
+                    } else {
+                        slice
+                    };
+
+                    let slice = if extent.len() >= 3 {
+                        let label = &extent.labels()[2];
+                        let size = extent.size(label).unwrap();
+                        let start = if size > 1 { 1 } else { 0 };
+                        let end = (if size > 1 { size - 1 } else { 1 }).max(start + 1);
+                        slice.select(label, start..end).unwrap()
+                    } else {
+                        slice
+                    };
+
+                    let slice = if extent.len() >= 4 {
+                        let label = &extent.labels()[3];
+                        let size = extent.size(label).unwrap();
+                        let start = if size > 1 { 1 } else { 0 };
+                        let end = (if size > 1 { size - 1 } else { 1 }).max(start + 1);
+                        slice.select(label, start..end).unwrap()
+                    } else {
+                        slice
+                    };
+
+
+                    let mut runner = TestRunner::default();
+                    let selection = gen_selection(4, slice.shape().slice().sizes().to_vec(), 0)
+                        .new_tree(&mut runner)
+                        .unwrap()
+                        .current();
+
+                    validate_cast(
+                        &slice,
+                        actor_mesh.proc_mesh().client(),
+                        addr,
+                        selection
+                    ).await;
+                }
+                runtime.block_on(inner(extent));
             }
         }
 
@@ -1932,35 +1935,38 @@ mod tests {
              #[test]
              fn test_reshaped_actor_mesh_cast_with_selection(extent in gen_extent(1..=4, 8)) {
                 let runtime = make_tokio_runtime();
-                let alloc = runtime.block_on(LocalAllocator
-                    .allocate(AllocSpec {
-                        extent,
-                        constraints: Default::default(),
-                        proc_name: None,
-                        transport: ChannelTransport::Local,
-                        proc_allocation_mode: Default::default(),
-                    }))
-                    .unwrap();
-                let instance = runtime.block_on(crate::v1::testing::instance());
-                let proc_mesh = runtime.block_on(ProcMesh::allocate(alloc)).unwrap();
+                async fn inner(extent: Extent) {
+                    let alloc = LocalAllocator
+                        .allocate(AllocSpec {
+                            extent,
+                            constraints: Default::default(),
+                            proc_name: None,
+                            transport: ChannelTransport::Local,
+                            proc_allocation_mode: Default::default(),
+                        }).await
+                        .unwrap();
+                    let instance = crate::v1::testing::instance();
+                    let proc_mesh = ProcMesh::allocate(alloc).await.unwrap();
 
-                let addr = ChannelAddr::any(ChannelTransport::Unix);
+                    let addr = ChannelAddr::any(ChannelTransport::Unix);
 
-                let actor_mesh: RootActorMesh<EchoActor> =
-                    runtime.block_on(proc_mesh.spawn(&instance, "echo", &addr)).unwrap();
+                    let actor_mesh: RootActorMesh<EchoActor> =
+                        proc_mesh.spawn(&instance, "echo", &addr).await.unwrap();
 
-                let mut runner = TestRunner::default();
-                let selection = gen_selection(4, actor_mesh.shape().slice().sizes().to_vec(), 0)
-                    .new_tree(&mut runner)
-                    .unwrap()
-                    .current();
+                    let mut runner = TestRunner::default();
+                    let selection = gen_selection(4, actor_mesh.shape().slice().sizes().to_vec(), 0)
+                        .new_tree(&mut runner)
+                        .unwrap()
+                        .current();
 
-                runtime.block_on(validate_cast(
-                    &actor_mesh,
-                    actor_mesh.proc_mesh().client(),
-                    addr,
-                    selection
-                ));
+                    validate_cast(
+                        &actor_mesh,
+                        actor_mesh.proc_mesh().client(),
+                        addr,
+                        selection
+                    ).await;
+                }
+                runtime.block_on(inner(extent));
             }
         }
     }
@@ -1978,7 +1984,7 @@ mod tests {
         #[tokio::test]
         #[cfg(fbcode_build)]
         async fn test_basic() {
-            let instance = v1::testing::instance().await;
+            let instance = v1::testing::instance();
             let host_mesh = v1::testing::host_mesh(extent!(host = 4)).await;
             let proc_mesh = host_mesh
                 .spawn(instance, "test", Extent::unity())

--- a/hyperactor_mesh/src/alloc/sim.rs
+++ b/hyperactor_mesh/src/alloc/sim.rs
@@ -200,7 +200,7 @@ mod tests {
             })
             .await
             .unwrap();
-        let instance = crate::v1::testing::instance().await;
+        let instance = crate::v1::testing::instance();
 
         let proc_mesh = ProcMesh::allocate(alloc).await.unwrap();
 

--- a/hyperactor_mesh/src/bootstrap.rs
+++ b/hyperactor_mesh/src/bootstrap.rs
@@ -3536,9 +3536,8 @@ mod tests {
     #[cfg(fbcode_build)]
     async fn bootstrap_handle_terminate_graceful() {
         // Create a root direct-addressed proc + client instance.
-        let root = hyperactor::Proc::direct(ChannelTransport::Unix.any(), "root".to_string())
-            .await
-            .unwrap();
+        let root =
+            hyperactor::Proc::direct(ChannelTransport::Unix.any(), "root".to_string()).unwrap();
         let (instance, _handle) = root.instance("client").unwrap();
 
         let mgr = BootstrapProcManager::new(BootstrapCommand::test()).unwrap();
@@ -3600,9 +3599,8 @@ mod tests {
     #[cfg(fbcode_build)]
     async fn bootstrap_handle_kill_forced() {
         // Root proc + client instance (so the child can dial back).
-        let root = hyperactor::Proc::direct(ChannelTransport::Unix.any(), "root".to_string())
-            .await
-            .unwrap();
+        let root =
+            hyperactor::Proc::direct(ChannelTransport::Unix.any(), "root".to_string()).unwrap();
         let (instance, _handle) = root.instance("client").unwrap();
 
         let mgr = BootstrapProcManager::new(BootstrapCommand::test()).unwrap();
@@ -3655,7 +3653,7 @@ mod tests {
         }
         // Create an actor instance we'll use to send and receive
         // messages.
-        let instance = testing::instance().await;
+        let instance = testing::instance();
 
         // Configure a ProcessAllocator with the bootstrap binary.
         let mut allocator = ProcessAllocator::new(Command::new(crate::testresource::get(

--- a/hyperactor_mesh/src/comm.rs
+++ b/hyperactor_mesh/src/comm.rs
@@ -841,7 +841,7 @@ mod tests {
         let params = TestActorParams {
             forward_port: tx.bind(),
         };
-        let instance = crate::v1::testing::instance().await;
+        let instance = crate::v1::testing::instance();
         let actor_mesh: RootActorMesh<TestActor> = Arc::clone(&proc_mesh)
             .spawn(&instance, dest_actor_name, &params)
             .await
@@ -1059,7 +1059,7 @@ mod tests {
     where
         A: Accumulator<Update = u64, State = u64> + Send + Sync + 'static,
     {
-        let instance = v1::testing::instance().await;
+        let instance = v1::testing::instance();
 
         let extent = extent!(replica = 4, host = 4, gpu = 4);
         let alloc = LocalAllocator

--- a/hyperactor_mesh/src/proc_mesh.rs
+++ b/hyperactor_mesh/src/proc_mesh.rs
@@ -1231,7 +1231,7 @@ mod tests {
         let mut mesh = ProcMesh::allocate(alloc).await.unwrap();
         let mut events = mesh.events().unwrap();
 
-        let instance = crate::v1::testing::instance().await;
+        let instance = crate::v1::testing::instance();
 
         let mut actors: RootActorMesh<TestActor> =
             mesh.spawn(&instance, "failing", &()).await.unwrap();
@@ -1285,7 +1285,7 @@ mod tests {
             .unwrap();
         let mesh = ProcMesh::allocate(alloc).await.unwrap();
 
-        let instance = crate::v1::testing::instance().await;
+        let instance = crate::v1::testing::instance();
         let _: RootActorMesh<TestActor> = mesh.spawn(&instance, "dup", &()).await.unwrap();
         let result: Result<RootActorMesh<TestActor>, _> = mesh.spawn(&instance, "dup", &()).await;
         assert!(result.is_err());
@@ -1304,7 +1304,7 @@ mod tests {
         #[tokio::test]
         #[cfg(fbcode_build)]
         async fn test_basic() {
-            let instance = v1::testing::instance().await;
+            let instance = v1::testing::instance();
             let ext = extent!(host = 4);
             let host_mesh = v1::testing::host_mesh(ext.clone()).await;
             let proc_mesh = host_mesh

--- a/hyperactor_mesh/src/reference.rs
+++ b/hyperactor_mesh/src/reference.rs
@@ -341,7 +341,7 @@ mod tests {
             })
             .await
             .unwrap();
-        let instance = crate::v1::testing::instance().await;
+        let instance = crate::v1::testing::instance();
         let ping_proc_mesh = ProcMesh::allocate(alloc_ping).await.unwrap();
         let ping_mesh: RootActorMesh<MeshPingPongActor> = ping_proc_mesh
             .spawn(

--- a/hyperactor_mesh/src/v1/actor_mesh.rs
+++ b/hyperactor_mesh/src/v1/actor_mesh.rs
@@ -478,7 +478,7 @@ mod tests {
     #[cfg(fbcode_build)]
     async fn test_actor_mesh_ref_lazy_materialization() {
         // 1) Bring up procs and spawn actors.
-        let instance = testing::instance().await;
+        let instance = testing::instance();
         // Small mesh so the test runs fast, but > page_size so we
         // cross a boundary
         let extent = extent!(replicas = 3, hosts = 2); // 6 ranks
@@ -579,7 +579,7 @@ mod tests {
     async fn test_actor_states_with_panic() {
         hyperactor_telemetry::initialize_logging_for_test();
 
-        let instance = testing::instance().await;
+        let instance = testing::instance();
         // Listen for supervision events sent to the parent instance.
         let (supervision_port, mut supervision_receiver) =
             instance.open_port::<resource::State<ActorState>>();
@@ -649,7 +649,7 @@ mod tests {
         let config = hyperactor_config::global::lock();
         let _guard = config.override_key(GET_ACTOR_STATE_MAX_IDLE, Duration::from_secs(1));
 
-        let instance = testing::instance().await;
+        let instance = testing::instance();
         // Listen for supervision events sent to the parent instance.
         let (supervision_port, mut supervision_receiver) =
             instance.open_port::<resource::State<ActorState>>();
@@ -714,7 +714,7 @@ mod tests {
     async fn test_actor_states_on_sliced_mesh() {
         hyperactor_telemetry::initialize_logging_for_test();
 
-        let instance = testing::instance().await;
+        let instance = testing::instance();
         // Listen for supervision events sent to the parent instance.
         let (supervision_port, mut supervision_receiver) =
             instance.open_port::<resource::State<ActorState>>();
@@ -789,7 +789,7 @@ mod tests {
         let config = hyperactor_config::global::lock();
         let _guard = config.override_key(crate::bootstrap::MESH_BOOTSTRAP_ENABLE_PDEATHSIG, false);
 
-        let instance = testing::instance().await;
+        let instance = testing::instance();
         let mut host_mesh = testing::host_mesh(extent!(host = 4)).await;
         let proc_mesh = host_mesh
             .spawn(instance, "test", Extent::unity())
@@ -845,7 +845,7 @@ mod tests {
             std::time::Duration::from_secs(1),
         );
 
-        let instance = testing::instance().await;
+        let instance = testing::instance();
 
         // Create a proc mesh with 2 replicas.
         let meshes = testing::proc_meshes(instance, extent!(replicas = 2)).await;
@@ -956,7 +956,7 @@ mod tests {
         let config = hyperactor_config::global::lock();
         let _guard = config.override_key(ACTOR_SPAWN_MAX_IDLE, std::time::Duration::from_secs(1));
 
-        let instance = testing::instance().await;
+        let instance = testing::instance();
 
         // Create proc mesh with 2 replicas
         let meshes = testing::proc_meshes(instance, extent!(replicas = 2)).await;
@@ -1037,7 +1037,7 @@ mod tests {
     async fn test_actor_mesh_stop_graceful() {
         hyperactor_telemetry::initialize_logging_for_test();
 
-        let instance = testing::instance().await;
+        let instance = testing::instance();
 
         // Create proc mesh with 2 replicas
         let meshes = testing::proc_meshes(instance, extent!(replicas = 2)).await;

--- a/hyperactor_mesh/src/v1/host_mesh.rs
+++ b/hyperactor_mesh/src/v1/host_mesh.rs
@@ -595,7 +595,6 @@ impl Drop for HostMesh {
                     ChannelTransport::Unix.any(),
                     "hostmesh-drop".to_string(),
                 )
-                    .await
                 {
                     Err(e) => {
                         tracing::warn!(
@@ -1394,7 +1393,7 @@ mod tests {
         let config = hyperactor_config::global::lock();
         let _guard = config.override_key(crate::bootstrap::MESH_BOOTSTRAP_ENABLE_PDEATHSIG, false);
 
-        let instance = testing::instance().await;
+        let instance = testing::instance();
 
         for alloc in testing::allocs(extent!(replicas = 4)).await {
             let mut host_mesh = HostMesh::allocate(instance, alloc, "test", None)
@@ -1522,16 +1521,16 @@ mod tests {
             children.push(cmd.spawn().unwrap());
         }
 
-        let instance = testing::instance().await;
+        let instance = testing::instance();
         let host_mesh = HostMeshRef::from_hosts(Name::new("test").unwrap(), hosts);
 
         let proc_mesh = host_mesh
-            .spawn(&testing::instance().await, "test", Extent::unity())
+            .spawn(&testing::instance(), "test", Extent::unity())
             .await
             .unwrap();
 
         let actor_mesh: ActorMesh<testactor::TestActor> = proc_mesh
-            .spawn(&testing::instance().await, "test", &())
+            .spawn(&testing::instance(), "test", &())
             .await
             .unwrap();
 
@@ -1568,7 +1567,7 @@ mod tests {
         }
         let host_mesh = HostMeshRef::from_hosts(Name::new("test").unwrap(), hosts);
 
-        let instance = testing::instance().await;
+        let instance = testing::instance();
 
         let err = host_mesh
             .spawn(&instance, "test", Extent::unity())
@@ -1613,7 +1612,7 @@ mod tests {
         }
         let host_mesh = HostMeshRef::from_hosts(Name::new("test").unwrap(), hosts);
 
-        let instance = testing::instance().await;
+        let instance = testing::instance();
 
         let err = host_mesh
             .spawn(&instance, "test", Extent::unity())
@@ -1649,7 +1648,7 @@ mod tests {
             std::env::remove_var("HYPERACTOR_MESSAGE_DELIVERY_TIMEOUT");
         }
 
-        let instance = testing::instance().await;
+        let instance = testing::instance();
 
         let proc_meshes = testing::proc_meshes(instance, extent!(replicas = 2)).await;
         let proc_mesh = proc_meshes.get(1).unwrap();

--- a/hyperactor_mesh/src/v1/host_mesh/mesh_agent.rs
+++ b/hyperactor_mesh/src/v1/host_mesh/mesh_agent.rs
@@ -598,9 +598,7 @@ mod tests {
             .spawn("agent", HostMeshAgent::new(HostAgentMode::Process(host)))
             .unwrap();
 
-        let client_proc = Proc::direct(ChannelTransport::Unix.any(), "client".to_string())
-            .await
-            .unwrap();
+        let client_proc = Proc::direct(ChannelTransport::Unix.any(), "client".to_string()).unwrap();
         let (client, _client_handle) = client_proc.instance("client").unwrap();
 
         let name = Name::new("proc1").unwrap();

--- a/hyperactor_mesh/src/v1/proc_mesh.rs
+++ b/hyperactor_mesh/src/v1/proc_mesh.rs
@@ -1287,7 +1287,7 @@ mod tests {
     async fn test_spawn_actor() {
         hyperactor_telemetry::initialize_logging(hyperactor::clock::ClockKind::default());
 
-        let instance = testing::instance().await;
+        let instance = testing::instance();
 
         for proc_mesh in testing::proc_meshes(&instance, extent!(replicas = 4, hosts = 2)).await {
             testactor::assert_mesh_shape(proc_mesh.spawn(instance, "test", &()).await.unwrap())
@@ -1300,7 +1300,7 @@ mod tests {
     async fn test_failing_spawn_actor() {
         hyperactor_telemetry::initialize_logging(hyperactor::clock::ClockKind::default());
 
-        let instance = testing::instance().await;
+        let instance = testing::instance();
 
         for proc_mesh in testing::proc_meshes(&instance, extent!(replicas = 4, hosts = 2)).await {
             let err = proc_mesh

--- a/hyperactor_mesh/src/v1/testactor.rs
+++ b/hyperactor_mesh/src/v1/testactor.rs
@@ -290,7 +290,7 @@ impl Handler<GetConfigAttrs> for TestActor {
 /// and all actors are assigned the correct ranks. We also test
 /// slicing the mesh.
 pub async fn assert_mesh_shape(actor_mesh: ActorMesh<TestActor>) {
-    let instance = testing::instance().await;
+    let instance = testing::instance();
     // Verify casting to the root actor mesh
     assert_casting_correctness(&actor_mesh, instance).await;
 

--- a/hyperactor_mesh/src/v1/testing.rs
+++ b/hyperactor_mesh/src/v1/testing.rs
@@ -117,11 +117,9 @@ impl TestRootClient {
 }
 
 /// Returns a new test instance; it is initialized lazily.
-pub async fn fresh_instance() -> &'static Instance<TestRootClient> {
+pub fn fresh_instance() -> &'static Instance<TestRootClient> {
     static INSTANCE: OnceLock<Instance<TestRootClient>> = OnceLock::new();
-    let proc = Proc::direct(ChannelTransport::Unix.any(), "testproc".to_string())
-        .await
-        .unwrap();
+    let proc = Proc::direct(ChannelTransport::Unix.any(), "testproc".to_string()).unwrap();
     let (actor, _handle, supervision_rx, signal_rx, work_rx) =
         proc.actor_instance("testclient").unwrap();
     // Use the OnceLock to get a 'static lifetime for the instance.
@@ -140,9 +138,9 @@ pub async fn fresh_instance() -> &'static Instance<TestRootClient> {
 }
 
 /// Returns the singleton test instance; it is initialized lazily.
-pub async fn instance() -> &'static Instance<TestRootClient> {
-    static INSTANCE: OnceCell<&'static Instance<TestRootClient>> = OnceCell::const_new();
-    INSTANCE.get_or_init(fresh_instance).await
+pub fn instance() -> &'static Instance<TestRootClient> {
+    static INSTANCE: OnceLock<&'static Instance<TestRootClient>> = OnceLock::new();
+    INSTANCE.get_or_init(fresh_instance)
 }
 
 #[cfg(fbcode_build)]
@@ -291,7 +289,7 @@ pub async fn host_mesh(extent: Extent) -> HostMesh {
         .await
         .unwrap();
 
-    HostMesh::allocate(instance().await, Box::new(alloc), "test", None)
+    HostMesh::allocate(instance(), Box::new(alloc), "test", None)
         .await
         .unwrap()
 }

--- a/monarch_hyperactor/src/v1/logging.rs
+++ b/monarch_hyperactor/src/v1/logging.rs
@@ -481,7 +481,6 @@ mod tests {
         ensure_python();
 
         let proc = Proc::direct(ChannelTransport::Unix.any(), "root".to_string())
-            .await
             .expect("failed to start root Proc");
 
         let (instance, ..) = proc


### PR DESCRIPTION
Summary:
The `Proc::direct` function was async when it didn't use any async features.
Remove these to simplify the use cases. No semantic changes.
`channel::serve` still needs a tokio runtime active, so the caller has to make sure
there is an async function wrapping it.

Reviewed By: thedavekwon

Differential Revision: D88979850


