### PR TITLE
Treat ProcStatus::Stopping as a clean stop in supervision

### DIFF
--- a/hyperactor_mesh/src/mesh_controller.rs
+++ b/hyperactor_mesh/src/mesh_controller.rs
@@ -637,6 +637,36 @@ fn actor_state_to_supervision_events(
     (rank, events)
 }
 
+/// Map a process-level [`ProcStatus`] to an actor-level [`ActorStatus`].
+///
+/// When the supervision poll discovers that a process is terminating, this
+/// function decides whether to treat it as a clean stop or a failure.
+/// Notably, [`ProcStatus::Stopping`] (SIGTERM sent, process not yet exited)
+/// is mapped to [`ActorStatus::Stopped`] rather than [`ActorStatus::Failed`]
+/// so that a graceful shutdown in progress does not trigger unhandled
+/// supervision errors.
+fn proc_status_to_actor_status(proc_status: Option<ProcStatus>) -> ActorStatus {
+    match proc_status {
+        Some(ProcStatus::Stopped { exit_code: 0, .. }) => {
+            ActorStatus::Stopped("process exited cleanly".to_string())
+        }
+        Some(ProcStatus::Stopped { exit_code, .. }) => ActorStatus::Failed(
+            ActorErrorKind::Generic(format!("process exited with non-zero code {}", exit_code)),
+        ),
+        // Stopping is a transient state during graceful shutdown. Treat it the
+        // same as a clean stop rather than a failure.
+        Some(ProcStatus::Stopping { .. }) => {
+            ActorStatus::Stopped("process is stopping".to_string())
+        }
+        // Conservatively treat lack of status as stopped
+        None => ActorStatus::Stopped("no status received from process".to_string()),
+        Some(status) => ActorStatus::Failed(ActorErrorKind::Generic(format!(
+            "process failure: {}",
+            status
+        ))),
+    }
+}
+
 fn format_system_time(time: std::time::SystemTime) -> String {
     let datetime: chrono::DateTime<chrono::Local> = time.into();
     datetime.format("%Y-%m-%d %H:%M:%S").to_string()
@@ -717,23 +747,8 @@ impl<A: Referable> Handler<CheckState> for ActorMeshController<A> {
                 // TODO: allow "actor supervision event" to be general, and
                 // make the proc failure the cause. It is a hack to try to determine
                 // the correct status based on process exit status.
-                let actor_status = match state.state.and_then(|s| s.proc_status) {
-                    Some(ProcStatus::Stopped { exit_code: 0, .. }) => {
-                        ActorStatus::Stopped("process exited cleanly".to_string())
-                    }
-                    Some(ProcStatus::Stopped { exit_code, .. }) => {
-                        ActorStatus::Failed(ActorErrorKind::Generic(format!(
-                            "process exited with non-zero code {}",
-                            exit_code
-                        )))
-                    }
-                    // Conservatively treat lack of status as stopped
-                    None => ActorStatus::Stopped("no status received from process".to_string()),
-                    Some(status) => ActorStatus::Failed(ActorErrorKind::Generic(format!(
-                        "process failure: {}",
-                        status
-                    ))),
-                };
+                let actor_status =
+                    proc_status_to_actor_status(state.state.and_then(|s| s.proc_status));
                 let display_name = crate::actor_display_name(supervision_display_name, &point);
                 send_state_change(
                     cx,
@@ -952,14 +967,17 @@ mod tests {
     use std::ops::Deref;
     use std::time::Duration;
 
+    use hyperactor::actor::ActorStatus;
     use hyperactor::clock::Clock;
     use hyperactor::clock::RealClock;
     use ndslice::Extent;
     use ndslice::ViewExt;
 
     use super::SUPERVISION_POLL_FREQUENCY;
+    use super::proc_status_to_actor_status;
     use crate::ActorMesh;
     use crate::Name;
+    use crate::bootstrap::ProcStatus;
     use crate::proc_agent::MESH_ORPHAN_TIMEOUT;
     use crate::resource;
     use crate::supervision::MeshFailure;
@@ -1181,5 +1199,78 @@ mod tests {
 
         let _ = actor_hm.shutdown(instance).await;
         let _ = controller_hm.shutdown(instance).await;
+    }
+
+    #[test]
+    fn test_proc_status_to_actor_status_stopped_cleanly() {
+        let status = proc_status_to_actor_status(Some(ProcStatus::Stopped {
+            exit_code: 0,
+            stderr_tail: vec![],
+        }));
+        assert!(
+            matches!(status, ActorStatus::Stopped(ref msg) if msg.contains("cleanly")),
+            "expected Stopped, got {:?}",
+            status
+        );
+    }
+
+    #[test]
+    fn test_proc_status_to_actor_status_nonzero_exit() {
+        let status = proc_status_to_actor_status(Some(ProcStatus::Stopped {
+            exit_code: 1,
+            stderr_tail: vec![],
+        }));
+        assert!(
+            matches!(status, ActorStatus::Failed(_)),
+            "expected Failed, got {:?}",
+            status
+        );
+    }
+
+    #[test]
+    fn test_proc_status_to_actor_status_stopping_is_not_a_failure() {
+        let status = proc_status_to_actor_status(Some(ProcStatus::Stopping {
+            started_at: std::time::SystemTime::now(),
+        }));
+        assert!(
+            matches!(status, ActorStatus::Stopped(ref msg) if msg.contains("stopping")),
+            "expected Stopped, got {:?}",
+            status
+        );
+    }
+
+    #[test]
+    fn test_proc_status_to_actor_status_none() {
+        let status = proc_status_to_actor_status(None);
+        assert!(
+            matches!(status, ActorStatus::Stopped(_)),
+            "expected Stopped, got {:?}",
+            status
+        );
+    }
+
+    #[test]
+    fn test_proc_status_to_actor_status_killed() {
+        let status = proc_status_to_actor_status(Some(ProcStatus::Killed {
+            signal: 9,
+            core_dumped: false,
+        }));
+        assert!(
+            matches!(status, ActorStatus::Failed(_)),
+            "expected Failed, got {:?}",
+            status
+        );
+    }
+
+    #[test]
+    fn test_proc_status_to_actor_status_failed() {
+        let status = proc_status_to_actor_status(Some(ProcStatus::Failed {
+            reason: "oom".to_string(),
+        }));
+        assert!(
+            matches!(status, ActorStatus::Failed(_)),
+            "expected Failed, got {:?}",
+            status
+        );
     }
 }


### PR DESCRIPTION
Summary:
When a proc mesh is stopped gracefully via `proc_mesh.stop()`, the
process transitions through `ProcStatus::Stopping` before reaching
`ProcStatus::Stopped`. If the supervision poll fires during this
window, the catch-all match arm in `CheckState` treats the transient
`Stopping` state as a failure, producing a spurious
`"process failure: Stopping up <duration>"` supervision event that
propagates to the root actor's unhandled fault hook.

This adds an explicit match arm for `ProcStatus::Stopping` that maps
it to `ActorStatus::Stopped` (like a clean exit) instead of
`ActorStatus::Failed`. The mapping logic is extracted into a standalone
`proc_status_to_actor_status` function with unit tests covering all
`ProcStatus` variants.

Differential Revision: D95875401


