### PR TITLE
Add missing docstring to example for sphinx documentation

### DIFF
--- a/docs/source/examples/grpo_sim.py
+++ b/docs/source/examples/grpo_sim.py
@@ -6,6 +6,17 @@
 
 # pyre-strict
 
+"""
+Simulation of GRPO without Tensor Engine
+=====================================
+Demonstrates working with grpo_actor.py to show that GRPO can be simulated
+without real GPUs.
+
+Run with::
+
+    buck2 run //monarch/docs/source/examples:grpo_sim
+"""
+
 import asyncio
 from typing import Any, Dict, Optional
 


### PR DESCRIPTION
Summary:
Fixing documentation build error:
```
sphinx.errors.ExtensionError: Could not find docstring in file
"/meta-pytorch/monarch/docs/source/examples/grpo_sim.py".
A docstring is required by sphinx-gallery unless the file is ignored by "ignore_pattern"
```
Added a docstring to this file, which is the only file in examples missing it.

Differential Revision: D89931402


