### PR TITLE
Add NUMA bindings for spawning proc meshes (#2996)

### DIFF
--- a/docs/source/actors.md
+++ b/docs/source/actors.md
@@ -9,7 +9,8 @@
 6. [ActorMesh](#actormesh)
 7. [Error Handling in Meshes](#error-handling-in-meshes)
 8. [Advanced Patterns](#advanced-patterns)
-9. [Best Practices](#best-practices)
+9. [CPU/NUMA Binding](#cpunuma-binding)
+10. [Best Practices](#best-practices)
 
 ---
 
@@ -863,6 +864,76 @@ config_mesh = ValueMesh.from_list(configs, extent={"gpus": 8})
 # Spawn actors with value mesh
 actors = procs.spawn("actors", ConfigActor, config_mesh)
 ```
+
+---
+
+## CPU/NUMA Binding
+
+On multi-socket machines, pinning each process to a specific NUMA node
+or CPU set can significantly improve memory bandwidth and reduce
+cross-socket traffic. Monarch exposes this through the `proc_bind`
+parameter on `HostMesh.spawn_procs()`.
+
+### How it works
+
+Each entry in the `proc_bind` list is a dict of binding keys that map
+to the corresponding process in the mesh. On NUMA-capable Linux hosts,
+Monarch wraps the process command with `numactl`; on other Linux hosts
+it falls back to `taskset`. Non-Linux platforms ignore binding.
+
+### Binding keys
+
+| Key | Tool | Effect |
+|---|---|---|
+| `cpunodebind` | `numactl --cpunodebind` | Pin CPUs to a NUMA node |
+| `membind` | `numactl --membind` | Pin memory allocation to a NUMA node |
+| `physcpubind` | `numactl --physcpubind` | Pin to specific physical CPU cores |
+| `cpus` | `taskset -c` | Fallback CPU set (used when NUMA is unavailable) |
+
+The `numactl` keys (`cpunodebind`, `membind`, `physcpubind`) take
+precedence when the host is NUMA-capable. If none of them are set,
+`cpus` is used with `taskset` as a fallback.
+
+### Example: pin each GPU process to its NUMA node
+
+```python
+from monarch.actor import this_host
+
+host = this_host()
+
+# 8 GPUs, 2 NUMA nodes. Pin GPUs 0-3 to node 0, GPUs 4-7 to node 1.
+bindings = [
+    {"cpunodebind": "0", "membind": "0"} for _ in range(4)
+] + [
+    {"cpunodebind": "1", "membind": "1"} for _ in range(4)
+]
+
+procs = host.spawn_procs(per_host={"gpus": 8}, proc_bind=bindings)
+trainers = procs.spawn("trainers", Trainer)
+```
+
+### Example: pin to specific CPU cores with taskset
+
+```python
+# 4 processes, each pinned to a disjoint set of cores.
+bindings = [
+    {"cpus": "0-15"},
+    {"cpus": "16-31"},
+    {"cpus": "32-47"},
+    {"cpus": "48-63"},
+]
+
+procs = host.spawn_procs(per_host={"gpus": 4}, proc_bind=bindings)
+```
+
+### Notes
+
+- The length of `proc_bind` must equal the total number of processes
+  per host (i.e. `math.prod(per_host.values())`).
+- Passing `None` (the default) disables binding entirely.
+- Custom proc launchers receive the binding configuration in
+  `LaunchOptions.proc_bind` and may apply it using backend-appropriate
+  mechanisms (e.g., systemd unit properties, Docker `--cpuset-cpus`).
 
 ---
 

--- a/hyperactor_mesh/benches/main.rs
+++ b/hyperactor_mesh/benches/main.rs
@@ -54,7 +54,7 @@ fn bench_actor_scaling(c: &mut Criterion) {
                 let instance = cx.actor_instance;
                 let mut host_mesh = test_utils::local_host_mesh(host_count).await;
                 let mut proc_mesh = host_mesh
-                    .spawn(instance, "bench", extent!(gpus = gpus))
+                    .spawn(instance, "bench", extent!(gpus = gpus), None)
                     .await
                     .unwrap();
                 let actor_mesh: ActorMesh<BenchActor> = proc_mesh
@@ -144,7 +144,7 @@ fn bench_actor_mesh_message_sizes(c: &mut Criterion) {
                         let instance = cx.actor_instance;
                         let mut host_mesh = test_utils::local_host_mesh(1).await;
                         let mut proc_mesh = host_mesh
-                            .spawn(instance, "bench", extent!(gpus = actor_count))
+                            .spawn(instance, "bench", extent!(gpus = actor_count), None)
                             .await
                             .unwrap();
                         let actor_mesh: ActorMesh<BenchActor> = proc_mesh

--- a/hyperactor_mesh/examples/dining_philosophers.rs
+++ b/hyperactor_mesh/examples/dining_philosophers.rs
@@ -303,7 +303,12 @@ async fn main() -> Result<ExitCode> {
     );
 
     let proc_mesh = host_mesh
-        .spawn(instance, "philosophers", extent!(replica = group_size))
+        .spawn(
+            instance,
+            "philosophers",
+            extent!(replica = group_size),
+            None,
+        )
         .await?;
 
     let params = PhilosopherActorParams { size: group_size };

--- a/hyperactor_mesh/examples/test_bench.rs
+++ b/hyperactor_mesh/examples/test_bench.rs
@@ -75,7 +75,7 @@ async fn main() {
     let instance = cx.actor_instance;
 
     let proc_mesh = host_mesh
-        .spawn(instance, "test", extent!(procs = 2))
+        .spawn(instance, "test", extent!(procs = 2), None)
         .await
         .unwrap();
 

--- a/hyperactor_mesh/src/actor_mesh.rs
+++ b/hyperactor_mesh/src/actor_mesh.rs
@@ -967,7 +967,10 @@ mod tests {
         // Small mesh so the test runs fast, but > page_size so we
         // cross a boundary
         let mut hm = testing::host_mesh(3).await;
-        let pm: ProcMesh = hm.spawn(instance, "test", extent!(gpus = 2)).await.unwrap();
+        let pm: ProcMesh = hm
+            .spawn(instance, "test", extent!(gpus = 2), None)
+            .await
+            .unwrap();
         let am: ActorMesh<testactor::TestActor> = pm.spawn(instance, "test", &()).await.unwrap();
 
         // 2) Build our ActorMeshRef with a tiny page size (2) to
@@ -1066,7 +1069,10 @@ mod tests {
         let supervisor = supervision_port.bind();
         let num_replicas = 4;
         let mut hm = testing::host_mesh(num_replicas).await;
-        let proc_mesh = hm.spawn(instance, "test", Extent::unity()).await.unwrap();
+        let proc_mesh = hm
+            .spawn(instance, "test", Extent::unity(), None)
+            .await
+            .unwrap();
         let child_name = Name::new("child").unwrap();
 
         // Need to use a wrapper as there's no way to customize the handler for MeshFailure
@@ -1156,10 +1162,13 @@ mod tests {
         let supervisor = supervision_port.bind();
         let num_replicas = 4;
         let mut hm = testing::host_mesh(num_replicas).await;
-        let proc_mesh = hm.spawn(instance, "test", Extent::unity()).await.unwrap();
+        let proc_mesh = hm
+            .spawn(instance, "test", Extent::unity(), None)
+            .await
+            .unwrap();
         let mut second_hm = testing::host_mesh(num_replicas).await;
         let second_proc_mesh = second_hm
-            .spawn(instance, "test2", Extent::unity())
+            .spawn(instance, "test2", Extent::unity(), None)
             .await
             .unwrap();
         let child_name = Name::new("child").unwrap();
@@ -1245,7 +1254,10 @@ mod tests {
         let supervisor = supervision_port.bind();
         let num_replicas = 4;
         let mut hm = testing::host_mesh(num_replicas).await;
-        let proc_mesh = hm.spawn(instance, "test", Extent::unity()).await.unwrap();
+        let proc_mesh = hm
+            .spawn(instance, "test", Extent::unity(), None)
+            .await
+            .unwrap();
         let child_name = Name::new("child").unwrap();
 
         // Need to use a wrapper as there's no way to customize the handler for MeshFailure
@@ -1302,7 +1314,7 @@ mod tests {
         let instance = testing::instance();
         let mut host_mesh = testing::host_mesh(4).await;
         let proc_mesh = host_mesh
-            .spawn(instance, "test", Extent::unity())
+            .spawn(instance, "test", Extent::unity(), None)
             .await
             .unwrap();
         let actor_mesh: ActorMesh<testactor::TestActor> =
@@ -1352,7 +1364,10 @@ mod tests {
 
         // Create a proc mesh with 2 hosts.
         let mut hm = testing::host_mesh(2).await;
-        let proc_mesh = hm.spawn(instance, "test", Extent::unity()).await.unwrap();
+        let proc_mesh = hm
+            .spawn(instance, "test", Extent::unity(), None)
+            .await
+            .unwrap();
 
         // Set up undeliverable message port for collecting undeliverables
         let (undeliverable_port, mut undeliverable_rx) =
@@ -1474,7 +1489,10 @@ mod tests {
 
         // Create proc mesh with 2 procs
         let mut hm = testing::host_mesh(2).await;
-        let proc_mesh = hm.spawn(instance, "test", Extent::unity()).await.unwrap();
+        let proc_mesh = hm
+            .spawn(instance, "test", Extent::unity(), None)
+            .await
+            .unwrap();
 
         // Spawn SleepActors across the mesh that will block longer
         // than timeout
@@ -1557,7 +1575,10 @@ mod tests {
 
         // Create proc mesh with 2 procs
         let mut hm = testing::host_mesh(2).await;
-        let proc_mesh = hm.spawn(instance, "test", Extent::unity()).await.unwrap();
+        let proc_mesh = hm
+            .spawn(instance, "test", Extent::unity(), None)
+            .await
+            .unwrap();
 
         // Spawn TestActors - these stop cleanly (no blocking
         // operations)

--- a/hyperactor_mesh/src/bootstrap.rs
+++ b/hyperactor_mesh/src/bootstrap.rs
@@ -1914,6 +1914,8 @@ impl BootstrapProcManager {
     }
 }
 
+pub use crate::proc_launcher::ProcBind;
+
 /// The configuration used for bootstrapped procs.
 pub struct BootstrapProcConfig {
     /// The proc's create rank.
@@ -1922,6 +1924,11 @@ pub struct BootstrapProcConfig {
     /// Config values to set on the spawned proc's global config,
     /// at the `ClientOverride` layer.
     pub client_config_override: Attrs,
+
+    /// Optional per-process CPU/NUMA binding configuration.
+    /// When set, the bootstrap command is wrapped with `numactl`
+    /// (on NUMA systems) or `taskset` (Linux fallback) before launch.
+    pub proc_bind: Option<ProcBind>,
 }
 
 #[async_trait]
@@ -2009,6 +2016,7 @@ impl ProcManager for BootstrapProcManager {
             } else {
                 None
             },
+            proc_bind: config.proc_bind.clone(),
         };
 
         // Launch via the configured launcher backend.
@@ -3236,6 +3244,7 @@ mod tests {
                 BootstrapProcConfig {
                     create_rank: 0,
                     client_config_override: Attrs::new(),
+                    proc_bind: None,
                 },
             )
             .await
@@ -3305,6 +3314,7 @@ mod tests {
                 BootstrapProcConfig {
                     create_rank: 0,
                     client_config_override: Attrs::new(),
+                    proc_bind: None,
                 },
             )
             .await
@@ -3405,7 +3415,7 @@ mod tests {
         // (4) We collect the per-host procs into a `ProcMesh` and
         // return it.
         let proc_mesh = host_mesh
-            .spawn(&instance, "p0", Extent::unity())
+            .spawn(&instance, "p0", Extent::unity(), None)
             .await
             .unwrap();
 
@@ -3486,7 +3496,7 @@ mod tests {
 
         // Spawn a ProcMesh named "p0" on the host mesh.
         let proc_mesh = host_mesh
-            .spawn(&instance, "p0", Extent::unity())
+            .spawn(&instance, "p0", Extent::unity(), None)
             .await
             .unwrap();
 

--- a/hyperactor_mesh/src/comm.rs
+++ b/hyperactor_mesh/src/comm.rs
@@ -1095,7 +1095,7 @@ mod tests {
         // can collect paths from the same process.
         let host_mesh = local_host_mesh(8).await;
         let proc_mesh = host_mesh
-            .spawn(instance, "test", extent!(gpu = 8))
+            .spawn(instance, "test", extent!(gpu = 8), None)
             .await
             .unwrap();
 
@@ -1277,7 +1277,7 @@ mod tests {
         // can collect paths from the same process.
         let host_mesh = local_host_mesh(8).await;
         let proc_mesh = host_mesh
-            .spawn(instance, "test", extent!(gpu = 8))
+            .spawn(instance, "test", extent!(gpu = 8), None)
             .await
             .unwrap();
 

--- a/hyperactor_mesh/src/host_mesh.rs
+++ b/hyperactor_mesh/src/host_mesh.rs
@@ -51,6 +51,7 @@ use crate::ValueMesh;
 use crate::alloc::Alloc;
 use crate::bootstrap::BootstrapCommand;
 use crate::bootstrap::BootstrapProcManager;
+use crate::bootstrap::ProcBind;
 pub use crate::host_mesh::host_agent::HostAgent;
 use crate::host_mesh::host_agent::HostAgentMode;
 use crate::host_mesh::host_agent::HostMeshAgentProcMeshTrampoline;
@@ -992,6 +993,12 @@ impl HostMeshRef {
     /// Spawn a ProcMesh onto this host mesh. The per_host extent specifies the shape
     /// of the procs to spawn on each host.
     ///
+    /// `proc_bind`, when provided, is a per-process CPU/NUMA binding
+    /// configuration. Its length must equal the number of ranks in
+    /// `per_host`. Each entry maps binding keys (`cpunodebind`,
+    /// `membind`, `physcpubind`, `cpus`) to their values.
+    /// Only takes effect when running on Linux.
+    ///
     /// Currently, spawn issues direct calls to each host agent. This will be fixed by
     /// maintaining a comm actor on the host service procs themselves.
     #[allow(clippy::result_large_err)]
@@ -1000,11 +1007,13 @@ impl HostMeshRef {
         cx: &C,
         name: &str,
         per_host: Extent,
+        proc_bind: Option<Vec<ProcBind>>,
     ) -> crate::Result<ProcMesh>
     where
         C::A: Handler<MeshFailure>,
     {
-        self.spawn_inner(cx, Name::new(name)?, per_host).await
+        self.spawn_inner(cx, Name::new(name)?, per_host, proc_bind)
+            .await
     }
 
     #[hyperactor::instrument(fields(host_mesh=self.name.to_string(), proc_mesh=proc_mesh_name.to_string()))]
@@ -1013,13 +1022,16 @@ impl HostMeshRef {
         cx: &C,
         proc_mesh_name: Name,
         per_host: Extent,
+        proc_bind: Option<Vec<ProcBind>>,
     ) -> crate::Result<ProcMesh>
     where
         C::A: Handler<MeshFailure>,
     {
         tracing::info!(name = "HostMeshStatus", status = "ProcMesh::Spawn::Attempt");
         tracing::info!(name = "ProcMeshStatus", status = "Spawn::Attempt",);
-        let result = self.spawn_inner_inner(cx, proc_mesh_name, per_host).await;
+        let result = self
+            .spawn_inner_inner(cx, proc_mesh_name, per_host, proc_bind)
+            .await;
         match &result {
             Ok(_) => {
                 tracing::info!(name = "HostMeshStatus", status = "ProcMesh::Spawn::Success");
@@ -1038,6 +1050,7 @@ impl HostMeshRef {
         cx: &C,
         proc_mesh_name: Name,
         per_host: Extent,
+        proc_bind: Option<Vec<ProcBind>>,
     ) -> crate::Result<ProcMesh>
     where
         C::A: Handler<MeshFailure>,
@@ -1052,6 +1065,13 @@ impl HostMeshRef {
             return Err(crate::Error::ConfigurationError(anyhow::anyhow!(
                 "per_host dims overlap with existing dims when spawning proc mesh"
             )));
+        }
+        if let Some(proc_bind) = proc_bind.as_ref() {
+            if proc_bind.len() != per_host.num_ranks() {
+                return Err(crate::Error::ConfigurationError(anyhow::anyhow!(
+                    "proc_bind length does not match per_host extent"
+                )));
+            }
         }
 
         let extent = self
@@ -1094,12 +1114,13 @@ impl HostMeshRef {
                 let create_rank = per_host.num_ranks() * host_rank + per_host_rank;
                 let proc_name = Name::new(format!("{}_{}", proc_mesh_name.name(), per_host_rank))?;
                 proc_names.push(proc_name.clone());
+                let bind = proc_bind.as_ref().map(|v| v[per_host_rank].clone());
                 host.mesh_agent()
                     .create_or_update(
                         cx,
                         proc_name.clone(),
                         resource::Rank::new(create_rank),
-                        ProcSpec::new(client_config_override.clone()),
+                        ProcSpec::new(client_config_override.clone(), bind),
                     )
                     .await
                     .map_err(|e| {
@@ -1689,7 +1710,7 @@ mod tests {
                 .unwrap();
 
             let proc_mesh1 = host_mesh
-                .spawn(instance, "test_1", Extent::unity())
+                .spawn(instance, "test_1", Extent::unity(), None)
                 .await
                 .unwrap();
 
@@ -1697,7 +1718,7 @@ mod tests {
                 proc_mesh1.spawn(instance, "test", &()).await.unwrap();
 
             let proc_mesh2 = host_mesh
-                .spawn(instance, "test_2", extent!(gpus = 3, extra = 2))
+                .spawn(instance, "test_2", extent!(gpus = 3, extra = 2), None)
                 .await
                 .unwrap();
             assert_eq!(
@@ -1829,7 +1850,7 @@ mod tests {
         let host_mesh = HostMeshRef::from_hosts(Name::new("test").unwrap(), hosts);
 
         let proc_mesh = host_mesh
-            .spawn(&testing::instance(), "test", Extent::unity())
+            .spawn(&testing::instance(), "test", Extent::unity(), None)
             .await
             .unwrap();
 
@@ -1892,7 +1913,7 @@ mod tests {
         let instance = testing::instance();
 
         let err = host_mesh
-            .spawn(&instance, "test", Extent::unity())
+            .spawn(&instance, "test", Extent::unity(), None)
             .await
             .unwrap_err();
         assert_matches!(
@@ -1938,7 +1959,7 @@ mod tests {
         let instance = testing::instance();
 
         let err = host_mesh
-            .spawn(&instance, "test", Extent::unity())
+            .spawn(&instance, "test", Extent::unity(), None)
             .await
             .unwrap_err();
         let statuses = err.into_proc_spawn_error().unwrap();
@@ -1974,7 +1995,10 @@ mod tests {
         let instance = testing::instance();
 
         let mut hm = testing::host_mesh(2).await;
-        let proc_mesh = hm.spawn(instance, "test", Extent::unity()).await.unwrap();
+        let proc_mesh = hm
+            .spawn(instance, "test", Extent::unity(), None)
+            .await
+            .unwrap();
 
         let actor_mesh: ActorMesh<testactor::TestActor> =
             proc_mesh.spawn(instance, "test", &()).await.unwrap();

--- a/hyperactor_mesh/src/host_mesh/host_agent.rs
+++ b/hyperactor_mesh/src/host_mesh/host_agent.rs
@@ -441,6 +441,7 @@ impl Handler<resource::CreateOrUpdate<ProcSpec>> for HostAgent {
                             .spec
                             .client_config_override
                             .clone(),
+                        proc_bind: create_or_update.spec.proc_bind.clone(),
                     },
                 )
                 .await

--- a/hyperactor_mesh/src/mesh_controller.rs
+++ b/hyperactor_mesh/src/mesh_controller.rs
@@ -999,7 +999,7 @@ mod tests {
         let instance = testing::instance();
         let host_mesh = local_host_mesh(2).await;
         let proc_mesh = host_mesh
-            .spawn(instance, "test", Extent::unity())
+            .spawn(instance, "test", Extent::unity(), None)
             .await
             .unwrap();
 
@@ -1113,14 +1113,14 @@ mod tests {
         // MESH_ORPHAN_TIMEOUT=2s and start the SelfCheck loop.
         let mut actor_hm = host_mesh_with_config(num_replicas).await;
         let actor_proc_mesh = actor_hm
-            .spawn(instance, "actors", Extent::unity())
+            .spawn(instance, "actors", Extent::unity(), None)
             .await
             .unwrap();
 
         // Host mesh for the wrapper + controller (will be killed).
         let mut controller_hm = host_mesh_with_config(1).await;
         let controller_proc_mesh = controller_hm
-            .spawn(instance, "controller", Extent::unity())
+            .spawn(instance, "controller", Extent::unity(), None)
             .await
             .unwrap();
 

--- a/hyperactor_mesh/src/proc_launcher.rs
+++ b/hyperactor_mesh/src/proc_launcher.rs
@@ -41,15 +41,19 @@
 //! launcher (`ManagedByLauncher`).
 #![allow(dead_code, unused_imports)] // Temporary
 
+use std::collections::HashMap;
 use std::fmt;
 use std::time::Duration;
 
 use async_trait::async_trait;
 use hyperactor::channel::ChannelAddr;
 use hyperactor::reference as hyperactor_reference;
+use serde::Deserialize;
+use serde::Serialize;
 use tokio::process::ChildStderr;
 use tokio::process::ChildStdout;
 use tokio::sync::oneshot;
+use typeuri::Named;
 
 use crate::bootstrap::BootstrapCommand;
 
@@ -158,6 +162,34 @@ pub enum ProcLauncherError {
     Other(String),
 }
 
+/// Per-process CPU/NUMA binding configuration.
+///
+/// When attached to a proc spec, the bootstrap command is wrapped with
+/// `numactl` (on NUMA systems) or `taskset` (Linux fallback) before launch.
+#[derive(Clone, Debug, Default, Serialize, Deserialize, Named)]
+pub struct ProcBind {
+    /// NUMA node for CPU binding (`numactl --cpunodebind`).
+    pub cpunodebind: Option<String>,
+    /// NUMA node for memory binding (`numactl --membind`).
+    pub membind: Option<String>,
+    /// Physical CPU list (`numactl --physcpubind`).
+    pub physcpubind: Option<String>,
+    /// CPU set for taskset fallback (`taskset -c`).
+    pub cpus: Option<String>,
+}
+wirevalue::register_type!(ProcBind);
+
+impl From<HashMap<String, String>> for ProcBind {
+    fn from(map: HashMap<String, String>) -> Self {
+        Self {
+            cpunodebind: map.get("cpunodebind").cloned(),
+            membind: map.get("membind").cloned(),
+            physcpubind: map.get("physcpubind").cloned(),
+            cpus: map.get("cpus").cloned(),
+        }
+    }
+}
+
 /// Per-launch policy computed by the manager and handed to the
 /// launcher.
 ///
@@ -224,6 +256,14 @@ pub struct LaunchOptions {
     /// env when `Some`. Other backends may ignore it or use it to
     /// wire their own forwarding mechanism.
     pub log_channel: Option<ChannelAddr>,
+
+    /// Optional CPU/NUMA binding for this proc.
+    ///
+    /// Launchers that support binding should apply it using
+    /// backend-appropriate mechanisms (e.g., `numactl` for native,
+    /// unit properties for systemd). Launchers that do not support
+    /// it may ignore this field.
+    pub proc_bind: Option<ProcBind>,
 }
 
 /// Format a human-readable process name for diagnostics and logs.

--- a/hyperactor_mesh/src/proc_launcher/native.rs
+++ b/hyperactor_mesh/src/proc_launcher/native.rs
@@ -94,6 +94,7 @@ use crate::bootstrap::BootstrapProcConfig;
 use crate::bootstrap::PROCESS_NAME_ENV;
 use crate::proc_launcher::LaunchOptions;
 use crate::proc_launcher::LaunchResult;
+use crate::proc_launcher::ProcBind;
 use crate::proc_launcher::ProcExitKind;
 use crate::proc_launcher::ProcExitResult;
 use crate::proc_launcher::ProcLauncher;
@@ -184,6 +185,57 @@ impl NativeProcLauncher {
     }
 }
 
+#[cfg(target_os = "linux")]
+/// Wrap a [`BootstrapCommand`] with `numactl` or `taskset` based on the
+/// binding config. On NUMA-capable systems the numactl keys
+/// (`cpunodebind`, `membind`, `physcpubind`) take precedence. On Linux,
+/// `cpus` falls back to `taskset -c`.
+fn wrap_command_for_binding(mut cmd: BootstrapCommand, bind: &ProcBind) -> BootstrapCommand {
+    let numa = std::path::Path::new("/sys/devices/system/node/node0").exists();
+
+    if numa {
+        let mut numactl_args = Vec::new();
+        if let Some(v) = bind.cpunodebind.as_deref() {
+            numactl_args.push(format!("--cpunodebind={v}"));
+        }
+        if let Some(v) = bind.membind.as_deref() {
+            numactl_args.push(format!("--membind={v}"));
+        }
+        if let Some(v) = bind.physcpubind.as_deref() {
+            numactl_args.push(format!("--physcpubind={v}"));
+        }
+        if !numactl_args.is_empty() {
+            numactl_args.push(cmd.program.to_string_lossy().into_owned());
+            numactl_args.append(&mut cmd.args);
+            cmd.program = "numactl".into();
+            cmd.arg0 = None;
+            cmd.args = numactl_args;
+            return cmd;
+        }
+    }
+
+    // Fallback: taskset for CPU pinning on Linux.
+    if let Some(cpus) = bind.cpus.as_deref() {
+        let mut taskset_args = vec![
+            "-c".to_string(),
+            cpus.to_string(),
+            cmd.program.to_string_lossy().into_owned(),
+        ];
+        taskset_args.append(&mut cmd.args);
+        cmd.program = "taskset".into();
+        cmd.arg0 = None;
+        cmd.args = taskset_args;
+    }
+
+    cmd
+}
+
+#[cfg(not(target_os = "linux"))]
+/// No bindings available outside of Linux.
+fn wrap_command_for_binding(cmd: BootstrapCommand, _bind: &ProcBind) -> BootstrapCommand {
+    cmd
+}
+
 /// Convert a platform `std::process::ExitStatus` into our
 /// launcher-neutral [`ProcExitKind`] representation.
 ///
@@ -265,8 +317,14 @@ impl ProcLauncher for NativeProcLauncher {
         proc_id: &hyperactor_reference::ProcId,
         opts: LaunchOptions,
     ) -> Result<LaunchResult, ProcLauncherError> {
+        // Apply NUMA/CPU binding if requested.
+        let command = match &opts.proc_bind {
+            Some(bind) => wrap_command_for_binding(opts.command.clone(), bind),
+            None => opts.command.clone(),
+        };
+
         // New Tokio Command from BootstrapCommand (template)
-        let mut cmd = opts.command.new();
+        let mut cmd = command.new();
 
         // Bootstrap payload
         cmd.env(BOOTSTRAP_MODE_ENV, opts.bootstrap_payload);
@@ -668,6 +726,7 @@ mod tests {
             want_stdio: true,
             tail_lines: 0,
             log_channel: Some(log_channel.clone()),
+            proc_bind: None,
         };
 
         let lr = launcher.launch(&proc_id, opts).await.expect("launch");
@@ -755,6 +814,7 @@ mod tests {
                 want_stdio: true,
                 tail_lines: 0,
                 log_channel: None,
+                proc_bind: None,
             };
             let lr = launcher.launch(&proc_id, opts).await.expect("launch");
             let (lines, stderr_bytes) = read_captured_lines(lr.stdio).await;
@@ -789,6 +849,7 @@ mod tests {
                 want_stdio: false,
                 tail_lines: 0,
                 log_channel: None,
+                proc_bind: None,
             };
             let lr = launcher.launch(&proc_id, opts).await.expect("launch");
 
@@ -826,6 +887,7 @@ mod tests {
             want_stdio: false,
             tail_lines: 0,
             log_channel: None,
+            proc_bind: None,
         };
 
         let lr = launcher.launch(&proc_id, opts).await.expect("launch");
@@ -864,6 +926,7 @@ mod tests {
             want_stdio: false,
             tail_lines: 0,
             log_channel: None,
+            proc_bind: None,
         };
 
         let lr = launcher.launch(&proc_id, opts).await.expect("launch");
@@ -936,6 +999,7 @@ mod tests {
             want_stdio: true,
             tail_lines: 0,
             log_channel: None,
+            proc_bind: None,
         };
 
         let lr = launcher.launch(&proc_id, opts).await.expect("launch");
@@ -1021,6 +1085,7 @@ while True:
             want_stdio: true,
             tail_lines: 0,
             log_channel: None,
+            proc_bind: None,
         };
 
         // Keep stdout in outer scope so we can read after launcher

--- a/hyperactor_mesh/src/proc_launcher/systemd.rs
+++ b/hyperactor_mesh/src/proc_launcher/systemd.rs
@@ -1200,6 +1200,7 @@ mod tests {
             want_stdio: true,
             tail_lines: 0,
             log_channel: Some(log_channel.clone()),
+            proc_bind: None,
         };
 
         let lr = launcher.launch(&proc_id, opts).await.expect("launch");
@@ -1296,6 +1297,7 @@ mod tests {
             want_stdio: false,
             tail_lines: 0,
             log_channel: None,
+            proc_bind: None,
         };
 
         let lr = launcher.launch(&proc_id, opts).await.expect("launch");
@@ -1337,6 +1339,7 @@ mod tests {
             want_stdio: false,
             tail_lines: 0,
             log_channel: None,
+            proc_bind: None,
         };
 
         let lr = launcher.launch(&proc_id, opts).await.expect("launch");
@@ -1398,6 +1401,7 @@ mod tests {
             want_stdio: false,
             tail_lines: 0,
             log_channel: None,
+            proc_bind: None,
         };
 
         let lr = launcher.launch(&proc_id, opts).await.expect("launch");
@@ -1572,6 +1576,7 @@ mod tests {
                 want_stdio: false,
                 tail_lines: 0,
                 log_channel: None,
+                proc_bind: None,
             };
 
             let lr = launcher.launch(&proc_id, opts).await.expect("launch");
@@ -1665,6 +1670,7 @@ mod tests {
             want_stdio: false,
             tail_lines: 0,
             log_channel: None,
+            proc_bind: None,
         };
 
         // IMPORTANT: lr must be mutable because we take &mut

--- a/hyperactor_mesh/src/proc_mesh.rs
+++ b/hyperactor_mesh/src/proc_mesh.rs
@@ -1427,7 +1427,7 @@ mod tests {
 
         let mut hm = testing::host_mesh(4).await;
         let proc_mesh = hm
-            .spawn(&instance, "test", extent!(gpus = 2))
+            .spawn(&instance, "test", extent!(gpus = 2), None)
             .await
             .unwrap();
         let actor_mesh = proc_mesh.spawn(instance, "test", &()).await.unwrap();
@@ -1445,7 +1445,7 @@ mod tests {
 
         let mut hm = testing::host_mesh(4).await;
         let proc_mesh = hm
-            .spawn(&instance, "test", extent!(gpus = 2))
+            .spawn(&instance, "test", extent!(gpus = 2), None)
             .await
             .unwrap();
         let err = proc_mesh

--- a/hyperactor_mesh/src/resource.rs
+++ b/hyperactor_mesh/src/resource.rs
@@ -45,6 +45,7 @@ use typeuri::Named;
 use crate::Name;
 use crate::StatusOverlay;
 use crate::bootstrap;
+use crate::bootstrap::ProcBind;
 use crate::host_mesh::host_agent::ProcState;
 use crate::proc_agent::ActorSpec;
 use crate::proc_agent::ActorState;
@@ -679,13 +680,16 @@ pub(crate) struct ProcSpec {
     /// Config values to set on the spawned proc's global config,
     /// at the `ClientOverride` layer.
     pub(crate) client_config_override: Attrs,
+    /// Optional per-process CPU/NUMA binding configuration.
+    pub(crate) proc_bind: Option<ProcBind>,
 }
 wirevalue::register_type!(ProcSpec);
 
 impl ProcSpec {
-    pub(crate) fn new(client_config_override: Attrs) -> Self {
+    pub(crate) fn new(client_config_override: Attrs, proc_bind: Option<ProcBind>) -> Self {
         Self {
             client_config_override,
+            proc_bind,
         }
     }
 }

--- a/hyperactor_mesh/src/testing.rs
+++ b/hyperactor_mesh/src/testing.rs
@@ -232,7 +232,7 @@ pub async fn local_proc_mesh(
 /// // spawn a process mesh on this host mesh with the name "test", abd per_host
 /// // extent gpu = 8.
 /// let proc_mesh = host_mesh
-///     .spawn(instance, "test", extent!(gpu = 8))
+///     .spawn(instance, "test", extent!(gpu = 8), None)
 ///     .await
 ///     .unwrap();
 /// // ... do something with the proc mesh ...

--- a/monarch_hyperactor/src/code_sync/manager.rs
+++ b/monarch_hyperactor/src/code_sync/manager.rs
@@ -614,7 +614,7 @@ mod tests {
         // Set up actor mesh with CodeSyncManager actors
         let mut host_mesh = test_utils::local_host_mesh(2).await;
         let proc_mesh = host_mesh
-            .spawn(instance, "code_sync_test", ndslice::Extent::unity())
+            .spawn(instance, "code_sync_test", ndslice::Extent::unity(), None)
             .await
             .unwrap();
 

--- a/monarch_hyperactor/src/code_sync/rsync.rs
+++ b/monarch_hyperactor/src/code_sync/rsync.rs
@@ -503,7 +503,7 @@ mod tests {
         let instance = cx.actor_instance;
         let mut host_mesh = test_utils::local_host_mesh(1).await;
         let proc_mesh = host_mesh
-            .spawn(instance, "rsync_test", ndslice::Extent::unity())
+            .spawn(instance, "rsync_test", ndslice::Extent::unity(), None)
             .await
             .unwrap();
         // Spawn actor mesh with RsyncActors

--- a/monarch_hyperactor/src/host_mesh.rs
+++ b/monarch_hyperactor/src/host_mesh.rs
@@ -17,6 +17,7 @@ use hyperactor::Instance;
 use hyperactor::Proc;
 use hyperactor_mesh::ProcMeshRef;
 use hyperactor_mesh::bootstrap::BootstrapCommand;
+use hyperactor_mesh::bootstrap::ProcBind;
 use hyperactor_mesh::bootstrap::host;
 use hyperactor_mesh::host_mesh::HostMesh;
 use hyperactor_mesh::host_mesh::HostMeshRef;
@@ -163,18 +164,21 @@ impl PyHostMesh {
         })
     }
 
+    #[pyo3(signature = (instance, name, per_host, proc_bind = None))]
     fn spawn_nonblocking(
         &self,
         instance: &PyInstance,
         name: String,
         per_host: &PyExtent,
+        proc_bind: Option<Vec<HashMap<String, String>>>,
     ) -> PyResult<PyPythonTask> {
         let host_mesh = self.mesh_ref()?.clone();
         let instance = instance.clone();
         let per_host = per_host.clone().into();
+        let proc_bind = proc_bind.map(|v| v.into_iter().map(ProcBind::from).collect());
         let mesh_impl = async move {
             let proc_mesh = host_mesh
-                .spawn(instance.deref(), &name, per_host)
+                .spawn(instance.deref(), &name, per_host, proc_bind)
                 .await
                 .map_err(to_py_error)?;
             Ok(PyProcMesh::new_owned(proc_mesh))

--- a/monarch_hyperactor/src/logging.rs
+++ b/monarch_hyperactor/src/logging.rs
@@ -612,7 +612,7 @@ mod tests {
         .expect("failed to bootstrap HostMesh");
 
         let proc_mesh = host_mesh
-            .spawn(&instance, "p0", Extent::unity())
+            .spawn(&instance, "p0", Extent::unity(), None)
             .await
             .expect("failed to spawn ProcMesh");
 

--- a/monarch_hyperactor/src/proc_launcher.rs
+++ b/monarch_hyperactor/src/proc_launcher.rs
@@ -646,6 +646,23 @@ impl ProcLauncher for ActorProcLauncher {
                     .map_err(|e| ProcLauncherError::Other(format!("set env item: {e}")))?;
             }
 
+            let py_proc_bind = opts.proc_bind.as_ref().map(|bind| {
+                let d = pyo3::types::PyDict::new(py);
+                if let Some(v) = &bind.cpunodebind {
+                    d.set_item("cpunodebind", v).unwrap();
+                }
+                if let Some(v) = &bind.membind {
+                    d.set_item("membind", v).unwrap();
+                }
+                if let Some(v) = &bind.physcpubind {
+                    d.set_item("physcpubind", v).unwrap();
+                }
+                if let Some(v) = &bind.cpus {
+                    d.set_item("cpus", v).unwrap();
+                }
+                d
+            });
+
             let py_opts = launch_opts_cls
                 .call1((
                     &opts.bootstrap_payload,
@@ -657,6 +674,7 @@ impl ProcLauncher for ActorProcLauncher {
                     opts.want_stdio,
                     opts.tail_lines,
                     opts.log_channel.as_ref().map(|a| a.to_string()),
+                    py_proc_bind,
                 ))
                 .map_err(|e| ProcLauncherError::Other(format!("construct LaunchOptions: {e}")))?;
 

--- a/monarch_hyperactor/tests/code_sync/auto_reload.rs
+++ b/monarch_hyperactor/tests/code_sync/auto_reload.rs
@@ -47,7 +47,7 @@ CONSTANT = "initial_constant"
     let instance = cx.actor_instance;
     let mut host_mesh = test_utils::local_host_mesh(1).await;
     let proc_mesh = host_mesh
-        .spawn(instance, "auto_reload_test", ndslice::Extent::unity())
+        .spawn(instance, "auto_reload_test", ndslice::Extent::unity(), None)
         .await
         .unwrap();
     let params = AutoReloadParams {};

--- a/monarch_rdma/examples/cuda_ping_pong/src/cuda_ping_pong.rs
+++ b/monarch_rdma/examples/cuda_ping_pong/src/cuda_ping_pong.rs
@@ -757,10 +757,10 @@ pub async fn run() -> Result<(), anyhow::Error> {
 
     // Create proc meshes (one proc per host mesh)
     let device_1_proc_mesh: ProcMesh = host_mesh_1
-        .spawn(&instance, "procs", Extent::unity())
+        .spawn(&instance, "procs", Extent::unity(), None)
         .await?;
     let device_2_proc_mesh: ProcMesh = host_mesh_2
-        .spawn(&instance, "procs", Extent::unity())
+        .spawn(&instance, "procs", Extent::unity(), None)
         .await?;
 
     // Create RDMA manager for the first device

--- a/monarch_rdma/examples/parameter_server/src/parameter_server.rs
+++ b/monarch_rdma/examples/parameter_server/src/parameter_server.rs
@@ -477,7 +477,9 @@ pub async fn run(num_workers: usize, num_steps: usize) -> Result<(), anyhow::Err
     let _child = command.spawn().unwrap();
 
     let host_mesh = HostMeshRef::from_hosts(Name::new("test").unwrap(), vec![host_addr]);
-    let ps_proc_mesh = host_mesh.spawn(instance, "ps", extent!(gpu = 1)).await?;
+    let ps_proc_mesh = host_mesh
+        .spawn(instance, "ps", extent!(gpu = 1), None)
+        .await?;
 
     tracing::info!(
         "creating parameter server's RDMA manager with config: {}",
@@ -496,7 +498,7 @@ pub async fn run(num_workers: usize, num_steps: usize) -> Result<(), anyhow::Err
     // Create a proc mesh for workers, where each worker is assigned to its own GPU.
     tracing::info!("creating worker proc mesh ({} workers)...", num_workers);
     let worker_proc_mesh = host_mesh
-        .spawn(instance, "workers", extent!(gpu = num_workers))
+        .spawn(instance, "workers", extent!(gpu = num_workers), None)
         .await?;
 
     tracing::info!(

--- a/monarch_rdma/src/backend/ibverbs/mlx5dv_tests.rs
+++ b/monarch_rdma/src/backend/ibverbs/mlx5dv_tests.rs
@@ -28,7 +28,6 @@ use crate::IbvConfig;
 use crate::RdmaManagerActor;
 use crate::RdmaManagerMessageClient;
 use crate::RdmaRemoteBuffer;
-use crate::cu_check;
 use crate::local_memory::RdmaLocalMemory;
 use crate::local_memory::UnsafeLocalMemory;
 use crate::register_segment_scanner;
@@ -315,6 +314,7 @@ async fn test_indirect_mkey_read_at_large_offset() -> Result<(), anyhow::Error> 
             instance,
             "mkey_test_procs",
             hyperactor_mesh::extent!(procs = 2),
+            None,
         )
         .await?;
 

--- a/python/monarch/_rust_bindings/monarch_hyperactor/host_mesh.pyi
+++ b/python/monarch/_rust_bindings/monarch_hyperactor/host_mesh.pyi
@@ -40,6 +40,7 @@ class HostMesh:
         instance: Instance,
         name: str,
         per_host: Extent,
+        proc_bind: list[dict[str, str]] | None = None,
     ) -> PythonTask[ProcMesh]:
         """
         Spawn a new actor on this mesh.

--- a/python/monarch/_src/actor/host_mesh.py
+++ b/python/monarch/_src/actor/host_mesh.py
@@ -122,18 +122,40 @@ class HostMesh(MeshTrait):
         per_host: Dict[str, int] | None = None,
         bootstrap: Callable[[], None] | Callable[[], Awaitable[None]] | None = None,
         name: str | None = None,
+        proc_bind: list[dict[str, str]] | None = None,
     ) -> "ProcMesh":
+        """Spawn a ProcMesh onto this host mesh.
+
+        Args:
+            per_host: shape of procs per host, e.g. ``{"gpus": 4}``.
+            bootstrap: optional setup callable run on each proc.
+            name: optional name for the proc mesh.
+            proc_bind: optional per-process CPU/NUMA binding config.
+                Length must equal ``math.prod(per_host.values())``.
+                Each dict maps binding keys (``cpunodebind``,
+                ``membind``, ``physcpubind``, ``cpus``) to values.
+        """
         if not per_host:
             per_host = {}
 
         if not name:
             name = "anon"
 
+        import math
+
+        procs_per_host = math.prod(per_host.values()) if per_host else 1
+        if proc_bind is not None and len(proc_bind) != procs_per_host:
+            raise ValueError(
+                f"proc_bind length ({len(proc_bind)}) must equal "
+                f"procs_per_host ({procs_per_host})"
+            )
+
         return self._spawn_nonblocking(
             name,
             Extent(list(per_host.keys()), list(per_host.values())),
             bootstrap,
             True,
+            proc_bind,
         )
 
     def _spawn_admin(self, admin_addr: Optional[str] = None) -> "Future[str]":
@@ -170,6 +192,7 @@ class HostMesh(MeshTrait):
         per_host: Extent,
         setup: Callable[[], None] | Callable[[], Awaitable[None]] | None,
         _attach_controller_controller: bool,
+        proc_bind: list[dict[str, str]] | None = None,
     ) -> "ProcMesh":
         if set(per_host.labels) & set(self._labels):
             # The rust side will catch this too, but this lets us fail fast
@@ -180,7 +203,7 @@ class HostMesh(MeshTrait):
         async def task() -> HyProcMesh:
             hy_host_mesh = await self._hy_host_mesh
             return await hy_host_mesh.spawn_nonblocking(
-                context().actor_instance._as_rust(), name, per_host
+                context().actor_instance._as_rust(), name, per_host, proc_bind
             )
 
         return ProcMesh.from_host_mesh(

--- a/python/monarch/_src/actor/proc_launcher.py
+++ b/python/monarch/_src/actor/proc_launcher.py
@@ -40,6 +40,8 @@ class LaunchOptions:
             (0 = none).
         log_channel: Optional ChannelAddr string for mesh log
             forwarding.
+        proc_bind: Optional CPU/NUMA binding configuration dict.
+            Keys may include cpunodebind, membind, physcpubind, cpus.
     """
 
     bootstrap_payload: str
@@ -51,6 +53,7 @@ class LaunchOptions:
     want_stdio: bool
     tail_lines: int
     log_channel: str | None
+    proc_bind: dict[str, str] | None
 
 
 @dataclass

--- a/python/tests/test_host_mesh.py
+++ b/python/tests/test_host_mesh.py
@@ -7,8 +7,11 @@
 # pyre-unsafe
 
 import os
+import pathlib
+import shutil
 import threading
 import time
+from typing import List, Set
 from unittest.mock import patch
 
 import cloudpickle
@@ -145,6 +148,24 @@ class PidActor(Actor):
         return os.getpid()
 
 
+class CpuAffinityActor(Actor):
+    @endpoint
+    def get_affinity(self) -> List[int]:
+        return sorted(os.sched_getaffinity(0))
+
+
+def _parse_cpu_list(s: str) -> Set[int]:
+    """Parse kernel CPU-list format (e.g. "0-3,8-11") into a set of ints."""
+    cpus = set()
+    for part in s.strip().split(","):
+        if "-" in part:
+            lo, hi = part.split("-", 1)
+            cpus.update(range(int(lo), int(hi) + 1))
+        else:
+            cpus.add(int(part))
+    return cpus
+
+
 @pytest.mark.timeout(60)
 @isolate_in_subprocess
 def test_this_host_on_client_can_spawn_actual_os_processes() -> None:
@@ -209,3 +230,68 @@ def test_root_client_does_not_leak_host_meshes() -> None:
             t.join()
 
         assert mock_get_client_context.call_count == 100
+
+
+@pytest.mark.timeout(60)
+def test_spawn_procs_proc_bind_length_mismatch() -> None:
+    host = ProcessJob({"hosts": 1}).state(cached_path=None).hosts
+    with pytest.raises(
+        ValueError, match=r"proc_bind length \(1\) must equal procs_per_host \(4\)"
+    ):
+        host.spawn_procs(
+            per_host={"gpus": 4},
+            proc_bind=[{"cpunodebind": "0"}],
+        )
+
+
+@pytest.mark.timeout(120)
+def test_spawn_procs_with_numactl_bind() -> None:
+    numa_node0 = pathlib.Path("/sys/devices/system/node/node0")
+    if not numa_node0.exists():
+        # pyre-fixme[29]: skip is a function
+        pytest.skip("NUMA node0 not available")
+    if shutil.which("numactl") is None:
+        # pyre-fixme[29]: skip is a function
+        pytest.skip("numactl binary not found")
+
+    node0_cpus = _parse_cpu_list((numa_node0 / "cpulist").read_text())
+    assert node0_cpus, "node0 has no CPUs"
+
+    host = ProcessJob({"hosts": 1}).state(cached_path=None).hosts
+    proc_mesh = host.spawn_procs(
+        name="numa_bound",
+        per_host={"gpus": 2},
+        proc_bind=[{"cpunodebind": "0"}, {"cpunodebind": "0"}],
+    )
+    am = proc_mesh.spawn("affinity", CpuAffinityActor)
+    affinities = am.get_affinity.call().get()
+    for rank, cpus in affinities.items():
+        cpu_set = set(cpus)
+        assert cpu_set, f"rank {rank} has empty affinity"
+        assert cpu_set <= node0_cpus, (
+            f"rank {rank} affinity {cpu_set} is not a subset of node0 CPUs {node0_cpus}"
+        )
+
+
+@pytest.mark.timeout(120)
+def test_spawn_procs_with_taskset_bind() -> None:
+    available = sorted(os.sched_getaffinity(0))
+    if len(available) < 2:
+        # pyre-fixme[29]: skip is a function
+        pytest.skip("fewer than 2 CPUs available")
+
+    cpu_a = available[0]
+    cpu_b = available[1]
+
+    host = ProcessJob({"hosts": 1}).state(cached_path=None).hosts
+    proc_mesh = host.spawn_procs(
+        name="taskset_bound",
+        per_host={"gpus": 2},
+        proc_bind=[{"cpus": str(cpu_a)}, {"cpus": str(cpu_b)}],
+    )
+    am = proc_mesh.spawn("affinity", CpuAffinityActor)
+    affinities = am.get_affinity.call().get()
+    observed = {frozenset(cpus) for cpus in affinities.values()}
+    assert observed == {frozenset({cpu_a}), frozenset({cpu_b})}, (
+        f"expected affinities {{{cpu_a}}} and {{{cpu_b}}}, got {affinities}"
+    )


### PR DESCRIPTION
Summary:

For some users, they want to ensure their procs are closely located with their GPU.
They can use `numactl` to pin a proc to a certain CPU socket so that it is always closest to
the GPU.
Add an option to `spawn_procs` at the Rust and Python level so users can choose when to bind
procs. The default is to not, as it is today.
`taskset` is allowed as a backup for platforms without NUMA hardware.

This is done at process spawn time so there is never a need to migrate a process off one
CPU and onto another, the memory is always nearby from as soon as the process starts.
The configuration is added to LaunchOptions, such that current and future process launchers
can customize how this is applied.

The API looks like this:
```lang=py
proc_mesh = host.spawn_procs(                                
  name="bound",                                            
  per_host={"gpus": 2},
  proc_bind=[                                              
      {"cpus": "0-3"},                                     
      {"cpus": "4-7"},                                     
  ],
)
```
The length of the "proc_bind" list needs to match the total cardinality of the
"per_host" dimensions.

Reviewed By: shayne-fletcher

Differential Revision: D96240585


