### PR TITLE
Demote non-essential spans to DEBUG

### DIFF
--- a/hyperactor/src/channel.rs
+++ b/hyperactor/src/channel.rs
@@ -126,7 +126,7 @@ pub trait Tx<M: RemoteMessage> {
     /// message is either delivered, or we eventually discover that
     /// the channel has failed and it will be sent back on `return_channel`.
     #[allow(clippy::result_large_err)] // TODO: Consider reducing the size of `SendError`.
-    #[hyperactor::instrument_infallible]
+    #[tracing::instrument(level = "debug", skip_all)]
     fn try_post(&self, message: M, return_channel: oneshot::Sender<SendError<M>>) {
         self.do_post(message, Some(return_channel));
     }
@@ -974,7 +974,7 @@ enum ChannelRxKind<M: RemoteMessage> {
 
 #[async_trait]
 impl<M: RemoteMessage> Rx<M> for ChannelRx<M> {
-    #[hyperactor::instrument]
+    #[tracing::instrument(level = "debug", skip_all)]
     async fn recv(&mut self) -> Result<M, ChannelError> {
         match &mut self.inner {
             ChannelRxKind::Local(rx) => rx.recv().await,

--- a/hyperactor/src/channel/net/client.rs
+++ b/hyperactor/src/channel/net/client.rs
@@ -595,13 +595,21 @@ async fn run<M: RemoteMessage>(
     let dest = link.dest();
     let mut state = State::init(&log_id, &dest, session_id);
     let mut conn = Conn::reconnect_with_default();
-
+    let write_bytes_span = tracing::debug_span!("write bytes");
     let (state, conn) = loop {
         let span = state_span(&state, &conn, session_id, &link);
 
-        (state, conn) = step(state, conn, session_id, &log_id, &link, &mut receiver)
-            .instrument(span)
-            .await;
+        (state, conn) = step(
+            state,
+            conn,
+            session_id,
+            &log_id,
+            &link,
+            &mut receiver,
+            write_bytes_span.clone(),
+        )
+        .instrument(span)
+        .await;
 
         if state.is_closing() {
             break (state, conn);
@@ -835,6 +843,7 @@ async fn step<'a, L, S, M>(
     log_id: &'a str,
     link: &L,
     receiver: &mut mpsc::UnboundedReceiver<(M, oneshot::Sender<SendError<M>>, Instant)>,
+    write_bytes_span: tracing::Span,
 ) -> (State<'a, M>, Conn<S>)
 where
     S: Stream,
@@ -957,7 +966,7 @@ where
             tokio::select! {
                 biased;
 
-                ack_result = reader.next().instrument(hyperactor_telemetry::context_span!("read ack")) => {
+                ack_result = reader.next() => {
                     match ack_result {
                         Ok(Some(buffer)) => {
                             match deserialize_response(buffer) {
@@ -1049,7 +1058,7 @@ where
 
                 // We have to be careful to manage outgoing write states, so that we never write
                 // partial frames in the presence cancellation.
-                send_result = write_state.send().instrument(hyperactor_telemetry::context_span!("write bytes")) => {
+                send_result = write_state.send().instrument(write_bytes_span) => {
                     match send_result {
                         Ok(()) => {
                             let mut message = outbox.pop_front().expect("outbox should not be empty");

--- a/hyperactor/src/mailbox.rs
+++ b/hyperactor/src/mailbox.rs
@@ -107,7 +107,7 @@ use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 use typeuri::Named;
 
-use crate as hyperactor; // for macros
+// for macros
 use crate::OncePortRef;
 use crate::PortRef;
 use crate::Proc;
@@ -126,7 +126,6 @@ use crate::context;
 use crate::id;
 use crate::metrics;
 use crate::ordering::SEQ_INFO;
-use crate::ordering::SeqInfo;
 use crate::reference::ActorId;
 use crate::reference::PortId;
 use crate::reference::Reference;
@@ -1178,7 +1177,7 @@ impl MailboxClient {
 }
 
 impl MailboxSender for MailboxClient {
-    #[hyperactor::instrument_infallible]
+    #[tracing::instrument(level = "debug", skip_all)]
     fn post_unchecked(
         &self,
         envelope: MessageEnvelope,

--- a/hyperactor/src/proc.rs
+++ b/hyperactor/src/proc.rs
@@ -1620,7 +1620,7 @@ impl<A: Actor> Instance<A> {
         }
     }
 
-    #[hyperactor::instrument(fields(actor_id = self.self_id().to_string(), actor_name = self.self_id().name()))]
+    #[tracing::instrument(level = "debug", skip_all)]
     async unsafe fn handle_message<M: Message>(
         &self,
         actor: &mut A,

--- a/hyperactor_mesh/src/actor_mesh.rs
+++ b/hyperactor_mesh/src/actor_mesh.rs
@@ -121,7 +121,7 @@ pub fn update_undeliverable_envelope_for_casting(
 /// Common implementation for `ActorMesh`s and `ActorMeshRef`s to cast
 /// an `M`-typed message
 #[allow(clippy::result_large_err)] // TODO: Consider reducing the size of `CastError`.
-#[hyperactor::instrument]
+#[tracing::instrument(level = "debug", skip_all)]
 pub(crate) fn actor_mesh_cast<A, M>(
     cx: &impl context::Actor,
     actor_mesh_id: ActorMeshId,

--- a/hyperactor_mesh/src/comm.rs
+++ b/hyperactor_mesh/src/comm.rs
@@ -393,7 +393,7 @@ impl Handler<CommMeshConfig> for CommActor {
 // TODO(T218630526): reliable casting for mutable topology
 #[async_trait]
 impl Handler<CastMessage> for CommActor {
-    #[hyperactor::instrument]
+    #[tracing::instrument(level = "debug", skip_all)]
     async fn handle(&mut self, cx: &Context<Self>, cast_message: CastMessage) -> Result<()> {
         // Always forward the message to the root rank of the slice, casting starts from there.
         let slice = cast_message.dest.slice.clone();
@@ -433,7 +433,7 @@ impl Handler<CastMessage> for CommActor {
 
 #[async_trait]
 impl Handler<ForwardMessage> for CommActor {
-    #[hyperactor::instrument]
+    #[tracing::instrument(level = "debug", skip_all)]
     async fn handle(&mut self, cx: &Context<Self>, fwd_message: ForwardMessage) -> Result<()> {
         let ForwardMessage {
             sender,

--- a/monarch_hyperactor/src/actor_mesh.rs
+++ b/monarch_hyperactor/src/actor_mesh.rs
@@ -149,7 +149,7 @@ pub(crate) fn to_hy_sel(selection: &str) -> PyResult<Selection> {
 
 #[pymethods]
 impl PythonActorMesh {
-    #[hyperactor::instrument]
+    #[tracing::instrument(level = "debug", skip_all)]
     pub(crate) fn cast(
         &self,
         message: &PythonMessage,


### PR DESCRIPTION
Summary:
Almost all the telemetry overhead comes from spans. We will take an aggressive approach where we demote almost every single system (not related to user endpoints) span on the data path to DEBUG and promote the ones where people actually complain about needing.

One span that we will keep is the one corresponding to Proc::spawn_inner, as this one provides context to logs on the active Actor type, Actor Id, and Actor Name. It is cheap and is expected to provide the highest ROI

Differential Revision: D92309593


