### PR TITLE
Per-device PD segment registration (#3043)

### DIFF
--- a/monarch_rdma/Cargo.toml
+++ b/monarch_rdma/Cargo.toml
@@ -33,3 +33,6 @@ timed_test = { version = "0.0.0", path = "../timed_test" }
 [features]
 cuda = []
 default = ["cuda"]
+
+[lints]
+rust = { unexpected_cfgs = { check-cfg = ["cfg(test_8_gpus)"], level = "warn" } }

--- a/monarch_rdma/src/backend/ibverbs/manager_actor.rs
+++ b/monarch_rdma/src/backend/ibverbs/manager_actor.rs
@@ -177,6 +177,10 @@ pub struct IbvManagerActor {
     // This is populated during actor initialization using the device selection algorithm
     pci_to_device: HashMap<String, IbvDevice>,
 
+    /// Maps CUDA device ordinal to IbvDevice (the optimal RDMA NIC for that GPU).
+    /// `None` if the device has no mapped NIC.
+    cuda_device_to_ibv_device: Vec<Option<IbvDevice>>,
+
     // Map from buffer_id to registration details.
     buffer_registrations: HashMap<usize, IbvBuffer>,
 }
@@ -314,7 +318,24 @@ impl IbvManagerActor {
             pci_to_device.len()
         );
 
-        Ok(Self {
+        // Build per-CUDA-device NIC mapping
+        let cuda_device_count = unsafe {
+            let mut count: i32 = 0;
+            rdmaxcel_sys::rdmaxcel_cuDeviceGetCount(&mut count);
+            count.max(0) as usize
+        };
+        let mut cuda_device_to_ibv_device = Vec::with_capacity(cuda_device_count);
+        for ordinal in 0..cuda_device_count {
+            let device = crate::device_selection::get_cuda_pci_address(&ordinal.to_string())
+                .and_then(|pci_addr| pci_to_device.get(&pci_addr).cloned());
+            cuda_device_to_ibv_device.push(device);
+        }
+        tracing::debug!(
+            "Built per-device NIC mapping for {} CUDA devices",
+            cuda_device_count,
+        );
+
+        let mut actor = Self {
             owner: OnceLock::new(),
             device_qps: HashMap::new(),
             pending_qp_creation: Arc::new(Mutex::new(HashSet::new())),
@@ -324,8 +345,27 @@ impl IbvManagerActor {
             mr_map: HashMap::new(),
             mrv_id: 0,
             pci_to_device,
+            cuda_device_to_ibv_device,
             buffer_registrations: HashMap::new(),
-        })
+        };
+
+        // Eagerly create domains for each unique NIC so PDs/QPs are ready
+        // at segment registration time.
+        if mlx5dv_enabled {
+            let mut seen = HashSet::new();
+            let devices_to_init: Vec<IbvDevice> = actor
+                .cuda_device_to_ibv_device
+                .iter()
+                .flatten()
+                .filter(|d| seen.insert(d.name().clone()))
+                .cloned()
+                .collect();
+            for device in &devices_to_init {
+                actor.get_or_create_device_domain(device.name(), device)?;
+            }
+        }
+
+        Ok(actor)
     }
 
     /// Get or create a domain and loopback QP for the specified RDMA device
@@ -381,12 +421,44 @@ impl IbvManagerActor {
         Ok((domain, qp))
     }
 
+    /// Build parallel PD/QP arrays indexed by CUDA device ordinal
+    /// for the C++ register_segments call.
+    fn build_per_device_pd_qp_arrays(
+        &self,
+    ) -> (
+        Vec<*mut rdmaxcel_sys::ibv_pd>,
+        Vec<*mut rdmaxcel_sys::rdmaxcel_qp_t>,
+    ) {
+        let mut pds = Vec::with_capacity(self.cuda_device_to_ibv_device.len());
+        let mut qps = Vec::with_capacity(self.cuda_device_to_ibv_device.len());
+        for maybe_device in &self.cuda_device_to_ibv_device {
+            if let Some(device) = maybe_device {
+                if let Some((domain, qp)) = self.device_domains.get(device.name()) {
+                    pds.push(domain.pd);
+                    qps.push(
+                        qp.as_ref()
+                            .map(|q| q.qp as *mut rdmaxcel_sys::rdmaxcel_qp_t)
+                            .unwrap_or(std::ptr::null_mut()),
+                    );
+                } else {
+                    pds.push(std::ptr::null_mut());
+                    qps.push(std::ptr::null_mut());
+                }
+            } else {
+                pds.push(std::ptr::null_mut());
+                qps.push(std::ptr::null_mut());
+            }
+        }
+        (pds, qps)
+    }
+
     fn find_cuda_segment_for_address(
         &mut self,
         addr: usize,
         size: usize,
+        pd: *mut rdmaxcel_sys::ibv_pd,
     ) -> Option<IbvMemoryRegionView> {
-        let registered_segments = get_registered_cuda_segments();
+        let registered_segments = get_registered_cuda_segments(pd);
         for segment in registered_segments {
             let start_addr = segment.phys_address;
             let end_addr = start_addr + segment.phys_size;
@@ -427,28 +499,19 @@ impl IbvManagerActor {
             let mut selected_rdma_device = None;
 
             if is_cuda {
-                // Use rdmaxcel utility to get PCI address from CUDA pointer
-                let mut pci_addr_buf: [std::os::raw::c_char; 16] = [0; 16]; // Enough space for "ffff:ff:ff.0\0"
-                let err = rdmaxcel_sys::get_cuda_pci_address_from_ptr(
-                    addr as rdmaxcel_sys::CUdeviceptr,
-                    pci_addr_buf.as_mut_ptr(),
-                    pci_addr_buf.len(),
+                // Get device ordinal from the CUDA pointer
+                let mut device_ordinal: i32 = -1;
+                let err = rdmaxcel_sys::rdmaxcel_cuPointerGetAttribute(
+                    &mut device_ordinal as *mut _ as *mut std::ffi::c_void,
+                    rdmaxcel_sys::CU_POINTER_ATTRIBUTE_DEVICE_ORDINAL,
+                    ptr,
                 );
-                if err != 0 {
-                    let error_msg = get_rdmaxcel_error_message(err);
-                    return Err(anyhow::anyhow!(
-                        "RdmaXcel get_cuda_pci_address_from_ptr failed (addr: 0x{:x}, size: {}): {}",
-                        addr,
-                        size,
-                        error_msg
-                    ));
+                if err == rdmaxcel_sys::CUDA_SUCCESS && device_ordinal >= 0 {
+                    selected_rdma_device = self
+                        .cuda_device_to_ibv_device
+                        .get(device_ordinal as usize)
+                        .and_then(|d| d.clone());
                 }
-
-                // Convert C string to Rust string
-                let pci_addr = std::ffi::CStr::from_ptr(pci_addr_buf.as_ptr())
-                    .to_str()
-                    .unwrap();
-                selected_rdma_device = self.pci_to_device.get(pci_addr).cloned();
             }
 
             // Determine the RDMA device to use
@@ -467,7 +530,7 @@ impl IbvManagerActor {
             );
 
             // Get or create domain and loopback QP for this device
-            let (domain, qp) = self.get_or_create_device_domain(&device_name, &rdma_device)?;
+            let (domain, _qp) = self.get_or_create_device_domain(&device_name, &rdma_device)?;
 
             let access = if crate::efa::is_efa_device() {
                 crate::efa::mr_access_flags()
@@ -486,18 +549,20 @@ impl IbvManagerActor {
                 let mut segment_mrv = None;
                 if self.mlx5dv_enabled {
                     // Try to find in already registered segments
-                    segment_mrv = self.find_cuda_segment_for_address(addr, size);
+                    segment_mrv = self.find_cuda_segment_for_address(addr, size, domain.pd);
 
                     // If not found, trigger a re-sync with the allocator and retry
                     if segment_mrv.is_none() {
+                        let (mut pds, mut qps) = self.build_per_device_pd_qp_arrays();
                         let err = rdmaxcel_sys::register_segments(
-                            domain.pd,
-                            qp.unwrap().qp as *mut rdmaxcel_sys::rdmaxcel_qp_t,
+                            pds.as_mut_ptr(),
+                            qps.as_mut_ptr(),
+                            pds.len() as i32,
                         );
                         // Only retry if register_segments succeeded
                         // If it fails (e.g., scanner returns 0 segments), we'll fall back to dmabuf
                         if err == 0 {
-                            segment_mrv = self.find_cuda_segment_for_address(addr, size);
+                            segment_mrv = self.find_cuda_segment_for_address(addr, size, domain.pd);
                         }
                     }
                 }

--- a/monarch_rdma/src/backend/ibverbs/mlx5dv_tests.rs
+++ b/monarch_rdma/src/backend/ibverbs/mlx5dv_tests.rs
@@ -9,7 +9,6 @@
 //! Tests for mlx5dv-specific functionality (indirect mkeys, segment scanning).
 
 use std::sync::Arc;
-use std::sync::OnceLock;
 
 use async_trait::async_trait;
 use hyperactor::Actor;
@@ -24,6 +23,11 @@ use hyperactor_mesh::context;
 use hyperactor_mesh::host_mesh::HostMesh;
 use ndslice::ViewExt;
 
+use super::test_utils::CudaAllocation;
+use super::test_utils::CudaAllocator;
+use super::test_utils::cuda_allocator_scanner;
+#[cfg(test_8_gpus)]
+use super::test_utils::find_devices_on_different_nics;
 use crate::IbvConfig;
 use crate::RdmaManagerActor;
 use crate::RdmaManagerMessageClient;
@@ -33,41 +37,19 @@ use crate::local_memory::UnsafeLocalMemory;
 use crate::register_segment_scanner;
 
 // ---------------------------------------------------------------------------
-// Helpers: segment scanner, sender actor, receiver actor
+// Helpers: sender actor, receiver actor
 // ---------------------------------------------------------------------------
 
-static SCANNER_CFG: OnceLock<(usize, usize, i32)> = OnceLock::new();
-
-unsafe extern "C" fn test_scanner(
-    out: *mut rdmaxcel_sys::rdmaxcel_scanned_segment_t,
-    max: usize,
-) -> usize {
-    let Some(&(base, size, device)) = SCANNER_CFG.get() else {
-        return 0;
-    };
-    if max == 0 || out.is_null() {
-        return 1;
-    }
-    // SAFETY: caller guarantees `out` points to a buffer of at least `max` entries.
-    unsafe {
-        *out = rdmaxcel_sys::rdmaxcel_scanned_segment_t {
-            address: base,
-            size,
-            device,
-            is_expandable: 0,
-        };
-    }
-    1
-}
-
-/// Runs in the sender's child process. Initializes CUDA, allocates GPU memory,
-/// registers the segment scanner, and registers sub-buffers with the RDMA manager.
+/// Runs in the sender's child process. Allocates GPU memory via CudaAllocator,
+/// registers sub-buffers with the RDMA manager, and can free the allocation on
+/// request. Allocate and register are separate messages so that multiple senders
+/// can allocate first (making all segments visible to the scanner) before any
+/// of them trigger registration.
 #[hyperactor::export(spawn = true, handlers = [SenderMessage])]
 #[derive(Debug)]
 struct SenderActor {
     device: i32,
-    // CUcontext stored as usize so we don't need a Send+Sync newtype wrapper.
-    cuda_ctx: usize,
+    allocation: Option<CudaAllocation>,
 }
 
 impl Actor for SenderActor {}
@@ -77,19 +59,11 @@ impl RemoteSpawn for SenderActor {
     type Params = i32;
 
     async fn new(device_id: i32, _env: Flattrs) -> Result<Self, anyhow::Error> {
-        unsafe {
-            cu_check!(rdmaxcel_sys::rdmaxcel_cuInit(0));
-            let mut dev: rdmaxcel_sys::CUdevice = std::mem::zeroed();
-            cu_check!(rdmaxcel_sys::rdmaxcel_cuDeviceGet(&mut dev, device_id));
-            let mut ctx: rdmaxcel_sys::CUcontext = std::mem::zeroed();
-            cu_check!(rdmaxcel_sys::rdmaxcel_cuCtxCreate_v2(
-                &mut ctx, 0, device_id
-            ));
-            Ok(Self {
-                device: device_id,
-                cuda_ctx: ctx as usize,
-            })
-        }
+        register_segment_scanner(Some(cuda_allocator_scanner));
+        Ok(Self {
+            device: device_id,
+            allocation: None,
+        })
     }
 }
 
@@ -102,102 +76,86 @@ impl RemoteSpawn for SenderActor {
     Debug
 )]
 enum SenderMessage {
-    AllocateAndRegister {
+    /// Allocate GPU memory for later registration.
+    Allocate {
         total_size: usize,
-        buf0_offset: usize,
-        buf0_size: usize,
-        buf1_offset: usize,
-        buf1_size: usize,
+        #[reply]
+        reply: reference::OncePortRef<()>,
+    },
+    /// Register sub-buffers from the previous allocation with the RDMA manager.
+    Register {
+        buffers: Vec<(usize, usize)>,
         rdma_manager: reference::ActorRef<RdmaManagerActor>,
         #[reply]
-        reply: reference::OncePortRef<(RdmaRemoteBuffer, RdmaRemoteBuffer)>,
+        reply: reference::OncePortRef<Vec<RdmaRemoteBuffer>>,
+    },
+    FreeAllocation {
+        #[reply]
+        reply: reference::OncePortRef<()>,
     },
 }
 
 #[async_trait]
 #[hyperactor::handle(SenderMessage)]
 impl SenderMessageHandler for SenderActor {
-    async fn allocate_and_register(
+    async fn allocate(
+        &mut self,
+        _cx: &Context<Self>,
+        total_size: usize,
+    ) -> Result<(), anyhow::Error> {
+        self.allocation = Some(CudaAllocator::get().allocate(self.device, total_size));
+        Ok(())
+    }
+
+    async fn register(
         &mut self,
         cx: &Context<Self>,
-        total_size: usize,
-        buf0_offset: usize,
-        buf0_size: usize,
-        buf1_offset: usize,
-        buf1_size: usize,
+        buffers: Vec<(usize, usize)>,
         rdma_manager: reference::ActorRef<RdmaManagerActor>,
-    ) -> Result<(RdmaRemoteBuffer, RdmaRemoteBuffer), anyhow::Error> {
-        let (dptr, padded_size) = unsafe {
-            let ctx = self.cuda_ctx as rdmaxcel_sys::CUcontext;
+    ) -> Result<Vec<RdmaRemoteBuffer>, anyhow::Error> {
+        let alloc = self
+            .allocation
+            .ok_or_else(|| anyhow::anyhow!("register called before allocate"))?;
+
+        for (i, &(offset, size)) in buffers.iter().enumerate() {
+            anyhow::ensure!(
+                offset + size <= alloc.size,
+                "buffer {i} exceeds allocation: offset=0x{offset:x} size={size} padded={}",
+                alloc.size
+            );
+        }
+
+        // CudaAllocator::allocate already retained the primary context; set it
+        // as current so subsequent CUDA calls on this thread use the right device.
+        unsafe {
+            let mut dev: rdmaxcel_sys::CUdevice = std::mem::zeroed();
+            cu_check!(rdmaxcel_sys::rdmaxcel_cuDeviceGet(&mut dev, self.device));
+            let mut ctx: rdmaxcel_sys::CUcontext = std::mem::zeroed();
+            cu_check!(rdmaxcel_sys::rdmaxcel_cuDevicePrimaryCtxRetain(
+                &mut ctx, dev
+            ));
             cu_check!(rdmaxcel_sys::rdmaxcel_cuCtxSetCurrent(ctx));
-
-            let mut granularity: usize = 0;
-            let mut prop: rdmaxcel_sys::CUmemAllocationProp = std::mem::zeroed();
-            prop.type_ = rdmaxcel_sys::CU_MEM_ALLOCATION_TYPE_PINNED;
-            prop.location.type_ = rdmaxcel_sys::CU_MEM_LOCATION_TYPE_DEVICE;
-            prop.location.id = self.device;
-            prop.allocFlags.gpuDirectRDMACapable = 1;
-            prop.requestedHandleTypes = rdmaxcel_sys::CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR;
-
-            cu_check!(rdmaxcel_sys::rdmaxcel_cuMemGetAllocationGranularity(
-                &mut granularity,
-                &prop,
-                rdmaxcel_sys::CU_MEM_ALLOC_GRANULARITY_MINIMUM,
-            ));
-
-            let padded = ((total_size - 1) / granularity + 1) * granularity;
-
-            let mut handle: rdmaxcel_sys::CUmemGenericAllocationHandle = std::mem::zeroed();
-            cu_check!(rdmaxcel_sys::rdmaxcel_cuMemCreate(
-                &mut handle,
-                padded,
-                &prop,
-                0
-            ));
-
-            let mut dptr: rdmaxcel_sys::CUdeviceptr = std::mem::zeroed();
-            cu_check!(rdmaxcel_sys::rdmaxcel_cuMemAddressReserve(
-                &mut dptr, padded, 0, 0, 0,
-            ));
-
-            cu_check!(rdmaxcel_sys::rdmaxcel_cuMemMap(dptr, padded, 0, handle, 0));
-
-            let mut access: rdmaxcel_sys::CUmemAccessDesc = std::mem::zeroed();
-            access.location.type_ = rdmaxcel_sys::CU_MEM_LOCATION_TYPE_DEVICE;
-            access.location.id = self.device;
-            access.flags = rdmaxcel_sys::CU_MEM_ACCESS_FLAGS_PROT_READWRITE;
-            cu_check!(rdmaxcel_sys::rdmaxcel_cuMemSetAccess(
-                dptr, padded, &access, 1
-            ));
-
-            (dptr, padded)
-        };
-
-        let base = dptr as usize;
-        SCANNER_CFG
-            .set((base, padded_size, self.device))
-            .expect("scanner config already set");
-        register_segment_scanner(Some(test_scanner));
-
-        anyhow::ensure!(
-            buf0_offset + buf0_size <= padded_size && buf1_offset + buf1_size <= padded_size,
-            "buffer offsets exceed allocation: padded={padded_size} \
-             buf0=[0x{buf0_offset:x},{buf0_size}] buf1=[0x{buf1_offset:x},{buf1_size}]"
-        );
+        }
 
         let handle = rdma_manager
             .downcast_handle(cx)
             .ok_or_else(|| anyhow::anyhow!("failed to get rdma handle"))?;
 
-        let buf0_local: Arc<dyn RdmaLocalMemory> =
-            Arc::new(UnsafeLocalMemory::new(base + buf0_offset, buf0_size));
-        let remote0 = handle.request_buffer(cx, buf0_local).await?;
+        let mut remotes = Vec::with_capacity(buffers.len());
+        for &(offset, size) in &buffers {
+            let local: Arc<dyn RdmaLocalMemory> =
+                Arc::new(UnsafeLocalMemory::new(alloc.ptr + offset, size));
+            remotes.push(handle.request_buffer(cx, local).await?);
+        }
 
-        let buf1_local: Arc<dyn RdmaLocalMemory> =
-            Arc::new(UnsafeLocalMemory::new(base + buf1_offset, buf1_size));
-        let remote1 = handle.request_buffer(cx, buf1_local).await?;
+        Ok(remotes)
+    }
 
-        Ok((remote0, remote1))
+    async fn free_allocation(&mut self, _cx: &Context<Self>) -> Result<(), anyhow::Error> {
+        if let Some(alloc) = self.allocation.take() {
+            alloc.free();
+        }
+        Ok(())
     }
 }
 
@@ -288,6 +246,7 @@ impl ReceiverMessageHandler for ReceiverActor {
 ///
 /// See also: D84387295 (internal discovery of the same bug by dstaay),
 /// upstream fix in rdma-core v61.0.
+#[cfg(not(test_8_gpus))]
 #[timed_test::async_timed_test(timeout_secs = 60)]
 async fn test_indirect_mkey_read_at_large_offset() -> Result<(), anyhow::Error> {
     use crate::backend::ibverbs::primitives::mlx5dv_supported;
@@ -337,21 +296,18 @@ async fn test_indirect_mkey_read_at_large_offset() -> Result<(), anyhow::Error> 
     let sender = sender_mesh.values().next().unwrap().clone();
     let receiver = receiver_mesh.values().next().unwrap().clone();
 
-    let (remote_buf0, remote_buf1) = sender
-        .allocate_and_register(
+    sender.allocate(instance, SEGMENT_SIZE).await?;
+    let remotes = sender
+        .register(
             instance,
-            SEGMENT_SIZE,
-            0,
-            BUF0_SIZE,
-            BUF1_OFFSET,
-            BUF1_SIZE,
+            vec![(0, BUF0_SIZE), (BUF1_OFFSET, BUF1_SIZE)],
             sender_rdma_ref,
         )
         .await?;
 
     // Read at offset 0 — should always work.
     let buf0_result = receiver
-        .read_remote(instance, remote_buf0, BUF0_SIZE, 10)
+        .read_remote(instance, remotes[0].clone(), BUF0_SIZE, 10)
         .await?;
     assert!(
         buf0_result.is_ok(),
@@ -361,7 +317,7 @@ async fn test_indirect_mkey_read_at_large_offset() -> Result<(), anyhow::Error> 
 
     // Read at offset 0x66000000 (1.71 GB) — fails without the rdma-core fix.
     let buf1_result = receiver
-        .read_remote(instance, remote_buf1, BUF1_SIZE, 10)
+        .read_remote(instance, remotes[1].clone(), BUF1_SIZE, 10)
         .await?;
     assert!(
         buf1_result.is_ok(),
@@ -370,6 +326,140 @@ async fn test_indirect_mkey_read_at_large_offset() -> Result<(), anyhow::Error> 
         BUF1_OFFSET,
         buf1_result.unwrap_err()
     );
+
+    sender.free_allocation(instance).await?;
+    let _ = host_mesh.shutdown(instance).await;
+    Ok(())
+}
+
+/// Validates that per-PD segment registration works correctly when two GPU
+/// buffers on different RDMA NICs are registered through the same
+/// RdmaManagerActor. The manager internally creates a separate PD for each NIC,
+/// so segments on different devices get different PDs.
+///
+/// Dynamically discovers two CUDA devices that map to different NICs, allocates
+/// memory on each (so the scanner sees both before registration), then registers
+/// both and performs RDMA reads from separate receiver processes — one per NIC,
+/// since RoCEv2 NICs on different subnets can't reach each other.
+///
+/// Without the per-PD fix (keying `activeSegments` by `(address, pd)` instead
+/// of just `address`), the second buffer would never register with the correct
+/// PD, causing the second read to fail.
+#[cfg(test_8_gpus)]
+#[timed_test::async_timed_test(timeout_secs = 60)]
+async fn test_multi_pd_segment_registration() -> Result<(), anyhow::Error> {
+    use crate::backend::ibverbs::primitives::mlx5dv_supported;
+
+    if !crate::is_cuda_available() {
+        panic!("SKIPPED: CUDA not available (required for GPU memory allocation)");
+    }
+    if !mlx5dv_supported() {
+        panic!("SKIPPED: mlx5dv not supported (required for indirect mkey creation)");
+    }
+
+    let (device_a, device_b) = match find_devices_on_different_nics() {
+        Some(pair) => pair,
+        None => panic!("SKIPPED: need at least 2 CUDA devices on different RDMA NICs"),
+    };
+
+    const BUF_SIZE: usize = 4 * 1024 * 1024; // 4 MB per buffer
+
+    let cx = context().await;
+    let instance = cx.actor_instance;
+    let mut host_mesh = HostMesh::local().await?;
+
+    let proc_mesh = host_mesh
+        .spawn(
+            instance,
+            "multi_pd_procs",
+            hyperactor_mesh::extent!(procs = 3),
+            None,
+        )
+        .await?;
+
+    let sender_proc = proc_mesh.range("procs", 0..1).unwrap();
+    let receiver_a_proc = proc_mesh.range("procs", 1..2).unwrap();
+    let receiver_b_proc = proc_mesh.range("procs", 2..3).unwrap();
+
+    // Single RDMA manager for both senders. It uses different PDs internally
+    // for each NIC, which is exactly what we're testing.
+    let rdma: ActorMesh<RdmaManagerActor> = sender_proc
+        .spawn_service(instance, "rdma_manager", &Some(IbvConfig::default()))
+        .await?;
+
+    // Each receiver gets an RDMA manager targeting the NIC that matches its
+    // sender's device. This ensures the receiver's QP is on the same subnet
+    // as the sender's NIC (required for RoCEv2).
+    let _rdma_recv_a: ActorMesh<RdmaManagerActor> = receiver_a_proc
+        .spawn_service(
+            instance,
+            "rdma_manager",
+            &Some(IbvConfig::targeting(&format!("cuda:{device_a}"))),
+        )
+        .await?;
+    let _rdma_recv_b: ActorMesh<RdmaManagerActor> = receiver_b_proc
+        .spawn_service(
+            instance,
+            "rdma_manager",
+            &Some(IbvConfig::targeting(&format!("cuda:{device_b}"))),
+        )
+        .await?;
+
+    let rdma_ref = rdma.values().next().unwrap().clone();
+
+    // Both senders on the same proc, sharing the RDMA manager.
+    let sender_a_mesh: ActorMesh<SenderActor> =
+        sender_proc.spawn(instance, "sender_a", &device_a).await?;
+    let sender_b_mesh: ActorMesh<SenderActor> =
+        sender_proc.spawn(instance, "sender_b", &device_b).await?;
+    let receiver_a_mesh: ActorMesh<ReceiverActor> =
+        receiver_a_proc.spawn(instance, "receiver_a", &()).await?;
+    let receiver_b_mesh: ActorMesh<ReceiverActor> =
+        receiver_b_proc.spawn(instance, "receiver_b", &()).await?;
+
+    let sender_a = sender_a_mesh.values().next().unwrap().clone();
+    let sender_b = sender_b_mesh.values().next().unwrap().clone();
+    let receiver_a = receiver_a_mesh.values().next().unwrap().clone();
+    let receiver_b = receiver_b_mesh.values().next().unwrap().clone();
+
+    // Both senders allocate first, so the scanner sees both segments before
+    // either triggers registration.
+    sender_a.allocate(instance, BUF_SIZE).await?;
+    sender_b.allocate(instance, BUF_SIZE).await?;
+
+    // Now register — each triggers segment scanning and gets its own PD
+    // based on the NIC closest to its device.
+    let remotes_a = sender_a
+        .register(instance, vec![(0, BUF_SIZE)], rdma_ref.clone())
+        .await?;
+    let remotes_b = sender_b
+        .register(instance, vec![(0, BUF_SIZE)], rdma_ref)
+        .await?;
+
+    // Each receiver reads using a QP on the matching NIC/subnet.
+    let result_a = receiver_a
+        .read_remote(instance, remotes_a[0].clone(), BUF_SIZE, 10)
+        .await?;
+    assert!(
+        result_a.is_ok(),
+        "RDMA read from device {device_a} failed: {:?}",
+        result_a.unwrap_err()
+    );
+
+    // On the base revision (address-only key), B's segment would never be
+    // registered with the correct PD, causing this read to fail.
+    let result_b = receiver_b
+        .read_remote(instance, remotes_b[0].clone(), BUF_SIZE, 10)
+        .await?;
+    assert!(
+        result_b.is_ok(),
+        "RDMA read from device {device_b} failed (per-PD segment registration bug): {:?}",
+        result_b.unwrap_err()
+    );
+
+    // Clean up allocations.
+    sender_a.free_allocation(instance).await?;
+    sender_b.free_allocation(instance).await?;
 
     let _ = host_mesh.shutdown(instance).await;
     Ok(())

--- a/monarch_rdma/src/backend/ibverbs/test_utils.rs
+++ b/monarch_rdma/src/backend/ibverbs/test_utils.rs
@@ -6,7 +6,10 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+use std::collections::HashMap;
 use std::sync::Arc;
+use std::sync::Mutex;
+use std::sync::OnceLock;
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
 use std::time::Duration;
@@ -780,4 +783,205 @@ impl IbvTestEnv {
         }
         Ok(())
     }
+}
+
+// ---------------------------------------------------------------------------
+// CudaAllocator: reusable CUDA VMM allocator with a segment scanner
+// ---------------------------------------------------------------------------
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct CudaAllocation {
+    pub(crate) ptr: usize,
+    pub(crate) size: usize,
+    pub(crate) device: i32,
+    handle: u64,
+}
+
+pub(crate) struct CudaAllocator {
+    allocations: Mutex<HashMap<usize, CudaAllocation>>,
+}
+
+static CUDA_ALLOCATOR: OnceLock<CudaAllocator> = OnceLock::new();
+
+unsafe fn cuda_err(result: rdmaxcel_sys::CUresult) -> String {
+    unsafe {
+        let mut s: *const std::os::raw::c_char = std::ptr::null();
+        rdmaxcel_sys::rdmaxcel_cuGetErrorString(result, &mut s);
+        if s.is_null() {
+            format!("CUDA error {result}")
+        } else {
+            std::ffi::CStr::from_ptr(s).to_string_lossy().into_owned()
+        }
+    }
+}
+
+impl CudaAllocator {
+    pub(crate) fn get() -> &'static CudaAllocator {
+        CUDA_ALLOCATOR.get_or_init(|| {
+            unsafe {
+                cu_check!(rdmaxcel_sys::rdmaxcel_cuInit(0));
+            }
+            CudaAllocator {
+                allocations: Mutex::new(HashMap::new()),
+            }
+        })
+    }
+
+    /// Allocate GPU memory on `device` of at least `size` bytes via the CUDA
+    /// VMM API. Returns the device pointer. Panics on failure, cleaning up
+    /// any partially-allocated resources.
+    pub(crate) fn allocate(&self, device: i32, size: usize) -> CudaAllocation {
+        unsafe {
+            // Context setup — shared primary context, nothing to roll back.
+            let mut dev: rdmaxcel_sys::CUdevice = std::mem::zeroed();
+            cu_check!(rdmaxcel_sys::rdmaxcel_cuDeviceGet(&mut dev, device));
+
+            let mut ctx: rdmaxcel_sys::CUcontext = std::mem::zeroed();
+            cu_check!(rdmaxcel_sys::rdmaxcel_cuDevicePrimaryCtxRetain(
+                &mut ctx, dev
+            ));
+            cu_check!(rdmaxcel_sys::rdmaxcel_cuCtxSetCurrent(ctx));
+
+            let mut granularity: usize = 0;
+            let mut prop: rdmaxcel_sys::CUmemAllocationProp = std::mem::zeroed();
+            prop.type_ = rdmaxcel_sys::CU_MEM_ALLOCATION_TYPE_PINNED;
+            prop.location.type_ = rdmaxcel_sys::CU_MEM_LOCATION_TYPE_DEVICE;
+            prop.location.id = device;
+            prop.allocFlags.gpuDirectRDMACapable = 1;
+            prop.requestedHandleTypes = rdmaxcel_sys::CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR;
+
+            cu_check!(rdmaxcel_sys::rdmaxcel_cuMemGetAllocationGranularity(
+                &mut granularity,
+                &prop,
+                rdmaxcel_sys::CU_MEM_ALLOC_GRANULARITY_MINIMUM,
+            ));
+
+            let padded = ((size - 1) / granularity + 1) * granularity;
+
+            // From here each step acquires a resource; clean up predecessors
+            // before panicking if a later step fails.
+            let mut handle: rdmaxcel_sys::CUmemGenericAllocationHandle = std::mem::zeroed();
+            cu_check!(rdmaxcel_sys::rdmaxcel_cuMemCreate(
+                &mut handle,
+                padded,
+                &prop,
+                0
+            ));
+
+            let mut dptr: rdmaxcel_sys::CUdeviceptr = std::mem::zeroed();
+            let r = rdmaxcel_sys::rdmaxcel_cuMemAddressReserve(&mut dptr, padded, 0, 0, 0);
+            if r != rdmaxcel_sys::CUDA_SUCCESS {
+                rdmaxcel_sys::rdmaxcel_cuMemRelease(handle);
+                panic!("cuMemAddressReserve: {}", cuda_err(r));
+            }
+
+            let r = rdmaxcel_sys::rdmaxcel_cuMemMap(dptr, padded, 0, handle, 0);
+            if r != rdmaxcel_sys::CUDA_SUCCESS {
+                rdmaxcel_sys::rdmaxcel_cuMemRelease(handle);
+                rdmaxcel_sys::rdmaxcel_cuMemAddressFree(dptr, padded);
+                panic!("cuMemMap: {}", cuda_err(r));
+            }
+
+            let mut access: rdmaxcel_sys::CUmemAccessDesc = std::mem::zeroed();
+            access.location.type_ = rdmaxcel_sys::CU_MEM_LOCATION_TYPE_DEVICE;
+            access.location.id = device;
+            access.flags = rdmaxcel_sys::CU_MEM_ACCESS_FLAGS_PROT_READWRITE;
+            let r = rdmaxcel_sys::rdmaxcel_cuMemSetAccess(dptr, padded, &access, 1);
+            if r != rdmaxcel_sys::CUDA_SUCCESS {
+                rdmaxcel_sys::rdmaxcel_cuMemUnmap(dptr, padded);
+                rdmaxcel_sys::rdmaxcel_cuMemRelease(handle);
+                rdmaxcel_sys::rdmaxcel_cuMemAddressFree(dptr, padded);
+                panic!("cuMemSetAccess: {}", cuda_err(r));
+            }
+
+            let ptr = dptr as usize;
+            let alloc = CudaAllocation {
+                ptr,
+                size: padded,
+                device,
+                handle,
+            };
+            self.allocations.lock().unwrap().insert(ptr, alloc);
+            alloc
+        }
+    }
+    pub(crate) fn free(&self, ptr: usize) {
+        let alloc = self
+            .allocations
+            .lock()
+            .unwrap()
+            .remove(&ptr)
+            .unwrap_or_else(|| panic!("unknown allocation 0x{ptr:x}"));
+
+        // Unmap first, then release the backing allocation, then free the VA range.
+        unsafe {
+            cu_check!(rdmaxcel_sys::rdmaxcel_cuMemUnmap(
+                alloc.ptr as rdmaxcel_sys::CUdeviceptr,
+                alloc.size
+            ));
+            cu_check!(rdmaxcel_sys::rdmaxcel_cuMemRelease(alloc.handle));
+            cu_check!(rdmaxcel_sys::rdmaxcel_cuMemAddressFree(
+                alloc.ptr as rdmaxcel_sys::CUdeviceptr,
+                alloc.size
+            ));
+        }
+    }
+}
+
+impl CudaAllocation {
+    pub(crate) fn free(self) {
+        CudaAllocator::get().free(self.ptr);
+    }
+}
+
+/// Segment scanner callback compatible with `rdmaxcel_segment_scanner_fn`.
+/// Reports all allocations tracked by `CudaAllocator`.
+pub(crate) unsafe extern "C" fn cuda_allocator_scanner(
+    out: *mut rdmaxcel_sys::rdmaxcel_scanned_segment_t,
+    max: usize,
+) -> usize {
+    let Some(allocator) = CUDA_ALLOCATOR.get() else {
+        return 0;
+    };
+    let allocs = allocator.allocations.lock().unwrap();
+    let count = allocs.len();
+    if max == 0 || out.is_null() {
+        return count;
+    }
+    for (i, alloc) in allocs.values().enumerate().take(max.min(count)) {
+        // SAFETY: caller guarantees `out` points to a buffer of at least `max` entries.
+        unsafe {
+            *out.add(i) = rdmaxcel_sys::rdmaxcel_scanned_segment_t {
+                address: alloc.ptr,
+                size: alloc.size,
+                device: alloc.device,
+                is_expandable: 1,
+            };
+        }
+    }
+    count
+}
+
+/// Finds two CUDA devices that map to different RDMA NICs via PCI topology.
+/// Returns `Some((device_a, device_b))` or `None` if all devices share one NIC.
+#[cfg(test_8_gpus)]
+pub(crate) fn find_devices_on_different_nics() -> Option<(i32, i32)> {
+    use super::device_selection::select_optimal_ibv_device;
+
+    let mut gpu_to_nic: Vec<(i32, String)> = Vec::new();
+    for gpu_idx in 0..8 {
+        let hint = format!("cuda:{gpu_idx}");
+        if let Some(device) = select_optimal_ibv_device(Some(&hint)) {
+            gpu_to_nic.push((gpu_idx, device.name().to_string()));
+        }
+    }
+
+    for i in 0..gpu_to_nic.len() {
+        for j in (i + 1)..gpu_to_nic.len() {
+            if gpu_to_nic[i].1 != gpu_to_nic[j].1 {
+                return Some((gpu_to_nic[i].0, gpu_to_nic[j].0));
+            }
+        }
+    }
+    None
 }

--- a/monarch_rdma/src/rdma_components.rs
+++ b/monarch_rdma/src/rdma_components.rs
@@ -298,13 +298,15 @@ pub async fn validate_execution_context() -> Result<(), anyhow::Error> {
     Ok(())
 }
 
-/// Get all segments that have been registered with MRs
+/// Get all segments that have been registered with MRs for the given PD.
 ///
-/// # Returns
-/// * `Vec<SegmentInfo>` - Vector containing all registered segment information
-pub fn get_registered_cuda_segments() -> Vec<rdmaxcel_sys::rdma_segment_info_t> {
+/// Each protection domain maintains independent segment registrations, so
+/// callers must pass the PD whose lkeys they intend to use.
+pub fn get_registered_cuda_segments(
+    pd: *mut rdmaxcel_sys::ibv_pd,
+) -> Vec<rdmaxcel_sys::rdma_segment_info_t> {
     unsafe {
-        let segment_count = rdmaxcel_sys::rdma_get_active_segment_count();
+        let segment_count = rdmaxcel_sys::rdma_get_active_segment_count(pd);
         if segment_count <= 0 {
             return Vec::new();
         }
@@ -315,7 +317,7 @@ pub fn get_registered_cuda_segments() -> Vec<rdmaxcel_sys::rdma_segment_info_t> 
             segment_count as usize
         ];
         let actual_count =
-            rdmaxcel_sys::rdma_get_all_segment_info(segments.as_mut_ptr(), segment_count);
+            rdmaxcel_sys::rdma_get_all_segment_info(pd, segments.as_mut_ptr(), segment_count);
 
         if actual_count > 0 {
             segments.truncate(actual_count as usize);

--- a/rdmaxcel-sys/src/driver_api.cpp
+++ b/rdmaxcel-sys/src/driver_api.cpp
@@ -37,6 +37,7 @@
 #define SYM_DEVICE_GET_COUNT hipGetDeviceCount
 #define SYM_DEVICE_GET_ATTRIBUTE hipDeviceGetAttribute
 #define SYM_CTX_CREATE hipCtxCreate
+#define SYM_DEVICE_PRIMARY_CTX_RETAIN hipDevicePrimaryCtxRetain
 #define SYM_CTX_SET_CURRENT hipCtxSetCurrent
 #define SYM_CTX_SYNCHRONIZE hipCtxSynchronize
 #define SYM_GET_ERROR_STRING hipDrvGetErrorString
@@ -59,6 +60,7 @@
 #define SYM_DEVICE_GET_COUNT cuDeviceGetCount
 #define SYM_DEVICE_GET_ATTRIBUTE cuDeviceGetAttribute
 #define SYM_CTX_CREATE cuCtxCreate_v2
+#define SYM_DEVICE_PRIMARY_CTX_RETAIN cuDevicePrimaryCtxRetain
 #define SYM_CTX_SET_CURRENT cuCtxSetCurrent
 #define SYM_CTX_SYNCHRONIZE cuCtxSynchronize
 #define SYM_GET_ERROR_STRING cuGetErrorString
@@ -87,6 +89,7 @@
   _(deviceGetCount, SYM_DEVICE_GET_COUNT)                              \
   _(deviceGetAttribute, SYM_DEVICE_GET_ATTRIBUTE)                      \
   _(ctxCreate, SYM_CTX_CREATE)                                         \
+  _(devicePrimaryCtxRetain, SYM_DEVICE_PRIMARY_CTX_RETAIN)             \
   _(ctxSetCurrent, SYM_CTX_SET_CURRENT)                                \
   _(ctxSynchronize, SYM_CTX_SYNCHRONIZE)                               \
   _(getErrorString, SYM_GET_ERROR_STRING)
@@ -281,6 +284,10 @@ CUresult rdmaxcel_cuDeviceGetAttribute(
 CUresult
 rdmaxcel_cuCtxCreate_v2(CUcontext* pctx, unsigned int flags, CUdevice dev) {
   return rdmaxcel::DriverAPI::get()->ctxCreate_(pctx, flags, dev);
+}
+
+CUresult rdmaxcel_cuDevicePrimaryCtxRetain(CUcontext* pctx, CUdevice dev) {
+  return rdmaxcel::DriverAPI::get()->devicePrimaryCtxRetain_(pctx, dev);
 }
 
 CUresult rdmaxcel_cuCtxSetCurrent(CUcontext ctx) {

--- a/rdmaxcel-sys/src/driver_api.h
+++ b/rdmaxcel-sys/src/driver_api.h
@@ -102,6 +102,8 @@ rdmaxcel_cuDeviceGetAttribute(int* pi, CUdevice_attribute attrib, CUdevice dev);
 CUresult
 rdmaxcel_cuCtxCreate_v2(CUcontext* pctx, unsigned int flags, CUdevice dev);
 
+CUresult rdmaxcel_cuDevicePrimaryCtxRetain(CUcontext* pctx, CUdevice dev);
+
 CUresult rdmaxcel_cuCtxSetCurrent(CUcontext ctx);
 
 CUresult rdmaxcel_cuCtxSynchronize(void);

--- a/rdmaxcel-sys/src/rdmaxcel.cpp
+++ b/rdmaxcel-sys/src/rdmaxcel.cpp
@@ -44,6 +44,7 @@ struct SegmentInfo {
   size_t mr_size;
   uintptr_t mr_addr;
   struct mlx5dv_mkey* mkey;
+  void* registered_pd; // which PD this segment's MR was created under
 
   // Default constructor - initialize mr as null, keys as 0
   SegmentInfo()
@@ -54,7 +55,8 @@ struct SegmentInfo {
         mrs(),
         mr_size(0),
         mr_addr(0),
-        mkey(nullptr) {}
+        mkey(nullptr),
+        registered_pd(nullptr) {}
 
   // Parameterized constructor
   SegmentInfo(size_t addr, size_t sz, int32_t dev, bool expandable)
@@ -65,10 +67,13 @@ struct SegmentInfo {
         mrs(),
         mr_size(0),
         mr_addr(0),
-        mkey(nullptr) {}
+        mkey(nullptr),
+        registered_pd(nullptr) {}
 };
 
-// Global map to track active CUDA segments by address
+// Global map to track active CUDA segments: address -> SegmentInfo.
+// Each segment is registered to exactly one PD (the one for its device's NIC),
+// tracked by SegmentInfo::registered_pd.
 static std::unordered_map<size_t, SegmentInfo> activeSegments;
 static std::mutex segmentsMutex;
 
@@ -161,27 +166,38 @@ void rdmaxcel_register_segment_scanner(rdmaxcel_segment_scanner_fn scanner) {
   g_segment_scanner = scanner;
 }
 
-// Get count of active segments
-int rdma_get_active_segment_count() {
+// Get count of active segments registered under the given PD
+int rdma_get_active_segment_count(struct ibv_pd* pd) {
   std::lock_guard<std::mutex> lock(segmentsMutex);
-  return static_cast<int>(activeSegments.size());
+  int count = 0;
+  for (const auto& [addr, seg] : activeSegments) {
+    if (seg.registered_pd == static_cast<void*>(pd)) {
+      count++;
+    }
+  }
+  return count;
 }
 
-// Get all segment info into an array
-int rdma_get_all_segment_info(rdma_segment_info_t* info_array, int max_count) {
+// Get all segment info for the given PD into an array
+int rdma_get_all_segment_info(
+    struct ibv_pd* pd,
+    rdma_segment_info_t* info_array,
+    int max_count) {
   if (!info_array || max_count <= 0) {
-    return RDMAXCEL_INVALID_PARAMS; // Invalid parameters
+    return RDMAXCEL_INVALID_PARAMS;
   }
 
   std::lock_guard<std::mutex> lock(segmentsMutex);
 
   int count = 0;
-  for (const auto& pair : activeSegments) {
+  for (const auto& [addr, seg] : activeSegments) {
+    if (seg.registered_pd != static_cast<void*>(pd)) {
+      continue;
+    }
     if (count >= max_count) {
-      break; // Avoid buffer overflow
+      break;
     }
 
-    const SegmentInfo& seg = pair.second;
     info_array[count].phys_address = seg.phys_address;
     info_array[count].phys_size = seg.phys_size;
     info_array[count].device = seg.device;
@@ -193,7 +209,7 @@ int rdma_get_all_segment_info(rdma_segment_info_t* info_array, int max_count) {
     count++;
   }
 
-  return count; // Return number of segments copied
+  return count;
 }
 
 int bind_mrs(
@@ -298,85 +314,112 @@ int compact_mrs(struct ibv_pd* pd, SegmentInfo& seg, int access_flags) {
   return 0;
 }
 
-// Register memory region for a specific segment address, assume cuda
-int register_segments(struct ibv_pd* pd, rdmaxcel_qp_t* qp) {
-  if (!pd || !qp) {
-    return RDMAXCEL_INVALID_PARAMS; // Invalid parameter
+// Register CUDA segments to the PD of each device's NIC.
+// pds and qps are parallel arrays indexed by CUDA device ordinal.
+// num_devices is the length of both arrays.
+// A null entry means that device has no mapped NIC; its segments are skipped.
+int register_segments(
+    struct ibv_pd** pds,
+    rdmaxcel_qp_t** qps,
+    int num_devices) {
+  if (!pds || !qps || num_devices <= 0) {
+    return RDMAXCEL_INVALID_PARAMS;
   }
   scan_existing_segments();
   std::lock_guard<std::mutex> lock(segmentsMutex);
 
-  struct ibv_device_attr dev_attr;
-  if (ibv_query_device(pd->context, &dev_attr)) {
-    return RDMAXCEL_QUERY_DEVICE_FAILED;
-  }
-  uint32_t max_sge = dev_attr.max_sge;
-
   int access_flags =
       IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_WRITE | IBV_ACCESS_REMOTE_READ;
 
-  // Logic, we have active segments but only registered up to mr_size. need to
-  // register the rest in extra MR, and push unto MRS vector.
-  for (auto& pair : activeSegments) {
-    SegmentInfo& seg = pair.second;
-    if (seg.mr_size != seg.phys_size) {
-      auto mr_start = seg.phys_address + seg.mr_size;
-      auto mr_end = seg.phys_address + seg.phys_size;
-      auto remaining_size = mr_end - mr_start;
+  // We cache max_sge per PD context to avoid repeated queries
+  std::unordered_map<void*, uint32_t> max_sge_cache;
 
-      // Register in chunks of MAX_MR_SIZE
-      size_t current_offset = 0;
-      while (current_offset < remaining_size) {
-        size_t chunk_size =
-            std::min(remaining_size - current_offset, MAX_MR_SIZE);
-        auto chunk_start = mr_start + current_offset;
+  for (auto& [addr, seg] : activeSegments) {
+    if (seg.mr_size == seg.phys_size) {
+      continue; // already fully registered
+    }
 
-        // Validate that chunk_size is a multiple of 2MB
-        if (chunk_size % MR_ALIGNMENT != 0) {
-          return RDMAXCEL_MR_REGISTRATION_FAILED;
-        }
+    // Look up the PD for this segment's device
+    if (seg.device < 0 || seg.device >= num_devices) {
+      continue; // device ordinal out of range
+    }
+    auto* pd = pds[seg.device];
+    auto* qp = qps[seg.device];
+    if (!pd || !qp) {
+      continue; // no NIC for this device
+    }
 
-        int fd = -1;
-        CUresult cu_result = rdmaxcel_cuMemGetHandleForAddressRange(
-            &fd,
-            deviceptr_cast(chunk_start),
-            chunk_size,
-            CU_MEM_RANGE_HANDLE_TYPE_DMA_BUF_FD,
-            0);
+    // Get max_sge for this PD's device
+    uint32_t max_sge;
+    auto cache_it = max_sge_cache.find(static_cast<void*>(pd));
+    if (cache_it != max_sge_cache.end()) {
+      max_sge = cache_it->second;
+    } else {
+      struct ibv_device_attr dev_attr{};
+      if (ibv_query_device(pd->context, &dev_attr)) {
+        return RDMAXCEL_QUERY_DEVICE_FAILED;
+      }
+      max_sge = dev_attr.max_sge;
+      max_sge_cache[static_cast<void*>(pd)] = max_sge;
+    }
 
-        if (cu_result != CUDA_SUCCESS || fd < 0) {
-          return RDMAXCEL_DMABUF_HANDLE_FAILED; // Failed to get dmabuf handle
-        }
+    auto mr_start = seg.phys_address + seg.mr_size;
+    auto mr_end = seg.phys_address + seg.phys_size;
+    auto remaining_size = mr_end - mr_start;
 
-        // Register the dmabuf with fd, address is always 0.
-        auto mr = ibv_reg_dmabuf_mr(pd, 0, chunk_size, 0, fd, access_flags);
-        close(fd);
+    // Register in chunks of MAX_MR_SIZE
+    size_t current_offset = 0;
+    while (current_offset < remaining_size) {
+      size_t chunk_size =
+          std::min(remaining_size - current_offset, MAX_MR_SIZE);
+      auto chunk_start = mr_start + current_offset;
 
-        if (!mr) {
-          return RDMAXCEL_MR_REG_FAILED; // MR registration failed
-        }
-
-        seg.mrs.push_back(mr);
-        current_offset += chunk_size;
-
-        // If we have too many MRs, compact them into a single MR
-        if (seg.mrs.size() > max_sge) {
-          // TODO: find a safe way to compact with low performance cost.
-          // return MAX_SGE error auto err = compact_mrs(pd, seg, access_flags);
-          // if (err != 0) {
-          //   return err;
-          // }
-          return RDMAXCEL_MKEY_REG_LIMIT;
-        }
+      // Validate that chunk_size is a multiple of 2MB
+      if (chunk_size % MR_ALIGNMENT != 0) {
+        return RDMAXCEL_MR_REGISTRATION_FAILED;
       }
 
-      seg.mr_size = seg.phys_size;
+      int fd = -1;
+      CUresult cu_result = rdmaxcel_cuMemGetHandleForAddressRange(
+          &fd,
+          deviceptr_cast(chunk_start),
+          chunk_size,
+          CU_MEM_RANGE_HANDLE_TYPE_DMA_BUF_FD,
+          0);
 
-      // Create vector of GPU addresses for bind_mrs
-      auto err = bind_mrs(pd, qp->ibv_qp, access_flags, seg);
-      if (err != 0) {
-        return err; // Bind MR's failed
+      if (cu_result != CUDA_SUCCESS || fd < 0) {
+        return RDMAXCEL_DMABUF_HANDLE_FAILED; // Failed to get dmabuf handle
       }
+
+      // Register the dmabuf with fd, address is always 0.
+      auto mr = ibv_reg_dmabuf_mr(pd, 0, chunk_size, 0, fd, access_flags);
+      close(fd);
+
+      if (!mr) {
+        return RDMAXCEL_MR_REG_FAILED; // MR registration failed
+      }
+
+      seg.mrs.push_back(mr);
+      current_offset += chunk_size;
+
+      // If we have too many MRs, compact them into a single MR
+      if (seg.mrs.size() > max_sge) {
+        // TODO: find a safe way to compact with low performance cost.
+        // return MAX_SGE error auto err = compact_mrs(pd, seg, access_flags);
+        // if (err != 0) {
+        //   return err;
+        // }
+        return RDMAXCEL_MKEY_REG_LIMIT;
+      }
+    }
+
+    seg.mr_size = seg.phys_size;
+    seg.registered_pd = static_cast<void*>(pd);
+
+    // Create vector of GPU addresses for bind_mrs
+    auto err = bind_mrs(pd, qp->ibv_qp, access_flags, seg);
+    if (err != 0) {
+      return err; // Bind MR's failed
     }
   }
   return 0; // Success

--- a/rdmaxcel-sys/src/rdmaxcel.h
+++ b/rdmaxcel-sys/src/rdmaxcel.h
@@ -156,8 +156,12 @@ void rdmaxcel_print_device_info(struct ibv_context* context);
 const char* rdmaxcel_error_string(int error_code);
 
 // Active segment tracking functions (implemented in C++)
-int rdma_get_active_segment_count();
-int rdma_get_all_segment_info(rdma_segment_info_t* info_array, int max_count);
+// Lookup segment info for segments registered on the provided PD.
+int rdma_get_active_segment_count(struct ibv_pd* pd);
+int rdma_get_all_segment_info(
+    struct ibv_pd* pd,
+    rdma_segment_info_t* info_array,
+    int max_count);
 int deregister_segments();
 
 // Scanned segment information - minimal fields needed from external scanner
@@ -274,8 +278,13 @@ void rdmaxcel_qp_store_rts_timestamp(rdmaxcel_qp_t* qp, uint64_t value);
 completion_cache_t* rdmaxcel_qp_get_send_cache(rdmaxcel_qp_t* qp);
 completion_cache_t* rdmaxcel_qp_get_recv_cache(rdmaxcel_qp_t* qp);
 
-// Segment registration (uses rdmaxcel_qp_t, so must come after type definition)
-int register_segments(struct ibv_pd* pd, rdmaxcel_qp_t* qp);
+// Per-device segment registration.
+// pds and qps are parallel arrays indexed by CUDA device ordinal.
+// num_devices is the length of both arrays.
+int register_segments(
+    struct ibv_pd** pds,
+    rdmaxcel_qp_t** qps,
+    int num_devices);
 
 // Completion Cache Structures and Functions
 #define MAX_CACHED_COMPLETIONS 128


### PR DESCRIPTION
Summary:

Previously, `register_segments` took a single PD and registered every scanned
CUDA segment to it. When a `RdmaManagerActor` manages GPUs on different RDMA
NICs (each with its own PD), calling `register_segments` for NIC A's PD would
register all segments — including those on device B — under NIC A's PD. Device
B's segment would then have `mr_size == phys_size` when NIC B's PD called
`register_segments`, so it would be skipped. The result: device B's mkeys
belong to the wrong PD, causing `IBV_WC_REM_ACCESS_ERR` on RDMA operations
through NIC B.

Changes:

**rdmaxcel.cpp / rdmaxcel.h:**
- Add `registered_pd` field to `SegmentInfo` to track which PD owns each
  segment's MR.
- Change `register_segments` signature to take parallel `pds[]`/`qps[]` arrays
  indexed by CUDA device ordinal. Each segment is now registered to exactly
  `pds[seg.device]`; null entries (devices with no NIC) are skipped.
- `rdma_get_active_segment_count(pd)` and `rdma_get_all_segment_info(pd, ...)`
  now take a PD parameter and filter by `registered_pd`.

**manager_actor.rs:**
- Add `cuda_device_to_ibv_device: Vec<Option<IbvDevice>>` built at startup from
  `rdmaxcel_cuDeviceGetCount` + PCI topology. Maps CUDA device ordinal to the
  optimal RDMA NIC.
- Eagerly create domains for all mapped NICs when mlx5dv is enabled so PDs/QPs
  are ready at registration time.
- `register_mr` resolves the RDMA device for a CUDA pointer via
  `CU_POINTER_ATTRIBUTE_DEVICE_ORDINAL` + the prebuilt vec, replacing
  `get_cuda_pci_address_from_ptr` + PCI string lookup.
- `build_per_device_pd_qp_arrays` constructs the parallel arrays for the C++
  `register_segments` call.

**rdma_components.rs:**
- `get_registered_cuda_segments` now takes a PD parameter, passed through to
  `rdma_get_active_segment_count` and `rdma_get_all_segment_info`.

Reviewed By: zdevito

Differential Revision: D96819234


