### PR TITLE
Carry error message in TwTaskIp::Error(String)

### DIFF
--- a/hyperactor/src/lib.rs
+++ b/hyperactor/src/lib.rs
@@ -94,6 +94,9 @@ pub mod sync;
 pub mod test_utils;
 pub mod time;
 
+#[cfg(fbcode_build)]
+mod meta;
+
 /// Re-exports of external crates used by hyperactor_macros codegen.
 /// This module is not part of the public API and should not be used directly.
 #[doc(hidden)]


### PR DESCRIPTION
Summary: Change `TwTaskIp::Error` to `TwTaskIp::Error(String)` so that `tw_task_ip()` no longer logs internally. Instead, the error message is carried in the enum variant and logging moves to the call site in `channel.rs`. The function now returns `&'static TwTaskIp` to avoid needing `Clone` on every call, and `Copy` is removed from the derive since `String` is not `Copy`.

Differential Revision: D93236404


