### PR TITLE
Use SmallVec for storing trace fields

### DIFF
--- a/hyperactor_telemetry/Cargo.toml
+++ b/hyperactor_telemetry/Cargo.toml
@@ -15,7 +15,6 @@ erased-serde = "0.4.9"
 fbinit = { version = "0.2.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main" }
 hdrhistogram = "7.5"
 hyperactor_config = { version = "0.0.0", path = "../hyperactor_config" }
-indexmap = { version = "2.9.0", features = ["arbitrary", "rayon", "serde"] }
 lazy_static = "1.5"
 libc = "0.2.139"
 opentelemetry = "0.29"
@@ -27,6 +26,7 @@ scuba = { version = "0.1.0", git = "https://github.com/facebookexperimental/rust
 serde = { version = "1.0.219", features = ["derive", "rc"] }
 serde_json = { version = "1.0.140", features = ["alloc", "float_roundtrip", "raw_value", "unbounded_depth"] }
 serde_rusqlite = "0.40.1"
+smallvec = { version = "1.15", features = ["impl_bincode", "serde", "specialization", "union"] }
 smol_str = "0.1.22"
 tokio = { version = "1.47.1", features = ["full", "test-util", "tracing"] }
 tracing = { version = "0.1.41", features = ["attributes", "valuable"] }

--- a/hyperactor_telemetry/src/sinks/sqlite.rs
+++ b/hyperactor_telemetry/src/sinks/sqlite.rs
@@ -154,7 +154,7 @@ impl SqliteSink {
                     FieldValue::Str(s) => JValue::String(s.clone()),
                     FieldValue::Debug(d) => JValue::String(d.clone()),
                 };
-                visitor.0.insert(key.clone(), json_value);
+                visitor.0.insert(key.to_string(), json_value);
             }
 
             let table = if &**target == sqlite::TableName::ACTOR_LIFECYCLE_STR {


### PR DESCRIPTION
Summary:
# Stack summary
This stack is a series of diffs in which we attempt to optimize what happens in `on_new_span` `on_enter` `on_exit` `on_event` and `on_close` as these happen on the application thread and we want tracing to get off of the application thread as soon as possible.

Final comparisons for times spent on the 5 methods here:
 {F1984839578} 

Times were measured by counting cpu clock cycles using `core::arch::x86_64::_rdtsc()`

`process_state_span`: https://fburl.com/code/duqwv5al and `state_span`: https://fburl.com/code/7g9667wf used to instrument our tcp channel loops were commented out during measurement as these have fields with extreme tail latency (30us) when recording

================================================

# Diff summary
Most traces should have very few fields so stack allocating is better here
{F1984836734}
{F1984836741}

Differential Revision: D91182937


