### PR TITLE
[hyperactor] add HTTP admin server for introspecting procs and actors

### DIFF
--- a/hyperactor/Cargo.toml
+++ b/hyperactor/Cargo.toml
@@ -33,6 +33,7 @@ path = "benches/main.rs"
 algebra = { version = "0.0.0", path = "../algebra" }
 anyhow = "1.0.98"
 async-trait = "0.1.86"
+axum = { version = "0.8", features = ["macros", "ws"] }
 backoff = { version = "0.4.0", features = ["futures", "tokio"] }
 bincode = "1.3.3"
 bytes = { version = "1.10", features = ["serde"] }
@@ -88,6 +89,7 @@ serde_bytes = "0.11"
 tempfile = "3.22"
 timed_test = { version = "0.0.0", path = "../timed_test" }
 tokio-test = "0.4.4"
+tower = "0.4"
 tracing-subscriber = { version = "0.3.20", features = ["chrono", "env-filter", "json", "local-time", "parking_lot", "registry"] }
 tracing-test = { version = "0.2.3", features = ["no-env-filter"] }
 

--- a/hyperactor/src/admin/handlers.rs
+++ b/hyperactor/src/admin/handlers.rs
@@ -1,0 +1,199 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+//! HTTP route handlers for the admin server.
+
+use std::str::FromStr;
+
+use axum::Json;
+use axum::extract::Path;
+use axum::http::StatusCode;
+use axum::http::header::HeaderMap;
+use axum::response::IntoResponse;
+
+use super::global;
+use super::responses::ActorDetails;
+use super::responses::ProcDetails;
+use super::responses::ProcSummary;
+use super::responses::ReferenceInfo;
+use super::tree::format_proc_tree_with_urls;
+use crate::reference::Reference;
+
+/// GET / - List all registered procs.
+pub async fn list_procs() -> Json<Vec<ProcSummary>> {
+    let state = global();
+    let procs: Vec<ProcSummary> = state
+        .procs
+        .iter()
+        .map(|entry| {
+            let proc = entry.value();
+            let mut num_actors = 0;
+            proc.traverse(&mut |_, _| {
+                num_actors += 1;
+            });
+            ProcSummary {
+                name: entry.key().clone(),
+                num_actors,
+            }
+        })
+        .collect();
+    Json(procs)
+}
+
+/// GET /tree - ASCII tree dump of all procs and actors with URLs.
+pub async fn tree_dump(headers: HeaderMap) -> String {
+    let state = global();
+
+    // Extract host from headers
+    let host = headers
+        .get("host")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("localhost");
+
+    // Determine the scheme (default to http)
+    let scheme = headers
+        .get("x-forwarded-proto")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("http");
+
+    let base_url = format!("{}://{}", scheme, host);
+
+    let mut output = String::new();
+    for entry in state.procs.iter() {
+        let proc = entry.value();
+        output.push_str(&format_proc_tree_with_urls(proc, Some(&base_url)));
+        output.push('\n');
+    }
+    output
+}
+
+/// GET /procs/{proc_name} - Get details for a specific proc.
+pub async fn get_proc(Path(proc_name): Path<String>) -> Result<Json<ProcDetails>, StatusCode> {
+    let state = global();
+    let proc = state.procs.get(&proc_name).ok_or(StatusCode::NOT_FOUND)?;
+
+    let root_actors: Vec<String> = proc
+        .root_actor_ids()
+        .into_iter()
+        .map(|id| id.to_string())
+        .collect();
+
+    Ok(Json(ProcDetails {
+        proc_name,
+        root_actors,
+    }))
+}
+
+/// GET /procs/{proc_name}/{actor_name} - Get details for a specific actor.
+pub async fn get_actor(
+    Path((proc_name, actor_name)): Path<(String, String)>,
+) -> Result<Json<ActorDetails>, StatusCode> {
+    let state = global();
+    let proc = state.procs.get(&proc_name).ok_or(StatusCode::NOT_FOUND)?;
+
+    // Find actor by name by traversing all actors
+    let mut found_actor_id = None;
+    proc.traverse(&mut |cell, _| {
+        if cell.actor_id().name() == actor_name && found_actor_id.is_none() {
+            found_actor_id = Some(cell.actor_id().clone());
+        }
+    });
+
+    let actor_id = found_actor_id.ok_or(StatusCode::NOT_FOUND)?;
+    let cell = proc.get_instance(&actor_id).ok_or(StatusCode::NOT_FOUND)?;
+
+    let status = cell.status().borrow().clone();
+    let mut children = Vec::new();
+    cell.traverse(&mut |child, depth| {
+        if depth == 1 {
+            children.push(child.actor_id().to_string());
+        }
+    });
+
+    Ok(Json(ActorDetails {
+        actor_status: status.to_string(),
+        children,
+    }))
+}
+
+/// GET /{reference} - Resolve a reference and show status.
+pub async fn resolve_reference(Path(reference): Path<String>) -> impl IntoResponse {
+    let parsed = match Reference::from_str(&reference) {
+        Ok(r) => r,
+        Err(_) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({"error": "invalid reference"})),
+            );
+        }
+    };
+
+    let state = global();
+
+    match &parsed {
+        Reference::Proc(proc_id) => {
+            let proc_name = proc_id.to_string();
+            match state.procs.get(&proc_name) {
+                Some(proc) => {
+                    let root_actors: Vec<String> = proc
+                        .root_actor_ids()
+                        .into_iter()
+                        .map(|id| id.to_string())
+                        .collect();
+                    (
+                        StatusCode::OK,
+                        Json(serde_json::json!(ReferenceInfo::Proc(ProcDetails {
+                            proc_name,
+                            root_actors,
+                        }))),
+                    )
+                }
+                None => (
+                    StatusCode::NOT_FOUND,
+                    Json(serde_json::json!({"error": "proc not found"})),
+                ),
+            }
+        }
+        Reference::Actor(actor_id) => {
+            let proc_id = actor_id.proc_id();
+            let proc_name = proc_id.to_string();
+            match state.procs.get(&proc_name) {
+                Some(proc) => match proc.get_instance(actor_id) {
+                    Some(cell) => {
+                        let status = cell.status().borrow().clone();
+                        let mut children = Vec::new();
+                        cell.traverse(&mut |child, depth| {
+                            if depth == 1 {
+                                children.push(child.actor_id().to_string());
+                            }
+                        });
+                        (
+                            StatusCode::OK,
+                            Json(serde_json::json!(ReferenceInfo::Actor(ActorDetails {
+                                actor_status: status.to_string(),
+                                children,
+                            }))),
+                        )
+                    }
+                    None => (
+                        StatusCode::NOT_FOUND,
+                        Json(serde_json::json!({"error": "actor not found"})),
+                    ),
+                },
+                None => (
+                    StatusCode::NOT_FOUND,
+                    Json(serde_json::json!({"error": "proc not found"})),
+                ),
+            }
+        }
+        _ => (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({"error": "unsupported reference type"})),
+        ),
+    }
+}

--- a/hyperactor/src/admin/mod.rs
+++ b/hyperactor/src/admin/mod.rs
@@ -1,0 +1,154 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+//! HTTP admin server for introspecting procs and actors.
+//!
+//! The admin server provides a REST API for querying registered procs
+//! and their actor hierarchies.
+//!
+//! # Example
+//!
+//! ```ignore
+//! use hyperactor::admin;
+//! use tokio::net::TcpListener;
+//!
+//! // Register a proc
+//! admin::register_proc(&proc);
+//!
+//! // Start the admin server
+//! let listener = TcpListener::bind("127.0.0.1:8080").await?;
+//! admin::serve(listener).await?;
+//! ```
+
+mod handlers;
+mod responses;
+mod tree;
+
+use std::sync::OnceLock;
+
+use axum::Router;
+use axum::routing::get;
+use dashmap::DashMap;
+pub use responses::ActorDetails;
+pub use responses::ProcDetails;
+pub use responses::ProcSummary;
+pub use responses::ReferenceInfo;
+use tokio::net::TcpListener;
+pub use tree::format_proc_tree;
+pub use tree::format_proc_tree_with_urls;
+
+use crate::Proc;
+
+/// Global admin state holding registered procs.
+struct AdminState {
+    procs: DashMap<String, Proc>,
+}
+
+/// Returns the global admin state singleton.
+fn global() -> &'static AdminState {
+    static ADMIN_STATE: OnceLock<AdminState> = OnceLock::new();
+    ADMIN_STATE.get_or_init(|| AdminState {
+        procs: DashMap::new(),
+    })
+}
+
+/// Register a proc with the admin server.
+///
+/// Once registered, the proc's actors can be queried via the HTTP API.
+pub fn register_proc(proc: &Proc) {
+    global()
+        .procs
+        .insert(proc.proc_id().to_string(), proc.clone());
+}
+
+/// Deregister a proc from the admin server.
+///
+/// After deregistration, the proc will no longer appear in API responses.
+pub fn deregister_proc(proc: &Proc) {
+    global().procs.remove(&proc.proc_id().to_string());
+}
+
+/// Creates the axum router for the admin server.
+fn create_router() -> Router {
+    Router::new()
+        .route("/", get(handlers::list_procs))
+        .route("/tree", get(handlers::tree_dump))
+        .route("/procs/{proc_name}", get(handlers::get_proc))
+        .route("/procs/{proc_name}/{actor_name}", get(handlers::get_actor))
+        .route("/{*reference}", get(handlers::resolve_reference))
+}
+
+/// Start serving the admin HTTP server.
+///
+/// This function runs indefinitely until the server encounters an error.
+pub async fn serve(listener: TcpListener) -> std::io::Result<()> {
+    let app = create_router();
+    axum::serve(listener, app).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_register_deregister_proc() {
+        let proc = Proc::local();
+        let proc_id = proc.proc_id().to_string();
+
+        // Register
+        register_proc(&proc);
+        assert!(global().procs.contains_key(&proc_id));
+
+        // Deregister
+        deregister_proc(&proc);
+        assert!(!global().procs.contains_key(&proc_id));
+    }
+
+    #[tokio::test]
+    async fn test_list_procs_endpoint() {
+        use axum::body::Body;
+        use axum::http::Request;
+        use tower::ServiceExt;
+
+        let proc = Proc::local();
+        let proc_id = proc.proc_id().to_string();
+        register_proc(&proc);
+
+        let app = create_router();
+        let response = app
+            .oneshot(Request::builder().uri("/").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), axum::http::StatusCode::OK);
+
+        // Cleanup
+        deregister_proc(&proc);
+    }
+
+    #[tokio::test]
+    async fn test_tree_endpoint() {
+        use axum::body::Body;
+        use axum::http::Request;
+        use tower::ServiceExt;
+
+        let proc = Proc::local();
+        register_proc(&proc);
+
+        let app = create_router();
+        let response = app
+            .oneshot(Request::builder().uri("/tree").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), axum::http::StatusCode::OK);
+
+        // Cleanup
+        deregister_proc(&proc);
+    }
+}

--- a/hyperactor/src/admin/responses.rs
+++ b/hyperactor/src/admin/responses.rs
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+//! Response types for the admin HTTP API.
+
+use serde::Serialize;
+
+/// Summary of a registered proc.
+#[derive(Debug, Serialize)]
+pub struct ProcSummary {
+    /// The proc's name/ID.
+    pub name: String,
+    /// Number of actors in the proc.
+    pub num_actors: usize,
+}
+
+/// Details about a specific proc.
+#[derive(Debug, Serialize)]
+pub struct ProcDetails {
+    /// The proc's name/ID.
+    pub proc_name: String,
+    /// Names of root actors (pid=0).
+    pub root_actors: Vec<String>,
+}
+
+/// Details about a specific actor.
+#[derive(Debug, Serialize)]
+pub struct ActorDetails {
+    /// Current status of the actor.
+    pub actor_status: String,
+    /// Names of child actors.
+    pub children: Vec<String>,
+}
+
+/// Information about a resolved reference.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ReferenceInfo {
+    /// A proc reference with details.
+    Proc(ProcDetails),
+    /// An actor reference with details.
+    Actor(ActorDetails),
+}

--- a/hyperactor/src/admin/tree.rs
+++ b/hyperactor/src/admin/tree.rs
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+//! ASCII tree rendering for proc and actor hierarchies.
+
+use crate::Proc;
+use crate::reference::ActorId;
+
+/// Renders an ASCII tree of all actors in a proc (without URLs).
+pub fn format_proc_tree(proc: &Proc) -> String {
+    format_proc_tree_with_urls(proc, None)
+}
+
+/// Renders an ASCII tree of all actors in a proc, optionally with URLs.
+pub fn format_proc_tree_with_urls(proc: &Proc, base_url: Option<&str>) -> String {
+    let mut nodes: Vec<(ActorId, usize)> = Vec::new();
+    proc.traverse(&mut |cell, depth| {
+        nodes.push((cell.actor_id().clone(), depth));
+    });
+    render_tree(&nodes, base_url)
+}
+
+/// URL-encode a string for use in a URL path component.
+fn url_encode_path(s: &str) -> String {
+    let mut result = String::with_capacity(s.len() * 3);
+    for c in s.chars() {
+        match c {
+            // Unreserved characters (RFC 3986)
+            'A'..='Z' | 'a'..='z' | '0'..='9' | '-' | '_' | '.' | '~' => {
+                result.push(c);
+            }
+            // Encode everything else
+            _ => {
+                for byte in c.to_string().as_bytes() {
+                    result.push_str(&format!("%{:02X}", byte));
+                }
+            }
+        }
+    }
+    result
+}
+
+/// Renders a list of (actor_id, depth) pairs as an ASCII tree.
+fn render_tree(nodes: &[(ActorId, usize)], base_url: Option<&str>) -> String {
+    let mut output = String::new();
+    for (i, (actor_id, depth)) in nodes.iter().enumerate() {
+        let url_suffix = base_url
+            .map(|base| {
+                let encoded = url_encode_path(&actor_id.to_string());
+                format!("  ->  {}/{}", base.trim_end_matches('/'), encoded)
+            })
+            .unwrap_or_default();
+
+        if *depth == 0 {
+            output.push_str(&format!("{}{}\n", actor_id, url_suffix));
+        } else {
+            // Find if this is the last sibling at this depth
+            let is_last = nodes[i + 1..]
+                .iter()
+                .take_while(|(_, d)| *d >= *depth)
+                .all(|(_, d)| *d > *depth);
+
+            let mut prefix = String::new();
+            for d in 1..*depth {
+                // Check if there are more siblings at depth d after this node
+                let has_more_at_d = nodes[i + 1..].iter().any(|(_, dd)| *dd == d);
+                prefix.push_str(if has_more_at_d { "│   " } else { "    " });
+            }
+            prefix.push_str(if is_last { "└── " } else { "├── " });
+            output.push_str(&format!("{}{}{}\n", prefix, actor_id, url_suffix));
+        }
+    }
+    output
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_render_empty_tree() {
+        let nodes: Vec<(ActorId, usize)> = Vec::new();
+        let result = render_tree(&nodes, None);
+        assert_eq!(result, "");
+    }
+
+    #[test]
+    fn test_url_encode_path() {
+        assert_eq!(url_encode_path("simple"), "simple");
+        assert_eq!(url_encode_path("with[brackets]"), "with%5Bbrackets%5D");
+        assert_eq!(url_encode_path("with,comma"), "with%2Ccomma");
+        assert_eq!(url_encode_path("with@at"), "with%40at");
+        assert_eq!(url_encode_path("with:colon"), "with%3Acolon");
+    }
+}

--- a/hyperactor/src/lib.rs
+++ b/hyperactor/src/lib.rs
@@ -70,6 +70,7 @@
 pub mod accum;
 pub mod actor;
 pub mod actor_local;
+pub mod admin;
 pub mod channel;
 pub mod checkpoint;
 pub mod clock;

--- a/hyperactor/src/proc.rs
+++ b/hyperactor/src/proc.rs
@@ -415,6 +415,24 @@ impl Proc {
         }
     }
 
+    /// Look up an instance by ActorId.
+    pub fn get_instance(&self, actor_id: &ActorId) -> Option<InstanceCell> {
+        self.state()
+            .instances
+            .get(actor_id)
+            .and_then(|weak| weak.upgrade())
+    }
+
+    /// Returns the ActorIds of all root actors (pid=0) in this proc.
+    pub fn root_actor_ids(&self) -> Vec<ActorId> {
+        self.state()
+            .instances
+            .iter()
+            .filter(|entry| entry.key().pid() == 0)
+            .map(|entry| entry.key().clone())
+            .collect()
+    }
+
     /// Create a child instance. Called from `Instance`.
     fn child_instance(
         &self,
@@ -1713,7 +1731,7 @@ impl InstanceCell {
     }
 
     /// The instance's status observer.
-    pub(crate) fn status(&self) -> &watch::Receiver<ActorStatus> {
+    pub fn status(&self) -> &watch::Receiver<ActorStatus> {
         &self.inner.status
     }
 
@@ -1821,7 +1839,7 @@ impl InstanceCell {
     }
 
     /// The number of children this instance has.
-    fn child_count(&self) -> usize {
+    pub fn child_count(&self) -> usize {
         self.inner.children.len()
     }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #2497
* #2496
* #2495
* __->__ #2494
* #2493
* #2492

Add a new `hyperactor::admin` module providing an HTTP admin server using axum.
The server exposes a REST API for introspecting registered procs and their actors.

Endpoints:
- GET / - List all registered procs with actor counts
- GET /tree - ASCII tree dump with clickable URLs for each actor
- GET /procs/{proc_name} - Get proc details with root actors
- GET /procs/{proc_name}/{actor_name} - Get actor status and children
- GET /{reference} - Resolve any reference and show status

Key features:
- Singleton pattern using OnceLock<AdminState> with DashMap for thread-safe access
- URL-encoded paths in tree output for curl compatibility
- Simple registration API: admin::register_proc() and admin::deregister_proc()

Also updates dining_philosophers example to demonstrate admin server usage.

Differential Revision: [D92159360](https://our.internmc.facebook.com/intern/diff/D92159360/)