### PR TITLE
Add dashboard to OSS package

### DIFF
--- a/.github/workflows/build-dist.yml
+++ b/.github/workflows/build-dist.yml
@@ -60,6 +60,17 @@ jobs:
 
         cargo install --path monarch_hyperactor
 
+        # Build dashboard frontend (if Node.js is available)
+        FRONTEND_DIR="python/monarch/monarch_dashboard/frontend"
+        if [ -d "$FRONTEND_DIR" ]; then
+          if command -v npm &> /dev/null; then
+            echo "Building dashboard frontend..."
+            (cd "$FRONTEND_DIR" && npm ci && npm run build)
+          else
+            echo "npm not found, skipping frontend build"
+          fi
+        fi
+
         # Build wheel
         if [ -n "${{ inputs.version }}" ]; then
           export MONARCH_VERSION="${{ inputs.version }}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
     "tabulate",
     "opentelemetry-api",
     "clusterscope",
+    "flask>=2.0",
 ]
 
 # PyTorch nightly build indices for different platforms
@@ -115,12 +116,16 @@ dev = [
 [project.scripts]
 monarch = "monarch.tools.cli:main"
 monarch_bootstrap = "monarch._src.actor.bootstrap_main:invoke_main"
+monarch-dashboard = "monarch.monarch_dashboard.__main__:main"
 
 [tool.setuptools]
 packages = {find = {where = ["python"]}}
 
 [tool.setuptools.package-dir]
 "" = "python"
+
+[tool.setuptools.package-data]
+"monarch.monarch_dashboard" = ["frontend/build/**/*"]
 
 [tool.pytest.ini_options]
 markers = [

--- a/python/monarch/monarch_dashboard/__init__.py
+++ b/python/monarch/monarch_dashboard/__init__.py
@@ -1,0 +1,9 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from importlib.resources import files
+
+_PKG = files("monarch.monarch_dashboard")

--- a/python/monarch/monarch_dashboard/__main__.py
+++ b/python/monarch/monarch_dashboard/__main__.py
@@ -7,52 +7,28 @@
 import argparse
 import atexit
 import os
-import shutil
 import signal
 import subprocess
 import sys
 
+from monarch.monarch_dashboard import _PKG
 from monarch.monarch_dashboard.server.app import create_app
 
 _DEFAULT_DB = os.environ.get(
     "MONARCH_DB_PATH",
-    os.path.join(
-        os.path.dirname(os.path.abspath(__file__)), "fake_data", "fake_data.db"
-    ),
+    str(_PKG / "fake_data" / "fake_data.db"),
 )
 
 
-def start_dashboard(db_path, host="0.0.0.0", port=5000, rebuild=False):
-    pkg_dir = os.path.dirname(os.path.abspath(__file__))
-    # Force rebuild if requested
-    build_dir = os.path.join(pkg_dir, "frontend", "build")
-    if rebuild and os.path.isdir(build_dir):
-        print(">> --rebuild: removing frontend/build/ ...")
-        shutil.rmtree(build_dir)
-
-    # Auto-build frontend if needed
-    build_index = os.path.join(build_dir, "index.html")
-    if not os.path.isfile(build_index):
-        frontend_dir = os.path.join(pkg_dir, "frontend")
-        if os.path.isdir(frontend_dir):
-            try:
-                print(">> Building frontend...")
-                node_modules = os.path.join(frontend_dir, "node_modules")
-                if not os.path.isdir(node_modules):
-                    subprocess.run(
-                        ["/usr/bin/npm", "install"], cwd=frontend_dir, check=True
-                    )
-                subprocess.run(
-                    ["npx", "react-scripts", "build"], cwd=frontend_dir, check=True
-                )
-                print(">> Frontend built!")
-            except (subprocess.CalledProcessError, FileNotFoundError) as e:
-                print(f">> Frontend build failed: {e}")
-                print(
-                    ">> Continuing in API-only mode (use pre-built frontend or buck2 run)"
-                )
-        else:
-            print(">> No frontend directory found (API-only mode)")
+def start_dashboard(db_path, host="0.0.0.0", port=5000):
+    build_index = _PKG / "frontend" / "build" / "index.html"
+    if build_index.is_file():
+        print(">> Serving pre-built frontend assets")
+    else:
+        print(
+            ">> WARNING: No frontend build found. Serving API-only.\n"
+            ">> To build the frontend, run: python setup.py build_frontend or run uv build --wheel --no-build-isolation"
+        )
 
     app = create_app(db_path)
     app.run(host=host, port=port)
@@ -60,11 +36,14 @@ def start_dashboard(db_path, host="0.0.0.0", port=5000, rebuild=False):
 
 def _launch_simulator(db_path, interval, failure_at, host_failure=False):
     """Launch fake_data/simulate.py as a background subprocess."""
-    pkg_dir = os.path.dirname(os.path.abspath(__file__))
-    sim_script = os.path.join(pkg_dir, "fake_data", "simulate.py")
+    sim_ref = _PKG / "fake_data" / "simulate.py"
+    sim_path = str(sim_ref)
+    if not os.path.isfile(sim_path):
+        print(f">> ERROR: simulate.py not found at {sim_path}")
+        sys.exit(1)
     cmd = [
         sys.executable,
-        sim_script,
+        sim_path,
         "--db",
         db_path,
         "--interval",
@@ -90,16 +69,14 @@ def _launch_simulator(db_path, interval, failure_at, host_failure=False):
     return proc
 
 
-if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description="Monarch Dashboard")
+def main():
+    """Entry point for the monarch-dashboard CLI command."""
+    parser = argparse.ArgumentParser(
+        description="CLI Entrypoint for the Monarch Dashboard. You should not need to use this unless bringing up the dashboard manually."
+    )
     parser.add_argument("--db", default=_DEFAULT_DB)
     parser.add_argument("--host", default="0.0.0.0")
     parser.add_argument("--port", type=int, default=5000)
-    parser.add_argument(
-        "--rebuild",
-        action="store_true",
-        help="Force frontend rebuild (rm -rf frontend/build, npm install, build)",
-    )
     parser.add_argument(
         "--simulate",
         action="store_true",
@@ -134,4 +111,8 @@ if __name__ == "__main__":
         exit(1)
 
     print(f"Starting Monarch Dashboard on http://{args.host}:{args.port}")
-    start_dashboard(args.db, args.host, args.port, rebuild=args.rebuild)
+    start_dashboard(args.db, args.host, args.port)
+
+
+if __name__ == "__main__":
+    main()

--- a/python/monarch/monarch_dashboard/fake_data/generate.py
+++ b/python/monarch/monarch_dashboard/fake_data/generate.py
@@ -48,7 +48,7 @@ import json
 import os
 import random
 import sqlite3
-from pathlib import Path
+from importlib.resources import files
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -713,7 +713,7 @@ def generate_fake_data(db_path: str | None = None) -> str:
         Absolute path to the generated database file.
     """
     if db_path is None:
-        db_path = str(Path(__file__).parent / "fake_data.db")
+        db_path = str(files("monarch.monarch_dashboard.fake_data") / "fake_data.db")
 
     rng = random.Random(SEED)
 

--- a/python/monarch/monarch_dashboard/fake_data/simulate.py
+++ b/python/monarch/monarch_dashboard/fake_data/simulate.py
@@ -25,7 +25,7 @@ import random
 import signal
 import sqlite3
 import time
-from pathlib import Path
+from importlib.resources import files
 
 from generate import _ACTOR_MESH_CLASSES, _insert_rows, ENDPOINTS, SCHEMA_SQL
 
@@ -498,7 +498,7 @@ def main() -> None:
     )
     parser.add_argument(
         "--db",
-        default=str(Path(__file__).parent / "fake_data.db"),
+        default=str(files("monarch.monarch_dashboard.fake_data") / "fake_data.db"),
         help="SQLite database path (default: fake_data/fake_data.db)",
     )
     parser.add_argument(

--- a/python/monarch/monarch_dashboard/server/app.py
+++ b/python/monarch/monarch_dashboard/server/app.py
@@ -14,6 +14,7 @@ and serves the React frontend build as static files.
 import os
 
 from flask import Flask, send_from_directory
+from monarch.monarch_dashboard import _PKG
 
 from . import db
 from .routes import api
@@ -27,8 +28,7 @@ def create_app(db_path: str | None = None) -> Flask:
             ``MONARCH_DB_PATH`` environment variable, or
             ``fake_data/fake_data.db`` relative to the package root.
     """
-    base = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-    build_dir = os.path.join(base, "frontend", "build")
+    build_dir = str(_PKG / "frontend" / "build")
 
     app = Flask(
         __name__,
@@ -40,12 +40,7 @@ def create_app(db_path: str | None = None) -> Flask:
     if db_path is None:
         db_path = os.environ.get(
             "MONARCH_DB_PATH",
-            os.path.join(
-                os.path.dirname(os.path.abspath(__file__)),
-                "..",
-                "fake_data",
-                "fake_data.db",
-            ),
+            str(_PKG / "fake_data" / "fake_data.db"),
         )
 
     db.init(db_path)
@@ -55,6 +50,8 @@ def create_app(db_path: str | None = None) -> Flask:
     @app.route("/", defaults={"path": ""})
     @app.route("/<path:path>")
     def serve_frontend(path):
+        if not os.path.isdir(build_dir):
+            return {"error": "Frontend not built. API available at /api/"}, 404
         if path and os.path.isfile(os.path.join(build_dir, path)):
             return send_from_directory(build_dir, path)
         return send_from_directory(build_dir, "index.html")

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ lark
 tabulate
 opentelemetry-api
 clusterscope
+flask>=2.0

--- a/scripts/common-setup.sh
+++ b/scripts/common-setup.sh
@@ -28,6 +28,13 @@ install_system_dependencies() {
     dnf install clang-devel libunwind libunwind-devel protobuf-compiler -y
 }
 
+# Install Node.js and npm (needed to build the dashboard frontend).
+install_node() {
+    echo "Installing Node.js..."
+    conda install -y -c conda-forge 'nodejs>=18'
+    echo "Node $(node --version), npm $(npm --version)"
+}
+
 # Install and configure Rust nightly toolchain
 setup_rust_toolchain() {
     echo "Setting up Rust toolchain..."
@@ -131,6 +138,7 @@ setup_build_environment() {
     local python_version=${1:-3.10}
     setup_conda_environment "${python_version}"
     install_system_dependencies
+    install_node
     setup_rust_toolchain
 }
 

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ from typing import Dict, List, Optional
 
 from setuptools import Command, setup
 from setuptools.command.build_ext import build_ext
+from setuptools.command.build_py import build_py
 from setuptools.extension import Extension
 from setuptools_rust import Binding, RustExtension
 
@@ -265,6 +266,56 @@ rust_extensions.append(
 )
 
 
+# BuildFrontend command
+class BuildFrontend(Command):
+    """Build the React frontend for monarch_dashboard"""
+
+    user_options = []
+
+    def initialize_options(self):
+        pass
+
+    def finalize_options(self):
+        pass
+
+    def run(self):
+        frontend_dir = os.path.join(
+            os.path.dirname(__file__),
+            "python",
+            "monarch",
+            "monarch_dashboard",
+            "frontend",
+        )
+        build_dir = os.path.join(frontend_dir, "build")
+        build_index = os.path.join(build_dir, "index.html")
+
+        # Skip npm if pre-built assets already exist (e.g. from CI).
+        if os.path.isfile(build_index):
+            print(">> Pre-built frontend found, skipping npm build")
+            return
+
+        if not os.path.exists(frontend_dir):
+            print(f"Frontend directory not found: {frontend_dir}")
+            return
+
+        # Use real npm, bypassing any system wrappers
+        npm_cmd = "/usr/bin/npm" if os.path.exists("/usr/bin/npm") else "npm"
+
+        print("Building dashboard frontend...")
+        try:
+            subprocess.check_call([npm_cmd, "install"], cwd=frontend_dir)
+            subprocess.check_call([npm_cmd, "run", "build"], cwd=frontend_dir)
+            print("Frontend build completed successfully")
+        except FileNotFoundError:
+            print("WARNING: npm not found. Skipping frontend build.")
+            print(
+                "Install Node.js to build the dashboard frontend, "
+                "or use pre-built assets."
+            )
+        except subprocess.CalledProcessError as e:
+            print("Frontend build failed with error:", e)
+
+
 # Clean command
 class Clean(Command):
     user_options = []
@@ -298,6 +349,14 @@ class Clean(Command):
         subprocess.run(["cargo", "clean"])
 
 
+class BuildPyWithFrontend(build_py):
+    """Build the frontend before collecting package data."""
+
+    def run(self):
+        self.run_command("build_frontend")
+        build_py.run(self)
+
+
 # Actual Setup
 package_name = os.environ.get("MONARCH_PACKAGE_NAME", "torchmonarch")
 package_version = os.environ.get("MONARCH_VERSION", "0.4.0.dev0")
@@ -308,7 +367,9 @@ setup(
     ext_modules=ext_modules,
     rust_extensions=rust_extensions,
     cmdclass={
+        "build_py": BuildPyWithFrontend,
         "build_ext": build_ext,
         "clean": Clean,
+        "build_frontend": BuildFrontend,
     },
 )

--- a/uv.lock
+++ b/uv.lock
@@ -51,6 +51,15 @@ wheels = [
 ]
 
 [[package]]
+name = "blinker"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/21/28/9b3f50ce0e048515135495f198351908d99540d69bfdc8c1d15b73dc55ce/blinker-1.9.0.tar.gz", hash = "sha256:b4ce2265a7abece45e7cc896e98dbebe6cead56bcf805a3d23136d145f5445bf", size = 22460, upload-time = "2024-11-08T17:25:47.436Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/cb/f2ad4230dc2eb1a74edf38f1a38b9b52277f75bef262d8908e60d957e13c/blinker-1.9.0-py3-none-any.whl", hash = "sha256:ba0efaa9080b619ff2f3459d1d500c57bddea4a6b424b60a91141db6fd2f08bc", size = 8458, upload-time = "2024-11-08T17:25:46.184Z" },
+]
+
+[[package]]
 name = "bs4"
 version = "0.0.2"
 source = { registry = "https://pypi.org/simple" }
@@ -410,6 +419,23 @@ wheels = [
 ]
 
 [[package]]
+name = "flask"
+version = "3.1.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "blinker" },
+    { name = "click" },
+    { name = "itsdangerous" },
+    { name = "jinja2" },
+    { name = "markupsafe" },
+    { name = "werkzeug" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/26/00/35d85dcce6c57fdc871f3867d465d780f302a175ea360f62533f12b27e2b/flask-3.1.3.tar.gz", hash = "sha256:0ef0e52b8a9cd932855379197dd8f94047b359ca0a78695144304cb45f87c9eb", size = 759004, upload-time = "2026-02-19T05:00:57.678Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/9c/34f6962f9b9e9c71f6e5ed806e0d0ff03c9d1b0b2340088a0cf4bce09b18/flask-3.1.3-py3-none-any.whl", hash = "sha256:f4bcbefc124291925f1a26446da31a5178f9483862233b23c0c96a20701f670c", size = 103424, upload-time = "2026-02-19T05:00:56.027Z" },
+]
+
+[[package]]
 name = "fsspec"
 version = "2025.12.0"
 source = { registry = "https://pypi.org/simple" }
@@ -515,6 +541,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ef/4c/5dd1d8af08107f88c7f741ead7a40854b8ac24ddf9ae850afbcf698aa552/ipython_pygments_lexers-1.1.1.tar.gz", hash = "sha256:09c0138009e56b6854f9535736f4171d855c8c08a563a0dcd8022f78355c7e81", size = 8393, upload-time = "2025-01-17T11:24:34.505Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d9/33/1f075bf72b0b747cb3288d011319aaf64083cf2efef8354174e3ed4540e2/ipython_pygments_lexers-1.1.1-py3-none-any.whl", hash = "sha256:a9462224a505ade19a605f71f8fa63c2048833ce50abc86768a0d81d876dc81c", size = 8074, upload-time = "2025-01-17T11:24:33.271Z" },
+]
+
+[[package]]
+name = "itsdangerous"
+version = "2.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9c/cb/8ac0172223afbccb63986cc25049b154ecfb5e85932587206f42317be31d/itsdangerous-2.2.0.tar.gz", hash = "sha256:e0050c0b7da1eea53ffaf149c0cfbb5c6e2e2b69c4bef22c81fa6eb73e5f6173", size = 54410, upload-time = "2024-04-16T21:28:15.614Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/96/92447566d16df59b2a776c0fb82dbc4d9e07cd95062562af01e408583fc4/itsdangerous-2.2.0-py3-none-any.whl", hash = "sha256:c6242fc49e35958c8b15141343aa660db5fc54d4f13a1db01a3f5891b98700ef", size = 16234, upload-time = "2024-04-16T21:28:14.499Z" },
 ]
 
 [[package]]
@@ -1639,6 +1674,10 @@ wheels = [
     { url = "https://download.pytorch.org/whl/cpu/torch-2.10.0-1-cp311-none-macosx_11_0_arm64.whl", hash = "sha256:0826ac8e409551e12b2360ac18b4161a838cbd111933e694752f351191331d09" },
     { url = "https://download.pytorch.org/whl/cpu/torch-2.10.0-1-cp312-none-macosx_11_0_arm64.whl", hash = "sha256:7fbbf409143a4fe0812a40c0b46a436030a7e1d14fe8c5234dfbe44df47f617e" },
     { url = "https://download.pytorch.org/whl/cpu/torch-2.10.0-1-cp313-none-macosx_11_0_arm64.whl", hash = "sha256:b39cafff7229699f9d6e172cac74d85fd71b568268e439e08d9c540e54732a3e" },
+    { url = "https://download.pytorch.org/whl/cpu/torch-2.10.0-2-cp310-none-macosx_11_0_arm64.whl", hash = "sha256:7417ef370d7c3969dd509dae8d5c7daeb945af335ab76dd38358ba30a91251c1" },
+    { url = "https://download.pytorch.org/whl/cpu/torch-2.10.0-2-cp311-none-macosx_11_0_arm64.whl", hash = "sha256:90821a3194b8806d9fa9fdaa9308c1bc73df0c26808274b14129a97c99f35794" },
+    { url = "https://download.pytorch.org/whl/cpu/torch-2.10.0-2-cp312-none-macosx_11_0_arm64.whl", hash = "sha256:358bd7125cbec6e692d60618a5eec7f55a51b29e3652a849fd42af021d818023" },
+    { url = "https://download.pytorch.org/whl/cpu/torch-2.10.0-2-cp313-none-macosx_11_0_arm64.whl", hash = "sha256:470de4176007c2700735e003a830828a88d27129032a3add07291da07e2a94e8" },
     { url = "https://download.pytorch.org/whl/cpu/torch-2.10.0-cp310-none-macosx_11_0_arm64.whl", hash = "sha256:2d16abfce6c92584ceeb00c3b2665d5798424dd9ed235ea69b72e045cd53ae97" },
     { url = "https://download.pytorch.org/whl/cpu/torch-2.10.0-cp311-none-macosx_11_0_arm64.whl", hash = "sha256:4584ab167995c0479f6821e3dceaf199c8166c811d3adbba5d8eedbbfa6764fd" },
     { url = "https://download.pytorch.org/whl/cpu/torch-2.10.0-cp312-none-macosx_11_0_arm64.whl", hash = "sha256:45a1c5057629444aeb1c452c18298fa7f30f2f7aeadd4dc41f9d340980294407" },
@@ -1717,6 +1756,7 @@ source = { editable = "." }
 dependencies = [
     { name = "cloudpickle" },
     { name = "clusterscope" },
+    { name = "flask" },
     { name = "lark" },
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.4.0rc1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
@@ -1765,6 +1805,7 @@ requires-dist = [
     { name = "bs4", marker = "extra == 'examples'" },
     { name = "cloudpickle" },
     { name = "clusterscope" },
+    { name = "flask", specifier = ">=2.0" },
     { name = "ipython", marker = "extra == 'examples'" },
     { name = "kubernetes", marker = "extra == 'kubernetes'" },
     { name = "kubernetes", marker = "extra == 'test'" },
@@ -1891,6 +1932,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/2c/41/aa4bf9664e4cda14c3b39865b12251e8e7d239f4cd0e3cc1b6c2ccde25c1/websocket_client-1.9.0.tar.gz", hash = "sha256:9e813624b6eb619999a97dc7958469217c3176312b3a16a4bd1bc7e08a46ec98", size = 70576, upload-time = "2025-10-07T21:16:36.495Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/34/db/b10e48aa8fff7407e67470363eac595018441cf32d5e1001567a7aeba5d2/websocket_client-1.9.0-py3-none-any.whl", hash = "sha256:af248a825037ef591efbf6ed20cc5faa03d3b47b9e5a2230a529eeee1c1fc3ef", size = 82616, upload-time = "2025-10-07T21:16:34.951Z" },
+]
+
+[[package]]
+name = "werkzeug"
+version = "3.1.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/61/f1/ee81806690a87dab5f5653c1f146c92bc066d7f4cebc603ef88eb9e13957/werkzeug-3.1.6.tar.gz", hash = "sha256:210c6bede5a420a913956b4791a7f4d6843a43b6fcee4dfa08a65e93007d0d25", size = 864736, upload-time = "2026-02-19T15:17:18.884Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4d/ec/d58832f89ede95652fd01f4f24236af7d32b70cab2196dfcc2d2fd13c5c2/werkzeug-3.1.6-py3-none-any.whl", hash = "sha256:7ddf3357bb9564e407607f988f683d72038551200c704012bb9a4c523d42f131", size = 225166, upload-time = "2026-02-19T15:17:17.475Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Summary:
Add the Monarch Dashboard to the OSS torchmonarch package.
- flask>=2.0 added as a required dependency
- monarch-dashboard CLI entry point
- BuildFrontend command for React frontend during pip install
- MANIFEST.in includes monarch_dashboard directory

Differential Revision: D95861380
