### PR TITLE
: MONARCH_INFO.md: use RealClock advice

### DIFF
--- a/MONARCH_INFO.md
+++ b/MONARCH_INFO.md
@@ -16,6 +16,14 @@
 - In Rust, make illegal state *unrepresentable*. For example, if you find structs with Option<> that are always Some in certain contexts but not in others, consider using an enum instead to explicitly enumerate the legal states of the data structure.
 - Do NOT engage in defensive coding. If the program is in an illegal state (e.g., violated some invariant), *panic* instead of returning errors. In Rust use panic! and .unwrap() for these cases.
 - Where appropriate, embrace the actor model: use actors for concurrency, fault tolerance, and messaging.  Use the supervision tree model for fault tolerance. Actors can be organized into a tree, where failures propagate up the tree. The root actor is the supervisor of all other actors.
+- In Rust, use `hyperactor::clock::RealClock` for time operations instead of `tokio::time` directly:
+  ```rust
+  use hyperactor::clock::Clock;
+  use hyperactor::clock::RealClock;
+
+  RealClock.sleep(duration).await;    // not tokio::time::sleep
+  RealClock.timeout(duration, fut).await;  // not tokio::time::timeout
+  ```
 
 ## Style
 


### PR DESCRIPTION
Summary: teach claude about how we prefer `RealClock` to `tokio::time`.

Differential Revision: D91621342


