### PR TITLE
[hyperactor] qualify all reference type usages inline

### DIFF
--- a/hyper/src/commands/list.rs
+++ b/hyper/src/commands/list.rs
@@ -6,10 +6,9 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-use hyperactor::ActorRef;
 use hyperactor::channel::ChannelAddr;
 use hyperactor::host::SERVICE_PROC_NAME;
-use hyperactor::reference::ProcId;
+use hyperactor::reference;
 use hyperactor_mesh::context;
 use hyperactor_mesh::host_mesh::host_agent::HOST_MESH_AGENT_ACTOR_NAME;
 use hyperactor_mesh::host_mesh::host_agent::HostAgent;
@@ -37,8 +36,9 @@ impl ListCommand {
         let client = cx.actor_instance;
 
         // Codify obtaining a proc's agent in `hyperactor_mesh` somewhere.
-        let agent: ActorRef<HostAgent> = ActorRef::attest(
-            ProcId::with_name(host, SERVICE_PROC_NAME).actor_id(HOST_MESH_AGENT_ACTOR_NAME, 0),
+        let agent: reference::ActorRef<HostAgent> = reference::ActorRef::attest(
+            reference::ProcId::with_name(host, SERVICE_PROC_NAME)
+                .actor_id(HOST_MESH_AGENT_ACTOR_NAME, 0),
         );
 
         let resources = agent.list(&client).await?;

--- a/hyper/src/commands/show.rs
+++ b/hyper/src/commands/show.rs
@@ -6,10 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-use hyperactor::ActorRef;
 use hyperactor::host::SERVICE_PROC_NAME;
-use hyperactor::reference::ProcId;
-use hyperactor::reference::Reference;
+use hyperactor::reference;
 use hyperactor_mesh::context;
 use hyperactor_mesh::host_mesh::host_agent::HOST_MESH_AGENT_ACTOR_NAME;
 use hyperactor_mesh::host_mesh::host_agent::HostAgent;
@@ -19,21 +17,21 @@ use hyperactor_mesh::resource::GetStateClient;
 pub struct ShowCommand {
     /// The string repsentation of what we want to show, such as world, proc,
     /// actor, etc.
-    reference: Reference,
+    reference: reference::Reference,
 }
 
 impl ShowCommand {
     pub async fn run(self) -> anyhow::Result<()> {
         match self.reference {
-            Reference::Proc(proc_id) => {
+            reference::Reference::Proc(proc_id) => {
                 let host = proc_id.addr().clone();
                 let proc = proc_id.name().to_string();
                 let cx = context().await;
                 let client = cx.actor_instance;
 
                 // Codify obtaining a proc's agent in `hyperactor_mesh` somewhere.
-                let agent: ActorRef<HostAgent> = ActorRef::attest(
-                    ProcId::with_name(host, SERVICE_PROC_NAME)
+                let agent: reference::ActorRef<HostAgent> = reference::ActorRef::attest(
+                    reference::ProcId::with_name(host, SERVICE_PROC_NAME)
                         .actor_id(HOST_MESH_AGENT_ACTOR_NAME, 0),
                 );
 

--- a/hyperactor/example/derive.rs
+++ b/hyperactor/example/derive.rs
@@ -15,9 +15,9 @@ use hyperactor::Actor;
 use hyperactor::Context;
 use hyperactor::HandleClient;
 use hyperactor::Handler;
-use hyperactor::OncePortRef;
 use hyperactor::RefClient;
 use hyperactor::proc::Proc;
+use hyperactor::reference;
 use serde::Deserialize;
 use serde::Serialize;
 use typeuri::Named;
@@ -30,9 +30,9 @@ enum ShoppingList {
 
     // Call messages dispatch a request, expecting a reply to the
     // provided port, which must be in the last position.
-    Exists(String, #[reply] OncePortRef<bool>),
+    Exists(String, #[reply] reference::OncePortRef<bool>),
 
-    List(#[reply] OncePortRef<Vec<String>>),
+    List(#[reply] reference::OncePortRef<Vec<String>>),
 }
 
 // Example struct-based message types (demonstrating the new struct support)
@@ -45,7 +45,7 @@ struct ClearList {
 struct GetItemCount<C> {
     category_filter: String,
     #[reply]
-    reply: OncePortRef<C>,
+    reply: reference::OncePortRef<C>,
 }
 
 // Define an actor.
@@ -135,7 +135,7 @@ async fn main() -> Result<(), anyhow::Error> {
     // Spawn our actor, and get a handle for rank 0.
     let shopping_list_actor: hyperactor::ActorHandle<ShoppingListActor> =
         proc.spawn("shopping", ShoppingListActor::default())?;
-    let shopping_api: hyperactor::ActorRef<ShoppingApi> = shopping_list_actor.bind();
+    let shopping_api: reference::ActorRef<ShoppingApi> = shopping_list_actor.bind();
     // We join the system, so that we can send messages to actors.
     let (client, _) = proc.instance("client").unwrap();
 

--- a/hyperactor/example/stream.rs
+++ b/hyperactor/example/stream.rs
@@ -16,22 +16,22 @@ use hyperactor::ActorHandle;
 use hyperactor::Context;
 use hyperactor::Handler;
 use hyperactor::Instance;
-use hyperactor::PortRef;
 use hyperactor::proc::Proc;
+use hyperactor::reference;
 use serde::Deserialize;
 use serde::Serialize;
 use typeuri::Named;
 
 #[derive(Debug, Default)]
 struct CounterActor {
-    subscribers: Vec<PortRef<u64>>,
+    subscribers: Vec<reference::PortRef<u64>>,
     n: u64,
 }
 
 impl Actor for CounterActor {}
 
 #[derive(Serialize, Deserialize, Debug, Named)]
-struct Subscribe(PortRef<u64>);
+struct Subscribe(reference::PortRef<u64>);
 
 #[async_trait]
 impl Handler<Subscribe> for CounterActor {
@@ -51,11 +51,11 @@ impl Handler<Subscribe> for CounterActor {
 
 #[derive(Debug)]
 struct CountClient {
-    counter: PortRef<Subscribe>,
+    counter: reference::PortRef<Subscribe>,
 }
 
 impl CountClient {
-    fn new(counter: PortRef<Subscribe>) -> Self {
+    fn new(counter: reference::PortRef<Subscribe>) -> Self {
         Self { counter }
     }
 }

--- a/hyperactor/src/accum.rs
+++ b/hyperactor/src/accum.rs
@@ -22,7 +22,7 @@ use typeuri::Named;
 
 // for macros
 use crate::config;
-use crate::reference::Index;
+use crate::reference;
 
 /// An accumulator is a object that accumulates updates into a state.
 pub trait Accumulator {
@@ -414,7 +414,7 @@ pub use algebra::Min;
 /// reports. "Latest" is determined by logical timestamp, not arrival
 /// order.
 #[derive(Default, Debug, Clone, Serialize, Deserialize, typeuri::Named)]
-pub struct WatermarkUpdate<T>(algebra::LatticeMap<Index, algebra::LWW<T>>);
+pub struct WatermarkUpdate<T>(algebra::LatticeMap<reference::Index, algebra::LWW<T>>);
 
 impl<T: Ord + Clone> WatermarkUpdate<T> {
     /// Get the watermark value (minimum of all ranks' current values).
@@ -430,7 +430,7 @@ impl<T: Ord + Clone> WatermarkUpdate<T> {
     }
 
     /// Get the current value for a specific rank, if present.
-    pub fn get_rank(&self, rank: Index) -> Option<&T> {
+    pub fn get_rank(&self, rank: reference::Index) -> Option<&T> {
         self.0.get(&rank).map(|lww| &lww.value)
     }
 
@@ -440,13 +440,13 @@ impl<T: Ord + Clone> WatermarkUpdate<T> {
     }
 }
 
-impl<T> From<(Index, T, u64)> for WatermarkUpdate<T> {
+impl<T> From<(reference::Index, T, u64)> for WatermarkUpdate<T> {
     /// Create a watermark update from (rank, value, timestamp).
     ///
     /// The timestamp should be a logical clock value (Lamport clock, sequence
     /// number, or monotonic counter) that increases with each update from
     /// the same rank.
-    fn from((rank, value, timestamp): (Index, T, u64)) -> Self {
+    fn from((rank, value, timestamp): (reference::Index, T, u64)) -> Self {
         let mut map = algebra::LatticeMap::new();
         // Use rank as replica ID - each rank is a unique writer
         map.insert(rank, algebra::LWW::new(value, timestamp, rank as u64));
@@ -472,7 +472,7 @@ impl<T: Clone + PartialEq> JoinSemilattice for WatermarkUpdate<T> {
 /// - *Idempotent*: Merging duplicate updates has no effect
 /// - *Convergent*: All replicas converge to the same state
 #[derive(Default, Debug, Clone, Serialize, Deserialize, typeuri::Named)]
-pub struct GCounterUpdate(algebra::LatticeMap<Index, Max<u64>>);
+pub struct GCounterUpdate(algebra::LatticeMap<reference::Index, Max<u64>>);
 wirevalue::register_type!(GCounterUpdate);
 
 impl GCounterUpdate {
@@ -482,7 +482,7 @@ impl GCounterUpdate {
     }
 
     /// Get count for a specific rank.
-    pub fn get_rank(&self, rank: Index) -> Option<u64> {
+    pub fn get_rank(&self, rank: reference::Index) -> Option<u64> {
         self.0.get(&rank).map(|max| max.0)
     }
 
@@ -492,9 +492,9 @@ impl GCounterUpdate {
     }
 }
 
-impl From<(Index, u64)> for GCounterUpdate {
+impl From<(reference::Index, u64)> for GCounterUpdate {
     /// Create a GCounter update from (rank, count).
-    fn from((rank, count): (Index, u64)) -> Self {
+    fn from((rank, count): (reference::Index, u64)) -> Self {
         let mut map = algebra::LatticeMap::new();
         map.insert(rank, Max(count));
         Self(map)
@@ -515,8 +515,8 @@ impl JoinSemilattice for GCounterUpdate {
 /// via pointwise max.
 #[derive(Default, Debug, Clone, Serialize, Deserialize, typeuri::Named)]
 pub struct PNCounterUpdate {
-    p: algebra::LatticeMap<Index, Max<u64>>,
-    n: algebra::LatticeMap<Index, Max<u64>>,
+    p: algebra::LatticeMap<reference::Index, Max<u64>>,
+    n: algebra::LatticeMap<reference::Index, Max<u64>>,
 }
 wirevalue::register_type!(PNCounterUpdate);
 
@@ -529,7 +529,7 @@ impl PNCounterUpdate {
     }
 
     /// Create an increment update for a rank.
-    pub fn inc(rank: Index, delta: u64) -> Self {
+    pub fn inc(rank: reference::Index, delta: u64) -> Self {
         let mut p = algebra::LatticeMap::new();
         p.insert(rank, Max(delta));
         Self {
@@ -539,7 +539,7 @@ impl PNCounterUpdate {
     }
 
     /// Create a decrement update for a rank.
-    pub fn dec(rank: Index, delta: u64) -> Self {
+    pub fn dec(rank: reference::Index, delta: u64) -> Self {
         let mut n = algebra::LatticeMap::new();
         n.insert(rank, Max(delta));
         Self {
@@ -707,7 +707,7 @@ mod tests {
 
         fn verify<T: Ord + Clone + PartialEq + DeserializeOwned + Debug + Named>(
             updates: Vec<wirevalue::Any>,
-            expected: HashMap<Index, T>,
+            expected: HashMap<reference::Index, T>,
         ) {
             let typehash = <SemilatticeReducer<WatermarkUpdate<T>> as Named>::typehash();
             let result = resolve_reducer(typehash, None)
@@ -894,7 +894,7 @@ mod tests {
     fn test_gcounter_accumulator() {
         let accumulator = join_semilattice::<GCounterUpdate>();
         // (rank, count, expected_total)
-        let ranks_counts_expectations: [(Index, u64, u64); 17] = [
+        let ranks_counts_expectations: [(reference::Index, u64, u64); 17] = [
             // initialize all 3 ranks in descending order
             (0, 1000, 1000),
             (1, 100, 1100),
@@ -1014,8 +1014,8 @@ mod tests {
         // Helper to make updates clearer
         #[derive(Clone, Copy, Debug)]
         enum Op {
-            Inc(Index, u64),
-            Dec(Index, u64),
+            Inc(reference::Index, u64),
+            Dec(reference::Index, u64),
         }
         use Op::*;
 

--- a/hyperactor/src/actor.rs
+++ b/hyperactor/src/actor.rs
@@ -32,7 +32,6 @@ use tokio::task::JoinHandle;
 use typeuri::Named;
 
 use crate as hyperactor; // for macros
-use crate::ActorRef;
 use crate::Data;
 use crate::Message;
 use crate::RemoteMessage;
@@ -55,8 +54,7 @@ use crate::proc::Instance;
 use crate::proc::InstanceCell;
 use crate::proc::Ports;
 use crate::proc::Proc;
-use crate::reference::ActorId;
-use crate::reference::Index;
+use crate::reference;
 use crate::supervision::ActorSupervisionEvent;
 
 pub mod remote;
@@ -294,7 +292,7 @@ pub trait RemoteSpawn: Actor + Referable + Binds<Self> {
         name: &str,
         serialized_params: Data,
         environment: Flattrs,
-    ) -> Pin<Box<dyn Future<Output = Result<ActorId, anyhow::Error>> + Send>> {
+    ) -> Pin<Box<dyn Future<Output = Result<reference::ActorId, anyhow::Error>> + Send>> {
         let proc = proc.clone();
         let name = name.to_string();
         Box::pin(async move {
@@ -353,7 +351,7 @@ where
 #[derive(Debug)]
 pub struct ActorError {
     /// The ActorId for the actor that generated this error.
-    pub actor_id: Box<ActorId>,
+    pub actor_id: Box<reference::ActorId>,
     /// The kind of error that occurred.
     pub kind: Box<ActorErrorKind>,
 }
@@ -433,7 +431,7 @@ impl ActorErrorKind {
 
 impl ActorError {
     /// Create a new actor server error with the provided id and kind.
-    pub(crate) fn new(actor_id: &ActorId, kind: ActorErrorKind) -> Self {
+    pub(crate) fn new(actor_id: &reference::ActorId, kind: ActorErrorKind) -> Self {
         Self {
             actor_id: Box::new(actor_id.clone()),
             kind: Box::new(kind),
@@ -487,7 +485,7 @@ pub enum Signal {
     Stop(String),
 
     /// The direct child with the given PID was stopped.
-    ChildStopped(Index),
+    ChildStopped(reference::Index),
 
     /// Abort the actor. This will exit the actor loop with an error,
     /// causing a supervision event to propagate up the supervision
@@ -687,7 +685,7 @@ impl<A: Actor> ActorHandle<A> {
     }
 
     /// The [`ActorId`] of the actor represented by this handle.
-    pub fn actor_id(&self) -> &ActorId {
+    pub fn actor_id(&self) -> &reference::ActorId {
         self.cell.actor_id()
     }
 
@@ -725,7 +723,7 @@ impl<A: Actor> ActorHandle<A> {
 
     /// TEMPORARY: bind...
     /// TODO: we shoudl also have a default binding(?)
-    pub fn bind<R: Binds<A>>(&self) -> ActorRef<R> {
+    pub fn bind<R: Binds<A>>(&self) -> reference::ActorRef<R> {
         self.cell.bind(self.ports.as_ref())
     }
 }
@@ -847,7 +845,6 @@ mod tests {
     use crate as hyperactor;
     use crate::Actor;
     use crate::OncePortHandle;
-    use crate::PortRef;
     use crate::checkpoint::CheckpointError;
     use crate::checkpoint::Checkpointable;
     use crate::clock::Clock;
@@ -865,14 +862,13 @@ mod tests {
     use crate::mailbox::monitored_return_handle;
     use crate::ordering::SEQ_INFO;
     use crate::ordering::SeqInfo;
-    use crate::reference::Reference;
     use crate::testing::ids::test_proc_id;
     use crate::testing::pingpong::PingPongActor;
     use crate::testing::pingpong::PingPongMessage;
     use crate::testing::proc_supervison::ProcSupervisionCoordinator; // for macros
 
     #[derive(Debug)]
-    struct EchoActor(PortRef<u64>);
+    struct EchoActor(reference::PortRef<u64>);
 
     #[async_trait]
     impl Actor for EchoActor {}
@@ -1004,7 +1000,7 @@ mod tests {
     struct CheckpointActor {
         // The actor does nothing but sum the values of messages.
         sum: u64,
-        port: PortRef<u64>,
+        port: reference::PortRef<u64>,
     }
 
     #[async_trait]
@@ -1021,7 +1017,7 @@ mod tests {
 
     #[async_trait]
     impl Checkpointable for CheckpointActor {
-        type State = (u64, PortRef<u64>);
+        type State = (u64, reference::PortRef<u64>);
 
         async fn save(&self) -> Result<Self::State, CheckpointError> {
             Ok((self.sum, self.port.clone()))
@@ -1128,7 +1124,7 @@ mod tests {
         test.sync().await;
         assert_eq!(test.get_values(), (123u64, "foo".to_string()));
 
-        let myref: ActorRef<MultiActor> = test.handle.bind();
+        let myref: reference::ActorRef<MultiActor> = test.handle.bind();
 
         myref.port().send(&test.client, 321u64).unwrap();
         test.sync().await;
@@ -1148,7 +1144,7 @@ mod tests {
 
         hyperactor::behavior!(MyActorBehavior, u64, String);
 
-        let myref: ActorRef<MyActorBehavior> = test.handle.bind();
+        let myref: reference::ActorRef<MyActorBehavior> = test.handle.bind();
         myref.port().send(&test.client, "biz".to_string()).unwrap();
         myref.port().send(&test.client, 999u64).unwrap();
 
@@ -1180,7 +1176,7 @@ mod tests {
     // Returning the sequence number assigned to the message.
     #[derive(Debug)]
     #[hyperactor::export(handlers = [String, Callback])]
-    struct GetSeqActor(PortRef<(String, SeqInfo)>);
+    struct GetSeqActor(reference::PortRef<(String, SeqInfo)>);
 
     #[async_trait]
     impl Actor for GetSeqActor {}
@@ -1204,7 +1200,7 @@ mod tests {
     // handler will reply that port with its own callback port. Then sender can
     // send the string message through this callback port.
     #[derive(Clone, Debug, Serialize, Deserialize, Named)]
-    struct Callback(PortRef<PortRef<String>>);
+    struct Callback(reference::PortRef<reference::PortRef<String>>);
 
     #[async_trait]
     impl Handler<Callback> for GetSeqActor {
@@ -1236,7 +1232,7 @@ mod tests {
             ("unbound".to_string(), SeqInfo::Direct)
         );
 
-        let actor_ref: ActorRef<GetSeqActor> = actor_handle.bind();
+        let actor_ref: reference::ActorRef<GetSeqActor> = actor_handle.bind();
 
         let session_id = client.sequencer().session_id();
         let mut expected_seq = 0;
@@ -1285,7 +1281,7 @@ mod tests {
         let (non_actor_tx, mut non_actor_rx) = mpsc::unbounded_channel::<Option<SeqInfo>>();
 
         let actor_handle = proc.spawn("get_seq", GetSeqActor(actor_tx.bind())).unwrap();
-        let actor_ref: ActorRef<GetSeqActor> = actor_handle.bind();
+        let actor_ref: reference::ActorRef<GetSeqActor> = actor_handle.bind();
 
         // Create a non-actor port using open_enqueue_port
         let non_actor_tx_clone = non_actor_tx.clone();
@@ -1362,7 +1358,7 @@ mod tests {
         let (tx, mut rx) = client1.open_port();
 
         let actor_handle = proc.spawn("get_seq", GetSeqActor(tx.bind())).unwrap();
-        let actor_ref: ActorRef<GetSeqActor> = actor_handle.bind();
+        let actor_ref: reference::ActorRef<GetSeqActor> = actor_handle.bind();
 
         // Each client should have a different session_id
         let session_id_1 = client1.sequencer().session_id();
@@ -1471,7 +1467,7 @@ mod tests {
         let (tx, mut rx) = client.open_port();
 
         let actor_handle = proc.spawn("get_seq", GetSeqActor(tx.bind())).unwrap();
-        let actor_ref: ActorRef<GetSeqActor> = actor_handle.bind();
+        let actor_ref: reference::ActorRef<GetSeqActor> = actor_handle.bind();
 
         let (callback_tx, mut callback_rx) = client.open_port();
         // Client sends the 1st message
@@ -1558,7 +1554,7 @@ mod tests {
         let (tx, mut rx) = client.open_port();
 
         let handle = local_proc.spawn("get_seq", GetSeqActor(tx.bind())).unwrap();
-        let actor_ref: ActorRef<GetSeqActor> = handle.bind();
+        let actor_ref: reference::ActorRef<GetSeqActor> = handle.bind();
 
         let remote_proc = Proc::configured(
             test_proc_id("remote_0"),
@@ -1672,7 +1668,7 @@ mod tests {
         let handle = proc.spawn::<EchoActor>("echo_introspect", actor).unwrap();
 
         let (reply_port, reply_rx) = client.open_once_port::<NodePayload>();
-        PortRef::<IntrospectMessage>::attest_message_port(handle.actor_id())
+        reference::PortRef::<IntrospectMessage>::attest_message_port(handle.actor_id())
             .send(
                 &client,
                 IntrospectMessage::Query {
@@ -1718,9 +1714,10 @@ mod tests {
         let actor = EchoActor(tx.bind());
         let handle = proc.spawn::<EchoActor>("echo_qc", actor).unwrap();
 
-        let child_ref = Reference::Actor(test_proc_id("nonexistent").actor_id("child", 0));
+        let child_ref =
+            reference::Reference::Actor(test_proc_id("nonexistent").actor_id("child", 0));
         let (reply_port, reply_rx) = client.open_once_port::<NodePayload>();
-        PortRef::<IntrospectMessage>::attest_message_port(handle.actor_id())
+        reference::PortRef::<IntrospectMessage>::attest_message_port(handle.actor_id())
             .send(
                 &client,
                 IntrospectMessage::QueryChild {
@@ -1770,7 +1767,7 @@ mod tests {
             .unwrap();
 
         let (reply_port, reply_rx) = client.open_once_port::<NodePayload>();
-        PortRef::<IntrospectMessage>::attest_message_port(handle.actor_id())
+        reference::PortRef::<IntrospectMessage>::attest_message_port(handle.actor_id())
             .send(
                 &client,
                 IntrospectMessage::Query {
@@ -1815,7 +1812,7 @@ mod tests {
 
         // Query the child — supervisor should be the parent.
         let (reply_port, reply_rx) = client.open_once_port::<NodePayload>();
-        PortRef::<IntrospectMessage>::attest_message_port(child_handle.actor_id())
+        reference::PortRef::<IntrospectMessage>::attest_message_port(child_handle.actor_id())
             .send(
                 &client,
                 IntrospectMessage::Query {
@@ -1838,7 +1835,7 @@ mod tests {
 
         // Query the parent — children should include the child.
         let (reply_port, reply_rx) = client.open_once_port::<NodePayload>();
-        PortRef::<IntrospectMessage>::attest_message_port(parent_handle.actor_id())
+        reference::PortRef::<IntrospectMessage>::attest_message_port(parent_handle.actor_id())
             .send(
                 &client,
                 IntrospectMessage::Query {
@@ -1882,7 +1879,7 @@ mod tests {
             .unwrap();
 
         let (reply_port, reply_rx) = client.open_once_port::<NodePayload>();
-        PortRef::<IntrospectMessage>::attest_message_port(handle.actor_id())
+        reference::PortRef::<IntrospectMessage>::attest_message_port(handle.actor_id())
             .send(
                 &client,
                 IntrospectMessage::Query {
@@ -1926,7 +1923,7 @@ mod tests {
         let _ = rx.recv().await.unwrap();
 
         let (reply_port, reply_rx) = client.open_once_port::<NodePayload>();
-        PortRef::<IntrospectMessage>::attest_message_port(handle.actor_id())
+        reference::PortRef::<IntrospectMessage>::attest_message_port(handle.actor_id())
             .send(
                 &client,
                 IntrospectMessage::Query {
@@ -1980,7 +1977,7 @@ mod tests {
 
         // First introspect query.
         let (reply_port, reply_rx) = client.open_once_port::<NodePayload>();
-        PortRef::<IntrospectMessage>::attest_message_port(handle.actor_id())
+        reference::PortRef::<IntrospectMessage>::attest_message_port(handle.actor_id())
             .send(
                 &client,
                 IntrospectMessage::Query {
@@ -1993,7 +1990,7 @@ mod tests {
 
         // Second introspect query.
         let (reply_port2, reply_rx2) = client.open_once_port::<NodePayload>();
-        PortRef::<IntrospectMessage>::attest_message_port(handle.actor_id())
+        reference::PortRef::<IntrospectMessage>::attest_message_port(handle.actor_id())
             .send(
                 &client,
                 IntrospectMessage::Query {
@@ -2107,7 +2104,7 @@ mod tests {
         let handle = proc.spawn::<EchoActor>("echo_qch", actor).unwrap();
 
         // Before registering, query_child returns None.
-        let test_ref = Reference::Actor(test_proc_id("test").actor_id("child", 0));
+        let test_ref = reference::Reference::Actor(test_proc_id("test").actor_id("child", 0));
         assert!(handle.cell().query_child(&test_ref).is_none());
 
         // Register a callback.
@@ -2198,7 +2195,7 @@ mod tests {
 
         // Send introspect query via the dedicated introspect port.
         let (reply_port, reply_rx) = client.open_once_port::<NodePayload>();
-        PortRef::<IntrospectMessage>::attest_message_port(handle.actor_id())
+        reference::PortRef::<IntrospectMessage>::attest_message_port(handle.actor_id())
             .send(
                 &client,
                 IntrospectMessage::Query {
@@ -2262,7 +2259,7 @@ mod tests {
 
         // First introspect query.
         let (reply_port1, reply_rx1) = client.open_once_port::<NodePayload>();
-        PortRef::<IntrospectMessage>::attest_message_port(handle.actor_id())
+        reference::PortRef::<IntrospectMessage>::attest_message_port(handle.actor_id())
             .send(
                 &client,
                 IntrospectMessage::Query {
@@ -2275,7 +2272,7 @@ mod tests {
 
         // Second introspect query.
         let (reply_port2, reply_rx2) = client.open_once_port::<NodePayload>();
-        PortRef::<IntrospectMessage>::attest_message_port(handle.actor_id())
+        reference::PortRef::<IntrospectMessage>::attest_message_port(handle.actor_id())
             .send(
                 &client,
                 IntrospectMessage::Query {
@@ -2334,7 +2331,7 @@ mod tests {
         let actor_id = handle.actor_id().clone();
 
         let (reply_port, reply_rx) = bridge.open_once_port::<NodePayload>();
-        PortRef::<IntrospectMessage>::attest_message_port(&actor_id)
+        reference::PortRef::<IntrospectMessage>::attest_message_port(&actor_id)
             .send(
                 &bridge,
                 IntrospectMessage::Query {
@@ -2377,7 +2374,7 @@ mod tests {
         let mailbox_id = mailbox_handle.actor_id().clone();
 
         let (reply_port, reply_rx) = client.open_once_port::<NodePayload>();
-        PortRef::<IntrospectMessage>::attest_message_port(&mailbox_id)
+        reference::PortRef::<IntrospectMessage>::attest_message_port(&mailbox_id)
             .send(
                 &client,
                 IntrospectMessage::Query {

--- a/hyperactor/src/actor/remote.rs
+++ b/hyperactor/src/actor/remote.rs
@@ -19,7 +19,7 @@ use hyperactor_config::Flattrs;
 use crate::Actor;
 use crate::Data;
 use crate::proc::Proc;
-use crate::reference::ActorId;
+use crate::reference;
 
 /// The offset of user-defined ports (i.e., arbitrarily bound).
 pub const USER_PORT_OFFSET: u64 = 1024;
@@ -69,7 +69,9 @@ pub struct SpawnableActor {
         &str,
         Data,
         Flattrs,
-    ) -> Pin<Box<dyn Future<Output = Result<ActorId, anyhow::Error>> + Send>>,
+    ) -> Pin<
+        Box<dyn Future<Output = Result<reference::ActorId, anyhow::Error>> + Send>,
+    >,
 
     /// A function to retrieve the type id of the actor itself. This is
     /// used to translate a concrete type to a global name.
@@ -126,7 +128,7 @@ impl Remote {
         actor_name: &str,
         params: Data,
         environment: Flattrs,
-    ) -> Result<ActorId, anyhow::Error> {
+    ) -> Result<reference::ActorId, anyhow::Error> {
         let entry = self
             .by_name
             .get(actor_type)

--- a/hyperactor/src/channel/sim.rs
+++ b/hyperactor/src/channel/sim.rs
@@ -420,10 +420,10 @@ mod tests {
     use ndslice::extent;
 
     use super::*;
-    use crate::PortId;
     use crate::clock::Clock;
     use crate::clock::RealClock;
     use crate::clock::SimClock;
+    use crate::reference;
     use crate::simnet;
     use crate::simnet::BetaDistribution;
     use crate::simnet::LatencyConfig;
@@ -470,8 +470,12 @@ mod tests {
                 ext.point(vec![0, 0, 0, 1, 0]).unwrap(),
             );
 
-            let msg =
-                MessageEnvelope::new(sender, PortId::new(dest, 0), data.clone(), Flattrs::new());
+            let msg = MessageEnvelope::new(
+                sender,
+                reference::PortId::new(dest, 0),
+                data.clone(),
+                Flattrs::new(),
+            );
             tx.post(msg);
             assert_eq!(*rx.recv().await.unwrap().data(), data);
         }
@@ -553,7 +557,7 @@ mod tests {
         // This message will be delievered at simulator time = 100 seconds
         tx.post(MessageEnvelope::new(
             controller,
-            PortId::new(dest, 0),
+            reference::PortId::new(dest, 0),
             wirevalue::Any::serialize(&456).unwrap(),
             Flattrs::new(),
         ));
@@ -634,14 +638,14 @@ mod tests {
             // Send client message
             client_tx.post(MessageEnvelope::new(
                 client.clone(),
-                PortId::new(dest.clone(), 0),
+                reference::PortId::new(dest.clone(), 0),
                 wirevalue::Any::serialize(&456).unwrap(),
                 Flattrs::new(),
             ));
             // Send system message
             controller_tx.post(MessageEnvelope::new(
                 controller.clone(),
-                PortId::new(dest.clone(), 0),
+                reference::PortId::new(dest.clone(), 0),
                 wirevalue::Any::serialize(&456).unwrap(),
                 Flattrs::new(),
             ));

--- a/hyperactor/src/context.rs
+++ b/hyperactor/src/context.rs
@@ -25,9 +25,7 @@ use backoff::backoff::Backoff;
 use dashmap::DashSet;
 use hyperactor_config::Flattrs;
 
-use crate::ActorId;
 use crate::Instance;
-use crate::PortId;
 use crate::accum;
 use crate::accum::ErasedCommReducer;
 use crate::accum::ReducerMode;
@@ -37,6 +35,7 @@ use crate::mailbox;
 use crate::mailbox::MailboxSender;
 use crate::mailbox::MessageEnvelope;
 use crate::ordering::SEQ_INFO;
+use crate::reference;
 use crate::time::Alarm;
 
 /// Policy for handling SEQ_INFO in message headers.
@@ -74,7 +73,7 @@ pub(crate) trait MailboxExt: Mailbox {
     /// All messages posted from actors should use this implementation.
     fn post(
         &self,
-        dest: PortId,
+        dest: reference::PortId,
         headers: Flattrs,
         data: wirevalue::Any,
         return_undeliverable: bool,
@@ -84,24 +83,24 @@ pub(crate) trait MailboxExt: Mailbox {
     /// Split a port, using a provided reducer spec, if provided.
     fn split(
         &self,
-        port_id: PortId,
+        port_id: reference::PortId,
         reducer_spec: Option<ReducerSpec>,
         reducer_mode: ReducerMode,
         return_undeliverable: bool,
-    ) -> anyhow::Result<PortId>;
+    ) -> anyhow::Result<reference::PortId>;
 }
 
 // Tracks mailboxes that have emitted a `CanSend::post` warning due to
 // missing an `Undeliverable<MessageEnvelope>` binding. In this
 // context, mailboxes are few and long-lived; unbounded growth is not
 // a realistic concern.
-static CAN_SEND_WARNED_MAILBOXES: OnceLock<DashSet<ActorId>> = OnceLock::new();
+static CAN_SEND_WARNED_MAILBOXES: OnceLock<DashSet<reference::ActorId>> = OnceLock::new();
 
 /// Only actors CanSend because they need a return port.
 impl<T: Actor + Send + Sync> MailboxExt for T {
     fn post(
         &self,
-        dest: PortId,
+        dest: reference::PortId,
         mut headers: Flattrs,
         data: wirevalue::Any,
         return_undeliverable: bool,
@@ -144,14 +143,14 @@ impl<T: Actor + Send + Sync> MailboxExt for T {
 
     fn split(
         &self,
-        port_id: PortId,
+        port_id: reference::PortId,
         reducer_spec: Option<ReducerSpec>,
         reducer_mode: ReducerMode,
         return_undeliverable: bool,
-    ) -> anyhow::Result<PortId> {
+    ) -> anyhow::Result<reference::PortId> {
         fn post(
             mailbox: &mailbox::Mailbox,
-            port_id: PortId,
+            port_id: reference::PortId,
             msg: wirevalue::Any,
             return_undeliverable: bool,
         ) {

--- a/hyperactor/src/host.rs
+++ b/hyperactor/src/host.rs
@@ -59,11 +59,8 @@ use tokio::sync::Mutex;
 use crate as hyperactor;
 use crate::Actor;
 use crate::ActorHandle;
-use crate::ActorId;
-use crate::ActorRef;
 use crate::PortHandle;
 use crate::Proc;
-use crate::ProcId;
 use crate::actor::Binds;
 use crate::actor::Referable;
 use crate::channel;
@@ -86,6 +83,7 @@ use crate::mailbox::MailboxServer;
 use crate::mailbox::MailboxServerHandle;
 use crate::mailbox::MessageEnvelope;
 use crate::mailbox::Undeliverable;
+use crate::reference;
 
 /// Name of the system service proc on a host — hosts the admin actor
 /// layer (HostMeshAgent, MeshAdminAgent, bridge).
@@ -123,15 +121,15 @@ pub enum HostError {
 
     /// Failures occuring while spawning a subprocess.
     #[error("proc '{0}' failed to spawn process: {1}")]
-    ProcessSpawnFailure(ProcId, #[source] std::io::Error),
+    ProcessSpawnFailure(reference::ProcId, #[source] std::io::Error),
 
     /// Failures occuring while configuring a subprocess.
     #[error("proc '{0}' failed to configure process: {1}")]
-    ProcessConfigurationFailure(ProcId, #[source] anyhow::Error),
+    ProcessConfigurationFailure(reference::ProcId, #[source] anyhow::Error),
 
     /// Failures occuring while spawning a management actor in a proc.
     #[error("failed to spawn agent on proc '{0}': {1}")]
-    AgentSpawnFailure(ProcId, #[source] anyhow::Error),
+    AgentSpawnFailure(reference::ProcId, #[source] anyhow::Error),
 
     /// An input parameter was missing.
     #[error("parameter '{0}' missing: {1}")]
@@ -189,10 +187,11 @@ impl<M: ProcManager> Host<M> {
         // These use with_name (not unique) because their uniqueness is
         // guaranteed by the ChannelAddr component, and the Name type's
         // '-' delimiter must not collide with a hash suffix.
-        let service_proc_id = ProcId::with_name(frontend_addr.clone(), SERVICE_PROC_NAME);
+        let service_proc_id =
+            reference::ProcId::with_name(frontend_addr.clone(), SERVICE_PROC_NAME);
         let service_proc = Proc::configured(service_proc_id.clone(), router.boxed());
 
-        let local_proc_id = ProcId::with_name(frontend_addr.clone(), LOCAL_PROC_NAME);
+        let local_proc_id = reference::ProcId::with_name(frontend_addr.clone(), LOCAL_PROC_NAME);
         let local_proc = Proc::configured(local_proc_id.clone(), router.boxed());
 
         tracing::info!(
@@ -258,12 +257,12 @@ impl<M: ProcManager> Host<M> {
         &mut self,
         name: String,
         config: M::Config,
-    ) -> Result<(ProcId, ActorRef<ManagerAgent<M>>), HostError> {
+    ) -> Result<(reference::ProcId, reference::ActorRef<ManagerAgent<M>>), HostError> {
         if self.procs.contains(&name) {
             return Err(HostError::ProcExists(name));
         }
 
-        let proc_id = ProcId::with_name(self.frontend_addr.clone(), &name);
+        let proc_id = reference::ProcId::with_name(self.frontend_addr.clone(), &name);
         let handle = self
             .manager
             .spawn(proc_id.clone(), self.backend_addr.clone(), config)
@@ -474,10 +473,10 @@ pub trait SingleTerminate: Send + Sync {
     async fn terminate_proc(
         &self,
         cx: &impl context::Actor,
-        proc: &ProcId,
+        proc: &reference::ProcId,
         timeout: std::time::Duration,
         reason: &str,
-    ) -> Result<(Vec<ActorId>, Vec<ActorId>), anyhow::Error>;
+    ) -> Result<(Vec<reference::ActorId>, Vec<reference::ActorId>), anyhow::Error>;
 }
 
 /// Trait for managers that can terminate many child **units** in
@@ -556,10 +555,10 @@ impl<M: ProcManager + SingleTerminate> SingleTerminate for Host<M> {
     async fn terminate_proc(
         &self,
         cx: &impl context::Actor,
-        proc: &ProcId,
+        proc: &reference::ProcId,
         timeout: Duration,
         reason: &str,
-    ) -> Result<(Vec<ActorId>, Vec<ActorId>), anyhow::Error> {
+    ) -> Result<(Vec<reference::ActorId>, Vec<reference::ActorId>), anyhow::Error> {
         self.manager.terminate_proc(cx, proc, timeout, reason).await
     }
 }
@@ -574,7 +573,7 @@ impl<M: ProcManager + SingleTerminate> SingleTerminate for Host<M> {
 pub struct ReadyProc<'a, H: ProcHandle> {
     handle: &'a H,
     addr: ChannelAddr,
-    agent_ref: ActorRef<H::Agent>,
+    agent_ref: reference::ActorRef<H::Agent>,
 }
 
 impl<'a, H: ProcHandle> ReadyProc<'a, H> {
@@ -599,7 +598,7 @@ impl<'a, H: ProcHandle> ReadyProc<'a, H> {
     }
 
     /// The proc's logical identity.
-    pub fn proc_id(&self) -> &ProcId {
+    pub fn proc_id(&self) -> &reference::ProcId {
         self.handle.proc_id()
     }
 
@@ -609,7 +608,7 @@ impl<'a, H: ProcHandle> ReadyProc<'a, H> {
     }
 
     /// The agent actor reference (guaranteed available after ready).
-    pub fn agent_ref(&self) -> &ActorRef<H::Agent> {
+    pub fn agent_ref(&self) -> &reference::ActorRef<H::Agent> {
         &self.agent_ref
     }
 }
@@ -666,7 +665,7 @@ pub trait ProcHandle: Clone + Send + Sync + 'static {
     type TerminalStatus: std::fmt::Debug + Clone + Send + Sync + 'static;
 
     /// The proc's logical identity on this host.
-    fn proc_id(&self) -> &ProcId;
+    fn proc_id(&self) -> &reference::ProcId;
 
     /// The proc's address (the one callers bind into the host
     /// router). May return `None` before `ready()` completes.
@@ -682,7 +681,7 @@ pub trait ProcHandle: Clone + Send + Sync + 'static {
     ///
     /// **Prefer [`ready_proc()`]** for type-safe access that
     /// guarantees availability at compile time.
-    fn agent_ref(&self) -> Option<ActorRef<Self::Agent>>;
+    fn agent_ref(&self) -> Option<reference::ActorRef<Self::Agent>>;
 
     /// Resolves when the proc becomes Ready. Multi-waiter,
     /// non-consuming.
@@ -747,7 +746,7 @@ pub trait ProcManager {
     /// ref is returned.
     async fn spawn(
         &self,
-        proc_id: ProcId,
+        proc_id: reference::ProcId,
         forwarder_addr: ChannelAddr,
         config: Self::Config,
     ) -> Result<Self::Handle, HostError>;
@@ -792,8 +791,8 @@ pub enum LocalProcStatus {
 ///
 ///   No OS signals are sent or required.
 pub struct LocalProcManager<S> {
-    procs: Arc<Mutex<HashMap<ProcId, Proc>>>,
-    stopping: Arc<Mutex<HashMap<ProcId, LocalProcStatus>>>,
+    procs: Arc<Mutex<HashMap<reference::ProcId, Proc>>>,
+    stopping: Arc<Mutex<HashMap<reference::ProcId, LocalProcStatus>>>,
     spawn: S,
 }
 
@@ -814,7 +813,7 @@ impl<S> LocalProcManager<S> {
     /// Status transitions through `Stopping` -> `Stopped` and is
     /// observable via [`local_proc_status`]. Idempotent: no-ops if
     /// the proc is already stopping or stopped.
-    pub async fn request_stop(&self, proc: &ProcId, timeout: Duration, reason: &str) {
+    pub async fn request_stop(&self, proc: &reference::ProcId, timeout: Duration, reason: &str) {
         {
             let guard = self.stopping.lock().await;
             if guard.contains_key(proc) {
@@ -856,7 +855,7 @@ impl<S> LocalProcManager<S> {
     /// [`request_stop`].
     ///
     /// Returns `None` if the proc was never stopped through this path.
-    pub async fn local_proc_status(&self, proc: &ProcId) -> Option<LocalProcStatus> {
+    pub async fn local_proc_status(&self, proc: &reference::ProcId) -> Option<LocalProcStatus> {
         self.stopping.lock().await.get(proc).copied()
     }
 }
@@ -913,10 +912,10 @@ where
     async fn terminate_proc(
         &self,
         _cx: &impl context::Actor,
-        proc: &ProcId,
+        proc: &reference::ProcId,
         timeout: std::time::Duration,
         reason: &str,
-    ) -> Result<(Vec<ActorId>, Vec<ActorId>), anyhow::Error> {
+    ) -> Result<(Vec<reference::ActorId>, Vec<reference::ActorId>), anyhow::Error> {
         // Snapshot procs so we don't hold the lock across awaits.
         let procs: Option<Proc> = {
             let mut guard = self.procs.lock().await;
@@ -948,10 +947,10 @@ where
 /// **Type parameter:** `A` is constrained by the `ProcHandle::Agent`
 /// bound (`Actor + Referable`).
 pub struct LocalHandle<A: Actor + Referable> {
-    proc_id: ProcId,
+    proc_id: reference::ProcId,
     addr: ChannelAddr,
-    agent_ref: ActorRef<A>,
-    procs: Arc<Mutex<HashMap<ProcId, Proc>>>,
+    agent_ref: reference::ActorRef<A>,
+    procs: Arc<Mutex<HashMap<reference::ProcId, Proc>>>,
 }
 
 // Manual `Clone` to avoid requiring `A: Clone`.
@@ -973,7 +972,7 @@ impl<A: Actor + Referable> ProcHandle for LocalHandle<A> {
     type Agent = A;
     type TerminalStatus = ();
 
-    fn proc_id(&self) -> &ProcId {
+    fn proc_id(&self) -> &reference::ProcId {
         &self.proc_id
     }
 
@@ -981,7 +980,7 @@ impl<A: Actor + Referable> ProcHandle for LocalHandle<A> {
         Some(self.addr.clone())
     }
 
-    fn agent_ref(&self) -> Option<ActorRef<Self::Agent>> {
+    fn agent_ref(&self) -> Option<reference::ActorRef<Self::Agent>> {
         Some(self.agent_ref.clone())
     }
 
@@ -1075,7 +1074,7 @@ where
     #[crate::instrument(fields(proc_id=proc_id.to_string(), addr=forwarder_addr.to_string()))]
     async fn spawn(
         &self,
-        proc_id: ProcId,
+        proc_id: reference::ProcId,
         forwarder_addr: ChannelAddr,
         _config: (),
     ) -> Result<Self::Handle, HostError> {
@@ -1128,7 +1127,7 @@ where
 /// protocol.
 pub struct ProcessProcManager<A> {
     program: std::path::PathBuf,
-    children: Arc<Mutex<HashMap<ProcId, Child>>>,
+    children: Arc<Mutex<HashMap<reference::ProcId, Child>>>,
     _phantom: PhantomData<A>,
 }
 
@@ -1179,9 +1178,9 @@ impl<A> Drop for ProcessProcManager<A> {
 /// typed remote reference).
 #[derive(Debug)]
 pub struct ProcessHandle<A: Actor + Referable> {
-    proc_id: ProcId,
+    proc_id: reference::ProcId,
     addr: ChannelAddr,
-    agent_ref: ActorRef<A>,
+    agent_ref: reference::ActorRef<A>,
 }
 
 // Manual `Clone` to avoid requiring `A: Clone`.
@@ -1202,7 +1201,7 @@ impl<A: Actor + Referable> ProcHandle for ProcessHandle<A> {
     type Agent = A;
     type TerminalStatus = ();
 
-    fn proc_id(&self) -> &ProcId {
+    fn proc_id(&self) -> &reference::ProcId {
         &self.proc_id
     }
 
@@ -1210,7 +1209,7 @@ impl<A: Actor + Referable> ProcHandle for ProcessHandle<A> {
         Some(self.addr.clone())
     }
 
-    fn agent_ref(&self) -> Option<ActorRef<Self::Agent>> {
+    fn agent_ref(&self) -> Option<reference::ActorRef<Self::Agent>> {
         Some(self.agent_ref.clone())
     }
 
@@ -1256,7 +1255,7 @@ where
     #[crate::instrument(fields(proc_id=proc_id.to_string(), addr=forwarder_addr.to_string()))]
     async fn spawn(
         &self,
-        proc_id: ProcId,
+        proc_id: reference::ProcId,
         forwarder_addr: ChannelAddr,
         _config: (),
     ) -> Result<Self::Handle, HostError> {
@@ -1325,7 +1324,7 @@ where
         S: FnOnce(Proc) -> F,
         F: Future<Output = Result<ActorHandle<A>, anyhow::Error>>,
     {
-        let proc_id: ProcId = Self::parse_env("HYPERACTOR_HOST_PROC_ID")?;
+        let proc_id: reference::ProcId = Self::parse_env("HYPERACTOR_HOST_PROC_ID")?;
         let backend_addr: ChannelAddr = Self::parse_env("HYPERACTOR_HOST_BACKEND_ADDR")?;
         let callback_addr: ChannelAddr = Self::parse_env("HYPERACTOR_HOST_CALLBACK_ADDR")?;
         spawn_proc(proc_id, backend_addr, callback_addr, spawn).await
@@ -1349,7 +1348,7 @@ where
 /// the provided `callback_addr`.
 #[crate::instrument(fields(proc_id=proc_id.to_string(), addr=backend_addr.to_string(), callback_addr=callback_addr.to_string()))]
 pub async fn spawn_proc<A, S, F>(
-    proc_id: ProcId,
+    proc_id: reference::ProcId,
     backend_addr: ChannelAddr,
     callback_addr: ChannelAddr,
     spawn: S,
@@ -1390,25 +1389,24 @@ pub mod testing {
 
     use crate as hyperactor;
     use crate::Actor;
-    use crate::ActorId;
     use crate::Context;
     use crate::Handler;
-    use crate::OncePortRef;
+    use crate::reference;
 
     /// Just a simple actor, available in both the bootstrap binary as well as
     /// hyperactor tests.
     #[derive(Debug, Default)]
-    #[hyperactor::export(handlers = [OncePortRef<ActorId>])]
+    #[hyperactor::export(handlers = [reference::OncePortRef<reference::ActorId>])]
     pub struct EchoActor;
 
     impl Actor for EchoActor {}
 
     #[async_trait]
-    impl Handler<OncePortRef<ActorId>> for EchoActor {
+    impl Handler<reference::OncePortRef<reference::ActorId>> for EchoActor {
         async fn handle(
             &mut self,
             cx: &Context<Self>,
-            reply: OncePortRef<ActorId>,
+            reply: reference::OncePortRef<reference::ActorId>,
         ) -> Result<(), anyhow::Error> {
             reply.send(cx, cx.self_id().clone())?;
             Ok(())
@@ -1438,7 +1436,10 @@ mod tests {
             .unwrap();
 
         let (proc_id1, _ref) = host.spawn("proc1".to_string(), ()).await.unwrap();
-        assert_eq!(proc_id1, ProcId::with_name(host.addr().clone(), "proc1"));
+        assert_eq!(
+            proc_id1,
+            reference::ProcId::with_name(host.addr().clone(), "proc1")
+        );
         assert!(procs.lock().await.contains_key(&proc_id1));
 
         let (proc_id2, _ref) = host.spawn("proc2".to_string(), ()).await.unwrap();
@@ -1579,8 +1580,8 @@ mod tests {
     async fn local_ready_and_wait_are_immediate() {
         // Build a LocalHandle directly.
         let addr = ChannelAddr::any(ChannelTransport::Local);
-        let proc_id = ProcId::with_name(addr.clone(), "p");
-        let agent_ref = ActorRef::<()>::attest(proc_id.actor_id("host_agent", 0));
+        let proc_id = reference::ProcId::with_name(addr.clone(), "p");
+        let agent_ref = reference::ActorRef::<()>::attest(proc_id.actor_id("host_agent", 0));
         let h = LocalHandle::<()> {
             proc_id,
             addr,
@@ -1611,9 +1612,9 @@ mod tests {
 
     #[derive(Debug, Clone)]
     struct TestHandle {
-        id: ProcId,
+        id: reference::ProcId,
         addr: ChannelAddr,
-        agent: ActorRef<()>,
+        agent: reference::ActorRef<()>,
         mode: ReadyMode,
         omit_addr: bool,
         omit_agent: bool,
@@ -1624,7 +1625,7 @@ mod tests {
         type Agent = ();
         type TerminalStatus = ();
 
-        fn proc_id(&self) -> &ProcId {
+        fn proc_id(&self) -> &reference::ProcId {
             &self.id
         }
 
@@ -1636,7 +1637,7 @@ mod tests {
             }
         }
 
-        fn agent_ref(&self) -> Option<ActorRef<Self::Agent>> {
+        fn agent_ref(&self) -> Option<reference::ActorRef<Self::Agent>> {
             if self.omit_agent {
                 None
             } else {
@@ -1706,11 +1707,11 @@ mod tests {
 
         async fn spawn(
             &self,
-            proc_id: ProcId,
+            proc_id: reference::ProcId,
             forwarder_addr: ChannelAddr,
             _config: (),
         ) -> Result<Self::Handle, HostError> {
-            let agent = ActorRef::<()>::attest(proc_id.actor_id("host_agent", 0));
+            let agent = reference::ActorRef::<()>::attest(proc_id.actor_id("host_agent", 0));
             Ok(TestHandle {
                 id: proc_id,
                 addr: forwarder_addr,

--- a/hyperactor/src/introspect.rs
+++ b/hyperactor/src/introspect.rs
@@ -68,9 +68,8 @@ use serde::Serialize;
 use typeuri::Named;
 
 use crate::InstanceCell;
-use crate::OncePortRef;
 use crate::clock::Clock;
-use crate::reference::Reference;
+use crate::reference;
 
 /// Structured failure information extracted from an
 /// [`ActorSupervisionEvent`](crate::supervision::ActorSupervisionEvent)
@@ -270,14 +269,14 @@ pub enum IntrospectMessage {
         /// View context - Entity or Actor.
         view: IntrospectView,
         /// Reply port receiving the actor's self-description.
-        reply: OncePortRef<NodePayload>,
+        reply: reference::OncePortRef<NodePayload>,
     },
     /// "Describe one of your children."
     QueryChild {
         /// Reference identifying the child to describe.
-        child_ref: Reference,
+        child_ref: reference::Reference,
         /// Reply port receiving the child's description.
-        reply: OncePortRef<NodePayload>,
+        reply: reference::OncePortRef<NodePayload>,
     },
 }
 wirevalue::register_type!(IntrospectMessage);

--- a/hyperactor/src/lib.rs
+++ b/hyperactor/src/lib.rs
@@ -112,7 +112,6 @@ pub use actor::ActorHandle;
 pub use actor::Handler;
 pub use actor::HandlerInfo;
 pub use actor::RemoteHandles;
-pub use remote::Accepts;
 pub use actor::RemoteSpawn;
 pub use actor_local::ActorLocal;
 #[doc(inline)]
@@ -164,12 +163,10 @@ pub use proc::Instance;
 pub use proc::InstanceCell;
 pub use proc::Proc;
 pub use proc::WeakProc;
-pub use reference::ActorId;
+// Re-exported because `hyperactor_macros::RefClient` generates code referencing `hyperactor::ActorRef`.
+#[doc(hidden)]
 pub use reference::ActorRef;
-pub use reference::OncePortRef;
-pub use reference::PortId;
-pub use reference::PortRef;
-pub use reference::ProcId;
+pub use remote::Accepts;
 #[doc(inline)]
 pub use signal_handler::SignalCleanupGuard;
 #[doc(inline)]

--- a/hyperactor/src/mailbox.rs
+++ b/hyperactor/src/mailbox.rs
@@ -104,10 +104,7 @@ use tokio_util::sync::CancellationToken;
 use typeuri::Named;
 
 // for macros
-use crate::OncePortRef;
-use crate::PortRef;
 use crate::Proc;
-use crate::ProcId;
 use crate::accum::Accumulator;
 use crate::accum::ReducerSpec;
 use crate::accum::StreamingReducerOpts;
@@ -124,9 +121,7 @@ use crate::context;
 use crate::metrics;
 use crate::ordering::SEQ_INFO;
 use crate::ordering::SeqInfo;
-use crate::reference::ActorId;
-use crate::reference::PortId;
-use crate::reference::Reference;
+use crate::reference;
 
 mod undeliverable;
 /// For [`Undeliverable`], a message type for delivery failures.
@@ -200,10 +195,10 @@ pub enum DeliveryError {
 #[derive(Debug, Serialize, Deserialize, Clone, typeuri::Named)]
 pub struct MessageEnvelope {
     /// The sender of this message.
-    sender: ActorId,
+    sender: reference::ActorId,
 
     /// The destination of the message.
-    dest: PortId,
+    dest: reference::PortId,
 
     /// The serialized message.
     data: wirevalue::Any,
@@ -226,7 +221,12 @@ wirevalue::register_type!(MessageEnvelope);
 
 impl MessageEnvelope {
     /// Create a new envelope with the provided sender, destination, and message.
-    pub fn new(sender: ActorId, dest: PortId, data: wirevalue::Any, headers: Flattrs) -> Self {
+    pub fn new(
+        sender: reference::ActorId,
+        dest: reference::PortId,
+        data: wirevalue::Any,
+        headers: Flattrs,
+    ) -> Self {
         Self {
             sender,
             dest,
@@ -240,7 +240,7 @@ impl MessageEnvelope {
     }
 
     /// Create a new envelope whose sender ID is unknown.
-    pub(crate) fn new_unknown(dest: PortId, data: wirevalue::Any) -> Self {
+    pub(crate) fn new_unknown(dest: reference::PortId, data: wirevalue::Any) -> Self {
         // Create a synthetic "unknown" actor ID for messages with no known sender
         let unknown_addr = ChannelAddr::any(ChannelTransport::Local);
         let unknown_proc_id = crate::reference::ProcId::unique(unknown_addr, "unknown");
@@ -251,8 +251,8 @@ impl MessageEnvelope {
 
     /// Construct a new serialized value by serializing the provided T-typed value.
     pub fn serialize<T: Serialize + Named>(
-        source: ActorId,
-        dest: PortId,
+        source: reference::ActorId,
+        dest: reference::PortId,
         value: &T,
         headers: Flattrs,
     ) -> Result<Self, wirevalue::Error> {
@@ -318,12 +318,12 @@ impl MessageEnvelope {
     }
 
     /// The message sender.
-    pub fn sender(&self) -> &ActorId {
+    pub fn sender(&self) -> &reference::ActorId {
         &self.sender
     }
 
     /// The destination of the message.
-    pub fn dest(&self) -> &PortId {
+    pub fn dest(&self) -> &reference::PortId {
         &self.dest
     }
 
@@ -346,7 +346,7 @@ impl MessageEnvelope {
     /// Change the sender on the envelope in case it was set incorrectly. This
     /// should only be used by CommActor since it is forwarding from another
     /// sender.
-    pub fn update_sender(&mut self, sender: ActorId) {
+    pub fn update_sender(&mut self, sender: reference::ActorId) {
         self.sender = sender;
     }
 
@@ -484,8 +484,8 @@ impl fmt::Display for MessageEnvelope {
 /// Metadata about a message sent via a MessageEnvelope.
 #[derive(Clone)]
 pub struct MessageMetadata {
-    sender: ActorId,
-    dest: PortId,
+    sender: reference::ActorId,
+    dest: reference::PortId,
     errors: Vec<DeliveryError>,
     headers: Flattrs,
     ttl: u8,
@@ -496,7 +496,7 @@ pub struct MessageMetadata {
 /// with the mailbox's actor id.
 #[derive(Debug)]
 pub struct MailboxError {
-    actor_id: ActorId,
+    actor_id: reference::ActorId,
     kind: MailboxErrorKind,
 }
 
@@ -511,28 +511,28 @@ pub enum MailboxErrorKind {
 
     /// The port associated with an operation was invalid.
     #[error("invalid port: {0}")]
-    InvalidPort(PortId),
+    InvalidPort(reference::PortId),
 
     /// There was no sender associated with the port.
     #[error("no sender for port: {0}")]
-    NoSenderForPort(PortId),
+    NoSenderForPort(reference::PortId),
 
     /// There was no local sender associated with the port.
     /// Returned by operations that require a local port.
     #[error("no local sender for port: {0}")]
-    NoLocalSenderForPort(PortId),
+    NoLocalSenderForPort(reference::PortId),
 
     /// The port was closed.
     #[error("{0}: port closed")]
-    PortClosed(PortId),
+    PortClosed(reference::PortId),
 
     /// An error occured during a send operation.
     #[error("send {0}: {1}")]
-    Send(PortId, #[source] anyhow::Error),
+    Send(reference::PortId, #[source] anyhow::Error),
 
     /// An error occured during a receive operation.
     #[error("recv {0}: {1}")]
-    Recv(PortId, #[source] anyhow::Error),
+    Recv(reference::PortId, #[source] anyhow::Error),
 
     /// There was a serialization failure.
     #[error("serialize: {0}")]
@@ -554,12 +554,12 @@ pub enum MailboxErrorKind {
 impl MailboxError {
     /// Create a new mailbox error associated with the provided actor
     /// id and of the given kind.
-    pub fn new(actor_id: ActorId, kind: MailboxErrorKind) -> Self {
+    pub fn new(actor_id: reference::ActorId, kind: MailboxErrorKind) -> Self {
         Self { actor_id, kind }
     }
 
     /// The ID of the mailbox producing this error.
-    pub fn actor_id(&self) -> &ActorId {
+    pub fn actor_id(&self) -> &reference::ActorId {
         &self.actor_id
     }
 
@@ -588,23 +588,23 @@ impl std::error::Error for MailboxError {
 #[derive(Debug, Clone)]
 pub enum PortLocation {
     /// The port was bound: the location is its underlying bound ID.
-    Bound(PortId),
+    Bound(reference::PortId),
     /// The port was not bound: we provide the actor ID and the message type.
-    Unbound(ActorId, &'static str),
+    Unbound(reference::ActorId, &'static str),
 }
 
 impl PortLocation {
-    fn new_unbound<M: Message>(actor_id: ActorId) -> Self {
+    fn new_unbound<M: Message>(actor_id: reference::ActorId) -> Self {
         PortLocation::Unbound(actor_id, std::any::type_name::<M>())
     }
 
     #[allow(dead_code)]
-    fn new_unbound_type(actor_id: ActorId, ty: &'static str) -> Self {
+    fn new_unbound_type(actor_id: reference::ActorId, ty: &'static str) -> Self {
         PortLocation::Unbound(actor_id, ty)
     }
 
     /// The actor id of the location.
-    pub fn actor_id(&self) -> &ActorId {
+    pub fn actor_id(&self) -> &reference::ActorId {
         match self {
             PortLocation::Bound(port_id) => port_id.actor_id(),
             PortLocation::Unbound(actor_id, _) => actor_id,
@@ -672,7 +672,7 @@ pub enum MailboxSenderErrorKind {
 
 impl MailboxSenderError {
     /// Create a new mailbox sender error to an unbound port.
-    pub fn new_unbound<M>(actor_id: ActorId, kind: MailboxSenderErrorKind) -> Self {
+    pub fn new_unbound<M>(actor_id: reference::ActorId, kind: MailboxSenderErrorKind) -> Self {
         Self {
             location: Box::new(PortLocation::Unbound(actor_id, std::any::type_name::<M>())),
             kind: Box::new(kind),
@@ -681,7 +681,7 @@ impl MailboxSenderError {
 
     /// Create a new mailbox sender, manually providing the type.
     pub fn new_unbound_type(
-        actor_id: ActorId,
+        actor_id: reference::ActorId,
         kind: MailboxSenderErrorKind,
         ty: &'static str,
     ) -> Self {
@@ -692,7 +692,7 @@ impl MailboxSenderError {
     }
 
     /// Create a new mailbox sender error with the provided port ID and kind.
-    pub fn new_bound(port_id: PortId, kind: MailboxSenderErrorKind) -> Self {
+    pub fn new_bound(port_id: reference::PortId, kind: MailboxSenderErrorKind) -> Self {
         Self {
             location: Box::new(PortLocation::Bound(port_id)),
             kind: Box::new(kind),
@@ -754,7 +754,7 @@ pub trait PortSender: MailboxSender {
     /// Deliver a message to the provided port.
     fn serialize_and_send<M: RemoteMessage>(
         &self,
-        port: &PortRef<M>,
+        port: &reference::PortRef<M>,
         message: M,
         return_handle: PortHandle<Undeliverable<MessageEnvelope>>,
     ) -> Result<(), MailboxSenderError> {
@@ -776,7 +776,7 @@ pub trait PortSender: MailboxSender {
     /// which is not reusable.
     fn serialize_and_send_once<M: RemoteMessage>(
         &self,
-        once_port: OncePortRef<M>,
+        once_port: reference::OncePortRef<M>,
         message: M,
         return_handle: PortHandle<Undeliverable<MessageEnvelope>>,
     ) -> Result<(), MailboxSenderError> {
@@ -1020,7 +1020,7 @@ pub trait MailboxServer: MailboxSender + Clone + Sized + 'static {
             static NEXT_RANK: AtomicUsize = AtomicUsize::new(0);
             let rank = NEXT_RANK.fetch_add(1, Ordering::Relaxed);
             let addr = ChannelAddr::any(ChannelTransport::Local);
-            let proc_id = ProcId::unique(addr, format!("mailbox_server_{}", rank));
+            let proc_id = reference::ProcId::unique(addr, format!("mailbox_server_{}", rank));
             // Use this mailbox server as the forwarder, so we can use it to
             // return message back to the sender.
             let proc = Proc::configured(proc_id, BoxedMailboxSender::new(server));
@@ -1036,9 +1036,10 @@ pub trait MailboxServer: MailboxSender + Clone + Sized + 'static {
                 envelope.set_error(DeliveryError::BrokenLink(
                     "message was undeliverable".to_owned(),
                 ));
-                let return_port = PortRef::<Undeliverable<MessageEnvelope>>::attest_message_port(
-                    envelope.sender(),
-                );
+                let return_port =
+                    reference::PortRef::<Undeliverable<MessageEnvelope>>::attest_message_port(
+                        envelope.sender(),
+                    );
                 return_port.send_serialized(
                     &client,
                     Flattrs::new(),
@@ -1213,12 +1214,12 @@ impl MailboxSender for MailboxClient {
 /// Wrapper to turn `PortRef` into a `Sink`.
 pub struct PortSink<C: context::Actor, M: RemoteMessage> {
     cx: C,
-    port: PortRef<M>,
+    port: reference::PortRef<M>,
 }
 
 impl<C: context::Actor, M: RemoteMessage> PortSink<C, M> {
     /// Create new PortSink
-    pub fn new(cx: C, port: PortRef<M>) -> Self {
+    pub fn new(cx: C, port: reference::PortRef<M>) -> Self {
         Self { cx, port }
     }
 }
@@ -1253,21 +1254,21 @@ pub struct Mailbox {
 impl Mailbox {
     /// Create a new mailbox associated with the provided actor ID, using the provided
     /// forwarder for external destinations.
-    pub fn new(actor_id: ActorId, forwarder: BoxedMailboxSender) -> Self {
+    pub fn new(actor_id: reference::ActorId, forwarder: BoxedMailboxSender) -> Self {
         Self {
             inner: Arc::new(State::new(actor_id, forwarder)),
         }
     }
 
     /// Create a new detached mailbox associated with the provided actor ID.
-    pub fn new_detached(actor_id: ActorId) -> Self {
+    pub fn new_detached(actor_id: reference::ActorId) -> Self {
         Self {
             inner: Arc::new(State::new(actor_id, BOXED_PANICKING_MAILBOX_SENDER.clone())),
         }
     }
 
     /// The actor id associated with this mailbox.
-    pub fn actor_id(&self) -> &ActorId {
+    pub fn actor_id(&self) -> &reference::ActorId {
         &self.inner.actor_id
     }
 
@@ -1278,7 +1279,7 @@ impl Mailbox {
     pub fn open_port<M: Message>(&self) -> (PortHandle<M>, PortReceiver<M>) {
         let port_index = self.inner.allocate_port();
         let (sender, receiver) = mpsc::unbounded_channel::<M>();
-        let port_id = PortId::new(self.inner.actor_id.clone(), port_index);
+        let port_id = reference::PortId::new(self.inner.actor_id.clone(), port_index);
         tracing::trace!(
             name = "open_port",
             "opening port for {} at {}",
@@ -1333,7 +1334,7 @@ impl Mailbox {
     {
         let port_index = self.inner.allocate_port();
         let (sender, receiver) = mpsc::unbounded_channel::<A::State>();
-        let port_id = PortId::new(self.inner.actor_id.clone(), port_index);
+        let port_id = reference::PortId::new(self.inner.actor_id.clone(), port_index);
         let state = Mutex::new(A::State::default());
         let reducer_spec = accum.reducer_spec();
         let enqueue = move |_, update: A::Update| {
@@ -1377,7 +1378,7 @@ impl Mailbox {
     /// receiver may receive a single message.
     pub fn open_once_port<M: Message>(&self) -> (OncePortHandle<M>, OncePortReceiver<M>) {
         let port_index = self.inner.allocate_port();
-        let port_id = PortId::new(self.inner.actor_id.clone(), port_index);
+        let port_id = reference::PortId::new(self.inner.actor_id.clone(), port_index);
         let (sender, receiver) = oneshot::channel::<M>();
         (
             OncePortHandle {
@@ -1418,7 +1419,7 @@ impl Mailbox {
     {
         let port_index = self.inner.allocate_port();
         let (sender, receiver) = oneshot::channel::<T>();
-        let port_id = PortId::new(self.inner.actor_id.clone(), port_index);
+        let port_id = reference::PortId::new(self.inner.actor_id.clone(), port_index);
         let reducer_spec = accum.reducer_spec();
         assert!(
             reducer_spec.is_some(),
@@ -1473,7 +1474,7 @@ impl Mailbox {
         self.inner.allocate_port()
     }
 
-    fn bind<M: RemoteMessage>(&self, handle: &PortHandle<M>) -> PortRef<M> {
+    fn bind<M: RemoteMessage>(&self, handle: &PortHandle<M>) -> reference::PortRef<M> {
         assert_eq!(
             handle.mailbox.actor_id(),
             self.actor_id(),
@@ -1493,7 +1494,7 @@ impl Mailbox {
             Entry::Occupied(_entry) => {}
         }
 
-        PortRef::attest(port_id)
+        reference::PortRef::attest(port_id)
     }
 
     fn bind_to_actor_port<M: RemoteMessage>(&self, handle: &PortHandle<M>) {
@@ -1526,7 +1527,7 @@ impl Mailbox {
         }
     }
 
-    pub(crate) fn bind_untyped(&self, port_id: &PortId, sender: UntypedUnboundedSender) {
+    pub(crate) fn bind_untyped(&self, port_id: &reference::PortId, sender: UntypedUnboundedSender) {
         assert_eq!(
             port_id.actor_id(),
             self.actor_id(),
@@ -1710,7 +1711,7 @@ pub struct PortHandle<M: Message> {
     // making PortRef<M> valid for M: Message, but constructible only for
     // M: RemoteMessage, but the guarantees offered by the impossibilty of even
     // writing down the type are appealing.
-    bound: Arc<RwLock<Option<PortId>>>,
+    bound: Arc<RwLock<Option<reference::PortId>>>,
     // Typehash of an optional reducer. When it's defined, we include it in port
     /// references to optionally enable incremental accumulation.
     reducer_spec: Option<ReducerSpec>,
@@ -1811,14 +1812,14 @@ impl<M: Message> PortHandle<M> {
 
 impl<M: RemoteMessage> PortHandle<M> {
     /// Bind this port, making it accessible to remote actors.
-    pub fn bind(&self) -> PortRef<M> {
+    pub fn bind(&self) -> reference::PortRef<M> {
         let port_id = {
             let mut guard = self.bound.write().unwrap();
             guard
                 .get_or_insert_with(|| self.mailbox.bind(self).port_id().clone())
                 .clone()
         };
-        PortRef::attest_reducible(
+        reference::PortRef::attest_reducible(
             port_id,
             self.reducer_spec.clone(),
             self.streaming_opts.clone(),
@@ -1870,7 +1871,7 @@ impl<M: Message> fmt::Display for PortHandle<M> {
 pub struct OncePortHandle<M: Message> {
     mailbox: Mailbox,
     port_index: u64,
-    port_id: PortId,
+    port_id: reference::PortId,
     sender: oneshot::Sender<M>,
     reducer_spec: Option<ReducerSpec>,
 }
@@ -1878,7 +1879,7 @@ pub struct OncePortHandle<M: Message> {
 impl<M: Message> OncePortHandle<M> {
     /// This port's ID.
     // TODO: make value
-    pub fn port_id(&self) -> &PortId {
+    pub fn port_id(&self) -> &reference::PortId {
         &self.port_id
     }
 
@@ -1911,11 +1912,11 @@ impl<M: RemoteMessage> OncePortHandle<M> {
     /// a remote actor. The remote actor can then use the
     /// ref to send a message to the port. Creating a ref also
     /// binds the port, so that it is remotely writable.
-    pub fn bind(self) -> OncePortRef<M> {
+    pub fn bind(self) -> reference::OncePortRef<M> {
         let port_id = self.port_id().clone();
         let reducer_spec = self.reducer_spec.clone();
         self.mailbox.clone().bind_once(self);
-        OncePortRef::attest_reducible(port_id, reducer_spec)
+        reference::OncePortRef::attest_reducible(port_id, reducer_spec)
     }
 }
 
@@ -1930,7 +1931,7 @@ impl<M: Message> fmt::Display for OncePortHandle<M> {
 #[derive(Debug)]
 pub struct PortReceiver<M> {
     receiver: mpsc::UnboundedReceiver<M>,
-    port_id: PortId,
+    port_id: reference::PortId,
     /// When multiple messages are put in channel, only receive the latest one
     /// if coalesce is true. Other messages will be discarded.
     coalesce: bool,
@@ -1942,7 +1943,7 @@ pub struct PortReceiver<M> {
 impl<M> PortReceiver<M> {
     fn new(
         receiver: mpsc::UnboundedReceiver<M>,
-        port_id: PortId,
+        port_id: reference::PortId,
         coalesce: bool,
         mailbox: Mailbox,
     ) -> Self {
@@ -2010,7 +2011,7 @@ impl<M> PortReceiver<M> {
         self.port_id.index()
     }
 
-    fn actor_id(&self) -> &ActorId {
+    fn actor_id(&self) -> &reference::ActorId {
         self.port_id.actor_id()
     }
 }
@@ -2035,7 +2036,7 @@ impl<M> Stream for PortReceiver<M> {
 /// A receiver of M-typed messages from [`OncePort`]s.
 pub struct OncePortReceiver<M> {
     receiver: Option<oneshot::Receiver<M>>,
-    port_id: PortId,
+    port_id: reference::PortId,
 
     /// Mailbox is used to remove the port from service when the receiver
     /// is dropped.
@@ -2062,7 +2063,7 @@ impl<M> OncePortReceiver<M> {
         self.port_id.index()
     }
 
-    fn actor_id(&self) -> &ActorId {
+    fn actor_id(&self) -> &reference::ActorId {
         self.port_id.actor_id()
     }
 }
@@ -2154,13 +2155,13 @@ impl<M: Message> Debug for UnboundedPortSender<M> {
 
 struct UnboundedSender<M: Message> {
     sender: UnboundedPortSender<M>,
-    port_id: PortId,
+    port_id: reference::PortId,
 }
 
 impl<M: Message> UnboundedSender<M> {
     /// Create a new UnboundedSender encapsulating the provided
     /// sender.
-    fn new(sender: UnboundedPortSender<M>, port_id: PortId) -> Self {
+    fn new(sender: UnboundedPortSender<M>, port_id: reference::PortId) -> Self {
         Self { sender, port_id }
     }
 
@@ -2231,13 +2232,13 @@ impl<M: RemoteMessage> SerializedSender for UnboundedSender<M> {
 #[derive(Debug)]
 struct OnceSender<M: Message> {
     sender: Arc<Mutex<Option<oneshot::Sender<M>>>>,
-    port_id: PortId,
+    port_id: reference::PortId,
 }
 
 impl<M: Message> OnceSender<M> {
     /// Create a new OnceSender encapsulating the provided one-shot
     /// sender.
-    fn new(sender: oneshot::Sender<M>, port_id: PortId) -> Self {
+    fn new(sender: oneshot::Sender<M>, port_id: reference::PortId) -> Self {
         Self {
             sender: Arc::new(Mutex::new(Some(sender))),
             port_id,
@@ -2312,7 +2313,7 @@ impl<M: RemoteMessage> SerializedSender for OnceSender<M> {
 pub(crate) struct UntypedUnboundedSender {
     pub(crate) sender:
         Box<dyn Fn(wirevalue::Any) -> Result<bool, (wirevalue::Any, anyhow::Error)> + Send + Sync>,
-    pub(crate) port_id: PortId,
+    pub(crate) port_id: reference::PortId,
 }
 
 impl SerializedSender for UntypedUnboundedSender {
@@ -2339,7 +2340,7 @@ impl SerializedSender for UntypedUnboundedSender {
 /// State is the internal state of the mailbox.
 struct State {
     /// The ID of the mailbox owner.
-    actor_id: ActorId,
+    actor_id: reference::ActorId,
 
     // insert if it's serializable; otherwise don't.
     /// The set of active ports in the mailbox. All currently
@@ -2359,7 +2360,7 @@ struct State {
 
 impl State {
     /// Create a new state with the provided owning ActorId.
-    fn new(actor_id: ActorId, forwarder: BoxedMailboxSender) -> Self {
+    fn new(actor_id: reference::ActorId, forwarder: BoxedMailboxSender) -> Self {
         Self {
             actor_id,
             ports: DashMap::new(),
@@ -2395,7 +2396,7 @@ impl fmt::Debug for State {
 /// different underlying senders.
 #[derive(Clone)]
 pub struct MailboxMuxer {
-    mailboxes: Arc<DashMap<ActorId, Box<dyn MailboxSender + Send + Sync>>>,
+    mailboxes: Arc<DashMap<reference::ActorId, Box<dyn MailboxSender + Send + Sync>>>,
 }
 
 impl Default for MailboxMuxer {
@@ -2416,7 +2417,7 @@ impl MailboxMuxer {
     /// sender. Returns false if there is already a sender associated
     /// with the actor. In this case, the sender is not replaced, and
     /// the caller must [`MailboxMuxer::unbind`] it first.
-    pub fn bind(&self, actor_id: ActorId, sender: impl MailboxSender + 'static) -> bool {
+    pub fn bind(&self, actor_id: reference::ActorId, sender: impl MailboxSender + 'static) -> bool {
         match self.mailboxes.entry(actor_id) {
             Entry::Occupied(_) => false,
             Entry::Vacant(entry) => {
@@ -2435,12 +2436,12 @@ impl MailboxMuxer {
     /// unbinding, the muxer will no longer be able to send messages to
     /// that actor.
     #[allow(dead_code)]
-    pub(crate) fn unbind(&self, actor_id: &ActorId) {
+    pub(crate) fn unbind(&self, actor_id: &reference::ActorId) {
         self.mailboxes.remove(actor_id);
     }
 
     /// Returns a list of all actors bound to this muxer. Useful in debugging.
-    pub fn bound_actors(&self) -> Vec<ActorId> {
+    pub fn bound_actors(&self) -> Vec<reference::ActorId> {
         self.mailboxes.iter().map(|e| e.key().clone()).collect()
     }
 }
@@ -2466,7 +2467,7 @@ impl MailboxSender for MailboxMuxer {
 /// nearest prefix.
 #[derive(Clone)]
 pub struct MailboxRouter {
-    entries: Arc<RwLock<BTreeMap<Reference, Arc<dyn MailboxSender + Send + Sync>>>>,
+    entries: Arc<RwLock<BTreeMap<reference::Reference, Arc<dyn MailboxSender + Send + Sync>>>>,
 }
 
 impl Default for MailboxRouter {
@@ -2501,12 +2502,15 @@ impl MailboxRouter {
     /// Bind the provided sender to the given reference. The destination
     /// is treated as a prefix to which messages can be routed, and
     /// messages are routed to their longest matching prefix.
-    pub fn bind(&self, dest: Reference, sender: impl MailboxSender + 'static) {
+    pub fn bind(&self, dest: reference::Reference, sender: impl MailboxSender + 'static) {
         let mut w = self.entries.write().unwrap();
         w.insert(dest, Arc::new(sender));
     }
 
-    fn sender(&self, actor_id: &ActorId) -> Option<Arc<dyn MailboxSender + Send + Sync>> {
+    fn sender(
+        &self,
+        actor_id: &reference::ActorId,
+    ) -> Option<Arc<dyn MailboxSender + Send + Sync>> {
         match self
             .entries
             .read()
@@ -2570,7 +2574,7 @@ impl MailboxSender for FallbackMailboxRouter {
 /// on a per-entry basis.
 #[derive(Debug, Clone)]
 pub struct WeakMailboxRouter(
-    Weak<RwLock<BTreeMap<Reference, Arc<dyn MailboxSender + Send + Sync>>>>,
+    Weak<RwLock<BTreeMap<reference::Reference, Arc<dyn MailboxSender + Send + Sync>>>>,
 );
 
 impl WeakMailboxRouter {
@@ -2611,7 +2615,7 @@ impl MailboxSender for WeakMailboxRouter {
 /// sender, if present.
 #[derive(Clone)]
 pub struct DialMailboxRouter {
-    address_book: Arc<RwLock<BTreeMap<Reference, ChannelAddr>>>,
+    address_book: Arc<RwLock<BTreeMap<reference::Reference, ChannelAddr>>>,
     sender_cache: Arc<DashMap<ChannelAddr, Arc<MailboxClient>>>,
 
     // The default sender, to which messages for unknown recipients
@@ -2666,7 +2670,7 @@ impl DialMailboxRouter {
     ///
     /// If the address changes, the old sender is evicted from the
     /// cache to ensure fresh routing on next use.
-    pub fn bind(&self, dest: Reference, addr: ChannelAddr) {
+    pub fn bind(&self, dest: reference::Reference, addr: ChannelAddr) {
         if let Ok(mut w) = self.address_book.write() {
             if let Some(old_addr) = w.insert(dest.clone(), addr.clone())
                 && old_addr != addr
@@ -2684,9 +2688,9 @@ impl DialMailboxRouter {
     ///
     /// Also evicts any corresponding cached senders to prevent reuse
     /// of stale connections.
-    pub fn unbind(&self, dest: &Reference) {
+    pub fn unbind(&self, dest: &reference::Reference) {
         if let Ok(mut w) = self.address_book.write() {
-            let to_remove: Vec<(Reference, ChannelAddr)> = w
+            let to_remove: Vec<(reference::Reference, ChannelAddr)> = w
                 .range(dest..)
                 .take_while(|(key, _)| dest.is_prefix_of(key))
                 .map(|(key, addr)| (key.clone(), addr.clone()))
@@ -2703,7 +2707,7 @@ impl DialMailboxRouter {
     }
 
     /// Lookup an actor's channel in the router's address bok.
-    pub fn lookup_addr(&self, actor_id: &ActorId) -> Option<ChannelAddr> {
+    pub fn lookup_addr(&self, actor_id: &reference::ActorId) -> Option<ChannelAddr> {
         let address_book = self.address_book.read().unwrap();
         let found = address_book
             .lower_bound(Excluded(&actor_id.clone().into()))
@@ -2727,9 +2731,9 @@ impl DialMailboxRouter {
 
     /// Return all covering prefixes of this router. That is, all references that are not
     /// prefixed by another reference in the routing table
-    pub fn prefixes(&self) -> BTreeSet<Reference> {
+    pub fn prefixes(&self) -> BTreeSet<reference::Reference> {
         let addrs = self.address_book.read().unwrap();
-        let mut prefixes: BTreeSet<Reference> = BTreeSet::new();
+        let mut prefixes: BTreeSet<reference::Reference> = BTreeSet::new();
         for (reference, _) in addrs.iter() {
             match prefixes.lower_bound(Excluded(reference)).peek_prev() {
                 Some(candidate) if candidate.is_prefix_of(reference) => (),
@@ -2745,7 +2749,7 @@ impl DialMailboxRouter {
     fn dial(
         &self,
         addr: &ChannelAddr,
-        actor_id: &ActorId,
+        actor_id: &reference::ActorId,
     ) -> Result<Arc<MailboxClient>, MailboxSenderError> {
         // Get the sender. Create it if needed. Do not send the
         // messages inside this block so we do not hold onto the
@@ -2821,7 +2825,6 @@ mod tests {
     use crate::Actor;
     use crate::ActorHandle;
     use crate::Instance;
-    use crate::PortId;
     use crate::accum;
     use crate::accum::ReducerMode;
     use crate::channel::ChannelTransport;
@@ -2837,12 +2840,12 @@ mod tests {
     use crate::testing::ids::test_port_id;
     use crate::testing::ids::test_proc_id;
 
-    fn test_proc_ref(name: &str) -> Reference {
-        Reference::Proc(test_proc_id(name))
+    fn test_proc_ref(name: &str) -> reference::Reference {
+        reference::Reference::Proc(test_proc_id(name))
     }
 
-    fn test_actor_ref(proc_name: &str, actor_name: &str) -> Reference {
-        Reference::Actor(test_actor_id(proc_name, actor_name))
+    fn test_actor_ref(proc_name: &str, actor_name: &str) -> reference::Reference {
+        reference::Reference::Actor(test_actor_id(proc_name, actor_name))
     }
 
     #[test]
@@ -3078,7 +3081,7 @@ mod tests {
         let mbox2 = Mailbox::new_detached(test_actor_id("world1_1", "actor0"));
         let mbox3 = Mailbox::new_detached(test_actor_id("world1_1", "actor1"));
 
-        let comms: Vec<(OncePortRef<u64>, OncePortReceiver<u64>)> =
+        let comms: Vec<(reference::OncePortRef<u64>, OncePortReceiver<u64>)> =
             [&mbox0, &mbox1, &mbox2, &mbox3]
                 .into_iter()
                 .map(|mbox| {
@@ -3146,7 +3149,7 @@ mod tests {
             .lookup_addr(&test_actor_id("world1_0", "actor"))
             .unwrap();
 
-        let actor_id = Reference::from_str("unix:@4,my_proc,my_actor")
+        let actor_id = reference::Reference::from_str("unix:@4,my_proc,my_actor")
             .unwrap()
             .into_actor()
             .unwrap();
@@ -3401,7 +3404,7 @@ mod tests {
                 dummy_actor_id.clone(),
                 BOXED_PANICKING_MAILBOX_SENDER.clone(),
             );
-            let dummy_port_id = PortId::new(dummy_actor_id, 0);
+            let dummy_port_id = reference::PortId::new(dummy_actor_id, 0);
             let (sender, receiver) = mpsc::unbounded_channel::<M>();
             let receiver = PortReceiver {
                 receiver,
@@ -3550,10 +3553,10 @@ mod tests {
         actor1: Instance<()>,
         _actor0_handle: ActorHandle<()>,
         _actor1_handle: ActorHandle<()>,
-        port_id: PortId,
-        port_id1: PortId,
-        port_id2: PortId,
-        port_id2_1: PortId,
+        port_id: reference::PortId,
+        port_id1: reference::PortId,
+        port_id2: reference::PortId,
+        port_id2_1: reference::PortId,
     }
 
     async fn setup_split_port_ids(
@@ -3594,7 +3597,7 @@ mod tests {
         }
     }
 
-    fn post(cx: &impl context::Actor, port_id: PortId, msg: u64) {
+    fn post(cx: &impl context::Actor, port_id: reference::PortId, msg: u64) {
         let serialized = wirevalue::Any::serialize(&msg).unwrap();
         port_id.send(cx, serialized);
     }
@@ -3902,7 +3905,7 @@ mod tests {
         let router = DialMailboxRouter::new();
         router.bind(test_proc_ref("world0"), "unix!@1".parse().unwrap());
 
-        let prefixes: Vec<Reference> = router.prefixes().into_iter().collect();
+        let prefixes: Vec<reference::Reference> = router.prefixes().into_iter().collect();
         assert_eq!(prefixes.len(), 1);
         assert_eq!(prefixes[0], test_proc_ref("world0"));
     }
@@ -3914,7 +3917,7 @@ mod tests {
         router.bind(test_proc_ref("world1"), "unix!@2".parse().unwrap());
         router.bind(test_proc_ref("world2"), "unix!@3".parse().unwrap());
 
-        let mut prefixes: Vec<Reference> = router.prefixes().into_iter().collect();
+        let mut prefixes: Vec<reference::Reference> = router.prefixes().into_iter().collect();
         prefixes.sort();
 
         let mut expected = vec![
@@ -3937,7 +3940,7 @@ mod tests {
         router.bind(test_proc_ref("world1"), "unix!@4".parse().unwrap());
         router.bind(test_proc_ref("world1_0"), "unix!@5".parse().unwrap());
 
-        let mut prefixes: Vec<Reference> = router.prefixes().into_iter().collect();
+        let mut prefixes: Vec<reference::Reference> = router.prefixes().into_iter().collect();
         prefixes.sort();
 
         let mut expected = vec![
@@ -3969,7 +3972,7 @@ mod tests {
             "unix!@6".parse().unwrap(),
         );
 
-        let mut prefixes: Vec<Reference> = router.prefixes().into_iter().collect();
+        let mut prefixes: Vec<reference::Reference> = router.prefixes().into_iter().collect();
         prefixes.sort();
 
         // Covering prefixes:
@@ -3997,7 +4000,7 @@ mod tests {
         router.bind(test_proc_ref("world0_1"), "unix!@2".parse().unwrap());
         router.bind(test_proc_ref("world0_2"), "unix!@3".parse().unwrap());
 
-        let mut prefixes: Vec<Reference> = router.prefixes().into_iter().collect();
+        let mut prefixes: Vec<reference::Reference> = router.prefixes().into_iter().collect();
         prefixes.sort();
 
         // All should be covering prefixes since none is a prefix of another
@@ -4043,7 +4046,7 @@ mod tests {
         // Create a destination not owned by this mailbox to force
         // forwarding.
         let remote_actor = test_actor_id("remote_world_1", "remote");
-        let dest = PortId::new(remote_actor.clone(), /*port index*/ 4242);
+        let dest = reference::PortId::new(remote_actor.clone(), /*port index*/ 4242);
 
         // Build an envelope (TTL is seeded in `MessageEnvelope::new` /
         // `::serialize`).

--- a/hyperactor/src/mailbox/mailbox_admin_message.rs
+++ b/hyperactor/src/mailbox/mailbox_admin_message.rs
@@ -12,9 +12,9 @@ use serde::Serialize;
 pub use crate as hyperactor;
 use crate::HandleClient;
 use crate::Handler;
-use crate::ProcId;
 use crate::RefClient;
 use crate::mailbox::ChannelAddr;
+use crate::reference;
 
 /// Messages relating to mailbox administration.
 #[derive(
@@ -32,7 +32,7 @@ pub enum MailboxAdminMessage {
     /// An address update.
     UpdateAddress {
         /// The ID of the proc.
-        proc_id: ProcId,
+        proc_id: reference::ProcId,
 
         /// The address at which it listens.
         addr: ChannelAddr,

--- a/hyperactor/src/message.rs
+++ b/hyperactor/src/message.rs
@@ -39,12 +39,12 @@ use serde::de::DeserializeOwned;
 use typeuri::Named;
 
 // for macros
-use crate::ActorRef;
 use crate::Mailbox;
 use crate::RemoteHandles;
 use crate::RemoteMessage;
 use crate::actor::Referable;
 use crate::context;
+use crate::reference;
 
 /// An object `T` that is [`Unbind`] can extract a set of parameters from itself,
 /// and store in [`Bindings`]. The extracted parameters in [`Bindings`] can be
@@ -233,7 +233,7 @@ impl<M: Bind> IndexedErasedUnbound<M> {
     /// Used in unit tests to bind CastBlobT<M> to the given actor. Do not use in
     /// production.
     pub fn bind_for_test_only<A, C>(
-        actor_ref: ActorRef<A>,
+        actor_ref: reference::ActorRef<A>,
         cx: C,
         mailbox: Mailbox,
     ) -> anyhow::Result<()>
@@ -321,11 +321,9 @@ mod tests {
     use super::*;
     use crate as hyperactor; // for macros
     use crate::Bind;
-    use crate::PortRef;
     use crate::Unbind;
     use crate::accum::ReducerSpec;
     use crate::accum::StreamingReducerOpts;
-    use crate::reference::UnboundPort;
     use crate::testing::ids::test_port_id_with_pid;
 
     // Used to demonstrate a user defined reply type.
@@ -347,15 +345,16 @@ mod tests {
         arg0: bool,
         arg1: u32,
         #[binding(include)]
-        reply0: PortRef<String>,
+        reply0: reference::PortRef<String>,
         #[binding(include)]
-        reply1: PortRef<MyReply>,
+        reply1: reference::PortRef<MyReply>,
     }
 
     #[test]
     fn test_castable() {
-        let original_port0 = PortRef::attest(test_port_id_with_pid("world_0", "actor", 0, 123));
-        let original_port1 = PortRef::attest_reducible(
+        let original_port0 =
+            reference::PortRef::attest(test_port_id_with_pid("world_0", "actor", 0, 123));
+        let original_port1 = reference::PortRef::attest_reducible(
             test_port_id_with_pid("world_1", "actor1", 0, 456),
             Some(ReducerSpec {
                 typehash: 123,
@@ -381,12 +380,18 @@ mod tests {
                 bindings: Bindings(
                     [
                         (
-                            UnboundPort::typehash(),
-                            wirevalue::Any::serialize(&UnboundPort::from(&original_port0)).unwrap(),
+                            reference::UnboundPort::typehash(),
+                            wirevalue::Any::serialize(&reference::UnboundPort::from(
+                                &original_port0
+                            ))
+                            .unwrap(),
                         ),
                         (
-                            UnboundPort::typehash(),
-                            wirevalue::Any::serialize(&UnboundPort::from(&original_port1)).unwrap(),
+                            reference::UnboundPort::typehash(),
+                            wirevalue::Any::serialize(&reference::UnboundPort::from(
+                                &original_port1
+                            ))
+                            .unwrap(),
                         ),
                     ]
                     .into_iter()
@@ -403,15 +408,15 @@ mod tests {
 
         let mut new_ports = vec![&new_port_id0, &new_port_id1].into_iter();
         erased
-            .visit_mut::<UnboundPort>(|b| {
+            .visit_mut::<reference::UnboundPort>(|b| {
                 let port = new_ports.next().unwrap();
                 b.update(port.clone());
                 Ok(())
             })
             .unwrap();
 
-        let new_port0 = PortRef::<String>::attest(new_port_id0);
-        let new_port1 = PortRef::<MyReply>::attest_reducible(
+        let new_port0 = reference::PortRef::<String>::attest(new_port_id0);
+        let new_port1 = reference::PortRef::<MyReply>::attest_reducible(
             new_port_id1,
             Some(ReducerSpec {
                 typehash: 123,
@@ -422,12 +427,12 @@ mod tests {
         let new_bindings = Bindings(
             [
                 (
-                    UnboundPort::typehash(),
-                    wirevalue::Any::serialize(&UnboundPort::from(&new_port0)).unwrap(),
+                    reference::UnboundPort::typehash(),
+                    wirevalue::Any::serialize(&reference::UnboundPort::from(&new_port0)).unwrap(),
                 ),
                 (
-                    UnboundPort::typehash(),
-                    wirevalue::Any::serialize(&UnboundPort::from(&new_port1)).unwrap(),
+                    reference::UnboundPort::typehash(),
+                    wirevalue::Any::serialize(&reference::UnboundPort::from(&new_port1)).unwrap(),
                 ),
             ]
             .into_iter()

--- a/hyperactor/src/ordering.rs
+++ b/hyperactor/src/ordering.rs
@@ -25,8 +25,7 @@ use tokio::sync::mpsc::error::SendError;
 use typeuri::Named;
 use uuid::Uuid;
 
-use crate::ActorId;
-use crate::PortId;
+use crate::reference;
 
 /// A client's re-ordering buffer state.
 struct BufferState<T> {
@@ -180,9 +179,9 @@ impl<T> OrderedSender<T> {
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
 enum SeqKey {
     /// Shared sequence for all actor ports of an actor
-    Actor(ActorId),
+    Actor(reference::ActorId),
     /// Individual sequence for a specific non-actor port
-    Port(PortId),
+    Port(reference::PortId),
 }
 
 /// A message's sequencer number infomation.
@@ -256,7 +255,7 @@ impl Sequencer {
     ///
     /// - Actor ports: share the same sequence scheme per actor (keyed by ActorId)
     /// - Non-actor ports: get individual sequence schemes (keyed by PortId)
-    pub fn assign_seq(&self, port_id: &PortId) -> SeqInfo {
+    pub fn assign_seq(&self, port_id: &reference::PortId) -> SeqInfo {
         let key = if port_id.is_actor_port() {
             SeqKey::Actor(port_id.actor_id().clone())
         } else {

--- a/hyperactor/src/proc.rs
+++ b/hyperactor/src/proc.rs
@@ -53,7 +53,6 @@ use wirevalue::TypeInfo;
 
 use crate as hyperactor;
 use crate::Actor;
-use crate::ActorRef;
 use crate::Handler;
 use crate::Message;
 use crate::RemoteMessage;
@@ -106,10 +105,7 @@ use crate::ordering::SeqInfo;
 use crate::ordering::Sequencer;
 use crate::ordering::ordered_channel;
 use crate::panic_handler;
-use crate::reference::ActorId;
-use crate::reference::Index;
-use crate::reference::PortId;
-use crate::reference::ProcId;
+use crate::reference;
 use crate::supervision::ActorSupervisionEvent;
 
 /// This is used to mint new local ranks for [`Proc::local`].
@@ -137,7 +133,7 @@ impl fmt::Debug for Proc {
 struct ProcState {
     /// The proc's id. This should be globally unique, but is not (yet)
     /// for local-only procs.
-    proc_id: ProcId,
+    proc_id: reference::ProcId,
 
     /// A muxer instance that has entries for every actor managed by
     /// the proc.
@@ -153,13 +149,13 @@ struct ProcState {
     roots: DashMap<String, AtomicUsize>,
 
     /// All actor instances in this proc.
-    instances: DashMap<ActorId, WeakInstanceCell>,
+    instances: DashMap<reference::ActorId, WeakInstanceCell>,
 
     /// Snapshots of terminated actors for post-mortem introspection.
     /// Populated by the introspect task just before it exits on
     /// terminal status. Bounded by
     /// [`config::TERMINATED_SNAPSHOT_RETENTION`].
-    terminated_snapshots: DashMap<ActorId, crate::introspect::NodePayload>,
+    terminated_snapshots: DashMap<reference::ActorId, crate::introspect::NodePayload>,
 
     /// Used by root actors to send events to the actor coordinating
     /// supervision of root actors in this proc.
@@ -200,14 +196,14 @@ pub struct ActorInstance<A: Actor> {
 
 impl Proc {
     /// Create a pre-configured proc with the given proc id and forwarder.
-    pub fn configured(proc_id: ProcId, forwarder: BoxedMailboxSender) -> Self {
+    pub fn configured(proc_id: reference::ProcId, forwarder: BoxedMailboxSender) -> Self {
         Self::configured_with_clock(proc_id, forwarder, ClockKind::default())
     }
 
     /// Create a new direct-addressed proc.
     pub fn direct(addr: ChannelAddr, name: String) -> Result<Self, ChannelError> {
         let (addr, rx) = channel::serve(addr)?;
-        let proc_id = ProcId::with_name(addr, name);
+        let proc_id = reference::ProcId::with_name(addr, name);
         let proc = Self::configured(proc_id, DialMailboxRouter::new().into_boxed());
         proc.clone().serve(rx);
         Ok(proc)
@@ -215,7 +211,7 @@ impl Proc {
 
     /// Create a pre-configured proc with the given proc id, forwarder and clock kind.
     pub fn configured_with_clock(
-        proc_id: ProcId,
+        proc_id: reference::ProcId,
         forwarder: BoxedMailboxSender,
         clock: ClockKind,
     ) -> Self {
@@ -282,12 +278,12 @@ impl Proc {
     pub fn local() -> Self {
         let rank = NEXT_LOCAL_RANK.fetch_add(1, Ordering::Relaxed);
         let addr = ChannelAddr::any(ChannelTransport::Local);
-        let proc_id = ProcId::unique(addr, format!("local_{}", rank));
+        let proc_id = reference::ProcId::unique(addr, format!("local_{}", rank));
         Proc::configured(proc_id, BoxedMailboxSender::new(PanickingMailboxSender))
     }
 
     /// The proc's ID.
-    pub fn proc_id(&self) -> &ProcId {
+    pub fn proc_id(&self) -> &reference::ProcId {
         &self.state().proc_id
     }
 
@@ -312,25 +308,25 @@ impl Proc {
         static RUNTIME_PROC: OnceLock<Proc> = OnceLock::new();
         RUNTIME_PROC.get_or_init(|| {
             let addr = ChannelAddr::any(ChannelTransport::Local);
-            let proc_id = ProcId::unique(addr, "hyperactor_runtime");
+            let proc_id = reference::ProcId::unique(addr, "hyperactor_runtime");
             Proc::configured(proc_id, BoxedMailboxSender::new(PanickingMailboxSender))
         })
     }
 
     /// Attach a mailbox to the proc with the provided root name.
     pub fn attach(&self, name: &str) -> Result<Mailbox, anyhow::Error> {
-        let actor_id: ActorId = self.allocate_root_id(name)?;
+        let actor_id: reference::ActorId = self.allocate_root_id(name)?;
         Ok(self.bind_mailbox(actor_id))
     }
 
     /// Attach a mailbox to the proc as a child actor.
-    pub fn attach_child(&self, parent_id: &ActorId) -> Result<Mailbox, anyhow::Error> {
-        let actor_id: ActorId = self.allocate_child_id(parent_id)?;
+    pub fn attach_child(&self, parent_id: &reference::ActorId) -> Result<Mailbox, anyhow::Error> {
+        let actor_id: reference::ActorId = self.allocate_child_id(parent_id)?;
         Ok(self.bind_mailbox(actor_id))
     }
 
     /// Bind a mailbox to the proc.
-    fn bind_mailbox(&self, actor_id: ActorId) -> Mailbox {
+    fn bind_mailbox(&self, actor_id: reference::ActorId) -> Mailbox {
         let mbox = Mailbox::new(actor_id, BoxedMailboxSender::new(self.downgrade()));
 
         // TODO: T210748165 tie the muxer entry to the lifecycle of the mailbox held
@@ -344,14 +340,14 @@ impl Proc {
     pub fn attach_actor<R, M>(
         &self,
         name: &str,
-    ) -> Result<(Instance<()>, ActorRef<R>, PortReceiver<M>), anyhow::Error>
+    ) -> Result<(Instance<()>, reference::ActorRef<R>, PortReceiver<M>), anyhow::Error>
     where
         M: RemoteMessage,
         R: Referable + RemoteHandles<M>,
     {
         let (instance, _handle) = self.instance(name)?;
         let (_handle, rx) = instance.bind_actor_port::<M>();
-        let actor_ref = ActorRef::attest(instance.self_id().clone());
+        let actor_ref = reference::ActorRef::attest(instance.self_id().clone());
         Ok((instance, actor_ref, rx))
     }
 
@@ -367,7 +363,7 @@ impl Proc {
     #[hyperactor::instrument(fields(actor_id = actor_id.to_string(), actor_name = actor_id.name(), actor_type = std::any::type_name::<A>()))]
     fn spawn_inner<A: Actor>(
         &self,
-        actor_id: ActorId,
+        actor_id: reference::ActorId,
         actor: A,
         parent: Option<InstanceCell>,
     ) -> Result<ActorHandle<A>, anyhow::Error> {
@@ -474,7 +470,7 @@ impl Proc {
     }
 
     /// Look up an instance by ActorId.
-    pub fn get_instance(&self, actor_id: &ActorId) -> Option<InstanceCell> {
+    pub fn get_instance(&self, actor_id: &reference::ActorId) -> Option<InstanceCell> {
         self.state()
             .instances
             .get(actor_id)
@@ -482,7 +478,7 @@ impl Proc {
     }
 
     /// Returns the ActorIds of all root actors (pid=0) in this proc.
-    pub fn root_actor_ids(&self) -> Vec<ActorId> {
+    pub fn root_actor_ids(&self) -> Vec<reference::ActorId> {
         self.state()
             .instances
             .iter()
@@ -499,7 +495,7 @@ impl Proc {
     /// actors whose `InstanceCell` has been dropped and actors that
     /// have stopped or failed but whose Arc is still held (e.g. by
     /// the introspect task during teardown).
-    pub fn all_actor_ids(&self) -> Vec<ActorId> {
+    pub fn all_actor_ids(&self) -> Vec<reference::ActorId> {
         self.state()
             .instances
             .iter()
@@ -516,7 +512,7 @@ impl Proc {
     /// Look up a terminated actor's snapshot by ID.
     pub fn terminated_snapshot(
         &self,
-        actor_id: &ActorId,
+        actor_id: &reference::ActorId,
     ) -> Option<crate::introspect::NodePayload> {
         self.state()
             .terminated_snapshots
@@ -525,7 +521,7 @@ impl Proc {
     }
 
     /// Return all terminated actor IDs currently retained.
-    pub fn all_terminated_actor_ids(&self) -> Vec<ActorId> {
+    pub fn all_terminated_actor_ids(&self) -> Vec<reference::ActorId> {
         self.state()
             .terminated_snapshots
             .iter()
@@ -586,9 +582,9 @@ impl Proc {
     /// `None`.
     pub fn abort_root_actor(
         &self,
-        root: &ActorId,
+        root: &reference::ActorId,
         this_handle: Option<&JoinHandle<()>>,
-    ) -> Option<impl Future<Output = ActorId>> {
+    ) -> Option<impl Future<Output = reference::ActorId>> {
         self.state()
             .instances
             .get(root)
@@ -627,7 +623,7 @@ impl Proc {
     /// returning a status observer if successful.
     pub fn stop_actor(
         &self,
-        actor_id: &ActorId,
+        actor_id: &reference::ActorId,
         reason: String,
     ) -> Option<watch::Receiver<ActorStatus>> {
         if let Some(entry) = self.state().instances.get(actor_id) {
@@ -666,7 +662,7 @@ impl Proc {
         timeout: Duration,
         cx: Option<&Context<'_, A>>,
         reason: &str,
-    ) -> Result<(Vec<ActorId>, Vec<ActorId>), anyhow::Error> {
+    ) -> Result<(Vec<reference::ActorId>, Vec<reference::ActorId>), anyhow::Error> {
         self.destroy_and_wait_except_current::<A>(timeout, cx, false, reason)
             .await
     }
@@ -687,7 +683,7 @@ impl Proc {
         cx: Option<&Context<'_, A>>,
         except_current: bool,
         reason: &str,
-    ) -> Result<(Vec<ActorId>, Vec<ActorId>), anyhow::Error> {
+    ) -> Result<(Vec<reference::ActorId>, Vec<reference::ActorId>), anyhow::Error> {
         tracing::debug!("{}: proc stopping", self.proc_id());
 
         let (this_handle, this_actor_id) = cx.map_or((None, None), |cx| {
@@ -792,7 +788,7 @@ impl Proc {
     ///   `ActorRef<R>`.
     pub fn resolve_actor_ref<R: Actor + Referable>(
         &self,
-        actor_ref: &ActorRef<R>,
+        actor_ref: &reference::ActorRef<R>,
     ) -> Option<ActorHandle<R>> {
         let cell = self.inner.instances.get(actor_ref.actor_id())?.upgrade()?;
         // An actor whose status is terminal has stopped processing
@@ -805,7 +801,7 @@ impl Proc {
     }
 
     /// Create a root allocation in the proc.
-    fn allocate_root_id(&self, name: &str) -> Result<ActorId, anyhow::Error> {
+    fn allocate_root_id(&self, name: &str) -> Result<reference::ActorId, anyhow::Error> {
         let name = name.to_string();
         match self.state().roots.entry(name.to_string()) {
             Entry::Vacant(entry) => {
@@ -815,7 +811,7 @@ impl Proc {
                 anyhow::bail!("an actor with name '{}' has already been spawned", name)
             }
         }
-        Ok(ActorId::new(
+        Ok(reference::ActorId::new(
             self.state().proc_id.clone(),
             name.to_string(),
             0,
@@ -824,7 +820,10 @@ impl Proc {
 
     /// Create a child allocation in the proc.
     #[hyperactor::instrument(fields(actor_name=parent_id.name()))]
-    pub(crate) fn allocate_child_id(&self, parent_id: &ActorId) -> Result<ActorId, anyhow::Error> {
+    pub(crate) fn allocate_child_id(
+        &self,
+        parent_id: &reference::ActorId,
+    ) -> Result<reference::ActorId, anyhow::Error> {
         assert_eq!(*parent_id.proc_id(), self.state().proc_id);
         let pid = match self.state().roots.get(parent_id.name()) {
             None => anyhow::bail!(
@@ -861,11 +860,11 @@ impl Proc {
     /// `host_mesh.rs`).
     pub(crate) fn allocate_named_child_id(
         &self,
-        parent_id: &ActorId,
+        parent_id: &reference::ActorId,
         name: &str,
-    ) -> Result<ActorId, anyhow::Error> {
+    ) -> Result<reference::ActorId, anyhow::Error> {
         let inherited = self.allocate_child_id(parent_id)?;
-        Ok(ActorId::new(
+        Ok(reference::ActorId::new(
             inherited.proc_id().clone(),
             name,
             inherited.pid(),
@@ -1029,7 +1028,7 @@ struct InstanceState<A: Actor> {
 }
 
 impl<A: Actor> InstanceState<A> {
-    fn self_id(&self) -> &ActorId {
+    fn self_id(&self) -> &reference::ActorId {
         self.mailbox.actor_id()
     }
 }
@@ -1078,7 +1077,7 @@ impl<A: Actor> Instance<A> {
     /// Create a new actor instance in Created state.
     fn new(
         proc: Proc,
-        actor_id: ActorId,
+        actor_id: reference::ActorId,
         detached: bool,
         parent: Option<InstanceCell>,
     ) -> (Self, InstanceReceivers<A>) {
@@ -1220,7 +1219,7 @@ impl<A: Actor> Instance<A> {
     }
 
     /// This instance's actor ID.
-    pub fn self_id(&self) -> &ActorId {
+    pub fn self_id(&self) -> &reference::ActorId {
         self.inner.self_id()
     }
 
@@ -1334,7 +1333,7 @@ impl<A: Actor> Instance<A> {
     }
 
     /// Send a message to the actor running on the proc.
-    pub fn post(&self, port_id: PortId, headers: Flattrs, message: wirevalue::Any) {
+    pub fn post(&self, port_id: reference::PortId, headers: Flattrs, message: wirevalue::Any) {
         <Self as context::MailboxExt>::post(
             self,
             port_id,
@@ -1353,7 +1352,7 @@ impl<A: Actor> Instance<A> {
     #[doc(hidden)]
     pub fn post_with_external_seq_info(
         &self,
-        port_id: PortId,
+        port_id: reference::PortId,
         headers: Flattrs,
         message: wirevalue::Any,
     ) {
@@ -1866,7 +1865,7 @@ impl<A: Actor> Instance<A> {
     }
 
     /// The owning actor ref.
-    pub fn bind<R: Binds<A>>(&self) -> ActorRef<R> {
+    pub fn bind<R: Binds<A>>(&self) -> reference::ActorRef<R> {
         self.inner.cell.bind(self.inner.ports.as_ref())
     }
 
@@ -2022,7 +2021,7 @@ impl fmt::Debug for InstanceCell {
 
 struct InstanceCellState {
     /// The actor's id.
-    actor_id: ActorId,
+    actor_id: reference::ActorId,
 
     /// Actor info contains the actor's type information.
     actor_type: ActorType,
@@ -2040,7 +2039,7 @@ struct InstanceCellState {
     parent: WeakInstanceCell,
 
     /// This instance's children by their PIDs.
-    children: DashMap<Index, InstanceCell>,
+    children: DashMap<reference::Index, InstanceCell>,
 
     /// Access to the spawned actor's join handle.
     actor_task_handle: OnceLock<JoinHandle<()>>,
@@ -2134,11 +2133,11 @@ impl InstanceCellState {
 ///    newest-first (descending `occurred_at`), preserving the
 ///    earliest failures which are closest to the root cause.
 fn select_eviction_candidates(
-    entries: &[(ActorId, Option<String>)],
+    entries: &[(reference::ActorId, Option<String>)],
     excess: usize,
-) -> Vec<ActorId> {
-    let mut clean: Vec<&ActorId> = Vec::new();
-    let mut failed: Vec<(&ActorId, &str)> = Vec::new();
+) -> Vec<reference::ActorId> {
+    let mut clean: Vec<&reference::ActorId> = Vec::new();
+    let mut failed: Vec<(&reference::ActorId, &str)> = Vec::new();
     for (id, occurred_at) in entries {
         match occurred_at {
             Some(ts) => failed.push((id, ts.as_str())),
@@ -2146,7 +2145,7 @@ fn select_eviction_candidates(
         }
     }
 
-    let mut to_remove: Vec<ActorId> = Vec::new();
+    let mut to_remove: Vec<reference::ActorId> = Vec::new();
     let mut remaining = excess;
 
     // Evict cleanly-stopped first.
@@ -2173,7 +2172,7 @@ impl InstanceCell {
     /// Creates a new instance cell with the provided internal state. If a parent
     /// is provided, it is linked to this cell.
     fn new(
-        actor_id: ActorId,
+        actor_id: reference::ActorId,
         actor_type: ActorType,
         proc: Proc,
         actor_loop: Option<(PortHandle<Signal>, PortHandle<ActorSupervisionEvent>)>,
@@ -2217,12 +2216,12 @@ impl InstanceCell {
     }
 
     /// The actor's ID.
-    pub fn actor_id(&self) -> &ActorId {
+    pub fn actor_id(&self) -> &reference::ActorId {
         &self.inner.actor_id
     }
 
     /// The actor's PID.
-    pub(crate) fn pid(&self) -> Index {
+    pub(crate) fn pid(&self) -> reference::Index {
         self.inner.actor_id.pid()
     }
 
@@ -2336,7 +2335,7 @@ impl InstanceCell {
 
     /// Return an iterator over this instance's children. This may deadlock if the
     /// caller already holds a reference to any item in map.
-    fn child_iter(&self) -> impl Iterator<Item = RefMulti<'_, Index, InstanceCell>> {
+    fn child_iter(&self) -> impl Iterator<Item = RefMulti<'_, reference::Index, InstanceCell>> {
         self.inner.children.iter()
     }
 
@@ -2346,7 +2345,7 @@ impl InstanceCell {
     }
 
     /// Returns the ActorIds of this instance's direct children.
-    pub fn child_actor_ids(&self) -> Vec<ActorId> {
+    pub fn child_actor_ids(&self) -> Vec<reference::ActorId> {
         self.inner
             .children
             .iter()
@@ -2355,7 +2354,7 @@ impl InstanceCell {
     }
 
     /// Get a child by its PID.
-    fn get_child(&self, pid: Index) -> Option<InstanceCell> {
+    fn get_child(&self, pid: reference::Index) -> Option<InstanceCell> {
         self.inner.children.get(&pid).map(|child| child.clone())
     }
 
@@ -2476,7 +2475,7 @@ impl InstanceCell {
 
     /// This is temporary so that we can share binding code between handle and instance.
     /// We should find some (better) way to consolidate the two.
-    pub(crate) fn bind<A: Actor, R: Binds<A>>(&self, ports: &Ports<A>) -> ActorRef<R> {
+    pub(crate) fn bind<A: Actor, R: Binds<A>>(&self, ports: &Ports<A>) -> reference::ActorRef<R> {
         <R as Binds<A>>::bind(ports);
         // Signal: pre-registered via open_message_port() in
         // Instance::new(), handled by the actor loop's select!.
@@ -2497,7 +2496,7 @@ impl InstanceCell {
                 .exported_named_ports
                 .insert(*entry.key(), entry.value());
         }
-        ActorRef::attest(self.actor_id().clone())
+        reference::ActorRef::attest(self.actor_id().clone())
     }
 
     /// Attempt to downcast this cell to a concrete actor handle.
@@ -2734,8 +2733,6 @@ mod tests {
     use crate as hyperactor;
     use crate::HandleClient;
     use crate::Handler;
-    use crate::OncePortRef;
-    use crate::PortRef;
     use crate::clock::RealClock;
     use crate::testing::proc_supervison::ProcSupervisionCoordinator;
     use crate::testing::process_assertion::assert_termination;
@@ -2909,7 +2906,10 @@ mod tests {
 
     #[derive(Handler, HandleClient, Debug)]
     enum LookupTestMessage {
-        ActorExists(ActorRef<TestActor>, #[reply] OncePortRef<bool>),
+        ActorExists(
+            reference::ActorRef<TestActor>,
+            #[reply] reference::OncePortRef<bool>,
+        ),
     }
 
     #[async_trait]
@@ -2918,7 +2918,7 @@ mod tests {
         async fn actor_exists(
             &mut self,
             cx: &crate::Context<Self>,
-            actor_ref: ActorRef<TestActor>,
+            actor_ref: reference::ActorRef<TestActor>,
         ) -> Result<bool, anyhow::Error> {
             Ok(actor_ref.downcast_handle(cx).is_some())
         }
@@ -2947,7 +2947,7 @@ mod tests {
             !lookup_actor
                 .actor_exists(
                     &client,
-                    ActorRef::attest(target_actor.actor_id().child_id(123).clone())
+                    reference::ActorRef::attest(target_actor.actor_id().child_id(123).clone())
                 )
                 .await
                 .unwrap()
@@ -2955,7 +2955,10 @@ mod tests {
         // A wrongly-typed actor ref should also not obtain.
         assert!(
             !lookup_actor
-                .actor_exists(&client, ActorRef::attest(lookup_actor.actor_id().clone()))
+                .actor_exists(
+                    &client,
+                    reference::ActorRef::attest(lookup_actor.actor_id().clone())
+                )
                 .await
                 .unwrap()
         );
@@ -3314,11 +3317,11 @@ mod tests {
         impl Actor for TestActor {}
 
         #[async_trait]
-        impl Handler<(String, PortRef<String>)> for TestActor {
+        impl Handler<(String, reference::PortRef<String>)> for TestActor {
             async fn handle(
                 &mut self,
                 cx: &crate::Context<Self>,
-                (message, port): (String, PortRef<String>),
+                (message, port): (String, reference::PortRef<String>),
             ) -> anyhow::Result<()> {
                 port.send(cx, message)?;
                 Ok(())
@@ -3569,7 +3572,7 @@ mod tests {
     /// have stored the snapshot by the time `handle.await` returns.
     async fn wait_for_terminated_snapshot(
         proc: &Proc,
-        actor_id: &ActorId,
+        actor_id: &reference::ActorId,
     ) -> crate::introspect::NodePayload {
         // Yield to let the introspect task run, then poll. Use a
         // combination of yields (for fast paths) and sleeps (to
@@ -3753,7 +3756,7 @@ mod tests {
         let (_client, _client_handle) = proc.instance("client").unwrap();
 
         let handle = proc.spawn::<TestActor>("target", TestActor).unwrap();
-        let actor_ref: ActorRef<TestActor> = handle.bind();
+        let actor_ref: reference::ActorRef<TestActor> = handle.bind();
 
         // Actor is live — resolve should succeed.
         assert!(

--- a/hyperactor/src/simnet.rs
+++ b/hyperactor/src/simnet.rs
@@ -43,12 +43,11 @@ use tokio::task::JoinError;
 use tokio::task::JoinHandle;
 use tokio::time::interval;
 
-use crate::ActorId;
-use crate::ProcId;
 use crate::channel::ChannelAddr;
 use crate::clock::Clock;
 use crate::clock::RealClock;
 use crate::clock::SimClock;
+use crate::reference;
 
 static HANDLE: OnceLock<SimNetHandle> = OnceLock::new();
 
@@ -140,7 +139,7 @@ pub struct TorchOpEvent {
     done_tx: Arc<Mutex<Option<oneshot::Sender<()>>>>,
     args_string: String,
     kwargs_string: String,
-    worker_actor_id: ActorId,
+    worker_actor_id: reference::ActorId,
 }
 
 #[async_trait]
@@ -188,7 +187,7 @@ impl TorchOpEvent {
         done_tx: oneshot::Sender<()>,
         args_string: String,
         kwargs_string: String,
-        worker_actor_id: ActorId,
+        worker_actor_id: reference::ActorId,
     ) -> Box<Self> {
         Box::new(Self {
             op,
@@ -442,7 +441,7 @@ pub struct SimNetHandle {
     training_script_state_tx: tokio::sync::watch::Sender<TrainingScriptState>,
     /// Signal to stop the simnet loop
     stop_signal: Arc<AtomicBool>,
-    resources: DashMap<ProcId, Point>,
+    resources: DashMap<reference::ProcId, Point>,
     latencies: std::sync::Mutex<LatencyConfig>,
 }
 
@@ -541,12 +540,16 @@ impl SimNetHandle {
     }
 
     /// Register the location in resource space for a Proc
-    pub fn register_proc(&self, proc_id: ProcId, point: Point) {
+    pub fn register_proc(&self, proc_id: reference::ProcId, point: Point) {
         self.resources.insert(proc_id, point);
     }
 
     /// Sample a latency between two procs
-    pub fn sample_latency(&self, src: &ProcId, dest: &ProcId) -> tokio::time::Duration {
+    pub fn sample_latency(
+        &self,
+        src: &reference::ProcId,
+        dest: &reference::ProcId,
+    ) -> tokio::time::Duration {
         let distances = [
             Distance::Region,
             Distance::DataCenter,

--- a/hyperactor/src/spawn.rs
+++ b/hyperactor/src/spawn.rs
@@ -15,10 +15,10 @@ use async_trait::async_trait;
 use crate::actor::Actor;
 use crate::actor::ActorHandle;
 use crate::mailbox::BoxedMailboxSender;
-use crate::reference::ActorId;
+use crate::reference;
 #[derive(Debug)]
 struct LocalSpawnerState {
-    root: ActorId,
+    root: reference::ActorId,
     sender: BoxedMailboxSender,
     next_pid: AtomicU64,
 }
@@ -27,7 +27,7 @@ struct LocalSpawnerState {
 pub(crate) struct LocalSpawner(Option<Arc<LocalSpawnerState>>);
 
 impl LocalSpawner {
-    pub(crate) fn new(root: ActorId, sender: BoxedMailboxSender) -> Self {
+    pub(crate) fn new(root: reference::ActorId, sender: BoxedMailboxSender) -> Self {
         Self(Some(Arc::new(LocalSpawnerState {
             root,
             sender,

--- a/hyperactor/src/supervision.rs
+++ b/hyperactor/src/supervision.rs
@@ -24,14 +24,14 @@ use serde::Serialize;
 use crate as hyperactor; // for macros
 use crate::actor::ActorErrorKind;
 use crate::actor::ActorStatus;
-use crate::reference::ActorId;
+use crate::reference;
 
 /// This is the local actor supervision event. Child actor will propagate this event to its parent.
 #[derive(Clone, Debug, Derivative, Serialize, Deserialize, typeuri::Named)]
 #[derivative(PartialEq, Eq)]
 pub struct ActorSupervisionEvent {
     /// The actor id of the child actor where the event is triggered.
-    pub actor_id: ActorId,
+    pub actor_id: reference::ActorId,
     /// Friendly display name, if the actor class customized it.
     pub display_name: Option<String>,
     /// The time when the event is triggered.
@@ -48,7 +48,7 @@ wirevalue::register_type!(ActorSupervisionEvent);
 impl ActorSupervisionEvent {
     /// Create a new supervision event. Timestamp is set to the current time.
     pub fn new(
-        actor_id: ActorId,
+        actor_id: reference::ActorId,
         display_name: Option<String>,
         actor_status: ActorStatus,
         message_headers: Option<Flattrs>,
@@ -89,7 +89,7 @@ impl ActorSupervisionEvent {
 impl std::error::Error for ActorSupervisionEvent {}
 
 fn fmt_status<'a>(
-    actor_id: &ActorId,
+    actor_id: &reference::ActorId,
     status: &'a ActorStatus,
     f: &mut fmt::Formatter<'_>,
 ) -> Result<Option<&'a ActorSupervisionEvent>, fmt::Error> {

--- a/hyperactor/src/testing/ids.rs
+++ b/hyperactor/src/testing/ids.rs
@@ -13,39 +13,42 @@
 
 use crate::channel::ChannelAddr;
 use crate::channel::ChannelTransport;
-use crate::reference::ActorId;
-use crate::reference::PortId;
-use crate::reference::ProcId;
+use crate::reference;
 
 /// Create a test `ProcId` with a local channel address and name `"test_{name}"`.
-pub fn test_proc_id(name: &str) -> ProcId {
-    ProcId::with_name(
+pub fn test_proc_id(name: &str) -> reference::ProcId {
+    reference::ProcId::with_name(
         ChannelAddr::any(ChannelTransport::Local),
         format!("test_{name}"),
     )
 }
 
 /// Create a test `ProcId` with a custom address and name `"test_{name}"`.
-pub fn test_proc_id_with_addr(addr: ChannelAddr, name: &str) -> ProcId {
-    ProcId::with_name(addr, format!("test_{name}"))
+pub fn test_proc_id_with_addr(addr: ChannelAddr, name: &str) -> reference::ProcId {
+    reference::ProcId::with_name(addr, format!("test_{name}"))
 }
 
 /// Create a test `ActorId` with pid 0.
-pub fn test_actor_id(proc_name: &str, actor_name: &str) -> ActorId {
+pub fn test_actor_id(proc_name: &str, actor_name: &str) -> reference::ActorId {
     test_proc_id(proc_name).actor_id(actor_name, 0)
 }
 
 /// Create a test `ActorId` with a custom pid.
-pub fn test_actor_id_with_pid(proc_name: &str, actor_name: &str, pid: usize) -> ActorId {
+pub fn test_actor_id_with_pid(proc_name: &str, actor_name: &str, pid: usize) -> reference::ActorId {
     test_proc_id(proc_name).actor_id(actor_name, pid)
 }
 
 /// Create a test `PortId` with pid 0.
-pub fn test_port_id(proc_name: &str, actor_name: &str, port: u64) -> PortId {
-    PortId::new(test_actor_id(proc_name, actor_name), port)
+pub fn test_port_id(proc_name: &str, actor_name: &str, port: u64) -> reference::PortId {
+    reference::PortId::new(test_actor_id(proc_name, actor_name), port)
 }
 
 /// Create a test `PortId` with a custom pid.
-pub fn test_port_id_with_pid(proc_name: &str, actor_name: &str, pid: usize, port: u64) -> PortId {
-    PortId::new(test_actor_id_with_pid(proc_name, actor_name, pid), port)
+pub fn test_port_id_with_pid(
+    proc_name: &str,
+    actor_name: &str,
+    pid: usize,
+    port: u64,
+) -> reference::PortId {
+    reference::PortId::new(test_actor_id_with_pid(proc_name, actor_name, pid), port)
 }

--- a/hyperactor/src/testing/pingpong.rs
+++ b/hyperactor/src/testing/pingpong.rs
@@ -15,25 +15,27 @@ use serde::Serialize;
 
 use crate as hyperactor; // for macros
 use crate::Actor;
-use crate::ActorRef;
 use crate::Context;
 use crate::Handler;
 use crate::Instance;
-use crate::OncePortRef;
-use crate::PortRef;
 use crate::RemoteSpawn;
 use crate::clock::Clock;
 use crate::clock::RealClock;
 use crate::mailbox::MessageEnvelope;
 use crate::mailbox::Undeliverable;
 use crate::mailbox::UndeliverableMessageError;
+use crate::reference;
 
 /// A message that can be passed around. It contains
 /// 0. the TTL of this PingPong game
 /// 1. the next actor to send the message to
 /// 2. a port to send a true value to when TTL = 0.
 #[derive(Serialize, Deserialize, Debug, typeuri::Named)]
-pub struct PingPongMessage(pub u64, pub ActorRef<PingPongActor>, pub OncePortRef<bool>);
+pub struct PingPongMessage(
+    pub u64,
+    pub reference::ActorRef<PingPongActor>,
+    pub reference::OncePortRef<bool>,
+);
 wirevalue::register_type!(PingPongMessage);
 
 /// A PingPong actor that can play the PingPong game by sending messages around.
@@ -41,7 +43,7 @@ wirevalue::register_type!(PingPongMessage);
 #[hyperactor::export(spawn = true, handlers = [PingPongMessage])]
 pub struct PingPongActor {
     /// A port to send undeliverable messages to.
-    undeliverable_port_ref: Option<PortRef<Undeliverable<MessageEnvelope>>>,
+    undeliverable_port_ref: Option<reference::PortRef<Undeliverable<MessageEnvelope>>>,
     /// The TTL at which the actor will exit with error.
     error_ttl: Option<u64>,
     /// Manual delay before sending handling the message.
@@ -55,7 +57,7 @@ impl PingPongActor {
     /// - `error_ttl`: The TTL at which the actor will exit with error.
     /// - `delay`: Manual delay before sending handling the message.
     pub fn new(
-        undeliverable_port_ref: Option<PortRef<Undeliverable<MessageEnvelope>>>,
+        undeliverable_port_ref: Option<reference::PortRef<Undeliverable<MessageEnvelope>>>,
         error_ttl: Option<u64>,
         delay: Option<Duration>,
     ) -> Self {
@@ -70,7 +72,7 @@ impl PingPongActor {
 #[async_trait]
 impl RemoteSpawn for PingPongActor {
     type Params = (
-        Option<PortRef<Undeliverable<MessageEnvelope>>>,
+        Option<reference::PortRef<Undeliverable<MessageEnvelope>>>,
         Option<u64>,
         Option<Duration>,
     );

--- a/hyperactor_macros/src/lib.rs
+++ b/hyperactor_macros/src/lib.rs
@@ -538,9 +538,9 @@ fn parse_messages(input: DeriveInput) -> Result<Vec<Message>, syn::Error> {
 /// use hyperactor::HandleClient;
 /// use hyperactor::Handler;
 /// use hyperactor::Instance;
-/// use hyperactor::OncePortRef;
 /// use hyperactor::RefClient;
 /// use hyperactor::proc::Proc;
+/// use hyperactor::reference;
 /// use serde::Deserialize;
 /// use serde::Serialize;
 /// use typeuri::Named;
@@ -553,9 +553,9 @@ fn parse_messages(input: DeriveInput) -> Result<Vec<Message>, syn::Error> {
 ///
 ///     // Call messages dispatch a request, expecting a reply to the
 ///     // provided port, which must be in the last position.
-///     Exists(String, #[reply] OncePortRef<bool>),
+///     Exists(String, #[reply] reference::OncePortRef<bool>),
 ///
-///     List(#[reply] OncePortRef<Vec<String>>),
+///     List(#[reply] reference::OncePortRef<Vec<String>>),
 /// }
 ///
 /// // Define an actor.

--- a/hyperactor_macros/tests/basic.rs
+++ b/hyperactor_macros/tests/basic.rs
@@ -18,11 +18,11 @@ use hyperactor::Actor;
 use hyperactor::Context;
 use hyperactor::HandleClient;
 use hyperactor::Handler;
-use hyperactor::OncePortRef;
 use hyperactor::RefClient;
 use hyperactor::handle;
 use hyperactor::instrument;
 use hyperactor::instrument_infallible;
+use hyperactor::reference;
 use serde::Deserialize;
 use serde::Serialize;
 use typeuri::Named;
@@ -37,13 +37,13 @@ enum ShoppingList {
 
     // Call messages dispatch a request, expecting a reply to the
     // provided port, which must be in the last position.
-    Exists(String, #[reply] OncePortRef<bool>),
+    Exists(String, #[reply] reference::OncePortRef<bool>),
 
     // Tests macro hygience. We use 'result' as a keyword in the implementation.
     Clobber {
         arg: String,
         #[reply]
-        result: OncePortRef<bool>,
+        result: reference::OncePortRef<bool>,
     },
 }
 
@@ -65,16 +65,16 @@ enum TestVariantForms {
     CallStruct {
         a: u64,
         #[reply]
-        b: OncePortRef<u64>,
+        b: reference::OncePortRef<u64>,
     },
 
-    CallTuple(u64, #[reply] OncePortRef<u64>),
+    CallTuple(u64, #[reply] reference::OncePortRef<u64>),
 
-    CallTupleNoArgs(#[reply] OncePortRef<u64>),
+    CallTupleNoArgs(#[reply] reference::OncePortRef<u64>),
 
     CallStructNoArgs {
         #[reply]
-        a: OncePortRef<u64>,
+        a: reference::OncePortRef<u64>,
     },
 }
 

--- a/hyperactor_macros/tests/castable.rs
+++ b/hyperactor_macros/tests/castable.rs
@@ -9,10 +9,10 @@
 #![allow(dead_code)]
 
 use hyperactor::Bind;
-use hyperactor::PortRef;
 use hyperactor::Unbind;
 use hyperactor::message::Bind;
 use hyperactor::message::Unbind;
+use hyperactor::reference;
 use serde::Deserialize;
 use serde::Serialize;
 use typeuri::Named;
@@ -34,19 +34,19 @@ struct MyNamedStruct {
     field0: u64,
     field1: MyReply,
     #[binding(include)]
-    field2: PortRef<MyReply>,
+    field2: reference::PortRef<MyReply>,
     field3: bool,
     #[binding(include)]
-    field4: hyperactor::PortRef<u64>,
+    field4: hyperactor::reference::PortRef<u64>,
 }
 
 #[derive(Clone, Debug, PartialEq, Bind, Unbind)]
 struct MyUnamedStruct(
     u64,
     MyReply,
-    #[binding(include)] hyperactor::PortRef<MyReply>,
+    #[binding(include)] hyperactor::reference::PortRef<MyReply>,
     bool,
-    #[binding(include)] PortRef<u64>,
+    #[binding(include)] reference::PortRef<u64>,
 );
 
 #[derive(Clone, Debug, PartialEq, Bind, Unbind)]
@@ -65,18 +65,18 @@ enum MyEnum {
     Tuple(
         u64,
         MyReply,
-        #[binding(include)] PortRef<MyReply>,
+        #[binding(include)] reference::PortRef<MyReply>,
         bool,
-        #[binding(include)] hyperactor::PortRef<u64>,
+        #[binding(include)] hyperactor::reference::PortRef<u64>,
     ),
     Struct {
         field0: u64,
         field1: MyReply,
         #[binding(include)]
-        field2: PortRef<MyReply>,
+        field2: reference::PortRef<MyReply>,
         field3: bool,
         #[binding(include)]
-        field4: hyperactor::PortRef<u64>,
+        field4: hyperactor::reference::PortRef<u64>,
     },
 }
 
@@ -113,8 +113,8 @@ mod tests {
     fn test_named_struct() {
         let port_id2 = test_port_id("world_0", "comm", 2);
         let port_id4 = test_port_id("world_1", "worker", 4);
-        let port2 = PortRef::attest(port_id2.clone());
-        let port4 = PortRef::attest(port_id4.clone());
+        let port2 = reference::PortRef::attest(port_id2.clone());
+        let port4 = reference::PortRef::attest(port_id4.clone());
         let my_struct = MyNamedStruct {
             field0: 11,
             field1: MyReply("hello".to_string()),
@@ -132,8 +132,8 @@ mod tests {
     fn test_unnamed_struct() {
         let port_id2 = test_port_id("world_0", "comm", 2);
         let port_id4 = test_port_id("world_1", "worker", 4);
-        let port2 = PortRef::attest(port_id2.clone());
-        let port4 = PortRef::attest(port_id4.clone());
+        let port2 = reference::PortRef::attest(port_id2.clone());
+        let port4 = reference::PortRef::attest(port_id4.clone());
         let my_struct = MyUnamedStruct(
             11,
             MyReply("hello".to_string()),
@@ -151,8 +151,8 @@ mod tests {
     fn test_named_enum() {
         let port_id2 = test_port_id("world_0", "comm", 2);
         let port_id4 = test_port_id("world_1", "worker", 4);
-        let port2 = PortRef::attest(port_id2.clone());
-        let port4 = PortRef::attest(port_id4.clone());
+        let port2 = reference::PortRef::attest(port_id2.clone());
+        let port4 = reference::PortRef::attest(port_id4.clone());
         let my_enum = MyEnum::Struct {
             field0: 11,
             field1: MyReply("hello".to_string()),
@@ -170,8 +170,8 @@ mod tests {
     fn test_unnamed_enum() {
         let port_id2 = test_port_id("world_0", "comm", 2);
         let port_id4 = test_port_id("world_1", "worker", 4);
-        let port2 = PortRef::attest(port_id2.clone());
-        let port4 = PortRef::attest(port_id4.clone());
+        let port2 = reference::PortRef::attest(port_id2.clone());
+        let port4 = reference::PortRef::attest(port_id4.clone());
         let my_enum = MyEnum::Tuple(
             11,
             MyReply("hello".to_string()),
@@ -196,8 +196,8 @@ mod tests {
     fn test_my_generic_struct() {
         let port_id2 = test_port_id("world_0", "comm", 2);
         let port_id4 = test_port_id("world_1", "worker", 4);
-        let port2: PortRef<()> = PortRef::attest(port_id2.clone());
-        let port4: PortRef<()> = PortRef::attest(port_id4.clone());
+        let port2: reference::PortRef<()> = reference::PortRef::attest(port_id2.clone());
+        let port4: reference::PortRef<()> = reference::PortRef::attest(port_id4.clone());
         let my_struct = MyGenericStruct(port2.clone(), &11, port4.clone());
         let mut bindings = Bindings::default();
         port2.unbind(&mut bindings).unwrap();
@@ -208,8 +208,8 @@ mod tests {
     fn test_my_generic_enum() {
         let port_id2 = test_port_id("world_0", "comm", 2);
         let port_id4 = test_port_id("world_1", "worker", 4);
-        let port2: PortRef<()> = PortRef::attest(port_id2.clone());
-        let port4: PortRef<()> = PortRef::attest(port_id4.clone());
+        let port2: reference::PortRef<()> = reference::PortRef::attest(port_id2.clone());
+        let port4: reference::PortRef<()> = reference::PortRef::attest(port_id4.clone());
         let my_enum = MyGenericEnum::Tuple(port2.clone(), &11, port4.clone());
         let mut bindings = Bindings::default();
         port2.unbind(&mut bindings).unwrap();

--- a/hyperactor_macros/tests/export.rs
+++ b/hyperactor_macros/tests/export.rs
@@ -11,8 +11,8 @@ use hyperactor::Actor;
 use hyperactor::Bind;
 use hyperactor::Context;
 use hyperactor::Handler;
-use hyperactor::PortRef;
 use hyperactor::Unbind;
+use hyperactor::reference;
 use serde::Deserialize;
 use serde::Serialize;
 use typeuri::Named;
@@ -29,11 +29,11 @@ use typeuri::Named;
 struct TestActor {
     // Forward the received message to this port, so it can be inspected by
     // the unit test.
-    forward_port: PortRef<String>,
+    forward_port: reference::PortRef<String>,
 }
 
 impl TestActor {
-    fn new(forward_port: PortRef<String>) -> Self {
+    fn new(forward_port: reference::PortRef<String>) -> Self {
         Self { forward_port }
     }
 }
@@ -88,8 +88,6 @@ hyperactor::behavior!(
 
 #[cfg(test)]
 mod tests {
-    use hyperactor::ActorRef;
-    use hyperactor::PortRef;
     use hyperactor::message::ErasedUnbound;
     use hyperactor::message::IndexedErasedUnbound;
     use hyperactor::proc::Proc;
@@ -113,7 +111,7 @@ mod tests {
         {
             // TestMessage type
             let port_id = actor_handle.actor_id().port_id(TestMessage::port());
-            let port_ref: PortRef<TestMessage> = PortRef::attest(port_id);
+            let port_ref: reference::PortRef<TestMessage> = reference::PortRef::attest(port_id);
             port_ref
                 .send(&client, TestMessage("abc".to_string()))
                 .unwrap();
@@ -122,21 +120,21 @@ mod tests {
         {
             // () type
             let port_id = actor_handle.actor_id().port_id(<()>::port());
-            let port_ref: PortRef<()> = PortRef::attest(port_id);
+            let port_ref: reference::PortRef<()> = reference::PortRef::attest(port_id);
             port_ref.send(&client, ()).unwrap();
             assert_eq!(rx.recv().await.unwrap(), "()");
         }
         {
             // u64 type
             let port_id = actor_handle.actor_id().port_id(<u64>::port());
-            let port_ref: PortRef<u64> = PortRef::attest(port_id);
+            let port_ref: reference::PortRef<u64> = reference::PortRef::attest(port_id);
             port_ref.send(&client, 987654321).unwrap();
             assert_eq!(rx.recv().await.unwrap(), "u64: 987654321");
         }
         {
             // MyGeneric<()> type
             let port_id = actor_handle.actor_id().port_id(MyGeneric::<()>::port());
-            let port_ref: PortRef<MyGeneric<()>> = PortRef::attest(port_id);
+            let port_ref: reference::PortRef<MyGeneric<()>> = reference::PortRef::attest(port_id);
             port_ref.send(&client, MyGeneric(())).unwrap();
             assert_eq!(rx.recv().await.unwrap(), "MyGeneric<()>");
         }
@@ -149,7 +147,8 @@ mod tests {
             let port_id = actor_handle
                 .actor_id()
                 .port_id(<IndexedErasedUnbound<TestMessage>>::port());
-            let port_ref: PortRef<IndexedErasedUnbound<TestMessage>> = PortRef::attest(port_id);
+            let port_ref: reference::PortRef<IndexedErasedUnbound<TestMessage>> =
+                reference::PortRef::attest(port_id);
             port_ref.send(&client, indexed_msg).unwrap();
             assert_eq!(rx.recv().await.unwrap(), "efg");
         }
@@ -161,7 +160,8 @@ mod tests {
             let port_id = actor_handle
                 .actor_id()
                 .port_id(<IndexedErasedUnbound<()>>::port());
-            let port_ref: PortRef<IndexedErasedUnbound<()>> = PortRef::attest(port_id);
+            let port_ref: reference::PortRef<IndexedErasedUnbound<()>> =
+                reference::PortRef::attest(port_id);
             port_ref.send(&client, indexed_msg).unwrap();
             assert_eq!(rx.recv().await.unwrap(), "()");
         }
@@ -173,7 +173,8 @@ mod tests {
             let port_id = actor_handle
                 .actor_id()
                 .port_id(<IndexedErasedUnbound<MyGeneric<()>>>::port());
-            let port_ref: PortRef<IndexedErasedUnbound<MyGeneric<()>>> = PortRef::attest(port_id);
+            let port_ref: reference::PortRef<IndexedErasedUnbound<MyGeneric<()>>> =
+                reference::PortRef::attest(port_id);
             port_ref.send(&client, indexed_msg).unwrap();
             assert_eq!(rx.recv().await.unwrap(), "MyGeneric<()>");
         }
@@ -191,7 +192,7 @@ mod tests {
             .send(&client, TestMessage("foo".to_string()))
             .unwrap();
 
-        let myref: ActorRef<TestActorAlias> = actor_handle.bind();
+        let myref: reference::ActorRef<TestActorAlias> = actor_handle.bind();
         myref.port().send(&client, MyGeneric(())).unwrap();
         myref
             .port()

--- a/hyperactor_mesh/benches/bench_actor.rs
+++ b/hyperactor_mesh/benches/bench_actor.rs
@@ -14,10 +14,10 @@ use hyperactor::Actor;
 use hyperactor::Bind;
 use hyperactor::Context;
 use hyperactor::Handler;
-use hyperactor::PortRef;
 use hyperactor::RemoteSpawn;
 use hyperactor::Unbind;
 use hyperactor::clock::Clock;
+use hyperactor::reference;
 use hyperactor_config::Flattrs;
 use serde::Deserialize;
 use serde::Serialize;
@@ -26,7 +26,7 @@ use typeuri::Named;
 #[derive(Debug, Clone, Serialize, Deserialize, Named, Bind, Unbind)]
 pub struct BenchMessage {
     pub step: usize,
-    pub reply: PortRef<usize>,
+    pub reply: reference::PortRef<usize>,
     #[serde(with = "serde_bytes")]
     pub payload: Vec<u8>,
 }

--- a/hyperactor_mesh/bin/admin_tui/format.rs
+++ b/hyperactor_mesh/bin/admin_tui/format.rs
@@ -9,10 +9,9 @@
 use std::str::FromStr;
 use std::time::Duration;
 
-use hyperactor::ActorId;
-use hyperactor::ProcId;
 use hyperactor::introspect::NodePayload;
 use hyperactor::introspect::NodeProperties;
+use hyperactor::reference as hyperactor_reference;
 use serde_json::Value;
 
 /// Derive a human-friendly label for a resolved node payload.
@@ -45,7 +44,7 @@ pub(crate) fn derive_label(payload: &NodePayload) -> String {
             failed_actor_count,
             ..
         } => {
-            let short = ProcId::from_str(proc_name)
+            let short = hyperactor_reference::ProcId::from_str(proc_name)
                 .map(|pid| pid.name().to_string())
                 .unwrap_or_else(|_| proc_name.clone());
             let num_system = system_children.len();
@@ -77,10 +76,12 @@ pub(crate) fn derive_label(payload: &NodePayload) -> String {
                 base
             }
         }
-        NodeProperties::Actor { .. } => match ActorId::from_str(&payload.identity) {
-            Ok(actor_id) => format!("{}[{}]", actor_id.name(), actor_id.pid()),
-            Err(_) => payload.identity.clone(),
-        },
+        NodeProperties::Actor { .. } => {
+            match hyperactor_reference::ActorId::from_str(&payload.identity) {
+                Ok(actor_id) => format!("{}[{}]", actor_id.name(), actor_id.pid()),
+                Err(_) => payload.identity.clone(),
+            }
+        }
         NodeProperties::Error { code, message } => {
             format!("[error] {}: {}", code, message)
         }
@@ -93,7 +94,7 @@ pub(crate) fn derive_label(payload: &NodePayload) -> String {
 /// If the reference parses as an `ActorId`, format it as `name[pid]`;
 /// otherwise fall back to showing the raw reference.
 pub(crate) fn derive_label_from_ref(reference: &str) -> String {
-    match ActorId::from_str(reference) {
+    match hyperactor_reference::ActorId::from_str(reference) {
         Ok(actor_id) => format!("{}[{}]", actor_id.name(), actor_id.pid()),
         Err(_) => reference.to_string(),
     }

--- a/hyperactor_mesh/bin/admin_tui/render/detail_pane.rs
+++ b/hyperactor_mesh/bin/admin_tui/render/detail_pane.rs
@@ -8,11 +8,11 @@
 
 use std::str::FromStr;
 
-use hyperactor::ProcId;
 use hyperactor::introspect::FailureInfo;
 use hyperactor::introspect::NodePayload;
 use hyperactor::introspect::NodeProperties;
 use hyperactor::introspect::RecordedEvent;
+use hyperactor::reference as hyperactor_reference;
 use ratatui::layout::Constraint;
 use ratatui::layout::Direction;
 use ratatui::layout::Layout;
@@ -245,7 +245,7 @@ fn render_host_detail(
         Line::default(),
     ];
     for child in &payload.children {
-        let short = ProcId::from_str(child)
+        let short = hyperactor_reference::ProcId::from_str(child)
             .map(|pid| pid.name().to_string())
             .unwrap_or_else(|_| child.clone());
         lines.push(Line::from(vec![

--- a/hyperactor_mesh/examples/dining_philosophers.rs
+++ b/hyperactor_mesh/examples/dining_philosophers.rs
@@ -20,10 +20,10 @@ use hyperactor::Bind;
 use hyperactor::Context;
 use hyperactor::Handler;
 use hyperactor::Instance;
-use hyperactor::PortRef;
 use hyperactor::RemoteSpawn;
 use hyperactor::Unbind;
 use hyperactor::context;
+use hyperactor::reference;
 use hyperactor_config::Flattrs;
 use hyperactor_mesh::ActorMesh;
 use hyperactor_mesh::ActorMeshRef;
@@ -71,13 +71,13 @@ struct PhilosopherActor {
     /// Total size of the group.
     size: usize,
     /// The waiter's port
-    waiter: OnceCell<PortRef<WaiterMessage>>,
+    waiter: OnceCell<reference::PortRef<WaiterMessage>>,
 }
 
 /// Message from the waiter to a philosopher
 #[derive(Debug, Serialize, Deserialize, Named, Clone, Bind, Unbind)]
 enum PhilosopherMessage {
-    Start(#[binding(include)] PortRef<WaiterMessage>),
+    Start(#[binding(include)] reference::PortRef<WaiterMessage>),
     GrantChopstick(usize),
 }
 

--- a/hyperactor_mesh/examples/sieve.rs
+++ b/hyperactor_mesh/examples/sieve.rs
@@ -22,10 +22,10 @@ use hyperactor::Actor;
 use hyperactor::ActorHandle;
 use hyperactor::Context;
 use hyperactor::Handler;
-use hyperactor::PortRef;
 use hyperactor::RemoteSpawn;
 use hyperactor::clock::Clock;
 use hyperactor::clock::RealClock;
+use hyperactor::reference;
 use hyperactor_config::Flattrs;
 use hyperactor_mesh::context;
 use hyperactor_mesh::this_host;
@@ -58,7 +58,7 @@ pub struct NextNumber {
     /// Candidate number to test.
     pub number: u64,
     /// Port for reporting discovered primes.
-    pub prime_collector: PortRef<u64>,
+    pub prime_collector: reference::PortRef<u64>,
 }
 
 /// Parameters for spawning a `SieveActor`.

--- a/hyperactor_mesh/examples/test_bench.rs
+++ b/hyperactor_mesh/examples/test_bench.rs
@@ -19,10 +19,10 @@ use hyperactor::Actor;
 use hyperactor::Bind;
 use hyperactor::Context;
 use hyperactor::Handler;
-use hyperactor::PortRef;
 use hyperactor::Unbind;
 use hyperactor::clock::Clock;
 use hyperactor::clock::RealClock;
+use hyperactor::reference;
 use hyperactor_mesh::actor_mesh::ActorMesh;
 use hyperactor_mesh::bootstrap::BootstrapCommand;
 use hyperactor_mesh::comm::multicast::CastInfo;
@@ -48,7 +48,7 @@ impl Actor for TestActor {}
 
 #[derive(Debug, Serialize, Deserialize, Named, Clone, Bind, Unbind)]
 enum TestMessage {
-    Ping(#[binding(include)] PortRef<Point>),
+    Ping(#[binding(include)] reference::PortRef<Point>),
 }
 
 #[async_trait]

--- a/hyperactor_mesh/src/actor_mesh.rs
+++ b/hyperactor_mesh/src/actor_mesh.rs
@@ -16,8 +16,6 @@ use std::sync::OnceLock as OnceCell;
 use std::time::Duration;
 
 use hyperactor::ActorLocal;
-use hyperactor::ActorRef;
-use hyperactor::PortRef;
 use hyperactor::RemoteHandles;
 use hyperactor::RemoteMessage;
 use hyperactor::actor::ActorStatus;
@@ -29,6 +27,7 @@ use hyperactor::mailbox::PortReceiver;
 use hyperactor::message::Castable;
 use hyperactor::message::IndexedErasedUnbound;
 use hyperactor::message::Unbound;
+use hyperactor::reference as hyperactor_reference;
 use hyperactor::supervision::ActorSupervisionEvent;
 use hyperactor_config::CONFIG;
 use hyperactor_config::ConfigAttr;
@@ -82,7 +81,7 @@ declare_attrs! {
 /// An ActorMesh is a collection of ranked A-typed actors.
 ///
 /// Bound note: `A: Referable` because the mesh stores/returns
-/// `ActorRef<A>`, which is only defined for `A: Referable`.
+/// `hyperactor_reference::ActorRef<A>`, which is only defined for `A: Referable`.
 #[derive(Debug)]
 pub struct ActorMesh<A: Referable> {
     proc_mesh: ProcMeshRef,
@@ -93,16 +92,16 @@ pub struct ActorMesh<A: Referable> {
     /// supervision events via subscribing.
     /// It may not be present for some types of actors, typically system actors
     /// such as ProcAgent or CommActor.
-    controller: Option<ActorRef<ActorMeshController<A>>>,
+    controller: Option<hyperactor_reference::ActorRef<ActorMeshController<A>>>,
 }
 
 // `A: Referable` for the same reason as the struct: the mesh holds
-// `ActorRef<A>`.
+// `hyperactor_reference::ActorRef<A>`.
 impl<A: Referable> ActorMesh<A> {
     pub(crate) fn new(
         proc_mesh: ProcMeshRef,
         name: Name,
-        controller: Option<ActorRef<ActorMeshController<A>>>,
+        controller: Option<hyperactor_reference::ActorRef<ActorMeshController<A>>>,
     ) -> Self {
         let current_ref = ActorMeshRef::with_page_size(
             name.clone(),
@@ -123,7 +122,10 @@ impl<A: Referable> ActorMesh<A> {
         &self.name
     }
 
-    pub(crate) fn set_controller(&mut self, controller: Option<ActorRef<ActorMeshController<A>>>) {
+    pub(crate) fn set_controller(
+        &mut self,
+        controller: Option<hyperactor_reference::ActorRef<ActorMeshController<A>>>,
+    ) {
         self.controller = controller.clone();
         self.current_ref.set_controller(controller);
     }
@@ -257,7 +259,7 @@ const DEFAULT_PAGE: usize = 1024;
 
 /// A lazily materialized page of ActorRefs.
 struct Page<A: Referable> {
-    slots: Box<[OnceCell<ActorRef<A>>]>,
+    slots: Box<[OnceCell<hyperactor_reference::ActorRef<A>>]>,
 }
 
 impl<A: Referable> Page<A> {
@@ -365,7 +367,7 @@ pub struct ActorMeshRef<A: Referable> {
     /// not be stopped. If Some, the actor mesh may still be stopped, and the
     /// next_supervision_event function can be used to alert that the mesh has
     /// stopped.
-    controller: Option<ActorRef<ActorMeshController<A>>>,
+    controller: Option<hyperactor_reference::ActorRef<ActorMeshController<A>>>,
 
     /// Recorded health issues with the mesh, to quickly consult before sending
     /// out any casted messages. This is a locally updated copy of the authoritative
@@ -378,7 +380,7 @@ pub struct ActorMeshRef<A: Referable> {
     receiver: ActorLocal<
         Arc<
             tokio::sync::Mutex<(
-                PortRef<Option<MeshFailure>>,
+                hyperactor_reference::PortRef<Option<MeshFailure>>,
                 watch::Receiver<MessageOrFailure<Option<MeshFailure>>>,
             )>,
         >,
@@ -389,7 +391,7 @@ pub struct ActorMeshRef<A: Referable> {
     /// - The `Vec` holds slots for multiple pages.
     /// - Each slot is itself a `OnceCell<Box<Page<A>>>`, so that each
     ///   page can be initialized on demand.
-    /// - A `Page<A>` is a boxed slice of `OnceCell<ActorRef<A>>`,
+    /// - A `Page<A>` is a boxed slice of `OnceCell<hyperactor_reference::ActorRef<A>>`,
     ///   i.e. the actual storage for actor references within that
     ///   page.
     pages: OnceCell<Vec<OnceCell<Box<Page<A>>>>>,
@@ -523,7 +525,7 @@ impl<A: Referable> ActorMeshRef<A> {
     pub(crate) fn new(
         name: Name,
         proc_mesh: ProcMeshRef,
-        controller: Option<ActorRef<ActorMeshController<A>>>,
+        controller: Option<hyperactor_reference::ActorRef<ActorMeshController<A>>>,
     ) -> Self {
         Self::with_page_size(name, proc_mesh, DEFAULT_PAGE, controller)
     }
@@ -536,7 +538,7 @@ impl<A: Referable> ActorMeshRef<A> {
         name: Name,
         proc_mesh: ProcMeshRef,
         page_size: usize,
-        controller: Option<ActorRef<ActorMeshController<A>>>,
+        controller: Option<hyperactor_reference::ActorRef<ActorMeshController<A>>>,
     ) -> Self {
         Self {
             proc_mesh,
@@ -558,11 +560,14 @@ impl<A: Referable> ActorMeshRef<A> {
         view::Ranked::region(&self.proc_mesh).num_ranks()
     }
 
-    pub fn controller(&self) -> &Option<ActorRef<ActorMeshController<A>>> {
+    pub fn controller(&self) -> &Option<hyperactor_reference::ActorRef<ActorMeshController<A>>> {
         &self.controller
     }
 
-    fn set_controller(&mut self, controller: Option<ActorRef<ActorMeshController<A>>>) {
+    fn set_controller(
+        &mut self,
+        controller: Option<hyperactor_reference::ActorRef<ActorMeshController<A>>>,
+    ) {
         self.controller = controller;
     }
 
@@ -572,7 +577,7 @@ impl<A: Referable> ActorMeshRef<A> {
             .get_or_init(|| (0..n).map(|_| OnceCell::new()).collect())
     }
 
-    fn materialize(&self, rank: usize) -> Option<&ActorRef<A>> {
+    fn materialize(&self, rank: usize) -> Option<&hyperactor_reference::ActorRef<A>> {
         let len = self.len();
         if rank >= len {
             return None;
@@ -610,10 +615,10 @@ impl<A: Referable> ActorMeshRef<A> {
     }
 
     fn init_supervision_receiver(
-        controller: &ActorRef<ActorMeshController<A>>,
+        controller: &hyperactor_reference::ActorRef<ActorMeshController<A>>,
         cx: &impl context::Actor,
     ) -> (
-        PortRef<Option<MeshFailure>>,
+        hyperactor_reference::PortRef<Option<MeshFailure>>,
         watch::Receiver<MessageOrFailure<Option<MeshFailure>>>,
     ) {
         let (tx, rx) = cx.mailbox().open_port();
@@ -826,10 +831,11 @@ impl<'de, A: Referable> Deserialize<'de> for ActorMeshRef<A> {
     where
         D: Deserializer<'de>,
     {
-        let (proc_mesh, name, controller) =
-            <(ProcMeshRef, Name, Option<ActorRef<ActorMeshController<A>>>)>::deserialize(
-                deserializer,
-            )?;
+        let (proc_mesh, name, controller) = <(
+            ProcMeshRef,
+            Name,
+            Option<hyperactor_reference::ActorRef<ActorMeshController<A>>>,
+        )>::deserialize(deserializer)?;
         Ok(ActorMeshRef::with_page_size(
             name,
             proc_mesh,
@@ -840,7 +846,7 @@ impl<'de, A: Referable> Deserialize<'de> for ActorMeshRef<A> {
 }
 
 impl<A: Referable> view::Ranked for ActorMeshRef<A> {
-    type Item = ActorRef<A>;
+    type Item = hyperactor_reference::ActorRef<A>;
 
     #[inline]
     fn region(&self) -> &Region {

--- a/hyperactor_mesh/src/alloc.rs
+++ b/hyperactor_mesh/src/alloc.rs
@@ -24,10 +24,10 @@ use std::fmt;
 
 use async_trait::async_trait;
 use enum_as_inner::EnumAsInner;
-use hyperactor::ActorRef;
 use hyperactor::channel::ChannelAddr;
 use hyperactor::channel::ChannelTransport;
 use hyperactor::channel::TlsAddr;
+use hyperactor::reference as hyperactor_reference;
 pub use local::LocalAlloc;
 pub use local::LocalAllocator;
 use mockall::predicate::*;
@@ -187,7 +187,7 @@ pub enum ProcState {
         /// The address the host is serving on.
         host_addr: ChannelAddr,
         /// Reference to this host's mesh agent.
-        host_agent: ActorRef<HostAgent>,
+        host_agent: hyperactor_reference::ActorRef<HostAgent>,
     },
     /// A proc was stopped.
     Stopped {
@@ -352,7 +352,7 @@ pub trait Alloc {
 pub(crate) struct AllocatedHost {
     pub create_key: ShortUuid,
     pub host_addr: ChannelAddr,
-    pub host_agent: ActorRef<HostAgent>,
+    pub host_agent: hyperactor_reference::ActorRef<HostAgent>,
 }
 
 /// Extension trait that drives an [`Alloc`] to collect host information.

--- a/hyperactor_mesh/src/alloc/local.rs
+++ b/hyperactor_mesh/src/alloc/local.rs
@@ -14,10 +14,10 @@ use std::collections::HashMap;
 use std::collections::VecDeque;
 
 use async_trait::async_trait;
-use hyperactor::ActorRef;
 use hyperactor::channel::ChannelAddr;
 use hyperactor::host::Host;
 use hyperactor::host::LocalProcManager;
+use hyperactor::reference as hyperactor_reference;
 use ndslice::view::Extent;
 use tokio::sync::mpsc;
 
@@ -66,7 +66,7 @@ impl Allocator for LocalAllocator {
 struct LocalProc {
     create_key: ShortUuid,
     host_addr: ChannelAddr,
-    host_agent: ActorRef<HostAgent>,
+    host_agent: hyperactor_reference::ActorRef<HostAgent>,
 }
 
 /// A local allocation. It is a collection of procs that are running in the local process.

--- a/hyperactor_mesh/src/alloc/process.rs
+++ b/hyperactor_mesh/src/alloc/process.rs
@@ -17,11 +17,11 @@ use std::sync::Arc;
 use std::sync::OnceLock;
 
 use async_trait::async_trait;
-use hyperactor::ProcId;
 use hyperactor::channel;
 use hyperactor::channel::ChannelAddr;
 use hyperactor::channel::ChannelTransport;
 use hyperactor::channel::Rx;
+use hyperactor::reference as hyperactor_reference;
 use hyperactor::sync::flag;
 use hyperactor::sync::monitor;
 use ndslice::view::Extent;
@@ -166,7 +166,7 @@ impl Child {
         mut process: tokio::process::Child,
         log_channel: Option<ChannelAddr>,
         tail_size: usize,
-        proc_id: ProcId,
+        proc_id: hyperactor_reference::ProcId,
     ) -> (Self, impl Future<Output = ProcStopReason>) {
         let (group, handle) = monitor::group();
         let (exit_flag, exit_guard) = flag::guarded();
@@ -349,12 +349,16 @@ impl ProcessAlloc {
     // the process.
 
     #[hyperactor::instrument_infallible]
-    fn stop(&mut self, proc_id: &ProcId, reason: ProcStopReason) -> Result<(), anyhow::Error> {
+    fn stop(
+        &mut self,
+        proc_id: &hyperactor_reference::ProcId,
+        reason: ProcStopReason,
+    ) -> Result<(), anyhow::Error> {
         self.get_mut(proc_id)?.stop(reason);
         Ok(())
     }
 
-    fn get(&self, proc_id: &ProcId) -> Result<&Child, anyhow::Error> {
+    fn get(&self, proc_id: &hyperactor_reference::ProcId) -> Result<&Child, anyhow::Error> {
         self.active.get(&self.index(proc_id)?).ok_or_else(|| {
             anyhow::anyhow!(
                 "proc {} not currently active in alloc {}",
@@ -364,7 +368,10 @@ impl ProcessAlloc {
         })
     }
 
-    fn get_mut(&mut self, proc_id: &ProcId) -> Result<&mut Child, anyhow::Error> {
+    fn get_mut(
+        &mut self,
+        proc_id: &hyperactor_reference::ProcId,
+    ) -> Result<&mut Child, anyhow::Error> {
         self.active.get_mut(&self.index(proc_id)?).ok_or_else(|| {
             anyhow::anyhow!(
                 "proc {} not currently active in alloc {}",
@@ -379,7 +386,7 @@ impl ProcessAlloc {
         &self.name
     }
 
-    fn index(&self, proc_id: &ProcId) -> Result<usize, anyhow::Error> {
+    fn index(&self, proc_id: &hyperactor_reference::ProcId) -> Result<usize, anyhow::Error> {
         // ProcId names have format "{alloc_name}_{index}" (e.g., "abc123_0")
         let name = proc_id.name();
         let expected_prefix = format!("{}_", self.name);
@@ -492,7 +499,7 @@ impl ProcessAlloc {
                         // For spawned processes, we use a temporary placeholder ProcId.
                         // The actual ProcId will be set when the process calls Hello with its address.
                         let temp_addr = ChannelAddr::any(ChannelTransport::Local);
-                        let proc_id = ProcId::with_name(
+                        let proc_id = hyperactor_reference::ProcId::with_name(
                             temp_addr,
                             format!("{}_{}", self.alloc_name.name(), rank),
                         );

--- a/hyperactor_mesh/src/alloc/remoteprocess.rs
+++ b/hyperactor_mesh/src/alloc/remoteprocess.rs
@@ -35,7 +35,6 @@ use hyperactor::mailbox::DialMailboxRouter;
 use hyperactor::mailbox::MailboxServer;
 use hyperactor::observe_async;
 use hyperactor::observe_result;
-use hyperactor::reference::Reference;
 use mockall::automock;
 use ndslice::Region;
 use ndslice::Slice;
@@ -447,7 +446,7 @@ impl RemoteProcessAllocator {
                                     match mesh_agents_by_create_key.remove(&create_key) {
                                         Some(mesh_agent) => {
                                             tracing::debug!("unmapping mesh_agent {}", mesh_agent);
-                                            let agent_ref: Reference = mesh_agent.actor_id().proc_id().clone().into();
+                                            let agent_ref: hyperactor::reference::Reference = mesh_agent.actor_id().proc_id().clone().into();
                                             router.unbind(&agent_ref);
                                         },
                                         None => {
@@ -1363,9 +1362,9 @@ impl Drop for RemoteProcessAlloc {
 mod test {
     use std::assert_matches::assert_matches;
 
-    use hyperactor::ActorRef;
     use hyperactor::channel::ChannelRx;
     use hyperactor::clock::ClockKind;
+    use hyperactor::reference as hyperactor_reference;
     use hyperactor::testing::ids::test_proc_id;
     use ndslice::extent;
     use tokio::sync::oneshot;
@@ -1377,6 +1376,7 @@ mod test {
     use crate::alloc::MockAllocator;
     use crate::alloc::ProcStopReason;
     use crate::alloc::with_unspecified_port_or_any;
+    use crate::host_mesh::host_agent::HostAgent;
 
     async fn read_all_created(rx: &mut ChannelRx<RemoteProcessProcStateMessage>, alloc_len: usize) {
         let mut i: usize = 0;
@@ -1435,7 +1435,9 @@ mod test {
             .enumerate()
         {
             let proc_id = test_proc_id(&format!("{i}"));
-            let host_agent = ActorRef::<HostAgent>::attest(proc_id.actor_id("host_agent", i));
+            let host_agent = hyperactor_reference::ActorRef::<HostAgent>::attest(
+                proc_id.actor_id("host_agent", i),
+            );
             alloc.expect_next().times(1).return_once(move || {
                 Some(ProcState::Running {
                     create_key,
@@ -1559,7 +1561,7 @@ mod test {
                     assert_eq!(got_alloc_key, alloc_key);
                     assert_eq!(create_key, create_keys[rank]);
                     let expected_proc_id = test_proc_id(&format!("{}", rank));
-                    let expected_host_agent = ActorRef::<HostAgent>::attest(
+                    let expected_host_agent = hyperactor_reference::ActorRef::<HostAgent>::attest(
                         expected_proc_id.actor_id("host_agent", rank),
                     );
                     assert_eq!(host_agent, expected_host_agent);

--- a/hyperactor_mesh/src/bootstrap.rs
+++ b/hyperactor_mesh/src/bootstrap.rs
@@ -30,9 +30,6 @@ use futures::StreamExt;
 use futures::stream;
 use humantime::format_duration;
 use hyperactor::ActorHandle;
-use hyperactor::ActorId;
-use hyperactor::ActorRef;
-use hyperactor::ProcId;
 use hyperactor::channel;
 use hyperactor::channel::ChannelAddr;
 use hyperactor::channel::ChannelError;
@@ -52,6 +49,7 @@ use hyperactor::mailbox::MailboxClient;
 use hyperactor::mailbox::MailboxServer;
 use hyperactor::mailbox::MailboxServerHandle;
 use hyperactor::proc::Proc;
+use hyperactor::reference as hyperactor_reference;
 use hyperactor_config::CONFIG;
 use hyperactor_config::ConfigAttr;
 use hyperactor_config::attrs::Attrs;
@@ -195,7 +193,7 @@ pub(crate) struct BootstrapHostMessage {
     /// The address the host is serving on.
     pub host_addr: ChannelAddr,
     /// Reference to the host's mesh agent.
-    pub host_agent: ActorRef<HostAgent>,
+    pub host_agent: hyperactor_reference::ActorRef<HostAgent>,
 }
 wirevalue::register_type!(BootstrapHostMessage);
 
@@ -315,7 +313,7 @@ pub enum Bootstrap {
     /// Bootstrap as a "v1" proc
     Proc {
         /// The ProcId of the proc to be bootstrapped.
-        proc_id: ProcId,
+        proc_id: hyperactor_reference::ProcId,
         /// The backend address to which messages are forwarded.
         /// See [`hyperactor::host`] for channel topology details.
         backend_addr: ChannelAddr,
@@ -625,7 +623,7 @@ pub enum ProcStatus {
     Ready {
         started_at: SystemTime,
         addr: ChannelAddr,
-        agent: ActorRef<ProcAgent>,
+        agent: hyperactor_reference::ActorRef<ProcAgent>,
     },
     /// A stop has been requested (SIGTERM, graceful shutdown, etc.),
     /// but the OS process has not yet fully exited. (Proc-level:
@@ -762,7 +760,7 @@ impl std::error::Error for ReadyError {}
 #[derive(Clone)]
 pub struct BootstrapProcHandle {
     /// Logical identity of the proc in the mesh.
-    proc_id: ProcId,
+    proc_id: hyperactor_reference::ProcId,
 
     /// Live lifecycle snapshot (see [`ProcStatus`]). Kept in a mutex
     /// so [`BootstrapProcHandle::status`] can return a synchronous
@@ -832,7 +830,10 @@ impl BootstrapProcHandle {
     /// This is the canonical entry point used by
     /// `BootstrapProcManager` when it launches a proc into a new
     /// process.
-    pub(crate) fn new(proc_id: ProcId, launcher: Weak<dyn ProcLauncher>) -> Self {
+    pub(crate) fn new(
+        proc_id: hyperactor_reference::ProcId,
+        launcher: Weak<dyn ProcLauncher>,
+    ) -> Self {
         let (tx, rx) = watch::channel(ProcStatus::Starting);
         Self {
             proc_id,
@@ -847,7 +848,7 @@ impl BootstrapProcHandle {
 
     /// Return the logical proc identity in the mesh.
     #[inline]
-    pub fn proc_id(&self) -> &ProcId {
+    pub fn proc_id(&self) -> &hyperactor_reference::ProcId {
         &self.proc_id
     }
 
@@ -965,7 +966,11 @@ impl BootstrapProcHandle {
     /// `Running`), or `false` if the current state did not allow
     /// moving to `Ready`. In the latter case the state is left
     /// unchanged and a warning is logged.
-    pub(crate) fn mark_ready(&self, addr: ChannelAddr, agent: ActorRef<ProcAgent>) -> bool {
+    pub(crate) fn mark_ready(
+        &self,
+        addr: ChannelAddr,
+        agent: hyperactor_reference::ActorRef<ProcAgent>,
+    ) -> bool {
         tracing::info!(proc_id = %self.proc_id, %addr, "{} ready at {}", self.proc_id, addr);
         self.transition(|st| match st {
             ProcStatus::Starting => {
@@ -1217,7 +1222,7 @@ impl BootstrapProcHandle {
     async fn send_stop_all(
         &self,
         cx: &impl context::Actor,
-        agent: ActorRef<ProcAgent>,
+        agent: hyperactor_reference::ActorRef<ProcAgent>,
         timeout: Duration,
         reason: &str,
     ) -> anyhow::Result<ProcStatus> {
@@ -1251,7 +1256,7 @@ impl hyperactor::host::ProcHandle for BootstrapProcHandle {
     type TerminalStatus = ProcStatus;
 
     #[inline]
-    fn proc_id(&self) -> &ProcId {
+    fn proc_id(&self) -> &hyperactor_reference::ProcId {
         &self.proc_id
     }
 
@@ -1264,7 +1269,7 @@ impl hyperactor::host::ProcHandle for BootstrapProcHandle {
     }
 
     #[inline]
-    fn agent_ref(&self) -> Option<ActorRef<Self::Agent>> {
+    fn agent_ref(&self) -> Option<hyperactor_reference::ActorRef<Self::Agent>> {
         match &*self.status.lock().expect("status mutex poisoned") {
             ProcStatus::Ready { agent, .. } => Some(agent.clone()),
             _ => None,
@@ -1610,7 +1615,7 @@ pub struct BootstrapProcManager {
     /// Async registry of running children, keyed by [`ProcId`]. Holds
     /// [`BootstrapProcHandle`]s so callers can query or monitor
     /// status.
-    children: Arc<tokio::sync::Mutex<HashMap<ProcId, BootstrapProcHandle>>>,
+    children: Arc<tokio::sync::Mutex<HashMap<hyperactor_reference::ProcId, BootstrapProcHandle>>>,
 
     /// FileMonitor that aggregates logs from all children. None if
     /// file monitor creation failed.
@@ -1708,7 +1713,7 @@ impl BootstrapProcManager {
     ///
     /// Returns `None` if the manager has no record of the proc (e.g.
     /// never spawned here, or entry already removed).
-    pub async fn status(&self, proc_id: &ProcId) -> Option<ProcStatus> {
+    pub async fn status(&self, proc_id: &hyperactor_reference::ProcId) -> Option<ProcStatus> {
         self.children.lock().await.get(proc_id).map(|h| h.status())
     }
 
@@ -1721,7 +1726,7 @@ impl BootstrapProcManager {
     pub(crate) async fn request_stop(
         &self,
         cx: &impl context::Actor,
-        proc: &ProcId,
+        proc: &hyperactor_reference::ProcId,
         timeout: Duration,
         reason: &str,
     ) {
@@ -1756,7 +1761,7 @@ impl BootstrapProcManager {
 
     fn spawn_exit_monitor(
         &self,
-        proc_id: ProcId,
+        proc_id: hyperactor_reference::ProcId,
         handle: BootstrapProcHandle,
         exit_rx: tokio::sync::oneshot::Receiver<ProcExitResult>,
     ) {
@@ -1899,13 +1904,14 @@ impl ProcManager for BootstrapProcManager {
     #[hyperactor::instrument(fields(proc_id=proc_id.to_string(), addr=backend_addr.to_string()))]
     async fn spawn(
         &self,
-        proc_id: ProcId,
+        proc_id: hyperactor_reference::ProcId,
         backend_addr: ChannelAddr,
         config: BootstrapProcConfig,
     ) -> Result<Self::Handle, HostError> {
-        let (callback_addr, mut callback_rx) = channel::serve::<(ChannelAddr, ActorRef<ProcAgent>)>(
-            ChannelAddr::any(ChannelTransport::Unix),
-        )?;
+        let (callback_addr, mut callback_rx) =
+            channel::serve::<(ChannelAddr, hyperactor_reference::ActorRef<ProcAgent>)>(
+                ChannelAddr::any(ChannelTransport::Unix),
+            )?;
 
         // Decide whether we need to capture stdio.
         let overrides = &config.client_config_override;
@@ -2050,10 +2056,16 @@ impl hyperactor::host::SingleTerminate for BootstrapProcManager {
     async fn terminate_proc(
         &self,
         cx: &impl context::Actor,
-        proc: &ProcId,
+        proc: &hyperactor_reference::ProcId,
         timeout: Duration,
         reason: &str,
-    ) -> Result<(Vec<ActorId>, Vec<ActorId>), anyhow::Error> {
+    ) -> Result<
+        (
+            Vec<hyperactor_reference::ActorId>,
+            Vec<hyperactor_reference::ActorId>,
+        ),
+        anyhow::Error,
+    > {
         // Snapshot to avoid holding the lock across awaits.
         let proc_handle: Option<BootstrapProcHandle> = {
             let mut guard = self.children.lock().await;
@@ -2270,8 +2282,6 @@ fn runtime_dir() -> io::Result<TempDir> {
 mod tests {
     use std::path::PathBuf;
 
-    use hyperactor::ActorRef;
-    use hyperactor::ProcId;
     use hyperactor::RemoteSpawn;
     use hyperactor::channel::ChannelAddr;
     use hyperactor::channel::ChannelTransport;
@@ -2279,6 +2289,7 @@ mod tests {
     use hyperactor::clock::RealClock;
     use hyperactor::context::Mailbox as _;
     use hyperactor::host::ProcHandle;
+    use hyperactor::reference as hyperactor_reference;
     use hyperactor::testing::ids::test_proc_id;
     use hyperactor::testing::ids::test_proc_id_with_addr;
     use hyperactor_config::Flattrs;
@@ -2466,7 +2477,7 @@ mod tests {
         // Spawn the log client and disable aggregation (immediate
         // print + tap push).
         let log_client_actor = LogClientActor::new((), Flattrs::default()).await.unwrap();
-        let log_client: ActorRef<LogClientActor> =
+        let log_client: hyperactor_reference::ActorRef<LogClientActor> =
             proc.spawn("log_client", log_client_actor).unwrap().bind();
         log_client.set_aggregate(&client, None).await.unwrap();
 
@@ -2475,7 +2486,7 @@ mod tests {
         let log_forwarder_actor = LogForwardActor::new(log_client.clone(), Flattrs::default())
             .await
             .unwrap();
-        let _log_forwarder: ActorRef<LogForwardActor> = proc
+        let _log_forwarder: hyperactor_reference::ActorRef<LogForwardActor> = proc
             .spawn("log_forwarder", log_forwarder_actor)
             .unwrap()
             .bind();
@@ -2511,8 +2522,8 @@ mod tests {
         use std::time::Duration;
 
         use async_trait::async_trait;
-        use hyperactor::ProcId;
         use hyperactor::host::ProcHandle;
+        use hyperactor::reference as hyperactor_reference;
         use hyperactor::testing::ids::test_proc_id;
 
         use super::super::*;
@@ -2534,7 +2545,7 @@ mod tests {
         impl ProcLauncher for TestProcLauncher {
             async fn launch(
                 &self,
-                _proc_id: &ProcId,
+                _proc_id: &hyperactor_reference::ProcId,
                 _opts: LaunchOptions,
             ) -> Result<LaunchResult, ProcLauncherError> {
                 panic!("TestProcLauncher::launch should not be called in unit tests");
@@ -2542,13 +2553,16 @@ mod tests {
 
             async fn terminate(
                 &self,
-                _proc_id: &ProcId,
+                _proc_id: &hyperactor_reference::ProcId,
                 _timeout: Duration,
             ) -> Result<(), ProcLauncherError> {
                 panic!("TestProcLauncher::terminate should not be called in unit tests");
             }
 
-            async fn kill(&self, _proc_id: &ProcId) -> Result<(), ProcLauncherError> {
+            async fn kill(
+                &self,
+                _proc_id: &hyperactor_reference::ProcId,
+            ) -> Result<(), ProcLauncherError> {
                 panic!("TestProcLauncher::kill should not be called in unit tests");
             }
         }
@@ -2654,7 +2668,8 @@ mod tests {
             // handle's ProcId.
             let proc_id = <BootstrapProcHandle as ProcHandle>::proc_id(&h);
             let actor_id = proc_id.actor_id("proc_agent", 0);
-            let agent_ref: ActorRef<ProcAgent> = ActorRef::attest(actor_id);
+            let agent_ref: hyperactor_reference::ActorRef<ProcAgent> =
+                hyperactor_reference::ActorRef::attest(actor_id);
             // Ready -> Stopping -> Stopped should be legal.
             assert!(h.mark_ready(addr, agent_ref));
             assert!(h.mark_stopping());
@@ -2672,7 +2687,8 @@ mod tests {
             // handle's ProcId.
             let proc_id = <BootstrapProcHandle as ProcHandle>::proc_id(&h);
             let actor_id = proc_id.actor_id("proc_agent", 0);
-            let agent: ActorRef<ProcAgent> = ActorRef::attest(actor_id);
+            let agent: hyperactor_reference::ActorRef<ProcAgent> =
+                hyperactor_reference::ActorRef::attest(actor_id);
             // Running -> Ready
             assert!(h.mark_ready(addr, agent));
             // Ready -> Killed
@@ -2709,7 +2725,7 @@ mod tests {
     impl crate::proc_launcher::ProcLauncher for TestLauncher {
         async fn launch(
             &self,
-            _proc_id: &ProcId,
+            _proc_id: &hyperactor_reference::ProcId,
             _opts: crate::proc_launcher::LaunchOptions,
         ) -> Result<crate::proc_launcher::LaunchResult, crate::proc_launcher::ProcLauncherError>
         {
@@ -2718,7 +2734,7 @@ mod tests {
 
         async fn terminate(
             &self,
-            _proc_id: &ProcId,
+            _proc_id: &hyperactor_reference::ProcId,
             _timeout: std::time::Duration,
         ) -> Result<(), crate::proc_launcher::ProcLauncherError> {
             panic!("TestLauncher::terminate should not be called in unit tests");
@@ -2726,13 +2742,13 @@ mod tests {
 
         async fn kill(
             &self,
-            _proc_id: &ProcId,
+            _proc_id: &hyperactor_reference::ProcId,
         ) -> Result<(), crate::proc_launcher::ProcLauncherError> {
             panic!("TestLauncher::kill should not be called in unit tests");
         }
     }
 
-    fn test_handle(proc_id: ProcId) -> BootstrapProcHandle {
+    fn test_handle(proc_id: hyperactor_reference::ProcId) -> BootstrapProcHandle {
         let launcher: std::sync::Arc<dyn crate::proc_launcher::ProcLauncher> =
             std::sync::Arc::new(TestLauncher);
         BootstrapProcHandle::new(proc_id, std::sync::Arc::downgrade(&launcher))
@@ -2804,7 +2820,8 @@ mod tests {
         assert!(handle.mark_running(started_at));
 
         let actor_id = proc_id.actor_id("proc_agent", 0);
-        let agent_ref: ActorRef<ProcAgent> = ActorRef::attest(actor_id);
+        let agent_ref: hyperactor_reference::ActorRef<ProcAgent> =
+            hyperactor_reference::ActorRef::attest(actor_id);
 
         // Pick any addr to carry in Ready (what the child would have
         // called back with).
@@ -2846,7 +2863,7 @@ mod tests {
     fn display_ready_includes_addr() {
         let started_at = RealClock.system_time_now() - Duration::from_secs(5);
         let addr = ChannelAddr::any(ChannelTransport::Unix);
-        let agent = ActorRef::attest(
+        let agent = hyperactor_reference::ActorRef::attest(
             test_proc_id_with_addr(addr.clone(), "proc")
                 .actor_id(crate::proc_agent::PROC_AGENT_ACTOR_NAME, 0),
         );
@@ -2883,7 +2900,7 @@ mod tests {
             ProcStatus::Ready {
                 started_at: RealClock.system_time_now(),
                 addr: ChannelAddr::any(ChannelTransport::Unix),
-                agent: ActorRef::attest(
+                agent: hyperactor_reference::ActorRef::attest(
                     test_proc_id_with_addr(ChannelAddr::any(ChannelTransport::Unix), "x")
                         .actor_id(crate::proc_agent::PROC_AGENT_ACTOR_NAME, 0),
                 ),
@@ -2914,7 +2931,8 @@ mod tests {
 
         // Synthesize Ready data
         let addr = ChannelAddr::any(ChannelTransport::Unix);
-        let agent: ActorRef<ProcAgent> = ActorRef::attest(proc_id.actor_id("proc_agent", 0));
+        let agent: hyperactor_reference::ActorRef<ProcAgent> =
+            hyperactor_reference::ActorRef::attest(proc_id.actor_id("proc_agent", 0));
         assert!(handle.mark_ready(addr, agent));
 
         // Call the trait method (not ready_inner).
@@ -2971,7 +2989,7 @@ mod tests {
     async fn make_proc_id_and_backend_addr(
         instance: &hyperactor::Instance<()>,
         _tag: &str,
-    ) -> (ProcId, ChannelAddr) {
+    ) -> (hyperactor_reference::ProcId, ChannelAddr) {
         // Serve a Unix channel as the "backend_addr" and hook it into
         // this test proc.
         let (backend_addr, rx) = channel::serve(ChannelAddr::any(ChannelTransport::Unix)).unwrap();
@@ -3402,7 +3420,7 @@ mod tests {
     impl ProcLauncher for DummyLauncher {
         async fn launch(
             &self,
-            _proc_id: &ProcId,
+            _proc_id: &hyperactor_reference::ProcId,
             _opts: LaunchOptions,
         ) -> Result<LaunchResult, ProcLauncherError> {
             let (tx, rx) = tokio::sync::oneshot::channel();
@@ -3421,13 +3439,16 @@ mod tests {
 
         async fn terminate(
             &self,
-            _proc_id: &ProcId,
+            _proc_id: &hyperactor_reference::ProcId,
             _timeout: Duration,
         ) -> Result<(), ProcLauncherError> {
             Ok(())
         }
 
-        async fn kill(&self, _proc_id: &ProcId) -> Result<(), ProcLauncherError> {
+        async fn kill(
+            &self,
+            _proc_id: &hyperactor_reference::ProcId,
+        ) -> Result<(), ProcLauncherError> {
             Ok(())
         }
     }

--- a/hyperactor_mesh/src/bootstrap/mailbox.rs
+++ b/hyperactor_mesh/src/bootstrap/mailbox.rs
@@ -108,12 +108,11 @@ mod tests {
     use std::assert_matches::assert_matches;
 
     use hyperactor::Mailbox;
-    use hyperactor::PortId;
-    use hyperactor::ProcId;
     use hyperactor::channel::ChannelAddr;
     use hyperactor::channel::ChannelTransport;
     use hyperactor::channel::Rx;
     use hyperactor::channel::{self};
+    use hyperactor::reference as hyperactor_reference;
     use hyperactor::testing::ids::test_actor_id;
     use hyperactor_config::Flattrs;
 
@@ -145,11 +144,14 @@ mod tests {
         // construct the IDs directly rather than via test_proc_id.
         let local_addr: ChannelAddr = "tcp:3.4.5.6:123".parse().unwrap();
         let first_actor_id =
-            ProcId::with_name(local_addr.clone(), first.to_string()).actor_id("actor", 0);
+            hyperactor_reference::ProcId::with_name(local_addr.clone(), first.to_string())
+                .actor_id("actor", 0);
         let second_actor_id =
-            ProcId::with_name(local_addr.clone(), second.to_string()).actor_id("actor", 0);
+            hyperactor_reference::ProcId::with_name(local_addr.clone(), second.to_string())
+                .actor_id("actor", 0);
         let third_notexist_actor_id =
-            ProcId::with_name(local_addr.clone(), third.to_string()).actor_id("actor", 0);
+            hyperactor_reference::ProcId::with_name(local_addr.clone(), third.to_string())
+                .actor_id("actor", 0);
         let proc_dialer = LocalProcDialer::new(
             local_addr.clone(),
             dir.path().to_owned(),
@@ -163,7 +165,7 @@ mod tests {
         // Existing address on the host:
         let envelope = MessageEnvelope::new(
             third_notexist_actor_id.clone(),
-            PortId::new(first_actor_id.clone(), 0),
+            hyperactor_reference::PortId::new(first_actor_id.clone(), 0),
             wirevalue::Any::serialize(&()).unwrap(),
             Flattrs::new(),
         );
@@ -176,7 +178,7 @@ mod tests {
         // Nonexistant address on the host:
         let envelope = MessageEnvelope::new(
             second_actor_id.clone(),
-            PortId::new(third_notexist_actor_id.clone(), 0),
+            hyperactor_reference::PortId::new(third_notexist_actor_id.clone(), 0),
             wirevalue::Any::serialize(&()).unwrap(),
             Flattrs::new(),
         );
@@ -189,7 +191,7 @@ mod tests {
         // Outside the host:
         let envelope = MessageEnvelope::new(
             second_actor_id.clone(),
-            PortId::new(test_actor_id("external_0", "actor"), 0),
+            hyperactor_reference::PortId::new(test_actor_id("external_0", "actor"), 0),
             wirevalue::Any::serialize(&()).unwrap(),
             Flattrs::new(),
         );
@@ -198,10 +200,11 @@ mod tests {
 
         // System proc on the host (name must be exactly "system"):
         let system_actor_id =
-            ProcId::with_name(local_addr.clone(), "system".to_string()).actor_id("actor", 0);
+            hyperactor_reference::ProcId::with_name(local_addr.clone(), "system".to_string())
+                .actor_id("actor", 0);
         let envelope = MessageEnvelope::new(
             second_actor_id.clone(),
-            PortId::new(system_actor_id, 0),
+            hyperactor_reference::PortId::new(system_actor_id, 0),
             wirevalue::Any::serialize(&()).unwrap(),
             Flattrs::new(),
         );

--- a/hyperactor_mesh/src/casting.rs
+++ b/hyperactor_mesh/src/casting.rs
@@ -10,7 +10,6 @@
 
 use std::collections::BTreeSet;
 
-use hyperactor::ActorRef;
 use hyperactor::RemoteHandles;
 use hyperactor::RemoteMessage;
 use hyperactor::actor::Referable;
@@ -21,6 +20,7 @@ use hyperactor::mailbox::MessageEnvelope;
 use hyperactor::mailbox::Undeliverable;
 use hyperactor::message::Castable;
 use hyperactor::message::IndexedErasedUnbound;
+use hyperactor::reference as hyperactor_reference;
 use hyperactor_config::Flattrs;
 use hyperactor_config::attrs::declare_attrs;
 use ndslice::Selection;
@@ -77,7 +77,7 @@ pub fn update_undeliverable_envelope_for_casting(
 pub(crate) fn actor_mesh_cast<A, M>(
     cx: &impl context::Actor,
     actor_mesh_id: ActorMeshId,
-    comm_actor_ref: &ActorRef<CommActor>,
+    comm_actor_ref: &hyperactor_reference::ActorRef<CommActor>,
     selection_of_root: Selection,
     root_mesh_shape: &Shape,
     cast_mesh_shape: &Shape,
@@ -153,7 +153,7 @@ where
 pub(crate) fn cast_to_sliced_mesh<A, M>(
     cx: &impl context::Actor,
     actor_mesh_id: ActorMeshId,
-    comm_actor_ref: &ActorRef<CommActor>,
+    comm_actor_ref: &hyperactor_reference::ActorRef<CommActor>,
     sel_of_sliced: &Selection,
     message: M,
     sliced_shape: &Shape,

--- a/hyperactor_mesh/src/comm.rs
+++ b/hyperactor_mesh/src/comm.rs
@@ -22,12 +22,9 @@ use std::fmt::Debug;
 use anyhow::Result;
 use async_trait::async_trait;
 use hyperactor::Actor;
-use hyperactor::ActorId;
-use hyperactor::ActorRef;
 use hyperactor::Context;
 use hyperactor::Handler;
 use hyperactor::Instance;
-use hyperactor::PortRef;
 use hyperactor::RemoteMessage;
 use hyperactor::accum::ReducerMode;
 use hyperactor::mailbox::DeliveryError;
@@ -39,8 +36,7 @@ use hyperactor::mailbox::monitored_return_handle;
 use hyperactor::message::ErasedUnbound;
 use hyperactor::ordering::SEQ_INFO;
 use hyperactor::ordering::SeqInfo;
-use hyperactor::reference::UnboundPort;
-use hyperactor::reference::UnboundPortKind;
+use hyperactor::reference as hyperactor_reference;
 use hyperactor_config::CONFIG;
 use hyperactor_config::ConfigAttr;
 use hyperactor_config::Flattrs;
@@ -114,9 +110,9 @@ struct ReceiveState {
 )]
 pub struct CommActor {
     /// Sequence numbers are maintained for each (actor mesh id, sender).
-    send_seq: HashMap<(ActorMeshId, ActorId), usize>,
+    send_seq: HashMap<(ActorMeshId, hyperactor_reference::ActorId), usize>,
     /// Each sender is a unique stream.
-    recv_state: HashMap<(ActorMeshId, ActorId), ReceiveState>,
+    recv_state: HashMap<(ActorMeshId, hyperactor_reference::ActorId), ReceiveState>,
 
     /// The comm actor's mesh configuration.
     mesh_config: Option<CommMeshConfig>,
@@ -128,18 +124,21 @@ pub struct CommMeshConfig {
     /// The rank of this comm actor on the root mesh.
     rank: usize,
     /// Key is the rank of the peer on the root mesh. Value is the peer's comm actor.
-    peers: HashMap<usize, ActorRef<CommActor>>,
+    peers: HashMap<usize, hyperactor_reference::ActorRef<CommActor>>,
 }
 wirevalue::register_type!(CommMeshConfig);
 
 impl CommMeshConfig {
     /// Create a new mesh configuration with the given rank and peer mapping.
-    pub fn new(rank: usize, peers: HashMap<usize, ActorRef<CommActor>>) -> Self {
+    pub fn new(
+        rank: usize,
+        peers: HashMap<usize, hyperactor_reference::ActorRef<CommActor>>,
+    ) -> Self {
         Self { rank, peers }
     }
 
     /// Return the peer comm actor for the given rank.
-    fn peer_for_rank(&self, rank: usize) -> Result<ActorRef<CommActor>> {
+    fn peer_for_rank(&self, rank: usize) -> Result<hyperactor_reference::ActorRef<CommActor>> {
         self.peers
             .get(&rank)
             .cloned()
@@ -172,7 +171,7 @@ impl Actor for CommActor {
             message_envelope.deserialized::<ForwardMessage>()
         {
             let sender = message.sender();
-            let return_port = PortRef::attest_message_port(sender);
+            let return_port = hyperactor_reference::PortRef::attest_message_port(sender);
             message_envelope.set_error(DeliveryError::Multicast(format!(
                 "comm actor {} failed to forward the cast message; returning to origin {}",
                 cx.self_id(),
@@ -202,7 +201,7 @@ impl Actor for CommActor {
 
         // 2. Case delivery failure at a "deliver here" step.
         if let Some(sender) = message_envelope.headers().get(CAST_ORIGINATING_SENDER) {
-            let return_port = PortRef::attest_message_port(&sender);
+            let return_port = hyperactor_reference::PortRef::attest_message_port(&sender);
             message_envelope.set_error(DeliveryError::Multicast(format!(
                 "comm actor {} failed to deliver the cast message to the dest \
                 actor; returning to origin {}",
@@ -261,7 +260,7 @@ impl CommActor {
         config: &CommMeshConfig,
         deliver_here: bool,
         next_steps: HashMap<usize, Vec<RoutingFrame>>,
-        sender: ActorId,
+        sender: hyperactor_reference::ActorId,
         mut message: CastMessageEnvelope,
         seq: usize,
         last_seqs: &mut HashMap<usize, usize>,
@@ -338,13 +337,13 @@ fn split_ports(
     // Split ports, if any, and update message with new ports. In this
     // way, children actors will reply to this comm actor's ports, instead
     // of to the original ports provided by parent.
-    data.visit_mut::<UnboundPort>(
-        |UnboundPort(port_id, reducer_spec, return_undeliverable, kind)| {
+    data.visit_mut::<hyperactor_reference::UnboundPort>(
+        |hyperactor_reference::UnboundPort(port_id, reducer_spec, return_undeliverable, kind)| {
             let reducer_mode = match kind {
-                UnboundPortKind::Streaming(opts) => {
+                hyperactor_reference::UnboundPortKind::Streaming(opts) => {
                     ReducerMode::Streaming(opts.clone().unwrap_or_default())
                 }
-                UnboundPortKind::Once if reducer_spec.is_none() => {
+                hyperactor_reference::UnboundPortKind::Once if reducer_spec.is_none() => {
                     // We can only split OncePorts that have reducers.
                     // Pass this through -- if it is used multiple times,
                     // it will cause a delivery error downstream.
@@ -353,7 +352,7 @@ fn split_ports(
                     // unicast and broadcast messages.
                     return Ok(());
                 }
-                UnboundPortKind::Once => {
+                hyperactor_reference::UnboundPortKind::Once => {
                     // Compute peer count for OncePort splitting. This is the number of
                     // destinations the message will be delivered to, so that the split
                     // port can correctly accumulate responses.
@@ -591,12 +590,11 @@ pub mod test_utils {
     use anyhow::Result;
     use async_trait::async_trait;
     use hyperactor::Actor;
-    use hyperactor::ActorId;
     use hyperactor::Bind;
     use hyperactor::Context;
     use hyperactor::Handler;
-    use hyperactor::PortRef;
     use hyperactor::Unbind;
+    use hyperactor::reference as hyperactor_reference;
     use serde::Deserialize;
     use serde::Serialize;
     use typeuri::Named;
@@ -605,7 +603,7 @@ pub mod test_utils {
 
     #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Named)]
     pub struct MyReply {
-        pub sender: ActorId,
+        pub sender: hyperactor_reference::ActorId,
         pub value: u64,
     }
 
@@ -617,16 +615,16 @@ pub mod test_utils {
             // Intentionally not including 0. As a result, this port will not be
             // split.
             // #[binding(include)]
-            reply_to0: PortRef<String>,
+            reply_to0: hyperactor_reference::PortRef<String>,
             #[binding(include)]
-            reply_to1: PortRef<u64>,
+            reply_to1: hyperactor_reference::PortRef<u64>,
             #[binding(include)]
-            reply_to2: PortRef<MyReply>,
+            reply_to2: hyperactor_reference::PortRef<MyReply>,
         },
         CastAndReplyOnce {
             arg: String,
             #[binding(include)]
-            reply_to: hyperactor::OncePortRef<u64>,
+            reply_to: hyperactor::reference::OncePortRef<u64>,
         },
     }
 
@@ -640,12 +638,12 @@ pub mod test_utils {
     pub struct TestActor {
         // Forward the received message to this port, so it can be inspected by
         // the unit test.
-        forward_port: PortRef<TestMessage>,
+        forward_port: hyperactor_reference::PortRef<TestMessage>,
     }
 
     #[derive(Debug, Clone, Named, Serialize, Deserialize)]
     pub struct TestActorParams {
-        pub forward_port: PortRef<TestMessage>,
+        pub forward_port: hyperactor_reference::PortRef<TestMessage>,
     }
 
     #[async_trait]
@@ -681,9 +679,6 @@ mod tests {
     use std::sync::Mutex;
     use std::sync::OnceLock;
 
-    use hyperactor::PortId;
-    use hyperactor::PortRef;
-    use hyperactor::ProcId;
     use hyperactor::accum;
     use hyperactor::accum::Accumulator;
     use hyperactor::accum::ReducerSpec;
@@ -693,7 +688,7 @@ mod tests {
     use hyperactor::context::Mailbox;
     use hyperactor::mailbox::PortReceiver;
     use hyperactor::mailbox::open_port;
-    use hyperactor::reference::Index;
+    use hyperactor::reference as hyperactor_reference;
     use hyperactor_config;
     use hyperactor_mesh_macros::sel;
     use maplit::btreemap;
@@ -713,7 +708,10 @@ mod tests {
     use crate::testing;
 
     // Helper to look up the rank for a given actor ID using the rank_lookup table.
-    fn lookup_rank(actor_id: &hyperactor::ActorId, rank_lookup: &HashMap<ProcId, usize>) -> usize {
+    fn lookup_rank(
+        actor_id: &hyperactor::reference::ActorId,
+        rank_lookup: &HashMap<hyperactor_reference::ProcId, usize>,
+    ) -> usize {
         let proc_id = actor_id.proc_id();
         *rank_lookup
             .get(proc_id)
@@ -734,11 +732,16 @@ mod tests {
 
     // The relationship between original ports and split ports. The elements in
     // the tuple are (original port, split port, deliver_here).
-    static SPLIT_PORT_TREE: OnceLock<Mutex<Vec<Edge<PortId>>>> = OnceLock::new();
+    static SPLIT_PORT_TREE: OnceLock<Mutex<Vec<Edge<hyperactor_reference::PortId>>>> =
+        OnceLock::new();
 
     // Collect the relationships between original ports and split ports into
     // SPLIT_PORT_TREE. This is used by tests to verify that ports are split as expected.
-    pub(crate) fn collect_split_port(original: &PortId, split: &PortId, deliver_here: bool) {
+    pub(crate) fn collect_split_port(
+        original: &hyperactor_reference::PortId,
+        split: &hyperactor_reference::PortId,
+        deliver_here: bool,
+    ) {
         let mutex = SPLIT_PORT_TREE.get_or_init(|| Mutex::new(vec![]));
         let mut tree = mutex.lock().unwrap();
 
@@ -868,10 +871,10 @@ mod tests {
     //     2 -> 0, 2
     //     3 -> 0, 2, 3
     fn get_ranks(
-        paths: PathToLeaves<PortId>,
-        client_reply: &PortId,
-        rank_lookup: &HashMap<ProcId, usize>,
-    ) -> PathToLeaves<Index> {
+        paths: PathToLeaves<hyperactor_reference::PortId>,
+        client_reply: &hyperactor_reference::PortId,
+        rank_lookup: &HashMap<hyperactor_reference::ProcId, usize>,
+    ) -> PathToLeaves<hyperactor_reference::Index> {
         let ranks = paths
             .0
             .into_iter()
@@ -918,9 +921,9 @@ mod tests {
     fn verify_split_port_paths(
         selection: &Selection,
         extent: &Extent,
-        reply_port_ref1: &PortRef<u64>,
-        reply_port_ref2: &PortRef<MyReply>,
-        rank_lookup: &HashMap<ProcId, usize>,
+        reply_port_ref1: &hyperactor_reference::PortRef<u64>,
+        reply_port_ref2: &hyperactor_reference::PortRef<MyReply>,
+        rank_lookup: &HashMap<hyperactor_reference::ProcId, usize>,
     ) {
         // Get the paths used in casting
         let sel_paths = PathToLeaves(
@@ -952,11 +955,14 @@ mod tests {
     }
 
     async fn execute_cast_and_reply(
-        ranks: Vec<ActorRef<TestActor>>,
+        ranks: Vec<hyperactor_reference::ActorRef<TestActor>>,
         instance: &impl context::Actor,
         mut reply1_rx: PortReceiver<u64>,
         mut reply2_rx: PortReceiver<MyReply>,
-        reply_tos: Vec<(PortRef<u64>, PortRef<MyReply>)>,
+        reply_tos: Vec<(
+            hyperactor_reference::PortRef<u64>,
+            hyperactor_reference::PortRef<MyReply>,
+        )>,
     ) {
         // Reply from each dest actor. The replies should be received by client.
         {
@@ -983,7 +989,7 @@ mod tests {
         // be received in the same order as they were sent out.
         {
             let n = 100;
-            let mut expected2: HashMap<ActorId, Vec<MyReply>> = hashmap! {};
+            let mut expected2: HashMap<hyperactor_reference::ActorId, Vec<MyReply>> = hashmap! {};
             for (i, (dest_actor, (_reply_to1, reply_to2))) in
                 ranks.iter().zip(reply_tos.iter()).enumerate()
             {
@@ -1006,7 +1012,7 @@ mod tests {
                 );
             }
 
-            let mut received2: HashMap<ActorId, Vec<MyReply>> = hashmap! {};
+            let mut received2: HashMap<hyperactor_reference::ActorId, Vec<MyReply>> = hashmap! {};
 
             for _ in 0..(n * ranks.len()) {
                 let my_reply = reply2_rx.recv().await.unwrap();
@@ -1039,10 +1045,13 @@ mod tests {
     }
 
     async fn execute_cast_and_accum(
-        ranks: Vec<ActorRef<TestActor>>,
+        ranks: Vec<hyperactor_reference::ActorRef<TestActor>>,
         instance: &impl context::Actor,
         mut reply1_rx: PortReceiver<u64>,
-        reply_tos: Vec<(PortRef<u64>, PortRef<MyReply>)>,
+        reply_tos: Vec<(
+            hyperactor_reference::PortRef<u64>,
+            hyperactor_reference::PortRef<MyReply>,
+        )>,
     ) {
         // Now send multiple replies from the dest actors. They should all be
         // received by client. Replies sent from the same dest actor should
@@ -1072,7 +1081,10 @@ mod tests {
         actor_mesh_ref: crate::ActorMeshRef<TestActor>,
         reply1_rx: PortReceiver<u64>,
         reply2_rx: PortReceiver<MyReply>,
-        reply_tos: Vec<(PortRef<u64>, PortRef<MyReply>)>,
+        reply_tos: Vec<(
+            hyperactor_reference::PortRef<u64>,
+            hyperactor_reference::PortRef<MyReply>,
+        )>,
         // Keep the host mesh alive so comm actors aren't shut down.
         host_mesh: HostMesh,
     }
@@ -1157,7 +1169,7 @@ mod tests {
             .iter()
             .enumerate()
             .map(|(i, r)| (r.proc_id().clone(), i))
-            .collect::<HashMap<ProcId, usize>>();
+            .collect::<HashMap<hyperactor_reference::ProcId, usize>>();
 
         // v1 always uses sel!(*) when casting to a mesh.
         let selection = sel!(*);
@@ -1254,8 +1266,8 @@ mod tests {
     struct OncePortMeshSetupV1 {
         instance: &'static Instance<testing::TestRootClient>,
         reply_rx: hyperactor::mailbox::OncePortReceiver<u64>,
-        reply_tos: Vec<hyperactor::OncePortRef<u64>>,
-        _reply_port_ref: hyperactor::OncePortRef<u64>,
+        reply_tos: Vec<hyperactor::reference::OncePortRef<u64>>,
+        _reply_port_ref: hyperactor::reference::OncePortRef<u64>,
         host_mesh: HostMesh,
     }
 

--- a/hyperactor_mesh/src/comm/multicast.rs
+++ b/hyperactor_mesh/src/comm/multicast.rs
@@ -16,7 +16,7 @@ use hyperactor::actor::Referable;
 use hyperactor::message::Castable;
 use hyperactor::message::ErasedUnbound;
 use hyperactor::message::IndexedErasedUnbound;
-use hyperactor::reference::ActorId;
+use hyperactor::reference as hyperactor_reference;
 use hyperactor_config::Flattrs;
 use hyperactor_config::attrs::declare_attrs;
 use ndslice::Extent;
@@ -41,7 +41,7 @@ use crate::reference::ActorMeshId;
 pub(crate) trait CastEnvelope {
     fn dest_port(&self) -> &DestinationPort;
     fn headers(&self) -> &Flattrs;
-    fn sender(&self) -> &ActorId;
+    fn sender(&self) -> &hyperactor_reference::ActorId;
     fn cast_point(&self, config: &CommMeshConfig) -> anyhow::Result<Point>;
     fn data(&self) -> &ErasedUnbound;
     fn data_mut(&mut self) -> &mut ErasedUnbound;
@@ -67,7 +67,7 @@ pub struct CastMessageEnvelope {
     /// The end-to-end message headers.
     headers: Flattrs,
     /// The sender of this message.
-    sender: ActorId,
+    sender: hyperactor_reference::ActorId,
     /// The destination port of the message. It could match multiple actors with
     /// rank wildcard.
     dest_port: DestinationPort,
@@ -79,7 +79,7 @@ pub struct CastMessageEnvelope {
 wirevalue::register_type!(CastMessageEnvelope);
 
 impl CastEnvelope for CastMessageEnvelope {
-    fn sender(&self) -> &ActorId {
+    fn sender(&self) -> &hyperactor_reference::ActorId {
         &self.sender
     }
 
@@ -115,7 +115,7 @@ impl CastMessageEnvelope {
     /// Create a new CastMessageEnvelope.
     pub fn new<A, M>(
         actor_mesh_id: ActorMeshId,
-        sender: ActorId,
+        sender: hyperactor_reference::ActorId,
         shape: Shape,
         headers: Flattrs,
         message: M,
@@ -141,7 +141,7 @@ impl CastMessageEnvelope {
     /// with the destination actors reply to the client actor directly.
     pub fn from_serialized(
         actor_mesh_id: ActorMeshId,
-        sender: ActorId,
+        sender: hyperactor_reference::ActorId,
         dest_port: DestinationPort,
         shape: Shape,
         headers: Flattrs,
@@ -197,7 +197,7 @@ impl CastMessageEnvelope {
     /// The unique key used to indicate the stream to which to deliver this message.
     /// Concretely, the comm actors along the path should use this key to manage
     /// sequence numbers and reorder buffers.
-    pub(crate) fn stream_key(&self) -> (ActorMeshId, ActorId) {
+    pub(crate) fn stream_key(&self) -> (ActorMeshId, hyperactor_reference::ActorId) {
         (self.actor_mesh_id.clone(), self.sender.clone())
     }
 }
@@ -257,7 +257,7 @@ wirevalue::register_type!(CastMessage);
 #[derive(Serialize, Deserialize, Debug, Clone, Named)]
 pub(crate) struct ForwardMessage {
     /// The comm actor who originally casted the message.
-    pub(crate) sender: ActorId,
+    pub(crate) sender: hyperactor_reference::ActorId,
     /// The destination of the message.
     pub(crate) dests: Vec<RoutingFrame>,
     /// The sequence number of this message.
@@ -275,7 +275,7 @@ pub(crate) struct CastMessageV1 {
     /// The additional end-to-end message headers.
     pub(super) headers: Flattrs,
     /// The client who sent this message.
-    pub(super) sender: ActorId,
+    pub(super) sender: hyperactor_reference::ActorId,
     /// The client-assigned session id of this message.
     pub(super) session_id: Uuid,
     /// The client-assigned sequence numbers of this message.
@@ -290,7 +290,7 @@ pub(crate) struct CastMessageV1 {
 }
 
 impl CastEnvelope for CastMessageV1 {
-    fn sender(&self) -> &ActorId {
+    fn sender(&self) -> &hyperactor_reference::ActorId {
         &self.sender
     }
 
@@ -321,7 +321,7 @@ impl CastMessageV1 {
     /// Create a new CastMessageEnvelope.
     #[allow(unused)]
     pub(crate) fn new<A, M>(
-        sender: ActorId,
+        sender: hyperactor_reference::ActorId,
         dest_mesh: &Name,
         dest_region: Region,
         headers: Flattrs,
@@ -359,13 +359,17 @@ pub(super) struct ForwardMessageV1 {
 
 declare_attrs! {
     /// Used inside headers to store the originating sender of a cast.
-    pub attr CAST_ORIGINATING_SENDER: ActorId;
+    pub attr CAST_ORIGINATING_SENDER: hyperactor_reference::ActorId;
 
     /// The point in the casted region that this message was sent to.
     pub attr CAST_POINT: Point;
 }
 
-pub fn set_cast_info_on_headers(headers: &mut Flattrs, cast_point: Point, sender: ActorId) {
+pub fn set_cast_info_on_headers(
+    headers: &mut Flattrs,
+    cast_point: Point,
+    sender: hyperactor_reference::ActorId,
+) {
     headers.set(CAST_POINT, cast_point);
     headers.set(CAST_ORIGINATING_SENDER, sender);
 }
@@ -376,7 +380,7 @@ pub trait CastInfo {
     /// we represent it as the only member of a 0-dimensonal cast shape,
     /// which is the same as a singleton.
     fn cast_point(&self) -> Point;
-    fn sender(&self) -> ActorId;
+    fn sender(&self) -> hyperactor_reference::ActorId;
 }
 
 impl<A: Actor> CastInfo for Context<'_, A> {
@@ -387,7 +391,7 @@ impl<A: Actor> CastInfo for Context<'_, A> {
         }
     }
 
-    fn sender(&self) -> ActorId {
+    fn sender(&self) -> hyperactor_reference::ActorId {
         self.headers()
             .get(CAST_ORIGINATING_SENDER)
             .expect("has sender header")

--- a/hyperactor_mesh/src/connect.rs
+++ b/hyperactor_mesh/src/connect.rs
@@ -47,9 +47,6 @@ use futures::future;
 use futures::stream::FusedStream;
 use futures::task::Context;
 use futures::task::Poll;
-use hyperactor::ActorId;
-use hyperactor::OncePortRef;
-use hyperactor::PortRef;
 use hyperactor::clock::Clock;
 use hyperactor::clock::RealClock;
 use hyperactor::context;
@@ -60,6 +57,7 @@ use hyperactor::mailbox::open_port;
 use hyperactor::message::Bind;
 use hyperactor::message::Bindings;
 use hyperactor::message::Unbind;
+use hyperactor::reference as hyperactor_reference;
 use pin_project::pin_project;
 use pin_project::pinned_drop;
 use serde::Deserialize;
@@ -89,18 +87,18 @@ struct OwnedReadHalfStream {
 
 /// Wrap a `PortReceiver<IoMsg>` as a `AsyncRead`.
 pub struct OwnedReadHalf {
-    peer: ActorId,
+    peer: hyperactor_reference::ActorId,
     inner: StreamReader<OwnedReadHalfStream, Cursor<Vec<u8>>>,
 }
 
 /// Wrap a `PortRef<IoMsg>` as a `AsyncWrite`.
 #[pin_project(PinnedDrop)]
 pub struct OwnedWriteHalf<C: context::Actor> {
-    peer: ActorId,
+    peer: hyperactor_reference::ActorId,
     #[pin]
     caps: C,
     #[pin]
-    port: PortRef<Io>,
+    port: hyperactor_reference::PortRef<Io>,
     #[pin]
     shutdown: bool,
 }
@@ -119,13 +117,13 @@ impl<C: context::Actor> ActorConnection<C> {
         (self.reader, self.writer)
     }
 
-    pub fn peer(&self) -> &ActorId {
+    pub fn peer(&self) -> &hyperactor_reference::ActorId {
         self.reader.peer()
     }
 }
 
 impl OwnedReadHalf {
-    fn new(peer: ActorId, port: PortReceiver<Io>) -> Self {
+    fn new(peer: hyperactor_reference::ActorId, port: PortReceiver<Io>) -> Self {
         Self {
             peer,
             inner: StreamReader::new(OwnedReadHalfStream {
@@ -135,7 +133,7 @@ impl OwnedReadHalf {
         }
     }
 
-    pub fn peer(&self) -> &ActorId {
+    pub fn peer(&self) -> &hyperactor_reference::ActorId {
         &self.peer
     }
 
@@ -148,7 +146,11 @@ impl OwnedReadHalf {
 }
 
 impl<C: context::Actor> OwnedWriteHalf<C> {
-    fn new(peer: ActorId, caps: C, port: PortRef<Io>) -> Self {
+    fn new(
+        peer: hyperactor_reference::ActorId,
+        caps: C,
+        port: hyperactor_reference::PortRef<Io>,
+    ) -> Self {
         Self {
             peer,
             caps,
@@ -157,7 +159,7 @@ impl<C: context::Actor> OwnedWriteHalf<C> {
         }
     }
 
-    pub fn peer(&self) -> &ActorId {
+    pub fn peer(&self) -> &hyperactor_reference::ActorId {
         &self.peer
     }
 
@@ -318,17 +320,20 @@ impl<C: context::Actor> ConnectionCompleter<C> {
 #[derive(Debug, Serialize, Deserialize, Named, Clone)]
 pub struct Connect {
     /// The ID of the client initiating the connection.
-    id: ActorId,
-    conn: PortRef<Io>,
+    id: hyperactor_reference::ActorId,
+    conn: hyperactor_reference::PortRef<Io>,
     /// The port the server can use to complete the connection.
-    return_conn: OncePortRef<Accept>,
+    return_conn: hyperactor_reference::OncePortRef<Accept>,
 }
 wirevalue::register_type!(Connect);
 
 impl Connect {
     /// Allocate a new `Connect` message and return the associated `ConnectionCompleter` that can be used
     /// to finish setting up the connection.
-    pub fn allocate<C: context::Actor>(id: ActorId, caps: C) -> (Self, ConnectionCompleter<C>) {
+    pub fn allocate<C: context::Actor>(
+        id: hyperactor_reference::ActorId,
+        caps: C,
+    ) -> (Self, ConnectionCompleter<C>) {
         let (conn_tx, conn_rx) = open_port::<Io>(&caps);
         let (return_tx, return_rx) = open_once_port::<Accept>(&caps);
         (
@@ -351,9 +356,9 @@ impl Connect {
 #[derive(Debug, Serialize, Deserialize, Named, Clone)]
 struct Accept {
     /// The ID of the server that accepted the connection.
-    id: ActorId,
+    id: hyperactor_reference::ActorId,
     /// The port the client will use to send data over the connection to the server.
-    conn: PortRef<Io>,
+    conn: hyperactor_reference::PortRef<Io>,
 }
 wirevalue::register_type!(Accept);
 
@@ -375,7 +380,7 @@ impl Unbind for Connect {
 /// return `AsyncRead` and `AsyncWrite` streams that can be used to communicate with the other side.
 pub async fn accept<C: context::Actor>(
     caps: C,
-    self_id: ActorId,
+    self_id: hyperactor_reference::ActorId,
     message: Connect,
 ) -> Result<ActorConnection<C>> {
     let (tx, rx) = open_port::<Io>(&caps);

--- a/hyperactor_mesh/src/global_context.rs
+++ b/hyperactor_mesh/src/global_context.rs
@@ -70,7 +70,7 @@ use hyperactor::mailbox::PortReceiver;
 use hyperactor::mailbox::Undeliverable;
 use hyperactor::proc::Proc;
 use hyperactor::proc::WorkCell;
-use hyperactor::reference::PortRef;
+use hyperactor::reference as hyperactor_reference;
 use hyperactor::supervision::ActorSupervisionEvent;
 use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
@@ -97,12 +97,13 @@ use crate::transport::default_bind_spec;
 ///
 /// Uses `PortRef` (not `PortHandle`) because the sink target
 /// (`ProcAgent`) runs in a remote worker process.
-static GLOBAL_SUPERVISION_SINK: OnceLock<RwLock<Option<PortRef<ActorSupervisionEvent>>>> =
-    OnceLock::new();
+static GLOBAL_SUPERVISION_SINK: OnceLock<
+    RwLock<Option<hyperactor_reference::PortRef<ActorSupervisionEvent>>>,
+> = OnceLock::new();
 
 /// Returns the lazily-initialized container that holds the current
 /// process-global supervision sink.
-fn sink_cell() -> &'static RwLock<Option<PortRef<ActorSupervisionEvent>>> {
+fn sink_cell() -> &'static RwLock<Option<hyperactor_reference::PortRef<ActorSupervisionEvent>>> {
     GLOBAL_SUPERVISION_SINK.get_or_init(|| RwLock::new(None))
 }
 
@@ -122,8 +123,8 @@ fn sink_cell() -> &'static RwLock<Option<PortRef<ActorSupervisionEvent>>> {
 /// destination [`ProcAgent`] may live in a different
 /// process/rank.
 pub(crate) fn set_global_supervision_sink(
-    sink: PortRef<ActorSupervisionEvent>,
-) -> Option<PortRef<ActorSupervisionEvent>> {
+    sink: hyperactor_reference::PortRef<ActorSupervisionEvent>,
+) -> Option<hyperactor_reference::PortRef<ActorSupervisionEvent>> {
     let cell = sink_cell();
     let mut guard = cell.write().unwrap();
     let prev = guard.take();
@@ -142,7 +143,7 @@ pub(crate) fn set_global_supervision_sink(
 /// Cloning a [`PortRef`] is cheap.
 ///
 /// Used only by the process-global root client.
-fn get_global_supervision_sink() -> Option<PortRef<ActorSupervisionEvent>> {
+fn get_global_supervision_sink() -> Option<hyperactor_reference::PortRef<ActorSupervisionEvent>> {
     sink_cell().read().unwrap().clone()
 }
 
@@ -506,9 +507,9 @@ pub fn try_this_host() -> Option<&'static HostMeshRef> {
 mod tests {
     use std::time::Duration;
 
-    use hyperactor::PortId;
     use hyperactor::clock::Clock;
     use hyperactor::clock::RealClock;
+    use hyperactor::reference as hyperactor_reference;
     use hyperactor::testing::ids::test_actor_id;
     use hyperactor_config::Flattrs;
     use ndslice::extent;
@@ -528,17 +529,19 @@ mod tests {
     /// sink is shared across tests running in the same process).
     fn inject_undeliverable(
         client: &'static Instance<GlobalClientActor>,
-        dest_actor: hyperactor::ActorId,
+        dest_actor: hyperactor::reference::ActorId,
     ) {
         let env = MessageEnvelope::new(
             client.self_id().clone(),
-            PortId::new(dest_actor, 0),
+            hyperactor_reference::PortId::new(dest_actor, 0),
             wirevalue::Any::serialize(&0u64).unwrap(),
             Flattrs::new(),
         );
         // Target the global root client's well-known Undeliverable port.
         let undeliverable_port =
-            PortRef::<Undeliverable<MessageEnvelope>>::attest_message_port(client.self_id());
+            hyperactor_reference::PortRef::<Undeliverable<MessageEnvelope>>::attest_message_port(
+                client.self_id(),
+            );
         undeliverable_port
             .send(client, Undeliverable(env))
             .expect("inject_undeliverable: send failed");

--- a/hyperactor_mesh/src/host_mesh.rs
+++ b/hyperactor_mesh/src/host_mesh.rs
@@ -31,10 +31,9 @@ use std::str::FromStr;
 use std::sync::Arc;
 use std::time::Duration;
 
-use hyperactor::ActorRef;
-use hyperactor::ProcId;
 use hyperactor::channel::ChannelAddr;
 use hyperactor::context;
+use hyperactor::reference as hyperactor_reference;
 use ndslice::Extent;
 use ndslice::Region;
 use ndslice::ViewExt;
@@ -112,21 +111,21 @@ wirevalue::register_type!(HostRef);
 
 impl HostRef {
     /// The host mesh agent associated with this host.
-    fn mesh_agent(&self) -> ActorRef<HostAgent> {
-        ActorRef::attest(
+    fn mesh_agent(&self) -> hyperactor_reference::ActorRef<HostAgent> {
+        hyperactor_reference::ActorRef::attest(
             self.service_proc()
                 .actor_id(host_agent::HOST_MESH_AGENT_ACTOR_NAME, 0),
         )
     }
 
     /// The ProcId for the proc with name `name` on this host.
-    fn named_proc(&self, name: &Name) -> ProcId {
-        ProcId::with_name(self.0.clone(), name.to_string())
+    fn named_proc(&self, name: &Name) -> hyperactor_reference::ProcId {
+        hyperactor_reference::ProcId::with_name(self.0.clone(), name.to_string())
     }
 
     /// The service proc on this host.
-    fn service_proc(&self) -> ProcId {
-        ProcId::with_name(self.0.clone(), SERVICE_PROC_NAME)
+    fn service_proc(&self) -> hyperactor_reference::ProcId {
+        hyperactor_reference::ProcId::with_name(self.0.clone(), SERVICE_PROC_NAME)
     }
 
     /// Request an orderly teardown of this host and all procs it
@@ -163,10 +162,10 @@ impl HostRef {
     }
 }
 
-impl TryFrom<ActorRef<HostAgent>> for HostRef {
+impl TryFrom<hyperactor_reference::ActorRef<HostAgent>> for HostRef {
     type Error = crate::Error;
 
-    fn try_from(value: ActorRef<HostAgent>) -> Result<Self, crate::Error> {
+    fn try_from(value: hyperactor_reference::ActorRef<HostAgent>) -> Result<Self, crate::Error> {
         let proc_id = value.actor_id().proc_id();
         Ok(HostRef(proc_id.addr().clone()))
     }
@@ -523,7 +522,7 @@ impl HostMesh {
         let controller_handle = controller
             .spawn_with_name(cx, &controller_name)
             .map_err(|e| crate::Error::ControllerActorSpawnError(mesh.name().clone(), e))?;
-        let _: hyperactor::ActorRef<HostMeshController> = controller_handle.bind();
+        let _: hyperactor::reference::ActorRef<HostMeshController> = controller_handle.bind();
 
         tracing::info!(name = "HostMeshStatus", status = "Allocate::Created");
 
@@ -828,7 +827,10 @@ impl HostMeshRef {
     }
 
     /// Create a new HostMeshRef from an arbitrary set of host mesh agents.
-    pub fn from_host_agents(name: Name, agents: Vec<ActorRef<HostAgent>>) -> crate::Result<Self> {
+    pub fn from_host_agents(
+        name: Name,
+        agents: Vec<hyperactor_reference::ActorRef<HostAgent>>,
+    ) -> crate::Result<Self> {
         Ok(Self {
             name,
             region: extent!(hosts = agents.len()).into(),
@@ -842,7 +844,10 @@ impl HostMeshRef {
     }
 
     /// Create a unit HostMeshRef from a host mesh agent.
-    pub fn from_host_agent(name: Name, agent: ActorRef<HostAgent>) -> crate::Result<Self> {
+    pub fn from_host_agent(
+        name: Name,
+        agent: hyperactor_reference::ActorRef<HostAgent>,
+    ) -> crate::Result<Self> {
         Ok(Self {
             name,
             region: Extent::unity().into(),
@@ -853,7 +858,7 @@ impl HostMeshRef {
     /// Returns the host entries as `(addr_string, ActorRef<HostAgent>)` pairs.
     /// Used by `MeshAdminAgent::effective_hosts()` to merge C into the
     /// admin's host list (A/C invariant).
-    pub(crate) fn host_entries(&self) -> Vec<(String, ActorRef<HostAgent>)> {
+    pub(crate) fn host_entries(&self) -> Vec<(String, hyperactor_reference::ActorRef<HostAgent>)> {
         self.ranks
             .iter()
             .map(|h| (h.0.to_string(), h.mesh_agent()))
@@ -1063,7 +1068,7 @@ impl HostMeshRef {
                     proc_id,
                     create_rank,
                     // TODO: specify or retrieve from state instead, to avoid attestation.
-                    ActorRef::attest(
+                    hyperactor_reference::ActorRef::attest(
                         host.named_proc(&proc_name)
                             .actor_id(crate::proc_agent::PROC_AGENT_ACTOR_NAME, 0),
                     ),
@@ -1176,7 +1181,7 @@ impl HostMeshRef {
             // Undeliverable). Without this, the controller's mailbox has no
             // port entries and messages (including introspection queries)
             // are returned as undeliverable.
-            let _: hyperactor::ActorRef<ProcMeshController> = controller_handle.bind();
+            let _: hyperactor::reference::ActorRef<ProcMeshController> = controller_handle.bind();
         }
         mesh
     }
@@ -1204,7 +1209,7 @@ impl HostMeshRef {
         cx: &impl hyperactor::context::Actor,
         admin_addr: Option<std::net::SocketAddr>,
     ) -> anyhow::Result<String> {
-        let mut hosts: Vec<(String, ActorRef<HostAgent>)> = self
+        let mut hosts: Vec<(String, hyperactor_reference::ActorRef<HostAgent>)> = self
             .ranks
             .iter()
             .map(|h| (h.0.to_string(), h.mesh_agent()))
@@ -1242,7 +1247,7 @@ impl HostMeshRef {
         &self,
         cx: &impl hyperactor::context::Actor,
         proc_mesh_name: &Name,
-        procs: impl IntoIterator<Item = ProcId>,
+        procs: impl IntoIterator<Item = hyperactor_reference::ProcId>,
         region: Region,
         reason: String,
     ) -> anyhow::Result<()> {
@@ -1358,13 +1363,13 @@ impl HostMeshRef {
     pub(crate) async fn proc_states(
         &self,
         cx: &impl context::Actor,
-        procs: impl IntoIterator<Item = ProcId>,
+        procs: impl IntoIterator<Item = hyperactor_reference::ProcId>,
         region: Region,
     ) -> crate::Result<ValueMesh<resource::State<ProcState>>> {
         let (tx, mut rx) = cx.mailbox().open_port();
 
         let mut num_ranks = 0;
-        let procs: Vec<ProcId> = procs.into_iter().collect();
+        let procs: Vec<hyperactor_reference::ProcId> = procs.into_iter().collect();
         let mut proc_names = Vec::new();
         for proc_id in procs.iter() {
             num_ranks += 1;

--- a/hyperactor_mesh/src/host_mesh/host_agent.rs
+++ b/hyperactor_mesh/src/host_mesh/host_agent.rs
@@ -24,16 +24,12 @@ use async_trait::async_trait;
 use enum_as_inner::EnumAsInner;
 use hyperactor::Actor;
 use hyperactor::ActorHandle;
-use hyperactor::ActorId;
-use hyperactor::ActorRef;
 use hyperactor::Context;
 use hyperactor::HandleClient;
 use hyperactor::Handler;
 use hyperactor::Instance;
 use hyperactor::PortHandle;
-use hyperactor::PortRef;
 use hyperactor::Proc;
-use hyperactor::ProcId;
 use hyperactor::RefClient;
 use hyperactor::channel::ChannelTransport;
 use hyperactor::clock::Clock;
@@ -47,6 +43,7 @@ use hyperactor::host::LocalProcManager;
 use hyperactor::host::SERVICE_PROC_NAME;
 use hyperactor::mailbox::MailboxServerHandle;
 use hyperactor::mailbox::PortSender as _;
+use hyperactor::reference as hyperactor_reference;
 use hyperactor_config::Flattrs;
 use hyperactor_config::attrs::Attrs;
 use serde::Deserialize;
@@ -73,7 +70,7 @@ use crate::resource::ProcSpec;
 /// (from root's children) and as an actor (from a proc's children);
 /// `HostId` makes the host case unambiguous.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct HostId(pub ActorId);
+pub(crate) struct HostId(pub hyperactor_reference::ActorId);
 
 /// Prefix used by [`HostId`] for display/parse round-tripping.
 const HOST_ID_PREFIX: &str = "host:";
@@ -91,7 +88,7 @@ impl FromStr for HostId {
         let inner = s
             .strip_prefix(HOST_ID_PREFIX)
             .ok_or_else(|| anyhow::anyhow!("not a host reference: {}", s))?;
-        let actor_id: ActorId = inner
+        let actor_id: hyperactor_reference::ActorId = inner
             .parse()
             .map_err(|e| anyhow::anyhow!("invalid actor id in host ref '{}': {}", s, e))?;
         Ok(HostId(actor_id))
@@ -155,7 +152,7 @@ impl HostAgentMode {
     async fn request_stop(
         &self,
         cx: &impl context::Actor,
-        proc: &ProcId,
+        proc: &hyperactor_reference::ProcId,
         timeout: Duration,
         reason: &str,
     ) {
@@ -175,7 +172,7 @@ impl HostAgentMode {
     /// that need process-level detail such as PIDs or exit codes.
     async fn proc_status(
         &self,
-        proc_id: &ProcId,
+        proc_id: &hyperactor_reference::ProcId,
     ) -> (resource::Status, Option<bootstrap::ProcStatus>) {
         match self {
             HostAgentMode::Process { host, .. } => match host.manager().status(proc_id).await {
@@ -205,7 +202,13 @@ impl HostAgentMode {
 #[derive(Debug)]
 pub(crate) struct ProcCreationState {
     pub(crate) rank: usize,
-    pub(crate) created: Result<(ProcId, ActorRef<ProcAgent>), HostError>,
+    pub(crate) created: Result<
+        (
+            hyperactor_reference::ProcId,
+            hyperactor_reference::ActorRef<ProcAgent>,
+        ),
+        HostError,
+    >,
 }
 
 /// Actor name used when spawning the host mesh agent on the system proc.
@@ -327,10 +330,9 @@ impl Actor for HostAgent {
         this.set_query_child_handler(move |child_ref| {
             use hyperactor::introspect::NodePayload;
             use hyperactor::introspect::NodeProperties;
-            use hyperactor::reference::Reference;
 
             let proc = match child_ref {
-                Reference::Proc(proc_id) => {
+                hyperactor::reference::Reference::Proc(proc_id) => {
                     if *proc_id == *system_proc.proc_id() {
                         Some((&system_proc, SERVICE_PROC_NAME))
                     } else if *proc_id == *local_proc.proc_id() {
@@ -537,7 +539,7 @@ pub struct ShutdownHost {
     pub max_in_flight: usize,
     /// Ack that the agent finished shutdown work (best-effort).
     #[reply]
-    pub ack: hyperactor::PortRef<()>,
+    pub ack: hyperactor::reference::PortRef<()>,
 }
 wirevalue::register_type!(ShutdownHost);
 
@@ -601,9 +603,9 @@ impl Handler<ShutdownHost> for HostAgent {
 
 #[derive(Debug, Clone, PartialEq, Eq, Named, Serialize, Deserialize)]
 pub struct ProcState {
-    pub proc_id: ProcId,
+    pub proc_id: hyperactor_reference::ProcId,
     pub create_rank: usize,
-    pub mesh_agent: ActorRef<ProcAgent>,
+    pub mesh_agent: hyperactor_reference::ActorRef<ProcAgent>,
     pub bootstrap_command: Option<BootstrapCommand>,
     pub proc_status: Option<bootstrap::ProcStatus>,
 }
@@ -688,12 +690,12 @@ pub struct SpawnMeshAdmin {
     /// All hosts in the mesh as `(address, agent_ref)` pairs. Passed
     /// through to [`MeshAdminAgent::new`] so the admin can fan out
     /// introspection queries to every host.
-    pub hosts: Vec<(String, ActorRef<HostAgent>)>,
+    pub hosts: Vec<(String, hyperactor_reference::ActorRef<HostAgent>)>,
 
     /// `ActorId` of the process-global root client, exposed as a
     /// child node in the admin introspection tree. `None` if no root
     /// client is available.
-    pub root_client_actor_id: Option<ActorId>,
+    pub root_client_actor_id: Option<hyperactor_reference::ActorId>,
 
     /// Explicit bind address for the admin HTTP server. When `None`,
     /// the server reads `MESH_ADMIN_ADDR` from config.
@@ -702,7 +704,7 @@ pub struct SpawnMeshAdmin {
     /// Reply port for the admin HTTP address string (e.g.
     /// `"myhost.facebook.com:8080"`).
     #[reply]
-    pub addr: hyperactor::PortRef<String>,
+    pub addr: hyperactor::reference::PortRef<String>,
 }
 wirevalue::register_type!(SpawnMeshAdmin);
 
@@ -750,7 +752,7 @@ impl Handler<SpawnMeshAdmin> for HostAgent {
 pub struct SetClientConfig {
     pub attrs: Attrs,
     #[reply]
-    pub done: PortRef<()>,
+    pub done: hyperactor_reference::PortRef<()>,
 }
 wirevalue::register_type!(SetClientConfig);
 
@@ -815,7 +817,7 @@ impl Handler<GetLocalProc> for HostAgent {
 )]
 pub(crate) struct HostMeshAgentProcMeshTrampoline {
     host_mesh_agent: ActorHandle<HostAgent>,
-    reply_port: PortRef<ActorRef<HostAgent>>,
+    reply_port: hyperactor_reference::PortRef<hyperactor_reference::ActorRef<HostAgent>>,
 }
 
 #[async_trait]
@@ -830,7 +832,7 @@ impl Actor for HostMeshAgentProcMeshTrampoline {
 impl hyperactor::RemoteSpawn for HostMeshAgentProcMeshTrampoline {
     type Params = (
         ChannelTransport,
-        PortRef<ActorRef<HostAgent>>,
+        hyperactor_reference::PortRef<hyperactor_reference::ActorRef<HostAgent>>,
         Option<BootstrapCommand>,
         bool, /* local? */
     );
@@ -873,7 +875,7 @@ impl hyperactor::RemoteSpawn for HostMeshAgentProcMeshTrampoline {
 #[derive(Serialize, Deserialize, Debug, Named, Handler, RefClient)]
 pub struct GetHostMeshAgent {
     #[reply]
-    pub host_mesh_agent: PortRef<ActorRef<HostAgent>>,
+    pub host_mesh_agent: hyperactor_reference::PortRef<hyperactor_reference::ActorRef<HostAgent>>,
 }
 wirevalue::register_type!(GetHostMeshAgent);
 
@@ -957,8 +959,8 @@ mod tests {
                     ..
                 }),
             } if name == resource_name
-              && proc_id == ProcId::with_name(host_addr.clone(), name.to_string())
-              && mesh_agent == ActorRef::attest(ProcId::with_name(host_addr.clone(), name.to_string()).actor_id(crate::proc_agent::PROC_AGENT_ACTOR_NAME, 0)) && bootstrap_command == Some(BootstrapCommand::test())
+              && proc_id == hyperactor_reference::ProcId::with_name(host_addr.clone(), name.to_string())
+              && mesh_agent == hyperactor_reference::ActorRef::attest(hyperactor_reference::ProcId::with_name(host_addr.clone(), name.to_string()).actor_id(crate::proc_agent::PROC_AGENT_ACTOR_NAME, 0)) && bootstrap_command == Some(BootstrapCommand::test())
               && mesh_agent == proc_status_mesh_agent
         );
     }

--- a/hyperactor_mesh/src/lib.rs
+++ b/hyperactor_mesh/src/lib.rs
@@ -72,9 +72,6 @@ pub use global_context::context;
 pub use global_context::this_host;
 pub use global_context::this_proc;
 pub use host_mesh::HostMeshRef;
-use hyperactor::ActorId;
-use hyperactor::ActorRef;
-use hyperactor::ProcId;
 use hyperactor::host::HostError;
 use hyperactor::mailbox::MailboxSenderError;
 use hyperactor::reference as hyperactor_reference;
@@ -150,7 +147,7 @@ pub enum Error {
     UnroutableMesh(),
 
     #[error("error while calling actor {0}: {1}")]
-    CallError(ActorId, anyhow::Error),
+    CallError(hyperactor_reference::ActorId, anyhow::Error),
 
     #[error("actor not registered for type {0}")]
     ActorTypeNotRegistered(String),
@@ -160,13 +157,13 @@ pub enum Error {
     GspawnError(Name, String),
 
     #[error("error while sending message to actor {0}: {1}")]
-    SendingError(ActorId, Box<MailboxSenderError>),
+    SendingError(hyperactor_reference::ActorId, Box<MailboxSenderError>),
 
     #[error("error while casting message to {0}: {1}")]
     CastingError(Name, anyhow::Error),
 
     #[error("error configuring host mesh agent {0}: {1}")]
-    HostMeshAgentConfigurationError(ActorId, String),
+    HostMeshAgentConfigurationError(hyperactor_reference::ActorId, String),
 
     #[error(
         "error creating proc (host rank {host_rank}) on host mesh agent {mesh_agent}, state: {state}"
@@ -174,7 +171,7 @@ pub enum Error {
     ProcCreationError {
         state: Box<resource::State<ProcState>>,
         host_rank: usize,
-        mesh_agent: ActorRef<HostAgent>,
+        mesh_agent: hyperactor_reference::ActorRef<HostAgent>,
     },
 
     #[error(
@@ -202,7 +199,7 @@ pub enum Error {
     ControllerActorSpawnError(Name, anyhow::Error),
 
     #[error("proc {0} must be direct-addressable")]
-    RankedProc(ProcId),
+    RankedProc(hyperactor_reference::ProcId),
 
     #[error("{0}")]
     Supervision(Box<MeshFailure>),

--- a/hyperactor_mesh/src/logging.rs
+++ b/hyperactor_mesh/src/logging.rs
@@ -21,14 +21,11 @@ use chrono::DateTime;
 use chrono::Local;
 use hostname;
 use hyperactor::Actor;
-use hyperactor::ActorRef;
 use hyperactor::Bind;
 use hyperactor::Context;
 use hyperactor::HandleClient;
 use hyperactor::Handler;
 use hyperactor::Instance;
-use hyperactor::OncePortRef;
-use hyperactor::ProcId;
 use hyperactor::RefClient;
 use hyperactor::Unbind;
 use hyperactor::channel;
@@ -41,6 +38,7 @@ use hyperactor::channel::Tx;
 use hyperactor::channel::TxStatus;
 use hyperactor::clock::Clock;
 use hyperactor::clock::RealClock;
+use hyperactor::reference as hyperactor_reference;
 use hyperactor_config::CONFIG;
 use hyperactor_config::ConfigAttr;
 use hyperactor_config::Flattrs;
@@ -327,9 +325,9 @@ pub enum LogClientMessage {
         /// Expect these many procs to ack the flush message.
         expected_procs: usize,
         /// Return once we have received the acks from all the procs
-        reply: OncePortRef<()>,
+        reply: hyperactor_reference::OncePortRef<()>,
         /// Return to the caller the current flush version
-        version: OncePortRef<u64>,
+        version: hyperactor_reference::OncePortRef<u64>,
     },
 }
 
@@ -370,7 +368,10 @@ pub struct LocalLogSender {
 }
 
 impl LocalLogSender {
-    fn new(log_channel: ChannelAddr, proc_id: &ProcId) -> Result<Self, anyhow::Error> {
+    fn new(
+        log_channel: ChannelAddr,
+        proc_id: &hyperactor_reference::ProcId,
+    ) -> Result<Self, anyhow::Error> {
         let tx = channel::dial::<LogMessage>(log_channel)?;
         let status = tx.status().clone();
 
@@ -854,7 +855,7 @@ impl StreamFwder {
         target: OutputTarget,
         max_buffer_size: usize,
         log_channel: Option<ChannelAddr>,
-        proc_id: &ProcId,
+        proc_id: &hyperactor_reference::ProcId,
         local_rank: usize,
     ) -> Self {
         let prefix = match hyperactor_config::global::get(PREFIX_WITH_RANK) {
@@ -883,7 +884,7 @@ impl StreamFwder {
         target: OutputTarget,
         max_buffer_size: usize,
         log_channel: Option<ChannelAddr>,
-        proc_id: &ProcId,
+        proc_id: &hyperactor_reference::ProcId,
         prefix: Option<String>,
     ) -> Self {
         // Sanity: when there is no file sink, no log forwarding, and
@@ -993,7 +994,7 @@ pub struct LogForwardActor {
     rx: ChannelRx<LogMessage>,
     flush_tx: Arc<Mutex<ChannelTx<LogMessage>>>,
     next_flush_deadline: SystemTime,
-    logging_client_ref: ActorRef<LogClientActor>,
+    logging_client_ref: hyperactor_reference::ActorRef<LogClientActor>,
     stream_to_client: bool,
 }
 
@@ -1015,7 +1016,7 @@ impl Actor for LogForwardActor {
 
 #[async_trait]
 impl hyperactor::RemoteSpawn for LogForwardActor {
-    type Params = ActorRef<LogClientActor>;
+    type Params = hyperactor_reference::ActorRef<LogClientActor>;
 
     async fn new(logging_client_ref: Self::Params, _environment: Flattrs) -> Result<Self> {
         let log_channel: ChannelAddr = match std::env::var(BOOTSTRAP_LOG_CHANNEL) {
@@ -1181,7 +1182,7 @@ pub struct LogClientActor {
 
     // For flush sync barrier
     current_flush_version: u64,
-    current_flush_port: Option<OncePortRef<()>>,
+    current_flush_port: Option<hyperactor_reference::OncePortRef<()>>,
     current_unflushed_procs: usize,
 }
 
@@ -1393,8 +1394,8 @@ impl LogClientMessageHandler for LogClientActor {
         &mut self,
         cx: &Context<Self>,
         expected_procs_flushed: usize,
-        reply: OncePortRef<()>,
-        version: OncePortRef<u64>,
+        reply: hyperactor_reference::OncePortRef<()>,
+        version: hyperactor_reference::OncePortRef<u64>,
     ) -> Result<(), anyhow::Error> {
         if self.current_unflushed_procs > 0 || self.current_flush_port.is_some() {
             tracing::warn!(
@@ -1611,12 +1612,12 @@ mod tests {
             std::env::set_var(BOOTSTRAP_LOG_CHANNEL, log_channel.to_string());
         }
         let log_client_actor = LogClientActor::new((), Flattrs::default()).await.unwrap();
-        let log_client: ActorRef<LogClientActor> =
+        let log_client: hyperactor_reference::ActorRef<LogClientActor> =
             proc.spawn("log_client", log_client_actor).unwrap().bind();
         let log_forwarder_actor = LogForwardActor::new(log_client.clone(), Flattrs::default())
             .await
             .unwrap();
-        let log_forwarder: ActorRef<LogForwardActor> = proc
+        let log_forwarder: hyperactor_reference::ActorRef<LogForwardActor> = proc
             .spawn("log_forwarder", log_forwarder_actor)
             .unwrap()
             .bind();

--- a/hyperactor_mesh/src/mesh_admin.rs
+++ b/hyperactor_mesh/src/mesh_admin.rs
@@ -154,15 +154,10 @@ use axum::response::IntoResponse;
 use axum::routing::get;
 use hyperactor::Actor;
 use hyperactor::ActorHandle;
-use hyperactor::ActorId;
-use hyperactor::ActorRef;
 use hyperactor::Context;
 use hyperactor::HandleClient;
 use hyperactor::Handler;
 use hyperactor::Instance;
-use hyperactor::OncePortRef;
-use hyperactor::PortRef;
-use hyperactor::ProcId;
 use hyperactor::RefClient;
 use hyperactor::channel::try_tls_acceptor;
 use hyperactor::clock::Clock;
@@ -171,7 +166,7 @@ use hyperactor::introspect::IntrospectMessage;
 use hyperactor::introspect::NodePayload;
 use hyperactor::introspect::NodeProperties;
 use hyperactor::mailbox::open_once_port;
-use hyperactor::reference::Reference;
+use hyperactor::reference as hyperactor_reference;
 use serde::Deserialize;
 use serde::Serialize;
 use serde_json::Value;
@@ -306,7 +301,7 @@ pub enum MeshAdminMessage {
     /// The reply contains `None` if the server hasn't started yet.
     GetAdminAddr {
         #[reply]
-        reply: OncePortRef<MeshAdminAddrResponse>,
+        reply: hyperactor_reference::OncePortRef<MeshAdminAddrResponse>,
     },
 }
 wirevalue::register_type!(MeshAdminMessage);
@@ -355,7 +350,7 @@ pub enum ResolveReferenceMessage {
         reference_string: String,
         /// Reply port receiving the resolution result.
         #[reply]
-        reply: OncePortRef<ResolveReferenceResponse>,
+        reply: hyperactor_reference::OncePortRef<ResolveReferenceResponse>,
     },
 }
 wirevalue::register_type!(ResolveReferenceMessage);
@@ -363,7 +358,7 @@ wirevalue::register_type!(ResolveReferenceMessage);
 /// Actor that serves a mesh-level admin HTTP endpoint.
 ///
 /// `MeshAdminAgent` is the mesh-wide aggregation point for
-/// introspection: it holds `ActorRef<HostAgent>` handles for each
+/// introspection: it holds `hyperactor_reference::ActorRef<HostAgent>` handles for each
 /// host, and answers admin queries by forwarding targeted requests to
 /// the appropriate host agent and assembling a uniform `NodePayload`
 /// response for the client.
@@ -376,7 +371,7 @@ wirevalue::register_type!(ResolveReferenceMessage);
 pub struct MeshAdminAgent {
     /// Map of host address string → `HostAgent` reference used to
     /// fan out our target admin queries.
-    hosts: HashMap<String, ActorRef<HostAgent>>,
+    hosts: HashMap<String, hyperactor_reference::ActorRef<HostAgent>>,
 
     /// Reverse index: `HostAgent` `ActorId` → host address
     /// string.
@@ -387,19 +382,19 @@ pub struct MeshAdminAgent {
     /// `ActorId` as a *Host* node (via `resolve_host_node`) rather
     /// than a generic *Actor* node, avoiding cycles / dropped nodes
     /// in clients like the TUI.
-    host_agents_by_actor_id: HashMap<ActorId, String>,
+    host_agents_by_actor_id: HashMap<hyperactor_reference::ActorId, String>,
 
     /// `ActorId` of the process-global root client (`client[0]` on
     /// the singleton Host's `local_proc`), exposed as a first-class
     /// child of the root node. Routable and introspectable via the
     /// blanket `Handler<IntrospectMessage>`.
-    root_client_actor_id: Option<ActorId>,
+    root_client_actor_id: Option<hyperactor_reference::ActorId>,
 
     /// This agent's own `ActorId`, captured during `init`. Used to
     /// include the admin proc as a visible node in the introspection
     /// tree (the principle: "if you can send it a message, you can
     /// introspect it").
-    self_actor_id: Option<ActorId>,
+    self_actor_id: Option<hyperactor_reference::ActorId>,
 
     // -- HTTP server address fields --
     //
@@ -453,11 +448,11 @@ impl MeshAdminAgent {
     /// The HTTP listen address is initialized to `None` and populated
     /// during `init()` after the server socket is bound.
     pub fn new(
-        hosts: Vec<(String, ActorRef<HostAgent>)>,
-        root_client_actor_id: Option<ActorId>,
+        hosts: Vec<(String, hyperactor_reference::ActorRef<HostAgent>)>,
+        root_client_actor_id: Option<hyperactor_reference::ActorId>,
         admin_addr: Option<std::net::SocketAddr>,
     ) -> Self {
-        let host_agents_by_actor_id: HashMap<ActorId, String> = hosts
+        let host_agents_by_actor_id: HashMap<hyperactor_reference::ActorId, String> = hosts
             .iter()
             .map(|(addr, agent_ref)| (agent_ref.actor_id().clone(), addr.clone()))
             .collect();
@@ -508,7 +503,7 @@ impl std::fmt::Debug for MeshAdminAgent {
 struct BridgeState {
     /// Reference to the `MeshAdminAgent` actor that performs
     /// reference resolution.
-    admin_ref: ActorRef<MeshAdminAgent>,
+    admin_ref: hyperactor_reference::ActorRef<MeshAdminAgent>,
     /// Dedicated client mailbox on system_proc for HTTP bridge reply
     /// ports. Using a separate `Instance<()>` avoids sharing the
     /// actor's own mailbox with the HTTP bridge and ensures the
@@ -625,7 +620,7 @@ impl Actor for MeshAdminAgent {
             .introspectable_instance(MESH_ADMIN_BRIDGE_NAME)?;
         bridge_cx.set_system();
         let bridge_state = Arc::new(BridgeState {
-            admin_ref: ActorRef::attest(this.self_id().clone()),
+            admin_ref: hyperactor_reference::ActorRef::attest(this.self_id().clone()),
             bridge_cx,
             _bridge_handle: bridge_handle,
         });
@@ -784,12 +779,12 @@ impl MeshAdminAgent {
             return self.resolve_host_node(cx, &host_id.0).await;
         }
 
-        let reference: Reference = reference_string
+        let reference: hyperactor_reference::Reference = reference_string
             .parse()
             .map_err(|e| anyhow::anyhow!("invalid reference '{}': {}", reference_string, e))?;
 
         match &reference {
-            Reference::Proc(proc_id) => {
+            hyperactor_reference::Reference::Proc(proc_id) => {
                 // Try the host-managed path first (uses ProcAgent,
                 // sees all actors). Fall back to the standalone
                 // anchor path for procs truly off-mesh (A != C).
@@ -801,7 +796,9 @@ impl MeshAdminAgent {
                     Err(e) => Err(e),
                 }
             }
-            Reference::Actor(actor_id) => self.resolve_actor_node(cx, actor_id).await,
+            hyperactor_reference::Reference::Actor(actor_id) => {
+                self.resolve_actor_node(cx, actor_id).await
+            }
             _ => Err(anyhow::anyhow!(
                 "unsupported reference type: {}",
                 reference_string
@@ -816,19 +813,22 @@ impl MeshAdminAgent {
     ///
     /// The root client is no longer standalone: spawn_admin registers
     /// C (the bootstrap host) as a normal host entry (A/C invariant).
-    fn standalone_proc_actors(&self) -> impl Iterator<Item = &ActorId> {
+    fn standalone_proc_actors(&self) -> impl Iterator<Item = &hyperactor_reference::ActorId> {
         std::iter::empty()
     }
 
     /// If `proc_id` belongs to a standalone proc, return the anchor
     /// actor on that proc. Returns `None` for host-managed procs.
-    fn standalone_proc_anchor(&self, proc_id: &ProcId) -> Option<&ActorId> {
+    fn standalone_proc_anchor(
+        &self,
+        proc_id: &hyperactor_reference::ProcId,
+    ) -> Option<&hyperactor_reference::ActorId> {
         self.standalone_proc_actors()
             .find(|actor_id| *actor_id.proc_id() == *proc_id)
     }
 
     /// Returns true if `actor_id` lives on a standalone proc.
-    fn is_standalone_proc_actor(&self, actor_id: &ActorId) -> bool {
+    fn is_standalone_proc_actor(&self, actor_id: &hyperactor_reference::ActorId) -> bool {
         self.standalone_proc_actors()
             .any(|a| *a.proc_id() == *actor_id.proc_id())
     }
@@ -871,9 +871,10 @@ impl MeshAdminAgent {
     async fn resolve_host_node(
         &self,
         cx: &Context<'_, Self>,
-        actor_id: &ActorId,
+        actor_id: &hyperactor_reference::ActorId,
     ) -> Result<NodePayload, anyhow::Error> {
-        let introspect_port = PortRef::<IntrospectMessage>::attest_message_port(actor_id);
+        let introspect_port =
+            hyperactor_reference::PortRef::<IntrospectMessage>::attest_message_port(actor_id);
         let (reply_handle, reply_rx) = open_once_port::<NodePayload>(cx);
         introspect_port.send(
             cx,
@@ -899,7 +900,7 @@ impl MeshAdminAgent {
     /// First tries `IntrospectMessage::QueryChild` against the owning
     /// `HostAgent` (which recognizes service and local procs). If that returns an error
     /// payload, falls back to `ProcAgent` for user procs by querying
-    /// `QueryChild(Reference::Proc(proc_id))` on
+    /// `QueryChild(hyperactor_reference::Reference::Proc(proc_id))` on
     /// `<proc_id>/proc_agent[0]`.
     ///
     /// Invariant PA-1: proc-node children used by admin/TUI must be
@@ -909,7 +910,7 @@ impl MeshAdminAgent {
     async fn resolve_proc_node(
         &self,
         cx: &Context<'_, Self>,
-        proc_id: &ProcId,
+        proc_id: &hyperactor_reference::ProcId,
     ) -> Result<NodePayload, anyhow::Error> {
         let host_addr = proc_id.addr().to_string();
 
@@ -919,8 +920,11 @@ impl MeshAdminAgent {
             .ok_or_else(|| anyhow::anyhow!("host not found: {}", host_addr))?;
 
         // Try the host agent's QueryChild first.
-        let child_ref = Reference::Proc(proc_id.clone());
-        let introspect_port = PortRef::<IntrospectMessage>::attest_message_port(agent.actor_id());
+        let child_ref = hyperactor_reference::Reference::Proc(proc_id.clone());
+        let introspect_port =
+            hyperactor_reference::PortRef::<IntrospectMessage>::attest_message_port(
+                agent.actor_id(),
+            );
         let (reply_handle, reply_rx) = open_once_port::<NodePayload>(cx);
         introspect_port.send(
             cx,
@@ -945,12 +949,13 @@ impl MeshAdminAgent {
         // procs). The conventional ProcAgent ActorId is
         // <proc_id>/proc_agent[0].
         let mesh_agent_id = proc_id.actor_id(crate::proc_agent::PROC_AGENT_ACTOR_NAME, 0);
-        let agent_port = PortRef::<IntrospectMessage>::attest_message_port(&mesh_agent_id);
+        let agent_port =
+            hyperactor_reference::PortRef::<IntrospectMessage>::attest_message_port(&mesh_agent_id);
         let (reply_handle, reply_rx) = open_once_port::<NodePayload>(cx);
         agent_port.send(
             cx,
             IntrospectMessage::QueryChild {
-                child_ref: Reference::Proc(proc_id.clone()),
+                child_ref: hyperactor_reference::Reference::Proc(proc_id.clone()),
                 reply: reply_handle.bind(),
             },
         )?;
@@ -989,7 +994,7 @@ impl MeshAdminAgent {
     async fn resolve_standalone_proc_node(
         &self,
         cx: &Context<'_, Self>,
-        proc_id: &ProcId,
+        proc_id: &hyperactor_reference::ProcId,
     ) -> Result<NodePayload, anyhow::Error> {
         let actor_id = self
             .standalone_proc_anchor(proc_id)
@@ -1002,7 +1007,8 @@ impl MeshAdminAgent {
             (vec![self_ref.clone()], vec![self_ref])
         } else {
             // Query the anchor actor for its supervision children.
-            let introspect_port = PortRef::<IntrospectMessage>::attest_message_port(actor_id);
+            let introspect_port =
+                hyperactor_reference::PortRef::<IntrospectMessage>::attest_message_port(actor_id);
             let (reply_handle, reply_rx) = open_once_port::<NodePayload>(cx);
             introspect_port.send(
                 cx,
@@ -1038,9 +1044,11 @@ impl MeshAdminAgent {
 
             // Query each supervision child to check is_system.
             for child_ref in actor_payload.children {
-                if let Ok(child_actor_id) = child_ref.parse::<ActorId>() {
+                if let Ok(child_actor_id) = child_ref.parse::<hyperactor_reference::ActorId>() {
                     let child_port =
-                        PortRef::<IntrospectMessage>::attest_message_port(&child_actor_id);
+                        hyperactor_reference::PortRef::<IntrospectMessage>::attest_message_port(
+                            &child_actor_id,
+                        );
                     let (reply_handle, reply_rx) = open_once_port::<NodePayload>(cx);
                     let child_is_system = if child_port
                         .send(
@@ -1107,7 +1115,7 @@ impl MeshAdminAgent {
     async fn resolve_actor_node(
         &self,
         cx: &Context<'_, Self>,
-        actor_id: &ActorId,
+        actor_id: &hyperactor_reference::ActorId,
     ) -> Result<NodePayload, anyhow::Error> {
         // Self-resolution: we cannot send IntrospectMessage to our
         // own actor loop while handling a resolve request (deadlock).
@@ -1119,7 +1127,8 @@ impl MeshAdminAgent {
             // Standalone procs (e.g. the admin proc itself) have no
             // ProcAgent at agent[0], so skip the QueryChild
             // terminated-snapshot check and query the actor directly.
-            let introspect_port = PortRef::<IntrospectMessage>::attest_message_port(actor_id);
+            let introspect_port =
+                hyperactor_reference::PortRef::<IntrospectMessage>::attest_message_port(actor_id);
             let (reply_handle, reply_rx) = open_once_port::<NodePayload>(cx);
             introspect_port.send(
                 cx,
@@ -1139,8 +1148,11 @@ impl MeshAdminAgent {
             let terminated = {
                 let proc_id = actor_id.proc_id();
                 let mesh_agent_id = proc_id.actor_id(crate::proc_agent::PROC_AGENT_ACTOR_NAME, 0);
-                let agent_port = PortRef::<IntrospectMessage>::attest_message_port(&mesh_agent_id);
-                let child_ref = Reference::Actor(actor_id.clone());
+                let agent_port =
+                    hyperactor_reference::PortRef::<IntrospectMessage>::attest_message_port(
+                        &mesh_agent_id,
+                    );
+                let child_ref = hyperactor_reference::Reference::Actor(actor_id.clone());
                 let (reply_handle, reply_rx) = open_once_port::<NodePayload>(cx);
                 agent_port.send(
                     cx,
@@ -1163,7 +1175,9 @@ impl MeshAdminAgent {
                     // Not terminated — query the live actor with
                     // the full timeout.
                     let introspect_port =
-                        PortRef::<IntrospectMessage>::attest_message_port(actor_id);
+                        hyperactor_reference::PortRef::<IntrospectMessage>::attest_message_port(
+                            actor_id,
+                        );
                     let (reply_handle, reply_rx) = open_once_port::<NodePayload>(cx);
                     introspect_port.send(
                         cx,
@@ -1814,8 +1828,10 @@ mod tests {
         let actor_id1 = proc1.actor_id("mesh_agent", 0);
         let actor_id2 = proc2.actor_id("mesh_agent", 0);
 
-        let ref1: ActorRef<HostAgent> = ActorRef::attest(actor_id1.clone());
-        let ref2: ActorRef<HostAgent> = ActorRef::attest(actor_id2.clone());
+        let ref1: hyperactor_reference::ActorRef<HostAgent> =
+            hyperactor_reference::ActorRef::attest(actor_id1.clone());
+        let ref2: hyperactor_reference::ActorRef<HostAgent> =
+            hyperactor_reference::ActorRef::attest(actor_id2.clone());
 
         let agent = MeshAdminAgent::new(
             vec![("host_a".to_string(), ref1), ("host_b".to_string(), ref2)],
@@ -1878,7 +1894,7 @@ mod tests {
                 HostAgent::new(HostAgentMode::Local(host)),
             )
             .unwrap();
-        let host_agent_ref: ActorRef<HostAgent> = host_agent_handle.bind();
+        let host_agent_ref: hyperactor_reference::ActorRef<HostAgent> = host_agent_handle.bind();
         let host_addr_str = host_addr.to_string();
 
         // -- 2. Spawn MeshAdminAgent on a separate proc --
@@ -1897,7 +1913,7 @@ mod tests {
                 ),
             )
             .unwrap();
-        let admin_ref: ActorRef<MeshAdminAgent> = admin_handle.bind();
+        let admin_ref: hyperactor_reference::ActorRef<MeshAdminAgent> = admin_handle.bind();
 
         // -- 3. Create a bare client instance for sending messages --
         // Only a mailbox is needed for reply ports — no actor message
@@ -2038,7 +2054,7 @@ mod tests {
                 HostAgent::new(HostAgentMode::Local(host)),
             )
             .unwrap();
-        let host_agent_ref: ActorRef<HostAgent> = host_agent_handle.bind();
+        let host_agent_ref: hyperactor_reference::ActorRef<HostAgent> = host_agent_handle.bind();
         let host_addr_str = host_addr.to_string();
 
         // Spawn MeshAdminAgent on a separate proc.
@@ -2055,7 +2071,7 @@ mod tests {
                 ),
             )
             .unwrap();
-        let admin_ref: ActorRef<MeshAdminAgent> = admin_handle.bind();
+        let admin_ref: hyperactor_reference::ActorRef<MeshAdminAgent> = admin_handle.bind();
 
         // Create a bare client instance for sending messages.
         let client_proc = Proc::direct(ChannelTransport::Unix.any(), "client".to_string()).unwrap();
@@ -2123,11 +2139,13 @@ mod tests {
     #[test]
     fn test_build_root_payload_with_root_client() {
         let addr1: SocketAddr = "127.0.0.1:9001".parse().unwrap();
-        let proc1 = ProcId::with_name(ChannelAddr::Tcp(addr1), "host1");
-        let actor_id1 = ActorId::root(proc1, "mesh_agent".to_string());
-        let ref1: ActorRef<HostAgent> = ActorRef::attest(actor_id1.clone());
+        let proc1 = hyperactor_reference::ProcId::with_name(ChannelAddr::Tcp(addr1), "host1");
+        let actor_id1 = hyperactor_reference::ActorId::root(proc1, "mesh_agent".to_string());
+        let ref1: hyperactor_reference::ActorRef<HostAgent> =
+            hyperactor_reference::ActorRef::attest(actor_id1.clone());
 
-        let client_proc_id = ProcId::with_name(ChannelAddr::Tcp(addr1), "local");
+        let client_proc_id =
+            hyperactor_reference::ProcId::with_name(ChannelAddr::Tcp(addr1), "local");
         let client_actor_id = client_proc_id.actor_id("client", 0);
 
         let agent = MeshAdminAgent::new(
@@ -2179,7 +2197,8 @@ mod tests {
         let local_proc = host.local_proc();
         let local_proc_id = local_proc.proc_id().clone();
         let root_client_handle = local_proc.spawn("client", TestIntrospectableActor).unwrap();
-        let root_client_ref: ActorRef<TestIntrospectableActor> = root_client_handle.bind();
+        let root_client_ref: hyperactor_reference::ActorRef<TestIntrospectableActor> =
+            root_client_handle.bind();
         let root_client_actor_id = root_client_ref.actor_id().clone();
 
         let host_agent_handle = system_proc
@@ -2188,7 +2207,7 @@ mod tests {
                 HostAgent::new(HostAgentMode::Local(host)),
             )
             .unwrap();
-        let host_agent_ref: ActorRef<HostAgent> = host_agent_handle.bind();
+        let host_agent_ref: hyperactor_reference::ActorRef<HostAgent> = host_agent_handle.bind();
         let host_addr_str = host_addr.to_string();
 
         // Spawn MeshAdminAgent with the root client ActorId.
@@ -2206,7 +2225,7 @@ mod tests {
                 ),
             )
             .unwrap();
-        let admin_ref: ActorRef<MeshAdminAgent> = admin_handle.bind();
+        let admin_ref: hyperactor_reference::ActorRef<MeshAdminAgent> = admin_handle.bind();
 
         // Client for sending messages.
         let client_proc =
@@ -2342,7 +2361,7 @@ mod tests {
                 HostAgent::new(HostAgentMode::Local(host)),
             )
             .unwrap();
-        let host_agent_ref: ActorRef<HostAgent> = host_agent_handle.bind();
+        let host_agent_ref: hyperactor_reference::ActorRef<HostAgent> = host_agent_handle.bind();
         let host_addr_str = host_addr.to_string();
 
         // Spawn MeshAdminAgent on a separate proc.
@@ -2359,7 +2378,7 @@ mod tests {
                 ),
             )
             .unwrap();
-        let admin_ref: ActorRef<MeshAdminAgent> = admin_handle.bind();
+        let admin_ref: hyperactor_reference::ActorRef<MeshAdminAgent> = admin_handle.bind();
 
         let client_proc = Proc::direct(ChannelTransport::Unix.any(), "client".to_string()).unwrap();
         let (client, _handle) = client_proc.instance("client").unwrap();
@@ -2448,7 +2467,7 @@ mod tests {
                 HostAgent::new(HostAgentMode::Local(host)),
             )
             .unwrap();
-        let host_agent_ref: ActorRef<HostAgent> = host_agent_handle.bind();
+        let host_agent_ref: hyperactor_reference::ActorRef<HostAgent> = host_agent_handle.bind();
         let host_addr_str = host_addr.to_string();
 
         // -- 2. Spawn MeshAdminAgent on a separate proc --
@@ -2465,7 +2484,7 @@ mod tests {
                 ),
             )
             .unwrap();
-        let admin_ref: ActorRef<MeshAdminAgent> = admin_handle.bind();
+        let admin_ref: hyperactor_reference::ActorRef<MeshAdminAgent> = admin_handle.bind();
 
         // -- 3. Create a bare client instance for sending messages --
         let client_proc = Proc::direct(ChannelTransport::Unix.any(), "client".to_string()).unwrap();
@@ -2895,7 +2914,7 @@ mod tests {
                 HostAgent::new(HostAgentMode::Local(host)),
             )
             .unwrap();
-        let host_agent_ref: ActorRef<HostAgent> = host_agent_handle.bind();
+        let host_agent_ref: hyperactor_reference::ActorRef<HostAgent> = host_agent_handle.bind();
 
         // User proc: own ephemeral Unix socket, own ProcAgent.
         let user_proc =
@@ -2923,7 +2942,7 @@ mod tests {
                 ),
             )
             .unwrap();
-        let admin_ref: ActorRef<MeshAdminAgent> = admin_handle.bind();
+        let admin_ref: hyperactor_reference::ActorRef<MeshAdminAgent> = admin_handle.bind();
 
         let client_proc = Proc::direct(ChannelTransport::Unix.any(), "client".to_string()).unwrap();
         let (client, _client_handle) = client_proc.instance("client").unwrap();

--- a/hyperactor_mesh/src/mesh_controller.rs
+++ b/hyperactor_mesh/src/mesh_controller.rs
@@ -16,8 +16,6 @@ use hyperactor::Bind;
 use hyperactor::Context;
 use hyperactor::Handler;
 use hyperactor::Instance;
-use hyperactor::PortRef;
-use hyperactor::ProcId;
 use hyperactor::Unbind;
 use hyperactor::actor::ActorError;
 use hyperactor::actor::ActorErrorKind;
@@ -30,6 +28,7 @@ use hyperactor::context;
 use hyperactor::kv_pairs;
 use hyperactor::mailbox::MessageEnvelope;
 use hyperactor::mailbox::Undeliverable;
+use hyperactor::reference as hyperactor_reference;
 use hyperactor::supervision::ActorSupervisionEvent;
 use hyperactor_config::CONFIG;
 use hyperactor_config::ConfigAttr;
@@ -89,15 +88,15 @@ struct HealthState {
     unhealthy_event: Option<Unhealthy>,
     crashed_ranks: HashMap<usize, ActorSupervisionEvent>,
     // The unique owner of this actor.
-    owner: Option<PortRef<MeshFailure>>,
+    owner: Option<hyperactor_reference::PortRef<MeshFailure>>,
     /// A set of subscribers to send messages to when events are encountered.
-    subscribers: HashSet<PortRef<Option<MeshFailure>>>,
+    subscribers: HashSet<hyperactor_reference::PortRef<Option<MeshFailure>>>,
 }
 
 impl HealthState {
     fn new(
         statuses: HashMap<Point, resource::Status>,
-        owner: Option<PortRef<MeshFailure>>,
+        owner: Option<hyperactor_reference::PortRef<MeshFailure>>,
     ) -> Self {
         Self {
             statuses,
@@ -115,16 +114,16 @@ impl HealthState {
 /// the listener that the controller is still alive. Make sure to filter such events
 /// out as not useful.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Named, Bind, Unbind)]
-pub struct Subscribe(pub PortRef<Option<MeshFailure>>);
+pub struct Subscribe(pub hyperactor_reference::PortRef<Option<MeshFailure>>);
 
 /// Unsubscribe me to future updates about a mesh. Should be the same port used in
 /// the Subscribe message.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Named, Bind, Unbind)]
-pub struct Unsubscribe(pub PortRef<Option<MeshFailure>>);
+pub struct Unsubscribe(pub hyperactor_reference::PortRef<Option<MeshFailure>>);
 
 /// Query the number of active supervision subscribers on this controller.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Named, Bind, Unbind)]
-pub struct GetSubscriberCount(#[binding(include)] pub PortRef<usize>);
+pub struct GetSubscriberCount(#[binding(include)] pub hyperactor_reference::PortRef<usize>);
 
 /// Check state of the actors in the mesh. This is used as a self message to
 /// periodically check.
@@ -172,7 +171,7 @@ impl<A: Referable> ActorMeshController<A> {
     pub(crate) fn new(
         mesh: ActorMeshRef<A>,
         supervision_display_name: Option<String>,
-        port: Option<PortRef<MeshFailure>>,
+        port: Option<hyperactor_reference::PortRef<MeshFailure>>,
         initial_statuses: ValueMesh<resource::Status>,
     ) -> Self {
         let supervision_display_name =
@@ -218,7 +217,7 @@ declare_attrs! {
 
 fn send_subscriber_message(
     cx: &impl context::Actor,
-    subscriber: &PortRef<Option<MeshFailure>>,
+    subscriber: &hyperactor_reference::PortRef<Option<MeshFailure>>,
     message: MeshFailure,
 ) {
     let mut headers = Flattrs::new();
@@ -292,7 +291,7 @@ impl<A: Referable> Actor for ActorMeshController<A> {
             // NOTE: The only part of the port that is used for equality checks is
             // the port id, so create a new one just for the comparison.
             let dest_port_id = envelope.0.dest().clone();
-            let port = PortRef::<Option<MeshFailure>>::attest(dest_port_id);
+            let port = hyperactor_reference::PortRef::<Option<MeshFailure>>::attest(dest_port_id);
             let did_exist = self.health_state.subscribers.remove(&port);
             if did_exist {
                 tracing::debug!(
@@ -894,7 +893,10 @@ impl Actor for ProcMeshController {
         _err: Option<&ActorError>,
     ) -> Result<(), anyhow::Error> {
         // Cannot use "ProcMesh::stop" as it's only defined on ProcMesh, not ProcMeshRef.
-        let names = self.mesh.proc_ids().collect::<Vec<ProcId>>();
+        let names = self
+            .mesh
+            .proc_ids()
+            .collect::<Vec<hyperactor_reference::ProcId>>();
         let region = self.mesh.region().clone();
         if let Some(hosts) = self.mesh.hosts() {
             hosts

--- a/hyperactor_mesh/src/proc_agent.rs
+++ b/hyperactor_mesh/src/proc_agent.rs
@@ -14,14 +14,12 @@ use std::time::Duration;
 use async_trait::async_trait;
 use hyperactor::Actor;
 use hyperactor::ActorHandle;
-use hyperactor::ActorId;
 use hyperactor::Bind;
 use hyperactor::Context;
 use hyperactor::Data;
 use hyperactor::HandleClient;
 use hyperactor::Handler;
 use hyperactor::Instance;
-use hyperactor::OncePortRef;
 use hyperactor::PortHandle;
 use hyperactor::RefClient;
 use hyperactor::Unbind;
@@ -30,6 +28,7 @@ use hyperactor::actor::remote::Remote;
 use hyperactor::clock::Clock;
 use hyperactor::clock::RealClock;
 use hyperactor::proc::Proc;
+use hyperactor::reference as hyperactor_reference;
 use hyperactor::supervision::ActorSupervisionEvent;
 use hyperactor_config::CONFIG;
 use hyperactor_config::ConfigAttr;
@@ -93,14 +92,14 @@ pub(crate) enum MeshAgentMessage {
     /// Stop actors of a specific mesh name
     StopActor {
         /// The actor to stop
-        actor_id: ActorId,
+        actor_id: hyperactor_reference::ActorId,
         /// The timeout for waiting for the actor to stop
         timeout_ms: u64,
         /// The reason for stopping the actor
         reason: String,
         /// The result when trying to stop the actor
         #[reply]
-        stopped: OncePortRef<StopActorResult>,
+        stopped: hyperactor_reference::OncePortRef<StopActorResult>,
     },
 }
 
@@ -108,7 +107,7 @@ pub(crate) enum MeshAgentMessage {
 #[derive(Debug)]
 struct ActorInstanceState {
     create_rank: usize,
-    spawn: Result<ActorId, anyhow::Error>,
+    spawn: Result<hyperactor_reference::ActorId, anyhow::Error>,
     /// If true, the actor has been stopped. There is no way to restart it, a new
     /// actor must be spawned.
     stopped: bool,
@@ -172,7 +171,7 @@ pub struct ProcAgent {
     /// If true, record supervision events to be reported to owning actors later.
     record_supervision_events: bool,
     /// Contains the list of all supervision events that were received.
-    supervision_events: HashMap<ActorId, Vec<ActorSupervisionEvent>>,
+    supervision_events: HashMap<hyperactor_reference::ActorId, Vec<ActorSupervisionEvent>>,
     /// True when supervision events have arrived but introspect
     /// properties haven't been republished yet.
     introspect_dirty: bool,
@@ -216,7 +215,13 @@ impl ProcAgent {
         cx: &Context<'a, Self>,
         timeout: tokio::time::Duration,
         reason: &str,
-    ) -> Result<(Vec<ActorId>, Vec<ActorId>), anyhow::Error> {
+    ) -> Result<
+        (
+            Vec<hyperactor_reference::ActorId>,
+            Vec<hyperactor_reference::ActorId>,
+        ),
+        anyhow::Error,
+    > {
         self.proc
             .destroy_and_wait_except_current::<Self>(timeout, Some(cx), true, reason)
             .await
@@ -303,9 +308,8 @@ impl Actor for ProcAgent {
             use hyperactor::introspect::NodePayload;
             use hyperactor::introspect::NodeProperties;
             use hyperactor::introspect::PublishedPropertiesKind;
-            use hyperactor::reference::Reference;
 
-            if let Reference::Actor(id) = child_ref {
+            if let hyperactor::reference::Reference::Actor(id) = child_ref {
                 if let Some(snapshot) = proc.terminated_snapshot(id) {
                     return snapshot;
                 }
@@ -318,7 +322,7 @@ impl Actor for ProcAgent {
             // next QueryChild(Reference::Proc) response without an
             // extra publish event. See
             // test_query_child_proc_returns_live_children.
-            if let Reference::Proc(proc_id) = child_ref {
+            if let hyperactor::reference::Reference::Proc(proc_id) = child_ref {
                 if proc_id == proc.proc_id() {
                     let live_ids = proc.all_actor_ids();
                     let num_live = live_ids.len();
@@ -418,7 +422,7 @@ impl MeshAgentMessageHandler for ProcAgent {
     async fn stop_actor(
         &mut self,
         cx: &Context<Self>,
-        actor_id: ActorId,
+        actor_id: hyperactor_reference::ActorId,
         timeout_ms: u64,
         reason: String,
     ) -> Result<StopActorResult, anyhow::Error> {
@@ -527,7 +531,7 @@ wirevalue::register_type!(ActorSpec);
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Named, Bind, Unbind)]
 pub struct ActorState {
     /// The actor's ID.
-    pub actor_id: ActorId,
+    pub actor_id: hyperactor_reference::ActorId,
     /// The rank of the proc that created the actor. This is before any slicing.
     pub create_rank: usize,
     // TODO status: ActorStatus,
@@ -902,7 +906,7 @@ impl Handler<SelfCheck> for ProcAgent {
         let now = RealClock.system_time_now();
 
         // Collect expired actors before mutating, since stop_actor borrows &mut self.
-        let expired: Vec<(Name, ActorId)> = self
+        let expired: Vec<(Name, hyperactor_reference::ActorId)> = self
             .actor_states
             .iter()
             .filter_map(|(name, state)| {
@@ -976,14 +980,13 @@ mod tests {
     // mesh_admin::tests::test_proc_children_reflect_directly_spawned_actors.
     #[tokio::test]
     async fn test_query_child_proc_returns_live_children() {
-        use hyperactor::PortRef;
         use hyperactor::Proc;
         use hyperactor::actor::ActorStatus;
         use hyperactor::channel::ChannelTransport;
         use hyperactor::introspect::IntrospectMessage;
         use hyperactor::introspect::NodePayload;
         use hyperactor::introspect::NodeProperties;
-        use hyperactor::reference::Reference;
+        use hyperactor::reference as hyperactor_reference;
 
         let proc = Proc::direct(ChannelTransport::Unix.any(), "test_proc".to_string()).unwrap();
         let agent_handle = ProcAgent::boot(proc.clone(), None).unwrap();
@@ -1000,7 +1003,8 @@ mod tests {
         let (client, _client_handle) = client_proc.instance("client").unwrap();
 
         let agent_id = proc.proc_id().actor_id(PROC_AGENT_ACTOR_NAME, 0);
-        let port = PortRef::<IntrospectMessage>::attest_message_port(&agent_id);
+        let port =
+            hyperactor_reference::PortRef::<IntrospectMessage>::attest_message_port(&agent_id);
 
         // Helper: send QueryChild(Proc) and return the payload with a
         // timeout so a misrouted reply fails fast rather than hanging.
@@ -1009,7 +1013,7 @@ mod tests {
             port.send(
                 client,
                 IntrospectMessage::QueryChild {
-                    child_ref: Reference::Proc(proc.proc_id().clone()),
+                    child_ref: hyperactor_reference::Reference::Proc(proc.proc_id().clone()),
                     reply: reply_port.bind(),
                 },
             )

--- a/hyperactor_mesh/src/proc_launcher.rs
+++ b/hyperactor_mesh/src/proc_launcher.rs
@@ -45,8 +45,8 @@ use std::fmt;
 use std::time::Duration;
 
 use async_trait::async_trait;
-use hyperactor::ProcId;
 use hyperactor::channel::ChannelAddr;
+use hyperactor::reference as hyperactor_reference;
 use tokio::process::ChildStderr;
 use tokio::process::ChildStdout;
 use tokio::sync::oneshot;
@@ -243,7 +243,7 @@ pub struct LaunchOptions {
 ///   non-UTF8 we fall back to `"unknown_host"`.
 /// - This is **not** guaranteed to be unique and should not be parsed
 ///   for program logic.
-pub fn format_process_name(proc_id: &ProcId) -> String {
+pub fn format_process_name(proc_id: &hyperactor_reference::ProcId) -> String {
     let who = proc_id.name();
 
     let host = hostname::get()
@@ -299,7 +299,7 @@ pub trait ProcLauncher: Send + Sync + 'static {
     /// (pipes vs inherit, log streaming, etc.).
     async fn launch(
         &self,
-        proc_id: &ProcId,
+        proc_id: &hyperactor_reference::ProcId,
         opts: LaunchOptions,
     ) -> Result<LaunchResult, ProcLauncherError>;
 
@@ -315,8 +315,11 @@ pub trait ProcLauncher: Send + Sync + 'static {
     ///
     /// This is a fallback mechanism used when higher-level
     /// (agent-first) termination cannot be applied or fails.
-    async fn terminate(&self, proc_id: &ProcId, timeout: Duration)
-    -> Result<(), ProcLauncherError>;
+    async fn terminate(
+        &self,
+        proc_id: &hyperactor_reference::ProcId,
+        timeout: Duration,
+    ) -> Result<(), ProcLauncherError>;
 
     /// Initiate a force-kill.
     ///
@@ -340,5 +343,5 @@ pub trait ProcLauncher: Send + Sync + 'static {
     /// Idempotent behavior is preferred: killing an already-dead proc
     /// should not be treated as an error unless the backend cannot
     /// determine state.
-    async fn kill(&self, proc_id: &ProcId) -> Result<(), ProcLauncherError>;
+    async fn kill(&self, proc_id: &hyperactor_reference::ProcId) -> Result<(), ProcLauncherError>;
 }

--- a/hyperactor_mesh/src/proc_launcher/native.rs
+++ b/hyperactor_mesh/src/proc_launcher/native.rs
@@ -82,9 +82,9 @@ use std::time::Duration;
 use std::time::SystemTime;
 
 use async_trait::async_trait;
-use hyperactor::ProcId;
 use hyperactor::clock::Clock;
 use hyperactor::clock::RealClock;
+use hyperactor::reference as hyperactor_reference;
 use tokio::sync::oneshot;
 use tracing::Instrument;
 
@@ -129,7 +129,7 @@ pub(crate) struct NativeProcLauncher {
     /// removed by the exit-monitor task after `wait()` completes.
     /// Missing entries are treated as idempotent success (already
     /// exited / unknown).
-    pid_table: Arc<Mutex<HashMap<ProcId, u32>>>,
+    pid_table: Arc<Mutex<HashMap<hyperactor_reference::ProcId, u32>>>,
 }
 
 impl NativeProcLauncher {
@@ -264,7 +264,7 @@ impl ProcLauncher for NativeProcLauncher {
     )]
     async fn launch(
         &self,
-        proc_id: &ProcId,
+        proc_id: &hyperactor_reference::ProcId,
         opts: LaunchOptions,
     ) -> Result<LaunchResult, ProcLauncherError> {
         // New Tokio Command from BootstrapCommand (template)
@@ -422,7 +422,7 @@ impl ProcLauncher for NativeProcLauncher {
     ///   channel when the proc actually terminates.
     async fn terminate(
         &self,
-        proc_id: &ProcId,
+        proc_id: &hyperactor_reference::ProcId,
         timeout: Duration,
     ) -> Result<(), ProcLauncherError> {
         let pid = {
@@ -502,7 +502,7 @@ impl ProcLauncher for NativeProcLauncher {
     /// - We do not remove `proc_id` from `pid_table` here; the
     ///   exit-monitor task spawned in `launch` removes it once the
     ///   child actually exits.
-    async fn kill(&self, proc_id: &ProcId) -> Result<(), ProcLauncherError> {
+    async fn kill(&self, proc_id: &hyperactor_reference::ProcId) -> Result<(), ProcLauncherError> {
         let pid = {
             let table = self.pid_table.lock().expect("pid_table mutex poisoned");
             table.get(proc_id).copied()
@@ -549,7 +549,7 @@ impl Drop for NativeProcLauncher {
     fn drop(&mut self) {
         // Collect PIDs while holding the lock, then release before killing.
         // This avoids holding the lock during syscalls.
-        let pids: Vec<(ProcId, u32)> = {
+        let pids: Vec<(hyperactor_reference::ProcId, u32)> = {
             let table = self.pid_table.lock().expect("pid_table mutex poisoned");
             table.iter().map(|(k, v)| (k.clone(), *v)).collect()
         };
@@ -749,7 +749,8 @@ mod tests {
             let launcher = NativeProcLauncher::new();
             // v0 bootstrap by default but it doesn't matter here.
             let bootstrap = Bootstrap::dummy();
-            let proc_id = ProcId::with_name(any_unix_addr(), "stdio-captured");
+            let proc_id =
+                hyperactor_reference::ProcId::with_name(any_unix_addr(), "stdio-captured");
             let opts = LaunchOptions {
                 command: with_sh(script),
                 bootstrap_payload: bootstrap.to_env_safe_string().unwrap(),
@@ -783,7 +784,8 @@ mod tests {
             let launcher = NativeProcLauncher::new();
             // v0 bootstrap by default but it doesn't matter here.
             let bootstrap = Bootstrap::dummy();
-            let proc_id = ProcId::with_name(any_unix_addr(), "stdio-inherited");
+            let proc_id =
+                hyperactor_reference::ProcId::with_name(any_unix_addr(), "stdio-inherited");
             let opts = LaunchOptions {
                 command: with_sh(script),
                 bootstrap_payload: bootstrap.to_env_safe_string().unwrap(),
@@ -821,7 +823,7 @@ mod tests {
         let launcher = NativeProcLauncher::new();
         // v0 bootstrap by default but it doesn't matter here.
         let bootstrap = Bootstrap::dummy();
-        let proc_id = ProcId::with_name(any_unix_addr(), "exit-7");
+        let proc_id = hyperactor_reference::ProcId::with_name(any_unix_addr(), "exit-7");
         let opts = LaunchOptions {
             command: with_sh("exit 7"),
             bootstrap_payload: bootstrap.to_env_safe_string().unwrap(),
@@ -860,7 +862,7 @@ mod tests {
         let launcher = NativeProcLauncher::new();
         // v0 bootstrap by default but it doesn't matter here.
         let bootstrap = Bootstrap::dummy();
-        let proc_id = ProcId::with_name(any_unix_addr(), "killed");
+        let proc_id = hyperactor_reference::ProcId::with_name(any_unix_addr(), "killed");
         let opts = LaunchOptions {
             command: with_sh("sleep 30"),
             bootstrap_payload: bootstrap.to_env_safe_string().unwrap(),
@@ -932,7 +934,7 @@ mod tests {
 
         // v0 bootstrap by default but it doesn't matter here.
         let bootstrap = Bootstrap::dummy();
-        let proc_id = ProcId::with_name(any_unix_addr(), "term-escalate");
+        let proc_id = hyperactor_reference::ProcId::with_name(any_unix_addr(), "term-escalate");
         let opts = LaunchOptions {
             command: with_sh(script),
             bootstrap_payload: bootstrap.to_env_safe_string().unwrap(),
@@ -1020,7 +1022,7 @@ while True:
         };
 
         let bootstrap = Bootstrap::dummy();
-        let proc_id = ProcId::with_name(any_unix_addr(), "drop-cleanup-test");
+        let proc_id = hyperactor_reference::ProcId::with_name(any_unix_addr(), "drop-cleanup-test");
         let opts = LaunchOptions {
             command,
             bootstrap_payload: bootstrap.to_env_safe_string().unwrap(),

--- a/hyperactor_mesh/src/proc_launcher/systemd.rs
+++ b/hyperactor_mesh/src/proc_launcher/systemd.rs
@@ -71,10 +71,10 @@ use std::time::Duration;
 
 use async_trait::async_trait;
 use futures::StreamExt;
-use hyperactor::ProcId;
 use hyperactor::channel::ChannelAddr;
 use hyperactor::clock::Clock;
 use hyperactor::clock::RealClock;
+use hyperactor::reference as hyperactor_reference;
 use tokio::sync::oneshot;
 use tracing::Instrument;
 use zbus::Connection;
@@ -149,8 +149,8 @@ fn is_unit_gone(e: &zbus::Error) -> bool {
 /// it), we log a warning and recover the guard anyway. This ensures
 /// cleanup can proceed even after a panic.
 fn units_lock_recover(
-    units: &std::sync::Mutex<HashMap<ProcId, String>>,
-) -> MutexGuard<'_, HashMap<ProcId, String>> {
+    units: &std::sync::Mutex<HashMap<hyperactor_reference::ProcId, String>>,
+) -> MutexGuard<'_, HashMap<hyperactor_reference::ProcId, String>> {
     units.lock().unwrap_or_else(|p| {
         tracing::warn!("mutex was poisoned, recovering");
         p.into_inner()
@@ -264,8 +264,8 @@ fn is_terminal(active: &str, sub: &str) -> bool {
 /// Log exit, remove proc from units map, and send result on channel.
 fn send_and_cleanup(
     kind: ProcExitKind,
-    proc_id: &ProcId,
-    units: &std::sync::Mutex<HashMap<ProcId, String>>,
+    proc_id: &hyperactor_reference::ProcId,
+    units: &std::sync::Mutex<HashMap<hyperactor_reference::ProcId, String>>,
     exit_tx: oneshot::Sender<ProcExitResult>,
 ) {
     tracing::debug!(?kind, "exit_observed");
@@ -398,8 +398,8 @@ fn map_exit_from_result(result: &str, status: i32, active: &str, sub: &str) -> P
 /// 7. Sends the result on `exit_tx`
 async fn monitor_exit(
     conn: Connection,
-    units: Arc<std::sync::Mutex<HashMap<ProcId, String>>>,
-    proc_id: ProcId,
+    units: Arc<std::sync::Mutex<HashMap<hyperactor_reference::ProcId, String>>>,
+    proc_id: hyperactor_reference::ProcId,
     handle: SystemdUnitHandle,
     exit_tx: oneshot::Sender<ProcExitResult>,
 ) {
@@ -666,7 +666,7 @@ pub(crate) struct SystemdProcLauncher {
     ///
     /// Uses `std::sync::Mutex` (not tokio) so Drop can synchronously
     /// acquire the lock.
-    units: Arc<std::sync::Mutex<HashMap<ProcId, String>>>,
+    units: Arc<std::sync::Mutex<HashMap<hyperactor_reference::ProcId, String>>>,
 }
 
 impl SystemdProcLauncher {
@@ -712,7 +712,7 @@ impl SystemdProcLauncher {
     ///   unit names (hex encoding is collision-free on bytes).
     /// - **Systemd-safe**: output contains only ASCII hex digits plus
     ///   `-` and `.service`.
-    pub(crate) fn unit_name(proc_id: &ProcId) -> String {
+    pub(crate) fn unit_name(proc_id: &hyperactor_reference::ProcId) -> String {
         // Hex-encode the ProcId string to ensure only valid systemd
         // unit name characters. This is bijective (collision-free)
         // and stable.
@@ -782,7 +782,7 @@ impl SystemdProcLauncher {
 
     /// Build the properties for `StartTransientUnit`.
     fn build_unit_props<'a>(
-        proc_id: &ProcId,
+        proc_id: &hyperactor_reference::ProcId,
         exec_start: Vec<(String, Vec<String>, bool)>,
         env_kv: Vec<String>,
     ) -> Vec<(&'a str, Value<'a>)> {
@@ -807,7 +807,11 @@ impl SystemdProcLauncher {
     }
 
     /// Shared implementation for terminate/kill via systemd StopUnit.
-    async fn stop_unit_impl(&self, proc_id: &ProcId, op: StopOp) -> Result<(), ProcLauncherError> {
+    async fn stop_unit_impl(
+        &self,
+        proc_id: &hyperactor_reference::ProcId,
+        op: StopOp,
+    ) -> Result<(), ProcLauncherError> {
         let unit = match self.units.lock().unwrap().get(proc_id).cloned() {
             Some(u) => u,
             None => {
@@ -906,7 +910,7 @@ impl ProcLauncher for SystemdProcLauncher {
     )]
     async fn launch(
         &self,
-        proc_id: &ProcId,
+        proc_id: &hyperactor_reference::ProcId,
         opts: LaunchOptions,
     ) -> Result<LaunchResult, ProcLauncherError> {
         let unit = Self::unit_name(proc_id);
@@ -987,7 +991,7 @@ impl ProcLauncher for SystemdProcLauncher {
     ///   from the `units` map when observed.
     async fn terminate(
         &self,
-        proc_id: &ProcId,
+        proc_id: &hyperactor_reference::ProcId,
         timeout: Duration,
     ) -> Result<(), ProcLauncherError> {
         self.stop_unit_impl(proc_id, StopOp::Terminate { timeout })
@@ -1008,7 +1012,7 @@ impl ProcLauncher for SystemdProcLauncher {
     /// - The exit monitor is responsible for observing the final exit
     ///   status (Exited vs Signaled) and for removing the proc from
     ///   the `units` map.
-    async fn kill(&self, proc_id: &ProcId) -> Result<(), ProcLauncherError> {
+    async fn kill(&self, proc_id: &hyperactor_reference::ProcId) -> Result<(), ProcLauncherError> {
         self.stop_unit_impl(proc_id, StopOp::Kill).await
     }
 }
@@ -1022,7 +1026,7 @@ impl Drop for SystemdProcLauncher {
         // Note: This cleanup is best-effort. If the process is
         // terminating, the spawned cleanup thread may not complete
         // before the process exits.
-        let units: Vec<(ProcId, String)> = {
+        let units: Vec<(hyperactor_reference::ProcId, String)> = {
             let mut guard = units_lock_recover(&self.units);
             guard.drain().collect()
         };
@@ -1191,7 +1195,7 @@ mod tests {
 
         let launcher = SystemdProcLauncher::new();
 
-        let proc_id = ProcId::with_name(any_unix_addr(), "env-vars");
+        let proc_id = hyperactor_reference::ProcId::with_name(any_unix_addr(), "env-vars");
         // v0 bootstrap by default but it doesn't matter here.
         let bootstrap = Bootstrap::dummy();
         let opts = LaunchOptions {
@@ -1290,7 +1294,7 @@ mod tests {
 
         // v0 bootstrap by default but it doesn't matter here.
         let bootstrap = Bootstrap::dummy();
-        let proc_id = ProcId::with_name(any_unix_addr(), "exit-7");
+        let proc_id = hyperactor_reference::ProcId::with_name(any_unix_addr(), "exit-7");
         let opts = LaunchOptions {
             command: with_sh("exit 7"),
             bootstrap_payload: bootstrap.to_env_safe_string().unwrap(),
@@ -1332,7 +1336,7 @@ mod tests {
 
         // v0 bootstrap by default but it doesn't matter here.
         let bootstrap = Bootstrap::dummy();
-        let proc_id = ProcId::with_name(any_unix_addr(), "killed");
+        let proc_id = hyperactor_reference::ProcId::with_name(any_unix_addr(), "killed");
         let opts = LaunchOptions {
             command: with_sh("sleep 30"),
             bootstrap_payload: bootstrap.to_env_safe_string().unwrap(),
@@ -1394,7 +1398,7 @@ mod tests {
 
         // v0 bootstrap by default but it doesn't matter here.
         let bootstrap = Bootstrap::dummy();
-        let proc_id = ProcId::with_name(any_unix_addr(), "terminated");
+        let proc_id = hyperactor_reference::ProcId::with_name(any_unix_addr(), "terminated");
         let opts = LaunchOptions {
             command: with_sh("sleep 30"),
             bootstrap_payload: bootstrap.to_env_safe_string().unwrap(),
@@ -1438,7 +1442,7 @@ mod tests {
 
         let launcher = SystemdProcLauncher::new();
 
-        let unknown_proc_id = ProcId::with_name(any_unix_addr(), "unknown");
+        let unknown_proc_id = hyperactor_reference::ProcId::with_name(any_unix_addr(), "unknown");
 
         let result = launcher
             .terminate(&unknown_proc_id, Duration::from_secs(1))
@@ -1460,7 +1464,7 @@ mod tests {
 
         let launcher = SystemdProcLauncher::new();
 
-        let unknown_proc_id = ProcId::with_name(any_unix_addr(), "unknown");
+        let unknown_proc_id = hyperactor_reference::ProcId::with_name(any_unix_addr(), "unknown");
 
         let result = launcher.kill(&unknown_proc_id).await;
 
@@ -1564,7 +1568,7 @@ mod tests {
         );
 
         let bootstrap = Bootstrap::dummy();
-        let proc_id = ProcId::with_name(any_unix_addr(), "drop-cleanup-test");
+        let proc_id = hyperactor_reference::ProcId::with_name(any_unix_addr(), "drop-cleanup-test");
 
         let exit_rx;
 
@@ -1663,7 +1667,7 @@ mod tests {
 
         let launcher = SystemdProcLauncher::new();
 
-        let proc_id = ProcId::with_name(any_unix_addr(), "long-running");
+        let proc_id = hyperactor_reference::ProcId::with_name(any_unix_addr(), "long-running");
         let bootstrap = Bootstrap::dummy();
         let opts = LaunchOptions {
             command: with_sh("sleep 60"),

--- a/hyperactor_mesh/src/proc_mesh.rs
+++ b/hyperactor_mesh/src/proc_mesh.rs
@@ -16,10 +16,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use hyperactor::Actor;
-use hyperactor::ActorId;
-use hyperactor::ActorRef;
 use hyperactor::Handler;
-use hyperactor::ProcId;
 use hyperactor::RemoteMessage;
 use hyperactor::RemoteSpawn;
 use hyperactor::accum::StreamingReducerOpts;
@@ -29,6 +26,7 @@ use hyperactor::actor::remote::Remote;
 use hyperactor::clock::Clock;
 use hyperactor::clock::RealClock;
 use hyperactor::context;
+use hyperactor::reference as hyperactor_reference;
 use hyperactor::supervision::ActorSupervisionEvent;
 use hyperactor_config::CONFIG;
 use hyperactor_config::ConfigAttr;
@@ -89,16 +87,20 @@ pub const COMM_ACTOR_NAME: &str = "comm";
 /// A reference to a single [`hyperactor::Proc`].
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct ProcRef {
-    proc_id: ProcId,
+    proc_id: hyperactor_reference::ProcId,
     /// The rank of this proc at creation.
     create_rank: usize,
     /// The agent managing this proc.
-    agent: ActorRef<ProcAgent>,
+    agent: hyperactor_reference::ActorRef<ProcAgent>,
 }
 
 impl ProcRef {
     /// Create a new proc ref from the provided id, create rank and agent.
-    pub fn new(proc_id: ProcId, create_rank: usize, agent: ActorRef<ProcAgent>) -> Self {
+    pub fn new(
+        proc_id: hyperactor_reference::ProcId,
+        create_rank: usize,
+        agent: hyperactor_reference::ActorRef<ProcAgent>,
+    ) -> Self {
         Self {
             proc_id,
             create_rank,
@@ -106,18 +108,18 @@ impl ProcRef {
         }
     }
 
-    pub fn proc_id(&self) -> &ProcId {
+    pub fn proc_id(&self) -> &hyperactor_reference::ProcId {
         &self.proc_id
     }
 
-    pub(crate) fn actor_id(&self, name: &Name) -> ActorId {
+    pub(crate) fn actor_id(&self, name: &Name) -> hyperactor_reference::ActorId {
         self.proc_id.actor_id(name.to_string(), 0)
     }
 
     /// Generic bound: `A: Referable` - required because we return
     /// an `ActorRef<A>`.
-    pub(crate) fn attest<A: Referable>(&self, name: &Name) -> ActorRef<A> {
-        ActorRef::attest(self.actor_id(name))
+    pub(crate) fn attest<A: Referable>(&self, name: &Name) -> hyperactor_reference::ActorRef<A> {
+        hyperactor_reference::ActorRef::attest(self.actor_id(name))
     }
 }
 
@@ -263,7 +265,10 @@ impl ProcMesh {
         let region = self.region.clone();
         match &mut self.allocation {
             ProcMeshAllocation::Owned { hosts, .. } => {
-                let procs = self.current_ref.proc_ids().collect::<Vec<ProcId>>();
+                let procs = self
+                    .current_ref
+                    .proc_ids()
+                    .collect::<Vec<hyperactor_reference::ProcId>>();
                 hosts
                     .stop_proc_mesh(cx, &self.name, procs, region, reason)
                     .await
@@ -540,7 +545,9 @@ impl ProcMeshRef {
         &self,
         cx: &impl context::Actor,
     ) -> crate::Result<Option<ValueMesh<resource::State<ProcState>>>> {
-        let names = self.proc_ids().collect::<Vec<ProcId>>();
+        let names = self
+            .proc_ids()
+            .collect::<Vec<hyperactor_reference::ProcId>>();
         if let Some(host_mesh) = &self.host_mesh {
             Ok(Some(
                 host_mesh
@@ -553,7 +560,7 @@ impl ProcMeshRef {
     }
 
     /// Returns an iterator over the proc ids in this mesh.
-    pub(crate) fn proc_ids(&self) -> impl Iterator<Item = ProcId> {
+    pub(crate) fn proc_ids(&self) -> impl Iterator<Item = hyperactor_reference::ProcId> {
         self.ranks.iter().map(|proc_ref| proc_ref.proc_id.clone())
     }
 

--- a/hyperactor_mesh/src/resource.rs
+++ b/hyperactor_mesh/src/resource.rs
@@ -27,7 +27,6 @@ use enum_as_inner::EnumAsInner;
 use hyperactor::Bind;
 use hyperactor::HandleClient;
 use hyperactor::Handler;
-use hyperactor::PortRef;
 use hyperactor::RefClient;
 use hyperactor::RemoteMessage;
 use hyperactor::Unbind;
@@ -35,6 +34,7 @@ use hyperactor::mailbox::PortReceiver;
 use hyperactor::message::Bind;
 use hyperactor::message::Bindings;
 use hyperactor::message::Unbind;
+use hyperactor::reference as hyperactor_reference;
 use hyperactor_config::attrs::Attrs;
 use ndslice::Region;
 use ndslice::ViewExt;
@@ -176,7 +176,7 @@ pub struct GetRankStatus {
     pub name: Name,
     /// Sparse status updates (overlays) from a rank.
     #[binding(include)]
-    pub reply: PortRef<StatusOverlay>,
+    pub reply: hyperactor_reference::PortRef<StatusOverlay>,
 }
 
 impl GetRankStatus {
@@ -318,7 +318,7 @@ pub struct GetState<S> {
     pub name: Name,
     /// A reply containing the state.
     #[reply]
-    pub reply: PortRef<State<S>>,
+    pub reply: hyperactor_reference::PortRef<State<S>>,
 }
 wirevalue::register_type!(GetState<ProcState>);
 wirevalue::register_type!(GetState<ActorState>);
@@ -406,7 +406,7 @@ where
 pub struct List {
     /// List of resource names managed by this controller.
     #[reply]
-    pub reply: PortRef<Vec<Name>>,
+    pub reply: hyperactor_reference::PortRef<Vec<Name>>,
 }
 wirevalue::register_type!(List);
 

--- a/hyperactor_mesh/src/testactor.rs
+++ b/hyperactor_mesh/src/testactor.rs
@@ -20,13 +20,10 @@ use std::time::Duration;
 
 use async_trait::async_trait;
 use hyperactor::Actor;
-use hyperactor::ActorId;
-use hyperactor::ActorRef;
 use hyperactor::Bind;
 use hyperactor::Context;
 use hyperactor::Handler;
 use hyperactor::Instance;
-use hyperactor::PortRef;
 use hyperactor::RefClient;
 use hyperactor::Unbind;
 use hyperactor::clock::Clock as _;
@@ -35,6 +32,7 @@ use hyperactor::clock::RealClock;
 use hyperactor::context;
 use hyperactor::ordering::SEQ_INFO;
 use hyperactor::ordering::SeqInfo;
+use hyperactor::reference as hyperactor_reference;
 use hyperactor::supervision::ActorSupervisionEvent;
 use hyperactor_config::Flattrs;
 use hyperactor_config::global::Source;
@@ -77,7 +75,10 @@ impl Actor for TestActor {}
 
 /// A message that returns the recipient actor's id and cast message's seq info.
 #[derive(Debug, Clone, Named, Bind, Unbind, Serialize, Deserialize)]
-pub struct GetActorId(#[binding(include)] pub PortRef<(ActorId, Option<SeqInfo>)>);
+pub struct GetActorId(
+    #[binding(include)]
+    pub  hyperactor_reference::PortRef<(hyperactor_reference::ActorId, Option<SeqInfo>)>,
+);
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum SupervisionEventType {
@@ -208,8 +209,8 @@ impl Handler<std::time::Duration> for SleepActor {
 /// 'visited' list.
 #[derive(Debug, Clone, Named, Bind, Unbind, Serialize, Deserialize)]
 pub struct Forward {
-    pub to_visit: VecDeque<PortRef<Forward>>,
-    pub visited: Vec<PortRef<Forward>>,
+    pub to_visit: VecDeque<hyperactor_reference::PortRef<Forward>>,
+    pub visited: Vec<hyperactor_reference::PortRef<Forward>>,
 }
 
 #[async_trait]
@@ -248,7 +249,11 @@ impl Handler<Forward> for TestActor {
 pub struct GetCastInfo {
     /// Originating actor, point, sender.
     #[reply]
-    pub cast_info: PortRef<(Point, ActorRef<TestActor>, ActorId)>,
+    pub cast_info: hyperactor_reference::PortRef<(
+        Point,
+        hyperactor_reference::ActorRef<TestActor>,
+        hyperactor_reference::ActorId,
+    )>,
 }
 
 #[async_trait]
@@ -299,7 +304,7 @@ impl Handler<SetConfigAttrs> for TestActor {
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, Named, Bind, Unbind)]
-pub struct GetConfigAttrs(pub PortRef<Vec<u8>>);
+pub struct GetConfigAttrs(pub hyperactor_reference::PortRef<Vec<u8>>);
 
 #[async_trait]
 impl Handler<GetConfigAttrs> for TestActor {
@@ -318,7 +323,7 @@ impl Handler<GetConfigAttrs> for TestActor {
 /// Replies with None if no supervision event is encountered within a timeout
 /// (10 seconds).
 #[derive(Clone, Debug, Serialize, Deserialize, Named, Bind, Unbind)]
-pub struct NextSupervisionFailure(pub PortRef<Option<MeshFailure>>);
+pub struct NextSupervisionFailure(pub hyperactor_reference::PortRef<Option<MeshFailure>>);
 
 /// A small wrapper to handle supervision messages so they don't
 /// need to reach the client. This just wraps and forwards all messages to TestActor.
@@ -336,13 +341,17 @@ pub struct WrapperActor {
     proc_mesh: ProcMeshRef,
     // Needs to be a mesh so we own this actor and have a controller for it.
     mesh: Option<ActorMesh<TestActor>>,
-    supervisor: PortRef<MeshFailure>,
+    supervisor: hyperactor_reference::PortRef<MeshFailure>,
     test_name: Name,
 }
 
 #[async_trait]
 impl hyperactor::RemoteSpawn for WrapperActor {
-    type Params = (ProcMeshRef, PortRef<MeshFailure>, Name);
+    type Params = (
+        ProcMeshRef,
+        hyperactor_reference::PortRef<MeshFailure>,
+        Name,
+    );
 
     async fn new(
         (proc_mesh, supervisor, test_name): Self::Params,
@@ -467,7 +476,8 @@ pub async fn assert_casting_correctness(
         .values()
         .map(|actor_ref| actor_ref.actor_id().clone())
         .collect::<Vec<_>>();
-    let mut expected: HashMap<&ActorId, Option<SeqInfo>> = match expected_seqs {
+    let mut expected: HashMap<&hyperactor_reference::ActorId, Option<SeqInfo>> = match expected_seqs
+    {
         None => expected_actor_ids
             .iter()
             .map(|actor_id| (actor_id, None))

--- a/hyperactor_mesh/test/hyperactor_mesh_proxy_test.rs
+++ b/hyperactor_mesh/test/hyperactor_mesh_proxy_test.rs
@@ -18,10 +18,10 @@ use hyperactor::Actor;
 use hyperactor::Context;
 use hyperactor::Handler;
 use hyperactor::Instance;
-use hyperactor::PortRef;
 use hyperactor::RemoteSpawn;
 use hyperactor::channel::ChannelTransport;
 use hyperactor::context::Mailbox;
+use hyperactor::reference;
 use hyperactor_config::Flattrs;
 use hyperactor_mesh::ActorMesh;
 use hyperactor_mesh::ProcMesh;
@@ -79,7 +79,7 @@ impl RemoteSpawn for TestActor {
 }
 
 #[derive(Debug, Serialize, Deserialize, Named, Clone)]
-pub struct Echo(pub String, pub PortRef<String>);
+pub struct Echo(pub String, pub reference::PortRef<String>);
 
 #[async_trait]
 impl Handler<Echo> for TestActor {

--- a/monarch_distributed_telemetry/src/database_scanner.rs
+++ b/monarch_distributed_telemetry/src/database_scanner.rs
@@ -18,8 +18,7 @@ use datafusion::datasource::MemTable;
 use datafusion::datasource::TableProvider;
 use datafusion::prelude::SessionContext;
 use hyperactor::Instance;
-use hyperactor::PortId;
-use hyperactor::PortRef;
+use hyperactor::reference;
 use monarch_hyperactor::actor::PythonActor;
 use monarch_hyperactor::context::PyInstance;
 use monarch_hyperactor::mailbox::PyPortId;
@@ -198,8 +197,8 @@ impl DatabaseScanner {
         let instance: Instance<PythonActor> = py_instance.clone_for_py();
 
         // Build destination PortRef once
-        let dest_port_id: PortId = dest.clone().into();
-        let dest_ref: PortRef<QueryResponse> = PortRef::attest(dest_port_id);
+        let dest_port_id: reference::PortId = dest.clone().into();
+        let dest_ref: reference::PortRef<QueryResponse> = reference::PortRef::attest(dest_port_id);
 
         // Execute scan, streaming batches directly to destination
         self.execute_scan_streaming(
@@ -308,7 +307,7 @@ impl DatabaseScanner {
         where_clause: Option<String>,
         limit: Option<usize>,
         instance: &Instance<PythonActor>,
-        dest_ref: &PortRef<QueryResponse>,
+        dest_ref: &reference::PortRef<QueryResponse>,
     ) -> PyResult<usize> {
         let rank = self.rank;
 

--- a/monarch_extension/src/client.rs
+++ b/monarch_extension/src/client.rs
@@ -8,7 +8,7 @@
 
 use std::sync::Arc;
 
-use hyperactor::ActorRef;
+use hyperactor::reference;
 use monarch_hyperactor::ndslice::PySlice;
 use monarch_hyperactor::proc::InstanceWrapper;
 use monarch_hyperactor::proc::PyActorId;
@@ -410,8 +410,8 @@ impl ClientActor {
             .map_err(|err| PyRuntimeError::new_err(err.to_string()))?;
 
         signal_safe_block_on(py, async move {
-            ActorRef::<ControllerActor>::attest((&controller_id).into())
-                .attach(&instance, ActorRef::attest(actor_id))
+            reference::ActorRef::<ControllerActor>::attest((&controller_id).into())
+                .attach(&instance, reference::ActorRef::attest(actor_id))
                 .await
                 .map_err(|err| PyRuntimeError::new_err(err.to_string()))
         })?
@@ -425,7 +425,7 @@ impl ClientActor {
             .map_err(|err| PyRuntimeError::new_err(err.to_string()))?;
 
         signal_safe_block_on(py, async move {
-            ActorRef::<ControllerActor>::attest((&controller_id).into())
+            reference::ActorRef::<ControllerActor>::attest((&controller_id).into())
                 .drop_refs(&instance, refs)
                 .await
                 .map_err(|err| PyRuntimeError::new_err(err.to_string()))

--- a/monarch_extension/src/convert.rs
+++ b/monarch_extension/src/convert.rs
@@ -9,7 +9,7 @@
 use std::collections::HashMap;
 use std::sync::OnceLock;
 
-use hyperactor::ActorId;
+use hyperactor::reference;
 use monarch_hyperactor::ndslice::PySlice;
 use monarch_hyperactor::proc::PyActorId;
 use monarch_messages::controller::Seq;
@@ -176,7 +176,10 @@ impl<'a> MessageParser<'a> {
     fn parseWorkerMessageList(&self, name: &str) -> PyResult<Vec<WorkerMessage>> {
         self.attr(name)?.try_iter()?.map(|x| convert(x?)).collect()
     }
-    fn parse_error_reason(&self, name: &str) -> PyResult<Option<(Option<ActorId>, String)>> {
+    fn parse_error_reason(
+        &self,
+        name: &str,
+    ) -> PyResult<Option<(Option<reference::ActorId>, String)>> {
         let err = self.attr(name)?;
         if err.is_none() {
             return Ok(None);

--- a/monarch_extension/src/debugger.rs
+++ b/monarch_extension/src/debugger.rs
@@ -8,7 +8,7 @@
 
 use std::sync::Arc;
 
-use hyperactor::ActorRef;
+use hyperactor::reference;
 use monarch_hyperactor::proc::InstanceWrapper;
 use monarch_hyperactor::proc::PyProc;
 use monarch_hyperactor::proc::PySerialized;
@@ -72,7 +72,7 @@ pub fn get_bytes_from_write_action(
 #[pyclass(module = "monarch._rust_bindings.monarch_extension.debugger")]
 pub struct PdbActor {
     instance: Arc<Mutex<InstanceWrapper<DebuggerMessage>>>,
-    controller_actor_ref: ActorRef<ControllerActor>,
+    controller_actor_ref: reference::ActorRef<ControllerActor>,
 }
 
 #[pymethods]
@@ -151,17 +151,21 @@ pub fn register_python_bindings(debugger: &Bound<'_, PyModule>) -> PyResult<()> 
 
 #[cfg(test)]
 mod tests {
-    use hyperactor::ActorId;
     use hyperactor::Mailbox;
     use hyperactor::mailbox::PortReceiver;
     use hyperactor::proc::Proc;
+    use hyperactor::reference;
     use monarch_hyperactor::runtime::monarch_with_gil_blocking;
     use monarch_messages::controller::ControllerMessage;
     use typeuri::Named;
 
     use super::*;
 
-    fn send_to_debugger(mbox: &Mailbox, debugger_actor_id: &ActorId, action: DebuggerAction) {
+    fn send_to_debugger(
+        mbox: &Mailbox,
+        debugger_actor_id: &reference::ActorId,
+        action: DebuggerAction,
+    ) {
         let debugger_port_id = debugger_actor_id.port_id(DebuggerMessage::port());
         let msg: DebuggerMessage = action.into();
         debugger_port_id.send(
@@ -180,7 +184,7 @@ mod tests {
 
     fn receive_on_controller(
         rx: Arc<Mutex<PortReceiver<ControllerMessage>>>,
-    ) -> (ActorId, DebuggerAction) {
+    ) -> (reference::ActorId, DebuggerAction) {
         let msg = monarch_with_gil_blocking(|py| {
             signal_safe_block_on(py, async move { rx.lock().await.recv().await.unwrap() }).unwrap()
         });

--- a/monarch_extension/src/mesh_controller.rs
+++ b/monarch_extension/src/mesh_controller.rs
@@ -23,19 +23,16 @@ use std::sync::atomic::AtomicUsize;
 use async_trait::async_trait;
 use hyperactor::Actor;
 use hyperactor::ActorHandle;
-use hyperactor::ActorId;
-use hyperactor::ActorRef;
 use hyperactor::Context;
 use hyperactor::HandleClient;
 use hyperactor::Handler;
 use hyperactor::Instance;
 use hyperactor::OncePortHandle;
-use hyperactor::PortRef;
-use hyperactor::ProcId;
 use hyperactor::actor::ActorErrorKind;
 use hyperactor::actor::ActorStatus;
 use hyperactor::context;
 use hyperactor::mailbox::MailboxSenderError;
+use hyperactor::reference;
 use hyperactor::supervision::ActorSupervisionEvent;
 use hyperactor_mesh::ActorMesh;
 use hyperactor_mesh::ProcMeshRef;
@@ -104,7 +101,7 @@ impl _Controller {
         let proc_mesh = py_proc_mesh.downcast::<PyProcMesh>()?.borrow().mesh_ref()?;
 
         // Build rank map from proc ids to ranks.
-        let rank_map: HashMap<ProcId, usize> = proc_mesh
+        let rank_map: HashMap<reference::ProcId, usize> = proc_mesh
             .iter()
             .map(|(point, proc)| (proc.proc_id().clone(), point.rank()))
             .collect();
@@ -156,7 +153,7 @@ impl _Controller {
         tracebacks: Py<PyAny>,
     ) -> PyResult<()> {
         let response_port: Option<PortInfo> = response_port.map(|(port, ranks)| PortInfo {
-            port: PortRef::attest(port.into()),
+            port: reference::PortRef::attest(port.into()),
             ranks: ranks.into(),
         });
         let msg = ClientToControllerMessage::Node {
@@ -194,7 +191,7 @@ impl _Controller {
             .send(
                 instance.deref(),
                 ClientToControllerMessage::SyncAtExit {
-                    port: PortRef::attest(port.into()),
+                    port: reference::PortRef::attest(port.into()),
                 },
             )
             .map_err(to_py_error)
@@ -425,7 +422,7 @@ struct History {
     // sanity checking.
     seq_lower_bound: Seq,
     unreported_exception: Option<Arc<PythonMessage>>,
-    exit_port: Option<PortRef<PythonMessage>>,
+    exit_port: Option<reference::PortRef<PythonMessage>>,
 }
 
 /// A vector that keeps track of the minimum value.
@@ -626,14 +623,14 @@ impl History {
         invocation.lock().unwrap().set_result(result);
     }
 
-    fn report_exit(&mut self, port: PortRef<PythonMessage>) {
+    fn report_exit(&mut self, port: reference::PortRef<PythonMessage>) {
         self.exit_port = Some(port);
     }
 }
 
 #[derive(Debug)]
 struct PortInfo {
-    port: PortRef<PythonMessage>,
+    port: reference::PortRef<PythonMessage>,
     // the slice of ranks expected to respond
     // to the port. used for error reporting.
     ranks: Slice,
@@ -656,7 +653,7 @@ enum ClientToControllerMessage {
         refs: Vec<Ref>,
     },
     SyncAtExit {
-        port: PortRef<PythonMessage>,
+        port: reference::PortRef<PythonMessage>,
     },
     StopWorkers {
         response_port: OncePortHandle<Result<(), String>>,
@@ -669,15 +666,15 @@ struct MeshControllerActor {
     brokers: Option<ActorMesh<LocalStateBrokerActor>>,
     history: History,
     id: usize,
-    debugger_active: Option<ActorRef<DebuggerActor>>,
-    debugger_paused: VecDeque<ActorRef<DebuggerActor>>,
-    rank_map: HashMap<ProcId, usize>,
+    debugger_active: Option<reference::ActorRef<DebuggerActor>>,
+    debugger_paused: VecDeque<reference::ActorRef<DebuggerActor>>,
+    rank_map: HashMap<reference::ProcId, usize>,
 }
 
 struct MeshControllerActorParams {
     proc_mesh_ref: ProcMeshRef,
     id: usize,
-    rank_map: HashMap<ProcId, usize>,
+    rank_map: HashMap<reference::ProcId, usize>,
 }
 
 impl MeshControllerActor {
@@ -716,12 +713,12 @@ impl MeshControllerActor {
     async fn handle_debug(
         &mut self,
         this: &Context<'_, Self>,
-        debugger_actor_id: ActorId,
+        debugger_actor_id: reference::ActorId,
         action: DebuggerAction,
     ) -> anyhow::Result<()> {
         if matches!(action, DebuggerAction::Paused()) {
             self.debugger_paused
-                .push_back(ActorRef::attest(debugger_actor_id));
+                .push_back(reference::ActorRef::attest(debugger_actor_id));
         } else {
             let debugger_actor = self
                 .debugger_active
@@ -792,7 +789,7 @@ impl MeshControllerActor {
 #[async_trait]
 impl Actor for MeshControllerActor {
     async fn init(&mut self, this: &Instance<Self>) -> Result<(), anyhow::Error> {
-        let controller_actor_ref: ActorRef<ControllerActor> = this.bind();
+        let controller_actor_ref: reference::ActorRef<ControllerActor> = this.bind();
         let world_size = Ranked::region(&self.proc_mesh_ref).num_ranks();
         let param = WorkerParams {
             world_size,
@@ -829,7 +826,7 @@ impl Debug for MeshControllerActor {
 }
 
 impl MeshControllerActor {
-    fn rank_of_worker(&self, actor_id: &ActorId) -> usize {
+    fn rank_of_worker(&self, actor_id: &reference::ActorId) -> usize {
         *self
             .rank_map
             .get(actor_id.proc_id())

--- a/monarch_hyperactor/src/actor.rs
+++ b/monarch_hyperactor/src/actor.rs
@@ -1500,12 +1500,11 @@ pub fn register_python_bindings(hyperactor_mod: &Bound<'_, PyModule>) -> PyResul
 
 #[cfg(test)]
 mod tests {
-    use hyperactor::PortRef;
     use hyperactor::accum::ReducerSpec;
     use hyperactor::accum::StreamingReducerOpts;
     use hyperactor::message::ErasedUnbound;
     use hyperactor::message::Unbound;
-    use hyperactor::reference::UnboundPort;
+    use hyperactor::reference;
     use hyperactor::testing::ids::test_port_id;
     use hyperactor_mesh::Error as MeshError;
     use hyperactor_mesh::Name;
@@ -1523,7 +1522,7 @@ mod tests {
             typehash: 123,
             builder_params: Some(wirevalue::Any::serialize(&"abcdefg12345".to_string()).unwrap()),
         };
-        let port_ref = PortRef::<PythonMessage>::attest_reducible(
+        let port_ref = reference::PortRef::<PythonMessage>::attest_reducible(
             test_port_id("world_0", "client", 123),
             Some(reducer_spec),
             StreamingReducerOpts::default(),
@@ -1541,12 +1540,12 @@ mod tests {
             let mut erased = ErasedUnbound::try_from_message(message.clone()).unwrap();
             let mut bindings = vec![];
             erased
-                .visit_mut::<UnboundPort>(|b| {
+                .visit_mut::<reference::UnboundPort>(|b| {
                     bindings.push(b.clone());
                     Ok(())
                 })
                 .unwrap();
-            assert_eq!(bindings, vec![UnboundPort::from(&port_ref)]);
+            assert_eq!(bindings, vec![reference::UnboundPort::from(&port_ref)]);
             let unbound = Unbound::try_from_message(message.clone()).unwrap();
             assert_eq!(message, unbound.bind().unwrap());
         }
@@ -1564,7 +1563,7 @@ mod tests {
             let mut erased = ErasedUnbound::try_from_message(no_port_message.clone()).unwrap();
             let mut bindings = vec![];
             erased
-                .visit_mut::<UnboundPort>(|b| {
+                .visit_mut::<reference::UnboundPort>(|b| {
                     bindings.push(b.clone());
                     Ok(())
                 })
@@ -1585,8 +1584,10 @@ mod tests {
         };
 
         // A ProcCreationError
-        let mesh_agent: hyperactor::ActorRef<hyperactor_mesh::host_mesh::HostAgent> =
-            hyperactor::ActorRef::attest(test_port_id("hello_0", "actor", 0).actor_id().clone());
+        let mesh_agent: hyperactor::reference::ActorRef<hyperactor_mesh::host_mesh::HostAgent> =
+            hyperactor::reference::ActorRef::attest(
+                test_port_id("hello_0", "actor", 0).actor_id().clone(),
+            );
         let expected_prefix = format!(
             "error creating proc (host rank 0) on host mesh agent {}",
             mesh_agent

--- a/monarch_hyperactor/src/actor_mesh.rs
+++ b/monarch_hyperactor/src/actor_mesh.rs
@@ -17,8 +17,8 @@ use async_trait::async_trait;
 use futures::future;
 use futures::future::FutureExt;
 use futures::future::Shared;
-use hyperactor::ActorRef;
 use hyperactor::Instance;
+use hyperactor::reference;
 use hyperactor::supervision::ActorSupervisionEvent;
 use hyperactor_mesh::actor_mesh::ActorMesh;
 use hyperactor_mesh::actor_mesh::ActorMeshRef;
@@ -634,7 +634,7 @@ impl PythonActorMeshImpl {
         Ok(self
             .mesh_ref()
             .get(rank)
-            .map(|r| ActorRef::into_actor_id(r.clone()))
+            .map(|r| reference::ActorRef::into_actor_id(r.clone()))
             .map(PyActorId::from))
     }
 

--- a/monarch_hyperactor/src/code_sync/auto_reload.rs
+++ b/monarch_hyperactor/src/code_sync/auto_reload.rs
@@ -13,8 +13,8 @@ use async_trait::async_trait;
 use hyperactor::Actor;
 use hyperactor::Context;
 use hyperactor::Handler;
-use hyperactor::PortRef;
 use hyperactor::RemoteSpawn;
+use hyperactor::reference;
 use hyperactor_config::Flattrs;
 use monarch_types::SerializablePyErr;
 use pyo3::prelude::*;
@@ -27,7 +27,7 @@ use crate::runtime::monarch_with_gil_blocking;
 /// Message to trigger module reloading
 #[derive(Debug, Clone, Named, Serialize, Deserialize)]
 pub struct AutoReloadMessage {
-    pub result: PortRef<Result<(), String>>,
+    pub result: reference::PortRef<Result<(), String>>,
 }
 wirevalue::register_type!(AutoReloadMessage);
 

--- a/monarch_hyperactor/src/code_sync/conda_sync.rs
+++ b/monarch_hyperactor/src/code_sync/conda_sync.rs
@@ -18,9 +18,9 @@ use hyperactor::Actor;
 use hyperactor::Bind;
 use hyperactor::Handler;
 use hyperactor::Instance;
-use hyperactor::PortRef;
 use hyperactor::Unbind;
 use hyperactor::context::Mailbox;
+use hyperactor::reference;
 use hyperactor_mesh::ActorMeshRef;
 use hyperactor_mesh::connect::Connect;
 use hyperactor_mesh::connect::accept;
@@ -51,9 +51,9 @@ wirevalue::register_type!(CondaSyncResult);
 #[derive(Debug, Clone, Named, Serialize, Deserialize, Bind, Unbind)]
 pub struct CondaSyncMessage {
     /// The connect message to create a duplex bytestream with the client.
-    pub connect: PortRef<Connect>,
+    pub connect: reference::PortRef<Connect>,
     /// A port to send back the result or any errors.
-    pub result: PortRef<Result<CondaSyncResult, String>>,
+    pub result: reference::PortRef<Result<CondaSyncResult, String>>,
     /// The location of the workspace to sync.
     pub workspace: WorkspaceLocation,
     /// Path prefixes to fixup/replace when copying.

--- a/monarch_hyperactor/src/code_sync/manager.rs
+++ b/monarch_hyperactor/src/code_sync/manager.rs
@@ -25,11 +25,11 @@ use hyperactor::ActorHandle;
 use hyperactor::Bind;
 use hyperactor::Context;
 use hyperactor::Handler;
-use hyperactor::PortRef;
 use hyperactor::RemoteSpawn;
 use hyperactor::Unbind;
 use hyperactor::context;
 use hyperactor::handle;
+use hyperactor::reference;
 use hyperactor_config::Flattrs;
 use hyperactor_mesh::connect::Connect;
 use hyperactor_mesh::connect::accept;
@@ -63,10 +63,10 @@ use crate::code_sync::rsync::RsyncResult;
 #[derive(Clone, Serialize, Deserialize, Debug)]
 pub enum Method {
     Rsync {
-        connect: PortRef<Connect>,
+        connect: reference::PortRef<Connect>,
     },
     CondaSync {
-        connect: PortRef<Connect>,
+        connect: reference::PortRef<Connect>,
         path_prefix_replacements: HashMap<PathBuf, WorkspaceLocation>,
     },
 }
@@ -155,11 +155,11 @@ pub enum CodeSyncMessage {
         /// Whether to hot-reload code after syncing.
         reload: Option<WorkspaceShape>,
         /// A port to send back the result of the sync operation.
-        result: PortRef<Result<(), String>>,
+        result: reference::PortRef<Result<(), String>>,
     },
     Reload {
         sender_rank: Option<usize>,
-        result: PortRef<Result<(), String>>,
+        result: reference::PortRef<Result<(), String>>,
     },
 }
 wirevalue::register_type!(CodeSyncMessage);
@@ -245,7 +245,7 @@ impl CodeSyncMessageHandler for CodeSyncManager {
         workspace: WorkspaceLocation,
         method: Method,
         reload: Option<WorkspaceShape>,
-        result: PortRef<Result<(), String>>,
+        result: reference::PortRef<Result<(), String>>,
     ) -> Result<()> {
         let res = async move {
             match method {
@@ -337,7 +337,7 @@ impl CodeSyncMessageHandler for CodeSyncManager {
         &mut self,
         cx: &Context<Self>,
         sender_rank: Option<usize>,
-        result: PortRef<Result<(), String>>,
+        result: reference::PortRef<Result<(), String>>,
     ) -> Result<()> {
         if self
             .rank

--- a/monarch_hyperactor/src/code_sync/rsync.rs
+++ b/monarch_hyperactor/src/code_sync/rsync.rs
@@ -26,11 +26,11 @@ use futures::try_join;
 use hyperactor::Actor;
 use hyperactor::Bind;
 use hyperactor::Handler;
-use hyperactor::PortRef;
 use hyperactor::Unbind;
 use hyperactor::clock::Clock;
 use hyperactor::clock::RealClock;
 use hyperactor::context;
+use hyperactor::reference;
 use hyperactor_mesh::ActorMesh;
 use hyperactor_mesh::connect::Connect;
 use hyperactor_mesh::connect::accept;
@@ -329,9 +329,9 @@ impl RsyncDaemon {
 #[derive(Debug, Clone, Named, Serialize, Deserialize, Bind, Unbind)]
 pub struct RsyncMessage {
     /// The connect message to create a duplex bytestream with the client.
-    pub connect: PortRef<Connect>,
+    pub connect: reference::PortRef<Connect>,
     /// A port to send back the rsync result or any errors.
-    pub result: PortRef<Result<RsyncResult, String>>,
+    pub result: reference::PortRef<Result<RsyncResult, String>>,
     /// The location of the workspace to sync.
     pub workspace: WorkspaceLocation,
 }

--- a/monarch_hyperactor/src/local_state_broker.rs
+++ b/monarch_hyperactor/src/local_state_broker.rs
@@ -11,13 +11,12 @@ use std::collections::HashMap;
 use async_trait::async_trait;
 use hyperactor::Actor;
 use hyperactor::ActorHandle;
-use hyperactor::ActorId;
-use hyperactor::ActorRef;
 use hyperactor::Context;
 use hyperactor::Handler;
 use hyperactor::OncePortHandle;
 use hyperactor::clock::Clock;
 use hyperactor::clock::RealClock;
+use hyperactor::reference;
 use pyo3::prelude::*;
 
 #[derive(Debug)]
@@ -90,8 +89,9 @@ impl BrokerId {
         use std::time::Duration;
 
         let broker_name = format!("{:?}", self);
-        let actor_id = ActorId::new(cx.proc().proc_id().clone(), self.0.clone(), self.1);
-        let actor_ref: ActorRef<LocalStateBrokerActor> = ActorRef::attest(actor_id);
+        let actor_id = reference::ActorId::new(cx.proc().proc_id().clone(), self.0.clone(), self.1);
+        let actor_ref: reference::ActorRef<LocalStateBrokerActor> =
+            reference::ActorRef::attest(actor_id);
 
         let mut delay_ms = 1;
         loop {

--- a/monarch_hyperactor/src/mailbox.rs
+++ b/monarch_hyperactor/src/mailbox.rs
@@ -14,10 +14,7 @@ use std::sync::Arc;
 
 use hyperactor::Mailbox;
 use hyperactor::OncePortHandle;
-use hyperactor::OncePortRef;
 use hyperactor::PortHandle;
-use hyperactor::PortId;
-use hyperactor::PortRef;
 use hyperactor::accum::Accumulator;
 use hyperactor::accum::CommReducer;
 use hyperactor::accum::ReducerFactory;
@@ -31,6 +28,7 @@ use hyperactor::mailbox::monitored_return_handle;
 use hyperactor::message::Bind;
 use hyperactor::message::Bindings;
 use hyperactor::message::Unbind;
+use hyperactor::reference;
 use hyperactor_config::Flattrs;
 use monarch_types::PickledPyObject;
 use monarch_types::py_global;
@@ -158,16 +156,16 @@ impl PyMailbox {
 )]
 #[derive(Clone)]
 pub struct PyPortId {
-    inner: PortId,
+    inner: reference::PortId,
 }
 
-impl From<PortId> for PyPortId {
-    fn from(port_id: PortId) -> Self {
+impl From<reference::PortId> for PyPortId {
+    fn from(port_id: reference::PortId) -> Self {
         Self { inner: port_id }
     }
 }
 
-impl From<PyPortId> for PortId {
+impl From<PyPortId> for reference::PortId {
     fn from(port_id: PyPortId) -> Self {
         port_id.inner
     }
@@ -185,7 +183,7 @@ impl PyPortId {
     #[pyo3(signature = (*, actor_id, port))]
     fn new(actor_id: &PyActorId, port: u64) -> Self {
         Self {
-            inner: PortId::new(actor_id.inner.clone(), port),
+            inner: reference::PortId::new(actor_id.inner.clone(), port),
         }
     }
 
@@ -276,7 +274,7 @@ impl PythonPortHandle {
     module = "monarch._rust_bindings.monarch_hyperactor.mailbox"
 )]
 pub struct PythonPortRef {
-    pub(crate) inner: PortRef<PythonMessage>,
+    pub(crate) inner: reference::PortRef<PythonMessage>,
 }
 
 #[pymethods]
@@ -284,7 +282,7 @@ impl PythonPortRef {
     #[new]
     fn new(port: PyPortId) -> Self {
         Self {
-            inner: PortRef::attest(port.into()),
+            inner: reference::PortRef::attest(port.into()),
         }
     }
     fn __reduce__<'py>(
@@ -321,8 +319,8 @@ impl PythonPortRef {
     }
 }
 
-impl From<PortRef<PythonMessage>> for PythonPortRef {
-    fn from(port_ref: PortRef<PythonMessage>) -> Self {
+impl From<reference::PortRef<PythonMessage>> for PythonPortRef {
+    fn from(port_ref: reference::PortRef<PythonMessage>) -> Self {
         Self { inner: port_ref }
     }
 }
@@ -455,7 +453,7 @@ impl PythonOncePortHandle {
     module = "monarch._rust_bindings.monarch_hyperactor.mailbox"
 )]
 pub struct PythonOncePortRef {
-    pub(crate) inner: Option<OncePortRef<PythonMessage>>,
+    pub(crate) inner: Option<reference::OncePortRef<PythonMessage>>,
 }
 
 #[pymethods]
@@ -463,7 +461,7 @@ impl PythonOncePortRef {
     #[new]
     fn new(port: Option<PyPortId>) -> Self {
         Self {
-            inner: port.map(|port| PortRef::attest(port.inner).into_once()),
+            inner: port.map(|port| reference::PortRef::attest(port.inner).into_once()),
         }
     }
     fn __reduce__<'py>(
@@ -510,8 +508,8 @@ impl PythonOncePortRef {
     }
 }
 
-impl From<OncePortRef<PythonMessage>> for PythonOncePortRef {
-    fn from(port_ref: OncePortRef<PythonMessage>) -> Self {
+impl From<reference::OncePortRef<PythonMessage>> for PythonOncePortRef {
+    fn from(port_ref: reference::OncePortRef<PythonMessage>) -> Self {
         Self {
             inner: Some(port_ref),
         }

--- a/monarch_hyperactor/src/proc.rs
+++ b/monarch_hyperactor/src/proc.rs
@@ -20,9 +20,7 @@ use hyperactor::clock::ClockKind;
 use hyperactor::mailbox::PortReceiver;
 use hyperactor::proc::Instance;
 use hyperactor::proc::Proc;
-use hyperactor::reference::ActorId;
-use hyperactor::reference::Index;
-use hyperactor::reference::ProcId;
+use hyperactor::reference;
 use monarch_types::PickledPyObject;
 use pyo3::exceptions::PyRuntimeError;
 use pyo3::exceptions::PyValueError;
@@ -143,16 +141,16 @@ impl PyProc {
 )]
 #[derive(Clone)]
 pub struct PyActorId {
-    pub(super) inner: ActorId,
+    pub(super) inner: reference::ActorId,
 }
 
-impl From<ActorId> for PyActorId {
-    fn from(actor_id: ActorId) -> Self {
+impl From<reference::ActorId> for PyActorId {
+    fn from(actor_id: reference::ActorId) -> Self {
         Self { inner: actor_id }
     }
 }
 
-impl From<PyActorId> for ActorId {
+impl From<PyActorId> for reference::ActorId {
     fn from(val: PyActorId) -> Self {
         val.inner
     }
@@ -162,12 +160,16 @@ impl From<PyActorId> for ActorId {
 impl PyActorId {
     #[new]
     #[pyo3(signature = (*, addr, proc_name, actor_name, pid = 0))]
-    fn new(addr: &str, proc_name: &str, actor_name: &str, pid: Index) -> PyResult<Self> {
+    fn new(addr: &str, proc_name: &str, actor_name: &str, pid: reference::Index) -> PyResult<Self> {
         let addr: ChannelAddr = addr.parse().map_err(|e| {
             PyValueError::new_err(format!("Failed to parse channel address '{}': {}", addr, e))
         })?;
         Ok(Self {
-            inner: ActorId::new(ProcId::with_name(addr, proc_name), actor_name, pid),
+            inner: reference::ActorId::new(
+                reference::ProcId::with_name(addr, proc_name),
+                actor_name,
+                pid,
+            ),
         })
     }
 
@@ -199,7 +201,7 @@ impl PyActorId {
     }
 
     #[getter]
-    fn pid(&self) -> Index {
+    fn pid(&self) -> reference::Index {
         self.inner.pid()
     }
 
@@ -231,7 +233,7 @@ impl PyActorId {
     }
 }
 
-impl From<&PyActorId> for ActorId {
+impl From<&PyActorId> for reference::ActorId {
     fn from(actor_id: &PyActorId) -> Self {
         actor_id.inner.clone()
     }
@@ -299,7 +301,7 @@ pub struct InstanceWrapper<M: RemoteMessage> {
     status: InstanceStatus,
 
     clock: ClockKind,
-    actor_id: ActorId,
+    actor_id: reference::ActorId,
 }
 
 impl<M: RemoteMessage> InstanceWrapper<M> {
@@ -432,7 +434,7 @@ impl<M: RemoteMessage> InstanceWrapper<M> {
         &self.instance
     }
 
-    pub fn actor_id(&self) -> &ActorId {
+    pub fn actor_id(&self) -> &reference::ActorId {
         &self.actor_id
     }
 }

--- a/monarch_hyperactor/src/proc_launcher.rs
+++ b/monarch_hyperactor/src/proc_launcher.rs
@@ -24,9 +24,9 @@ use async_trait::async_trait;
 use hyperactor::ActorHandle;
 use hyperactor::Instance;
 use hyperactor::Mailbox;
-use hyperactor::ProcId;
 use hyperactor::clock::Clock;
 use hyperactor::clock::RealClock;
+use hyperactor::reference;
 use hyperactor_mesh::proc_launcher::LaunchOptions;
 use hyperactor_mesh::proc_launcher::LaunchResult;
 use hyperactor_mesh::proc_launcher::ProcExitKind;
@@ -569,7 +569,7 @@ pub struct ActorProcLauncher {
     ///
     /// Not used for correctness; used for diagnostics and sanity
     /// checks.
-    active_procs: Arc<Mutex<HashSet<ProcId>>>,
+    active_procs: Arc<Mutex<HashSet<reference::ProcId>>>,
 }
 
 impl ActorProcLauncher {
@@ -623,7 +623,7 @@ impl ProcLauncher for ActorProcLauncher {
     ///   resolves to `ProcExitKind::Failed` with a decode error reason.
     async fn launch(
         &self,
-        proc_id: &ProcId,
+        proc_id: &reference::ProcId,
         opts: LaunchOptions,
     ) -> Result<LaunchResult, ProcLauncherError> {
         let (exit_port, exit_port_rx) = self.mailbox.open_once_port::<PythonMessage>();
@@ -739,7 +739,7 @@ impl ProcLauncher for ActorProcLauncher {
     /// - send the message to the spawner actor.
     async fn terminate(
         &self,
-        proc_id: &ProcId,
+        proc_id: &reference::ProcId,
         timeout: Duration,
     ) -> Result<(), ProcLauncherError> {
         let pickled = Python::attach(|py| -> Result<Vec<u8>, ProcLauncherError> {
@@ -782,7 +782,7 @@ impl ProcLauncher for ActorProcLauncher {
     /// Returns `ProcLauncherError::Kill` if we fail to:
     /// - import/serialize the request via `cloudpickle`, or
     /// - send the message to the spawner actor.
-    async fn kill(&self, proc_id: &ProcId) -> Result<(), ProcLauncherError> {
+    async fn kill(&self, proc_id: &reference::ProcId) -> Result<(), ProcLauncherError> {
         let pickled = Python::attach(|py| -> Result<Vec<u8>, ProcLauncherError> {
             let cloudpickle =
                 import_cloudpickle(py).map_err(|e| ProcLauncherError::Kill(format!("{e}")))?;

--- a/monarch_hyperactor/src/runtime.rs
+++ b/monarch_hyperactor/src/runtime.rs
@@ -21,7 +21,7 @@ use hyperactor::channel::ChannelAddr;
 use hyperactor::channel::ChannelTransport;
 use hyperactor::mailbox::BoxedMailboxSender;
 use hyperactor::mailbox::PanickingMailboxSender;
-use hyperactor::reference::ProcId;
+use hyperactor::reference;
 use once_cell::sync::Lazy;
 use once_cell::unsync::OnceCell as UnsyncOnceCell;
 use pyo3::PyResult;
@@ -89,7 +89,7 @@ pub(crate) fn get_proc_runtime() -> &'static Proc {
     static RUNTIME_PROC: OnceLock<Proc> = OnceLock::new();
     RUNTIME_PROC.get_or_init(|| {
         let addr = ChannelAddr::any(ChannelTransport::Local);
-        let proc_id = ProcId::unique(addr, "monarch_hyperactor_runtime");
+        let proc_id = reference::ProcId::unique(addr, "monarch_hyperactor_runtime");
         Proc::configured(proc_id, BoxedMailboxSender::new(PanickingMailboxSender))
     })
 }

--- a/monarch_messages/src/client.rs
+++ b/monarch_messages/src/client.rs
@@ -13,10 +13,10 @@
 #![allow(unused_assignments)]
 
 use enum_as_inner::EnumAsInner;
-use hyperactor::ActorId;
 use hyperactor::HandleClient;
 use hyperactor::Handler;
 use hyperactor::RefClient;
+use hyperactor::reference;
 use serde::Deserialize;
 use serde::Serialize;
 use typeuri::Named;
@@ -94,7 +94,7 @@ pub enum ClientMessage {
     /// Notify the client of a debugger event.
     DebuggerMessage {
         /// The actor id of the debugger.
-        debugger_actor_id: ActorId,
+        debugger_actor_id: reference::ActorId,
         /// The action to take.
         action: DebuggerAction,
     },

--- a/monarch_messages/src/controller.rs
+++ b/monarch_messages/src/controller.rs
@@ -7,11 +7,10 @@
  */
 
 use derive_more::Display;
-use hyperactor::ActorRef;
 use hyperactor::HandleClient;
 use hyperactor::Handler;
 use hyperactor::RefClient;
-use hyperactor::reference::ActorId;
+use hyperactor::reference;
 use pyo3::FromPyObject;
 use pyo3::IntoPyObject;
 use pyo3::IntoPyObjectExt;
@@ -130,7 +129,7 @@ pub struct WorkerError {
 
     /// Actor id of the worker that had the error.
     // TODO: arguably at this level we only care about the rank
-    pub worker_actor_id: ActorId,
+    pub worker_actor_id: reference::ActorId,
 }
 
 /// Device operation failures.
@@ -145,7 +144,7 @@ pub struct DeviceFailure {
 
     /// Actor id of the worker that had the error.
     // TODO: arguably at this level we only care about the rank
-    pub actor_id: ActorId,
+    pub actor_id: reference::ActorId,
 }
 
 /// Controller messages. These define the contract that the controller has with the client
@@ -156,11 +155,11 @@ pub enum ControllerMessage {
     /// and allow the controller to send messages back to the client.
     Attach {
         /// The client actor that is being attached.
-        client_actor: ActorRef<ClientActor>,
+        client_actor: reference::ActorRef<ClientActor>,
 
         /// The response to indicate if the client was successfully attached.
         #[reply]
-        response_port: hyperactor::OncePortRef<()>,
+        response_port: reference::OncePortRef<()>,
     },
 
     /// Notify the controller of the dependencies for a worker operation with the same seq.
@@ -206,7 +205,7 @@ pub enum ControllerMessage {
     // TODO: T212094401 take a ActorRef
     Status {
         seq: Seq,
-        worker_actor_id: ActorId,
+        worker_actor_id: reference::ActorId,
         controller: bool,
     },
 
@@ -223,7 +222,7 @@ pub enum ControllerMessage {
     /// by the controller.
     GetFirstIncompleteSeqsUnitTestsOnly {
         #[reply]
-        response_port: hyperactor::OncePortRef<Vec<Seq>>,
+        response_port: reference::OncePortRef<Vec<Seq>>,
     },
 
     /// The message to schedule next supervision check task on the controller.
@@ -231,7 +230,7 @@ pub enum ControllerMessage {
 
     /// Debugger message sent from a debugger to be forwarded back to the client.
     DebuggerMessage {
-        debugger_actor_id: ActorId,
+        debugger_actor_id: reference::ActorId,
         action: DebuggerAction,
     },
 }

--- a/monarch_messages/src/worker.rs
+++ b/monarch_messages/src/worker.rs
@@ -24,13 +24,12 @@ use derive_more::Display;
 use derive_more::From;
 use derive_more::TryInto;
 use enum_as_inner::EnumAsInner;
-use hyperactor::ActorRef;
 use hyperactor::Bind;
 use hyperactor::HandleClient;
 use hyperactor::Handler;
 use hyperactor::RefClient;
 use hyperactor::Unbind;
-use hyperactor::reference::ActorId;
+use hyperactor::reference;
 use monarch_types::SerializablePyErr;
 use monarch_types::py_global;
 use ndslice::Slice;
@@ -858,7 +857,7 @@ pub enum WorkerMessage {
         /// - optional actor id to indicate the source of the error
         /// - error message or stacktrace
         /// The worker process will be stopped if the error is provided.
-        error: Option<(Option<ActorId>, String)>,
+        error: Option<(Option<reference::ActorId>, String)>,
     },
 
     /// Defines (part of) a new recording on the worker. This is a list of commands
@@ -934,7 +933,7 @@ pub enum WorkerMessage {
         /// The stream to retrieve from.
         stream: StreamRef,
         #[reply]
-        response_port: hyperactor::OncePortRef<Option<Result<WireValue, String>>>,
+        response_port: reference::OncePortRef<Option<Result<WireValue, String>>>,
     },
 }
 
@@ -952,7 +951,7 @@ pub struct WorkerParams {
     pub device_index: Option<i8>,
 
     // Actor Ref for the controller that the worker is associated with.
-    pub controller_actor: ActorRef<ControllerActor>,
+    pub controller_actor: reference::ActorRef<ControllerActor>,
 }
 wirevalue::register_type!(WorkerParams);
 

--- a/monarch_rdma/examples/cuda_ping_pong/src/cuda_ping_pong.rs
+++ b/monarch_rdma/examples/cuda_ping_pong/src/cuda_ping_pong.rs
@@ -60,15 +60,14 @@ use async_trait::async_trait;
 use clap::Arg;
 use clap::Command as ClapCommand;
 use hyperactor::Actor;
-use hyperactor::ActorRef;
 use hyperactor::Bind;
 use hyperactor::Context;
 use hyperactor::Handler;
 use hyperactor::Instance;
-use hyperactor::OncePortRef;
 use hyperactor::RemoteSpawn;
 use hyperactor::Unbind;
 use hyperactor::channel::ChannelAddr;
+use hyperactor::reference;
 use hyperactor::supervision::ActorSupervisionEvent;
 use hyperactor_config::Flattrs;
 use hyperactor_mesh::ActorMesh;
@@ -265,7 +264,7 @@ pub struct CudaRdmaActor {
     // RDMA buffer handle for the CUDA memory
     rdma_buffer_handle: Option<RdmaRemoteBuffer>,
     // Reference to the RDMA manager actor
-    rdma_manager: ActorRef<RdmaManagerActor>,
+    rdma_manager: reference::ActorRef<RdmaManagerActor>,
 }
 
 #[async_trait]
@@ -283,7 +282,7 @@ impl Actor for CudaRdmaActor {
 
 #[async_trait]
 impl RemoteSpawn for CudaRdmaActor {
-    type Params = (ActorRef<RdmaManagerActor>, usize, usize);
+    type Params = (reference::ActorRef<RdmaManagerActor>, usize, usize);
 
     async fn new(params: Self::Params, _environment: Flattrs) -> Result<Self, anyhow::Error> {
         let (rdma_manager, device_id, buffer_size) = params;
@@ -383,21 +382,21 @@ impl RemoteSpawn for CudaRdmaActor {
 
 // Message to initialize the buffer with data
 #[derive(Debug, Serialize, Deserialize, Named, Clone)]
-struct InitializeBuffer(pub u8, pub OncePortRef<bool>);
+struct InitializeBuffer(pub u8, pub reference::OncePortRef<bool>);
 
 // Message to perform an RDMA ping-pong operation with another actor
 #[derive(Debug, Serialize, Deserialize, Named, Clone)]
 struct PerformPingPong(
-    pub ActorRef<CudaRdmaActor>,
+    pub reference::ActorRef<CudaRdmaActor>,
     pub RdmaRemoteBuffer,
     pub i32,
     pub i32,
-    pub OncePortRef<bool>,
+    pub reference::OncePortRef<bool>,
 );
 
 // Message to verify the buffer contents
 #[derive(Debug, Serialize, Deserialize, Named, Clone)]
-struct VerifyBuffer(pub Box<[u8]>, pub OncePortRef<bool>);
+struct VerifyBuffer(pub Box<[u8]>, pub reference::OncePortRef<bool>);
 
 #[async_trait]
 impl Handler<InitializeBuffer> for CudaRdmaActor {
@@ -649,7 +648,7 @@ impl Handler<VerifyBuffer> for CudaRdmaActor {
 
 // Message to get the buffer handle from an actor
 #[derive(Debug, Serialize, Deserialize, Named, Clone, Bind, Unbind)]
-struct GetBufferHandle(#[binding(include)] pub OncePortRef<RdmaRemoteBuffer>);
+struct GetBufferHandle(#[binding(include)] pub reference::OncePortRef<RdmaRemoteBuffer>);
 
 #[async_trait]
 impl Handler<GetBufferHandle> for CudaRdmaActor {

--- a/monarch_rdma/examples/parameter_server/src/parameter_server.rs
+++ b/monarch_rdma/examples/parameter_server/src/parameter_server.rs
@@ -58,17 +58,15 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use hyperactor::Actor;
-use hyperactor::ActorRef;
 use hyperactor::Bind;
 use hyperactor::Context;
 use hyperactor::Handler;
 use hyperactor::Instance;
-use hyperactor::OncePortRef;
-use hyperactor::PortRef;
 use hyperactor::RemoteSpawn;
 use hyperactor::Unbind;
 use hyperactor::channel::ChannelTransport;
 use hyperactor::context::Mailbox as _;
+use hyperactor::reference;
 use hyperactor::supervision::ActorSupervisionEvent;
 use hyperactor_config::Flattrs;
 use hyperactor_mesh::ActorMesh;
@@ -108,7 +106,7 @@ pub struct ParameterServerActor {
     grad_buffer_data: Box<[Box<[u8]>]>,
     weights_handle: Option<RdmaRemoteBuffer>,
     grad_buffer_handles: HashMap<usize, RdmaRemoteBuffer>,
-    owner_ref: ActorRef<RdmaManagerActor>,
+    owner_ref: reference::ActorRef<RdmaManagerActor>,
 }
 
 #[async_trait]
@@ -128,7 +126,7 @@ impl Actor for ParameterServerActor {
 
 #[async_trait]
 impl RemoteSpawn for ParameterServerActor {
-    type Params = (ActorRef<RdmaManagerActor>, usize);
+    type Params = (reference::ActorRef<RdmaManagerActor>, usize);
 
     async fn new(_params: Self::Params, _environment: Flattrs) -> Result<Self, anyhow::Error> {
         let (owner_ref, worker_world_size) = _params;
@@ -149,17 +147,17 @@ impl RemoteSpawn for ParameterServerActor {
 }
 
 // Message to get handles to the parameter server's weights and gradient buffers.
-// - OncePortRef<(RdmaRemoteBuffer, RdmaRemoteBuffer)>: OncePortRef to the parameter server's weights and gradient buffers.
+// - reference::OncePortRef<(RdmaRemoteBuffer, RdmaRemoteBuffer)>: OncePortRef to the parameter server's weights and gradient buffers.
 #[derive(Debug, Serialize, Deserialize, Named, Clone)]
 struct PsGetBuffers(
     pub usize,
-    pub OncePortRef<(RdmaRemoteBuffer, RdmaRemoteBuffer)>,
+    pub reference::OncePortRef<(RdmaRemoteBuffer, RdmaRemoteBuffer)>,
 );
 
 // Message to update the parameter server's weights with its current gradient buffer.
-// - OncePortRef<bool>: OncePortRef used primarily for workload synchronization.
+// - reference::OncePortRef<bool>: OncePortRef used primarily for workload synchronization.
 #[derive(Debug, Serialize, Deserialize, Named, Clone)]
-struct PsUpdate(pub OncePortRef<bool>);
+struct PsUpdate(pub reference::OncePortRef<bool>);
 
 // Message to log actors' weights and gradients.
 #[derive(Debug, Serialize, Deserialize, Named, Clone, Bind, Unbind)]
@@ -296,21 +294,21 @@ impl RemoteSpawn for WorkerActor {
 // This message is sent to workers to establish their connection with the parameter server
 // and obtain handles to the shared weights and gradient buffers.
 #[derive(Debug, Serialize, Deserialize, Named, Clone, Bind, Unbind)]
-pub struct WorkerInit(pub ActorRef<ParameterServerActor>);
+pub struct WorkerInit(pub reference::ActorRef<ParameterServerActor>);
 
 // Message to signal the worker to update its gradients and transmit them to the server.
-// The PortRef<bool> is used to notify the main process when the operation completes.
+// The reference::PortRef<bool> is used to notify the main process when the operation completes.
 // - Workers compute local gradients (weights + 1)
 // - Workers write these gradients to their assigned buffer on the parameter server using RDMA
 #[derive(Debug, Serialize, Deserialize, Named, Clone, Bind, Unbind)]
-pub struct WorkerStep(#[binding(include)] PortRef<bool>);
+pub struct WorkerStep(#[binding(include)] reference::PortRef<bool>);
 
 // Message to signal the worker to pull updated weights from the parameter server.
-// The PortRef<bool> is used to notify the main process when the operation completes.
+// The reference::PortRef<bool> is used to notify the main process when the operation completes.
 // - Workers read the updated weights from the parameter server using RDMA
 // - This happens after the parameter server has applied all gradients to update the weights
 #[derive(Debug, Serialize, Deserialize, Named, Clone, Bind, Unbind)]
-pub struct WorkerUpdate(#[binding(include)] PortRef<bool>);
+pub struct WorkerUpdate(#[binding(include)] reference::PortRef<bool>);
 
 #[async_trait]
 impl Handler<WorkerInit> for WorkerActor {

--- a/monarch_rdma/src/backend.rs
+++ b/monarch_rdma/src/backend.rs
@@ -16,7 +16,7 @@ use std::time::Duration;
 
 use anyhow::Result;
 use async_trait::async_trait;
-use hyperactor::ActorRef;
+use hyperactor::reference;
 use serde::Deserialize;
 use serde::Serialize;
 use tokio::sync::OnceCell;
@@ -34,7 +34,7 @@ use crate::RdmaTransportLevel;
 #[derive(Debug, Clone)]
 pub enum RdmaBackendContext {
     Ibverbs(
-        ActorRef<ibverbs::manager_actor::IbvManagerActor>,
+        reference::ActorRef<ibverbs::manager_actor::IbvManagerActor>,
         Arc<OnceCell<ibverbs::IbvBuffer>>,
     ),
 }
@@ -54,7 +54,7 @@ impl<'de> Deserialize<'de> for RdmaBackendContext {
         #[derive(Deserialize)]
         #[serde(rename = "RdmaBackendContext")]
         enum Repr {
-            Ibverbs(ActorRef<ibverbs::manager_actor::IbvManagerActor>),
+            Ibverbs(reference::ActorRef<ibverbs::manager_actor::IbvManagerActor>),
         }
 
         match Repr::deserialize(deserializer)? {

--- a/monarch_rdma/src/backend/ibverbs.rs
+++ b/monarch_rdma/src/backend/ibverbs.rs
@@ -10,7 +10,7 @@
 
 use std::sync::Arc;
 
-use hyperactor::ActorRef;
+use hyperactor::reference;
 use serde::Deserialize;
 use serde::Serialize;
 use typeuri::Named;
@@ -56,5 +56,5 @@ pub struct IbvOp {
     pub op_type: RdmaOpType,
     pub local_memory: Arc<dyn RdmaLocalMemory>,
     pub remote_buffer: IbvBuffer,
-    pub remote_manager: ActorRef<IbvManagerActor>,
+    pub remote_manager: reference::ActorRef<IbvManagerActor>,
 }

--- a/monarch_rdma/src/backend/ibverbs/manager_actor.rs
+++ b/monarch_rdma/src/backend/ibverbs/manager_actor.rs
@@ -28,17 +28,15 @@ use async_trait::async_trait;
 use futures::lock::Mutex;
 use hyperactor::Actor;
 use hyperactor::ActorHandle;
-use hyperactor::ActorId;
-use hyperactor::ActorRef;
 use hyperactor::Context;
 use hyperactor::HandleClient;
 use hyperactor::Handler;
 use hyperactor::Instance;
 use hyperactor::OncePortHandle;
-use hyperactor::OncePortRef;
 use hyperactor::RefClient;
 use hyperactor::clock::Clock;
 use hyperactor::clock::RealClock;
+use hyperactor::reference;
 use serde::Deserialize;
 use serde::Serialize;
 use typeuri::Named;
@@ -79,53 +77,53 @@ pub enum IbvManagerMessage {
     RequestBuffer {
         remote_buf_id: usize,
         #[reply]
-        reply: OncePortRef<Option<IbvBuffer>>,
+        reply: reference::OncePortRef<Option<IbvBuffer>>,
     },
     /// Release a buffer registration by `remote_buf_id`.
     ReleaseBuffer {
         remote_buf_id: usize,
         #[reply]
-        reply: OncePortRef<()>,
+        reply: reference::OncePortRef<()>,
     },
     RequestQueuePair {
-        other: ActorRef<IbvManagerActor>,
+        other: reference::ActorRef<IbvManagerActor>,
         self_device: String,
         other_device: String,
         #[reply]
-        reply: OncePortRef<IbvQueuePair>,
+        reply: reference::OncePortRef<IbvQueuePair>,
     },
     Connect {
-        other: ActorRef<IbvManagerActor>,
+        other: reference::ActorRef<IbvManagerActor>,
         self_device: String,
         other_device: String,
         endpoint: IbvQpInfo,
     },
     InitializeQP {
-        other: ActorRef<IbvManagerActor>,
+        other: reference::ActorRef<IbvManagerActor>,
         self_device: String,
         other_device: String,
         #[reply]
-        reply: OncePortRef<bool>,
+        reply: reference::OncePortRef<bool>,
     },
     ConnectionInfo {
-        other: ActorRef<IbvManagerActor>,
+        other: reference::ActorRef<IbvManagerActor>,
         self_device: String,
         other_device: String,
         #[reply]
-        reply: OncePortRef<IbvQpInfo>,
+        reply: reference::OncePortRef<IbvQpInfo>,
     },
     ReleaseQueuePair {
-        other: ActorRef<IbvManagerActor>,
+        other: reference::ActorRef<IbvManagerActor>,
         self_device: String,
         other_device: String,
         qp: IbvQueuePair,
     },
     GetQpState {
-        other: ActorRef<IbvManagerActor>,
+        other: reference::ActorRef<IbvManagerActor>,
         self_device: String,
         other_device: String,
         #[reply]
-        reply: OncePortRef<u32>,
+        reply: reference::OncePortRef<u32>,
     },
 }
 wirevalue::register_type!(IbvManagerMessage);
@@ -156,11 +154,11 @@ pub struct IbvManagerActor {
     owner: OnceLock<ActorHandle<RdmaManagerActor>>,
 
     // Nested map: local_device -> (ActorId, remote_device) -> IbvQueuePair
-    device_qps: HashMap<String, HashMap<(ActorId, String), IbvQueuePair>>,
+    device_qps: HashMap<String, HashMap<(reference::ActorId, String), IbvQueuePair>>,
 
     // Track QPs currently being created to prevent duplicate creation
     // Wrapped in Arc<Mutex> to allow safe concurrent access
-    pending_qp_creation: Arc<Mutex<HashSet<(String, ActorId, String)>>>,
+    pending_qp_creation: Arc<Mutex<HashSet<(String, reference::ActorId, String)>>>,
 
     // Map of RDMA device names to their domains and loopback QPs
     // Created lazily when memory is registered for a specific device
@@ -745,11 +743,11 @@ impl IbvManagerMessageHandler for IbvManagerActor {
     async fn request_queue_pair(
         &mut self,
         cx: &Context<Self>,
-        other: ActorRef<IbvManagerActor>,
+        other: reference::ActorRef<IbvManagerActor>,
         self_device: String,
         other_device: String,
     ) -> Result<IbvQueuePair, anyhow::Error> {
-        let self_ref: ActorRef<IbvManagerActor> = cx.bind();
+        let self_ref: reference::ActorRef<IbvManagerActor> = cx.bind();
         let other_id = other.actor_id().clone();
 
         // Use the nested map structure: local_device -> (actor_id, remote_device) -> IbvQueuePair
@@ -915,7 +913,7 @@ impl IbvManagerMessageHandler for IbvManagerActor {
     async fn connect(
         &mut self,
         _cx: &Context<Self>,
-        other: ActorRef<IbvManagerActor>,
+        other: reference::ActorRef<IbvManagerActor>,
         self_device: String,
         other_device: String,
         endpoint: IbvQpInfo,
@@ -949,7 +947,7 @@ impl IbvManagerMessageHandler for IbvManagerActor {
     async fn initialize_qp(
         &mut self,
         _cx: &Context<Self>,
-        other: ActorRef<IbvManagerActor>,
+        other: reference::ActorRef<IbvManagerActor>,
         self_device: String,
         other_device: String,
     ) -> Result<bool, anyhow::Error> {
@@ -1004,7 +1002,7 @@ impl IbvManagerMessageHandler for IbvManagerActor {
     async fn connection_info(
         &mut self,
         _cx: &Context<Self>,
-        other: ActorRef<IbvManagerActor>,
+        other: reference::ActorRef<IbvManagerActor>,
         self_device: String,
         other_device: String,
     ) -> Result<IbvQpInfo, anyhow::Error> {
@@ -1035,7 +1033,7 @@ impl IbvManagerMessageHandler for IbvManagerActor {
     async fn release_queue_pair(
         &mut self,
         _cx: &Context<Self>,
-        _other: ActorRef<IbvManagerActor>,
+        _other: reference::ActorRef<IbvManagerActor>,
         _self_device: String,
         _other_device: String,
         _qp: IbvQueuePair,
@@ -1046,7 +1044,7 @@ impl IbvManagerMessageHandler for IbvManagerActor {
     async fn get_qp_state(
         &mut self,
         _cx: &Context<Self>,
-        other: ActorRef<IbvManagerActor>,
+        other: reference::ActorRef<IbvManagerActor>,
         self_device: String,
         other_device: String,
     ) -> Result<u32, anyhow::Error> {

--- a/monarch_rdma/src/backend/ibverbs/mlx5dv_tests.rs
+++ b/monarch_rdma/src/backend/ibverbs/mlx5dv_tests.rs
@@ -13,11 +13,11 @@ use std::sync::OnceLock;
 
 use async_trait::async_trait;
 use hyperactor::Actor;
-use hyperactor::ActorRef;
 use hyperactor::Context;
 use hyperactor::Handler;
 use hyperactor::RefClient;
 use hyperactor::RemoteSpawn;
+use hyperactor::reference;
 use hyperactor_config::Flattrs;
 use hyperactor_mesh::ActorMesh;
 use hyperactor_mesh::context;
@@ -109,9 +109,9 @@ enum SenderMessage {
         buf0_size: usize,
         buf1_offset: usize,
         buf1_size: usize,
-        rdma_manager: ActorRef<RdmaManagerActor>,
+        rdma_manager: reference::ActorRef<RdmaManagerActor>,
         #[reply]
-        reply: hyperactor::OncePortRef<(RdmaRemoteBuffer, RdmaRemoteBuffer)>,
+        reply: reference::OncePortRef<(RdmaRemoteBuffer, RdmaRemoteBuffer)>,
     },
 }
 
@@ -126,7 +126,7 @@ impl SenderMessageHandler for SenderActor {
         buf0_size: usize,
         buf1_offset: usize,
         buf1_size: usize,
-        rdma_manager: ActorRef<RdmaManagerActor>,
+        rdma_manager: reference::ActorRef<RdmaManagerActor>,
     ) -> Result<(RdmaRemoteBuffer, RdmaRemoteBuffer), anyhow::Error> {
         let (dptr, padded_size) = unsafe {
             let ctx = self.cuda_ctx as rdmaxcel_sys::CUcontext;
@@ -233,7 +233,7 @@ enum ReceiverMessage {
         size: usize,
         timeout_secs: u64,
         #[reply]
-        reply: hyperactor::OncePortRef<Result<(), String>>,
+        reply: reference::OncePortRef<Result<(), String>>,
     },
 }
 

--- a/monarch_rdma/src/backend/ibverbs/test_utils.rs
+++ b/monarch_rdma/src/backend/ibverbs/test_utils.rs
@@ -13,7 +13,6 @@ use std::time::Duration;
 use std::time::Instant;
 
 use hyperactor::Actor;
-use hyperactor::ActorRef;
 use hyperactor::Context;
 use hyperactor::HandleClient;
 use hyperactor::Handler;
@@ -24,6 +23,7 @@ use hyperactor::RemoteSpawn;
 use hyperactor::channel::ChannelAddr;
 use hyperactor::clock::Clock;
 use hyperactor::clock::RealClock;
+use hyperactor::reference;
 use hyperactor_config::Flattrs;
 
 use super::IbvBuffer;
@@ -96,23 +96,23 @@ impl RemoteSpawn for CudaActor {
 pub enum CudaActorMessage {
     CreateBuffer {
         size: usize,
-        rdma_actor: ActorRef<RdmaManagerActor>,
+        rdma_actor: reference::ActorRef<RdmaManagerActor>,
         #[reply]
-        reply: hyperactor::OncePortRef<(RdmaRemoteBuffer, usize)>,
+        reply: reference::OncePortRef<(RdmaRemoteBuffer, usize)>,
     },
     FillBuffer {
         device_ptr: usize,
         size: usize,
         value: u8,
         #[reply]
-        reply: hyperactor::OncePortRef<()>,
+        reply: reference::OncePortRef<()>,
     },
     VerifyBuffer {
         cpu_buffer_ptr: usize,
         device_ptr: usize,
         size: usize,
         #[reply]
-        reply: hyperactor::OncePortRef<()>,
+        reply: reference::OncePortRef<()>,
     },
 }
 
@@ -454,18 +454,18 @@ pub struct IbvTestEnv {
     buffer_2: Buffer,
     pub client_1: Instance<()>,
     pub client_2: Instance<()>,
-    pub actor_1: ActorRef<RdmaManagerActor>,
-    pub actor_2: ActorRef<RdmaManagerActor>,
-    pub ibv_actor_1: ActorRef<IbvManagerActor>,
-    pub ibv_actor_2: ActorRef<IbvManagerActor>,
+    pub actor_1: reference::ActorRef<RdmaManagerActor>,
+    pub actor_2: reference::ActorRef<RdmaManagerActor>,
+    pub ibv_actor_1: reference::ActorRef<IbvManagerActor>,
+    pub ibv_actor_2: reference::ActorRef<IbvManagerActor>,
     pub rdma_handle_1: RdmaRemoteBuffer,
     pub rdma_handle_2: RdmaRemoteBuffer,
     pub local_memory_1: Arc<dyn RdmaLocalMemory>,
     pub local_memory_2: Arc<dyn RdmaLocalMemory>,
     pub ibv_buffer_1: IbvBuffer,
     pub ibv_buffer_2: IbvBuffer,
-    cuda_actor_1: Option<ActorRef<CudaActor>>,
-    cuda_actor_2: Option<ActorRef<CudaActor>>,
+    cuda_actor_1: Option<reference::ActorRef<CudaActor>>,
+    cuda_actor_2: Option<reference::ActorRef<CudaActor>>,
     device_ptr_1: Option<usize>,
     device_ptr_2: Option<usize>,
 }
@@ -541,11 +541,11 @@ impl IbvTestEnv {
 
         let rdma_actor_1 = RdmaManagerActor::new(Some(config1), Flattrs::default()).await?;
         let rdma_actor_handle_1 = proc_1.spawn("rdma_manager", rdma_actor_1)?;
-        let actor_1: ActorRef<RdmaManagerActor> = rdma_actor_handle_1.bind();
+        let actor_1: reference::ActorRef<RdmaManagerActor> = rdma_actor_handle_1.bind();
 
         let rdma_actor_2 = RdmaManagerActor::new(Some(config2), Flattrs::default()).await?;
         let rdma_actor_handle_2 = proc_2.spawn("rdma_manager", rdma_actor_2)?;
-        let actor_2: ActorRef<RdmaManagerActor> = rdma_actor_handle_2.bind();
+        let actor_2: reference::ActorRef<RdmaManagerActor> = rdma_actor_handle_2.bind();
 
         let mut buf_vec = Vec::new();
         let mut cuda_actor_1 = None;
@@ -578,7 +578,7 @@ impl IbvTestEnv {
             // CUDA case - spawn CudaActor on the same proc
             let cuda_actor = CudaActor::new(parsed_accel1.1 as i32, Flattrs::default()).await?;
             let cuda_handle = proc_1.spawn("cuda_init", cuda_actor)?;
-            let cuda_actor_ref_1: ActorRef<CudaActor> = cuda_handle.bind();
+            let cuda_actor_ref_1: reference::ActorRef<CudaActor> = cuda_handle.bind();
 
             let (rdma_buf, dev_ptr) = cuda_actor_ref_1
                 .create_buffer(&instance_1, buffer_size, actor_1.clone())
@@ -615,7 +615,7 @@ impl IbvTestEnv {
             // CUDA case - spawn CudaActor on the same proc
             let cuda_actor = CudaActor::new(parsed_accel2.1 as i32, Flattrs::default()).await?;
             let cuda_handle = proc_2.spawn("cuda_init", cuda_actor)?;
-            let cuda_actor_ref_2: ActorRef<CudaActor> = cuda_handle.bind();
+            let cuda_actor_ref_2: reference::ActorRef<CudaActor> = cuda_handle.bind();
 
             let (rdma_buf, dev_ptr) = cuda_actor_ref_2
                 .create_buffer(&instance_2, buffer_size, actor_2.clone())

--- a/monarch_rdma/src/rdma_components.rs
+++ b/monarch_rdma/src/rdma_components.rs
@@ -46,8 +46,8 @@ use std::result::Result;
 use std::sync::Arc;
 use std::time::Duration;
 
-use hyperactor::ActorRef;
 use hyperactor::context;
+use hyperactor::reference;
 use serde::Deserialize;
 use serde::Serialize;
 use typeuri::Named;
@@ -72,7 +72,7 @@ use crate::local_memory::RdmaLocalMemory;
 pub struct RdmaRemoteBuffer {
     pub id: usize,
     pub size: usize,
-    pub owner: ActorRef<RdmaManagerActor>,
+    pub owner: reference::ActorRef<RdmaManagerActor>,
     pub backends: Vec<RdmaBackendContext>,
 }
 wirevalue::register_type!(RdmaRemoteBuffer);
@@ -138,7 +138,7 @@ impl RdmaRemoteBuffer {
     pub async fn resolve_ibv(
         &self,
         client: &impl context::Actor,
-    ) -> Result<(ActorRef<IbvManagerActor>, IbvBuffer), anyhow::Error> {
+    ) -> Result<(reference::ActorRef<IbvManagerActor>, IbvBuffer), anyhow::Error> {
         let RdmaBackendContext::Ibverbs(remote_ibv_mgr, remote_ibv_buf) =
             self.backends.iter().map(Ok).next().unwrap_or_else(|| {
                 Err(anyhow::anyhow!(

--- a/monarch_rdma/src/rdma_manager_actor.rs
+++ b/monarch_rdma/src/rdma_manager_actor.rs
@@ -27,17 +27,15 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use hyperactor::Actor;
 use hyperactor::ActorHandle;
-use hyperactor::ActorId;
-use hyperactor::ActorRef;
 use hyperactor::Context;
 use hyperactor::HandleClient;
 use hyperactor::Handler;
 use hyperactor::Instance;
 use hyperactor::OncePortHandle;
-use hyperactor::OncePortRef;
 use hyperactor::RefClient;
 use hyperactor::RemoteSpawn;
 use hyperactor::context;
+use hyperactor::reference;
 use hyperactor::supervision::ActorSupervisionEvent;
 use hyperactor_config::Flattrs;
 use serde::Deserialize;
@@ -99,7 +97,7 @@ wirevalue::register_type!(ReleaseBuffer);
 #[derive(Handler, HandleClient, RefClient, Debug, Serialize, Deserialize, Named)]
 pub struct GetIbvActorRef {
     #[reply]
-    pub reply: OncePortRef<Option<ActorRef<IbvManagerActor>>>,
+    pub reply: reference::OncePortRef<Option<reference::ActorRef<IbvManagerActor>>>,
 }
 wirevalue::register_type!(GetIbvActorRef);
 
@@ -151,7 +149,8 @@ impl RdmaManagerActor {
     /// with the caller.
     pub fn local_handle(client: &impl context::Actor) -> ActorHandle<Self> {
         let proc_id = client.mailbox().actor_id().proc_id().clone();
-        let actor_ref = ActorRef::attest(ActorId::new(proc_id, "rdma_manager", 0));
+        let actor_ref =
+            reference::ActorRef::attest(reference::ActorId::new(proc_id, "rdma_manager", 0));
         actor_ref
             .downcast_handle(client)
             .expect("RdmaManagerActor is not in the local process")
@@ -197,7 +196,7 @@ impl GetIbvActorRefHandler for RdmaManagerActor {
     async fn get_ibv_actor_ref(
         &mut self,
         _cx: &Context<Self>,
-    ) -> Result<Option<ActorRef<IbvManagerActor>>, anyhow::Error> {
+    ) -> Result<Option<reference::ActorRef<IbvManagerActor>>, anyhow::Error> {
         Ok(Some(self.ibverbs.handle().bind()))
     }
 }

--- a/monarch_tensor_worker/src/lib.rs
+++ b/monarch_tensor_worker/src/lib.rs
@@ -52,14 +52,13 @@ use derive_more::TryInto;
 use device_mesh::DeviceMesh;
 use futures::future::try_join_all;
 use hyperactor::Actor;
-use hyperactor::ActorRef;
 use hyperactor::Bind;
 use hyperactor::Handler;
 use hyperactor::RemoteSpawn;
 use hyperactor::Unbind;
 use hyperactor::actor::ActorHandle;
 use hyperactor::context;
-use hyperactor::reference::ActorId;
+use hyperactor::reference;
 use hyperactor_config::Flattrs;
 use hyperactor_mesh::comm::multicast::CastInfo;
 use itertools::Itertools;
@@ -167,7 +166,7 @@ pub struct WorkerActor {
     rank: usize,
     borrows: HashMap<u64, Borrow>,
     comm: Option<ActorHandle<NcclCommActor>>,
-    controller_actor: ActorRef<ControllerActor>,
+    controller_actor: reference::ActorRef<ControllerActor>,
     /// Remember the process groups "created" via `CreateRemoteProcessGroup` for
     /// subsequent `CallFunction` calls, as this is where the actual allocation
     /// will happen.
@@ -694,7 +693,7 @@ impl WorkerMessageHandler for WorkerActor {
     async fn exit(
         &mut self,
         cx: &hyperactor::Context<Self>,
-        error: Option<(Option<ActorId>, String)>,
+        error: Option<(Option<reference::ActorId>, String)>,
     ) -> Result<()> {
         for (_, stream) in self.streams.drain() {
             stream.drain_and_stop("tensor worker exit cleanup")?;

--- a/monarch_tensor_worker/src/stream.rs
+++ b/monarch_tensor_worker/src/stream.rs
@@ -21,8 +21,6 @@ use anyhow::bail;
 use anyhow::ensure;
 use async_trait::async_trait;
 use hyperactor::Actor;
-use hyperactor::ActorId;
-use hyperactor::ActorRef;
 use hyperactor::Context;
 use hyperactor::HandleClient;
 use hyperactor::Handler;
@@ -33,6 +31,7 @@ use hyperactor::handle;
 use hyperactor::mailbox::OncePortHandle;
 use hyperactor::mailbox::PortReceiver;
 use hyperactor::proc::Proc;
+use hyperactor::reference;
 use monarch_hyperactor::actor::PythonMessage;
 use monarch_hyperactor::actor::PythonMessageKind;
 use monarch_hyperactor::local_state_broker::BrokerId;
@@ -83,9 +82,9 @@ pub type TensorCellResult = Result<TensorCell, Arc<SeqError>>;
 
 // These thread locals are accessed by the python runtime for debugging sessions.
 thread_local! {
-    pub static CONTROLLER_ACTOR_REF: OnceCell<ActorRef<ControllerActor>> = const { OnceCell::new() };
+    pub static CONTROLLER_ACTOR_REF: OnceCell<reference::ActorRef<ControllerActor>> = const { OnceCell::new() };
     pub static PROC: OnceCell<Proc> = const { OnceCell::new() };
-    pub static ROOT_ACTOR_ID: OnceCell<ActorId> = const { OnceCell::new() };
+    pub static ROOT_ACTOR_ID: OnceCell<reference::ActorId> = const { OnceCell::new() };
 }
 
 fn pickle_python_result(
@@ -204,7 +203,7 @@ pub enum StreamMessage {
 
     SendValue {
         seq: Seq,
-        worker_actor_id: ActorId,
+        worker_actor_id: reference::ActorId,
         mutates: Vec<Ref>,
         function: Option<ResolvableFunction>,
         args_kwargs: ArgsKwargs,
@@ -429,7 +428,7 @@ pub struct StreamActor {
     /// Communicator for this stream. Optional as we lazily initialize it.
     comm: Option<ActorHandle<NcclCommActor>>,
     /// Actor ref of the controller that created this stream.
-    controller_actor: ActorRef<ControllerActor>,
+    controller_actor: reference::ActorRef<ControllerActor>,
     remote_process_groups: HashMap<Ref, Py<PyAny>>,
     recordings: HashMap<Ref, Recording>,
     active_recording: Option<RecordingState>,
@@ -450,7 +449,7 @@ pub struct StreamParams {
     /// synchronization.
     pub device: Option<CudaDevice>,
     /// Actor ref of the controller that created this stream.
-    pub controller_actor: ActorRef<ControllerActor>,
+    pub controller_actor: reference::ActorRef<ControllerActor>,
     pub respond_with_python_message: bool,
 }
 
@@ -496,7 +495,7 @@ impl Actor for StreamActor {
         PROC.with(|proc| proc.set(cx.proc().clone()).ok());
         ROOT_ACTOR_ID.with(|root_actor_id| {
             root_actor_id
-                .set(ActorId::root(
+                .set(reference::ActorId::root(
                     cx.self_id().proc_id().clone(),
                     cx.self_id().name().to_string(),
                 ))
@@ -1444,7 +1443,7 @@ impl StreamMessageHandler for StreamActor {
         &mut self,
         cx: &Context<Self>,
         seq: Seq,
-        worker_actor_id: ActorId,
+        worker_actor_id: reference::ActorId,
         mutates: Vec<Ref>,
         function: Option<ResolvableFunction>,
         args_kwargs: ArgsKwargs,
@@ -1958,7 +1957,7 @@ mod tests {
         #[allow(dead_code)]
         controller_rx: PortReceiver<ControllerMessage>,
         #[allow(dead_code)]
-        controller_actor: ActorRef<ControllerActor>,
+        controller_actor: reference::ActorRef<ControllerActor>,
         next_ref: Ref,
     }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #2933
* #2932
* #2928
* #2927
* #2926
* #2925

Preparatory refactor for eventually removing the `reference` module
re-exports from `hyperactor/src/lib.rs`. Every usage site now explicitly
qualifies reference types through the module path (`reference::ActorId`,
`reference::ProcId`, etc.) instead of importing them directly.

Changes:
- Remove 5 `pub use reference::*` re-exports from `hyperactor/src/lib.rs`
  (`ActorId`, `ProcId`, `PortId`, `PortRef`, `OncePortRef`). Keep
  `ActorRef` as `#[doc(hidden)]` because the `RefClient` derive macro
  generates code referencing `hyperactor::ActorRef`.
- Within the `hyperactor` crate (22 files): replace
  `use crate::{ActorId, ProcId, ...}` with `use crate::reference;` and
  qualify all usages inline as `reference::ActorId`, etc.
- Within `hyperactor_mesh` (28 files): use
  `use hyperactor::reference as hyperactor_reference;` (aliased because
  `hyperactor_mesh` has its own `pub mod reference`) and qualify as
  `hyperactor_reference::ActorId`, etc.
- Within `monarch_hyperactor` (11 files) and all other downstream crates
  (27 files): use `use hyperactor::reference;` and qualify as
  `reference::ActorId`, etc.

88 files modified across 12 crates. No behavioral changes.

Differential Revision: [D95832785](https://our.internmc.facebook.com/intern/diff/D95832785/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D95832785/)!