### PR TITLE
Migrate all internal conda builds to py3.12

### DIFF
--- a/python/tests/_src/tools/test_commands.py
+++ b/python/tests/_src/tools/test_commands.py
@@ -394,7 +394,7 @@ class TestCommandsAsync(unittest.IsolatedAsyncioTestCase):
                         check_interval=_5_MS,
                     )
 
-                    mock_create.called_once_with(config, "123")
+                    mock_create.assert_called_once_with(config, "123")
                     self.assertEqual(server_info.server_handle, "slurm:///456")
                     self.assertListEqual(
                         mock_info.call_args_list,
@@ -490,7 +490,7 @@ class TestCommandsAsync(unittest.IsolatedAsyncioTestCase):
                 force_restart=True,
             )
 
-            mock_create.called_once_with(config, "123")
+            mock_create.assert_called_once_with(config, "123")
             mock_kill.assert_called_once_with("slurm:///123")
             self.assertEqual(server_info.server_handle, "slurm:///456")
             self.assertListEqual(

--- a/python/tests/test_allocator.py
+++ b/python/tests/test_allocator.py
@@ -424,7 +424,7 @@ class TestRemoteAllocator(unittest.IsolatedAsyncioTestCase):
 
             with self.assertRaisesRegex(
                 Exception,
-                r"(?s)fail on init(?s)",
+                r"(?s)fail on init",
             ):
                 await actor_mesh.dummy.call()
 


### PR DESCRIPTION
Summary: Fixes for python 3.12

Reviewed By: pzhan9

Differential Revision: D91825950


