### PR TITLE
Make @rust_struct classes subscriptable at runtime when inheriting Generic

### DIFF
--- a/python/monarch/_src/actor/python_extension_methods.py
+++ b/python/monarch/_src/actor/python_extension_methods.py
@@ -43,6 +43,13 @@ class PatchRustClass:
                     setattr(self.rust_class, name, implementation)
             base.register(self.rust_class)
 
+        # If the Python class inherited from Generic, make the Rust class
+        # subscriptable so that ValueMesh[T] works at runtime.
+        if hasattr(python_class, "__class_getitem__") and not hasattr(
+            self.rust_class, "__class_getitem__"
+        ):
+            self.rust_class.__class_getitem__ = classmethod(lambda cls, params: cls)
+
         return cast(Type[T], self.rust_class)
 
     def _should_patch(self, name: str, implementation: object) -> bool:

--- a/python/tests/test_rust_struct_value_mesh.py
+++ b/python/tests/test_rust_struct_value_mesh.py
@@ -24,6 +24,7 @@ from monarch._rust_bindings.monarch_hyperactor.value_mesh import _make_test_valu
 
 # Import ValueMesh from actor_mesh — this triggers the @rust_struct patching
 from monarch._src.actor.actor_mesh import ValueMesh
+from monarch._src.actor.mpsc import Receiver
 
 
 class TestRustStructValueMesh:
@@ -130,3 +131,14 @@ class TestRustStructValueMesh:
         assert type(vm2) is ValueMesh
         assert list(vm2.values()) == list(range(6))
         assert vm2.sizes == {"x": 2, "y": 3}
+
+    def test_value_mesh_runtime_subscript(self) -> None:
+        """ValueMesh[T] works at runtime (not just under TYPE_CHECKING)."""
+        # This must not raise TypeError: type 'ValueMesh' is not subscriptable
+        alias = ValueMesh[int]
+        assert alias is ValueMesh
+
+    def test_receiver_runtime_subscript(self) -> None:
+        """Receiver[T] works at runtime (not just under TYPE_CHECKING)."""
+        alias = Receiver[int]
+        assert alias is Receiver


### PR DESCRIPTION
Summary:
Rust-backed classes decorated with `rust_struct` that inherit from
`Generic[T]` in their Python stub lose `__class_getitem__` because the
decorator replaces the Python class with the Rust class. This causes
`TypeError: type 'ValueMesh' is not subscriptable` when code uses
`ValueMesh[T]` at runtime (outside of `TYPE_CHECKING` blocks).

Fix: in `PatchRustClass.__call__`, if the Python class has
`__class_getitem__` but the Rust class does not, attach a trivial
`__class_getitem__` that returns the class unchanged. This makes
`ValueMesh[int]`, `Receiver[Msg]`, etc. work at runtime just like
regular generic Python classes.

Differential Revision: D93805610


