### PR TITLE
[ROCm][CI] Enable USE_TENSOR_ENGINE for ROCm build

### DIFF
--- a/.github/workflows/build-rocm.yml
+++ b/.github/workflows/build-rocm.yml
@@ -44,5 +44,4 @@ jobs:
         # Setup Tensor Engine
         setup_tensor_engine
         # Build monarch (ROCm version)
-        # TODO TEMPORARY: Use USE_TENSOR_ENGINE=0 to avoid Rust build errors with cuda-sys, nccl-sys etc.
-        USE_TENSOR_ENGINE=0 python setup.py bdist_wheel
+        python setup.py bdist_wheel


### PR DESCRIPTION
Removed temporary workaround for Rust build errors in ROCm build process. No need to use `USE_TENSOR_ENGINE=0` anymore since https://github.com/meta-pytorch/monarch/pull/2891

Depends on https://github.com/meta-pytorch/monarch/pull/2828 to enable ROCm CI.