### PR TITLE
[hyperactor] unify channel I/O with Mux, TaggedStream, and Completion; add duplex streams

### DIFF
--- a/hyperactor/example/pingpong.rs
+++ b/hyperactor/example/pingpong.rs
@@ -11,10 +11,12 @@
 //! Ping-pong latency benchmark using hyperactor channels.
 //!
 //! Equivalent to the ZMQ-based Python ping-pong benchmark, but uses hyperactor
-//! channels directly. Supports TCP, Unix, and Local transports.
+//! channels directly. Supports TCP, Unix, and Local transports, as well as
+//! duplex mode (single connection, both directions).
 //!
 //! Usage:
 //!   (no args)                        run locally (subprocesses for TCP, in-process otherwise)
+//!   --duplex                         run using duplex channels (in-process)
 //!   --server [--transport tcp]       run as echo server
 //!   --client <ADDR>                  run as client connecting to ADDR (e.g. tcp:[::1]:5555)
 
@@ -36,6 +38,7 @@ use hyperactor::channel::ChannelTransport;
 use hyperactor::channel::Rx;
 use hyperactor::channel::TcpMode;
 use hyperactor::channel::Tx;
+use hyperactor::channel::duplex;
 use serde::Deserialize;
 use serde::Serialize;
 use typeuri::Named;
@@ -83,6 +86,10 @@ struct Cli {
     /// Payload size in bytes.
     #[arg(long, default_value_t = 100)]
     message_size: usize,
+
+    /// Use duplex channels (single connection, both directions).
+    #[arg(long)]
+    duplex: bool,
 
     /// Run a full benchmark suite; write CSV to the given path.
     #[arg(long)]
@@ -268,6 +275,126 @@ async fn run_server_loop(mut rx: ChannelRx<Message>) -> anyhow::Result<()> {
     }
 }
 
+/// Run a duplex benchmark in-process.
+async fn run_local_duplex(
+    transport: ChannelTransport,
+    iterations: usize,
+    message_size: usize,
+) -> anyhow::Result<()> {
+    println!("Running duplex benchmark (in-process, {transport})...");
+
+    let mut server = duplex::serve::<Message, Message>(ChannelAddr::any(transport))?;
+    let server_addr = server.addr().clone();
+
+    // Server task: accept one link, echo back.
+    let server_handle = tokio::spawn(async move {
+        let (mut rx, tx) = server.accept().await.unwrap();
+        while let Ok(msg) = rx.recv().await {
+            tx.post(msg);
+        }
+    });
+
+    let (client_tx, mut client_rx) = duplex::dial::<Message, Message>(server_addr.clone()).await?;
+
+    println!("Client connected to {server_addr} (duplex)");
+
+    let message = Message::Echo(serde_multipart::Part::from(vec![0u8; message_size]));
+    let message_bytes = message.payload_len();
+
+    // Warmup.
+    for _ in 0..10 {
+        client_tx.post(message.clone());
+        client_rx.recv().await?;
+    }
+
+    println!("Payload size: {message_size} bytes");
+    println!("Starting {iterations} ping-pong iterations...");
+
+    let mut latencies = Vec::with_capacity(iterations);
+    let mut total_bytes_sent = 0usize;
+    let mut total_bytes_received = 0usize;
+
+    let total_start = Instant::now();
+
+    for i in 0..iterations {
+        let start = Instant::now();
+        client_tx.post(message.clone());
+        total_bytes_sent += message_bytes;
+
+        let response = client_rx.recv().await?;
+        total_bytes_received += response.payload_len();
+
+        latencies.push(start.elapsed());
+
+        if (i + 1) % 100 == 0 {
+            println!("Completed {}/{iterations} iterations", i + 1);
+        }
+    }
+
+    let total_elapsed = total_start.elapsed();
+
+    let avg_ms = latencies.iter().sum::<Duration>().as_secs_f64() * 1000.0 / latencies.len() as f64;
+    let min_ms = latencies.iter().min().unwrap().as_secs_f64() * 1000.0;
+    let max_ms = latencies.iter().max().unwrap().as_secs_f64() * 1000.0;
+
+    let total_bytes = total_bytes_sent + total_bytes_received;
+    let total_secs = total_elapsed.as_secs_f64();
+    let bw_bps = total_bytes as f64 / total_secs;
+    let bw_mbps = bw_bps * 8.0 / (1024.0 * 1024.0);
+
+    println!();
+    println!("Results:");
+    println!("Average latency: {avg_ms:.3} ms");
+    println!("Min latency: {min_ms:.3} ms");
+    println!("Max latency: {max_ms:.3} ms");
+    println!("Total iterations: {}", latencies.len());
+    println!("Total time: {total_secs:.3} seconds");
+    println!("Bytes sent: {total_bytes_sent} bytes");
+    println!("Bytes received: {total_bytes_received} bytes");
+    println!("Total bytes transferred: {total_bytes} bytes");
+    println!("Bandwidth: {bw_bps:.0} bytes/sec ({bw_mbps:.2} Mbps)");
+
+    server_handle.abort();
+    Ok(())
+}
+
+/// Quiet duplex ping-pong benchmark for suite mode, returning total elapsed time.
+async fn bench_ping_pong_duplex(
+    transport: ChannelTransport,
+    num_iterations: usize,
+    message_size: usize,
+) -> anyhow::Result<Duration> {
+    let mut server = duplex::serve::<Message, Message>(ChannelAddr::any(transport))?;
+    let server_addr = server.addr().clone();
+
+    let server_handle = tokio::spawn(async move {
+        let (mut rx, tx) = server.accept().await.unwrap();
+        while let Ok(msg) = rx.recv().await {
+            tx.post(msg);
+        }
+    });
+
+    let (client_tx, mut client_rx) = duplex::dial::<Message, Message>(server_addr).await?;
+
+    let message = Message::Echo(serde_multipart::Part::from(vec![0u8; message_size]));
+
+    // Warmup.
+    for _ in 0..10 {
+        client_tx.post(message.clone());
+        client_rx.recv().await?;
+    }
+
+    let start = Instant::now();
+    for _ in 0..num_iterations {
+        client_tx.post(message.clone());
+        client_rx.recv().await?;
+    }
+    let elapsed = start.elapsed();
+
+    server_handle.abort();
+    Ok(elapsed)
+}
+
 const SUITE_SIZES: &[usize] = &[100, 1_000, 10_000, 100_000, 1_000_000];
 
 /// Run a single in-process ping-pong benchmark, returning total elapsed time.
@@ -305,12 +432,41 @@ async fn bench_ping_pong(
     Ok(elapsed)
 }
 
+/// Benchmark entry: name, transport, and whether to use duplex.
+struct BenchEntry {
+    name: &'static str,
+    transport: ChannelTransport,
+    use_duplex: bool,
+}
+
 /// Run a benchmark suite across transports and message sizes, writing CSV output.
 async fn run_suite(output: &std::path::Path, iterations: usize) -> anyhow::Result<()> {
-    let transports: Vec<(&str, ChannelTransport)> = vec![
-        ("local", ChannelTransport::Local),
-        ("unix", ChannelTransport::Unix),
-        ("tcp", ChannelTransport::Tcp(TcpMode::Hostname)),
+    let entries = vec![
+        BenchEntry {
+            name: "local",
+            transport: ChannelTransport::Local,
+            use_duplex: false,
+        },
+        BenchEntry {
+            name: "unix",
+            transport: ChannelTransport::Unix,
+            use_duplex: false,
+        },
+        BenchEntry {
+            name: "tcp",
+            transport: ChannelTransport::Tcp(TcpMode::Hostname),
+            use_duplex: false,
+        },
+        BenchEntry {
+            name: "duplex-unix",
+            transport: ChannelTransport::Unix,
+            use_duplex: true,
+        },
+        BenchEntry {
+            name: "duplex-tcp",
+            transport: ChannelTransport::Tcp(TcpMode::Hostname),
+            use_duplex: true,
+        },
     ];
 
     let mut file = std::fs::File::create(output)?;
@@ -320,17 +476,21 @@ async fn run_suite(output: &std::path::Path, iterations: usize) -> anyhow::Resul
     writeln!(file, "transport,{}", headers.join(","))?;
 
     // Table header to stdout.
-    print!("{:<12}", "transport");
+    print!("{:<14}", "transport");
     for size in SUITE_SIZES {
         print!("{:>14}", size);
     }
     println!();
 
-    for (name, transport) in &transports {
-        print!("{:<12}", name);
+    for entry in &entries {
+        print!("{:<14}", entry.name);
         let mut times_ms = Vec::new();
         for &size in SUITE_SIZES {
-            let dur = bench_ping_pong(transport.clone(), iterations, size).await?;
+            let dur = if entry.use_duplex {
+                bench_ping_pong_duplex(entry.transport.clone(), iterations, size).await?
+            } else {
+                bench_ping_pong(entry.transport.clone(), iterations, size).await?
+            };
             let ms = dur.as_secs_f64() * 1000.0;
             times_ms.push(ms);
             print!("{:>12.3}ms", ms);
@@ -338,7 +498,7 @@ async fn run_suite(output: &std::path::Path, iterations: usize) -> anyhow::Resul
         println!();
 
         let values: Vec<String> = times_ms.iter().map(|t| format!("{t:.3}")).collect();
-        writeln!(file, "{name},{}", values.join(","))?;
+        writeln!(file, "{},{}", entry.name, values.join(","))?;
     }
 
     eprintln!("\nResults written to {}", output.display());
@@ -448,6 +608,8 @@ async fn main() -> anyhow::Result<()> {
         run_server(addr).await
     } else if let Some(addr) = args.client {
         run_client(addr, args.iterations, args.message_size).await
+    } else if args.duplex {
+        run_local_duplex(args.transport, args.iterations, args.message_size).await
     } else {
         match &args.transport {
             ChannelTransport::Tcp(_) => {

--- a/hyperactor/src/channel.rs
+++ b/hyperactor/src/channel.rs
@@ -43,6 +43,15 @@ pub use net::try_tls_acceptor;
 pub use net::try_tls_connector;
 pub use net::try_tls_pem_bundle;
 
+/// Duplex channel API: a single connection carries messages in both directions.
+pub mod duplex {
+    pub use super::net::duplex::DuplexRx;
+    pub use super::net::duplex::DuplexServer;
+    pub use super::net::duplex::DuplexTx;
+    pub use super::net::duplex::dial;
+    pub use super::net::duplex::serve;
+}
+
 /// The type of error that can occur on channel operations.
 #[derive(thiserror::Error, Debug)]
 pub enum ChannelError {

--- a/hyperactor/src/channel/net.rs
+++ b/hyperactor/src/channel/net.rs
@@ -74,7 +74,7 @@ use crate::clock::RealClock;
 // the suppression must be at module scope.
 #[allow(unused_assignments)]
 mod client;
-pub(crate) mod duplex;
+pub mod duplex;
 mod framed;
 pub(super) mod session;
 use client::dial;
@@ -738,6 +738,9 @@ pub(crate) mod tcp {
                 .inner
                 .accept()
                 .await
+                .map_err(|err| ServerError::Io(ChannelAddr::Tcp(self.addr), err))?;
+            stream
+                .set_nodelay(true)
                 .map_err(|err| ServerError::Io(ChannelAddr::Tcp(self.addr), err))?;
             Ok((stream, ChannelAddr::Tcp(peer_addr)))
         }

--- a/hyperactor/src/channel/net/client.rs
+++ b/hyperactor/src/channel/net/client.rs
@@ -9,7 +9,6 @@
 //! Simplex client: dial + SimplexConnector implementation.
 
 use async_trait::async_trait;
-use tokio::io::AsyncWriteExt;
 use tokio::io::ReadHalf;
 use tokio::io::WriteHalf;
 use tokio::sync::mpsc;
@@ -18,13 +17,11 @@ use tokio::sync::watch;
 use tokio::time::Instant;
 use tokio_util::sync::CancellationToken;
 
-use super::framed::FrameReader;
 use super::session;
 use super::session::Deliveries;
-use super::session::MuxWriter;
+use super::session::Mux;
 use super::session::SendLoopResult;
 use super::session::SessionConnector;
-use super::session::SimplexFrameStream;
 use crate::RemoteMessage;
 use crate::channel::ChannelAddr;
 use crate::channel::SendError;
@@ -36,8 +33,7 @@ use crate::channel::net::Stream;
 use crate::config;
 
 pub(super) struct SimplexConnection<S: Stream> {
-    reader: SimplexFrameStream<ReadHalf<S>>,
-    writer: MuxWriter<WriteHalf<S>>,
+    mux: Mux<ReadHalf<S>, WriteHalf<S>>,
 }
 
 pub(super) struct SimplexConnector<L: Link>(pub L);
@@ -59,8 +55,7 @@ impl<L: Link + 'static, M: RemoteMessage> SessionConnector<M> for SimplexConnect
         let (r, w) = tokio::io::split(stream);
         let max = hyperactor_config::global::get(config::CODEC_MAX_FRAME_LENGTH);
         Ok(SimplexConnection {
-            reader: SimplexFrameStream::new(FrameReader::new(r, max)),
-            writer: MuxWriter::new(w, max),
+            mux: Mux::new(r, w, max),
         })
     }
 
@@ -71,21 +66,12 @@ impl<L: Link + 'static, M: RemoteMessage> SessionConnector<M> for SimplexConnect
         receiver: &mut mpsc::UnboundedReceiver<(M, oneshot::Sender<SendError<M>>, Instant)>,
         cancel: CancellationToken,
     ) -> SendLoopResult {
-        session::send_loop(
-            &connected.reader,
-            &connected.writer,
-            0,
-            deliveries,
-            receiver,
-            cancel,
-        )
-        .await
+        let stream = connected.mux.stream(0);
+        session::send_loop(&stream, deliveries, receiver, cancel).await
     }
 
     async fn shutdown(connected: Self::Connected) {
-        let inner = connected.writer.into_inner();
-        let mut w = inner.lock().await;
-        let _ = w.shutdown().await;
+        connected.mux.shutdown().await;
     }
 }
 

--- a/hyperactor/src/channel/net/duplex.rs
+++ b/hyperactor/src/channel/net/duplex.rs
@@ -39,20 +39,23 @@ use tokio::io::AsyncWrite;
 use tokio::io::AsyncWriteExt;
 use tokio::sync::mpsc;
 use tokio::sync::oneshot;
+use tokio::sync::watch;
 use tokio::task::JoinSet;
 use tokio::time::Instant;
 use tokio_util::sync::CancellationToken;
 
 use super::LinkId;
 use super::ServerError;
-use super::framed::FrameReader;
 use super::session;
 use super::session::Next;
 use super::session::SessionConnector;
 use crate::RemoteMessage;
 use crate::channel::ChannelAddr;
 use crate::channel::ChannelError;
+use crate::channel::Rx;
 use crate::channel::SendError;
+use crate::channel::Tx;
+use crate::channel::TxStatus;
 use crate::clock::Clock;
 use crate::clock::RealClock;
 use crate::config;
@@ -113,71 +116,82 @@ struct DuplexServerLink<M1: RemoteMessage, M2: RemoteMessage> {
     outbound_rx: MVar<mpsc::UnboundedReceiver<(M2, oneshot::Sender<SendError<M2>>, Instant)>>,
 }
 
-/// Public duplex server that yields `(NetRx<M1>, DuplexNetTx<M2>)` pairs.
-pub(crate) struct DuplexServer<M1: RemoteMessage, M2: RemoteMessage> {
-    accept_rx: mpsc::Receiver<(DuplexNetRx<M1>, DuplexNetTx<M2>)>,
+/// Public duplex server that yields `(DuplexRx<M1>, DuplexTx<M2>)` pairs.
+pub struct DuplexServer<M1: RemoteMessage, M2: RemoteMessage> {
+    accept_rx: mpsc::Receiver<(DuplexRx<M1>, DuplexTx<M2>)>,
     _handle: ServerHandle,
     addr: ChannelAddr,
 }
 
 impl<M1: RemoteMessage, M2: RemoteMessage> DuplexServer<M1, M2> {
-    pub async fn accept(&mut self) -> Result<(DuplexNetRx<M1>, DuplexNetTx<M2>), ChannelError> {
+    /// Accept a new duplex link, returning `(rx, tx)` handles.
+    pub async fn accept(&mut self) -> Result<(DuplexRx<M1>, DuplexTx<M2>), ChannelError> {
         self.accept_rx.recv().await.ok_or(ChannelError::Closed)
     }
 
+    /// The address this server is listening on.
     pub fn addr(&self) -> &ChannelAddr {
         &self.addr
     }
 }
 
 /// Receiver half of a duplex channel.
-pub(crate) struct DuplexNetRx<M: RemoteMessage> {
-    rx: mpsc::Receiver<M>,
-    addr: ChannelAddr,
-}
+pub struct DuplexRx<M: RemoteMessage>(mpsc::Receiver<M>, ChannelAddr);
 
-impl<M: RemoteMessage> DuplexNetRx<M> {
-    pub async fn recv(&mut self) -> Result<M, ChannelError> {
-        self.rx.recv().await.ok_or(ChannelError::Closed)
+#[async_trait]
+impl<M: RemoteMessage> Rx<M> for DuplexRx<M> {
+    async fn recv(&mut self) -> Result<M, ChannelError> {
+        self.0.recv().await.ok_or(ChannelError::Closed)
     }
 
-    #[allow(dead_code)]
-    pub fn addr(&self) -> &ChannelAddr {
-        &self.addr
+    fn addr(&self) -> ChannelAddr {
+        self.1.clone()
     }
 }
 
 /// Sender half of a duplex channel.
-pub(crate) struct DuplexNetTx<M: RemoteMessage> {
+pub struct DuplexTx<M: RemoteMessage> {
     tx: mpsc::UnboundedSender<(M, oneshot::Sender<SendError<M>>, Instant)>,
     addr: ChannelAddr,
+    status: watch::Receiver<TxStatus>,
 }
 
-impl<M: RemoteMessage> DuplexNetTx<M> {
-    pub fn send(&self, message: M) -> Result<(), ChannelError> {
-        let (return_tx, _) = oneshot::channel();
-        self.tx
-            .send((message, return_tx, RealClock.now()))
-            .map_err(|_| ChannelError::Closed)
+#[async_trait]
+impl<M: RemoteMessage> Tx<M> for DuplexTx<M> {
+    fn do_post(&self, message: M, return_channel: Option<oneshot::Sender<SendError<M>>>) {
+        let return_channel = return_channel.unwrap_or_else(|| oneshot::channel().0);
+        if let Err(mpsc::error::SendError((message, return_channel, _))) =
+            self.tx.send((message, return_channel, RealClock.now()))
+        {
+            let _ = return_channel.send(SendError {
+                error: ChannelError::Closed,
+                message,
+                reason: None,
+            });
+        }
     }
 
-    #[allow(dead_code)]
-    pub fn addr(&self) -> &ChannelAddr {
-        &self.addr
+    fn addr(&self) -> ChannelAddr {
+        self.addr.clone()
+    }
+
+    fn status(&self) -> &watch::Receiver<TxStatus> {
+        &self.status
     }
 }
 
-impl<M: RemoteMessage> Clone for DuplexNetTx<M> {
+impl<M: RemoteMessage> Clone for DuplexTx<M> {
     fn clone(&self) -> Self {
         Self {
             tx: self.tx.clone(),
             addr: self.addr.clone(),
+            status: self.status.clone(),
         }
     }
 }
 
 /// Start a duplex server on the given address.
-pub(crate) fn serve<M1: RemoteMessage, M2: RemoteMessage>(
+pub fn serve<M1: RemoteMessage, M2: RemoteMessage>(
     addr: ChannelAddr,
 ) -> Result<DuplexServer<M1, M2>, ServerError> {
     match addr {
@@ -263,7 +277,7 @@ fn serve_with_listener<M1: RemoteMessage, M2: RemoteMessage, L: super::Listener>
 async fn duplex_listen<M1: RemoteMessage, M2: RemoteMessage, L: super::Listener>(
     mut listener: L,
     listener_addr: ChannelAddr,
-    accept_tx: mpsc::Sender<(DuplexNetRx<M1>, DuplexNetTx<M2>)>,
+    accept_tx: mpsc::Sender<(DuplexRx<M1>, DuplexTx<M2>)>,
     cancel_token: CancellationToken,
 ) -> Result<(), ServerError> {
     let child_cancel_token = CancellationToken::new();
@@ -315,13 +329,12 @@ async fn duplex_listen<M1: RemoteMessage, M2: RemoteMessage, L: super::Listener>
                                         e.insert(link.clone());
 
                                         // Send the new channel pair to accept().
-                                        let net_rx = DuplexNetRx {
-                                            rx: inbound_rx,
-                                            addr: addr.clone(),
-                                        };
-                                        let net_tx = DuplexNetTx {
+                                        let (_, status) = watch::channel(TxStatus::Active);
+                                        let net_rx = DuplexRx(inbound_rx, addr.clone());
+                                        let net_tx = DuplexTx {
                                             tx: outbound_tx,
                                             addr: addr.clone(),
+                                            status,
                                         };
                                         let _ = accept_tx.send((net_rx, net_tx)).await;
 
@@ -383,15 +396,14 @@ where
 {
     let (reader, writer) = tokio::io::split(stream);
     let max = hyperactor_config::global::get(config::CODEC_MAX_FRAME_LENGTH);
-    let demux = session::DemuxFrameReader::new(FrameReader::new(reader, max));
-    let mux = session::MuxWriter::new(writer, max);
+    let mux = session::Mux::new(reader, writer, max);
+    let stream_a = mux.stream(Side::A as u8);
+    let stream_b = mux.stream(Side::B as u8);
 
     let (mut inbound_next, outbound_next) = link.next.take().await;
     let mut outbound_rx = link.outbound_rx.take().await;
 
     let ct = cancel_token.child_token();
-    let side_a = demux.side(Side::A as u8);
-    let side_b = demux.side(Side::B as u8);
 
     let session_id = link.id.0;
     let log_id = format!("duplex server {:016x}", session_id);
@@ -404,13 +416,11 @@ where
     // Run both directions concurrently. When either finishes, the other
     // is dropped (the physical stream is broken once one direction fails).
     let result: Result<(), anyhow::Error> = tokio::select! {
-        r = session::recv_loop::<M1, _>(
-            &side_a, &mux, Side::A as u8,
-            &link.inbound_tx, &mut inbound_next, ct.clone(),
+        r = session::recv_loop::<M1, _, _>(
+            &stream_a, &link.inbound_tx, &mut inbound_next, ct.clone(),
         ) => r.map(|_| ()),
         r = session::send_loop(
-            &side_b, &mux, Side::B as u8,
-            &mut deliveries, &mut outbound_rx, ct.clone(),
+            &stream_b, &mut deliveries, &mut outbound_rx, ct.clone(),
         ) => match r {
             session::SendLoopResult::Error(e) => Err(e),
             _ => Ok(()),
@@ -431,8 +441,10 @@ where
 }
 
 struct DuplexConnection {
-    reader: session::DemuxFrameReader<tokio::io::ReadHalf<Box<dyn super::Stream>>>,
-    writer: session::MuxWriter<tokio::io::WriteHalf<Box<dyn super::Stream>>>,
+    mux: session::Mux<
+        tokio::io::ReadHalf<Box<dyn super::Stream>>,
+        tokio::io::WriteHalf<Box<dyn super::Stream>>,
+    >,
 }
 
 struct DuplexConnector<M2: RemoteMessage> {
@@ -468,8 +480,7 @@ impl<M1: RemoteMessage, M2: RemoteMessage> SessionConnector<M1> for DuplexConnec
         let (r, w) = tokio::io::split(s);
         let max = hyperactor_config::global::get(config::CODEC_MAX_FRAME_LENGTH);
         Ok(DuplexConnection {
-            reader: session::DemuxFrameReader::new(FrameReader::new(r, max)),
-            writer: session::MuxWriter::new(w, max),
+            mux: session::Mux::new(r, w, max),
         })
     }
 
@@ -480,18 +491,16 @@ impl<M1: RemoteMessage, M2: RemoteMessage> SessionConnector<M1> for DuplexConnec
         receiver: &mut mpsc::UnboundedReceiver<(M1, oneshot::Sender<SendError<M1>>, Instant)>,
         cancel: CancellationToken,
     ) -> session::SendLoopResult {
-        let side_a = connected.reader.side(Side::A as u8);
-        let side_b = connected.reader.side(Side::B as u8);
+        let stream_a = connected.mux.stream(Side::A as u8);
+        let stream_b = connected.mux.stream(Side::B as u8);
         tokio::select! {
             r = session::send_loop(
-                &side_a, &connected.writer, Side::A as u8,
-                deliveries, receiver, cancel.clone(),
+                &stream_a, deliveries, receiver, cancel.clone(),
             ) => r,
-            r = session::recv_loop::<M2, _>(
-                &side_b, &connected.writer, Side::B as u8,
-                &self.inbound_tx, &mut self.inbound_next, cancel,
+            r = session::recv_loop::<M2, _, _>(
+                &stream_b, &self.inbound_tx, &mut self.inbound_next, cancel,
             ) => match r {
-                Ok(outcome) => match outcome {
+                Ok(status) => match status {
                     session::RecvResult::Eof => session::SendLoopResult::Eof,
                     session::RecvResult::Cancelled => session::SendLoopResult::Cancelled,
                     session::RecvResult::SequenceError(e) => session::SendLoopResult::Rejected(e),
@@ -502,16 +511,14 @@ impl<M1: RemoteMessage, M2: RemoteMessage> SessionConnector<M1> for DuplexConnec
     }
 
     async fn shutdown(connected: DuplexConnection) {
-        let inner = connected.writer.into_inner();
-        let mut w = inner.lock().await;
-        let _ = w.shutdown().await;
+        connected.mux.shutdown().await;
     }
 }
 
 /// Connect to a duplex server, returning tx and rx handles.
-pub(crate) async fn dial<M1: RemoteMessage, M2: RemoteMessage>(
+pub async fn dial<M1: RemoteMessage, M2: RemoteMessage>(
     addr: ChannelAddr,
-) -> Result<(DuplexNetTx<M1>, DuplexNetRx<M2>), super::ClientError> {
+) -> Result<(DuplexTx<M1>, DuplexRx<M2>), super::ClientError> {
     let link_id = LinkId::random();
 
     let (outbound_tx, outbound_rx) =
@@ -529,15 +536,14 @@ pub(crate) async fn dial<M1: RemoteMessage, M2: RemoteMessage>(
         session::client_run(connector, outbound_rx, None).await;
     });
 
+    let (_, status) = watch::channel(TxStatus::Active);
     Ok((
-        DuplexNetTx {
+        DuplexTx {
             tx: outbound_tx,
             addr: addr.clone(),
+            status,
         },
-        DuplexNetRx {
-            rx: inbound_rx,
-            addr,
-        },
+        DuplexRx(inbound_rx, addr),
     ))
 }
 
@@ -546,6 +552,7 @@ mod tests {
     use timed_test::async_timed_test;
 
     use super::*;
+    use crate::channel::ChannelTransport;
 
     #[async_timed_test(timeout_secs = 30)]
     // TODO: OSS: called `Result::unwrap()` on an `Err` value: Listen(Tcp([::1]:0), Os { code: 99, kind: AddrNotAvailable, message: "Cannot assign requested address" })
@@ -562,21 +569,21 @@ mod tests {
         let (mut server_rx, server_tx) = server.accept().await.unwrap();
 
         // Client sends to server.
-        client_tx.send(42).unwrap();
+        client_tx.post(42);
         let received = server_rx.recv().await.unwrap();
         assert_eq!(received, 42);
 
         // Server sends to client.
-        server_tx.send("hello".to_string()).unwrap();
+        server_tx.post("hello".to_string());
         let received = client_rx.recv().await.unwrap();
         assert_eq!(received, "hello");
 
         // Multiple messages both ways.
         for i in 0..10u64 {
-            client_tx.send(i).unwrap();
+            client_tx.post(i);
             assert_eq!(server_rx.recv().await.unwrap(), i);
 
-            server_tx.send(format!("msg-{}", i)).unwrap();
+            server_tx.post(format!("msg-{}", i));
             assert_eq!(client_rx.recv().await.unwrap(), format!("msg-{}", i));
         }
     }
@@ -595,15 +602,67 @@ mod tests {
         let (mut srx2, stx2) = server.accept().await.unwrap();
 
         // Send on link 1.
-        tx1.send(100).unwrap();
+        tx1.post(100);
         assert_eq!(srx1.recv().await.unwrap(), 100);
-        stx1.send(200).unwrap();
+        stx1.post(200);
         assert_eq!(rx1.recv().await.unwrap(), 200);
 
         // Send on link 2.
-        tx2.send(300).unwrap();
+        tx2.post(300);
         assert_eq!(srx2.recv().await.unwrap(), 300);
-        stx2.send(400).unwrap();
+        stx2.post(400);
         assert_eq!(rx2.recv().await.unwrap(), 400);
+    }
+
+    /// Ping-pong helper: server echoes back each message it receives.
+    /// Returns elapsed time for `iterations` round-trips.
+    async fn duplex_ping_pong(
+        addr: ChannelAddr,
+        iterations: usize,
+    ) -> anyhow::Result<std::time::Duration> {
+        let mut server = serve::<u64, u64>(addr)?;
+        let server_addr = server.addr().clone();
+
+        let server_handle = tokio::spawn(async move {
+            let (mut rx, tx) = server.accept().await.unwrap();
+            while let Ok(msg) = rx.recv().await {
+                tx.post(msg);
+            }
+        });
+
+        let (client_tx, mut client_rx) = dial::<u64, u64>(server_addr).await?;
+
+        // Warmup.
+        for i in 0..10u64 {
+            client_tx.post(i);
+            assert_eq!(client_rx.recv().await?, i);
+        }
+
+        let start = std::time::Instant::now();
+        for i in 0..iterations as u64 {
+            client_tx.post(i);
+            assert_eq!(client_rx.recv().await?, i);
+        }
+        let elapsed = start.elapsed();
+
+        server_handle.abort();
+        Ok(elapsed)
+    }
+
+    #[async_timed_test(timeout_secs = 30)]
+    #[cfg_attr(not(fbcode_build), ignore)]
+    async fn test_duplex_ping_pong_tcp() {
+        let elapsed = duplex_ping_pong(ChannelAddr::Tcp("[::1]:0".parse().unwrap()), 100)
+            .await
+            .unwrap();
+        println!("TCP duplex: 100 round-trips in {elapsed:?}");
+    }
+
+    #[async_timed_test(timeout_secs = 30)]
+    async fn test_duplex_ping_pong_unix() {
+        let elapsed = duplex_ping_pong(ChannelAddr::any(ChannelTransport::Unix), 100)
+            .await
+            .unwrap();
+        println!("Unix duplex: 100 round-trips in {elapsed:?}");
     }
 }

--- a/hyperactor/src/channel/net/server.rs
+++ b/hyperactor/src/channel/net/server.rs
@@ -13,11 +13,9 @@ use std::pin::Pin;
 use std::sync::Arc;
 use std::task::Poll;
 
-use bytes::Bytes;
 use dashmap::DashMap;
 use tokio::io::AsyncRead;
 use tokio::io::AsyncWrite;
-use tokio::io::AsyncWriteExt as _;
 use tokio::sync::mpsc;
 use tokio::task::JoinError;
 use tokio::task::JoinHandle;
@@ -28,6 +26,7 @@ use tokio_util::sync::CancellationToken;
 use super::read_link_init;
 use super::serialize_response;
 use super::session;
+use super::session::Mux;
 use super::session::Next;
 use crate::RemoteMessage;
 use crate::channel::ChannelAddr;
@@ -35,7 +34,6 @@ use crate::channel::ChannelTransport;
 use crate::channel::net::NetRx;
 use crate::channel::net::NetRxResponse;
 use crate::channel::net::ServerError;
-use crate::channel::net::framed::FrameReader;
 use crate::channel::net::meta;
 use crate::channel::net::tls;
 use crate::config;
@@ -90,18 +88,10 @@ where
 
     let (reader, writer) = tokio::io::split(stream);
     let max = hyperactor_config::global::get(config::CODEC_MAX_FRAME_LENGTH);
-    let frame_stream = session::SimplexFrameStream::new(FrameReader::new(reader, max));
-    let mux_writer = session::MuxWriter::new(writer, max);
+    let mux = Mux::new(reader, writer, max);
+    let stream = mux.stream(0);
 
-    let result = session::recv_loop::<M, _>(
-        &frame_stream,
-        &mux_writer,
-        0, // simplex tag
-        &tx,
-        &mut next,
-        cancel_token,
-    )
-    .await;
+    let result = session::recv_loop::<M, _, _>(&stream, &tx, &mut next, cancel_token).await;
 
     tracing::info!(
         source = %source,
@@ -117,13 +107,12 @@ where
     );
 
     // Post-loop cleanup: flush final ack, send reject/closed, shutdown.
-    let mut cleanup_state: session::MuxWriteState<_, Bytes, ()> = session::MuxWriteState::Idle;
 
     // Flush remaining ack if behind.
     if next.ack < next.seq {
         if let Ok(ack) = serialize_response(NetRxResponse::Ack(next.seq - 1)) {
-            cleanup_state.begin_write(&mux_writer, ack, 0, ());
-            match cleanup_state.send().await {
+            let mut completion = stream.write(ack);
+            match completion.drive().await {
                 Ok(()) => {
                     next.ack = next.seq;
                 }
@@ -150,27 +139,20 @@ where
     };
 
     if let Some(rsp) = terminal_response {
-        if cleanup_state.is_idle() {
-            if let Ok(data) = serialize_response(rsp) {
-                cleanup_state.begin_write(&mux_writer, data, 0, ());
-                let _ = cleanup_state.send().await;
-            }
+        if let Ok(data) = serialize_response(rsp) {
+            let mut completion = stream.write(data);
+            let _ = completion.drive().await;
         }
     }
 
     // Shutdown the underlying writer.
-    if let Ok(inner) = Arc::try_unwrap(mux_writer.into_inner()) {
-        let mut w = inner.into_inner();
-        let _ = w.shutdown().await;
-    }
+    drop(stream);
+    mux.shutdown().await;
 
     link.next.put(next).await;
 
-    // CLAUDE: Ok(result?) instead
-    match result {
-        Ok(_) => Ok(()),
-        Err(e) => Err(e),
-    }
+    result?;
+    Ok(())
 }
 
 /// Main listen loop. Each accepted connection spawns a task that looks up (or

--- a/hyperactor/src/channel/net/session.rs
+++ b/hyperactor/src/channel/net/session.rs
@@ -31,6 +31,7 @@ use bytes::Buf;
 use bytes::Bytes;
 use tokio::io::AsyncRead;
 use tokio::io::AsyncWrite;
+use tokio::io::AsyncWriteExt;
 use tokio::sync::OwnedMutexGuard;
 use tokio::sync::mpsc;
 use tokio::sync::oneshot;
@@ -58,51 +59,20 @@ use crate::clock::RealClock;
 use crate::config;
 use crate::metrics;
 
-/// Read side abstraction over framed transport. Simplex wraps a
-/// `FrameReader` directly; duplex wraps a per-side view of a
-/// `DemuxFrameReader`.
-#[async_trait]
-pub(super) trait FrameStream: Send + Sync {
-    /// Read the next frame body. Returns `None` on EOF.
-    async fn next(&self) -> io::Result<Option<Bytes>>;
-}
-
-/// Simplex `FrameStream`: wraps a `FrameReader`, ignoring the tag byte.
-/// Uses a `Mutex` because `FrameStream::next` takes `&self` (required
-/// by the shared duplex trait), so interior mutability is needed even
-/// though simplex access is uncontended.
-pub(super) struct SimplexFrameStream<R> {
-    reader: tokio::sync::Mutex<FrameReader<R>>,
-}
-
-impl<R> SimplexFrameStream<R> {
-    pub fn new(reader: FrameReader<R>) -> Self {
-        Self {
-            reader: tokio::sync::Mutex::new(reader),
-        }
-    }
-}
-
-#[async_trait]
-impl<R: AsyncRead + Unpin + Send> FrameStream for SimplexFrameStream<R> {
-    async fn next(&self) -> io::Result<Option<Bytes>> {
-        self.reader
-            .lock()
-            .await
-            .next()
-            .await
-            .map(|opt| opt.map(|(_tag, bytes)| bytes))
-    }
-}
+/// Per-tag buffer array. Each tag value (0..255) gets its own slot.
+const NUM_TAGS: usize = 256;
 
 struct DemuxState<R> {
     reader: FrameReader<R>,
-    buffered: Option<(u8, Bytes)>,
+    /// One buffer slot per tag value. A reader for tag `t` checks
+    /// `buffered[t]`; if populated, it takes the frame without
+    /// touching the underlying reader.
+    buffered: Box<[Option<Bytes>; NUM_TAGS]>,
     eof: bool,
 }
 
-/// Demultiplexes a single `FrameReader` into per-side views using
-/// the tag byte. Buffers at most one frame for the other side.
+/// Demultiplexes a single `FrameReader` into per-tag views.
+/// Buffers at most one frame per tag value.
 pub(super) struct DemuxFrameReader<R> {
     inner: tokio::sync::Mutex<DemuxState<R>>,
     notify: tokio::sync::Notify,
@@ -110,19 +80,16 @@ pub(super) struct DemuxFrameReader<R> {
 
 impl<R: AsyncRead + Unpin + Send> DemuxFrameReader<R> {
     pub fn new(reader: FrameReader<R>) -> Self {
+        // Use Box to keep the large array off the stack.
+        const NONE: Option<Bytes> = None;
         Self {
             inner: tokio::sync::Mutex::new(DemuxState {
                 reader,
-                buffered: None,
+                buffered: Box::new([NONE; NUM_TAGS]),
                 eof: false,
             }),
             notify: tokio::sync::Notify::new(),
         }
-    }
-
-    /// Create a view that reads only frames with the given tag.
-    pub fn side(&self, tag: u8) -> SideReader<'_, R> {
-        SideReader { demux: self, tag }
     }
 
     async fn next_tagged(&self, tag: u8) -> io::Result<Option<Bytes>> {
@@ -132,46 +99,30 @@ impl<R: AsyncRead + Unpin + Send> DemuxFrameReader<R> {
                 if state.eof {
                     return Ok(None);
                 }
-                if let Some((t, _)) = &state.buffered {
-                    if *t == tag {
-                        let (_, bytes) = state.buffered.take().unwrap();
+                // Check if our tag already has a buffered frame.
+                if let Some(bytes) = state.buffered[tag as usize].take() {
+                    drop(state);
+                    self.notify.notify_waiters();
+                    return Ok(Some(bytes));
+                }
+                // No buffered frame for our tag — read from the underlying reader.
+                match state.reader.next().await? {
+                    Some((t, bytes)) if t == tag => return Ok(Some(bytes)),
+                    Some((t, bytes)) => {
+                        state.buffered[t as usize] = Some(bytes);
                         drop(state);
                         self.notify.notify_waiters();
-                        return Ok(Some(bytes));
                     }
-                    // Buffer has a frame for the other side; drop lock and wait.
-                } else {
-                    match state.reader.next().await? {
-                        Some((t, bytes)) if t == tag => return Ok(Some(bytes)),
-                        Some((t, bytes)) => {
-                            state.buffered = Some((t, bytes));
-                            drop(state);
-                            self.notify.notify_waiters();
-                        }
-                        None => {
-                            state.eof = true;
-                            drop(state);
-                            self.notify.notify_waiters();
-                            return Ok(None);
-                        }
+                    None => {
+                        state.eof = true;
+                        drop(state);
+                        self.notify.notify_waiters();
+                        return Ok(None);
                     }
                 }
             }
             self.notify.notified().await;
         }
-    }
-}
-
-/// Per-side view of a [`DemuxFrameReader`].
-pub(super) struct SideReader<'a, R> {
-    demux: &'a DemuxFrameReader<R>,
-    tag: u8,
-}
-
-#[async_trait]
-impl<R: AsyncRead + Unpin + Send> FrameStream for SideReader<'_, R> {
-    async fn next(&self) -> io::Result<Option<Bytes>> {
-        self.demux.next_tagged(self.tag).await
     }
 }
 
@@ -215,110 +166,165 @@ impl<W: AsyncWrite + Unpin> AsyncWrite for OwnedWriter<W> {
     }
 }
 
-/// Shared writer. For simplex the mutex is uncontended; for duplex
-/// two protocol loops share the same `MuxWriter`.
-pub(super) struct MuxWriter<W> {
-    inner: Arc<tokio::sync::Mutex<W>>,
+/// Handle for a single in-flight frame write.
+///
+/// Created by [`TaggedStream::write`] (sync, no I/O). Must be driven
+/// via [`drive`](Completion::drive) until it returns `Ok(())`.
+///
+/// Cancel safety: `drive()` is cancel-safe at every await point.
+/// Dropping a `Completion` before it completes releases the lock but
+/// corrupts the stream (the connection should be torn down).
+pub(super) enum Completion<W: AsyncWrite + Unpin + Send, B: Buf> {
+    Pending {
+        writer: Arc<tokio::sync::Mutex<W>>,
+        body: B,
+        tag: u8,
+        max_len: usize,
+    },
+    Acquiring {
+        writer: Arc<tokio::sync::Mutex<W>>,
+        body: B,
+        tag: u8,
+        max_len: usize,
+    },
+    Writing(FrameWrite<OwnedWriter<W>, B>),
+    Broken,
+}
+
+impl<W: AsyncWrite + Unpin + Send, B: Buf> Completion<W, B> {
+    /// Drive the write to completion. Cancel-safe at every await point.
+    pub async fn drive(&mut self) -> io::Result<()> {
+        loop {
+            match self {
+                Self::Pending { writer: _, .. } => {
+                    // Transition to Acquiring (same state, just marks intent).
+                    let Self::Pending {
+                        writer,
+                        body,
+                        tag,
+                        max_len,
+                    } = std::mem::replace(self, Self::Broken)
+                    else {
+                        unreachable!()
+                    };
+                    *self = Self::Acquiring {
+                        writer,
+                        body,
+                        tag,
+                        max_len,
+                    };
+                }
+                Self::Acquiring { writer, .. } => {
+                    let writer_clone = Arc::clone(writer);
+                    let guard = writer_clone.lock_owned().await;
+                    let Self::Acquiring {
+                        body, tag, max_len, ..
+                    } = std::mem::replace(self, Self::Broken)
+                    else {
+                        unreachable!()
+                    };
+                    match FrameWrite::new(OwnedWriter(guard), body, max_len, tag) {
+                        Ok(fw) => *self = Self::Writing(fw),
+                        Err((_owned, e)) => {
+                            *self = Self::Broken;
+                            return Err(e);
+                        }
+                    }
+                }
+                Self::Writing(fw) => {
+                    fw.send().await?;
+                    let Self::Writing(fw) = std::mem::replace(self, Self::Broken) else {
+                        unreachable!()
+                    };
+                    let _ = fw.complete(); // drops OwnedWriter → releases lock
+                    return Ok(());
+                }
+                Self::Broken => panic!("Completion: illegal state"),
+            }
+        }
+    }
+}
+
+/// Bidirectional frame channel for a single mux tag.
+///
+/// Reads are demuxed: only frames whose tag matches are returned.
+/// Writes are muxed: the tag byte is written into the frame header.
+///
+/// Multiple `TaggedStream`s can coexist (sharing the underlying
+/// reader and writer) as long as they use different tags.
+pub(super) struct TaggedStream<R, W> {
+    demux: Arc<DemuxFrameReader<R>>,
+    writer: Arc<tokio::sync::Mutex<W>>,
+    tag: u8,
     max_frame_len: usize,
 }
 
-impl<W> MuxWriter<W> {
-    pub fn new(writer: W, max_frame_len: usize) -> Self {
-        Self {
-            inner: Arc::new(tokio::sync::Mutex::new(writer)),
-            max_frame_len,
+impl<R: AsyncRead + Unpin + Send, W: AsyncWrite + Unpin + Send> TaggedStream<R, W> {
+    /// Read the next frame body for this tag. Cancel-safe.
+    pub async fn next(&self) -> io::Result<Option<Bytes>> {
+        self.demux.next_tagged(self.tag).await
+    }
+
+    /// Begin a frame write. Sync (no I/O). Returns a [`Completion`]
+    /// that must be driven via [`Completion::drive`].
+    pub fn write<B: Buf>(&self, body: B) -> Completion<W, B> {
+        Completion::Pending {
+            writer: Arc::clone(&self.writer),
+            body,
+            tag: self.tag,
+            max_len: self.max_frame_len,
         }
     }
 
-    /// Consume the `MuxWriter`, returning the inner `Arc<Mutex<W>>`.
-    /// Used during connection cleanup to recover the writer for shutdown.
-    pub fn into_inner(self) -> Arc<tokio::sync::Mutex<W>> {
-        self.inner
-    }
-
-    /// Maximum frame body length accepted by this writer.
+    /// Maximum frame body length accepted by this stream's writer.
     pub fn max_frame_len(&self) -> usize {
         self.max_frame_len
     }
 }
 
-/// Cancel-safe write state machine for shared writers.
+/// Tagged frame multiplexer over a split connection.
 ///
-/// Transitions: Idle → Acquiring → Writing → Idle.
+/// A `Mux` wraps a `DemuxFrameReader` (read side) and a shared
+/// writer (write side). Call [`stream`](Mux::stream) to get a
+/// [`TaggedStream`] for a specific tag byte.
 ///
-/// Cancel safety:
-/// - **Idle**: `pending()` never completes.
-/// - **Acquiring**: if cancelled during `lock_owned().await`, `self`
-///   is still `Acquiring`. Retries on next `send()`.
-/// - **Writing**: `FrameWrite::send` preserves progress;
-///   `OwnedWriter` keeps the mutex held.
-pub(super) enum MuxWriteState<W: AsyncWrite + Unpin + Send, B: Buf, T> {
-    Idle,
-    Acquiring {
-        mux: Arc<tokio::sync::Mutex<W>>,
-        body: B,
-        tag: u8,
-        max: usize,
-        value: T,
-    },
-    Writing(FrameWrite<OwnedWriter<W>, B>, T),
-    Broken,
+/// For simplex, use `mux.stream(0)`.
+/// For duplex, use `mux.stream(Side::A)` and `mux.stream(Side::B)`.
+pub(super) struct Mux<R, W> {
+    demux: Arc<DemuxFrameReader<R>>,
+    writer: Arc<tokio::sync::Mutex<W>>,
+    max_frame_len: usize,
 }
 
-impl<W: AsyncWrite + Unpin + Send, B: Buf, T> MuxWriteState<W, B, T> {
-    pub fn is_idle(&self) -> bool {
-        matches!(self, Self::Idle)
-    }
-
-    /// Begin a write. Transitions Idle → Acquiring (no I/O).
-    pub fn begin_write(&mut self, mux: &MuxWriter<W>, body: B, tag: u8, value: T) {
-        debug_assert!(self.is_idle());
-        *self = Self::Acquiring {
-            mux: Arc::clone(&mux.inner),
-            body,
-            tag,
-            max: mux.max_frame_len,
-            value,
-        };
-    }
-
-    /// Drive the state machine to completion. Cancel-safe at every await.
-    pub async fn send(&mut self) -> io::Result<T> {
-        loop {
-            match self {
-                Self::Idle => return std::future::pending().await,
-                Self::Acquiring { mux, .. } => {
-                    let mux_clone = Arc::clone(mux);
-                    let guard = mux_clone.lock_owned().await;
-                    let Self::Acquiring {
-                        body,
-                        tag,
-                        max,
-                        value,
-                        ..
-                    } = std::mem::replace(self, Self::Broken)
-                    else {
-                        unreachable!()
-                    };
-                    match FrameWrite::new(OwnedWriter(guard), body, max, tag) {
-                        Ok(fw) => *self = Self::Writing(fw, value),
-                        Err((_owned, e)) => {
-                            *self = Self::Idle;
-                            return Err(e);
-                        }
-                    }
-                }
-                Self::Writing(fw, _) => {
-                    fw.send().await?;
-                    let Self::Writing(fw, value) = std::mem::replace(self, Self::Idle) else {
-                        unreachable!()
-                    };
-                    let _ = fw.complete(); // drops OwnedWriter → releases lock
-                    return Ok(value);
-                }
-                Self::Broken => panic!("MuxWriteState: illegal state"),
-            }
+impl<R: AsyncRead + Unpin + Send, W> Mux<R, W> {
+    /// Create a new Mux from a reader and writer half.
+    pub fn new(reader: R, writer: W, max_frame_len: usize) -> Self {
+        Self {
+            demux: Arc::new(DemuxFrameReader::new(FrameReader::new(
+                reader,
+                max_frame_len,
+            ))),
+            writer: Arc::new(tokio::sync::Mutex::new(writer)),
+            max_frame_len,
         }
+    }
+
+    /// Create a [`TaggedStream`] for the given tag byte.
+    pub fn stream(&self, tag: u8) -> TaggedStream<R, W> {
+        TaggedStream {
+            demux: Arc::clone(&self.demux),
+            writer: Arc::clone(&self.writer),
+            tag,
+            max_frame_len: self.max_frame_len,
+        }
+    }
+}
+
+impl<R, W: AsyncWrite + Unpin> Mux<R, W> {
+    /// Shutdown the underlying writer. Best-effort.
+    pub async fn shutdown(self) {
+        let mut w = self.writer.lock().await;
+        let _ = w.shutdown().await;
     }
 }
 
@@ -726,10 +732,12 @@ pub(super) enum RecvResult {
 ///
 /// This is the shared implementation used by both simplex (`server.rs`)
 /// and duplex (`duplex.rs`).
-pub(super) async fn recv_loop<M: RemoteMessage, W: AsyncWrite + Unpin + Send>(
-    reader: &impl FrameStream,
-    writer: &MuxWriter<W>,
-    ack_tag: u8,
+pub(super) async fn recv_loop<
+    M: RemoteMessage,
+    R: AsyncRead + Unpin + Send,
+    W: AsyncWrite + Unpin + Send,
+>(
+    stream: &TaggedStream<R, W>,
     deliver_tx: &mpsc::Sender<M>,
     next: &mut Next,
     cancel: CancellationToken,
@@ -739,25 +747,27 @@ pub(super) async fn recv_loop<M: RemoteMessage, W: AsyncWrite + Unpin + Send>(
         hyperactor_config::global::get(config::MESSAGE_ACK_EVERY_N_MESSAGES);
 
     let mut last_ack_time = RealClock.now();
-    let mut write_state: MuxWriteState<W, Bytes, u64> = MuxWriteState::Idle;
+    let mut pending_ack: Option<(Completion<W, Bytes>, u64)> = None;
 
     loop {
         let ack_behind = next.ack + ack_msg_interval <= next.seq
             || (next.ack < next.seq && last_ack_time.elapsed() > ack_time_interval);
 
         // Begin ack write if idle and behind.
-        if write_state.is_idle() && ack_behind {
+        if pending_ack.is_none() && ack_behind {
             let ack = serialize_response(NetRxResponse::Ack(next.seq - 1))?;
-            write_state.begin_write(writer, ack, ack_tag, next.seq);
+            pending_ack = Some((stream.write(ack), next.seq));
         }
 
         tokio::select! {
             biased;
 
             // Drive ack write to completion.
-            result = write_state.send() => {
+            result = async { pending_ack.as_mut().unwrap().0.drive().await },
+                if pending_ack.is_some() => {
                 match result {
-                    Ok(acked_seq) => {
+                    Ok(()) => {
+                        let acked_seq = pending_ack.take().unwrap().1;
                         last_ack_time = RealClock.now();
                         next.ack = acked_seq;
                     }
@@ -773,7 +783,7 @@ pub(super) async fn recv_loop<M: RemoteMessage, W: AsyncWrite + Unpin + Send>(
                 return Ok(RecvResult::Cancelled);
             }
 
-            bytes_result = reader.next() => {
+            bytes_result = stream.next() => {
                 let bytes = match bytes_result {
                     Ok(Some(bytes)) => bytes,
                     Ok(None) => return Ok(RecvResult::Eof),
@@ -841,30 +851,29 @@ impl fmt::Display for Next {
 }
 
 /// Send protocol loop: accept messages from the application,
-/// serialize, write via `MuxWriteState`, read ack responses, and
+/// serialize, write via [`Completion`], read ack responses, and
 /// manage the outbox/unacked buffers.
 ///
 /// This is the shared implementation used by both simplex (`client.rs`)
 /// and duplex (`duplex.rs`).
-pub(super) async fn send_loop<M, W>(
-    reader: &impl FrameStream,
-    writer: &MuxWriter<W>,
-    msg_tag: u8,
+pub(super) async fn send_loop<M, R, W>(
+    stream: &TaggedStream<R, W>,
     deliveries: &mut Deliveries<M>,
     receiver: &mut mpsc::UnboundedReceiver<(M, oneshot::Sender<SendError<M>>, Instant)>,
     cancel: CancellationToken,
 ) -> SendLoopResult
 where
     M: RemoteMessage,
+    R: AsyncRead + Unpin + Send,
     W: AsyncWrite + Unpin + Send,
 {
-    let mut write_state: MuxWriteState<W, serde_multipart::Frame, ()> = MuxWriteState::Idle;
+    let mut pending: Option<Completion<W, serde_multipart::Frame>> = None;
 
     loop {
         // Begin write if idle and outbox has messages.
-        if write_state.is_idle() && !deliveries.outbox.is_empty() {
+        if pending.is_none() && !deliveries.outbox.is_empty() {
             let len = deliveries.outbox.front_size().expect("not empty");
-            let max = writer.max_frame_len();
+            let max = stream.max_frame_len();
             if len > max {
                 let reason = format!(
                     "rejecting oversize frame: len={} > max={}. \
@@ -879,14 +888,14 @@ where
                 return SendLoopResult::OversizedFrame(reason);
             }
             let message = deliveries.outbox.front_message().expect("not empty");
-            write_state.begin_write(writer, message.framed(), msg_tag, ());
+            pending = Some(stream.write(message.framed()));
         }
 
         tokio::select! {
             biased;
 
             // Read acks/responses from the peer.
-            ack_result = reader.next() => {
+            ack_result = stream.next() => {
                 match ack_result {
                     Ok(Some(buffer)) => {
                         let response = match deserialize_response(buffer) {
@@ -921,9 +930,11 @@ where
             }
 
             // Drive frame write to completion.
-            send_result = write_state.send() => {
+            send_result = async { pending.as_mut().unwrap().drive().await },
+                if pending.is_some() => {
                 match send_result {
                     Ok(()) => {
+                        pending = None;
                         let mut message = deliveries.outbox.pop_front()
                             .expect("outbox should not be empty");
                         message.sent_at = Some(RealClock.now());


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #2846
* #2845
* #2844
* #2843
* #2842
* #2841

Introduce `Mux`, `TaggedStream`, and `Completion` abstractions in
session.rs that unify simplex and duplex channel I/O into a single
API surface. Make duplex channels implement the standard `Tx`/`Rx`
traits so they are interchangeable with simplex channels.

New abstractions (session.rs):
- `Mux<R, W>`: wraps a DemuxFrameReader + shared writer. Call
  `mux.stream(tag)` to get a TaggedStream for a specific tag byte.
  Simplex uses `mux.stream(0)`, duplex uses `mux.stream(Side::A/B)`.
- `TaggedStream<R, W>`: bidirectional frame channel for a single mux
  tag. `next()` reads demuxed frames; `write(body)` returns a
  `Completion` handle.
- `Completion<W, B>`: cancel-safe frame write handle with states
  Pending → Acquiring (lock) → Writing (FrameWrite) → done. Replaces
  `MuxWriteState` with a simpler `Option<Completion>` pattern.

DemuxFrameReader generalized: buffer changed from a single
`Option<(u8, Bytes)>` to `Box<[Option<Bytes>; 256]>` (one slot per
tag), supporting arbitrary numbers of concurrent logical channels.

Duplex types implement Tx/Rx:
- `DuplexNetTx`/`DuplexNetRx` renamed to `DuplexTx`/`DuplexRx`.
- `DuplexTx` implements `Tx<M>` (do_post, addr, status) with a
  `watch::Receiver<TxStatus>` field.
- `DuplexRx` implements `Rx<M>` (recv, addr), changed to tuple struct.
- Tests updated: `.send()` → `.post()`.

Simplified callers:
- `send_loop()` / `recv_loop()` now take `&TaggedStream` instead of
  separate `&impl FrameStream` + `&MuxWriter` + tag.
- `SimplexConnection` holds a single `Mux` instead of separate
  reader/writer. `SimplexFrameStream` removed.
- Server cleanup uses `stream.write()` + `completion.drive()` instead
  of raw MuxWriteState. Addressed CLAUDE comment: `result?; Ok(())`.

Differential Revision: [D94930354](https://our.internmc.facebook.com/intern/diff/D94930354/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D94930354/)!