### PR TITLE
Temporarily disable exporting KubernetesJob

### DIFF
--- a/examples/kubernetes/hello_kubernetes_job.py
+++ b/examples/kubernetes/hello_kubernetes_job.py
@@ -6,8 +6,8 @@
 
 import socket
 
+from monarch._src.job.kubernetes import KubernetesJob
 from monarch.actor import Actor, endpoint
-from monarch.job import KubernetesJob
 
 
 class SimpleActor(Actor):

--- a/python/monarch/job/__init__.py
+++ b/python/monarch/job/__init__.py
@@ -6,7 +6,9 @@
 
 # Re-export the job module directly
 from monarch._src.job.job import job_load, job_loads, JobState, JobTrait, LocalJob
-from monarch._src.job.kubernetes import KubernetesJob
+
+# TODO: Re-enable once we have kubernetes dependencies sorted it out
+# from monarch._src.job.kubernetes import KubernetesJob
 from monarch._src.job.slurm import SlurmJob
 
 # Define exports
@@ -17,5 +19,5 @@ __all__ = [
     "JobState",
     "LocalJob",
     "SlurmJob",
-    "KubernetesJob",
+    # "KubernetesJob",
 ]


### PR DESCRIPTION
Summary: Don't re-export until we sort out dependencies.

Reviewed By: colin2328

Differential Revision: D90270412


