### PR TITLE
Temporary change to readme for publishing

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -47,7 +47,7 @@ jobs:
         cargo install --path monarch_hyperactor
 
         # Build wheel
-        export MONARCH_VERSION=0.3.0.dev$(date +'%Y%m%d')
+        export MONARCH_VERSION=$(date +'%Y.%m.%d')
         export MONARCH_BUILD_MESH_ONLY=0
 
         python setup.py bdist_wheel
@@ -60,11 +60,20 @@ jobs:
         install_python_test_dependencies
         pip install dist/*.whl
         python -c "import monarch"
+  upload:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          # Name of the artifact to upload (optional, default is 'artifact')
+          name: wheels
+          # A file, directory or wildcard pattern to upload (required)
+          path: dist
   publish:
     name: Publish to PyPI
     needs: build
     runs-on: ubuntu-latest
-    environment: nightly
     if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
     permissions:
       id-token: write  # Required for PyPI trusted publishing

--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
+# Deprecation Notice
+
+The torchmonarch-nightly package is deprecated. Please use [torchmonarch](https://pypi.org/project/torchmonarch)
+instead.
+Nightly builds will be published there, and can be installed with `pip install --pre torchmonarch`.
+The version format is <major>.<minor>.<patch>.dev<date>
+
 # Monarch 🦋
 
 **Monarch** is a distributed programming framework for PyTorch based on scalable

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ requires = ["setuptools>=64", "setuptools-rust", "wheel", "numpy", "torch"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "torchmonarch"
+name = "torchmonarch-nightly"
 dynamic = ["version"]  # overridden via MONARCH_VERSION env var
 description = "Monarch: Single controller library"
 readme = "README.md"


### PR DESCRIPTION
Summary: Not to land, just to generate a PyPI release for torchmonarch-nightly.

Differential Revision: D90356126


