### PR TITLE
Adds a new dockerfile that builds from source.

### DIFF
--- a/DockerfileSourceBuild
+++ b/DockerfileSourceBuild
@@ -1,0 +1,84 @@
+# Dockerfile for building Monarch from source
+# Usage: docker build -f DockerfileSourceBuild -t monarch:source-build .
+#
+# Multi-stage build:
+#   Stage 1 (builder): Full build environment with Rust, clang, CUDA devel, etc.
+#   Stage 2 (runtime): Slim runtime image with CUDA runtime (not devel)
+#
+# The devel image (~15GB) is only used for building. The final image uses
+# the runtime variant (~5GB) which excludes compilers, headers, and static libs.
+
+# Override on build from CI.
+ARG PYTORCH_NIGHTLY_TAG=2.11.0.dev20260103-cuda12.6-cudnn9-devel
+# Runtime tag should match CUDA version but use runtime instead of devel
+ARG PYTORCH_RUNTIME_TAG=2.11.0.dev20260103-cuda12.6-cudnn9-runtime
+
+# ============================================================
+# STAGE 1: Builder - compile Monarch from source
+# ============================================================
+FROM ghcr.io/pytorch/pytorch-nightly:${PYTORCH_NIGHTLY_TAG} AS builder
+
+SHELL ["/bin/bash", "-c"]
+
+# System dependencies for building
+RUN apt-get update -y && \
+    apt-get install -y \
+    curl \
+    clang \
+    liblzma-dev \
+    libunwind-dev \
+    libibverbs-dev \
+    librdmacm-dev \
+    protobuf-compiler \
+    build-essential \
+    pkg-config \
+    libssl-dev \
+    git \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Rust nightly toolchain
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+ENV PATH="/root/.cargo/bin:${PATH}"
+RUN rustup toolchain install nightly-2025-09-14 && \
+    rustup default nightly-2025-09-14
+
+# Copy source code
+WORKDIR /monarch
+COPY . .
+
+# Build monarch wheel (without tensor_engine for broader compatibility)
+RUN USE_TENSOR_ENGINE=0 pip wheel --no-deps -w /wheels .
+
+# ============================================================
+# STAGE 2: Runtime - slim image with only what's needed to run
+# ============================================================
+FROM ghcr.io/pytorch/pytorch-nightly:${PYTORCH_RUNTIME_TAG} AS runtime
+
+SHELL ["/bin/bash", "-c"]
+
+# Runtime-only system dependencies (RDMA libs needed at runtime)
+RUN apt-get update -y && \
+    apt-get install -y --no-install-recommends \
+    curl \
+    libibverbs1 \
+    librdmacm1 \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copy the built wheel from builder and install it (this also installs dependencies)
+COPY --from=builder /wheels/*.whl /wheels/
+RUN pip install --break-system-packages /wheels/*.whl && \
+    pip install --break-system-packages torchx-nightly[kubernetes] && \
+    rm -rf /wheels /root/.cache/pip
+
+# Set up library path for PyTorch libs
+ENV LD_LIBRARY_PATH=/usr/local/lib/python3.12/dist-packages/torch/lib:/usr/local/lib:$LD_LIBRARY_PATH
+
+# Install kubectl (nice to have on client for debugging)
+RUN curl -LO https://dl.k8s.io/release/v1.34.0/bin/linux/amd64/kubectl && \
+    chmod +x kubectl && \
+    mv kubectl /usr/local/bin
+
+WORKDIR /workspace
+
+# Default command
+CMD ["/bin/bash"]

--- a/examples/kubernetes/torchx_kubernetes_job.py
+++ b/examples/kubernetes/torchx_kubernetes_job.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""
+Test script for TorchXKubernetesJob
+
+This script tests the Monarch Kubernetes JobTrait implementation by:
+1. Launching workers on a Kubernetes cluster using TorchX/Volcano
+2. Spawning a simple actor across the workers
+3. Running a basic distributed computation
+4. Verifying the results
+
+Prerequisites:
+- Minikube/Kubernetes cluster with Volcano scheduler installed
+- kubectl configured to access the cluster
+- Docker image monarch:source-build built and loaded into cluster
+"""
+
+import asyncio
+import sys
+
+from monarch._src.job.torchx_kubernetes import TorchXKubernetesJob
+from monarch.actor import Actor, current_rank, current_size, endpoint
+
+
+class TestActor(Actor):
+    """Simple actor for testing distributed execution."""
+
+    def __init__(self):
+        self.rank = dict(current_rank())
+        self.size = dict(current_size())
+
+    @endpoint
+    async def hello(self) -> str:
+        """Return a greeting with rank information."""
+        return f"Hello from rank {self.rank}, world size: {self.size}"
+
+    @endpoint
+    async def compute(self, x: int) -> int:
+        """Simple computation: multiply input by rank."""
+        result = x * (self.rank.get("hosts", 0) + 1)
+        print(f"Rank {self.rank}: {x} * {self.rank.get('hosts', 0) + 1} = {result}")
+        return result
+
+
+async def main():
+    print("=" * 80)
+    print("Monarch Kubernetes JobTrait Test")
+    print("=" * 80)
+
+    # Create a Kubernetes job with 2 workers (pods)
+    # Each worker gets 1 CPU and 4GB memory
+    print("\n[1/4] Creating TorchXKubernetesJob...")
+    job = TorchXKubernetesJob(
+        meshes={"workers": 2},
+        namespace="monarch-tests",
+        queue="monarch",
+        image="383172230265.dkr.ecr.us-east-1.amazonaws.com/monarch-k8s:source-build-skinny2",
+        job_name="monarch-test",
+        cpu=1,
+        memMB=4096,
+        gpu=0,
+        job_start_timeout=300,
+    )
+
+    try:
+        # Get the job state (this will submit the job and wait for workers to start)
+        print("\n[2/4] Submitting job and waiting for workers to start...")
+        print("This may take a few minutes while Kubernetes schedules pods...")
+        state = job.state()
+
+        # Access the workers mesh (HostMesh)
+        workers_host_mesh = state.workers
+        print(f"\n[3/4] Workers ready! HostMesh extent: {workers_host_mesh.extent}")
+
+        # Wait for HostMesh initialization
+        print("    Waiting for HostMesh initialization...")
+        await workers_host_mesh.initialized
+        print("    HostMesh initialized!")
+
+        # First spawn a ProcMesh from the HostMesh, then spawn actors on it
+        print("    Spawning ProcMesh from HostMesh...")
+        workers_proc_mesh = workers_host_mesh.spawn_procs()
+        print(f"    ProcMesh extent: {workers_proc_mesh.extent}")
+
+        # Wait for ProcMesh initialization
+        print("    Waiting for ProcMesh initialization...")
+        await workers_proc_mesh.initialized
+        print("    ProcMesh initialized!")
+
+        # Spawn actors on the ProcMesh
+        print("\n[4/4] Spawning test actors and running computations...")
+        test_actors = workers_proc_mesh.spawn("test_actor", TestActor)
+
+        # Test 1: Call hello on all actors
+        print("\n--- Test 1: Hello from all actors ---")
+        greetings = await test_actors.hello.call()
+        for rank, greeting in greetings.items():
+            print(f"  Rank {rank}: {greeting}")
+
+        # Test 2: Run a simple computation on all actors
+        print("\n--- Test 2: Distributed computation ---")
+        input_value = 10
+        print(f"Input value: {input_value}")
+        results = await test_actors.compute.call(input_value)
+        print(f"Results from all workers: {results}")
+        total = sum(results.values())
+        print(f"Sum of all results: {total}")
+
+        # Verify results
+        expected_total = sum(input_value * (i + 1) for i in range(2))
+        if total == expected_total:
+            print("\nSUCCESS! All tests passed.")
+            print(f"   Expected total: {expected_total}, Got: {total}")
+        else:
+            print("\nFAILURE! Results don't match.")
+            print(f"   Expected total: {expected_total}, Got: {total}")
+            sys.exit(1)
+
+    except Exception as e:
+        print(f"\n❌ ERROR: {e}")
+        import traceback
+
+        traceback.print_exc()
+        sys.exit(1)
+    finally:
+        # Clean up the job
+        print("\n[Cleanup] Killing job...")
+        job.kill()
+        print("Done!")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/python/monarch/_src/job/torchx_kubernetes.py
+++ b/python/monarch/_src/job/torchx_kubernetes.py
@@ -1,0 +1,387 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+"""
+Monarch JobTrait implementation for TorchX Kubernetes scheduler.
+
+TorchXKubernetesJob allows running Monarch workers on Kubernetes clusters
+using TorchX with the Volcano scheduler backend.
+
+Requirements:
+    - pip install torchx[kubernetes]
+    - Volcano scheduler installed on the Kubernetes cluster
+    - kubectl configured with access to the target cluster
+"""
+
+import logging
+import sys
+import time
+from typing import Any, Dict, FrozenSet, List, Mapping, Optional
+
+from monarch._rust_bindings.monarch_hyperactor.channel import ChannelTransport
+from monarch._rust_bindings.monarch_hyperactor.config import configure
+
+from monarch._src.actor.bootstrap import attach_to_workers
+from monarch._src.job.job import JobState, JobTrait
+
+
+logger: logging.Logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+logger.addHandler(logging.StreamHandler(sys.stderr))
+logger.propagate = False
+
+
+# Terminal states that indicate the job is no longer active
+# Note: UNKNOWN is not included because TorchX may return UNKNOWN briefly
+# when the job is first submitted before Kubernetes reports the real status
+_TORCHX_TERMINAL_STATES: FrozenSet[str] = frozenset(
+    ["SUCCEEDED", "FAILED", "CANCELLED"]
+)
+
+
+class TorchXKubernetesJob(JobTrait):
+    """
+    A job scheduler that uses TorchX with Kubernetes/Volcano to schedule jobs.
+
+    This implementation:
+    1. Uses TorchX Runner to submit Kubernetes jobs via Volcano scheduler
+    2. Queries job status through TorchX to get pod hostnames/IPs
+    3. Uses the pod addresses to connect to the started Monarch workers
+
+    Prerequisites:
+    - Volcano scheduler must be installed on the Kubernetes cluster:
+      kubectl apply -f https://raw.githubusercontent.com/volcano-sh/volcano/v1.6.0/installer/volcano-development.yaml
+    - A Volcano queue must exist (default queue is typically available)
+
+    Example:
+        >>> job = TorchXKubernetesJob(
+        ...     meshes={"trainers": 2},
+        ...     namespace="monarch",
+        ...     queue="default",
+        ...     image="ghcr.io/meta-pytorch/monarch:latest",
+        ... )
+        >>> state = job.state()
+        >>> trainers = state.trainers  # HostMesh with 2 nodes
+    """
+
+    def __init__(
+        self,
+        meshes: Dict[str, int],
+        namespace: str = "default",
+        queue: str = "default",
+        image: str = "ghcr.io/meta-pytorch/monarch:latest",
+        service_account: Optional[str] = None,
+        monarch_port: int = 22222,
+        job_name: str = "monarch-job",
+        cpu: int = 1,
+        memMB: int = 4096,
+        gpu: int = 0,
+        job_start_timeout: Optional[int] = 300,
+        scheduler_args: Optional[Mapping[str, Any]] = None,
+    ) -> None:
+        """
+        Args:
+            meshes: Dictionary mapping mesh names to number of replicas (pods).
+            namespace: Kubernetes namespace to deploy jobs in.
+            queue: Volcano queue name for job scheduling.
+            image: Docker image containing Monarch installation.
+            service_account: Kubernetes service account for pods.
+            monarch_port: Port for TCP communication between workers.
+            job_name: Base name for the Kubernetes job.
+            cpu: Number of CPU cores per pod.
+            memMB: Memory in MB per pod.
+            gpu: Number of GPUs per pod.
+            job_start_timeout: Maximum time in seconds to wait for job to start.
+                If None, waits indefinitely.
+            scheduler_args: Additional TorchX scheduler arguments to pass.
+        """
+        configure(default_transport=ChannelTransport.TcpWithHostname)
+
+        self._meshes = meshes
+        self._namespace = namespace
+        self._queue = queue
+        self._image = image
+        self._service_account = service_account
+        self._port = monarch_port
+        self._job_name = job_name
+        self._cpu = cpu
+        self._memMB = memMB
+        self._gpu = gpu
+        self._job_start_timeout = job_start_timeout
+        self._scheduler_args = dict(scheduler_args) if scheduler_args else {}
+
+        # Runtime state
+        self._job_handle: Optional[str] = None
+        self._all_pod_ips: List[str] = []
+
+        super().__init__()
+
+    def add_mesh(self, name: str, num_replicas: int) -> None:
+        self._meshes[name] = num_replicas
+
+    def _get_scheduler_cfg(self) -> Dict[str, Any]:
+        """Build TorchX scheduler configuration."""
+        cfg: Dict[str, Any] = {
+            "namespace": self._namespace,
+            "queue": self._queue,
+        }
+        if self._service_account:
+            cfg["service_account"] = self._service_account
+
+        # Merge any additional scheduler args
+        cfg.update(self._scheduler_args)
+        return cfg
+
+    def _create(self, client_script: Optional[str]) -> None:
+        """Submit a TorchX Kubernetes job for all meshes."""
+        if client_script is not None:
+            raise RuntimeError("TorchXKubernetesJob cannot run batch-mode scripts")
+
+        # Lazy import torchx to avoid import errors when not installed
+        try:
+            from torchx import specs
+            from torchx.runner import get_runner
+        except ImportError as e:
+            raise RuntimeError(
+                "TorchX is not installed. Install with: pip install torchx[kubernetes]"
+            ) from e
+
+        total_replicas = sum(self._meshes.values())
+
+        # Build the worker startup command
+        # Use pod IP address for the worker since kubernetes pod hostnames
+        # may not resolve correctly across pods
+        #
+        # We use a simple startup script. The PyTorch nightly Docker images have
+        # packages installed in /usr/local/lib/python3.12/dist-packages.
+        # The Monarch Rust code uses std::env::current_exe() to determine
+        # the Python executable for child processes, so we just need to make
+        # sure the environment is set up correctly.
+        bash_script = f'''
+exec python3 -c '
+import socket
+hostname = socket.gethostname()
+address = f"tcp://{{hostname}}:{self._port}"
+print(f"Starting Monarch worker at {{address}}", flush=True)
+from monarch.actor import run_worker_loop_forever
+run_worker_loop_forever(address=address, ca="trust_all_connections")
+'
+'''
+        entrypoint = "bash"
+        entrypoint_args = ["-c", bash_script]
+
+        # Create TorchX AppDef with a single role containing all replicas
+        unique_job_name = f"{self._job_name}-{int(time.time())}"
+
+        role = specs.Role(
+            name="worker",
+            image=self._image,
+            entrypoint=entrypoint,
+            args=entrypoint_args,
+            num_replicas=total_replicas,
+            resource=specs.Resource(
+                cpu=self._cpu,
+                memMB=self._memMB,
+                gpu=self._gpu,
+            ),
+            port_map={"monarch": self._port},
+        )
+
+        appdef = specs.AppDef(
+            name=unique_job_name,
+            roles=[role],
+        )
+
+        logger.info(
+            f"Submitting TorchX Kubernetes job '{unique_job_name}' "
+            f"with {total_replicas} replicas to namespace '{self._namespace}'"
+        )
+
+        # Submit the job using TorchX Runner
+        with get_runner() as runner:
+            cfg = self._get_scheduler_cfg()
+            self._job_handle = runner.run(appdef, scheduler="kubernetes", cfg=cfg)
+
+        logger.info(f"TorchX job submitted: {self._job_handle}")
+
+    def _wait_for_job_start(
+        self, timeout: Optional[int] = None
+    ) -> List[str]:
+        """
+        Wait for the TorchX job to start and return pod IP addresses.
+
+        Returns:
+            List of pod IP addresses where workers are running.
+        """
+        # Lazy import torchx
+        try:
+            from torchx.runner import get_runner
+            from torchx.specs import AppState
+        except ImportError as e:
+            raise RuntimeError(
+                "TorchX is not installed. Install with: pip install torchx[kubernetes]"
+            ) from e
+
+        if not self._job_handle:
+            raise RuntimeError("Job has not been submitted yet")
+
+        start_time = time.time()
+        total_replicas = sum(self._meshes.values())
+
+        try:
+            while timeout is None or time.time() - start_time < timeout:
+                with get_runner() as runner:
+                    status = runner.status(self._job_handle)
+
+                    if status is None:
+                        raise RuntimeError(
+                            f"TorchX job {self._job_handle} not found"
+                        )
+
+                    state_name = status.state.name if hasattr(status.state, 'name') else str(status.state)
+
+                    if status.state == AppState.RUNNING:
+                        # Get pod IPs from replica status
+                        pod_ips: List[str] = []
+                        for role_status in status.roles:
+                            for replica in role_status.replicas:
+                                # The hostname field contains the pod IP for k8s
+                                if replica.hostname:
+                                    pod_ips.append(replica.hostname)
+
+                        if len(pod_ips) >= total_replicas:
+                            logger.info(
+                                f"TorchX job {self._job_handle} is running "
+                                f"with {len(pod_ips)} pods: {pod_ips}"
+                            )
+                            return pod_ips
+
+                        logger.debug(
+                            f"Job running but only {len(pod_ips)}/{total_replicas} "
+                            f"pods ready, waiting..."
+                        )
+
+                    elif state_name in _TORCHX_TERMINAL_STATES:
+                        raise RuntimeError(
+                            f"TorchX job {self._job_handle} failed with state: {state_name}"
+                        )
+                    else:
+                        logger.debug(
+                            f"TorchX job {self._job_handle} state: {state_name}, waiting..."
+                        )
+
+                time.sleep(5)  # Poll every 5 seconds
+
+            raise RuntimeError(
+                f"Timeout waiting for TorchX job {self._job_handle} to start"
+            )
+
+        except Exception:
+            logger.error(
+                f"Failed waiting for TorchX job {self._job_handle}, cancelling"
+            )
+            self._kill()
+            raise
+
+    def _state(self) -> JobState:
+        """Get the current state with HostMesh objects for each mesh."""
+        if not self._jobs_active():
+            raise RuntimeError("TorchX Kubernetes job is no longer active")
+
+        # Wait for job to start and get pod IPs if not already cached
+        if not self._all_pod_ips:
+            self._all_pod_ips = self._wait_for_job_start(
+                timeout=self._job_start_timeout
+            )
+
+        # Distribute pod IPs among meshes
+        host_meshes = {}
+        ip_idx = 0
+
+        for mesh_name, num_replicas in self._meshes.items():
+            mesh_ips = self._all_pod_ips[ip_idx : ip_idx + num_replicas]
+            ip_idx += num_replicas
+
+            workers = [f"tcp://{ip}:{self._port}" for ip in mesh_ips]
+            logger.info(f"Connecting to workers for mesh '{mesh_name}': {workers}")
+
+            host_mesh = attach_to_workers(
+                name=mesh_name,
+                ca="trust_all_connections",
+                workers=workers,  # type: ignore[arg-type]
+            )
+
+            host_meshes[mesh_name] = host_mesh
+
+        return JobState(host_meshes)
+
+    def can_run(self, spec: "JobTrait") -> bool:
+        """Check if this job can run the given spec."""
+        return (
+            isinstance(spec, TorchXKubernetesJob)
+            and spec._meshes == self._meshes
+            and spec._namespace == self._namespace
+            and spec._queue == self._queue
+            and spec._image == self._image
+            and spec._port == self._port
+            and spec._cpu == self._cpu
+            and spec._memMB == self._memMB
+            and spec._gpu == self._gpu
+            and self._jobs_active()
+        )
+
+    def _jobs_active(self) -> bool:
+        """Check if the TorchX job is still active."""
+        if not self.active or self._job_handle is None:
+            return False
+
+        try:
+            from torchx.runner import get_runner
+            from torchx.specs import AppState
+
+            with get_runner() as runner:
+                status = runner.status(self._job_handle)
+
+                if status is None:
+                    logger.warning(f"TorchX job {self._job_handle} not found")
+                    return False
+
+                state_name = status.state.name if hasattr(status.state, 'name') else str(status.state)
+
+                if state_name in _TORCHX_TERMINAL_STATES:
+                    logger.warning(
+                        f"TorchX job {self._job_handle} has state: {state_name}"
+                    )
+                    return False
+
+                return True
+
+        except ImportError:
+            logger.warning("TorchX not installed, cannot check job status")
+            return False
+        except Exception as e:
+            logger.warning(f"Error checking job status: {e}")
+            return False
+
+    def _kill(self) -> None:
+        """Cancel the TorchX Kubernetes job."""
+        if self._job_handle is not None:
+            try:
+                from torchx.runner import get_runner
+
+                with get_runner() as runner:
+                    runner.cancel(self._job_handle)
+                logger.info(f"Cancelled TorchX job {self._job_handle}")
+
+            except ImportError:
+                logger.warning("TorchX not installed, cannot cancel job")
+            except Exception as e:
+                logger.warning(f"Failed to cancel TorchX job {self._job_handle}: {e}")
+
+        self._job_handle = None
+        self._all_pod_ips.clear()


### PR DESCRIPTION
Summary:
# Dockerfile Build From Source

I remade our main/default Dockerfile a while back and intentionally made the decision to have it be minimal; it derives from the PyTorch nightly image, adds some minimal installs, then installs the monarch and torchx wheels that are already published.  This is great and will even work fine for CI if it is scheduled *after* the wheel publishing or a day trailing.  It avoids doing another full rebuild and also will help us to test our wheels from pypi and keep consistency.

Having said that, as we go into a world of Docker, Kubernetes, etc, there will be deployment issues that require code changes to RUST and/or python.  One recent notable one while building this was that the spawn_procs API actually didn't work in containers because of some odd issue we had with pid=1!  Anyway, this kind of thing means we really do need to be able to build a docker file from source easily to iterate on this kind of development.  We could use it as our main one for releases; but I still think reusing the simpler one with our pypi outputs is better there.

This diff adds a build from source dockerfile which will be passive/unused for now except when needed by developers.  It is a Multi Stage build, meaning it builds in one container and then makes a smaller runtime container from the outputs, so it is generally well made.  I've used it and it build and runs fine for simpler cases.  We can evolve it as needed and there is no risk to this diff as it's a dev helper for now.

Differential Revision: D90361795
