### PR TITLE
mesh admin: delegate PySpyDump to a spawn-per-request child actor so ProcAgent never blocks on py-spy execution (#3065)

### DIFF
--- a/hyperactor_mesh/src/introspect.rs
+++ b/hyperactor_mesh/src/introspect.rs
@@ -89,19 +89,36 @@
 //!   required.
 //! - **PS-4 (raw output passthrough):** On success, `stack` is raw
 //!   py-spy stdout text; no parsing, no transformation.
-//! - **PS-5 (subprocess timeout):** `try_exec` kills and reaps the
-//!   py-spy child after `MESH_ADMIN_PYSPY_TIMEOUT`, returning `Failed`
-//!   rather than blocking the ProcAgent indefinitely.
+//! - **PS-5 (subprocess timeout):** `try_exec` bounds the py-spy
+//!   subprocess inside the worker to `MESH_ADMIN_PYSPY_TIMEOUT`.
+//!   On expiry the child is killed and reaped, and the worker
+//!   returns `Failed { stderr: "…timed out…" }`.
 //! - **PS-6 (bridge timeout):** The HTTP bridge uses a separate
 //!   `MESH_ADMIN_PYSPY_BRIDGE_TIMEOUT` (default 7s), which must
 //!   exceed `MESH_ADMIN_PYSPY_TIMEOUT` so the subprocess kill/reap
 //!   and reply can arrive before the bridge declares
 //!   `gateway_timeout`. Independent of
 //!   `MESH_ADMIN_SINGLE_HOST_TIMEOUT`.
+//! - **PS-7 (non-blocking delegation):** ProcAgent never awaits
+//!   py-spy execution inline. On `PySpyDump` it spawns a child
+//!   `PySpyWorker`, forwards the request, and returns immediately.
+//! - **PS-8 (worker lifecycle):** Each `PySpyWorker` handles
+//!   exactly one forwarded `RunPySpyDump`, replies directly to the
+//!   forwarded `OncePortRef`, then self-terminates via
+//!   `cx.stop()`. Clean exit, no supervision event.
+//! - **PS-9 (concurrent dumps):** py-spy is spawn-per-request, so
+//!   overlapping dumps on the same proc are allowed. Each worker
+//!   runs independently.
 //!
-//! v1 contract note: the current py-spy bridge expects a ProcId-form
-//! reference and rejects other forms as `bad_request`. This may be
-//! broadened in future versions.
+//! v1 contract notes:
+//! - The current py-spy bridge expects a ProcId-form reference and
+//!   rejects other forms as `bad_request`. This may be broadened in
+//!   future versions.
+//! - If `worker.send()` fails after the reply port has moved into
+//!   `RunPySpyDump`, the caller receives no explicit
+//!   `PySpyResult::Failed` — they observe a timeout.
+//!   `MailboxSenderError` does not carry the unsent message, so the
+//!   port is irrecoverable on this path.
 //!
 //! ## Mesh-admin config (MA-*)
 //!

--- a/hyperactor_mesh/src/proc_agent.rs
+++ b/hyperactor_mesh/src/proc_agent.rs
@@ -58,6 +58,9 @@ use serde::Serialize;
 use typeuri::Named;
 
 use crate::Name;
+use crate::pyspy::PySpyResult;
+use crate::pyspy::PySpyWorker;
+use crate::pyspy::RunPySpyDump;
 use crate::resource;
 
 /// Actor name used when spawning the proc agent on user procs.
@@ -911,9 +914,37 @@ impl Handler<PySpyDump> for ProcAgent {
         cx: &Context<Self>,
         message: PySpyDump,
     ) -> Result<(), anyhow::Error> {
-        let runner = crate::pyspy::PySpyRunner;
-        let result = runner.dump_self(message.threads).await;
-        message.result.send(cx, result)?;
+        // Spawn a short-lived child actor to run py-spy without
+        // blocking the ProcAgent message loop. The worker replies
+        // directly to the original caller and self-terminates.
+        let worker = match PySpyWorker.spawn(cx) {
+            Ok(handle) => handle,
+            Err(e) => {
+                message.result.send(
+                    cx,
+                    PySpyResult::Failed {
+                        pid: std::process::id(),
+                        binary: String::new(),
+                        exit_code: None,
+                        stderr: format!("failed to spawn pyspy worker: {}", e),
+                    },
+                )?;
+                return Ok(());
+            }
+        };
+        // Once message.result moves into RunPySpyDump, we lose the
+        // reply port. MailboxSenderError does not carry the unsent
+        // message, so on send failure the caller will observe a
+        // timeout rather than an explicit Failed reply.
+        if let Err(e) = worker.send(
+            cx,
+            RunPySpyDump {
+                threads: message.threads,
+                reply_port: message.result,
+            },
+        ) {
+            tracing::error!("failed to send to pyspy worker: {}", e);
+        }
         Ok(())
     }
 }

--- a/hyperactor_mesh/src/pyspy.rs
+++ b/hyperactor_mesh/src/pyspy.rs
@@ -10,6 +10,10 @@
 //!
 //! See PS-* invariants in `introspect` module doc.
 
+use async_trait::async_trait;
+use hyperactor::Actor;
+use hyperactor::Context;
+use hyperactor::Handler;
 use serde::Deserialize;
 use serde::Serialize;
 use typeuri::Named;
@@ -71,6 +75,40 @@ impl PySpyRunner {
         }
 
         PySpyResult::BinaryNotFound { searched }
+    }
+}
+
+/// Internal message from ProcAgent to a spawned PySpyWorker.
+/// Carries the original caller's reply port so the worker
+/// responds directly without routing back through ProcAgent.
+#[derive(Debug, Serialize, Deserialize, Named)]
+pub struct RunPySpyDump {
+    pub threads: bool,
+    /// The original caller's reply port, forwarded from PySpyDump.
+    pub reply_port: hyperactor::reference::OncePortRef<PySpyResult>,
+}
+wirevalue::register_type!(RunPySpyDump);
+
+/// Short-lived child actor that runs py-spy off the ProcAgent
+/// handler path. Spawned per-request; self-terminates after reply.
+/// Concurrent instances are permitted — py-spy attaches read-only
+/// via `process_vm_readv` and multiple concurrent dumps are safe.
+#[hyperactor::export(handlers = [RunPySpyDump])]
+pub struct PySpyWorker;
+
+impl Actor for PySpyWorker {}
+
+#[async_trait]
+impl Handler<RunPySpyDump> for PySpyWorker {
+    async fn handle(
+        &mut self,
+        cx: &Context<Self>,
+        message: RunPySpyDump,
+    ) -> Result<(), anyhow::Error> {
+        let result = PySpyRunner.dump_self(message.threads).await;
+        message.reply_port.send(cx, result)?;
+        cx.stop("pyspy dump complete")?;
+        Ok(())
     }
 }
 


### PR DESCRIPTION
Summary:

address mariusae's comment on D96756537 by moving py-spy execution off the ProcAgent handler path. ProcAgent no longer awaits PySpyRunner::dump_self() inline; instead it spawns a short-lived PySpyWorker, forwards the original reply port, and returns immediately, while the worker runs py-spy, replies directly to the caller, and self-terminates via cx.stop(). update the py-spy invariant registry to reflect the new non-blocking delegation model, worker lifecycle, concurrent spawn-per-request behavior, the narrower role of subprocess timeout inside the worker, and the remaining send-failure timeout caveat.

Reviewed By: thedavekwon

Differential Revision: D97124994


