### PR TITLE
Export KubernetesJob from separate module

### DIFF
--- a/examples/kubernetes/hello_kubernetes_job.py
+++ b/examples/kubernetes/hello_kubernetes_job.py
@@ -6,8 +6,8 @@
 
 import socket
 
-from monarch._src.job.kubernetes import KubernetesJob
 from monarch.actor import Actor, endpoint
+from monarch.job.kubernetes import KubernetesJob
 
 
 class SimpleActor(Actor):

--- a/python/monarch/job/__init__.py
+++ b/python/monarch/job/__init__.py
@@ -6,9 +6,6 @@
 
 # Re-export the job module directly
 from monarch._src.job.job import job_load, job_loads, JobState, JobTrait, LocalJob
-
-# TODO: Re-enable once we have kubernetes dependencies sorted it out
-# from monarch._src.job.kubernetes import KubernetesJob
 from monarch._src.job.slurm import SlurmJob
 
 # Define exports
@@ -19,5 +16,4 @@ __all__ = [
     "JobState",
     "LocalJob",
     "SlurmJob",
-    # "KubernetesJob",
 ]

--- a/python/monarch/job/kubernetes.py
+++ b/python/monarch/job/kubernetes.py
@@ -1,0 +1,9 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from monarch._src.job.kubernetes import KubernetesJob
+
+__all__ = ["KubernetesJob"]


### PR DESCRIPTION
Summary: We want to make kubernetes dependency as an extra optional dependency. Export it from separate module so that KubernetesJob is imported if `monarch.job.kubernetes` is imported.

Differential Revision: D90276504


