### PR TITLE
Decouple RDMA/TCP data-plane from actor loops via IbvBackend/TcpBackend (#3007)

### DIFF
--- a/monarch_rdma/examples/cuda_ping_pong/src/cuda_ping_pong.rs
+++ b/monarch_rdma/examples/cuda_ping_pong/src/cuda_ping_pong.rs
@@ -516,7 +516,8 @@ impl Handler<PerformPingPong> for CudaRdmaActor {
                 local_ibv.device_name.clone(),
                 remote_ibv.device_name.clone(),
             )
-            .await?;
+            .await?
+            .map_err(|e| anyhow::anyhow!(e))?;
 
         unsafe {
             let ibv_qp = qp.qp as *mut rdmaxcel_sys::ibv_qp;

--- a/monarch_rdma/src/backend/ibverbs.rs
+++ b/monarch_rdma/src/backend/ibverbs.rs
@@ -50,7 +50,7 @@ pub struct IbvBuffer {
     pub device_name: String,
 }
 
-/// A single RDMA op for the [`IbvSubmit`] message.
+/// A single RDMA op for the [`IbvBackend`](manager_actor::IbvBackend).
 #[derive(Debug, Clone, Named)]
 pub struct IbvOp {
     pub op_type: RdmaOpType,

--- a/monarch_rdma/src/backend/ibverbs/ibv_manager_actor_tests.rs
+++ b/monarch_rdma/src/backend/ibverbs/ibv_manager_actor_tests.rs
@@ -41,7 +41,8 @@ mod tests {
                 env.ibv_buffer_1.device_name.clone(),
                 env.ibv_buffer_2.device_name.clone(),
             )
-            .await?;
+            .await?
+            .map_err(|e| anyhow::anyhow!(e))?;
         let wr_id = qp_1.put(env.ibv_buffer_1.clone(), env.ibv_buffer_2.clone())?;
 
         // Poll for completion
@@ -79,7 +80,8 @@ mod tests {
                 env.ibv_buffer_1.device_name.clone(),
                 env.ibv_buffer_2.device_name.clone(),
             )
-            .await?;
+            .await?
+            .map_err(|e| anyhow::anyhow!(e))?;
         let wr_id = qp_1.put(env.ibv_buffer_1.clone(), env.ibv_buffer_2.clone())?;
 
         wait_for_completion(&mut qp_1, PollTarget::Send, &wr_id, 2).await?;
@@ -118,7 +120,8 @@ mod tests {
                 env.ibv_buffer_1.device_name.clone(),
                 env.ibv_buffer_2.device_name.clone(),
             )
-            .await?;
+            .await?
+            .map_err(|e| anyhow::anyhow!(e))?;
         let wr_id = qp_1.get(env.ibv_buffer_1.clone(), env.ibv_buffer_2.clone())?;
 
         // Poll for completion
@@ -148,7 +151,8 @@ mod tests {
                 env.ibv_buffer_1.device_name.clone(),
                 env.ibv_buffer_2.device_name.clone(),
             )
-            .await?;
+            .await?
+            .map_err(|e| anyhow::anyhow!(e))?;
         let wr_id = qp_1.put(env.ibv_buffer_1.clone(), env.ibv_buffer_2.clone())?;
         wait_for_completion(&mut qp_1, PollTarget::Send, &wr_id, 2).await?;
 
@@ -176,7 +180,8 @@ mod tests {
                 env.ibv_buffer_1.device_name.clone(),
                 env.ibv_buffer_2.device_name.clone(),
             )
-            .await?;
+            .await?
+            .map_err(|e| anyhow::anyhow!(e))?;
         let mut qp_2 = env
             .ibv_actor_2
             .request_queue_pair(
@@ -185,7 +190,8 @@ mod tests {
                 env.ibv_buffer_2.device_name.clone(),
                 env.ibv_buffer_1.device_name.clone(),
             )
-            .await?;
+            .await?
+            .map_err(|e| anyhow::anyhow!(e))?;
         qp_1.recv(env.ibv_buffer_1.clone(), env.ibv_buffer_2.clone())?;
         let wr_id = qp_2.put_with_recv(env.ibv_buffer_2.clone(), env.ibv_buffer_1.clone())?;
         wait_for_completion(&mut qp_2, PollTarget::Send, &wr_id, 5).await?;
@@ -214,7 +220,8 @@ mod tests {
                 env.ibv_buffer_1.device_name.clone(),
                 env.ibv_buffer_2.device_name.clone(),
             )
-            .await?;
+            .await?
+            .map_err(|e| anyhow::anyhow!(e))?;
         let wr_id = qp_1.enqueue_put(env.ibv_buffer_1.clone(), env.ibv_buffer_2.clone())?;
         qp_1.ring_doorbell()?;
         // Poll for completion
@@ -244,7 +251,8 @@ mod tests {
                 env.ibv_buffer_2.device_name.clone(),
                 env.ibv_buffer_1.device_name.clone(),
             )
-            .await?;
+            .await?
+            .map_err(|e| anyhow::anyhow!(e))?;
         let wr_id = qp_2.enqueue_get(env.ibv_buffer_2.clone(), env.ibv_buffer_1.clone())?;
         qp_2.ring_doorbell()?;
         // Poll for completion
@@ -335,7 +343,8 @@ mod tests {
                 env.ibv_buffer_1.device_name.clone(),
                 env.ibv_buffer_2.device_name.clone(),
             )
-            .await?;
+            .await?
+            .map_err(|e| anyhow::anyhow!(e))?;
         qp_1.enqueue_put(env.ibv_buffer_1.clone(), env.ibv_buffer_2.clone())?;
         ring_db_gpu(&qp_1).await?;
         // Poll for completion
@@ -374,7 +383,8 @@ mod tests {
                 env.ibv_buffer_1.device_name.clone(),
                 env.ibv_buffer_2.device_name.clone(),
             )
-            .await?;
+            .await?
+            .map_err(|e| anyhow::anyhow!(e))?;
         qp_1.enqueue_get(env.ibv_buffer_1.clone(), env.ibv_buffer_2.clone())?;
         ring_db_gpu(&qp_1).await?;
         // Poll for completion
@@ -412,7 +422,8 @@ mod tests {
                 env.ibv_buffer_1.device_name.clone(),
                 env.ibv_buffer_2.device_name.clone(),
             )
-            .await?;
+            .await?
+            .map_err(|e| anyhow::anyhow!(e))?;
         let mut qp_2 = env
             .ibv_actor_2
             .request_queue_pair(
@@ -421,7 +432,8 @@ mod tests {
                 env.ibv_buffer_2.device_name.clone(),
                 env.ibv_buffer_1.device_name.clone(),
             )
-            .await?;
+            .await?
+            .map_err(|e| anyhow::anyhow!(e))?;
         recv_wqe_gpu(
             &mut qp_1,
             &env.ibv_buffer_1,
@@ -469,7 +481,8 @@ mod tests {
                 env.ibv_buffer_1.device_name.clone(),
                 env.ibv_buffer_2.device_name.clone(),
             )
-            .await?;
+            .await?
+            .map_err(|e| anyhow::anyhow!(e))?;
         let wr_id = qp_1.put(env.ibv_buffer_1.clone(), env.ibv_buffer_2.clone())?;
 
         wait_for_completion(&mut qp_1, PollTarget::Send, &wr_id, 5).await?;
@@ -504,7 +517,8 @@ mod tests {
                 env.ibv_buffer_1.device_name.clone(),
                 env.ibv_buffer_2.device_name.clone(),
             )
-            .await?;
+            .await?
+            .map_err(|e| anyhow::anyhow!(e))?;
         let wr_id = qp_1.put(env.ibv_buffer_1.clone(), env.ibv_buffer_2.clone())?;
 
         wait_for_completion(&mut qp_1, PollTarget::Send, &wr_id, 5).await?;

--- a/monarch_rdma/src/backend/ibverbs/manager_actor.rs
+++ b/monarch_rdma/src/backend/ibverbs/manager_actor.rs
@@ -88,7 +88,7 @@ pub enum IbvManagerMessage {
         self_device: String,
         other_device: String,
         #[reply]
-        reply: reference::OncePortRef<IbvQueuePair>,
+        reply: reference::OncePortRef<Result<IbvQueuePair, String>>,
     },
     Connect {
         other: reference::ActorRef<IbvManagerActor>,
@@ -126,16 +126,22 @@ pub enum IbvManagerMessage {
 }
 wirevalue::register_type!(IbvManagerMessage);
 
-/// Local-only submit message for the [`IbvManagerActor`].
-///
-/// Not serializable because [`IbvOp`] contains `Arc<dyn RdmaLocalMemory>`.
-/// Can only be sent within the same process.
+/// Local-only messages for MR registration/deregistration.
 #[derive(Handler, HandleClient, Debug)]
-pub struct IbvSubmit {
-    pub ops: Vec<IbvOp>,
-    pub timeout: Duration,
-    #[reply]
-    pub reply: OncePortHandle<Result<(), String>>,
+pub enum IbvManagerLocalMessage {
+    /// Register a memory region, returning the MR view and device name.
+    RegisterMr {
+        addr: usize,
+        size: usize,
+        #[reply]
+        reply: OncePortHandle<Result<(IbvMemoryRegionView, String), String>>,
+    },
+    /// Deregister a memory region by its MR view id.
+    DeregisterMr {
+        id: usize,
+        #[reply]
+        reply: OncePortHandle<Result<(), String>>,
+    },
 }
 
 /// Manages all ibverbs-specific RDMA resources and operations.
@@ -481,7 +487,7 @@ impl IbvManagerActor {
         None
     }
 
-    fn register_mr(
+    fn register_mr_impl(
         &mut self,
         addr: usize,
         size: usize,
@@ -623,7 +629,7 @@ impl IbvManagerActor {
         }
     }
 
-    fn deregister_mr(&mut self, id: usize) -> Result<(), anyhow::Error> {
+    fn deregister_mr_impl(&mut self, id: usize) -> Result<(), anyhow::Error> {
         if let Some(mr_ptr) = self.mr_map.remove(&id) {
             if mr_ptr != 0 {
                 unsafe {
@@ -634,178 +640,9 @@ impl IbvManagerActor {
         Ok(())
     }
 
-    /// Waits for the completion of RDMA operations.
-    ///
-    /// Polls the completion queue until all specified work requests complete
-    /// or until the timeout is reached.
-    ///
-    /// # Arguments
-    /// * `local_buf` - The ibv buffer describing the local side of the RDMA ops
-    /// * `qp` - The RDMA Queue Pair to poll for completion
-    /// * `poll_target` - Which CQ to poll (Send or Recv)
-    /// * `expected_wr_ids` - The work request IDs to wait for
-    /// * `timeout` - Timeout for the RDMA operation to complete.
-    async fn wait_for_completion(
-        &self,
-        local_buf: &IbvBuffer,
-        qp: &mut IbvQueuePair,
-        poll_target: PollTarget,
-        expected_wr_ids: &[u64],
-        timeout: Duration,
-    ) -> Result<(), anyhow::Error> {
-        let start_time = std::time::Instant::now();
-
-        let mut remaining: std::collections::HashSet<u64> =
-            expected_wr_ids.iter().copied().collect();
-
-        while start_time.elapsed() < timeout {
-            if remaining.is_empty() {
-                return Ok(());
-            }
-
-            let wr_ids_to_poll: Vec<u64> = remaining.iter().copied().collect();
-            match qp.poll_completion(poll_target, &wr_ids_to_poll) {
-                Ok(completions) => {
-                    for (wr_id, _wc) in completions {
-                        remaining.remove(&wr_id);
-                    }
-                    if remaining.is_empty() {
-                        return Ok(());
-                    }
-                    tokio::time::sleep(Duration::from_millis(1)).await;
-                }
-                Err(e) => {
-                    return Err(anyhow::anyhow!(
-                        "RDMA polling completion failed: {} [lkey={}, rkey={}, addr=0x{:x}, size={}]",
-                        e,
-                        local_buf.lkey,
-                        local_buf.rkey,
-                        local_buf.addr,
-                        local_buf.size
-                    ));
-                }
-            }
-        }
-        tracing::error!(
-            "timed out while waiting on request completion for wr_ids={:?}",
-            remaining
-        );
-        Err(anyhow::anyhow!(
-            "[ibv_buffer({:?})] rdma operation did not complete in time (expected wr_ids={:?})",
-            local_buf,
-            expected_wr_ids
-        ))
-    }
-
-    /// Core submit logic: registers local MR, resolves remote
-    /// IbvBuffer lazily, executes the op, and deregisters local MR.
-    async fn execute_op(
+    async fn request_queue_pair_impl(
         &mut self,
         cx: &Context<'_, Self>,
-        op: IbvOp,
-        timeout: Duration,
-    ) -> Result<(), anyhow::Error> {
-        // Register the local memory to get an IbvBuffer
-        let (local_mrv, local_device_name) =
-            self.register_mr(op.local_memory.addr(), op.local_memory.size())?;
-        let local_buffer = IbvBuffer {
-            mr_id: local_mrv.id,
-            lkey: local_mrv.lkey,
-            rkey: local_mrv.rkey,
-            addr: local_mrv.rdma_addr,
-            size: local_mrv.size,
-            device_name: local_device_name,
-        };
-
-        let op_result = async {
-            let mut qp = self
-                .request_queue_pair(
-                    cx,
-                    op.remote_manager.clone(),
-                    local_buffer.device_name.clone(),
-                    op.remote_buffer.device_name.clone(),
-                )
-                .await?;
-
-            let wr_id = match op.op_type {
-                RdmaOpType::WriteFromLocal => qp.put(local_buffer.clone(), op.remote_buffer)?,
-                RdmaOpType::ReadIntoLocal => qp.get(local_buffer.clone(), op.remote_buffer)?,
-            };
-
-            self.wait_for_completion(&local_buffer, &mut qp, PollTarget::Send, &wr_id, timeout)
-                .await
-        }
-        .await;
-
-        // Always deregister the locally registered MR
-        let dereg_result = self.deregister_mr(local_buffer.mr_id);
-
-        match (op_result, dereg_result) {
-            (Ok(()), Ok(())) => Ok(()),
-            (Err(e), Ok(())) => Err(e),
-            (Ok(()), Err(e)) => Err(e),
-            (Err(op_err), Err(dereg_err)) => Err(anyhow::anyhow!(
-                "deregister MR error: {}; op error: {}",
-                dereg_err,
-                op_err
-            )),
-        }
-    }
-}
-
-#[async_trait]
-#[hyperactor::handle(IbvManagerMessage)]
-impl IbvManagerMessageHandler for IbvManagerActor {
-    async fn request_buffer(
-        &mut self,
-        cx: &Context<Self>,
-        remote_buf_id: usize,
-    ) -> Result<Option<IbvBuffer>, anyhow::Error> {
-        // If already registered, return it
-        if let Some(buf) = self.buffer_registrations.get(&remote_buf_id) {
-            return Ok(Some(buf.clone()));
-        }
-
-        // Resolve local memory from the parent RdmaManagerActor.
-        // Returns None if the buffer has already been released or does
-        // not exist.
-        let owner = self.owner.get().unwrap();
-        let mem = match owner.request_local_memory(cx, remote_buf_id).await? {
-            Some(mem) => mem,
-            None => return Ok(None),
-        };
-
-        let (mrv, device_name) = self.register_mr(mem.addr(), mem.size())?;
-
-        let buf = IbvBuffer {
-            mr_id: mrv.id,
-            lkey: mrv.lkey,
-            rkey: mrv.rkey,
-            addr: mrv.rdma_addr,
-            size: mrv.size,
-            device_name,
-        };
-
-        self.buffer_registrations.insert(remote_buf_id, buf.clone());
-
-        Ok(Some(buf))
-    }
-
-    async fn release_buffer(
-        &mut self,
-        _cx: &Context<Self>,
-        remote_buf_id: usize,
-    ) -> Result<(), anyhow::Error> {
-        if let Some(buf) = self.buffer_registrations.remove(&remote_buf_id) {
-            self.deregister_mr(buf.mr_id)
-                .map_err(|e| anyhow::anyhow!("could not deregister buffer: {}", e))?;
-        }
-        Ok(())
-    }
-
-    async fn request_queue_pair(
-        &mut self,
-        cx: &Context<Self>,
         other: reference::ActorRef<IbvManagerActor>,
         self_device: String,
         other_device: String,
@@ -972,6 +809,70 @@ impl IbvManagerMessageHandler for IbvManagerActor {
 
         result
     }
+}
+
+#[async_trait]
+#[hyperactor::handle(IbvManagerMessage)]
+impl IbvManagerMessageHandler for IbvManagerActor {
+    async fn request_buffer(
+        &mut self,
+        cx: &Context<Self>,
+        remote_buf_id: usize,
+    ) -> Result<Option<IbvBuffer>, anyhow::Error> {
+        // If already registered, return it
+        if let Some(buf) = self.buffer_registrations.get(&remote_buf_id) {
+            return Ok(Some(buf.clone()));
+        }
+
+        // Resolve local memory from the parent RdmaManagerActor.
+        // Returns None if the buffer has already been released or does
+        // not exist.
+        let owner = self.owner.get().unwrap();
+        let mem = match owner.request_local_memory(cx, remote_buf_id).await? {
+            Some(mem) => mem,
+            None => return Ok(None),
+        };
+
+        let (mrv, device_name) = self.register_mr_impl(mem.addr(), mem.size())?;
+
+        let buf = IbvBuffer {
+            mr_id: mrv.id,
+            lkey: mrv.lkey,
+            rkey: mrv.rkey,
+            addr: mrv.rdma_addr,
+            size: mrv.size,
+            device_name,
+        };
+
+        self.buffer_registrations.insert(remote_buf_id, buf.clone());
+
+        Ok(Some(buf))
+    }
+
+    async fn release_buffer(
+        &mut self,
+        _cx: &Context<Self>,
+        remote_buf_id: usize,
+    ) -> Result<(), anyhow::Error> {
+        if let Some(buf) = self.buffer_registrations.remove(&remote_buf_id) {
+            self.deregister_mr_impl(buf.mr_id)
+                .map_err(|e| anyhow::anyhow!("could not deregister buffer: {}", e))?;
+        }
+        Ok(())
+    }
+
+    async fn request_queue_pair(
+        &mut self,
+        cx: &Context<Self>,
+        other: reference::ActorRef<IbvManagerActor>,
+        self_device: String,
+        other_device: String,
+    ) -> Result<Result<IbvQueuePair, String>, anyhow::Error> {
+        Ok(self
+            .request_queue_pair_impl(cx, other, self_device, other_device)
+            .await
+            .map_err(|e| e.to_string()))
+    }
 
     async fn connect(
         &mut self,
@@ -1133,41 +1034,167 @@ impl IbvManagerMessageHandler for IbvManagerActor {
 }
 
 #[async_trait]
-#[hyperactor::handle(IbvSubmit)]
-impl IbvSubmitHandler for IbvManagerActor {
-    async fn ibv_submit(
+#[hyperactor::handle(IbvManagerLocalMessage)]
+impl IbvManagerLocalMessageHandler for IbvManagerActor {
+    async fn register_mr(
         &mut self,
-        cx: &Context<Self>,
-        ops: Vec<IbvOp>,
-        timeout: Duration,
+        _cx: &Context<Self>,
+        addr: usize,
+        size: usize,
+    ) -> Result<Result<(IbvMemoryRegionView, String), String>, anyhow::Error> {
+        Ok(self.register_mr_impl(addr, size).map_err(|e| e.to_string()))
+    }
+
+    async fn deregister_mr(
+        &mut self,
+        _cx: &Context<Self>,
+        id: usize,
     ) -> Result<Result<(), String>, anyhow::Error> {
-        let deadline = Instant::now() + timeout;
-        let mut result = Ok(());
-        for op in ops {
-            let remaining = deadline.saturating_duration_since(Instant::now());
-            if remaining.is_zero() {
-                result = Err("submit timed out".to_string());
-                break;
+        Ok(self.deregister_mr_impl(id).map_err(|e| e.to_string()))
+    }
+}
+
+/// Wrapper around [`ActorHandle<IbvManagerActor>`] that moves the RDMA
+/// data-plane (post send/recv, poll CQ) off the actor loop while keeping
+/// state-mutating operations (MR registration/deregistration, QP management)
+/// serialized through actor messages.
+#[derive(Debug, Clone)]
+pub struct IbvBackend(pub ActorHandle<IbvManagerActor>);
+
+impl std::ops::Deref for IbvBackend {
+    type Target = ActorHandle<IbvManagerActor>;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl IbvBackend {
+    /// Waits for the completion of RDMA operations.
+    ///
+    /// Polls the completion queue until all specified work requests complete
+    /// or until the timeout is reached. Pure CQ polling — no actor state needed.
+    async fn wait_for_completion(
+        local_buf: &IbvBuffer,
+        qp: &mut IbvQueuePair,
+        poll_target: PollTarget,
+        expected_wr_ids: &[u64],
+        timeout: Duration,
+    ) -> Result<(), anyhow::Error> {
+        let start_time = std::time::Instant::now();
+
+        let mut remaining: std::collections::HashSet<u64> =
+            expected_wr_ids.iter().copied().collect();
+
+        while start_time.elapsed() < timeout {
+            if remaining.is_empty() {
+                return Ok(());
             }
-            if let Err(e) = self.execute_op(cx, op, remaining).await {
-                result = Err(e.to_string());
-                break;
+
+            let wr_ids_to_poll: Vec<u64> = remaining.iter().copied().collect();
+            match qp.poll_completion(poll_target, &wr_ids_to_poll) {
+                Ok(completions) => {
+                    for (wr_id, _wc) in completions {
+                        remaining.remove(&wr_id);
+                    }
+                    if remaining.is_empty() {
+                        return Ok(());
+                    }
+                    tokio::time::sleep(Duration::from_millis(1)).await;
+                }
+                Err(e) => {
+                    return Err(anyhow::anyhow!(
+                        "RDMA polling completion failed: {} [lkey={}, rkey={}, addr=0x{:x}, size={}]",
+                        e,
+                        local_buf.lkey,
+                        local_buf.rkey,
+                        local_buf.addr,
+                        local_buf.size
+                    ));
+                }
             }
         }
-        Ok(result)
+        tracing::error!(
+            "timed out while waiting on request completion for wr_ids={:?}",
+            remaining
+        );
+        Err(anyhow::anyhow!(
+            "[ibv_buffer({:?})] rdma operation did not complete in time (expected wr_ids={:?})",
+            local_buf,
+            expected_wr_ids
+        ))
+    }
+
+    /// Core submit logic: registers local MR via actor message, resolves remote
+    /// IbvBuffer lazily, executes the op locally, and deregisters local MR.
+    async fn execute_op(
+        &self,
+        cx: &(impl hyperactor::context::Actor + Send + Sync),
+        op: IbvOp,
+        timeout: Duration,
+    ) -> Result<(), anyhow::Error> {
+        // Register the local memory via actor message
+        let (local_mrv, local_device_name) = self
+            .register_mr(cx, op.local_memory.addr(), op.local_memory.size())
+            .await?
+            .map_err(|e| anyhow::anyhow!(e))?;
+
+        let local_buffer = IbvBuffer {
+            mr_id: local_mrv.id,
+            lkey: local_mrv.lkey,
+            rkey: local_mrv.rkey,
+            addr: local_mrv.rdma_addr,
+            size: local_mrv.size,
+            device_name: local_device_name,
+        };
+
+        let op_result = async {
+            let mut qp = self
+                .request_queue_pair(
+                    cx,
+                    op.remote_manager.clone(),
+                    local_buffer.device_name.clone(),
+                    op.remote_buffer.device_name.clone(),
+                )
+                .await?
+                .map_err(|e| anyhow::anyhow!(e))?;
+
+            let wr_id = match op.op_type {
+                RdmaOpType::WriteFromLocal => qp.put(local_buffer.clone(), op.remote_buffer)?,
+                RdmaOpType::ReadIntoLocal => qp.get(local_buffer.clone(), op.remote_buffer)?,
+            };
+
+            Self::wait_for_completion(&local_buffer, &mut qp, PollTarget::Send, &wr_id, timeout)
+                .await
+        }
+        .await;
+
+        // Always deregister the locally registered MR via actor message
+        let dereg_result = self
+            .deregister_mr(cx, local_buffer.mr_id)
+            .await?
+            .map_err(|e| anyhow::anyhow!(e));
+
+        match (op_result, dereg_result) {
+            (Ok(()), Ok(())) => Ok(()),
+            (Err(e), Ok(())) => Err(e),
+            (Ok(()), Err(e)) => Err(e),
+            (Err(op_err), Err(dereg_err)) => Err(anyhow::anyhow!(
+                "deregister MR error: {}; op error: {}",
+                dereg_err,
+                op_err
+            )),
+        }
     }
 }
 
 #[async_trait]
-impl RdmaBackend for ActorHandle<IbvManagerActor> {
+impl RdmaBackend for IbvBackend {
     type TransportInfo = ();
 
     /// Submit a batch of RDMA operations.
     ///
-    /// Delegates to the [`IbvManagerActor`], which manages QPs and connections
-    /// internally. Each op is routed based on its type (read/write).
-    /// Registers local memory on the fly; remote buffers are lazily
-    /// resolved via [`IbvManagerMessageClient::request_buffer`].
+    /// Resolves ibv ops, then executes each directly — registering/deregistering
+    /// MRs via actor messages, while performing QP put/get and CQ polling locally.
     async fn submit(
         &mut self,
         cx: &(impl hyperactor::context::Actor + Send + Sync),
@@ -1189,9 +1216,15 @@ impl RdmaBackend for ActorHandle<IbvManagerActor> {
             });
         }
 
-        <Self as IbvSubmitClient>::ibv_submit(self, cx, ibv_ops, timeout)
-            .await?
-            .map_err(|e: String| anyhow::anyhow!(e))
+        let deadline = Instant::now() + timeout;
+        for op in ibv_ops {
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            if remaining.is_zero() {
+                return Err(anyhow::anyhow!("submit timed out"));
+            }
+            self.execute_op(cx, op, remaining).await?;
+        }
+        Ok(())
     }
 
     fn transport_level(&self) -> RdmaTransportLevel {

--- a/monarch_rdma/src/backend/tcp.rs
+++ b/monarch_rdma/src/backend/tcp.rs
@@ -22,7 +22,7 @@ use manager_actor::TcpManagerActor;
 use crate::RdmaLocalMemory;
 use crate::RdmaOpType;
 
-/// A single operation for the [`TcpSubmit`] local message.
+/// A single operation for the [`TcpBackend`](manager_actor::TcpBackend).
 #[derive(Debug)]
 pub struct TcpOp {
     pub op_type: RdmaOpType,

--- a/monarch_rdma/src/backend/tcp/manager_actor.rs
+++ b/monarch_rdma/src/backend/tcp/manager_actor.rs
@@ -26,10 +26,8 @@ use hyperactor::Context;
 use hyperactor::HandleClient;
 use hyperactor::Handler;
 use hyperactor::Instance;
-use hyperactor::OncePortHandle;
 use hyperactor::RefClient;
 use hyperactor::context;
-use hyperactor::context::Mailbox;
 use hyperactor::reference::OncePortRef;
 use serde::Deserialize;
 use serde::Serialize;
@@ -79,17 +77,6 @@ pub enum TcpManagerMessage {
 }
 wirevalue::register_type!(TcpManagerMessage);
 
-/// Local-only submit message for the [`TcpManagerActor`].
-///
-/// Not serializable because [`TcpOp`] contains `Arc<dyn RdmaLocalMemory>`.
-#[derive(Handler, HandleClient, Debug)]
-pub struct TcpSubmit {
-    pub ops: Vec<TcpOp>,
-    pub timeout: Duration,
-    #[reply]
-    pub reply: OncePortHandle<Result<(), String>>,
-}
-
 /// TCP fallback RDMA backend actor.
 ///
 /// Spawned as a child of [`RdmaManagerActor`]. Transfers buffer data
@@ -119,122 +106,6 @@ impl TcpManagerActor {
         tcp_ref
             .downcast_handle(client)
             .ok_or_else(|| anyhow::anyhow!("TcpManagerActor is not in the local process"))
-    }
-
-    /// Return true if the remote TCP manager is ourselves.
-    fn is_same_actor(cx: &Context<'_, Self>, op: &TcpOp) -> bool {
-        cx.mailbox().actor_id() == op.remote_tcp_manager.actor_id()
-    }
-
-    /// Execute a write operation: read local memory in chunks and write
-    /// them into the remote buffer.
-    ///
-    /// When the remote buffer is in the same process, calls the
-    /// `write_chunk` handler directly to avoid deadlocking on ourselves.
-    async fn execute_write(
-        &mut self,
-        cx: &Context<'_, Self>,
-        op: &TcpOp,
-        chunk_size: usize,
-        deadline: Instant,
-    ) -> Result<()> {
-        let same_process = Self::is_same_actor(cx, op);
-        let size = op.local_memory.size();
-        let mut offset = 0;
-
-        while offset < size {
-            let remaining = deadline.saturating_duration_since(Instant::now());
-            if remaining.is_zero() {
-                anyhow::bail!("tcp write timed out");
-            }
-
-            let len = std::cmp::min(chunk_size, size - offset);
-
-            let mut buf = vec![0u8; len];
-            op.local_memory.read_at(offset, &mut buf)?;
-            let data = Part::from(Bytes::from(buf));
-
-            if same_process {
-                tokio_timeout(
-                    remaining,
-                    self.write_chunk(cx, op.remote_buf_id, offset, data),
-                )
-                .await
-                .map_err(|_| anyhow::anyhow!("tcp write chunk timed out"))??
-                .map_err(|e| anyhow::anyhow!(e))?;
-            } else {
-                tokio_timeout(
-                    remaining,
-                    op.remote_tcp_manager
-                        .write_chunk(cx, op.remote_buf_id, offset, data),
-                )
-                .await
-                .map_err(|_| anyhow::anyhow!("tcp write chunk timed out"))??
-                .map_err(|e| anyhow::anyhow!(e))?;
-            }
-
-            offset += len;
-        }
-
-        Ok(())
-    }
-
-    /// Execute a read operation: request chunks from the remote buffer
-    /// and write them into local memory.
-    ///
-    /// When the remote buffer is in the same process, calls the
-    /// `read_chunk` handler directly to avoid deadlocking on ourselves.
-    async fn execute_read(
-        &mut self,
-        cx: &Context<'_, Self>,
-        op: &TcpOp,
-        chunk_size: usize,
-        deadline: Instant,
-    ) -> Result<()> {
-        let same_process = Self::is_same_actor(cx, op);
-        let size = op.local_memory.size();
-        let mut offset = 0;
-
-        while offset < size {
-            let remaining = deadline.saturating_duration_since(Instant::now());
-            if remaining.is_zero() {
-                anyhow::bail!("tcp read timed out");
-            }
-
-            let len = std::cmp::min(chunk_size, size - offset);
-
-            let chunk = if same_process {
-                tokio_timeout(
-                    remaining,
-                    self.read_chunk(cx, op.remote_buf_id, offset, len),
-                )
-                .await
-                .map_err(|_| anyhow::anyhow!("tcp read chunk timed out"))??
-                .map_err(|e| anyhow::anyhow!(e))?
-            } else {
-                tokio_timeout(
-                    remaining,
-                    op.remote_tcp_manager
-                        .read_chunk(cx, op.remote_buf_id, offset, len),
-                )
-                .await
-                .map_err(|_| anyhow::anyhow!("tcp read chunk timed out"))??
-                .map_err(|e| anyhow::anyhow!(e))?
-            };
-            let data = chunk.0.into_bytes();
-
-            anyhow::ensure!(
-                data.len() == len,
-                "tcp read chunk size mismatch: expected {len}, got {}",
-                data.len()
-            );
-
-            op.local_memory.write_at(offset, &data)?;
-
-            offset += len;
-        }
-
-        Ok(())
     }
 }
 
@@ -298,74 +169,153 @@ impl TcpManagerMessageHandler for TcpManagerActor {
     }
 }
 
-#[async_trait]
-#[hyperactor::handle(TcpSubmit)]
-impl TcpSubmitHandler for TcpManagerActor {
-    async fn tcp_submit(
-        &mut self,
-        cx: &Context<Self>,
-        ops: Vec<TcpOp>,
-        timeout: Duration,
-    ) -> Result<Result<(), String>, anyhow::Error> {
-        let chunk_size =
-            hyperactor_config::global::get(crate::config::RDMA_MAX_CHUNK_SIZE_MB) * 1024 * 1024;
-        let deadline = Instant::now() + timeout;
-        let mut result = Ok(());
+/// Wrapper around [`ActorHandle<TcpManagerActor>`] that moves the TCP
+/// data-plane (chunked reads/writes) off the actor loop while keeping
+/// buffer resolution serialized through actor messages.
+///
+/// Because submit logic now runs outside the actor loop, same-process
+/// messages no longer deadlock — the actor loop is free to handle
+/// `WriteChunk`/`ReadChunk` messages.
+#[derive(Debug, Clone)]
+pub struct TcpBackend(pub ActorHandle<TcpManagerActor>);
 
-        for op in &ops {
+impl std::ops::Deref for TcpBackend {
+    type Target = ActorHandle<TcpManagerActor>;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl TcpBackend {
+    /// Execute a write operation: read local memory in chunks and write
+    /// them into the remote buffer via actor messages.
+    async fn execute_write(
+        &self,
+        cx: &(impl context::Actor + Send + Sync),
+        op: &TcpOp,
+        chunk_size: usize,
+        deadline: Instant,
+    ) -> Result<()> {
+        let size = op.local_memory.size();
+        let mut offset = 0;
+
+        while offset < size {
             let remaining = deadline.saturating_duration_since(Instant::now());
             if remaining.is_zero() {
-                result = Err("tcp submit timed out".to_string());
-                break;
+                anyhow::bail!("tcp write timed out");
             }
 
-            let op_result = match op.op_type {
-                RdmaOpType::WriteFromLocal => {
-                    self.execute_write(cx, op, chunk_size, deadline).await
-                }
-                RdmaOpType::ReadIntoLocal => self.execute_read(cx, op, chunk_size, deadline).await,
-            };
+            let len = std::cmp::min(chunk_size, size - offset);
 
-            if let Err(e) = op_result {
-                result = Err(e.to_string());
-                break;
-            }
+            let mut buf = vec![0u8; len];
+            op.local_memory.read_at(offset, &mut buf)?;
+            let data = Part::from(Bytes::from(buf));
+
+            tokio_timeout(
+                remaining,
+                op.remote_tcp_manager
+                    .write_chunk(cx, op.remote_buf_id, offset, data),
+            )
+            .await
+            .map_err(|_| anyhow::anyhow!("tcp write chunk timed out"))??
+            .map_err(|e| anyhow::anyhow!(e))?;
+
+            offset += len;
         }
 
-        Ok(result)
+        Ok(())
+    }
+
+    /// Execute a read operation: request chunks from the remote buffer
+    /// and write them into local memory via actor messages.
+    async fn execute_read(
+        &self,
+        cx: &(impl context::Actor + Send + Sync),
+        op: &TcpOp,
+        chunk_size: usize,
+        deadline: Instant,
+    ) -> Result<()> {
+        let size = op.local_memory.size();
+        let mut offset = 0;
+
+        while offset < size {
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            if remaining.is_zero() {
+                anyhow::bail!("tcp read timed out");
+            }
+
+            let len = std::cmp::min(chunk_size, size - offset);
+
+            let chunk = tokio_timeout(
+                remaining,
+                op.remote_tcp_manager
+                    .read_chunk(cx, op.remote_buf_id, offset, len),
+            )
+            .await
+            .map_err(|_| anyhow::anyhow!("tcp read chunk timed out"))??
+            .map_err(|e| anyhow::anyhow!(e))?;
+            let data = chunk.0.into_bytes();
+
+            anyhow::ensure!(
+                data.len() == len,
+                "tcp read chunk size mismatch: expected {len}, got {}",
+                data.len()
+            );
+
+            op.local_memory.write_at(offset, &data)?;
+
+            offset += len;
+        }
+
+        Ok(())
     }
 }
 
 #[async_trait]
-impl RdmaBackend for ActorHandle<TcpManagerActor> {
+impl RdmaBackend for TcpBackend {
     type TransportInfo = ();
 
     /// Submit a batch of RDMA operations over TCP.
     ///
     /// Each operation's remote buffer is resolved to its TCP backend
-    /// context, then the batch is delegated to the local
-    /// [`TcpManagerActor`] via [`TcpSubmit`].
+    /// context, then executed directly — sending chunked write/read
+    /// messages to the remote [`TcpManagerActor`].
     async fn submit(
         &mut self,
         cx: &(impl context::Actor + Send + Sync),
         ops: Vec<RdmaOp>,
         timeout: Duration,
     ) -> Result<()> {
-        let mut tcp_ops = Vec::with_capacity(ops.len());
+        let chunk_size =
+            hyperactor_config::global::get(crate::config::RDMA_MAX_CHUNK_SIZE_MB) * 1024 * 1024;
+        let deadline = Instant::now() + timeout;
 
         for op in ops {
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            if remaining.is_zero() {
+                anyhow::bail!("tcp submit timed out");
+            }
+
             let (remote_tcp_mgr, remote_buf_id) = op.remote.resolve_tcp()?;
-            tcp_ops.push(TcpOp {
-                op_type: op.op_type,
+            let tcp_op = TcpOp {
+                op_type: op.op_type.clone(),
                 local_memory: op.local,
                 remote_tcp_manager: remote_tcp_mgr,
                 remote_buf_id,
-            });
+            };
+
+            match tcp_op.op_type {
+                RdmaOpType::WriteFromLocal => {
+                    self.execute_write(cx, &tcp_op, chunk_size, deadline)
+                        .await?;
+                }
+                RdmaOpType::ReadIntoLocal => {
+                    self.execute_read(cx, &tcp_op, chunk_size, deadline).await?;
+                }
+            }
         }
 
-        <Self as TcpSubmitClient>::tcp_submit(self, cx, tcp_ops, timeout)
-            .await?
-            .map_err(|e| anyhow::anyhow!(e))
+        Ok(())
     }
 
     fn transport_level(&self) -> RdmaTransportLevel {
@@ -383,12 +333,12 @@ mod tests {
     use std::sync::atomic::AtomicUsize;
     use std::sync::atomic::Ordering;
 
-    use hyperactor::ActorHandle;
     use hyperactor::Proc;
     use hyperactor::RemoteSpawn;
     use hyperactor::channel::ChannelAddr;
     use hyperactor_config::Flattrs;
 
+    use super::TcpBackend;
     use super::TcpManagerActor;
     use crate::RdmaManagerMessageClient;
     use crate::RdmaOp;
@@ -406,8 +356,8 @@ mod tests {
         _proc_2: Proc,
         instance_1: hyperactor::Instance<()>,
         _instance_2: hyperactor::Instance<()>,
-        tcp_handle_1: ActorHandle<TcpManagerActor>,
-        tcp_handle_2: ActorHandle<TcpManagerActor>,
+        tcp_handle_1: TcpBackend,
+        tcp_handle_2: TcpBackend,
         rdma_buf_1: crate::RdmaRemoteBuffer,
         rdma_buf_2: crate::RdmaRemoteBuffer,
         local_mem_1: Arc<dyn RdmaLocalMemory>,
@@ -444,14 +394,18 @@ mod tests {
 
         // Resolve local TcpManagerActor handles for direct backend access.
         let tcp_ref_1 = rdma_handle_1.get_tcp_actor_ref(&instance_1).await?;
-        let tcp_handle_1 = tcp_ref_1
-            .downcast_handle(&instance_1)
-            .ok_or_else(|| anyhow::anyhow!("tcp actor 1 not local"))?;
+        let tcp_handle_1 = TcpBackend(
+            tcp_ref_1
+                .downcast_handle(&instance_1)
+                .ok_or_else(|| anyhow::anyhow!("tcp actor 1 not local"))?,
+        );
 
         let tcp_ref_2 = rdma_handle_2.get_tcp_actor_ref(&instance_2).await?;
-        let tcp_handle_2 = tcp_ref_2
-            .downcast_handle(&instance_2)
-            .ok_or_else(|| anyhow::anyhow!("tcp actor 2 not local"))?;
+        let tcp_handle_2 = TcpBackend(
+            tcp_ref_2
+                .downcast_handle(&instance_2)
+                .ok_or_else(|| anyhow::anyhow!("tcp actor 2 not local"))?,
+        );
 
         // Allocate CPU buffers.
         let mut cpu_buf_1 = vec![0u8; buffer_size].into_boxed_slice();
@@ -892,7 +846,7 @@ mod tests {
     struct SameProcTcpTestEnv {
         _proc: Proc,
         instance: hyperactor::Instance<()>,
-        tcp_handle: ActorHandle<TcpManagerActor>,
+        tcp_handle: TcpBackend,
         _rdma_buf_1: crate::RdmaRemoteBuffer,
         rdma_buf_2: crate::RdmaRemoteBuffer,
         local_mem_1: Arc<dyn RdmaLocalMemory>,
@@ -914,9 +868,11 @@ mod tests {
         let rdma_handle = proc.spawn("rdma_manager", rdma_actor)?;
 
         let tcp_ref = rdma_handle.get_tcp_actor_ref(&instance).await?;
-        let tcp_handle = tcp_ref
-            .downcast_handle(&instance)
-            .ok_or_else(|| anyhow::anyhow!("tcp actor not local"))?;
+        let tcp_handle = TcpBackend(
+            tcp_ref
+                .downcast_handle(&instance)
+                .ok_or_else(|| anyhow::anyhow!("tcp actor not local"))?,
+        );
 
         let mut cpu_buf_1 = vec![0u8; buffer_size].into_boxed_slice();
         let ptr_1 = cpu_buf_1.as_mut_ptr() as usize;

--- a/monarch_rdma/src/rdma_components.rs
+++ b/monarch_rdma/src/rdma_components.rs
@@ -46,7 +46,6 @@ use std::result::Result;
 use std::sync::Arc;
 use std::time::Duration;
 
-use hyperactor::ActorHandle;
 use hyperactor::ActorRef;
 use hyperactor::context;
 use hyperactor::reference;
@@ -61,8 +60,10 @@ use crate::ReleaseBufferClient;
 use crate::backend::RdmaBackend;
 use crate::backend::RdmaRemoteBackendContext;
 use crate::backend::ibverbs::IbvBuffer;
+use crate::backend::ibverbs::manager_actor::IbvBackend;
 use crate::backend::ibverbs::manager_actor::IbvManagerActor;
 use crate::backend::ibverbs::manager_actor::IbvManagerMessageClient;
+use crate::backend::tcp::manager_actor::TcpBackend;
 use crate::backend::tcp::manager_actor::TcpManagerActor;
 use crate::local_memory::RdmaLocalMemory;
 
@@ -86,8 +87,8 @@ wirevalue::register_type!(RdmaRemoteBuffer);
 /// on `submit`), so we use an enum that delegates to the concrete handle.
 #[derive(Debug)]
 pub enum RdmaLocalBackend {
-    Ibv(ActorHandle<IbvManagerActor>),
-    Tcp(ActorHandle<TcpManagerActor>),
+    Ibv(IbvBackend),
+    Tcp(TcpBackend),
 }
 
 impl RdmaLocalBackend {
@@ -116,8 +117,8 @@ impl RdmaRemoteBuffer {
         client: &(impl context::Actor + Send + Sync),
     ) -> Result<RdmaLocalBackend, anyhow::Error> {
         if self.has_ibverbs_backend() {
-            if let Ok(ibv_backend) = IbvManagerActor::local_handle(client).await {
-                return Ok(RdmaLocalBackend::Ibv(ibv_backend));
+            if let Ok(ibv_handle) = IbvManagerActor::local_handle(client).await {
+                return Ok(RdmaLocalBackend::Ibv(IbvBackend(ibv_handle)));
             }
 
             return self
@@ -194,8 +195,8 @@ impl RdmaRemoteBuffer {
 
         tracing::warn!("falling back to TCP transport ({reason})");
 
-        let tcp_backend = TcpManagerActor::local_handle(client).await?;
-        Ok(RdmaLocalBackend::Tcp(tcp_backend))
+        let tcp_handle = TcpManagerActor::local_handle(client).await?;
+        Ok(RdmaLocalBackend::Tcp(TcpBackend(tcp_handle)))
     }
 
     /// Drop the buffer and release remote handles.

--- a/python/tests/rdma_load_test.py
+++ b/python/tests/rdma_load_test.py
@@ -24,12 +24,20 @@ if __name__ == "__main__":
         default=100,
         help="Number of test iterations (default: 100)",
     )
-    parser.add_argument(
+    device_group = parser.add_mutually_exclusive_group()
+    device_group.add_argument(
         "--device",
         type=str,
         nargs=2,
         default=["cpu", "cpu"],
         help="Two devices for actor0 and actor1: cpu or cuda:X where X is 0-7 (default: ['cpu', 'cpu'])",
+    )
+    device_group.add_argument(
+        "--device-pairs",
+        type=str,
+        nargs="+",
+        default=None,
+        help="Device pairs for multi-pair mode, e.g.: cuda:0,cuda:1 cuda:2,cuda:3",
     )
     parser.add_argument(
         "--operation",
@@ -74,7 +82,7 @@ else:
 
 # pyre-ignore
 import torch
-from monarch.actor import Actor, endpoint, this_host
+from monarch.actor import Actor, endpoint, ProcMesh, this_host
 from monarch.rdma import RDMABuffer
 
 
@@ -166,6 +174,7 @@ class RDMATest(Actor):
 
         # cleanup
         await buffer.drop()
+        del tensor, byte_view
 
     @endpoint
     async def recv(self, rdma_buffer, shape, dtype, is_warmup):
@@ -193,6 +202,8 @@ class RDMATest(Actor):
         if not is_warmup:
             self.timing_data.append(elapsed)
             self.size_data.append(size_elem)
+
+        del tensor, byte_view
 
     @endpoint
     async def print_statistics(self, calc_bwd: bool = False):
@@ -344,6 +355,124 @@ async def main(
     await mesh_1.stop()
 
 
+def validate_device(device: str) -> str:
+    """Validate and return a device string, falling back to cpu if needed."""
+    device = device.lower()
+    if device == "cpu":
+        return device
+    if device.startswith("cuda:"):
+        device_id = -1
+        try:
+            device_id = int(device.split(":")[1])
+            if device_id < 0 or device_id > 7:
+                print(f"Error: CUDA device ID must be 0-7. Got: {device_id}")
+                exit(1)
+        except (ValueError, IndexError):
+            print(
+                f"Error: Invalid device format. Use 'cpu' or 'cuda:X' where X is 0-7. Got: {device}"
+            )
+            exit(1)
+        if not torch.cuda.is_available():
+            print("Warning: CUDA requested but not available. Falling back to CPU.")
+            return "cpu"
+        elif device_id >= torch.cuda.device_count():
+            print(
+                f"Warning: CUDA device {device_id} not available. "
+                f"Available devices: 0-{torch.cuda.device_count() - 1}. Falling back to CPU."
+            )
+            return "cpu"
+        return device
+    print(
+        f"Error: Invalid device format. Use 'cpu' or 'cuda:X' where X is 0-7. Got: {device}"
+    )
+    exit(1)
+
+
+async def run_pair(
+    label: str,
+    mesh_left: ProcMesh,
+    mesh_right: ProcMesh,
+    device_left: str,
+    device_right: str,
+    operation: str,
+    size_mb: int,
+    iterations: int,
+    warmup_iterations: int,
+    concurrency: int,
+):
+    """Run a single device pair's warmup + timed iterations. Returns (label, actor_0, actor_1, elapsed)."""
+    actor_0 = mesh_left.spawn(
+        f"rdma_{label}_left", RDMATest, device_left, operation, size_mb
+    )
+    actor_1 = mesh_right.spawn(
+        f"rdma_{label}_right", RDMATest, device_right, operation, size_mb
+    )
+    await actor_0.set_other_actor.call(actor_1)
+
+    for _ in range(warmup_iterations):
+        await actor_0.send.call(is_warmup=True, concurrency=concurrency)
+
+    start = time.time()
+    for _ in range(iterations):
+        await actor_0.send.call(concurrency=concurrency)
+    elapsed = time.time() - start
+
+    return label, actor_0, actor_1, elapsed
+
+
+async def main_multi_pair(
+    device_pairs: list[tuple[str, str]],
+    iterations: int = 100,
+    operation: str = "write",
+    size_mb: int = 64,
+    warmup_iterations: int = 10,
+    concurrency: int = 1,
+):
+    mesh_left = this_host().spawn_procs()
+    mesh_right = this_host().spawn_procs()
+
+    tasks = []
+    for i, (dev_l, dev_r) in enumerate(device_pairs):
+        label = f"pair{i}_{dev_l}_{dev_r}".replace(":", "")
+        tasks.append(
+            run_pair(
+                label,
+                mesh_left,
+                mesh_right,
+                dev_l,
+                dev_r,
+                operation,
+                size_mb,
+                iterations,
+                warmup_iterations,
+                concurrency,
+            )
+        )
+
+    results = await asyncio.gather(*tasks)
+
+    # Per-pair statistics
+    for label, actor_0, actor_1, elapsed in results:
+        print(f"\n{'#' * 60}")
+        print(f"# {label}")
+        print(f"{'#' * 60}")
+        await actor_0.print_batch_statistics.call(
+            concurrency=concurrency, total_elapsed_time=elapsed
+        )
+        await actor_1.print_statistics.call(calc_bwd=True)
+
+    # Aggregate summary
+    total_elapsed = max(r[3] for r in results)
+    print(f"\n{'=' * 60}")
+    print("AGGREGATE MULTI-PAIR SUMMARY")
+    print(f"{'=' * 60}")
+    print(f"  Pairs: {len(device_pairs)}")
+    print(f"  Max wall-clock time across pairs: {total_elapsed:.3f} s")
+
+    await mesh_left.stop()
+    await mesh_right.stop()
+
+
 if __name__ == "__main__":
     assert args
 
@@ -352,50 +481,40 @@ if __name__ == "__main__":
         print(f"Error: --size must be a multiple of 4. Got: {args.size}")
         exit(1)
 
-    # Parse and validate device list
-    devices = [device.lower() for device in args.device]
-    validated_devices = []
-
-    for i, device in enumerate(devices):
-        if device == "cpu":
-            validated_devices.append(device)  # CPU is always valid
-        elif device.startswith("cuda:"):
-            # Validate CUDA device format
-            try:
-                device_id = int(device.split(":")[1])
-                if device_id < 0 or device_id > 7:
-                    print(f"Error: CUDA device ID must be 0-7. Got: {device_id}")
-                    exit(1)
-            except (ValueError, IndexError):
+    if args.device_pairs is not None:
+        # Multi-pair mode
+        parsed_pairs = []
+        for pair_str in args.device_pairs:
+            parts = pair_str.split(",")
+            if len(parts) != 2:
                 print(
-                    f"Error: Invalid device format. Use 'cpu' or 'cuda:X' where X is 0-7. Got: {args.device[i]}"
+                    f"Error: Each device pair must be two devices separated by comma. Got: {pair_str}"
                 )
                 exit(1)
+            dev_l = validate_device(parts[0])
+            dev_r = validate_device(parts[1])
+            parsed_pairs.append((dev_l, dev_r))
 
-            # Check if CUDA is available
-            if not torch.cuda.is_available():
-                print("Warning: CUDA requested but not available. Falling back to CPU.")
-                validated_devices.append("cpu")
-            elif device_id >= torch.cuda.device_count():
-                print(
-                    f"Warning: CUDA device {device_id} not available. Available devices: 0-{torch.cuda.device_count() - 1}. Falling back to CPU."
-                )
-                validated_devices.append("cpu")
-            else:
-                validated_devices.append(device)
-        else:
-            print(
-                f"Error: Invalid device format. Use 'cpu' or 'cuda:X' where X is 0-7. Got: {args.device[i]}"
+        asyncio.run(
+            main_multi_pair(
+                parsed_pairs,
+                args.iterations,
+                args.operation,
+                args.size,
+                args.warmup_iterations,
+                args.concurrency,
             )
-            exit(1)
-
-    asyncio.run(
-        main(
-            validated_devices,
-            args.iterations,
-            args.operation,
-            args.size,
-            args.warmup_iterations,
-            args.concurrency,
         )
-    )
+    else:
+        # Single-pair mode
+        validated_devices = [validate_device(d) for d in args.device]
+        asyncio.run(
+            main(
+                validated_devices,
+                args.iterations,
+                args.operation,
+                args.size,
+                args.warmup_iterations,
+                args.concurrency,
+            )
+        )


### PR DESCRIPTION
Summary:

Move RDMA data-plane operations (post send/recv, poll CQ, chunked TCP
reads/writes) off the single-threaded actor loops into new `IbvBackend`
and `TcpBackend` wrapper types. State-mutating operations (MR
registration/deregistration, QP management, buffer resolution) remain
serialized through actor messages.

For ibverbs: `IbvSubmit` is replaced by `IbvManagerLocalMessage` enum
with `RegisterMr`/`DeregisterMr` variants. `execute_op` and
`wait_for_completion` move to `IbvBackend`, which calls MR
registration/deregistration via handle messages and does QP put/get +
CQ polling locally. `RequestQueuePair` now returns
`Result<Result<IbvQueuePair, String>, ...>` so errors propagate through
the reply port.

For TCP: `TcpSubmit` is removed. `execute_write`/`execute_read` move to
`TcpBackend`. The same-process optimization (direct handler calls to
avoid deadlock) is removed since submit logic now runs outside the actor
loop, leaving it free to handle `WriteChunk`/`ReadChunk` messages.

`RdmaLocalBackend` enum variants now hold `IbvBackend`/`TcpBackend`
instead of raw `ActorHandle`s.

**Benchmark: multi-pair RDMA ping-pong, 1 GB, 100 iterations**

On my devgpu, GPUs 0–3 map to one NIC (~24 GB/s cap) and GPUs 4–7 map
to a second NIC. Before this change, all RDMA operations ran serially
through the actor loop regardless of NIC, so total throughput plateaued
at ~25 GB/s. After this change, operations on independent NICs run in
parallel, scaling to ~51 GB/s at 4 pairs.

Command (example for 4 pairs, concurrency=1):
```
buck2 run fbcode//mode/dev-nosan -c 'fbcode.enable_gpu_sections=true' -c 'fbcode.nvcc_arch=a100,h100a' -c 'hpc_comms.use_ncclx=stable' fbcode//monarch/python/tests:rdma_load_test -- --device-pairs cuda:0,cuda:1 cuda:2,cuda:3 cuda:4,cuda:5 cuda:6,cuda:7 --operation ping-pong --size 1024 --iterations 100 --concurrency 1
```

| Pairs | HEAD total GB/s | BASE total GB/s | Speedup |
|-------|-----------------|-----------------|---------|
| 1     | 22–25           | 22–24           | 1.0x    |
| 2     | 25–26           | 25              | 1.0x    |
| 3     | 48–50           | 25              | 2.0x    |
| 4     | 51              | 25              | 2.0x    |

At 3 pairs, pair 4,5 (sole occupant of NIC 2) hits ~24 GB/s while pairs
0,1 and 2,3 (sharing NIC 1) each get ~13 GB/s — confirming per-NIC
saturation. At 4 pairs (two per NIC), bandwidth divides evenly at
~13 GB/s per pair. Concurrency (1/2/4 concurrent ops per pair) has
negligible effect; the bottleneck was in the serialized backend, not
operation-level queuing.

Per-pair latency drops 45–55% at 3–4 pairs (e.g. 79 ms vs. 175 ms
average batch time at 4 pairs, concurrency=1).

Reviewed By: cpuhrsch

Differential Revision: D96523742


