### PR TITLE
make Python::with_gil nonblocking in async functions

### DIFF
--- a/monarch_extension/src/client.rs
+++ b/monarch_extension/src/client.rs
@@ -14,6 +14,7 @@ use monarch_hyperactor::proc::InstanceWrapper;
 use monarch_hyperactor::proc::PyActorId;
 use monarch_hyperactor::proc::PyProc;
 use monarch_hyperactor::proc::PySerialized;
+use monarch_hyperactor::runtime::monarch_with_gil_blocking;
 use monarch_hyperactor::runtime::signal_safe_block_on;
 use monarch_messages::client::ClientMessage;
 use monarch_messages::client::Exception;
@@ -445,7 +446,7 @@ impl ClientActor {
             instance.lock().await.next_message(timeout_msec).await
         })?;
 
-        Python::with_gil(|py| match result {
+        monarch_with_gil_blocking(|py| match result {
             Ok(Some(ClientMessage::Result { seq, result })) => {
                 WorkerResponse { seq, result }.into_py_any(py)
             }

--- a/python/monarch/_rust_bindings/monarch_hyperactor/v1/actor_mesh.pyi
+++ b/python/monarch/_rust_bindings/monarch_hyperactor/v1/actor_mesh.pyi
@@ -1,0 +1,20 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+def hold_gil_for_test(delay_secs: float, hold_secs: float) -> None:
+    """
+    Test utility that holds the GIL for a specified duration.
+
+    This spawns a background thread that waits for `delay_secs` before
+    acquiring the Python GIL, then holds it for `hold_secs`.
+
+    Args:
+        delay_secs: Seconds to wait before acquiring the GIL
+        hold_secs: Seconds to hold the GIL
+    """
+    ...

--- a/python/monarch/_src/actor/logging.py
+++ b/python/monarch/_src/actor/logging.py
@@ -175,3 +175,16 @@ class LoggingManager:
             # accessing shared resources via logging_mesh_client. Flush works fine
             # but shared resource management under loggingMeshClient needs to be investigated
             pass
+
+    async def flush_async(self) -> None:
+        """Async version of flush for use in async contexts."""
+        if self._logging_mesh_client is None:
+            return
+        try:
+            await (
+                self._logging_mesh_client.flush(context().actor_instance._as_rust())
+                .spawn()
+                .task()
+            )
+        except Exception:
+            pass

--- a/python/monarch/_src/actor/proc_mesh.py
+++ b/python/monarch/_src/actor/proc_mesh.py
@@ -567,7 +567,7 @@ class ProcMesh(MeshTrait):
 
         async def _stop_nonblocking(instance: HyInstance) -> None:
             pm = await self._proc_mesh
-            await PythonTask.spawn_blocking(lambda: self._logging_manager.flush())
+            await self._logging_manager.flush_async()
             await pm.stop_nonblocking(instance)
             self._stopped = True
 


### PR DESCRIPTION
Summary:
Context: https://fb.workplace.com/groups/1434680487636162/posts/1485249462579264

This diff implements the Async Lock idea mentioned in the post. It makes async functions non-blocking, sync functions are still blocking.

This is done by introducing two functions `monarch_with_gil` and `monarch_with_gil_blocking`
* async functions should use `monarch_with_gil`
* sync functions should use `monarch_with_gil_blocking`

Note, this is a short term solution to avoid the blocking issue as much as we can. We proper long-term solution will come after this, which is also briefly discussed in the comments of the post.

Reviewed By: shayne-fletcher

Differential Revision: D89026961


