### PR TITLE
Handle exit code 0 differently

### DIFF
--- a/hyperactor_mesh/src/mesh_controller.rs
+++ b/hyperactor_mesh/src/mesh_controller.rs
@@ -658,8 +658,14 @@ impl<A: Referable> Handler<CheckState> for ActorMeshController<A> {
                 // make the proc failure the cause. It is a hack to try to determine
                 // the correct status based on process exit status.
                 let actor_status = match state.state.and_then(|s| s.proc_status) {
+                    Some(ProcStatus::Stopped { exit_code: 0, .. }) => {
+                        ActorStatus::Stopped("process exited cleanly".to_string())
+                    }
                     Some(ProcStatus::Stopped { exit_code, .. }) => {
-                        ActorStatus::Stopped(format!("process exited with code {}", exit_code))
+                        ActorStatus::Failed(ActorErrorKind::Generic(format!(
+                            "process exited with non-zero code {}",
+                            exit_code
+                        )))
                     }
                     // Conservatively treat lack of status as stopped
                     None => ActorStatus::Stopped("no status received from process".to_string()),


### PR DESCRIPTION
Summary:
Remove testing::proc_meshes entirely. Each test now calls testing::host_mesh(n) directly and spawns its own ProcMesh with Extent::unity() as the per-host extent.

The proc_meshes function previously created two ProcMesh variants (local in-process and process-based) and returned them in a Vec, requiring callers to index into the result. This indirection is replaced by direct host_mesh + spawn calls at each test site, simplifying ownership (owned ProcMesh instead of borrowed from Vec) and making each test's setup explicit.

All callers in actor_mesh.rs, proc_mesh.rs, and host_mesh.rs are updated. The slice dimension in test_actor_mesh_ref_lazy_materialization is updated from "proc" to "hosts" to match the new extent shape. test_spawn_actor in proc_mesh.rs now uses assert_mesh_shape instead of a loop with assert_casting_correctness.

v1/ callers are out of scope as they use a separate v1::testing::proc_meshes function.

Differential Revision: D93548901


