### PR TITLE
Send responses with Rust ports

### DIFF
--- a/monarch_hyperactor/src/mailbox.rs
+++ b/monarch_hyperactor/src/mailbox.rs
@@ -585,6 +585,29 @@ impl Bind for EitherPortRef {
 }
 
 impl EitherPortRef {
+    pub fn get_return_undeliverable(&self) -> bool {
+        match self {
+            EitherPortRef::Unbounded(port_ref) => port_ref.inner.get_return_undeliverable(),
+            EitherPortRef::Once(once_port_ref) => once_port_ref
+                .inner
+                .as_ref()
+                .is_some_and(|r| r.get_return_undeliverable()),
+        }
+    }
+
+    pub fn set_return_undeliverable(&mut self, return_undeliverable: bool) {
+        match self {
+            EitherPortRef::Unbounded(port_ref) => {
+                port_ref.inner.return_undeliverable(return_undeliverable);
+            }
+            EitherPortRef::Once(once_port_ref) => {
+                if let Some(ref mut inner) = once_port_ref.inner {
+                    inner.return_undeliverable(return_undeliverable);
+                }
+            }
+        }
+    }
+
     /// Send a message through this port reference.
     /// The message is first resolved for any pending pickle state before sending.
     pub fn send(

--- a/python/monarch/_rust_bindings/monarch_hyperactor/actor.pyi
+++ b/python/monarch/_rust_bindings/monarch_hyperactor/actor.pyi
@@ -109,6 +109,21 @@ class Uninit(PythonMessageKind):
     pass
 
 @final
+class DroppingPort:
+    """
+    Used in place of a real port when the message has no response port.
+    Makes sure any exception sent to it causes the actor to report an exception.
+    """
+
+    def __init__(self) -> None: ...
+    def send(self, obj: Any) -> None: ...
+    def exception(self, obj: BaseException) -> None: ...
+    @property
+    def return_undeliverable(self) -> bool: ...
+    @return_undeliverable.setter
+    def return_undeliverable(self, value: bool) -> None: ...
+
+@final
 class PythonMessage:
     """
     A message that carries a python method and a pickled message that contains


### PR DESCRIPTION
Summary:
We spend a lot of time constructing Python `Port`s in the `PythonActor` handler for `PythonMessage`

Here we create a Rust `Port` and `DroppingPort` to replace the Python versions.

`Port` is annotated with `rust_struct` so we can patch the Python implementation of `__reduce__`

Reviewed By: zdevito

Differential Revision: D94142916


