### PR TITLE
Actually enable GPU direct RDMA

### DIFF
--- a/monarch_rdma/extension/Cargo.toml
+++ b/monarch_rdma/extension/Cargo.toml
@@ -17,6 +17,7 @@ hyperactor = { version = "0.0.0", path = "../../hyperactor" }
 hyperactor_mesh = { version = "0.0.0", path = "../../hyperactor_mesh" }
 monarch_hyperactor = { version = "0.0.0", path = "../../monarch_hyperactor" }
 monarch_rdma = { version = "0.0.0", path = ".." }
+monarch_types = { version = "0.0.0", path = "../../monarch_types" }
 pyo3 = { version = "0.24", features = ["anyhow", "multiple-pymethods", "py-clone"] }
 serde = { version = "1.0.219", features = ["derive", "rc"] }
 serde_json = { version = "1.0.140", features = ["alloc", "float_roundtrip", "raw_value", "unbounded_depth"] }

--- a/monarch_rdma/src/rdma_components.rs
+++ b/monarch_rdma/src/rdma_components.rs
@@ -1415,7 +1415,7 @@ impl RdmaQueuePair {
 ///
 /// * `Ok(())` if the execution context is valid
 /// * `Err(anyhow::Error)` if the execution context is invalid
-pub async fn validate_execution_context() -> Result<(), anyhow::Error> {
+pub fn validate_execution_context() -> Result<(), anyhow::Error> {
     // Check for nvidia peermem
     match fs::read_to_string("/proc/modules") {
         Ok(contents) => {

--- a/monarch_rdma/src/rdma_manager_actor.rs
+++ b/monarch_rdma/src/rdma_manager_actor.rs
@@ -497,7 +497,7 @@ impl RemoteSpawn for RdmaManagerActor {
 
         // check config and hardware support align
         if config.use_gpu_direct {
-            match validate_execution_context().await {
+            match validate_execution_context() {
                 Ok(_) => {
                     tracing::info!("GPU Direct RDMA execution context validated successfully");
                 }

--- a/monarch_rdma/src/rdma_manager_actor_tests.rs
+++ b/monarch_rdma/src/rdma_manager_actor_tests.rs
@@ -304,8 +304,8 @@ mod tests {
     }
 
     // Helper function to check if GPU supports P2P
-    async fn does_gpu_support_p2p() -> bool {
-        validate_execution_context().await.is_ok()
+    fn does_gpu_support_p2p() -> bool {
+        validate_execution_context().is_ok()
     }
 
     // Test that RDMA write can be performed between two actors on separate devices with CUDA.
@@ -315,7 +315,7 @@ mod tests {
             println!("Skipping CUDA test in CPU-only mode");
             return Ok(());
         }
-        if !does_gpu_support_p2p().await {
+        if !does_gpu_support_p2p() {
             println!("Skipping test: GPU P2P not supported");
             return Ok(());
         }
@@ -338,7 +338,7 @@ mod tests {
             )
             .await?;
         qp_1.enqueue_put(env.rdma_handle_1.clone(), env.rdma_handle_2.clone())?;
-        ring_db_gpu(&mut qp_1).await?;
+        ring_db_gpu(&qp_1).await?;
         // Poll for completion
         wait_for_completion_gpu(&mut qp_1, PollTarget::Send, 5).await?;
 
@@ -354,7 +354,7 @@ mod tests {
             println!("Skipping CUDA test in CPU-only mode");
             return Ok(());
         }
-        if !does_gpu_support_p2p().await {
+        if !does_gpu_support_p2p() {
             println!("Skipping test: GPU P2P not supported");
             return Ok(());
         }
@@ -392,7 +392,7 @@ mod tests {
             println!("Skipping CUDA test in CPU-only mode");
             return Ok(());
         }
-        if !does_gpu_support_p2p().await {
+        if !does_gpu_support_p2p() {
             println!("Skipping test: GPU P2P not supported");
             return Ok(());
         }
@@ -437,7 +437,7 @@ mod tests {
             rdmaxcel_sys::MLX5_OPCODE_RDMA_WRITE_IMM,
         )
         .await?;
-        ring_db_gpu(&mut qp_2).await?;
+        ring_db_gpu(&qp_2).await?;
         wait_for_completion_gpu(&mut qp_1, PollTarget::Send, 10).await?;
         wait_for_completion_gpu(&mut qp_2, PollTarget::Send, 10).await?;
         env.verify_buffers(BSIZE, 0).await?;

--- a/monarch_rdma/src/test_utils.rs
+++ b/monarch_rdma/src/test_utils.rs
@@ -541,7 +541,7 @@ pub mod test_utils {
         let parsed_idx = idx.parse::<usize>().unwrap();
 
         if backend == "cuda" {
-            config.use_gpu_direct = validate_execution_context().await.is_ok();
+            config.use_gpu_direct = validate_execution_context().is_ok();
             eprintln!("Using GPU Direct: {}", config.use_gpu_direct);
         }
 

--- a/monarch_types/src/lib.rs
+++ b/monarch_types/src/lib.rs
@@ -38,6 +38,16 @@ macro_rules! py_global {
     };
 }
 
+/// Macro to register a function to a Python module.
+#[macro_export]
+macro_rules! py_module_add_function {
+    ($mod:ident, $mod_name:literal, $fn:ident) => {
+        let f = pyo3::wrap_pyfunction!($fn, $mod)?;
+        f.setattr("__module__", $mod_name)?;
+        $mod.add_function(f)?;
+    };
+}
+
 pub trait MapPyErr<T> {
     fn map_pyerr(self) -> Result<T, PyErr>;
 }

--- a/python/monarch/_rust_bindings/rdma.pyi
+++ b/python/monarch/_rust_bindings/rdma.pyi
@@ -13,15 +13,45 @@ from monarch._rust_bindings.monarch_hyperactor.pytokio import PythonTask
 class _RdmaMemoryRegionView:
     def __init__(self, addr: int, size_in_bytes: int) -> None: ...
 
+def gpu_direct_rdma_supported() -> bool: ...
+@final
+class _IbverbsConfig:
+    use_gpu_direct: bool
+    cq_entries: int
+    max_send_wr: int
+    max_recv_wr: int
+    max_send_sge: int
+    max_recv_sge: int
+    retry_cnt: int
+    rnr_retry: int
+    qp_timeout: int
+    hw_init_delay_ms: int
+
+    def __init__(
+        self,
+        use_gpu_direct: bool = False,
+        cq_entries: int | None = None,
+        max_send_wr: int | None = None,
+        max_recv_wr: int | None = None,
+        max_send_sge: int | None = None,
+        max_recv_sge: int | None = None,
+        retry_cnt: int | None = None,
+        rnr_retry: int | None = None,
+        qp_timeout: int | None = None,
+        hw_init_delay_ms: int | None = None,
+    ) -> None: ...
+    def __repr__(self) -> str: ...
+
 @final
 class _RdmaManager:
     device: str
     def __repr__(self) -> str: ...
     @classmethod
     def create_rdma_manager_nonblocking(
-        self,
+        cls,
         proc_mesh: Any,
         client: Any,
+        config: _IbverbsConfig,
     ) -> PythonTask[_RdmaManager | None]: ...
 
 @final

--- a/python/monarch/_src/rdma/rdma.py
+++ b/python/monarch/_src/rdma/rdma.py
@@ -18,7 +18,7 @@ from monarch._src.actor.proc_mesh import ProcMesh
 from typing_extensions import Self
 
 try:
-    from monarch._rust_bindings.rdma import _RdmaBuffer, _RdmaManager
+    from monarch._rust_bindings.rdma import _IbverbsConfig, _RdmaBuffer, _RdmaManager
 except ImportError as e:
     logging.error("RDMA is not available: {}".format(e))
     raise e
@@ -136,7 +136,11 @@ class RdmaController(Actor):
                 )
                 return none_throws(
                     await _RdmaManager.create_rdma_manager_nonblocking(
-                        proc_mesh_result, context().actor_instance
+                        proc_mesh_result,
+                        context().actor_instance,
+                        # Always use GPU direct RDMA if it's available on the target nodes.
+                        # It will fall back to standard CPU RDMA if GPU direct is not available.
+                        _IbverbsConfig(use_gpu_direct=True),
                     )
                 )
 

--- a/python/monarch/actor/__init__.py
+++ b/python/monarch/actor/__init__.py
@@ -12,6 +12,7 @@ Monarch Actor API - Public interface for actor functionality.
 from monarch._rust_bindings.monarch_hyperactor.channel import ChannelTransport
 from monarch._rust_bindings.monarch_hyperactor.shape import Extent
 from monarch._rust_bindings.monarch_hyperactor.supervision import MeshFailure
+from monarch._rust_bindings.rdma import gpu_direct_rdma_supported
 from monarch._src.actor import config
 from monarch._src.actor.actor_mesh import (
     Accumulator,
@@ -90,4 +91,5 @@ __all__ = [
     "unhandled_fault_hook",
     "MeshFailure",
     "config",
+    "gpu_direct_rdma_supported",
 ]


### PR DESCRIPTION
Summary:
Even though GPU direct rdma capabilities were added to the rust layer, it was never plumbed through python, which always passed a `None` ibverbs config to the rdma manager actor, which would then use the default `use_gpu_direct = false`. This PR ensures we pass `use_gpu_direct = true` to the rdma manager actor from python, and more generally enables configuring the full ibverbs config from python.

As a bonus, this also adds/exposes the `monarch.actor.gpu_direct_rdma_supported()` function in python so that users can quickly verify if GPU direct rdma is supported on their machine.

Differential Revision: D91157556


