### PR TITLE
test isolate fault handlers

### DIFF
--- a/python/tests/test_host_mesh.py
+++ b/python/tests/test_host_mesh.py
@@ -13,6 +13,7 @@ from unittest.mock import patch
 
 import cloudpickle
 import pytest
+from isolate_in_subprocess import isolate_in_subprocess
 from monarch._rust_bindings.monarch_hyperactor.shape import Shape, Slice
 from monarch._src.actor.actor_mesh import _client_context, Actor, context
 from monarch._src.actor.endpoint import endpoint
@@ -153,6 +154,7 @@ class PidActor(Actor):
 
 
 @pytest.mark.timeout(60)
+@isolate_in_subprocess
 def test_this_host_on_client_can_spawn_actual_os_processes() -> None:
     hm = this_host()
     assert not hm.is_fake_in_process
@@ -178,6 +180,7 @@ class PidActorController(Actor):
 
 
 @pytest.mark.timeout(60)
+@isolate_in_subprocess
 def test_this_host_on_controllers_can_spawn_actual_os_processes() -> None:
     pid_controller_0 = get_or_spawn_controller(
         "pid_test_this_host_on_controllers_0", PidActorController

--- a/python/tests/test_proc_mesh.py
+++ b/python/tests/test_proc_mesh.py
@@ -18,6 +18,7 @@ import cloudpickle
 import monarch._src.actor.host_mesh
 import monarch.actor
 import pytest
+from isolate_in_subprocess import isolate_in_subprocess
 from monarch._rust_bindings.monarch_hyperactor.alloc import AllocConstraints, AllocSpec
 from monarch._rust_bindings.monarch_hyperactor.proc_mesh import ProcMesh as HyProcMesh
 from monarch._rust_bindings.monarch_hyperactor.pytokio import PythonTask, Shared
@@ -145,6 +146,7 @@ def test_proc_mesh_sliced() -> None:
 
 
 @pytest.mark.timeout(120)
+@isolate_in_subprocess
 def test_nested_meshes() -> None:
     host = ProcessJob({"hosts": 2}).state(cached_path=None).hosts
     proc = host.spawn_procs(name="proc")
@@ -167,6 +169,7 @@ def test_nested_meshes() -> None:
 
 
 @pytest.mark.timeout(60)
+@isolate_in_subprocess
 async def test_pickle_initialized_proc_mesh_in_tokio_thread() -> None:
     monarch.actor.unhandled_fault_hook = lambda failure: None
     host = ProcessJob({"hosts": 2}).state(cached_path=None).hosts

--- a/python/tests/test_python_actors.py
+++ b/python/tests/test_python_actors.py
@@ -29,6 +29,7 @@ from typing import Any, cast, Dict, Iterator, NamedTuple, Tuple
 import cloudpickle
 import monarch.actor
 import pytest
+from isolate_in_subprocess import isolate_in_subprocess
 from monarch._rust_bindings.monarch_hyperactor.actor import (
     PythonMessage,
     PythonMessageKind,
@@ -966,6 +967,7 @@ async def test_flush_on_disable_aggregation() -> None:
 
 @pytest.mark.timeout(120)
 @parametrize_config(actor_queue_dispatch={True, False})
+@isolate_in_subprocess
 async def test_multiple_ongoing_flushes_no_deadlock() -> None:
     """
     The goal is to make sure when a user sends multiple sync flushes, we are not deadlocked.
@@ -1127,6 +1129,7 @@ async def test_sync_workspace() -> None:
 
 @pytest.mark.timeout(120)
 @parametrize_config(actor_queue_dispatch={True, False})
+@isolate_in_subprocess
 async def test_proc_mesh_stop_after_actor_mesh_stop() -> None:
     pm = this_host().spawn_procs(per_host={"gpus": 2})
     am = pm.spawn("printer", Printer)
@@ -1254,6 +1257,7 @@ class UndeliverableMessageSenderWithOverride(UndeliverableMessageSender):
 
 @pytest.mark.timeout(10)
 # Not compatible with queue dispatch, as it assumes concurrent dispatch
+@isolate_in_subprocess
 async def test_undeliverable_message_with_override() -> None:
     pm = this_host().spawn_procs(per_host={"gpus": 1})
     receiver = pm.spawn("undeliverable_receiver", UndeliverableMessageReceiver)
@@ -1270,6 +1274,7 @@ async def test_undeliverable_message_with_override() -> None:
 
 @pytest.mark.timeout(60)
 @parametrize_config(actor_queue_dispatch={True, False})
+@isolate_in_subprocess
 async def test_undeliverable_message_without_override() -> None:
     # This test generates a fault that reaches the client. We don't want it to
     # crash.
@@ -1366,6 +1371,7 @@ class Hello(Actor):
 
 
 @parametrize_config(actor_queue_dispatch={True, False})
+@isolate_in_subprocess
 def test_simple_bootstrap():
     with TemporaryDirectory() as d:
         procs = []
@@ -1475,6 +1481,7 @@ class FakeLocalLoginJob(LoginJob):
 
 
 @parametrize_config(actor_queue_dispatch={True, False})
+@isolate_in_subprocess
 def test_login_job():
     with TemporaryDirectory() as temp_dir:
         j = FakeLocalLoginJob(temp_dir)
@@ -1650,6 +1657,7 @@ class ActorWithAsyncCleanup(Actor):
 
 
 @parametrize_config(actor_queue_dispatch={True, False})
+@isolate_in_subprocess
 def test_cleanup():
     procs = this_host().spawn_procs(per_host={"gpus": 1})
     counter = procs.spawn("counter", Counter, 0)
@@ -1661,6 +1669,7 @@ def test_cleanup():
 
 
 @parametrize_config(actor_queue_dispatch={True, False})
+@isolate_in_subprocess
 def test_cleanup_async():
     procs = this_host().spawn_procs(per_host={"gpus": 1})
     counter = procs.spawn("counter", Counter, 0)
@@ -1697,6 +1706,7 @@ class WrapperActor(Actor):
 
 
 @parametrize_config(actor_queue_dispatch={True, False})
+@isolate_in_subprocess
 def test_recursive_stop():
     """Tests that if A owns B, and A is stopped, B is also stopped. Cleanup
     actors are used because we can observe a side effect of them stopping"""

--- a/python/tests/test_supervision_hierarchy.py
+++ b/python/tests/test_supervision_hierarchy.py
@@ -12,6 +12,7 @@ from threading import Event
 from typing import Callable, Optional, TypeVar
 
 import monarch.actor
+from isolate_in_subprocess import isolate_in_subprocess
 from monarch._rust_bindings.monarch_hyperactor.supervision import MeshFailure
 from monarch.actor import Actor, endpoint, this_host
 from monarch.config import parametrize_config
@@ -101,6 +102,7 @@ class FaultCapture:
 
 
 @parametrize_config(actor_queue_dispatch={True, False})
+@isolate_in_subprocess
 def test_actor_failure():
     """
     If an actor dies, the client should receive an unhandled fault.
@@ -113,6 +115,7 @@ def test_actor_failure():
 
 
 @parametrize_config(actor_queue_dispatch={True, False})
+@isolate_in_subprocess
 def test_proc_failure():
     """
     If a proc dies, the client should receive an unhandled fault.
@@ -128,6 +131,7 @@ def test_proc_failure():
 
 
 @parametrize_config(actor_queue_dispatch={True, False})
+@isolate_in_subprocess
 def test_nested_mesh_kills_actor_actor_error():
     """
     If a nested actor errors, the fault should propagate to the client.


### PR DESCRIPTION
Summary: Trying to see if doing test isolation _just_ for the things that mess with the fault handler, which is also the code likely to get stray faults, is enough to make the oss tests stop flaking.

Reviewed By: johnwhumphreys

Differential Revision: D94293169
