### PR TITLE
Update examples using old docker tag

### DIFF
--- a/docs/source/examples/ddp/manifests/ddp_mesh.yaml
+++ b/docs/source/examples/ddp/manifests/ddp_mesh.yaml
@@ -65,7 +65,7 @@ spec:
   podTemplate:
     containers:
     - name: worker
-      image: ghcr.io/meta-pytorch/monarch:2026-01-11-alpha
+      image: ghcr.io/meta-pytorch/monarch:latest
 
       resources:
         limits:
@@ -117,7 +117,7 @@ metadata:
 spec:
   containers:
     - name: controller
-      image: ghcr.io/meta-pytorch/monarch:2026-01-11-alpha
+      image: ghcr.io/meta-pytorch/monarch:latest
       command: ["sleep"]
       args: ["infinity"]
   serviceAccountName: ddp-controller

--- a/examples/kubernetes/gpu_collective_demo/manifests/gpu_mesh.yaml
+++ b/examples/kubernetes/gpu_collective_demo/manifests/gpu_mesh.yaml
@@ -11,7 +11,7 @@ spec:
     containers:
     - name: worker
       # We use a public image and inline the python commands below.
-      image: ghcr.io/meta-pytorch/monarch:2026-01-11-alpha
+      image: ghcr.io/meta-pytorch/monarch:latest
 
       # Ensure we always try to pull (helpful during development)
       imagePullPolicy: Always

--- a/examples/kubernetes/gpu_collective_demo/manifests/simple_controller.yaml
+++ b/examples/kubernetes/gpu_collective_demo/manifests/simple_controller.yaml
@@ -8,6 +8,6 @@ spec:
   serviceAccountName: monarch-client
   containers:
     - name: monarch
-      image: ghcr.io/meta-pytorch/monarch:2026-01-11-alpha
+      image: ghcr.io/meta-pytorch/monarch:latest
       command: ["sleep"]
       args: ["infinity"]

--- a/examples/kubernetes/hello_kubernetes_job/manifests/hello_mesh.yaml
+++ b/examples/kubernetes/hello_kubernetes_job/manifests/hello_mesh.yaml
@@ -59,7 +59,7 @@ spec:
   podTemplate:
     containers:
     - name: worker
-      image: ghcr.io/meta-pytorch/monarch:2026-01-11-alpha
+      image: ghcr.io/meta-pytorch/monarch:latest
       command:
         - python
         - -u
@@ -95,7 +95,7 @@ spec:
   podTemplate:
     containers:
     - name: worker
-      image: ghcr.io/meta-pytorch/monarch:2026-01-11-alpha
+      image: ghcr.io/meta-pytorch/monarch:latest
       command:
         - python
         - -u
@@ -125,7 +125,7 @@ metadata:
 spec:
   containers:
     - name: controller
-      image: ghcr.io/meta-pytorch/monarch:2026-01-11-alpha
+      image: ghcr.io/meta-pytorch/monarch:latest
       command: ["sleep"]
       args: ["infinity"]
   serviceAccountName: hello-controller

--- a/examples/kubernetes/hello_kubernetes_job/manifests/volcano_workers.yaml
+++ b/examples/kubernetes/hello_kubernetes_job/manifests/volcano_workers.yaml
@@ -23,7 +23,7 @@ spec:
       spec:
         containers:
         - name: worker
-          image: ghcr.io/meta-pytorch/monarch:2026-01-11-alpha
+          image: ghcr.io/meta-pytorch/monarch:latest
           # TODO: use worker.py when it's available
           command:
             - python
@@ -64,7 +64,7 @@ spec:
       spec:
         containers:
         - name: worker
-          image: ghcr.io/meta-pytorch/monarch:2026-01-11-alpha
+          image: ghcr.io/meta-pytorch/monarch:latest
           # TODO: use worker.py when it's available
           command:
             - python


### PR DESCRIPTION
Summary:
Some of the examples were using an old one-off docker image instead of the new stable
images. Update these to use the latest stable image.

Differential Revision: D92540882


