### PR TITLE
Update bytes 1.11.0 -> 1.11.1 (fix RUSTSEC-2026-0007)

### DIFF
--- a/hyperactor/Cargo.toml
+++ b/hyperactor/Cargo.toml
@@ -35,7 +35,7 @@ anyhow = "1.0.98"
 async-trait = "0.1.86"
 backoff = { version = "0.4.0", features = ["futures", "tokio"] }
 bincode = "1.3.3"
-bytes = { version = "1.10", features = ["serde"] }
+bytes = { version = "1.11.1", features = ["serde"] }
 clap = { version = "4.5.42", features = ["derive", "env", "string", "unicode", "wrap_help"] }
 dashmap = { version = "5.5.3", features = ["rayon", "serde"] }
 derivative = "2.2"

--- a/hyperactor_mesh/Cargo.toml
+++ b/hyperactor_mesh/Cargo.toml
@@ -80,7 +80,7 @@ wirevalue = { version = "0.0.0", path = "../wirevalue" }
 zbus = { version = "5.11.0", features = ["async-executor", "async-fs", "async-io", "async-lock", "async-process", "async-task", "p2p", "tokio"], default-features = false }
 
 [dev-dependencies]
-bytes = { version = "1.10", features = ["serde"] }
+bytes = { version = "1.11.1", features = ["serde"] }
 criterion = { version = "0.5.1", features = ["async_tokio", "csv_output"] }
 itertools = "0.14.0"
 maplit = "1.0"

--- a/monarch_hyperactor/Cargo.toml
+++ b/monarch_hyperactor/Cargo.toml
@@ -20,7 +20,7 @@ anyhow = "1.0.98"
 async-once-cell = "0.4.2"
 async-trait = "0.1.86"
 bincode = "1.3.3"
-bytes = { version = "1.10", features = ["serde"] }
+bytes = { version = "1.11.1", features = ["serde"] }
 clap = { version = "4.5.42", features = ["derive", "env", "string", "unicode", "wrap_help"] }
 erased-serde = "0.4.9"
 fastrand = "2.1.1"

--- a/serde_multipart/Cargo.toml
+++ b/serde_multipart/Cargo.toml
@@ -11,7 +11,7 @@ license = "BSD-3-Clause"
 
 [dependencies]
 bincode = "1.3.3"
-bytes = { version = "1.10", features = ["serde"] }
+bytes = { version = "1.11.1", features = ["serde"] }
 serde = { version = "1.0.219", features = ["derive", "rc"] }
 
 [dev-dependencies]

--- a/typeuri/Cargo.toml
+++ b/typeuri/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/meta-pytorch/monarch/"
 license = "BSD-3-Clause"
 
 [dependencies]
-bytes = { version = "1.10", features = ["serde"] }
+bytes = { version = "1.11.1", features = ["serde"] }
 cityhasher = "0.1.0"
 dashmap = { version = "5.5.3", features = ["rayon", "serde"] }
 typeuri_macros = { version = "0.0.0", path = "../typeuri_macros" }

--- a/wirevalue/Cargo.toml
+++ b/wirevalue/Cargo.toml
@@ -12,7 +12,7 @@ license = "BSD-3-Clause"
 [dependencies]
 anyhow = "1.0.98"
 bincode = "1.3.3"
-bytes = { version = "1.10", features = ["serde"] }
+bytes = { version = "1.11.1", features = ["serde"] }
 crc32fast = "1.4"
 enum-as-inner = "0.6.0"
 erased-serde = "0.4.9"


### PR DESCRIPTION
Summary: Integer overflow in `BytesMut::reserve`

Reviewed By: dtolnay

Differential Revision: D92286167
