### PR TITLE
Add continuous fake data simulator with failure event

### DIFF
--- a/monarch_dashboard/README.md
+++ b/monarch_dashboard/README.md
@@ -1,0 +1,137 @@
+# Monarch Dashboard
+
+A web dashboard for monitoring Monarch training jobs. Shows real-time actor status, message traffic, and health metrics across the Monarch hierarchy (Meshes > Host Units > Proc Meshes > Procs > Actor Meshes > Actors).
+
+## Quick Start
+
+```bash
+cd fbcode/monarch/monarch_dashboard
+
+# Option 1: Shell script (sets up venv + builds frontend automatically)
+bash run.sh
+
+# Option 2: Python module (requires deps already installed)
+python -m monarch_dashboard
+```
+
+Then open http://localhost:5000 in your browser (or use an SSH tunnel, see below).
+
+## Running Modes
+
+### Static Data (default)
+
+Serves the dashboard with a pre-generated SQLite database (`fake_data/fake_data.db`).
+
+```bash
+# Shell script
+bash run.sh
+
+# Python module
+python -m monarch_dashboard
+```
+
+### Force Frontend Rebuild
+
+Deletes `frontend/build/` and rebuilds from source before starting.
+
+```bash
+# Shell script
+bash run.sh --rebuild
+
+# Python module
+python -m monarch_dashboard --rebuild
+```
+
+### Live Simulator
+
+Launches a background simulator that writes data with real wall-clock timestamps, so the dashboard shows live-updating state. At 4.5 minutes (configurable), a CUDA OOM failure triggers on one host unit with death propagation.
+
+```bash
+# Shell script
+bash run.sh --simulate
+
+# Python module
+python -m monarch_dashboard --simulate
+```
+
+### Live Simulator with Custom Failure Time
+
+```bash
+# Trigger failure after 30 seconds instead of 4.5 minutes
+bash run.sh --simulate --failure-at 30
+
+# Python module equivalent
+python -m monarch_dashboard --simulate --failure-at 30
+```
+
+### Custom Tick Interval
+
+```bash
+# Simulator ticks every 0.5 seconds instead of 1.0
+bash run.sh --simulate --interval 0.5
+
+python -m monarch_dashboard --simulate --interval 0.5
+```
+
+### Standalone Simulator
+
+Run the simulator by itself (without the Flask server), useful for pre-populating a database.
+
+```bash
+python fake_data/simulate.py --db fake_data/fake_data.db --failure-at 270
+```
+
+Options:
+- `--db PATH` — SQLite database path (default: `fake_data/fake_data.db`)
+- `--interval SECONDS` — tick interval (default: 1.0)
+- `--failure-at SECONDS` — seconds until failure event (default: 270)
+
+### Filter by Time Range
+
+Restrict the dashboard API to only return data from the last N seconds.
+
+```bash
+python -m monarch_dashboard --time-range 60
+```
+
+## SSH Tunnel
+
+The dashboard binds to `0.0.0.0:5000` on your devserver. To access it from your laptop:
+
+```bash
+ssh -L 5000:localhost:5000 YOUR_DEVSERVER
+```
+
+Then open http://localhost:5000 in your local browser.
+
+## All CLI Flags
+
+### `run.sh`
+
+| Flag | Description |
+|------|-------------|
+| `--rebuild` | Force frontend rebuild before starting |
+| `--simulate` | Launch live data simulator alongside server |
+| `--failure-at N` | Seconds until simulator failure event (default: 270) |
+| `--interval N` | Simulator tick interval in seconds (default: 1.0) |
+
+### `python -m monarch_dashboard`
+
+| Flag | Description |
+|------|-------------|
+| `--db PATH` | SQLite database path |
+| `--host HOST` | Bind address (default: 0.0.0.0) |
+| `--port PORT` | Bind port (default: 5000) |
+| `--rebuild` | Force frontend rebuild |
+| `--simulate` | Launch live data simulator |
+| `--failure-at N` | Seconds until simulator failure (default: 270) |
+| `--interval N` | Simulator tick interval (default: 1.0) |
+| `--time-range N` | Filter API to last N seconds |
+
+### `fake_data/simulate.py`
+
+| Flag | Description |
+|------|-------------|
+| `--db PATH` | SQLite database path (default: fake_data/fake_data.db) |
+| `--interval N` | Tick interval in seconds (default: 1.0) |
+| `--failure-at N` | Seconds until failure event (default: 270) |

--- a/monarch_dashboard/__main__.py
+++ b/monarch_dashboard/__main__.py
@@ -5,9 +5,12 @@
 # LICENSE file in the root directory of this source tree.
 
 import argparse
+import atexit
 import os
 import shutil
+import signal
 import subprocess
+import sys
 
 from monarch.monarch_dashboard.server.app import create_app
 
@@ -55,6 +58,36 @@ def start_dashboard(db_path, host="0.0.0.0", port=5000, rebuild=False):
     app.run(host=host, port=port)
 
 
+def _launch_simulator(db_path, interval, failure_at):
+    """Launch fake_data/simulate.py as a background subprocess."""
+    pkg_dir = os.path.dirname(os.path.abspath(__file__))
+    sim_script = os.path.join(pkg_dir, "fake_data", "simulate.py")
+    cmd = [
+        sys.executable,
+        sim_script,
+        "--db",
+        db_path,
+        "--interval",
+        str(interval),
+        "--failure-at",
+        str(failure_at),
+    ]
+    print(f">> Launching simulator (failure at {failure_at}s) ...")
+    proc = subprocess.Popen(cmd)
+
+    def _cleanup():
+        if proc.poll() is None:
+            print(">> Stopping simulator ...")
+            proc.send_signal(signal.SIGINT)
+            try:
+                proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+
+    atexit.register(_cleanup)
+    return proc
+
+
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Monarch Dashboard")
     parser.add_argument("--db", default=_DEFAULT_DB)
@@ -65,9 +98,29 @@ if __name__ == "__main__":
         action="store_true",
         help="Force frontend rebuild (rm -rf frontend/build, npm install, build)",
     )
+    parser.add_argument(
+        "--simulate",
+        action="store_true",
+        help="Run the live data simulator alongside the server",
+    )
+    parser.add_argument(
+        "--interval",
+        type=float,
+        default=1.0,
+        help="Simulator tick interval in seconds (default: 1.0)",
+    )
+    parser.add_argument(
+        "--failure-at",
+        type=float,
+        default=270.0,
+        help="Seconds until simulator triggers a failure (default: 270)",
+    )
     args = parser.parse_args()
 
-    if not os.path.exists(args.db):
+    sim_proc = None
+    if args.simulate:
+        sim_proc = _launch_simulator(args.db, args.interval, args.failure_at)
+    elif not os.path.exists(args.db):
         print(f"Database not found: {args.db}")
         exit(1)
 

--- a/monarch_dashboard/fake_data/simulate.py
+++ b/monarch_dashboard/fake_data/simulate.py
@@ -1,0 +1,504 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Continuous fake data simulator for the Monarch Dashboard.
+
+Unlike ``generate.py`` which produces a static database with pre-computed
+timestamps, this script writes data with **real wall-clock timestamps** so
+the dashboard can display live-updating state.
+
+At a configurable time (default ~4.5 minutes) a failure event triggers on
+one host mesh, exercising the dashboard's error / degraded-health display.
+
+Usage:
+    python fake_data/simulate.py [--db PATH] [--interval SECONDS] [--failure-at SECONDS]
+"""
+
+import argparse
+import json
+import os
+import random
+import signal
+import sqlite3
+import time
+from pathlib import Path
+
+from generate import _ACTOR_MESH_CLASSES, _insert_rows, ENDPOINTS, SCHEMA_SQL
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _now_us() -> int:
+    """Current wall-clock time in microseconds."""
+    return time.time_ns() // 1000
+
+
+class _IdSeq:
+    """Monotonically increasing ID generator, starting at 1."""
+
+    def __init__(self) -> None:
+        self._next = 1
+
+    def __call__(self) -> int:
+        val = self._next
+        self._next += 1
+        return val
+
+
+# ---------------------------------------------------------------------------
+# Hierarchy builder (real timestamps, deterministic topology)
+# ---------------------------------------------------------------------------
+
+
+def _build_hierarchy() -> dict:
+    """Build the 2-table Monarch hierarchy using real timestamps.
+
+    Deterministic topology matching generate.py:
+      2 host meshes, 2 proc meshes each, 1 actor mesh each, 1 user actor each.
+      Total: 10 meshes, 10 actors (2 HostAgent + 4 ProcAgent + 4 user).
+
+    Returns a dict with all hierarchy rows plus bookkeeping structures
+    needed by the simulation loop.
+    """
+    ts = _now_us()
+
+    mesh_seq = _IdSeq()
+    actor_seq = _IdSeq()
+
+    meshes: list[dict] = []
+    actors: list[dict] = []
+    actor_to_host_mesh: dict[int, int] = {}
+
+    failed_host_mesh_id: int | None = None
+    trigger_actor_id: int | None = None
+    failed_host_name: str = ""
+
+    for h_idx in range(2):
+        host_mesh_id = mesh_seq()
+        host_given = f"host_mesh_{h_idx}"
+        host_full = host_given
+        meshes.append(
+            {
+                "id": host_mesh_id,
+                "timestamp_us": ts,
+                "class": "Host",
+                "given_name": host_given,
+                "full_name": host_full,
+                "shape_json": json.dumps({"dims": [1]}),
+                "parent_mesh_id": None,
+                "parent_view_json": None,
+            }
+        )
+
+        # Second host mesh is the failure target.
+        if h_idx == 1:
+            failed_host_mesh_id = host_mesh_id
+            failed_host_name = host_full
+
+        # HostAgent actor for this host mesh.
+        hma_id = actor_seq()
+        actors.append(
+            {
+                "id": hma_id,
+                "timestamp_us": ts,
+                "mesh_id": host_mesh_id,
+                "rank": 0,
+                "full_name": f"{host_full}/HostAgent[0]",
+            }
+        )
+        actor_to_host_mesh[hma_id] = host_mesh_id
+
+        if host_mesh_id == failed_host_mesh_id and trigger_actor_id is None:
+            trigger_actor_id = hma_id
+
+        # 2 proc meshes per host mesh.
+        for pm_idx in range(2):
+            proc_mesh_id = mesh_seq()
+            pm_given = f"proc_mesh_{pm_idx}"
+            pm_full = f"{host_full}/{pm_given}"
+            meshes.append(
+                {
+                    "id": proc_mesh_id,
+                    "timestamp_us": ts,
+                    "class": "Proc",
+                    "given_name": pm_given,
+                    "full_name": pm_full,
+                    "shape_json": json.dumps({"dims": [1]}),
+                    "parent_mesh_id": host_mesh_id,
+                    "parent_view_json": json.dumps({"offset": [0], "sizes": [1]}),
+                }
+            )
+
+            # ProcAgent actor for this proc mesh.
+            pma_id = actor_seq()
+            actors.append(
+                {
+                    "id": pma_id,
+                    "timestamp_us": ts,
+                    "mesh_id": proc_mesh_id,
+                    "rank": 0,
+                    "full_name": f"{pm_full}/ProcAgent[0]",
+                }
+            )
+            actor_to_host_mesh[pma_id] = host_mesh_id
+
+            if host_mesh_id == failed_host_mesh_id and trigger_actor_id is None:
+                trigger_actor_id = pma_id
+
+            # 1 actor mesh per proc mesh.
+            am_class = _ACTOR_MESH_CLASSES[pm_idx % len(_ACTOR_MESH_CLASSES)]
+            actor_mesh_id = mesh_seq()
+            am_full = f"{pm_full}/{am_class}"
+            meshes.append(
+                {
+                    "id": actor_mesh_id,
+                    "timestamp_us": ts,
+                    "class": am_class,
+                    "given_name": am_class,
+                    "full_name": am_full,
+                    "shape_json": json.dumps({"dims": [2]}),
+                    "parent_mesh_id": proc_mesh_id,
+                    "parent_view_json": json.dumps({"offset": [0], "sizes": [1]}),
+                }
+            )
+
+            # 1 user actor per actor mesh.
+            actor_type = am_class.replace("Python<", "PythonActor<")
+            aid = actor_seq()
+            actors.append(
+                {
+                    "id": aid,
+                    "timestamp_us": ts,
+                    "mesh_id": actor_mesh_id,
+                    "rank": 0,
+                    "full_name": f"{am_full}/{actor_type}[0]",
+                }
+            )
+            actor_to_host_mesh[aid] = host_mesh_id
+
+            if host_mesh_id == failed_host_mesh_id and trigger_actor_id is None:
+                trigger_actor_id = aid
+
+    assert failed_host_mesh_id is not None
+    assert trigger_actor_id is not None
+
+    return {
+        "meshes": meshes,
+        "actors": actors,
+        "actor_to_host_mesh": actor_to_host_mesh,
+        "failed_host_mesh_id": failed_host_mesh_id,
+        "trigger_actor_id": trigger_actor_id,
+        "failed_host_name": failed_host_name,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Simulation loop
+# ---------------------------------------------------------------------------
+
+
+def _run_simulation(
+    db_path: str,
+    interval: float,
+    failure_at: float,
+) -> None:
+    """Run the continuous simulation until interrupted."""
+
+    rng = random.Random()
+
+    # -- Build hierarchy ------------------------------------------------
+    hierarchy = _build_hierarchy()
+
+    actors = hierarchy["actors"]
+    actor_to_host = hierarchy["actor_to_host_mesh"]
+    failed_host_id = hierarchy["failed_host_mesh_id"]
+    trigger_actor_id = hierarchy["trigger_actor_id"]
+    failed_host_name = hierarchy["failed_host_name"]
+
+    actor_ids = [a["id"] for a in actors]
+
+    # -- Open DB --------------------------------------------------------
+    if os.path.exists(db_path):
+        os.remove(db_path)
+
+    conn = sqlite3.connect(db_path)
+    conn.execute("PRAGMA journal_mode=WAL")
+    conn.executescript(SCHEMA_SQL)
+
+    # Insert hierarchy rows.
+    _insert_rows(conn, "meshes", hierarchy["meshes"])
+    _insert_rows(conn, "actors", hierarchy["actors"])
+    conn.commit()
+
+    # -- ID sequences for event tables ----------------------------------
+    event_seq = _IdSeq()
+    msg_seq = _IdSeq()
+    mse_seq = _IdSeq()
+    sm_seq = _IdSeq()
+
+    # -- Actor state tracking -------------------------------------------
+    # Emit initial "created" -> "initializing" -> "idle" for every actor.
+    init_events: list[dict] = []
+    actor_state: dict[int, str] = {}
+
+    ts_created = _now_us()
+    for a in actors:
+        aid = a["id"]
+        init_events.append(
+            {
+                "id": event_seq(),
+                "timestamp_us": ts_created,
+                "actor_id": aid,
+                "new_status": "created",
+                "reason": None,
+            }
+        )
+
+    ts_init = ts_created + 500_000  # +0.5 s
+    for a in actors:
+        aid = a["id"]
+        init_events.append(
+            {
+                "id": event_seq(),
+                "timestamp_us": ts_init,
+                "actor_id": aid,
+                "new_status": "initializing",
+                "reason": None,
+            }
+        )
+
+    ts_idle = ts_init + 1_000_000  # +1 s
+    for a in actors:
+        aid = a["id"]
+        init_events.append(
+            {
+                "id": event_seq(),
+                "timestamp_us": ts_idle,
+                "actor_id": aid,
+                "new_status": "idle",
+                "reason": None,
+            }
+        )
+        actor_state[aid] = "idle"
+
+    _insert_rows(conn, "actor_status_events", init_events)
+    conn.commit()
+
+    n_actors_total = len(actor_ids)
+    print(
+        f"Simulator started: {n_actors_total} actors, "
+        f"failure at {failure_at:.0f}s, tick every {interval:.1f}s"
+    )
+    print(f"Database: {os.path.abspath(db_path)}")
+
+    # -- Graceful shutdown via SIGINT ------------------------------------
+    shutting_down = False
+
+    def _handle_sigint(sig: int, frame: object) -> None:
+        nonlocal shutting_down
+        shutting_down = True
+
+    signal.signal(signal.SIGINT, _handle_sigint)
+
+    # -- Main loop ------------------------------------------------------
+    start_time = time.monotonic()
+    tick = 0
+    failure_triggered = False
+    dead_actors: set[int] = set()
+
+    try:
+        while not shutting_down:
+            tick += 1
+            elapsed = time.monotonic() - start_time
+            now = _now_us()
+
+            new_events: list[dict] = []
+            new_messages: list[dict] = []
+            new_msg_events: list[dict] = []
+            new_sent: list[dict] = []
+
+            # -- Failure event ------------------------------------------
+            if not failure_triggered and elapsed >= failure_at:
+                failure_triggered = True
+
+                # Trigger actor fails.
+                new_events.append(
+                    {
+                        "id": event_seq(),
+                        "timestamp_us": now,
+                        "actor_id": trigger_actor_id,
+                        "new_status": "failed",
+                        "reason": "CUDA OOM",
+                    }
+                )
+                actor_state[trigger_actor_id] = "failed"
+                dead_actors.add(trigger_actor_id)
+
+                # Siblings in same host mesh -> stopping -> stopped.
+                for aid in actor_ids:
+                    if aid == trigger_actor_id:
+                        continue
+                    if actor_to_host[aid] == failed_host_id:
+                        new_events.append(
+                            {
+                                "id": event_seq(),
+                                "timestamp_us": now + 100_000,
+                                "actor_id": aid,
+                                "new_status": "stopping",
+                                "reason": f"death propagation from {failed_host_name}",
+                            }
+                        )
+                        new_events.append(
+                            {
+                                "id": event_seq(),
+                                "timestamp_us": now + 500_000,
+                                "actor_id": aid,
+                                "new_status": "stopped",
+                                "reason": f"death propagation from {failed_host_name}",
+                            }
+                        )
+                        actor_state[aid] = "stopped"
+                        dead_actors.add(aid)
+
+                print(
+                    f"  [tick {tick}] FAILURE triggered — "
+                    f"{len(dead_actors)} actors dead"
+                )
+
+            # -- Transition healthy actors ------------------------------
+            live_actors = [a for a in actor_ids if a not in dead_actors]
+
+            n_transitions = rng.randint(2, max(3, len(live_actors) // 3))
+            to_transition = rng.sample(
+                live_actors, min(n_transitions, len(live_actors))
+            )
+
+            for aid in to_transition:
+                cur = actor_state[aid]
+                if cur == "idle":
+                    new_status = "processing"
+                elif cur == "processing":
+                    new_status = "idle"
+                else:
+                    continue
+
+                actor_state[aid] = new_status
+                new_events.append(
+                    {
+                        "id": event_seq(),
+                        "timestamp_us": now + rng.randint(0, 100_000),
+                        "actor_id": aid,
+                        "new_status": new_status,
+                        "reason": None,
+                    }
+                )
+
+            # -- Generate messages between live actors ------------------
+            if len(live_actors) >= 2:
+                n_msgs = rng.randint(2, 4)
+                for _ in range(n_msgs):
+                    sender_id = rng.choice(live_actors)
+                    receiver_id = rng.choice([a for a in live_actors if a != sender_id])
+                    endpoint = rng.choice(ENDPOINTS)
+                    mid = msg_seq()
+                    ts_msg = now + rng.randint(0, 500_000)
+
+                    final_status = rng.choices(
+                        ["delivered", "failed"],
+                        weights=[15, 1],
+                    )[0]
+
+                    sender_actor = next(a for a in actors if a["id"] == sender_id)
+
+                    new_messages.append(
+                        {
+                            "id": mid,
+                            "timestamp_us": ts_msg,
+                            "from_actor_id": sender_id,
+                            "to_actor_id": receiver_id,
+                            "status": final_status,
+                            "endpoint": endpoint,
+                            "port_id": rng.randint(1, 100),
+                        }
+                    )
+
+                    for step_idx, step_status in enumerate(
+                        ["queued", "sent", final_status]
+                    ):
+                        new_msg_events.append(
+                            {
+                                "id": mse_seq(),
+                                "timestamp_us": ts_msg + step_idx * 50_000,
+                                "message_id": mid,
+                                "status": step_status,
+                            }
+                        )
+
+                    new_sent.append(
+                        {
+                            "id": sm_seq(),
+                            "timestamp_us": ts_msg,
+                            "sender_actor_id": sender_id,
+                            "mesh_id": sender_actor["mesh_id"],
+                            "view_json": '{"offset": [0], "sizes": [1]}',
+                            "shape_json": '{"dims": [1]}',
+                        }
+                    )
+
+            # -- Write to DB --------------------------------------------
+            _insert_rows(conn, "actor_status_events", new_events)
+            _insert_rows(conn, "messages", new_messages)
+            _insert_rows(conn, "message_status_events", new_msg_events)
+            _insert_rows(conn, "sent_messages", new_sent)
+            conn.commit()
+
+            status_summary = (
+                f"live={len(live_actors)} dead={len(dead_actors)} "
+                f"events={len(new_events)} msgs={len(new_messages)}"
+            )
+            print(f"  [tick {tick}] {elapsed:6.1f}s  {status_summary}")
+
+            time.sleep(interval)
+
+    finally:
+        conn.close()
+        print(f"\nSimulator stopped after {tick} ticks.")
+
+
+# ---------------------------------------------------------------------------
+# CLI entry point
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Run a continuous Monarch fake data simulator."
+    )
+    parser.add_argument(
+        "--db",
+        default=str(Path(__file__).parent / "fake_data.db"),
+        help="SQLite database path (default: fake_data/fake_data.db)",
+    )
+    parser.add_argument(
+        "--interval",
+        type=float,
+        default=1.0,
+        help="Seconds between ticks (default: 1.0)",
+    )
+    parser.add_argument(
+        "--failure-at",
+        type=float,
+        default=270.0,
+        help="Seconds until failure event (default: 270 = 4.5 minutes)",
+    )
+    args = parser.parse_args()
+    _run_simulation(args.db, args.interval, args.failure_at)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Summary:
Add `fake_data/simulate.py`, a live simulator that writes Monarch telemetry
data with real wall-clock timestamps. Unlike `generate.py` which produces a
static database, the simulator runs continuously and lets the dashboard show
live-updating state.

Key features:
- Reuses schema, constants, and helpers from `generate.py`
- Builds a smaller hierarchy (~60 actors) with real timestamps
- Ticks every second: transitions actors between idle/processing, generates
  messages between random actor pairs
- At a configurable time (default 4.5 min), triggers a CUDA OOM failure with
  death propagation to sibling actors
- WAL mode for concurrent reads from the Flask server
- Graceful SIGINT handling

CLI: `python fake_data/simulate.py [--db PATH] [--interval SECONDS] [--failure-at SECONDS]`

Differential Revision: D94542735
