### PR TITLE
Add `Unordered` variant to SeqInfo

### DIFF
--- a/hyperactor/src/actor.rs
+++ b/hyperactor/src/actor.rs
@@ -1185,31 +1185,45 @@ mod tests {
         let (tx, mut rx) = client.open_port();
 
         let actor_handle = proc.spawn("get_seq", GetSeqActor(tx.bind())).unwrap();
+
+        // Verify that unbound handle can send message.
+        actor_handle.send(&client, "unbound".to_string()).unwrap();
+        assert_eq!(
+            rx.recv().await.unwrap(),
+            ("unbound".to_string(), SeqInfo::Direct)
+        );
+
         let actor_ref: ActorRef<GetSeqActor> = actor_handle.bind();
 
         let session_id = client.sequencer().session_id();
         let mut expected_seq = 0;
         // Interleave messages sent through the handle and the reference.
-        for _ in 0..10 {
-            actor_handle.send(&client, "".to_string()).unwrap();
+        for m in 0..10 {
+            actor_handle.send(&client, format!("{m}")).unwrap();
             expected_seq += 1;
             assert_eq!(
-                rx.recv().await.unwrap().1,
-                SeqInfo {
-                    session_id,
-                    seq: expected_seq,
-                }
-            );
-
-            for _ in 0..2 {
-                actor_ref.port().send(&client, "".to_string()).unwrap();
-                expected_seq += 1;
-                assert_eq!(
-                    rx.recv().await.unwrap().1,
-                    SeqInfo {
+                rx.recv().await.unwrap(),
+                (
+                    format!("{m}"),
+                    SeqInfo::Session {
                         session_id,
                         seq: expected_seq,
                     }
+                )
+            );
+
+            for n in 0..2 {
+                actor_ref.port().send(&client, format!("{m}-{n}")).unwrap();
+                expected_seq += 1;
+                assert_eq!(
+                    rx.recv().await.unwrap(),
+                    (
+                        format!("{m}-{n}"),
+                        SeqInfo::Session {
+                            session_id,
+                            seq: expected_seq,
+                        }
+                    )
                 );
             }
         }
@@ -1252,42 +1266,42 @@ mod tests {
         actor_handle.send(&client, "msg1".to_string()).unwrap();
         assert_eq!(
             actor_rx.recv().await.unwrap().1,
-            SeqInfo { session_id, seq: 1 }
+            SeqInfo::Session { session_id, seq: 1 }
         );
 
         // Send to actor ports via ActorRef - seq 2 (shared with ActorHandle)
         actor_ref.port().send(&client, "msg2".to_string()).unwrap();
         assert_eq!(
             actor_rx.recv().await.unwrap().1,
-            SeqInfo { session_id, seq: 2 }
+            SeqInfo::Session { session_id, seq: 2 }
         );
 
         // Send to non-actor port - has its own sequence starting at 1
         non_actor_port_handle.send(&client, ()).unwrap();
         assert_eq!(
             non_actor_rx.recv().await.unwrap(),
-            Some(SeqInfo { session_id, seq: 1 })
+            Some(SeqInfo::Session { session_id, seq: 1 })
         );
 
         // Send more to actor ports via ActorHandle - seq continues at 3
         actor_handle.send(&client, "msg3".to_string()).unwrap();
         assert_eq!(
             actor_rx.recv().await.unwrap().1,
-            SeqInfo { session_id, seq: 3 }
+            SeqInfo::Session { session_id, seq: 3 }
         );
 
         // Send more to non-actor port - its sequence continues at 2
         non_actor_port_handle.send(&client, ()).unwrap();
         assert_eq!(
             non_actor_rx.recv().await.unwrap(),
-            Some(SeqInfo { session_id, seq: 2 })
+            Some(SeqInfo::Session { session_id, seq: 2 })
         );
 
         // Send via ActorRef again - seq 4
         actor_ref.port().send(&client, "msg4".to_string()).unwrap();
         assert_eq!(
             actor_rx.recv().await.unwrap().1,
-            SeqInfo { session_id, seq: 4 }
+            SeqInfo::Session { session_id, seq: 4 }
         );
 
         actor_handle.drain_and_stop("test cleanup").unwrap();
@@ -1316,7 +1330,7 @@ mod tests {
         actor_handle.send(&client1, "c1_msg1".to_string()).unwrap();
         assert_eq!(
             rx.recv().await.unwrap().1,
-            SeqInfo {
+            SeqInfo::Session {
                 session_id: session_id_1,
                 seq: 1
             }
@@ -1326,7 +1340,7 @@ mod tests {
         actor_handle.send(&client2, "c2_msg1".to_string()).unwrap();
         assert_eq!(
             rx.recv().await.unwrap().1,
-            SeqInfo {
+            SeqInfo::Session {
                 session_id: session_id_2,
                 seq: 1
             }
@@ -1339,7 +1353,7 @@ mod tests {
             .unwrap();
         assert_eq!(
             rx.recv().await.unwrap().1,
-            SeqInfo {
+            SeqInfo::Session {
                 session_id: session_id_1,
                 seq: 2
             }
@@ -1352,7 +1366,7 @@ mod tests {
             .unwrap();
         assert_eq!(
             rx.recv().await.unwrap().1,
-            SeqInfo {
+            SeqInfo::Session {
                 session_id: session_id_2,
                 seq: 2
             }
@@ -1362,7 +1376,7 @@ mod tests {
         actor_handle.send(&client1, "c1_msg3".to_string()).unwrap();
         assert_eq!(
             rx.recv().await.unwrap().1,
-            SeqInfo {
+            SeqInfo::Session {
                 session_id: session_id_1,
                 seq: 3
             }
@@ -1374,7 +1388,7 @@ mod tests {
             .unwrap();
         assert_eq!(
             rx.recv().await.unwrap().1,
-            SeqInfo {
+            SeqInfo::Session {
                 session_id: session_id_2,
                 seq: 3
             }
@@ -1430,7 +1444,10 @@ mod tests {
         // passing this assert means GetSeqActor processed the 2nd message.
         assert_eq!(
             rx.recv().await.unwrap(),
-            ("finally".to_string(), SeqInfo { session_id, seq: 1 })
+            (
+                "finally".to_string(),
+                SeqInfo::Session { session_id, seq: 1 }
+            )
         );
     }
 
@@ -1463,7 +1480,10 @@ mod tests {
                 }
 
                 for m in buffer.clone() {
-                    let seq = m.headers().get(SEQ_INFO).expect("seq should be set").seq as usize;
+                    let seq = match m.headers().get(SEQ_INFO).expect("seq should be set") {
+                        SeqInfo::Session { seq, .. } => *seq as usize,
+                        SeqInfo::Direct => panic!("expected Session variant"),
+                    };
                     // seq no is one-based.
                     let order = relay_orders[seq - 1];
                     buffer[order] = m;
@@ -1512,7 +1532,7 @@ mod tests {
         for expect in expected {
             let expected = (
                 expect.0,
-                SeqInfo {
+                SeqInfo::Session {
                     session_id,
                     seq: expect.1,
                 },

--- a/hyperactor/src/mailbox.rs
+++ b/hyperactor/src/mailbox.rs
@@ -69,8 +69,6 @@
 //! implementation to avoid a serialization roundtrip when passing
 //! messages locally.
 
-#![allow(dead_code)] // Allow until this is used outside of tests.
-
 use std::any::Any;
 use std::collections::BTreeMap;
 use std::collections::BTreeSet;
@@ -128,6 +126,7 @@ use crate::context;
 use crate::id;
 use crate::metrics;
 use crate::ordering::SEQ_INFO;
+use crate::ordering::SeqInfo;
 use crate::reference::ActorId;
 use crate::reference::PortId;
 use crate::reference::Reference;
@@ -599,6 +598,7 @@ impl PortLocation {
         PortLocation::Unbound(actor_id, std::any::type_name::<M>())
     }
 
+    #[allow(dead_code)]
     fn new_unbound_type(actor_id: ActorId, ty: &'static str) -> Self {
         PortLocation::Unbound(actor_id, ty)
     }
@@ -843,6 +843,7 @@ impl MailboxSender for UndeliverableMailboxSender {
 
 struct Buffer<T: Message> {
     queue: mpsc::UnboundedSender<(T, PortHandle<Undeliverable<T>>)>,
+    #[allow(dead_code)]
     processed: watch::Receiver<usize>,
     seq: AtomicUsize,
 }
@@ -881,6 +882,7 @@ impl<T: Message> Buffer<T> {
         Ok(())
     }
 
+    #[allow(dead_code)]
     async fn flush(&mut self) -> Result<(), watch::error::RecvError> {
         let seq = self.seq.load(Ordering::SeqCst);
         while *self.processed.borrow_and_update() < seq {
@@ -1434,6 +1436,7 @@ impl Mailbox {
         )
     }
 
+    #[allow(dead_code)]
     fn error(&self, err: MailboxErrorKind) -> MailboxError {
         MailboxError::new(self.inner.actor_id.clone(), err)
     }
@@ -1756,6 +1759,12 @@ impl<M: Message> PortHandle<M> {
             let sequencer = cx.instance().sequencer();
             let seq_info = sequencer.assign_seq(bound_port);
             headers.set(SEQ_INFO, seq_info);
+        } else {
+            // Because the port is not bound, messages can only be sent through
+            // this port handle's underlying tokio channel directly. As a result,
+            // we do not need to assign seq to the message. We do not need to
+            // worry about race condition due to bound_guard.
+            headers.set(SEQ_INFO, SeqInfo::Direct);
         }
         // Encountering error means the port is closed. So we do not need to
         // rollback the seq, because no message can be delivered to it, and
@@ -2150,6 +2159,7 @@ impl<M: Message> UnboundedSender<M> {
         Self { sender, port_id }
     }
 
+    #[allow(dead_code)]
     fn send(&self, headers: Attrs, message: M) -> Result<(), MailboxSenderError> {
         self.sender.send(headers, message).map_err(|err| {
             MailboxSenderError::new_bound(self.port_id.clone(), MailboxSenderErrorKind::Other(err))
@@ -2419,6 +2429,7 @@ impl MailboxMuxer {
     /// Unbind the sender associated with the provided actor ID. After
     /// unbinding, the muxer will no longer be able to send messages to
     /// that actor.
+    #[allow(dead_code)]
     pub(crate) fn unbind(&self, actor_id: &ActorId) {
         self.mailboxes.remove(actor_id);
     }

--- a/hyperactor_mesh/src/comm.rs
+++ b/hyperactor_mesh/src/comm.rs
@@ -563,7 +563,7 @@ impl Handler<ForwardMessageV1> for CommActor {
                 .expect("mismatched seqs and dest_region");
             headers.set(
                 SEQ_INFO,
-                SeqInfo {
+                SeqInfo::Session {
                     session_id: message.session_id,
                     seq,
                 },

--- a/hyperactor_mesh/src/v1/testactor.rs
+++ b/hyperactor_mesh/src/v1/testactor.rs
@@ -476,7 +476,7 @@ pub async fn assert_casting_correctness(
             .iter()
             .zip(
                 seqs.into_iter()
-                    .map(|seq| Some(SeqInfo { session_id, seq })),
+                    .map(|seq| Some(SeqInfo::Session { session_id, seq })),
             )
             .collect(),
     };


### PR DESCRIPTION
Summary:
In D82537988, I added a new config `ENABLE_DEST_ACTOR_REORDERING_BUFFER` to fail-close the SEQ_INFO header requirement. But I realize there are a couple of places where we do assign seq no, yet the messages are still sent to actor handlers.

This diff makes `SeqInfo` an enum, and add an `Unordered` variant to cover those places. In this way, all messages sent to actor handlers will have the `SEQ_INFO` header set and we can subsequently fail-close there.

Differential Revision: D83839619


