### PR TITLE
Add pytest fixture for shutting down monarch client

### DIFF
--- a/monarch_hyperactor/src/context.rs
+++ b/monarch_hyperactor/src/context.rs
@@ -11,6 +11,7 @@ use hyperactor::context;
 use hyperactor_mesh::comm::multicast::CastInfo;
 use ndslice::Extent;
 use ndslice::Point;
+use pyo3::exceptions::PyRuntimeError;
 use pyo3::prelude::*;
 
 use crate::actor::PythonActor;
@@ -85,6 +86,15 @@ impl PyInstance {
     fn abort(&self, reason: Option<&str>) -> PyResult<()> {
         let reason = reason.unwrap_or("(no reason provided)");
         Ok(self.inner.abort(reason).map_err(anyhow::Error::from)?)
+    }
+
+    #[pyo3(signature = (reason = None))]
+    fn _stop_instance(&self, reason: Option<&str>) -> PyResult<()> {
+        tracing::info!(actor_id = %self.inner.self_id(), "stopping PyInstance");
+        let reason = reason.unwrap_or("(no reason provided)");
+        self.inner
+            .stop(reason)
+            .map_err(|e| PyRuntimeError::new_err(e.to_string()))
     }
 }
 

--- a/monarch_hyperactor/src/host_mesh.rs
+++ b/monarch_hyperactor/src/host_mesh.rs
@@ -25,7 +25,7 @@ use hyperactor_mesh::v1::host_mesh::HostMesh;
 use hyperactor_mesh::v1::host_mesh::HostMeshRef;
 use hyperactor_mesh::v1::host_mesh::mesh_agent::GetLocalProcClient;
 use hyperactor_mesh::v1::host_mesh::mesh_agent::HostMeshAgent;
-use hyperactor_mesh::v1::host_mesh::mesh_agent::ShutdownHostClient;
+use hyperactor_mesh::v1::host_mesh::mesh_agent::ShutdownHost;
 use hyperactor_mesh::v1::proc_mesh::ProcRef;
 use ndslice::View;
 use ndslice::view::RankedSliceable;
@@ -360,12 +360,28 @@ fn shutdown_local_host_mesh() -> PyResult<PyPythonTask> {
             .instance("shutdown_requester")
             .map_err(|e| PyException::new_err(e.to_string()))?;
 
+        tracing::info!(
+            "sending shutdown_host request to agent {}",
+            agent.actor_id()
+        );
         // Use same defaults as HostMesh::shutdown():
         // - MESH_TERMINATE_TIMEOUT = 10 seconds
         // - MESH_TERMINATE_CONCURRENCY = 16
+
+        let (port, _) = instance.open_port();
+        let mut port = port.bind();
+        // We don't need the ack, and this temporary proc doesn't have a mailbox
+        // receiver set up anyways. Just ignore the message.
+        port.return_undeliverable(false);
         agent
-            .shutdown_host(&instance, Duration::from_secs(10), 16)
-            .await
+            .send(
+                &instance,
+                ShutdownHost {
+                    timeout: Duration::from_secs(10),
+                    max_in_flight: 16,
+                    ack: port,
+                },
+            )
             .map_err(|e| PyException::new_err(e.to_string()))?;
 
         Ok(())

--- a/python/tests/test_client_shutdown.py
+++ b/python/tests/test_client_shutdown.py
@@ -1,0 +1,58 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import os
+import time
+
+import pytest
+from monarch.actor import Actor, endpoint, shutdown_context, this_host
+
+
+class Simple(Actor):
+    @endpoint
+    def get_pid(self) -> int:
+        return os.getpid()
+
+
+def pid_exists(pid: int) -> bool:
+    """True if pid exists, else false"""
+    try:
+        os.kill(pid, 0)
+    except OSError:
+        return False
+    else:
+        return True
+
+
+# This test has to be in its own file so it does not share any process state
+# with other tests. The client cannot be restarted after it has been shutdown.
+# pyre-fixme[56]: invalid decoration
+@pytest.mark.timeout(30)
+def test_client_shutdown() -> None:
+    procs = this_host().spawn_procs(per_host={"gpus": 2})
+    actors = procs.spawn("simple", Simple)
+    pids = actors.get_pid.call().get()
+    pids = [p for _, p in pids]
+    # Now shutdown the client. Delete references to avoid accidental reuse.
+    del procs
+    del actors
+    shutdown_context().get()
+    # After this, all the resources created by the client should be released,
+    # including this_host and the procs. We check this by seeing if the pids are
+    # still alive after a short wait period (procs are cleaned up with an async
+    # message).
+    still_alive = []
+    for _ in range(4):
+        time.sleep(5)
+        still_alive = [pid_exists(pid) for pid in pids]
+        if not any(still_alive):
+            # successfully shut off all pids.
+            return
+    raise ValueError(
+        "Some pids are still alive at the end of the waiting period: {}", still_alive
+    )


### PR DESCRIPTION
Summary:
Fixes: https://github.com/meta-pytorch/monarch/issues/1955

In order to guarantee each test is executed predictably regardless of order with respect
to other tests, add a pytest fixture that initializes and tears down the client at startup and teardown.

By doing a "stop()" on the global root client, it will do a cleanup that will stop all resources (hosts, procs, actors, meshes of these) it created.
Then a new client can be generated for the next test.

Differential Revision: D90618802


