### PR TITLE
Pin the keyword in unhandled_fault_hook message

### DIFF
--- a/python/monarch/_src/actor/supervision.py
+++ b/python/monarch/_src/actor/supervision.py
@@ -40,8 +40,14 @@ def unhandled_fault_hook(failure: MeshFailure) -> None:
 
     pid = os.getpid()
     hostname = socket.gethostname()
+    # Do not modify this keyword string for now. It is used by the keyword when
+    # searching this log in stderr.
+    # It is technically temporary to pin this string to aid debugging. Ideally,
+    # this message should be the last one in stderr. But unfortrantely that is
+    # not always the case. So until we fix that, we need to rely on it for now.
+    keyword = "monarch error"
     message = (
-        f"Unhandled monarch error on the root actor, hostname={hostname}, "
+        f"Unhandled {keyword} on the root actor, hostname={hostname}, "
         f"PID={pid} at time {datetime.now()}: {failure.report()}\n"
     )
     # use stderr, not a logger because loggers are sometimes set


### PR DESCRIPTION
Summary:
***Note**: this change is a temporary hack.  We are not designing to depending magic strings.*

The design goal for `unhandled_fault_hook` message is it should be the last log on stderr, so it should be easy to find. But in realty, it is not the case, at least now.

 Take this job. It failed with multiple supervision messages (more than one): https://fburl.com/msl/rl7bkrwf
If you remove my filter, you should see what I mean that it is hard to find them.

My workaround so far is to use "monarch error" as the keyword. But this is fragile since devs might change them if they see fits.

This diff pins this string in the error message, so it will be not be changed without notification and break debugging flows.

Differential Revision: D91328547


