### PR TITLE
mesh_admin: now reference based

### DIFF
--- a/hyperactor/Cargo.toml
+++ b/hyperactor/Cargo.toml
@@ -76,6 +76,7 @@ tokio-util = { version = "0.7.15", features = ["full"] }
 tracing = { version = "0.1.41", features = ["attributes", "valuable"] }
 typeuri = { version = "0.0.0", path = "../typeuri" }
 unicode-ident = "1.0.12"
+urlencoding = "2.1.0"
 uuid = { version = "1.17", features = ["rng-getrandom", "serde", "v4", "v5", "v6", "v7", "v8"] }
 valuable = { version = "0.1.1", features = ["derive"] }
 wirevalue = { version = "0.0.0", path = "../wirevalue" }

--- a/hyperactor/src/admin/handlers.rs
+++ b/hyperactor/src/admin/handlers.rs
@@ -30,7 +30,6 @@ use super::responses::ProcSummary;
 use super::responses::RecordedEvent;
 use super::responses::ReferenceInfo;
 use super::tree::format_proc_tree_with_urls;
-use super::tree::url_encode_path;
 use crate::ActorId;
 use crate::ProcId;
 use crate::proc::InstanceCell;
@@ -283,7 +282,7 @@ pub async fn get_host(
         .proc_names()
         .into_iter()
         .map(|name| {
-            let url = format!("{}/procs/{}", base_url, url_encode_path(&name));
+            let url = format!("{}/procs/{}", base_url, urlencoding::encode(&name));
             HostProcEntry {
                 name,
                 num_actors: 0,

--- a/hyperactor_mesh/Cargo.toml
+++ b/hyperactor_mesh/Cargo.toml
@@ -84,6 +84,7 @@ tokio-util = { version = "0.7.15", features = ["full"] }
 tracing = { version = "0.1.41", features = ["attributes", "valuable"] }
 tracing-subscriber = { version = "0.3.20", features = ["chrono", "env-filter", "json", "local-time", "parking_lot", "registry"] }
 typeuri = { version = "0.0.0", path = "../typeuri" }
+urlencoding = "2.1.0"
 uuid = { version = "1.17", features = ["rng-getrandom", "serde", "v4", "v5", "v6", "v7", "v8"] }
 wirevalue = { version = "0.0.0", path = "../wirevalue" }
 zbus = { version = "5.11.0", features = ["async-executor", "async-fs", "async-io", "async-lock", "async-process", "async-task", "p2p", "tokio"], default-features = false }

--- a/hyperactor_mesh/examples/dining_philosophers.rs
+++ b/hyperactor_mesh/examples/dining_philosophers.rs
@@ -267,11 +267,12 @@ async fn main() -> Result<ExitCode> {
     let admin_proc = Proc::direct(ChannelTransport::Unix.any(), "mesh_admin".to_string())?;
     let mesh_admin_addr = host_mesh.spawn_admin(instance, &admin_proc).await?;
     println!("Mesh admin server listening on http://{}", mesh_admin_addr);
+    println!("  - Root node:     curl http://{}/v1/root", mesh_admin_addr);
+    println!("  - Mesh tree:     curl http://{}/v1/tree", mesh_admin_addr);
     println!(
-        "  - List hosts:    curl http://{}/v1/hosts",
+        "  - TUI:           buck2 run fbcode//monarch/hyperactor_mesh:hyperactor_mesh_admin_tui -- http://{}",
         mesh_admin_addr
     );
-    println!("  - Mesh tree:     curl http://{}/v1/tree", mesh_admin_addr);
 
     let proc_mesh = host_mesh
         .spawn(instance, "philosophers", extent!(replica = group_size))

--- a/hyperactor_mesh/examples/sieve.rs
+++ b/hyperactor_mesh/examples/sieve.rs
@@ -130,10 +130,7 @@ async fn main() -> Result<ExitCode> {
     let admin_proc = Proc::direct(ChannelTransport::Unix.any(), "mesh_admin".to_string())?;
     let mesh_admin_addr = host_mesh.spawn_admin(instance, &admin_proc).await?;
     println!("Mesh admin server listening on http://{}", mesh_admin_addr);
-    println!(
-        "  - List hosts:    curl http://{}/v1/hosts",
-        mesh_admin_addr
-    );
+    println!("  - Root node:     curl http://{}/v1/root", mesh_admin_addr);
     println!("  - Mesh tree:     curl http://{}/v1/tree", mesh_admin_addr);
     println!(
         "  - TUI:           buck2 run fbcode//monarch/hyperactor_mesh:hyperactor_mesh_admin_tui -- http://{}",


### PR DESCRIPTION
Summary:
wwitch TUI to Reference Walking

this diff rewrites the mesh admin TUI to become topology-agnostic by walking the reference-based admin API instead of relying on the structured /v1/hosts/... route family or any host/proc/actor-specific traversal logic.

the tree is now built by fetching GET /v1/root, rendering its children, and then expanding nodes by issuing GET /v1/{reference} for the selected child reference to obtain a uniform NodePayload (properties + children). the client no longer needs to know what a “host”, “proc”, or “actor” is in order to navigate — it just follows references.

to support this, the TUI collapses its previous NodeKind model into a single reference-keyed node representation (TreeNode { reference, depth, expanded, has_children }) plus a lightweight NodeType derived from NodeProperties for UI concerns like color-coding. a single fetch_node(base_url, reference) -> NodePayload method becomes the core API surface, and a small reference-keyed cache keeps detail rendering responsive without re-fetching on every keypress.

the right-hand pane is updated to render NodePayload generically: it dispatches on NodeProperties (root/host/proc/actor) to show key fields and renders children as navigable references, including flight-recorder display for actor nodes. refresh behavior is now “re-walk the reference graph from root”, while preserving expansion state and attempting to preserve the current selection across rebuilds.

finally, the diff cleans up URL encoding by switching to the urlencoding crate (removing local percent-encoding helpers), tweaks refresh defaults, and adds small UX improvements such as natural sorting for bracketed indices and local-time formatting for event timestamps.

this is part of an ongoing transition toward a self-describing actor graph: subsequent diffs will further enrich the payload model and move additional tooling to reference-based navigation.

Differential Revision: D93014511


