### PR TITLE
Normalize IP address strings for metatls/tls hostname storage

### DIFF
--- a/hyperactor/src/channel/net.rs
+++ b/hyperactor/src/channel/net.rs
@@ -577,6 +577,7 @@ pub(crate) mod meta {
 
     use super::*;
     use crate::RemoteMessage;
+    use crate::channel::normalize_host;
     use crate::config::Pem;
     use crate::config::PemBundle;
 
@@ -602,7 +603,7 @@ pub(crate) mod meta {
                     return Err(ChannelError::InvalidAddress(addr_string.to_string()));
                 };
                 Ok(ChannelAddr::MetaTls(TlsAddr::Host {
-                    hostname: hostname.to_string(),
+                    hostname: normalize_host(hostname),
                     port,
                 }))
             }
@@ -710,6 +711,7 @@ pub(crate) mod tls {
     use super::*;
     use crate::RemoteMessage;
     use crate::channel::TlsAddr;
+    use crate::channel::normalize_host;
     use crate::config::Pem;
     use crate::config::PemBundle;
     use crate::config::TLS_CA;
@@ -740,7 +742,7 @@ pub(crate) mod tls {
                     return Err(ChannelError::InvalidAddress(addr_string.to_string()));
                 };
                 Ok(ChannelAddr::Tls(TlsAddr::Host {
-                    hostname: hostname.to_string(),
+                    hostname: normalize_host(hostname),
                     port,
                 }))
             }


### PR DESCRIPTION
Summary:
The same IPv6 address can arrive in different string forms (e.g.,
`56d7:cf` vs `56d7:00cf`), causing equality comparisons to fail for
what is logically the same address. Normalize IP address strings via
`IpAddr::to_string()` (standard shortest form) before storing them
in the `hostname` field of `TlsAddr::Host`.

Add `ChannelAddr::normalize_host` which strips URI-style brackets and
parses the host as an `IpAddr` to produce a canonical representation.
Apply it in `from_zmq_url`, `net::meta::parse`, and `net::tls::parse`.

Differential Revision: D94159405


