### PR TITLE
Fix mesh_ref usage in PythonActorMeshImpl to limit subscriptions

### DIFF
--- a/hyperactor/src/actor_local.rs
+++ b/hyperactor/src/actor_local.rs
@@ -309,6 +309,18 @@ impl<T: Send + Sync + 'static> ActorLocal<T> {
     }
 }
 
+// Can't use derive(Clone) because it enforces T: Clone which is not necessary.
+impl<T: Send + Sync + 'static> Clone for ActorLocal<T> {
+    /// Clones only the key, not the value. If this clone is used from a different
+    /// context it'll get a different value.
+    fn clone(&self) -> Self {
+        Self {
+            key: self.key.clone(),
+            _marker: PhantomData,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/hyperactor_mesh/src/supervision.rs
+++ b/hyperactor_mesh/src/supervision.rs
@@ -52,10 +52,20 @@ impl MeshFailure {
 
 impl std::fmt::Display for MeshFailure {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let actor_mesh_name = self
+            .actor_mesh_name
+            .as_ref()
+            .map(|m| format!(" on mesh \"{}\"", m))
+            .unwrap_or("".to_string());
+        let rank = self
+            .rank
+            .as_ref()
+            .map(|r| format!(" at rank {}", r))
+            .unwrap_or("".to_string());
         write!(
             f,
-            "Supervision failure on mesh {:?} at rank {:?} with event: {}",
-            self.actor_mesh_name, self.rank, self.event
+            "failure{}{} with event: {}",
+            actor_mesh_name, rank, self.event
         )
     }
 }

--- a/hyperactor_mesh/src/v1.rs
+++ b/hyperactor_mesh/src/v1.rs
@@ -62,6 +62,7 @@ use crate::resource;
 use crate::resource::RankedValues;
 use crate::resource::Status;
 use crate::shortuuid::ShortUuid;
+use crate::supervision::MeshFailure;
 use crate::v1::host_mesh::HostMeshAgent;
 use crate::v1::host_mesh::HostMeshRefParseError;
 use crate::v1::host_mesh::mesh_agent::ProcState;
@@ -152,6 +153,9 @@ pub enum Error {
 
     #[error("proc {0} must be direct-addressable")]
     RankedProc(ProcId),
+
+    #[error("{0}")]
+    Supervision(Box<MeshFailure>),
 
     #[error("error: {0} does not exist")]
     NotExist(Name),

--- a/monarch_hyperactor/src/supervision.rs
+++ b/monarch_hyperactor/src/supervision.rs
@@ -57,6 +57,17 @@ impl SupervisionError {
     }
 }
 
+impl SupervisionError {
+    // Not From<MeshFailure> because the return type needs to be PyErr.
+    pub(crate) fn new_err_from(failure: MeshFailure) -> PyErr {
+        let event = failure.event;
+        Self::new_err(format!(
+            "Actor {} exited because of the following reason: {}",
+            event.actor_id, event,
+        ))
+    }
+}
+
 // TODO: find out how to extend a Python exception and have internal data.
 #[derive(Clone, Debug)]
 #[pyclass(

--- a/monarch_hyperactor/src/v1/actor_mesh.rs
+++ b/monarch_hyperactor/src/v1/actor_mesh.rs
@@ -81,10 +81,10 @@ impl PythonActorMeshImpl {
         PythonActorMeshImpl::Ref(PyActorMeshRef { mesh: inner })
     }
 
-    fn mesh_ref(&self) -> ActorMeshRef<PythonActor> {
+    fn mesh_ref(&self) -> &ActorMeshRef<PythonActor> {
         match self {
-            PythonActorMeshImpl::Owned(inner) => (*inner.mesh).clone(),
-            PythonActorMeshImpl::Ref(inner) => inner.mesh.clone(),
+            PythonActorMeshImpl::Owned(inner) => &inner.mesh,
+            PythonActorMeshImpl::Ref(inner) => &inner.mesh,
         }
     }
 }
@@ -96,27 +96,28 @@ impl ActorMeshProtocol for PythonActorMeshImpl {
         selection: Selection,
         instance: &PyInstance,
     ) -> PyResult<()> {
-        let mesh_ref = self.mesh_ref();
-
         <ActorMeshRef<PythonActor> as ActorMeshProtocol>::cast(
-            &mesh_ref, message, selection, instance,
+            self.mesh_ref(),
+            message,
+            selection,
+            instance,
         )
     }
 
     fn supervision_event(&self, instance: &PyInstance) -> PyResult<Option<PyShared>> {
-        let mesh = self.mesh_ref();
+        // We clone here so the future can outlive the self reference, but we want
+        // to share the supervision receiver with the original mesh. This way
+        // if a second endpoint is started, it can reuse the same subscriber.
+        let mesh = self.mesh_ref().clone_with_supervision_receiver();
         let instance = monarch_with_gil_blocking(|_py| instance.clone());
         let shared = PyPythonTask::new::<_, ()>(async move {
             let supervision_failure = mesh
                 .next_supervision_event(instance.deref())
                 .await
                 .map_err(|e| PyValueError::new_err(e.to_string()))?;
-            let event = supervision_failure.event;
-            let pyerr = SupervisionError::new_err(format!(
-                "Actor {} exited because of the following reason: {}",
-                event.actor_id, event,
-            ));
-            Err(pyerr)
+            // Don't Unsubscribe here, as the receiver may have other copies being
+            // used.
+            Err(SupervisionError::new_err_from(supervision_failure))
         })?
         .spawn_abortable()?;
         Ok(Some(shared))
@@ -159,6 +160,16 @@ impl ActorMeshProtocol for PythonActorMeshImpl {
     }
 }
 
+// Convert a v1::Error to a Python exception. v1::Error::Supervision becomes a SupervisionError,
+// all others become a RuntimeError.
+fn cast_error_to_py_error(err: v1::Error) -> PyErr {
+    if let v1::Error::Supervision(failure) = err {
+        SupervisionError::new_err_from(failure)
+    } else {
+        PyRuntimeError::new_err(err.to_string())
+    }
+}
+
 impl ActorMeshProtocol for ActorMeshRef<PythonActor> {
     fn cast(
         &self,
@@ -168,7 +179,7 @@ impl ActorMeshProtocol for ActorMeshRef<PythonActor> {
     ) -> PyResult<()> {
         if structurally_equal(&selection, &Selection::All(Box::new(Selection::True))) {
             self.cast(instance.deref(), message.clone())
-                .map_err(|err| PyException::new_err(err.to_string()))?;
+                .map_err(cast_error_to_py_error)?;
         } else if structurally_equal(&selection, &Selection::Any(Box::new(Selection::True))) {
             let region = Ranked::region(self);
             let random_rank = fastrand::usize(0..region.num_ranks());
@@ -182,7 +193,7 @@ impl ActorMeshProtocol for ActorMeshRef<PythonActor> {
             );
             self.sliced(singleton_region)
                 .cast(instance.deref(), message.clone())
-                .map_err(|err| PyException::new_err(err.to_string()))?;
+                .map_err(cast_error_to_py_error)?;
         } else {
             return Err(PyRuntimeError::new_err(format!(
                 "invalid selection: {:?}",

--- a/python/tests/test_actor_error.py
+++ b/python/tests/test_actor_error.py
@@ -733,8 +733,10 @@ async def test_actor_mesh_supervision_handling() -> None:
 
         # new call should fail with check of health state of actor mesh
         with pytest.raises(
-            SupervisionError,
-            match="Actor .* (is unhealthy with reason|exited because of the following reason)",
+            RuntimeError,
+            match="failure on mesh.*error.*with event: "
+            "The actor.*ErrorActor error.* and all its descendants have failed|"
+            "Actor.*error.*exited because of the following",
         ):
             await e.check.call()
         print("after subsequent endpoint call")
@@ -809,7 +811,7 @@ async def test_actor_mesh_supervision_handling_chained_error() -> None:
     # calling success endpoint should fail with ActorError, but with supervision msg.
     with pytest.raises(
         ActorError,
-        match="Actor .* (is unhealthy with reason|exited because of the following reason)",
+        match="The actor.*Intermediate intermediate.*ErrorActor error.*and all its descendants have failed",
     ):
         await intermediate_actor.forward_success.call()
 
@@ -847,10 +849,15 @@ async def test_base_exception_handling(mesh, error_actor_cls) -> None:
         ):
             await error_actor.fail_with_supervision_error.call_one()
 
-        # Subsequent calls should fail with a health state error
+        # Subsequent calls should fail with a health state error, including
+        # the previous error that had occurred.
         with pytest.raises(
             RuntimeError,
-            match="Actor .* (is unhealthy with reason|exited because of the following reason)",
+            match="failure on mesh .*error.* at rank 0 with event:.*"
+            "The actor .*ErrorActor error.*and all its descendants have failed.*"
+            "|"
+            "Actor .*error.*exited because of the following reason:"
+            ".*ErrorActor error.*and all its descendants have failed",
         ):
             await error_actor.check.call()
         # The above check call is undeliverable and might get returned to the client
@@ -887,7 +894,11 @@ async def test_process_exit_handling(error_actor_cls) -> None:
         # Subsequent calls should fail with a health state error
         with pytest.raises(
             RuntimeError,
-            match=base_match.format("error.check"),
+            # Message changes depending on actor_queue_dispatch.
+            match="failure on mesh .*error.* at rank 0 with event: "
+            "The actor.*ErrorActor error.*was running on a process which and all its descendants have failed"
+            "|"
+            "Actor.*error.*exited because of the following reason",
         ):
             await error_actor.check.call()
 
@@ -912,38 +923,38 @@ class FaultActor(Actor):
 @parametrize_config(actor_queue_dispatch={True, False})
 async def test_sigsegv_handling():
     # This test doesn't want the client process to crash during testing.
-    monarch.actor.unhandled_fault_hook = lambda failure: None
-    hosts = this_host()
-    procs = hosts.spawn_procs({"gpus": 2})
-    actor = procs.spawn("fault", FaultActor)
+    with override_fault_hook():
+        hosts = this_host()
+        procs = hosts.spawn_procs({"gpus": 2})
+        actor = procs.spawn("fault", FaultActor)
 
-    # Make sure the actor is healthy first
-    await actor.check.call()
-
-    # Depending on the timing, any of these messages could come back first.
-    error_msg = (
-        "actor mesh is stopped due to proc mesh shutdown|"
-        'actor mesh is stopped due to proc mesh shutdown.*Failed\\("Killed\\(sig=11.*\\)"\\)|'
-        "Actor .* exited because of the following reason|"
-        "Actor .* is unhealthy with reason"
-    )
-    with pytest.raises(SupervisionError, match=error_msg):
-        await actor.sigsegv.call()
-
-    # Check that a second call still fails and doesn't hang.
-    with pytest.raises(SupervisionError, match=error_msg):
+        # Make sure the actor is healthy first
         await actor.check.call()
 
-    # Check that proc_mesh.stop() still works, even though the processes are dead.
-    # It should check for the procs status without trying to kill them again.
-    await procs.stop()
+        with pytest.raises(
+            SupervisionError,
+            match="Actor .* and all its descendants have failed",
+        ):
+            await actor.sigsegv.call()
 
-    # Re-spawn on the same host mesh should work.
-    procs = hosts.spawn_procs({"gpus": 2})
-    actor = procs.spawn("fault", FaultActor)
+        # Check that a second call still fails and doesn't hang.
+        with pytest.raises(
+            RuntimeError,
+            match="failure on mesh.*fault.*with event.*|"
+            "Actor.*fault.*exited because of the following reason",
+        ):
+            await actor.check.call()
 
-    # Results don't matter, just make sure there's no exception.
-    await actor.check.call()
+        # Check that proc_mesh.stop() still works, even though the processes are dead.
+        # It should check for the procs status without trying to kill them again.
+        await procs.stop()
+
+        # Re-spawn on the same host mesh should work.
+        procs = hosts.spawn_procs({"gpus": 2})
+        actor = procs.spawn("fault", FaultActor)
+
+        # Results don't matter, just make sure there's no exception.
+        await actor.check.call()
 
 
 @parametrize_config(actor_queue_dispatch={True, False})
@@ -1107,12 +1118,16 @@ async def test_slice_supervision() -> None:
 
         print("before slice_3.check")
         # Slice containing only gpus=3 is unhealthy
-        with pytest.raises(SupervisionError, match=match):
+        with pytest.raises(
+            RuntimeError,
+            match="failure on mesh.*error.*at rank 3 with event: The actor.*ErrorActor error.* and all its descendants have failed|"
+            "Actor.*error.*exited because of the following",
+        ):
             await slice_3.check.call()
 
         print("before slice_1.check")
         # Slice containing gpus=3 is unhealthy
-        with pytest.raises(SupervisionError, match=match):
+        with pytest.raises(RuntimeError, match=match):
             await slice_1.check.call()
 
         print("before slice_2.check")


### PR DESCRIPTION
Summary:
We saw that there were way too many subscriptions being created to actor meshes
in real world examples, and discovered that we were accidentally re-creating the supervision
receiver each time `supervision_event` was called.

This was because we cloned the ActorMeshRef, and the default clone implementation did not
share the receiver + health state across the two copies. We needed these to be shared in
order to actually preserve the health state changes.

This change accomplishes two things:
* majorly reduces number of subscribers from O(num endpoint calls) -> O(num actor mesh refs)
* Actually uses the saved health state to preempt future uses of the same actor mesh on `cast`

Reviewed By: mariusae

Differential Revision: D91179185


