### PR TITLE
Add OTLP MeterProvider for OSS metrics export

### DIFF
--- a/examples/kubernetes/otel_collector/README.md
+++ b/examples/kubernetes/otel_collector/README.md
@@ -1,0 +1,125 @@
+# OTEL Collector on Kubernetes
+
+End-to-end example of exporting Monarch metrics to an [OpenTelemetry Collector](https://opentelemetry.io/docs/collector/) running in a Kubernetes cluster.
+
+When `OTEL_EXPORTER_OTLP_ENDPOINT` is set, Monarch's telemetry layer exports metrics via OTLP/HTTP to the specified collector. Built-in actor system metrics (mailbox posts, messages sent/received, queue sizes, etc.) are exported automatically with no code changes.
+
+## Architecture
+
+```
+┌──────────────┐
+│  Controller  │──OTLP/HTTP──┐
+│  (main.py)   │             │
+└──────────────┘             ▼
+                        ┌────────────────┐     ┌────────────┐
+                        │ OTEL Collector │────▶│  stdout    │
+                        │  (port 4318)   │     │  (debug)   │
+                        └────────────────┘     └────────────┘
+┌──────────────┐             ▲                ┌────────────┐
+│  Worker pods │──OTLP/HTTP──┘           ────▶ │ Prometheus │
+│  (mesh)      │                               │ (port 8889)│
+└──────────────┘                               └────────────┘
+```
+
+Both the controller and worker pods set `OTEL_EXPORTER_OTLP_ENDPOINT` pointing at the collector service. The collector receives OTLP metrics and fans them out to:
+
+- **debug exporter** — logs metrics to stdout (verify with `kubectl logs`)
+- **prometheus exporter** — exposes a `/metrics` endpoint on port 8889
+
+## Prerequisites
+
+- A Kubernetes cluster with [Monarch CRD and operator](https://github.com/meta-pytorch/monarch-kubernetes/) installed
+- `kubectl` configured to access the cluster
+
+## Deploy
+
+```bash
+# Create the namespace
+kubectl create namespace monarch-tests
+
+# Deploy the OTEL collector
+kubectl apply -f manifests/otel-collector.yaml
+
+# Wait for the collector to be ready
+kubectl rollout status deployment/otel-collector -n monarch-tests
+
+# Deploy the controller pod (includes RBAC)
+kubectl apply -f manifests/controller.yaml
+
+# Wait for the controller pod
+kubectl wait --for=condition=Ready pod/otel-controller -n monarch-tests --timeout=120s
+```
+
+## Run the Example
+
+```bash
+# Copy the script to the controller
+kubectl cp main.py monarch-tests/otel-controller:/tmp/main.py
+
+# Run the example
+kubectl exec -it otel-controller -n monarch-tests -- \
+  python /tmp/main.py --num-replicas=2 --iterations=5
+```
+
+The script provisions a MonarchMesh with `OTEL_EXPORTER_OTLP_ENDPOINT` set on worker pods, spawns actors, runs several rounds of work, then cleans up.
+
+## Verify Metrics
+
+Check the collector's debug output to confirm metrics are being received:
+
+```bash
+kubectl logs -n monarch-tests deployment/otel-collector --tail=100
+```
+
+You should see metric data points logged with names like `mailbox.posts`, `actor.messages_sent`, `actor.messages_received`, etc.
+
+To view metrics via Prometheus:
+
+```bash
+# Port-forward the Prometheus endpoint
+kubectl port-forward -n monarch-tests svc/otel-collector 8889:8889
+
+# In another terminal, scrape metrics
+curl -s http://localhost:8889/metrics | head -50
+```
+
+## Expected Output
+
+```
+Controller OTEL_EXPORTER_OTLP_ENDPOINT: http://otel-collector.monarch-tests.svc.cluster.local:4318
+Connecting to Kubernetes...
+Waiting for 2 worker pod(s)...
+Spawning actors...
+  Round 1: ['pong from workers-0.workers.monarch-tests.svc.cluster.local', ...]
+    workers-0...: computed 1000 iterations
+    workers-1...: computed 1000 iterations
+  Round 2: ['pong from workers-0...', ...]
+  ...
+Waiting for metrics to flush to collector...
+
+Verify metrics in the OTEL collector logs:
+  kubectl logs -n monarch-tests deployment/otel-collector --tail=100
+
+Scrape Prometheus endpoint:
+  kubectl port-forward -n monarch-tests svc/otel-collector 8889:8889
+  curl http://localhost:8889/metrics
+Done.
+```
+
+## Cleanup
+
+```bash
+kubectl delete -f manifests/controller.yaml
+kubectl delete -f manifests/otel-collector.yaml
+kubectl delete namespace monarch-tests
+```
+
+## Configuration
+
+| Environment Variable | Default | Description |
+|---|---|---|
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | (unset) | Collector endpoint. When set, enables OTLP metric export. |
+| `OTEL_METRIC_EXPORT_INTERVAL` | `1s` | How often the periodic metric reader pushes to the exporter. |
+| `ENABLE_OTEL_METRICS` | `true` | Set to `false` to disable OTel metrics entirely. |
+| `OTEL_EXPORTER_OTLP_HEADERS` | (unset) | Additional headers for the OTLP exporter (e.g., auth tokens). |
+| `OTEL_EXPORTER_OTLP_TIMEOUT` | (unset) | Timeout for OTLP export requests. |

--- a/examples/kubernetes/otel_collector/main.py
+++ b/examples/kubernetes/otel_collector/main.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""
+OTEL Collector integration example for Monarch on Kubernetes.
+
+Demonstrates exporting Monarch's built-in actor metrics (mailbox posts,
+messages sent/received, queue sizes, etc.) to an OpenTelemetry Collector
+running in the same Kubernetes cluster.
+
+The OTEL_EXPORTER_OTLP_ENDPOINT env var is set on both the controller
+and worker pods, enabling the OTLP/HTTP metric exporter in Monarch's
+telemetry layer. Metrics are pushed to the collector, which exports
+them via its debug exporter (stdout) and a Prometheus scrape endpoint.
+"""
+
+import argparse
+import os
+import socket
+import textwrap
+import time
+
+from kubernetes import client
+from monarch.actor import Actor, endpoint
+from monarch.job.kubernetes import KubernetesJob
+
+
+_OTEL_ENDPOINT = "http://otel-collector.monarch-tests.svc.cluster.local:4318"
+
+_WORKER_BOOTSTRAP_SCRIPT: str = textwrap.dedent("""\
+    import os
+    import socket
+    from monarch.actor import run_worker_loop_forever
+    port = os.environ.get("MONARCH_PORT", "26600")
+    hostname = socket.getfqdn()
+    address = f"tcp://{hostname}:{port}"
+    run_worker_loop_forever(address=address, ca="trust_all_connections")
+""")
+
+
+class WorkActor(Actor):
+    """Actor that performs work to generate telemetry."""
+
+    @endpoint
+    def do_work(self, iterations: int) -> dict:
+        """Run a loop to generate actor message metrics."""
+        total = 0
+        for i in range(iterations):
+            total += i * i
+        return {
+            "hostname": socket.gethostname(),
+            "iterations": iterations,
+            "result": total,
+        }
+
+    @endpoint
+    def ping(self) -> str:
+        return f"pong from {socket.gethostname()}"
+
+
+def build_worker_pod_spec(port: int) -> client.V1PodSpec:
+    """Build a V1PodSpec with OTEL_EXPORTER_OTLP_ENDPOINT configured."""
+    return client.V1PodSpec(
+        containers=[
+            client.V1Container(
+                name="worker",
+                image="ghcr.io/meta-pytorch/monarch:latest",
+                command=["python", "-u", "-c", _WORKER_BOOTSTRAP_SCRIPT],
+                env=[
+                    client.V1EnvVar(name="MONARCH_PORT", value=str(port)),
+                    client.V1EnvVar(
+                        name="OTEL_EXPORTER_OTLP_ENDPOINT",
+                        value=_OTEL_ENDPOINT,
+                    ),
+                ],
+            )
+        ]
+    )
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Monarch OTEL Collector Kubernetes example"
+    )
+    parser.add_argument(
+        "--num-replicas",
+        type=int,
+        default=2,
+        help="Number of worker replicas (default: 2)",
+    )
+    parser.add_argument(
+        "--iterations",
+        type=int,
+        default=5,
+        help="Number of work rounds to generate metrics (default: 5)",
+    )
+    args = parser.parse_args()
+
+    otel_endpoint = os.environ.get("OTEL_EXPORTER_OTLP_ENDPOINT", "")
+    print(f"Controller OTEL_EXPORTER_OTLP_ENDPOINT: {otel_endpoint}")
+
+    print("Connecting to Kubernetes...")
+    job = KubernetesJob(namespace="monarch-tests")
+    port = 26600
+    job.add_mesh(
+        "workers",
+        num_replicas=args.num_replicas,
+        pod_spec=build_worker_pod_spec(port),
+        port=port,
+    )
+
+    print(f"Waiting for {args.num_replicas} worker pod(s)...")
+    state = job.state()
+    host_mesh = state.workers
+    procs = host_mesh.spawn_procs()
+
+    print("Spawning actors...")
+    actors = procs.spawn("work_actor", WorkActor)
+
+    # Run several rounds of work to generate a stream of metrics.
+    for i in range(args.iterations):
+        results = actors.ping.call().get()
+        print(f"  Round {i + 1}: {list(results)}")
+        work_results = actors.do_work.call(1000).get()
+        for _, result in work_results.items():
+            print(
+                f"    {result['hostname']}: computed {result['iterations']} iterations"
+            )
+
+    # Wait for the periodic metric reader to flush at least once.
+    print("Waiting for metrics to flush to collector...")
+    time.sleep(3)
+
+    print()
+    print("Verify metrics in the OTEL collector logs:")
+    print("  kubectl logs -n monarch-tests deployment/otel-collector --tail=100")
+    print()
+    print("Scrape Prometheus endpoint:")
+    print("  kubectl port-forward -n monarch-tests svc/otel-collector 8889:8889")
+    print("  curl http://localhost:8889/metrics")
+
+    procs.stop().get()
+    job.kill()
+    print("Done.")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/kubernetes/otel_collector/manifests/controller.yaml
+++ b/examples/kubernetes/otel_collector/manifests/controller.yaml
@@ -1,0 +1,64 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Controller pod for running the OTEL collector example.
+# Includes RBAC for creating MonarchMesh CRDs and watching pods,
+# and sets OTEL_EXPORTER_OTLP_ENDPOINT so the controller process
+# also exports its own metrics to the collector.
+#
+# Prerequisites:
+# - monarch-tests namespace created
+# - otel-collector deployed (see otel-collector.yaml)
+# - Monarch operator installed
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: otel-controller
+  namespace: monarch-tests
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: otel-controller
+  namespace: monarch-tests
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["monarch.pytorch.org"]
+    resources: ["monarchmeshes"]
+    verbs: ["create", "get", "patch", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: otel-controller
+  namespace: monarch-tests
+subjects:
+  - kind: ServiceAccount
+    name: otel-controller
+    namespace: monarch-tests
+roleRef:
+  kind: Role
+  name: otel-controller
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: otel-controller
+  namespace: monarch-tests
+spec:
+  serviceAccountName: otel-controller
+  containers:
+    - name: controller
+      image: ghcr.io/meta-pytorch/monarch:latest
+      command: ["sleep"]
+      args: ["infinity"]
+      env:
+        - name: OTEL_EXPORTER_OTLP_ENDPOINT
+          value: "http://otel-collector.monarch-tests.svc.cluster.local:4318"

--- a/examples/kubernetes/otel_collector/manifests/otel-collector.yaml
+++ b/examples/kubernetes/otel_collector/manifests/otel-collector.yaml
@@ -1,0 +1,93 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# OpenTelemetry Collector deployment for receiving Monarch metrics.
+#
+# Receives OTLP/HTTP on port 4318 and exports via:
+# - debug exporter (logs metrics to stdout for verification)
+# - prometheus exporter (exposes /metrics on port 8889 for scraping)
+#
+# Prerequisites:
+# - monarch-tests namespace created
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: otel-collector-config
+  namespace: monarch-tests
+data:
+  config.yaml: |
+    receivers:
+      otlp:
+        protocols:
+          http:
+            endpoint: "0.0.0.0:4318"
+
+    processors:
+      batch:
+        timeout: 5s
+        send_batch_size: 1024
+
+    exporters:
+      debug:
+        verbosity: detailed
+      prometheus:
+        endpoint: "0.0.0.0:8889"
+
+    service:
+      pipelines:
+        metrics:
+          receivers: [otlp]
+          processors: [batch]
+          exporters: [debug, prometheus]
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: otel-collector
+  namespace: monarch-tests
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: otel-collector
+  template:
+    metadata:
+      labels:
+        app: otel-collector
+    spec:
+      containers:
+        - name: collector
+          image: otel/opentelemetry-collector-contrib:0.120.0
+          args: ["--config=/etc/otel/config.yaml"]
+          ports:
+            - containerPort: 4318
+              name: otlp-http
+            - containerPort: 8889
+              name: prometheus
+          volumeMounts:
+            - name: config
+              mountPath: /etc/otel
+      volumes:
+        - name: config
+          configMap:
+            name: otel-collector-config
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: otel-collector
+  namespace: monarch-tests
+spec:
+  selector:
+    app: otel-collector
+  ports:
+    - name: otlp-http
+      port: 4318
+      targetPort: 4318
+    - name: prometheus
+      port: 8889
+      targetPort: 8889

--- a/hyperactor_telemetry/Cargo.toml
+++ b/hyperactor_telemetry/Cargo.toml
@@ -18,6 +18,7 @@ hyperactor_config = { version = "0.0.0", path = "../hyperactor_config" }
 lazy_static = "1.5"
 libc = "0.2.139"
 opentelemetry = "0.31"
+opentelemetry-otlp = { version = "0.31", features = ["grpc-tonic", "http-proto", "logs", "metrics", "reqwest-blocking-client", "trace", "zstd-tonic"], default-features = false }
 opentelemetry_sdk = { version = "0.31", features = ["experimental_metrics_custom_reader", "metrics", "rt-tokio"] }
 prost = { version = "0.14.3", default-features = false }
 rand = { version = "0.9", features = ["small_rng"] }

--- a/hyperactor_telemetry/src/lib.rs
+++ b/hyperactor_telemetry/src/lib.rs
@@ -55,6 +55,7 @@ pub mod in_memory_reader;
 #[cfg(fbcode_build)]
 mod meta;
 mod otel;
+pub(crate) mod otlp;
 mod pool;
 mod rate_limit;
 pub mod recorder;
@@ -1223,6 +1224,8 @@ fn initialize_logging_with_log_prefix_impl(
                 tracing::debug!("logging already initialized for this process: {}", err);
             }
         }
+
+        otel::init_metrics();
 
         Box::new(EmptyTestHandle)
     }

--- a/hyperactor_telemetry/src/otel.rs
+++ b/hyperactor_telemetry/src/otel.rs
@@ -26,4 +26,10 @@ pub fn init_metrics() {
     {
         opentelemetry::global::set_meter_provider(crate::meta::meter_provider());
     }
+    #[cfg(not(fbcode_build))]
+    {
+        if let Some(provider) = crate::otlp::otlp_meter_provider() {
+            opentelemetry::global::set_meter_provider(provider);
+        }
+    }
 }

--- a/hyperactor_telemetry/src/otlp.rs
+++ b/hyperactor_telemetry/src/otlp.rs
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+//! OTLP export for OSS observability.
+//!
+//! When `OTEL_EXPORTER_OTLP_ENDPOINT` is set, this module provides:
+//! - A `SdkMeterProvider` that exports metrics via OTLP/HTTP+protobuf
+//! - An `OtlpTraceSink` that exports traces via OTLP/HTTP+protobuf
+//!
+//! When the env var is unset, both functions return `None`, preserving
+//! the current no-op behavior for OSS builds.
+
+use opentelemetry_sdk::metrics::SdkMeterProvider;
+
+use crate::config::OTEL_METRIC_EXPORT_INTERVAL;
+
+#[allow(dead_code)]
+const OTLP_ENDPOINT_ENV: &str = "OTEL_EXPORTER_OTLP_ENDPOINT";
+
+/// Build an OTLP-backed `SdkMeterProvider` if `OTEL_EXPORTER_OTLP_ENDPOINT` is set.
+///
+/// The `opentelemetry-otlp` crate automatically reads standard OTel env vars
+/// (`OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_EXPORTER_OTLP_HEADERS`,
+/// `OTEL_EXPORTER_OTLP_TIMEOUT`, etc.), so callers only need to set those.
+///
+/// Returns `None` if the endpoint is not configured, leaving the global
+/// meter provider as the default no-op.
+#[allow(dead_code)]
+pub fn otlp_meter_provider() -> Option<SdkMeterProvider> {
+    if std::env::var(OTLP_ENDPOINT_ENV).is_err() {
+        return None;
+    }
+
+    let exporter = match opentelemetry_otlp::MetricExporter::builder()
+        .with_http()
+        .build()
+    {
+        Ok(e) => e,
+        Err(e) => {
+            eprintln!("[telemetry] failed to build OTLP metric exporter: {}", e);
+            return None;
+        }
+    };
+
+    let interval = hyperactor_config::global::get(OTEL_METRIC_EXPORT_INTERVAL);
+
+    let reader = opentelemetry_sdk::metrics::PeriodicReader::builder(exporter)
+        .with_interval(interval)
+        .build();
+
+    let provider = SdkMeterProvider::builder().with_reader(reader).build();
+
+    Some(provider)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_otlp_meter_provider_returns_none_without_endpoint() {
+        // Safety: test-only; no other threads read this env var concurrently.
+        unsafe { std::env::remove_var(OTLP_ENDPOINT_ENV) };
+        assert!(otlp_meter_provider().is_none());
+    }
+}


### PR DESCRIPTION
Summary: Add an OTLP-backed SdkMeterProvider that exports metrics to an OTel Collector via HTTP/protobuf when OTEL_EXPORTER_OTLP_ENDPOINT is set. When the env var is unset, the existing no-op behavior is preserved. The opentelemetry-otlp crate automatically reads standard OTel env vars for endpoint, headers, and timeout configuration.

Differential Revision: D95336575
