### PR TITLE
upgrading `tokio` to `1.48.0`

### DIFF
--- a/hyper/Cargo.toml
+++ b/hyper/Cargo.toml
@@ -20,7 +20,7 @@ hyperactor_mesh = { version = "0.0.0", path = "../hyperactor_mesh" }
 reqwest = { version = "0.11.18", features = ["blocking", "cookies", "gzip", "json", "multipart", "native-tls", "rustls-tls", "rustls-tls-native-roots", "socks", "stream"] }
 serde_json = { version = "1.0.140", features = ["alloc", "float_roundtrip", "raw_value", "unbounded_depth"] }
 tabwriter = { version = "1.4.1", features = ["ansi_formatting"] }
-tokio = { version = "1.47.1", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.48.0", features = ["full", "test-util", "tracing"] }
 urlencoding = "2.1.0"
 
 [lints]

--- a/hyperactor/Cargo.toml
+++ b/hyperactor/Cargo.toml
@@ -69,7 +69,7 @@ serde_multipart = { version = "0.0.0", path = "../serde_multipart" }
 signal-hook-tokio = { version = "0.3", features = ["futures-v0_3"] }
 strum = { version = "0.27.1", features = ["derive"] }
 thiserror = "2.0.18"
-tokio = { version = "1.47.1", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.48.0", features = ["full", "test-util", "tracing"] }
 tokio-rustls = { version = "0.26.2", features = ["logging", "ring", "tls12"], default-features = false }
 tokio-stream = { version = "0.1.17", features = ["fs", "io-util", "net", "signal", "sync", "time"] }
 tokio-util = { version = "0.7.15", features = ["full"] }

--- a/hyperactor_macros/Cargo.toml
+++ b/hyperactor_macros/Cargo.toml
@@ -32,7 +32,7 @@ hyperactor = { version = "0.0.0", path = "../hyperactor" }
 serde = { version = "1.0.185", features = ["derive", "rc"] }
 static_assertions = "1.1.0"
 timed_test = { version = "0.0.0", path = "../timed_test" }
-tokio = { version = "1.37.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.48.0", features = ["full", "test-util", "tracing"] }
 tracing = { version = "0.1.41", features = ["attributes", "valuable"] }
 typeuri = { version = "0.0.0", path = "../typeuri" }
 wirevalue = { version = "0.0.0", path = "../wirevalue" }

--- a/hyperactor_mesh/Cargo.toml
+++ b/hyperactor_mesh/Cargo.toml
@@ -78,7 +78,7 @@ strum = { version = "0.27.1", features = ["derive"] }
 systemd = { version = "0.10.1", optional = true }
 tempfile = "3.22"
 thiserror = "2.0.18"
-tokio = { version = "1.47.1", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.48.0", features = ["full", "test-util", "tracing"] }
 tokio-stream = { version = "0.1.17", features = ["fs", "io-util", "net", "signal", "sync", "time"] }
 tokio-util = { version = "0.7.15", features = ["full"] }
 tracing = { version = "0.1.41", features = ["attributes", "valuable"] }

--- a/hyperactor_telemetry/Cargo.toml
+++ b/hyperactor_telemetry/Cargo.toml
@@ -28,7 +28,7 @@ serde_json = { version = "1.0.140", features = ["alloc", "float_roundtrip", "raw
 serde_rusqlite = "0.40.1"
 smallvec = { version = "1.15", features = ["impl_bincode", "serde", "specialization", "union"] }
 smol_str = "0.1.24"
-tokio = { version = "1.47.1", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.48.0", features = ["full", "test-util", "tracing"] }
 tracing = { version = "0.1.41", features = ["attributes", "valuable"] }
 tracing-appender = "0.2.4"
 tracing-core = { version = "0.1.33", features = ["valuable"] }

--- a/monarch_bench/Cargo.toml
+++ b/monarch_bench/Cargo.toml
@@ -9,4 +9,4 @@ license = "BSD-3-Clause"
 
 [dev-dependencies]
 criterion = { version = "0.5.1", features = ["async_tokio", "csv_output"] }
-tokio = { version = "1.47.1", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.48.0", features = ["full", "test-util", "tracing"] }

--- a/monarch_conda/Cargo.toml
+++ b/monarch_conda/Cargo.toml
@@ -29,7 +29,7 @@ rattler_conda_types = "0.28.3"
 serde = { version = "1.0.219", features = ["derive", "rc"] }
 serde_json = { version = "1.0.140", features = ["alloc", "float_roundtrip", "raw_value", "unbounded_depth"] }
 sha2 = "0.10.6"
-tokio = { version = "1.47.1", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.48.0", features = ["full", "test-util", "tracing"] }
 tokio-util = { version = "0.7.15", features = ["full"] }
 walkdir = "2.3"
 

--- a/monarch_distributed_telemetry/Cargo.toml
+++ b/monarch_distributed_telemetry/Cargo.toml
@@ -21,6 +21,6 @@ record_batch_derive = { version = "0.0.0", path = "../record_batch_derive" }
 serde = { version = "1.0.219", features = ["derive", "rc"] }
 serde_json = { version = "1.0.140", features = ["alloc", "float_roundtrip", "raw_value", "unbounded_depth"] }
 serde_multipart = { version = "0.0.0", path = "../serde_multipart" }
-tokio = { version = "1.47.1", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.48.0", features = ["full", "test-util", "tracing"] }
 tracing = { version = "0.1.41", features = ["attributes", "valuable"] }
 typeuri = { version = "0.0.0", path = "../typeuri" }

--- a/monarch_extension/Cargo.toml
+++ b/monarch_extension/Cargo.toml
@@ -33,7 +33,7 @@ ndslice = { version = "0.0.0", path = "../ndslice" }
 pyo3 = { version = "0.26", features = ["anyhow", "multiple-pymethods", "py-clone"] }
 rdmaxcel-sys = { path = "../rdmaxcel-sys", optional = true }
 serde = { version = "1.0.219", features = ["derive", "rc"] }
-tokio = { version = "1.47.1", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.48.0", features = ["full", "test-util", "tracing"] }
 torch-sys-cuda = { path = "../torch-sys-cuda", optional = true }
 wirevalue = { version = "0.0.0", path = "../wirevalue" }
 

--- a/monarch_hyperactor/Cargo.toml
+++ b/monarch_hyperactor/Cargo.toml
@@ -46,7 +46,7 @@ pyo3-async-runtimes = { version = "0.26", features = ["attributes", "tokio-runti
 serde = { version = "1.0.219", features = ["derive", "rc"] }
 serde_multipart = { version = "0.0.0", path = "../serde_multipart" }
 tempfile = "3.22"
-tokio = { version = "1.47.1", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.48.0", features = ["full", "test-util", "tracing"] }
 tracing = { version = "0.1.41", features = ["attributes", "valuable"] }
 typeuri = { version = "0.0.0", path = "../typeuri" }
 wirevalue = { version = "0.0.0", path = "../wirevalue" }

--- a/monarch_rdma/Cargo.toml
+++ b/monarch_rdma/Cargo.toml
@@ -25,7 +25,7 @@ wirevalue = { version = "0.0.0", path = "../wirevalue" }
 hyperactor_mesh = { version = "0.0.0", path = "../hyperactor_mesh" }
 ndslice = { version = "0.0.0", path = "../ndslice" }
 timed_test = { version = "0.0.0", path = "../timed_test" }
-tokio = { version = "1.47.1", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.48.0", features = ["full", "test-util", "tracing"] }
 
 [features]
 cuda = []

--- a/monarch_rdma/examples/cuda_ping_pong/Cargo.toml
+++ b/monarch_rdma/examples/cuda_ping_pong/Cargo.toml
@@ -33,7 +33,7 @@ hyperactor_mesh = { version = "0.0.0", path = "../../../hyperactor_mesh" }
 monarch_rdma = { version = "0.0.0", path = "../.." }
 ndslice = { version = "0.0.0", path = "../../../ndslice" }
 serde = { version = "1.0.219", features = ["derive", "rc"] }
-tokio = { version = "1.47.1", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.48.0", features = ["full", "test-util", "tracing"] }
 tracing = { version = "0.1.41", features = ["attributes", "valuable"] }
 tracing-subscriber = { version = "0.3.20", features = ["chrono", "env-filter", "json", "local-time", "parking_lot", "registry"] }
 typeuri = { version = "0.0.0", path = "../../../typeuri" }

--- a/monarch_rdma/examples/parameter_server/Cargo.toml
+++ b/monarch_rdma/examples/parameter_server/Cargo.toml
@@ -30,7 +30,7 @@ hyperactor_mesh = { version = "0.0.0", path = "../../../hyperactor_mesh" }
 monarch_rdma = { version = "0.0.0", path = "../.." }
 ndslice = { version = "0.0.0", path = "../../../ndslice" }
 serde = { version = "1.0.219", features = ["derive", "rc"] }
-tokio = { version = "1.47.1", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.48.0", features = ["full", "test-util", "tracing"] }
 tracing = { version = "0.1.41", features = ["attributes", "valuable"] }
 tracing-subscriber = { version = "0.3.20", features = ["chrono", "env-filter", "json", "local-time", "parking_lot", "registry"] }
 typeuri = { version = "0.0.0", path = "../../../typeuri" }

--- a/monarch_tensor_worker/Cargo.toml
+++ b/monarch_tensor_worker/Cargo.toml
@@ -24,7 +24,7 @@ parking_lot = { version = "0.12.1", features = ["send_guard"] }
 pyo3 = { version = "0.26", features = ["anyhow", "multiple-pymethods", "py-clone"] }
 serde = { version = "1.0.219", features = ["derive", "rc"] }
 sorted-vec = "0.8.10"
-tokio = { version = "1.47.1", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.48.0", features = ["full", "test-util", "tracing"] }
 torch-sys-cuda = { version = "0.0.0", path = "../torch-sys-cuda" }
 torch-sys2 = { version = "0.0.0", path = "../torch-sys2" }
 tracing = { version = "0.1.41", features = ["attributes", "valuable"] }

--- a/monarch_types/Cargo.toml
+++ b/monarch_types/Cargo.toml
@@ -17,7 +17,7 @@ typeuri = { version = "0.0.0", path = "../typeuri" }
 [dev-dependencies]
 anyhow = "1.0.98"
 timed_test = { version = "0.0.0", path = "../timed_test" }
-tokio = { version = "1.47.1", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.48.0", features = ["full", "test-util", "tracing"] }
 
 [build-dependencies]
 build_utils = { path = "../build_utils" }

--- a/preempt_rwlock/Cargo.toml
+++ b/preempt_rwlock/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2024"
 license = "BSD-3-Clause"
 
 [dependencies]
-tokio = { version = "1.47.1", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.48.0", features = ["full", "test-util", "tracing"] }
 
 [dev-dependencies]
 anyhow = "1.0.98"

--- a/struct_diff_patch/Cargo.toml
+++ b/struct_diff_patch/Cargo.toml
@@ -13,4 +13,4 @@ license = "BSD-3-Clause"
 paste = "1.0.14"
 struct_diff_patch_macros = { version = "0.0.0", path = "../struct_diff_patch_macros" }
 thiserror = "2.0.18"
-tokio = { version = "1.47.1", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.48.0", features = ["full", "test-util", "tracing"] }

--- a/timed_test/Cargo.toml
+++ b/timed_test/Cargo.toml
@@ -21,4 +21,4 @@ quote = "1.0.44"
 syn = { version = "2.0.110", features = ["extra-traits", "fold", "full", "visit", "visit-mut"] }
 
 [dev-dependencies]
-tokio = { version = "1.47.1", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.48.0", features = ["full", "test-util", "tracing"] }


### PR DESCRIPTION
Summary:
Upgrading `tokio` from `1.47.1` to `1.48.0` (resolves to `1.49.0`).

Notable changes in 1.48.0:
- Added `File::max_buf_size`, `TcpStream::quickack`, `LocalKey::try_get`
- MSRV bumped to 1.71
- Deprecated `{TcpStream,TcpSocket}::set_linger` (no fbcode usage found)

Notable changes in 1.49.0:
- Stabilized `runtime::id::Id`
- Implemented `Extend` for `JoinSet`
- Fixed hygiene issue in `join!` and `try_join!`

No breaking API changes. Downstream spot-checks pass.

Differential Revision: D93281176


