### PR TITLE
Fix test_job and test_python_actors

### DIFF
--- a/python/tests/test_job.py
+++ b/python/tests/test_job.py
@@ -348,6 +348,8 @@ def test_local_job_compatibility():
 train_script = os.path.join(os.path.dirname(__file__), "job_train.py")
 
 
+# TODO(https://github.com/meta-pytorch/monarch/issues/2213): Occasional GIL release failure.
+@pytest.mark.oss_skip
 def test_train_script_job_state_regular():
     """
     Test that the train.py script picks up the default 'hosts' in regular mode.
@@ -385,6 +387,8 @@ def test_train_script_job_state_regular():
         assert "batch_launched_hosts False" in result.stdout
 
 
+# TODO(https://github.com/meta-pytorch/monarch/issues/2213): Occasional GIL release failure.
+@pytest.mark.oss_skip
 def test_train_script_job_state_batch():
     """
     Test that the train.py script picks up the 'batch_launched_hosts' in batch mode.

--- a/python/tests/test_python_actors.py
+++ b/python/tests/test_python_actors.py
@@ -1179,6 +1179,9 @@ async def test_sync_workspace() -> None:
 async def test_proc_mesh_stop_after_actor_mesh_stop() -> None:
     pm = this_host().spawn_procs(per_host={"gpus": 2})
     am = pm.spawn("printer", Printer)
+    # Make sure the actor is initialized first, else the stop and init can
+    # race and the message becomes undeliverable.
+    await am.print.call("hello world")
 
     await cast(ActorMesh, am).stop()
     await pm.stop()


### PR DESCRIPTION
Summary:
Part of: https://github.com/meta-pytorch/monarch/issues/2213

test_job.py tests have flaky failures, described in the issue. This doesn't fix them, but
skips them in Github CI. We'll follow up to fix them when we have time.

test_proc_mesh_stop_after_actor_mesh_stop is not part of that task, but also had an
occasional failure due to a race condition between the actor constructor and stop. The stop
is sent to a different actor (ProcMeshAgent) and doesn't have ordering guarantees with
messages to the actor itself.

Reviewed By: vidhyav

Differential Revision: D89894540


