### PR TITLE
Add actor_status_events telemetry table

### DIFF
--- a/examples/distributed_telemetry_real_data.py
+++ b/examples/distributed_telemetry_real_data.py
@@ -253,6 +253,30 @@ def main() -> None:
                FROM actor_meshes
                ORDER BY given_name""",
         ),
+        # Actor status events schema
+        (
+            "Schema of 'actor_status_events' table",
+            """SELECT column_name, data_type, is_nullable
+               FROM information_schema.columns
+               WHERE table_name = 'actor_status_events'
+               ORDER BY ordinal_position""",
+        ),
+        # Actor status events by status
+        (
+            "Actor status transitions",
+            """SELECT new_status, COUNT(*) as count
+               FROM actor_status_events
+               GROUP BY new_status
+               ORDER BY count DESC""",
+        ),
+        # Actor status events joined with actors
+        (
+            "Actor status timeline",
+            """SELECT a.full_name, s.new_status, s.prev_status, s.reason
+               FROM actor_status_events s
+               JOIN actors a ON s.actor_id = a.full_name
+               ORDER BY s.timestamp_us""",
+        ),
     ]
 
     for title, sql in queries:

--- a/hyperactor/src/proc.rs
+++ b/hyperactor/src/proc.rs
@@ -39,7 +39,9 @@ use dashmap::mapref::multiple::RefMulti;
 use futures::FutureExt;
 use hyperactor_config::Flattrs;
 use hyperactor_telemetry::ActorEvent;
+use hyperactor_telemetry::ActorStatusEvent;
 use hyperactor_telemetry::notify_actor_created;
+use hyperactor_telemetry::notify_actor_status_changed;
 use hyperactor_telemetry::recorder::Recording;
 use tokio::sync::mpsc;
 use tokio::sync::watch;
@@ -1035,6 +1037,17 @@ impl<A: Actor> Instance<A> {
                 caller = %Location::caller(),
                 change_reason,
             );
+            notify_actor_status_changed(ActorStatusEvent {
+                actor_id: self.self_id().to_string(),
+                timestamp: RealClock.system_time_now(),
+                new_status: new_status.to_string(),
+                prev_status: old.arm().unwrap_or("Unknown").to_string(),
+                reason: if change_reason.is_empty() {
+                    None
+                } else {
+                    Some(change_reason)
+                },
+            });
         }
     }
 


### PR DESCRIPTION
Summary:
Add a new `actor_status_events` table to the distributed telemetry system that tracks actor lifecycle state transitions (Created, Initializing, Idle, Processing, Stopping, Stopped, Failed, etc.).

This follows the existing Actor/ActorMesh entity dispatch pattern:
- `hyperactor_telemetry`: Add `ActorStatusEvent` struct, `EntityEvent::ActorStatus` variant, and `notify_actor_status_changed()` function
- `entity_dispatcher.rs`: Add `ActorStatusRow` RecordBatchRow struct with buffer, flush, and dispatch logic
- `proc.rs`: Emit `notify_actor_status_changed()` in `Instance::change_status()`, reusing the existing filter that skips noisy Idle<->Processing transitions
- Python test verifying schema columns, event count, and valid status values
- Example SQL queries for schema inspection, status aggregation, and join with actors table

Reviewed By: thedavekwon

Differential Revision: D93276820


