### PR TITLE
Take `event` by value for EntityEventDispatcher::dispatch

### DIFF
--- a/hyperactor_telemetry/src/lib.rs
+++ b/hyperactor_telemetry/src/lib.rs
@@ -314,7 +314,7 @@ pub struct ActorEvent {
 pub fn notify_actor_created(event: ActorEvent) {
     if let Ok(dispatcher) = ENTITY_EVENT_DISPATCHER.lock() {
         if let Some(ref d) = *dispatcher {
-            if let Err(e) = d.dispatch(&EntityEvent::Actor(event)) {
+            if let Err(e) = d.dispatch(EntityEvent::Actor(event)) {
                 tracing::error!("Failed to dispatch actor event: {:?}", e);
             }
         }
@@ -348,7 +348,7 @@ pub struct ActorMeshEvent {
 pub fn notify_actor_mesh_created(event: ActorMeshEvent) {
     if let Ok(dispatcher) = ENTITY_EVENT_DISPATCHER.lock() {
         if let Some(ref d) = *dispatcher {
-            if let Err(e) = d.dispatch(&EntityEvent::ActorMesh(event)) {
+            if let Err(e) = d.dispatch(EntityEvent::ActorMesh(event)) {
                 tracing::error!("Failed to dispatch actor mesh event: {}", e);
             }
         }
@@ -376,7 +376,7 @@ pub struct ActorStatusEvent {
 pub fn notify_actor_status_changed(event: ActorStatusEvent) {
     if let Ok(dispatcher) = ENTITY_EVENT_DISPATCHER.lock() {
         if let Some(ref d) = *dispatcher {
-            if let Err(e) = d.dispatch(&EntityEvent::ActorStatus(event)) {
+            if let Err(e) = d.dispatch(EntityEvent::ActorStatus(event)) {
                 tracing::error!("Failed to dispatch actor status event: {:?}", e);
             }
         }
@@ -419,7 +419,7 @@ pub enum EntityEvent {
 ///
 /// struct MyEntityDispatcher;
 /// impl EntityEventDispatcher for MyEntityDispatcher {
-///     fn dispatch(&self, event: &EntityEvent) -> Result<(), anyhow::Error> {
+///     fn dispatch(&self, event: EntityEvent) -> Result<(), anyhow::Error> {
 ///         match event {
 ///             EntityEvent::Actor(actor) => println!("Actor: {}", actor.full_name),
 ///             EntityEvent::ActorMesh(mesh) => println!("Mesh: {}", mesh.full_name),
@@ -433,7 +433,7 @@ pub enum EntityEvent {
 /// ```
 pub trait EntityEventDispatcher: Send + Sync {
     /// Dispatch an entity event to the appropriate handler.
-    fn dispatch(&self, event: &EntityEvent) -> Result<(), anyhow::Error>;
+    fn dispatch(&self, event: EntityEvent) -> Result<(), anyhow::Error>;
 }
 
 /// Set the dispatcher to receive all entity events.

--- a/monarch_distributed_telemetry/src/entity_dispatcher.rs
+++ b/monarch_distributed_telemetry/src/entity_dispatcher.rs
@@ -190,7 +190,7 @@ impl EntityDispatcher {
 }
 
 impl EntityEventDispatcher for EntityDispatcher {
-    fn dispatch(&self, event: &EntityEvent) -> Result<(), anyhow::Error> {
+    fn dispatch(&self, event: EntityEvent) -> Result<(), anyhow::Error> {
         match event {
             EntityEvent::Actor(actor_event) => {
                 let mut inner = self
@@ -202,7 +202,7 @@ impl EntityEventDispatcher for EntityDispatcher {
                     timestamp_us: timestamp_to_micros(&actor_event.timestamp),
                     mesh_id: actor_event.mesh_id,
                     rank: actor_event.rank,
-                    full_name: actor_event.full_name.clone(),
+                    full_name: actor_event.full_name,
                 });
                 inner.flush_actors_if_full()?;
             }
@@ -214,12 +214,12 @@ impl EntityEventDispatcher for EntityDispatcher {
                 inner.actor_meshes_buffer.insert(ActorMesh {
                     id: mesh_event.id,
                     timestamp_us: timestamp_to_micros(&mesh_event.timestamp),
-                    class: mesh_event.class.clone(),
-                    given_name: mesh_event.given_name.clone(),
-                    full_name: mesh_event.full_name.clone(),
-                    shape_json: mesh_event.shape_json.clone(),
+                    class: mesh_event.class,
+                    given_name: mesh_event.given_name,
+                    full_name: mesh_event.full_name,
+                    shape_json: mesh_event.shape_json,
                     parent_mesh_id: mesh_event.parent_mesh_id,
-                    parent_view_json: mesh_event.parent_view_json.clone(),
+                    parent_view_json: mesh_event.parent_view_json,
                 });
                 inner.flush_actor_meshes_if_full()?;
             }
@@ -230,10 +230,10 @@ impl EntityEventDispatcher for EntityDispatcher {
                     .map_err(|_| anyhow::anyhow!("lock poisoned"))?;
                 inner.actor_status_events_buffer.insert(ActorStatusEvent {
                     timestamp_us: timestamp_to_micros(&status_event.timestamp),
-                    actor_id: status_event.actor_id.clone(),
-                    new_status: status_event.new_status.clone(),
-                    prev_status: status_event.prev_status.clone(),
-                    reason: status_event.reason.clone(),
+                    actor_id: status_event.actor_id,
+                    new_status: status_event.new_status,
+                    prev_status: status_event.prev_status,
+                    reason: status_event.reason,
                 });
                 inner.flush_actor_status_events_if_full()?;
             }


### PR DESCRIPTION
Summary: `event`s are discarded after being used. We can take ownership and move the inner data instead of cloning.

Reviewed By: zhangrmatthew

Differential Revision: D93632153
