### PR TITLE
Cache ActorId Strings

### DIFF
--- a/hyperactor/Cargo.toml
+++ b/hyperactor/Cargo.toml
@@ -53,6 +53,7 @@ indenter = "0.3.4"
 inventory = "0.3.21"
 lazy_static = "1.5"
 local-ip-address = "0.5.7"
+lru = { version = "0.16", default-features = false }
 ndslice = { version = "0.0.0", path = "../ndslice" }
 nix = { version = "0.30.1", features = ["dir", "event", "hostname", "inotify", "ioctl", "mman", "mount", "net", "poll", "ptrace", "reboot", "resource", "sched", "signal", "term", "time", "user", "zerocopy"] }
 opentelemetry = "0.29"

--- a/hyperactor/src/mailbox.rs
+++ b/hyperactor/src/mailbox.rs
@@ -364,7 +364,7 @@ impl MessageEnvelope {
     ) {
         tracing::error!(
             name = "undelivered_message_attempt",
-            sender = self.sender.to_string(),
+            sender = %self.sender.cached_to_string(),
             dest = self.dest.to_string(),
             error = error.to_string(),
             return_handle = %return_handle,
@@ -372,7 +372,7 @@ impl MessageEnvelope {
         metrics::MAILBOX_UNDELIVERABLE_MESSAGES.add(
             1,
             hyperactor_telemetry::kv_pairs!(
-                "sender_actor_id" => self.sender.to_string(),
+                "sender_actor_id" => self.sender.cached_to_string(),
                 "dest_actor_id" => self.dest.to_string(),
                 "message_type" => self.data.typename().unwrap_or("unknown"),
                 "error_type" =>  error.to_string(),
@@ -827,7 +827,7 @@ impl MailboxSender for UndeliverableMailboxSender {
         tracing::error!(
             name = "undelivered_message_abandoned",
             actor_name = sender_name,
-            actor_id = envelope.sender.to_string(),
+            actor_id = %envelope.sender.cached_to_string(),
             dest = envelope.dest.to_string(),
             headers = envelope.headers().to_string(), // todo: implement tracing::Value for Flattrs
             data = envelope.data().to_string(),
@@ -1575,14 +1575,14 @@ impl MailboxSender for Mailbox {
         metrics::MAILBOX_POSTS.add(
             1,
             hyperactor_telemetry::kv_pairs!(
-                "actor_id" => envelope.sender.to_string(),
-                "dest_actor_id" => envelope.dest.0.to_string(),
+                "actor_id" => envelope.sender.cached_to_string(),
+                "dest_actor_id" => envelope.dest.0.cached_to_string(),
             ),
         );
         tracing::trace!(
             name = "post",
             actor_name = envelope.sender.name(),
-            actor_id = envelope.sender.to_string(),
+            actor_id = %envelope.sender.cached_to_string(),
             "posting message to {}",
             envelope.dest
         );


### PR DESCRIPTION
Summary: In many places where we log otel metrics we provide a String for ActorId. This happens in some hot paths, notably in Mailbox.post().

Differential Revision: D93515230


