### PR TITLE
fix: remove inline publish_introspect_properties from supervision handler to unblock ProcAgent

### DIFF
--- a/hyper/Cargo.toml
+++ b/hyper/Cargo.toml
@@ -17,6 +17,7 @@ fbinit-tokio = { version = "0.1.2", git = "https://github.com/facebookexperiment
 hyperactor = { version = "0.0.0", path = "../hyperactor" }
 hyperactor_mesh = { version = "0.0.0", path = "../hyperactor_mesh" }
 serde_json = { version = "1.0.140", features = ["alloc", "float_roundtrip", "raw_value", "unbounded_depth"] }
+tokio = { version = "1.47.1", features = ["full", "test-util", "tracing"] }
 
 [lints]
 rust = { unexpected_cfgs = { check-cfg = ["cfg(fbcode_build)"], level = "warn" } }

--- a/hyperactor_mesh/src/proc_agent.rs
+++ b/hyperactor_mesh/src/proc_agent.rs
@@ -575,8 +575,14 @@ impl Handler<ActorSupervisionEvent> for ProcAgent {
                 .entry(event.actor_id.clone())
                 .or_default()
                 .push(event.clone());
-            // Republish so introspection picks up is_poisoned / failed_actor_count.
-            self.publish_introspect_properties(cx);
+            // TODO(T257699334): republish introspect properties so the
+            // TUI picks up is_poisoned / failed_actor_count immediately.
+            // Calling publish_introspect_properties inline here is a
+            // known regression: it iterates all live + terminated
+            // actors to rebuild the children list, blocking the
+            // ProcAgent message loop and starving GetRankStatus polls.
+            // Follow up with a deferred + coalesced republish (dirty
+            // flag + self-message) so the handler returns immediately.
         }
         if let Some(supervisor) = self.state.supervisor() {
             supervisor.send(cx, event)?;

--- a/python/tests/test_failure_introspection.py
+++ b/python/tests/test_failure_introspection.py
@@ -57,8 +57,14 @@ def _encode(ref: str) -> str:
     return urllib.parse.quote(ref, safe="")
 
 
+# T257699334 (SF, 2026-03-02): publish_introspect_properties was removed
+# from the supervision event handler to avoid blocking the ProcAgent
+# message loop (starves GetRankStatus polls). is_poisoned won't update
+# until a deferred + coalesced republish is implemented. Re-enable when
+# that lands.
 @pytest.mark.timeout(60)
 @parametrize_config(actor_queue_dispatch={True, False})
+@pytest.mark.skip(reason="Needs deferred republish of introspect properties")
 async def test_failed_actor_has_failure_info() -> None:
     """After an actor crashes, its introspection payload has failure_info."""
     original_hook = monarch.actor.unhandled_fault_hook
@@ -128,8 +134,10 @@ async def test_failed_actor_has_failure_info() -> None:
         await procs.stop()
 
 
+# T257699334 (SF, 2026-03-02): same reason as test_failed_actor_has_failure_info above.
 @pytest.mark.timeout(60)
 @parametrize_config(actor_queue_dispatch={True, False})
+@pytest.mark.skip(reason="Needs deferred republish of introspect properties")
 async def test_healthy_procs_not_poisoned() -> None:
     """Procs without failed actors should not be poisoned."""
     original_hook = monarch.actor.unhandled_fault_hook


### PR DESCRIPTION
Summary:
removes the inline publish_introspect_properties call from the supervision event handler because rebuilding the children list synchronously blocks the ProcAgent message loop and starves GetRankStatus polls.

the affected Python failure-introspection tests are temporarily skipped until a deferred, coalesced republish mechanism (dirty flag + self-message) is implemented.

also includes minor cleanup of unused imports in the Python supervision module.

Reviewed By: pzhan9

Differential Revision: D94960791
