### PR TITLE
Refactoring: re-organize the 2 handle_supervision_event methods owned by Instance

### DIFF
--- a/hyperactor/src/proc.rs
+++ b/hyperactor/src/proc.rs
@@ -418,7 +418,7 @@ impl Proc {
 
     /// Handle a supervision event received by the proc. Attempt to forward it to the
     /// supervision coordinator port if one is set, otherwise crash the process.
-    pub fn handle_supervision_event(&self, event: ActorSupervisionEvent) {
+    pub fn handle_unhandled_supervision_event(&self, event: ActorSupervisionEvent) {
         let result = match self.state().supervision_coordinator_port.get() {
             Some(port) => port.send(event.clone()).map_err(anyhow::Error::from),
             None => Err(anyhow::anyhow!(
@@ -1300,7 +1300,7 @@ impl<A: Actor> Instance<A> {
             // Note that orphaned actor is unexpected and would only happen if
             // there is a bug.
             if let Some(event) = event {
-                self.inner.proc.handle_supervision_event(event);
+                self.inner.proc.handle_unhandled_supervision_event(event);
             }
         }
     }

--- a/hyperactor_mesh/src/proc_mesh.rs
+++ b/hyperactor_mesh/src/proc_mesh.rs
@@ -227,7 +227,7 @@ impl GlobalClientActor {
                     )
                 }
             };
-            instance.proc().handle_supervision_event(event);
+            instance.proc().handle_unhandled_supervision_event(event);
         })
     }
 }

--- a/hyperactor_mesh/src/v1/testing.rs
+++ b/hyperactor_mesh/src/v1/testing.rs
@@ -107,7 +107,7 @@ impl TestRootClient {
                     )
                 }
             };
-            instance.proc().handle_supervision_event(event);
+            instance.proc().handle_unhandled_supervision_event(event);
         })
     }
 }


### PR DESCRIPTION
Summary:
There are current 3 `handle_supervision_event` methods:
* One owned by actor;
* One owned by Instance, which is a wrapper of actor's `handle_supervision_event`.
* One owned by proc, which is only used by Instance.

It is a little to follow their relationship in the code because:
1. same name;
2. the confusing call relationship.

This diff renames the last 2 methods, so it is easier to tell from their method name what they are doing.

More importantly, moves the 3rd method, i.e. `handle_supervision_event_with_proc`, to be Instance's associated method. This change makes it clear *which* proc should be used by this method.

Differential Revision: D90683843


