### PR TITLE
Add kubernetes to test dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,6 +77,7 @@ examples = [
     "psutil",
 ]
 test = [
+    "kubernetes",
     "pytest",
     "pytest-timeout",
     "pytest-asyncio",

--- a/python/tests/requirements.txt
+++ b/python/tests/requirements.txt
@@ -1,3 +1,4 @@
+kubernetes
 pytest
 pytest-timeout
 pytest-asyncio

--- a/uv.lock
+++ b/uv.lock
@@ -1676,6 +1676,7 @@ kubernetes = [
     { name = "kubernetes" },
 ]
 test = [
+    { name = "kubernetes" },
     { name = "pyright" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
@@ -1700,6 +1701,7 @@ requires-dist = [
     { name = "clusterscope" },
     { name = "ipython", marker = "extra == 'examples'" },
     { name = "kubernetes", marker = "extra == 'kubernetes'" },
+    { name = "kubernetes", marker = "extra == 'test'" },
     { name = "lark" },
     { name = "numpy" },
     { name = "opentelemetry-api" },


### PR DESCRIPTION
Summary: `test_kubernetes.py` adds tests with KubernetesJob that requires kubernetes dependency.

Differential Revision: D93178771


