### PR TITLE
Use SpanEnter/SpanExit thread ids for perfetto

### DIFF
--- a/hyperactor_telemetry/src/trace_dispatcher.rs
+++ b/hyperactor_telemetry/src/trace_dispatcher.rs
@@ -58,9 +58,17 @@ pub enum TraceEvent {
         line: Option<u32>,
     },
     /// A span was entered (on_enter)
-    SpanEnter { id: u64, timestamp: SystemTime },
+    SpanEnter {
+        id: u64,
+        timestamp: SystemTime,
+        thread_name: &'static str,
+    },
     /// A span was exited (on_exit)
-    SpanExit { id: u64, timestamp: SystemTime },
+    SpanExit {
+        id: u64,
+        timestamp: SystemTime,
+        thread_name: &'static str,
+    },
     /// A span was closed (dropped)
     SpanClose { id: u64, timestamp: SystemTime },
     /// A tracing event occurred (e.g., tracing::info!())
@@ -382,18 +390,22 @@ where
     }
 
     fn on_enter(&self, id: &Id, _ctx: Context<'_, S>) {
+        let (thread_name, _) = get_thread_info();
         let event = TraceEvent::SpanEnter {
             id: id.into_u64(),
             timestamp: SystemTime::now(),
+            thread_name,
         };
 
         self.send_event(event);
     }
 
     fn on_exit(&self, id: &Id, _ctx: Context<'_, S>) {
+        let (thread_name, _) = get_thread_info();
         let event = TraceEvent::SpanExit {
             id: id.into_u64(),
             timestamp: SystemTime::now(),
+            thread_name,
         };
 
         self.send_event(event);

--- a/monarch_distributed_telemetry/src/record_batch_sink.rs
+++ b/monarch_distributed_telemetry/src/record_batch_sink.rs
@@ -282,7 +282,7 @@ impl TraceEventSink for RecordBatchSink {
                 });
                 inner.flush_spans_if_full()?;
             }
-            TraceEvent::SpanEnter { id, timestamp } => {
+            TraceEvent::SpanEnter { id, timestamp, .. } => {
                 inner.span_events_buffer.insert(SpanEvent {
                     id: *id,
                     timestamp_us: timestamp_to_micros(timestamp),
@@ -290,7 +290,7 @@ impl TraceEventSink for RecordBatchSink {
                 });
                 inner.flush_span_events_if_full()?;
             }
-            TraceEvent::SpanExit { id, timestamp } => {
+            TraceEvent::SpanExit { id, timestamp, .. } => {
                 inner.span_events_buffer.insert(SpanEvent {
                     id: *id,
                     timestamp_us: timestamp_to_micros(timestamp),


### PR DESCRIPTION
Summary: Previously we were using the thread the Span was created to determine its trace for perfetto but it should actually be the thread that the span actually enters and exits from

Reviewed By: thedavekwon

Differential Revision: D91932033


