### PR TITLE
Move Drop on HostMesh to guard object

### DIFF
--- a/hyperactor_mesh/src/host_mesh.rs
+++ b/hyperactor_mesh/src/host_mesh.rs
@@ -25,6 +25,7 @@ pub mod host_agent;
 use std::collections::HashSet;
 use std::hash::Hash;
 use std::ops::Deref;
+use std::ops::DerefMut;
 use std::str::FromStr;
 use std::sync::Arc;
 use std::time::Duration;
@@ -190,15 +191,12 @@ impl FromStr for HostRef {
 ///
 /// # Lifecycle
 /// `HostMesh` owns host lifecycles. Callers **must** invoke
-/// [`HostMesh::shutdown`] for deterministic teardown. The `Drop` impl
-/// performs **best-effort** cleanup only (spawned via Tokio if
-/// available); it is a safety net, not a substitute for orderly
-/// shutdown.
+/// [`HostMesh::shutdown`] for deterministic teardown.
 ///
 /// In tests and production, prefer explicit shutdown to guarantee
 /// that host agents drop their `BootstrapProcManager`s and that all
-/// child procs are reaped.
-#[allow(dead_code)]
+/// child procs are reaped. You can use `shutdown_guard` to get a wrapper
+/// which will try to do a best-effort shutdown on Drop.
 pub struct HostMesh {
     name: Name,
     extent: Extent,
@@ -675,6 +673,12 @@ impl HostMesh {
         }
         Ok(())
     }
+
+    /// Consumes and wraps this HostMesh with a HostMeshShutdownGuard, which will
+    /// ensure shutdown is run on Drop.
+    pub fn shutdown_guard(self) -> HostMeshShutdownGuard {
+        HostMeshShutdownGuard(self)
+    }
 }
 
 impl Deref for HostMesh {
@@ -685,7 +689,24 @@ impl Deref for HostMesh {
     }
 }
 
-impl Drop for HostMesh {
+/// Wrapper around HostMesh that runs shutdown on Drop.
+pub struct HostMeshShutdownGuard(pub HostMesh);
+
+impl Deref for HostMeshShutdownGuard {
+    type Target = HostMesh;
+
+    fn deref(&self) -> &HostMesh {
+        &self.0
+    }
+}
+
+impl DerefMut for HostMeshShutdownGuard {
+    fn deref_mut(&mut self) -> &mut HostMesh {
+        &mut self.0
+    }
+}
+
+impl Drop for HostMeshShutdownGuard {
     /// Best-effort cleanup for owned host meshes on drop.
     ///
     /// When a `HostMesh` is dropped, it attempts to shut down all
@@ -706,11 +727,11 @@ impl Drop for HostMesh {
     fn drop(&mut self) {
         tracing::info!(
             name = "HostMeshStatus",
-            host_mesh = %self.name,
+            host_mesh = %self.0.name,
             status = "Dropping",
         );
         // Snapshot the owned hosts we're responsible for.
-        let hosts: Vec<HostRef> = match &self.allocation {
+        let hosts: Vec<HostRef> = match &self.0.allocation {
             HostMeshAllocation::ProcMesh { hosts, .. } | HostMeshAllocation::Owned { hosts } => {
                 hosts.clone()
             }
@@ -718,8 +739,8 @@ impl Drop for HostMesh {
 
         // Best-effort only when a Tokio runtime is available.
         if let Ok(handle) = tokio::runtime::Handle::try_current() {
-            let mesh_name = self.name.clone();
-            let allocation_label = match &self.allocation {
+            let mesh_name = self.0.name.clone();
+            let allocation_label = match &self.0.allocation {
                 HostMeshAllocation::ProcMesh { .. } => "proc_mesh",
                 HostMeshAllocation::Owned { .. } => "owned",
             }
@@ -790,7 +811,7 @@ impl Drop for HostMesh {
             // No runtime here; PDEATHSIG and manager Drop remain the
             // last-resort safety net.
             tracing::warn!(
-                host_mesh = %self.name,
+                host_mesh = %self.0.name,
                 hosts = hosts.len(),
                 "HostMesh dropped without a Tokio runtime; skipping \
                  best-effort shutdown. This indicates that .shutdown() \
@@ -804,7 +825,7 @@ impl Drop for HostMesh {
 
         tracing::info!(
             name = "HostMeshStatus",
-            host_mesh = %self.name,
+            host_mesh = %self.0.name,
             status = "Dropped",
         );
     }

--- a/hyperactor_mesh/src/mesh_controller.rs
+++ b/hyperactor_mesh/src/mesh_controller.rs
@@ -1059,7 +1059,7 @@ mod tests {
     /// Create a multi-process host mesh that propagates the current
     /// process's config overrides to child processes via Bootstrap.
     #[cfg(fbcode_build)]
-    async fn host_mesh_with_config(n: usize) -> crate::host_mesh::HostMesh {
+    async fn host_mesh_with_config(n: usize) -> crate::host_mesh::HostMeshShutdownGuard {
         use hyperactor::channel::ChannelTransport;
         use tokio::process::Command;
 
@@ -1088,7 +1088,7 @@ mod tests {
         }
 
         let host_mesh = crate::HostMeshRef::from_hosts(Name::new("test").unwrap(), host_addrs);
-        crate::host_mesh::HostMesh::take(host_mesh)
+        crate::host_mesh::HostMesh::take(host_mesh).shutdown_guard()
     }
 
     /// Verify that actors are cleaned up via the orphan timeout when the

--- a/hyperactor_mesh/src/testing.rs
+++ b/hyperactor_mesh/src/testing.rs
@@ -44,6 +44,7 @@ use crate::alloc::Allocator;
 use crate::alloc::LocalAllocator;
 use crate::alloc::ProcessAllocator;
 use crate::host_mesh::HostMesh;
+use crate::host_mesh::HostMeshShutdownGuard;
 use crate::supervision::MeshFailure;
 use crate::transport::default_transport;
 
@@ -240,7 +241,7 @@ pub async fn local_proc_mesh(
 /// let _ = host_mesh.shutdown(&instance).await;
 /// ```
 #[cfg(fbcode_build)]
-pub async fn host_mesh(n: usize) -> HostMesh {
+pub async fn host_mesh(n: usize) -> HostMeshShutdownGuard {
     use crate::Name;
 
     let program = crate::testresource::get("monarch/hyperactor_mesh/bootstrap");
@@ -270,5 +271,5 @@ pub async fn host_mesh(n: usize) -> HostMesh {
     }
 
     let host_mesh = HostMeshRef::from_hosts(Name::new("test").unwrap(), host_addrs);
-    HostMesh::take(host_mesh)
+    HostMesh::take(host_mesh).shutdown_guard()
 }

--- a/python/monarch/_src/actor/host_mesh.py
+++ b/python/monarch/_src/actor/host_mesh.py
@@ -11,6 +11,7 @@ import subprocess
 import sys
 import tempfile
 import warnings
+from contextlib import asynccontextmanager
 from typing import Any, Awaitable, Callable, Dict, Literal, Optional, Tuple
 
 from monarch._rust_bindings.monarch_hyperactor.alloc import AllocConstraints, AllocSpec
@@ -60,6 +61,18 @@ class HostMesh(MeshTrait):
     """
     HostMesh represents a collection of compute hosts that can be used to spawn
     processes and actors.
+
+    Can be used as an async context manager, which will shut down the hosts on
+    exit:
+    ```
+    host_mesh = job.state().hosts
+    async with host_mesh:
+        # spawn proc meshes, actor meshes, etc.
+    # shutdown() is called automatically on exit.
+    ```
+
+    If you don't want to shutdown the hosts, you don't need to use it as a
+    context manager.
     """
 
     def __init__(
@@ -70,7 +83,7 @@ class HostMesh(MeshTrait):
         is_fake_in_process: bool,
         _code_sync_proc_mesh: Optional["_Lazy[ProcMesh]"],
     ) -> None:
-        self._hy_host_mesh = hy_host_mesh
+        self._inner_host_mesh: Optional[Shared[HyHostMesh]] = hy_host_mesh
         self._region = region
         self._stream_logs = stream_logs
         self._is_fake_in_process = is_fake_in_process
@@ -199,6 +212,10 @@ class HostMesh(MeshTrait):
             raise ValueError(
                 f"per_host labels {per_host.labels} overlap with host labels {self._labels}"
             )
+        # This is checked inside the task as well, but we can pre-emptively raise
+        # earlier.
+        if self._inner_host_mesh is None:
+            raise RuntimeError("HostMesh has already been shut down")
 
         async def task() -> HyProcMesh:
             hy_host_mesh = await self._hy_host_mesh
@@ -318,6 +335,8 @@ class HostMesh(MeshTrait):
         if this `HostMesh` object was received from a remote actor or if it was
         produced by slicing.
 
+        This is run automatically on __aexit__ when used as an async context manager.
+
         Returns:
             Future[None]: A future that completes when the host mesh has been shut down.
         """
@@ -325,8 +344,23 @@ class HostMesh(MeshTrait):
         async def task() -> None:
             hy_mesh = await self._hy_host_mesh
             await hy_mesh.shutdown(context().actor_instance._as_rust())
+            # Remove the inner host mesh to clean up associated memory.
+            self._inner_host_mesh = None
 
         return Future(coro=task())
+
+    async def __aenter__(self) -> "HostMesh":
+        if self._inner_host_mesh is None:
+            raise RuntimeError("HostMesh has already been shut down")
+        return self
+
+    async def __aexit__(
+        self, exc_type: object, exc_val: object, exc_tb: object
+    ) -> None:
+        # In case there are multiple nested "async with" statements, we only
+        # want it to close once.
+        if self._inner_host_mesh is not None:
+            await self.shutdown()
 
     async def sync_workspace(
         self,
@@ -365,6 +399,12 @@ class HostMesh(MeshTrait):
             return True
 
         return Future(coro=task())
+
+    @property
+    def _hy_host_mesh(self) -> Shared[HyHostMesh]:
+        if self._inner_host_mesh is None:
+            raise RuntimeError("HostMesh has already been shut down")
+        return self._inner_host_mesh
 
 
 def hosts_from_config(name: str) -> HostMesh:

--- a/python/tests/test_host_mesh.py
+++ b/python/tests/test_host_mesh.py
@@ -124,6 +124,22 @@ def test_shutdown_host_mesh() -> None:
 
 
 @pytest.mark.timeout(60)
+@isolate_in_subprocess
+async def test_host_mesh_context_manager() -> None:
+    """Tests that the HostMesh can be used as a context manager and that it runs
+    shutdown on exit"""
+    async with ProcessJob({"hosts": 2}).state(cached_path=None).hosts as hm:
+        pm = hm.spawn_procs(per_host={"gpus": 2})
+        am = pm.spawn("actor", RankActor)
+        await am.get_rank.choose()
+    # Ensure that other operations fail after shutdown.
+    with pytest.raises(RuntimeError, match="HostMesh has already been shut down"):
+        hm.spawn_procs(per_host={"gpus": 2})
+    with pytest.raises(RuntimeError, match="HostMesh has already been shut down"):
+        await hm.shutdown()
+
+
+@pytest.mark.timeout(60)
 def test_shutdown_sliced_host_mesh_throws_exception() -> None:
     hm = ProcessJob({"hosts": 2}).state(cached_path=None).hosts
     hm_sliced = hm.slice(hosts=1)


### PR DESCRIPTION
Summary:
Previously when a HostMesh is Dropped, it would do a best-effort attempt to
run shutdown. This would make the Hosts unreachable, and also make any procs or
actors unreachable.

This was surprising behavior for users of the Python API, who might do something like this:
```lang=py
def make_procs(self, job: JobTrait) -> ProcMesh:
  hosts = job.state().hosts
  return hosts.spawn_procs(per_host={"gpus": 8})
```

This usage would leave the HostMesh object (and its inner HyHostMesh) unreachable and
will be garbage collected. This would then shutdown the host mesh and the procs would
become unreachable.

Change this so it would only happen when using an `async with` block, which makes it
more clear that resources might not be available after exiting. This doesn't impact
existing uses, they can call shutdown the same way.
After shutdown, all modifying APIs on the HostMesh are unusable (spawn_procs, shutdown, etc.) and will raise a RuntimeError.
The Drop on HostMesh is moved to a transparent guard object that can be used just like
a normal HostMesh.

The main alternative would be to have ProcMesh maintain a reference to the HostMesh which
spawned it, which would fix the immediate problem, but would still have visible side-effects
on `__del__`, which is not desirable.

Differential Revision: D96954833


