### PR TITLE
bump to rust resolver 3 in workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-resolver = "2"
+resolver = "3"
 members = [
     "build_utils",
     "erased_lifetime",


### PR DESCRIPTION
Summary: this is the default resolver for the 2024 edition. as we are on 2, bumping to 3 is low risk.

Differential Revision: D93152428


