### PR TITLE
Generalize actor_meshes table to meshes table

### DIFF
--- a/examples/distributed_telemetry_real_data.py
+++ b/examples/distributed_telemetry_real_data.py
@@ -241,7 +241,7 @@ def main() -> None:
         # Sample of actor meshes
         (
             "Sample actor meshes",
-            """SELECT id, class, given_name, full_name, timestamp_us
+            """SELECT id, class, given_name, full_name, shape_json, parent_view_json, timestamp_us
                FROM actor_meshes
                ORDER BY timestamp_us DESC
                LIMIT 10""",
@@ -249,7 +249,7 @@ def main() -> None:
         # Actor meshes by name pattern
         (
             "Actor meshes by name",
-            """SELECT given_name, class, shape_json
+            """SELECT given_name, class, shape_json, parent_view_json
                FROM actor_meshes
                ORDER BY given_name""",
         ),

--- a/examples/distributed_telemetry_real_data.py
+++ b/examples/distributed_telemetry_real_data.py
@@ -155,10 +155,10 @@ def main() -> None:
                ORDER BY ordinal_position""",
         ),
         (
-            "Schema of 'actor_meshes' table",
+            "Schema of 'meshes' table",
             """SELECT column_name, data_type, is_nullable
                FROM information_schema.columns
-               WHERE table_name = 'actor_meshes'
+               WHERE table_name = 'meshes'
                ORDER BY ordinal_position""",
         ),
         # Show available spans
@@ -171,7 +171,8 @@ def main() -> None:
         ("Count of actors", "SELECT COUNT(*) as total_actors FROM actors"),
         (
             "Count of actor meshes",
-            "SELECT COUNT(*) as total_actor_meshes FROM actor_meshes",
+            """SELECT COUNT(*) as total_actor_meshes FROM meshes
+               WHERE class LIKE 'ActorMesh%'""",
         ),
         # Show span details
         (
@@ -242,15 +243,17 @@ def main() -> None:
         (
             "Sample actor meshes",
             """SELECT id, class, given_name, full_name, shape_json, parent_view_json, timestamp_us
-               FROM actor_meshes
+               FROM meshes
+               WHERE class LIKE 'ActorMesh%'
                ORDER BY timestamp_us DESC
                LIMIT 10""",
         ),
-        # Actor meshes by name pattern
+        # Actor meshes by name
         (
             "Actor meshes by name",
             """SELECT given_name, class, shape_json, parent_view_json
-               FROM actor_meshes
+               FROM meshes
+               WHERE class LIKE 'ActorMesh%'
                ORDER BY given_name""",
         ),
     ]

--- a/hyperactor_mesh/src/proc_mesh.rs
+++ b/hyperactor_mesh/src/proc_mesh.rs
@@ -60,8 +60,8 @@ use hyperactor_config::CONFIG;
 use hyperactor_config::ConfigAttr;
 use hyperactor_config::attrs::declare_attrs;
 use hyperactor_config::global;
-use hyperactor_telemetry::ActorMeshEvent;
-use hyperactor_telemetry::notify_actor_mesh_created;
+use hyperactor_telemetry::MeshEvent;
+use hyperactor_telemetry::notify_mesh_created;
 use ndslice::Range;
 use ndslice::Shape;
 use ndslice::ShapeError;
@@ -777,10 +777,13 @@ impl ProcMesh {
                     let shape_json = serde_json::to_string(self.shape()).unwrap_or_default();
                     let full_name = format!("{}/{}", self.world_id(), actor_name);
 
-                    notify_actor_mesh_created(ActorMeshEvent {
+                    notify_mesh_created(MeshEvent {
                         id: mesh_id,
                         timestamp: RealClock.system_time_now(),
-                        class: std::any::type_name::<A>().to_string(),
+                        class: format!("ActorMesh<{}>", {
+                            let full = std::any::type_name::<A>();
+                            full.rsplit("::").next().unwrap_or(full)
+                        }),
                         given_name: actor_name.to_string(),
                         full_name,
                         shape_json,

--- a/hyperactor_mesh/src/v1/proc_mesh.rs
+++ b/hyperactor_mesh/src/v1/proc_mesh.rs
@@ -43,8 +43,8 @@ use hyperactor::supervision::ActorSupervisionEvent;
 use hyperactor_config::CONFIG;
 use hyperactor_config::ConfigAttr;
 use hyperactor_config::attrs::declare_attrs;
-use hyperactor_telemetry::ActorMeshEvent;
-use hyperactor_telemetry::notify_actor_mesh_created;
+use hyperactor_telemetry::MeshEvent;
+use hyperactor_telemetry::notify_mesh_created;
 use ndslice::Extent;
 use ndslice::ViewExt as _;
 use ndslice::view;
@@ -83,6 +83,13 @@ use crate::v1::ValueMesh;
 use crate::v1::host_mesh::mesh_agent::ProcState;
 use crate::v1::host_mesh::mesh_to_rankedvalues_with_default;
 use crate::v1::mesh_controller::ActorMeshController;
+
+/// Extract the short type name from a fully qualified Rust type path.
+/// e.g., "monarch_hyperactor::actor::PythonActor" -> "PythonActor"
+fn short_type_name<T: ?Sized>() -> &'static str {
+    let full = type_name::<T>();
+    full.rsplit("::").next().unwrap_or(full)
+}
 
 declare_attrs! {
     /// The maximum idle time between updates while spawning actor
@@ -1144,10 +1151,10 @@ impl ProcMeshRef {
             let shape_json =
                 serde_json::to_string(&mesh.region().extent()).unwrap_or_else(|_| "{}".to_string());
 
-            notify_actor_mesh_created(ActorMeshEvent {
+            notify_mesh_created(MeshEvent {
                 id: mesh_id,
                 timestamp: RealClock.system_time_now(),
-                class: type_name::<A>().to_string(),
+                class: format!("ActorMesh<{}>", short_type_name::<A>()),
                 given_name: mesh.name().to_string(),
                 full_name,
                 shape_json,

--- a/hyperactor_mesh/src/v1/proc_mesh.rs
+++ b/hyperactor_mesh/src/v1/proc_mesh.rs
@@ -1142,7 +1142,7 @@ impl ProcMeshRef {
 
             let full_name = format!("{}/{}", self.name, mesh.name());
             let shape_json =
-                serde_json::to_string(&self.region().extent()).unwrap_or_else(|_| "{}".to_string());
+                serde_json::to_string(&mesh.region().extent()).unwrap_or_else(|_| "{}".to_string());
 
             notify_actor_mesh_created(ActorMeshEvent {
                 id: mesh_id,
@@ -1152,7 +1152,9 @@ impl ProcMeshRef {
                 full_name,
                 shape_json,
                 parent_mesh_id: Some(parent_mesh_id),
-                parent_view_json: None,
+                parent_view_json: Some(
+                    serde_json::to_string(self.region()).unwrap_or_else(|_| "{}".to_string()),
+                ),
             });
         }
 

--- a/hyperactor_telemetry/src/lib.rs
+++ b/hyperactor_telemetry/src/lib.rs
@@ -335,7 +335,7 @@ pub struct ActorMeshEvent {
     pub given_name: String,
     /// Full hierarchical name as it appears in supervision events
     pub full_name: String,
-    /// Shape of the mesh, serialized from ndslice::Shape (labels + slice topology)
+    /// Shape of the mesh, serialized from ndslice::Extent
     pub shape_json: String,
     /// Parent mesh ID (None for root meshes)
     pub parent_mesh_id: Option<u64>,

--- a/hyperactor_telemetry/src/lib.rs
+++ b/hyperactor_telemetry/src/lib.rs
@@ -321,15 +321,15 @@ pub fn notify_actor_created(event: ActorEvent) {
     }
 }
 
-/// Event data for actor mesh creation.
-/// This is passed to EntityEventDispatcher implementations when an actor mesh is spawned.
+/// Event data for mesh creation.
+/// This is passed to EntityEventDispatcher implementations when a mesh is spawned.
 #[derive(Debug, Clone)]
-pub struct ActorMeshEvent {
+pub struct MeshEvent {
     /// Unique identifier for this mesh (hashed)
     pub id: u64,
     /// Timestamp when the mesh was created
     pub timestamp: SystemTime,
-    /// Mesh class (e.g., "Proc", "Host", "Python<SomeUserDefinedActor>")
+    /// Mesh class (e.g., "ProcMesh", "ActorMesh<PythonActor>")
     pub class: String,
     /// User-provided name for this mesh
     pub given_name: String,
@@ -343,13 +343,13 @@ pub struct ActorMeshEvent {
     pub parent_view_json: Option<String>,
 }
 
-/// Notify the registered dispatcher that an actor mesh was created.
-/// This is called from hyperactor_mesh when an actor mesh is spawned.
-pub fn notify_actor_mesh_created(event: ActorMeshEvent) {
+/// Notify the registered dispatcher that a mesh was created.
+/// This is called from hyperactor_mesh when a mesh is spawned.
+pub fn notify_mesh_created(event: MeshEvent) {
     if let Ok(dispatcher) = ENTITY_EVENT_DISPATCHER.lock() {
         if let Some(ref d) = *dispatcher {
-            if let Err(e) = d.dispatch(&EntityEvent::ActorMesh(event)) {
-                tracing::error!("Failed to dispatch actor mesh event: {}", e);
+            if let Err(e) = d.dispatch(&EntityEvent::Mesh(event)) {
+                tracing::error!("Failed to dispatch mesh event: {}", e);
             }
         }
     }
@@ -370,8 +370,8 @@ pub fn notify_actor_mesh_created(event: ActorMeshEvent) {
 pub enum EntityEvent {
     /// An actor was created.
     Actor(ActorEvent),
-    /// An actor mesh was created.
-    ActorMesh(ActorMeshEvent),
+    /// A mesh was created.
+    Mesh(MeshEvent),
 }
 
 /// Trait for dispatchers that receive unified entity events.
@@ -393,7 +393,7 @@ pub enum EntityEvent {
 ///     fn dispatch(&self, event: &EntityEvent) -> Result<(), anyhow::Error> {
 ///         match event {
 ///             EntityEvent::Actor(actor) => println!("Actor: {}", actor.full_name),
-///             EntityEvent::ActorMesh(mesh) => println!("Mesh: {}", mesh.full_name),
+///             EntityEvent::Mesh(mesh) => println!("Mesh: {}", mesh.full_name),
 ///         }
 ///         Ok(())
 ///     }

--- a/monarch_distributed_telemetry/src/entity_dispatcher.rs
+++ b/monarch_distributed_telemetry/src/entity_dispatcher.rs
@@ -8,12 +8,12 @@
 
 //! EntityDispatcher - Dispatches entity lifecycle events to Arrow RecordBatches
 //!
-//! Handles actor and actor mesh creation events, buffering them and flushing
+//! Handles actor and mesh creation events, buffering them and flushing
 //! to tables when the buffer reaches the configured batch size.
 //!
 //! Produces two tables:
 //! - `actors`: Actor creation events
-//! - `actor_meshes`: Actor mesh creation events
+//! - `meshes`: Mesh creation events (actor meshes, proc meshes, etc.)
 
 use std::sync::Arc;
 use std::sync::Mutex;
@@ -42,32 +42,32 @@ pub struct Actor {
     pub full_name: String,
 }
 
-/// Row data for the actor_meshes table.
-/// Logged when actor meshes are created.
+/// Row data for the meshes table.
+/// Logged when meshes are created (actor meshes, proc meshes, etc.).
 #[derive(RecordBatchRow)]
-pub struct ActorMesh {
-    /// Unique identifier for this actor mesh
+pub struct Mesh {
+    /// Unique identifier for this mesh
     pub id: u64,
     /// Timestamp in microseconds since Unix epoch
     pub timestamp_us: i64,
-    /// Actor mesh class (e.g., "Proc", "Host", "Python<SomeUserDefinedActor>")
+    /// Mesh class (e.g., "ProcMesh", "Python<SomeUserDefinedActor>")
     pub class: String,
-    /// User-provided name for this actor mesh
+    /// User-provided name for this mesh
     pub given_name: String,
     /// Full hierarchical name as it appears in supervision events
     pub full_name: String,
-    /// Shape of the actor mesh, serialized from ndslice::Extent
+    /// Shape of the mesh, serialized from ndslice::Extent
     pub shape_json: String,
-    /// Parent actor mesh ID (None for root meshes)
+    /// Parent mesh ID (None for root meshes)
     pub parent_mesh_id: Option<u64>,
-    /// Region over which the parent spawned this actor mesh, serialized from ndslice::Region
+    /// Region over which the parent spawned this mesh, serialized from ndslice::Region
     pub parent_view_json: Option<String>,
 }
 
 /// Inner state of EntityDispatcher.
 struct EntityDispatcherInner {
     actors_buffer: ActorBuffer,
-    actor_meshes_buffer: ActorMeshBuffer,
+    meshes_buffer: MeshBuffer,
     batch_size: usize,
     flush_callback: FlushCallback,
 }
@@ -85,11 +85,7 @@ impl EntityDispatcherInner {
 
     fn flush(&mut self) -> anyhow::Result<()> {
         Self::flush_buffer(&mut self.actors_buffer, "actors", &self.flush_callback)?;
-        Self::flush_buffer(
-            &mut self.actor_meshes_buffer,
-            "actor_meshes",
-            &self.flush_callback,
-        )?;
+        Self::flush_buffer(&mut self.meshes_buffer, "meshes", &self.flush_callback)?;
         Ok(())
     }
 
@@ -100,13 +96,9 @@ impl EntityDispatcherInner {
         Ok(())
     }
 
-    fn flush_actor_meshes_if_full(&mut self) -> anyhow::Result<()> {
-        if self.actor_meshes_buffer.len() >= self.batch_size {
-            Self::flush_buffer(
-                &mut self.actor_meshes_buffer,
-                "actor_meshes",
-                &self.flush_callback,
-            )?;
+    fn flush_meshes_if_full(&mut self) -> anyhow::Result<()> {
+        if self.meshes_buffer.len() >= self.batch_size {
+            Self::flush_buffer(&mut self.meshes_buffer, "meshes", &self.flush_callback)?;
         }
         Ok(())
     }
@@ -134,14 +126,14 @@ impl EntityDispatcher {
     pub fn new(batch_size: usize, flush_callback: FlushCallback) -> Self {
         let inner = Arc::new(Mutex::new(EntityDispatcherInner {
             actors_buffer: ActorBuffer::default(),
-            actor_meshes_buffer: ActorMeshBuffer::default(),
+            meshes_buffer: MeshBuffer::default(),
             batch_size,
             flush_callback,
         }));
         Self { inner }
     }
 
-    /// Flush all buffers, emitting batches for actors and actor_meshes tables.
+    /// Flush all buffers, emitting batches for actors and meshes tables.
     ///
     /// This always emits batches for both tables, even if they are empty.
     /// The callback is expected to handle empty batches by creating the table
@@ -172,12 +164,12 @@ impl EntityEventDispatcher for EntityDispatcher {
                 });
                 inner.flush_actors_if_full()?;
             }
-            EntityEvent::ActorMesh(mesh_event) => {
+            EntityEvent::Mesh(mesh_event) => {
                 let mut inner = self
                     .inner
                     .lock()
                     .map_err(|_| anyhow::anyhow!("lock poisoned"))?;
-                inner.actor_meshes_buffer.insert(ActorMesh {
+                inner.meshes_buffer.insert(Mesh {
                     id: mesh_event.id,
                     timestamp_us: timestamp_to_micros(&mesh_event.timestamp),
                     class: mesh_event.class.clone(),
@@ -187,7 +179,7 @@ impl EntityEventDispatcher for EntityDispatcher {
                     parent_mesh_id: mesh_event.parent_mesh_id,
                     parent_view_json: mesh_event.parent_view_json.clone(),
                 });
-                inner.flush_actor_meshes_if_full()?;
+                inner.flush_meshes_if_full()?;
             }
         }
         Ok(())

--- a/monarch_distributed_telemetry/src/entity_dispatcher.rs
+++ b/monarch_distributed_telemetry/src/entity_dispatcher.rs
@@ -56,7 +56,7 @@ pub struct ActorMesh {
     pub given_name: String,
     /// Full hierarchical name as it appears in supervision events
     pub full_name: String,
-    /// Shape of the actor mesh, serialized from ndslice::Shape (labels + slice topology)
+    /// Shape of the actor mesh, serialized from ndslice::Extent
     pub shape_json: String,
     /// Parent actor mesh ID (None for root meshes)
     pub parent_mesh_id: Option<u64>,

--- a/python/tests/test_distributed_telemetry.py
+++ b/python/tests/test_distributed_telemetry.py
@@ -180,12 +180,12 @@ def test_actors_table(cleanup_callbacks) -> None:
 
 
 @pytest.mark.timeout(120)
-def test_actor_meshes_table(cleanup_callbacks) -> None:
-    """Test that the actor_meshes table is populated when actor meshes are spawned."""
+def test_meshes_table(cleanup_callbacks) -> None:
+    """Test that the meshes table is populated when actor meshes are spawned."""
     # Start telemetry with real data (not fake) so RecordBatchSink receives events
     engine = start_telemetry(use_fake_data=False, batch_size=10)
 
-    # Spawn some worker actors - this should trigger notify_actor_mesh_created
+    # Spawn some worker actors - this should trigger notify_mesh_created
     worker_procs = this_host().spawn_procs(per_host={"workers": 2})
     workers = worker_procs.spawn("test_mesh_worker", WorkerActor)
 
@@ -194,13 +194,13 @@ def test_actor_meshes_table(cleanup_callbacks) -> None:
     # pyre-ignore[29]: workers is an ActorMesh
     workers.spawn_child.call("dummy_child").get()
 
-    # Query the actor_meshes table to verify actor meshes were recorded
-    result = engine.query("SELECT * FROM actor_meshes")
+    # Query the meshes table to verify meshes were recorded
+    result = engine.query("SELECT * FROM meshes")
     result_dict = result.to_pydict()
 
-    # We should have at least some actor meshes recorded
+    # We should have at least some meshes recorded
     mesh_count = len(result_dict.get("id", []))
-    assert mesh_count > 0, f"Expected at least one actor mesh, got {mesh_count}"
+    assert mesh_count > 0, f"Expected at least one mesh, got {mesh_count}"
 
     # Verify the schema has the expected columns
     expected_columns = {
@@ -265,11 +265,11 @@ def test_actor_meshes_table(cleanup_callbacks) -> None:
 
 
 @pytest.mark.timeout(120)
-def test_actors_join_actor_meshes_on_mesh_id(cleanup_callbacks) -> None:
-    """Test that actors.mesh_id matches actor_meshes.id, enabling joins."""
+def test_actors_join_meshes_on_mesh_id(cleanup_callbacks) -> None:
+    """Test that actors.mesh_id matches meshes.id, enabling joins."""
     engine = start_telemetry(use_fake_data=False, batch_size=10)
 
-    # Spawn actors — this populates both the actors and actor_meshes tables
+    # Spawn actors — this populates both the actors and meshes tables
     worker_procs = this_host().spawn_procs(per_host={"workers": 2})
     workers = worker_procs.spawn("join_test_worker", WorkerActor)
 
@@ -277,7 +277,7 @@ def test_actors_join_actor_meshes_on_mesh_id(cleanup_callbacks) -> None:
     # pyre-ignore[29]: workers is an ActorMesh
     workers.spawn_child.call("dummy").get()
 
-    # Join actors with actor_meshes on mesh_id = id
+    # Join actors with meshes on mesh_id = id
     result = engine.query(
         """SELECT a.full_name AS actor_name,
                   a.mesh_id,
@@ -285,7 +285,7 @@ def test_actors_join_actor_meshes_on_mesh_id(cleanup_callbacks) -> None:
                   m.given_name AS mesh_name,
                   m.class AS mesh_class
            FROM actors a
-           INNER JOIN actor_meshes m ON a.mesh_id = m.id
+           INNER JOIN meshes m ON a.mesh_id = m.id
            WHERE a.full_name LIKE '%join_test_worker%'
            ORDER BY a.rank"""
     )
@@ -294,8 +294,8 @@ def test_actors_join_actor_meshes_on_mesh_id(cleanup_callbacks) -> None:
     # The join should produce results — if mesh_id doesn't match, this is empty
     joined_count = len(result_dict.get("actor_name", []))
     assert joined_count > 0, (
-        "Expected actors to join with actor_meshes on mesh_id, but got 0 rows. "
-        "This means actors.mesh_id does not match any actor_meshes.id."
+        "Expected actors to join with meshes on mesh_id, but got 0 rows. "
+        "This means actors.mesh_id does not match any meshes.id."
     )
 
     # Every joined row should reference our mesh name


### PR DESCRIPTION
Summary: Rename ActorMesh/ActorMeshEvent/actor_meshes to Mesh/MeshEvent/meshes throughout the distributed telemetry stack. The `class` field in each row distinguishes mesh types (e.g., actor meshes use the actor type name like "WorkerActor", while proc meshes will use "ProcMesh"). This prepares the table to hold all mesh types (actor, proc, host) in a single unified table, enabling cross-mesh-type JOINs via parent_mesh_id.

Differential Revision: D93014774


