### PR TITLE
Add who_am_i_ip fallback to TlsMode::IpV6 address resolution

### DIFF
--- a/hyperactor/src/channel.rs
+++ b/hyperactor/src/channel.rs
@@ -688,21 +688,40 @@ impl ChannelAddr {
                         .unwrap_or("unknown_host".to_string()),
                     TlsMode::IpV6 => match net::meta::tw_task_ip() {
                         net::meta::TwTaskIp::Ip(v6) => v6.to_string(),
-                        net::meta::TwTaskIp::NotTwTask => {
-                            tracing::debug!(
-                                "this host is not a TW task, falling back to local_ipv6"
-                            );
-                            local_ipv6()
-                                .ok()
-                                .and_then(|addr| addr.to_string().parse().ok())
-                                .expect("failed to retrieve ipv6 address")
-                        }
-                        net::meta::TwTaskIp::Error(msg) => {
-                            tracing::error!("{}, falling back to local_ipv6", msg);
-                            local_ipv6()
-                                .ok()
-                                .and_then(|addr| addr.to_string().parse().ok())
-                                .expect("failed to retrieve ipv6 address")
+                        other => {
+                            match &other {
+                                net::meta::TwTaskIp::NotTwTask => {
+                                    tracing::debug!(
+                                        "this host is not a TW task, falling back to who_am_i_ip"
+                                    );
+                                }
+                                net::meta::TwTaskIp::Error(msg) => {
+                                    tracing::error!("{}, falling back to who_am_i_ip", msg);
+                                }
+                                net::meta::TwTaskIp::Ip(_) => unreachable!(),
+                            }
+                            match net::meta::who_am_i_ip() {
+                                net::meta::WhoAmIIp::Ip(v6) => v6.to_string(),
+                                net::meta::WhoAmIIp::NotFound => {
+                                    tracing::warn!(
+                                        "who_am_i_ip: fbwhoami not found, falling back to local_ipv6"
+                                    );
+                                    local_ipv6()
+                                        .ok()
+                                        .and_then(|addr| addr.to_string().parse().ok())
+                                        .expect("failed to retrieve ipv6 address")
+                                }
+                                net::meta::WhoAmIIp::Error(msg) => {
+                                    tracing::warn!(
+                                        "who_am_i_ip returned error: {}, falling back to local_ipv6",
+                                        msg
+                                    );
+                                    local_ipv6()
+                                        .ok()
+                                        .and_then(|addr| addr.to_string().parse().ok())
+                                        .expect("failed to retrieve ipv6 address")
+                                }
+                            }
                         }
                     },
                 };


### PR DESCRIPTION
Summary:
This is a follow-up of D93236404. For dev machines, we want to get IP address from WhoAmI, since that is the IP address in cert. So we end up with a 3-tier fallback:

1. TW metadata;
2. WhoAmI;
3. localhost.

This seems to be an established pattern inside the company:

https://www.internalfb.com/code/fbsource/[307d7558881dc707f93f917cd14cd64cc5558b64]/fbcode/libfb/py/tw/local_task.py?lines=62-72

Differential Revision: D93288330


