### PR TITLE
Fix actor log filter breaking torch.compile structured logging

### DIFF
--- a/python/tests/test_actor_logging.py
+++ b/python/tests/test_actor_logging.py
@@ -7,6 +7,7 @@
 # pyre-unsafe
 
 import asyncio
+import io
 import logging
 import os
 import re
@@ -67,6 +68,31 @@ class Logger(Actor):
         self._logger.error(f"{content}")
         self._stdout_handler.flush()
         self._stderr_handler.flush()
+
+    @endpoint
+    async def log_structured(self) -> dict:
+        """
+        Log with empty message like torch.compile's trace_structured does.
+
+        torch uses: logger.debug("") with structured data in record attributes.
+        The actor filter must not modify empty messages.
+        """
+        output = io.StringIO()
+        handler = logging.StreamHandler(output)
+        handler.setFormatter(logging.Formatter("%(message)s"))
+
+        logger = logging.getLogger("test.structured")
+        logger.setLevel(logging.DEBUG)
+        logger.addHandler(handler)
+
+        try:
+            # Log with empty message like torch does
+            logger.debug("")
+        finally:
+            logger.removeHandler(handler)
+
+        captured = output.getvalue().strip()
+        return {"captured": captured, "is_empty": captured == ""}
 
 
 @pytest.mark.timeout(60)
@@ -134,3 +160,21 @@ async def test_actor_logging_smoke() -> None:
             os.unlink(stderr_path)
         except OSError:
             pass
+
+
+@pytest.mark.timeout(60)
+async def test_structured_logging():
+    """
+    Tests that empty-message logging works correctly in actors.
+
+    torch.compile uses empty messages for structured trace logging.
+    The actor filter must not modify empty messages, or torch's
+    formatter fails with "expected empty string for trace".
+    """
+    pm = this_host().spawn_procs()
+    actor = pm.spawn("logger", Logger)
+    result = await actor.log_structured.call_one()
+
+    assert result["is_empty"], (
+        f"Actor prefix corrupted empty message: got {result['captured']!r}"
+    )


### PR DESCRIPTION
Summary:
`torch.compile` uses empty log messages for structured trace logging
  (e.g., `logger.debug("")`). Monarch's `_ActorFilter` was unconditionally
  prepending `[actor=...]` to all messages, which caused torch's formatter
  to fail with "expected empty string for trace".

The fix only adds the actor prefix when:
- `record.msg` is non-empty (empty messages are used for structured logging)
- `record.args` is empty (non-empty args means msg is a format string)

An example of a failure I was seeing:

```
"/workspace/job/.venv/lib/python3.12/site-packages/torch/_dynamo/guards.py", line 
  3965, in __init__                                                                           
  torch._logging.trace_structured(                                                            
  File "/root/.local/share/uv/python/cpython-3.12.12-linux-x86_64-gnu/lib/python3.12/loggin   
  g/__init__.py", line 1762, in callHandlers                                                  
  hdlr.handle(record)                                                                         
  File                                                                                        
  "/workspace/workload/.venv/lib/python3.12/site-packages/torch/_logging/_internal.py",  
  line 1476, in trace_structured                                                              
  trace_log.debug(                                                                            
  File "/root/.local/share/uv/python/cpython-3.12.12-linux-x86_64-gnu/lib/python3.12/loggin   
  g/__init__.py", line 1028, in handle                                                        
  self.emit(record)                                                                           
  File "/root/.local/share/uv/python/cpython-3.12.12-linux-x86_64-gnu/lib/python3.12/loggin   
  g/__init__.py", line 1527, in debug                                                         
  self._log(DEBUG, msg, args, **kwargs)                                                       
  File                                                                                        
  "/workspace/sixlib_sample/.venv/lib/python3.12/site-packages/torch/_logging/_internal.py",  
  line 1266, in emit                                                                          
  super().emit(record)                                                                        
  File "/root/.local/share/uv/python/cpython-3.12.12-linux-x86_64-gnu/lib/python3.12/loggin   
  g/__init__.py", line 1684, in _log                                                          
  self.handle(record)                                                                         
  Message: "[actor=<root>.<monarch._src.spmd.actor.SPMDActor trainer{'hosts': 1/2, 'gpus':    
  5/8}>] "                                                                                    
  Arguments: ()                                                                               
  File "/root/.local/share/uv/python/cpython-3.12.12-linux-x86_64-gnu/lib/python3.12/loggin   
  g/__init__.py", line 1700, in handle                                                        
  self.callHandlers(record)                                                                   
  File "/root/.local/share/uv/python/cpython-3.12.12-linux-x86_64-gnu/lib/python3.12/loggin   
  g/__init__.py", line 1762, in callHandlers                                                  
  hdlr.handle(record)                                                                         
  File "/root/.local/share/uv/python/cpython-3.12.12-linux-x86_64-gnu/lib/python3.12/loggin   
  g/__init__.py", line 1028, in handle                                                        
  self.emit(record)                                                                           
  File                                                                                        
  "/workspace/sixlib_sample/.venv/lib/python3.12/site-packages/torch/_logging/_internal.py",  
  line 1266, in emit                                                                          
  super().emit(record)                                                                        
  Message: "[actor=<root>.<monarch._src.spmd.actor.SPMDActor trainer{'hosts': 1/2, 'gpus':    
  1/8}>] "                                                                                    
  Arguments: ()                                          
```

Differential Revision: D91063587


