### PR TITLE
Make the test regex for test_controller_controller_error less strict

### DIFF
--- a/python/tests/test_actor_error.py
+++ b/python/tests/test_actor_error.py
@@ -1536,7 +1536,7 @@ def test_controller_controller_error():
     # Make sure the error message includes what originally happened.
     with pytest.raises(
         ActorError,
-        match="Actor call actor_1.fail_with_supervision_error failed with BaseException",
+        match="Simulated actor failure for supervision testing",
     ):
         get_or_spawn_controller("actor_1", ErrorActor).get()
 


### PR DESCRIPTION
Summary:
Fixes: https://github.com/meta-pytorch/monarch/issues/2984

Depending on timing, different errors were surfaced for this test.
We only want to test for the smallest kernel of the error instead of the surrounding information.
And we also want to make sure the fault doesn't reach the client.

Differential Revision: D96214766


