### PR TITLE
python/tests: bump timeout on test_supervise_callback_without_await_handled

### DIFF
--- a/python/tests/test_actor_error.py
+++ b/python/tests/test_actor_error.py
@@ -1291,7 +1291,7 @@ async def test_supervise_callback_handled():
     await pm.stop()
 
 
-@pytest.mark.timeout(60)
+@pytest.mark.timeout(120)
 @parametrize_config(actor_queue_dispatch={True, False})
 async def test_supervise_callback_without_await_handled():
     pm = spawn_procs_on_this_host({"gpus": 4})


### PR DESCRIPTION
Summary: increase timeout to reduce flakiness per oncall meeting discussion

Reviewed By: dulinriley

Differential Revision: D92734537


