### PR TITLE
remove convert_case_10 & upgrade convert_case to 0.10.0

### DIFF
--- a/hyperactor_macros/Cargo.toml
+++ b/hyperactor_macros/Cargo.toml
@@ -19,7 +19,7 @@ name = "hyperactor_macros_test"
 path = "tests/basic.rs"
 
 [dependencies]
-convert_case = "0.6"
+convert_case = "0.10.0"
 indoc = "2.0.2"
 proc-macro2 = { version = "1.0.70", features = ["span-locations"] }
 quote = "1.0.29"


### PR DESCRIPTION
Summary:
As per the title:
1. Migrating `convert_case_10` dependents to use `convert_case`
2. Removing multi-versioned `convert_case_10`
3. Upgrading single version of `convert_case` to `0.10.0`

Differential Revision: D89699070


