### PR TITLE
Add worker.py for launching run_worker_loop_forever in the monarch build

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,6 +99,7 @@ dev = [
 [project.scripts]
 monarch = "monarch.tools.cli:main"
 monarch_bootstrap = "monarch._src.actor.bootstrap_main:invoke_main"
+worker = "monarch.tools.worker:main"
 
 [tool.setuptools]
 packages = {find = {where = ["python"]}}

--- a/python/monarch/tools/worker.py
+++ b/python/monarch/tools/worker.py
@@ -1,0 +1,82 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+"""
+Worker startup script
+
+"""
+
+import argparse
+import socket
+
+from monarch.actor import run_worker_loop_forever
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Start a monarch worker listening on the given address"
+    )
+    addr_default = f"tcp://{socket.gethostname()}:26600"
+    parser.add_argument(
+        "--addr",
+        type=str,
+        default=None,
+        help=f"address to listen on for connections. defaults to tcp://{{socket.gethostname()}}:26600 ({addr_default})",
+    )
+    group = parser.add_argument_group(
+        "address builder",
+        description="Options to build an address instead of specifying",
+    )
+    group.add_argument(
+        "--scheme",
+        type=str,
+        default="tcp",
+        choices=("tcp", "metatls"),
+        help="scheme to use if addr is not set",
+    )
+    group.add_argument(
+        "--host",
+        type=str,
+        default="hostname",
+        help="how to resolve the hostname if addr is not set. Can be 'hostname' to use socket.gethostname(), "
+        "'fqdn' to use socket.getfqdn(), or any other string will be the raw hostname",
+    )
+    group.add_argument(
+        "--port",
+        type=int,
+        default=26600,
+        help="port to use. Used if addr is not set.",
+    )
+
+    parser.add_argument(
+        "--ca",
+        type=str,
+        default="trust_all_connections",
+        help="certificate authority to use for TLS connections",
+    )
+    args = parser.parse_args()
+    if not args.addr:
+        if args.host == "hostname":
+            hostname = socket.gethostname()
+        elif args.host == "fqdn":
+            hostname = socket.getfqdn()
+        else:
+            hostname = args.host
+        args.addr = f"{args.scheme}://{hostname}:{args.port}"
+    return args
+
+
+def main() -> None:
+    args = parse_args()
+    print(
+        f"Starting monarch worker on address {args.addr} with ca={args.ca}. Ctrl-C to stop"
+    )
+    run_worker_loop_forever(address=args.addr, ca=args.ca)
+
+
+if __name__ == "__main__":
+    main()

--- a/python/tests/test_python_actors.py
+++ b/python/tests/test_python_actors.py
@@ -1423,8 +1423,10 @@ def test_simple_bootstrap():
             proc = subprocess.Popen(
                 [
                     sys.executable,
-                    "-c",
-                    f'import sys; from monarch.actor import run_worker_loop_forever; run_worker_loop_forever(address={repr(addr)}, ca="trust_all_connections")',
+                    "-m",
+                    "monarch.tools.worker",
+                    "--addr",
+                    addr,
                 ],
                 env=env,
             )
@@ -1508,8 +1510,10 @@ class FakeLocalLoginJob(LoginJob):
         proc = subprocess.Popen(
             [
                 sys.executable,
-                "-c",
-                f'from monarch.actor import run_worker_loop_forever; run_worker_loop_forever(address={repr(addr)}, ca="trust_all_connections")',
+                "-m",
+                "monarch.tools.worker",
+                "--addr",
+                addr,
             ],
             env=env,
             start_new_session=True,


### PR DESCRIPTION
Summary:
For using monarch with simple bootstrap, there is a common task of launching a simple
script on the worker to start running forever.
Most users were doing this as a string given to `python -c`. This still works, but we can
deduplicate code by providing this.

Now you can do `python -m monarch.tools.worker` to launch a worker process. It has
a default address, but you can overwrite it with either:
* `--addr`: Take full control over the address
* `--scheme` + `--port` + `--host`: Customize parts of the default address

Full control works well for ipc and unix schemes, and the parts customization works better
for tcp/tls connections where we don't know their hostname and let them figure it out.

Reviewed By: ahmadsharif1

Differential Revision: D90707603


