### PR TITLE
Rename deprecated methods to private: allocate_nonblocking, from_alloc, host_mesh

### DIFF
--- a/docs/source/api/monarch.actor.rst
+++ b/docs/source/api/monarch.actor.rst
@@ -23,7 +23,7 @@ are launch across hosts. HostMesh represents a mesh of hosts. ProcMesh is a mesh
    :undoc-members:
    :inherited-members:
    :show-inheritance:
-   :exclude-members: __init__, monitor, from_alloc, sync_workspace, logging_option, get
+   :exclude-members: __init__, monitor, _from_alloc, sync_workspace, logging_option, get
 
 .. autofunction:: get_or_spawn_controller
 

--- a/docs/source/books/hyperactor-mesh-book/src/meshes/bootstrapping-from-python.md
+++ b/docs/source/books/hyperactor-mesh-book/src/meshes/bootstrapping-from-python.md
@@ -208,7 +208,7 @@ def create_local_host_mesh(
     if env is not None:
         bootstrap_env.update(env)
 
-    return HostMesh.allocate_nonblocking(
+    return HostMesh._allocate_nonblocking(
         "local_host",
         extent if extent is not None else Extent([], []),
         ProcessAllocator(cmd, args, bootstrap_env),
@@ -218,7 +218,7 @@ def create_local_host_mesh(
 
 - `_get_bootstrap_args()` = "what command/env do we use to start a hyperactor proc?"
 - we wrap that in a `ProcessAllocator(...)`
-- we tell the Rust side to `allocate_nonblocking(...)` a v1 HostMesh using that allocator.
+- we tell the Rust side to `_allocate_nonblocking(...)` a v1 HostMesh using that allocator.
 
 ## 2. Hand-off to Rust
 

--- a/python/monarch/_src/actor/bootstrap_main.py
+++ b/python/monarch/_src/actor/bootstrap_main.py
@@ -80,7 +80,7 @@ def invoke_main() -> None:
         bootstrap_err = RuntimeError(
             f"Failed to bootstrap proc due to: {e}\nMake sure your proc bootstrap command is correct. "
             f"Provided command:\n{' '.join([sys.executable, *sys.argv])}\nTo specify your proc bootstrap command, use the "
-            f"`bootstrap_cmd` kwarg in `monarch.actor.HostMesh.allocate_nonblocking(...)`."
+            f"`bootstrap_cmd` kwarg in `monarch.actor.HostMesh._allocate_nonblocking(...)`."
         )
         raise bootstrap_err from e
 

--- a/python/monarch/_src/actor/host_mesh.py
+++ b/python/monarch/_src/actor/host_mesh.py
@@ -77,7 +77,7 @@ class HostMesh(MeshTrait):
         self._code_sync_proc_mesh: Optional["_Lazy[ProcMesh]"] = _code_sync_proc_mesh
 
     @classmethod
-    def allocate_nonblocking(
+    def _allocate_nonblocking(
         cls,
         name: str,
         extent: Extent,

--- a/python/monarch/_src/actor/proc_mesh.py
+++ b/python/monarch/_src/actor/proc_mesh.py
@@ -792,7 +792,7 @@ class ProcMesh(MeshTrait):
         )
 
     @classmethod
-    def from_alloc(
+    def _from_alloc(
         self,
         alloc: AllocHandle,
         setup: Callable[[], None] | None = None,
@@ -810,7 +810,7 @@ class ProcMesh(MeshTrait):
 
         from monarch._src.actor.host_mesh import HostMesh
 
-        return HostMesh.allocate_nonblocking(
+        return HostMesh._allocate_nonblocking(
             "host_mesh_from_alloc",
             Extent(*zip(*alloc._extent.items())),
             alloc._allocator,

--- a/python/monarch/tools/components/hyperactor.py
+++ b/python/monarch/tools/components/hyperactor.py
@@ -23,7 +23,7 @@ DEFAULT_NAME: str = f"monarch-{_USER}"
 __version__ = "latest"  # TODO get version from monarch.__version_
 
 
-def host_mesh(
+def _host_mesh(
     image: str = f"ghcr.io/meta-pytorch/monarch:{__version__}",  # TODO docker needs to be built and pushed to ghcr
     meshes: list[str] = _DEFAULT_MESHES,
     env: Optional[dict[str, str]] = None,

--- a/python/monarch/tools/config/defaults.py
+++ b/python/monarch/tools/config/defaults.py
@@ -26,7 +26,7 @@ from torchx.schedulers import (
 
 def component_fn(scheduler: str) -> Callable[..., specs.AppDef]:
     """The default TorchX component function for the scheduler"""
-    return hyperactor.host_mesh
+    return hyperactor._host_mesh
 
 
 def scheduler_factories() -> dict[str, SchedulerFactory]:

--- a/python/monarch/tools/config/workspace.py
+++ b/python/monarch/tools/config/workspace.py
@@ -23,7 +23,7 @@ class Workspace:
     At the time of job submission an ephemeral version of the "image" is built and the
     new job is configured to run on this image. The "image" is the one specified by
     `Role.image` attribute in the job's `AppDef`
-    (see `monarch.tools.components.hyperactor.host_mesh()`).
+    (see `monarch.tools.components.hyperactor._host_mesh()`).
 
     For example when launching onto Kubernetes, "image" is interpreted as a Docker image (e.g. "name:tag")
 

--- a/python/tests/test_allocator.py
+++ b/python/tests/test_allocator.py
@@ -68,7 +68,7 @@ def proc_mesh_from_alloc(
     setup: Optional[Callable[[], None]] = None,
     constraints: Optional[AllocConstraints] = None,
 ) -> ProcMesh:
-    return HostMesh.allocate_nonblocking(
+    return HostMesh._allocate_nonblocking(
         "hosts",
         Extent(*zip(*list(spec.extent.items()))),
         allocator,
@@ -284,7 +284,7 @@ class TestRemoteAllocator(unittest.IsolatedAsyncioTestCase):
                 )
                 alloc = allocator.allocate(spec)
                 await alloc.initialized
-                pm = HostMesh.allocate_nonblocking(
+                pm = HostMesh._allocate_nonblocking(
                     "hosts",
                     Extent(*zip(*list(spec.extent.items()))),
                     allocator,

--- a/python/tests/test_proc_mesh.py
+++ b/python/tests/test_proc_mesh.py
@@ -208,13 +208,13 @@ async def test_deprecated_proc_mesh_from_alloc_mock() -> None:
         gpus=num_gpus,
     )
 
-    with patch.object(HostMesh, "allocate_nonblocking") as mock_host_alloc:
+    with patch.object(HostMesh, "_allocate_nonblocking") as mock_host_alloc:
         mock_host_mesh = MagicMock()
         mock_host_mesh.spawn_procs = MagicMock()
         mock_host_alloc.return_value = mock_host_mesh
 
         alloc_handle = allocator.allocate(spec)
-        ProcMesh.from_alloc(alloc_handle, test_setup)
+        ProcMesh._from_alloc(alloc_handle, test_setup)
 
         mock_host_alloc.assert_called_once()
         (name, extent, allocator, constraints) = mock_host_alloc.call_args.args
@@ -233,7 +233,7 @@ def test_deprecated_proc_mesh_from_alloc_multi_actor() -> None:
     allocator = ProcessAllocator(*_get_bootstrap_args())
     spec = AllocSpec(AllocConstraints(), replicas=2, hosts=2, gpus=3)
     alloc_handle = allocator.allocate(spec)
-    proc_mesh = ProcMesh.from_alloc(alloc_handle)
+    proc_mesh = ProcMesh._from_alloc(alloc_handle)
 
     actor = proc_mesh.spawn("test_actor", TestActor, 42)
 


### PR DESCRIPTION
Summary:
Rename deprecated methods with a leading underscore to mark them as private/internal and discourage external use:

- `HostMesh.allocate_nonblocking` → `HostMesh._allocate_nonblocking`
- `ProcMesh.from_alloc` → `ProcMesh._from_alloc`
- `host_mesh()` → `_host_mesh()` in `monarch.tools.components.hyperactor`

All internal callsites, tests, mocks, and documentation references updated accordingly.

Note: The Rust `PyHostMesh.allocate_nonblocking` binding and `AllocateMixin.allocate_nonblocking` on allocator classes are different methods and are NOT renamed.

Differential Revision: D95994628


