### PR TITLE
Use multi-phase module initialization for monarch C modules

### DIFF
--- a/python/monarch/common/init.cpp
+++ b/python/monarch/common/init.cpp
@@ -56,17 +56,28 @@ static PyMethodDef _C_methods[] = {
      "Get the version of pytorch monarch was built against."},
     {NULL, NULL, 0, NULL}};
 
+static int module_exec(PyObject* /* module */) {
+  return 0;
+}
+
+static PyModuleDef_Slot _C_slots[] = {
+    {Py_mod_exec, (void*)module_exec},
+#if PY_VERSION_HEX >= 0x030D0000
+    {Py_mod_gil, Py_MOD_GIL_USED},
+#endif
+    {0, NULL}};
+
 static struct PyModuleDef _C_module = {
     PyModuleDef_HEAD_INIT,
     "_C",
     "A module containing monarch C++ functionality.",
-    -1,
+    0,
     _C_methods,
-    NULL,
+    _C_slots,
     NULL,
     NULL,
     NULL};
 
 PyMODINIT_FUNC PyInit__C(void) {
-  return PyModule_Create(&_C_module);
+  return PyModuleDef_Init(&_C_module);
 }

--- a/python/monarch/gradient/_gradient_generator.cpp
+++ b/python/monarch/gradient/_gradient_generator.cpp
@@ -772,18 +772,7 @@ static PyObject* PyGradientGenerator_iternext(PyObject* self) {
 
 static PyTypeObject PyGradientGeneratorType = {PyVarObject_HEAD_INIT(NULL, 0)};
 
-static PyModuleDef gradientmodule = {
-    PyModuleDef_HEAD_INIT,
-    "monarch.gradient._gradient_generator",
-    "Python interface for the GradientGenerator C++ class",
-    -1,
-    NULL,
-    NULL,
-    NULL,
-    NULL,
-    NULL};
-
-PyMODINIT_FUNC PyInit__gradient_generator(void) {
+static int gradientmodule_exec(PyObject* m) {
   PyGradientGeneratorType.tp_name =
       "monarch.gradient._gradient_generator.GradientGenerator";
   PyGradientGeneratorType.tp_basicsize = sizeof(PyGradientGenerator);
@@ -797,20 +786,36 @@ PyMODINIT_FUNC PyInit__gradient_generator(void) {
   PyGradientGeneratorType.tp_init = (initproc)PyGradientGenerator_init;
   PyGradientGeneratorType.tp_new = PyType_GenericNew;
 
-  PyObject* m;
   if (PyType_Ready(&PyGradientGeneratorType) < 0) {
-    return NULL;
-  }
-  m = PyModule_Create(&gradientmodule);
-  if (m == NULL) {
-    return NULL;
+    return -1;
   }
   Py_INCREF(&PyGradientGeneratorType);
   if (PyModule_AddObject(
           m, "GradientGenerator", (PyObject*)&PyGradientGeneratorType) < 0) {
     Py_DECREF(&PyGradientGeneratorType);
-    Py_DECREF(m);
-    return NULL;
+    return -1;
   }
-  return m;
+  return 0;
+}
+
+static PyModuleDef_Slot gradientmodule_slots[] = {
+    {Py_mod_exec, (void*)gradientmodule_exec},
+#if PY_VERSION_HEX >= 0x030D0000
+    {Py_mod_gil, Py_MOD_GIL_USED},
+#endif
+    {0, NULL}};
+
+static PyModuleDef gradientmodule = {
+    PyModuleDef_HEAD_INIT,
+    "monarch.gradient._gradient_generator",
+    "Python interface for the GradientGenerator C++ class",
+    0,
+    NULL,
+    gradientmodule_slots,
+    NULL,
+    NULL,
+    NULL};
+
+PyMODINIT_FUNC PyInit__gradient_generator(void) {
+  return PyModuleDef_Init(&gradientmodule);
 }


### PR DESCRIPTION
Summary:
Change our C++-based python modules to use multi-phase module initialization.
This helps the module be used by some modern features like subinterpreters and
in GIL-less mode.

It just separates the Module allocation (Init) from the initialization of
the functions and classes available in it (Py_mod_exec).
Since these modules have not yet had their behavior verified, we put in that they
require the GIL for now.

Reviewed By: shayne-fletcher

Differential Revision: D95861581


