### PR TITLE
[hyperactor_mesh] remove dead StopActor message variant from ProcAgent

### DIFF
--- a/hyperactor_mesh/src/proc_agent.rs
+++ b/hyperactor_mesh/src/proc_agent.rs
@@ -35,7 +35,6 @@ use hyperactor::Instance;
 use hyperactor::PortHandle;
 use hyperactor::RefClient;
 use hyperactor::Unbind;
-use hyperactor::actor::ActorStatus;
 use hyperactor::actor::remote::Remote;
 use hyperactor::channel;
 use hyperactor::channel::ChannelAddr;
@@ -81,29 +80,6 @@ pub enum GspawnResult {
 }
 wirevalue::register_type!(GspawnResult);
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Named)]
-pub enum StopActorResult {
-    Success,
-    Timeout,
-    NotFound,
-}
-wirevalue::register_type!(StopActorResult);
-
-/// Request a py-spy stack dump from this process.
-///
-/// The ProcAgent runs inside the target OS process (1:1 mapping).
-/// py-spy attaches to `std::process::id()` to capture Python stacks.
-/// See PS-1 in `introspect` module doc.
-#[derive(Debug, Serialize, Deserialize, Named, Handler, HandleClient, RefClient)]
-pub struct PySpyDump {
-    /// Include per-thread stacks.
-    pub threads: bool,
-    /// Reply port for the result.
-    #[reply]
-    pub result: hyperactor_reference::OncePortRef<crate::pyspy::PySpyResult>,
-}
-wirevalue::register_type!(PySpyDump);
-
 /// Deferred republish of introspect properties.
 ///
 /// Sent as a zero-delay self-message from the supervision event
@@ -120,6 +96,18 @@ wirevalue::register_type!(PySpyDump);
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Named, Bind, Unbind)]
 struct RepublishIntrospect;
 wirevalue::register_type!(RepublishIntrospect);
+
+/// py-spy attaches to `std::process::id()` to capture Python stacks.
+/// See PS-1 in `introspect` module doc.
+#[derive(Debug, Serialize, Deserialize, Named, Handler, HandleClient, RefClient)]
+pub struct PySpyDump {
+    /// Include per-thread stacks.
+    pub threads: bool,
+    /// Reply port for the result.
+    #[reply]
+    pub result: hyperactor_reference::OncePortRef<crate::pyspy::PySpyResult>,
+}
+wirevalue::register_type!(PySpyDump);
 
 /// Collect live actor children and system actor children from the
 /// proc's instance DashMap using `all_instance_keys()` with point
@@ -188,19 +176,6 @@ pub(crate) enum MeshAgentMessage {
         params_data: Data,
         /// reply port; the proc should send its rank to indicated a spawned actor
         status_port: hyperactor_reference::PortRef<GspawnResult>,
-    },
-
-    /// Stop actors of a specific mesh name
-    StopActor {
-        /// The actor to stop
-        actor_id: hyperactor_reference::ActorId,
-        /// The timeout for waiting for the actor to stop
-        timeout_ms: u64,
-        /// The reason for stopping the actor
-        reason: String,
-        /// The result when trying to stop the actor
-        #[reply]
-        stopped: hyperactor_reference::OncePortRef<StopActorResult>,
     },
 }
 
@@ -389,6 +364,18 @@ impl ProcAgent {
         self.proc
             .destroy_and_wait_except_current::<Self>(timeout, Some(cx), true, reason)
             .await
+    }
+
+    /// Send a stop signal to an actor on this proc. This is fire-and-forget;
+    /// it does not wait for the actor to reach terminal status.
+    fn stop_actor_by_id(&self, actor_id: &hyperactor_reference::ActorId, reason: &str) {
+        tracing::info!(
+            name = "StopActor",
+            %actor_id,
+            actor_name = actor_id.name(),
+            %reason,
+        );
+        self.proc.stop_actor(actor_id, reason.to_string());
     }
 
     /// Publish the current proc properties and children list for
@@ -656,37 +643,6 @@ impl MeshAgentMessageHandler for ProcAgent {
         Ok(())
     }
 
-    async fn stop_actor(
-        &mut self,
-        cx: &Context<Self>,
-        actor_id: hyperactor_reference::ActorId,
-        timeout_ms: u64,
-        reason: String,
-    ) -> Result<StopActorResult, anyhow::Error> {
-        tracing::info!(
-            name = "StopActor",
-            %actor_id,
-            actor_name = actor_id.name(),
-            %reason,
-        );
-
-        let result = if let Some(mut status) = self.proc.stop_actor(&actor_id, reason) {
-            match tokio::time::timeout(
-                tokio::time::Duration::from_millis(timeout_ms),
-                status.wait_for(|state: &ActorStatus| state.is_terminal()),
-            )
-            .await
-            {
-                Ok(_) => Ok(StopActorResult::Success),
-                Err(_) => Ok(StopActorResult::Timeout),
-            }
-        } else {
-            Ok(StopActorResult::NotFound)
-        };
-        self.publish_introspect_properties(cx);
-        result
-    }
-
     async fn status(
         &mut self,
         cx: &Context<Self>,
@@ -884,7 +840,7 @@ impl Handler<resource::CreateOrUpdate<ActorSpec>> for ProcAgent {
 
 #[async_trait]
 impl Handler<resource::Stop> for ProcAgent {
-    async fn handle(&mut self, cx: &Context<Self>, message: resource::Stop) -> anyhow::Result<()> {
+    async fn handle(&mut self, _cx: &Context<Self>, message: resource::Stop) -> anyhow::Result<()> {
         // We don't remove the actor from the state map, instead we just store
         // its state as Stopped.
         let actor = self.actor_states.get_mut(&message.name);
@@ -909,15 +865,8 @@ impl Handler<resource::Stop> for ProcAgent {
             // TODO: represent unknown rank
             None => None,
         };
-        let timeout = hyperactor_config::global::get(hyperactor::config::STOP_ACTOR_TIMEOUT);
         if let Some(actor_id) = actor_id {
-            // The orphaned actor SelfCheck will consult the stopped field before
-            // trying to stop any actor again.
-            // While this function returns a Result, it never returns an Err
-            // value so we can simply expect without any failure handling.
-            self.stop_actor(cx, actor_id, timeout.as_millis() as u64, message.reason)
-                .await
-                .expect("stop_actor cannot fail");
+            self.stop_actor_by_id(&actor_id, &message.reason);
         }
 
         Ok(())
@@ -1213,19 +1162,11 @@ impl Handler<SelfCheck> for ProcAgent {
             );
         }
 
-        let timeout = hyperactor_config::global::get(hyperactor::config::STOP_ACTOR_TIMEOUT);
         for (name, actor_id) in expired {
             if let Some(state) = self.actor_states.get_mut(&name) {
                 state.stopped = true;
             }
-            self.stop_actor(
-                cx,
-                actor_id,
-                timeout.as_millis() as u64,
-                "orphaned".to_string(),
-            )
-            .await
-            .expect("stop_actor cannot fail");
+            self.stop_actor_by_id(&actor_id, "orphaned");
         }
 
         // Reschedule.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #3088
* #3087
* #3086
* #3085
* #3084
* #3083
* #3082
* #3081
* #3080
* __->__ #3079
* #3078
* #3077
* #3076
* #3075
* #3074
* #3073
* #3072
* #3071
* #3070

\nStack walkthrough: https://www.internalfb.com/intern/phabricator/paste/markdown/P2239132492/
`StopActor` was never sent as a message — only its macro-generated
`self.stop_actor()` method was called internally. Replace it with a
plain `stop_actor_by_id()` method that sends a stop signal to the proc
without waiting for termination (callers never used the result).

Remove the associated `StopActorResult` type.

Differential Revision: [D96760759](https://our.internmc.facebook.com/intern/diff/D96760759/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D96760759/)!