### PR TITLE
Swallow exception from Job.kill for unrunnable cached jobs

### DIFF
--- a/python/monarch/_src/job/job.py
+++ b/python/monarch/_src/job/job.py
@@ -183,7 +183,10 @@ class JobTrait(ABC):
             return None
         if not running.can_run(self):
             logger.info("Cached job cannot run this spec, removing cache")
-            running._kill()
+            try:
+                running._kill()
+            except NotImplementedError as e:
+                logger.info("Failed to kill cached job: %s", e)
             os.remove(cached_path)
             return None
         return job


### PR DESCRIPTION
Summary: KubernetesJob currently works with pre-provisioned meshes where we do not allow killing the meshes from it. Ignore exception when it tries to kill from cached jobs.

Reviewed By: ahmadsharif1

Differential Revision: D90142177


