### PR TITLE
Bump versions for new nightlies targeting 0.4.0

### DIFF
--- a/.github/workflows/build-dist.yml
+++ b/.github/workflows/build-dist.yml
@@ -24,7 +24,7 @@ on:
         type: string
         default: 'linux.g5.4xlarge.nvidia.gpu'
       version:
-        description: 'Version string for the wheel (default: 0.3.0.dev<date>)'
+        description: 'Version string for the wheel (default: $current_version.dev<date>)'
         type: string
         default: ''
       timeout:
@@ -64,7 +64,7 @@ jobs:
         if [ -n "${{ inputs.version }}" ]; then
           export MONARCH_VERSION="${{ inputs.version }}"
         else
-          export MONARCH_VERSION=0.3.0.dev$(date +'%Y%m%d')
+          export MONARCH_VERSION=0.4.0.dev$(date +'%Y%m%d')
         fi
         export MONARCH_BUILD_MESH_ONLY=0
 

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -94,7 +94,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Get tag for publishing
-        run: echo "DOCKER_TAG=0.3.0.dev$(date +'%Y%m%d')-cuda12.8" >> $GITHUB_ENV
+        run: echo "DOCKER_TAG=0.4.0.dev$(date +'%Y%m%d')-cuda12.8" >> $GITHUB_ENV
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v6

--- a/setup.py
+++ b/setup.py
@@ -312,7 +312,7 @@ class Clean(Command):
 
 # Actual Setup
 package_name = os.environ.get("MONARCH_PACKAGE_NAME", "torchmonarch")
-package_version = os.environ.get("MONARCH_VERSION", "0.3.0.dev0")
+package_version = os.environ.get("MONARCH_VERSION", "0.4.0.dev0")
 
 setup(
     name=package_name,


### PR DESCRIPTION
Summary:
We're still publishing nightlies on PyPI with 0.3.0.dev...,
these should be bumped to be 0.4.0.dev... because
they're newer than the released stable 0.3.0.

In the future we can try to refactor these to use a common constant to make this easier
to fix.

Reviewed By: thedavekwon

Differential Revision: D92184572


