### PR TITLE
Fix OSS CI: add missing tokio dep and check-cfg lint

### DIFF
--- a/hyper/Cargo.toml
+++ b/hyper/Cargo.toml
@@ -20,4 +20,8 @@ hyperactor_mesh = { version = "0.0.0", path = "../hyperactor_mesh" }
 reqwest = { version = "0.11.18", features = ["blocking", "cookies", "gzip", "json", "multipart", "native-tls", "rustls-tls", "rustls-tls-native-roots", "socks", "stream"] }
 serde_json = { version = "1.0.140", features = ["alloc", "float_roundtrip", "raw_value", "unbounded_depth"] }
 tabwriter = { version = "1.4.1", features = ["ansi_formatting"] }
+tokio = { version = "1.47.1", features = ["full", "test-util", "tracing"] }
 urlencoding = "2.1.0"
+
+[lints]
+rust = { unexpected_cfgs = { check-cfg = ["cfg(fbcode_build)"], level = "warn" } }


### PR DESCRIPTION
Summary: D92861122 re-enabled autocargo for hyper and D92863288 updated the ShipIt config, fixing the `hyper/Cargo.toml` not found error in OSS CI. However, the autocargo-generated Cargo.toml is missing `tokio` as a direct dependency, which is needed because `main.rs` uses `#[tokio::main]` under `#[cfg(not(fbcode_build))]` (the OSS code path). Other crates with the same pattern (`monarch_conda`, `monarch_hyperactor`) already have `tokio` in their BUCK deps. Also adds `check-cfg` for `cfg(fbcode_build)` to suppress Rust 2024 edition warnings, following the pattern from `hyperactor/BUCK`.

Differential Revision: D92975621


