### PR TITLE
Update to Rust 1.93

### DIFF
--- a/MONARCH_INFO.md
+++ b/MONARCH_INFO.md
@@ -327,7 +327,7 @@ Default pytest timeout is 5 minutes (configured in `pyproject.toml`).
 - `setup.py` - Build configuration, extension definitions, environment detection
 - `Cargo.toml` - Rust workspace definition
 - `.cargo/config.toml` - Rust build flags (`tracing_unstable`)
-- `rust-toolchain` - Pinned to `nightly-2025-10-25`
+- `rust-toolchain` - Pinned to `nightly-2025-12-05`
 - `.flake8` - Python linting configuration (max-line-length: 256)
 - `docs/source/conf.py` - Sphinx documentation configuration
 

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,3 +1,3 @@
-# @rustc_version: rustc 1.92.0-nightly (2aaa62b89 2025-10-24)
+# @rustc_version: rustc 1.93.0-nightly (b33119ffd 2025-12-04)
 [toolchain]
-channel = "nightly-2025-10-25"
+channel = "nightly-2025-12-05"

--- a/serde_multipart/src/lib.rs
+++ b/serde_multipart/src/lib.rs
@@ -28,7 +28,6 @@
 
 #![feature(min_specialization)]
 #![feature(assert_matches)]
-#![feature(vec_deque_pop_if)]
 
 use std::cell::UnsafeCell;
 use std::cmp::min;


### PR DESCRIPTION
Summary:
Release notes: https://blog.rust-lang.org/2026/01/22/Rust-1.93.0/

- Stabilized features:
    - `feature(maybe_uninit_slice)`
    - `feature(maybe_uninit_write_slice)`
    - `feature(vec_deque_pop_if)`
    - `feature(vec_into_raw_parts)`

- Changes to `feature(try_blocks)` desugaring and return type inference

- Unstable `Cow::is_borrowed` changed from method to associated function

- Clippy lint rename: `clippy::empty_enum` to `clippy::empty_enums`

- New warning on function pointers cast to integer

- New warning on null pointer dereference

Reviewed By: diliop

Differential Revision: D92551155


