### PR TITLE
Add sent_messages telemetry table and populate cast from sender

### DIFF
--- a/examples/distributed_telemetry.py
+++ b/examples/distributed_telemetry.py
@@ -73,6 +73,20 @@ class ComputeActor(Actor):
         return child.compute.call_one(100).get()
 
 
+class SenderActor(Actor):
+    """Actor that sends messages to another actor mesh.
+
+    The sent_messages table records this actor's ID as sender_actor_id,
+    joinable with actors.id to retrieve display_name.
+    """
+
+    @endpoint
+    def send_compute(self, target: ComputeActor, iterations: int) -> int:
+        """Send a compute request to the target actor mesh."""
+        # pyre-ignore[29]: target is an ActorMesh
+        return sum(target.compute.call(iterations).get().values())
+
+
 def print_table(table: pa.Table, max_rows: int = 50) -> None:
     """Pretty print a PyArrow table."""
     if table.num_rows == 0:
@@ -88,42 +102,6 @@ def print_table(table: pa.Table, max_rows: int = 50) -> None:
 
 # Shared queries for telemetry tables
 QUERIES = [
-    # Show table schemas first
-    (
-        "Schema of 'spans' table",
-        """SELECT column_name, data_type, is_nullable
-           FROM information_schema.columns
-           WHERE table_name = 'spans'
-           ORDER BY ordinal_position""",
-    ),
-    (
-        "Schema of 'span_events' table",
-        """SELECT column_name, data_type, is_nullable
-           FROM information_schema.columns
-           WHERE table_name = 'span_events'
-           ORDER BY ordinal_position""",
-    ),
-    (
-        "Schema of 'events' table",
-        """SELECT column_name, data_type, is_nullable
-           FROM information_schema.columns
-           WHERE table_name = 'events'
-           ORDER BY ordinal_position""",
-    ),
-    (
-        "Schema of 'actors' table",
-        """SELECT column_name, data_type, is_nullable
-           FROM information_schema.columns
-           WHERE table_name = 'actors'
-           ORDER BY ordinal_position""",
-    ),
-    (
-        "Schema of 'meshes' table",
-        """SELECT column_name, data_type, is_nullable
-           FROM information_schema.columns
-           WHERE table_name = 'meshes'
-           ORDER BY ordinal_position""",
-    ),
     # Show available spans
     ("Count of spans", "SELECT COUNT(*) as total_spans FROM spans"),
     (
@@ -197,14 +175,14 @@ QUERIES = [
     # Actors by name pattern
     (
         "Actors by full_name",
-        """SELECT full_name
+        """SELECT id, full_name
            FROM actors
            ORDER BY full_name""",
     ),
     # Actors by name pattern
     (
         "Actors by display_name",
-        """SELECT display_name
+        """SELECT id, display_name
            FROM actors
            WHERE display_name IS NOT NULL
            ORDER BY display_name""",
@@ -295,14 +273,6 @@ QUERIES = [
            WHERE hm.class = 'Host'
            ORDER BY host_mesh_name, proc_mesh_name, actor_mesh_name, rank""",
     ),
-    # Actor status events schema
-    (
-        "Schema of 'actor_status_events' table",
-        """SELECT column_name, data_type, is_nullable
-           FROM information_schema.columns
-           WHERE table_name = 'actor_status_events'
-           ORDER BY ordinal_position""",
-    ),
     # Actor status events by status
     (
         "Actor status transitions",
@@ -337,6 +307,27 @@ QUERIES = [
         "Meshes detail",
         """SELECT given_name, class, shape_json
            FROM meshes""",
+    ),
+    (
+        "Count of sent messages",
+        "SELECT COUNT(*) as total_sent_messages FROM sent_messages",
+    ),
+    (
+        "Sent messages to 'compute' actor mesh",
+        """SELECT sm.id, sm.timestamp_us, a.display_name AS sender, m.given_name AS mesh_name
+           FROM sent_messages sm
+           LEFT JOIN meshes m ON sm.actor_mesh_id = m.id
+           LEFT JOIN actors a ON sm.sender_actor_id = a.id
+           WHERE m.given_name = 'compute'""",
+    ),
+    (
+        "Sample sent messages",
+        """SELECT sm.timestamp_us, a.display_name AS sender,
+                  sm.view_json, sm.shape_json
+           FROM sent_messages sm
+           JOIN actors a ON sm.sender_actor_id = a.id
+           ORDER BY sm.timestamp_us DESC
+           LIMIT 10""",
     ),
 ]
 
@@ -393,17 +384,15 @@ def run_queries(engine, summary: bool = False) -> None:
         print()
 
 
-def run_workload(procs, summary=False, spawn_child=None):
-    """Shared workload: start telemetry, spawn actors, run work, and query.
+def run_workload(procs, engine, summary=False, spawn_child=None):
+    """Shared workload: spawn actors, run work, and query.
 
     Args:
         procs: The proc mesh to spawn actors on.
+        engine: The QueryEngine returned by start_telemetry().
         summary: If True, print summary output instead of full tables.
         spawn_child: Optional callable(actors) to spawn a child process and do work.
     """
-    print("Starting telemetry with real data collection...")
-    engine = start_telemetry()
-
     print("Spawning compute actors...")
     # pyre-ignore[29]: procs is a ProcMesh
     actors = procs.spawn("compute", ComputeActor)
@@ -417,6 +406,15 @@ def run_workload(procs, summary=False, spawn_child=None):
     # pyre-ignore[29]: actors is an ActorMesh
     nested_results = actors.nested_work.call(3).get()
     print(f"Nested work results: {list(nested_results)}")
+
+    print("Spawning sender actor for actor-to-actor messaging...")
+    # pyre-ignore[29]: procs is a ProcMesh
+    sender = procs.slice(workers=0).spawn("sender", SenderActor)
+
+    print("Sending from sender actor to compute actors...")
+    # pyre-ignore[29]: sender is an ActorMesh
+    result = sender.send_compute.call_one(actors, 42).get()
+    print(f"Sender-to-compute result: {result}")
 
     if spawn_child is not None:
         spawn_child(actors)
@@ -440,6 +438,8 @@ def main(summary: bool = False) -> None:
     print("=" * 50)
     print()
 
+    engine = start_telemetry()
+
     # Spawn worker processes - telemetry automatically tracks them
     print(f"Spawning {NUM_WORKERS} worker processes...")
     hosts = ProcessJob({"hosts": 1}).state(cached_path=None).hosts
@@ -452,7 +452,7 @@ def main(summary: bool = False) -> None:
         # pyre-ignore[29]: child_actors is an ActorMesh
         child_actors.compute.call(100).get()
 
-    run_workload(procs, summary, spawn_child=spawn_child)
+    run_workload(procs, engine, summary, spawn_child=spawn_child)
 
     # Clean up
     hosts.shutdown().get()

--- a/hyperactor_mesh/src/actor_mesh.rs
+++ b/hyperactor_mesh/src/actor_mesh.rs
@@ -460,6 +460,17 @@ impl<A: Referable> ActorMeshRef<A> {
             }
         }
 
+        hyperactor_telemetry::notify_sent_message(hyperactor_telemetry::SentMessageEvent {
+            timestamp: RealClock.system_time_now(),
+            sender_actor_id: hyperactor_telemetry::hash_to_u64(cx.mailbox().actor_id()),
+            actor_mesh_id: hyperactor_telemetry::hash_to_u64(&self.name.to_string()),
+            view_json: serde_json::to_string(view::Ranked::region(self)).unwrap_or_default(),
+            shape_json: {
+                let shape: ndslice::Shape = view::Ranked::region(self).into();
+                serde_json::to_string(&shape).unwrap_or_default()
+            },
+        });
+
         // Now that we know these ranks are active, send out the actual messages.
         if let Some(root_comm_actor) = self.proc_mesh.root_comm_actor() {
             self.cast_v0(cx, message, sel, root_comm_actor)

--- a/hyperactor_mesh/src/host_mesh.rs
+++ b/hyperactor_mesh/src/host_mesh.rs
@@ -25,9 +25,7 @@ use crate::supervision::MeshFailure;
 pub mod host_agent;
 
 use std::collections::HashSet;
-use std::collections::hash_map::DefaultHasher;
 use std::hash::Hash;
-use std::hash::Hasher;
 use std::ops::Deref;
 use std::str::FromStr;
 use std::sync::Arc;
@@ -248,9 +246,7 @@ impl HostMesh {
     /// Emit a telemetry event for this host mesh creation.
     fn notify_created(&self) {
         let name_str = self.name.to_string();
-        let mut mesh_hasher = DefaultHasher::new();
-        name_str.hash(&mut mesh_hasher);
-        let mesh_id_hash = mesh_hasher.finish();
+        let mesh_id_hash = hyperactor_telemetry::hash_to_u64(&name_str);
 
         hyperactor_telemetry::notify_mesh_created(hyperactor_telemetry::MeshEvent {
             id: mesh_id_hash,
@@ -267,16 +263,13 @@ impl HostMesh {
         // These are skipped in Proc::spawn_inner. mesh_id directly points to host mesh.
         let now = RealClock.system_time_now();
         for (rank, host) in self.current_ref.hosts().iter().enumerate() {
-            let actor_id = host.mesh_agent().actor_id().clone();
-            let mut actor_hasher = DefaultHasher::new();
-            actor_id.hash(&mut actor_hasher);
-
+            let actor = host.mesh_agent();
             hyperactor_telemetry::notify_actor_created(hyperactor_telemetry::ActorEvent {
-                id: actor_hasher.finish(),
+                id: hyperactor_telemetry::hash_to_u64(actor.actor_id()),
                 timestamp: now,
                 mesh_id: mesh_id_hash,
                 rank: rank as u64,
-                full_name: actor_id.to_string(),
+                full_name: actor.actor_id().to_string(),
                 display_name: None,
             });
         }

--- a/hyperactor_mesh/src/proc_mesh.rs
+++ b/hyperactor_mesh/src/proc_mesh.rs
@@ -9,10 +9,8 @@
 use std::any::type_name;
 use std::collections::HashMap;
 use std::collections::HashSet;
-use std::collections::hash_map::DefaultHasher;
 use std::fmt;
 use std::hash::Hash;
-use std::hash::Hasher;
 use std::ops::Deref;
 use std::panic::Location;
 use std::sync::Arc;
@@ -220,19 +218,13 @@ impl ProcMesh {
         // Notify telemetry that the ProcAgent mesh was created.
         {
             let name_str = name.to_string();
-            let mut mesh_hasher = DefaultHasher::new();
-            name_str.hash(&mut mesh_hasher);
-            let mesh_id_hash = mesh_hasher.finish();
+            let mesh_id_hash = hyperactor_telemetry::hash_to_u64(&name_str);
 
             let (parent_mesh_id, parent_view_json) = match host_mesh {
-                Some(hm) => {
-                    let mut parent_hasher = DefaultHasher::new();
-                    hm.name().to_string().hash(&mut parent_hasher);
-                    (
-                        Some(parent_hasher.finish()),
-                        serde_json::to_string(hm.region()).ok(),
-                    )
-                }
+                Some(hm) => (
+                    Some(hyperactor_telemetry::hash_to_u64(&hm.name().to_string())),
+                    serde_json::to_string(hm.region()).ok(),
+                ),
                 None => (None, None),
             };
 
@@ -252,11 +244,9 @@ impl ProcMesh {
             let now = RealClock.system_time_now();
             for rank in current_ref.ranks.iter() {
                 let actor_id = rank.agent.actor_id();
-                let mut actor_hasher = DefaultHasher::new();
-                actor_id.hash(&mut actor_hasher);
 
                 hyperactor_telemetry::notify_actor_created(hyperactor_telemetry::ActorEvent {
-                    id: actor_hasher.finish(),
+                    id: hyperactor_telemetry::hash_to_u64(actor_id),
                     timestamp: now,
                     mesh_id: mesh_id_hash,
                     rank: rank.create_rank as u64,
@@ -1175,14 +1165,10 @@ impl ProcMeshRef {
 
             // Hash the actor mesh name. This is used as mesh_id for both
             // the MeshEvent and the per-actor ActorEvents below.
-            let mut mesh_hasher = DefaultHasher::new();
-            name_str.hash(&mut mesh_hasher);
-            let mesh_id_hash = mesh_hasher.finish();
+            let mesh_id_hash = hyperactor_telemetry::hash_to_u64(&name_str);
 
             // Hash the proc mesh name for parent_mesh_id.
-            let mut parent_hasher = DefaultHasher::new();
-            self.name().to_string().hash(&mut parent_hasher);
-            let parent_mesh_id_hash = parent_hasher.finish();
+            let parent_mesh_id_hash = hyperactor_telemetry::hash_to_u64(&self.name().to_string());
 
             hyperactor_telemetry::notify_mesh_created(hyperactor_telemetry::MeshEvent {
                 id: mesh_id_hash,
@@ -1200,16 +1186,13 @@ impl ProcMeshRef {
             // create_rank, which reflects the original unsliced mesh).
             let now = RealClock.system_time_now();
             for (rank, proc_ref) in self.ranks.iter().enumerate() {
-                let actor_id = proc_ref.actor_id(&name);
-                let mut actor_hasher = DefaultHasher::new();
-                actor_id.hash(&mut actor_hasher);
-
                 let display_name = supervision_display_name.as_ref().map(|sdn| {
                     let point = self.region().extent().point_of_rank(rank).unwrap();
                     crate::actor_display_name(sdn, &point)
                 });
+                let actor_id = proc_ref.actor_id(&name);
                 hyperactor_telemetry::notify_actor_created(hyperactor_telemetry::ActorEvent {
-                    id: actor_hasher.finish(),
+                    id: hyperactor_telemetry::hash_to_u64(&actor_id),
                     timestamp: now,
                     mesh_id: mesh_id_hash,
                     rank: rank as u64,

--- a/hyperactor_telemetry/src/lib.rs
+++ b/hyperactor_telemetry/src/lib.rs
@@ -66,10 +66,15 @@ pub mod trace;
 pub mod trace_dispatcher;
 
 // Re-export key types for external sink implementations
+use std::collections::hash_map::DefaultHasher;
+use std::hash::Hash;
+use std::hash::Hasher;
 use std::io::Write;
 use std::str::FromStr;
 use std::sync::Arc;
 use std::sync::Mutex;
+use std::sync::atomic::AtomicU64;
+use std::sync::atomic::Ordering;
 use std::sync::mpsc;
 use std::time::Instant;
 use std::time::SystemTime;
@@ -110,6 +115,13 @@ use crate::config::MONARCH_LOG_SUFFIX;
 use crate::config::USE_UNIFIED_LAYER;
 use crate::recorder::Recorder;
 use crate::sqlite::get_reloadable_sqlite_layer;
+
+/// Hash any hashable value to a u64 using DefaultHasher.
+pub fn hash_to_u64(value: &impl Hash) -> u64 {
+    let mut hasher = DefaultHasher::new();
+    value.hash(&mut hasher);
+    hasher.finish()
+}
 
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 pub struct TelemetrySample {
@@ -383,16 +395,36 @@ pub fn notify_actor_status_changed(event: ActorStatusEvent) {
     dispatch_or_buffer(EntityEvent::ActorStatus(event));
 }
 
+/// Event fired when a message is sent (cast or point-to-point).
+#[derive(Debug, Clone)]
+pub struct SentMessageEvent {
+    pub timestamp: SystemTime,
+    pub sender_actor_id: u64,
+    pub actor_mesh_id: u64,
+    pub view_json: String,
+    pub shape_json: String,
+}
+
+/// Notify the registered dispatcher that a message was sent.
+/// If no dispatcher is registered yet, the event is buffered and will be
+/// replayed when `set_entity_dispatcher` is called.
+pub fn notify_sent_message(event: SentMessageEvent) {
+    dispatch_or_buffer(EntityEvent::SentMessage(event));
+}
+
+static SEND_SEQ: AtomicU64 = AtomicU64::new(1);
+
+/// Generate a globally unique SentMessage ID.
+pub fn generate_sent_message_id(sender_actor_id: u64) -> u64 {
+    let seq = SEND_SEQ.fetch_add(1, Ordering::Relaxed);
+    hash_to_u64(&(sender_actor_id, seq))
+}
+
 /// Unified event enum for all entity lifecycle events.
 ///
 /// This enum wraps all entity events (actors, meshes, and future event types)
 /// into a single type. This enables a single sink to handle all entity events,
 /// simplifying the registration and notification infrastructure.
-///
-/// # Future Extensions
-/// Additional variants can be added for:
-/// - `Message(MessageEvent)` - message sends/receives
-/// - `SentMessage(SentMessageEvent)` - outgoing message tracking
 #[derive(Debug, Clone)]
 pub enum EntityEvent {
     /// An actor was created.
@@ -401,6 +433,8 @@ pub enum EntityEvent {
     Mesh(MeshEvent),
     /// An actor changed status.
     ActorStatus(ActorStatusEvent),
+    /// A message was sent.
+    SentMessage(SentMessageEvent),
 }
 
 /// Trait for dispatchers that receive unified entity events.
@@ -424,6 +458,7 @@ pub enum EntityEvent {
 ///             EntityEvent::Actor(actor) => println!("Actor: {}", actor.full_name),
 ///             EntityEvent::Mesh(mesh) => println!("Mesh: {}", mesh.full_name),
 ///             EntityEvent::ActorStatus(status) => println!("Status: {}", status.new_status),
+///             EntityEvent::SentMessage(msg) => println!("Sent: {}", msg.id),
 ///         }
 ///         Ok(())
 ///     }

--- a/monarch_distributed_telemetry/src/entity_dispatcher.rs
+++ b/monarch_distributed_telemetry/src/entity_dispatcher.rs
@@ -8,10 +8,11 @@
 
 //! EntityDispatcher - Dispatches entity lifecycle events to Arrow RecordBatches
 //!
-//! Produces two tables:
+//! Produces tables:
 //! - `actors`: Actor creation events
 //! - `meshes`: Mesh creation events
 //! - `actor_status_events`: Actor status change events
+//! - `sent_messages`: Sent message events
 
 use std::sync::Arc;
 use std::sync::Mutex;
@@ -80,11 +81,32 @@ pub struct ActorStatusEvent {
     pub reason: Option<String>,
 }
 
+/// Row data for the sent_messages table.
+///
+/// Tracks messages from the perspective of the sending actor.
+/// Logged from send (cast or point-to-point).
+#[derive(RecordBatchRow)]
+pub struct SentMessage {
+    /// Unique identifier for this sent message record
+    pub id: u64,
+    /// Timestamp in microseconds since Unix epoch
+    pub timestamp_us: i64,
+    /// ID of the sending actor
+    pub sender_actor_id: u64,
+    /// ID of the actor mesh over which the message was sent (0 for point-to-point)
+    pub actor_mesh_id: u64,
+    /// Region over which the message was sent, serialized from ndslice::Region
+    pub view_json: String,
+    /// Shape of the message, serialized from ndslice::Shape
+    pub shape_json: String,
+}
+
 /// Inner state of EntityDispatcher.
 struct EntityDispatcherInner {
     actors_buffer: ActorBuffer,
     meshes_buffer: MeshBuffer,
     actor_status_events_buffer: ActorStatusEventBuffer,
+    sent_messages_buffer: SentMessageBuffer,
     batch_size: usize,
     flush_callback: FlushCallback,
 }
@@ -106,6 +128,11 @@ impl EntityDispatcherInner {
         Self::flush_buffer(
             &mut self.actor_status_events_buffer,
             "actor_status_events",
+            &self.flush_callback,
+        )?;
+        Self::flush_buffer(
+            &mut self.sent_messages_buffer,
+            "sent_messages",
             &self.flush_callback,
         )?;
         Ok(())
@@ -130,6 +157,17 @@ impl EntityDispatcherInner {
             Self::flush_buffer(
                 &mut self.actor_status_events_buffer,
                 "actor_status_events",
+                &self.flush_callback,
+            )?;
+        }
+        Ok(())
+    }
+
+    fn flush_sent_messages_if_full(&mut self) -> anyhow::Result<()> {
+        if self.sent_messages_buffer.len() >= self.batch_size {
+            Self::flush_buffer(
+                &mut self.sent_messages_buffer,
+                "sent_messages",
                 &self.flush_callback,
             )?;
         }
@@ -161,6 +199,7 @@ impl EntityDispatcher {
             actors_buffer: ActorBuffer::default(),
             meshes_buffer: MeshBuffer::default(),
             actor_status_events_buffer: ActorStatusEventBuffer::default(),
+            sent_messages_buffer: SentMessageBuffer::default(),
             batch_size,
             flush_callback,
         }));
@@ -229,6 +268,21 @@ impl EntityEventDispatcher for EntityDispatcher {
                     reason: status_event.reason,
                 });
                 inner.flush_actor_status_events_if_full()?;
+            }
+            EntityEvent::SentMessage(event) => {
+                let mut inner = self
+                    .inner
+                    .lock()
+                    .map_err(|_| anyhow::anyhow!("lock poisoned"))?;
+                inner.sent_messages_buffer.insert(SentMessage {
+                    id: hyperactor_telemetry::generate_sent_message_id(event.sender_actor_id),
+                    timestamp_us: timestamp_to_micros(&event.timestamp),
+                    sender_actor_id: event.sender_actor_id,
+                    actor_mesh_id: event.actor_mesh_id,
+                    view_json: event.view_json,
+                    shape_json: event.shape_json,
+                });
+                inner.flush_sent_messages_if_full()?;
             }
         }
         Ok(())

--- a/python/tests/test_distributed_telemetry.py
+++ b/python/tests/test_distributed_telemetry.py
@@ -36,6 +36,16 @@ class WorkerActor(Actor):
         pass
 
 
+class SenderActor(Actor):
+    """Actor that sends messages to another actor mesh."""
+
+    @endpoint
+    def send_ping(self, target: WorkerActor) -> None:
+        """Cast to the target actor mesh from within this actor."""
+        # pyre-ignore[29]: target is an ActorMesh
+        target.ping.call().get()
+
+
 @pytest.fixture
 def cleanup_callbacks():
     """Fixture to clean up any callbacks registered during tests."""
@@ -621,6 +631,179 @@ def test_sliced_vs_full_view_rank(cleanup_callbacks) -> None:
     )
     sliced_ranks = sliced_actors_result.to_pydict()["rank"]
     assert sliced_ranks == [0, 1], f"Expected ranks [0, 1], got {sliced_ranks}"
+
+    # Clean up
+    hosts.shutdown().get()
+
+
+@pytest.mark.timeout(120)
+def test_sent_messages_table(cleanup_callbacks) -> None:
+    """Test that the sent_messages table is populated when messages are sent."""
+    engine = start_telemetry(batch_size=10)
+
+    # Spawn worker actors and send messages to generate sent_messages events
+    job = ProcessJob({"hosts": 1})
+    hosts = job.state(cached_path=None).hosts
+    worker_procs = hosts.spawn_procs(per_host={"workers": 2})
+    workers = worker_procs.spawn("sent_msg_worker", WorkerActor)
+    workers.initialized.get()
+
+    # Cast a message to generate a sent_messages record via the cast path
+    for _ in range(42):
+        workers.ping.call().get()
+
+    # Verify the schema
+    result = engine.query(
+        "SELECT column_name FROM information_schema.columns "
+        "WHERE table_name = 'sent_messages' ORDER BY ordinal_position"
+    )
+    column_names = result.to_pydict().get("column_name", [])
+    assert column_names == [
+        "id",
+        "timestamp_us",
+        "sender_actor_id",
+        "actor_mesh_id",
+        "view_json",
+        "shape_json",
+    ], f"Unexpected columns: {column_names}"
+
+    # Verify rows exist
+    result = engine.query("SELECT * FROM sent_messages")
+    result_dict = result.to_pydict()
+    row_count = len(result_dict.get("id", []))
+    assert row_count > 0, f"Expected at least one sent message, got {row_count}"
+
+    # Verify join with mesh table
+    joined = engine.query(
+        "SELECT sm.id FROM sent_messages sm LEFT JOIN meshes m "
+        "ON sm.actor_mesh_id = m.id WHERE m.given_name = 'sent_msg_worker'"
+    )
+    joined_count = len(joined.to_pydict().get("id", []))
+    assert joined_count == 42, (
+        "Expected sent_messages to join with actors on sender_actor_id"
+    )
+
+    # Clean up
+    hosts.shutdown().get()
+
+
+@pytest.mark.timeout(120)
+def test_sent_messages_with_sliced_mesh(cleanup_callbacks) -> None:
+    """Test that sent_messages view_json/shape_json reflect sliced vs full actor mesh casts."""
+    engine = start_telemetry(batch_size=10)
+
+    job = ProcessJob({"hosts": 1})
+    hosts = job.state(cached_path=None).hosts
+    worker_procs = hosts.spawn_procs(per_host={"workers": 4}, name="sm_slice_procs")
+
+    # Spawn actors on the full proc mesh
+    actors = worker_procs.spawn("sm_actors", WorkerActor)
+    actors.initialized.get()
+
+    # Cast to the full actor mesh (all 4 workers)
+    actors.ping.call().get()
+
+    # Slice the actor mesh and cast to the slice (workers 1..3, i.e. 2 workers)
+    sliced_actors = actors.slice(workers=slice(1, 3))
+    sliced_actors.ping.call().get()
+
+    # Both casts target the same actor mesh, so actor_mesh_id is the same.
+    # The view_json distinguishes full vs sliced.
+    mesh = engine.query("SELECT id FROM meshes WHERE given_name = 'sm_actors'")
+    mesh_id = mesh.to_pydict()["id"][0]
+
+    msgs = engine.query(
+        f"SELECT view_json, shape_json FROM sent_messages "
+        f"WHERE actor_mesh_id = {mesh_id} ORDER BY timestamp_us"
+    )
+    msgs_dict = msgs.to_pydict()
+    assert len(msgs_dict["view_json"]) == 2, (
+        f"Expected 2 sent messages, got {len(msgs_dict['view_json'])}"
+    )
+
+    # First cast: full mesh (all 4 workers)
+    full_view = json.loads(msgs_dict["view_json"][0])
+    workers_idx = full_view["labels"].index("workers")
+    assert full_view["slice"]["sizes"][workers_idx] == 4, (
+        f"Expected full view size=4, got {full_view['slice']['sizes'][workers_idx]}"
+    )
+
+    # Second cast: sliced mesh (2 workers, offset > 0)
+    sliced_view = json.loads(msgs_dict["view_json"][1])
+    workers_idx = sliced_view["labels"].index("workers")
+    assert sliced_view["slice"]["sizes"][workers_idx] == 2, (
+        f"Expected sliced view size=2, got {sliced_view['slice']['sizes'][workers_idx]}"
+    )
+    assert sliced_view["slice"]["offset"] > 0, (
+        f"Expected sliced view offset > 0, got {sliced_view['slice']['offset']}"
+    )
+
+    # Clean up
+    hosts.shutdown().get()
+
+
+@pytest.mark.timeout(120)
+def test_sent_messages_sender_actor_id(cleanup_callbacks) -> None:
+    """Test that sender_actor_id identifies the actor that initiated the cast,
+    not the target actor, when one actor casts to another actor mesh."""
+    engine = start_telemetry(batch_size=10)
+
+    job = ProcessJob({"hosts": 1})
+    hosts = job.state(cached_path=None).hosts
+    worker_procs = hosts.spawn_procs(per_host={"workers": 2}, name="sender_test_procs")
+
+    # Spawn target actors on the full proc mesh
+    targets = worker_procs.spawn("target_workers", WorkerActor)
+    targets.initialized.get()
+
+    # Spawn a single sender actor on worker 0
+    sender = worker_procs.slice(workers=0).spawn("sender_actor", SenderActor)
+    sender.initialized.get()
+
+    # SenderActor casts to the target actor mesh from within its endpoint
+    sender.send_ping.call_one(targets).get()
+
+    # Find the sent_messages row targeting the "target_workers" mesh
+    target_mesh = engine.query(
+        "SELECT id FROM meshes WHERE given_name = 'target_workers'"
+    )
+    target_mesh_id = target_mesh.to_pydict()["id"][0]
+
+    msgs = engine.query(
+        f"SELECT sender_actor_id FROM sent_messages "
+        f"WHERE actor_mesh_id = {target_mesh_id}"
+    )
+    msgs_dict = msgs.to_pydict()
+    assert len(msgs_dict["sender_actor_id"]) > 0, (
+        "Expected at least one sent message targeting 'target_workers'"
+    )
+
+    # The sender_actor_id should match an actor in the "sender_actor" mesh,
+    # not an actor in the "target_workers" mesh.
+    sender_mesh = engine.query(
+        "SELECT id FROM meshes WHERE given_name = 'sender_actor'"
+    )
+    sender_mesh_id = sender_mesh.to_pydict()["id"][0]
+
+    sender_actors = engine.query(
+        f"SELECT id, display_name FROM actors WHERE mesh_id = {sender_mesh_id}"
+    )
+    sender_actor_ids = set(sender_actors.to_pydict()["id"])
+
+    target_actors = engine.query(
+        f"SELECT id FROM actors WHERE mesh_id = {target_mesh_id}"
+    )
+    target_actor_ids = set(target_actors.to_pydict()["id"])
+
+    for sender_id in msgs_dict["sender_actor_id"]:
+        assert sender_id in sender_actor_ids, (
+            f"sender_actor_id {sender_id} should be a sender actor, "
+            f"not a target actor. sender_actor_ids={sender_actor_ids}, "
+            f"target_actor_ids={target_actor_ids}"
+        )
+        assert sender_id not in target_actor_ids, (
+            f"sender_actor_id {sender_id} should NOT be a target actor"
+        )
 
     # Clean up
     hosts.shutdown().get()


### PR DESCRIPTION
Summary:
* introduce hash_to_u64 to reduce duplication
* misc clean up (remove schema printing)
* record sent_message table for all cast
* currently it only populates cast path from sender (need to investigate p2p)
* realized that we don't have root client actor being recording resulting in when actor is called from python there is a gap.

Differential Revision: D95119090


