### PR TITLE
[hyperactor_mesh] add WaitRankStatus for race-free proc mesh shutdown

### DIFF
--- a/hyperactor/src/host.rs
+++ b/hyperactor/src/host.rs
@@ -803,7 +803,7 @@ pub enum LocalProcStatus {
 ///   No OS signals are sent or required.
 pub struct LocalProcManager<S> {
     procs: Arc<Mutex<HashMap<reference::ProcId, Proc>>>,
-    stopping: Arc<Mutex<HashMap<reference::ProcId, LocalProcStatus>>>,
+    stopping: Arc<Mutex<HashMap<reference::ProcId, tokio::sync::watch::Sender<LocalProcStatus>>>>,
     spawn: S,
 }
 
@@ -822,8 +822,8 @@ impl<S> LocalProcManager<S> {
     /// that tears it down.
     ///
     /// Status transitions through `Stopping` -> `Stopped` and is
-    /// observable via [`local_proc_status`]. Idempotent: no-ops if
-    /// the proc is already stopping or stopped.
+    /// observable via [`local_proc_status`] and [`watch`]. Idempotent:
+    /// no-ops if the proc is already stopping or stopped.
     pub async fn request_stop(&self, proc: &reference::ProcId, timeout: Duration, reason: &str) {
         {
             let guard = self.stopping.lock().await;
@@ -841,10 +841,11 @@ impl<S> LocalProcManager<S> {
         };
 
         let proc_id = proc_handle.proc_id().clone();
+        let (tx, _) = tokio::sync::watch::channel(LocalProcStatus::Stopping);
         self.stopping
             .lock()
             .await
-            .insert(proc_id.clone(), LocalProcStatus::Stopping);
+            .insert(proc_id.clone(), tx);
 
         let stopping = Arc::clone(&self.stopping);
         let reason = reason.to_string();
@@ -855,10 +856,9 @@ impl<S> LocalProcManager<S> {
             {
                 tracing::warn!(error = %e, "request_stop(local): destroy_and_wait failed");
             }
-            stopping
-                .lock()
-                .await
-                .insert(proc_id, LocalProcStatus::Stopped);
+            if let Some(tx) = stopping.lock().await.get(&proc_id) {
+                let _ = tx.send(LocalProcStatus::Stopped);
+            }
         });
     }
 
@@ -867,7 +867,26 @@ impl<S> LocalProcManager<S> {
     ///
     /// Returns `None` if the proc was never stopped through this path.
     pub async fn local_proc_status(&self, proc: &reference::ProcId) -> Option<LocalProcStatus> {
-        self.stopping.lock().await.get(proc).copied()
+        self.stopping
+            .lock()
+            .await
+            .get(proc)
+            .map(|tx| *tx.borrow())
+    }
+
+    /// Subscribe to lifecycle status changes for a proc that was
+    /// stopped via [`request_stop`].
+    ///
+    /// Returns `None` if the proc was never stopped through this path.
+    pub async fn watch(
+        &self,
+        proc: &reference::ProcId,
+    ) -> Option<tokio::sync::watch::Receiver<LocalProcStatus>> {
+        self.stopping
+            .lock()
+            .await
+            .get(proc)
+            .map(|tx| tx.subscribe())
     }
 }
 

--- a/hyperactor/src/proc.rs
+++ b/hyperactor/src/proc.rs
@@ -1498,17 +1498,25 @@ impl<A: Actor> Instance<A> {
         )
     }
 
+    /// Return a static client instance that can be used to send
+    /// messages to port handles from outside an actor context
+    /// (e.g. from background tokio tasks).
+    // TODO: replace with a proper mechanism for sending to port
+    // handles without an actor context.
+    pub fn self_client() -> &'static Instance<()> {
+        static CLIENT: OnceLock<(Instance<()>, ActorHandle<()>)> = OnceLock::new();
+        &CLIENT
+            .get_or_init(|| Proc::runtime().instance("self_message_client").unwrap())
+            .0
+    }
+
     /// Send a message to the actor itself with a delay usually to trigger some event.
     pub fn self_message_with_delay<M>(&self, message: M, delay: Duration) -> Result<(), ActorError>
     where
         M: Message,
         A: Handler<M>,
     {
-        // A global client to send self message.
-        static CLIENT: OnceLock<(Instance<()>, ActorHandle<()>)> = OnceLock::new();
-        let client = &CLIENT
-            .get_or_init(|| Proc::runtime().instance("self_message_client").unwrap())
-            .0;
+        let client = Self::self_client();
         let port = self.port();
         let self_id = self.self_id().clone();
         tokio::spawn(async move {

--- a/hyperactor_mesh/src/bootstrap.rs
+++ b/hyperactor_mesh/src/bootstrap.rs
@@ -1782,6 +1782,15 @@ impl BootstrapProcManager {
         self.children.lock().await.get(proc_id).map(|h| h.status())
     }
 
+    /// Return a watch receiver for the given proc's status stream,
+    /// if the proc is known to this manager.
+    pub async fn watch(
+        &self,
+        proc_id: &hyperactor_reference::ProcId,
+    ) -> Option<tokio::sync::watch::Receiver<ProcStatus>> {
+        self.children.lock().await.get(proc_id).map(|h| h.watch())
+    }
+
     /// Non-blocking stop: send `StopAll`, then spawn a background task
     /// that waits for exit and escalates if needed.
     ///

--- a/hyperactor_mesh/src/host_mesh.rs
+++ b/hyperactor_mesh/src/host_mesh.rs
@@ -68,6 +68,7 @@ use crate::resource::CreateOrUpdateClient;
 use crate::resource::GetRankStatus;
 use crate::resource::GetRankStatusClient;
 use crate::resource::ProcSpec;
+use crate::resource::WaitRankStatusClient;
 use crate::resource::RankedValues;
 use crate::resource::Status;
 use crate::transport::DEFAULT_TRANSPORT;
@@ -1345,7 +1346,7 @@ impl HostMeshRef {
                 },
             )?;
             host.mesh_agent()
-                .get_rank_status(cx, proc_name, port.bind())
+                .wait_rank_status(cx, proc_name, Status::Stopped, port.bind())
                 .await?;
 
             tracing::info!(
@@ -1377,7 +1378,7 @@ impl HostMeshRef {
         .await
         {
             Ok(statuses) => {
-                let all_stopped = statuses.values().all(|s| s.is_terminating());
+                let all_stopped = statuses.values().all(|s| s.is_terminated());
                 if !all_stopped {
                     tracing::error!(
                         name = "ProcMeshStatus",

--- a/hyperactor_mesh/src/host_mesh/host_agent.rs
+++ b/hyperactor_mesh/src/host_mesh/host_agent.rs
@@ -15,6 +15,7 @@
 #![allow(unused_assignments)]
 
 use std::collections::HashMap;
+use std::collections::HashSet;
 use std::fmt;
 use std::pin::Pin;
 use std::str::FromStr;
@@ -214,21 +215,39 @@ pub const HOST_MESH_AGENT_ACTOR_NAME: &str = "host_agent";
 
 /// A mesh agent is responsible for managing a host in a [`HostMesh`],
 /// through the resource behaviors defined in [`crate::resource`].
+/// Self-notification sent by bridge tasks when a proc's status changes.
+/// Not exported or registered — only used internally via `PortHandle`.
+#[derive(Debug, Serialize, Deserialize, Named)]
+struct ProcStatusChanged {
+    name: Name,
+}
+
 #[hyperactor::export(
     handlers=[
         resource::CreateOrUpdate<ProcSpec>,
         resource::Stop,
         resource::GetState<ProcState>,
         resource::GetRankStatus { cast = true },
+        resource::WaitRankStatus { cast = true },
         resource::List,
         ShutdownHost,
         SpawnMeshAdmin,
         SetClientConfig,
+        ProcStatusChanged,
     ]
 )]
 pub struct HostAgent {
     pub(crate) host: Option<HostAgentMode>,
     pub(crate) created: HashMap<Name, ProcCreationState>,
+    /// Pending `WaitRankStatus` waiters, keyed by resource name.
+    /// Each entry is `(min_status, rank, reply_port)`. Only touched
+    /// from `&mut self` handlers.
+    pending_proc_waiters:
+        HashMap<Name, Vec<(resource::Status, usize, hyperactor_reference::PortRef<crate::StatusOverlay>)>>,
+    /// Procs that already have an active bridge task watching their status.
+    watching: HashSet<Name>,
+    /// Port handle for sending `ProcStatusChanged` to self. Set in `init()`.
+    proc_status_port: Option<PortHandle<ProcStatusChanged>>,
     /// Lazily initialized ProcAgent on the host's local proc.
     /// Boots on first [`GetLocalProc`] (LP-1 — see
     /// `hyperactor::host::LOCAL_PROC_NAME`).
@@ -246,6 +265,9 @@ impl HostAgent {
         Self {
             host: Some(host),
             created: HashMap::new(),
+            pending_proc_waiters: HashMap::new(),
+            watching: HashSet::new(),
+            proc_status_port: None,
             local_mesh_agent: OnceLock::new(),
             mailbox_handle: None,
         }
@@ -404,6 +426,8 @@ impl Actor for HostAgent {
             }
         });
 
+        self.proc_status_port = Some(this.port::<ProcStatusChanged>());
+
         Ok(())
     }
 }
@@ -451,16 +475,45 @@ impl Handler<resource::CreateOrUpdate<ProcSpec>> for HostAgent {
             }
         };
 
+        let rank = create_or_update.rank.unwrap();
+
         if let Err(e) = &created {
             tracing::error!("failed to spawn proc {}: {}", create_or_update.name, e);
         }
         self.created.insert(
             create_or_update.name.clone(),
             ProcCreationState {
-                rank: create_or_update.rank.unwrap(),
+                rank,
                 created,
             },
         );
+
+        // If any WaitRankStatus messages arrived before this proc
+        // existed, their waiters were stashed with a sentinel rank.
+        // Now that we know the real rank, fix them up and start a
+        // watch bridge.
+        // Extract the proc_id before mutably borrowing pending_proc_waiters.
+        let proc_id = self
+            .created
+            .get(&create_or_update.name)
+            .and_then(|s| s.created.as_ref().ok())
+            .map(|(pid, _)| pid.clone());
+
+        if let Some(waiters) = self.pending_proc_waiters.get_mut(&create_or_update.name) {
+            for (_, waiter_rank, _) in waiters.iter_mut() {
+                if *waiter_rank == usize::MAX {
+                    *waiter_rank = rank;
+                }
+            }
+        }
+
+        // Start a bridge and send ourselves an initial check.
+        if self.pending_proc_waiters.contains_key(&create_or_update.name) {
+            if let Some(proc_id) = &proc_id {
+                self.start_watch_bridge(&create_or_update.name, proc_id).await;
+            }
+            self.notify_proc_status_changed(&create_or_update.name);
+        }
 
         self.publish_introspect_properties(cx);
         Ok(())
@@ -490,6 +543,9 @@ impl Handler<resource::Stop> for HostAgent {
             host.request_stop(cx, proc_id, timeout, &message.reason)
                 .await;
         }
+
+        // Status may have changed to Stopping; notify pending waiters.
+        self.notify_proc_status_changed(&message.name);
 
         self.publish_introspect_properties(cx);
         Ok(())
@@ -545,6 +601,200 @@ impl Handler<resource::GetRankStatus> for HostAgent {
         }
         Ok(())
     }
+}
+
+#[async_trait]
+impl Handler<resource::WaitRankStatus> for HostAgent {
+    async fn handle(
+        &mut self,
+        cx: &Context<Self>,
+        msg: resource::WaitRankStatus,
+    ) -> anyhow::Result<()> {
+        use crate::StatusOverlay;
+        use crate::resource::Status;
+
+        match self.created.get(&msg.name) {
+            Some(ProcCreationState {
+                rank,
+                created: Ok((proc_id, _)),
+            }) => {
+                let rank = *rank;
+                let status = match self.host.as_ref() {
+                    Some(host) => host.proc_status(proc_id).await.0,
+                    None => Status::Stopped,
+                };
+
+                // If already at or past the requested threshold, reply immediately.
+                if status >= msg.min_status {
+                    let overlay =
+                        StatusOverlay::try_from_runs(vec![(rank..(rank + 1), status)])
+                            .expect("valid single-run overlay");
+                    let _ = msg.reply.send(cx, overlay);
+                    return Ok(());
+                }
+
+                // Stash the waiter and start a bridge if we don't have one yet.
+                self.pending_proc_waiters
+                    .entry(msg.name.clone())
+                    .or_default()
+                    .push((msg.min_status, rank, msg.reply));
+
+                let proc_id = proc_id.clone();
+                self.start_watch_bridge(&msg.name, &proc_id).await;
+            }
+            Some(ProcCreationState {
+                rank,
+                created: Err(e),
+                ..
+            }) => {
+                // Creation failed — reply immediately with Failed status.
+                let overlay =
+                    StatusOverlay::try_from_runs(vec![(*rank..(*rank + 1), Status::Failed(e.to_string()))])
+                        .expect("valid single-run overlay");
+                let _ = msg.reply.send(cx, overlay);
+            }
+            None => {
+                // Proc doesn't exist yet. Stash the waiter with a
+                // sentinel rank; CreateOrUpdate will fill it in and
+                // start the watch bridge.
+                self.pending_proc_waiters
+                    .entry(msg.name.clone())
+                    .or_default()
+                    .push((msg.min_status, usize::MAX, msg.reply));
+            }
+        }
+
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl Handler<ProcStatusChanged> for HostAgent {
+    async fn handle(
+        &mut self,
+        cx: &Context<Self>,
+        msg: ProcStatusChanged,
+    ) -> anyhow::Result<()> {
+        use crate::StatusOverlay;
+        use crate::resource::Status;
+
+        let status = match self.created.get(&msg.name) {
+            Some(ProcCreationState {
+                created: Ok((proc_id, _)),
+                ..
+            }) => match self.host.as_ref() {
+                Some(host) => host.proc_status(proc_id).await.0,
+                None => Status::Stopped,
+            },
+            Some(ProcCreationState {
+                created: Err(_), ..
+            }) => {
+                // Already replied with Failed when they were stashed.
+                return Ok(());
+            }
+            None => {
+                // Proc not created yet, nothing to flush.
+                return Ok(());
+            }
+        };
+
+        let Some(waiters) = self.pending_proc_waiters.get_mut(&msg.name) else {
+            return Ok(());
+        };
+
+        let remaining = std::mem::take(waiters);
+        for (min_status, rank, reply) in remaining {
+            if status >= min_status {
+                let overlay =
+                    StatusOverlay::try_from_runs(vec![(rank..(rank + 1), status.clone())])
+                        .expect("valid single-run overlay");
+                let _ = reply.send(cx, overlay);
+            } else {
+                waiters.push((min_status, rank, reply));
+            }
+        }
+
+        if waiters.is_empty() {
+            self.pending_proc_waiters.remove(&msg.name);
+        }
+
+        Ok(())
+    }
+}
+
+impl HostAgent {
+    /// Send a `ProcStatusChanged` self-notification for the given proc name.
+    fn notify_proc_status_changed(&self, name: &Name) {
+        if let Some(port) = &self.proc_status_port {
+            let client = Instance::<()>::self_client();
+            let _ = port.send(client, ProcStatusChanged { name: name.clone() });
+        }
+    }
+
+    /// Start a bridge task that watches a proc's status channel and sends
+    /// `ProcStatusChanged` to self on each change. At most one bridge per proc.
+    async fn start_watch_bridge(
+        &mut self,
+        name: &Name,
+        proc_id: &hyperactor_reference::ProcId,
+    ) {
+        if self.watching.contains(name) {
+            return;
+        }
+        self.watching.insert(name.clone());
+
+        let port = match &self.proc_status_port {
+            Some(p) => p.clone(),
+            None => return,
+        };
+
+        match self.host.as_ref() {
+            Some(HostAgentMode::Process { host, .. }) => {
+                if let Some(rx) = host.manager().watch(proc_id).await {
+                    start_proc_watch(port, rx, name.clone(), |s| s.clone().into());
+                }
+            }
+            Some(HostAgentMode::Local(host)) => {
+                if let Some(rx) = host.manager().watch(proc_id).await {
+                    start_proc_watch(port, rx, name.clone(), |s| (*s).into());
+                }
+            }
+            None => {}
+        }
+    }
+}
+
+/// Spawn a bridge task that watches a proc's status channel and sends
+/// `ProcStatusChanged` to the actor via the given `PortHandle`.
+fn start_proc_watch<S>(
+    port: PortHandle<ProcStatusChanged>,
+    mut rx: tokio::sync::watch::Receiver<S>,
+    name: Name,
+    to_status: impl Fn(&S) -> resource::Status + Send + 'static,
+) where
+    S: Send + Sync + 'static,
+{
+    // TODO: replace Instance::self_client() with a proper mechanism
+    // for sending to port handles without an actor context.
+    let client = Instance::<()>::self_client();
+    tokio::spawn(async move {
+        loop {
+            match rx.changed().await {
+                Ok(()) => {
+                    let status = to_status(&*rx.borrow());
+                    let terminated = status.is_terminated();
+                    let _ = port.send(client, ProcStatusChanged { name: name.clone() });
+                    if terminated {
+                        return;
+                    }
+                }
+                Err(_) => {
+                    let _ = port.send(client, ProcStatusChanged { name: name.clone() });
+                    return;
+                }
+            }
+        }
+    });
 }
 
 #[derive(Serialize, Deserialize, Debug, Named, Handler, RefClient, HandleClient)]

--- a/hyperactor_mesh/src/proc_agent.rs
+++ b/hyperactor_mesh/src/proc_agent.rs
@@ -231,6 +231,10 @@ struct ActorInstanceState {
     /// operation (spawn, stop, supervision event). Used for last-writer-wins
     /// ordering in the mesh controller.
     generation: u64,
+    /// Pending `WaitRankStatus` callers: each entry is the minimum
+    /// status threshold and the reply port to send once the threshold
+    /// is met.
+    pending_wait_status: Vec<(resource::Status, hyperactor_reference::PortRef<crate::StatusOverlay>)>,
 }
 
 impl ActorInstanceState {
@@ -280,6 +284,24 @@ impl ActorInstanceState {
             generation: self.generation,
             timestamp: std::time::SystemTime::now(),
         }
+    }
+
+    /// Drain any pending `WaitRankStatus` waiters whose threshold is
+    /// now met by the current status.
+    fn flush_wait_status(&mut self, cx: &impl hyperactor::context::Actor) {
+        let status = self.status();
+        self.pending_wait_status.retain(|(min_status, reply)| {
+            if status >= *min_status {
+                let rank = self.create_rank;
+                let overlay =
+                    crate::StatusOverlay::try_from_runs(vec![(rank..(rank + 1), status.clone())])
+                        .expect("valid single-run overlay");
+                let _ = reply.send(cx, overlay);
+                false // remove from pending
+            } else {
+                true // keep waiting
+            }
+        });
     }
 
     /// Send the current state to all streaming subscribers.
@@ -343,6 +365,7 @@ struct SelfCheck {}
         resource::StreamState<ActorState> { cast = true },
         resource::KeepaliveGetState<ActorState> { cast = true },
         resource::GetRankStatus { cast = true },
+        resource::WaitRankStatus { cast = true },
         RepublishIntrospect { cast = true },
     ]
 )]
@@ -815,6 +838,7 @@ impl Handler<ActorSupervisionEvent> for ProcAgent {
                 instance.generation += 1;
                 let name = name.clone();
                 instance.notify_subscribers(cx, &name);
+                instance.flush_wait_status(cx);
             }
             // Defer republish so introspection picks up is_poisoned /
             // failed_actor_count without blocking the message loop.
@@ -916,6 +940,7 @@ impl Handler<resource::CreateOrUpdate<ActorSpec>> for ProcAgent {
                     subscribers: Vec::new(),
                     expiry_time: None,
                     generation: 1,
+                    pending_wait_status: Vec::new(),
                 },
             );
             return Ok(());
@@ -944,6 +969,7 @@ impl Handler<resource::CreateOrUpdate<ActorSpec>> for ProcAgent {
                 subscribers: Vec::new(),
                 expiry_time: None,
                 generation: 1,
+                pending_wait_status: Vec::new(),
             },
         );
 
@@ -956,19 +982,18 @@ impl Handler<resource::CreateOrUpdate<ActorSpec>> for ProcAgent {
 impl Handler<resource::Stop> for ProcAgent {
     async fn handle(&mut self, cx: &Context<Self>, message: resource::Stop) -> anyhow::Result<()> {
         let actor_id = match self.actor_states.get_mut(&message.name) {
-            Some(actor_state) => match &actor_state.spawn {
-                Ok(actor_id) => {
-                    if actor_state.stop_initiated {
-                        None
-                    } else {
-                        actor_state.stop_initiated = true;
-                        actor_state.generation += 1;
-                        actor_state.notify_subscribers(cx, &message.name);
-                        Some(actor_id.clone())
-                    }
+            Some(actor_state) => {
+                let id = actor_state.spawn.as_ref().ok().cloned();
+                if id.is_some() && !actor_state.stop_initiated {
+                    actor_state.stop_initiated = true;
+                    actor_state.generation += 1;
+                    actor_state.notify_subscribers(cx, &message.name);
+                    actor_state.flush_wait_status(cx);
+                    id
+                } else {
+                    None
                 }
-                Err(_) => None,
-            },
+            }
             None => None,
         };
         if let Some(actor_id) = actor_id {
@@ -1051,6 +1076,42 @@ impl Handler<resource::GetRankStatus> for ProcAgent {
                 get_rank_status.reply.port_id().actor_id(),
                 e
             );
+        }
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl Handler<resource::WaitRankStatus> for ProcAgent {
+    async fn handle(
+        &mut self,
+        cx: &Context<Self>,
+        msg: resource::WaitRankStatus,
+    ) -> anyhow::Result<()> {
+        use crate::StatusOverlay;
+        use crate::resource::Status;
+
+        let (rank, status) = match self.actor_states.get(&msg.name) {
+            Some(state) => (state.create_rank, state.status()),
+            None => (usize::MAX, Status::NotExist),
+        };
+
+        // If already at or past the requested threshold, reply immediately.
+        if status >= msg.min_status || rank == usize::MAX {
+            let overlay = if rank == usize::MAX {
+                StatusOverlay::new()
+            } else {
+                StatusOverlay::try_from_runs(vec![(rank..(rank + 1), status)])
+                    .expect("valid single-run overlay")
+            };
+            let _ = msg.reply.send(cx, overlay);
+            return Ok(());
+        }
+
+        // Otherwise, stash the waiter. It will be flushed when the
+        // status changes (supervision event or stop).
+        if let Some(state) = self.actor_states.get_mut(&msg.name) {
+            state.pending_wait_status.push((msg.min_status, msg.reply));
         }
         Ok(())
     }

--- a/hyperactor_mesh/src/resource.rs
+++ b/hyperactor_mesh/src/resource.rs
@@ -103,6 +103,15 @@ impl Status {
         matches!(self, Self::Failed(_) | Self::Timeout(_))
     }
 
+    /// Returns whether the status is fully terminal (the resource has
+    /// stopped, failed, or timed out — but NOT merely `Stopping`).
+    pub fn is_terminated(&self) -> bool {
+        matches!(
+            self,
+            Status::Stopped | Status::Failed(_) | Status::Timeout(_)
+        )
+    }
+
     pub fn is_healthy(&self) -> bool {
         matches!(self, Status::Initializing | Status::Running)
     }
@@ -118,6 +127,15 @@ impl From<bootstrap::ProcStatus> for Status {
             ProcStatus::Stopped { .. } => Status::Stopped,
             ProcStatus::Failed { reason } => Status::Failed(reason),
             ProcStatus::Killed { .. } => Status::Failed(format!("{}", status)),
+        }
+    }
+}
+
+impl From<hyperactor::host::LocalProcStatus> for Status {
+    fn from(status: hyperactor::host::LocalProcStatus) -> Self {
+        match status {
+            hyperactor::host::LocalProcStatus::Stopping => Status::Stopping,
+            hyperactor::host::LocalProcStatus::Stopped => Status::Stopped,
         }
     }
 }
@@ -176,6 +194,33 @@ impl Bind for Rank {
 pub struct GetRankStatus {
     /// The name of the resource.
     pub name: Name,
+    /// Sparse status updates (overlays) from a rank.
+    #[binding(include)]
+    pub reply: hyperactor_reference::PortRef<StatusOverlay>,
+}
+
+/// Like [`GetRankStatus`], but the handler defers its reply until the
+/// resource's status is >= `min_status`. This avoids the race where
+/// the caller sees `Stopping` before the process has actually exited.
+#[derive(
+    Clone,
+    Debug,
+    Serialize,
+    Deserialize,
+    Named,
+    Handler,
+    HandleClient,
+    RefClient,
+    Bind,
+    Unbind
+)]
+pub struct WaitRankStatus {
+    /// The name of the resource.
+    pub name: Name,
+    /// The minimum status the caller wants to observe.
+    /// The handler will not reply until the resource's status
+    /// is >= this threshold.
+    pub min_status: Status,
     /// Sparse status updates (overlays) from a rank.
     #[binding(include)]
     pub reply: hyperactor_reference::PortRef<StatusOverlay>,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #3047
* #3046
* #3041
* #3040
* #3039
* #3038
* #3037
* #3036
* #3035
* #3034
* #3033
* #3032
* #3031
* #3030
* #3029
* #3028
* #3027
* #3026

`stop_proc_mesh` sends a stop signal to each proc and then queries status
to confirm procs have stopped. Previously it used `GetRankStatus`, which
replies immediately with the current status. Because the stop signal is
asynchronous, the reply is typically `Stopping` (signal sent, process
hasn't exited yet). `stop_proc_mesh` treated any non-`NotExist` status as
complete and returned, allowing `hosts.shutdown()` to tear down the
HostAgent while `ActorMeshController`s were still polling — causing
undeliverable message errors and crashes.

`WaitRankStatus` fixes this by deferring the reply until the resource's
status reaches a caller-specified threshold. For proc-level status
(HostAgent), this means waiting on the `BootstrapProcHandle`'s watch
channel until the process actually exits. For actor-level status
(ProcAgent), pending waiters are stashed and flushed when supervision
events or stop transitions move the status past the threshold.

The HostAgent handler spawns a background tokio task to avoid blocking
the agent's message loop while waiting.

## Race-free shutdown guarantees

The fix relies on three properties that form a causal chain (this is
all in the "clean shutdown" case):

**1. flush-before-exit:** `ProcAgent::shutdown()` calls `proc.flush()`
before exiting. This drains the outbound message queue, ensuring all
`StreamState<ActorState>{ Stopped }` notifications are handed to the
transport before the process dies.

**2. wait-for-exit-before-proceeding:** `WaitRankStatus` blocks on the
proc's watch channel, which fires only after the process has actually
exited (not just received a stop signal). Combined with (1), when
`stop_proc_mesh` returns, every `StreamState<ActorState>{ Stopped }`
for every actor on every rank is **on the wire**.

**3. stop-before-shutdown ordering:** `worker_procs.stop().get()`
completes before `hosts.shutdown().get()` begins. By this point all
controllers have either already processed the streaming Stopped updates
and stopped polling, or any in-flight polls target dead procs and are
silently dropped (`return_undeliverable(false)`).

### Invariants when `stop_proc_mesh` returns:

- All ProcAgent processes have exited (WaitRankStatus waits on watch
  channel, which fires on exit)
- All `StreamState<ActorState>{ Stopped }` are delivered or are on the
  wire (flush before exit, exit before WaitRankStatus reply)
- Controllers will stop polling (they receive Stopped updates via actor
  in-order delivery, or their polls target dead procs)
- No new actor work is happening (all actor instances have been dropped)

### Invariants when `hosts.shutdown().get()` returns:

- All host processes have exited
- No controller is actively polling
- No in-flight messages to any HostAgent
- All streaming subscriptions are drained

Differential Revision: [D96862238](https://our.internmc.facebook.com/intern/diff/D96862238/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D96862238/)!