### PR TITLE
Fix panic in HostMeshAgent after shutdown

### DIFF
--- a/hyperactor_mesh/src/host_mesh/host_agent.rs
+++ b/hyperactor_mesh/src/host_mesh/host_agent.rs
@@ -476,13 +476,15 @@ impl Handler<resource::GetRankStatus> for HostAgent {
         use crate::StatusOverlay;
         use crate::resource::Status;
 
-        let host = self.host.as_ref().expect("host present");
         let (rank, status) = match self.created.get(&get_rank_status.name) {
             Some(ProcCreationState {
                 rank,
                 created: Ok((proc_id, _mesh_agent)),
             }) => {
-                let (status, _) = host.proc_status(proc_id).await;
+                let status = match self.host.as_ref() {
+                    Some(host) => host.proc_status(proc_id).await.0,
+                    None => Status::Stopped,
+                };
                 (*rank, status)
             }
             Some(ProcCreationState {
@@ -601,13 +603,18 @@ impl Handler<resource::GetState<ProcState>> for HostAgent {
         cx: &Context<Self>,
         get_state: resource::GetState<ProcState>,
     ) -> anyhow::Result<()> {
-        let host = self.host.as_ref().expect("host present");
         let state = match self.created.get(&get_state.name) {
             Some(ProcCreationState {
                 rank,
                 created: Ok((proc_id, mesh_agent)),
             }) => {
-                let (status, proc_status) = host.proc_status(proc_id).await;
+                let (status, proc_status, bootstrap_command) = match self.host.as_ref() {
+                    Some(host) => {
+                        let (status, proc_status) = host.proc_status(proc_id).await;
+                        (status, proc_status, host.bootstrap_command())
+                    }
+                    None => (resource::Status::Stopped, None, None),
+                };
                 resource::State {
                     name: get_state.name.clone(),
                     status,
@@ -615,7 +622,7 @@ impl Handler<resource::GetState<ProcState>> for HostAgent {
                         proc_id: proc_id.clone(),
                         create_rank: *rank,
                         mesh_agent: mesh_agent.clone(),
-                        bootstrap_command: host.bootstrap_command(),
+                        bootstrap_command,
                         proc_status,
                     }),
                 }


### PR DESCRIPTION
Summary:
D94549846 replaced graceful `Option` handling of `self.host` with
`.expect("host present")` in `GetRankStatus` and `GetState<ProcState>`
handlers. After `ShutdownHost` calls `self.host.take()`, 

https://www.internalfb.com/code/fbsource/[43958303c0067a4e8139132130319a6846b244c3]/fbcode/monarch/hyperactor_mesh/src/host_mesh/mesh_agent.rs?lines=529-530%2C537

subsequent supervision polling sends `GetRankStatus` to the agent, hitting the
`expect` and panicking. The panic on the service proc triggers
`handle_unhandled_supervision_event`, which calls `process::exit(1)`
because no coordinator port is set, crashing the test.

Handle the `None` case gracefully by returning `Status::Stopped` when
the host has already been shut down.

Reviewed By: mariusae

Differential Revision: D94906943


