### PR TITLE
normalize invariant labels/docs and consolidate canonical references across introspection/admin modules (2)

### DIFF
--- a/hyperactor/src/introspect.rs
+++ b/hyperactor/src/introspect.rs
@@ -60,6 +60,39 @@
 //!   `store_terminated_snapshot` writes to the proc's snapshot map,
 //!   not the instances map. `resolve_actor_ref` checks terminal
 //!   status independently and is unaffected by snapshot storage.
+//!
+//! ## Introspection key invariants (IK-*)
+//!
+//! - **IK-1 (metadata completeness):** Every actor-runtime
+//!   introspection key must carry `@meta(INTROSPECT = ...)` with
+//!   non-empty `name` and `desc`.
+//! - **IK-2 (short-name uniqueness):** No two introspection keys
+//!   may share the same `IntrospectAttr.name`. Duplicates would break
+//!   the FQ-to-short HTTP remap and schema output.
+//!
+//! ## Failure introspection invariants (FI-*)
+//!
+//! The FailureInfo presentation type lives in
+//! `hyperactor_mesh::introspect`; these invariants are documented
+//! here because the enforcement sites are in hyperactor
+//! (`proc.rs` `serve()`, `live_actor_payload`).
+//!
+//! - **FI-1 (event-before-status):** All `InstanceCell` state that
+//!   `live_actor_payload` reads must be written BEFORE
+//!   `change_status()` transitions to terminal.
+//! - **FI-2 (write-once):** `InstanceCellState::supervision_event`
+//!   is written at most once per actor lifetime.
+//! - **FI-3 (failure attrs <-> status):** Failure attrs are present
+//!   iff status is `"failed"`.
+//! - **FI-4 (is_propagated <-> root_cause_actor):**
+//!   `failure_is_propagated == true` iff
+//!   `failure_root_cause_actor != this_actor_id`.
+//! - **FI-5 (is_poisoned <-> failed_actor_count):**
+//!   `is_poisoned == true` iff `failed_actor_count > 0`.
+//! - **FI-6 (clean stop = no artifacts):** When an actor stops
+//!   cleanly, `supervision_event` is `None`, failure attrs are
+//!   absent, and the actor does not contribute to
+//!   `failed_actor_count`.
 
 use std::time::SystemTime;
 
@@ -99,18 +132,8 @@ use crate::reference;
 //   IntrospectAttr { name, desc })`. Keep `name` explicit so API
 //   stability is decoupled from internal refactors.
 //
-// Invariants:
-//
-// - **IK-1 (metadata completeness):** Every actor-runtime
-//   introspection key must carry `@meta(INTROSPECT = ...)` with
-//   non-empty `name` and `desc`. Enforced by
-//   `test_introspect_keys_are_tagged`.
-// - **IK-2 (short-name uniqueness):** No two introspection keys
-//   may share the same `IntrospectAttr.name`. Duplicates would break
-//   the FQ→short HTTP remap and schema output. Enforced by
-//   `test_introspect_short_names_are_globally_unique` within this
-//   test binary; full cross-crate coverage requires an integration
-//   test that links all introspection key crates.
+// See IK-1 (metadata completeness) and IK-2 (short-name uniqueness)
+// in module doc.
 declare_attrs! {
     /// Actor lifecycle status: "running", "stopped", "failed".
     ///
@@ -251,33 +274,7 @@ declare_attrs! {
     pub attr FAILURE_IS_PROPAGATED: bool = false;
 }
 
-// Failure introspection pipeline invariants (FI-1 through FI-6).
-//
-// The FailureInfo presentation type lives in
-// hyperactor_mesh::introspect; these invariants are documented
-// here because the enforcement sites are in hyperactor
-// (proc.rs serve(), live_actor_payload).
-//
-// - **FI-1 (event-before-status):** All `InstanceCell` state that
-//   `live_actor_payload` reads must be written BEFORE
-//   `change_status()` transitions to terminal. Enforced in
-//   `proc.rs` `serve()`.
-// - **FI-2 (write-once):** `InstanceCellState::supervision_event`
-//   is written at most once per actor lifetime. Enforced in
-//   `proc.rs` `serve()` terminal paths.
-// - **FI-3 (failure attrs ↔ status):** Failure attrs are present
-//   iff status is `"failed"`. Enforced in `build_actor_attrs`.
-// - **FI-4 (is_propagated ↔ root_cause_actor):**
-//   `failure_is_propagated == true` iff
-//   `failure_root_cause_actor != this_actor_id`. Enforced in
-//   `live_actor_payload`.
-// - **FI-5 (is_poisoned ↔ failed_actor_count):**
-//   `is_poisoned == true` iff `failed_actor_count > 0`. Enforced
-//   in `ProcAgent::publish_introspect_properties()`.
-// - **FI-6 (clean stop = no artifacts):** When an actor stops
-//   cleanly, `supervision_event` is `None`, failure attrs are
-//   absent, and the actor does not contribute to
-//   `failed_actor_count`.
+// See FI-1 through FI-6 in module doc.
 
 /// Internal introspection result. Carries attrs as a JSON string.
 /// The mesh layer constructs the API-facing `NodePayload` (with
@@ -649,8 +646,7 @@ pub async fn serve_introspect(
 mod tests {
     use super::*;
 
-    /// Enforces IK-1 (metadata completeness) for all actor-runtime
-    /// introspection keys.
+    /// Exercises IK-1 (see module doc).
     #[test]
     fn test_introspect_keys_are_tagged() {
         let cases = vec![
@@ -674,8 +670,7 @@ mod tests {
         ];
 
         for (expected_name, meta) in &cases {
-            // IK-1: every key must have INTROSPECT with non-empty
-            // name and desc.
+            // IK-1: see module doc.
             let introspect = meta
                 .get(INTROSPECT)
                 .unwrap_or_else(|| panic!("{expected_name}: missing INTROSPECT meta-attr"));
@@ -705,11 +700,7 @@ mod tests {
         );
     }
 
-    /// Enforces IK-2 (short-name uniqueness) and metadata quality
-    /// across all crates linked into this test binary. Iterates
-    /// the global `declare_attrs!` inventory and checks that no two
-    /// keys tagged with `INTROSPECT` share the same short name, and
-    /// that all tagged keys have non-empty name and desc.
+    /// Exercises IK-2 (see module doc).
     #[test]
     fn test_introspect_short_names_are_globally_unique() {
         use hyperactor_config::attrs::AttrKeyInfo;

--- a/hyperactor/src/proc.rs
+++ b/hyperactor/src/proc.rs
@@ -23,6 +23,17 @@
 //! - **CI-2 (snapshot on drop):** Dropping the returned `Instance<()>`
 //!   transitions its status to terminal, causing the introspect task
 //!   to store a terminated snapshot.
+//!
+//! ## Actor identity invariants (AI-*)
+//!
+//! - **AI-1 (named-child pid):** The pid of a named child must
+//!   remain in the parent's sibling pid domain. The name is
+//!   presentation only; the numeric pid is allocated from the
+//!   parent's counter, preserving supervision linkage.
+//! - **AI-3 (controller ActorId uniqueness):** Callers must ensure
+//!   the name is unique proc-wide. Two children with the same name
+//!   under different parents get distinct pids but the same name
+//!   prefix.
 
 use std::any::Any;
 use std::any::TypeId;
@@ -843,26 +854,8 @@ impl Proc {
 
     /// Allocate an actor ID with a custom name on this proc.
     ///
-    /// **AI-1 (named-child pid):** The pid of a named child must
-    /// remain in the parent's sibling pid domain (allocated via the
-    /// parent's counter in `roots`). The name field is presentation
-    /// /identity flavor only — it does not affect pid allocation,
-    /// supervision linkage, or the parent's `children` DashMap keying.
-    /// Violating this (e.g. allocating pids from a separate per-name
-    /// counter) causes sibling pid collisions in the parent's
-    /// `children: DashMap<Index, InstanceCell>`.
-    ///
-    /// Named children use plain infrastructure-style strings (e.g.
-    /// `"actor_mesh_controller"`), not the mesh `Name` system with
-    /// `ShortUuid` suffixes.
-    ///
-    /// **AI-3 (controller ActorId uniqueness):** Callers must ensure
-    /// `name` is unique proc-wide, not just unique within the parent.
-    /// Pid allocation is parent-scoped, so a fixed `name` across
-    /// different parents produces duplicate `(proc_id, name, pid)`
-    /// tuples. Controller actors include mesh identity in the name
-    /// to satisfy this (see spawn sites in `proc_mesh.rs` /
-    /// `host_mesh.rs`).
+    /// See AI-1 (named-child pid) and AI-3 (controller ActorId
+    /// uniqueness) in module doc.
     pub(crate) fn allocate_named_child_id(
         &self,
         parent_id: &reference::ActorId,
@@ -2135,11 +2128,8 @@ struct InstanceCellState {
         Option<Box<dyn (Fn(&crate::reference::Reference) -> IntrospectResult) + Send + Sync>>,
     >,
 
-    /// The supervision event produced when this actor failed, if any.
-    /// Written in `serve()` BEFORE `change_status()` transitions to
-    /// terminal, so that `serve_introspect` sees it when
-    /// `wait_for(is_terminal)` fires. `None` for actors that stopped
-    /// cleanly. Write-once per actor lifetime (FI-2).
+    /// The supervision event for this actor's failure, if any.
+    /// See FI-1, FI-2 in `introspect` module doc.
     supervision_event: std::sync::Mutex<Option<crate::supervision::ActorSupervisionEvent>>,
 
     /// Whether this actor is infrastructure/system (hidden by default
@@ -3841,7 +3831,7 @@ mod tests {
         );
     }
 
-    // FI-3: terminated snapshot for a failed actor has failure_info.
+    // Exercises FI-3 (see introspect module doc).
     #[async_timed_test(timeout_secs = 30)]
     async fn test_terminated_snapshot_has_failure_info() {
         let proc = Proc::local();
@@ -3885,7 +3875,7 @@ mod tests {
         );
     }
 
-    // FI-4: propagated failure has root_cause pointing to child.
+    // Exercises FI-4 (see introspect module doc).
     #[async_timed_test(timeout_secs = 30)]
     async fn test_propagated_failure_info() {
         let proc = Proc::local();
@@ -3921,8 +3911,7 @@ mod tests {
         );
     }
 
-    /// AI-1: name is presentation only, pid
-    /// comes from parent's counter.
+    /// Exercises AI-1 (see module doc).
     #[async_timed_test(timeout_secs = 30)]
     async fn test_spawn_with_name_creates_descriptive_name() {
         let proc = Proc::local();
@@ -3934,8 +3923,7 @@ mod tests {
         assert_eq!(handle.actor_id().pid(), 1);
     }
 
-    /// AI-1: same-name children increment from
-    /// parent's counter.
+    /// Exercises AI-1 (see module doc).
     #[async_timed_test(timeout_secs = 30)]
     async fn test_spawn_with_name_increments_index() {
         let proc = Proc::local();
@@ -3950,7 +3938,7 @@ mod tests {
         assert_eq!(second.actor_id().pid(), 2);
     }
 
-    /// AI-1: named children preserve supervision linkage to parent.
+    /// Exercises AI-1 (see module doc).
     /// spawn_named_child passes Some(parent) to spawn_inner.
     #[async_timed_test(timeout_secs = 30)]
     async fn test_spawn_with_name_preserves_supervision() {
@@ -3964,8 +3952,7 @@ mod tests {
         assert_eq!(parent.actor_id(), root.actor_id());
     }
 
-    /// AI-1: existing spawn path is unaffected — unnamed children
-    /// still inherit the parent's name.
+    /// Exercises AI-1 (see module doc).
     #[async_timed_test(timeout_secs = 30)]
     async fn test_spawn_unchanged() {
         let proc = Proc::local();
@@ -3974,8 +3961,7 @@ mod tests {
         assert_eq!(child.actor_id().name(), root.actor_id().name());
     }
 
-    /// AI-1: named children with different names
-    /// still get unique pids from the parent's counter.
+    /// Exercises AI-1 (see module doc).
     #[async_timed_test(timeout_secs = 30)]
     async fn test_spawn_with_name_different_names_different_pids() {
         let proc = Proc::local();
@@ -3991,8 +3977,7 @@ mod tests {
         assert_eq!(b.actor_id().name(), "controller_b");
     }
 
-    /// AI-1: no DashMap overwrite — all children
-    /// visible via parent child_count().
+    /// Exercises AI-1 (see module doc).
     #[async_timed_test(timeout_secs = 30)]
     async fn test_spawn_with_name_no_child_overwrite() {
         let proc = Proc::local();
@@ -4007,8 +3992,7 @@ mod tests {
         assert_eq!(root.cell().child_count(), 3);
     }
 
-    /// AI-1: named children do not pollute the roots map — a root
-    /// actor with a different name can still be spawned.
+    /// Exercises AI-1 (see module doc).
     #[async_timed_test(timeout_secs = 30)]
     async fn test_spawn_with_name_does_not_pollute_roots() {
         let proc = Proc::local();
@@ -4022,9 +4006,7 @@ mod tests {
         assert!(result.is_ok(), "named child should not pollute roots");
     }
 
-    /// AI-3: named children with the same fixed name under different
-    /// parents produce duplicate ActorIds. Controller names must
-    /// include mesh identity to stay unique proc-wide.
+    /// Exercises AI-3 (see module doc).
     #[async_timed_test(timeout_secs = 30)]
     async fn test_ai3_controller_actor_ids_unique_across_parents_same_proc() {
         let proc = Proc::local();
@@ -4046,8 +4028,7 @@ mod tests {
         );
     }
 
-    /// AI-3: both controllers remain resolvable after spawn — no
-    /// silent overwrite in proc instance maps.
+    /// Exercises AI-3 (see module doc).
     #[async_timed_test(timeout_secs = 30)]
     async fn test_ai3_no_controller_overwrite_in_parent_or_proc_maps() {
         let proc = Proc::local();
@@ -4075,7 +4056,7 @@ mod tests {
         assert_eq!(parent_b.cell().child_count(), 1);
     }
 
-    // FI-6: cleanly stopped actor has no failure_info.
+    // Exercises FI-6 (see introspect module doc).
     #[async_timed_test(timeout_secs = 30)]
     async fn test_stopped_snapshot_has_no_failure_info() {
         let proc = Proc::local();

--- a/hyperactor_mesh/bin/admin_tui/tree.rs
+++ b/hyperactor_mesh/bin/admin_tui/tree.rs
@@ -6,12 +6,12 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Invariants:
-//
-// - **TR-1 (fold-result-safety):** In `fold_tree` and
-//   `fold_tree_with_depth`, `result` is only set when the
-//   callback returns `Break`. This guarantees the `unwrap()`
-//   on `result` after the loop is safe.
+//! Invariants:
+//!
+//! - **TR-1 (fold-result-safety):** In `fold_tree` and
+//!   `fold_tree_with_depth`, `result` is only set when the
+//!   callback returns `Break`. This guarantees the `unwrap()`
+//!   on `result` after the loop is safe.
 
 use std::collections::HashSet;
 

--- a/hyperactor_mesh/src/host_mesh.rs
+++ b/hyperactor_mesh/src/host_mesh.rs
@@ -921,7 +921,7 @@ impl HostMeshRef {
 
     /// Returns the host entries as `(addr_string, ActorRef<HostAgent>)` pairs.
     /// Used by `MeshAdminAgent::effective_hosts()` to merge C into the
-    /// admin's host list (A/C invariant).
+    /// admin's host list (see CH-1 in mesh_admin module doc).
     pub(crate) fn host_entries(&self) -> Vec<(String, hyperactor_reference::ActorRef<HostAgent>)> {
         self.ranks
             .iter()
@@ -1278,11 +1278,8 @@ impl HostMeshRef {
             .map(|h| (h.0.to_string(), h.mesh_agent()))
             .collect();
 
-        // A/C invariant: include C (the client host) so the admin
-        // can introspect it as a normal host subtree. Dedup by
-        // HostAgent ActorId for C ∈ A. Works for both same-process
-        // and cross-process (MAST) because we read C here on the
-        // caller's process and send it in the message.
+        // CH-1: see mesh_admin module doc. Include C (the client
+        // host) so the admin can introspect it. Dedup for C in A.
         if let Some(client_host) = crate::global_context::try_this_host() {
             for (addr, agent_ref) in client_host.host_entries() {
                 let agent_id = agent_ref.actor_id();

--- a/hyperactor_mesh/src/introspect.rs
+++ b/hyperactor_mesh/src/introspect.rs
@@ -15,39 +15,38 @@
 //!
 //! See `hyperactor::introspect` for naming convention, invariant
 //! labels, and the `IntrospectAttr` meta-attribute pattern.
+//!
+//! ## Mesh key invariants (MK-*)
+//!
+//! - **MK-1 (metadata completeness):** Every mesh-topology
+//!   introspection key must carry `@meta(INTROSPECT = ...)` with
+//!   non-empty `name` and `desc`.
+//! - **MK-2 (short-name uniqueness):** Covered by
+//!   `test_introspect_short_names_are_globally_unique` in
+//!   `hyperactor::introspect` (cross-crate).
+//!
+//! ## Attrs invariants (IA-*)
+//!
+//! These govern how `IntrospectResult.attrs` is built in
+//! `hyperactor::introspect` and how `properties` is derived via
+//! `derive_properties`.
+//!
+//! - **IA-1 (attrs-json):** `IntrospectResult.attrs` is always a
+//!   valid JSON object string.
+//! - **IA-2 (runtime-precedence):** Runtime-owned introspection keys
+//!   override any same-named keys in published attrs.
+//! - **IA-3 (status-shape):** `status_reason` is present in attrs
+//!   iff the status string carries a reason.
+//! - **IA-4 (failure-shape):** `failure_*` attrs are present iff
+//!   effective status is `failed`.
+//! - **IA-5 (payload-totality):** Every `IntrospectResult` sets
+//!   `attrs` -- never omitted, never null.
 
 use hyperactor_config::INTROSPECT;
 use hyperactor_config::IntrospectAttr;
 use hyperactor_config::declare_attrs;
 
-// Invariants:
-//
-// - **MK-1 (metadata completeness):** Every mesh-topology
-//   introspection key must carry `@meta(INTROSPECT = ...)` with
-//   non-empty `name` and `desc`. Enforced by
-//   `test_mesh_introspect_keys_are_tagged`.
-// - **MK-2 (short-name uniqueness):** Covered by
-//   `test_introspect_short_names_are_globally_unique` in
-//   `hyperactor::introspect` (which iterates all linked crates). Full
-//   cross-crate coverage requires a test binary that links both
-//   `hyperactor` and `hyperactor_mesh`.
-//
-// ## Attrs invariants (IA-*)
-//
-// These govern how `IntrospectResult.attrs` is built in
-// `hyperactor::introspect` and how `properties` is derived via
-// `derive_properties`.
-//
-// - **IA-1 (attrs-json):** `IntrospectResult.attrs` is always a
-//   valid JSON object string.
-// - **IA-2 (runtime-precedence):** Runtime-owned introspection keys
-//   override any same-named keys in published attrs.
-// - **IA-3 (status-shape):** `status_reason` is present in attrs
-//   iff the status string carries a reason.
-// - **IA-4 (failure-shape):** `failure_*` attrs are present iff
-//   effective status is `failed`.
-// - **IA-5 (payload-totality):** Every `IntrospectResult` sets
-//   `attrs` — never omitted, never null.
+// See MK-1, MK-2, IA-1..IA-5 in module doc.
 declare_attrs! {
     /// Topology role of this node: "root", "host", "proc", "error".
     @meta(INTROSPECT = IntrospectAttr {

--- a/hyperactor_mesh/src/mesh_admin.rs
+++ b/hyperactor_mesh/src/mesh_admin.rs
@@ -710,7 +710,7 @@ impl Actor for MeshAdminAgent {
 
         // At Meta: mTLS is mandatory — fail if no certs are found.
         // In OSS: TLS is best-effort with plain HTTP fallback.
-        // See "TLS transport invariant" in module docs.
+        // See MA-T1 in module doc.
         let enforce_mtls = cfg!(fbcode_build);
         let tls_acceptor = try_tls_acceptor(enforce_mtls);
 

--- a/hyperactor_mesh/src/proc_agent.rs
+++ b/hyperactor_mesh/src/proc_agent.rs
@@ -248,8 +248,7 @@ struct SelfCheck {}
 /// degrade to log-only behavior (events become undeliverable again or
 /// are dropped).
 ///
-/// See `global_context.rs` for the invariant and the forwarding path
-/// ("last sink wins").
+/// See GC-1 in `global_context` module doc.
 #[hyperactor::export(
     handlers=[
         MeshAgentMessage,

--- a/hyperactor_mesh/src/value_mesh.rs
+++ b/hyperactor_mesh/src/value_mesh.rs
@@ -6,6 +6,11 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+//! ## Value mesh invariants (VM-*)
+//!
+//! - **VM-1 (completeness):** Every rank in `region` has exactly one
+//!   value. Iteration and indexing follow the region's linearization.
+
 use std::cmp::Ordering;
 use std::collections::HashMap;
 use std::collections::hash_map::Entry;
@@ -41,9 +46,7 @@ pub use value_overlay::ValueOverlay;
 /// but externally the mesh always behaves as a complete mapping from
 /// rank index → value.
 ///
-/// # Invariants (VM-1)
-/// - **VM-1 (completeness):** Every rank in `region` has exactly one value.
-/// - Order: iteration and indexing follow the region's linearization.
+/// See VM-1 in module doc.
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)] // only if T implements
 pub struct ValueMesh<T> {
     /// The logical multidimensional domain of the mesh.


### PR DESCRIPTION
Summary: missed work from D96294935. this pass normalizes invariant-label conventions across hyperactor, hyperactor_mesh, and admin_tui by enforcing canonical definition sites at module scope and replacing duplicate inline definitions with references.

Differential Revision: D96294935


