### PR TITLE
[hyperactor] generate supervision events on normal actor stop

### DIFF
--- a/hyperactor/src/actor.rs
+++ b/hyperactor/src/actor.rs
@@ -133,10 +133,11 @@ pub trait Actor: Sized + Send + 'static {
     async fn handle_supervision_event(
         &mut self,
         _this: &Instance<Self>,
-        _event: &ActorSupervisionEvent,
+        event: &ActorSupervisionEvent,
     ) -> Result<bool, anyhow::Error> {
-        // By default, the supervision event is not handled, caller is expected to bubble it up.
-        Ok(false)
+        // Error events are not handled by default and bubble up to the parent.
+        // Normal lifecycle events (e.g. clean stop) are absorbed.
+        Ok(!event.is_error())
     }
 
     /// Default undeliverable message handling behavior.

--- a/hyperactor/src/proc.rs
+++ b/hyperactor/src/proc.rs
@@ -267,12 +267,30 @@ impl Proc {
     ) {
         let result = match self.state().supervision_coordinator_port.get() {
             Some(port) => port.send(cx, event.clone()).map_err(anyhow::Error::from),
-            None => Err(anyhow::anyhow!(
-                "coordinator port is not set for proc {}",
-                self.proc_id(),
-            )),
+            None => {
+                if !event.is_error() {
+                    // Normal lifecycle events (e.g. clean stop) without a coordinator
+                    // are silently dropped.
+                    return;
+                }
+                Err(anyhow::anyhow!(
+                    "coordinator port is not set for proc {}",
+                    self.proc_id(),
+                ))
+            }
         };
         if let Err(err) = result {
+            if !event.is_error() {
+                // Normal lifecycle events that fail to send (e.g. coordinator
+                // mailbox already closed during shutdown) are silently dropped.
+                tracing::debug!(
+                    "proc {}: dropping non-error supervision event {}: {:?}",
+                    self.proc_id(),
+                    event,
+                    err
+                );
+                return;
+            }
             tracing::error!(
                 "proc {}: could not propagate supervision event {} due to error: {:?}: crashing",
                 self.proc_id(),
@@ -1477,17 +1495,21 @@ impl<A: Actor> Instance<A> {
             Ok(stop_reason) => {
                 let status = ActorStatus::Stopped(stop_reason);
                 self.mailbox().close(status.clone());
-                // success exit case
+                let event = ActorSupervisionEvent::new(
+                    self.inner.cell.actor_id().clone(),
+                    actor.display_name(),
+                    status.clone(),
+                    None,
+                );
+                // FI-1: store supervision_event BEFORE change_status.
+                *self.inner.cell.inner.supervision_event.lock().unwrap() = Some(event.clone());
                 self.change_status(status);
-                None
+                Some(event)
             }
             Err(err) => {
                 match *err.kind {
                     ActorErrorKind::UnhandledSupervisionEvent(box event) => {
-                        // Currently only terminated actors are allowed to raise supervision events.
-                        // If we want to change that in the future, we need to modify the exit
-                        // status here too, because we use event's actor_status as this actor's
-                        // terminal status.
+                        // We use the event's actor_status as this actor's terminal status.
                         assert!(event.actor_status.is_terminal());
                         self.mailbox().close(event.actor_status.clone());
                         // FI-1: store supervision_event BEFORE change_status.
@@ -2328,7 +2350,16 @@ impl InstanceCell {
     ) {
         match &self.inner.actor_loop {
             Some((_, supervision_port)) => {
-                if let Err(err) = supervision_port.send(child_cx, event) {
+                if let Err(err) = supervision_port.send(child_cx, event.clone()) {
+                    if !event.is_error() {
+                        tracing::debug!(
+                            "{}: dropping non-error supervision event {}: {:?}",
+                            self.actor_id(),
+                            event,
+                            err
+                        );
+                        return;
+                    }
                     tracing::error!(
                         "{}: failed to send supervision event to actor: {:?}. Crash the process.",
                         self.actor_id(),
@@ -2338,6 +2369,14 @@ impl InstanceCell {
                 }
             }
             None => {
+                if !event.is_error() {
+                    tracing::debug!(
+                        "{}: dropping non-error supervision event to detached actor: {}",
+                        self.actor_id(),
+                        event,
+                    );
+                    return;
+                }
                 tracing::error!(
                     "{}: failed: {}: cannot send supervision event to detached actor: crashing",
                     self.actor_id(),
@@ -3761,7 +3800,7 @@ mod tests {
 
     // Exercises FI-2 (see introspect.rs module-scope comment).
     #[async_timed_test(timeout_secs = 30)]
-    async fn test_supervision_event_none_on_clean_stop() {
+    async fn test_supervision_event_on_clean_stop() {
         let proc = Proc::local();
         let (_client, _client_handle) = proc.instance("client").unwrap();
 
@@ -3771,10 +3810,15 @@ mod tests {
         handle.drain_and_stop("test").unwrap();
         handle.await;
 
+        let event = cell
+            .supervision_event()
+            .expect("cleanly stopped actor must have a supervision_event");
         assert!(
-            cell.supervision_event().is_none(),
-            "cleanly stopped actor must have no supervision_event"
+            matches!(event.actor_status, ActorStatus::Stopped(_)),
+            "expected Stopped status, got {:?}",
+            event.actor_status
         );
+        assert!(!event.is_error());
     }
 
     // Exercises FI-4 (see introspect.rs module-scope comment).

--- a/hyperactor_mesh/Cargo.toml
+++ b/hyperactor_mesh/Cargo.toml
@@ -64,7 +64,6 @@ hyperactor_config = { version = "0.0.0", path = "../hyperactor_config" }
 hyperactor_mesh_macros = { version = "0.0.0", path = "../hyperactor_mesh_macros" }
 hyperactor_telemetry = { version = "0.0.0", path = "../hyperactor_telemetry" }
 indicatif = { version = "0.18.4", features = ["futures", "improved_unicode", "rayon", "tokio"] }
-inventory = "0.3.22"
 libc = "0.2.139"
 mockall = "0.13.1"
 ndslice = { version = "0.0.0", path = "../ndslice" }
@@ -97,6 +96,7 @@ zbus = { version = "5.14.0", features = ["async-executor", "async-fs", "async-io
 
 [dev-dependencies]
 criterion = { version = "0.5.1", features = ["async_tokio", "csv_output"] }
+inventory = "0.3.22"
 itertools = "0.14.0"
 jsonschema = "0.17.0"
 maplit = "1.0"

--- a/hyperactor_mesh/src/proc_agent.rs
+++ b/hyperactor_mesh/src/proc_agent.rs
@@ -757,9 +757,9 @@ impl Handler<ActorSupervisionEvent> for ProcAgent {
         }
         if let Some(supervisor) = self.state.supervisor() {
             supervisor.send(cx, event)?;
-        } else if !self.record_supervision_events {
+        } else if !self.record_supervision_events && event.is_error() {
             // If there is no supervisor, and nothing is recording these, crash
-            // the whole process.
+            // the whole process on error events.
             tracing::error!(
                 name = "supervision_event_transmit_failed",
                 proc_id = %cx.self_id().proc_id(),

--- a/monarch_rdma/examples/cuda_ping_pong/src/cuda_ping_pong.rs
+++ b/monarch_rdma/examples/cuda_ping_pong/src/cuda_ping_pong.rs
@@ -272,9 +272,12 @@ impl Actor for CudaRdmaActor {
     async fn handle_supervision_event(
         &mut self,
         _cx: &Instance<Self>,
-        _event: &ActorSupervisionEvent,
+        event: &ActorSupervisionEvent,
     ) -> Result<bool, anyhow::Error> {
-        tracing::error!("CudaRdmaActor supervision event: {:?}", _event);
+        if !event.is_error() {
+            return Ok(true);
+        }
+        tracing::error!("CudaRdmaActor supervision event: {:?}", event);
         tracing::error!("CudaRdmaActor error occurred, stop the worker process, exit code: 1");
         std::process::exit(1);
     }

--- a/monarch_rdma/examples/parameter_server/src/parameter_server.rs
+++ b/monarch_rdma/examples/parameter_server/src/parameter_server.rs
@@ -114,9 +114,12 @@ impl Actor for ParameterServerActor {
     async fn handle_supervision_event(
         &mut self,
         _cx: &Instance<Self>,
-        _event: &ActorSupervisionEvent,
+        event: &ActorSupervisionEvent,
     ) -> Result<bool, anyhow::Error> {
-        tracing::error!("parameterServerActor supervision event: {:?}", _event);
+        if !event.is_error() {
+            return Ok(true);
+        }
+        tracing::error!("parameterServerActor supervision event: {:?}", event);
         tracing::error!(
             "parameterServerActor error occurred, stop the worker process, exit code: 1"
         );
@@ -266,9 +269,12 @@ impl Actor for WorkerActor {
     async fn handle_supervision_event(
         &mut self,
         _cx: &Instance<Self>,
-        _event: &ActorSupervisionEvent,
+        event: &ActorSupervisionEvent,
     ) -> Result<bool, anyhow::Error> {
-        tracing::error!("workerActor supervision event: {:?}", _event);
+        if !event.is_error() {
+            return Ok(true);
+        }
+        tracing::error!("workerActor supervision event: {:?}", event);
         tracing::error!("workerActor error occurred, stop the worker process, exit code: 1");
         std::process::exit(1);
     }

--- a/monarch_rdma/src/rdma_manager_actor.rs
+++ b/monarch_rdma/src/rdma_manager_actor.rs
@@ -228,9 +228,12 @@ impl Actor for RdmaManagerActor {
     async fn handle_supervision_event(
         &mut self,
         _cx: &Instance<Self>,
-        _event: &ActorSupervisionEvent,
+        event: &ActorSupervisionEvent,
     ) -> Result<bool, anyhow::Error> {
-        tracing::error!("rdmaManagerActor supervision event: {:?}", _event);
+        if !event.is_error() {
+            return Ok(true);
+        }
+        tracing::error!("rdmaManagerActor supervision event: {:?}", event);
         tracing::error!("rdmaManagerActor error occurred, stop the worker process, exit code: 1");
         std::process::exit(1);
     }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #3088
* #3087
* #3086
* #3085
* #3084
* #3083
* #3082
* #3081
* #3080
* #3079
* #3078
* #3077
* #3076
* #3075
* __->__ #3074
* #3073
* #3072
* #3071
* #3070

\nStack walkthrough: https://www.internalfb.com/intern/phabricator/paste/markdown/P2239132492/
Previously, supervision events were only generated when an actor failed.
The `Ok(stop_reason)` path in `Instance::serve` produced no event, so
parents never learned that a child stopped normally.

Now every actor stop — normal or abnormal — generates an
`ActorSupervisionEvent`. The event carries `ActorStatus::Stopped(reason)`
for clean stops and `ActorStatus::Failed(...)` for failures.

To preserve existing behavior where a child's clean stop doesn't kill
its parent, the default `Actor::handle_supervision_event` returns
`Ok(true)` (handled) for non-error events and `Ok(false)` (bubble up)
for error events. All existing overrides are updated to guard
`process::exit(1)` behind `event.is_error()`:

- RDMA actors: RdmaManagerActor, ParameterServerActor, WorkerActor,
  CudaRdmaActor
- ProcAgent coordinator: guard no-supervisor crash path
- Proc::handle_unhandled_supervision_event: silently drop non-error
  events when no coordinator is set

Differential Revision: [D96760756](https://our.internmc.facebook.com/intern/diff/D96760756/)