### PR TITLE
Remove edition in record_batch_derive target

### DIFF
--- a/record_batch_derive/Cargo.toml
+++ b/record_batch_derive/Cargo.toml
@@ -11,7 +11,6 @@ license = "BSD-3-Clause"
 test = false
 doctest = false
 proc-macro = true
-edition = "2021"
 
 [dependencies]
 proc-macro2 = { version = "1.0.106", features = ["span-locations"] }


### PR DESCRIPTION
Summary: Resolves the warning "edition is set on library record_batch_derive which is deprecated".

Reviewed By: shayne-fletcher

Differential Revision: D93490482


