### PR TITLE
Update docker tag names

### DIFF
--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -77,5 +77,5 @@ jobs:
           context: . # Build context is the root directory
           file: ./Dockerfile
           push: true # Push the image to the registry
-          tags: ghcr.io/${{ github.repository }}:latest
+          tags: ghcr.io/${{ github.repository }}:${{ github.event.inputs.version }}-cuda12.8
           build-args: PYTORCH_TAG=2.10.0-cuda12.8-cudnn9-runtime

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -94,7 +94,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Get tag for publishing
-        run: echo "DOCKER_TAG=$(date +'%Y-%m-%d')-nightly" >> $GITHUB_ENV
+        run: echo "DOCKER_TAG=0.3.0.dev$(date +'%Y%m%d')-cuda12.8" >> $GITHUB_ENV
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v6
@@ -102,7 +102,8 @@ jobs:
           context: . # Build context is the root directory
           file: ./Dockerfile.nightly
           push: true # Push the image to the registry
-          tags: ghcr.io/${{ github.repository }}:${{ env.DOCKER_TAG }}
+          # Push to monarch-nightly package instead of monarch.
+          tags: ghcr.io/${{ github.repository }}-nightly:${{ env.DOCKER_TAG }}
           # TODO: find docker tag that gets updated automatically.
           build-args: |
             PYTORCH_TAG=2.11.0.dev20260109-cuda12.8-cudnn9-runtime


### PR DESCRIPTION
Summary:
For nightly uploads, use a specific docker image name `monarch-nightly`. Also fix the
version tag to match the way pytorch does it.

For stable uploads, keep using "monarch" and use the same version (so any "rc" suffix will
be applied).

Differential Revision: D91911446


