### PR TITLE
[hyperactor] shut down supervision coordinator last during proc teardown

### DIFF
--- a/hyperactor/src/proc.rs
+++ b/hyperactor/src/proc.rs
@@ -183,6 +183,10 @@ struct ProcState {
     /// Used by root actors to send events to the actor coordinating
     /// supervision of root actors in this proc.
     supervision_coordinator_port: OnceLock<PortHandle<ActorSupervisionEvent>>,
+
+    /// The actor ID of the supervision coordinator, if it lives on this proc.
+    /// Used to ensure the coordinator is shut down last during proc teardown.
+    supervision_coordinator_actor_id: OnceLock<reference::ActorId>,
 }
 
 impl Drop for ProcState {
@@ -233,6 +237,7 @@ impl Proc {
                 instances: DashMap::new(),
                 terminated_snapshots: DashMap::new(),
                 supervision_coordinator_port: OnceLock::new(),
+                supervision_coordinator_actor_id: OnceLock::new(),
             }),
         }
     }
@@ -252,10 +257,19 @@ impl Proc {
         &self,
         port: PortHandle<ActorSupervisionEvent>,
     ) -> Result<(), anyhow::Error> {
+        let actor_id = port.location().actor_id().clone();
         self.state()
             .supervision_coordinator_port
             .set(port)
-            .map_err(|existing| anyhow::anyhow!("coordinator port is already set to {existing}"))
+            .map_err(|existing| anyhow::anyhow!("coordinator port is already set to {existing}"))?;
+        let _ = self.state().supervision_coordinator_actor_id.set(actor_id);
+        Ok(())
+    }
+
+    /// The actor ID of the supervision coordinator, if one is set and
+    /// lives on this proc.
+    pub fn supervision_coordinator_actor_id(&self) -> Option<&reference::ActorId> {
+        self.state().supervision_coordinator_actor_id.get()
     }
 
     /// Handle a supervision event received by the proc. Attempt to forward it to the
@@ -742,6 +756,10 @@ impl Proc {
             )
         });
 
+        let coordinator_id = self.supervision_coordinator_actor_id().cloned();
+
+        // Phase 1: stop all root actors except the supervision coordinator
+        // (which must stay alive to receive stop events from the others).
         let mut statuses = HashMap::new();
         for actor_id in self
             .state()
@@ -751,11 +769,14 @@ impl Proc {
             .map(|entry| entry.key().clone())
             .collect::<Vec<_>>()
         {
+            if coordinator_id.as_ref() == Some(&actor_id) {
+                continue;
+            }
             if let Some(status) = self.stop_actor(&actor_id, reason.to_string()) {
                 statuses.insert(actor_id, status);
             }
         }
-        tracing::debug!("{}: proc stopped", self.proc_id());
+        tracing::debug!("{}: non-coordinator actors stopped", self.proc_id());
 
         let waits: Vec<_> = statuses
             .iter_mut()
@@ -775,7 +796,7 @@ impl Proc {
             .collect();
 
         let results = futures::future::join_all(waits).await;
-        let stopped_actors: Vec<_> = results
+        let mut stopped_actors: Vec<_> = results
             .iter()
             .filter_map(|actor_id| actor_id.as_ref())
             .cloned()
@@ -795,7 +816,31 @@ impl Proc {
                 }
             })
             .collect();
-        let aborted_actors = futures::future::join_all(aborted_actors).await;
+        let mut aborted_actors = futures::future::join_all(aborted_actors).await;
+
+        // Phase 2: now that all other actors have stopped, stop the
+        // supervision coordinator so it had a chance to receive all
+        // supervision events.
+        if let Some(ref coord_id) = coordinator_id
+            && this_actor_id != Some(coord_id)
+        {
+            if let Some(mut status) = self.stop_actor(coord_id, reason.to_string()) {
+                let stopped = tokio::time::timeout(
+                    timeout,
+                    status.wait_for(|s: &ActorStatus| s.is_terminal()),
+                )
+                .await
+                .is_ok();
+                if stopped {
+                    stopped_actors.push(coord_id.clone());
+                } else {
+                    if let Some(f) = self.abort_root_actor(coord_id, this_handle) {
+                        f.await;
+                    }
+                    aborted_actors.push(coord_id.clone());
+                }
+            }
+        }
 
         if let Some(this_handle) = this_handle
             && let Some(this_actor_id) = this_actor_id
@@ -2352,6 +2397,11 @@ impl InstanceCell {
             Some((_, supervision_port)) => {
                 if let Err(err) = supervision_port.send(child_cx, event.clone()) {
                     if !event.is_error() {
+                        // Normal lifecycle events (e.g. clean stop) that fail to
+                        // send are silently dropped. This happens when a child
+                        // stops after the parent's mailbox has been closed or its
+                        // supervision port receiver has been dropped (e.g. client
+                        // instances created via Proc::instance()).
                         tracing::debug!(
                             "{}: dropping non-error supervision event {}: {:?}",
                             self.actor_id(),
@@ -2371,7 +2421,7 @@ impl InstanceCell {
             None => {
                 if !event.is_error() {
                     tracing::debug!(
-                        "{}: dropping non-error supervision event to detached actor: {}",
+                        "{}: dropping non-error supervision event {} to detached actor",
                         self.actor_id(),
                         event,
                     );
@@ -3842,6 +3892,46 @@ mod tests {
             event.actor_status
         );
         assert!(!event.is_error());
+    }
+
+    #[async_timed_test(timeout_secs = 30)]
+    async fn test_coordinator_shuts_down_last_during_destroy() {
+        let mut proc = Proc::local();
+        let (_client, _client_handle) = proc.instance("client").unwrap();
+        let (mut reported_event, _coordinator_handle) =
+            ProcSupervisionCoordinator::set(&proc).await.unwrap();
+
+        // Spawn several actors that will all stop during destroy_and_wait.
+        let mut actor_ids = Vec::new();
+        for i in 0..3 {
+            let handle = proc
+                .spawn::<TestActor>(&format!("actor_{i}"), TestActor)
+                .unwrap();
+            actor_ids.push(handle.actor_id().clone());
+        }
+
+        // destroy_and_wait stops all actors. If the coordinator were stopped
+        // simultaneously, supervision event delivery would fail and crash
+        // the process. The fact that this completes without crashing proves
+        // the coordinator outlived the other actors.
+        proc.destroy_and_wait::<()>(Duration::from_secs(5), None, "test")
+            .await
+            .unwrap();
+
+        // Verify the coordinator received stop events from all three actors.
+        let mut received_ids = Vec::new();
+        for _ in 0..actor_ids.len() {
+            let event = reported_event.recv().await;
+            assert!(
+                matches!(event.actor_status, ActorStatus::Stopped(_)),
+                "expected Stopped, got {:?}",
+                event.actor_status
+            );
+            received_ids.push(event.actor_id);
+        }
+        received_ids.sort();
+        actor_ids.sort();
+        assert_eq!(received_ids, actor_ids);
     }
 
     // Exercises FI-4 (see introspect.rs module-scope comment).

--- a/hyperactor/src/testing/proc_supervison.rs
+++ b/hyperactor/src/testing/proc_supervison.rs
@@ -6,8 +6,11 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+use std::sync::Arc;
+use std::sync::Mutex;
+
 use async_trait::async_trait;
-use tokio::sync::watch;
+use tokio::sync::mpsc;
 
 use crate::Actor;
 use crate::ActorHandle;
@@ -30,7 +33,10 @@ use crate::supervision::ActorSupervisionEvent;
 ///   If the the proc supervison coordinator is not set, supervision will crash the
 ///   process because it cannot find the coordinator during the "bubbling up".
 #[derive(Debug)]
-pub struct ProcSupervisionCoordinator(watch::Sender<Option<ActorSupervisionEvent>>);
+pub struct ProcSupervisionCoordinator {
+    tx: mpsc::UnboundedSender<ActorSupervisionEvent>,
+    last: Arc<Mutex<Option<ActorSupervisionEvent>>>,
+}
 
 impl ProcSupervisionCoordinator {
     /// Spawn a coordinator actor and set it as the coordinator for the given
@@ -40,32 +46,37 @@ impl ProcSupervisionCoordinator {
     pub async fn set(
         proc: &Proc,
     ) -> Result<(ReportedEvent, ActorHandle<ProcSupervisionCoordinator>), anyhow::Error> {
-        let (tx, rx) = watch::channel(None);
-        let actor = ProcSupervisionCoordinator(tx);
+        let (tx, rx) = mpsc::unbounded_channel();
+        let last = Arc::new(Mutex::new(None));
+        let actor = ProcSupervisionCoordinator {
+            tx,
+            last: last.clone(),
+        };
         let coordinator = proc.spawn::<ProcSupervisionCoordinator>("coordinator", actor)?;
         proc.set_supervision_coordinator(coordinator.port())?;
-        Ok((ReportedEvent(rx), coordinator))
+        Ok((ReportedEvent { rx, last }, coordinator))
     }
 }
 
-/// Used to store the last event reported to [ProcSupervisionCoordinator].
-#[derive(Clone, Debug)]
-pub struct ReportedEvent(watch::Receiver<Option<ActorSupervisionEvent>>);
+/// Collects supervision events reported to [ProcSupervisionCoordinator].
+#[derive(Debug)]
+pub struct ReportedEvent {
+    rx: mpsc::UnboundedReceiver<ActorSupervisionEvent>,
+    last: Arc<Mutex<Option<ActorSupervisionEvent>>>,
+}
 
 impl ReportedEvent {
     /// The last event reported to the coordinator.
     pub fn event(&self) -> Option<ActorSupervisionEvent> {
-        self.0.borrow().clone()
+        self.last.lock().unwrap().clone()
     }
 
     /// Wait until the coordinator receives an event.
     pub async fn recv(&mut self) -> ActorSupervisionEvent {
-        self.0
-            .wait_for(|v| v.is_some())
+        self.rx
+            .recv()
             .await
             .expect("coordinator sender dropped without sending an event")
-            .clone()
-            .unwrap()
     }
 }
 
@@ -80,7 +91,8 @@ impl Handler<ActorSupervisionEvent> for ProcSupervisionCoordinator {
         msg: ActorSupervisionEvent,
     ) -> anyhow::Result<()> {
         tracing::debug!("in handler, handling supervision event");
-        self.0.send_replace(Some(msg));
+        *self.last.lock().unwrap() = Some(msg.clone());
+        let _ = self.tx.send(msg);
         Ok(())
     }
 }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #3088
* #3087
* #3086
* #3085
* #3084
* #3083
* #3082
* #3081
* #3080
* #3079
* #3078
* #3077
* __->__ #3076
* #3075
* #3074
* #3073
* #3072
* #3071
* #3070

\nStack walkthrough: https://www.internalfb.com/intern/phabricator/paste/markdown/P2239132492/
When a supervision coordinator is an actor on the same proc, it must
outlive all other actors so it can receive their stop events. Previously,
`destroy_and_wait` sent `DrainAndStop` to all root actors simultaneously,
racing the coordinator against the actors it supervises.

Split shutdown into two phases:
1. Stop all root actors except the coordinator; wait/abort as before.
2. Stop the coordinator after everything else has terminated.

Store the coordinator's actor ID in `ProcState` (alongside the port) so
`destroy_and_wait` can identify and defer it.

Also switch `ProcSupervisionCoordinator`'s `ReportedEvent` from `watch`
to `mpsc` so tests can `recv()` successive events rather than only the
last.

Differential Revision: [D96760749](https://our.internmc.facebook.com/intern/diff/D96760749/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D96760749/)!