### PR TITLE
context().actor_instance.abort()

### DIFF
--- a/hyperactor/src/actor.rs
+++ b/hyperactor/src/actor.rs
@@ -328,9 +328,14 @@ pub enum ActorErrorKind {
     /// An error that occurred while trying to handle a supervision event.
     #[error("{0} while handling {1}")]
     ErrorDuringHandlingSupervision(String, Box<ActorSupervisionEvent>),
+
     /// The actor did not attempt to handle
     #[error("{0}")]
     UnhandledSupervisionEvent(Box<ActorSupervisionEvent>),
+
+    /// The actor was explicitly aborted with the provided reason.
+    #[error("actor explicitly aborted due to: {0}")]
+    Aborted(String),
 }
 
 impl ActorErrorKind {
@@ -443,6 +448,11 @@ pub enum Signal {
 
     /// The direct child with the given PID was stopped.
     ChildStopped(Index),
+
+    /// Abort the actor. This will exit the actor loop with an error,
+    /// causing a supervision event to propagate up the supervision
+    /// hierarchy.
+    Abort(String),
 }
 wirevalue::register_type!(Signal);
 
@@ -452,6 +462,7 @@ impl fmt::Display for Signal {
             Signal::DrainAndStop => write!(f, "DrainAndStop"),
             Signal::Stop => write!(f, "Stop"),
             Signal::ChildStopped(index) => write!(f, "ChildStopped({})", index),
+            Signal::Abort(reason) => write!(f, "Abort({})", reason),
         }
     }
 }

--- a/hyperactor_mesh/src/resource.rs
+++ b/hyperactor_mesh/src/resource.rs
@@ -43,8 +43,11 @@ use serde::Serialize;
 use typeuri::Named;
 
 use crate::bootstrap;
+use crate::proc_mesh::mesh_agent::ActorSpec;
+use crate::proc_mesh::mesh_agent::ActorState;
 use crate::v1::Name;
 use crate::v1::StatusOverlay;
+use crate::v1::host_mesh::mesh_agent::ProcState;
 
 /// The current lifecycle status of a resource.
 #[derive(
@@ -261,6 +264,8 @@ pub struct CreateOrUpdate<S> {
     /// The specification of the resource.
     pub spec: S,
 }
+wirevalue::register_type!(CreateOrUpdate<ProcSpec>);
+wirevalue::register_type!(CreateOrUpdate<ActorSpec>);
 
 /// Stop a resource according to a spec.
 #[derive(
@@ -279,6 +284,7 @@ pub struct Stop {
     /// The name of the resource to stop.
     pub name: Name,
 }
+wirevalue::register_type!(Stop);
 
 /// Stop all resources owned by the receiver of this message.
 /// No reply, this just issues the stop command.
@@ -296,6 +302,7 @@ pub struct Stop {
     Unbind
 )]
 pub struct StopAll {}
+wirevalue::register_type!(StopAll);
 
 /// Retrieve the current state of the resource.
 #[derive(Debug, Serialize, Deserialize, Named, Handler, HandleClient, RefClient)]
@@ -306,6 +313,8 @@ pub struct GetState<S> {
     #[reply]
     pub reply: PortRef<State<S>>,
 }
+wirevalue::register_type!(GetState<ProcState>);
+wirevalue::register_type!(GetState<ActorState>);
 
 // Cannot derive Bind and Unbind for this generic, implement manually.
 impl<S> Unbind for GetState<S>

--- a/monarch_hyperactor/src/context.rs
+++ b/monarch_hyperactor/src/context.rs
@@ -80,6 +80,12 @@ impl PyInstance {
     pub fn actor_id(&self) -> PyActorId {
         self.inner.self_id().clone().into()
     }
+
+    #[pyo3(signature = (reason = None))]
+    fn abort(&self, reason: Option<&str>) -> PyResult<()> {
+        let reason = reason.unwrap_or("(no reason provided)");
+        Ok(self.inner.abort(reason).map_err(anyhow::Error::from)?)
+    }
 }
 
 impl PyInstance {

--- a/python/monarch/_src/actor/actor_mesh.py
+++ b/python/monarch/_src/actor/actor_mesh.py
@@ -15,7 +15,7 @@ import itertools
 import logging
 import threading
 import warnings
-from abc import abstractproperty
+from abc import abstractmethod, abstractproperty
 from dataclasses import dataclass
 from functools import cache
 from pprint import pformat
@@ -230,6 +230,14 @@ class Instance(abc.ABC):
 
     def __repr__(self) -> str:
         return _qualified_name(self)
+
+    @abstractmethod
+    def abort(self, reason: Optional[str] = None) -> None:
+        """
+        Abort the current actor. This will cause the actor to terminate
+        with a failure, and a supervision error will propagate to its creator.
+        """
+        ...
 
 
 @dataclass

--- a/python/tests/test_python_actors.py
+++ b/python/tests/test_python_actors.py
@@ -42,7 +42,6 @@ from monarch._rust_bindings.monarch_hyperactor.mailbox import (
 from monarch._rust_bindings.monarch_hyperactor.proc import ActorId
 from monarch._rust_bindings.monarch_hyperactor.pytokio import PythonTask
 from monarch._rust_bindings.monarch_hyperactor.shape import Extent
-from monarch._rust_bindings.monarch_hyperactor.supervision import SupervisionError
 from monarch._src.actor.actor_mesh import ActorMesh, Channel, context, Port
 from monarch._src.actor.allocator import ProcessAllocator
 from monarch._src.actor.future import Future


### PR DESCRIPTION
Summary: Add an `abort()` method on `context().actor_instance`. This will cause the actor to terminate in a way that causes a supervision error to propagate to the actor's creator.

Differential Revision: D90538279


