### PR TITLE
Fix navbar logo, typos, broken link, stale repo URL. (#3060)

### DIFF
--- a/docs/source/_static/custom.css
+++ b/docs/source/_static/custom.css
@@ -1,0 +1,15 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/* Increase navbar logo size (default theme sets max-height: 20px) */
+.navbar-header-items__start .navbar-brand .logo__image {
+    max-height: 50px !important;
+}
+.navbar-header-items__mobile-logo .logo__image {
+    max-height: 50px !important;
+}

--- a/docs/source/api/monarch.actor.rst
+++ b/docs/source/api/monarch.actor.rst
@@ -9,7 +9,7 @@ The ``monarch.actor`` module provides the actor-based programming model for dist
 Creating Actors
 ===============
 
-Actors are created on multidmensional meshes of processes that
+Actors are created on multidimensional meshes of processes that
 are launch across hosts. HostMesh represents a mesh of hosts. ProcMesh is a mesh of processes.
 
 .. autoclass:: HostMesh

--- a/docs/source/books/hyperactor-book/src/actors/checkpointable.md
+++ b/docs/source/books/hyperactor-book/src/actors/checkpointable.md
@@ -15,11 +15,11 @@ pub trait Checkpointable: Send + Sync + Sized {
 
 ## Associated Type
 
-- `type State`: A serializable type representing the object's saved state. This must implement `RemoteMessage` so it can serialized and transmitted.
+- `type State`: A serializable type representing the object's saved state. This must implement `RemoteMessage` so it can be serialized and transmitted.
 
 ## `save`
 
-Persists the current state of the component. Returns the Returns a `Self::State` value. If the operation fails, returns `CheckpointError::Save`.
+Persists the current state of the component. Returns a `Self::State` value. If the operation fails, returns `CheckpointError::Save`.
 
 ## `load`
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -108,6 +108,7 @@ html_theme_options = {
 }
 
 html_favicon = "_static/torch-monarch-icons.svg"
+html_css_files = ["custom.css"]
 
 html_sidebars = {
     "generated/examples/getting_started": [],

--- a/docs/source/examples/README.rst
+++ b/docs/source/examples/README.rst
@@ -10,7 +10,7 @@ Examples
 - :doc:`distributed_tensors.py </generated/examples/distributed_tensors>`: Shows how to dispatch tensors and tensor level operations to a distributed mesh of workers and GPUs
 - :doc:`debugging.py </generated/examples/debugging>`: Shows how to use the Monarch debugger to debug a distributed program
 - `Multinode Slurm Tutorial <https://docs.pytorch.org/tutorials/intermediate/monarch_distributed_tutorial.html>`_: Multinode distributed training tutorial using Monarch and Slurm to run an SPMD training job.
-- `Running on Kubernetes using Skypilot <https://github.com/pytorch-labs/monarch/tree/main/examples/skypilot>`_: Run Monarch on Kubernetes and cloud VMs via SkyPilot.
+- `Running on Kubernetes using Skypilot <https://github.com/meta-pytorch/monarch/tree/main/examples/skypilot>`_: Run Monarch on Kubernetes and cloud VMs via SkyPilot.
 
 .. toctree::
    :hidden:

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -4,8 +4,8 @@
 actor messaging. It provides:
 
 1. Remote actors with scalable messaging: Actors are grouped into collections called meshes and messages can be broadcast to all members.
-2. Fault tolerance through supervision trees: Actors and processes for a tree and failures propagate up the tree, providing good default error behavior and enabling fine-grained fault recovery.
-3. Point-to-point RDMA transfers: cheap registration of any GPU or CPU memory in a process, with the one-sided tranfers based on libibverbs
+2. Fault tolerance through supervision trees: Actors and processes form a tree and failures propagate up the tree, providing good default error behavior and enabling fine-grained fault recovery.
+3. Point-to-point RDMA transfers: cheap registration of any GPU or CPU memory in a process, with the one-sided transfers based on libibverbs
 4. Distributed tensors: actors can work with tensor objects sharded across processes
 
 Monarch code imperatively describes how to create processes and actors using a simple python API:
@@ -46,11 +46,11 @@ Here are some suggested steps to get started with Monarch:
 
 1. **Installation**: Check out the [Install guide](installation) for getting monarch installed.
 2. **Getting Started**: The [getting started](./generated/examples/getting_started) provides an introduction to monarchs core API
-2. **Explore Examples**: Review the [Examples](./generated/examples/index) to see Monarch in action
-3. **Dive Deeper**: Explore the API Documentation for more detailed information:
+3. **Explore Examples**: Review the [Examples](./generated/examples/index) to see Monarch in action
+4. **Dive Deeper**: Explore the API Documentation for more detailed information:
     - [Python API](api/index)
     - [Rust API](rust-api)
-4. **Deep Understanding of Actors**: Gain comprehensive knowledge of [Actors](actors), the foundational building blocks of Monarch.
+5. **Deep Understanding of Actors**: Gain comprehensive knowledge of [Actors](actors), the foundational building blocks of Monarch.
 
 ```{toctree}
 :maxdepth: 2

--- a/docs/source/installation.md
+++ b/docs/source/installation.md
@@ -17,8 +17,8 @@ See [README](https://github.com/meta-pytorch/monarch?tab=readme-ov-file#installa
 Now that you've got the basics, you can:
 
 1. Read the [getting started](./generated/examples/getting_started) guide to understand the core concepts.
-1. Check out the [Examples](./generated/examples/index) directory for more detailed demonstrations
-2. Explore the [API documentation](python-api) for a complete reference
+2. Check out the [Examples](./generated/examples/index) directory for more detailed demonstrations
+3. Explore the [API documentation](api/index) for a complete reference
 
 ## Troubleshooting
 


### PR DESCRIPTION
Summary:

Fix multiple minor documentation issues across Monarch docs:
- conf.py + custom.css: Increase navbar logo from 20px to 50px (~2.5x) so the Torch Monarch logo is legible - something had gone wrong to make it extremely small.
- index.md: "for a tree" → "form a tree", "tranfers" → "transfers", duplicate "2." numbering → "3."
- installation.md: broken link `python-api` → `api/index`
- monarch.actor.rst: "multidmensional" → "multidimensional"
- checkpointable.md: "can serialized" → "can be serialized", "Returns the Returns a" → "Returns a"
- README.rst: stale repo URL `pytorch-labs/monarch` → `meta-pytorch/monarch

Reviewed By: dulinriley

Differential Revision: D96941360
