### PR TITLE
Improve ActorSupervisionEvent display, fix double fault hook invocation, and simplify error output (#3068)

### DIFF
--- a/hyperactor/src/introspect.rs
+++ b/hyperactor/src/introspect.rs
@@ -739,15 +739,15 @@ pub fn live_actor_payload(cell: &InstanceCell) -> IntrospectResult {
     // FI-3: failure_info is computed from the same status value as
     // actor_status, ensuring they agree on whether the actor failed.
     let failure = if status.is_failed() {
-        cell.supervision_event().map(|event| {
-            let root = event.actually_failing_actor();
-            FailureSnapshot {
+        cell.supervision_event().and_then(|event| {
+            let root = event.actually_failing_actor()?;
+            Some(FailureSnapshot {
                 error_message: event.actor_status.to_string(),
                 root_cause_actor: root.actor_id.to_string(),
                 root_cause_name: root.display_name.clone(),
                 occurred_at: format_timestamp(event.occurred_at),
                 is_propagated: root.actor_id != *actor_id,
-            }
+            })
         })
     } else {
         None
@@ -1146,7 +1146,9 @@ mod tests {
 
         // -- reproduce FailureSnapshot construction (same logic as
         // live_actor_payload lines 734-743) --
-        let root = parent_event.actually_failing_actor();
+        let root = parent_event
+            .actually_failing_actor()
+            .expect("parent_event is a failure");
         let snap = FailureSnapshot {
             error_message: parent_event.actor_status.to_string(),
             root_cause_actor: root.actor_id.to_string(),

--- a/hyperactor/src/proc.rs
+++ b/hyperactor/src/proc.rs
@@ -3903,7 +3903,7 @@ mod tests {
         assert_eq!(event.actor_id, actor_id);
         assert!(event.actor_status.is_failed());
         // Originated here, not propagated.
-        assert_eq!(event.actually_failing_actor().actor_id, actor_id);
+        assert_eq!(event.actually_failing_actor().unwrap().actor_id, actor_id);
     }
 
     // Exercises FI-2 (see introspect.rs module-scope comment).
@@ -4024,7 +4024,7 @@ mod tests {
         );
         let event = event.unwrap();
         // Root cause is the child, not the parent.
-        assert_eq!(event.actually_failing_actor().actor_id, child_id);
+        assert_eq!(event.actually_failing_actor().unwrap().actor_id, child_id);
     }
 
     // Exercises S11 (see introspect.rs module doc).

--- a/hyperactor/src/supervision.rs
+++ b/hyperactor/src/supervision.rs
@@ -74,99 +74,473 @@ impl ActorSupervisionEvent {
             .unwrap_or_else(|| self.actor_id.to_string())
     }
 
-    /// Walk the `UnhandledSupervisionEvent` chain to find the root-cause
-    /// actor that originally failed.
-    pub fn actually_failing_actor(&self) -> &ActorSupervisionEvent {
+    /// Walk the `UnhandledSupervisionEvent` chain to the root-cause
+    /// event — the first event whose status is not
+    /// `UnhandledSupervisionEvent`.
+    pub fn caused_by(&self) -> &ActorSupervisionEvent {
         let mut event = self;
-        while let ActorStatus::Failed(ActorErrorKind::UnhandledSupervisionEvent(e)) =
+        while let ActorStatus::Failed(ActorErrorKind::UnhandledSupervisionEvent(inner)) =
             &event.actor_status
         {
-            event = e;
+            event = inner;
         }
         event
     }
 
-    /// This event is for a a supervision error.
+    /// Walk the `UnhandledSupervisionEvent` chain to find the root-cause
+    /// actor that originally failed.
+    ///
+    /// Returns `None` if the event is not a failure. Always returns the
+    /// leaf of the chain — the actor whose status is the root cause,
+    /// even if that leaf is a non-failure (e.g. a stopped process).
+    pub fn actually_failing_actor(&self) -> Option<&ActorSupervisionEvent> {
+        if !self.is_error() {
+            return None;
+        }
+        Some(self.caused_by())
+    }
+
+    /// This event is for a supervision error.
     pub fn is_error(&self) -> bool {
         self.actor_status.is_failed()
+    }
+
+    /// Produce a concise failure report. Returns `None` for non-failure
+    /// events.
+    pub fn failure_report(&self) -> Option<String> {
+        if !self.is_error() {
+            return None;
+        }
+        let mut output = String::new();
+        self.write_failure_report(&mut output)
+            .expect("writing to String cannot fail");
+        Some(output)
+    }
+
+    fn write_failure_report(&self, f: &mut String) -> fmt::Result {
+        let mut current = self;
+        let mut last_unhandled: Option<&ActorSupervisionEvent> = None;
+        while let ActorStatus::Failed(ActorErrorKind::UnhandledSupervisionEvent(inner)) =
+            &current.actor_status
+        {
+            last_unhandled = Some(current);
+            current = inner;
+        }
+
+        if !current.actor_status.is_failed() {
+            let parent = last_unhandled.expect(
+                "top-level event is a failure but leaf is not; \
+                 chain must contain an UnhandledSupervisionEvent",
+            );
+            writeln!(
+                f,
+                "The actor {} failed because it did not handle a supervision event \
+                 from its child. The event was:",
+                parent.actor_name()
+            )?;
+            return write!(indented(f).with_str("  "), "{}", current);
+        }
+
+        writeln!(
+            f,
+            "The actor {} and all its descendants have failed:",
+            current.actor_name()
+        )?;
+        match &current.actor_status {
+            ActorStatus::Failed(ActorErrorKind::ErrorDuringHandlingSupervision(msg, child)) => {
+                writeln!(indented(f).with_str("  "), "{}", msg.trim_end())?;
+                writeln!(f, "This error occurred while handling another failure:")?;
+                let child_report = child
+                    .failure_report()
+                    .expect("child of ErrorDuringHandlingSupervision is always a failure");
+                write!(indented(f).with_str("  "), "{}", child_report)
+            }
+            ActorStatus::Failed(err) => write!(indented(f).with_str("  "), "{}", err),
+            _ => unreachable!("current.is_failed() was true"),
+        }
     }
 }
 
 impl std::error::Error for ActorSupervisionEvent {}
 
-fn fmt_status<'a>(
-    actor_id: &reference::ActorId,
-    status: &'a ActorStatus,
-    f: &mut fmt::Formatter<'_>,
-) -> Result<Option<&'a ActorSupervisionEvent>, fmt::Error> {
-    let mut f = indented(f).with_str(" ");
-
-    match status {
-        ActorStatus::Stopped(_)
-            if actor_id.name() == "host_agent" || actor_id.name() == "proc_agent" =>
-        {
-            // Host agent stopped - use simplified message from D86984496
-            let name = actor_id.proc_id().addr().to_string();
-            write!(
-                f,
-                "The process {} owned by this actor became unresponsive and is assumed dead, check the log on the host for details",
-                name
-            )?;
-            Ok(None)
-        }
-        ActorStatus::Failed(ActorErrorKind::ErrorDuringHandlingSupervision(
-            msg,
-            during_handling_of,
-        )) => {
-            write!(f, "{}", msg)?;
-            Ok(Some(during_handling_of))
-        }
-        ActorStatus::Failed(ActorErrorKind::Generic(msg)) => {
-            write!(f, "{}", msg)?;
-            Ok(None)
-        }
-        status => {
-            write!(f, "{}", status)?;
-            Ok(None)
-        }
-    }
-}
-
 impl fmt::Display for ActorSupervisionEvent {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let actor_name = self.actor_name();
-        writeln!(
-            f,
-            "The actor {} and all its descendants have failed.",
-            actor_name
-        )?;
-        let failing_event = self.actually_failing_actor();
-        let failing_actor = failing_event.actor_name();
-        let its_name = if failing_actor == actor_name {
-            "itself"
-        } else {
-            &failing_actor
-        };
-        writeln!(f, "This occurred because the actor {} failed.", its_name)?;
-        writeln!(f, "The error was:")?;
-        let during_handling_of =
-            fmt_status(&failing_event.actor_id, &failing_event.actor_status, f)?;
-        if let Some(event) = during_handling_of {
-            writeln!(
-                f,
-                "This error occurred during the handling of another failure:"
-            )?;
-            fmt::Display::fmt(event, f)?;
+        let name = self.actor_name();
+        match &self.actor_status {
+            ActorStatus::Failed(
+                err @ (ActorErrorKind::Generic(_) | ActorErrorKind::Aborted(_)),
+            ) => {
+                writeln!(f, "Supervision event: actor {} failed:", name)?;
+                write!(indented(f).with_str("  "), "{}", err)
+            }
+            ActorStatus::Failed(ActorErrorKind::UnhandledSupervisionEvent(child)) => {
+                writeln!(
+                    f,
+                    "Supervision event: actor {} failed because it did not handle \
+                     a supervision event from its child. The child's event was:",
+                    name
+                )?;
+                write!(indented(f).with_str("  "), "{}", child)
+            }
+            ActorStatus::Failed(ActorErrorKind::ErrorDuringHandlingSupervision(msg, child)) => {
+                writeln!(f, "Supervision event: actor {} failed:", name)?;
+                writeln!(indented(f).with_str("  "), "{}", msg.trim_end())?;
+                writeln!(
+                    f,
+                    "This error occurred while handling a supervision event from \
+                     its child. The event was:"
+                )?;
+                write!(indented(f).with_str("  "), "{}", child)
+            }
+            ActorStatus::Stopped(_)
+                if self.actor_id.name() == "host_agent" || self.actor_id.name() == "proc_agent" =>
+            {
+                let addr = self.actor_id.proc_id().addr().to_string();
+                write!(
+                    f,
+                    "Supervision event: the process {} owned by actor {} became unresponsive \
+                     and is assumed dead, check the log on the host for details",
+                    addr,
+                    self.actor_name()
+                )
+            }
+            status => {
+                writeln!(f, "Supervision event: actor {} has status:", name)?;
+                write!(indented(f).with_str("  "), "{}", status)
+            }
         }
-        Ok(())
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::actor::ActorErrorKind;
+    use crate::actor::ActorStatus;
     use crate::channel::ChannelAddr;
-    use crate::reference::ProcId;
+
+    fn test_event(name: &str, status: ActorStatus) -> ActorSupervisionEvent {
+        let proc_id = reference::ProcId::with_name(ChannelAddr::Local(0), "test_proc");
+        ActorSupervisionEvent::new(
+            proc_id.actor_id(name, 0),
+            Some(name.to_string()),
+            status,
+            None,
+        )
+    }
+
+    fn test_event_with_addr(
+        name: &str,
+        addr: ChannelAddr,
+        status: ActorStatus,
+    ) -> ActorSupervisionEvent {
+        let proc_id = reference::ProcId::with_name(addr, "test_proc");
+        ActorSupervisionEvent::new(proc_id.actor_id(name, 0), None, status, None)
+    }
+
+    fn generic(name: &str, msg: &str) -> ActorSupervisionEvent {
+        test_event(
+            name,
+            ActorStatus::Failed(ActorErrorKind::Generic(msg.to_string())),
+        )
+    }
+
+    fn aborted(name: &str, msg: &str) -> ActorSupervisionEvent {
+        test_event(
+            name,
+            ActorStatus::Failed(ActorErrorKind::Aborted(msg.to_string())),
+        )
+    }
+
+    fn unhandled(name: &str, child: ActorSupervisionEvent) -> ActorSupervisionEvent {
+        test_event(
+            name,
+            ActorStatus::Failed(ActorErrorKind::UnhandledSupervisionEvent(Box::new(child))),
+        )
+    }
+
+    fn error_during(name: &str, msg: &str, child: ActorSupervisionEvent) -> ActorSupervisionEvent {
+        test_event(
+            name,
+            ActorStatus::Failed(ActorErrorKind::ErrorDuringHandlingSupervision(
+                msg.to_string(),
+                Box::new(child),
+            )),
+        )
+    }
+
+    fn stopped(name: &str, reason: &str) -> ActorSupervisionEvent {
+        test_event(name, ActorStatus::Stopped(reason.to_string()))
+    }
+
+    // Display tests
+
+    #[test]
+    fn test_display_generic() {
+        let e = generic("actor_a", "something went wrong");
+        assert_eq!(
+            format!("{}", e),
+            "Supervision event: actor actor_a failed:\n\
+             \x20 something went wrong"
+        );
+    }
+
+    #[test]
+    fn test_display_aborted() {
+        let e = aborted("actor_a", "user requested");
+        assert_eq!(
+            format!("{}", e),
+            "Supervision event: actor actor_a failed:\n\
+             \x20 actor explicitly aborted due to: user requested"
+        );
+    }
+
+    #[test]
+    fn test_display_unhandled_with_generic_child() {
+        let child = generic("child", "child error");
+        let parent = unhandled("parent", child);
+        assert_eq!(
+            format!("{}", parent),
+            "Supervision event: actor parent failed because it did not handle \
+             a supervision event from its child. The child's event was:\n\
+             \x20 Supervision event: actor child failed:\n\
+             \x20   child error"
+        );
+    }
+
+    #[test]
+    fn test_display_error_during_handling() {
+        let child = generic("child", "child error");
+        let parent = error_during("parent", "handler crashed", child);
+        assert_eq!(
+            format!("{}", parent),
+            "Supervision event: actor parent failed:\n\
+             \x20 handler crashed\n\
+             This error occurred while handling a supervision event from \
+             its child. The event was:\n\
+             \x20 Supervision event: actor child failed:\n\
+             \x20   child error"
+        );
+    }
+
+    #[test]
+    fn test_display_stopped() {
+        let e = stopped("actor_a", "done");
+        assert_eq!(
+            format!("{}", e),
+            "Supervision event: actor actor_a has status:\n\
+             \x20 stopped: done"
+        );
+    }
+
+    #[test]
+    fn test_display_deep_nesting() {
+        let leaf = generic("leaf", "root cause");
+        let mid = unhandled("mid", leaf);
+        let top = unhandled("top", mid);
+        let output = format!("{}", top);
+        assert!(output.contains("actor top failed because"));
+        assert!(output.contains("  Supervision event: actor mid failed because"));
+        assert!(output.contains("    Supervision event: actor leaf failed:"));
+        assert!(output.contains("      root cause"));
+    }
+
+    #[test]
+    fn test_display_unhandled_stopped_child() {
+        let child = stopped("child", "process exited");
+        let parent = unhandled("parent", child);
+        assert_eq!(
+            format!("{}", parent),
+            "Supervision event: actor parent failed because it did not handle \
+             a supervision event from its child. The child's event was:\n\
+             \x20 Supervision event: actor child has status:\n\
+             \x20   stopped: process exited"
+        );
+    }
+
+    // failure_report tests
+
+    #[test]
+    fn test_failure_report_generic() {
+        let e = generic("actor_a", "boom");
+        assert_eq!(
+            e.failure_report().unwrap(),
+            "The actor actor_a and all its descendants have failed:\n\
+             \x20 boom"
+        );
+    }
+
+    #[test]
+    fn test_failure_report_aborted() {
+        let e = aborted("actor_a", "user requested");
+        assert_eq!(
+            e.failure_report().unwrap(),
+            "The actor actor_a and all its descendants have failed:\n\
+             \x20 actor explicitly aborted due to: user requested"
+        );
+    }
+
+    #[test]
+    fn test_failure_report_unhandled_chain_to_generic() {
+        let leaf = generic("leaf", "root cause");
+        let mid = unhandled("mid", leaf);
+        let top = unhandled("top", mid);
+        assert_eq!(
+            top.failure_report().unwrap(),
+            "The actor leaf and all its descendants have failed:\n\
+             \x20 root cause"
+        );
+    }
+
+    #[test]
+    fn test_failure_report_unhandled_chain_to_stopped() {
+        let leaf = stopped("some_actor", "process exited");
+        let mid = unhandled("mid", leaf);
+        let top = unhandled("top", mid);
+        let report = top.failure_report().unwrap();
+        assert_eq!(
+            report,
+            "The actor mid failed because it did not handle a supervision event \
+             from its child. The event was:\n\
+             \x20 Supervision event: actor some_actor has status:\n\
+             \x20   stopped: process exited"
+        );
+    }
+
+    #[test]
+    fn test_failure_report_unhandled_chain_to_stopped_proc_agent() {
+        let leaf = test_event_with_addr(
+            "proc_agent",
+            ChannelAddr::Local(99),
+            ActorStatus::Stopped("process exited".to_string()),
+        );
+        let mid = unhandled("mid", leaf);
+        let top = unhandled("top", mid);
+        let report = top.failure_report().unwrap();
+        assert!(
+            report.contains("did not handle a supervision event"),
+            "got: {}",
+            report
+        );
+        assert!(
+            report.contains("process local:99 owned by actor") && report.contains("unresponsive"),
+            "got: {}",
+            report
+        );
+    }
+
+    #[test]
+    fn test_failure_report_error_during_handling() {
+        let child = generic("child", "original error");
+        let parent = error_during("parent", "handler failed", child);
+        assert_eq!(
+            parent.failure_report().unwrap(),
+            "The actor parent and all its descendants have failed:\n\
+             \x20 handler failed\n\
+             This error occurred while handling another failure:\n\
+             \x20 The actor child and all its descendants have failed:\n\
+             \x20   original error"
+        );
+    }
+
+    #[test]
+    fn test_failure_report_error_during_handling_nested() {
+        let leaf = generic("leaf", "root cause");
+        let mid = error_during("mid", "mid failed", leaf);
+        let top = error_during("top", "top failed", mid);
+        let report = top.failure_report().unwrap();
+        assert!(report.starts_with(
+            "The actor top and all its descendants have failed:\n\
+             \x20 top failed\n\
+             This error occurred while handling another failure:\n\
+             \x20 The actor mid and all its descendants have failed:\n\
+             \x20   mid failed\n\
+             \x20 This error occurred while handling another failure:\n\
+             \x20   The actor leaf and all its descendants have failed:\n\
+             \x20     root cause"
+        ));
+    }
+
+    #[test]
+    fn test_failure_report_unhandled_to_error_during_handling() {
+        let leaf = generic("leaf", "root cause");
+        let handler_err = error_during("handler", "while handling", leaf);
+        let top = unhandled("top", handler_err);
+        let report = top.failure_report().unwrap();
+        assert!(report.contains("The actor handler and all its descendants have failed:"));
+        assert!(report.contains("while handling"));
+        assert!(report.contains("root cause"));
+    }
+
+    #[test]
+    fn test_failure_report_none_on_non_failure() {
+        let e = stopped("actor_a", "done");
+        assert!(e.failure_report().is_none());
+    }
+
+    #[test]
+    fn test_failure_report_direct_generic_no_chain() {
+        let e = generic("solo", "direct error");
+        assert_eq!(
+            e.failure_report().unwrap(),
+            "The actor solo and all its descendants have failed:\n\
+             \x20 direct error"
+        );
+    }
+
+    #[test]
+    fn test_display_host_agent_stopped() {
+        let e = test_event_with_addr(
+            "host_agent",
+            ChannelAddr::Local(42),
+            ActorStatus::Stopped("gone".to_string()),
+        );
+        let output = format!("{}", e);
+        assert!(
+            output.contains("process local:42 owned by actor") && output.contains("unresponsive"),
+            "got: {}",
+            output
+        );
+    }
+
+    #[test]
+    fn test_display_proc_agent_stopped() {
+        let e = test_event_with_addr(
+            "proc_agent",
+            ChannelAddr::Local(7),
+            ActorStatus::Stopped("dead".to_string()),
+        );
+        let output = format!("{}", e);
+        assert!(
+            output.contains("process local:7 owned by actor") && output.contains("unresponsive"),
+            "got: {}",
+            output
+        );
+    }
+
+    #[test]
+    fn test_display_error_during_handling_trim_end() {
+        let child = generic("child", "child error");
+        let parent = error_during("parent", "msg with trailing newline\n", child);
+        let output = format!("{}", parent);
+        assert!(
+            output.contains("  msg with trailing newline\nThis error occurred"),
+            "writeln! should trim trailing newline from msg: {}",
+            output
+        );
+    }
+
+    #[test]
+    fn test_failure_report_error_during_handling_trim_end() {
+        let child = generic("child", "child error");
+        let parent = error_during("parent", "msg with trailing newline\n", child);
+        let report = parent.failure_report().unwrap();
+        assert!(
+            report.contains("  msg with trailing newline\nThis error occurred"),
+            "writeln! should trim trailing newline from msg: {}",
+            report
+        );
+    }
 
     /// Exercises SV-1 (see module doc): for a parent wrapping a
     /// stopped child in `UnhandledSupervisionEvent`,
@@ -174,7 +548,7 @@ mod tests {
     /// root cause for structured failure attribution.
     #[test]
     fn test_sv1_actually_failing_actor_returns_stopped_child() {
-        let proc_id = ProcId::with_name(ChannelAddr::Local(0), "test_proc");
+        let proc_id = reference::ProcId::with_name(ChannelAddr::Local(0), "test_proc");
         let child_id = proc_id.actor_id("proc_agent", 0);
         let parent_id = proc_id.actor_id("controller", 0);
 
@@ -194,7 +568,9 @@ mod tests {
         );
 
         // SV-1: root cause is the stopped child, not the parent.
-        let root = parent_event.actually_failing_actor();
+        let root = parent_event
+            .actually_failing_actor()
+            .expect("parent_event is a failure");
         assert_eq!(root.actor_id, child_id);
         assert!(
             matches!(root.actor_status, ActorStatus::Stopped(_)),

--- a/hyperactor_mesh/src/actor_mesh.rs
+++ b/hyperactor_mesh/src/actor_mesh.rs
@@ -1222,11 +1222,7 @@ mod tests {
             assert_eq!(failure.actor_mesh_name, Some(child_name.to_string()));
             assert_eq!(failure.event.actor_id.name(), child_name.to_string());
             if let ActorStatus::Failed(ActorErrorKind::Generic(msg)) = &failure.event.actor_status {
-                assert!(
-                    msg.contains("process exited with non-zero code 1"),
-                    "{}",
-                    msg
-                );
+                assert!(msg.contains("exited with non-zero code 1"), "{}", msg);
             } else {
                 panic!("actor status is not failed: {}", failure.event.actor_status);
             }

--- a/hyperactor_mesh/src/mesh_controller.rs
+++ b/hyperactor_mesh/src/mesh_controller.rs
@@ -726,9 +726,12 @@ fn proc_status_to_actor_status(proc_status: Option<ProcStatus>) -> ActorStatus {
         Some(ProcStatus::Stopped { exit_code: 0, .. }) => {
             ActorStatus::Stopped("process exited cleanly".to_string())
         }
-        Some(ProcStatus::Stopped { exit_code, .. }) => ActorStatus::Failed(
-            ActorErrorKind::Generic(format!("process exited with non-zero code {}", exit_code)),
-        ),
+        Some(ProcStatus::Stopped { exit_code, .. }) => {
+            ActorStatus::Failed(ActorErrorKind::Generic(format!(
+                "the process this actor was running on exited with non-zero code {}",
+                exit_code
+            )))
+        }
         // Stopping is a transient state during graceful shutdown. Treat it the
         // same as a clean stop rather than a failure.
         Some(ProcStatus::Stopping { .. }) => {
@@ -737,7 +740,7 @@ fn proc_status_to_actor_status(proc_status: Option<ProcStatus>) -> ActorStatus {
         // Conservatively treat lack of status as stopped
         None => ActorStatus::Stopped("no status received from process".to_string()),
         Some(status) => ActorStatus::Failed(ActorErrorKind::Generic(format!(
-            "process failure: {}",
+            "the process this actor was running on failed: {}",
             status
         ))),
     }
@@ -878,7 +881,7 @@ impl<A: Referable> Handler<CheckState> for ActorMeshController<A> {
                         // Attribute this to the monitored actor, even if the underlying
                         // cause is a proc_failure. We propagate the cause explicitly.
                         mesh.get(point.rank()).unwrap().actor_id().clone(),
-                        Some(format!("{} was running on a process which", display_name)),
+                        Some(display_name),
                         actor_status,
                         None,
                     ),

--- a/monarch_hyperactor/src/actor.rs
+++ b/monarch_hyperactor/src/actor.rs
@@ -42,6 +42,7 @@ use hyperactor_mesh::transport::default_bind_spec;
 use hyperactor_mesh::value_mesh::ValueOverlay;
 use monarch_types::PickledPyObject;
 use monarch_types::SerializablePyErr;
+use monarch_types::py_global;
 use ndslice::Point;
 use ndslice::extent;
 use pyo3::IntoPyObjectExt;
@@ -81,6 +82,12 @@ use crate::runtime::get_tokio_runtime;
 use crate::runtime::monarch_with_gil;
 use crate::runtime::monarch_with_gil_blocking;
 use crate::supervision::PyMeshFailure;
+
+py_global!(
+    unhandled_fault_hook_exception,
+    "monarch._src.actor.supervision",
+    "UnhandledFaultHookException"
+);
 
 #[pyclass(module = "monarch._rust_bindings.monarch_hyperactor.actor")]
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
@@ -632,11 +639,32 @@ impl PythonActor {
                     work = work_rx.recv() => {
                         let work = work.expect("inconsistent work queue state");
                         if let Err(err) = work.handle(&mut actor, instance).await {
+                            // Check for UnhandledFaultHookException on the raw
+                            // anyhow::Error before wrapping in ActorErrorKind.
+                            // If __supervise__ already processed the supervision
+                            // event and the hook raised, don't re-handle it via
+                            // handle_supervision_event — that would call
+                            // __supervise__ a second time.
+                            let is_hook_exception = monarch_with_gil(|py| {
+                                err.downcast_ref::<pyo3::PyErr>()
+                                    .is_some_and(|pyerr| {
+                                        pyerr.is_instance(
+                                            py,
+                                            &unhandled_fault_hook_exception(py),
+                                        )
+                                    })
+                            }).await;
+
                             let kind = ActorErrorKind::processing(err);
                             let err = ActorError {
                                 actor_id: Box::new(instance.self_id().clone()),
                                 kind: Box::new(kind),
                             };
+
+                            if is_hook_exception {
+                                break Some(err);
+                            }
+
                             // Give the actor a chance to handle the error produced
                             // in its own message handler. This is important because
                             // we want Undeliverable<MessageEnvelope>, which returns
@@ -1321,6 +1349,17 @@ impl Handler<MeshFailure> for PythonActor {
                     }
                 }
                 Err(err) => {
+                    // If __supervise__ raised UnhandledFaultHookException,
+                    // return the PyErr directly without wrapping in
+                    // ActorErrorKind. The custom run loop detects this by
+                    // downcasting the anyhow::Error to PyErr.
+                    if err.is_instance(
+                        py,
+                        &unhandled_fault_hook_exception(py),
+                    ) {
+                        return Err(err.into());
+                    }
+
                     // Any other exception will supersede in the propagation chain,
                     // and will become its own supervision failure.
                     // Include the event it was handling in the error message.

--- a/monarch_hyperactor/src/supervision.rs
+++ b/monarch_hyperactor/src/supervision.rs
@@ -80,10 +80,10 @@ impl SupervisionError {
     #[allow(dead_code)]
     pub(crate) fn new_err_from(failure: MeshFailure) -> PyErr {
         let event = failure.event;
-        Self::new_err(format!(
-            "Actor {} exited because of the following reason: {}",
-            event.actor_id, event,
-        ))
+        let message = event
+            .failure_report()
+            .unwrap_or_else(|| format!("{}", event));
+        Self::new_err(message)
     }
     /// Set the endpoint on a PyErr containing a SupervisionError.
     ///
@@ -154,7 +154,10 @@ impl PyMeshFailure {
     }
 
     fn report(&self) -> String {
-        format!("{}", self.inner.event)
+        self.inner
+            .event
+            .failure_report()
+            .unwrap_or_else(|| format!("{}", self.inner.event))
     }
 }
 

--- a/python/monarch/_src/actor/actor_mesh.py
+++ b/python/monarch/_src/actor/actor_mesh.py
@@ -1702,9 +1702,34 @@ class RootClientActor(Actor):
     name: str = "client"
 
     def __supervise__(self, failure: MeshFailure) -> bool:
+        import os
+        import socket
+        import sys
+        from datetime import datetime
+
+        from monarch._src.actor.supervision import UnhandledFaultHookException
         from monarch.actor import unhandled_fault_hook  # pyre-ignore
 
-        unhandled_fault_hook(failure)  # pyre-ignore
+        try:
+            unhandled_fault_hook(failure)  # pyre-ignore
+        except BaseException as e:  # noqa: B036 - catch SystemExit from sys.exit; re-raised wrapped
+            pid = os.getpid()
+            hostname = socket.gethostname()
+            report = failure.report()
+            message = (
+                f"Unhandled monarch error on the root actor, "
+                f"hostname={hostname}, PID={pid} at time {datetime.now()}:\n"
+                f"{report}\n"
+            )
+            sys.stderr.write(message)
+            sys.stderr.flush()
+
+            from monarch._rust_bindings.monarch_hyperactor.telemetry import (  # pyre-ignore
+                instant_event,
+            )
+
+            instant_event(message)
+            raise UnhandledFaultHookException(repr(e)) from e
         return True
 
     @staticmethod

--- a/python/monarch/_src/actor/supervision.py
+++ b/python/monarch/_src/actor/supervision.py
@@ -6,12 +6,20 @@
 
 # pyre-strict
 
-import os
-import socket
 import sys
-from datetime import datetime
 
 from monarch._rust_bindings.monarch_hyperactor.supervision import MeshFailure
+
+
+class UnhandledFaultHookException(Exception):
+    """Wraps exceptions raised by the unhandled fault hook.
+
+    When `unhandled_fault_hook` raises (e.g. `sys.exit`), the
+    `RootClientActor` catches the exception, logs it, and re-raises
+    it wrapped in this type. The Rust root-client message loop
+    recognises this wrapper and skips re-dispatching the supervision
+    event, which would otherwise call `__supervise__` a second time.
+    """
 
 
 def unhandled_fault_hook(failure: MeshFailure) -> None:
@@ -43,19 +51,4 @@ def unhandled_fault_hook(failure: MeshFailure) -> None:
     "KeyboardInterrupt" happening that you didn't send, it's because there was
     an unhandled fault.
     """
-    from monarch._rust_bindings.monarch_hyperactor.telemetry import instant_event
-
-    pid = os.getpid()
-    hostname = socket.gethostname()
-    message = (
-        f"Unhandled monarch error on the root actor, hostname={hostname}, "
-        f"PID={pid} at time {datetime.now()}: {failure.report()}\n"
-        "Delivering KeyboardInterrupt to main thread to exit the program\n"
-    )
-    # use stderr, not a logger because loggers are sometimes set
-    # not print anything (e.g. in pytest)
-    sys.stderr.write(message)
-    sys.stderr.flush()
-    # In addition to writing to stderr, log the event to telemetry.
-    instant_event(message)
     sys.exit(1)

--- a/python/tests/test_actor_error.py
+++ b/python/tests/test_actor_error.py
@@ -670,7 +670,7 @@ async def test_actor_mesh_supervision_handling() -> None:
     # existing call should fail with supervision error
     with pytest.raises(
         SupervisionError,
-        match=".*Actor .* exited because of the following reason",
+        match="The actor .* and all its descendants have failed",
     ):
         await e.fail_with_supervision_error.call_one()
     print("after failure")
@@ -679,8 +679,8 @@ async def test_actor_mesh_supervision_handling() -> None:
     with pytest.raises(
         RuntimeError,
         match="failure on mesh.*error.*with event: "
-        "The actor.*ErrorActor error.* and all its descendants have failed|"
-        "Actor.*error.*exited because of the following",
+        "Supervision event: actor.*ErrorActor error.* failed|"
+        "The actor.*error.*and all its descendants have failed",
     ):
         await e.check.call()
     print("after subsequent endpoint call")
@@ -751,7 +751,7 @@ async def test_actor_mesh_supervision_handling_chained_error() -> None:
     # as an application error (ActorError).
     with pytest.raises(
         ActorError,
-        match=".*Actor .* exited because of the following reason",
+        match="The actor .* and all its descendants have failed",
     ):
         await intermediate_actor.forward_error.call()
 
@@ -795,7 +795,7 @@ async def test_base_exception_handling(mesh, error_actor_cls) -> None:
     # The call should raise a SupervisionError
     with pytest.raises(
         SupervisionError,
-        match=".*Actor .* exited because of the following reason",
+        match="The actor .* and all its descendants have failed",
     ):
         await error_actor.fail_with_supervision_error.call_one()
 
@@ -804,10 +804,9 @@ async def test_base_exception_handling(mesh, error_actor_cls) -> None:
     with pytest.raises(
         RuntimeError,
         match="failure on mesh .*error.* at rank 0 with event:.*"
-        "The actor .*ErrorActor error.*and all its descendants have failed.*"
+        "Supervision event: actor .*ErrorActor error.*failed.*"
         "|"
-        "Actor .*error.*exited because of the following reason:"
-        ".*ErrorActor error.*and all its descendants have failed",
+        "The actor.*error.*and all its descendants have failed",
     ):
         await error_actor.check.call()
     # The above check call is undeliverable and might get returned to the client
@@ -836,7 +835,7 @@ async def test_process_exit_handling(error_actor_cls) -> None:
     proc = spawn_procs_on_this_host({"gpus": 1})
     error_actor = proc.spawn("error", error_actor_cls)
 
-    base_match = "Endpoint call {}\\(\\) failed, (Actor .*error.* exited because of the following reason|actor mesh is stopped due to proc mesh shutdown)"
+    base_match = "Endpoint call {}\\(\\) failed, (The actor .*error.* and all its descendants have failed|actor mesh is stopped due to proc mesh shutdown)"
     # The call should raise a SupervisionError
     with pytest.raises(
         SupervisionError,
@@ -849,9 +848,9 @@ async def test_process_exit_handling(error_actor_cls) -> None:
         RuntimeError,
         # Message changes depending on actor_queue_dispatch.
         match="failure on mesh .*error.* at rank 0 with event: "
-        "The actor.*ErrorActor error.*was running on a process which and all its descendants have failed"
+        "The actor.*ErrorActor error.*and all its descendants have failed"
         "|"
-        "Actor.*error.*exited because of the following reason",
+        "The actor.*error.*and all its descendants have failed",
     ):
         await error_actor.check.call()
 
@@ -897,7 +896,7 @@ async def test_sigsegv_handling():
     with pytest.raises(
         RuntimeError,
         match="failure on mesh.*fault.*with event.*|"
-        "Actor.*fault.*exited because of the following reason",
+        "The actor.*fault.*and all its descendants have failed",
     ):
         await actor.check.call()
 
@@ -938,7 +937,8 @@ async def test_supervision_with_proc_mesh_stopped(mesh) -> None:
         match="Endpoint call healthy.check\\(\\) failed, Actor.*healthy.*is "
         "unhealthy with reason:.*timeout waiting for response from host mesh agent for"
         "|actor mesh is stopped due to proc mesh shutdown"
-        "|The actor .* and all its descendants have failed",
+        "|The actor .* and all its descendants have failed"
+        "|Supervision event: actor .* has status:",
     ):
         await actor_mesh.check.call()
 
@@ -970,7 +970,7 @@ async def test_actor_mesh_stop() -> None:
     # the right error message.
     with pytest.raises(
         SupervisionError,
-        match=r"(?s)Actor .*printer-.* exited because of the following reason:.*stopped",
+        match=r"(?s)(The actor|Supervision event: actor) .*printer-.* (and all its descendants have failed|has status:).*stopped",
     ):
         await am_1.print.call("hello 2")
 
@@ -1011,7 +1011,8 @@ async def test_supervision_with_sending_error() -> None:
         # The host mesh agent sends or the proc mesh agent sends might break.
         # Either case is an error that tells us that the send failed.
         error_msg_regx = (
-            "Actor .* (is unhealthy with reason|exited because of the following reason)|"
+            "Actor .* is unhealthy with reason|"
+            "The actor .* and all its descendants have failed|"
             "actor mesh is stopped due to proc mesh shutdown"
         )
 
@@ -1068,7 +1069,8 @@ async def test_slice_supervision() -> None:
     slice_3 = error_mesh.slice(gpus=3)
 
     match = (
-        "Actor .* (is unhealthy with reason:|exited because of the following reason:)"
+        "Actor .* is unhealthy with reason:|"
+        "The actor .* and all its descendants have failed"
     )
     print("before slice_3 fail")
     # Trigger supervision error on gpus=3
@@ -1084,8 +1086,8 @@ async def test_slice_supervision() -> None:
     # Slice containing only gpus=3 is unhealthy
     with pytest.raises(
         RuntimeError,
-        match="failure on mesh.*error.*at rank 3 with event: The actor.*ErrorActor error.* and all its descendants have failed|"
-        "Actor.*error.*exited because of the following",
+        match="failure on mesh.*error.*at rank 3 with event: Supervision event: actor.*ErrorActor error.* failed|"
+        "The actor.*error.*and all its descendants have failed",
     ):
         await slice_3.check.call()
 
@@ -1377,7 +1379,7 @@ async def test_supervise_callback_unhandled():
     )
 
     message = re.compile(
-        r"The actor .* and all its descendants have failed\..*error_actor",
+        r"The actor.*error_actor.*and all its descendants have failed",
         re.DOTALL,
     )
     # Note that __supervise__ will not get called until the next message
@@ -1538,6 +1540,58 @@ def test_controller_controller_error():
     # Note that we cannot spawn new actors on a proc mesh that has prior supervision
     # events at the moment, so we have to use a pre-existing one.
     actor_2.check.call_one().get()
+
+
+def _subprocess_fault_hook_called_once(marker_path: str) -> None:
+    """Subprocess helper: sets a fault hook that counts invocations and raises,
+    then triggers a supervision error. Writes the invocation count to marker_path."""
+    call_count = 0
+
+    def counting_hook(failure):
+        nonlocal call_count
+        call_count += 1
+        # Write count after each invocation so the parent can inspect it.
+        with open(marker_path, "w") as f:
+            f.write(str(call_count))
+        raise RuntimeError("hook raised")
+
+    monarch.actor.unhandled_fault_hook = counting_hook
+
+    proc = this_host().spawn_procs({"gpus": 1})
+    actor = proc.spawn("error", ErrorActor)
+    actor.check.call().get()
+
+    # Trigger supervision error that reaches unhandled_fault_hook.
+    with pytest.raises(SupervisionError):
+        actor.fail_with_supervision_error.call().get()
+
+    # Give the fault time to propagate back to the client.
+    time.sleep(5)
+
+
+@pytest.mark.timeout(60)
+@parametrize_config(actor_queue_dispatch={True, False})
+def test_unhandled_fault_hook_called_once() -> None:
+    """Regression test: when the fault hook raises, __supervise__ must not
+    re-dispatch the event, so the hook is invoked exactly once."""
+    import tempfile
+
+    marker = tempfile.NamedTemporaryFile(delete=False, suffix=".txt")
+    marker_path = marker.name
+    marker.write(b"0")
+    marker.close()
+
+    ctx = multiprocessing.get_context("spawn")
+    p = ctx.Process(target=_subprocess_fault_hook_called_once, args=[marker_path])
+    p.start()
+    p.join(30)
+
+    with open(marker_path) as f:
+        count = f.read().strip()
+    os.unlink(marker_path)
+    assert count == "1", (
+        f"unhandled_fault_hook should be called exactly once, but was called {count} time(s)"
+    )
 
 
 def _subprocess_unhandled_fault_hook_atexit(marker_path: str) -> None:

--- a/python/tests/test_supervision_hierarchy.py
+++ b/python/tests/test_supervision_hierarchy.py
@@ -111,7 +111,7 @@ def test_actor_failure():
         actor = this_host().spawn_procs().spawn("actor", Lambda)
         actor.run.broadcast(error)
 
-    capture.assert_fault_occurred("This occurred because the actor itself failed\\.")
+    capture.assert_fault_occurred("and all its descendants have failed:")
 
 
 @parametrize_config(actor_queue_dispatch={True, False})
@@ -127,7 +127,9 @@ def test_proc_failure():
     # Any actors on the proc mesh can report the proc failure, so it might be
     # "nested" or it might be other broken actors such as "logger".
     capture.assert_fault_occurred("(nested|logger-.*)\\{'a_dim': 0/1\\}")
-    capture.assert_fault_occurred("process failure: Killed\\(sig=9\\)")
+    capture.assert_fault_occurred(
+        "the process this actor was running on failed: Killed\\(sig=9\\)"
+    )
 
 
 @parametrize_config(actor_queue_dispatch={True, False})
@@ -143,5 +145,5 @@ def test_nested_mesh_kills_actor_actor_error():
         actor.nested.call_one(error).get()
         print("ERRORED THE ACTOR")
     capture.assert_fault_occurred(
-        "actor <root>\\.<.*(tests\\.)?test_supervision_hierarchy\\.Nest actor>\\.<.*(tests\\.)?test_supervision_hierarchy\\.Lambda nested\\{'a_dim': 0/1\\}> failed"
+        "The actor.*test_supervision_hierarchy\\.Lambda nested\\{'a_dim': 0/1\\}.*and all its descendants have failed"
     )


### PR DESCRIPTION
Summary:

## Walkthrough

**`hyperactor/src/supervision.rs`**: Separated `fmt::Display` and
`failure_report()` into distinct implementations with different purposes.

`Display` renders every supervision event in the chain with indentation.
Each `ActorErrorKind` variant has its own format: Generic and Aborted show
"Supervision event: actor X failed:" with the error indented;
`UnhandledSupervisionEvent` says the actor did not handle a child event
and recurses; `ErrorDuringHandlingSupervision` shows the error and then
the child event it occurred while handling. Non-failure statuses show "has
status:". The special host_agent/proc_agent Stopped case is preserved
with its "process became unresponsive" message. `trim_end()` is applied
to messages passed through `writeln!` to avoid double newlines.

`failure_report()` returns `Option<String>` (`None` for non-failure events).
It produces a concise error report for the unhandled fault hook and
`SupervisionError`. It walks the `UnhandledSupervisionEvent` chain to the
root cause. If the root cause is a failure, it reports "The actor X and all
its descendants have failed:" and recurses for
`ErrorDuringHandlingSupervision`. If the root cause is not a failure
(e.g. a stopped process), it reports that the parent did not handle the
child's event and falls back to `Display` for the child.

`caused_by()` walks the `UnhandledSupervisionEvent` chain to the root-cause
event. `actually_failing_actor()` delegates to it and returns `Option` —
`None` for non-failure events.

28 unit tests cover all `Display` and `failure_report` code paths.

**`monarch_hyperactor/src/supervision.rs`**: `PyMeshFailure::report()`
and `SupervisionError::new_err_from()` use `failure_report()` for
failure events, falling back to `Display` for non-failure events.

**`hyperactor_mesh/src/mesh_controller.rs`**: Removed the sentence
fragment `" was running on a process which"` from supervision display
names. Process failure context is now conveyed in the error message.

**`monarch_hyperactor/src/actor.rs`**: When `__supervise__` raises an
`UnhandledFaultHookException`, the handler returns early and the root
client message loop skips re-dispatching through
`handle_supervision_event`, preventing `__supervise__` from being called
a second time.

**`python/monarch/_src/actor/supervision.py`**: Added
`UnhandledFaultHookException`. Moved error reporting out of the default
`unhandled_fault_hook` into `RootClientActor.__supervise__`.

**`python/monarch/_src/actor/actor_mesh.py`**:
`RootClientActor.__supervise__` now catches exceptions from
`unhandled_fault_hook`, prints the supervision failure report to stderr
and telemetry, then re-raises wrapped in `UnhandledFaultHookException`.

**`python/tests/test_actor_error.py`**: Added
`test_unhandled_fault_hook_called_once` regression test verifying the hook
is invoked exactly once when it raises.

**`python/tests/test_supervision_hierarchy.py`**: Updated assertion
patterns to match the new `failure_report()` output format.

Reviewed By: mariusae

Differential Revision: D97155967
