### PR TITLE
tui: register client host (C) with MeshAdminAgent via spawn_admin so admin introspects it as a normal host subtree (A/C invariant)

### DIFF
--- a/hyperactor_mesh/bin/admin_tui/diagnostics.rs
+++ b/hyperactor_mesh/bin/admin_tui/diagnostics.rs
@@ -286,9 +286,8 @@ async fn walk(client: &reqwest::Client, base_url: &str, tx: &mpsc::Sender<DiagRe
         None => return,
     };
 
-    // Root-level system children are admin infrastructure managed by
-    // the framework. Skip them here — they are not host agents and
-    // their children are not user procs.
+    // Root system_children is always empty (procs are never system,
+    // standalone procs removed from root). Filter kept for robustness.
     let root_system_refs: HashSet<&str> = match &root_payload.properties {
         NodeProperties::Root {
             system_children, ..

--- a/hyperactor_mesh/bin/admin_tui/theme.rs
+++ b/hyperactor_mesh/bin/admin_tui/theme.rs
@@ -75,7 +75,7 @@ pub(crate) struct Args {
     pub(crate) mast_resolver: Option<String>,
 
     /// Refresh interval in milliseconds
-    #[arg(long, default_value_t = 1000)]
+    #[arg(long, default_value_t = 2000)]
     pub(crate) refresh_ms: u64,
 
     /// Color theme

--- a/hyperactor_mesh/src/global_context.rs
+++ b/hyperactor_mesh/src/global_context.rs
@@ -479,6 +479,29 @@ pub async fn this_proc() -> &'static ProcMeshRef {
     &GLOBAL_CONTEXT.get_or_init(bootstrap_host).await.proc_mesh
 }
 
+/// Separate storage for client host registered by non-Rust runtimes
+/// (e.g. Python's `bootstrap_host()`). Checked by `try_this_host()`
+/// alongside `GLOBAL_CONTEXT`.
+static REGISTERED_CLIENT_HOST: std::sync::OnceLock<HostMeshRef> = std::sync::OnceLock::new();
+
+/// Register the client host mesh from an external runtime (Python).
+/// Called by Python's `bootstrap_host()` so that `try_this_host()`
+/// can discover C for the A/C invariant.
+pub fn register_client_host(host_mesh: HostMeshRef) {
+    let _ = REGISTERED_CLIENT_HOST.set(host_mesh);
+}
+
+/// Returns the client host mesh if available, without triggering
+/// lazy bootstrap. Checks both the Rust global context and the
+/// external registration (Python). Used by `MeshAdminAgent` to
+/// discover C at query time (A/C invariant).
+pub fn try_this_host() -> Option<&'static HostMeshRef> {
+    GLOBAL_CONTEXT
+        .get()
+        .map(|state| &state.host_mesh)
+        .or_else(|| REGISTERED_CLIENT_HOST.get())
+}
+
 #[cfg(test)]
 mod tests {
     use std::time::Duration;

--- a/hyperactor_mesh/src/host_mesh.rs
+++ b/hyperactor_mesh/src/host_mesh.rs
@@ -903,6 +903,16 @@ impl HostMeshRef {
         })
     }
 
+    /// Returns the host entries as `(addr_string, ActorRef<HostAgent>)` pairs.
+    /// Used by `MeshAdminAgent::effective_hosts()` to merge C into the
+    /// admin's host list (A/C invariant).
+    pub(crate) fn host_entries(&self) -> Vec<(String, ActorRef<HostAgent>)> {
+        self.ranks
+            .iter()
+            .map(|h| (h.0.to_string(), h.mesh_agent()))
+            .collect()
+    }
+
     /// Push client config to all host agents in this mesh, in parallel.
     ///
     /// Each host installs the attrs as `Source::ClientOverride`.
@@ -1244,11 +1254,29 @@ impl HostMeshRef {
         cx: &impl hyperactor::context::Actor,
         admin_addr: Option<std::net::SocketAddr>,
     ) -> anyhow::Result<String> {
-        let hosts: Vec<(String, ActorRef<HostAgent>)> = self
+        let mut hosts: Vec<(String, ActorRef<HostAgent>)> = self
             .ranks
             .iter()
             .map(|h| (h.0.to_string(), h.mesh_agent()))
             .collect();
+
+        // A/C invariant: include C (the client host) so the admin
+        // can introspect it as a normal host subtree. Dedup by
+        // HostAgent ActorId for C ∈ A. Works for both same-process
+        // and cross-process (MAST) because we read C here on the
+        // caller's process and send it in the message.
+        if let Some(client_host) = crate::global_context::try_this_host() {
+            for (addr, agent_ref) in client_host.host_entries() {
+                let agent_id = agent_ref.actor_id();
+                if !hosts
+                    .iter()
+                    .any(|(_, existing)| existing.actor_id() == agent_id)
+                {
+                    hosts.push((addr, agent_ref));
+                }
+            }
+        }
+
         let root_client_id = cx.mailbox().actor_id().clone();
 
         let head_agent = self.ranks[0].mesh_agent();

--- a/hyperactor_mesh/src/mesh_admin.rs
+++ b/hyperactor_mesh/src/mesh_admin.rs
@@ -90,9 +90,7 @@
 //! error payloads (`ResolveReferenceResponse(Err(..))`,
 //! `NodeProperties::Error`, etc.) rather than propagating panics or
 //! unwinding. Failed reply sends (the caller went away) are silently
-//! swallowed. This is critical because the admin agent is
-//! co-located with the mesh coordinator — an unhandled panic would
-//! tear down the entire mesh.
+//! swallowed.
 //!
 //! ## TLS transport invariant
 //!
@@ -106,6 +104,40 @@
 //! `http://host:port`, never a bare `host:port`. All callers (Rust
 //! examples, Python examples, TUI, tests) receive and use this full
 //! URL directly.
+//!
+//! ## Client host invariant (A/C)
+//!
+//! Let **A** denote the observed host mesh (the host mesh for which
+//! this `MeshAdminAgent` was spawned), and let **C** denote the
+//! process-global singleton client host mesh in the caller process
+//! (whose local proc hosts the root client actor).
+//!
+//! C may or may not be a member of A:
+//!
+//! - **C ∈ A:** The client host is already one of A's hosts. It
+//!   appears exactly once in the admin host list (deduplicated by
+//!   `HostAgent` `ActorId` identity).
+//! - **C ∉ A:** The client host is separate from A.
+//!   [`HostMeshRef::spawn_admin`] includes C alongside A's hosts so
+//!   the admin introspects C as a normal host subtree (`host -> proc
+//!   -> actors`), not as a standalone proc.
+//!
+//! In both cases, the root client actor is reachable through the
+//! standard host -> proc -> actor walk.
+//!
+//! **Ordering invariant:** `spawn_admin` requires `cx: &impl
+//! context::Actor` (the caller's root client instance). Constructing
+//! that instance initializes C (Rust: `context().await`; Python:
+//! bootstrap path). Therefore C is available when `spawn_admin`
+//! executes. Any refactor must preserve this ordering: creating `cx`
+//! initializes C, and `spawn_admin` consumes `cx`.
+//!
+//! **Mechanism:** [`HostMeshRef::spawn_admin`] reads C from the
+//! caller process (via `try_this_host()`), merges it with A's host
+//! list, deduplicates by `HostAgent` `ActorId`, and sends the merged
+//! list in `SpawnMeshAdmin`. This works for same-process and
+//! cross-process setups because merge+dedeup happens in the caller
+//! process before sending the spawn request.
 
 use std::collections::HashMap;
 use std::io;
@@ -343,7 +375,7 @@ wirevalue::register_type!(ResolveReferenceMessage);
 #[hyperactor::export(handlers = [MeshAdminMessage, ResolveReferenceMessage])]
 pub struct MeshAdminAgent {
     /// Map of host address string → `HostAgent` reference used to
-    /// fan out or target admin queries.
+    /// fan out our target admin queries.
     hosts: HashMap<String, ActorRef<HostAgent>>,
 
     /// Reverse index: `HostAgent` `ActorId` → host address
@@ -781,8 +813,11 @@ impl MeshAdminAgent {
     /// managed by any host but whose actors are routable and
     /// introspectable. Each proc appears as a root child; the
     /// actor is the "anchor" used to discover the proc's contents.
+    ///
+    /// The root client is no longer standalone: spawn_admin registers
+    /// C (the bootstrap host) as a normal host entry (A/C invariant).
     fn standalone_proc_actors(&self) -> impl Iterator<Item = &ActorId> {
-        self.root_client_actor_id.iter()
+        std::iter::empty()
     }
 
     /// If `proc_id` belongs to a standalone proc, return the anchor
@@ -805,17 +840,11 @@ impl MeshAdminAgent {
     /// `HostAgent` actor IDs (as reference strings) plus any
     /// standalone procs (root client proc, admin proc).
     fn build_root_payload(&self) -> NodePayload {
-        let mut children: Vec<String> = self
+        let children: Vec<String> = self
             .hosts
             .values()
             .map(|agent| HostId(agent.actor_id().clone()).to_string())
             .collect();
-        // Standalone procs are visible at root level but not hidden
-        // as system — procs are never system, only actors are.
-        for actor_id in self.standalone_proc_actors() {
-            let proc_ref = actor_id.proc_id().to_string();
-            children.push(proc_ref);
-        }
         let system_children: Vec<String> = Vec::new();
         NodePayload {
             identity: "root".to_string(),
@@ -2106,9 +2135,9 @@ mod tests {
         assert!(found_user, "should have resolved the user proc");
     }
 
-    // Verifies that build_root_payload includes the root client proc
-    // ID in the children list when provided, alongside the host
-    // children.
+    // Verifies that build_root_payload lists only the host as a
+    // child. The root client is visible under its host's local proc,
+    // not at root level.
     #[test]
     fn test_build_root_payload_with_root_client() {
         let addr1: SocketAddr = "127.0.0.1:9001".parse().unwrap();
@@ -2116,8 +2145,6 @@ mod tests {
         let actor_id1 = ActorId::root(proc1, "mesh_agent".to_string());
         let ref1: ActorRef<HostAgent> = ActorRef::attest(actor_id1.clone());
 
-        // The root client now lives on the Host's "local" proc, not a
-        // standalone "mesh_root_client_proc". Using "local" here to match.
         let client_proc_id = ProcId(ChannelAddr::Tcp(addr1), "local".to_string());
         let client_actor_id = client_proc_id.actor_id("client", 0);
 
@@ -2132,23 +2159,20 @@ mod tests {
             payload.properties,
             NodeProperties::Root { num_hosts: 1, .. }
         ));
-        // Should have 2 children: one host + one root client proc.
-        assert_eq!(payload.children.len(), 2);
+        // Only the host; root client is under host → local proc.
+        assert_eq!(payload.children.len(), 1);
         assert!(
             payload
                 .children
                 .contains(&HostId(actor_id1.clone()).to_string())
         );
-        assert!(payload.children.contains(&client_proc_id.to_string()));
     }
 
-    // Verifies that resolving the root client ActorId via the
-    // resolver returns a NodePayload with parent = "root",
-    // confirming that the root client is treated as a first-class
-    // child of root.
+    // Verifies that the root client actor is visible through the
+    // host → local proc → actor path, not as a standalone child of
+    // root.
     #[tokio::test]
     async fn test_resolve_root_client_actor() {
-        use hyperactor::Proc;
         use hyperactor::channel::ChannelTransport;
         use hyperactor::host::Host;
         use hyperactor::host::LocalProcManager;
@@ -2167,6 +2191,15 @@ mod tests {
                 .unwrap();
         let host_addr = host.addr().clone();
         let system_proc = host.system_proc().clone();
+
+        // Spawn the root client on the host's local proc (before
+        // moving the host into HostAgentMode).
+        let local_proc = host.local_proc();
+        let local_proc_id = local_proc.proc_id().clone();
+        let root_client_handle = local_proc.spawn("client", TestIntrospectableActor).unwrap();
+        let root_client_ref: ActorRef<TestIntrospectableActor> = root_client_handle.bind();
+        let root_client_actor_id = root_client_ref.actor_id().clone();
+
         let host_agent_handle = system_proc
             .spawn(
                 crate::host_mesh::host_agent::HOST_MESH_AGENT_ACTOR_NAME,
@@ -2176,22 +2209,9 @@ mod tests {
         let host_agent_ref: ActorRef<HostAgent> = host_agent_handle.bind();
         let host_addr_str = host_addr.to_string();
 
-        // Create a genuinely introspectable root client actor.
-        // proc.spawn() starts the message loop; handle.bind()
-        // registers the IntrospectMessage port for remote delivery.
-        let root_client_proc =
-            Proc::direct(ChannelTransport::Unix.any(), "root_client".to_string()).unwrap();
-        let _root_client_supervision = ProcSupervisionCoordinator::set(&root_client_proc)
-            .await
-            .unwrap();
-        let root_client_handle = root_client_proc
-            .spawn("client", TestIntrospectableActor)
-            .unwrap();
-        let root_client_ref: ActorRef<TestIntrospectableActor> = root_client_handle.bind();
-        let root_client_actor_id = root_client_ref.actor_id().clone();
-
         // Spawn MeshAdminAgent with the root client ActorId.
-        let admin_proc = Proc::direct(ChannelTransport::Unix.any(), "admin".to_string()).unwrap();
+        let admin_proc =
+            hyperactor::Proc::direct(ChannelTransport::Unix.any(), "admin".to_string()).unwrap();
         use hyperactor::testing::proc_supervison::ProcSupervisionCoordinator;
         let _supervision = ProcSupervisionCoordinator::set(&admin_proc).await.unwrap();
         let admin_handle = admin_proc
@@ -2207,27 +2227,41 @@ mod tests {
         let admin_ref: ActorRef<MeshAdminAgent> = admin_handle.bind();
 
         // Client for sending messages.
-        let client_proc = Proc::direct(ChannelTransport::Unix.any(), "client".to_string()).unwrap();
+        let client_proc =
+            hyperactor::Proc::direct(ChannelTransport::Unix.any(), "client".to_string()).unwrap();
         let (client, _handle) = client_proc.instance("client").unwrap();
 
-        // Resolve "root" — should include the root client proc in children.
+        // Resolve "root" — should contain only the host.
         let root_resp = admin_ref
             .resolve(&client, "root".to_string())
             .await
             .unwrap();
         let root = root_resp.0.unwrap();
-        let root_client_proc_id = root_client_actor_id.proc_id().to_string();
+        let host_id_str = HostId(host_agent_ref.actor_id().clone()).to_string();
         assert!(
-            root.children.contains(&root_client_proc_id),
-            "root children {:?} should contain root client proc {}",
+            root.children.contains(&host_id_str),
+            "root children {:?} should contain host {}",
             root.children,
-            root_client_proc_id
+            host_id_str
         );
 
-        // Resolve the root client proc — should return Proc properties
-        // with parent = "root" and the root client actor as a child.
+        // Resolve the host — should list the local proc in children.
+        let host_resp = admin_ref
+            .resolve(&client, host_id_str.clone())
+            .await
+            .unwrap();
+        let host_node = host_resp.0.unwrap();
+        let local_proc_str = local_proc_id.to_string();
+        assert!(
+            host_node.children.contains(&local_proc_str),
+            "host children {:?} should contain local proc {}",
+            host_node.children,
+            local_proc_str
+        );
+
+        // Resolve the local proc — should contain the root client actor.
         let proc_resp = admin_ref
-            .resolve(&client, root_client_proc_id.clone())
+            .resolve(&client, local_proc_str.clone())
             .await
             .unwrap();
         let proc_node = proc_resp.0.unwrap();
@@ -2236,22 +2270,16 @@ mod tests {
             "expected Proc properties, got {:?}",
             proc_node.properties
         );
-        assert_eq!(
-            proc_node.parent,
-            Some("root".to_string()),
-            "root client proc parent should be 'root'"
-        );
         assert!(
             proc_node
                 .children
                 .contains(&root_client_actor_id.to_string()),
-            "proc children {:?} should contain root client actor {}",
+            "local proc children {:?} should contain root client actor {}",
             proc_node.children,
             root_client_actor_id
         );
 
-        // Resolve the root client ActorId — should return Actor
-        // properties with parent = the proc.
+        // Resolve the root client actor — parent should be the local proc.
         let client_resp = admin_ref
             .resolve(&client, root_client_actor_id.to_string())
             .await
@@ -2264,8 +2292,8 @@ mod tests {
         );
         assert_eq!(
             client_node.parent,
-            Some(root_client_proc_id),
-            "root client parent should be the proc"
+            Some(local_proc_str),
+            "root client parent should be the local proc"
         );
     }
 

--- a/monarch_hyperactor/src/host_mesh.rs
+++ b/monarch_hyperactor/src/host_mesh.rs
@@ -328,6 +328,10 @@ fn bootstrap_host(bootstrap_cmd: Option<PyBootstrapCommand>) -> PyResult<PyPytho
         let host_mesh = HostMeshRef::from_host_agent(host_mesh_name, host_mesh_agent.bind())
             .map_err(|e| PyException::new_err(e.to_string()))?;
 
+        // Register C so MeshAdminAgent can discover it ("A/C
+        // invariant" - hyperactor_mesh/src/mesh_admin.rs).
+        hyperactor_mesh::global_context::register_client_host(host_mesh.clone());
+
         // We require a temporary instance to make a call to the host/proc agent.
         let temp_proc = Proc::local();
         let (temp_instance, _) = temp_proc


### PR DESCRIPTION
Differential Revision: D95553063


