### PR TITLE
If a message is undeliverable because an actor stopped/failed, include that in the error

### DIFF
--- a/hyperactor/src/actor.rs
+++ b/hyperactor/src/actor.rs
@@ -501,8 +501,9 @@ pub enum ActorStatus {
     Loading(SystemTime),
     /// The actor is stopping. It is draining messages.
     Stopping,
-    /// The actor is stopped. It is no longer processing messages.
-    Stopped,
+    /// The actor is stopped with a provided reason.
+    /// It is no longer processing messages.
+    Stopped(String),
     /// The actor failed with the provided actor error.
     Failed(ActorErrorKind),
 }
@@ -590,7 +591,7 @@ impl fmt::Display for ActorStatus {
                 )
             }
             Self::Stopping => write!(f, "stopping"),
-            Self::Stopped => write!(f, "stopped"),
+            Self::Stopped(reason) => write!(f, "stopped: {}", reason),
             Self::Failed(err) => write!(f, "failed: {}", err),
         }
     }

--- a/hyperactor/src/mailbox/undeliverable.rs
+++ b/hyperactor/src/mailbox/undeliverable.rs
@@ -117,12 +117,6 @@ pub(crate) fn return_undeliverable(
 /// Errors that occur during message delivery and return.
 pub enum UndeliverableMessageError {
     /// Delivery of a message to its destination failed.
-    #[error(
-        "a message from {} to {} was undeliverable and returned: {:?}: {envelope}",
-        .envelope.sender(),
-        .envelope.dest(),
-        .envelope.error_msg()
-    )]
     DeliveryFailure {
         /// The undelivered message.
         envelope: MessageEnvelope,
@@ -130,15 +124,49 @@ pub enum UndeliverableMessageError {
 
     /// Delivery of an undeliverable message back to its sender
     /// failed.
-    #[error(
-        "returning an undeliverable message to sender {} failed: {:?}: {envelope}",
-        .envelope.sender(),
-        .envelope.error_msg()
-    )]
     ReturnFailure {
         /// The undelivered message.
         envelope: MessageEnvelope,
     },
+}
+
+impl std::fmt::Display for UndeliverableMessageError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            UndeliverableMessageError::DeliveryFailure { envelope } => {
+                writeln!(f, "undeliverable message error:")?;
+                writeln!(
+                    f,
+                    "\tdescription: delivery of message from sender to dest failed"
+                )?;
+                writeln!(f, "\tsender: {}", envelope.sender())?;
+                writeln!(f, "\tdest: {}", envelope.dest())?;
+                writeln!(f, "\theaders: {}", envelope.headers())?;
+                writeln!(f, "\tdata: {}", envelope.data())?;
+                writeln!(
+                    f,
+                    "\terror: {}",
+                    envelope.error_msg().unwrap_or("<none>".to_string())
+                )
+            }
+            UndeliverableMessageError::ReturnFailure { envelope } => {
+                writeln!(f, "undeliverable message error:")?;
+                writeln!(
+                    f,
+                    "\tdescription: returning undeliverable message to original sender failed"
+                )?;
+                writeln!(f, "\toriginal sender: {}", envelope.sender())?;
+                writeln!(f, "\toriginal dest: {}", envelope.dest())?;
+                writeln!(f, "\theaders: {}", envelope.headers())?;
+                writeln!(f, "\tdata: {}", envelope.data())?;
+                writeln!(
+                    f,
+                    "\terror: {}",
+                    envelope.error_msg().unwrap_or("<none>".to_string())
+                )
+            }
+        }
+    }
 }
 
 /// Drain undeliverables and convert them into

--- a/hyperactor/src/proc.rs
+++ b/hyperactor/src/proc.rs
@@ -74,6 +74,7 @@ use crate::clock::ClockKind;
 use crate::clock::RealClock;
 use crate::config;
 use crate::context;
+use crate::context::Mailbox as _;
 use crate::mailbox::BoxedMailboxSender;
 use crate::mailbox::DeliveryError;
 use crate::mailbox::DialMailboxRouter;
@@ -1045,7 +1046,7 @@ impl<A: Actor> Drop for InstanceState<A> {
                     prev_status = status.arm().unwrap_or("unknown"),
                     "instance is dropped",
                 );
-                *status = ActorStatus::Stopped;
+                *status = ActorStatus::Stopped("instance is dropped".into());
                 true
             }
         });
@@ -1308,20 +1309,17 @@ impl<A: Actor> Instance<A> {
         actor_loop_receivers: (PortReceiver<Signal>, PortReceiver<ActorSupervisionEvent>),
         mut work_rx: mpsc::UnboundedReceiver<WorkCell<A>>,
     ) {
-        // `run_actor_tree` borrows `work_rx` instead of taking ownership because
-        // `work_rx` needs to remain alive until this function returns. If the owning
-        // proc's `supervision_coordinator_port` is a port on this instance, if `work_rx`
-        // is dropped before `self.proc.handle_supervision_event` is called, the process
-        // will exit due to a "channel closed" failure.
         let result = self
             .run_actor_tree(&mut actor, actor_loop_receivers, &mut work_rx)
             .await;
 
         assert!(self.is_stopping());
         let event = match result {
-            Ok(_) => {
+            Ok(stop_reason) => {
+                let status = ActorStatus::Stopped(stop_reason);
+                self.mailbox().close(status.clone());
                 // success exit case
-                self.change_status(ActorStatus::Stopped);
+                self.change_status(status);
                 None
             }
             Err(err) => {
@@ -1332,12 +1330,14 @@ impl<A: Actor> Instance<A> {
                         // status here too, because we use event's actor_status as this actor's
                         // terminal status.
                         assert!(event.actor_status.is_terminal());
+                        self.mailbox().close(event.actor_status.clone());
                         self.change_status(event.actor_status.clone());
                         Some(event)
                     }
                     _ => {
                         let error_kind = ActorErrorKind::Generic(err.kind.to_string());
                         let status = ActorStatus::Failed(error_kind);
+                        self.mailbox().close(status.clone());
                         self.change_status(status.clone());
                         Some(ActorSupervisionEvent::new(
                             self.inner.cell.actor_id().clone(),
@@ -1380,13 +1380,14 @@ impl<A: Actor> Instance<A> {
     }
 
     /// Runs the actor, and manages its supervision tree. When the function returns,
-    /// the whole tree rooted at this actor has stopped.
+    /// the whole tree rooted at this actor has stopped. On success, returns the reason
+    /// why the actor stopped. On failure, returns the error that caused the failure.
     async fn run_actor_tree(
         &mut self,
         actor: &mut A,
         mut actor_loop_receivers: (PortReceiver<Signal>, PortReceiver<ActorSupervisionEvent>),
         work_rx: &mut mpsc::UnboundedReceiver<WorkCell<A>>,
-    ) -> Result<(), ActorError> {
+    ) -> Result<String, ActorError> {
         // It is okay to catch all panics here, because we are in a tokio task,
         // and tokio will catch the panic anyway:
         // https://docs.rs/tokio/latest/tokio/task/struct.JoinError.html#method.is_panic
@@ -1495,16 +1496,18 @@ impl<A: Actor> Instance<A> {
         }
         // If the original exit was not an error, let cleanup errors be
         // surfaced.
-        result.and(cleanup_result)
+        result.and_then(|reason| cleanup_result.map(|_| reason))
     }
 
-    /// Initialize and run the actor until it fails or is stopped.
+    /// Initialize and run the actor until it fails or is stopped. On success,
+    /// returns the reason why the actor stopped. On failure, returns the error
+    /// that caused the failure.
     async fn run(
         &mut self,
         actor: &mut A,
         actor_loop_receivers: &mut (PortReceiver<Signal>, PortReceiver<ActorSupervisionEvent>),
         work_rx: &mut mpsc::UnboundedReceiver<WorkCell<A>>,
-    ) -> Result<(), ActorError> {
+    ) -> Result<String, ActorError> {
         let (signal_receiver, supervision_event_receiver) = actor_loop_receivers;
 
         self.change_status(ActorStatus::Initializing);
@@ -1586,7 +1589,7 @@ impl<A: Actor> Instance<A> {
             reason = stop_reason,
             "exited actor loop",
         );
-        Ok(())
+        Ok(stop_reason)
     }
 
     /// Handle a supervision event using the provided actor.
@@ -2437,7 +2440,7 @@ mod tests {
 
         handle.drain_and_stop("test").unwrap();
         handle.await;
-        assert_matches!(*state.borrow(), ActorStatus::Stopped);
+        assert_matches!(&*state.borrow(), ActorStatus::Stopped(reason) if reason == "test");
     }
 
     #[async_timed_test(timeout_secs = 30)]
@@ -2627,7 +2630,7 @@ mod tests {
 
         for actor in [root_1, root_2, root_2_1] {
             assert!(actor.send(&client, TestActorMessage::Noop()).is_err());
-            assert_matches!(actor.await, ActorStatus::Stopped);
+            assert_matches!(actor.await, ActorStatus::Stopped(reason) if reason == "parent stopping");
         }
     }
 
@@ -2663,8 +2666,8 @@ mod tests {
             root.await,
             ActorStatus::Failed(err) if err.to_string().contains("some random failure")
         );
-        assert_eq!(root_2_1.await, ActorStatus::Stopped);
-        assert_eq!(root_1.await, ActorStatus::Stopped);
+        assert_matches!(root_2_1.await, ActorStatus::Stopped(_));
+        assert_matches!(root_1.await, ActorStatus::Stopped(_));
     }
 
     #[async_timed_test(timeout_secs = 30)]
@@ -3130,7 +3133,7 @@ mod tests {
 
         assert_eq!(*handle.status().borrow(), ActorStatus::Client);
         drop(instance);
-        assert_eq!(*handle.status().borrow(), ActorStatus::Stopped);
+        assert_matches!(*handle.status().borrow(), ActorStatus::Stopped(_));
         handle.await;
     }
 
@@ -3273,5 +3276,80 @@ mod tests {
             assert_eq!(stacks[0].len(), 1);
             assert_eq!(stacks[0][0].name(), "child_span");
         })
+    }
+
+    #[async_timed_test(timeout_secs = 30)]
+    async fn test_mailbox_closed_with_owner_stopped_reason() {
+        use crate::actor::ActorStatus;
+        use crate::mailbox::MailboxErrorKind;
+        use crate::mailbox::MailboxSenderErrorKind;
+
+        let proc = Proc::local();
+        let (client, _) = proc.instance("client").unwrap();
+        let actor_handle = proc.spawn("test", TestActor).unwrap();
+
+        // Clone the handle before awaiting since await consumes the handle
+        let handle_for_send = actor_handle.clone();
+
+        // Stop the actor gracefully
+        actor_handle.drain_and_stop("healthy shutdown").unwrap();
+        actor_handle.await;
+
+        // Try to send a message to the stopped actor
+        let result = handle_for_send.send(&client, TestActorMessage::Noop());
+
+        assert!(result.is_err(), "send should fail when actor is stopped");
+        let err = result.unwrap_err();
+        assert_matches!(
+            err.kind(),
+            MailboxSenderErrorKind::Mailbox(mailbox_err)
+                if matches!(
+                    mailbox_err.kind(),
+                    MailboxErrorKind::OwnerTerminated(ActorStatus::Stopped(reason)) if reason == "healthy shutdown"
+                )
+        );
+    }
+
+    #[async_timed_test(timeout_secs = 30)]
+    async fn test_mailbox_closed_with_owner_failed_reason() {
+        use crate::actor::ActorErrorKind;
+        use crate::actor::ActorStatus;
+        use crate::mailbox::MailboxErrorKind;
+        use crate::mailbox::MailboxSenderErrorKind;
+
+        let proc = Proc::local();
+        let (client, _) = proc.instance("client").unwrap();
+        // Need to set a supervison coordinator for this Proc because there will
+        // be actor failure(s) in this test which trigger supervision.
+        ProcSupervisionCoordinator::set(&proc).await.unwrap();
+
+        let actor_handle = proc.spawn("test", TestActor).unwrap();
+
+        // Clone the handle before awaiting since await consumes the handle
+        let handle_for_send = actor_handle.clone();
+
+        // Cause the actor to fail
+        actor_handle
+            .send(
+                &client,
+                TestActorMessage::Fail(anyhow::anyhow!("intentional failure")),
+            )
+            .unwrap();
+        actor_handle.await;
+
+        // Try to send a message to the failed actor
+        let result = handle_for_send.send(&client, TestActorMessage::Noop());
+
+        assert!(result.is_err(), "send should fail when actor has failed");
+        let err = result.unwrap_err();
+        assert_matches!(
+            err.kind(),
+            MailboxSenderErrorKind::Mailbox(mailbox_err)
+                if matches!(
+                    mailbox_err.kind(),
+                    MailboxErrorKind::OwnerTerminated(ActorStatus::Failed(ActorErrorKind::Generic(msg)))
+                        if msg.contains("intentional failure")
+                )
+        );
     }
 }

--- a/hyperactor/src/supervision.rs
+++ b/hyperactor/src/supervision.rs
@@ -94,7 +94,7 @@ fn fmt_status<'a>(
     let mut f = indented(f).with_str(" ");
 
     match status {
-        ActorStatus::Stopped if actor_id.name() == "agent" => {
+        ActorStatus::Stopped(_) if actor_id.name() == "agent" => {
             // Host agent stopped - use simplified message from D86984496
             let name = match actor_id.proc_id() {
                 crate::reference::ProcId::Direct(addr, _) => addr.to_string(),

--- a/hyperactor_mesh/src/proc_mesh.rs
+++ b/hyperactor_mesh/src/proc_mesh.rs
@@ -1349,26 +1349,6 @@ mod tests {
         assert_eq!(event.actor_id.2, 0);
     }
 
-    #[timed_test::async_timed_test(timeout_secs = 5)]
-    async fn test_spawn_twice() {
-        let alloc = LocalAllocator
-            .allocate(AllocSpec {
-                extent: extent!(replica = 1),
-                constraints: Default::default(),
-                proc_name: None,
-                transport: ChannelTransport::Local,
-                proc_allocation_mode: Default::default(),
-            })
-            .await
-            .unwrap();
-        let mesh = ProcMesh::allocate(alloc).await.unwrap();
-
-        let instance = crate::v1::testing::instance();
-        let _: RootActorMesh<TestActor> = mesh.spawn(&instance, "dup", &()).await.unwrap();
-        let result: Result<RootActorMesh<TestActor>, _> = mesh.spawn(&instance, "dup", &()).await;
-        assert!(result.is_err());
-    }
-
     mod shim {
         use std::collections::HashSet;
 

--- a/monarch_tensor_worker/src/comm.rs
+++ b/monarch_tensor_worker/src/comm.rs
@@ -994,9 +994,9 @@ mod tests {
         assert!(val, "send_tensor result was unexpected value: {val}");
 
         handle1.drain_and_stop("test").unwrap();
-        assert_matches!(handle1.await, ActorStatus::Stopped);
+        assert_matches!(handle1.await, ActorStatus::Stopped(_));
         handle2.drain_and_stop("test").unwrap();
-        assert_matches!(handle2.await, ActorStatus::Stopped);
+        assert_matches!(handle2.await, ActorStatus::Stopped(_));
 
         let error_responses = controller_rx.drain();
         assert!(
@@ -1135,7 +1135,7 @@ mod tests {
         assert!(val, "send_tensor_local result was unexpected value: {val}");
 
         handle.drain_and_stop("test").unwrap();
-        assert_matches!(handle.await, ActorStatus::Stopped);
+        assert_matches!(handle.await, ActorStatus::Stopped(_));
 
         let error_responses = controller_rx.drain();
         assert!(

--- a/python/tests/test_actor_error.py
+++ b/python/tests/test_actor_error.py
@@ -1082,9 +1082,9 @@ async def test_supervision_with_sending_error() -> None:
     assert "MeshFailure" in error_msg
     assert "RootClientActor" in error_msg
     assert re.search(
-        "a message from .*client.*was undeliverable and returned",
+        "undeliverable message error.*client.*",
         error_msg,
-        flags=re.MULTILINE,
+        flags=re.DOTALL,
     )
     assert re.search(
         "rejecting oversize frame: len=[0-9]+ > max=50000000.*CODEC_MAX_FRAME_LENGTH",


### PR DESCRIPTION
Summary:
If a message is undeliverable because an actor stopped or failed, we should never (or as little as possible) create an undeliverable message error with the "channel closed" error. This PR makes a few related changes:
1. Add a reason to `ActorStatus::Stopped`, and fill in this reason in a bunch of places in the supervision implementation.
2. When the actor loop exits, return the reason why it stopped so that we can store the reason in `ActorStatus::Stopped`.
3. Add an optional `ActorStatus` watcher inside `Mailbox`. Inside `Mailbox::post_unchecked` and `PortHandle::send`, check the actor status first; if it is stopped or failed, include this in the error message/undeliverable envelope, along with the reason why.
4. Change the format of `DeliveryError` to be much more readable.

Differential Revision: D91829469


