### PR TITLE
upgrading tracing-test to 0.2.6

### DIFF
--- a/hyperactor/Cargo.toml
+++ b/hyperactor/Cargo.toml
@@ -90,7 +90,7 @@ tempfile = "3.22"
 timed_test = { version = "0.0.0", path = "../timed_test" }
 tokio-test = "0.4.5"
 tracing-subscriber = { version = "0.3.20", features = ["chrono", "env-filter", "json", "local-time", "parking_lot", "registry"] }
-tracing-test = { version = "0.2.3", features = ["no-env-filter"] }
+tracing-test = { version = "0.2.6", features = ["no-env-filter"] }
 
 [features]
 default = []

--- a/hyperactor_config/Cargo.toml
+++ b/hyperactor_config/Cargo.toml
@@ -30,4 +30,4 @@ typeuri = { version = "0.0.0", path = "../typeuri" }
 
 [dev-dependencies]
 indoc = "2.0.2"
-tracing-test = { version = "0.2.3", features = ["no-env-filter"] }
+tracing-test = { version = "0.2.6", features = ["no-env-filter"] }

--- a/hyperactor_config/src/lib.rs
+++ b/hyperactor_config/src/lib.rs
@@ -227,6 +227,19 @@ mod tests {
     use crate::from_yaml;
     use crate::to_yaml;
 
+    /// Like the `logs_assert` injected by `#[traced_test]`, but without scope
+    /// filtering. Use when asserting on events emitted outside the test's span
+    /// (e.g. from spawned tasks or panic hooks).
+    fn logs_assert_unscoped(f: impl Fn(&[&str]) -> Result<(), String>) {
+        let buf = tracing_test::internal::global_buf().lock().unwrap();
+        let logs_str = std::str::from_utf8(&buf).expect("Logs contain invalid UTF8");
+        let lines: Vec<&str> = logs_str.lines().collect();
+        match f(&lines) {
+            Ok(()) => {}
+            Err(msg) => panic!("{}", msg),
+        }
+    }
+
     #[derive(
         Debug,
         Clone,
@@ -423,7 +436,7 @@ mod tests {
         // For some reason, logs_contain fails to find these lines individually
         // (possibly to do with the fact that we have newlines in our log entries);
         // instead, we test it manually.
-        logs_assert(|logged_lines: &[&str]| {
+        logs_assert_unscoped(|logged_lines: &[&str]| {
             let mut expected_lines = expected_lines.clone(); // this is an `Fn` closure
             for logged in logged_lines {
                 expected_lines.remove(logged);

--- a/hyperactor_telemetry/Cargo.toml
+++ b/hyperactor_telemetry/Cargo.toml
@@ -41,7 +41,7 @@ whoami = "1.5"
 [dev-dependencies]
 quickcheck = "1.0"
 quickcheck_macros = "1.2.0"
-tracing-test = { version = "0.2.3", features = ["no-env-filter"] }
+tracing-test = { version = "0.2.6", features = ["no-env-filter"] }
 
 [lints]
 rust = { unexpected_cfgs = { check-cfg = ["cfg(fbcode_build)"], level = "warn" } }


### PR DESCRIPTION
Summary:
Upgrading `tracing-test` from `0.2.3` to `0.2.6`.
- All downstream consumers checked with arc rust-check — 0 errors.

Differential Revision: D94564997
