### PR TITLE
[hyperactor] expose flush() on Proc and call it during ProcAgent shutdown

### DIFF
--- a/hyperactor/src/proc.rs
+++ b/hyperactor/src/proc.rs
@@ -961,6 +961,13 @@ impl Proc {
     pub fn downgrade(&self) -> WeakProc {
         WeakProc::new(self)
     }
+
+    /// Flush the forwarder so that any buffered outbound messages
+    /// (e.g. supervision events posted during teardown) are
+    /// wire-delivered before the proc's networking is torn down.
+    pub async fn flush(&self) -> Result<(), anyhow::Error> {
+        self.state().forwarder.flush().await
+    }
 }
 
 #[async_trait]

--- a/hyperactor_mesh/src/proc_agent.rs
+++ b/hyperactor_mesh/src/proc_agent.rs
@@ -393,11 +393,16 @@ impl ProcAgent {
         self.actor_states.values().all(|state| state.is_terminal())
     }
 
-    /// Trigger process shutdown. Sends through `shutdown_tx` if available,
-    /// otherwise calls `process::exit`.
-    fn shutdown(&mut self) {
+    /// Trigger process shutdown. Flushes the forwarder first so that
+    /// supervision events reach their destinations, then sends through
+    /// `shutdown_tx` if available, otherwise calls `process::exit`.
+    async fn shutdown(&mut self) {
         let has_errors = self.actor_states.values().any(|state| state.has_errors());
         let exit_code = if has_errors { 1 } else { 0 };
+
+        if let Err(err) = self.proc.flush().await {
+            tracing::warn!("failed to flush forwarder during shutdown: {}", err);
+        }
 
         tracing::info!(
             "shutting down process after all actors reached terminal state (exit_code={})",
@@ -767,7 +772,7 @@ impl Handler<ActorSupervisionEvent> for ProcAgent {
             // If StopAll was requested, check whether all actors have now
             // reached terminal state. If so, shut down the process.
             if self.stopping_all && self.all_actors_terminal() {
-                self.shutdown();
+                self.shutdown().await;
             }
         }
         if let Some(supervisor) = self.state.supervisor() {
@@ -958,7 +963,7 @@ impl Handler<resource::StopAll> for ProcAgent {
 
         // If there are no actors to stop, shut down immediately.
         if self.all_actors_terminal() {
-            self.shutdown();
+            self.shutdown().await;
         }
 
         Ok(())


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #3088
* #3087
* #3086
* #3085
* #3084
* #3083
* #3082
* __->__ #3081
* #3080
* #3079
* #3078
* #3077
* #3076
* #3075
* #3074
* #3073
* #3072
* #3071
* #3070

\nStack walkthrough: https://www.internalfb.com/intern/phabricator/paste/markdown/P2239132492/
Add an inherent `Proc::flush()` method that flushes the forwarder,
ensuring buffered outbound messages (e.g. supervision events) are
wire-delivered before the process exits.

`ProcAgent::shutdown()` is now async and calls `self.proc.flush().await`
before signaling the exit code or calling `process::exit`.

Differential Revision: [D96760753](https://our.internmc.facebook.com/intern/diff/D96760753/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D96760753/)!