### PR TITLE
Fix docs to support mermaid diagram rendering

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -164,6 +164,8 @@ html_static_path = ["_static"]
 # Configure MyST-Parser to find markdown files in the books directory
 myst_update_mathjax = False
 myst_heading_anchors = 3
+# Configure code blocks with just mermaid to be rendered as diagrams.
+myst_fence_as_directive = ["mermaid"]
 
 # The suffix(es) of source filenames.
 source_suffix = {


### PR DESCRIPTION
Summary:
I noticed that https://meta-pytorch.org/monarch/actors.html#lifecycle-stages has an
unrendered mermaid diagram.
I saw in the Docs github action this warning:
```
/meta-pytorch/monarch/docs/source/actors.md:36: WARNING: Pygments lexer name 'mermaid' is not known
```
I think the problem is the lack of curly braces around mermaid, so I followed these instructions
to enable it correctly:
https://github.com/mgaitan/sphinxcontrib-mermaid?tab=readme-ov-file#markdown-support

Differential Revision: D90611984


