### PR TITLE
Add DDP example for Kubernetes

### DIFF
--- a/examples/kubernetes/ddp/README.md
+++ b/examples/kubernetes/ddp/README.md
@@ -1,0 +1,142 @@
+# Distributed Data Parallel (DDP) on Kubernetes
+
+This example demonstrates how to run PyTorch Distributed Data Parallel (DDP) training on Kubernetes using Monarch's `KubernetesJob` and the MonarchMesh CRD.
+
+## Overview
+
+The example:
+- Provisions GPU-enabled worker pods using the MonarchMesh CRD
+- Connects to the workers using `KubernetesJob`
+- Runs a basic DDP training loop across multiple GPUs and hosts
+
+## Prerequisites
+
+- Kubernetes cluster with:
+  - [Monarch CRD and operator](https://github.com/meta-pytorch/monarch-kubernetes/) installed
+  - GPU nodes with `nvidia.com/gpu` resources
+  - NVIDIA device plugin deployed
+- `kubectl` configured to access the cluster
+- The `monarch-tests` namespace created:
+  ```bash
+  kubectl create namespace monarch-tests
+  ```
+
+## Configuration
+
+### Adjusting Resources
+
+Edit `ddp_mesh.yaml` to match your cluster's GPU configuration:
+
+```yaml
+# Number of worker pods (hosts)
+spec:
+  replicas: 2  # Change to your desired number of hosts
+
+# GPUs per pod
+resources:
+  limits:
+    nvidia.com/gpu: 4  # Change to match available GPUs per node
+  requests:
+    nvidia.com/gpu: 4
+```
+
+Update the script arguments to match:
+
+```bash
+python kubernetes_ddp.py --num_hosts 2 --gpus_per_host 4 --mesh_name ddpmesh
+```
+
+Arguments:
+- `--num_hosts`: Must match `spec.replicas` in YAML
+- `--gpus_per_host`: Must match `nvidia.com/gpu` in YAML
+- `--mesh_name`: Must match `metadata.name` in YAML
+
+## Deployment
+
+### 1. Deploy the MonarchMesh and Controller
+
+```bash
+kubectl apply -f manifests/ddp_mesh.yaml
+```
+
+### 2. Verify Pods are Running
+
+```bash
+# Check worker pods
+kubectl get pods -n monarch-tests -l app.kubernetes.io/name=monarch-worker
+
+# Check controller pod
+kubectl get pods -n monarch-tests ddp-controller
+```
+
+Wait for all pods to show `Running` status.
+
+### 3. Run the DDP Example
+
+Copy and execute the script from the controller pod:
+
+```bash
+# Copy the script to the controller
+kubectl cp kubernetes_ddp.py monarch-tests/ddp-controller:/tmp/kubernetes_ddp.py
+
+# Get a shell into the controller
+kubectl exec -it ddp-controller -n monarch-tests -- /bin/bash
+
+# Inside the controller, run the DDP example
+python /tmp/kubernetes_ddp.py --num_hosts 2 --gpus_per_host 4
+```
+
+Or run directly without shell:
+
+```bash
+kubectl exec -it ddp-controller -n monarch-tests -- python /tmp/kubernetes_ddp.py
+```
+
+## Expected Output
+
+```bash
+kubectl logs -n monarch-tests -l app.kubernetes.io/name=monarch-worker
+```
+
+Expected output:
+```
+self.rank=0 Initializing torch distributed
+self.rank=1 Initializing torch distributed
+...
+self.rank=0 Finished initializing torch distributed
+self.rank=0 Running basic DDP example
+self.rank=0 local_rank=0
+...
+self.rank=0 Finished running basic DDP example
+```
+
+## Cleanup
+
+```bash
+kubectl delete -f manifests/ddp_mesh.yaml
+```
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                    Kubernetes Cluster                       │
+│                                                             │
+│  ┌──────────────┐                                           │
+│  │  Controller  │  ← Runs KubernetesJob + DDP training      │
+│  │     Pod      │    script                                 │
+│  └──────┬───────┘                                           │
+│         │                                                   │
+│         │ Discovers pods via labels                         │
+│         │ app.kubernetes.io/name=monarch-worker             │
+│         │ monarch.pytorch.org/mesh-name=ddpmesh             │
+│         ▼                                                   │
+│  ┌──────────────┐  ┌──────────────┐                         │
+│  │   Worker 0   │  │   Worker 1   │  ← MonarchMesh pods     │
+│  │   (4 GPUs)   │  │   (4 GPUs)   │    with GPU resources   │
+│  └──────────────┘  └──────────────┘                         │
+│         │                  │                                │
+│         └────── NCCL ──────┘                                │
+│              (GPU-to-GPU)                                   │
+└─────────────────────────────────────────────────────────────┘
+```

--- a/examples/kubernetes/ddp/kubernetes_ddp.py
+++ b/examples/kubernetes/ddp/kubernetes_ddp.py
@@ -1,0 +1,178 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""
+Kubernetes DDP Example
+
+Demonstrates running PyTorch Distributed Data Parallel (DDP) training
+on Kubernetes using Monarch's KubernetesJob and MonarchMesh CRD and operator.
+
+Usage:
+    python kubernetes_ddp.py --num_hosts 2 --gpus_per_host 4
+"""
+
+# pyre-ignore-all-errors
+
+import argparse
+import asyncio
+import logging
+import os
+
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+import torch.optim as optim
+from monarch.actor import Actor, current_rank, endpoint
+from monarch.job.kubernetes import KubernetesJob
+from monarch.spmd import setup_torch_elastic_env_async
+from monarch.tools.network import AddrType
+from torch.nn.parallel import DistributedDataParallel as DDP
+
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(name)s %(asctime)s %(levelname)s %(message)s",
+    datefmt="%Y-%m-%d %H:%M:%S",
+    force=True,
+)
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+
+class ToyModel(nn.Module):
+    """A simple toy model for demonstration purposes."""
+
+    def __init__(self):
+        super(ToyModel, self).__init__()
+        self.net1 = nn.Linear(10, 10)
+        self.relu = nn.ReLU()
+        self.net2 = nn.Linear(10, 5)
+
+    def forward(self, x):
+        return self.net2(self.relu(self.net1(x)))
+
+
+class DDPActor(Actor):
+    """Actor that wraps PyTorch DDP functionality.
+
+    Adapted from: https://docs.pytorch.org/tutorials/intermediate/ddp_tutorial.html
+    """
+
+    def __init__(self):
+        self.rank = current_rank().rank
+
+    def _rprint(self, msg):
+        """Helper method to print with rank information."""
+        print(f"{self.rank=} {msg}", flush=True)
+
+    @endpoint
+    async def setup(self):
+        """Initialize the PyTorch distributed process group."""
+        self._rprint("Initializing torch distributed")
+
+        world_size = int(os.environ["WORLD_SIZE"])
+        rank = int(os.environ["RANK"])
+        dist.init_process_group("nccl", rank=rank, world_size=world_size)
+        self._rprint("Finished initializing torch distributed")
+
+    @endpoint
+    async def cleanup(self):
+        """Clean up the PyTorch distributed process group."""
+        self._rprint("Cleaning up torch distributed")
+        dist.destroy_process_group()
+
+    @endpoint
+    async def demo_basic(self):
+        """Run a basic DDP training example."""
+        self._rprint("Running basic DDP example")
+
+        local_rank = int(os.environ["LOCAL_RANK"])
+        self._rprint(f"{local_rank=}")
+
+        # Create model and move to GPU
+        model = ToyModel().to(local_rank)
+        ddp_model = DDP(model, device_ids=[local_rank])
+
+        loss_fn = nn.MSELoss()
+        optimizer = optim.SGD(ddp_model.parameters(), lr=0.001)
+
+        # Forward pass
+        optimizer.zero_grad()
+        outputs = ddp_model(torch.randn(20, 10))
+        labels = torch.randn(20, 5).to(local_rank)
+
+        # Backward pass
+        loss_fn(outputs, labels).backward()
+        optimizer.step()
+
+        print(f"{self.rank=} Finished running basic DDP example", flush=True)
+
+
+async def main(num_hosts: int, gpus_per_host: int, mesh_name: str) -> None:
+    logger.info("=" * 60)
+    logger.info("Kubernetes DDP Example")
+    logger.info(f"Configuration: {num_hosts} hosts, {gpus_per_host} GPUs/host")
+    logger.info("=" * 60)
+
+    # Create Kubernetes job connecting to pre-provisioned pods
+    k8s_job = KubernetesJob(namespace="monarch-tests")
+
+    # Add mesh configuration - uses MonarchMesh CRD labels by default
+    k8s_job.add_mesh(mesh_name, num_replicas=num_hosts)
+
+    try:
+        # Get job state and create process mesh
+        job_state = k8s_job.state()
+        host_mesh = getattr(job_state, mesh_name)
+        proc_mesh = host_mesh.spawn_procs({"gpus": gpus_per_host})
+
+        # Setup distributed environment (RANK, LOCAL_RANK, WORLD_SIZE, MASTER_ADDR, etc.)
+        # Use IPv4 addresses since short hostnames may not resolve across pods
+        await setup_torch_elastic_env_async(proc_mesh, use_ipaddr=AddrType.IPv4)
+
+        # Spawn DDP actor
+        ddp_actor = proc_mesh.spawn("ddp_actor", DDPActor)
+
+        # Run DDP example
+        await ddp_actor.setup.call()
+        await ddp_actor.demo_basic.call()
+        await ddp_actor.cleanup.call()
+
+        logger.info("=" * 60)
+        logger.info("DDP example completed successfully!")
+        logger.info("=" * 60)
+
+        # Stop the proc mesh
+        proc_mesh.stop().get()
+
+    except Exception as e:
+        logger.error(f"DDP example failed: {e}")
+        raise
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Kubernetes DDP Example")
+    parser.add_argument(
+        "--num_hosts",
+        type=int,
+        default=2,
+        help="Number of hosts (must match MonarchMesh replicas)",
+    )
+    parser.add_argument(
+        "--gpus_per_host",
+        type=int,
+        default=4,
+        help="Number of GPUs per host (must match GPU resources in MonarchMesh Pod Template)",
+    )
+    parser.add_argument(
+        "--mesh_name",
+        type=str,
+        default="ddpmesh",
+        help="Name of the MonarchMesh (must match MonarchMesh name)",
+    )
+    args = parser.parse_args()
+
+    asyncio.run(main(args.num_hosts, args.gpus_per_host, args.mesh_name))

--- a/examples/kubernetes/ddp/manifests/ddp_mesh.yaml
+++ b/examples/kubernetes/ddp/manifests/ddp_mesh.yaml
@@ -1,0 +1,118 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# MonarchMesh CRD for DDP training example.
+# Provisions GPU-enabled worker pods for distributed data parallel training.
+#
+# Prerequisites:
+# - Kubernetes cluster with Monarch operator installed
+# - GPU nodes with nvidia.com/gpu resources available
+# - monarch-tests namespace created
+---
+# ServiceAccount for the controller pod
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ddp-controller
+  namespace: monarch-tests
+---
+# Role granting permission to list and get pods
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: ddp-controller
+  namespace: monarch-tests
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch"]
+---
+# Bind the role to the service account
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: ddp-controller
+  namespace: monarch-tests
+subjects:
+  - kind: ServiceAccount
+    name: ddp-controller
+    namespace: monarch-tests
+roleRef:
+  kind: Role
+  name: ddp-controller
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: monarch.pytorch.org/v1alpha1
+kind: MonarchMesh
+metadata:
+  name: ddpmesh
+  namespace: monarch-tests
+spec:
+  # Number of worker pods (hosts) in the mesh
+  replicas: 2
+
+  # Port for Monarch worker communication
+  port: 26600
+
+  podTemplate:
+    containers:
+    - name: worker
+      image: ghcr.io/meta-pytorch/monarch:2026-01-11-alpha
+
+      resources:
+        limits:
+          nvidia.com/gpu: 4
+        requests:
+          nvidia.com/gpu: 4
+
+      env:
+        - name: MONARCH_PORT
+          value: "26600"
+
+      command:
+        - python
+        - -u
+        - -c
+        - |
+          import os
+          import socket
+          import logging
+          from monarch.actor import run_worker_loop_forever
+          logging.basicConfig(level=logging.INFO)
+          logger = logging.getLogger("monarch-worker")
+          port = os.environ.get("MONARCH_PORT", "26600")
+          # Use FQDN for cross-pod DNS resolution
+          hostname = socket.getfqdn()
+          address = f"tcp://{hostname}:{port}"
+          logger.info(f"--- Starting Monarch Worker ---")
+          logger.info(f"Identity: {hostname}")
+          logger.info(f"Listening on: {address}")
+          run_worker_loop_forever(address=address, ca="trust_all_connections")
+
+      # Shared memory for NCCL (default 64MB is insufficient)
+      volumeMounts:
+        - name: dshm
+          mountPath: /dev/shm
+
+    volumes:
+      - name: dshm
+        emptyDir:
+          medium: Memory
+          sizeLimit: "16Gi"
+---
+# Controller pod for running the DDP training script
+apiVersion: v1
+kind: Pod
+metadata:
+  name: ddp-controller
+  namespace: monarch-tests
+spec:
+  containers:
+    - name: controller
+      image: ghcr.io/meta-pytorch/monarch:2026-01-11-alpha
+      command: ["sleep"]
+      args: ["infinity"]
+  serviceAccountName: ddp-controller


### PR DESCRIPTION
Summary: Mostly follows slurm_ddp example, but provide instruction to how to work with KuberentesJob and MonarchMesh CRD

Differential Revision: D91271481


