### PR TITLE
Optimize supervision timeouts and polling frequency

### DIFF
--- a/docs/source/api/monarch.config.rst
+++ b/docs/source/api/monarch.config.rst
@@ -194,12 +194,12 @@ Timeouts
     - **Default**: ``"1m"``
     - **Environment**: ``HYPERACTOR_MESH_GET_ACTOR_STATE_MAX_IDLE``
 
-``supervision_liveness_timeout``
+``supervision_watchdog_timeout``
     Liveness timeout for the actor-mesh supervision stream.
 
     - **Type**: ``str`` (duration format)
-    - **Default**: ``"30s"``
-    - **Environment**: ``HYPERACTOR_MESH_SUPERVISION_LIVENESS_TIMEOUT``
+    - **Default**: ``"2m"``
+    - **Environment**: ``HYPERACTOR_MESH_SUPERVISION_WATCHDOG_TIMEOUT``
 
     During actor-mesh supervision, the controller is expected to
     periodically publish on the subscription stream (including benign

--- a/hyperactor_mesh/src/v1/host_mesh.rs
+++ b/hyperactor_mesh/src/v1/host_mesh.rs
@@ -86,6 +86,8 @@ declare_attrs! {
     })
     pub attr PROC_STOP_MAX_IDLE: Duration = Duration::from_secs(30);
 
+    /// The maximum idle time between updates while querying host meshes
+    /// for their proc states.
     @meta(CONFIG = ConfigAttr {
         env_name: Some("HYPERACTOR_MESH_GET_PROC_STATE_MAX_IDLE".to_string()),
         py_name: Some("get_proc_state_max_idle".to_string()),

--- a/hyperactor_mesh/src/v1/mesh_controller.rs
+++ b/hyperactor_mesh/src/v1/mesh_controller.rs
@@ -66,7 +66,7 @@ declare_attrs! {
         env_name: Some("HYPERACTOR_MESH_SUPERVISION_POLL_FREQUENCY".to_string()),
         py_name: None,
     })
-    pub attr SUPERVISION_POLL_FREQUENCY: Duration = Duration::from_secs(3);
+    pub attr SUPERVISION_POLL_FREQUENCY: Duration = Duration::from_secs(10);
 }
 
 #[derive(Debug)]
@@ -272,6 +272,7 @@ impl<A: Referable> Actor for ActorMeshController<A> {
             if did_exist {
                 tracing::debug!(
                     actor_id = %cx.self_id(),
+                    num_subscribers = self.health_state.subscribers.len(),
                     "ActorMeshController: handle_undeliverable_message: removed subscriber {} from mesh controller",
                     port.port_id()
                 );
@@ -470,8 +471,8 @@ impl<A: Referable> Handler<resource::Stop> for ActorMeshController<A> {
 /// Without sending these hearbeats, subscribers will assume the mesh is dead.
 fn send_heartbeat(cx: &impl context::Actor, health_state: &HealthState) {
     tracing::debug!(
-        "sending heartbeat to subscribers, num subscribers = {}",
-        health_state.subscribers.len()
+        num_subscribers = health_state.subscribers.len(),
+        "sending heartbeat to subscribers",
     );
 
     for subscriber in health_state.subscribers.iter() {

--- a/hyperactor_mesh/src/v1/proc_mesh.rs
+++ b/hyperactor_mesh/src/v1/proc_mesh.rs
@@ -88,11 +88,13 @@ declare_attrs! {
     })
     pub attr ACTOR_SPAWN_MAX_IDLE: Duration = Duration::from_secs(30);
 
+    /// The maximum idle time between updates while waiting for a response to GetState
+    /// from ProcMeshAgent.
     @meta(CONFIG = ConfigAttr {
         env_name: Some("HYPERACTOR_MESH_GET_ACTOR_STATE_MAX_IDLE".to_string()),
         py_name: Some("get_actor_state_max_idle".to_string()),
     })
-    pub attr GET_ACTOR_STATE_MAX_IDLE: Duration = Duration::from_mins(1);
+    pub attr GET_ACTOR_STATE_MAX_IDLE: Duration = Duration::from_secs(30);
 }
 
 /// A reference to a single [`hyperactor::Proc`].

--- a/hyperactor_mesh/src/v1/testactor.rs
+++ b/hyperactor_mesh/src/v1/testactor.rs
@@ -391,7 +391,7 @@ impl Handler<NextSupervisionFailure> for WrapperActor {
         };
         let failure = match RealClock
             .timeout(
-                tokio::time::Duration::from_secs(10),
+                tokio::time::Duration::from_secs(20),
                 mesh.next_supervision_event(cx),
             )
             .await

--- a/python/monarch/_rust_bindings/monarch_hyperactor/config.pyi
+++ b/python/monarch/_rust_bindings/monarch_hyperactor/config.pyi
@@ -75,7 +75,7 @@ def configure(
     prefix_with_rank: bool = ...,
     actor_spawn_max_idle: str = ...,
     get_actor_state_max_idle: str = ...,
-    supervision_liveness_timeout: str = ...,
+    supervision_watchdog_timeout: str = ...,
     proc_stop_max_idle: str = ...,
     get_proc_state_max_idle: str = ...,
     actor_queue_dispatch: bool = ...,
@@ -158,7 +158,7 @@ def configure(
             (humantime)
         get_actor_state_max_idle: Maximum idle time for actor state
             queries (humantime)
-        supervision_liveness_timeout: Liveness timeout for the
+        supervision_watchdog_timeout: Liveness timeout for the
             actor-mesh supervision stream; prolonged silence is
             interpreted as the controller being unreachable
             (humantime)

--- a/python/monarch/config/__init__.py
+++ b/python/monarch/config/__init__.py
@@ -74,7 +74,7 @@ def configure(
     prefix_with_rank: bool | None = None,
     actor_spawn_max_idle: str | None = None,
     get_actor_state_max_idle: str | None = None,
-    supervision_liveness_timeout: str | None = None,
+    supervision_watchdog_timeout: str | None = None,
     proc_stop_max_idle: str | None = None,
     get_proc_state_max_idle: str | None = None,
     actor_queue_dispatch: bool | None = None,
@@ -146,7 +146,7 @@ def configure(
         Proc mesh timeouts:
             actor_spawn_max_idle: Maximum idle time while spawning actors (humantime).
             get_actor_state_max_idle: Maximum idle time for actor state queries (humantime).
-            supervision_liveness_timeout: Liveness timeout for the actor-mesh supervision stream; prolonged
+            supervision_watchdog_timeout: Watchdog timeout for the actor-mesh supervision stream; prolonged
                 silence is interpreted as the controller being unreachable (humantime).
 
         Host mesh timeouts:
@@ -234,8 +234,8 @@ def configure(
         params["actor_spawn_max_idle"] = actor_spawn_max_idle
     if get_actor_state_max_idle is not None:
         params["get_actor_state_max_idle"] = get_actor_state_max_idle
-    if supervision_liveness_timeout is not None:
-        params["supervision_liveness_timeout"] = supervision_liveness_timeout
+    if supervision_watchdog_timeout is not None:
+        params["supervision_watchdog_timeout"] = supervision_watchdog_timeout
     if proc_stop_max_idle is not None:
         params["proc_stop_max_idle"] = proc_stop_max_idle
     if get_proc_state_max_idle is not None:

--- a/python/tests/test_config.py
+++ b/python/tests/test_config.py
@@ -274,8 +274,8 @@ def test_duration_config_multiple() -> None:
         ("mesh_terminate_timeout", "20s", "20s", "10s"),
         # Proc mesh timeouts
         ("actor_spawn_max_idle", "45s", "45s", "30s"),
-        ("get_actor_state_max_idle", "90s", "1m 30s", "1m"),
-        ("supervision_liveness_timeout", "90s", "1m 30s", "30s"),
+        ("get_actor_state_max_idle", "90s", "1m 30s", "30s"),
+        ("supervision_watchdog_timeout", "90s", "1m 30s", "2m"),
         # Host mesh timeouts
         ("proc_stop_max_idle", "45s", "45s", "30s"),
         ("get_proc_state_max_idle", "90s", "1m 30s", "1m"),
@@ -444,7 +444,7 @@ def test_all_params_together():
         # Proc mesh timeouts
         actor_spawn_max_idle="45s",
         get_actor_state_max_idle="90s",
-        supervision_liveness_timeout="90s",
+        supervision_watchdog_timeout="90s",
         # Host mesh timeouts
         proc_stop_max_idle="45s",
         get_proc_state_max_idle="90s",
@@ -476,7 +476,7 @@ def test_all_params_together():
         assert config["prefix_with_rank"] is True
         assert config["actor_spawn_max_idle"] == "45s"
         assert config["get_actor_state_max_idle"] == "1m 30s"
-        assert config["supervision_liveness_timeout"] == "1m 30s"
+        assert config["supervision_watchdog_timeout"] == "1m 30s"
         assert config["proc_stop_max_idle"] == "45s"
         assert config["get_proc_state_max_idle"] == "1m 30s"
         assert config["actor_queue_dispatch"] is True
@@ -506,8 +506,8 @@ def test_all_params_together():
     assert config["force_file_log"] is False
     assert config["prefix_with_rank"] is True
     assert config["actor_spawn_max_idle"] == "30s"
-    assert config["get_actor_state_max_idle"] == "1m"
-    assert config["supervision_liveness_timeout"] == "30s"
+    assert config["get_actor_state_max_idle"] == "30s"
+    assert config["supervision_watchdog_timeout"] == "2m"
     assert config["proc_stop_max_idle"] == "30s"
     assert config["get_proc_state_max_idle"] == "1m"
     assert config["actor_queue_dispatch"] is False

--- a/python/tests/test_debugger.py
+++ b/python/tests/test_debugger.py
@@ -219,10 +219,6 @@ async def _wait_for_breakpoints(
 
 
 async def _test_debug(nested: bool) -> None:
-    # Increase supervision liveness timeout for opt mode where PAR
-    # extraction causes slower startup.
-    configure(supervision_liveness_timeout="45s")
-
     if not nested:
         proc = proc_mesh(hosts=2, gpus=2)
         debugee = proc.spawn("debugee", DebugeeActor)

--- a/python/tests/test_supervision_hierarchy.py
+++ b/python/tests/test_supervision_hierarchy.py
@@ -78,7 +78,7 @@ class FaultCapture:
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        self.failure_happened.wait(timeout=10)
+        self.failure_happened.wait(timeout=30)
         monarch.actor.unhandled_fault_hook = self.original_hook
 
     def capture_fault(self, failure: MeshFailure) -> None:


### PR DESCRIPTION
Summary:
The current supervision polling happens every 3 seconds. This was a holdover from the days
where it was started as soon as an endpoint began, and we wanted to ensure endpoints used
on already-dead actor meshes got quick replies.

Now that it's on a separate actor started from the spawning of the mesh, we don't need it to
be so frequent. Make it every 10 seconds instead. This puts less load on both the 
ProcMeshAgent and HostMeshAgent it queries, as well as the subscribers it sends heartbeats
and errors to.

Adjust other timeouts so that they fail in the right order:
* Earliest failure notice is for when an "Err" is encountered on an actor handler at supervision poll frequency, 10 seconds
* Next is for a timeout on querying the ProcMeshAgent at 30 seconds. This would happen if the ProcMeshAgent is unreachable (possibly because the proc crashed)
* Next is a timeout on querying the HostMeshAgent about procs. This would give the signal number if a proc was killed with a signal (this can be the same as the ProcMeshAgent timeout because they're not additive)
* Finally, at 2 minutes, if the user has received no healthy / unhealthy messages in that time frame from the controller, it assumes the controller itself is dead.

The last timeout (controller) has to be greater than the sum of all the previous times, because
otherwise it might assume the controller is dead before it may have gotten a message about
a proc. Added a check for this before setting up the configured timeout.

Reviewed By: mariusae

Differential Revision: D91147953


