### PR TITLE
make Handler<Stop> for HostMeshAgent non-blocking

### DIFF
--- a/hyperactor_mesh/src/resource.rs
+++ b/hyperactor_mesh/src/resource.rs
@@ -81,6 +81,8 @@ pub enum Status {
     /// The resource has been declared failed after a timeout.
     #[strum(to_string = "Timeout({0:?})")]
     Timeout(Duration),
+    /// The resource exists but its status is not known.
+    Unknown,
 }
 
 impl Status {


### PR DESCRIPTION
Summary:
Previously, the `Handler<Stop>` implementation for `HostMeshAgent`
called `terminate_proc`, which synchronously waited for the process to
exit. This blocked the actor's message loop, preventing it from
handling other messages (e.g., status queries) while a proc was
shutting down.

Replace the blocking `terminate_proc` call with a new `request_stop`
path that sends the stop signal and spawns a background task for
cleanup. This makes the Stop handler return immediately.

Key changes:
- Add `BootstrapProcManager::request_stop` and
  `BootstrapProcHandle::wait_or_brutally_kill` for non-blocking
  stop with background escalation (terminate -> kill).
- Add `LocalProcManager::request_stop` and `local_proc_status` for
  the in-process (test) path, with async-safe locking.
- Add `HostAgentMode::request_stop` and `local_proc_status` wrappers.
- Remove the `stopped` field from `ProcCreationState` — stop status
  is now derived from `BootstrapProcManager::status()` or
  `LocalProcManager::local_proc_status()`.
- Use `.lock().await` instead of `.blocking_lock()` throughout to
  avoid panics when called from within the tokio runtime.

Differential Revision: D94549846
