### PR TITLE
release the GIL during blocking shutdown

### DIFF
--- a/monarch_hyperactor/src/runtime.rs
+++ b/monarch_hyperactor/src/runtime.rs
@@ -67,12 +67,14 @@ pub fn get_tokio_runtime<'l>() -> std::sync::MappedRwLockReadGuard<'l, tokio::ru
 }
 
 #[pyfunction]
-pub fn shutdown_tokio_runtime() {
-    // It is important to not hold the GIL while calling this function.
-    // Other runtime threads may be waiting to acquire it and we will never get to shutdown.
-    if let Some(x) = INSTANCE.write().unwrap().take() {
-        x.shutdown_timeout(Duration::from_secs(1));
-    }
+pub fn shutdown_tokio_runtime(py: Python<'_>) {
+    // Called from Python's atexit, which holds the GIL. Release it so tokio
+    // worker threads can acquire it to complete their Python work.
+    py.allow_threads(|| {
+        if let Some(x) = INSTANCE.write().unwrap().take() {
+            x.shutdown_timeout(Duration::from_secs(1));
+        }
+    });
 }
 
 /// Stores the native thread ID of the main Python thread.


### PR DESCRIPTION
Summary: ## this diff is expected to fix this [monarch/release conveyor failure](https://www.internalfb.com/conveyor/monarch/release/releases/948.1/diff_summary), (see the failed tests [here](https://www.internalfb.com/ci/results/slp/4169838749937080?tag=conveyor_artifact%3A%3A%2F%2Fmonarch%3Amonarch)).

Differential Revision: D90415003
