### PR TITLE
[hyperactor] expose flight recorder in admin API

### DIFF
--- a/hyperactor/src/admin/mod.rs
+++ b/hyperactor/src/admin/mod.rs
@@ -37,7 +37,7 @@ use dashmap::DashMap;
 pub use responses::ActorDetails;
 pub use responses::ProcDetails;
 pub use responses::ProcSummary;
-pub use responses::ReferenceInfo;
+pub use responses::RecordedEvent;
 use tokio::net::TcpListener;
 pub use tree::format_proc_tree;
 pub use tree::format_proc_tree_with_urls;

--- a/hyperactor/src/admin/responses.rs
+++ b/hyperactor/src/admin/responses.rs
@@ -9,6 +9,7 @@
 //! Response types for the admin HTTP API.
 
 use serde::Serialize;
+use serde_json::Value;
 
 /// Summary of a registered proc.
 #[derive(Debug, Serialize)]
@@ -28,6 +29,23 @@ pub struct ProcDetails {
     pub root_actors: Vec<String>,
 }
 
+/// A recorded event from the flight recorder.
+#[derive(Debug, Serialize)]
+pub struct RecordedEvent {
+    /// ISO 8601 formatted timestamp.
+    pub timestamp: String,
+    /// Sequence number for ordering.
+    pub seq: usize,
+    /// Event level (INFO, DEBUG, etc.).
+    pub level: String,
+    /// Event target (module path).
+    pub target: String,
+    /// Event name.
+    pub name: String,
+    /// Event fields as JSON.
+    pub fields: Value,
+}
+
 /// Details about a specific actor.
 #[derive(Debug, Serialize)]
 pub struct ActorDetails {
@@ -35,6 +53,8 @@ pub struct ActorDetails {
     pub actor_status: String,
     /// Names of child actors.
     pub children: Vec<String>,
+    /// Recent events from the flight recorder.
+    pub flight_recorder: Vec<RecordedEvent>,
 }
 
 /// Information about a resolved reference.

--- a/hyperactor/src/proc.rs
+++ b/hyperactor/src/proc.rs
@@ -1456,7 +1456,10 @@ impl<A: Actor> Instance<A> {
         // Pass a reference to the context to the handler, so that deref
         // coercion allows the `this` argument to be treated exactly like
         // &Instance<A>.
-        actor.handle(&context, message).await
+        actor
+            .handle(&context, message)
+            .instrument(self.inner.cell.inner.recording.span())
+            .await
     }
 
     /// Spawn on child on this instance.
@@ -1846,6 +1849,11 @@ impl InstanceCell {
     /// Get a child by its PID.
     fn get_child(&self, pid: Index) -> Option<InstanceCell> {
         self.inner.children.get(&pid).map(|child| child.clone())
+    }
+
+    /// Access the flight recorder for this actor.
+    pub fn recording(&self) -> &Recording {
+        &self.inner.recording
     }
 
     /// This is temporary so that we can share binding code between handle and instance.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #2497
* #2496
* __->__ #2495
* #2494
* #2493
* #2492

Expose the actor's flight recorder (ring buffer of recent tracing events)
in the admin API. The flight recorder is a 64-entry ring buffer that
captures recent tracing events for each actor.

- Add `recording()` method to `InstanceCell` to access the flight recorder
- Add `RecordedEvent` type with timestamp, seq, level, target, name, fields
- Update `ActorDetails` to include `flight_recorder` field
- Update `get_actor` and `resolve_reference` handlers to return flight
  recorder events using shared helper functions
- Remove unused `ReferenceInfo` type; reference resolver now returns the
  same format as the direct object endpoints

Differential Revision: [D92159359](https://our.internmc.facebook.com/intern/diff/D92159359/)