### PR TITLE
Rename HostMeshAgent to HostAgent

### DIFF
--- a/docs/source/books/hyperactor-mesh-book/src/meshes/bootstrapping-appendix-canonical-test.md
+++ b/docs/source/books/hyperactor-mesh-book/src/meshes/bootstrapping-appendix-canonical-test.md
@@ -46,13 +46,13 @@ async fn bootstrap_canonical_simple() {
     //     an in-process service proc (`Proc::new(..)`), and
     //     stores the `BootstrapProcManager` for later spawns.
     //
-    // (3) Install HostMeshAgent (still no new OS process).
-    //     `host.system_proc().spawn::<HostMeshAgent>("agent",
-    //     host).await?` creates the HostMeshAgent actor in that
+    // (3) Install HostAgent (still no new OS process).
+    //     `host.system_proc().spawn::<HostAgent>("host_agent",
+    //     host).await?` creates the HostAgent actor in that
     //     service proc.
     //
     // (4) Collect & assemble. The trampoline returns a
-    //     direct-addressed `ActorRef<HostMeshAgent>`; we collect
+    //     direct-addressed `ActorRef<HostAgent>`; we collect
     //     one per rank and assemble a `HostMesh`.
     //
     // Note: When the Host is later asked to start a proc
@@ -66,7 +66,7 @@ async fn bootstrap_canonical_simple() {
 
     // 6) Spawn a ProcMesh named "p0" on the host mesh:
     //
-    // (1) Each HostMeshAgent (running inside its host's service
+    // (1) Each HostAgent (running inside its host's service
     //     proc) receives the request.
     //
     // (2) The Host calls into its `BootstrapProcManager::spawn`,

--- a/docs/source/books/hyperactor-mesh-book/src/meshes/bootstrapping-doing-real-work.md
+++ b/docs/source/books/hyperactor-mesh-book/src/meshes/bootstrapping-doing-real-work.md
@@ -34,7 +34,7 @@ This is **not** the same as the earlier `ProcMesh::allocate(...)` we saw inside 
 
 What actually happens here, per `HostMeshRef::spawn(...)` in `hyperactor_mesh/src/v1/host_mesh.rs`:
 
-1. For **each host** we already have, it sends a `create_or_update(...)` to that host's **HostMeshAgent** saying "you should have a proc named `p0_0` (then `p0_1`, ...) with this create-rank."
+1. For **each host** we already have, it sends a `create_or_update(...)` to that host's **HostAgent** saying "you should have a proc named `p0_0` (then `p0_1`, ...) with this create-rank."
 2. Each host uses its embedded **BootstrapProcManager** to do the *real* OS-level thing: spawn a new child process, run `bootstrap_or_die()` in it, and have it come back as a proc for that host.
 3. The parent waits for status from every host (so it doesn't return too early).
 4. Finally it gathers all those per-host procs into a `ProcMesh`.

--- a/docs/source/books/hyperactor-mesh-book/src/meshes/bootstrapping-from-python.md
+++ b/docs/source/books/hyperactor-mesh-book/src/meshes/bootstrapping-from-python.md
@@ -1,6 +1,6 @@
 # §5 Bootstrapping from Python
 
-So far we described the Rust side: there is a host, the host has a `HostMeshAgent`, and we send `CreateOrUpdate<ProcSpec>` etc. That's the control plane.
+So far we described the Rust side: there is a host, the host has a `HostAgent`, and we send `CreateOrUpdate<ProcSpec>` etc. That's the control plane.
 
 Most users won't do that by hand — they'll write Python like this:
 
@@ -278,4 +278,4 @@ impl PyHostMesh {
 ```
 (This returns a Python task because all v1 Python bindings wrap Rust async in a small bridge. See Appendix: **Python async bridge (pytokio)**.)
 
-`HostMesh::allocate(...)` is the entry point that stands up the host, creates its system proc, spawns the `HostMeshAgent`, and makes it reachable — it's the same path we used in the Rust canonical example.
+`HostMesh::allocate(...)` is the entry point that stands up the host, creates its system proc, spawns the `HostAgent`, and makes it reachable — it's the same path we used in the Rust canonical example.

--- a/docs/source/books/hyperactor-mesh-book/src/meshes/bootstrapping-overview.md
+++ b/docs/source/books/hyperactor-mesh-book/src/meshes/bootstrapping-overview.md
@@ -1,6 +1,6 @@
 # Bootstrapping Overview
 
-*One sentence:* the controller boots remote hosts, then spawns procs (**1 proc = 1 OS process**). Each host runs one **HostMeshAgent**; **every proc runs its own ProcAgent** supervising that proc’s user/service actors.
+*One sentence:* the controller boots remote hosts, then spawns procs (**1 proc = 1 OS process**). Each host runs one **HostAgent**; **every proc runs its own ProcAgent** supervising that proc’s user/service actors.
 
 <figure id="fig-arch" style="text-align:center;">
   <img src="image/mesh-elements.png"
@@ -15,7 +15,7 @@
 ## What you’re looking at
 
 - **Controller process** (left): owns orchestration APIs and kicks off bootstrapping.
-- **HostMeshAgent** (one per host): manages host-local resources and the service proc.
+- **HostAgent** (one per host): manages host-local resources and the service proc.
 - **ProcAgent** (one per proc): supervises that proc’s actors (service + user).
 - **Procs** (squares): runtime containers; *1 proc = 1 OS process*.
 
@@ -23,7 +23,7 @@
 
 1. Obtain a **proc + instance** (control endpoint).
 2. Use the **v0 process allocator** and **bootstrap handshake** to get remote runtimes.
-3. Promote those runtimes into real **hosts** (start HostMeshAgent).
+3. Promote those runtimes into real **hosts** (start HostAgent).
 4. **Spawn procs and actors** on those hosts (start proc/ProcAgent, spawn  actors).
 
 _For the full, runnable test (see `bootstrap_canonical_simple`), see the appendix._

--- a/docs/source/books/hyperactor-mesh-book/src/meshes/host-and-agents.md
+++ b/docs/source/books/hyperactor-mesh-book/src/meshes/host-and-agents.md
@@ -66,7 +66,7 @@ At the control plane we have the mesh-facing actor:
 
 ```rust
 // hyperactor_mesh/src/v1/host_mesh/mesh_agent.rs
-pub struct HostMeshAgent {
+pub struct HostAgent {
   host: Option<HostAgentMode>,
   created: HashMap<Name, ProcCreationState>,
 }
@@ -105,12 +105,12 @@ pub struct Host<M> {
 
 So the layering from the code's point of view is:
 
-1. `HostMeshAgent` (actor you message over v1)
+1. `HostAgent` (actor you message over v1)
 2. → maybe a `HostAgentMode`
 3. → definitely a `Host<...>` once materialized
 4. → which, through its manager (e.g. `BootstrapProcManager`), owns/spawns the procs and does the `*`/`#n` routing.
 
-## HostMeshAgent message handling
+## HostAgent message handling
 
 The agent is exported with exactly these handlers:
 
@@ -125,7 +125,7 @@ The agent is exported with exactly these handlers:
         ShutdownHost,
     ]
 )]
-pub struct HostMeshAgent {
+pub struct HostAgent {
     host: Option<HostAgentMode>,
     created: HashMap<Name, ProcCreationState>,
     local_mesh_agent: OnceCell<anyhow::Result<ActorHandle<ProcAgent>>>,
@@ -172,7 +172,7 @@ So everything it does is one of those 6 messages.
 
 ## Why this exists
 
-`Host` is local; `HostMeshAgent` is the remote handle for it. Bootstrap code just sends `CreateOrUpdate/Stop/GetState` to the agent; the agent is the one that actually owns the `Host` and can spawn/stop procs. That’s why all handlers use the shared `resource` messages.
+`Host` is local; `HostAgent` is the remote handle for it. Bootstrap code just sends `CreateOrUpdate/Stop/GetState` to the agent; the agent is the one that actually owns the `Host` and can spawn/stop procs. That’s why all handlers use the shared `resource` messages.
 
 ## 1. `ProcSpec` (what we tell the host to run)
 
@@ -200,7 +200,7 @@ pub struct CreateOrUpdate<S> {
     pub spec: S,
 }
 ```
-What the `HostMeshAgent` actually does matches this shape:
+What the `HostAgent` actually does matches this shape:
 - if the host is process-backed (`HostAgentMode::Process(...)`), it builds a `BootstrapProcConfig` using
 - the rank from `CreateOrUpdate::<ProcSpec>`, and
 - the `client_config_override` from `ProcSpec`, and passes that to `host.spawn(...);`
@@ -208,7 +208,7 @@ What the `HostMeshAgent` actually does matches this shape:
 
 Here is the bit of real code that does exactly that (abridged to just the decision):
 ```rust
-// from hyperactor_mesh/src/v1/host_mesh/mesh_agent.rs (`impl Handler<resource::CreateOrUpdate<ProcSpec>> for HostMeshAgent`)
+// from hyperactor_mesh/src/v1/host_mesh/mesh_agent.rs (`impl Handler<resource::CreateOrUpdate<ProcSpec>> for HostAgent`)
 
 let created = match host {
     HostAgentMode::Process(host) => {
@@ -241,7 +241,7 @@ We're not going to unpack the process-backed path here — that lives in **"Boot
 
 ## v1 bootstrap in one pass
 
-The reason the `HostMeshAgent` has those five messages (create, stop, get-state, get-rank-status, shutdown) is that the v1 protocol treats "things on a host" as **resources**. A typical sequence is:
+The reason the `HostAgent` has those five messages (create, stop, get-state, get-rank-status, shutdown) is that the v1 protocol treats "things on a host" as **resources**. A typical sequence is:
 
 1. **Coordinator → hosts:** send `CreateOrUpdate<ProcSpec>` to every host agent in the mesh ("each of you should have a proc called `p0` with this rank/config").
 2. **Coordinator → hosts (later):** send `GetState<ProcState>` (or `GetRankStatus`) to see which hosts actually brought that proc up and what address/command it got.

--- a/docs/source/books/hyperactor-mesh-book/src/meshes/index.md
+++ b/docs/source/books/hyperactor-mesh-book/src/meshes/index.md
@@ -22,7 +22,7 @@ So the through line is: *one process that can speak hyperactor → host → proc
 
 ## Pieces (conceptual)
 
-- **Host**: a long-lived runtime that owns "all procs on this machine" and gives them a single front door (`*` / mux). It also runs a **`HostMeshAgent`** in its system proc so other parts of the mesh can tell it "start/stop this proc."
+- **Host**: a long-lived runtime that owns "all procs on this machine" and gives them a single front door (`*` / mux). It also runs a **`HostAgent`** in its system proc so other parts of the mesh can tell it "start/stop this proc."
 - **Proc**: an actor runtime. In v1 the proc also runs a **`ProcAgent`** so it can be managed the same way as the host — that's why the agent handlers all look like the resource ones you saw.
 - **Actor mesh**: the thing you actually care about as a user — N copies of your actor (often one per proc), callable as a group.
 

--- a/docs/source/books/hyperactor-mesh-book/src/meshes/proc-mesh-and-agent.md
+++ b/docs/source/books/hyperactor-mesh-book/src/meshes/proc-mesh-and-agent.md
@@ -2,7 +2,7 @@
 
 ## What the `ProcAgent` Is
 
-Every proc in a mesh runs a `ProcAgent`. It plays the same role on the proc side that the `HostMeshAgent` plays on the host side: it implements the control-plane interface for "managing this proc as part of a mesh".
+Every proc in a mesh runs a `ProcAgent`. It plays the same role on the proc side that the `HostAgent` plays on the host side: it implements the control-plane interface for "managing this proc as part of a mesh".
 
 The agent has several responsibilities, all of which will be documented on this page:
 - wiring the proc into the mesh router,

--- a/hyper/src/commands/list.rs
+++ b/hyper/src/commands/list.rs
@@ -10,7 +10,7 @@ use hyperactor::ActorRef;
 use hyperactor::channel::ChannelAddr;
 use hyperactor::reference::ProcId;
 use hyperactor_mesh::global_root_client;
-use hyperactor_mesh::host_mesh::mesh_agent::HostMeshAgent;
+use hyperactor_mesh::host_mesh::host_agent::HostAgent;
 use hyperactor_mesh::resource::ListClient;
 
 #[derive(clap::Args, Debug)]
@@ -34,8 +34,8 @@ impl ListCommand {
         let client = global_root_client();
 
         // Codify obtaining a proc's agent in `hyperactor_mesh` somewhere.
-        let agent: ActorRef<HostMeshAgent> =
-            ActorRef::attest(ProcId::Direct(host, "service".to_string()).actor_id("agent", 0));
+        let agent: ActorRef<HostAgent> =
+            ActorRef::attest(ProcId::Direct(host, "service".to_string()).actor_id("host_agent", 0));
 
         let resources = agent.list(&client).await?;
         println!("{}", serde_json::to_string_pretty(&resources)?);

--- a/hyper/src/commands/show.rs
+++ b/hyper/src/commands/show.rs
@@ -10,7 +10,7 @@ use hyperactor::ActorRef;
 use hyperactor::reference::ProcId;
 use hyperactor::reference::Reference;
 use hyperactor_mesh::global_root_client;
-use hyperactor_mesh::host_mesh::mesh_agent::HostMeshAgent;
+use hyperactor_mesh::host_mesh::host_agent::HostAgent;
 use hyperactor_mesh::resource::GetStateClient;
 
 #[derive(clap::Args, Debug)]
@@ -27,8 +27,8 @@ impl ShowCommand {
                 let client = global_root_client();
 
                 // Codify obtaining a proc's agent in `hyperactor_mesh` somewhere.
-                let agent: ActorRef<HostMeshAgent> = ActorRef::attest(
-                    ProcId::Direct(host, "service".to_string()).actor_id("agent", 0),
+                let agent: ActorRef<HostAgent> = ActorRef::attest(
+                    ProcId::Direct(host, "service".to_string()).actor_id("host_agent", 0),
                 );
 
                 let state = agent.get_state(&client, proc.parse().unwrap()).await?;

--- a/hyper/src/main.rs
+++ b/hyper/src/main.rs
@@ -56,7 +56,7 @@ async fn run() -> Result<(), anyhow::Error> {
     // Allow the channel layer to flush pending acks before exit.
     // Without this, the remote host's MailboxClient observes a
     // broken link (30 s ack timeout) and the resulting undeliverable
-    // message crashes the HostMeshAgent, tearing down the entire
+    // message crashes the HostAgent, tearing down the entire
     // mesh.  The ack interval is 500 ms, so 1 s is sufficient.
     RealClock.sleep(std::time::Duration::from_secs(1)).await;
 

--- a/hyperactor/src/host.rs
+++ b/hyperactor/src/host.rs
@@ -1337,7 +1337,7 @@ mod tests {
     #[tokio::test]
     async fn test_basic() {
         let proc_manager =
-            LocalProcManager::new(|proc: Proc| async move { proc.spawn::<()>("agent", ()) });
+            LocalProcManager::new(|proc: Proc| async move { proc.spawn::<()>("host_agent", ()) });
         let procs = Arc::clone(&proc_manager.procs);
         let mut host = Host::new(proc_manager, ChannelAddr::any(ChannelTransport::Local))
             .await
@@ -1403,7 +1403,7 @@ mod tests {
     async fn test_process_proc_manager() {
         hyperactor_telemetry::initialize_logging(crate::clock::ClockKind::default());
 
-        // EchoActor is "agent" used to test connectivity.
+        // EchoActor is "host_agent" used to test connectivity.
         let process_manager = ProcessProcManager::<EchoActor>::new(
             buck_resources::get("monarch/hyperactor/bootstrap").unwrap(),
         );
@@ -1489,7 +1489,7 @@ mod tests {
         // Build a LocalHandle directly.
         let addr = ChannelAddr::any(ChannelTransport::Local);
         let proc_id = ProcId::Direct(addr.clone(), "p".into());
-        let agent_ref = ActorRef::<()>::attest(proc_id.actor_id("agent", 0));
+        let agent_ref = ActorRef::<()>::attest(proc_id.actor_id("host_agent", 0));
         let h = LocalHandle::<()> {
             proc_id,
             addr,
@@ -1619,7 +1619,7 @@ mod tests {
             forwarder_addr: ChannelAddr,
             _config: (),
         ) -> Result<Self::Handle, HostError> {
-            let agent = ActorRef::<()>::attest(proc_id.actor_id("agent", 0));
+            let agent = ActorRef::<()>::attest(proc_id.actor_id("host_agent", 0));
             Ok(TestHandle {
                 id: proc_id,
                 addr: forwarder_addr,

--- a/hyperactor/src/introspect.rs
+++ b/hyperactor/src/introspect.rs
@@ -139,7 +139,7 @@ pub enum NodeProperties {
         system_children: Vec<String>,
     },
 
-    /// A host in the mesh, represented by its `HostMeshAgent`.
+    /// A host in the mesh, represented by its `HostAgent`.
     Host {
         /// Host address (e.g. `127.0.0.1:12345`).
         addr: String,
@@ -200,7 +200,7 @@ pub enum NodeProperties {
         /// enabled/available.
         flight_recorder: Option<String>,
         /// Whether this actor is infrastructure-owned (e.g.
-        /// ProcAgent, HostMeshAgent) rather than user-created.
+        /// ProcAgent, HostAgent) rather than user-created.
         is_system: bool,
         /// Structured failure information, present only for failed
         /// actors. `None` for running or cleanly stopped actors.
@@ -244,7 +244,7 @@ wirevalue::register_type!(NodePayload);
 /// Context for introspection query - what aspect of the actor to
 /// describe.
 ///
-/// Infrastructure actors (e.g., ProcAgent, HostMeshAgent)
+/// Infrastructure actors (e.g., ProcAgent, HostAgent)
 /// have dual nature: they manage entities (Proc, Host) while also
 /// being actors themselves. IntrospectView allows callers to
 /// specify which aspect to query.
@@ -309,7 +309,7 @@ pub struct RecordedEvent {
 
 /// Domain-specific properties an actor may publish for introspection.
 ///
-/// Infrastructure actors (HostMeshAgent, ProcAgent) push these to
+/// Infrastructure actors (HostAgent, ProcAgent) push these to
 /// make their managed-entity metadata available to the introspection
 /// runtime without going through the actor's message handler. The
 /// runtime handler reads the last-published value and merges it into

--- a/hyperactor/src/proc.rs
+++ b/hyperactor/src/proc.rs
@@ -1238,7 +1238,7 @@ impl<A: Actor> Instance<A> {
     /// actor loop), so it must be `Send + Sync` and must not access
     /// actor-mutable state. Capture cloned `Proc` references.
     ///
-    /// Only `HostMeshAgent` uses this today — for resolving system
+    /// Only `HostAgent` uses this today — for resolving system
     /// procs that have no independent `ProcMeshAgent`.
     pub fn set_query_child_handler(
         &self,
@@ -1995,7 +1995,7 @@ struct InstanceCellState {
 
     /// Optional callback for resolving non-addressable children
     /// (e.g., system procs). Registered by infrastructure actors
-    /// like `HostMeshAgent` in `Actor::init`. Invoked by the
+    /// like `HostAgent` in `Actor::init`. Invoked by the
     /// introspection runtime handler for `QueryChild` messages.
     /// `None` means `QueryChild` returns a "not_found" error.
     ///
@@ -2314,7 +2314,7 @@ impl InstanceCell {
     /// introspection. The `published_at` timestamp is set
     /// automatically to `RealClock.system_time_now()`.
     ///
-    /// Infrastructure actors (HostMeshAgent, ProcMeshAgent) call this
+    /// Infrastructure actors (HostAgent, ProcMeshAgent) call this
     /// to make their managed-entity metadata available without going
     /// through the actor's message handler.
     pub fn set_published_properties(&self, kind: PublishedPropertiesKind) {

--- a/hyperactor/src/supervision.rs
+++ b/hyperactor/src/supervision.rs
@@ -97,7 +97,7 @@ fn fmt_status<'a>(
 
     match status {
         ActorStatus::Stopped(_)
-            if actor_id.name() == "agent" || actor_id.name() == "proc_agent" =>
+            if actor_id.name() == "host_agent" || actor_id.name() == "proc_agent" =>
         {
             // Host agent stopped - use simplified message from D86984496
             let name = match actor_id.proc_id() {

--- a/hyperactor_mesh/src/alloc/process.rs
+++ b/hyperactor_mesh/src/alloc/process.rs
@@ -475,7 +475,7 @@ impl ProcessAlloc {
         // (c.f. `enable_forwarding`), we do not do log forwarding on
         // these procs. This is because, now that we are on the v1
         // path, the only procs we spawn via this code path are those
-        // to support `HostMeshAgent`s.
+        // to support `HostAgent`s.
         let log_channel: Option<ChannelAddr> = None;
 
         let index = self.created.len();

--- a/hyperactor_mesh/src/bootstrap.rs
+++ b/hyperactor_mesh/src/bootstrap.rs
@@ -68,8 +68,8 @@ use tracing::Level;
 use typeuri::Named;
 
 use crate::config::MESH_PROC_LAUNCHER_KIND;
-use crate::host_mesh::mesh_agent::HostAgentMode;
-use crate::host_mesh::mesh_agent::HostMeshAgent;
+use crate::host_mesh::host_agent::HostAgent;
+use crate::host_mesh::host_agent::HostAgentMode;
 use crate::logging::OutputTarget;
 use crate::logging::StreamFwder;
 use crate::proc_agent::ProcAgent;
@@ -295,7 +295,7 @@ pub async fn host(
     command: Option<BootstrapCommand>,
     config: Option<Attrs>,
     exit_on_shutdown: bool,
-) -> anyhow::Result<ActorHandle<HostMeshAgent>> {
+) -> anyhow::Result<ActorHandle<HostAgent>> {
     if let Some(attrs) = config {
         hyperactor_config::global::set(hyperactor_config::global::Source::Runtime, attrs);
         tracing::debug!("bootstrap: installed Runtime config snapshot (Host)");
@@ -314,9 +314,9 @@ pub async fn host(
         .await?;
     let addr = host.addr().clone();
     let system_proc = host.system_proc().clone();
-    let host_mesh_agent = system_proc.spawn::<HostMeshAgent>(
-        "agent",
-        HostMeshAgent::new(HostAgentMode::Process {
+    let host_mesh_agent = system_proc.spawn::<HostAgent>(
+        "host_agent",
+        HostAgent::new(HostAgentMode::Process {
             host,
             exit_on_shutdown,
         }),
@@ -325,7 +325,7 @@ pub async fn host(
     tracing::info!(
         "serving host at {}, agent: {}",
         addr,
-        host_mesh_agent.bind::<HostMeshAgent>()
+        host_mesh_agent.bind::<HostAgent>()
     );
 
     Ok(host_mesh_agent)
@@ -362,7 +362,7 @@ pub enum Bootstrap {
     },
 
     /// Bootstrap as a "v1" host bootstrap. This sets up a new `Host`,
-    /// managed by a [`crate::host_mesh::mesh_agent::HostMeshAgent`].
+    /// managed by a [`crate::host_mesh::mesh_agent::HostAgent`].
     Host {
         /// The address on which to serve the host.
         addr: ChannelAddr,
@@ -3235,13 +3235,13 @@ mod tests {
         //     an in-process service proc (`Proc::new(..)`), and
         //     stores the `BootstrapProcManager` for later spawns.
         //
-        // (3) Install HostMeshAgent (still no new OS process).
-        //     `host.system_proc().spawn::<HostMeshAgent>("agent",
-        //     host).await?` creates the HostMeshAgent actor in that
+        // (3) Install HostAgent (still no new OS process).
+        //     `host.system_proc().spawn::<HostAgent>("host_agent",
+        //     host).await?` creates the HostAgent actor in that
         //     service proc.
         //
         // (4) Collect & assemble. The trampoline returns a
-        //     direct-addressed `ActorRef<HostMeshAgent>`; we collect
+        //     direct-addressed `ActorRef<HostAgent>`; we collect
         //     one per rank and assemble a `HostMesh`.
         //
         // Note: When the Host is later asked to start a proc
@@ -3255,7 +3255,7 @@ mod tests {
 
         // Spawn a ProcMesh named "p0" on the host mesh:
         //
-        // (1) Each HostMeshAgent (running inside its host's service
+        // (1) Each HostAgent (running inside its host's service
         // proc) receives the request.
         //
         // (2) The Host calls into its `BootstrapProcManager::spawn`,
@@ -3434,7 +3434,7 @@ mod tests {
     #[tokio::test]
     #[cfg(fbcode_build)]
     async fn test_host_bootstrap() {
-        use crate::host_mesh::mesh_agent::GetLocalProcClient;
+        use crate::host_mesh::host_agent::GetLocalProcClient;
         use crate::proc_agent::NewClientInstanceClient;
 
         // Create a local instance just to call the local bootstrap actor.

--- a/hyperactor_mesh/src/lib.rs
+++ b/hyperactor_mesh/src/lib.rs
@@ -88,9 +88,9 @@ use serde::Serialize;
 use typeuri::Named;
 pub use value_mesh::ValueMesh;
 
-use crate::host_mesh::HostMeshAgent;
+use crate::host_mesh::HostAgent;
 use crate::host_mesh::HostMeshRefParseError;
-use crate::host_mesh::mesh_agent::ProcState;
+use crate::host_mesh::host_agent::ProcState;
 use crate::resource::RankedValues;
 use crate::resource::Status;
 use crate::shortuuid::ShortUuid;
@@ -172,7 +172,7 @@ pub enum Error {
     ProcCreationError {
         state: Box<resource::State<ProcState>>,
         host_rank: usize,
-        mesh_agent: ActorRef<HostMeshAgent>,
+        mesh_agent: ActorRef<HostAgent>,
     },
 
     #[error(

--- a/hyperactor_mesh/src/proc_mesh.rs
+++ b/hyperactor_mesh/src/proc_mesh.rs
@@ -68,7 +68,7 @@ use crate::alloc::AllocExt;
 use crate::alloc::AllocatedProc;
 use crate::assign::Ranks;
 use crate::comm::CommMeshConfig;
-use crate::host_mesh::mesh_agent::ProcState;
+use crate::host_mesh::host_agent::ProcState;
 use crate::host_mesh::mesh_to_rankedvalues_with_default;
 use crate::mesh_controller::ActorMeshController;
 use crate::proc_agent;

--- a/hyperactor_mesh/src/resource.rs
+++ b/hyperactor_mesh/src/resource.rs
@@ -45,7 +45,7 @@ use typeuri::Named;
 use crate::Name;
 use crate::StatusOverlay;
 use crate::bootstrap;
-use crate::host_mesh::mesh_agent::ProcState;
+use crate::host_mesh::host_agent::ProcState;
 use crate::proc_agent::ActorSpec;
 use crate::proc_agent::ActorState;
 

--- a/hyperactor_telemetry/src/lib.rs
+++ b/hyperactor_telemetry/src/lib.rs
@@ -290,7 +290,7 @@ lazy_static! {
     /// Global unified entity event dispatcher with pre-registration buffering.
     /// Events emitted before a dispatcher is registered are buffered and replayed
     /// when `set_entity_dispatcher` is called. This ensures bootstrap actors
-    /// (e.g., HostMeshAgent and ProcAgent) are captured even though they are spawned before the
+    /// (e.g., HostAgent and ProcAgent) are captured even though they are spawned before the
     /// telemetry system is initialized.
     static ref ENTITY_EVENT_STATE: Mutex<EntityEventState> = Mutex::new(
         EntityEventState::Buffering(Vec::new())

--- a/monarch_hyperactor/src/actor.rs
+++ b/monarch_hyperactor/src/actor.rs
@@ -1513,7 +1513,7 @@ mod tests {
     use hyperactor::reference::UnboundPort;
     use hyperactor_mesh::Error as MeshError;
     use hyperactor_mesh::Name;
-    use hyperactor_mesh::host_mesh::mesh_agent::ProcState;
+    use hyperactor_mesh::host_mesh::host_agent::ProcState;
     use hyperactor_mesh::resource::Status;
     use hyperactor_mesh::resource::{self};
     use pyo3::PyTypeInfo;
@@ -1609,7 +1609,7 @@ mod tests {
             assert!(py_msg.contains(", state: "));
             assert!(py_msg.contains("\"status\":{\"Failed\":\"boom\"}"));
             // 3) Starts with the expected prefix
-            let expected_prefix = "error creating proc (host rank 0) on host mesh agent hello[0].actor[0]<hyperactor_mesh::host_mesh::mesh_agent::HostMeshAgent>";
+            let expected_prefix = "error creating proc (host rank 0) on host mesh agent hello[0].actor[0]<hyperactor_mesh::host_mesh::mesh_agent::HostAgent>";
             assert!(py_msg.starts_with(expected_prefix));
         });
     }

--- a/monarch_hyperactor/src/host_mesh.rs
+++ b/monarch_hyperactor/src/host_mesh.rs
@@ -20,9 +20,9 @@ use hyperactor_mesh::bootstrap::BootstrapCommand;
 use hyperactor_mesh::bootstrap::host;
 use hyperactor_mesh::host_mesh::HostMesh;
 use hyperactor_mesh::host_mesh::HostMeshRef;
-use hyperactor_mesh::host_mesh::mesh_agent::GetLocalProcClient;
-use hyperactor_mesh::host_mesh::mesh_agent::HostMeshAgent;
-use hyperactor_mesh::host_mesh::mesh_agent::ShutdownHost;
+use hyperactor_mesh::host_mesh::host_agent::GetLocalProcClient;
+use hyperactor_mesh::host_mesh::host_agent::HostAgent;
+use hyperactor_mesh::host_mesh::host_agent::ShutdownHost;
 use hyperactor_mesh::proc_agent::GetProcClient;
 use hyperactor_mesh::proc_mesh::ProcRef;
 use hyperactor_mesh::shared_cell::SharedCell;
@@ -196,7 +196,7 @@ impl PyHostMesh {
         let instance = instance.clone();
         PyPythonTask::new(async move {
             // Sends a SpawnMeshAdmin message to ranks[0]'s
-            // HostMeshAgent, which spawns the admin on that host's
+            // HostAgent, which spawns the admin on that host's
             // system proc.
             let addr = host_mesh
                 .spawn_admin(instance.deref(), admin_port)
@@ -283,7 +283,7 @@ impl PyHostMeshRefImpl {
 static ROOT_CLIENT_INSTANCE_FOR_HOST: OnceLock<Instance<PythonActor>> = OnceLock::new();
 
 /// Static storage for the host mesh agent created by bootstrap_host().
-static HOST_MESH_AGENT_FOR_HOST: OnceLock<ActorHandle<HostMeshAgent>> = OnceLock::new();
+static HOST_MESH_AGENT_FOR_HOST: OnceLock<ActorHandle<HostAgent>> = OnceLock::new();
 
 /// Bootstrap the client host and root client actor.
 ///

--- a/python/monarch/_src/actor/proc_launcher.py
+++ b/python/monarch/_src/actor/proc_launcher.py
@@ -75,7 +75,7 @@ class ProcLauncher(Actor, ABC):
     Implementations control how procs are spawned (Docker, VMs, custom
     orchestrators, etc.) while Monarch handles lifecycle wiring.
 
-    The launcher runs in the same proc as HostMeshAgent.
+    The launcher runs in the same proc as HostAgent.
     """
 
     def __init__(self, params: dict[str, Any] | None = None) -> None:

--- a/python/tests/test_distributed_telemetry.py
+++ b/python/tests/test_distributed_telemetry.py
@@ -378,7 +378,7 @@ def test_actors_join_meshes_on_mesh_id(cleanup_callbacks) -> None:
 
 @pytest.mark.timeout(120)
 def test_bootstrap_actors_captured(cleanup_callbacks) -> None:
-    """Test that bootstrap actors (ProcAgent, HostMeshAgent) are captured in the actors table.
+    """Test that bootstrap actors (ProcAgent, HostAgent) are captured in the actors table.
 
     These actors are spawned during process bootstrap, before `set_entity_dispatcher`
     is called. The buffering mechanism in `hyperactor_telemetry` should buffer their
@@ -395,7 +395,7 @@ def test_bootstrap_actors_captured(cleanup_callbacks) -> None:
     result = engine.query("SELECT full_name FROM actors")
     full_names = result.to_pydict().get("full_name", [])
 
-    # The Bootstrap actor HostMeshAgent is spawned with name "agent",
+    # The Bootstrap actor HostAgent is spawned with name "host_agent",
     # ProcAgent has the name "proc_agent".
     # Their full_name looks like "unix:@...,<proc>,agent[0]".
     agent_names = [
@@ -403,11 +403,11 @@ def test_bootstrap_actors_captured(cleanup_callbacks) -> None:
     ]
 
     # TODO: Enable this after finding discrepancy between OSS and internal test
-    # # Verify the HostMeshAgent (on the "service" proc) was captured.
+    # # Verify the HostAgent (on the "service" proc) was captured.
     # # This is the first actor spawned during bootstrap, before set_entity_dispatcher.
     # has_host_mesh_agent = any(",service,agent[" in name for name in full_names)
     # assert has_host_mesh_agent, (
-    #     f"Expected HostMeshAgent on service proc, but not found. "
+    #     f"Expected HostAgent on service proc, but not found. "
     #     f"Agent actors: {agent_names}"
     # )
 


### PR DESCRIPTION
Summary:
Same as https://github.com/meta-pytorch/monarch/pull/2811 but extended to changing
HostMeshAgent -> HostAgent.
Also rename the actor id from "agent" -> "host_agent". It is no longer ambiguous with
ProcAgent, but it is still more descriptive in case we add other agents in the future.

Reviewed By: thedavekwon

Differential Revision: D94689187
