### PR TITLE
Re-enable test_actor_error.py on Github CI

### DIFF
--- a/.github/workflows/test-gpu-python.yml
+++ b/.github/workflows/test-gpu-python.yml
@@ -60,8 +60,7 @@ jobs:
         # Each group runs separately with process cleanup in between
         pip install pytest-split
 
-        # Run tests with test_actor_error disabled
-        run_test_groups 0
+        run_test_groups
 
         # TODO(meriksen): temporarily disabled to unblock lands while debugging
         # mock CUDA issues on the OSS setup

--- a/python/tests/test_actor_error.py
+++ b/python/tests/test_actor_error.py
@@ -340,6 +340,7 @@ def test_proc_mesh_bootstrap_error():
     )
 
 
+@pytest.mark.oss_skip
 @pytest.mark.parametrize("raise_on_getstate", [True, False])
 @pytest.mark.parametrize("raise_on_setstate", [True, False])
 @pytest.mark.parametrize("num_procs", [1, 2])

--- a/python/tests/test_allocator.py
+++ b/python/tests/test_allocator.py
@@ -541,6 +541,7 @@ class TestRemoteAllocator(unittest.IsolatedAsyncioTestCase):
             # now we doing casting without accessing the wrapped type.
             del actor
 
+    @pytest.mark.oss_skip  # pyre-ignore[56]: Pyre cannot infer the type of this pytest marker
     async def test_remote_allocator_with_no_connection(self) -> None:
         spec = AllocSpec(AllocConstraints(), host=1, gpu=4)
 

--- a/scripts/common-setup.sh
+++ b/scripts/common-setup.sh
@@ -155,24 +155,13 @@ setup_test_environment() {
 }
 
 # Run Python test groups for Monarch.
-# Usage: run_test_groups <enable_actor_error_test: 0|1>
-#
-# Arguments:
-#   enable_actor_error_test:
-#       0 → skip python/tests/test_actor_error.py
-#       1 → include python/tests/test_actor_error.py
+# Usage: run_test_groups
 #
 # Tests are executed in 10 sequential groups with process cleanup
 # between runs.
 run_test_groups() {
   set +e
   local test_results_dir="${RUNNER_TEST_RESULTS_DIR:-test-results}"
-  local enable_actor_error_test="${2:-0}"
-  # Validate argument enable_actor_error_test
-  if [[ "$enable_actor_error_test" != "0" && "$enable_actor_error_test" != "1" ]]; then
-    echo "Usage: run_test_groups <enable_actor_error_test: 0|1>"
-    return 2
-  fi
   # Make sure the runtime linker uses the conda env's libstdc++
   # (which was used to compile monarch) instead of the system's.
   # TODO: Revisit this to determine if this is the proper/most
@@ -190,22 +179,12 @@ run_test_groups() {
     pkill -9 python || true
     pkill -9 pytest || true
     sleep 2
-    if [[ "$enable_actor_error_test" == "1" ]]; then
-        LC_ALL=C pytest python/tests/ -s -v -m "not oss_skip" \
-            --ignore-glob="**/meta/**" \
-            --dist=no \
-            --group="$GROUP" \
-            --junit-xml="$test_results_dir/test-results-$GROUP.xml" \
-            --splits=10
-    else
-        LC_ALL=C pytest python/tests/ -s -v -m "not oss_skip" \
-            --ignore-glob="**/meta/**" \
-            --dist=no \
-            --ignore=python/tests/test_actor_error.py \
-            --group="$GROUP" \
-            --junit-xml="$test_results_dir/test-results-$GROUP.xml" \
-            --splits=10
-    fi
+    LC_ALL=C pytest python/tests/ -s -v -m "not oss_skip" \
+        --ignore-glob="**/meta/**" \
+        --dist=no \
+        --group="$GROUP" \
+        --junit-xml="$test_results_dir/test-results-$GROUP.xml" \
+        --splits=10
     TEST_EXIT_CODE=$?
     # Check result and record failures
     if [[ $TEST_EXIT_CODE -eq 0 ]]; then


### PR DESCRIPTION
Summary:
test_actor_error.py was disabled on github a while ago, but we have since improved its
reliability and can re-enable it.

Differential Revision: D90213507


