### PR TITLE
Register callback on proc spawn

### DIFF
--- a/python/monarch/_src/actor/proc_mesh.py
+++ b/python/monarch/_src/actor/proc_mesh.py
@@ -224,6 +224,39 @@ except ImportError:
 
 _proc_mesh_registry: WeakSet["ProcMesh"] = WeakSet()
 
+# Callbacks invoked when a new ProcMesh is spawned via from_host_mesh.
+# Each callback receives the newly created ProcMesh.
+_proc_mesh_spawn_callbacks: List[Callable[["ProcMesh"], None]] = []
+
+
+def register_proc_mesh_spawn_callback(callback: Callable[["ProcMesh"], None]) -> None:
+    """
+    Register a callback to be invoked whenever a new ProcMesh is spawned.
+
+    The callback receives the newly created ProcMesh before it is returned
+    from from_host_mesh. This allows code to hook into process spawning
+    for monitoring, telemetry, or other cross-cutting concerns.
+
+    Args:
+        callback: A callable that takes a ProcMesh and returns None.
+    """
+    _proc_mesh_spawn_callbacks.append(callback)
+
+
+def unregister_proc_mesh_spawn_callback(
+    callback: Callable[["ProcMesh"], None]
+) -> None:
+    """
+    Unregister a previously registered spawn callback.
+
+    Args:
+        callback: The callback to remove.
+
+    Raises:
+        ValueError: If the callback was not registered.
+    """
+    _proc_mesh_spawn_callbacks.remove(callback)
+
 
 def get_active_proc_meshes() -> List["ProcMesh"]:
     """Get a list of all active ProcMesh instances."""
@@ -411,6 +444,10 @@ class ProcMesh(MeshTrait):
         pm._proc_mesh = PythonTask.from_coroutine(
             task(pm, hy_proc_mesh, setup_actor, host_mesh.stream_logs)
         ).spawn()
+
+        # Invoke registered spawn callbacks
+        for callback in _proc_mesh_spawn_callbacks:
+            callback(pm)
 
         return pm
 

--- a/python/monarch/_src/actor/proc_mesh.py
+++ b/python/monarch/_src/actor/proc_mesh.py
@@ -243,9 +243,7 @@ def register_proc_mesh_spawn_callback(callback: Callable[["ProcMesh"], None]) ->
     _proc_mesh_spawn_callbacks.append(callback)
 
 
-def unregister_proc_mesh_spawn_callback(
-    callback: Callable[["ProcMesh"], None]
-) -> None:
+def unregister_proc_mesh_spawn_callback(callback: Callable[["ProcMesh"], None]) -> None:
     """
     Unregister a previously registered spawn callback.
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #2413
* __->__ #2410

Private API to get a callback right after a process has spawned. Will be used by telemetry actors to set up messaging tree. This is different than the StartupActor functions because it runs on the spawning proc not the spawnee. I've left this API private for now because I am not sure we really should proliferate so many callbacks kinds in the public API. It might also be possible to do this with a get_or_create_controller call, but it would cause more direct messages to the head node which are unnecessary.

Differential Revision: [D91697620](https://our.internmc.facebook.com/intern/diff/D91697620/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D91697620/)!