### PR TITLE
repro for test_mesh_len broken link

### DIFF
--- a/hyperactor/src/channel.rs
+++ b/hyperactor/src/channel.rs
@@ -180,6 +180,13 @@ pub trait Rx<M: RemoteMessage> {
 
     /// The channel address from which this Rx is receiving.
     fn addr(&self) -> ChannelAddr;
+
+    /// Gracefully shut down the channel receiver, flushing any pending
+    /// acks before returning. Implementations must ensure all pending
+    /// acks are sent before this method returns.
+    async fn flush(self)
+    where
+        Self: Sized;
 }
 
 #[allow(dead_code)] // Not used outside tests.
@@ -267,6 +274,8 @@ impl<M: RemoteMessage> Rx<M> for MpscRx<M> {
     fn addr(&self) -> ChannelAddr {
         self.addr.clone()
     }
+
+    async fn flush(self) {}
 }
 
 /// The hostname to use for TLS connections.
@@ -1064,6 +1073,17 @@ impl<M: RemoteMessage> Rx<M> for ChannelRx<M> {
             ChannelRxKind::Tls(rx) => rx.addr(),
             ChannelRxKind::Sim(rx) => rx.addr(),
             ChannelRxKind::Unix(rx) => rx.addr(),
+        }
+    }
+
+    async fn flush(self) {
+        match self.inner {
+            ChannelRxKind::Local(rx) => rx.flush().await,
+            ChannelRxKind::Tcp(rx) => rx.flush().await,
+            ChannelRxKind::MetaTls(rx) => rx.flush().await,
+            ChannelRxKind::Tls(rx) => rx.flush().await,
+            ChannelRxKind::Unix(rx) => rx.flush().await,
+            ChannelRxKind::Sim(rx) => rx.flush().await,
         }
     }
 }

--- a/hyperactor/src/channel/local.rs
+++ b/hyperactor/src/channel/local.rs
@@ -127,6 +127,8 @@ impl<M: RemoteMessage> Rx<M> for LocalRx<M> {
     fn addr(&self) -> ChannelAddr {
         ChannelAddr::Local(self.port)
     }
+
+    async fn flush(self) {}
 }
 
 impl<M: RemoteMessage> Drop for LocalRx<M> {

--- a/hyperactor/src/channel/net.rs
+++ b/hyperactor/src/channel/net.rs
@@ -259,6 +259,15 @@ impl<M: RemoteMessage> Rx<M> for NetRx<M> {
     fn addr(&self) -> ChannelAddr {
         self.1.clone()
     }
+
+    /// Gracefully shut down the channel server, waiting for pending
+    /// acks to be flushed before returning.
+    async fn flush(mut self) {
+        self.2
+            .stop(&format!("NetRx flushed; channel address: {}", self.1));
+        let _ = (&mut self.2).await;
+        // Drop will call stop() again which is harmless (token already cancelled).
+    }
 }
 
 impl<M: RemoteMessage> Drop for NetRx<M> {

--- a/hyperactor/src/channel/sim.rs
+++ b/hyperactor/src/channel/sim.rs
@@ -405,6 +405,8 @@ impl<M: RemoteMessage> Rx<M> for SimRx<M> {
     fn addr(&self) -> ChannelAddr {
         self.addr.clone()
     }
+
+    async fn flush(self) {}
 }
 
 #[cfg(test)]

--- a/hyperactor/src/mailbox.rs
+++ b/hyperactor/src/mailbox.rs
@@ -1049,7 +1049,7 @@ pub trait MailboxServer: MailboxSender + Clone + Sized + 'static {
         let join_handle = tokio::spawn(async move {
             let mut detached = false;
 
-            loop {
+            let result = loop {
                 if *stopped_rx.borrow_and_update() {
                     break Ok(());
                 }
@@ -1079,7 +1079,13 @@ pub trait MailboxServer: MailboxSender + Clone + Sized + 'static {
                         }
                     }
                 }
-            }
+            };
+
+            // Flush the channel receiver to ensure pending acks are
+            // sent before the underlying channel server is torn down.
+            rx.flush().await;
+
+            result
         });
 
         MailboxServerHandle {

--- a/python/tests/test_python_actors.py
+++ b/python/tests/test_python_actors.py
@@ -58,7 +58,7 @@ from monarch.actor import (
     endpoint,
     ProcMesh,
 )
-from monarch.config import configured, parametrize_config
+from monarch.config import configure, configured, parametrize_config
 from monarch.tools.config import defaults
 from typing_extensions import assert_type
 
@@ -1189,9 +1189,12 @@ class SleepActor(Actor):
 
 @parametrize_config(actor_queue_dispatch={True, False})
 def test_mesh_len():
+    configure(message_delivery_timeout="5s")
     proc_mesh = this_host().spawn_procs(per_host={"gpus": 12})
     s = proc_mesh.spawn("sleep_actor", SleepActor)
     assert 12 == len(s)
+    proc_mesh.stop().get()
+    time.sleep(5)
 
 
 @pytest.mark.oss_skip


### PR DESCRIPTION
Summary:
## Investigation of CI GPU test failures

Investigated CI failures in PR #2760 where 4 out of 10 test groups were killed.

### Root cause: unhandled broken link errors killing pytest process

When spawning 12 proc agents (`test_mesh_len` with `gpus=12`), messages sent
during actor spawn (CommMeshConfig, CreateOrUpdate<ActorSpec>) sometimes don't
get acked within the `message_delivery_timeout` (default 30s). This causes a
"broken link" error that propagates as an unhandled fault to the RootClientActor,
which calls `sys.exit(1)` and kills the entire pytest process.

Key observations:
- The spawn and stop both complete successfully
- The error fires AFTER stop is done — it's a leftover in-flight message
  from spawn that was never acked
- Deterministically reproducible by setting `message_delivery_timeout="5s"`
  and sleeping after stop (see test_mesh_len changes in this diff)
- In CI (g5.4xlarge), the default 30s timeout is sometimes insufficient
  for 12 procs, causing the error to fire during a subsequent unrelated test
- The error kills whichever test happens to be running 30s later

### Reproduction

`test_mesh_len` in this diff reproduces the issue: set delivery timeout to 5s,
spawn 12 procs, spawn actors, stop, sleep 10s. The broken link error fires
every time during the sleep, showing the pattern:

```
Unhandled monarch error on the root actor:
  undeliverable message error:
    error: broken link: failed to receive ack within timeout 5s
```

Differential Revision: D94976517


