### PR TITLE
bugfix: proc mesh agent actor id

### DIFF
--- a/hyperactor_mesh/src/bootstrap.rs
+++ b/hyperactor_mesh/src/bootstrap.rs
@@ -3012,8 +3012,10 @@ mod tests {
     fn display_ready_includes_addr() {
         let started_at = RealClock.system_time_now() - Duration::from_secs(5);
         let addr = ChannelAddr::any(ChannelTransport::Unix);
-        let agent =
-            ActorRef::attest(ProcId::Direct(addr.clone(), "proc".into()).actor_id("proc_agent", 0));
+        let agent = ActorRef::attest(
+            ProcId::Direct(addr.clone(), "proc".into())
+                .actor_id(crate::proc_agent::PROC_AGENT_ACTOR_NAME, 0),
+        );
 
         let st = ProcStatus::Ready {
             started_at,
@@ -3049,7 +3051,7 @@ mod tests {
                 addr: ChannelAddr::any(ChannelTransport::Unix),
                 agent: ActorRef::attest(
                     ProcId::Direct(ChannelAddr::any(ChannelTransport::Unix), "x".into())
-                        .actor_id("proc_agent", 0),
+                        .actor_id(crate::proc_agent::PROC_AGENT_ACTOR_NAME, 0),
                 ),
             },
             ProcStatus::Killed {

--- a/hyperactor_mesh/src/host_mesh.rs
+++ b/hyperactor_mesh/src/host_mesh.rs
@@ -106,7 +106,10 @@ wirevalue::register_type!(HostRef);
 impl HostRef {
     /// The host mesh agent associated with this host.
     fn mesh_agent(&self) -> ActorRef<HostMeshAgent> {
-        ActorRef::attest(self.service_proc().actor_id("agent", 0))
+        ActorRef::attest(
+            self.service_proc()
+                .actor_id(mesh_agent::HOST_MESH_AGENT_ACTOR_NAME, 0),
+        )
     }
 
     /// The ProcId for the proc with name `name` on this host.
@@ -351,7 +354,10 @@ impl HostMesh {
         let addr = host.addr().clone();
         let system_proc = host.system_proc().clone();
         let host_mesh_agent = system_proc
-            .spawn("agent", HostMeshAgent::new(HostAgentMode::Local(host)))
+            .spawn(
+                mesh_agent::HOST_MESH_AGENT_ACTOR_NAME,
+                HostMeshAgent::new(HostAgentMode::Local(host)),
+            )
             .map_err(crate::Error::SingletonActorSpawnError)?;
         host_mesh_agent.bind::<HostMeshAgent>();
         Ok(HostRef(addr))
@@ -988,7 +994,10 @@ impl HostMeshRef {
                     proc_id,
                     create_rank,
                     // TODO: specify or retrieve from state instead, to avoid attestation.
-                    ActorRef::attest(host.named_proc(&proc_name).actor_id("proc_agent", 0)),
+                    ActorRef::attest(
+                        host.named_proc(&proc_name)
+                            .actor_id(crate::proc_agent::PROC_AGENT_ACTOR_NAME, 0),
+                    ),
                 ));
             }
         }

--- a/hyperactor_mesh/src/host_mesh/mesh_agent.rs
+++ b/hyperactor_mesh/src/host_mesh/mesh_agent.rs
@@ -201,7 +201,10 @@ pub(crate) struct ProcCreationState {
     pub(crate) created: Result<(ProcId, ActorRef<ProcAgent>), HostError>,
 }
 
-/// A mesh agent is responsible for managing a host iny a [`HostMesh`],
+/// Actor name used when spawning the host mesh agent on the system proc.
+pub const HOST_MESH_AGENT_ACTOR_NAME: &str = "agent";
+
+/// A mesh agent is responsible for managing a host in a [`HostMesh`],
 /// through the resource behaviors defined in [`crate::resource`].
 #[hyperactor::export(
     handlers=[
@@ -797,7 +800,8 @@ impl hyperactor::RemoteSpawn for HostMeshAgentProcMeshTrampoline {
         };
 
         let system_proc = host.system_proc().clone();
-        let host_mesh_agent = system_proc.spawn("agent", HostMeshAgent::new(host))?;
+        let host_mesh_agent =
+            system_proc.spawn(HOST_MESH_AGENT_ACTOR_NAME, HostMeshAgent::new(host))?;
 
         Ok(Self {
             host_mesh_agent,
@@ -853,7 +857,7 @@ mod tests {
         let system_proc = host.system_proc().clone();
         let host_agent = system_proc
             .spawn(
-                "agent",
+                HOST_MESH_AGENT_ACTOR_NAME,
                 HostMeshAgent::new(HostAgentMode::Process {
                     host,
                     exit_on_shutdown: false,
@@ -894,7 +898,7 @@ mod tests {
                 }),
             } if name == resource_name
               && proc_id == ProcId::Direct(host_addr.clone(), name.to_string())
-              && mesh_agent == ActorRef::attest(ProcId::Direct(host_addr.clone(), name.to_string()).actor_id("proc_agent", 0)) && bootstrap_command == Some(BootstrapCommand::test())
+              && mesh_agent == ActorRef::attest(ProcId::Direct(host_addr.clone(), name.to_string()).actor_id(crate::proc_agent::PROC_AGENT_ACTOR_NAME, 0)) && bootstrap_command == Some(BootstrapCommand::test())
               && mesh_agent == proc_status_mesh_agent
         );
     }

--- a/hyperactor_mesh/src/mesh_admin.rs
+++ b/hyperactor_mesh/src/mesh_admin.rs
@@ -159,6 +159,18 @@ pub const MESH_ADMIN_ACTOR_NAME: &str = "mesh_admin";
 /// all resolve requests, including the fast root refresh).
 const SINGLE_HOST_TIMEOUT: Duration = Duration::from_secs(3);
 
+/// Timeout for QueryChild snapshot lookups in resolve_actor_node.
+///
+/// QueryChild is handled by a synchronous callback on the target
+/// actor's IntrospectMessage port — it either returns a terminated
+/// snapshot immediately or returns Error { "not_found" } immediately.
+/// There is no async work behind it, so SINGLE_HOST_TIMEOUT is far
+/// too generous. A short budget here ensures the total time for
+/// resolve_actor_node (QueryChild + live actor Query) stays well
+/// under SINGLE_HOST_TIMEOUT, preventing cascading 504s when the
+/// outer bridge timeout fires before the inner work completes.
+const QUERY_CHILD_TIMEOUT: Duration = Duration::from_millis(100);
+
 /// Structured error response following the gateway RFC envelope
 /// pattern.
 #[derive(Debug, Serialize, Deserialize)]
@@ -850,7 +862,7 @@ impl MeshAdminAgent {
         )?;
 
         let payload = RealClock
-            .timeout(SINGLE_HOST_TIMEOUT, reply_rx.recv())
+            .timeout(QUERY_CHILD_TIMEOUT, reply_rx.recv())
             .await
             .map_err(|_| anyhow::anyhow!("timed out querying proc details"))?
             .map_err(|e| anyhow::anyhow!("failed to receive proc introspection: {}", e))?;
@@ -863,7 +875,7 @@ impl MeshAdminAgent {
         // Fall back to querying the ProcAgent directly (user
         // procs). The conventional ProcAgent ActorId is
         // <proc_id>/proc_agent[0].
-        let mesh_agent_id = proc_id.actor_id("proc_agent", 0);
+        let mesh_agent_id = proc_id.actor_id(crate::proc_agent::PROC_AGENT_ACTOR_NAME, 0);
         let agent_port = PortRef::<IntrospectMessage>::attest_message_port(&mesh_agent_id);
         let (reply_handle, reply_rx) = open_once_port::<NodePayload>(cx);
         agent_port.send(
@@ -1031,7 +1043,7 @@ impl MeshAdminAgent {
             // If found, the actor is definitively dead.
             let terminated = {
                 let proc_id = actor_id.proc_id();
-                let mesh_agent_id = proc_id.actor_id("agent", 0);
+                let mesh_agent_id = proc_id.actor_id(crate::proc_agent::PROC_AGENT_ACTOR_NAME, 0);
                 let agent_port = PortRef::<IntrospectMessage>::attest_message_port(&mesh_agent_id);
                 let child_ref = Reference::Actor(actor_id.clone());
                 let (reply_handle, reply_rx) = open_once_port::<NodePayload>(cx);
@@ -1043,7 +1055,7 @@ impl MeshAdminAgent {
                     },
                 )?;
                 RealClock
-                    .timeout(SINGLE_HOST_TIMEOUT, reply_rx.recv())
+                    .timeout(QUERY_CHILD_TIMEOUT, reply_rx.recv())
                     .await
                     .ok()
                     .and_then(|r| r.ok())
@@ -1527,7 +1539,10 @@ mod tests {
         let host_addr = host.addr().clone();
         let system_proc = host.system_proc().clone();
         let host_agent_handle = system_proc
-            .spawn("agent", HostMeshAgent::new(HostAgentMode::Local(host)))
+            .spawn(
+                crate::host_mesh::mesh_agent::HOST_MESH_AGENT_ACTOR_NAME,
+                HostMeshAgent::new(HostAgentMode::Local(host)),
+            )
             .unwrap();
         let host_agent_ref: ActorRef<HostMeshAgent> = host_agent_handle.bind();
         let host_addr_str = host_addr.to_string();
@@ -1686,7 +1701,10 @@ mod tests {
         let host_addr = host.addr().clone();
         let system_proc = host.system_proc().clone();
         let host_agent_handle = system_proc
-            .spawn("agent", HostMeshAgent::new(HostAgentMode::Local(host)))
+            .spawn(
+                crate::host_mesh::mesh_agent::HOST_MESH_AGENT_ACTOR_NAME,
+                HostMeshAgent::new(HostAgentMode::Local(host)),
+            )
             .unwrap();
         let host_agent_ref: ActorRef<HostMeshAgent> = host_agent_handle.bind();
         let host_addr_str = host_addr.to_string();
@@ -1843,7 +1861,10 @@ mod tests {
         let host_addr = host.addr().clone();
         let system_proc = host.system_proc().clone();
         let host_agent_handle = system_proc
-            .spawn("agent", HostMeshAgent::new(HostAgentMode::Local(host)))
+            .spawn(
+                crate::host_mesh::mesh_agent::HOST_MESH_AGENT_ACTOR_NAME,
+                HostMeshAgent::new(HostAgentMode::Local(host)),
+            )
             .unwrap();
         let host_agent_ref: ActorRef<HostMeshAgent> = host_agent_handle.bind();
         let host_addr_str = host_addr.to_string();
@@ -1999,7 +2020,10 @@ mod tests {
         let host_addr = host.addr().clone();
         let system_proc = host.system_proc().clone();
         let host_agent_handle = system_proc
-            .spawn("agent", HostMeshAgent::new(HostAgentMode::Local(host)))
+            .spawn(
+                crate::host_mesh::mesh_agent::HOST_MESH_AGENT_ACTOR_NAME,
+                HostMeshAgent::new(HostAgentMode::Local(host)),
+            )
             .unwrap();
         let host_agent_ref: ActorRef<HostMeshAgent> = host_agent_handle.bind();
         let host_addr_str = host_addr.to_string();
@@ -2098,7 +2122,10 @@ mod tests {
         let system_proc = host.system_proc().clone();
         let system_proc_id = system_proc.proc_id().clone();
         let host_agent_handle = system_proc
-            .spawn("agent", HostMeshAgent::new(HostAgentMode::Local(host)))
+            .spawn(
+                crate::host_mesh::mesh_agent::HOST_MESH_AGENT_ACTOR_NAME,
+                HostMeshAgent::new(HostAgentMode::Local(host)),
+            )
             .unwrap();
         let host_agent_ref: ActorRef<HostMeshAgent> = host_agent_handle.bind();
         let host_addr_str = host_addr.to_string();

--- a/hyperactor_mesh/src/proc_agent.rs
+++ b/hyperactor_mesh/src/proc_agent.rs
@@ -60,6 +60,9 @@ use typeuri::Named;
 use crate::Name;
 use crate::resource;
 
+/// Actor name used when spawning the proc agent on user procs.
+pub const PROC_AGENT_ACTOR_NAME: &str = "proc_agent";
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Named)]
 pub enum GspawnResult {
     Success { rank: usize, actor_id: ActorId },
@@ -270,7 +273,7 @@ impl ProcAgent {
             supervision_events: HashMap::new(),
             shutdown_tx,
         };
-        proc.spawn::<Self>("proc_agent", agent)
+        proc.spawn::<Self>(PROC_AGENT_ACTOR_NAME, agent)
     }
 
     async fn destroy_and_wait_except_current<'a>(


### PR DESCRIPTION
Summary:
## bugfix master

D94552142 changed the proc mesh agent's well known actor-id from "agent" to "proc_agent". 

in-flight tui diffs open-coded the id as "agent". those in-flight diffs did not get changed when the agent id changed. the result is changed runtime behavior (timeouts) resulting in a broken user experience. 

---


this change replaces hard-coded actor name strings with shared constants (HOST_MESH_AGENT_ACTOR_NAME, PROC_AGENT_ACTOR_NAME) and uses them consistently across spawn, attestation, and tests.

it also introduces a shorter QUERY_CHILD_TIMEOUT for QueryChild snapshot lookups, reflecting the synchronous callback semantics and preventing resolve_actor_node from consuming the full SINGLE_HOST_TIMEOUT budget. 

the net effect is improved correctness (single source of truth for agent names) and more predictable latency under failure conditions.

Differential Revision: D94833190


