### PR TITLE
Migrate asyncio.get_event_loop() to get_running_loop() in monarch

### DIFF
--- a/python/monarch/_src/actor/waker.py
+++ b/python/monarch/_src/actor/waker.py
@@ -30,7 +30,7 @@ class Event(abc.ABC):
             self._event = asyncio.Event()
         assert self._event is not None
 
-        event_loop = asyncio.get_event_loop()
+        event_loop = asyncio.get_running_loop()
         if self._event_loop is None:
             self._event_loop = event_loop
 

--- a/python/monarch/worker/worker.py
+++ b/python/monarch/worker/worker.py
@@ -1060,7 +1060,7 @@ class Worker:
     async def worker_loop(self):
         monitor = Monitor()
         monitor.start()
-        self.loop = asyncio.get_event_loop()
+        self.loop = asyncio.get_running_loop()
         debugq = deque()
         while True:
             try:


### PR DESCRIPTION
Summary:
Automated codemod to replace deprecated asyncio.get_event_loop() with
asyncio.get_running_loop() inside async functions.

Reviewed By: drinkmorewaterr

Differential Revision: D92191927


