### PR TITLE
Add filelock to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
     "opentelemetry-api",
     "clusterscope",
     "torch",
+    "filelock",
 ]
 
 # PyTorch nightly build indices for different platforms


### PR DESCRIPTION
Summary:
CI is failing with
```
Additionally, some packages in these conflicts have no matching distributions available for your environment:
    filelock
```

Differential Revision: D91062977


