### PR TITLE
[hyperactor_mesh] discard stale CheckState after controller stop

### DIFF
--- a/hyperactor_mesh/src/mesh_controller.rs
+++ b/hyperactor_mesh/src/mesh_controller.rs
@@ -784,6 +784,12 @@ impl<A: Referable> Handler<CheckState> for ActorMeshController<A> {
         cx: &Context<Self>,
         CheckState(expected_time): CheckState,
     ) -> Result<(), anyhow::Error> {
+        // A delayed CheckState may arrive after Stop has already dropped
+        // the monitor. Discard it — there is nothing left to poll.
+        if self.monitor.is_none() {
+            return Ok(());
+        }
+
         // This implementation polls every "time_between_checks" duration, checking
         // for changes in the actor states. It can be improved in two ways:
         // 1. Use accumulation, to get *any* actor with a change in state, not *all*


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #3088
* #3087
* #3086
* #3085
* #3084
* #3083
* #3082
* #3081
* #3080
* #3079
* #3078
* #3077
* #3076
* #3075
* #3074
* #3073
* #3072
* #3071
* #3070

When a `CheckState` self-message is already enqueued with a delay
(SUPERVISION_POLL_FREQUENCY, default 10s) and a `Stop` arrives before
it fires, the delayed `CheckState` still runs. It sends `GetState` to
the now-dead host agent, which returns an undeliverable message that
crashes the controller.

Fix: check `self.monitor` at entry to the `CheckState` handler and
return early if it has been dropped by a prior `Stop`.

Differential Revision: [D97035156](https://our.internmc.facebook.com/intern/diff/D97035156/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D97035156/)!