### PR TITLE
Remove unused lightning v0 flags

### DIFF
--- a/docs/source/api/monarch.config.rst
+++ b/docs/source/api/monarch.config.rst
@@ -438,33 +438,6 @@ Remote Allocation
     - **Default**: ``"5m"``
     - **Environment**: ``HYPERACTOR_REMOTE_ALLOCATOR_HEARTBEAT_INTERVAL``
 
-``remote_alloc_bind_to_inaddr_any``
-    Bind remote allocators to INADDR_ANY (0.0.0.0).
-
-    - **Type**: ``bool``
-    - **Default**: ``False``
-    - **Environment**: ``HYPERACTOR_REMOTE_ALLOC_BIND_TO_INADDR_ANY``
-
-``remote_alloc_bootstrap_addr``
-    Bootstrap address for remote allocators.
-
-    - **Type**: ``str``
-    - **Default**: None (no default)
-    - **Environment**: ``HYPERACTOR_REMOTE_ALLOC_BOOTSTRAP_ADDR``
-
-    Example: ``"tcp://127.0.0.1:9000"``
-
-``remote_alloc_allowed_port_range``
-    Allowed port range for remote allocators.
-
-    - **Type**: ``slice``
-    - **Default**: None (no default)
-    - **Environment**: ``HYPERACTOR_REMOTE_ALLOC_ALLOWED_PORT_RANGE`` (accepts ``"8000..9000"``)
-
-    Specify as a Python slice: ``slice(8000, 9000)`` (stop is exclusive, so
-    this allows ports 8000-8999). Empty ranges are allowed (e.g.,
-    ``slice(8000, 8000)``); backwards ranges are rejected.
-
 
 Validation and Error Handling
 -----------------------------

--- a/hyperactor_mesh/src/alloc/remoteprocess.rs
+++ b/hyperactor_mesh/src/alloc/remoteprocess.rs
@@ -66,10 +66,8 @@ use crate::alloc::AllocatorError;
 use crate::alloc::ProcState;
 use crate::alloc::ProcStopReason;
 use crate::alloc::ProcessAllocator;
-use crate::alloc::REMOTE_ALLOC_BOOTSTRAP_ADDR;
 use crate::alloc::process::CLIENT_TRACE_ID_LABEL;
 use crate::alloc::process::ClientContext;
-use crate::alloc::serve_with_config;
 use crate::alloc::with_unspecified_port_or_any;
 use crate::shortuuid::ShortUuid;
 
@@ -325,7 +323,7 @@ impl RemoteProcessAllocator {
     ) {
         tracing::info!("handle allocation request, bootstrap_addr: {bootstrap_addr}");
         // start proc message forwarder
-        let (forwarder_addr, forwarder_rx) = match serve_with_config(forwarder_addr) {
+        let (forwarder_addr, forwarder_rx) = match channel::serve(forwarder_addr) {
             Ok(v) => v,
             Err(e) => {
                 tracing::error!("failed to to bootstrap forwarder actor: {}", e);
@@ -629,13 +627,9 @@ impl RemoteProcessAlloc {
         remote_allocator_port: u16,
         initializer: impl RemoteProcessAllocInitializer + Send + Sync + 'static,
     ) -> Result<Self, anyhow::Error> {
-        let alloc_serve_addr =
-            match hyperactor_config::global::try_get_cloned(REMOTE_ALLOC_BOOTSTRAP_ADDR) {
-                Some(addr_str) => addr_str.parse()?,
-                None => ChannelAddr::any(spec.transport.clone()),
-            };
+        let alloc_serve_addr = ChannelAddr::any(spec.transport.clone());
 
-        let (bootstrap_addr, rx) = serve_with_config(alloc_serve_addr)?;
+        let (bootstrap_addr, rx) = channel::serve(alloc_serve_addr)?;
 
         tracing::info!(
             "starting alloc for {} on: {}",

--- a/hyperactor_mesh/src/proc_mesh.rs
+++ b/hyperactor_mesh/src/proc_mesh.rs
@@ -71,7 +71,6 @@ use crate::alloc::AllocatedProc;
 use crate::alloc::AllocatorError;
 use crate::alloc::ProcState;
 use crate::alloc::ProcStopReason;
-use crate::alloc::serve_with_config;
 use crate::assign::Ranks;
 use crate::comm::CommActorMode;
 use crate::proc_mesh::mesh_agent::GspawnResult;
@@ -420,8 +419,8 @@ impl ProcMesh {
         );
 
         // Ensure that the router is served so that agents may reach us.
-        let (router_channel_addr, router_rx) =
-            serve_with_config(alloc.client_router_addr()).map_err(AllocatorError::Other)?;
+        let (router_channel_addr, router_rx) = channel::serve(alloc.client_router_addr())
+            .map_err(|e| AllocatorError::Other(e.into()))?;
         router.serve(router_rx);
         tracing::info!("router channel started listening on addr: {router_channel_addr}");
 


### PR DESCRIPTION
Summary: These flags were added to support Lightning with MeshAPI V0. Now Lightning is using MeshAPI V1 + simple bootstrap. We do not need these flags anymore.

Differential Revision: D90206901
