### PR TITLE
Add cast point to RemoteSpawn::new

### DIFF
--- a/hyperactor/src/actor/remote.rs
+++ b/hyperactor/src/actor/remote.rs
@@ -14,6 +14,8 @@ use std::future::Future;
 use std::pin::Pin;
 use std::sync::LazyLock;
 
+use hyperactor_config::Attrs;
+
 use crate::Actor;
 use crate::Data;
 use crate::proc::Proc;
@@ -66,6 +68,7 @@ pub struct SpawnableActor {
         &Proc,
         &str,
         Data,
+        Attrs,
     ) -> Pin<Box<dyn Future<Output = Result<ActorId, anyhow::Error>> + Send>>,
 
     /// A function to retrieve the type id of the actor itself. This is
@@ -122,12 +125,13 @@ impl Remote {
         actor_type: &str,
         actor_name: &str,
         params: Data,
+        environment: Attrs,
     ) -> Result<ActorId, anyhow::Error> {
         let entry = self
             .by_name
             .get(actor_type)
             .ok_or_else(|| anyhow::anyhow!("actor type {} not registered", actor_type))?;
-        (entry.gspawn)(proc, actor_name, params).await
+        (entry.gspawn)(proc, actor_name, params, environment).await
     }
 }
 
@@ -136,6 +140,7 @@ mod tests {
     use std::assert_matches::assert_matches;
 
     use async_trait::async_trait;
+    use hyperactor_config::Attrs;
 
     use super::*;
     use crate as hyperactor; // for macros
@@ -154,7 +159,7 @@ mod tests {
     impl RemoteSpawn for MyActor {
         type Params = bool;
 
-        async fn new(params: bool) -> Result<Self, anyhow::Error> {
+        async fn new(params: bool, _environment: Attrs) -> Result<Self, anyhow::Error> {
             if params {
                 Ok(MyActor)
             } else {
@@ -186,6 +191,7 @@ mod tests {
                 "hyperactor::actor::remote::tests::MyActor",
                 "actor",
                 bincode::serialize(&true).unwrap(),
+                Attrs::default(),
             )
             .await
             .unwrap();
@@ -196,6 +202,7 @@ mod tests {
                 "hyperactor::actor::remote::tests::MyActor",
                 "actor",
                 bincode::serialize(&false).unwrap(),
+                Attrs::default(),
             )
             .await
             .unwrap_err();

--- a/hyperactor/src/test_utils/pingpong.rs
+++ b/hyperactor/src/test_utils/pingpong.rs
@@ -9,6 +9,7 @@
 use std::time::Duration;
 
 use async_trait::async_trait;
+use hyperactor_config::Attrs;
 use serde::Deserialize;
 use serde::Serialize;
 
@@ -74,7 +75,10 @@ impl RemoteSpawn for PingPongActor {
         Option<Duration>,
     );
 
-    async fn new((undeliverable_port_ref, error_ttl, delay): Self::Params) -> anyhow::Result<Self> {
+    async fn new(
+        (undeliverable_port_ref, error_ttl, delay): Self::Params,
+        _environment: Attrs,
+    ) -> anyhow::Result<Self> {
         Ok(Self::new(undeliverable_port_ref, error_ttl, delay))
     }
 }

--- a/hyperactor_mesh/benches/bench_actor.rs
+++ b/hyperactor_mesh/benches/bench_actor.rs
@@ -18,6 +18,7 @@ use hyperactor::PortRef;
 use hyperactor::RemoteSpawn;
 use hyperactor::Unbind;
 use hyperactor::clock::Clock;
+use hyperactor_config::Attrs;
 use serde::Deserialize;
 use serde::Serialize;
 use typeuri::Named;
@@ -46,7 +47,7 @@ impl Actor for BenchActor {}
 #[async_trait]
 impl RemoteSpawn for BenchActor {
     type Params = Duration;
-    async fn new(params: Duration) -> Result<Self, anyhow::Error> {
+    async fn new(params: Duration, _environment: Attrs) -> Result<Self, anyhow::Error> {
         Ok(Self {
             processing_time: params,
         })

--- a/hyperactor_mesh/examples/dining_philosophers.rs
+++ b/hyperactor_mesh/examples/dining_philosophers.rs
@@ -23,6 +23,7 @@ use hyperactor::PortRef;
 use hyperactor::RemoteSpawn;
 use hyperactor::Unbind;
 use hyperactor::context;
+use hyperactor_config::Attrs;
 use hyperactor_mesh::comm::multicast::CastInfo;
 use hyperactor_mesh::extent;
 use hyperactor_mesh::proc_mesh::global_root_client;
@@ -91,7 +92,7 @@ impl Actor for PhilosopherActor {}
 impl RemoteSpawn for PhilosopherActor {
     type Params = PhilosopherActorParams;
 
-    async fn new(params: Self::Params) -> Result<Self, anyhow::Error> {
+    async fn new(params: Self::Params, _environment: Attrs) -> Result<Self, anyhow::Error> {
         Ok(Self {
             chopsticks: (ChopstickStatus::None, ChopstickStatus::None),
             rank: 0, // will be set upon dining start

--- a/hyperactor_mesh/examples/sieve.rs
+++ b/hyperactor_mesh/examples/sieve.rs
@@ -23,6 +23,7 @@ use hyperactor::Handler;
 use hyperactor::PortRef;
 use hyperactor::RemoteSpawn;
 use hyperactor::channel::ChannelTransport;
+use hyperactor_config::Attrs;
 use hyperactor_mesh::Mesh;
 use hyperactor_mesh::ProcMesh;
 use hyperactor_mesh::RootActorMesh;
@@ -86,7 +87,7 @@ impl Handler<NextNumber> for SieveActor {
                     msg.prime_collector.send(cx, msg.number)?;
 
                     self.next = Some(
-                        SieveActor::new(SieveParams { prime: msg.number })
+                        SieveActor::new(SieveParams { prime: msg.number }, Attrs::default())
                             .await?
                             .spawn(cx)?,
                     );
@@ -104,7 +105,7 @@ impl RemoteSpawn for SieveActor {
     type Params = SieveParams;
 
     /// Creates a sieve actor for `prime`.
-    async fn new(params: Self::Params) -> Result<Self> {
+    async fn new(params: Self::Params, _environment: Attrs) -> Result<Self> {
         Ok(Self {
             prime: params.prime,
             next: None,

--- a/hyperactor_mesh/src/actor_mesh.rs
+++ b/hyperactor_mesh/src/actor_mesh.rs
@@ -831,7 +831,7 @@ pub(crate) mod test_util {
     impl RemoteSpawn for ProxyActor {
         type Params = ();
 
-        async fn new(_params: Self::Params) -> Result<Self, anyhow::Error> {
+        async fn new(_params: Self::Params, _environment: Attrs) -> Result<Self, anyhow::Error> {
             // The actor creates a mesh.
             use std::sync::Arc;
 
@@ -1786,6 +1786,7 @@ mod tests {
         use hyperactor::channel::serve;
         use hyperactor::clock::Clock;
         use hyperactor::clock::RealClock;
+        use hyperactor_config::Attrs;
         use ndslice::Extent;
         use ndslice::Selection;
 
@@ -1812,7 +1813,7 @@ mod tests {
         impl RemoteSpawn for EchoActor {
             type Params = ChannelAddr;
 
-            async fn new(params: ChannelAddr) -> Result<Self, anyhow::Error> {
+            async fn new(params: ChannelAddr, _environment: Attrs) -> Result<Self, anyhow::Error> {
                 Ok(Self(dial::<usize>(params)?))
             }
         }

--- a/hyperactor_mesh/src/bootstrap.rs
+++ b/hyperactor_mesh/src/bootstrap.rs
@@ -2514,14 +2514,16 @@ mod tests {
 
         // Spawn the log client and disable aggregation (immediate
         // print + tap push).
-        let log_client_actor = LogClientActor::new(()).await.unwrap();
+        let log_client_actor = LogClientActor::new((), Attrs::default()).await.unwrap();
         let log_client: ActorRef<LogClientActor> =
             proc.spawn("log_client", log_client_actor).unwrap().bind();
         log_client.set_aggregate(&client, None).await.unwrap();
 
         // Spawn the forwarder in this proc (it will serve
         // BOOTSTRAP_LOG_CHANNEL).
-        let log_forwarder_actor = LogForwardActor::new(log_client.clone()).await.unwrap();
+        let log_forwarder_actor = LogForwardActor::new(log_client.clone(), Attrs::default())
+            .await
+            .unwrap();
         let _log_forwarder: ActorRef<LogForwardActor> = proc
             .spawn("log_forwarder", log_forwarder_actor)
             .unwrap()

--- a/hyperactor_mesh/src/comm.rs
+++ b/hyperactor_mesh/src/comm.rs
@@ -652,7 +652,7 @@ pub mod test_utils {
     impl hyperactor::RemoteSpawn for TestActor {
         type Params = TestActorParams;
 
-        async fn new(params: Self::Params) -> Result<Self> {
+        async fn new(params: Self::Params, _environment: Attrs) -> Result<Self> {
             let Self::Params { forward_port } = params;
             Ok(Self { forward_port })
         }

--- a/hyperactor_mesh/src/logging.rs
+++ b/hyperactor_mesh/src/logging.rs
@@ -41,6 +41,7 @@ use hyperactor::channel::Tx;
 use hyperactor::channel::TxStatus;
 use hyperactor::clock::Clock;
 use hyperactor::clock::RealClock;
+use hyperactor_config::Attrs;
 use hyperactor_config::CONFIG;
 use hyperactor_config::ConfigAttr;
 use hyperactor_config::attrs::declare_attrs;
@@ -1015,7 +1016,7 @@ impl Actor for LogForwardActor {
 impl hyperactor::RemoteSpawn for LogForwardActor {
     type Params = ActorRef<LogClientActor>;
 
-    async fn new(logging_client_ref: Self::Params) -> Result<Self> {
+    async fn new(logging_client_ref: Self::Params, _environment: Attrs) -> Result<Self> {
         let log_channel: ChannelAddr = match std::env::var(BOOTSTRAP_LOG_CHANNEL) {
             Ok(channel) => channel.parse()?,
             Err(err) => {
@@ -1600,10 +1601,12 @@ mod tests {
         unsafe {
             std::env::set_var(BOOTSTRAP_LOG_CHANNEL, log_channel.to_string());
         }
-        let log_client_actor = LogClientActor::new(()).await.unwrap();
+        let log_client_actor = LogClientActor::new((), Attrs::default()).await.unwrap();
         let log_client: ActorRef<LogClientActor> =
             proc.spawn("log_client", log_client_actor).unwrap().bind();
-        let log_forwarder_actor = LogForwardActor::new(log_client.clone()).await.unwrap();
+        let log_forwarder_actor = LogForwardActor::new(log_client.clone(), Attrs::default())
+            .await
+            .unwrap();
         let log_forwarder: ActorRef<LogForwardActor> = proc
             .spawn("log_forwarder", log_forwarder_actor)
             .unwrap()

--- a/hyperactor_mesh/src/proc_mesh/mesh_agent.rs
+++ b/hyperactor_mesh/src/proc_mesh/mesh_agent.rs
@@ -363,7 +363,13 @@ impl MeshAgentMessageHandler for ProcMeshAgent {
         );
         let actor_id = match self
             .remote
-            .gspawn(&self.proc, &actor_type, &actor_name, params_data)
+            .gspawn(
+                &self.proc,
+                &actor_type,
+                &actor_name,
+                params_data,
+                cx.headers().clone(),
+            )
             .await
         {
             Ok(id) => id,
@@ -518,7 +524,7 @@ wirevalue::register_type!(ActorState);
 impl Handler<resource::CreateOrUpdate<ActorSpec>> for ProcMeshAgent {
     async fn handle(
         &mut self,
-        _cx: &Context<Self>,
+        cx: &Context<Self>,
         create_or_update: resource::CreateOrUpdate<ActorSpec>,
     ) -> anyhow::Result<()> {
         if self.actor_states.contains_key(&create_or_update.name) {
@@ -558,6 +564,7 @@ impl Handler<resource::CreateOrUpdate<ActorSpec>> for ProcMeshAgent {
                         &actor_type,
                         &create_or_update.name.to_string(),
                         params_data,
+                        cx.headers().clone(),
                     )
                     .await,
                 stopped: false,

--- a/hyperactor_mesh/src/reference.rs
+++ b/hyperactor_mesh/src/reference.rs
@@ -295,7 +295,10 @@ mod tests {
     impl hyperactor::RemoteSpawn for MeshPingPongActor {
         type Params = MeshPingPongActorParams;
 
-        async fn new(params: Self::Params) -> Result<Self, anyhow::Error> {
+        async fn new(
+            params: Self::Params,
+            _environment: hyperactor_config::Attrs,
+        ) -> Result<Self, anyhow::Error> {
             Ok(Self {
                 mesh_ref: ActorMeshRef::attest(params.mesh_id, params.shape, params.comm_actor_ref),
             })

--- a/hyperactor_mesh/src/v1/host_mesh/mesh_agent.rs
+++ b/hyperactor_mesh/src/v1/host_mesh/mesh_agent.rs
@@ -36,6 +36,7 @@ use hyperactor::host::HostError;
 use hyperactor::host::LocalProcManager;
 use hyperactor::host::SingleTerminate;
 use hyperactor::mailbox::PortSender as _;
+use hyperactor_config::Attrs;
 use serde::Deserialize;
 use serde::Serialize;
 use tokio::time::Duration;
@@ -568,7 +569,10 @@ impl hyperactor::RemoteSpawn for HostMeshAgentProcMeshTrampoline {
         bool, /* local? */
     );
 
-    async fn new((transport, reply_port, command, local): Self::Params) -> anyhow::Result<Self> {
+    async fn new(
+        (transport, reply_port, command, local): Self::Params,
+        _environment: Attrs,
+    ) -> anyhow::Result<Self> {
         let host = if local {
             let spawn: ProcManagerSpawnFn =
                 Box::new(|proc| Box::pin(std::future::ready(ProcMeshAgent::boot_v1(proc))));

--- a/hyperactor_mesh/src/v1/testactor.rs
+++ b/hyperactor_mesh/src/v1/testactor.rs
@@ -36,6 +36,7 @@ use hyperactor::context;
 use hyperactor::ordering::SEQ_INFO;
 use hyperactor::ordering::SeqInfo;
 use hyperactor::supervision::ActorSupervisionEvent;
+use hyperactor_config::Attrs;
 use hyperactor_config::global::Source;
 use ndslice::Point;
 #[cfg(test)]
@@ -275,6 +276,7 @@ impl hyperactor::RemoteSpawn for FailingCreateTestActor {
 
     async fn new(
         _params: Self::Params,
+        _environment: Attrs,
     ) -> Result<Self, hyperactor::internal_macro_support::anyhow::Error> {
         Err(anyhow::anyhow!("test failure"))
     }
@@ -344,6 +346,7 @@ impl hyperactor::RemoteSpawn for WrapperActor {
 
     async fn new(
         (proc_mesh, supervisor, test_name): Self::Params,
+        _environment: Attrs,
     ) -> Result<Self, hyperactor::internal_macro_support::anyhow::Error> {
         Ok(Self {
             proc_mesh,

--- a/hyperactor_mesh/test/hyperactor_mesh_proxy_test.rs
+++ b/hyperactor_mesh/test/hyperactor_mesh_proxy_test.rs
@@ -21,6 +21,7 @@ use hyperactor::Instance;
 use hyperactor::PortRef;
 use hyperactor::RemoteSpawn;
 use hyperactor::channel::ChannelTransport;
+use hyperactor_config::Attrs;
 use hyperactor_mesh::Mesh;
 use hyperactor_mesh::ProcMesh;
 use hyperactor_mesh::RootActorMesh;
@@ -71,7 +72,7 @@ impl Actor for TestActor {}
 impl RemoteSpawn for TestActor {
     type Params = ();
 
-    async fn new(_params: Self::Params) -> Result<Self, anyhow::Error> {
+    async fn new(_params: Self::Params, _environment: Attrs) -> Result<Self, anyhow::Error> {
         Ok(Self)
     }
 }
@@ -122,7 +123,10 @@ impl Actor for ProxyActor {
 impl RemoteSpawn for ProxyActor {
     type Params = String;
 
-    async fn new(exe_path: Self::Params) -> anyhow::Result<Self, anyhow::Error> {
+    async fn new(
+        exe_path: Self::Params,
+        _environment: Attrs,
+    ) -> anyhow::Result<Self, anyhow::Error> {
         let mut cmd = Command::new(PathBuf::from(&exe_path));
         cmd.arg("--bootstrap");
 

--- a/monarch_hyperactor/src/actor.rs
+++ b/monarch_hyperactor/src/actor.rs
@@ -41,6 +41,7 @@ use hyperactor_mesh::router;
 use hyperactor_mesh::supervision::MeshFailure;
 use monarch_types::PickledPyObject;
 use monarch_types::SerializablePyErr;
+use ndslice::Point;
 use pyo3::IntoPyObjectExt;
 use pyo3::exceptions::PyBaseException;
 use pyo3::exceptions::PyRuntimeError;
@@ -923,7 +924,10 @@ impl Actor for PythonActor {
 impl RemoteSpawn for PythonActor {
     type Params = PickledPyObject;
 
-    async fn new(actor_type: PickledPyObject) -> Result<Self, anyhow::Error> {
+    async fn new(
+        actor_type: PickledPyObject,
+        _environment: hyperactor_config::Attrs,
+    ) -> Result<Self, anyhow::Error> {
         Self::new(actor_type)
     }
 }

--- a/monarch_hyperactor/src/code_sync/auto_reload.rs
+++ b/monarch_hyperactor/src/code_sync/auto_reload.rs
@@ -15,6 +15,7 @@ use hyperactor::Context;
 use hyperactor::Handler;
 use hyperactor::PortRef;
 use hyperactor::RemoteSpawn;
+use hyperactor_config::Attrs;
 use monarch_types::SerializablePyErr;
 use pyo3::prelude::*;
 use serde::Deserialize;
@@ -48,7 +49,7 @@ impl Actor for AutoReloadActor {}
 impl RemoteSpawn for AutoReloadActor {
     type Params = AutoReloadParams;
 
-    async fn new(Self::Params {}: Self::Params) -> Result<Self> {
+    async fn new(Self::Params {}: Self::Params, _environment: Attrs) -> Result<Self> {
         AutoReloadActor::new().await
     }
 }

--- a/monarch_hyperactor/src/code_sync/manager.rs
+++ b/monarch_hyperactor/src/code_sync/manager.rs
@@ -33,6 +33,7 @@ use hyperactor::RemoteSpawn;
 use hyperactor::Unbind;
 use hyperactor::context;
 use hyperactor::forward;
+use hyperactor_config::Attrs;
 use hyperactor_mesh::RootActorMesh;
 use hyperactor_mesh::SlicedActorMesh;
 use hyperactor_mesh::actor_mesh::ActorMesh;
@@ -46,6 +47,7 @@ use hyperactor_mesh::v1;
 use lazy_errors::ErrorStash;
 use lazy_errors::TryCollectOrStash;
 use monarch_conda::sync::sender;
+use ndslice::Point;
 use ndslice::Selection;
 use ndslice::Shape;
 use ndslice::ShapeError;
@@ -219,7 +221,7 @@ impl Actor for CodeSyncManager {}
 impl RemoteSpawn for CodeSyncManager {
     type Params = CodeSyncManagerParams;
 
-    async fn new(CodeSyncManagerParams {}: Self::Params) -> Result<Self> {
+    async fn new(CodeSyncManagerParams {}: Self::Params, _environment: Attrs) -> Result<Self> {
         Ok(Self {
             rsync: OnceCell::new(),
             auto_reload: OnceCell::new(),

--- a/monarch_hyperactor/src/logging.rs
+++ b/monarch_hyperactor/src/logging.rs
@@ -23,6 +23,7 @@ use hyperactor::RefClient;
 use hyperactor::RemoteSpawn;
 use hyperactor::Unbind;
 use hyperactor::context;
+use hyperactor_config::Attrs;
 use hyperactor_mesh::bootstrap::MESH_ENABLE_LOG_FORWARDING;
 use hyperactor_mesh::logging::LogClientActor;
 use hyperactor_mesh::logging::LogClientMessage;
@@ -31,6 +32,7 @@ use hyperactor_mesh::logging::LogForwardMessage;
 use hyperactor_mesh::v1::ActorMesh;
 use hyperactor_mesh::v1::actor_mesh::ActorMeshRef;
 use monarch_types::SerializablePyErr;
+use ndslice::Point;
 use ndslice::View;
 use pyo3::Bound;
 use pyo3::prelude::*;
@@ -90,7 +92,7 @@ impl Actor for LoggerRuntimeActor {}
 impl RemoteSpawn for LoggerRuntimeActor {
     type Params = ();
 
-    async fn new(_: ()) -> Result<Self, anyhow::Error> {
+    async fn new(_: (), _environment: Attrs) -> Result<Self, anyhow::Error> {
         let logger =
             monarch_with_gil(|py| Self::get_logger(py).map_err(SerializablePyErr::from_fn(py)))
                 .await?;

--- a/monarch_rdma/Cargo.toml
+++ b/monarch_rdma/Cargo.toml
@@ -12,6 +12,7 @@ anyhow = "1.0.98"
 async-trait = "0.1.86"
 futures = { version = "0.3.31", features = ["async-await", "compat"] }
 hyperactor = { version = "0.0.0", path = "../hyperactor" }
+hyperactor_config = { version = "0.0.0", path = "../hyperactor_config" }
 rand = { version = "0.9", features = ["small_rng"] }
 rdmaxcel-sys = { path = "../rdmaxcel-sys" }
 regex = "1.12.2"

--- a/monarch_rdma/examples/cuda_ping_pong/Cargo.toml
+++ b/monarch_rdma/examples/cuda_ping_pong/Cargo.toml
@@ -28,8 +28,10 @@ async-trait = "0.1.86"
 buck-resources = "1"
 clap = { version = "4.5.42", features = ["derive", "env", "string", "unicode", "wrap_help"] }
 hyperactor = { version = "0.0.0", path = "../../../hyperactor" }
+hyperactor_config = { version = "0.0.0", path = "../../../hyperactor_config" }
 hyperactor_mesh = { version = "0.0.0", path = "../../../hyperactor_mesh" }
 monarch_rdma = { version = "0.0.0", path = "../.." }
+ndslice = { version = "0.0.0", path = "../../../ndslice" }
 serde = { version = "1.0.219", features = ["derive", "rc"] }
 tokio = { version = "1.47.1", features = ["full", "test-util", "tracing"] }
 tracing = { version = "0.1.41", features = ["attributes", "valuable"] }

--- a/monarch_rdma/examples/cuda_ping_pong/src/cuda_ping_pong.rs
+++ b/monarch_rdma/examples/cuda_ping_pong/src/cuda_ping_pong.rs
@@ -69,6 +69,7 @@ use hyperactor::RemoteSpawn;
 use hyperactor::Unbind;
 use hyperactor::channel::ChannelTransport;
 use hyperactor::supervision::ActorSupervisionEvent;
+use hyperactor_config::Attrs;
 use hyperactor_mesh::Mesh;
 use hyperactor_mesh::ProcMesh;
 use hyperactor_mesh::RootActorMesh;
@@ -274,7 +275,7 @@ impl Actor for CudaRdmaActor {
 impl RemoteSpawn for CudaRdmaActor {
     type Params = (ActorRef<RdmaManagerActor>, usize, usize);
 
-    async fn new(params: Self::Params) -> Result<Self, anyhow::Error> {
+    async fn new(params: Self::Params, _environment: Attrs) -> Result<Self, anyhow::Error> {
         let (rdma_manager, device_id, buffer_size) = params;
         let cpu_buffer = vec![0u8; buffer_size].into_boxed_slice();
 

--- a/monarch_rdma/examples/parameter_server/Cargo.toml
+++ b/monarch_rdma/examples/parameter_server/Cargo.toml
@@ -25,6 +25,7 @@ anyhow = "1.0.98"
 async-trait = "0.1.86"
 buck-resources = "1"
 hyperactor = { version = "0.0.0", path = "../../../hyperactor" }
+hyperactor_config = { version = "0.0.0", path = "../../../hyperactor_config" }
 hyperactor_mesh = { version = "0.0.0", path = "../../../hyperactor_mesh" }
 monarch_rdma = { version = "0.0.0", path = "../.." }
 ndslice = { version = "0.0.0", path = "../../../ndslice" }

--- a/monarch_rdma/examples/parameter_server/src/parameter_server.rs
+++ b/monarch_rdma/examples/parameter_server/src/parameter_server.rs
@@ -69,6 +69,7 @@ use hyperactor::Unbind;
 use hyperactor::channel::ChannelTransport;
 use hyperactor::context::Mailbox as _;
 use hyperactor::supervision::ActorSupervisionEvent;
+use hyperactor_config::Attrs;
 use hyperactor_mesh::Mesh;
 use hyperactor_mesh::ProcMesh;
 use hyperactor_mesh::RootActorMesh;
@@ -129,7 +130,7 @@ impl Actor for ParameterServerActor {
 impl RemoteSpawn for ParameterServerActor {
     type Params = (ActorRef<RdmaManagerActor>, usize);
 
-    async fn new(_params: Self::Params) -> Result<Self, anyhow::Error> {
+    async fn new(_params: Self::Params, _environment: Attrs) -> Result<Self, anyhow::Error> {
         let (owner_ref, worker_world_size) = _params;
         tracing::info!("creating parameter server actor");
         let weights_data = vec![0u8; BUFFER_SIZE].into_boxed_slice();
@@ -265,7 +266,7 @@ impl Actor for WorkerActor {
 impl RemoteSpawn for WorkerActor {
     type Params = ();
 
-    async fn new(_params: Self::Params) -> Result<Self, anyhow::Error> {
+    async fn new(_params: Self::Params, _environment: Attrs) -> Result<Self, anyhow::Error> {
         let weights_data = vec![0u8; BUFFER_SIZE].into_boxed_slice();
         let local_gradients = vec![0u8; BUFFER_SIZE].into_boxed_slice();
         Ok(Self {

--- a/monarch_rdma/src/rdma_manager_actor.rs
+++ b/monarch_rdma/src/rdma_manager_actor.rs
@@ -47,6 +47,7 @@ use hyperactor::RefClient;
 use hyperactor::RemoteSpawn;
 use hyperactor::clock::Clock;
 use hyperactor::supervision::ActorSupervisionEvent;
+use hyperactor_config::Attrs;
 use serde::Deserialize;
 use serde::Serialize;
 use typeuri::Named;
@@ -482,7 +483,7 @@ impl RdmaManagerActor {
 impl RemoteSpawn for RdmaManagerActor {
     type Params = Option<IbverbsConfig>;
 
-    async fn new(params: Self::Params) -> Result<Self, anyhow::Error> {
+    async fn new(params: Self::Params, _environment: Attrs) -> Result<Self, anyhow::Error> {
         if !ibverbs_supported() {
             return Err(anyhow::anyhow!(
                 "Cannot create RdmaManagerActor because RDMA is not supported on this machine"

--- a/monarch_rdma/src/test_utils.rs
+++ b/monarch_rdma/src/test_utils.rs
@@ -88,6 +88,7 @@ pub mod test_utils {
     use hyperactor::channel::ChannelTransport;
     use hyperactor::clock::Clock;
     use hyperactor::clock::RealClock;
+    use hyperactor_config::Attrs;
     use hyperactor_mesh::Mesh;
     use hyperactor_mesh::ProcMesh;
     use hyperactor_mesh::RootActorMesh;
@@ -131,7 +132,7 @@ pub mod test_utils {
     impl RemoteSpawn for CudaActor {
         type Params = i32;
 
-        async fn new(device_id: i32) -> Result<Self, anyhow::Error> {
+        async fn new(device_id: i32, _environment: Attrs) -> Result<Self, anyhow::Error> {
             unsafe {
                 cu_check!(rdmaxcel_sys::rdmaxcel_cuInit(0));
                 let mut device: rdmaxcel_sys::CUdevice = std::mem::zeroed();

--- a/monarch_tensor_worker/Cargo.toml
+++ b/monarch_tensor_worker/Cargo.toml
@@ -13,6 +13,7 @@ async-trait = "0.1.86"
 derive_more = { version = "1.0.0", features = ["full"] }
 futures = { version = "0.3.31", features = ["async-await", "compat"] }
 hyperactor = { version = "0.0.0", path = "../hyperactor" }
+hyperactor_config = { version = "0.0.0", path = "../hyperactor_config" }
 hyperactor_mesh = { version = "0.0.0", path = "../hyperactor_mesh" }
 itertools = "0.14.0"
 monarch_hyperactor = { version = "0.0.0", path = "../monarch_hyperactor" }

--- a/monarch_tensor_worker/src/borrow.rs
+++ b/monarch_tensor_worker/src/borrow.rs
@@ -15,6 +15,7 @@ use hyperactor::PortHandle;
 use hyperactor::actor::ActorHandle;
 use hyperactor::context;
 use hyperactor::mailbox::PortReceiver;
+use hyperactor_config::Attrs;
 use tokio::sync::Mutex;
 use torch_sys_cuda::cuda::Event;
 
@@ -201,12 +202,15 @@ mod tests {
         let worker_handle = proc
             .spawn::<WorkerActor>(
                 "worker",
-                WorkerActor::new(WorkerParams {
-                    world_size: 1,
-                    rank: 0,
-                    device_index: None,
-                    controller_actor: controller_ref,
-                })
+                WorkerActor::new(
+                    WorkerParams {
+                        world_size: 1,
+                        rank: 0,
+                        device_index: None,
+                        controller_actor: controller_ref,
+                    },
+                    Attrs::default(),
+                )
                 .await?,
             )
             .unwrap();
@@ -353,12 +357,15 @@ mod tests {
         let worker_handle = proc
             .spawn::<WorkerActor>(
                 "worker",
-                WorkerActor::new(WorkerParams {
-                    world_size: 1,
-                    rank: 0,
-                    device_index: None,
-                    controller_actor: controller_ref,
-                })
+                WorkerActor::new(
+                    WorkerParams {
+                        world_size: 1,
+                        rank: 0,
+                        device_index: None,
+                        controller_actor: controller_ref,
+                    },
+                    Attrs::default(),
+                )
                 .await
                 .unwrap(),
             )

--- a/monarch_tensor_worker/src/comm.rs
+++ b/monarch_tensor_worker/src/comm.rs
@@ -19,6 +19,7 @@ use hyperactor::Handler;
 use hyperactor::actor::ActorHandle;
 use hyperactor::forward;
 use hyperactor::mailbox::OncePortHandle;
+use hyperactor_config::Attrs;
 use parking_lot::Mutex;
 use tokio::task::spawn_blocking;
 use torch_sys_cuda::cuda::Event;
@@ -655,12 +656,15 @@ mod tests {
         let workers = try_join_all((0..world_size).map(async |rank| {
             proc.spawn(
                 &format!("worker{}", rank),
-                WorkerActor::new(WorkerParams {
-                    world_size,
-                    rank,
-                    device_index: Some(rank.try_into()?),
-                    controller_actor: controller_ref.clone(),
-                })
+                WorkerActor::new(
+                    WorkerParams {
+                        world_size,
+                        rank,
+                        device_index: Some(rank.try_into()?),
+                        controller_actor: controller_ref.clone(),
+                    },
+                    Attrs::default(),
+                )
                 .await
                 .unwrap(),
             )
@@ -839,12 +843,15 @@ mod tests {
         let handle1 = proc
             .spawn(
                 "worker1",
-                WorkerActor::new(WorkerParams {
-                    world_size: 2,
-                    rank: 0,
-                    device_index: Some(0),
-                    controller_actor: controller_ref.clone(),
-                })
+                WorkerActor::new(
+                    WorkerParams {
+                        world_size: 2,
+                        rank: 0,
+                        device_index: Some(0),
+                        controller_actor: controller_ref.clone(),
+                    },
+                    Attrs::default(),
+                )
                 .await
                 .unwrap(),
             )
@@ -852,12 +859,15 @@ mod tests {
         let handle2 = proc
             .spawn(
                 "worker2",
-                WorkerActor::new(WorkerParams {
-                    world_size: 2,
-                    rank: 1,
-                    device_index: Some(1),
-                    controller_actor: controller_ref,
-                })
+                WorkerActor::new(
+                    WorkerParams {
+                        world_size: 2,
+                        rank: 1,
+                        device_index: Some(1),
+                        controller_actor: controller_ref,
+                    },
+                    Attrs::default(),
+                )
                 .await
                 .unwrap(),
             )
@@ -1018,12 +1028,15 @@ mod tests {
         let handle = proc
             .spawn(
                 "worker",
-                WorkerActor::new(WorkerParams {
-                    world_size: 1,
-                    rank: 0,
-                    device_index: Some(0),
-                    controller_actor: controller_ref,
-                })
+                WorkerActor::new(
+                    WorkerParams {
+                        world_size: 1,
+                        rank: 0,
+                        device_index: Some(0),
+                        controller_actor: controller_ref,
+                    },
+                    Attrs::default(),
+                )
                 .await
                 .unwrap(),
             )

--- a/monarch_tensor_worker/src/lib.rs
+++ b/monarch_tensor_worker/src/lib.rs
@@ -60,6 +60,7 @@ use hyperactor::Unbind;
 use hyperactor::actor::ActorHandle;
 use hyperactor::context;
 use hyperactor::reference::ActorId;
+use hyperactor_config::Attrs;
 use hyperactor_mesh::comm::multicast::CastInfo;
 use itertools::Itertools;
 use monarch_hyperactor::shape::PyPoint;
@@ -228,6 +229,7 @@ impl RemoteSpawn for WorkerActor {
             device_index,
             controller_actor,
         }: Self::Params,
+        _environment: Attrs,
     ) -> Result<Self> {
         Python::with_gil(|py| {
             py.import("monarch.safe_torch").unwrap();
@@ -1116,12 +1118,15 @@ mod tests {
         let worker_handle = proc
             .spawn(
                 "worker",
-                WorkerActor::new(WorkerParams {
-                    world_size: 1,
-                    rank: 0,
-                    device_index: None,
-                    controller_actor: controller_ref,
-                })
+                WorkerActor::new(
+                    WorkerParams {
+                        world_size: 1,
+                        rank: 0,
+                        device_index: None,
+                        controller_actor: controller_ref,
+                    },
+                    Attrs::default(),
+                )
                 .await
                 .unwrap(),
             )
@@ -1222,12 +1227,15 @@ mod tests {
         let worker_handle = proc
             .spawn(
                 "worker",
-                WorkerActor::new(WorkerParams {
-                    world_size: 1,
-                    rank: 0,
-                    device_index: None,
-                    controller_actor: controller_ref,
-                })
+                WorkerActor::new(
+                    WorkerParams {
+                        world_size: 1,
+                        rank: 0,
+                        device_index: None,
+                        controller_actor: controller_ref,
+                    },
+                    Attrs::default(),
+                )
                 .await
                 .unwrap(),
             )
@@ -1282,12 +1290,15 @@ mod tests {
         let worker_handle = proc
             .spawn(
                 "worker",
-                WorkerActor::new(WorkerParams {
-                    world_size: 1,
-                    rank: 0,
-                    device_index: None,
-                    controller_actor: controller_ref,
-                })
+                WorkerActor::new(
+                    WorkerParams {
+                        world_size: 1,
+                        rank: 0,
+                        device_index: None,
+                        controller_actor: controller_ref,
+                    },
+                    Attrs::default(),
+                )
                 .await
                 .unwrap(),
             )
@@ -1353,12 +1364,15 @@ mod tests {
         let worker_handle = proc
             .spawn(
                 "worker",
-                WorkerActor::new(WorkerParams {
-                    world_size: 1,
-                    rank: 0,
-                    device_index: None,
-                    controller_actor: controller_ref,
-                })
+                WorkerActor::new(
+                    WorkerParams {
+                        world_size: 1,
+                        rank: 0,
+                        device_index: None,
+                        controller_actor: controller_ref,
+                    },
+                    Attrs::default(),
+                )
                 .await
                 .unwrap(),
             )
@@ -1429,12 +1443,15 @@ mod tests {
         let worker_handle = proc
             .spawn(
                 "worker",
-                WorkerActor::new(WorkerParams {
-                    world_size: 1,
-                    rank: 0,
-                    device_index: None,
-                    controller_actor: controller_ref,
-                })
+                WorkerActor::new(
+                    WorkerParams {
+                        world_size: 1,
+                        rank: 0,
+                        device_index: None,
+                        controller_actor: controller_ref,
+                    },
+                    Attrs::default(),
+                )
                 .await
                 .unwrap(),
             )
@@ -1728,12 +1745,15 @@ mod tests {
         let worker_handle = proc
             .spawn(
                 "worker",
-                WorkerActor::new(WorkerParams {
-                    world_size: 1,
-                    rank: 0,
-                    device_index: None,
-                    controller_actor: controller_ref,
-                })
+                WorkerActor::new(
+                    WorkerParams {
+                        world_size: 1,
+                        rank: 0,
+                        device_index: None,
+                        controller_actor: controller_ref,
+                    },
+                    Attrs::default(),
+                )
                 .await
                 .unwrap(),
             )
@@ -1803,12 +1823,15 @@ mod tests {
         let worker_handle = proc
             .spawn(
                 "worker",
-                WorkerActor::new(WorkerParams {
-                    world_size: 1,
-                    rank: 0,
-                    device_index: None,
-                    controller_actor: controller_ref,
-                })
+                WorkerActor::new(
+                    WorkerParams {
+                        world_size: 1,
+                        rank: 0,
+                        device_index: None,
+                        controller_actor: controller_ref,
+                    },
+                    Attrs::default(),
+                )
                 .await
                 .unwrap(),
             )
@@ -1889,12 +1912,15 @@ mod tests {
         let worker_handle1 = proc
             .spawn(
                 "worker0",
-                WorkerActor::new(WorkerParams {
-                    world_size: 2,
-                    rank: 0,
-                    device_index: Some(0),
-                    controller_actor: controller_ref.clone(),
-                })
+                WorkerActor::new(
+                    WorkerParams {
+                        world_size: 2,
+                        rank: 0,
+                        device_index: Some(0),
+                        controller_actor: controller_ref.clone(),
+                    },
+                    Attrs::default(),
+                )
                 .await
                 .unwrap(),
             )
@@ -1902,12 +1928,15 @@ mod tests {
         let worker_handle2 = proc
             .spawn(
                 "worker1",
-                WorkerActor::new(WorkerParams {
-                    world_size: 2,
-                    rank: 1,
-                    device_index: Some(1),
-                    controller_actor: controller_ref,
-                })
+                WorkerActor::new(
+                    WorkerParams {
+                        world_size: 2,
+                        rank: 1,
+                        device_index: Some(1),
+                        controller_actor: controller_ref,
+                    },
+                    Attrs::default(),
+                )
                 .await
                 .unwrap(),
             )


### PR DESCRIPTION
Summary:
Add an optional `ndslice::Point` as an argument to `RemoteSpawn::new`. When an actor is spawned remotely as part of a proc mesh, the proc mesh agent will plumb the cast point through `RemoteSpawn::gspawn` so that the actor being spawned has access to its cast rank and coordinates when it is created.

This will improve the experience for actors (like PythonActor) that need to know their position in an actor mesh before their full capabilities are available; previously, we would need to first spawn the actor, and then separately send a message with its cast point, which can cause race conditions.

Differential Revision: D91663308


