### PR TITLE
tokio-rustls crypto provider fix

### DIFF
--- a/hyperactor/Cargo.toml
+++ b/hyperactor/Cargo.toml
@@ -60,6 +60,7 @@ paste = "1.0.14"
 rand = { version = "0.8", features = ["small_rng"] }
 rand_distr = "0.4"
 regex = "1.12.2"
+ring = "0.17.14"
 rustls-pemfile = "1.0.0"
 serde = { version = "1.0.219", features = ["derive", "rc"] }
 serde_json = { version = "1.0.140", features = ["alloc", "float_roundtrip", "raw_value", "unbounded_depth"] }
@@ -68,7 +69,7 @@ signal-hook-tokio = { version = "0.3", features = ["futures-v0_3"] }
 strum = { version = "0.27.1", features = ["derive"] }
 thiserror = "2.0.12"
 tokio = { version = "1.47.1", features = ["full", "test-util", "tracing"] }
-tokio-rustls = "0.26.2"
+tokio-rustls = { version = "0.26.2", features = ["logging", "ring", "tls12"], default-features = false }
 tokio-stream = { version = "0.1.17", features = ["fs", "io-util", "net", "signal", "sync", "time"] }
 tokio-util = { version = "0.7.15", features = ["full"] }
 tracing = { version = "0.1.41", features = ["attributes", "valuable"] }


### PR DESCRIPTION
Summary:
When building Monarch for docker + uv, I started seeing this error:
```
thread 'monarch-pytokio-worker-142' panicked at rustls-0.23.36/src/crypto/mod.rs:249:14:
Could not automatically determine the process-level CryptoProvider from Rustls crate features.
  Call CryptoProvider::install_default() before this point to select a provider manually, or make sure exactly one of the 'aws-lc-rs'
  and 'ring' features is enabled.
```

From Claude: rustls 0.23+ requires exactly one crypto provider. tokio-rustls 0.26's default features enable aws_lc_rs, but when building outside fbcode (e.g., via cargo/uv in Docker), this caused a panic because no provider was properly selected. The fix disables default features and explicitly enables ring via autocargo's dependencies_override.

The fix is to use only ring, rather than both `ring` and `aws_lc_rs`.

Differential Revision: D91923963


