### PR TITLE
Remove TlsAddr::Socket variant, convert enum to struct

### DIFF
--- a/hyperactor_mesh/src/alloc.rs
+++ b/hyperactor_mesh/src/alloc.rs
@@ -484,16 +484,8 @@ pub(crate) fn with_unspecified_port_or_any(addr: &ChannelAddr) -> ChannelAddr {
             new_socket.set_port(0);
             ChannelAddr::Tcp(new_socket)
         }
-        ChannelAddr::MetaTls(TlsAddr::Socket(socket)) => {
-            let mut new_socket = socket.clone();
-            new_socket.set_port(0);
-            ChannelAddr::MetaTls(TlsAddr::Socket(new_socket))
-        }
-        ChannelAddr::MetaTls(TlsAddr::Host { hostname, port: _ }) => {
-            ChannelAddr::MetaTls(TlsAddr::Host {
-                hostname: hostname.clone(),
-                port: 0,
-            })
+        ChannelAddr::MetaTls(TlsAddr { hostname, .. }) => {
+            ChannelAddr::MetaTls(TlsAddr::new(hostname.clone(), 0))
         }
         _ => addr.transport().any(),
     }

--- a/monarch_hyperactor/src/alloc.rs
+++ b/monarch_hyperactor/src/alloc.rs
@@ -402,7 +402,7 @@ impl RemoteProcessAllocInitializer for PyRemoteProcessAllocInitializer {
             .map(|channel_addr| {
                 let addr = ChannelAddr::from_str(channel_addr)?;
                 let (id, hostname) = match addr {
-                    ChannelAddr::Tcp(socket) | ChannelAddr::MetaTls(TlsAddr::Socket(socket)) => {
+                    ChannelAddr::Tcp(socket) => {
                         if socket.is_ipv6() {
                             // ipv6 addresses need to be wrapped in square-brackets [ipv6_addr]
                             // since the return value here gets concatenated with 'port' to make up a sockaddr
@@ -413,7 +413,7 @@ impl RemoteProcessAllocInitializer for PyRemoteProcessAllocInitializer {
                             (ipv4_addr.clone(), ipv4_addr.clone())
                         }
                     }
-                    ChannelAddr::MetaTls(TlsAddr::Host { hostname, .. }) => {
+                    ChannelAddr::MetaTls(TlsAddr { hostname, .. }) => {
                         (hostname.clone(), hostname.clone())
                     }
                     ChannelAddr::Unix(_) => (addr.to_string(), addr.to_string()),

--- a/monarch_hyperactor/src/channel.rs
+++ b/monarch_hyperactor/src/channel.rs
@@ -177,11 +177,10 @@ impl PyChannelAddr {
     /// `0` for transports for which unix ports do not apply (e.g. `unix`, `local`)
     pub fn get_port(&self) -> PyResult<u16> {
         match &self.inner {
-            ChannelAddr::Tcp(socket_addr)
-            | ChannelAddr::MetaTls(TlsAddr::Socket(socket_addr))
-            | ChannelAddr::Tls(TlsAddr::Socket(socket_addr)) => Ok(socket_addr.port()),
-            ChannelAddr::MetaTls(TlsAddr::Host { port, .. })
-            | ChannelAddr::Tls(TlsAddr::Host { port, .. }) => Ok(*port),
+            ChannelAddr::Tcp(socket_addr) => Ok(socket_addr.port()),
+            ChannelAddr::MetaTls(TlsAddr { port, .. }) | ChannelAddr::Tls(TlsAddr { port, .. }) => {
+                Ok(*port)
+            }
             ChannelAddr::Unix(_) | ChannelAddr::Local(_) => Ok(0),
             _ => Err(PyRuntimeError::new_err(format!(
                 "unsupported transport: `{:?}` for channel address: `{}`",


### PR DESCRIPTION
Summary:
`TlsAddr` was an enum with two variants: `Host { hostname, port }` and
`Socket(SocketAddr)`. The `Socket` variant was only used by servers for
direct socket binding, and TLS clients explicitly rejected it with an
error. We only need the `Host` variant, so we convert `TlsAddr` from an
enum to a struct with `hostname` and `port` fields.

With `TlsAddr` as a struct, the `addr_string.parse::<SocketAddr>()`
early-return branch in `meta::parse()` and `tls::parse()` is redundant:
the `rsplit_once(":")` path produces the same result for all inputs,
because `TlsAddr::new()` calls `normalize_host()` which strips brackets
and canonicalizes IPs. Remove the dead branch from both functions.

Walkthrough:
- `hyperactor/src/channel.rs`: Convert `TlsAddr` to a struct. Add
  `TlsAddr::new()` constructor that normalizes hostnames. Extract
  `normalize_host` to a free function. Simplify `hostname()` to return
  `&str` instead of `Option<&str>`. Remove `EnumAsInner` derive and
  import.
- `hyperactor/src/channel/net.rs`: In `meta::parse()` and `tls::parse()`,
  remove redundant `SocketAddr` parse branch, keeping only the
  `rsplit_once(":")` path. Simplify `dial_with_connector()` and
  `serve_with_acceptor()` by removing `Socket` match arms. Update tests.
- `monarch_hyperactor/src/alloc.rs`: Remove `TlsAddr::Socket` match arm.
- `monarch_hyperactor/src/channel.rs`: Simplify `get_port()` with struct
  destructuring.
- `hyperactor_mesh/src/alloc.rs`: Replace two `TlsAddr` match arms with
  one struct match.
- `hyperactor_meta/src/mast_main.rs`: Use `TlsAddr::new()` at all
  construction sites.

Differential Revision: D94226215


