### PR TITLE
Fix python interpreter shutdown on monarch procs

### DIFF
--- a/docs/source/examples/getting_started.py
+++ b/docs/source/examples/getting_started.py
@@ -316,11 +316,13 @@ class SupervisorActor(Actor):
 # %%
 # If a MeshFailure is not handled by any __supervise__ in the supervision tree,
 # it will reach the client, where monarch.actor.unhandled_fault_hook will be
-# called with the MeshFailure object. By default, this function crashes the
-# client process with exit code 1.
+# called with the MeshFailure object. By default, this function exits the process
+# with a KeyboardInterrupt.
 
 # You can overwrite the global unhandled_fault_hook function to customize this
-# behavior.
+# behavior. The function can either:
+# - raise any exception (including BaseException) to indicate that the failure was not handled
+# - return any value (including None) to indicate that the failure was handled
 
 import monarch.actor
 

--- a/hyperactor_mesh/src/bootstrap.rs
+++ b/hyperactor_mesh/src/bootstrap.rs
@@ -472,8 +472,9 @@ impl Bootstrap {
     }
 
     /// Bootstrap this binary according to this configuration.
-    /// This either runs forever, or returns an error.
-    pub async fn bootstrap(self) -> anyhow::Error {
+    /// This runs until all processes are ready to exit, or returns an error.
+    /// The Ok value is the exit code that should be used.
+    pub async fn bootstrap(self) -> anyhow::Result<i32> {
         tracing::info!(
             "bootstrapping mesh process: {}",
             serde_json::to_string(&self).unwrap()
@@ -564,33 +565,36 @@ impl Bootstrap {
                 let proc_sender = mailbox::LocalProcDialer::new(
                     local_addr.clone(),
                     socket_dir_path,
-                    ok!(MailboxClient::dial(backend_addr)),
+                    MailboxClient::dial(backend_addr)?,
                 );
 
                 let proc = Proc::configured(proc_id.clone(), proc_sender.into_boxed());
 
                 let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<i32>();
-                let agent_handle = ok!(ProcAgent::boot_v1(proc.clone(), Some(shutdown_tx))
-                    .map_err(|e| HostError::AgentSpawnFailure(proc_id, e)));
+                let agent_handle = ProcAgent::boot_v1(proc.clone(), Some(shutdown_tx))
+                    .map_err(|e| HostError::AgentSpawnFailure(proc_id, e))?;
 
                 let span = entered.exit();
 
                 // Finally serve the proc on the same transport as the backend address,
                 // and call back.
-                let (proc_addr, proc_rx) = ok!(channel::serve(serve_addr));
+                let (proc_addr, proc_rx) = channel::serve(serve_addr)?;
                 let mailbox_handle = proc.clone().serve(proc_rx);
-                ok!(ok!(channel::dial(callback_addr))
+                channel::dial(callback_addr)?
                     .send((proc_addr, agent_handle.bind::<ProcAgent>()))
                     .instrument(span)
                     .await
-                    .map_err(ChannelError::from));
+                    .map_err(ChannelError::from)?;
 
                 // Wait for the StopAll handler to signal the exit code, then
                 // gracefully stop the mailbox server before exiting.
                 let exit_code = shutdown_rx.await.unwrap_or(1);
                 mailbox_handle.stop("process shutting down");
                 let _ = mailbox_handle.await;
-                std::process::exit(exit_code)
+                tracing::info!("bootstrap shutting down with exit code {}", exit_code);
+                // Don't exit the proc, return Ok so the parent function can decide
+                // how to stop.
+                Ok(exit_code)
             }
             Bootstrap::Host {
                 addr,
@@ -599,20 +603,25 @@ impl Bootstrap {
                 exit_on_shutdown,
             } => {
                 let (_agent_handle, shutdown) =
-                    ok!(host(addr, command, config, exit_on_shutdown).await);
+                    host(addr, command, config, exit_on_shutdown).await?;
                 shutdown.join().await;
                 halt().await
             }
-            Bootstrap::V0ProcMesh { config } => bootstrap_v0_proc_mesh(config).await,
+            Bootstrap::V0ProcMesh { config } => Err(bootstrap_v0_proc_mesh(config).await),
         }
     }
 
     /// A variant of [`bootstrap`] that logs the error and exits the process
     /// if bootstrapping fails.
     pub async fn bootstrap_or_die(self) -> ! {
-        let err = self.bootstrap().await;
-        tracing::error!("failed to bootstrap mesh process: {}", err);
-        std::process::exit(1)
+        let exit_code = match self.bootstrap().await {
+            Ok(exit_code) => exit_code,
+            Err(err) => {
+                tracing::error!("failed to bootstrap mesh process: {}", err);
+                1
+            }
+        };
+        std::process::exit(exit_code);
     }
 }
 
@@ -2210,8 +2219,10 @@ impl hyperactor::host::BulkTerminate for BootstrapProcManager {
 /// ```
 ///
 /// Use [`bootstrap_or_die`] to implement this behavior directly.
-pub async fn bootstrap() -> anyhow::Error {
-    let boot = ok!(Bootstrap::get_from_env()).unwrap_or_else(Bootstrap::default);
+/// Else if the bootstrap returns Ok, the process has cleaned up successfully and
+/// should exit the "main" of the program.
+pub async fn bootstrap() -> anyhow::Result<i32> {
+    let boot = Bootstrap::get_from_env()?.unwrap_or_else(Bootstrap::default);
     boot.bootstrap().await
 }
 
@@ -2367,10 +2378,14 @@ async fn bootstrap_v0_proc_mesh(config: Option<Attrs>) -> anyhow::Error {
 /// A variant of [`bootstrap`] that logs the error and exits the process
 /// if bootstrapping fails.
 pub async fn bootstrap_or_die() -> ! {
-    let err = bootstrap().await;
-    let _ = writeln!(Debug, "failed to bootstrap mesh process: {}", err);
-    tracing::error!("failed to bootstrap mesh process: {}", err);
-    std::process::exit(1)
+    match bootstrap().await {
+        Ok(exit_code) => std::process::exit(exit_code),
+        Err(err) => {
+            let _ = writeln!(Debug, "failed to bootstrap mesh process: {}", err);
+            tracing::error!("failed to bootstrap mesh process: {}", err);
+            std::process::exit(1);
+        }
+    }
 }
 
 #[derive(enum_as_inner::EnumAsInner)]

--- a/hyperactor_mesh/src/host_mesh.rs
+++ b/hyperactor_mesh/src/host_mesh.rs
@@ -313,8 +313,10 @@ impl HostMesh {
     /// `boot.bootstrap().await` in those children.
     pub async fn local_with_bootstrap(bootstrap_cmd: BootstrapCommand) -> crate::Result<HostMesh> {
         if let Ok(Some(boot)) = Bootstrap::get_from_env() {
-            let err = boot.bootstrap().await;
-            tracing::error!("failed to bootstrap local host mesh process: {}", err);
+            let result = boot.bootstrap().await;
+            if let Err(err) = result {
+                tracing::error!("failed to bootstrap local host mesh process: {}", err);
+            }
             std::process::exit(1);
         }
 
@@ -410,8 +412,10 @@ impl HostMesh {
     /// TODO: thread through ownership
     pub async fn process(extent: Extent, command: BootstrapCommand) -> crate::Result<HostMesh> {
         if let Ok(Some(boot)) = Bootstrap::get_from_env() {
-            let err = boot.bootstrap().await;
-            tracing::error!("failed to bootstrap process host mesh process: {}", err);
+            let result = boot.bootstrap().await;
+            if let Err(err) = result {
+                tracing::error!("failed to bootstrap process host mesh process: {}", err);
+            }
             std::process::exit(1);
         }
 

--- a/monarch_hyperactor/src/actor.rs
+++ b/monarch_hyperactor/src/actor.rs
@@ -632,11 +632,33 @@ impl PythonActor {
                 // monitor the client ProcAgent for now.
                 tracing::error!(
                     actor_id = %instance.self_id(),
-                    "could not propagate supervision event {} because it reached the global client: exiting the process with code 1",
+                    "could not propagate supervision event {} because it reached the global client: signaling KeyboardInterrupt to main thread",
                     event,
                 );
 
-                std::process::exit(1);
+                // This is running in a background thread, and thus cannot run
+                // Py_FinalizeEx when it exits the process to properly shut down
+                // all python objects.
+                // We use _thread.interrupt_main to raise a KeyboardInterrupt
+                // to the main thread at some point in the future.
+                // There is no way to propagate the exception message, but it
+                // will at least run proper shutdown code as long as BaseException
+                // isn't caught.
+                monarch_with_gil_blocking(|py| {
+                    // Use _thread.interrupt_main to force the client to exit if it has an
+                    // unhandled supervision event.
+                    let thread_mod = py.import("_thread").expect("import _thread");
+                    let interrupt_main = thread_mod
+                        .getattr("interrupt_main")
+                        .expect("get interrupt_main");
+
+                    // Ignore any exception from calling interrupt_main
+                    if let Err(e) = interrupt_main.call0() {
+                        tracing::error!("unable to interrupt main, exiting the process instead: {:?}", e);
+                        eprintln!("unable to interrupt main, exiting the process with code 1 instead: {:?}", e);
+                        std::process::exit(1);
+                    }
+                });
             } else {
                 tracing::info!(actor_id = %instance.self_id(), "client stopped");
             }

--- a/monarch_hyperactor/src/bootstrap.rs
+++ b/monarch_hyperactor/src/bootstrap.rs
@@ -11,7 +11,7 @@ use hyperactor::channel::ChannelAddr;
 use hyperactor_mesh::Bootstrap;
 use hyperactor_mesh::Name;
 use hyperactor_mesh::bootstrap::BootstrapCommand;
-use hyperactor_mesh::bootstrap_or_die;
+use hyperactor_mesh::bootstrap::bootstrap;
 use hyperactor_mesh::host_mesh::HostMesh;
 use monarch_types::MapPyErr;
 use pyo3::Bound;
@@ -19,6 +19,7 @@ use pyo3::PyAny;
 use pyo3::PyResult;
 use pyo3::Python;
 use pyo3::exceptions::PyException;
+use pyo3::exceptions::PyRuntimeError;
 use pyo3::pyfunction;
 use pyo3::types::PyAnyMethods;
 use pyo3::types::PyModule;
@@ -38,13 +39,15 @@ pub fn bootstrap_main(py: Python) -> PyResult<Bound<PyAny>> {
     };
 
     hyperactor::internal_macro_support::tracing::debug!("entering async bootstrap");
-    crate::runtime::future_into_py::<_, ()>(py, async move {
+    crate::runtime::future_into_py::<_, i32>(py, async move {
         // SAFETY:
         // - Only one of these is ever created.
         // - This is the entry point of this program, so this will be dropped when
         // no more FB C++ code is running.
         let _destroy_guard = unsafe { fbinit::DestroyGuard::new() };
-        bootstrap_or_die().await;
+        bootstrap()
+            .await
+            .map_err(|e| PyRuntimeError::new_err(format!("{:?}", e)))
     })
 }
 
@@ -102,7 +105,8 @@ pub fn run_worker_loop_forever(_py: Python<'_>, address: &str) -> PyResult<PyPyt
     };
 
     PyPythonTask::new(async {
-        let err = boot.bootstrap().await;
+        // This should never return Ok because exit_on_shutdown is true.
+        let err = boot.bootstrap().await.unwrap_err();
         Err(err).map_pyerr()?;
         Ok(())
     })

--- a/python/monarch/_rust_bindings/monarch_hyperactor/bootstrap.pyi
+++ b/python/monarch/_rust_bindings/monarch_hyperactor/bootstrap.pyi
@@ -16,7 +16,11 @@ from monarch._rust_bindings.monarch_hyperactor.context import Instance
 from monarch._rust_bindings.monarch_hyperactor.host_mesh import HostMesh
 from monarch._rust_bindings.monarch_hyperactor.pytokio import PythonTask
 
-def bootstrap_main() -> None: ...
+def bootstrap_main() -> int:
+    """Bootstrap a proc. Returns an exit code that should be used to exit the process
+    with sys.exit()."""
+    ...
+
 def run_worker_loop_forever(address: str) -> PythonTask[None]: ...
 def attach_to_workers(
     instance: Instance,

--- a/python/monarch/_src/actor/bootstrap_main.py
+++ b/python/monarch/_src/actor/bootstrap_main.py
@@ -32,8 +32,12 @@ except ImportError:
 async def main() -> None:
     from monarch._rust_bindings.monarch_hyperactor.bootstrap import bootstrap_main
 
+    # This will return when the process is done, and we can exit this script.
+    # That will run Py_FinalizeEx which has to be done in the main thread after
+    # all other threads have exited.
     # pyre-ignore[12]: bootstrap_main is async but imported from Rust bindings
-    await bootstrap_main()
+    exit_code = await bootstrap_main()
+    sys.exit(exit_code)
 
 
 def invoke_main() -> None:

--- a/python/monarch/_src/actor/supervision.py
+++ b/python/monarch/_src/actor/supervision.py
@@ -20,9 +20,10 @@ def unhandled_fault_hook(failure: MeshFailure) -> None:
     The default implementation is to exit the process with error code 1
     after logging the event.
     If this function raises any exception (including BaseException classes such
-    as SystemExit), the client process will exit. Any normal return value will
-    cause the fault to be dropped. Logs will be written containing the failure
-    message in either case.
+    as SystemExit from sys.exit), this fault is considered unhandled.
+    Any normal return value will cause the fault to be dropped. Logs will be
+    written containing the failure message in either case.
+
     To customize this behavior, overwrite this function in your client code like so:
     ```
     import monarch.actor
@@ -35,6 +36,12 @@ def unhandled_fault_hook(failure: MeshFailure) -> None:
 
     monarch.actor.unhandled_fault_hook = my_unhandled_fault_hook
     ```
+
+    If the fault is unhandled, it exits the main thread by delivering a KeyboardInterrupt.
+    This is done because the Python Interpreter can only be finalized to run
+    destructors and atexit hooks from the main thread. So if you see a
+    "KeyboardInterrupt" happening that you didn't send, it's because there was
+    an unhandled fault.
     """
     from monarch._rust_bindings.monarch_hyperactor.telemetry import instant_event
 
@@ -43,6 +50,7 @@ def unhandled_fault_hook(failure: MeshFailure) -> None:
     message = (
         f"Unhandled monarch error on the root actor, hostname={hostname}, "
         f"PID={pid} at time {datetime.now()}: {failure.report()}\n"
+        "Delivering KeyboardInterrupt to main thread to exit the program\n"
     )
     # use stderr, not a logger because loggers are sometimes set
     # not print anything (e.g. in pytest)

--- a/python/tests/test_actor_error.py
+++ b/python/tests/test_actor_error.py
@@ -10,12 +10,13 @@ import asyncio
 import ctypes
 import datetime
 import importlib.resources
+import multiprocessing
 import os
 import re
 import subprocess
 import sys
 import time
-from typing import cast, Optional
+from typing import cast, IO, Optional
 
 import monarch.actor
 import pytest
@@ -1543,3 +1544,53 @@ def test_controller_controller_error():
     # Note that we cannot spawn new actors on a proc mesh that has prior supervision
     # events at the moment, so we have to use a pre-existing one.
     actor_2.check.call_one().get()
+
+
+def _subprocess_unhandled_fault_hook_atexit(marker_path: str) -> None:
+    import atexit
+
+    def finalize_file(file: IO[str]) -> None:
+        file.write("finalized")
+        file.close()
+
+    # Callback which should run even if we get an unhandled fault hook.
+    atexit.register(finalize_file, open(marker_path, "w"))
+
+    proc = this_host().spawn_procs({"gpus": 1})
+    actor = proc.spawn("error", ErrorActor)
+    actor.check.call().get()
+
+    # Trigger supervision error that reaches unhandled_fault_hook.
+    with pytest.raises(SupervisionError):
+        actor.fail_with_supervision_error.call().get()
+
+    # Wait for the fault to come back before exiting the process. The fault
+    # will raise KeyboardInterrupt at some point, but it needs to have a chance
+    # to interrupt the interpreter, so don't sleep for the whole time.
+    for _ in range(5):
+        time.sleep(5)
+
+
+@pytest.mark.timeout(60)
+@parametrize_config(actor_queue_dispatch={True, False})
+def test_unhandled_fault_hook_runs_atexit() -> None:
+    """Tests that atexit hooks are run in case of an unhandled fault"""
+    import tempfile
+
+    marker = tempfile.NamedTemporaryFile(delete=False, suffix=".txt")
+    marker_path = marker.name
+    marker.write(b"not finalized")
+    marker.close()
+
+    ctx = multiprocessing.get_context("spawn")
+    p = ctx.Process(target=_subprocess_unhandled_fault_hook_atexit, args=[marker_path])
+    p.start()
+    p.join(30)
+    assert p.exitcode == 1
+
+    # Test that the file got the right contents
+    with open(marker_path) as f:
+        assert f.read() == "finalized", (
+            f"file {marker_path} should have contents 'finalized' if the atexit handlers were run"
+        )
+    os.unlink(marker_path)

--- a/python/tests/test_python_actors.py
+++ b/python/tests/test_python_actors.py
@@ -1976,3 +1976,73 @@ def test_graceful_shutdown_no_unacked_messages() -> None:
         f"Worker exited with code {result.returncode}.\nstderr: {result.stderr[-2000:]}"
     )
     assert "OK: 0 faults" in result.stdout
+
+
+class ObjectWithFinalizer:
+    """Object whose __del__ writes a marker file"""
+
+    def __init__(self, path: str) -> None:
+        # This is bad etiquette, but "open" doesn't exist at interpreter finalization
+        # time. So we have to open it prematurely.
+        self._file = open(path, "w")
+
+    def __del__(self) -> None:
+        self._file.write("finalized")
+        self._file.close()
+
+
+# Only used in a proc for test_del_runs_on_proc_mesh_stop.
+_finalizer_sentinel: ObjectWithFinalizer | None = None
+
+
+class CleanupMarkerActor(Actor):
+    """Actor that stashes a ObjectWithFinalizer in a module global to ensure
+    the Python process is finalized on monarch procs."""
+
+    def __init__(self, path: str) -> None:
+        # Store the sentinel in a module-level global so it outlives
+        # the actor and is only collected during interpreter finalization.
+        global _finalizer_sentinel
+        _finalizer_sentinel = ObjectWithFinalizer(path)
+        print(f"Assigned {_finalizer_sentinel} to module global")
+
+    @endpoint
+    def getpid(self) -> int:
+        return os.getpid()
+
+
+def is_process_running(pid: int) -> bool:
+    """Check if a process with the given PID is still running."""
+    try:
+        os.kill(pid, 0)  # Signal 0 doesn't kill, just checks if process exists
+        return True
+    except OSError:
+        return False
+
+
+@pytest.mark.timeout(120)
+@parametrize_config(actor_queue_dispatch={True, False})
+async def test_del_runs_on_proc_mesh_stop() -> None:
+    """__del__ on a module global should fire via Py_FinalizeEx when the proc exits."""
+    marker = tempfile.NamedTemporaryFile(delete=False, suffix=".txt")
+    marker_path = marker.name
+    marker.write(b"not finalized")
+    marker.close()
+
+    pm = this_host().spawn_procs(per_host={"gpus": 1})
+    am = pm.spawn("cleanup", CleanupMarkerActor, marker_path)
+    pids = await am.getpid.call()
+    pids = [pid for _, pid in pids]
+    assert os.getpid() not in pids, "ensure the processes are separate"
+    # Stop the proc mesh, which should stop the proc the actor is running on.
+    await pm.stop()
+    # Make sure the PID is gone before checking the file, in case there was
+    # a delay.
+    while any(is_process_running(pid) for pid in pids):
+        await asyncio.sleep(5)
+
+    with open(marker_path) as f:
+        assert f.read() == "finalized", (
+            f"file {marker_path} should have contents 'finalized' if the finalizers were run"
+        )
+    os.unlink(marker_path)


### PR DESCRIPTION
Summary:
Fixes: https://github.com/meta-pytorch/monarch/issues/2524

When user actors were spawned that used Python, and then the proc was told to stop,
it didn't run Python finalization to clean up all objects used in the interpreter.
This could cause issues with atexit destructors from static C/C++ objects like `pybind11::ref`
which tried to acquire the GIL to decrement the refcount of an object.

In order to fix this, we want to run `Py_FinalizeEx` which will not only run finalizers on all
GC objects in Python, but will also run the Python `atexit` module handlers (not to be confused
with the C function of the same name, which Python is not using). We want to only do this in
Procs that are not part of the main client process that are running user-level python code. In
other words, only in procs that spawn PythonActors.

Why not use the libc "atexit" function? Because we want to ensure the python interpreter is
finalized before other types of atexit handlers run, such as from loaded shared libraries. The
libc atexit guarantees LIFO order, but we don't know in what order the monarch library
was loaded compared to other shared libraries.

Put a clippy warning on "std::process::exit" to warn people to use Proc::exit instead when
they are able to. This is just a warning because there are still valid times to hard exit (when
there is no Proc object yet, for example).

Differential Revision: D94961749
