### PR TITLE
enforce mandatory mTLS for mesh admin HTTP server in meta builds

### DIFF
--- a/hyperactor/src/channel/net.rs
+++ b/hyperactor/src/channel/net.rs
@@ -1518,19 +1518,20 @@ pub fn try_tls_pem_bundle() -> Option<crate::config::PemBundle> {
 /// 3. **None** — no usable certificates found; caller should fall
 ///    back to plain HTTP.
 ///
-/// The returned acceptor does **not** require client certificates
-/// (`with_no_client_auth`), matching the convention for HTTP admin
-/// endpoints where the server authenticates itself but does not
-/// demand mutual TLS from browsers or CLI tools.
-pub fn try_tls_acceptor() -> Option<tokio_rustls::TlsAcceptor> {
+/// When `enforce_client_tls` is `true`, the returned acceptor
+/// requires clients to present a valid certificate signed by the
+/// configured CA (mutual TLS via `WebPkiClientVerifier`). When
+/// `false`, the acceptor authenticates itself but does not demand
+/// client certificates.
+pub fn try_tls_acceptor(enforce_client_tls: bool) -> Option<tokio_rustls::TlsAcceptor> {
     let oss_bundle = oss_pem_bundle();
-    if let Ok(acceptor) = tls::tls_acceptor_from_bundle(&oss_bundle, false) {
+    if let Ok(acceptor) = tls::tls_acceptor_from_bundle(&oss_bundle, enforce_client_tls) {
         return Some(acceptor);
     }
     tracing::debug!("OSS TLS acceptor failed, trying Meta paths");
 
     let meta_bundle = meta::get_server_pem_bundle();
-    if let Ok(acceptor) = tls::tls_acceptor_from_bundle(&meta_bundle, false) {
+    if let Ok(acceptor) = tls::tls_acceptor_from_bundle(&meta_bundle, enforce_client_tls) {
         return Some(acceptor);
     }
     tracing::debug!("Meta TLS acceptor failed, no TLS available");

--- a/hyperactor_mesh/bin/admin_tui/client.rs
+++ b/hyperactor_mesh/bin/admin_tui/client.rs
@@ -63,10 +63,11 @@
 //!    locations.
 //! 3. Fallback to plain HTTP when no usable CA is found.
 //!
-//! When TLS is enabled, the returned client verifies the server
-//! certificate against the configured CA. When mutual TLS material is
-//! present, a client identity is attached on a best-effort basis
-//! (failure to parse the identity does not disable TLS).
+//! **Note:** At Meta (`fbcode_build`), the mesh admin server requires
+//! mutual TLS. If the client cannot load a CA certificate or fails to
+//! parse a client identity, the connection will be rejected at the TLS
+//! handshake. In OSS, the server falls back to plain HTTP when no
+//! certs are available, so the client's HTTP fallback still works.
 
 use std::time::Duration;
 
@@ -206,11 +207,69 @@ fn add_tls(
     let mut builder = builder.add_root_certificate(root_cert);
 
     if let (Some(cert), Some(key)) = (cert_bytes, key_bytes) {
-        let mut id_pem = cert;
-        id_pem.extend_from_slice(&key);
-        match reqwest::Identity::from_pem(&id_pem) {
-            Ok(identity) => builder = builder.identity(identity),
-            Err(e) => eprintln!("TLS: invalid client identity PEM: {}", e),
+        // reqwest's Identity type is backend-specific: from_pkcs8_pem
+        // creates a native-tls identity, from_pem creates a rustls
+        // identity. When both features are compiled (fbcode Buck builds),
+        // using the wrong variant silently fails at connect time with
+        // "incompatible TLS identity type".
+        //
+        // Meta's server.pem bundles certs + key in one file.
+        // from_pkcs8_pem requires the key as a separate buffer, so we
+        // split it out by finding the private key marker.
+        let combined = if cert == key {
+            cert
+        } else {
+            let mut c = cert;
+            c.extend_from_slice(&key);
+            c
+        };
+        let identity_result = {
+            // Split PEM into cert-only and key-only buffers for native-tls.
+            // reqwest 0.11 with both native-tls and rustls features compiled
+            // (fbcode Buck builds) defaults to the native-tls connector.
+            // Identity::from_pem creates a rustls-flavored identity that is
+            // silently rejected by native-tls at connect time. We must use
+            // from_pkcs8_pem (native-tls) in fbcode, and from_pem (rustls)
+            // in OSS where native-tls is excluded (D93626607).
+            let combined_str = String::from_utf8_lossy(&combined);
+            let key_markers = [
+                // @lint-ignore PRIVATEKEY
+                "-----BEGIN PRIVATE KEY-----",
+                // @lint-ignore PRIVATEKEY
+                "-----BEGIN RSA PRIVATE KEY-----",
+                // @lint-ignore PRIVATEKEY
+                "-----BEGIN EC PRIVATE KEY-----",
+            ];
+            let key_pos = key_markers
+                .iter()
+                .filter_map(|m| combined_str.find(m))
+                .min();
+            #[cfg(fbcode_build)]
+            {
+                if let Some(key_start) = key_pos {
+                    let cert_pem = combined_str[..key_start].trim().as_bytes();
+                    let key_pem = combined_str[key_start..].trim().as_bytes();
+                    reqwest::Identity::from_pkcs8_pem(cert_pem, key_pem)
+                } else {
+                    reqwest::Identity::from_pem(&combined)
+                }
+            }
+            #[cfg(not(fbcode_build))]
+            {
+                let _ = key_pos; // suppress unused warning
+                reqwest::Identity::from_pem(&combined)
+            }
+        };
+        match identity_result {
+            Ok(identity) => {
+                builder = builder.identity(identity);
+            }
+            Err(e) => eprintln!(
+                "WARNING: TLS: failed to parse client identity PEM: {}. \
+                 The mesh admin server requires mTLS — connection will fail \
+                 without a valid client certificate.",
+                e
+            ),
         }
     }
 
@@ -293,9 +352,11 @@ fn add_tls_from_bundle(
 /// 1. If `--tls-ca` is provided, attempt to load the CA (and
 ///    optionally `--tls-cert` + `--tls-key` for a client identity)
 ///    from those paths.
-/// 2. Otherwise, if no explicit scheme was given, try auto-detection
-///    via [`hyperactor::channel::try_tls_pem_bundle`] (OSS config
-///    first, then Meta well-known paths).
+/// 2. Otherwise, if no `--tls-ca` was given, try auto-detection via
+///    [`hyperactor::channel::try_tls_pem_bundle`] (OSS config first,
+///    then Meta well-known paths). This runs even when the user
+///    provides an explicit `https://` scheme, so the mTLS client
+///    identity is picked up from well-known paths.
 /// 3. If no CA can be loaded, fall back to plain HTTP.
 ///
 /// Returns `(base_url, client)` where `base_url` always includes the
@@ -318,12 +379,14 @@ pub(crate) fn build_client(args: &Args) -> (String, reqwest::Client) {
         use_tls = use_tls || ok;
     }
 
-    // 2. Auto-detect (only when no explicit scheme or CLI certs).
-    if explicit_scheme.is_none() && !use_tls {
+    // 2. Auto-detect (when no CLI certs were provided).
+    // This runs even with an explicit https:// scheme, so the client
+    // picks up the mTLS identity from Meta well-known paths.
+    if args.tls_ca.is_none() {
         if let Some(bundle) = hyperactor::channel::try_tls_pem_bundle() {
             let (b, ok) = add_tls_from_bundle(builder, &bundle);
             builder = b;
-            use_tls = ok;
+            use_tls = use_tls || ok;
         }
     }
 

--- a/hyperactor_mesh/examples/dining_philosophers.rs
+++ b/hyperactor_mesh/examples/dining_philosophers.rs
@@ -264,23 +264,25 @@ async fn main() -> Result<ExitCode> {
     // Start the mesh admin agent, which aggregates admin state
     // across all hosts and serves an HTTP API.
     let mesh_admin_url = host_mesh.spawn_admin(instance, None).await?;
-    let cacert = if mesh_admin_url.starts_with("https") {
-        "--cacert /var/facebook/rootcanal/ca.pem "
+    let mtls_flags = if mesh_admin_url.starts_with("https") {
+        "--cacert /var/facebook/rootcanal/ca.pem \
+         --cert /var/facebook/x509_identities/server.pem \
+         --key /var/facebook/x509_identities/server.pem "
     } else {
         ""
     };
     println!("Mesh admin server listening on {}", mesh_admin_url);
     println!(
         "  - Root node:     curl {}{}/v1/root",
-        cacert, mesh_admin_url
+        mtls_flags, mesh_admin_url
     );
     println!(
         "  - Mesh tree:     curl {}{}/v1/tree",
-        cacert, mesh_admin_url
+        mtls_flags, mesh_admin_url
     );
     println!(
         "  - API docs:      curl {}{}/SKILL.md",
-        cacert, mesh_admin_url
+        mtls_flags, mesh_admin_url
     );
     println!(
         "  - TUI:           buck2 run fbcode//monarch/hyperactor_mesh:hyperactor_mesh_admin_tui -- --addr {}\n                   cargo run -p hyperactor_mesh --bin hyperactor_mesh_admin_tui -- --addr {}",

--- a/hyperactor_mesh/examples/sieve.rs
+++ b/hyperactor_mesh/examples/sieve.rs
@@ -142,23 +142,25 @@ async fn main() -> Result<ExitCode> {
 
     // Start the mesh admin agent.
     let mesh_admin_url = this_host().await.spawn_admin(instance, None).await?;
-    let cacert = if mesh_admin_url.starts_with("https") {
-        "--cacert /var/facebook/rootcanal/ca.pem "
+    let mtls_flags = if mesh_admin_url.starts_with("https") {
+        "--cacert /var/facebook/rootcanal/ca.pem \
+         --cert /var/facebook/x509_identities/server.pem \
+         --key /var/facebook/x509_identities/server.pem "
     } else {
         ""
     };
     println!("Mesh admin server listening on {}", mesh_admin_url);
     println!(
         "  - Root node:     curl {}{}/v1/root",
-        cacert, mesh_admin_url
+        mtls_flags, mesh_admin_url
     );
     println!(
         "  - Mesh tree:     curl {}{}/v1/tree",
-        cacert, mesh_admin_url
+        mtls_flags, mesh_admin_url
     );
     println!(
         "  - API docs:      curl {}{}/SKILL.md",
-        cacert, mesh_admin_url
+        mtls_flags, mesh_admin_url
     );
     println!(
         "  - TUI:           buck2 run fbcode//monarch/hyperactor_mesh:hyperactor_mesh_admin_tui -- --addr {}\n                   cargo run -p hyperactor_mesh --bin hyperactor_mesh_admin_tui -- --addr {}",

--- a/hyperactor_mesh/src/mesh_admin.rs
+++ b/hyperactor_mesh/src/mesh_admin.rs
@@ -94,10 +94,18 @@
 //!
 //! ## TLS transport invariant
 //!
-//! The admin HTTP server auto-detects TLS certificates at startup via
-//! [`try_tls_acceptor`](hyperactor::channel::try_tls_acceptor): OSS
-//! config attrs → Meta well-known paths → plain HTTP fallback. When
-//! certs are found, the server serves HTTPS; otherwise HTTP.
+//! **At Meta (`fbcode_build`):** The admin HTTP server **requires**
+//! mutual TLS. At startup it probes for certificates via
+//! [`try_tls_acceptor`](hyperactor::channel::try_tls_acceptor) with
+//! client cert enforcement enabled. If no usable certificate bundle
+//! is found, `init()` returns an error — there is no plain HTTP
+//! fallback. Clients must present a valid certificate signed by
+//! Meta's root CA; connections without a client cert are rejected
+//! during the TLS handshake.
+//!
+//! **In OSS:** TLS is best-effort. The server probes for certificates
+//! but falls back to plain HTTP if none are found. Client certificates
+//! are not required.
 //!
 //! **`admin_host` includes the scheme**: the URL returned by
 //! `GetAdminAddr` is always `https://host:port` or
@@ -569,13 +577,15 @@ impl Actor for MeshAdminAgent {
     ///    call `bind()` — unlike `gspawn` — so the actor must do it
     ///    itself before becoming reachable).
     /// 2. Binds a TCP listener (ephemeral or fixed port).
-    /// 3. Probes for TLS certificates (explicit env vars, then Meta
-    ///    default paths, then falls back to plain HTTP).
+    /// 3. Builds a TLS acceptor (explicit env vars, then Meta default
+    ///    paths). At Meta (`fbcode_build`), mTLS is mandatory and
+    ///    init fails if no certs are found. In OSS, falls back to
+    ///    plain HTTP.
     /// 4. Creates a dedicated `Instance<()>` client mailbox on
     ///    system_proc for the HTTP bridge's reply ports, keeping
     ///    bridge traffic off the actor's own mailbox.
-    /// 5. Spawns the axum server in a background task (HTTPS or HTTP
-    ///    depending on step 3).
+    /// 5. Spawns the axum server in a background task (HTTPS with
+    ///    mTLS at Meta, HTTPS or HTTP in OSS depending on step 3).
     ///
     /// The hostname-based listen address is stored in `admin_host` so
     /// it can be returned via `GetAdminAddr`. The scheme (`https://`
@@ -606,15 +616,25 @@ impl Actor for MeshAdminAgent {
             .unwrap_or_else(|_| "localhost".to_string());
         self.admin_addr = Some(bound_addr);
 
-        // Probe for TLS certificates (OSS config, then Meta paths,
-        // then plain HTTP fallback). See `try_tls_acceptor` docs.
-        let tls_acceptor = try_tls_acceptor();
+        // At Meta: mTLS is mandatory — fail if no certs are found.
+        // In OSS: TLS is best-effort with plain HTTP fallback.
+        // See "TLS transport invariant" in module docs.
+        let enforce_mtls = cfg!(fbcode_build);
+        let tls_acceptor = try_tls_acceptor(enforce_mtls);
+
+        if enforce_mtls && tls_acceptor.is_none() {
+            return Err(anyhow::anyhow!(
+                "mesh admin requires mTLS but no TLS certificates found; \
+                 set HYPERACTOR_TLS_CERT/KEY/CA or ensure Meta cert paths exist \
+                 (/var/facebook/x509_identities/server.pem, /var/facebook/rootcanal/ca.pem)"
+            ));
+        }
+
         let scheme = if tls_acceptor.is_some() {
             "https"
         } else {
             "http"
         };
-
         self.admin_host = Some(format!("{}://{}:{}", scheme, host, bound_addr.port()));
 
         // Create a dedicated client mailbox on system_proc for the
@@ -638,10 +658,11 @@ impl Actor for MeshAdminAgent {
             };
             tokio::spawn(async move {
                 if let Err(e) = axum::serve(tls_listener, router).await {
-                    tracing::error!("mesh admin server (TLS) error: {}", e);
+                    tracing::error!("mesh admin server (mTLS) error: {}", e);
                 }
             });
         } else {
+            // OSS fallback: plain HTTP (only reachable when !fbcode_build).
             tokio::spawn(async move {
                 if let Err(e) = axum::serve(listener, router).await {
                     tracing::error!("mesh admin server error: {}", e);
@@ -1331,14 +1352,14 @@ const TREE_TIMEOUT: Duration = Duration::from_secs(10);
 ///
 /// Output format:
 /// ```text
-/// unix:@hash  ->  http://127.0.0.1:port/v1/...
-/// ├── service  ->  http://127.0.0.1:port/v1/...
-/// │   ├── agent[0]  ->  http://127.0.0.1:port/v1/...
-/// │   └── client[0]  ->  http://127.0.0.1:port/v1/...
-/// ├── local  ->  http://127.0.0.1:port/v1/...
-/// └── philosophers_0  ->  http://127.0.0.1:port/v1/...
-///     ├── agent[0]  ->  http://127.0.0.1:port/v1/...
-///     └── philosopher[0]  ->  http://127.0.0.1:port/v1/...
+/// unix:@hash  ->  https://host:port/v1/...  (or http:// in OSS)
+/// ├── service  ->  https://host:port/v1/...
+/// │   ├── agent[0]  ->  https://host:port/v1/...
+/// │   └── client[0]  ->  https://host:port/v1/...
+/// ├── local  ->  https://host:port/v1/...
+/// └── philosophers_0  ->  https://host:port/v1/...
+///     ├── agent[0]  ->  https://host:port/v1/...
+///     └── philosopher[0]  ->  https://host:port/v1/...
 /// ```
 async fn tree_dump(
     State(state): State<Arc<BridgeState>>,

--- a/hyperactor_mesh/src/mesh_admin_skill.md
+++ b/hyperactor_mesh/src/mesh_admin_skill.md
@@ -49,10 +49,10 @@ Each child reference can be resolved via `/v1/{reference}`.
 ## Navigation algorithm
 
 1. Fetch root:
-   `curl '{base}/v1/root'`
+   `curl --cacert /var/facebook/rootcanal/ca.pem --cert /var/facebook/x509_identities/server.pem --key /var/facebook/x509_identities/server.pem '{base}/v1/root'`
 
 2. Select a child reference:
-   `curl '{base}/v1/{child_reference}'`
+   `curl --cacert /var/facebook/rootcanal/ca.pem --cert /var/facebook/x509_identities/server.pem --key /var/facebook/x509_identities/server.pem '{base}/v1/{child_reference}'`
 
 3. Repeat. Each node describes its next traversal step.
 
@@ -75,15 +75,21 @@ Common examples include:
 
 ## Examples
 
+In Meta environments, the admin server requires mutual TLS. All `curl`
+commands need:
+```
+--cacert /var/facebook/rootcanal/ca.pem --cert /var/facebook/x509_identities/server.pem --key /var/facebook/x509_identities/server.pem
+```
+
 List root children:
 
-`curl '{base}/v1/root' | jq -r '.children[]'`
+`curl --cacert /var/facebook/rootcanal/ca.pem --cert /var/facebook/x509_identities/server.pem --key /var/facebook/x509_identities/server.pem '{base}/v1/root' | jq -r '.children[]'`
 
 Resolve a child (URL-encoded):
 
-`curl '{base}/v1/'$(python3 -c "import urllib.parse,sys; print(urllib.parse.quote(sys.argv[1], safe=''))" '{example_ref}')`
+`curl --cacert /var/facebook/rootcanal/ca.pem --cert /var/facebook/x509_identities/server.pem --key /var/facebook/x509_identities/server.pem '{base}/v1/'$(python3 -c "import urllib.parse,sys; print(urllib.parse.quote(sys.argv[1], safe=''))" '{example_ref}')`
 
 Actor nodes include a `flight_recorder` field with recent trace events.
 To focus on structure and stats, filter it out:
 
-`curl '{base}/v1/{reference}' | jq '{identity, properties, children}'`
+`curl --cacert /var/facebook/rootcanal/ca.pem --cert /var/facebook/x509_identities/server.pem --key /var/facebook/x509_identities/server.pem '{base}/v1/{reference}' | jq '{identity, properties, children}'`

--- a/hyperactor_mesh/test/mesh_admin_tree_test.sh
+++ b/hyperactor_mesh/test/mesh_admin_tree_test.sh
@@ -7,13 +7,39 @@
 
 # Integration test for the mesh admin tree endpoint.
 #
-# Spins up the dining philosophers example, waits for the admin server
-# to start, then verifies that GET /v1/tree and GET /v1/root return
-# the expected structure.
+# Generates a self-signed CA + cert + key, launches the dining
+# philosophers example with those certs (via HYPERACTOR_TLS_* env
+# vars), then verifies /v1/tree and /v1/root via mTLS curl, and
+# confirms that connections without a client cert are rejected.
 
 set -euo pipefail
 
 BIN="$1"
+
+# --- Generate test PKI (self-signed CA + server/client cert) ---
+CERTDIR=$(mktemp -d)
+
+# CA key + cert
+openssl req -x509 -newkey ec -pkeyopt ec_paramgen_curve:prime256v1 \
+    -keyout "$CERTDIR/ca.key" -out "$CERTDIR/ca.crt" \
+    -days 1 -nodes -subj "/CN=test-ca" 2>/dev/null
+
+# Server/client key + CSR + cert (signed by CA)
+openssl req -newkey ec -pkeyopt ec_paramgen_curve:prime256v1 \
+    -keyout "$CERTDIR/server.key" -out "$CERTDIR/server.csr" \
+    -nodes -subj "/CN=localhost" 2>/dev/null
+openssl x509 -req -in "$CERTDIR/server.csr" \
+    -CA "$CERTDIR/ca.crt" -CAkey "$CERTDIR/ca.key" -CAcreateserial \
+    -out "$CERTDIR/server.crt" -days 1 2>/dev/null
+
+# Combined PEM (cert + key) — matches Meta's server.pem format.
+cat "$CERTDIR/server.crt" "$CERTDIR/ca.crt" "$CERTDIR/server.key" \
+    > "$CERTDIR/combined.pem"
+
+# Point hyperactor at our test certs.
+export HYPERACTOR_TLS_CERT="$CERTDIR/combined.pem"
+export HYPERACTOR_TLS_KEY="$CERTDIR/combined.pem"
+export HYPERACTOR_TLS_CA="$CERTDIR/ca.crt"
 
 # Launch dining philosophers in background; capture output.
 OUTFILE=$(mktemp)
@@ -24,6 +50,7 @@ cleanup() {
     kill "$BIN_PID" 2>/dev/null || true
     wait "$BIN_PID" 2>/dev/null || true
     rm -f "$OUTFILE"
+    rm -rf "$CERTDIR"
 }
 trap cleanup EXIT
 
@@ -46,11 +73,13 @@ fi
 
 echo "Admin server at: $ADMIN_ADDR"
 
-# For HTTPS, skip certificate verification — the server's x509 identity
-# may not match the hostname in CI environments (Sandcastle).
+# Build curl flags. For HTTPS (mTLS), supply client cert and skip
+# hostname verification (test cert CN=localhost may not match the
+# advertised hostname).
 CURL_FLAGS=(-sf)
 if [[ "$ADMIN_ADDR" == https://* ]]; then
-    CURL_FLAGS+=(--insecure)
+    CURL_FLAGS+=(--insecure --cacert "$CERTDIR/ca.crt" \
+                 --cert "$CERTDIR/combined.pem" --key "$CERTDIR/combined.pem")
 fi
 
 # --- Test /v1/root ---
@@ -105,5 +134,15 @@ echo "  tree: OK"
 echo ""
 echo "--- tree output ---"
 echo "$TREE_RESP"
+
+# --- Test mTLS rejection (no client cert) ---
+if [[ "$ADMIN_ADDR" == https://* ]]; then
+    echo "Testing mTLS rejection (no client cert)..."
+    if curl -sf --insecure "$ADMIN_ADDR/v1/root" 2>/dev/null; then
+        echo "FAIL: connection without client cert should be rejected"
+        exit 1
+    fi
+    echo "  mTLS rejection: OK"
+fi
 
 echo "PASS: All mesh admin integration checks passed"

--- a/python/examples/dining_philosophers.py
+++ b/python/examples/dining_philosophers.py
@@ -145,15 +145,17 @@ async def async_main() -> None:
 
     # Spawn the admin agent so the TUI can attach.
     admin_url = await host._spawn_admin()
-    cacert = (
+    mtls_flags = (
         "--cacert /var/facebook/rootcanal/ca.pem "
+        "--cert /var/facebook/x509_identities/server.pem "
+        "--key /var/facebook/x509_identities/server.pem "
         if admin_url.startswith("https")
         else ""
     )
     print(f"\nMesh admin server listening on {admin_url}")
-    print(f"  - Root node:     curl {cacert}{admin_url}/v1/root")
-    print(f"  - Mesh tree:     curl {cacert}{admin_url}/v1/tree")
-    print(f"  - API docs:      curl {cacert}{admin_url}/SKILL.md")
+    print(f"  - Root node:     curl {mtls_flags}{admin_url}/v1/root")
+    print(f"  - Mesh tree:     curl {mtls_flags}{admin_url}/v1/tree")
+    print(f"  - API docs:      curl {mtls_flags}{admin_url}/SKILL.md")
     print(
         f"  - TUI:           buck2 run fbcode//monarch/hyperactor_mesh:hyperactor_mesh_admin_tui -- --addr {admin_url}"
     )

--- a/python/examples/poisoned_mesh.py
+++ b/python/examples/poisoned_mesh.py
@@ -85,15 +85,17 @@ async def async_main(num_procs: int) -> None:
     host = this_host()
 
     admin_url = await host._spawn_admin()
-    cacert = (
+    mtls_flags = (
         "--cacert /var/facebook/rootcanal/ca.pem "
+        "--cert /var/facebook/x509_identities/server.pem "
+        "--key /var/facebook/x509_identities/server.pem "
         if admin_url.startswith("https")
         else ""
     )
     print(f"\nMesh admin server listening on {admin_url}")
-    print(f"  - Root node:     curl {cacert}{admin_url}/v1/root")
-    print(f"  - Mesh tree:     curl {cacert}{admin_url}/v1/tree")
-    print(f"  - API docs:      curl {cacert}{admin_url}/SKILL.md")
+    print(f"  - Root node:     curl {mtls_flags}{admin_url}/v1/root")
+    print(f"  - Mesh tree:     curl {mtls_flags}{admin_url}/v1/tree")
+    print(f"  - API docs:      curl {mtls_flags}{admin_url}/SKILL.md")
     print(
         f"  - TUI:           buck2 run fbcode//monarch/hyperactor_mesh:hyperactor_mesh_admin_tui -- --addr {admin_url}"
     )

--- a/python/examples/sleep_actors.py
+++ b/python/examples/sleep_actors.py
@@ -60,15 +60,17 @@ async def async_main(num_procs: int) -> None:
 
     # Spawn the admin agent so the TUI can attach.
     admin_url = await host._spawn_admin()
-    cacert = (
+    mtls_flags = (
         "--cacert /var/facebook/rootcanal/ca.pem "
+        "--cert /var/facebook/x509_identities/server.pem "
+        "--key /var/facebook/x509_identities/server.pem "
         if admin_url.startswith("https")
         else ""
     )
     print(f"\nMesh admin server listening on {admin_url}")
-    print(f"  - Root node:     curl {cacert}{admin_url}/v1/root")
-    print(f"  - Mesh tree:     curl {cacert}{admin_url}/v1/tree")
-    print(f"  - API docs:      curl {cacert}{admin_url}/SKILL.md")
+    print(f"  - Root node:     curl {mtls_flags}{admin_url}/v1/root")
+    print(f"  - Mesh tree:     curl {mtls_flags}{admin_url}/v1/tree")
+    print(f"  - API docs:      curl {mtls_flags}{admin_url}/SKILL.md")
     print(
         f"  - TUI:           buck2 run fbcode//monarch/hyperactor_mesh:hyperactor_mesh_admin_tui -- --addr {admin_url}"
     )

--- a/python/examples/stop_mesh.py
+++ b/python/examples/stop_mesh.py
@@ -46,15 +46,17 @@ async def async_main(num_procs: int) -> None:
     host = this_host()
 
     admin_url = await host._spawn_admin()
-    cacert = (
+    mtls_flags = (
         "--cacert /var/facebook/rootcanal/ca.pem "
+        "--cert /var/facebook/x509_identities/server.pem "
+        "--key /var/facebook/x509_identities/server.pem "
         if admin_url.startswith("https")
         else ""
     )
     print(f"\nMesh admin server listening on {admin_url}")
-    print(f"  - Root node:     curl {cacert}{admin_url}/v1/root")
-    print(f"  - Mesh tree:     curl {cacert}{admin_url}/v1/tree")
-    print(f"  - API docs:      curl {cacert}{admin_url}/SKILL.md")
+    print(f"  - Root node:     curl {mtls_flags}{admin_url}/v1/root")
+    print(f"  - Mesh tree:     curl {mtls_flags}{admin_url}/v1/tree")
+    print(f"  - API docs:      curl {mtls_flags}{admin_url}/SKILL.md")
     print(
         f"  - TUI:           buck2 run fbcode//monarch/hyperactor_mesh:hyperactor_mesh_admin_tui -- --addr {admin_url}"
     )

--- a/python/tests/test_failure_introspection.py
+++ b/python/tests/test_failure_introspection.py
@@ -16,6 +16,7 @@ Verifies that when an actor fails, the introspection API exposes:
 
 import asyncio
 import json
+import os
 import ssl
 import urllib.parse
 import urllib.request
@@ -64,6 +65,10 @@ def _fetch_json(url: str) -> dict:
     if url.startswith("https"):
         ctx.check_hostname = False
         ctx.verify_mode = ssl.CERT_NONE
+        # mTLS: the admin server requires a client cert in fbcode builds.
+        cert = "/var/facebook/x509_identities/server.pem"
+        if os.path.exists(cert):
+            ctx.load_cert_chain(cert, cert)
     # Bypass proxy to avoid env-variable proxy handlers adding latency
     # or flaking under stress.
     opener = urllib.request.build_opener(


### PR DESCRIPTION
Summary:
this diff makes mesh admin mutual-TLS-only in fbcode_build, while preserving the existing best-effort TLS / plain-HTTP fallback in OSS.

it threads client-cert enforcement into try_tls_acceptor, fails admin startup if no usable cert bundle is available at Meta, updates the admin TUI client to reliably load a client identity in the native-tls Buck build, and updates examples, skill docs, and the integration test to use and verify the required mTLS flags.

Differential Revision: D95843188


