### PR TITLE
Add GET /api/dag endpoint — centralize graph data server-side

### DIFF
--- a/monarch_dashboard/server/db.py
+++ b/monarch_dashboard/server/db.py
@@ -227,6 +227,285 @@ def list_sent_messages(
 # ---------------------------------------------------------------------------
 
 
+def get_dag_data() -> dict[str, Any]:
+    """Return classified nodes and edges for the DAG visualization.
+
+    Fetches all meshes, actors (with latest status), and messages in a single
+    connection, then builds the 6-tier graph structure server-side:
+
+      host_mesh -> host_unit -> proc_mesh -> proc_unit -> actor_mesh -> actor
+
+    Status propagation: if a host_unit has a terminal status (failed/stopped/
+    stopping), all proc_units and actors under that host inherit it.
+
+    Returns ``{"nodes": [...], "edges": [...]}``.
+    """
+    conn = _connect()
+    try:
+        meshes = [
+            dict(r) for r in conn.execute("SELECT * FROM meshes ORDER BY id").fetchall()
+        ]
+
+        # Actors with latest status via JOIN.
+        actor_rows = conn.execute(
+            "SELECT a.*, latest.new_status AS latest_status "
+            "FROM actors a LEFT JOIN ("
+            "  SELECT ase.actor_id, ase.new_status, sub.max_ts "
+            "  FROM actor_status_events ase "
+            "  INNER JOIN ("
+            "    SELECT actor_id, MAX(timestamp_us) AS max_ts "
+            "    FROM actor_status_events GROUP BY actor_id"
+            "  ) sub ON ase.actor_id = sub.actor_id "
+            "    AND ase.timestamp_us = sub.max_ts"
+            ") latest ON a.id = latest.actor_id "
+            "ORDER BY a.id"
+        ).fetchall()
+        actors = [dict(r) for r in actor_rows]
+
+        messages = [
+            dict(r)
+            for r in conn.execute(
+                "SELECT from_actor_id, to_actor_id FROM messages ORDER BY id"
+            ).fetchall()
+        ]
+    finally:
+        conn.close()
+
+    # -- Classify meshes --
+    host_meshes = [m for m in meshes if m["class"] == "Host"]
+    proc_meshes = [m for m in meshes if m["class"] == "Proc"]
+    actor_meshes = [m for m in meshes if m["class"] not in ("Host", "Proc")]
+
+    # -- Classify actors by name pattern --
+    host_agents_by_mesh: dict[int, list[dict]] = {}
+    proc_agents_by_mesh: dict[int, list[dict]] = {}
+    regular_actors: list[dict] = []
+
+    for a in actors:
+        if "HostAgent" in a["full_name"]:
+            host_agents_by_mesh.setdefault(a["mesh_id"], []).append(a)
+        elif "ProcAgent" in a["full_name"]:
+            proc_agents_by_mesh.setdefault(a["mesh_id"], []).append(a)
+        else:
+            regular_actors.append(a)
+
+    # -- Build parent -> children mesh map --
+    mesh_children: dict[int, list[dict]] = {}
+    for m in meshes:
+        pid = m["parent_mesh_id"]
+        if pid is not None:
+            mesh_children.setdefault(pid, []).append(m)
+
+    # -- Build mesh -> regular actors map --
+    mesh_actors: dict[int, list[dict]] = {}
+    for a in regular_actors:
+        mesh_actors.setdefault(a["mesh_id"], []).append(a)
+
+    # -- Actor statuses --
+    actor_statuses: dict[int, str] = {}
+    for a in actors:
+        actor_statuses[a["id"]] = (a.get("latest_status") or "unknown").lower()
+
+    # -- Terminal status propagation --
+    terminal = {"stopped", "failed", "stopping"}
+
+    def host_terminal_status(host_mesh_id: int) -> str | None:
+        for agent in host_agents_by_mesh.get(host_mesh_id, []):
+            s = actor_statuses.get(agent["id"], "unknown")
+            if s in terminal:
+                return s
+        return None
+
+    proc_to_host: dict[int, int] = {}
+    for pm in proc_meshes:
+        if pm["parent_mesh_id"] is not None:
+            proc_to_host[pm["id"]] = pm["parent_mesh_id"]
+
+    def _short(name: str) -> str:
+        return name.rsplit("/", 1)[-1]
+
+    # -- Build nodes --
+    nodes: list[dict[str, Any]] = []
+
+    for m in host_meshes:
+        nodes.append(
+            {
+                "id": f"host_mesh-{m['id']}",
+                "entity_id": m["id"],
+                "tier": "host_mesh",
+                "label": _short(m["given_name"]),
+                "subtitle": "Host Mesh",
+                "status": "n/a",
+            }
+        )
+
+    for hm in host_meshes:
+        for agent in host_agents_by_mesh.get(hm["id"], []):
+            nodes.append(
+                {
+                    "id": f"host_unit-{agent['id']}",
+                    "entity_id": agent["id"],
+                    "tier": "host_unit",
+                    "label": _short(hm["given_name"]).replace("_mesh", ""),
+                    "subtitle": "Host",
+                    "status": actor_statuses.get(agent["id"], "unknown"),
+                }
+            )
+
+    for m in proc_meshes:
+        nodes.append(
+            {
+                "id": f"proc_mesh-{m['id']}",
+                "entity_id": m["id"],
+                "tier": "proc_mesh",
+                "label": _short(m["given_name"]),
+                "subtitle": "Proc Mesh",
+                "status": "n/a",
+            }
+        )
+
+    for pm in proc_meshes:
+        host_id = proc_to_host.get(pm["id"])
+        t_host = host_terminal_status(host_id) if host_id is not None else None
+        for agent in proc_agents_by_mesh.get(pm["id"], []):
+            own = actor_statuses.get(agent["id"], "unknown")
+            nodes.append(
+                {
+                    "id": f"proc_unit-{agent['id']}",
+                    "entity_id": agent["id"],
+                    "tier": "proc_unit",
+                    "label": _short(pm["given_name"]).replace("_mesh", ""),
+                    "subtitle": "Proc",
+                    "status": t_host if t_host else own,
+                }
+            )
+
+    for m in actor_meshes:
+        nodes.append(
+            {
+                "id": f"actor_mesh-{m['id']}",
+                "entity_id": m["id"],
+                "tier": "actor_mesh",
+                "label": _short(m["given_name"]),
+                "subtitle": "Actor Mesh",
+                "status": "n/a",
+            }
+        )
+
+    for a in regular_actors:
+        parent_mesh = next((m for m in meshes if m["id"] == a["mesh_id"]), None)
+        parent_proc_id = parent_mesh["parent_mesh_id"] if parent_mesh else None
+        host_id = (
+            proc_to_host.get(parent_proc_id) if parent_proc_id is not None else None
+        )
+        t_host = host_terminal_status(host_id) if host_id is not None else None
+        nodes.append(
+            {
+                "id": f"actor-{a['id']}",
+                "entity_id": a["id"],
+                "tier": "actor",
+                "label": _short(a["full_name"]),
+                "subtitle": f"rank {a['rank']}",
+                "status": t_host if t_host else actor_statuses.get(a["id"], "unknown"),
+            }
+        )
+
+    # -- Build edges --
+    edges: list[dict[str, Any]] = []
+
+    # Host mesh -> host unit
+    for hm in host_meshes:
+        for agent in host_agents_by_mesh.get(hm["id"], []):
+            edges.append(
+                {
+                    "id": f"hier-host_mesh-{hm['id']}-host_unit-{agent['id']}",
+                    "source_id": f"host_mesh-{hm['id']}",
+                    "target_id": f"host_unit-{agent['id']}",
+                    "type": "hierarchy",
+                }
+            )
+
+    # Host unit -> proc mesh
+    for pm in proc_meshes:
+        if pm["parent_mesh_id"] is None:
+            continue
+        for agent in host_agents_by_mesh.get(pm["parent_mesh_id"], []):
+            edges.append(
+                {
+                    "id": f"hier-host_unit-{agent['id']}-proc_mesh-{pm['id']}",
+                    "source_id": f"host_unit-{agent['id']}",
+                    "target_id": f"proc_mesh-{pm['id']}",
+                    "type": "hierarchy",
+                }
+            )
+
+    # Proc mesh -> proc unit
+    for pm in proc_meshes:
+        for agent in proc_agents_by_mesh.get(pm["id"], []):
+            edges.append(
+                {
+                    "id": f"hier-proc_mesh-{pm['id']}-proc_unit-{agent['id']}",
+                    "source_id": f"proc_mesh-{pm['id']}",
+                    "target_id": f"proc_unit-{agent['id']}",
+                    "type": "hierarchy",
+                }
+            )
+
+    # Proc unit -> actor mesh
+    for am in actor_meshes:
+        if am["parent_mesh_id"] is None:
+            continue
+        for agent in proc_agents_by_mesh.get(am["parent_mesh_id"], []):
+            edges.append(
+                {
+                    "id": f"hier-proc_unit-{agent['id']}-actor_mesh-{am['id']}",
+                    "source_id": f"proc_unit-{agent['id']}",
+                    "target_id": f"actor_mesh-{am['id']}",
+                    "type": "hierarchy",
+                }
+            )
+
+    # Actor mesh -> actor
+    for a in regular_actors:
+        edges.append(
+            {
+                "id": f"hier-actor_mesh-{a['mesh_id']}-actor-{a['id']}",
+                "source_id": f"actor_mesh-{a['mesh_id']}",
+                "target_id": f"actor-{a['id']}",
+                "type": "hierarchy",
+            }
+        )
+
+    # Message edges (deduplicated by actor pair).
+    # Map actor_id -> node_id so messages reference the correct node prefix
+    # (host_unit/proc_unit/actor rather than always "actor-").
+    actor_node_id: dict[int, str] = {}
+    for n in nodes:
+        if n["tier"] in ("host_unit", "proc_unit", "actor"):
+            actor_node_id[n["entity_id"]] = n["id"]
+
+    seen: set[str] = set()
+    for m in messages:
+        src = actor_node_id.get(m["from_actor_id"])
+        tgt = actor_node_id.get(m["to_actor_id"])
+        if not src or not tgt:
+            continue
+        key = f"{m['from_actor_id']}-{m['to_actor_id']}"
+        if key in seen:
+            continue
+        seen.add(key)
+        edges.append(
+            {
+                "id": f"msg-{m['from_actor_id']}-{m['to_actor_id']}",
+                "source_id": src,
+                "target_id": tgt,
+                "type": "message",
+            }
+        )
+
+    return {"nodes": nodes, "edges": edges}
+
+
 def get_summary() -> dict[str, Any]:
     """Return aggregate metrics for the summary dashboard.
 

--- a/monarch_dashboard/server/routes.py
+++ b/monarch_dashboard/server/routes.py
@@ -35,6 +35,12 @@ def summary():
     return jsonify(db.get_summary())
 
 
+@api.route("/dag")
+def dag():
+    """Classified nodes and edges for the DAG visualization."""
+    return jsonify(db.get_dag_data())
+
+
 # ---------------------------------------------------------------------------
 # Meshes
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Summary: New /api/dag endpoint in routes.py + get_dag_data() in db.py. Queries meshes, actors, hierarchy edges (mesh parent_id), and inter-actor messages. Returns a single JSON payload with nodes (typed by tier: host_mesh, host_unit, proc_mesh, proc_unit, actor_mesh, actor) and edges (hierarchy + message). Frontend will consume this instead of making multiple API calls.

Differential Revision: D95329787
