### PR TITLE
Re-enable ROCm build workflow triggers

### DIFF
--- a/.github/workflows/build-rocm.yml
+++ b/.github/workflows/build-rocm.yml
@@ -1,12 +1,10 @@
 name: Build ROCm
 
 on:
-  # Temporarily disabled.
-  # To re-enable, uncomment the triggers below and the build-rocm job in ci.yml
-  # workflow_call:
-  # push:
-  #   tags:
-  #     - ciflow/rocm/*
+  workflow_call:
+  push:
+    tags:
+      - ciflow/rocm/*
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,10 +19,9 @@ jobs:
     name: Build CUDA
     uses: ./.github/workflows/build-cuda.yml
 
-  # NOTE: ROCm build is temporarily disabled.
-  # build-rocm:
-  #   name: Build ROCm
-  #   uses: ./.github/workflows/build-rocm.yml
+  build-rocm:
+    name: Build ROCm
+    uses: ./.github/workflows/build-rocm.yml
 
   build-cpu:
     name: Build CPU


### PR DESCRIPTION
Companion to https://github.com/meta-pytorch/monarch/pull/2710 to actually enable ROCm CI.