### PR TITLE
Add Future.gather() for concurrent future execution

### DIFF
--- a/python/monarch/_src/actor/future.py
+++ b/python/monarch/_src/actor/future.py
@@ -13,6 +13,7 @@ from typing import (
     Coroutine,
     Generator,
     Generic,
+    List,
     NamedTuple,
     Optional,
     TypeVar,
@@ -198,3 +199,54 @@ class Future(Generic[R]):
             return None
         except Exception as e:
             return e
+
+    @staticmethod
+    def gather(
+        *futures: "Future[Any]",
+        return_exceptions: bool = False,
+    ) -> "Future[List[Any]]":
+        """Drive multiple Futures concurrently, returning a Future of their results.
+
+        Results are returned in the same order as the input futures.
+        Input futures are consumed and should not be reused.
+
+        Args:
+            return_exceptions: If False (default), the first exception raised by
+                any future propagates immediately. If True, exceptions are treated
+                as successful results and returned in the result list.
+        """
+        if not futures:
+
+            async def _empty() -> List[Any]:
+                return []
+
+            return Future(coro=_empty())
+
+        tasks: List[PythonTask[Any]] = []
+        for f in futures:
+            match f._status:
+                case _Unawaited(coro=coro):
+                    tasks.append(coro)
+                    f._status = _Exception(
+                        ValueError("this Future was consumed by gather()")
+                    )
+                case _:
+                    raise ValueError(
+                        "Future passed to gather() has already been consumed "
+                        "(via .get(), await, or another gather call)"
+                    )
+
+        async def _gather() -> List[Any]:
+            shared = [t.spawn() for t in tasks]
+            results: List[Any] = []
+            for s in shared:
+                if return_exceptions:
+                    try:
+                        results.append(await s)
+                    except Exception as e:
+                        results.append(e)
+                else:
+                    results.append(await s)
+            return results
+
+        return Future(coro=_gather())

--- a/python/tests/test_actor_future.py
+++ b/python/tests/test_actor_future.py
@@ -1,0 +1,82 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import pytest
+from monarch._src.actor.future import Future
+
+
+async def _return_value(v: object) -> object:
+    return v
+
+
+async def _raise_error(msg: str) -> object:
+    raise ValueError(msg)
+
+
+def test_gather_sync() -> None:
+    f1 = Future(coro=_return_value(1))
+    f2 = Future(coro=_return_value(2))
+    f3 = Future(coro=_return_value(3))
+    results = Future.gather(f1, f2, f3).get()
+    assert results == [1, 2, 3]
+
+
+def test_gather_preserves_order() -> None:
+    futures = [Future(coro=_return_value(i)) for i in range(10)]
+    results = Future.gather(*futures).get()
+    assert results == list(range(10))
+
+
+def test_gather_empty() -> None:
+    results = Future.gather().get()
+    assert results == []
+
+
+def test_gather_single() -> None:
+    result = Future.gather(Future(coro=_return_value(42))).get()
+    assert result == [42]
+
+
+def test_gather_error_propagation() -> None:
+    f1 = Future(coro=_return_value(1))
+    f2 = Future(coro=_raise_error("boom"))
+    f3 = Future(coro=_return_value(3))
+    with pytest.raises(ValueError, match="boom"):
+        Future.gather(f1, f2, f3).get()
+
+
+def test_gather_return_exceptions() -> None:
+    f1 = Future(coro=_return_value(1))
+    f2 = Future(coro=_raise_error("boom"))
+    f3 = Future(coro=_return_value(3))
+    results = Future.gather(f1, f2, f3, return_exceptions=True).get()
+    assert results[0] == 1
+    assert isinstance(results[1], ValueError)
+    assert str(results[1]) == "boom"
+    assert results[2] == 3
+
+
+def test_gather_consumed_future() -> None:
+    f1 = Future(coro=_return_value(1))
+    Future.gather(f1)
+    with pytest.raises(ValueError, match="consumed"):
+        f1.get()
+
+
+def test_gather_already_consumed_raises() -> None:
+    f1 = Future(coro=_return_value(1))
+    f1.get()
+    with pytest.raises(ValueError, match="already been consumed"):
+        Future.gather(f1)
+
+
+async def test_gather_async() -> None:
+    f1 = Future(coro=_return_value(10))
+    f2 = Future(coro=_return_value(20))
+    results = await Future.gather(f1, f2)
+    assert results == [10, 20]


### PR DESCRIPTION
Summary:
Add a `gather()` static method to the actor `Future` class that drives
multiple Futures concurrently. This provides a clean, context-agnostic
API (works in sync, asyncio, and tokio contexts) as an alternative to
manually implementing the spawn-then-await pattern or falling back to
`asyncio.gather`.

The implementation spawns all underlying PythonTasks onto the Tokio
runtime concurrently, then collects results in order. Supports a
`return_exceptions` parameter that, when True, places exceptions in the
result list instead of propagating them.

Differential Revision: D95757394


