### PR TITLE
Add messages telemetry table

### DIFF
--- a/examples/distributed_telemetry.py
+++ b/examples/distributed_telemetry.py
@@ -315,7 +315,8 @@ QUERIES = [
            FROM sent_messages sm
            LEFT JOIN meshes m ON sm.actor_mesh_id = m.id
            LEFT JOIN actors a ON sm.sender_actor_id = a.id
-           WHERE m.given_name = 'compute'""",
+           WHERE m.given_name = 'compute'
+           ORDER BY sm.timestamp_us DESC""",
     ),
     (
         "Sample sent messages",
@@ -325,6 +326,29 @@ QUERIES = [
            JOIN actors a ON sm.sender_actor_id = a.id
            ORDER BY sm.timestamp_us DESC
            LIMIT 10""",
+    ),
+    (
+        "Received Messages",
+        """SELECT m.id, m.timestamp_us, m.port_id,
+                  sender.full_name AS from_actor, receiver.full_name AS to_actor,
+           FROM messages m
+           LEFT JOIN actors sender ON m.from_actor_id = sender.id
+           LEFT JOIN actors receiver ON m.to_actor_id = receiver.id
+           ORDER BY m.timestamp_us
+           LIMIT 10""",
+    ),
+    (
+        "Messages received by 'compuate' actor mesh sent from 'sender' actor mesh",
+        """SELECT m.id, m.timestamp_us,
+                  sender.display_name AS from_actor, receiver.display_name AS to_actor,
+                  m.port_id
+           FROM messages m
+           JOIN actors sender ON m.from_actor_id = sender.id
+           JOIN actors receiver ON m.to_actor_id = receiver.id
+           JOIN meshes sm ON sender.mesh_id = sm.id
+           JOIN meshes rm ON receiver.mesh_id = rm.id
+           WHERE sm.given_name = 'sender' AND rm.given_name = 'compute'
+           ORDER BY m.timestamp_us DESC""",
     ),
 ]
 

--- a/hyperactor/src/mailbox.rs
+++ b/hyperactor/src/mailbox.rs
@@ -93,6 +93,7 @@ use dashmap::mapref::entry::Entry;
 use futures::Sink;
 use futures::Stream;
 use hyperactor_config::Flattrs;
+use hyperactor_telemetry::hash_to_u64;
 use serde::Deserialize;
 use serde::Serialize;
 use serde::de::DeserializeOwned;
@@ -1646,13 +1647,26 @@ impl MailboxSender for Mailbox {
 
                 let (metadata, data) = envelope.open();
                 let MessageMetadata {
-                    headers,
+                    mut headers,
                     sender,
                     dest,
                     errors: metadata_errors,
                     ttl,
                     return_undeliverable,
                 } = metadata;
+
+                let to_actor_id = hash_to_u64(&dest);
+                let message_id = hyperactor_telemetry::generate_message_id(to_actor_id);
+                headers.set(crate::mailbox::headers::TELEMETRY_MESSAGE_ID, message_id);
+                // Only set sender hash if not already present (cast path
+                // pre-sets it with the originating actor).
+                if !headers.contains_key(crate::mailbox::headers::SENDER_ACTOR_ID_HASH) {
+                    headers.set(
+                        crate::mailbox::headers::SENDER_ACTOR_ID_HASH,
+                        hash_to_u64(&sender),
+                    );
+                }
+                headers.set(crate::mailbox::headers::TELEMETRY_PORT_ID, dest.index());
 
                 // We use the entry API here so that we can remove the
                 // entry while holding an (entry) reference. The DashMap

--- a/hyperactor/src/mailbox/headers.rs
+++ b/hyperactor/src/mailbox/headers.rs
@@ -26,6 +26,15 @@ declare_attrs! {
 
     /// The rust type of the message.
     pub attr RUST_MESSAGE_TYPE: String;
+
+    /// Hashed ActorId of the message sender, injected in post_unchecked().
+    pub attr SENDER_ACTOR_ID_HASH: u64;
+
+    /// Telemetry message ID for correlating lifecycle events, injected in post_unchecked().
+    pub attr TELEMETRY_MESSAGE_ID: u64;
+
+    /// Port index the message was delivered to, injected in post_unchecked().
+    pub attr TELEMETRY_PORT_ID: u64;
 }
 
 /// Set the send timestamp for latency tracking if timestamp not already set.

--- a/hyperactor/src/proc.rs
+++ b/hyperactor/src/proc.rs
@@ -43,6 +43,7 @@ use hyperactor_telemetry::ActorStatusEvent;
 use hyperactor_telemetry::generate_actor_status_event_id;
 use hyperactor_telemetry::hash_to_u64;
 use hyperactor_telemetry::notify_actor_status_changed;
+use hyperactor_telemetry::notify_message;
 use hyperactor_telemetry::recorder::Recording;
 use tokio::sync::mpsc;
 use tokio::sync::watch;
@@ -1773,15 +1774,31 @@ impl<A: Actor> Instance<A> {
     where
         A: Handler<M>,
     {
+        let now = std::time::SystemTime::now();
         let handler_info = Some(handler_info);
-        self.change_status(ActorStatus::Processing(
-            std::time::SystemTime::now(),
-            handler_info.clone(),
-        ));
+        self.change_status(ActorStatus::Processing(now, handler_info.clone()));
         crate::mailbox::headers::log_message_latency_if_sampling(
             &headers,
             self.self_id().to_string(),
         );
+
+        if let Some(message_id) = headers.get(crate::mailbox::headers::TELEMETRY_MESSAGE_ID) {
+            let from_actor_id = headers
+                .get(crate::mailbox::headers::SENDER_ACTOR_ID_HASH)
+                .unwrap_or(0);
+            let to_actor_id = hash_to_u64(self.self_id());
+            let port_id = headers.get(crate::mailbox::headers::TELEMETRY_PORT_ID);
+
+            notify_message(hyperactor_telemetry::MessageEvent {
+                timestamp: now,
+                id: message_id,
+                from_actor_id,
+                to_actor_id,
+                // TODO: populate endpoint
+                endpoint: None,
+                port_id,
+            });
+        }
 
         // Record the message handler being invoked.
         *self.inner.cell.inner.last_message_handler.write().unwrap() = handler_info;

--- a/hyperactor_mesh/src/actor_mesh.rs
+++ b/hyperactor_mesh/src/actor_mesh.rs
@@ -478,11 +478,11 @@ impl<A: Referable> ActorMeshRef<A> {
             for (point, actor) in self.iter() {
                 let create_rank = point.rank();
                 let mut headers = Flattrs::new();
-                headers.set(
-                    multicast::CAST_ORIGINATING_SENDER,
+                multicast::set_cast_info_on_headers(
+                    &mut headers,
+                    point,
                     cx.instance().self_id().clone(),
                 );
-                headers.set(multicast::CAST_POINT, point);
 
                 // Make sure that we re-bind ranks, as these may be used for
                 // bootstrapping comm actors.

--- a/hyperactor_mesh/src/comm/multicast.rs
+++ b/hyperactor_mesh/src/comm/multicast.rs
@@ -370,6 +370,14 @@ pub fn set_cast_info_on_headers(
     cast_point: Point,
     sender: hyperactor_reference::ActorId,
 ) {
+    // Pre-set the telemetry sender hash to the originating actor,
+    // so post_unchecked() does not overwrite it with the comm actor.
+    // TODO: consider merging SENDER_ACTOR_ID_HASH and
+    // CAST_ORIGINATING_SENDER -- they carry overlapping sender identity.
+    headers.set(
+        hyperactor::mailbox::headers::SENDER_ACTOR_ID_HASH,
+        hyperactor_telemetry::hash_to_u64(&sender),
+    );
     headers.set(CAST_POINT, cast_point);
     headers.set(CAST_ORIGINATING_SENDER, sender);
 }

--- a/hyperactor_telemetry/src/lib.rs
+++ b/hyperactor_telemetry/src/lib.rs
@@ -412,6 +412,27 @@ pub fn notify_sent_message(event: SentMessageEvent) {
     dispatch_or_buffer(EntityEvent::SentMessage(event));
 }
 
+/// Event fired when a message is received (from receiver's perspective).
+#[derive(Debug, Clone)]
+pub struct MessageEvent {
+    pub timestamp: SystemTime,
+    /// Unique identifier for this received message.
+    pub id: u64,
+    /// Hash of sender's ActorId.
+    pub from_actor_id: u64,
+    /// Hash of receiver's ActorId.
+    pub to_actor_id: u64,
+    /// Endpoint name if this message targets a specific actor endpoint
+    pub endpoint: Option<String>,
+    /// Destination port ID
+    pub port_id: Option<u64>,
+}
+
+/// Notify the registered dispatcher that a message was received.
+pub fn notify_message(event: MessageEvent) {
+    dispatch_or_buffer(EntityEvent::Message(event));
+}
+
 static ACTOR_STATUS_SEQ: AtomicU64 = AtomicU64::new(1);
 
 /// Generate a globally unique ActorStatusEvent ID.
@@ -431,6 +452,17 @@ pub fn generate_sent_message_id(sender_actor_id: u64) -> u64 {
     hash_to_u64(&(sender_actor_id, seq))
 }
 
+static RECV_MSG_SEQ: AtomicU64 = AtomicU64::new(1);
+
+/// Generate a unique received-message ID (cross-process unique).
+///
+/// Hashes (to_actor_id, seq) following the same pattern as
+/// `generate_sent_message_id`.
+pub fn generate_message_id(to_actor_id: u64) -> u64 {
+    let seq = RECV_MSG_SEQ.fetch_add(1, Ordering::Relaxed);
+    hash_to_u64(&(to_actor_id, seq))
+}
+
 /// Unified event enum for all entity lifecycle events.
 ///
 /// This enum wraps all entity events (actors, meshes, and future event types)
@@ -446,6 +478,8 @@ pub enum EntityEvent {
     ActorStatus(ActorStatusEvent),
     /// A message was sent.
     SentMessage(SentMessageEvent),
+    /// A message was received.
+    Message(MessageEvent),
 }
 
 /// Trait for dispatchers that receive unified entity events.
@@ -470,6 +504,7 @@ pub enum EntityEvent {
 ///             EntityEvent::Mesh(mesh) => println!("Mesh: {}", mesh.full_name),
 ///             EntityEvent::ActorStatus(status) => println!("Status: {}", status.new_status),
 ///             EntityEvent::SentMessage(msg) => println!("Sent: {}", msg.id),
+///             EntityEvent::Message(msg) => println!("Recv: {}", msg.id),
 ///         }
 ///         Ok(())
 ///     }

--- a/monarch_distributed_telemetry/src/entity_dispatcher.rs
+++ b/monarch_distributed_telemetry/src/entity_dispatcher.rs
@@ -13,6 +13,7 @@
 //! - `meshes`: Mesh creation events
 //! - `actor_status_events`: Actor status change events
 //! - `sent_messages`: Sent message events
+//! - `messages`: Received message events
 
 use std::sync::Arc;
 use std::sync::Mutex;
@@ -101,12 +102,32 @@ pub struct SentMessage {
     pub shape_json: String,
 }
 
+/// Row data for the messages table.
+///
+/// Tracks messages from the receiver's perspective.
+#[derive(RecordBatchRow)]
+pub struct Message {
+    /// Unique identifier for this received message
+    pub id: u64,
+    /// Timestamp in microseconds since Unix epoch
+    pub timestamp_us: i64,
+    /// Hash of sender's ActorId
+    pub from_actor_id: u64,
+    /// Hash of receiver's ActorId
+    pub to_actor_id: u64,
+    /// Message handler type name
+    pub endpoint: Option<String>,
+    /// Port identifier (reserved)
+    pub port_id: Option<u64>,
+}
+
 /// Inner state of EntityDispatcher.
 struct EntityDispatcherInner {
     actors_buffer: ActorBuffer,
     meshes_buffer: MeshBuffer,
     actor_status_events_buffer: ActorStatusEventBuffer,
     sent_messages_buffer: SentMessageBuffer,
+    messages_buffer: MessageBuffer,
     batch_size: usize,
     flush_callback: FlushCallback,
 }
@@ -135,6 +156,7 @@ impl EntityDispatcherInner {
             "sent_messages",
             &self.flush_callback,
         )?;
+        Self::flush_buffer(&mut self.messages_buffer, "messages", &self.flush_callback)?;
         Ok(())
     }
 
@@ -173,6 +195,13 @@ impl EntityDispatcherInner {
         }
         Ok(())
     }
+
+    fn flush_messages_if_full(&mut self) -> anyhow::Result<()> {
+        if self.messages_buffer.len() >= self.batch_size {
+            Self::flush_buffer(&mut self.messages_buffer, "messages", &self.flush_callback)?;
+        }
+        Ok(())
+    }
 }
 
 /// Dispatches entity lifecycle events to Arrow RecordBatches.
@@ -200,6 +229,7 @@ impl EntityDispatcher {
             meshes_buffer: MeshBuffer::default(),
             actor_status_events_buffer: ActorStatusEventBuffer::default(),
             sent_messages_buffer: SentMessageBuffer::default(),
+            messages_buffer: MessageBuffer::default(),
             batch_size,
             flush_callback,
         }));
@@ -283,6 +313,21 @@ impl EntityEventDispatcher for EntityDispatcher {
                     shape_json: event.shape_json,
                 });
                 inner.flush_sent_messages_if_full()?;
+            }
+            EntityEvent::Message(event) => {
+                let mut inner = self
+                    .inner
+                    .lock()
+                    .map_err(|_| anyhow::anyhow!("lock poisoned"))?;
+                inner.messages_buffer.insert(Message {
+                    id: event.id,
+                    timestamp_us: timestamp_to_micros(&event.timestamp),
+                    from_actor_id: event.from_actor_id,
+                    to_actor_id: event.to_actor_id,
+                    endpoint: event.endpoint,
+                    port_id: event.port_id,
+                });
+                inner.flush_messages_if_full()?;
             }
         }
         Ok(())

--- a/python/tests/test_distributed_telemetry.py
+++ b/python/tests/test_distributed_telemetry.py
@@ -702,6 +702,59 @@ def test_sent_messages_table(cleanup_callbacks) -> None:
 
 
 @pytest.mark.timeout(120)
+def test_messages_table(cleanup_callbacks) -> None:
+    """Test that the messages table is populated when messages are received."""
+    engine = start_telemetry(batch_size=10)
+
+    job = ProcessJob({"hosts": 1})
+    hosts = job.state(cached_path=None).hosts
+    worker_procs = hosts.spawn_procs(per_host={"workers": 2}, name="msg_workers_procs")
+    workers = worker_procs.spawn("msg_test_worker", WorkerActor)
+    workers.initialized.get()
+
+    # Send several messages to trigger telemetry
+    for _ in range(5):
+        workers.ping.call().get()
+
+    # Verify schema
+    result = engine.query(
+        "SELECT column_name FROM information_schema.columns "
+        "WHERE table_name = 'messages' ORDER BY ordinal_position"
+    )
+    column_names = result.to_pydict().get("column_name", [])
+    assert column_names == [
+        "id",
+        "timestamp_us",
+        "from_actor_id",
+        "to_actor_id",
+        "endpoint",
+        "port_id",
+    ], f"Unexpected columns: {column_names}"
+
+    # Verify rows exist
+    result = engine.query("SELECT * FROM messages")
+    result_dict = result.to_pydict()
+    row_count = len(result_dict.get("id", []))
+    assert row_count > 0, f"Expected messages, got {row_count}"
+
+    # Verify to_actor_id joins with actors table (receiver is a known actor)
+    joined = engine.query(
+        "SELECT m.id FROM messages m "
+        "JOIN actors a ON m.to_actor_id = a.id "
+        "JOIN meshes mesh ON a.mesh_id = mesh.id "
+        "WHERE mesh.given_name = 'msg_test_worker'"
+    )
+    joined_count = len(joined.to_pydict().get("id", []))
+    # 5 casts x 2 workers = 10 messages received by msg_test_worker actors
+    assert joined_count == 10, (
+        f"Expected 10 messages received by msg_test_worker, got {joined_count}"
+    )
+
+    # Clean up
+    hosts.shutdown().get()
+
+
+@pytest.mark.timeout(120)
 def test_sent_messages_with_sliced_mesh(cleanup_callbacks) -> None:
     """Test that sent_messages view_json/shape_json reflect sliced vs full actor mesh casts."""
     engine = start_telemetry(batch_size=10)


### PR DESCRIPTION
Summary:
Add a `messages` distributed telemetry table that tracks messages from the
receiver's perspective.

The Message row is emitted in handle_message(). Sender identity propagates via a SENDER_ACTOR_ID_HASH header injected in
post_unchecked(). A TELEMETRY_MESSAGE_ID header provides a unique per-message ID using hash(to_actor_id, seq) for cross-process uniqueness.

Reviewed By: zhangrmatthew

Differential Revision: D95817753
