### PR TITLE
Fix wrong python version for nightly docker image

### DIFF
--- a/.github/workflows/build-dist.yml
+++ b/.github/workflows/build-dist.yml
@@ -46,7 +46,7 @@ jobs:
       gpu-arch-type: ${{ inputs.gpu-arch-type }}
       gpu-arch-version: ${{ inputs.gpu-arch-version }}
       submodules: recursive
-      upload-artifact: monarch-${{ matrix.python-version }}-${{ inputs.gpu-arch-type }}${{ inputs.gpu-arch-version }}
+      upload-artifact: monarch-py${{ matrix.python-version }}-${{ inputs.gpu-arch-type }}${{ inputs.gpu-arch-version }}
       script: |
         source scripts/common-setup.sh
         setup_build_environment ${{ matrix.python-version }}

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -16,9 +16,9 @@ jobs:
     with:
       # TODO add 3.14 once we figure out py03 issue
       python-versions: '["3.10", "3.11", "3.12", "3.13"]'
-      torch-spec: '--pre torch --extra-index-url https://download.pytorch.org/whl/nightly/cu126'
-      gpu-arch-type: 'cuda'
-      gpu-arch-version: '12.6'
+      torch-spec: 'torch==2.10.0 --extra-index-url https://download.pytorch.org/whl/cu128'
+      gpu-arch-type: cuda
+      gpu-arch-version: '12.8'
       version: ${{ github.event.inputs.version }}
   publish:
     name: Publish to PyPI
@@ -78,4 +78,4 @@ jobs:
           file: ./Dockerfile
           push: true # Push the image to the registry
           tags: ghcr.io/${{ github.repository }}:latest
-          build-args: PYTORCH_TAG=2.9.1-cuda12.6-cudnn9-runtime
+          build-args: PYTORCH_TAG=2.10.0-cuda12.8-cudnn9-runtime

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -2,6 +2,15 @@ name: Build and publish nightly monarch wheels
 
 on:
   workflow_dispatch:
+  # For testing changes to this workflow.
+  pull_request:
+    branches:
+      - main
+      - gh/**
+    paths:
+      - .github/workflows/wheels.yml
+      - .github/workflows/build-dist.yml
+      - Dockerfile.nightly
   push:
     branches:
       - main
@@ -19,9 +28,9 @@ jobs:
     uses: ./.github/workflows/build-dist.yml
     with:
       python-versions: '["3.10", "3.11", "3.12", "3.13"]'
-      torch-spec: '--pre torch --extra-index-url https://download.pytorch.org/whl/nightly/cu126'
-      gpu-arch-type: 'cuda'
-      gpu-arch-version: '12.6'
+      torch-spec: '--pre torch --extra-index-url https://download.pytorch.org/whl/nightly/cu128'
+      gpu-arch-type: cuda
+      gpu-arch-version: '12.8'
 
   publish-to-pypi:
     name: Publish to PyPI
@@ -69,6 +78,8 @@ jobs:
       - name: Download all artifacts
         uses: actions/download-artifact@v4
         with:
+          # Docker container only has python 3.12, so we need to use the 3.12 wheel.
+          name: monarch-py3.12-cuda12.8
           path: dist
           merge-multiple: true
 
@@ -92,6 +103,7 @@ jobs:
           file: ./Dockerfile.nightly
           push: true # Push the image to the registry
           tags: ghcr.io/${{ github.repository }}:${{ env.DOCKER_TAG }}
+          # TODO: find docker tag that gets updated automatically.
           build-args: |
-            PYTORCH_TAG=2.11.0.dev20260109-cuda12.6-cudnn9-runtime
+            PYTORCH_TAG=2.11.0.dev20260109-cuda12.8-cudnn9-runtime
             MONARCH_WHEELS=dist


### PR DESCRIPTION
Summary:
The nightly docker image was being made incorrectly, because it was trying to
install multiple python version wheels instead of just the one matching the python version.

Change this in "download" to only get the python3.12 version which matches the one stored
in the base docker image.

Differential Revision: D91796157


