### PR TITLE
PublishedProperties slot, QueryChild callback, and is_system flag

### DIFF
--- a/hyperactor_mesh/bin/admin_tui.rs
+++ b/hyperactor_mesh/bin/admin_tui.rs
@@ -2304,6 +2304,7 @@ fn render_node_detail(
             last_message_handler,
             total_processing_time_us,
             flight_recorder,
+            ..
         } => {
             render_actor_detail(
                 frame,
@@ -2672,6 +2673,7 @@ mod tests {
                 last_message_handler: None,
                 total_processing_time_us: 0,
                 flight_recorder: None,
+                is_system: false,
             },
             children: vec![],
             parent: None,


### PR DESCRIPTION
Summary: this diff adds the data plumbing needed for runtime introspection without changing behavior yet: introduces PublishedProperties{ published_at, kind: Host|Proc } in introspect.rs, adds published_properties and query_child_handler slots to InstanceCellState in proc.rs with accessors (set_published_properties, published_properties, set_query_child_handler, query_child), and exposes Instance::publish_properties() / Instance::set_query_child_handler() as the public API. it also adds an is_system: bool field to NodeProperties::Actor (defaulted to false in default_actor_payload) and updates the TUI actor-detail match to ignore the new field. two unit tests validate properties round-trip and callback round-trip at the cell level.

Differential Revision: D93768689


