### PR TITLE
[hyperactor] test that supervision coordinators receive actor stop events

### DIFF
--- a/hyperactor/src/proc.rs
+++ b/hyperactor/src/proc.rs
@@ -3821,6 +3821,29 @@ mod tests {
         assert!(!event.is_error());
     }
 
+    #[async_timed_test(timeout_secs = 30)]
+    async fn test_supervision_coordinator_receives_clean_stop() {
+        let proc = Proc::local();
+        let (_client, _client_handle) = proc.instance("client").unwrap();
+        let (mut reported_event, _coordinator_handle) =
+            ProcSupervisionCoordinator::set(&proc).await.unwrap();
+
+        let handle = proc.spawn::<TestActor>("stop_actor", TestActor).unwrap();
+        let actor_id = handle.actor_id().clone();
+
+        handle.drain_and_stop("test").unwrap();
+        handle.await;
+
+        let event = reported_event.recv().await;
+        assert_eq!(event.actor_id, actor_id);
+        assert!(
+            matches!(event.actor_status, ActorStatus::Stopped(_)),
+            "expected Stopped status, got {:?}",
+            event.actor_status
+        );
+        assert!(!event.is_error());
+    }
+
     // Exercises FI-4 (see introspect.rs module-scope comment).
     #[async_timed_test(timeout_secs = 30)]
     async fn test_supervision_event_on_propagated_failure() {

--- a/hyperactor/src/testing/proc_supervison.rs
+++ b/hyperactor/src/testing/proc_supervison.rs
@@ -6,10 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-use std::sync::Arc;
-use std::sync::Mutex;
-
 use async_trait::async_trait;
+use tokio::sync::watch;
 
 use crate::Actor;
 use crate::ActorHandle;
@@ -26,13 +24,13 @@ use crate::supervision::ActorSupervisionEvent;
 ///
 ///   This is because hyperactor's supervision logic requires actor failures in
 ///   a proc to be bubbled up to through the supervision chain:
-///      
+///
 ///   grandchild actor -> child actor -> root actor -> proc supervison coordinator
 ///
 ///   If the the proc supervison coordinator is not set, supervision will crash the
 ///   process because it cannot find the coordinator during the "bubbling up".
 #[derive(Debug)]
-pub struct ProcSupervisionCoordinator(ReportedEvent);
+pub struct ProcSupervisionCoordinator(watch::Sender<Option<ActorSupervisionEvent>>);
 
 impl ProcSupervisionCoordinator {
     /// Spawn a coordinator actor and set it as the coordinator for the given
@@ -42,29 +40,32 @@ impl ProcSupervisionCoordinator {
     pub async fn set(
         proc: &Proc,
     ) -> Result<(ReportedEvent, ActorHandle<ProcSupervisionCoordinator>), anyhow::Error> {
-        let state = ReportedEvent::new();
-        let actor = ProcSupervisionCoordinator(state.clone());
+        let (tx, rx) = watch::channel(None);
+        let actor = ProcSupervisionCoordinator(tx);
         let coordinator = proc.spawn::<ProcSupervisionCoordinator>("coordinator", actor)?;
         proc.set_supervision_coordinator(coordinator.port())?;
-        Ok((state, coordinator))
+        Ok((ReportedEvent(rx), coordinator))
     }
 }
 
 /// Used to store the last event reported to [ProcSupervisionCoordinator].
 #[derive(Clone, Debug)]
-pub struct ReportedEvent(Arc<Mutex<Option<ActorSupervisionEvent>>>);
-impl ReportedEvent {
-    fn new() -> Self {
-        Self(Arc::new(Mutex::new(None)))
-    }
+pub struct ReportedEvent(watch::Receiver<Option<ActorSupervisionEvent>>);
 
+impl ReportedEvent {
     /// The last event reported to the coordinator.
     pub fn event(&self) -> Option<ActorSupervisionEvent> {
-        self.0.lock().unwrap().clone()
+        self.0.borrow().clone()
     }
 
-    fn set(&self, event: ActorSupervisionEvent) {
-        *self.0.lock().unwrap() = Some(event);
+    /// Wait until the coordinator receives an event.
+    pub async fn recv(&mut self) -> ActorSupervisionEvent {
+        self.0
+            .wait_for(|v| v.is_some())
+            .await
+            .expect("coordinator sender dropped without sending an event")
+            .clone()
+            .unwrap()
     }
 }
 
@@ -79,7 +80,7 @@ impl Handler<ActorSupervisionEvent> for ProcSupervisionCoordinator {
         msg: ActorSupervisionEvent,
     ) -> anyhow::Result<()> {
         tracing::debug!("in handler, handling supervision event");
-        self.0.set(msg);
+        self.0.send_replace(Some(msg));
         Ok(())
     }
 }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #3088
* #3087
* #3086
* #3085
* #3084
* #3083
* #3082
* #3081
* #3080
* #3079
* #3078
* #3077
* #3076
* __->__ #3075
* #3074
* #3073
* #3072
* #3071
* #3070

\nStack walkthrough: https://www.internalfb.com/intern/phabricator/paste/markdown/P2239132492/
Add a unit test verifying that `ProcSupervisionCoordinator` receives a
`Stopped` supervision event when an actor cleanly shuts down.

Also refactor `ReportedEvent` from `Arc<Mutex<Option<...>>>` to
`tokio::sync::watch`, adding an async `recv()` method so tests can await
events without sleeping.

Differential Revision: [D96760751](https://our.internmc.facebook.com/intern/diff/D96760751/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D96760751/)!