### PR TITLE
tell claude not to create `use` aliases in Rust

### DIFF
--- a/MONARCH_INFO.md
+++ b/MONARCH_INFO.md
@@ -26,6 +26,7 @@
 - Do NOT add headers (e.g., in comments) to denote different sections of code; only use modules, structs, impl blocks, etc. for organization.
 - Use "that" for restrictive clauses (essential to meaning, no commas) and "which" for non-restrictive clauses (additional info, set off by commas). "The actor that crashed must be restarted" (identifies a specific actor) vs "The actor, which was created yesterday, is still running" (adds extra detail about an already-identified actor).
 - In Rust code, error messages are concise lowercase sentences without trailing punctuation
+- In Rust, avoid creating type aliases in `use` statements; prefer to use qualified identifiers to disambiguate
 
 
 ## Workflow


### PR DESCRIPTION
Summary: It seems to want to do this; better to use qualified identifiers.

Differential Revision: D94666476


