### PR TITLE
Add server heartbeat metric for death observability

### DIFF
--- a/hyperactor/src/channel/net/client.rs
+++ b/hyperactor/src/channel/net/client.rs
@@ -1242,7 +1242,9 @@ where
                                 error = %err,
                                 session_id = session_id,
                                 elapsed_secs = elapsed.as_secs_f64(),
-                                "failed to reconnect after {:.1}s", elapsed.as_secs_f64()
+                                "failed to reconnect after {:.1}s; check {} metric to verify server is alive",
+                                elapsed.as_secs_f64(),
+                                metrics::SERVER_HEARTBEAT_METRIC_NAME
                             );
                         } else {
                             tracing::debug!(

--- a/hyperactor/src/config.rs
+++ b/hyperactor/src/config.rs
@@ -129,6 +129,14 @@ declare_attrs! {
         py_name: Some("host_spawn_ready_timeout".to_string()),
     })
     pub attr HOST_SPAWN_READY_TIMEOUT: Duration = Duration::from_secs(30);
+
+    /// Heartbeat interval for server health metrics. The server emits a
+    /// heartbeat metric at this interval to indicate it is alive.
+    @meta(CONFIG = ConfigAttr {
+        env_name: Some("HYPERACTOR_SERVER_HEARTBEAT_INTERVAL".to_string()),
+        py_name: Some("server_heartbeat_interval".to_string()),
+    })
+    pub attr SERVER_HEARTBEAT_INTERVAL: Duration = Duration::from_secs(1);
 }
 
 #[cfg(test)]

--- a/hyperactor/src/metrics.rs
+++ b/hyperactor/src/metrics.rs
@@ -97,3 +97,9 @@ declare_static_counter!(PROC_MESH_ACTOR_FAILURES, "proc_mesh.actor_failures");
 // MESSAGE LATENCY
 // Tracks end-to-end message latency in microseconds (sampled at 1% by default)
 declare_static_histogram!(MESSAGE_LATENCY_MICROS, "message.e2e_latency.us");
+
+// SERVER HEARTBEAT
+/// Metric name for server heartbeat, used in both metric emission and client error messages.
+pub const SERVER_HEARTBEAT_METRIC_NAME: &str = "channel.server.heartbeat";
+// Tracks server heartbeat to indicate the server is alive
+declare_static_counter!(SERVER_HEARTBEAT, "channel.server.heartbeat");


### PR DESCRIPTION
Summary: Adds a periodic heartbeat metric from the channel server to enable detection of sudden server death (SIGKILL, OOM, crash). When the server dies unexpectedly without logging, we can use the sudden absence of this counter as the indicator.

Differential Revision: D91406485


