### PR TITLE
Copy CAST_ACTOR_MESH_ID for all cast hops

### DIFF
--- a/hyperactor_mesh/src/actor_mesh.rs
+++ b/hyperactor_mesh/src/actor_mesh.rs
@@ -139,10 +139,13 @@ where
         "message_variant" => message.arm().unwrap_or_default(),
     ));
 
+    let mut header_props = Attrs::new();
+    header_props.set(CAST_ACTOR_MESH_ID, actor_mesh_id.clone());
     let message = CastMessageEnvelope::new::<A, M>(
-        actor_mesh_id.clone(),
+        actor_mesh_id,
         cx.mailbox().actor_id().clone(),
         cast_mesh_shape.clone(),
+        header_props.clone(),
         message,
     )?;
 
@@ -180,12 +183,10 @@ where
         message,
     };
 
-    let mut headers = Attrs::new();
-    headers.set(CAST_ACTOR_MESH_ID, actor_mesh_id);
-
+    // header_props needs to be set for source->comm message too.
     comm_actor_ref
         .port()
-        .send_with_headers(cx, headers, cast_message)?;
+        .send_with_headers(cx, header_props, cast_message)?;
 
     Ok(())
 }


### PR DESCRIPTION
Summary:
Two changes:

1. this diff makes sure the `CAST_ACTOR_MESH_ID` header will be copied during comm->comm hop, i.e. through `ForwardMessage`;
2. in the final delivery, i.e. comm->dest, we should not copy headers from `ForwardMessage`. Instead, for any headers we want to pass from `source` actor, we should do that via `set_cast_info_on_headers`.
  * this was the original change which started to copy the old header. The diff does not offer [any explanation](https://www.internalfb.com/diff/D77341169?dst_version_fbid=707456142209082&transaction_fbid=1364688811650957).

Differential Revision: D91170370


