### PR TITLE
Move RdmaDomain to backend/ibverbs/domain.rs

### DIFF
--- a/monarch_rdma/examples/cuda_ping_pong/src/cuda_ping_pong.rs
+++ b/monarch_rdma/examples/cuda_ping_pong/src/cuda_ping_pong.rs
@@ -77,7 +77,7 @@ use hyperactor_mesh::Name;
 use hyperactor_mesh::ProcMesh;
 use hyperactor_mesh::global_root_client;
 use hyperactor_mesh::host_mesh::HostMesh;
-use monarch_rdma::IbverbsConfig;
+use monarch_rdma::IbvConfig;
 use monarch_rdma::RdmaBuffer;
 use monarch_rdma::RdmaManagerActor;
 use monarch_rdma::RdmaManagerMessageClient;
@@ -682,26 +682,26 @@ pub async fn run() -> Result<(), anyhow::Error> {
     let devices = monarch_rdma::get_all_devices();
     // Configure RDMA for the two actors
     // For H100 machines, we use different devices for better performance
-    let device_1_ibv_config: IbverbsConfig;
-    let device_2_ibv_config: IbverbsConfig;
+    let device_1_ibv_config: IbvConfig;
+    let device_2_ibv_config: IbvConfig;
 
     // Check if we have enough devices for optimal configuration
     if devices.len() > 4 {
         // Use separate backend devices for H100 configuration
-        device_1_ibv_config = IbverbsConfig {
+        device_1_ibv_config = IbvConfig {
             device: devices.clone().into_iter().next().unwrap(),
             ..Default::default()
         };
         // The second device used is the 3rd. Main reason is because 0 and 3 are both backend
         // devices on gtn H100 devices.
-        device_2_ibv_config = IbverbsConfig {
+        device_2_ibv_config = IbvConfig {
             device: devices.clone().into_iter().nth(3).unwrap(),
             ..Default::default()
         };
     } else {
         // For other configurations, use default settings
-        device_1_ibv_config = IbverbsConfig::default();
-        device_2_ibv_config = IbverbsConfig::default();
+        device_1_ibv_config = IbvConfig::default();
+        device_2_ibv_config = IbvConfig::default();
     }
 
     let instance = global_root_client();

--- a/monarch_rdma/examples/parameter_server/src/parameter_server.rs
+++ b/monarch_rdma/examples/parameter_server/src/parameter_server.rs
@@ -76,7 +76,7 @@ use hyperactor_mesh::HostMeshRef;
 use hyperactor_mesh::Name;
 use hyperactor_mesh::comm::multicast::CastInfo;
 use hyperactor_mesh::global_root_client;
-use monarch_rdma::IbverbsConfig;
+use monarch_rdma::IbvConfig;
 use monarch_rdma::RdmaBuffer;
 use monarch_rdma::RdmaManagerActor;
 use monarch_rdma::RdmaManagerMessageClient;
@@ -445,29 +445,29 @@ pub async fn run(num_workers: usize, num_steps: usize) -> Result<(), anyhow::Err
     // In practice, this toy example could have a single ibverbs device shared across
     // all entities, but this serves to demonstrate that we can specify the underlying
     // device used.
-    let ps_ibv_config: IbverbsConfig;
-    let worker_ibv_config: IbverbsConfig;
+    let ps_ibv_config: IbvConfig;
+    let worker_ibv_config: IbvConfig;
 
     // Quick check for H100
     if devices.len() > 4 {
-        ps_ibv_config = IbverbsConfig {
+        ps_ibv_config = IbvConfig {
             device: devices.clone().into_iter().next().unwrap(),
             ..Default::default()
         };
         // The second device used is the 3rd. Main reason is because 0 and 3 are both backend
         // devices on gtn H100 devices.
-        worker_ibv_config = IbverbsConfig {
+        worker_ibv_config = IbvConfig {
             device: devices.clone().into_iter().nth(3).unwrap(),
             ..Default::default()
         };
     } else {
         // For other configurations, use default settings (parameter server + workers all use the same ibv device)
         tracing::info!(
-            "using default IbverbsConfig as {} devices were found (expected > 4 for H100)",
+            "using default IbvConfig as {} devices were found (expected > 4 for H100)",
             devices.len()
         );
-        ps_ibv_config = IbverbsConfig::default();
-        worker_ibv_config = IbverbsConfig::default();
+        ps_ibv_config = IbvConfig::default();
+        worker_ibv_config = IbvConfig::default();
     }
 
     // As normal, create a proc mesh for the parameter server.

--- a/monarch_rdma/src/backend.rs
+++ b/monarch_rdma/src/backend.rs
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+//! RDMA backend implementations.
+
+pub(crate) mod ibverbs;

--- a/monarch_rdma/src/backend/ibverbs.rs
+++ b/monarch_rdma/src/backend/ibverbs.rs
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+//! ibverbs backend implementation for RDMA operations.
+
+pub(crate) mod manager_actor;
+pub mod primitives;

--- a/monarch_rdma/src/backend/ibverbs.rs
+++ b/monarch_rdma/src/backend/ibverbs.rs
@@ -8,5 +8,6 @@
 
 //! ibverbs backend implementation for RDMA operations.
 
+pub(crate) mod domain;
 pub(crate) mod manager_actor;
 pub mod primitives;

--- a/monarch_rdma/src/backend/ibverbs/domain.rs
+++ b/monarch_rdma/src/backend/ibverbs/domain.rs
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+//! ibverbs RDMA domain.
+//!
+//! An [`IbvDomain`] manages the device context and protection domain (PD)
+//! required for RDMA operations. It provides the foundation for creating
+//! queue pairs and establishing connections between RDMA devices.
+
+use std::ffi::CStr;
+use std::io::Error;
+use std::result::Result;
+
+use super::primitives::IbvDevice;
+
+/// Manages RDMA resources including context and protection domain.
+///
+/// # Fields
+///
+/// * `context`: A pointer to the RDMA device context.
+/// * `pd`: A pointer to the protection domain, which provides isolation between
+///   different connections.
+#[derive(Clone)]
+pub struct IbvDomain {
+    pub context: *mut rdmaxcel_sys::ibv_context,
+    pub pd: *mut rdmaxcel_sys::ibv_pd,
+}
+
+impl std::fmt::Debug for IbvDomain {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("IbvDomain")
+            .field("context", &format!("{:p}", self.context))
+            .field("pd", &format!("{:p}", self.pd))
+            .finish()
+    }
+}
+
+// SAFETY:
+// IbvDomain is `Send` because the raw pointers to ibverbs structs can be
+// accessed from any thread, and it is safe to drop `IbvDomain` (and run the
+// ibverbs destructors) from any thread.
+unsafe impl Send for IbvDomain {}
+
+// SAFETY:
+// IbvDomain is `Sync` because the underlying ibverbs APIs are thread-safe.
+unsafe impl Sync for IbvDomain {}
+
+impl Drop for IbvDomain {
+    fn drop(&mut self) {
+        unsafe {
+            rdmaxcel_sys::ibv_dealloc_pd(self.pd);
+        }
+    }
+}
+
+impl IbvDomain {
+    /// Creates a new IbvDomain for the given device.
+    ///
+    /// Initializes the RDMA device context and creates a protection domain.
+    ///
+    /// SAFETY:
+    /// Our memory region (MR) registration uses implicit ODP for RDMA access, which maps large virtual
+    /// address ranges without explicit pinning. This is convenient, but it broadens the memory footprint
+    /// exposed to the NIC and introduces a security liability.
+    ///
+    /// We currently assume a trusted, single-environment and are not enforcing finer-grained memory isolation
+    /// at this layer. We plan to investigate mitigations - such as memory windows or tighter registration
+    /// boundaries in future follow-ups.
+    ///
+    /// # Errors
+    ///
+    /// Returns errors if no RDMA devices are found, the specified device cannot be found,
+    /// device context creation fails, or protection domain allocation fails.
+    pub fn new(device: IbvDevice) -> Result<Self, anyhow::Error> {
+        tracing::debug!("creating IbvDomain for device {}", device.name());
+        unsafe {
+            let device_name = device.name();
+            let mut num_devices = 0i32;
+            let devices = rdmaxcel_sys::ibv_get_device_list(&mut num_devices as *mut _);
+
+            if devices.is_null() || num_devices == 0 {
+                return Err(anyhow::anyhow!("no RDMA devices found"));
+            }
+
+            let mut device_ptr = std::ptr::null_mut();
+            for i in 0..num_devices {
+                let dev = *devices.offset(i as isize);
+                let dev_name =
+                    CStr::from_ptr(rdmaxcel_sys::ibv_get_device_name(dev)).to_string_lossy();
+
+                if dev_name == *device_name {
+                    device_ptr = dev;
+                    break;
+                }
+            }
+
+            if device_ptr.is_null() {
+                rdmaxcel_sys::ibv_free_device_list(devices);
+                return Err(anyhow::anyhow!("device '{}' not found", device_name));
+            }
+            tracing::info!("using RDMA device: {}", device_name);
+
+            let context = rdmaxcel_sys::ibv_open_device(device_ptr);
+            if context.is_null() {
+                rdmaxcel_sys::ibv_free_device_list(devices);
+                let os_error = Error::last_os_error();
+                return Err(anyhow::anyhow!("failed to create context: {}", os_error));
+            }
+
+            let pd = rdmaxcel_sys::ibv_alloc_pd(context);
+            if pd.is_null() {
+                rdmaxcel_sys::ibv_close_device(context);
+                rdmaxcel_sys::ibv_free_device_list(devices);
+                let os_error = Error::last_os_error();
+                return Err(anyhow::anyhow!(
+                    "failed to create protection domain (PD): {}",
+                    os_error
+                ));
+            }
+
+            rdmaxcel_sys::ibv_free_device_list(devices);
+
+            let domain = IbvDomain { context, pd };
+
+            Ok(domain)
+        }
+    }
+}

--- a/monarch_rdma/src/backend/ibverbs/manager_actor.rs
+++ b/monarch_rdma/src/backend/ibverbs/manager_actor.rs
@@ -1,0 +1,874 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+//! # Ibverbs Manager
+//!
+//! Contains ibverbs-specific RDMA logic.
+//!
+//! Manages ibverbs resources including:
+//! - Memory registration (CPU and CUDA via dmabuf or segment scanning)
+//! - Queue pair creation and connection establishment
+//! - RDMA domain and protection domain management
+//! - Device selection and PCI-to-RDMA device mapping
+
+use std::collections::HashMap;
+use std::collections::HashSet;
+use std::sync::Arc;
+use std::time::Duration;
+use std::time::Instant;
+
+use anyhow::Result;
+use async_trait::async_trait;
+use futures::lock::Mutex;
+use hyperactor::ActorId;
+use hyperactor::ActorRef;
+use hyperactor::Context;
+use hyperactor::HandleClient;
+use hyperactor::Handler;
+use hyperactor::OncePortRef;
+use hyperactor::RefClient;
+use hyperactor::clock::Clock;
+use hyperactor::clock::RealClock;
+use serde::Deserialize;
+use serde::Serialize;
+use typeuri::Named;
+
+use super::primitives::IbvConfig;
+use super::primitives::IbvDevice;
+use super::primitives::IbvMemoryRegionView;
+use super::primitives::IbvQpInfo;
+use super::primitives::ibverbs_supported;
+use super::primitives::mlx5dv_supported;
+use super::primitives::resolve_qp_type;
+use crate::rdma_components::RdmaBuffer;
+use crate::rdma_components::RdmaDomain;
+use crate::rdma_components::RdmaQueuePair;
+use crate::rdma_components::get_registered_cuda_segments;
+use crate::rdma_manager_actor::RdmaManagerActor;
+use crate::rdma_manager_actor::RdmaManagerMessageClient;
+use crate::rdma_manager_actor::get_rdmaxcel_error_message;
+use crate::validate_execution_context;
+
+/// Messages handled by [`IbvManagerActor`].
+#[derive(Handler, HandleClient, RefClient, Debug, Serialize, Deserialize, Named)]
+pub(crate) enum IbvManagerMessage {
+    RequestBuffer {
+        owner: ActorRef<RdmaManagerActor>,
+        addr: usize,
+        size: usize,
+        #[reply]
+        reply: OncePortRef<RdmaBuffer>,
+    },
+    ReleaseBuffer {
+        buffer: RdmaBuffer,
+    },
+    RequestQueuePair {
+        self_ref: ActorRef<RdmaManagerActor>,
+        other: ActorRef<RdmaManagerActor>,
+        self_device: String,
+        other_device: String,
+        #[reply]
+        reply: OncePortRef<RdmaQueuePair>,
+    },
+    Connect {
+        other: ActorRef<RdmaManagerActor>,
+        self_device: String,
+        other_device: String,
+        endpoint: IbvQpInfo,
+    },
+    InitializeQP {
+        other: ActorRef<RdmaManagerActor>,
+        self_device: String,
+        other_device: String,
+        #[reply]
+        reply: OncePortRef<bool>,
+    },
+    ConnectionInfo {
+        other: ActorRef<RdmaManagerActor>,
+        self_device: String,
+        other_device: String,
+        #[reply]
+        reply: OncePortRef<IbvQpInfo>,
+    },
+    ReleaseQueuePair {
+        other: ActorRef<RdmaManagerActor>,
+        self_device: String,
+        other_device: String,
+        qp: RdmaQueuePair,
+    },
+    GetQpState {
+        other: ActorRef<RdmaManagerActor>,
+        self_device: String,
+        other_device: String,
+        #[reply]
+        reply: OncePortRef<u32>,
+    },
+}
+wirevalue::register_type!(IbvManagerMessage);
+
+/// Manages all ibverbs-specific RDMA resources and operations.
+///
+/// This struct handles memory registration, queue pair management,
+/// and connection establishment using the ibverbs API.
+#[derive(Debug)]
+#[hyperactor::export(
+    handlers = [
+        IbvManagerMessage,
+    ],
+)]
+pub(crate) struct IbvManagerActor {
+    // Nested map: local_device -> (ActorId, remote_device) -> RdmaQueuePair
+    device_qps: HashMap<String, HashMap<(ActorId, String), RdmaQueuePair>>,
+
+    // Track QPs currently being created to prevent duplicate creation
+    // Wrapped in Arc<Mutex> to allow safe concurrent access
+    pending_qp_creation: Arc<Mutex<HashSet<(String, ActorId, String)>>>,
+
+    // Map of RDMA device names to their domains and loopback QPs
+    // Created lazily when memory is registered for a specific device
+    device_domains: HashMap<String, (RdmaDomain, Option<RdmaQueuePair>)>,
+
+    config: IbvConfig,
+
+    mlx5dv_enabled: bool,
+
+    // Map of unique IbvMemoryRegionView to ibv_mr*.  In case of cuda w/ pytorch its -1
+    // since its managed independently.  Only used for registration/deregistration purposes
+    mr_map: HashMap<usize, usize>,
+
+    // Id for next mrv created
+    mrv_id: usize,
+
+    // Map of PCI addresses to their optimal RDMA devices
+    // This is populated during actor initialization using the device selection algorithm
+    pci_to_device: HashMap<String, IbvDevice>,
+}
+
+impl Drop for IbvManagerActor {
+    fn drop(&mut self) {
+        // Helper function to destroy QP resources
+        // We can't use Drop on RdmaQueuePair because it derives Clone
+        // Note: rdmaxcel_qp_destroy handles destroying both the QP and its CQs internally,
+        // so we must NOT call ibv_destroy_cq separately (would cause double-free/SIGSEGV)
+        fn destroy_queue_pair(qp: &RdmaQueuePair, _context: &str) {
+            unsafe {
+                if qp.qp != 0 {
+                    let rdmaxcel_qp = qp.qp as *mut rdmaxcel_sys::rdmaxcel_qp;
+                    rdmaxcel_sys::rdmaxcel_qp_destroy(rdmaxcel_qp);
+                }
+            }
+        }
+
+        // 1. Clean up all queue pairs (both regular and loopback)
+        for (_device_name, device_map) in self.device_qps.drain() {
+            for ((actor_id, _remote_device), qp) in device_map {
+                destroy_queue_pair(&qp, &format!("actor {:?}", actor_id));
+            }
+        }
+
+        // 2. Clean up device domains (which contain PDs and loopback QPs)
+        for (device_name, (domain, qp)) in self.device_domains.drain() {
+            if let Some(qp) = qp {
+                destroy_queue_pair(&qp, &format!("loopback QP on device {}", device_name));
+            }
+            drop(domain);
+        }
+
+        // 3. Clean up memory regions
+        let _mr_count = self.mr_map.len();
+        for (id, mr_ptr) in self.mr_map.drain() {
+            if mr_ptr != 0 {
+                unsafe {
+                    let result = rdmaxcel_sys::ibv_dereg_mr(mr_ptr as *mut rdmaxcel_sys::ibv_mr);
+                    if result != 0 {
+                        tracing::error!(
+                            "Failed to deregister MR with id {}: error code {}",
+                            id,
+                            result
+                        );
+                    }
+                }
+            }
+        }
+
+        // 4. Deregister all CUDA segments (if using mlx5dv)
+        // The segment scanner in Python handles compatibility checks
+        if self.mlx5dv_enabled {
+            unsafe {
+                let result = rdmaxcel_sys::deregister_segments();
+                if result != 0 {
+                    let error_msg = get_rdmaxcel_error_message(result);
+                    tracing::error!(
+                        "Failed to deregister CUDA segments: {} (error code: {})",
+                        error_msg,
+                        result
+                    );
+                }
+            }
+        }
+    }
+}
+
+impl IbvManagerActor {
+    /// Create a new IbvManagerActor with the given configuration.
+    pub async fn new(params: Option<IbvConfig>) -> Result<Self, anyhow::Error> {
+        if !ibverbs_supported() {
+            return Err(anyhow::anyhow!(
+                "Cannot create IbvManagerActor because RDMA is not supported on this machine"
+            ));
+        }
+
+        // Use provided config or default if none provided
+        let mut config = params.unwrap_or_default();
+        tracing::debug!("rdma is enabled, config device hint: {}", config.device);
+
+        let mlx5dv_enabled = resolve_qp_type(config.qp_type) == rdmaxcel_sys::RDMA_QP_TYPE_MLX5DV;
+
+        // check config and hardware support align
+        if config.use_gpu_direct {
+            match validate_execution_context().await {
+                Ok(_) => {
+                    tracing::info!("GPU Direct RDMA execution context validated successfully");
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        "GPU Direct RDMA execution context validation failed: {}. Downgrading to standard ibverbs mode.",
+                        e
+                    );
+                    config.use_gpu_direct = false;
+                }
+            }
+        }
+
+        // Build the CUDA to RDMA device mapping using device selection algorithm
+        let pci_to_device = crate::device_selection::create_cuda_to_rdma_mapping();
+        tracing::debug!(
+            "Built CUDA to RDMA device mapping with {} entries",
+            pci_to_device.len()
+        );
+
+        Ok(Self {
+            device_qps: HashMap::new(),
+            pending_qp_creation: Arc::new(Mutex::new(HashSet::new())),
+            device_domains: HashMap::new(),
+            config,
+            mlx5dv_enabled,
+            mr_map: HashMap::new(),
+            mrv_id: 0,
+            pci_to_device,
+        })
+    }
+
+    /// Get or create a domain and loopback QP for the specified RDMA device
+    fn get_or_create_device_domain(
+        &mut self,
+        device_name: &str,
+        rdma_device: &IbvDevice,
+    ) -> Result<(RdmaDomain, Option<RdmaQueuePair>), anyhow::Error> {
+        // Check if we already have a domain for this device
+        if let Some((domain, qp)) = self.device_domains.get(device_name) {
+            return Ok((domain.clone(), qp.clone()));
+        }
+
+        // Create new domain for this device
+        let domain = RdmaDomain::new(rdma_device.clone()).map_err(|e| {
+            anyhow::anyhow!("could not create domain for device {}: {}", device_name, e)
+        })?;
+
+        // Print device info if MONARCH_DEBUG_RDMA=1 is set (before initial QP creation)
+        crate::print_device_info_if_debug_enabled(domain.context);
+
+        // Create loopback QP for this domain if mlx5dv is supported (needed for segment registration)
+        // For EFA, we don't need a loopback QP for segment scanning
+        let qp = if mlx5dv_supported() && !crate::efa::is_efa_device() {
+            let mut qp = RdmaQueuePair::new(domain.context, domain.pd, self.config.clone())
+                .map_err(|e| {
+                    anyhow::anyhow!(
+                        "could not create loopback QP for device {}: {}",
+                        device_name,
+                        e
+                    )
+                })?;
+
+            // Get connection info and connect to itself
+            let endpoint = qp.get_qp_info().map_err(|e| {
+                anyhow::anyhow!("could not get QP info for device {}: {}", device_name, e)
+            })?;
+
+            qp.connect(&endpoint).map_err(|e| {
+                anyhow::anyhow!(
+                    "could not connect loopback QP for device {}: {}",
+                    device_name,
+                    e
+                )
+            })?;
+
+            Some(qp)
+        } else {
+            None
+        };
+
+        self.device_domains
+            .insert(device_name.to_string(), (domain.clone(), qp.clone()));
+        Ok((domain, qp))
+    }
+
+    fn find_cuda_segment_for_address(
+        &mut self,
+        addr: usize,
+        size: usize,
+    ) -> Option<IbvMemoryRegionView> {
+        let registered_segments = get_registered_cuda_segments();
+        for segment in registered_segments {
+            let start_addr = segment.phys_address;
+            let end_addr = start_addr + segment.phys_size;
+            if start_addr <= addr && addr + size <= end_addr {
+                let offset = addr - start_addr;
+                let rdma_addr = segment.mr_addr + offset;
+
+                let mrv = IbvMemoryRegionView {
+                    id: self.mrv_id,
+                    virtual_addr: addr,
+                    rdma_addr,
+                    size,
+                    lkey: segment.lkey,
+                    rkey: segment.rkey,
+                };
+                self.mrv_id += 1;
+                return Some(mrv);
+            }
+        }
+        None
+    }
+
+    fn register_mr(
+        &mut self,
+        addr: usize,
+        size: usize,
+    ) -> Result<(IbvMemoryRegionView, String), anyhow::Error> {
+        unsafe {
+            let mut mem_type: i32 = 0;
+            let ptr = addr as rdmaxcel_sys::CUdeviceptr;
+            let err = rdmaxcel_sys::rdmaxcel_cuPointerGetAttribute(
+                &mut mem_type as *mut _ as *mut std::ffi::c_void,
+                rdmaxcel_sys::CU_POINTER_ATTRIBUTE_MEMORY_TYPE,
+                ptr,
+            );
+            let is_cuda = err == rdmaxcel_sys::CUDA_SUCCESS;
+
+            let mut selected_rdma_device = None;
+
+            if is_cuda {
+                // Use rdmaxcel utility to get PCI address from CUDA pointer
+                let mut pci_addr_buf: [std::os::raw::c_char; 16] = [0; 16]; // Enough space for "ffff:ff:ff.0\0"
+                let err = rdmaxcel_sys::get_cuda_pci_address_from_ptr(
+                    addr as u64,
+                    pci_addr_buf.as_mut_ptr(),
+                    pci_addr_buf.len(),
+                );
+                if err != 0 {
+                    let error_msg = get_rdmaxcel_error_message(err);
+                    return Err(anyhow::anyhow!(
+                        "RdmaXcel get_cuda_pci_address_from_ptr failed (addr: 0x{:x}, size: {}): {}",
+                        addr,
+                        size,
+                        error_msg
+                    ));
+                }
+
+                // Convert C string to Rust string
+                let pci_addr = std::ffi::CStr::from_ptr(pci_addr_buf.as_ptr())
+                    .to_str()
+                    .unwrap();
+                selected_rdma_device = self.pci_to_device.get(pci_addr).cloned();
+            }
+
+            // Determine the RDMA device to use
+            let rdma_device = if let Some(device) = selected_rdma_device {
+                device
+            } else {
+                // Fallback to default device from config
+                self.config.device.clone()
+            };
+
+            let device_name = rdma_device.name().clone();
+            tracing::debug!(
+                "Using RDMA device: {} for memory at 0x{:x}",
+                device_name,
+                addr
+            );
+
+            // Get or create domain and loopback QP for this device
+            let (domain, qp) = self.get_or_create_device_domain(&device_name, &rdma_device)?;
+
+            let access = if crate::efa::is_efa_device() {
+                crate::efa::mr_access_flags()
+            } else {
+                rdmaxcel_sys::ibv_access_flags::IBV_ACCESS_LOCAL_WRITE
+                    | rdmaxcel_sys::ibv_access_flags::IBV_ACCESS_REMOTE_WRITE
+                    | rdmaxcel_sys::ibv_access_flags::IBV_ACCESS_REMOTE_READ
+                    | rdmaxcel_sys::ibv_access_flags::IBV_ACCESS_REMOTE_ATOMIC
+            };
+
+            let mut mr: *mut rdmaxcel_sys::ibv_mr = std::ptr::null_mut();
+            let mrv;
+
+            if is_cuda {
+                // First, try to use segment scanning if mlx5dv is enabled
+                let mut segment_mrv = None;
+                if self.mlx5dv_enabled {
+                    // Try to find in already registered segments
+                    segment_mrv = self.find_cuda_segment_for_address(addr, size);
+
+                    // If not found, trigger a re-sync with the allocator and retry
+                    if segment_mrv.is_none() {
+                        let err = rdmaxcel_sys::register_segments(
+                            domain.pd,
+                            qp.unwrap().qp as *mut rdmaxcel_sys::rdmaxcel_qp_t,
+                        );
+                        // Only retry if register_segments succeeded
+                        // If it fails (e.g., scanner returns 0 segments), we'll fall back to dmabuf
+                        if err == 0 {
+                            segment_mrv = self.find_cuda_segment_for_address(addr, size);
+                        }
+                    }
+                }
+
+                // Use segment if found, otherwise fall back to direct dmabuf registration
+                if let Some(mrv_from_segment) = segment_mrv {
+                    mrv = mrv_from_segment;
+                } else {
+                    // Dmabuf path: used when mlx5dv is disabled OR scanner returns no segments
+                    let mut fd: i32 = -1;
+                    rdmaxcel_sys::rdmaxcel_cuMemGetHandleForAddressRange(
+                        &mut fd,
+                        addr as rdmaxcel_sys::CUdeviceptr,
+                        size,
+                        rdmaxcel_sys::CU_MEM_RANGE_HANDLE_TYPE_DMA_BUF_FD,
+                        0,
+                    );
+                    mr =
+                        rdmaxcel_sys::ibv_reg_dmabuf_mr(domain.pd, 0, size, 0, fd, access.0 as i32);
+                    if mr.is_null() {
+                        return Err(anyhow::anyhow!("Failed to register dmabuf MR"));
+                    }
+                    mrv = IbvMemoryRegionView {
+                        id: self.mrv_id,
+                        virtual_addr: addr,
+                        rdma_addr: (*mr).addr as usize,
+                        size,
+                        lkey: (*mr).lkey,
+                        rkey: (*mr).rkey,
+                    };
+                    self.mrv_id += 1;
+                }
+            } else {
+                // CPU memory path
+                mr = rdmaxcel_sys::ibv_reg_mr(
+                    domain.pd,
+                    addr as *mut std::ffi::c_void,
+                    size,
+                    access.0 as i32,
+                );
+
+                if mr.is_null() {
+                    return Err(anyhow::anyhow!("failed to register standard MR"));
+                }
+
+                mrv = IbvMemoryRegionView {
+                    id: self.mrv_id,
+                    virtual_addr: addr,
+                    rdma_addr: (*mr).addr as usize,
+                    size,
+                    lkey: (*mr).lkey,
+                    rkey: (*mr).rkey,
+                };
+                self.mrv_id += 1;
+            }
+            self.mr_map.insert(mrv.id, mr as usize);
+            Ok((mrv, device_name))
+        }
+    }
+
+    fn deregister_mr(&mut self, id: usize) -> Result<(), anyhow::Error> {
+        if let Some(mr_ptr) = self.mr_map.remove(&id) {
+            if mr_ptr != 0 {
+                unsafe {
+                    rdmaxcel_sys::ibv_dereg_mr(mr_ptr as *mut rdmaxcel_sys::ibv_mr);
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl hyperactor::Actor for IbvManagerActor {}
+
+#[async_trait]
+#[hyperactor::handle(IbvManagerMessage)]
+impl IbvManagerMessageHandler for IbvManagerActor {
+    async fn request_buffer(
+        &mut self,
+        _cx: &Context<Self>,
+        owner: ActorRef<RdmaManagerActor>,
+        addr: usize,
+        size: usize,
+    ) -> Result<RdmaBuffer, anyhow::Error> {
+        let (mrv, device_name) = self.register_mr(addr, size)?;
+
+        Ok(RdmaBuffer {
+            owner,
+            mr_id: mrv.id,
+            addr: mrv.rdma_addr,
+            size: mrv.size,
+            rkey: mrv.rkey,
+            lkey: mrv.lkey,
+            device_name,
+        })
+    }
+
+    async fn release_buffer(
+        &mut self,
+        _cx: &Context<Self>,
+        buffer: RdmaBuffer,
+    ) -> Result<(), anyhow::Error> {
+        self.deregister_mr(buffer.mr_id)
+            .map_err(|e| anyhow::anyhow!("could not deregister buffer: {}", e))?;
+        Ok(())
+    }
+
+    async fn request_queue_pair(
+        &mut self,
+        cx: &Context<Self>,
+        self_ref: ActorRef<RdmaManagerActor>,
+        other: ActorRef<RdmaManagerActor>,
+        self_device: String,
+        other_device: String,
+    ) -> Result<RdmaQueuePair, anyhow::Error> {
+        let other_id = other.actor_id().clone();
+
+        // Use the nested map structure: local_device -> (actor_id, remote_device) -> RdmaQueuePair
+        let inner_key = (other_id.clone(), other_device.clone());
+
+        // Check if queue pair exists in map
+        if let Some(device_map) = self.device_qps.get(&self_device) {
+            if let Some(qp) = device_map.get(&inner_key) {
+                return Ok(qp.clone());
+            }
+        }
+
+        // Try to acquire lock and mark as pending (hold lock only once!)
+        let pending_key = (self_device.clone(), other_id.clone(), other_device.clone());
+        let mut pending = self.pending_qp_creation.lock().await;
+
+        if pending.contains(&pending_key) {
+            // Another task is creating this QP, release lock and wait
+            drop(pending);
+
+            // Loop checking device_qps until QP is created (no more locks needed)
+            // Timeout after 1 second
+            let start = Instant::now();
+            let timeout = Duration::from_secs(1);
+
+            loop {
+                RealClock.sleep(Duration::from_micros(200)).await;
+
+                // Check if QP was created while we waited
+                if let Some(device_map) = self.device_qps.get(&self_device) {
+                    if let Some(qp) = device_map.get(&inner_key) {
+                        return Ok(qp.clone());
+                    }
+                }
+
+                // Check for timeout
+                if start.elapsed() >= timeout {
+                    return Err(anyhow::anyhow!(
+                        "Timeout waiting for QP creation (device {} -> actor {} device {}). \
+                         Another task is creating it but hasn't completed in 1 second",
+                        self_device,
+                        other_id,
+                        other_device
+                    ));
+                }
+            }
+        } else {
+            // Not pending, add to set and proceed with creation
+            pending.insert(pending_key.clone());
+            drop(pending);
+            // Fall through to create QP
+        }
+
+        // Queue pair doesn't exist - need to create connection
+        let result = async {
+            let is_loopback =
+                other_id == self_ref.actor_id().clone() && self_device == other_device;
+
+            if is_loopback {
+                // Loopback connection setup
+                self.initialize_qp(cx, other.clone(), self_device.clone(), other_device.clone())
+                    .await?;
+                let endpoint = self
+                    .connection_info(cx, other.clone(), other_device.clone(), self_device.clone())
+                    .await?;
+                self.connect(
+                    cx,
+                    other.clone(),
+                    self_device.clone(),
+                    other_device.clone(),
+                    endpoint,
+                )
+                .await?;
+            } else {
+                // Remote connection setup
+                self.initialize_qp(cx, other.clone(), self_device.clone(), other_device.clone())
+                    .await?;
+                other
+                    .initialize_qp(
+                        cx,
+                        self_ref.clone(),
+                        other_device.clone(),
+                        self_device.clone(),
+                    )
+                    .await?;
+                let other_endpoint: IbvQpInfo = other
+                    .connection_info(
+                        cx,
+                        self_ref.clone(),
+                        other_device.clone(),
+                        self_device.clone(),
+                    )
+                    .await?;
+                self.connect(
+                    cx,
+                    other.clone(),
+                    self_device.clone(),
+                    other_device.clone(),
+                    other_endpoint,
+                )
+                .await?;
+                let local_endpoint = self
+                    .connection_info(cx, other.clone(), self_device.clone(), other_device.clone())
+                    .await?;
+                other
+                    .connect(
+                        cx,
+                        self_ref.clone(),
+                        other_device.clone(),
+                        self_device.clone(),
+                        local_endpoint,
+                    )
+                    .await?;
+
+                // BARRIER: Ensure remote side has completed its connection and is ready
+                let remote_state = other
+                    .get_qp_state(
+                        cx,
+                        self_ref.clone(),
+                        other_device.clone(),
+                        self_device.clone(),
+                    )
+                    .await?;
+
+                if remote_state != rdmaxcel_sys::ibv_qp_state::IBV_QPS_RTS {
+                    return Err(anyhow::anyhow!(
+                        "Remote QP not in RTS state after connection setup. \
+                         Local is ready but remote is in state {}. \
+                         This indicates a synchronization issue in connection setup.",
+                        remote_state
+                    ));
+                }
+            }
+
+            // Now that connection is established, get and clone the queue pair
+            if let Some(device_map) = self.device_qps.get(&self_device) {
+                if let Some(qp) = device_map.get(&inner_key) {
+                    Ok(qp.clone())
+                } else {
+                    Err(anyhow::anyhow!(
+                        "Failed to create connection for actor {} on device {}",
+                        other_id,
+                        other_device
+                    ))
+                }
+            } else {
+                Err(anyhow::anyhow!(
+                    "Failed to create connection for actor {} on device {} - no device map",
+                    other_id,
+                    other_device
+                ))
+            }
+        }
+        .await;
+
+        // Always remove from pending set when done (success or failure)
+        let mut pending = self.pending_qp_creation.lock().await;
+        pending.remove(&pending_key);
+        drop(pending);
+
+        result
+    }
+
+    async fn connect(
+        &mut self,
+        _cx: &Context<Self>,
+        other: ActorRef<RdmaManagerActor>,
+        self_device: String,
+        other_device: String,
+        endpoint: IbvQpInfo,
+    ) -> Result<(), anyhow::Error> {
+        tracing::debug!("connecting with {:?}", other);
+        let other_id = other.actor_id().clone();
+
+        let inner_key = (other_id.clone(), other_device.clone());
+
+        if let Some(device_map) = self.device_qps.get_mut(&self_device) {
+            match device_map.get_mut(&inner_key) {
+                Some(qp) => {
+                    qp.connect(&endpoint).map_err(|e| {
+                        anyhow::anyhow!("could not connect to RDMA endpoint: {}", e)
+                    })?;
+                    Ok(())
+                }
+                None => Err(anyhow::anyhow!(
+                    "No connection found for actor {}",
+                    other_id
+                )),
+            }
+        } else {
+            Err(anyhow::anyhow!(
+                "No device map found for device {}",
+                self_device
+            ))
+        }
+    }
+
+    async fn initialize_qp(
+        &mut self,
+        _cx: &Context<Self>,
+        other: ActorRef<RdmaManagerActor>,
+        self_device: String,
+        other_device: String,
+    ) -> Result<bool, anyhow::Error> {
+        let other_id = other.actor_id().clone();
+        let inner_key = (other_id.clone(), other_device.clone());
+
+        // Check if QP already exists in nested structure
+        if let Some(device_map) = self.device_qps.get(&self_device) {
+            if device_map.contains_key(&inner_key) {
+                return Ok(true);
+            }
+        }
+
+        // Resolve the RDMA device for the local device
+        let rdma_device = self
+            .pci_to_device
+            .iter()
+            .find(|(_, device)| device.name() == &self_device)
+            .map(|(_, device)| device.clone())
+            .unwrap_or_else(|| {
+                // Fallback to default device from config
+                crate::device_selection::resolve_rdma_device(&self.config.device)
+                    .unwrap_or_else(|| self.config.device.clone())
+            });
+
+        // Get or create domain and extract pointers to avoid borrowing issues
+        let (domain_context, domain_pd) = {
+            // Check if we already have a domain for the device
+            let (domain, _) = self.get_or_create_device_domain(&self_device, &rdma_device)?;
+            (domain.context, domain.pd)
+        };
+
+        let qp = RdmaQueuePair::new(domain_context, domain_pd, self.config.clone())
+            .map_err(|e| anyhow::anyhow!("could not create RdmaQueuePair: {}", e))?;
+
+        // Insert the QP into the nested map structure
+        self.device_qps
+            .entry(self_device.clone())
+            .or_insert_with(HashMap::new)
+            .insert(inner_key, qp);
+
+        tracing::debug!(
+            "successfully created a connection with {:?} for local device {} -> remote device {}",
+            other,
+            self_device,
+            other_device
+        );
+
+        Ok(true)
+    }
+
+    async fn connection_info(
+        &mut self,
+        _cx: &Context<Self>,
+        other: ActorRef<RdmaManagerActor>,
+        self_device: String,
+        other_device: String,
+    ) -> Result<IbvQpInfo, anyhow::Error> {
+        tracing::debug!("getting connection info with {:?}", other);
+        let other_id = other.actor_id().clone();
+
+        let inner_key = (other_id.clone(), other_device.clone());
+
+        if let Some(device_map) = self.device_qps.get_mut(&self_device) {
+            match device_map.get_mut(&inner_key) {
+                Some(qp) => {
+                    let connection_info = qp.get_qp_info()?;
+                    Ok(connection_info)
+                }
+                None => Err(anyhow::anyhow!(
+                    "No connection found for actor {}",
+                    other_id
+                )),
+            }
+        } else {
+            Err(anyhow::anyhow!(
+                "No device map found for self device {}",
+                self_device
+            ))
+        }
+    }
+
+    async fn release_queue_pair(
+        &mut self,
+        _cx: &Context<Self>,
+        _other: ActorRef<RdmaManagerActor>,
+        _self_device: String,
+        _other_device: String,
+        _qp: RdmaQueuePair,
+    ) -> Result<(), anyhow::Error> {
+        Ok(())
+    }
+
+    async fn get_qp_state(
+        &mut self,
+        _cx: &Context<Self>,
+        other: ActorRef<RdmaManagerActor>,
+        self_device: String,
+        other_device: String,
+    ) -> Result<u32, anyhow::Error> {
+        let other_id = other.actor_id().clone();
+        let inner_key = (other_id.clone(), other_device.clone());
+
+        if let Some(device_map) = self.device_qps.get_mut(&self_device) {
+            match device_map.get_mut(&inner_key) {
+                Some(qp) => qp.state(),
+                None => Err(anyhow::anyhow!(
+                    "No connection found for actor {} on device {}",
+                    other_id,
+                    other_device
+                )),
+            }
+        } else {
+            Err(anyhow::anyhow!(
+                "No device map found for self device {}",
+                self_device
+            ))
+        }
+    }
+}

--- a/monarch_rdma/src/backend/ibverbs/primitives.rs
+++ b/monarch_rdma/src/backend/ibverbs/primitives.rs
@@ -14,17 +14,17 @@
 //! This file contains primitive data structures for interacting with ibverbs.
 //!
 //! Primitives:
-//! - `IbverbsConfig`: Represents ibverbs specific configurations, holding parameters required to establish and
+//! - `IbvConfig`: Represents ibverbs specific configurations, holding parameters required to establish and
 //!   manage an RDMA connection, including settings for the RDMA device, queue pair attributes, and other
 //!   connection-specific parameters.
-//! - `RdmaDevice`: Represents an RDMA device, i.e. 'mlx5_0'. Contains information about the device, such as:
+//! - `IbvDevice`: Represents an RDMA device, i.e. 'mlx5_0'. Contains information about the device, such as:
 //!   its name, vendor ID, vendor part ID, hardware version, firmware version, node GUID, and capabilities.
-//! - `RdmaPort`: Represents information about the port of an RDMA device, including state, physical state,
+//! - `IbvPort`: Represents information about the port of an RDMA device, including state, physical state,
 //!   LID (Local Identifier), and GID (Global Identifier) information.
-//! - `RdmaMemoryRegionView`: Represents a memory region that can be registered with an RDMA device for direct
+//! - `IbvMemoryRegionView`: Represents a memory region that can be registered with an RDMA device for direct
 //!   memory access operations.
-//! - `RdmaOperation`: Represents the type of RDMA operation to perform (Read or Write).
-//! - `RdmaQpInfo`: Contains connection information needed to establish an RDMA connection with a remote endpoint.
+//! - `IbvOperation`: Represents the type of RDMA operation to perform (Read or Write).
+//! - `IbvQpInfo`: Contains connection information needed to establish an RDMA connection with a remote endpoint.
 //! - `IbvWc`: Wrapper around ibverbs work completion structure, used to track the status of RDMA operations.
 use std::ffi::CStr;
 use std::fmt;
@@ -92,7 +92,7 @@ impl AsMut<rdmaxcel_sys::ibv_gid> for Gid {
 /// Controls whether to use standard ibverbs queue pairs, mlx5dv extended queue pairs,
 /// or EFA SRD queue pairs. Auto mode automatically selects based on device capabilities.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
-pub enum RdmaQpType {
+pub enum IbvQpType {
     /// Auto-detect based on device capabilities
     Auto,
     /// Force standard ibverbs queue pair
@@ -103,10 +103,10 @@ pub enum RdmaQpType {
     Efa,
 }
 
-/// Converts `RdmaQpType` to the corresponding integer enum value in rdmaxcel_sys.
-pub fn resolve_qp_type(qp_type: RdmaQpType) -> u32 {
+/// Converts `IbvQpType` to the corresponding integer enum value in rdmaxcel_sys.
+pub fn resolve_qp_type(qp_type: IbvQpType) -> u32 {
     match qp_type {
-        RdmaQpType::Auto => {
+        IbvQpType::Auto => {
             if crate::efa::is_efa_device() {
                 rdmaxcel_sys::RDMA_QP_TYPE_EFA
             } else if mlx5dv_supported() {
@@ -115,9 +115,9 @@ pub fn resolve_qp_type(qp_type: RdmaQpType) -> u32 {
                 rdmaxcel_sys::RDMA_QP_TYPE_STANDARD
             }
         }
-        RdmaQpType::Standard => rdmaxcel_sys::RDMA_QP_TYPE_STANDARD,
-        RdmaQpType::Mlx5dv => rdmaxcel_sys::RDMA_QP_TYPE_MLX5DV,
-        RdmaQpType::Efa => rdmaxcel_sys::RDMA_QP_TYPE_EFA,
+        IbvQpType::Standard => rdmaxcel_sys::RDMA_QP_TYPE_STANDARD,
+        IbvQpType::Mlx5dv => rdmaxcel_sys::RDMA_QP_TYPE_MLX5DV,
+        IbvQpType::Efa => rdmaxcel_sys::RDMA_QP_TYPE_EFA,
     }
 }
 
@@ -127,9 +127,9 @@ pub fn resolve_qp_type(qp_type: RdmaQpType) -> u32 {
 /// It includes settings for the RDMA device, queue pair attributes, and other connection-specific
 /// parameters.
 #[derive(Debug, Named, Clone, Serialize, Deserialize)]
-pub struct IbverbsConfig {
+pub struct IbvConfig {
     /// `device` - The RDMA device to use for the connection.
-    pub device: RdmaDevice,
+    pub device: IbvDevice,
     /// `cq_entries` - The number of completion queue entries.
     pub cq_entries: i32,
     /// `port_num` - The physical port number on the device.
@@ -168,17 +168,17 @@ pub struct IbverbsConfig {
     /// This is used to allow the hardware to settle before starting the first transmission.
     pub hw_init_delay_ms: u64,
     /// `qp_type` - The type of queue pair to create (Auto, Standard, or Mlx5dv).
-    pub qp_type: RdmaQpType,
+    pub qp_type: IbvQpType,
 }
-wirevalue::register_type!(IbverbsConfig);
+wirevalue::register_type!(IbvConfig);
 
 /// Default RDMA parameters below are based on common values from rdma-core examples
 /// For high-performance or production use, consider tuning
 /// based on ibv_query_device() results and workload characteristics
-impl Default for IbverbsConfig {
+impl Default for IbvConfig {
     fn default() -> Self {
         let mut config = Self {
-            device: RdmaDevice::default(),
+            device: IbvDevice::default(),
             cq_entries: 1024,
             port_num: 1,
             gid_index: 3,
@@ -197,7 +197,7 @@ impl Default for IbverbsConfig {
             psn: rand::random::<u32>() & 0xffffff,
             use_gpu_direct: false, // nv_peermem enabled for cuda
             hw_init_delay_ms: 2,
-            qp_type: RdmaQpType::Auto,
+            qp_type: IbvQpType::Auto,
         };
         if crate::efa::is_efa_device() {
             crate::efa::apply_efa_defaults(&mut config);
@@ -206,8 +206,8 @@ impl Default for IbverbsConfig {
     }
 }
 
-impl IbverbsConfig {
-    /// Create a new IbverbsConfig targeting a specific device
+impl IbvConfig {
+    /// Create a new IbvConfig targeting a specific device
     ///
     /// Device targets use a unified "type:id" format:
     /// - "cpu:N" -> finds RDMA device closest to NUMA node N
@@ -224,7 +224,7 @@ impl IbverbsConfig {
     ///
     /// # Returns
     ///
-    /// * `IbverbsConfig` with resolved device, or default device if resolution fails
+    /// * `IbvConfig` with resolved device, or default device if resolution fails
     pub fn targeting(target: &str) -> Self {
         // Normalize shortcuts
         let normalized_target = match target {
@@ -234,7 +234,7 @@ impl IbverbsConfig {
         };
 
         let device = crate::device_selection::select_optimal_rdma_device(Some(normalized_target))
-            .unwrap_or_else(RdmaDevice::default);
+            .unwrap_or_else(IbvDevice::default);
 
         Self {
             device,
@@ -243,11 +243,11 @@ impl IbverbsConfig {
     }
 }
 
-impl std::fmt::Display for IbverbsConfig {
+impl std::fmt::Display for IbvConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "IbverbsConfig {{ device: {}, port_num: {}, gid_index: {}, max_send_wr: {}, max_recv_wr: {}, max_send_sge: {}, max_recv_sge: {}, path_mtu: {:?}, retry_cnt: {}, rnr_retry: {}, qp_timeout: {}, min_rnr_timer: {}, max_dest_rd_atomic: {}, max_rd_atomic: {}, pkey_index: {}, psn: 0x{:x} }}",
+            "IbvConfig {{ device: {}, port_num: {}, gid_index: {}, max_send_wr: {}, max_recv_wr: {}, max_send_sge: {}, max_recv_sge: {}, path_mtu: {:?}, retry_cnt: {}, rnr_retry: {}, qp_timeout: {}, min_rnr_timer: {}, max_dest_rd_atomic: {}, max_rd_atomic: {}, pkey_index: {}, psn: 0x{:x} }}",
             self.device.name(),
             self.port_num,
             self.gid_index,
@@ -287,7 +287,7 @@ impl std::fmt::Display for IbverbsConfig {
 /// }
 /// ```
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct RdmaDevice {
+pub struct IbvDevice {
     /// `name` - The name of the RDMA device (e.g., "mlx5_0").
     pub name: String,
     /// `vendor_id` - The vendor ID of the device.
@@ -301,7 +301,7 @@ pub struct RdmaDevice {
     /// `node_guid` - Node GUID (Globally Unique Identifier) of the device.
     node_guid: u64,
     /// `ports` - Vector of ports available on this device.
-    ports: Vec<RdmaPort>,
+    ports: Vec<IbvPort>,
     /// `max_qp` - Maximum number of queue pairs supported.
     max_qp: i32,
     /// `max_cq` - Maximum number of completion queues supported.
@@ -316,14 +316,14 @@ pub struct RdmaDevice {
     max_sge: i32,
 }
 
-impl RdmaDevice {
+impl IbvDevice {
     /// Returns the name of the RDMA device.
     pub fn name(&self) -> &String {
         &self.name
     }
 
     /// Returns the first available RDMA device, if any.
-    pub fn first_available() -> Option<RdmaDevice> {
+    pub fn first_available() -> Option<IbvDevice> {
         let devices = get_all_devices();
         if devices.is_empty() {
             None
@@ -358,7 +358,7 @@ impl RdmaDevice {
     }
 
     /// Returns a reference to the vector of ports available on the RDMA device.
-    pub fn ports(&self) -> &Vec<RdmaPort> {
+    pub fn ports(&self) -> &Vec<IbvPort> {
         &self.ports
     }
 
@@ -393,7 +393,7 @@ impl RdmaDevice {
     }
 }
 
-impl Default for RdmaDevice {
+impl Default for IbvDevice {
     fn default() -> Self {
         // Try to get a smart default using device selection logic (defaults to cpu:0)
         if let Some(device) = crate::device_selection::select_optimal_rdma_device(Some("cpu:0")) {
@@ -409,7 +409,7 @@ impl Default for RdmaDevice {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct RdmaPort {
+pub struct IbvPort {
     /// `port_num` - The physical port number on the device.
     port_num: u8,
     /// `state` - The current state of the port.
@@ -432,7 +432,7 @@ pub struct RdmaPort {
     gid_tbl_len: i32,
 }
 
-impl fmt::Display for RdmaDevice {
+impl fmt::Display for IbvDevice {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         writeln!(f, "{}", self.name)?;
         writeln!(f, "\tNumber of ports: {}", self.ports.len())?;
@@ -456,7 +456,7 @@ impl fmt::Display for RdmaDevice {
     }
 }
 
-impl fmt::Display for RdmaPort {
+impl fmt::Display for IbvPort {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         writeln!(f, "\tPort {}:", self.port_num)?;
         writeln!(f, "\t\tState: {}", self.state)?;
@@ -570,10 +570,10 @@ pub fn format_gid(gid: &[u8; 16]) -> String {
 ///
 /// # Returns
 ///
-/// A vector of `RdmaDevice` structures, each representing an RDMA device in the system.
+/// A vector of `IbvDevice` structures, each representing an RDMA device in the system.
 /// Returns an empty vector if no devices are found or if there was an error querying
 /// the devices.
-pub fn get_all_devices() -> Vec<RdmaDevice> {
+pub fn get_all_devices() -> Vec<IbvDevice> {
     let mut devices = Vec::new();
 
     // SAFETY: We are calling several C functions from libibverbs.
@@ -609,7 +609,7 @@ pub fn get_all_devices() -> Vec<RdmaDevice> {
                 .to_string_lossy()
                 .into_owned();
 
-            let mut rdma_device = RdmaDevice {
+            let mut rdma_device = IbvDevice {
                 name: device_name,
                 vendor_id: device_attr.vendor_id,
                 vendor_part_id: device_attr.vendor_part_id,
@@ -647,7 +647,7 @@ pub fn get_all_devices() -> Vec<RdmaDevice> {
                     "N/A".to_string()
                 };
 
-                let rdma_port = RdmaPort {
+                let rdma_port = IbvPort {
                     port_num,
                     state,
                     physical_state,
@@ -770,7 +770,7 @@ pub fn rdma_supported() -> bool {
     Clone,
     Copy
 )]
-pub struct RdmaMemoryRegionView {
+pub struct IbvMemoryRegionView {
     // id should be unique with a given rdmam manager
     pub id: usize,
     /// Virtual address in the process address space.
@@ -784,25 +784,25 @@ pub struct RdmaMemoryRegionView {
     pub rkey: u32,
 }
 
-// SAFETY: RdmaMemoryRegionView can be safely sent between threads because it only
+// SAFETY: IbvMemoryRegionView can be safely sent between threads because it only
 // contains address and size information without any thread-local state. However,
 // this DOES NOT provide any protection against data races in the underlying memory.
 // If one thread initiates an RDMA operation while another thread modifies the same
 // memory region, undefined behavior will occur. The caller is responsible for proper
 // synchronization of access to the underlying memory.
-unsafe impl Send for RdmaMemoryRegionView {}
+unsafe impl Send for IbvMemoryRegionView {}
 
-// SAFETY: RdmaMemoryRegionView is safe for concurrent access by multiple threads
+// SAFETY: IbvMemoryRegionView is safe for concurrent access by multiple threads
 // as it only provides a view into memory without modifying its own state. However,
 // it provides NO PROTECTION against concurrent access to the underlying memory region.
 // The caller must ensure proper synchronization when:
 // 1. Initiating RDMA operations while local code reads/writes the same memory
 // 2. Performing multiple overlapping RDMA operations on the same memory region
 // 3. Freeing or reallocating memory that has in-flight RDMA operations
-unsafe impl Sync for RdmaMemoryRegionView {}
+unsafe impl Sync for IbvMemoryRegionView {}
 
-impl RdmaMemoryRegionView {
-    /// Creates a new `RdmaMemoryRegionView` with the given address and size.
+impl IbvMemoryRegionView {
+    /// Creates a new `IbvMemoryRegionView` with the given address and size.
     pub fn new(
         id: usize,
         virtual_addr: usize,
@@ -835,7 +835,7 @@ impl RdmaMemoryRegionView {
 /// * `Read` - Represents an RDMA read operation where data is read from a remote memory
 ///   region into the local memory.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum RdmaOperation {
+pub enum IbvOperation {
     /// RDMA write operations
     Write,
     WriteWithImm,
@@ -845,22 +845,22 @@ pub enum RdmaOperation {
     Recv,
 }
 
-impl From<RdmaOperation> for rdmaxcel_sys::ibv_wr_opcode::Type {
-    fn from(op: RdmaOperation) -> Self {
+impl From<IbvOperation> for rdmaxcel_sys::ibv_wr_opcode::Type {
+    fn from(op: IbvOperation) -> Self {
         match op {
-            RdmaOperation::Write => rdmaxcel_sys::ibv_wr_opcode::IBV_WR_RDMA_WRITE,
-            RdmaOperation::WriteWithImm => rdmaxcel_sys::ibv_wr_opcode::IBV_WR_RDMA_WRITE_WITH_IMM,
-            RdmaOperation::Read => rdmaxcel_sys::ibv_wr_opcode::IBV_WR_RDMA_READ,
-            RdmaOperation::Recv => panic!("Invalid wr opcode"),
+            IbvOperation::Write => rdmaxcel_sys::ibv_wr_opcode::IBV_WR_RDMA_WRITE,
+            IbvOperation::WriteWithImm => rdmaxcel_sys::ibv_wr_opcode::IBV_WR_RDMA_WRITE_WITH_IMM,
+            IbvOperation::Read => rdmaxcel_sys::ibv_wr_opcode::IBV_WR_RDMA_READ,
+            IbvOperation::Recv => panic!("Invalid wr opcode"),
         }
     }
 }
 
-impl From<rdmaxcel_sys::ibv_wc_opcode::Type> for RdmaOperation {
+impl From<rdmaxcel_sys::ibv_wc_opcode::Type> for IbvOperation {
     fn from(op: rdmaxcel_sys::ibv_wc_opcode::Type) -> Self {
         match op {
-            rdmaxcel_sys::ibv_wc_opcode::IBV_WC_RDMA_WRITE => RdmaOperation::Write,
-            rdmaxcel_sys::ibv_wc_opcode::IBV_WC_RDMA_READ => RdmaOperation::Read,
+            rdmaxcel_sys::ibv_wc_opcode::IBV_WC_RDMA_WRITE => IbvOperation::Write,
+            rdmaxcel_sys::ibv_wc_opcode::IBV_WC_RDMA_READ => IbvOperation::Read,
             _ => panic!("Unsupported operation type"),
         }
     }
@@ -868,11 +868,11 @@ impl From<rdmaxcel_sys::ibv_wc_opcode::Type> for RdmaOperation {
 
 /// Contains information needed to establish an RDMA queue pair with a remote endpoint.
 ///
-/// `RdmaQpInfo` encapsulates all the necessary information to establish a queue pair
+/// `IbvQpInfo` encapsulates all the necessary information to establish a queue pair
 /// with a remote RDMA device. This includes queue pair number, LID (Local Identifier),
 /// GID (Global Identifier), remote memory address, remote key, and packet sequence number.
 #[derive(Default, Named, Clone, serde::Serialize, serde::Deserialize)]
-pub struct RdmaQpInfo {
+pub struct IbvQpInfo {
     /// `qp_num` - Queue Pair Number, uniquely identifies a queue pair on the remote device
     pub qp_num: u32,
     /// `lid` - Local Identifier, used for addressing in InfiniBand subnet
@@ -882,13 +882,13 @@ pub struct RdmaQpInfo {
     /// `psn` - Packet Sequence Number, used for ordering packets
     pub psn: u32,
 }
-wirevalue::register_type!(RdmaQpInfo);
+wirevalue::register_type!(IbvQpInfo);
 
-impl std::fmt::Debug for RdmaQpInfo {
+impl std::fmt::Debug for IbvQpInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "RdmaQpInfo {{ qp_num: {}, lid: {}, gid: {:?}, psn: 0x{:x} }}",
+            "IbvQpInfo {{ qp_num: {}, lid: {}, gid: {:?}, psn: 0x{:x} }}",
             self.qp_num, self.lid, self.gid, self.psn
         )
     }
@@ -1015,7 +1015,7 @@ mod tests {
 
     #[test]
     fn test_device_display() {
-        if let Some(device) = RdmaDevice::first_available() {
+        if let Some(device) = IbvDevice::first_available() {
             let display_output = format!("{}", device);
             assert!(
                 display_output.contains(&device.name),
@@ -1030,7 +1030,7 @@ mod tests {
 
     #[test]
     fn test_port_display() {
-        if let Some(device) = RdmaDevice::first_available() {
+        if let Some(device) = IbvDevice::first_available() {
             if !device.ports().is_empty() {
                 let port = &device.ports()[0];
                 let display_output = format!("{}", port);
@@ -1050,26 +1050,26 @@ mod tests {
     fn test_rdma_operation_conversion() {
         assert_eq!(
             rdmaxcel_sys::ibv_wr_opcode::IBV_WR_RDMA_WRITE,
-            rdmaxcel_sys::ibv_wr_opcode::Type::from(RdmaOperation::Write)
+            rdmaxcel_sys::ibv_wr_opcode::Type::from(IbvOperation::Write)
         );
         assert_eq!(
             rdmaxcel_sys::ibv_wr_opcode::IBV_WR_RDMA_READ,
-            rdmaxcel_sys::ibv_wr_opcode::Type::from(RdmaOperation::Read)
+            rdmaxcel_sys::ibv_wr_opcode::Type::from(IbvOperation::Read)
         );
 
         assert_eq!(
-            RdmaOperation::Write,
-            RdmaOperation::from(rdmaxcel_sys::ibv_wc_opcode::IBV_WC_RDMA_WRITE)
+            IbvOperation::Write,
+            IbvOperation::from(rdmaxcel_sys::ibv_wc_opcode::IBV_WC_RDMA_WRITE)
         );
         assert_eq!(
-            RdmaOperation::Read,
-            RdmaOperation::from(rdmaxcel_sys::ibv_wc_opcode::IBV_WC_RDMA_READ)
+            IbvOperation::Read,
+            IbvOperation::from(rdmaxcel_sys::ibv_wc_opcode::IBV_WC_RDMA_READ)
         );
     }
 
     #[test]
     fn test_rdma_endpoint() {
-        let endpoint = RdmaQpInfo {
+        let endpoint = IbvQpInfo {
             qp_num: 42,
             lid: 123,
             gid: None,

--- a/monarch_rdma/src/efa.rs
+++ b/monarch_rdma/src/efa.rs
@@ -13,7 +13,7 @@
 
 use std::sync::OnceLock;
 
-use crate::ibverbs_primitives::IbverbsConfig;
+use crate::backend::ibverbs::primitives::IbvConfig;
 
 /// Cached result of EFA device check.
 static EFA_DEVICE_CACHE: OnceLock<bool> = OnceLock::new();
@@ -56,13 +56,13 @@ fn is_efa_device_impl() -> bool {
     }
 }
 
-/// Applies EFA-specific defaults to an `IbverbsConfig`.
+/// Applies EFA-specific defaults to an `IbvConfig`.
 ///
 /// EFA devices have different capabilities than standard InfiniBand/RoCE devices:
 /// - GID index 0 (instead of 3)
 /// - Max 1 SGE per work request
 /// - No RDMA atomics support
-pub fn apply_efa_defaults(config: &mut IbverbsConfig) {
+pub fn apply_efa_defaults(config: &mut IbvConfig) {
     config.gid_index = 0;
     config.max_send_sge = 1;
     config.max_recv_sge = 1;

--- a/monarch_rdma/src/lib.rs
+++ b/monarch_rdma/src/lib.rs
@@ -9,16 +9,16 @@
 // RDMA requires frequent unsafe code blocks
 #![allow(clippy::undocumented_unsafe_blocks)]
 
+pub(crate) mod backend;
 pub mod device_selection;
 pub mod efa;
-mod ibverbs_primitives;
 mod rdma_components;
 mod rdma_manager_actor;
 
 #[macro_use]
 mod macros;
 
-pub use ibverbs_primitives::*;
+pub use backend::ibverbs::primitives::*;
 pub use rdma_components::SegmentScannerFn;
 // Re-export segment scanner types for extension crate
 pub use rdma_components::register_segment_scanner;

--- a/monarch_rdma/src/rdma_manager_actor.rs
+++ b/monarch_rdma/src/rdma_manager_actor.rs
@@ -12,10 +12,8 @@
 //!
 //! ## Architecture
 //!
-//! `RdmaManagerActor` is a per-host entity that:
-//! - Manages connections to multiple remote RdmaManagerActors (i.e. across the hosts in a Monarch cluster)
-//! - Handles memory registration, connection setup, and data transfer
-//! - Manages all RdmaBuffers in its associated host
+//! `RdmaManagerActor` is a per-host entity that delegates to backend-specific
+//! managers (currently `IbvManagerActor`) for the actual RDMA operations.
 //!
 //! ## Core Operations
 //!
@@ -27,16 +25,10 @@
 //! ## Usage
 //!
 //! See test examples: `test_rdma_write_loopback` and `test_rdma_read_loopback`.
-use std::collections::HashMap;
-use std::collections::HashSet;
-use std::sync::Arc;
-use std::time::Duration;
-use std::time::Instant;
 
 use async_trait::async_trait;
-use futures::lock::Mutex;
 use hyperactor::Actor;
-use hyperactor::ActorId;
+use hyperactor::ActorHandle;
 use hyperactor::ActorRef;
 use hyperactor::Context;
 use hyperactor::HandleClient;
@@ -45,25 +37,18 @@ use hyperactor::Instance;
 use hyperactor::OncePortRef;
 use hyperactor::RefClient;
 use hyperactor::RemoteSpawn;
-use hyperactor::clock::Clock;
 use hyperactor::supervision::ActorSupervisionEvent;
 use hyperactor_config::Flattrs;
 use serde::Deserialize;
 use serde::Serialize;
 use typeuri::Named;
 
-use crate::efa::is_efa_device;
-use crate::ibverbs_primitives::IbverbsConfig;
-use crate::ibverbs_primitives::RdmaMemoryRegionView;
-use crate::ibverbs_primitives::RdmaQpInfo;
-use crate::ibverbs_primitives::ibverbs_supported;
-use crate::ibverbs_primitives::mlx5dv_supported;
-use crate::ibverbs_primitives::resolve_qp_type;
+use crate::backend::ibverbs::manager_actor::IbvManagerActor;
+use crate::backend::ibverbs::manager_actor::IbvManagerMessageClient;
+use crate::backend::ibverbs::primitives::IbvConfig;
+use crate::backend::ibverbs::primitives::IbvQpInfo;
 use crate::rdma_components::RdmaBuffer;
-use crate::rdma_components::RdmaDomain;
 use crate::rdma_components::RdmaQueuePair;
-use crate::rdma_components::get_registered_cuda_segments;
-use crate::validate_execution_context;
 
 /// Helper function to get detailed error messages from RDMAXCEL error codes
 pub fn get_rdmaxcel_error_message(error_code: i32) -> String {
@@ -104,7 +89,7 @@ pub enum RdmaManagerMessage {
         self_device: String,
         other_device: String,
         /// `endpoint` - Connection information needed to establish the RDMA connection
-        endpoint: RdmaQpInfo,
+        endpoint: IbvQpInfo,
     },
     InitializeQP {
         other: ActorRef<RdmaManagerActor>,
@@ -121,7 +106,7 @@ pub enum RdmaManagerMessage {
         other_device: String,
         #[reply]
         /// `reply` - Reply channel to return the connection info
-        reply: OncePortRef<RdmaQpInfo>,
+        reply: OncePortRef<IbvQpInfo>,
     },
     ReleaseQueuePair {
         /// `other` - The ActorId to release queue pair for
@@ -143,6 +128,35 @@ pub enum RdmaManagerMessage {
 wirevalue::register_type!(RdmaManagerMessage);
 
 #[derive(Debug)]
+enum RdmaBackendActor<A: Actor> {
+    Uninit,
+    Created(A),
+    Spawned(ActorHandle<A>),
+}
+
+impl<A: Actor> RdmaBackendActor<A> {
+    fn spawn(&mut self, rdma_manager: &Instance<RdmaManagerActor>) -> anyhow::Result<()> {
+        let created = std::mem::replace(self, RdmaBackendActor::Uninit);
+        let actor = if let RdmaBackendActor::Created(actor) = created {
+            actor
+        } else {
+            panic!("rdma backend actor already spawned");
+        };
+        let handle = rdma_manager.spawn(actor)?;
+        *self = RdmaBackendActor::Spawned(handle);
+        Ok(())
+    }
+
+    fn handle(&self) -> &ActorHandle<A> {
+        if let RdmaBackendActor::Spawned(handle) = self {
+            handle
+        } else {
+            panic!("cannot get handle")
+        }
+    }
+}
+
+#[derive(Debug)]
 #[hyperactor::export(
     spawn = true,
     handlers = [
@@ -150,397 +164,27 @@ wirevalue::register_type!(RdmaManagerMessage);
     ],
 )]
 pub struct RdmaManagerActor {
-    // Nested map: local_device -> (ActorId, remote_device) -> RdmaQueuePair
-    device_qps: HashMap<String, HashMap<(ActorId, String), RdmaQueuePair>>,
-
-    // Track QPs currently being created to prevent duplicate creation
-    // Wrapped in Arc<Mutex> to allow safe concurrent access
-    pending_qp_creation: Arc<Mutex<HashSet<(String, ActorId, String)>>>,
-
-    // Map of RDMA device names to their domains and loopback QPs
-    // Created lazily when memory is registered for a specific device
-    device_domains: HashMap<String, (RdmaDomain, Option<RdmaQueuePair>)>,
-
-    config: IbverbsConfig,
-
-    mlx5dv_enabled: bool,
-
-    // Map of unique RdmaMemoryRegionView to ibv_mr*.  In case of cuda w/ pytorch its -1
-    // since its managed independently.  Only used for registration/deregistration purposes
-    mr_map: HashMap<usize, usize>,
-    // Id for next mrv created
-    mrv_id: usize,
-
-    // Map of PCI addresses to their optimal RDMA devices
-    // This is populated during actor initialization using the device selection algorithm
-    pci_to_device: HashMap<String, crate::ibverbs_primitives::RdmaDevice>,
-}
-
-impl Drop for RdmaManagerActor {
-    fn drop(&mut self) {
-        // Helper function to destroy QP resources
-        // We can't use Drop on RdmaQueuePair because it derives Clone
-        // Note: rdmaxcel_qp_destroy handles destroying both the QP and its CQs internally,
-        // so we must NOT call ibv_destroy_cq separately (would cause double-free/SIGSEGV)
-        fn destroy_queue_pair(qp: &RdmaQueuePair, _context: &str) {
-            unsafe {
-                if qp.qp != 0 {
-                    let rdmaxcel_qp = qp.qp as *mut rdmaxcel_sys::rdmaxcel_qp;
-                    rdmaxcel_sys::rdmaxcel_qp_destroy(rdmaxcel_qp);
-                }
-            }
-        }
-
-        // 1. Clean up all queue pairs (both regular and loopback)
-        for (_device_name, device_map) in self.device_qps.drain() {
-            for ((actor_id, _remote_device), qp) in device_map {
-                destroy_queue_pair(&qp, &format!("actor {:?}", actor_id));
-            }
-        }
-
-        // 2. Clean up device domains (which contain PDs and loopback QPs)
-        for (device_name, (domain, qp)) in self.device_domains.drain() {
-            if let Some(qp) = qp {
-                destroy_queue_pair(&qp, &format!("loopback QP on device {}", device_name));
-            }
-            drop(domain);
-        }
-
-        // 3. Clean up memory regions
-        let _mr_count = self.mr_map.len();
-        for (id, mr_ptr) in self.mr_map.drain() {
-            if mr_ptr != 0 {
-                unsafe {
-                    let result = rdmaxcel_sys::ibv_dereg_mr(mr_ptr as *mut rdmaxcel_sys::ibv_mr);
-                    if result != 0 {
-                        tracing::error!(
-                            "Failed to deregister MR with id {}: error code {}",
-                            id,
-                            result
-                        );
-                    }
-                }
-            }
-        }
-
-        // 4. Deregister all CUDA segments (if using mlx5dv)
-        // The segment scanner in Python handles compatibility checks
-        if self.mlx5dv_enabled {
-            unsafe {
-                let result = rdmaxcel_sys::deregister_segments();
-                if result != 0 {
-                    let error_msg = get_rdmaxcel_error_message(result);
-                    tracing::error!(
-                        "Failed to deregister CUDA segments: {} (error code: {})",
-                        error_msg,
-                        result
-                    );
-                }
-            }
-        }
-    }
-}
-
-impl RdmaManagerActor {
-    /// Get or create a domain and loopback QP for the specified RDMA device
-    fn get_or_create_device_domain(
-        &mut self,
-        device_name: &str,
-        rdma_device: &crate::ibverbs_primitives::RdmaDevice,
-    ) -> Result<(RdmaDomain, Option<RdmaQueuePair>), anyhow::Error> {
-        // Check if we already have a domain for this device
-        if let Some((domain, qp)) = self.device_domains.get(device_name) {
-            return Ok((domain.clone(), qp.clone()));
-        }
-
-        // Create new domain for this device
-        let domain = RdmaDomain::new(rdma_device.clone()).map_err(|e| {
-            anyhow::anyhow!("could not create domain for device {}: {}", device_name, e)
-        })?;
-
-        // Print device info if MONARCH_DEBUG_RDMA=1 is set (before initial QP creation)
-        crate::print_device_info_if_debug_enabled(domain.context);
-
-        // Create loopback QP for this domain if mlx5dv is supported (needed for segment registration)
-        // For EFA, we don't need a loopback QP for segment scanning
-        let qp = if mlx5dv_supported() && !is_efa_device() {
-            let mut qp = RdmaQueuePair::new(domain.context, domain.pd, self.config.clone())
-                .map_err(|e| {
-                    anyhow::anyhow!(
-                        "could not create loopback QP for device {}: {}",
-                        device_name,
-                        e
-                    )
-                })?;
-
-            // Get connection info and connect to itself
-            let endpoint = qp.get_qp_info().map_err(|e| {
-                anyhow::anyhow!("could not get QP info for device {}: {}", device_name, e)
-            })?;
-
-            qp.connect(&endpoint).map_err(|e| {
-                anyhow::anyhow!(
-                    "could not connect loopback QP for device {}: {}",
-                    device_name,
-                    e
-                )
-            })?;
-
-            Some(qp)
-        } else {
-            None
-        };
-
-        self.device_domains
-            .insert(device_name.to_string(), (domain.clone(), qp.clone()));
-        Ok((domain, qp))
-    }
-
-    fn find_cuda_segment_for_address(
-        &mut self,
-        addr: usize,
-        size: usize,
-    ) -> Option<RdmaMemoryRegionView> {
-        let registered_segments = get_registered_cuda_segments();
-        for segment in registered_segments {
-            let start_addr = segment.phys_address;
-            let end_addr = start_addr + segment.phys_size;
-            if start_addr <= addr && addr + size <= end_addr {
-                let offset = addr - start_addr;
-                let rdma_addr = segment.mr_addr + offset;
-
-                let mrv = RdmaMemoryRegionView {
-                    id: self.mrv_id,
-                    virtual_addr: addr,
-                    rdma_addr,
-                    size,
-                    lkey: segment.lkey,
-                    rkey: segment.rkey,
-                };
-                self.mrv_id += 1;
-                return Some(mrv);
-            }
-        }
-        None
-    }
-
-    fn register_mr(
-        &mut self,
-        addr: usize,
-        size: usize,
-    ) -> Result<(RdmaMemoryRegionView, String), anyhow::Error> {
-        unsafe {
-            let mut mem_type: i32 = 0;
-            let ptr = addr as rdmaxcel_sys::CUdeviceptr;
-            let err = rdmaxcel_sys::rdmaxcel_cuPointerGetAttribute(
-                &mut mem_type as *mut _ as *mut std::ffi::c_void,
-                rdmaxcel_sys::CU_POINTER_ATTRIBUTE_MEMORY_TYPE,
-                ptr,
-            );
-            let is_cuda = err == rdmaxcel_sys::CUDA_SUCCESS;
-
-            let mut selected_rdma_device = None;
-
-            if is_cuda {
-                // Use rdmaxcel utility to get PCI address from CUDA pointer
-                let mut pci_addr_buf: [std::os::raw::c_char; 16] = [0; 16]; // Enough space for "ffff:ff:ff.0\0"
-                let err = rdmaxcel_sys::get_cuda_pci_address_from_ptr(
-                    addr as u64,
-                    pci_addr_buf.as_mut_ptr(),
-                    pci_addr_buf.len(),
-                );
-                if err != 0 {
-                    let error_msg = get_rdmaxcel_error_message(err);
-                    return Err(anyhow::anyhow!(
-                        "RdmaXcel get_cuda_pci_address_from_ptr failed (addr: 0x{:x}, size: {}): {}",
-                        addr,
-                        size,
-                        error_msg
-                    ));
-                }
-
-                // Convert C string to Rust string
-                let pci_addr = std::ffi::CStr::from_ptr(pci_addr_buf.as_ptr())
-                    .to_str()
-                    .unwrap();
-                selected_rdma_device = self.pci_to_device.get(pci_addr).cloned();
-            }
-
-            // Determine the RDMA device to use
-            let rdma_device = if let Some(device) = selected_rdma_device {
-                device
-            } else {
-                // Fallback to default device from config
-                self.config.device.clone()
-            };
-
-            let device_name = rdma_device.name().clone();
-            tracing::debug!(
-                "Using RDMA device: {} for memory at 0x{:x}",
-                device_name,
-                addr
-            );
-
-            // Get or create domain and loopback QP for this device
-            let (domain, qp) = self.get_or_create_device_domain(&device_name, &rdma_device)?;
-
-            let access = if is_efa_device() {
-                crate::efa::mr_access_flags()
-            } else {
-                rdmaxcel_sys::ibv_access_flags::IBV_ACCESS_LOCAL_WRITE
-                    | rdmaxcel_sys::ibv_access_flags::IBV_ACCESS_REMOTE_WRITE
-                    | rdmaxcel_sys::ibv_access_flags::IBV_ACCESS_REMOTE_READ
-                    | rdmaxcel_sys::ibv_access_flags::IBV_ACCESS_REMOTE_ATOMIC
-            };
-
-            let mut mr: *mut rdmaxcel_sys::ibv_mr = std::ptr::null_mut();
-            let mrv;
-
-            if is_cuda {
-                // First, try to use segment scanning if mlx5dv is enabled
-                let mut segment_mrv = None;
-                if self.mlx5dv_enabled {
-                    // Try to find in already registered segments
-                    segment_mrv = self.find_cuda_segment_for_address(addr, size);
-
-                    // If not found, trigger a re-sync with the allocator and retry
-                    if segment_mrv.is_none() {
-                        let err = rdmaxcel_sys::register_segments(
-                            domain.pd,
-                            qp.unwrap().qp as *mut rdmaxcel_sys::rdmaxcel_qp_t,
-                        );
-                        // Only retry if register_segments succeeded
-                        // If it fails (e.g., scanner returns 0 segments), we'll fall back to dmabuf
-                        if err == 0 {
-                            segment_mrv = self.find_cuda_segment_for_address(addr, size);
-                        }
-                    }
-                }
-
-                // Use segment if found, otherwise fall back to direct dmabuf registration
-                if let Some(mrv_from_segment) = segment_mrv {
-                    mrv = mrv_from_segment;
-                } else {
-                    // Dmabuf path: used when mlx5dv is disabled OR scanner returns no segments
-                    let mut fd: i32 = -1;
-                    rdmaxcel_sys::rdmaxcel_cuMemGetHandleForAddressRange(
-                        &mut fd,
-                        addr as rdmaxcel_sys::CUdeviceptr,
-                        size,
-                        rdmaxcel_sys::CU_MEM_RANGE_HANDLE_TYPE_DMA_BUF_FD,
-                        0,
-                    );
-                    mr =
-                        rdmaxcel_sys::ibv_reg_dmabuf_mr(domain.pd, 0, size, 0, fd, access.0 as i32);
-                    if mr.is_null() {
-                        return Err(anyhow::anyhow!("Failed to register dmabuf MR"));
-                    }
-                    mrv = RdmaMemoryRegionView {
-                        id: self.mrv_id,
-                        virtual_addr: addr,
-                        rdma_addr: (*mr).addr as usize,
-                        size,
-                        lkey: (*mr).lkey,
-                        rkey: (*mr).rkey,
-                    };
-                    self.mrv_id += 1;
-                }
-            } else {
-                // CPU memory path
-                mr = rdmaxcel_sys::ibv_reg_mr(
-                    domain.pd,
-                    addr as *mut std::ffi::c_void,
-                    size,
-                    access.0 as i32,
-                );
-
-                if mr.is_null() {
-                    return Err(anyhow::anyhow!("failed to register standard MR"));
-                }
-
-                mrv = RdmaMemoryRegionView {
-                    id: self.mrv_id,
-                    virtual_addr: addr,
-                    rdma_addr: (*mr).addr as usize,
-                    size,
-                    lkey: (*mr).lkey,
-                    rkey: (*mr).rkey,
-                };
-                self.mrv_id += 1;
-            }
-            self.mr_map.insert(mrv.id, mr as usize);
-            Ok((mrv, device_name))
-        }
-    }
-
-    fn deregister_mr(&mut self, id: usize) -> Result<(), anyhow::Error> {
-        if let Some(mr_ptr) = self.mr_map.remove(&id) {
-            if mr_ptr != 0 {
-                unsafe {
-                    rdmaxcel_sys::ibv_dereg_mr(mr_ptr as *mut rdmaxcel_sys::ibv_mr);
-                }
-            }
-        }
-        Ok(())
-    }
+    // Eventually, this will be an Option, but for now
+    // to maintain existing behavior, we assume that
+    // RdmaManagerActor only exists if ibverbs is supported.
+    // This will change very soon.
+    ibverbs: RdmaBackendActor<IbvManagerActor>,
 }
 
 #[async_trait]
 impl RemoteSpawn for RdmaManagerActor {
-    type Params = Option<IbverbsConfig>;
+    type Params = Option<IbvConfig>;
 
     async fn new(params: Self::Params, _environment: Flattrs) -> Result<Self, anyhow::Error> {
-        if !ibverbs_supported() {
-            return Err(anyhow::anyhow!(
-                "Cannot create RdmaManagerActor because RDMA is not supported on this machine"
-            ));
-        }
-
-        // Use provided config or default if none provided
-        let mut config = params.unwrap_or_default();
-        tracing::debug!("rdma is enabled, config device hint: {}", config.device);
-
-        let mlx5dv_enabled = resolve_qp_type(config.qp_type) == rdmaxcel_sys::RDMA_QP_TYPE_MLX5DV;
-
-        // check config and hardware support align
-        if config.use_gpu_direct {
-            match validate_execution_context().await {
-                Ok(_) => {
-                    tracing::info!("GPU Direct RDMA execution context validated successfully");
-                }
-                Err(e) => {
-                    tracing::warn!(
-                        "GPU Direct RDMA execution context validation failed: {}. Downgrading to standard ibverbs mode.",
-                        e
-                    );
-                    config.use_gpu_direct = false;
-                }
-            }
-        }
-
-        // Build the CUDA to RDMA device mapping using device selection algorithm
-        let pci_to_device = crate::device_selection::create_cuda_to_rdma_mapping();
-        tracing::debug!(
-            "Built CUDA to RDMA device mapping with {} entries",
-            pci_to_device.len()
-        );
-
-        Ok(Self {
-            device_qps: HashMap::new(),
-            pending_qp_creation: Arc::new(Mutex::new(HashSet::new())),
-            device_domains: HashMap::new(),
-            config,
-            mlx5dv_enabled,
-            mr_map: HashMap::new(),
-            mrv_id: 0,
-            pci_to_device,
-        })
+        let ibv = RdmaBackendActor::Created(IbvManagerActor::new(params).await?);
+        Ok(Self { ibverbs: ibv })
     }
 }
 
 #[async_trait]
 impl Actor for RdmaManagerActor {
-    async fn init(&mut self, _this: &Instance<Self>) -> Result<(), anyhow::Error> {
+    async fn init(&mut self, this: &Instance<Self>) -> Result<(), anyhow::Error> {
+        self.ibverbs.spawn(this)?;
         tracing::debug!("RdmaManagerActor initialized with lazy domain/QP creation");
         Ok(())
     }
@@ -559,76 +203,26 @@ impl Actor for RdmaManagerActor {
 #[async_trait]
 #[hyperactor::handle(RdmaManagerMessage)]
 impl RdmaManagerMessageHandler for RdmaManagerActor {
-    /// Requests a buffer to be registered with the RDMA domain.
-    ///
-    /// This function registers a memory region with the RDMA domain and returns an `RdmaBuffer`
-    /// that encapsulates the necessary information for RDMA operations.
-    ///
-    /// # Arguments
-    ///
-    /// * `this` - The context of the actor requesting the buffer.
-    /// * `addr` - The starting address of the memory region to be registered.
-    /// * `size` - The size of the memory region to be registered.
-    ///
-    /// # Returns
-    ///
-    /// * `Result<RdmaBuffer, anyhow::Error>` - On success, returns an `RdmaBuffer` containing
-    ///   the registered memory region's details. On failure, returns an error.
     async fn request_buffer(
         &mut self,
         cx: &Context<Self>,
         addr: usize,
         size: usize,
     ) -> Result<RdmaBuffer, anyhow::Error> {
-        let (mrv, device_name) = self.register_mr(addr, size)?;
-
-        Ok(RdmaBuffer {
-            owner: cx.bind().clone(),
-            mr_id: mrv.id,
-            addr: mrv.rdma_addr,
-            size: mrv.size,
-            rkey: mrv.rkey,
-            lkey: mrv.lkey,
-            device_name,
-        })
+        self.ibverbs
+            .handle()
+            .request_buffer(cx, cx.bind().clone(), addr, size)
+            .await
     }
 
-    /// Deregisters a buffer from the RDMA domain.
-    ///
-    /// This function removes the specified `RdmaBuffer` from the RDMA domain,
-    /// effectively releasing the resources associated with it.
-    ///
-    /// # Arguments
-    ///
-    /// * `_this` - The context of the actor releasing the buffer.
-    /// * `buffer` - The `RdmaBuffer` to be deregistered.
-    ///
-    /// # Returns
-    ///
-    /// * `Result<(), anyhow::Error>` - On success, returns `Ok(())`. On failure, returns an error.
     async fn release_buffer(
         &mut self,
-        _cx: &Context<Self>,
+        cx: &Context<Self>,
         buffer: RdmaBuffer,
     ) -> Result<(), anyhow::Error> {
-        self.deregister_mr(buffer.mr_id)
-            .map_err(|e| anyhow::anyhow!("could not deregister buffer: {}", e))?;
-        Ok(())
+        self.ibverbs.handle().release_buffer(cx, buffer).await
     }
 
-    /// Requests a queue pair for communication with a remote RDMA manager actor.
-    ///
-    /// Basic logic: if queue pair exists in map, return it; if None, create connection first.
-    ///
-    /// # Arguments
-    ///
-    /// * `cx` - The context of the actor requesting the queue pair.
-    /// * `remote` - The ActorRef of the remote RDMA manager actor to communicate with.
-    ///
-    /// # Returns
-    ///
-    /// * `Result<RdmaQueuePair, anyhow::Error>` - On success, returns the queue pair for communication.
-    ///   On failure, returns an error.
     async fn request_queue_pair(
         &mut self,
         cx: &Context<Self>,
@@ -636,356 +230,76 @@ impl RdmaManagerMessageHandler for RdmaManagerActor {
         self_device: String,
         other_device: String,
     ) -> Result<RdmaQueuePair, anyhow::Error> {
-        let other_id = other.actor_id().clone();
-
-        // Use the nested map structure: local_device -> (actor_id, remote_device) -> RdmaQueuePair
-        let inner_key = (other_id.clone(), other_device.clone());
-
-        // Check if queue pair exists in map
-        if let Some(device_map) = self.device_qps.get(&self_device) {
-            if let Some(qp) = device_map.get(&inner_key) {
-                return Ok(qp.clone());
-            }
-        }
-
-        // Try to acquire lock and mark as pending (hold lock only once!)
-        let pending_key = (self_device.clone(), other_id.clone(), other_device.clone());
-        let mut pending = self.pending_qp_creation.lock().await;
-
-        if pending.contains(&pending_key) {
-            // Another task is creating this QP, release lock and wait
-            drop(pending);
-
-            // Loop checking device_qps until QP is created (no more locks needed)
-            // Timeout after 1 second
-            let start = Instant::now();
-            let timeout = Duration::from_secs(1);
-
-            loop {
-                cx.clock().sleep(Duration::from_micros(200)).await;
-
-                // Check if QP was created while we waited
-                if let Some(device_map) = self.device_qps.get(&self_device) {
-                    if let Some(qp) = device_map.get(&inner_key) {
-                        return Ok(qp.clone());
-                    }
-                }
-
-                // Check for timeout
-                if start.elapsed() >= timeout {
-                    return Err(anyhow::anyhow!(
-                        "Timeout waiting for QP creation (device {} -> actor {} device {}). \
-                         Another task is creating it but hasn't completed in 1 second",
-                        self_device,
-                        other_id,
-                        other_device
-                    ));
-                }
-            }
-        } else {
-            // Not pending, add to set and proceed with creation
-            pending.insert(pending_key.clone());
-            drop(pending);
-            // Fall through to create QP
-        }
-
-        // Queue pair doesn't exist - need to create connection
-        let result = async {
-            let is_loopback = other_id == cx.bind::<RdmaManagerActor>().actor_id().clone()
-                && self_device == other_device;
-
-            if is_loopback {
-                // Loopback connection setup
-                self.initialize_qp(cx, other.clone(), self_device.clone(), other_device.clone())
-                    .await?;
-                let endpoint = self
-                    .connection_info(cx, other.clone(), other_device.clone(), self_device.clone())
-                    .await?;
-                self.connect(
-                    cx,
-                    other.clone(),
-                    self_device.clone(),
-                    other_device.clone(),
-                    endpoint,
-                )
-                .await?;
-            } else {
-                // Remote connection setup
-                self.initialize_qp(cx, other.clone(), self_device.clone(), other_device.clone())
-                    .await?;
-                other
-                    .initialize_qp(
-                        cx,
-                        cx.bind().clone(),
-                        other_device.clone(),
-                        self_device.clone(),
-                    )
-                    .await?;
-                let other_endpoint: RdmaQpInfo = other
-                    .connection_info(
-                        cx,
-                        cx.bind().clone(),
-                        other_device.clone(),
-                        self_device.clone(),
-                    )
-                    .await?;
-                self.connect(
-                    cx,
-                    other.clone(),
-                    self_device.clone(),
-                    other_device.clone(),
-                    other_endpoint,
-                )
-                .await?;
-                let local_endpoint = self
-                    .connection_info(cx, other.clone(), self_device.clone(), other_device.clone())
-                    .await?;
-                other
-                    .connect(
-                        cx,
-                        cx.bind().clone(),
-                        other_device.clone(),
-                        self_device.clone(),
-                        local_endpoint,
-                    )
-                    .await?;
-
-                // BARRIER: Ensure remote side has completed its connection and is ready
-                let remote_state = other
-                    .get_qp_state(
-                        cx,
-                        cx.bind().clone(),
-                        other_device.clone(),
-                        self_device.clone(),
-                    )
-                    .await?;
-
-                if remote_state != rdmaxcel_sys::ibv_qp_state::IBV_QPS_RTS {
-                    return Err(anyhow::anyhow!(
-                        "Remote QP not in RTS state after connection setup. \
-                         Local is ready but remote is in state {}. \
-                         This indicates a synchronization issue in connection setup.",
-                        remote_state
-                    ));
-                }
-            }
-
-            // Now that connection is established, get and clone the queue pair
-            if let Some(device_map) = self.device_qps.get(&self_device) {
-                if let Some(qp) = device_map.get(&inner_key) {
-                    Ok(qp.clone())
-                } else {
-                    Err(anyhow::anyhow!(
-                        "Failed to create connection for actor {} on device {}",
-                        other_id,
-                        other_device
-                    ))
-                }
-            } else {
-                Err(anyhow::anyhow!(
-                    "Failed to create connection for actor {} on device {} - no device map",
-                    other_id,
-                    other_device
-                ))
-            }
-        }
-        .await;
-
-        // Always remove from pending set when done (success or failure)
-        let mut pending = self.pending_qp_creation.lock().await;
-        pending.remove(&pending_key);
-        drop(pending);
-
-        result
+        self.ibverbs
+            .handle()
+            .request_queue_pair(cx, cx.bind().clone(), other, self_device, other_device)
+            .await
     }
 
     async fn initialize_qp(
         &mut self,
-        _cx: &Context<Self>,
+        cx: &Context<Self>,
         other: ActorRef<RdmaManagerActor>,
         self_device: String,
         other_device: String,
     ) -> Result<bool, anyhow::Error> {
-        let other_id = other.actor_id().clone();
-        let inner_key = (other_id.clone(), other_device.clone());
-
-        // Check if QP already exists in nested structure
-        if let Some(device_map) = self.device_qps.get(&self_device) {
-            if device_map.contains_key(&inner_key) {
-                return Ok(true);
-            }
-        }
-
-        // Resolve the RDMA device for the local device
-        let rdma_device = self
-            .pci_to_device
-            .iter()
-            .find(|(_, device)| device.name() == &self_device)
-            .map(|(_, device)| device.clone())
-            .unwrap_or_else(|| {
-                // Fallback to default device from config
-                crate::device_selection::resolve_rdma_device(&self.config.device)
-                    .unwrap_or_else(|| self.config.device.clone())
-            });
-
-        // Get or create domain and extract pointers to avoid borrowing issues
-        let (domain_context, domain_pd) = {
-            // Check if we already have a domain for the device
-            let (domain, _) = self.get_or_create_device_domain(&self_device, &rdma_device)?;
-            (domain.context, domain.pd)
-        };
-
-        let qp = RdmaQueuePair::new(domain_context, domain_pd, self.config.clone())
-            .map_err(|e| anyhow::anyhow!("could not create RdmaQueuePair: {}", e))?;
-
-        // Insert the QP into the nested map structure
-        self.device_qps
-            .entry(self_device.clone())
-            .or_insert_with(HashMap::new)
-            .insert(inner_key, qp);
-
-        tracing::debug!(
-            "successfully created a connection with {:?} for local device {} -> remote device {}",
-            other,
-            self_device,
-            other_device
-        );
-
-        Ok(true)
+        self.ibverbs
+            .handle()
+            .initialize_qp(cx, other, self_device, other_device)
+            .await
     }
 
-    /// Establishes a connection with another actor
-    ///
-    /// # Arguments
-    /// * `other` - The ActorRef of the actor to connect to
-    /// * `endpoint` - Connection information needed to establish the RDMA connection
     async fn connect(
         &mut self,
-        _cx: &Context<Self>,
+        cx: &Context<Self>,
         other: ActorRef<RdmaManagerActor>,
         self_device: String,
         other_device: String,
-        endpoint: RdmaQpInfo,
+        endpoint: IbvQpInfo,
     ) -> Result<(), anyhow::Error> {
-        tracing::debug!("connecting with {:?}", other);
-        let other_id = other.actor_id().clone();
-
-        let inner_key = (other_id.clone(), other_device.clone());
-
-        if let Some(device_map) = self.device_qps.get_mut(&self_device) {
-            match device_map.get_mut(&inner_key) {
-                Some(qp) => {
-                    qp.connect(&endpoint).map_err(|e| {
-                        anyhow::anyhow!("could not connect to RDMA endpoint: {}", e)
-                    })?;
-                    Ok(())
-                }
-                None => Err(anyhow::anyhow!(
-                    "No connection found for actor {}",
-                    other_id
-                )),
-            }
-        } else {
-            Err(anyhow::anyhow!(
-                "No device map found for device {}",
-                self_device
-            ))
-        }
+        self.ibverbs
+            .handle()
+            .connect(cx, other, self_device, other_device, endpoint)
+            .await
     }
 
-    /// Gets connection information for establishing an RDMA connection
-    ///
-    /// # Arguments
-    /// * `other` - The ActorRef to get connection info for
-    ///
-    /// # Returns
-    /// * `RdmaQpInfo` - Connection information needed for the RDMA connection
     async fn connection_info(
         &mut self,
-        _cx: &Context<Self>,
+        cx: &Context<Self>,
         other: ActorRef<RdmaManagerActor>,
         self_device: String,
         other_device: String,
-    ) -> Result<RdmaQpInfo, anyhow::Error> {
-        tracing::debug!("getting connection info with {:?}", other);
-        let other_id = other.actor_id().clone();
-
-        let inner_key = (other_id.clone(), other_device.clone());
-
-        if let Some(device_map) = self.device_qps.get_mut(&self_device) {
-            match device_map.get_mut(&inner_key) {
-                Some(qp) => {
-                    let connection_info = qp.get_qp_info()?;
-                    Ok(connection_info)
-                }
-                None => Err(anyhow::anyhow!(
-                    "No connection found for actor {}",
-                    other_id
-                )),
-            }
-        } else {
-            Err(anyhow::anyhow!(
-                "No device map found for self device {}",
-                self_device
-            ))
-        }
+    ) -> Result<IbvQpInfo, anyhow::Error> {
+        self.ibverbs
+            .handle()
+            .connection_info(cx, other, self_device, other_device)
+            .await
     }
 
-    /// Releases a queue pair back to the HashMap
-    ///
-    /// This method is now a no-op since RdmaQueuePair is Clone and can be safely shared.
-    /// The queue pair is not actually checked out, so there's nothing to release.
-    /// This method is kept for API compatibility.
-    ///
-    /// # Arguments
-    /// * `remote` - The ActorRef of the remote actor to return the queue pair for
-    /// * `qp` - The queue pair to release (ignored)
     async fn release_queue_pair(
         &mut self,
-        _cx: &Context<Self>,
-        _other: ActorRef<RdmaManagerActor>,
-        _self_device: String,
-        _other_device: String,
-        _qp: RdmaQueuePair,
+        cx: &Context<Self>,
+        other: ActorRef<RdmaManagerActor>,
+        self_device: String,
+        other_device: String,
+        qp: RdmaQueuePair,
     ) -> Result<(), anyhow::Error> {
-        // No-op: Queue pairs are now cloned and shared via atomic counters
-        // Nothing needs to be released
-        Ok(())
+        self.ibverbs
+            .handle()
+            .release_queue_pair(cx, other, self_device, other_device, qp)
+            .await
     }
 
-    /// Gets the state of a queue pair
-    ///
-    /// # Arguments
-    /// * `other` - The ActorRef to get the QP state for
-    /// * `self_device` - Local device name
-    /// * `other_device` - Remote device name
-    ///
-    /// # Returns
-    /// * `u32` - The QP state (e.g., IBV_QPS_RTS = Ready To Send)
     async fn get_qp_state(
         &mut self,
-        _cx: &Context<Self>,
+        cx: &Context<Self>,
         other: ActorRef<RdmaManagerActor>,
         self_device: String,
         other_device: String,
     ) -> Result<u32, anyhow::Error> {
-        let other_id = other.actor_id().clone();
-        let inner_key = (other_id.clone(), other_device.clone());
-
-        if let Some(device_map) = self.device_qps.get_mut(&self_device) {
-            match device_map.get_mut(&inner_key) {
-                Some(qp) => qp.state(),
-                None => Err(anyhow::anyhow!(
-                    "No connection found for actor {} on device {}",
-                    other_id,
-                    other_device
-                )),
-            }
-        } else {
-            Err(anyhow::anyhow!(
-                "No device map found for self device {}",
-                self_device
-            ))
-        }
+        self.ibverbs
+            .handle()
+            .get_qp_state(cx, other, self_device, other_device)
+            .await
     }
 }

--- a/monarch_rdma/src/rdma_manager_actor_tests.rs
+++ b/monarch_rdma/src/rdma_manager_actor_tests.rs
@@ -16,7 +16,7 @@
 #[cfg(test)]
 mod tests {
     use crate::PollTarget;
-    use crate::ibverbs_primitives::get_all_devices;
+    use crate::backend::ibverbs::primitives::get_all_devices;
     use crate::rdma_components::validate_execution_context;
     use crate::rdma_manager_actor::RdmaManagerMessageClient;
     use crate::test_utils::test_utils::RdmaManagerTestEnv;
@@ -678,7 +678,7 @@ mod tests {
             BSIZE,
             "cpu:0",
             "cpu:0",
-            crate::ibverbs_primitives::RdmaQpType::Standard,
+            crate::backend::ibverbs::primitives::IbvQpType::Standard,
         )
         .await?;
 
@@ -706,7 +706,7 @@ mod tests {
             BSIZE,
             "cpu:0",
             "cpu:0",
-            crate::ibverbs_primitives::RdmaQpType::Standard,
+            crate::backend::ibverbs::primitives::IbvQpType::Standard,
         )
         .await?;
 
@@ -738,7 +738,7 @@ mod tests {
             BSIZE,
             "cuda:0",
             "cuda:1",
-            crate::ibverbs_primitives::RdmaQpType::Standard,
+            crate::backend::ibverbs::primitives::IbvQpType::Standard,
         )
         .await?;
 
@@ -770,7 +770,7 @@ mod tests {
             BSIZE,
             "cuda:0",
             "cuda:1",
-            crate::ibverbs_primitives::RdmaQpType::Standard,
+            crate::backend::ibverbs::primitives::IbvQpType::Standard,
         )
         .await?;
 

--- a/monarch_rdma/src/test_utils.rs
+++ b/monarch_rdma/src/test_utils.rs
@@ -97,7 +97,7 @@ pub mod test_utils {
     use ndslice::View;
     use ndslice::extent;
 
-    use crate::IbverbsConfig;
+    use crate::IbvConfig;
     use crate::RdmaBuffer;
     use crate::rdma_components::PollTarget;
     use crate::rdma_components::RdmaQueuePair;
@@ -536,7 +536,7 @@ pub mod test_utils {
         cpu_ref: Option<Box<[u8]>>,
     }
     /// Helper function to parse accelerator strings
-    async fn parse_accel(accel: &str, config: &mut IbverbsConfig) -> (String, usize) {
+    async fn parse_accel(accel: &str, config: &mut IbvConfig) -> (String, usize) {
         let (backend, idx) = accel.split_once(':').unwrap();
         let parsed_idx = idx.parse::<usize>().unwrap();
 
@@ -565,11 +565,11 @@ pub mod test_utils {
             buffer_size: usize,
             accel1: &str,
             accel2: &str,
-            qp_type: crate::ibverbs_primitives::RdmaQpType,
+            qp_type: crate::backend::ibverbs::primitives::IbvQpType,
         ) -> Result<Self, anyhow::Error> {
             // Use device selection logic to find optimal RDMA devices
-            let mut config1 = IbverbsConfig::targeting(accel1);
-            let mut config2 = IbverbsConfig::targeting(accel2);
+            let mut config1 = IbvConfig::targeting(accel1);
+            let mut config2 = IbvConfig::targeting(accel2);
 
             // Set the QP type
             config1.qp_type = qp_type;
@@ -748,7 +748,7 @@ pub mod test_utils {
         /// Sets up the RDMA test environment with auto-detected QP type.
         ///
         /// This is a convenience wrapper around `setup_with_qp_type` that uses
-        /// `RdmaQpType::Auto` to automatically select the appropriate QP type.
+        /// `IbvQpType::Auto` to automatically select the appropriate QP type.
         ///
         /// # Arguments
         ///
@@ -764,7 +764,7 @@ pub mod test_utils {
                 buffer_size,
                 accel1,
                 accel2,
-                crate::ibverbs_primitives::RdmaQpType::Auto,
+                crate::backend::ibverbs::primitives::IbvQpType::Auto,
             )
             .await
         }

--- a/python/tests/test_rdma_unsupported.py
+++ b/python/tests/test_rdma_unsupported.py
@@ -52,6 +52,6 @@ async def test_rdma_manager_creation_fails_when_unsupported():
 
     error_message = str(exc_info.value)
     assert (
-        "Cannot create RdmaManagerActor because RDMA is not supported on this machine"
+        "Cannot create IbvManagerActor because RDMA is not supported on this machine"
         in error_message
     ), f"Expected specific error message not found. Actual error: {error_message}"


### PR DESCRIPTION
Summary: Move the ibverbs-specific RdmaDomain struct into its own module under the ibverbs backend directory. This continues isolating ibverbs-specific logic inside monarch_rdma/src/backend/ibverbs.

Differential Revision: D92885598
