### PR TITLE
Implement HostMesh.stop() (#3052)

### DIFF
--- a/docs/source/books/hyperactor-mesh-book/src/meshes/bootstrapping-doing-real-work.md
+++ b/docs/source/books/hyperactor-mesh-book/src/meshes/bootstrapping-doing-real-work.md
@@ -110,6 +110,10 @@ host_mesh.shutdown(&instance).await.expect("host shutdown");
 
 This is important: the host is holding a `BootstrapProcManager`, and that thing is the one that really owns the PIDs of the procs it spawned. `shutdown(...)` walks the hosts, tells each agent to terminate its children, and drops the host. If you don't do this, you can leak the OS children.
 
+You can use host_mesh.stop instead, which also cleans up all of the procs, but leaves the
+host running and a new host mesh can connect to it. This is useful for interactive
+sessions where you don't want to restart the server process.
+
 ---
 
 ### 4.5 Recap of layers

--- a/hyperactor/src/host.rs
+++ b/hyperactor/src/host.rs
@@ -549,15 +549,23 @@ impl<M: ProcManager + BulkTerminate> Host<M> {
     /// A [`TerminateSummary`] with counts of attempted/ok/failed
     /// terminations.
     pub async fn terminate_children(
-        &self,
+        &mut self,
         cx: &impl context::Actor,
         timeout: Duration,
         max_in_flight: usize,
         reason: &str,
     ) -> TerminateSummary {
-        self.manager
+        let summary = self
+            .manager
             .terminate_all(cx, timeout, max_in_flight, reason)
-            .await
+            .await;
+        // Unbind procs from the router so if new procs are made with the same
+        // names, they can use the same slot.
+        for name in self.procs.drain() {
+            let proc_id = reference::ProcId::with_name(self.frontend_addr.clone(), &name);
+            self.router.unbind(&proc_id.into());
+        }
+        summary
     }
 }
 
@@ -895,10 +903,11 @@ where
         max_in_flight: usize,
         reason: &str,
     ) -> TerminateSummary {
-        // Snapshot procs so we don't hold the lock across awaits.
+        // Drain procs so we don't hold the lock across awaits and subsequent
+        // calls to terminate_all don't try to re-terminate.
         let procs: Vec<Proc> = {
-            let guard = self.procs.lock().await;
-            guard.values().cloned().collect()
+            let mut guard = self.procs.lock().await;
+            guard.drain().map(|(_, v)| v).collect()
         };
 
         let attempted = procs.len();

--- a/hyperactor_mesh/src/bootstrap.rs
+++ b/hyperactor_mesh/src/bootstrap.rs
@@ -292,6 +292,10 @@ async fn halt<R>() -> R {
 /// Obtained from [`host`]. Awaiting [`HostShutdownHandle::join`] blocks until
 /// the [`ShutdownHost`] handler sends back the mailbox server handle, drains
 /// it, and (if `exit_on_shutdown`) calls `process::exit`.
+///
+/// Note: [`StopHost`] does **not** trigger this handle — a stopped host
+/// keeps its mailbox server (and Unix socket) alive so new clients can
+/// reconnect to the same address.
 pub struct HostShutdownHandle {
     rx: tokio::sync::oneshot::Receiver<MailboxServerHandle>,
     exit_on_shutdown: bool,
@@ -345,9 +349,9 @@ pub async fn host(
     let host = Host::new(manager, addr).await?;
     let addr = host.addr().clone();
 
-    // The ShutdownHost handler will call host.serve() inside HostAgent::init
-    // (after this.bind::<Self>(), so the actor port is bound before the
-    // frontend starts routing messages), then send the resulting
+    // The ShutdownHost/StopHost handler will call host.serve() inside
+    // HostAgent::init (after this.bind::<Self>(), so the actor port is bound
+    // before the frontend starts routing messages), then send the resulting
     // MailboxServerHandle back here for draining.
     let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<MailboxServerHandle>();
 
@@ -2216,10 +2220,11 @@ impl hyperactor::host::BulkTerminate for BootstrapProcManager {
         max_in_flight: usize,
         reason: &str,
     ) -> TerminateSummary {
-        // Snapshot to avoid holding the lock across awaits.
+        // Drain the children list to avoid holding the lock across awaits and
+        // avoid subsequent calls from trying to terminate again.
         let handles: Vec<BootstrapProcHandle> = {
-            let guard = self.children.lock().await;
-            guard.values().cloned().collect()
+            let mut guard = self.children.lock().await;
+            guard.drain().map(|(_, v)| v).collect()
         };
 
         let attempted = handles.len();

--- a/hyperactor_mesh/src/host_mesh.rs
+++ b/hyperactor_mesh/src/host_mesh.rs
@@ -61,6 +61,7 @@ use crate::host_mesh::host_agent::ProcState;
 use crate::host_mesh::host_agent::SetClientConfigClient;
 use crate::host_mesh::host_agent::ShutdownHostClient;
 use crate::host_mesh::host_agent::SpawnMeshAdminClient;
+use crate::host_mesh::host_agent::StopHostClient;
 use crate::mesh_controller::HostMeshController;
 use crate::mesh_controller::ProcMeshController;
 use crate::proc_agent::ProcAgent;
@@ -159,6 +160,20 @@ impl HostRef {
             hyperactor_config::global::get(crate::bootstrap::MESH_TERMINATE_CONCURRENCY);
         agent
             .shutdown_host(cx, terminate_timeout, max_in_flight.clamp(1, 256))
+            .await?;
+        Ok(())
+    }
+
+    /// Request a stop of this host: tear down all resources but keep
+    /// the worker process alive for reconnection.
+    pub(crate) async fn stop(&self, cx: &impl hyperactor::context::Actor) -> anyhow::Result<()> {
+        let agent = self.mesh_agent();
+        let terminate_timeout =
+            hyperactor_config::global::get(crate::bootstrap::MESH_TERMINATE_TIMEOUT);
+        let max_in_flight =
+            hyperactor_config::global::get(crate::bootstrap::MESH_TERMINATE_CONCURRENCY);
+        agent
+            .stop_host(cx, terminate_timeout, max_in_flight.clamp(1, 256))
             .await?;
         Ok(())
     }
@@ -678,6 +693,47 @@ impl HostMesh {
     /// ensure shutdown is run on Drop.
     pub fn shutdown_guard(self) -> HostMeshShutdownGuard {
         HostMeshShutdownGuard(self)
+    }
+
+    /// Stop all hosts owned by this `HostMesh`, terminating user procs
+    /// but keeping worker processes and their sockets alive for
+    /// reconnection.
+    ///
+    /// After `stop`, the same worker addresses can be passed to
+    /// [`HostMesh::attach`] to create a new mesh.
+    #[hyperactor::instrument(fields(host_mesh=self.name.to_string()))]
+    pub async fn stop(&mut self, cx: &impl hyperactor::context::Actor) -> anyhow::Result<()> {
+        tracing::info!(name = "HostMeshStatus", status = "Stop::Attempt");
+        let mut failed_hosts = vec![];
+        for host in self.current_ref.values() {
+            if let Err(e) = host.stop(cx).await {
+                tracing::warn!(
+                    name = "HostMeshStatus",
+                    status = "Stop::Host::Failed",
+                    %host,
+                    error = %e,
+                    "host stop failed"
+                );
+                failed_hosts.push(host);
+            }
+        }
+        if failed_hosts.is_empty() {
+            tracing::info!(name = "HostMeshStatus", status = "Stop::Success");
+        } else {
+            tracing::error!(
+                name = "HostMeshStatus",
+                status = "Stop::Failed",
+                "host mesh stop failed; check the logs of the failed hosts for details: {:?}",
+                failed_hosts
+            );
+        }
+
+        // Defuse the Drop impl so it doesn't send ShutdownHost to hosts
+        // we intentionally kept alive. Replace the allocation with an
+        // empty Owned variant so Drop has no hosts to iterate.
+        self.allocation = HostMeshAllocation::Owned { hosts: vec![] };
+
+        Ok(())
     }
 }
 

--- a/hyperactor_mesh/src/host_mesh/host_agent.rs
+++ b/hyperactor_mesh/src/host_mesh/host_agent.rs
@@ -234,6 +234,7 @@ struct ProcStatusChanged {
         resource::WaitRankStatus { cast = true },
         resource::List,
         ShutdownHost,
+        StopHost,
         SpawnMeshAdmin,
         SetClientConfig,
         ProcStatusChanged,
@@ -265,7 +266,8 @@ pub struct HostAgent {
     /// Handle to the host's frontend mailbox server, set during `init` after
     /// `this.bind::<Self>()` ensures the actor port is registered before the
     /// mailbox starts routing messages. Sent back to the bootstrap loop via
-    /// `shutdown_tx` when the host shuts down so the caller can drain it.
+    /// `shutdown_tx` when the host shuts down so the caller can
+    /// drain it.
     mailbox_handle: Option<MailboxServerHandle>,
 }
 
@@ -281,6 +283,36 @@ impl HostAgent {
             local_mesh_agent: OnceLock::new(),
             mailbox_handle: None,
         }
+    }
+
+    /// Terminate all tracked children on the host and clear proc state.
+    ///
+    /// The host, system proc, mailbox server, and HostAgent all stay
+    /// alive — only user procs are killed. After this returns the host
+    /// is ready to accept new spawn requests with the same proc names.
+    async fn terminate_children_and_clear(
+        &mut self,
+        cx: &Context<'_, Self>,
+        timeout: std::time::Duration,
+        max_in_flight: usize,
+    ) {
+        if let Some(host_mode) = self.host.as_mut() {
+            match host_mode {
+                HostAgentMode::Process { host, .. } => {
+                    let summary = host
+                        .terminate_children(cx, timeout, max_in_flight.clamp(1, 256), "stop host")
+                        .await;
+                    tracing::info!(?summary, "terminated children on host");
+                }
+                HostAgentMode::Local(host) => {
+                    let summary = host
+                        .terminate_children(cx, timeout, max_in_flight, "stop host")
+                        .await;
+                    tracing::info!(?summary, "terminated children on local host");
+                }
+            }
+        }
+        self.created.clear();
     }
 
     /// Publish the current host properties and children list for
@@ -816,6 +848,51 @@ pub struct ShutdownHost {
 }
 wirevalue::register_type!(ShutdownHost);
 
+/// Stop the host: tear down all resources (procs, host, router) but
+/// keep the worker process alive so a new client can re-bootstrap.
+/// TODO: consider generalizing resource::StopAll to use for this case.
+#[derive(Serialize, Deserialize, Debug, Named, Handler, RefClient, HandleClient)]
+pub struct StopHost {
+    /// Grace window: send SIGTERM and wait this long before
+    /// escalating.
+    pub timeout: std::time::Duration,
+    /// Max number of children to terminate concurrently on this host.
+    pub max_in_flight: usize,
+    /// Ack that the agent finished stop work (best-effort).
+    #[reply]
+    pub ack: hyperactor::reference::PortRef<()>,
+}
+wirevalue::register_type!(StopHost);
+
+#[async_trait]
+impl Handler<StopHost> for HostAgent {
+    async fn handle(&mut self, cx: &Context<Self>, msg: StopHost) -> anyhow::Result<()> {
+        // Terminate children BEFORE acking, so the caller's networking
+        // stays alive while children flush their forwarders during
+        // teardown. If we ack first, the caller proceeds to tear down
+        // the host proc's networking while children are still running,
+        // causing their forwarder flushes to hang until
+        // MESSAGE_DELIVERY_TIMEOUT expires.
+        self.terminate_children_and_clear(cx, msg.timeout, msg.max_in_flight)
+            .await;
+
+        // Ack after children are terminated so the caller does not
+        // tear down the host's networking prematurely.
+        let (return_handle, mut return_receiver) = cx.mailbox().open_port();
+        cx.mailbox()
+            .serialize_and_send(&msg.ack, (), return_handle)?;
+        if return_receiver.recv().await.is_ok() {
+            tracing::warn!("failed to send ack");
+        }
+        tracing::info!(
+            proc_id = %cx.self_id().proc_id(),
+            actor_id = %cx.self_id(),
+            "host stopped, ready for new client"
+        );
+        Ok(())
+    }
+}
+
 #[async_trait]
 impl Handler<ShutdownHost> for HostAgent {
     async fn handle(&mut self, cx: &Context<Self>, msg: ShutdownHost) -> anyhow::Result<()> {
@@ -825,32 +902,8 @@ impl Handler<ShutdownHost> for HostAgent {
         // the host proc's networking while children are still running,
         // causing their forwarder flushes to hang until
         // MESSAGE_DELIVERY_TIMEOUT expires.
-        let mut shutdown_tx = None;
-        if let Some(host_mode) = self.host.take() {
-            match host_mode {
-                HostAgentMode::Process {
-                    host,
-                    shutdown_tx: tx,
-                } => {
-                    let summary = host
-                        .terminate_children(
-                            cx,
-                            msg.timeout,
-                            msg.max_in_flight.clamp(1, 256),
-                            "shutdown host",
-                        )
-                        .await;
-                    tracing::info!(?summary, "terminated children on host");
-                    shutdown_tx = tx;
-                }
-                HostAgentMode::Local(host) => {
-                    let summary = host
-                        .terminate_children(cx, msg.timeout, msg.max_in_flight, "shutdown host")
-                        .await;
-                    tracing::info!(?summary, "terminated children on local host");
-                }
-            }
-        }
+        self.terminate_children_and_clear(cx, msg.timeout, msg.max_in_flight)
+            .await;
 
         // Ack after children are terminated so the caller does not
         // tear down the host's networking prematurely.
@@ -863,10 +916,13 @@ impl Handler<ShutdownHost> for HostAgent {
             tracing::warn!("failed to send ack");
         }
 
-        // Drop the host to release any resources that somehow survived.
-        let _ = self.host.take();
-
-        if let Some(tx) = shutdown_tx {
+        // Drop the host and signal the bootstrap loop to drain the
+        // mailbox and exit.
+        if let Some(HostAgentMode::Process {
+            shutdown_tx: Some(tx),
+            ..
+        }) = self.host.take()
+        {
             tracing::info!(
                 proc_id = %cx.self_id().proc_id(),
                 actor_id = %cx.self_id(),

--- a/monarch_hyperactor/src/host_mesh.rs
+++ b/monarch_hyperactor/src/host_mesh.rs
@@ -271,6 +271,31 @@ impl PyHostMesh {
             )),
         }
     }
+
+    fn stop(&self, instance: &PyInstance) -> PyResult<PyPythonTask> {
+        match self {
+            PyHostMesh::Owned(inner) => {
+                let instance = instance.clone();
+                let mesh_borrow = inner.0.clone();
+                let fut = async move {
+                    match mesh_borrow.take().await {
+                        Ok(mut mesh) => {
+                            mesh.stop(instance.deref()).await?;
+                            Ok(())
+                        }
+                        Err(_) => {
+                            tracing::info!("stop was already called on host mesh");
+                            Ok(())
+                        }
+                    }
+                };
+                PyPythonTask::new(fut)
+            }
+            PyHostMesh::Ref(_) => Err(PyRuntimeError::new_err(
+                "cannot stop `HostMesh` that is a reference instead of owned",
+            )),
+        }
+    }
 }
 
 #[derive(Clone)]

--- a/python/monarch/_rust_bindings/monarch_hyperactor/host_mesh.pyi
+++ b/python/monarch/_rust_bindings/monarch_hyperactor/host_mesh.pyi
@@ -113,6 +113,17 @@ class HostMesh:
         """
         ...
 
+    def stop(self, instance: Instance) -> PythonTask[None]:
+        """
+        Stop the hosts in this mesh, releasing all resources but keeping
+        worker processes alive for reconnection. Throws if this object is
+        backed by a reference rather than an owned mesh.
+
+        Arguments:
+        - `instance`: The instance to use to stop the mesh.
+        """
+        ...
+
 @final
 class BootstrapCommand:
     def __init__(

--- a/python/monarch/_src/actor/host_mesh.py
+++ b/python/monarch/_src/actor/host_mesh.py
@@ -365,6 +365,10 @@ class HostMesh(MeshTrait):
         if this host mesh is a *reference* rather than *owned*, which can happen
         if this `HostMesh` object was received from a remote actor or if it was
         produced by slicing.
+        After shutting down, the hosts in this mesh will be unusable, and no new
+        HostMeshes will be able to connect to them.
+        If you want to stop everything on the host but keep them available for
+        new clients, use `stop()` instead.
 
         This is run automatically on __aexit__ when used as an async context manager.
 
@@ -377,6 +381,25 @@ class HostMesh(MeshTrait):
             await hy_mesh.shutdown(context().actor_instance._as_rust())
             # Remove the inner host mesh to clean up associated memory.
             self._inner_host_mesh = None
+
+        return Future(coro=task())
+
+    def stop(self) -> Future[None]:
+        """
+        Stop the host mesh, releasing all resources but keeping worker
+        processes alive for reconnection. A new HostMesh can be created that
+        points to the same hosts.
+
+        Like `shutdown`, this throws if the host mesh is a reference
+        rather than owned.
+
+        Returns:
+            Future[None]: A future that completes when the host mesh has been stopped.
+        """
+
+        async def task() -> None:
+            hy_mesh = await self._hy_host_mesh
+            await hy_mesh.stop(context().actor_instance._as_rust())
 
         return Future(coro=task())
 
@@ -420,7 +443,7 @@ class HostMesh(MeshTrait):
     def initialized(self) -> Future[Literal[True]]:
         """
         Future completes with 'True' when the `HostMesh` has initialized.
-        Because `HostMesh` are remote objects, there is no guarentee that the `HostMesh` is
+        Because `HostMesh` are remote objects, there is no guarantee that the `HostMesh` is
         still usable after this completes, only that at some point in the past it was usable.
         """
         hm: Shared[HyHostMesh] = self._hy_host_mesh

--- a/python/tests/test_host_mesh.py
+++ b/python/tests/test_host_mesh.py
@@ -116,6 +116,19 @@ class RankActor(Actor):
     async def get_rank(self) -> int:
         return context().actor_instance.rank.rank
 
+    @endpoint
+    async def get_pid(self) -> int:
+        return os.getpid()
+
+
+def is_process_running(pid: int) -> bool:
+    """Check if a process with the given PID is still running."""
+    try:
+        os.kill(pid, 0)  # Signal 0 doesn't kill, just checks if process exists
+        return True
+    except OSError:
+        return False
+
 
 @pytest.mark.timeout(60)
 @isolate_in_subprocess
@@ -160,6 +173,41 @@ def test_shutdown_unpickled_host_mesh_throws_exception() -> None:
     with pytest.raises(RuntimeError):
         hm_unpickled.shutdown().get()
     hm.shutdown().get()
+
+
+@pytest.mark.timeout(120)
+@isolate_in_subprocess
+def test_stop_and_reconnect() -> None:
+    job = ProcessJob({"hosts": 2})
+
+    # First connection: spawn actors, verify they work.
+    hm = job.state(cached_path=None).hosts
+    pm = hm.spawn_procs(per_host={"gpus": 1})
+    am = pm.spawn("actor", RankActor)
+    pids = am.get_pid.call().get()
+    assert len(pids) == 2
+    pids = [pid for _, pid in pids.items()]
+
+    # Stop: terminate user procs but keep workers alive.
+    hm.stop().get()
+    # Ensure that the procs are actually dead.
+    assert all(not is_process_running(pid) for pid in pids)
+
+    # Sleep for a bit to ensure that there's no error after the stop. 30 seconds
+    # is the default channel timeout for an undeliverable message. The actor
+    # mesh and proc mesh controllers should be able to stop fine and not send
+    # any messages to the dead procs and actors.
+    time.sleep(35)
+
+    # Second connection: reconnect to the same workers via state().
+    hm2 = job.state(cached_path=None).hosts
+    pm2 = hm2.spawn_procs(per_host={"gpus": 1})
+    am2 = pm2.spawn("actor", RankActor)
+    ranks2 = am2.get_rank.call().get()
+    assert len(ranks2) == 2
+
+    # Shutdown: fully tear down and exit workers.
+    hm2.shutdown().get()
 
 
 class PidActor(Actor):


### PR DESCRIPTION
Summary:

Fixes: https://github.com/meta-pytorch/monarch/issues/2179

HostMesh.shutdown today takes down all hosts in the mesh, such that they cannot
be connected to again. Add a HostMesh.stop alternative that cleans up all resources, but
leaves the process running `run_worker_loop_forever` up so that new host meshes can
reuse it.

The stop drops the Host object after clearing all its procs so it doesn't try to stop them
itself in impl Drop for Host.

This style works well for interactive sessions with Jobs, where you may restart a
script multiple times and want to keep reconnecting to the same hosts. It is also a good
default to use for an orphaned host mesh, i.e. one whose owner disappears.

Reviewed By: zdevito

Differential Revision: D96343344
