### PR TITLE
mesh admin: structured py-spy JSON output with native frames, nonblocking retry, and extended capture flags (#3066)

### DIFF
--- a/hyperactor_mesh/bin/admin_tui/app.rs
+++ b/hyperactor_mesh/bin/admin_tui/app.rs
@@ -929,11 +929,9 @@ pub(crate) fn parse_error_envelope(json: &serde_json::Value) -> Vec<Line<'static
 ///
 /// ## Ok variant
 /// Renders a two-field metadata header (`pid` / `binary` basename),
-/// a blank separator, then the stack with thread-header lines styled
-/// using `scheme.node_proc` and indented frame lines styled using
-/// `scheme.node_actor`. `Process N: ...` banner lines emitted by
-/// py-spy are suppressed because the metadata header already contains
-/// that information.
+/// a blank separator, then per-thread sections from the structured
+/// `stack_traces` array. Thread headers are styled using
+/// `scheme.node_proc` and frame lines using `scheme.node_actor`.
 pub(crate) fn pyspy_json_to_lines(
     json: &serde_json::Value,
     scheme: &ColorScheme,
@@ -951,7 +949,6 @@ pub(crate) fn pyspy_json_to_lines(
             .and_then(|n| n.to_str())
             .unwrap_or(binary)
             .to_owned();
-        let stack = ok.get("stack").and_then(|s| s.as_str()).unwrap_or("");
 
         let mut lines: Vec<Line<'static>> = vec![];
 
@@ -967,26 +964,92 @@ pub(crate) fn pyspy_json_to_lines(
         lines.push(Line::from(header));
         lines.push(Line::from("")); // blank separator
 
-        if stack.is_empty() {
+        let traces = ok
+            .get("stack_traces")
+            .and_then(|v| v.as_array())
+            .map(Vec::as_slice)
+            .unwrap_or_default();
+
+        if traces.is_empty() {
             lines.push(Line::from("(empty stack)"));
             return lines;
         }
 
-        for l in stack.lines() {
-            // Suppress the "Process N: /very/long/path ..." banner that
-            // py-spy emits at the top of the output — pid and binary are
-            // already shown in the metadata header above.
-            if l.starts_with("Process ") {
-                continue;
+        for trace in traces {
+            // Thread header: "Thread 0x1234 (MainThread) [active, gil]"
+            let thread_id = trace.get("thread_id").and_then(|v| v.as_u64()).unwrap_or(0);
+            let thread_name = trace
+                .get("thread_name")
+                .and_then(|v| v.as_str())
+                .unwrap_or("");
+            let active = trace
+                .get("active")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false);
+            let owns_gil = trace
+                .get("owns_gil")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false);
+
+            let mut flags = Vec::new();
+            if active {
+                flags.push("active");
             }
-            if l.starts_with(|c: char| c.is_whitespace()) {
-                // Indented stack frame line
-                lines.push(Line::from(Span::styled(l.to_owned(), scheme.node_actor)));
+            if owns_gil {
+                flags.push("gil");
+            }
+            let flags_str = if flags.is_empty() {
+                String::new()
             } else {
-                // Thread header or other top-level line
-                lines.push(Line::from(Span::styled(l.to_owned(), scheme.node_proc)));
+                format!(" [{}]", flags.join(", "))
+            };
+            let name_part = if thread_name.is_empty() {
+                String::new()
+            } else {
+                format!(" ({})", thread_name)
+            };
+            lines.push(Line::from(Span::styled(
+                format!("Thread 0x{thread_id:x}{name_part}{flags_str}"),
+                scheme.node_proc,
+            )));
+
+            // Frames, innermost first.
+            let frames = trace
+                .get("frames")
+                .and_then(|v| v.as_array())
+                .map(Vec::as_slice)
+                .unwrap_or_default();
+            for (i, frame) in frames.iter().enumerate() {
+                let name = frame.get("name").and_then(|v| v.as_str()).unwrap_or("?");
+                let filename = frame
+                    .get("short_filename")
+                    .and_then(|v| v.as_str())
+                    .or_else(|| frame.get("filename").and_then(|v| v.as_str()))
+                    .unwrap_or("");
+                let line_no = frame.get("line").and_then(|v| v.as_i64()).unwrap_or(0);
+                lines.push(Line::from(Span::styled(
+                    format!("  #{i:<3} {name} ({filename}:{line_no})"),
+                    scheme.node_actor,
+                )));
+            }
+            lines.push(Line::from("")); // blank separator between threads
+        }
+
+        // Render non-fatal warnings (e.g., --native-all fallback).
+        let warnings = ok
+            .get("warnings")
+            .and_then(|v| v.as_array())
+            .map(Vec::as_slice)
+            .unwrap_or_default();
+        for w in warnings {
+            if let Some(s) = w.as_str() {
+                lines.push(Line::from(Span::styled(
+                    format!("warn: {s}"),
+                    scheme.detail_status_warn,
+                )));
             }
         }
+
         return lines;
     }
     if let Some(nf) = json.get("BinaryNotFound") {

--- a/hyperactor_mesh/bin/admin_tui/client.rs
+++ b/hyperactor_mesh/bin/admin_tui/client.rs
@@ -343,7 +343,10 @@ fn add_tls_from_bundle(
 pub(crate) fn build_client(args: &Args) -> (String, reqwest::Client) {
     let (explicit_scheme, host) = parse_addr(&args.addr);
 
-    let mut builder = reqwest::Client::builder().timeout(Duration::from_secs(5));
+    // Must exceed the server-side MESH_ADMIN_PYSPY_BRIDGE_TIMEOUT
+    // (13s) so py-spy dumps with --native can complete before the
+    // client gives up.
+    let mut builder = reqwest::Client::builder().timeout(Duration::from_secs(15));
     let mut use_tls = explicit_scheme == Some("https");
 
     // 1. Explicit CLI cert paths.

--- a/hyperactor_mesh/bin/admin_tui/tests/mod.rs
+++ b/hyperactor_mesh/bin/admin_tui/tests/mod.rs
@@ -1655,26 +1655,47 @@ fn parse_error_envelope_missing_code_and_message() {
     assert_eq!(lines[0].spans[0].content, "unknown: ");
 }
 
-// PY-3: Ok result replaces overlay content with the stack lines.
-// pyspy_json_to_lines: Ok with non-empty stack → metadata header + blank + stack lines.
+// PY-3: Ok result replaces overlay content with structured stack traces.
+// pyspy_json_to_lines: Ok with one thread/frame → header + blank + thread + frame + trailing blank.
 #[test]
 fn pyspy_json_to_lines_ok_with_stack() {
-    let json = serde_json::json!({"Ok": {"pid": 1, "binary": "py-spy", "stack": "Thread 0\n  foo.py:1\n"}});
+    let json = serde_json::json!({"Ok": {
+        "pid": 1,
+        "binary": "py-spy",
+        "stack_traces": [{
+            "pid": 1,
+            "thread_id": 0,
+            "thread_name": null,
+            "os_thread_id": null,
+            "active": false,
+            "owns_gil": false,
+            "frames": [{
+                "name": "foo",
+                "filename": "foo.py",
+                "module": null,
+                "short_filename": null,
+                "line": 1,
+                "locals": null,
+                "is_entry": false
+            }]
+        }]
+    }});
     let scheme = ColorScheme::nord();
     let lines = pyspy_json_to_lines(&json, &scheme);
-    // header + blank separator + 2 stack lines; trailing newline must not produce empty line
-    assert_eq!(lines.len(), 4);
+    // header + blank + thread header + frame + trailing blank
+    assert_eq!(lines.len(), 5);
     assert_eq!(line_text(&lines[0]), "pid: 1  binary: py-spy");
     assert_eq!(line_text(&lines[1]), ""); // blank separator
-    assert_eq!(line_text(&lines[2]), "Thread 0");
-    assert_eq!(line_text(&lines[3]), "  foo.py:1");
+    assert_eq!(line_text(&lines[2]), "Thread 0x0");
+    assert_eq!(line_text(&lines[3]), "  #0   foo (foo.py:1)");
+    assert_eq!(line_text(&lines[4]), ""); // trailing blank
 }
 
 // PY-3: empty stack still produces a readable sentinel rather than a blank overlay.
-// pyspy_json_to_lines: Ok with empty stack → metadata header + blank + sentinel line.
+// pyspy_json_to_lines: Ok with empty stack_traces → metadata header + blank + sentinel line.
 #[test]
 fn pyspy_json_to_lines_ok_empty_stack() {
-    let json = serde_json::json!({"Ok": {"pid": 1, "binary": "py-spy", "stack": ""}});
+    let json = serde_json::json!({"Ok": {"pid": 1, "binary": "py-spy", "stack_traces": []}});
     let scheme = ColorScheme::nord();
     let lines = pyspy_json_to_lines(&json, &scheme);
     assert_eq!(lines.len(), 3); // header + blank + sentinel
@@ -1752,26 +1773,46 @@ fn pyspy_json_to_lines_unknown_variant() {
     );
 }
 
-// PY-3: "Process N: /path ..." banner emitted by py-spy is stripped so the
-// pid/binary metadata header (already rendered at the top) doesn't dominate.
-// pyspy_json_to_lines: Ok with Process banner → banner line stripped.
+// PY-3: structured output renders thread name, flags, and binary basename.
+// pyspy_json_to_lines: Ok with named active thread holding GIL → thread
+// header includes name and [active, gil] flags; binary path is basename-only.
 #[test]
-fn pyspy_json_to_lines_ok_strips_process_banner() {
+fn pyspy_json_to_lines_ok_thread_name_and_flags() {
     let json = serde_json::json!({
         "Ok": {
             "pid": 123,
             "binary": "/very/long/path/to/pyspy_workload",
-            "stack": "Process 123: /very/long/path/to/pyspy_workload --args\nThread 0\n  foo.py:1\n"
+            "stack_traces": [{
+                "pid": 123,
+                "thread_id": 4660,
+                "thread_name": "MainThread",
+                "os_thread_id": null,
+                "active": true,
+                "owns_gil": true,
+                "frames": [{
+                    "name": "foo",
+                    "filename": "/path/to/foo.py",
+                    "module": null,
+                    "short_filename": "foo.py",
+                    "line": 1,
+                    "locals": null,
+                    "is_entry": false
+                }]
+            }]
         }
     });
     let scheme = ColorScheme::nord();
     let lines = pyspy_json_to_lines(&json, &scheme);
-    // header + blank + "Thread 0" + "  foo.py:1" = 4; Process banner stripped
-    assert_eq!(lines.len(), 4);
+    // header + blank + thread header + frame + trailing blank
+    assert_eq!(lines.len(), 5);
     assert_eq!(line_text(&lines[0]), "pid: 123  binary: pyspy_workload");
     assert_eq!(line_text(&lines[1]), "");
-    assert_eq!(line_text(&lines[2]), "Thread 0");
-    assert_eq!(line_text(&lines[3]), "  foo.py:1");
+    assert_eq!(
+        line_text(&lines[2]),
+        "Thread 0x1234 (MainThread) [active, gil]"
+    );
+    assert_eq!(line_text(&lines[3]), "  #0   foo (foo.py:1)");
+    assert_eq!(line_text(&lines[4]), "");
 }
 
 // ── TUI-21 build_diag_overlay tests ────────────────────────────────────────

--- a/hyperactor_mesh/src/config.rs
+++ b/hyperactor_mesh/src/config.rs
@@ -191,15 +191,17 @@ declare_attrs! {
     pub attr MESH_ADMIN_QUERY_CHILD_TIMEOUT: Duration = Duration::from_millis(100);
 
     /// Timeout for py-spy dump requests. See PS-5 in `introspect`
-    /// module doc. py-spy dump is typically ~100ms, but ptrace attach
-    /// can stall on heavily loaded hosts. Independent of
+    /// module doc. With `--native --native-all`, py-spy unwinds native
+    /// stacks via libunwind which is significantly slower than
+    /// Python-only capture (~100ms). 10s accommodates native unwinding
+    /// on heavily loaded hosts. Independent of
     /// `MESH_ADMIN_SINGLE_HOST_TIMEOUT` because py-spy does real I/O
     /// (subprocess + ptrace) rather than actor messaging.
     @meta(CONFIG = ConfigAttr::new(
         Some("HYPERACTOR_MESH_ADMIN_PYSPY_TIMEOUT".to_string()),
         Some("mesh_admin_pyspy_timeout".to_string()),
     ))
-    pub attr MESH_ADMIN_PYSPY_TIMEOUT: Duration = Duration::from_secs(5);
+    pub attr MESH_ADMIN_PYSPY_TIMEOUT: Duration = Duration::from_secs(10);
 
     /// Timeout for the `/v1/tree` fan-out. Kept generous because the
     /// tree dump walks every host and proc in the mesh.
@@ -217,5 +219,5 @@ declare_attrs! {
         Some("HYPERACTOR_MESH_ADMIN_PYSPY_BRIDGE_TIMEOUT".to_string()),
         Some("mesh_admin_pyspy_bridge_timeout".to_string()),
     ))
-    pub attr MESH_ADMIN_PYSPY_BRIDGE_TIMEOUT: Duration = Duration::from_secs(7);
+    pub attr MESH_ADMIN_PYSPY_BRIDGE_TIMEOUT: Duration = Duration::from_secs(13);
 }

--- a/hyperactor_mesh/src/introspect.rs
+++ b/hyperactor_mesh/src/introspect.rs
@@ -87,14 +87,18 @@
 //!   `PYSPY_BIN` (if set and non-empty) then `"py-spy"` on PATH.
 //!   If the first attempt is not found, the fallback attempt is
 //!   required.
-//! - **PS-4 (raw output passthrough):** On success, `stack` is raw
-//!   py-spy stdout text; no parsing, no transformation.
+//! - **PS-4 (structured JSON output):** py-spy runs with `--json`;
+//!   output is parsed into `Vec<PySpyStackTrace>`. Parse failure
+//!   maps to `PySpyResult::Failed`.
 //! - **PS-5 (subprocess timeout):** `try_exec` bounds the py-spy
-//!   subprocess inside the worker to `MESH_ADMIN_PYSPY_TIMEOUT`.
-//!   On expiry the child is killed and reaped, and the worker
-//!   returns `Failed { stderr: "…timed out…" }`.
+//!   subprocess inside the worker to `MESH_ADMIN_PYSPY_TIMEOUT`
+//!   (default 10s). The budget is sized for `--native --native-all`
+//!   which unwinds native stacks via libunwind — significantly
+//!   slower than Python-only capture on loaded hosts. On expiry the
+//!   child is killed and reaped, and the worker returns
+//!   `Failed { stderr: "…timed out…" }`.
 //! - **PS-6 (bridge timeout):** The HTTP bridge uses a separate
-//!   `MESH_ADMIN_PYSPY_BRIDGE_TIMEOUT` (default 7s), which must
+//!   `MESH_ADMIN_PYSPY_BRIDGE_TIMEOUT` (default 13s), which must
 //!   exceed `MESH_ADMIN_PYSPY_TIMEOUT` so the subprocess kill/reap
 //!   and reply can arrive before the bridge declares
 //!   `gateway_timeout`. Independent of
@@ -109,6 +113,16 @@
 //! - **PS-9 (concurrent dumps):** py-spy is spawn-per-request, so
 //!   overlapping dumps on the same proc are allowed. Each worker
 //!   runs independently.
+//! - **PS-10 (nonblocking retry):** In nonblocking mode, `try_exec`
+//!   retries up to 3 times with 100ms backoff on failure, because
+//!   py-spy can segfault reading mutating process memory. All
+//!   attempts share a single deadline bounded by
+//!   `MESH_ADMIN_PYSPY_TIMEOUT` (PS-5).
+//! - **PS-11 (native-all fallback):** If `native_all` is requested
+//!   but the py-spy binary rejects `--native-all` (exit code 2,
+//!   stderr mentions the flag), `try_exec` drops the flag and
+//!   retries automatically. This handles version skew where deployed
+//!   py-spy predates `--native-all` support.
 //!
 //! v1 contract notes:
 //! - The current py-spy bridge expects a ProcId-form reference and

--- a/hyperactor_mesh/src/mesh_admin.rs
+++ b/hyperactor_mesh/src/mesh_admin.rs
@@ -285,6 +285,9 @@ use crate::host_mesh::host_agent::HostId;
 use crate::introspect::NodePayload;
 use crate::introspect::NodeProperties;
 use crate::introspect::to_node_payload;
+use crate::proc_agent::PROC_AGENT_ACTOR_NAME;
+use crate::proc_agent::PySpyDump;
+use crate::pyspy::PySpyResult;
 
 /// Send an `IntrospectMessage` to an actor and receive the reply.
 /// Encapsulates open_once_port + send + timeout + error handling.
@@ -1095,7 +1098,7 @@ impl MeshAdminAgent {
         }
 
         // Fall back to querying the ProcAgent directly (user procs).
-        let mesh_agent_id = proc_id.actor_id(crate::proc_agent::PROC_AGENT_ACTOR_NAME, 0);
+        let mesh_agent_id = proc_id.actor_id(PROC_AGENT_ACTOR_NAME, 0);
         let result = query_child_introspect(
             cx,
             &mesh_agent_id,
@@ -1257,7 +1260,7 @@ impl MeshAdminAgent {
         } else {
             // Check terminated snapshots first — fast, no ambiguity.
             let proc_id = actor_id.proc_id();
-            let mesh_agent_id = proc_id.actor_id(crate::proc_agent::PROC_AGENT_ACTOR_NAME, 0);
+            let mesh_agent_id = proc_id.actor_id(PROC_AGENT_ACTOR_NAME, 0);
             let terminated = query_child_introspect(
                 cx,
                 &mesh_agent_id,
@@ -1614,20 +1617,25 @@ fn parse_pyspy_proc_reference(
 async fn pyspy_bridge(
     State(state): State<Arc<BridgeState>>,
     AxumPath(proc_reference): AxumPath<String>,
-) -> Result<Json<crate::pyspy::PySpyResult>, ApiError> {
+) -> Result<Json<PySpyResult>, ApiError> {
     let (proc_reference, proc_id) = parse_pyspy_proc_reference(&proc_reference)?;
-    let agent_id = proc_id.actor_id(crate::proc_agent::PROC_AGENT_ACTOR_NAME, 0);
+    let agent_id = proc_id.actor_id(PROC_AGENT_ACTOR_NAME, 0);
 
     // Send PySpyDump directly to ProcAgent.
     let cx = &state.bridge_cx;
-    let port = hyperactor_reference::PortRef::<crate::proc_agent::PySpyDump>::attest_message_port(
-        &agent_id,
-    );
-    let (reply_handle, reply_rx) = open_once_port::<crate::pyspy::PySpyResult>(cx);
+    let port = hyperactor_reference::PortRef::<PySpyDump>::attest_message_port(&agent_id);
+    let (reply_handle, reply_rx) = open_once_port::<PySpyResult>(cx);
+    // Native frames are essential for diagnosing hangs in C
+    // extensions and CUDA calls — the primary py-spy use case in
+    // Monarch. These defaults match the old hyperactor_multiprocess
+    // battle-tested diagnostics.
     port.send(
         cx,
-        crate::proc_agent::PySpyDump {
+        PySpyDump {
             threads: false,
+            native: true,
+            native_all: true,
+            nonblocking: false,
             result: reply_handle.bind(),
         },
     )
@@ -1637,7 +1645,7 @@ async fn pyspy_bridge(
         details: None,
     })?;
 
-    let result = tokio::time::timeout(
+    let wire_result = tokio::time::timeout(
         hyperactor_config::global::get(crate::config::MESH_ADMIN_PYSPY_BRIDGE_TIMEOUT),
         reply_rx.recv(),
     )
@@ -1659,7 +1667,7 @@ async fn pyspy_bridge(
         details: None,
     })?;
 
-    Ok(Json(result))
+    Ok(Json(wire_result))
 }
 
 /// Resolve an opaque reference string to a `NodePayload` via the

--- a/hyperactor_mesh/src/mesh_admin_skill.md
+++ b/hyperactor_mesh/src/mesh_admin_skill.md
@@ -96,7 +96,7 @@ except `/SKILL.md` (`text/markdown`).
   target environment and ptrace permissions.
 
   Success returns a `PySpyResult` JSON variant:
-  - `{"Ok": {"pid": N, "binary": "...", "stack": "..."}}` — stack dump
+  - `{"Ok": {"pid": N, "binary": "...", "stack_traces": [...], "warnings": [...]}}` — structured stack dump
   - `{"BinaryNotFound": {"searched": [...]}}` — py-spy not available
   - `{"Failed": {"pid": N, "binary": "...", "exit_code": N, "stderr": "..."}}` — py-spy error
 

--- a/hyperactor_mesh/src/proc_agent.rs
+++ b/hyperactor_mesh/src/proc_agent.rs
@@ -58,6 +58,7 @@ use serde::Serialize;
 use typeuri::Named;
 
 use crate::Name;
+use crate::pyspy::PySpyOpts;
 use crate::pyspy::PySpyResult;
 use crate::pyspy::PySpyWorker;
 use crate::pyspy::RunPySpyDump;
@@ -90,6 +91,29 @@ pub enum GspawnResult {
 }
 wirevalue::register_type!(GspawnResult);
 
+/// Request a py-spy stack dump from this process.
+///
+/// The ProcAgent runs inside the target OS process (1:1 mapping).
+/// py-spy attaches to `std::process::id()` to capture Python stacks.
+/// See PS-1 in `introspect` module doc.
+#[derive(Debug, Serialize, Deserialize, Named, Handler, HandleClient, RefClient)]
+pub struct PySpyDump {
+    /// Include per-thread stacks.
+    pub threads: bool,
+    /// Include native C/C++ frames for threads that have Python frames
+    /// (`--native`).
+    pub native: bool,
+    /// Include native C/C++ frames for all threads, even those without
+    /// Python frames (`--native-all`).
+    pub native_all: bool,
+    /// Use nonblocking mode (py-spy reads without pausing the target).
+    pub nonblocking: bool,
+    /// Reply port for the result.
+    #[reply]
+    pub result: hyperactor_reference::OncePortRef<crate::pyspy::PySpyResult>,
+}
+wirevalue::register_type!(PySpyDump);
+
 /// Deferred republish of introspect properties.
 ///
 /// Sent as a zero-delay self-message from the supervision event
@@ -106,18 +130,6 @@ wirevalue::register_type!(GspawnResult);
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Named, Bind, Unbind)]
 struct RepublishIntrospect;
 wirevalue::register_type!(RepublishIntrospect);
-
-/// py-spy attaches to `std::process::id()` to capture Python stacks.
-/// See PS-1 in `introspect` module doc.
-#[derive(Debug, Serialize, Deserialize, Named, Handler, HandleClient, RefClient)]
-pub struct PySpyDump {
-    /// Include per-thread stacks.
-    pub threads: bool,
-    /// Reply port for the result.
-    #[reply]
-    pub result: hyperactor_reference::OncePortRef<crate::pyspy::PySpyResult>,
-}
-wirevalue::register_type!(PySpyDump);
 
 /// Collect live actor children and system actor children from the
 /// proc's instance DashMap using `all_instance_keys()` with point
@@ -920,17 +932,21 @@ impl Handler<PySpyDump> for ProcAgent {
         let worker = match PySpyWorker.spawn(cx) {
             Ok(handle) => handle,
             Err(e) => {
-                message.result.send(
-                    cx,
-                    PySpyResult::Failed {
-                        pid: std::process::id(),
-                        binary: String::new(),
-                        exit_code: None,
-                        stderr: format!("failed to spawn pyspy worker: {}", e),
-                    },
-                )?;
+                let fail = PySpyResult::Failed {
+                    pid: std::process::id(),
+                    binary: String::new(),
+                    exit_code: None,
+                    stderr: format!("failed to spawn pyspy worker: {}", e),
+                };
+                message.result.send(cx, fail)?;
                 return Ok(());
             }
+        };
+        let opts = PySpyOpts {
+            threads: message.threads,
+            native: message.native,
+            native_all: message.native_all,
+            nonblocking: message.nonblocking,
         };
         // Once message.result moves into RunPySpyDump, we lose the
         // reply port. MailboxSenderError does not carry the unsent
@@ -939,7 +955,7 @@ impl Handler<PySpyDump> for ProcAgent {
         if let Err(e) = worker.send(
             cx,
             RunPySpyDump {
-                threads: message.threads,
+                opts,
                 reply_port: message.result,
             },
         ) {

--- a/hyperactor_mesh/src/pyspy.rs
+++ b/hyperactor_mesh/src/pyspy.rs
@@ -23,23 +23,103 @@ use typeuri::Named;
 /// See PS-2, PS-4 in `introspect` module doc.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Named)]
 pub enum PySpyResult {
-    /// Successful stack dump.
+    /// Successful stack dump with structured traces.
     Ok {
+        /// OS process ID that was dumped.
         pid: u32,
+        /// Path or name of the py-spy binary that produced the dump.
         binary: String,
-        stack: String,
+        /// Per-thread stack traces from py-spy.
+        stack_traces: Vec<PySpyStackTrace>,
+        /// Non-fatal warnings from the capture (e.g., flag
+        /// fallbacks). Empty when the capture completed without
+        /// caveats.
+        warnings: Vec<String>,
     },
     /// py-spy binary not found in environment.
-    BinaryNotFound { searched: Vec<String> },
+    BinaryNotFound {
+        /// Candidate paths that were tried before giving up.
+        searched: Vec<String>,
+    },
     /// py-spy exited with an error.
     Failed {
+        /// OS process ID that was targeted.
         pid: u32,
+        /// Path or name of the py-spy binary that failed.
         binary: String,
+        /// Exit code from the py-spy process, if available.
         exit_code: Option<i32>,
+        /// Captured stderr output.
         stderr: String,
     },
 }
 wirevalue::register_type!(PySpyResult);
+
+/// A single thread's stack trace from py-spy `--json` output.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct PySpyStackTrace {
+    /// OS process ID that owns this thread.
+    pub pid: i32,
+    /// Python-level thread identifier (`threading.get_ident()`).
+    pub thread_id: u64,
+    /// Python thread name, if set.
+    pub thread_name: Option<String>,
+    /// OS-level thread ID (e.g., `gettid()` on Linux).
+    pub os_thread_id: Option<u64>,
+    /// Whether the thread is actively running (not idle/waiting).
+    pub active: bool,
+    /// Whether the thread currently holds the GIL.
+    pub owns_gil: bool,
+    /// Stack frames, innermost first.
+    pub frames: Vec<PySpyFrame>,
+}
+
+/// A single frame in a py-spy stack trace.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct PySpyFrame {
+    /// Function or method name.
+    pub name: String,
+    /// Absolute path to the source file.
+    pub filename: String,
+    /// Python module name, if known.
+    pub module: Option<String>,
+    /// Basename or abbreviated path.
+    pub short_filename: Option<String>,
+    /// Source line number.
+    pub line: i32,
+    /// Local variables captured in this frame, if available.
+    pub locals: Option<Vec<PySpyLocalVariable>>,
+    /// Whether this frame is an entry point (e.g., module `__main__`).
+    pub is_entry: bool,
+}
+
+/// A local variable captured in a py-spy frame.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct PySpyLocalVariable {
+    /// Variable name.
+    pub name: String,
+    /// Memory address of the Python object.
+    pub addr: usize,
+    /// Whether this variable is a function argument.
+    pub arg: bool,
+    /// `repr()` of the value, if captured.
+    pub repr: Option<String>,
+}
+
+/// Options controlling py-spy capture behavior.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PySpyOpts {
+    /// Include per-thread stacks (`--threads`).
+    pub threads: bool,
+    /// Include native C/C++ frames (`--native`).
+    pub native: bool,
+    /// Include native frames for all threads, not just those with
+    /// Python frames (`--native-all`).
+    pub native_all: bool,
+    /// Use nonblocking mode — py-spy reads without pausing the
+    /// target process (`--nonblocking`). Enables retry logic (PS-10).
+    pub nonblocking: bool,
+}
 
 /// Runs py-spy against the current process.
 ///
@@ -50,12 +130,13 @@ impl PySpyRunner {
     /// Dump Python stacks for this process.
     ///
     /// Resolves the py-spy binary (PS-3), attaches to
-    /// `std::process::id()` (PS-1), and returns raw output (PS-4).
+    /// `std::process::id()` (PS-1), and returns structured JSON
+    /// output (PS-4).
     ///
     /// PS-1 is structurally enforced: `PySpyDump` carries no PID
     /// field, and this method hardcodes `std::process::id()`. There
     /// is no code path that could substitute a different PID.
-    pub async fn dump_self(&self, threads: bool) -> PySpyResult {
+    pub async fn dump_self(&self, opts: &PySpyOpts) -> PySpyResult {
         let pid = std::process::id();
         let candidates = resolve_candidates(std::env::var("PYSPY_BIN").ok());
         let mut searched = vec![];
@@ -65,7 +146,7 @@ impl PySpyRunner {
             if let Some(result) = try_exec(
                 binary,
                 pid,
-                threads,
+                opts,
                 hyperactor_config::global::get(crate::config::MESH_ADMIN_PYSPY_TIMEOUT),
             )
             .await
@@ -83,7 +164,7 @@ impl PySpyRunner {
 /// responds directly without routing back through ProcAgent.
 #[derive(Debug, Serialize, Deserialize, Named)]
 pub struct RunPySpyDump {
-    pub threads: bool,
+    pub opts: PySpyOpts,
     /// The original caller's reply port, forwarded from PySpyDump.
     pub reply_port: hyperactor::reference::OncePortRef<PySpyResult>,
 }
@@ -105,7 +186,7 @@ impl Handler<RunPySpyDump> for PySpyWorker {
         cx: &Context<Self>,
         message: RunPySpyDump,
     ) -> Result<(), anyhow::Error> {
-        let result = PySpyRunner.dump_self(message.threads).await;
+        let result = PySpyRunner.dump_self(&message.opts).await;
         message.reply_port.send(cx, result)?;
         cx.stop("pyspy dump complete")?;
         Ok(())
@@ -127,26 +208,47 @@ fn resolve_candidates(pyspy_bin_env: Option<String>) -> Vec<(String, String)> {
 }
 
 /// Build the py-spy command for a given binary path.
-fn build_command(binary: &str, pid: u32, threads: bool) -> tokio::process::Command {
+fn build_command(binary: &str, pid: u32, opts: &PySpyOpts) -> tokio::process::Command {
     let mut cmd = tokio::process::Command::new(binary);
-    cmd.arg("dump").arg("--pid").arg(pid.to_string());
-    if threads {
+    cmd.arg("dump")
+        .arg("--pid")
+        .arg(pid.to_string())
+        .arg("--json");
+    if opts.threads {
         cmd.arg("--threads");
+    }
+    if opts.native {
+        cmd.arg("--native");
+    }
+    if opts.native_all {
+        cmd.arg("--native-all");
+    }
+    if opts.nonblocking {
+        cmd.arg("--nonblocking");
     }
     cmd.stdout(std::process::Stdio::piped());
     cmd.stderr(std::process::Stdio::piped());
     cmd
 }
 
-/// Map a process::Output to a PySpyResult.
+/// Map a process::Output to a PySpyResult, parsing the `--json`
+/// output into structured `PySpyStackTrace` values.
 /// See PS-2, PS-4 in `introspect` module doc.
 fn map_output(output: std::process::Output, pid: u32, binary: &str) -> PySpyResult {
     if output.status.success() {
-        let stack = String::from_utf8_lossy(&output.stdout).into_owned();
-        PySpyResult::Ok {
-            pid,
-            binary: binary.to_string(),
-            stack,
+        match serde_json::from_slice::<Vec<PySpyStackTrace>>(&output.stdout) {
+            Ok(stack_traces) => PySpyResult::Ok {
+                pid,
+                binary: binary.to_string(),
+                stack_traces,
+                warnings: vec![],
+            },
+            Err(e) => PySpyResult::Failed {
+                pid,
+                binary: binary.to_string(),
+                exit_code: None,
+                stderr: format!("failed to parse py-spy JSON output: {}", e),
+            },
         }
     } else {
         let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
@@ -159,28 +261,112 @@ fn map_output(output: std::process::Output, pid: u32, binary: &str) -> PySpyResu
     }
 }
 
+/// Returns true if the failure indicates the py-spy binary does not
+/// support `--native-all` (exit code 2, stderr mentions the flag).
+/// Used by `try_exec` to downgrade and retry (PS-11).
+fn is_unsupported_native_all(result: &PySpyResult) -> bool {
+    matches!(
+        result,
+        PySpyResult::Failed {
+            exit_code: Some(2),
+            stderr,
+            ..
+        } if stderr.contains("--native-all")
+    )
+}
+
 /// Try to execute py-spy with the given binary path. Returns `None`
 /// if the binary was not found (NotFound error), allowing the caller
 /// to try the next candidate.
+///
+/// In nonblocking mode, retries up to 3 times with 100ms backoff
+/// because py-spy can segfault reading mutating process memory
+/// (PS-10). All attempts share a single deadline so total wall time
+/// never exceeds the caller's timeout budget (PS-5).
+///
+/// If `native_all` is requested but the py-spy binary does not
+/// support `--native-all` (exit code 2), the flag is dropped and
+/// the command is retried automatically (PS-11).
 async fn try_exec(
     binary: &str,
     pid: u32,
-    threads: bool,
+    opts: &PySpyOpts,
     timeout: std::time::Duration,
 ) -> Option<PySpyResult> {
-    let child = match build_command(binary, pid, threads).spawn() {
-        Ok(child) => child,
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return None,
-        Err(e) => {
+    let deadline = tokio::time::Instant::now() + timeout;
+    let retries = if opts.nonblocking { 3 } else { 1 };
+    let mut last_result = None;
+    let mut effective_opts = opts.clone();
+
+    for attempt in 0..retries {
+        if attempt > 0 {
+            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        }
+        let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+        if remaining.is_zero() {
             return Some(PySpyResult::Failed {
                 pid,
                 binary: binary.to_string(),
                 exit_code: None,
-                stderr: format!("failed to execute: {}", e),
+                stderr: format!("py-spy subprocess timed out after {}s", timeout.as_secs()),
             });
         }
-    };
-    Some(collect_with_timeout(child, pid, binary, timeout).await)
+        let child = match build_command(binary, pid, &effective_opts).spawn() {
+            Ok(child) => child,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return None,
+            Err(e) => {
+                return Some(PySpyResult::Failed {
+                    pid,
+                    binary: binary.to_string(),
+                    exit_code: None,
+                    stderr: format!("failed to execute: {}", e),
+                });
+            }
+        };
+        let result = collect_with_timeout(child, pid, binary, remaining).await;
+        match &result {
+            PySpyResult::Ok { .. } => return Some(result),
+            _ if is_unsupported_native_all(&result) && effective_opts.native_all => {
+                // PS-11: py-spy too old for --native-all; downgrade and
+                // retry immediately (does not consume a nonblocking retry).
+                effective_opts.native_all = false;
+                let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+                if remaining.is_zero() {
+                    return Some(result);
+                }
+                let child = match build_command(binary, pid, &effective_opts).spawn() {
+                    Ok(child) => child,
+                    Err(e) if e.kind() == std::io::ErrorKind::NotFound => return None,
+                    Err(e) => {
+                        return Some(PySpyResult::Failed {
+                            pid,
+                            binary: binary.to_string(),
+                            exit_code: None,
+                            stderr: format!("failed to execute: {}", e),
+                        });
+                    }
+                };
+                let mut retry_result = collect_with_timeout(child, pid, binary, remaining).await;
+                if let PySpyResult::Ok { warnings, .. } = &mut retry_result {
+                    warnings.push(
+                        "--native-all unsupported by this py-spy; fell back to --native"
+                            .to_string(),
+                    );
+                }
+                match &retry_result {
+                    PySpyResult::Ok { .. } => return Some(retry_result),
+                    _ => {
+                        last_result = Some(retry_result);
+                    }
+                }
+            }
+            _ => {
+                last_result = Some(result);
+            }
+        }
+    }
+
+    last_result
 }
 
 /// Collect stdout/stderr from a spawned child concurrently with wait,
@@ -254,6 +440,39 @@ mod tests {
     use super::*;
 
     #[test]
+    fn pyspy_result_wirevalue_roundtrip() {
+        // Regression test: #[serde(skip_serializing_if)] is
+        // incompatible with bincode (positional format). Empty
+        // warnings must still round-trip correctly through wirevalue
+        // Multipart encoding.
+        let original = PySpyResult::Ok {
+            pid: 42,
+            binary: "py-spy".to_string(),
+            stack_traces: vec![PySpyStackTrace {
+                pid: 42,
+                thread_id: 1,
+                thread_name: Some("main".to_string()),
+                os_thread_id: Some(100),
+                active: true,
+                owns_gil: true,
+                frames: vec![PySpyFrame {
+                    name: "do_work".to_string(),
+                    filename: "test.py".to_string(),
+                    module: None,
+                    short_filename: None,
+                    line: 10,
+                    locals: None,
+                    is_entry: false,
+                }],
+            }],
+            warnings: vec![],
+        };
+        let any = wirevalue::Any::serialize(&original).expect("serialize");
+        let restored: PySpyResult = any.deserialized().expect("deserialize");
+        assert_eq!(original, restored);
+    }
+
+    #[test]
     fn candidates_no_env() {
         // PS-3: no PYSPY_BIN → only PATH candidate.
         let candidates = resolve_candidates(None);
@@ -281,21 +500,71 @@ mod tests {
     }
 
     #[test]
-    fn output_success_passthrough() {
-        // PS-4: raw stdout passthrough, no transformation.
+    fn output_success_parses_json() {
+        // PS-4: py-spy --json stdout is parsed into structured traces.
+        let json = serde_json::json!([{
+            "pid": 42,
+            "thread_id": 1234,
+            "thread_name": "MainThread",
+            "os_thread_id": 5678,
+            "active": true,
+            "owns_gil": true,
+            "frames": [{
+                "name": "do_work",
+                "filename": "foo.py",
+                "module": null,
+                "short_filename": null,
+                "line": 10,
+                "locals": null,
+                "is_entry": false
+            }]
+        }]);
         let output = std::process::Output {
             status: std::process::ExitStatus::default(),
-            stdout: b"Thread 0x7f abc\n  foo.py:10\n".to_vec(),
+            stdout: serde_json::to_vec(&json).unwrap(),
             stderr: vec![],
         };
         let result = map_output(output, 42, "/usr/bin/py-spy");
         match result {
-            PySpyResult::Ok { pid, binary, stack } => {
+            PySpyResult::Ok {
+                pid,
+                binary,
+                stack_traces,
+                ..
+            } => {
                 assert_eq!(pid, 42);
                 assert_eq!(binary, "/usr/bin/py-spy");
-                assert_eq!(stack, "Thread 0x7f abc\n  foo.py:10\n");
+                assert_eq!(stack_traces.len(), 1);
+                assert_eq!(stack_traces[0].thread_id, 1234);
+                assert_eq!(stack_traces[0].thread_name.as_deref(), Some("MainThread"));
+                assert!(stack_traces[0].owns_gil);
+                assert_eq!(stack_traces[0].frames.len(), 1);
+                assert_eq!(stack_traces[0].frames[0].name, "do_work");
+                assert_eq!(stack_traces[0].frames[0].filename, "foo.py");
+                assert_eq!(stack_traces[0].frames[0].line, 10);
             }
             other => panic!("expected Ok, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn output_invalid_json_maps_to_failed() {
+        // PS-4: unparseable JSON maps to Failed.
+        let output = std::process::Output {
+            status: std::process::ExitStatus::default(),
+            stdout: b"not valid json".to_vec(),
+            stderr: vec![],
+        };
+        let result = map_output(output, 42, "py-spy");
+        match result {
+            PySpyResult::Failed { pid, stderr, .. } => {
+                assert_eq!(pid, 42);
+                assert!(
+                    stderr.contains("failed to parse py-spy JSON output"),
+                    "unexpected stderr: {stderr}"
+                );
+            }
+            other => panic!("expected Failed, got {:?}", other),
         }
     }
 
@@ -329,9 +598,10 @@ mod tests {
     #[test]
     fn output_preserves_caller_pid() {
         // PS-1: pid in result is exactly what the caller passes.
+        let json = serde_json::json!([]);
         let output = std::process::Output {
             status: std::process::ExitStatus::default(),
-            stdout: b"stack".to_vec(),
+            stdout: serde_json::to_vec(&json).unwrap(),
             stderr: vec![],
         };
         let result = map_output(output, 12345, "bin");
@@ -341,13 +611,22 @@ mod tests {
         }
     }
 
+    fn default_opts() -> PySpyOpts {
+        PySpyOpts {
+            threads: false,
+            native: false,
+            native_all: false,
+            nonblocking: false,
+        }
+    }
+
     #[tokio::test]
     async fn exec_missing_binary_returns_none() {
         // PS-3: NotFound from exec → None (triggers fallback).
         let result = try_exec(
             "/definitely/not/a/real/binary",
             1,
-            false,
+            &default_opts(),
             std::time::Duration::from_secs(5),
         )
         .await;
@@ -356,12 +635,23 @@ mod tests {
 
     #[tokio::test]
     async fn exec_present_binary_returns_some() {
-        // "true" exists on all unix systems and exits 0.
-        let result = try_exec("true", 1, false, std::time::Duration::from_secs(5)).await;
-        assert!(result.is_some());
-        match result.unwrap() {
-            PySpyResult::Ok { binary, .. } => assert_eq!(binary, "true"),
-            other => panic!("expected Ok, got {:?}", other),
+        // "true" exits 0 with empty stdout, which is not valid
+        // py-spy JSON. We expect a Failed result from parse error.
+        let result = try_exec(
+            "true",
+            1,
+            &default_opts(),
+            std::time::Duration::from_secs(5),
+        )
+        .await;
+        match result {
+            Some(PySpyResult::Failed { stderr, .. }) => {
+                assert!(
+                    stderr.contains("parse"),
+                    "expected JSON parse error, got: {stderr}"
+                );
+            }
+            other => panic!("expected Some(Failed{{parse..}}), got: {other:?}"),
         }
     }
 
@@ -400,7 +690,13 @@ mod tests {
     #[tokio::test]
     async fn exec_failing_binary_returns_failed() {
         // "false" exists on all unix systems and exits 1.
-        let result = try_exec("false", 42, false, std::time::Duration::from_secs(5)).await;
+        let result = try_exec(
+            "false",
+            42,
+            &default_opts(),
+            std::time::Duration::from_secs(5),
+        )
+        .await;
         assert!(result.is_some());
         match result.unwrap() {
             PySpyResult::Failed {

--- a/python/examples/verify_pyspy.py
+++ b/python/examples/verify_pyspy.py
@@ -145,10 +145,26 @@ def sample_pyspy(
     return fetch_json(f"{admin_url}/v1/pyspy/{encoded}", ctx)
 
 
-def has_evidence(stack: str, mode: str) -> bool:
-    """Check whether a stack contains mode-specific evidence frames."""
+def qualified_frame_name(frame: dict) -> str:
+    """Build a qualified name from a structured py-spy frame.
+
+    In py-spy ``--json`` output the function name and module are separate
+    fields (e.g. ``name="sleep"``, ``module="time"``).  Evidence patterns
+    like ``"time.sleep"`` need to match against a combined representation.
+    Returns ``"module.name"`` when a module is present, otherwise just
+    ``"name"``.
+    """
+    name = frame.get("name", "")
+    module = frame.get("module")
+    if module:
+        return f"{module}.{name}"
+    return name
+
+
+def has_evidence(name: str, mode: str) -> bool:
+    """Check whether a (possibly qualified) frame name matches mode evidence."""
     patterns = MODE_EVIDENCE.get(mode, [])
-    return any(p in stack for p in patterns)
+    return any(p in name for p in patterns)
 
 
 def short_name(proc_ref: str) -> str:
@@ -187,18 +203,37 @@ def run_verification(args: argparse.Namespace) -> int:
             try:
                 result = sample_pyspy(args.admin_url, proc_ref, ctx)
             except Exception as e:
-                print(f"  {name}: ERROR {e}")
+                body = ""
+                reader = getattr(e, "read", None)
+                if reader is not None:
+                    try:
+                        body = reader().decode("utf-8", errors="replace")
+                    except Exception:
+                        pass
+                print(f"  {name}: ERROR {e} {body}")
                 failed += 1
                 continue
 
             if "Ok" in result:
                 ok += 1
-                stack = result["Ok"].get("stack", "")
-                if has_evidence(stack, args.mode):
+                stack_traces = result["Ok"].get("stack_traces", [])
+                found = False
+                for trace in stack_traces:
+                    for frame in trace.get("frames", []):
+                        if has_evidence(qualified_frame_name(frame), args.mode):
+                            found = True
+                            break
+                    if found:
+                        break
+                if found:
                     evidence += 1
             elif "BinaryNotFound" in result:
                 not_found += 1
             elif "Failed" in result:
+                f = result["Failed"]
+                stderr = f.get("stderr", "")
+                exit_code = f.get("exit_code")
+                print(f"  {name}: FAILED exit={exit_code} stderr={stderr[:200]}")
                 failed += 1
 
         total_ok += ok
@@ -230,9 +265,18 @@ def run_verification(args: argparse.Namespace) -> int:
         )
 
     # Evaluate.
-    if total_failed > 0:
-        print(f"FAIL: {total_failed} failed response(s)")
+    # Occasional timeouts are expected with --native/--native-all
+    # (native stack unwinding is slower than Python-only capture).
+    # Fail only when failures dominate — no Ok responses at all.
+    if total_failed > 0 and total_ok == 0:
+        print(f"FAIL: all {total_failed} response(s) failed")
         return EXIT_FAIL
+    if total_failed > 0:
+        total_samples = total_ok + total_not_found + total_failed
+        print(
+            f"WARN: {total_failed}/{total_samples} response(s) failed "
+            f"(timeouts expected with native stack unwinding)"
+        )
 
     if total_ok == 0 and total_not_found > 0:
         print("SKIP: py-spy not available (all BinaryNotFound)")


### PR DESCRIPTION
Summary:

address mariusae's D96756537 pyspy.rs comments by moving the py-spy result contract from raw stdout text to structured --json output, extending the capture request with native, native_all, and nonblocking flags, and adopting the older hyperactor_multiprocess capture defaults and retry behavior that had already been battle-tested. PySpyResult::Ok now returns parsed stack_traces plus non-fatal warnings, try_exec retries nonblocking captures within a single shared timeout budget and automatically falls back from --native-all to --native when the deployed py-spy binary is too old for that flag, and the mesh-admin py-spy timeout budgets are increased to accommodate native stack unwinding. update downstream consumers so the TUI renders structured thread and frame data, surfaces capture warnings, and uses a client timeout that exceeds the server bridge timeout, and update the verifier to match qualified module.name frame evidence against the new response shape while tolerating occasional native-unwinding failures.

Reviewed By: allenwang28

Differential Revision: D97138412


