### PR TITLE
[monarch] fix subprocess spawning to preserve venv python path

### DIFF
--- a/monarch_hyperactor/src/bootstrap.rs
+++ b/monarch_hyperactor/src/bootstrap.rs
@@ -73,13 +73,19 @@ pub fn run_worker_loop_forever(_py: Python<'_>, address: &str) -> PyResult<PyPyt
             env,
         }
     } else {
-        // For regular Python builds: use current_exe() and -m arguments
-        let current_exe = std::env::current_exe().map_err(|e| {
-            pyo3::PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(format!(
-                "Failed to get current executable: {}",
-                e
-            ))
-        })?;
+        // For regular Python builds: use argv[0] to preserve the original
+        // invocation path.  current_exe() resolves symlinks, which breaks
+        // virtual environments — the resolved path doesn't find pyvenv.cfg
+        // so site-packages aren't activated in subprocesses.
+        let current_exe = std::env::args()
+            .next()
+            .map(std::path::PathBuf::from)
+            .or_else(|| std::env::current_exe().ok())
+            .ok_or_else(|| {
+                pyo3::PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(
+                    "Failed to determine current executable",
+                )
+            })?;
         let current_exe_str = current_exe.to_string_lossy().to_string();
         BootstrapCommand {
             program: current_exe,

--- a/python/monarch/_src/actor/proc_mesh.py
+++ b/python/monarch/_src/actor/proc_mesh.py
@@ -908,6 +908,22 @@ def get_or_spawn_controller(
 _BOOTSTRAP_MAIN = "monarch._src.actor.bootstrap_main"
 
 
+def _get_python_executable() -> str:
+    """Return a Python path that preserves the active virtual environment.
+
+    ``sys.executable`` may resolve through symlinks to the base interpreter
+    (e.g. ``/usr/local/bin/python3.12``).  When a subprocess is spawned with
+    that path, Python won't find the venv's ``pyvenv.cfg`` and will not add
+    the venv's site-packages to ``sys.path``.  Using the venv's own
+    ``bin/python`` avoids this.
+    """
+    if sys.prefix != sys.base_prefix:
+        venv_python = os.path.join(sys.prefix, "bin", "python")
+        if os.path.exists(venv_python):
+            return venv_python
+    return sys.executable
+
+
 def _get_bootstrap_args() -> tuple[str, Optional[list[str]], dict[str, str]]:
     if IN_PAR:
         cmd = sys.argv[0]
@@ -916,7 +932,7 @@ def _get_bootstrap_args() -> tuple[str, Optional[list[str]], dict[str, str]]:
             "PAR_MAIN_OVERRIDE": _BOOTSTRAP_MAIN,
         }
     else:
-        cmd = sys.executable
+        cmd = _get_python_executable()
         args = ["-m", _BOOTSTRAP_MAIN]
         env = {}
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #2980

`current_exe()` (Rust) and `sys.executable` (Python) resolve symlinks,
so `.venv/bin/python` becomes e.g. `/usr/local/fbcode/platform010/bin/python3.12`.
The resolved path doesn't find `pyvenv.cfg`, so subprocesses lose the
venv's site-packages and can't import monarch.

Specifically, this makes host meshes work with `uv`.

Two fixes:
- `bootstrap.rs`: use `argv[0]` instead of `current_exe()` to preserve
  the original invocation path when constructing `BootstrapCommand`
- `proc_mesh.py`: add `_get_python_executable()` that uses
  `{sys.prefix}/bin/python` when running inside a venv, and use it in
  `_get_bootstrap_args()`

Differential Revision: [D96176392](https://our.internmc.facebook.com/intern/diff/D96176392/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D96176392/)!