### PR TITLE
update mast job to use ipv6 metatls to accomododate the netns per task IP rollout

### DIFF
--- a/python/monarch/tools/mesh_spec.py
+++ b/python/monarch/tools/mesh_spec.py
@@ -39,6 +39,7 @@ class MeshSpec:
     transport: str = "tcp"
     port: int = DEFAULT_REMOTE_ALLOCATOR_PORT
     hostnames: list[str] = field(default_factory=list)
+    task_ips: list[str] = field(default_factory=list)
     state: specs.AppState = specs.AppState.UNSUBMITTED
     image: str = _UNSET_STR
 
@@ -220,6 +221,7 @@ class ServerSpec:
                     "hosts": mesh.num_hosts,
                     "gpus": mesh.gpus,
                     "hostnames": mesh.hostnames,
+                    "task_ips": mesh.task_ips,
                 }
                 for mesh in self.meshes
             },

--- a/python/tests/tools/test_mesh_spec.py
+++ b/python/tests/tools/test_mesh_spec.py
@@ -106,6 +106,7 @@ class TestMeshSpec(unittest.TestCase):
     "n2",
     "n3"
   ],
+  "task_ips": [],
   "state": 0,
   "image": "test_pkg:123"
 }


### PR DESCRIPTION
Differential Revision: D92108597


