### PR TITLE
Derive max_level from sinks in TraceEventDispatcher

### DIFF
--- a/hyperactor_telemetry/src/lib.rs
+++ b/hyperactor_telemetry/src/lib.rs
@@ -688,14 +688,11 @@ fn initialize_logging_with_log_prefix_impl(
                 file_log_level,
             )));
 
-            let mut max_level = None;
-
             let sqlite_enabled = hyperactor_config::global::get(ENABLE_SQLITE_TRACING);
 
             if sqlite_enabled {
                 match create_sqlite_sink() {
                     Ok(sink) => {
-                        max_level = Some(tracing::level_filters::LevelFilter::TRACE);
                         sinks.push(Box::new(sink));
                     }
                     Err(e) => {
@@ -716,7 +713,6 @@ fn initialize_logging_with_log_prefix_impl(
                     &process_name,
                 ) {
                     Ok(sink) => {
-                        max_level = Some(tracing::level_filters::LevelFilter::TRACE);
                         sinks.push(Box::new(sink));
                     }
                     Err(e) => {
@@ -761,9 +757,7 @@ fn initialize_logging_with_log_prefix_impl(
                 } else {
                     None
                 })
-                .with(trace_dispatcher::TraceEventDispatcher::new(
-                    sinks, max_level,
-                ))
+                .with(trace_dispatcher::TraceEventDispatcher::new(sinks))
                 .try_init()
             {
                 tracing::debug!("logging already initialized for this process: {}", err);
@@ -891,13 +885,11 @@ fn initialize_logging_with_log_prefix_impl(
         if use_unified {
             let mut sinks: Vec<Box<dyn trace_dispatcher::TraceEventSink>> = Vec::new();
 
-            let mut max_level = None;
             let sqlite_enabled = hyperactor_config::global::get(ENABLE_SQLITE_TRACING);
 
             if sqlite_enabled {
                 match create_sqlite_sink() {
                     Ok(sink) => {
-                        max_level = Some(tracing::level_filters::LevelFilter::TRACE);
                         sinks.push(Box::new(sink));
                     }
                     Err(e) => {
@@ -913,9 +905,7 @@ fn initialize_logging_with_log_prefix_impl(
             )));
 
             if let Err(err) = registry
-                .with(trace_dispatcher::TraceEventDispatcher::new(
-                    sinks, max_level,
-                ))
+                .with(trace_dispatcher::TraceEventDispatcher::new(sinks))
                 .try_init()
             {
                 tracing::debug!("logging already initialized for this process: {}", err);


### PR DESCRIPTION
Summary:
Previously, lib.rs manually tracked max_level when adding sinks. This change
moves that logic into TraceEventDispatcher by having sinks declare their
desired level via a new `max_level_hint()` method on the TraceEventSink trait.

PerfettoFileSink now returns the level from MONARCH_FILE_LOG_LEVEL config,
matching the behavior in the meta scuba tracing layer.

Differential Revision: D91157349


