### PR TITLE
[monarch] add a shared CLAUDE.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,7 +23,7 @@ Cargo.lock
 # mdbook output
 books/hyperactor-book/book/**
 
-CLAUDE.md
+# CLAUDE.md
 
 # macOS files
 */.DS_Store


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #2233

This was created by /init in claude; I added the first section.

We should update this aggressively as we discover new and better ways to direct Claude in Monarch.

Differential Revision: [D90138019](https://our.internmc.facebook.com/intern/diff/D90138019/)