### PR TITLE
[monarch] fix uv cache-keys to exclude target/ build artifacts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,11 +77,13 @@ python-downloads = "automatic"  # Automatically download Python if needed
 cache-keys = [
     { file = "pyproject.toml" },
     { file = "setup.py" },
-    { file = "**/*.rs" },
-    { file = "**/Cargo.toml" },
+    # Note: we intentionally avoid "**/*.rs" because it matches generated
+    # .rs files in target/release/build/, causing a full rebuild every time.
+    { file = "*/src/**/*.rs" },
+    { file = "*/Cargo.toml" },
     { file = "Cargo.lock" },
-    { file = "**/*.{cc, cpp, c, h}" },
-    { file = "**/*.{cu, cuh}" },
+    { file = "*/src/**/*.{cc,cpp,c,h}" },
+    { file = "*/src/**/*.{cu,cuh}" },
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #3088
* #3087
* #3086
* #3085
* #3084
* #3083
* #3082
* #3081
* #3080
* #3079
* #3078
* #3077
* #3076
* #3075
* #3074
* #3073
* __->__ #3072
* #3071
* #3070

\nStack walkthrough: https://www.internalfb.com/intern/phabricator/paste/markdown/P2239132492/
The **/*.rs glob matched generated .rs files in target/release/build/,
causing uv to invalidate its build cache after every build and triggering
a full rebuild on each `uv run` invocation. Scope globs to */src/** to
only track actual source files. Also fix spaces in brace expansions.

Differential Revision: [D96315288](https://our.internmc.facebook.com/intern/diff/D96315288/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D96315288/)!