### PR TITLE
[monarch] update extension bindings to use v1 mesh types directly, migrate Python bindings to use v1 ProcMesh only

### DIFF
--- a/python/tests/_monarch/test_hyperactor.py
+++ b/python/tests/_monarch/test_hyperactor.py
@@ -83,10 +83,10 @@ async def test_proc_mesh() -> None:
     spec = AllocSpec(AllocConstraints(), replica=2)
     allocator = LocalAllocator()
     alloc = await allocator.allocate_nonblocking(spec)
-    proc_mesh = await ProcMesh.allocate_nonblocking(
-        context().actor_instance._as_rust(), alloc, "test"
-    )
-    assert str(proc_mesh).startswith("<ProcMesh: ")
+    instance = context().actor_instance._as_rust()
+    proc_mesh = await ProcMesh.allocate_nonblocking(instance, alloc, "proc_mesh")
+    # v1 has a different repr format
+    assert "ProcMesh" in str(proc_mesh)
 
 
 @_python_task_test
@@ -94,12 +94,9 @@ async def test_actor_mesh() -> None:
     spec = AllocSpec(AllocConstraints(), replica=2)
     allocator = LocalAllocator()
     alloc = await allocator.allocate_nonblocking(spec)
-    proc_mesh = await ProcMesh.allocate_nonblocking(
-        context().actor_instance._as_rust(), alloc, "test"
-    )
-    actor_mesh = await proc_mesh.spawn_nonblocking(
-        context().actor_instance._as_rust(), "test", MyActor
-    )
+    instance = context().actor_instance._as_rust()
+    proc_mesh = await ProcMesh.allocate_nonblocking(instance, alloc, "proc_mesh")
+    actor_mesh = await proc_mesh.spawn_nonblocking(instance, "test", MyActor)
 
     await actor_mesh.initialized()
 

--- a/python/tests/_monarch/test_mailbox.py
+++ b/python/tests/_monarch/test_mailbox.py
@@ -98,9 +98,8 @@ async def allocate() -> ProcMesh:
     spec = AllocSpec(AllocConstraints(), replica=1)
     allocator = LocalAllocator()
     alloc = await allocator.allocate_nonblocking(spec)
-    return await ProcMesh.allocate_nonblocking(
-        context().actor_instance._as_rust(), alloc, "test"
-    )
+    instance = context().actor_instance._as_rust()
+    return await ProcMesh.allocate_nonblocking(instance, alloc, "proc_mesh")
 
 
 def _python_task_test(
@@ -171,9 +170,8 @@ class MyActor:
 @_python_task_test
 async def test_reducer() -> None:
     proc_mesh = await allocate()
-    actor_mesh = await proc_mesh.spawn_nonblocking(
-        context().actor_instance._as_rust(), "test", MyActor
-    )
+    instance = context().actor_instance._as_rust()
+    actor_mesh = await proc_mesh.spawn_nonblocking(instance, "test", MyActor)
     ins = context().actor_instance
 
     def my_accumulate(state: str, update: str) -> str:
@@ -203,6 +201,4 @@ async def test_reducer() -> None:
     assert "[reduced](start+msg0)" in value
 
     #  Note: occasionally test would hang without this stop
-    await proc_mesh.stop_nonblocking(
-        context().actor_instance._as_rust(), "test cleanup"
-    )
+    await proc_mesh.stop_nonblocking(instance, "test cleanup")


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #2592
* #2603
* __->__ #2590
* #2589
* #2598

Migrate logging and RDMA extension bindings from v0 to v1 mesh abstractions.
This eliminates direct dependencies on v0 ProcMesh types from the extension
crates, moving closer to removing the v0 shim layer entirely.

Changes:
- logging.rs: accept v1 PyProcMesh, use ProcMeshRef::spawn(), remove
  on-stop callback (users should call flush() explicitly)
- lib.rs (rdma): accept v1 PyProcMesh, use spawn_service() directly
Update all Python files that imported v0 ProcMesh to use v1 exclusively.
This removes Python-level dependencies on the v0 mesh API, preparing
for the removal of v0 bindings from Rust.
- logging.py: remove v0 LoggingMeshClientV1 branching, use v1 only
- test_actor_mesh.py: remove use_v1 parametrization, use v1 only
- test_hyperactor.py: use v1 ProcMesh and context()
- test_mailbox.py: use v1 ProcMesh and spawn API
- test_alloc.py: use v1 ProcMesh allocation and spawn
@exported-using-ghexport

Differential Revision: [D90857115](https://our.internmc.facebook.com/intern/diff/D90857115/)