### PR TITLE
bugfix dining philosophers

### DIFF
--- a/hyperactor_mesh/examples/dining_philosophers.rs
+++ b/hyperactor_mesh/examples/dining_philosophers.rs
@@ -151,10 +151,10 @@ impl Handler<PhilosopherMessage> for PhilosopherActor {
         match message {
             PhilosopherMessage::Start(waiter) => {
                 self.waiter.set(waiter)?;
-                self.request_chopsticks(cx).await?;
-                // Start is always broadcasted to all philosophers; so this is
-                // our global rank.
+                // Set rank before requesting chopsticks so we request
+                // the correct pair and identify ourselves properly.
                 self.rank = point.rank();
+                self.request_chopsticks(cx).await?;
             }
             PhilosopherMessage::GrantChopstick(chopstick) => {
                 tracing::debug!("philosopher {} granted chopstick {}", self.rank, chopstick);


### PR DESCRIPTION
Summary: moves initialization of the philosopher’s rank ahead of the first chopstick request in the `Start handler`. previously, `request_chopsticks` could run before `self.rank` was set, causing the philosopher to compute its chopstick pair using an uninitialized/default rank. the new ordering ensures the rank derived from the mesh point is established first, so the initial request targets the correct chopsticks and logs/reporting use the correct identity.

Differential Revision: D92630260


