### PR TITLE
Add mixins support to PatchRustClass

### DIFF
--- a/monarch_extension/src/lib.rs
+++ b/monarch_extension/src/lib.rs
@@ -201,6 +201,10 @@ pub fn mod_init(module: &Bound<'_, PyModule>) -> PyResult<()> {
         module,
         "monarch_hyperactor.telemetry",
     )?)?;
+    monarch_hyperactor::testing::register_python_bindings(&get_or_add_new_module(
+        module,
+        "monarch_hyperactor.testing",
+    )?)?;
     code_sync::register_python_bindings(&get_or_add_new_module(
         module,
         "monarch_extension.code_sync",

--- a/monarch_hyperactor/src/lib.rs
+++ b/monarch_hyperactor/src/lib.rs
@@ -39,6 +39,7 @@ pub mod selection;
 pub mod shape;
 pub mod supervision;
 pub mod telemetry;
+pub mod testing;
 mod testresource;
 pub mod value_mesh;
 

--- a/monarch_hyperactor/src/testing.rs
+++ b/monarch_hyperactor/src/testing.rs
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+//! Minimal PyO3 struct for testing `@rust_struct` mixin patching.
+//!
+//! The `#[pyclass]` module is set to the Python file that defines
+//! the `@rust_struct`-decorated class so the name-validation check passes.
+
+use pyo3::prelude::*;
+
+#[pyclass(name = "TestStruct", module = "monarch._src.actor.testing")]
+pub struct PyTestStruct {
+    value: i64,
+}
+
+#[pymethods]
+impl PyTestStruct {
+    #[new]
+    fn new(value: i64) -> Self {
+        Self { value }
+    }
+
+    fn rust_method(&self) -> i64 {
+        self.value
+    }
+
+    fn shared_method(&self) -> String {
+        "from_rust".to_string()
+    }
+}
+
+#[pyfunction]
+fn _make_test_struct(value: i64) -> PyTestStruct {
+    PyTestStruct { value }
+}
+
+pub fn register_python_bindings(module: &Bound<'_, PyModule>) -> PyResult<()> {
+    module.add_class::<PyTestStruct>()?;
+    module.add_function(wrap_pyfunction!(_make_test_struct, module)?)?;
+    Ok(())
+}

--- a/python/monarch/_rust_bindings/monarch_hyperactor/testing.pyi
+++ b/python/monarch/_rust_bindings/monarch_hyperactor/testing.pyi
@@ -1,0 +1,19 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from typing import Any, final
+
+@final
+class TestStruct:
+    """Minimal Rust struct for testing @rust_struct mixin patching."""
+
+    def __init__(self, value: int) -> None: ...
+    def rust_method(self) -> int: ...
+    def shared_method(self) -> str: ...
+
+def _make_test_struct(value: int) -> Any: ...

--- a/python/monarch/_src/actor/python_extension_methods.py
+++ b/python/monarch/_src/actor/python_extension_methods.py
@@ -6,11 +6,14 @@
 
 # pyre-strict
 
+import abc
 import importlib
-from typing import cast, Type, TypeVar
+from typing import cast, Generic, Type, TypeVar
 
 
 T = TypeVar("T")
+
+_SKIP_BASES: frozenset[Type[object]] = frozenset({object, abc.ABC, Generic})
 
 
 class PatchRustClass:
@@ -23,21 +26,40 @@ class PatchRustClass:
         if rust_name != python_name:
             raise ValueError(f"mismatched type names {rust_name} != {python_name}")
         for name, implementation in python_class.__dict__.items():
-            if hasattr(self.rust_class, name):
-                the_attr = getattr(self.rust_class, name)
-                is_object_default = name.startswith("__") and getattr(
-                    the_attr, "__qualname__", ""
-                ).startswith("object.")
-                if not is_object_default:
-                    # do not patch in the stub methods that
-                    # are already defined by the rust implementation
-                    continue
-            if not callable(implementation) and not isinstance(
-                implementation, property
-            ):
+            if self._should_patch(name, implementation):
+                setattr(self.rust_class, name, implementation)
+
+        # Patch in methods from mixins. We enforce that mixins must be ABC
+        for base in python_class.__bases__:
+            if base in _SKIP_BASES:
                 continue
-            setattr(self.rust_class, name, implementation)
+            if not isinstance(base, abc.ABCMeta):
+                raise TypeError(
+                    f"Mixin {base.__name__} must inherit from ABC to be used "
+                    f"with @rust_struct (isinstance() checks won't work otherwise)."
+                )
+            for name, implementation in base.__dict__.items():
+                if self._should_patch(name, implementation):
+                    setattr(self.rust_class, name, implementation)
+            base.register(self.rust_class)
+
         return cast(Type[T], self.rust_class)
+
+    def _should_patch(self, name: str, implementation: object) -> bool:
+        if getattr(implementation, "__isabstractmethod__", False):
+            return False
+        if hasattr(self.rust_class, name):
+            the_attr = getattr(self.rust_class, name)
+            is_object_default = name.startswith("__") and getattr(
+                the_attr, "__qualname__", ""
+            ).startswith("object.")
+            if not is_object_default:
+                # do not patch in the stub methods that
+                # are already defined by the rust implementation
+                return False
+        if not callable(implementation) and not isinstance(implementation, property):
+            return False
+        return True
 
 
 def rust_struct(name: str) -> PatchRustClass:
@@ -85,6 +107,25 @@ def rust_struct(name: str) -> PatchRustClass:
     It is ok to have the pyclass module not match where it is defined because (1) we patch it into the right place
     to make sure pickling works, and (2) the rust_struct annotation points directly to where to find the rust code,
     and will be discovered by goto line in the IDE.
+
+    Mixins via inheritance:
+        Base classes listed in the Python class definition are automatically
+        treated as mixins.  Their concrete (non-abstract) methods and properties
+        are patched onto the Rust class after the Python class body is applied.
+        ABC bases are also registered so that ``isinstance()`` checks work.
+
+        This is useful when a Rust struct should implement a Python
+        trait/interface (e.g. MeshTrait) whose concrete methods depend on a
+        small abstract interface that the ``@rust_struct`` class provides::
+
+            @rust_struct("monarch_hyperactor::value_mesh::ValueMesh")
+            class ValueMesh(MeshTrait):
+                # provide the abstract interface MeshTrait needs
+                @property
+                def _ndslice(self) -> NDSlice: ...
+                @property
+                def _labels(self) -> ...: ...
+                def _new_with_shape(self, shape): ...
     """
 
     *modules, name = name.split("::")

--- a/python/monarch/_src/actor/testing.py
+++ b/python/monarch/_src/actor/testing.py
@@ -1,0 +1,77 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+"""
+Test-only @rust_struct class with mixin inheritance.
+
+Mirrors the real pattern (e.g. ValueMesh + MeshTrait) using a minimal
+Rust PyO3 TestStruct to verify mixin patching behavior.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+from monarch._src.actor.python_extension_methods import rust_struct
+
+
+class TraitMixin(ABC):
+    """ABC mixin with abstract + concrete methods, like MeshTrait."""
+
+    @abstractmethod
+    def abstract_method(self) -> str: ...
+
+    def concrete_from_trait(self) -> str:
+        return "from_trait"
+
+    def overlap(self) -> str:
+        return "from_trait"
+
+    @property
+    def trait_prop(self) -> int:
+        return 67
+
+
+class PlainMixin(ABC):
+    """Non-abstract ABC mixin — isinstance() works via register()."""
+
+    @abstractmethod
+    def abstract_for_lint(self) -> None:
+        """Abstract method to satisfy B024 lint (ABC must have abstract methods)."""
+        ...
+
+    def plain_method(self) -> str:
+        return "from_plain"
+
+    def overlap(self) -> str:
+        return "from_plain"
+
+
+@rust_struct("monarch_hyperactor::testing::TestStruct")
+class TestStruct(TraitMixin, PlainMixin):
+    """Rust struct with mixin inheritance, exactly like real usage."""
+
+    def __init__(self, value: int) -> None: ...
+
+    # Stubs for Rust-implemented methods (type-checker only):
+    # fn rust_method(&self) -> i64 { self.value }
+    def rust_method(self) -> int: ...
+    # fn shared_method(&self) -> String { "from_rust".to_string() }
+    def shared_method(self) -> str: ...
+
+    # Concrete implementation of TraitMixin's abstract method:
+    def abstract_method(self) -> str:
+        return f"implemented_{self.rust_method()}"
+
+    # Python-only method that calls into Rust:
+    def python_only(self) -> str:
+        return f"python_{self.rust_method()}"
+
+    # Implement PlainMixin's abstract method (required for ABC):
+    def abstract_for_lint(self) -> None:
+        pass

--- a/python/tests/test_rust_struct_mixins.py
+++ b/python/tests/test_rust_struct_mixins.py
@@ -1,0 +1,133 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+"""
+Tests for the base-class mixin feature of @rust_struct.
+
+Uses a dedicated Rust PyO3 TestStruct with ABC mixins to verify that
+concrete methods from base classes are patched onto the Rust class,
+abstract methods are skipped, and isinstance() checks work — just as
+they do for real @rust_struct usage like ValueMesh(MeshTrait).
+"""
+
+from __future__ import annotations
+
+import pytest
+from monarch._rust_bindings.monarch_hyperactor.testing import _make_test_struct
+from monarch._src.actor.python_extension_methods import PatchRustClass
+from monarch._src.actor.testing import PlainMixin, TestStruct, TraitMixin
+
+
+class TestShouldPatch:
+    """Unit tests for PatchRustClass._should_patch."""
+
+    def test_new_method_should_patch(self) -> None:
+        class Target:
+            pass
+
+        patcher = PatchRustClass(Target)
+        assert patcher._should_patch("foo", lambda self: None)
+
+    def test_existing_method_should_not_patch(self) -> None:
+        class Target:
+            def foo(self) -> None:
+                pass
+
+        patcher = PatchRustClass(Target)
+        assert not patcher._should_patch("foo", lambda self: None)
+
+    def test_object_default_dunder_should_patch(self) -> None:
+        class Target:
+            pass
+
+        patcher = PatchRustClass(Target)
+        # __repr__ comes from object, so it should be overridable
+        assert patcher._should_patch("__repr__", lambda self: "hi")
+
+    def test_non_callable_should_not_patch(self) -> None:
+        class Target:
+            pass
+
+        patcher = PatchRustClass(Target)
+        assert not patcher._should_patch("x", 67)
+
+    def test_property_should_patch(self) -> None:
+        class Target:
+            pass
+
+        patcher = PatchRustClass(Target)
+        assert patcher._should_patch("x", property(lambda self: 1))
+
+
+class TestMixinPatching:
+    """Tests for mixin patching using @rust_struct with a real Rust struct.
+
+    TestStruct is a Rust #[pyclass] decorated with @rust_struct and
+    inheriting from TraitMixin (ABC) and PlainMixin (ABC).
+    _make_test_struct creates instances entirely from Rust.
+    """
+
+    def test_concrete_mixin_methods_are_patched(self) -> None:
+        """Concrete methods from ABC mixin are available on Rust objects."""
+        obj = _make_test_struct(67)
+        assert obj.concrete_from_trait() == "from_trait"
+
+    def test_abstract_mixin_methods_are_skipped(self) -> None:
+        """Abstract methods from mixin are not patched as stubs."""
+        obj = _make_test_struct(67)
+        # abstract_method is abstract on TraitMixin but concrete in TestStruct body
+        assert obj.abstract_method() == "implemented_67"
+
+    def test_rust_methods_not_overridden_by_mixins(self) -> None:
+        """Rust-implemented methods survive mixin patching."""
+        obj = _make_test_struct(67)
+        assert obj.rust_method() == 67
+        assert obj.shared_method() == "from_rust"
+
+    def test_python_only_method_patched(self) -> None:
+        """Python-only methods from the class body are patched onto Rust class."""
+        obj = _make_test_struct(10)
+        assert obj.python_only() == "python_10"
+
+    def test_multiple_mixins_applied_in_order(self) -> None:
+        """Methods from multiple mixins are applied; first mixin wins on overlap."""
+        obj = _make_test_struct(1)
+        assert obj.plain_method() == "from_plain"  # from PlainMixin
+        # overlap is on both TraitMixin and PlainMixin; TraitMixin listed first
+        assert obj.overlap() == "from_trait"
+
+    def test_mixin_property_is_patched(self) -> None:
+        """Properties from mixin are patched onto the Rust class."""
+        obj = _make_test_struct(1)
+        assert obj.trait_prop == 67
+
+    def test_abc_mixin_registers_isinstance(self) -> None:
+        """ABC mixins are registered so isinstance() checks work."""
+        obj = _make_test_struct(1)
+        assert isinstance(obj, TraitMixin)
+        assert isinstance(obj, PlainMixin)
+
+    def test_non_abc_mixin_raises_type_error(self) -> None:
+        """Non-ABC mixins are rejected with a clear error."""
+
+        class NotABC:
+            def method(self) -> str:
+                return "plain"
+
+        RustClass = type("C", (), {"__module__": "test.mod", "__qualname__": "C"})
+        PythonClass = type(
+            "C", (NotABC,), {"__module__": "test.mod", "__qualname__": "C"}
+        )
+        patcher = PatchRustClass(RustClass)
+        with pytest.raises(TypeError, match="must inherit from ABC"):
+            patcher(PythonClass)
+
+    def test_rust_returned_is_same_type(self) -> None:
+        """The Rust-returned object is the exact same type as TestStruct."""
+        obj = _make_test_struct(1)
+        assert type(obj) is TestStruct


### PR DESCRIPTION
Summary:
Add a `mixins` parameter to `PatchRustClass` and `rust_struct` that patches concrete (non-abstract) methods from mixin classes onto the Rust class. This enables Rust PyO3 classes to implement Python trait/interface patterns (e.g. MeshTrait) without reimplementing all concrete methods in Rust or using Python wrapper classes.

The implementation extracts the existing patching logic into a `_should_patch` method and adds a second pass that iterates over mixin classes, skipping abstract methods and respecting the same precedence rules as the Python class body.

Differential Revision: D93371994


