### PR TITLE
Migrate Monarch code from MastProdCluster to MastGenAICluster

### DIFF
--- a/python/monarch/_src/job/spmd.py
+++ b/python/monarch/_src/job/spmd.py
@@ -197,7 +197,7 @@ def serve(
         job = serve(
             appdef=appdef("--lr", "0.001", h="gtt_any", nnodes=2),
             scheduler="mast_conda",
-            scheduler_cfg={"hpcClusterUuid": "MastProdCluster"}
+            scheduler_cfg={"hpcClusterUuid": "MastGenAICluster"}
         )
     """
     # Clean up stale job state file


### PR DESCRIPTION
Summary:
The MAST-MSL fork has enforced tenant tree separation via the filter_tenant_tree_by_shard JustKnob on RC tier.

The pytorch_distributed identity is now on the GenAI/MSL tier, so all references to MastProdCluster need to be updated to MastGenAICluster.

Differential Revision: D91244274


