### PR TITLE
Make USE_UNIFIED_LAYER=true default in hyperactor_telemetry

### DIFF
--- a/hyperactor_telemetry/src/config.rs
+++ b/hyperactor_telemetry/src/config.rs
@@ -81,7 +81,7 @@ declare_attrs! {
         Some("USE_UNIFIED_LAYER".to_string()),
         Some("use_unified_layer".to_string()),
     ))
-    pub attr USE_UNIFIED_LAYER: bool = false;
+    pub attr USE_UNIFIED_LAYER: bool = true;
 
     // Suffix to append to log filenames for test isolation
     @meta(CONFIG = ConfigAttr::new(


### PR DESCRIPTION
Summary:
Changes the default value of the `USE_UNIFIED_LAYER` config attribute in
`hyperactor_telemetry` from `false` to `true`.

This enables the unified tracing layer by default. Users can still override
it by setting the `USE_UNIFIED_LAYER` environment variable or the
`use_unified_layer` config key to `false` if needed.

Reviewed By: mariusae

Differential Revision: D96836392


