### PR TITLE
channel::net::tls::tests use install ring as the default CryptoProvider

### DIFF
--- a/hyperactor/src/channel/net.rs
+++ b/hyperactor/src/channel/net.rs
@@ -1129,6 +1129,10 @@ u19txmtkiMEH+aNmekk=
 
         #[async_timed_test(timeout_secs = 30)]
         async fn test_tls_basic() {
+            // Ensure ring is installed as the default crypto provider
+            // (no-op if already installed, e.g. under Buck with native-tls).
+            let _ = rustls::crypto::ring::default_provider().install_default();
+
             // Set up TLS config using the standard override pattern
             let config = hyperactor_config::global::lock();
             let _guard_cert =
@@ -1163,6 +1167,8 @@ u19txmtkiMEH+aNmekk=
 
         #[async_timed_test(timeout_secs = 30)]
         async fn test_tls_multiple_messages() {
+            let _ = rustls::crypto::ring::default_provider().install_default();
+
             // Set up TLS config using the standard override pattern
             let config = hyperactor_config::global::lock();
             let _guard_cert =
@@ -1230,6 +1236,10 @@ u19txmtkiMEH+aNmekk=
 
         #[test]
         fn test_tls_acceptor_creation() {
+            // Ensure ring is installed as the default crypto provider
+            // (no-op if already installed, e.g. under Buck with native-tls).
+            let _ = rustls::crypto::ring::default_provider().install_default();
+
             // Set up TLS config using the standard override pattern
             let config = hyperactor_config::global::lock();
             let _guard_cert =
@@ -1245,6 +1255,10 @@ u19txmtkiMEH+aNmekk=
 
         #[test]
         fn test_tls_connector_creation() {
+            // Ensure ring is installed as the default crypto provider
+            // (no-op if already installed, e.g. under Buck with native-tls).
+            let _ = rustls::crypto::ring::default_provider().install_default();
+
             // Set up TLS config using the standard override pattern
             let config = hyperactor_config::global::lock();
             let _guard_cert =


### PR DESCRIPTION
Summary:
D93626607  appears to have affected the OSS build.

explicitly make ring the  process level default `CryptoProvider` in the hyperactor tls unit-tests

Differential Revision: D94163068


