### PR TITLE
DistributedTelemetry startup bug fixes

### DIFF
--- a/python/monarch/distributed_telemetry/engine.py
+++ b/python/monarch/distributed_telemetry/engine.py
@@ -12,7 +12,7 @@ QueryEngine - Wrapper for the Rust QueryEngine.
 Provides SQL query execution over distributed telemetry actors.
 """
 
-from typing import Optional, TYPE_CHECKING
+from typing import Optional, Tuple, TYPE_CHECKING
 
 import pyarrow as pa
 from monarch._rust_bindings.monarch_distributed_telemetry.query_engine import (
@@ -44,6 +44,12 @@ class QueryEngine:
         """
         self._actor: "DistributedTelemetryActor" = actor
         self._engine: Optional[_QueryEngine] = None
+
+    def __reduce__(
+        self,
+    ) -> Tuple[type, Tuple["DistributedTelemetryActor"]]:
+        """Make QueryEngine serializable by recreating the Rust object on unpickle."""
+        return (QueryEngine, (self._actor,))
 
     def _ensure_engine(self) -> _QueryEngine:
         """Lazily create the Rust QueryEngine on first use."""

--- a/python/tests/test_distributed_telemetry.py
+++ b/python/tests/test_distributed_telemetry.py
@@ -59,6 +59,8 @@ def cleanup_callbacks():
     # Reset module-level state for next test
     telemetry_actor._scanner = None
     telemetry_actor._scanner_startup_impl = None
+    telemetry_actor._spawned_procs = []
+    telemetry_actor._spawn_callback_registered = False
 
 
 @pytest.mark.timeout(120)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #2484
* #2479
* #2412

Previously it was possible to miss some proc spawns because they could occur before the DistributedTelemetryActor started. There is probably a more principled way to handle service startup.

Differential Revision: [D92110044](https://our.internmc.facebook.com/intern/diff/D92110044/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D92110044/)!