### PR TITLE
[monarch] speed up uv sync by skipping fresh C++ extensions and scoping RUSTFLAGS

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,6 +84,7 @@ cache-keys = [
     { file = "Cargo.lock" },
     { file = "*/src/**/*.{cc,cpp,c,h}" },
     { file = "*/src/**/*.{cu,cuh}" },
+    { file = "python/monarch/**/*.{cpp,c,h}" },
 ]
 
 [project.optional-dependencies]

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ import sysconfig
 from typing import Dict, List, Optional
 
 from setuptools import Command, setup
-from setuptools.command.build_ext import build_ext
+from setuptools.command.build_ext import build_ext as _build_ext
 from setuptools.command.build_py import build_py
 from setuptools.extension import Extension
 from setuptools_rust import Binding, RustExtension
@@ -210,6 +210,13 @@ elif build_rocm:
 os.environ.update(env_vars)
 
 # RPATH configuration for Linux
+# These flags are passed via RustExtension.rustc_flags (applied only to the final
+# cdylib link) rather than RUSTFLAGS (which would apply to every crate in the
+# workspace). Putting environment-specific paths in RUSTFLAGS invalidates cargo's
+# fingerprint cache for all 800+ dependency crates, causing a full rebuild every
+# time the build environment path changes (e.g. uv's PEP 517 build isolation
+# creates a new temp venv per invocation).
+rust_link_flags: List[str] = []
 if sys.platform.startswith("linux"):
     conda_lib = os.path.join(sys.prefix, "lib")
     ldlib = sysconfig.get_config_var("LDLIBRARY") or ""
@@ -223,7 +230,7 @@ if sys.platform.startswith("linux"):
         ):
             py_lib = libdir
 
-    rpath_flags = [
+    rust_link_flags = [
         "-C",
         "link-arg=-Wl,--enable-new-dtags",
         "-C",
@@ -240,10 +247,42 @@ if sys.platform.startswith("linux"):
         conda_lib,
     ]
     if py_lib:
-        rpath_flags += ["-C", f"link-arg=-Wl,-rpath,{py_lib}"]
+        rust_link_flags += ["-C", f"link-arg=-Wl,-rpath,{py_lib}"]
 
-    cur_rustflags = os.environ.get("RUSTFLAGS", "")
-    os.environ["RUSTFLAGS"] = (cur_rustflags + " " + " ".join(rpath_flags)).strip()
+
+# Custom build_ext that skips C++ extensions when .so files are already fresh.
+# uv's PEP 517 build isolation rebuilds the entire package whenever any cache-key
+# file changes (e.g. a .rs file). Cargo handles its own caching, but setuptools
+# always recompiles C++ into fresh temp dirs. This skips that when unnecessary.
+class build_ext(_build_ext):
+    def build_extension(self, ext):
+        # Only apply caching to C/C++ extensions (those with .sources)
+        if not hasattr(ext, "sources") or not ext.sources:
+            return super().build_extension(ext)
+
+        # In PEP 517 builds, get_ext_fullpath points to a temp build dir.
+        # Look for the .so in the source tree instead (editable install puts
+        # the .so alongside the Python package).
+        ext_filename = self.get_ext_filename(ext.name)
+        # ext_filename is e.g. "monarch/common/_C.cpython-312-x86_64-linux-gnu.so"
+        # source tree location is python/<ext_filename>
+        src_root = os.path.dirname(os.path.abspath(__file__))
+        so_path = os.path.join(src_root, "python", ext_filename)
+        if not os.path.exists(so_path):
+            return super().build_extension(ext)
+
+        so_mtime = os.path.getmtime(so_path)
+
+        # Rebuild if any source file is newer than the .so
+        for src in ext.sources:
+            if os.path.exists(src) and os.path.getmtime(src) > so_mtime:
+                return super().build_extension(ext)
+
+        # .so is up to date — copy it to the build dir instead of recompiling
+        dest = self.get_ext_fullpath(ext.name)
+        os.makedirs(os.path.dirname(dest), exist_ok=True)
+        shutil.copy2(so_path, dest)
+        print(f"skipping {ext.name} (up to date, copied existing .so)")
 
 
 # Extension Creation
@@ -307,6 +346,7 @@ rust_extensions.append(
         debug=False,
         features=rust_features,
         args=[] if build_tensor_engine else ["--no-default-features"],
+        rustc_flags=rust_link_flags,
     )
 )
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #3088
* #3087
* #3086
* #3085
* #3084
* #3083
* #3082
* #3081
* #3080
* #3079
* #3078
* #3077
* #3076
* #3075
* #3074
* __->__ #3073
* #3072
* #3071
* #3070

\nStack walkthrough: https://www.internalfb.com/intern/phabricator/paste/markdown/P2239132492/
Two changes to reduce unnecessary rebuilds during `uv sync`:

1. Move RPATH flags from RUSTFLAGS env var to RustExtension.rustc_flags.
   RUSTFLAGS applies to every crate in the workspace, so environment-specific
   paths (from uv's PEP 517 build isolation temp venvs) invalidate cargo's
   fingerprint cache for all 800+ dependency crates.

2. Add a custom build_ext that skips C++ extension compilation when the
   existing .so in the source tree is newer than all source files. uv rebuilds
   the entire package whenever any cache-key file changes (e.g. a .rs file),
   but cargo handles its own caching while setuptools always recompiles C++
   into fresh temp dirs. This copies the existing .so instead.

Also adds python/monarch/**/*.{cpp,c,h} to uv cache-keys so C++ source
changes properly trigger rebuilds.

Measured improvement for Rust-only changes: 1m42s -> 58s.

Differential Revision: [D96472597](https://our.internmc.facebook.com/intern/diff/D96472597/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D96472597/)!