### PR TITLE
Fix circular deadlock between RdmaManagerActor and IbvManagerActor

### DIFF
--- a/monarch_rdma/src/backend/ibverbs/manager_actor.rs
+++ b/monarch_rdma/src/backend/ibverbs/manager_actor.rs
@@ -78,11 +78,11 @@ pub enum IbvManagerMessage {
         reply: reference::OncePortRef<Option<IbvBuffer>>,
     },
     /// Release a buffer registration by `remote_buf_id`.
-    ReleaseBuffer {
-        remote_buf_id: usize,
-        #[reply]
-        reply: reference::OncePortRef<()>,
-    },
+    /// IMPORTANT: This needs to be fire-and-forget (no reply port)
+    /// to avoid a circular deadlock where RdmaManagerActor waits for
+    /// IbvManagerMessage::ReleaseBuffer while IbvManagerActor waits for
+    /// RdmaManagerMessage::RequestLocalMemory.
+    ReleaseBuffer { remote_buf_id: usize },
     RequestQueuePair {
         other: reference::ActorRef<IbvManagerActor>,
         self_device: String,


### PR DESCRIPTION
Summary:
RdmaManagerActor::release_buffer awaited a reply from
IbvManagerActor::release_buffer. Meanwhile, IbvManagerActor::request_buffer
could be awaiting RdmaManagerActor::request_local_memory. Since both actors
process messages sequentially, this created a circular wait.

Make IbvManagerMessage::ReleaseBuffer fire-and-forget (remove the reply port)
so RdmaManagerActor never blocks waiting on IbvManagerActor during release.

Differential Revision: D96886857


