### PR TITLE
Buckify distributed telemetry

### DIFF
--- a/python/monarch/_rust_bindings/monarch_distributed_telemetry/__init__.pyi
+++ b/python/monarch/_rust_bindings/monarch_distributed_telemetry/__init__.pyi
@@ -1,0 +1,22 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from monarch._rust_bindings.monarch_distributed_telemetry import (
+    database_scanner as database_scanner,
+    query_engine as query_engine,
+)
+
+def enable_record_batch_tracing(batch_size: int) -> None:
+    """Register a RecordBatchSink with the telemetry system."""
+    ...
+
+def get_record_batch_flush_count() -> int:
+    """Get the total number of RecordBatches flushed by the sink."""
+    ...
+
+def reset_record_batch_flush_count() -> None:
+    """Reset the flush counter to zero."""
+    ...

--- a/python/monarch/_rust_bindings/monarch_distributed_telemetry/database_scanner.pyi
+++ b/python/monarch/_rust_bindings/monarch_distributed_telemetry/database_scanner.pyi
@@ -1,0 +1,37 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import List, Optional
+
+class DatabaseScanner:
+    """Local MemTable operations, scans with child stream merging."""
+
+    def __new__(
+        cls,
+        rank: int,
+        use_fake_data: bool = True,
+        max_batches: int = 100,
+        batch_size: int = 1000,
+    ) -> "DatabaseScanner": ...
+    def flush(self) -> None:
+        """Flush any pending trace events to the tables."""
+        ...
+    def table_names(self) -> List[str]:
+        """Get list of table names."""
+        ...
+    def schema_for(self, table: str) -> bytes:
+        """Get schema for a table in Arrow IPC format."""
+        ...
+    def scan(
+        self,
+        dest: object,
+        table_name: str,
+        projection: Optional[List[int]] = None,
+        limit: Optional[int] = None,
+        filter_expr: Optional[str] = None,
+    ) -> int:
+        """Perform a scan, sending results directly to the dest port."""
+        ...

--- a/python/monarch/_rust_bindings/monarch_distributed_telemetry/query_engine.pyi
+++ b/python/monarch/_rust_bindings/monarch_distributed_telemetry/query_engine.pyi
@@ -1,0 +1,14 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+class QueryEngine:
+    """DataFusion query execution, creates ports, collects results."""
+
+    def __new__(cls, actor: object) -> "QueryEngine": ...
+    def __repr__(self) -> str: ...
+    def query(self, sql: str) -> bytes:
+        """Execute a SQL query and return results as Arrow IPC bytes."""
+        ...

--- a/python/monarch/distributed_telemetry/actor.py
+++ b/python/monarch/distributed_telemetry/actor.py
@@ -20,7 +20,7 @@ variable and used by the DistributedTelemetryActor when it initializes.
 """
 
 import functools
-from typing import Any, List, Optional
+from typing import Any, Callable, List, Optional
 
 from monarch._rust_bindings.monarch_distributed_telemetry.database_scanner import (
     DatabaseScanner,
@@ -36,7 +36,7 @@ from monarch.distributed_telemetry.engine import QueryEngine
 
 # Module-level scanner created at process startup to avoid race conditions.
 _scanner: Optional[DatabaseScanner] = None
-_scanner_startup_impl = None
+_scanner_startup_impl: Optional[Callable[[], None]] = None
 
 # Module-level list of spawned ProcMeshes, recorded by the spawn callback.
 _spawned_procs: List[ProcMesh] = []
@@ -48,7 +48,7 @@ def _on_proc_mesh_spawned(pm: ProcMesh) -> None:
     _spawned_procs.append(pm)
 
 
-def _scanner_startup():
+def _scanner_startup() -> Optional[Callable[[], None]]:
     return _scanner_startup_impl
 
 

--- a/python/monarch/distributed_telemetry/engine.py
+++ b/python/monarch/distributed_telemetry/engine.py
@@ -12,7 +12,7 @@ QueryEngine - Wrapper for the Rust QueryEngine.
 Provides SQL query execution over distributed telemetry actors.
 """
 
-from typing import Optional, Tuple, TYPE_CHECKING
+from typing import Optional, Tuple, Type, TYPE_CHECKING
 
 import pyarrow as pa
 from monarch._rust_bindings.monarch_distributed_telemetry.query_engine import (
@@ -47,7 +47,7 @@ class QueryEngine:
 
     def __reduce__(
         self,
-    ) -> Tuple[type, Tuple["DistributedTelemetryActor"]]:
+    ) -> Tuple[Type["QueryEngine"], Tuple["DistributedTelemetryActor"]]:
         """Make QueryEngine serializable by recreating the Rust object on unpickle."""
         return (QueryEngine, (self._actor,))
 

--- a/python/tests/test_distributed_telemetry.py
+++ b/python/tests/test_distributed_telemetry.py
@@ -122,7 +122,7 @@ def test_record_batch_tracing(cleanup_callbacks) -> None:
             reset_record_batch_flush_count,
         )
     except ImportError:
-        pytest.skip(
+        pytest.skip(  # pyre-ignore[29]: pytest.skip is callable
             "RecordBatch tracing not available (requires distributed_sql_telemetry feature)"
         )
         return


### PR DESCRIPTION
Summary:
This enables distributed telemetry always on buck builds - seems like its not used in outside of tests now so probably safe?

Added *.pyi files to satisfy pyre checks.

Reviewed By: thedavekwon

Differential Revision: D91928823


