### PR TITLE
surpress unused dependency warnings

### DIFF
--- a/build_utils/src/lib.rs
+++ b/build_utils/src/lib.rs
@@ -16,6 +16,12 @@ use std::path::Path;
 use std::path::PathBuf;
 
 use glob::glob;
+// pyo3_build_config is only called inside #[cfg(not(fbcode_build))],
+// so the Buck compiler never sees a direct reference. This import
+// suppresses the unused_extern warning while keeping the dep explicit
+// in the generated Cargo.toml (autocargo doesn't propagate transitive
+// deps).
+use pyo3_build_config as _;
 use which::which;
 
 pub mod rocm;

--- a/hyper/src/main.rs
+++ b/hyper/src/main.rs
@@ -12,6 +12,12 @@ use clap::Parser;
 use clap::Subcommand;
 use hyperactor::clock::Clock;
 use hyperactor::clock::RealClock;
+// tokio is used by #[tokio::main] in OSS builds
+// (cfg(not(fbcode_build))). In fbcode builds fbinit-tokio provides
+// the runtime, so the compiler doesn't see a direct reference. This
+// import suppresses the unused_extern warning while keeping tokio
+// explicit in the generated Cargo.toml.
+use tokio as _;
 
 use crate::commands::list::ListCommand;
 use crate::commands::resolve::ResolveCommand;


### PR DESCRIPTION
Summary:
this
```lang=text,counterexample
Target `fbcode//monarch/build_utils:build_utils` has unused dependencies:
    fbsource//third-party/rust:pyo3-build-config: pyo3_build_config

Target `fbcode//monarch/hyper:hyper` has unused dependencies:
    fbsource//third-party/rust:tokio: tokio

Target `fbcode//monarch/hyper:hyper-unittest` has unused dependencies:
    fbsource//third-party/rust:tokio: tokio
```
has been driving me up the wall. fix it.

Differential Revision: D95444505


