### PR TITLE
[hyperactor] add flush() to MailboxSender

### DIFF
--- a/hyperactor/src/actor.rs
+++ b/hyperactor/src/actor.rs
@@ -1465,6 +1465,7 @@ mod tests {
         }
     }
 
+    #[async_trait]
     impl MailboxSender for DelayedMailboxSender {
         fn post_unchecked(
             &self,

--- a/hyperactor/src/host.rs
+++ b/hyperactor/src/host.rs
@@ -304,6 +304,7 @@ struct ProcOrDial {
     dialer: DialMailboxRouter,
 }
 
+#[async_trait]
 impl MailboxSender for ProcOrDial {
     fn post_unchecked(
         &self,
@@ -317,6 +318,19 @@ impl MailboxSender for ProcOrDial {
         } else {
             self.dialer.post_unchecked(envelope, return_handle)
         }
+    }
+
+    async fn flush(&self) -> Result<(), anyhow::Error> {
+        let (r1, r2, r3) = futures::future::join3(
+            self.service_proc.flush(),
+            self.local_proc.flush(),
+            self.dialer.flush(),
+        )
+        .await;
+        r1?;
+        r2?;
+        r3?;
+        Ok(())
     }
 }
 

--- a/hyperactor/src/mailbox.rs
+++ b/hyperactor/src/mailbox.rs
@@ -72,6 +72,7 @@ use std::collections::BTreeMap;
 use std::collections::BTreeSet;
 use std::fmt;
 use std::fmt::Debug;
+use std::future;
 use std::future::Future;
 use std::ops::Bound::Excluded;
 use std::pin::Pin;
@@ -86,6 +87,7 @@ use std::sync::atomic::Ordering;
 use std::task::Context;
 use std::task::Poll;
 
+use async_trait::async_trait;
 use dashmap::DashMap;
 use dashmap::mapref::entry::Entry;
 use futures::Sink;
@@ -716,6 +718,7 @@ impl std::error::Error for MailboxSenderError {
 
 /// MailboxSenders can send messages through ports to mailboxes. It
 /// provides a unified interface for message delivery in the system.
+#[async_trait]
 pub trait MailboxSender: Send + Sync + Any {
     /// Apply hop semantics (TTL decrement; undeliverable on 0), then
     /// delegate to transport.
@@ -737,6 +740,14 @@ pub trait MailboxSender: Send + Sync + Any {
         envelope: MessageEnvelope,
         return_handle: PortHandle<Undeliverable<MessageEnvelope>>,
     );
+
+    /// Wait until all messages previously posted through this sender
+    /// have been delivered (wire-acked) or confirmed undeliverable.
+    /// The default implementation is a no-op, appropriate for senders
+    /// whose `post` is synchronous (e.g. local in-process delivery).
+    async fn flush(&self) -> Result<(), anyhow::Error> {
+        Ok(())
+    }
 }
 
 /// PortSender extends [`MailboxSender`] by providing typed endpoints
@@ -793,6 +804,7 @@ impl<T: ?Sized + MailboxSender> PortSender for T {}
 #[derive(Debug, Clone)]
 pub struct PanickingMailboxSender;
 
+#[async_trait]
 impl MailboxSender for PanickingMailboxSender {
     fn post_unchecked(
         &self,
@@ -808,6 +820,7 @@ impl MailboxSender for PanickingMailboxSender {
 #[derive(Debug)]
 pub struct UndeliverableMailboxSender;
 
+#[async_trait]
 impl MailboxSender for UndeliverableMailboxSender {
     fn post_unchecked(
         &self,
@@ -886,6 +899,7 @@ impl<T: MailboxSender + 'static> IntoBoxedMailboxSender for T {
     }
 }
 
+#[async_trait]
 impl MailboxSender for BoxedMailboxSender {
     fn post_unchecked(
         &self,
@@ -893,6 +907,10 @@ impl MailboxSender for BoxedMailboxSender {
         return_handle: PortHandle<Undeliverable<MessageEnvelope>>,
     ) {
         self.0.post_unchecked(envelope, return_handle);
+    }
+
+    async fn flush(&self) -> Result<(), anyhow::Error> {
+        self.0.flush().await
     }
 }
 
@@ -1040,17 +1058,69 @@ pub trait MailboxServer: MailboxSender + Clone + Sized + 'static {
 
 impl<T: MailboxSender + Clone + Sized + Sync + Send + 'static> MailboxServer for T {}
 
+struct Buffer<T: Message> {
+    queue: mpsc::UnboundedSender<(T, PortHandle<Undeliverable<T>>)>,
+    #[allow(dead_code)]
+    processed: watch::Receiver<usize>,
+    seq: AtomicUsize,
+}
+
+impl<T: Message> Buffer<T> {
+    fn new<Fut>(
+        process: impl Fn(T, PortHandle<Undeliverable<T>>) -> Fut + Send + Sync + 'static,
+    ) -> Self
+    where
+        Fut: Future<Output = ()> + Send + 'static,
+    {
+        let (queue, mut next) = mpsc::unbounded_channel();
+        let (last_processed, processed) = watch::channel(0);
+        crate::init::get_runtime().spawn(async move {
+            let mut seq = 0;
+            while let Some((msg, return_handle)) = next.recv().await {
+                process(msg, return_handle).await;
+                seq += 1;
+                let _ = last_processed.send(seq);
+            }
+        });
+        Self {
+            queue,
+            processed,
+            seq: AtomicUsize::new(0),
+        }
+    }
+
+    fn send(
+        &self,
+        item: (T, PortHandle<Undeliverable<T>>),
+    ) -> Result<(), mpsc::error::SendError<(T, PortHandle<Undeliverable<T>>)>> {
+        self.seq.fetch_add(1, Ordering::SeqCst);
+        self.queue.send(item)?;
+        Ok(())
+    }
+}
+
 /// A mailbox server client that transmits messages on a Tx channel.
 pub struct MailboxClient {
-    queue: mpsc::UnboundedSender<(MessageEnvelope, PortHandle<Undeliverable<MessageEnvelope>>)>,
+    // The unbounded sender.
+    buffer: Buffer<MessageEnvelope>,
 
     // To cancel monitoring tx health.
     _tx_monitoring: CancellationToken,
+
+    // Flush tracking: counts messages successfully submitted to the buffer.
+    submitted: Arc<AtomicUsize>,
+    // Flush tracking: counts messages whose delivery oneshot has resolved
+    // (acked or failed).
+    completed: Arc<AtomicUsize>,
+    // Notifies flush waiters when `completed` changes.
+    completed_notify: Arc<tokio::sync::Notify>,
 }
 
 impl fmt::Debug for MailboxClient {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("MailboxClient").finish()
+        f.debug_struct("MailboxClient")
+            .field("buffer", &"<Buffer>")
+            .finish()
     }
 }
 
@@ -1062,39 +1132,51 @@ impl MailboxClient {
         let tx = Arc::new(tx);
         let tx_status = tx.status().clone();
         let tx_monitoring = CancellationToken::new();
-        let (queue, mut next) = mpsc::unbounded_channel::<(
-            MessageEnvelope,
-            PortHandle<Undeliverable<MessageEnvelope>>,
-        )>();
-        crate::init::get_runtime().spawn(async move {
-            while let Some((envelope, return_handle)) = next.recv().await {
+        let completed = Arc::new(AtomicUsize::new(0));
+        let completed_notify = Arc::new(tokio::sync::Notify::new());
+        let buffer = {
+            let completed = completed.clone();
+            let completed_notify = completed_notify.clone();
+            Buffer::new(move |envelope, return_handle| {
                 let tx = Arc::clone(&tx);
                 let (return_channel, return_receiver) =
                     oneshot::channel::<SendError<MessageEnvelope>>();
                 // Set up for delivery failure.
                 let return_handle_0 = return_handle.clone();
+                let completed = completed.clone();
+                let completed_notify = completed_notify.clone();
                 tokio::spawn(async move {
-                    if let Ok(SendError {
-                        error,
-                        message,
-                        reason,
-                    }) = return_receiver.await
-                    {
-                        message.undeliverable(
-                            DeliveryError::BrokenLink(format!(
-                                "failed to enqueue in MailboxClient: {error} with reason {reason:?}"
-                            )),
-                            return_handle_0,
-                        );
+                    match return_receiver.await {
+                        Ok(SendError {
+                            error,
+                            message,
+                            reason,
+                        }) => {
+                            message.undeliverable(
+                                DeliveryError::BrokenLink(format!(
+                                    "failed to enqueue in MailboxClient when processing buffer: {error} with reason {reason:?}"
+                                )),
+                                return_handle_0,
+                            );
+                        }
+                        Err(_) => {
+                            // Oneshot sender was dropped — message was acked.
+                        }
                     }
+                    completed.fetch_add(1, Ordering::SeqCst);
+                    completed_notify.notify_waiters();
                 });
                 // Send the message for transmission.
                 tx.try_post(envelope, return_channel);
-            }
-        });
+                future::ready(())
+            })
+        };
         let this = Self {
-            queue,
+            buffer,
             _tx_monitoring: tx_monitoring.clone(),
+            submitted: Arc::new(AtomicUsize::new(0)),
+            completed,
+            completed_notify,
         };
         Self::monitor_tx_health(tx_status, tx_monitoring, addr);
         this
@@ -1132,6 +1214,7 @@ impl MailboxClient {
     }
 }
 
+#[async_trait]
 impl MailboxSender for MailboxClient {
     #[tracing::instrument(level = "debug", skip_all)]
     fn post_unchecked(
@@ -1141,14 +1224,26 @@ impl MailboxSender for MailboxClient {
     ) {
         tracing::event!(target:"messages", tracing::Level::TRACE,  "size"=envelope.data.len(), "sender"= %envelope.sender, "dest" = %envelope.dest.actor_id(), "port"= envelope.dest.index(), "message_type" = envelope.data.typename().unwrap_or("unknown"), "send_message");
         if let Err(mpsc::error::SendError((envelope, return_handle))) =
-            self.queue.send((envelope, return_handle))
+            self.buffer.send((envelope, return_handle))
         {
             let err = DeliveryError::BrokenLink(
-                "failed to enqueue in MailboxClient; queue is closed".to_string(),
+                "failed to enqueue in MailboxClient; buffer's queue is closed".to_string(),
             );
 
             // Failed to enqueue.
             envelope.undeliverable(err, return_handle);
+        } else {
+            self.submitted.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+
+    async fn flush(&self) -> Result<(), anyhow::Error> {
+        let target = self.submitted.load(Ordering::SeqCst);
+        loop {
+            if self.completed.load(Ordering::SeqCst) >= target {
+                return Ok(());
+            }
+            self.completed_notify.notified().await;
         }
     }
 }
@@ -1515,6 +1610,7 @@ pub fn open_once_port<M: Message>(
     cx.mailbox().open_once_port()
 }
 
+#[async_trait]
 impl MailboxSender for Mailbox {
     /// Deliver a serialized message to the provided port ID. This method fails
     /// if the message does not deserialize into the expected type.
@@ -2418,6 +2514,7 @@ impl MailboxMuxer {
     }
 }
 
+#[async_trait]
 impl MailboxSender for MailboxMuxer {
     fn post_unchecked(
         &self,
@@ -2432,6 +2529,20 @@ impl MailboxSender for MailboxMuxer {
             }
             Some(sender) => sender.post(envelope, return_handle),
         }
+    }
+
+    async fn flush(&self) -> Result<(), anyhow::Error> {
+        let keys: Vec<_> = self
+            .mailboxes
+            .iter()
+            .map(|entry| entry.key().clone())
+            .collect();
+        for key in keys {
+            if let Some(sender) = self.mailboxes.get(&key) {
+                sender.value().flush().await?;
+            }
+        }
+        Ok(())
     }
 }
 
@@ -2499,6 +2610,7 @@ impl MailboxRouter {
     }
 }
 
+#[async_trait]
 impl MailboxSender for MailboxRouter {
     fn post_unchecked(
         &self,
@@ -2515,6 +2627,13 @@ impl MailboxSender for MailboxRouter {
             Some(sender) => sender.post(envelope, return_handle),
         }
     }
+
+    async fn flush(&self) -> Result<(), anyhow::Error> {
+        let senders: Vec<_> = self.entries.read().unwrap().values().cloned().collect();
+        let futs: Vec<_> = senders.iter().map(|s| s.flush()).collect();
+        futures::future::try_join_all(futs).await?;
+        Ok(())
+    }
 }
 
 #[derive(Clone)]
@@ -2523,6 +2642,7 @@ struct FallbackMailboxRouter {
     default: BoxedMailboxSender,
 }
 
+#[async_trait]
 impl MailboxSender for FallbackMailboxRouter {
     fn post_unchecked(
         &self,
@@ -2533,6 +2653,13 @@ impl MailboxSender for FallbackMailboxRouter {
             Some(sender) => sender.post(envelope, return_handle),
             None => self.default.post(envelope, return_handle),
         }
+    }
+
+    async fn flush(&self) -> Result<(), anyhow::Error> {
+        let (r1, r2) = futures::future::join(self.router.flush(), self.default.flush()).await;
+        r1?;
+        r2?;
+        Ok(())
     }
 }
 
@@ -2556,6 +2683,7 @@ impl WeakMailboxRouter {
     }
 }
 
+#[async_trait]
 impl MailboxSender for WeakMailboxRouter {
     fn post_unchecked(
         &self,
@@ -2568,6 +2696,13 @@ impl MailboxSender for WeakMailboxRouter {
                 DeliveryError::BrokenLink("failed to upgrade WeakMailboxRouter".to_string()),
                 return_handle,
             ),
+        }
+    }
+
+    async fn flush(&self) -> Result<(), anyhow::Error> {
+        match self.upgrade() {
+            Some(router) => router.flush().await,
+            None => Ok(()),
         }
     }
 }
@@ -2743,6 +2878,7 @@ impl DialMailboxRouter {
     }
 }
 
+#[async_trait]
 impl MailboxSender for DialMailboxRouter {
     fn post_unchecked(
         &self,
@@ -2762,6 +2898,18 @@ impl MailboxSender for DialMailboxRouter {
             Ok(sender) => sender.post(envelope, return_handle),
         }
     }
+
+    async fn flush(&self) -> Result<(), anyhow::Error> {
+        let senders: Vec<_> = self
+            .sender_cache
+            .iter()
+            .map(|entry| entry.value().clone())
+            .collect();
+        let mut futs: Vec<_> = senders.iter().map(|s| s.flush()).collect();
+        futs.push(self.default.flush());
+        futures::future::try_join_all(futs).await?;
+        Ok(())
+    }
 }
 
 /// A MailboxSender that reports any envelope as undeliverable due to
@@ -2769,6 +2917,7 @@ impl MailboxSender for DialMailboxRouter {
 #[derive(Debug)]
 pub struct UnroutableMailboxSender;
 
+#[async_trait]
 impl MailboxSender for UnroutableMailboxSender {
     fn post_unchecked(
         &self,
@@ -3951,6 +4100,7 @@ mod tests {
     #[derive(Clone, Debug)]
     struct AsyncLoopForwarder;
 
+    #[async_trait]
     impl MailboxSender for AsyncLoopForwarder {
         fn post_unchecked(
             &self,
@@ -4277,5 +4427,48 @@ mod tests {
 
         // Different accumulators should have different reducer typehashes
         assert_ne!(sum_typehash, max_typehash);
+    }
+
+    /// Test that `MailboxClient::flush()` waits until messages are wire-acked
+    /// over a unix domain socket channel. We send messages, flush, and then
+    /// confirm that the messages have already been delivered to the receiving
+    /// mailbox.
+    #[tokio::test]
+    async fn test_flush_over_unix_channel() {
+        let mbox = Mailbox::new_detached(test_actor_id("0", "actor0"));
+
+        // Serve the mailbox on a unix domain socket channel.
+        let (addr, rx) = channel::serve(ChannelAddr::any(ChannelTransport::Unix)).unwrap();
+        let serve_handle = mbox.clone().serve(rx);
+
+        // Dial the unix address to get a MailboxClient.
+        let client = MailboxClient::dial(addr).unwrap();
+
+        // Open a streaming port so we can receive multiple messages.
+        let (port, mut receiver) = mbox.open_port::<u64>();
+        let port = port.bind();
+
+        // Send several messages without awaiting delivery.
+        for i in 0..10u64 {
+            client
+                .serialize_and_send(&port, i, monitored_return_handle())
+                .unwrap();
+        }
+
+        // Flush: this should block until all 10 messages are wire-acked,
+        // meaning they've been enqueued into the receiving mailbox.
+        client.flush().await.unwrap();
+
+        // After flush, all messages should already be available.
+        for i in 0..10u64 {
+            let msg = receiver
+                .try_recv()
+                .expect("message should be available after flush")
+                .expect("receiver should not be empty after flush");
+            assert_eq!(msg, i);
+        }
+
+        serve_handle.stop("test done");
+        serve_handle.await.unwrap().unwrap();
     }
 }

--- a/hyperactor/src/proc.rs
+++ b/hyperactor/src/proc.rs
@@ -965,6 +965,17 @@ impl MailboxSender for Proc {
             self.state().forwarder.post(envelope, return_handle)
         }
     }
+
+    async fn flush(&self) -> Result<(), anyhow::Error> {
+        let (r1, r2) = futures::future::join(
+            self.state().proc_muxer.flush(),
+            self.state().forwarder.flush(),
+        )
+        .await;
+        r1?;
+        r2?;
+        Ok(())
+    }
 }
 
 /// A weak reference to a Proc that doesn't prevent it from being dropped.
@@ -995,6 +1006,13 @@ impl MailboxSender for WeakProc {
                 DeliveryError::BrokenLink("fail to upgrade WeakProc".to_string()),
                 return_handle,
             ),
+        }
+    }
+
+    async fn flush(&self) -> Result<(), anyhow::Error> {
+        match self.upgrade() {
+            Some(proc) => proc.flush().await,
+            None => Ok(()),
         }
     }
 }

--- a/hyperactor_mesh/src/bootstrap/mailbox.rs
+++ b/hyperactor_mesh/src/bootstrap/mailbox.rs
@@ -12,6 +12,7 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::RwLock;
 
+use async_trait::async_trait;
 use hyperactor::PortHandle;
 use hyperactor::channel::ChannelAddr;
 use hyperactor::channel::ChannelError;
@@ -52,6 +53,7 @@ impl LocalProcDialer {
     }
 }
 
+#[async_trait]
 impl MailboxSender for LocalProcDialer {
     fn post_unchecked(
         &self,
@@ -99,6 +101,14 @@ impl MailboxSender for LocalProcDialer {
         } else {
             self.backend_sender.post_unchecked(envelope, return_handle);
         }
+    }
+
+    async fn flush(&self) -> Result<(), anyhow::Error> {
+        // We can't hold the RwLockReadGuard across an await, so flush
+        // the backend sender (the primary outbound path) only.
+        // Local senders are unix-socket MailboxClients whose flush
+        // semantics are equivalent.
+        self.backend_sender.flush().await
     }
 }
 

--- a/hyperactor_mesh/src/proc_agent.rs
+++ b/hyperactor_mesh/src/proc_agent.rs
@@ -1328,6 +1328,7 @@ impl ReconfigurableMailboxSender {
     }
 }
 
+#[async_trait]
 impl MailboxSender for ReconfigurableMailboxSender {
     fn post(
         &self,
@@ -1357,6 +1358,14 @@ impl MailboxSender for ReconfigurableMailboxSender {
                 sender.post_unchecked(envelope, return_handle);
             }
         }
+    }
+
+    async fn flush(&self) -> Result<(), anyhow::Error> {
+        let sender = match &*self.state.read().unwrap() {
+            ReconfigurableMailboxSenderState::Queueing(_) => return Ok(()),
+            ReconfigurableMailboxSenderState::Configured(sender) => sender.clone(),
+        };
+        sender.flush().await
     }
 }
 
@@ -1394,6 +1403,7 @@ mod tests {
         }
     }
 
+    #[async_trait]
     impl MailboxSender for QueueingMailboxSender {
         fn post_unchecked(
             &self,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #3088
* #3087
* #3086
* #3085
* #3084
* #3083
* #3082
* #3081
* #3080
* #3079
* #3078
* __->__ #3077
* #3076
* #3075
* #3074
* #3073
* #3072
* #3071
* #3070

\nStack walkthrough: https://www.internalfb.com/intern/phabricator/paste/markdown/P2239132492/
Add `async fn flush(&self)` to the `MailboxSender` trait, providing a
sender-level guarantee that all previously posted messages have been
wire-acked (or confirmed undeliverable) before returning.

The core implementation lives in `MailboxClient`, which tracks submitted
vs completed message counts using atomics and a `Notify`. The buffer's
spawned ack-watcher task increments the completed counter when the
delivery oneshot resolves (success or failure), and `flush()` waits
until completed >= the snapshot of submitted at call time. This does not
affect send throughput — `try_post` remains fire-and-forget.

All 20 `MailboxSender` implementations are updated:
- Local/terminal senders (Mailbox, PanickingMailboxSender, etc.): no-op default
- Routing layers (Proc, MailboxMuxer, MailboxRouter, DialMailboxRouter,
  ProcOrDial, etc.): delegate to inner senders
- MailboxClient: real wire-ack flush via submitted/completed tracking

The trait now uses `#[async_trait]` for object safety.

Differential Revision: [D96519755](https://our.internmc.facebook.com/intern/diff/D96519755/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D96519755/)!