### PR TITLE
[ROCm][CI] Change runner for ROCm build workflow

### DIFF
--- a/.github/workflows/build-rocm.yml
+++ b/.github/workflows/build-rocm.yml
@@ -29,7 +29,7 @@ jobs:
             torch-spec: 'torch --extra-index-url https://download.pytorch.org/whl/nightly/rocm7.2/'
     with:
       timeout: 60
-      runner: linux.rocm.gpu.gfx942.1.meta-pytorch
+      runner: linux.c7i.2xlarge
       gpu-arch-type: rocm
       gpu-arch-version: ${{ matrix.name }}
       submodules: recursive

--- a/.github/workflows/build-rocm.yml
+++ b/.github/workflows/build-rocm.yml
@@ -30,7 +30,7 @@ jobs:
     with:
       timeout: 60
       runner: linux.c7i.2xlarge
-      docker-image: pytorch/almalinux-builder:${{ matrix.name }}
+      docker-image: pytorch/almalinux-builder:rocm${{ matrix.name }}
       submodules: recursive
       upload-artifact: monarch-rocm${{ matrix.name }}-${{ github.sha }}
       script: |

--- a/.github/workflows/build-rocm.yml
+++ b/.github/workflows/build-rocm.yml
@@ -30,8 +30,7 @@ jobs:
     with:
       timeout: 60
       runner: linux.c7i.2xlarge
-      gpu-arch-type: rocm
-      gpu-arch-version: ${{ matrix.name }}
+      docker-image: pytorch/almalinux-builder:${{ matrix.name }}
       submodules: recursive
       upload-artifact: monarch-rocm${{ matrix.name }}-${{ github.sha }}
       script: |


### PR DESCRIPTION
`ci.yml` gets [triggered on `pull_request`](https://github.com/meta-pytorch/monarch/blob/b0e32ebe597873196cb02b49ed35fd22eb8d8da6/.github/workflows/ci.yml#L4), which then runs the `build-rocm.yml` workflow on a ROCm runner. However, since the PR branch may not be on `meta-pytorch/monarch`, OIDC login for AWS credentials doesn't work. E.g. [this build](https://github.com/meta-pytorch/monarch/actions/runs/22368457701/job/64740843841?fbclid=IwY2xjawQK6MFleHRuA2FlbQIxMQBicmlkETFCbDBiTjZZWTdvS0hPNHZZc3J0YwZhcHBfaWQBMAABHnuazVWHOFQJoYDDB9wt5JGyLSJYLhadXMJ0ymqCj2GJaE7z-xNeIuUAYMx4_aem_LTi916bH4jh8qmBvxKT7oA)

Also, the build shouldn't need a GPU runner; it just needs a docker image with ROCm installed. Hence this PR switches to a CPU-only runner.

Fixes issue related to https://github.com/meta-pytorch/monarch/pull/2761 and https://github.com/meta-pytorch/monarch/pull/2694