### PR TITLE
Remove fake_in_process_host and replace with this_host

### DIFF
--- a/python/monarch/_src/actor/host_mesh.py
+++ b/python/monarch/_src/actor/host_mesh.py
@@ -345,21 +345,6 @@ class HostMesh(MeshTrait):
         return Future(coro=task())
 
 
-def fake_in_process_host() -> "HostMesh":
-    """
-    Create a host mesh for testing and development using a local allocator.
-
-    Returns:
-        HostMesh: A host mesh configured with local allocation for in-process use.
-    """
-    return HostMesh.allocate_nonblocking(
-        "fake_host",
-        Extent([], []),
-        LocalAllocator(),
-        bootstrap_cmd=_bootstrap_cmd(),
-    )
-
-
 def hosts_from_config(name: str) -> HostMesh:
     """
     Get the host mesh 'name' from the monarch configuration for the project.

--- a/python/tests/test_actor_error.py
+++ b/python/tests/test_actor_error.py
@@ -26,7 +26,7 @@ from monarch._rust_bindings.monarch_hyperactor.mailbox import (
 )
 from monarch._rust_bindings.monarch_hyperactor.supervision import SupervisionError
 from monarch._src.actor.actor_mesh import ActorMesh, context
-from monarch._src.actor.host_mesh import fake_in_process_host, this_host
+from monarch._src.actor.host_mesh import this_host
 from monarch._src.actor.proc_mesh import ProcMesh
 from monarch.actor import Actor, ActorError, endpoint, MeshFailure
 from monarch.config import configured, parametrize_config
@@ -121,7 +121,7 @@ class BrokenPickleClass:
 
 
 def spawn_procs_on_fake_host(per_host: dict[str, int]) -> ProcMesh:
-    return fake_in_process_host().spawn_procs(per_host)
+    return this_host().spawn_procs(per_host)
 
 
 def spawn_procs_on_this_host(per_host: dict[str, int]) -> ProcMesh:

--- a/python/tests/test_cuda.py
+++ b/python/tests/test_cuda.py
@@ -15,7 +15,6 @@ import cloudpickle
 import torch
 import torch.distributed as dist
 from monarch._src.actor.actor_mesh import ActorMesh
-from monarch._src.actor.host_mesh import fake_in_process_host
 from monarch._src.job.process import ProcessJob
 from monarch.actor import Actor, current_rank, current_size, endpoint, this_host
 
@@ -109,7 +108,7 @@ class TestEnvBeforeCuda(unittest.IsolatedAsyncioTestCase):
             for name, value in cuda_env_vars.items():
                 os.environ[name] = value
 
-        proc_mesh = fake_in_process_host().spawn_procs(bootstrap=setup_cuda_env)
+        proc_mesh = this_host().spawn_procs(bootstrap=setup_cuda_env)
 
         try:
             actor = proc_mesh.spawn("cuda_init", CudaInitTestActor)

--- a/python/tests/test_host_mesh.py
+++ b/python/tests/test_host_mesh.py
@@ -17,21 +17,10 @@ from isolate_in_subprocess import isolate_in_subprocess
 from monarch._rust_bindings.monarch_hyperactor.shape import Shape, Slice
 from monarch._src.actor.actor_mesh import _client_context, Actor, context
 from monarch._src.actor.endpoint import endpoint
-from monarch._src.actor.host_mesh import fake_in_process_host, HostMesh, this_host
+from monarch._src.actor.host_mesh import HostMesh, this_host
 from monarch._src.actor.pickle import flatten, unflatten
 from monarch._src.actor.proc_mesh import get_or_spawn_controller
 from monarch._src.job.process import ProcessJob
-
-
-@pytest.mark.timeout(60)
-def test_fake_in_process_host() -> None:
-    host = fake_in_process_host()
-    assert host.extent.labels == []
-    assert host.extent.sizes == []
-    assert not host.stream_logs
-    hy_host = host._hy_host_mesh.block_on()
-    assert hy_host.region.labels == host.region.labels
-    assert hy_host.region.slice() == host.region.slice()
 
 
 @pytest.mark.timeout(60)

--- a/python/tests/test_proc_mesh.py
+++ b/python/tests/test_proc_mesh.py
@@ -15,7 +15,6 @@ from typing import cast
 from unittest.mock import MagicMock, patch
 
 import cloudpickle
-import monarch._src.actor.host_mesh
 import monarch.actor
 import pytest
 from isolate_in_subprocess import isolate_in_subprocess
@@ -302,12 +301,7 @@ def test_context_proc_mesh_in_controller_spawns_actor_in_client_os_process() -> 
 @pytest.mark.timeout(60)
 def test_root_client_does_not_leak_proc_meshes() -> None:
     orig_get_client_context = _client_context.get
-    with (
-        patch.object(_client_context, "get") as mock_get_client_context,
-        patch.object(
-            monarch._src.actor.host_mesh, "fake_in_process_host"
-        ) as mock_fake_in_process_host,
-    ):
+    with patch.object(_client_context, "get") as mock_get_client_context:
         mock_get_client_context.side_effect = orig_get_client_context
 
         def sync_sleep_then_context():
@@ -324,11 +318,6 @@ def test_root_client_does_not_leak_proc_meshes() -> None:
             t.join()
 
         assert mock_get_client_context.call_count == 100
-        # If this test is run in isolation, the local host mesh will
-        # be created once. But if it runs with other tests, the host mesh
-        # will have already been initialized and the function never gets
-        # called.
-        assert mock_fake_in_process_host.call_count in (0, 1)
 
 
 @pytest.mark.timeout(60)

--- a/python/tests/test_python_actors.py
+++ b/python/tests/test_python_actors.py
@@ -44,12 +44,7 @@ from monarch._rust_bindings.monarch_hyperactor.proc import ActorId
 from monarch._rust_bindings.monarch_hyperactor.pytokio import PythonTask, Shared
 from monarch._src.actor.actor_mesh import ActorMesh, Channel, context, Port
 from monarch._src.actor.future import Future
-from monarch._src.actor.host_mesh import (
-    fake_in_process_host,
-    HostMesh,
-    this_host,
-    this_proc,
-)
+from monarch._src.actor.host_mesh import HostMesh, this_host, this_proc
 from monarch._src.actor.proc_mesh import get_or_spawn_controller, HyProcMesh
 from monarch._src.job.job import LoginJob, ProcessState
 from monarch._src.job.process import ProcessJob
@@ -99,7 +94,7 @@ class Indirect(Actor):
 @pytest.mark.timeout(60)
 @parametrize_config(actor_queue_dispatch={True, False})
 async def test_choose():
-    proc = fake_in_process_host().spawn_procs(per_host={"gpus": 2})
+    proc = this_host().spawn_procs(per_host={"gpus": 2})
     v = proc.spawn("counter", Counter, 3)
     i = proc.spawn("indirect", Indirect)
     v.incr.broadcast()
@@ -120,7 +115,7 @@ async def test_choose():
 @pytest.mark.timeout(60)
 @parametrize_config(actor_queue_dispatch={True, False})
 async def test_stream():
-    proc = fake_in_process_host().spawn_procs(per_host={"gpus": 2})
+    proc = this_host().spawn_procs(per_host={"gpus": 2})
     v = proc.spawn("counter2", Counter, 3)
     v.incr.broadcast()
 
@@ -142,7 +137,7 @@ class From(Actor):
 @pytest.mark.timeout(60)
 @parametrize_config(actor_queue_dispatch={True, False})
 async def test_mesh_passed_to_mesh():
-    proc = fake_in_process_host().spawn_procs(per_host={"gpus": 2})
+    proc = this_host().spawn_procs(per_host={"gpus": 2})
     f = proc.spawn("from", From)
     t = proc.spawn("to", To)
     # Make sure t is initialized before sending to f. Otherwise
@@ -156,8 +151,8 @@ async def test_mesh_passed_to_mesh():
 @pytest.mark.timeout(60)
 @parametrize_config(actor_queue_dispatch={True, False})
 async def test_mesh_passed_to_mesh_on_different_proc_mesh():
-    proc = fake_in_process_host().spawn_procs(per_host={"gpus": 2})
-    proc2 = fake_in_process_host().spawn_procs(per_host={"gpus": 2})
+    proc = this_host().spawn_procs(per_host={"gpus": 2})
+    proc2 = this_host().spawn_procs(per_host={"gpus": 2})
     f = proc.spawn("from", From)
     t = proc2.spawn("to", To)
     # Make sure t is initialized before sending to f. Otherwise
@@ -171,8 +166,8 @@ async def test_mesh_passed_to_mesh_on_different_proc_mesh():
 @pytest.mark.timeout(60)
 @parametrize_config(actor_queue_dispatch={True, False})
 def test_actor_slicing():
-    proc = fake_in_process_host().spawn_procs(per_host={"gpus": 2})
-    proc2 = fake_in_process_host().spawn_procs(per_host={"gpus": 2})
+    proc = this_host().spawn_procs(per_host={"gpus": 2})
+    proc2 = this_host().spawn_procs(per_host={"gpus": 2})
 
     f = proc.spawn("from", From)
     t = proc2.spawn("to", To)
@@ -188,7 +183,7 @@ def test_actor_slicing():
 @pytest.mark.timeout(60)
 @parametrize_config(actor_queue_dispatch={True, False})
 async def test_aggregate():
-    proc = fake_in_process_host().spawn_procs(per_host={"gpus": 2})
+    proc = this_host().spawn_procs(per_host={"gpus": 2})
     counter = proc.spawn("counter", Counter, 1)
     counter.incr.broadcast()
     acc = Accumulator(counter.value, 0, operator.add)
@@ -209,7 +204,7 @@ class RunIt(Actor):
 @pytest.mark.timeout(60)
 @parametrize_config(actor_queue_dispatch={True, False})
 async def test_rank_size():
-    proc = fake_in_process_host().spawn_procs(per_host={"gpus": 2})
+    proc = this_host().spawn_procs(per_host={"gpus": 2})
     r = proc.spawn("runit", RunIt)
 
     acc = Accumulator(r.run, 0, operator.add)
@@ -222,7 +217,7 @@ async def test_rank_size():
 @parametrize_config(actor_queue_dispatch={True, False})
 async def test_rank_string():
     per_host = {"hosts": 1, "gpus": 2}
-    proc = fake_in_process_host().spawn_procs(per_host=per_host)
+    proc = this_host().spawn_procs(per_host=per_host)
     r = proc.spawn("runit", RunIt)
     vm = r.return_current_rank_str.call().get()
     r0 = vm.flatten("r").slice(r=0).item()
@@ -240,7 +235,7 @@ class SyncActor(Actor):
 @pytest.mark.timeout(60)
 @parametrize_config(actor_queue_dispatch={True, False})
 async def test_sync_actor():
-    proc = fake_in_process_host().spawn_procs(per_host={"gpus": 2})
+    proc = this_host().spawn_procs(per_host={"gpus": 2})
     a = proc.spawn("actor", SyncActor)
     c = proc.spawn("counter", Counter, 5)
     r = await a.sync_endpoint.choose(c)
@@ -250,7 +245,7 @@ async def test_sync_actor():
 @pytest.mark.timeout(60)
 @parametrize_config(actor_queue_dispatch={True, False})
 def test_sync_actor_sync_client() -> None:
-    proc = fake_in_process_host().spawn_procs(per_host={"gpus": 2})
+    proc = this_host().spawn_procs(per_host={"gpus": 2})
     a = proc.spawn("actor", SyncActor)
     c = proc.spawn("counter", Counter, 5)
     r = a.sync_endpoint.choose(c).get()
@@ -260,14 +255,14 @@ def test_sync_actor_sync_client() -> None:
 @pytest.mark.timeout(60)
 @parametrize_config(actor_queue_dispatch={True, False})
 def test_proc_mesh_size() -> None:
-    proc = fake_in_process_host().spawn_procs(per_host={"gpus": 2})
+    proc = this_host().spawn_procs(per_host={"gpus": 2})
     assert 2 == proc.size("gpus")
 
 
 @pytest.mark.timeout(60)
 @parametrize_config(actor_queue_dispatch={True, False})
 def test_rank_size_sync() -> None:
-    proc = fake_in_process_host().spawn_procs(per_host={"gpus": 2})
+    proc = this_host().spawn_procs(per_host={"gpus": 2})
     r = proc.spawn("runit", RunIt)
 
     acc = Accumulator(r.run, 0, operator.add)
@@ -278,7 +273,7 @@ def test_rank_size_sync() -> None:
 @pytest.mark.timeout(60)
 @parametrize_config(actor_queue_dispatch={True, False})
 def test_accumulate_sync() -> None:
-    proc = fake_in_process_host().spawn_procs(per_host={"gpus": 2})
+    proc = this_host().spawn_procs(per_host={"gpus": 2})
     counter = proc.spawn("counter", Counter, 1)
     counter.incr.broadcast()
     acc = Accumulator(counter.value, 0, operator.add)
@@ -296,7 +291,7 @@ class CastToCounter(Actor):
 @parametrize_config(actor_queue_dispatch={True, False})
 def test_value_mesh() -> None:
     per_host = {"hosts": 1, "gpus": 2}
-    proc = fake_in_process_host().spawn_procs(per_host=per_host)
+    proc = this_host().spawn_procs(per_host=per_host)
     counter = proc.spawn("counter", Counter, 0)
     counter.slice(hosts=0, gpus=1).incr.broadcast()
     x = counter.value.call().get()
@@ -1065,7 +1060,7 @@ class SendAlot(Actor):
 @pytest.mark.timeout(60)
 @parametrize_config(actor_queue_dispatch={True, False})
 def test_port_as_argument() -> None:
-    proc_mesh = fake_in_process_host().spawn_procs(per_host={"gpus": 1})
+    proc_mesh = this_host().spawn_procs(per_host={"gpus": 1})
     s = proc_mesh.spawn("send_alot", SendAlot)
     send, recv = Channel[int].open()
 
@@ -1151,7 +1146,7 @@ class PortedActor(Actor):
 @pytest.mark.timeout(60)
 @parametrize_config(actor_queue_dispatch={True, False})
 def test_ported_actor():
-    proc_mesh = fake_in_process_host().spawn_procs(per_host={"gpus": 1})
+    proc_mesh = this_host().spawn_procs(per_host={"gpus": 1})
     a = proc_mesh.spawn("port_actor", PortedActor)
     assert 5 == a.add.call_one(2).get()
 
@@ -1194,7 +1189,7 @@ class SleepActor(Actor):
 
 @parametrize_config(actor_queue_dispatch={True, False})
 def test_mesh_len():
-    proc_mesh = fake_in_process_host().spawn_procs(per_host={"gpus": 12})
+    proc_mesh = this_host().spawn_procs(per_host={"gpus": 12})
     s = proc_mesh.spawn("sleep_actor", SleepActor)
     assert 12 == len(s)
 
@@ -1790,7 +1785,7 @@ class RunForeverOnInitActor(Actor):
 async def test_run_forever_on_init():
     """Test that an actor whose __init__ never returns still allows
     initialization side effects to propagate."""
-    pm = fake_in_process_host().spawn_procs(per_host={"gpus": 1})
+    pm = this_host().spawn_procs(per_host={"gpus": 1})
     # Fake type, actually ActorMesh[Counter], but necessary for type-checking.
     send, recv = Channel[Counter].open()
     forever = pm.spawn("forever", RunForeverOnInitActor, pm, send)


### PR DESCRIPTION
Summary:
Delete `fake_in_process_host()` from `host_mesh.py` and replace all callsites
with `this_host()`. The fake in-process host used `LocalAllocator` with an empty
extent for testing, but `this_host()` provides the same functionality through
the standard bootstrap path.

Differential Revision: D94379763


