### PR TITLE
[hyperactor] flush forwarder during proc teardown

### DIFF
--- a/hyperactor/src/proc.rs
+++ b/hyperactor/src/proc.rs
@@ -842,6 +842,17 @@ impl Proc {
             }
         }
 
+        // Flush the forwarder so that any messages posted during
+        // teardown (e.g. supervision events) are wire-delivered
+        // before we tear down the proc's networking.
+        if let Err(err) = self.state().forwarder.flush().await {
+            tracing::warn!(
+                "{}: forwarder flush failed during proc exit: {:?}",
+                self.proc_id(),
+                err
+            );
+        }
+
         if let Some(this_handle) = this_handle
             && let Some(this_actor_id) = this_actor_id
             && !except_current


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #3088
* #3087
* #3086
* #3085
* #3084
* #3083
* #3082
* #3081
* #3080
* #3079
* __->__ #3078
* #3077
* #3076
* #3075
* #3074
* #3073
* #3072
* #3071
* #3070

\nStack walkthrough: https://www.internalfb.com/intern/phabricator/paste/markdown/P2239132492/
After all actors (including the supervision coordinator) are stopped,
flush the forwarder before tearing down the proc's networking. This
is an invariant we want to provide on proc destruction: all messages
posted during teardown — such as supervision events — are guaranteed
to be wire-delivered (or confirmed undeliverable) before the proc
exits.

Flush failures are logged as warnings but do not fail the shutdown.

Differential Revision: [D96760755](https://our.internmc.facebook.com/intern/diff/D96760755/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D96760755/)!