### PR TITLE
[monarch] fix subprocess spawning to preserve venv python path

### DIFF
--- a/monarch_hyperactor/src/bootstrap.rs
+++ b/monarch_hyperactor/src/bootstrap.rs
@@ -76,13 +76,19 @@ pub fn run_worker_loop_forever(_py: Python<'_>, address: &str) -> PyResult<PyPyt
             env,
         }
     } else {
-        // For regular Python builds: use current_exe() and -m arguments
-        let current_exe = std::env::current_exe().map_err(|e| {
-            pyo3::PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(format!(
-                "Failed to get current executable: {}",
-                e
-            ))
-        })?;
+        // For regular Python builds: use argv[0] to preserve the original
+        // invocation path.  current_exe() resolves symlinks, which breaks
+        // virtual environments — the resolved path doesn't find pyvenv.cfg
+        // so site-packages aren't activated in subprocesses.
+        let current_exe = std::env::args()
+            .next()
+            .map(std::path::PathBuf::from)
+            .or_else(|| std::env::current_exe().ok())
+            .ok_or_else(|| {
+                pyo3::PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(
+                    "Failed to determine current executable",
+                )
+            })?;
         let current_exe_str = current_exe.to_string_lossy().to_string();
         BootstrapCommand {
             program: current_exe,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #3088
* #3087
* #3086
* #3085
* #3084
* #3083
* #3082
* #3081
* #3080
* #3079
* #3078
* #3077
* #3076
* #3075
* #3074
* #3073
* #3072
* #3071
* __->__ #3070

Stack walkthrough: https://www.internalfb.com/intern/phabricator/paste/markdown/P2239132492/
`std::env::current_exe()` resolves symlinks, so `.venv/bin/python`
becomes `/usr/local/fbcode/platform010/bin/python3.12`. The resolved
path doesn't find `pyvenv.cfg`, so subprocesses lose the venv's
site-packages and can't import monarch.

Use `argv[0]` instead of `current_exe()` in `run_worker_loop_forever`'s
`BootstrapCommand` construction to preserve the original invocation path.

Differential Revision: [D96176392](https://our.internmc.facebook.com/intern/diff/D96176392/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D96176392/)!