### PR TITLE
Remove deprecated allocator-related methods

### DIFF
--- a/python/benches/actor_mesh_benchmark.py
+++ b/python/benches/actor_mesh_benchmark.py
@@ -28,8 +28,8 @@ from monarch._rust_bindings.monarch_hyperactor.config import (  # @manual=//mona
 from monarch.actor import (  # @manual=//monarch/python/monarch/actor:actor
     Actor,
     endpoint,
-    proc_mesh,
     ProcMesh,
+    this_host,
 )
 from windtunnel.benchmarks.python_benchmark_runner.benchmark import (
     main,
@@ -208,7 +208,9 @@ class ActorLatency(Benchmark):
 
     async def setup(self) -> None:
         reload_config_from_env()
-        pong_mesh = proc_mesh(hosts=self.host_count, gpus=self.gpu_count)
+        pong_mesh = this_host().spawn_procs(
+            per_host={"hosts": self.host_count, "gpus": self.gpu_count},
+        )
         await pong_mesh.logging_option(stream_to_client=True, aggregate_window_sec=None)
 
         self.pong_actors = pong_mesh.spawn("pong", Pong)

--- a/python/monarch/actor/__init__.py
+++ b/python/monarch/actor/__init__.py
@@ -43,12 +43,7 @@ from monarch._src.actor.host_mesh import (
     this_host,
     this_proc,
 )
-from monarch._src.actor.proc_mesh import (
-    get_or_spawn_controller,
-    local_proc_mesh,
-    proc_mesh,
-    ProcMesh,
-)
+from monarch._src.actor.proc_mesh import get_or_spawn_controller, ProcMesh
 from monarch._src.actor.supervision import unhandled_fault_hook
 
 __all__ = [
@@ -61,9 +56,7 @@ __all__ = [
     "current_size",
     "endpoint",
     "Future",
-    "local_proc_mesh",
     "Point",
-    "proc_mesh",
     "ProcMesh",
     "Channel",
     "send",

--- a/python/tests/test_debugger.py
+++ b/python/tests/test_debugger.py
@@ -46,13 +46,8 @@ from monarch._src.actor.debugger.debug_session import (
 )
 from monarch._src.actor.endpoint import endpoint, Extent
 from monarch._src.actor.host_mesh import create_local_host_mesh, this_host
-from monarch._src.actor.proc_mesh import (
-    get_or_spawn_controller,
-    proc_mesh as proc_mesh_v0,
-    ProcMesh,
-)
+from monarch._src.actor.proc_mesh import get_or_spawn_controller, ProcMesh
 from monarch._src.actor.source_loader import SourceLoaderController
-from monarch.config import configure
 from monarch.tools.debug_env import (
     _MONARCH_DEBUG_SERVER_HOST_ENV_VAR,
     _MONARCH_DEBUG_SERVER_PORT_ENV_VAR,


### PR DESCRIPTION
Summary: These 3 methods are already marked as deprecated. They are allocator related methods, which we do not want the user to use.

Differential Revision: D93735974


