### PR TITLE
Wire thread into start_telemetry()

### DIFF
--- a/examples/distributed_telemetry.py
+++ b/examples/distributed_telemetry.py
@@ -32,7 +32,7 @@ os.environ["USE_UNIFIED_LAYER"] = "true"
 
 import pyarrow as pa
 from monarch.actor import Actor, endpoint
-from monarch.distributed_telemetry import start_telemetry
+from monarch.distributed_telemetry.actor import start_telemetry
 from monarch.job import ProcessJob
 
 

--- a/python/monarch/distributed_telemetry/__init__.py
+++ b/python/monarch/distributed_telemetry/__init__.py
@@ -15,17 +15,9 @@ Three-component architecture:
 3. QueryEngine (Rust): DataFusion query execution
 
 Usage:
-    from monarch.distributed_telemetry import start_telemetry
+    from monarch.distributed_telemetry.actor import start_telemetry
 
     engine = start_telemetry().get()
     # ... spawn procs, they're automatically tracked ...
     result = engine.query("SELECT * FROM metrics")
 """
-
-from monarch.distributed_telemetry.actor import (
-    DistributedTelemetryActor,
-    start_telemetry,
-)
-from monarch.distributed_telemetry.engine import QueryEngine
-
-__all__ = ["DistributedTelemetryActor", "QueryEngine", "start_telemetry"]

--- a/python/monarch/distributed_telemetry/actor.py
+++ b/python/monarch/distributed_telemetry/actor.py
@@ -21,6 +21,7 @@ variable and used by the DistributedTelemetryActor when it initializes.
 
 import functools
 import logging
+import os
 from typing import Any, Callable, Dict, List, Optional
 
 from monarch._rust_bindings.monarch_distributed_telemetry.database_scanner import (
@@ -38,6 +39,8 @@ from monarch._src.actor.proc_mesh import (
 )
 from monarch.actor import Actor, current_rank, endpoint, this_proc
 from monarch.distributed_telemetry.engine import QueryEngine
+from monarch.monarch_dashboard.server.app import start_dashboard
+from monarch.monarch_dashboard.server.query_engine_adapter import QueryEngineAdapter
 
 logger: logging.Logger = logging.getLogger(__name__)
 
@@ -216,6 +219,8 @@ class DistributedTelemetryActor(Actor):
 def start_telemetry(
     batch_size: int = 1000,
     retention_secs: int = 600,
+    include_dashboard: bool = True,
+    dashboard_port: int = 8265,
 ) -> QueryEngine:
     """
     Start the distributed telemetry system and return a QueryEngine.
@@ -228,10 +233,24 @@ def start_telemetry(
         batch_size: Number of rows to buffer before flushing to a RecordBatch.
         retention_secs: Retention window in seconds for message tables.
             Defaults to 600 (10 minutes). 0 disables retention.
+        include_dashboard: Whether to start the monarch dashboard web server.
+        dashboard_port: Preferred port for the dashboard (default 8265).
 
     Returns:
         The QueryEngine for executing SQL queries.
     """
     _register_scanner(batch_size, retention_secs=retention_secs)
     coordinator = this_proc().spawn("telemetry_coordinator", DistributedTelemetryActor)
-    return QueryEngine(coordinator)
+    query_engine = QueryEngine(coordinator)
+
+    if include_dashboard:
+        adapter = QueryEngineAdapter(query_engine)
+        info = start_dashboard(
+            adapter=adapter,
+            port=dashboard_port,
+        )
+        dashboard_url = info["url"]
+        os.environ["MONARCH_DASHBOARD_URL"] = dashboard_url
+        logger.info("Monarch Dashboard: %s", dashboard_url)
+
+    return query_engine

--- a/python/monarch/distributed_telemetry/engine.py
+++ b/python/monarch/distributed_telemetry/engine.py
@@ -12,15 +12,12 @@ QueryEngine - Wrapper for the Rust QueryEngine.
 Provides SQL query execution over distributed telemetry actors.
 """
 
-from typing import Optional, Tuple, Type, TYPE_CHECKING
+from typing import Any, Optional, Tuple, Type
 
 import pyarrow as pa
 from monarch._rust_bindings.monarch_distributed_telemetry.query_engine import (
     QueryEngine as _QueryEngine,
 )
-
-if TYPE_CHECKING:
-    from monarch.distributed_telemetry.actor import DistributedTelemetryActor
 
 
 class QueryEngine:
@@ -34,7 +31,7 @@ class QueryEngine:
     to be created from async contexts without blocking.
     """
 
-    def __init__(self, actor: "DistributedTelemetryActor") -> None:
+    def __init__(self, actor: Any) -> None:
         """
         Create a QueryEngine.
 
@@ -42,12 +39,12 @@ class QueryEngine:
             actor: A singleton DistributedTelemetryActor (ActorMesh with one element)
                    that has all children added.
         """
-        self._actor: "DistributedTelemetryActor" = actor
+        self._actor: Any = actor
         self._engine: Optional[_QueryEngine] = None
 
     def __reduce__(
         self,
-    ) -> Tuple[Type["QueryEngine"], Tuple["DistributedTelemetryActor"]]:
+    ) -> Tuple[Type["QueryEngine"], Tuple[Any]]:
         """Make QueryEngine serializable by recreating the Rust object on unpickle."""
         return (QueryEngine, (self._actor,))
 

--- a/python/monarch/monarch_dashboard/server/app.py
+++ b/python/monarch/monarch_dashboard/server/app.py
@@ -26,13 +26,6 @@ from .routes import api
 logger = logging.getLogger(__name__)
 
 
-def find_free_port() -> int:
-    """Find an available TCP port on localhost."""
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-        s.bind(("localhost", 0))
-        return s.getsockname()[1]
-
-
 def create_app(adapter: DBAdapter) -> Flask:
     """Build a configured Flask application.
 
@@ -67,24 +60,38 @@ def create_app(adapter: DBAdapter) -> Flask:
 
 def start_dashboard(
     adapter: DBAdapter,
-    port: int = 5000,
+    port: int = 8265,
     host: str = "0.0.0.0",
 ) -> dict:
     """Start the dashboard server in a daemon thread.
 
+    The dashboard runs in-process because telemetry data lives entirely
+    in-memory as DataFusion MemTables. There is no on-disk database, so
+    the dashboard must share the process to access the QueryEngine.
+
     Args:
         adapter: A DBAdapter instance for data access.
-        port: HTTP port to listen on.  Use 0 to auto-select a free port.
+        port: HTTP port to listen on.
         host: Bind address.
 
     Returns:
         A dict with keys: ``url``, ``port``, ``pid`` (always None),
         ``handle`` (Thread).
-    """
-    if port == 0:
-        port = find_free_port()
 
-    url = f"http://{host}:{port}"
+    Raises:
+        OSError: If the port is already in use.
+    """
+    # Check port availability before starting the thread so failures
+    # are raised to the caller instead of silently killing the thread.
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        try:
+            s.bind((host, port))
+        except OSError:
+            logger.error("Dashboard failed to start: port %d is unavailable", port)
+            raise
+
+    display_host = "localhost" if host == "0.0.0.0" else host
+    url = f"http://{display_host}:{port}"
 
     app = create_app(adapter)
     thread = threading.Thread(

--- a/python/monarch/monarch_dashboard/server/query_engine_adapter.py
+++ b/python/monarch/monarch_dashboard/server/query_engine_adapter.py
@@ -25,7 +25,7 @@ class QueryEngineAdapter(DBAdapter):
 
     Usage::
 
-        from monarch.distributed_telemetry import start_telemetry
+        from monarch.distributed_telemetry.actor import start_telemetry
         engine = start_telemetry()
         adapter = QueryEngineAdapter(engine)
         rows = adapter.query("SELECT * FROM actors LIMIT 10")

--- a/python/tests/test_distributed_telemetry.py
+++ b/python/tests/test_distributed_telemetry.py
@@ -28,7 +28,7 @@ from monarch._src.actor.proc_mesh import (
     SetupActor,
     unregister_proc_mesh_spawn_callback,
 )
-from monarch.distributed_telemetry import start_telemetry
+from monarch.distributed_telemetry.actor import start_telemetry
 from monarch.job import ProcessJob
 
 
@@ -119,7 +119,7 @@ def test_record_batch_tracing(cleanup_callbacks) -> None:
 def test_actors_table() -> None:
     """Test that the actors table is populated when actors are spawned."""
     # Start telemetry with real data (not fake) so RecordBatchSink receives events
-    engine = start_telemetry(batch_size=10)
+    engine = start_telemetry(batch_size=10, include_dashboard=False)
 
     # Spawn some worker actors - this should trigger notify_actor_created
     job = ProcessJob({"hosts": 1})
@@ -173,7 +173,7 @@ def test_actors_table() -> None:
 def test_meshes_table() -> None:
     """Test that the meshes table is populated when actor meshes are spawned."""
     # Start telemetry with real data (not fake) so RecordBatchSink receives events
-    engine = start_telemetry(batch_size=10)
+    engine = start_telemetry(batch_size=10, include_dashboard=False)
 
     # Spawn some worker actors - this should trigger notify_mesh_created
     job = ProcessJob({"hosts": 1})
@@ -268,7 +268,7 @@ def test_meshes_table() -> None:
 @isolate_in_subprocess
 def test_proc_mesh_in_meshes_table() -> None:
     """Test that ProcMesh creation is recorded in the meshes table with class 'Proc'."""
-    engine = start_telemetry(batch_size=10)
+    engine = start_telemetry(batch_size=10, include_dashboard=False)
 
     # Spawn a named proc mesh — this should emit a mesh event with class "Proc"
     job = ProcessJob({"hosts": 1})
@@ -330,7 +330,7 @@ def test_proc_mesh_in_meshes_table() -> None:
 @pytest.mark.timeout(120)
 def test_actors_join_meshes_on_mesh_id(cleanup_callbacks) -> None:
     """Test that actors.mesh_id matches meshes.id, enabling joins."""
-    engine = start_telemetry(batch_size=10)
+    engine = start_telemetry(batch_size=10, include_dashboard=False)
 
     # Spawn actors — this populates both the actors and meshes tables
     job = ProcessJob({"hosts": 1})
@@ -378,7 +378,7 @@ def test_actors_join_meshes_on_mesh_id(cleanup_callbacks) -> None:
 @pytest.mark.timeout(120)
 def test_all_actors_in_proc_mesh(cleanup_callbacks) -> None:
     """Test that all actor meshes within a proc mesh have actors in the actors table."""
-    engine = start_telemetry(batch_size=10)
+    engine = start_telemetry(batch_size=10, include_dashboard=False)
 
     # Spawn a named proc mesh and user actors
     job = ProcessJob({"hosts": 1})
@@ -438,7 +438,7 @@ def test_all_actors_in_proc_mesh(cleanup_callbacks) -> None:
 @pytest.mark.timeout(120)
 def test_all_actors_in_host_mesh(cleanup_callbacks) -> None:
     """Test that all actor meshes within a proc mesh have actors in the actors table."""
-    engine = start_telemetry(batch_size=10)
+    engine = start_telemetry(batch_size=10, include_dashboard=False)
 
     # Spawn a named proc mesh and user actors
     job = ProcessJob({"hosts": 2})
@@ -514,7 +514,7 @@ def test_all_actors_in_host_mesh(cleanup_callbacks) -> None:
 @isolate_in_subprocess
 def test_actor_status_events_table() -> None:
     """Test that the actor_status_events table is populated when actors change status."""
-    engine = start_telemetry(batch_size=10)
+    engine = start_telemetry(batch_size=10, include_dashboard=False)
 
     # Spawn worker actors — actors go through status transitions during spawn
     job = ProcessJob({"hosts": 1})
@@ -573,7 +573,7 @@ def test_actor_status_events_table() -> None:
 @pytest.mark.timeout(120)
 def test_sliced_vs_full_view_rank(cleanup_callbacks) -> None:
     """Test that rank and parent_view_json are correct for sliced and full actor meshes."""
-    engine = start_telemetry(batch_size=10)
+    engine = start_telemetry(batch_size=10, include_dashboard=False)
 
     # Spawn 3 workers so we can slice a subset
     job = ProcessJob({"hosts": 1})
@@ -678,7 +678,7 @@ def test_sent_messages_table(
       - view_json: serialized ndslice::Region of the current view
       - shape_json: serialized ndslice::Shape (converted from the Region)
     """
-    engine = start_telemetry(batch_size=10)
+    engine = start_telemetry(batch_size=10, include_dashboard=False)
 
     job = ProcessJob({"hosts": 1})
     hosts = job.state(cached_path=None).hosts
@@ -759,7 +759,7 @@ def test_sent_messages_table(
 @pytest.mark.timeout(120)
 def test_messages_table(cleanup_callbacks) -> None:
     """Test that the messages table is populated when messages are received."""
-    engine = start_telemetry(batch_size=10)
+    engine = start_telemetry(batch_size=10, include_dashboard=False)
 
     job = ProcessJob({"hosts": 1})
     hosts = job.state(cached_path=None).hosts
@@ -812,7 +812,7 @@ def test_messages_table(cleanup_callbacks) -> None:
 @pytest.mark.timeout(120)
 def test_message_status_events_table(cleanup_callbacks) -> None:
     """Test that message_status_events captures queued/active/complete transitions."""
-    engine = start_telemetry(batch_size=10)
+    engine = start_telemetry(batch_size=10, include_dashboard=False)
 
     job = ProcessJob({"hosts": 1})
     hosts = job.state(cached_path=None).hosts
@@ -864,7 +864,7 @@ def test_message_status_events_table(cleanup_callbacks) -> None:
 @pytest.mark.timeout(120)
 def test_sent_messages_with_sliced_mesh(cleanup_callbacks) -> None:
     """Test that sent_messages view_json/shape_json reflect sliced vs full actor mesh casts."""
-    engine = start_telemetry(batch_size=10)
+    engine = start_telemetry(batch_size=10, include_dashboard=False)
 
     job = ProcessJob({"hosts": 1})
     hosts = job.state(cached_path=None).hosts
@@ -920,7 +920,7 @@ def test_sent_messages_with_sliced_mesh(cleanup_callbacks) -> None:
 def test_sent_messages_sender_actor_id(cleanup_callbacks) -> None:
     """Test that sender_actor_id identifies the actor that initiated the cast,
     not the target actor, when one actor casts to another actor mesh."""
-    engine = start_telemetry(batch_size=10)
+    engine = start_telemetry(batch_size=10, include_dashboard=False)
 
     job = ProcessJob({"hosts": 1})
     hosts = job.state(cached_path=None).hosts
@@ -986,7 +986,7 @@ def test_sent_messages_sender_actor_id(cleanup_callbacks) -> None:
 @pytest.mark.timeout(120)
 def test_query_after_stopping_proc_mesh(cleanup_callbacks) -> None:
     """Test that query still works after a user-spawned actor's proc mesh is stopped."""
-    engine = start_telemetry(batch_size=10)
+    engine = start_telemetry(batch_size=10, include_dashboard=False)
 
     job = ProcessJob({"hosts": 1})
     hosts = job.state(cached_path=None).hosts
@@ -1069,7 +1069,7 @@ def test_query_after_stopping_actor_mesh(cleanup_callbacks) -> None:
     ProcMesh remain alive, so all data (including process-local tables like
     messages) is still queryable.
     """
-    engine = start_telemetry(batch_size=10)
+    engine = start_telemetry(batch_size=10, include_dashboard=False)
 
     job = ProcessJob({"hosts": 1})
     hosts = job.state(cached_path=None).hosts
@@ -1153,7 +1153,7 @@ def test_per_table_row_retention(cleanup_callbacks) -> None:
     import time
 
     # Use a 1-second retention window so rows expire quickly.
-    engine = start_telemetry(batch_size=2, retention_secs=1)
+    engine = start_telemetry(batch_size=2, retention_secs=1, include_dashboard=False)
 
     job = ProcessJob({"hosts": 1})
     hosts = job.state(cached_path=None).hosts


### PR DESCRIPTION
Summary:
Integrate the dashboard as a thread launched from start_telemetry()

- start_telemetry() now accepts include_dashboard (True/False/None) and
  dashboard_port parameters. None (default) is best-effort: starts the
  dashboard but continues if it fails.
- Dashboard launches as a subprocess (python -m monarch.monarch_dashboard)
  for fault isolation — a dashboard crash cannot bring down the parent.
- Port selection uses 8265 (Ray convention) with 50-retry fallback.
- Health check polls /api/health for up to 20s after launch.
- Dashboard URL is written to MONARCH_DASHBOARD_URL env var.

app.py changes:
- Added find_available_port() with sequential retry logic.
- Added _wait_for_dashboard() health check polling.
- start_dashboard() now returns a dict with url/port/pid/handle.
- Fixed subprocess module path to monarch.monarch_dashboard.
- Default port changed from 5000 to 8265.

Differential Revision: D95889134


