### PR TITLE
Skip test_normal_stop for OSS CI

### DIFF
--- a/hyperactor_mesh/src/alloc/remoteprocess.rs
+++ b/hyperactor_mesh/src/alloc/remoteprocess.rs
@@ -1609,6 +1609,10 @@ mod test {
     }
 
     #[timed_test::async_timed_test(timeout_secs = 60)]
+    // This test is flaky in OSS CI, but healthy in sandcastle. Considering we
+    // are in the middle of deprecating allocator, it is not worth the effort to
+    // fix it for OSS.
+    #[cfg_attr(not(fbcode_build), ignore)]
     async fn test_normal_stop() {
         let config = hyperactor_config::global::lock();
         let _guard = config.override_key(


### PR DESCRIPTION
Summary:
As explained in the in-line comment:

    // This test is flaky in OSS CI, but healthy in sandcastle. Considering we
    // are in the middle of deprecating allocator, it is not worth the effort to
    // fix it for OSS.

Reviewed By: shayne-fletcher

Differential Revision: D93746803


