### PR TITLE
Turn on orphaned mesh timeout

### DIFF
--- a/hyperactor_mesh/src/proc_agent.rs
+++ b/hyperactor_mesh/src/proc_agent.rs
@@ -73,7 +73,7 @@ declare_attrs! {
         Some("HYPERACTOR_MESH_ORPHAN_TIMEOUT".to_string()),
         Some("mesh_orphan_timeout".to_string()),
     ))
-    pub attr MESH_ORPHAN_TIMEOUT: Duration = Duration::from_secs(0);
+    pub attr MESH_ORPHAN_TIMEOUT: Duration = Duration::from_secs(60);
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Named)]


### PR DESCRIPTION
Summary:
Part of: https://github.com/meta-pytorch/monarch/issues/2198

Turn on the mesh orphan timeout by default. This will mean that actors whose owners
dies will now clean themselves up after this timeout (approximately).

Differential Revision: D95099535


