### PR TITLE
add live admin/TUI diagnostics and fix proc introspection to reflect direct spawned actors

### DIFF
--- a/hyperactor_mesh/bin/admin_tui/actions.rs
+++ b/hyperactor_mesh/bin/admin_tui/actions.rs
@@ -16,4 +16,6 @@ pub(crate) enum KeyResult {
     NeedsRefresh,
     /// Lazily expand the node at the given (reference, depth).
     ExpandNode(String, usize),
+    /// Start the self-diagnostic suite against the attached mesh.
+    RunDiagnostics,
 }

--- a/hyperactor_mesh/bin/admin_tui/app.rs
+++ b/hyperactor_mesh/bin/admin_tui/app.rs
@@ -21,6 +21,7 @@ use hyperactor::introspect::NodePayload;
 use hyperactor::introspect::NodeProperties;
 use ratatui::Terminal;
 use ratatui::backend::CrosstermBackend;
+use tokio::sync::mpsc;
 
 use crate::Args;
 use crate::Cursor;
@@ -37,6 +38,8 @@ use crate::collapse_all;
 use crate::collect_expanded_refs;
 use crate::collect_refs;
 use crate::derive_label;
+use crate::diagnostics::DiagResult;
+use crate::diagnostics::run_diagnostics;
 use crate::fetch_with_join;
 use crate::find_at_depth_from_root_mut;
 use crate::flatten_tree;
@@ -111,6 +114,15 @@ pub(crate) struct App {
     pub(crate) theme_name: ThemeName,
     /// Active language (for display in header).
     pub(crate) lang_name: LangName,
+
+    /// Accumulated results from the running/completed diagnostic suite.
+    pub(crate) diag_results: Vec<DiagResult>,
+    /// True while the diagnostic task is still sending results.
+    pub(crate) diag_running: bool,
+    /// Live channel from `run_diagnostics`; `None` when idle.
+    pub(crate) diag_rx: Option<mpsc::Receiver<DiagResult>>,
+    /// Vertical scroll offset for the diagnostics pane.
+    pub(crate) diag_scroll: u16,
 }
 
 impl App {
@@ -145,6 +157,10 @@ impl App {
             theme: Theme::new(theme_name, lang_name),
             theme_name,
             lang_name,
+            diag_results: Vec::new(),
+            diag_running: false,
+            diag_rx: None,
+            diag_scroll: 0,
         }
     }
 
@@ -576,6 +592,26 @@ impl App {
     /// (e.g. after expanding nodes or toggling system-proc
     /// visibility).
     pub(crate) fn on_key(&mut self, key: KeyEvent) -> KeyResult {
+        // When the diagnostics pane is showing, intercept navigation keys.
+        if self.diag_running || !self.diag_results.is_empty() {
+            match key.code {
+                KeyCode::Esc => {
+                    self.diag_results.clear();
+                    self.diag_running = false;
+                    self.diag_rx = None;
+                    self.diag_scroll = 0;
+                }
+                KeyCode::Up | KeyCode::Char('k') => {
+                    self.diag_scroll = self.diag_scroll.saturating_sub(1);
+                }
+                KeyCode::Down | KeyCode::Char('j') => {
+                    self.diag_scroll = self.diag_scroll.saturating_add(1);
+                }
+                _ => {}
+            }
+            return KeyResult::None;
+        }
+
         let rows = self.visible_rows();
 
         match key.code {
@@ -696,6 +732,10 @@ impl App {
                     KeyResult::None
                 }
             }
+            KeyCode::Char('d') => {
+                // Open diagnostics pane (any key closes it).
+                KeyResult::RunDiagnostics
+            }
             KeyCode::Char('u') if key.modifiers.contains(KeyModifiers::CONTROL) => {
                 // Page up (Ctrl+U, vi-style)
                 if self.cursor.page_up(10) {
@@ -725,6 +765,18 @@ impl App {
             }
             _ => KeyResult::None,
         }
+    }
+}
+
+/// Receive the next diagnostic result if a run is in progress.
+///
+/// Returns `std::future::pending()` when `rx` is `None` so the
+/// `tokio::select!` arm is never woken — equivalent to disabling
+/// the arm without requiring conditional compilation.
+async fn recv_diag(rx: &mut Option<mpsc::Receiver<DiagResult>>) -> Option<DiagResult> {
+    match rx {
+        Some(rx) => rx.recv().await,
+        None => std::future::pending().await,
     }
 }
 
@@ -779,11 +831,29 @@ pub(crate) async fn run_app(
                                 }
                                 app.update_selected_detail().await;
                             }
+                            KeyResult::RunDiagnostics => {
+                                app.diag_running = true;
+                                app.diag_results.clear();
+                                app.diag_scroll = 0;
+                                app.diag_rx = Some(run_diagnostics(
+                                    app.client.clone(),
+                                    app.base_url.clone(),
+                                ));
+                            }
                             KeyResult::None => {}
                         }
                     }
                     Some(Ok(Event::Resize(_, _))) => {}
                     _ => {}
+                }
+            }
+            result = recv_diag(&mut app.diag_rx) => {
+                match result {
+                    Some(r) => app.diag_results.push(r),
+                    None => {
+                        app.diag_running = false;
+                        app.diag_rx = None;
+                    }
                 }
             }
         }

--- a/hyperactor_mesh/bin/admin_tui/diagnostics.rs
+++ b/hyperactor_mesh/bin/admin_tui/diagnostics.rs
@@ -1,0 +1,409 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+//! Self-diagnostic for the mesh admin TUI.
+//!
+//! Walks the full resolution graph (root → hosts → service proc
+//! actors → first user proc → first user actor) and probes each node
+//! via `GET /v1/{reference}`. Results stream through an
+//! `mpsc::Receiver` so the TUI can render them live as each check
+//! completes.
+//!
+//! # Failure domains
+//!
+//! Checks are tagged with a [`DiagPhase`]:
+//!
+//! - **[`DiagPhase::AdminInfra`]**: root, host agents, service proc,
+//!   `agent[0]`, `mesh_admin[0]`, `mesh_admin_bridge[0]`. These test
+//!   the admin layer itself independent of user workloads.
+//! - **[`DiagPhase::Mesh`]**: first user proc and actor. These test
+//!   whether the user's mesh is healthy.
+//!
+//! If Phase 1 passes but Phase 2 fails → mesh problem.
+//! If Phase 1 fails → admin infra bug.
+
+use std::collections::HashSet;
+use std::time::Duration;
+use std::time::Instant;
+
+use hyperactor::clock::Clock;
+use hyperactor::introspect::NodeProperties;
+use hyperactor_mesh::host_mesh::host_agent::HOST_MESH_AGENT_ACTOR_NAME;
+use hyperactor_mesh::mesh_admin::MESH_ADMIN_ACTOR_NAME;
+use hyperactor_mesh::mesh_admin::MESH_ADMIN_BRIDGE_NAME;
+use hyperactor_mesh::proc_agent::PROC_AGENT_ACTOR_NAME;
+use hyperactor_mesh::proc_mesh::COMM_ACTOR_NAME;
+use serde::Serialize;
+use tokio::sync::mpsc;
+
+use crate::fetch::fetch_node_raw;
+
+/// Which layer of the stack a diagnostic check exercises.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub(crate) enum DiagPhase {
+    /// Root, host agents, service proc, and its actors — tests admin
+    /// infra independent of user workloads.
+    AdminInfra,
+    /// First user proc and actor — tests whether the mesh itself is
+    /// healthy.
+    Mesh,
+}
+
+/// Outcome of a single diagnostic probe.
+#[derive(Debug, Clone, Serialize)]
+pub(crate) enum DiagOutcome {
+    /// HTTP 200 received within [`SLOW_MS`] milliseconds.
+    Pass { elapsed_ms: u64 },
+    /// HTTP 200 received, but slower than [`SLOW_MS`].
+    Slow { elapsed_ms: u64 },
+    /// HTTP error, non-200 status, or timeout.
+    Fail { elapsed_ms: u64, error: String },
+}
+
+/// The semantic role of a probed node, used to look up a localised
+/// annotation in [`Labels`](crate::theme::Labels).
+#[derive(Debug, Clone, Copy, Serialize)]
+pub(crate) enum DiagNodeRole {
+    /// The admin HTTP server itself — the root of the resolution graph.
+    AdminServer,
+    /// A host agent process — one per machine, manages all procs.
+    HostAgent,
+    /// The system proc that houses the admin actor layer.
+    AdminServiceProc,
+    /// The `mesh_admin` actor that handles all `GET /v1/…` requests.
+    IntrospectionHandler,
+    /// The `agent` actor that manages actor spawn and lifecycle.
+    ActorLifecycleManager,
+    /// The `mesh_admin_bridge` instance that connects admin to the mesh.
+    RootClientBridge,
+    /// The `comm` actor on a user proc — enables proc-to-proc mesh messaging.
+    CommActor,
+    /// The `proc_agent` actor on a user proc — manages actor spawn and lifecycle.
+    ProcAgent,
+    /// The first non-system proc — confirms user workload is alive.
+    UserProc,
+    /// The first non-system actor in a user proc — reachable through full stack.
+    UserActor,
+}
+
+/// Result of a single diagnostic probe.
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct DiagResult {
+    /// Human-readable check name shown in the TUI (e.g. `"agent[0]"`).
+    pub(crate) label: String,
+    /// Exact reference passed to `GET /v1/{reference}` — use this to
+    /// reproduce the probe or identify the failing node directly.
+    pub(crate) reference: String,
+    /// Semantic role used to look up the localised annotation.
+    pub(crate) note: Option<DiagNodeRole>,
+    /// Which failure domain this check belongs to.
+    pub(crate) phase: DiagPhase,
+    /// Probe outcome.
+    pub(crate) outcome: DiagOutcome,
+}
+
+// Response latency above which a pass is reported as slow.
+const SLOW_MS: u64 = 500;
+
+// Per-probe timeout. Set above the server's SINGLE_HOST_TIMEOUT (3 s)
+// so server-side 504s are surfaced as Fail(error) rather than our own
+// timeout.
+const TIMEOUT_MS: u64 = 5000;
+
+/// Run the full diagnostic suite against `base_url`.
+///
+/// Returns a channel receiver. The spawned task sends one
+/// [`DiagResult`] as each probe completes (in walk order). The
+/// channel closes when all probes finish, signalling completion.
+pub(crate) fn run_diagnostics(
+    client: reqwest::Client,
+    base_url: String,
+) -> mpsc::Receiver<DiagResult> {
+    let (tx, rx) = mpsc::channel(64);
+    tokio::spawn(async move {
+        walk(&client, &base_url, &tx).await;
+    });
+    rx
+}
+
+/// Send a single `DiagResult` and ignore send errors (TUI exited).
+macro_rules! emit {
+    ($tx:expr, $result:expr) => {
+        let _ = $tx.send($result).await;
+    };
+}
+
+/// Probe one reference and return both the `DiagResult` and (on
+/// success) the fetched `NodePayload`.
+async fn probe(
+    client: &reqwest::Client,
+    base_url: &str,
+    label: impl Into<String>,
+    reference: impl Into<String>,
+    phase: DiagPhase,
+) -> (DiagResult, Option<hyperactor::introspect::NodePayload>) {
+    let label = label.into();
+    let reference = reference.into();
+    let t0 = Instant::now();
+
+    let result = hyperactor::clock::RealClock
+        .timeout(
+            Duration::from_millis(TIMEOUT_MS),
+            fetch_node_raw(client, base_url, &reference),
+        )
+        .await;
+
+    let elapsed_ms = t0.elapsed().as_millis() as u64;
+
+    let (outcome, payload) = match result {
+        Ok(Ok(p)) if elapsed_ms >= SLOW_MS => (DiagOutcome::Slow { elapsed_ms }, Some(p)),
+        Ok(Ok(p)) => (DiagOutcome::Pass { elapsed_ms }, Some(p)),
+        Ok(Err(e)) => (
+            DiagOutcome::Fail {
+                elapsed_ms,
+                error: e,
+            },
+            None,
+        ),
+        Err(_) => (
+            DiagOutcome::Fail {
+                elapsed_ms,
+                error: format!("timed out after {}ms", TIMEOUT_MS),
+            },
+            None,
+        ),
+    };
+
+    (
+        DiagResult {
+            label,
+            reference,
+            note: None,
+            phase,
+            outcome,
+        },
+        payload,
+    )
+}
+
+/// Derive a short human-readable label from the resolved NodePayload.
+fn label_from_payload(reference: &str, payload: &hyperactor::introspect::NodePayload) -> String {
+    match &payload.properties {
+        NodeProperties::Root { .. } => "root".to_string(),
+        NodeProperties::Host { addr, .. } => addr.clone(),
+        NodeProperties::Proc { proc_name, .. } => proc_name.clone(),
+        NodeProperties::Actor { .. } => {
+            // ActorId format: "proc_id,actor_name[rank]" — extract
+            // the last comma-separated component.
+            reference
+                .rsplit(',')
+                .next()
+                .unwrap_or(reference)
+                .to_string()
+        }
+        NodeProperties::Error { message, .. } => message.clone(),
+    }
+}
+
+/// Full diagnostic walk. Probes in order and emits results.
+async fn walk(client: &reqwest::Client, base_url: &str, tx: &mpsc::Sender<DiagResult>) {
+    // Phase 1 — Admin Infra
+
+    // Root.
+    let (mut result, root_payload) =
+        probe(client, base_url, "root", "root", DiagPhase::AdminInfra).await;
+    result.note = Some(DiagNodeRole::AdminServer);
+    emit!(tx, result);
+    let root_payload = match root_payload {
+        Some(p) => p,
+        None => return,
+    };
+
+    // Root-level system procs (e.g. mesh_root_client_proc) are admin
+    // infrastructure managed by the framework. Skip them here — they
+    // are not host agents and their children are not user procs.
+    let root_system_refs: HashSet<&str> = match &root_payload.properties {
+        NodeProperties::Root {
+            system_children, ..
+        } => system_children.iter().map(|s| s.as_str()).collect(),
+        _ => HashSet::new(),
+    };
+
+    for host_ref in root_payload
+        .children
+        .iter()
+        .filter(|r| !root_system_refs.contains(r.as_str()))
+    {
+        // Host agent.
+        let (mut r, host_payload) = probe(
+            client,
+            base_url,
+            host_ref.as_str(),
+            host_ref.as_str(),
+            DiagPhase::AdminInfra,
+        )
+        .await;
+        if let Some(p) = &host_payload {
+            r.label = label_from_payload(host_ref, p);
+        }
+        r.note = Some(DiagNodeRole::HostAgent);
+        emit!(tx, r);
+
+        let host_payload = match host_payload {
+            Some(p) => p,
+            None => continue,
+        };
+
+        let system_refs: HashSet<&str> = match &host_payload.properties {
+            NodeProperties::Host {
+                system_children, ..
+            } => system_children.iter().map(|s| s.as_str()).collect(),
+            _ => HashSet::new(),
+        };
+
+        // Service proc(s) and their actors.
+        for proc_ref in host_payload
+            .children
+            .iter()
+            .filter(|r| system_refs.contains(r.as_str()))
+        {
+            let (mut r, proc_payload) = probe(
+                client,
+                base_url,
+                proc_ref.as_str(),
+                proc_ref.as_str(),
+                DiagPhase::AdminInfra,
+            )
+            .await;
+            if let Some(p) = &proc_payload {
+                r.label = label_from_payload(proc_ref, p);
+            }
+            r.note = Some(DiagNodeRole::AdminServiceProc);
+            emit!(tx, r);
+
+            if let Some(proc_payload) = proc_payload {
+                for actor_ref in &proc_payload.children {
+                    let (mut r, payload) = probe(
+                        client,
+                        base_url,
+                        actor_ref.as_str(),
+                        actor_ref.as_str(),
+                        DiagPhase::AdminInfra,
+                    )
+                    .await;
+                    // Use fetched label if available; otherwise derive
+                    // from ref string directly (same logic as
+                    // label_from_payload for Actor).
+                    if let Some(p) = &payload {
+                        r.label = format!("  {}", label_from_payload(actor_ref, p));
+                    } else {
+                        let name = actor_ref.rsplit(',').next().unwrap_or(actor_ref.as_str());
+                        r.label = format!("  {}", name);
+                    }
+                    let actor_name = actor_ref.rsplit(',').next().unwrap_or("");
+                    r.note = if actor_name.starts_with(MESH_ADMIN_BRIDGE_NAME) {
+                        Some(DiagNodeRole::RootClientBridge)
+                    } else if actor_name.starts_with(MESH_ADMIN_ACTOR_NAME) {
+                        Some(DiagNodeRole::IntrospectionHandler)
+                    } else if actor_name.starts_with(HOST_MESH_AGENT_ACTOR_NAME) {
+                        Some(DiagNodeRole::ActorLifecycleManager)
+                    } else {
+                        None
+                    };
+                    emit!(tx, r);
+                }
+            }
+        }
+
+        // Phase 2 — Mesh: every user proc, all its system actors, and
+        // the first non-system actor as a representative user actor.
+        for user_proc_ref in host_payload
+            .children
+            .iter()
+            .filter(|r| !system_refs.contains(r.as_str()))
+        {
+            let (mut r, proc_payload) = probe(
+                client,
+                base_url,
+                user_proc_ref.as_str(),
+                user_proc_ref.as_str(),
+                DiagPhase::Mesh,
+            )
+            .await;
+            if let Some(p) = &proc_payload {
+                r.label = label_from_payload(user_proc_ref, p);
+            }
+            r.note = Some(DiagNodeRole::UserProc);
+            emit!(tx, r);
+
+            if let Some(proc_payload) = proc_payload {
+                let proc_system_refs: HashSet<&str> = match &proc_payload.properties {
+                    NodeProperties::Proc {
+                        system_children, ..
+                    } => system_children.iter().map(|s| s.as_str()).collect(),
+                    _ => HashSet::new(),
+                };
+
+                // Probe every system actor on this user proc.
+                for actor_ref in proc_payload
+                    .children
+                    .iter()
+                    .filter(|r| proc_system_refs.contains(r.as_str()))
+                {
+                    let (mut r, payload) = probe(
+                        client,
+                        base_url,
+                        actor_ref.as_str(),
+                        actor_ref.as_str(),
+                        DiagPhase::Mesh,
+                    )
+                    .await;
+                    if let Some(p) = &payload {
+                        r.label = format!("  {}", label_from_payload(actor_ref, p));
+                    } else {
+                        let name = actor_ref.rsplit(',').next().unwrap_or(actor_ref.as_str());
+                        r.label = format!("  {}", name);
+                    }
+                    let actor_name = actor_ref.rsplit(',').next().unwrap_or("");
+                    r.note = if actor_name.starts_with(COMM_ACTOR_NAME) {
+                        Some(DiagNodeRole::CommActor)
+                    } else if actor_name.starts_with(PROC_AGENT_ACTOR_NAME) {
+                        Some(DiagNodeRole::ProcAgent)
+                    } else {
+                        None
+                    };
+                    emit!(tx, r);
+                }
+
+                // Probe the first non-system actor as a representative.
+                if let Some(actor_ref) = proc_payload
+                    .children
+                    .iter()
+                    .find(|r| !proc_system_refs.contains(r.as_str()))
+                {
+                    let (mut r, payload) = probe(
+                        client,
+                        base_url,
+                        actor_ref.as_str(),
+                        actor_ref.as_str(),
+                        DiagPhase::Mesh,
+                    )
+                    .await;
+                    if let Some(p) = &payload {
+                        r.label = format!("  {}", label_from_payload(actor_ref, p));
+                    } else {
+                        let name = actor_ref.rsplit(',').next().unwrap_or(actor_ref.as_str());
+                        r.label = format!("  {}", name);
+                    }
+                    r.note = Some(DiagNodeRole::UserActor);
+                    emit!(tx, r);
+                }
+            }
+        }
+    }
+}

--- a/hyperactor_mesh/bin/admin_tui/main.rs
+++ b/hyperactor_mesh/bin/admin_tui/main.rs
@@ -108,6 +108,7 @@
 mod actions;
 mod app;
 mod client;
+mod diagnostics;
 mod fetch;
 mod filter;
 mod format;
@@ -195,13 +196,78 @@ async fn main() -> io::Result<()> {
     run(None).await
 }
 
+async fn run_diagnose(client: reqwest::Client, base_url: String) -> io::Result<()> {
+    use crate::diagnostics::DiagOutcome;
+    use crate::diagnostics::DiagPhase;
+    use crate::diagnostics::run_diagnostics;
+
+    // Global timeout: prevents hanging if the server is unreachable or
+    // per-probe timeouts interact badly with very large meshes.
+    const GLOBAL_TIMEOUT_SECS: u64 = 120;
+
+    let mut rx = run_diagnostics(client, base_url);
+    let mut results = Vec::new();
+
+    let timed_out = RealClock
+        .timeout(Duration::from_secs(GLOBAL_TIMEOUT_SECS), async {
+            while let Some(r) = rx.recv().await {
+                results.push(r);
+            }
+        })
+        .await
+        .is_err();
+
+    let is_pass =
+        |o: &DiagOutcome| matches!(o, DiagOutcome::Pass { .. } | DiagOutcome::Slow { .. });
+
+    let total = results.len();
+    let passed = results.iter().filter(|r| is_pass(&r.outcome)).count();
+    let admin_total = results
+        .iter()
+        .filter(|r| r.phase == DiagPhase::AdminInfra)
+        .count();
+    let admin_passed = results
+        .iter()
+        .filter(|r| r.phase == DiagPhase::AdminInfra && is_pass(&r.outcome))
+        .count();
+    let mesh_total = results
+        .iter()
+        .filter(|r| r.phase == DiagPhase::Mesh)
+        .count();
+    let mesh_passed = results
+        .iter()
+        .filter(|r| r.phase == DiagPhase::Mesh && is_pass(&r.outcome))
+        .count();
+    let healthy = passed == total && !timed_out;
+
+    let report = serde_json::json!({
+        "checks": results,
+        "timed_out": timed_out,
+        "summary": {
+            "total": total,
+            "passed": passed,
+            "failed": total - passed,
+            "admin_infra_passed": admin_passed,
+            "admin_infra_total": admin_total,
+            "mesh_passed": mesh_passed,
+            "mesh_total": mesh_total,
+            "healthy": healthy,
+        }
+    });
+
+    println!(
+        "{}",
+        serde_json::to_string_pretty(&report).unwrap_or_else(|e| format!("{{\"error\": \"{e}\"}}"))
+    );
+
+    if !healthy {
+        std::process::exit(1);
+    }
+    Ok(())
+}
+
 async fn run(fb: Option<fbinit::FacebookInit>) -> io::Result<()> {
     let mut args = Args::parse();
-
-    if !io::stdout().is_terminal() {
-        eprintln!("This TUI requires a real terminal.");
-        return Ok(());
-    }
 
     // Resolve mast_conda:/// handles to https://fqdn:port before
     // building the HTTP client (INV-DISPATCH).
@@ -213,6 +279,15 @@ async fn run(fb: Option<fbinit::FacebookInit>) -> io::Result<()> {
     // Build the HTTP client and base URL, configuring TLS when
     // certificates are available.
     let (base_url, client) = client::build_client(&args);
+
+    if args.diagnose {
+        return run_diagnose(client, base_url).await;
+    }
+
+    if !io::stdout().is_terminal() {
+        eprintln!("This TUI requires a real terminal.");
+        return Ok(());
+    }
 
     // Show an indicatif spinner on stderr while fetching initial data.
     // This runs before the alternate screen so it's visible as a normal

--- a/hyperactor_mesh/bin/admin_tui/render/detail_pane.rs
+++ b/hyperactor_mesh/bin/admin_tui/render/detail_pane.rs
@@ -18,6 +18,7 @@ use ratatui::layout::Direction;
 use ratatui::layout::Layout;
 use ratatui::layout::Rect;
 use ratatui::style::Color;
+use ratatui::style::Modifier;
 use ratatui::style::Style;
 use ratatui::text::Line;
 use ratatui::text::Span;
@@ -27,6 +28,10 @@ use ratatui::widgets::Paragraph;
 use ratatui::widgets::Wrap;
 
 use crate::App;
+use crate::diagnostics::DiagNodeRole;
+use crate::diagnostics::DiagOutcome;
+use crate::diagnostics::DiagPhase;
+use crate::diagnostics::DiagResult;
 use crate::format::format_event_summary;
 use crate::format::format_local_time;
 use crate::format::format_relative_time;
@@ -42,6 +47,10 @@ use crate::theme::Labels;
 /// the last fetch error (`app.detail_error`) or a neutral "select a
 /// node" placeholder message.
 pub(crate) fn render_detail_pane(frame: &mut ratatui::Frame<'_>, area: Rect, app: &App) {
+    if app.diag_running || !app.diag_results.is_empty() {
+        render_diagnostics_pane(frame, area, app);
+        return;
+    }
     match &app.detail {
         Some(payload) => {
             render_node_detail(frame, area, payload, &app.theme.scheme, &app.theme.labels)
@@ -440,4 +449,168 @@ fn render_actor_detail(
         .block(recorder_block)
         .wrap(Wrap { trim: true });
     frame.render_widget(recorder, chunks[1]);
+}
+
+/// Render the live self-diagnostic pane.
+///
+/// Shows phase-separated probe results as they stream in. While the
+/// run is still in progress a "Running…" indicator is shown; once
+/// complete a summary line reports overall health.
+fn render_diagnostics_pane(frame: &mut ratatui::Frame<'_>, area: Rect, app: &App) {
+    let scheme = &app.theme.scheme;
+    let labels = &app.theme.labels;
+    let results = &app.diag_results;
+
+    let mut lines: Vec<Line<'static>> = Vec::new();
+    let sep_style = Style::default().add_modifier(Modifier::BOLD);
+
+    // Admin Infra section
+    lines.push(Line::from(Span::styled(
+        "── Admin Infra ──────────────────────────────────",
+        sep_style,
+    )));
+    for r in results.iter().filter(|r| r.phase == DiagPhase::AdminInfra) {
+        lines.push(diag_result_line(r, scheme, labels));
+    }
+
+    lines.push(Line::default());
+
+    // Mesh section
+    lines.push(Line::from(Span::styled(
+        "── Mesh ─────────────────────────────────────────",
+        sep_style,
+    )));
+    for r in results.iter().filter(|r| r.phase == DiagPhase::Mesh) {
+        lines.push(diag_result_line(r, scheme, labels));
+    }
+
+    if app.diag_running {
+        lines.push(Line::default());
+        lines.push(Line::from(Span::styled(labels.diag_running, scheme.info)));
+    } else if !results.is_empty() {
+        let admin_pass = results
+            .iter()
+            .filter(|r| {
+                r.phase == DiagPhase::AdminInfra
+                    && matches!(
+                        r.outcome,
+                        DiagOutcome::Pass { .. } | DiagOutcome::Slow { .. }
+                    )
+            })
+            .count();
+        let admin_total = results
+            .iter()
+            .filter(|r| r.phase == DiagPhase::AdminInfra)
+            .count();
+        let mesh_pass = results
+            .iter()
+            .filter(|r| {
+                r.phase == DiagPhase::Mesh
+                    && matches!(
+                        r.outcome,
+                        DiagOutcome::Pass { .. } | DiagOutcome::Slow { .. }
+                    )
+            })
+            .count();
+        let mesh_total = results
+            .iter()
+            .filter(|r| r.phase == DiagPhase::Mesh)
+            .count();
+        let total_pass = admin_pass + mesh_pass;
+        let total = results.len();
+        let any_fail = results
+            .iter()
+            .any(|r| matches!(r.outcome, DiagOutcome::Fail { .. }));
+
+        let admin_status = if admin_pass == admin_total && admin_total > 0 {
+            labels.diag_status_healthy
+        } else {
+            labels.diag_status_failing
+        };
+        let mesh_status = if mesh_total == 0 {
+            labels.diag_status_na
+        } else if mesh_pass == mesh_total {
+            labels.diag_status_healthy
+        } else {
+            labels.diag_status_failing
+        };
+        let summary = if !any_fail {
+            format!(
+                "{} {} {}. {} {} {} {}.",
+                labels.diag_checks_all,
+                total,
+                labels.diag_checks_passed,
+                labels.diag_admin_label,
+                admin_status,
+                labels.diag_mesh_label,
+                mesh_status,
+            )
+        } else {
+            format!(
+                "{}/{} {}. {} {}/{}. {} {}/{}.",
+                total_pass,
+                total,
+                labels.diag_checks_passed,
+                labels.diag_admin_label,
+                admin_pass,
+                admin_total,
+                labels.diag_mesh_label,
+                mesh_pass,
+                mesh_total,
+            )
+        };
+        let summary_style = if any_fail {
+            scheme.error
+        } else {
+            scheme.detail_status_ok
+        };
+        lines.push(Line::default());
+        lines.push(Line::from(Span::styled(summary, summary_style)));
+    }
+
+    let block = Block::default()
+        .title(labels.pane_diagnostics)
+        .borders(Borders::ALL)
+        .border_style(scheme.border);
+    let p = Paragraph::new(lines)
+        .block(block)
+        .wrap(Wrap { trim: false })
+        .scroll((app.diag_scroll, 0));
+    frame.render_widget(p, area);
+}
+
+/// Format one diagnostic probe result as a TUI row.
+fn diag_result_line(r: &DiagResult, scheme: &ColorScheme, labels: &Labels) -> Line<'static> {
+    let (icon, icon_style) = match &r.outcome {
+        DiagOutcome::Pass { .. } => ("✓", scheme.detail_status_ok),
+        DiagOutcome::Slow { .. } => ("⚠", scheme.detail_status_warn),
+        DiagOutcome::Fail { .. } => ("✗", scheme.error),
+    };
+    let timing = match &r.outcome {
+        DiagOutcome::Pass { elapsed_ms } | DiagOutcome::Slow { elapsed_ms } => {
+            format!(" {}ms", elapsed_ms)
+        }
+        DiagOutcome::Fail { elapsed_ms, error } => format!(" {}ms — {}", elapsed_ms, error),
+    };
+    let mut spans = vec![
+        Span::styled(format!(" {} ", icon), icon_style),
+        Span::raw(r.label.clone()),
+        Span::styled(timing, scheme.detail_label),
+    ];
+    if let Some(role) = r.note {
+        let note = match role {
+            DiagNodeRole::AdminServer => labels.diag_note_admin_server,
+            DiagNodeRole::HostAgent => labels.diag_note_host_agent,
+            DiagNodeRole::AdminServiceProc => labels.diag_note_admin_service_proc,
+            DiagNodeRole::IntrospectionHandler => labels.diag_note_introspection_handler,
+            DiagNodeRole::ActorLifecycleManager => labels.diag_note_actor_lifecycle_manager,
+            DiagNodeRole::RootClientBridge => labels.diag_note_root_client_bridge,
+            DiagNodeRole::CommActor => labels.diag_note_comm_actor,
+            DiagNodeRole::ProcAgent => labels.diag_note_proc_agent,
+            DiagNodeRole::UserProc => labels.diag_note_user_proc,
+            DiagNodeRole::UserActor => labels.diag_note_user_actor,
+        };
+        spans.push(Span::styled(format!("  — {}", note), scheme.stat_url));
+    }
+    Line::from(spans)
 }

--- a/hyperactor_mesh/bin/admin_tui/theme.rs
+++ b/hyperactor_mesh/bin/admin_tui/theme.rs
@@ -105,6 +105,14 @@ pub(crate) struct Args {
     /// Path to a PEM client private key for mutual TLS.
     #[arg(long)]
     pub(crate) tls_key: Option<String>,
+
+    /// Run diagnostics and print a JSON report to stdout, then exit.
+    ///
+    /// Walks the full resolution graph (root → hosts → service proc
+    /// actors → user procs → user actors) and probes each node.
+    /// Exits 0 when all checks pass, 1 when any fail.
+    #[arg(long)]
+    pub(crate) diagnose: bool,
 }
 
 /// All user-visible text in the TUI.
@@ -159,6 +167,28 @@ pub(crate) struct Labels {
     pub(crate) yes: &'static str,
     pub(crate) no: &'static str,
 
+    // Diagnostic pane status / summary strings
+    pub(crate) diag_running: &'static str,
+    pub(crate) diag_checks_all: &'static str,
+    pub(crate) diag_checks_passed: &'static str,
+    pub(crate) diag_admin_label: &'static str,
+    pub(crate) diag_mesh_label: &'static str,
+    pub(crate) diag_status_healthy: &'static str,
+    pub(crate) diag_status_failing: &'static str,
+    pub(crate) diag_status_na: &'static str,
+
+    // Diagnostic pane node annotations
+    pub(crate) diag_note_admin_server: &'static str,
+    pub(crate) diag_note_host_agent: &'static str,
+    pub(crate) diag_note_admin_service_proc: &'static str,
+    pub(crate) diag_note_introspection_handler: &'static str,
+    pub(crate) diag_note_actor_lifecycle_manager: &'static str,
+    pub(crate) diag_note_root_client_bridge: &'static str,
+    pub(crate) diag_note_comm_actor: &'static str,
+    pub(crate) diag_note_proc_agent: &'static str,
+    pub(crate) diag_note_user_proc: &'static str,
+    pub(crate) diag_note_user_actor: &'static str,
+
     // Pane titles
     pub(crate) pane_topology: &'static str,
     pub(crate) pane_details: &'static str,
@@ -168,6 +198,7 @@ pub(crate) struct Labels {
     pub(crate) pane_proc_details: &'static str,
     pub(crate) pane_actor_details: &'static str,
     pub(crate) pane_flight_recorder: &'static str,
+    pub(crate) pane_diagnostics: &'static str,
 
     // Footer
     pub(crate) footer_help_text: &'static str,
@@ -213,6 +244,24 @@ impl Labels {
             failed_actors: "Failed actors: ",
             yes: "yes",
             no: "no",
+            diag_running: "Running\u{2026}",
+            diag_checks_all: "All",
+            diag_checks_passed: "checks passed",
+            diag_admin_label: "Admin:",
+            diag_mesh_label: "Mesh:",
+            diag_status_healthy: "healthy",
+            diag_status_failing: "failing",
+            diag_status_na: "n/a",
+            diag_note_admin_server: "admin HTTP server — lists connected hosts",
+            diag_note_host_agent: "host agent — manages procs on this machine",
+            diag_note_admin_service_proc: "admin service proc — hosts the admin actor layer",
+            diag_note_introspection_handler: "handles GET /v1/\u{2026} HTTP requests",
+            diag_note_actor_lifecycle_manager: "manages actor spawn and lifecycle",
+            diag_note_root_client_bridge: "root client bridge — connects admin to the mesh",
+            diag_note_comm_actor: "mesh comm actor — enables proc-to-proc messaging",
+            diag_note_proc_agent: "proc agent — manages actor spawn and lifecycle on this proc",
+            diag_note_user_proc: "user proc — your workload is alive",
+            diag_note_user_actor: "user actor — reachable through full stack",
             pane_topology: "Topology",
             pane_details: "Details",
             pane_error: "Error",
@@ -221,7 +270,8 @@ impl Labels {
             pane_proc_details: "Proc Details",
             pane_actor_details: "Actor Details",
             pane_flight_recorder: "Flight Recorder",
-            footer_help_text: "q: quit | j/k: navigate | g/G: top/bottom | Tab: expand/collapse | c: collapse all | s: system procs | h: stopped actors",
+            pane_diagnostics: "Diagnostics",
+            footer_help_text: "q: quit | j/k: navigate | g/G: top/bottom | Tab: expand/collapse | c: collapse all | s: system procs | h: stopped actors | d: diag",
         }
     }
 
@@ -264,6 +314,24 @@ impl Labels {
             failed_actors: "失败执行器: ",
             yes: "是",
             no: "否",
+            diag_running: "运行中\u{2026}",
+            diag_checks_all: "所有",
+            diag_checks_passed: "项检查通过",
+            diag_admin_label: "管理:",
+            diag_mesh_label: "网格:",
+            diag_status_healthy: "健康",
+            diag_status_failing: "失败",
+            diag_status_na: "不适用",
+            diag_note_admin_server: "管理HTTP服务器 — 列出已连接主机",
+            diag_note_host_agent: "主机代理 — 管理此机器上的进程",
+            diag_note_admin_service_proc: "管理服务进程 — 承载管理员Actor层",
+            diag_note_introspection_handler: "处理 GET /v1/\u{2026} HTTP请求",
+            diag_note_actor_lifecycle_manager: "管理Actor派生和生命周期",
+            diag_note_root_client_bridge: "根客户端桥 — 连接管理员与用户网格",
+            diag_note_comm_actor: "网格通信Actor — 实现进程间消息传递",
+            diag_note_proc_agent: "进程代理 — 管理此进程上的Actor派生和生命周期",
+            diag_note_user_proc: "用户进程 — 您的工作负载正在运行",
+            diag_note_user_actor: "用户Actor — 可通过完整堆栈访问",
             pane_topology: "拓扑",
             pane_details: "详情",
             pane_error: "错误",
@@ -272,7 +340,8 @@ impl Labels {
             pane_proc_details: "进程详情",
             pane_actor_details: "执行器详情",
             pane_flight_recorder: "飞行记录器",
-            footer_help_text: "q: 退出 | j/k: 导航 | g/G: 顶部/底部 | Tab: 展开/折叠 | c: 全部折叠 | s: 系统进程 | h: 已停止",
+            pane_diagnostics: "诊断",
+            footer_help_text: "q: 退出 | j/k: 导航 | g/G: 顶部/底部 | Tab: 展开/折叠 | c: 全部折叠 | s: 系统进程 | h: 已停止 | d: 诊断",
         }
     }
 }

--- a/hyperactor_mesh/examples/dining_philosophers.rs
+++ b/hyperactor_mesh/examples/dining_philosophers.rs
@@ -285,6 +285,10 @@ async fn main() -> Result<ExitCode> {
         "  - TUI:           buck2 run fbcode//monarch/hyperactor_mesh:hyperactor_mesh_admin_tui -- --addr {}\n                   cargo run -p hyperactor_mesh --bin hyperactor_mesh_admin_tui -- --addr {}",
         mesh_admin_url, mesh_admin_url
     );
+    println!(
+        "  - Diagnose:      cargo run -p hyperactor_mesh --bin hyperactor_mesh_admin_tui -- --addr {} --diagnose",
+        mesh_admin_url
+    );
     let host_addr = &host_mesh.hosts()[0];
     println!(
         "  - Hyper list:    buck2 run fbcode//monarch/hyper:hyper -- list {}\n                   cargo run --manifest-path hyper/Cargo.toml -- list {}",

--- a/hyperactor_mesh/src/global_client.rs
+++ b/hyperactor_mesh/src/global_client.rs
@@ -358,6 +358,11 @@ fn fresh_instance() -> (
         work,
     } = ai;
 
+    // GlobalClientActor uses a custom run loop that bypasses the
+    // standard Actor::init lifecycle hook, so set_system() must be
+    // called here explicitly.
+    client_instance.set_system();
+
     // Bind the actor's well-known ports (Signal,
     // Undeliverable<MessageEnvelope>, IntrospectMessage, and the
     // MeshFailure handler). Undeliverable messages are routed to

--- a/hyperactor_mesh/src/mesh_admin.rs
+++ b/hyperactor_mesh/src/mesh_admin.rs
@@ -861,9 +861,14 @@ impl MeshAdminAgent {
     ///
     /// First tries `IntrospectMessage::QueryChild` against the owning
     /// `HostAgent` (system procs). If that returns an error
-    /// payload, falls back to sending `IntrospectMessage::Query` to
-    /// the conventional `ProcAgent` actor (`<proc_id>/agent[0]`)
-    /// for user procs.
+    /// payload, falls back to `ProcAgent` for user procs by querying
+    /// `QueryChild(Reference::Proc(proc_id))` on
+    /// `<proc_id>/proc_agent[0]`.
+    ///
+    /// Invariant PA-1: proc-node children used by admin/TUI must be
+    /// derived from live proc state at query time (no additional
+    /// publish event required). An `Entity`-view fallback is kept for
+    /// backward compatibility with older agents.
     async fn resolve_proc_node(
         &self,
         cx: &Context<'_, Self>,
@@ -907,8 +912,8 @@ impl MeshAdminAgent {
         let (reply_handle, reply_rx) = open_once_port::<NodePayload>(cx);
         agent_port.send(
             cx,
-            IntrospectMessage::Query {
-                view: hyperactor::introspect::IntrospectView::Entity,
+            IntrospectMessage::QueryChild {
+                child_ref: Reference::Proc(proc_id.clone()),
                 reply: reply_handle.bind(),
             },
         )?;
@@ -993,7 +998,40 @@ impl MeshAdminAgent {
             if anchor_is_system {
                 system_children.push(anchor_ref);
             }
-            children.extend(actor_payload.children);
+
+            // Query each supervision child to check is_system.
+            for child_ref in actor_payload.children {
+                if let Ok(child_actor_id) = child_ref.parse::<ActorId>() {
+                    let child_port =
+                        PortRef::<IntrospectMessage>::attest_message_port(&child_actor_id);
+                    let (reply_handle, reply_rx) = open_once_port::<NodePayload>(cx);
+                    let child_is_system = if child_port
+                        .send(
+                            cx,
+                            IntrospectMessage::Query {
+                                view: hyperactor::introspect::IntrospectView::Actor,
+                                reply: reply_handle.bind(),
+                            },
+                        )
+                        .is_ok()
+                    {
+                        matches!(
+                            RealClock.timeout(SINGLE_HOST_TIMEOUT, reply_rx.recv()).await,
+                            Ok(Ok(p))
+                                if matches!(
+                                    &p.properties,
+                                    NodeProperties::Actor { is_system: true, .. }
+                                )
+                        )
+                    } else {
+                        false
+                    };
+                    if child_is_system {
+                        system_children.push(child_ref.clone());
+                    }
+                }
+                children.push(child_ref);
+            }
             (children, system_children)
         };
 
@@ -2847,5 +2885,144 @@ mod tests {
         };
         let head = super::head_hostname(&response).unwrap();
         assert_eq!(head, "host_0");
+    }
+
+    // Verifies that GET /v1/{proc_id} reflects actors spawned directly
+    // on a proc — bypassing ProcAgent's gspawn message and therefore
+    // never triggering publish_introspect_properties — so that the
+    // resolved children list is always derived from live proc state.
+    //
+    // Regression guard for the bug introduced in 9a08d559: the switch
+    // from a live handle_introspect to a cached publish model made
+    // supervision-spawned actors (e.g. every sieve actor after
+    // sieve[0]) invisible to the TUI.
+    //
+    // Invariant PA-1 (admin path): proc-node children consumed by the
+    // TUI are sourced from live proc state via ProcAgent
+    // QueryChild(Reference::Proc), not solely from cached published
+    // snapshots. Direct proc.spawn() of actor X must make X visible on
+    // the next resolve of that proc. See also
+    // proc_agent::tests::test_query_child_proc_returns_live_children.
+    #[tokio::test]
+    async fn test_proc_children_reflect_directly_spawned_actors() {
+        use hyperactor::Proc;
+        use hyperactor::actor::ActorStatus;
+        use hyperactor::channel::ChannelTransport;
+        use hyperactor::host::Host;
+        use hyperactor::host::LocalProcManager;
+        use hyperactor::testing::proc_supervison::ProcSupervisionCoordinator;
+
+        use crate::host_mesh::host_agent::HOST_MESH_AGENT_ACTOR_NAME;
+        use crate::host_mesh::host_agent::HostAgentMode;
+        use crate::host_mesh::host_agent::ProcManagerSpawnFn;
+        use crate::proc_agent::PROC_AGENT_ACTOR_NAME;
+        use crate::proc_agent::ProcAgent;
+
+        // Stand up a HostMeshAgent. The user proc gets its own
+        // ephemeral address; we register that address in
+        // MeshAdminAgent so resolve_proc_node can look it up.
+        // HostMeshAgent won't know the user proc (it wasn't spawned
+        // through it), so QueryChild returns Error and resolve falls
+        // back to querying proc_agent[0] via QueryChild(Proc) — the
+        // path being tested.
+        let spawn_fn: ProcManagerSpawnFn =
+            Box::new(|proc| Box::pin(std::future::ready(ProcAgent::boot_v1(proc, None))));
+        let manager: LocalProcManager<ProcManagerSpawnFn> = LocalProcManager::new(spawn_fn);
+        let host: Host<LocalProcManager<ProcManagerSpawnFn>> =
+            Host::new(manager, ChannelTransport::Unix.any())
+                .await
+                .unwrap();
+        let system_proc = host.system_proc().clone();
+        let host_agent_handle = system_proc
+            .spawn(
+                HOST_MESH_AGENT_ACTOR_NAME,
+                HostAgent::new(HostAgentMode::Local(host)),
+            )
+            .unwrap();
+        let host_agent_ref: ActorRef<HostAgent> = host_agent_handle.bind();
+
+        // User proc: own ephemeral Unix socket, own ProcAgent.
+        let user_proc =
+            Proc::direct(ChannelTransport::Unix.any(), "user_proc".to_string()).unwrap();
+        let user_proc_addr = user_proc.proc_id().addr().to_string();
+        let agent_handle = ProcAgent::boot_v1(user_proc.clone(), None).unwrap();
+        agent_handle
+            .status()
+            .wait_for(|s| matches!(s, ActorStatus::Idle))
+            .await
+            .unwrap();
+
+        // MeshAdminAgent: register the user proc's addr as a "host"
+        // pointing to host_agent_ref. That agent doesn't know the
+        // user proc, so QueryChild → Error → fallback to proc_agent.
+        let admin_proc = Proc::direct(ChannelTransport::Unix.any(), "admin".to_string()).unwrap();
+        let _supervision = ProcSupervisionCoordinator::set(&admin_proc).await.unwrap();
+        let admin_handle = admin_proc
+            .spawn(
+                MESH_ADMIN_ACTOR_NAME,
+                MeshAdminAgent::new(
+                    vec![(user_proc_addr, host_agent_ref.clone())],
+                    None,
+                    Some("[::]:0".parse().unwrap()),
+                ),
+            )
+            .unwrap();
+        let admin_ref: ActorRef<MeshAdminAgent> = admin_handle.bind();
+
+        let client_proc = Proc::direct(ChannelTransport::Unix.any(), "client".to_string()).unwrap();
+        let (client, _client_handle) = client_proc.instance("client").unwrap();
+
+        // Resolve the user proc via MeshAdminAgent. HostMeshAgent
+        // returns Error for QueryChild → fallback to proc_agent[0]
+        // QueryChild(Reference::Proc) → live NodeProperties::Proc.
+        let user_proc_ref = user_proc.proc_id().to_string();
+        let resp = admin_ref
+            .resolve(&client, user_proc_ref.clone())
+            .await
+            .unwrap();
+        let node = resp.0.unwrap();
+        assert!(
+            matches!(node.properties, NodeProperties::Proc { .. }),
+            "expected Proc, got {:?}",
+            node.properties
+        );
+        let initial_count = node.children.len();
+        assert!(
+            node.children
+                .iter()
+                .any(|c| c.contains(PROC_AGENT_ACTOR_NAME)),
+            "initial children {:?} should contain proc_agent",
+            node.children
+        );
+
+        // Spawn an actor directly on the user proc, bypassing gspawn.
+        // This simulates how sieve[0] spawns sieve[1], sieve[2], etc.
+        user_proc
+            .spawn("extra_actor", TestIntrospectableActor)
+            .unwrap();
+
+        // Resolve again — the new actor must appear immediately
+        // without any republish, proving PA-1 is satisfied.
+        let resp2 = admin_ref
+            .resolve(&client, user_proc_ref.clone())
+            .await
+            .unwrap();
+        let node2 = resp2.0.unwrap();
+        assert!(
+            matches!(node2.properties, NodeProperties::Proc { .. }),
+            "expected Proc, got {:?}",
+            node2.properties
+        );
+        assert!(
+            node2.children.iter().any(|c| c.contains("extra_actor")),
+            "after direct spawn, children {:?} should contain extra_actor",
+            node2.children
+        );
+        assert!(
+            node2.children.len() > initial_count,
+            "expected at least {} children after direct spawn, got {:?}",
+            initial_count + 1,
+            node2.children
+        );
     }
 }

--- a/hyperactor_mesh/src/mesh_admin_skill.md
+++ b/hyperactor_mesh/src/mesh_admin_skill.md
@@ -5,6 +5,22 @@ Base URL: `{base}`
 This server exposes a reference-walking introspection API for a mesh.
 Start at `root`, resolve it, then follow `children` to traverse topology.
 
+## One-shot diagnostic (recommended starting point)
+
+Run this first to get a structured JSON health report of the full mesh
+(root → hosts → service proc actors → every user proc → user actors).
+Exit code 0 = healthy, 1 = any failure.
+
+```
+cargo run -p hyperactor_mesh --bin hyperactor_mesh_admin_tui -- \
+  --addr {base} --diagnose
+```
+
+Each entry in `checks[]` includes `reference` (the exact ref that
+failed), `note` (role), `phase` (AdminInfra or Mesh), and `outcome`
+(Pass/Slow/Fail with `elapsed_ms` and `error`). Use failing
+`reference` values to probe further with the endpoints below.
+
 ## Endpoints
 
 - `GET {base}/v1/root`

--- a/hyperactor_mesh/src/mesh_controller.rs
+++ b/hyperactor_mesh/src/mesh_controller.rs
@@ -236,6 +236,7 @@ impl<A: Referable> Debug for ActorMeshController<A> {
 #[async_trait]
 impl<A: Referable> Actor for ActorMeshController<A> {
     async fn init(&mut self, this: &Instance<Self>) -> Result<(), anyhow::Error> {
+        this.set_system();
         // Start the monitor task.
         // There's a shared monitor for all whole mesh ref. Note that slices do
         // not share the health state. This is fine because requerying a slice
@@ -857,6 +858,11 @@ impl ProcMeshController {
 
 #[async_trait]
 impl Actor for ProcMeshController {
+    async fn init(&mut self, this: &Instance<Self>) -> Result<(), anyhow::Error> {
+        this.set_system();
+        Ok(())
+    }
+
     async fn cleanup(
         &mut self,
         this: &Instance<Self>,
@@ -896,6 +902,11 @@ impl HostMeshController {
 
 #[async_trait]
 impl Actor for HostMeshController {
+    async fn init(&mut self, this: &Instance<Self>) -> Result<(), anyhow::Error> {
+        this.set_system();
+        Ok(())
+    }
+
     async fn cleanup(
         &mut self,
         this: &Instance<Self>,

--- a/hyperactor_mesh/src/proc_agent.rs
+++ b/hyperactor_mesh/src/proc_agent.rs
@@ -432,14 +432,96 @@ impl Actor for ProcAgent {
         // Resolve terminated actor snapshots via QueryChild so that
         // dead actors remain directly queryable by reference.
         let proc = self.proc.clone();
+        let self_id = this.self_id().clone();
         this.set_query_child_handler(move |child_ref| {
             use hyperactor::introspect::NodePayload;
             use hyperactor::introspect::NodeProperties;
+            use hyperactor::introspect::PublishedPropertiesKind;
             use hyperactor::reference::Reference;
 
             if let Reference::Actor(id) = child_ref {
                 if let Some(snapshot) = proc.terminated_snapshot(id) {
                     return snapshot;
+                }
+            }
+
+            // PA-1 (ProcAgent path): proc-node children used by
+            // admin/TUI must be computed from live proc state at query
+            // time, not solely from cached published_properties.
+            // Therefore a direct proc.spawn() actor must appear on the
+            // next QueryChild(Reference::Proc) response without an
+            // extra publish event. See
+            // test_query_child_proc_returns_live_children.
+            if let Reference::Proc(proc_id) = child_ref {
+                if proc_id == proc.proc_id() {
+                    let live_ids = proc.all_actor_ids();
+                    let num_live = live_ids.len();
+                    let mut children = Vec::with_capacity(num_live);
+                    let mut system_children = Vec::new();
+                    for id in live_ids {
+                        let ref_str = id.to_string();
+                        if proc.get_instance(&id).is_some_and(|cell| cell.is_system()) {
+                            system_children.push(ref_str.clone());
+                        }
+                        children.push(ref_str);
+                    }
+
+                    let mut stopped_children: Vec<String> = Vec::new();
+                    for id in proc.all_terminated_actor_ids() {
+                        let ref_str = id.to_string();
+                        stopped_children.push(ref_str.clone());
+                        if let Some(snapshot) = proc.terminated_snapshot(&id) {
+                            if matches!(
+                                snapshot.properties,
+                                hyperactor::introspect::NodeProperties::Actor {
+                                    is_system: true,
+                                    ..
+                                }
+                            ) {
+                                system_children.push(ref_str.clone());
+                            }
+                        }
+                        if !children.contains(&ref_str) {
+                            children.push(ref_str);
+                        }
+                    }
+
+                    let stopped_retention_cap = hyperactor_config::global::get(
+                        hyperactor::config::TERMINATED_SNAPSHOT_RETENTION,
+                    );
+
+                    let (is_poisoned, failed_actor_count) = proc
+                        .get_instance(&self_id)
+                        .and_then(|cell| cell.published_properties())
+                        .and_then(|p| match p.kind {
+                            PublishedPropertiesKind::Proc {
+                                is_poisoned,
+                                failed_actor_count,
+                                ..
+                            } => Some((is_poisoned, failed_actor_count)),
+                            _ => None,
+                        })
+                        .unwrap_or((false, 0));
+
+                    return NodePayload {
+                        identity: proc_id.to_string(),
+                        properties: NodeProperties::Proc {
+                            proc_name: proc_id.to_string(),
+                            num_actors: num_live,
+                            is_system: false,
+                            system_children,
+                            stopped_children,
+                            stopped_retention_cap,
+                            is_poisoned,
+                            failed_actor_count,
+                        },
+                        children,
+                        parent: None,
+                        as_of: humantime::format_rfc3339_millis(
+                            hyperactor::clock::RealClock.system_time_now(),
+                        )
+                        .to_string(),
+                    };
                 }
             }
 
@@ -1384,5 +1466,122 @@ mod tests {
         assert_eq!(messages[1].deserialized::<u64>().unwrap(), 6);
         assert_eq!(messages[2].deserialized::<u64>().unwrap(), 7);
         assert_eq!(messages[3].deserialized::<u64>().unwrap(), 8);
+    }
+
+    // A no-op actor used to test direct proc-level spawning.
+    #[derive(Debug, Default)]
+    #[hyperactor::export(handlers = [])]
+    struct ExtraActor;
+    impl hyperactor::Actor for ExtraActor {}
+
+    // Verifies that QueryChild(Reference::Proc) on a ProcAgent returns
+    // a live NodeProperties::Proc whose children reflect actors spawned
+    // directly on the proc — i.e. via proc.spawn(), which bypasses the
+    // gspawn message handler and therefore never triggers
+    // publish_introspect_properties.
+    //
+    // Invariant PA-1 (canonical):
+    // For proc-node resolution used by admin/TUI, children lists
+    // (children/system_children/stopped_children) must be derived from
+    // live proc state at query time rather than only from the last
+    // published snapshot.
+    // Required behavior: direct proc.spawn() of actor X is visible on
+    // the next proc resolve (no extra publish event required).
+    //
+    // Regression guard for the bug introduced in 9a08d559: removing
+    // handle_introspect left publish_introspect_properties as the only
+    // update path, which missed supervision-spawned actors (e.g. every
+    // sieve actor after sieve[0]). See also
+    // mesh_admin::tests::test_proc_children_reflect_directly_spawned_actors.
+    #[tokio::test]
+    async fn test_query_child_proc_returns_live_children() {
+        use hyperactor::PortRef;
+        use hyperactor::Proc;
+        use hyperactor::actor::ActorStatus;
+        use hyperactor::channel::ChannelTransport;
+        use hyperactor::introspect::IntrospectMessage;
+        use hyperactor::introspect::NodePayload;
+        use hyperactor::introspect::NodeProperties;
+        use hyperactor::reference::Reference;
+
+        let proc = Proc::direct(ChannelTransport::Unix.any(), "test_proc".to_string()).unwrap();
+        let agent_handle = ProcAgent::boot_v1(proc.clone(), None).unwrap();
+
+        // Wait for ProcAgent to finish init.
+        agent_handle
+            .status()
+            .wait_for(|s| matches!(s, ActorStatus::Idle))
+            .await
+            .unwrap();
+
+        // Client instance for opening reply ports.
+        let client_proc = Proc::direct(ChannelTransport::Unix.any(), "client".to_string()).unwrap();
+        let (client, _client_handle) = client_proc.instance("client").unwrap();
+
+        let agent_id = proc.proc_id().actor_id(PROC_AGENT_ACTOR_NAME, 0);
+        let port = PortRef::<IntrospectMessage>::attest_message_port(&agent_id);
+
+        // Helper: send QueryChild(Proc) and return the payload with a
+        // timeout so a misrouted reply fails fast rather than hanging.
+        let query = |client: &hyperactor::Instance<()>| {
+            let (reply_port, reply_rx) = client.open_once_port::<NodePayload>();
+            port.send(
+                client,
+                IntrospectMessage::QueryChild {
+                    child_ref: Reference::Proc(proc.proc_id().clone()),
+                    reply: reply_port.bind(),
+                },
+            )
+            .unwrap();
+            reply_rx
+        };
+        let recv = |rx: hyperactor::mailbox::OncePortReceiver<NodePayload>| async move {
+            hyperactor::clock::RealClock
+                .timeout(std::time::Duration::from_secs(5), rx.recv())
+                .await
+                .expect("QueryChild(Proc) timed out — reply never delivered")
+                .expect("reply channel closed")
+        };
+
+        // Initial query: ProcAgent itself should appear in children.
+        let payload = recv(query(&client)).await;
+        assert!(
+            matches!(payload.properties, NodeProperties::Proc { .. }),
+            "expected Proc, got {:?}",
+            payload.properties
+        );
+        assert!(
+            payload
+                .children
+                .iter()
+                .any(|c| c.contains(PROC_AGENT_ACTOR_NAME)),
+            "initial children {:?} should contain proc_agent",
+            payload.children
+        );
+        let initial_count = payload.children.len();
+
+        // Spawn an actor directly on the proc, bypassing ProcAgent's
+        // gspawn message handler. This is how supervision-spawned
+        // actors (e.g. sieve children) are created.
+        proc.spawn("extra_actor", ExtraActor).unwrap();
+
+        // Second query: extra_actor must appear without any republish.
+        let payload2 = recv(query(&client)).await;
+        assert!(
+            matches!(payload2.properties, NodeProperties::Proc { .. }),
+            "expected Proc, got {:?}",
+            payload2.properties
+        );
+        assert!(
+            payload2.children.iter().any(|c| c.contains("extra_actor")),
+            "after direct spawn, children {:?} should contain extra_actor",
+            payload2.children
+        );
+        assert!(
+            payload2.children.len() > initial_count,
+            "expected at least {} children after direct spawn, got {:?}",
+            initial_count + 1,
+            payload2.children
+        );
     }
 }

--- a/hyperactor_mesh/src/proc_mesh.rs
+++ b/hyperactor_mesh/src/proc_mesh.rs
@@ -99,6 +99,12 @@ declare_attrs! {
     pub attr GET_ACTOR_STATE_MAX_IDLE: Duration = Duration::from_secs(30);
 }
 
+/// Name used for the mesh communication actor spawned on each user proc.
+///
+/// The `CommActor` enables proc-to-proc mesh messaging and is always
+/// present as a system actor (`system_children`) on every proc mesh member.
+pub const COMM_ACTOR_NAME: &str = "comm";
+
 /// A reference to a single [`hyperactor::Proc`].
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct ProcRef {
@@ -175,7 +181,7 @@ impl ProcMesh {
         C::A: Handler<MeshFailure>,
     {
         let comm_actor_name = if spawn_comm_actor {
-            Some(Name::new("comm").unwrap())
+            Some(Name::new(COMM_ACTOR_NAME).unwrap())
         } else {
             None
         };


### PR DESCRIPTION
Summary:
this commit adds a new diagnostics capability to the admin TUI and fixes proc introspection freshness for user procs.

the diagnostics work introduces a streaming diagnostic runner, a --diagnose CLI mode that emits JSON and exits non-zero on unhealthy results, and an interactive diagnostics pane in the TUI that renders live check results and summary status.

the proc introspection fix changes user-poc resolution in mesh_admin to query ProcAgent via QueryChild(Reference::Proc) so proc children are derived from live proc state at query time rather than only from cached published properties, with an Entity fallback retained for compatibility.

this addresses a regression where actors spawned directly on a proc, including supervision-spawned sieve  actors, could be missing from the TUI topology.

supporting updates include system-actor classification consistency (set_system on relevant controllers/clients), shared actor-name constants, additional diagnostics/help text and docs, and regression tests that verify direct proc.spawn() actors appear on the next proc resolve.

Differential Revision: D94847922
