### PR TITLE
Atomic PythonActor spawn + init message

### DIFF
--- a/monarch_hyperactor/src/actor.rs
+++ b/monarch_hyperactor/src/actor.rs
@@ -35,12 +35,15 @@ use hyperactor::message::Unbind;
 use hyperactor::supervision::ActorSupervisionEvent;
 use hyperactor_config::Flattrs;
 use hyperactor_mesh::casting::update_undeliverable_envelope_for_casting;
+use hyperactor_mesh::comm::multicast::CAST_POINT;
 use hyperactor_mesh::comm::multicast::CastInfo;
 use hyperactor_mesh::router;
 use hyperactor_mesh::supervision::MeshFailure;
 use hyperactor_mesh::transport::default_bind_spec;
 use monarch_types::PickledPyObject;
 use monarch_types::SerializablePyErr;
+use ndslice::Point;
+use ndslice::extent;
 use pyo3::IntoPyObjectExt;
 use pyo3::exceptions::PyBaseException;
 use pyo3::exceptions::PyRuntimeError;
@@ -446,10 +449,18 @@ pub struct PythonActor {
     instance: Option<Py<crate::context::PyInstance>>,
     /// Dispatch mode for this actor.
     dispatch_mode: PythonActorDispatchMode,
+    /// The location in the actor mesh at which this actor was spawned.
+    spawn_point: OnceLock<Option<Point>>,
+    /// Initial message to process during PythonActor::init.
+    init_message: Option<PythonMessage>,
 }
 
 impl PythonActor {
-    pub(crate) fn new(actor_type: PickledPyObject) -> Result<Self, anyhow::Error> {
+    pub(crate) fn new(
+        actor_type: PickledPyObject,
+        init_message: Option<PythonMessage>,
+        spawn_point: Option<Point>,
+    ) -> Result<Self, anyhow::Error> {
         let use_queue_dispatch = hyperactor_config::global::get(ACTOR_QUEUE_DISPATCH);
 
         Ok(monarch_with_gil_blocking(
@@ -480,6 +491,8 @@ impl PythonActor {
                     task_locals,
                     instance: None,
                     dispatch_mode,
+                    spawn_point: OnceLock::from(spawn_point),
+                    init_message,
                 })
             },
         )?)
@@ -529,9 +542,26 @@ impl PythonActor {
             .getattr("RootClientActor")
             .expect("get RootClientActor");
 
-        let mut actor = PythonActor::new(
+        let actor_type =
             PickledPyObject::pickle(&actor_mesh_mod.getattr("_Actor").expect("get _Actor"))
-                .expect("pickle _Actor"),
+                .expect("pickle _Actor");
+
+        let init_message = PythonMessage::new(
+            PythonMessageKind::CallMethod {
+                name: MethodSpecifier::Init {},
+                response_port: None,
+            },
+            root_client_class
+                .call_method0("_pickled_init_args")
+                .expect("call RootClientActor._pickled_init_args"),
+            None,
+        )
+        .expect("create RootClientActor init message");
+
+        let mut actor = PythonActor::new(
+            actor_type,
+            Some(init_message),
+            Some(extent!().point_of_rank(0).unwrap()),
         )
         .expect("create client PythonActor");
 
@@ -551,22 +581,6 @@ impl PythonActor {
             .unwrap();
         let instance = root_client_instance.get().unwrap();
 
-        handle
-            .send(
-                instance,
-                PythonMessage::new(
-                    PythonMessageKind::CallMethod {
-                        name: MethodSpecifier::Init {},
-                        response_port: None,
-                    },
-                    root_client_class
-                        .call_method0("_pickled_init_args")
-                        .expect("call RootClientActor._pickled_init_args"),
-                    None,
-                )
-                .expect("create RootClientActor init message"),
-            )
-            .expect("initialize root client");
         // Bind to ensure the Signal and Undeliverable<MessageEnvelope> ports
         // are bound.
         let _client_ref = handle.bind::<PythonActor>();
@@ -704,62 +718,68 @@ pub(crate) fn root_client_actor(py: Python<'_>) -> &'static Instance<PythonActor
 #[async_trait]
 impl Actor for PythonActor {
     async fn init(&mut self, this: &Instance<Self>) -> Result<(), anyhow::Error> {
-        let PythonActorDispatchMode::Queue { receiver, .. } = &mut self.dispatch_mode else {
-            return Ok(());
-        };
+        if let PythonActorDispatchMode::Queue { receiver, .. } = &mut self.dispatch_mode {
+            let receiver = receiver.take().unwrap();
 
-        let receiver = receiver.take().unwrap();
+            // Create an error port that converts PythonMessage to an abort signal.
+            // This allows Python to send errors that trigger actor supervision.
+            let error_port: hyperactor::PortHandle<PythonMessage> =
+                this.port::<Signal>().contramap(|msg: PythonMessage| {
+                    monarch_with_gil_blocking(|py| {
+                        let err = match msg.kind {
+                            PythonMessageKind::Exception { .. } => {
+                                // Deserialize the error from the message
+                                let cloudpickle = py.import("cloudpickle").unwrap();
+                                let err_obj = cloudpickle
+                                    .call_method1("loads", (msg.message.to_bytes().as_ref(),))
+                                    .unwrap();
+                                let py_err = pyo3::PyErr::from_value(err_obj);
+                                SerializablePyErr::from(py, &py_err)
+                            }
+                            _ => {
+                                let py_err = PyRuntimeError::new_err(format!(
+                                    "expected Exception, got {:?}",
+                                    msg.kind
+                                ));
+                                SerializablePyErr::from(py, &py_err)
+                            }
+                        };
+                        Signal::Abort(err.to_string())
+                    })
+                });
 
-        // Create an error port that converts PythonMessage to an abort signal.
-        // This allows Python to send errors that trigger actor supervision.
-        let error_port: hyperactor::PortHandle<PythonMessage> =
-            this.port::<Signal>().contramap(|msg: PythonMessage| {
-                monarch_with_gil_blocking(|py| {
-                    let err = match msg.kind {
-                        PythonMessageKind::Exception { .. } => {
-                            // Deserialize the error from the message
-                            let cloudpickle = py.import("cloudpickle").unwrap();
-                            let err_obj = cloudpickle
-                                .call_method1("loads", (msg.message.to_bytes().as_ref(),))
-                                .unwrap();
-                            let py_err = pyo3::PyErr::from_value(err_obj);
-                            SerializablePyErr::from(py, &py_err)
-                        }
-                        _ => {
-                            let py_err = PyRuntimeError::new_err(format!(
-                                "expected Exception, got {:?}",
-                                msg.kind
-                            ));
-                            SerializablePyErr::from(py, &py_err)
-                        }
-                    };
-                    Signal::Abort(err.to_string())
-                })
-            });
+            let error_port_handle = PythonPortHandle::new(error_port);
 
-        let error_port_handle = PythonPortHandle::new(error_port);
+            monarch_with_gil(|py| {
+                let tl = self
+                    .task_locals
+                    .as_ref()
+                    .unwrap_or_else(|| shared_task_locals(py));
+                let awaitable = self.actor.call_method(
+                    py,
+                    "_dispatch_loop",
+                    (receiver, error_port_handle),
+                    None,
+                )?;
+                let future =
+                    pyo3_async_runtimes::into_future_with_locals(tl, awaitable.into_bound(py))?;
+                tokio::spawn(async move {
+                    if let Err(e) = future.await {
+                        tracing::error!("message loop error: {}", e);
+                    }
+                });
+                Ok::<_, anyhow::Error>(())
+            })
+            .await?;
+        }
 
-        monarch_with_gil(|py| {
-            let tl = self
-                .task_locals
-                .as_ref()
-                .unwrap_or_else(|| shared_task_locals(py));
-            let awaitable = self.actor.call_method(
-                py,
-                "_dispatch_loop",
-                (receiver, error_port_handle),
-                None,
-            )?;
-            let future =
-                pyo3_async_runtimes::into_future_with_locals(tl, awaitable.into_bound(py))?;
-            tokio::spawn(async move {
-                if let Err(e) = future.await {
-                    tracing::error!("message loop error: {}", e);
-                }
-            });
-            Ok::<_, anyhow::Error>(())
-        })
-        .await?;
+        if let Some(init_message) = self.init_message.take() {
+            let spawn_point = self.spawn_point.get().unwrap().as_ref().expect("PythonActor should never be spawned with init_message unless spawn_point also specified").clone();
+            let mut headers = Flattrs::new();
+            headers.set(CAST_POINT, spawn_point);
+            let cx = Context::new(this, headers);
+            <Self as Handler<PythonMessage>>::handle(self, &cx, init_message).await?;
+        }
 
         Ok(())
     }
@@ -919,15 +939,36 @@ impl Actor for PythonActor {
     }
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, Named)]
+pub struct PythonActorParams {
+    // The pickled actor class to instantiate.
+    actor_type: PickledPyObject,
+    // Python message to process as part of the actor initialization.
+    init_message: Option<PythonMessage>,
+}
+
+impl PythonActorParams {
+    pub(crate) fn new(actor_type: PickledPyObject, init_message: Option<PythonMessage>) -> Self {
+        Self {
+            actor_type,
+            init_message,
+        }
+    }
+}
+
 #[async_trait]
 impl RemoteSpawn for PythonActor {
-    type Params = PickledPyObject;
+    type Params = PythonActorParams;
 
     async fn new(
-        actor_type: PickledPyObject,
-        _environment: hyperactor_config::Flattrs,
+        PythonActorParams {
+            actor_type,
+            init_message,
+        }: PythonActorParams,
+        environment: Flattrs,
     ) -> Result<Self, anyhow::Error> {
-        Self::new(actor_type)
+        let spawn_point = environment.get(CAST_POINT);
+        Self::new(actor_type, init_message, spawn_point)
     }
 }
 

--- a/monarch_hyperactor/src/proc.rs
+++ b/monarch_hyperactor/src/proc.rs
@@ -110,7 +110,7 @@ impl PyProc {
             Ok(PythonActorHandle {
                 inner: proc.spawn(
                     name.as_deref().unwrap_or("anon"),
-                    PythonActor::new(pickled_type)?,
+                    PythonActor::new(pickled_type, None, None)?,
                 )?,
             })
         })
@@ -129,7 +129,7 @@ impl PyProc {
             inner: signal_safe_block_on(py, async move {
                 proc.spawn(
                     name.as_deref().unwrap_or("anon"),
-                    PythonActor::new(pickled_type)?,
+                    PythonActor::new(pickled_type, None, None)?,
                 )
             })
             .map_err(|e| PyRuntimeError::new_err(e.to_string()))??,

--- a/python/monarch/_rust_bindings/monarch_hyperactor/proc_mesh.pyi
+++ b/python/monarch/_rust_bindings/monarch_hyperactor/proc_mesh.pyi
@@ -9,7 +9,7 @@
 from typing import Any, final, Type, TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from monarch._rust_bindings.monarch_hyperactor.actor import Actor
+    from monarch._rust_bindings.monarch_hyperactor.actor import Actor, PythonMessage
 from monarch._rust_bindings.monarch_hyperactor.actor_mesh import PythonActorMesh
 from monarch._rust_bindings.monarch_hyperactor.alloc import Alloc
 from monarch._rust_bindings.monarch_hyperactor.context import Instance
@@ -33,31 +33,13 @@ class ProcMesh:
         """
         ...
 
-    def spawn_nonblocking(
-        self,
-        instance: Instance,
-        name: str,
-        actor: Any,
-        supervision_display_name: str | None = None,
-    ) -> PythonTask[PythonActorMesh]:
-        """
-        Spawn a new actor on this mesh.
-
-        Arguments:
-        - `instance`: The actor instance that will own the returned actor mesh.
-        - `name`: Name of the actor.
-        - `actor`: The type of the actor that will be spawned.
-        - `supervision_display_name`: The name of the actor to display in supervision. If not None, this
-            will be used instead of the fully qualified name of the actor.
-        """
-        ...
-
     @staticmethod
     def spawn_async(
         proc_mesh: Shared["ProcMesh"],
         instance: Instance,
         name: str,
         actor: Type["Actor"],
+        init_message: PythonMessage,
         emulated: bool,
         supervision_display_name: str | None = None,
     ) -> PythonActorMesh: ...

--- a/python/monarch/_src/actor/actor_mesh.py
+++ b/python/monarch/_src/actor/actor_mesh.py
@@ -49,7 +49,6 @@ from monarch._rust_bindings.monarch_hyperactor.actor import (
     PythonMessage,
     PythonMessageKind,
 )
-from monarch._rust_bindings.monarch_hyperactor.actor_mesh import PythonActorMesh
 from monarch._rust_bindings.monarch_hyperactor.buffers import Buffer, FrozenBuffer
 from monarch._rust_bindings.monarch_hyperactor.channel import BindSpec, ChannelTransport
 from monarch._rust_bindings.monarch_hyperactor.config import configure
@@ -1351,22 +1350,11 @@ class _Actor:
                     response_port = DroppingPort()
 
             if self.instance is None:
-                # This could happen because of the following reasons. Both
-                # indicates a possible bug in the framework:
-                # 1. the execution of the previous message for "__init__" failed,
-                #    but that error is not surfaced to the caller.
-                #      - TODO(T229200522): there is a known bug. fix it.
-                # 2. this message is delivered to this actor before the previous
-                #    message of "__init__" is delivered. Out-of-order delivery
-                #    should never happen. It indicates either a bug in the
-                #    message delivery mechanism, or the framework accidentally
-                #    mixed the usage of cast and direct send.
-
-                error_message = f'Actor object is missing when executing method "{method_name}" on actor {ctx.actor_instance.actor_id}.'
-                if self._saved_error is not None:
-                    error_message += (
-                        f" This is likely due to an earlier error: {self._saved_error}"
-                    )
+                assert self._saved_error is not None
+                error_message = (
+                    f'Actor object is missing when executing method "{method_name}" on actor {ctx.actor_instance.actor_id}. '
+                    f"This is due to an earlier error: {self._saved_error}."
+                )
                 raise AssertionError(error_message)
 
             the_method = getattr(self.instance, method_name)
@@ -1756,56 +1744,6 @@ class ActorMesh(MeshTrait, Generic[T]):
             impl,
             propagator,
         )
-
-    @classmethod
-    def _create(
-        cls,
-        Class: Type[T],
-        name: str,
-        actor_mesh: "PythonActorMesh",
-        shape: Shape,
-        proc_mesh: "ProcMesh",
-        controller_controller: Optional["_ControllerController"],
-        # args and kwargs are passed to the __init__ method of the user defined
-        # python actor object.
-        *args: Any,
-        **kwargs: Any,
-    ) -> "ActorMesh[T]":
-        mesh = cls(Class, name, actor_mesh, shape, proc_mesh)
-
-        # We don't start the supervision polling loop until the first call to
-        # supervision_event, which needs an Instance. Initialize here so events
-        # can be collected even without any endpoints being awaited.
-        instance = context().actor_instance
-        # Supervision display name is unused here now, it is set in ProcMesh::spawn.
-        mesh._inner.start_supervision(instance._as_rust(), "")
-
-        async def null_func(*_args: Iterable[Any], **_kwargs: Dict[str, Any]) -> None:
-            return None
-
-        # send __init__ message to the mesh to initialize the user defined
-        # python actor object.
-        ep = mesh._endpoint(
-            MethodSpecifier.Init(),
-            null_func,
-            None,
-        )
-        send(
-            ep,
-            (
-                ActorInitArgs(
-                    cast(Type[Actor], mesh._class),
-                    proc_mesh,
-                    controller_controller,
-                    name,
-                    context().actor_instance._as_creator(),
-                    args,
-                ),
-            ),
-            kwargs,
-        )
-
-        return mesh
 
     @classmethod
     def from_actor_id(

--- a/python/monarch/_src/actor/proc_mesh.py
+++ b/python/monarch/_src/actor/proc_mesh.py
@@ -476,33 +476,13 @@ class ProcMesh(MeshTrait):
         supervision_display_name = (
             f"{str(instance)}.<{Class.__module__}.{Class.__name__} {name}>"
         )
-        actor_mesh = HyProcMesh.spawn_async(
-            pm,
-            instance._as_rust(),
-            name,
-            _Actor,
-            emulated=False,
-            supervision_display_name=supervision_display_name,
-        )
-        # Inlined ActorMesh._create implementation
-        mesh = ActorMesh(Class, name, actor_mesh, self._region.as_shape(), self)
 
-        # We don't start the supervision polling loop until the first call to
-        # supervision_event, which needs an Instance. Initialize here so events
-        # can be collected even without any endpoints being awaited.
-        supervision_display_name = (
-            f"{str(instance)}.<{Class.__module__}.{Class.__name__} {name}>"
-        )
-        mesh._inner.start_supervision(instance._as_rust(), supervision_display_name)
-
-        # send __init__ message to the mesh to initialize the user defined
-        # python actor object.
-        message = _create_endpoint_message(
+        init_message = _create_endpoint_message(
             MethodSpecifier.Init(),
             inspect.signature(Class.__init__),
             (
                 ActorInitArgs(
-                    cast(Type[Actor], mesh._class),
+                    cast(Type[Actor], Class),
                     self,
                     self._controller_controller or instance._controller_controller,
                     name,
@@ -514,7 +494,26 @@ class ProcMesh(MeshTrait):
             None,
             self,
         )
-        mesh._inner.cast(message, "all", instance._as_rust())
+
+        actor_mesh = HyProcMesh.spawn_async(
+            pm,
+            instance._as_rust(),
+            name,
+            _Actor,
+            init_message,
+            emulated=False,
+            supervision_display_name=supervision_display_name,
+        )
+
+        mesh = ActorMesh(Class, name, actor_mesh, self._region.as_shape(), self)
+
+        # We don't start the supervision polling loop until the first call to
+        # supervision_event, which needs an Instance. Initialize here so events
+        # can be collected even without any endpoints being awaited.
+        supervision_display_name = (
+            f"{str(instance)}.<{Class.__module__}.{Class.__name__} {name}>"
+        )
+        mesh._inner.start_supervision(instance._as_rust(), supervision_display_name)
 
         instance._add_child(mesh)
         return cast(TActor, mesh)

--- a/python/tests/_monarch/test_actor_mesh.py
+++ b/python/tests/_monarch/test_actor_mesh.py
@@ -7,7 +7,7 @@
 # pyre-unsafe
 
 import pickle
-from typing import Any, Callable, cast, Coroutine, Iterable, List, TYPE_CHECKING
+from typing import Any, Callable, cast, Coroutine, Iterable, List, Type, TYPE_CHECKING
 
 import pytest
 from monarch._rust_bindings.monarch_hyperactor.actor import (
@@ -28,7 +28,7 @@ from monarch._src.actor.proc_mesh import _get_bootstrap_args
 
 
 if TYPE_CHECKING:
-    from monarch._rust_bindings.monarch_hyperactor.actor import PortProtocol
+    from monarch._rust_bindings.monarch_hyperactor.actor import Actor, PortProtocol
 
 from monarch._rust_bindings.monarch_hyperactor.host_mesh import (
     BootstrapCommand,
@@ -36,7 +36,7 @@ from monarch._rust_bindings.monarch_hyperactor.host_mesh import (
 )
 from monarch._rust_bindings.monarch_hyperactor.mailbox import PortReceiver
 from monarch._rust_bindings.monarch_hyperactor.proc_mesh import ProcMesh
-from monarch._rust_bindings.monarch_hyperactor.pytokio import PythonTask
+from monarch._rust_bindings.monarch_hyperactor.pytokio import PythonTask, Shared
 from monarch._src.actor.actor_mesh import Context, context, Instance
 
 
@@ -56,11 +56,13 @@ async def alloc() -> Alloc:
     return await allocator.allocate_nonblocking(spec)
 
 
-async def allocate() -> ProcMesh:
-    proc_mesh = await ProcMesh.allocate_nonblocking(
-        context().actor_instance._as_rust(), await alloc(), "proc_mesh"
-    )
-    return proc_mesh
+def allocate() -> Shared[ProcMesh]:
+    async def task() -> ProcMesh:
+        return await ProcMesh.allocate_nonblocking(
+            context().actor_instance._as_rust(), await alloc(), "proc_mesh"
+        )
+
+    return PythonTask.from_coroutine(task()).spawn()
 
 
 class MyActor:
@@ -84,7 +86,8 @@ class MyActor:
                 # Since this actor is spawn from the root proc mesh, the rank
                 # passed from init should be the rank on the root mesh.
                 self._rank_on_root_mesh = ctx.message_rank.rank
-                response_port.send(None)
+                if response_port is not None:
+                    response_port.send(None)
                 return None
             case MethodSpecifier.ReturnsResponse(name=_):
                 response_port.send(self._rank_on_root_mesh)
@@ -102,13 +105,24 @@ class MyActor:
 async def test_bind_and_pickling() -> None:
     @run_on_tokio
     async def run() -> None:
-        proc_mesh = await allocate()
-        actor_mesh = await proc_mesh.spawn_nonblocking(
-            context().actor_instance._as_rust(), "test", MyActor
-        )
+        proc_mesh_task = allocate()
+        actor_mesh = spawn_actor_mesh(proc_mesh_task)
+
+        # Need to make sure the mesh is initialized before pickling to
+        # prevent blocking the tokio runtime.
+        await actor_mesh.initialized()
+
         pickle.dumps(actor_mesh)
 
+        # Get the actual ProcMesh to access its region
+        proc_mesh = await proc_mesh_task
+
         actor_mesh_ref = actor_mesh.new_with_region(proc_mesh.region)
+
+        # Need to make sure the mesh is initialized before pickling to
+        # prevent blocking the tokio runtime.
+        await actor_mesh_ref.initialized()
+
         obj = pickle.dumps(actor_mesh_ref)
         pickle.loads(obj)
 
@@ -118,25 +132,22 @@ async def test_bind_and_pickling() -> None:
     run()
 
 
-async def spawn_actor_mesh(proc_mesh: ProcMesh) -> PythonActorMesh:
-    actor_mesh = await proc_mesh.spawn_nonblocking(
-        context().actor_instance._as_rust(), "test", MyActor
-    )
-    # init actors to record their root ranks
-    receiver: PortReceiver
-    instance = context().actor_instance
-    client = instance._mailbox
-    handle, receiver = client.open_port()
-    port_ref = handle.bind()
-
-    message = PythonMessage(
-        PythonMessageKind.CallMethod(MethodSpecifier.Init(), port_ref),
+def spawn_actor_mesh(proc_mesh_task: Shared[ProcMesh]) -> PythonActorMesh:
+    # Create an explicit init message
+    init_message = PythonMessage(
+        PythonMessageKind.CallMethod(MethodSpecifier.Init(), None),
         pickle.dumps(None),
     )
-    actor_mesh.cast(message, "all", instance._as_rust())
-    # wait for init to complete
-    for _ in range(len(proc_mesh.region.as_shape().ndslice)):
-        await receiver.recv_task()
+
+    # Use spawn_async with the explicit init message
+    actor_mesh = ProcMesh.spawn_async(
+        proc_mesh_task,
+        context().actor_instance._as_rust(),
+        "test",
+        cast(Type["Actor"], MyActor),
+        init_message,
+        False,  # emulated
+    )
 
     return actor_mesh
 
@@ -193,12 +204,13 @@ async def verify_cast_to_call(
 async def test_cast_handle() -> None:
     @run_on_tokio
     async def run() -> None:
-        proc_mesh = await allocate()
-        actor_mesh = await spawn_actor_mesh(proc_mesh)
+        proc_mesh_task = allocate()
+        actor_mesh = spawn_actor_mesh(proc_mesh_task)
         await verify_cast_to_call(
             actor_mesh, context().actor_instance, list(range(3 * 8 * 8))
         )
 
+        proc_mesh = await proc_mesh_task
         instance = context().actor_instance._as_rust()
         await proc_mesh.stop_nonblocking(instance, "test cleanup")
 
@@ -211,8 +223,9 @@ async def test_cast_handle() -> None:
 async def test_cast_ref() -> None:
     @run_on_tokio
     async def run() -> None:
-        proc_mesh = await allocate()
-        actor_mesh = await spawn_actor_mesh(proc_mesh)
+        proc_mesh_task = allocate()
+        actor_mesh = spawn_actor_mesh(proc_mesh_task)
+        proc_mesh = await proc_mesh_task
         actor_mesh_ref = actor_mesh.new_with_region(proc_mesh.region)
         await verify_cast_to_call(
             actor_mesh_ref, context().actor_instance, list(range(3 * 8 * 8))
@@ -249,12 +262,16 @@ async def test_host_mesh() -> None:
         assert host_mesh.region.labels == ["hosts"]
         assert host_mesh.region.slice() == Slice(offset=0, sizes=[2], strides=[1])
 
-        proc_mesh = await host_mesh.spawn_nonblocking(
-            context().actor_instance._as_rust(),
-            "proc_mesh",
-            Extent(["gpus", "replicas"], [2, 4]),
-        ).spawn()
-        actor_mesh = await spawn_actor_mesh(proc_mesh)
+        # Create spawned proc_mesh task
+        async def proc_mesh_task() -> ProcMesh:
+            return await host_mesh.spawn_nonblocking(
+                context().actor_instance._as_rust(),
+                "proc_mesh",
+                Extent(["gpus", "replicas"], [2, 4]),
+            ).spawn()
+
+        proc_mesh_shared = PythonTask.from_coroutine(proc_mesh_task()).spawn()
+        actor_mesh = spawn_actor_mesh(proc_mesh_shared)
 
         await verify_cast_to_call(actor_mesh, context().actor_instance, list(range(16)))
 
@@ -268,12 +285,16 @@ async def test_host_mesh() -> None:
         assert sliced_hm.region.labels == ["hosts"]
         assert sliced_hm.region.slice() == Slice(offset=1, sizes=[1], strides=[1])
 
-        sliced_pm = await sliced_hm.spawn_nonblocking(
-            context().actor_instance._as_rust(),
-            "sliced_pm",
-            Extent(["gpus", "replicas"], [2, 3]),
-        )
-        sliced_am = await spawn_actor_mesh(sliced_pm)
+        # Create spawned sliced_pm task
+        async def sliced_pm_task() -> ProcMesh:
+            return await sliced_hm.spawn_nonblocking(
+                context().actor_instance._as_rust(),
+                "sliced_pm",
+                Extent(["gpus", "replicas"], [2, 3]),
+            )
+
+        sliced_pm_shared = PythonTask.from_coroutine(sliced_pm_task()).spawn()
+        sliced_am = spawn_actor_mesh(sliced_pm_shared)
 
         await verify_cast_to_call(sliced_am, context().actor_instance, list(range(6)))
 

--- a/python/tests/_monarch/test_hyperactor.py
+++ b/python/tests/_monarch/test_hyperactor.py
@@ -8,10 +8,17 @@
 
 import multiprocessing
 import os
+import pickle
 import signal
 import time
-from typing import Any, Callable, Coroutine
+from typing import Any, Callable, cast, Coroutine, Iterable, Type, TYPE_CHECKING
 
+from monarch._rust_bindings.monarch_hyperactor.actor import (
+    MethodSpecifier,
+    PanicFlag,
+    PythonMessage,
+    PythonMessageKind,
+)
 from monarch._rust_bindings.monarch_hyperactor.alloc import (  # @manual=//monarch/monarch_extension:monarch_extension
     AllocConstraints,
     AllocSpec,
@@ -19,15 +26,34 @@ from monarch._rust_bindings.monarch_hyperactor.alloc import (  # @manual=//monar
 from monarch._rust_bindings.monarch_hyperactor.buffers import Buffer
 from monarch._rust_bindings.monarch_hyperactor.proc import ActorId
 from monarch._rust_bindings.monarch_hyperactor.proc_mesh import ProcMesh
-from monarch._rust_bindings.monarch_hyperactor.pytokio import PythonTask
+from monarch._rust_bindings.monarch_hyperactor.pytokio import PythonTask, Shared
 from monarch._src.actor.allocator import LocalAllocator
 from monarch._src.actor.pickle import flatten, unflatten
 from monarch.actor import context
 
 
+if TYPE_CHECKING:
+    from monarch._rust_bindings.monarch_hyperactor.actor import Actor, PortProtocol
+
+
 class MyActor:
-    async def handle(self, *args: Any, **kwargs: Any) -> None:
-        raise NotImplementedError()
+    async def handle(
+        self,
+        ctx: Any,
+        method: MethodSpecifier,
+        message: bytes,
+        panic_flag: PanicFlag,
+        local_state: Iterable[Any],
+        response_port: "PortProtocol[Any]",
+    ) -> None:
+        match method:
+            case MethodSpecifier.Init():
+                # Handle init message - response_port may be None
+                if response_port is not None:
+                    response_port.send(None)
+                return None
+            case _:
+                raise NotImplementedError()
 
 
 def test_import() -> None:
@@ -91,12 +117,31 @@ async def test_proc_mesh() -> None:
 
 @_python_task_test
 async def test_actor_mesh() -> None:
-    spec = AllocSpec(AllocConstraints(), replica=2)
-    allocator = LocalAllocator()
-    alloc = await allocator.allocate_nonblocking(spec)
-    instance = context().actor_instance._as_rust()
-    proc_mesh = await ProcMesh.allocate_nonblocking(instance, alloc, "proc_mesh")
-    actor_mesh = await proc_mesh.spawn_nonblocking(instance, "test", MyActor)
+    async def task() -> ProcMesh:
+        spec = AllocSpec(AllocConstraints(), replica=2)
+        allocator = LocalAllocator()
+        alloc = await allocator.allocate_nonblocking(spec)
+        return await ProcMesh.allocate_nonblocking(
+            context().actor_instance._as_rust(), alloc, "test"
+        )
+
+    proc_mesh_task: Shared[ProcMesh] = PythonTask.from_coroutine(task()).spawn()
+
+    # Create an explicit init message
+    init_message = PythonMessage(
+        PythonMessageKind.CallMethod(MethodSpecifier.Init(), None),
+        pickle.dumps(None),
+    )
+
+    # Use spawn_async with the explicit init message
+    actor_mesh = ProcMesh.spawn_async(
+        proc_mesh_task,
+        context().actor_instance._as_rust(),
+        "test",
+        cast(Type["Actor"], MyActor),
+        init_message,
+        False,  # emulated
+    )
 
     await actor_mesh.initialized()
 

--- a/python/tests/_monarch/test_mailbox.py
+++ b/python/tests/_monarch/test_mailbox.py
@@ -15,6 +15,7 @@ from typing import (
     final,
     Generic,
     Iterable,
+    Type,
     TYPE_CHECKING,
     TypeVar,
 )
@@ -25,11 +26,11 @@ from monarch._rust_bindings.monarch_hyperactor.actor import (
     PythonMessage,
     PythonMessageKind,
 )
-from monarch._rust_bindings.monarch_hyperactor.pytokio import PythonTask
+from monarch._rust_bindings.monarch_hyperactor.pytokio import PythonTask, Shared
 from monarch._src.actor.allocator import LocalAllocator
 
 if TYPE_CHECKING:
-    from monarch._rust_bindings.monarch_hyperactor.actor import PortProtocol
+    from monarch._rust_bindings.monarch_hyperactor.actor import Actor, PortProtocol
 
 from monarch._rust_bindings.monarch_hyperactor.alloc import AllocConstraints, AllocSpec
 from monarch._rust_bindings.monarch_hyperactor.mailbox import (
@@ -94,12 +95,16 @@ class Accumulator(Generic[S, U]):
         return self._reducer
 
 
-async def allocate() -> ProcMesh:
-    spec = AllocSpec(AllocConstraints(), replica=1)
-    allocator = LocalAllocator()
-    alloc = await allocator.allocate_nonblocking(spec)
-    instance = context().actor_instance._as_rust()
-    return await ProcMesh.allocate_nonblocking(instance, alloc, "proc_mesh")
+def allocate() -> Shared[ProcMesh]:
+    async def task() -> ProcMesh:
+        spec = AllocSpec(AllocConstraints(), replica=1)
+        allocator = LocalAllocator()
+        alloc = await allocator.allocate_nonblocking(spec)
+        return await ProcMesh.allocate_nonblocking(
+            context().actor_instance._as_rust(), alloc, "test"
+        )
+
+    return PythonTask.from_coroutine(task()).spawn()
 
 
 def _python_task_test(
@@ -162,16 +167,38 @@ class MyActor:
         local_state: Iterable[Any],
         response_port: "PortProtocol[Any]",
     ) -> None:
-        response_port.send(pickle.loads(message))
-        for i in range(100):
-            response_port.send(f"msg{i}")
+        match method:
+            case MethodSpecifier.Init():
+                # Handle init message - response_port may be None
+                if response_port is not None:
+                    response_port.send(None)
+                return None
+            case _:
+                response_port.send(pickle.loads(message))
+                for i in range(100):
+                    response_port.send(f"msg{i}")
 
 
 @_python_task_test
 async def test_reducer() -> None:
-    proc_mesh = await allocate()
-    instance = context().actor_instance._as_rust()
-    actor_mesh = await proc_mesh.spawn_nonblocking(instance, "test", MyActor)
+    proc_mesh_task = allocate()
+
+    # Create an explicit init message
+    init_message = PythonMessage(
+        PythonMessageKind.CallMethod(MethodSpecifier.Init(), None),
+        pickle.dumps(None),
+    )
+
+    # Use spawn_async with the explicit init message
+    actor_mesh = ProcMesh.spawn_async(
+        proc_mesh_task,
+        context().actor_instance._as_rust(),
+        "test",
+        cast(Type["Actor"], MyActor),
+        init_message,
+        False,  # emulated
+    )
+
     ins = context().actor_instance
 
     def my_accumulate(state: str, update: str) -> str:
@@ -201,4 +228,5 @@ async def test_reducer() -> None:
     assert "[reduced](start+msg0)" in value
 
     #  Note: occasionally test would hang without this stop
-    await proc_mesh.stop_nonblocking(instance, "test cleanup")
+    proc_mesh = await proc_mesh_task
+    await proc_mesh.stop_nonblocking(ins._as_rust(), "test cleanup")


### PR DESCRIPTION
Summary:
Currently, spawning a `PythonActor` happens in two stages -- first, we spawn the actors in the actor mesh; then, in a second, separate message, we construct the instance of the user's `Actor` implementation in python. This opens the door for a race condition where:
1. Actor A spawns a python actor mesh and passes a mesh ref to Actor B.
2. Actor B calls an endpoint on the mesh ref.
3. Actor B's message arrives in between actor spawn and the `Init` message from Actor A.
4. Actor B's call fails because the python actor thinks it hasn't been properly initialized yet.

This PR solves the problem by processing the `Init` message as part of `PythonActor::init`, which is guaranteed to run before any other message is processed. This wasn't possible before https://github.com/meta-pytorch/monarch/pull/2414 because we didn't have access to the point/rank of the actor until after `PythonActor::init`.

Reviewed By: mariusae

Differential Revision: D91739758


