### PR TITLE
Update all workflows to install torch with --extra-index-url

### DIFF
--- a/.github/workflows/build-cpu.yml
+++ b/.github/workflows/build-cpu.yml
@@ -30,7 +30,7 @@ jobs:
         setup_build_environment
 
         # Install torch nightly (CPU version)
-        pip install --pre torch --index-url https://download.pytorch.org/whl/nightly/cpu
+        pip install --pre torch --extra-index-url https://download.pytorch.org/whl/nightly/cpu
         pip install -r build-requirements.txt
 
         # Build monarch (No tensor engine, CPU version)

--- a/.github/workflows/build-cuda.yml
+++ b/.github/workflows/build-cuda.yml
@@ -17,7 +17,7 @@ jobs:
         include:
           - name: 4xlargegpu
             runs-on: linux.g5.4xlarge.nvidia.gpu
-            torch-spec: '--pre torch --index-url https://download.pytorch.org/whl/nightly/cu126'
+            torch-spec: '--pre torch --extra-index-url https://download.pytorch.org/whl/nightly/cu126'
             gpu-arch-type: "cuda"
             gpu-arch-version: "12.6"
     with:

--- a/.github/workflows/build-rocm.yml
+++ b/.github/workflows/build-rocm.yml
@@ -25,7 +25,7 @@ jobs:
         include:
           - name: 4xlargegpu
             runs-on: linux.rocm.gpu.gfx942.8.meta-pytorch
-            torch-spec: 'torch --index-url https://download.pytorch.org/whl/rocm6.4/'
+            torch-spec: 'torch --extra-index-url https://download.pytorch.org/whl/rocm6.4/'
             gpu-arch-type: "rocm"
             gpu-arch-version: "6.4"
     with:

--- a/.github/workflows/doc_build.yml
+++ b/.github/workflows/doc_build.yml
@@ -31,7 +31,7 @@ jobs:
         setup_build_environment 3.13
 
         # Install PyTorch with CUDA support (matching build-cuda.yml)
-        pip install --pre torch --index-url https://download.pytorch.org/whl/nightly/cu126
+        pip install --pre torch --extra-index-url https://download.pytorch.org/whl/nightly/cu126
 
         # Setup Tensor Engine
         setup_tensor_engine

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -21,7 +21,7 @@ jobs:
         include:
           - name: 4xlarge
             runs-on: linux.g5.4xlarge.nvidia.gpu
-            torch-spec: '--pre torch --index-url https://download.pytorch.org/whl/cu128'
+            torch-spec: '--pre torch --extra-index-url https://download.pytorch.org/whl/cu128'
             gpu-arch-type: "cuda"
             gpu-arch-version: "12.8"
     uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main

--- a/.github/workflows/test-cpu-python.yml
+++ b/.github/workflows/test-cpu-python.yml
@@ -32,7 +32,7 @@ jobs:
         export USE_TENSOR_ENGINE=0
 
         # Install PyTorch nightly
-        pip install --pre torch --index-url https://download.pytorch.org/whl/nightly/cpu
+        pip install --pre torch --extra-index-url https://download.pytorch.org/whl/nightly/cpu
 
         # Install the built wheel from artifact
         install_wheel_from_artifact

--- a/.github/workflows/test-gpu-python.yml
+++ b/.github/workflows/test-gpu-python.yml
@@ -22,7 +22,7 @@ jobs:
         include:
           - name: 4xlargegpu
             runs-on: linux.g5.4xlarge.nvidia.gpu
-            torch-spec: '--pre torch --index-url https://download.pytorch.org/whl/nightly/cu126'
+            torch-spec: '--pre torch --extra-index-url https://download.pytorch.org/whl/nightly/cu126'
             gpu-arch-type: "cuda"
             gpu-arch-version: "12.6"
     with:

--- a/.github/workflows/test-gpu-rust.yml
+++ b/.github/workflows/test-gpu-rust.yml
@@ -22,7 +22,7 @@ jobs:
         include:
           - name: 4xlargegpu
             runs-on: linux.g5.4xlarge.nvidia.gpu
-            torch-spec: '--pre torch --index-url https://download.pytorch.org/whl/nightly/cu126'
+            torch-spec: '--pre torch --extra-index-url https://download.pytorch.org/whl/nightly/cu126'
             gpu-arch-type: "cuda"
             gpu-arch-version: "12.6"
     with:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -21,7 +21,7 @@ jobs:
         include:
           - name: 4xlarge
             runs-on: linux.g5.4xlarge.nvidia.gpu
-            torch-spec: '--pre torch --index-url https://download.pytorch.org/whl/nightly/cu126'
+            torch-spec: '--pre torch --extra-index-url https://download.pytorch.org/whl/nightly/cu126'
             gpu-arch-type: "cuda"
             gpu-arch-version: "12.6"
     uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main


### PR DESCRIPTION
Summary:
Testing approach get around `filelock` issue:

```
+ pip install --pre torch --index-url https://download.pytorch.org/whl/nightly/cu126
Looking in indexes: https://download.pytorch.org/whl/nightly/cu126
Collecting torch
  Downloading https://download.pytorch.org/whl/nightly/cu126/torch-2.11.0.dev20260120%2Bcu126-cp310-cp310-manylinux_2_28_x86_64.whl.metadata (30 kB)
WARNING: Retrying (Retry(total=4, connect=None, read=None, redirect=None, status=None)) after connection broken by 'ReadTimeoutError("HTTPSConnectionPool(host='download.pytorch.org', port=443): Read timed out. (read timeout=15)")': /whl/nightly/cu126/filelock/
WARNING: Retrying (Retry(total=3, connect=None, read=None, redirect=None, status=None)) after connection broken by 'ReadTimeoutError("HTTPSConnectionPool(host='download.pytorch.org', port=443): Read timed out. (read timeout=15)")': /whl/nightly/cu126/filelock/
WARNING: Retrying (Retry(total=2, connect=None, read=None, redirect=None, status=None)) after connection broken by 'ReadTimeoutError("HTTPSConnectionPool(host='download.pytorch.org', port=443): Read timed out. (read timeout=15)")': /whl/nightly/cu126/filelock/
WARNING: Retrying (Retry(total=1, connect=None, read=None, redirect=None, status=None)) after connection broken by 'ReadTimeoutError("HTTPSConnectionPool(host='download.pytorch.org', port=443): Read timed out. (read timeout=15)")': /whl/nightly/cu126/filelock/
WARNING: Retrying (Retry(total=0, connect=None, read=None, redirect=None, status=None)) after connection broken by 'ReadTimeoutError("HTTPSConnectionPool(host='download.pytorch.org', port=443): Read timed out. (read timeout=15)")': /whl/nightly/cu126/filelock/
INFO: pip is looking at multiple versions of torch to determine which version is compatible with other requirements. This could take a while.
  Downloading https://download.pytorch.org/whl/nightly/cu126/torch-2.11.0.dev20260119%2Bcu126-cp310-cp310-manylinux_2_28_x86_64.whl.metadata (30 kB)
  Downloading https://download.pytorch.org/whl/nightly/cu126/torch-2.11.0.dev20260118%2Bcu126-cp310-cp310-manylinux_2_28_x86_64.whl.metadata (30 kB)
  Downloading https://download.pytorch.org/whl/nightly/cu126/torch-2.11.0.dev20260117%2Bcu126-cp310-cp310-manylinux_2_28_x86_64.whl.metadata (30 kB)
  Downloading https://download.pytorch.org/whl/nightly/cu126/torch-2.11.0.dev20260116%2Bcu126-cp310-cp310-manylinux_2_28_x86_64.whl.metadata (30 kB)
  Downloading https://download.pytorch.org/whl/nightly/cu126/torch-2.11.0.dev20260115%2Bcu126-cp310-cp310-manylinux_2_28_x86_64.whl.metadata (30 kB)
  Downloading https://download.pytorch.org/whl/nightly/cu126/torch-2.11.0.dev20260114%2Bcu126-cp310-cp310-manylinux_2_28_x86_64.whl.metadata (30 kB)
  Downloading https://download.pytorch.org/whl/nightly/cu126/torch-2.11.0.dev20260113%2Bcu126-cp310-cp310-manylinux_2_28_x86_64.whl.metadata (30 kB)
INFO: pip is still looking at multiple versions of torch to determine which version is compatible with other requirements. This could take a while.
  Downloading https://download.pytorch.org/whl/nightly/cu126/torch-2.11.0.dev20260112%2Bcu126-cp310-cp310-manylinux_2_28_x86_64.whl.metadata (30 kB)
  Downloading https://download.pytorch.org/whl/nightly/cu126/torch-2.11.0.dev20260111%2Bcu126-cp310-cp310-manylinux_2_28_x86_64.whl.metadata (30 kB)
  Downloading https://download.pytorch.org/whl/nightly/cu126/torch-2.11.0.dev20260110%2Bcu126-cp310-cp310-manylinux_2_28_x86_64.whl.metadata (30 kB)
  Downloading https://download.pytorch.org/whl/nightly/cu126/torch-2.11.0.dev20260109%2Bcu126-cp310-cp310-manylinux_2_28_x86_64.whl.metadata (30 kB)
  Downloading https://download.pytorch.org/whl/nightly/cu126/torch-2.11.0.dev20260108%2Bcu126-cp310-cp310-manylinux_2_28_x86_64.whl.metadata (30 kB)
INFO: This is taking longer than usual. You might need to provide the dependency resolver with stricter constraints to reduce runtime. See https://pip.pypa.io/warnings/backtracking for guidance. If you want to abort this run, press Ctrl + C.
  File "/home/ec2-user/actions-runner/_work/monarch/monarch/test-infra/.github/scripts/run_with_env_secrets.py", line 39, in run_cmd_or_die
ERROR: Cannot install torch==2.10.0.dev20251116+cu126, torch==2.10.0.dev20251117+cu126, torch==2.10.0.dev20251118+cu126, torch==2.10.0.dev20251119+cu126, torch==2.10.0.dev20251120+cu126, torch==2.10.0.dev20251121+cu126, torch==2.10.0.dev20251122+cu126, torch==2.10.0.dev20251124+cu126, torch==2.10.0.dev20251201+cu126, torch==2.10.0.dev20251202+cu126, torch==2.10.0.dev20251203+cu126, torch==2.10.0.dev20251204+cu126, torch==2.10.0.dev20251205+cu126, torch==2.10.0.dev20251206+cu126, torch==2.10.0.dev20251207+cu126, torch==2.10.0.dev20251208+cu126, torch==2.10.0.dev20251209+cu126, torch==2.10.0.dev20251210+cu126, torch==2.10.0.dev20251212+cu126, torch==2.10.0.dev20251213+cu126, torch==2.11.0.dev20251214+cu126, torch==2.11.0.dev20251215+cu126, torch==2.11.0.dev20251216+cu126, torch==2.11.0.dev20251217+cu126, torch==2.11.0.dev20251218+cu126, torch==2.11.0.dev20251219+cu126, torch==2.11.0.dev20251220+cu126, torch==2.11.0.dev20251221+cu126, torch==2.11.0.dev20251222+cu126, torch==2.11.0.dev20251223+cu126, torch==2.11.0.dev20251224+cu126, torch==2.11.0.dev20251225+cu126, torch==2.11.0.dev20251226+cu126, torch==2.11.0.dev20251227+cu126, torch==2.11.0.dev20251228+cu126, torch==2.11.0.dev20251229+cu126, torch==2.11.0.dev20251230+cu126, torch==2.11.0.dev20251231+cu126, torch==2.11.0.dev20260101+cu126, torch==2.11.0.dev20260102+cu126, torch==2.11.0.dev20260103+cu126, torch==2.11.0.dev20260104+cu126, torch==2.11.0.dev20260105+cu126, torch==2.11.0.dev20260106+cu126, torch==2.11.0.dev20260107+cu126, torch==2.11.0.dev20260108+cu126, torch==2.11.0.dev20260109+cu126, torch==2.11.0.dev20260110+cu126, torch==2.11.0.dev20260111+cu126, torch==2.11.0.dev20260112+cu126, torch==2.11.0.dev20260113+cu126, torch==2.11.0.dev20260114+cu126, torch==2.11.0.dev20260115+cu126, torch==2.11.0.dev20260116+cu126, torch==2.11.0.dev20260117+cu126, torch==2.11.0.dev20260118+cu126, torch==2.11.0.dev20260119+cu126 and torch==2.11.0.dev20260120+cu126 because these package versions have conflicting dependencies.

The conflict is caused by:
    torch 2.11.0.dev20260120+cu126 depends on filelock
    torch 2.11.0.dev20260119+cu126 depends on filelock
    torch 2.11.0.dev20260118+cu126 depends on filelock
    torch 2.11.0.dev20260117+cu126 depends on filelock
    torch 2.11.0.dev20260116+cu126 depends on filelock
    torch 2.11.0.dev20260115+cu126 depends on filelock
    torch 2.11.0.dev20260114+cu126 depends on filelock
    torch 2.11.0.dev20260113+cu126 depends on filelock
    torch 2.11.0.dev20260112+cu126 depends on filelock
    torch 2.11.0.dev20260111+cu126 depends on filelock
    torch 2.11.0.dev20260110+cu126 depends on filelock
    torch 2.11.0.dev20260109+cu126 depends on filelock
    torch 2.11.0.dev20260108+cu126 depends on filelock
    torch 2.11.0.dev20260107+cu126 depends on filelock
    torch 2.11.0.dev20260106+cu126 depends on filelock
    torch 2.11.0.dev20260105+cu126 depends on filelock
    torch 2.11.0.dev20260104+cu126 depends on filelock
    torch 2.11.0.dev20260103+cu126 depends on filelock
    torch 2.11.0.dev20260102+cu126 depends on filelock
    torch 2.11.0.dev20260101+cu126 depends on filelock
    torch 2.11.0.dev20251231+cu126 depends on filelock
    torch 2.11.0.dev20251230+cu126 depends on filelock
    torch 2.11.0.dev20251229+cu126 depends on filelock
    torch 2.11.0.dev20251228+cu126 depends on filelock
    torch 2.11.0.dev20251227+cu126 depends on filelock
    torch 2.11.0.dev20251226+cu126 depends on filelock
    torch 2.11.0.dev20251225+cu126 depends on filelock
    torch 2.11.0.dev20251224+cu126 depends on filelock
    torch 2.11.0.dev20251223+cu126 depends on filelock
    torch 2.11.0.dev20251222+cu126 depends on filelock
    torch 2.11.0.dev20251221+cu126 depends on filelock
    torch 2.11.0.dev20251220+cu126 depends on filelock
    torch 2.11.0.dev20251219+cu126 depends on filelock
    torch 2.11.0.dev20251218+cu126 depends on filelock
    torch 2.11.0.dev20251217+cu126 depends on filelock
    torch 2.11.0.dev20251216+cu126 depends on filelock
    torch 2.11.0.dev20251215+cu126 depends on filelock
    torch 2.11.0.dev20251214+cu126 depends on filelock
    torch 2.10.0.dev20251213+cu126 depends on filelock
    torch 2.10.0.dev20251212+cu126 depends on filelock
    torch 2.10.0.dev20251210+cu126 depends on filelock
    torch 2.10.0.dev20251209+cu126 depends on filelock
    torch 2.10.0.dev20251208+cu126 depends on filelock
    torch 2.10.0.dev20251207+cu126 depends on filelock
    torch 2.10.0.dev20251206+cu126 depends on filelock
    torch 2.10.0.dev20251205+cu126 depends on filelock
    torch 2.10.0.dev20251204+cu126 depends on filelock
    torch 2.10.0.dev20251203+cu126 depends on filelock
    torch 2.10.0.dev20251202+cu126 depends on filelock
    torch 2.10.0.dev20251201+cu126 depends on filelock
    torch 2.10.0.dev20251124+cu126 depends on filelock
    torch 2.10.0.dev20251122+cu126 depends on filelock
    torch 2.10.0.dev20251121+cu126 depends on filelock
    torch 2.10.0.dev20251120+cu126 depends on filelock
    torch 2.10.0.dev20251119+cu126 depends on filelock
    torch 2.10.0.dev20251118+cu126 depends on filelock
    torch 2.10.0.dev20251117+cu126 depends on filelock
    torch 2.10.0.dev20251116+cu126 depends on filelock

Additionally, some packages in these conflicts have no matching distributions available for your environment:
    filelock

To fix this you could try to:
1. loosen the range of package versions you've specified
2. remove package versions to allow pip to attempt to solve the dependency conflict
```

Differential Revision: D91071183


