### PR TITLE
[hyperactor_mesh] add WaitRankStatus for race-free proc mesh shutdown

### DIFF
--- a/hyperactor/src/host.rs
+++ b/hyperactor/src/host.rs
@@ -803,7 +803,7 @@ pub enum LocalProcStatus {
 ///   No OS signals are sent or required.
 pub struct LocalProcManager<S> {
     procs: Arc<Mutex<HashMap<reference::ProcId, Proc>>>,
-    stopping: Arc<Mutex<HashMap<reference::ProcId, LocalProcStatus>>>,
+    stopping: Arc<Mutex<HashMap<reference::ProcId, tokio::sync::watch::Sender<LocalProcStatus>>>>,
     spawn: S,
 }
 
@@ -822,8 +822,8 @@ impl<S> LocalProcManager<S> {
     /// that tears it down.
     ///
     /// Status transitions through `Stopping` -> `Stopped` and is
-    /// observable via [`local_proc_status`]. Idempotent: no-ops if
-    /// the proc is already stopping or stopped.
+    /// observable via [`local_proc_status`] and [`watch`]. Idempotent:
+    /// no-ops if the proc is already stopping or stopped.
     pub async fn request_stop(&self, proc: &reference::ProcId, timeout: Duration, reason: &str) {
         {
             let guard = self.stopping.lock().await;
@@ -841,10 +841,8 @@ impl<S> LocalProcManager<S> {
         };
 
         let proc_id = proc_handle.proc_id().clone();
-        self.stopping
-            .lock()
-            .await
-            .insert(proc_id.clone(), LocalProcStatus::Stopping);
+        let (tx, _) = tokio::sync::watch::channel(LocalProcStatus::Stopping);
+        self.stopping.lock().await.insert(proc_id.clone(), tx);
 
         let stopping = Arc::clone(&self.stopping);
         let reason = reason.to_string();
@@ -855,10 +853,9 @@ impl<S> LocalProcManager<S> {
             {
                 tracing::warn!(error = %e, "request_stop(local): destroy_and_wait failed");
             }
-            stopping
-                .lock()
-                .await
-                .insert(proc_id, LocalProcStatus::Stopped);
+            if let Some(tx) = stopping.lock().await.get(&proc_id) {
+                let _ = tx.send(LocalProcStatus::Stopped);
+            }
         });
     }
 
@@ -867,7 +864,22 @@ impl<S> LocalProcManager<S> {
     ///
     /// Returns `None` if the proc was never stopped through this path.
     pub async fn local_proc_status(&self, proc: &reference::ProcId) -> Option<LocalProcStatus> {
-        self.stopping.lock().await.get(proc).copied()
+        self.stopping.lock().await.get(proc).map(|tx| *tx.borrow())
+    }
+
+    /// Subscribe to lifecycle status changes for a proc that was
+    /// stopped via [`request_stop`].
+    ///
+    /// Returns `None` if the proc was never stopped through this path.
+    pub async fn watch(
+        &self,
+        proc: &reference::ProcId,
+    ) -> Option<tokio::sync::watch::Receiver<LocalProcStatus>> {
+        self.stopping
+            .lock()
+            .await
+            .get(proc)
+            .map(|tx| tx.subscribe())
     }
 }
 

--- a/hyperactor/src/proc.rs
+++ b/hyperactor/src/proc.rs
@@ -1498,17 +1498,25 @@ impl<A: Actor> Instance<A> {
         )
     }
 
+    /// Return a static client instance that can be used to send
+    /// messages to port handles from outside an actor context
+    /// (e.g. from background tokio tasks).
+    // TODO: replace with a proper mechanism for sending to port
+    // handles without an actor context.
+    pub fn self_client() -> &'static Instance<()> {
+        static CLIENT: OnceLock<(Instance<()>, ActorHandle<()>)> = OnceLock::new();
+        &CLIENT
+            .get_or_init(|| Proc::runtime().instance("self_message_client").unwrap())
+            .0
+    }
+
     /// Send a message to the actor itself with a delay usually to trigger some event.
     pub fn self_message_with_delay<M>(&self, message: M, delay: Duration) -> Result<(), ActorError>
     where
         M: Message,
         A: Handler<M>,
     {
-        // A global client to send self message.
-        static CLIENT: OnceLock<(Instance<()>, ActorHandle<()>)> = OnceLock::new();
-        let client = &CLIENT
-            .get_or_init(|| Proc::runtime().instance("self_message_client").unwrap())
-            .0;
+        let client = Self::self_client();
         let port = self.port();
         let self_id = self.self_id().clone();
         tokio::spawn(async move {

--- a/hyperactor_mesh/src/bootstrap.rs
+++ b/hyperactor_mesh/src/bootstrap.rs
@@ -1782,6 +1782,15 @@ impl BootstrapProcManager {
         self.children.lock().await.get(proc_id).map(|h| h.status())
     }
 
+    /// Return a watch receiver for the given proc's status stream,
+    /// if the proc is known to this manager.
+    pub async fn watch(
+        &self,
+        proc_id: &hyperactor_reference::ProcId,
+    ) -> Option<tokio::sync::watch::Receiver<ProcStatus>> {
+        self.children.lock().await.get(proc_id).map(|h| h.watch())
+    }
+
     /// Non-blocking stop: send `StopAll`, then spawn a background task
     /// that waits for exit and escalates if needed.
     ///

--- a/hyperactor_mesh/src/host_mesh.rs
+++ b/hyperactor_mesh/src/host_mesh.rs
@@ -72,6 +72,7 @@ use crate::resource::GetRankStatusClient;
 use crate::resource::ProcSpec;
 use crate::resource::RankedValues;
 use crate::resource::Status;
+use crate::resource::WaitRankStatusClient;
 use crate::transport::DEFAULT_TRANSPORT;
 
 /// Actor name for `HostMeshController` when spawned as a named child.
@@ -1387,7 +1388,7 @@ impl HostMeshRef {
                 },
             )?;
             host.mesh_agent()
-                .get_rank_status(cx, proc_name, port.bind())
+                .wait_rank_status(cx, proc_name, Status::Stopped, port.bind())
                 .await?;
 
             tracing::info!(
@@ -1419,7 +1420,7 @@ impl HostMeshRef {
         .await
         {
             Ok(statuses) => {
-                let all_stopped = statuses.values().all(|s| s.is_terminating());
+                let all_stopped = statuses.values().all(|s| s.is_terminated());
                 if !all_stopped {
                     tracing::error!(
                         name = "ProcMeshStatus",

--- a/hyperactor_mesh/src/host_mesh/host_agent.rs
+++ b/hyperactor_mesh/src/host_mesh/host_agent.rs
@@ -15,6 +15,7 @@
 #![allow(unused_assignments)]
 
 use std::collections::HashMap;
+use std::collections::HashSet;
 use std::fmt;
 use std::pin::Pin;
 use std::str::FromStr;
@@ -214,21 +215,45 @@ pub const HOST_MESH_AGENT_ACTOR_NAME: &str = "host_agent";
 
 /// A mesh agent is responsible for managing a host in a [`HostMesh`],
 /// through the resource behaviors defined in [`crate::resource`].
+/// Self-notification sent by bridge tasks when a proc's status changes.
+/// Not exported or registered — only used internally via `PortHandle`.
+#[derive(Debug, Serialize, Deserialize, Named)]
+struct ProcStatusChanged {
+    name: Name,
+}
+
 #[hyperactor::export(
     handlers=[
         resource::CreateOrUpdate<ProcSpec>,
         resource::Stop,
         resource::GetState<ProcState>,
         resource::GetRankStatus { cast = true },
+        resource::WaitRankStatus { cast = true },
         resource::List,
         ShutdownHost,
         SpawnMeshAdmin,
         SetClientConfig,
+        ProcStatusChanged,
     ]
 )]
 pub struct HostAgent {
     pub(crate) host: Option<HostAgentMode>,
     pub(crate) created: HashMap<Name, ProcCreationState>,
+    /// Pending `WaitRankStatus` waiters, keyed by resource name.
+    /// Each entry is `(min_status, rank, reply_port)`. Only touched
+    /// from `&mut self` handlers.
+    pending_proc_waiters: HashMap<
+        Name,
+        Vec<(
+            resource::Status,
+            usize,
+            hyperactor_reference::PortRef<crate::StatusOverlay>,
+        )>,
+    >,
+    /// Procs that already have an active bridge task watching their status.
+    watching: HashSet<Name>,
+    /// Port handle for sending `ProcStatusChanged` to self. Set in `init()`.
+    proc_status_port: Option<PortHandle<ProcStatusChanged>>,
     /// Lazily initialized ProcAgent on the host's local proc.
     /// Boots on first [`GetLocalProc`] (LP-1 — see
     /// `hyperactor::host::LOCAL_PROC_NAME`).
@@ -246,6 +271,9 @@ impl HostAgent {
         Self {
             host: Some(host),
             created: HashMap::new(),
+            pending_proc_waiters: HashMap::new(),
+            watching: HashSet::new(),
+            proc_status_port: None,
             local_mesh_agent: OnceLock::new(),
             mailbox_handle: None,
         }
@@ -404,6 +432,8 @@ impl Actor for HostAgent {
             }
         });
 
+        self.proc_status_port = Some(this.port::<ProcStatusChanged>());
+
         Ok(())
     }
 }
@@ -452,16 +482,46 @@ impl Handler<resource::CreateOrUpdate<ProcSpec>> for HostAgent {
             }
         };
 
+        let rank = create_or_update.rank.unwrap();
+
         if let Err(e) = &created {
             tracing::error!("failed to spawn proc {}: {}", create_or_update.name, e);
         }
         self.created.insert(
             create_or_update.name.clone(),
-            ProcCreationState {
-                rank: create_or_update.rank.unwrap(),
-                created,
-            },
+            ProcCreationState { rank, created },
         );
+
+        // If any WaitRankStatus messages arrived before this proc
+        // existed, their waiters were stashed with a sentinel rank.
+        // Now that we know the real rank, fix them up and start a
+        // watch bridge.
+        // Extract the proc_id before mutably borrowing pending_proc_waiters.
+        let proc_id = self
+            .created
+            .get(&create_or_update.name)
+            .and_then(|s| s.created.as_ref().ok())
+            .map(|(pid, _)| pid.clone());
+
+        if let Some(waiters) = self.pending_proc_waiters.get_mut(&create_or_update.name) {
+            for (_, waiter_rank, _) in waiters.iter_mut() {
+                if *waiter_rank == usize::MAX {
+                    *waiter_rank = rank;
+                }
+            }
+        }
+
+        // Start a bridge and send ourselves an initial check.
+        if self
+            .pending_proc_waiters
+            .contains_key(&create_or_update.name)
+        {
+            if let Some(proc_id) = &proc_id {
+                self.start_watch_bridge(&create_or_update.name, proc_id)
+                    .await;
+            }
+            self.notify_proc_status_changed(&create_or_update.name);
+        }
 
         self.publish_introspect_properties(cx);
         Ok(())
@@ -491,6 +551,9 @@ impl Handler<resource::Stop> for HostAgent {
             host.request_stop(cx, proc_id, timeout, &message.reason)
                 .await;
         }
+
+        // Status may have changed to Stopping; notify pending waiters.
+        self.notify_proc_status_changed(&message.name);
 
         self.publish_introspect_properties(cx);
         Ok(())
@@ -546,6 +609,193 @@ impl Handler<resource::GetRankStatus> for HostAgent {
         }
         Ok(())
     }
+}
+
+#[async_trait]
+impl Handler<resource::WaitRankStatus> for HostAgent {
+    async fn handle(
+        &mut self,
+        cx: &Context<Self>,
+        msg: resource::WaitRankStatus,
+    ) -> anyhow::Result<()> {
+        use crate::StatusOverlay;
+        use crate::resource::Status;
+
+        match self.created.get(&msg.name) {
+            Some(ProcCreationState {
+                rank,
+                created: Ok((proc_id, _)),
+            }) => {
+                let rank = *rank;
+                let status = match self.host.as_ref() {
+                    Some(host) => host.proc_status(proc_id).await.0,
+                    None => Status::Stopped,
+                };
+
+                // If already at or past the requested threshold, reply immediately.
+                if status >= msg.min_status {
+                    let overlay = StatusOverlay::try_from_runs(vec![(rank..(rank + 1), status)])
+                        .expect("valid single-run overlay");
+                    let _ = msg.reply.send(cx, overlay);
+                    return Ok(());
+                }
+
+                // Stash the waiter and start a bridge if we don't have one yet.
+                self.pending_proc_waiters
+                    .entry(msg.name.clone())
+                    .or_default()
+                    .push((msg.min_status, rank, msg.reply));
+
+                let proc_id = proc_id.clone();
+                self.start_watch_bridge(&msg.name, &proc_id).await;
+            }
+            Some(ProcCreationState {
+                rank,
+                created: Err(e),
+                ..
+            }) => {
+                // Creation failed — reply immediately with Failed status.
+                let overlay = StatusOverlay::try_from_runs(vec![(
+                    *rank..(*rank + 1),
+                    Status::Failed(e.to_string()),
+                )])
+                .expect("valid single-run overlay");
+                let _ = msg.reply.send(cx, overlay);
+            }
+            None => {
+                // Proc doesn't exist yet. Stash the waiter with a
+                // sentinel rank; CreateOrUpdate will fill it in and
+                // start the watch bridge.
+                self.pending_proc_waiters
+                    .entry(msg.name.clone())
+                    .or_default()
+                    .push((msg.min_status, usize::MAX, msg.reply));
+            }
+        }
+
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl Handler<ProcStatusChanged> for HostAgent {
+    async fn handle(&mut self, cx: &Context<Self>, msg: ProcStatusChanged) -> anyhow::Result<()> {
+        use crate::StatusOverlay;
+        use crate::resource::Status;
+
+        let status = match self.created.get(&msg.name) {
+            Some(ProcCreationState {
+                created: Ok((proc_id, _)),
+                ..
+            }) => match self.host.as_ref() {
+                Some(host) => host.proc_status(proc_id).await.0,
+                None => Status::Stopped,
+            },
+            Some(ProcCreationState {
+                created: Err(_), ..
+            }) => {
+                // Already replied with Failed when they were stashed.
+                return Ok(());
+            }
+            None => {
+                // Proc not created yet, nothing to flush.
+                return Ok(());
+            }
+        };
+
+        let Some(waiters) = self.pending_proc_waiters.get_mut(&msg.name) else {
+            return Ok(());
+        };
+
+        let remaining = std::mem::take(waiters);
+        for (min_status, rank, reply) in remaining {
+            if status >= min_status {
+                let overlay =
+                    StatusOverlay::try_from_runs(vec![(rank..(rank + 1), status.clone())])
+                        .expect("valid single-run overlay");
+                let _ = reply.send(cx, overlay);
+            } else {
+                waiters.push((min_status, rank, reply));
+            }
+        }
+
+        if waiters.is_empty() {
+            self.pending_proc_waiters.remove(&msg.name);
+        }
+
+        Ok(())
+    }
+}
+
+impl HostAgent {
+    /// Send a `ProcStatusChanged` self-notification for the given proc name.
+    fn notify_proc_status_changed(&self, name: &Name) {
+        if let Some(port) = &self.proc_status_port {
+            let client = Instance::<()>::self_client();
+            let _ = port.send(client, ProcStatusChanged { name: name.clone() });
+        }
+    }
+
+    /// Start a bridge task that watches a proc's status channel and sends
+    /// `ProcStatusChanged` to self on each change. At most one bridge per proc.
+    async fn start_watch_bridge(&mut self, name: &Name, proc_id: &hyperactor_reference::ProcId) {
+        if self.watching.contains(name) {
+            return;
+        }
+        self.watching.insert(name.clone());
+
+        let port = match &self.proc_status_port {
+            Some(p) => p.clone(),
+            None => return,
+        };
+
+        match self.host.as_ref() {
+            Some(HostAgentMode::Process { host, .. }) => {
+                if let Some(rx) = host.manager().watch(proc_id).await {
+                    start_proc_watch(port, rx, name.clone(), |s| s.clone().into());
+                }
+            }
+            Some(HostAgentMode::Local(host)) => {
+                if let Some(rx) = host.manager().watch(proc_id).await {
+                    start_proc_watch(port, rx, name.clone(), |s| (*s).into());
+                }
+            }
+            None => {}
+        }
+    }
+}
+
+/// Spawn a bridge task that watches a proc's status channel and sends
+/// `ProcStatusChanged` to the actor via the given `PortHandle`.
+fn start_proc_watch<S>(
+    port: PortHandle<ProcStatusChanged>,
+    mut rx: tokio::sync::watch::Receiver<S>,
+    name: Name,
+    to_status: impl Fn(&S) -> resource::Status + Send + 'static,
+) where
+    S: Send + Sync + 'static,
+{
+    // TODO: replace Instance::self_client() with a proper mechanism
+    // for sending to port handles without an actor context.
+    let client = Instance::<()>::self_client();
+    tokio::spawn(async move {
+        loop {
+            match rx.changed().await {
+                Ok(()) => {
+                    let status = to_status(&*rx.borrow());
+                    let terminated = status.is_terminated();
+                    let _ = port.send(client, ProcStatusChanged { name: name.clone() });
+                    if terminated {
+                        return;
+                    }
+                }
+                Err(_) => {
+                    let _ = port.send(client, ProcStatusChanged { name: name.clone() });
+                    return;
+                }
+            }
+        }
+    });
 }
 
 #[derive(Serialize, Deserialize, Debug, Named, Handler, RefClient, HandleClient)]
@@ -928,6 +1178,8 @@ mod tests {
     use crate::bootstrap::ProcStatus;
     use crate::resource::CreateOrUpdateClient;
     use crate::resource::GetStateClient;
+    use crate::resource::StopClient;
+    use crate::resource::WaitRankStatusClient;
 
     #[tokio::test]
     #[cfg(fbcode_build)]
@@ -988,5 +1240,172 @@ mod tests {
               && mesh_agent == hyperactor_reference::ActorRef::attest(hyperactor_reference::ProcId::with_name(host_addr.clone(), name.to_string()).actor_id(crate::proc_agent::PROC_AGENT_ACTOR_NAME, 0)) && bootstrap_command == Some(BootstrapCommand::test())
               && mesh_agent == proc_status_mesh_agent
         );
+    }
+
+    /// WaitRankStatus on a running proc replies immediately with Running.
+    #[tokio::test]
+    #[cfg(fbcode_build)]
+    async fn test_wait_rank_status_already_running() {
+        let host = Host::new(
+            BootstrapProcManager::new(BootstrapCommand::test()).unwrap(),
+            ChannelTransport::Unix.any(),
+        )
+        .await
+        .unwrap();
+
+        let system_proc = host.system_proc().clone();
+        let host_agent = system_proc
+            .spawn(
+                HOST_MESH_AGENT_ACTOR_NAME,
+                HostAgent::new(HostAgentMode::Process {
+                    host,
+                    shutdown_tx: None,
+                }),
+            )
+            .unwrap();
+
+        let client_proc = Proc::direct(ChannelTransport::Unix.any(), "client".to_string()).unwrap();
+        let (client, _client_handle) = client_proc.instance("client").unwrap();
+
+        let name = Name::new("proc1").unwrap();
+        host_agent
+            .create_or_update(
+                &client,
+                name.clone(),
+                resource::Rank::new(0),
+                ProcSpec::default(),
+            )
+            .await
+            .unwrap();
+
+        // Proc is Running; wait for Running should reply immediately.
+        let (port, mut rx) = client.open_port::<crate::StatusOverlay>();
+        host_agent
+            .wait_rank_status(&client, name, resource::Status::Running, port.bind())
+            .await
+            .unwrap();
+
+        let overlay = tokio::time::timeout(Duration::from_secs(5), rx.recv())
+            .await
+            .expect("reply timed out")
+            .expect("reply channel closed");
+        assert!(!overlay.is_empty(), "expected non-empty overlay");
+    }
+
+    /// WaitRankStatus for Stopped, then stop the proc — reply should
+    /// arrive only after the proc actually stops.
+    #[tokio::test]
+    #[cfg(fbcode_build)]
+    async fn test_wait_rank_status_stop() {
+        let host = Host::new(
+            BootstrapProcManager::new(BootstrapCommand::test()).unwrap(),
+            ChannelTransport::Unix.any(),
+        )
+        .await
+        .unwrap();
+
+        let system_proc = host.system_proc().clone();
+        let host_agent = system_proc
+            .spawn(
+                HOST_MESH_AGENT_ACTOR_NAME,
+                HostAgent::new(HostAgentMode::Process {
+                    host,
+                    shutdown_tx: None,
+                }),
+            )
+            .unwrap();
+
+        let client_proc = Proc::direct(ChannelTransport::Unix.any(), "client".to_string()).unwrap();
+        let (client, _client_handle) = client_proc.instance("client").unwrap();
+
+        let name = Name::new("proc1").unwrap();
+        host_agent
+            .create_or_update(
+                &client,
+                name.clone(),
+                resource::Rank::new(0),
+                ProcSpec::default(),
+            )
+            .await
+            .unwrap();
+
+        // Wait for Stopped — should not reply yet.
+        let (port, mut rx) = client.open_port::<crate::StatusOverlay>();
+        host_agent
+            .wait_rank_status(
+                &client,
+                name.clone(),
+                resource::Status::Stopped,
+                port.bind(),
+            )
+            .await
+            .unwrap();
+
+        // Stop the proc.
+        host_agent
+            .stop(&client, name, "test".to_string())
+            .await
+            .unwrap();
+
+        // Now the reply should arrive.
+        let overlay = tokio::time::timeout(Duration::from_secs(30), rx.recv())
+            .await
+            .expect("reply timed out — proc did not reach Stopped")
+            .expect("reply channel closed");
+        assert!(!overlay.is_empty(), "expected non-empty overlay");
+    }
+
+    /// WaitRankStatus sent before the proc is created — the waiter is
+    /// stashed and replied to once CreateOrUpdate runs.
+    #[tokio::test]
+    #[cfg(fbcode_build)]
+    async fn test_wait_rank_status_before_proc_exists() {
+        let host = Host::new(
+            BootstrapProcManager::new(BootstrapCommand::test()).unwrap(),
+            ChannelTransport::Unix.any(),
+        )
+        .await
+        .unwrap();
+
+        let system_proc = host.system_proc().clone();
+        let host_agent = system_proc
+            .spawn(
+                HOST_MESH_AGENT_ACTOR_NAME,
+                HostAgent::new(HostAgentMode::Process {
+                    host,
+                    shutdown_tx: None,
+                }),
+            )
+            .unwrap();
+
+        let client_proc = Proc::direct(ChannelTransport::Unix.any(), "client".to_string()).unwrap();
+        let (client, _client_handle) = client_proc.instance("client").unwrap();
+
+        let name = Name::new("proc1").unwrap();
+
+        // Wait for Running on a proc that doesn't exist yet.
+        let (port, mut rx) = client.open_port::<crate::StatusOverlay>();
+        host_agent
+            .wait_rank_status(
+                &client,
+                name.clone(),
+                resource::Status::Running,
+                port.bind(),
+            )
+            .await
+            .unwrap();
+
+        // Now create the proc — the stashed waiter should get its
+        // sentinel rank fixed and be flushed once the proc is Running.
+        host_agent
+            .create_or_update(&client, name, resource::Rank::new(0), ProcSpec::default())
+            .await
+            .unwrap();
+
+        let overlay = tokio::time::timeout(Duration::from_secs(10), rx.recv())
+            .await
+            .expect("reply timed out — waiter was not flushed after CreateOrUpdate")
+            .expect("reply channel closed");
+        assert!(!overlay.is_empty(), "expected non-empty overlay");
     }
 }

--- a/hyperactor_mesh/src/proc_agent.rs
+++ b/hyperactor_mesh/src/proc_agent.rs
@@ -243,6 +243,13 @@ struct ActorInstanceState {
     /// operation (spawn, stop, supervision event). Used for last-writer-wins
     /// ordering in the mesh controller.
     generation: u64,
+    /// Pending `WaitRankStatus` callers: each entry is the minimum
+    /// status threshold and the reply port to send once the threshold
+    /// is met.
+    pending_wait_status: Vec<(
+        resource::Status,
+        hyperactor_reference::PortRef<crate::StatusOverlay>,
+    )>,
 }
 
 impl ActorInstanceState {
@@ -294,8 +301,12 @@ impl ActorInstanceState {
         }
     }
 
-    /// Send the current state to all streaming subscribers.
-    fn notify_subscribers(&self, cx: &impl hyperactor::context::Actor, name: &Name) {
+    /// Notify all observers that this actor's status has changed:
+    /// streaming subscribers get the full state, and one-shot
+    /// `WaitRankStatus` waiters whose threshold is now met get replied
+    /// to and removed.
+    fn notify_status_changed(&mut self, cx: &impl hyperactor::context::Actor, name: &Name) {
+        // Streaming subscribers (persistent).
         let state = self.to_state(name);
         for subscriber in &self.subscribers {
             let mut headers = Flattrs::new();
@@ -308,6 +319,21 @@ impl ActorInstanceState {
                 );
             }
         }
+
+        // One-shot waiters (predicated).
+        let status = self.status();
+        self.pending_wait_status.retain(|(min_status, reply)| {
+            if status >= *min_status {
+                let rank = self.create_rank;
+                let overlay =
+                    crate::StatusOverlay::try_from_runs(vec![(rank..(rank + 1), status.clone())])
+                        .expect("valid single-run overlay");
+                let _ = reply.send(cx, overlay);
+                false
+            } else {
+                true
+            }
+        });
     }
 }
 
@@ -355,6 +381,7 @@ struct SelfCheck {}
         resource::StreamState<ActorState> { cast = true },
         resource::KeepaliveGetState<ActorState> { cast = true },
         resource::GetRankStatus { cast = true },
+        resource::WaitRankStatus { cast = true },
         RepublishIntrospect { cast = true },
         PySpyDump,
     ]
@@ -827,7 +854,7 @@ impl Handler<ActorSupervisionEvent> for ProcAgent {
                 instance.supervision_event = Some(event.clone());
                 instance.generation += 1;
                 let name = name.clone();
-                instance.notify_subscribers(cx, &name);
+                instance.notify_status_changed(cx, &name);
             }
             // Defer republish so introspection picks up is_poisoned /
             // failed_actor_count without blocking the message loop.
@@ -943,6 +970,7 @@ impl Handler<resource::CreateOrUpdate<ActorSpec>> for ProcAgent {
                     subscribers: Vec::new(),
                     expiry_time: None,
                     generation: 1,
+                    pending_wait_status: Vec::new(),
                 },
             );
             return Ok(());
@@ -971,6 +999,7 @@ impl Handler<resource::CreateOrUpdate<ActorSpec>> for ProcAgent {
                 subscribers: Vec::new(),
                 expiry_time: None,
                 generation: 1,
+                pending_wait_status: Vec::new(),
             },
         );
 
@@ -983,19 +1012,17 @@ impl Handler<resource::CreateOrUpdate<ActorSpec>> for ProcAgent {
 impl Handler<resource::Stop> for ProcAgent {
     async fn handle(&mut self, cx: &Context<Self>, message: resource::Stop) -> anyhow::Result<()> {
         let actor_id = match self.actor_states.get_mut(&message.name) {
-            Some(actor_state) => match &actor_state.spawn {
-                Ok(actor_id) => {
-                    if actor_state.stop_initiated {
-                        None
-                    } else {
-                        actor_state.stop_initiated = true;
-                        actor_state.generation += 1;
-                        actor_state.notify_subscribers(cx, &message.name);
-                        Some(actor_id.clone())
-                    }
+            Some(actor_state) => {
+                let id = actor_state.spawn.as_ref().ok().cloned();
+                if id.is_some() && !actor_state.stop_initiated {
+                    actor_state.stop_initiated = true;
+                    actor_state.generation += 1;
+                    actor_state.notify_status_changed(cx, &message.name);
+                    id
+                } else {
+                    None
                 }
-                Err(_) => None,
-            },
+            }
             None => None,
         };
         if let Some(actor_id) = actor_id {
@@ -1078,6 +1105,42 @@ impl Handler<resource::GetRankStatus> for ProcAgent {
                 get_rank_status.reply.port_id().actor_id(),
                 e
             );
+        }
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl Handler<resource::WaitRankStatus> for ProcAgent {
+    async fn handle(
+        &mut self,
+        cx: &Context<Self>,
+        msg: resource::WaitRankStatus,
+    ) -> anyhow::Result<()> {
+        use crate::StatusOverlay;
+        use crate::resource::Status;
+
+        let (rank, status) = match self.actor_states.get(&msg.name) {
+            Some(state) => (state.create_rank, state.status()),
+            None => (usize::MAX, Status::NotExist),
+        };
+
+        // If already at or past the requested threshold, reply immediately.
+        if status >= msg.min_status || rank == usize::MAX {
+            let overlay = if rank == usize::MAX {
+                StatusOverlay::new()
+            } else {
+                StatusOverlay::try_from_runs(vec![(rank..(rank + 1), status)])
+                    .expect("valid single-run overlay")
+            };
+            let _ = msg.reply.send(cx, overlay);
+            return Ok(());
+        }
+
+        // Otherwise, stash the waiter. It will be flushed when the
+        // status changes (supervision event or stop).
+        if let Some(state) = self.actor_states.get_mut(&msg.name) {
+            state.pending_wait_status.push((msg.min_status, msg.reply));
         }
         Ok(())
     }
@@ -1884,7 +1947,7 @@ mod tests {
         // Drop the receiver so the next send bounces as undeliverable.
         drop(sub_rx_2);
 
-        // Stop the second actor — triggers notify_subscribers to the
+        // Stop the second actor — triggers notify_status_changed to the
         // dead subscriber. ProcAgent should handle the undeliverable
         // gracefully.
         agent_ref

--- a/hyperactor_mesh/src/resource.rs
+++ b/hyperactor_mesh/src/resource.rs
@@ -104,6 +104,15 @@ impl Status {
         matches!(self, Self::Failed(_) | Self::Timeout(_))
     }
 
+    /// Returns whether the status is fully terminal (the resource has
+    /// stopped, failed, or timed out — but NOT merely `Stopping`).
+    pub fn is_terminated(&self) -> bool {
+        matches!(
+            self,
+            Status::Stopped | Status::Failed(_) | Status::Timeout(_)
+        )
+    }
+
     pub fn is_healthy(&self) -> bool {
         matches!(self, Status::Initializing | Status::Running)
     }
@@ -119,6 +128,15 @@ impl From<bootstrap::ProcStatus> for Status {
             ProcStatus::Stopped { .. } => Status::Stopped,
             ProcStatus::Failed { reason } => Status::Failed(reason),
             ProcStatus::Killed { .. } => Status::Failed(format!("{}", status)),
+        }
+    }
+}
+
+impl From<hyperactor::host::LocalProcStatus> for Status {
+    fn from(status: hyperactor::host::LocalProcStatus) -> Self {
+        match status {
+            hyperactor::host::LocalProcStatus::Stopping => Status::Stopping,
+            hyperactor::host::LocalProcStatus::Stopped => Status::Stopped,
         }
     }
 }
@@ -177,6 +195,33 @@ impl Bind for Rank {
 pub struct GetRankStatus {
     /// The name of the resource.
     pub name: Name,
+    /// Sparse status updates (overlays) from a rank.
+    #[binding(include)]
+    pub reply: hyperactor_reference::PortRef<StatusOverlay>,
+}
+
+/// Like [`GetRankStatus`], but the handler defers its reply until the
+/// resource's status is >= `min_status`. This avoids the race where
+/// the caller sees `Stopping` before the process has actually exited.
+#[derive(
+    Clone,
+    Debug,
+    Serialize,
+    Deserialize,
+    Named,
+    Handler,
+    HandleClient,
+    RefClient,
+    Bind,
+    Unbind
+)]
+pub struct WaitRankStatus {
+    /// The name of the resource.
+    pub name: Name,
+    /// The minimum status the caller wants to observe.
+    /// The handler will not reply until the resource's status
+    /// is >= this threshold.
+    pub min_status: Status,
     /// Sparse status updates (overlays) from a rank.
     #[binding(include)]
     pub reply: hyperactor_reference::PortRef<StatusOverlay>,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #3088
* __->__ #3087
* #3086
* #3085
* #3084
* #3083
* #3082
* #3081
* #3080
* #3079
* #3078
* #3077
* #3076
* #3075
* #3074
* #3073
* #3072
* #3071
* #3070

`stop_proc_mesh` sends a stop signal to each proc and then queries status
to confirm procs have stopped. Previously it used `GetRankStatus`, which
replies immediately with the current status. Because the stop signal is
asynchronous, the reply is typically `Stopping` (signal sent, process
hasn't exited yet). `stop_proc_mesh` treated any non-`NotExist` status as
complete and returned, allowing `hosts.shutdown()` to tear down the
HostAgent while `ActorMeshController`s were still polling — causing
undeliverable message errors and crashes.

`WaitRankStatus` fixes this by deferring the reply until the resource's
status reaches a caller-specified threshold. For proc-level status
(HostAgent), a `ProcStatusChanged` self-notification pattern routes
watch-channel updates through the actor's message loop: bridge tasks
watch each proc's status channel and send `ProcStatusChanged` to the
actor via a `PortHandle`, which triggers a handler that checks pending
waiters against the current status and replies to any whose threshold
is met. For actor-level status (ProcAgent), pending waiters are stashed
and flushed inline via `notify_status_changed` when supervision events
or stop transitions move the status past the threshold.

Changes by file:
- `proc.rs`: extract `Instance::self_client()` from `self_message_with_delay`
  so background tasks can send to `PortHandle`s without an actor context.
- `host.rs`: add `LocalProcManager::watch()` for subscribing to local
  proc lifecycle changes (mirrors `BootstrapProcManager::watch()`).
- `bootstrap.rs`: add `BootstrapProcManager::watch()`.
- `resource.rs`: add `WaitRankStatus` message type.
- `host_agent.rs`: add `WaitRankStatus` + `ProcStatusChanged` handlers,
  `start_watch_bridge` (one bridge per proc), `notify_proc_status_changed`.
  No `Arc`/`Mutex` — pending waiters are a plain `HashMap` touched only
  from `&mut self` handlers.
- `proc_agent.rs`: add `WaitRankStatus` handler, merge `notify_subscribers`
  and `flush_wait_status` into `notify_status_changed`.
- `host_mesh.rs`: switch `stop_proc_mesh` from `get_rank_status` to
  `wait_rank_status(..., Status::Stopped)`, fix `is_terminating` →
  `is_terminated` in the status check.

## Race-free shutdown guarantees

The fix relies on three properties that form a causal chain (this is
all in the "clean shutdown" case):

**1. flush-before-exit:** `ProcAgent::shutdown()` calls `proc.flush()`
before exiting. This drains the outbound message queue, ensuring all
`StreamState<ActorState>{ Stopped }` notifications are handed to the
transport before the process dies.

**2. wait-for-exit-before-proceeding:** `WaitRankStatus` blocks on the
proc's watch channel, which fires only after the process has actually
exited (not just received a stop signal). Combined with (1), when
`stop_proc_mesh` returns, every `StreamState<ActorState>{ Stopped }`
for every actor on every rank is **on the wire**.

**3. stop-before-shutdown ordering:** `worker_procs.stop().get()`
completes before `hosts.shutdown().get()` begins. By this point all
controllers have either already processed the streaming Stopped updates
and stopped polling, or any in-flight polls target dead procs and are
silently dropped (`return_undeliverable(false)`).

Differential Revision: [D96862238](https://our.internmc.facebook.com/intern/diff/D96862238/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D96862238/)!