### PR TITLE
Fix #[track_caller] in channel::serve

### DIFF
--- a/hyperactor/src/channel.rs
+++ b/hyperactor/src/channel.rs
@@ -1016,7 +1016,6 @@ pub fn dial<M: RemoteMessage>(addr: ChannelAddr) -> Result<ChannelTx<M>, Channel
 
 /// Serve on the provided channel address. The server is turned down
 /// when the returned Rx is dropped.
-#[crate::instrument]
 #[track_caller]
 pub fn serve<M: RemoteMessage>(
     addr: ChannelAddr,


### PR DESCRIPTION
Summary:
The #[crate::instrument] attribute was breaking #[track_caller] on the
serve function. Proc macros like instrument generate wrapper code that
breaks the caller location chain, causing Location::caller() to capture
the wrong location (line where caller is defined, not the actual caller).

Removing #[crate::instrument] fixes this since serve already has manual
tracing::debug! inside the .map() closure.

Reviewed By: thomasywang

Differential Revision: D91721169


