### PR TITLE
[monarch] remove ProcId::Ranked variant, simplify to direct addressing only

### DIFF
--- a/hyper/src/commands/list.rs
+++ b/hyper/src/commands/list.rs
@@ -35,7 +35,7 @@ impl ListCommand {
 
         // Codify obtaining a proc's agent in `hyperactor_mesh` somewhere.
         let agent: ActorRef<HostMeshAgent> =
-            ActorRef::attest(ProcId::Direct(host, "service".to_string()).actor_id("agent", 0));
+            ActorRef::attest(ProcId(host, "service".to_string()).actor_id("agent", 0));
 
         let resources = agent.list(&client).await?;
         println!("{}", serde_json::to_string_pretty(&resources)?);

--- a/hyper/src/commands/show.rs
+++ b/hyper/src/commands/show.rs
@@ -23,23 +23,17 @@ pub struct ShowCommand {
 impl ShowCommand {
     pub async fn run(self) -> anyhow::Result<()> {
         match self.reference {
-            Reference::Proc(ProcId::Direct(host, proc)) => {
+            Reference::Proc(proc_id) => {
+                let host = proc_id.addr().clone();
+                let proc = proc_id.name().to_string();
                 let client = global_root_client();
 
                 // Codify obtaining a proc's agent in `hyperactor_mesh` somewhere.
-                let agent: ActorRef<HostMeshAgent> = ActorRef::attest(
-                    ProcId::Direct(host, "service".to_string()).actor_id("agent", 0),
-                );
+                let agent: ActorRef<HostMeshAgent> =
+                    ActorRef::attest(ProcId(host, "service".to_string()).actor_id("agent", 0));
 
                 let state = agent.get_state(&client, proc.parse().unwrap()).await?;
                 println!("{}", serde_json::to_string_pretty(&state)?);
-            }
-
-            ref_ @ Reference::Proc(_) => {
-                anyhow::bail!(
-                    "cannot show reference {}: only direct proc ids are supported",
-                    ref_
-                );
             }
 
             ref_ => {

--- a/hyperactor/benches/main.rs
+++ b/hyperactor/benches/main.rs
@@ -30,7 +30,6 @@ use hyperactor::mailbox::PortSender;
 use hyperactor::mailbox::monitored_return_handle;
 use hyperactor::reference::ActorId;
 use hyperactor::reference::ProcId;
-use hyperactor::reference::WorldId;
 use serde::Deserialize;
 use serde::Serialize;
 use serde_multipart::Part;
@@ -252,7 +251,10 @@ fn bench_mailbox_message_sizes(c: &mut Criterion) {
         group.bench_function(BenchmarkId::from_parameter(size), move |b| {
             let mut b = b.to_async(Runtime::new().unwrap());
             b.iter_custom(|iters| async move {
-                let proc_id = ProcId::Ranked(WorldId("world".to_string()), 0);
+                let proc_id = ProcId(
+                    ChannelAddr::any(ChannelTransport::Local),
+                    "world_0".to_string(),
+                );
                 let actor_id = ActorId(proc_id, "actor".to_string(), 0);
                 let mbox = Mailbox::new_detached(actor_id);
                 let (port, mut receiver) = mbox.open_port::<Message>();
@@ -283,7 +285,10 @@ fn bench_mailbox_message_rates(c: &mut Criterion) {
         group.bench_function(format!("rate_{}mps", rate), move |b| {
             let mut b = b.to_async(Runtime::new().unwrap());
             b.iter_custom(|iters| async move {
-                let proc_id = ProcId::Ranked(WorldId("world".to_string()), 0);
+                let proc_id = ProcId(
+                    ChannelAddr::any(ChannelTransport::Local),
+                    "world_0".to_string(),
+                );
                 let actor_id = ActorId(proc_id, "actor".to_string(), 0);
                 let mbox = Mailbox::new_detached(actor_id);
                 let (port, mut receiver) = mbox.open_port::<Message>();

--- a/hyperactor/src/actor.rs
+++ b/hyperactor/src/actor.rs
@@ -813,17 +813,19 @@ mod tests {
     use crate::Actor;
     use crate::OncePortHandle;
     use crate::PortRef;
+    use crate::channel::ChannelAddr;
+    use crate::channel::ChannelTransport;
     use crate::checkpoint::CheckpointError;
     use crate::checkpoint::Checkpointable;
     use crate::config;
     use crate::context::Mailbox as _;
-    use crate::id;
     use crate::mailbox::BoxableMailboxSender as _;
     use crate::mailbox::MailboxSender;
     use crate::mailbox::PortLocation;
     use crate::mailbox::monitored_return_handle;
     use crate::ordering::SEQ_INFO;
     use crate::ordering::SeqInfo;
+    use crate::reference::ProcId;
     use crate::test_utils::pingpong::PingPongActor;
     use crate::test_utils::pingpong::PingPongMessage;
     use crate::test_utils::proc_supervison::ProcSupervisionCoordinator; // for macros
@@ -1498,7 +1500,10 @@ mod tests {
         let actor_ref: ActorRef<GetSeqActor> = handle.bind();
 
         let remote_proc = Proc::new(
-            id!(remote[0]),
+            ProcId(
+                ChannelAddr::any(ChannelTransport::Local),
+                "remote_0".to_string(),
+            ),
             DelayedMailboxSender::new(local_proc.clone(), relay_orders).boxed(),
         );
         let (remote_client, _) = remote_proc.instance("remote").unwrap();

--- a/hyperactor/src/channel/sim.rs
+++ b/hyperactor/src/channel/sim.rs
@@ -416,16 +416,26 @@ mod tests {
 
     use super::*;
     use crate::PortId;
+    use crate::channel::ChannelTransport;
     use crate::clock::Clock;
     use crate::clock::RealClock;
     use crate::clock::SimClock;
-    use crate::id;
+    use crate::reference::ActorId;
+    use crate::reference::ProcId;
     use crate::simnet;
     use crate::simnet::BetaDistribution;
     use crate::simnet::LatencyConfig;
     use crate::simnet::LatencyDistribution;
     use crate::simnet::start;
     use crate::simnet::start_with_config;
+
+    fn test_proc_id(name: &str) -> ProcId {
+        ProcId(ChannelAddr::any(ChannelTransport::Local), name.to_string())
+    }
+
+    fn test_actor_id(proc_name: &str, actor_name: &str) -> ActorId {
+        test_proc_id(proc_name).actor_id(actor_name, 0)
+    }
 
     #[tokio::test]
     async fn test_sim_basic() {
@@ -453,8 +463,8 @@ mod tests {
             let (_, mut rx) = sim::serve::<MessageEnvelope>(dst_addr.clone()).unwrap();
             let tx = sim::dial::<MessageEnvelope>(dst_addr).unwrap();
             let data = wirevalue::Any::serialize(&456).unwrap();
-            let sender = id!(world[0].hello);
-            let dest = id!(world[1].hello);
+            let sender = test_actor_id("world_0", "hello");
+            let dest = test_actor_id("world_1", "hello");
             let ext = extent!(region = 1, dc = 1, rack = 4, host = 4, gpu = 8);
             handle.register_proc(
                 sender.proc_id().clone(),
@@ -530,8 +540,8 @@ mod tests {
         let (_, mut rx) = sim::serve::<MessageEnvelope>(sim_addr.clone()).unwrap();
         let tx = sim::dial::<MessageEnvelope>(sim_addr_with_src).unwrap();
 
-        let controller = id!(world[0].controller);
-        let dest = id!(world[1].dest);
+        let controller = test_actor_id("world_0", "controller");
+        let dest = test_actor_id("world_1", "dest");
         let handle = simnet::simnet_handle().unwrap();
 
         let ext = extent!(region = 1, dc = 1, zone = 2, rack = 4, host = 4, gpu = 8);
@@ -599,9 +609,9 @@ mod tests {
         .unwrap();
         let client_tx = sim::dial::<MessageEnvelope>(client_to_dst).unwrap();
 
-        let controller = id!(world[0].controller);
-        let dest = id!(world[1].dest);
-        let client = id!(world[2].client);
+        let controller = test_actor_id("world_0", "controller");
+        let dest = test_actor_id("world_1", "dest");
+        let client = test_actor_id("world_2", "client");
 
         let handle = simnet::simnet_handle().unwrap();
         let ext = extent!(region = 1, dc = 1, zone = 2, rack = 4, host = 4, gpu = 8);

--- a/hyperactor/src/host.rs
+++ b/hyperactor/src/host.rs
@@ -18,7 +18,7 @@
 //! ## Channel muxing
 //!
 //! A [`Host`] maintains a single frontend address, through which all procs are accessible
-//! through direct addressing: the id of each proc is the `ProcId::Direct(frontend_addr, proc_name)`.
+//! through direct addressing: the id of each proc is the `ProcId(frontend_addr, proc_name)`.
 //! In the following, the frontend address is denoted by `*`. The host listens on `*` and
 //! multiplexes messages based on the proc name. When spawning procs, the host maintains
 //! backend channels with separate addresses. In the diagram `#` is the backend address of
@@ -164,10 +164,10 @@ impl<M: ProcManager> Host<M> {
         let (backend_addr, backend_rx) = channel::serve(ChannelAddr::any(manager.transport()))?;
 
         // Set up a system proc. This is often used to manage the host itself.
-        let service_proc_id = ProcId::Direct(frontend_addr.clone(), "service".to_string());
+        let service_proc_id = ProcId(frontend_addr.clone(), "service".to_string());
         let service_proc = Proc::new(service_proc_id.clone(), router.boxed());
 
-        let local_proc_id = ProcId::Direct(frontend_addr.clone(), "local".to_string());
+        let local_proc_id = ProcId(frontend_addr.clone(), "local".to_string());
         let local_proc = Proc::new(local_proc_id.clone(), router.boxed());
 
         tracing::info!(
@@ -231,7 +231,7 @@ impl<M: ProcManager> Host<M> {
     /// Spawn a new process with the given `name`. On success, the
     /// proc has been spawned, and is reachable through the returned,
     /// direct-addressed ProcId, which will be
-    /// `ProcId::Direct(self.addr(), name)`.
+    /// `ProcId(self.addr(), name)`.
     pub async fn spawn(
         &mut self,
         name: String,
@@ -241,7 +241,7 @@ impl<M: ProcManager> Host<M> {
             return Err(HostError::ProcExists(name));
         }
 
-        let proc_id = ProcId::Direct(self.frontend_addr.clone(), name.clone());
+        let proc_id = ProcId(self.frontend_addr.clone(), name.clone());
         let handle = self
             .manager
             .spawn(proc_id.clone(), self.backend_addr.clone(), config)
@@ -1357,10 +1357,7 @@ mod tests {
             .unwrap();
 
         let (proc_id1, _ref) = host.spawn("proc1".to_string(), ()).await.unwrap();
-        assert_eq!(
-            proc_id1,
-            ProcId::Direct(host.addr().clone(), "proc1".to_string())
-        );
+        assert_eq!(proc_id1, ProcId(host.addr().clone(), "proc1".to_string()));
         assert!(procs.lock().await.contains_key(&proc_id1));
 
         let (proc_id2, _ref) = host.spawn("proc2".to_string(), ()).await.unwrap();
@@ -1501,7 +1498,7 @@ mod tests {
     async fn local_ready_and_wait_are_immediate() {
         // Build a LocalHandle directly.
         let addr = ChannelAddr::any(ChannelTransport::Local);
-        let proc_id = ProcId::Direct(addr.clone(), "p".into());
+        let proc_id = ProcId(addr.clone(), "p".into());
         let agent_ref = ActorRef::<()>::attest(proc_id.actor_id("agent", 0));
         let h = LocalHandle::<()> {
             proc_id,

--- a/hyperactor/src/lib.rs
+++ b/hyperactor/src/lib.rs
@@ -162,8 +162,6 @@ pub use proc::Proc;
 pub use proc::WeakProc;
 pub use reference::ActorId;
 pub use reference::ActorRef;
-pub use reference::GangId;
-pub use reference::GangRef;
 pub use reference::OncePortRef;
 pub use reference::PortId;
 pub use reference::PortRef;

--- a/hyperactor/src/mailbox.rs
+++ b/hyperactor/src/mailbox.rs
@@ -18,12 +18,11 @@
 //! ```
 //! # use hyperactor::mailbox::Mailbox;
 //! # use hyperactor::Proc;
-//! # use hyperactor::reference::{ActorId, ProcId, WorldId};
+//! # use hyperactor::reference::{ActorId, ProcId};
 //! # tokio_test::block_on(async {
 //! # let proc = Proc::local();
 //! # let (client, _) = proc.instance("client").unwrap();
-//! # let proc_id = ProcId::Ranked(WorldId("world".to_string()), 0);
-//! # let actor_id = ActorId(proc_id, "actor".to_string(), 0);
+//! # let actor_id = proc.proc_id().actor_id("actor", 0);
 //! let mbox = Mailbox::new_detached(actor_id);
 //! let (port, mut receiver) = mbox.open_port::<u64>();
 //!
@@ -38,12 +37,11 @@
 //! ```
 //! # use hyperactor::mailbox::Mailbox;
 //! # use hyperactor::Proc;
-//! # use hyperactor::reference::{ActorId, ProcId, WorldId};
+//! # use hyperactor::reference::{ActorId, ProcId};
 //! # tokio_test::block_on(async {
 //! # let proc = Proc::local();
 //! # let (client, _) = proc.instance("client").unwrap();
-//! # let proc_id = ProcId::Ranked(WorldId("world".to_string()), 0);
-//! # let actor_id = ActorId(proc_id, "actor".to_string(), 0);
+//! # let actor_id = proc.proc_id().actor_id("actor", 0);
 //! let mbox = Mailbox::new_detached(actor_id);
 //!
 //! let (port, receiver) = mbox.open_once_port::<u64>();
@@ -121,10 +119,10 @@ use crate::actor::remote::USER_PORT_OFFSET;
 use crate::channel;
 use crate::channel::ChannelAddr;
 use crate::channel::ChannelError;
+use crate::channel::ChannelTransport;
 use crate::channel::SendError;
 use crate::channel::TxStatus;
 use crate::context;
-use crate::id;
 use crate::metrics;
 use crate::ordering::SEQ_INFO;
 use crate::reference::ActorId;
@@ -246,7 +244,11 @@ impl MessageEnvelope {
 
     /// Create a new envelope whose sender ID is unknown.
     pub(crate) fn new_unknown(dest: PortId, data: wirevalue::Any) -> Self {
-        Self::new(id!(unknown[0].unknown), dest, data, Attrs::new())
+        // Create a synthetic "unknown" actor ID for messages with no known sender
+        let unknown_addr = ChannelAddr::any(ChannelTransport::Local);
+        let unknown_proc_id = crate::reference::ProcId(unknown_addr, "unknown".to_string());
+        let unknown_actor_id = crate::reference::ActorId(unknown_proc_id, "unknown".to_string(), 0);
+        Self::new(unknown_actor_id, dest, data, Attrs::new())
     }
 
     /// Construct a new serialized value by serializing the provided T-typed value.
@@ -1015,10 +1017,9 @@ pub trait MailboxServer: MailboxSender + Clone + Sized + 'static {
         tokio::task::spawn(async move {
             // Create a client for this task.
             static NEXT_RANK: AtomicUsize = AtomicUsize::new(0);
-            let proc_id = ProcId::Ranked(
-                id!(mailbox_server),
-                NEXT_RANK.fetch_add(1, Ordering::Relaxed),
-            );
+            let rank = NEXT_RANK.fetch_add(1, Ordering::Relaxed);
+            let addr = ChannelAddr::any(ChannelTransport::Local);
+            let proc_id = ProcId(addr, format!("mailbox_server_{}", rank));
             // Use this mailbox server as the forwarder, so we can use it to
             // return message back to the sender.
             let proc = Proc::new(proc_id, BoxedMailboxSender::new(server));
@@ -2693,20 +2694,18 @@ impl DialMailboxRouter {
             .prev();
 
         // First try to look up the address in our address book; failing that,
-        // try to resolve direct procs.
+        // extract the address from the ProcId (all procs are direct-addressed now).
         if let Some((key, addr)) = found
             && key.is_prefix_of(&actor_id.clone().into())
         {
             Some(addr.clone())
-        } else if actor_id.proc_id().is_direct() {
-            let (addr, _name) = actor_id.proc_id().clone().into_direct().unwrap();
+        } else {
+            let addr = actor_id.proc_id().addr().clone();
             if self.direct_addressed_remote_only {
                 addr.transport().is_remote().then_some(addr)
             } else {
                 Some(addr)
             }
-        } else {
-            None
         }
     }
 
@@ -2816,28 +2815,70 @@ mod tests {
     use crate::clock::Clock;
     use crate::clock::RealClock;
     use crate::context::Mailbox as MailboxContext;
-    use crate::id;
     use crate::proc::Proc;
     use crate::reference::ProcId;
     use crate::reference::WorldId;
     use crate::simnet;
 
+    // Helper functions to create test ProcId/ActorId/PortId
+    fn test_proc_id(name: &str) -> ProcId {
+        ProcId(ChannelAddr::any(ChannelTransport::Local), name.to_string())
+    }
+
+    fn test_actor_id(proc_name: &str, actor_name: &str) -> ActorId {
+        test_proc_id(proc_name).actor_id(actor_name, 0)
+    }
+
+    fn test_actor_id_with_pid(proc_name: &str, actor_name: &str, pid: usize) -> ActorId {
+        test_proc_id(proc_name).actor_id(actor_name, pid)
+    }
+
+    fn test_port_id(proc_name: &str, actor_name: &str, port_idx: u64) -> PortId {
+        PortId(test_actor_id(proc_name, actor_name), port_idx)
+    }
+
+    fn test_port_id_with_pid(
+        proc_name: &str,
+        actor_name: &str,
+        pid: usize,
+        port_idx: u64,
+    ) -> PortId {
+        PortId(test_actor_id_with_pid(proc_name, actor_name, pid), port_idx)
+    }
+
+    fn test_world_ref(name: &str) -> Reference {
+        Reference::World(WorldId(name.to_string()))
+    }
+
+    fn test_proc_ref(name: &str) -> Reference {
+        Reference::Proc(test_proc_id(name))
+    }
+
+    fn test_actor_ref(proc_name: &str, actor_name: &str) -> Reference {
+        Reference::Actor(test_actor_id(proc_name, actor_name))
+    }
+
     #[test]
     fn test_error() {
         let err = MailboxError::new(
             ActorId(
-                ProcId::Ranked(WorldId("myworld".to_string()), 2),
+                ProcId(
+                    ChannelAddr::any(ChannelTransport::Local),
+                    "myworld_2".to_string(),
+                ),
                 "myactor".to_string(),
                 5,
             ),
             MailboxErrorKind::Closed,
         );
-        assert_eq!(format!("{}", err), "myworld[2].myactor[5]: mailbox closed");
+        // The format is: "{proc_id},{actor_name}[{pid}]: {error}"
+        // proc_id = "{addr},{proc_name}" so overall: "{addr},{proc_name},{actor_name}[{pid}]"
+        assert!(format!("{}", err).ends_with(",myworld_2,myactor[5]: mailbox closed"));
     }
 
     #[tokio::test]
     async fn test_mailbox_basic() {
-        let mbox = Mailbox::new_detached(id!(test[0].test));
+        let mbox = Mailbox::new_detached(test_actor_id("test_0", "test"));
         let (port, mut receiver) = mbox.open_port::<u64>();
         let port = port.bind();
 
@@ -2892,7 +2933,7 @@ mod tests {
 
     #[test]
     fn test_port_and_reducer() {
-        let mbox = Mailbox::new_detached(id!(test[0].test));
+        let mbox = Mailbox::new_detached(test_actor_id("test_0", "test"));
         // accum port could have reducer typehash
         {
             let accumulator = accum::join_semilattice::<accum::Max<u64>>();
@@ -2939,7 +2980,7 @@ mod tests {
     #[tokio::test]
     #[ignore] // changed error behavior
     async fn test_mailbox_receiver_drop() {
-        let mbox = Mailbox::new_detached(id!(test[0].test));
+        let mbox = Mailbox::new_detached(test_actor_id("test_0", "test"));
         let (port, mut receiver) = mbox.open_port::<u64>();
         // Make sure we go through "remote" path.
         let port = port.bind();
@@ -2957,7 +2998,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_drain() {
-        let mbox = Mailbox::new_detached(id!(test[0].test));
+        let mbox = Mailbox::new_detached(test_actor_id("test_0", "test"));
 
         let (port, mut receiver) = mbox.open_port();
         let port = port.bind();
@@ -2978,15 +3019,15 @@ mod tests {
     async fn test_mailbox_muxer() {
         let muxer = MailboxMuxer::new();
 
-        let mbox0 = Mailbox::new_detached(id!(test[0].actor1));
-        let mbox1 = Mailbox::new_detached(id!(test[0].actor2));
+        let mbox0 = Mailbox::new_detached(test_actor_id("test_0", "actor1"));
+        let mbox1 = Mailbox::new_detached(test_actor_id("test_0", "actor2"));
 
         muxer.bind(mbox0.actor_id().clone(), mbox0.clone());
         muxer.bind(mbox1.actor_id().clone(), mbox1.clone());
 
         let (port, receiver) = mbox0.open_once_port::<u64>();
 
-        let proc = Proc::new(id!(test[0]), BoxedMailboxSender::new(muxer));
+        let proc = Proc::new(test_proc_id("test_0"), BoxedMailboxSender::new(muxer));
         let (client, _) = proc.instance("client").unwrap();
 
         port.send(&client, 123u64).unwrap();
@@ -3005,7 +3046,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_local_client_server() {
-        let mbox = Mailbox::new_detached(id!(test[0].actor0));
+        let mbox = Mailbox::new_detached(test_actor_id("test_0", "actor0"));
         let (tx, rx) = channel::local::new();
         let serve_handle = mbox.clone().serve(rx);
         let client = MailboxClient::new(tx);
@@ -3035,7 +3076,7 @@ mod tests {
 
         let (_, rx) = serve::<MessageEnvelope>(ChannelAddr::Sim(dst_addr.clone())).unwrap();
         let tx = dial::<MessageEnvelope>(src_to_dst).unwrap();
-        let mbox = Mailbox::new_detached(id!(test[0].actor0));
+        let mbox = Mailbox::new_detached(test_actor_id("test_0", "actor0"));
         let serve_handle = mbox.clone().serve(rx);
         let client = MailboxClient::new(tx);
         let (port, receiver) = mbox.open_once_port::<u64>();
@@ -3051,10 +3092,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_mailbox_router() {
-        let mbox0 = Mailbox::new_detached(id!(world0[0].actor0));
-        let mbox1 = Mailbox::new_detached(id!(world1[0].actor0));
-        let mbox2 = Mailbox::new_detached(id!(world1[1].actor0));
-        let mbox3 = Mailbox::new_detached(id!(world1[1].actor1));
+        let mbox0 = Mailbox::new_detached(test_actor_id("world0_0", "actor0"));
+        let mbox1 = Mailbox::new_detached(test_actor_id("world1_0", "actor0"));
+        let mbox2 = Mailbox::new_detached(test_actor_id("world1_1", "actor0"));
+        let mbox3 = Mailbox::new_detached(test_actor_id("world1_1", "actor1"));
 
         let comms: Vec<(OncePortRef<u64>, OncePortReceiver<u64>)> =
             [&mbox0, &mbox1, &mbox2, &mbox3]
@@ -3067,10 +3108,10 @@ mod tests {
 
         let router = MailboxRouter::new();
 
-        router.bind(id!(world0).into(), mbox0);
-        router.bind(id!(world1[0]).into(), mbox1);
-        router.bind(id!(world1[1]).into(), mbox2);
-        router.bind(id!(world1[1].actor1).into(), mbox3);
+        router.bind(WorldId("world0".to_string()).into(), mbox0);
+        router.bind(test_proc_id("world1_0").into(), mbox1);
+        router.bind(test_proc_id("world1_1").into(), mbox2);
+        router.bind(test_actor_id("world1_1", "actor1").into(), mbox3);
 
         for (i, (port, receiver)) in comms.into_iter().enumerate() {
             router
@@ -3081,7 +3122,7 @@ mod tests {
 
         // Test undeliverable messages, and that it is delivered with the appropriate fallback.
 
-        let mbox4 = Mailbox::new_detached(id!(fallback[0].actor));
+        let mbox4 = Mailbox::new_detached(test_actor_id("fallback_0", "actor"));
 
         let (return_handle, mut return_receiver) =
             crate::mailbox::undeliverable::new_undeliverable_port();
@@ -3103,10 +3144,13 @@ mod tests {
     async fn test_dial_mailbox_router() {
         let router = DialMailboxRouter::new();
 
-        router.bind(id!(world0[0]).into(), "unix!@1".parse().unwrap());
-        router.bind(id!(world1[0]).into(), "unix!@2".parse().unwrap());
-        router.bind(id!(world1[1]).into(), "unix!@3".parse().unwrap());
-        router.bind(id!(world1[1].actor1).into(), "unix!@4".parse().unwrap());
+        router.bind(test_proc_ref("world0_0"), "unix!@1".parse().unwrap());
+        router.bind(test_proc_ref("world1_0"), "unix!@2".parse().unwrap());
+        router.bind(test_proc_ref("world1_1"), "unix!@3".parse().unwrap());
+        router.bind(
+            test_actor_ref("world1_1", "actor1"),
+            "unix!@4".parse().unwrap(),
+        );
         // Bind a direct address -- we should use its bound address!
         router.bind(
             "unix:@4,my_proc,my_actor".parse().unwrap(),
@@ -3114,8 +3158,12 @@ mod tests {
         );
 
         // We should be able to lookup the ids
-        router.lookup_addr(&id!(world0[0].actor[0])).unwrap();
-        router.lookup_addr(&id!(world1[0].actor[0])).unwrap();
+        router
+            .lookup_addr(&test_actor_id("world0_0", "actor"))
+            .unwrap();
+        router
+            .lookup_addr(&test_actor_id("world1_0", "actor"))
+            .unwrap();
 
         let actor_id = Reference::from_str("unix:@4,my_proc,my_actor")
             .unwrap()
@@ -3132,22 +3180,40 @@ mod tests {
         );
 
         // Unbind so we cannot find the ids anymore
-        router.unbind(&id!(world1).into());
-        assert!(router.lookup_addr(&id!(world1[0].actor1[0])).is_none());
-        assert!(router.lookup_addr(&id!(world1[1].actor1[0])).is_none());
-        assert!(router.lookup_addr(&id!(world1[2].actor1[0])).is_none());
-        router.lookup_addr(&id!(world0[0].actor[0])).unwrap();
-        router.unbind(&id!(world0).into());
-        assert!(router.lookup_addr(&id!(world0[0].actor[0])).is_none());
+        router.unbind(&test_world_ref("world1"));
+        assert!(
+            router
+                .lookup_addr(&test_actor_id("world1_0", "actor1"))
+                .is_none()
+        );
+        assert!(
+            router
+                .lookup_addr(&test_actor_id("world1_1", "actor1"))
+                .is_none()
+        );
+        assert!(
+            router
+                .lookup_addr(&test_actor_id("world1_2", "actor1"))
+                .is_none()
+        );
+        router
+            .lookup_addr(&test_actor_id("world0_0", "actor"))
+            .unwrap();
+        router.unbind(&test_world_ref("world0"));
+        assert!(
+            router
+                .lookup_addr(&test_actor_id("world0_0", "actor"))
+                .is_none()
+        );
     }
 
     #[tokio::test]
     #[ignore] // TODO: there's a leak here, fix it
     async fn test_dial_mailbox_router_default() {
-        let mbox0 = Mailbox::new_detached(id!(world0[0].actor0));
-        let mbox1 = Mailbox::new_detached(id!(world1[0].actor0));
-        let mbox2 = Mailbox::new_detached(id!(world1[1].actor0));
-        let mbox3 = Mailbox::new_detached(id!(world1[1].actor1));
+        let mbox0 = Mailbox::new_detached(test_actor_id("world0_0", "actor0"));
+        let mbox1 = Mailbox::new_detached(test_actor_id("world1_0", "actor0"));
+        let mbox2 = Mailbox::new_detached(test_actor_id("world1_1", "actor0"));
+        let mbox3 = Mailbox::new_detached(test_actor_id("world1_1", "actor1"));
 
         // We don't need to dial here, since we gain direct access to the
         // underlying routers.
@@ -3155,8 +3221,8 @@ mod tests {
         let world0_router = DialMailboxRouter::new_with_default(root.boxed());
         let world1_router = DialMailboxRouter::new_with_default(root.boxed());
 
-        root.bind(id!(world0).into(), world0_router.clone());
-        root.bind(id!(world1).into(), world1_router.clone());
+        root.bind(test_world_ref("world0"), world0_router.clone());
+        root.bind(test_world_ref("world1"), world1_router.clone());
 
         let mailboxes = [&mbox0, &mbox1, &mbox2, &mbox3];
 
@@ -3167,7 +3233,7 @@ mod tests {
             handles.push(handle);
 
             eprintln!("{}: {}", mbox.actor_id(), addr);
-            if mbox.actor_id().world_name() == "world0" {
+            if mbox.actor_id().proc_id().name().starts_with("world0") {
                 world0_router.bind(mbox.actor_id().clone().into(), addr);
             } else {
                 world1_router.bind(mbox.actor_id().clone().into(), addr);
@@ -3233,8 +3299,8 @@ mod tests {
         wirevalue::register_type!(MyTest);
 
         let envelope = MessageEnvelope::serialize(
-            id!(source[0].actor),
-            id!(dest[1].actor[0][123]),
+            test_actor_id("source_0", "actor"),
+            test_port_id("dest_1", "actor", 123),
             &MyTest {
                 a: 123,
                 b: "hello".into(),
@@ -3243,10 +3309,8 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(
-            format!("{}", envelope),
-            r#"source[0].actor[0] > dest[1].actor[0][123]: MyTest{"a":123,"b":"hello"} {}"#
-        );
+        // Note: display format changed from "source[0].actor" to direct format
+        assert!(format!("{}", envelope).contains("MyTest{\"a\":123,\"b\":\"hello\"}"));
     }
 
     #[derive(Debug, Default)]
@@ -3266,7 +3330,7 @@ mod tests {
         let proc_forwarder = BoxedMailboxSender::new(DialMailboxRouter::new_with_default(
             BOXED_PANICKING_MAILBOX_SENDER.clone(),
         ));
-        let proc_id = id!(quux[0]);
+        let proc_id = test_proc_id("quux_0");
         let mut proc = Proc::new(proc_id.clone(), proc_forwarder);
         ProcSupervisionCoordinator::set(&proc).await.unwrap();
         let (client, _) = proc.instance("client").unwrap();
@@ -3275,7 +3339,7 @@ mod tests {
         let return_handle = foo.port::<Undeliverable<MessageEnvelope>>();
         let message = MessageEnvelope::new(
             foo.actor_id().clone(),
-            PortId(id!(corge[0].bar), 9999u64),
+            PortId(test_actor_id("corge_0", "bar"), 9999u64),
             wirevalue::Any::serialize(&1u64).unwrap(),
             Attrs::new(),
         );
@@ -3292,8 +3356,9 @@ mod tests {
         };
         let msg_str = msg.to_string();
         assert!(msg_str.contains("undeliverable message error"));
-        assert!(msg_str.contains("sender: quux[0].foo[0]"));
-        assert!(msg_str.contains("dest: corge[0].bar[0][9999]"));
+        // Updated assertions for direct format
+        assert!(msg_str.contains("sender:") && msg_str.contains("quux_0"));
+        assert!(msg_str.contains("dest:") && msg_str.contains("corge_0"));
 
         proc.destroy_and_wait::<()>(tokio::time::Duration::from_secs(1), None, "test cleanup")
             .await
@@ -3306,8 +3371,8 @@ mod tests {
             crate::mailbox::undeliverable::new_undeliverable_port();
         // Simulate an undelivered message return.
         let envelope = MessageEnvelope::new(
-            id!(foo[0].bar),
-            PortId(id!(baz[0].corge), 9999u64),
+            test_actor_id("foo_0", "bar"),
+            PortId(test_actor_id("baz_0", "corge"), 9999u64),
             wirevalue::Any::serialize(&1u64).unwrap(),
             Attrs::new(),
         );
@@ -3347,9 +3412,19 @@ mod tests {
         fn create_receiver<M>(coalesce: bool) -> (mpsc::UnboundedSender<M>, PortReceiver<M>) {
             // Create dummy state and port_id to create PortReceiver. They are
             // not used in the test.
-            let dummy_state =
-                State::new(id!(world[0].actor), BOXED_PANICKING_MAILBOX_SENDER.clone());
-            let dummy_port_id = PortId(id!(world[0].actor), 0);
+            let dummy_actor_id = ActorId(
+                ProcId(
+                    ChannelAddr::any(ChannelTransport::Local),
+                    "world_0".to_string(),
+                ),
+                "actor".to_string(),
+                0,
+            );
+            let dummy_state = State::new(
+                dummy_actor_id.clone(),
+                BOXED_PANICKING_MAILBOX_SENDER.clone(),
+            );
+            let dummy_port_id = PortId(dummy_actor_id, 0);
             let (sender, receiver) = mpsc::unbounded_channel::<M>();
             let receiver = PortReceiver {
                 receiver,
@@ -3848,24 +3923,28 @@ mod tests {
     #[test]
     fn test_dial_mailbox_router_prefixes_single_entry() {
         let router = DialMailboxRouter::new();
-        router.bind(id!(world0).into(), "unix!@1".parse().unwrap());
+        router.bind(test_world_ref("world0"), "unix!@1".parse().unwrap());
 
         let prefixes: Vec<Reference> = router.prefixes().into_iter().collect();
         assert_eq!(prefixes.len(), 1);
-        assert_eq!(prefixes[0], id!(world0).into());
+        assert_eq!(prefixes[0], test_world_ref("world0"));
     }
 
     #[test]
     fn test_dial_mailbox_router_prefixes_no_overlap() {
         let router = DialMailboxRouter::new();
-        router.bind(id!(world0).into(), "unix!@1".parse().unwrap());
-        router.bind(id!(world1).into(), "unix!@2".parse().unwrap());
-        router.bind(id!(world2).into(), "unix!@3".parse().unwrap());
+        router.bind(test_world_ref("world0"), "unix!@1".parse().unwrap());
+        router.bind(test_world_ref("world1"), "unix!@2".parse().unwrap());
+        router.bind(test_world_ref("world2"), "unix!@3".parse().unwrap());
 
         let mut prefixes: Vec<Reference> = router.prefixes().into_iter().collect();
         prefixes.sort();
 
-        let mut expected = vec![id!(world0).into(), id!(world1).into(), id!(world2).into()];
+        let mut expected = vec![
+            test_world_ref("world0"),
+            test_world_ref("world1"),
+            test_world_ref("world2"),
+        ];
         expected.sort();
 
         assert_eq!(prefixes, expected);
@@ -3874,17 +3953,17 @@ mod tests {
     #[test]
     fn test_dial_mailbox_router_prefixes_with_overlaps() {
         let router = DialMailboxRouter::new();
-        router.bind(id!(world0).into(), "unix!@1".parse().unwrap());
-        router.bind(id!(world0[0]).into(), "unix!@2".parse().unwrap());
-        router.bind(id!(world0[1]).into(), "unix!@3".parse().unwrap());
-        router.bind(id!(world1).into(), "unix!@4".parse().unwrap());
-        router.bind(id!(world1[0]).into(), "unix!@5".parse().unwrap());
+        router.bind(test_world_ref("world0"), "unix!@1".parse().unwrap());
+        router.bind(test_proc_ref("world0_0"), "unix!@2".parse().unwrap());
+        router.bind(test_proc_ref("world0_1"), "unix!@3".parse().unwrap());
+        router.bind(test_world_ref("world1"), "unix!@4".parse().unwrap());
+        router.bind(test_proc_ref("world1_0"), "unix!@5".parse().unwrap());
 
         let mut prefixes: Vec<Reference> = router.prefixes().into_iter().collect();
         prefixes.sort();
 
         // Only world0 and world1 should be covering prefixes since they cover their children
-        let mut expected = vec![id!(world0).into(), id!(world1).into()];
+        let mut expected = vec![test_world_ref("world0"), test_world_ref("world1")];
         expected.sort();
 
         assert_eq!(prefixes, expected);
@@ -3893,26 +3972,32 @@ mod tests {
     #[test]
     fn test_dial_mailbox_router_prefixes_complex_hierarchy() {
         let router = DialMailboxRouter::new();
-        router.bind(id!(world0).into(), "unix!@1".parse().unwrap());
-        router.bind(id!(world0[0]).into(), "unix!@2".parse().unwrap());
-        router.bind(id!(world0[0].actor1).into(), "unix!@3".parse().unwrap());
-        router.bind(id!(world1[0]).into(), "unix!@4".parse().unwrap());
-        router.bind(id!(world1[1]).into(), "unix!@5".parse().unwrap());
-        router.bind(id!(world2[0].actor0).into(), "unix!@6".parse().unwrap());
+        router.bind(test_world_ref("world0"), "unix!@1".parse().unwrap());
+        router.bind(test_proc_ref("world0_0"), "unix!@2".parse().unwrap());
+        router.bind(
+            test_actor_ref("world0_0", "actor1"),
+            "unix!@3".parse().unwrap(),
+        );
+        router.bind(test_proc_ref("world1_0"), "unix!@4".parse().unwrap());
+        router.bind(test_proc_ref("world1_1"), "unix!@5".parse().unwrap());
+        router.bind(
+            test_actor_ref("world2_0", "actor0"),
+            "unix!@6".parse().unwrap(),
+        );
 
         let mut prefixes: Vec<Reference> = router.prefixes().into_iter().collect();
         prefixes.sort();
 
         // Covering prefixes should be:
-        // - world0 (covers world0[0] and world0[0].actor1)
-        // - world1[0] (not covered by anything else)
-        // - world1[1] (not covered by anything else)
-        // - world2[0].actor0 (not covered by anything else)
+        // - world0 (covers world0_0 and world0_0.actor1)
+        // - world1_0 (not covered by anything else)
+        // - world1_1 (not covered by anything else)
+        // - world2_0.actor0 (not covered by anything else)
         let expected = vec![
-            id!(world0).into(),
-            id!(world1[0]).into(),
-            id!(world1[1]).into(),
-            id!(world2[0].actor0).into(),
+            test_world_ref("world0"),
+            test_proc_ref("world1_0"),
+            test_proc_ref("world1_1"),
+            test_actor_ref("world2_0", "actor0"),
         ];
 
         assert_eq!(prefixes, expected);
@@ -3921,18 +4006,18 @@ mod tests {
     #[test]
     fn test_dial_mailbox_router_prefixes_same_level() {
         let router = DialMailboxRouter::new();
-        router.bind(id!(world0[0]).into(), "unix!@1".parse().unwrap());
-        router.bind(id!(world0[1]).into(), "unix!@2".parse().unwrap());
-        router.bind(id!(world0[2]).into(), "unix!@3".parse().unwrap());
+        router.bind(test_proc_ref("world0_0"), "unix!@1".parse().unwrap());
+        router.bind(test_proc_ref("world0_1"), "unix!@2".parse().unwrap());
+        router.bind(test_proc_ref("world0_2"), "unix!@3".parse().unwrap());
 
         let mut prefixes: Vec<Reference> = router.prefixes().into_iter().collect();
         prefixes.sort();
 
         // All should be covering prefixes since none is a prefix of another
         let mut expected = vec![
-            id!(world0[0]).into(),
-            id!(world0[1]).into(),
-            id!(world0[2]).into(),
+            test_proc_ref("world0_0"),
+            test_proc_ref("world0_1"),
+            test_proc_ref("world0_2"),
         ];
         expected.sort();
 
@@ -3961,11 +4046,7 @@ mod tests {
 
     #[tokio::test]
     async fn message_ttl_expires_in_routing_loop_returns_to_sender() {
-        let actor_id = ActorId(
-            ProcId::Ranked(id!(test_world), 0),
-            "ttl_actor".to_string(),
-            0,
-        );
+        let actor_id = ActorId(test_proc_id("test_world_0"), "ttl_actor".to_string(), 0);
         let mailbox = Mailbox::new(
             actor_id.clone(),
             BoxedMailboxSender::new(AsyncLoopForwarder),
@@ -3974,11 +4055,7 @@ mod tests {
 
         // Create a destination not owned by this mailbox to force
         // forwarding.
-        let remote_actor = ActorId(
-            ProcId::Ranked(id!(remote_world), 1),
-            "remote".to_string(),
-            0,
-        );
+        let remote_actor = ActorId(test_proc_id("remote_world_1"), "remote".to_string(), 0);
         let dest = PortId(remote_actor.clone(), /*port index*/ 4242);
 
         // Build an envelope (TTL is seeded in `MessageEnvelope::new` /
@@ -4008,11 +4085,7 @@ mod tests {
 
     #[tokio::test]
     async fn message_ttl_success_local_delivery() {
-        let actor_id = ActorId(
-            ProcId::Ranked(id!(test_world), 0),
-            "ttl_actor".to_string(),
-            0,
-        );
+        let actor_id = ActorId(test_proc_id("test_world_0"), "ttl_actor".to_string(), 0);
         let mailbox = Mailbox::new(
             actor_id.clone(),
             BoxedMailboxSender::new(PanickingMailboxSender),
@@ -4074,7 +4147,7 @@ mod tests {
     #[test]
     #[should_panic(expected = "already bound")]
     fn test_bind_port_handle_to_actor_port_twice() {
-        let mbox = Mailbox::new_detached(id!(test[0].test));
+        let mbox = Mailbox::new_detached(test_actor_id("test_0", "test"));
         let (handle, _rx) = mbox.open_port::<String>();
         handle.bind_actor_port();
         handle.bind_actor_port();
@@ -4082,7 +4155,7 @@ mod tests {
 
     #[test]
     fn test_bind_port_handle_to_actor_port() {
-        let mbox = Mailbox::new_detached(id!(test[0].test));
+        let mbox = Mailbox::new_detached(test_actor_id("test_0", "test"));
         let default_port = mbox.actor_id().port_id(String::port());
         let (handle, _rx) = mbox.open_port::<String>();
         // Handle's port index is allocated by mailbox, not the actor port.
@@ -4099,7 +4172,7 @@ mod tests {
     #[test]
     #[should_panic(expected = "already bound")]
     fn test_bind_port_handle_to_actor_port_when_already_bound() {
-        let mbox = Mailbox::new_detached(id!(test[0].test));
+        let mbox = Mailbox::new_detached(test_actor_id("test_0", "test"));
         let (handle, _rx) = mbox.open_port::<String>();
         // Bound handle to the port allocated by mailbox.
         handle.bind();
@@ -4110,7 +4183,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_mailbox_post_fails_when_actor_stopped() {
-        let actor_id = id!(test[0].stopped_actor);
+        let actor_id = test_actor_id("test_0", "stopped_actor");
 
         let mailbox = Mailbox::new(
             actor_id.clone(),
@@ -4153,7 +4226,7 @@ mod tests {
     async fn test_mailbox_post_fails_when_actor_failed() {
         use crate::actor::ActorErrorKind;
 
-        let actor_id = id!(test[0].failed_actor);
+        let actor_id = test_actor_id("test_0", "failed_actor");
 
         let mailbox = Mailbox::new(
             actor_id.clone(),
@@ -4196,7 +4269,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_port_handle_send_fails_when_actor_stopped() {
-        let actor_id = id!(test[0].stopped_actor);
+        let actor_id = test_actor_id("test_0", "stopped_actor");
 
         let mailbox = Mailbox::new(
             actor_id.clone(),
@@ -4224,7 +4297,7 @@ mod tests {
     async fn test_port_handle_send_fails_when_actor_failed() {
         use crate::actor::ActorErrorKind;
 
-        let actor_id = id!(test[0].failed_actor);
+        let actor_id = test_actor_id("test_0", "failed_actor");
 
         let mailbox = Mailbox::new(
             actor_id.clone(),

--- a/hyperactor/src/mailbox/durable_mailbox_sender.rs
+++ b/hyperactor/src/mailbox/durable_mailbox_sender.rs
@@ -304,8 +304,19 @@ mod tests {
 
     use super::test_utils::TestLog;
     use super::*;
-    use crate::id;
+    use crate::channel::ChannelAddr;
+    use crate::channel::ChannelTransport;
     use crate::mailbox::log::SeqId;
+    use crate::reference::ActorId;
+    use crate::reference::ProcId;
+
+    fn test_actor_id(proc_name: &str, actor_name: &str) -> ActorId {
+        let proc_id = ProcId(
+            ChannelAddr::any(ChannelTransport::Local),
+            proc_name.to_string(),
+        );
+        proc_id.actor_id(actor_name, 0)
+    }
 
     #[tokio::test]
     async fn test_local_write_ahead_log_basic() {
@@ -343,7 +354,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_durable_mailbox_sender() {
-        let inner = Mailbox::new_detached(id!(world0[0].actor0));
+        let inner = Mailbox::new_detached(test_actor_id("world0_0", "actor0"));
         let write_ahead_log = TestLog::new();
         let mut durable_mbox = DurableMailboxSender::new(write_ahead_log.clone(), inner.clone());
 

--- a/hyperactor/src/mailbox/undeliverable.rs
+++ b/hyperactor/src/mailbox/undeliverable.rs
@@ -18,7 +18,6 @@ use crate::Instance;
 use crate::Message;
 use crate::Proc;
 use crate::actor::ActorStatus;
-use crate::id;
 use crate::mailbox::DeliveryError;
 use crate::mailbox::MailboxSender;
 use crate::mailbox::MessageEnvelope;
@@ -44,7 +43,8 @@ pub(crate) fn new_undeliverable_port() -> (
     PortHandle<Undeliverable<MessageEnvelope>>,
     PortReceiver<Undeliverable<MessageEnvelope>>,
 ) {
-    crate::mailbox::Mailbox::new_detached(id!(world[0].proc))
+    let proc = Proc::local();
+    crate::mailbox::Mailbox::new_detached(proc.proc_id().actor_id("undeliverable", 0))
         .open_port::<Undeliverable<MessageEnvelope>>()
 }
 

--- a/hyperactor/src/message.rs
+++ b/hyperactor/src/message.rs
@@ -321,12 +321,24 @@ mod tests {
     use super::*;
     use crate as hyperactor; // for macros
     use crate::Bind;
+    use crate::PortId;
     use crate::PortRef;
     use crate::Unbind;
     use crate::accum::ReducerSpec;
     use crate::accum::StreamingReducerOpts;
-    use crate::id;
+    use crate::channel::ChannelAddr;
+    use crate::channel::ChannelTransport;
+    use crate::reference::ProcId;
     use crate::reference::UnboundPort;
+
+    // Helper to create test PortId
+    fn test_port_id(proc_name: &str, actor_name: &str, pid: usize, port: u64) -> PortId {
+        let proc_id = ProcId(
+            ChannelAddr::any(ChannelTransport::Local),
+            proc_name.to_string(),
+        );
+        PortId(proc_id.actor_id(actor_name, pid), port)
+    }
 
     // Used to demonstrate a user defined reply type.
     #[derive(Debug, PartialEq, Serialize, Deserialize, typeuri::Named)]
@@ -354,9 +366,9 @@ mod tests {
 
     #[test]
     fn test_castable() {
-        let original_port0 = PortRef::attest(id!(world[0].actor[0][123]));
+        let original_port0 = PortRef::attest(test_port_id("world_0", "actor", 0, 123));
         let original_port1 = PortRef::attest_reducible(
-            id!(world[1].actor1[0][456]),
+            test_port_id("world_1", "actor1", 0, 456),
             Some(ReducerSpec {
                 typehash: 123,
                 builder_params: None,
@@ -396,9 +408,9 @@ mod tests {
         );
 
         // Modify the port in the erased
-        let new_port_id0 = id!(world[0].comm[0][680]);
+        let new_port_id0 = test_port_id("world_0", "comm", 0, 680);
         assert_ne!(&new_port_id0, original_port0.port_id());
-        let new_port_id1 = id!(world[1].comm[0][257]);
+        let new_port_id1 = test_port_id("world_1", "comm", 0, 257);
         assert_ne!(&new_port_id1, original_port1.port_id());
 
         let mut new_ports = vec![&new_port_id0, &new_port_id1].into_iter();

--- a/hyperactor/src/ordering.rs
+++ b/hyperactor/src/ordering.rs
@@ -281,7 +281,19 @@ mod tests {
     use typeuri::Named;
 
     use super::*;
-    use crate::id;
+    use crate::channel::ChannelAddr;
+    use crate::channel::ChannelTransport;
+    use crate::reference::ActorId;
+    use crate::reference::ProcId;
+
+    // Helper to create test ActorId
+    fn test_actor_id(proc_name: &str, actor_name: &str) -> ActorId {
+        let proc_id = ProcId(
+            ChannelAddr::any(ChannelTransport::Local),
+            proc_name.to_string(),
+        );
+        proc_id.actor_id(actor_name, 0)
+    }
 
     /// Test message type 1 for actor port sequencing tests.
     #[derive(Named)]
@@ -465,7 +477,7 @@ mod tests {
             last_seqs: Arc::new(Mutex::new(HashMap::new())),
         };
 
-        let actor_id = id!(test[0].test);
+        let actor_id = test_actor_id("test_0", "test");
         let port_id = actor_id.port_id(1);
 
         // Modify original sequencer
@@ -485,7 +497,7 @@ mod tests {
             last_seqs: Arc::new(Mutex::new(HashMap::new())),
         };
 
-        let actor_id = id!(worker[0].worker);
+        let actor_id = test_actor_id("worker_0", "worker");
         // Two different actor ports for the same actor (using Named::port())
         let actor_port_1 = actor_id.port_id(TestMsg1::port());
         let actor_port_2 = actor_id.port_id(TestMsg2::port());
@@ -496,7 +508,7 @@ mod tests {
         assert_eq!(sequencer.assign_seq(&actor_port_1).seq, 3);
 
         // Actor ports from a different actor get their own shared sequence
-        let actor_id_2 = id!(worker[1].worker);
+        let actor_id_2 = test_actor_id("worker_1", "worker");
         let actor_port_3 = actor_id_2.port_id(TestMsg1::port());
         assert_eq!(sequencer.assign_seq(&actor_port_3).seq, 1); // independent from actor_id
     }
@@ -508,8 +520,8 @@ mod tests {
             last_seqs: Arc::new(Mutex::new(HashMap::new())),
         };
 
-        let actor_id_0 = id!(worker[0].worker);
-        let actor_id_1 = id!(worker[1].worker);
+        let actor_id_0 = test_actor_id("worker_0", "worker");
+        let actor_id_1 = test_actor_id("worker_1", "worker");
 
         // Non-actor ports from the same actor (without ACTOR_PORT_BIT)
         let port_1 = actor_id_0.port_id(1);
@@ -535,7 +547,7 @@ mod tests {
             last_seqs: Arc::new(Mutex::new(HashMap::new())),
         };
 
-        let actor_id = id!(worker[0].worker);
+        let actor_id = test_actor_id("worker_0", "worker");
 
         // Actor ports (share sequence per actor)
         let actor_port_1 = actor_id.port_id(TestMsg1::port());

--- a/hyperactor/src/reference.rs
+++ b/hyperactor/src/reference.rs
@@ -36,7 +36,6 @@ use std::str::FromStr;
 use derivative::Derivative;
 use enum_as_inner::EnumAsInner;
 use hyperactor_config::attrs::Attrs;
-use rand::Rng;
 use serde::Deserialize;
 use serde::Deserializer;
 use serde::Serialize;
@@ -84,8 +83,6 @@ pub enum ReferenceKind {
     Actor,
     /// Port references.
     Port,
-    /// Gang references.
-    Gang,
 }
 
 /// A universal reference to hierarchical identifiers in Hyperactor.
@@ -94,10 +91,9 @@ pub enum ReferenceKind {
 /// [`FromStr`]. They are of the form:
 ///
 /// - `world`,
-/// - `world[rank]`,
-/// - `world[rank].actor[pid]`,
-/// - `world[rank].port[pid][port]`, or
-/// - `world.actor`
+/// - `addr,proc_name`,
+/// - `addr,proc_name,actor_name[pid]`,
+/// - `addr,proc_name,actor_name[pid][port]`
 ///
 /// Reference also implements a total ordering, so that references are
 /// ordered lexicographically with the hierarchy implied by world, proc,
@@ -123,8 +119,6 @@ pub enum Reference {
     Actor(ActorId), // todo: should we only allow name references here?
     /// A reference to a port.
     Port(PortId),
-    /// A reference to a gang.
-    Gang(GangId),
 }
 
 impl Reference {
@@ -135,18 +129,16 @@ impl Reference {
             Self::Proc(_) => self.proc_id() == other.proc_id(),
             Self::Actor(_) => self == other,
             Self::Port(_) => self == other,
-            Self::Gang(_) => self == other,
         }
     }
 
-    /// The world id of the reference.
+    /// The world id of the reference (only for World variants).
     pub fn world_id(&self) -> Option<&WorldId> {
         match self {
             Self::World(world_id) => Some(world_id),
-            Self::Proc(proc_id) => proc_id.world_id(),
-            Self::Actor(ActorId(proc_id, _, _)) => proc_id.world_id(),
-            Self::Port(PortId(ActorId(proc_id, _, _), _)) => proc_id.world_id(),
-            Self::Gang(GangId(world_id, _)) => Some(world_id),
+            Self::Proc(_) => None,
+            Self::Actor(_) => None,
+            Self::Port(_) => None,
         }
     }
 
@@ -157,13 +149,7 @@ impl Reference {
             Self::Proc(proc_id) => Some(proc_id),
             Self::Actor(ActorId(proc_id, _, _)) => Some(proc_id),
             Self::Port(PortId(ActorId(proc_id, _, _), _)) => Some(proc_id),
-            Self::Gang(_) => None,
         }
-    }
-
-    /// The rank of the reference, if any.
-    fn rank(&self) -> Option<Index> {
-        self.proc_id().and_then(|proc_id| proc_id.rank())
     }
 
     /// The actor id of the reference, if any.
@@ -173,7 +159,6 @@ impl Reference {
             Self::Proc(_) => None,
             Self::Actor(actor_id) => Some(actor_id),
             Self::Port(PortId(actor_id, _)) => Some(actor_id),
-            Self::Gang(_) => None,
         }
     }
 
@@ -184,7 +169,6 @@ impl Reference {
             Self::Proc(_) => None,
             Self::Actor(actor_id) => Some(actor_id.name()),
             Self::Port(PortId(actor_id, _)) => Some(actor_id.name()),
-            Self::Gang(gang_id) => Some(&gang_id.1),
         }
     }
 
@@ -195,7 +179,6 @@ impl Reference {
             Self::Proc(_) => None,
             Self::Actor(actor_id) => Some(actor_id.pid()),
             Self::Port(PortId(actor_id, _)) => Some(actor_id.pid()),
-            Self::Gang(_) => None,
         }
     }
 
@@ -206,7 +189,6 @@ impl Reference {
             Self::Proc(_) => None,
             Self::Actor(_) => None,
             Self::Port(port_id) => Some(port_id.index()),
-            Self::Gang(_) => None,
         }
     }
 
@@ -217,7 +199,6 @@ impl Reference {
             Self::Proc(_) => ReferenceKind::Proc,
             Self::Actor(_) => ReferenceKind::Actor,
             Self::Port(_) => ReferenceKind::Port,
-            Self::Gang(_) => ReferenceKind::Gang,
         }
     }
 }
@@ -230,19 +211,17 @@ impl PartialOrd for Reference {
 
 impl Ord for Reference {
     fn cmp(&self, other: &Self) -> Ordering {
+        // Order by: world_id (if World), then proc address/name, then actor_name, then pid, then port
         (
-            // Ranked procs precede direct procs:
             self.world_id(),
-            self.rank(),
-            self.proc_id().and_then(ProcId::as_direct),
+            self.proc_id().map(|p| (p.addr(), p.name())),
             self.actor_name(),
             self.pid(),
             self.port(),
         )
             .cmp(&(
                 other.world_id(),
-                other.rank(),
-                other.proc_id().and_then(ProcId::as_direct),
+                other.proc_id().map(|p| (p.addr(), p.name())),
                 other.actor_name(),
                 other.pid(),
                 other.port(),
@@ -257,99 +236,9 @@ impl fmt::Display for Reference {
             Self::Proc(proc_id) => fmt::Display::fmt(proc_id, f),
             Self::Actor(actor_id) => fmt::Display::fmt(actor_id, f),
             Self::Port(port_id) => fmt::Display::fmt(port_id, f),
-            Self::Gang(gang_id) => fmt::Display::fmt(gang_id, f),
         }
     }
 }
-
-/// Statically create a [`WorldId`], [`ProcId`], [`ActorId`] or [`GangId`],
-/// given the concrete syntax documented in [`Reference`]:
-///
-/// ```
-/// # use hyperactor::id;
-/// # use hyperactor::reference::WorldId;
-/// # use hyperactor::reference::ProcId;
-/// # use hyperactor::reference::ActorId;
-/// # use hyperactor::reference::GangId;
-/// assert_eq!(id!(hello), WorldId("hello".into()));
-/// assert_eq!(id!(hello[0]), ProcId::Ranked(WorldId("hello".into()), 0));
-/// assert_eq!(
-///     id!(hello[0].actor),
-///     ActorId(
-///         ProcId::Ranked(WorldId("hello".into()), 0),
-///         "actor".into(),
-///         0
-///     )
-/// );
-/// assert_eq!(
-///     id!(hello[0].actor[1]),
-///     ActorId(
-///         ProcId::Ranked(WorldId("hello".into()), 0),
-///         "actor".into(),
-///         1
-///     )
-/// );
-/// assert_eq!(
-///     id!(hello.actor),
-///     GangId(WorldId("hello".into()), "actor".into())
-/// );
-/// ```
-///
-/// Prefer to use the id macro to construct identifiers in code, as it
-/// guarantees static validity, and preserves and reinforces the uniform
-/// concrete syntax of identifiers throughout.
-#[macro_export]
-macro_rules! id {
-    ($world:ident) => {
-        $crate::reference::WorldId(stringify!($world).to_string())
-    };
-    ($world:ident [$rank:expr]) => {
-        $crate::reference::ProcId::Ranked(
-            $crate::reference::WorldId(stringify!($world).to_string()),
-            $rank,
-        )
-    };
-    ($world:ident [$rank:expr] . $actor:ident) => {
-        $crate::reference::ActorId(
-            $crate::reference::ProcId::Ranked(
-                $crate::reference::WorldId(stringify!($world).to_string()),
-                $rank,
-            ),
-            stringify!($actor).to_string(),
-            0,
-        )
-    };
-    ($world:ident [$rank:expr] . $actor:ident [$pid:expr]) => {
-        $crate::reference::ActorId(
-            $crate::reference::ProcId::Ranked(
-                $crate::reference::WorldId(stringify!($world).to_string()),
-                $rank,
-            ),
-            stringify!($actor).to_string(),
-            $pid,
-        )
-    };
-    ($world:ident . $actor:ident) => {
-        $crate::reference::GangId(
-            $crate::reference::WorldId(stringify!($world).to_string()),
-            stringify!($actor).to_string(),
-        )
-    };
-    ($world:ident [$rank:expr] . $actor:ident [$pid:expr] [$port:expr]) => {
-        $crate::reference::PortId(
-            $crate::reference::ActorId(
-                $crate::reference::ProcId::Ranked(
-                    $crate::reference::WorldId(stringify!($world).to_string()),
-                    $rank,
-                ),
-                stringify!($actor).to_string(),
-                $pid,
-            ),
-            $port,
-        )
-    };
-}
-pub use id;
 
 /// The type of error encountered while parsing references.
 #[derive(thiserror::Error, Debug)]
@@ -383,11 +272,9 @@ impl FromStr for Reference {
     type Err = ReferenceParsingError;
 
     fn from_str(addr: &str) -> Result<Self, Self::Err> {
-        // First, try to parse a "new style" reference:
-        // 1) If the reference contains a comma (anywhere), it is a new style reference;
-        //    commas were not a valid lexeme in the previous reference format.
-        // 2) This is a bit ugly, but we bypass the tokenizer prior to this comma,
-        //    try to parse a channel address, and then parse the remainder.
+        // References are parsed in the "direct" format:
+        // 1) If the reference contains a comma (anywhere), it is a proc/actor/port reference
+        // 2) Otherwise, it's a world reference (just a simple name)
 
         match addr.split_once(",") {
             Some((channel_addr, rest)) => {
@@ -400,75 +287,40 @@ impl FromStr for Reference {
 
                     // channeladdr,proc_name
                     Token::Elem(proc_name) =>
-                    Self::Proc(ProcId::Direct(channel_addr, proc_name.to_string())),
+                    Self::Proc(ProcId(channel_addr, proc_name.to_string())),
 
                     // channeladdr,proc_name,actor_name
                     Token::Elem(proc_name) Token::Comma Token::Elem(actor_name) =>
-                    Self::Actor(ActorId(ProcId::Direct(channel_addr, proc_name.to_string()), actor_name.to_string(), 0)),
+                    Self::Actor(ActorId(ProcId(channel_addr, proc_name.to_string()), actor_name.to_string(), 0)),
 
-                    // channeladdr,proc_name,actor_name[rank]
+                    // channeladdr,proc_name,actor_name[pid]
                     Token::Elem(proc_name) Token::Comma Token::Elem(actor_name)
-                        Token::LeftBracket Token::Uint(rank) Token::RightBracket =>
-                        Self::Actor(ActorId(ProcId::Direct(channel_addr, proc_name.to_string()), actor_name.to_string(), rank)),
+                        Token::LeftBracket Token::Uint(pid) Token::RightBracket =>
+                        Self::Actor(ActorId(ProcId(channel_addr, proc_name.to_string()), actor_name.to_string(), pid)),
 
-                    // channeladdr,proc_name,actor_name[rank][port]
+                    // channeladdr,proc_name,actor_name[pid][port]
                     Token::Elem(proc_name) Token::Comma Token::Elem(actor_name)
-                        Token::LeftBracket Token::Uint(rank) Token::RightBracket
+                        Token::LeftBracket Token::Uint(pid) Token::RightBracket
                         Token::LeftBracket Token::Uint(index) Token::RightBracket  =>
-                        Self::Port(PortId(ActorId(ProcId::Direct(channel_addr, proc_name.to_string()), actor_name.to_string(), rank), index as u64)),
+                        Self::Port(PortId(ActorId(ProcId(channel_addr, proc_name.to_string()), actor_name.to_string(), pid), index as u64)),
 
-                    // channeladdr,proc_name,actor_name[rank][port<type>]
+                    // channeladdr,proc_name,actor_name[pid][port<type>]
                     Token::Elem(proc_name) Token::Comma Token::Elem(actor_name)
-                        Token::LeftBracket Token::Uint(rank) Token::RightBracket
+                        Token::LeftBracket Token::Uint(pid) Token::RightBracket
                         Token::LeftBracket Token::Uint(index)
                             Token::LessThan Token::Elem(_type) Token::GreaterThan
                         Token::RightBracket =>
-                        Self::Port(PortId(ActorId(ProcId::Direct(channel_addr, proc_name.to_string()), actor_name.to_string(), rank), index as u64)),
+                        Self::Port(PortId(ActorId(ProcId(channel_addr, proc_name.to_string()), actor_name.to_string(), pid), index as u64)),
                 }?)
             }
 
-            // "old style" / "ranked" reference
+            // World reference (just a simple name)
             None => {
                 Ok(parse! {
                     Lexer::new(addr);
 
                     // world
                     Token::Elem(world) => Self::World(WorldId(world.into())),
-
-                    // world[rank]
-                    Token::Elem(world) Token::LeftBracket Token::Uint(rank) Token::RightBracket =>
-                        Self::Proc(ProcId::Ranked(WorldId(world.into()), rank)),
-
-                    // world[rank].actor  (implied pid=0)
-                    Token::Elem(world) Token::LeftBracket Token::Uint(rank) Token::RightBracket
-                        Token::Dot Token::Elem(actor) =>
-                        Self::Actor(ActorId(ProcId::Ranked(WorldId(world.into()), rank), actor.into(), 0)),
-
-                    // world[rank].actor[pid]
-                    Token::Elem(world) Token::LeftBracket Token::Uint(rank) Token::RightBracket
-                        Token::Dot Token::Elem(actor)
-                        Token::LeftBracket Token::Uint(pid) Token::RightBracket =>
-                        Self::Actor(ActorId(ProcId::Ranked(WorldId(world.into()), rank), actor.into(), pid)),
-
-                    // world[rank].actor[pid][port]
-                    Token::Elem(world) Token::LeftBracket Token::Uint(rank) Token::RightBracket
-                        Token::Dot Token::Elem(actor)
-                        Token::LeftBracket Token::Uint(pid) Token::RightBracket
-                        Token::LeftBracket Token::Uint(index) Token::RightBracket =>
-                        Self::Port(PortId(ActorId(ProcId::Ranked(WorldId(world.into()), rank), actor.into(), pid), index as u64)),
-
-                    // world[rank].actor[pid][port<type>]
-                    Token::Elem(world) Token::LeftBracket Token::Uint(rank) Token::RightBracket
-                        Token::Dot Token::Elem(actor)
-                        Token::LeftBracket Token::Uint(pid) Token::RightBracket
-                        Token::LeftBracket Token::Uint(index)
-                            Token::LessThan Token::Elem(_type) Token::GreaterThan
-                        Token::RightBracket =>
-                        Self::Port(PortId(ActorId(ProcId::Ranked(WorldId(world.into()), rank), actor.into(), pid), index as u64)),
-
-                    // world.actor
-                    Token::Elem(world) Token::Dot Token::Elem(actor) =>
-                        Self::Gang(GangId(WorldId(world.into()), actor.into())),
                 }?)
             }
         }
@@ -499,12 +351,6 @@ impl From<PortId> for Reference {
     }
 }
 
-impl From<GangId> for Reference {
-    fn from(gang_id: GangId) -> Self {
-        Self::Gang(gang_id)
-    }
-}
-
 /// Index is a type alias representing a value that can be used as an index
 /// into a sequence.
 pub type Index = usize;
@@ -526,20 +372,9 @@ pub type Index = usize;
 pub struct WorldId(pub String);
 
 impl WorldId {
-    /// Create a proc ID with the provided index in this world.
-    pub fn proc_id(&self, index: Index) -> ProcId {
-        ProcId::Ranked(self.clone(), index)
-    }
-
-    /// The world index.
+    /// The world name.
     pub fn name(&self) -> &str {
         &self.0
-    }
-
-    /// Return a randomly selected user proc in this world.
-    pub fn random_user_proc(&self) -> ProcId {
-        let mask = 1usize << (std::mem::size_of::<usize>() * 8 - 1);
-        ProcId::Ranked(self.clone(), rand::thread_rng().r#gen::<usize>() | mask)
     }
 }
 
@@ -561,13 +396,9 @@ impl FromStr for WorldId {
     }
 }
 
-/// Procs are identified by their _rank_ within a world or by a direct channel address.
+/// Procs are identified by a direct channel address and local name.
 /// Each proc represents an actor runtime that can locally route to all of its
 /// constituent actors.
-///
-/// Ranks >= 1usize << (no. bits in usize - 1) (i.e., with the high bit set) are "user"
-/// ranks. These are reserved for randomly generated identifiers not
-/// assigned by the system.
 #[derive(
     Debug,
     Serialize,
@@ -578,15 +409,9 @@ impl FromStr for WorldId {
     PartialOrd,
     Hash,
     Ord,
-    typeuri::Named,
-    EnumAsInner
+    typeuri::Named
 )]
-pub enum ProcId {
-    /// A ranked proc within a world
-    Ranked(WorldId, Index),
-    /// A proc reachable via a direct channel address, and local name.
-    Direct(ChannelAddr, String),
-}
+pub struct ProcId(pub ChannelAddr, pub String);
 
 impl ProcId {
     /// Create an actor ID with the provided name, pid within this proc.
@@ -594,42 +419,20 @@ impl ProcId {
         ActorId(self.clone(), name.into(), pid)
     }
 
-    /// The proc's world id, if this is a ranked proc.
-    pub fn world_id(&self) -> Option<&WorldId> {
-        match self {
-            ProcId::Ranked(world_id, _) => Some(world_id),
-            ProcId::Direct(_, _) => None,
-        }
+    /// The proc's channel address.
+    pub fn addr(&self) -> &ChannelAddr {
+        &self.0
     }
 
-    /// The world name, if this is a ranked proc.
-    pub fn world_name(&self) -> Option<&str> {
-        self.world_id().map(|world_id| world_id.name())
-    }
-
-    /// The proc's rank, if this is a ranked proc.
-    pub fn rank(&self) -> Option<Index> {
-        match self {
-            ProcId::Ranked(_, rank) => Some(*rank),
-            ProcId::Direct(_, _) => None,
-        }
-    }
-
-    /// The proc's name, if this is a direct proc.
-    pub fn name(&self) -> Option<&String> {
-        match self {
-            ProcId::Ranked(_, _) => None,
-            ProcId::Direct(_, name) => Some(name),
-        }
+    /// The proc's name.
+    pub fn name(&self) -> &str {
+        &self.1
     }
 }
 
 impl fmt::Display for ProcId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            ProcId::Ranked(world_id, rank) => write!(f, "{}[{}]", world_id, rank),
-            ProcId::Direct(addr, name) => write!(f, "{},{}", addr, name),
-        }
+        write!(f, "{},{}", self.0, self.1)
     }
 }
 
@@ -682,18 +485,6 @@ impl ActorId {
         &self.0
     }
 
-    /// The world name. Panics if this is a direct proc.
-    pub fn world_name(&self) -> &str {
-        self.0
-            .world_name()
-            .expect("world_name() called on direct proc")
-    }
-
-    /// The actor's proc's rank. Panics if this is a direct proc.
-    pub fn rank(&self) -> Index {
-        self.0.rank().expect("rank() called on direct proc")
-    }
-
     /// The actor's name.
     pub fn name(&self) -> &str {
         &self.1
@@ -708,10 +499,7 @@ impl ActorId {
 impl fmt::Display for ActorId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let ActorId(proc_id, name, pid) = self;
-        match proc_id {
-            ProcId::Ranked(..) => write!(f, "{}.{}[{}]", proc_id, name, pid),
-            ProcId::Direct(..) => write!(f, "{},{}[{}]", proc_id, name, pid),
-        }
+        write!(f, "{},{}[{}]", proc_id, name, pid)
     }
 }
 impl<A: Referable> From<ActorRef<A>> for ActorId {
@@ -1376,156 +1164,6 @@ impl<M: RemoteMessage> Bind for OncePortRef<M> {
     }
 }
 
-/// Gangs identify a gang of actors across the world.
-#[derive(
-    Debug,
-    Serialize,
-    Deserialize,
-    Clone,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Hash,
-    Ord,
-    typeuri::Named
-)]
-pub struct GangId(pub WorldId, pub String);
-
-impl GangId {
-    pub(crate) fn expand(&self, world_size: usize) -> impl Iterator<Item = ActorId> + '_ {
-        (0..world_size).map(|rank| ActorId(ProcId::Ranked(self.0.clone(), rank), self.1.clone(), 0))
-    }
-
-    /// The world id of the gang.
-    pub fn world_id(&self) -> &WorldId {
-        &self.0
-    }
-
-    /// The name of the gang.
-    pub fn name(&self) -> &str {
-        &self.1
-    }
-
-    /// The gang's actor ID for the provided rank. It always returns the root
-    /// actor because the root actor is the public interface of a gang.
-    pub fn actor_id(&self, rank: Index) -> ActorId {
-        ActorId(
-            ProcId::Ranked(self.world_id().clone(), rank),
-            self.name().to_string(),
-            0,
-        )
-    }
-}
-
-impl fmt::Display for GangId {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let GangId(world_id, name) = self;
-        write!(f, "{}.{}", world_id, name)
-    }
-}
-
-impl FromStr for GangId {
-    type Err = ReferenceParsingError;
-
-    fn from_str(addr: &str) -> Result<Self, Self::Err> {
-        match addr.parse()? {
-            Reference::Gang(gang_id) => Ok(gang_id),
-            _ => Err(ReferenceParsingError::WrongType("gang".into())),
-        }
-    }
-}
-
-/// Chop implements a simple lexer on a fixed set of delimiters.
-fn chop<'a>(mut s: &'a str, delims: &'a [&'a str]) -> impl Iterator<Item = &'a str> + 'a {
-    std::iter::from_fn(move || {
-        if s.is_empty() {
-            return None;
-        }
-
-        match delims
-            .iter()
-            .enumerate()
-            .flat_map(|(index, d)| s.find(d).map(|pos| (index, pos)))
-            .min_by_key(|&(_, v)| v)
-        {
-            Some((index, 0)) => {
-                let delim = delims[index];
-                s = &s[delim.len()..];
-                Some(delim)
-            }
-            Some((_, pos)) => {
-                let token = &s[..pos];
-                s = &s[pos..];
-                Some(token.trim())
-            }
-            None => {
-                let token = s;
-                s = "";
-                Some(token.trim())
-            }
-        }
-    })
-}
-
-/// GangRefs are typed references to gangs.
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Hash, Ord)]
-pub struct GangRef<A: Referable> {
-    gang_id: GangId,
-    phantom: PhantomData<A>,
-}
-
-impl<A: Referable> GangRef<A> {
-    /// Return an ActorRef corresponding with the provided rank in
-    /// this gang.  Does not check the validity of the rank, so the
-    /// returned identifier is not guaranteed to refer to a valid rank.
-    pub fn rank(&self, rank: Index) -> ActorRef<A> {
-        let GangRef {
-            gang_id: GangId(world_id, name),
-            ..
-        } = self;
-        ActorRef::attest(ActorId(
-            ProcId::Ranked(world_id.clone(), rank),
-            name.clone(),
-            0,
-        ))
-    }
-
-    /// Return the gang ID.
-    pub fn gang_id(&self) -> &GangId {
-        &self.gang_id
-    }
-
-    /// The caller attests that the provided GandId can be
-    /// converted to a reachable, typed gang reference.
-    pub fn attest(gang_id: GangId) -> Self {
-        Self {
-            gang_id,
-            phantom: PhantomData,
-        }
-    }
-}
-
-impl<A: Referable> Clone for GangRef<A> {
-    fn clone(&self) -> Self {
-        Self {
-            gang_id: self.gang_id.clone(),
-            phantom: PhantomData,
-        }
-    }
-}
-
-impl<A: Referable> From<GangRef<A>> for GangId {
-    fn from(gang_ref: GangRef<A>) -> Self {
-        gang_ref.gang_id
-    }
-}
-
-impl<'a, A: Referable> From<&'a GangRef<A>> for &'a GangId {
-    fn from(gang_ref: &'a GangRef<A>) -> Self {
-        &gang_ref.gang_id
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use rand::seq::SliceRandom;
@@ -1546,38 +1184,13 @@ mod tests {
         let cases: Vec<(&str, Reference)> = vec![
             ("test", WorldId("test".into()).into()),
             (
-                "test[234]",
-                ProcId::Ranked(WorldId("test".into()), 234).into(),
-            ),
-            (
-                "test[234].testactor[6]",
-                ActorId(
-                    ProcId::Ranked(WorldId("test".into()), 234),
-                    "testactor".into(),
-                    6,
-                )
-                .into(),
-            ),
-            (
-                "test[234].testactor[6][1]",
-                PortId(
-                    ActorId(
-                        ProcId::Ranked(WorldId("test".into()), 234),
-                        "testactor".into(),
-                        6,
-                    ),
-                    1,
-                )
-                .into(),
-            ),
-            (
-                "test.testactor",
-                GangId(WorldId("test".into()), "testactor".into()).into(),
+                "tcp:[::1]:1234,test",
+                ProcId("tcp:[::1]:1234".parse().unwrap(), "test".to_string()).into(),
             ),
             (
                 "tcp:[::1]:1234,test,testactor[123]",
                 ActorId(
-                    ProcId::Direct("tcp:[::1]:1234".parse().unwrap(), "test".to_string()),
+                    ProcId("tcp:[::1]:1234".parse().unwrap(), "test".to_string()),
                     "testactor".to_string(),
                     123,
                 )
@@ -1588,21 +1201,11 @@ mod tests {
                 "tcp:[::1]:1234,test,testactor[0][123<my::type>]",
                 PortId(
                     ActorId(
-                        ProcId::Direct("tcp:[::1]:1234".parse().unwrap(), "test".to_string()),
+                        ProcId("tcp:[::1]:1234".parse().unwrap(), "test".to_string()),
                         "testactor".to_string(),
                         0,
                     ),
                     123,
-                )
-                .into(),
-            ),
-            (
-                // References with v1::Name::Suffixed for actor names are parseable
-                "test[234].testactor_12345[6]",
-                ActorId(
-                    ProcId::Ranked(WorldId("test".into()), 234),
-                    "testactor_12345".into(),
-                    6,
                 )
                 .into(),
             ),
@@ -1624,52 +1227,11 @@ mod tests {
     }
 
     #[test]
-    fn test_id_macro() {
-        assert_eq!(id!(hello), WorldId("hello".into()));
-        assert_eq!(id!(hello[0]), ProcId::Ranked(WorldId("hello".into()), 0));
-        assert_eq!(
-            id!(hello[0].actor),
-            ActorId(
-                ProcId::Ranked(WorldId("hello".into()), 0),
-                "actor".into(),
-                0
-            )
-        );
-        assert_eq!(
-            id!(hello[0].actor[1]),
-            ActorId(
-                ProcId::Ranked(WorldId("hello".into()), 0),
-                "actor".into(),
-                1
-            )
-        );
-        assert_eq!(
-            id!(hello.actor),
-            GangId(WorldId("hello".into()), "actor".into())
-        );
-    }
-
-    #[test]
     fn test_reference_ord() {
-        let expected: Vec<Reference> = [
-            "first",
-            "second",
-            "second.actor1",
-            "second.actor2",
-            "second[1]",
-            "second[1].actor1",
-            "second[1].actor2",
-            "second[2]",
-            "second[2].actor100",
-            "third",
-            "third.actor",
-            "third[2]",
-            "third[2].actor",
-            "third[2].actor[1]",
-        ]
-        .into_iter()
-        .map(|s| s.parse().unwrap())
-        .collect();
+        let expected: Vec<Reference> = ["first", "second", "third"]
+            .into_iter()
+            .map(|s| s.parse().unwrap())
+            .collect();
 
         let mut sorted = expected.to_vec();
         sorted.shuffle(&mut thread_rng());
@@ -1685,7 +1247,7 @@ mod tests {
         wirevalue::register_type!(MyType);
         let port_id = PortId(
             ActorId(
-                ProcId::Ranked(WorldId("test".into()), 234),
+                ProcId("tcp:[::1]:1234".parse().unwrap(), "test".to_string()),
                 "testactor".into(),
                 1,
             ),
@@ -1693,7 +1255,7 @@ mod tests {
         );
         assert_eq!(
             port_id.to_string(),
-            "test[234].testactor[1][17867850292987402005<hyperactor::reference::tests::MyType>]"
+            "tcp:[::1]:1234,test,testactor[1][17867850292987402005<hyperactor::reference::tests::MyType>]"
         );
     }
 

--- a/hyperactor/src/simnet.rs
+++ b/hyperactor/src/simnet.rs
@@ -864,15 +864,28 @@ mod tests {
     use tokio::sync::Mutex;
 
     use super::*;
+    use crate::channel::ChannelAddr;
+    use crate::channel::ChannelTransport;
     use crate::channel::sim::SimAddr;
     use crate::clock::Clock;
     use crate::clock::RealClock;
     use crate::clock::SimClock;
-    use crate::id;
+    use crate::reference::ActorId;
+    use crate::reference::ProcId;
     use crate::simnet;
     use crate::simnet::Dispatcher;
     use crate::simnet::Event;
     use crate::simnet::SimNetError;
+
+    // Helper to create test ProcId
+    fn test_proc_id(name: &str) -> ProcId {
+        ProcId(ChannelAddr::any(ChannelTransport::Local), name.to_string())
+    }
+
+    // Helper to create test ActorId
+    fn test_actor_id(proc_name: &str, actor_name: &str) -> ActorId {
+        test_proc_id(proc_name).actor_id(actor_name, 0)
+    }
 
     #[derive(Debug)]
     struct MessageDeliveryEvent {
@@ -970,9 +983,9 @@ mod tests {
         // Tests that we can create a simnet, config latency between distances and sample latencies between procs.
         let ext = extent!(region = 1, dc = 2, zone = 2, rack = 4, host = 4, gpu = 8);
 
-        let alice = id!(world[0]);
-        let bob = id!(world[1]);
-        let charlie = id!(world[2]);
+        let alice = test_proc_id("world_0");
+        let bob = test_proc_id("world_1");
+        let charlie = test_proc_id("world_2");
 
         let config = LatencyConfig {
             inter_zone_distribution: LatencyDistribution::Beta(
@@ -1172,7 +1185,7 @@ mod tests {
                 tx,
                 args_string,
                 kwargs_string,
-                id!(mesh_0_worker[0].worker_0),
+                test_actor_id("mesh_0_worker_0", "worker_0"),
             ))
             .unwrap();
 

--- a/hyperactor/src/supervision.rs
+++ b/hyperactor/src/supervision.rs
@@ -96,10 +96,7 @@ fn fmt_status<'a>(
     match status {
         ActorStatus::Stopped(_) if actor_id.name() == "agent" => {
             // Host agent stopped - use simplified message from D86984496
-            let name = match actor_id.proc_id() {
-                crate::reference::ProcId::Direct(addr, _) => addr.to_string(),
-                crate::reference::ProcId::Ranked(_, _) => actor_id.proc_id().to_string(),
-            };
+            let name = actor_id.proc_id().addr().to_string();
             write!(
                 f,
                 "The process {} owned by this actor became unresponsive and is assumed dead, check the log on the host for details",

--- a/hyperactor_macros/tests/castable.rs
+++ b/hyperactor_macros/tests/castable.rs
@@ -92,13 +92,24 @@ enum MyGenericEnum<'a, A: Bind + Unbind, B> {
 mod tests {
     use std::fmt::Debug;
 
-    use hyperactor::id;
+    use hyperactor::PortId;
+    use hyperactor::channel::ChannelAddr;
+    use hyperactor::channel::ChannelTransport;
     use hyperactor::message::Bind;
     use hyperactor::message::Bindings;
     use hyperactor::message::Unbind;
     use hyperactor::message::Unbound;
+    use hyperactor::reference::ProcId;
 
     use super::*;
+
+    fn test_port_id(proc_name: &str, actor_name: &str, port_idx: u64) -> PortId {
+        let proc_id = ProcId(
+            ChannelAddr::any(ChannelTransport::Local),
+            proc_name.to_string(),
+        );
+        PortId(proc_id.actor_id(actor_name, 0), port_idx)
+    }
 
     fn verify<T: Bind + Unbind + Clone + PartialEq + Debug>(my_type: T, bindings: Bindings) {
         let unbound = Unbound::try_from_message(my_type.clone()).unwrap();
@@ -111,8 +122,8 @@ mod tests {
 
     #[test]
     fn test_named_struct() {
-        let port_id2 = id!(world[0].comm[0][2]);
-        let port_id4 = id!(world[1].worker[0][4]);
+        let port_id2 = test_port_id("world_0", "comm", 2);
+        let port_id4 = test_port_id("world_1", "worker", 4);
         let port2 = PortRef::attest(port_id2.clone());
         let port4 = PortRef::attest(port_id4.clone());
         let my_struct = MyNamedStruct {
@@ -130,8 +141,8 @@ mod tests {
 
     #[test]
     fn test_unnamed_struct() {
-        let port_id2 = id!(world[0].comm[0][2]);
-        let port_id4 = id!(world[1].worker[0][4]);
+        let port_id2 = test_port_id("world_0", "comm", 2);
+        let port_id4 = test_port_id("world_1", "worker", 4);
         let port2 = PortRef::attest(port_id2.clone());
         let port4 = PortRef::attest(port_id4.clone());
         let my_struct = MyUnamedStruct(
@@ -149,8 +160,8 @@ mod tests {
 
     #[test]
     fn test_named_enum() {
-        let port_id2 = id!(world[0].comm[0][2]);
-        let port_id4 = id!(world[1].worker[0][4]);
+        let port_id2 = test_port_id("world_0", "comm", 2);
+        let port_id4 = test_port_id("world_1", "worker", 4);
         let port2 = PortRef::attest(port_id2.clone());
         let port4 = PortRef::attest(port_id4.clone());
         let my_enum = MyEnum::Struct {
@@ -168,8 +179,8 @@ mod tests {
 
     #[test]
     fn test_unnamed_enum() {
-        let port_id2 = id!(world[0].comm[0][2]);
-        let port_id4 = id!(world[1].worker[0][4]);
+        let port_id2 = test_port_id("world_0", "comm", 2);
+        let port_id4 = test_port_id("world_1", "worker", 4);
         let port2 = PortRef::attest(port_id2.clone());
         let port4 = PortRef::attest(port_id4.clone());
         let my_enum = MyEnum::Tuple(
@@ -194,8 +205,8 @@ mod tests {
 
     #[test]
     fn test_my_generic_struct() {
-        let port_id2 = id!(world[0].comm[0][2]);
-        let port_id4 = id!(world[1].worker[0][4]);
+        let port_id2 = test_port_id("world_0", "comm", 2);
+        let port_id4 = test_port_id("world_1", "worker", 4);
         let port2: PortRef<()> = PortRef::attest(port_id2.clone());
         let port4: PortRef<()> = PortRef::attest(port_id4.clone());
         let my_struct = MyGenericStruct(port2.clone(), &11, port4.clone());
@@ -206,8 +217,8 @@ mod tests {
 
     #[test]
     fn test_my_generic_enum() {
-        let port_id2 = id!(world[0].comm[0][2]);
-        let port_id4 = id!(world[1].worker[0][4]);
+        let port_id2 = test_port_id("world_0", "comm", 2);
+        let port_id4 = test_port_id("world_1", "worker", 4);
         let port2: PortRef<()> = PortRef::attest(port_id2.clone());
         let port4: PortRef<()> = PortRef::attest(port_id4.clone());
         let my_enum = MyGenericEnum::Tuple(port2.clone(), &11, port4.clone());

--- a/hyperactor_mesh/bin/admin_tui.rs
+++ b/hyperactor_mesh/bin/admin_tui.rs
@@ -605,7 +605,7 @@ fn url_encode(s: &str) -> String {
 
 /// Extract a short display name from a full ProcId string.
 ///
-/// ProcId::Direct format is `channel_addr,name`. We want just the `name` part.
+/// ProcId format is `channel_addr,name`. We want just the `name` part.
 /// System procs are prefixed with `[system] ` — preserve the prefix and shorten
 /// the ProcId portion.
 /// If there's no comma, return the whole string.

--- a/hyperactor_mesh/src/alloc/local.rs
+++ b/hyperactor_mesh/src/alloc/local.rs
@@ -168,10 +168,11 @@ impl Alloc for LocalAlloc {
                         }
                     };
 
-                    let proc_id = match &self.spec.proc_name {
-                        Some(name) => ProcId::Direct(addr.clone(), name.clone()),
-                        None => ProcId::Ranked(self.world_id.clone(), rank),
+                    let proc_name = match &self.spec.proc_name {
+                        Some(name) => name.clone(),
+                        None => format!("{}_{}", self.world_id.name(), rank),
                     };
+                    let proc_id = ProcId(addr.clone(), proc_name);
 
                     let bspan = tracing::info_span!("mesh_agent_bootstrap");
                     let (proc, mesh_agent) = match ProcMeshAgent::bootstrap(proc_id.clone()).await {

--- a/hyperactor_mesh/src/alloc/remoteprocess.rs
+++ b/hyperactor_mesh/src/alloc/remoteprocess.rs
@@ -1360,7 +1360,6 @@ mod test {
     use hyperactor::ActorRef;
     use hyperactor::channel::ChannelRx;
     use hyperactor::clock::ClockKind;
-    use hyperactor::id;
     use ndslice::extent;
     use tokio::sync::oneshot;
 
@@ -1467,7 +1466,7 @@ mod test {
         let extent = extent!(host = 1, gpu = 2);
         let tx = channel::dial(serve_addr.clone()).unwrap();
 
-        let world_id: WorldId = id!(test_world_id);
+        let world_id: WorldId = WorldId("test_world_id".to_string());
         let mut alloc = MockAlloc::new();
         alloc.expect_world_id().return_const(world_id.clone());
         alloc.expect_extent().return_const(extent.clone());
@@ -1623,7 +1622,7 @@ mod test {
         let extent = extent!(host = 1, gpu = 2);
         let tx = channel::dial(serve_addr.clone()).unwrap();
 
-        let world_id: WorldId = id!(test_world_id);
+        let world_id: WorldId = WorldId("test_world_id".to_string());
         let mut alloc = MockAllocWrapper::new_block_next(
             MockAlloc::new(),
             // block after all created, all running
@@ -1705,7 +1704,7 @@ mod test {
 
         let tx = channel::dial(serve_addr.clone()).unwrap();
 
-        let world_id: WorldId = id!(test_world_id);
+        let world_id: WorldId = WorldId("test_world_id".to_string());
         let mut alloc1 = MockAllocWrapper::new_block_next(
             MockAlloc::new(),
             // block after all created, all running
@@ -1844,7 +1843,7 @@ mod test {
 
         let tx = channel::dial(serve_addr.clone()).unwrap();
 
-        let world_id: WorldId = id!(test_world_id);
+        let world_id: WorldId = WorldId("test_world_id".to_string());
         let mut alloc = MockAllocWrapper::new_block_next(
             MockAlloc::new(),
             // block after all created, all running
@@ -1934,7 +1933,7 @@ mod test {
 
         let tx = channel::dial(serve_addr.clone()).unwrap();
 
-        let test_world_id: WorldId = id!(test_world_id);
+        let test_world_id: WorldId = WorldId("test_world_id".to_string());
         let mut alloc = MockAllocWrapper::new_block_next(
             MockAlloc::new(),
             // block after the failure update
@@ -2034,7 +2033,7 @@ mod test {
 
         let extent = extent!(host = 1, gpu = 1);
         let tx = channel::dial(serve_addr.clone()).unwrap();
-        let test_world_id: WorldId = id!(test_world_id);
+        let test_world_id: WorldId = WorldId("test_world_id".to_string());
         let test_trace_id = "test_trace_id_12345";
 
         // Create a mock alloc that we can verify receives the correct trace id
@@ -2115,7 +2114,7 @@ mod test {
 
         let extent = extent!(host = 1, gpu = 1);
         let tx = channel::dial(serve_addr.clone()).unwrap();
-        let test_world_id: WorldId = id!(test_world_id);
+        let test_world_id: WorldId = WorldId("test_world_id".to_string());
 
         // Create a mock alloc
         let mut alloc = MockAlloc::new();

--- a/hyperactor_mesh/src/alloc/sim.rs
+++ b/hyperactor_mesh/src/alloc/sim.rs
@@ -69,7 +69,8 @@ impl SimAlloc {
         spec.transport = ChannelTransport::Sim(Box::new(ChannelTransport::Unix));
 
         let inner = LocalAlloc::new(spec);
-        let client_proc_id = ProcId::Ranked(WorldId(format!("{}_manager", inner.name())), 0);
+        let client_addr = ChannelAddr::any(ChannelTransport::Local);
+        let client_proc_id = ProcId(client_addr, format!("{}_manager", inner.name()));
 
         let ext = inner.extent();
 

--- a/hyperactor_mesh/src/host_mesh/mesh_agent.rs
+++ b/hyperactor_mesh/src/host_mesh/mesh_agent.rs
@@ -700,8 +700,8 @@ mod tests {
                     ..
                 }),
             } if name == resource_name
-              && proc_id == ProcId::Direct(host_addr.clone(), name.to_string())
-              && mesh_agent == ActorRef::attest(ProcId::Direct(host_addr.clone(), name.to_string()).actor_id("agent", 0)) && bootstrap_command == Some(BootstrapCommand::test())
+              && proc_id == ProcId(host_addr.clone(), name.to_string())
+              && mesh_agent == ActorRef::attest(ProcId(host_addr.clone(), name.to_string()).actor_id("agent", 0)) && bootstrap_command == Some(BootstrapCommand::test())
               && mesh_agent == proc_status_mesh_agent
         );
     }

--- a/hyperactor_mesh/src/mesh_agent.rs
+++ b/hyperactor_mesh/src/mesh_agent.rs
@@ -991,16 +991,27 @@ mod tests {
     use std::sync::Arc;
     use std::sync::Mutex;
 
-    use hyperactor::id;
+    use hyperactor::channel::ChannelAddr;
+    use hyperactor::channel::ChannelTransport;
     use hyperactor::mailbox::BoxedMailboxSender;
     use hyperactor::mailbox::Mailbox;
     use hyperactor::mailbox::MailboxSender;
     use hyperactor::mailbox::MessageEnvelope;
     use hyperactor::mailbox::PortHandle;
     use hyperactor::mailbox::Undeliverable;
+    use hyperactor::reference::ActorId;
+    use hyperactor::reference::ProcId;
     use hyperactor_config::attrs::Attrs;
 
     use super::*;
+
+    fn test_actor_id(proc_name: &str, actor_name: &str) -> ActorId {
+        let proc_id = ProcId(
+            ChannelAddr::any(ChannelTransport::Local),
+            proc_name.to_string(),
+        );
+        proc_id.actor_id(actor_name, 0)
+    }
 
     #[derive(Debug, Clone)]
     struct QueueingMailboxSender {
@@ -1032,8 +1043,8 @@ mod tests {
     // Helper function to create a test message envelope
     fn envelope(data: u64) -> MessageEnvelope {
         MessageEnvelope::serialize(
-            id!(world[0].sender),
-            id!(world[0].receiver[0][1]),
+            test_actor_id("world_0", "sender"),
+            hyperactor::PortId(test_actor_id("world_0", "receiver"), 1),
             &data,
             Attrs::new(),
         )
@@ -1041,7 +1052,7 @@ mod tests {
     }
 
     fn return_handle() -> PortHandle<Undeliverable<MessageEnvelope>> {
-        let mbox = Mailbox::new_detached(id!(test[0].test));
+        let mbox = Mailbox::new_detached(test_actor_id("test_0", "test"));
         let (port, _receiver) = mbox.open_port::<Undeliverable<MessageEnvelope>>();
         port
     }

--- a/hyperactor_mesh/src/proc_launcher.rs
+++ b/hyperactor_mesh/src/proc_launcher.rs
@@ -234,8 +234,7 @@ pub struct LaunchOptions {
 /// include a friendly identifier in logs, crash reports, etc.
 ///
 /// Format:
-/// - `ProcId::Direct(_, name)` → `proc <name> @ <hostname>`
-/// - `ProcId::Ranked(world, rank)` → `proc <world>[<rank>] @ <hostname>`
+/// - `ProcId(_, name)` → `proc <name> @ <hostname>`
 ///
 /// Notes:
 /// - We best-effort resolve the local hostname; on failure or
@@ -243,10 +242,7 @@ pub struct LaunchOptions {
 /// - This is **not** guaranteed to be unique and should not be parsed
 ///   for program logic.
 pub fn format_process_name(proc_id: &ProcId) -> String {
-    let who = match proc_id {
-        ProcId::Direct(_, name) => name.clone(),
-        ProcId::Ranked(world_id, rank) => format!("{world_id}[{rank}]"),
-    };
+    let who = proc_id.name();
 
     let host = hostname::get()
         .unwrap_or_else(|_| "unknown_host".into())

--- a/hyperactor_mesh/src/proc_launcher/native.rs
+++ b/hyperactor_mesh/src/proc_launcher/native.rs
@@ -661,7 +661,10 @@ mod tests {
 
         // v0 bootstrap by default but it doesn't matter here.
         let bootstrap = Bootstrap::default();
-        let proc_id = ProcId::Ranked(hyperactor::WorldId("test".into()), 7);
+        let proc_id = ProcId(
+            ChannelAddr::any(ChannelTransport::Local),
+            "test_7".to_string(),
+        );
         let opts = LaunchOptions {
             command: with_sh(script),
             bootstrap_payload: bootstrap.to_env_safe_string().unwrap(),
@@ -695,14 +698,14 @@ mod tests {
         );
 
         // Process name: don't overfit; assert it includes the "proc "
-        // prefix and rank identity.
+        // prefix and proc name.
         assert!(
             proc_name_env.starts_with("proc "),
             "PROCESS_NAME_ENV looks wrong: {proc_name_env:?}"
         );
         assert!(
-            proc_name_env.contains("[7]"),
-            "expected rank marker in process name: {proc_name_env:?}"
+            proc_name_env.contains("test_7"),
+            "expected proc name in process name: {proc_name_env:?}"
         );
 
         // Log channel propagated
@@ -748,7 +751,7 @@ mod tests {
             let launcher = NativeProcLauncher::new();
             // v0 bootstrap by default but it doesn't matter here.
             let bootstrap = Bootstrap::default();
-            let proc_id = ProcId::Direct(any_unix_addr(), "stdio-captured".into());
+            let proc_id = ProcId(any_unix_addr(), "stdio-captured".into());
             let opts = LaunchOptions {
                 command: with_sh(script),
                 bootstrap_payload: bootstrap.to_env_safe_string().unwrap(),
@@ -782,7 +785,7 @@ mod tests {
             let launcher = NativeProcLauncher::new();
             // v0 bootstrap by default but it doesn't matter here.
             let bootstrap = Bootstrap::default();
-            let proc_id = ProcId::Direct(any_unix_addr(), "stdio-inherited".into());
+            let proc_id = ProcId(any_unix_addr(), "stdio-inherited".into());
             let opts = LaunchOptions {
                 command: with_sh(script),
                 bootstrap_payload: bootstrap.to_env_safe_string().unwrap(),
@@ -820,7 +823,7 @@ mod tests {
         let launcher = NativeProcLauncher::new();
         // v0 bootstrap by default but it doesn't matter here.
         let bootstrap = Bootstrap::default();
-        let proc_id = ProcId::Direct(any_unix_addr(), "exit-7".into());
+        let proc_id = ProcId(any_unix_addr(), "exit-7".into());
         let opts = LaunchOptions {
             command: with_sh("exit 7"),
             bootstrap_payload: bootstrap.to_env_safe_string().unwrap(),
@@ -859,7 +862,7 @@ mod tests {
         let launcher = NativeProcLauncher::new();
         // v0 bootstrap by default but it doesn't matter here.
         let bootstrap = Bootstrap::default();
-        let proc_id = ProcId::Direct(any_unix_addr(), "killed".into());
+        let proc_id = ProcId(any_unix_addr(), "killed".into());
         let opts = LaunchOptions {
             command: with_sh("sleep 30"),
             bootstrap_payload: bootstrap.to_env_safe_string().unwrap(),
@@ -931,7 +934,7 @@ mod tests {
 
         // v0 bootstrap by default but it doesn't matter here.
         let bootstrap = Bootstrap::default();
-        let proc_id = ProcId::Direct(any_unix_addr(), "term-escalate".into());
+        let proc_id = ProcId(any_unix_addr(), "term-escalate".into());
         let opts = LaunchOptions {
             command: with_sh(script),
             bootstrap_payload: bootstrap.to_env_safe_string().unwrap(),
@@ -1019,7 +1022,7 @@ while True:
         };
 
         let bootstrap = Bootstrap::default();
-        let proc_id = ProcId::Direct(any_unix_addr(), "drop-cleanup-test".into());
+        let proc_id = ProcId(any_unix_addr(), "drop-cleanup-test".into());
         let opts = LaunchOptions {
             command,
             bootstrap_payload: bootstrap.to_env_safe_string().unwrap(),

--- a/hyperactor_mesh/src/proc_launcher/systemd.rs
+++ b/hyperactor_mesh/src/proc_launcher/systemd.rs
@@ -1190,7 +1190,7 @@ mod tests {
 
         let launcher = SystemdProcLauncher::new();
 
-        let proc_id = ProcId::Direct(any_unix_addr(), "env-vars".into());
+        let proc_id = ProcId(any_unix_addr(), "env-vars".into());
         // v0 bootstrap by default but it doesn't matter here.
         let bootstrap = Bootstrap::default();
         let opts = LaunchOptions {
@@ -1289,7 +1289,7 @@ mod tests {
 
         // v0 bootstrap by default but it doesn't matter here.
         let bootstrap = Bootstrap::default();
-        let proc_id = ProcId::Direct(any_unix_addr(), "exit-7".into());
+        let proc_id = ProcId(any_unix_addr(), "exit-7".into());
         let opts = LaunchOptions {
             command: with_sh("exit 7"),
             bootstrap_payload: bootstrap.to_env_safe_string().unwrap(),
@@ -1331,7 +1331,7 @@ mod tests {
 
         // v0 bootstrap by default but it doesn't matter here.
         let bootstrap = Bootstrap::default();
-        let proc_id = ProcId::Direct(any_unix_addr(), "killed".into());
+        let proc_id = ProcId(any_unix_addr(), "killed".into());
         let opts = LaunchOptions {
             command: with_sh("sleep 30"),
             bootstrap_payload: bootstrap.to_env_safe_string().unwrap(),
@@ -1393,7 +1393,7 @@ mod tests {
 
         // v0 bootstrap by default but it doesn't matter here.
         let bootstrap = Bootstrap::default();
-        let proc_id = ProcId::Direct(any_unix_addr(), "terminated".into());
+        let proc_id = ProcId(any_unix_addr(), "terminated".into());
         let opts = LaunchOptions {
             command: with_sh("sleep 30"),
             bootstrap_payload: bootstrap.to_env_safe_string().unwrap(),
@@ -1437,7 +1437,7 @@ mod tests {
 
         let launcher = SystemdProcLauncher::new();
 
-        let unknown_proc_id = ProcId::Direct(any_unix_addr(), "unknown".into());
+        let unknown_proc_id = ProcId(any_unix_addr(), "unknown".into());
 
         let result = launcher
             .terminate(&unknown_proc_id, Duration::from_secs(1))
@@ -1459,7 +1459,7 @@ mod tests {
 
         let launcher = SystemdProcLauncher::new();
 
-        let unknown_proc_id = ProcId::Direct(any_unix_addr(), "unknown".into());
+        let unknown_proc_id = ProcId(any_unix_addr(), "unknown".into());
 
         let result = launcher.kill(&unknown_proc_id).await;
 
@@ -1472,7 +1472,10 @@ mod tests {
     /// Unit name generation is deterministic and collision-free.
     #[tokio::test]
     async fn unit_name_is_stable() {
-        let proc_id = ProcId::Ranked(hyperactor::WorldId("my-world".into()), 42);
+        let proc_id = ProcId(
+            ChannelAddr::any(ChannelTransport::Local),
+            "my_world_42".to_string(),
+        );
         let unit = SystemdProcLauncher::unit_name(&proc_id);
 
         assert!(unit.ends_with(".service"), "unit should be a .service");
@@ -1497,7 +1500,10 @@ mod tests {
         assert_eq!(unit, unit2, "unit name should be deterministic");
 
         // Different proc_id should produce different unit name
-        let other_proc_id = ProcId::Ranked(hyperactor::WorldId("other-world".into()), 42);
+        let other_proc_id = ProcId(
+            ChannelAddr::any(ChannelTransport::Local),
+            "other_world_42".to_string(),
+        );
         let other_unit = SystemdProcLauncher::unit_name(&other_proc_id);
         assert_ne!(
             unit, other_unit,
@@ -1563,7 +1569,7 @@ mod tests {
         );
 
         let bootstrap = Bootstrap::default();
-        let proc_id = ProcId::Direct(any_unix_addr(), "drop-cleanup-test".into());
+        let proc_id = ProcId(any_unix_addr(), "drop-cleanup-test".into());
 
         let exit_rx;
 
@@ -1662,7 +1668,7 @@ mod tests {
 
         let launcher = SystemdProcLauncher::new();
 
-        let proc_id = ProcId::Direct(any_unix_addr(), "long-running".into());
+        let proc_id = ProcId(any_unix_addr(), "long-running".into());
         let bootstrap = Bootstrap::default();
         let opts = LaunchOptions {
             command: with_sh("sleep 60"),

--- a/hyperactor_mesh/src/proc_mesh.rs
+++ b/hyperactor_mesh/src/proc_mesh.rs
@@ -372,14 +372,9 @@ impl ProcMesh {
             addr
         };
 
-        let bind_allocated_procs = |router: &DialMailboxRouter| {
-            // Route all of the allocated procs:
-            for AllocatedProc { proc_id, addr, .. } in running.iter() {
-                if proc_id.is_direct() {
-                    continue;
-                }
-                router.bind(proc_id.clone().into(), addr.clone());
-            }
+        let bind_allocated_procs = |_router: &DialMailboxRouter| {
+            // All procs are now direct (self-routing), so no binding needed.
+            // This closure is kept for backward compatibility but does nothing.
         };
 
         // Temporary for backward compatibility with ranked procs and v0 API.

--- a/hyperactor_mesh/src/testing.rs
+++ b/hyperactor_mesh/src/testing.rs
@@ -22,13 +22,14 @@ use hyperactor::actor::ActorError;
 use hyperactor::actor::ActorErrorKind;
 use hyperactor::actor::ActorStatus;
 use hyperactor::actor::Signal;
+use hyperactor::channel::ChannelAddr;
 use hyperactor::channel::ChannelTransport;
 use hyperactor::context;
-use hyperactor::id;
 use hyperactor::mailbox::BoxableMailboxSender;
 use hyperactor::mailbox::DialMailboxRouter;
 use hyperactor::mailbox::PortReceiver;
 use hyperactor::proc::WorkCell;
+use hyperactor::reference::ProcId;
 use hyperactor::supervision::ActorSupervisionEvent;
 use ndslice::Extent;
 use tokio::process::Command;
@@ -220,7 +221,13 @@ async fn fresh_instance_with_router() -> (
 ) {
     static INSTANCE: OnceLock<(Instance<TestRootClient>, DialMailboxRouter)> = OnceLock::new();
     let router = DialMailboxRouter::new();
-    let proc = Proc::new(id!(test[0]), router.boxed());
+    let proc = Proc::new(
+        ProcId(
+            ChannelAddr::any(ChannelTransport::Local),
+            "test_0".to_string(),
+        ),
+        router.boxed(),
+    );
     let (actor, _handle, supervision_rx, signal_rx, work_rx) =
         proc.actor_instance("testclient").unwrap();
     // Use the OnceLock to get a 'static lifetime for the instance.

--- a/monarch_extension/src/mesh_controller.rs
+++ b/monarch_extension/src/mesh_controller.rs
@@ -836,14 +836,10 @@ impl Debug for MeshControllerActor {
 
 impl MeshControllerActor {
     fn rank_of_worker(&self, actor_id: &ActorId) -> usize {
-        if actor_id.proc_id().is_ranked() {
-            actor_id.rank()
-        } else {
-            *self
-                .rank_map
-                .get(actor_id.proc_id())
-                .expect("rank map should contain worker")
-        }
+        *self
+            .rank_map
+            .get(actor_id.proc_id())
+            .expect("rank map should contain worker")
     }
 }
 

--- a/monarch_hyperactor/src/runtime.rs
+++ b/monarch_hyperactor/src/runtime.rs
@@ -17,10 +17,11 @@ use std::time::Duration;
 
 use anyhow::Result;
 use hyperactor::Proc;
+use hyperactor::channel::ChannelAddr;
+use hyperactor::channel::ChannelTransport;
 use hyperactor::mailbox::BoxedMailboxSender;
 use hyperactor::mailbox::PanickingMailboxSender;
 use hyperactor::reference::ProcId;
-use hyperactor::reference::id;
 use once_cell::sync::Lazy;
 use once_cell::unsync::OnceCell as UnsyncOnceCell;
 use pyo3::PyResult;
@@ -87,7 +88,8 @@ pub fn shutdown_tokio_runtime(py: Python<'_>) {
 pub(crate) fn get_proc_runtime() -> &'static Proc {
     static RUNTIME_PROC: OnceLock<Proc> = OnceLock::new();
     RUNTIME_PROC.get_or_init(|| {
-        let proc_id = ProcId::Ranked(id!(monarch_hyperactor_runtime), 0);
+        let addr = ChannelAddr::any(ChannelTransport::Local);
+        let proc_id = ProcId(addr, "monarch_hyperactor_runtime".to_string());
         Proc::new(proc_id, BoxedMailboxSender::new(PanickingMailboxSender))
     })
 }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #2600
* #2592
* #2594
* #2590
* #2589
* #2598

This removes the ProcId::Ranked variant, converting ProcId from an enum to a simple struct `ProcId(pub ChannelAddr, pub String)`. All process identification now uses direct addressing with a channel address and name.

Key changes:
- ProcId is now a struct with (ChannelAddr, String) instead of enum with Ranked/Direct variants
- Removed the `id!` macro entirely
- Removed GangId and GangRef (no production usage)
- Proc::local() and Proc::runtime() now use ChannelAddr::any(ChannelTransport::Local) with unique names
- Simplified routing logic since all procs are now self-routing with their address
- Updated all allocators to create direct ProcIds with format "{alloc_name}_{rank}"
- Updated Python bindings to work with new ProcId structure
- WorldId struct is retained for allocator naming/grouping purposes

Differential Revision: [D93005991](https://our.internmc.facebook.com/intern/diff/D93005991/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D93005991/)!