### PR TITLE
Rename HostMeshAgent to HostAgent

### DIFF
--- a/docs/source/books/hyperactor-mesh-book/src/meshes/bootstrapping-appendix-canonical-test.md
+++ b/docs/source/books/hyperactor-mesh-book/src/meshes/bootstrapping-appendix-canonical-test.md
@@ -46,13 +46,13 @@ async fn bootstrap_canonical_simple() {
     //     an in-process service proc (`Proc::new(..)`), and
     //     stores the `BootstrapProcManager` for later spawns.
     //
-    // (3) Install HostMeshAgent (still no new OS process).
-    //     `host.system_proc().spawn::<HostMeshAgent>("agent",
-    //     host).await?` creates the HostMeshAgent actor in that
+    // (3) Install HostAgent (still no new OS process).
+    //     `host.system_proc().spawn::<HostAgent>("host_agent",
+    //     host).await?` creates the HostAgent actor in that
     //     service proc.
     //
     // (4) Collect & assemble. The trampoline returns a
-    //     direct-addressed `ActorRef<HostMeshAgent>`; we collect
+    //     direct-addressed `ActorRef<HostAgent>`; we collect
     //     one per rank and assemble a `HostMesh`.
     //
     // Note: When the Host is later asked to start a proc
@@ -66,7 +66,7 @@ async fn bootstrap_canonical_simple() {
 
     // 6) Spawn a ProcMesh named "p0" on the host mesh:
     //
-    // (1) Each HostMeshAgent (running inside its host's service
+    // (1) Each HostAgent (running inside its host's service
     //     proc) receives the request.
     //
     // (2) The Host calls into its `BootstrapProcManager::spawn`,

--- a/docs/source/books/hyperactor-mesh-book/src/meshes/bootstrapping-doing-real-work.md
+++ b/docs/source/books/hyperactor-mesh-book/src/meshes/bootstrapping-doing-real-work.md
@@ -34,7 +34,7 @@ This is **not** the same as the earlier `ProcMesh::allocate(...)` we saw inside 
 
 What actually happens here, per `HostMeshRef::spawn(...)` in `hyperactor_mesh/src/v1/host_mesh.rs`:
 
-1. For **each host** we already have, it sends a `create_or_update(...)` to that host's **HostMeshAgent** saying "you should have a proc named `p0_0` (then `p0_1`, ...) with this create-rank."
+1. For **each host** we already have, it sends a `create_or_update(...)` to that host's **HostAgent** saying "you should have a proc named `p0_0` (then `p0_1`, ...) with this create-rank."
 2. Each host uses its embedded **BootstrapProcManager** to do the *real* OS-level thing: spawn a new child process, run `bootstrap_or_die()` in it, and have it come back as a proc for that host.
 3. The parent waits for status from every host (so it doesn't return too early).
 4. Finally it gathers all those per-host procs into a `ProcMesh`.

--- a/docs/source/books/hyperactor-mesh-book/src/meshes/bootstrapping-from-python.md
+++ b/docs/source/books/hyperactor-mesh-book/src/meshes/bootstrapping-from-python.md
@@ -1,6 +1,6 @@
 # §5 Bootstrapping from Python
 
-So far we described the Rust side: there is a host, the host has a `HostMeshAgent`, and we send `CreateOrUpdate<ProcSpec>` etc. That's the control plane.
+So far we described the Rust side: there is a host, the host has a `HostAgent`, and we send `CreateOrUpdate<ProcSpec>` etc. That's the control plane.
 
 Most users won't do that by hand — they'll write Python like this:
 
@@ -278,4 +278,4 @@ impl PyHostMesh {
 ```
 (This returns a Python task because all v1 Python bindings wrap Rust async in a small bridge. See Appendix: **Python async bridge (pytokio)**.)
 
-`HostMesh::allocate(...)` is the entry point that stands up the host, creates its system proc, spawns the `HostMeshAgent`, and makes it reachable — it's the same path we used in the Rust canonical example.
+`HostMesh::allocate(...)` is the entry point that stands up the host, creates its system proc, spawns the `HostAgent`, and makes it reachable — it's the same path we used in the Rust canonical example.

--- a/docs/source/books/hyperactor-mesh-book/src/meshes/bootstrapping-overview.md
+++ b/docs/source/books/hyperactor-mesh-book/src/meshes/bootstrapping-overview.md
@@ -1,6 +1,6 @@
 # Bootstrapping Overview
 
-*One sentence:* the controller boots remote hosts, then spawns procs (**1 proc = 1 OS process**). Each host runs one **HostMeshAgent**; **every proc runs its own ProcAgent** supervising that proc’s user/service actors.
+*One sentence:* the controller boots remote hosts, then spawns procs (**1 proc = 1 OS process**). Each host runs one **HostAgent**; **every proc runs its own ProcAgent** supervising that proc’s user/service actors.
 
 <figure id="fig-arch" style="text-align:center;">
   <img src="image/mesh-elements.png"
@@ -15,7 +15,7 @@
 ## What you’re looking at
 
 - **Controller process** (left): owns orchestration APIs and kicks off bootstrapping.
-- **HostMeshAgent** (one per host): manages host-local resources and the service proc.
+- **HostAgent** (one per host): manages host-local resources and the service proc.
 - **ProcAgent** (one per proc): supervises that proc’s actors (service + user).
 - **Procs** (squares): runtime containers; *1 proc = 1 OS process*.
 
@@ -23,7 +23,7 @@
 
 1. Obtain a **proc + instance** (control endpoint).
 2. Use the **v0 process allocator** and **bootstrap handshake** to get remote runtimes.
-3. Promote those runtimes into real **hosts** (start HostMeshAgent).
+3. Promote those runtimes into real **hosts** (start HostAgent).
 4. **Spawn procs and actors** on those hosts (start proc/ProcAgent, spawn  actors).
 
 _For the full, runnable test (see `bootstrap_canonical_simple`), see the appendix._

--- a/docs/source/books/hyperactor-mesh-book/src/meshes/host-and-agents.md
+++ b/docs/source/books/hyperactor-mesh-book/src/meshes/host-and-agents.md
@@ -66,7 +66,7 @@ At the control plane we have the mesh-facing actor:
 
 ```rust
 // hyperactor_mesh/src/v1/host_mesh/mesh_agent.rs
-pub struct HostMeshAgent {
+pub struct HostAgent {
   host: Option<HostAgentMode>,
   created: HashMap<Name, ProcCreationState>,
 }
@@ -105,12 +105,12 @@ pub struct Host<M> {
 
 So the layering from the code's point of view is:
 
-1. `HostMeshAgent` (actor you message over v1)
+1. `HostAgent` (actor you message over v1)
 2. → maybe a `HostAgentMode`
 3. → definitely a `Host<...>` once materialized
 4. → which, through its manager (e.g. `BootstrapProcManager`), owns/spawns the procs and does the `*`/`#n` routing.
 
-## HostMeshAgent message handling
+## HostAgent message handling
 
 The agent is exported with exactly these handlers:
 
@@ -125,7 +125,7 @@ The agent is exported with exactly these handlers:
         ShutdownHost,
     ]
 )]
-pub struct HostMeshAgent {
+pub struct HostAgent {
     host: Option<HostAgentMode>,
     created: HashMap<Name, ProcCreationState>,
     local_mesh_agent: OnceCell<anyhow::Result<ActorHandle<ProcAgent>>>,
@@ -172,7 +172,7 @@ So everything it does is one of those 6 messages.
 
 ## Why this exists
 
-`Host` is local; `HostMeshAgent` is the remote handle for it. Bootstrap code just sends `CreateOrUpdate/Stop/GetState` to the agent; the agent is the one that actually owns the `Host` and can spawn/stop procs. That’s why all handlers use the shared `resource` messages.
+`Host` is local; `HostAgent` is the remote handle for it. Bootstrap code just sends `CreateOrUpdate/Stop/GetState` to the agent; the agent is the one that actually owns the `Host` and can spawn/stop procs. That’s why all handlers use the shared `resource` messages.
 
 ## 1. `ProcSpec` (what we tell the host to run)
 
@@ -200,7 +200,7 @@ pub struct CreateOrUpdate<S> {
     pub spec: S,
 }
 ```
-What the `HostMeshAgent` actually does matches this shape:
+What the `HostAgent` actually does matches this shape:
 - if the host is process-backed (`HostAgentMode::Process(...)`), it builds a `BootstrapProcConfig` using
 - the rank from `CreateOrUpdate::<ProcSpec>`, and
 - the `client_config_override` from `ProcSpec`, and passes that to `host.spawn(...);`
@@ -208,7 +208,7 @@ What the `HostMeshAgent` actually does matches this shape:
 
 Here is the bit of real code that does exactly that (abridged to just the decision):
 ```rust
-// from hyperactor_mesh/src/v1/host_mesh/mesh_agent.rs (`impl Handler<resource::CreateOrUpdate<ProcSpec>> for HostMeshAgent`)
+// from hyperactor_mesh/src/v1/host_mesh/mesh_agent.rs (`impl Handler<resource::CreateOrUpdate<ProcSpec>> for HostAgent`)
 
 let created = match host {
     HostAgentMode::Process(host) => {
@@ -241,10 +241,10 @@ We're not going to unpack the process-backed path here — that lives in **"Boot
 
 ## v1 bootstrap in one pass
 
-The reason the `HostMeshAgent` has those five messages (create, stop, get-state, get-rank-status, shutdown) is that the v1 protocol treats "things on a host" as **resources**. A typical sequence is:
+The reason the `HostAgent` has those five messages (create, stop, get-state, get-rank-status, shutdown) is that the v1 protocol treats "things on a host" as **resources**. A typical sequence is:
 
 1. **Coordinator → hosts:** send `CreateOrUpdate<ProcSpec>` to every host agent in the mesh ("each of you should have a proc called `p0` with this rank/config").
 2. **Coordinator → hosts (later):** send `GetState<ProcState>` (or `GetRankStatus`) to see which hosts actually brought that proc up and what address/command it got.
 3. **Coordinator → hosts (teardown):** send `ShutdownHost` to have each agent tell its host to terminate all children and drop the host.
 
-Because everyone speaks this same resource shape — `CreateOrUpdate<T>`, `GetState<T>`, `Stop`, `StopAll`/`ShutdownHost` — the handlers on `HostMeshAgent` all look the same, and the coordinator can fan the same message out to N hosts.
+Because everyone speaks this same resource shape — `CreateOrUpdate<T>`, `GetState<T>`, `Stop`, `StopAll`/`ShutdownHost` — the handlers on `HostAgent` all look the same, and the coordinator can fan the same message out to N hosts.

--- a/docs/source/books/hyperactor-mesh-book/src/meshes/index.md
+++ b/docs/source/books/hyperactor-mesh-book/src/meshes/index.md
@@ -22,7 +22,7 @@ So the through line is: *one process that can speak hyperactor → host → proc
 
 ## Pieces (conceptual)
 
-- **Host**: a long-lived runtime that owns "all procs on this machine" and gives them a single front door (`*` / mux). It also runs a **`HostMeshAgent`** in its system proc so other parts of the mesh can tell it "start/stop this proc."
+- **Host**: a long-lived runtime that owns "all procs on this machine" and gives them a single front door (`*` / mux). It also runs a **`HostAgent`** in its system proc so other parts of the mesh can tell it "start/stop this proc."
 - **Proc**: an actor runtime. In v1 the proc also runs a **`ProcAgent`** so it can be managed the same way as the host — that's why the agent handlers all look like the resource ones you saw.
 - **Actor mesh**: the thing you actually care about as a user — N copies of your actor (often one per proc), callable as a group.
 
@@ -45,7 +45,7 @@ After that, it's just "send messages to the mesh."
     - **2. Process allocator & v0 bootstrap** — the older path / allocator angle.
     - **3. HostMesh from an allocation** — taking an allocation and saying "these are my hosts."
     - **4. Doing real work (hosts → procs → actors)** — actually spawning actors once procs exist.
-- **Host & agents (control plane & mux)** — deep dive on the thing the host runs (`HostMeshAgent`), how it maps `CreateOrUpdate<ProcSpec>` to `host.spawn(...)`, and why all the handlers look the same.
+- **Host & agents (control plane & mux)** — deep dive on the thing the host runs (`HostAgent`), how it maps `CreateOrUpdate<ProcSpec>` to `host.spawn(...)`, and why all the handlers look the same.
 - **Proc meshes & ProcAgent** — deep dive on the proc-level agent: how it turns `CreateOrUpdate<ActorSpec>` and `MeshAgentMessage::Gspawn` into actor spawns via hyperactor's `Remote` registry.
 - **Process-backed hosts: BootstrapProcManager** — the "real OS child, real bootstrap command" path the host delegates to.
 - **Bootstrapping from Python** — show that `this_host().spawn_procs(...).spawn(...)` is using the same Rust v1 path, just through the Python bindings.

--- a/docs/source/books/hyperactor-mesh-book/src/meshes/proc-mesh-and-agent.md
+++ b/docs/source/books/hyperactor-mesh-book/src/meshes/proc-mesh-and-agent.md
@@ -2,7 +2,7 @@
 
 ## What the `ProcAgent` Is
 
-Every proc in a mesh runs a `ProcAgent`. It plays the same role on the proc side that the `HostMeshAgent` plays on the host side: it implements the control-plane interface for "managing this proc as part of a mesh".
+Every proc in a mesh runs a `ProcAgent`. It plays the same role on the proc side that the `HostAgent` plays on the host side: it implements the control-plane interface for "managing this proc as part of a mesh".
 
 The agent has several responsibilities, all of which will be documented on this page:
 - wiring the proc into the mesh router,

--- a/hyper/Cargo.toml
+++ b/hyper/Cargo.toml
@@ -17,7 +17,6 @@ fbinit-tokio = { version = "0.1.2", git = "https://github.com/facebookexperiment
 hyperactor = { version = "0.0.0", path = "../hyperactor" }
 hyperactor_mesh = { version = "0.0.0", path = "../hyperactor_mesh" }
 serde_json = { version = "1.0.140", features = ["alloc", "float_roundtrip", "raw_value", "unbounded_depth"] }
-tokio = { version = "1.47.1", features = ["full", "test-util", "tracing"] }
 
 [lints]
 rust = { unexpected_cfgs = { check-cfg = ["cfg(fbcode_build)"], level = "warn" } }

--- a/hyper/src/commands/list.rs
+++ b/hyper/src/commands/list.rs
@@ -10,7 +10,7 @@ use hyperactor::ActorRef;
 use hyperactor::channel::ChannelAddr;
 use hyperactor::reference::ProcId;
 use hyperactor_mesh::global_root_client;
-use hyperactor_mesh::host_mesh::mesh_agent::HostMeshAgent;
+use hyperactor_mesh::host_mesh::host_agent::HostAgent;
 use hyperactor_mesh::resource::ListClient;
 
 #[derive(clap::Args, Debug)]
@@ -34,8 +34,8 @@ impl ListCommand {
         let client = global_root_client();
 
         // Codify obtaining a proc's agent in `hyperactor_mesh` somewhere.
-        let agent: ActorRef<HostMeshAgent> =
-            ActorRef::attest(ProcId::Direct(host, "service".to_string()).actor_id("agent", 0));
+        let agent: ActorRef<HostAgent> =
+            ActorRef::attest(ProcId::Direct(host, "service".to_string()).actor_id("host_agent", 0));
 
         let resources = agent.list(&client).await?;
         println!("{}", serde_json::to_string_pretty(&resources)?);

--- a/hyper/src/commands/show.rs
+++ b/hyper/src/commands/show.rs
@@ -10,7 +10,7 @@ use hyperactor::ActorRef;
 use hyperactor::reference::ProcId;
 use hyperactor::reference::Reference;
 use hyperactor_mesh::global_root_client;
-use hyperactor_mesh::host_mesh::mesh_agent::HostMeshAgent;
+use hyperactor_mesh::host_mesh::host_agent::HostAgent;
 use hyperactor_mesh::resource::GetStateClient;
 
 #[derive(clap::Args, Debug)]
@@ -27,8 +27,8 @@ impl ShowCommand {
                 let client = global_root_client();
 
                 // Codify obtaining a proc's agent in `hyperactor_mesh` somewhere.
-                let agent: ActorRef<HostMeshAgent> = ActorRef::attest(
-                    ProcId::Direct(host, "service".to_string()).actor_id("agent", 0),
+                let agent: ActorRef<HostAgent> = ActorRef::attest(
+                    ProcId::Direct(host, "service".to_string()).actor_id("host_agent", 0),
                 );
 
                 let state = agent.get_state(&client, proc.parse().unwrap()).await?;

--- a/hyper/src/main.rs
+++ b/hyper/src/main.rs
@@ -107,7 +107,7 @@ async fn run(fb: Option<fbinit::FacebookInit>) -> Result<(), anyhow::Error> {
     // Allow the channel layer to flush pending acks before exit.
     // Without this, the remote host's MailboxClient observes a
     // broken link (30 s ack timeout) and the resulting undeliverable
-    // message crashes the HostMeshAgent, tearing down the entire
+    // message crashes the HostAgent, tearing down the entire
     // mesh.  The ack interval is 500 ms, so 1 s is sufficient.
     RealClock.sleep(std::time::Duration::from_secs(1)).await;
 

--- a/hyperactor/src/host.rs
+++ b/hyperactor/src/host.rs
@@ -1403,7 +1403,7 @@ mod tests {
     #[tokio::test]
     async fn test_basic() {
         let proc_manager =
-            LocalProcManager::new(|proc: Proc| async move { proc.spawn::<()>("agent", ()) });
+            LocalProcManager::new(|proc: Proc| async move { proc.spawn::<()>("host_agent", ()) });
         let procs = Arc::clone(&proc_manager.procs);
         let mut host = Host::new(proc_manager, ChannelAddr::any(ChannelTransport::Local))
             .await
@@ -1469,7 +1469,7 @@ mod tests {
     async fn test_process_proc_manager() {
         hyperactor_telemetry::initialize_logging(crate::clock::ClockKind::default());
 
-        // EchoActor is "agent" used to test connectivity.
+        // EchoActor is "host_agent" used to test connectivity.
         let process_manager = ProcessProcManager::<EchoActor>::new(
             buck_resources::get("monarch/hyperactor/bootstrap").unwrap(),
         );
@@ -1555,7 +1555,7 @@ mod tests {
         // Build a LocalHandle directly.
         let addr = ChannelAddr::any(ChannelTransport::Local);
         let proc_id = ProcId::Direct(addr.clone(), "p".into());
-        let agent_ref = ActorRef::<()>::attest(proc_id.actor_id("agent", 0));
+        let agent_ref = ActorRef::<()>::attest(proc_id.actor_id("host_agent", 0));
         let h = LocalHandle::<()> {
             proc_id,
             addr,
@@ -1685,7 +1685,7 @@ mod tests {
             forwarder_addr: ChannelAddr,
             _config: (),
         ) -> Result<Self::Handle, HostError> {
-            let agent = ActorRef::<()>::attest(proc_id.actor_id("agent", 0));
+            let agent = ActorRef::<()>::attest(proc_id.actor_id("host_agent", 0));
             Ok(TestHandle {
                 id: proc_id,
                 addr: forwarder_addr,

--- a/hyperactor/src/introspect.rs
+++ b/hyperactor/src/introspect.rs
@@ -139,7 +139,7 @@ pub enum NodeProperties {
         system_children: Vec<String>,
     },
 
-    /// A host in the mesh, represented by its `HostMeshAgent`.
+    /// A host in the mesh, represented by its `HostAgent`.
     Host {
         /// Host address (e.g. `127.0.0.1:12345`).
         addr: String,
@@ -200,7 +200,7 @@ pub enum NodeProperties {
         /// enabled/available.
         flight_recorder: Option<String>,
         /// Whether this actor is infrastructure-owned (e.g.
-        /// ProcAgent, HostMeshAgent) rather than user-created.
+        /// ProcAgent, HostAgent) rather than user-created.
         is_system: bool,
         /// Structured failure information, present only for failed
         /// actors. `None` for running or cleanly stopped actors.
@@ -244,7 +244,7 @@ wirevalue::register_type!(NodePayload);
 /// Context for introspection query - what aspect of the actor to
 /// describe.
 ///
-/// Infrastructure actors (e.g., ProcAgent, HostMeshAgent)
+/// Infrastructure actors (e.g., ProcAgent, HostAgent)
 /// have dual nature: they manage entities (Proc, Host) while also
 /// being actors themselves. IntrospectView allows callers to
 /// specify which aspect to query.
@@ -309,7 +309,7 @@ pub struct RecordedEvent {
 
 /// Domain-specific properties an actor may publish for introspection.
 ///
-/// Infrastructure actors (HostMeshAgent, ProcAgent) push these to
+/// Infrastructure actors (HostAgent, ProcAgent) push these to
 /// make their managed-entity metadata available to the introspection
 /// runtime without going through the actor's message handler. The
 /// runtime handler reads the last-published value and merges it into

--- a/hyperactor/src/proc.rs
+++ b/hyperactor/src/proc.rs
@@ -1274,8 +1274,8 @@ impl<A: Actor> Instance<A> {
     /// actor loop), so it must be `Send + Sync` and must not access
     /// actor-mutable state. Capture cloned `Proc` references.
     ///
-    /// Only `HostMeshAgent` uses this today — for resolving system
-    /// procs that have no independent `ProcMeshAgent`.
+    /// Only `HostAgent` uses this today — for resolving system
+    /// procs that have no independent `ProcAgent`.
     pub fn set_query_child_handler(
         &self,
         handler: impl (Fn(&crate::reference::Reference) -> NodePayload) + Send + Sync + 'static,
@@ -2042,7 +2042,7 @@ struct InstanceCellState {
 
     /// Optional callback for resolving non-addressable children
     /// (e.g., system procs). Registered by infrastructure actors
-    /// like `HostMeshAgent` in `Actor::init`. Invoked by the
+    /// like `HostAgent` in `Actor::init`. Invoked by the
     /// introspection runtime handler for `QueryChild` messages.
     /// `None` means `QueryChild` returns a "not_found" error.
     ///
@@ -2361,7 +2361,7 @@ impl InstanceCell {
     /// introspection. The `published_at` timestamp is set
     /// automatically to `RealClock.system_time_now()`.
     ///
-    /// Infrastructure actors (HostMeshAgent, ProcMeshAgent) call this
+    /// Infrastructure actors (HostAgent, ProcAgent) call this
     /// to make their managed-entity metadata available without going
     /// through the actor's message handler.
     pub fn set_published_properties(&self, kind: PublishedPropertiesKind) {

--- a/hyperactor/src/supervision.rs
+++ b/hyperactor/src/supervision.rs
@@ -97,7 +97,7 @@ fn fmt_status<'a>(
 
     match status {
         ActorStatus::Stopped(_)
-            if actor_id.name() == "agent" || actor_id.name() == "proc_agent" =>
+            if actor_id.name() == "host_agent" || actor_id.name() == "proc_agent" =>
         {
             // Host agent stopped - use simplified message from D86984496
             let name = match actor_id.proc_id() {

--- a/hyperactor_mesh/bin/admin_tui/model.rs
+++ b/hyperactor_mesh/bin/admin_tui/model.rs
@@ -603,10 +603,10 @@ mod tests {
     #[test]
     fn from_payload_sets_is_system_for_system_actor() {
         let payload = NodePayload {
-            identity: "agent[0]".to_string(),
+            identity: "host_agent[0]".to_string(),
             properties: NodeProperties::Actor {
                 actor_status: "idle".to_string(),
-                actor_type: "hyperactor_mesh::mesh_agent::ProcMeshAgent".to_string(),
+                actor_type: "hyperactor_mesh::proc_agent::ProcAgent".to_string(),
                 messages_processed: 10,
                 created_at: "".to_string(),
                 last_message_handler: None,
@@ -619,7 +619,7 @@ mod tests {
             parent: None,
             as_of: "".to_string(),
         };
-        let node = TreeNode::from_payload("agent[0]".to_string(), &payload);
+        let node = TreeNode::from_payload("host_agent[0]".to_string(), &payload);
         assert!(node.is_system);
         assert!(!node.stopped);
     }

--- a/hyperactor_mesh/src/alloc/process.rs
+++ b/hyperactor_mesh/src/alloc/process.rs
@@ -475,7 +475,7 @@ impl ProcessAlloc {
         // (c.f. `enable_forwarding`), we do not do log forwarding on
         // these procs. This is because, now that we are on the v1
         // path, the only procs we spawn via this code path are those
-        // to support `HostMeshAgent`s.
+        // to support `HostAgent`s.
         let log_channel: Option<ChannelAddr> = None;
 
         let index = self.created.len();

--- a/hyperactor_mesh/src/bootstrap.rs
+++ b/hyperactor_mesh/src/bootstrap.rs
@@ -68,8 +68,8 @@ use tracing::Level;
 use typeuri::Named;
 
 use crate::config::MESH_PROC_LAUNCHER_KIND;
-use crate::host_mesh::mesh_agent::HostAgentMode;
-use crate::host_mesh::mesh_agent::HostMeshAgent;
+use crate::host_mesh::host_agent::HostAgent;
+use crate::host_mesh::host_agent::HostAgentMode;
 use crate::logging::OutputTarget;
 use crate::logging::StreamFwder;
 use crate::proc_agent::ProcAgent;
@@ -295,7 +295,7 @@ pub async fn host(
     command: Option<BootstrapCommand>,
     config: Option<Attrs>,
     exit_on_shutdown: bool,
-) -> anyhow::Result<ActorHandle<HostMeshAgent>> {
+) -> anyhow::Result<ActorHandle<HostAgent>> {
     if let Some(attrs) = config {
         hyperactor_config::global::set(hyperactor_config::global::Source::Runtime, attrs);
         tracing::debug!("bootstrap: installed Runtime config snapshot (Host)");
@@ -314,9 +314,9 @@ pub async fn host(
         .await?;
     let addr = host.addr().clone();
     let system_proc = host.system_proc().clone();
-    let host_mesh_agent = system_proc.spawn::<HostMeshAgent>(
-        "agent",
-        HostMeshAgent::new(HostAgentMode::Process {
+    let host_mesh_agent = system_proc.spawn::<HostAgent>(
+        "host_agent",
+        HostAgent::new(HostAgentMode::Process {
             host,
             exit_on_shutdown,
         }),
@@ -325,7 +325,7 @@ pub async fn host(
     tracing::info!(
         "serving host at {}, agent: {}",
         addr,
-        host_mesh_agent.bind::<HostMeshAgent>()
+        host_mesh_agent.bind::<HostAgent>()
     );
 
     Ok(host_mesh_agent)
@@ -362,7 +362,7 @@ pub enum Bootstrap {
     },
 
     /// Bootstrap as a "v1" host bootstrap. This sets up a new `Host`,
-    /// managed by a [`crate::host_mesh::mesh_agent::HostMeshAgent`].
+    /// managed by a [`crate::host_mesh::host_agent::HostAgent`].
     Host {
         /// The address on which to serve the host.
         addr: ChannelAddr,
@@ -3307,13 +3307,13 @@ mod tests {
         //     an in-process service proc (`Proc::new(..)`), and
         //     stores the `BootstrapProcManager` for later spawns.
         //
-        // (3) Install HostMeshAgent (still no new OS process).
-        //     `host.system_proc().spawn::<HostMeshAgent>("agent",
-        //     host).await?` creates the HostMeshAgent actor in that
+        // (3) Install HostAgent (still no new OS process).
+        //     `host.system_proc().spawn::<HostAgent>("host_agent",
+        //     host).await?` creates the HostAgent actor in that
         //     service proc.
         //
         // (4) Collect & assemble. The trampoline returns a
-        //     direct-addressed `ActorRef<HostMeshAgent>`; we collect
+        //     direct-addressed `ActorRef<HostAgent>`; we collect
         //     one per rank and assemble a `HostMesh`.
         //
         // Note: When the Host is later asked to start a proc
@@ -3327,7 +3327,7 @@ mod tests {
 
         // Spawn a ProcMesh named "p0" on the host mesh:
         //
-        // (1) Each HostMeshAgent (running inside its host's service
+        // (1) Each HostAgent (running inside its host's service
         // proc) receives the request.
         //
         // (2) The Host calls into its `BootstrapProcManager::spawn`,
@@ -3506,7 +3506,7 @@ mod tests {
     #[tokio::test]
     #[cfg(fbcode_build)]
     async fn test_host_bootstrap() {
-        use crate::host_mesh::mesh_agent::GetLocalProcClient;
+        use crate::host_mesh::host_agent::GetLocalProcClient;
         use crate::proc_agent::NewClientInstanceClient;
 
         // Create a local instance just to call the local bootstrap actor.

--- a/hyperactor_mesh/src/host_mesh.rs
+++ b/hyperactor_mesh/src/host_mesh.rs
@@ -21,7 +21,7 @@ use ndslice::view::CollectMeshExt;
 
 use crate::supervision::MeshFailure;
 
-pub mod mesh_agent;
+pub mod host_agent;
 
 use std::collections::HashSet;
 use std::ops::Deref;
@@ -52,14 +52,14 @@ use crate::ValueMesh;
 use crate::alloc::Alloc;
 use crate::bootstrap::BootstrapCommand;
 use crate::bootstrap::BootstrapProcManager;
-use crate::host_mesh::mesh_agent::HostAgentMode;
-pub use crate::host_mesh::mesh_agent::HostMeshAgent;
-use crate::host_mesh::mesh_agent::HostMeshAgentProcMeshTrampoline;
-use crate::host_mesh::mesh_agent::ProcManagerSpawnFn;
-use crate::host_mesh::mesh_agent::ProcState;
-use crate::host_mesh::mesh_agent::SetClientConfigClient;
-use crate::host_mesh::mesh_agent::ShutdownHostClient;
-use crate::host_mesh::mesh_agent::SpawnMeshAdminClient;
+pub use crate::host_mesh::host_agent::HostAgent;
+use crate::host_mesh::host_agent::HostAgentMode;
+use crate::host_mesh::host_agent::HostMeshAgentProcMeshTrampoline;
+use crate::host_mesh::host_agent::ProcManagerSpawnFn;
+use crate::host_mesh::host_agent::ProcState;
+use crate::host_mesh::host_agent::SetClientConfigClient;
+use crate::host_mesh::host_agent::ShutdownHostClient;
+use crate::host_mesh::host_agent::SpawnMeshAdminClient;
 use crate::mesh_controller::HostMeshController;
 use crate::mesh_controller::ProcMeshController;
 use crate::proc_agent::ProcAgent;
@@ -106,10 +106,10 @@ wirevalue::register_type!(HostRef);
 
 impl HostRef {
     /// The host mesh agent associated with this host.
-    fn mesh_agent(&self) -> ActorRef<HostMeshAgent> {
+    fn mesh_agent(&self) -> ActorRef<HostAgent> {
         ActorRef::attest(
             self.service_proc()
-                .actor_id(mesh_agent::HOST_MESH_AGENT_ACTOR_NAME, 0),
+                .actor_id(host_agent::HOST_MESH_AGENT_ACTOR_NAME, 0),
         )
     }
 
@@ -157,10 +157,10 @@ impl HostRef {
     }
 }
 
-impl TryFrom<ActorRef<HostMeshAgent>> for HostRef {
+impl TryFrom<ActorRef<HostAgent>> for HostRef {
     type Error = crate::Error;
 
-    fn try_from(value: ActorRef<HostMeshAgent>) -> Result<Self, crate::Error> {
+    fn try_from(value: ActorRef<HostAgent>) -> Result<Self, crate::Error> {
         let proc_id = value.actor_id().proc_id();
         match proc_id.as_direct() {
             Some((addr, _)) => Ok(HostRef(addr.clone())),
@@ -258,7 +258,7 @@ impl HostMesh {
     ///   does not produce a `HostMesh`.
     ///
     /// - launcher mode: otherwise, we are the process that is setting
-    ///   up the mesh. we create a `Host`, spawn a `HostMeshAgent` in
+    ///   up the mesh. we create a `Host`, spawn a `HostAgent` in
     ///   it, and build a single-host `HostMesh` around that. that
     ///   `HostMesh` is returned to the caller.
     ///
@@ -292,14 +292,14 @@ impl HostMesh {
         let system_proc = host.system_proc().clone();
         let host_mesh_agent = system_proc
             .spawn(
-                "agent",
-                HostMeshAgent::new(HostAgentMode::Process {
+                "host_agent",
+                HostAgent::new(HostAgentMode::Process {
                     host,
                     exit_on_shutdown: false,
                 }),
             )
             .map_err(crate::Error::SingletonActorSpawnError)?;
-        host_mesh_agent.bind::<HostMeshAgent>();
+        host_mesh_agent.bind::<HostAgent>();
 
         let host = HostRef(addr);
         let host_mesh_ref = HostMeshRef::new(
@@ -356,11 +356,11 @@ impl HostMesh {
         let system_proc = host.system_proc().clone();
         let host_mesh_agent = system_proc
             .spawn(
-                mesh_agent::HOST_MESH_AGENT_ACTOR_NAME,
-                HostMeshAgent::new(HostAgentMode::Local(host)),
+                host_agent::HOST_MESH_AGENT_ACTOR_NAME,
+                HostAgent::new(HostAgentMode::Local(host)),
             )
             .map_err(crate::Error::SingletonActorSpawnError)?;
-        host_mesh_agent.bind::<HostMeshAgent>();
+        host_mesh_agent.bind::<HostAgent>();
         Ok(HostRef(addr))
     }
 
@@ -411,7 +411,7 @@ impl HostMesh {
     ///
     /// Because HostMeshes use direct-addressed procs, and must fully control the procs they are
     /// managing, `HostMesh::allocate` uses a trampoline actor to launch the host, which in turn
-    /// runs a [`crate::host_mesh::mesh_agent::HostMeshAgent`] actor to manage the host itself.
+    /// runs a [`crate::host_mesh::host_agent::HostAgent`] actor to manage the host itself.
     /// The host (and thus all of its procs) are exposed directly through a separate listening
     /// channel, established by the host.
     ///
@@ -593,7 +593,7 @@ impl HostMesh {
     /// `HostMesh`.
     ///
     /// For each host, this sends `ShutdownHost` to its
-    /// `HostMeshAgent`. The agent takes and drops its `Host` (via
+    /// `HostAgent`. The agent takes and drops its `Host` (via
     /// `Option::take()`), which in turn drops the embedded
     /// `BootstrapProcManager`. On drop, the manager walks its PID
     /// table and sends SIGKILL to any procs it spawned—tying proc
@@ -850,10 +850,7 @@ impl HostMeshRef {
     }
 
     /// Create a new HostMeshRef from an arbitrary set of host mesh agents.
-    pub fn from_host_agents(
-        name: Name,
-        agents: Vec<ActorRef<HostMeshAgent>>,
-    ) -> crate::Result<Self> {
+    pub fn from_host_agents(name: Name, agents: Vec<ActorRef<HostAgent>>) -> crate::Result<Self> {
         Ok(Self {
             name,
             region: extent!(hosts = agents.len()).into(),
@@ -867,7 +864,7 @@ impl HostMeshRef {
     }
 
     /// Create a unit HostMeshRef from a host mesh agent.
-    pub fn from_host_agent(name: Name, agent: ActorRef<HostMeshAgent>) -> crate::Result<Self> {
+    pub fn from_host_agent(name: Name, agent: ActorRef<HostAgent>) -> crate::Result<Self> {
         Ok(Self {
             name,
             region: Extent::unity().into(),
@@ -1207,7 +1204,7 @@ impl HostMeshRef {
     /// return its HTTP address.
     ///
     /// Sends a `SpawnMeshAdmin` message to `ranks[0]`'s
-    /// `HostMeshAgent`, which spawns the admin agent on that host's
+    /// `HostAgent`, which spawns the admin agent on that host's
     /// system proc. When `admin_addr` is `Some`, the HTTP server
     /// binds to that address; otherwise it reads `MESH_ADMIN_ADDR`
     /// from config.
@@ -1216,7 +1213,7 @@ impl HostMeshRef {
         cx: &impl hyperactor::context::Actor,
         admin_addr: Option<std::net::SocketAddr>,
     ) -> anyhow::Result<String> {
-        let hosts: Vec<(String, ActorRef<HostMeshAgent>)> = self
+        let hosts: Vec<(String, ActorRef<HostAgent>)> = self
             .ranks
             .iter()
             .map(|h| (h.0.to_string(), h.mesh_agent()))
@@ -1260,7 +1257,7 @@ impl HostMeshRef {
                     proc_id,
                 ));
             };
-            // The name stored in HostMeshAgent is not the same as the
+            // The name stored in HostAgent is not the same as the
             // one stored in the ProcMesh. We instead take each proc id
             // and map it to that particular agent.
             let proc_name = proc_name.parse::<Name>()?;

--- a/hyperactor_mesh/src/host_mesh/host_agent.rs
+++ b/hyperactor_mesh/src/host_mesh/host_agent.rs
@@ -63,10 +63,10 @@ use crate::resource::ProcSpec;
 
 /// Typed host-node identifier for mesh admin navigation.
 ///
-/// Wraps an [`ActorId`] (the `HostMeshAgent`'s actor id) and
+/// Wraps an [`ActorId`] (the `HostAgent`'s actor id) and
 /// serializes with a `host:` prefix so that the admin resolver can
 /// distinguish host-level references from plain actor references.
-/// The same `HostMeshAgent` `ActorId` can appear as both a host
+/// The same `HostAgent` `ActorId` can appear as both a host
 /// (from root's children) and as an actor (from a proc's children);
 /// `HostId` makes the host case unambiguous.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -203,7 +203,7 @@ pub(crate) struct ProcCreationState {
 }
 
 /// Actor name used when spawning the host mesh agent on the system proc.
-pub const HOST_MESH_AGENT_ACTOR_NAME: &str = "agent";
+pub const HOST_MESH_AGENT_ACTOR_NAME: &str = "host_agent";
 
 /// A mesh agent is responsible for managing a host in a [`HostMesh`],
 /// through the resource behaviors defined in [`crate::resource`].
@@ -219,14 +219,14 @@ pub const HOST_MESH_AGENT_ACTOR_NAME: &str = "agent";
         SetClientConfig,
     ]
 )]
-pub struct HostMeshAgent {
+pub struct HostAgent {
     pub(crate) host: Option<HostAgentMode>,
     pub(crate) created: HashMap<Name, ProcCreationState>,
     /// Stores the lazily initialized proc mesh agent for the local proc.
     local_mesh_agent: OnceLock<anyhow::Result<ActorHandle<ProcAgent>>>,
 }
 
-impl HostMeshAgent {
+impl HostAgent {
     /// Create a new host mesh agent running in the provided mode.
     pub fn new(host: HostAgentMode) -> Self {
         Self {
@@ -279,7 +279,7 @@ impl HostMeshAgent {
 }
 
 #[async_trait]
-impl Actor for HostMeshAgent {
+impl Actor for HostAgent {
     async fn init(&mut self, this: &Instance<Self>) -> Result<(), anyhow::Error> {
         // Serve the host now that the agent is initialized. Make sure our port is
         // bound before serving.
@@ -378,9 +378,9 @@ impl Actor for HostMeshAgent {
     }
 }
 
-impl fmt::Debug for HostMeshAgent {
+impl fmt::Debug for HostAgent {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("HostMeshAgent")
+        f.debug_struct("HostAgent")
             .field("host", &"..")
             .field("created", &self.created)
             .finish()
@@ -388,8 +388,8 @@ impl fmt::Debug for HostMeshAgent {
 }
 
 #[async_trait]
-impl Handler<resource::CreateOrUpdate<ProcSpec>> for HostMeshAgent {
-    #[tracing::instrument("HostMeshAgent::CreateOrUpdate", level = "info", skip_all, fields(name=%create_or_update.name))]
+impl Handler<resource::CreateOrUpdate<ProcSpec>> for HostAgent {
+    #[tracing::instrument("HostAgent::CreateOrUpdate", level = "info", skip_all, fields(name=%create_or_update.name))]
     async fn handle(
         &mut self,
         cx: &Context<Self>,
@@ -438,7 +438,7 @@ impl Handler<resource::CreateOrUpdate<ProcSpec>> for HostMeshAgent {
 }
 
 #[async_trait]
-impl Handler<resource::Stop> for HostMeshAgent {
+impl Handler<resource::Stop> for HostAgent {
     async fn handle(&mut self, cx: &Context<Self>, message: resource::Stop) -> anyhow::Result<()> {
         tracing::info!(
             name = "HostMeshAgentStatus",
@@ -449,7 +449,7 @@ impl Handler<resource::Stop> for HostMeshAgent {
         let host = self
             .host
             .as_ref()
-            .ok_or(anyhow::anyhow!("HostMeshAgent has already shut down"))?;
+            .ok_or(anyhow::anyhow!("HostAgent has already shut down"))?;
         let timeout = hyperactor_config::global::get(hyperactor::config::PROCESS_EXIT_TIMEOUT);
 
         if let Some(ProcCreationState {
@@ -467,7 +467,7 @@ impl Handler<resource::Stop> for HostMeshAgent {
 }
 
 #[async_trait]
-impl Handler<resource::GetRankStatus> for HostMeshAgent {
+impl Handler<resource::GetRankStatus> for HostAgent {
     async fn handle(
         &mut self,
         cx: &Context<Self>,
@@ -500,7 +500,7 @@ impl Handler<resource::GetRankStatus> for HostMeshAgent {
                 .expect("valid single-run overlay")
         };
         let result = get_rank_status.reply.send(cx, overlay);
-        // Ignore errors, because returning Err from here would cause the HostMeshAgent
+        // Ignore errors, because returning Err from here would cause the HostAgent
         // to be stopped, which would take down the entire host. This only means
         // some actor that requested the rank status failed to receive it.
         if let Err(e) = result {
@@ -529,7 +529,7 @@ pub struct ShutdownHost {
 wirevalue::register_type!(ShutdownHost);
 
 #[async_trait]
-impl Handler<ShutdownHost> for HostMeshAgent {
+impl Handler<ShutdownHost> for HostAgent {
     async fn handle(&mut self, cx: &Context<Self>, msg: ShutdownHost) -> anyhow::Result<()> {
         // Ack immediately so caller can stop waiting.
         let (return_handle, mut return_receiver) = cx.mailbox().open_port();
@@ -595,7 +595,7 @@ pub struct ProcState {
 wirevalue::register_type!(ProcState);
 
 #[async_trait]
-impl Handler<resource::GetState<ProcState>> for HostMeshAgent {
+impl Handler<resource::GetState<ProcState>> for HostAgent {
     async fn handle(
         &mut self,
         cx: &Context<Self>,
@@ -635,7 +635,7 @@ impl Handler<resource::GetState<ProcState>> for HostMeshAgent {
         };
 
         let result = get_state.reply.send(cx, state);
-        // Ignore errors, because returning Err from here would cause the HostMeshAgent
+        // Ignore errors, because returning Err from here would cause the HostAgent
         // to be stopped, which would take down the entire host. This only means
         // some actor that requested the state of a proc failed to receive it.
         if let Err(e) = result {
@@ -651,7 +651,7 @@ impl Handler<resource::GetState<ProcState>> for HostMeshAgent {
 }
 
 #[async_trait]
-impl Handler<resource::List> for HostMeshAgent {
+impl Handler<resource::List> for HostAgent {
     async fn handle(&mut self, cx: &Context<Self>, list: resource::List) -> anyhow::Result<()> {
         list.reply
             .send(cx, self.created.keys().cloned().collect())?;
@@ -668,7 +668,7 @@ pub struct SpawnMeshAdmin {
     /// All hosts in the mesh as `(address, agent_ref)` pairs. Passed
     /// through to [`MeshAdminAgent::new`] so the admin can fan out
     /// introspection queries to every host.
-    pub hosts: Vec<(String, ActorRef<HostMeshAgent>)>,
+    pub hosts: Vec<(String, ActorRef<HostAgent>)>,
 
     /// `ActorId` of the process-global root client, exposed as a
     /// child node in the admin introspection tree. `None` if no root
@@ -687,7 +687,7 @@ pub struct SpawnMeshAdmin {
 wirevalue::register_type!(SpawnMeshAdmin);
 
 #[async_trait]
-impl Handler<SpawnMeshAdmin> for HostMeshAgent {
+impl Handler<SpawnMeshAdmin> for HostAgent {
     /// Spawns a [`MeshAdminAgent`] on this host's system proc, waits
     /// for its HTTP server to bind, and replies with the listen
     /// address.
@@ -735,7 +735,7 @@ pub struct SetClientConfig {
 wirevalue::register_type!(SetClientConfig);
 
 #[async_trait]
-impl Handler<SetClientConfig> for HostMeshAgent {
+impl Handler<SetClientConfig> for HostAgent {
     async fn handle(&mut self, cx: &Context<Self>, msg: SetClientConfig) -> anyhow::Result<()> {
         // Use `set` (not `create_or_merge`) because `push_config` always
         // sends a complete `propagatable_attrs()` snapshot. Replacing the
@@ -760,7 +760,7 @@ pub struct GetLocalProc {
 }
 
 #[async_trait]
-impl Handler<GetLocalProc> for HostMeshAgent {
+impl Handler<GetLocalProc> for HostAgent {
     async fn handle(
         &mut self,
         cx: &Context<Self>,
@@ -780,7 +780,7 @@ impl Handler<GetLocalProc> for HostMeshAgent {
 }
 
 /// A trampoline actor that spawns a [`Host`], and sends a reference to the
-/// corresponding [`HostMeshAgent`] to the provided reply port.
+/// corresponding [`HostAgent`] to the provided reply port.
 ///
 /// This is used to bootstrap host meshes from proc meshes.
 #[derive(Debug)]
@@ -789,8 +789,8 @@ impl Handler<GetLocalProc> for HostMeshAgent {
     handlers=[GetHostMeshAgent]
 )]
 pub(crate) struct HostMeshAgentProcMeshTrampoline {
-    host_mesh_agent: ActorHandle<HostMeshAgent>,
-    reply_port: PortRef<ActorRef<HostMeshAgent>>,
+    host_mesh_agent: ActorHandle<HostAgent>,
+    reply_port: PortRef<ActorRef<HostAgent>>,
 }
 
 #[async_trait]
@@ -805,7 +805,7 @@ impl Actor for HostMeshAgentProcMeshTrampoline {
 impl hyperactor::RemoteSpawn for HostMeshAgentProcMeshTrampoline {
     type Params = (
         ChannelTransport,
-        PortRef<ActorRef<HostMeshAgent>>,
+        PortRef<ActorRef<HostAgent>>,
         Option<BootstrapCommand>,
         bool, /* local? */
     );
@@ -836,7 +836,7 @@ impl hyperactor::RemoteSpawn for HostMeshAgentProcMeshTrampoline {
 
         let system_proc = host.system_proc().clone();
         let host_mesh_agent =
-            system_proc.spawn(HOST_MESH_AGENT_ACTOR_NAME, HostMeshAgent::new(host))?;
+            system_proc.spawn(HOST_MESH_AGENT_ACTOR_NAME, HostAgent::new(host))?;
 
         Ok(Self {
             host_mesh_agent,
@@ -848,7 +848,7 @@ impl hyperactor::RemoteSpawn for HostMeshAgentProcMeshTrampoline {
 #[derive(Serialize, Deserialize, Debug, Named, Handler, RefClient)]
 pub struct GetHostMeshAgent {
     #[reply]
-    pub host_mesh_agent: PortRef<ActorRef<HostMeshAgent>>,
+    pub host_mesh_agent: PortRef<ActorRef<HostAgent>>,
 }
 wirevalue::register_type!(GetHostMeshAgent);
 
@@ -893,7 +893,7 @@ mod tests {
         let host_agent = system_proc
             .spawn(
                 HOST_MESH_AGENT_ACTOR_NAME,
-                HostMeshAgent::new(HostAgentMode::Process {
+                HostAgent::new(HostAgentMode::Process {
                     host,
                     exit_on_shutdown: false,
                 }),

--- a/hyperactor_mesh/src/lib.rs
+++ b/hyperactor_mesh/src/lib.rs
@@ -88,9 +88,9 @@ use serde::Serialize;
 use typeuri::Named;
 pub use value_mesh::ValueMesh;
 
-use crate::host_mesh::HostMeshAgent;
+use crate::host_mesh::HostAgent;
 use crate::host_mesh::HostMeshRefParseError;
-use crate::host_mesh::mesh_agent::ProcState;
+use crate::host_mesh::host_agent::ProcState;
 use crate::resource::RankedValues;
 use crate::resource::Status;
 use crate::shortuuid::ShortUuid;
@@ -172,7 +172,7 @@ pub enum Error {
     ProcCreationError {
         state: Box<resource::State<ProcState>>,
         host_rank: usize,
-        mesh_agent: ActorRef<HostMeshAgent>,
+        mesh_agent: ActorRef<HostAgent>,
     },
 
     #[error(

--- a/hyperactor_mesh/src/mesh_admin.rs
+++ b/hyperactor_mesh/src/mesh_admin.rs
@@ -17,7 +17,7 @@
 //! Incoming HTTP requests are bridged into the actor message loop
 //! using `ResolveReferenceMessage`, ensuring that all topology
 //! resolution and data collection happens through actor messaging.
-//! The agent fans out to `HostMeshAgent` instances to fetch host,
+//! The agent fans out to `HostAgent` instances to fetch host,
 //! proc, and actor details, then normalizes them into a single
 //! tree-shaped model (`NodeProperties` + children references)
 //! suitable for topology-agnostic clients such as the admin TUI.
@@ -147,8 +147,8 @@ use tokio::net::TcpListener;
 use tokio_rustls::TlsAcceptor;
 use typeuri::Named;
 
-use crate::host_mesh::mesh_agent::HostId;
-use crate::host_mesh::mesh_agent::HostMeshAgent;
+use crate::host_mesh::host_agent::HostAgent;
+use crate::host_mesh::host_agent::HostId;
 
 /// Actor name used when spawning the mesh admin agent.
 pub const MESH_ADMIN_ACTOR_NAME: &str = "mesh_admin";
@@ -331,7 +331,7 @@ wirevalue::register_type!(ResolveReferenceMessage);
 /// Actor that serves a mesh-level admin HTTP endpoint.
 ///
 /// `MeshAdminAgent` is the mesh-wide aggregation point for
-/// introspection: it holds `ActorRef<HostMeshAgent>` handles for each
+/// introspection: it holds `ActorRef<HostAgent>` handles for each
 /// host, and answers admin queries by forwarding targeted requests to
 /// the appropriate host agent and assembling a uniform `NodePayload`
 /// response for the client.
@@ -342,11 +342,11 @@ wirevalue::register_type!(ResolveReferenceMessage);
 /// plus child references.
 #[hyperactor::export(handlers = [MeshAdminMessage, ResolveReferenceMessage])]
 pub struct MeshAdminAgent {
-    /// Map of host address string → `HostMeshAgent` reference used to
+    /// Map of host address string → `HostAgent` reference used to
     /// fan out or target admin queries.
-    hosts: HashMap<String, ActorRef<HostMeshAgent>>,
+    hosts: HashMap<String, ActorRef<HostAgent>>,
 
-    /// Reverse index: `HostMeshAgent` `ActorId` → host address
+    /// Reverse index: `HostAgent` `ActorId` → host address
     /// string.
     ///
     /// The host agent itself is an actor that can appear in multiple
@@ -408,7 +408,7 @@ impl MeshAdminAgent {
     ///
     /// Builds both:
     /// - `hosts`: the forward map used to route admin queries to the
-    ///   correct `HostMeshAgent`, and
+    ///   correct `HostAgent`, and
     /// - `host_agents_by_actor_id`: a reverse index used during
     ///   reference resolution to recognize host-agent `ActorId`s and
     ///   resolve them as `NodeProperties::Host` rather than as
@@ -421,7 +421,7 @@ impl MeshAdminAgent {
     /// The HTTP listen address is initialized to `None` and populated
     /// during `init()` after the server socket is bound.
     pub fn new(
-        hosts: Vec<(String, ActorRef<HostMeshAgent>)>,
+        hosts: Vec<(String, ActorRef<HostAgent>)>,
         root_client_actor_id: Option<ActorId>,
         admin_addr: Option<std::net::SocketAddr>,
     ) -> Self {
@@ -746,7 +746,7 @@ impl MeshAdminAgent {
 
         // Host refs use the "host:<actor_id>" format so they are
         // unambiguous from plain actor references. The same
-        // HostMeshAgent ActorId can appear both as a host (from root)
+        // HostAgent ActorId can appear both as a host (from root)
         // and as an actor (from a proc's children list).
         if let Ok(host_id) = reference_string.parse::<HostId>() {
             return self.resolve_host_node(cx, &host_id.0).await;
@@ -794,7 +794,7 @@ impl MeshAdminAgent {
     ///
     /// The root is not a real actor/proc; it's a convenience node
     /// that anchors navigation. Its children are the configured
-    /// `HostMeshAgent` actor IDs (as reference strings) plus any
+    /// `HostAgent` actor IDs (as reference strings) plus any
     /// standalone procs (root client proc, admin proc).
     fn build_root_payload(&self) -> NodePayload {
         let mut children: Vec<String> = self
@@ -823,11 +823,11 @@ impl MeshAdminAgent {
         }
     }
 
-    /// Resolve a `HostMeshAgent` actor reference into a host-level
+    /// Resolve a `HostAgent` actor reference into a host-level
     /// `NodePayload`.
     ///
     /// Sends `IntrospectMessage::Query` directly to the
-    /// `HostMeshAgent`, which returns a `NodePayload` with
+    /// `HostAgent`, which returns a `NodePayload` with
     /// `NodeProperties::Host` and the host's children. The resolver
     /// overrides `parent` to `"root"` since the host agent
     /// doesn't know its position in the navigation tree.
@@ -860,7 +860,7 @@ impl MeshAdminAgent {
     /// Resolve a `ProcId` reference into a proc-level `NodePayload`.
     ///
     /// First tries `IntrospectMessage::QueryChild` against the owning
-    /// `HostMeshAgent` (system procs). If that returns an error
+    /// `HostAgent` (system procs). If that returns an error
     /// payload, falls back to sending `IntrospectMessage::Query` to
     /// the conventional `ProcAgent` actor (`<proc_id>/agent[0]`)
     /// for user procs.
@@ -942,7 +942,7 @@ impl MeshAdminAgent {
     /// Resolve a standalone proc into a proc-level `NodePayload`.
     ///
     /// Standalone procs (e.g. `mesh_root_client_proc`, the admin
-    /// proc) are not managed by any `HostMeshAgent`, so
+    /// proc) are not managed by any `HostAgent`, so
     /// `resolve_proc_node` cannot resolve them. Instead, we query the
     /// anchor actor on the proc for its introspection data, collect
     /// its supervision children, and build a synthetic proc node.
@@ -1057,7 +1057,7 @@ impl MeshAdminAgent {
             cx.introspect_payload()
         } else if self.is_standalone_proc_actor(actor_id) {
             // Standalone procs (e.g. mesh_root_client_proc) have no
-            // ProcMeshAgent at agent[0], so skip the QueryChild
+            // ProcAgent at agent[0], so skip the QueryChild
             // terminated-snapshot check and query the actor directly.
             let introspect_port = PortRef::<IntrospectMessage>::attest_message_port(actor_id);
             let (reply_handle, reply_rx) = open_once_port::<NodePayload>(cx);
@@ -1443,7 +1443,7 @@ async fn tree_dump(
 ///
 /// Extracts the proc name — the meaningful identifier for tree
 /// display — from the various reference formats emitted by
-/// `HostMeshAgent`'s children list:
+/// `HostAgent`'s children list:
 ///
 /// - System proc ref `"[system] unix:@hash,service"` → `"service"`
 /// - ProcAgent ActorId `"unix:@hash,my_proc,agent[0]"` →
@@ -1759,8 +1759,8 @@ mod tests {
         let actor_id1 = ActorId::root(proc1, "mesh_agent".to_string());
         let actor_id2 = ActorId::root(proc2, "mesh_agent".to_string());
 
-        let ref1: ActorRef<HostMeshAgent> = ActorRef::attest(actor_id1.clone());
-        let ref2: ActorRef<HostMeshAgent> = ActorRef::attest(actor_id2.clone());
+        let ref1: ActorRef<HostAgent> = ActorRef::attest(actor_id1.clone());
+        let ref2: ActorRef<HostAgent> = ActorRef::attest(actor_id2.clone());
 
         let agent = MeshAdminAgent::new(
             vec![("host_a".to_string(), ref1), ("host_b".to_string(), ref2)],
@@ -1792,7 +1792,7 @@ mod tests {
     // End-to-end smoke test for MeshAdminAgent::resolve that walks
     // the reference tree: root → host → system proc → host-agent
     // cross-reference. Verifies the reverse index routes the
-    // HostMeshAgent ActorId to NodeProperties::Host (not Actor),
+    // HostAgent ActorId to NodeProperties::Host (not Actor),
     // preventing the TUI's cycle detection from dropping that node.
     #[tokio::test]
     async fn test_resolve_reference_tree_walk() {
@@ -1801,11 +1801,11 @@ mod tests {
         use hyperactor::host::Host;
         use hyperactor::host::LocalProcManager;
 
-        use crate::host_mesh::mesh_agent::HostAgentMode;
-        use crate::host_mesh::mesh_agent::ProcManagerSpawnFn;
+        use crate::host_mesh::host_agent::HostAgentMode;
+        use crate::host_mesh::host_agent::ProcManagerSpawnFn;
         use crate::proc_agent::ProcAgent;
 
-        // -- 1. Stand up a local in-process Host with a HostMeshAgent --
+        // -- 1. Stand up a local in-process Host with a HostAgent --
         // Use Unix transport for all procs — Local transport does not
         // support cross-proc message routing.
         let spawn: ProcManagerSpawnFn =
@@ -1819,11 +1819,11 @@ mod tests {
         let system_proc = host.system_proc().clone();
         let host_agent_handle = system_proc
             .spawn(
-                crate::host_mesh::mesh_agent::HOST_MESH_AGENT_ACTOR_NAME,
-                HostMeshAgent::new(HostAgentMode::Local(host)),
+                crate::host_mesh::host_agent::HOST_MESH_AGENT_ACTOR_NAME,
+                HostAgent::new(HostAgentMode::Local(host)),
             )
             .unwrap();
-        let host_agent_ref: ActorRef<HostMeshAgent> = host_agent_handle.bind();
+        let host_agent_ref: ActorRef<HostAgent> = host_agent_handle.bind();
         let host_addr_str = host_addr.to_string();
 
         // -- 2. Spawn MeshAdminAgent on a separate proc --
@@ -1905,7 +1905,7 @@ mod tests {
             panic!("expected Proc properties, got {:?}", proc_node.properties);
         }
         assert_eq!(proc_node.parent, Some(host_child_ref_str.clone()));
-        // The system proc should have at least the "agent" actor.
+        // The system proc should have at least the "host_agent" actor.
         assert!(
             !proc_node.children.is_empty(),
             "proc should have at least one actor child"
@@ -1913,7 +1913,7 @@ mod tests {
 
         // -- 7. Cross-reference: system proc child is the host agent --
         //
-        // The service proc's actor (agent[0]) IS the HostMeshAgent, so
+        // The service proc's actor (agent[0]) IS the HostAgent, so
         // it appears both as a host node (from root, via HostId) and
         // as an actor (from a proc's children list, via plain ActorId).
         // HostId in root children makes resolution unambiguous: host
@@ -1962,14 +1962,14 @@ mod tests {
         use hyperactor::host::LocalProcManager;
 
         use crate::Name;
-        use crate::host_mesh::mesh_agent::HostAgentMode;
-        use crate::host_mesh::mesh_agent::ProcManagerSpawnFn;
+        use crate::host_mesh::host_agent::HostAgentMode;
+        use crate::host_mesh::host_agent::ProcManagerSpawnFn;
         use crate::proc_agent::ProcAgent;
         use crate::resource;
         use crate::resource::ProcSpec;
         use crate::resource::Rank;
 
-        // Stand up a local in-process Host with a HostMeshAgent.
+        // Stand up a local in-process Host with a HostAgent.
         let spawn: ProcManagerSpawnFn =
             Box::new(|proc| Box::pin(std::future::ready(ProcAgent::boot_v1(proc, None))));
         let manager: LocalProcManager<ProcManagerSpawnFn> = LocalProcManager::new(spawn);
@@ -1981,11 +1981,11 @@ mod tests {
         let system_proc = host.system_proc().clone();
         let host_agent_handle = system_proc
             .spawn(
-                crate::host_mesh::mesh_agent::HOST_MESH_AGENT_ACTOR_NAME,
-                HostMeshAgent::new(HostAgentMode::Local(host)),
+                crate::host_mesh::host_agent::HOST_MESH_AGENT_ACTOR_NAME,
+                HostAgent::new(HostAgentMode::Local(host)),
             )
             .unwrap();
-        let host_agent_ref: ActorRef<HostMeshAgent> = host_agent_handle.bind();
+        let host_agent_ref: ActorRef<HostAgent> = host_agent_handle.bind();
         let host_addr_str = host_addr.to_string();
 
         // Spawn MeshAdminAgent on a separate proc.
@@ -2087,7 +2087,7 @@ mod tests {
         let addr1: SocketAddr = "127.0.0.1:9001".parse().unwrap();
         let proc1 = ProcId::Direct(ChannelAddr::Tcp(addr1), "host1".to_string());
         let actor_id1 = ActorId::root(proc1, "mesh_agent".to_string());
-        let ref1: ActorRef<HostMeshAgent> = ActorRef::attest(actor_id1.clone());
+        let ref1: ActorRef<HostAgent> = ActorRef::attest(actor_id1.clone());
 
         let client_proc_id =
             ProcId::Direct(ChannelAddr::Tcp(addr1), "mesh_root_client_proc".to_string());
@@ -2125,11 +2125,11 @@ mod tests {
         use hyperactor::host::Host;
         use hyperactor::host::LocalProcManager;
 
-        use crate::host_mesh::mesh_agent::HostAgentMode;
-        use crate::host_mesh::mesh_agent::ProcManagerSpawnFn;
+        use crate::host_mesh::host_agent::HostAgentMode;
+        use crate::host_mesh::host_agent::ProcManagerSpawnFn;
         use crate::proc_agent::ProcAgent;
 
-        // Stand up a local in-process Host with a HostMeshAgent.
+        // Stand up a local in-process Host with a HostAgent.
         let spawn: ProcManagerSpawnFn =
             Box::new(|proc| Box::pin(std::future::ready(ProcAgent::boot_v1(proc, None))));
         let manager: LocalProcManager<ProcManagerSpawnFn> = LocalProcManager::new(spawn);
@@ -2141,11 +2141,11 @@ mod tests {
         let system_proc = host.system_proc().clone();
         let host_agent_handle = system_proc
             .spawn(
-                crate::host_mesh::mesh_agent::HOST_MESH_AGENT_ACTOR_NAME,
-                HostMeshAgent::new(HostAgentMode::Local(host)),
+                crate::host_mesh::host_agent::HOST_MESH_AGENT_ACTOR_NAME,
+                HostAgent::new(HostAgentMode::Local(host)),
             )
             .unwrap();
-        let host_agent_ref: ActorRef<HostMeshAgent> = host_agent_handle.bind();
+        let host_agent_ref: ActorRef<HostAgent> = host_agent_handle.bind();
         let host_addr_str = host_addr.to_string();
 
         // Create a genuinely introspectable root client actor.
@@ -2284,11 +2284,11 @@ mod tests {
         use hyperactor::host::Host;
         use hyperactor::host::LocalProcManager;
 
-        use crate::host_mesh::mesh_agent::HostAgentMode;
-        use crate::host_mesh::mesh_agent::ProcManagerSpawnFn;
+        use crate::host_mesh::host_agent::HostAgentMode;
+        use crate::host_mesh::host_agent::ProcManagerSpawnFn;
         use crate::proc_agent::ProcAgent;
 
-        // Stand up a local host with a HostMeshAgent.
+        // Stand up a local host with a HostAgent.
         let spawn: ProcManagerSpawnFn =
             Box::new(|proc| Box::pin(std::future::ready(ProcAgent::boot_v1(proc, None))));
         let manager: LocalProcManager<ProcManagerSpawnFn> = LocalProcManager::new(spawn);
@@ -2300,11 +2300,11 @@ mod tests {
         let system_proc = host.system_proc().clone();
         let host_agent_handle = system_proc
             .spawn(
-                crate::host_mesh::mesh_agent::HOST_MESH_AGENT_ACTOR_NAME,
-                HostMeshAgent::new(HostAgentMode::Local(host)),
+                crate::host_mesh::host_agent::HOST_MESH_AGENT_ACTOR_NAME,
+                HostAgent::new(HostAgentMode::Local(host)),
             )
             .unwrap();
-        let host_agent_ref: ActorRef<HostMeshAgent> = host_agent_handle.bind();
+        let host_agent_ref: ActorRef<HostAgent> = host_agent_handle.bind();
         let host_addr_str = host_addr.to_string();
 
         // Spawn MeshAdminAgent on a separate proc.
@@ -2389,11 +2389,11 @@ mod tests {
         use hyperactor::host::Host;
         use hyperactor::host::LocalProcManager;
 
-        use crate::host_mesh::mesh_agent::HostAgentMode;
-        use crate::host_mesh::mesh_agent::ProcManagerSpawnFn;
+        use crate::host_mesh::host_agent::HostAgentMode;
+        use crate::host_mesh::host_agent::ProcManagerSpawnFn;
         use crate::proc_agent::ProcAgent;
 
-        // -- 1. Stand up a local in-process Host with a HostMeshAgent --
+        // -- 1. Stand up a local in-process Host with a HostAgent --
         let spawn: ProcManagerSpawnFn =
             Box::new(|proc| Box::pin(std::future::ready(ProcAgent::boot_v1(proc, None))));
         let manager: LocalProcManager<ProcManagerSpawnFn> = LocalProcManager::new(spawn);
@@ -2406,11 +2406,11 @@ mod tests {
         let system_proc_id = system_proc.proc_id().clone();
         let host_agent_handle = system_proc
             .spawn(
-                crate::host_mesh::mesh_agent::HOST_MESH_AGENT_ACTOR_NAME,
-                HostMeshAgent::new(HostAgentMode::Local(host)),
+                crate::host_mesh::host_agent::HOST_MESH_AGENT_ACTOR_NAME,
+                HostAgent::new(HostAgentMode::Local(host)),
             )
             .unwrap();
-        let host_agent_ref: ActorRef<HostMeshAgent> = host_agent_handle.bind();
+        let host_agent_ref: ActorRef<HostAgent> = host_agent_handle.bind();
         let host_addr_str = host_addr.to_string();
 
         // -- 2. Spawn MeshAdminAgent on a separate proc --

--- a/hyperactor_mesh/src/proc_mesh.rs
+++ b/hyperactor_mesh/src/proc_mesh.rs
@@ -68,7 +68,7 @@ use crate::alloc::AllocExt;
 use crate::alloc::AllocatedProc;
 use crate::assign::Ranks;
 use crate::comm::CommMeshConfig;
-use crate::host_mesh::mesh_agent::ProcState;
+use crate::host_mesh::host_agent::ProcState;
 use crate::host_mesh::mesh_to_rankedvalues_with_default;
 use crate::mesh_controller::ActorMeshController;
 use crate::proc_agent;

--- a/hyperactor_mesh/src/resource.rs
+++ b/hyperactor_mesh/src/resource.rs
@@ -45,7 +45,7 @@ use typeuri::Named;
 use crate::Name;
 use crate::StatusOverlay;
 use crate::bootstrap;
-use crate::host_mesh::mesh_agent::ProcState;
+use crate::host_mesh::host_agent::ProcState;
 use crate::proc_agent::ActorSpec;
 use crate::proc_agent::ActorState;
 

--- a/hyperactor_telemetry/src/lib.rs
+++ b/hyperactor_telemetry/src/lib.rs
@@ -290,7 +290,7 @@ lazy_static! {
     /// Global unified entity event dispatcher with pre-registration buffering.
     /// Events emitted before a dispatcher is registered are buffered and replayed
     /// when `set_entity_dispatcher` is called. This ensures bootstrap actors
-    /// (e.g., HostMeshAgent and ProcAgent) are captured even though they are spawned before the
+    /// (e.g., HostAgent and ProcAgent) are captured even though they are spawned before the
     /// telemetry system is initialized.
     static ref ENTITY_EVENT_STATE: Mutex<EntityEventState> = Mutex::new(
         EntityEventState::Buffering(Vec::new())

--- a/monarch_dashboard/fake_data/generate.py
+++ b/monarch_dashboard/fake_data/generate.py
@@ -4,15 +4,17 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+# pyre-unsafe
+
 """Deterministic fake data generator for the Monarch Dashboard.
 
 Produces a SQLite database with realistic Monarch telemetry data spanning
 a 5-minute window. The topology includes 2 host meshes, 2 procs per host,
-and 4 actors per host mesh (1 system ProcMeshAgent + 1 user actor per proc).
+and 4 actors per host mesh (1 system ProcAgent + 1 user actor per proc).
 
 The generated data exercises all dashboard features:
   - Full mesh hierarchy (host -> proc -> actor meshes)
-  - System actors (HostMeshAgent, ProcMeshAgent) and user actors
+  - System actors (HostAgent, ProcAgent) and user actors
   - Complete ActorStatus lifecycle with failure at T=4:00
   - Non-sparse message traffic across multiple endpoints
   - Death propagation from a failed actor to its mesh siblings
@@ -254,8 +256,8 @@ def _generate_meshes() -> list[dict]:
 def _generate_actors(meshes: list[dict]) -> list[dict]:
     """Create actors for each mesh.
 
-    For each host mesh: 1 HostMeshAgent (rank 0).
-    For each proc mesh: 1 ProcMeshAgent (rank 0).
+    For each host mesh: 1 HostAgent (rank 0).
+    For each proc mesh: 1 ProcAgent (rank 0).
     For each actor mesh: 1 PythonActor<Trainer> user actor (rank 0).
 
     This yields 2 + 4 + 4 = 10 actors total.
@@ -275,7 +277,7 @@ def _generate_actors(meshes: list[dict]) -> list[dict]:
                     "timestamp_us": ts,
                     "mesh_id": m["id"],
                     "rank": 0,
-                    "full_name": f"{m['full_name']}/HostMeshAgent[0]",
+                    "full_name": f"{m['full_name']}/HostAgent[0]",
                 }
             )
         elif cls == "Proc":
@@ -285,7 +287,7 @@ def _generate_actors(meshes: list[dict]) -> list[dict]:
                     "timestamp_us": ts,
                     "mesh_id": m["id"],
                     "rank": 0,
-                    "full_name": f"{m['full_name']}/ProcMeshAgent[0]",
+                    "full_name": f"{m['full_name']}/ProcAgent[0]",
                 }
             )
         else:

--- a/monarch_dashboard/fake_data/tests/test_generate.py
+++ b/monarch_dashboard/fake_data/tests/test_generate.py
@@ -4,6 +4,8 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+# pyre-unsafe
+
 """Tests for the Monarch Dashboard fake data generator.
 
 Validates that the generated SQLite database conforms to the data contract
@@ -13,7 +15,7 @@ defined in the data contract, including:
   - 5-minute timeline with actor failure at minute 4
   - All ActorStatus enum values are exercised
   - Non-sparse message data
-  - Proper system actor (HostMeshAgent/ProcMeshAgent) and user actor presence
+  - Proper system actor (HostAgent/ProcAgent) and user actor presence
   - Death propagation semantics
   - Deterministic (reproducible) output
 """
@@ -221,19 +223,19 @@ class ActorTest(unittest.TestCase):
         os.remove(cls.db_path)
 
     def test_total_actor_count(self):
-        """10 actors: 2 HostMeshAgent + 4 ProcMeshAgent + 4 user actors."""
+        """10 actors: 2 HostAgent + 4 ProcAgent + 4 user actors."""
         count = self.conn.execute("SELECT COUNT(*) FROM actors").fetchone()[0]
         self.assertEqual(count, 10)
 
     def test_host_mesh_agents(self):
         rows = self.conn.execute(
-            "SELECT * FROM actors WHERE full_name LIKE '%HostMeshAgent%'"
+            "SELECT * FROM actors WHERE full_name LIKE '%HostAgent%'"
         ).fetchall()
         self.assertEqual(len(rows), 2)
 
     def test_proc_mesh_agents(self):
         rows = self.conn.execute(
-            "SELECT * FROM actors WHERE full_name LIKE '%ProcMeshAgent%'"
+            "SELECT * FROM actors WHERE full_name LIKE '%ProcAgent%'"
         ).fetchall()
         self.assertEqual(len(rows), 4)
 
@@ -258,16 +260,16 @@ class ActorTest(unittest.TestCase):
         """Each host mesh should have 4 actors in its subtree.
 
         host -> proc meshes -> actor meshes, each with one actor, plus
-        the host-level HostMeshAgent and proc-level ProcMeshAgents.
+        the host-level HostAgent and proc-level ProcMeshAgents.
         That's 1 (host agent) + 2 (proc agents) + 2 (user actors) = 5 per host...
         Wait — the plan says "4 actors per host mesh", meaning user+system
         actors linked under the host's subtree.  Our count is:
-          host mesh -> 1 HostMeshAgent
+          host mesh -> 1 HostAgent
           2 proc meshes -> 2 ProcMeshAgents
           2 actor meshes -> 2 user actors
           Total = 5.
         The plan's "4 actors per host mesh" likely counts the proc-level and
-        actor-level entities (excluding the HostMeshAgent itself).  We verify
+        actor-level entities (excluding the HostAgent itself).  We verify
         the subtree total is 5.
         """
         host_ids = [

--- a/monarch_dashboard/frontend/src/__tests__/App.test.tsx
+++ b/monarch_dashboard/frontend/src/__tests__/App.test.tsx
@@ -23,7 +23,7 @@ const MOCK_CHILDREN: any[] = [];
 const MOCK_ACTORS = [
   {
     id: 1, timestamp_us: 1700000000000000, mesh_id: 1,
-    rank: 0, full_name: "/host_mesh_0/HostMeshAgent[0]",
+    rank: 0, full_name: "/host_mesh_0/HostAgent[0]",
   },
 ];
 

--- a/monarch_dashboard/frontend/src/__tests__/SummaryView.test.tsx
+++ b/monarch_dashboard/frontend/src/__tests__/SummaryView.test.tsx
@@ -45,7 +45,7 @@ const MOCK_SUMMARY = {
     stopped_actors: [
       {
         actor_id: 6,
-        full_name: "//root/host_mesh_1/proc_mesh_1_1/ProcMeshAgent[0]",
+        full_name: "//root/host_mesh_1/proc_mesh_1_1/ProcAgent[0]",
         reason: "death propagation from proc_mesh_1_1",
         timestamp_us: 1700000250000000,
         mesh_id: 6,

--- a/monarch_dashboard/frontend/src/__tests__/dagLayout.test.ts
+++ b/monarch_dashboard/frontend/src/__tests__/dagLayout.test.ts
@@ -20,9 +20,9 @@ const meshes: Mesh[] = [
 ];
 
 const actors: Actor[] = [
-  { id: 1, timestamp_us: 0, mesh_id: 3, rank: 0, full_name: "ProcMeshAgent[0,0]" },
+  { id: 1, timestamp_us: 0, mesh_id: 3, rank: 0, full_name: "ProcAgent[0,0]" },
   { id: 2, timestamp_us: 0, mesh_id: 7, rank: 0, full_name: "PythonActor<Trainer>[0,0]" },
-  { id: 3, timestamp_us: 0, mesh_id: 4, rank: 0, full_name: "ProcMeshAgent[0,1]" },
+  { id: 3, timestamp_us: 0, mesh_id: 4, rank: 0, full_name: "ProcAgent[0,1]" },
   { id: 4, timestamp_us: 0, mesh_id: 8, rank: 0, full_name: "PythonActor<Trainer>[0,1]" },
 ];
 

--- a/monarch_hyperactor/src/actor.rs
+++ b/monarch_hyperactor/src/actor.rs
@@ -1513,7 +1513,7 @@ mod tests {
     use hyperactor::reference::UnboundPort;
     use hyperactor_mesh::Error as MeshError;
     use hyperactor_mesh::Name;
-    use hyperactor_mesh::host_mesh::mesh_agent::ProcState;
+    use hyperactor_mesh::host_mesh::host_agent::ProcState;
     use hyperactor_mesh::resource::Status;
     use hyperactor_mesh::resource::{self};
     use pyo3::PyTypeInfo;
@@ -1609,7 +1609,7 @@ mod tests {
             assert!(py_msg.contains(", state: "));
             assert!(py_msg.contains("\"status\":{\"Failed\":\"boom\"}"));
             // 3) Starts with the expected prefix
-            let expected_prefix = "error creating proc (host rank 0) on host mesh agent hello[0].actor[0]<hyperactor_mesh::host_mesh::mesh_agent::HostMeshAgent>";
+            let expected_prefix = "error creating proc (host rank 0) on host mesh agent hello[0].actor[0]<hyperactor_mesh::host_mesh::host_agent::HostAgent>";
             assert!(py_msg.starts_with(expected_prefix));
         });
     }

--- a/monarch_hyperactor/src/host_mesh.rs
+++ b/monarch_hyperactor/src/host_mesh.rs
@@ -20,9 +20,9 @@ use hyperactor_mesh::bootstrap::BootstrapCommand;
 use hyperactor_mesh::bootstrap::host;
 use hyperactor_mesh::host_mesh::HostMesh;
 use hyperactor_mesh::host_mesh::HostMeshRef;
-use hyperactor_mesh::host_mesh::mesh_agent::GetLocalProcClient;
-use hyperactor_mesh::host_mesh::mesh_agent::HostMeshAgent;
-use hyperactor_mesh::host_mesh::mesh_agent::ShutdownHost;
+use hyperactor_mesh::host_mesh::host_agent::GetLocalProcClient;
+use hyperactor_mesh::host_mesh::host_agent::HostAgent;
+use hyperactor_mesh::host_mesh::host_agent::ShutdownHost;
 use hyperactor_mesh::proc_agent::GetProcClient;
 use hyperactor_mesh::proc_mesh::ProcRef;
 use hyperactor_mesh::shared_cell::SharedCell;
@@ -287,7 +287,7 @@ impl PyHostMeshRefImpl {
 static ROOT_CLIENT_INSTANCE_FOR_HOST: OnceLock<Instance<PythonActor>> = OnceLock::new();
 
 /// Static storage for the host mesh agent created by bootstrap_host().
-static HOST_MESH_AGENT_FOR_HOST: OnceLock<ActorHandle<HostMeshAgent>> = OnceLock::new();
+static HOST_MESH_AGENT_FOR_HOST: OnceLock<ActorHandle<HostAgent>> = OnceLock::new();
 
 /// Bootstrap the client host and root client actor.
 ///

--- a/python/monarch/_src/actor/proc_launcher.py
+++ b/python/monarch/_src/actor/proc_launcher.py
@@ -75,7 +75,7 @@ class ProcLauncher(Actor, ABC):
     Implementations control how procs are spawned (Docker, VMs, custom
     orchestrators, etc.) while Monarch handles lifecycle wiring.
 
-    The launcher runs in the same proc as HostMeshAgent.
+    The launcher runs in the same proc as HostAgent.
     """
 
     def __init__(self, params: dict[str, Any] | None = None) -> None:

--- a/python/tests/test_distributed_telemetry.py
+++ b/python/tests/test_distributed_telemetry.py
@@ -378,7 +378,7 @@ def test_actors_join_meshes_on_mesh_id(cleanup_callbacks) -> None:
 
 @pytest.mark.timeout(120)
 def test_bootstrap_actors_captured(cleanup_callbacks) -> None:
-    """Test that bootstrap actors (ProcAgent, HostMeshAgent) are captured in the actors table.
+    """Test that bootstrap actors (ProcAgent, HostAgent) are captured in the actors table.
 
     These actors are spawned during process bootstrap, before `set_entity_dispatcher`
     is called. The buffering mechanism in `hyperactor_telemetry` should buffer their
@@ -395,7 +395,7 @@ def test_bootstrap_actors_captured(cleanup_callbacks) -> None:
     result = engine.query("SELECT full_name FROM actors")
     full_names = result.to_pydict().get("full_name", [])
 
-    # The Bootstrap actor HostMeshAgent is spawned with name "agent",
+    # The Bootstrap actor HostAgent is spawned with name "host_agent",
     # ProcAgent has the name "proc_agent".
     # Their full_name looks like "unix:@...,<proc>,agent[0]".
     agent_names = [
@@ -403,11 +403,11 @@ def test_bootstrap_actors_captured(cleanup_callbacks) -> None:
     ]
 
     # TODO: Enable this after finding discrepancy between OSS and internal test
-    # # Verify the HostMeshAgent (on the "service" proc) was captured.
+    # # Verify the HostAgent (on the "service" proc) was captured.
     # # This is the first actor spawned during bootstrap, before set_entity_dispatcher.
     # has_host_mesh_agent = any(",service,agent[" in name for name in full_names)
     # assert has_host_mesh_agent, (
-    #     f"Expected HostMeshAgent on service proc, but not found. "
+    #     f"Expected HostAgent on service proc, but not found. "
     #     f"Agent actors: {agent_names}"
     # )
 


### PR DESCRIPTION
Summary:
Same as https://github.com/meta-pytorch/monarch/pull/2811 but extended to changing
HostMeshAgent -> HostAgent.
Also rename the actor id from "agent" -> "host_agent". It is no longer ambiguous with
ProcAgent, but it is still more descriptive in case we add other agents in the future.

Reviewed By: thedavekwon

Differential Revision: D94689187
