### PR TITLE
Add process leak detection diagnostics to test suite

### DIFF
--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -6,6 +6,9 @@
 
 import os
 import sys
+import time
+
+import pytest
 
 # Propagate sys.path to PYTHONPATH so that worker subprocesses spawned by
 # monarch (e.g. distributed_proc_mesh) see the same import paths as the
@@ -13,3 +16,39 @@ import sys
 # sys.path at the Python level, but child processes don't inherit that —
 # they only see PYTHONPATH.
 os.environ["PYTHONPATH"] = os.pathsep.join(sys.path)
+
+
+def _total_threads() -> int:
+    """Read total thread/process count from /proc/loadavg (4th field: running/total)."""
+    try:
+        with open("/proc/loadavg") as f:
+            return int(f.read().split()[3].split("/")[1])
+    except Exception:
+        return -1
+
+
+_last_start_time: dict[str, float] = {}
+_last_start_threads: dict[str, int] = {}
+
+
+@pytest.hookimpl(tryfirst=True)
+def pytest_runtest_setup(item: pytest.Item) -> None:
+    _last_start_time[item.nodeid] = time.monotonic()
+    _last_start_threads[item.nodeid] = _total_threads()
+
+
+def pytest_runtest_logreport(report: pytest.TestReport) -> None:
+    if report.when != "teardown":
+        return
+    elapsed = time.monotonic() - _last_start_time.pop(report.nodeid, 0.0)
+    before = _last_start_threads.pop(report.nodeid, 0)
+    after = _total_threads()
+    leaked = after - before if before >= 0 and after >= 0 else -1
+    sys.stderr.write(
+        f"\nMONARCH_TEST_DIAG: test={report.nodeid} "
+        f"duration={elapsed:.2f}s "
+        f"threads_before={before} "
+        f"threads_after={after} "
+        f"threads_leaked={leaked}\n"
+    )
+    sys.stderr.flush()

--- a/python/tests/test_leak_detection.py
+++ b/python/tests/test_leak_detection.py
@@ -1,0 +1,53 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Test to verify the MONARCH_TEST_DIAG process leak detection in conftest.py.
+
+Run with: uv run pytest python/tests/test_leak_detection.py -s
+Then grep for MONARCH_TEST_DIAG in the output — the leaky test should show
+processes_leaked > 0.
+"""
+
+import subprocess
+
+import pytest
+
+from monarch._src.actor.host_mesh import this_host
+from monarch.actor import Actor, endpoint
+
+
+class Dummy(Actor):
+    @endpoint
+    async def ping(self) -> str:
+        return "pong"
+
+
+@pytest.mark.timeout(60)
+async def test_no_leak() -> None:
+    """Properly cleaned up — should show processes_leaked=0."""
+    pm = this_host().spawn_procs(per_host={"gpus": 1})
+    am = pm.spawn("dummy", Dummy)
+    await am.ping.call()
+    await pm.stop()
+
+
+@pytest.mark.timeout(60)
+async def test_leak() -> None:
+    """Intentionally leaks — should show processes_leaked > 0."""
+    pm = this_host().spawn_procs(per_host={"gpus": 1})
+    am = pm.spawn("dummy", Dummy)
+    await am.ping.call()
+    # Intentionally NOT calling await pm.stop()
+
+
+def test_subprocess_no_leak() -> None:
+    """Subprocess that exits — should show processes_leaked=0."""
+    subprocess.run(["true"])
+
+
+def test_subprocess_leak() -> None:
+    """Subprocess left running — should show processes_leaked > 0."""
+    subprocess.Popen(["sleep", "300"])


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #2908
* #2896
* __->__ #2889
* #2888

- Add MONARCH_TEST_DIAG output to conftest.py that logs thread/process counts before and after each test
- Add test_leak_detection.py with intentional leak/no-leak tests to verify the diagnostics work

Differential Revision: [D94943652](https://our.internmc.facebook.com/intern/diff/D94943652/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D94943652/)!