### PR TITLE
fix edition 2021 -> 2024

### DIFF
--- a/build_utils/Cargo.toml
+++ b/build_utils/Cargo.toml
@@ -4,7 +4,7 @@
 name = "build_utils"
 version = "0.0.0"
 authors = ["Meta"]
-edition = "2021"
+edition = "2024"
 license = "BSD-3-Clause"
 
 [lib]

--- a/erased_lifetime/Cargo.toml
+++ b/erased_lifetime/Cargo.toml
@@ -4,10 +4,7 @@
 name = "erased_lifetime"
 version = "0.0.0"
 authors = ["Facebook <opensource+crates-dyn_refcell@fb.com>"]
-edition = "2021"
+edition = "2024"
 description = "dynamic, lifetime-erased refcell"
 repository = "https://github.com/meta-pytorch/monarch/"
 license = "BSD-3-Clause"
-
-[lib]
-edition = "2024"

--- a/hyperactor/Cargo.toml
+++ b/hyperactor/Cargo.toml
@@ -4,33 +4,26 @@
 name = "hyperactor"
 version = "0.0.0"
 authors = ["Facebook <opensource+crates-hyperactor@fb.com>"]
-edition = "2021"
+edition = "2024"
 description = "a high-performance, scalable actor framework for cluster computing"
 repository = "https://github.com/meta-pytorch/monarch/"
 license = "BSD-3-Clause"
 
-[lib]
-edition = "2024"
-
 [[bin]]
 name = "hyperactor_example_channel"
 path = "example/channel.rs"
-edition = "2024"
 
 [[bin]]
 name = "hyperactor_example_derive"
 path = "example/derive.rs"
-edition = "2024"
 
 [[bin]]
 name = "hyperactor_example_stream"
 path = "example/stream.rs"
-edition = "2024"
 
 [[bin]]
 name = "hyperactor_host_test_bootstrap"
 path = "test/host_bootstrap.rs"
-edition = "2024"
 
 [[bench]]
 name = "channel_benchmarks"

--- a/hyperactor_config/Cargo.toml
+++ b/hyperactor_config/Cargo.toml
@@ -4,13 +4,10 @@
 name = "hyperactor_config"
 version = "0.0.0"
 authors = ["Facebook <opensource+crates-hyperactor@fb.com>"]
-edition = "2021"
+edition = "2024"
 description = "Core configuration and attribute infrastructure for Hyperactor"
 repository = "https://github.com/meta-pytorch/monarch/"
 license = "BSD-3-Clause"
-
-[lib]
-edition = "2024"
 
 [dependencies]
 anyhow = "1.0.98"

--- a/hyperactor_macros/Cargo.toml
+++ b/hyperactor_macros/Cargo.toml
@@ -4,7 +4,7 @@
 name = "hyperactor_macros"
 version = "0.0.0"
 authors = ["Facebook <opensource+crates-hyperactor-macros@fb.com>"]
-edition = "2021"
+edition = "2024"
 description = "macros to support the Hyperactor actors and data exchange"
 repository = "https://github.com/meta-pytorch/monarch/"
 license = "BSD-3-Clause"
@@ -13,7 +13,6 @@ license = "BSD-3-Clause"
 test = false
 doctest = false
 proc-macro = true
-edition = "2024"
 
 [[test]]
 name = "hyperactor_macros_test"

--- a/hyperactor_mesh/Cargo.toml
+++ b/hyperactor_mesh/Cargo.toml
@@ -4,36 +4,28 @@
 name = "hyperactor_mesh"
 version = "0.0.0"
 authors = ["Meta"]
-edition = "2021"
-license = "BSD-3-Clause"
-
-[lib]
 edition = "2024"
+license = "BSD-3-Clause"
 
 [[bin]]
 name = "hyperactor_mesh_test_bootstrap"
 path = "test/bootstrap.rs"
-edition = "2024"
 
 [[bin]]
 name = "hyperactor_mesh_test_remote_process_alloc"
 path = "test/remote_process_alloc.rs"
-edition = "2024"
 
 [[bin]]
 name = "hyperactor_mesh_test_remote_process_allocator"
 path = "test/remote_process_allocator.rs"
-edition = "2024"
 
 [[bin]]
 name = "process_allocator_test_bin"
 path = "test/process_allocator_cleanup/process_allocator_test_bin.rs"
-edition = "2024"
 
 [[bin]]
 name = "process_allocator_test_bootstrap"
 path = "test/process_allocator_cleanup/process_allocator_test_bootstrap.rs"
-edition = "2024"
 
 [[test]]
 name = "process_allocator_cleanup"

--- a/hyperactor_mesh_macros/Cargo.toml
+++ b/hyperactor_mesh_macros/Cargo.toml
@@ -4,14 +4,13 @@
 name = "hyperactor_mesh_macros"
 version = "0.0.0"
 authors = ["Meta"]
-edition = "2021"
+edition = "2024"
 license = "BSD-3-Clause"
 
 [lib]
 test = false
 doctest = false
 proc-macro = true
-edition = "2024"
 
 [dependencies]
 ndslice = { version = "0.0.0", path = "../ndslice" }

--- a/hyperactor_telemetry/Cargo.toml
+++ b/hyperactor_telemetry/Cargo.toml
@@ -4,19 +4,8 @@
 name = "hyperactor_telemetry"
 version = "0.0.0"
 authors = ["Meta"]
-edition = "2021"
+edition = "2024"
 license = "BSD-3-Clause"
-
-[lib]
-edition = "2024"
-
-[[bench]]
-name = "correctness_test"
-edition = "2024"
-
-[[bench]]
-name = "telemetry_benchmark"
-edition = "2024"
 
 [dependencies]
 anyhow = "1.0.98"

--- a/hyperactor_telemetry/tester/Cargo.toml
+++ b/hyperactor_telemetry/tester/Cargo.toml
@@ -4,13 +4,12 @@
 name = "tester"
 version = "0.0.0"
 authors = ["Meta"]
-edition = "2021"
+edition = "2024"
 license = "BSD-3-Clause"
 
 [[bin]]
 name = "tester"
 path = "main.rs"
-edition = "2024"
 
 [dependencies]
 hyperactor_telemetry = { version = "0.0.0", path = ".." }

--- a/monarch_bench/Cargo.toml
+++ b/monarch_bench/Cargo.toml
@@ -4,7 +4,7 @@
 name = "monarch_monarch_bench"
 version = "0.0.0"
 authors = ["Meta"]
-edition = "2021"
+edition = "2024"
 license = "BSD-3-Clause"
 
 [dev-dependencies]

--- a/monarch_conda/Cargo.toml
+++ b/monarch_conda/Cargo.toml
@@ -4,16 +4,12 @@
 name = "monarch_conda"
 version = "0.0.0"
 authors = ["Meta"]
-edition = "2021"
-license = "BSD-3-Clause"
-
-[lib]
 edition = "2024"
+license = "BSD-3-Clause"
 
 [[bin]]
 name = "conda_sync_cli"
 path = "src/main.rs"
-edition = "2024"
 
 [dependencies]
 aho-corasick = "1.1.4"

--- a/monarch_cpp_static_libs/Cargo.toml
+++ b/monarch_cpp_static_libs/Cargo.toml
@@ -4,7 +4,7 @@
 name = "monarch_cpp_static_libs"
 version = "0.0.0"
 authors = ["Meta"]
-edition = "2021"
+edition = "2024"
 license = "BSD-3-Clause"
 build = "build.rs"
 links = "monarch_cpp_static_libs"

--- a/monarch_extension/Cargo.toml
+++ b/monarch_extension/Cargo.toml
@@ -4,7 +4,7 @@
 name = "monarch_extension"
 version = "0.0.0"
 authors = ["Meta"]
-edition = "2021"
+edition = "2024"
 license = "BSD-3-Clause"
 
 [lib]

--- a/monarch_hyperactor/Cargo.toml
+++ b/monarch_hyperactor/Cargo.toml
@@ -4,17 +4,12 @@
 name = "monarch_hyperactor"
 version = "0.0.0"
 authors = ["Meta"]
-edition = "2021"
+edition = "2024"
 license = "BSD-3-Clause"
 
 [[bin]]
 name = "monarch_hyperactor_test_bootstrap"
 path = "test/bootstrap.rs"
-edition = "2024"
-
-[[bin]]
-name = "process_allocator"
-edition = "2024"
 
 [[test]]
 name = "test_monarch_hyperactor"

--- a/monarch_messages/Cargo.toml
+++ b/monarch_messages/Cargo.toml
@@ -4,7 +4,7 @@
 name = "monarch_messages"
 version = "0.0.0"
 authors = ["Meta"]
-edition = "2021"
+edition = "2024"
 license = "BSD-3-Clause"
 
 [dependencies]

--- a/monarch_perfetto_trace/Cargo.toml
+++ b/monarch_perfetto_trace/Cargo.toml
@@ -4,11 +4,8 @@
 name = "monarch_perfetto_trace"
 version = "0.0.0"
 authors = ["Meta"]
-edition = "2021"
-license = "BSD-3-Clause"
-
-[lib]
 edition = "2024"
+license = "BSD-3-Clause"
 
 [dependencies]
 serde = { version = "1.0.219", features = ["derive", "rc"] }

--- a/monarch_rdma/Cargo.toml
+++ b/monarch_rdma/Cargo.toml
@@ -4,11 +4,8 @@
 name = "monarch_rdma"
 version = "0.0.0"
 authors = ["Meta"]
-edition = "2021"
-license = "BSD-3-Clause"
-
-[lib]
 edition = "2024"
+license = "BSD-3-Clause"
 
 [dependencies]
 anyhow = "1.0.98"

--- a/monarch_rdma/examples/cuda_ping_pong/Cargo.toml
+++ b/monarch_rdma/examples/cuda_ping_pong/Cargo.toml
@@ -4,26 +4,23 @@
 name = "cuda_ping_pong"
 version = "0.0.0"
 authors = ["Meta"]
-edition = "2021"
+edition = "2024"
 license = "BSD-3-Clause"
 
 [lib]
 path = "src/cuda_ping_pong.rs"
 test = false
 doctest = false
-edition = "2024"
 
 [[bin]]
 name = "cuda_ping_pong_bootstrap"
 path = "bootstrap.rs"
 test = false
-edition = "2024"
 
 [[bin]]
 name = "cuda_ping_pong_example"
 path = "src/lib.rs"
 test = false
-edition = "2024"
 
 [dependencies]
 anyhow = "1.0.98"

--- a/monarch_rdma/examples/parameter_server/Cargo.toml
+++ b/monarch_rdma/examples/parameter_server/Cargo.toml
@@ -4,24 +4,21 @@
 name = "parameter_server"
 version = "0.0.0"
 authors = ["Meta"]
-edition = "2021"
+edition = "2024"
 license = "BSD-3-Clause"
 
 [lib]
 path = "src/parameter_server.rs"
-edition = "2024"
 
 [[bin]]
 name = "parameter_server_bootstrap"
 path = "bootstrap.rs"
 test = false
-edition = "2024"
 
 [[bin]]
 name = "parameter_server_example"
 path = "src/lib.rs"
 test = false
-edition = "2024"
 
 [dependencies]
 anyhow = "1.0.98"

--- a/monarch_rdma/extension/Cargo.toml
+++ b/monarch_rdma/extension/Cargo.toml
@@ -4,14 +4,13 @@
 name = "monarch_rdma_extension"
 version = "0.0.0"
 authors = ["Meta"]
-edition = "2021"
+edition = "2024"
 license = "BSD-3-Clause"
 
 [lib]
 path = "lib.rs"
 test = false
 doctest = false
-edition = "2024"
 
 [dependencies]
 hyperactor = { version = "0.0.0", path = "../../hyperactor" }

--- a/monarch_tensor_worker/Cargo.toml
+++ b/monarch_tensor_worker/Cargo.toml
@@ -4,7 +4,7 @@
 name = "monarch_tensor_worker"
 version = "0.0.0"
 authors = ["Meta"]
-edition = "2021"
+edition = "2024"
 license = "BSD-3-Clause"
 
 [dependencies]

--- a/monarch_types/Cargo.toml
+++ b/monarch_types/Cargo.toml
@@ -4,7 +4,7 @@
 name = "monarch_types"
 version = "0.0.0"
 authors = ["Meta"]
-edition = "2021"
+edition = "2024"
 license = "BSD-3-Clause"
 
 [dependencies]

--- a/ndslice/Cargo.toml
+++ b/ndslice/Cargo.toml
@@ -4,13 +4,10 @@
 name = "ndslice"
 version = "0.0.0"
 authors = ["Facebook <opensource+crates-ndslice@fb.com>"]
-edition = "2021"
+edition = "2024"
 description = "data structures to support n-d arrays of ranks"
 repository = "https://github.com/meta-pytorch/monarch/"
 license = "BSD-3-Clause"
-
-[lib]
-edition = "2024"
 
 [[bin]]
 name = "fuzz_reshape_selection"

--- a/preempt_rwlock/Cargo.toml
+++ b/preempt_rwlock/Cargo.toml
@@ -4,11 +4,8 @@
 name = "preempt_rwlock"
 version = "0.0.0"
 authors = ["Meta"]
-edition = "2021"
-license = "BSD-3-Clause"
-
-[lib]
 edition = "2024"
+license = "BSD-3-Clause"
 
 [dependencies]
 tokio = { version = "1.47.1", features = ["full", "test-util", "tracing"] }

--- a/serde_multipart/Cargo.toml
+++ b/serde_multipart/Cargo.toml
@@ -4,13 +4,10 @@
 name = "serde_multipart"
 version = "0.0.0"
 authors = ["Facebook <opensource+crates-serde_multipart@fb.com>"]
-edition = "2021"
+edition = "2024"
 description = "multipart encoding for serde"
 repository = "https://github.com/meta-pytorch/monarch/"
 license = "BSD-3-Clause"
-
-[lib]
-edition = "2024"
 
 [dependencies]
 bincode = "1.3.3"

--- a/struct_diff_patch/Cargo.toml
+++ b/struct_diff_patch/Cargo.toml
@@ -4,13 +4,10 @@
 name = "struct_diff_patch"
 version = "0.0.0"
 authors = ["Facebook <opensource+crates-struct_diff_patch@fb.com>"]
-edition = "2021"
+edition = "2024"
 description = "diff/patch for Rust structs"
 repository = "https://github.com/meta-pytorch/monarch/"
 license = "BSD-3-Clause"
-
-[lib]
-edition = "2024"
 
 [dependencies]
 paste = "1.0.14"

--- a/struct_diff_patch_macros/Cargo.toml
+++ b/struct_diff_patch_macros/Cargo.toml
@@ -4,7 +4,7 @@
 name = "struct_diff_patch_macros"
 version = "0.0.0"
 authors = ["Facebook <opensource+crates-struct_diff_patch_macros@fb.com>"]
-edition = "2021"
+edition = "2024"
 description = "derive macros for struct_diff_patch"
 repository = "https://github.com/meta-pytorch/monarch/"
 license = "BSD-3-Clause"
@@ -13,7 +13,6 @@ license = "BSD-3-Clause"
 test = false
 doctest = false
 proc-macro = true
-edition = "2024"
 
 [dependencies]
 proc-macro2 = { version = "1.0.70", features = ["span-locations"] }

--- a/timed_test/Cargo.toml
+++ b/timed_test/Cargo.toml
@@ -4,14 +4,13 @@
 name = "timed_test"
 version = "0.0.0"
 authors = ["Meta"]
-edition = "2021"
+edition = "2024"
 license = "BSD-3-Clause"
 
 [lib]
 test = false
 doctest = false
 proc-macro = true
-edition = "2024"
 
 [[test]]
 name = "timed_test_test"

--- a/torch-sys-cuda/Cargo.toml
+++ b/torch-sys-cuda/Cargo.toml
@@ -4,7 +4,7 @@
 name = "torch-sys-cuda"
 version = "0.0.0"
 authors = ["Meta"]
-edition = "2021"
+edition = "2024"
 license = "BSD-3-Clause"
 links = "torch_cuda"
 

--- a/torch-sys2/Cargo.toml
+++ b/torch-sys2/Cargo.toml
@@ -4,7 +4,7 @@
 name = "torch-sys2"
 version = "0.0.0"
 authors = ["Meta"]
-edition = "2021"
+edition = "2024"
 license = "BSD-3-Clause"
 
 [dependencies]

--- a/typeuri/Cargo.toml
+++ b/typeuri/Cargo.toml
@@ -4,13 +4,10 @@
 name = "typeuri"
 version = "0.0.0"
 authors = ["Facebook <opensource+crates-typeuri@fb.com>"]
-edition = "2021"
+edition = "2024"
 description = "Named trait for types with globally unique type URIs"
 repository = "https://github.com/meta-pytorch/monarch/"
 license = "BSD-3-Clause"
-
-[lib]
-edition = "2024"
 
 [dependencies]
 bytes = { version = "1.10", features = ["serde"] }

--- a/typeuri_macros/Cargo.toml
+++ b/typeuri_macros/Cargo.toml
@@ -4,7 +4,7 @@
 name = "typeuri_macros"
 version = "0.0.0"
 authors = ["Facebook <opensource+crates-typeuri-macros@fb.com>"]
-edition = "2021"
+edition = "2024"
 description = "Derive macros for typeuri Named trait"
 repository = "https://github.com/meta-pytorch/monarch/"
 license = "BSD-3-Clause"
@@ -13,7 +13,6 @@ license = "BSD-3-Clause"
 test = false
 doctest = false
 proc-macro = true
-edition = "2024"
 
 [dependencies]
 quote = "1.0.29"


### PR DESCRIPTION
Summary: this change makes the Cargo manifests generated by cargo_from_buck consistent with our Buck compilation settings by switching the monarch.toml default package.edition from 2021 → 2024 and regenerating public_autocargo accordingly. It also fixes a typo in the OSS git URL (https://https://… → https://…). as part of regeneration, autocargo normalizes the manifests to rely on package.edition = 2024 and drops redundant per-target edition = "2024" stanzas from [lib], [[bin]], and benches, avoiding mixed or duplicate edition declarations.

Differential Revision: D90284469
