### PR TITLE
Update cuda versions for all tests and builds on Github

### DIFF
--- a/.github/workflows/build-cuda.yml
+++ b/.github/workflows/build-cuda.yml
@@ -9,7 +9,7 @@ concurrency:
 
 jobs:
   build-cuda:
-    name: Build CUDA (cuda12.6-py3.10)
+    name: Build CUDA (cuda12.8)
     uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
     strategy:
       fail-fast: true
@@ -18,9 +18,9 @@ jobs:
         include:
           - name: 4xlargegpu
             runs-on: linux.g5.4xlarge.nvidia.gpu
-            torch-spec: '--pre torch --extra-index-url https://download.pytorch.org/whl/nightly/cu126'
+            torch-spec: '--pre torch --extra-index-url https://download.pytorch.org/whl/nightly/cu128'
             gpu-arch-type: "cuda"
-            gpu-arch-version: "12.6"
+            gpu-arch-version: "12.8"
     with:
       timeout: 60
       runner: ${{ matrix.runs-on }}

--- a/.github/workflows/build-dist.yml
+++ b/.github/workflows/build-dist.yml
@@ -10,7 +10,7 @@ on:
       torch-spec:
         description: 'Torch installation specification'
         type: string
-        default: '--pre torch --extra-index-url https://download.pytorch.org/whl/nightly/cu126'
+        default: '--pre torch --extra-index-url https://download.pytorch.org/whl/nightly/cu128'
       gpu-arch-type:
         description: 'GPU architecture type'
         type: string
@@ -18,7 +18,7 @@ on:
       gpu-arch-version:
         description: 'GPU architecture version'
         type: string
-        default: '12.6'
+        default: '12.8'
       runner:
         description: 'Runner to use for the build'
         type: string

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -60,7 +60,7 @@ jobs:
           file: ./Dockerfile.nightly
           push: false # Just building the image, not publishing
           build-args: |
-            PYTORCH_TAG=2.11.0.dev20260109-cuda12.6-cudnn9-runtime
+            PYTORCH_TAG=2.11.0.dev20260109-cuda12.8-cudnn9-runtime
             MONARCH_WHEELS=dist
           outputs: type=docker,dest=${{ runner.temp }}/monarch_image.tar
 

--- a/.github/workflows/doc_build.yml
+++ b/.github/workflows/doc_build.yml
@@ -19,7 +19,7 @@ jobs:
       timeout: 120
       runner: linux.g5.4xlarge.nvidia.gpu
       gpu-arch-type: cuda
-      gpu-arch-version: "12.6"
+      gpu-arch-version: "12.8"
       submodules: recursive
       upload-artifact: docs
       script: |
@@ -31,7 +31,7 @@ jobs:
         setup_build_environment 3.13
 
         # Install PyTorch with CUDA support (matching build-cuda.yml)
-        pip install --pre torch --extra-index-url https://download.pytorch.org/whl/nightly/cu126
+        pip install --pre torch --extra-index-url https://download.pytorch.org/whl/nightly/cu128
 
         # Setup Tensor Engine
         setup_tensor_engine

--- a/.github/workflows/test-gpu-python.yml
+++ b/.github/workflows/test-gpu-python.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   test-gpu-python:
-    name: Test GPU Python (cuda12.6-py3.10)
+    name: Test GPU Python (cuda12.8-py3.10)
     uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
     strategy:
       fail-fast: true
@@ -22,9 +22,9 @@ jobs:
         include:
           - name: 4xlargegpu
             runs-on: linux.g5.4xlarge.nvidia.gpu
-            torch-spec: '--pre torch --extra-index-url https://download.pytorch.org/whl/nightly/cu126'
+            torch-spec: '--pre torch --extra-index-url https://download.pytorch.org/whl/nightly/cu128'
             gpu-arch-type: "cuda"
-            gpu-arch-version: "12.6"
+            gpu-arch-version: "12.8"
     with:
       timeout: 120
       runner: ${{ matrix.runs-on }}

--- a/.github/workflows/test-gpu-rust.yml
+++ b/.github/workflows/test-gpu-rust.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   test-gpu-rust:
-    name: Test GPU Rust (cuda12.6)
+    name: Test GPU Rust (cuda12.8)
     uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
     strategy:
       fail-fast: true
@@ -22,9 +22,9 @@ jobs:
         include:
           - name: 4xlargegpu
             runs-on: linux.g5.4xlarge.nvidia.gpu
-            torch-spec: '--pre torch --extra-index-url https://download.pytorch.org/whl/nightly/cu126'
+            torch-spec: '--pre torch --extra-index-url https://download.pytorch.org/whl/nightly/cu128'
             gpu-arch-type: "cuda"
-            gpu-arch-version: "12.6"
+            gpu-arch-version: "12.8"
     with:
       timeout: 120
       runner: ${{ matrix.runs-on }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Override on build from CI.
-ARG PYTORCH_TAG=2.9.1-cuda12.6-cudnn9-runtime
+ARG PYTORCH_TAG=2.10.0-cuda12.8-cudnn9-runtime
 
 # Build from latest pytorch stable image; should be relatively in sync with torchmonarch and pytorch.
 FROM ghcr.io/pytorch/pytorch:${PYTORCH_TAG}

--- a/Dockerfile.nightly
+++ b/Dockerfile.nightly
@@ -1,5 +1,5 @@
 # Override on build from CI, default only to prevent warnings.
-ARG PYTORCH_TAG=2.11.0.dev20260109-cuda12.6-cudnn9-runtime
+ARG PYTORCH_TAG=2.11.0.dev20260109-cuda12.8-cudnn9-runtime
 
 # Build from latest pytorch nightly base image; should be relatively in sync with torchmonarch and pytorch-nightly.
 FROM ghcr.io/pytorch/pytorch-nightly:${PYTORCH_TAG}

--- a/scripts/common-setup.sh
+++ b/scripts/common-setup.sh
@@ -69,12 +69,12 @@ setup_tensor_engine() {
 
 # Install PyTorch with C++ development headers (libtorch) for Rust compilation
 setup_pytorch_with_headers() {
-    local gpu_arch_version=${1:-"12.6"}
-    local torch_spec=${2:-"--pre torch --index-url https://download.pytorch.org/whl/nightly/cu126"}
+    local gpu_arch_version=${1:-"12.8"}
+    local torch_spec=${2:-"--pre torch --index-url https://download.pytorch.org/whl/nightly/cu128"}
 
     echo "Setting up PyTorch with C++ headers (GPU arch: ${gpu_arch_version})..."
 
-    # Extract CUDA version for libtorch URL (remove dots: "12.6" -> "126")
+    # Extract CUDA version for libtorch URL (remove dots: "12.8" -> "128")
     local cuda_version_short=$(echo "${gpu_arch_version}" | tr -d '.')
     local libtorch_url="https://download.pytorch.org/libtorch/nightly/cu${cuda_version_short}/libtorch-cxx11-abi-shared-with-deps-latest.zip"
 


### PR DESCRIPTION
Summary:
Now that our nightly and stable builds use cuda 12.8, our tests should use it as well.
It shouldn't affect the majority of tests that don't use GPUs, but there are a couple tensor
engine and RDMA tests it could affect.

Reviewed By: allenwang28

Differential Revision: D91807566


