### PR TITLE
upgrading quickcheck to 1.1.0

### DIFF
--- a/hyperactor_telemetry/Cargo.toml
+++ b/hyperactor_telemetry/Cargo.toml
@@ -39,7 +39,7 @@ urlencoding = "2.1.0"
 whoami = "1.5"
 
 [dev-dependencies]
-quickcheck = "1.0"
+quickcheck = "1.1.0"
 quickcheck_macros = "1.1.0"
 tracing-test = { version = "0.2.3", features = ["no-env-filter"] }
 


### PR DESCRIPTION
Summary:
Upgrading `quickcheck` from `1.0` (git fork) to `1.1.0` (crates.io release).
- Removed `[patch.crates-io]` git fork entry for quickcheck (PR #278 is now included in the 1.1.0 release)
- Removed quickcheck from pyrefly autocargo project config patch list
- Replaced `Gen::from_seed(seed)` + `set_size(n)` calls with `Gen::from_size_and_seed(n, seed)` in `fbcode/dcoi/signal_grouping_rete/benches/main.rs` and `fbcode/eden/scm/lib/edenapi/types/src/wire/tests.rs`
- Updated autocargo version pin in `fbcode/eden/fs/cli_rs/edenfs-utils/BUCK` from "1.0" to "1.1.0"
- All downstream consumers checked with arc rust-check — 0 errors.

Differential Revision: D94105476
