### PR TITLE
Add exit_on_shutdown flag to terminate host process after shutdown

### DIFF
--- a/hyperactor_mesh/src/v1/host_mesh.rs
+++ b/hyperactor_mesh/src/v1/host_mesh.rs
@@ -284,7 +284,13 @@ impl HostMesh {
         let addr = host.addr().clone();
         let system_proc = host.system_proc().clone();
         let host_mesh_agent = system_proc
-            .spawn("agent", HostMeshAgent::new(HostAgentMode::Process(host)))
+            .spawn(
+                "agent",
+                HostMeshAgent::new(HostAgentMode::Process {
+                    host,
+                    exit_on_shutdown: false,
+                }),
+            )
             .map_err(v1::Error::SingletonActorSpawnError)?;
         host_mesh_agent.bind::<HostMeshAgent>();
 
@@ -323,6 +329,7 @@ impl HostMesh {
                 addr: addr.clone(),
                 command: Some(command.clone()),
                 config: Some(hyperactor_config::global::attrs()),
+                exit_on_shutdown: false,
             };
 
             let mut cmd = command.new();
@@ -1545,6 +1552,7 @@ mod tests {
                 addr: host.clone(),
                 command: None, // use current binary
                 config: None,
+                exit_on_shutdown: false,
             };
             boot.to_env(&mut cmd);
             cmd.kill_on_drop(true);
@@ -1590,6 +1598,7 @@ mod tests {
                 config: None,
                 // The entire purpose of this is to fail:
                 command: Some(BootstrapCommand::from("false")),
+                exit_on_shutdown: false,
             };
             boot.to_env(&mut cmd);
             cmd.kill_on_drop(true);
@@ -1635,6 +1644,7 @@ mod tests {
                 addr: host.clone(),
                 config: None,
                 command,
+                exit_on_shutdown: false,
             };
             boot.to_env(&mut cmd);
             cmd.kill_on_drop(true);

--- a/monarch_hyperactor/src/bootstrap.rs
+++ b/monarch_hyperactor/src/bootstrap.rs
@@ -97,6 +97,9 @@ pub fn run_worker_loop_forever(_py: Python<'_>, address: &str) -> PyResult<PyPyt
         addr,
         config: None,
         command,
+        // This function is the entry point of the program, and no one else
+        // will terminate this process. So it needs to exit on its own.
+        exit_on_shutdown: true,
     };
 
     PyPythonTask::new(async {

--- a/monarch_hyperactor/src/host_mesh.rs
+++ b/monarch_hyperactor/src/host_mesh.rs
@@ -286,6 +286,7 @@ fn bootstrap_host(bootstrap_cmd: Option<PyBootstrapCommand>) -> PyResult<PyPytho
             default_bind_spec().binding_addr(),
             Some(bootstrap_cmd),
             None,
+            false,
         )
         .await
         .map_err(|e| PyException::new_err(e.to_string()))?;


### PR DESCRIPTION
Summary:
For Host boostrapped through simple bootstrap, `run_worker_loop_forever` specifically, after the Host is shut down, there is currently no other mechanism to terminate the process this Host run on. As a result, that process would hang forever.

This diff adds a `exit_on_shutdown` flag so we can configure from `run_worker_loop_forever` to ask `Host` terminates the process at the end.

Differential Revision: D91747144


