### PR TITLE
Special case ProcAgent telemetry

### DIFF
--- a/examples/distributed_telemetry_real_data.py
+++ b/examples/distributed_telemetry_real_data.py
@@ -217,8 +217,9 @@ QUERIES = [
            FROM meshes
            ORDER BY given_name""",
     ),
-    # Find all actors in a proc mesh by joining through the actor mesh
-    # actors -> actor mesh (via mesh_id) -> proc mesh (via parent_mesh_id)
+    # Find all actors in a proc mesh.
+    # Regular actors: actor -> actor mesh (mesh_id) -> proc mesh (parent_mesh_id)
+    # ProcMeshAgent actors: actor -> proc mesh (mesh_id) directly
     (
         "Actors in each proc mesh",
         """SELECT pm.given_name AS proc_mesh_name,
@@ -226,10 +227,18 @@ QUERIES = [
                   a.full_name AS actor_name,
                   a.rank
            FROM actors a
-           INNER JOIN meshes am ON a.mesh_id = am.id
-           INNER JOIN meshes pm ON am.parent_mesh_id = pm.id
+           JOIN meshes am ON a.mesh_id = am.id
+           JOIN meshes pm ON am.parent_mesh_id = pm.id
            WHERE pm.class = 'Proc'
-           ORDER BY pm.given_name, am.given_name, a.rank""",
+           UNION ALL
+           SELECT pm.given_name AS proc_mesh_name,
+                  pm.given_name AS actor_mesh_name,
+                  a.full_name AS actor_name,
+                  a.rank
+           FROM actors a
+           JOIN meshes pm ON a.mesh_id = pm.id
+           WHERE pm.class = 'Proc'
+           ORDER BY proc_mesh_name, actor_mesh_name, rank""",
     ),
     # Actor status events schema
     (
@@ -255,7 +264,6 @@ QUERIES = [
            JOIN actors a ON s.actor_id = a.full_name
            ORDER BY s.timestamp_us""",
     ),
-    # NEW queries: actors by class from meshes
     (
         "Actors by class",
         """SELECT class, count(*) as cnt

--- a/hyperactor/src/proc.rs
+++ b/hyperactor/src/proc.rs
@@ -14,8 +14,11 @@
 use std::any::Any;
 use std::any::TypeId;
 use std::collections::HashMap;
+use std::collections::hash_map::DefaultHasher;
 use std::fmt;
 use std::future::Future;
+use std::hash::Hash;
+use std::hash::Hasher;
 use std::ops::Deref;
 use std::panic;
 use std::panic::AssertUnwindSafe;
@@ -391,10 +394,8 @@ impl Proc {
         let (instance, receivers) = Instance::new(self.clone(), actor_id.clone(), false, parent);
 
         // Notify telemetry sinks of actor creation
-        {
-            use std::collections::hash_map::DefaultHasher;
-            use std::hash::Hash;
-            use std::hash::Hasher;
+        // ProcAent and HostAgent are notified separately.
+        if actor_id.name() != "host_agent" && actor_id.name() != "proc_agent" {
             let mut actor_hasher = DefaultHasher::new();
             actor_id.hash(&mut actor_hasher);
             let actor_id_hash = actor_hasher.finish();

--- a/hyperactor_mesh/src/proc_mesh.rs
+++ b/hyperactor_mesh/src/proc_mesh.rs
@@ -284,6 +284,23 @@ impl ProcMesh {
                 parent_mesh_id,
                 parent_view_json,
             });
+
+            // Notify telemetry of each ProcAgent actor in this mesh.
+            // These are skipped in Proc::spawn_inner. mesh_id directly points to proc mesh.
+            let now = RealClock.system_time_now();
+            for rank in current_ref.ranks.iter() {
+                let actor_id = rank.agent.actor_id();
+                let mut actor_hasher = DefaultHasher::new();
+                actor_id.hash(&mut actor_hasher);
+
+                hyperactor_telemetry::notify_actor_created(hyperactor_telemetry::ActorEvent {
+                    id: actor_hasher.finish(),
+                    timestamp: now,
+                    mesh_id: mesh_id_hash,
+                    rank: rank.create_rank as u64,
+                    full_name: actor_id.to_string(),
+                });
+            }
         }
 
         let mut proc_mesh = Self {


### PR DESCRIPTION
Summary:
* we can't rely on Actor's name for ProcAgent and HostAgent since they use reserved "proc_agent" and "host_agent"
* We don't a dedicated actor mesh entry for ProcAgent actors. ProcAgent are treated as proc and it's mesh id directly points to procmesh.
* HostAgent will be handled separately

Reviewed By: zhangrmatthew

Differential Revision: D94564841
