### PR TITLE
[hyperactor] add `unsplit` flag to PortRef to prevent port splitting during cast

### DIFF
--- a/hyperactor/src/reference.rs
+++ b/hyperactor/src/reference.rs
@@ -780,6 +780,13 @@ pub struct PortRef<M> {
     streaming_opts: StreamingReducerOpts,
     phantom: PhantomData<M>,
     return_undeliverable: bool,
+    #[derivative(
+        PartialEq = "ignore",
+        PartialOrd = "ignore",
+        Ord = "ignore",
+        Hash = "ignore"
+    )]
+    unsplit: bool,
 }
 
 impl<M: RemoteMessage> PortRef<M> {
@@ -792,6 +799,7 @@ impl<M: RemoteMessage> PortRef<M> {
             streaming_opts: StreamingReducerOpts::default(),
             phantom: PhantomData,
             return_undeliverable: true,
+            unsplit: false,
         }
     }
 
@@ -808,7 +816,14 @@ impl<M: RemoteMessage> PortRef<M> {
             streaming_opts,
             phantom: PhantomData,
             return_undeliverable: true,
+            unsplit: false,
         }
+    }
+
+    /// Prevents the port from being split.
+    pub fn unsplit(mut self) -> Self {
+        self.unsplit = true;
+        self
     }
 
     /// The caller attests that the provided PortId can be
@@ -837,8 +852,10 @@ impl<M: RemoteMessage> PortRef<M> {
     /// APIs requires OncePortRef.
     pub fn into_once(self) -> OncePortRef<M> {
         let return_undeliverable = self.return_undeliverable;
+        let unsplit = self.unsplit;
         let mut once = OncePortRef::attest(self.into_port_id());
         once.return_undeliverable = return_undeliverable;
+        once.unsplit = unsplit;
         once
     }
 
@@ -912,6 +929,7 @@ impl<M: RemoteMessage> Clone for PortRef<M> {
             streaming_opts: self.streaming_opts.clone(),
             phantom: PhantomData,
             return_undeliverable: self.return_undeliverable,
+            unsplit: self.unsplit,
         }
     }
 }
@@ -938,6 +956,7 @@ pub struct UnboundPort(
     pub Option<ReducerSpec>,
     pub bool, // return_undeliverable
     pub UnboundPortKind,
+    pub bool, // unsplit
 );
 wirevalue::register_type!(UnboundPort);
 
@@ -955,6 +974,7 @@ impl<M: RemoteMessage> From<&PortRef<M>> for UnboundPort {
             port_ref.reducer_spec.clone(),
             port_ref.return_undeliverable,
             UnboundPortKind::Streaming(Some(port_ref.streaming_opts.clone())),
+            port_ref.unsplit,
         )
     }
 }
@@ -967,11 +987,12 @@ impl<M: RemoteMessage> Unbind for PortRef<M> {
 
 impl<M: RemoteMessage> Bind for PortRef<M> {
     fn bind(&mut self, bindings: &mut Bindings) -> anyhow::Result<()> {
-        let UnboundPort(port_id, reducer_spec, return_undeliverable, port_kind) =
+        let UnboundPort(port_id, reducer_spec, return_undeliverable, port_kind, unsplit) =
             bindings.try_pop_front::<UnboundPort>()?;
         self.port_id = port_id;
         self.reducer_spec = reducer_spec;
         self.return_undeliverable = return_undeliverable;
+        self.unsplit = unsplit;
         self.streaming_opts = match port_kind {
             UnboundPortKind::Streaming(opts) => opts.unwrap_or_default(),
             UnboundPortKind::Once => {
@@ -990,6 +1011,7 @@ pub struct OncePortRef<M> {
     port_id: PortId,
     reducer_spec: Option<ReducerSpec>,
     return_undeliverable: bool,
+    unsplit: bool,
     phantom: PhantomData<M>,
 }
 
@@ -999,6 +1021,7 @@ impl<M: RemoteMessage> OncePortRef<M> {
             port_id,
             reducer_spec: None,
             return_undeliverable: true,
+            unsplit: false,
             phantom: PhantomData,
         }
     }
@@ -1010,8 +1033,15 @@ impl<M: RemoteMessage> OncePortRef<M> {
             port_id,
             reducer_spec,
             return_undeliverable: true,
+            unsplit: false,
             phantom: PhantomData,
         }
+    }
+
+    /// Prevents the port from being split.
+    pub fn unsplit(mut self) -> Self {
+        self.unsplit = true;
+        self
     }
 
     /// The typehash of this port's reducer, if any.
@@ -1079,6 +1109,7 @@ impl<M: RemoteMessage> Clone for OncePortRef<M> {
             port_id: self.port_id.clone(),
             reducer_spec: self.reducer_spec.clone(),
             return_undeliverable: self.return_undeliverable,
+            unsplit: self.unsplit,
             phantom: PhantomData,
         }
     }
@@ -1103,6 +1134,7 @@ impl<M: RemoteMessage> From<&OncePortRef<M>> for UnboundPort {
             port_ref.reducer_spec.clone(),
             true, // return_undeliverable
             UnboundPortKind::Once,
+            port_ref.unsplit,
         )
     }
 }
@@ -1115,12 +1147,13 @@ impl<M: RemoteMessage> Unbind for OncePortRef<M> {
 
 impl<M: RemoteMessage> Bind for OncePortRef<M> {
     fn bind(&mut self, bindings: &mut Bindings) -> anyhow::Result<()> {
-        let UnboundPort(port_id, reducer_spec, _return_undeliverable, port_kind) =
+        let UnboundPort(port_id, reducer_spec, _return_undeliverable, port_kind, unsplit) =
             bindings.try_pop_front::<UnboundPort>()?;
         match port_kind {
             UnboundPortKind::Once => {
                 self.port_id = port_id;
                 self.reducer_spec = reducer_spec;
+                self.unsplit = unsplit;
                 Ok(())
             }
             UnboundPortKind::Streaming(_) => {

--- a/hyperactor_mesh/src/comm.rs
+++ b/hyperactor_mesh/src/comm.rs
@@ -338,7 +338,16 @@ fn split_ports(
     // way, children actors will reply to this comm actor's ports, instead
     // of to the original ports provided by parent.
     data.visit_mut::<hyperactor_reference::UnboundPort>(
-        |hyperactor_reference::UnboundPort(port_id, reducer_spec, return_undeliverable, kind)| {
+        |hyperactor_reference::UnboundPort(
+            port_id,
+            reducer_spec,
+            return_undeliverable,
+            kind,
+            unsplit,
+        )| {
+            if *unsplit {
+                return Ok(());
+            }
             let reducer_mode = match kind {
                 hyperactor_reference::UnboundPortKind::Streaming(opts) => {
                     ReducerMode::Streaming(opts.clone().unwrap_or_default())
@@ -626,6 +635,10 @@ pub mod test_utils {
             #[binding(include)]
             reply_to: hyperactor::reference::OncePortRef<u64>,
         },
+        CastWithUnsplitPort {
+            #[binding(include)]
+            reply_to: hyperactor_reference::PortRef<u64>,
+        },
     }
 
     #[derive(Debug)]
@@ -662,6 +675,11 @@ pub mod test_utils {
     #[async_trait]
     impl Handler<TestMessage> for TestActor {
         async fn handle(&mut self, cx: &Context<Self>, msg: TestMessage) -> anyhow::Result<()> {
+            // For CastWithUnsplitPort, send a reply so the test can
+            // verify that the unsplit port is still directly reachable.
+            if let TestMessage::CastWithUnsplitPort { ref reply_to } = msg {
+                reply_to.send(cx, 42)?;
+            }
             self.forward_port.send(cx, msg)?;
             Ok(())
         }
@@ -701,6 +719,8 @@ mod tests {
     use tokio::time::Duration;
 
     use super::*;
+    use crate::ActorMesh;
+    use crate::Name;
     use crate::host_mesh::HostMesh;
     use crate::test_utils::local_host_mesh;
     use crate::testing;
@@ -1380,5 +1400,58 @@ mod tests {
         assert_eq!(result, expected_sum);
 
         let _ = setup.host_mesh.shutdown(setup.instance).await;
+    }
+
+    #[async_timed_test(timeout_secs = 60)]
+    async fn test_unsplit_port_not_split() {
+        let instance = crate::testing::instance();
+        let mut host_mesh = local_host_mesh(8).await;
+        let proc_mesh = host_mesh
+            .spawn(instance, "test", extent!(gpu = 8), None)
+            .await
+            .unwrap();
+
+        let (tx, mut rx) = hyperactor::mailbox::open_port(instance);
+        let params = TestActorParams {
+            forward_port: tx.bind(),
+        };
+        let actor_name = Name::new("test").expect("valid test name");
+        let actor_mesh: ActorMesh<TestActor> = proc_mesh
+            .spawn_with_name(&instance, actor_name, &params, None, true)
+            .await
+            .unwrap();
+        let (reply_port_handle, mut reply_rx) = open_port::<u64>(instance);
+        let reply_port_ref = reply_port_handle.bind().unsplit();
+
+        let message = TestMessage::CastWithUnsplitPort {
+            reply_to: reply_port_ref.clone(),
+        };
+
+        clear_collected_tree();
+        actor_mesh.cast(instance, message).unwrap();
+
+        // Verify that all destinations received the original port (not split).
+        for _ in proc_mesh.extent().points() {
+            let msg = rx.recv().await.expect("missing");
+            match msg {
+                TestMessage::CastWithUnsplitPort { reply_to } => {
+                    assert_eq!(
+                        reply_to.port_id(),
+                        reply_port_ref.port_id(),
+                        "unsplit port should not be replaced by a comm actor split port"
+                    );
+                }
+                _ => panic!("unexpected message: {:?}", msg),
+            }
+        }
+
+        // All 8 actors sent replies directly to the same port.
+        // Verify we receive all 8 replies.
+        for _ in 0..8 {
+            let val = reply_rx.recv().await.unwrap();
+            assert_eq!(val, 42);
+        }
+
+        let _ = host_mesh.shutdown(instance).await;
     }
 }

--- a/hyperactor_mesh/src/mesh_controller.rs
+++ b/hyperactor_mesh/src/mesh_controller.rs
@@ -288,7 +288,10 @@ impl<A: Referable> Actor for ActorMeshController<A> {
             this,
             resource::StreamState::<ActorState> {
                 name: self.mesh.name().clone(),
-                subscriber: this.port().bind(),
+                // All ProcAgents send updates directly to this port
+                // so that failures along the comm tree path does not
+                // affect clean shutdowns.
+                subscriber: this.port().bind().unsplit(),
             },
         )?;
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #3088
* #3087
* #3086
* __->__ #3085
* #3084
* #3083
* #3082
* #3081
* #3080
* #3079
* #3078
* #3077
* #3076
* #3075
* #3074
* #3073
* #3072
* #3071
* #3070

\nStack walkthrough: https://www.internalfb.com/intern/phabricator/paste/markdown/P2239132492/
When a message is cast to N actors in a mesh, all PortRef fields are
"split" at each comm actor hop — each hop allocates a local proxy port
that reduces replies before forwarding upstream, creating a hierarchical
reduction tree.

For StreamState subscriptions in the mesh controller, we want all N
ProcAgents to send updates directly to the controller's single subscriber
port. Today this port gets split, creating unnecessary proxy chains. The
`unsplit` flag marks a port as "don't split — broadcast as-is."

API:

    subscriber: this.port().bind().unsplit(),

The flag is added to PortRef, OncePortRef, and UnboundPort so it survives
serialization through the bind/unbind cycle. In split_ports, unsplit ports
are skipped with an early return.

The mesh controller's StreamState subscriber port is marked unsplit so
that all ProcAgents send status updates directly to the controller without
intermediate reduction proxies.

Includes a test (`test_unsplit_port_not_split`) that verifies unsplit
ports are not rewritten during casting and replies arrive directly.

Differential Revision: [D96760758](https://our.internmc.facebook.com/intern/diff/D96760758/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D96760758/)!