### PR TITLE
Rename actormesh table to mesh table

### DIFF
--- a/examples/distributed_telemetry_real_data.py
+++ b/examples/distributed_telemetry_real_data.py
@@ -152,10 +152,10 @@ def main() -> None:
                ORDER BY ordinal_position""",
         ),
         (
-            "Schema of 'actor_meshes' table",
+            "Schema of 'meshes' table",
             """SELECT column_name, data_type, is_nullable
                FROM information_schema.columns
-               WHERE table_name = 'actor_meshes'
+               WHERE table_name = 'meshes'
                ORDER BY ordinal_position""",
         ),
         # Show available spans
@@ -167,8 +167,8 @@ def main() -> None:
         ("Count of events", "SELECT COUNT(*) as total_events FROM events"),
         ("Count of actors", "SELECT COUNT(*) as total_actors FROM actors"),
         (
-            "Count of actor meshes",
-            "SELECT COUNT(*) as total_actor_meshes FROM actor_meshes",
+            "Count of meshes",
+            "SELECT COUNT(*) as total_meshes FROM meshes",
         ),
         # Show span details
         (
@@ -235,19 +235,19 @@ def main() -> None:
                FROM actors
                ORDER BY full_name""",
         ),
-        # Sample of actor meshes
+        # Sample of meshes
         (
-            "Sample actor meshes",
+            "Sample meshes",
             """SELECT id, class, given_name, full_name, shape_json, parent_view_json, timestamp_us
-               FROM actor_meshes
+               FROM meshes
                ORDER BY timestamp_us DESC
                LIMIT 10""",
         ),
-        # Actor meshes by name pattern
+        # Meshes by name pattern
         (
-            "Actor meshes by name",
+            "meshes by name",
             """SELECT given_name, class, shape_json, parent_view_json
-               FROM actor_meshes
+               FROM meshes
                ORDER BY given_name""",
         ),
         # Actor status events schema

--- a/hyperactor_mesh/src/proc_mesh.rs
+++ b/hyperactor_mesh/src/proc_mesh.rs
@@ -1149,7 +1149,7 @@ impl ProcMeshRef {
             self.name().to_string().hash(&mut parent_hasher);
             let parent_mesh_id_hash = parent_hasher.finish();
 
-            hyperactor_telemetry::notify_actor_mesh_created(hyperactor_telemetry::ActorMeshEvent {
+            hyperactor_telemetry::notify_mesh_created(hyperactor_telemetry::MeshEvent {
                 id: mesh_id_hash,
                 timestamp: RealClock.system_time_now(),
                 class: actor_type,

--- a/hyperactor_telemetry/src/lib.rs
+++ b/hyperactor_telemetry/src/lib.rs
@@ -329,10 +329,10 @@ pub fn notify_actor_created(event: ActorEvent) {
     dispatch_or_buffer(EntityEvent::Actor(event));
 }
 
-/// Event data for actor mesh creation.
-/// This is passed to EntityEventDispatcher implementations when an actor mesh is spawned.
+/// Event data for mesh creation.
+/// This is passed to EntityEventDispatcher implementations when a mesh is spawned.
 #[derive(Debug, Clone)]
-pub struct ActorMeshEvent {
+pub struct MeshEvent {
     /// Unique identifier for this mesh (hashed)
     pub id: u64,
     /// Timestamp when the mesh was created
@@ -351,11 +351,11 @@ pub struct ActorMeshEvent {
     pub parent_view_json: Option<String>,
 }
 
-/// Notify the registered dispatcher that an actor mesh was created.
+/// Notify the registered dispatcher that a mesh was created.
 /// If no dispatcher is registered yet, the event is buffered and will be
 /// replayed when `set_entity_dispatcher` is called.
-pub fn notify_actor_mesh_created(event: ActorMeshEvent) {
-    dispatch_or_buffer(EntityEvent::ActorMesh(event));
+pub fn notify_mesh_created(event: MeshEvent) {
+    dispatch_or_buffer(EntityEvent::Mesh(event));
 }
 
 /// Event data for actor status changes.
@@ -395,8 +395,8 @@ pub fn notify_actor_status_changed(event: ActorStatusEvent) {
 pub enum EntityEvent {
     /// An actor was created.
     Actor(ActorEvent),
-    /// An actor mesh was created.
-    ActorMesh(ActorMeshEvent),
+    /// A mesh was created.
+    Mesh(MeshEvent),
     /// An actor changed status.
     ActorStatus(ActorStatusEvent),
 }
@@ -420,7 +420,7 @@ pub enum EntityEvent {
 ///     fn dispatch(&self, event: EntityEvent) -> Result<(), anyhow::Error> {
 ///         match event {
 ///             EntityEvent::Actor(actor) => println!("Actor: {}", actor.full_name),
-///             EntityEvent::ActorMesh(mesh) => println!("Mesh: {}", mesh.full_name),
+///             EntityEvent::Mesh(mesh) => println!("Mesh: {}", mesh.full_name),
 ///             EntityEvent::ActorStatus(status) => println!("Status: {}", status.new_status),
 ///         }
 ///         Ok(())


### PR DESCRIPTION
Summary: We want to use the same table to track procmesh and hostmesh

Differential Revision: D94381489


