### PR TITLE
[hyperactor] make ProcId/ActorId/PortId fields private, add controlled constructors

### DIFF
--- a/hyper/src/commands/list.rs
+++ b/hyper/src/commands/list.rs
@@ -38,7 +38,7 @@ impl ListCommand {
 
         // Codify obtaining a proc's agent in `hyperactor_mesh` somewhere.
         let agent: ActorRef<HostAgent> = ActorRef::attest(
-            ProcId(host, SERVICE_PROC_NAME.to_string()).actor_id(HOST_MESH_AGENT_ACTOR_NAME, 0),
+            ProcId::with_name(host, SERVICE_PROC_NAME).actor_id(HOST_MESH_AGENT_ACTOR_NAME, 0),
         );
 
         let resources = agent.list(&client).await?;

--- a/hyper/src/commands/show.rs
+++ b/hyper/src/commands/show.rs
@@ -33,7 +33,7 @@ impl ShowCommand {
 
                 // Codify obtaining a proc's agent in `hyperactor_mesh` somewhere.
                 let agent: ActorRef<HostAgent> = ActorRef::attest(
-                    ProcId(host, SERVICE_PROC_NAME.to_string())
+                    ProcId::with_name(host, SERVICE_PROC_NAME)
                         .actor_id(HOST_MESH_AGENT_ACTOR_NAME, 0),
                 );
 

--- a/hyperactor/src/channel/sim.rs
+++ b/hyperactor/src/channel/sim.rs
@@ -301,7 +301,10 @@ impl<M: RemoteMessage + Any> Tx<M> for SimTx<M> {
             .downcast_ref::<MessageEnvelope>()
             .expect("RemoteMessage should always be a MessageEnvelope");
 
-        let (sender, dest) = (envelope.sender().clone(), envelope.dest().0.clone());
+        let (sender, dest) = (
+            envelope.sender().clone(),
+            envelope.dest().actor_id().clone(),
+        );
 
         match simnet_handle() {
             Ok(handle) => {
@@ -467,7 +470,8 @@ mod tests {
                 ext.point(vec![0, 0, 0, 1, 0]).unwrap(),
             );
 
-            let msg = MessageEnvelope::new(sender, PortId(dest, 0), data.clone(), Flattrs::new());
+            let msg =
+                MessageEnvelope::new(sender, PortId::new(dest, 0), data.clone(), Flattrs::new());
             tx.post(msg);
             assert_eq!(*rx.recv().await.unwrap().data(), data);
         }
@@ -549,7 +553,7 @@ mod tests {
         // This message will be delievered at simulator time = 100 seconds
         tx.post(MessageEnvelope::new(
             controller,
-            PortId(dest, 0),
+            PortId::new(dest, 0),
             wirevalue::Any::serialize(&456).unwrap(),
             Flattrs::new(),
         ));
@@ -630,14 +634,14 @@ mod tests {
             // Send client message
             client_tx.post(MessageEnvelope::new(
                 client.clone(),
-                PortId(dest.clone(), 0),
+                PortId::new(dest.clone(), 0),
                 wirevalue::Any::serialize(&456).unwrap(),
                 Flattrs::new(),
             ));
             // Send system message
             controller_tx.post(MessageEnvelope::new(
                 controller.clone(),
-                PortId(dest.clone(), 0),
+                PortId::new(dest.clone(), 0),
                 wirevalue::Any::serialize(&456).unwrap(),
                 Flattrs::new(),
             ));

--- a/hyperactor/src/host.rs
+++ b/hyperactor/src/host.rs
@@ -186,10 +186,13 @@ impl<M: ProcManager> Host<M> {
         let (backend_addr, backend_rx) = channel::serve(ChannelAddr::any(manager.transport()))?;
 
         // Set up a system proc. This is often used to manage the host itself.
-        let service_proc_id = ProcId(frontend_addr.clone(), SERVICE_PROC_NAME.to_string());
+        // These use with_name (not unique) because their uniqueness is
+        // guaranteed by the ChannelAddr component, and the Name type's
+        // '-' delimiter must not collide with a hash suffix.
+        let service_proc_id = ProcId::with_name(frontend_addr.clone(), SERVICE_PROC_NAME);
         let service_proc = Proc::new(service_proc_id.clone(), router.boxed());
 
-        let local_proc_id = ProcId(frontend_addr.clone(), LOCAL_PROC_NAME.to_string());
+        let local_proc_id = ProcId::with_name(frontend_addr.clone(), LOCAL_PROC_NAME);
         let local_proc = Proc::new(local_proc_id.clone(), router.boxed());
 
         tracing::info!(
@@ -260,7 +263,7 @@ impl<M: ProcManager> Host<M> {
             return Err(HostError::ProcExists(name));
         }
 
-        let proc_id = ProcId(self.frontend_addr.clone(), name.clone());
+        let proc_id = ProcId::with_name(self.frontend_addr.clone(), &name);
         let handle = self
             .manager
             .spawn(proc_id.clone(), self.backend_addr.clone(), config)
@@ -1435,7 +1438,7 @@ mod tests {
             .unwrap();
 
         let (proc_id1, _ref) = host.spawn("proc1".to_string(), ()).await.unwrap();
-        assert_eq!(proc_id1, ProcId(host.addr().clone(), "proc1".to_string()));
+        assert_eq!(proc_id1, ProcId::with_name(host.addr().clone(), "proc1"));
         assert!(procs.lock().await.contains_key(&proc_id1));
 
         let (proc_id2, _ref) = host.spawn("proc2".to_string(), ()).await.unwrap();
@@ -1576,7 +1579,7 @@ mod tests {
     async fn local_ready_and_wait_are_immediate() {
         // Build a LocalHandle directly.
         let addr = ChannelAddr::any(ChannelTransport::Local);
-        let proc_id = ProcId(addr.clone(), "p".into());
+        let proc_id = ProcId::with_name(addr.clone(), "p");
         let agent_ref = ActorRef::<()>::attest(proc_id.actor_id("host_agent", 0));
         let h = LocalHandle::<()> {
             proc_id,

--- a/hyperactor/src/mailbox.rs
+++ b/hyperactor/src/mailbox.rs
@@ -243,8 +243,9 @@ impl MessageEnvelope {
     pub(crate) fn new_unknown(dest: PortId, data: wirevalue::Any) -> Self {
         // Create a synthetic "unknown" actor ID for messages with no known sender
         let unknown_addr = ChannelAddr::any(ChannelTransport::Local);
-        let unknown_proc_id = crate::reference::ProcId(unknown_addr, "unknown".to_string());
-        let unknown_actor_id = crate::reference::ActorId(unknown_proc_id, "unknown".to_string(), 0);
+        let unknown_proc_id = crate::reference::ProcId::unique(unknown_addr, "unknown");
+        let unknown_actor_id =
+            crate::reference::ActorId::root(unknown_proc_id, "unknown".to_string());
         Self::new(unknown_actor_id, dest, data, Flattrs::new())
     }
 
@@ -1019,7 +1020,7 @@ pub trait MailboxServer: MailboxSender + Clone + Sized + 'static {
             static NEXT_RANK: AtomicUsize = AtomicUsize::new(0);
             let rank = NEXT_RANK.fetch_add(1, Ordering::Relaxed);
             let addr = ChannelAddr::any(ChannelTransport::Local);
-            let proc_id = ProcId(addr, format!("mailbox_server_{}", rank));
+            let proc_id = ProcId::unique(addr, format!("mailbox_server_{}", rank));
             // Use this mailbox server as the forwarder, so we can use it to
             // return message back to the sender.
             let proc = Proc::new(proc_id, BoxedMailboxSender::new(server));
@@ -1195,7 +1196,7 @@ impl MailboxSender for MailboxClient {
         envelope: MessageEnvelope,
         return_handle: PortHandle<Undeliverable<MessageEnvelope>>,
     ) {
-        tracing::event!(target:"messages", tracing::Level::TRACE,  "size"=envelope.data.len(), "sender"= %envelope.sender, "dest" = %envelope.dest.0, "port"= envelope.dest.1, "message_type" = envelope.data.typename().unwrap_or("unknown"), "send_message");
+        tracing::event!(target:"messages", tracing::Level::TRACE,  "size"=envelope.data.len(), "sender"= %envelope.sender, "dest" = %envelope.dest.actor_id(), "port"= envelope.dest.index(), "message_type" = envelope.data.typename().unwrap_or("unknown"), "send_message");
         if let Err(mpsc::error::SendError((envelope, return_handle))) =
             self.buffer.send((envelope, return_handle))
         {
@@ -1277,7 +1278,7 @@ impl Mailbox {
     pub fn open_port<M: Message>(&self) -> (PortHandle<M>, PortReceiver<M>) {
         let port_index = self.inner.allocate_port();
         let (sender, receiver) = mpsc::unbounded_channel::<M>();
-        let port_id = PortId(self.inner.actor_id.clone(), port_index);
+        let port_id = PortId::new(self.inner.actor_id.clone(), port_index);
         tracing::trace!(
             name = "open_port",
             "opening port for {} at {}",
@@ -1332,7 +1333,7 @@ impl Mailbox {
     {
         let port_index = self.inner.allocate_port();
         let (sender, receiver) = mpsc::unbounded_channel::<A::State>();
-        let port_id = PortId(self.inner.actor_id.clone(), port_index);
+        let port_id = PortId::new(self.inner.actor_id.clone(), port_index);
         let state = Mutex::new(A::State::default());
         let reducer_spec = accum.reducer_spec();
         let enqueue = move |_, update: A::Update| {
@@ -1376,7 +1377,7 @@ impl Mailbox {
     /// receiver may receive a single message.
     pub fn open_once_port<M: Message>(&self) -> (OncePortHandle<M>, OncePortReceiver<M>) {
         let port_index = self.inner.allocate_port();
-        let port_id = PortId(self.inner.actor_id.clone(), port_index);
+        let port_id = PortId::new(self.inner.actor_id.clone(), port_index);
         let (sender, receiver) = oneshot::channel::<M>();
         (
             OncePortHandle {
@@ -1417,7 +1418,7 @@ impl Mailbox {
     {
         let port_index = self.inner.allocate_port();
         let (sender, receiver) = oneshot::channel::<T>();
-        let port_id = PortId(self.inner.actor_id.clone(), port_index);
+        let port_id = PortId::new(self.inner.actor_id.clone(), port_index);
         let reducer_spec = accum.reducer_spec();
         assert!(
             reducer_spec.is_some(),
@@ -1583,7 +1584,7 @@ impl MailboxSender for Mailbox {
             1,
             hyperactor_telemetry::kv_pairs!(
                 "actor_id" => envelope.sender.to_string(),
-                "dest_actor_id" => envelope.dest.0.to_string(),
+                "dest_actor_id" => envelope.dest.actor_id().to_string(),
             ),
         );
         tracing::trace!(
@@ -2006,11 +2007,11 @@ impl<M> PortReceiver<M> {
     }
 
     fn port(&self) -> u64 {
-        self.port_id.1
+        self.port_id.index()
     }
 
     fn actor_id(&self) -> &ActorId {
-        &self.port_id.0
+        self.port_id.actor_id()
     }
 }
 
@@ -2058,11 +2059,11 @@ impl<M> OncePortReceiver<M> {
     }
 
     fn port(&self) -> u64 {
-        self.port_id.1
+        self.port_id.index()
     }
 
     fn actor_id(&self) -> &ActorId {
-        &self.port_id.0
+        self.port_id.actor_id()
     }
 }
 
@@ -3400,7 +3401,7 @@ mod tests {
                 dummy_actor_id.clone(),
                 BOXED_PANICKING_MAILBOX_SENDER.clone(),
             );
-            let dummy_port_id = PortId(dummy_actor_id, 0);
+            let dummy_port_id = PortId::new(dummy_actor_id, 0);
             let (sender, receiver) = mpsc::unbounded_channel::<M>();
             let receiver = PortReceiver {
                 receiver,
@@ -4042,7 +4043,7 @@ mod tests {
         // Create a destination not owned by this mailbox to force
         // forwarding.
         let remote_actor = test_actor_id("remote_world_1", "remote");
-        let dest = PortId(remote_actor.clone(), /*port index*/ 4242);
+        let dest = PortId::new(remote_actor.clone(), /*port index*/ 4242);
 
         // Build an envelope (TTL is seeded in `MessageEnvelope::new` /
         // `::serialize`).

--- a/hyperactor/src/proc.rs
+++ b/hyperactor/src/proc.rs
@@ -207,7 +207,7 @@ impl Proc {
     /// Create a new direct-addressed proc.
     pub fn direct(addr: ChannelAddr, name: String) -> Result<Self, ChannelError> {
         let (addr, rx) = channel::serve(addr)?;
-        let proc_id = ProcId(addr, name);
+        let proc_id = ProcId::with_name(addr, name);
         let proc = Self::new(proc_id, DialMailboxRouter::new().into_boxed());
         proc.clone().serve(rx);
         Ok(proc)
@@ -220,7 +220,7 @@ impl Proc {
         default: BoxedMailboxSender,
     ) -> Result<Self, ChannelError> {
         let (addr, rx) = channel::serve(addr)?;
-        let proc_id = ProcId(addr, name);
+        let proc_id = ProcId::with_name(addr, name);
         let proc = Self::new(
             proc_id,
             DialMailboxRouter::new_with_default(default).into_boxed(),
@@ -298,7 +298,7 @@ impl Proc {
     pub fn local() -> Self {
         let rank = NEXT_LOCAL_RANK.fetch_add(1, Ordering::Relaxed);
         let addr = ChannelAddr::any(ChannelTransport::Local);
-        let proc_id = ProcId(addr, format!("local_{}", rank));
+        let proc_id = ProcId::unique(addr, format!("local_{}", rank));
         Proc::new(proc_id, BoxedMailboxSender::new(PanickingMailboxSender))
     }
 
@@ -328,7 +328,7 @@ impl Proc {
         static RUNTIME_PROC: OnceLock<Proc> = OnceLock::new();
         RUNTIME_PROC.get_or_init(|| {
             let addr = ChannelAddr::any(ChannelTransport::Local);
-            let proc_id = ProcId(addr, "hyperactor_runtime".to_string());
+            let proc_id = ProcId::unique(addr, "hyperactor_runtime");
             Proc::new(proc_id, BoxedMailboxSender::new(PanickingMailboxSender))
         })
     }
@@ -831,7 +831,11 @@ impl Proc {
                 anyhow::bail!("an actor with name '{}' has already been spawned", name)
             }
         }
-        Ok(ActorId(self.state().proc_id.clone(), name.to_string(), 0))
+        Ok(ActorId::new(
+            self.state().proc_id.clone(),
+            name.to_string(),
+            0,
+        ))
     }
 
     /// Create a child allocation in the proc.
@@ -877,9 +881,9 @@ impl Proc {
         name: &str,
     ) -> Result<ActorId, anyhow::Error> {
         let inherited = self.allocate_child_id(parent_id)?;
-        Ok(ActorId(
+        Ok(ActorId::new(
             inherited.proc_id().clone(),
-            name.to_string(),
+            name,
             inherited.pid(),
         ))
     }

--- a/hyperactor/src/reference.rs
+++ b/hyperactor/src/reference.rs
@@ -130,8 +130,8 @@ impl Reference {
     pub fn proc_id(&self) -> Option<&ProcId> {
         match self {
             Self::Proc(proc_id) => Some(proc_id),
-            Self::Actor(ActorId(proc_id, _, _)) => Some(proc_id),
-            Self::Port(PortId(ActorId(proc_id, _, _), _)) => Some(proc_id),
+            Self::Actor(actor_id) => Some(actor_id.proc_id()),
+            Self::Port(port_id) => Some(port_id.actor_id().proc_id()),
         }
     }
 
@@ -140,7 +140,7 @@ impl Reference {
         match self {
             Self::Proc(_) => None,
             Self::Actor(actor_id) => Some(actor_id),
-            Self::Port(PortId(actor_id, _)) => Some(actor_id),
+            Self::Port(port_id) => Some(port_id.actor_id()),
         }
     }
 
@@ -149,7 +149,7 @@ impl Reference {
         match self {
             Self::Proc(_) => None,
             Self::Actor(actor_id) => Some(actor_id.name()),
-            Self::Port(PortId(actor_id, _)) => Some(actor_id.name()),
+            Self::Port(port_id) => Some(port_id.actor_id().name()),
         }
     }
 
@@ -158,7 +158,7 @@ impl Reference {
         match self {
             Self::Proc(_) => None,
             Self::Actor(actor_id) => Some(actor_id.pid()),
-            Self::Port(PortId(actor_id, _)) => Some(actor_id.pid()),
+            Self::Port(port_id) => Some(port_id.actor_id().pid()),
         }
     }
 
@@ -255,22 +255,22 @@ impl FromStr for Reference {
 
                     // channeladdr,proc_name
                     Token::Elem(proc_name) =>
-                    Self::Proc(ProcId(channel_addr, proc_name.to_string())),
+                    Self::Proc(ProcId::with_name(channel_addr, proc_name)),
 
                     // channeladdr,proc_name,actor_name
                     Token::Elem(proc_name) Token::Comma Token::Elem(actor_name) =>
-                    Self::Actor(ActorId(ProcId(channel_addr, proc_name.to_string()), actor_name.to_string(), 0)),
+                    Self::Actor(ActorId::new(ProcId::with_name(channel_addr, proc_name), actor_name, 0)),
 
                     // channeladdr,proc_name,actor_name[pid]
                     Token::Elem(proc_name) Token::Comma Token::Elem(actor_name)
                         Token::LeftBracket Token::Uint(pid) Token::RightBracket =>
-                        Self::Actor(ActorId(ProcId(channel_addr, proc_name.to_string()), actor_name.to_string(), pid)),
+                        Self::Actor(ActorId::new(ProcId::with_name(channel_addr, proc_name), actor_name, pid)),
 
                     // channeladdr,proc_name,actor_name[pid][port]
                     Token::Elem(proc_name) Token::Comma Token::Elem(actor_name)
                         Token::LeftBracket Token::Uint(pid) Token::RightBracket
                         Token::LeftBracket Token::Uint(index) Token::RightBracket  =>
-                        Self::Port(PortId(ActorId(ProcId(channel_addr, proc_name.to_string()), actor_name.to_string(), pid), index as u64)),
+                        Self::Port(PortId::new(ActorId::new(ProcId::with_name(channel_addr, proc_name), actor_name, pid), index as u64)),
 
                     // channeladdr,proc_name,actor_name[pid][port<type>]
                     Token::Elem(proc_name) Token::Comma Token::Elem(actor_name)
@@ -278,7 +278,7 @@ impl FromStr for Reference {
                         Token::LeftBracket Token::Uint(index)
                             Token::LessThan Token::Elem(_type) Token::GreaterThan
                         Token::RightBracket =>
-                        Self::Port(PortId(ActorId(ProcId(channel_addr, proc_name.to_string()), actor_name.to_string(), pid), index as u64)),
+                        Self::Port(PortId::new(ActorId::new(ProcId::with_name(channel_addr, proc_name), actor_name, pid), index as u64)),
                 }?)
             }
 
@@ -327,9 +327,50 @@ pub type Index = usize;
     Ord,
     typeuri::Named
 )]
-pub struct ProcId(pub ChannelAddr, pub String);
+pub struct ProcId(ChannelAddr, String);
+
+/// Compute an 8-char hex hash suffix from a [`ChannelAddr`].
+fn addr_hash_suffix(addr: &ChannelAddr) -> String {
+    use std::collections::hash_map::DefaultHasher;
+    let mut hasher = DefaultHasher::new();
+    addr.hash(&mut hasher);
+    format!("{:08x}", hasher.finish() as u32)
+}
 
 impl ProcId {
+    /// Create a ProcId with a globally-unique name: `"{base_name}-{hash_of_addr}"`.
+    ///
+    /// Use this for well-known / fixed proc names (e.g. `"service"`, `"local"`)
+    /// that are not already unique across hosts.
+    pub fn unique(addr: ChannelAddr, base_name: impl Into<String>) -> Self {
+        let base = base_name.into();
+        let suffix = addr_hash_suffix(&addr);
+        Self(addr, format!("{}-{}", base, suffix))
+    }
+
+    /// Create a ProcId with an already-unique name (no suffix added).
+    ///
+    /// Use this for deserialization, test helpers, and names that already
+    /// contain a UUID or other uniquifying component.
+    pub fn with_name(addr: ChannelAddr, name: impl Into<String>) -> Self {
+        Self(addr, name.into())
+    }
+
+    /// The base name before the `-{hash}` suffix, if present.
+    ///
+    /// If the name ends with `-XXXXXXXX` (8 hex chars), returns the part
+    /// before that suffix. Otherwise returns the full name.
+    pub fn base_name(&self) -> &str {
+        match self.1.rsplit_once('-') {
+            Some((base, suffix))
+                if suffix.len() == 8 && suffix.chars().all(|c| c.is_ascii_hexdigit()) =>
+            {
+                base
+            }
+            _ => &self.1,
+        }
+    }
+
     /// Create an actor ID with the provided name, pid within this proc.
     pub fn actor_id(&self, name: impl Into<String>, pid: Index) -> ActorId {
         ActorId(self.clone(), name.into(), pid)
@@ -376,11 +417,16 @@ impl FromStr for ProcId {
     Ord,
     typeuri::Named
 )]
-pub struct ActorId(pub ProcId, pub String, pub Index);
+pub struct ActorId(ProcId, String, Index);
 
 hyperactor_config::impl_attrvalue!(ActorId);
 
 impl ActorId {
+    /// Create a new actor ID.
+    pub fn new(proc_id: ProcId, name: impl Into<String>, pid: Index) -> Self {
+        Self(proc_id, name.into(), pid)
+    }
+
     /// Create a new port ID with the provided port for this actor.
     pub fn port_id(&self, port: u64) -> PortId {
         PortId(self.clone(), port)
@@ -414,8 +460,7 @@ impl ActorId {
 
 impl fmt::Display for ActorId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let ActorId(proc_id, name, pid) = self;
-        write!(f, "{},{}[{}]", proc_id, name, pid)
+        write!(f, "{},{}[{}]", self.0, self.1, self.2)
     }
 }
 impl<A: Referable> From<ActorRef<A>> for ActorId {
@@ -610,9 +655,14 @@ impl<A: Referable> Hash for ActorRef<A> {
     Ord,
     typeuri::Named
 )]
-pub struct PortId(pub ActorId, pub u64);
+pub struct PortId(ActorId, u64);
 
 impl PortId {
+    /// Create a new port ID.
+    pub fn new(actor_id: ActorId, port: u64) -> Self {
+        Self(actor_id, port)
+    }
+
     /// The ID of the port's owning actor.
     pub fn actor_id(&self) -> &ActorId {
         &self.0
@@ -1100,13 +1150,13 @@ mod tests {
         let cases: Vec<(&str, Reference)> = vec![
             (
                 "tcp:[::1]:1234,test",
-                ProcId("tcp:[::1]:1234".parse().unwrap(), "test".to_string()).into(),
+                ProcId::with_name("tcp:[::1]:1234".parse::<ChannelAddr>().unwrap(), "test").into(),
             ),
             (
                 "tcp:[::1]:1234,test,testactor[123]",
-                ActorId(
-                    ProcId("tcp:[::1]:1234".parse().unwrap(), "test".to_string()),
-                    "testactor".to_string(),
+                ActorId::new(
+                    ProcId::with_name("tcp:[::1]:1234".parse::<ChannelAddr>().unwrap(), "test"),
+                    "testactor",
                     123,
                 )
                 .into(),
@@ -1114,10 +1164,10 @@ mod tests {
             (
                 // type annotations are ignored
                 "tcp:[::1]:1234,test,testactor[0][123<my::type>]",
-                PortId(
-                    ActorId(
-                        ProcId("tcp:[::1]:1234".parse().unwrap(), "test".to_string()),
-                        "testactor".to_string(),
+                PortId::new(
+                    ActorId::new(
+                        ProcId::with_name("tcp:[::1]:1234".parse::<ChannelAddr>().unwrap(), "test"),
+                        "testactor",
                         0,
                     ),
                     123,
@@ -1164,10 +1214,10 @@ mod tests {
         #[derive(typeuri::Named, Serialize, Deserialize)]
         struct MyType;
         wirevalue::register_type!(MyType);
-        let port_id = PortId(
-            ActorId(
-                ProcId("tcp:[::1]:1234".parse().unwrap(), "test".to_string()),
-                "testactor".into(),
+        let port_id = PortId::new(
+            ActorId::new(
+                ProcId::with_name("tcp:[::1]:1234".parse::<ChannelAddr>().unwrap(), "test"),
+                "testactor",
                 1,
             ),
             MyType::port(),

--- a/hyperactor/src/testing/ids.rs
+++ b/hyperactor/src/testing/ids.rs
@@ -19,7 +19,7 @@ use crate::reference::ProcId;
 
 /// Create a test `ProcId` with a local channel address and name `"test_{name}"`.
 pub fn test_proc_id(name: &str) -> ProcId {
-    ProcId(
+    ProcId::with_name(
         ChannelAddr::any(ChannelTransport::Local),
         format!("test_{name}"),
     )
@@ -27,7 +27,7 @@ pub fn test_proc_id(name: &str) -> ProcId {
 
 /// Create a test `ProcId` with a custom address and name `"test_{name}"`.
 pub fn test_proc_id_with_addr(addr: ChannelAddr, name: &str) -> ProcId {
-    ProcId(addr, format!("test_{name}"))
+    ProcId::with_name(addr, format!("test_{name}"))
 }
 
 /// Create a test `ActorId` with pid 0.
@@ -42,10 +42,10 @@ pub fn test_actor_id_with_pid(proc_name: &str, actor_name: &str, pid: usize) -> 
 
 /// Create a test `PortId` with pid 0.
 pub fn test_port_id(proc_name: &str, actor_name: &str, port: u64) -> PortId {
-    PortId(test_actor_id(proc_name, actor_name), port)
+    PortId::new(test_actor_id(proc_name, actor_name), port)
 }
 
 /// Create a test `PortId` with a custom pid.
 pub fn test_port_id_with_pid(proc_name: &str, actor_name: &str, pid: usize, port: u64) -> PortId {
-    PortId(test_actor_id_with_pid(proc_name, actor_name, pid), port)
+    PortId::new(test_actor_id_with_pid(proc_name, actor_name, pid), port)
 }

--- a/hyperactor_mesh/src/alloc.rs
+++ b/hyperactor_mesh/src/alloc.rs
@@ -749,10 +749,8 @@ pub(crate) mod testing {
             DialMailboxRouter::new_with_default((UndeliverableMailboxSender {}).into_boxed());
         router.clone().serve(router_rx);
 
-        let client_proc_id = ProcId(
-            ChannelAddr::any(ChannelTransport::Local),
-            "test_stuck_0".to_string(),
-        );
+        let client_proc_id =
+            ProcId::with_name(ChannelAddr::any(ChannelTransport::Local), "test_stuck_0");
         let (client_proc_addr, client_rx) = channel::serve(ChannelAddr::any(transport)).unwrap();
         let client_proc = Proc::new(
             client_proc_id.clone(),

--- a/hyperactor_mesh/src/alloc/local.rs
+++ b/hyperactor_mesh/src/alloc/local.rs
@@ -172,7 +172,7 @@ impl Alloc for LocalAlloc {
                         Some(name) => name.clone(),
                         None => format!("{}_{}", self.alloc_name.name(), rank),
                     };
-                    let proc_id = ProcId(addr.clone(), proc_name);
+                    let proc_id = ProcId::with_name(addr.clone(), proc_name);
 
                     let bspan = tracing::info_span!("mesh_agent_bootstrap");
                     let (proc, mesh_agent) = match ProcAgent::bootstrap(proc_id.clone()).await {

--- a/hyperactor_mesh/src/alloc/process.rs
+++ b/hyperactor_mesh/src/alloc/process.rs
@@ -538,8 +538,10 @@ impl ProcessAlloc {
                         // For spawned processes, we use a temporary placeholder ProcId.
                         // The actual ProcId will be set when the process calls Hello with its address.
                         let temp_addr = ChannelAddr::any(ChannelTransport::Local);
-                        let proc_id =
-                            ProcId(temp_addr, format!("{}_{}", self.alloc_name.name(), rank));
+                        let proc_id = ProcId::with_name(
+                            temp_addr,
+                            format!("{}_{}", self.alloc_name.name(), rank),
+                        );
                         let (handle, monitor) =
                             Child::monitored(rank, process, log_channel, tail_size, proc_id);
 
@@ -610,7 +612,7 @@ impl Alloc for ProcessAlloc {
                                 None => format!("{}_{}", self.name, index),
                             };
                             child.post(Allocator2Process::StartProc(
-                                ProcId(addr.clone(), proc_name),
+                                ProcId::with_name(addr.clone(), proc_name),
                                 transport,
                             ));
                         }

--- a/hyperactor_mesh/src/bootstrap/mailbox.rs
+++ b/hyperactor_mesh/src/bootstrap/mailbox.rs
@@ -144,10 +144,12 @@ mod tests {
         // These proc names must match the socket file names on disk, so we
         // construct the IDs directly rather than via test_proc_id.
         let local_addr: ChannelAddr = "tcp:3.4.5.6:123".parse().unwrap();
-        let first_actor_id = ProcId(local_addr.clone(), first.to_string()).actor_id("actor", 0);
-        let second_actor_id = ProcId(local_addr.clone(), second.to_string()).actor_id("actor", 0);
+        let first_actor_id =
+            ProcId::with_name(local_addr.clone(), first.to_string()).actor_id("actor", 0);
+        let second_actor_id =
+            ProcId::with_name(local_addr.clone(), second.to_string()).actor_id("actor", 0);
         let third_notexist_actor_id =
-            ProcId(local_addr.clone(), third.to_string()).actor_id("actor", 0);
+            ProcId::with_name(local_addr.clone(), third.to_string()).actor_id("actor", 0);
         let proc_dialer = LocalProcDialer::new(
             local_addr.clone(),
             dir.path().to_owned(),
@@ -161,7 +163,7 @@ mod tests {
         // Existing address on the host:
         let envelope = MessageEnvelope::new(
             third_notexist_actor_id.clone(),
-            PortId(first_actor_id.clone(), 0),
+            PortId::new(first_actor_id.clone(), 0),
             wirevalue::Any::serialize(&()).unwrap(),
             Flattrs::new(),
         );
@@ -174,7 +176,7 @@ mod tests {
         // Nonexistant address on the host:
         let envelope = MessageEnvelope::new(
             second_actor_id.clone(),
-            PortId(third_notexist_actor_id.clone(), 0),
+            PortId::new(third_notexist_actor_id.clone(), 0),
             wirevalue::Any::serialize(&()).unwrap(),
             Flattrs::new(),
         );
@@ -187,7 +189,7 @@ mod tests {
         // Outside the host:
         let envelope = MessageEnvelope::new(
             second_actor_id.clone(),
-            PortId(test_actor_id("external_0", "actor"), 0),
+            PortId::new(test_actor_id("external_0", "actor"), 0),
             wirevalue::Any::serialize(&()).unwrap(),
             Flattrs::new(),
         );
@@ -195,10 +197,11 @@ mod tests {
         assert_eq!(backend_rx.recv().await.unwrap().sender(), &second_actor_id);
 
         // System proc on the host (name must be exactly "system"):
-        let system_actor_id = ProcId(local_addr.clone(), "system".to_string()).actor_id("actor", 0);
+        let system_actor_id =
+            ProcId::with_name(local_addr.clone(), "system".to_string()).actor_id("actor", 0);
         let envelope = MessageEnvelope::new(
             second_actor_id.clone(),
-            PortId(system_actor_id, 0),
+            PortId::new(system_actor_id, 0),
             wirevalue::Any::serialize(&()).unwrap(),
             Flattrs::new(),
         );

--- a/hyperactor_mesh/src/global_context.rs
+++ b/hyperactor_mesh/src/global_context.rs
@@ -532,7 +532,7 @@ mod tests {
     ) {
         let env = MessageEnvelope::new(
             client.self_id().clone(),
-            PortId(dest_actor, 0),
+            PortId::new(dest_actor, 0),
             wirevalue::Any::serialize(&0u64).unwrap(),
             Flattrs::new(),
         );

--- a/hyperactor_mesh/src/host_mesh.rs
+++ b/hyperactor_mesh/src/host_mesh.rs
@@ -123,12 +123,12 @@ impl HostRef {
 
     /// The ProcId for the proc with name `name` on this host.
     fn named_proc(&self, name: &Name) -> ProcId {
-        ProcId(self.0.clone(), name.to_string())
+        ProcId::with_name(self.0.clone(), name.to_string())
     }
 
     /// The service proc on this host.
     fn service_proc(&self) -> ProcId {
-        ProcId(self.0.clone(), SERVICE_PROC_NAME.to_string())
+        ProcId::with_name(self.0.clone(), SERVICE_PROC_NAME)
     }
 
     /// Request an orderly teardown of this host and all procs it

--- a/hyperactor_mesh/src/host_mesh/host_agent.rs
+++ b/hyperactor_mesh/src/host_mesh/host_agent.rs
@@ -957,8 +957,8 @@ mod tests {
                     ..
                 }),
             } if name == resource_name
-              && proc_id == ProcId(host_addr.clone(), name.to_string())
-              && mesh_agent == ActorRef::attest(ProcId(host_addr.clone(), name.to_string()).actor_id(crate::proc_agent::PROC_AGENT_ACTOR_NAME, 0)) && bootstrap_command == Some(BootstrapCommand::test())
+              && proc_id == ProcId::with_name(host_addr.clone(), name.to_string())
+              && mesh_agent == ActorRef::attest(ProcId::with_name(host_addr.clone(), name.to_string()).actor_id(crate::proc_agent::PROC_AGENT_ACTOR_NAME, 0)) && bootstrap_command == Some(BootstrapCommand::test())
               && mesh_agent == proc_status_mesh_agent
         );
     }

--- a/hyperactor_mesh/src/mesh_admin.rs
+++ b/hyperactor_mesh/src/mesh_admin.rs
@@ -2123,11 +2123,11 @@ mod tests {
     #[test]
     fn test_build_root_payload_with_root_client() {
         let addr1: SocketAddr = "127.0.0.1:9001".parse().unwrap();
-        let proc1 = ProcId(ChannelAddr::Tcp(addr1), "host1".to_string());
+        let proc1 = ProcId::with_name(ChannelAddr::Tcp(addr1), "host1");
         let actor_id1 = ActorId::root(proc1, "mesh_agent".to_string());
         let ref1: ActorRef<HostAgent> = ActorRef::attest(actor_id1.clone());
 
-        let client_proc_id = ProcId(ChannelAddr::Tcp(addr1), "local".to_string());
+        let client_proc_id = ProcId::with_name(ChannelAddr::Tcp(addr1), "local");
         let client_actor_id = client_proc_id.actor_id("client", 0);
 
         let agent = MeshAdminAgent::new(

--- a/hyperactor_mesh/src/proc_launcher/native.rs
+++ b/hyperactor_mesh/src/proc_launcher/native.rs
@@ -749,7 +749,7 @@ mod tests {
             let launcher = NativeProcLauncher::new();
             // v0 bootstrap by default but it doesn't matter here.
             let bootstrap = Bootstrap::default();
-            let proc_id = ProcId(any_unix_addr(), "stdio-captured".into());
+            let proc_id = ProcId::with_name(any_unix_addr(), "stdio-captured");
             let opts = LaunchOptions {
                 command: with_sh(script),
                 bootstrap_payload: bootstrap.to_env_safe_string().unwrap(),
@@ -783,7 +783,7 @@ mod tests {
             let launcher = NativeProcLauncher::new();
             // v0 bootstrap by default but it doesn't matter here.
             let bootstrap = Bootstrap::default();
-            let proc_id = ProcId(any_unix_addr(), "stdio-inherited".into());
+            let proc_id = ProcId::with_name(any_unix_addr(), "stdio-inherited");
             let opts = LaunchOptions {
                 command: with_sh(script),
                 bootstrap_payload: bootstrap.to_env_safe_string().unwrap(),
@@ -821,7 +821,7 @@ mod tests {
         let launcher = NativeProcLauncher::new();
         // v0 bootstrap by default but it doesn't matter here.
         let bootstrap = Bootstrap::default();
-        let proc_id = ProcId(any_unix_addr(), "exit-7".into());
+        let proc_id = ProcId::with_name(any_unix_addr(), "exit-7");
         let opts = LaunchOptions {
             command: with_sh("exit 7"),
             bootstrap_payload: bootstrap.to_env_safe_string().unwrap(),
@@ -860,7 +860,7 @@ mod tests {
         let launcher = NativeProcLauncher::new();
         // v0 bootstrap by default but it doesn't matter here.
         let bootstrap = Bootstrap::default();
-        let proc_id = ProcId(any_unix_addr(), "killed".into());
+        let proc_id = ProcId::with_name(any_unix_addr(), "killed");
         let opts = LaunchOptions {
             command: with_sh("sleep 30"),
             bootstrap_payload: bootstrap.to_env_safe_string().unwrap(),
@@ -932,7 +932,7 @@ mod tests {
 
         // v0 bootstrap by default but it doesn't matter here.
         let bootstrap = Bootstrap::default();
-        let proc_id = ProcId(any_unix_addr(), "term-escalate".into());
+        let proc_id = ProcId::with_name(any_unix_addr(), "term-escalate");
         let opts = LaunchOptions {
             command: with_sh(script),
             bootstrap_payload: bootstrap.to_env_safe_string().unwrap(),
@@ -1020,7 +1020,7 @@ while True:
         };
 
         let bootstrap = Bootstrap::default();
-        let proc_id = ProcId(any_unix_addr(), "drop-cleanup-test".into());
+        let proc_id = ProcId::with_name(any_unix_addr(), "drop-cleanup-test");
         let opts = LaunchOptions {
             command,
             bootstrap_payload: bootstrap.to_env_safe_string().unwrap(),

--- a/hyperactor_mesh/src/proc_launcher/systemd.rs
+++ b/hyperactor_mesh/src/proc_launcher/systemd.rs
@@ -1191,7 +1191,7 @@ mod tests {
 
         let launcher = SystemdProcLauncher::new();
 
-        let proc_id = ProcId(any_unix_addr(), "env-vars".into());
+        let proc_id = ProcId::with_name(any_unix_addr(), "env-vars");
         // v0 bootstrap by default but it doesn't matter here.
         let bootstrap = Bootstrap::default();
         let opts = LaunchOptions {
@@ -1290,7 +1290,7 @@ mod tests {
 
         // v0 bootstrap by default but it doesn't matter here.
         let bootstrap = Bootstrap::default();
-        let proc_id = ProcId(any_unix_addr(), "exit-7".into());
+        let proc_id = ProcId::with_name(any_unix_addr(), "exit-7");
         let opts = LaunchOptions {
             command: with_sh("exit 7"),
             bootstrap_payload: bootstrap.to_env_safe_string().unwrap(),
@@ -1332,7 +1332,7 @@ mod tests {
 
         // v0 bootstrap by default but it doesn't matter here.
         let bootstrap = Bootstrap::default();
-        let proc_id = ProcId(any_unix_addr(), "killed".into());
+        let proc_id = ProcId::with_name(any_unix_addr(), "killed");
         let opts = LaunchOptions {
             command: with_sh("sleep 30"),
             bootstrap_payload: bootstrap.to_env_safe_string().unwrap(),
@@ -1394,7 +1394,7 @@ mod tests {
 
         // v0 bootstrap by default but it doesn't matter here.
         let bootstrap = Bootstrap::default();
-        let proc_id = ProcId(any_unix_addr(), "terminated".into());
+        let proc_id = ProcId::with_name(any_unix_addr(), "terminated");
         let opts = LaunchOptions {
             command: with_sh("sleep 30"),
             bootstrap_payload: bootstrap.to_env_safe_string().unwrap(),
@@ -1438,7 +1438,7 @@ mod tests {
 
         let launcher = SystemdProcLauncher::new();
 
-        let unknown_proc_id = ProcId(any_unix_addr(), "unknown".into());
+        let unknown_proc_id = ProcId::with_name(any_unix_addr(), "unknown");
 
         let result = launcher
             .terminate(&unknown_proc_id, Duration::from_secs(1))
@@ -1460,7 +1460,7 @@ mod tests {
 
         let launcher = SystemdProcLauncher::new();
 
-        let unknown_proc_id = ProcId(any_unix_addr(), "unknown".into());
+        let unknown_proc_id = ProcId::with_name(any_unix_addr(), "unknown");
 
         let result = launcher.kill(&unknown_proc_id).await;
 
@@ -1564,7 +1564,7 @@ mod tests {
         );
 
         let bootstrap = Bootstrap::default();
-        let proc_id = ProcId(any_unix_addr(), "drop-cleanup-test".into());
+        let proc_id = ProcId::with_name(any_unix_addr(), "drop-cleanup-test");
 
         let exit_rx;
 
@@ -1663,7 +1663,7 @@ mod tests {
 
         let launcher = SystemdProcLauncher::new();
 
-        let proc_id = ProcId(any_unix_addr(), "long-running".into());
+        let proc_id = ProcId::with_name(any_unix_addr(), "long-running");
         let bootstrap = Bootstrap::default();
         let opts = LaunchOptions {
             command: with_sh("sleep 60"),

--- a/monarch_hyperactor/src/local_state_broker.rs
+++ b/monarch_hyperactor/src/local_state_broker.rs
@@ -90,7 +90,7 @@ impl BrokerId {
         use std::time::Duration;
 
         let broker_name = format!("{:?}", self);
-        let actor_id = ActorId(cx.proc().proc_id().clone(), self.0, self.1);
+        let actor_id = ActorId::new(cx.proc().proc_id().clone(), self.0.clone(), self.1);
         let actor_ref: ActorRef<LocalStateBrokerActor> = ActorRef::attest(actor_id);
 
         let mut delay_ms = 1;

--- a/monarch_hyperactor/src/mailbox.rs
+++ b/monarch_hyperactor/src/mailbox.rs
@@ -185,7 +185,7 @@ impl PyPortId {
     #[pyo3(signature = (*, actor_id, port))]
     fn new(actor_id: &PyActorId, port: u64) -> Self {
         Self {
-            inner: PortId(actor_id.inner.clone(), port),
+            inner: PortId::new(actor_id.inner.clone(), port),
         }
     }
 

--- a/monarch_hyperactor/src/proc.rs
+++ b/monarch_hyperactor/src/proc.rs
@@ -167,11 +167,7 @@ impl PyActorId {
             PyValueError::new_err(format!("Failed to parse channel address '{}': {}", addr, e))
         })?;
         Ok(Self {
-            inner: ActorId(
-                ProcId(addr, proc_name.to_string()),
-                actor_name.to_string(),
-                pid,
-            ),
+            inner: ActorId::new(ProcId::with_name(addr, proc_name), actor_name, pid),
         })
     }
 

--- a/monarch_hyperactor/src/runtime.rs
+++ b/monarch_hyperactor/src/runtime.rs
@@ -89,7 +89,7 @@ pub(crate) fn get_proc_runtime() -> &'static Proc {
     static RUNTIME_PROC: OnceLock<Proc> = OnceLock::new();
     RUNTIME_PROC.get_or_init(|| {
         let addr = ChannelAddr::any(ChannelTransport::Local);
-        let proc_id = ProcId(addr, "monarch_hyperactor_runtime".to_string());
+        let proc_id = ProcId::unique(addr, "monarch_hyperactor_runtime");
         Proc::new(proc_id, BoxedMailboxSender::new(PanickingMailboxSender))
     })
 }

--- a/monarch_rdma/src/rdma_manager_actor.rs
+++ b/monarch_rdma/src/rdma_manager_actor.rs
@@ -150,8 +150,8 @@ impl RdmaManagerActor {
     /// Construct an [`ActorHandle`] for the [`RdmaManagerActor`] co-located
     /// with the caller.
     pub fn local_handle(client: &impl context::Actor) -> ActorHandle<Self> {
-        let proc_id = client.mailbox().actor_id().0.clone();
-        let actor_ref = ActorRef::attest(ActorId(proc_id, "rdma_manager".to_string(), 0));
+        let proc_id = client.mailbox().actor_id().proc_id().clone();
+        let actor_ref = ActorRef::attest(ActorId::new(proc_id, "rdma_manager", 0));
         actor_ref
             .downcast_handle(client)
             .expect("RdmaManagerActor is not in the local process")


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #2933
* #2932
* #2928
* __->__ #2927
* #2926
* #2925

Make the fields of ProcId, ActorId, and PortId private and provide
controlled constructors as a preparatory step for enforcing ProcId
name uniqueness.

- ProcId::with_name(addr, name) — for names that are already unique
  (contain a UUID, come from deserialization, or are host-scoped)
- ProcId::unique(addr, base_name) — appends a deterministic hash
  suffix for standalone procs that need globally unique names
  (runtime procs, mailbox internals)
- ProcId::base_name() — strips the hash suffix if present
- ActorId::new(proc_id, name, pid) — replaces direct tuple construction
- PortId::new(actor_id, port) — replaces direct tuple construction

All 23 files with direct field access or tuple construction migrated
to use the new API. No semantic change to proc naming in production
paths — service/local/spawned procs retain their original names.

Differential Revision: [D95801212](https://our.internmc.facebook.com/intern/diff/D95801212/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D95801212/)!