### PR TITLE
Log when stalls occur in ActorMeshController supervision loop

### DIFF
--- a/hyperactor/src/proc.rs
+++ b/hyperactor/src/proc.rs
@@ -1721,7 +1721,6 @@ impl<A: Actor> Instance<A> {
         }
     }
 
-    #[tracing::instrument(level = "debug", skip_all)]
     async unsafe fn handle_message<M: Message>(
         &self,
         actor: &mut A,
@@ -1737,14 +1736,31 @@ impl<A: Actor> Instance<A> {
             Some(info) => {
                 // SAFETY: The caller promises to pass the correct type info.
                 let arm = unsafe { info.arm_unchecked(&message as *const M as *const ()) };
-                Some(HandlerInfo::from_static(info.typename(), arm))
+                HandlerInfo::from_static(info.typename(), arm)
             }
             None => {
                 // Fall back to std::any::type_name (also static, zero-copy).
-                Some(HandlerInfo::from_static(std::any::type_name::<M>(), None))
+                HandlerInfo::from_static(std::any::type_name::<M>(), None)
             }
         };
+        // Use a helper function for a better instrument log.
+        self.handle_message_with_handler_info(actor, handler_info, headers, message)
+            .await
+    }
 
+    // Skip serializing all fields except HandlerInfo which includes the typename.
+    #[tracing::instrument(level = "debug", name = "handle_message", skip_all, fields(actor_id = %self.self_id(), message_type = %handler_info))]
+    async fn handle_message_with_handler_info<M: Message>(
+        &self,
+        actor: &mut A,
+        handler_info: HandlerInfo,
+        headers: Flattrs,
+        message: M,
+    ) -> Result<(), anyhow::Error>
+    where
+        A: Handler<M>,
+    {
+        let handler_info = Some(handler_info);
         self.change_status(ActorStatus::Processing(
             self.clock().system_time_now(),
             handler_info.clone(),

--- a/hyperactor_mesh/src/mesh_controller.rs
+++ b/hyperactor_mesh/src/mesh_controller.rs
@@ -27,6 +27,7 @@ use hyperactor::actor::handle_undeliverable_message;
 use hyperactor::clock::Clock;
 use hyperactor::clock::RealClock;
 use hyperactor::context;
+use hyperactor::kv_pairs;
 use hyperactor::mailbox::MessageEnvelope;
 use hyperactor::mailbox::Undeliverable;
 use hyperactor::supervision::ActorSupervisionEvent;
@@ -34,6 +35,7 @@ use hyperactor_config::CONFIG;
 use hyperactor_config::ConfigAttr;
 use hyperactor_config::Flattrs;
 use hyperactor_config::attrs::declare_attrs;
+use hyperactor_telemetry::declare_static_counter;
 use ndslice::ViewExt;
 use ndslice::view::CollectMeshExt;
 use ndslice::view::Point;
@@ -70,6 +72,11 @@ declare_attrs! {
     ))
     pub attr SUPERVISION_POLL_FREQUENCY: Duration = Duration::from_secs(10);
 }
+
+declare_static_counter!(
+    ACTOR_MESH_CONTROLLER_SUPERVISION_STALLS,
+    "actor.actor_mesh_controller.num_stalls"
+);
 
 #[derive(Debug)]
 struct HealthState {
@@ -118,8 +125,10 @@ pub struct GetSubscriberCount(#[binding(include)] pub PortRef<usize>);
 
 /// Check state of the actors in the mesh. This is used as a self message to
 /// periodically check.
+/// Stores the next time we expect to start running a check state message.
+/// Used to check for stalls in message handling.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Named, Bind, Unbind)]
-pub struct CheckState();
+pub struct CheckState(pub std::time::SystemTime);
 
 /// The implementation of monitoring works as follows:
 /// * ActorMesh and ActorMeshRef subscribe for updates from this controller,
@@ -188,10 +197,10 @@ impl<A: Referable> ActorMeshController<A> {
     fn self_check_state_message(&self, cx: &Instance<Self>) -> Result<(), ActorError> {
         // Only schedule a self message if the monitor has not been dropped.
         if self.monitor.is_some() {
-            cx.self_message_with_delay(
-                CheckState {},
-                hyperactor_config::global::get(SUPERVISION_POLL_FREQUENCY),
-            )
+            // Save when we expect the next check state message, so we can automatically
+            // detect stalls as they accumulate.
+            let delay = hyperactor_config::global::get(SUPERVISION_POLL_FREQUENCY);
+            cx.self_message_with_delay(CheckState(RealClock.system_time_now() + delay), delay)
         } else {
             Ok(())
         }
@@ -625,6 +634,11 @@ fn actor_state_to_supervision_events(
     (rank, events)
 }
 
+fn format_system_time(time: std::time::SystemTime) -> String {
+    let datetime: chrono::DateTime<chrono::Local> = time.into();
+    datetime.format("%Y-%m-%d %H:%M:%S").to_string()
+}
+
 #[async_trait]
 impl<A: Referable> Handler<CheckState> for ActorMeshController<A> {
     /// Checks actor states and reschedules as a self-message.
@@ -638,13 +652,35 @@ impl<A: Referable> Handler<CheckState> for ActorMeshController<A> {
     ///
     /// * SUPERVISION_POLL_FREQUENCY controls how frequently to poll.
     /// * self-messaging stops when self.monitor is set to None.
-    async fn handle(&mut self, cx: &Context<Self>, _: CheckState) -> Result<(), anyhow::Error> {
+    async fn handle(
+        &mut self,
+        cx: &Context<Self>,
+        CheckState(expected_time): CheckState,
+    ) -> Result<(), anyhow::Error> {
         // This implementation polls every "time_between_checks" duration, checking
         // for changes in the actor states. It can be improved in two ways:
         // 1. Use accumulation, to get *any* actor with a change in state, not *all*
         //    actors.
         // 2. Use a push-based mode instead of polling.
         // Wait in between checking to avoid using too much network.
+
+        // Check for stalls in the supervision loop. These delays can cause the
+        // subscribers to think the controller is dead.
+        // Allow a little slack time to avoid logging for innocuous delays.
+        // If it's greater than 2x the expected time, log a warning.
+        if RealClock.system_time_now()
+            > expected_time + hyperactor_config::global::get(SUPERVISION_POLL_FREQUENCY)
+        {
+            // Current time is included by default in the log message.
+            let expected_time = format_system_time(expected_time);
+            // Track in both metrics and tracing.
+            ACTOR_MESH_CONTROLLER_SUPERVISION_STALLS.add(1, kv_pairs!("actor_id" => cx.self_id().to_string(), "expected_time" => expected_time.clone()));
+            tracing::warn!(
+                actor_id = %cx.self_id(),
+                "Handler<CheckState> is being stalled, expected at {}",
+                expected_time,
+            );
+        }
         let mesh = &self.mesh;
         let supervision_display_name = &self.supervision_display_name;
         // First check if the proc mesh is dead before trying to query their agents.


### PR DESCRIPTION
Summary:
This diff improves logging to help detect stalls in the actor mesh controller supervision
loop. It relies on a self message every 10 seconds. If this gets stalled too much, subscribers
may think the controller is dead (they wait for 2 minutes to get a heartbeat). Add a metric for
this event, and also log a warning.

While investigating this, I realized we don't have a simple way to query for what messages
are getting processed. To this end, I enhanced the `instrument` on `Instance::handle_message`
to include the message typename and the actor id. If this would cause a performance regression,
I can downgrade the logging level to trace.

Reviewed By: thomasywang

Differential Revision: D95421329


