### PR TITLE
Fix a race condition in ShutdownHost

### DIFF
--- a/hyperactor_mesh/src/bootstrap.rs
+++ b/hyperactor_mesh/src/bootstrap.rs
@@ -3342,7 +3342,7 @@ mod tests {
             .expect("manager proxy");
 
         let mut ok = false;
-        for _ in 0..50 {
+        for _ in 0..100 {
             match manager.get_unit(&expected_unit).await {
                 Err(_) => {
                     // Unit already gone: fine.


### PR DESCRIPTION
Summary:
In `Host`'s current `ShutdownHost` handle, it sends an ack back to client:

https://www.internalfb.com/code/fbsource/[ebe92230d1cf11782156f1870bf12996606d180f]/fbcode/monarch/hyperactor_mesh/src/v1/host_mesh/mesh_agent.rs?lines=357-360

But `send` only means to put the message into the queue/channel. There is no guarantee when this message will be send. As a result, we might end up in this race condition:

1. `ShutdownHost` finished very quickly, and the process is terminated, e.g. by allocator if this is a allocator based bootstrap.
2. But when the process was terminated, the message still has not been sent out yet.

As a result, this message is lost, and client will never get it.

But on the client side, user generally await for this reply:

```
host_mesh.shutdown().await
```

As a result, client will hang at this step.

This diff changes `send` to `PortSender::serialize_and_send`, which we can argument it with `return_handle`. Then we can use `return_handle` to be certain the message is sent over the wire or not.

Differential Revision: D91803488


