### PR TITLE
Block tokio runtime when pickling meshes outside of endpoint pathways

### DIFF
--- a/python/monarch/_src/actor/actor_mesh.py
+++ b/python/monarch/_src/actor/actor_mesh.py
@@ -100,7 +100,7 @@ from monarch._src.actor.metrics import endpoint_message_size_histogram
 from monarch._src.actor.mpsc import (  # noqa: F401 - import runs @rust_struct patching
     Receiver,
 )
-from monarch._src.actor.pickle import flatten, unflatten
+from monarch._src.actor.pickle import allow_pending_pickle_mesh, flatten, unflatten
 from monarch._src.actor.python_extension_methods import rust_struct
 from monarch._src.actor.shape import MeshTrait, NDSlice
 from monarch._src.actor.sync_state import fake_sync_state
@@ -616,7 +616,8 @@ def _create_endpoint_message(
         PythonMessage ready to be sent to the actor mesh
     """
     _check_endpoint_arguments(method_name, signature, args, kwargs)
-    objects, buffer = flatten((args, kwargs), _is_ref_or_mailbox_or_pending_pickle)
+    with allow_pending_pickle_mesh():
+        objects, buffer = flatten((args, kwargs), _is_ref_or_mailbox_or_pending_pickle)
 
     has_ref = False
     has_pending_pickle = False
@@ -1552,7 +1553,8 @@ def _is_ref_or_mailbox_or_pending_pickle(x: object) -> bool:
 def _flatten_with_pending_pickle(
     x: object,
 ) -> Tuple[List[Any], Buffer, Optional[PendingPickleState]]:
-    objs, buff = flatten(x, _is_ref_or_mailbox_or_pending_pickle)
+    with allow_pending_pickle_mesh():
+        objs, buff = flatten(x, _is_ref_or_mailbox_or_pending_pickle)
     pending_pickle_state = None
     if any(isinstance(obj, PendingPickle) for obj in objs):
         pending_pickle_state = PendingPickleState(

--- a/python/monarch/_src/actor/proc_mesh.py
+++ b/python/monarch/_src/actor/proc_mesh.py
@@ -69,6 +69,7 @@ from monarch._src.actor.device_utils import _local_device_count
 from monarch._src.actor.endpoint import endpoint
 from monarch._src.actor.future import Future
 from monarch._src.actor.logging import LoggingManager
+from monarch._src.actor.pickle import is_pending_pickle_allowed
 from monarch._src.actor.shape import MeshTrait
 from monarch.tools.config.environment import CondaEnvironment
 from monarch.tools.config.workspace import Workspace
@@ -609,7 +610,12 @@ class ProcMesh(MeshTrait):
 
     def __reduce_ex__(self, protocol: ...) -> Tuple[Any, Tuple[Any, ...]]:
         return ProcMesh._from_initialized_hy_proc_mesh, (
-            self._proc_mesh.poll() or PendingPickle(self._proc_mesh),
+            self._proc_mesh.poll()
+            or (
+                PendingPickle(self._proc_mesh)
+                if is_pending_pickle_allowed()
+                else self._proc_mesh.block_on()
+            ),
             self._host_mesh,
             self._region,
             self._root_region,


### PR DESCRIPTION
Summary: The `PendingPickle` mechanism was added to allow for actor spawning that doesn't require blocking the tokio runtime on proc mesh initialization. This works when meshes are pickled as part of the typical monarch endpoint path, but fails when users try to pickle mesh refs using their own logic. This PR makes it so that pickling a mesh outside of the endpoint path bypasses `PendingPickle` and instead blocks the tokio runtime to wait until the mesh is initialized (which is the same as the old behavior).

Differential Revision: D90927590


