### PR TITLE
mailbox: typestate-ish refactor for bound ports

### DIFF
--- a/hyperactor/src/lib.rs
+++ b/hyperactor/src/lib.rs
@@ -145,6 +145,10 @@ pub use init::initialize;
 pub use init::initialize_with_current_runtime;
 #[doc(inline)]
 pub use init::initialize_with_log_prefix;
+#[doc(hidden)]
+pub use inventory; // For remote! macro
+pub use mailbox::BoundOncePort;
+pub use mailbox::BoundPort;
 pub use mailbox::Data;
 pub use mailbox::Mailbox;
 pub use mailbox::Message;

--- a/hyperactor/src/proc.rs
+++ b/hyperactor/src/proc.rs
@@ -3045,7 +3045,7 @@ mod tests {
 
         let (port, mut receiver) = instance.open_port();
         child_actor
-            .send(&instance, ("hello".to_string(), port.bind()))
+            .send(&instance, ("hello".to_string(), port.bind().into_port_ref()))
             .unwrap();
 
         let message = receiver.recv().await.unwrap();

--- a/hyperactor_macros/src/lib.rs
+++ b/hyperactor_macros/src/lib.rs
@@ -994,7 +994,7 @@ fn derive_client(input: TokenStream, is_handle: bool) -> TokenStream {
                             -> Result<#return_type, hyperactor::internal_macro_support::anyhow::Error> {
                             let (#reply_port_arg, #rx_mod reply_receiver) =
                                 #open_port::<#return_type>(cx);
-                            let #reply_port_arg = #reply_port_arg.bind();
+                            let #reply_port_arg = #reply_port_arg.bind().into_port_ref();
                             let message = #constructor;
                             #log_message;
                             #send_message;
@@ -1009,7 +1009,7 @@ fn derive_client(input: TokenStream, is_handle: bool) -> TokenStream {
                             -> Result<#return_type, hyperactor::internal_macro_support::anyhow::Error> {
                             let (#reply_port_arg, #rx_mod reply_receiver) =
                                 #open_port::<#return_type>(cx);
-                            let #reply_port_arg = #reply_port_arg.bind();
+                            let #reply_port_arg = #reply_port_arg.bind().into_port_ref();
                             let message = #constructor;
                             #log_message;
                             #send_message;

--- a/hyperactor_macros/tests/export.rs
+++ b/hyperactor_macros/tests/export.rs
@@ -106,7 +106,9 @@ mod tests {
         let proc = Proc::local();
         let (client, _) = proc.instance("client").unwrap();
         let (tx, mut rx) = client.open_port();
-        let actor_handle = proc.spawn("test", TestActor::new(tx.bind())).unwrap();
+        let actor_handle = proc
+            .spawn("test", TestActor::new(tx.bind().into_port_ref()))
+            .unwrap();
         //  This will call binds
         actor_handle.bind::<TestActor>();
         // Verify that the ports can be gotten successfully.
@@ -184,7 +186,9 @@ mod tests {
         let proc = Proc::local();
         let (client, _) = proc.instance("client").unwrap();
         let (tx, mut rx) = client.open_port();
-        let actor_handle = proc.spawn("test", TestActor::new(tx.bind())).unwrap();
+        let actor_handle = proc
+            .spawn("test", TestActor::new(tx.bind().into_port_ref()))
+            .unwrap();
 
         actor_handle.send(&client, 123u64).unwrap();
         actor_handle

--- a/hyperactor_mesh/benches/main.rs
+++ b/hyperactor_mesh/benches/main.rs
@@ -72,7 +72,7 @@ fn bench_actor_scaling(c: &mut Criterion) {
                             all(true_()),
                             BenchMessage {
                                 step: i as usize,
-                                reply: tx.bind(),
+                                reply: tx.bind().into_port_ref(),
                                 payload,
                             },
                         )
@@ -173,7 +173,7 @@ fn bench_actor_mesh_message_sizes(c: &mut Criterion) {
                                     all(true_()),
                                     BenchMessage {
                                         step: i as usize,
-                                        reply: tx.bind(),
+                                        reply: tx.bind().into_port_ref(),
                                         payload,
                                     },
                                 )

--- a/hyperactor_mesh/examples/dining_philosophers.rs
+++ b/hyperactor_mesh/examples/dining_philosophers.rs
@@ -258,7 +258,7 @@ async fn main() -> Result<ExitCode> {
     actor_mesh
         .cast(
             instance,
-            PhilosopherMessage::Start(dining_message_handle.bind()),
+            PhilosopherMessage::Start(dining_message_handle.bind().into_port_ref()),
         )
         .unwrap();
     let mut waiter = Waiter::new(actor_mesh.deref().clone());

--- a/hyperactor_mesh/examples/sieve.rs
+++ b/hyperactor_mesh/examples/sieve.rs
@@ -137,14 +137,14 @@ async fn main() -> Result<ExitCode> {
     let mut candidate = 3;
 
     let (prime_collector_tx, mut prime_collector_rx) = mesh.client().open_port();
-    let prime_collector_ref = prime_collector_tx.bind();
+    let prime_collector = prime_collector_tx.bind();
 
     while primes.len() < 100 {
         sieve_head.send(
             mesh.client(),
             NextNumber {
                 number: candidate,
-                prime_collector: prime_collector_ref.clone(),
+                prime_collector: prime_collector.port_ref().clone(),
             },
         )?;
         while let Ok(Some(prime)) = prime_collector_rx.try_recv() {

--- a/hyperactor_mesh/examples/test_bench.rs
+++ b/hyperactor_mesh/examples/test_bench.rs
@@ -87,7 +87,7 @@ async fn main() {
         let (port, mut rx) = instance.open_port();
         let begin = RealClock.now();
         actor_mesh
-            .cast(instance, TestMessage::Ping(port.bind()))
+            .cast(instance, TestMessage::Ping(port.bind().into_port_ref()))
             .unwrap();
         while received.len() < actor_mesh.extent().num_ranks() {
             received.insert(rx.recv().await.unwrap());

--- a/hyperactor_mesh/src/alloc.rs
+++ b/hyperactor_mesh/src/alloc.rs
@@ -755,9 +755,9 @@ pub(crate) mod testing {
                 cx,
                 rank,
                 router_channel_addr,
-                Some(supervison_port.bind()),
+                Some(supervison_port.bind().into_port_ref()),
                 HashMap::new(),
-                config_handle.bind(),
+                config_handle.bind().into_port_ref(),
                 false,
             )
             .await
@@ -777,7 +777,7 @@ pub(crate) mod testing {
                 actor_type,
                 "Stuck".to_string(),
                 bincode::serialize(params).unwrap(),
-                completed_handle.bind(),
+                completed_handle.bind().into_port_ref(),
             )
             .await
             .unwrap();

--- a/hyperactor_mesh/src/bootstrap.rs
+++ b/hyperactor_mesh/src/bootstrap.rs
@@ -3757,7 +3757,10 @@ mod tests {
         // the mesh.
         let (port, mut rx) = instance.mailbox().open_port();
         actor_mesh
-            .cast(&instance, testactor::GetActorId(port.bind()))
+            .cast(
+                &instance,
+                testactor::GetActorId(port.bind().into_port_ref()),
+            )
             .unwrap();
         let got_id = rx.recv().await.unwrap();
         assert_eq!(

--- a/hyperactor_mesh/src/connect.rs
+++ b/hyperactor_mesh/src/connect.rs
@@ -334,8 +334,8 @@ impl Connect {
         (
             Self {
                 id,
-                conn: conn_tx.bind(),
-                return_conn: return_tx.bind(),
+                conn: conn_tx.bind().into_port_ref(),
+                return_conn: return_tx.bind().into_port_ref(),
             },
             ConnectionCompleter {
                 caps,
@@ -383,7 +383,7 @@ pub async fn accept<C: context::Actor>(
         &caps,
         Accept {
             id: self_id,
-            conn: tx.bind(),
+            conn: tx.bind().into_port_ref(),
         },
     )?;
     Ok(ActorConnection {

--- a/hyperactor_mesh/src/proc_mesh.rs
+++ b/hyperactor_mesh/src/proc_mesh.rs
@@ -513,9 +513,9 @@ impl ProcMesh {
                     &client,
                     rank,
                     router_channel_addr.clone(),
-                    Some(supervision_port.bind()),
+                    Some(supervision_port.bind().into_port_ref()),
                     address_book.clone(),
-                    config_handle.bind(),
+                    config_handle.bind().into_port_ref(),
                     false,
                 )
                 .await?;
@@ -635,7 +635,7 @@ impl ProcMesh {
                     actor_type.clone(),
                     actor_name.to_string(),
                     bincode::serialize(params)?,
-                    completed_handle.bind(),
+                    completed_handle.bind().into_port_ref(),
                 )
                 .await?;
             n += 1;
@@ -1392,7 +1392,7 @@ mod tests {
                     instance,
                     sel!(*),
                     v1::testactor::GetCastInfo {
-                        cast_info: cast_info.bind(),
+                        cast_info: cast_info.bind().into_port_ref(),
                     },
                 )
                 .unwrap();

--- a/hyperactor_mesh/src/reference.rs
+++ b/hyperactor_mesh/src/reference.rs
@@ -385,7 +385,7 @@ mod tests {
             .cast(
                 ping_proc_mesh.client(),
                 sel!(?),
-                MeshPingPongMessage(10, pong_mesh_ref, done_tx.bind()),
+                MeshPingPongMessage(10, pong_mesh_ref, done_tx.bind().into_port_ref()),
             )
             .unwrap();
 

--- a/hyperactor_mesh/src/v1/testactor.rs
+++ b/hyperactor_mesh/src/v1/testactor.rs
@@ -446,7 +446,9 @@ pub async fn assert_casting_correctness(
     instance: &impl context::Actor,
 ) {
     let (port, mut rx) = mailbox::open_port(instance);
-    actor_mesh.cast(instance, GetActorId(port.bind())).unwrap();
+    actor_mesh
+        .cast(instance, GetActorId(port.bind().into_port_ref()))
+        .unwrap();
 
     let mut expected_actor_ids: HashSet<_> = actor_mesh
         .values()

--- a/hyperactor_mesh/test/hyperactor_mesh_proxy_test.rs
+++ b/hyperactor_mesh/test/hyperactor_mesh_proxy_test.rs
@@ -153,7 +153,7 @@ impl Handler<Echo> for ProxyActor {
         let actor = self.actor_mesh.as_ref().unwrap().get(0).unwrap();
 
         let (tx, mut rx) = cx.open_port();
-        actor.send(cx, Echo(message.0, tx.bind()))?;
+        actor.send(cx, Echo(message.0, tx.bind().into_port_ref()))?;
         message.1.send(cx, rx.recv().await.unwrap())?;
 
         Ok(())
@@ -195,7 +195,10 @@ async fn run_client(exe_path: PathBuf, keep_alive: bool) -> Result<(), anyhow::E
         .await?;
     let proxy_actor = actor_mesh.get(0).unwrap();
     let (tx, mut rx) = actor_mesh.open_port::<String>();
-    proxy_actor.send(proc_mesh.client(), Echo("hello!".to_owned(), tx.bind()))?;
+    proxy_actor.send(
+        proc_mesh.client(),
+        Echo("hello!".to_owned(), tx.bind().into_port_ref()),
+    )?;
 
     let msg = rx.recv().await?;
     println!("{}", msg);

--- a/monarch_extension/src/logging.rs
+++ b/monarch_extension/src/logging.rs
@@ -68,8 +68,8 @@ impl LoggingMeshClient {
             cx,
             LogClientMessage::StartSyncFlush {
                 expected_procs: forwarder_inner_mesh.proc_mesh().shape().slice().len(),
-                reply: reply_tx.bind(),
-                version: version_tx.bind(),
+                reply: reply_tx.bind().into_port_ref(),
+                version: version_tx.bind().into_port_ref(),
             },
         )?;
 

--- a/monarch_hyperactor/src/code_sync/conda_sync.rs
+++ b/monarch_hyperactor/src/code_sync/conda_sync.rs
@@ -149,8 +149,8 @@ where
                 instance,
                 sel!(*),
                 CondaSyncMessage {
-                    connect: conns_tx.bind(),
-                    result: result_tx.bind(),
+                    connect: conns_tx.bind().into_port_ref(),
+                    result: result_tx.bind().into_port_ref(),
                     workspace: remote_workspace,
                     path_prefix_replacements,
                 },

--- a/monarch_hyperactor/src/code_sync/rsync.rs
+++ b/monarch_hyperactor/src/code_sync/rsync.rs
@@ -421,8 +421,8 @@ where
                 instance,
                 sel!(*),
                 RsyncMessage {
-                    connect: rsync_conns_tx.bind(),
-                    result: result_tx.bind(),
+                    connect: rsync_conns_tx.bind().into_port_ref(),
+                    result: result_tx.bind().into_port_ref(),
                     workspace: remote_workspace,
                 },
             )?;

--- a/monarch_hyperactor/src/mailbox.rs
+++ b/monarch_hyperactor/src/mailbox.rs
@@ -258,7 +258,7 @@ impl PythonPortHandle {
 
     fn bind(&self) -> PythonPortRef {
         PythonPortRef {
-            inner: self.inner.bind(),
+            inner: self.inner.bind().into_port_ref(),
         }
     }
 }
@@ -427,7 +427,7 @@ impl PythonOncePortHandle {
             return Err(PyErr::new::<PyValueError, _>("OncePort is already used"));
         };
         Ok(PythonOncePortRef {
-            inner: Some(port.bind()),
+            inner: Some(port.bind().into_port_ref()),
         })
     }
 }

--- a/monarch_hyperactor/src/v1/logging.rs
+++ b/monarch_hyperactor/src/v1/logging.rs
@@ -148,8 +148,8 @@ impl LoggingMeshClient {
             cx,
             LogClientMessage::StartSyncFlush {
                 expected_procs: forwarder_mesh.region().num_ranks(),
-                reply: reply_tx.bind(),
-                version: version_tx.bind(),
+                reply: reply_tx.bind().into_port_ref(),
+                version: version_tx.bind().into_port_ref(),
             },
         )?;
 

--- a/monarch_hyperactor/tests/code_sync/auto_reload.rs
+++ b/monarch_hyperactor/tests/code_sync/auto_reload.rs
@@ -115,7 +115,7 @@ CONSTANT = "modified_constant"
     actor_ref.send(
         &mailbox,
         AutoReloadMessage {
-            result: result_tx.bind(),
+            result: result_tx.bind().into_port_ref(),
         },
     )?;
 

--- a/monarch_rdma/examples/cuda_ping_pong/src/cuda_ping_pong.rs
+++ b/monarch_rdma/examples/cuda_ping_pong/src/cuda_ping_pong.rs
@@ -780,7 +780,7 @@ pub async fn run() -> Result<(), anyhow::Error> {
     let (handle_1, receiver_1) = device_1_proc_mesh.client().open_once_port::<bool>();
     device_1_actor.send(
         device_1_proc_mesh.client(),
-        InitializeBuffer(DATA_VALUE, handle_1.bind()),
+        InitializeBuffer(DATA_VALUE, handle_1.bind().into_port_ref()),
     )?;
     receiver_1.recv().await?;
 
@@ -788,7 +788,7 @@ pub async fn run() -> Result<(), anyhow::Error> {
     let (handle_2, receiver_2) = device_2_proc_mesh.client().open_once_port::<bool>();
     device_2_actor.send(
         device_2_proc_mesh.client(),
-        InitializeBuffer(0, handle_2.bind()),
+        InitializeBuffer(0, handle_2.bind().into_port_ref()),
     )?;
     receiver_2.recv().await?;
 
@@ -797,7 +797,7 @@ pub async fn run() -> Result<(), anyhow::Error> {
         device_1_proc_mesh.client().open_once_port::<RdmaBuffer>();
     device_1_actor.send(
         device_1_proc_mesh.client(),
-        GetBufferHandle(handle_remote.bind()),
+        GetBufferHandle(handle_remote.bind().into_port_ref()),
     )?;
     let buffer_1 = receiver_remote.recv().await?;
 
@@ -805,7 +805,7 @@ pub async fn run() -> Result<(), anyhow::Error> {
         device_2_proc_mesh.client().open_once_port::<RdmaBuffer>();
     device_2_actor.send(
         device_2_proc_mesh.client(),
-        GetBufferHandle(handle_remote.bind()),
+        GetBufferHandle(handle_remote.bind().into_port_ref()),
     )?;
     let buffer_2 = receiver_remote.recv().await?;
 
@@ -820,7 +820,7 @@ pub async fn run() -> Result<(), anyhow::Error> {
             buffer_1,
             config.iterations,
             config.initial_length,
-            handle_2.bind(),
+            handle_2.bind().into_port_ref(),
         ),
     )?;
     receiver_2.recv().await?;
@@ -831,7 +831,7 @@ pub async fn run() -> Result<(), anyhow::Error> {
             buffer_2,
             config.iterations,
             config.initial_length,
-            handle_1.bind(),
+            handle_1.bind().into_port_ref(),
         ),
     )?;
     receiver_1.recv().await?;
@@ -839,14 +839,14 @@ pub async fn run() -> Result<(), anyhow::Error> {
     let (handle, receiver) = device_2_proc_mesh.client().open_once_port::<bool>();
     device_2_actor.send(
         device_2_proc_mesh.client(),
-        VerifyBuffer(expected_data_values.clone(), handle.bind()),
+        VerifyBuffer(expected_data_values.clone(), handle.bind().into_port_ref()),
     )?;
     let verification_result2 = receiver.recv().await?;
 
     let (handle, receiver) = device_1_proc_mesh.client().open_once_port::<bool>();
     device_1_actor.send(
         device_1_proc_mesh.client(),
-        VerifyBuffer(expected_data_values.clone(), handle.bind()),
+        VerifyBuffer(expected_data_values.clone(), handle.bind().into_port_ref()),
     )?;
     let verification_result1 = receiver.recv().await?;
 


### PR DESCRIPTION
Summary: small "parse, don’t validate" refactor that introduces bound-port witnesses (BoundPort, BoundOncePort) to explicitly represent the "port is bound" invariant, making binding a first-class concept instead of an implicit side effect.

Differential Revision: D90426083
