### PR TITLE
: python/tests/_monarch: test_logging: fix race due to missing mock

### DIFF
--- a/python/tests/_monarch/test_logging.py
+++ b/python/tests/_monarch/test_logging.py
@@ -86,8 +86,13 @@ class LoggingManagerTest(TestCase):
         mock_future_instance.get.assert_called_once_with(timeout=3)
 
     @patch("monarch._src.actor.logging.Future")
-    def test_flush_handles_exception_gracefully(self, mock_future: Mock) -> None:
-        # Setup: mock client and Future that raises exception
+    @patch("monarch._src.actor.logging.context")
+    def test_flush_handles_exception_gracefully(
+        self, mock_context: Mock, mock_future: Mock
+    ) -> None:
+        # Setup: mock context, client, and Future that raises exception
+        mock_instance = Mock()
+        mock_context.return_value.actor_instance._as_rust.return_value = mock_instance
         mock_client = Mock()
         self.logging_manager._logging_mesh_client = mock_client
 


### PR DESCRIPTION
Summary:
## this diff is expected to fix this [monarch/release conveyor failure](https://www.internalfb.com/conveyor/monarch/release/releases/947.1/nodes/Contbuild%20Tracking%20Node%20(monarch)/runs/1586211755903199), (see the failed tests [here](https://www.internalfb.com/ci/results/slp/4169838749937080?tag=conveyor_artifact%3A%3A%2F%2Fmonarch%3Amonarch)).

the failure was caused by unintended initialization of global actor state in a single test.

`_client_context` in actor_mesh.py is a global, lazy-initialized singleton:
```
_client_context: _Lazy[Context] = _Lazy(_init_client_context)
```

in `test_flush_handles_exception_gracefully`, `context()` was previously called without being mocked. that caused:
1.	`_init_client_context()` to run
2.	`bootstrap_host()` to spawn real host/proc mesh actors
3.	those actors to spawn `tokio::spawn()` tasks holding python object references
4.	the `initialized _client_context` (and its running tokio tasks) to persist for the remainder of the test process

because this global state lived for the entire process lifetime, all subsequent tests were affected, even ones that correctly mocked `context()` or didn’t touch it at all. on process exit, the orphaned tokio tasks caused a SIGSEGV during python object teardown.

the failure only reproduces intermittently because the tokio runtime gets 1 second to shut down gracefully on process exit. whether the orphaned tokio tasks happen to be actively holding python object references at the moment they are forcibly terminated depends on thread scheduling and timing; most of the time they are idle or past the critical section (so the suite passes), but occasionally they are mid-execution and crash during python object teardown, resulting in the observed ~1/10 failure rate.

the added `patch("monarch._src.actor.logging.context")` prevents `context()` from ever `initializing _client_context` in this test, so no real actors or tokio tasks are created during the test suite.

the other failing tests were not independently broken - they were victims of this earlier global state pollution. fixing the single "infection source" test eliminates the issue for the entire suite.

this also explains why the failures were order-dependent: `LoggingManagerTest` runs before the other affected test classes, so the global state was already poisoned by the time they executed.

Differential Revision: D90389891


