### PR TITLE
Add latest tag docker image

### DIFF
--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -77,5 +77,7 @@ jobs:
           context: . # Build context is the root directory
           file: ./Dockerfile
           push: true # Push the image to the registry
-          tags: ghcr.io/${{ github.repository }}:${{ github.event.inputs.version }}-cuda12.8
+          tags: |
+            ghcr.io/${{ github.repository }}:${{ github.event.inputs.version }}-cuda12.8
+            ghcr.io/${{ github.repository }}:latest
           build-args: PYTORCH_TAG=2.10.0-cuda12.8-cudnn9-runtime

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -103,7 +103,9 @@ jobs:
           file: ./Dockerfile.nightly
           push: true # Push the image to the registry
           # Push to monarch-nightly package instead of monarch.
-          tags: ghcr.io/${{ github.repository }}-nightly:${{ env.DOCKER_TAG }}
+          tags: |
+            ghcr.io/${{ github.repository }}-nightly:${{ env.DOCKER_TAG }}
+            ghcr.io/${{ github.repository }}-nightly:latest
           # TODO: find docker tag that gets updated automatically.
           build-args: |
             PYTORCH_TAG=2.11.0.dev20260109-cuda12.8-cudnn9-runtime


### PR DESCRIPTION
Summary: This is useful for examples where we just let users run the latest tag.

Differential Revision: D92425082


