### PR TITLE
migrate some tests from allocator-bootstrap to simple bootstrap

### DIFF
--- a/hyperactor_mesh/src/actor_mesh.rs
+++ b/hyperactor_mesh/src/actor_mesh.rs
@@ -126,12 +126,6 @@ impl<A: Referable> ActorMesh<A> {
         &self.name
     }
 
-    /// Detach this mesh from the lifetime of `self`, and return its reference.
-    #[allow(dead_code)]
-    pub(crate) fn detach(self) -> ActorMeshRef<A> {
-        self.current_ref.clone()
-    }
-
     pub(crate) fn set_controller(&mut self, controller: Option<ActorRef<ActorMeshController<A>>>) {
         self.controller = controller.clone();
         self.current_ref.set_controller(controller);
@@ -939,12 +933,8 @@ mod tests {
         let instance = testing::instance();
         // Small mesh so the test runs fast, but > page_size so we
         // cross a boundary
-        let extent = extent!(replicas = 3, hosts = 2); // 6 ranks
-        let pm: ProcMesh = testing::proc_meshes(instance, extent.clone())
-            .await
-            .into_iter()
-            .next()
-            .expect("at least one proc mesh");
+        let mut hm = testing::host_mesh(3).await;
+        let pm: ProcMesh = hm.spawn(instance, "test", extent!(gpus = 2)).await.unwrap();
         let am: ActorMesh<testactor::TestActor> = pm.spawn(instance, "test", &()).await.unwrap();
 
         // 2) Build our ActorMeshRef with a tiny page size (2) to
@@ -953,7 +943,7 @@ mod tests {
         let page_size = 2;
         let amr: ActorMeshRef<testactor::TestActor> =
             ActorMeshRef::with_page_size(am.name.clone(), pm.clone(), page_size, None);
-        assert_eq!(amr.extent(), extent);
+        assert_eq!(amr.extent(), extent!(hosts = 3, gpus = 2));
         assert_eq!(amr.region().num_ranks(), 6);
 
         // 3) Within-rank pointer stability (OnceLock caches &ActorRef)
@@ -988,7 +978,7 @@ mod tests {
 
         // 7) Slicing preserves page_size and clears cache
         // (RankedSliceable::sliced)
-        let sliced = amr.range("replicas", 1..).expect("slice should be valid"); // leaves 4 ranks
+        let sliced = amr.range("hosts", 1..).expect("slice should be valid"); // leaves 4 ranks
         assert_eq!(sliced.region().num_ranks(), 4);
         // First access materializes a new cache for the sliced view.
         let sp0_a = sliced.get(0).unwrap() as *const _;
@@ -1030,6 +1020,8 @@ mod tests {
             .expect("timed out waiting for second reply")
             .expect("channel closed before second reply");
         assert_ne!(id_a, id_b, "two different ranks responded");
+
+        let _ = hm.shutdown(instance).await;
     }
 
     #[async_timed_test(timeout_secs = 30)]
@@ -1042,8 +1034,8 @@ mod tests {
         let (supervision_port, mut supervision_receiver) = instance.open_port::<MeshFailure>();
         let supervisor = supervision_port.bind();
         let num_replicas = 4;
-        let meshes = testing::proc_meshes(instance, extent!(replicas = num_replicas)).await;
-        let proc_mesh = &meshes[1];
+        let mut hm = testing::host_mesh(num_replicas).await;
+        let proc_mesh = hm.spawn(instance, "test", Extent::unity()).await.unwrap();
         let child_name = Name::new("child").unwrap();
 
         // Need to use a wrapper as there's no way to customize the handler for MeshFailure
@@ -1115,6 +1107,8 @@ mod tests {
                 .unwrap();
             check_failure(failure);
         }
+
+        let _ = hm.shutdown(instance).await;
     }
 
     #[async_timed_test(timeout_secs = 30)]
@@ -1130,10 +1124,13 @@ mod tests {
         let (supervision_port, mut supervision_receiver) = instance.open_port::<MeshFailure>();
         let supervisor = supervision_port.bind();
         let num_replicas = 4;
-        let meshes = testing::proc_meshes(instance, extent!(replicas = num_replicas)).await;
-        let second_meshes = testing::proc_meshes(instance, extent!(replicas = num_replicas)).await;
-        let proc_mesh = &meshes[1];
-        let second_proc_mesh = &second_meshes[1];
+        let mut hm = testing::host_mesh(num_replicas).await;
+        let proc_mesh = hm.spawn(instance, "test", Extent::unity()).await.unwrap();
+        let mut second_hm = testing::host_mesh(num_replicas).await;
+        let second_proc_mesh = second_hm
+            .spawn(instance, "test2", Extent::unity())
+            .await
+            .unwrap();
         let child_name = Name::new("child").unwrap();
 
         // Need to use a wrapper as there's no way to customize the handler for MeshFailure
@@ -1178,12 +1175,11 @@ mod tests {
             .expect("no supervision event found on ref from wrapper actor");
 
         let check_failure = move |failure: MeshFailure| {
-            // TODO: It can't find the real actor id, so it says the agent failed.
             assert_eq!(failure.actor_mesh_name, Some(child_name.to_string()));
-            assert_eq!(failure.event.actor_id.name(), "mesh");
+            assert_eq!(failure.event.actor_id.name(), child_name.to_string());
             if let ActorStatus::Failed(ActorErrorKind::Generic(msg)) = &failure.event.actor_status {
                 assert!(
-                    msg.contains("timeout waiting for message from proc mesh agent"),
+                    msg.contains("process exited with non-zero code 1"),
                     "{}",
                     msg
                 );
@@ -1202,6 +1198,9 @@ mod tests {
                 .unwrap();
             check_failure(failure);
         }
+
+        let _ = second_hm.shutdown(instance).await;
+        let _ = hm.shutdown(instance).await;
     }
 
     #[async_timed_test(timeout_secs = 30)]
@@ -1214,8 +1213,8 @@ mod tests {
         let (supervision_port, mut supervision_receiver) = instance.open_port::<MeshFailure>();
         let supervisor = supervision_port.bind();
         let num_replicas = 4;
-        let meshes = testing::proc_meshes(instance, extent!(replicas = num_replicas)).await;
-        let proc_mesh = &meshes[1];
+        let mut hm = testing::host_mesh(num_replicas).await;
+        let proc_mesh = hm.spawn(instance, "test", Extent::unity()).await.unwrap();
         let child_name = Name::new("child").unwrap();
 
         // Need to use a wrapper as there's no way to customize the handler for MeshFailure
@@ -1229,7 +1228,7 @@ mod tests {
             .await
             .unwrap();
         let sliced = actor_mesh
-            .range("replicas", 1..3)
+            .range("hosts", 1..3)
             .expect("slice should be valid");
         let sliced_replicas = sliced.len();
 
@@ -1259,6 +1258,8 @@ mod tests {
                 panic!("actor status is not failed: {}", event.actor_status);
             }
         }
+
+        let _ = hm.shutdown(instance).await;
     }
 
     #[async_timed_test(timeout_secs = 30)]
@@ -1268,7 +1269,7 @@ mod tests {
         let _guard = config.override_key(crate::bootstrap::MESH_BOOTSTRAP_ENABLE_PDEATHSIG, false);
 
         let instance = testing::instance();
-        let host_mesh = testing::host_mesh(4).await;
+        let mut host_mesh = testing::host_mesh(4).await;
         let proc_mesh = host_mesh
             .spawn(instance, "test", Extent::unity())
             .await
@@ -1298,7 +1299,7 @@ mod tests {
             assert_eq!(&sender_actor_id, instance.self_id());
         }
 
-        drop(host_mesh);
+        let _ = host_mesh.shutdown(instance).await;
     }
 
     /// Test that undeliverable messages are properly returned to the
@@ -1306,7 +1307,7 @@ mod tests {
     ///
     /// This is the V1 version of the test from
     /// hyperactor_multiprocess/src/proc_actor.rs::test_undeliverable_message_return.
-    #[async_timed_test(timeout_secs = 30)]
+    #[async_timed_test(timeout_secs = 60)]
     #[cfg(fbcode_build)]
     async fn test_undeliverable_message_return() {
         use hyperactor::mailbox::MessageEnvelope;
@@ -1316,27 +1317,20 @@ mod tests {
 
         hyperactor_telemetry::initialize_logging_for_test();
 
-        // Set message delivery timeout for faster test
-        let config = hyperactor_config::global::lock();
-        let _guard = config.override_key(
-            hyperactor::config::MESSAGE_DELIVERY_TIMEOUT,
-            std::time::Duration::from_secs(1),
-        );
-
         let instance = testing::instance();
 
-        // Create a proc mesh with 2 replicas.
-        let meshes = testing::proc_meshes(instance, extent!(replicas = 2)).await;
-        let proc_mesh = &meshes[1]; // Use the ProcessAllocator version
+        // Create a proc mesh with 2 hosts.
+        let mut hm = testing::host_mesh(2).await;
+        let proc_mesh = hm.spawn(instance, "test", Extent::unity()).await.unwrap();
 
         // Set up undeliverable message port for collecting undeliverables
         let (undeliverable_port, mut undeliverable_rx) =
             instance.open_port::<Undeliverable<MessageEnvelope>>();
 
-        // Spawn actors individually on each replica by spawning separate actor meshes
+        // Spawn actors individually on each host by spawning separate actor meshes
         // with specific proc selections.
-        let ping_proc_mesh = proc_mesh.range("replicas", 0..1).unwrap();
-        let pong_proc_mesh = proc_mesh.range("replicas", 1..2).unwrap();
+        let ping_proc_mesh = proc_mesh.range("hosts", 0..1).unwrap();
+        let pong_proc_mesh = proc_mesh.range("hosts", 1..2).unwrap();
 
         let ping_mesh: ActorMesh<PingPongActor> = ping_proc_mesh
             .spawn(
@@ -1378,6 +1372,13 @@ mod tests {
         // Give it a moment to fully stop
         RealClock.sleep(std::time::Duration::from_millis(200)).await;
 
+        // Set message delivery timeout for faster test
+        let config = hyperactor_config::global::lock();
+        let _guard = config.override_key(
+            hyperactor::config::MESSAGE_DELIVERY_TIMEOUT,
+            std::time::Duration::from_secs(5),
+        );
+
         // Send multiple messages that will all fail to be delivered
         let n = 100usize;
         for i in 1..=n {
@@ -1415,6 +1416,8 @@ mod tests {
             "Expected {} undeliverable messages, got {}",
             n, count
         );
+
+        let _ = hm.shutdown(instance).await;
     }
 
     /// Test that actors not responding within stop timeout are
@@ -1439,9 +1442,9 @@ mod tests {
 
         let instance = testing::instance();
 
-        // Create proc mesh with 2 replicas
-        let meshes = testing::proc_meshes(instance, extent!(replicas = 2)).await;
-        let proc_mesh = &meshes[1]; // Use ProcessAllocator version
+        // Create proc mesh with 2 procs
+        let mut hm = testing::host_mesh(2).await;
+        let proc_mesh = hm.spawn(instance, "test", Extent::unity()).await.unwrap();
 
         // Spawn SleepActors across the mesh that will block longer
         // than timeout
@@ -1506,6 +1509,8 @@ mod tests {
             "Stop took {:?}, expected >= 900ms (should have waited for timeout)",
             stop_duration
         );
+
+        let _ = hm.shutdown(instance).await;
     }
 
     /// Test that actors stop gracefully when they respond to stop
@@ -1520,9 +1525,9 @@ mod tests {
 
         let instance = testing::instance();
 
-        // Create proc mesh with 2 replicas
-        let meshes = testing::proc_meshes(instance, extent!(replicas = 2)).await;
-        let proc_mesh = &meshes[1];
+        // Create proc mesh with 2 procs
+        let mut hm = testing::host_mesh(2).await;
+        let proc_mesh = hm.spawn(instance, "test", Extent::unity()).await.unwrap();
 
         // Spawn TestActors - these stop cleanly (no blocking
         // operations)
@@ -1588,5 +1593,7 @@ mod tests {
             next_event.event.actor_status,
             ActorStatus::Stopped(_)
         ));
+
+        let _ = hm.shutdown(instance).await;
     }
 }

--- a/hyperactor_mesh/src/host_mesh.rs
+++ b/hyperactor_mesh/src/host_mesh.rs
@@ -1802,8 +1802,8 @@ mod tests {
 
         let instance = testing::instance();
 
-        let proc_meshes = testing::proc_meshes(instance, extent!(replicas = 2)).await;
-        let proc_mesh = proc_meshes.get(1).unwrap();
+        let mut hm = testing::host_mesh(2).await;
+        let proc_mesh = hm.spawn(instance, "test", Extent::unity()).await.unwrap();
 
         let actor_mesh: ActorMesh<testactor::TestActor> =
             proc_mesh.spawn(instance, "test", &()).await.unwrap();
@@ -1839,5 +1839,7 @@ mod tests {
                 .unwrap(),
             Duration::from_mins(1)
         );
+
+        let _ = hm.shutdown(instance).await;
     }
 }

--- a/hyperactor_mesh/src/proc_mesh.rs
+++ b/hyperactor_mesh/src/proc_mesh.rs
@@ -527,14 +527,6 @@ impl ProcMesh {
         mesh
     }
 
-    /// Detach the proc mesh from the lifetime of `self`, and return its reference.
-    #[allow(unused)]
-    #[cfg(test)]
-    pub(crate) fn detach(self) -> ProcMeshRef {
-        // This also keeps the ProcMeshAllocation::Allocated alloc task alive.
-        self.current_ref.clone()
-    }
-
     /// Stop this mesh gracefully.
     pub async fn stop(&mut self, cx: &impl context::Actor, reason: String) -> anyhow::Result<()> {
         let region = self.region.clone();
@@ -1360,10 +1352,15 @@ mod tests {
 
         let instance = testing::instance();
 
-        for proc_mesh in testing::proc_meshes(&instance, extent!(replicas = 4, hosts = 2)).await {
-            testactor::assert_mesh_shape(proc_mesh.spawn(instance, "test", &()).await.unwrap())
-                .await;
-        }
+        let mut hm = testing::host_mesh(4).await;
+        let proc_mesh = hm
+            .spawn(&instance, "test", extent!(gpus = 2))
+            .await
+            .unwrap();
+        let actor_mesh = proc_mesh.spawn(instance, "test", &()).await.unwrap();
+        testactor::assert_mesh_shape(actor_mesh).await;
+
+        let _ = hm.shutdown(instance).await;
     }
 
     #[tokio::test]
@@ -1373,20 +1370,25 @@ mod tests {
 
         let instance = testing::instance();
 
-        for proc_mesh in testing::proc_meshes(&instance, extent!(replicas = 4, hosts = 2)).await {
-            let err = proc_mesh
-                .spawn::<testactor::FailingCreateTestActor, Instance<testing::TestRootClient>>(
-                    instance,
-                    "testfail",
-                    &(),
-                )
-                .await
-                .unwrap_err();
-            let statuses = err.into_actor_spawn_error().unwrap();
-            assert_eq!(
-                statuses,
-                RankedValues::from((0..8, Status::Failed("test failure".to_string()))),
-            );
-        }
+        let mut hm = testing::host_mesh(4).await;
+        let proc_mesh = hm
+            .spawn(&instance, "test", extent!(gpus = 2))
+            .await
+            .unwrap();
+        let err = proc_mesh
+            .spawn::<testactor::FailingCreateTestActor, Instance<testing::TestRootClient>>(
+                instance,
+                "testfail",
+                &(),
+            )
+            .await
+            .unwrap_err();
+        let statuses = err.into_actor_spawn_error().unwrap();
+        assert_eq!(
+            statuses,
+            RankedValues::from((0..8, Status::Failed("test failure".to_string()))),
+        );
+
+        let _ = hm.shutdown(instance).await;
     }
 }


### PR DESCRIPTION
Summary: This diff is part of the effort to deprecate allocator. Basically, this diff migrate some tests from allocator-bootstrap to simple bootstrap.

Differential Revision: D93493245


