### PR TITLE
upgrading convert_case to 0.11

### DIFF
--- a/hyperactor_macros/Cargo.toml
+++ b/hyperactor_macros/Cargo.toml
@@ -19,7 +19,7 @@ name = "hyperactor_macros_test"
 path = "tests/basic.rs"
 
 [dependencies]
-convert_case = "0.10.0"
+convert_case = "0.11"
 indoc = "2.0.2"
 proc-macro2 = { version = "1.0.106", features = ["span-locations"] }
 quote = "1.0.44"


### PR DESCRIPTION
Summary:
* Upgrading `convert_case` from `0.10.0` to `0.11.0`
* The `is_case` method was removed from the `Casing` trait in `0.11`, so the one downstream usage in `fbcode/docdb/lib/compiler/opts/src/lib.rs` was updated to use an equivalent inline comparison `(s == s.to_case(Case::Snake))`.

Differential Revision: D93146002


