### PR TITLE
[hyperactor] add message types to undeliverable message errors

### DIFF
--- a/hyperactor/src/mailbox/undeliverable.rs
+++ b/hyperactor/src/mailbox/undeliverable.rs
@@ -139,6 +139,11 @@ impl std::fmt::Display for UndeliverableMessageError {
                 )?;
                 writeln!(f, "\tsender: {}", envelope.sender())?;
                 writeln!(f, "\tdest: {}", envelope.dest())?;
+                writeln!(
+                    f,
+                    "\tmessage type: {}",
+                    envelope.data().typename().unwrap_or("unknown")
+                )?;
                 writeln!(f, "\theaders: {}", envelope.headers())?;
                 writeln!(f, "\tdata: {}", envelope.data())?;
                 writeln!(
@@ -155,6 +160,11 @@ impl std::fmt::Display for UndeliverableMessageError {
                 )?;
                 writeln!(f, "\toriginal sender: {}", envelope.sender())?;
                 writeln!(f, "\toriginal dest: {}", envelope.dest())?;
+                writeln!(
+                    f,
+                    "\tmessage type: {}",
+                    envelope.data().typename().unwrap_or("unknown")
+                )?;
                 writeln!(f, "\theaders: {}", envelope.headers())?;
                 writeln!(f, "\tdata: {}", envelope.data())?;
                 writeln!(

--- a/monarch_hyperactor/src/actor.rs
+++ b/monarch_hyperactor/src/actor.rs
@@ -917,10 +917,11 @@ impl Actor for PythonActor {
             envelope.0.sender(),
             ins.self_id(),
             "undeliverable message was returned to the wrong actor. \
-            Return address = {}, src actor = {}, dest actor port = {}, envelope headers = {}",
+            Return address = {}, src actor = {}, dest actor port = {}, message type = {}, envelope headers = {}",
             envelope.0.sender(),
             ins.self_id(),
             envelope.0.dest(),
+            envelope.0.data().typename().unwrap_or("unknown"),
             envelope.0.headers()
         );
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #3088
* #3087
* __->__ #3086
* #3085
* #3084
* #3083
* #3082
* #3081
* #3080
* #3079
* #3078
* #3077
* #3076
* #3075
* #3074
* #3073
* #3072
* #3071
* #3070

Include the message type name in undeliverable message error output.
Previously these errors only showed sender, dest, headers, and data,
making it hard to identify which message was undeliverable. Now both
`Undeliverable` and `UndeliverableReturned` variants include a
`message type:` line using `envelope.data().typename()`. Also adds
the message type to the assertion message in `monarch_hyperactor`'s
undeliverable handler.

Differential Revision: [D96790834](https://our.internmc.facebook.com/intern/diff/D96790834/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D96790834/)!