### PR TITLE
Add display_name column to actor table

### DIFF
--- a/examples/distributed_telemetry.py
+++ b/examples/distributed_telemetry.py
@@ -19,8 +19,8 @@ in queryable Arrow tables. Actor creation events are captured separately
 via the ActorEventSink.
 
 Usage:
-    buck2 run //monarch/examples:distributed_telemetry_real_data
-    buck2 run //monarch/examples:distributed_telemetry_real_data -- --summary
+    buck2 run //monarch/examples:distributed_telemetry
+    buck2 run //monarch/examples:distributed_telemetry -- --summary
 """
 
 import argparse
@@ -196,10 +196,18 @@ QUERIES = [
     ),
     # Actors by name pattern
     (
-        "Actors by name",
-        """SELECT full_name, rank
+        "Actors by full_name",
+        """SELECT full_name
            FROM actors
            ORDER BY full_name""",
+    ),
+    # Actors by name pattern
+    (
+        "Actors by display_name",
+        """SELECT display_name
+           FROM actors
+           WHERE display_name IS NOT NULL
+           ORDER BY display_name""",
     ),
     # Sample of meshes
     (

--- a/hyperactor_mesh/src/host_mesh.rs
+++ b/hyperactor_mesh/src/host_mesh.rs
@@ -276,6 +276,7 @@ impl HostMesh {
                 mesh_id: mesh_id_hash,
                 rank: rank as u64,
                 full_name: actor_id.to_string(),
+                display_name: None,
             });
         }
     }

--- a/hyperactor_mesh/src/lib.rs
+++ b/hyperactor_mesh/src/lib.rs
@@ -285,6 +285,22 @@ impl From<view::InvalidCardinality> for Error {
 /// The type of result used in `hyperactor_mesh`.
 pub type Result<T> = std::result::Result<T, Error>;
 
+/// Construct a per-actor display name from a mesh-level base name and a
+/// rank's coordinates. Inserts `point.format_as_dict()` before the last
+/// `>` in `base`, or appends it if no `>` is found. Returns `base`
+/// unchanged for scalar (empty) points.
+pub(crate) fn actor_display_name(base: &str, point: &view::Point) -> String {
+    if point.is_empty() {
+        return base.to_string();
+    }
+    let coords = point.format_as_dict();
+    if let Some(pos) = base.rfind('>') {
+        format!("{}{}{}", &base[..pos], coords, &base[pos..])
+    } else {
+        format!("{}{}", base, coords)
+    }
+}
+
 /// Names are used to identify objects in the system. They have a user-provided name,
 /// and a unique UUID.
 ///

--- a/hyperactor_mesh/src/mesh_controller.rs
+++ b/hyperactor_mesh/src/mesh_controller.rs
@@ -694,21 +694,7 @@ impl<A: Referable> Handler<CheckState> for ActorMeshController<A> {
                         status
                     ))),
                 };
-                let display_name = if !point.is_empty() {
-                    let coords_display = point.format_as_dict();
-                    if let Some(pos) = supervision_display_name.rfind('>') {
-                        format!(
-                            "{}{}{}",
-                            &supervision_display_name[..pos],
-                            coords_display,
-                            &supervision_display_name[pos..]
-                        )
-                    } else {
-                        format!("{}{}", supervision_display_name, coords_display)
-                    }
-                } else {
-                    supervision_display_name.clone()
-                };
+                let display_name = crate::actor_display_name(supervision_display_name, &point);
                 send_state_change(
                     cx,
                     point.rank(),

--- a/hyperactor_mesh/src/proc_mesh.rs
+++ b/hyperactor_mesh/src/proc_mesh.rs
@@ -255,6 +255,7 @@ impl ProcMesh {
                     mesh_id: mesh_id_hash,
                     rank: rank.create_rank as u64,
                     full_name: actor_id.to_string(),
+                    display_name: None,
                 });
             }
         }
@@ -1151,7 +1152,7 @@ impl ProcMeshRef {
             // mesh can be preserved.
             let controller: ActorMeshController<A> = ActorMeshController::new(
                 mesh.deref().clone(),
-                supervision_display_name,
+                supervision_display_name.clone(),
                 Some(cx.instance().port().bind()),
                 statuses,
             );
@@ -1197,12 +1198,17 @@ impl ProcMeshRef {
                 let mut actor_hasher = DefaultHasher::new();
                 actor_id.hash(&mut actor_hasher);
 
+                let display_name = supervision_display_name.as_ref().map(|sdn| {
+                    let point = self.region().extent().point_of_rank(rank).unwrap();
+                    crate::actor_display_name(sdn, &point)
+                });
                 hyperactor_telemetry::notify_actor_created(hyperactor_telemetry::ActorEvent {
                     id: actor_hasher.finish(),
                     timestamp: now,
                     mesh_id: mesh_id_hash,
                     rank: rank as u64,
                     full_name: actor_id.to_string(),
+                    display_name,
                 });
             }
         }

--- a/hyperactor_telemetry/src/lib.rs
+++ b/hyperactor_telemetry/src/lib.rs
@@ -320,6 +320,8 @@ pub struct ActorEvent {
     pub rank: u64,
     /// Full hierarchical name of this actor
     pub full_name: String,
+    /// User-facing name for this actor
+    pub display_name: Option<String>,
 }
 
 /// Notify the registered dispatcher that an actor was created.

--- a/monarch_distributed_telemetry/src/entity_dispatcher.rs
+++ b/monarch_distributed_telemetry/src/entity_dispatcher.rs
@@ -38,6 +38,8 @@ pub struct Actor {
     pub rank: u64,
     /// Full hierarchical name of this actor
     pub full_name: String,
+    /// User-facing name for this actor
+    pub display_name: Option<String>,
 }
 
 /// Row data for the meshes table.
@@ -193,6 +195,7 @@ impl EntityEventDispatcher for EntityDispatcher {
                     mesh_id: actor_event.mesh_id,
                     rank: actor_event.rank,
                     full_name: actor_event.full_name,
+                    display_name: actor_event.display_name,
                 });
                 inner.flush_actors_if_full()?;
             }

--- a/python/tests/test_distributed_telemetry.py
+++ b/python/tests/test_distributed_telemetry.py
@@ -123,7 +123,14 @@ def test_actors_table(cleanup_callbacks) -> None:
     assert actor_count > 0, f"Expected at least one actor, got {actor_count}"
 
     # Verify the schema has the expected columns
-    expected_columns = {"id", "timestamp_us", "mesh_id", "rank", "full_name"}
+    expected_columns = {
+        "id",
+        "timestamp_us",
+        "mesh_id",
+        "rank",
+        "full_name",
+        "display_name",
+    }
     actual_columns = set(result_dict.keys())
     assert expected_columns == actual_columns, (
         f"Expected columns {expected_columns}, got {actual_columns}"


### PR DESCRIPTION
Summary: This is useful to provide consistent display name for users (used in supervision event as well)

Reviewed By: zhangrmatthew

Differential Revision: D94974796


