### PR TITLE
Add parent_view_json to actor mesh distributed telemetry

### DIFF
--- a/examples/distributed_telemetry_real_data.py
+++ b/examples/distributed_telemetry_real_data.py
@@ -241,7 +241,7 @@ def main() -> None:
         # Sample of actor meshes
         (
             "Sample actor meshes",
-            """SELECT id, class, given_name, full_name, timestamp_us
+            """SELECT id, class, given_name, full_name, shape_json, parent_view_json, timestamp_us
                FROM actor_meshes
                ORDER BY timestamp_us DESC
                LIMIT 10""",
@@ -249,7 +249,7 @@ def main() -> None:
         # Actor meshes by name pattern
         (
             "Actor meshes by name",
-            """SELECT given_name, class, shape_json
+            """SELECT given_name, class, shape_json, parent_view_json
                FROM actor_meshes
                ORDER BY given_name""",
         ),

--- a/hyperactor_mesh/src/v1/proc_mesh.rs
+++ b/hyperactor_mesh/src/v1/proc_mesh.rs
@@ -1142,7 +1142,7 @@ impl ProcMeshRef {
 
             let full_name = format!("{}/{}", self.name, mesh.name());
             let shape_json =
-                serde_json::to_string(&self.region().extent()).unwrap_or_else(|_| "{}".to_string());
+                serde_json::to_string(&mesh.region().extent()).unwrap_or_else(|_| "{}".to_string());
 
             notify_actor_mesh_created(ActorMeshEvent {
                 id: mesh_id,
@@ -1152,7 +1152,9 @@ impl ProcMeshRef {
                 full_name,
                 shape_json,
                 parent_mesh_id: Some(parent_mesh_id),
-                parent_view_json: None,
+                parent_view_json: Some(
+                    serde_json::to_string(self.region()).unwrap_or_else(|_| "{}".to_string()),
+                ),
             });
         }
 

--- a/hyperactor_telemetry/src/lib.rs
+++ b/hyperactor_telemetry/src/lib.rs
@@ -335,7 +335,7 @@ pub struct ActorMeshEvent {
     pub given_name: String,
     /// Full hierarchical name as it appears in supervision events
     pub full_name: String,
-    /// Shape of the mesh, serialized from ndslice::Shape (labels + slice topology)
+    /// Shape of the mesh, serialized from ndslice::Extent
     pub shape_json: String,
     /// Parent mesh ID (None for root meshes)
     pub parent_mesh_id: Option<u64>,

--- a/monarch_distributed_telemetry/src/entity_dispatcher.rs
+++ b/monarch_distributed_telemetry/src/entity_dispatcher.rs
@@ -56,7 +56,7 @@ pub struct ActorMesh {
     pub given_name: String,
     /// Full hierarchical name as it appears in supervision events
     pub full_name: String,
-    /// Shape of the actor mesh, serialized from ndslice::Shape (labels + slice topology)
+    /// Shape of the actor mesh, serialized from ndslice::Extent
     pub shape_json: String,
     /// Parent actor mesh ID (None for root meshes)
     pub parent_mesh_id: Option<u64>,


### PR DESCRIPTION
Summary:
The actor_meshes table had two issues: parent_view_json was always NULL despite the spawning proc mesh's Region being available at the call site, and the shape_json doc comments incorrectly referenced ndslice::Shape (the V0 type) when V1
actually serializes ndslice::Extent.

This diff:
- Populates parent_view_json with the serialized ndslice::Region of the proc mesh that spawned the actor mesh. This captures which slice/view of the parent was used for spawning — useful for understanding mesh topology when a proc mesh is
sliced before spawning actors.
- Fixes shape_json doc comments in both hyperactor_telemetry and entity_dispatcher to reference ndslice::Extent instead of ndslice::Shape
- Adds a test assertion verifying parent_view_json is populated.

Differential Revision: D92905607


