### PR TITLE
Delete sim allocator tests

### DIFF
--- a/hyperactor_mesh/src/actor_mesh.rs
+++ b/hyperactor_mesh/src/actor_mesh.rs
@@ -1765,12 +1765,6 @@ mod tests {
         }
     }
 
-    mod sim {
-        use crate::alloc::sim::SimAllocator;
-
-        actor_mesh_test_suite!(SimAllocator::new_and_start_simnet());
-    }
-
     mod reshape_cast {
         use async_trait::async_trait;
         use hyperactor::Actor;


### PR DESCRIPTION
Summary: These tests are sometimes failing on CI and test the backend simulator which is not in use at the moment

Reviewed By: shayne-fletcher

Differential Revision: D93008047


