### PR TITLE
Add metadata parameter to host_mesh() for Kubernetes pod overlays

### DIFF
--- a/python/monarch/tools/components/hyperactor.py
+++ b/python/monarch/tools/components/hyperactor.py
@@ -6,7 +6,7 @@
 
 # pyre-strict
 import getpass
-from typing import Optional
+from typing import Any, Optional
 
 from monarch.tools import mesh_spec
 from monarch.tools.config import NOT_SET
@@ -29,6 +29,7 @@ def host_mesh(
     env: Optional[dict[str, str]] = None,
     port: int = mesh_spec.DEFAULT_REMOTE_ALLOCATOR_PORT,
     program: str = "monarch_bootstrap",  # installed with monarch wheel (as console script)
+    metadata: Optional[dict[str, Any]] = None,
 ) -> specs.AppDef:
     """
     Args:
@@ -38,6 +39,7 @@ def host_mesh(
         env: environment variables to be passed to the main command (e.g. ENV1=v1,ENV2=v2,ENV3=v3)
         port: the port that the remote process allocator runs on (must be reachable from the client)
         program: path to the binary that the remote process allocator spawns on an allocation request
+        metadata: scheduler-specific metadata to pass to each role
     """
 
     appdef = specs.AppDef(name=NOT_SET)
@@ -55,6 +57,7 @@ def host_mesh(
             resource=specs.resource(h=mesh.host_type),
             env=env or {},
             port_map={"mesh": port},
+            metadata=metadata or {},
         )
         appdef.roles.append(mesh_role)
 

--- a/python/tests/tools/test_hyperactor.py
+++ b/python/tests/tools/test_hyperactor.py
@@ -1,0 +1,51 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+import unittest
+
+from monarch.tools.components.hyperactor import host_mesh
+
+
+class TestHostMesh(unittest.TestCase):
+    def test_host_mesh_default_no_metadata(self) -> None:
+        """Test that host_mesh creates roles with empty metadata by default."""
+        appdef = host_mesh(meshes=["trainer:2:gpu.small"])
+
+        self.assertEqual(1, len(appdef.roles))
+        role = appdef.roles[0]
+        self.assertEqual("trainer", role.name)
+        self.assertEqual({}, role.metadata)
+
+    def test_host_mesh_with_metadata(self) -> None:
+        """Test that host_mesh passes metadata through to each role."""
+        metadata = {"kubernetes": {"spec": {"runtimeClassName": "nvidia"}}}
+        appdef = host_mesh(meshes=["trainer:2:gpu.small"], metadata=metadata)
+
+        self.assertEqual(1, len(appdef.roles))
+        role = appdef.roles[0]
+        self.assertEqual("trainer", role.name)
+        self.assertEqual(metadata, role.metadata)
+
+    def test_host_mesh_metadata_applied_to_all_roles(self) -> None:
+        """Test that metadata is applied to all roles when multiple meshes are specified."""
+        metadata = {"kubernetes": {"spec": {"runtimeClassName": "nvidia"}}}
+        appdef = host_mesh(
+            meshes=["trainer:2:gpu.small", "generator:4:gpu.medium"],
+            metadata=metadata,
+        )
+
+        self.assertEqual(2, len(appdef.roles))
+        for role in appdef.roles:
+            self.assertEqual(metadata, role.metadata)
+
+    def test_host_mesh_with_none_metadata(self) -> None:
+        """Test that passing None for metadata results in empty metadata dict."""
+        appdef = host_mesh(meshes=["trainer:2:gpu.small"], metadata=None)
+
+        self.assertEqual(1, len(appdef.roles))
+        role = appdef.roles[0]
+        self.assertEqual({}, role.metadata)


### PR DESCRIPTION
## Summary

- Adds an optional `metadata` parameter to `hyperactor.host_mesh()` that gets passed through to each role
- This enables Kubernetes-specific configuration like `runtimeClassName: nvidia` for GPU access without patching roles after the fact

## Motivation

Many Kubernetes clusters require `runtimeClassName: nvidia` in the pod spec for GPU access. TorchX supports this via [pod overlays](https://pytorch.org/torchx/latest/schedulers/kubernetes.html), but `hyperactor.host_mesh()` creates roles internally without exposing the metadata parameter.

Previously, users had to patch `appdef.roles` after calling `host_mesh()`:
```python
appdef = hyperactor.host_mesh(image=..., meshes=[...], env={...})

for role in appdef.roles:
    role.metadata["kubernetes"] = {"spec": {"runtimeClassName": "nvidia"}}
```

Now it can be done cleanly:
```python
appdef = hyperactor.host_mesh(
    image=...,
    meshes=[...],
    env={...},
    metadata={"kubernetes": {"spec": {"runtimeClassName": "nvidia"}}},
)
```