### PR TITLE
Fix RDMA on EFA clusters by forcing EFA provider inclusion

### DIFF
--- a/rdmaxcel-sys/src/rdmaxcel.c
+++ b/rdmaxcel-sys/src/rdmaxcel.c
@@ -15,6 +15,14 @@
 #include <time.h>
 #include <unistd.h>
 
+// Force the linker to include the EFA provider from libefa.a.
+// Without this reference, the linker strips the EFA provider object
+// (which self-registers via __attribute__((constructor))) because
+// nothing else in the binary references its symbols directly.
+// The mlx5 provider is pulled in implicitly via mlx5dv_* function calls.
+extern const struct verbs_device_ops verbs_provider_efa;
+const void *_rdmaxcel_force_efa_provider = &verbs_provider_efa;
+
 // ============================================================================
 // RDMAXCEL QP Wrapper Implementation
 // ============================================================================


### PR DESCRIPTION
  ## Summary
  - Force the linker to include the EFA provider from libefa.a by adding an explicit reference to `verbs_provider_efa` in `rdmaxcel.c`
  - Without this, the linker strips the EFA provider object because nothing directly references its symbols (mlx5 survives because `mlx5dv_*` calls create implicit references)
  - This fixes `rdma_supported()` returning `False` on EFA clusters (e.g., AWS H100 nodes)

  ## Test plan
  - [x] Verified `verbs_provider_efa` symbol present in rebuilt binary
  - [x] Verified `rdma_supported()` returns `True` on EFA node
  - [ ] Run `examples/rdma_pingpong.py` end-to-end on 2-node EFA cluster
  - [ ] Verify no regression on Mellanox/mlx5 clusters