### PR TITLE
Use host process name instead of hostname for proc naming

### DIFF
--- a/hyperactor_mesh/src/proc_launcher.rs
+++ b/hyperactor_mesh/src/proc_launcher.rs
@@ -51,6 +51,7 @@ use tokio::process::ChildStderr;
 use tokio::process::ChildStdout;
 use tokio::sync::oneshot;
 
+use crate::bootstrap;
 use crate::bootstrap::BootstrapCommand;
 
 mod native;
@@ -236,22 +237,22 @@ pub struct LaunchOptions {
 /// include a friendly identifier in logs, crash reports, etc.
 ///
 /// Format:
-/// - `ProcId(_, name)` → `proc <name> @ <hostname>`
+/// - `ProcId(_, name)` → `<name> @ <host_process_name>`
 ///
-/// Notes:
-/// - We best-effort resolve the local hostname; on failure or
-///   non-UTF8 we fall back to `"unknown_host"`.
-/// - This is **not** guaranteed to be unique and should not be parsed
-///   for program logic.
+/// The host identity is taken from the current process's
+/// `HYPERACTOR_PROCESS_NAME`, falling back to the machine hostname.
+/// This groups procs under their host process in traces and logs.
 pub fn format_process_name(proc_id: &hyperactor_reference::ProcId) -> String {
     let who = proc_id.name();
 
-    let host = hostname::get()
-        .unwrap_or_else(|_| "unknown_host".into())
-        .into_string()
-        .unwrap_or("unknown_host".to_string());
+    let host = std::env::var(bootstrap::PROCESS_NAME_ENV).unwrap_or_else(|_| {
+        hostname::get()
+            .unwrap_or_else(|_| "unknown_host".into())
+            .into_string()
+            .unwrap_or("unknown_host".to_string())
+    });
 
-    format!("proc {} @ {}", who, host)
+    format!("{} @ {}", who, host)
 }
 
 /// Strategy interface for launching and stopping a proc.

--- a/hyperactor_mesh/src/proc_launcher/native.rs
+++ b/hyperactor_mesh/src/proc_launcher/native.rs
@@ -693,15 +693,15 @@ mod tests {
             "env-safe encoding should be deterministic/stable"
         );
 
-        // Process name: don't overfit; assert it includes the "proc "
-        // prefix and proc name.
+        // Process name: don't overfit; assert it includes the proc name
+        // and " @ " separator.
         assert!(
-            proc_name_env.starts_with("proc "),
+            proc_name_env.starts_with("test_7"),
             "PROCESS_NAME_ENV looks wrong: {proc_name_env:?}"
         );
         assert!(
-            proc_name_env.contains("test_7"),
-            "expected proc name in process name: {proc_name_env:?}"
+            proc_name_env.contains(" @ "),
+            "expected ' @ ' separator in process name: {proc_name_env:?}"
         );
 
         // Log channel propagated

--- a/hyperactor_mesh/src/proc_launcher/systemd.rs
+++ b/hyperactor_mesh/src/proc_launcher/systemd.rs
@@ -1247,14 +1247,14 @@ mod tests {
             "env-safe encoding should be deterministic/stable"
         );
 
-        // Process name includes "proc " prefix and the proc name
+        // Process name includes the proc name and " @ " separator
         assert!(
-            proc_name_env.starts_with("proc "),
+            proc_name_env.starts_with("env-vars"),
             "PROCESS_NAME_ENV looks wrong: {proc_name_env:?}"
         );
         assert!(
-            proc_name_env.contains("env-vars"),
-            "expected proc name in process name: {proc_name_env:?}"
+            proc_name_env.contains(" @ "),
+            "expected ' @ ' separator in process name: {proc_name_env:?}"
         );
 
         // Log channel propagated


### PR DESCRIPTION
Summary: Changes format_process_name to read HYPERACTOR_PROCESS_NAME env var (the host process identity) instead of the machine hostname. Falls back to hostname if the env var is unset. This is because when we run ProcessJob we still want to logically see which procs belong to which hosts

Differential Revision: D96754593


