### PR TITLE
Update example with a roleAccount that uses the monarch-client-role clusterRole

### DIFF
--- a/examples/kubernetes/gpu_collective_demo/README.md
+++ b/examples/kubernetes/gpu_collective_demo/README.md
@@ -8,6 +8,9 @@ This demo gives an example of running a GPU collective across ranks using native
 # Run the worker mesh
 kubectl apply -f manifests/gpu_mesh.yaml
 
+# Create the service account for the controller and bind the cluster role to it:
+kubectl apply -f manifests/client-rbac.yaml
+
 # Start the controller
 kubectl apply -f manifests/simple_controller.yaml
 

--- a/examples/kubernetes/gpu_collective_demo/manifests/client-rbac.yaml
+++ b/examples/kubernetes/gpu_collective_demo/manifests/client-rbac.yaml
@@ -1,0 +1,27 @@
+# RBAC setup for MonarchJob client pods.
+# Apply this before running simple_controller.yaml.
+#
+# Usage:
+#   kubectl create namespace monarch-tests
+#   kubectl apply -f client-rbac.yaml
+#   kubectl apply -f simple_controller.yaml
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: monarch-client
+  namespace: monarch-tests
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: monarch-client-binding
+  namespace: monarch-tests
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: monarch-client-role
+subjects:
+  - kind: ServiceAccount
+    name: monarch-client
+    namespace: monarch-tests

--- a/examples/kubernetes/gpu_collective_demo/manifests/simple_controller.yaml
+++ b/examples/kubernetes/gpu_collective_demo/manifests/simple_controller.yaml
@@ -5,6 +5,7 @@ metadata:
   name: monarch-client-demo
   namespace: monarch-tests
 spec:
+  serviceAccountName: monarch-client
   containers:
     - name: monarch
       image: ghcr.io/meta-pytorch/monarch:2026-01-11-alpha


### PR DESCRIPTION
Summary: After https://github.com/meta-pytorch/monarch-kubernetes/pull/26, we can create a service account and bind the ClusterRole to it.

Differential Revision: D91501968


