### PR TITLE
Update futures family to 0.3.32

### DIFF
--- a/hyperactor/Cargo.toml
+++ b/hyperactor/Cargo.toml
@@ -43,7 +43,7 @@ dns-lookup = "1.0"
 enum-as-inner = "0.6.1"
 erased-serde = "0.4.9"
 fastrand = "2.1.1"
-futures = { version = "0.3.31", features = ["async-await", "compat"] }
+futures = { version = "0.3.32", features = ["async-await", "compat"] }
 hostname = "0.3"
 humantime = "2.1"
 hyperactor_config = { version = "0.0.0", path = "../hyperactor_config" }

--- a/hyperactor_mesh/Cargo.toml
+++ b/hyperactor_mesh/Cargo.toml
@@ -54,7 +54,7 @@ crossterm = { version = "0.28", features = ["event-stream", "serde"] }
 dashmap = { version = "5.5.3", features = ["rayon", "serde"] }
 enum-as-inner = "0.6.1"
 erased-serde = "0.4.9"
-futures = { version = "0.3.31", features = ["async-await", "compat"] }
+futures = { version = "0.3.32", features = ["async-await", "compat"] }
 hostname = "0.3"
 humantime = "2.1"
 hyperactor = { version = "0.0.0", path = "../hyperactor" }

--- a/monarch_conda/Cargo.toml
+++ b/monarch_conda/Cargo.toml
@@ -20,7 +20,7 @@ clap = { version = "4.5.42", features = ["derive", "env", "string", "unicode", "
 dashmap = { version = "5.5.3", features = ["rayon", "serde"] }
 digest = "0.10"
 filetime = "0.2.27"
-futures = { version = "0.3.31", features = ["async-await", "compat"] }
+futures = { version = "0.3.32", features = ["async-await", "compat"] }
 globset = { version = "0.4.13", features = ["serde1"] }
 ignore = "0.4"
 itertools = "0.14.0"

--- a/monarch_distributed_telemetry/Cargo.toml
+++ b/monarch_distributed_telemetry/Cargo.toml
@@ -11,7 +11,7 @@ license = "BSD-3-Clause"
 anyhow = "1.0.98"
 async-trait = "0.1.86"
 datafusion = "52.1"
-futures = { version = "0.3.31", features = ["async-await", "compat"] }
+futures = { version = "0.3.32", features = ["async-await", "compat"] }
 hyperactor = { version = "0.0.0", path = "../hyperactor" }
 hyperactor_telemetry = { version = "0.0.0", path = "../hyperactor_telemetry" }
 monarch_hyperactor = { version = "0.0.0", path = "../monarch_hyperactor" }

--- a/monarch_extension/Cargo.toml
+++ b/monarch_extension/Cargo.toml
@@ -17,7 +17,7 @@ crate-type = ["cdylib"]
 anyhow = "1.0.98"
 async-trait = "0.1.86"
 bincode = "1.3.3"
-futures = { version = "0.3.31", features = ["async-await", "compat"] }
+futures = { version = "0.3.32", features = ["async-await", "compat"] }
 hyperactor = { version = "0.0.0", path = "../hyperactor" }
 hyperactor_mesh = { version = "0.0.0", path = "../hyperactor_mesh" }
 hyperactor_telemetry = { version = "0.0.0", path = "../hyperactor_telemetry" }

--- a/monarch_hyperactor/Cargo.toml
+++ b/monarch_hyperactor/Cargo.toml
@@ -25,7 +25,7 @@ clap = { version = "4.5.42", features = ["derive", "env", "string", "unicode", "
 erased-serde = "0.4.9"
 fastrand = "2.1.1"
 fbinit = { version = "0.2.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main" }
-futures = { version = "0.3.31", features = ["async-await", "compat"] }
+futures = { version = "0.3.32", features = ["async-await", "compat"] }
 humantime = "2.1"
 hyperactor = { version = "0.0.0", path = "../hyperactor" }
 hyperactor_config = { version = "0.0.0", path = "../hyperactor_config" }

--- a/monarch_rdma/Cargo.toml
+++ b/monarch_rdma/Cargo.toml
@@ -10,7 +10,7 @@ license = "BSD-3-Clause"
 [dependencies]
 anyhow = "1.0.98"
 async-trait = "0.1.86"
-futures = { version = "0.3.31", features = ["async-await", "compat"] }
+futures = { version = "0.3.32", features = ["async-await", "compat"] }
 hyperactor = { version = "0.0.0", path = "../hyperactor" }
 hyperactor_config = { version = "0.0.0", path = "../hyperactor_config" }
 rand = { version = "0.9", features = ["small_rng"] }

--- a/monarch_tensor_worker/Cargo.toml
+++ b/monarch_tensor_worker/Cargo.toml
@@ -11,7 +11,7 @@ license = "BSD-3-Clause"
 anyhow = "1.0.98"
 async-trait = "0.1.86"
 derive_more = { version = "1.0.0", features = ["full"] }
-futures = { version = "0.3.31", features = ["async-await", "compat"] }
+futures = { version = "0.3.32", features = ["async-await", "compat"] }
 hyperactor = { version = "0.0.0", path = "../hyperactor" }
 hyperactor_config = { version = "0.0.0", path = "../hyperactor_config" }
 hyperactor_mesh = { version = "0.0.0", path = "../hyperactor_mesh" }

--- a/preempt_rwlock/Cargo.toml
+++ b/preempt_rwlock/Cargo.toml
@@ -12,4 +12,4 @@ tokio = { version = "1.47.1", features = ["full", "test-util", "tracing"] }
 
 [dev-dependencies]
 anyhow = "1.0.98"
-futures = { version = "0.3.31", features = ["async-await", "compat"] }
+futures = { version = "0.3.32", features = ["async-await", "compat"] }


### PR DESCRIPTION
Summary: Update the futures family of Rust crates from 0.3.30/0.3.31 to 0.3.32: futures, futures-channel, futures-core, and futures-util. This is a minor version bump that includes upstream bug fixes and improvements.

Reviewed By: dtolnay

Differential Revision: D93684256
