### PR TITLE
[monarch] Refactor pickling to use thread-local Rust storage

### DIFF
--- a/monarch_extension/src/lib.rs
+++ b/monarch_extension/src/lib.rs
@@ -141,6 +141,11 @@ pub fn mod_init(module: &Bound<'_, PyModule>) -> PyResult<()> {
         "monarch_hyperactor.actor",
     )?)?;
 
+    monarch_hyperactor::pickle::register_python_bindings(&get_or_add_new_module(
+        module,
+        "monarch_hyperactor.pickle",
+    )?)?;
+
     monarch_hyperactor::pytokio::register_python_bindings(&get_or_add_new_module(
         module,
         "monarch_hyperactor.pytokio",

--- a/monarch_extension/src/mesh_controller.rs
+++ b/monarch_extension/src/mesh_controller.rs
@@ -42,11 +42,11 @@ use hyperactor_mesh::v1::actor_mesh::ActorMesh;
 use hyperactor_mesh::v1::proc_mesh::ProcMeshRef;
 use monarch_hyperactor::actor::PythonMessage;
 use monarch_hyperactor::actor::PythonMessageKind;
-use monarch_hyperactor::buffers::Buffer;
 use monarch_hyperactor::context::PyInstance;
 use monarch_hyperactor::local_state_broker::LocalStateBrokerActor;
 use monarch_hyperactor::mailbox::PyPortId;
 use monarch_hyperactor::ndslice::PySlice;
+use monarch_hyperactor::pickle::pickle;
 use monarch_hyperactor::proc_mesh::PyProcMesh;
 use monarch_hyperactor::runtime::signal_safe_block_on;
 use monarch_messages::controller::ControllerActor;
@@ -563,19 +563,14 @@ impl History {
                     .unwrap()
                     .getattr("RemoteException")
                     .unwrap();
-                let pickle = py
-                    .import("monarch._src.actor.actor_mesh")
-                    .unwrap()
-                    .getattr("_pickle")
-                    .unwrap();
                 let exe = remote_exception
                     .call1((exception.backtrace, traceback, rank))
                     .unwrap();
-                let mut data: Buffer = pickle.call1((exe,)).unwrap().extract().unwrap();
+                let mut state = pickle(py, exe.unbind(), false, false).unwrap();
+                let inner = state.take_inner().unwrap();
                 PythonMessage::new_from_buf(
                     PythonMessageKind::Exception { rank: Some(rank) },
-                    data.take_part(),
-                    None,
+                    inner.take_buffer(),
                 )
             })
             .await,
@@ -623,7 +618,6 @@ impl History {
                         PythonMessage::new_from_buf(
                             PythonMessageKind::Result { rank: None },
                             b"\x80\x04N.".to_vec(),
-                            None,
                         )
                     }
                 };

--- a/monarch_hyperactor/src/lib.rs
+++ b/monarch_hyperactor/src/lib.rs
@@ -27,6 +27,7 @@ pub mod mailbox;
 pub mod metrics;
 pub mod namespace;
 pub mod ndslice;
+pub mod pickle;
 pub mod proc;
 pub mod proc_launcher_probe;
 pub mod proc_mesh;

--- a/monarch_hyperactor/src/mailbox.rs
+++ b/monarch_hyperactor/src/mailbox.rs
@@ -258,8 +258,6 @@ impl PythonPortHandle {
 #[pymethods]
 impl PythonPortHandle {
     fn send(&self, instance: &PyInstance, message: PythonMessage) -> PyResult<()> {
-        let message = resolve_pending_pickle_blocking(message)?;
-
         self.inner
             .send(instance.deref(), message)
             .map_err(|err| PyErr::new::<PyEOFError, _>(format!("Port closed: {}", err)))?;
@@ -298,8 +296,6 @@ impl PythonPortRef {
     }
 
     fn send(&self, instance: &PyInstance, message: PythonMessage) -> PyResult<()> {
-        let message = resolve_pending_pickle_blocking(message)?;
-
         self.inner
             .send(instance.deref(), message)
             .map_err(|err| PyErr::new::<PyEOFError, _>(format!("Port closed: {}", err)))?;
@@ -439,9 +435,6 @@ impl PythonOncePortHandle {
         let Some(port) = self.inner.take() else {
             return Err(PyErr::new::<PyValueError, _>("OncePort is already used"));
         };
-
-        let message = resolve_pending_pickle_blocking(message)?;
-
         port.send(instance.deref(), message)
             .map_err(|err| PyErr::new::<PyEOFError, _>(format!("Port closed: {}", err)))?;
         Ok(())
@@ -488,9 +481,6 @@ impl PythonOncePortRef {
         let Some(port_ref) = self.inner.take() else {
             return Err(PyErr::new::<PyValueError, _>("OncePortRef is already used"));
         };
-
-        let message = resolve_pending_pickle_blocking(message)?;
-
         port_ref
             .send(instance.deref(), message)
             .map_err(|err| PyErr::new::<PyEOFError, _>(format!("Port closed: {}", err)))?;
@@ -688,24 +678,6 @@ inventory::submit! {
 }
 
 py_global!(point, "monarch._src.actor.actor_mesh", "Point");
-
-fn resolve_pending_pickle_blocking(mut message: PythonMessage) -> PyResult<PythonMessage> {
-    // TODO(slurye): Cleanly handle PendingPickle objects sent directly over ports. This is new
-    // code but it isn't a regression -- PendingPickle objects are only created for objects that,
-    // in earlier commits, either (a) already had to be awaited explicitly in the tokio runtime
-    // before pickling, or (b) already had to be explicitly blocked on outside the tokio runtime
-    // before pickling. Any use case that worked before should still work now.
-    if let Some(pending_pickle_state) = message.pending_pickle_state.take() {
-        message.message = Python::with_gil(|py| {
-            signal_safe_block_on(
-                py,
-                pending_pickle_state.resolve(message.message.into_bytes()),
-            )
-        })??;
-    }
-
-    Ok(message)
-}
 
 pub fn register_python_bindings(hyperactor_mod: &Bound<'_, PyModule>) -> PyResult<()> {
     hyperactor_mod.add_class::<PyMailbox>()?;

--- a/monarch_hyperactor/src/pickle.rs
+++ b/monarch_hyperactor/src/pickle.rs
@@ -1,0 +1,528 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+//! Deferred pickling support for Monarch.
+//!
+//! This module provides utilities for deferring the pickling of objects
+//! that contain async values (futures/tasks) that must be resolved before
+//! the final pickle can be produced.
+
+use std::cell::RefCell;
+use std::collections::VecDeque;
+
+use monarch_types::py_global;
+use pyo3::prelude::*;
+use pyo3::types::PyList;
+use pyo3::types::PyTuple;
+
+use crate::actor::PythonMessage;
+use crate::actor::PythonMessageKind;
+use crate::buffers::Buffer;
+use crate::pytokio::PyShared;
+
+// Python helper used to reconstruct an object graph from a pickled
+// buffer plus a list of "unflatten values" (including placeholders).
+py_global!(unflatten, "monarch._src.actor.pickle", "unflatten");
+
+// Python helper used to pickle an object graph, optionally using a
+// filter to replace certain values with placeholders (e.g.
+// `PendingPickle`).
+//
+// We use `flatten`/`unflatten` to support "deferred pickling":
+// initially pickle with placeholders, then later resolve futures and
+// re-pickle with concrete values.
+py_global!(flatten, "monarch._src.actor.pickle", "flatten");
+
+// cloudpickle module for serialization
+py_global!(cloudpickle, "cloudpickle", "cloudpickle");
+
+// Shared class for pickling PyShared values
+py_global!(
+    shared_class,
+    "monarch._rust_bindings.monarch_hyperactor.pytokio",
+    "Shared"
+);
+
+// pop_pending_pickle function for unpickling deferred PyShared values
+py_global!(
+    pop_pending_pickle_fn,
+    "monarch._rust_bindings.monarch_hyperactor.pickle",
+    "pop_pending_pickle"
+);
+
+// Thread-local storage for the active pickling state.
+// Set by pickle/unpickle operations so free functions used in __reduce__
+// implementations can access it.
+thread_local! {
+    static ACTIVE_PICKLING_STATE: RefCell<Option<ActivePicklingState>> = const { RefCell::new(None) };
+}
+
+/// State maintained during active pickling/unpickling operations.
+///
+/// This is the thread-local state used while cloudpickle is running.
+/// It collects tensor engine references and pending pickles during serialization.
+struct ActivePicklingState {
+    /// References to tensor engine objects that need special handling.
+    tensor_engine_references: VecDeque<PyObject>,
+    /// Pending pickles (PyShared values) that must be resolved.
+    pending_pickles: VecDeque<Py<PyShared>>,
+    /// Whether pending pickles are allowed in this pickling context.
+    allow_pending_pickles: bool,
+    /// Whether tensor engine references are allowed in this pickling context.
+    allow_tensor_engine_references: bool,
+}
+
+impl ActivePicklingState {
+    /// Create a new ActivePicklingState.
+    fn new(allow_pending_pickles: bool, allow_tensor_engine_references: bool) -> Self {
+        Self {
+            tensor_engine_references: VecDeque::new(),
+            pending_pickles: VecDeque::new(),
+            allow_pending_pickles,
+            allow_tensor_engine_references,
+        }
+    }
+
+    /// Convert this active state into a frozen PicklingState.
+    fn into_pickling_state(self, buffer: crate::buffers::FrozenBuffer) -> PicklingStateInner {
+        PicklingStateInner {
+            buffer,
+            tensor_engine_references: self.tensor_engine_references,
+            pending_pickles: self.pending_pickles,
+        }
+    }
+}
+
+/// Inner data for a completed pickling operation.
+///
+/// This contains the frozen pickled bytes and any collected references.
+/// Does not require GIL for access to the FrozenBuffer.
+pub struct PicklingStateInner {
+    /// The pickled bytes as a FrozenBuffer (zero-copy).
+    buffer: crate::buffers::FrozenBuffer,
+    /// References to tensor engine objects that need special handling.
+    tensor_engine_references: VecDeque<PyObject>,
+    /// Pending pickles (PyShared values) that must be resolved.
+    pending_pickles: VecDeque<Py<PyShared>>,
+}
+
+impl PicklingStateInner {
+    /// Get a reference to the pending pickles.
+    pub fn pending_pickles(&self) -> &VecDeque<Py<PyShared>> {
+        &self.pending_pickles
+    }
+
+    /// Take the FrozenBuffer (pickled bytes) from this inner state.
+    pub fn take_buffer(self) -> crate::buffers::FrozenBuffer {
+        self.buffer
+    }
+}
+
+/// Python-visible wrapper for the result of a pickling operation.
+///
+/// Contains the pickled bytes and any tensor engine references or pending
+/// pickles that were collected during serialization.
+#[pyclass(module = "monarch._rust_bindings.monarch_hyperactor.pickle")]
+pub struct PicklingState {
+    inner: Option<PicklingStateInner>,
+}
+
+impl PicklingState {
+    pub fn take_inner(&mut self) -> PyResult<PicklingStateInner> {
+        self.inner.take().ok_or_else(|| {
+            pyo3::exceptions::PyRuntimeError::new_err("PicklingState has already been consumed")
+        })
+    }
+
+    fn inner_ref(&self) -> PyResult<&PicklingStateInner> {
+        self.inner.as_ref().ok_or_else(|| {
+            pyo3::exceptions::PyRuntimeError::new_err("PicklingState has already been consumed")
+        })
+    }
+}
+
+#[pymethods]
+impl PicklingState {
+    /// Create a new PicklingState from a buffer and optional tensor engine references.
+    ///
+    /// This is used for unpickling received messages that may contain tensor engine
+    /// references that need to be restored during deserialization.
+    #[new]
+    #[pyo3(signature = (buffer, tensor_engine_references=None))]
+    fn py_new(
+        buffer: PyRef<'_, crate::buffers::FrozenBuffer>,
+        tensor_engine_references: Option<&Bound<'_, PyList>>,
+    ) -> PyResult<Self> {
+        let refs: VecDeque<PyObject> = tensor_engine_references
+            .map(|list| list.iter().map(|item| item.unbind()).collect())
+            .unwrap_or_default();
+
+        Ok(Self {
+            inner: Some(PicklingStateInner {
+                buffer: buffer.clone(),
+                tensor_engine_references: refs,
+                pending_pickles: VecDeque::new(),
+            }),
+        })
+    }
+
+    /// Get a copy of all tensor engine references from this pickling state.
+    ///
+    /// Returns a Python list containing copies of the tensor engine references.
+    fn tensor_engine_references(&self, py: Python<'_>) -> PyResult<Py<PyList>> {
+        let inner = self.inner_ref()?;
+        let refs: Vec<PyObject> = inner
+            .tensor_engine_references
+            .iter()
+            .map(|r| r.clone_ref(py))
+            .collect();
+        Ok(PyList::new(py, refs)?.unbind())
+    }
+
+    /// Get the buffer from this pickling state.
+    ///
+    /// Returns a FrozenBuffer containing the pickled bytes.
+    /// This does not consume the PicklingState.
+    fn buffer(&self) -> PyResult<crate::buffers::FrozenBuffer> {
+        let inner = self.inner_ref()?;
+        Ok(inner.buffer.clone())
+    }
+
+    /// Unpickle the buffer contents.
+    ///
+    /// This consumes the PicklingState. It will fail if there are any pending
+    /// pickles that haven't been resolved.
+    fn unpickle(&mut self, py: Python<'_>) -> PyResult<PyObject> {
+        let inner = self.take_inner()?;
+
+        // Verify all pending pickles are resolved before unpickling
+        for pending in &inner.pending_pickles {
+            if pending.borrow(py).poll()?.is_none() {
+                return Err(pyo3::exceptions::PyRuntimeError::new_err(
+                    "Cannot unpickle: there are unresolved pending pickles",
+                ));
+            }
+        }
+
+        // Set up an active state for unpickling (to handle pop calls)
+        let mut active = ActivePicklingState::new(false, false);
+        active.pending_pickles = inner.pending_pickles;
+        active.tensor_engine_references = inner.tensor_engine_references;
+
+        ACTIVE_PICKLING_STATE.with(|cell| {
+            *cell.borrow_mut() = Some(active);
+        });
+
+        // Unpickle the object
+        let result = cloudpickle(py).getattr("loads")?.call1((inner.buffer,));
+
+        // Clear the active state
+        ACTIVE_PICKLING_STATE.with(|cell| {
+            *cell.borrow_mut() = None;
+        });
+
+        result.map(|obj| obj.unbind())
+    }
+}
+
+impl PicklingState {
+    /// Resolve all pending pickles and return a new PicklingState without pending pickles.
+    ///
+    /// This consumes the PicklingState. It:
+    /// 1. If there are no pending pickles, returns self immediately
+    /// 2. Otherwise, awaits all pending pickles until they're finished
+    /// 3. Calls unpickle to reconstruct the object
+    /// 4. Calls pickle again to get a new PicklingState without pending pickles
+    pub async fn resolve(mut self) -> PyResult<PicklingState> {
+        // Short-circuit if there are no pending pickles
+        if self.inner_ref()?.pending_pickles.is_empty() {
+            return Ok(self);
+        }
+
+        // Await all pending pickles to ensure they're resolved
+        let pending: Vec<Py<PyShared>> = Python::with_gil(|py| {
+            self.inner_ref().map(|inner| {
+                inner
+                    .pending_pickles
+                    .iter()
+                    .map(|p| p.clone_ref(py))
+                    .collect()
+            })
+        })?;
+
+        for pending_pickle in pending {
+            let mut task = Python::with_gil(|py| pending_pickle.borrow(py).task())?;
+            task.take_task()?.await?;
+        }
+
+        // Unpickle (pending pickles are now resolved) and re-pickle without allowing new ones
+        Python::with_gil(|py| {
+            let obj = self.unpickle(py)?;
+            pickle(py, obj, false, true)
+        })
+    }
+}
+
+/// A message that is pending resolution of async values before it can be sent.
+///
+/// Contains a `PythonMessageKind` and a `PicklingState`. The `PicklingState` may contain
+/// pending pickles (unresolved async values) that must be resolved before the message
+/// can be converted into a `PythonMessage`.
+#[pyclass(module = "monarch._rust_bindings.monarch_hyperactor.pickle")]
+pub struct PendingMessage {
+    kind: PythonMessageKind,
+    state: PicklingState,
+}
+
+impl PendingMessage {
+    /// Create a new PendingMessage from a kind and pickling state.
+    pub fn new(kind: PythonMessageKind, state: PicklingState) -> Self {
+        Self { kind, state }
+    }
+
+    /// Take ownership of the inner state from a mutable reference.
+    ///
+    /// This is used by pyo3 pymethods that receive `&mut PendingMessage`
+    /// but need to pass ownership to the trait method.
+    pub fn take(&mut self) -> PyResult<PendingMessage> {
+        let inner = self.state.take_inner()?;
+        Ok(PendingMessage {
+            kind: std::mem::take(&mut self.kind),
+            state: PicklingState { inner: Some(inner) },
+        })
+    }
+
+    /// Resolve all pending pickles and convert this into a PythonMessage.
+    ///
+    /// This is an async method that:
+    /// 1. Awaits all pending pickles in the PicklingState
+    /// 2. Re-pickles the resolved object
+    /// 3. Returns a PythonMessage with the resolved bytes (no GIL needed for final step)
+    pub async fn resolve(self) -> PyResult<PythonMessage> {
+        // Resolve the pickling state (awaits all pending pickles and re-pickles)
+        let mut resolved_state = self.state.resolve().await?;
+
+        // Take the FrozenBuffer directly - no GIL needed since FrozenBuffer doesn't contain Py<>
+        let inner = resolved_state.take_inner()?;
+        Ok(PythonMessage::new_from_buf(self.kind, inner.take_buffer()))
+    }
+}
+
+#[pymethods]
+impl PendingMessage {
+    /// Create a new PendingMessage from a kind and pickling state.
+    #[new]
+    fn py_new(kind: PythonMessageKind, mut state: PyRefMut<'_, PicklingState>) -> PyResult<Self> {
+        // Take the inner state from the PicklingState
+        let inner = state.take_inner()?;
+        Ok(Self {
+            kind,
+            state: PicklingState { inner: Some(inner) },
+        })
+    }
+
+    /// Get the message kind.
+    #[getter]
+    fn kind(&self) -> PythonMessageKind {
+        self.kind.clone()
+    }
+}
+
+/// Push a tensor engine reference to the active pickling state if one is active.
+///
+/// This is called from Python during pickling when a tensor engine object
+/// is encountered that needs special handling.
+///
+/// Returns False if there is no active pickling state.
+/// Returns True if the reference was successfully pushed.
+/// Raises an error if tensor engine references are not allowed in the current pickling context.
+#[pyfunction]
+fn push_tensor_engine_reference_if_active(obj: PyObject) -> PyResult<bool> {
+    ACTIVE_PICKLING_STATE.with(|cell| {
+        let mut state = cell.borrow_mut();
+        match state.as_mut() {
+            Some(s) => {
+                if !s.allow_tensor_engine_references {
+                    return Err(pyo3::exceptions::PyRuntimeError::new_err(
+                        "Tensor engine references are not allowed in the current pickling context",
+                    ));
+                }
+                s.tensor_engine_references.push_back(obj);
+                Ok(true)
+            }
+            None => Ok(false),
+        }
+    })
+}
+
+/// Pop a tensor engine reference from the active pickling state.
+///
+/// This is called from Python during unpickling to retrieve tensor engine
+/// objects in the order they were pushed.
+#[pyfunction]
+fn pop_tensor_engine_reference(py: Python<'_>) -> PyResult<PyObject> {
+    ACTIVE_PICKLING_STATE
+        .with(|cell| {
+            let mut state = cell.borrow_mut();
+            match state.as_mut() {
+                Some(s) => s.tensor_engine_references.pop_front().ok_or_else(|| {
+                    pyo3::exceptions::PyRuntimeError::new_err(
+                        "No tensor engine references remaining",
+                    )
+                }),
+                None => Err(pyo3::exceptions::PyRuntimeError::new_err(
+                    "No active pickling state",
+                )),
+            }
+        })
+        .map(|obj| obj.clone_ref(py))
+}
+
+/// Pop a pending pickle from the active pickling state.
+///
+/// This is called from Python during unpickling to retrieve the PyShared
+/// object that was deferred during pickling.
+#[pyfunction]
+fn pop_pending_pickle(py: Python<'_>) -> PyResult<Py<PyShared>> {
+    ACTIVE_PICKLING_STATE.with(|cell| {
+        let mut state = cell.borrow_mut();
+        match state.as_mut() {
+            Some(s) => {
+                let shared = s.pending_pickles.pop_front().ok_or_else(|| {
+                    pyo3::exceptions::PyRuntimeError::new_err("No pending pickles remaining")
+                })?;
+                Ok(shared.clone_ref(py))
+            }
+            None => Err(pyo3::exceptions::PyRuntimeError::new_err(
+                "No active pickling state",
+            )),
+        }
+    })
+}
+
+/// Push a pending pickle to the active pickling state (Rust-only).
+///
+/// This is used by __reduce__ implementations to register a PyShared
+/// that must be resolved before the pickle is complete.
+///
+/// Returns an error if there is no active pickling state or if pending
+/// pickles are not allowed in the current pickling context.
+pub fn push_pending_pickle(py_shared: Py<PyShared>) -> PyResult<()> {
+    ACTIVE_PICKLING_STATE.with(|cell| {
+        let mut state = cell.borrow_mut();
+        match state.as_mut() {
+            Some(s) => {
+                if !s.allow_pending_pickles {
+                    return Err(pyo3::exceptions::PyRuntimeError::new_err(
+                        "Pending pickles are not allowed in the current pickling context",
+                    ));
+                }
+                s.pending_pickles.push_back(py_shared);
+                Ok(())
+            }
+            None => Err(pyo3::exceptions::PyRuntimeError::new_err(
+                "No active pickling state",
+            )),
+        }
+    })
+}
+
+/// Reduce a PyShared for pickling.
+///
+/// This function implements the pickle protocol for PyShared:
+/// 1. If the shared is already finished, return (Shared.from_value, (value,))
+/// 2. If pending pickles are allowed, push it as a pending pickle and return (pop_pending_pickle, ())
+/// 3. Otherwise, block on the shared and return (Shared.from_value, (value,))
+pub fn reduce_shared<'py>(
+    py: Python<'py>,
+    py_shared: &Bound<'py, PyShared>,
+) -> PyResult<(Bound<'py, PyAny>, Bound<'py, PyTuple>)> {
+    // First, check if the shared is already finished
+    if let Some(value) = py_shared.borrow().poll()? {
+        let from_value = shared_class(py).getattr("from_value")?;
+        let args = PyTuple::new(py, [value])?;
+        return Ok((from_value, args));
+    }
+
+    // Try to push as a pending pickle (will fail if not allowed or no active state)
+    let py_shared_py: Py<PyShared> = py_shared.clone().unbind();
+    if push_pending_pickle(py_shared_py).is_ok() {
+        let pop_fn = pop_pending_pickle_fn(py);
+        let args = PyTuple::empty(py);
+        return Ok((pop_fn, args));
+    }
+
+    // Fall back to blocking on the shared
+    let value = PyShared::block_on(py_shared.borrow(), py)?;
+    let from_value = shared_class(py).getattr("from_value")?;
+    let args = PyTuple::new(py, [value])?;
+    Ok((from_value, args))
+}
+
+/// Pickle an object with support for pending pickles and tensor engine references.
+///
+/// This function creates a PicklingState and calls cloudpickle.dumps with
+/// an active thread-local PicklingState, allowing __reduce__ implementations
+/// to push tensor engine references and pending pickles.
+///
+/// # Arguments
+/// * `obj` - The Python object to pickle
+/// * `allow_pending_pickles` - If true, allow PyShared values to be registered as pending
+/// * `allow_tensor_engine_references` - If true, allow tensor engine references to be registered
+///
+/// # Returns
+/// A PicklingState containing the pickled buffer and any registered references/pending pickles
+#[pyfunction]
+#[pyo3(signature = (obj, allow_pending_pickles=true, allow_tensor_engine_references=true))]
+pub fn pickle(
+    py: Python<'_>,
+    obj: PyObject,
+    allow_pending_pickles: bool,
+    allow_tensor_engine_references: bool,
+) -> PyResult<PicklingState> {
+    let active = ActivePicklingState::new(allow_pending_pickles, allow_tensor_engine_references);
+    let buffer = Py::new(py, Buffer::default())?;
+
+    // Set up this state as the active pickling state
+    ACTIVE_PICKLING_STATE.with(|cell| {
+        *cell.borrow_mut() = Some(active);
+    });
+
+    // Get the Pickler class and create an instance with our buffer
+    let pickler = cloudpickle(py)
+        .getattr("Pickler")?
+        .call1((buffer.bind(py),))?;
+
+    // Dump the object
+    let result = pickler.call_method1("dump", (&obj,));
+
+    // Retrieve the state (which may have been modified during pickling)
+    let active = ACTIVE_PICKLING_STATE
+        .with(|cell| cell.borrow_mut().take())
+        .ok_or_else(|| {
+            pyo3::exceptions::PyRuntimeError::new_err("Pickling state was unexpectedly cleared")
+        })?;
+
+    result?;
+
+    // Convert to frozen PicklingState
+    let frozen_buffer = buffer.borrow_mut(py).freeze();
+    let inner = active.into_pickling_state(frozen_buffer);
+    Ok(PicklingState { inner: Some(inner) })
+}
+
+/// Register the pickle Python bindings into the given module.
+pub fn register_python_bindings(module: &Bound<'_, PyModule>) -> PyResult<()> {
+    module.add_class::<PicklingState>()?;
+    module.add_class::<PendingMessage>()?;
+    module.add_function(wrap_pyfunction!(pickle, module)?)?;
+    module.add_function(wrap_pyfunction!(push_tensor_engine_reference_if_active, module)?)?;
+    module.add_function(wrap_pyfunction!(pop_tensor_engine_reference, module)?)?;
+    module.add_function(wrap_pyfunction!(pop_pending_pickle, module)?)?;
+    Ok(())
+}

--- a/monarch_hyperactor/src/proc_launcher_probe.rs
+++ b/monarch_hyperactor/src/proc_launcher_probe.rs
@@ -56,10 +56,6 @@ pub struct ProbeReport {
     #[pyo3(get)]
     pub rank: Option<usize>,
 
-    /// Whether the message carried a pending pickle state.
-    #[pyo3(get)]
-    pub pending_pickle_state_present: Option<bool>,
-
     /// Length in bytes of the raw message payload.
     #[pyo3(get)]
     pub payload_len: usize,
@@ -128,7 +124,6 @@ pub(crate) fn probe_exit_port_via_mesh(
             response_port: Some(EitherPortRef::Once(PythonOncePortRef::from(bound_port))),
         },
         message: pickled_args.into(),
-        pending_pickle_state: None,
     };
 
     // Cast to all actors in the mesh (should be just 1 for sliced
@@ -156,7 +151,6 @@ pub(crate) fn probe_exit_port_via_mesh(
             received_type: "PythonMessage".to_string(),
             kind: Some(kind),
             rank,
-            pending_pickle_state_present: Some(msg.pending_pickle_state.is_some()),
             payload_len: payload.len(),
             payload_bytes: payload,
             error: None,

--- a/monarch_hyperactor/src/pytokio.rs
+++ b/monarch_hyperactor/src/pytokio.rs
@@ -98,7 +98,6 @@ use std::error::Error;
 use std::future::Future;
 use std::pin::Pin;
 
-use bytes::Bytes;
 use hyperactor::clock::Clock;
 use hyperactor::clock::RealClock;
 use hyperactor_config::CONFIG;
@@ -118,13 +117,11 @@ use pyo3::types::PyNone;
 use pyo3::types::PyString;
 use pyo3::types::PyTuple;
 use pyo3::types::PyType;
-use serde_multipart::Part;
 use tokio::sync::Mutex;
 use tokio::sync::watch;
 use tokio::task::JoinHandle;
 
-use crate::buffers::Buffer;
-use crate::buffers::FrozenBuffer;
+use crate::pickle::reduce_shared;
 use crate::runtime::get_tokio_runtime;
 use crate::runtime::monarch_with_gil;
 use crate::runtime::monarch_with_gil_blocking;
@@ -843,7 +840,19 @@ impl PyShared {
     /// background task has published its result into the watch
     /// channel, then returns that `PyObject` (or raises the stored
     /// Python exception).
+    ///
+    /// If the value is already available, returns immediately without
+    /// blocking. This is important for cases where `block_on` is called
+    /// from within a tokio runtime (e.g., during unpickling on a worker
+    /// thread) - we can't call `runtime.block_on()` from within a runtime.
     pub fn block_on(slf: PyRef<PyShared>, py: Python<'_>) -> PyResult<PyObject> {
+        // Check if value is already available - return immediately if so.
+        // This avoids calling into the tokio runtime when unnecessary,
+        // which is critical when called from within a tokio worker thread.
+        if let Some(value) = slf.poll()? {
+            return Ok(value);
+        }
+
         let task = slf.task()?.take_task()?;
         // Explicitly drop the reference so that if another thread attempts to borrow
         // this object mutably during signal_safe_block_on, it won't throw an exception.
@@ -895,6 +904,19 @@ impl PyShared {
             traceback: None,
         })
     }
+
+    /// Pickle protocol support for PyShared.
+    ///
+    /// This implements the pickle reduce protocol:
+    /// - If the shared is finished, pickle as (Shared.from_value, (value,))
+    /// - If pending pickles are allowed, defer pickling and return (pop_pending_pickle, ())
+    /// - Otherwise, block on the shared and pickle as (Shared.from_value, (value,))
+    fn __reduce__<'py>(
+        slf: &Bound<'py, Self>,
+        py: Python<'py>,
+    ) -> PyResult<(Bound<'py, PyAny>, Bound<'py, PyTuple>)> {
+        reduce_shared(py, slf)
+    }
 }
 
 /// Return true if the current thread is executing within a Tokio
@@ -907,188 +929,13 @@ fn is_tokio_thread() -> bool {
     tokio::runtime::Handle::try_current().is_ok()
 }
 
-/// Marker wrapper for a `Shared` whose value will be pickled later.
-///
-/// Some message payloads are pickled as part of sending/forwarding,
-/// but certain values cannot be pickled yet because they depend on
-/// async work (represented by a `Shared`). `PendingPickle` marks
-/// those `Shared`s as *allowed* placeholders during an initial
-/// `flatten(...)` pass.
-///
-/// Later, in an async context, we await the underlying `Shared`,
-/// substitute its resolved value, and re-pickle the payload.
-///
-/// A plain `Shared` is *not* generally picklable; only `Shared`s
-/// wrapped in `PendingPickle` participate in this deferred-pickling
-/// protocol.
-#[pyclass(module = "monarch._rust_bindings.monarch_hyperactor.pytokio")]
-#[derive(Clone)]
-pub(crate) struct PendingPickle(Py<PyShared>);
-
-#[pymethods]
-impl PendingPickle {
-    /// Wrap an existing `Shared` as a deferred-pickling placeholder.
-    #[new]
-    pub(crate) fn new(py_shared: Py<PyShared>) -> PyResult<Self> {
-        Ok(Self(py_shared))
-    }
-}
-
-impl PendingPickle {
-    /// Convenience: create a deferred-pickling placeholder from a
-    /// Rust future.
-    ///
-    /// Spawns the future as an abortable background task and wraps
-    /// the resulting `Shared` in `PendingPickle`, making it eligible
-    /// for the deferred pickling flow.
-    pub(crate) fn from_future<F>(f: F) -> PyResult<Self>
-    where
-        F: Future<Output = PyResult<Py<PyAny>>> + Send + 'static,
-    {
-        let py_shared = PyPythonTask::new(f)?.spawn_abortable()?;
-        Ok(Self(Python::with_gil(|py| {
-            Ok::<_, PyErr>(py_shared.into_pyobject(py)?.unbind())
-        })?))
-    }
-
-    /// Await the underlying `Shared` and return its resolved Python
-    /// value.
-    ///
-    /// Used by `PendingPickleState::resolve` to substitute resolved
-    /// values before re-pickling.
-    pub(crate) async fn result(&self) -> PyResult<Py<PyAny>> {
-        let mut task = Python::with_gil(|py| self.0.borrow(py).task())?;
-        task.take_task()?.await
-    }
-}
-
-// Python helper used to reconstruct an object graph from a pickled
-// buffer plus a list of “unflatten values” (including placeholders).
-py_global!(unflatten, "monarch._src.actor.pickle", "unflatten");
-
-// Python helper used to pickle an object graph, optionally using a
-// filter to replace certain values with placeholders (e.g.
-// `PendingPickle`).
-//
-// We use `flatten`/`unflatten` to support “deferred pickling”:
-// initially pickle with placeholders, then later resolve futures and
-// re-pickle with concrete values.
-py_global!(flatten, "monarch._src.actor.pickle", "flatten");
-
-/// State captured during “deferred pickling”.
-///
-/// `flatten(...)` can be called with a Python-side filter that
-/// replaces certain values with placeholders (notably
-/// `PendingPickle`, i.e. a `Shared` that will eventually produce a
-/// Python value). When that happens, `flatten` returns:
-///
-/// - a pickled payload that references an *unflatten list*, and
-/// - the corresponding `unflatten_values` list (some entries may be
-///   placeholders), plus the `flatten_filter` used to produce it.
-///
-/// `PendingPickleState` stores the pieces needed to finish the job
-/// later: resolve the placeholders (by awaiting them) and then re-run
-/// `flatten` so the final pickled payload contains the concrete
-/// values.
-#[pyclass(module = "monarch._rust_bindings.monarch_hyperactor.pytokio")]
-#[derive(Debug, Clone)]
-pub struct PendingPickleState {
-    /// The `unflatten` value list captured from the initial `flatten`
-    /// call. Some entries may be `PendingPickle` placeholders that
-    /// must be resolved.
-    unflatten_values: Vec<Py<PyAny>>,
-
-    /// The filter object originally passed to `flatten`, used when
-    /// re-pickling after placeholders have been resolved.
-    flatten_filter: Py<PyAny>,
-}
-
-#[pymethods]
-impl PendingPickleState {
-    /// Construct a deferred-pickling state object from `flatten`
-    /// outputs.
-    #[new]
-    fn new(unflatten_values: Vec<Py<PyAny>>, flatten_filter: Py<PyAny>) -> Self {
-        Self {
-            unflatten_values,
-            flatten_filter,
-        }
-    }
-}
-
-impl PendingPickleState {
-    /// Finish deferred pickling.
-    ///
-    /// Takes the "pre-pickled" payload produced by the initial
-    /// `flatten` call, awaits any `PendingPickle` placeholders stored
-    /// in `unflatten_values`, then `unflatten`s the object graph and
-    /// `flatten`s it again so the returned payload contains resolved
-    /// values.
-    pub(crate) async fn resolve(self, pickled: impl Into<Bytes>) -> PyResult<Part> {
-        let (idxs, futs): (Vec<_>, Vec<_>) = Python::with_gil(|py| {
-            self.unflatten_values
-                .iter()
-                .enumerate()
-                .filter_map(|(i, py_obj)| {
-                    py_obj.extract::<PendingPickle>(py).map_or(None, |pending| {
-                        Some((i, async move { pending.result().await }))
-                    })
-                })
-                .unzip()
-        });
-
-        // This really shouldn't happen. This `PendingPickleState` object
-        // shouldn't have been created if there are no futures to resolve.
-        if futs.is_empty() {
-            return Ok(Part::from(pickled.into()));
-        }
-
-        let result = futures::future::join_all(futs)
-            .await
-            .into_iter()
-            .collect::<PyResult<Vec<_>>>()?;
-
-        let mut unflatten_values = Vec::with_capacity(self.unflatten_values.len());
-        let mut fut_idx = 0;
-        for i in 0..self.unflatten_values.len() {
-            if idxs.get(fut_idx).is_some_and(|idx| *idx == i) {
-                Python::with_gil(|py| {
-                    unflatten_values.push(result[fut_idx].clone_ref(py));
-                });
-                fut_idx += 1;
-            } else {
-                Python::with_gil(|py| {
-                    unflatten_values.push(self.unflatten_values[i].clone_ref(py));
-                });
-            }
-        }
-
-        Python::with_gil(|py| {
-            let unpickled = unflatten(py).call1((
-                FrozenBuffer {
-                    inner: pickled.into(),
-                },
-                unflatten_values,
-            ))?;
-            let repickled = flatten(py)
-                .call1((unpickled, self.flatten_filter))?
-                .downcast_into::<PyTuple>()?;
-            let buffer = repickled.get_item(1)?.downcast_into::<Buffer>()?;
-            Ok(buffer.borrow_mut().take_part())
-        })
-    }
-}
-
 /// Register the pytokio Python bindings into the given module.
 ///
-/// This wires up the exported pyclasses (`PythonTask`, `Shared`,
-/// deferred pickling helpers) and module-level functions used by the
-/// Monarch Python layer.
+/// This wires up the exported pyclasses (`PythonTask`, `Shared`)
+/// and module-level functions used by the Monarch Python layer.
 pub fn register_python_bindings(hyperactor_mod: &Bound<'_, PyModule>) -> PyResult<()> {
     hyperactor_mod.add_class::<PyPythonTask>()?;
     hyperactor_mod.add_class::<PyShared>()?;
-    hyperactor_mod.add_class::<PendingPickle>()?;
-    hyperactor_mod.add_class::<PendingPickleState>()?;
     let f = wrap_pyfunction!(is_tokio_thread, hyperactor_mod)?;
     f.setattr(
         "__module__",

--- a/monarch_tensor_worker/src/stream.rs
+++ b/monarch_tensor_worker/src/stream.rs
@@ -35,10 +35,10 @@ use hyperactor::mailbox::PortReceiver;
 use hyperactor::proc::Proc;
 use monarch_hyperactor::actor::PythonMessage;
 use monarch_hyperactor::actor::PythonMessageKind;
-use monarch_hyperactor::buffers::Buffer;
 use monarch_hyperactor::local_state_broker::BrokerId;
 use monarch_hyperactor::local_state_broker::LocalState;
 use monarch_hyperactor::local_state_broker::LocalStateBrokerMessage;
+use monarch_hyperactor::pickle::pickle;
 use monarch_messages::controller::ControllerMessageClient;
 use monarch_messages::controller::Seq;
 use monarch_messages::controller::WorkerError;
@@ -93,22 +93,16 @@ fn pickle_python_result(
     result: Bound<'_, PyAny>,
     worker_rank: usize,
 ) -> Result<PythonMessage, anyhow::Error> {
-    let pickle = py
-        .import("monarch._src.actor.actor_mesh")
-        .unwrap()
-        .getattr("_pickle")
-        .unwrap();
-    let mut data: Buffer = pickle
-        .call1((result,))
-        .map_err(|pyerr| anyhow::Error::from(SerializablePyErr::from(py, &pyerr)))?
-        .extract()
-        .unwrap();
+    let mut state = pickle(py, result.unbind(), false, false)
+        .map_err(|pyerr| anyhow::Error::from(SerializablePyErr::from(py, &pyerr)))?;
+    let inner = state
+        .take_inner()
+        .map_err(|pyerr| anyhow::Error::from(SerializablePyErr::from(py, &pyerr)))?;
     Ok(PythonMessage::new_from_buf(
         PythonMessageKind::Result {
             rank: Some(worker_rank),
         },
-        data.take_part(),
-        None,
+        inner.take_buffer(),
     ))
 }
 

--- a/python/monarch/_rust_bindings/monarch_hyperactor/actor.pyi
+++ b/python/monarch/_rust_bindings/monarch_hyperactor/actor.pyi
@@ -23,8 +23,8 @@ from typing import (
 
 from monarch._rust_bindings.monarch_hyperactor.buffers import Buffer, FrozenBuffer
 from monarch._rust_bindings.monarch_hyperactor.mailbox import OncePortRef, PortRef
+from monarch._rust_bindings.monarch_hyperactor.pickle import PicklingState
 from monarch._rust_bindings.monarch_hyperactor.proc import ActorId, Proc, Serialized
-from monarch._rust_bindings.monarch_hyperactor.pytokio import PendingPickleState
 
 class PythonMessageKind:
     @classmethod
@@ -117,9 +117,16 @@ class PythonMessage:
     def __init__(
         self,
         kind: PythonMessageKind,
-        message: Union[Buffer, bytes],
-        pending_pickle_state: Optional[PendingPickleState] = None,
-    ) -> None: ...
+        message: FrozenBuffer,
+    ) -> None:
+        """
+        Create a PythonMessage.
+
+        Args:
+            kind: The message kind specifying the method to call.
+            message: The pickled arguments as a FrozenBuffer.
+        """
+        ...
     @property
     def message(self) -> FrozenBuffer:
         """The pickled arguments."""
@@ -178,7 +185,7 @@ class Actor(Protocol):
         method: MethodSpecifier,
         message: FrozenBuffer,
         panic_flag: PanicFlag,
-        local_state: Iterable[Any],
+        local_state: List[Any],
         response_port: PortProtocol[Any],
     ) -> None: ...
 

--- a/python/monarch/_rust_bindings/monarch_hyperactor/actor_mesh.pyi
+++ b/python/monarch/_rust_bindings/monarch_hyperactor/actor_mesh.pyi
@@ -10,6 +10,7 @@ from typing import final, Optional, Protocol
 
 from monarch._rust_bindings.monarch_hyperactor.actor import PythonMessage
 from monarch._rust_bindings.monarch_hyperactor.context import Instance
+from monarch._rust_bindings.monarch_hyperactor.pickle import PendingMessage
 from monarch._rust_bindings.monarch_hyperactor.proc import ActorId
 from monarch._rust_bindings.monarch_hyperactor.pytokio import PythonTask, Shared
 from monarch._rust_bindings.monarch_hyperactor.shape import Region
@@ -34,7 +35,18 @@ class ActorMeshProtocol(Protocol):
         message: PythonMessage,
         selection: str,
         instance: Instance,
-    ) -> None: ...
+    ) -> None:
+        """Cast an already-resolved PythonMessage to actors."""
+        ...
+
+    def cast_unresolved(
+        self,
+        message: PendingMessage,
+        selection: str,
+        instance: Instance,
+    ) -> None:
+        """Cast a PendingMessage (which may contain unresolved async values) to actors."""
+        ...
     def new_with_region(self, region: Region) -> Self: ...
     def supervision_event(
         self, instance: Instance

--- a/python/monarch/_rust_bindings/monarch_hyperactor/pickle.pyi
+++ b/python/monarch/_rust_bindings/monarch_hyperactor/pickle.pyi
@@ -1,0 +1,150 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from typing import Any, List
+
+from monarch._rust_bindings.monarch_hyperactor.actor import PythonMessageKind
+from monarch._rust_bindings.monarch_hyperactor.buffers import FrozenBuffer
+from monarch._rust_bindings.monarch_hyperactor.pytokio import Shared
+
+class PicklingState:
+    """
+    Result of a pickling operation.
+
+    Contains the pickled bytes and any tensor engine references or pending
+    pickles that were collected during serialization.
+    """
+
+    def __init__(
+        self,
+        buffer: FrozenBuffer,
+        tensor_engine_references: List[Any] | None = None,
+    ) -> None:
+        """
+        Create a new PicklingState from a buffer and optional tensor engine references.
+
+        This is used for unpickling received messages that may contain tensor engine
+        references that need to be restored during deserialization.
+
+        Args:
+            buffer: The pickled bytes as a FrozenBuffer.
+            tensor_engine_references: Optional list of tensor engine references
+                to restore during unpickling.
+        """
+        ...
+
+    def tensor_engine_references(self) -> List[Any]:
+        """
+        Get a copy of all tensor engine references from this pickling state.
+
+        Returns a list containing copies of the tensor engine references.
+        """
+        ...
+
+    def buffer(self) -> FrozenBuffer:
+        """
+        Get the buffer from this pickling state.
+
+        Returns a FrozenBuffer containing the pickled bytes.
+        This does not consume the PicklingState.
+        """
+        ...
+
+    def unpickle(self) -> Any:
+        """
+        Unpickle the buffer contents.
+
+        This consumes the PicklingState. It will fail if there are any pending
+        pickles that haven't been resolved.
+        """
+        ...
+
+class PendingMessage:
+    """
+    A message that is pending resolution of async values before it can be sent.
+
+    Contains a PythonMessageKind and a PicklingState. The PicklingState may contain
+    pending pickles (unresolved async values) that must be resolved before the message
+    can be converted into a PythonMessage.
+    """
+
+    def __init__(self, kind: PythonMessageKind, state: PicklingState) -> None:
+        """
+        Create a new PendingMessage from a kind and pickling state.
+
+        Note: This takes ownership of the PicklingState's inner state.
+        """
+        ...
+
+    @property
+    def kind(self) -> PythonMessageKind:
+        """Get the message kind."""
+        ...
+
+def pickle(
+    obj: Any,
+    allow_pending_pickles: bool = True,
+    allow_tensor_engine_references: bool = True,
+) -> PicklingState:
+    """
+    Pickle an object with support for pending pickles and tensor engine references.
+
+    Creates a PicklingState and calls cloudpickle.dumps with an active
+    thread-local pickling state, allowing __reduce__ implementations to push
+    tensor engine references and pending pickles.
+
+    Args:
+        obj: The Python object to pickle
+        allow_pending_pickles: If true, allow PyShared values to be registered as pending
+        allow_tensor_engine_references: If true, allow tensor engine references to be registered
+
+    Returns:
+        A PicklingState containing the pickled bytes and any registered references/pending pickles
+    """
+    ...
+
+def push_tensor_engine_reference_if_active(obj: Any) -> bool:
+    """
+    Push a tensor engine reference to the active pickling state if one is active.
+
+    Called from Python during pickling when a tensor engine object
+    is encountered that needs special handling.
+
+    Returns:
+        False if there is no active pickling state.
+        True if the reference was successfully pushed.
+
+    Raises:
+        RuntimeError: If tensor engine references are not allowed in the
+            current pickling context.
+    """
+    ...
+
+def pop_tensor_engine_reference() -> Any:
+    """
+    Pop a tensor engine reference from the active pickling state.
+
+    Called from Python during unpickling to retrieve tensor engine
+    objects in the order they were pushed.
+
+    Raises:
+        RuntimeError: If there is no active pickling state or no references remaining.
+    """
+    ...
+
+def pop_pending_pickle() -> Shared[Any]:
+    """
+    Pop a pending pickle from the active pickling state.
+
+    Called from Python during unpickling to retrieve the PyShared
+    object that was deferred during pickling.
+
+    Raises:
+        RuntimeError: If there is no active pickling state or no pending pickles remaining.
+    """
+    ...

--- a/python/monarch/_rust_bindings/monarch_hyperactor/pytokio.pyi
+++ b/python/monarch/_rust_bindings/monarch_hyperactor/pytokio.pyi
@@ -13,7 +13,6 @@ from typing import (
     Coroutine,
     Generator,
     Generic,
-    List,
     Optional,
     Sequence,
     Tuple,
@@ -116,21 +115,3 @@ def is_tokio_thread() -> bool:
     Returns true if the current thread is a tokio worker thread (and block_on will fail).
     """
     ...
-
-class PendingPickle:
-    """
-    Represents an object that we are eventually going to pickle,
-    but we can't yet because it hasn't been fully initialized.
-    """
-    def __init__(self, fut: Shared[T]) -> None: ...
-
-class PendingPickleState:
-    """
-    A special class used to allow deferring the full pickling of an object.
-    It contains a list of objects that were returned by the filter in a call
-    to `flatten`, and the filter itself. Crucially, some of these objects
-    may be futures that need to be awaited in an asynchronous context.
-    """
-    def __init__(
-        self, unflatten_values: List[Any], flatten_filter: Callable[[Any], bool]
-    ) -> None: ...

--- a/python/monarch/_src/actor/actor_mesh.py
+++ b/python/monarch/_src/actor/actor_mesh.py
@@ -61,13 +61,13 @@ from monarch._rust_bindings.monarch_hyperactor.mailbox import (
     PortRef,
     UndeliverableMessageEnvelope,
 )
-from monarch._rust_bindings.monarch_hyperactor.proc import ActorId
-from monarch._rust_bindings.monarch_hyperactor.pytokio import (
-    PendingPickle,
-    PendingPickleState,
-    PythonTask,
-    Shared,
+from monarch._rust_bindings.monarch_hyperactor.pickle import (
+    PendingMessage,
+    pickle,
+    PicklingState,
 )
+from monarch._rust_bindings.monarch_hyperactor.proc import ActorId
+from monarch._rust_bindings.monarch_hyperactor.pytokio import PythonTask, Shared
 from monarch._rust_bindings.monarch_hyperactor.selection import (
     Selection as HySelection,  # noqa: F401
 )
@@ -95,16 +95,14 @@ from monarch._src.actor.endpoint import (
     Selection,
 )
 from monarch._src.actor.future import Future
-from monarch._src.actor.metrics import endpoint_message_size_histogram
 from monarch._src.actor.mpsc import (  # noqa: F401 - import runs @rust_struct patching
     Receiver,
 )
-from monarch._src.actor.pickle import allow_pending_pickle_mesh, flatten, unflatten
 from monarch._src.actor.python_extension_methods import rust_struct
 from monarch._src.actor.shape import MeshTrait, NDSlice
 from monarch._src.actor.sync_state import fake_sync_state
 from monarch._src.actor.telemetry import METER
-from monarch._src.actor.tensor_engine_shim import actor_rref, create_actor_message
+from monarch._src.actor.tensor_engine_shim import actor_rref, create_actor_message_kind
 from opentelemetry.metrics import Counter
 from opentelemetry.trace import Tracer
 from typing_extensions import Self
@@ -565,51 +563,6 @@ R = TypeVar("R")
 A = TypeVar("A")
 
 
-class _SingletonActorAdapator:
-    def __init__(self, inner: ActorId, region: Optional[Region] = None) -> None:
-        self._inner: ActorId = inner
-        if region is None:
-            region = singleton_shape.region
-        self._region: Region = region
-
-    @property
-    def region(self) -> Region:
-        return self._region
-
-    def get(self, rank: int) -> Optional[ActorId]:
-        if rank == 0:
-            return self._inner
-        return None
-
-    def cast(
-        self,
-        message: PythonMessage,
-        selection: str,
-        instance: HyInstance,
-    ) -> None:
-        Instance._as_py(instance)._mailbox.post(self._inner, message)
-
-    def new_with_region(self, region: Region) -> "_SingletonActorAdapator":
-        return _SingletonActorAdapator(self._inner, self._region)
-
-    def supervision_event(self, instance: HyInstance) -> "Optional[Shared[Exception]]":
-        return None
-
-    def start_supervision(
-        self, instance: HyInstance, supervision_display_name: str
-    ) -> None:
-        return None
-
-    def stop(self, instance: HyInstance, reason: str) -> "PythonTask[None]":
-        raise NotImplementedError("stop()")
-
-    def initialized(self) -> "PythonTask[None]":
-        async def empty() -> None:
-            pass
-
-        return PythonTask.from_coroutine(empty())
-
-
 def _check_endpoint_arguments(
     method_name: MethodSpecifier,
     signature: inspect.Signature,
@@ -647,7 +600,7 @@ def _create_endpoint_message(
     kwargs: Dict[str, Any],
     port: "Optional[Port[Any]]",
     proc_mesh: "Optional[ProcMesh]",
-) -> PythonMessage:
+) -> PendingMessage:
     """
     Create a PythonMessage for sending to an actor endpoint.
 
@@ -658,41 +611,18 @@ def _create_endpoint_message(
         PythonMessage ready to be sent to the actor mesh
     """
     _check_endpoint_arguments(method_name, signature, args, kwargs)
-    with allow_pending_pickle_mesh():
-        objects, buffer = flatten((args, kwargs), _is_ref_or_mailbox_or_pending_pickle)
-
-    has_ref = False
-    has_pending_pickle = False
-    mailbox_or_refs = []
-    for obj in objects:
-        if isinstance(obj, PendingPickle):
-            has_pending_pickle = True
-        elif hasattr(obj, "__monarch_ref__"):
-            mailbox_or_refs.append(obj)
-            has_ref = True
-        else:
-            mailbox_or_refs.append(obj)
-
-    pending_pickle_state = None
-    if has_pending_pickle:
-        pending_pickle_state = PendingPickleState(
-            objects, _is_ref_or_mailbox_or_pending_pickle
-        )
-
-    if not has_ref:
-        message = PythonMessage(
-            PythonMessageKind.CallMethod(
-                method_name, None if port is None else port._port_ref
-            ),
-            buffer,
-            pending_pickle_state,
+    pickling_state = pickle(
+        (args, kwargs), allow_pending_pickles=True, allow_tensor_engine_references=True
+    )
+    objects = pickling_state.tensor_engine_references()
+    if not objects:
+        message_kind = PythonMessageKind.CallMethod(
+            method_name, None if port is None else port._port_ref
         )
     else:
-        message = create_actor_message(
-            method_name, proc_mesh, buffer, objects, port, pending_pickle_state
-        )
+        message_kind = create_actor_message_kind(method_name, proc_mesh, objects, port)
 
-    return message
+    return PendingMessage(message_kind, pickling_state)
 
 
 class ActorEndpoint(Endpoint[P, R]):
@@ -733,12 +663,9 @@ class ActorEndpoint(Endpoint[P, R]):
             self._name, self._signature, args, kwargs, port, self._proc_mesh
         )
 
-        # Record the message size with method name attribute
-        endpoint_message_size_histogram.record(
-            len(message.message), {"method": self._get_method_name()}
+        self._actor_mesh.cast_unresolved(
+            message, selection, context().actor_instance._as_rust()
         )
-
-        self._actor_mesh.cast(message, selection, context().actor_instance._as_rust())
         shape = self._shape
         return Extent(shape.labels, shape.ndslice.sizes)
 
@@ -757,11 +684,9 @@ class ActorEndpoint(Endpoint[P, R]):
 
     def _rref(self, args: Tuple[Any, ...], kwargs: Dict[str, Any]) -> R:
         _check_endpoint_arguments(self._name, self._signature, args, kwargs)
-        refs, buffer, pending_pickle_state = _flatten_with_pending_pickle(
-            (args, kwargs)
-        )
+        state = pickle((args, kwargs))
 
-        return actor_rref(self, buffer, refs, pending_pickle_state)
+        return actor_rref(self, state)
 
 
 @overload
@@ -1035,21 +960,26 @@ class Port(Generic[R]):
         Args:
             obj: R-typed object to send.
         """
-        _, buffer, pending_pickle_state = _flatten_with_pending_pickle(obj)
+        pickle_state = pickle(
+            obj, allow_pending_pickles=False, allow_tensor_engine_references=False
+        )
 
         self._port_ref.send(
             self._instance,
-            PythonMessage(
-                PythonMessageKind.Result(self._rank), buffer, pending_pickle_state
-            ),
+            PythonMessage(PythonMessageKind.Result(self._rank), pickle_state.buffer()),
         )
 
     def exception(self, obj: Exception) -> None:
         # we deliver each error exactly once, so if there is no port to respond to,
         # the error is sent to the current actor as an exception.
+        pickle_state = pickle(
+            obj, allow_pending_pickles=False, allow_tensor_engine_references=False
+        )
         self._port_ref.send(
             self._instance,
-            PythonMessage(PythonMessageKind.Exception(self._rank), _pickle(obj)),
+            PythonMessage(
+                PythonMessageKind.Exception(self._rank), pickle_state.buffer()
+            ),
         )
 
     def __reduce__(self) -> Tuple[Any, Tuple[Any, ...]]:
@@ -1196,7 +1126,7 @@ class PortReceiver(Generic[R]):
 
     def _process(self, msg: PythonMessage) -> R:
         # TODO: Try to do something more structured than a cast here
-        payload = cast(R, unflatten(msg.message, itertools.repeat(self._mailbox)))
+        payload = cast(R, PicklingState(msg.message).unpickle())
         match msg.kind:
             case PythonMessageKind.Result():
                 return payload
@@ -1291,7 +1221,7 @@ class _Actor:
         method: MethodSpecifier,
         message: FrozenBuffer,
         panic_flag: PanicFlag,
-        local_state: Iterable[Any],
+        local_state: List[Any],
         response_port: "PortProtocol[Any]",
     ) -> None:
         MESSAGES_HANDLED.add(1)
@@ -1307,7 +1237,7 @@ class _Actor:
 
             DebugContext.set(DebugContext())
 
-            args, kwargs = unflatten(message, local_state)
+            args, kwargs = PicklingState(message, local_state).unpickle()
 
             match method:
                 case MethodSpecifier.Init():
@@ -1547,12 +1477,12 @@ class _Actor:
             try:
                 await self._handle_queued_message(msg)
             except BaseException as e:
-                import cloudpickle
-
-                error_bytes = cloudpickle.dumps(e)
+                state = pickle(
+                    e, allow_pending_pickles=False, allow_tensor_engine_references=False
+                )
                 error_msg = PythonMessage(
                     PythonMessageKind.Exception(rank=None),
-                    error_bytes,
+                    state.buffer(),
                 )
                 error_port.send(msg.context.actor_instance, error_msg)
                 raise
@@ -1588,40 +1518,6 @@ class _Actor:
 
     def __repr__(self) -> str:
         return f"_Actor(instance={self.instance!r})"
-
-
-def _is_mailbox(x: object) -> bool:
-    if hasattr(x, "__monarch_ref__"):
-        raise NotImplementedError(
-            "Sending monarch tensor references directly to a port."
-        )
-    return isinstance(x, Mailbox)
-
-
-def _is_ref_or_mailbox(x: object) -> bool:
-    return hasattr(x, "__monarch_ref__") or isinstance(x, Mailbox)
-
-
-def _is_ref_or_mailbox_or_pending_pickle(x: object) -> bool:
-    return _is_ref_or_mailbox(x) or isinstance(x, PendingPickle)
-
-
-def _flatten_with_pending_pickle(
-    x: object,
-) -> Tuple[List[Any], Buffer, Optional[PendingPickleState]]:
-    with allow_pending_pickle_mesh():
-        objs, buff = flatten(x, _is_ref_or_mailbox_or_pending_pickle)
-    pending_pickle_state = None
-    if any(isinstance(obj, PendingPickle) for obj in objs):
-        pending_pickle_state = PendingPickleState(
-            objs, _is_ref_or_mailbox_or_pending_pickle
-        )
-    return objs, buff, pending_pickle_state
-
-
-def _pickle(obj: object) -> Buffer:
-    _, buff = flatten(obj, _is_mailbox)
-    return buff
 
 
 class Actor(MeshTrait):
@@ -1807,14 +1703,6 @@ class ActorMesh(MeshTrait, Generic[T]):
 
         return mesh
 
-    @classmethod
-    def from_actor_id(
-        cls,
-        Class: Type[T],
-        actor_id: ActorId,
-    ) -> "ActorMesh[T]":
-        return cls(Class, "", _SingletonActorAdapator(actor_id), singleton_shape, None)
-
     def __reduce_ex__(
         self, protocol: Any
     ) -> "Tuple[Type[ActorMesh[T]], Tuple[Any, ...]]":
@@ -1907,10 +1795,14 @@ class RootClientActor(Actor):
         return True
 
     @staticmethod
-    def _pickled_init_args() -> Buffer:
+    def _pickled_init_args() -> FrozenBuffer:
         args = (
             ActorInitArgs(RootClientActor, None, None, RootClientActor.name, None, ()),
         )
         kwargs = {}
-        _, buffer = flatten((args, kwargs), lambda _: False)
-        return buffer
+        state = pickle(
+            (args, kwargs),
+            allow_pending_pickles=False,
+            allow_tensor_engine_references=False,
+        )
+        return state.buffer()

--- a/python/monarch/_src/actor/host_mesh.py
+++ b/python/monarch/_src/actor/host_mesh.py
@@ -14,11 +14,7 @@ from monarch._rust_bindings.monarch_hyperactor.host_mesh import (
     HostMesh as HyHostMesh,
 )
 from monarch._rust_bindings.monarch_hyperactor.proc_mesh import ProcMesh as HyProcMesh
-from monarch._rust_bindings.monarch_hyperactor.pytokio import (
-    PendingPickle,
-    PythonTask,
-    Shared,
-)
+from monarch._rust_bindings.monarch_hyperactor.pytokio import PythonTask, Shared
 from monarch._rust_bindings.monarch_hyperactor.shape import Extent, Region
 from monarch._src.actor.actor_mesh import _Lazy, context
 from monarch._src.actor.allocator import (
@@ -260,16 +256,12 @@ class HostMesh(MeshTrait):
         )
 
     def __reduce_ex__(self, protocol: ...) -> Tuple[Any, Tuple[Any, ...]]:
-        return HostMesh._from_initialized_hy_host_mesh, (
-            self._hy_host_mesh.poll()
-            or (
-                PendingPickle(self._hy_host_mesh)
-                if is_pending_pickle_allowed()
-                else self._hy_host_mesh.block_on()
-            ),
+        return HostMesh, (
+            self._hy_host_mesh,
             self._region,
             self.stream_logs,
             self.is_fake_in_process,
+            None,
         )
 
     @property

--- a/python/monarch/_src/actor/proc_mesh.py
+++ b/python/monarch/_src/actor/proc_mesh.py
@@ -39,11 +39,7 @@ from monarch._rust_bindings.monarch_hyperactor.actor import MethodSpecifier
 from monarch._rust_bindings.monarch_hyperactor.alloc import AllocConstraints
 from monarch._rust_bindings.monarch_hyperactor.context import Instance as HyInstance
 from monarch._rust_bindings.monarch_hyperactor.proc_mesh import ProcMesh as HyProcMesh
-from monarch._rust_bindings.monarch_hyperactor.pytokio import (
-    PendingPickle,
-    PythonTask,
-    Shared,
-)
+from monarch._rust_bindings.monarch_hyperactor.pytokio import PythonTask, Shared
 from monarch._rust_bindings.monarch_hyperactor.shape import Extent, Region, Shape, Slice
 from monarch._src.actor.actor_mesh import (
     _Actor,
@@ -514,7 +510,7 @@ class ProcMesh(MeshTrait):
             None,
             self,
         )
-        mesh._inner.cast(message, "all", instance._as_rust())
+        mesh._inner.cast_unresolved(message, "all", instance._as_rust())
 
         instance._add_child(mesh)
         return cast(TActor, mesh)
@@ -639,13 +635,8 @@ class ProcMesh(MeshTrait):
         )
 
     def __reduce_ex__(self, protocol: ...) -> Tuple[Any, Tuple[Any, ...]]:
-        return ProcMesh._from_initialized_hy_proc_mesh, (
-            self._proc_mesh.poll()
-            or (
-                PendingPickle(self._proc_mesh)
-                if is_pending_pickle_allowed()
-                else self._proc_mesh.block_on()
-            ),
+        return ProcMesh, (
+            self._proc_mesh,
             self._host_mesh,
             self._region,
             self._root_region,

--- a/python/monarch/_src/actor/tensor_engine_shim.py
+++ b/python/monarch/_src/actor/tensor_engine_shim.py
@@ -33,7 +33,7 @@ if TYPE_CHECKING:
     from monarch._src.actor.actor_mesh import Port
 
 from monarch._rust_bindings.monarch_hyperactor.buffers import Buffer
-from monarch._rust_bindings.monarch_hyperactor.pytokio import PendingPickleState
+from monarch._rust_bindings.monarch_hyperactor.pickle import PicklingState
 
 P = ParamSpec("P")
 F = TypeVar("F", bound=Callable[..., Any])
@@ -70,22 +70,18 @@ def shim(
 
 
 @shim(module="monarch.mesh_controller")
-def create_actor_message(
+def create_actor_message_kind(
     method_name: "MethodSpecifier",
     proc_mesh: "Optional[Any]",
-    args_kwargs_tuple: Buffer,
     refs: "Sequence[Any]",
     port: "Optional[Port[Any]]",
-    pending_pickle_state: Optional[PendingPickleState],
 ) -> "Any": ...
 
 
 @shim(module="monarch.mesh_controller")
 def actor_rref(
     endpoint: Any,
-    args_kwargs_tuple: Buffer,
-    refs: Sequence[Any],
-    pending_pickle_state: Optional[PendingPickleState],
+    pickling_state: Optional[PicklingState],
 ) -> Any: ...
 
 

--- a/python/monarch/common/reference.py
+++ b/python/monarch/common/reference.py
@@ -8,6 +8,10 @@
 from typing import Optional
 
 from monarch._rust_bindings.monarch_extension.tensor_worker import Ref
+from monarch._rust_bindings.monarch_hyperactor.pickle import (
+    pop_tensor_engine_reference,
+    push_tensor_engine_reference_if_active,
+)
 
 
 class Referenceable:
@@ -21,6 +25,8 @@ class Referenceable:
         assert self.ref is not None, (
             f"{self} is being sent but does not have a reference"
         )
+        if push_tensor_engine_reference_if_active(self):
+            return pop_tensor_engine_reference, ()
         return Ref, (self.ref,)
 
     # Used by rust backend to get the ref for this object

--- a/python/monarch/mesh_controller.py
+++ b/python/monarch/mesh_controller.py
@@ -40,10 +40,13 @@ from monarch._rust_bindings.monarch_hyperactor.actor import (
 )
 from monarch._rust_bindings.monarch_hyperactor.buffers import Buffer
 from monarch._rust_bindings.monarch_hyperactor.mailbox import Mailbox, PortId
+from monarch._rust_bindings.monarch_hyperactor.pickle import (
+    PendingMessage,
+    PicklingState,
+)
 from monarch._rust_bindings.monarch_hyperactor.proc import (  # @manual=//monarch/monarch_extension:monarch_extension
     ActorId,
 )
-from monarch._rust_bindings.monarch_hyperactor.pytokio import PendingPickleState
 from monarch._src.actor.actor_mesh import Channel, Port
 from monarch._src.actor.shape import NDSlice
 from monarch.common import device_mesh, messages, stream
@@ -435,33 +438,26 @@ def _create_call_method_indirect_message(
     method_name: "MethodSpecifier",
     client: MeshClient,
     seq: Seq,
-    args_kwargs_tuple: Buffer,
     refs: Sequence[Any],
-    pending_pickle_state: Optional[PendingPickleState],
-) -> Tuple[PythonMessage, Tuple[str, int]]:
+) -> Tuple[PythonMessageKind, Tuple[str, int]]:
     unflatten_args = [
         UnflattenArg.PyObject if isinstance(ref, Tensor) else UnflattenArg.Mailbox
         for ref in refs
     ]
     broker_id: Tuple[str, int] = client._mesh_controller.broker_id
-    actor_msg = PythonMessage(
-        PythonMessageKind.CallMethodIndirect(
-            method_name, broker_id, seq, unflatten_args
-        ),
-        args_kwargs_tuple,
-        pending_pickle_state,
+    actor_msg_kind = PythonMessageKind.CallMethodIndirect(
+        method_name, broker_id, seq, unflatten_args
     )
-    return (actor_msg, broker_id)
+
+    return (actor_msg_kind, broker_id)
 
 
-def create_actor_message(
+def create_actor_message_kind(
     method_name: MethodSpecifier,
     proc_mesh: Optional["ProcMesh"],
-    args_kwargs_tuple: Buffer,
     refs: Sequence[Any],
     port: Optional[Port[Any]],
-    pending_pickle_state: Optional[PendingPickleState],
-) -> PythonMessage:
+) -> PythonMessageKind:
     tensors = [ref for ref in refs if isinstance(ref, Tensor)]
     # we have some monarch references, we need to ensure their
     # proc_mesh matches that of the tensors we sent to it
@@ -484,30 +480,26 @@ def create_actor_message(
 
     client = cast(MeshClient, checker.mesh.client)
 
-    return _create_actor_message(
+    return _create_actor_message_kind(
         method_name,
-        args_kwargs_tuple,
         refs,
         port,
         client,
         checker.mesh,
         tensors,
         chosen_stream,
-        pending_pickle_state,
     )
 
 
-def _create_actor_message(
+def _create_actor_message_kind(
     method_name: MethodSpecifier,
-    args_kwargs_tuple: Buffer,
     refs: Sequence[Any],
     port: Optional[Port[Any]],
     client: MeshClient,
     mesh: DeviceMesh,
     tensors: List[Tensor],
     chosen_stream: Stream,
-    pending_pickle_state: Optional[PendingPickleState],
-) -> PythonMessage:
+) -> PythonMessageKind:
     stream_ref = chosen_stream._to_ref(client)
     fut = (port, mesh._ndslice) if port is not None else None
 
@@ -522,7 +514,7 @@ def _create_actor_message(
     # from the stream, then it will run the actor method, and send the result to response port.
 
     actor_msg, broker_id = _create_call_method_indirect_message(
-        method_name, client, ident, args_kwargs_tuple, refs, pending_pickle_state
+        method_name, client, ident, refs
     )
     worker_msg = SendResultOfActorCall(ident, broker_id, tensors, [], stream_ref)
     client.send(mesh._ndslice, worker_msg)
@@ -534,13 +526,9 @@ def _create_actor_message(
     return actor_msg
 
 
-def actor_rref(
-    endpoint,
-    args_kwargs_tuple: Buffer,
-    refs: Sequence[Any],
-    pending_pickle_state: Optional[PendingPickleState],
-):
+def actor_rref(endpoint, pickling_state: PicklingState):
     chosen_stream = stream._active
+    refs = pickling_state.tensor_engine_references()
     fake_result, dtensors, mutates, mesh = dtensor_check(
         endpoint._propagate,
         cast(ResolvableFunction, endpoint._name),
@@ -564,10 +552,13 @@ def actor_rref(
     if len(result_dtensors) == 0:
         result_msg = None
 
-    actor_msg, broker_id = _create_call_method_indirect_message(
-        endpoint._name, mesh.client, seq, args_kwargs_tuple, refs, pending_pickle_state
+    actor_msg_kind, broker_id = _create_call_method_indirect_message(
+        endpoint._name, mesh.client, seq, refs
     )
-    endpoint._actor_mesh.cast(actor_msg, "all", context().actor_instance._as_rust())
+    actor_msg = PendingMessage(actor_msg_kind, pickling_state)
+    endpoint._actor_mesh.cast_unresolved(
+        actor_msg, "all", context().actor_instance._as_rust()
+    )
     # note the device mesh has to be defined regardles so the remote functions
     # can invoke mesh.rank("...")
 

--- a/python/tests/test_python_actors.py
+++ b/python/tests/test_python_actors.py
@@ -35,6 +35,7 @@ from monarch._rust_bindings.monarch_hyperactor.actor import (
     PythonMessageKind,
 )
 from monarch._rust_bindings.monarch_hyperactor.alloc import Alloc, AllocSpec
+from monarch._rust_bindings.monarch_hyperactor.buffers import Buffer
 from monarch._rust_bindings.monarch_hyperactor.mailbox import (
     PortId,
     PortRef,
@@ -1311,9 +1312,11 @@ class UndeliverableMessageSender(Actor):
             port=1234,
         )
         port_ref = PortRef(port_id)
+        buf = Buffer()
+        buf.write(b"123")
         port_ref.send(
             actor_instance._as_rust(),
-            PythonMessage(PythonMessageKind.Result(None), b"123"),
+            PythonMessage(PythonMessageKind.Result(None), buf.freeze()),
         )
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #2520

This diff refactors Monarch's pickling system by moving from a Python-based
`persistent_id`/`flatten`/`unflatten` approach to a simpler Rust-based
thread-local storage mechanism.

**Key Changes:**

1. **New `pickle.rs` module** - Introduces thread-local `ACTIVE_PICKLING_STATE`
   storage for tracking out-of-band pickling information during cloudpickle
   operations. Provides `PicklingState`, `PendingMessage`, and `pickle()` function.

2. **Simplified `PythonMessage`** - Removed `pending_pickle_state` field entirely.
   Constructor now takes `FrozenBuffer` directly instead of `Buffer | bytes`.

3. **Removed mailbox handling from references** - The `local_state` for message
   dispatch changed from `itertools.repeat(mailbox)` to an empty list. Mailboxes
   are no longer passed through this mechanism.

4. **Deleted `PendingPickle` and `PendingPickleState`** from `pytokio.rs` - These
   Python-side classes handled deferred pickling via `flatten`/`unflatten`.
   Replaced by Rust-side `PicklingState.resolve()` and `PendingMessage.resolve()`.

5. **`PyShared` now has `__reduce__`** - Added pickle protocol support directly
   via `reduce_shared()`. Also optimized `block_on` to check if value is already
   available before calling into tokio runtime.

6. **New `cast_unresolved()` method** - Trait method for casting messages with
   unresolved async values. `AsyncActorMesh` provides async implementation.

7. **Python-side simplifications** - Removed helper functions (`_is_mailbox`,
   `_flatten_with_pending_pickle`, `_pickle`), `_SingletonActorAdapator` class,
   and `allow_pending_pickle_mesh()` context manager usage.

**Benefits:**
- Reduced Python overhead: No more Python-side `persistent_id` callbacks or
  `flatten`/`unflatten` traversals during pickling
- Cleaner architecture: Pickling state handled via thread-local Rust storage
  that `__reduce__` implementations can access directly
- Simplified message type: `PythonMessage` no longer carries pending pickle state
- ~200 lines of Python removed, ~175 lines of Rust removed from pytokio.rs

Differential Revision: [D92435072](https://our.internmc.facebook.com/intern/diff/D92435072/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D92435072/)!