### PR TITLE
Fix "undeliverable message was returned to the wrong actor"

### DIFF
--- a/hyperactor/src/mailbox.rs
+++ b/hyperactor/src/mailbox.rs
@@ -448,6 +448,11 @@ impl MessageEnvelope {
     fn return_undeliverable(&self) -> bool {
         self.return_undeliverable
     }
+
+    /// Get a mutable reference to this envelope's headers.
+    pub fn headers_mut(&mut self) -> &mut Attrs {
+        &mut self.headers
+    }
 }
 
 impl fmt::Display for MessageEnvelope {

--- a/hyperactor_mesh/src/comm.rs
+++ b/hyperactor_mesh/src/comm.rs
@@ -179,6 +179,13 @@ impl Actor for CommActor {
                 cx.self_id(),
                 return_port.port_id(),
             )));
+
+            // Needed so that the receiver of the undeliverable message can easily find the
+            // original sender of the cast message.
+            message_envelope
+                .headers_mut()
+                .set(CAST_ORIGINATING_SENDER, sender.clone());
+
             return_port
                 .send(cx, Undeliverable(message_envelope.clone()))
                 .map_err(|err| {


### PR DESCRIPTION
Summary: I don't know why this wasn't a problem before, but we're suddenly seeing consistent github CI failures like this: https://fburl.com/7w7q0j4o. The problem is that when a comm actor fails to deliver a `ForwardMessage` and attempts to return this to the original sending actor, we never actually set CAST_ORIGINATING_SENDER on the headers, so https://fburl.com/code/i1vo4a6y fails to properly update the sender actor id. This diff makes it so that before returning a `ForwardMessage` to the original sender, we set CAST_ORIGINATING_SENDER on the envelope's headers.

Differential Revision: D90547608


