### PR TITLE
restore global_root_client undeliverable → supervision forwarding

### DIFF
--- a/hyperactor/src/mailbox.rs
+++ b/hyperactor/src/mailbox.rs
@@ -136,8 +136,6 @@ pub use undeliverable::Undeliverable;
 pub use undeliverable::UndeliverableMessageError;
 pub use undeliverable::custom_monitored_return_handle;
 pub use undeliverable::monitored_return_handle; // TODO: Audit
-pub use undeliverable::supervise_undeliverable_messages;
-pub use undeliverable::supervise_undeliverable_messages_with;
 /// For [`MailboxAdminMessage`], a message type for mailbox administration.
 pub mod mailbox_admin_message;
 pub use mailbox_admin_message::MailboxAdminMessage;

--- a/hyperactor/src/mailbox/undeliverable.rs
+++ b/hyperactor/src/mailbox/undeliverable.rs
@@ -17,7 +17,6 @@ use crate::Instance;
 // for macros
 use crate::Message;
 use crate::Proc;
-use crate::actor::ActorStatus;
 use crate::id;
 use crate::mailbox::DeliveryError;
 use crate::mailbox::MailboxSender;
@@ -25,7 +24,6 @@ use crate::mailbox::MessageEnvelope;
 use crate::mailbox::PortHandle;
 use crate::mailbox::PortReceiver;
 use crate::mailbox::UndeliverableMailboxSender;
-use crate::supervision::ActorSupervisionEvent;
 
 /// An undeliverable `M`-typed message (in practice `M` is
 /// [MessageEnvelope]).
@@ -167,86 +165,4 @@ impl std::fmt::Display for UndeliverableMessageError {
             }
         }
     }
-}
-
-/// Drain undeliverables and convert them into
-/// `ActorSupervisionEvent`, using a caller-provided resolver to
-/// obtain the (possibly late) sink. If the resolver returns `None`,
-/// we **log and drop** the undeliverable.
-pub fn supervise_undeliverable_messages_with<R, F>(
-    mut rx: PortReceiver<Undeliverable<MessageEnvelope>>,
-    mut resolve_sink: R,
-    on_undeliverable: F,
-) where
-    R: FnMut() -> Option<PortHandle<ActorSupervisionEvent>> + Send + 'static,
-    F: Fn(&MessageEnvelope) + Send + Sync + 'static,
-{
-    crate::init::get_runtime().spawn(async move {
-        // Create a local client for this task. Since we only use this client
-        // to send message with PortHandle, it is okay this proc does not have
-        // a forwarder.
-        let proc = Proc::local();
-        let (client, _) = proc.instance("undeliverable_supervisor").unwrap();
-        while let Ok(Undeliverable(mut env)) = rx.recv().await {
-            // Let caller log/trace before we mutate.
-            on_undeliverable(&env);
-
-            // `resolve_sink` provides the current supervision sink,
-            // which may appear later (e.g., after a ProcMesh finishes
-            // allocation). We call it on each message to ensure we
-            // always target the latest sink.
-            match resolve_sink() {
-                Some(sink) => {
-                    env.set_error(DeliveryError::BrokenLink(
-                        "message returned to supervised undeliverable port".to_string(),
-                    ));
-                    let actor_id = env.dest().actor_id().clone();
-                    let headers = env.headers().clone();
-
-                    if let Err(e) = sink.send(
-                        &client,
-                        ActorSupervisionEvent::new(
-                            actor_id,
-                            None,
-                            ActorStatus::generic_failure(format!("message not delivered: {}", env)),
-                            Some(headers),
-                        ),
-                    ) {
-                        tracing::warn!(
-                            %e,
-                            actor=%env.dest().actor_id(),
-                            headers=?env.headers(),
-                            "failed to forward supervision event; logging undeliverable"
-                        );
-                        UndeliverableMailboxSender.post(env, monitored_return_handle());
-                    }
-                }
-                None => {
-                    tracing::warn!(
-                        actor=%env.dest().actor_id(),
-                        headers=?env.headers(),
-                        "no supervision sink yet; logging undeliverable"
-                    );
-                    UndeliverableMailboxSender.post(env, monitored_return_handle());
-                }
-            }
-        }
-    });
-}
-
-/// Spawns a task that listens for undeliverable messages and posts a
-/// corresponding `ActorSupervisionEvent` to the given supervision
-/// port.
-pub fn supervise_undeliverable_messages<F>(
-    supervision_port: PortHandle<ActorSupervisionEvent>,
-    rx: PortReceiver<Undeliverable<MessageEnvelope>>,
-    on_deliverable: F,
-) where
-    F: Fn(&MessageEnvelope) + Send + Sync + 'static,
-{
-    supervise_undeliverable_messages_with(
-        rx,
-        move || Some(supervision_port.clone()),
-        on_deliverable,
-    );
 }

--- a/hyperactor/src/proc.rs
+++ b/hyperactor/src/proc.rs
@@ -214,6 +214,7 @@ impl Proc {
             name = "ProcStatus",
             status = "Created"
         );
+
         let proc = Self {
             inner: Arc::new(ProcState {
                 proc_id,

--- a/hyperactor_mesh/src/global_client.rs
+++ b/hyperactor_mesh/src/global_client.rs
@@ -6,7 +6,43 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-//! Global client actor and supervision sink management.
+//! Process-global root client actor and supervision bridge.
+//!
+//! This module defines the *global root client*: a single,
+//! lazily-initialized actor used by driver processes (e.g. Python
+//! entrypoints) to inject messages into meshes. It runs in its own
+//! proc and can be used before any specific [`ProcMesh`] is fully
+//! constructed.
+//!
+//! ## Undeliverables → supervision
+//!
+//! When the runtime detects that a message cannot be delivered, it
+//! produces an [`Undeliverable<MessageEnvelope>`]. The global root
+//! client observes these failures, converts them into
+//! [`ActorSupervisionEvent`]s, and forwards them to the currently
+//! active mesh supervision sink.
+//!
+//! **Invariant:** Any `Undeliverable<MessageEnvelope>` observed by
+//! [`global_root_client()`] must be reported as an
+//! [`ActorSupervisionEvent`] to the active `ProcMesh`, and handling
+//! that failure must never crash the global client. The root client
+//! acts as a monitor, not a participant: routing failures are treated
+//! as signals to be reported, not fatal errors.
+//!
+//! ## Multiple ProcMeshes
+//!
+//! A process may allocate more than one `ProcMesh` (e.g.
+//! internal/controller meshes plus an application mesh). The root
+//! client is a process-wide singleton, so its supervision sink is
+//! also process-global.
+//!
+//! The active mesh is defined using **last-sink-wins** semantics:
+//! each newly allocated `ProcMesh` installs its sink, overriding the
+//! previous one.
+//!
+//! If no sink has been installed yet (early/late binding),
+//! undeliverables are logged and dropped, preserving forward progress
+//! until a mesh becomes available.
 
 use std::sync::OnceLock;
 use std::sync::RwLock;
@@ -22,12 +58,13 @@ use hyperactor::actor::ActorErrorKind;
 use hyperactor::actor::ActorStatus;
 use hyperactor::actor::Signal;
 use hyperactor::mailbox::BoxableMailboxSender;
+use hyperactor::mailbox::DeliveryError;
 use hyperactor::mailbox::MessageEnvelope;
-use hyperactor::mailbox::PortHandle;
 use hyperactor::mailbox::PortReceiver;
 use hyperactor::mailbox::Undeliverable;
 use hyperactor::proc::Proc;
 use hyperactor::proc::WorkCell;
+use hyperactor::reference::PortRef;
 use hyperactor::supervision::ActorSupervisionEvent;
 use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
@@ -38,38 +75,39 @@ use crate::transport::default_bind_spec;
 
 /// Single, process-wide supervision sink storage.
 ///
-/// This is a pragmatic "good enough for now" global used to route
-/// undeliverables observed by the process-global root client (c.f.
-/// [`global_root_client`])to the *currently active* `ProcMesh`. Newer
-/// meshes override older ones ("last sink wins").
-static GLOBAL_SUPERVISION_SINK: OnceLock<RwLock<Option<PortHandle<ActorSupervisionEvent>>>> =
+/// Routes undeliverables observed by the process-global root client
+/// (c.f. [`global_root_client`]) to the *currently active* `ProcMesh`'s
+/// agent. Newer meshes override older ones ("last sink wins").
+///
+/// Uses `PortRef` (not `PortHandle`) because the sink target
+/// (`ProcMeshAgent`) runs in a remote worker process.
+static GLOBAL_SUPERVISION_SINK: OnceLock<RwLock<Option<PortRef<ActorSupervisionEvent>>>> =
     OnceLock::new();
 
 /// Returns the lazily-initialized container that holds the current
 /// process-global supervision sink.
-///
-/// Internal helper: callers should use `set_global_supervision_sink`
-/// and `get_global_supervision_sink` instead.
-fn sink_cell() -> &'static RwLock<Option<PortHandle<ActorSupervisionEvent>>> {
+fn sink_cell() -> &'static RwLock<Option<PortRef<ActorSupervisionEvent>>> {
     GLOBAL_SUPERVISION_SINK.get_or_init(|| RwLock::new(None))
 }
 
-/// Install (or replace) the process-global supervision sink.
+/// Install (or replace) the process-global supervision sink used by
+/// the [`global_root_client()`] undeliverable → supervision bridge.
 ///
-/// This function enforces "last sink wins" semantics: if a sink was
-/// already installed, it is replaced and the previous sink is
-/// returned. Called from `ProcMesh::allocate_boxed`, after creating
-/// the mesh's supervision port.
+/// This uses **last-sink-wins** semantics: if multiple `ProcMesh`
+/// instances are created in the same process (e.g. controller meshes
+/// plus an application mesh), the most recently installed sink
+/// becomes the active destination for forwarded
+/// [`ActorSupervisionEvent`]s.
 ///
-/// Returns:
-/// - `Some(prev)` if a prior sink was installed, allowing the caller
-///   to log/inspect it if desired;
-/// - `None` if this is the first sink.
+/// Returns the previously installed sink, if any, to allow callers to
+/// log/inspect overrides.
 ///
-/// Thread-safety: takes a write lock briefly to swap the handle.
+/// Note: the sink is a [`PortRef`] (not a `PortHandle`) because the
+/// destination [`ProcMeshAgent`] may live in a different
+/// process/rank.
 pub(crate) fn set_global_supervision_sink(
-    sink: PortHandle<ActorSupervisionEvent>,
-) -> Option<PortHandle<ActorSupervisionEvent>> {
+    sink: PortRef<ActorSupervisionEvent>,
+) -> Option<PortRef<ActorSupervisionEvent>> {
     let cell = sink_cell();
     let mut guard = cell.write().unwrap();
     let prev = guard.take();
@@ -77,25 +115,55 @@ pub(crate) fn set_global_supervision_sink(
     prev
 }
 
-/// Get a clone of the current process-global supervision sink, if
-/// any.
+/// Get the current process-global supervision sink used by the
+/// [`global_root_client()`] undeliverable → supervision bridge.
 ///
-/// This is used by the process-global root client [c.f.
-/// `global_root_client`] to forward undeliverables once a mesh has
-/// installed its sink. If no sink has been installed yet, returns
-/// `None` and callers should defer/ignore forwarding until one
-/// appears.
+/// Returns `None` until some mesh creation path installs a sink
+/// (early/late binding). Callers should treat this as "no active mesh
+/// yet": log and drop undeliverables rather than crashing the global
+/// root client.
 ///
-/// Thread-safety: takes a read lock briefly; cloning the `PortHandle`
-/// is cheap.
-pub(crate) fn get_global_supervision_sink() -> Option<PortHandle<ActorSupervisionEvent>> {
+/// Cloning a [`PortRef`] is cheap.
+///
+/// Used only by the process-global root client.
+fn get_global_supervision_sink() -> Option<PortRef<ActorSupervisionEvent>> {
     sink_cell().read().unwrap().clone()
 }
 
+/// Process-global "root client" actor.
+///
+/// This actor lives in a dedicated, lazily-initialized proc and is
+/// used by driver code (e.g. Python entrypoints) to inject messages
+/// into meshes before a specific [`ProcMesh`] is fully constructed.
+///
+/// It also acts as a *monitor* for routing failures observed at the
+/// process boundary: undeliverable messages are treated as signals to
+/// be reported via mesh supervision (when a sink is installed), not
+/// as fatal errors.
+///
+/// The actor is driven by `run()`, which `select!`s over:
+/// - `work_rx`: the primary dispatch queue for bound handler work
+///   items (including `Undeliverable<MessageEnvelope>` and
+///   `MeshFailure>`),
+/// - `supervision_rx`: supervision events delivered to this actor,
+///   and
+/// - `signal_rx`: control signals (currently minimal handling).
 #[derive(Debug)]
+#[hyperactor::export(handlers = [MeshFailure])]
 pub struct GlobalClientActor {
+    /// Control signals for the actor’s proc (shutdown, etc.).
     signal_rx: PortReceiver<Signal>,
+    /// Supervision events delivered to this actor instance.
+    ///
+    /// The root client is a monitor, so it should process these
+    /// events without crashing on routine routing/delivery failures
+    /// it observes.
     supervision_rx: PortReceiver<ActorSupervisionEvent>,
+    /// Primary work queue for handler dispatch.
+    ///
+    /// Any bound handler message (e.g. `MeshFailure`,
+    /// `Undeliverable<MessageEnvelope>`, introspection, etc.) is
+    /// received here and executed via `WorkCell::handle`.
     work_rx: mpsc::UnboundedReceiver<WorkCell<Self>>,
 }
 
@@ -148,16 +216,92 @@ impl GlobalClientActor {
     }
 }
 
-impl Actor for GlobalClientActor {}
+/// Handle a returned (undeliverable) message observed by the
+/// process-global root client.
+///
+/// The global root client is a **monitor**, not a participant: it
+/// must not crash or propagate failures just because a routed message
+/// could not be delivered.
+///
+/// Instead, we translate the undeliverable into an
+/// `ActorSupervisionEvent` and forward it to the **active**
+/// `ProcMesh` via the process-global supervision sink ("last sink
+/// wins"). If no sink has been installed yet (e.g., before the first
+/// `ProcMesh` allocation completes), we log and drop the event.
+#[async_trait]
+impl Actor for GlobalClientActor {
+    async fn handle_undeliverable_message(
+        &mut self,
+        cx: &Instance<Self>,
+        Undeliverable(mut env): Undeliverable<MessageEnvelope>,
+    ) -> Result<(), anyhow::Error> {
+        env.set_error(DeliveryError::BrokenLink(
+            "message returned to global root client".to_string(),
+        ));
+        let actor_id = env.dest().actor_id().clone();
+        let headers = env.headers().clone();
+        let event = ActorSupervisionEvent::new(
+            actor_id.clone(),
+            None,
+            ActorStatus::generic_failure(format!("message not delivered: {}", env)),
+            Some(headers),
+        );
 
+        match get_global_supervision_sink() {
+            Some(sink) => {
+                if let Err(e) = sink.send(cx, event) {
+                    tracing::warn!(
+                        %e,
+                        actor=%actor_id,
+                        "failed to forward supervision event from undeliverable"
+                    );
+                }
+            }
+            None => {
+                tracing::warn!(
+                    actor=%actor_id,
+                    error=?env.errors(),
+                    "no supervision sink; undeliverable message logged but not forwarded"
+                );
+            }
+        }
+        Ok(())
+    }
+}
+
+/// `MeshFailure` is a terminal supervision signal for an `ActorMesh`.
+///
+/// The process-global root client should never be a consumer of
+/// mesh-level supervision failures during normal operation: those
+/// events are expected to be observed and handled by the owning
+/// mesh/controller, not by the global client.
+///
+/// In processes that create and destroy multiple meshes (e.g.,
+/// benchmarks), `MeshFailure` events may arrive here during or after
+/// mesh teardown. Log loudly but do not crash — the global client is
+/// a monitor and must preserve forward progress.
 #[async_trait]
 impl Handler<MeshFailure> for GlobalClientActor {
     async fn handle(&mut self, _cx: &Context<Self>, message: MeshFailure) -> anyhow::Result<()> {
         tracing::error!("supervision failure reached global client: {}", message);
-        panic!("supervision failure reached global client: {}", message);
+        Ok(())
     }
 }
 
+/// Lazily create (and start) the process-global root client actor
+/// instance.
+///
+/// This initializes the dedicated `mesh_root_client_proc`, creates
+/// the `GlobalClientActor` instance within it, binds the actor's
+/// well-known ports, and spawns the actor's run loop. The returned
+/// references are `'static` via a `OnceLock`, ensuring there is
+/// exactly one global root client per process.
+///
+/// The global root client is a monitor/entrypoint: it must not crash
+/// due to routing or delivery failures it observes. Undeliverables
+/// are handled non-fatally and (when a global supervision sink is
+/// installed) are converted into `ActorSupervisionEvent`s and
+/// forwarded to the active `ProcMesh`.
 fn fresh_instance() -> (
     &'static Instance<GlobalClientActor>,
     &'static ActorHandle<GlobalClientActor>,
@@ -175,40 +319,28 @@ fn fresh_instance() -> (
     // same client in both direct-addressed and ranked-addressed modes.
     router::global().bind(client_proc.proc_id().clone().into(), client_proc.clone());
 
-    // The work_rx messages loop is ignored. v0 will support Handler<MeshFailure>,
-    // but it doesn't actually handle the messages.
-    // This is fine because v0 doesn't use this supervision mechanism anyway.
+    // Drive the global root client actor.
+    //
+    // `work_rx` is the primary dispatch queue: messages received on
+    // bound ports are enqueued as work items and executed via
+    // `work.handle(..)`.
+    //
+    // `supervision_rx` carries supervision events delivered to this
+    // actor; we process them via
+    // `Instance::handle_supervision_event`. The global root client is
+    // a monitor and must not crash due to routing / delivery failures
+    // it observes; undeliverables are handled non-fatally.
     let (client, handle, supervision_rx, signal_rx, work_rx) = client_proc
         .actor_instance::<GlobalClientActor>("client")
         .expect("root instance create");
 
-    // Bind the global root client's undeliverable port and
-    // forward any undeliverable messages to the currently active
+    // Bind the actor's well-known ports (Signal,
+    // Undeliverable<MessageEnvelope>, IntrospectMessage, and the
+    // MeshFailure handler). Undeliverable messages are routed to
+    // GlobalClientActor::handle_undeliverable_message, which converts
+    // them to ActorSupervisionEvents and forwards to the global
     // supervision sink.
-    //
-    // The resolver (`get_global_supervision_sink`) is passed as a
-    // function pointer, so each time an undeliverable is
-    // processed, we look up the *latest* sink. This allows the
-    // root client to seamlessly track whichever ProcMesh most
-    // recently installed a supervision sink (e.g., the
-    // application mesh instead of an internal controller mesh).
-    //
-    // The hook logs each undeliverable, along with whether a sink
-    // was present at the time of receipt, which helps diagnose
-    // lost or misrouted events.
-    let (_undeliverable_tx, undeliverable_rx) =
-        client.open_port::<Undeliverable<MessageEnvelope>>();
-    hyperactor::mailbox::supervise_undeliverable_messages_with(
-        undeliverable_rx,
-        get_global_supervision_sink,
-        |env| {
-            let sink_present = get_global_supervision_sink().is_some();
-            tracing::info!(
-                actor_id = %env.dest().actor_id(),
-                "global root client undeliverable observed with headers {:?} {}", env.headers(), sink_present
-            );
-        },
-    );
+    handle.bind::<GlobalClientActor>();
 
     // Use the OnceLock to get a 'static lifetime for the instance.
     INSTANCE
@@ -234,4 +366,168 @@ pub fn global_root_client() -> &'static Instance<GlobalClientActor> {
         &'static ActorHandle<GlobalClientActor>,
     )> = OnceLock::new();
     GLOBAL_INSTANCE.get_or_init(fresh_instance).0
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use hyperactor::PortId;
+    use hyperactor::id;
+    use hyperactor_config::attrs::Attrs;
+    use ndslice::extent;
+
+    use super::*;
+    use crate::testing;
+
+    /// Helper: send an `Undeliverable<MessageEnvelope>` to the global
+    /// root client's well-known undeliverable port via the runtime's
+    /// routing/dispatch path.
+    ///
+    /// This exercises the full integration boundary: serialisation →
+    /// routing → work_rx dispatch → `handle_undeliverable_message`.
+    ///
+    /// Uses the provided `dest_actor` so callers can distinguish
+    /// events from different injections (important because the global
+    /// sink is shared across tests running in the same process).
+    fn inject_undeliverable(
+        client: &'static Instance<GlobalClientActor>,
+        dest_actor: hyperactor::ActorId,
+    ) {
+        let env = MessageEnvelope::new(
+            client.self_id().clone(),
+            PortId(dest_actor, 0),
+            wirevalue::Any::serialize(&0u64).unwrap(),
+            Attrs::new(),
+        );
+        // Target the global root client's well-known Undeliverable port.
+        let undeliverable_port =
+            PortRef::<Undeliverable<MessageEnvelope>>::attest_message_port(client.self_id());
+        undeliverable_port
+            .send(client, Undeliverable(env))
+            .expect("inject_undeliverable: send failed");
+    }
+
+    /// Verifies that creating a `ProcMesh` installs the
+    /// process-global supervision sink used by the global root
+    /// client.
+    #[tokio::test]
+    async fn test_sink_installed_after_mesh_creation() {
+        let (_mesh, _actor, _router) = testing::local_proc_mesh(extent!(replica = 2)).await;
+        assert!(
+            get_global_supervision_sink().is_some(),
+            "supervision sink must be set after ProcMesh creation"
+        );
+    }
+
+    /// Proves the full forwarding pipeline:
+    ///
+    ///   Undeliverable<MessageEnvelope>
+    ///       → GlobalClientActor::handle_undeliverable_message
+    ///       → GLOBAL_SUPERVISION_SINK (PortRef)
+    ///       → ActorSupervisionEvent delivered
+    ///
+    /// Installs a local port as the sink and verifies that the
+    /// `ActorSupervisionEvent` arrives there.
+    #[tokio::test]
+    async fn test_undeliverable_forwarded_to_sink() {
+        let client = global_root_client();
+
+        // Install a test sink we control.
+        let (sink_handle, mut sink_rx) = client.open_port::<ActorSupervisionEvent>();
+        set_global_supervision_sink(sink_handle.bind());
+
+        let marker = id!(fwd_test[0].marker_actor);
+        inject_undeliverable(client, marker.clone());
+
+        // The handler runs asynchronously via work_rx; wait for the
+        // forwarded event with our marker.
+        let event = tokio::time::timeout(Duration::from_secs(5), async {
+            loop {
+                let ev = sink_rx.recv().await.expect("sink channel closed");
+                if ev.actor_id == marker {
+                    return ev;
+                }
+                // Discard stale events from other tests sharing the
+                // global sink.
+            }
+        })
+        .await
+        .expect("timed out waiting for supervision event");
+
+        assert_eq!(
+            event.actor_id, marker,
+            "forwarded event must reference the undeliverable's destination actor"
+        );
+    }
+
+    /// Proves last-sink-wins: when two sinks are installed in
+    /// sequence, only the second receives the forwarded event.
+    #[tokio::test]
+    async fn test_last_sink_wins() {
+        let client = global_root_client();
+
+        // Install sink A.
+        let (sink_a_handle, _sink_a_rx) = client.open_port::<ActorSupervisionEvent>();
+        set_global_supervision_sink(sink_a_handle.bind());
+
+        // Install sink B (overrides A).
+        let (sink_b_handle, mut sink_b_rx) = client.open_port::<ActorSupervisionEvent>();
+        set_global_supervision_sink(sink_b_handle.bind());
+
+        let marker = id!(last_wins[0].marker_actor);
+        inject_undeliverable(client, marker.clone());
+
+        // B should receive our marked event.
+        let event = tokio::time::timeout(Duration::from_secs(5), async {
+            loop {
+                let ev = sink_b_rx.recv().await.expect("sink B channel closed");
+                if ev.actor_id == marker {
+                    return ev;
+                }
+            }
+        })
+        .await
+        .expect("timed out waiting for supervision event on sink B");
+        assert_eq!(event.actor_id, marker);
+    }
+
+    /// Proves the global client does not crash when no sink is
+    /// installed (early/late binding). The handler must log and
+    /// drop gracefully, and the client must remain usable
+    /// afterward.
+    #[tokio::test]
+    async fn test_no_crash_without_sink() {
+        let client = global_root_client();
+
+        // Clear any previously installed sink.
+        *sink_cell().write().unwrap() = None;
+
+        // Inject an undeliverable — should not panic.
+        inject_undeliverable(client, id!(no_sink[0].marker_actor));
+
+        // Give the async handler time to run.
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        // The global client must still be alive and usable.
+        // Verify by installing a new sink and sending another
+        // undeliverable that arrives correctly.
+        let (sink_handle, mut sink_rx) = client.open_port::<ActorSupervisionEvent>();
+        set_global_supervision_sink(sink_handle.bind());
+
+        let marker = id!(no_sink_recovery[0].marker_actor);
+        inject_undeliverable(client, marker.clone());
+
+        let event = tokio::time::timeout(Duration::from_secs(5), async {
+            loop {
+                let ev = sink_rx.recv().await.expect("sink channel closed");
+                if ev.actor_id == marker {
+                    return ev;
+                }
+            }
+        })
+        .await
+        .expect("timed out: global client crashed or stopped processing");
+        assert_eq!(event.actor_id, marker);
+    }
 }

--- a/hyperactor_mesh/src/host_mesh.rs
+++ b/hyperactor_mesh/src/host_mesh.rs
@@ -1587,17 +1587,17 @@ mod tests {
         }
     }
 
-    #[async_timed_test(timeout_secs = 180)]
+    #[async_timed_test(timeout_secs = 600)]
     #[cfg(fbcode_build)]
-    async fn test_allocate() {
+    async fn test_allocate_dest_reorder_buffer_off() {
         let config = hyperactor_config::global::lock();
         let _guard = config.override_key(ENABLE_NATIVE_V1_CASTING, false);
         execute_allocate(&config).await;
     }
 
-    #[async_timed_test(timeout_secs = 180)]
+    #[async_timed_test(timeout_secs = 600)]
     #[cfg(fbcode_build)]
-    async fn test_allocate_v1() {
+    async fn test_allocate_dest_reorder_buffer_on() {
         let config = hyperactor_config::global::lock();
         let _guard = config.override_key(ENABLE_NATIVE_V1_CASTING, true);
         let _guard1 = config.override_key(ENABLE_DEST_ACTOR_REORDERING_BUFFER, true);

--- a/hyperactor_mesh/src/proc_mesh.rs
+++ b/hyperactor_mesh/src/proc_mesh.rs
@@ -224,6 +224,16 @@ impl ProcMesh {
 
         let region = allocation.extent().clone().into();
         let ranks = allocation.ranks();
+
+        // Set the global supervision sink to the first ProcMeshAgent's
+        // supervision event handler. Last-mesh-wins semantics: if a
+        // previous mesh installed a sink, it is replaced.
+        if let Some(first) = ranks.first() {
+            crate::global_client::set_global_supervision_sink(
+                first.agent.port::<ActorSupervisionEvent>(),
+            );
+        }
+
         let root_comm_actor = comm_actor_name.as_ref().map(|name| {
             ActorRef::attest(
                 ranks


### PR DESCRIPTION
Summary:
summary / intent

this diff restores the pre- D92046194 (”[monarch] delete v0 mesh code and simplify ActorMeshId”) behavior/invariant for the process-global root client:

undeliverables observed by `global_root_client()` are treated as first-class supervision signals, not log-only noise.

invariant being restored

any `Undeliverable<MessageEnvelope>` observed by `global_root_client()` must result in an `ActorSupervisionEvent` delivered to the active `ProcMesh` (last sink wins), and the global root client must not crash while doing so.

D92046194 removed the v0-era plumbing that effectively implemented this behavior (binding + forwarding path), and the system regressed to "undeliverables get logged via `monitored_return_handle()` but do not generate supervision events".

what changed
- replaces the previous "drain task + local `PortHandle` send" approach with v1-native routing:
- `GlobalClientActor` overrides `Actor::handle_undeliverable_message` so undeliverables are handled on the actor work queue and translated into `ActorSupervisionEvent`s.
- adds process-global sink storage as `a PortRef<ActorSupervisionEvent>` (remote address) rather than `PortHandle` (local queue handle), because the sink target lives in a mesh agent process.
- binds well-known ports via `handle.bind::<GlobalClientActor>()` so undeliverables are actually routed to the actor.
- exports `ActorSupervisionEvent` on `ProcMeshAgent` so the global client can send the event cross-proc via `PortRef`.
- installs the sink from `ProcMesh` creation (proc_mesh.rs) using last-sink-wins semantics, matching the "multiple meshes in one process" reality (controller mesh + application mesh).

why `PortRef` (not `PortHandle`)

the old pipeline used a local "drain undeliverables and send through a local handle" task. once we remove that task and send directly into the mesh's supervision sink, the destination is remote (the agent proc/rank), so we need a serializable remote address (`PortRef`). in other words: we moved from local queue forwarding to remote address routing.

safety / monitor semantics

the global root client is a monitor/entrypoint; it must not crash merely because it observed a routing failure. the undeliverable path logs and forwards (or logs+drops if no sink yet) and returns `Ok(())`.

tests

this diff adds targeted integration tests in global_client.rs that encode the restored undeliverable → supervision invariant:

- `test_sink_installed_after_mesh_creation`
verifies that creating a ProcMesh installs the process-global supervision sink. This prevents regressions where undeliverables would silently degrade to log-only handling because no sink was registered.

- `test_undeliverable_forwarded_to_sink`
injects an `Undeliverable<MessageEnvelope>` into the global root client and asserts that an `ActorSupervisionEvent` is forwarded to the installed sink. this proves the full routing → actor dispatch → supervision forwarding pipeline is live.

- `test_last_sink_wins`
installs two sinks sequentially and verifies that only the most recently installed sink receives the forwarded event. this locks in the intended "last-sink-wins" semantics when multiple meshes exist in a single process.

- `test_no_crash_without_sink`
clears the sink, injects an undeliverable, and verifies the global client continues running and can resume forwarding once a sink is installed. this enforces the monitor invariant: routing failures must not crash the global root client.

together these tests directly encode the restored contract:

undeliverables observed by `global_root_client()` are surfaced as supervision events when possible, and never cause the client itself to fail.

Differential Revision: D93190253


