### PR TITLE
[hyper] add admin subcommand for terminal access to admin HTTP API

### DIFF
--- a/hyper/src/commands.rs
+++ b/hyper/src/commands.rs
@@ -6,5 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+pub mod admin;
 pub mod list;
 pub mod show;

--- a/hyper/src/commands/admin.rs
+++ b/hyper/src/commands/admin.rs
@@ -1,0 +1,273 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+//! Admin commands for interacting with the hyperactor admin HTTP API.
+
+use std::io::Write;
+
+use anyhow::Result;
+use chrono::DateTime;
+use chrono::Duration;
+use chrono::Local;
+use hyperactor::admin::ActorDetails;
+use hyperactor::admin::ProcDetails;
+use hyperactor::admin::ProcSummary;
+use hyperactor::admin::ReferenceInfo;
+use tabwriter::TabWriter;
+
+/// Admin command for interacting with the admin HTTP API.
+#[derive(clap::Args, Debug)]
+pub struct AdminCommand {
+    /// Admin server address (e.g., localhost:1234)
+    server: String,
+
+    #[command(subcommand)]
+    action: AdminAction,
+}
+
+#[derive(clap::Subcommand, Debug)]
+enum AdminAction {
+    /// List actors
+    Ps(PsCommand),
+    /// Show actor info
+    Info(InfoCommand),
+    /// Show flight recorder events
+    Events(EventsCommand),
+}
+
+#[derive(clap::Args, Debug)]
+struct PsCommand {
+    /// Optional proc name filter
+    proc_name: Option<String>,
+}
+
+#[derive(clap::Args, Debug)]
+struct InfoCommand {
+    /// Actor reference
+    actor_ref: String,
+}
+
+#[derive(clap::Args, Debug)]
+struct EventsCommand {
+    /// Actor reference
+    actor_ref: String,
+}
+
+impl AdminCommand {
+    pub async fn run(self) -> Result<()> {
+        let client = reqwest::Client::new();
+        let base_url = format!("http://{}", self.server);
+
+        match self.action {
+            AdminAction::Ps(cmd) => cmd.run(&client, &base_url).await,
+            AdminAction::Info(cmd) => cmd.run(&client, &base_url).await,
+            AdminAction::Events(cmd) => cmd.run(&client, &base_url).await,
+        }
+    }
+}
+
+/// Fetch actor details by reference, with proper URL encoding.
+async fn fetch_actor_details(
+    client: &reqwest::Client,
+    base_url: &str,
+    actor_ref: &str,
+) -> Result<ActorDetails> {
+    let encoded_ref = urlencoding::encode(actor_ref);
+    let url = format!("{}/{}", base_url, encoded_ref);
+    let resp = client.get(&url).send().await?;
+    if !resp.status().is_success() {
+        anyhow::bail!("actor not found: {}", actor_ref);
+    }
+    let ref_info: ReferenceInfo = resp.json().await?;
+    match ref_info {
+        ReferenceInfo::Actor(details) => Ok(details),
+        ReferenceInfo::Proc(_) => anyhow::bail!("expected actor, got proc: {}", actor_ref),
+    }
+}
+
+/// Recursively collect all actors starting from a given actor.
+async fn collect_actors_recursive(
+    client: &reqwest::Client,
+    base_url: &str,
+    actor_ref: &str,
+    actors: &mut Vec<(String, ActorDetails)>,
+) {
+    if let Ok(details) = fetch_actor_details(client, base_url, actor_ref).await {
+        let children: Vec<String> = details.children.clone();
+        actors.push((actor_ref.to_string(), details));
+
+        // Recursively fetch children
+        for child_ref in children {
+            Box::pin(collect_actors_recursive(
+                client, base_url, &child_ref, actors,
+            ))
+            .await;
+        }
+    }
+}
+
+impl PsCommand {
+    async fn run(self, client: &reqwest::Client, base_url: &str) -> Result<()> {
+        // List all procs first
+        let url = format!("{}/", base_url);
+        let resp = client.get(&url).send().await?;
+        let procs: Vec<ProcSummary> = resp.json().await?;
+
+        // Collect all actors from all procs (optionally filtered)
+        let mut all_actors = Vec::new();
+
+        for proc in &procs {
+            // Apply proc filter if specified
+            if let Some(ref filter) = self.proc_name {
+                if !proc.name.contains(filter) {
+                    continue;
+                }
+            }
+
+            // Get proc details to find root actors
+            let encoded_proc = urlencoding::encode(&proc.name);
+            let url = format!("{}/procs/{}", base_url, encoded_proc);
+            if let Ok(resp) = client.get(&url).send().await {
+                if resp.status().is_success() {
+                    if let Ok(proc_details) = resp.json::<ProcDetails>().await {
+                        // Recursively collect all actors starting from roots
+                        for root_actor in &proc_details.root_actors {
+                            collect_actors_recursive(client, base_url, root_actor, &mut all_actors)
+                                .await;
+                        }
+                    }
+                }
+            }
+        }
+
+        print_actor_table(&all_actors)?;
+        Ok(())
+    }
+}
+
+impl InfoCommand {
+    async fn run(self, client: &reqwest::Client, base_url: &str) -> Result<()> {
+        let details = fetch_actor_details(client, base_url, &self.actor_ref).await?;
+
+        println!("id: {}", self.actor_ref);
+        println!("type: {}", details.actor_type);
+        println!("status: {}", details.actor_status);
+        println!("parent: {}", details.parent.as_deref().unwrap_or("-"));
+        println!("created: {}", details.created_at);
+        println!("messages_processed: {}", details.messages_processed);
+        println!(
+            "processing_time: {}",
+            format_duration_us(details.total_processing_time_us)
+        );
+        println!(
+            "last_handler: {}",
+            details.last_message_handler.as_deref().unwrap_or("-")
+        );
+        if details.children.is_empty() {
+            println!("children: []");
+        } else {
+            println!("children:");
+            for child in &details.children {
+                println!("  - {}", child);
+            }
+        }
+        Ok(())
+    }
+}
+
+impl EventsCommand {
+    async fn run(self, client: &reqwest::Client, base_url: &str) -> Result<()> {
+        let details = fetch_actor_details(client, base_url, &self.actor_ref).await?;
+
+        for event in &details.flight_recorder {
+            // Format in glog style: L0202 15:30:45.123456 message
+            let level_char = match event.level.as_str() {
+                "INFO" => 'I',
+                "DEBUG" => 'D',
+                "WARN" => 'W',
+                "ERROR" => 'E',
+                "TRACE" => 'T',
+                _ => '?',
+            };
+
+            // Parse timestamp and format for glog
+            let formatted_time = if let Ok(dt) = DateTime::parse_from_rfc3339(&event.timestamp) {
+                dt.format("%m%d %H:%M:%S%.6f").to_string()
+            } else {
+                event.timestamp.clone()
+            };
+
+            // Format fields as key:value pairs
+            let fields_str = if let Some(obj) = event.fields.as_object() {
+                obj.iter()
+                    .map(|(k, v)| {
+                        let v_str = match v {
+                            serde_json::Value::String(s) => s.clone(),
+                            _ => v.to_string(),
+                        };
+                        format!("{}:{}", k, v_str)
+                    })
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            } else {
+                event.fields.to_string()
+            };
+
+            println!(
+                "{}{} {}, {}",
+                level_char, formatted_time, event.name, fields_str
+            );
+        }
+        Ok(())
+    }
+}
+
+/// Format a relative time string from an ISO timestamp.
+fn format_relative_time(iso_timestamp: &str) -> String {
+    let dt = DateTime::parse_from_rfc3339(iso_timestamp)
+        .map(|d| d.with_timezone(&Local))
+        .unwrap_or_else(|_| Local::now());
+    let dur = Local::now().signed_duration_since(dt);
+
+    if dur > Duration::days(6) {
+        dt.format("%Y-%m-%dT%H:%M:%S").to_string()
+    } else if dur > Duration::days(1) {
+        dt.format("%a%-l:%M%P").to_string()
+    } else {
+        dt.format("%-l:%M%P").to_string()
+    }
+}
+
+/// Format a duration in microseconds as a human-readable string.
+fn format_duration_us(us: u64) -> String {
+    if us < 1_000 {
+        format!("{}µs", us)
+    } else if us < 1_000_000 {
+        format!("{:.2}ms", us as f64 / 1_000.0)
+    } else {
+        format!("{:.2}s", us as f64 / 1_000_000.0)
+    }
+}
+
+/// Print a table of actors with their details.
+fn print_actor_table(actors: &[(String, ActorDetails)]) -> Result<()> {
+    let mut tw = TabWriter::new(vec![]);
+    writeln!(tw, "ACTOR_ID\tTYPE\tSTATUS\tPROC_TIME\tCREATED")?;
+    for (actor_id, details) in actors {
+        let created = format_relative_time(&details.created_at);
+        let proc_time = format_duration_us(details.total_processing_time_us);
+        writeln!(
+            tw,
+            "{}\t{}\t{}\t{}\t{}",
+            actor_id, details.actor_type, details.actor_status, proc_time, created
+        )?;
+    }
+    tw.flush()?;
+    print!("{}", String::from_utf8(tw.into_inner()?)?);
+    Ok(())
+}

--- a/hyper/src/main.rs
+++ b/hyper/src/main.rs
@@ -11,6 +11,7 @@ mod commands;
 use clap::Parser;
 use clap::Subcommand;
 
+use crate::commands::admin::AdminCommand;
 use crate::commands::list::ListCommand;
 use crate::commands::show::ShowCommand;
 
@@ -28,6 +29,9 @@ enum Command {
 
     #[clap(about = r#"List available resources"#)]
     List(ListCommand),
+
+    #[clap(about = r#"Admin commands for the hyperactor admin HTTP API"#)]
+    Admin(AdminCommand),
 }
 
 #[cfg(fbcode_build)]
@@ -49,5 +53,6 @@ async fn run() -> Result<(), anyhow::Error> {
     match args.command {
         Command::Show(command) => Ok(command.run().await?),
         Command::List(command) => Ok(command.run().await?),
+        Command::Admin(command) => Ok(command.run().await?),
     }
 }

--- a/hyperactor/src/admin/handlers.rs
+++ b/hyperactor/src/admin/handlers.rs
@@ -139,10 +139,23 @@ fn build_actor_details(cell: &InstanceCell) -> ActorDetails {
         })
         .collect();
 
+    let parent = cell.parent().map(|p| p.actor_id().to_string());
+    let messages_processed = cell.num_processed_messages();
+    let created_at = format_timestamp(cell.created_at());
+    let last_message_handler = cell.last_message_handler().map(|info| info.to_string());
+    let total_processing_time_us = cell.total_processing_time_us();
+    let actor_type = cell.actor_type_name().to_string();
+
     ActorDetails {
         actor_status: status.to_string(),
+        actor_type,
         children,
         flight_recorder,
+        parent,
+        messages_processed,
+        created_at,
+        last_message_handler,
+        total_processing_time_us,
     }
 }
 

--- a/hyperactor/src/admin/mod.rs
+++ b/hyperactor/src/admin/mod.rs
@@ -38,6 +38,7 @@ pub use responses::ActorDetails;
 pub use responses::ProcDetails;
 pub use responses::ProcSummary;
 pub use responses::RecordedEvent;
+pub use responses::ReferenceInfo;
 use tokio::net::TcpListener;
 pub use tree::format_proc_tree;
 pub use tree::format_proc_tree_with_urls;

--- a/hyperactor/src/admin/responses.rs
+++ b/hyperactor/src/admin/responses.rs
@@ -8,11 +8,12 @@
 
 //! Response types for the admin HTTP API.
 
+use serde::Deserialize;
 use serde::Serialize;
 use serde_json::Value;
 
 /// Summary of a registered proc.
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct ProcSummary {
     /// The proc's name/ID.
     pub name: String,
@@ -21,7 +22,7 @@ pub struct ProcSummary {
 }
 
 /// Details about a specific proc.
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct ProcDetails {
     /// The proc's name/ID.
     pub proc_name: String,
@@ -30,7 +31,7 @@ pub struct ProcDetails {
 }
 
 /// A recorded event from the flight recorder.
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct RecordedEvent {
     /// ISO 8601 formatted timestamp.
     pub timestamp: String,
@@ -47,18 +48,30 @@ pub struct RecordedEvent {
 }
 
 /// Details about a specific actor.
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct ActorDetails {
     /// Current status of the actor.
     pub actor_status: String,
+    /// The actor's type name.
+    pub actor_type: String,
     /// Names of child actors.
     pub children: Vec<String>,
     /// Recent events from the flight recorder.
     pub flight_recorder: Vec<RecordedEvent>,
+    /// Parent actor ID, if any.
+    pub parent: Option<String>,
+    /// Number of messages processed.
+    pub messages_processed: u64,
+    /// ISO 8601 formatted creation timestamp.
+    pub created_at: String,
+    /// Last message handler invoked.
+    pub last_message_handler: Option<String>,
+    /// Total processing time in microseconds.
+    pub total_processing_time_us: u64,
 }
 
 /// Information about a resolved reference.
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ReferenceInfo {
     /// A proc reference with details.

--- a/hyperactor/src/lib.rs
+++ b/hyperactor/src/lib.rs
@@ -111,6 +111,7 @@ pub mod internal_macro_support {
 pub use actor::Actor;
 pub use actor::ActorHandle;
 pub use actor::Handler;
+pub use actor::HandlerInfo;
 pub use actor::RemoteHandles;
 pub use actor::RemoteSpawn;
 pub use actor_local::ActorLocal;

--- a/hyperactor/src/proc.rs
+++ b/hyperactor/src/proc.rs
@@ -23,11 +23,14 @@ use std::panic::Location;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::sync::OnceLock;
+use std::sync::RwLock;
 use std::sync::Weak;
 use std::sync::atomic::AtomicU64;
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
 use std::time::Duration;
+use std::time::Instant;
+use std::time::SystemTime;
 
 use async_trait::async_trait;
 use dashmap::DashMap;
@@ -58,6 +61,7 @@ use crate::actor::ActorErrorKind;
 use crate::actor::ActorHandle;
 use crate::actor::ActorStatus;
 use crate::actor::Binds;
+use crate::actor::HandlerInfo;
 use crate::actor::Referable;
 use crate::actor::RemoteHandles;
 use crate::actor::Signal;
@@ -1432,34 +1436,47 @@ impl<A: Actor> Instance<A> {
     where
         A: Handler<M>,
     {
-        let handler = type_info.map(|info| {
-            (
-                info.typename().to_string(),
+        // Build HandlerInfo from TypeInfo (zero-copy) or fall back to type_name.
+        let handler_info = match type_info {
+            Some(info) => {
                 // SAFETY: The caller promises to pass the correct type info.
-                unsafe {
-                    info.arm_unchecked(&message as *const M as *const ())
-                        .map(str::to_string)
-                },
-            )
-        });
+                let arm = unsafe { info.arm_unchecked(&message as *const M as *const ()) };
+                Some(HandlerInfo::from_static(info.typename(), arm))
+            }
+            None => {
+                // Fall back to std::any::type_name (also static, zero-copy).
+                Some(HandlerInfo::from_static(std::any::type_name::<M>(), None))
+            }
+        };
 
         self.change_status(ActorStatus::Processing(
             self.clock().system_time_now(),
-            handler,
+            handler_info.clone(),
         ));
         crate::mailbox::headers::log_message_latency_if_sampling(
             &headers,
             self.self_id().to_string(),
         );
 
+        // Record the message handler being invoked.
+        *self.inner.cell.inner.last_message_handler.write().unwrap() = handler_info;
+
         let context = Context::new(self, headers);
         // Pass a reference to the context to the handler, so that deref
         // coercion allows the `this` argument to be treated exactly like
         // &Instance<A>.
-        actor
+        let start = Instant::now();
+        let result = actor
             .handle(&context, message)
             .instrument(self.inner.cell.inner.recording.span())
-            .await
+            .await;
+        let elapsed_us = start.elapsed().as_micros() as u64;
+        self.inner
+            .cell
+            .inner
+            .total_processing_time_us
+            .fetch_add(elapsed_us, Ordering::SeqCst);
+        result
     }
 
     /// Spawn on child on this instance.
@@ -1602,6 +1619,15 @@ enum ActorType {
     Anonymous(&'static str),
 }
 
+impl ActorType {
+    fn type_name(&self) -> &str {
+        match self {
+            ActorType::Named(info) => info.typename(),
+            ActorType::Anonymous(name) => name,
+        }
+    }
+}
+
 /// InstanceCell contains all of the type-erased, shareable state of an instance.
 /// Specifically, InstanceCells form a supervision tree, and is used by ActorHandle
 /// to access the underlying instance.
@@ -1651,6 +1677,15 @@ struct InstanceCellState {
 
     /// The number of messages processed by this actor.
     num_processed_messages: AtomicU64,
+
+    /// When this actor was created.
+    created_at: SystemTime,
+
+    /// Name of the last message handler invoked.
+    last_message_handler: RwLock<Option<HandlerInfo>>,
+
+    /// Total time spent processing messages, in microseconds.
+    total_processing_time_us: AtomicU64,
 
     /// The log recording associated with this actor. It is used to
     /// store a 'flight record' of events while the actor is running.
@@ -1702,6 +1737,9 @@ impl InstanceCell {
                 actor_task_handle: OnceLock::new(),
                 exported_named_ports: DashMap::new(),
                 num_processed_messages: AtomicU64::new(0),
+                created_at: SystemTime::now(),
+                last_message_handler: RwLock::new(None),
+                total_processing_time_us: AtomicU64::new(0),
                 recording: hyperactor_telemetry::recorder().record(64),
                 ports,
             }),
@@ -1829,12 +1867,6 @@ impl InstanceCell {
         self.inner.maybe_unlink_parent()
     }
 
-    /// Get parent instance cell, if it exists.
-    #[allow(dead_code)]
-    fn get_parent_cell(&self) -> Option<InstanceCell> {
-        self.inner.parent.upgrade()
-    }
-
     /// Return an iterator over this instance's children. This may deadlock if the
     /// caller already holds a reference to any item in map.
     fn child_iter(&self) -> impl Iterator<Item = RefMulti<'_, Index, InstanceCell>> {
@@ -1854,6 +1886,36 @@ impl InstanceCell {
     /// Access the flight recorder for this actor.
     pub fn recording(&self) -> &Recording {
         &self.inner.recording
+    }
+
+    /// When this actor was created.
+    pub fn created_at(&self) -> SystemTime {
+        self.inner.created_at
+    }
+
+    /// The number of messages processed by this actor.
+    pub fn num_processed_messages(&self) -> u64 {
+        self.inner.num_processed_messages.load(Ordering::SeqCst)
+    }
+
+    /// The last message handler invoked by this actor.
+    pub fn last_message_handler(&self) -> Option<HandlerInfo> {
+        self.inner.last_message_handler.read().unwrap().clone()
+    }
+
+    /// Total time spent processing messages, in microseconds.
+    pub fn total_processing_time_us(&self) -> u64 {
+        self.inner.total_processing_time_us.load(Ordering::SeqCst)
+    }
+
+    /// Get parent instance cell, if it exists.
+    pub fn parent(&self) -> Option<InstanceCell> {
+        self.inner.parent.upgrade()
+    }
+
+    /// The actor's type name.
+    pub fn actor_type_name(&self) -> &str {
+        self.inner.actor_type.type_name()
     }
 
     /// This is temporary so that we can share binding code between handle and instance.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #2497
* __->__ #2496
* #2495
* #2494
* #2493
* #2492

Add a `hyper admin` subcommand that provides terminal access to the hyperactor admin
HTTP API. This enables operators to inspect running actors from the command line.

Commands:
- `hyper admin <host:port> ps` - List all actors with type, status, processing time
- `hyper admin <host:port> ps <filter>` - Filter to procs matching filter
- `hyper admin <host:port> info <actor_ref>` - Show detailed actor info
- `hyper admin <host:port> events <actor_ref>` - Show flight recorder events

Also adds tracking fields to InstanceCellState:
- `created_at` - When the actor was created
- `last_message_type` - The type of the last processed message
- `total_processing_time_us` - Cumulative message processing time

These fields are exposed via the admin API's ActorDetails response.

Differential Revision: [D92159355](https://our.internmc.facebook.com/intern/diff/D92159355/)