### PR TITLE
Add KubernetesJob example for provisioning Monarch hosts using Volcano Schduler

### DIFF
--- a/examples/kubernetes/README.md
+++ b/examples/kubernetes/README.md
@@ -1,0 +1,54 @@
+# Running Monarch on Kubernetes
+
+This directory contains examples for running Monarch on Kubernetes. KubernetesJob supports Monarch hosts provisioned by MonarchMesh CRD.
+It is also vendor-independent and lets users decide how they want to schedule and orchestrate Monarch hosts.
+
+## Provision Monarch Hosts with MonarchMesh CRD and operator
+Coming Soon!
+
+## Provision Monarch Hosts with Third-Party Scheduler
+### Volcano Scheduler
+#### Prerequisites
+
+- A Kubernetes cluster with [Volcano scheduler](https://volcano.sh/en/docs/installation/) installed
+- `kubectl` configured to access the cluster
+- The `monarch-tests` namespace created
+
+#### Provisioning Monarch Hosts with Volcano Scheduler
+
+The `volcano_workers.yaml` manifest launches Monarch worker pods using Volcano's gang scheduling. This ensures all pods in a mesh are scheduled together or not at all.
+
+Volcano automatically adds labels to pods:
+- `volcano.sh/job-name` - the Volcano Job name (used for pod discovery)
+- `volcano.sh/task-index` - ordinal index (0, 1, 2, ...) for ordering workers
+
+#### Deploy the workers
+
+```bash
+kubectl apply -f volcano_workers.yaml
+```
+
+#### Verify pods are running
+
+```bash
+kubectl get pods -n monarch-tests -l volcano.sh/job-name=mesh1
+kubectl get pods -n monarch-tests -l volcano.sh/job-name=mesh2
+```
+
+#### Running the Example
+
+Once the workers are running, execute the example script from a pod within the cluster:
+
+```bash
+python hello_kubernetes_job.py --volcano
+```
+
+The `--volcano` flag configures `KubernetesJob` to use Volcano's labels:
+- `volcano.sh/job-name=<mesh-name>` for pod discovery
+- `volcano.sh/task-index` for pod ordering
+
+#### Cleanup
+
+```bash
+kubectl delete -f volcano_workers.yaml
+```

--- a/examples/kubernetes/volcano_workers.yaml
+++ b/examples/kubernetes/volcano_workers.yaml
@@ -1,0 +1,91 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Volcano Job for launching Monarch workers with gang scheduling.
+# Requires Volcano scheduler to be installed in the cluster.
+# See: https://volcano.sh/en/docs/installation/
+---
+apiVersion: batch.volcano.sh/v1alpha1
+kind: Job
+metadata:
+  name: mesh1
+  namespace: monarch-tests
+spec:
+  minAvailable: 2
+  schedulerName: volcano
+  tasks:
+  - replicas: 2
+    name: worker
+    template:
+      spec:
+        containers:
+        - name: worker
+          image: ghcr.io/meta-pytorch/monarch:2026-01-11-alpha
+          # TODO: use worker.py when it's available
+          command:
+            - python
+            - -u
+            - -c
+            - |
+              import os
+              import socket
+              import logging
+              from monarch.actor import run_worker_loop_forever
+              logging.basicConfig(level=logging.INFO)
+              logger = logging.getLogger("monarch-worker")
+              port = os.environ.get("MONARCH_PORT", "26600")
+              hostname = socket.gethostname()
+              address = f"tcp://{hostname}:{port}"
+              logger.info(f"--- Starting Monarch Worker ---")
+              logger.info(f"Identity: {hostname}")
+              logger.info(f"Listening on: {address}")
+              run_worker_loop_forever(address=address, ca="trust_all_connections")
+
+          ports:
+            - containerPort: 26600
+              name: monarch
+              protocol: TCP
+---
+apiVersion: batch.volcano.sh/v1alpha1
+kind: Job
+metadata:
+  name: mesh2
+  namespace: monarch-tests
+spec:
+  minAvailable: 2
+  schedulerName: volcano
+  tasks:
+  - replicas: 2
+    name: worker
+    template:
+      spec:
+        containers:
+        - name: worker
+          image: ghcr.io/meta-pytorch/monarch:2026-01-11-alpha
+          # TODO: use worker.py when it's available
+          command:
+            - python
+            - -u
+            - -c
+            - |
+              import os
+              import socket
+              import logging
+              from monarch.actor import run_worker_loop_forever
+              logging.basicConfig(level=logging.INFO)
+              logger = logging.getLogger("monarch-worker")
+              port = os.environ.get("MONARCH_PORT", "26600")
+              hostname = socket.gethostname()
+              address = f"tcp://{hostname}:{port}"
+              logger.info(f"--- Starting Monarch Worker ---")
+              logger.info(f"Identity: {hostname}")
+              logger.info(f"Listening on: {address}")
+              run_worker_loop_forever(address=address, ca="trust_all_connections")
+
+          ports:
+            - containerPort: 26600
+              name: monarch
+              protocol: TCP


### PR DESCRIPTION
Summary: Showcase that KubernetesJob is vendor independent

Differential Revision: D90652542


