### PR TITLE
: host: typestate-ish refactor for ready procs

### DIFF
--- a/hyperactor_mesh/src/v1/host_mesh.rs
+++ b/hyperactor_mesh/src/v1/host_mesh.rs
@@ -1582,7 +1582,7 @@ mod tests {
         assert_matches!(
             err,
             v1::Error::ProcCreationError { state, .. }
-            if matches!(state.status, resource::Status::Failed(ref msg) if msg.contains("failed to configure process: Terminal(Stopped { exit_code: 1"))
+            if matches!(state.status, resource::Status::Failed(ref msg) if msg.contains("failed to configure process: Ready(Terminal(Stopped { exit_code: 1"))
         );
     }
 


### PR DESCRIPTION
Summary: a "parse, don’t validate" refactor that moves validation to the boundary: `ready_proc` checks the invariant ("after ready, `addr` and `agent_ref` exist") once and returns a `ReadyProc` capability, enabling infallible accessors and eliminating scattered `Option` checks.

Differential Revision: D90271770


