### PR TITLE
Requre hyperactor defaults to be passed through host_mesh_conda explicitly

### DIFF
--- a/python/monarch/_src/job/meta.py
+++ b/python/monarch/_src/job/meta.py
@@ -201,7 +201,12 @@ class MASTJob(JobTrait):
             ],
             additional_packages=packages,
             timeout_sec=self._spec.timeout_sec,
-            env=self._spec.env,
+            env={
+                **hyperactor.DEFAULT_NVRT_ENVS,
+                **hyperactor.DEFAULT_NCCL_ENVS,
+                **hyperactor.DEFAULT_TORCH_ENVS,
+                **self._spec.env,
+            },
         )
         with ExitStack() as stack:
             workspace = Workspace(self._spec.workspace)


### PR DESCRIPTION
Summary:
`host_mesh_conda` currently silently modify a number of env vars:

https://www.internalfb.com/code/fbsource/[7b2f13387b6fa1ef941152b4ff5cf0a4521d67d6]/fbcode/monarch/python/monarch/tools/components/meta/hyperactor.py?lines=150%2C188-194

This is surprising to the end users who are expecting default values from those libraries.

This diff remove this behavior. Furthermore, all existing call sites are updated to pass these variables explicitly. In this way no regression would happen.

Differential Revision: D90210273


