### PR TITLE
Make PyChannelTransport picklable

### DIFF
--- a/python/tests/test_config.py
+++ b/python/tests/test_config.py
@@ -513,6 +513,21 @@ def test_all_params_together():
     assert config["actor_queue_dispatch"] is False
 
 
+def test_channel_transport_pickle() -> None:
+    import pickle
+
+    for transport in (
+        ChannelTransport.Unix,
+        ChannelTransport.TcpWithLocalhost,
+        ChannelTransport.TcpWithHostname,
+        ChannelTransport.MetaTlsWithHostname,
+        ChannelTransport.MetaTlsWithIpV6,
+        ChannelTransport.Tls,
+        ChannelTransport.Local,
+    ):
+        assert pickle.loads(pickle.dumps(transport)) == transport
+
+
 def test_params_type_errors():
     """Test that type errors are raised for incorrect parameter types."""
     # Duration param with wrong type


### PR DESCRIPTION
Summary:
The Sandcastle job `monarch-sandcastle-test-conveyor` ([workflow 571957152689997951](https://fburl.com/conveyor/3i3ab228)) fails because the `ping_pong.pingpong` test tries to pickle a `BatchJob` object, and the object graph contains a `PyChannelTransport` (`monarch._rust_bindings.monarch_hyperactor.channel.ChannelTransport`). This PyO3 `#[pyclass]` enum doesn't implement pickle support, causing:

```
TypeError: cannot pickle 'monarch._rust_bindings.monarch_hyperactor.channel.ChannelTransport' object
```

Fix: add a `__reduce__` method to `PyChannelTransport` so it can be pickled. The approach uses `builtins.getattr` as the pickle callable, reconstructing as `getattr(ChannelTransport, "VariantName")` on unpickle. This follows the same pattern used in `mailbox.rs` (`PyPortId`) and `shape.rs` (`PyExtent`).

Differential Revision: D94311202


