### PR TITLE
Ensure execution id is set the same on all processes

### DIFF
--- a/python/monarch/_src/job/process.py
+++ b/python/monarch/_src/job/process.py
@@ -71,7 +71,7 @@ class ProcessJob(JobTrait):
                 for i in range(count):
                     host_key = f"{mesh_name}_{i}"
                     addr = f"ipc://{self._tmpdir}/{host_key}"
-                    env = {**os.environ}
+                    env = {**os.environ, "HYPERACTOR_PROCESS_NAME": host_key}
                     if self._env is not None:
                         env.update(self._env)
                     if _IN_PAR:


### PR DESCRIPTION
Summary:
Perfetto traces were messed up since the host + proc execution ids would be set independently of the client  execution id.

Here we resolve an execution id early on and set the env with this so that it propagates to host + proc

Reviewed By: junli0202

Differential Revision: D94408740


