### PR TITLE
Promote user py spans to INFO

### DIFF
--- a/monarch_hyperactor/src/telemetry.rs
+++ b/monarch_hyperactor/src/telemetry.rs
@@ -233,13 +233,13 @@ impl PySpan {
     fn new(name: &str, actor_id: Option<&str>) -> Self {
         let span = if let Some(actor_id) = actor_id {
             tracing::span!(
-                tracing::Level::DEBUG,
+                tracing::Level::INFO,
                 "python.span",
                 name = name,
                 actor_id = actor_id
             )
         } else {
-            tracing::span!(tracing::Level::DEBUG, "python.span", name = name)
+            tracing::span!(tracing::Level::INFO, "python.span", name = name)
         };
         let entered_span = span.entered();
 


### PR DESCRIPTION
Summary: We want to be able to see these at INFO since this is used to instrument the user defined endpoint

Differential Revision: D92308232


