### PR TITLE
: third-party: zbus-5: enable feature blocking-api

### DIFF
--- a/hyperactor_mesh/Cargo.toml
+++ b/hyperactor_mesh/Cargo.toml
@@ -78,7 +78,7 @@ tracing = { version = "0.1.41", features = ["attributes", "valuable"] }
 tracing-subscriber = { version = "0.3.20", features = ["chrono", "env-filter", "json", "local-time", "parking_lot", "registry"] }
 typeuri = { version = "0.0.0", path = "../typeuri" }
 wirevalue = { version = "0.0.0", path = "../wirevalue" }
-zbus = { version = "5.11.0", features = ["async-executor", "async-fs", "async-io", "async-lock", "async-process", "async-task", "p2p", "tokio"], default-features = false }
+zbus = { version = "5.11.0", features = ["async-executor", "async-fs", "async-io", "async-lock", "async-process", "async-task", "blocking-api", "p2p", "tokio"], default-features = false }
 
 [dev-dependencies]
 bytes = { version = "1.10", features = ["serde"] }


### PR DESCRIPTION
Summary: enable feature "blocking-api" on zbus-5 crate.

Reviewed By: mariusae

Differential Revision: D91474962


