### PR TITLE
Fix flaky test_actor_init_exception tests

### DIFF
--- a/hyperactor_mesh/src/mesh_controller.rs
+++ b/hyperactor_mesh/src/mesh_controller.rs
@@ -63,7 +63,7 @@ declare_attrs! {
     /// subscribers if there are no failures encountered.
     @meta(CONFIG = ConfigAttr::new(
         Some("HYPERACTOR_MESH_SUPERVISION_POLL_FREQUENCY".to_string()),
-        None,
+        Some("supervision_poll_frequency".to_string()),
     ))
     pub attr SUPERVISION_POLL_FREQUENCY: Duration = Duration::from_secs(10);
 }

--- a/python/monarch/config/__init__.py
+++ b/python/monarch/config/__init__.py
@@ -75,6 +75,7 @@ def configure(
     actor_spawn_max_idle: str | None = None,
     get_actor_state_max_idle: str | None = None,
     supervision_watchdog_timeout: str | None = None,
+    supervision_poll_frequency: str | None = None,
     proc_stop_max_idle: str | None = None,
     get_proc_state_max_idle: str | None = None,
     actor_queue_dispatch: bool | None = None,
@@ -148,6 +149,7 @@ def configure(
             get_actor_state_max_idle: Maximum idle time for actor state queries (humantime).
             supervision_watchdog_timeout: Watchdog timeout for the actor-mesh supervision stream; prolonged
                 silence is interpreted as the controller being unreachable (humantime).
+            supervision_poll_frequency: Interval between supervision polls of actor states (humantime).
 
         Host mesh timeouts:
             proc_stop_max_idle: Maximum idle time while stopping procs (humantime).
@@ -236,6 +238,8 @@ def configure(
         params["get_actor_state_max_idle"] = get_actor_state_max_idle
     if supervision_watchdog_timeout is not None:
         params["supervision_watchdog_timeout"] = supervision_watchdog_timeout
+    if supervision_poll_frequency is not None:
+        params["supervision_poll_frequency"] = supervision_poll_frequency
     if proc_stop_max_idle is not None:
         params["proc_stop_max_idle"] = proc_stop_max_idle
     if get_proc_state_max_idle is not None:


### PR DESCRIPTION
Summary:
Fix two independent bugs causing flakiness in test_actor_init_exception:

1. Thread-safety: The fault_hook callback is invoked from a tokio worker
thread, but asyncio.Event.set() is not thread-safe. Use
loop.call_soon_threadsafe(faulted.set) instead, matching the pattern
already used by test_actor_abort and test_allocator's test_init_failure.
The sync variant uses threading.Event which is already thread-safe.

2. Timeout: Increase from 15s to 60s and reduce supervision_poll_frequency
from the default 10s to 5s via configured(). The old 15s timeout with
10s polling left only ~5s margin, insufficient under CI load.

Differential Revision: D93607089


