### PR TITLE
Add __supervise__ for ControllerController

### DIFF
--- a/monarch_hyperactor/src/supervision.rs
+++ b/monarch_hyperactor/src/supervision.rs
@@ -141,6 +141,14 @@ impl PyMeshFailure {
     #[getter]
     fn mesh(&self) {}
 
+    #[getter]
+    fn mesh_name(&self) -> String {
+        self.inner
+            .actor_mesh_name
+            .clone()
+            .unwrap_or("<none>".into())
+    }
+
     fn __repr__(&self) -> String {
         format!("{}", self)
     }

--- a/python/monarch/_rust_bindings/monarch_hyperactor/actor_mesh.pyi
+++ b/python/monarch/_rust_bindings/monarch_hyperactor/actor_mesh.pyi
@@ -30,6 +30,10 @@ class ActorMeshProtocol(Protocol):
         """Get the actor id at the given rank."""
         ...
 
+    def name(self) -> PythonTask[str]:
+        """Get the name of the mesh."""
+        ...
+
     def cast(
         self,
         message: PythonMessage,

--- a/python/monarch/_rust_bindings/monarch_hyperactor/supervision.pyi
+++ b/python/monarch/_rust_bindings/monarch_hyperactor/supervision.pyi
@@ -30,6 +30,12 @@ class MeshFailure:
     """
     @property
     def mesh(self) -> object: ...
+    @property
+    def mesh_name(self) -> str:
+        """The name of the mesh that this failure occurred on. Can be compared
+        to existing meshes names to determine identity"""
+        ...
+
     def report(self) -> str:
         """
         User-readable error report for this particular failure.

--- a/python/monarch/_src/actor/actor_mesh.py
+++ b/python/monarch/_src/actor/actor_mesh.py
@@ -1466,11 +1466,35 @@ class Actor(MeshTrait):
             "actor implementations are not meshes, but we can't convince the typechecker of it..."
         )
 
+    # Methods to be (optionally) overridden by user code
     def _handle_undeliverable_message(
         self, message: UndeliverableMessageEnvelope
     ) -> bool:
+        """If a message sent by this actor cannot be delivered to its destination, this
+        method is called. The default implementation returns False, indicating that the
+        undeliverable message was not handled. Returning True indicates that the message
+        was handled in some way and does not need to be escalated as an error."""
         # Return False to indicate that the undeliverable message was not handled.
         return False
+
+    def __supervise__(self, failure: MeshFailure) -> bool:
+        """Called when the actor is stopped due to a failure in a resource that it
+        owns. A resource is a host, proc, actor, or meshes of these.
+        If a truthy value is returned, the failure is considered handled and will not
+        propagate any further. If a falsey value is returned, the failure will be
+        further sent to the owner of this Actor.
+        Note that this is *not* called for errors within this Actor.
+        """
+        return False
+
+    # This method can be sync or async, and thus there is no way to have a common
+    # super implementation.
+    # def __cleanup__(self, exc: str | Exception | None) -> None:
+    #     """Runs any cleanup of resources that should happen when the Actor is stopped or fails.
+    #     This is called even if there is an error.
+    #     It is *not* called in cases of fatal errors, which include (but are not limited to):
+    #     OOMs, panics, signals like SIGSEGV, etc."""
+    #     pass
 
 
 class ActorMesh(MeshTrait, Generic[T]):
@@ -1506,6 +1530,14 @@ class ActorMesh(MeshTrait, Generic[T]):
         for attr_name in dir(self._class):
             attr_value = getattr(self._class, attr_name, None)
             if isinstance(attr_value, EndpointProperty):
+                # The ActorMesh builtin methods may clash with user-defined endpoints,
+                # check for this and raise an explainable error.
+                existing_attr = getattr(self, attr_name, None)
+                if not isinstance(existing_attr, NotAnEndpoint):
+                    raise ValueError(
+                        "ActorMesh has an attribute that collides with an endpoint name: "
+                        f"attribute={attr_name}, ActorMesh.{attr_name}={getattr(self, attr_name)}, endpoint={attr_value}"
+                    )
                 # Convert string method name to appropriate MethodSpecifier
                 kind = (
                     MethodSpecifier.ExplicitPort
@@ -1603,6 +1635,12 @@ class ActorMesh(MeshTrait, Generic[T]):
     def initialized(self) -> Future[None]:
         return Future(coro=self._inner.initialized())
 
+    @property
+    def _name(self) -> Future[str]:
+        """Retrieves the name stored in the ActorMesh internally."""
+        # Not called "name" to avoid clashing with a common endpoint name.
+        return Future(coro=self._inner.name())
+
 
 class ActorError(Exception):
     """
@@ -1654,7 +1692,7 @@ def current_size() -> Dict[str, int]:
 class RootClientActor(Actor):
     name: str = "client"
 
-    def __supervise__(self, failure: MeshFailure) -> object:
+    def __supervise__(self, failure: MeshFailure) -> bool:
         from monarch.actor import unhandled_fault_hook  # pyre-ignore
 
         unhandled_fault_hook(failure)  # pyre-ignore

--- a/python/monarch/_src/actor/proc_mesh.py
+++ b/python/monarch/_src/actor/proc_mesh.py
@@ -40,6 +40,7 @@ from monarch._rust_bindings.monarch_hyperactor.context import Instance as HyInst
 from monarch._rust_bindings.monarch_hyperactor.proc_mesh import ProcMesh as HyProcMesh
 from monarch._rust_bindings.monarch_hyperactor.pytokio import PythonTask, Shared
 from monarch._rust_bindings.monarch_hyperactor.shape import Extent, Region, Shape, Slice
+from monarch._rust_bindings.monarch_hyperactor.supervision import MeshFailure
 from monarch._src.actor.actor_mesh import (
     _Actor,
     _create_endpoint_message,
@@ -819,7 +820,11 @@ class ProcMesh(MeshTrait):
 
 class _ControllerController(Actor):
     def __init__(self) -> None:
-        self._controllers: Dict[str, Actor] = {}
+        # Store failed actors in the dict so we can forward their failures to
+        # the user.
+        self._controllers: Dict[str, Actor | MeshFailure] = {}
+        # Internal mesh name mapped back to the key from _controllers.
+        self._mesh_name_to_name: Dict[str, str] = {}
 
     # pyre-ignore
     @endpoint
@@ -836,8 +841,29 @@ class _ControllerController(Actor):
 
             proc = this_proc()
             proc._controller_controller = self_ref
-            self._controllers[name] = proc.spawn(name, Class, *args, **kwargs)
-        return cast(TActor, self._controllers[name])
+            mesh = proc.spawn(name, Class, *args, **kwargs)
+            mesh_name = cast(ActorMesh[Actor], mesh)._name.get()
+            self._controllers[name] = mesh
+            self._mesh_name_to_name[mesh_name] = name
+        actor = cast(TActor, self._controllers[name])
+        if isinstance(actor, MeshFailure):
+            raise ValueError(f"Failure on {name}: {actor}")
+        else:
+            return actor
+
+    def __supervise__(self, failure: MeshFailure) -> bool:
+        controller_name = self._mesh_name_to_name.get(failure.mesh_name)
+        if controller_name is not None:
+            controller = self._controllers.get(controller_name)
+            if controller is not None:
+                if not isinstance(controller, MeshFailure):
+                    # This might be a duplicate failure delivered for the same controller,
+                    # make sure to only store the first such failure.
+                    self._controllers[controller_name] = failure
+                return True
+        # Failure is not one we recognize, let it flow further to end the whole
+        # program.
+        return False
 
 
 # Lazy init so that the controller_controller and does not produce logs when it isn't used.

--- a/python/tests/test_actor_error.py
+++ b/python/tests/test_actor_error.py
@@ -28,7 +28,13 @@ from monarch._rust_bindings.monarch_hyperactor.supervision import SupervisionErr
 from monarch._src.actor.actor_mesh import ActorMesh, context
 from monarch._src.actor.host_mesh import this_host
 from monarch._src.actor.proc_mesh import ProcMesh
-from monarch.actor import Actor, ActorError, endpoint, MeshFailure
+from monarch.actor import (
+    Actor,
+    ActorError,
+    endpoint,
+    get_or_spawn_controller,
+    MeshFailure,
+)
 from monarch.config import configured, parametrize_config
 
 
@@ -1470,3 +1476,29 @@ async def test_gil_stall():
         f"[{timestamp()}] all requests completed, gathering took {gather_end - gather_start:.3f} seconds",
         file=sys.stderr,
     )
+
+
+@pytest.mark.timeout(60)
+def test_controller_controller_error():
+    """Tests that errors on actors spawned from the ControllerController don't
+    make it unavailable"""
+    actor_1 = get_or_spawn_controller("actor_1", ErrorActor).get()
+    actor_1.check.call_one().get()
+    actor_2 = get_or_spawn_controller("actor_2", ErrorActor).get()
+    actor_2.check.call_one().get()
+    # Trigger a supervision error that will propagate to the owner (the controller-controller).
+    # We get an exception here too as a subscriber, which we will ignore.
+    with pytest.raises(SupervisionError):
+        actor_1.fail_with_supervision_error.call_one().get()
+
+    # Make sure the error message includes what originally happened.
+    with pytest.raises(
+        ActorError,
+        match="Actor call actor_1.fail_with_supervision_error failed with BaseException",
+    ):
+        get_or_spawn_controller("actor_1", ErrorActor).get()
+
+    # Verify that the other actor is still reachable.
+    # Note that we cannot spawn new actors on a proc mesh that has prior supervision
+    # events at the moment, so we have to use a pre-existing one.
+    actor_2.check.call_one().get()


### PR DESCRIPTION
Summary:
The ControllerController is in charge of spawning singleton actors shared across the
whole monarch universe. Since this is an Actor, it owns the actors it spawns and gets any
supervision errors from them.
We don't want some actors that were unaffected by the supervision error to become
unreachable or to take down the whole client.
Adding a `__supervise__` implementation to catch and handle these errors.

While writing this, I realized that there was no way to detect which mesh the failure came
from, a serious limitation. The `.mesh` object was just None always.
Add the `mesh_name` that can be used as a lookup key. While this is suboptimal to storing
and using a MeshRef, it avoids serialization issues with templatizing `MeshFailure<A>`.

Also, it turns out that getting the real internal name for an ActorMesh is a bit of a pain, needing
a bunch of async PythonTasks to accomplish a simple task. In theory we could generate the
real internal name much earlier and store it at multiple places along the way instead.

Differential Revision: D94712410


