### PR TITLE
Add self kill when controller no longer messages

### DIFF
--- a/hyperactor_mesh/src/actor_mesh.rs
+++ b/hyperactor_mesh/src/actor_mesh.rs
@@ -535,12 +535,28 @@ impl<A: Referable> ActorMeshRef<A> {
         }
     }
 
+    /// Query the state of all actors in this mesh.
+    /// If keepalive is Some, use a message that indicates to the recipient
+    /// that the owner of the mesh is still alive, along with the expiry time
+    /// after which the actor should be considered orphaned. Else, use a normal
+    /// state query.
     #[allow(clippy::result_large_err)]
     pub async fn actor_states(
         &self,
         cx: &impl context::Actor,
     ) -> crate::Result<ValueMesh<resource::State<ActorState>>> {
-        self.proc_mesh.actor_states(cx, self.name.clone()).await
+        self.actor_states_with_keepalive(cx, None).await
+    }
+
+    #[allow(clippy::result_large_err)]
+    pub(crate) async fn actor_states_with_keepalive(
+        &self,
+        cx: &impl context::Actor,
+        keepalive: Option<std::time::SystemTime>,
+    ) -> crate::Result<ValueMesh<resource::State<ActorState>>> {
+        self.proc_mesh
+            .actor_states_with_keepalive(cx, self.name.clone(), keepalive)
+            .await
     }
 
     pub(crate) fn new(

--- a/hyperactor_mesh/src/mesh_controller.rs
+++ b/hyperactor_mesh/src/mesh_controller.rs
@@ -24,6 +24,8 @@ use hyperactor::actor::ActorErrorKind;
 use hyperactor::actor::ActorStatus;
 use hyperactor::actor::Referable;
 use hyperactor::actor::handle_undeliverable_message;
+use hyperactor::clock::Clock;
+use hyperactor::clock::RealClock;
 use hyperactor::context;
 use hyperactor::mailbox::MessageEnvelope;
 use hyperactor::mailbox::Undeliverable;
@@ -48,6 +50,7 @@ use crate::bootstrap::ProcStatus;
 use crate::casting::update_undeliverable_envelope_for_casting;
 use crate::host_mesh::HostMeshRef;
 use crate::proc_agent::ActorState;
+use crate::proc_agent::MESH_ORPHAN_TIMEOUT;
 use crate::proc_mesh::ProcMeshRef;
 use crate::resource;
 use crate::supervision::MeshFailure;
@@ -727,7 +730,13 @@ impl<A: Referable> Handler<CheckState> for ActorMeshController<A> {
         }
 
         // Now that we know the proc mesh is alive, check for actor state changes.
-        let events = mesh.actor_states(cx).await;
+        let orphan_timeout = hyperactor_config::global::get(MESH_ORPHAN_TIMEOUT);
+        let keepalive = if orphan_timeout.is_zero() {
+            None
+        } else {
+            Some(RealClock.system_time_now() + orphan_timeout)
+        };
+        let events = mesh.actor_states_with_keepalive(cx, keepalive).await;
         if let Err(e) = events {
             send_state_change(
                 cx,
@@ -899,5 +908,242 @@ impl Actor for HostMeshController {
             }
         }
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::ops::Deref;
+    use std::time::Duration;
+
+    use hyperactor::clock::Clock;
+    use hyperactor::clock::RealClock;
+    use ndslice::Extent;
+    use ndslice::ViewExt;
+
+    use super::SUPERVISION_POLL_FREQUENCY;
+    use crate::ActorMesh;
+    use crate::Name;
+    use crate::proc_agent::MESH_ORPHAN_TIMEOUT;
+    use crate::resource;
+    use crate::supervision::MeshFailure;
+    use crate::test_utils::local_host_mesh;
+    use crate::testactor;
+    use crate::testing;
+
+    /// Verify that actors spawned without a controller are cleaned up
+    /// when their keepalive expiry lapses. We:
+    ///   1. Enable the orphan timeout on the `ProcMeshAgent`.
+    ///   2. Spawn actors as *system actors* (no `ActorMeshController`).
+    ///   3. Send a single keepalive with a short expiry time.
+    ///   4. Wait for the expiry to pass and `SelfCheck` to fire.
+    ///   5. Assert that the actors are now stopped.
+    #[tokio::test]
+    async fn test_orphaned_actors_are_cleaned_up() {
+        let config = hyperactor_config::global::lock();
+        // Short orphan timeout so SelfCheck fires frequently.
+        let _orphan = config.override_key(MESH_ORPHAN_TIMEOUT, Duration::from_secs(1));
+
+        let instance = testing::instance();
+        let host_mesh = local_host_mesh(2).await;
+        let proc_mesh = host_mesh
+            .spawn(instance, "test", Extent::unity())
+            .await
+            .unwrap();
+
+        let actor_name = Name::new("orphan_test").unwrap();
+        // Spawn as a system actor so no controller is created. This lets us
+        // control keepalive messages directly without the controller
+        // interfering.
+        let actor_mesh: ActorMesh<testactor::TestActor> = proc_mesh
+            .spawn_with_name(instance, actor_name.clone(), &(), None, true)
+            .await
+            .unwrap();
+        assert!(
+            actor_mesh.deref().extent().num_ranks() > 0,
+            "should have spawned at least one actor"
+        );
+
+        // Send a keepalive with a short expiry. This is what the
+        // ActorMeshController would normally do on each supervision poll.
+        let states = proc_mesh
+            .actor_states_with_keepalive(
+                instance,
+                actor_name.clone(),
+                Some(RealClock.system_time_now() + Duration::from_secs(2)),
+            )
+            .await
+            .unwrap();
+        // All actors should be running right now.
+        for state in states.values() {
+            assert_eq!(
+                state.status,
+                resource::Status::Running,
+                "actor should be running before expiry"
+            );
+        }
+
+        // Wait long enough for the expiry to pass and at least one
+        // SelfCheck cycle to fire. With MESH_ORPHAN_TIMEOUT = 1s and
+        // expiry in 2s, by around 4s at least two SelfCheck cycles will
+        // have elapsed after the expiry.
+        RealClock.sleep(Duration::from_secs(5)).await;
+
+        // Query again, this time *without* a keepalive so we don't
+        // extend the expiry.
+        let states = proc_mesh
+            .actor_states(instance, actor_name.clone())
+            .await
+            .unwrap();
+        for state in states.values() {
+            assert_eq!(
+                state.status,
+                resource::Status::Stopped,
+                "actor should be stopped after keepalive expiry"
+            );
+        }
+    }
+
+    /// Create a multi-process host mesh that propagates the current
+    /// process's config overrides to child processes via Bootstrap.
+    #[cfg(fbcode_build)]
+    async fn host_mesh_with_config(n: usize) -> crate::host_mesh::HostMesh {
+        use hyperactor::channel::ChannelTransport;
+        use tokio::process::Command;
+
+        let program = crate::testresource::get("monarch/hyperactor_mesh/bootstrap");
+        let mut host_addrs = vec![];
+        for _ in 0..n {
+            host_addrs.push(ChannelTransport::Unix.any());
+        }
+
+        for host in host_addrs.iter() {
+            let mut cmd = Command::new(program.clone());
+            let boot = crate::Bootstrap::Host {
+                addr: host.clone(),
+                command: None,
+                config: Some(hyperactor_config::global::attrs()),
+                exit_on_shutdown: false,
+            };
+            boot.to_env(&mut cmd);
+            cmd.kill_on_drop(false);
+            // SAFETY: pre_exec sets PR_SET_PDEATHSIG so the child is
+            // cleaned up if the parent (test) process dies.
+            unsafe {
+                cmd.pre_exec(crate::bootstrap::install_pdeathsig_kill);
+            }
+            cmd.spawn().unwrap();
+        }
+
+        let host_mesh = crate::HostMeshRef::from_hosts(Name::new("test").unwrap(), host_addrs);
+        crate::host_mesh::HostMesh::take(host_mesh)
+    }
+
+    /// Verify that actors are cleaned up via the orphan timeout when the
+    /// `ActorMeshController`'s process crashes. Unlike the system-actor test
+    /// above, this spawns actors through a real controller (via `WrapperActor`)
+    /// and then kills the controller's process uncleanly with `ProcessExit`.
+    /// The agents on the surviving proc mesh detect the expired keepalive
+    /// and stop the actors.
+    #[tokio::test]
+    #[cfg(fbcode_build)]
+    async fn test_orphaned_actors_cleaned_up_on_controller_crash() {
+        let config = hyperactor_config::global::lock();
+        let _orphan = config.override_key(MESH_ORPHAN_TIMEOUT, Duration::from_secs(2));
+        let _poll = config.override_key(SUPERVISION_POLL_FREQUENCY, Duration::from_secs(1));
+
+        let instance = testing::instance();
+        let num_replicas = 2;
+
+        // Host mesh for the test actors (these survive the crash).
+        // host_mesh_with_config propagates config overrides to child
+        // processes via Bootstrap, so agents boot with
+        // MESH_ORPHAN_TIMEOUT=2s and start the SelfCheck loop.
+        let mut actor_hm = host_mesh_with_config(num_replicas).await;
+        let actor_proc_mesh = actor_hm
+            .spawn(instance, "actors", Extent::unity())
+            .await
+            .unwrap();
+
+        // Host mesh for the wrapper + controller (will be killed).
+        let mut controller_hm = host_mesh_with_config(1).await;
+        let controller_proc_mesh = controller_hm
+            .spawn(instance, "controller", Extent::unity())
+            .await
+            .unwrap();
+
+        let child_name = Name::new("orphan_child").unwrap();
+
+        // Supervision port required by WrapperActor params.
+        let (supervision_port, _supervision_receiver) = instance.open_port::<MeshFailure>();
+        let supervisor = supervision_port.bind();
+
+        // Spawn WrapperActor on controller_proc_mesh. Its init() spawns
+        // ActorMesh<TestActor> on actor_proc_mesh with a real
+        // ActorMeshController co-located on the controller's process.
+        let wrapper_mesh: ActorMesh<testactor::WrapperActor> = controller_proc_mesh
+            .spawn(
+                instance,
+                "wrapper",
+                &(
+                    actor_proc_mesh.deref().clone(),
+                    supervisor,
+                    child_name.clone(),
+                ),
+            )
+            .await
+            .unwrap();
+
+        // Give the controller time to run at least one CheckState cycle
+        // (polling every 1s) so it sends KeepaliveGetState to the agents.
+        RealClock.sleep(Duration::from_secs(3)).await;
+
+        // Verify actors are running before the crash.
+        let states = actor_proc_mesh
+            .actor_states(instance, child_name.clone())
+            .await
+            .unwrap();
+        for state in states.values() {
+            assert_eq!(
+                state.status,
+                resource::Status::Running,
+                "actor should be running before controller crash"
+            );
+        }
+
+        // Kill the controller's process uncleanly. send_to_children: false
+        // means only the WrapperActor's process exits; the TestActors on
+        // actor_proc_mesh survive.
+        wrapper_mesh
+            .cast(
+                instance,
+                testactor::CauseSupervisionEvent {
+                    kind: testactor::SupervisionEventType::ProcessExit(1),
+                    send_to_children: false,
+                },
+            )
+            .unwrap();
+
+        // Wait for:
+        //  - keepalive expiry (2s from last CheckState)
+        //  - at least one SelfCheck cycle (every 2s)
+        //  - margin for processing
+        RealClock.sleep(Duration::from_secs(8)).await;
+
+        // Actors should now be stopped via the orphan timeout.
+        let states = actor_proc_mesh
+            .actor_states(instance, child_name.clone())
+            .await
+            .unwrap();
+        for state in states.values() {
+            assert_eq!(
+                state.status,
+                resource::Status::Stopped,
+                "actor should be stopped after controller crash and orphan timeout"
+            );
+        }
+
+        let _ = actor_hm.shutdown(instance).await;
+        let _ = controller_hm.shutdown(instance).await;
     }
 }

--- a/hyperactor_mesh/src/proc_agent.rs
+++ b/hyperactor_mesh/src/proc_agent.rs
@@ -20,6 +20,7 @@ use std::sync::Arc;
 use std::sync::Mutex;
 use std::sync::RwLock;
 use std::sync::RwLockReadGuard;
+use std::time::Duration;
 
 use async_trait::async_trait;
 use enum_as_inner::EnumAsInner;
@@ -53,6 +54,9 @@ use hyperactor::mailbox::MessageEnvelope;
 use hyperactor::mailbox::Undeliverable;
 use hyperactor::proc::Proc;
 use hyperactor::supervision::ActorSupervisionEvent;
+use hyperactor_config::CONFIG;
+use hyperactor_config::ConfigAttr;
+use hyperactor_config::attrs::declare_attrs;
 use serde::Deserialize;
 use serde::Serialize;
 use typeuri::Named;
@@ -62,6 +66,15 @@ use crate::resource;
 
 /// Actor name used when spawning the proc agent on user procs.
 pub const PROC_AGENT_ACTOR_NAME: &str = "proc_agent";
+
+declare_attrs! {
+    /// Whether to self kill actors, procs, and hosts whose owner is not reachable.
+    @meta(CONFIG = ConfigAttr::new(
+        Some("HYPERACTOR_MESH_ORPHAN_TIMEOUT".to_string()),
+        Some("mesh_orphan_timeout".to_string()),
+    ))
+    pub attr MESH_ORPHAN_TIMEOUT: Duration = Duration::from_secs(0);
+}
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Named)]
 pub enum GspawnResult {
@@ -200,7 +213,23 @@ struct ActorInstanceState {
     /// If true, the actor has been stopped. There is no way to restart it, a new
     /// actor must be spawned.
     stopped: bool,
+    /// The time at which the actor should be considered expired if no further
+    /// keepalive is received. `None` meaning it will never expire.
+    expiry_time: Option<std::time::SystemTime>,
 }
+
+#[derive(
+    Clone,
+    Debug,
+    Default,
+    PartialEq,
+    Serialize,
+    Deserialize,
+    Named,
+    Bind,
+    Unbind
+)]
+struct SelfCheck {}
 
 /// A mesh agent is responsible for managing procs in a [`ProcMesh`].
 ///
@@ -231,6 +260,7 @@ struct ActorInstanceState {
         resource::Stop { cast = true },
         resource::StopAll { cast = true },
         resource::GetState<ActorState> { cast = true },
+        resource::KeepaliveGetState<ActorState> { cast = true },
         resource::GetRankStatus { cast = true },
         RepublishIntrospect { cast = true },
     ]
@@ -254,6 +284,8 @@ pub struct ProcAgent {
     /// channel instead of calling process::exit directly, allowing the
     /// caller to perform graceful shutdown (e.g. draining the mailbox server).
     shutdown_tx: Option<tokio::sync::oneshot::Sender<i32>>,
+    /// If set, check for expired actors whose keepalive has lapsed.
+    mesh_orphan_timeout: Option<Duration>,
 }
 
 impl ProcAgent {
@@ -277,6 +309,9 @@ impl ProcAgent {
             supervision_events: HashMap::new(),
             introspect_dirty: false,
             shutdown_tx: None,
+            // v0 procs don't have an owner they can check for, so they should
+            // never try to kill the children.
+            mesh_orphan_timeout: None,
         };
         let handle = proc.spawn::<Self>("mesh", agent)?;
         Ok((proc, handle))
@@ -286,6 +321,15 @@ impl ProcAgent {
         proc: Proc,
         shutdown_tx: Option<tokio::sync::oneshot::Sender<i32>>,
     ) -> Result<ActorHandle<Self>, anyhow::Error> {
+        // We can't use Option<Duration> directly in config attrs because AttrValue
+        // is not implemented for Option<Duration>. So we use a zero timeout to
+        // indicate no timeout.
+        let orphan_timeout = hyperactor_config::global::get(MESH_ORPHAN_TIMEOUT);
+        let orphan_timeout = if orphan_timeout.is_zero() {
+            None
+        } else {
+            Some(orphan_timeout)
+        };
         let agent = ProcAgent {
             proc: proc.clone(),
             remote: Remote::collect(),
@@ -295,6 +339,7 @@ impl ProcAgent {
             supervision_events: HashMap::new(),
             introspect_dirty: false,
             shutdown_tx,
+            mesh_orphan_timeout: orphan_timeout,
         };
         proc.spawn::<Self>(PROC_AGENT_ACTOR_NAME, agent)
     }
@@ -413,6 +458,9 @@ impl Actor for ProcAgent {
             }
         });
 
+        if let Some(delay) = &self.mesh_orphan_timeout {
+            this.self_message_with_delay(SelfCheck::default(), *delay)?;
+        }
         Ok(())
     }
 }
@@ -519,8 +567,9 @@ impl MeshAgentMessageHandler for ProcAgent {
     ) -> Result<StopActorResult, anyhow::Error> {
         tracing::info!(
             name = "StopActor",
-            actor_id = %actor_id,
+            %actor_id,
             actor_name = actor_id.name(),
+            %reason,
         );
 
         let result = if let Some(mut status) = self.proc.stop_actor(&actor_id, reason) {
@@ -688,6 +737,7 @@ impl Handler<resource::CreateOrUpdate<ActorSpec>> for ProcAgent {
                     )),
                     create_rank,
                     stopped: false,
+                    expiry_time: None,
                 },
             );
             return Ok(());
@@ -712,6 +762,7 @@ impl Handler<resource::CreateOrUpdate<ActorSpec>> for ProcAgent {
                     )
                     .await,
                 stopped: false,
+                expiry_time: None,
             },
         );
 
@@ -749,6 +800,8 @@ impl Handler<resource::Stop> for ProcAgent {
         };
         let timeout = hyperactor_config::global::get(hyperactor::config::STOP_ACTOR_TIMEOUT);
         if let Some(actor_id) = actor_id {
+            // The orphaned actor SelfCheck will consult the stopped field before
+            // trying to stop any actor again.
             // While this function returns a Result, it never returns an Err
             // value so we can simply expect without any failure handling.
             self.stop_actor(cx, actor_id, timeout.as_millis() as u64, message.reason)
@@ -824,6 +877,7 @@ impl Handler<resource::GetRankStatus> for ProcAgent {
                 spawn: Ok(actor_id),
                 create_rank,
                 stopped,
+                ..
             }) => {
                 if *stopped {
                     (*create_rank, resource::Status::Stopped)
@@ -890,6 +944,7 @@ impl Handler<resource::GetState<ActorState>> for ProcAgent {
                 create_rank,
                 spawn: Ok(actor_id),
                 stopped,
+                ..
             }) => {
                 let supervision_events = self
                     .supervision_events
@@ -943,6 +998,32 @@ impl Handler<resource::GetState<ActorState>> for ProcAgent {
     }
 }
 
+#[async_trait]
+impl Handler<resource::KeepaliveGetState<ActorState>> for ProcAgent {
+    async fn handle(
+        &mut self,
+        cx: &Context<Self>,
+        message: resource::KeepaliveGetState<ActorState>,
+    ) -> anyhow::Result<()> {
+        // Same impl as GetState, but additionally update the expiry time on the actor.
+        if let Ok(instance_state) = self
+            .actor_states
+            .get_mut(&message.get_state.name)
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "attempting to register a keepalive for an actor that doesn't exist: {}",
+                    message.get_state.name
+                )
+            })
+        {
+            instance_state.expiry_time = Some(message.expires_after);
+        }
+
+        // Forward the rest of the impl to GetState.
+        <Self as Handler<resource::GetState<ActorState>>>::handle(self, cx, message.get_state).await
+    }
+}
+
 /// A local handler to get a new client instance on the proc.
 /// This is used to create root client instances.
 #[derive(Debug, hyperactor::Handler, hyperactor::HandleClient)]
@@ -980,6 +1061,64 @@ impl Handler<GetProc> for ProcAgent {
         GetProc { proc }: GetProc,
     ) -> anyhow::Result<()> {
         proc.send(cx, self.proc.clone())?;
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl Handler<SelfCheck> for ProcAgent {
+    async fn handle(&mut self, cx: &Context<Self>, _: SelfCheck) -> anyhow::Result<()> {
+        // Check each actor's expiry time. If the current time is past the expiry,
+        // stop the actor. This allows automatic cleanup when a controller disappears
+        // but owned resources remain. It is important that this check runs on the
+        // same proc as the child actor itself, since the controller could be dead or
+        // disconnected.
+        let Some(duration) = &self.mesh_orphan_timeout else {
+            return Ok(());
+        };
+        let duration = duration.clone();
+        let now = RealClock.system_time_now();
+
+        // Collect expired actors before mutating, since stop_actor borrows &mut self.
+        let expired: Vec<(Name, ActorId)> = self
+            .actor_states
+            .iter()
+            .filter_map(|(name, state)| {
+                let expiry = state.expiry_time?;
+                // If the actor was already stopped we don't need to stop it again.
+                if now > expiry && !state.stopped {
+                    if let Ok(actor_id) = &state.spawn {
+                        return Some((name.clone(), actor_id.clone()));
+                    }
+                }
+                None
+            })
+            .collect();
+
+        if !expired.is_empty() {
+            tracing::info!(
+                "stopping {} orphaned actors past their keepalive expiry",
+                expired.len(),
+            );
+        }
+
+        let timeout = hyperactor_config::global::get(hyperactor::config::STOP_ACTOR_TIMEOUT);
+        for (name, actor_id) in expired {
+            if let Some(state) = self.actor_states.get_mut(&name) {
+                state.stopped = true;
+            }
+            self.stop_actor(
+                cx,
+                actor_id,
+                timeout.as_millis() as u64,
+                "orphaned".to_string(),
+            )
+            .await
+            .expect("stop_actor cannot fail");
+        }
+
+        // Reschedule.
+        cx.self_message_with_delay(SelfCheck::default(), duration)?;
         Ok(())
     }
 }

--- a/hyperactor_mesh/src/proc_mesh.rs
+++ b/hyperactor_mesh/src/proc_mesh.rs
@@ -138,50 +138,6 @@ impl ProcRef {
         }
     }
 
-    /// Get the supervision events for one actor with the given name.
-    #[allow(dead_code)]
-    async fn actor_state(
-        &self,
-        cx: &impl context::Actor,
-        name: Name,
-    ) -> crate::Result<resource::State<ActorState>> {
-        let (port, mut rx) = cx.mailbox().open_port::<resource::State<ActorState>>();
-        self.agent
-            .send(
-                cx,
-                resource::GetState::<ActorState> {
-                    name: name.clone(),
-                    reply: port.bind(),
-                },
-            )
-            .map_err(|e| Error::CallError(self.agent.actor_id().clone(), e.into()))?;
-        let state = rx
-            .recv()
-            .await
-            .map_err(|e| Error::CallError(self.agent.actor_id().clone(), e.into()))?;
-        if let Some(ref inner) = state.state {
-            let rank = inner.create_rank;
-            if rank == self.create_rank {
-                Ok(state)
-            } else {
-                Err(Error::CallError(
-                    self.agent.actor_id().clone(),
-                    anyhow::anyhow!(
-                        "Rank on mesh agent not matching for Actor {}: returned {}, expected {}",
-                        name,
-                        rank,
-                        self.create_rank
-                    ),
-                ))
-            }
-        } else {
-            Err(Error::CallError(
-                self.agent.actor_id().clone(),
-                anyhow::anyhow!("Actor {} does not exist", name),
-            ))
-        }
-    }
-
     pub fn proc_id(&self) -> &ProcId {
         &self.proc_id
     }
@@ -832,23 +788,45 @@ impl ProcMeshRef {
         ActorMeshRef::new(Name::new_reserved(agent_name).unwrap(), self.clone(), None)
     }
 
-    /// The supervision events of procs in this mesh.
+    /// Query the state of all actors in this mesh matching "name".
     pub async fn actor_states(
         &self,
         cx: &impl context::Actor,
         name: Name,
     ) -> crate::Result<ValueMesh<resource::State<ActorState>>> {
+        self.actor_states_with_keepalive(cx, name, None).await
+    }
+
+    /// Query the state of all actors in this mesh matching "name".
+    /// If keepalive is Some, use a message that indicates to the recipient
+    /// that the owner of the mesh is still alive, along with the expiry time
+    /// after which the actor should be considered orphaned. Else, use a normal
+    /// state query.
+    pub(crate) async fn actor_states_with_keepalive(
+        &self,
+        cx: &impl context::Actor,
+        name: Name,
+        keepalive: Option<std::time::SystemTime>,
+    ) -> crate::Result<ValueMesh<resource::State<ActorState>>> {
         let agent_mesh = self.agent_mesh();
         let (port, mut rx) = cx.mailbox().open_port::<resource::State<ActorState>>();
         // TODO: Use accumulation to get back a single value (representing whether
         // *any* of the actors failed) instead of a mesh.
-        agent_mesh.cast(
-            cx,
-            resource::GetState::<ActorState> {
-                name: name.clone(),
-                reply: port.bind(),
-            },
-        )?;
+        let get_state = resource::GetState::<ActorState> {
+            name: name.clone(),
+            reply: port.bind(),
+        };
+        if let Some(expires_after) = keepalive {
+            agent_mesh.cast(
+                cx,
+                resource::KeepaliveGetState {
+                    expires_after,
+                    get_state,
+                },
+            )?;
+        } else {
+            agent_mesh.cast(cx, get_state)?;
+        }
         let expected = self.ranks.len();
         let mut states = Vec::with_capacity(expected);
         let timeout = hyperactor_config::global::get(GET_ACTOR_STATE_MAX_IDLE);

--- a/hyperactor_mesh/src/resource.rs
+++ b/hyperactor_mesh/src/resource.rs
@@ -356,6 +356,51 @@ where
     }
 }
 
+/// Same as GetState, but additionally tells the receiver that the owner is still alive.
+/// If the receiver does not receive this message for a while, it might assume the owner is dead.
+#[derive(Debug, Serialize, Deserialize, Named, Handler, HandleClient, RefClient)]
+pub struct KeepaliveGetState<S> {
+    /// The time at which the actor should be considered expired if no further
+    /// keepalive is received.
+    pub expires_after: std::time::SystemTime,
+    pub get_state: GetState<S>,
+}
+wirevalue::register_type!(KeepaliveGetState<ProcState>);
+wirevalue::register_type!(KeepaliveGetState<ActorState>);
+
+// Cannot derive Bind and Unbind for this generic, implement manually.
+impl<S> Unbind for KeepaliveGetState<S>
+where
+    S: RemoteMessage,
+    S: Unbind,
+{
+    fn unbind(&self, bindings: &mut Bindings) -> anyhow::Result<()> {
+        self.get_state.unbind(bindings)
+    }
+}
+
+impl<S> Bind for KeepaliveGetState<S>
+where
+    S: RemoteMessage,
+    S: Bind,
+{
+    fn bind(&mut self, bindings: &mut Bindings) -> anyhow::Result<()> {
+        self.get_state.bind(bindings)
+    }
+}
+
+impl<S> Clone for KeepaliveGetState<S>
+where
+    S: RemoteMessage,
+{
+    fn clone(&self) -> Self {
+        Self {
+            expires_after: self.expires_after.clone(),
+            get_state: self.get_state.clone(),
+        }
+    }
+}
+
 /// List the set of resources managed by the controller.
 #[derive(Debug, Serialize, Deserialize, Named, Handler, HandleClient, RefClient)]
 pub struct List {

--- a/python/monarch/_rust_bindings/monarch_hyperactor/config.pyi
+++ b/python/monarch/_rust_bindings/monarch_hyperactor/config.pyi
@@ -81,6 +81,7 @@ def configure(
     actor_queue_dispatch: bool = ...,
     mesh_admin_addr: str = ...,
     mesh_attach_config_timeout: str = ...,
+    mesh_orphan_timeout: str = ...,
     **kwargs: object,
 ) -> None:
     """Configure Hyperactor runtime defaults for this process.

--- a/python/monarch/config/__init__.py
+++ b/python/monarch/config/__init__.py
@@ -83,6 +83,7 @@ if TYPE_CHECKING:
             actor_queue_dispatch: NotRequired[bool]
             mesh_admin_addr: NotRequired[str]
             mesh_attach_config_timeout: NotRequired[str]
+            mesh_orphan_timeout: NotRequired[str]
 
         ConfigureKwargsType = Unpack[ConfigureArgs]
     else:


### PR DESCRIPTION
Summary:
Fixes: https://github.com/meta-pytorch/monarch/issues/2198

One of the principles of ownership we want to maintain in monarch is that if the owner of
a resource (meshes of hosts, procs, actors) is not alive, that all of the resources it owned
are also not alive. This should include if the owner hits a hard failure that prevents it from
running any cleanup.

Before this change, we didn't have that guarantee, an actor would keep running if its owner
went away, as long as the actor didn't message the owner. 
This change tracks every time a GetState message is received by a ProcMeshAgent, and tracks
which controller sent it. We use this information to infer the controller is alive and well.
We use a new KeepaliveGetState message which is the same as a GetState but has an explicit
side effect. Only ProcMeshAgent uses this for actors at the moment, but we will expand to cover
procs and hosts too.

Benefits of this change:
* Actors might be using resources like CPU, memory, or GPUs that are no
longer needed and can be recovered.
* If you disconnect the client, all of the actors it spawned
will shut themselves down. And then any resources those actors spawned will also shut
themselves down recursively. You don't need to run any special cleanup function on the client.

This feature is hidden behind a flag, and this flag defaults to off. It may have unexpected issues
when we start having actors stop themselves, so we want to test this thoroughly.

Differential Revision: D92726630


