### PR TITLE
[monarch] add missing build dependencies to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ rustup toolchain install nightly
 rustup default nightly
 
 # Install non-python dependencies
-sudo dnf install libunwind -y
+sudo dnf install -y cmake ninja-build protobuf-compiler libunwind
 
 # Install the correct cuda and cuda-toolkit versions for your machine
 sudo dnf install cuda-toolkit-12-8 cuda-12-8
@@ -173,7 +173,7 @@ rustup toolchain install nightly
 rustup default nightly
 
 # Install Ubuntu-specific system dependencies
-sudo apt install -y ninja-build libunwind-dev clang
+sudo apt install -y cmake ninja-build protobuf-compiler libunwind-dev clang
 
 # Set clang as the default C/C++ compiler
 export CC=clang


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #3088
* #3087
* #3086
* #3085
* #3084
* #3083
* #3082
* #3081
* #3080
* #3079
* #3078
* #3077
* #3076
* #3075
* #3074
* #3073
* #3072
* __->__ #3071
* #3070

\nStack walkthrough: https://www.internalfb.com/intern/phabricator/paste/markdown/P2239132492/
The rdma-core build requires cmake and ninja-build. Without ninja,
the build falls back to make, which can't build individual file-path
targets and fails with "No rule to make target 'lib/statics/libibverbs.a'".

Added cmake, ninja-build, and protobuf-compiler to the Fedora and
Ubuntu install instructions.

Differential Revision: [D96315289](https://our.internmc.facebook.com/intern/diff/D96315289/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D96315289/)!