### PR TITLE
Rename SupervisionFailureMessage -> MeshFailure

### DIFF
--- a/hyperactor_mesh/src/actor_mesh.rs
+++ b/hyperactor_mesh/src/actor_mesh.rs
@@ -677,7 +677,7 @@ pub(crate) mod test_util {
 
     use super::*;
     use crate::comm::multicast::CastInfo;
-    use crate::supervision::SupervisionFailureMessage;
+    use crate::supervision::MeshFailure;
 
     // This can't be defined under a `#[cfg(test)]` because there needs to
     // be an entry in the spawnable actor registry in the executable
@@ -890,11 +890,11 @@ pub(crate) mod test_util {
         }
     }
     #[async_trait]
-    impl Handler<SupervisionFailureMessage> for ProxyActor {
+    impl Handler<MeshFailure> for ProxyActor {
         async fn handle(
             &mut self,
             _cx: &Context<Self>,
-            message: SupervisionFailureMessage,
+            message: MeshFailure,
         ) -> Result<(), anyhow::Error> {
             panic!("unhandled supervision failure: {}", message);
         }

--- a/hyperactor_mesh/src/supervision.rs
+++ b/hyperactor_mesh/src/supervision.rs
@@ -21,7 +21,7 @@ use typeuri::Named;
 /// Message about a supervision failure on a mesh of actors instead of a single
 /// actor.
 #[derive(Clone, Debug, Serialize, Deserialize, Named, PartialEq, Bind, Unbind)]
-pub struct SupervisionFailureMessage {
+pub struct MeshFailure {
     /// Name of the mesh which the event originated from.
     pub actor_mesh_name: Option<String>,
     /// Rank of the mesh from which the event originated.
@@ -30,9 +30,9 @@ pub struct SupervisionFailureMessage {
     /// The supervision event on an actor located at mesh + rank.
     pub event: ActorSupervisionEvent,
 }
-wirevalue::register_type!(SupervisionFailureMessage);
+wirevalue::register_type!(MeshFailure);
 
-impl SupervisionFailureMessage {
+impl MeshFailure {
     /// Helper function to handle a message to an actor that just wants to forward
     /// it to the next owner.
     pub fn default_handler(&self, cx: &impl context::Actor) -> Result<(), anyhow::Error> {
@@ -50,7 +50,7 @@ impl SupervisionFailureMessage {
     }
 }
 
-impl std::fmt::Display for SupervisionFailureMessage {
+impl std::fmt::Display for MeshFailure {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
@@ -63,6 +63,6 @@ impl std::fmt::Display for SupervisionFailureMessage {
 // Shared between mesh types.
 #[derive(Debug, Clone)]
 pub(crate) enum Unhealthy {
-    StreamClosed(SupervisionFailureMessage), // Event stream closed
-    Crashed(SupervisionFailureMessage),      // Bad health event received
+    StreamClosed(MeshFailure), // Event stream closed
+    Crashed(MeshFailure),      // Bad health event received
 }

--- a/hyperactor_mesh/src/v1/actor_mesh.rs
+++ b/hyperactor_mesh/src/v1/actor_mesh.rs
@@ -47,7 +47,7 @@ use crate::comm::multicast;
 use crate::proc_mesh::mesh_agent::ActorState;
 use crate::reference::ActorMeshId;
 use crate::resource;
-use crate::supervision::SupervisionFailureMessage;
+use crate::supervision::MeshFailure;
 use crate::supervision::Unhealthy;
 use crate::v1;
 use crate::v1::Error;
@@ -169,21 +169,20 @@ impl<A: Referable> ActorMesh<A> {
             }?;
             // Update health state with the new statuses.
             let mut health_state = self.health_state.lock().expect("lock poisoned");
-            health_state.unhealthy_event =
-                Some(Unhealthy::StreamClosed(SupervisionFailureMessage {
-                    actor_mesh_name: Some(self.name().to_string()),
-                    rank: None,
-                    event: ActorSupervisionEvent::new(
-                        // Use an actor id from the mesh.
-                        ndslice::view::Ranked::get(&self.current_ref, 0)
-                            .unwrap()
-                            .actor_id()
-                            .clone(),
-                        None,
-                        ActorStatus::Stopped,
-                        None,
-                    ),
-                }));
+            health_state.unhealthy_event = Some(Unhealthy::StreamClosed(MeshFailure {
+                actor_mesh_name: Some(self.name().to_string()),
+                rank: None,
+                event: ActorSupervisionEvent::new(
+                    // Use an actor id from the mesh.
+                    ndslice::view::Ranked::get(&self.current_ref, 0)
+                        .unwrap()
+                        .actor_id()
+                        .clone(),
+                    None,
+                    ActorStatus::Stopped,
+                    None,
+                ),
+            }));
         }
         // Also take the controller from the ref, since that is used for
         // some operations.
@@ -335,11 +334,8 @@ pub struct ActorMeshRef<A: Referable> {
     /// Shared cloneable receiver for supervision events, used by next_supervision_event.
     /// Not a OnceCell since we need mutable borrows for "watch::Receiver::wait_for"
     /// mutable borrows of OnceCell are an unstable library feature.
-    receiver: Arc<
-        tokio::sync::Mutex<
-            Option<watch::Receiver<MessageOrFailure<Option<SupervisionFailureMessage>>>>,
-        >,
-    >,
+    receiver:
+        Arc<tokio::sync::Mutex<Option<watch::Receiver<MessageOrFailure<Option<MeshFailure>>>>>>,
     /// Lazily allocated collection of pages:
     /// - The outer `OnceCell` defers creating the vector until first
     ///   use.
@@ -611,7 +607,7 @@ impl<A: Referable> ActorMeshRef<A> {
     fn init_supervision_receiver(
         controller: &ActorRef<ActorMeshController<A>>,
         cx: &impl context::Actor,
-    ) -> watch::Receiver<MessageOrFailure<Option<SupervisionFailureMessage>>> {
+    ) -> watch::Receiver<MessageOrFailure<Option<MeshFailure>>> {
         let (tx, rx) = cx.mailbox().open_port();
         controller
             .send(cx, Subscribe(tx.bind()))
@@ -628,7 +624,7 @@ impl<A: Referable> ActorMeshRef<A> {
     pub async fn next_supervision_event(
         &self,
         cx: &impl context::Actor,
-    ) -> Result<SupervisionFailureMessage, anyhow::Error> {
+    ) -> Result<MeshFailure, anyhow::Error> {
         let controller = if let Some(c) = self.controller() {
             c
         } else {
@@ -673,16 +669,14 @@ impl<A: Referable> ActorMeshRef<A> {
                 .await?;
             let message = message.clone();
             match message {
-                MessageOrFailure::Message(message) => {
-                    Ok::<SupervisionFailureMessage, anyhow::Error>(
-                        message.expect("filter excludes any None messages"),
-                    )
-                }
+                MessageOrFailure::Message(message) => Ok::<MeshFailure, anyhow::Error>(
+                    message.expect("filter excludes any None messages"),
+                ),
                 MessageOrFailure::Failure(failure) => Err(anyhow::anyhow!("{}", failure)),
                 MessageOrFailure::Timeout => {
                     // Treat timeout from controller as a supervision failure,
                     // the controller is unreachable.
-                    Ok(SupervisionFailureMessage {
+                    Ok(MeshFailure {
                         actor_mesh_name: Some(self.name().to_string()),
                         rank: None,
                         event: ActorSupervisionEvent::new(
@@ -841,7 +835,7 @@ mod tests {
     use tokio::time::Duration;
 
     use super::ActorMesh;
-    use crate::supervision::SupervisionFailureMessage;
+    use crate::supervision::MeshFailure;
     use crate::v1::ActorMeshRef;
     use crate::v1::Name;
     use crate::v1::ProcMesh;
@@ -963,15 +957,14 @@ mod tests {
 
         let instance = testing::instance();
         // Listen for supervision events sent to the parent instance.
-        let (supervision_port, mut supervision_receiver) =
-            instance.open_port::<SupervisionFailureMessage>();
+        let (supervision_port, mut supervision_receiver) = instance.open_port::<MeshFailure>();
         let supervisor = supervision_port.bind();
         let num_replicas = 4;
         let meshes = testing::proc_meshes(instance, extent!(replicas = num_replicas)).await;
         let proc_mesh = &meshes[1];
         let child_name = Name::new("child").unwrap();
 
-        // Need to use a wrapper as there's no way to customize the handler for SupervisionFailureMessage
+        // Need to use a wrapper as there's no way to customize the handler for MeshFailure
         // on the client instance. The client would just panic with the message.
         let actor_mesh: ActorMesh<testactor::WrapperActor> = proc_mesh
             .spawn(
@@ -1002,8 +995,7 @@ mod tests {
         // First test the ActorMeshRef got the event.
         // Use a NextSupervisionFailure message to get the event from the wrapper
         // actor.
-        let (failure_port, mut failure_receiver) =
-            instance.open_port::<Option<SupervisionFailureMessage>>();
+        let (failure_port, mut failure_receiver) = instance.open_port::<Option<MeshFailure>>();
         actor_mesh
             .cast(
                 instance,
@@ -1015,7 +1007,7 @@ mod tests {
             .await
             .unwrap()
             .expect("no supervision event found on ref from wrapper actor");
-        let check_failure = move |failure: SupervisionFailureMessage| {
+        let check_failure = move |failure: MeshFailure| {
             assert_eq!(failure.actor_mesh_name, Some(child_name.to_string()));
             assert_eq!(
                 failure.event.actor_id.name(),
@@ -1053,8 +1045,7 @@ mod tests {
 
         let instance = testing::instance();
         // Listen for supervision events sent to the parent instance.
-        let (supervision_port, mut supervision_receiver) =
-            instance.open_port::<SupervisionFailureMessage>();
+        let (supervision_port, mut supervision_receiver) = instance.open_port::<MeshFailure>();
         let supervisor = supervision_port.bind();
         let num_replicas = 4;
         let meshes = testing::proc_meshes(instance, extent!(replicas = num_replicas)).await;
@@ -1063,7 +1054,7 @@ mod tests {
         let second_proc_mesh = &second_meshes[1];
         let child_name = Name::new("child").unwrap();
 
-        // Need to use a wrapper as there's no way to customize the handler for SupervisionFailureMessage
+        // Need to use a wrapper as there's no way to customize the handler for MeshFailure
         // on the client instance. The client would just panic with the message.
         let actor_mesh: ActorMesh<testactor::WrapperActor> = proc_mesh
             .spawn(
@@ -1091,8 +1082,7 @@ mod tests {
             .unwrap();
 
         // Same drill as for panic, except this one is for process exit.
-        let (failure_port, mut failure_receiver) =
-            instance.open_port::<Option<SupervisionFailureMessage>>();
+        let (failure_port, mut failure_receiver) = instance.open_port::<Option<MeshFailure>>();
         actor_mesh
             .cast(
                 instance,
@@ -1105,7 +1095,7 @@ mod tests {
             .unwrap()
             .expect("no supervision event found on ref from wrapper actor");
 
-        let check_failure = move |failure: SupervisionFailureMessage| {
+        let check_failure = move |failure: MeshFailure| {
             // TODO: It can't find the real actor id, so it says the agent failed.
             assert_eq!(failure.actor_mesh_name, Some(child_name.to_string()));
             assert_eq!(failure.event.actor_id.name(), "mesh");
@@ -1139,15 +1129,14 @@ mod tests {
 
         let instance = testing::instance();
         // Listen for supervision events sent to the parent instance.
-        let (supervision_port, mut supervision_receiver) =
-            instance.open_port::<SupervisionFailureMessage>();
+        let (supervision_port, mut supervision_receiver) = instance.open_port::<MeshFailure>();
         let supervisor = supervision_port.bind();
         let num_replicas = 4;
         let meshes = testing::proc_meshes(instance, extent!(replicas = num_replicas)).await;
         let proc_mesh = &meshes[1];
         let child_name = Name::new("child").unwrap();
 
-        // Need to use a wrapper as there's no way to customize the handler for SupervisionFailureMessage
+        // Need to use a wrapper as there's no way to customize the handler for MeshFailure
         // on the client instance. The client would just panic with the message.
         let actor_mesh: ActorMesh<testactor::WrapperActor> = proc_mesh
             .spawn(

--- a/hyperactor_mesh/src/v1/host_mesh.rs
+++ b/hyperactor_mesh/src/v1/host_mesh.rs
@@ -18,7 +18,7 @@ use hyperactor_config::ConfigAttr;
 use hyperactor_config::attrs::declare_attrs;
 use ndslice::view::CollectMeshExt;
 
-use crate::supervision::SupervisionFailureMessage;
+use crate::supervision::MeshFailure;
 
 pub mod mesh_agent;
 
@@ -383,7 +383,7 @@ impl HostMesh {
         bootstrap_params: Option<BootstrapCommand>,
     ) -> v1::Result<Self>
     where
-        C::A: Handler<SupervisionFailureMessage>,
+        C::A: Handler<MeshFailure>,
     {
         Self::allocate_inner(cx, alloc, Name::new(name)?, bootstrap_params).await
     }
@@ -397,7 +397,7 @@ impl HostMesh {
         bootstrap_params: Option<BootstrapCommand>,
     ) -> v1::Result<Self>
     where
-        C::A: Handler<SupervisionFailureMessage>,
+        C::A: Handler<MeshFailure>,
     {
         tracing::info!(name = "HostMeshStatus", status = "Allocate::Attempt");
         let transport = alloc.transport();
@@ -787,7 +787,7 @@ impl HostMeshRef {
         per_host: Extent,
     ) -> v1::Result<ProcMesh>
     where
-        C::A: Handler<SupervisionFailureMessage>,
+        C::A: Handler<MeshFailure>,
     {
         self.spawn_inner(cx, Name::new(name)?, per_host).await
     }
@@ -800,7 +800,7 @@ impl HostMeshRef {
         per_host: Extent,
     ) -> v1::Result<ProcMesh>
     where
-        C::A: Handler<SupervisionFailureMessage>,
+        C::A: Handler<MeshFailure>,
     {
         tracing::info!(name = "HostMeshStatus", status = "ProcMesh::Spawn::Attempt");
         tracing::info!(name = "ProcMeshStatus", status = "Spawn::Attempt",);
@@ -825,7 +825,7 @@ impl HostMeshRef {
         per_host: Extent,
     ) -> v1::Result<ProcMesh>
     where
-        C::A: Handler<SupervisionFailureMessage>,
+        C::A: Handler<MeshFailure>,
     {
         let per_host_labels = per_host.labels().iter().collect::<HashSet<_>>();
         let host_labels = self.region.labels().iter().collect::<HashSet<_>>();

--- a/hyperactor_mesh/src/v1/testactor.rs
+++ b/hyperactor_mesh/src/v1/testactor.rs
@@ -45,7 +45,7 @@ use serde::Serialize;
 use typeuri::Named;
 
 use crate::comm::multicast::CastInfo;
-use crate::supervision::SupervisionFailureMessage;
+use crate::supervision::MeshFailure;
 use crate::v1::ActorMesh;
 #[cfg(test)]
 use crate::v1::ActorMeshRef;
@@ -303,7 +303,7 @@ impl Handler<GetConfigAttrs> for TestActor {
 /// Replies with None if no supervision event is encountered within a timeout
 /// (10 seconds).
 #[derive(Clone, Debug, Serialize, Deserialize, Named, Bind, Unbind)]
-pub struct NextSupervisionFailure(pub PortRef<Option<SupervisionFailureMessage>>);
+pub struct NextSupervisionFailure(pub PortRef<Option<MeshFailure>>);
 
 /// A small wrapper to handle supervision messages so they don't
 /// need to reach the client. This just wraps and forwards all messages to TestActor.
@@ -313,7 +313,7 @@ pub struct NextSupervisionFailure(pub PortRef<Option<SupervisionFailureMessage>>
     spawn = true,
     handlers = [
         CauseSupervisionEvent { cast = true },
-        SupervisionFailureMessage { cast = true },
+        MeshFailure { cast = true },
         NextSupervisionFailure { cast = true },
     ]
 )]
@@ -321,13 +321,13 @@ pub struct WrapperActor {
     proc_mesh: ProcMeshRef,
     // Needs to be a mesh so we own this actor and have a controller for it.
     mesh: Option<ActorMesh<TestActor>>,
-    supervisor: PortRef<SupervisionFailureMessage>,
+    supervisor: PortRef<MeshFailure>,
     test_name: Name,
 }
 
 #[async_trait]
 impl hyperactor::RemoteSpawn for WrapperActor {
-    type Params = (ProcMeshRef, PortRef<SupervisionFailureMessage>, Name);
+    type Params = (ProcMeshRef, PortRef<MeshFailure>, Name);
 
     async fn new(
         (proc_mesh, supervisor, test_name): Self::Params,
@@ -406,14 +406,10 @@ impl Handler<NextSupervisionFailure> for WrapperActor {
 }
 
 #[async_trait]
-impl Handler<SupervisionFailureMessage> for WrapperActor {
-    async fn handle(
-        &mut self,
-        cx: &Context<Self>,
-        msg: SupervisionFailureMessage,
-    ) -> Result<(), anyhow::Error> {
+impl Handler<MeshFailure> for WrapperActor {
+    async fn handle(&mut self, cx: &Context<Self>, msg: MeshFailure) -> Result<(), anyhow::Error> {
         // All supervision events are considered handled so they don't bubble up
-        // to the client (who isn't listening for SupervisionFailureMessage).
+        // to the client (who isn't listening for MeshFailure).
         tracing::info!("got supervision event from child: {}", msg);
         // Send to a port so the client can view the messages.
         // Ignore the error if there is one.

--- a/hyperactor_mesh/src/v1/testing.rs
+++ b/hyperactor_mesh/src/v1/testing.rs
@@ -42,7 +42,7 @@ use crate::alloc::Allocator;
 use crate::alloc::LocalAllocator;
 use crate::alloc::ProcessAllocator;
 use crate::proc_mesh::default_transport;
-use crate::supervision::SupervisionFailureMessage;
+use crate::supervision::MeshFailure;
 use crate::v1::ProcMesh;
 use crate::v1::host_mesh::HostMesh;
 
@@ -56,12 +56,8 @@ pub struct TestRootClient {
 impl Actor for TestRootClient {}
 
 #[async_trait]
-impl Handler<SupervisionFailureMessage> for TestRootClient {
-    async fn handle(
-        &mut self,
-        _cx: &Context<Self>,
-        msg: SupervisionFailureMessage,
-    ) -> Result<(), anyhow::Error> {
+impl Handler<MeshFailure> for TestRootClient {
+    async fn handle(&mut self, _cx: &Context<Self>, msg: MeshFailure) -> Result<(), anyhow::Error> {
         // If a supervision failure reaches the root test client, the test has
         // failed.
         tracing::error!("got supervision event from child: {}", msg);
@@ -146,7 +142,7 @@ pub fn instance() -> &'static Instance<TestRootClient> {
 #[cfg(fbcode_build)]
 pub async fn proc_meshes<C: context::Actor>(cx: &C, extent: Extent) -> Vec<ProcMesh>
 where
-    C::A: Handler<SupervisionFailureMessage>,
+    C::A: Handler<MeshFailure>,
 {
     let mut meshes = Vec::new();
 

--- a/hyperactor_mesh/test/hyperactor_mesh_proxy_test.rs
+++ b/hyperactor_mesh/test/hyperactor_mesh_proxy_test.rs
@@ -28,7 +28,7 @@ use hyperactor_mesh::alloc::AllocSpec;
 use hyperactor_mesh::alloc::Allocator;
 use hyperactor_mesh::alloc::ProcessAllocator;
 use hyperactor_mesh::proc_mesh::global_root_client;
-use hyperactor_mesh::supervision::SupervisionFailureMessage;
+use hyperactor_mesh::supervision::MeshFailure;
 use ndslice::extent;
 use serde::Deserialize;
 use serde::Serialize;
@@ -161,11 +161,11 @@ impl Handler<Echo> for ProxyActor {
 }
 
 #[async_trait]
-impl Handler<SupervisionFailureMessage> for ProxyActor {
+impl Handler<MeshFailure> for ProxyActor {
     async fn handle(
         &mut self,
         cx: &Context<Self>,
-        message: SupervisionFailureMessage,
+        message: MeshFailure,
     ) -> Result<(), anyhow::Error> {
         message.default_handler(cx)
     }

--- a/monarch_extension/src/mesh_controller.rs
+++ b/monarch_extension/src/mesh_controller.rs
@@ -43,7 +43,7 @@ use hyperactor_mesh::actor_mesh::RootActorMesh;
 use hyperactor_mesh::selection::Selection;
 use hyperactor_mesh::shared_cell::SharedCell;
 use hyperactor_mesh::shared_cell::SharedCellRef;
-use hyperactor_mesh::supervision::SupervisionFailureMessage;
+use hyperactor_mesh::supervision::MeshFailure;
 use hyperactor_mesh_macros::sel;
 use monarch_hyperactor::actor::PythonMessage;
 use monarch_hyperactor::actor::PythonMessageKind;
@@ -935,12 +935,8 @@ impl Handler<ClientToControllerMessage> for MeshControllerActor {
 }
 
 #[async_trait]
-impl Handler<SupervisionFailureMessage> for MeshControllerActor {
-    async fn handle(
-        &mut self,
-        this: &Context<Self>,
-        message: SupervisionFailureMessage,
-    ) -> anyhow::Result<()> {
+impl Handler<MeshFailure> for MeshControllerActor {
+    async fn handle(&mut self, this: &Context<Self>, message: MeshFailure) -> anyhow::Result<()> {
         // If an actor spawned by this one fails, we can't handle it. We fail
         // ourselves with a chained error and bubble up to the next owner.
         let err = ActorErrorKind::UnhandledSupervisionEvent(Box::new(ActorSupervisionEvent::new(

--- a/monarch_hyperactor/src/proc_mesh.rs
+++ b/monarch_hyperactor/src/proc_mesh.rs
@@ -28,7 +28,7 @@ use hyperactor_mesh::proc_mesh::global_root_client;
 use hyperactor_mesh::shared_cell::SharedCell;
 use hyperactor_mesh::shared_cell::SharedCellPool;
 use hyperactor_mesh::shared_cell::SharedCellRef;
-use hyperactor_mesh::supervision::SupervisionFailureMessage;
+use hyperactor_mesh::supervision::MeshFailure;
 use monarch_types::PickledPyObject;
 use ndslice::Shape;
 use pyo3::IntoPyObjectExt;
@@ -95,7 +95,7 @@ impl TrackedProcMesh {
         params: &A::Params,
     ) -> Result<SharedCell<RootActorMesh<'static, A>>, anyhow::Error>
     where
-        C::A: Handler<SupervisionFailureMessage>,
+        C::A: Handler<MeshFailure>,
     {
         let mesh = self.cell.borrow()?;
         let actor = mesh.spawn(cx, actor_name, params).await?;


### PR DESCRIPTION
Summary:
SupervisionFailureMessage is not a great name. It was originally meant to be a small struct
used only by PythonActor, but it has since morphed and taken on a larger meaning as
ActorMeshController adopted it.

The new name, `MeshFailure`, expresses this new meaning, generalizes it to
work for ProcMesh, HostMesh, and ActorMesh, and also has a better parallel with the
pre-existing python MeshFailure object.

Differential Revision: D89392944
