### PR TITLE
[hyperactor] add duplex-mode channels over the net link layer

### DIFF
--- a/hyperactor/src/channel/net.rs
+++ b/hyperactor/src/channel/net.rs
@@ -74,6 +74,7 @@ use crate::clock::RealClock;
 // the suppression must be at module scope.
 #[allow(unused_assignments)]
 mod client;
+pub(crate) mod duplex;
 mod framed;
 use client::dial;
 mod server;
@@ -181,13 +182,13 @@ pub(crate) trait Listener: Send + Unpin + 'static {
 
 /// Frames are the messages sent between clients and servers over sessions.
 #[derive(Debug, Serialize, Deserialize, EnumAsInner, PartialEq)]
-enum Frame<M> {
+pub(super) enum Frame<M> {
     /// Send a message with the provided sequence number.
     Message(u64, M),
 }
 
 #[derive(Debug, Serialize, Deserialize, EnumAsInner)]
-enum NetRxResponse {
+pub(super) enum NetRxResponse {
     Ack(u64),
     /// This session is rejected with the given reason. NetTx should stop reconnecting.
     Reject(String),
@@ -195,11 +196,11 @@ enum NetRxResponse {
     Closed,
 }
 
-fn serialize_response(response: NetRxResponse) -> Result<Bytes, bincode::Error> {
+pub(super) fn serialize_response(response: NetRxResponse) -> Result<Bytes, bincode::Error> {
     bincode::serialize(&response).map(|bytes| bytes.into())
 }
 
-fn deserialize_response(data: Bytes) -> Result<NetRxResponse, bincode::Error> {
+pub(super) fn deserialize_response(data: Bytes) -> Result<NetRxResponse, bincode::Error> {
     bincode::deserialize(&data)
 }
 
@@ -306,6 +307,44 @@ pub(super) fn is_net_addr(addr: &ChannelAddr) -> bool {
     }
 }
 
+/// Establish a raw transport connection without writing any
+/// protocol-level init header. Used by duplex to separate
+/// transport from protocol.
+pub(crate) async fn connect_raw(addr: &ChannelAddr) -> Result<Box<dyn Stream>, ClientError> {
+    match addr {
+        ChannelAddr::Tcp(socket_addr) => {
+            let stream = tokio::net::TcpStream::connect(socket_addr)
+                .await
+                .map_err(|err| ClientError::Connect(addr.clone(), err, "TCP connect".into()))?;
+            stream
+                .set_nodelay(true)
+                .map_err(|err| ClientError::Connect(addr.clone(), err, "set_nodelay".into()))?;
+            Ok(Box::new(stream))
+        }
+        ChannelAddr::Unix(unix_addr) => {
+            let stream = match unix_addr {
+                unix::SocketAddr::Bound(sock_addr) => {
+                    let std_stream = std::os::unix::net::UnixStream::connect_addr(sock_addr)
+                        .map_err(|err| {
+                            ClientError::Connect(addr.clone(), err, "Unix connect".into())
+                        })?;
+                    std_stream
+                        .set_nonblocking(true)
+                        .map_err(|err| ClientError::Io(addr.clone(), err))?;
+                    tokio::net::UnixStream::from_std(std_stream)
+                        .map_err(|err| ClientError::Io(addr.clone(), err))?
+                }
+                unix::SocketAddr::Unbound => return Err(ClientError::Resolve(addr.clone())),
+            };
+            Ok(Box::new(stream))
+        }
+        _ => Err(ClientError::InvalidAddress(format!(
+            "duplex not supported for transport: {}",
+            addr
+        ))),
+    }
+}
+
 pub(crate) mod unix {
 
     use core::str;
@@ -371,8 +410,8 @@ pub(crate) mod unix {
     /// Server-side listener for Unix domain sockets.
     #[derive(Debug)]
     pub(crate) struct UnixSocketListener {
-        inner: UnixListener,
-        addr: SocketAddr,
+        pub(super) inner: UnixListener,
+        pub(super) addr: SocketAddr,
     }
 
     #[async_trait]
@@ -1990,7 +2029,7 @@ mod tests {
                     tokio::select! {
                         read_res = reader.next() => {
                             match read_res {
-                                Ok(Some(data)) => {
+                                Ok(Some((_, data))) => {
                                     queue.push_back((data, RealClock.now()));
                                 }
                                 Ok(None) | Err(_) => {
@@ -2031,7 +2070,7 @@ mod tests {
                                     }
                                 }
                             }
-                            let mut fw  = FrameWrite::new(writer, data, hyperactor_config::global::get(config::CODEC_MAX_FRAME_LENGTH)).unwrap();
+                            let mut fw  = FrameWrite::new(writer, data, hyperactor_config::global::get(config::CODEC_MAX_FRAME_LENGTH), 0).unwrap();
                             if fw.send().await.is_err() {
                                 break;
                             }
@@ -2181,6 +2220,7 @@ mod tests {
                 writer,
                 message.framed(),
                 hyperactor_config::global::get(config::CODEC_MAX_FRAME_LENGTH),
+                0,
             )
             .map_err(|(_w, e)| e)
             .unwrap();
@@ -2199,7 +2239,7 @@ mod tests {
         async fn verify_ack(reader: &mut FrameReader<ReadHalf<DuplexStream>>, expected_last: u64) {
             let mut last_acked: i128 = -1;
             loop {
-                let bytes = reader.next().await.unwrap().unwrap();
+                let (_, bytes) = reader.next().await.unwrap().unwrap();
                 let acked = deserialize_response(bytes).unwrap().into_ack().unwrap();
                 assert!(
                     acked as i128 > last_acked,
@@ -2315,7 +2355,7 @@ mod tests {
             drop(tx);
             assert!(rx.recv().await.is_none());
             // Should send NetRxResponse::Closed before stopping.
-            let bytes = reader2.next().await.unwrap().unwrap();
+            let (_, bytes) = reader2.next().await.unwrap().unwrap();
             assert!(deserialize_response(bytes).unwrap().is_closed());
             assert!(reader2.next().await.unwrap().is_none());
         }
@@ -2338,7 +2378,7 @@ mod tests {
             )
             .await;
             assert_eq!(rx.recv().await, Some(100u64 + i));
-            let bytes = reader.next().await.unwrap().unwrap();
+            let (_, bytes) = reader.next().await.unwrap().unwrap();
             let acked = deserialize_response(bytes).unwrap().into_ack().unwrap();
             assert_eq!(acked, i);
         }
@@ -2351,7 +2391,7 @@ mod tests {
         // mpsc is closed too and there should be no unread message left.
         assert!(rx.recv().await.is_none());
         // should send NetRxResponse::Closed before stopping server.
-        let bytes = reader.next().await.unwrap().unwrap();
+        let (_, bytes) = reader.next().await.unwrap().unwrap();
         assert!(deserialize_response(bytes).unwrap().is_closed());
         // No more acks from server.
         assert!(reader.next().await.unwrap().is_none());
@@ -2416,7 +2456,7 @@ mod tests {
         loc: u32,
     ) {
         let expected = Frame::Message(expect.0, expect.1);
-        let bytes = reader.next().await.unwrap().expect("unexpected EOF");
+        let (_, bytes) = reader.next().await.unwrap().expect("unexpected EOF");
         let message = serde_multipart::Message::from_framed(bytes).unwrap();
         let frame: Frame<M> = serde_multipart::deserialize_bincode(message).unwrap();
 
@@ -2470,6 +2510,7 @@ mod tests {
                     writer,
                     serialize_response(NetRxResponse::Ack(i)).unwrap(),
                     1024,
+                    0,
                 )
                 .await
                 .map_err(|(_, e)| e)
@@ -2531,6 +2572,7 @@ mod tests {
                         writer,
                         serialize_response(NetRxResponse::Ack(1)).unwrap(),
                         1024,
+                        0,
                     )
                     .await
                     .map_err(|(_, e)| e)
@@ -2594,6 +2636,7 @@ mod tests {
                         writer,
                         serialize_response(NetRxResponse::Ack(1)).unwrap(),
                         1024,
+                        0,
                     )
                     .await
                     .map_err(|(_, e)| e)
@@ -2602,6 +2645,7 @@ mod tests {
                         writer,
                         serialize_response(NetRxResponse::Ack(2)).unwrap(),
                         1024,
+                        0,
                     )
                     .await
                     .map_err(|(_, e)| e)
@@ -2610,6 +2654,7 @@ mod tests {
                         writer,
                         serialize_response(NetRxResponse::Ack(3)).unwrap(),
                         1024,
+                        0,
                     )
                     .await
                     .map_err(|(_, e)| e)
@@ -2649,6 +2694,7 @@ mod tests {
                         writer,
                         serialize_response(NetRxResponse::Ack(7)).unwrap(),
                         1024,
+                        0,
                     )
                     .await
                     .map_err(|(_, e)| e)
@@ -2700,6 +2746,7 @@ mod tests {
             writer,
             serialize_response(NetRxResponse::Ack(0)).unwrap(),
             1024,
+            0,
         )
         .await
         .map_err(|(_, e)| e)
@@ -2718,6 +2765,7 @@ mod tests {
             writer,
             serialize_response(NetRxResponse::Ack(1)).unwrap(),
             1024,
+            0,
         )
         .await
         .map_err(|(_, e)| e)
@@ -2757,6 +2805,7 @@ mod tests {
             writer,
             serialize_response(NetRxResponse::Ack(0)).unwrap(),
             hyperactor_config::global::get(config::CODEC_MAX_FRAME_LENGTH),
+            0,
         )
         .await
         .map_err(|(_, e)| e)
@@ -3023,6 +3072,7 @@ mod tests {
                 writer,
                 serialize_response(NetRxResponse::Reject("testing".to_string())).unwrap(),
                 1024,
+                0,
             )
             .await
             .map_err(|(_, e)| e);
@@ -3052,13 +3102,13 @@ mod tests {
         .await;
         assert_eq!(rx.recv().await, Some(100u64));
         assert_eq!(rx.recv().await, Some(101u64));
-        let bytes = reader.next().await.unwrap().unwrap();
+        let (_, bytes) = reader.next().await.unwrap().unwrap();
         let acked = deserialize_response(bytes).unwrap().into_ack().unwrap();
         assert_eq!(acked, 0);
-        let bytes = reader.next().await.unwrap().unwrap();
+        let (_, bytes) = reader.next().await.unwrap().unwrap();
         let acked = deserialize_response(bytes).unwrap().into_ack().unwrap();
         assert_eq!(acked, 1);
-        let bytes = reader.next().await.unwrap().unwrap();
+        let (_, bytes) = reader.next().await.unwrap().unwrap();
         assert!(deserialize_response(bytes).unwrap().is_reject());
     }
 

--- a/hyperactor/src/channel/net/client.rs
+++ b/hyperactor/src/channel/net/client.rs
@@ -903,7 +903,7 @@ where
             let len = outbox.front_size().expect("not empty");
             let message = outbox.front_message().expect("not empty");
 
-            match FrameWrite::new(writer, message.framed(), max) {
+            match FrameWrite::new(writer, message.framed(), max, 0) {
                 Ok(fw) => (
                     State::Running(Deliveries { outbox, unacked }),
                     Conn::Connected {
@@ -966,7 +966,7 @@ where
 
                 ack_result = reader.next() => {
                     match ack_result {
-                        Ok(Some(buffer)) => {
+                        Ok(Some((_, buffer))) => {
                             match deserialize_response(buffer) {
                                 Ok(response) => {
                                     match response {

--- a/hyperactor/src/channel/net/duplex.rs
+++ b/hyperactor/src/channel/net/duplex.rs
@@ -1,0 +1,931 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+//! Duplex-mode channels over the net link layer.
+//!
+//! A single physical connection carries messages in both directions,
+//! each with independent sequence/ack state.
+//!
+//! ## Wire protocol
+//!
+//! Each connection starts with a `DuplexLinkInit` header (12 bytes,
+//! unframed):
+//!
+//! ```text
+//! [magic: 4B "DPX\0"] [link_id: 8B u64 BE]
+//! ```
+//!
+//! After the init, the standard tagged frame format is used. The tag
+//! byte in the 8-byte header distinguishes logical channels:
+//!
+//! - `Side::A = 0x00` — initiator→acceptor channel
+//! - `Side::B = 0x01` — acceptor→initiator channel
+
+#![allow(dead_code)] // until used
+
+use std::io;
+use std::mem::replace;
+use std::sync::Arc;
+
+use bytes::Buf;
+use bytes::Bytes;
+use dashmap::DashMap;
+use tokio::io::AsyncRead;
+use tokio::io::AsyncReadExt;
+use tokio::io::AsyncWrite;
+use tokio::io::AsyncWriteExt;
+use tokio::io::WriteHalf;
+use tokio::sync::mpsc;
+use tokio::task::JoinSet;
+use tokio::time::Duration;
+use tokio_util::sync::CancellationToken;
+
+use super::Frame;
+use super::LinkId;
+use super::NetRxResponse;
+use super::ServerError;
+use super::deserialize_response;
+use super::framed::FrameReader;
+use super::framed::FrameWrite;
+use super::framed::WriteState;
+use super::serialize_response;
+use super::server::Next;
+use super::server::ServerHandle;
+use crate::RemoteMessage;
+use crate::channel::ChannelAddr;
+use crate::channel::ChannelError;
+use crate::clock::Clock;
+use crate::clock::RealClock;
+use crate::config;
+use crate::sync::mvar::MVar;
+
+/// Logical channel tag packed into the frame header's first byte.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub(crate) enum Side {
+    /// Initiator→acceptor logical channel.
+    A = 0x00,
+    /// Acceptor→initiator logical channel.
+    B = 0x01,
+}
+
+const DUPLEX_LINK_INIT_MAGIC: [u8; 4] = *b"DPX\0";
+const DUPLEX_LINK_INIT_SIZE: usize = 4 + 8;
+
+/// Write a DuplexLinkInit header to the stream.
+async fn write_duplex_link_init<S: AsyncWrite + Unpin>(
+    stream: &mut S,
+    link_id: LinkId,
+) -> Result<(), io::Error> {
+    let mut buf = [0u8; DUPLEX_LINK_INIT_SIZE];
+    buf[0..4].copy_from_slice(&DUPLEX_LINK_INIT_MAGIC);
+    buf[4..12].copy_from_slice(&link_id.0.to_be_bytes());
+    stream.write_all(&buf).await
+}
+
+/// Read a DuplexLinkInit header from the stream.
+async fn read_duplex_link_init<S: AsyncRead + Unpin>(stream: &mut S) -> Result<LinkId, io::Error> {
+    let mut buf = [0u8; DUPLEX_LINK_INIT_SIZE];
+    stream.read_exact(&mut buf).await?;
+    if buf[0..4] != DUPLEX_LINK_INIT_MAGIC {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!(
+                "invalid DuplexLinkInit magic: expected {:?}, got {:?}",
+                DUPLEX_LINK_INIT_MAGIC,
+                &buf[0..4]
+            ),
+        ));
+    }
+    let link_id = LinkId(u64::from_be_bytes(buf[4..12].try_into().unwrap()));
+    Ok(link_id)
+}
+
+/// Both channels share one `WriteState`. Acks are `Bytes` and messages
+/// are `serde_multipart::Frame`. This enum delegates `Buf` to the
+/// active variant without allocation.
+pub(crate) enum DuplexBuf {
+    Ack(Bytes),
+    Msg(serde_multipart::Frame),
+}
+
+impl Buf for DuplexBuf {
+    fn remaining(&self) -> usize {
+        match self {
+            DuplexBuf::Ack(b) => b.remaining(),
+            DuplexBuf::Msg(f) => f.remaining(),
+        }
+    }
+
+    fn chunk(&self) -> &[u8] {
+        match self {
+            DuplexBuf::Ack(b) => b.chunk(),
+            DuplexBuf::Msg(f) => f.chunk(),
+        }
+    }
+
+    fn advance(&mut self, cnt: usize) {
+        match self {
+            DuplexBuf::Ack(b) => b.advance(cnt),
+            DuplexBuf::Msg(f) => f.advance(cnt),
+        }
+    }
+
+    fn chunks_vectored<'a>(&'a self, dst: &mut [io::IoSlice<'a>]) -> usize {
+        match self {
+            DuplexBuf::Ack(b) => b.chunks_vectored(dst),
+            DuplexBuf::Msg(f) => f.chunks_vectored(dst),
+        }
+    }
+}
+
+/// Per-link server state persisting across reconnections.
+struct DuplexServerLink<M1: RemoteMessage, M2: RemoteMessage> {
+    #[allow(dead_code)]
+    id: LinkId,
+    /// (inbound_next, outbound_next) — taken/put atomically with MVar.
+    next: MVar<(Next, Next)>,
+    /// Delivers inbound M1 messages to the link's Rx.
+    inbound_tx: mpsc::Sender<M1>,
+    /// Taken by the connection handler, put back on disconnect.
+    outbound_rx: MVar<mpsc::UnboundedReceiver<M2>>,
+}
+
+/// Public duplex server that yields `(NetRx<M1>, DuplexNetTx<M2>)` pairs.
+pub(crate) struct DuplexServer<M1: RemoteMessage, M2: RemoteMessage> {
+    accept_rx: mpsc::Receiver<(DuplexNetRx<M1>, DuplexNetTx<M2>)>,
+    _handle: ServerHandle,
+    addr: ChannelAddr,
+}
+
+impl<M1: RemoteMessage, M2: RemoteMessage> DuplexServer<M1, M2> {
+    pub async fn accept(&mut self) -> Result<(DuplexNetRx<M1>, DuplexNetTx<M2>), ChannelError> {
+        self.accept_rx.recv().await.ok_or(ChannelError::Closed)
+    }
+
+    pub fn addr(&self) -> &ChannelAddr {
+        &self.addr
+    }
+}
+
+/// Receiver half of a duplex channel.
+pub(crate) struct DuplexNetRx<M: RemoteMessage> {
+    rx: mpsc::Receiver<M>,
+    addr: ChannelAddr,
+}
+
+impl<M: RemoteMessage> DuplexNetRx<M> {
+    pub async fn recv(&mut self) -> Result<M, ChannelError> {
+        self.rx.recv().await.ok_or(ChannelError::Closed)
+    }
+
+    #[allow(dead_code)]
+    pub fn addr(&self) -> &ChannelAddr {
+        &self.addr
+    }
+}
+
+/// Sender half of a duplex channel.
+pub(crate) struct DuplexNetTx<M: RemoteMessage> {
+    tx: mpsc::UnboundedSender<M>,
+    addr: ChannelAddr,
+}
+
+impl<M: RemoteMessage> DuplexNetTx<M> {
+    pub fn send(&self, message: M) -> Result<(), ChannelError> {
+        self.tx.send(message).map_err(|_| ChannelError::Closed)
+    }
+
+    #[allow(dead_code)]
+    pub fn addr(&self) -> &ChannelAddr {
+        &self.addr
+    }
+}
+
+impl<M: RemoteMessage> Clone for DuplexNetTx<M> {
+    fn clone(&self) -> Self {
+        Self {
+            tx: self.tx.clone(),
+            addr: self.addr.clone(),
+        }
+    }
+}
+
+/// Start a duplex server on the given address.
+pub(crate) fn serve<M1: RemoteMessage, M2: RemoteMessage>(
+    addr: ChannelAddr,
+) -> Result<DuplexServer<M1, M2>, ServerError> {
+    match addr {
+        ChannelAddr::Tcp(socket_addr) => {
+            let std_listener = std::net::TcpListener::bind(socket_addr)
+                .map_err(|err| ServerError::Listen(ChannelAddr::Tcp(socket_addr), err))?;
+            std_listener
+                .set_nonblocking(true)
+                .map_err(|e| ServerError::Listen(ChannelAddr::Tcp(socket_addr), e))?;
+            let tokio_listener = tokio::net::TcpListener::from_std(std_listener)
+                .map_err(|e| ServerError::Listen(ChannelAddr::Tcp(socket_addr), e))?;
+            let local_addr = tokio_listener
+                .local_addr()
+                .map_err(|err| ServerError::Resolve(ChannelAddr::Tcp(socket_addr), err))?;
+
+            let listener = super::tcp::TcpSocketListener {
+                inner: tokio_listener,
+                addr: local_addr,
+            };
+            let channel_addr = ChannelAddr::Tcp(local_addr);
+            serve_with_listener(listener, channel_addr)
+        }
+        ChannelAddr::Unix(ref unix_addr) => {
+            use std::os::unix::net::UnixDatagram as StdUnixDatagram;
+            use std::os::unix::net::UnixListener as StdUnixListener;
+
+            let caddr = addr.clone();
+            let maybe_listener = match unix_addr {
+                super::unix::SocketAddr::Bound(sock_addr) => StdUnixListener::bind_addr(sock_addr),
+                super::unix::SocketAddr::Unbound => StdUnixDatagram::unbound()
+                    .and_then(|u| u.local_addr())
+                    .and_then(|uaddr| StdUnixListener::bind_addr(&uaddr)),
+            };
+            let std_listener =
+                maybe_listener.map_err(|err| ServerError::Listen(caddr.clone(), err))?;
+            std_listener
+                .set_nonblocking(true)
+                .map_err(|err| ServerError::Listen(caddr.clone(), err))?;
+            let local_addr = std_listener
+                .local_addr()
+                .map_err(|err| ServerError::Resolve(caddr.clone(), err))?;
+            let tokio_listener = tokio::net::UnixListener::from_std(std_listener)
+                .map_err(|err| ServerError::Io(caddr, err))?;
+            let bound_addr = super::unix::SocketAddr::new(local_addr);
+            let listener = super::unix::UnixSocketListener {
+                inner: tokio_listener,
+                addr: bound_addr.clone(),
+            };
+            let channel_addr = ChannelAddr::Unix(bound_addr);
+            serve_with_listener(listener, channel_addr)
+        }
+        _ => Err(ServerError::Listen(
+            addr.clone(),
+            io::Error::other(format!("duplex not supported for transport: {}", addr)),
+        )),
+    }
+}
+
+/// Generic helper that wires a listener to the duplex listen loop.
+fn serve_with_listener<M1: RemoteMessage, M2: RemoteMessage, L: super::Listener>(
+    listener: L,
+    channel_addr: ChannelAddr,
+) -> Result<DuplexServer<M1, M2>, ServerError> {
+    let (accept_tx, accept_rx) = mpsc::channel(16);
+
+    let cancel_token = CancellationToken::new();
+    let child_token = cancel_token.child_token();
+    let ca = channel_addr.clone();
+    let join_handle = tokio::spawn(async move {
+        duplex_listen::<M1, M2, L>(listener, ca, accept_tx, child_token).await
+    });
+
+    let server_handle = ServerHandle::new(join_handle, cancel_token, channel_addr.clone());
+
+    Ok(DuplexServer {
+        accept_rx,
+        _handle: server_handle,
+        addr: channel_addr,
+    })
+}
+
+/// Main listen loop for duplex connections.
+async fn duplex_listen<M1: RemoteMessage, M2: RemoteMessage, L: super::Listener>(
+    mut listener: L,
+    listener_addr: ChannelAddr,
+    accept_tx: mpsc::Sender<(DuplexNetRx<M1>, DuplexNetTx<M2>)>,
+    cancel_token: CancellationToken,
+) -> Result<(), ServerError> {
+    let child_cancel_token = CancellationToken::new();
+    let links: Arc<DashMap<LinkId, Arc<DuplexServerLink<M1, M2>>>> = Arc::new(DashMap::new());
+    let mut connections: JoinSet<Result<(), anyhow::Error>> = JoinSet::new();
+
+    let result: Result<(), ServerError> = loop {
+        tokio::select! {
+            result = listener.accept() => {
+                match result {
+                    Ok((mut stream, _peer_addr)) => {
+                        // Read DuplexLinkInit from the connection.
+                        let link_id = match read_duplex_link_init(&mut stream).await {
+                            Ok(id) => id,
+                            Err(e) => {
+                                tracing::info!(error = %e, "failed to read DuplexLinkInit");
+                                continue;
+                            }
+                        };
+
+                        let links = Arc::clone(&links);
+                        let accept_tx = accept_tx.clone();
+                        let ct = child_cancel_token.child_token();
+                        let addr = listener_addr.clone();
+
+                        connections.spawn(async move {
+                            // Look up or create the link.
+                            let is_new;
+                            let link = {
+                                let entry = links.entry(link_id);
+                                match entry {
+                                    dashmap::mapref::entry::Entry::Occupied(e) => {
+                                        is_new = false;
+                                        e.get().clone()
+                                    }
+                                    dashmap::mapref::entry::Entry::Vacant(e) => {
+                                        is_new = true;
+                                        let (inbound_tx, inbound_rx) = mpsc::channel::<M1>(1024);
+                                        let (outbound_tx, outbound_rx) = mpsc::unbounded_channel::<M2>();
+                                        let link = Arc::new(DuplexServerLink {
+                                            id: link_id,
+                                            next: MVar::full((
+                                                Next { seq: 0, ack: 0 },
+                                                Next { seq: 0, ack: 0 },
+                                            )),
+                                            inbound_tx,
+                                            outbound_rx: MVar::full(outbound_rx),
+                                        });
+                                        e.insert(link.clone());
+
+                                        // Send the new channel pair to accept().
+                                        let net_rx = DuplexNetRx {
+                                            rx: inbound_rx,
+                                            addr: addr.clone(),
+                                        };
+                                        let net_tx = DuplexNetTx {
+                                            tx: outbound_tx,
+                                            addr: addr.clone(),
+                                        };
+                                        let _ = accept_tx.send((net_rx, net_tx)).await;
+
+                                        link
+                                    }
+                                }
+                            };
+
+                            tracing::debug!(
+                                link_id = %link_id,
+                                is_new = is_new,
+                                "duplex connection accepted"
+                            );
+
+                            handle_duplex_connection(stream, link, ct).await
+                        });
+                    }
+                    Err(err) => {
+                        tracing::info!(error = %err, "duplex accept error");
+                    }
+                }
+            }
+
+            _ = cancel_token.cancelled() => {
+                break Ok(());
+            }
+
+            result = join_nonempty(&mut connections) => {
+                if let Err(err) = result {
+                    tracing::info!(error = %err, "duplex connection task join error");
+                }
+            }
+        }
+    };
+
+    child_cancel_token.cancel();
+    while connections.join_next().await.is_some() {}
+    result
+}
+
+async fn join_nonempty<T: 'static>(set: &mut JoinSet<T>) -> Result<T, tokio::task::JoinError> {
+    match set.join_next().await {
+        None => std::future::pending().await,
+        Some(result) => result,
+    }
+}
+
+/// Handle a single duplex connection. Takes `(inbound_next, outbound_next)`
+/// from the link's MVar, runs the select! loop, and puts them back on close.
+async fn handle_duplex_connection<M1: RemoteMessage, M2: RemoteMessage, S>(
+    stream: S,
+    link: Arc<DuplexServerLink<M1, M2>>,
+    cancel_token: CancellationToken,
+) -> Result<(), anyhow::Error>
+where
+    S: AsyncRead + AsyncWrite + Send + Unpin + 'static,
+{
+    let (reader, writer) = tokio::io::split(stream);
+    let mut frame_reader = FrameReader::new(
+        reader,
+        hyperactor_config::global::get(config::CODEC_MAX_FRAME_LENGTH),
+    );
+
+    // Take session state.
+    let (mut inbound_next, mut outbound_next) = link.next.take().await;
+    let mut outbound_rx = link.outbound_rx.take().await;
+
+    let max = hyperactor_config::global::get(config::CODEC_MAX_FRAME_LENGTH);
+    let ack_msg_interval: u64 =
+        hyperactor_config::global::get(config::MESSAGE_ACK_EVERY_N_MESSAGES);
+    let ack_time_interval: Duration =
+        hyperactor_config::global::get(config::MESSAGE_ACK_TIME_INTERVAL);
+
+    let mut write_state: WriteState<WriteHalf<S>, DuplexBuf, Side> = WriteState::Idle(writer);
+    let mut last_inbound_ack_time = RealClock.now();
+
+    // Retransmit unacked outbound messages.
+    // We don't have a replay buffer on the server side for outbound yet,
+    // so we just track seq/ack for ordering. In a full implementation
+    // we'd replay from a buffer. For now, outbound starts fresh each
+    // connection.
+
+    let result: Result<(), anyhow::Error> = loop {
+        let inbound_ack_behind = inbound_next.ack + ack_msg_interval <= inbound_next.seq
+            || (inbound_next.ack < inbound_next.seq
+                && last_inbound_ack_time.elapsed() > ack_time_interval);
+
+        tokio::select! {
+            biased;
+
+            // Drive in-progress write to completion.
+            result = write_state.send() => {
+                match result {
+                    Ok(side) => {
+                        if side == Side::A {
+                            last_inbound_ack_time = RealClock.now();
+                            inbound_next.ack = inbound_next.seq;
+                        }
+                    }
+                    Err(e) => {
+                        break Err(e.into());
+                    }
+                }
+            }
+
+            // Inbound ack write (Side::A — we ack the client's messages).
+            _ = std::future::ready(()), if write_state.is_idle() && inbound_ack_behind => {
+                let Ok(writer) = replace(&mut write_state, WriteState::Broken).into_idle() else {
+                    panic!("illegal state");
+                };
+                let ack = serialize_response(NetRxResponse::Ack(inbound_next.seq - 1))?;
+                match FrameWrite::new(writer, DuplexBuf::Ack(ack), max, Side::A as u8) {
+                    Ok(fw) => {
+                        write_state = WriteState::Writing(fw, Side::A);
+                    }
+                    Err((w, _e)) => {
+                        write_state = WriteState::Idle(w);
+                    }
+                }
+            }
+
+            // Outbound message write (Side::B — server sends M2 to client).
+            msg = outbound_rx.recv(), if write_state.is_idle() => {
+                match msg {
+                    Some(message) => {
+                        let Ok(writer) = replace(&mut write_state, WriteState::Broken).into_idle() else {
+                            panic!("illegal state");
+                        };
+                        let msg = serde_multipart::serialize_bincode(
+                            &Frame::Message(outbound_next.seq, message),
+                        )?;
+                        match FrameWrite::new(writer, DuplexBuf::Msg(msg.framed()), max, Side::B as u8) {
+                            Ok(fw) => {
+                                outbound_next.seq += 1;
+                                write_state = WriteState::Writing(fw, Side::B);
+                            }
+                            Err((w, e)) => {
+                                write_state = WriteState::Idle(w);
+                                tracing::error!(error = %e, "failed to create outbound frame");
+                            }
+                        }
+                    }
+                    None => {
+                        // Outbound channel closed; send Closed response and exit.
+                        break Ok(());
+                    }
+                }
+            }
+
+            // Read from the wire.
+            frame_result = frame_reader.next() => {
+                match frame_result {
+                    Ok(Some((tag, bytes))) => {
+                        if tag == Side::A as u8 {
+                            // Side::A frame from client = inbound message (M1).
+                            let message = serde_multipart::Message::from_framed(bytes)?;
+                            let frame: Frame<M1> = serde_multipart::deserialize_bincode(message)?;
+                            match frame {
+                                Frame::Message(seq, msg) => {
+                                    if seq < inbound_next.seq {
+                                        // Retransmit — ignore.
+                                        tracing::debug!(seq, "duplex: ignoring inbound retransmit");
+                                    } else if seq == inbound_next.seq {
+                                        link.inbound_tx.send(msg).await
+                                            .map_err(|_| anyhow::anyhow!("inbound channel closed"))?;
+                                        inbound_next.seq += 1;
+                                    } else {
+                                        break Err(anyhow::anyhow!(
+                                            "out-of-sequence inbound message: expected {}, got {}",
+                                            inbound_next.seq, seq
+                                        ));
+                                    }
+                                }
+                            }
+                        } else if tag == Side::B as u8 {
+                            // Side::B frame from client = ack for our outbound M2.
+                            let response = deserialize_response(bytes)?;
+                            match response {
+                                NetRxResponse::Ack(acked_seq) => {
+                                    outbound_next.ack = acked_seq + 1;
+                                }
+                                NetRxResponse::Reject(reason) => {
+                                    break Err(anyhow::anyhow!("peer rejected: {}", reason));
+                                }
+                                NetRxResponse::Closed => {
+                                    break Ok(());
+                                }
+                            }
+                        } else {
+                            tracing::warn!(tag, "duplex: unknown tag, ignoring frame");
+                        }
+                    }
+                    Ok(None) => {
+                        // EOF — peer disconnected.
+                        break Ok(());
+                    }
+                    Err(e) => {
+                        break Err(e.into());
+                    }
+                }
+            }
+
+            _ = cancel_token.cancelled() => {
+                break Ok(());
+            }
+        }
+    };
+
+    // Put state back for reconnection.
+    link.next.put((inbound_next, outbound_next)).await;
+    link.outbound_rx.put(outbound_rx).await;
+
+    result
+}
+
+/// Connect to a duplex server, returning tx and rx handles.
+pub(crate) async fn dial<M1: RemoteMessage, M2: RemoteMessage>(
+    addr: ChannelAddr,
+) -> Result<(DuplexNetTx<M1>, DuplexNetRx<M2>), super::ClientError> {
+    let link_id = LinkId::random();
+
+    let (outbound_tx, outbound_rx) = mpsc::unbounded_channel::<M1>();
+    let (inbound_tx, inbound_rx) = mpsc::channel::<M2>(1024);
+
+    let ca = addr.clone();
+    tokio::spawn(async move {
+        duplex_client_run::<M1, M2>(ca, link_id, outbound_rx, inbound_tx).await;
+    });
+
+    Ok((
+        DuplexNetTx {
+            tx: outbound_tx,
+            addr: addr.clone(),
+        },
+        DuplexNetRx {
+            rx: inbound_rx,
+            addr,
+        },
+    ))
+}
+
+/// Background task that manages the client side of a duplex connection,
+/// including reconnection.
+async fn duplex_client_run<M1: RemoteMessage, M2: RemoteMessage>(
+    addr: ChannelAddr,
+    link_id: LinkId,
+    mut outbound_rx: mpsc::UnboundedReceiver<M1>,
+    inbound_tx: mpsc::Sender<M2>,
+) {
+    use backoff::ExponentialBackoffBuilder;
+    use backoff::backoff::Backoff;
+
+    let mut outbound_next = Next { seq: 0, ack: 0 };
+    let mut inbound_next = Next { seq: 0, ack: 0 };
+
+    // Replay buffer for unacked outbound messages.
+    let mut unacked: std::collections::VecDeque<(u64, Bytes)> = std::collections::VecDeque::new();
+
+    let max = hyperactor_config::global::get(config::CODEC_MAX_FRAME_LENGTH);
+    let ack_msg_interval: u64 =
+        hyperactor_config::global::get(config::MESSAGE_ACK_EVERY_N_MESSAGES);
+    let ack_time_interval: Duration =
+        hyperactor_config::global::get(config::MESSAGE_ACK_TIME_INTERVAL);
+
+    let mut backoff = ExponentialBackoffBuilder::new()
+        .with_initial_interval(Duration::from_millis(100))
+        .with_max_interval(Duration::from_secs(5))
+        .with_max_elapsed_time(None)
+        .build();
+
+    loop {
+        // Connect.
+        let stream = match super::connect_raw(&addr).await {
+            Ok(mut s) => {
+                if let Err(e) = write_duplex_link_init(&mut s, link_id).await {
+                    tracing::info!(error = %e, "failed to write DuplexLinkInit");
+                    if let Some(d) = backoff.next_backoff() {
+                        RealClock.sleep(d).await;
+                    }
+                    continue;
+                }
+                backoff.reset();
+                s
+            }
+            Err(e) => {
+                tracing::debug!(error = %e, "duplex client connect failed");
+                if let Some(d) = backoff.next_backoff() {
+                    RealClock.sleep(d).await;
+                }
+                continue;
+            }
+        };
+
+        let (reader, writer) = tokio::io::split(stream);
+        let mut frame_reader = FrameReader::new(reader, max);
+        let mut write_state: WriteState<WriteHalf<Box<dyn super::Stream>>, DuplexBuf, Side> =
+            WriteState::Idle(writer);
+
+        // Retransmit unacked outbound messages.
+        let mut retransmit_queue: std::collections::VecDeque<(u64, Bytes)> = unacked.clone();
+
+        let mut last_inbound_ack_time = RealClock.now();
+        #[allow(unused_assignments)] // initial false IS read on clean-break paths
+        let mut conn_broken = false;
+
+        loop {
+            let inbound_ack_behind = inbound_next.ack + ack_msg_interval <= inbound_next.seq
+                || (inbound_next.ack < inbound_next.seq
+                    && last_inbound_ack_time.elapsed() > ack_time_interval);
+            let has_retransmit = !retransmit_queue.is_empty();
+
+            tokio::select! {
+                biased;
+
+                // Drive in-progress write.
+                result = write_state.send() => {
+                    match result {
+                        Ok(side) => {
+                            if side == Side::B {
+                                last_inbound_ack_time = RealClock.now();
+                                inbound_next.ack = inbound_next.seq;
+                            }
+                        }
+                        Err(_e) => {
+                            break;
+                        }
+                    }
+                }
+
+                // Retransmit unacked outbound (Side::A).
+                _ = std::future::ready(()), if write_state.is_idle() && has_retransmit => {
+                    let Ok(writer) = replace(&mut write_state, WriteState::Broken).into_idle() else {
+                        panic!("illegal state");
+                    };
+                    let (_, data) = retransmit_queue.pop_front().unwrap();
+                    match FrameWrite::new(writer, DuplexBuf::Ack(data), max, Side::A as u8) {
+                        Ok(fw) => {
+                            write_state = WriteState::Writing(fw, Side::A);
+                        }
+                        Err((_w, _)) => {
+                            break;
+                        }
+                    }
+                }
+
+                // Send outbound M1 (Side::A).
+                msg = outbound_rx.recv(), if write_state.is_idle() && !has_retransmit => {
+                    match msg {
+                        Some(message) => {
+                            let Ok(writer) = replace(&mut write_state, WriteState::Broken).into_idle() else {
+                                panic!("illegal state");
+                            };
+                            let seq = outbound_next.seq;
+                            let msg = match serde_multipart::serialize_bincode(
+                                &Frame::Message(seq, message),
+                            ) {
+                                Ok(f) => f,
+                                Err(e) => {
+                                    tracing::error!(error = %e, "failed to serialize outbound message");
+                                    conn_broken = true;
+                                    break;
+                                }
+                            };
+                            // Convert to framed bytes for both sending and replay.
+                            let mut framed = msg.framed();
+                            let payload = framed.copy_to_bytes(framed.remaining());
+                            match FrameWrite::new(writer, DuplexBuf::Ack(payload.clone()), max, Side::A as u8) {
+                                Ok(fw) => {
+                                    unacked.push_back((seq, payload));
+                                    outbound_next.seq += 1;
+                                    write_state = WriteState::Writing(fw, Side::A);
+                                }
+                                Err((w, e)) => {
+                                    write_state = WriteState::Idle(w);
+                                    tracing::error!(error = %e, "failed to create outbound frame");
+                                }
+                            }
+                        }
+                        None => {
+                            // Outbound channel dropped — we're done.
+                            return;
+                        }
+                    }
+                }
+
+                // Ack inbound (Side::B).
+                _ = std::future::ready(()), if write_state.is_idle() && inbound_ack_behind && !has_retransmit => {
+                    let Ok(writer) = replace(&mut write_state, WriteState::Broken).into_idle() else {
+                        panic!("illegal state");
+                    };
+                    let ack = match serialize_response(NetRxResponse::Ack(inbound_next.seq - 1)) {
+                        Ok(a) => a,
+                        Err(_) => {
+                            break;
+                        }
+                    };
+                    match FrameWrite::new(writer, DuplexBuf::Ack(ack), max, Side::B as u8) {
+                        Ok(fw) => {
+                            write_state = WriteState::Writing(fw, Side::B);
+                        }
+                        Err((w, _)) => {
+                            write_state = WriteState::Idle(w);
+                        }
+                    }
+                }
+
+                // Read from the wire.
+                frame_result = frame_reader.next() => {
+                    match frame_result {
+                        Ok(Some((tag, bytes))) => {
+                            if tag == Side::A as u8 {
+                                // Side::A from server = ack for our outbound M1.
+                                match deserialize_response(bytes) {
+                                    Ok(NetRxResponse::Ack(acked_seq)) => {
+                                        // Prune unacked up to and including acked_seq.
+                                        while let Some((seq, _)) = unacked.front() {
+                                            if *seq <= acked_seq {
+                                                unacked.pop_front();
+                                            } else {
+                                                break;
+                                            }
+                                        }
+                                    }
+                                    Ok(NetRxResponse::Reject(reason)) => {
+                                        tracing::error!(reason = %reason, "duplex server rejected");
+                                        return;
+                                    }
+                                    Ok(NetRxResponse::Closed) => {
+                                        return;
+                                    }
+                                    Err(e) => {
+                                        tracing::warn!(error = %e, "failed to deserialize ack");
+                                        conn_broken = true;
+                                        break;
+                                    }
+                                }
+                            } else if tag == Side::B as u8 {
+                                // Side::B from server = inbound M2 message.
+                                match serde_multipart::Message::from_framed(bytes) {
+                                    Ok(message) => {
+                                        match serde_multipart::deserialize_bincode::<Frame<M2>>(message) {
+                                            Ok(Frame::Message(seq, msg)) => {
+                                                if seq < inbound_next.seq {
+                                                    // Retransmit — ignore.
+                                                    tracing::debug!(seq, "duplex client: ignoring inbound retransmit");
+                                                } else if seq == inbound_next.seq {
+                                                    if inbound_tx.send(msg).await.is_err() {
+                                                        // Receiver dropped.
+                                                        return;
+                                                    }
+                                                    inbound_next.seq += 1;
+                                                } else {
+                                                    tracing::error!(
+                                                        expected = inbound_next.seq,
+                                                        got = seq,
+                                                        "out-of-sequence inbound message"
+                                                    );
+                                                    conn_broken = true;
+                                                    break;
+                                                }
+                                            }
+                                            Err(e) => {
+                                                tracing::warn!(error = %e, "failed to deserialize inbound message");
+                                                conn_broken = true;
+                                                break;
+                                            }
+                                        }
+                                    }
+                                    Err(e) => {
+                                        tracing::warn!(error = %e, "failed to deframe inbound message");
+                                        conn_broken = true;
+                                        break;
+                                    }
+                                }
+                            } else {
+                                tracing::warn!(tag, "duplex client: unknown tag");
+                            }
+                        }
+                        Ok(None) => {
+                            // EOF — reconnect.
+                            break;
+                        }
+                        Err(_e) => {
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+
+        if !conn_broken {
+            return;
+        }
+
+        // Reconnect with backoff.
+        if let Some(d) = backoff.next_backoff() {
+            RealClock.sleep(d).await;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use timed_test::async_timed_test;
+
+    use super::*;
+
+    #[async_timed_test(timeout_secs = 30)]
+    // TODO: OSS: called `Result::unwrap()` on an `Err` value: Listen(Tcp([::1]:0), Os { code: 99, kind: AddrNotAvailable, message: "Cannot assign requested address" })
+    #[cfg_attr(not(fbcode_build), ignore)]
+    async fn test_duplex_basic() {
+        let mut server =
+            serve::<u64, String>(ChannelAddr::Tcp("[::1]:0".parse().unwrap())).unwrap();
+        let server_addr = server.addr().clone();
+
+        // Client: sends u64, receives String.
+        let (client_tx, mut client_rx) = dial::<u64, String>(server_addr).await.unwrap();
+
+        // Server: receives u64, sends String.
+        let (mut server_rx, server_tx) = server.accept().await.unwrap();
+
+        // Client sends to server.
+        client_tx.send(42).unwrap();
+        let received = server_rx.recv().await.unwrap();
+        assert_eq!(received, 42);
+
+        // Server sends to client.
+        server_tx.send("hello".to_string()).unwrap();
+        let received = client_rx.recv().await.unwrap();
+        assert_eq!(received, "hello");
+
+        // Multiple messages both ways.
+        for i in 0..10u64 {
+            client_tx.send(i).unwrap();
+            assert_eq!(server_rx.recv().await.unwrap(), i);
+
+            server_tx.send(format!("msg-{}", i)).unwrap();
+            assert_eq!(client_rx.recv().await.unwrap(), format!("msg-{}", i));
+        }
+    }
+
+    #[async_timed_test(timeout_secs = 30)]
+    #[cfg_attr(not(fbcode_build), ignore)]
+    async fn test_duplex_multiple_links() {
+        let mut server = serve::<u64, u64>(ChannelAddr::Tcp("[::1]:0".parse().unwrap())).unwrap();
+        let server_addr = server.addr().clone();
+
+        // Two independent clients.
+        let (tx1, mut rx1) = dial::<u64, u64>(server_addr.clone()).await.unwrap();
+        let (mut srx1, stx1) = server.accept().await.unwrap();
+
+        let (tx2, mut rx2) = dial::<u64, u64>(server_addr).await.unwrap();
+        let (mut srx2, stx2) = server.accept().await.unwrap();
+
+        // Send on link 1.
+        tx1.send(100).unwrap();
+        assert_eq!(srx1.recv().await.unwrap(), 100);
+        stx1.send(200).unwrap();
+        assert_eq!(rx1.recv().await.unwrap(), 200);
+
+        // Send on link 2.
+        tx2.send(300).unwrap();
+        assert_eq!(srx2.recv().await.unwrap(), 300);
+        stx2.send(400).unwrap();
+        assert_eq!(rx2.recv().await.unwrap(), 400);
+    }
+}

--- a/hyperactor/src/channel/net/framed.rs
+++ b/hyperactor/src/channel/net/framed.rs
@@ -15,9 +15,7 @@ use std::mem::take;
 use std::task::Poll;
 
 use bytes::Buf;
-use bytes::BufMut;
 use bytes::Bytes;
-use bytes::BytesMut;
 use enum_as_inner::EnumAsInner;
 use futures::future::poll_fn;
 use tokio::io::AsyncRead;
@@ -34,10 +32,10 @@ pub struct FrameReader<R> {
 }
 
 enum FrameReaderState {
-    /// Accumulating 8-byte length prefix.
+    /// Accumulating 8-byte header: `[tag: 1B][len: 7B BE]`.
     ReadLen { buf: [u8; 8], off: usize },
     /// Accumulating body of exactly `len` bytes.
-    ReadBody { buf: Vec<u8>, len: usize }, // buf.len() <= len
+    ReadBody { tag: u8, buf: Vec<u8>, len: usize }, // buf.len() <= len
 }
 
 impl<R: AsyncRead + Unpin> FrameReader<R> {
@@ -68,7 +66,14 @@ impl<R: AsyncRead + Unpin> FrameReader<R> {
     ///   `max_frame_length`. **This error is fatal:** once returned,
     ///   the `FrameReader` must be dropped; the underlying connection
     ///   is no longer valid.
-    pub async fn next(&mut self) -> io::Result<Option<Bytes>> {
+    ///
+    /// # Header format
+    ///
+    /// The 8-byte header is interpreted as `[tag: 1B][len: 7B BE]`.
+    /// The tag byte is returned alongside the frame body. Simplex
+    /// connections write `tag = 0` and ignore it on read; duplex
+    /// connections use the tag to distinguish logical channels.
+    pub async fn next(&mut self) -> io::Result<Option<(u8, Bytes)>> {
         loop {
             match &mut self.state {
                 FrameReaderState::ReadLen { buf, off } if *off < 8 => {
@@ -94,17 +99,20 @@ impl<R: AsyncRead + Unpin> FrameReader<R> {
 
                 FrameReaderState::ReadLen { buf, off } => {
                     assert_eq!(*off, 8);
-                    let len = (&buf[..]).get_u64() as usize;
+                    let tag = buf[0];
+                    buf[0] = 0;
+                    let len = u64::from_be_bytes(*buf) as usize;
                     if len > self.max_frame_length {
                         return Err(io::ErrorKind::InvalidData.into());
                     }
                     self.state = FrameReaderState::ReadBody {
+                        tag,
                         buf: Vec::with_capacity(len),
                         len,
                     };
                 }
 
-                FrameReaderState::ReadBody { buf, len } if buf.len() < *len => {
+                FrameReaderState::ReadBody { buf, len, .. } if buf.len() < *len => {
                     let num_to_read = *len - buf.len();
 
                     let num_read = poll_fn(|cx| {
@@ -131,14 +139,15 @@ impl<R: AsyncRead + Unpin> FrameReader<R> {
                     }
                 }
 
-                FrameReaderState::ReadBody { buf, len } => {
+                FrameReaderState::ReadBody { tag, buf, len } => {
                     assert_eq!(buf.len(), *len);
+                    let tag = *tag;
                     let frame = take(buf).into();
                     self.state = FrameReaderState::ReadLen {
                         buf: [0; 8],
                         off: 0,
                     };
-                    return Ok(Some(frame));
+                    return Ok(Some((tag, frame)));
                 }
             }
         }
@@ -167,7 +176,8 @@ impl<W, B: Buf> fmt::Debug for FrameWrite<W, B> {
 impl<W: AsyncWrite + Unpin, B: Buf> FrameWrite<W, B> {
     /// Create a new frame writer, writing `body` to `writer`.
     ///
-    /// The frame is length-prefixed with an 8-byte big-endian `u64`.
+    /// The 8-byte header is `[tag: 1B][len: 7B BE]`. Simplex
+    /// connections pass `tag = 0`.
     ///
     /// # Arguments
     ///
@@ -175,6 +185,7 @@ impl<W: AsyncWrite + Unpin, B: Buf> FrameWrite<W, B> {
     /// * `body` — the serialized frame body to send.
     /// * `max_len` — maximum allowed frame length; frames larger than this
     ///   yield an `io::ErrorKind::InvalidData`.
+    /// * `tag` — the tag byte written into the first byte of the header.
     ///
     /// # Returns
     ///
@@ -182,24 +193,7 @@ impl<W: AsyncWrite + Unpin, B: Buf> FrameWrite<W, B> {
     /// `body`.
     /// On error, returns the I/O error if the frame length exceeds
     /// `max_len`.
-    /// frame length exceeds `max_len`.
-    ///
-    /// # Examples
-    ///
-    /// ```ignore
-    /// use bytes::Bytes;
-    /// use hyperactor::channel::net::framed::FrameWrite;
-    ///
-    /// // `writer` is any AsyncWrite + Unpin (e.g. a tokio `WriteHalf`)
-    /// let mut fw = FrameWrite::new(writer, Bytes::from_static(b"hello"), 1024)?;
-    /// fw.send().await?;
-    /// let writer = fw.complete();
-    /// ```
-    ///
-    /// # See also
-    ///
-    /// For a one-shot convenience wrapper, see [`write_frame`].
-    pub fn new(writer: W, body: B, max_len: usize) -> Result<Self, (W, io::Error)> {
+    pub fn new(writer: W, body: B, max_len: usize, tag: u8) -> Result<Self, (W, io::Error)> {
         let len = body.remaining();
         if len > max_len {
             return Err((
@@ -210,9 +204,21 @@ impl<W: AsyncWrite + Unpin, B: Buf> FrameWrite<W, B> {
                 ),
             ));
         }
-        let mut len_buf = BytesMut::with_capacity(8);
-        len_buf.put_u64(len as u64);
-        let len_buf = len_buf.freeze();
+        if len > (1 << 56) - 1 {
+            return Err((
+                writer,
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!("frame length {} exceeds 7-byte maximum", len),
+                ),
+            ));
+        }
+        let mut len_buf = [0u8; 8];
+        len_buf[0] = tag;
+        // Encode length as 7-byte big-endian in bytes [1..8].
+        let len_be = (len as u64).to_be_bytes();
+        len_buf[1..8].copy_from_slice(&len_be[1..8]);
+        let len_buf = Bytes::copy_from_slice(&len_buf);
         Ok(Self {
             writer,
             len_buf,
@@ -305,8 +311,8 @@ impl<W: AsyncWrite + Unpin, B: Buf> FrameWrite<W, B> {
     /// let writer = FrameWrite::write_frame(writer, Bytes::from_static(b"hello"), 10usize).await?;
     /// ```
     #[allow(dead_code)] // Not used outside tests.
-    pub async fn write_frame(writer: W, buf: B, max: usize) -> Result<W, (W, io::Error)> {
-        let mut fw = FrameWrite::new(writer, buf, max)?;
+    pub async fn write_frame(writer: W, buf: B, max: usize, tag: u8) -> Result<W, (W, io::Error)> {
+        let mut fw = FrameWrite::new(writer, buf, max, tag)?;
         let res = fw.send().await;
         let writer = fw.complete();
         match res {
@@ -925,13 +931,13 @@ mod tests {
 
         for _ in 0..1024 {
             let body = random_buffer(MAX_LEN);
-            let mut frame_write = FrameWrite::new(writer.take().unwrap(), body.clone(), MAX_LEN)
+            let mut frame_write = FrameWrite::new(writer.take().unwrap(), body.clone(), MAX_LEN, 0)
                 .map_err(|(_, e)| e)
                 .unwrap();
             frame_write.send().await.unwrap();
             writer = Some(frame_write.complete());
 
-            let frame = reader.next().await.unwrap().unwrap();
+            let (_, frame) = reader.next().await.unwrap().unwrap();
             assert_eq!(frame, body);
         }
     }
@@ -947,20 +953,20 @@ mod tests {
         let mut reader = FrameReader::new(r, MAX_LEN);
 
         eprintln!("write 1");
-        let w = FrameWrite::write_frame(w, Bytes::from_static(b"hello"), MAX_LEN)
+        let w = FrameWrite::write_frame(w, Bytes::from_static(b"hello"), MAX_LEN, 0)
             .await
             .map_err(|(_, e)| e)
             .unwrap();
         eprintln!("write 2");
-        let _ = FrameWrite::write_frame(w, Bytes::from_static(b"world"), MAX_LEN)
+        let _ = FrameWrite::write_frame(w, Bytes::from_static(b"world"), MAX_LEN, 0)
             .await
             .map_err(|(_, e)| e)
             .unwrap();
 
         eprintln!("read 1");
-        let f1 = reader.next().await.unwrap().unwrap();
+        let (_, f1) = reader.next().await.unwrap().unwrap();
         eprintln!("read 2");
-        let f2 = reader.next().await.unwrap().unwrap();
+        let (_, f2) = reader.next().await.unwrap().unwrap();
 
         assert_eq!(f1.as_ref(), b"hello");
         assert_eq!(f2.as_ref(), b"world");
@@ -976,7 +982,7 @@ mod tests {
         let mut reader = FrameReader::new(r, 1024);
 
         // Write a complete frame.
-        w = FrameWrite::write_frame(w, Bytes::from_static(b"done"), MAX_LEN)
+        w = FrameWrite::write_frame(w, Bytes::from_static(b"done"), MAX_LEN, 0)
             .await
             .map_err(|(_, e)| e)
             .unwrap();
@@ -985,7 +991,7 @@ mod tests {
         drop(w);
         assert_eq!(
             reader.next().await.unwrap(),
-            Some(Bytes::from_static(b"done"))
+            Some((0, Bytes::from_static(b"done")))
         );
         // Boundary EOF.
         assert!(reader.next().await.unwrap().is_none());
@@ -1000,10 +1006,12 @@ mod tests {
         let (_ru, mut w) = tokio::io::split(b);
         let mut reader = FrameReader::new(r, MAX_LEN);
 
-        // Start a frame of length 5.
-        let mut len = bytes::BytesMut::with_capacity(8);
-        len.put_u64(5);
-        w.write_all(&len.freeze()).await.unwrap();
+        // Start a frame: [tag=0, len=5 as 7-byte BE].
+        let mut hdr = [0u8; 8];
+        hdr[0] = 0; // tag
+        let len_be = 5u64.to_be_bytes();
+        hdr[1..8].copy_from_slice(&len_be[1..8]);
+        w.write_all(&hdr).await.unwrap();
         // Write only 2 bytes of the body.
         w.write_all(b"he").await.unwrap();
         // Shutdown the writer so there's an EOF mid frame.
@@ -1027,7 +1035,7 @@ mod tests {
         // 256 bytes, all = 0x2A ('*'), "the answer"
         let body = Bytes::from_static(&[42u8; 256]);
         let mut reader = FrameReader::new(r, MAX_LEN);
-        let mut fw = FrameWrite::new(w, body.clone(), MAX_LEN)
+        let mut fw = FrameWrite::new(w, body.clone(), MAX_LEN, 0)
             .map_err(|(_, e)| e)
             .unwrap();
 
@@ -1053,7 +1061,7 @@ mod tests {
         fw.writer.set_budget(usize::MAX);
         fw.send().await.unwrap();
         let mut w = fw.complete();
-        let got = reader.next().await.unwrap().unwrap();
+        let (_, got) = reader.next().await.unwrap().unwrap();
         assert_eq!(got, body);
 
         // Shutdown and test for EOF on boundary.
@@ -1071,12 +1079,12 @@ mod tests {
         let mut reader = FrameReader::new(r, MAX);
 
         let bytes_written = Bytes::from(vec![0xAB; MAX]);
-        w = FrameWrite::write_frame(w, bytes_written.clone(), MAX)
+        w = FrameWrite::write_frame(w, bytes_written.clone(), MAX, 0)
             .await
             .map_err(|(_, e)| e)
             .unwrap();
 
-        let bytes_read = reader.next().await.unwrap().unwrap();
+        let (_, bytes_read) = reader.next().await.unwrap().unwrap();
         assert_eq!(bytes_read.len(), MAX);
         assert_eq!(bytes_read, bytes_written);
 
@@ -1094,7 +1102,7 @@ mod tests {
         let mut reader = FrameReader::new(r, MAX - 1);
 
         let bytes_written = Bytes::from(vec![0xAB; MAX]);
-        w = FrameWrite::write_frame(w, bytes_written, MAX)
+        w = FrameWrite::write_frame(w, bytes_written, MAX, 0)
             .await
             .map_err(|(_, e)| e)
             .unwrap();
@@ -1120,16 +1128,16 @@ mod tests {
         let (_ru, mut w) = tokio::io::split(b);
         let mut reader = FrameReader::new(r, MAX);
 
-        w = FrameWrite::write_frame(w, Bytes::new(), 0)
+        w = FrameWrite::write_frame(w, Bytes::new(), 0, 0)
             .await
             .map_err(|(_, e)| e)
             .unwrap();
-        assert_eq!(reader.next().await.unwrap().unwrap().len(), 0);
-        w = FrameWrite::write_frame(w, Bytes::new(), 0)
+        assert_eq!(reader.next().await.unwrap().unwrap().1.len(), 0);
+        w = FrameWrite::write_frame(w, Bytes::new(), 0, 0)
             .await
             .map_err(|(_, e)| e)
             .unwrap();
-        assert_eq!(reader.next().await.unwrap().unwrap().len(), 0);
+        assert_eq!(reader.next().await.unwrap().unwrap().1.len(), 0);
 
         w.shutdown().await.unwrap();
         assert!(reader.next().await.unwrap().is_none());
@@ -1282,7 +1290,7 @@ mod property_tests {
                         //   `PartialEq`).
                         {
                             let bw = BudgetedWriter::new(shared.clone(), gate.clone());
-                            let mut fw = FrameWrite::new(bw, body.clone(), 1024).map_err(|(_, e)| e).unwrap();
+                            let mut fw = FrameWrite::new(bw, body.clone(), 1024, 0).map_err(|(_, e)| e).unwrap();
                             async move { fw.send().await.map_err(|_| ()) }
                         },
                         Ok(()),
@@ -1323,7 +1331,7 @@ mod property_tests {
                     // written to the wire. Verifying that the next
                     // read yields exactly `body` checks the
                     // postcondition of `send()`.
-                    let got = reader.next().await.unwrap().unwrap();
+                    let (_, got) = reader.next().await.unwrap().unwrap();
                     assert_eq!(got, body);
                 }
                 ).await.expect("cancel-safety run timed out");
@@ -1409,7 +1417,7 @@ mod property_tests {
                         {
                             let bw = BudgetedWriter::new(shared.clone(), make_gate.clone());
                             let body = msg.clone().framed(); // multipart → vectored path
-                            let mut fw = FrameWrite::new(bw, body, MB).map_err(|(_, e)| e).unwrap();
+                            let mut fw = FrameWrite::new(bw, body, MB, 0).map_err(|(_, e)| e).unwrap();
                             async move { fw.send().await.map_err(|_| ()) }
                         },
                         Ok(()),
@@ -1447,7 +1455,7 @@ mod property_tests {
                     // read yields exactly `expected_body` checks the
                     // postcondition of `send()` (the reader sees the
                     // body bytes, with the length prefix stripped).
-                    let got = tokio::time::timeout(std::time::Duration::from_secs(1), reader.next())
+                    let (_, got) = tokio::time::timeout(std::time::Duration::from_secs(1), reader.next())
                         .await.expect("reader stalled").unwrap().unwrap();
                     assert_eq!(got, expected_body);
                 }).await.expect("strict multipart cancel-safety run timed out");
@@ -1524,7 +1532,7 @@ mod property_tests {
                         {
                             let bw = BudgetedWriter::new(shared.clone(), make_gate.clone());
                             let body = msg.clone().framed(); // may or may not be multipart
-                            let mut fw = FrameWrite::new(bw, body, MB).map_err(|(_, e)| e).unwrap();
+                            let mut fw = FrameWrite::new(bw, body, MB, 0).map_err(|(_, e)| e).unwrap();
                             async move { fw.send().await.map_err(|_| ()) }
                         },
                         Ok(()),
@@ -1553,7 +1561,7 @@ mod property_tests {
                     // must be fully written to the wire. Verifying that the next read
                     // yields exactly `expected_body` checks the postcondition of `send()`
                     // (the reader sees the body bytes, with the length prefix stripped).
-                    let got = tokio::time::timeout(std::time::Duration::from_secs(1), reader.next())
+                    let (_, got) = tokio::time::timeout(std::time::Duration::from_secs(1), reader.next())
                         .await.expect("reader stalled").unwrap().unwrap();
                     assert_eq!(got, expected_body);
                 }).await.expect("unipart/multipart cancel-safety run timed out");

--- a/hyperactor/src/channel/net/server.rs
+++ b/hyperactor/src/channel/net/server.rs
@@ -144,6 +144,7 @@ impl<S: AsyncRead + AsyncWrite + Send + 'static + Unpin> ServerConn<S> {
                 writer,
                 ack,
                 hyperactor_config::global::get(config::CODEC_MAX_FRAME_LENGTH),
+                0,
             ) {
                 Ok(fw) => {
                     self.write_state = WriteState::Writing(fw, next.seq);
@@ -198,7 +199,7 @@ impl<S: AsyncRead + AsyncWrite + Send + 'static + Unpin> ServerConn<S> {
                 *rcv_raw_frame_count += 1;
                 // First handle transport-level I/O errors, and EOFs.
                 let bytes = match bytes_result {
-                    Ok(Some(bytes)) => bytes,
+                    Ok(Some((_, bytes))) => bytes,
                     Ok(None) => {
                         tracing::debug!(
                                 source = %self.source,
@@ -437,8 +438,8 @@ impl<S: AsyncRead + AsyncWrite + Send + 'static + Unpin> ServerConn<S> {
                     .map_err(anyhow::Error::from)?;
 
                 let max = hyperactor_config::global::get(config::CODEC_MAX_FRAME_LENGTH);
-                let fw =
-                    FrameWrite::new(writer, ack, max).map_err(|(_, e)| anyhow::Error::from(e))?;
+                let fw = FrameWrite::new(writer, ack, max, 0)
+                    .map_err(|(_, e)| anyhow::Error::from(e))?;
                 self.write_state = WriteState::Writing(fw, final_next.seq);
                 self.write_state.send().await.map_err(anyhow::Error::from)
             };
@@ -478,6 +479,7 @@ impl<S: AsyncRead + AsyncWrite + Send + 'static + Unpin> ServerConn<S> {
                     writer,
                     data,
                     hyperactor_config::global::get(config::CODEC_MAX_FRAME_LENGTH),
+                    0,
                 ) {
                     Ok(fw) => {
                         self.write_state = WriteState::Writing(fw, 0);
@@ -556,11 +558,11 @@ impl<S: AsyncRead + AsyncWrite + Send + 'static + Unpin> ServerConn<S> {
 
 /// Used to bookkeep message processing states.
 #[derive(Clone)]
-struct Next {
+pub(super) struct Next {
     // The last received message's seq number + 1.
-    seq: u64,
+    pub(super) seq: u64,
     // The last acked seq number + 1.
-    ack: u64,
+    pub(super) ack: u64,
 }
 
 impl fmt::Display for Next {
@@ -794,6 +796,19 @@ impl fmt::Display for ServerHandle {
 }
 
 impl ServerHandle {
+    /// Create a new server handle.
+    pub(super) fn new(
+        join_handle: JoinHandle<Result<(), ServerError>>,
+        cancel_token: CancellationToken,
+        channel_addr: ChannelAddr,
+    ) -> Self {
+        Self {
+            join_handle,
+            cancel_token,
+            channel_addr,
+        }
+    }
+
     /// Signal the server to stop. This will stop accepting new
     /// incoming connection requests, and drain pending operations
     /// on active connections. After draining is completed, the


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #2846
* #2845
* __->__ #2844
* #2843
* #2842
* #2841

Add support for duplex channels: a single physical connection carries
messages in both directions, each with independent sequence/ack state.

Wire protocol changes:
- Reinterpret 8-byte frame header as [tag:1B][len:7B BE] (was [len:8B BE]).
  Zero wire overhead — same header size, same allocations, same I/O pattern.
  Added 7-byte length limit validation in FrameWrite::new().
- Simplex connections use tag=0 (functionally identical to before).
- Duplex connections use Side::A (0x00) and Side::B (0x01) to identify
  logical channels within a single TCP connection.
- DuplexLinkInit (12 bytes): [magic: "DPX\0"][link_id: 8B u64 BE]

New duplex API (src/channel/net/duplex.rs):
- Server: `duplex::serve::<M1, M2>(addr)` returns DuplexServer with
  `accept()` yielding `(DuplexNetRx<M1>, DuplexNetTx<M2>)`.
- Client: `duplex::dial::<M1, M2>(addr)` returns
  `(DuplexNetTx<M1>, DuplexNetRx<M2>)`.
- Supports TCP and Unix transports.

Design:
- Zero-copy DuplexBuf enum delegates Buf to either Bytes or
  serde_multipart::Frame — no boxing, no type erasure.
- Single select! loop per connection handles both directions, serializing
  writes through one WriteState (no extra task, no mpsc, no mutex).
- Reconnection with replay buffer on client side; MVar-based session
  state handoff on server side.
- `connect_raw()` in net.rs separates transport-level connection from
  protocol-level init, enabling duplex to write its own DuplexLinkInit.
- Internal types (Frame, NetRxResponse, Next, ServerHandle) given
  pub(super) visibility for reuse by the duplex module.

Differential Revision: [D94930353](https://our.internmc.facebook.com/intern/diff/D94930353/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D94930353/)!