### PR TITLE
Fix all cargo build warnings and errors

### DIFF
--- a/hyper/Cargo.toml
+++ b/hyper/Cargo.toml
@@ -17,10 +17,12 @@ console = "0.15.7"
 hyperactor = { path = "../hyperactor" }
 hyperactor_mesh = { path = "../hyperactor_mesh" }
 serde = { version = "1.0.185", features = ["derive", "rc"] }
+reqwest = { version = "0.12", features = ["json"] }
 serde_json = { version = "1.0.132", features = ["float_roundtrip", "unbounded_depth"] }
 tabwriter = { version = "1.2.1", features = ["ansi_formatting"] }
 tokio = { version = "1.41.0", features = ["full", "test-util", "tracing"] }
 tracing = { version = "0.1.41", features = ["attributes", "valuable"] }
+urlencoding = "2"
 
 [lints]
 rust = { unexpected_cfgs = { check-cfg = ["cfg(fbcode_build)"], level = "warn" } }

--- a/hyperactor/src/admin/mod.rs
+++ b/hyperactor/src/admin/mod.rs
@@ -132,6 +132,7 @@ pub(crate) fn register_proc(proc: &Proc) {
 /// Deregister a proc from the admin server.
 ///
 /// After deregistration, the proc will no longer appear in API responses.
+#[allow(dead_code)]
 pub(crate) fn deregister_proc(proc: &Proc) {
     deregister_proc_by_id(proc.proc_id());
 }

--- a/hyperactor/src/mailbox.rs
+++ b/hyperactor/src/mailbox.rs
@@ -115,7 +115,6 @@ use crate::ProcId;
 use crate::accum::Accumulator;
 use crate::accum::ReducerSpec;
 use crate::accum::StreamingReducerOpts;
-use crate::actor::ActorErrorKind;
 use crate::actor::ActorStatus;
 use crate::actor::Signal;
 use crate::actor::remote::USER_PORT_OFFSET;

--- a/hyperactor_config/Cargo.toml
+++ b/hyperactor_config/Cargo.toml
@@ -31,3 +31,6 @@ typeuri = { version = "0.0.0", path = "../typeuri" }
 [dev-dependencies]
 indoc = "2.0.2"
 tracing-test = { version = "0.2.3", features = ["no-env-filter"] }
+
+[lints]
+rust = { unexpected_cfgs = { check-cfg = ["cfg(fbcode_build)"], level = "warn" } }

--- a/hyperactor_mesh/Cargo.toml
+++ b/hyperactor_mesh/Cargo.toml
@@ -104,4 +104,4 @@ default = []
 systemd = ["dep:systemd"]
 
 [lints]
-rust = { unexpected_cfgs = { check-cfg = ["cfg(fbcode_build)"], level = "warn" } }
+rust = { unexpected_cfgs = { check-cfg = ["cfg(fbcode_build)", "cfg(FALSE)"], level = "warn" } }

--- a/hyperactor_mesh/src/actor_mesh.rs
+++ b/hyperactor_mesh/src/actor_mesh.rs
@@ -920,6 +920,7 @@ mod tests {
     use hyperactor::WorldId;
     use hyperactor_config::attrs::Attrs;
     use timed_test::async_timed_test;
+    #[cfg(fbcode_build)]
     use wirevalue::Encoding;
 
     use super::*;
@@ -1560,8 +1561,8 @@ mod tests {
         }
     } // mod local
 
+    #[cfg(fbcode_build)]
     mod process {
-
         use bytes::Bytes;
         use hyperactor::PortId;
         use hyperactor::channel::ChannelTransport;
@@ -1573,19 +1574,16 @@ mod tests {
 
         use crate::alloc::process::ProcessAllocator;
 
-        #[cfg(fbcode_build)]
         fn process_allocator() -> ProcessAllocator {
             ProcessAllocator::new(Command::new(crate::testresource::get(
                 "monarch/hyperactor_mesh/bootstrap",
             )))
         }
 
-        #[cfg(fbcode_build)] // we use an external binary, produced by buck
-        actor_mesh_test_suite!(process_allocator());
+        actor_mesh_test_suite!(process_allocator()); // we use an external binary, produced by buck
 
         // This test is concerned with correctly reporting failures
         // when message sizes exceed configured limits.
-        #[cfg(fbcode_build)]
         //#[tracing_test::traced_test]
         #[async_timed_test(timeout_secs = 30)]
         async fn test_oversized_frames() {
@@ -1707,7 +1705,6 @@ mod tests {
         // Set this test only for `mod process` because it relies on a
         // trick to emulate router failure that only works when using
         // non-local allocators.
-        #[cfg(fbcode_build)]
         #[tokio::test]
         async fn test_router_undeliverable_return() {
             // Test that an undeliverable message received by a
@@ -2036,6 +2033,7 @@ mod tests {
         }
     }
 
+    #[cfg(fbcode_build)]
     mod shim {
         use std::collections::HashSet;
 
@@ -2046,7 +2044,6 @@ mod tests {
         use crate::sel;
 
         #[tokio::test]
-        #[cfg(fbcode_build)]
         async fn test_basic() {
             let instance = v1::testing::instance();
             let host_mesh = v1::testing::host_mesh(4).await;

--- a/hyperactor_mesh/src/alloc.rs
+++ b/hyperactor_mesh/src/alloc.rs
@@ -616,6 +616,7 @@ pub(crate) mod testing {
     use core::panic;
     use std::collections::HashMap;
     use std::collections::HashSet;
+    #[cfg(fbcode_build)]
     use std::time::Duration;
 
     use hyperactor::Instance;
@@ -629,12 +630,15 @@ pub(crate) mod testing {
     use hyperactor::mailbox::MailboxServer;
     use hyperactor::mailbox::UndeliverableMailboxSender;
     use hyperactor::proc::Proc;
+    #[cfg(fbcode_build)]
     use hyperactor::reference::Reference;
     use ndslice::extent;
+    #[cfg(fbcode_build)]
     use tokio::process::Command;
 
     use super::*;
     use crate::alloc::test_utils::TestActor;
+    #[cfg(fbcode_build)]
     use crate::alloc::test_utils::Wait;
     use crate::proc_mesh::default_transport;
     use crate::proc_mesh::mesh_agent::GspawnResult;
@@ -712,6 +716,7 @@ pub(crate) mod testing {
         assert_eq!(stopped, running);
     }
 
+    #[allow(dead_code)]
     async fn spawn_proc(
         transport: ChannelTransport,
     ) -> (DialMailboxRouter, Instance<()>, Proc, ChannelAddr) {
@@ -737,6 +742,7 @@ pub(crate) mod testing {
         )
     }
 
+    #[allow(dead_code)]
     async fn spawn_test_actor(
         rank: usize,
         client_proc: &Proc,

--- a/hyperactor_mesh/src/alloc/process.rs
+++ b/hyperactor_mesh/src/alloc/process.rs
@@ -717,16 +717,14 @@ impl Drop for ProcessAlloc {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, fbcode_build))]
 mod tests {
     use super::*;
 
-    #[cfg(fbcode_build)] // we use an external binary, produced by buck
     crate::alloc_test_suite!(ProcessAllocator::new(Command::new(
         crate::testresource::get("monarch/hyperactor_mesh/bootstrap")
     )));
 
-    #[cfg(fbcode_build)]
     #[tokio::test]
     async fn test_sigterm_on_group_fail() {
         let bootstrap_binary = crate::testresource::get("monarch/hyperactor_mesh/bootstrap");

--- a/hyperactor_mesh/src/alloc/remoteprocess.rs
+++ b/hyperactor_mesh/src/alloc/remoteprocess.rs
@@ -2177,7 +2177,7 @@ mod test {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, fbcode_build))]
 mod test_alloc {
     use std::os::unix::process::ExitStatusExt;
 
@@ -2191,7 +2191,6 @@ mod test_alloc {
     use super::*;
 
     #[async_timed_test(timeout_secs = 60)]
-    #[cfg(fbcode_build)]
     async fn test_alloc_simple() {
         // Use temporary config for this test
         let config = hyperactor_config::global::lock();
@@ -2322,7 +2321,6 @@ mod test_alloc {
     }
 
     #[async_timed_test(timeout_secs = 60)]
-    #[cfg(fbcode_build)]
     async fn test_alloc_host_failure() {
         // Use temporary config for this test
         let config = hyperactor_config::global::lock();
@@ -2463,7 +2461,6 @@ mod test_alloc {
     }
 
     #[async_timed_test(timeout_secs = 15)]
-    #[cfg(fbcode_build)]
     async fn test_alloc_inner_alloc_failure() {
         // SAFETY: Test happens in single-threaded code.
         unsafe {
@@ -2599,7 +2596,6 @@ mod test_alloc {
     }
 
     #[async_timed_test(timeout_secs = 180)]
-    #[cfg(fbcode_build)]
     async fn test_remote_process_alloc_signal_handler() {
         hyperactor_telemetry::initialize_logging_for_test();
         let num_proc_meshes = 5;

--- a/hyperactor_mesh/src/proc_mesh.rs
+++ b/hyperactor_mesh/src/proc_mesh.rs
@@ -253,7 +253,7 @@ fn fresh_instance() -> (
     let client_proc = Proc::direct_with_default(
         default_bind_spec().binding_addr(),
         "mesh_root_client_proc".into(),
-        router::global().clone().boxed(),
+        (*router::global()).clone().boxed(),
     )
     .unwrap();
 
@@ -1349,6 +1349,7 @@ mod tests {
         assert_eq!(event.actor_id.2, 0);
     }
 
+    #[cfg(fbcode_build)]
     mod shim {
         use std::collections::HashSet;
 
@@ -1360,7 +1361,6 @@ mod tests {
         use crate::sel;
 
         #[tokio::test]
-        #[cfg(fbcode_build)]
         async fn test_basic() {
             let instance = v1::testing::instance();
             let host_mesh = v1::testing::host_mesh(4).await;

--- a/hyperactor_mesh/src/testresource.rs
+++ b/hyperactor_mesh/src/testresource.rs
@@ -8,6 +8,7 @@
 
 #![cfg(test)]
 
+#[cfg(fbcode_build)]
 use std::path::PathBuf;
 
 /// Fetch the named (BUCK) named resource, heuristically falling back on

--- a/hyperactor_mesh/src/v1/host_mesh/mesh_agent.rs
+++ b/hyperactor_mesh/src/v1/host_mesh/mesh_agent.rs
@@ -634,7 +634,7 @@ impl Handler<GetHostMeshAgent> for HostMeshAgentProcMeshTrampoline {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, fbcode_build))]
 mod tests {
     use std::assert_matches::assert_matches;
 
@@ -647,7 +647,6 @@ mod tests {
     use crate::resource::GetStateClient;
 
     #[tokio::test]
-    #[cfg(fbcode_build)]
     async fn test_basic() {
         let host = Host::new(
             BootstrapProcManager::new(BootstrapCommand::test()).unwrap(),

--- a/hyperactor_mesh/src/v1/proc_mesh.rs
+++ b/hyperactor_mesh/src/v1/proc_mesh.rs
@@ -519,6 +519,7 @@ impl ProcMesh {
 
     /// Detach the proc mesh from the lifetime of `self`, and return its reference.
     #[cfg(test)]
+    #[allow(dead_code)]
     pub(crate) fn detach(self) -> ProcMeshRef {
         // This also keeps the ProcMeshAllocation::Allocated alloc task alive.
         self.current_ref.clone()
@@ -1279,20 +1280,10 @@ impl view::RankedSliceable for ProcMeshRef {
 #[cfg(test)]
 mod tests {
     use hyperactor::Instance;
-    use hyperactor::Proc;
-    use hyperactor::config::ENABLE_DEST_ACTOR_REORDERING_BUFFER;
-    use hyperactor::id;
-    use hyperactor::mailbox::BoxableMailboxSender;
-    use hyperactor::mailbox::DialMailboxRouter;
     use ndslice::ViewExt;
     use ndslice::extent;
-    use timed_test::async_timed_test;
-    use uuid::Uuid;
 
     use super::*;
-    use crate::comm::ENABLE_NATIVE_V1_CASTING;
-    use crate::resource::RankedValues;
-    use crate::resource::Status;
     use crate::v1::testactor;
     use crate::v1::testing;
 
@@ -1319,210 +1310,225 @@ mod tests {
     }
 
     #[cfg(fbcode_build)]
-    async fn execute_spawn_actor() {
-        hyperactor_telemetry::initialize_logging(hyperactor::clock::ClockKind::default());
+    mod fbcode_tests {
+        use hyperactor::Proc;
+        use hyperactor::config::ENABLE_DEST_ACTOR_REORDERING_BUFFER;
+        use hyperactor::id;
+        use hyperactor::mailbox::BoxableMailboxSender;
+        use hyperactor::mailbox::DialMailboxRouter;
+        use timed_test::async_timed_test;
+        use uuid::Uuid;
 
-        let instance = testing::instance();
+        use super::*;
+        use crate::comm::ENABLE_NATIVE_V1_CASTING;
+        use crate::resource::RankedValues;
+        use crate::resource::Status;
 
-        for proc_mesh in testing::proc_meshes(&instance, extent!(replicas = 4, hosts = 2)).await {
-            testactor::assert_mesh_shape(proc_mesh.spawn(instance, "test", &()).await.unwrap())
-                .await;
+        async fn execute_spawn_actor() {
+            hyperactor_telemetry::initialize_logging(hyperactor::clock::ClockKind::default());
+
+            let instance = testing::instance();
+
+            for proc_mesh in testing::proc_meshes(&instance, extent!(replicas = 4, hosts = 2)).await
+            {
+                testactor::assert_mesh_shape(proc_mesh.spawn(instance, "test", &()).await.unwrap())
+                    .await;
+            }
         }
-    }
 
-    #[async_timed_test(timeout_secs = 30)]
-    #[cfg(fbcode_build)]
-    async fn test_spawn_actor_v1_casting() {
-        let config = hyperactor_config::global::lock();
-        let _guard = config.override_key(ENABLE_NATIVE_V1_CASTING, true);
-        let _guard2 = config.override_key(ENABLE_DEST_ACTOR_REORDERING_BUFFER, true);
-        execute_spawn_actor().await;
-    }
-
-    #[async_timed_test(timeout_secs = 30)]
-    #[cfg(fbcode_build)]
-    async fn test_spawn_actor_v0_casting() {
-        let config = hyperactor_config::global::lock();
-        let _guard = config.override_key(ENABLE_NATIVE_V1_CASTING, false);
-        execute_spawn_actor().await;
-    }
-
-    // * Spawn an actor mesh, and then
-    // * do a random numbers of cast to it to bump the seq numbers for all
-    //   actors participating in the cast.
-    //     * This is to avoid the test mistakenly passing.
-    async fn spawn_for_seq_test(
-        cx: &Instance<testing::TestRootClient>,
-        proc_mesh: &ProcMeshRef,
-    ) -> ActorMesh<testactor::TestActor> {
-        let actor_mesh: ActorMesh<testactor::TestActor> =
-            proc_mesh.spawn(cx, "test", &()).await.unwrap();
-
-        let (instance, _) = cx
-            .proc()
-            .instance(&format!("random_casts_{}", Uuid::now_v7()))
-            .unwrap();
-        let n = fastrand::u64(3..10);
-        for _ in 0..n {
-            actor_mesh.cast(&instance, ()).unwrap();
+        #[async_timed_test(timeout_secs = 30)]
+        async fn test_spawn_actor_v1_casting() {
+            let config = hyperactor_config::global::lock();
+            let _guard = config.override_key(ENABLE_NATIVE_V1_CASTING, true);
+            let _guard2 = config.override_key(ENABLE_DEST_ACTOR_REORDERING_BUFFER, true);
+            execute_spawn_actor().await;
         }
-        println!(
-            "did {} casts with sequencer session id {}",
-            n,
-            instance.sequencer().session_id()
-        );
-        actor_mesh
-    }
 
-    #[async_timed_test(timeout_secs = 30)]
-    #[cfg(fbcode_build)]
-    async fn test_seq_from_same_sender_to_different_meshes() {
-        let config = hyperactor_config::global::lock();
-        let _guard = config.override_key(ENABLE_NATIVE_V1_CASTING, true);
-        let _guard2 = config.override_key(ENABLE_DEST_ACTOR_REORDERING_BUFFER, true);
+        #[async_timed_test(timeout_secs = 30)]
+        async fn test_spawn_actor_v0_casting() {
+            let config = hyperactor_config::global::lock();
+            let _guard = config.override_key(ENABLE_NATIVE_V1_CASTING, false);
+            execute_spawn_actor().await;
+        }
 
-        hyperactor_telemetry::initialize_logging(hyperactor::clock::ClockKind::default());
-        let instance = testing::instance();
-        let session_id = instance.sequencer().session_id();
+        // * Spawn an actor mesh, and then
+        // * do a random numbers of cast to it to bump the seq numbers for all
+        //   actors participating in the cast.
+        //     * This is to avoid the test mistakenly passing.
+        async fn spawn_for_seq_test(
+            cx: &Instance<testing::TestRootClient>,
+            proc_mesh: &ProcMeshRef,
+        ) -> ActorMesh<testactor::TestActor> {
+            let actor_mesh: ActorMesh<testactor::TestActor> =
+                proc_mesh.spawn(cx, "test", &()).await.unwrap();
 
-        for proc_mesh in testing::proc_meshes(&instance, extent!(replicas = 4, hosts = 2)).await {
-            let proc_mesh_ref = proc_mesh.deref();
+            let (instance, _) = cx
+                .proc()
+                .instance(&format!("random_casts_{}", Uuid::now_v7()))
+                .unwrap();
+            let n = fastrand::u64(3..10);
+            for _ in 0..n {
+                actor_mesh.cast(&instance, ()).unwrap();
+            }
+            println!(
+                "did {} casts with sequencer session id {}",
+                n,
+                instance.sequencer().session_id()
+            );
+            actor_mesh
+        }
 
-            // Sequence numbers are scoped based on the (client, dest) pair.
-            // So casts to different meshes from the same client instance would
-            // result in seq 1 for all casts.
-            let handles = (0..3)
-                .map(|_| {
-                    let proc_mesh_ref_clone = proc_mesh_ref.clone();
-                    tokio::spawn(async move {
-                        let actor_mesh = spawn_for_seq_test(instance, &proc_mesh_ref_clone).await;
-                        let expected_seqs = vec![1; 8];
-                        testactor::assert_casting_correctness(
-                            &actor_mesh,
-                            instance,
-                            Some((session_id, expected_seqs)),
-                        )
-                        .await;
+        #[async_timed_test(timeout_secs = 30)]
+        async fn test_seq_from_same_sender_to_different_meshes() {
+            let config = hyperactor_config::global::lock();
+            let _guard = config.override_key(ENABLE_NATIVE_V1_CASTING, true);
+            let _guard2 = config.override_key(ENABLE_DEST_ACTOR_REORDERING_BUFFER, true);
+
+            hyperactor_telemetry::initialize_logging(hyperactor::clock::ClockKind::default());
+            let instance = testing::instance();
+            let session_id = instance.sequencer().session_id();
+
+            for proc_mesh in testing::proc_meshes(&instance, extent!(replicas = 4, hosts = 2)).await
+            {
+                let proc_mesh_ref = proc_mesh.deref();
+
+                // Sequence numbers are scoped based on the (client, dest) pair.
+                // So casts to different meshes from the same client instance would
+                // result in seq 1 for all casts.
+                let handles = (0..3)
+                    .map(|_| {
+                        let proc_mesh_ref_clone = proc_mesh_ref.clone();
+                        tokio::spawn(async move {
+                            let actor_mesh =
+                                spawn_for_seq_test(instance, &proc_mesh_ref_clone).await;
+                            let expected_seqs = vec![1; 8];
+                            testactor::assert_casting_correctness(
+                                &actor_mesh,
+                                instance,
+                                Some((session_id, expected_seqs)),
+                            )
+                            .await;
+                        })
                     })
-                })
-                .collect::<Vec<_>>();
-            futures::future::join_all(handles).await;
+                    .collect::<Vec<_>>();
+                futures::future::join_all(handles).await;
+            }
         }
-    }
 
-    // Verify that the seq numbers are assigned correctly when we cast to
-    // different views of the same root mesh.
-    #[async_timed_test(timeout_secs = 30)]
-    #[cfg(fbcode_build)]
-    async fn test_seq_from_same_sender_to_different_views() {
-        let config = hyperactor_config::global::lock();
-        let _guard = config.override_key(ENABLE_NATIVE_V1_CASTING, true);
-        let _guard2 = config.override_key(ENABLE_DEST_ACTOR_REORDERING_BUFFER, true);
+        // Verify that the seq numbers are assigned correctly when we cast to
+        // different views of the same root mesh.
+        #[async_timed_test(timeout_secs = 30)]
+        async fn test_seq_from_same_sender_to_different_views() {
+            let config = hyperactor_config::global::lock();
+            let _guard = config.override_key(ENABLE_NATIVE_V1_CASTING, true);
+            let _guard2 = config.override_key(ENABLE_DEST_ACTOR_REORDERING_BUFFER, true);
 
-        hyperactor_telemetry::initialize_logging(hyperactor::clock::ClockKind::default());
+            hyperactor_telemetry::initialize_logging(hyperactor::clock::ClockKind::default());
 
-        let instance = testing::instance();
-        let session_id = instance.sequencer().session_id();
+            let instance = testing::instance();
+            let session_id = instance.sequencer().session_id();
 
-        for proc_mesh in testing::proc_meshes(&instance, extent!(replicas = 4, hosts = 2)).await {
-            let actor_mesh = spawn_for_seq_test(instance, &proc_mesh).await;
+            for proc_mesh in testing::proc_meshes(&instance, extent!(replicas = 4, hosts = 2)).await
+            {
+                let actor_mesh = spawn_for_seq_test(instance, &proc_mesh).await;
 
-            // First cast. The seq should be 1 for all actors.
-            let expected_seqs = vec![1; 8];
-            testactor::assert_casting_correctness(
-                &actor_mesh,
-                instance,
-                Some((session_id, expected_seqs)),
-            )
-            .await;
-
-            // Verify casting to the sliced actor mesh
-            let sliced_actor_mesh = actor_mesh.range("replicas", 1..3).unwrap();
-            // Second cast. The seq should be 2 for actors in the sliced mesh.
-            let expected_seqs = vec![2; 4];
-            testactor::assert_casting_correctness(
-                &sliced_actor_mesh,
-                instance,
-                Some((session_id, expected_seqs)),
-            )
-            .await;
-
-            // Verify casting to a different sliced actor mesh
-            let sliced_actor_mesh = actor_mesh.range("replicas", 0..2).unwrap();
-            // For actors in the previous sliced mesh, the seq should be 3 since
-            // this is the third cast for them. For other actors, the seq should
-            // be 2.
-            let expected_seqs = vec![2, 2, 3, 3];
-            testactor::assert_casting_correctness(
-                &sliced_actor_mesh,
-                instance,
-                Some((session_id, expected_seqs)),
-            )
-            .await;
-        }
-    }
-
-    #[async_timed_test(timeout_secs = 30)]
-    #[cfg(fbcode_build)]
-    async fn test_seq_from_different_senders() {
-        let config = hyperactor_config::global::lock();
-        let _guard = config.override_key(ENABLE_NATIVE_V1_CASTING, true);
-        let _guard2 = config.override_key(ENABLE_DEST_ACTOR_REORDERING_BUFFER, true);
-
-        hyperactor_telemetry::initialize_logging(hyperactor::clock::ClockKind::default());
-        let proc = Proc::new(id!(test[0]), DialMailboxRouter::new().boxed());
-        let (instance, ..) = proc
-            .actor_instance::<testing::TestRootClient>("test_client")
-            .unwrap();
-        let (first_instance, ..) = proc
-            .actor_instance::<testing::TestRootClient>("first_client")
-            .unwrap();
-        let (second_instance, ..) = proc
-            .actor_instance::<testing::TestRootClient>("second_client")
-            .unwrap();
-        let (third_instance, ..) = proc
-            .actor_instance::<testing::TestRootClient>("third_client")
-            .unwrap();
-
-        for proc_mesh in testing::proc_meshes(&instance, extent!(replicas = 4, hosts = 2)).await {
-            let actor_mesh = spawn_for_seq_test(&instance, &proc_mesh).await;
-
-            // Sequence numbers are calculated based on the sequencer, i.e. the
-            // client name. So three casts would result in seq 1 for all actors.
-            for inst in [&first_instance, &second_instance, &third_instance] {
+                // First cast. The seq should be 1 for all actors.
                 let expected_seqs = vec![1; 8];
-                let session_id = inst.sequencer().session_id();
                 testactor::assert_casting_correctness(
                     &actor_mesh,
-                    inst,
+                    instance,
+                    Some((session_id, expected_seqs)),
+                )
+                .await;
+
+                // Verify casting to the sliced actor mesh
+                let sliced_actor_mesh = actor_mesh.range("replicas", 1..3).unwrap();
+                // Second cast. The seq should be 2 for actors in the sliced mesh.
+                let expected_seqs = vec![2; 4];
+                testactor::assert_casting_correctness(
+                    &sliced_actor_mesh,
+                    instance,
+                    Some((session_id, expected_seqs)),
+                )
+                .await;
+
+                // Verify casting to a different sliced actor mesh
+                let sliced_actor_mesh = actor_mesh.range("replicas", 0..2).unwrap();
+                // For actors in the previous sliced mesh, the seq should be 3 since
+                // this is the third cast for them. For other actors, the seq should
+                // be 2.
+                let expected_seqs = vec![2, 2, 3, 3];
+                testactor::assert_casting_correctness(
+                    &sliced_actor_mesh,
+                    instance,
                     Some((session_id, expected_seqs)),
                 )
                 .await;
             }
         }
-    }
 
-    #[tokio::test]
-    #[cfg(fbcode_build)]
-    async fn test_failing_spawn_actor() {
-        hyperactor_telemetry::initialize_logging(hyperactor::clock::ClockKind::default());
+        #[async_timed_test(timeout_secs = 30)]
+        async fn test_seq_from_different_senders() {
+            let config = hyperactor_config::global::lock();
+            let _guard = config.override_key(ENABLE_NATIVE_V1_CASTING, true);
+            let _guard2 = config.override_key(ENABLE_DEST_ACTOR_REORDERING_BUFFER, true);
 
-        let instance = testing::instance();
+            hyperactor_telemetry::initialize_logging(hyperactor::clock::ClockKind::default());
+            let proc = Proc::new(id!(test[0]), DialMailboxRouter::new().boxed());
+            let (instance, ..) = proc
+                .actor_instance::<testing::TestRootClient>("test_client")
+                .unwrap();
+            let (first_instance, ..) = proc
+                .actor_instance::<testing::TestRootClient>("first_client")
+                .unwrap();
+            let (second_instance, ..) = proc
+                .actor_instance::<testing::TestRootClient>("second_client")
+                .unwrap();
+            let (third_instance, ..) = proc
+                .actor_instance::<testing::TestRootClient>("third_client")
+                .unwrap();
 
-        for proc_mesh in testing::proc_meshes(&instance, extent!(replicas = 4, hosts = 2)).await {
-            let err = proc_mesh
-                .spawn::<testactor::FailingCreateTestActor, Instance<testing::TestRootClient>>(
-                    instance,
-                    "testfail",
-                    &(),
-                )
-                .await
-                .unwrap_err();
-            let statuses = err.into_actor_spawn_error().unwrap();
-            assert_eq!(
-                statuses,
-                RankedValues::from((0..8, Status::Failed("test failure".to_string()))),
-            );
+            for proc_mesh in testing::proc_meshes(&instance, extent!(replicas = 4, hosts = 2)).await
+            {
+                let actor_mesh = spawn_for_seq_test(&instance, &proc_mesh).await;
+
+                // Sequence numbers are calculated based on the sequencer, i.e. the
+                // client name. So three casts would result in seq 1 for all actors.
+                for inst in [&first_instance, &second_instance, &third_instance] {
+                    let expected_seqs = vec![1; 8];
+                    let session_id = inst.sequencer().session_id();
+                    testactor::assert_casting_correctness(
+                        &actor_mesh,
+                        inst,
+                        Some((session_id, expected_seqs)),
+                    )
+                    .await;
+                }
+            }
+        }
+
+        #[tokio::test]
+        async fn test_failing_spawn_actor() {
+            hyperactor_telemetry::initialize_logging(hyperactor::clock::ClockKind::default());
+
+            let instance = testing::instance();
+
+            for proc_mesh in testing::proc_meshes(&instance, extent!(replicas = 4, hosts = 2)).await
+            {
+                let err = proc_mesh
+                    .spawn::<testactor::FailingCreateTestActor, Instance<testing::TestRootClient>>(
+                        instance,
+                        "testfail",
+                        &(),
+                    )
+                    .await
+                    .unwrap_err();
+                let statuses = err.into_actor_spawn_error().unwrap();
+                assert_eq!(
+                    statuses,
+                    RankedValues::from((0..8, Status::Failed("test failure".to_string()))),
+                );
+            }
         }
     }
 }

--- a/hyperactor_mesh/src/v1/testing.rs
+++ b/hyperactor_mesh/src/v1/testing.rs
@@ -23,6 +23,7 @@ use hyperactor::actor::ActorErrorKind;
 use hyperactor::actor::ActorStatus;
 use hyperactor::actor::Signal;
 use hyperactor::channel::ChannelTransport;
+#[cfg(fbcode_build)]
 use hyperactor::context;
 use hyperactor::id;
 use hyperactor::mailbox::BoxableMailboxSender;
@@ -31,19 +32,25 @@ use hyperactor::mailbox::PortReceiver;
 use hyperactor::proc::WorkCell;
 use hyperactor::supervision::ActorSupervisionEvent;
 use ndslice::Extent;
+#[cfg(fbcode_build)]
 use tokio::process::Command;
 use tokio::sync::OnceCell;
 use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
 
+#[cfg(fbcode_build)]
 use crate::Bootstrap;
+#[cfg(fbcode_build)]
 use crate::alloc::Alloc;
 use crate::alloc::AllocSpec;
 use crate::alloc::Allocator;
 use crate::alloc::LocalAllocator;
+#[cfg(fbcode_build)]
 use crate::alloc::ProcessAllocator;
+#[cfg(fbcode_build)]
 use crate::proc_mesh::default_transport;
 use crate::supervision::MeshFailure;
+#[cfg(fbcode_build)]
 use crate::v1::HostMeshRef;
 use crate::v1::ProcMesh;
 

--- a/hyperactor_mesh/test/remote_process_alloc.rs
+++ b/hyperactor_mesh/test/remote_process_alloc.rs
@@ -9,7 +9,6 @@
 use std::time::Duration;
 
 use clap::Parser;
-use clap::command;
 use hyperactor::WorldId;
 use hyperactor::channel;
 use hyperactor::channel::ChannelTransport;

--- a/hyperactor_mesh/test/remote_process_allocator.rs
+++ b/hyperactor_mesh/test/remote_process_allocator.rs
@@ -11,7 +11,6 @@
 use std::str::FromStr;
 
 use clap::Parser;
-use clap::command;
 use hyperactor::channel::ChannelAddr;
 use hyperactor_mesh::alloc::remoteprocess::RemoteProcessAllocator;
 use tokio::process::Command;

--- a/hyperactor_telemetry/src/lib.rs
+++ b/hyperactor_telemetry/src/lib.rs
@@ -100,7 +100,9 @@ use tracing_subscriber::fmt::FormatFields;
 use tracing_subscriber::fmt::format::Writer;
 use tracing_subscriber::registry::LookupSpan;
 
+#[cfg(fbcode_build)]
 use crate::config::ENABLE_OTEL_METRICS;
+#[cfg(fbcode_build)]
 use crate::config::ENABLE_OTEL_TRACING;
 use crate::config::ENABLE_RECORDER_TRACING;
 use crate::config::ENABLE_SQLITE_TRACING;
@@ -108,6 +110,7 @@ use crate::config::MONARCH_FILE_LOG_LEVEL;
 use crate::config::MONARCH_LOG_SUFFIX;
 use crate::config::USE_UNIFIED_LAYER;
 use crate::recorder::Recorder;
+#[cfg(fbcode_build)]
 use crate::sqlite::get_reloadable_sqlite_layer;
 
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]

--- a/monarch_hyperactor/src/actor.rs
+++ b/monarch_hyperactor/src/actor.rs
@@ -41,7 +41,6 @@ use hyperactor_mesh::router;
 use hyperactor_mesh::supervision::MeshFailure;
 use monarch_types::PickledPyObject;
 use monarch_types::SerializablePyErr;
-use ndslice::Point;
 use pyo3::IntoPyObjectExt;
 use pyo3::exceptions::PyBaseException;
 use pyo3::exceptions::PyRuntimeError;
@@ -502,7 +501,7 @@ impl PythonActor {
         let client_proc = Proc::direct_with_default(
             default_bind_spec().binding_addr(),
             "mesh_root_client_proc".into(),
-            router::global().clone().boxed(),
+            (*router::global()).clone().boxed(),
         )
         .unwrap();
 

--- a/monarch_hyperactor/src/code_sync/manager.rs
+++ b/monarch_hyperactor/src/code_sync/manager.rs
@@ -47,7 +47,6 @@ use hyperactor_mesh::v1;
 use lazy_errors::ErrorStash;
 use lazy_errors::TryCollectOrStash;
 use monarch_conda::sync::sender;
-use ndslice::Point;
 use ndslice::Selection;
 use ndslice::Shape;
 use ndslice::ShapeError;

--- a/monarch_hyperactor/src/logging.rs
+++ b/monarch_hyperactor/src/logging.rs
@@ -32,7 +32,6 @@ use hyperactor_mesh::logging::LogForwardMessage;
 use hyperactor_mesh::v1::ActorMesh;
 use hyperactor_mesh::v1::actor_mesh::ActorMeshRef;
 use monarch_types::SerializablePyErr;
-use ndslice::Point;
 use ndslice::View;
 use pyo3::Bound;
 use pyo3::prelude::*;

--- a/monarch_hyperactor/src/proc_launcher.rs
+++ b/monarch_hyperactor/src/proc_launcher.rs
@@ -311,7 +311,7 @@ mod decode {
 
         super::protocol::reject_pending_pickle(&msg)?;
 
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let cloudpickle = super::py::import_cloudpickle(py)?;
 
             match msg.kind {
@@ -445,8 +445,8 @@ mod decode {
         // shape validation.
         #[test]
         fn test_validate_shape_valid_dataclass() {
-            pyo3::prepare_freethreaded_python();
-            Python::with_gil(|py| {
+            pyo3::Python::initialize();
+            Python::attach(|py| {
                 // Create a simple class with all required attributes
                 let locals = run_py_code(
                     py,
@@ -470,8 +470,8 @@ obj = FakeExit()
         // debugging.
         #[test]
         fn test_validate_shape_missing_attribute() {
-            pyo3::prepare_freethreaded_python();
-            Python::with_gil(|py| {
+            pyo3::Python::initialize();
+            Python::attach(|py| {
                 // Missing stderr_tail
                 let locals = run_py_code(
                     py,
@@ -497,8 +497,8 @@ obj = IncompleteExit()
         // `DecodedExit` with the expected field values.
         #[test]
         fn test_decode_exit_obj_valid() {
-            pyo3::prepare_freethreaded_python();
-            Python::with_gil(|py| {
+            pyo3::Python::initialize();
+            Python::attach(|py| {
                 let locals = run_py_code(
                     py,
                     c"
@@ -526,8 +526,8 @@ obj = FakeExit()
         // could not be extracted.
         #[test]
         fn test_decode_exit_obj_wrong_type() {
-            pyo3::prepare_freethreaded_python();
-            Python::with_gil(|py| {
+            pyo3::Python::initialize();
+            Python::attach(|py| {
                 // exit_code is a string instead of int
                 let locals = run_py_code(
                     py,
@@ -666,7 +666,7 @@ impl ProcLauncher for ActorProcLauncher {
     ) -> Result<LaunchResult, ProcLauncherError> {
         let (exit_port, exit_port_rx) = self.mailbox.open_once_port::<PythonMessage>();
 
-        let pickled_args = Python::with_gil(|py| -> Result<Vec<u8>, ProcLauncherError> {
+        let pickled_args = Python::attach(|py| -> Result<Vec<u8>, ProcLauncherError> {
             let cloudpickle = import_cloudpickle(py)?;
 
             let mod_ = py
@@ -781,7 +781,7 @@ impl ProcLauncher for ActorProcLauncher {
         proc_id: &ProcId,
         timeout: Duration,
     ) -> Result<(), ProcLauncherError> {
-        let pickled = Python::with_gil(|py| -> Result<Vec<u8>, ProcLauncherError> {
+        let pickled = Python::attach(|py| -> Result<Vec<u8>, ProcLauncherError> {
             let cloudpickle =
                 import_cloudpickle(py).map_err(|e| ProcLauncherError::Terminate(format!("{e}")))?;
             let args = (proc_id.to_string(), timeout.as_secs_f64());
@@ -823,7 +823,7 @@ impl ProcLauncher for ActorProcLauncher {
     /// - import/serialize the request via `cloudpickle`, or
     /// - send the message to the spawner actor.
     async fn kill(&self, proc_id: &ProcId) -> Result<(), ProcLauncherError> {
-        let pickled = Python::with_gil(|py| -> Result<Vec<u8>, ProcLauncherError> {
+        let pickled = Python::attach(|py| -> Result<Vec<u8>, ProcLauncherError> {
             let cloudpickle =
                 import_cloudpickle(py).map_err(|e| ProcLauncherError::Kill(format!("{e}")))?;
             let args = (proc_id.to_string(),);
@@ -894,8 +894,8 @@ mod tests {
     // using `str()` (falling back to `repr()`).
     #[test]
     fn test_pyany_to_error_string() {
-        pyo3::prepare_freethreaded_python();
-        Python::with_gil(|py| {
+        pyo3::Python::initialize();
+        Python::attach(|py| {
             // A Python string should round-trip through `str()`
             // unchanged.
             let s = pyo3::types::PyString::new(py, "hello");

--- a/ndslice/Cargo.toml
+++ b/ndslice/Cargo.toml
@@ -28,3 +28,6 @@ rand = { version = "0.9", features = ["small_rng"] }
 serde = { version = "1.0.219", features = ["derive", "rc"] }
 thiserror = "2.0.18"
 typeuri = { version = "0.0.0", path = "../typeuri" }
+
+[lints]
+rust = { unexpected_cfgs = { check-cfg = ["cfg(fbcode_build)"], level = "warn" } }


### PR DESCRIPTION
Summary:
Fix all compilation errors and warnings from P2178702116:

- Add missing `reqwest` and `urlencoding` dependencies to `hyper/Cargo.toml` to fix 11 compilation errors in `admin.rs`
- Remove ~100 unused imports across 15 source files in hyperactor, hyperactor_mesh, and monarch_hyperactor
- Gate imports used only in `#[cfg(fbcode_build)]` code with `#[cfg(fbcode_build)]` instead of removing them (in v1/proc_mesh.rs, v1/testing.rs, hyperactor_telemetry, testresource.rs)
- Fix suspicious `.clone()` on double references by dereferencing first: `(*router::global()).clone().boxed()` in bootstrap.rs, proc_mesh.rs, and monarch_hyperactor/actor.rs
- Add `#[allow(dead_code)]` to test utility functions that are intentionally kept: deregister_proc, spawn_proc, spawn_test_actor, make_proc_id_and_backend_addr, detach, free_localhost_addr
- Add `#[cfg(fbcode_build)]` to `spawn_for_seq_test` which is only called from fbcode-build tests
- Update deprecated pyo3 APIs in proc_launcher.rs: `prepare_freethreaded_python()` → `Python::initialize()`, `Python::with_gil()` → `Python::attach()`
- Add `[lints]` sections with `check-cfg` for `cfg(fbcode_build)` to hyperactor_config/Cargo.toml and ndslice/Cargo.toml
- Add `cfg(FALSE)` to hyperactor_mesh/Cargo.toml check-cfg list
- Rename unused parameter `mock_scuba` to `_mock_scuba` in hyperactor_telemetry

Differential Revision: D92842223


