### PR TITLE
[hyperactor_mesh] only allow a single transition to a terminating status

### DIFF
--- a/hyperactor_mesh/src/mesh_controller.rs
+++ b/hyperactor_mesh/src/mesh_controller.rs
@@ -118,7 +118,7 @@ impl HealthState {
         match self.statuses.entry(point) {
             Entry::Occupied(mut entry) => {
                 let (old_status, old_gen) = entry.get();
-                if *old_gen > generation {
+                if old_status.is_terminating() || *old_gen > generation {
                     return false;
                 }
                 let changed = *old_status != status;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #3088
* #3087
* #3086
* #3085
* __->__ #3084
* #3083
* #3082
* #3081
* #3080
* #3079
* #3078
* #3077
* #3076
* #3075
* #3074
* #3073
* #3072
* #3071
* #3070

\nStack walkthrough: https://www.internalfb.com/intern/phabricator/paste/markdown/P2239132492/
Guard `HealthState::maybe_update()` so that once a rank reaches a
terminal status (Stopped or Failed), subsequent updates for the same
rank are rejected regardless of generation. This prevents a stale
streaming update from overwriting a terminal status observed earlier
via polling.

Differential Revision: [D96675192](https://our.internmc.facebook.com/intern/diff/D96675192/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D96675192/)!