### PR TITLE
Refactor pickling to use thread-local Rust storage

### DIFF
--- a/monarch_extension/src/lib.rs
+++ b/monarch_extension/src/lib.rs
@@ -141,6 +141,11 @@ pub fn mod_init(module: &Bound<'_, PyModule>) -> PyResult<()> {
         "monarch_hyperactor.actor",
     )?)?;
 
+    monarch_hyperactor::pickle::register_python_bindings(&get_or_add_new_module(
+        module,
+        "monarch_hyperactor.pickle",
+    )?)?;
+
     monarch_hyperactor::pytokio::register_python_bindings(&get_or_add_new_module(
         module,
         "monarch_hyperactor.pytokio",

--- a/monarch_hyperactor/src/actor.rs
+++ b/monarch_hyperactor/src/actor.rs
@@ -47,10 +47,8 @@ use ndslice::extent;
 use pyo3::IntoPyObjectExt;
 use pyo3::exceptions::PyBaseException;
 use pyo3::exceptions::PyRuntimeError;
-use pyo3::exceptions::PyTypeError;
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
-use pyo3::types::PyBytes;
 use pyo3::types::PyDict;
 use pyo3::types::PyList;
 use pyo3::types::PyType;
@@ -60,7 +58,6 @@ use serde_multipart::Part;
 use tokio::sync::oneshot;
 use typeuri::Named;
 
-use crate::buffers::Buffer;
 use crate::buffers::FrozenBuffer;
 use crate::config::ACTOR_QUEUE_DISPATCH;
 use crate::config::SHARED_ASYNCIO_RUNTIME;
@@ -77,7 +74,6 @@ use crate::metrics::ENDPOINT_ACTOR_LATENCY_US_HISTOGRAM;
 use crate::metrics::ENDPOINT_ACTOR_PANIC;
 use crate::proc::PyActorId;
 use crate::pympsc;
-use crate::pytokio::PendingPickleState;
 use crate::pytokio::PythonTask;
 use crate::runtime::get_proc_runtime;
 use crate::runtime::get_tokio_runtime;
@@ -164,22 +160,12 @@ fn mailbox<'py, T: Actor>(py: Python<'py>, cx: &Context<'_, T>) -> Bound<'py, Py
 }
 
 #[pyclass(frozen, module = "monarch._rust_bindings.monarch_hyperactor.actor")]
-#[derive(Clone, Serialize, Deserialize, Named, Default)]
+#[derive(Clone, Serialize, Deserialize, Named, Default, PartialEq)]
 pub struct PythonMessage {
     pub kind: PythonMessageKind,
     pub message: Part,
-    #[serde(skip)]
-    pub pending_pickle_state: Option<PendingPickleState>,
 }
 
-impl PartialEq for PythonMessage {
-    fn eq(&self, other: &Self) -> bool {
-        self.kind == other.kind
-            && self.message == other.message
-            && self.pending_pickle_state.is_none() // PendingPickleState doesn't/can't implement PartialEq
-            && other.pending_pickle_state.is_none()
-    }
-}
 wirevalue::register_type!(PythonMessage);
 
 struct ResolvedCallMethod {
@@ -208,15 +194,10 @@ pub struct QueuedMessage {
 }
 
 impl PythonMessage {
-    pub fn new_from_buf(
-        kind: PythonMessageKind,
-        message: impl Into<Part>,
-        pending_pickle_state: Option<PendingPickleState>,
-    ) -> Self {
+    pub fn new_from_buf(kind: PythonMessageKind, message: impl Into<Part>) -> Self {
         Self {
             kind,
             message: message.into(),
-            pending_pickle_state,
         }
     }
 
@@ -226,12 +207,10 @@ impl PythonMessage {
             PythonMessageKind::Result { .. } => PythonMessage {
                 kind: PythonMessageKind::Result { rank },
                 message: self.message,
-                pending_pickle_state: self.pending_pickle_state,
             },
             PythonMessageKind::Exception { .. } => PythonMessage {
                 kind: PythonMessageKind::Exception { rank },
                 message: self.message,
-                pending_pickle_state: self.pending_pickle_state,
             },
             _ => panic!("PythonMessage is not a response but {:?}", self),
         }
@@ -287,13 +266,7 @@ impl PythonMessage {
                 response_port,
             } => {
                 monarch_with_gil(|py| {
-                    let mailbox = mailbox(py, cx);
-                    let local_state = py
-                        .import("itertools")
-                        .unwrap()
-                        .call_method1("repeat", (mailbox.clone(),))
-                        .unwrap()
-                        .unbind();
+                    let local_state: Py<PyAny> = PyList::empty(py).unbind().into();
                     let instance: PyInstance = cx.into();
                     let response_port = response_port
                         .map_or_else(
@@ -363,29 +336,9 @@ impl Bind for PythonMessage {
 #[pymethods]
 impl PythonMessage {
     #[new]
-    #[pyo3(signature = (kind, message, pending_pickle_state=None))]
-    pub fn new<'py>(
-        kind: PythonMessageKind,
-        message: Bound<'py, PyAny>,
-        pending_pickle_state: Option<PendingPickleState>,
-    ) -> PyResult<Self> {
-        if let Ok(mut buff) = message.extract::<PyRefMut<'py, Buffer>>() {
-            return Ok(PythonMessage::new_from_buf(
-                kind,
-                buff.take_part(),
-                pending_pickle_state,
-            ));
-        } else if let Ok(buff) = message.extract::<Bound<'py, PyBytes>>() {
-            return Ok(PythonMessage::new_from_buf(
-                kind,
-                Vec::from(buff.as_bytes()),
-                pending_pickle_state,
-            ));
-        }
-
-        Err(PyTypeError::new_err(
-            "PythonMessage(buff) takes Buffer or bytes objects only",
-        ))
+    #[pyo3(signature = (kind, message))]
+    pub fn new<'py>(kind: PythonMessageKind, message: PyRef<'py, FrozenBuffer>) -> PyResult<Self> {
+        Ok(PythonMessage::new_from_buf(kind, message.inner.clone()))
     }
 
     #[getter]
@@ -552,17 +505,18 @@ impl PythonActor {
             PickledPyObject::pickle(&actor_mesh_mod.getattr("_Actor").expect("get _Actor"))
                 .expect("pickle _Actor");
 
-        let init_message = PythonMessage::new(
+        let init_frozen_buffer: FrozenBuffer = root_client_class
+            .call_method0("_pickled_init_args")
+            .expect("call RootClientActor._pickled_init_args")
+            .extract()
+            .expect("extract FrozenBuffer from _pickled_init_args");
+        let init_message = PythonMessage::new_from_buf(
             PythonMessageKind::CallMethod {
                 name: MethodSpecifier::Init {},
                 response_port: None,
             },
-            root_client_class
-                .call_method0("_pickled_init_args")
-                .expect("call RootClientActor._pickled_init_args"),
-            None,
-        )
-        .expect("create RootClientActor init message");
+            init_frozen_buffer,
+        );
 
         let mut actor = PythonActor::new(
             actor_type,
@@ -1465,7 +1419,6 @@ mod tests {
                 response_port: Some(EitherPortRef::Unbounded(port_ref.clone().into())),
             },
             message: Part::from(vec![1, 2, 3]),
-            pending_pickle_state: None,
         };
         {
             let mut erased = ErasedUnbound::try_from_message(message.clone()).unwrap();

--- a/monarch_hyperactor/src/lib.rs
+++ b/monarch_hyperactor/src/lib.rs
@@ -27,6 +27,7 @@ pub mod mailbox;
 pub mod metrics;
 pub mod namespace;
 pub mod ndslice;
+pub mod pickle;
 pub mod proc;
 pub mod proc_launcher;
 pub mod proc_launcher_probe;

--- a/monarch_hyperactor/src/mailbox.rs
+++ b/monarch_hyperactor/src/mailbox.rs
@@ -53,7 +53,6 @@ use crate::pytokio::PyPythonTask;
 use crate::pytokio::PythonTask;
 use crate::runtime::monarch_with_gil;
 use crate::runtime::monarch_with_gil_blocking;
-use crate::runtime::signal_safe_block_on;
 
 #[derive(Clone, Debug)]
 #[pyclass(
@@ -258,8 +257,6 @@ impl PythonPortHandle {
 #[pymethods]
 impl PythonPortHandle {
     fn send(&self, instance: &PyInstance, message: PythonMessage) -> PyResult<()> {
-        let message = resolve_pending_pickle_blocking(message)?;
-
         self.inner
             .send(instance.deref(), message)
             .map_err(|err| PyErr::new::<PyEOFError, _>(format!("Port closed: {}", err)))?;
@@ -298,8 +295,6 @@ impl PythonPortRef {
     }
 
     fn send(&self, instance: &PyInstance, message: PythonMessage) -> PyResult<()> {
-        let message = resolve_pending_pickle_blocking(message)?;
-
         self.inner
             .send(instance.deref(), message)
             .map_err(|err| PyErr::new::<PyEOFError, _>(format!("Port closed: {}", err)))?;
@@ -439,9 +434,6 @@ impl PythonOncePortHandle {
         let Some(port) = self.inner.take() else {
             return Err(PyErr::new::<PyValueError, _>("OncePort is already used"));
         };
-
-        let message = resolve_pending_pickle_blocking(message)?;
-
         port.send(instance.deref(), message)
             .map_err(|err| PyErr::new::<PyEOFError, _>(format!("Port closed: {}", err)))?;
         Ok(())
@@ -488,9 +480,6 @@ impl PythonOncePortRef {
         let Some(port_ref) = self.inner.take() else {
             return Err(PyErr::new::<PyValueError, _>("OncePortRef is already used"));
         };
-
-        let message = resolve_pending_pickle_blocking(message)?;
-
         port_ref
             .send(instance.deref(), message)
             .map_err(|err| PyErr::new::<PyEOFError, _>(format!("Port closed: {}", err)))?;
@@ -603,8 +592,6 @@ impl EitherPortRef {
         cx: &impl hyperactor::context::Actor,
         message: crate::actor::PythonMessage,
     ) -> anyhow::Result<()> {
-        let message = resolve_pending_pickle_blocking(message)?;
-
         match self {
             EitherPortRef::Unbounded(port_ref) => port_ref.inner.send(cx, message)?,
             EitherPortRef::Once(once_port_ref) => {
@@ -712,24 +699,6 @@ inventory::submit! {
 }
 
 py_global!(point, "monarch._src.actor.actor_mesh", "Point");
-
-fn resolve_pending_pickle_blocking(mut message: PythonMessage) -> PyResult<PythonMessage> {
-    // TODO(slurye): Cleanly handle PendingPickle objects sent directly over ports. This is new
-    // code but it isn't a regression -- PendingPickle objects are only created for objects that,
-    // in earlier commits, either (a) already had to be awaited explicitly in the tokio runtime
-    // before pickling, or (b) already had to be explicitly blocked on outside the tokio runtime
-    // before pickling. Any use case that worked before should still work now.
-    if let Some(pending_pickle_state) = message.pending_pickle_state.take() {
-        message.message = Python::attach(|py| {
-            signal_safe_block_on(
-                py,
-                pending_pickle_state.resolve(message.message.into_bytes()),
-            )
-        })??;
-    }
-
-    Ok(message)
-}
 
 pub fn register_python_bindings(hyperactor_mod: &Bound<'_, PyModule>) -> PyResult<()> {
     hyperactor_mod.add_class::<PyMailbox>()?;

--- a/monarch_hyperactor/src/pickle.rs
+++ b/monarch_hyperactor/src/pickle.rs
@@ -1,0 +1,583 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+//! Deferred pickling support for Monarch.
+//!
+//! This module provides utilities for deferring the pickling of objects
+//! that contain async values (futures/tasks) that must be resolved before
+//! the final pickle can be produced.
+
+use std::cell::RefCell;
+use std::collections::VecDeque;
+
+use monarch_types::py_global;
+use pyo3::prelude::*;
+use pyo3::types::PyList;
+use pyo3::types::PyTuple;
+
+use crate::actor::PythonMessage;
+use crate::actor::PythonMessageKind;
+use crate::buffers::Buffer;
+use crate::pytokio::PyShared;
+
+// Python helper used to reconstruct an object graph from a pickled
+// buffer plus a list of "unflatten values" (including placeholders).
+py_global!(unflatten, "monarch._src.actor.pickle", "unflatten");
+
+// Python helper used to pickle an object graph, optionally using a
+// filter to replace certain values with placeholders (e.g.
+// `PendingPickle`).
+//
+// We use `flatten`/`unflatten` to support "deferred pickling":
+// initially pickle with placeholders, then later resolve futures and
+// re-pickle with concrete values.
+py_global!(flatten, "monarch._src.actor.pickle", "flatten");
+
+// cloudpickle module for serialization
+py_global!(cloudpickle, "cloudpickle", "cloudpickle");
+
+// Importing monarch._src.actor.pickle applies a monkeypatch to cloudpickle
+// that injects RemoteImportLoader into pickled function globals, enabling
+// source loading for pickle-by-value code on remote hosts (needed for
+// debugger and tracebacks). We access this before pickling to ensure
+// the monkeypatch is applied.
+py_global!(
+    pickle_monkeypatch,
+    "monarch._src.actor.pickle",
+    "_function_getstate"
+);
+
+// Check if torch has been loaded into the current Python process.
+// Returns the torch module if loaded, otherwise None.
+py_global!(maybe_torch_fn, "monarch._src.actor.pickle", "maybe_torch");
+
+// Torch-aware dump function: uses a Pickler subclass with dispatch_table
+// entries for torch storage types (UntypedStorage, TypedStorage, etc.).
+py_global!(torch_dump_fn, "monarch._src.actor.pickle", "torch_dump");
+
+// Torch-aware loads function: wraps cloudpickle.loads with
+// torch.utils._python_dispatch._disable_current_modes().
+py_global!(torch_loads_fn, "monarch._src.actor.pickle", "torch_loads");
+
+// Shared class for pickling PyShared values
+py_global!(
+    shared_class,
+    "monarch._rust_bindings.monarch_hyperactor.pytokio",
+    "Shared"
+);
+
+// pop_pending_pickle function for unpickling deferred PyShared values
+py_global!(
+    pop_pending_pickle_fn,
+    "monarch._rust_bindings.monarch_hyperactor.pickle",
+    "pop_pending_pickle"
+);
+
+// Thread-local storage for the active pickling state.
+// Set by pickle/unpickle operations so free functions used in __reduce__
+// implementations can access it.
+thread_local! {
+    static ACTIVE_PICKLING_STATE: RefCell<Option<ActivePicklingState>> = const { RefCell::new(None) };
+}
+
+/// RAII guard that sets the thread-local `ACTIVE_PICKLING_STATE` on creation
+/// and restores the previous state (if any) on drop. This supports nesting:
+/// if a guard already exists, the new guard saves the old state and restores
+/// it when dropped, even on panic.
+struct ActivePicklingGuard {
+    previous: Option<ActivePicklingState>,
+}
+
+impl ActivePicklingGuard {
+    /// Set `state` as the active pickling state, saving any existing state.
+    fn enter(state: ActivePicklingState) -> Self {
+        let previous = ACTIVE_PICKLING_STATE.with(|cell| cell.borrow_mut().replace(state));
+        Self { previous }
+    }
+}
+
+impl Drop for ActivePicklingGuard {
+    fn drop(&mut self) {
+        ACTIVE_PICKLING_STATE.with(|cell| {
+            *cell.borrow_mut() = self.previous.take();
+        });
+    }
+}
+
+/// State maintained during active pickling/unpickling operations.
+///
+/// This is the thread-local state used while cloudpickle is running.
+/// It collects tensor engine references and pending pickles during serialization.
+struct ActivePicklingState {
+    /// References to tensor engine objects that need special handling.
+    tensor_engine_references: VecDeque<Py<PyAny>>,
+    /// Pending pickles (PyShared values) that must be resolved.
+    pending_pickles: VecDeque<Py<PyShared>>,
+    /// Whether pending pickles are allowed in this pickling context.
+    allow_pending_pickles: bool,
+    /// Whether tensor engine references are allowed in this pickling context.
+    allow_tensor_engine_references: bool,
+}
+
+impl ActivePicklingState {
+    /// Create a new ActivePicklingState.
+    fn new(allow_pending_pickles: bool, allow_tensor_engine_references: bool) -> Self {
+        Self {
+            tensor_engine_references: VecDeque::new(),
+            pending_pickles: VecDeque::new(),
+            allow_pending_pickles,
+            allow_tensor_engine_references,
+        }
+    }
+
+    /// Convert this active state into a frozen PicklingState.
+    fn into_pickling_state(self, buffer: crate::buffers::FrozenBuffer) -> PicklingStateInner {
+        PicklingStateInner {
+            buffer,
+            tensor_engine_references: self.tensor_engine_references,
+            pending_pickles: self.pending_pickles,
+        }
+    }
+}
+
+/// Inner data for a completed pickling operation.
+///
+/// This contains the frozen pickled bytes and any collected references.
+/// Does not require GIL for access to the FrozenBuffer.
+pub struct PicklingStateInner {
+    /// The pickled bytes as a FrozenBuffer (zero-copy).
+    buffer: crate::buffers::FrozenBuffer,
+    /// References to tensor engine objects that need special handling.
+    tensor_engine_references: VecDeque<Py<PyAny>>,
+    /// Pending pickles (PyShared values) that must be resolved.
+    pending_pickles: VecDeque<Py<PyShared>>,
+}
+
+impl PicklingStateInner {
+    /// Get a reference to the pending pickles.
+    pub fn pending_pickles(&self) -> &VecDeque<Py<PyShared>> {
+        &self.pending_pickles
+    }
+
+    /// Take the FrozenBuffer (pickled bytes) from this inner state.
+    pub fn take_buffer(self) -> crate::buffers::FrozenBuffer {
+        self.buffer
+    }
+}
+
+/// Python-visible wrapper for the result of a pickling operation.
+///
+/// Contains the pickled bytes and any tensor engine references or pending
+/// pickles that were collected during serialization.
+#[pyclass(module = "monarch._rust_bindings.monarch_hyperactor.pickle")]
+pub struct PicklingState {
+    inner: Option<PicklingStateInner>,
+}
+
+impl PicklingState {
+    pub fn take_inner(&mut self) -> PyResult<PicklingStateInner> {
+        self.inner.take().ok_or_else(|| {
+            pyo3::exceptions::PyRuntimeError::new_err("PicklingState has already been consumed")
+        })
+    }
+
+    fn inner_ref(&self) -> PyResult<&PicklingStateInner> {
+        self.inner.as_ref().ok_or_else(|| {
+            pyo3::exceptions::PyRuntimeError::new_err("PicklingState has already been consumed")
+        })
+    }
+}
+
+#[pymethods]
+impl PicklingState {
+    /// Create a new PicklingState from a buffer and optional tensor engine references.
+    ///
+    /// This is used for unpickling received messages that may contain tensor engine
+    /// references that need to be restored during deserialization.
+    #[new]
+    #[pyo3(signature = (buffer, tensor_engine_references=None))]
+    fn py_new(
+        buffer: PyRef<'_, crate::buffers::FrozenBuffer>,
+        tensor_engine_references: Option<&Bound<'_, PyList>>,
+    ) -> PyResult<Self> {
+        let refs: VecDeque<Py<PyAny>> = tensor_engine_references
+            .map(|list| list.iter().map(|item| item.unbind()).collect())
+            .unwrap_or_default();
+
+        Ok(Self {
+            inner: Some(PicklingStateInner {
+                buffer: buffer.clone(),
+                tensor_engine_references: refs,
+                pending_pickles: VecDeque::new(),
+            }),
+        })
+    }
+
+    /// Get a copy of all tensor engine references from this pickling state.
+    ///
+    /// Returns a Python list containing copies of the tensor engine references.
+    fn tensor_engine_references(&self, py: Python<'_>) -> PyResult<Py<PyList>> {
+        let inner = self.inner_ref()?;
+        let refs: Vec<Py<PyAny>> = inner
+            .tensor_engine_references
+            .iter()
+            .map(|r| r.clone_ref(py))
+            .collect();
+        Ok(PyList::new(py, refs)?.unbind())
+    }
+
+    /// Get the buffer from this pickling state.
+    ///
+    /// Returns a FrozenBuffer containing the pickled bytes.
+    /// This does not consume the PicklingState.
+    fn buffer(&self) -> PyResult<crate::buffers::FrozenBuffer> {
+        let inner = self.inner_ref()?;
+        Ok(inner.buffer.clone())
+    }
+
+    /// Unpickle the buffer contents.
+    ///
+    /// This consumes the PicklingState. It will fail if there are any pending
+    /// pickles that haven't been resolved.
+    fn unpickle(&mut self, py: Python<'_>) -> PyResult<Py<PyAny>> {
+        let inner = self.take_inner()?;
+
+        // Verify all pending pickles are resolved before unpickling
+        for pending in &inner.pending_pickles {
+            if pending.borrow(py).poll()?.is_none() {
+                return Err(pyo3::exceptions::PyRuntimeError::new_err(
+                    "Cannot unpickle: there are unresolved pending pickles",
+                ));
+            }
+        }
+
+        // Set up an active state for unpickling (to handle pop calls).
+        // The guard restores any previous state on drop (including on panic).
+        let mut active = ActivePicklingState::new(false, false);
+        active.pending_pickles = inner.pending_pickles;
+        active.tensor_engine_references = inner.tensor_engine_references;
+
+        let _guard = ActivePicklingGuard::enter(active);
+
+        // Unpickle the object. If torch is loaded, use torch_loads which
+        // disables dispatch modes during unpickling.
+        let result = if maybe_torch_fn(py).call0()?.is_truthy()? {
+            torch_loads_fn(py).call1((inner.buffer,))
+        } else {
+            cloudpickle(py).getattr("loads")?.call1((inner.buffer,))
+        };
+
+        result.map(|obj| obj.unbind())
+    }
+}
+
+impl PicklingState {
+    /// Resolve all pending pickles and return a new PicklingState without pending pickles.
+    ///
+    /// This consumes the PicklingState. It:
+    /// 1. If there are no pending pickles, returns self immediately
+    /// 2. Otherwise, awaits all pending pickles until they're finished
+    /// 3. Calls unpickle to reconstruct the object
+    /// 4. Calls pickle again to get a new PicklingState without pending pickles
+    pub async fn resolve(mut self) -> PyResult<PicklingState> {
+        // Short-circuit if there are no pending pickles
+        if self.inner_ref()?.pending_pickles.is_empty() {
+            return Ok(self);
+        }
+
+        // Await all pending pickles to ensure they're resolved
+        let pending: Vec<Py<PyShared>> = Python::attach(|py| {
+            self.inner_ref().map(|inner| {
+                inner
+                    .pending_pickles
+                    .iter()
+                    .map(|p| p.clone_ref(py))
+                    .collect()
+            })
+        })?;
+
+        for pending_pickle in pending {
+            let mut task = Python::attach(|py| pending_pickle.borrow(py).task())?;
+            task.take_task()?.await?;
+        }
+
+        // Unpickle (pending pickles are now resolved) and re-pickle without allowing new ones
+        Python::attach(|py| {
+            let obj = self.unpickle(py)?;
+            pickle(py, obj, false, true)
+        })
+    }
+}
+
+/// A message that is pending resolution of async values before it can be sent.
+///
+/// Contains a `PythonMessageKind` and a `PicklingState`. The `PicklingState` may contain
+/// pending pickles (unresolved async values) that must be resolved before the message
+/// can be converted into a `PythonMessage`.
+#[pyclass(module = "monarch._rust_bindings.monarch_hyperactor.pickle")]
+pub struct PendingMessage {
+    pub(crate) kind: PythonMessageKind,
+    state: PicklingState,
+}
+
+impl PendingMessage {
+    /// Create a new PendingMessage from a kind and pickling state.
+    pub fn new(kind: PythonMessageKind, state: PicklingState) -> Self {
+        Self { kind, state }
+    }
+
+    /// Take ownership of the inner state from a mutable reference.
+    ///
+    /// This is used by pyo3 pymethods that receive `&mut PendingMessage`
+    /// but need to pass ownership to the trait method.
+    pub fn take(&mut self) -> PyResult<PendingMessage> {
+        let inner = self.state.take_inner()?;
+        Ok(PendingMessage {
+            kind: std::mem::take(&mut self.kind),
+            state: PicklingState { inner: Some(inner) },
+        })
+    }
+
+    /// Resolve all pending pickles and convert this into a PythonMessage.
+    ///
+    /// This is an async method that:
+    /// 1. Awaits all pending pickles in the PicklingState
+    /// 2. Re-pickles the resolved object
+    /// 3. Returns a PythonMessage with the resolved bytes (no GIL needed for final step)
+    pub async fn resolve(self) -> PyResult<PythonMessage> {
+        // Resolve the pickling state (awaits all pending pickles and re-pickles)
+        let mut resolved_state = self.state.resolve().await?;
+
+        // Take the FrozenBuffer directly - no GIL needed since FrozenBuffer doesn't contain Py<>
+        let inner = resolved_state.take_inner()?;
+        Ok(PythonMessage::new_from_buf(self.kind, inner.take_buffer()))
+    }
+}
+
+#[pymethods]
+impl PendingMessage {
+    /// Create a new PendingMessage from a kind and pickling state.
+    #[new]
+    pub fn py_new(
+        kind: PythonMessageKind,
+        mut state: PyRefMut<'_, PicklingState>,
+    ) -> PyResult<Self> {
+        // Take the inner state from the PicklingState
+        let inner = state.take_inner()?;
+        Ok(Self {
+            kind,
+            state: PicklingState { inner: Some(inner) },
+        })
+    }
+
+    /// Get the message kind.
+    #[getter]
+    fn kind(&self) -> PythonMessageKind {
+        self.kind.clone()
+    }
+}
+
+/// Push a tensor engine reference to the active pickling state if one is active.
+///
+/// This is called from Python during pickling when a tensor engine object
+/// is encountered that needs special handling.
+///
+/// Returns False if there is no active pickling state.
+/// Returns True if the reference was successfully pushed.
+/// Raises an error if tensor engine references are not allowed in the current pickling context.
+#[pyfunction]
+fn push_tensor_engine_reference_if_active(obj: Py<PyAny>) -> PyResult<bool> {
+    ACTIVE_PICKLING_STATE.with(|cell| {
+        let mut state = cell.borrow_mut();
+        match state.as_mut() {
+            Some(s) => {
+                if !s.allow_tensor_engine_references {
+                    return Err(pyo3::exceptions::PyRuntimeError::new_err(
+                        "Tensor engine references are not allowed in the current pickling context",
+                    ));
+                }
+                s.tensor_engine_references.push_back(obj);
+                Ok(true)
+            }
+            None => Ok(false),
+        }
+    })
+}
+
+/// Pop a tensor engine reference from the active pickling state.
+///
+/// This is called from Python during unpickling to retrieve tensor engine
+/// objects in the order they were pushed.
+#[pyfunction]
+fn pop_tensor_engine_reference(py: Python<'_>) -> PyResult<Py<PyAny>> {
+    ACTIVE_PICKLING_STATE
+        .with(|cell| {
+            let mut state = cell.borrow_mut();
+            match state.as_mut() {
+                Some(s) => s.tensor_engine_references.pop_front().ok_or_else(|| {
+                    pyo3::exceptions::PyRuntimeError::new_err(
+                        "No tensor engine references remaining",
+                    )
+                }),
+                None => Err(pyo3::exceptions::PyRuntimeError::new_err(
+                    "No active pickling state",
+                )),
+            }
+        })
+        .map(|obj| obj.clone_ref(py))
+}
+
+/// Pop a pending pickle from the active pickling state.
+///
+/// This is called from Python during unpickling to retrieve the PyShared
+/// object that was deferred during pickling.
+#[pyfunction]
+fn pop_pending_pickle(py: Python<'_>) -> PyResult<Py<PyShared>> {
+    ACTIVE_PICKLING_STATE.with(|cell| {
+        let mut state = cell.borrow_mut();
+        match state.as_mut() {
+            Some(s) => {
+                let shared = s.pending_pickles.pop_front().ok_or_else(|| {
+                    pyo3::exceptions::PyRuntimeError::new_err("No pending pickles remaining")
+                })?;
+                Ok(shared.clone_ref(py))
+            }
+            None => Err(pyo3::exceptions::PyRuntimeError::new_err(
+                "No active pickling state",
+            )),
+        }
+    })
+}
+
+/// Push a pending pickle to the active pickling state (Rust-only).
+///
+/// This is used by __reduce__ implementations to register a PyShared
+/// that must be resolved before the pickle is complete.
+///
+/// Returns an error if there is no active pickling state or if pending
+/// pickles are not allowed in the current pickling context.
+pub fn push_pending_pickle(py_shared: Py<PyShared>) -> PyResult<()> {
+    ACTIVE_PICKLING_STATE.with(|cell| {
+        let mut state = cell.borrow_mut();
+        match state.as_mut() {
+            Some(s) => {
+                if !s.allow_pending_pickles {
+                    return Err(pyo3::exceptions::PyRuntimeError::new_err(
+                        "Pending pickles are not allowed in the current pickling context",
+                    ));
+                }
+                s.pending_pickles.push_back(py_shared);
+                Ok(())
+            }
+            None => Err(pyo3::exceptions::PyRuntimeError::new_err(
+                "No active pickling state",
+            )),
+        }
+    })
+}
+
+/// Reduce a PyShared for pickling.
+///
+/// This function implements the pickle protocol for PyShared:
+/// 1. If the shared is already finished, return (Shared.from_value, (value,))
+/// 2. If pending pickles are allowed, push it as a pending pickle and return (pop_pending_pickle, ())
+/// 3. Otherwise, block on the shared and return (Shared.from_value, (value,))
+pub fn reduce_shared<'py>(
+    py: Python<'py>,
+    py_shared: &Bound<'py, PyShared>,
+) -> PyResult<(Bound<'py, PyAny>, Bound<'py, PyTuple>)> {
+    // First, check if the shared is already finished
+    if let Some(value) = py_shared.borrow().poll()? {
+        let from_value = shared_class(py).getattr("from_value")?;
+        let args = PyTuple::new(py, [value])?;
+        return Ok((from_value, args));
+    }
+
+    // Try to push as a pending pickle (will fail if not allowed or no active state)
+    let py_shared_py: Py<PyShared> = py_shared.clone().unbind();
+    if push_pending_pickle(py_shared_py).is_ok() {
+        let pop_fn = pop_pending_pickle_fn(py);
+        let args = PyTuple::empty(py);
+        return Ok((pop_fn, args));
+    }
+
+    // Fall back to blocking on the shared
+    let value = PyShared::block_on(py_shared.borrow(), py)?;
+    let from_value = shared_class(py).getattr("from_value")?;
+    let args = PyTuple::new(py, [value])?;
+    Ok((from_value, args))
+}
+
+/// Pickle an object with support for pending pickles and tensor engine references.
+///
+/// This function creates a PicklingState and calls cloudpickle.dumps with
+/// an active thread-local PicklingState, allowing __reduce__ implementations
+/// to push tensor engine references and pending pickles.
+///
+/// # Arguments
+/// * `obj` - The Python object to pickle
+/// * `allow_pending_pickles` - If true, allow PyShared values to be registered as pending
+/// * `allow_tensor_engine_references` - If true, allow tensor engine references to be registered
+///
+/// # Returns
+/// A PicklingState containing the pickled buffer and any registered references/pending pickles
+#[pyfunction]
+#[pyo3(signature = (obj, allow_pending_pickles=true, allow_tensor_engine_references=true))]
+pub fn pickle(
+    py: Python<'_>,
+    obj: Py<PyAny>,
+    allow_pending_pickles: bool,
+    allow_tensor_engine_references: bool,
+) -> PyResult<PicklingState> {
+    // Ensure the cloudpickle monkeypatch for RemoteImportLoader is applied.
+    pickle_monkeypatch(py);
+
+    let active = ActivePicklingState::new(allow_pending_pickles, allow_tensor_engine_references);
+    let buffer = Py::new(py, Buffer::default())?;
+
+    // Set up this state as the active pickling state.
+    // The guard saves any previous state and restores it on drop (including on panic).
+    let _guard = ActivePicklingGuard::enter(active);
+
+    // Get the Pickler class and create an instance with our buffer
+    // If torch is loaded, use the torch-aware pickler that handles
+    // torch storage types via dispatch_table.
+    if maybe_torch_fn(py).call0()?.is_truthy()? {
+        torch_dump_fn(py).call1((&obj, buffer.bind(py)))?;
+    } else {
+        let pickler = cloudpickle(py)
+            .getattr("Pickler")?
+            .call1((buffer.bind(py),))?;
+        pickler.call_method1("dump", (&obj,))?;
+    }
+
+    // Take the state (which may have been modified during pickling).
+    // The guard will restore the previous state on drop.
+    let active = ACTIVE_PICKLING_STATE
+        .with(|cell| cell.borrow_mut().take())
+        .expect("active pickling state should still be set");
+
+    // Convert to frozen PicklingState
+    let frozen_buffer = buffer.borrow_mut(py).freeze();
+    let inner = active.into_pickling_state(frozen_buffer);
+    Ok(PicklingState { inner: Some(inner) })
+}
+
+/// Register the pickle Python bindings into the given module.
+pub fn register_python_bindings(module: &Bound<'_, PyModule>) -> PyResult<()> {
+    module.add_class::<PicklingState>()?;
+    module.add_class::<PendingMessage>()?;
+    module.add_function(wrap_pyfunction!(pickle, module)?)?;
+    module.add_function(wrap_pyfunction!(
+        push_tensor_engine_reference_if_active,
+        module
+    )?)?;
+    module.add_function(wrap_pyfunction!(pop_tensor_engine_reference, module)?)?;
+    module.add_function(wrap_pyfunction!(pop_pending_pickle, module)?)?;
+    Ok(())
+}

--- a/monarch_hyperactor/src/proc_launcher_probe.rs
+++ b/monarch_hyperactor/src/proc_launcher_probe.rs
@@ -17,8 +17,6 @@
 //! `PythonMessage` envelope with `kind = Result` or `kind =
 //! Exception`?
 
-use hyperactor_mesh::sel;
-use ndslice::Selection;
 use pyo3::prelude::*;
 use pyo3::types::PyModule;
 use pyo3::types::PyModuleMethods;
@@ -30,6 +28,8 @@ use crate::actor_mesh::PythonActorMesh;
 use crate::context::PyInstance;
 use crate::mailbox::EitherPortRef;
 use crate::mailbox::PythonOncePortRef;
+use crate::pickle::PendingMessage;
+use crate::pickle::PicklingState;
 use crate::pytokio::PyPythonTask;
 
 /// Report describing what Rust received on the port.
@@ -56,10 +56,6 @@ pub struct ProbeReport {
     /// the message kind (if any).
     #[pyo3(get)]
     pub rank: Option<usize>,
-
-    /// Whether the message carried a pending pickle state.
-    #[pyo3(get)]
-    pub pending_pickle_state_present: Option<bool>,
 
     /// Length in bytes of the raw message payload.
     #[pyo3(get)]
@@ -89,7 +85,7 @@ pub fn register_python_bindings(module: &Bound<'_, PyModule>) -> PyResult<()> {
 /// This function:
 /// 1. Opens a `OncePort<PythonMessage>` from the given mailbox.
 /// 2. Sends a `CallMethod(ExplicitPort)` message to `method_name` via
-///    `actor_mesh_inner.cast(...)`.
+///    `actor_mesh_inner.cast_unresolved(...)`.
 /// 3. Awaits the first message received on the port.
 /// 4. Returns a `ProbeReport` describing what Rust observed.
 ///
@@ -102,17 +98,17 @@ pub fn register_python_bindings(module: &Bound<'_, PyModule>) -> PyResult<()> {
 /// - `instance`: The calling context's Rust instance handle.
 /// - `mailbox`: The mailbox used to allocate the response port.
 /// - `method_name`: Name of the Python endpoint to invoke.
-/// - `pickled_args`: Opaque serialized argument payload for the call.
+/// - `pickling_state`: The pickled arguments wrapped in a PicklingState.
 ///
 /// Returns:
 /// An awaitable task yielding a `ProbeReport`.
 #[pyfunction]
-#[pyo3(signature = (actor_mesh_inner, instance, method_name, pickled_args))]
+#[pyo3(signature = (actor_mesh_inner, instance, method_name, pickling_state))]
 pub(crate) fn probe_exit_port_via_mesh(
     actor_mesh_inner: &PythonActorMesh,
     instance: &PyInstance,
     method_name: String,
-    pickled_args: Vec<u8>,
+    pickling_state: PyRefMut<'_, PicklingState>,
 ) -> PyResult<PyPythonTask> {
     // Open a OncePort<PythonMessage> - this is what ActorProcLauncher
     // does
@@ -121,24 +117,20 @@ pub(crate) fn probe_exit_port_via_mesh(
         .get_inner()
         .open_once_port::<PythonMessage>();
 
-    // Build the PythonMessage with ExplicitPort
+    // Build the PythonMessageKind with ExplicitPort
     let bound_port = exit_port.bind();
-    let message = PythonMessage {
-        kind: PythonMessageKind::CallMethod {
-            name: MethodSpecifier::ExplicitPort {
-                name: method_name.clone(),
-            },
-            response_port: Some(EitherPortRef::Once(PythonOncePortRef::from(bound_port))),
+    let kind = PythonMessageKind::CallMethod {
+        name: MethodSpecifier::ExplicitPort {
+            name: method_name.clone(),
         },
-        message: pickled_args.into(),
-        pending_pickle_state: None,
+        response_port: Some(EitherPortRef::Once(PythonOncePortRef::from(bound_port))),
     };
 
-    // Cast to all actors in the mesh (should be just 1 for sliced
-    // mesh)
-    actor_mesh_inner
-        .get_inner()
-        .cast(message, sel!(*), &instance.clone().into_instance())?;
+    // Create a PendingMessage using py_new which takes PyRefMut
+    let mut pending_message = PendingMessage::py_new(kind, pickling_state)?;
+
+    // Cast to all actors in the mesh using cast_unresolved
+    actor_mesh_inner.cast_unresolved(&mut pending_message, "all", instance)?;
 
     // Return an awaitable task that receives the result
     PyPythonTask::new(async move {
@@ -161,7 +153,6 @@ pub(crate) fn probe_exit_port_via_mesh(
             received_type: "PythonMessage".to_string(),
             kind: Some(kind),
             rank,
-            pending_pickle_state_present: Some(msg.pending_pickle_state.is_some()),
             payload_len: payload.len(),
             payload_bytes: payload,
             error: None,

--- a/monarch_hyperactor/src/proc_mesh.rs
+++ b/monarch_hyperactor/src/proc_mesh.rs
@@ -25,12 +25,12 @@ use pyo3::types::PyBytes;
 use pyo3::types::PyType;
 
 use crate::actor::PythonActorParams;
-use crate::actor::PythonMessage;
 use crate::actor_mesh::PythonActorMesh;
 use crate::actor_mesh::PythonActorMeshImpl;
 use crate::actor_mesh::SupervisableActorMesh;
 use crate::alloc::PyAlloc;
 use crate::context::PyInstance;
+use crate::pickle::PendingMessage;
 use crate::pytokio::PyPythonTask;
 use crate::pytokio::PyShared;
 use crate::runtime::get_tokio_runtime;
@@ -102,20 +102,17 @@ impl PyProcMesh {
         instance: &PyInstance,
         name: String,
         actor: Py<PyType>,
-        mut init_message: PythonMessage,
+        init_message: &mut PendingMessage,
         emulated: bool,
         supervision_display_name: Option<String>,
     ) -> PyResult<Py<PyAny>> {
+        let init_message = init_message.take()?;
         let task = proc_mesh.task()?.take_task()?;
         let instance = instance.clone();
         let mesh_impl = async move {
             let proc_mesh = task.await?;
 
-            if let Some(pending_pickle_state) = init_message.pending_pickle_state.take() {
-                init_message.message = pending_pickle_state
-                    .resolve(init_message.message.into_bytes())
-                    .await?;
-            }
+            let init_message = init_message.resolve().await?;
 
             let (proc_mesh, params) = monarch_with_gil(|py| -> PyResult<_> {
                 let slf: Bound<PyProcMesh> = proc_mesh.extract(py)?;

--- a/monarch_tensor_worker/src/stream.rs
+++ b/monarch_tensor_worker/src/stream.rs
@@ -35,10 +35,10 @@ use hyperactor::mailbox::PortReceiver;
 use hyperactor::proc::Proc;
 use monarch_hyperactor::actor::PythonMessage;
 use monarch_hyperactor::actor::PythonMessageKind;
-use monarch_hyperactor::buffers::Buffer;
 use monarch_hyperactor::local_state_broker::BrokerId;
 use monarch_hyperactor::local_state_broker::LocalState;
 use monarch_hyperactor::local_state_broker::LocalStateBrokerMessage;
+use monarch_hyperactor::pickle::pickle;
 use monarch_messages::controller::ControllerMessageClient;
 use monarch_messages::controller::Seq;
 use monarch_messages::controller::WorkerError;
@@ -93,22 +93,16 @@ fn pickle_python_result(
     result: Bound<'_, PyAny>,
     worker_rank: usize,
 ) -> Result<PythonMessage, anyhow::Error> {
-    let pickle = py
-        .import("monarch._src.actor.actor_mesh")
-        .unwrap()
-        .getattr("_pickle")
-        .unwrap();
-    let mut data: Buffer = pickle
-        .call1((result,))
-        .map_err(|pyerr| anyhow::Error::from(SerializablePyErr::from(py, &pyerr)))?
-        .extract()
-        .unwrap();
+    let mut state = pickle(py, result.unbind(), false, false)
+        .map_err(|pyerr| anyhow::Error::from(SerializablePyErr::from(py, &pyerr)))?;
+    let inner = state
+        .take_inner()
+        .map_err(|pyerr| anyhow::Error::from(SerializablePyErr::from(py, &pyerr)))?;
     Ok(PythonMessage::new_from_buf(
         PythonMessageKind::Result {
             rank: Some(worker_rank),
         },
-        data.take_part(),
-        None,
+        inner.take_buffer(),
     ))
 }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,8 +14,7 @@ dynamic = ["version"]  # overridden via MONARCH_VERSION env var
 description = "Monarch: Single controller library"
 readme = "README.md"
 requires-python = ">=3.10"
-license = "BSD-3-Clause"
-license-files = ["LICENSE"]
+license = {text = "BSD-3-Clause"}
 authors = [
     {name = "Meta", email = "oncall+monarch@xmail.facebook.com"}
 ]

--- a/python/monarch/_rust_bindings/monarch_hyperactor/actor.pyi
+++ b/python/monarch/_rust_bindings/monarch_hyperactor/actor.pyi
@@ -23,8 +23,8 @@ from typing import (
 
 from monarch._rust_bindings.monarch_hyperactor.buffers import Buffer, FrozenBuffer
 from monarch._rust_bindings.monarch_hyperactor.mailbox import OncePortRef, PortRef
+from monarch._rust_bindings.monarch_hyperactor.pickle import PicklingState
 from monarch._rust_bindings.monarch_hyperactor.proc import ActorId, Proc, Serialized
-from monarch._rust_bindings.monarch_hyperactor.pytokio import PendingPickleState
 
 class PythonMessageKind:
     @classmethod
@@ -117,9 +117,16 @@ class PythonMessage:
     def __init__(
         self,
         kind: PythonMessageKind,
-        message: Union[Buffer, bytes],
-        pending_pickle_state: Optional[PendingPickleState] = None,
-    ) -> None: ...
+        message: FrozenBuffer,
+    ) -> None:
+        """
+        Create a PythonMessage.
+
+        Args:
+            kind: The message kind specifying the method to call.
+            message: The pickled arguments as a FrozenBuffer.
+        """
+        ...
     @property
     def message(self) -> FrozenBuffer:
         """The pickled arguments."""
@@ -178,7 +185,7 @@ class Actor(Protocol):
         method: MethodSpecifier,
         message: FrozenBuffer,
         panic_flag: PanicFlag,
-        local_state: Iterable[Any],
+        local_state: List[Any],
         response_port: PortProtocol[Any],
     ) -> None: ...
 

--- a/python/monarch/_rust_bindings/monarch_hyperactor/actor_mesh.pyi
+++ b/python/monarch/_rust_bindings/monarch_hyperactor/actor_mesh.pyi
@@ -10,6 +10,7 @@ from typing import final, Optional, Protocol
 
 from monarch._rust_bindings.monarch_hyperactor.actor import PythonMessage
 from monarch._rust_bindings.monarch_hyperactor.context import Instance
+from monarch._rust_bindings.monarch_hyperactor.pickle import PendingMessage
 from monarch._rust_bindings.monarch_hyperactor.proc import ActorId
 from monarch._rust_bindings.monarch_hyperactor.pytokio import PythonTask
 from monarch._rust_bindings.monarch_hyperactor.shape import Region
@@ -34,7 +35,18 @@ class ActorMeshProtocol(Protocol):
         message: PythonMessage,
         selection: str,
         instance: Instance,
-    ) -> None: ...
+    ) -> None:
+        """Cast an already-resolved PythonMessage to actors."""
+        ...
+
+    def cast_unresolved(
+        self,
+        message: PendingMessage,
+        selection: str,
+        instance: Instance,
+    ) -> None:
+        """Cast a PendingMessage (which may contain unresolved async values) to actors."""
+        ...
     def new_with_region(self, region: Region) -> Self: ...
     def stop(self, instance: Instance, reason: str) -> PythonTask[None]: ...
     def initialized(self) -> PythonTask[None]: ...

--- a/python/monarch/_rust_bindings/monarch_hyperactor/pickle.pyi
+++ b/python/monarch/_rust_bindings/monarch_hyperactor/pickle.pyi
@@ -1,0 +1,150 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from typing import Any, List
+
+from monarch._rust_bindings.monarch_hyperactor.actor import PythonMessageKind
+from monarch._rust_bindings.monarch_hyperactor.buffers import FrozenBuffer
+from monarch._rust_bindings.monarch_hyperactor.pytokio import Shared
+
+class PicklingState:
+    """
+    Result of a pickling operation.
+
+    Contains the pickled bytes and any tensor engine references or pending
+    pickles that were collected during serialization.
+    """
+
+    def __init__(
+        self,
+        buffer: FrozenBuffer,
+        tensor_engine_references: List[Any] | None = None,
+    ) -> None:
+        """
+        Create a new PicklingState from a buffer and optional tensor engine references.
+
+        This is used for unpickling received messages that may contain tensor engine
+        references that need to be restored during deserialization.
+
+        Args:
+            buffer: The pickled bytes as a FrozenBuffer.
+            tensor_engine_references: Optional list of tensor engine references
+                to restore during unpickling.
+        """
+        ...
+
+    def tensor_engine_references(self) -> List[Any]:
+        """
+        Get a copy of all tensor engine references from this pickling state.
+
+        Returns a list containing copies of the tensor engine references.
+        """
+        ...
+
+    def buffer(self) -> FrozenBuffer:
+        """
+        Get the buffer from this pickling state.
+
+        Returns a FrozenBuffer containing the pickled bytes.
+        This does not consume the PicklingState.
+        """
+        ...
+
+    def unpickle(self) -> Any:
+        """
+        Unpickle the buffer contents.
+
+        This consumes the PicklingState. It will fail if there are any pending
+        pickles that haven't been resolved.
+        """
+        ...
+
+class PendingMessage:
+    """
+    A message that is pending resolution of async values before it can be sent.
+
+    Contains a PythonMessageKind and a PicklingState. The PicklingState may contain
+    pending pickles (unresolved async values) that must be resolved before the message
+    can be converted into a PythonMessage.
+    """
+
+    def __init__(self, kind: PythonMessageKind, state: PicklingState) -> None:
+        """
+        Create a new PendingMessage from a kind and pickling state.
+
+        Note: This takes ownership of the PicklingState's inner state.
+        """
+        ...
+
+    @property
+    def kind(self) -> PythonMessageKind:
+        """Get the message kind."""
+        ...
+
+def pickle(
+    obj: Any,
+    allow_pending_pickles: bool = True,
+    allow_tensor_engine_references: bool = True,
+) -> PicklingState:
+    """
+    Pickle an object with support for pending pickles and tensor engine references.
+
+    Creates a PicklingState and calls cloudpickle.dumps with an active
+    thread-local pickling state, allowing __reduce__ implementations to push
+    tensor engine references and pending pickles.
+
+    Args:
+        obj: The Python object to pickle
+        allow_pending_pickles: If true, allow PyShared values to be registered as pending
+        allow_tensor_engine_references: If true, allow tensor engine references to be registered
+
+    Returns:
+        A PicklingState containing the pickled bytes and any registered references/pending pickles
+    """
+    ...
+
+def push_tensor_engine_reference_if_active(obj: Any) -> bool:
+    """
+    Push a tensor engine reference to the active pickling state if one is active.
+
+    Called from Python during pickling when a tensor engine object
+    is encountered that needs special handling.
+
+    Returns:
+        False if there is no active pickling state.
+        True if the reference was successfully pushed.
+
+    Raises:
+        RuntimeError: If tensor engine references are not allowed in the
+            current pickling context.
+    """
+    ...
+
+def pop_tensor_engine_reference() -> Any:
+    """
+    Pop a tensor engine reference from the active pickling state.
+
+    Called from Python during unpickling to retrieve tensor engine
+    objects in the order they were pushed.
+
+    Raises:
+        RuntimeError: If there is no active pickling state or no references remaining.
+    """
+    ...
+
+def pop_pending_pickle() -> Shared[Any]:
+    """
+    Pop a pending pickle from the active pickling state.
+
+    Called from Python during unpickling to retrieve the PyShared
+    object that was deferred during pickling.
+
+    Raises:
+        RuntimeError: If there is no active pickling state or no pending pickles remaining.
+    """
+    ...

--- a/python/monarch/_rust_bindings/monarch_hyperactor/proc_launcher_probe.pyi
+++ b/python/monarch/_rust_bindings/monarch_hyperactor/proc_launcher_probe.pyi
@@ -10,6 +10,7 @@ from typing import final
 
 from monarch._rust_bindings.monarch_hyperactor.actor_mesh import PythonActorMesh
 from monarch._rust_bindings.monarch_hyperactor.context import Instance
+from monarch._rust_bindings.monarch_hyperactor.pickle import PicklingState
 from monarch._rust_bindings.monarch_hyperactor.pytokio import PythonTask
 
 @final
@@ -32,11 +33,6 @@ class ProbeReport:
         ...
 
     @property
-    def pending_pickle_state_present(self) -> bool | None:
-        """If PythonMessage, whether pending_pickle_state was present."""
-        ...
-
-    @property
     def payload_len(self) -> int:
         """Length of the message payload bytes."""
         ...
@@ -55,7 +51,7 @@ def probe_exit_port_via_mesh(
     actor_mesh_inner: PythonActorMesh,
     instance: Instance,
     method_name: str,
-    pickled_args: bytes,
+    pickling_state: PicklingState,
 ) -> PythonTask[ProbeReport]:
     """Probe the wire format by calling an endpoint and receiving on a
     port."""

--- a/python/monarch/_rust_bindings/monarch_hyperactor/proc_mesh.pyi
+++ b/python/monarch/_rust_bindings/monarch_hyperactor/proc_mesh.pyi
@@ -13,6 +13,7 @@ if TYPE_CHECKING:
 from monarch._rust_bindings.monarch_hyperactor.actor_mesh import PythonActorMesh
 from monarch._rust_bindings.monarch_hyperactor.alloc import Alloc
 from monarch._rust_bindings.monarch_hyperactor.context import Instance
+from monarch._rust_bindings.monarch_hyperactor.pickle import PendingMessage
 from monarch._rust_bindings.monarch_hyperactor.pytokio import PythonTask, Shared
 from monarch._rust_bindings.monarch_hyperactor.shape import Region
 
@@ -39,7 +40,7 @@ class ProcMesh:
         instance: Instance,
         name: str,
         actor: Type["Actor"],
-        init_message: PythonMessage,
+        init_message: PendingMessage,
         emulated: bool,
         supervision_display_name: str | None = None,
     ) -> PythonActorMesh: ...

--- a/python/monarch/_rust_bindings/monarch_hyperactor/pytokio.pyi
+++ b/python/monarch/_rust_bindings/monarch_hyperactor/pytokio.pyi
@@ -13,7 +13,6 @@ from typing import (
     Coroutine,
     Generator,
     Generic,
-    List,
     Optional,
     Sequence,
     Tuple,
@@ -116,21 +115,3 @@ def is_tokio_thread() -> bool:
     Returns true if the current thread is a tokio worker thread (and block_on will fail).
     """
     ...
-
-class PendingPickle:
-    """
-    Represents an object that we are eventually going to pickle,
-    but we can't yet because it hasn't been fully initialized.
-    """
-    def __init__(self, fut: Shared[T]) -> None: ...
-
-class PendingPickleState:
-    """
-    A special class used to allow deferring the full pickling of an object.
-    It contains a list of objects that were returned by the filter in a call
-    to `flatten`, and the filter itself. Crucially, some of these objects
-    may be futures that need to be awaited in an asynchronous context.
-    """
-    def __init__(
-        self, unflatten_values: List[Any], flatten_filter: Callable[[Any], bool]
-    ) -> None: ...

--- a/python/monarch/_src/actor/host_mesh.py
+++ b/python/monarch/_src/actor/host_mesh.py
@@ -14,11 +14,7 @@ from monarch._rust_bindings.monarch_hyperactor.host_mesh import (
     HostMesh as HyHostMesh,
 )
 from monarch._rust_bindings.monarch_hyperactor.proc_mesh import ProcMesh as HyProcMesh
-from monarch._rust_bindings.monarch_hyperactor.pytokio import (
-    PendingPickle,
-    PythonTask,
-    Shared,
-)
+from monarch._rust_bindings.monarch_hyperactor.pytokio import PythonTask, Shared
 from monarch._rust_bindings.monarch_hyperactor.shape import Extent, Region
 from monarch._src.actor.actor_mesh import _Lazy, context
 from monarch._src.actor.allocator import (
@@ -28,7 +24,6 @@ from monarch._src.actor.allocator import (
     ProcessAllocator,
 )
 from monarch._src.actor.future import Future
-from monarch._src.actor.pickle import is_pending_pickle_allowed
 from monarch._src.actor.proc_mesh import _get_bootstrap_args, ProcMesh
 from monarch._src.actor.shape import MeshTrait, NDSlice, Shape
 from monarch.tools.config.workspace import Workspace
@@ -287,16 +282,12 @@ class HostMesh(MeshTrait):
         )
 
     def __reduce_ex__(self, protocol: ...) -> Tuple[Any, Tuple[Any, ...]]:
-        return HostMesh._from_initialized_hy_host_mesh, (
-            self._hy_host_mesh.poll()
-            or (
-                PendingPickle(self._hy_host_mesh)
-                if is_pending_pickle_allowed()
-                else self._hy_host_mesh.block_on()
-            ),
+        return HostMesh, (
+            self._hy_host_mesh,
             self._region,
             self.stream_logs,
             self.is_fake_in_process,
+            None,
         )
 
     @property

--- a/python/monarch/_src/actor/pickle.py
+++ b/python/monarch/_src/actor/pickle.py
@@ -83,6 +83,56 @@ def _torch_storage(obj: Any) -> Any:
     return (_load_from_bytes, (b.getvalue(),))
 
 
+# Torch-aware pickle classes - initialized lazily on first use.
+# These are used by pickle.rs when torch is loaded to handle
+# torch storage types and dispatch mode disabling.
+_TorchPickler: Any = None
+_torch_pickle_initialized: bool = False
+
+
+def _ensure_torch_pickle() -> None:
+    """Lazily initialize torch-aware pickle classes on first use."""
+    global _torch_pickle_initialized, _TorchPickler
+    if _torch_pickle_initialized:
+        return
+    _torch_pickle_initialized = True
+
+    import torch
+
+    dispatch: dict[Any, Any] = {}
+    # pyre-ignore[16]: dynamic torch attribute
+    keys: list[Any] = [torch.storage.UntypedStorage, torch.storage.TypedStorage]
+    scan = 0
+    while scan < len(keys):
+        keys.extend(keys[scan].__subclasses__())
+        scan += 1
+    for key in keys:
+        dispatch[key] = _torch_storage
+
+    class TorchPickler(cloudpickle.Pickler):
+        dispatch_table: ChainMap[Any, Any] = ChainMap(
+            dispatch, cloudpickle.Pickler.dispatch_table
+        )
+
+    _TorchPickler = TorchPickler
+
+
+def torch_dump(obj: Any, f: Buffer | io.BytesIO) -> None:
+    """Pickle obj into f using a torch-aware pickler with storage dispatch."""
+    _ensure_torch_pickle()
+    pickler = _TorchPickler(f)
+    pickler.dump(obj)
+
+
+def torch_loads(data: FrozenBuffer | bytes) -> Any:
+    """Unpickle data with torch dispatch modes disabled."""
+    import torch
+
+    # pyre-ignore[16]: dynamic torch attribute
+    with torch.utils._python_dispatch._disable_current_modes():
+        return cloudpickle.loads(data)
+
+
 class _Pickler(cloudpickle.Pickler):
     _torch_initialized = False
     _dispatch_table: dict[Any, Any] = {}

--- a/python/monarch/_src/actor/proc_mesh.py
+++ b/python/monarch/_src/actor/proc_mesh.py
@@ -38,11 +38,7 @@ from weakref import WeakSet
 from monarch._rust_bindings.monarch_hyperactor.actor import MethodSpecifier
 from monarch._rust_bindings.monarch_hyperactor.context import Instance as HyInstance
 from monarch._rust_bindings.monarch_hyperactor.proc_mesh import ProcMesh as HyProcMesh
-from monarch._rust_bindings.monarch_hyperactor.pytokio import (
-    PendingPickle,
-    PythonTask,
-    Shared,
-)
+from monarch._rust_bindings.monarch_hyperactor.pytokio import PythonTask, Shared
 from monarch._rust_bindings.monarch_hyperactor.shape import Extent, Region, Shape, Slice
 from monarch._src.actor.actor_mesh import (
     _Actor,
@@ -65,7 +61,6 @@ from monarch._src.actor.code_sync import (
 from monarch._src.actor.endpoint import endpoint
 from monarch._src.actor.future import Future
 from monarch._src.actor.logging import LoggingManager
-from monarch._src.actor.pickle import is_pending_pickle_allowed
 from monarch._src.actor.shape import MeshTrait
 from monarch.tools.config.environment import CondaEnvironment
 from monarch.tools.config.workspace import Workspace
@@ -635,13 +630,8 @@ class ProcMesh(MeshTrait):
         )
 
     def __reduce_ex__(self, protocol: ...) -> Tuple[Any, Tuple[Any, ...]]:
-        return ProcMesh._from_initialized_hy_proc_mesh, (
-            self._proc_mesh.poll()
-            or (
-                PendingPickle(self._proc_mesh)
-                if is_pending_pickle_allowed()
-                else self._proc_mesh.block_on()
-            ),
+        return ProcMesh, (
+            self._proc_mesh,
             self._host_mesh,
             self._region,
             self._root_region,

--- a/python/monarch/_src/actor/tensor_engine_shim.py
+++ b/python/monarch/_src/actor/tensor_engine_shim.py
@@ -32,8 +32,7 @@ if TYPE_CHECKING:
     from monarch._rust_bindings.monarch_hyperactor.actor import MethodSpecifier
     from monarch._rust_bindings.monarch_hyperactor.mailbox import OncePortRef, PortRef
 
-from monarch._rust_bindings.monarch_hyperactor.buffers import Buffer
-from monarch._rust_bindings.monarch_hyperactor.pytokio import PendingPickleState
+from monarch._rust_bindings.monarch_hyperactor.pickle import PicklingState
 
 P = ParamSpec("P")
 F = TypeVar("F", bound=Callable[..., Any])
@@ -70,22 +69,18 @@ def shim(
 
 
 @shim(module="monarch.mesh_controller")
-def create_actor_message(
+def create_actor_message_kind(
     method_name: "MethodSpecifier",
     proc_mesh: "Optional[Any]",
-    args_kwargs_tuple: Buffer,
     refs: "Sequence[Any]",
     port: "Optional[PortRef | OncePortRef]",
-    pending_pickle_state: Optional[PendingPickleState],
 ) -> "Any": ...
 
 
 @shim(module="monarch.mesh_controller")
 def actor_rref(
     endpoint: Any,
-    args_kwargs_tuple: Buffer,
-    refs: Sequence[Any],
-    pending_pickle_state: Optional[PendingPickleState],
+    pickling_state: Optional[PicklingState],
 ) -> Any: ...
 
 

--- a/python/monarch/common/reference.py
+++ b/python/monarch/common/reference.py
@@ -8,6 +8,10 @@
 from typing import Optional
 
 from monarch._rust_bindings.monarch_extension.tensor_worker import Ref
+from monarch._rust_bindings.monarch_hyperactor.pickle import (
+    pop_tensor_engine_reference,
+    push_tensor_engine_reference_if_active,
+)
 
 
 class Referenceable:
@@ -21,6 +25,8 @@ class Referenceable:
         assert self.ref is not None, (
             f"{self} is being sent but does not have a reference"
         )
+        if push_tensor_engine_reference_if_active(self):
+            return pop_tensor_engine_reference, ()
         return Ref, (self.ref,)
 
     # Used by rust backend to get the ref for this object

--- a/python/monarch/mesh_controller.py
+++ b/python/monarch/mesh_controller.py
@@ -34,20 +34,21 @@ from monarch._rust_bindings.monarch_extension.mesh_controller import _Controller
 from monarch._rust_bindings.monarch_extension.tensor_worker import Ref
 from monarch._rust_bindings.monarch_hyperactor.actor import (
     MethodSpecifier,
-    PythonMessage,
     PythonMessageKind,
     UnflattenArg,
 )
-from monarch._rust_bindings.monarch_hyperactor.buffers import Buffer
 from monarch._rust_bindings.monarch_hyperactor.mailbox import (
     OncePortRef,
     PortId,
     PortRef,
 )
+from monarch._rust_bindings.monarch_hyperactor.pickle import (
+    PendingMessage,
+    PicklingState,
+)
 from monarch._rust_bindings.monarch_hyperactor.proc import (  # @manual=//monarch/monarch_extension:monarch_extension
     ActorId,
 )
-from monarch._rust_bindings.monarch_hyperactor.pytokio import PendingPickleState
 from monarch._src.actor.actor_mesh import Channel
 from monarch._src.actor.shape import NDSlice
 from monarch.common import device_mesh, messages, stream
@@ -437,33 +438,26 @@ def _create_call_method_indirect_message(
     method_name: "MethodSpecifier",
     client: MeshClient,
     seq: Seq,
-    args_kwargs_tuple: Buffer,
     refs: Sequence[Any],
-    pending_pickle_state: Optional[PendingPickleState],
-) -> Tuple[PythonMessage, Tuple[str, int]]:
+) -> Tuple[PythonMessageKind, Tuple[str, int]]:
     unflatten_args = [
         UnflattenArg.PyObject if isinstance(ref, Tensor) else UnflattenArg.Mailbox
         for ref in refs
     ]
     broker_id: Tuple[str, int] = client._mesh_controller.broker_id
-    actor_msg = PythonMessage(
-        PythonMessageKind.CallMethodIndirect(
-            method_name, broker_id, seq, unflatten_args
-        ),
-        args_kwargs_tuple,
-        pending_pickle_state,
+    actor_msg_kind = PythonMessageKind.CallMethodIndirect(
+        method_name, broker_id, seq, unflatten_args
     )
-    return (actor_msg, broker_id)
+
+    return (actor_msg_kind, broker_id)
 
 
-def create_actor_message(
+def create_actor_message_kind(
     method_name: MethodSpecifier,
     proc_mesh: Optional["ProcMesh"],
-    args_kwargs_tuple: Buffer,
     refs: Sequence[Any],
     port: Optional[PortRef | OncePortRef],
-    pending_pickle_state: Optional[PendingPickleState],
-) -> PythonMessage:
+) -> PythonMessageKind:
     tensors = [ref for ref in refs if isinstance(ref, Tensor)]
     # we have some monarch references, we need to ensure their
     # proc_mesh matches that of the tensors we sent to it
@@ -486,30 +480,26 @@ def create_actor_message(
 
     client = cast(MeshClient, checker.mesh.client)
 
-    return _create_actor_message(
+    return _create_actor_message_kind(
         method_name,
-        args_kwargs_tuple,
         refs,
         port,
         client,
         checker.mesh,
         tensors,
         chosen_stream,
-        pending_pickle_state,
     )
 
 
-def _create_actor_message(
+def _create_actor_message_kind(
     method_name: MethodSpecifier,
-    args_kwargs_tuple: Buffer,
     refs: Sequence[Any],
     port: Optional[PortRef | OncePortRef],
     client: MeshClient,
     mesh: DeviceMesh,
     tensors: List[Tensor],
     chosen_stream: Stream,
-    pending_pickle_state: Optional[PendingPickleState],
-) -> PythonMessage:
+) -> PythonMessageKind:
     stream_ref = chosen_stream._to_ref(client)
     fut = (port, mesh._ndslice) if port is not None else None
 
@@ -524,7 +514,7 @@ def _create_actor_message(
     # from the stream, then it will run the actor method, and send the result to response port.
 
     actor_msg, broker_id = _create_call_method_indirect_message(
-        method_name, client, ident, args_kwargs_tuple, refs, pending_pickle_state
+        method_name, client, ident, refs
     )
     worker_msg = SendResultOfActorCall(ident, broker_id, tensors, [], stream_ref)
     client.send(mesh._ndslice, worker_msg)
@@ -536,13 +526,9 @@ def _create_actor_message(
     return actor_msg
 
 
-def actor_rref(
-    endpoint,
-    args_kwargs_tuple: Buffer,
-    refs: Sequence[Any],
-    pending_pickle_state: Optional[PendingPickleState],
-):
+def actor_rref(endpoint, pickling_state: PicklingState):
     chosen_stream = stream._active
+    refs = pickling_state.tensor_engine_references()
     fake_result, dtensors, mutates, mesh = dtensor_check(
         endpoint._propagate,
         cast(ResolvableFunction, endpoint._name),
@@ -566,10 +552,13 @@ def actor_rref(
     if len(result_dtensors) == 0:
         result_msg = None
 
-    actor_msg, broker_id = _create_call_method_indirect_message(
-        endpoint._name, mesh.client, seq, args_kwargs_tuple, refs, pending_pickle_state
+    actor_msg_kind, broker_id = _create_call_method_indirect_message(
+        endpoint._name, mesh.client, seq, refs
     )
-    endpoint._actor_mesh.cast(actor_msg, "all", context().actor_instance._as_rust())
+    actor_msg = PendingMessage(actor_msg_kind, pickling_state)
+    endpoint._actor_mesh.cast_unresolved(
+        actor_msg, "all", context().actor_instance._as_rust()
+    )
     # note the device mesh has to be defined regardles so the remote functions
     # can invoke mesh.rank("...")
 

--- a/python/tests/_monarch/test_hyperactor.py
+++ b/python/tests/_monarch/test_hyperactor.py
@@ -8,7 +8,6 @@
 
 import multiprocessing
 import os
-import pickle
 import signal
 import time
 from typing import Any, Callable, cast, Coroutine, Iterable, Type, TYPE_CHECKING
@@ -16,7 +15,6 @@ from typing import Any, Callable, cast, Coroutine, Iterable, Type, TYPE_CHECKING
 from monarch._rust_bindings.monarch_hyperactor.actor import (
     MethodSpecifier,
     PanicFlag,
-    PythonMessage,
     PythonMessageKind,
 )
 from monarch._rust_bindings.monarch_hyperactor.alloc import (  # @manual=//monarch/monarch_extension:monarch_extension
@@ -24,6 +22,10 @@ from monarch._rust_bindings.monarch_hyperactor.alloc import (  # @manual=//monar
     AllocSpec,
 )
 from monarch._rust_bindings.monarch_hyperactor.buffers import Buffer
+from monarch._rust_bindings.monarch_hyperactor.pickle import (
+    PendingMessage,
+    pickle as monarch_pickle,
+)
 from monarch._rust_bindings.monarch_hyperactor.proc import ActorId
 from monarch._rust_bindings.monarch_hyperactor.proc_mesh import ProcMesh
 from monarch._rust_bindings.monarch_hyperactor.pytokio import PythonTask, Shared
@@ -128,9 +130,10 @@ async def test_actor_mesh() -> None:
     proc_mesh_task: Shared[ProcMesh] = PythonTask.from_coroutine(task()).spawn()
 
     # Create an explicit init message
-    init_message = PythonMessage(
+    init_state = monarch_pickle(None)
+    init_message = PendingMessage(
         PythonMessageKind.CallMethod(MethodSpecifier.Init(), None),
-        pickle.dumps(None),
+        init_state,
     )
 
     # Use spawn_async with the explicit init message

--- a/python/tests/test_python_actors.py
+++ b/python/tests/test_python_actors.py
@@ -34,6 +34,7 @@ from monarch._rust_bindings.monarch_hyperactor.actor import (
     PythonMessageKind,
 )
 from monarch._rust_bindings.monarch_hyperactor.alloc import Alloc, AllocSpec
+from monarch._rust_bindings.monarch_hyperactor.buffers import Buffer
 from monarch._rust_bindings.monarch_hyperactor.mailbox import (
     PortId,
     PortRef,
@@ -1305,9 +1306,11 @@ class UndeliverableMessageSender(Actor):
             port=1234,
         )
         port_ref = PortRef(port_id)
+        buf = Buffer()
+        buf.write(b"123")
         port_ref.send(
             actor_instance._as_rust(),
-            PythonMessage(PythonMessageKind.Result(None), b"123"),
+            PythonMessage(PythonMessageKind.Result(None), buf.freeze()),
         )
 
 


### PR DESCRIPTION
Summary:
This diff refactors Monarch's pickling system by moving from a Python-based
`persistent_id`/`flatten`/`unflatten` approach to a simpler Rust-based
thread-local storage mechanism.

**Key Changes:**

1. **New `pickle.rs` module** - Introduces thread-local `ACTIVE_PICKLING_STATE`
   storage for tracking out-of-band pickling information during cloudpickle
   operations. Provides `PicklingState`, `PendingMessage`, and `pickle()` function.

2. **Simplified `PythonMessage`** - Removed `pending_pickle_state` field entirely.
   Constructor now takes `FrozenBuffer` directly instead of `Buffer | bytes`.

3. **Removed mailbox handling from references** - The `local_state` for message
   dispatch changed from `itertools.repeat(mailbox)` to an empty list. Mailboxes
   are no longer passed through this mechanism.

4. **Deleted `PendingPickle` and `PendingPickleState`** from `pytokio.rs` - These
   Python-side classes handled deferred pickling via `flatten`/`unflatten`.
   Replaced by Rust-side `PicklingState.resolve()` and `PendingMessage.resolve()`.

5. **`PyShared` now has `__reduce__`** - Added pickle protocol support directly
   via `reduce_shared()`. Also optimized `block_on` to check if value is already
   available before calling into tokio runtime.

6. **New `cast_unresolved()` method** - Trait method for casting messages with
   unresolved async values. `AsyncActorMesh` provides async implementation.

7. **Python-side simplifications** - Removed helper functions (`_is_mailbox`,
   `_flatten_with_pending_pickle`, `_pickle`), `_SingletonActorAdapator` class,
   and `allow_pending_pickle_mesh()` context manager usage.

**Benefits:**
- Reduced Python overhead: No more Python-side `persistent_id` callbacks or
  `flatten`/`unflatten` traversals during pickling
- Cleaner architecture: Pickling state handled via thread-local Rust storage
  that `__reduce__` implementations can access directly
- Simplified message type: `PythonMessage` no longer carries pending pickle state
- ~200 lines of Python removed, ~175 lines of Rust removed from pytokio.rs

Reviewed By: mariusae

Differential Revision: D92435072
