### PR TITLE
: v1: host_mesh: adjust test timeouts

### DIFF
--- a/hyperactor_mesh/src/alloc/remoteprocess.rs
+++ b/hyperactor_mesh/src/alloc/remoteprocess.rs
@@ -2598,7 +2598,7 @@ mod test_alloc {
         task2_allocator_handle.await.unwrap();
     }
 
-    #[async_timed_test(timeout_secs = 60)]
+    #[async_timed_test(timeout_secs = 180)]
     #[cfg(fbcode_build)]
     async fn test_remote_process_alloc_signal_handler() {
         hyperactor_telemetry::initialize_logging_for_test();

--- a/hyperactor_mesh/src/comm.rs
+++ b/hyperactor_mesh/src/comm.rs
@@ -1069,7 +1069,7 @@ mod tests {
                 sum += value;
             }
         }
-        wait_for_with_timeout(&mut reply1_rx, sum, Duration::from_secs(2))
+        wait_for_with_timeout(&mut reply1_rx, sum, Duration::from_secs(8))
             .await
             .unwrap();
         // no more messages


### PR DESCRIPTION
Summary: since D91147953, this particular test fairly reliably fails in my testing with mode/dev-nosan. adjusting  `GET_ACTOR_STATE_MAX_IDLE` and `SUPERVISION_POLL_FREQUENCY` appears to fix that. at the same time, i removed ` let _g0 = config.override_key(crate::bootstrap::MESH_BOOTSTRAP_ENABLE_PDEATHSIG, false); ` because if it does fail, it leaves a crippling number of zombies behind.

Differential Revision: D91519435


