### PR TITLE
Remove fake_in_process_host and replace with this_host

### DIFF
--- a/python/monarch/_src/actor/host_mesh.py
+++ b/python/monarch/_src/actor/host_mesh.py
@@ -344,21 +344,6 @@ class HostMesh(MeshTrait):
         return Future(coro=task())
 
 
-def fake_in_process_host() -> "HostMesh":
-    """
-    Create a host mesh for testing and development using a local allocator.
-
-    Returns:
-        HostMesh: A host mesh configured with local allocation for in-process use.
-    """
-    return HostMesh.allocate_nonblocking(
-        "fake_host",
-        Extent([], []),
-        LocalAllocator(),
-        bootstrap_cmd=_bootstrap_cmd(),
-    )
-
-
 def hosts_from_config(name: str) -> HostMesh:
     """
     Get the host mesh 'name' from the monarch configuration for the project.

--- a/python/monarch/_src/actor/proc_mesh.py
+++ b/python/monarch/_src/actor/proc_mesh.py
@@ -954,13 +954,13 @@ def local_proc_mesh(*, gpus: Optional[int] = None, hosts: int = 1) -> ProcMesh:
         ProcMesh: A locally allocated process mesh.
 
     Warning:
-        This function is deprecated. Use `fake_in_process_host().spawn_procs()`
+        This function is deprecated. Use `this_host().spawn_procs()`
         for testing or `this_proc().spawn_procs()` for current process actors.
     """
     warnings.warn(
         (
             "DEPRECATION WARNING: this function will soon be unsupported. "
-            "Use monarch._src.actor.host_mesh.fake_in_process_host().spawn_procs "
+            "Use this_host().spawn_procs(per_host = {'hosts': ..., 'gpus': ...}) "
             "for testing. For launching an actor in the current process use "
             "this_proc().spawn_procs()."
         ),
@@ -968,9 +968,9 @@ def local_proc_mesh(*, gpus: Optional[int] = None, hosts: int = 1) -> ProcMesh:
         stacklevel=2,
     )
 
-    from monarch._src.actor.host_mesh import fake_in_process_host
+    from monarch._src.actor.host_mesh import this_host
 
-    return fake_in_process_host().spawn_procs(
+    return this_host().spawn_procs(
         per_host={"hosts": hosts, "gpus": gpus if gpus else _local_device_count()},
     )
 

--- a/python/tests/test_cuda.py
+++ b/python/tests/test_cuda.py
@@ -15,7 +15,7 @@ import cloudpickle
 import torch
 import torch.distributed as dist
 from monarch._src.actor.actor_mesh import ActorMesh
-from monarch._src.actor.host_mesh import create_local_host_mesh, fake_in_process_host
+from monarch._src.actor.host_mesh import create_local_host_mesh
 from monarch.actor import Actor, current_rank, current_size, endpoint, this_host
 
 
@@ -108,7 +108,7 @@ class TestEnvBeforeCuda(unittest.IsolatedAsyncioTestCase):
             for name, value in cuda_env_vars.items():
                 os.environ[name] = value
 
-        proc_mesh = fake_in_process_host().spawn_procs(bootstrap=setup_cuda_env)
+        proc_mesh = this_host().spawn_procs(bootstrap=setup_cuda_env)
 
         try:
             actor = proc_mesh.spawn("cuda_init", CudaInitTestActor)

--- a/python/tests/test_host_mesh.py
+++ b/python/tests/test_host_mesh.py
@@ -17,25 +17,9 @@ import pytest
 from monarch._rust_bindings.monarch_hyperactor.shape import Extent, Shape, Slice
 from monarch._src.actor.actor_mesh import _client_context, Actor, context
 from monarch._src.actor.endpoint import endpoint
-from monarch._src.actor.host_mesh import (
-    create_local_host_mesh,
-    fake_in_process_host,
-    HostMesh,
-    this_host,
-)
+from monarch._src.actor.host_mesh import create_local_host_mesh, HostMesh, this_host
 from monarch._src.actor.pickle import flatten, unflatten
 from monarch._src.actor.proc_mesh import get_or_spawn_controller
-
-
-@pytest.mark.timeout(60)
-def test_fake_in_process_host() -> None:
-    host = fake_in_process_host()
-    assert host.extent.labels == []
-    assert host.extent.sizes == []
-    assert not host.stream_logs
-    hy_host = host._hy_host_mesh.block_on()
-    assert hy_host.region.labels == host.region.labels
-    assert hy_host.region.slice() == host.region.slice()
 
 
 @pytest.mark.timeout(60)
@@ -166,7 +150,6 @@ class PidActor(Actor):
 @pytest.mark.timeout(60)
 def test_this_host_on_client_can_spawn_actual_os_processes() -> None:
     hm = this_host()
-    assert not hm.is_fake_in_process
     am = hm.spawn_procs(per_host={"gpus": 4}).spawn("actor", PidActor)
     pids = am.get_pid.call().get()
     for pid in pids.values():

--- a/python/tests/test_proc_mesh.py
+++ b/python/tests/test_proc_mesh.py
@@ -13,7 +13,6 @@ from typing import cast
 from unittest.mock import MagicMock, patch
 
 import cloudpickle
-import monarch._src.actor.host_mesh
 import monarch.actor
 import pytest
 from monarch._rust_bindings.monarch_hyperactor.alloc import AllocConstraints, AllocSpec
@@ -303,9 +302,6 @@ def test_root_client_does_not_leak_proc_meshes() -> None:
     orig_get_client_context = _client_context.get
     with (
         patch.object(_client_context, "get") as mock_get_client_context,
-        patch.object(
-            monarch._src.actor.host_mesh, "fake_in_process_host"
-        ) as mock_fake_in_process_host,
     ):
         mock_get_client_context.side_effect = orig_get_client_context
 
@@ -323,11 +319,6 @@ def test_root_client_does_not_leak_proc_meshes() -> None:
             t.join()
 
         assert mock_get_client_context.call_count == 100
-        # If this test is run in isolation, the local host mesh will
-        # be created once. But if it runs with other tests, the host mesh
-        # will have already been initialized and the function never gets
-        # called.
-        assert mock_fake_in_process_host.call_count in (0, 1)
 
 
 @pytest.mark.timeout(60)

--- a/python/tests/test_python_actors.py
+++ b/python/tests/test_python_actors.py
@@ -48,7 +48,6 @@ from monarch._src.actor.future import Future
 from monarch._src.actor.host_mesh import (
     _bootstrap_cmd,
     create_local_host_mesh,
-    fake_in_process_host,
     HostMesh,
     this_host,
     this_proc,
@@ -105,7 +104,7 @@ class Indirect(Actor):
 @pytest.mark.timeout(60)
 @parametrize_config(actor_queue_dispatch={True, False})
 async def test_choose():
-    proc = fake_in_process_host().spawn_procs(per_host={"gpus": 2})
+    proc = this_host().spawn_procs(per_host={"gpus": 2})
     v = proc.spawn("counter", Counter, 3)
     i = proc.spawn("indirect", Indirect)
     v.incr.broadcast()
@@ -126,7 +125,7 @@ async def test_choose():
 @pytest.mark.timeout(60)
 @parametrize_config(actor_queue_dispatch={True, False})
 async def test_stream():
-    proc = fake_in_process_host().spawn_procs(per_host={"gpus": 2})
+    proc = this_host().spawn_procs(per_host={"gpus": 2})
     v = proc.spawn("counter2", Counter, 3)
     v.incr.broadcast()
 
@@ -148,7 +147,7 @@ class From(Actor):
 @pytest.mark.timeout(60)
 @parametrize_config(actor_queue_dispatch={True, False})
 async def test_mesh_passed_to_mesh():
-    proc = fake_in_process_host().spawn_procs(per_host={"gpus": 2})
+    proc = this_host().spawn_procs(per_host={"gpus": 2})
     f = proc.spawn("from", From)
     t = proc.spawn("to", To)
     # Make sure t is initialized before sending to f. Otherwise
@@ -162,8 +161,8 @@ async def test_mesh_passed_to_mesh():
 @pytest.mark.timeout(60)
 @parametrize_config(actor_queue_dispatch={True, False})
 async def test_mesh_passed_to_mesh_on_different_proc_mesh():
-    proc = fake_in_process_host().spawn_procs(per_host={"gpus": 2})
-    proc2 = fake_in_process_host().spawn_procs(per_host={"gpus": 2})
+    proc = this_host().spawn_procs(per_host={"gpus": 2})
+    proc2 = this_host().spawn_procs(per_host={"gpus": 2})
     f = proc.spawn("from", From)
     t = proc2.spawn("to", To)
     # Make sure t is initialized before sending to f. Otherwise
@@ -177,8 +176,8 @@ async def test_mesh_passed_to_mesh_on_different_proc_mesh():
 @pytest.mark.timeout(60)
 @parametrize_config(actor_queue_dispatch={True, False})
 def test_actor_slicing():
-    proc = fake_in_process_host().spawn_procs(per_host={"gpus": 2})
-    proc2 = fake_in_process_host().spawn_procs(per_host={"gpus": 2})
+    proc = this_host().spawn_procs(per_host={"gpus": 2})
+    proc2 = this_host().spawn_procs(per_host={"gpus": 2})
 
     f = proc.spawn("from", From)
     t = proc2.spawn("to", To)
@@ -194,7 +193,7 @@ def test_actor_slicing():
 @pytest.mark.timeout(60)
 @parametrize_config(actor_queue_dispatch={True, False})
 async def test_aggregate():
-    proc = fake_in_process_host().spawn_procs(per_host={"gpus": 2})
+    proc = this_host().spawn_procs(per_host={"gpus": 2})
     counter = proc.spawn("counter", Counter, 1)
     counter.incr.broadcast()
     acc = Accumulator(counter.value, 0, operator.add)
@@ -215,7 +214,7 @@ class RunIt(Actor):
 @pytest.mark.timeout(60)
 @parametrize_config(actor_queue_dispatch={True, False})
 async def test_rank_size():
-    proc = fake_in_process_host().spawn_procs(per_host={"gpus": 2})
+    proc = this_host().spawn_procs(per_host={"gpus": 2})
     r = proc.spawn("runit", RunIt)
 
     acc = Accumulator(r.run, 0, operator.add)
@@ -228,7 +227,7 @@ async def test_rank_size():
 @parametrize_config(actor_queue_dispatch={True, False})
 async def test_rank_string():
     per_host = {"hosts": 1, "gpus": 2}
-    proc = fake_in_process_host().spawn_procs(per_host=per_host)
+    proc = this_host().spawn_procs(per_host=per_host)
     r = proc.spawn("runit", RunIt)
     vm = r.return_current_rank_str.call().get()
     r0 = vm.flatten("r").slice(r=0).item()
@@ -246,7 +245,7 @@ class SyncActor(Actor):
 @pytest.mark.timeout(60)
 @parametrize_config(actor_queue_dispatch={True, False})
 async def test_sync_actor():
-    proc = fake_in_process_host().spawn_procs(per_host={"gpus": 2})
+    proc = this_host().spawn_procs(per_host={"gpus": 2})
     a = proc.spawn("actor", SyncActor)
     c = proc.spawn("counter", Counter, 5)
     r = await a.sync_endpoint.choose(c)
@@ -256,7 +255,7 @@ async def test_sync_actor():
 @pytest.mark.timeout(60)
 @parametrize_config(actor_queue_dispatch={True, False})
 def test_sync_actor_sync_client() -> None:
-    proc = fake_in_process_host().spawn_procs(per_host={"gpus": 2})
+    proc = this_host().spawn_procs(per_host={"gpus": 2})
     a = proc.spawn("actor", SyncActor)
     c = proc.spawn("counter", Counter, 5)
     r = a.sync_endpoint.choose(c).get()
@@ -266,14 +265,14 @@ def test_sync_actor_sync_client() -> None:
 @pytest.mark.timeout(60)
 @parametrize_config(actor_queue_dispatch={True, False})
 def test_proc_mesh_size() -> None:
-    proc = fake_in_process_host().spawn_procs(per_host={"gpus": 2})
+    proc = this_host().spawn_procs(per_host={"gpus": 2})
     assert 2 == proc.size("gpus")
 
 
 @pytest.mark.timeout(60)
 @parametrize_config(actor_queue_dispatch={True, False})
 def test_rank_size_sync() -> None:
-    proc = fake_in_process_host().spawn_procs(per_host={"gpus": 2})
+    proc = this_host().spawn_procs(per_host={"gpus": 2})
     r = proc.spawn("runit", RunIt)
 
     acc = Accumulator(r.run, 0, operator.add)
@@ -284,7 +283,7 @@ def test_rank_size_sync() -> None:
 @pytest.mark.timeout(60)
 @parametrize_config(actor_queue_dispatch={True, False})
 def test_accumulate_sync() -> None:
-    proc = fake_in_process_host().spawn_procs(per_host={"gpus": 2})
+    proc = this_host().spawn_procs(per_host={"gpus": 2})
     counter = proc.spawn("counter", Counter, 1)
     counter.incr.broadcast()
     acc = Accumulator(counter.value, 0, operator.add)
@@ -302,7 +301,7 @@ class CastToCounter(Actor):
 @parametrize_config(actor_queue_dispatch={True, False})
 def test_value_mesh() -> None:
     per_host = {"hosts": 1, "gpus": 2}
-    proc = fake_in_process_host().spawn_procs(per_host=per_host)
+    proc = this_host().spawn_procs(per_host=per_host)
     counter = proc.spawn("counter", Counter, 0)
     counter.slice(hosts=0, gpus=1).incr.broadcast()
     x = counter.value.call().get()
@@ -1142,7 +1141,7 @@ class SendAlot(Actor):
 @pytest.mark.timeout(60)
 @parametrize_config(actor_queue_dispatch={True, False})
 def test_port_as_argument() -> None:
-    proc_mesh = fake_in_process_host().spawn_procs(per_host={"gpus": 1})
+    proc_mesh = this_host().spawn_procs(per_host={"gpus": 1})
     s = proc_mesh.spawn("send_alot", SendAlot)
     send, recv = Channel[int].open()
 
@@ -1223,7 +1222,7 @@ class PortedActor(Actor):
 @pytest.mark.timeout(60)
 @parametrize_config(actor_queue_dispatch={True, False})
 def test_ported_actor():
-    proc_mesh = fake_in_process_host().spawn_procs(per_host={"gpus": 1})
+    proc_mesh = this_host().spawn_procs(per_host={"gpus": 1})
     a = proc_mesh.spawn("port_actor", PortedActor)
     assert 5 == a.add.call_one(2).get()
 
@@ -1266,7 +1265,7 @@ class SleepActor(Actor):
 
 @parametrize_config(actor_queue_dispatch={True, False})
 def test_mesh_len():
-    proc_mesh = fake_in_process_host().spawn_procs(per_host={"gpus": 12})
+    proc_mesh = this_host().spawn_procs(per_host={"gpus": 12})
     s = proc_mesh.spawn("sleep_actor", SleepActor)
     assert 12 == len(s)
 


### PR DESCRIPTION
Summary:
Replace all usages of `fake_in_process_host()` with `this_host()` in tests,
examples, and documentation. The `fake_in_process_host` API used a
`LocalAllocator` to run actors in-process, while `this_host` uses
`ProcessAllocator` to spawn real OS subprocesses. The `this_host` API is now
the canonical way to obtain a host mesh for both production and testing.

Changes:
- Delete `fake_in_process_host()` from `host_mesh.py`
- Update `local_proc_mesh()` in `proc_mesh.py` to delegate to `this_host()`
- Replace all test usages across `test_python_actors.py`, `test_host_mesh.py`,
  `test_actor_error.py`, `test_proc_mesh.py`, `test_cuda.py`
- Update `test_paft_manager.py` example to use `this_host()` unconditionally
- Update bootstrapping documentation to match current `_init_client_context()`
  implementation which uses `bootstrap_host()` from Rust

The `is_fake_in_process` flag and `LocalAllocator` are left in place for now.

Differential Revision: D92617766


