### PR TITLE
[monarch] Add remotemount docs, mast.py optimizations, and RDMA MR caching

### DIFF
--- a/docs/DOCS_INDEX.md
+++ b/docs/DOCS_INDEX.md
@@ -18,6 +18,7 @@
 | monarch.rdma | `docs/source/api/monarch.rdma.rst` |
 | monarch.config | `docs/source/api/monarch.config.rst` |
 | monarch.job | `docs/source/api/monarch.job.rst` |
+| monarch.remotemount | `docs/source/api/monarch.remotemount.rst` |
 | monarch.spmd | `docs/source/api/monarch.spmd.rst` |
 
 ## Examples
@@ -31,3 +32,4 @@
 | spmd_ddp.py | `docs/source/examples/ddp/spmd_ddp.py` |
 | kubernetes_ddp.py | `docs/source/examples/ddp/kubernetes_ddp.py` |
 | train.py | `docs/source/examples/ddp/train.py` |
+| remotemount.py | `docs/source/examples/remotemount.py` |

--- a/docs/source/api/index.rst
+++ b/docs/source/api/index.rst
@@ -9,6 +9,7 @@ The :doc:`monarch` package contains APIs related to computing with distributed t
 The :doc:`monarch.job` package provides a declarative interface for managing distributed job resources.
 The :doc:`monarch.rdma` package provides RDMA support for high-performance networking.
 The :doc:`monarch.spmd` package provides primitives for running torchrun-style SPMD scripts over Monarch meshes.
+The :doc:`monarch.remotemount` package mounts local directories on remote workers via FUSE.
 
 .. toctree::
    :maxdepth: 2
@@ -18,4 +19,5 @@ The :doc:`monarch.spmd` package provides primitives for running torchrun-style S
    monarch.job
    monarch
    monarch.rdma
+   monarch.remotemount
    monarch.spmd

--- a/docs/source/api/monarch.remotemount.rst
+++ b/docs/source/api/monarch.remotemount.rst
@@ -1,0 +1,24 @@
+monarch.remotemount
+===================
+
+.. currentmodule:: monarch.remotemount
+
+The ``monarch.remotemount`` module mounts a local directory as a read-only
+FUSE filesystem on every host in a Monarch mesh. Files are packed into a
+contiguous buffer, transferred via Monarch messaging (optionally over RDMA),
+and served from RAM on each remote host. See the
+`remotemount example <https://meta-pytorch.org/monarch/generated/examples/remotemount.html>`_
+for usage.
+
+remotemount
+===========
+
+.. autofunction:: remotemount
+
+MountHandler
+============
+
+.. autoclass:: MountHandler
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/examples/README.rst
+++ b/docs/source/examples/README.rst
@@ -9,6 +9,7 @@ Examples
 - :doc:`grpo_actor.py </generated/examples/grpo_actor>`: Implements a distributed PPO-like reinforcement learning algorithm using the Monarch actor framework
 - :doc:`distributed_tensors.py </generated/examples/distributed_tensors>`: Shows how to dispatch tensors and tensor level operations to a distributed mesh of workers and GPUs
 - :doc:`debugging.py </generated/examples/debugging>`: Shows how to use the Monarch debugger to debug a distributed program
+- :doc:`remotemount.py </generated/examples/remotemount>`: Mount a local directory as a read-only FUSE filesystem on remote workers via Monarch messaging or RDMA
 - `Multinode Slurm Tutorial <https://docs.pytorch.org/tutorials/intermediate/monarch_distributed_tutorial.html>`_: Multinode distributed training tutorial using Monarch and Slurm to run an SPMD training job.
 - `Running on Kubernetes using Skypilot <https://github.com/pytorch-labs/monarch/tree/main/examples/skypilot>`_: Run Monarch on Kubernetes and cloud VMs via SkyPilot.
 
@@ -23,4 +24,5 @@ Examples
    /generated/examples/grpo_actor
    /generated/examples/distributed_tensors
    /generated/examples/debugging
+   /generated/examples/remotemount
    Multinode Slurm Tutorial <https://docs.pytorch.org/tutorials/intermediate/monarch_distributed_tutorial.html>

--- a/docs/source/examples/remotemount.py
+++ b/docs/source/examples/remotemount.py
@@ -1,0 +1,120 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""
+Remote Filesystem Mounting with remotemount
+============================================
+
+This example demonstrates ``monarch.remotemount``, which mounts a local
+directory as a read-only FUSE filesystem on every host in a Monarch mesh.
+Files are packed into a contiguous buffer, transferred via Monarch messaging
+(optionally over RDMA), and served from RAM on each remote host.
+
+Use cases:
+
+- Distribute local Python environments to remote workers
+- Ship pip wheel caches for offline installs
+- Broadcast model checkpoints without NFS or object storage
+"""
+
+import subprocess
+import tempfile
+
+# %%
+# Basic usage
+# -----------
+# ``remotemount`` is a context manager. While it is open the source directory
+# appears at the mount point on every host in the mesh.
+
+import cloudpickle
+from monarch.actor import Actor, endpoint, this_host
+from monarch.remotemount import remotemount
+
+# %%
+# We define a simple actor that runs a bash script on each worker.
+
+
+class BashActor(Actor):
+    @endpoint
+    def run(self, script: str):
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".sh", delete=True) as f:
+            f.write(script)
+            f.flush()
+            result = subprocess.run(["bash", f.name], capture_output=True, text=True)
+        return {
+            "returncode": result.returncode,
+            "stdout": result.stdout,
+            "stderr": result.stderr,
+        }
+
+
+# Register BashActor for pickle-by-value so it is serialized to remote workers.
+import docs.source.examples.remotemount as _this_module  # noqa: E402
+
+cloudpickle.register_pickle_by_value(_this_module)
+
+# %%
+# Mount a local directory on remote workers
+# ------------------------------------------
+# Create a local process mesh (in practice this would be a multi-node mesh
+# from ``SlurmJob`` or ``MASTJob``), mount a source directory, and run a
+# command that reads from the mount.
+
+host_mesh = this_host()
+procs = host_mesh.spawn_procs(per_host={"gpus": 2})
+
+SOURCE_DIR = "/tmp/remotemount_example_src"
+MOUNT_POINT = "/tmp/remotemount_example_mnt"
+
+# Create a small source directory for the example.
+subprocess.run(["mkdir", "-p", SOURCE_DIR], check=True)
+with open(f"{SOURCE_DIR}/hello.txt", "w") as f:
+    f.write("hello from remotemount!\n")
+
+# %%
+# The ``remotemount`` context manager packs, transfers, and FUSE-mounts the
+# directory. Inside the ``with`` block, every worker sees the files at
+# ``MOUNT_POINT``.
+
+with remotemount(host_mesh, SOURCE_DIR, MOUNT_POINT):
+    bash_actors = procs.spawn("BashActor", BashActor)
+    results = bash_actors.run.call(f"cat {MOUNT_POINT}/hello.txt").get()
+    for i, r in enumerate(results):
+        print(f"rank {i}: {r[1]['stdout'].strip()}")
+
+# %%
+# Chunk size
+# ----------
+# Transfers use RDMA by default (ibverbs, EFA, or TCP fallback).
+# You can control the chunk size (default 8 GiB):
+#
+# .. code-block:: python
+#
+#     with remotemount(host_mesh, source_dir, mount_point,
+#                      chunk_size=1024 * 1024 * 1024):  # 1 GiB chunks
+#         ...
+
+# %%
+# Distributing a Python environment
+# ----------------------------------
+# A powerful pattern is mounting an entire virtualenv or conda environment
+# on remote workers. This lets you iterate without rebuilding packages or
+# waiting for NFS.
+#
+# .. code-block:: python
+#
+#     # On your devbox, create and populate the env:
+#     #   python -m venv /scratch/myenv && pip install torch transformers
+#     #
+#     # Then in your Monarch script:
+#     with remotemount(host_mesh, "/scratch/myenv"):
+#         bash_actors = procs.spawn("BashActor", BashActor)
+#         bash_actors.run.call("""
+#             source /scratch/myenv/bin/activate
+#             python -c "import torch; print(torch.randn(4).cuda().mean())"
+#         """).get()
+
+print("Example completed successfully!")

--- a/examples/remotemount/REMOTERUN_GUIDE.md
+++ b/examples/remotemount/REMOTERUN_GUIDE.md
@@ -7,8 +7,8 @@ This guide covers how to set up and run `remoterun` on MAST with different hardw
 Use the automated setup script:
 
 ```bash
-# Set up conda envs for GB300 (aarch64)
-bash examples/remotemount/setup_conda_env.sh gb300
+# Set up conda envs for GB200/GB300 (aarch64)
+bash examples/remotemount/setup_conda_env.sh gb200
 
 # Set up conda envs for GrandTeton/H100 (x86)
 bash examples/remotemount/setup_conda_env.sh grandteton
@@ -18,7 +18,7 @@ This creates `~/monarch_conda_envs/client/conda` (x86) and
 `~/monarch_conda_envs/worker/conda` (target arch). Then run:
 
 ```bash
-bash examples/remotemount/run_gb300.sh /tmp/myenv my_script.sh
+bash examples/remotemount/remoterun.sh /tmp/myenv my_script.sh
 ```
 
 Or directly:
@@ -27,7 +27,7 @@ Or directly:
 CONDA_PREFIX=~/monarch_conda_envs/worker/conda \
 ~/monarch_conda_envs/client/conda/bin/python3.12 \
   examples/remotemount/remoterun.py /tmp/myenv my_script.sh \
-  --backend mast --host_type gb300
+  --backend mast --host_type gb200
 
 ```
 
@@ -43,16 +43,17 @@ CONDA_PREFIX=~/monarch_conda_envs/worker/conda \
 - GrandTeton has ibverbs RDMA hardware, so transfers use native RDMA
   (significantly faster than TCP fallback).
 
-### GB300 (aarch64, Blackwell)
+### GB200 / GB300 (aarch64, Blackwell)
 
-- Our entitlement has **17 quota** on GB300 in the `lco` region —
-  scheduling takes ~2 minutes.
+- GB200 and GB300 use the same aarch64 conda environment and wheel.
+- GB200 schedules faster (~3 min) than GB300 (~10 min). Set the host
+  type via `MONARCH_HOST_TYPE=gb200` (default) or `MONARCH_HOST_TYPE=gb300`.
 - Must pass `--locality_constraints ""` to allow scheduling in all regions.
-- GB300 has ibverbs RDMA hardware (10 Mellanox ConnectX devices).
+- Both have ibverbs RDMA hardware (Mellanox ConnectX devices).
   Client-to-worker transfer uses TCP fallback (client has no ibverbs),
   but worker-to-worker fan-out uses native ibverbs.
 - The MAST preamble health checks (`toy_ddp`) fail with socket
-  timeouts on GB300 (ephemeral port firewall issue). Remoterun
+  timeouts on these hosts (ephemeral port firewall issue). Remoterun
   automatically skips them via `MAST_PRECHECK_SKIP_TIME_CONSUMING_CHECKS=1`.
 
 ---
@@ -80,16 +81,20 @@ The job state is cached in `.monarch/job_state.pkl`.
 
 ## Incremental Update Performance
 
-Remotemount uses block-level hashing for incremental updates. On
-re-open, only 100 MB blocks whose hash changed are re-transferred.
+Remotemount uses block-level hashing for incremental updates.
+Block hashes (xxh64, 100 MB blocks) are computed in the Rust packing
+step in a single pass — the hash runs over pages still hot in CPU
+cache from the file-read pass, so it adds negligible overhead.
+On re-open, only blocks whose hash changed are re-transferred.
 Unchanged workers skip transfer entirely (metadata + remount only).
 
 ### Benchmark setup
 
-- 2 GB300 hosts, 8 parallel TLS streams, TCP fallback (no ibverbs from client)
+- 2 GB200 hosts, 8 parallel TLS streams, Rust TLS receiver (rustls)
+- Client-to-worker transfer over TCP (client has no ibverbs),
+  worker-to-worker fan-out via native ibverbs RDMA
 - Each payload contains 1000 `.py` files (~50 MB total) plus a `data.bin`
   file sized to reach the target payload
-- `rdma_max_chunk_size_mb=256`
 - Warm-up step pre-spawns actors so cold start measures transfer time only
 
 ### Scenarios
@@ -106,24 +111,36 @@ Unchanged workers skip transfer entirely (metadata + remount only).
 
 | Payload | Cold start | No change | Rewrite data.bin | Rewrite .py | Delete file |
 |---------|-----------|-----------|-----------------|-------------|-------------|
-| 1 GB    | 22.0s     | 6.3s      | 22.1s           | 14.2s       | 20.1s       |
-| 2 GB    | 22.4s     | 9.0s      | 31.7s           | 16.5s       | 23.2s       |
-| 4 GB    | 25.9s     | 12.1s     | 53.7s           | 23.7s       | 30.0s       |
-| 8 GB    | 40.8s     | 20.0s     | 92.4s           | 31.8s       | 44.6s       |
+| 0 GB    | 12.6s     | 5.0s      | 5.3s            | 5.3s        | 12.8s       |
+| 1 GB    | 14.0s     | 5.3s      | 7.2s            | 6.7s        | 15.3s       |
+| 2 GB    | 15.4s     | 7.5s      | 9.7s            | 7.4s        | 16.6s       |
+| 4 GB    | 18.5s     | 9.7s      | 13.3s           | 8.0s        | 19.9s       |
+| 8 GB    | 26.7s     | 14.9s     | 17.9s           | 12.0s       | 28.5s       |
 
 Key observations:
 
-- **No change** is dominated by client-side packing + hash computation
-  (no network transfer). Time scales linearly with payload size.
+- **No change** is dominated by client-side packing (no network transfer).
+  Combined pack+hash in Rust eliminates a second data pass, reducing
+  "no change" time by ~27% at 8 GB vs a two-pass approach.
 - **Rewrite .py** only re-transfers the ~50 MB code portion; `data.bin`
   blocks are skipped via hash match.
 - **Rewrite data.bin** re-transfers the bulk of the payload since every
   block changes.
 - **Delete file** triggers a full re-pack (total size changes → stale),
   similar to cold start.
+- **Rust TLS receiver** (rustls) eliminates ~4.3s of Python OpenSSL
+  setup overhead per transfer. The receiver writes directly into
+  anonymous mmap, removing the separate `load_cache_into_storage` step.
+- **Parallel packing** distributes file read work round-robin by
+  descending size across 16 threads, achieving ~8 GB/s on the client
+  (vs ~1.5 GB/s with the naive sequential assignment).
+- **Direct buffer send** — dirty blocks are sent directly from the
+  client-side staging buffer (the same mmap used for packing and hashing),
+  eliminating a second file-read pass that previously doubled I/O on the
+  partial transfer path.
 
 To run the benchmark yourself:
 
 ```bash
-python3 examples/remotemount/bench_incremental.py --sizes 1 --num_hosts 2
+python3 examples/remotemount/bench_incremental.py --sizes 1 --hosts 2 --host_type gb200
 ```

--- a/examples/remotemount/bench_incremental.py
+++ b/examples/remotemount/bench_incremental.py
@@ -7,7 +7,7 @@
 
 """Benchmark persistent chunk cache for remotemount across actor restarts.
 
-Calls run_gb300.sh repeatedly with modifications between runs to
+Calls remoterun.sh repeatedly with modifications between runs to
 exercise cache hit, partial update, and full transfer paths.
 Cache files persist in /tmp/monarch_remotemount_cache/ on worker
 hosts, so subsequent runs on the same hosts skip unchanged data.
@@ -40,7 +40,7 @@ import time
 import fire
 
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
-RUN_GB300 = os.path.join(SCRIPT_DIR, "run_gb300.sh")
+RUN_SCRIPT = os.path.join(SCRIPT_DIR, "remoterun.sh")
 NUM_PY = 1000
 SCENARIOS = [
     "Cold start",
@@ -94,13 +94,13 @@ def _create_test_dir(base_dir, total_gb):
 def _run(
     label, num_hosts, source_dir, script="#!/bin/bash\necho done\n", extra_args=None
 ):
-    """Run remoterun via run_gb300.sh and return elapsed time."""
+    """Run remoterun via run.sh and return elapsed time."""
     sys.stdout.write(f"  {label:.<40s}")
     sys.stdout.flush()
 
     cmd = [
         "bash",
-        RUN_GB300,
+        RUN_SCRIPT,
         source_dir,
         "stdin",
         "--num_hosts",
@@ -133,6 +133,41 @@ def _run(
 
     status = "OK" if result.returncode == 0 else f"FAIL({result.returncode})"
     print(f" {elapsed:7.1f}s  {classification}  {status}")
+
+    # Print timing breakdown lines from logs.
+    for line in output.splitlines():
+        if any(
+            k in line.lower()
+            for k in (
+                "timings:",
+                "pack_directory_chunked:",
+                "persistent block transfer",
+                "fan-out:",
+                "_transfer_group",
+                "open() timings:",
+                "cache_write",
+                "write_cache",
+            )
+        ):
+            # Strip log prefix to show just the timing info.
+            idx = -1
+            for marker in (
+                "pack_directory_chunked:",
+                "Persistent block transfer",
+                "Fan-out:",
+                "Timings:",
+                "timings:",
+                "_transfer_group_direct_tls:",
+                "_transfer_group:",
+                "open() timings:",
+                "open(): cache_write",
+                "[WORKER] write_cache",
+            ):
+                idx = line.find(marker)
+                if idx >= 0:
+                    break
+            if idx >= 0:
+                print(f"    {line[idx:]}")
 
     if result.returncode != 0:
         stderr_lines = result.stderr.strip().splitlines()
@@ -207,17 +242,21 @@ def _kill_job():
     print("  Done.")
 
 
-def _run_scenarios(num_hosts, size_gb, bench_dir):
+def _run_scenarios(num_hosts, size_gb, bench_dir, extra_args=None):
     """Run all 5 scenarios for a given payload size, return dict of times."""
     src_dir = os.path.join(bench_dir, "src")
     data_path = os.path.join(bench_dir, "data.bin")
     results = {}
 
     # 1. Cold start (cache was cleared before this call)
-    results["Cold start"] = _run("Cold start", num_hosts, bench_dir)
+    results["Cold start"] = _run(
+        "Cold start", num_hosts, bench_dir, extra_args=extra_args
+    )
 
     # 2. No change (cache hit from cold start)
-    results["No change"] = _run("No change", num_hosts, bench_dir)
+    results["No change"] = _run(
+        "No change", num_hosts, bench_dir, extra_args=extra_args
+    )
 
     # 3. Rewrite data.bin (same size -> partial update)
     data_size = os.path.getsize(data_path)
@@ -227,7 +266,9 @@ def _run_scenarios(num_hosts, size_gb, bench_dir):
             chunk = min(remaining, 64 * 1024 * 1024)
             f.write(os.urandom(chunk))
             remaining -= chunk
-    results["Rewrite data.bin"] = _run("Rewrite data.bin", num_hosts, bench_dir)
+    results["Rewrite data.bin"] = _run(
+        "Rewrite data.bin", num_hosts, bench_dir, extra_args=extra_args
+    )
 
     # 4. Rewrite all .py files (partial update)
     # Use same-length prefix ("Modify" vs "Module" = 6 chars each) and
@@ -235,11 +276,15 @@ def _run_scenarios(num_hosts, size_gb, bench_dir):
     for i in range(NUM_PY):
         with open(os.path.join(src_dir, f"mod_{i}.py"), "w") as f:
             f.write(f"# Modify {i}\n" * 50 + f"def func_{i}(): return {i}\n")
-    results["Rewrite .py"] = _run("Rewrite .py files", num_hosts, bench_dir)
+    results["Rewrite .py"] = _run(
+        "Rewrite .py files", num_hosts, bench_dir, extra_args=extra_args
+    )
 
     # 5. Delete file (total size changes -> stale -> full transfer)
     os.remove(os.path.join(src_dir, "mod_0.py"))
-    results["Delete file"] = _run("Delete file", num_hosts, bench_dir)
+    results["Delete file"] = _run(
+        "Delete file", num_hosts, bench_dir, extra_args=extra_args
+    )
 
     return results
 
@@ -275,7 +320,7 @@ def _print_table(all_results):
     print()
 
 
-def _run_host_count(num_hosts, size_list, work_dir):
+def _run_host_count(num_hosts, size_list, work_dir, extra_args=None):
     """Run all payload sizes for a single host count.
 
     Uses work_dir for .monarch/job_state.pkl isolation and
@@ -303,7 +348,9 @@ def _run_host_count(num_hosts, size_list, work_dir):
             _create_test_dir(bench_dir, size_gb)
             _clear_worker_cache(num_hosts, warmup_dir)
 
-            results = _run_scenarios(num_hosts, size_gb, bench_dir)
+            results = _run_scenarios(
+                num_hosts, size_gb, bench_dir, extra_args=extra_args
+            )
             host_results[(num_hosts, size_gb)] = results
 
             shutil.rmtree(bench_dir, ignore_errors=True)
@@ -315,29 +362,41 @@ def _run_host_count(num_hosts, size_list, work_dir):
         os.chdir(orig_cwd)
 
 
-def main(sizes="1", hosts="2"):
+def main(host_type="gb200", sizes="1", hosts="2", streams=8):
     """Run persistent cache benchmark across payload sizes and host counts.
 
     Args:
+        host_type: MAST host type (default: gb200). Options: gb200, gb300, grandteton
         sizes: Comma-separated GB values (e.g., "1,2,4,8,16,32,64,128")
         hosts: Comma-separated host counts (e.g., "1,2,4,8,16")
+        streams: Number of parallel TLS streams per host (default: 8)
     """
     size_list = _parse_list(sizes)
     host_list = _parse_list(hosts)
+    streams = int(streams)
+
+    # Set host type for remoterun.sh.
+    os.environ["MONARCH_HOST_TYPE"] = host_type
 
     print("=" * 60)
     print("  Persistent Cache Benchmark")
     print(f"  Sizes: {size_list} GB")
     print(f"  Hosts: {host_list}")
+    print(f"  Streams: {streams}")
+    print(f"  Host type: {host_type}")
     print("=" * 60)
 
     base_work_dir = tempfile.mkdtemp(prefix="bench_incremental_")
+
+    extra_args = ["--num_parallel_streams", str(streams)]
 
     all_results = {}
     for num_hosts in host_list:
         work_dir = os.path.join(base_work_dir, f"h{num_hosts}")
         try:
-            host_results = _run_host_count(num_hosts, size_list, work_dir)
+            host_results = _run_host_count(
+                num_hosts, size_list, work_dir, extra_args=extra_args
+            )
             all_results.update(host_results)
         except Exception as e:
             print(f"\n  ERROR: {num_hosts} hosts failed: {e}")

--- a/examples/remotemount/remoterun.py
+++ b/examples/remotemount/remoterun.py
@@ -4,19 +4,24 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-import logging
-import os
-import subprocess
-import sys
-import tempfile
-from pathlib import Path
+import time as _time_mod
 
-import cloudpickle
-import fire
-from monarch.actor import Actor, endpoint, this_host
-from monarch.config import configure
-from monarch.job import SlurmJob
-from monarch.remotemount import remotemount
+_t_import_start = _time_mod.time()
+
+import logging  # noqa: E402
+import os  # noqa: E402
+import subprocess  # noqa: E402
+import sys  # noqa: E402
+import tempfile  # noqa: E402
+import time  # noqa: E402
+from pathlib import Path  # noqa: E402
+
+import cloudpickle  # noqa: E402
+import fire  # noqa: E402
+from monarch.actor import Actor, endpoint, this_host  # noqa: E402
+from monarch.config import configure  # noqa: E402
+from monarch.job import SlurmJob  # noqa: E402
+from monarch.remotemount import remotemount  # noqa: E402
 
 
 class BashActor(Actor):
@@ -43,10 +48,13 @@ def _get_mast_host_mesh(
     locality_constraints,
     host_type,
 ):
+    t0 = time.time()
     from monarch.actor import enable_transport
     from monarch.job.meta import MASTJob
 
+    t1 = time.time()
     enable_transport("metatls-hostname")
+    t2 = time.time()
 
     if locality_constraints is None:
         locality_constraints = []
@@ -66,13 +74,22 @@ def _get_mast_host_mesh(
             "RUST_LOG": "info",
         },
     )
+    t3 = time.time()
     job.add_mesh("workers", num_hosts, host_type=host_type)
     # A workspace directory is required to trigger conda-packing of
     # CONDA_PREFIX into an ephemeral fbpkg.  Without it the scheduler
     # deploys the base image as-is, which fails on cross-arch hosts
     # (e.g. aarch64 GB300 with an x86 base image).
     job.add_directory(tempfile.mkdtemp())
+    t4 = time.time()
     host_meshes = job.state()
+    t5 = time.time()
+    print(
+        f"remoterun timings: mast_import={t1 - t0:.2f}s, "
+        f"enable_transport={t2 - t1:.2f}s, MASTJob()={t3 - t2:.2f}s, "
+        f"add_mesh+dir={t4 - t3:.2f}s, job.state()={t5 - t4:.2f}s",
+        flush=True,
+    )
     return host_meshes.workers, {"job": job}
 
 
@@ -111,6 +128,7 @@ def main(
     host_type: str = "grandteton",
     num_parallel_streams: int = 8,
 ):
+    t_main_start = time.time()
     if verbose:
         logging.basicConfig(
             level=logging.DEBUG,
@@ -126,6 +144,7 @@ def main(
     # timeouts that gate on worker readiness must account for this
     # gap, including mesh_attach_config_timeout (the push_config ack
     # during attach) and the spawn idle timeouts.
+    t_configure_start = time.time()
     configure(
         enable_log_forwarding=True,
         tail_log_lines=100,
@@ -135,6 +154,12 @@ def main(
         actor_spawn_max_idle="120s",
         message_delivery_timeout="600s",
         rdma_max_chunk_size_mb=256,
+    )
+    t_configure_done = time.time()
+    print(
+        f"remoterun timings: import={t_main_start - _t_import_start:.2f}s, "
+        f"configure={t_configure_done - t_configure_start:.2f}s",
+        flush=True,
     )
 
     mount_point = source_dir if mount_point is None else mount_point
@@ -177,6 +202,7 @@ def main(
                 else [locality_constraints]
             )
 
+        t_mast_start = time.time()
         host_mesh, job_info = _get_mast_host_mesh(
             num_hosts,
             gpus_per_host,
@@ -188,6 +214,11 @@ def main(
             host_type,
         )
         procs = host_mesh.spawn_procs(per_host={"gpus": gpus_per_host})
+        t_mast_done = time.time()
+        print(
+            f"remoterun timings: mast_reconnect={t_mast_done - t_mast_start:.2f}s",
+            flush=True,
+        )
     else:
         raise ValueError(f"Unknown backend: {backend}. Must be 'slurm' or 'mast'.")
 
@@ -201,33 +232,44 @@ def main(
         chunk_size_mb = 1024
     chunk_size = chunk_size_mb * 1024 * 1024
 
-    with remotemount(
+    t_rm_start = time.time()
+    rm = remotemount(
         host_mesh,
         str(source_dir),
         str(mount_point),
         chunk_size=chunk_size,
         backend=backend,
         num_parallel_streams=num_parallel_streams,
-    ):
-        bash_actors = procs.spawn("BashActor", BashActor)
-        results = bash_actors.run.call(script).get()
-        # Print stdout for each rank in order
-        print(
-            "\n".join(
-                [
-                    f"== rank{i} stdout ==\n{r[1]['stdout']}"
-                    for i, r in enumerate(results)
-                ]
-            )
+    )
+    rm.open()
+    t_rm_open = time.time()
+
+    bash_actors = procs.spawn("BashActor", BashActor)
+    t_bash_spawn = time.time()
+    results = bash_actors.run.call(script).get()
+    t_bash_run = time.time()
+    # Print stdout for each rank in order
+    print(
+        "\n".join(
+            [f"== rank{i} stdout ==\n{r[1]['stdout']}" for i, r in enumerate(results)]
         )
-        print(
-            "\n".join(
-                [
-                    f"== rank{i} stderr ==\n{r[1]['stderr']}"
-                    for i, r in enumerate(results)
-                ]
-            )
+    )
+    print(
+        "\n".join(
+            [f"== rank{i} stderr ==\n{r[1]['stderr']}" for i, r in enumerate(results)]
         )
+    )
+
+    rm.close()
+    t_rm_close = time.time()
+    print(
+        f"remoterun timings: open={t_rm_open - t_rm_start:.2f}s, "
+        f"bash_spawn={t_bash_spawn - t_rm_open:.2f}s, "
+        f"bash_run={t_bash_run - t_bash_spawn:.2f}s, "
+        f"close={t_rm_close - t_bash_run:.2f}s, "
+        f"total={t_rm_close - t_rm_start:.2f}s",
+        flush=True,
+    )
 
     if backend == "mast" and job_info is not None and kill_job:
         _cleanup_mast_job(job_info, host_mesh, kill_job)

--- a/examples/remotemount/remoterun.sh
+++ b/examples/remotemount/remoterun.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Run remoterun on MAST hosts using pre-built conda environments.
+#
+# Prerequisites:
+#   Run setup_conda_env.sh first to create the conda environments.
+#
+# Usage:
+#   bash examples/remotemount/remoterun.sh <source_dir> <script> [extra remoterun args...]
+#
+# Examples:
+#   bash examples/remotemount/remoterun.sh /tmp/mydir /tmp/myscript.sh
+#   bash examples/remotemount/remoterun.sh /tmp/mydir /tmp/myscript.sh --num_hosts 4
+#   bash examples/remotemount/remoterun.sh /tmp/mydir stdin <<< '#!/bin/bash\nhostname'
+#
+# Environment variables:
+#   MONARCH_HOST_TYPE   Host type to use (default: gb200). Options: gb200, gb300, grandteton
+#   MONARCH_CONDA_ENVS  Path to conda environments (default: ~/monarch_conda_envs)
+
+set -euo pipefail
+
+ENVS="${MONARCH_CONDA_ENVS:-$HOME/monarch_conda_envs}"
+
+if [ ! -d "$ENVS/client/conda" ] || [ ! -d "$ENVS/worker/conda" ]; then
+    echo "Error: conda environments not found at $ENVS"
+    echo "Run setup_conda_env.sh first:"
+    echo "  bash examples/remotemount/setup_conda_env.sh <target> $ENVS"
+    exit 1
+fi
+
+if [ $# -lt 2 ]; then
+    echo "Usage: remoterun.sh <source_dir> <script> [extra remoterun args...]"
+    exit 1
+fi
+
+SOURCE_DIR="$1"
+SCRIPT="$2"
+shift 2
+
+HOST_TYPE="${MONARCH_HOST_TYPE:-gb200}"
+
+CONDA_PREFIX="$ENVS/worker/conda" \
+exec "$ENVS/client/conda/bin/python3.12" \
+    "$(dirname "$0")/remoterun.py" \
+    "$SOURCE_DIR" "$SCRIPT" \
+    --backend mast \
+    --host_type "$HOST_TYPE" \
+    --locality_constraints "" \
+    --verbose \
+    "$@"

--- a/examples/remotemount/setup_conda_env.sh
+++ b/examples/remotemount/setup_conda_env.sh
@@ -14,7 +14,7 @@
 # Usage:
 #   bash examples/setup_conda_env.sh <target> [DEST_DIR]
 #
-#   target:   "gb300" (aarch64) or "grandteton" (x86)
+#   target:   "gb200"/"gb300" (aarch64) or "grandteton"/"h100" (x86)
 #   DEST_DIR: where to create the envs (default: ~/monarch_conda_envs)
 #
 # After setup, run remoterun with:
@@ -25,11 +25,11 @@
 
 set -euo pipefail
 
-TARGET="${1:?Usage: $0 <target> [dest_dir]  (target: gb300 or grandteton)}"
+TARGET="${1:?Usage: $0 <target> [dest_dir]  (target: gb200, gb300, grandteton, or h100)}"
 DEST="${2:-$HOME/monarch_conda_envs}"
 
 case "$TARGET" in
-    gb300)
+    gb200|gb300)
         WORKER_ARCH="aarch64"
         WORKER_BASE_PKG="xlformers_gb200_conda:latest"
         WORKER_WHL_TARGET="fbcode//monarch/python/monarch:monarch_nightly_torch_gb200_py3.12.whl"
@@ -42,7 +42,7 @@ case "$TARGET" in
         WORKER_BUCK_ARGS=""
         ;;
     *)
-        echo "Unknown target: $TARGET (expected: gb300, grandteton, h100)"
+        echo "Unknown target: $TARGET (expected: gb200, gb300, grandteton, h100)"
         exit 1
         ;;
 esac
@@ -125,14 +125,20 @@ set -eEx
 export PYTHONDONTWRITEBYTECODE=1
 export PATH="${CONDA_DIR}/bin:$PATH"
 
-LIBCUDA="/usr/local/fbcode/platform010/lib/libcuda.so"
-if [ -f "$LIBCUDA" ]; then
+LIBCUDA=""
+for p in /usr/local/fbcode/platform010/lib /usr/local/fbcode/platform010-aarch64/lib; do
+    if [ -f "$p/libcuda.so" ]; then
+        LIBCUDA="$p/libcuda.so"
+        break
+    fi
+done
+if [ -n "$LIBCUDA" ]; then
     export LIBCUDA_DIR="${LIBCUDA%/*}"
     export TRITON_LIBCUDA_PATH="$LIBCUDA_DIR"
-    export LD_PRELOAD="$LIBCUDA:/usr/local/fbcode/platform010/lib/libnvidia-ml.so${PRELOAD_PATH:+:$PRELOAD_PATH}"
+    export LD_PRELOAD="$LIBCUDA:$LIBCUDA_DIR/libnvidia-ml.so${PRELOAD_PATH:+:$PRELOAD_PATH}"
 fi
 
-export LD_LIBRARY_PATH="${CONDA_DIR}/lib:${CONDA_DIR}/lib/python3.12/site-packages/torch/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+export LD_LIBRARY_PATH="${CONDA_DIR}/lib:${CONDA_DIR}/lib/python3.12/site-packages/torch/lib${LIBCUDA_DIR:+:$LIBCUDA_DIR}${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
 export PYTHONPATH="${PYTHONPATH:+$PYTHONPATH:}$TORCHX_RUN_PYTHONPATH"
 
 if [ -f "${CONDA_DIR}/bin/activate" ]; then

--- a/monarch_extension/src/lib.rs
+++ b/monarch_extension/src/lib.rs
@@ -234,11 +234,6 @@ pub fn mod_init(module: &Bound<'_, PyModule>) -> PyResult<()> {
         "monarch_extension.fast_pack",
     )?)?;
 
-    crate::chunked_fuse::register_python_bindings(&get_or_add_new_module(
-        module,
-        "monarch_extension.chunked_fuse",
-    )?)?;
-
     crate::tls_receiver::register_python_bindings(&get_or_add_new_module(
         module,
         "monarch_extension.tls_receiver",
@@ -247,6 +242,11 @@ pub fn mod_init(module: &Bound<'_, PyModule>) -> PyResult<()> {
     crate::tls_sender::register_python_bindings(&get_or_add_new_module(
         module,
         "monarch_extension.tls_sender",
+    )?)?;
+
+    crate::chunked_fuse::register_python_bindings(&get_or_add_new_module(
+        module,
+        "monarch_extension.chunked_fuse",
     )?)?;
 
     monarch_hyperactor::logging::register_python_bindings(&get_or_add_new_module(

--- a/monarch_extension/src/tls_sender.rs
+++ b/monarch_extension/src/tls_sender.rs
@@ -134,18 +134,146 @@ struct PackedBuffer {
 
 // SAFETY: the mmap region is process-global memory accessible from any thread.
 unsafe impl Send for PackedBuffer {}
-// SAFETY: the mmap region is immutable after packing; concurrent reads are safe.
 unsafe impl Sync for PackedBuffer {}
 
 impl Drop for PackedBuffer {
     fn drop(&mut self) {
         if self.size > 0 {
-            // SAFETY: self.ptr was allocated via mmap_anonymous(self.size).
             unsafe {
                 libc::munmap(self.ptr, self.size);
             }
         }
     }
+}
+
+/// Send dirty blocks from a buffer over parallel TLS connections.
+///
+/// Each address in `addresses` gets its own TCP+TLS stream. Blocks
+/// are distributed round-robin across streams.
+fn send_blocks_impl(
+    buf_ptr: usize,
+    total_size: usize,
+    dirty_blocks: &[usize],
+    addresses: &[String],
+    cache_path: &str,
+    block_size: usize,
+) -> PyResult<()> {
+    let tls_config = make_tls_config().map_err(|e| PyRuntimeError::new_err(e))?;
+
+    let num_streams = addresses.len();
+
+    // Partition blocks across streams round-robin.
+    let mut per_stream: Vec<Vec<(usize, usize)>> = vec![Vec::new(); num_streams];
+    for (i, &bi) in dirty_blocks.iter().enumerate() {
+        let offset = bi * block_size;
+        let size = std::cmp::min(block_size, total_size - offset);
+        per_stream[i % num_streams].push((offset, size));
+    }
+
+    let cache_path_bytes = cache_path.as_bytes();
+
+    thread::scope(|s| {
+        let mut handles = Vec::with_capacity(num_streams);
+
+        for (stream_idx, blocks) in per_stream.into_iter().enumerate() {
+            let addr = &addresses[stream_idx];
+            let config = Arc::clone(&tls_config);
+            let cp_bytes = cache_path_bytes;
+
+            handles.push(s.spawn(move || -> Result<(), String> {
+                let (host, port_str) = addr
+                    .rsplit_once(':')
+                    .ok_or_else(|| format!("invalid address: {addr}"))?;
+                let port: u16 = port_str
+                    .parse()
+                    .map_err(|e| format!("invalid port in {addr}: {e}"))?;
+
+                let tcp =
+                    TcpStream::connect((host, port)).map_err(|e| format!("connect {addr}: {e}"))?;
+                tcp.set_nodelay(true)
+                    .map_err(|e| format!("set_nodelay: {e}"))?;
+
+                let server_name = ServerName::try_from(host.to_string())
+                    .unwrap_or_else(|_| ServerName::try_from("localhost".to_string()).unwrap());
+
+                let conn = rustls::ClientConnection::new(config, server_name)
+                    .map_err(|e| format!("TLS handshake: {e}"))?;
+                let mut tls = rustls::StreamOwned::new(conn, tcp);
+
+                // Protocol header: cache_path_len(u32 BE) + cache_path + total_size(u64 BE)
+                let mut header = Vec::with_capacity(4 + cp_bytes.len() + 8);
+                header.extend_from_slice(&(cp_bytes.len() as u32).to_be_bytes());
+                header.extend_from_slice(cp_bytes);
+                header.extend_from_slice(&(total_size as u64).to_be_bytes());
+                tls.write_all(&header)
+                    .map_err(|e| format!("write header: {e}"))?;
+
+                // Send blocks: offset(u64 BE) + size(u64 BE) + data
+                for (offset, size) in &blocks {
+                    let mut block_header = [0u8; 16];
+                    block_header[..8].copy_from_slice(&(*offset as u64).to_be_bytes());
+                    block_header[8..].copy_from_slice(&(*size as u64).to_be_bytes());
+                    tls.write_all(&block_header)
+                        .map_err(|e| format!("write block header: {e}"))?;
+
+                    // SAFETY: offset + size <= total_size, buffer is valid.
+                    let data = unsafe {
+                        std::slice::from_raw_parts((buf_ptr + offset) as *const u8, *size)
+                    };
+                    tls.write_all(data)
+                        .map_err(|e| format!("write block data: {e}"))?;
+                }
+
+                // Done sentinel: offset=0, size=0
+                tls.write_all(&[0u8; 16])
+                    .map_err(|e| format!("write sentinel: {e}"))?;
+                // Flush all buffered TLS application data before closing.
+                tls.flush().map_err(|e| format!("flush: {e}"))?;
+                tls.conn.send_close_notify();
+                // Drain the close_notify record to TCP.
+                while tls.conn.wants_write() {
+                    tls.conn
+                        .write_tls(&mut tls.sock)
+                        .map_err(|e| format!("close_notify: {e}"))?;
+                }
+                // Shut down the write half of TCP to send FIN cleanly.
+                tls.sock
+                    .shutdown(std::net::Shutdown::Write)
+                    .map_err(|e| format!("tcp shutdown: {e}"))?;
+
+                // Drain the receive buffer (e.g. TLS 1.3 NewSessionTicket
+                // messages the server sent after the handshake). If unread
+                // data remains when close() is called, the kernel sends
+                // TCP RST instead of FIN, which can truncate in-flight
+                // application data at the receiver.
+                tls.sock
+                    .set_read_timeout(Some(std::time::Duration::from_millis(200)))
+                    .ok();
+                let mut drain = [0u8; 4096];
+                loop {
+                    match tls.sock.read(&mut drain) {
+                        Ok(0) => break,
+                        Ok(_) => continue,
+                        Err(_) => break,
+                    }
+                }
+
+                Ok(())
+            }));
+        }
+
+        let mut errors = Vec::new();
+        for h in handles {
+            if let Err(e) = h.join().unwrap() {
+                errors.push(e);
+            }
+        }
+        if errors.is_empty() {
+            Ok(())
+        } else {
+            Err(PyRuntimeError::new_err(errors.join("; ")))
+        }
+    })
 }
 
 #[pymethods]
@@ -169,126 +297,46 @@ impl PackedBuffer {
         let total_size = self.size;
 
         py.detach(move || {
-            let tls_config = make_tls_config().map_err(PyRuntimeError::new_err)?;
-
-            let num_streams = addresses.len();
-
-            // Partition blocks across streams round-robin.
-            let mut per_stream: Vec<Vec<(usize, usize)>> = vec![Vec::new(); num_streams];
-            for (i, &bi) in dirty_blocks.iter().enumerate() {
-                let offset = bi * block_size;
-                let size = std::cmp::min(block_size, total_size - offset);
-                per_stream[i % num_streams].push((offset, size));
-            }
-
-            let cache_path_bytes = cache_path.as_bytes();
-
-            thread::scope(|s| {
-                let mut handles = Vec::with_capacity(num_streams);
-
-                for (stream_idx, blocks) in per_stream.into_iter().enumerate() {
-                    let addr = &addresses[stream_idx];
-                    let config = Arc::clone(&tls_config);
-                    let cp_bytes = cache_path_bytes;
-
-                    handles.push(s.spawn(move || -> Result<(), String> {
-                        let (host, port_str) = addr
-                            .rsplit_once(':')
-                            .ok_or_else(|| format!("invalid address: {addr}"))?;
-                        let port: u16 = port_str
-                            .parse()
-                            .map_err(|e| format!("invalid port in {addr}: {e}"))?;
-
-                        let tcp = TcpStream::connect((host, port))
-                            .map_err(|e| format!("connect {addr}: {e}"))?;
-                        tcp.set_nodelay(true)
-                            .map_err(|e| format!("set_nodelay: {e}"))?;
-
-                        let server_name =
-                            ServerName::try_from(host.to_string()).unwrap_or_else(|_| {
-                                ServerName::try_from("localhost".to_string()).unwrap()
-                            });
-
-                        let conn = rustls::ClientConnection::new(config, server_name)
-                            .map_err(|e| format!("TLS handshake: {e}"))?;
-                        let mut tls = rustls::StreamOwned::new(conn, tcp);
-
-                        // Protocol header: cache_path_len(u32 BE) + cache_path + total_size(u64 BE)
-                        let mut header = Vec::with_capacity(4 + cp_bytes.len() + 8);
-                        header.extend_from_slice(&(cp_bytes.len() as u32).to_be_bytes());
-                        header.extend_from_slice(cp_bytes);
-                        header.extend_from_slice(&(total_size as u64).to_be_bytes());
-                        tls.write_all(&header)
-                            .map_err(|e| format!("write header: {e}"))?;
-
-                        // Send blocks: offset(u64 BE) + size(u64 BE) + data
-                        for (offset, size) in &blocks {
-                            let mut block_header = [0u8; 16];
-                            block_header[..8].copy_from_slice(&(*offset as u64).to_be_bytes());
-                            block_header[8..].copy_from_slice(&(*size as u64).to_be_bytes());
-                            tls.write_all(&block_header)
-                                .map_err(|e| format!("write block header: {e}"))?;
-
-                            // SAFETY: offset + size <= total_size, buffer is valid.
-                            let data = unsafe {
-                                std::slice::from_raw_parts((buf_ptr + offset) as *const u8, *size)
-                            };
-                            tls.write_all(data)
-                                .map_err(|e| format!("write block data: {e}"))?;
-                        }
-
-                        // Done sentinel: offset=0, size=0
-                        tls.write_all(&[0u8; 16])
-                            .map_err(|e| format!("write sentinel: {e}"))?;
-                        // Flush all buffered TLS application data before closing.
-                        tls.flush().map_err(|e| format!("flush: {e}"))?;
-                        tls.conn.send_close_notify();
-                        // Drain the close_notify record to TCP.
-                        while tls.conn.wants_write() {
-                            tls.conn
-                                .write_tls(&mut tls.sock)
-                                .map_err(|e| format!("close_notify: {e}"))?;
-                        }
-                        // Shut down the write half of TCP to send FIN cleanly.
-                        tls.sock
-                            .shutdown(std::net::Shutdown::Write)
-                            .map_err(|e| format!("tcp shutdown: {e}"))?;
-
-                        // Drain the receive buffer (e.g. TLS 1.3 NewSessionTicket
-                        // messages the server sent after the handshake). If unread
-                        // data remains when close() is called, the kernel sends
-                        // TCP RST instead of FIN, which can truncate in-flight
-                        // application data at the receiver.
-                        tls.sock
-                            .set_read_timeout(Some(std::time::Duration::from_millis(200)))
-                            .ok();
-                        let mut drain = [0u8; 4096];
-                        loop {
-                            match tls.sock.read(&mut drain) {
-                                Ok(0) => break,
-                                Ok(_) => continue,
-                                Err(_) => break,
-                            }
-                        }
-
-                        Ok(())
-                    }));
-                }
-
-                let mut errors = Vec::new();
-                for h in handles {
-                    if let Err(e) = h.join().unwrap() {
-                        errors.push(e);
-                    }
-                }
-                if errors.is_empty() {
-                    Ok(())
-                } else {
-                    Err(PyRuntimeError::new_err(errors.join("; ")))
-                }
-            })
+            send_blocks_impl(
+                buf_ptr,
+                total_size,
+                &dirty_blocks,
+                &addresses,
+                &cache_path,
+                block_size,
+            )
         })
     }
+}
+
+/// Send dirty blocks from an existing buffer over parallel TLS connections.
+///
+/// Like `PackedBuffer.send_blocks()` but operates on any buffer (e.g. a
+/// memoryview from `pack_directory_chunked`), avoiding a second pack step.
+#[pyfunction]
+#[pyo3(signature = (buffer, total_size, dirty_blocks, addresses, cache_path, hash_block_size=None))]
+fn send_blocks_from_buffer(
+    py: Python<'_>,
+    buffer: pyo3::buffer::PyBuffer<u8>,
+    total_size: usize,
+    dirty_blocks: Vec<usize>,
+    addresses: Vec<String>,
+    cache_path: String,
+    hash_block_size: Option<usize>,
+) -> PyResult<()> {
+    let block_size = hash_block_size.unwrap_or(HASH_BLOCK_SIZE);
+    let buf_ptr = buffer.buf_ptr() as usize;
+
+    py.detach(move || {
+        send_blocks_impl(
+            buf_ptr,
+            total_size,
+            &dirty_blocks,
+            &addresses,
+            &cache_path,
+            block_size,
+        )
+    })
 }
 
 /// Pack files into anonymous mmap and compute block hashes.
@@ -343,5 +391,11 @@ pub fn register_python_bindings(module: &Bound<'_, PyModule>) -> PyResult<()> {
         "monarch._rust_bindings.monarch_extension.tls_sender",
     )?;
     module.add_function(f)?;
+    let f2 = wrap_pyfunction!(send_blocks_from_buffer, module)?;
+    f2.setattr(
+        "__module__",
+        "monarch._rust_bindings.monarch_extension.tls_sender",
+    )?;
+    module.add_function(f2)?;
     Ok(())
 }

--- a/monarch_rdma/src/backend/ibverbs/manager_actor.rs
+++ b/monarch_rdma/src/backend/ibverbs/manager_actor.rs
@@ -179,6 +179,11 @@ pub struct IbvManagerActor {
 
     // Map from buffer_id to registration details.
     buffer_registrations: HashMap<usize, IbvBuffer>,
+
+    // Cache of local MR registrations keyed by (addr, size).
+    // Avoids re-registering the same staging buffer on every write_from call.
+    // Entries persist until the actor drops (cleaned up via mr_map).
+    local_mr_cache: HashMap<(usize, usize), (IbvMemoryRegionView, String)>,
 }
 
 #[async_trait]
@@ -325,6 +330,7 @@ impl IbvManagerActor {
             mrv_id: 0,
             pci_to_device,
             buffer_registrations: HashMap::new(),
+            local_mr_cache: HashMap::new(),
         })
     }
 
@@ -632,17 +638,32 @@ impl IbvManagerActor {
         ))
     }
 
-    /// Core submit logic: registers local MR, resolves remote
-    /// IbvBuffer lazily, executes the op, and deregisters local MR.
+    /// Core submit logic: registers local MR (with caching), resolves
+    /// remote IbvBuffer lazily, and executes the op.
+    ///
+    /// Local MR registrations are cached by (addr, size) so repeated
+    /// operations on the same buffer (e.g. a reusable staging buffer)
+    /// skip the expensive `ibv_reg_mr` call.  Cached MRs persist until
+    /// the actor drops (cleaned up via `mr_map`).
     async fn execute_op(
         &mut self,
         cx: &Context<'_, Self>,
         op: IbvOp,
         timeout: Duration,
     ) -> Result<(), anyhow::Error> {
-        // Register the local memory to get an IbvBuffer
+        let addr = op.local_memory.addr();
+        let size = op.local_memory.size();
+
+        // Reuse cached local MR if available; otherwise register and cache.
         let (local_mrv, local_device_name) =
-            self.register_mr(op.local_memory.addr(), op.local_memory.size())?;
+            if let Some(cached) = self.local_mr_cache.get(&(addr, size)) {
+                cached.clone()
+            } else {
+                let result = self.register_mr(addr, size)?;
+                self.local_mr_cache.insert((addr, size), result.clone());
+                result
+            };
+
         let local_buffer = IbvBuffer {
             mr_id: local_mrv.id,
             lkey: local_mrv.lkey,
@@ -652,39 +673,22 @@ impl IbvManagerActor {
             device_name: local_device_name,
         };
 
-        let op_result = async {
-            let mut qp = self
-                .request_queue_pair(
-                    cx,
-                    op.remote_manager.clone(),
-                    local_buffer.device_name.clone(),
-                    op.remote_buffer.device_name.clone(),
-                )
-                .await?;
+        let mut qp = self
+            .request_queue_pair(
+                cx,
+                op.remote_manager.clone(),
+                local_buffer.device_name.clone(),
+                op.remote_buffer.device_name.clone(),
+            )
+            .await?;
 
-            let wr_id = match op.op_type {
-                RdmaOpType::WriteFromLocal => qp.put(local_buffer.clone(), op.remote_buffer)?,
-                RdmaOpType::ReadIntoLocal => qp.get(local_buffer.clone(), op.remote_buffer)?,
-            };
+        let wr_id = match op.op_type {
+            RdmaOpType::WriteFromLocal => qp.put(local_buffer.clone(), op.remote_buffer)?,
+            RdmaOpType::ReadIntoLocal => qp.get(local_buffer.clone(), op.remote_buffer)?,
+        };
 
-            self.wait_for_completion(&local_buffer, &mut qp, PollTarget::Send, &wr_id, timeout)
-                .await
-        }
-        .await;
-
-        // Always deregister the locally registered MR
-        let dereg_result = self.deregister_mr(local_buffer.mr_id);
-
-        match (op_result, dereg_result) {
-            (Ok(()), Ok(())) => Ok(()),
-            (Err(e), Ok(())) => Err(e),
-            (Ok(()), Err(e)) => Err(e),
-            (Err(op_err), Err(dereg_err)) => Err(anyhow::anyhow!(
-                "deregister MR error: {}; op error: {}",
-                dereg_err,
-                op_err
-            )),
-        }
+        self.wait_for_completion(&local_buffer, &mut qp, PollTarget::Send, &wr_id, timeout)
+            .await
     }
 }
 

--- a/monarch_rdma/tests/test_no_gpu.rs
+++ b/monarch_rdma/tests/test_no_gpu.rs
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+//! Tests that run on non-GPU hosts to verify graceful degradation
+//! when the CUDA driver library cannot be loaded.
+
+use monarch_rdma::local_memory::driver_init_error;
+use monarch_rdma::local_memory::is_device_ptr;
+
+#[test]
+fn is_device_ptr_returns_false_without_crashing() {
+    // On non-GPU hosts, libcuda.so.1 is not available.
+    // is_device_ptr must return false (not SIGABRT or panic).
+    assert!(!is_device_ptr(0));
+}
+
+#[test]
+fn is_device_ptr_stack_pointer_returns_false() {
+    let x: u64 = 42;
+    assert!(!is_device_ptr(&x as *const u64 as usize));
+}
+
+#[test]
+fn driver_init_error_returns_message_when_cuda_unavailable() {
+    // Force driver initialization by probing a pointer.
+    let _ = is_device_ptr(0);
+
+    // On non-GPU hosts, driver_init_error should return a message
+    // explaining why libcuda.so.1 couldn't be loaded.
+    // On GPU hosts, it returns None (CUDA loaded fine).
+    if let Some(msg) = driver_init_error() {
+        assert!(
+            !msg.is_empty(),
+            "driver init error message should not be empty"
+        );
+        assert!(
+            msg.contains("libcuda") || msg.contains("RdmaXcel"),
+            "error message should mention libcuda or RdmaXcel, got: {msg}"
+        );
+    }
+    // If None, CUDA is available — that's fine too, test passes.
+}

--- a/python/monarch/_rust_bindings/monarch_extension/chunked_fuse.pyi
+++ b/python/monarch/_rust_bindings/monarch_extension/chunked_fuse.pyi
@@ -1,0 +1,19 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-unsafe
+
+from typing import Sequence
+
+class FuseMountHandle:
+    def unmount(self) -> None: ...
+
+def mount_chunked_fuse(
+    metadata_json: str,
+    chunks: Sequence[memoryview],
+    chunk_size: int,
+    mount_point: str,
+) -> FuseMountHandle: ...


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #3058
* #3020
* #3019
* #3018
* #3017
* #3016

1. **Remotemount documentation** — API reference docs and Sphinx Gallery
   example for monarch.remotemount.

2. **mast.py optimizations** — pickle support via `__getstate__` (drops
   unpicklable `_runner`), cached `_runner` property to avoid repeated
   torchx_runner imports, `_wait_for_job_ready` returns status object to
   avoid double query in `_state()`.

3. **RDMA MR caching** — `local_mr_cache` in IbvManagerActor reuses
   cached memory registrations by (addr, size) instead of re-registering
   on every `write_from` call.

4. **Updated benchmark results** in REMOTERUN_GUIDE.md and generalized
   scripts for GB200/GB300.

Differential Revision: [D96169395](https://our.internmc.facebook.com/intern/diff/D96169395/)