### PR TITLE
Don't log expensive TCP span fields at INFO

### DIFF
--- a/hyperactor/src/channel/net/client.rs
+++ b/hyperactor/src/channel/net/client.rs
@@ -685,6 +685,17 @@ where
 {
     let deliveries = state.deliveries();
 
+    // At INFO level and above, skip expensive field computation
+    if !tracing::enabled!(tracing::Level::DEBUG) {
+        return hyperactor_telemetry::context_span!(
+            "net i/o loop",
+            dest = %link.dest(),
+            session_id = session_id,
+            connected = conn.is_connected(),
+            next_seq = deliveries.outbox.next_seq,
+        );
+    }
+
     use valuable::NamedField;
     use valuable::Structable;
     use valuable::Tuplable;
@@ -795,7 +806,8 @@ where
 
     hyperactor_telemetry::context_span!(
         "net i/o loop",
-        session = format!("{}.{}", link.dest(), session_id),
+        dest = %link.dest(),
+        session_id = session_id,
         connected = conn.is_connected(),
         next_seq = deliveries.outbox.next_seq,
         largest_acked = largest_acked.as_value(),

--- a/hyperactor/src/channel/net/server.rs
+++ b/hyperactor/src/channel/net/server.rs
@@ -57,10 +57,7 @@ fn process_state_span(
     session_id: u64,
     next: &Next,
     rcv_raw_frame_count: u64,
-    last_ack_time: tokio::time::Instant,
 ) -> Span {
-    let since_last_ack_str = humantime::format_duration(last_ack_time.elapsed()).to_string();
-
     let pending_ack_count = if next.seq > next.ack {
         next.seq - next.ack - 1
     } else {
@@ -69,13 +66,13 @@ fn process_state_span(
 
     hyperactor_telemetry::context_span!(
         "net i/o loop",
-        session_id = format!("{}.{}", dest, session_id),
-        source = source.to_string(),
+        dest = %dest,
+        session_id = session_id,
+        source = %source,
         next_seq = next.seq,
         last_ack = next.ack,
         pending_ack_count = pending_ack_count,
         rcv_raw_frame_count = rcv_raw_frame_count,
-        since_last_ack = since_last_ack_str.as_str(),
     )
 }
 
@@ -414,7 +411,6 @@ impl<S: AsyncRead + AsyncWrite + Send + 'static + Unpin> ServerConn<S> {
                 session_id,
                 &next,
                 rcv_raw_frame_count,
-                last_ack_time,
             );
 
             let (new_next, break_info) = self


### PR DESCRIPTION
Summary:
Reduce tracing overhead in the network I/O loop by:
- Skipping expensive field computation (largest_acked, outbox, unacked) at INFO level and above in client.rs
- Removing since_last_ack field in server.rs
- Replacing format!() with tracing's display syntax to avoid allocations

The large struct fields implementing `Valuable` are quite expensive to visit (up to 30us) and must be copied at some point in the application thread

Differential Revision: D91262138


