### PR TITLE
Change undeliverable_message_attempt from an error to a debug log

### DIFF
--- a/hyperactor/src/actor.rs
+++ b/hyperactor/src/actor.rs
@@ -203,7 +203,32 @@ impl<A: Actor> Handler<Undeliverable<MessageEnvelope>> for A {
         cx: &Context<Self>,
         message: Undeliverable<MessageEnvelope>,
     ) -> Result<(), anyhow::Error> {
-        self.handle_undeliverable_message(cx, message).await
+        let sender = message.0.sender().clone();
+        let dest = message.0.dest().clone();
+        let error = message.0.error_msg().unwrap_or(String::new());
+        match self.handle_undeliverable_message(cx, message).await {
+            Ok(_) => {
+                tracing::debug!(
+                    actor_id = %cx.self_id(),
+                    name = "undeliverable_message_handled",
+                    %sender,
+                    %dest,
+                    error,
+                );
+                Ok(())
+            }
+            Err(e) => {
+                tracing::error!(
+                    actor_id = %cx.self_id(),
+                    name = "undeliverable_message",
+                    %sender,
+                    %dest,
+                    error,
+                    handler_error = %e,
+                );
+                Err(e)
+            }
+        }
     }
 }
 

--- a/hyperactor/src/mailbox.rs
+++ b/hyperactor/src/mailbox.rs
@@ -364,7 +364,7 @@ impl MessageEnvelope {
         error: DeliveryError,
         return_handle: PortHandle<Undeliverable<MessageEnvelope>>,
     ) {
-        tracing::error!(
+        tracing::debug!(
             name = "undelivered_message_attempt",
             sender = self.sender.to_string(),
             dest = self.dest.to_string(),


### PR DESCRIPTION
Summary:
The undeliverable_message_attempt is a bit too verbose, especially when it's an important
part of some actor's implementation like ActorMeshController, which uses undeliverable messages
to detect dead subscribers to prune.

Move the more serious message to the receiving side (when it arrives back to the sending actor),
and downgrade the sender side to debug.

This way, actors that override handle_undeliverable_message can avoid spamming error logs.

Differential Revision: D95240584


