### PR TITLE
multicast: properly separate end-to-end and hop-to-hop headers

### DIFF
--- a/hyperactor_mesh/src/comm.rs
+++ b/hyperactor_mesh/src/comm.rs
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+use crate::actor_mesh::CAST_ACTOR_MESH_ID;
 use crate::comm::multicast::CAST_ORIGINATING_SENDER;
 use crate::comm::multicast::CastEnvelope;
 use crate::reference::ActorMeshId;
@@ -147,8 +148,7 @@ impl Actor for CommActor {
             let sender = message.sender();
             let return_port = PortRef::attest_message_port(sender);
             message_envelope.set_error(DeliveryError::Multicast(format!(
-                "comm actor {} failed to forward the cast message; return to \
-                its original sender's port {}",
+                "comm actor {} failed to forward the cast message; returning to origin {}",
                 cx.self_id(),
                 return_port.port_id(),
             )));
@@ -181,7 +181,7 @@ impl Actor for CommActor {
             let return_port = PortRef::attest_message_port(sender);
             message_envelope.set_error(DeliveryError::Multicast(format!(
                 "comm actor {} failed to deliver the cast message to the dest \
-                actor; return to its original sender's port {}",
+                actor; returning to origin {}",
                 cx.self_id(),
                 return_port.port_id(),
             )));
@@ -189,8 +189,8 @@ impl Actor for CommActor {
                 .send(cx, Undeliverable(message_envelope.clone()))
                 .map_err(|err| {
                     let error = DeliveryError::BrokenLink(format!(
-                        "error occured when returning cast message to the original \
-                        sender's port {}; error is: {}",
+                        "error occured when returning cast message to the origin \
+                        sender {}; error is: {}",
                         return_port.port_id(),
                         err,
                     ));
@@ -215,14 +215,20 @@ impl CommActor {
         cx: &Context<Self>,
         config: &CommMeshConfig,
         rank: usize,
-        header_props: Attrs,
         message: M,
     ) -> Result<()>
     where
         CommActor: hyperactor::RemoteHandles<M>,
     {
         let child = config.peer_for_rank(rank)?;
-        child.send_with_headers(cx, header_props, message)?;
+        // TEMPORARY: until dropping v0 support
+        if let Some(cast_actor_mesh_id) = cx.headers().get(CAST_ACTOR_MESH_ID) {
+            let mut headers = Attrs::new();
+            headers.set(CAST_ACTOR_MESH_ID, cast_actor_mesh_id.clone());
+            child.send_with_headers(cx, headers, message);
+        } else {
+            child.send(cx, message)?;
+        }
         Ok(())
     }
 
@@ -243,7 +249,7 @@ impl CommActor {
             // We should not copy cx.headers() because it contains auto-generated
             // headers from mailbox. We want fresh headers only containing
             // user-provided headers.
-            let headers = message.header_props().clone();
+            let headers = message.headers().clone();
             Self::deliver_to_dest(cx, headers, &mut message, config)?;
         }
 
@@ -256,7 +262,6 @@ impl CommActor {
                     cx,
                     config,
                     peer,
-                    message.header_props().clone(),
                     ForwardMessage {
                         dests,
                         sender: sender.clone(),
@@ -399,13 +404,7 @@ impl Handler<CastMessage> for CommActor {
         if config.self_rank() == rank {
             Handler::<ForwardMessage>::handle(self, cx, fwd_message).await?;
         } else {
-            Self::forward(
-                cx,
-                config,
-                rank,
-                fwd_message.message.header_props().clone(),
-                fwd_message,
-            )?;
+            Self::forward(cx, config, rank, fwd_message)?;
         }
         Ok(())
     }

--- a/hyperactor_mesh/src/comm/multicast.rs
+++ b/hyperactor_mesh/src/comm/multicast.rs
@@ -36,7 +36,7 @@ use crate::reference::ActorMeshId;
 // v0 casting is deleted.
 pub(crate) trait CastEnvelope {
     fn dest_port(&self) -> &DestinationPort;
-    fn header_props(&self) -> &Attrs;
+    fn headers(&self) -> &Attrs;
     fn sender(&self) -> &ActorId;
     fn cast_point(&self, config: &CommMeshConfig) -> anyhow::Result<Point>;
     fn data(&self) -> &ErasedUnbound;
@@ -60,10 +60,8 @@ pub struct Uslice {
 pub struct CastMessageEnvelope {
     /// The destination actor mesh id.
     actor_mesh_id: ActorMeshId,
-    /// Headers that should be added to all messages sent between cast tree
-    /// nodes. Specifically, this includes source->comm, comm->comm, and
-    /// comm->dest.
-    header_props: Attrs,
+    /// The end-to-end message headers.
+    headers: Attrs,
     /// The sender of this message.
     sender: ActorId,
     /// The destination port of the message. It could match multiple actors with
@@ -81,8 +79,8 @@ impl CastEnvelope for CastMessageEnvelope {
         &self.sender
     }
 
-    fn header_props(&self) -> &Attrs {
-        &self.header_props
+    fn headers(&self) -> &Attrs {
+        &self.headers
     }
 
     fn dest_port(&self) -> &DestinationPort {
@@ -115,7 +113,7 @@ impl CastMessageEnvelope {
         actor_mesh_id: ActorMeshId,
         sender: ActorId,
         shape: Shape,
-        header_props: Attrs,
+        headers: Attrs,
         message: M,
     ) -> Result<Self, anyhow::Error>
     where
@@ -129,7 +127,7 @@ impl CastMessageEnvelope {
         };
         Ok(Self {
             actor_mesh_id,
-            header_props,
+            headers,
             sender,
             dest_port: DestinationPort::new::<A, M>(actor_name),
             data,
@@ -145,13 +143,13 @@ impl CastMessageEnvelope {
         sender: ActorId,
         dest_port: DestinationPort,
         shape: Shape,
-        header_props: Attrs,
+        headers: Attrs,
         data: wirevalue::Any,
     ) -> Self {
         Self {
             actor_mesh_id,
             sender,
-            header_props,
+            headers,
             dest_port,
             data: ErasedUnbound::new(data),
             shape,


### PR DESCRIPTION
Summary:
D91170370 introduced header_props to propagate headers through the cast tree. However, these mixed "propagated" headers with "message headers".

Instead: 1) separate end-to-end headers from hop-to-hop headers, which are now just managed by the MailboxSender directly; 2) set end-to-end versions of the standard headers when casting messages.

Reviewed By: pzhan9

Differential Revision: D91473902


