### PR TITLE
Gate fbcode-only test helpers with cfg(fbcode_build)

### DIFF
--- a/hyperactor_mesh/src/v1/host_mesh.rs
+++ b/hyperactor_mesh/src/v1/host_mesh.rs
@@ -1407,6 +1407,7 @@ mod tests {
         );
     }
 
+    #[cfg(fbcode_build)]
     async fn execute_allocate(config: &hyperactor_config::global::ConfigLock) {
         let poll = Duration::from_secs(3);
         let get_actor = Duration::from_mins(1);
@@ -1533,6 +1534,7 @@ mod tests {
     }
 
     #[async_timed_test(timeout_secs = 180)]
+    #[cfg(fbcode_build)]
     async fn test_allocate_v1() {
         let config = hyperactor_config::global::lock();
         let _guard = config.override_key(ENABLE_NATIVE_V1_CASTING, true);
@@ -1550,6 +1552,7 @@ mod tests {
         ChannelAddr::Tcp(listener.local_addr().unwrap())
     }
 
+    #[cfg(fbcode_build)]
     async fn execute_extrinsic_allocation(config: &hyperactor_config::global::ConfigLock) {
         let _guard = config.override_key(crate::bootstrap::MESH_BOOTSTRAP_ENABLE_PDEATHSIG, false);
 

--- a/hyperactor_mesh/src/v1/proc_mesh.rs
+++ b/hyperactor_mesh/src/v1/proc_mesh.rs
@@ -1318,6 +1318,7 @@ mod tests {
         );
     }
 
+    #[cfg(fbcode_build)]
     async fn execute_spawn_actor() {
         hyperactor_telemetry::initialize_logging(hyperactor::clock::ClockKind::default());
 


### PR DESCRIPTION
Summary:
Fix GitHub build errors by adding `#[cfg(fbcode_build)]` gates to test helper
functions that depend on fbcode-only code.

The `execute_allocate`, `execute_spawn_actor`, and `execute_extrinsic_allocation`
helper functions use `testing::allocs`, `testing::proc_meshes`, and
`testresource::get` respectively, all of which are gated with `#[cfg(fbcode_build)]`.
Without gating the helper functions themselves, the GitHub (non-fbcode) build
fails with "cannot find function" errors.

Also adds the missing `#[cfg(fbcode_build)]` to `test_allocate_v1` which was
inconsistent with `test_allocate`.

Differential Revision: D92417174


