### PR TITLE
Add Github Actions for aarch64 builds

### DIFF
--- a/.github/workflows/build-dist.yml
+++ b/.github/workflows/build-dist.yml
@@ -23,10 +23,18 @@ on:
         description: 'Runner to use for the build'
         type: string
         default: 'linux.g5.4xlarge.nvidia.gpu'
+      docker-image:
+        description: 'Docker image to use (default lets test-infra auto-select based on gpu-arch)'
+        type: string
+        default: 'pytorch/almalinux-builder'
       version:
         description: 'Version string for the wheel (default: $current_version.dev<date>)'
         type: string
         default: ''
+      platform:
+        description: 'Target platform architecture (e.g., x86_64, aarch64)'
+        type: string
+        default: 'x86_64'
       timeout:
         description: 'Job timeout in minutes'
         type: number
@@ -43,10 +51,11 @@ jobs:
     with:
       timeout: ${{ inputs.timeout }}
       runner: ${{ inputs.runner }}
+      docker-image: ${{ inputs.docker-image }}
       gpu-arch-type: ${{ inputs.gpu-arch-type }}
       gpu-arch-version: ${{ inputs.gpu-arch-version }}
       submodules: recursive
-      upload-artifact: monarch-py${{ matrix.python-version }}-${{ inputs.gpu-arch-type }}${{ inputs.gpu-arch-version }}
+      upload-artifact: monarch-py${{ matrix.python-version }}-${{ inputs.gpu-arch-type }}${{ inputs.gpu-arch-version }}-${{ inputs.platform }}
       script: |
         source scripts/common-setup.sh
         setup_build_environment ${{ matrix.python-version }}
@@ -57,6 +66,11 @@ jobs:
 
         # Setup Tensor Engine dependencies
         setup_tensor_engine
+
+        # Install CUDA toolkit if not already present (ARM64 runners lack GPU/CUDA)
+        if ! command -v nvcc &> /dev/null; then
+            setup_cuda_toolkit
+        fi
 
         cargo install --path monarch_hyperactor
 
@@ -84,7 +98,9 @@ jobs:
         echo "=== end sccache stats ==="
 
         # Rename to manylinux2014 for PyPI compatibility
-        find dist -name "*linux_x86_64.whl" -type f -exec bash -c 'mv "$1" "${1/linux_x86_64.whl/manylinux2014_x86_64.whl}"' _ {} \;
+        for f in dist/*linux_*.whl; do
+            mv "$f" "$(echo "$f" | sed 's/linux_/manylinux2014_/')"
+        done
         ls -la dist/
 
         # Verify the wheel can be installed and imported

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,17 @@ jobs:
     with:
       artifact-name: monarch-cuda-${{ github.sha }}-py3.10
 
+  test-cpu-rust:
+    name: Test CPU Rust
+    uses: ./.github/workflows/test-cpu-rust.yml
+
+  test-cpu-rust-arm64:
+    name: Test CPU Rust (ARM64)
+    uses: ./.github/workflows/test-cpu-rust.yml
+    with:
+      runner: linux.arm64.2xlarge
+      docker-image: 'pytorch/manylinuxaarch64-builder:cuda12.8'
+
   test-gpu-rust:
     name: Test GPU Rust
     needs: build-cuda
@@ -60,13 +71,15 @@ jobs:
   status-check:
     name: Status Check
     runs-on: ubuntu-latest
-    needs: [test-cpu-python, test-gpu-python, test-gpu-rust]
+    needs: [test-cpu-python, test-gpu-python, test-cpu-rust, test-cpu-rust-arm64, test-gpu-rust]
     if: always()
     steps:
       - name: Check all jobs status
         run: |
           if [[ "${{ needs.test-cpu-python.result }}" != "success" ]] ||
              [[ "${{ needs.test-gpu-python.result }}" != "success" ]] ||
+             [[ "${{ needs.test-cpu-rust.result }}" != "success" ]] ||
+             [[ "${{ needs.test-cpu-rust-arm64.result }}" != "success" ]] ||
              [[ "${{ needs.test-gpu-rust.result }}" != "success" ]]; then
             echo "One or more jobs failed"
             exit 1

--- a/.github/workflows/test-cpu-rust.yml
+++ b/.github/workflows/test-cpu-rust.yml
@@ -1,0 +1,63 @@
+name: Test CPU Rust
+
+on:
+  workflow_call:
+    inputs:
+      runner:
+        description: 'Runner to use for the test'
+        type: string
+        default: 'linux.4xlarge'
+      docker-image:
+        description: 'Docker image to use (default lets test-infra auto-select)'
+        type: string
+        default: 'pytorch/almalinux-builder'
+
+concurrency:
+  group: test-cpu-rust-${{ inputs.runner }}-${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.run_number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test-cpu-rust:
+    name: Test CPU Rust
+    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
+    with:
+      timeout: 120
+      runner: ${{ inputs.runner }}
+      docker-image: ${{ inputs.docker-image }}
+      submodules: recursive
+      script: |
+        # Source common setup functions
+        source scripts/common-setup.sh
+
+        # Setup test environment
+        setup_test_environment
+
+        # Install Rust
+        setup_rust_toolchain
+
+        # Install System dependencies
+        install_system_dependencies
+
+        # Install PyTorch (needed for ABI compatibility, no GPU required)
+        pip install --pre torch --extra-index-url https://download.pytorch.org/whl/nightly/cu128
+
+        # Run CPU-safe Rust tests (no GPU hardware available)
+        echo "Running CPU Rust tests..."
+        # Exclude crates that require GPU hardware, CUDA libraries, or
+        # torch C++ headers (libtorch) not available on CPU-only runners.
+        timeout 12m cargo nextest run --workspace --profile ci \
+          --exclude monarch_messages \
+          --exclude monarch_tensor_worker \
+          --exclude torch-sys-cuda \
+          --exclude monarch_rdma \
+          --exclude torch-sys \
+          --exclude nccl-sys \
+          --exclude rdmaxcel-sys \
+          --exclude monarch_cpp_static_libs \
+          --exclude monarch_extension \
+          --exclude monarch_bench \
+          --exclude monarch_conda
+
+        echo "=== sccache stats ==="
+        sccache --show-stats
+        echo "=== end sccache stats ==="

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -24,17 +24,30 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.run_number || github.ref }}
   cancel-in-progress: true
 jobs:
-  build:
+  build-x86_64:
     uses: ./.github/workflows/build-dist.yml
     with:
       python-versions: '["3.10", "3.11", "3.12", "3.13"]'
+      runner: linux.g5.4xlarge.nvidia.gpu
       torch-spec: '--pre torch --extra-index-url https://download.pytorch.org/whl/nightly/cu128'
       gpu-arch-type: cuda
       gpu-arch-version: '12.8'
+      platform: x86_64
+
+  build-arm64:
+    uses: ./.github/workflows/build-dist.yml
+    with:
+      python-versions: '["3.10", "3.11", "3.12", "3.13"]'
+      runner: linux.arm64.2xlarge
+      docker-image: 'pytorch/manylinuxaarch64-builder:cuda12.8'
+      torch-spec: '--pre torch --extra-index-url https://download.pytorch.org/whl/nightly/cu128'
+      gpu-arch-type: cuda
+      gpu-arch-version: '12.8'
+      platform: aarch64
 
   publish-to-pypi:
     name: Publish to PyPI
-    needs: build
+    needs: [build-x86_64, build-arm64]
     runs-on: ubuntu-latest
     environment: nightly
     if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
@@ -58,7 +71,7 @@ jobs:
 
   publish-to-container-registry:
     name: Publish to Github Container Registry
-    needs: build
+    needs: [build-x86_64, build-arm64]
     runs-on: ubuntu-latest
     environment: nightly
     if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
@@ -78,8 +91,8 @@ jobs:
       - name: Download all artifacts
         uses: actions/download-artifact@v4
         with:
-          # Docker container only has python 3.12, so we need to use the 3.12 wheel.
-          name: monarch-py3.12-cuda12.8
+          # Docker container only has python 3.12, so we need to use the x86_64 3.12 wheel.
+          name: monarch-py3.12-cuda12.8-x86_64
           path: dist
           merge-multiple: true
 

--- a/build_utils/src/lib.rs
+++ b/build_utils/src/lib.rs
@@ -379,6 +379,7 @@ impl CppStaticLibsConfig {
         let rdma_static_libraries = std::env::var("DEP_MONARCH_CPP_STATIC_LIBS_RDMA_STATIC_LIBRARIES")
             .expect("DEP_MONARCH_CPP_STATIC_LIBS_RDMA_STATIC_LIBRARIES not set - add monarch_cpp_static_libs as build-dependency")
             .split(';')
+            .filter(|s| !s.is_empty())
             .map(|s| s.to_string())
             .collect();
 

--- a/monarch_cpp_static_libs/build.rs
+++ b/monarch_cpp_static_libs/build.rs
@@ -141,6 +141,24 @@ fn copy_dir(src_dir: &Path, target_dir: &Path) {
     }
 }
 
+/// Detect a working ninja binary. Returns Some(cmd) if found, None otherwise.
+///
+/// Checks both the exit code and that the binary is actually ninja (not a shim
+/// that delegates to make). cmake -GNinja requires a real ninja binary.
+fn detect_ninja() -> Option<&'static str> {
+    for cmd in &["ninja-build", "ninja"] {
+        if let Ok(output) = Command::new(cmd).arg("--version").output() {
+            if output.status.success() {
+                let version = String::from_utf8_lossy(&output.stdout);
+                println!("cargo:warning=Found {} version: {}", cmd, version.trim());
+                return Some(cmd);
+            }
+        }
+    }
+    println!("cargo:warning=ninja not found, will use make (cmake Makefile generator)");
+    None
+}
+
 fn build_rdma_core(rdma_core_dir: &Path) -> PathBuf {
     let build_dir = rdma_core_dir.join("build");
 
@@ -153,6 +171,7 @@ fn build_rdma_core(rdma_core_dir: &Path) -> PathBuf {
     std::fs::create_dir_all(&build_dir).expect("Failed to create rdma-core build directory");
 
     println!("cargo:warning=Building rdma-core...");
+    println!("cargo:warning=Architecture: {}", std::env::consts::ARCH);
 
     // Detect cmake command
     let cmake = if Command::new("cmake3").arg("--version").status().is_ok() {
@@ -162,21 +181,7 @@ fn build_rdma_core(rdma_core_dir: &Path) -> PathBuf {
     };
 
     // Detect ninja
-    let use_ninja = Command::new("ninja-build")
-        .arg("--version")
-        .status()
-        .is_ok()
-        || Command::new("ninja").arg("--version").status().is_ok();
-
-    let ninja_cmd = if Command::new("ninja-build")
-        .arg("--version")
-        .status()
-        .is_ok()
-    {
-        "ninja-build"
-    } else {
-        "ninja"
-    };
+    let ninja_cmd = detect_ninja();
 
     // CMake configuration
     // IMPORTANT: -DCMAKE_POSITION_INDEPENDENT_CODE=ON is required for static libs
@@ -192,50 +197,123 @@ fn build_rdma_core(rdma_core_dir: &Path) -> PathBuf {
         "-DCMAKE_CXX_FLAGS=-fPIC",
     ];
 
-    if use_ninja {
+    if ninja_cmd.is_some() {
         cmake_args.push("-GNinja");
     }
 
     cmake_args.push("..");
 
-    let status = Command::new(cmake)
+    // Run cmake and capture output for diagnostics
+    let cmake_output = Command::new(cmake)
         .current_dir(&build_dir)
         .args(&cmake_args)
-        .status()
+        .output()
         .expect("Failed to run cmake for rdma-core");
 
-    if !status.success() {
-        panic!("Failed to configure rdma-core with cmake");
+    if !cmake_output.status.success() {
+        let stderr = String::from_utf8_lossy(&cmake_output.stderr);
+        let stdout = String::from_utf8_lossy(&cmake_output.stdout);
+        panic!(
+            "Failed to configure rdma-core with cmake.\nstdout: {}\nstderr: {}",
+            stdout, stderr
+        );
     }
 
-    // Build only the targets we need
-    let targets = [
+    // Log cmake generator info for diagnostics
+    let cmake_stdout = String::from_utf8_lossy(&cmake_output.stdout);
+    for line in cmake_stdout.lines() {
+        if line.contains("STATIC")
+            || line.contains("generator")
+            || line.contains("Ninja")
+            || line.contains("provider")
+            || line.contains("mlx5")
+            || line.contains("efa")
+        {
+            println!("cargo:warning=cmake: {}", line);
+        }
+    }
+
+    // Verify build.ninja or Makefile was generated
+    if ninja_cmd.is_some() {
+        let build_ninja = build_dir.join("build.ninja");
+        if !build_ninja.exists() {
+            panic!(
+                "cmake was invoked with -GNinja but build.ninja was not generated in {}. \
+                 This usually means cmake could not find the ninja binary despite it being \
+                 on PATH. Ensure ninja-build is properly installed.",
+                build_dir.display()
+            );
+        }
+    }
+
+    let expected_outputs = [
         "lib/statics/libibverbs.a",
         "lib/statics/libmlx5.a",
         "lib/statics/libefa.a",
         "util/librdma_util.a",
     ];
 
-    for target in &targets {
-        let status = if use_ninja {
-            Command::new(ninja_cmd)
+    let num_jobs = std::thread::available_parallelism()
+        .map(|p| p.get())
+        .unwrap_or(4);
+
+    if let Some(ninja) = ninja_cmd {
+        // Ninja supports building by output file path.
+        for target in &expected_outputs {
+            let output = Command::new(ninja)
                 .current_dir(&build_dir)
                 .arg(target)
-                .status()
-                .expect("Failed to run ninja for rdma-core")
-        } else {
-            let num_jobs = std::thread::available_parallelism()
-                .map(|p| p.get())
-                .unwrap_or(4);
-            Command::new("make")
-                .current_dir(&build_dir)
-                .args(["-j", &num_jobs.to_string(), target])
-                .status()
-                .expect("Failed to run make for rdma-core")
-        };
+                .output()
+                .expect("Failed to run ninja for rdma-core");
+
+            if !output.status.success() {
+                let stderr = String::from_utf8_lossy(&output.stderr);
+                panic!(
+                    "Failed to build rdma-core target: {}\nstderr: {}",
+                    target, stderr
+                );
+            }
+        }
+    } else {
+        // CMake's Makefile generator does not support building by output
+        // file path; only named cmake targets work with make. Build all
+        // targets and verify the expected outputs afterward.
+        let status = Command::new("make")
+            .current_dir(&build_dir)
+            .args(["-j", &num_jobs.to_string()])
+            .status()
+            .expect("Failed to run make for rdma-core");
 
         if !status.success() {
-            panic!("Failed to build rdma-core target: {}", target);
+            panic!("Failed to build rdma-core");
+        }
+    }
+
+    for output in &expected_outputs {
+        let path = build_dir.join(output);
+        if !path.exists() {
+            // List what IS in lib/statics/ for diagnostics
+            let statics_dir = build_dir.join("lib/statics");
+            let contents = if statics_dir.exists() {
+                std::fs::read_dir(&statics_dir)
+                    .map(|entries| {
+                        entries
+                            .filter_map(|e| e.ok())
+                            .map(|e| e.file_name().to_string_lossy().to_string())
+                            .collect::<Vec<_>>()
+                            .join(", ")
+                    })
+                    .unwrap_or_else(|_| "error reading directory".to_string())
+            } else {
+                "directory does not exist".to_string()
+            };
+            panic!(
+                "rdma-core build completed but expected output not found: {}\n\
+                 lib/statics/ contains: [{}]\n\
+                 Ensure libnl3-devel is installed (needed by rdma-core cmake to \
+                 enable mlx5/efa providers).",
+                output, contents
+            );
         }
     }
 

--- a/scripts/common-setup.sh
+++ b/scripts/common-setup.sh
@@ -9,10 +9,33 @@
 
 set -ex
 
+# Ensure conda is available. Checks common locations first, then
+# installs Miniconda if conda is not found anywhere.
+initialize_conda() {
+    if command -v conda &> /dev/null; then
+        return
+    fi
+    # Some images have conda installed but not on PATH.
+    if [ -f /opt/conda/etc/profile.d/conda.sh ]; then
+        source /opt/conda/etc/profile.d/conda.sh
+        return
+    fi
+    # Install Miniconda if conda is not present at all.
+    echo "conda not found, installing Miniconda..."
+    local arch
+    arch=$(uname -m)
+    local installer_url="https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-${arch}.sh"
+    curl -fsSL -o /tmp/miniconda.sh "$installer_url"
+    bash /tmp/miniconda.sh -b -p /opt/conda
+    rm /tmp/miniconda.sh
+    source /opt/conda/etc/profile.d/conda.sh
+}
+
 # Setup conda environment. Defaults to Python 3.10.
 setup_conda_environment() {
     local python_version=${1:-3.10}
     echo "Setting up conda environment with Python ${python_version}..."
+    initialize_conda
     conda create -n venv python="${python_version}" -y
     conda activate venv
     export LD_LIBRARY_PATH="${CONDA_PREFIX}/lib:$LD_LIBRARY_PATH"
@@ -26,6 +49,12 @@ install_system_dependencies() {
     dnf update -y
     # Protobuf compiler is required for the tracing-perfetto-sdk-schema crate.
     dnf install clang-devel libunwind libunwind-devel protobuf-compiler -y
+    # ninja is needed by monarch_cpp_static_libs to build rdma-core from source
+    # (cmake's Makefile generator cannot build by output file path, but Ninja can).
+    # Try dnf first (package name varies by distro), fall back to pip if unavailable.
+    if ! command -v ninja &> /dev/null; then
+        dnf install -y ninja-build 2>/dev/null || dnf install -y ninja 2>/dev/null || pip install ninja || echo "Warning: ninja not available, rdma-core build may use make instead"
+    fi
 }
 
 # Install Node.js and npm (needed to build the dashboard frontend).
@@ -45,7 +74,13 @@ setup_rust_toolchain() {
     # We use cargo nextest to run tests in individual processes for similarity
     # to buck test.
     # Replace "cargo test" commands with "cargo nextest run".
-    curl -LsSf https://get.nexte.st/latest/linux | tar zxf - -C "${CARGO_HOME:-$HOME/.cargo}/bin"
+    ARCH=$(uname -m)
+    if [ "$ARCH" = "aarch64" ]; then
+        NEXTEST_URL="https://get.nexte.st/latest/linux-arm"
+    else
+        NEXTEST_URL="https://get.nexte.st/latest/linux"
+    fi
+    curl -LsSf "$NEXTEST_URL" | tar zxf - -C "${CARGO_HOME:-$HOME/.cargo}/bin"
 
     # Setup sccache for distributed Rust compilation caching via S3.
     setup_sccache
@@ -88,7 +123,9 @@ setup_tensor_engine() {
     echo "Installing Tensor Engine dependencies..."
     # Install the fmt library for C++ headers in pytorch.
     conda install -y -c conda-forge fmt
-    dnf install -y libibverbs rdma-core libmlx5 libibverbs-devel rdma-core-devel
+    # libnl3-devel is needed by rdma-core's cmake to enable mlx5/efa providers
+    # and generate ENABLE_STATIC targets (lib/statics/*.a).
+    dnf install -y libibverbs rdma-core libmlx5 libibverbs-devel rdma-core-devel libefa libnl3-devel
 }
 
 # Install PyTorch with C++ development headers (libtorch) for Rust compilation
@@ -131,6 +168,24 @@ setup_pytorch_with_headers() {
 
     echo "LibTorch libraries available at: $LIBTORCH_ROOT/lib"
     ls -la "$LIBTORCH_ROOT/lib/lib"*.so | head -5 || echo "No .so files found"
+}
+
+# Install CUDA toolkit for build-only (no GPU required).
+# Used on ARM64 runners that lack a GPU but need CUDA for compilation.
+setup_cuda_toolkit() {
+    echo "Installing CUDA toolkit for build-only (no GPU required)..."
+    ARCH=$(uname -m)
+    if [ "$ARCH" = "aarch64" ]; then
+        dnf config-manager --add-repo \
+            https://developer.download.nvidia.com/compute/cuda/repos/rhel9/sbsa/cuda-rhel9.repo
+    else
+        dnf config-manager --add-repo \
+            https://developer.download.nvidia.com/compute/cuda/repos/rhel9/x86_64/cuda-rhel9.repo
+    fi
+    dnf install -y cuda-toolkit-12-8
+    export CUDA_HOME=/usr/local/cuda-12.8
+    export PATH="$CUDA_HOME/bin:$PATH"
+    export LD_LIBRARY_PATH="$CUDA_HOME/lib64:${LD_LIBRARY_PATH:-}"
 }
 
 # Common setup for build workflows (environment + system deps + rust)


### PR DESCRIPTION
Summary:
Fixes: https://github.com/meta-pytorch/monarch/issues/1875

Adds Rust testing on ARM, and publishing wheels.
Python testing not enabled yet because we need a way to shut off GPU tests, as the
ARM github runners don't have GPUs available.

We still build the tensor engine and use cuda libraries, we just can't do a test with them
due to the lack of hardware. We can do manual tests in the meantime.

MacOS builds are not included at this time, because there is no way to support the tensor
engine on them, and then downloading monarch on MacOS will have a reduced experience
by default.


Test Plan: Tested with github CI

Reviewed By: shayne-fletcher

Differential Revision: D96150230

Pulled By: dulinriley


