### PR TITLE
: use an Encoding (Python) enum

### DIFF
--- a/docs/source/api/monarch.config.rst
+++ b/docs/source/api/monarch.config.rst
@@ -359,15 +359,20 @@ Message Encoding
 ``default_encoding``
     Default message encoding format.
 
-    - **Type**: ``str``
-    - **Default**: ``"serde_multipart"``
-    - **Environment**: ``HYPERACTOR_DEFAULT_ENCODING``
+    - **Type**: ``Encoding`` enum
+    - **Default**: ``Encoding.Multipart``
+    - **Environment**: ``HYPERACTOR_DEFAULT_ENCODING`` (accepts ``"bincode"``, ``"serde_json"``, or ``"serde_multipart"``)
 
     Supported values:
 
-    - ``"bincode"`` - Binary encoding
-    - ``"serde_json"`` - JSON encoding
-    - ``"serde_multipart"`` - Multipart encoding (default)
+    - ``Encoding.Bincode`` - Bincode serialization (compact binary format via the ``bincode`` crate)
+    - ``Encoding.Json`` - JSON serialization (via ``serde_json``)
+    - ``Encoding.Multipart`` - Zero-copy multipart encoding that separates large binary fields from the message body, enabling efficient transmission via vectored I/O (default)
+
+    Example usage::
+
+        from monarch.config import Encoding, configure
+        configure(default_encoding=Encoding.Bincode)
 
 
 Mesh Bootstrap

--- a/python/monarch/_rust_bindings/monarch_hyperactor/config.pyi
+++ b/python/monarch/_rust_bindings/monarch_hyperactor/config.pyi
@@ -10,9 +10,17 @@
 Type hints for the monarch_hyperactor.config Rust bindings.
 """
 
+from enum import Enum
 from typing import Any, Dict
 
 from monarch._rust_bindings.monarch_hyperactor.channel import ChannelTransport
+
+class Encoding(Enum):
+    """Message encoding format for serialization."""
+
+    Bincode: int
+    Json: int
+    Multipart: int
 
 def reload_config_from_env() -> None:
     """
@@ -49,7 +57,7 @@ def configure(
     stop_actor_timeout: str = ...,
     cleanup_timeout: str = ...,
     remote_allocator_heartbeat_interval: str = ...,
-    default_encoding: str = ...,
+    default_encoding: Encoding = ...,
     channel_net_rx_buffer_full_check_interval: str = ...,
     message_latency_sampling_rate: float = ...,
     enable_client_seq_assignment: bool = ...,
@@ -115,8 +123,8 @@ def configure(
         cleanup_timeout: Timeout for cleanup operations (humantime)
         remote_allocator_heartbeat_interval: Heartbeat interval for
             remote allocator (humantime)
-        default_encoding: Default message encoding ("bincode",
-            "serde_json", or "serde_multipart")
+        default_encoding: Default message encoding (Encoding.Bincode,
+            Encoding.Json, or Encoding.Multipart)
         channel_net_rx_buffer_full_check_interval: Network receive buffer
             check interval (humantime)
         message_latency_sampling_rate: Sampling rate for message latency

--- a/python/monarch/config/__init__.py
+++ b/python/monarch/config/__init__.py
@@ -20,6 +20,7 @@ from monarch._rust_bindings.monarch_hyperactor.channel import ChannelTransport
 from monarch._rust_bindings.monarch_hyperactor.config import (
     clear_runtime_config as _clear_runtime_config,
     configure as _configure,
+    Encoding,
     get_global_config as _get_global_config,
     get_runtime_config as _get_runtime_config,
 )
@@ -29,6 +30,7 @@ __all__ = [
     "clear_runtime_config",
     "configure",
     "configured",
+    "Encoding",
     "get_global_config",
     "get_runtime_config",
 ]
@@ -53,7 +55,7 @@ def configure(
     stop_actor_timeout: str | None = None,
     cleanup_timeout: str | None = None,
     remote_allocator_heartbeat_interval: str | None = None,
-    default_encoding: str | None = None,
+    default_encoding: Encoding | None = None,
     channel_net_rx_buffer_full_check_interval: str | None = None,
     message_latency_sampling_rate: float | None = None,
     enable_client_seq_assignment: bool | None = None,
@@ -111,7 +113,7 @@ def configure(
             stop_actor_timeout: Timeout for stopping actors (humantime).
             cleanup_timeout: Timeout for cleanup operations (humantime).
             remote_allocator_heartbeat_interval: Heartbeat interval for remote allocator (humantime).
-            default_encoding: Default message encoding ("bincode", "serde_json", or "serde_multipart").
+            default_encoding: Default message encoding (Encoding.Bincode, Encoding.Json, or Encoding.Multipart).
             channel_net_rx_buffer_full_check_interval: Network receive buffer check interval (humantime).
             message_latency_sampling_rate: Sampling rate for message latency tracking (0.0 to 1.0).
             enable_client_seq_assignment: Enable client-side sequence assignment.


### PR DESCRIPTION
Summary:
follow up on [dulinriley's suggestion] from D89555029 to expose message encoding as a Python enum and model `default_encoding` as an `Encoding` value rather than a string.

this replaces string-based parsing with a typed `Encoding `enum across the rust bindings, python API, docs, and tests, improving type safety and discoverability while preserving the same underlying rust encodings.

Differential Revision: D90114835


