### PR TITLE
: python/tests/_monarch: test_proc_launcher_probe

### DIFF
--- a/monarch_extension/src/lib.rs
+++ b/monarch_extension/src/lib.rs
@@ -225,6 +225,11 @@ pub fn mod_init(module: &Bound<'_, PyModule>) -> PyResult<()> {
         "monarch_hyperactor.namespace",
     )?)?;
 
+    monarch_hyperactor::proc_launcher_probe::register_python_bindings(&get_or_add_new_module(
+        module,
+        "monarch_hyperactor.proc_launcher_probe",
+    )?)?;
+
     crate::trace::register_python_bindings(&get_or_add_new_module(
         module,
         "monarch_extension.trace",

--- a/monarch_hyperactor/src/actor_mesh.rs
+++ b/monarch_hyperactor/src/actor_mesh.rs
@@ -150,7 +150,7 @@ pub(crate) fn to_hy_sel(selection: &str) -> PyResult<Selection> {
 #[pymethods]
 impl PythonActorMesh {
     #[hyperactor::instrument]
-    fn cast(
+    pub(crate) fn cast(
         &self,
         message: &PythonMessage,
         selection: &str,

--- a/monarch_hyperactor/src/lib.rs
+++ b/monarch_hyperactor/src/lib.rs
@@ -28,6 +28,7 @@ pub mod metrics;
 pub mod namespace;
 pub mod ndslice;
 pub mod proc;
+pub mod proc_launcher_probe;
 pub mod proc_mesh;
 pub mod py_cell;
 pub mod pympsc;

--- a/monarch_hyperactor/src/proc_launcher_probe.rs
+++ b/monarch_hyperactor/src/proc_launcher_probe.rs
@@ -1,0 +1,165 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+//! Probe module for validating the explicit response port contract.
+//!
+//! This module exposes a Rust function callable from Python that
+//! inspects what Rust receives when a Python actor sends on a port
+//! created via `explicit_response_port=True`.
+//!
+//! In particular, it answers the question: when Python calls
+//! `Port.send(value)` or `Port.exception(error)`, does Rust receive a
+//! `PythonMessage` envelope with `kind = Result` or `kind =
+//! Exception`?
+
+use pyo3::prelude::*;
+use pyo3::types::PyModule;
+use pyo3::types::PyModuleMethods;
+
+use crate::actor::MethodSpecifier;
+use crate::actor::PythonMessage;
+use crate::actor::PythonMessageKind;
+use crate::actor_mesh::PythonActorMesh;
+use crate::context::PyInstance;
+use crate::mailbox::EitherPortRef;
+use crate::mailbox::PyMailbox;
+use crate::mailbox::PythonOncePortRef;
+use crate::pytokio::PyPythonTask;
+
+/// Report describing what Rust received on the port.
+///
+/// This is returned to Python so tests can assert on the wire-level
+/// message shape, without decoding or interpreting the payload.
+#[pyclass(
+    frozen,
+    module = "monarch._rust_bindings.monarch_hyperactor.proc_launcher_probe"
+)]
+#[derive(Debug, Clone)]
+pub struct ProbeReport {
+    /// High-level classification of what was received: e.g.
+    /// "PythonMessage" or "Error".
+    #[pyo3(get)]
+    pub received_type: String,
+
+    /// If a PythonMessage was received, the message kind ("Result",
+    /// "Exception", etc).
+    #[pyo3(get)]
+    pub kind: Option<String>,
+
+    /// If a PythonMessage was received, the `rank` field carried by
+    /// the message kind (if any).
+    #[pyo3(get)]
+    pub rank: Option<usize>,
+
+    /// Whether the message carried a pending pickle state.
+    #[pyo3(get)]
+    pub pending_pickle_state_present: Option<bool>,
+
+    /// Length in bytes of the raw message payload.
+    #[pyo3(get)]
+    pub payload_len: usize,
+
+    /// Raw payload bytes as received by Rust.
+    ///
+    /// Exposed so Python can decode the payload (e.g. via
+    /// cloudpickle) and verify its contents.
+    #[pyo3(get)]
+    pub payload_bytes: Vec<u8>,
+
+    /// Error message if the probe failed before receiving a message.
+    #[pyo3(get)]
+    pub error: Option<String>,
+}
+
+/// Register the probe bindings in the Python extension module.
+pub fn register_python_bindings(module: &Bound<'_, PyModule>) -> PyResult<()> {
+    module.add_class::<ProbeReport>()?;
+    module.add_function(wrap_pyfunction!(probe_exit_port_via_mesh, module)?)?;
+    Ok(())
+}
+
+/// Probe the explicit response port via the actor mesh.
+///
+/// This function:
+/// 1. Opens a `OncePort<PythonMessage>` from the given mailbox.
+/// 2. Sends a `CallMethod(ExplicitPort)` message to `method_name` via
+///    `actor_mesh_inner.cast(...)`.
+/// 3. Awaits the first message received on the port.
+/// 4. Returns a `ProbeReport` describing what Rust observed.
+///
+/// The purpose is not to test endpoint semantics, but to validate the
+/// *wire envelope* delivered to Rust for explicit response ports.
+///
+/// Arguments:
+/// - `actor_mesh_inner`: The internal actor mesh used to dispatch the
+///   call.
+/// - `instance`: The calling context's Rust instance handle.
+/// - `mailbox`: The mailbox used to allocate the response port.
+/// - `method_name`: Name of the Python endpoint to invoke.
+/// - `pickled_args`: Opaque serialized argument payload for the call.
+///
+/// Returns:
+/// An awaitable task yielding a `ProbeReport`.
+#[pyfunction]
+#[pyo3(signature = (actor_mesh_inner, instance, mailbox, method_name, pickled_args))]
+pub(crate) fn probe_exit_port_via_mesh(
+    actor_mesh_inner: &PythonActorMesh,
+    instance: &PyInstance,
+    mailbox: &PyMailbox,
+    method_name: String,
+    pickled_args: Vec<u8>,
+) -> PyResult<PyPythonTask> {
+    // Open a OncePort<PythonMessage> - this is what ActorProcLauncher
+    // does
+    let (exit_port, exit_port_rx) = mailbox.get_inner().open_once_port::<PythonMessage>();
+
+    // Build the PythonMessage with ExplicitPort
+    let bound_port = exit_port.bind();
+    let message = PythonMessage {
+        kind: PythonMessageKind::CallMethod {
+            name: MethodSpecifier::ExplicitPort {
+                name: method_name.clone(),
+            },
+            response_port: Some(EitherPortRef::Once(PythonOncePortRef::from(bound_port))),
+        },
+        message: pickled_args.into(),
+        pending_pickle_state: None,
+    };
+
+    // Cast to all actors in the mesh (should be just 1 for sliced
+    // mesh)
+    actor_mesh_inner.cast(&message, "all", instance)?;
+
+    // Return an awaitable task that receives the result
+    PyPythonTask::new(async move {
+        let msg = exit_port_rx.recv().await.map_err(|e| {
+            PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(format!("recv failed: {}", e))
+        })?;
+
+        let (kind, rank) = match &msg.kind {
+            PythonMessageKind::Result { rank } => ("Result".to_string(), *rank),
+            PythonMessageKind::Exception { rank } => ("Exception".to_string(), *rank),
+            PythonMessageKind::CallMethod { .. } => ("CallMethod".to_string(), None),
+            PythonMessageKind::CallMethodIndirect { .. } => {
+                ("CallMethodIndirect".to_string(), None)
+            }
+            PythonMessageKind::Uninit {} => ("Uninit".to_string(), None),
+        };
+
+        let payload = msg.message.to_bytes().to_vec();
+        Ok(ProbeReport {
+            received_type: "PythonMessage".to_string(),
+            kind: Some(kind),
+            rank,
+            pending_pickle_state_present: Some(msg.pending_pickle_state.is_some()),
+            payload_len: payload.len(),
+            payload_bytes: payload,
+            error: None,
+        })
+    })
+}

--- a/python/monarch/_rust_bindings/monarch_hyperactor/proc_launcher_probe.pyi
+++ b/python/monarch/_rust_bindings/monarch_hyperactor/proc_launcher_probe.pyi
@@ -1,0 +1,64 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from typing import final
+
+from monarch._rust_bindings.monarch_hyperactor.actor_mesh import PythonActorMesh
+from monarch._rust_bindings.monarch_hyperactor.context import Instance
+from monarch._rust_bindings.monarch_hyperactor.mailbox import Mailbox
+from monarch._rust_bindings.monarch_hyperactor.pytokio import PythonTask
+
+@final
+class ProbeReport:
+    """Report describing what Rust received on the port."""
+
+    @property
+    def received_type(self) -> str:
+        """High-level classification: 'PythonMessage' or 'Error'."""
+        ...
+
+    @property
+    def kind(self) -> str | None:
+        """If PythonMessage, the kind: 'Result', 'Exception', etc."""
+        ...
+
+    @property
+    def rank(self) -> int | None:
+        """If PythonMessage, the rank field from Result/Exception."""
+        ...
+
+    @property
+    def pending_pickle_state_present(self) -> bool | None:
+        """If PythonMessage, whether pending_pickle_state was present."""
+        ...
+
+    @property
+    def payload_len(self) -> int:
+        """Length of the message payload bytes."""
+        ...
+
+    @property
+    def payload_bytes(self) -> list[int]:
+        """Raw payload bytes."""
+        ...
+
+    @property
+    def error(self) -> str | None:
+        """Error message if something went wrong."""
+        ...
+
+def probe_exit_port_via_mesh(
+    actor_mesh_inner: PythonActorMesh,
+    instance: Instance,
+    mailbox: Mailbox,
+    method_name: str,
+    pickled_args: bytes,
+) -> PythonTask[ProbeReport]:
+    """Probe the wire format by calling an endpoint and receiving on a
+    port."""
+    ...

--- a/python/tests/test_proc_launcher_probe.py
+++ b/python/tests/test_proc_launcher_probe.py
@@ -1,0 +1,206 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-unsafe
+
+"""Wire format probe test for port communication.
+
+This is a wire-format probe, not a lifecycle simulation. It validates
+that when Python calls `port.send(value)` or `port.exception(exc)`,
+Rust receives the expected `PythonMessage` envelope with `kind=Result`
+or `kind=Exception`.
+
+"""
+
+import functools
+from dataclasses import dataclass
+from typing import Any, Callable, cast, Coroutine
+
+import cloudpickle
+from monarch._rust_bindings.monarch_hyperactor.actor_mesh import PythonActorMesh
+from monarch._rust_bindings.monarch_hyperactor.proc_launcher_probe import (
+    probe_exit_port_via_mesh,
+)
+from monarch._rust_bindings.monarch_hyperactor.pytokio import PythonTask
+from monarch._src.actor.actor_mesh import Actor, ActorMesh, context, Port
+from monarch._src.actor.endpoint import endpoint
+from monarch._src.actor.host_mesh import this_host
+
+
+@dataclass
+class ProbePayload:
+    """Payload for wire format testing."""
+
+    value: int
+    items: list[str]
+
+
+class WireFormatProbeActor(Actor):
+    """Test actor for probing port wire format. Not a realistic
+    launcher."""
+
+    @endpoint(explicit_response_port=True)
+    async def send_result_on_port(self, port: Port[ProbePayload], tag: str) -> None:
+        """Send a Result payload to the port."""
+        payload = ProbePayload(
+            value=42,
+            items=["line1", "line2"],
+        )
+        port.send(payload)
+
+    @endpoint(explicit_response_port=True)
+    async def send_exception_on_port(self, port: Port[ProbePayload], tag: str) -> None:
+        """Catch an error and explicitly send it as an exception on
+        the port.
+
+        This simulates a caller that catches a failure and reports it
+        via the port. It is NOT "endpoint threw" - the endpoint
+        completes normally after sending the exception.
+
+        """
+        try:
+            raise ValueError("simulated failure")
+        except ValueError as e:
+            port.exception(e)
+
+
+def _python_task_test(
+    fn: Callable[[], Coroutine[Any, Any, None]],
+) -> Callable[[], None]:
+    """
+    Wrapper for tests that use the internal tokio event loop
+    APIs and need to run on that event loop.
+    """
+
+    @functools.wraps(fn)
+    def wrapper() -> None:
+        return PythonTask.from_coroutine(fn()).block_on()
+
+    return wrapper
+
+
+@_python_task_test
+async def test_port_receives_result() -> None:
+    """Test that Rust receives PythonMessage(Result) with cloudpickled
+    payload."""
+
+    # Spawn the test actor.
+    # Cast needed: spawn() is typed to return TActor for ergonomic
+    # method access, but actually returns ActorMesh[TActor]. We need
+    # ActorMesh to call slice().
+    proc_mesh = this_host().spawn_procs(per_host={"gpus": 1})
+    actor_mesh = cast(
+        ActorMesh[WireFormatProbeActor],
+        proc_mesh.spawn("probe_actor", WireFormatProbeActor),
+    )
+
+    # Get instance and mailbox from the test context
+    ins = context().actor_instance
+    instance = ins._as_rust()
+    mailbox = ins._mailbox
+
+    # Slice to a single actor and get its _inner (PythonActorMesh).
+    # Cast needed: _inner is typed as ActorMeshProtocol but
+    # probe_exit_port_via_mesh expects PythonActorMesh. At runtime
+    # _inner is a PythonActorMesh.
+    single_actor_mesh = actor_mesh.slice(gpus=0)
+    actor_mesh_inner = cast(PythonActorMesh, single_actor_mesh._inner)
+
+    # Pickle the args - port will be injected by runtime Args should
+    # be (args_tuple, kwargs_dict) format
+    args = ("test_tag",)
+    kwargs = {}
+    pickled_args = cloudpickle.dumps((args, kwargs))
+
+    # Call the Rust probe and await the result
+    report = await probe_exit_port_via_mesh(
+        actor_mesh_inner, instance, mailbox, "send_result_on_port", pickled_args
+    )
+
+    # Assert we received a PythonMessage
+    assert report.received_type == "PythonMessage", f"Got {report.received_type}"
+    assert report.error is None, f"Unexpected error: {report.error}"
+
+    # Assert it's a Result, not an Exception
+    assert report.kind == "Result", f"Expected Result, got {report.kind}"
+    assert report.rank is not None, "rank should be present for Result"
+
+    # Assert no pending pickle state
+    assert report.pending_pickle_state_present is False, (
+        "pending_pickle_state should be None"
+    )
+
+    # Assert the payload can be decoded with cloudpickle
+    payload = cloudpickle.loads(bytes(report.payload_bytes))
+
+    # Verify it's the expected ProbePayload
+    assert isinstance(payload, ProbePayload), (
+        f"Expected ProbePayload, got {type(payload)}"
+    )
+    assert payload.value == 42, f"Expected value=42, got {payload.value}"
+    assert payload.items == [
+        "line1",
+        "line2",
+    ], f"Expected items=['line1', 'line2'], got {payload.items}"
+
+
+@_python_task_test
+async def test_port_receives_exception() -> None:
+    """Test that Rust receives PythonMessage(Exception) when
+    port.exception() is called."""
+
+    # Spawn the test actor.
+    # Cast needed: spawn() is typed to return TActor for ergonomic
+    # method access, but actually returns ActorMesh[TActor]. We need
+    # ActorMesh to call slice().
+    proc_mesh = this_host().spawn_procs(per_host={"gpus": 1})
+    actor_mesh = cast(
+        ActorMesh[WireFormatProbeActor],
+        proc_mesh.spawn("probe_actor", WireFormatProbeActor),
+    )
+
+    # Get instance and mailbox from the test context
+    ins = context().actor_instance
+    instance = ins._as_rust()
+    mailbox = ins._mailbox
+
+    # Slice to a single actor and get its _inner (PythonActorMesh).
+    # Cast needed: _inner is typed as ActorMeshProtocol but
+    # probe_exit_port_via_mesh expects PythonActorMesh. At runtime
+    # _inner is a PythonActorMesh.
+    single_actor_mesh = actor_mesh.slice(gpus=0)
+    actor_mesh_inner = cast(PythonActorMesh, single_actor_mesh._inner)
+
+    # Pickle the args - port will be injected by runtime Args should
+    # be (args_tuple, kwargs_dict) format
+    args = ("test_tag",)
+    kwargs = {}
+    pickled_args = cloudpickle.dumps((args, kwargs))
+
+    # Call the Rust probe and await the result
+    report = await probe_exit_port_via_mesh(
+        actor_mesh_inner, instance, mailbox, "send_exception_on_port", pickled_args
+    )
+
+    # Assert we received a PythonMessage
+    assert report.received_type == "PythonMessage", f"Got {report.received_type}"
+    assert report.error is None, f"Unexpected error: {report.error}"
+
+    # Assert it's an Exception, not a Result
+    assert report.kind == "Exception", f"Expected Exception, got {report.kind}"
+    assert report.rank is not None, "rank should be present for Exception"
+
+    # Assert no pending pickle state
+    assert report.pending_pickle_state_present is False, (
+        "pending_pickle_state should be None"
+    )
+
+    # Assert the payload can be decoded as an exception
+    exc = cloudpickle.loads(bytes(report.payload_bytes))
+
+    # Verify it's a ValueError with our message
+    assert isinstance(exc, ValueError), f"Expected ValueError, got {type(exc)}"
+    assert str(exc) == "simulated failure", f"Expected 'simulated failure', got '{exc}'"


### PR DESCRIPTION
Summary:
this change adds a rust-level probe for the explicit response port contract.

the probe opens a rust `OncePort<PythonMessage>`, dispatches a `CallMethod(ExplicitPort)` to a python actor, and records exactly what rust receives on that port.

the accompanying test verifies that calling `port.send(value)` in python results in rust receiving a `PythonMessage` with `kind = Result`, and that calling `port.exception(exc)` in python results in rust receiving a `PythonMessage` with `kind = Exception`. in both cases the payload is the raw cloudpickled bytes and `pending_pickle_state` is not set.

this directly validates the wire-level assumption relied on by (upcoming) `ActorProcLauncher` and `BootstrapProcManager`: when the python launcher writes to the exit port, the rust side receives a correctly formed `PythonMessage` envelope carrying the exit result or error.

Differential Revision: D91746589


