### PR TITLE
: shutdown panic resilience

### DIFF
--- a/monarch_extension/src/logging.rs
+++ b/monarch_extension/src/logging.rs
@@ -206,13 +206,18 @@ impl LoggingMeshClient {
 
 impl Drop for LoggingMeshClient {
     fn drop(&mut self) {
-        match self.client_actor.drain_and_stop() {
-            Ok(_) => {}
-            Err(e) => {
-                // it is ok as during shutdown, the channel might already be closed
-                tracing::debug!("error draining logging client actor during shutdown: {}", e);
+        // Use catch_unwind to guard against panics during interpreter shutdown.
+        // During Python teardown, the tokio runtime or channels may already be
+        // deallocated, and attempting to drain could cause a segfault.
+        let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            match self.client_actor.drain_and_stop() {
+                Ok(_) => {}
+                Err(e) => {
+                    // it is ok as during shutdown, the channel might already be closed
+                    tracing::debug!("error draining logging client actor during shutdown: {}", e);
+                }
             }
-        }
+        }));
     }
 }
 

--- a/monarch_hyperactor/src/actor_mesh.rs
+++ b/monarch_hyperactor/src/actor_mesh.rs
@@ -548,7 +548,10 @@ impl Drop for PythonActorMeshImpl {
                 "Dropping stopped PythonActorMesh. The underlying mesh is already stopped."
             );
         }
-        self.monitor.abort();
+        // Guard against panics during interpreter shutdown when tokio runtime may be gone
+        let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            self.monitor.abort();
+        }));
     }
 }
 

--- a/monarch_hyperactor/src/proc_mesh.rs
+++ b/monarch_hyperactor/src/proc_mesh.rs
@@ -450,7 +450,10 @@ struct KeepaliveState(tokio::task::JoinHandle<()>);
 
 impl Drop for KeepaliveState {
     fn drop(&mut self) {
-        self.0.abort();
+        // Guard against panics during interpreter shutdown when tokio runtime may be gone
+        let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            self.0.abort();
+        }));
     }
 }
 

--- a/monarch_hyperactor/src/pytokio.rs
+++ b/monarch_hyperactor/src/pytokio.rs
@@ -499,7 +499,10 @@ impl Drop for PyShared {
         if self.abort {
             // When the PyShared is dropped, we don't want the background task to go
             // forever, because nothing will wait on the rx.
-            self.handle.abort();
+            // Guard against panics during interpreter shutdown when tokio runtime may be gone
+            let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                self.handle.abort();
+            }));
         }
     }
 }


### PR DESCRIPTION
Summary: (as oncall monitoring the release/conveyor) i'm still seeing evidence of panics in shutdown races. this diff sprinkles some defensive resilience around.

Differential Revision: D90473520


