### PR TITLE
[hyperactor] add Port, PortId, and PortRef types

### DIFF
--- a/hyperactor/src/id.rs
+++ b/hyperactor/src/id.rs
@@ -25,6 +25,8 @@ use serde::Deserialize;
 use serde::Serialize;
 use smol_str::SmolStr;
 
+use crate::port::Port;
+
 /// Maximum length of an RFC 1035 label.
 const MAX_LABEL_LEN: usize = 63;
 
@@ -306,6 +308,12 @@ pub enum IdParseError {
     /// Error parsing the proc uid component of an [`ActorId`].
     #[error("invalid proc uid in actor id: {0}")]
     InvalidActorProcUid(UidParseError),
+    /// The `<actor_id>:<port>` separator is missing.
+    #[error("invalid port id: expected format `<actor_id>:<port>`")]
+    InvalidPortIdFormat,
+    /// The port component is invalid.
+    #[error("invalid port: {0}")]
+    InvalidPort(String),
 }
 
 /// Identifies a process in the actor system.
@@ -501,6 +509,112 @@ impl FromStr for ActorId {
             },
             label: None,
         })
+    }
+}
+
+/// Identifies a port on an actor.
+///
+/// Identity (Eq, Hash, Ord) is determined by `(actor_id, port)`.
+#[derive(Clone, Serialize, Deserialize)]
+pub struct PortId {
+    actor_id: ActorId,
+    port: Port,
+}
+
+impl PortId {
+    /// Create a new [`PortId`].
+    pub fn new(actor_id: ActorId, port: Port) -> Self {
+        Self { actor_id, port }
+    }
+
+    /// Returns the actor id.
+    pub fn actor_id(&self) -> &ActorId {
+        &self.actor_id
+    }
+
+    /// Returns the port.
+    pub fn port(&self) -> Port {
+        self.port
+    }
+
+    /// Returns the proc id (delegates to actor_id).
+    pub fn proc_id(&self) -> &ProcId {
+        self.actor_id.proc_id()
+    }
+}
+
+impl PartialEq for PortId {
+    fn eq(&self, other: &Self) -> bool {
+        self.actor_id == other.actor_id && self.port == other.port
+    }
+}
+
+impl Eq for PortId {}
+
+impl Hash for PortId {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.actor_id.hash(state);
+        self.port.hash(state);
+    }
+}
+
+impl PartialOrd for PortId {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for PortId {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.actor_id
+            .cmp(&other.actor_id)
+            .then_with(|| self.port.cmp(&other.port))
+    }
+}
+
+impl fmt::Display for PortId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}:{}", self.actor_id, self.port)
+    }
+}
+
+impl fmt::Debug for PortId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match (self.actor_id.label(), self.actor_id.proc_id().label()) {
+            (Some(actor_label), Some(proc_label)) => {
+                write!(
+                    f,
+                    "<'{}.{}' {}:{}>",
+                    actor_label, proc_label, self.actor_id, self.port
+                )
+            }
+            (Some(actor_label), None) => {
+                write!(f, "<'{}' {}:{}>", actor_label, self.actor_id, self.port)
+            }
+            (None, Some(proc_label)) => {
+                write!(f, "<'.{}' {}:{}>", proc_label, self.actor_id, self.port)
+            }
+            (None, None) => {
+                write!(f, "<{}:{}>", self.actor_id, self.port)
+            }
+        }
+    }
+}
+
+impl FromStr for PortId {
+    type Err = IdParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let colon = s.rfind(':').ok_or(IdParseError::InvalidPortIdFormat)?;
+        let actor_part = &s[..colon];
+        let port_part = &s[colon + 1..];
+
+        let actor_id: ActorId = actor_part.parse()?;
+        let port: Port = port_part
+            .parse()
+            .map_err(|_| IdParseError::InvalidPort(port_part.to_string()))?;
+
+        Ok(Self { actor_id, port })
     }
 }
 
@@ -949,5 +1063,221 @@ mod tests {
             parsed.proc_id().label().map(|l| l.as_str()),
             Some("my-proc")
         );
+    }
+
+    #[test]
+    fn test_port_id_construction_and_accessors() {
+        let actor_uid = Uid::Instance(0xabc);
+        let proc_id = ProcId::new(Uid::Instance(0xdef), Some(Label::new("my-proc").unwrap()));
+        let actor_id = ActorId::new(
+            actor_uid,
+            proc_id.clone(),
+            Some(Label::new("my-actor").unwrap()),
+        );
+        let port = Port::from(42);
+        let pid = PortId::new(actor_id.clone(), port);
+        assert_eq!(pid.actor_id(), &actor_id);
+        assert_eq!(pid.port(), port);
+        assert_eq!(pid.proc_id(), &proc_id);
+    }
+
+    #[test]
+    fn test_port_id_eq() {
+        let actor_id = ActorId::new(
+            Uid::Instance(0x42),
+            ProcId::new(Uid::Instance(0x99), Some(Label::new("proc").unwrap())),
+            Some(Label::new("actor").unwrap()),
+        );
+        let a = PortId::new(actor_id.clone(), Port::from(10));
+        let b = PortId::new(actor_id, Port::from(10));
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn test_port_id_neq_different_port() {
+        let actor_id = ActorId::new(
+            Uid::Instance(0x42),
+            ProcId::new(Uid::Instance(0x99), Some(Label::new("proc").unwrap())),
+            Some(Label::new("actor").unwrap()),
+        );
+        let a = PortId::new(actor_id.clone(), Port::from(10));
+        let b = PortId::new(actor_id, Port::from(20));
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn test_port_id_hash() {
+        use std::collections::hash_map::DefaultHasher;
+
+        let actor_id = ActorId::new(
+            Uid::Instance(0x42),
+            ProcId::new(Uid::Instance(0x99), Some(Label::new("proc").unwrap())),
+            Some(Label::new("actor").unwrap()),
+        );
+        let a = PortId::new(actor_id.clone(), Port::from(10));
+        let b = PortId::new(actor_id, Port::from(10));
+        let hash = |pid: &PortId| {
+            let mut h = DefaultHasher::new();
+            pid.hash(&mut h);
+            h.finish()
+        };
+        assert_eq!(hash(&a), hash(&b));
+    }
+
+    #[test]
+    fn test_port_id_ord() {
+        let actor_id = ActorId::new(
+            Uid::Instance(0x42),
+            ProcId::new(Uid::Instance(0x99), Some(Label::new("proc").unwrap())),
+            Some(Label::new("actor").unwrap()),
+        );
+        let a = PortId::new(actor_id.clone(), Port::from(1));
+        let b = PortId::new(actor_id, Port::from(2));
+        assert!(a < b);
+    }
+
+    #[test]
+    fn test_port_id_ord_actor_first() {
+        let a = PortId::new(
+            ActorId::new(
+                Uid::Instance(0x01),
+                ProcId::new(Uid::Instance(1), Some(Label::new("p").unwrap())),
+                Some(Label::new("a").unwrap()),
+            ),
+            Port::from(99),
+        );
+        let b = PortId::new(
+            ActorId::new(
+                Uid::Instance(0x02),
+                ProcId::new(Uid::Instance(1), Some(Label::new("p").unwrap())),
+                Some(Label::new("a").unwrap()),
+            ),
+            Port::from(1),
+        );
+        assert!(a < b, "actor_id should be compared first");
+    }
+
+    #[test]
+    fn test_port_id_display() {
+        let aid = ActorId::new(
+            Uid::Instance(0xabc123),
+            ProcId::new(
+                Uid::Instance(0xdef456),
+                Some(Label::new("my-proc").unwrap()),
+            ),
+            Some(Label::new("my-actor").unwrap()),
+        );
+        let pid = PortId::new(aid, Port::from(42));
+        assert_eq!(pid.to_string(), "0000000000abc123.0000000000def456:42");
+    }
+
+    #[test]
+    fn test_port_id_debug_all_labels() {
+        let aid = ActorId::new(
+            Uid::Instance(0xabc123),
+            ProcId::new(
+                Uid::Instance(0xdef456),
+                Some(Label::new("my-proc").unwrap()),
+            ),
+            Some(Label::new("my-actor").unwrap()),
+        );
+        let pid = PortId::new(aid, Port::from(42));
+        assert_eq!(
+            format!("{:?}", pid),
+            "<'my-actor.my-proc' 0000000000abc123.0000000000def456:42>"
+        );
+    }
+
+    #[test]
+    fn test_port_id_debug_no_labels() {
+        let aid = ActorId::new(
+            Uid::Instance(0xabc123),
+            ProcId::new(Uid::Instance(0xdef456), None),
+            None,
+        );
+        let pid = PortId::new(aid, Port::from(42));
+        assert_eq!(
+            format!("{:?}", pid),
+            "<0000000000abc123.0000000000def456:42>"
+        );
+    }
+
+    #[test]
+    fn test_port_id_debug_actor_label_only() {
+        let aid = ActorId::new(
+            Uid::Instance(0xabc123),
+            ProcId::new(Uid::Instance(0xdef456), None),
+            Some(Label::new("my-actor").unwrap()),
+        );
+        let pid = PortId::new(aid, Port::from(42));
+        assert_eq!(
+            format!("{:?}", pid),
+            "<'my-actor' 0000000000abc123.0000000000def456:42>"
+        );
+    }
+
+    #[test]
+    fn test_port_id_debug_proc_label_only() {
+        let aid = ActorId::new(
+            Uid::Instance(0xabc123),
+            ProcId::new(
+                Uid::Instance(0xdef456),
+                Some(Label::new("my-proc").unwrap()),
+            ),
+            None,
+        );
+        let pid = PortId::new(aid, Port::from(42));
+        assert_eq!(
+            format!("{:?}", pid),
+            "<'.my-proc' 0000000000abc123.0000000000def456:42>"
+        );
+    }
+
+    #[test]
+    fn test_port_id_fromstr_roundtrip() {
+        let aid = ActorId::new(
+            Uid::Instance(0xabc123),
+            ProcId::new(
+                Uid::Instance(0xdef456),
+                Some(Label::new("my-proc").unwrap()),
+            ),
+            Some(Label::new("my-actor").unwrap()),
+        );
+        let pid = PortId::new(aid, Port::from(42));
+        let s = pid.to_string();
+        let parsed: PortId = s.parse().unwrap();
+        assert_eq!(pid, parsed);
+    }
+
+    #[test]
+    fn test_port_id_fromstr_errors() {
+        // Missing colon.
+        assert!(
+            "0000000000abc123.0000000000def456"
+                .parse::<PortId>()
+                .is_err()
+        );
+        // Invalid port.
+        assert!(
+            "0000000000abc123.0000000000def456:notanumber"
+                .parse::<PortId>()
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn test_port_id_serde_roundtrip() {
+        let aid = ActorId::new(
+            Uid::Instance(0xabcdef),
+            ProcId::new(
+                Uid::Instance(0x123456),
+                Some(Label::new("my-proc").unwrap()),
+            ),
+            Some(Label::new("my-actor").unwrap()),
+        );
+        let pid = PortId::new(aid, Port::from(42));
+        let json = serde_json::to_string(&pid).unwrap();
+        let parsed: PortId = serde_json::from_str(&json).unwrap();
+        assert_eq!(pid, parsed);
     }
 }

--- a/hyperactor/src/lib.rs
+++ b/hyperactor/src/lib.rs
@@ -76,6 +76,7 @@ pub mod message;
 pub mod metrics;
 pub mod ordering;
 pub mod panic_handler;
+pub mod port;
 pub mod proc;
 pub mod ref_;
 pub mod reference;

--- a/hyperactor/src/port.rs
+++ b/hyperactor/src/port.rs
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+//! Port identifier newtype.
+
+use std::fmt;
+use std::str::FromStr;
+
+use serde::Deserialize;
+use serde::Serialize;
+use typeuri::ACTOR_PORT_BIT;
+use typeuri::Named;
+
+/// A port identifier within an actor.
+#[derive(
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    Hash,
+    PartialOrd,
+    Ord,
+    Serialize,
+    Deserialize
+)]
+pub struct Port(u64);
+
+impl Port {
+    /// Create a port for handler message type `M`.
+    pub fn handler<M: Named>() -> Self {
+        Port(M::port())
+    }
+
+    /// Whether this is a handler port (actor port bit set).
+    pub fn is_handler(&self) -> bool {
+        self.0 & ACTOR_PORT_BIT != 0
+    }
+
+    /// The raw port index.
+    pub fn as_u64(&self) -> u64 {
+        self.0
+    }
+}
+
+impl From<u64> for Port {
+    fn from(v: u64) -> Self {
+        Port(v)
+    }
+}
+
+impl fmt::Display for Port {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl fmt::Debug for Port {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Port({})", self.0)
+    }
+}
+
+impl FromStr for Port {
+    type Err = std::num::ParseIntError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let v: u64 = s.parse()?;
+        Ok(Port(v))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct TestMsg;
+
+    impl Named for TestMsg {
+        fn typename() -> &'static str {
+            "test::TestMsg"
+        }
+    }
+
+    #[test]
+    fn test_handler_port() {
+        let port = Port::handler::<TestMsg>();
+        assert!(
+            port.is_handler(),
+            "handler ports should have ACTOR_PORT_BIT set"
+        );
+        assert_eq!(port.as_u64(), TestMsg::port());
+    }
+
+    #[test]
+    fn test_non_handler_port() {
+        let port = Port::from(42);
+        assert!(
+            !port.is_handler(),
+            "plain ports should not have ACTOR_PORT_BIT set"
+        );
+        assert_eq!(port.as_u64(), 42);
+    }
+
+    #[test]
+    fn test_display_fromstr_roundtrip() {
+        let port = Port::from(12345);
+        assert_eq!(port.to_string(), "12345");
+        let parsed: Port = port.to_string().parse().unwrap();
+        assert_eq!(port, parsed);
+    }
+
+    #[test]
+    fn test_display_fromstr_roundtrip_handler() {
+        let port = Port::handler::<TestMsg>();
+        let s = port.to_string();
+        let parsed: Port = s.parse().unwrap();
+        assert_eq!(port, parsed);
+    }
+
+    #[test]
+    fn test_debug() {
+        let port = Port::from(42);
+        assert_eq!(format!("{:?}", port), "Port(42)");
+    }
+}

--- a/hyperactor/src/ref_.rs
+++ b/hyperactor/src/ref_.rs
@@ -17,6 +17,7 @@ use serde::Serialize;
 use crate::channel::ChannelAddr;
 use crate::id::ActorId;
 use crate::id::IdParseError;
+use crate::id::PortId;
 use crate::id::ProcId;
 
 /// A network location, wrapping a [`ChannelAddr`].
@@ -246,6 +247,109 @@ impl FromStr for ActorRef {
     }
 }
 
+/// A port identifier paired with a network location.
+#[derive(Clone, Serialize, Deserialize)]
+pub struct PortRef {
+    id: PortId,
+    location: Location,
+}
+
+impl PortRef {
+    /// Create a new [`PortRef`].
+    pub fn new(id: PortId, location: Location) -> Self {
+        Self { id, location }
+    }
+
+    /// Returns the port id.
+    pub fn id(&self) -> &PortId {
+        &self.id
+    }
+
+    /// Returns the location.
+    pub fn location(&self) -> &Location {
+        &self.location
+    }
+
+    /// Returns the actor id (delegates to port id).
+    pub fn actor_id(&self) -> &ActorId {
+        self.id.actor_id()
+    }
+}
+
+impl PartialEq for PortRef {
+    fn eq(&self, other: &Self) -> bool {
+        self.id == other.id && self.location == other.location
+    }
+}
+
+impl Eq for PortRef {}
+
+impl std::hash::Hash for PortRef {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.id.hash(state);
+        self.location.hash(state);
+    }
+}
+
+impl PartialOrd for PortRef {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for PortRef {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.id
+            .cmp(&other.id)
+            .then_with(|| self.location.cmp(&other.location))
+    }
+}
+
+impl fmt::Display for PortRef {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}@{}", self.id, self.location)
+    }
+}
+
+impl fmt::Debug for PortRef {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match (
+            self.id.actor_id().label(),
+            self.id.actor_id().proc_id().label(),
+        ) {
+            (Some(actor_label), Some(proc_label)) => {
+                write!(
+                    f,
+                    "<'{}.{}' {}@{}>",
+                    actor_label, proc_label, self.id, self.location
+                )
+            }
+            (Some(actor_label), None) => {
+                write!(f, "<'{}' {}@{}>", actor_label, self.id, self.location)
+            }
+            (None, Some(proc_label)) => {
+                write!(f, "<'.{}' {}@{}>", proc_label, self.id, self.location)
+            }
+            (None, None) => {
+                write!(f, "<{}@{}>", self.id, self.location)
+            }
+        }
+    }
+}
+
+impl FromStr for PortRef {
+    type Err = RefParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let at = s.find('@').ok_or(RefParseError::MissingSeparator)?;
+        let id: PortId = s[..at].parse()?;
+        let location: Location = s[at + 1..]
+            .parse()
+            .map_err(RefParseError::InvalidLocation)?;
+        Ok(Self { id, location })
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::hash::Hash;
@@ -253,6 +357,7 @@ mod tests {
     use super::*;
     use crate::id::Label;
     use crate::id::Uid;
+    use crate::port::Port;
 
     #[test]
     fn test_location_display_fromstr_roundtrip() {
@@ -560,6 +665,194 @@ mod tests {
         let s = pref.to_string();
         assert_eq!(s, "0000000000000042@metatls://example.com:443");
         let parsed: ProcRef = s.parse().unwrap();
+        assert_eq!(pref, parsed);
+    }
+
+    #[test]
+    fn test_port_ref_construction_and_accessors() {
+        let aid = ActorId::new(
+            Uid::Instance(0xabc123),
+            ProcId::new(
+                Uid::Instance(0xdef456),
+                Some(Label::new("my-proc").unwrap()),
+            ),
+            Some(Label::new("my-actor").unwrap()),
+        );
+        let port_id = PortId::new(aid.clone(), Port::from(42));
+        let loc: Location = ChannelAddr::Local(7).into();
+        let pref = PortRef::new(port_id.clone(), loc.clone());
+        assert_eq!(pref.id(), &port_id);
+        assert_eq!(pref.location(), &loc);
+        assert_eq!(pref.actor_id(), &aid);
+    }
+
+    #[test]
+    fn test_port_ref_display() {
+        let aid = ActorId::new(
+            Uid::Instance(0xabc123),
+            ProcId::new(
+                Uid::Instance(0xdef456),
+                Some(Label::new("my-proc").unwrap()),
+            ),
+            Some(Label::new("my-actor").unwrap()),
+        );
+        let port_id = PortId::new(aid, Port::from(42));
+        let loc: Location = ChannelAddr::Local(7).into();
+        let pref = PortRef::new(port_id, loc);
+        assert_eq!(
+            pref.to_string(),
+            "0000000000abc123.0000000000def456:42@inproc://7"
+        );
+    }
+
+    #[test]
+    fn test_port_ref_debug_all_labels() {
+        let aid = ActorId::new(
+            Uid::Instance(0xabc123),
+            ProcId::new(
+                Uid::Instance(0xdef456),
+                Some(Label::new("my-proc").unwrap()),
+            ),
+            Some(Label::new("my-actor").unwrap()),
+        );
+        let port_id = PortId::new(aid, Port::from(42));
+        let loc: Location = ChannelAddr::Local(7).into();
+        let pref = PortRef::new(port_id, loc);
+        assert_eq!(
+            format!("{:?}", pref),
+            "<'my-actor.my-proc' 0000000000abc123.0000000000def456:42@inproc://7>"
+        );
+    }
+
+    #[test]
+    fn test_port_ref_debug_no_labels() {
+        let aid = ActorId::new(
+            Uid::Instance(0xabc123),
+            ProcId::new(Uid::Instance(0xdef456), None),
+            None,
+        );
+        let port_id = PortId::new(aid, Port::from(42));
+        let loc: Location = ChannelAddr::Local(7).into();
+        let pref = PortRef::new(port_id, loc);
+        assert_eq!(
+            format!("{:?}", pref),
+            "<0000000000abc123.0000000000def456:42@inproc://7>"
+        );
+    }
+
+    #[test]
+    fn test_port_ref_debug_actor_label_only() {
+        let aid = ActorId::new(
+            Uid::Instance(0xabc123),
+            ProcId::new(Uid::Instance(0xdef456), None),
+            Some(Label::new("my-actor").unwrap()),
+        );
+        let port_id = PortId::new(aid, Port::from(42));
+        let loc: Location = ChannelAddr::Local(7).into();
+        let pref = PortRef::new(port_id, loc);
+        assert_eq!(
+            format!("{:?}", pref),
+            "<'my-actor' 0000000000abc123.0000000000def456:42@inproc://7>"
+        );
+    }
+
+    #[test]
+    fn test_port_ref_debug_proc_label_only() {
+        let aid = ActorId::new(
+            Uid::Instance(0xabc123),
+            ProcId::new(
+                Uid::Instance(0xdef456),
+                Some(Label::new("my-proc").unwrap()),
+            ),
+            None,
+        );
+        let port_id = PortId::new(aid, Port::from(42));
+        let loc: Location = ChannelAddr::Local(7).into();
+        let pref = PortRef::new(port_id, loc);
+        assert_eq!(
+            format!("{:?}", pref),
+            "<'.my-proc' 0000000000abc123.0000000000def456:42@inproc://7>"
+        );
+    }
+
+    #[test]
+    fn test_port_ref_fromstr_roundtrip() {
+        let aid = ActorId::new(
+            Uid::Instance(0xabc123),
+            ProcId::new(
+                Uid::Instance(0xdef456),
+                Some(Label::new("my-proc").unwrap()),
+            ),
+            Some(Label::new("my-actor").unwrap()),
+        );
+        let port_id = PortId::new(aid, Port::from(42));
+        let loc: Location = ChannelAddr::Local(7).into();
+        let pref = PortRef::new(port_id, loc);
+        let s = pref.to_string();
+        let parsed: PortRef = s.parse().unwrap();
+        assert_eq!(pref, parsed);
+    }
+
+    #[test]
+    fn test_port_ref_fromstr_missing_separator() {
+        let err = "0000000000abc123.0000000000def456:42"
+            .parse::<PortRef>()
+            .unwrap_err();
+        assert!(matches!(err, RefParseError::MissingSeparator));
+    }
+
+    #[test]
+    fn test_port_ref_eq_and_hash() {
+        use std::collections::hash_map::DefaultHasher;
+        use std::hash::Hasher;
+
+        let aid = ActorId::new(
+            Uid::Instance(0x42),
+            ProcId::new(Uid::Instance(0x99), Some(Label::new("proc").unwrap())),
+            Some(Label::new("actor").unwrap()),
+        );
+        let port_id = PortId::new(aid, Port::from(10));
+        let loc: Location = ChannelAddr::Local(1).into();
+        let a = PortRef::new(port_id.clone(), loc.clone());
+        let b = PortRef::new(port_id, loc);
+        assert_eq!(a, b);
+
+        let hash = |r: &PortRef| {
+            let mut h = DefaultHasher::new();
+            r.hash(&mut h);
+            h.finish()
+        };
+        assert_eq!(hash(&a), hash(&b));
+    }
+
+    #[test]
+    fn test_port_ref_neq_different_location() {
+        let aid = ActorId::new(
+            Uid::Instance(0x42),
+            ProcId::new(Uid::Instance(0x99), Some(Label::new("proc").unwrap())),
+            Some(Label::new("actor").unwrap()),
+        );
+        let port_id = PortId::new(aid, Port::from(10));
+        let a = PortRef::new(port_id.clone(), ChannelAddr::Local(1).into());
+        let b = PortRef::new(port_id, ChannelAddr::Local(2).into());
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn test_port_ref_serde_roundtrip() {
+        let aid = ActorId::new(
+            Uid::Instance(0xabcdef),
+            ProcId::new(
+                Uid::Instance(0x123456),
+                Some(Label::new("my-proc").unwrap()),
+            ),
+            Some(Label::new("my-actor").unwrap()),
+        );
+        let port_id = PortId::new(aid, Port::from(42));
+        let loc: Location = ChannelAddr::Local(7).into();
+        let pref = PortRef::new(port_id, loc);
+        let json = serde_json::to_string(&pref).unwrap();
+        let parsed: PortRef = serde_json::from_str(&json).unwrap();
         assert_eq!(pref, parsed);
     }
 }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #2933
* #2932
* #2928
* #2927
* #2926
* __->__ #2925

Add port-level types to the id/ref hierarchy. Port is a u64 newtype
in its own module; PortId pairs an ActorId with a Port; PortRef pairs
a PortId with a Location. All follow the same patterns as the existing
ProcId/ActorId/ProcRef/ActorRef types.

Differential Revision: [D95801208](https://our.internmc.facebook.com/intern/diff/D95801208/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D95801208/)!