### PR TITLE
Use rtrb instead of mpsc for sending events to background thread

### DIFF
--- a/hyperactor_telemetry/Cargo.toml
+++ b/hyperactor_telemetry/Cargo.toml
@@ -21,6 +21,7 @@ opentelemetry = "0.29"
 opentelemetry_sdk = { version = "0.29.0", features = ["rt-tokio"] }
 prost = { version = "0.13.4", default-features = false }
 rand = { version = "0.9", features = ["small_rng"] }
+rtrb = "0.3"
 rusqlite = { version = "0.37.0", features = ["backup", "blob", "bundled", "column_decltype", "functions", "limits", "modern_sqlite", "serde_json"] }
 scuba = { version = "0.1.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main" }
 serde = { version = "1.0.219", features = ["derive", "rc"] }


### PR DESCRIPTION
Summary:
# Stack summary
This stack is a series of diffs in which we attempt to optimize what happens in `on_new_span` `on_enter` `on_exit` `on_event` and `on_close` as these happen on the application thread and we want tracing to get off of the application thread as soon as possible.

Final comparisons for times spent on the 5 methods here:
 {F1984839578} 

Times were measured by counting cpu clock cycles using `core::arch::x86_64::_rdtsc()`

`process_state_span`: https://fburl.com/code/duqwv5al and `state_span`: https://fburl.com/code/7g9667wf used to instrument our tcp channel loops were commented out during measurement as these have fields with extreme tail latency (30us) when recording

================

# Diff summary

Sending with a per-thread ring buffer is much faster than mpsc
{F1984837217}

Differential Revision: D91182935


