### PR TITLE
Improve AttributeError message in JobState.__getattr__

### DIFF
--- a/python/monarch/_src/job/job.py
+++ b/python/monarch/_src/job/job.py
@@ -45,7 +45,10 @@ class JobState:
         try:
             return self._hosts[attr]
         except KeyError:
-            raise AttributeError(attr)
+            available = ", ".join(sorted(self._hosts.keys()))
+            raise AttributeError(
+                f"'{attr}' is not a valid host mesh name. Available names: {available}"
+            )
 
 
 class CachedRunning(NamedTuple):


### PR DESCRIPTION
Summary:
When accessing a non-existent host mesh name via JobState, the AttributeError
now includes the list of available host mesh names, making debugging easier.

Reviewed By: shayne-fletcher

Differential Revision: D92006251


