### PR TITLE
[hyperactor] auto-register procs with admin server using weak references

### DIFF
--- a/hyperactor/src/admin/handlers.rs
+++ b/hyperactor/src/admin/handlers.rs
@@ -27,6 +27,7 @@ use super::responses::RecordedEvent;
 use super::responses::ReferenceInfo;
 use super::tree::format_proc_tree_with_urls;
 use crate::ActorId;
+use crate::ProcId;
 use crate::proc::InstanceCell;
 use crate::reference::Reference;
 
@@ -36,16 +37,16 @@ pub async fn list_procs() -> Json<Vec<ProcSummary>> {
     let procs: Vec<ProcSummary> = state
         .procs
         .iter()
-        .map(|entry| {
-            let proc = entry.value();
+        .filter_map(|entry| {
+            let proc = entry.value().upgrade()?;
             let mut num_actors = 0;
             proc.traverse(&mut |_, _| {
                 num_actors += 1;
             });
-            ProcSummary {
-                name: entry.key().clone(),
+            Some(ProcSummary {
+                name: entry.key().to_string(),
                 num_actors,
-            }
+            })
         })
         .collect();
     Json(procs)
@@ -71,9 +72,10 @@ pub async fn tree_dump(headers: HeaderMap) -> String {
 
     let mut output = String::new();
     for entry in state.procs.iter() {
-        let proc = entry.value();
-        output.push_str(&format_proc_tree_with_urls(proc, Some(&base_url)));
-        output.push('\n');
+        if let Some(proc) = entry.value().upgrade() {
+            output.push_str(&format_proc_tree_with_urls(&proc, Some(&base_url)));
+            output.push('\n');
+        }
     }
     output
 }
@@ -81,7 +83,9 @@ pub async fn tree_dump(headers: HeaderMap) -> String {
 /// GET /procs/{proc_name} - Get details for a specific proc.
 pub async fn get_proc(Path(proc_name): Path<String>) -> Result<Json<ProcDetails>, StatusCode> {
     let state = global();
-    let proc = state.procs.get(&proc_name).ok_or(StatusCode::NOT_FOUND)?;
+    let proc_id = ProcId::from_str(&proc_name).map_err(|_| StatusCode::BAD_REQUEST)?;
+    let weak = state.procs.get(&proc_id).ok_or(StatusCode::NOT_FOUND)?;
+    let proc = weak.upgrade().ok_or(StatusCode::NOT_FOUND)?;
 
     let root_actors: Vec<String> = proc
         .root_actor_ids()
@@ -100,7 +104,9 @@ pub async fn get_actor(
     Path((proc_name, actor_name)): Path<(String, String)>,
 ) -> Result<Json<ActorDetails>, StatusCode> {
     let state = global();
-    let proc = state.procs.get(&proc_name).ok_or(StatusCode::NOT_FOUND)?;
+    let proc_id = ProcId::from_str(&proc_name).map_err(|_| StatusCode::BAD_REQUEST)?;
+    let weak = state.procs.get(&proc_id).ok_or(StatusCode::NOT_FOUND)?;
+    let proc = weak.upgrade().ok_or(StatusCode::NOT_FOUND)?;
 
     // Find actor by name by traversing all actors
     let mut found_actor_id = None;
@@ -162,10 +168,11 @@ fn build_actor_details(cell: &InstanceCell) -> ActorDetails {
 /// Look up an actor by ActorId and return its details.
 fn lookup_actor_details(actor_id: &ActorId) -> Option<ActorDetails> {
     let state = global();
-    let proc_name = actor_id.proc_id().to_string();
+    let proc_id = actor_id.proc_id();
     state
         .procs
-        .get(&proc_name)
+        .get(proc_id)
+        .and_then(|weak| weak.upgrade())
         .and_then(|proc| proc.get_instance(actor_id))
         .map(|cell| build_actor_details(&cell))
 }
@@ -192,8 +199,7 @@ pub async fn resolve_reference(Path(reference): Path<String>) -> impl IntoRespon
 
     match &parsed {
         Reference::Proc(proc_id) => {
-            let proc_name = proc_id.to_string();
-            match state.procs.get(&proc_name) {
+            match state.procs.get(proc_id).and_then(|w| w.upgrade()) {
                 Some(proc) => {
                     let root_actors: Vec<String> = proc
                         .root_actor_ids()
@@ -203,7 +209,7 @@ pub async fn resolve_reference(Path(reference): Path<String>) -> impl IntoRespon
                     (
                         StatusCode::OK,
                         Json(serde_json::json!(ReferenceInfo::Proc(ProcDetails {
-                            proc_name,
+                            proc_name: proc_id.to_string(),
                             root_actors,
                         }))),
                     )

--- a/hyperactor/src/lib.rs
+++ b/hyperactor/src/lib.rs
@@ -162,6 +162,7 @@ pub use proc::Context;
 pub use proc::Instance;
 pub use proc::InstanceCell;
 pub use proc::Proc;
+pub use proc::WeakProc;
 pub use reference::ActorId;
 pub use reference::ActorRef;
 pub use reference::GangId;

--- a/hyperactor/src/proc.rs
+++ b/hyperactor/src/proc.rs
@@ -157,6 +157,9 @@ struct ProcState {
 
 impl Drop for ProcState {
     fn drop(&mut self) {
+        // Deregister from admin server.
+        crate::admin::deregister_proc_by_id(&self.proc_id);
+
         // We only want log ProcStatus::Dropped when ProcState is dropped,
         // rather than Proc is dropped. This is because we need to wait for
         // Proc::inner's ref count becomes 0.
@@ -210,7 +213,7 @@ impl Proc {
             name = "ProcStatus",
             status = "Created"
         );
-        Self {
+        let proc = Self {
             inner: Arc::new(ProcState {
                 proc_id,
                 proc_muxer: MailboxMuxer::new(),
@@ -220,7 +223,12 @@ impl Proc {
                 supervision_coordinator_port: OnceLock::new(),
                 clock,
             }),
-        }
+        };
+
+        // Auto-register with admin server using a weak reference.
+        crate::admin::register_proc(&proc);
+
+        proc
     }
 
     /// Set the supervision coordinator's port for this proc. Return Err if it is
@@ -706,7 +714,8 @@ impl Proc {
         Ok(parent_id.child_id(pid))
     }
 
-    fn downgrade(&self) -> WeakProc {
+    /// Downgrade to a weak reference that doesn't prevent the proc from being dropped.
+    pub fn downgrade(&self) -> WeakProc {
         WeakProc::new(self)
     }
 }
@@ -726,15 +735,17 @@ impl MailboxSender for Proc {
     }
 }
 
-#[derive(Debug)]
-struct WeakProc(Weak<ProcState>);
+/// A weak reference to a Proc that doesn't prevent it from being dropped.
+#[derive(Clone, Debug)]
+pub struct WeakProc(Weak<ProcState>);
 
 impl WeakProc {
     fn new(proc: &Proc) -> Self {
         Self(Arc::downgrade(&proc.inner))
     }
 
-    fn upgrade(&self) -> Option<Proc> {
+    /// Upgrade to a strong Proc reference, if the proc is still alive.
+    pub fn upgrade(&self) -> Option<Proc> {
         self.0.upgrade().map(|inner| Proc { inner })
     }
 }

--- a/hyperactor_mesh/examples/dining_philosophers.rs
+++ b/hyperactor_mesh/examples/dining_philosophers.rs
@@ -250,9 +250,6 @@ async fn main() -> Result<ExitCode> {
     let group_size = 5;
     let instance = global_root_client();
 
-    // Register the local proc with the admin server
-    admin::register_proc(instance.proc());
-
     // Start the admin HTTP server in a background task
     let listener = TcpListener::bind("127.0.0.1:0").await?;
     let admin_addr = listener.local_addr()?;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #2497
* #2496
* #2495
* #2494
* #2493
* #2492

Procs are now automatically registered with the admin server on creation and
automatically deregistered when dropped, eliminating the need for manual
register_proc/deregister_proc calls. The admin server stores weak references
so it doesn't prevent procs from being dropped.

- Add public WeakProc type with upgrade() method
- Make Proc::downgrade() public
- Auto-register in Proc::new_with_clock()
- Auto-deregister in ProcState::drop()
- Make register_proc/deregister_proc crate-private
- Use ProcId as map key instead of String for type safety
- Update handlers to parse strings to ProcId for REST API lookups
- Update dining philosophers example to remove manual registration

Differential Revision: [D92159354](https://our.internmc.facebook.com/intern/diff/D92159354/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D92159354/)!