### PR TITLE
Standardize dest logging field in channel

### DIFF
--- a/hyperactor/src/channel/net.rs
+++ b/hyperactor/src/channel/net.rs
@@ -165,7 +165,7 @@ impl<M: RemoteMessage> Rx<M> for NetRx<M> {
     async fn recv(&mut self) -> Result<M, ChannelError> {
         tracing::trace!(
             name = "recv",
-            source = %self.1,
+            dest = %self.1,
             "receiving message"
         );
         self.0.recv().await.ok_or(ChannelError::Closed)

--- a/hyperactor/src/channel/net/server.rs
+++ b/hyperactor/src/channel/net/server.rs
@@ -694,7 +694,7 @@ where
                         let source : ChannelAddr = addr.into();
                         tracing::debug!(
                             source = %source,
-                            addr = %listener_channel_addr,
+                            dest = %listener_channel_addr,
                             "new connection accepted"
                         );
                         metrics::CHANNEL_CONNECTIONS.add(
@@ -760,7 +760,7 @@ where
                         );
 
                         tracing::info!(
-                            addr = %listener_channel_addr,
+                            dest = %listener_channel_addr,
                             error = %err,
                             "accept error"
                         );
@@ -770,7 +770,7 @@ where
 
             _ = parent_cancel_token.cancelled() => {
                 tracing::info!(
-                    addr = %listener_channel_addr,
+                    dest = %listener_channel_addr,
                     "received parent token cancellation"
                 );
                 break Ok(());
@@ -779,7 +779,7 @@ where
             result = join_nonempty(&mut connections) => {
                 if let Err(err) = result {
                     tracing::info!(
-                        addr = %listener_channel_addr,
+                        dest = %listener_channel_addr,
                         error = %err,
                         "connection task join error"
                     );
@@ -829,7 +829,7 @@ impl ServerHandle {
     pub(crate) fn stop(&self, reason: &str) {
         tracing::info!(
             name = "ChannelServerStatus",
-            addr = %self.channel_addr,
+            dest = %self.channel_addr,
             status = "Stop::Sent",
             reason,
             "sent Stop signal; check server logs for the stop progress"


### PR DESCRIPTION
Summary:
Net channel has 2 halves, Tx and Rx. For logs related to both halves, two fields are very important, the client's address, and the server's address.

In Tx, we use `dest` for server address:

https://www.internalfb.com/code/fbsource/[15977d7b2d7c3ec3116ad9f7ab61f129b29a4e56]/fbcode/monarch/hyperactor/src/channel/net/client.rs?lines=903-904

We want to do the same for the Rx side.

This will make it much easier to filter logs in scuba based a tcp server address.

Differential Revision: D91189836


