### PR TITLE
Fix rust bindings module dictionary keys

### DIFF
--- a/monarch_extension/src/lib.rs
+++ b/monarch_extension/src/lib.rs
@@ -46,7 +46,8 @@ fn get_or_add_new_module<'py>(
         } else {
             let full_name = format!("monarch._rust_bindings.{}", parts.join("."));
             let new_module = PyModule::new(current_module.py(), &full_name)?;
-            current_module.add_submodule(&new_module)?;
+            // Use setattr with short name instead of add_submodule which uses full name
+            current_module.setattr(part, &new_module)?;
             current_module
                 .py()
                 .import("sys")?


### PR DESCRIPTION
Summary:
There was an issue with the previous approach that caused errors when hierarchical modules existed.

get_or_add_new_module did not preserve keys properly when there was a hierarchical relationship (ie. between a parent and child module). The reason for this is that
```
let submodule = current_module.getattr(part).ok();
```
looks for the part as the key, while
```
current_module.add_submodule(&new_module)?;
```
adds the entire module name as the key.

So then the lookup for any parent module always fails - and sys.module[parent] actually gets overwritten because the parts array is built iteratively, so the child ends up overwriting the parent, as it goes through the part of its path that includes the parent. This is an issue because the parent module had functions that are needed in future python imports, but the child overwrite replaces it with an empty module, so the functions become unreachable.

Reviewed By: thedavekwon

Differential Revision: D92108857


