### PR TITLE
Fix overlap tracking early return

### DIFF
--- a/python/monarch/_src/rdma/rdma.py
+++ b/python/monarch/_src/rdma/rdma.py
@@ -466,7 +466,7 @@ class RDMAAction:
         )
 
         # range is unchanged - no need to update
-        if expanded_range == (new_start, new_end):
+        if expanded_range == overlapping_range:
             return
 
         # Update dictionary: remove old range, add expanded range


### PR DESCRIPTION
Summary:
`_check_and_merge_overlapping_range` returns early when
`expanded_range == (new_start, new_end)`, which is true when a new
range fully contains an existing one. The old (smaller) range stays
in the dictionary and the new (larger) range is never added.

Fix: change the comparison to `expanded_range == overlapping_range`
so the early return only fires when the existing range already covers
the new range.

Differential Revision: D94139581


