### PR TITLE
make proc.stop() flush acks

### DIFF
--- a/hyper/Cargo.toml
+++ b/hyper/Cargo.toml
@@ -17,7 +17,7 @@ fbinit-tokio = { version = "0.1.2", git = "https://github.com/facebookexperiment
 hyperactor = { version = "0.0.0", path = "../hyperactor" }
 hyperactor_mesh = { version = "0.0.0", path = "../hyperactor_mesh" }
 serde_json = { version = "1.0.140", features = ["alloc", "float_roundtrip", "raw_value", "unbounded_depth"] }
-tokio = { version = "1.47.1", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1", features = ["full"] }
 
 [lints]
 rust = { unexpected_cfgs = { check-cfg = ["cfg(fbcode_build)"], level = "warn" } }

--- a/hyperactor/src/channel.rs
+++ b/hyperactor/src/channel.rs
@@ -180,6 +180,13 @@ pub trait Rx<M: RemoteMessage> {
 
     /// The channel address from which this Rx is receiving.
     fn addr(&self) -> ChannelAddr;
+
+    /// Gracefully shut down the channel receiver, flushing any pending
+    /// acks before returning. Implementations must ensure all pending
+    /// acks are sent before this method returns.
+    async fn join(self)
+    where
+        Self: Sized;
 }
 
 #[allow(dead_code)] // Not used outside tests.
@@ -267,6 +274,8 @@ impl<M: RemoteMessage> Rx<M> for MpscRx<M> {
     fn addr(&self) -> ChannelAddr {
         self.addr.clone()
     }
+
+    async fn join(self) {}
 }
 
 /// The hostname to use for TLS connections.
@@ -1064,6 +1073,17 @@ impl<M: RemoteMessage> Rx<M> for ChannelRx<M> {
             ChannelRxKind::Tls(rx) => rx.addr(),
             ChannelRxKind::Sim(rx) => rx.addr(),
             ChannelRxKind::Unix(rx) => rx.addr(),
+        }
+    }
+
+    async fn join(self) {
+        match self.inner {
+            ChannelRxKind::Local(rx) => rx.join().await,
+            ChannelRxKind::Tcp(rx) => rx.join().await,
+            ChannelRxKind::MetaTls(rx) => rx.join().await,
+            ChannelRxKind::Tls(rx) => rx.join().await,
+            ChannelRxKind::Unix(rx) => rx.join().await,
+            ChannelRxKind::Sim(rx) => rx.join().await,
         }
     }
 }

--- a/hyperactor/src/channel/local.rs
+++ b/hyperactor/src/channel/local.rs
@@ -127,6 +127,8 @@ impl<M: RemoteMessage> Rx<M> for LocalRx<M> {
     fn addr(&self) -> ChannelAddr {
         ChannelAddr::Local(self.port)
     }
+
+    async fn join(self) {}
 }
 
 impl<M: RemoteMessage> Drop for LocalRx<M> {

--- a/hyperactor/src/channel/net.rs
+++ b/hyperactor/src/channel/net.rs
@@ -259,6 +259,15 @@ impl<M: RemoteMessage> Rx<M> for NetRx<M> {
     fn addr(&self) -> ChannelAddr {
         self.1.clone()
     }
+
+    /// Gracefully shut down the channel server, waiting for pending
+    /// acks to be flushed before returning.
+    async fn join(mut self) {
+        self.2
+            .stop(&format!("NetRx joined; channel address: {}", self.1));
+        let _ = (&mut self.2).await;
+        // Drop will call stop() again which is harmless (token already cancelled).
+    }
 }
 
 impl<M: RemoteMessage> Drop for NetRx<M> {
@@ -861,6 +870,10 @@ pub(crate) mod meta {
     /// Creates a TLS connector by looking for necessary certs and keys in a Meta server environment.
     /// Supports optional client authentication (unlike the tls module which always requires it).
     fn tls_connector() -> Result<TlsConnector> {
+        // Ensure ring is installed as the process-level crypto provider.
+        // No-op when already installed (e.g. under Buck with native-tls).
+        let _ = rustls::crypto::ring::default_provider().install_default();
+
         let ca_path = std::env::var_os(THRIFT_TLS_SRV_CA_PATH_ENV)
             .map(PathBuf::from)
             .unwrap_or_else(|| PathBuf::from(DEFAULT_SRV_CA_PATH));
@@ -998,6 +1011,10 @@ pub(crate) mod tls {
         bundle: &PemBundle,
         enforce_client_tls: bool,
     ) -> Result<TlsAcceptor> {
+        // Ensure ring is installed as the process-level crypto provider.
+        // No-op when already installed (e.g. under Buck with native-tls).
+        let _ = rustls::crypto::ring::default_provider().install_default();
+
         let certs = load_certs(&bundle.cert).context("load TLS certificate")?;
         let key = load_key(&bundle.key).context("load TLS key")?;
         let root_store = build_root_store(&bundle.ca).context("build root cert store")?;
@@ -1025,6 +1042,10 @@ pub(crate) mod tls {
 
     /// Creates a TLS connector using certificates from the provided PEM bundle.
     pub(super) fn tls_connector_from_bundle(bundle: &PemBundle) -> Result<TlsConnector> {
+        // Ensure ring is installed as the process-level crypto provider.
+        // No-op when already installed (e.g. under Buck with native-tls).
+        let _ = rustls::crypto::ring::default_provider().install_default();
+
         let certs = load_certs(&bundle.cert).context("load TLS certificate")?;
         let key = load_key(&bundle.key).context("load TLS key")?;
         let root_store = build_root_store(&bundle.ca).context("build root cert store")?;

--- a/hyperactor/src/channel/net/duplex.rs
+++ b/hyperactor/src/channel/net/duplex.rs
@@ -147,6 +147,8 @@ impl<M: RemoteMessage> Rx<M> for DuplexRx<M> {
     fn addr(&self) -> ChannelAddr {
         self.1.clone()
     }
+
+    async fn join(self) {}
 }
 
 /// Sender half of a duplex channel.

--- a/hyperactor/src/channel/sim.rs
+++ b/hyperactor/src/channel/sim.rs
@@ -405,6 +405,8 @@ impl<M: RemoteMessage> Rx<M> for SimRx<M> {
     fn addr(&self) -> ChannelAddr {
         self.addr.clone()
     }
+
+    async fn join(self) {}
 }
 
 #[cfg(test)]

--- a/hyperactor/src/mailbox.rs
+++ b/hyperactor/src/mailbox.rs
@@ -1050,7 +1050,7 @@ pub trait MailboxServer: MailboxSender + Clone + Sized + 'static {
         let join_handle = tokio::spawn(async move {
             let mut detached = false;
 
-            loop {
+            let result = loop {
                 if *stopped_rx.borrow_and_update() {
                     break Ok(());
                 }
@@ -1080,7 +1080,13 @@ pub trait MailboxServer: MailboxSender + Clone + Sized + 'static {
                         }
                     }
                 }
-            }
+            };
+
+            // Join the channel receiver to ensure pending acks are
+            // sent before the underlying channel server is torn down.
+            rx.join().await;
+
+            result
         });
 
         MailboxServerHandle {

--- a/python/tests/_monarch/test_sync_workspace.py
+++ b/python/tests/_monarch/test_sync_workspace.py
@@ -16,6 +16,7 @@ import unittest
 from pathlib import Path
 from typing import Generator
 
+import pytest
 from monarch._rust_bindings.monarch_hyperactor.alloc import AllocConstraints
 from monarch._rust_bindings.monarch_hyperactor.channel import (
     ChannelAddr,
@@ -72,6 +73,7 @@ class TestSyncWorkspace(unittest.IsolatedAsyncioTestCase):
     def tearDown(self) -> None:
         shutil.rmtree(self.tmpdir)
 
+    @pytest.mark.oss_skip  # pyre-ignore[56]: Pyre cannot infer the type of this pytest marker
     async def test_sync_workspace(self) -> None:
         local_workspace_dir = self.tmpdir / "local" / "github" / "torch"
         local_workspace_dir.mkdir(parents=True)

--- a/python/tests/test_failure_introspection.py
+++ b/python/tests/test_failure_introspection.py
@@ -22,6 +22,7 @@ import urllib.request
 
 import monarch.actor
 import pytest
+from isolate_in_subprocess import isolate_in_subprocess
 from monarch._src.actor.host_mesh import this_host
 from monarch.actor import Actor, endpoint
 from monarch.config import parametrize_config
@@ -59,6 +60,7 @@ def _encode(ref: str) -> str:
 
 
 @pytest.mark.timeout(60)
+@isolate_in_subprocess
 @parametrize_config(actor_queue_dispatch={True, False})
 async def test_failed_actor_has_failure_info() -> None:
     """After an actor crashes, its introspection payload has failure_info."""
@@ -130,6 +132,7 @@ async def test_failed_actor_has_failure_info() -> None:
 
 
 @pytest.mark.timeout(60)
+@isolate_in_subprocess
 @parametrize_config(actor_queue_dispatch={True, False})
 async def test_healthy_procs_not_poisoned() -> None:
     """Procs without failed actors should not be poisoned."""

--- a/python/tests/test_python_actors.py
+++ b/python/tests/test_python_actors.py
@@ -58,7 +58,7 @@ from monarch.actor import (
     endpoint,
     ProcMesh,
 )
-from monarch.config import configured, parametrize_config
+from monarch.config import configure, configured, parametrize_config
 from monarch.tools.config import defaults
 from typing_extensions import assert_type
 
@@ -1189,9 +1189,12 @@ class SleepActor(Actor):
 
 @parametrize_config(actor_queue_dispatch={True, False})
 def test_mesh_len():
+    configure(message_delivery_timeout="5s")
     proc_mesh = this_host().spawn_procs(per_host={"gpus": 12})
     s = proc_mesh.spawn("sleep_actor", SleepActor)
     assert 12 == len(s)
+    proc_mesh.stop().get()
+    time.sleep(5)
 
 
 @pytest.mark.oss_skip


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #2880

## Investigation of CI GPU test failures

Investigated CI failures in PR #2760 where 4 out of 10 test groups were killed.

### Root cause: unhandled broken link errors killing pytest process
This is a fix for the below issue where acks do not get flushed even though we are waiting on the Mailbox's JoinHandle.


When spawning 12 proc agents (`test_mesh_len` with `gpus=12`), messages sent
during actor spawn (CommMeshConfig, CreateOrUpdate<ActorSpec>) sometimes don't
get acked within the `message_delivery_timeout` (default 30s). This causes a
"broken link" error that propagates as an unhandled fault to the RootClientActor,
which calls `sys.exit(1)` and kills the entire pytest process.

Key observations:
- The spawn and stop both complete successfully
- The error fires AFTER stop is done — it's a leftover in-flight message
  from spawn that was never acked
- Deterministically reproducible by setting `message_delivery_timeout="5s"`
  and sleeping after stop (see test_mesh_len changes in this diff)
- In CI (g5.4xlarge), the default 30s timeout is sometimes insufficient
  for 12 procs, causing the error to fire during a subsequent unrelated test
- The error kills whichever test happens to be running 30s later

### Reproduction

`test_mesh_len` in this diff reproduces the issue: set delivery timeout to 5s,
spawn 12 procs, spawn actors, stop, sleep 10s. The broken link error fires
every time during the sleep, showing the pattern:

```
Unhandled monarch error on the root actor:
  undeliverable message error:
    error: broken link: failed to receive ack within timeout 5s
```

Differential Revision: [D94976517](https://our.internmc.facebook.com/intern/diff/D94976517/)