### PR TITLE
Updating Dockerfile for the latest pytorch base image.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Override on build from CI.
-ARG PYTORCH_NIGHTLY_TAG=2.10.0.dev20251115-cuda12.6-cudnn9-devel
+ARG PYTORCH_NIGHTLY_TAG=2.11.0.dev20260111-cuda12.6-cudnn9-runtime
 
 # Build from latest pytorch nightly base image; should be relatively in sync with torchmonarch-nightly and pytorch-nightly.
 FROM ghcr.io/pytorch/pytorch-nightly:${PYTORCH_NIGHTLY_TAG}
@@ -11,10 +11,10 @@ RUN apt-get update -y && \
     apt-get install curl clang liblzma-dev libunwind-dev libibverbs-dev librdmacm-dev protobuf-compiler -y
 
 # Install monarch-nightly.
-RUN pip install torchmonarch-nightly
+RUN pip install torchmonarch-nightly --break-system-packages
 
 # Install torchx-nightly w/ kubernetes.
-RUN pip install torchx-nightly[kubernetes]
+RUN pip install torchx-nightly[kubernetes] --break-system-packages
 
 # Path
 ENV LD_LIBRARY_PATH=/opt/conda/lib/python3.11/site-packages/torch/lib:/opt/conda/lib:$LD_LIBRARY_PATH


### PR DESCRIPTION
Summary:
PyTorch nightlies have updated their images to new versions (2.10). This update also brought in the preference of not using the system environment to install packages.

This chnage bumps us to the newest image and adds ` --break-system-packages` to the pip installs so they still work after that preference.

I did some research, and modifying the main system environment is considered okay/correct in containers as only one app is intended to run in them in the first place, and the containers should be optimized to make that app run well / by default.

Differential Revision: D90475815


