### PR TITLE
[monarch] migrate code_sync to v1 mesh types

### DIFF
--- a/hyperactor_mesh/proptest-regressions/actor_mesh.txt
+++ b/hyperactor_mesh/proptest-regressions/actor_mesh.txt
@@ -5,3 +5,4 @@
 # It is recommended to check this file in to source control so that
 # everyone who runs the test benefits from these saved cases.
 cc 7da0353e3138258986cf2598af0836656a1f7c3399a9ffa18ca93cf983b3e64c # shrinks to extent = Extent { inner: ExtentData { labels: ["d/0"], sizes: [1] } }
+cc 9e66a45c3b88c8717157ee7da4a27441b5d03520023e87fabfc4e5a5591bdb03 # shrinks to extent = Extent { inner: ExtentData { labels: ["d/0", "d/1", "d/2", "d/3"], sizes: [6, 4, 3, 7] } }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #2592
* #2603
* #2590
* #2589
* __->__ #2598

Migrate code_sync_mesh and related code from v0 shim types (RootActorMesh,
SlicedActorMesh, SharedCell) to v1 types (v1::ActorMeshRef). This enables
future deletion of v0 modules from hyperactor_mesh.

Key changes:
- CodeSyncMeshClient now stores v1::ActorMeshRef directly instead of SharedCell
- code_sync_mesh takes &v1::ActorMeshRef instead of &RootActorMesh
- Use actor_mesh.sliced() instead of SlicedActorMesh::new()
- Use Shape::from(actor_mesh.region()) for shape construction
- Use Ranked::region(&mesh).num_ranks() for rank counting
- Remove sel!(*) from v1 cast calls
- Remove v0 fallback branch and downstream_mesh_v0 method
- Add ndslice dependency to monarch_extension_no_torch and monarch_extension_test targets
@exported-using-ghexport

Differential Revision: [D90857117](https://our.internmc.facebook.com/intern/diff/D90857117/)