### PR TITLE
Add fast_pack: parallel file packing into contiguous buffers (#3089)

### DIFF
--- a/monarch_extension/Cargo.toml
+++ b/monarch_extension/Cargo.toml
@@ -36,6 +36,7 @@ serde = { version = "1.0.219", features = ["derive", "rc"] }
 tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
 torch-sys-cuda = { version = "0.0.0", path = "../torch-sys-cuda", optional = true }
 wirevalue = { version = "0.0.0", path = "../wirevalue" }
+xxhash-rust = { version = "0.8.15", features = ["xxh3", "xxh64"] }
 
 [build-dependencies]
 build_utils = { path = "../build_utils" }

--- a/monarch_extension/src/fast_pack.rs
+++ b/monarch_extension/src/fast_pack.rs
@@ -1,0 +1,509 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+//! Parallel file packing into a contiguous mmap buffer with block hashing.
+//!
+//! Given a list of (path, offset, size) entries and a total size,
+//! allocates an mmap region, reads all files into it using a thread
+//! pool, and computes xxh64 block hashes over the result — all in a
+//! single pass through the data (the hash pass reads from hot pages).
+
+use std::fs::File;
+use std::os::unix::io::AsRawFd;
+use std::thread;
+
+use pyo3::exceptions::PyOSError;
+use pyo3::ffi;
+use pyo3::prelude::*;
+// TODO: replace xxhash-rust with FFI bindings to Yann Collet's reference
+// C implementation (https://github.com/Cyan4973/xxHash) to avoid depending
+// on a third-party reimplementation.
+use xxhash_rust::xxh64;
+
+const DEFAULT_MAX_THREADS: usize = 16;
+
+fn num_threads() -> usize {
+    std::thread::available_parallelism()
+        .map(|n| n.get().min(DEFAULT_MAX_THREADS))
+        .unwrap_or(1)
+}
+const HASH_BLOCK_SIZE: usize = 64 * 1024 * 1024; // 64 MB
+/// Maximum bytes a single work unit reads. Large files are split into
+/// chunks of this size so multiple threads can read them in parallel.
+const READ_CHUNK_SIZE: usize = 64 * 1024 * 1024; // 64 MB
+
+struct FileInfo {
+    path: String,
+    offset: usize,
+    size: usize,
+}
+
+/// A unit of read work: read `size` bytes from `file_idx` at `file_offset`
+/// into the buffer at `buf_offset`.
+struct ReadWork {
+    file_idx: usize,
+    file_offset: usize,
+    buf_offset: usize,
+    size: usize,
+}
+
+/// Pack files into the buffer using a thread pool with byte-balanced work.
+///
+/// Large files are split into 64 MB chunks so all threads stay busy.
+/// Each chunk is read via `pread` for parallel access to the same file.
+/// Work units are distributed round-robin by descending size so that
+/// large chunks spread evenly across threads instead of piling up on
+/// thread 0.
+fn pack_files_into(buf_ptr: usize, files: &[FileInfo], max_threads: usize) {
+    // Build work units: split large files into READ_CHUNK_SIZE pieces.
+    let mut work_units: Vec<ReadWork> = Vec::new();
+    for (file_idx, f) in files.iter().enumerate() {
+        if f.size == 0 {
+            continue;
+        }
+        let mut file_off = 0;
+        while file_off < f.size {
+            let chunk = std::cmp::min(READ_CHUNK_SIZE, f.size - file_off);
+            work_units.push(ReadWork {
+                file_idx,
+                file_offset: file_off,
+                buf_offset: f.offset + file_off,
+                size: chunk,
+            });
+            file_off += chunk;
+        }
+    }
+
+    // Sort descending by size, then distribute round-robin across threads.
+    // This prevents all large chunks from landing on a single thread
+    // (e.g. 64 x 64 MB data.bin chunks all on thread 0 while threads
+    // 1-15 get only tiny .py files).
+    work_units.sort_by(|a, b| b.size.cmp(&a.size));
+
+    let num_threads = work_units.len().clamp(1, max_threads);
+    let mut per_thread: Vec<Vec<&ReadWork>> = vec![Vec::new(); num_threads];
+    for (i, w) in work_units.iter().enumerate() {
+        per_thread[i % num_threads].push(w);
+    }
+
+    thread::scope(|s| {
+        for thread_work in per_thread {
+            s.spawn(move || {
+                // Cache open file descriptors to avoid re-opening the same
+                // file for each chunk.
+                let mut cached_fd: Option<(usize, File)> = None;
+
+                for w in thread_work {
+                    let file = match &cached_fd {
+                        Some((idx, f)) if *idx == w.file_idx => f,
+                        _ => {
+                            let f = File::open(&files[w.file_idx].path).unwrap_or_else(|e| {
+                                panic!("fast_pack: failed to open {}: {e}", files[w.file_idx].path)
+                            });
+                            cached_fd = Some((w.file_idx, f));
+                            &cached_fd.as_ref().expect("cached_fd was just set").1
+                        }
+                    };
+
+                    // SAFETY: each work unit writes to a non-overlapping region
+                    // [buf_offset..buf_offset+size] of the buffer.
+                    let dst = unsafe {
+                        std::slice::from_raw_parts_mut((buf_ptr + w.buf_offset) as *mut u8, w.size)
+                    };
+
+                    let mut total_read = 0;
+                    while total_read < w.size {
+                        // SAFETY: file is a valid fd, dst is a valid mutable
+                        // slice within the mmap, and pread is thread-safe.
+                        let n = unsafe {
+                            libc::pread(
+                                file.as_raw_fd(),
+                                dst[total_read..].as_mut_ptr() as *mut libc::c_void,
+                                w.size - total_read,
+                                (w.file_offset + total_read) as libc::off_t,
+                            )
+                        };
+                        if n < 0 {
+                            let err = std::io::Error::last_os_error();
+                            panic!(
+                                "fast_pack: pread failed on {}: {err}",
+                                files[w.file_idx].path
+                            );
+                        }
+                        if n == 0 {
+                            panic!(
+                                "fast_pack: unexpected EOF on {} (read {total_read} of {} bytes)",
+                                files[w.file_idx].path, w.size
+                            );
+                        }
+                        total_read += n as usize;
+                    }
+                }
+            });
+        }
+    });
+}
+
+/// Compute xxh64 block hashes over the buffer in parallel.
+///
+/// Returns hex digest strings, one per `HASH_BLOCK_SIZE` block.
+fn compute_block_hashes(
+    buf_ptr: usize,
+    total_size: usize,
+    block_size: usize,
+    max_threads: usize,
+) -> Vec<String> {
+    let num_blocks = total_size.div_ceil(block_size);
+    let mut hashes = vec![String::new(); num_blocks];
+
+    let blocks_per_thread = num_blocks.div_ceil(max_threads);
+
+    thread::scope(|s| {
+        for (thread_idx, hash_chunk) in hashes.chunks_mut(blocks_per_thread).enumerate() {
+            let start_block = thread_idx * blocks_per_thread;
+            s.spawn(move || {
+                for (i, hash_slot) in hash_chunk.iter_mut().enumerate() {
+                    let block_idx = start_block + i;
+                    let offset = block_idx * block_size;
+                    let size = std::cmp::min(block_size, total_size - offset);
+
+                    debug_assert!(offset + size <= total_size);
+                    // SAFETY: buffer was allocated with total_size bytes;
+                    // offset + size <= total_size (checked above).
+                    let data = unsafe {
+                        std::slice::from_raw_parts((buf_ptr + offset) as *const u8, size)
+                    };
+
+                    *hash_slot = format!("{:016x}", xxh64::xxh64(data, 0));
+                }
+            });
+        }
+    });
+
+    hashes
+}
+
+/// Allocate an anonymous mmap region.
+fn mmap_anonymous(total_size: usize) -> Result<*mut libc::c_void, std::io::Error> {
+    // SAFETY: mmap with MAP_PRIVATE | MAP_ANONYMOUS allocates zeroed pages
+    // backed by swap, not a file descriptor.
+    let ptr = unsafe {
+        libc::mmap(
+            std::ptr::null_mut(),
+            total_size,
+            libc::PROT_READ | libc::PROT_WRITE,
+            libc::MAP_PRIVATE | libc::MAP_ANONYMOUS,
+            -1,
+            0,
+        )
+    };
+    if ptr == libc::MAP_FAILED {
+        Err(std::io::Error::last_os_error())
+    } else {
+        Ok(ptr)
+    }
+}
+
+/// Python-visible wrapper that owns an mmap region. When dropped, `munmap`
+/// is called. Callers can obtain a zero-copy `memoryview` via
+/// `memoryview(buf)`.
+#[pyclass(
+    name = "MmapBuffer",
+    module = "monarch._rust_bindings.monarch_extension.fast_pack"
+)]
+struct MmapBuffer {
+    ptr: *mut libc::c_void,
+    size: usize,
+}
+
+// SAFETY: the mmap region is process-wide; the pointer is safe to
+// send across threads for the lifetime of the object.
+unsafe impl Send for MmapBuffer {}
+// SAFETY: the mmap region is process-wide; read-only sharing across
+// threads is safe for the lifetime of the object.
+unsafe impl Sync for MmapBuffer {}
+
+impl Drop for MmapBuffer {
+    fn drop(&mut self) {
+        if !self.ptr.is_null() && self.size > 0 {
+            // SAFETY: ptr/size were returned by a successful mmap_anonymous call.
+            unsafe {
+                libc::munmap(self.ptr, self.size);
+            }
+        }
+    }
+}
+
+#[pymethods]
+impl MmapBuffer {
+    fn __len__(&self) -> usize {
+        self.size
+    }
+
+    unsafe fn __getbuffer__(
+        slf: PyRef<'_, Self>,
+        view: *mut ffi::Py_buffer,
+        flags: std::ffi::c_int,
+    ) -> PyResult<()> {
+        let ret = ffi::PyBuffer_FillInfo(
+            view,
+            slf.as_ptr(),
+            slf.ptr as *mut _,
+            slf.size as isize,
+            0, // writable
+            flags,
+        );
+        if ret < 0 {
+            return Err(PyErr::fetch(slf.py()));
+        }
+        Ok(())
+    }
+
+    unsafe fn __releasebuffer__(&self, _view: *mut ffi::Py_buffer) {}
+}
+
+/// Pack files into a contiguous mmap buffer in parallel, with block hashes.
+///
+/// Accepts a list of `(path, offset, size)` tuples, a `total_size`, and an
+/// optional `hash_block_size` (defaults to 64 MB).
+/// Returns `(MmapBuffer, [hash_hex_strings])`. Use `memoryview(buf)` for
+/// zero-copy access; the mmap is freed when the `MmapBuffer` is GC'd.
+#[pyfunction]
+#[pyo3(signature = (file_list, total_size, hash_block_size=None, max_threads=None))]
+fn pack_files_with_offsets(
+    py: Python<'_>,
+    file_list: Vec<(String, usize, usize)>,
+    total_size: usize,
+    hash_block_size: Option<usize>,
+    max_threads: Option<usize>,
+) -> PyResult<Py<PyAny>> {
+    let block_size = hash_block_size.unwrap_or(HASH_BLOCK_SIZE);
+    let nthreads = max_threads.unwrap_or_else(num_threads);
+
+    if file_list.is_empty() || total_size == 0 {
+        let buf = Py::new(
+            py,
+            MmapBuffer {
+                ptr: std::ptr::null_mut(),
+                size: 0,
+            },
+        )?;
+        let hashes = pyo3::types::PyList::empty(py).into_any().unbind();
+        let tuple = pyo3::types::PyTuple::new(py, [buf.into_any(), hashes])?;
+        return Ok(tuple.into_any().unbind());
+    }
+
+    let files: Vec<FileInfo> = file_list
+        .into_iter()
+        .map(|(path, offset, size)| FileInfo { path, offset, size })
+        .collect();
+
+    let buffer =
+        mmap_anonymous(total_size).map_err(|e| PyOSError::new_err(format!("mmap failed: {e}")))?;
+
+    // Wrap immediately so Drop handles cleanup on any subsequent error.
+    let buf = Py::new(
+        py,
+        MmapBuffer {
+            ptr: buffer,
+            size: total_size,
+        },
+    )?;
+
+    let buf_ptr = buffer as usize;
+    pack_files_into(buf_ptr, &files, nthreads);
+    let hashes = compute_block_hashes(buf_ptr, total_size, block_size, nthreads);
+
+    let py_hashes = pyo3::types::PyList::new(py, &hashes)?.into_any().unbind();
+    let tuple = pyo3::types::PyTuple::new(py, [buf.into_any(), py_hashes])?;
+    Ok(tuple.into_any().unbind())
+}
+
+/// Load a single file into anonymous mmap and compute block hashes in parallel.
+///
+/// Reads the file using the same parallel pread strategy as `pack_files_into`
+/// (16 threads, 64 MB chunks) and computes xxh64 hashes over the result.
+/// Returns `(MmapBuffer, [hash_hex_strings])`. Use `memoryview(buf)` for
+/// zero-copy access.
+///
+/// This is ~3-4x faster than the equivalent Python loop (`f.read(64MB)` +
+/// memoryview copy + separate xxhash pass) because it avoids the Python bytes
+/// allocation per chunk, reads directly into mmap, and hashes data still hot
+/// in CPU cache.
+#[pyfunction]
+#[pyo3(signature = (path, hash_block_size=None, padded_size=None, max_threads=None))]
+fn load_file_and_hash(
+    py: Python<'_>,
+    path: String,
+    hash_block_size: Option<usize>,
+    padded_size: Option<usize>,
+    max_threads: Option<usize>,
+) -> PyResult<Py<PyAny>> {
+    let block_size = hash_block_size.unwrap_or(HASH_BLOCK_SIZE);
+    let nthreads = max_threads.unwrap_or_else(num_threads);
+
+    let file_size = std::fs::metadata(&path)
+        .map_err(|e| PyOSError::new_err(format!("stat {path}: {e}")))?
+        .len() as usize;
+
+    if file_size == 0 {
+        let buf = Py::new(
+            py,
+            MmapBuffer {
+                ptr: std::ptr::null_mut(),
+                size: 0,
+            },
+        )?;
+        let hashes = pyo3::types::PyList::empty(py).into_any().unbind();
+        let tuple = pyo3::types::PyTuple::new(py, [buf.into_any(), hashes])?;
+        return Ok(tuple.into_any().unbind());
+    }
+
+    // Allocate padded_size if provided (for RDMA buffer reuse), but
+    // only read and hash file_size bytes.
+    let alloc_size = padded_size.map_or(file_size, |ps| ps.max(file_size));
+
+    let buffer =
+        mmap_anonymous(alloc_size).map_err(|e| PyOSError::new_err(format!("mmap failed: {e}")))?;
+
+    // Wrap immediately so Drop handles cleanup on any subsequent error.
+    let buf = Py::new(
+        py,
+        MmapBuffer {
+            ptr: buffer,
+            size: alloc_size,
+        },
+    )?;
+
+    let buf_ptr = buffer as usize;
+
+    // Treat the cache file as a single FileInfo entry — pack_files_into
+    // splits it into 64 MB chunks and reads them in parallel via pread.
+    let files = [FileInfo {
+        path,
+        offset: 0,
+        size: file_size,
+    }];
+    pack_files_into(buf_ptr, &files, nthreads);
+    let hashes = compute_block_hashes(buf_ptr, file_size, block_size, nthreads);
+    let py_hashes = pyo3::types::PyList::new(py, &hashes)?.into_any().unbind();
+    let tuple = pyo3::types::PyTuple::new(py, [buf.into_any(), py_hashes])?;
+    Ok(tuple.into_any().unbind())
+}
+
+/// Load a file into a pre-existing buffer and compute block hashes.
+///
+/// Reads the file using parallel pread (same as `load_file_and_hash`) but
+/// writes into the caller's buffer instead of allocating a new mmap.
+/// This preserves RDMA memory registrations across open() calls.
+/// Returns `[hash_hex_strings]`.
+#[pyfunction]
+#[pyo3(signature = (path, buffer, hash_block_size=None, max_threads=None))]
+fn load_file_into_buffer(
+    py: Python<'_>,
+    path: String,
+    buffer: pyo3::buffer::PyBuffer<u8>,
+    hash_block_size: Option<usize>,
+    max_threads: Option<usize>,
+) -> PyResult<Py<PyAny>> {
+    let block_size = hash_block_size.unwrap_or(HASH_BLOCK_SIZE);
+    let nthreads = max_threads.unwrap_or_else(num_threads);
+
+    if buffer.readonly() {
+        return Err(PyOSError::new_err("buffer is read-only"));
+    }
+
+    let file_size = std::fs::metadata(&path)
+        .map_err(|e| PyOSError::new_err(format!("stat {path}: {e}")))?
+        .len() as usize;
+
+    let buf_ptr = buffer.buf_ptr() as usize;
+    let buf_len = buffer.len_bytes();
+
+    if file_size > buf_len {
+        return Err(PyOSError::new_err(format!(
+            "file {path} is {file_size} bytes but buffer is only {buf_len} bytes"
+        )));
+    }
+
+    if file_size == 0 {
+        let hashes = pyo3::types::PyList::empty(py).into_any().unbind();
+        return Ok(hashes);
+    }
+
+    let files = [FileInfo {
+        path,
+        offset: 0,
+        size: file_size,
+    }];
+
+    // Release GIL for the heavy I/O + hash work.
+    let hashes = py.detach(move || {
+        pack_files_into(buf_ptr, &files, nthreads);
+        compute_block_hashes(buf_ptr, file_size, block_size, nthreads)
+    });
+
+    let py_hashes = pyo3::types::PyList::new(py, &hashes)?.into_any().unbind();
+    Ok(py_hashes)
+}
+
+/// Compute xxh64 block hashes over a Python buffer.
+///
+/// Returns a list of hex digest strings, one per `block_size` block.
+#[pyfunction]
+#[pyo3(signature = (buffer, block_size=None, max_threads=None))]
+fn block_hashes_py(
+    py: Python<'_>,
+    buffer: pyo3::buffer::PyBuffer<u8>,
+    block_size: Option<usize>,
+    max_threads: Option<usize>,
+) -> PyResult<Py<PyAny>> {
+    let bs = block_size.unwrap_or(HASH_BLOCK_SIZE);
+    let nthreads = max_threads.unwrap_or_else(num_threads);
+    let buf_ptr = buffer.buf_ptr() as usize;
+    let buf_len = buffer.len_bytes();
+
+    if buf_len == 0 {
+        let hashes = pyo3::types::PyList::empty(py).into_any().unbind();
+        return Ok(hashes);
+    }
+
+    let hashes = compute_block_hashes(buf_ptr, buf_len, bs, nthreads);
+    let py_hashes = pyo3::types::PyList::new(py, &hashes)?.into_any().unbind();
+    Ok(py_hashes)
+}
+
+/// Register Python bindings for the fast_pack module.
+pub fn register_python_bindings(module: &Bound<'_, PyModule>) -> PyResult<()> {
+    module.add_class::<MmapBuffer>()?;
+    let f = wrap_pyfunction!(pack_files_with_offsets, module)?;
+    f.setattr(
+        "__module__",
+        "monarch._rust_bindings.monarch_extension.fast_pack",
+    )?;
+    module.add_function(f)?;
+    let f3 = wrap_pyfunction!(load_file_and_hash, module)?;
+    f3.setattr(
+        "__module__",
+        "monarch._rust_bindings.monarch_extension.fast_pack",
+    )?;
+    module.add_function(f3)?;
+    let f4 = wrap_pyfunction!(load_file_into_buffer, module)?;
+    f4.setattr(
+        "__module__",
+        "monarch._rust_bindings.monarch_extension.fast_pack",
+    )?;
+    module.add_function(f4)?;
+    let f5 = wrap_pyfunction!(block_hashes_py, module)?;
+    f5.setattr(
+        "__module__",
+        "monarch._rust_bindings.monarch_extension.fast_pack",
+    )?;
+    module.add_function(f5)?;
+    Ok(())
+}

--- a/monarch_extension/src/lib.rs
+++ b/monarch_extension/src/lib.rs
@@ -21,6 +21,7 @@ mod mesh_controller;
 mod tensor_worker;
 
 mod blocking;
+mod fast_pack;
 mod panic;
 mod trace;
 
@@ -223,6 +224,11 @@ pub fn mod_init(module: &Bound<'_, PyModule>) -> PyResult<()> {
     crate::blocking::register_python_bindings(&get_or_add_new_module(
         module,
         "monarch_extension.blocking",
+    )?)?;
+
+    crate::fast_pack::register_python_bindings(&get_or_add_new_module(
+        module,
+        "monarch_extension.fast_pack",
     )?)?;
 
     monarch_hyperactor::logging::register_python_bindings(&get_or_add_new_module(

--- a/python/benches/bench_fast_pack.py
+++ b/python/benches/bench_fast_pack.py
@@ -1,0 +1,237 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+"""
+Benchmark for fast_pack: measures packing throughput (GB/s) across
+varying directory sizes with randomly sized files.
+
+Usage:
+    buck run @fbcode//mode/dev-nosan fbcode//monarch/python/benches:bench_fast_pack
+    buck run @fbcode//mode/dev-nosan fbcode//monarch/python/benches:bench_fast_pack -- --sizes 1,4,16,64
+"""
+
+from __future__ import annotations
+
+import argparse
+import gc
+import math
+import os
+import random
+import tempfile
+import time
+
+
+def create_random_directory(
+    base_dir: str,
+    total_bytes: int,
+    min_file: int = 1024,
+    max_file: int = 256 * 1024 * 1024,
+) -> tuple[int, list[int]]:
+    """Create a directory tree with randomly sized files summing to ~total_bytes.
+
+    Returns (actual_bytes_written, list_of_file_sizes).
+    """
+    written = 0
+    file_idx = 0
+    file_sizes: list[int] = []
+    subdirs = ["", "models", "data/train", "data/val", "config"]
+    for d in subdirs:
+        os.makedirs(os.path.join(base_dir, d), exist_ok=True)
+
+    while written < total_bytes:
+        remaining = total_bytes - written
+        size = min(random.randint(min_file, max_file), remaining)
+        subdir = random.choice(subdirs)
+        path = os.path.join(base_dir, subdir, f"file_{file_idx:06d}.bin")
+        with open(path, "wb") as f:
+            left = size
+            while left > 0:
+                chunk = min(left, 1024 * 1024)
+                f.write(os.urandom(chunk))
+                left -= chunk
+        written += size
+        file_sizes.append(size)
+        file_idx += 1
+
+    return written, file_sizes
+
+
+def format_bytes(n: int) -> str:
+    """Human-readable byte size."""
+    if n >= 1024 * 1024 * 1024:
+        return f"{n / (1024**3):.1f} GB"
+    if n >= 1024 * 1024:
+        return f"{n / (1024**2):.1f} MB"
+    if n >= 1024:
+        return f"{n / 1024:.1f} KB"
+    return f"{n} B"
+
+
+def file_size_stats(sizes: list[int]) -> str:
+    """Return mean/stddev/min/max summary."""
+    n = len(sizes)
+    if n == 0:
+        return "no files"
+    mean = sum(sizes) / n
+    variance = sum((s - mean) ** 2 for s in sizes) / n
+    stddev = math.sqrt(variance)
+    return (
+        f"{n} files, "
+        f"mean={format_bytes(int(mean))}, "
+        f"stddev={format_bytes(int(stddev))}, "
+        f"min={format_bytes(min(sizes))}, "
+        f"max={format_bytes(max(sizes))}"
+    )
+
+
+def bench_pack(total_gb: float, iterations: int = 3) -> None:
+    """Benchmark pack_directory_chunked at a given total size."""
+    from monarch.remotemount.fast_pack import pack_directory_chunked
+
+    total_bytes = int(total_gb * 1024 * 1024 * 1024)
+
+    with tempfile.TemporaryDirectory() as base_dir:
+        print(f"\n--- {total_gb:.1f} GB ---")
+        print("Creating test files...", end=" ", flush=True)
+        t0 = time.monotonic()
+        actual, file_sizes = create_random_directory(base_dir, total_bytes)
+        create_time = time.monotonic() - t0
+        actual_gb = actual / (1024**3)
+        print(f"{actual_gb:.2f} GB in {create_time:.1f}s")
+        print(f"  {file_size_stats(file_sizes)}")
+
+        # Warmup (first run populates page cache).
+        print("  Warmup...", end=" ", flush=True)
+        t0 = time.monotonic()
+        meta, staging_mv, chunks, hashes = pack_directory_chunked(base_dir)
+        warmup_time = time.monotonic() - t0
+        warmup_gbs = actual_gb / warmup_time
+        print(f"{warmup_time:.2f}s ({warmup_gbs:.2f} GB/s)")
+
+        # Verify data integrity.
+        total_packed = sum(len(c) for c in chunks)
+        assert total_packed == actual, f"packed {total_packed} != actual {actual}"
+        assert len(hashes) > 0, "expected at least one hash"
+
+        del meta, staging_mv, chunks, hashes
+        gc.collect()
+
+        # Timed runs.
+        times = []
+        nhashes = 0
+        for _i in range(iterations):
+            t0 = time.monotonic()
+            meta, staging_mv, chunks, hashes = pack_directory_chunked(base_dir)
+            elapsed = time.monotonic() - t0
+            times.append(elapsed)
+            nhashes = len(hashes)
+            del meta, staging_mv, chunks, hashes
+            gc.collect()
+
+        avg = sum(times) / len(times)
+        best = min(times)
+        gbs_avg = actual_gb / avg
+        gbs_best = actual_gb / best
+        print(f"  Avg:  {avg:.2f}s ({gbs_avg:.2f} GB/s)")
+        print(f"  Best: {best:.2f}s ({gbs_best:.2f} GB/s)")
+        print(f"  Hashes/run: {nhashes}")
+
+
+def bench_scaling(size_gb: float = 4.0) -> None:
+    """Benchmark with CPU affinity restricted to 1, 2, 4, 8, 16 cores."""
+    from monarch.remotemount.fast_pack import pack_directory_chunked
+
+    total_bytes = int(size_gb * 1024 * 1024 * 1024)
+    available = os.cpu_count() or 1
+
+    print(f"\n=== Scaling test ({size_gb:.0f} GB, {available} CPUs available) ===")
+
+    with tempfile.TemporaryDirectory() as base_dir:
+        print("Creating test files...", end=" ", flush=True)
+        t0 = time.monotonic()
+        actual, file_sizes = create_random_directory(base_dir, total_bytes)
+        actual_gb = actual / (1024**3)
+        print(f"{actual_gb:.2f} GB in {time.monotonic() - t0:.1f}s")
+        print(f"  {file_size_stats(file_sizes)}")
+
+        # Warmup.
+        meta, staging_mv, chunks, hashes = pack_directory_chunked(base_dir)
+        del meta, staging_mv, chunks, hashes
+        gc.collect()
+
+        core_counts = [c for c in [1, 2, 4, 8, 16] if c <= available]
+        all_cpus = list(range(available))
+
+        print(f"\n  {'Cores':>5}  {'Time':>7}  {'GB/s':>7}")
+        print(f"  {'-----':>5}  {'-----':>7}  {'-----':>7}")
+
+        for ncores in core_counts:
+            # Restrict this process to ncores CPUs.
+            target_cpus = all_cpus[:ncores]
+            os.sched_setaffinity(0, target_cpus)
+
+            times = []
+            for _i in range(3):
+                t0 = time.monotonic()
+                meta, staging_mv, chunks, hashes = pack_directory_chunked(base_dir)
+                elapsed = time.monotonic() - t0
+                times.append(elapsed)
+                del meta, staging_mv, chunks, hashes
+                gc.collect()
+
+            best = min(times)
+            gbs = actual_gb / best
+            print(f"  {ncores:>5}  {best:>6.2f}s  {gbs:>6.2f}")
+
+        # Restore full affinity.
+        os.sched_setaffinity(0, all_cpus)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="fast_pack benchmark")
+    parser.add_argument(
+        "--sizes",
+        type=str,
+        default="0.5,1,4,16,64",
+        help="Comma-separated sizes in GB (default: 0.5,1,4,16,64)",
+    )
+    parser.add_argument(
+        "--iterations",
+        type=int,
+        default=3,
+        help="Timed iterations per size (default: 3)",
+    )
+    parser.add_argument(
+        "--scaling",
+        action="store_true",
+        help="Run CPU scaling test (restricts affinity to 1,2,4,8,16 cores)",
+    )
+    parser.add_argument(
+        "--scaling-size",
+        type=float,
+        default=4.0,
+        help="Size in GB for scaling test (default: 4)",
+    )
+    args = parser.parse_args()
+
+    cpus = os.cpu_count() or 1
+    print(f"fast_pack benchmark ({cpus} CPUs available)")
+
+    if args.scaling:
+        bench_scaling(size_gb=args.scaling_size)
+    else:
+        sizes = [float(s) for s in args.sizes.split(",")]
+        print(f"Sizes: {sizes} GB, iterations: {args.iterations}")
+        for size in sizes:
+            bench_pack(size, iterations=args.iterations)
+
+    print("\nDone.")
+
+
+if __name__ == "__main__":
+    main()

--- a/python/monarch/_rust_bindings/monarch_extension/fast_pack.pyi
+++ b/python/monarch/_rust_bindings/monarch_extension/fast_pack.pyi
@@ -1,0 +1,33 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-unsafe
+
+from typing import Any
+
+def pack_files_with_offsets(
+    file_list: list[tuple[str, int, int]],
+    total_size: int,
+    hash_block_size: int | None = None,
+    max_threads: int | None = None,
+) -> tuple[Any, list[str]]: ...
+def load_file_and_hash(
+    path: str,
+    hash_block_size: int | None = None,
+    padded_size: int | None = None,
+    max_threads: int | None = None,
+) -> tuple[Any, list[str]]: ...
+def load_file_into_buffer(
+    path: str,
+    buffer: Any,
+    hash_block_size: int | None = None,
+    max_threads: int | None = None,
+) -> list[str]: ...
+def block_hashes_py(
+    buffer: Any,
+    block_size: int | None = None,
+    max_threads: int | None = None,
+) -> list[str]: ...

--- a/python/monarch/remotemount/__init__.py
+++ b/python/monarch/remotemount/__init__.py
@@ -1,0 +1,5 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.

--- a/python/monarch/remotemount/fast_pack.py
+++ b/python/monarch/remotemount/fast_pack.py
@@ -1,0 +1,144 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any
+
+from monarch._rust_bindings.monarch_extension.fast_pack import (
+    block_hashes_py,
+    pack_files_with_offsets,
+)
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+CHUNK_SIZE: int = (1024 * 1024 * 1024) * 8
+HASH_BLOCK_SIZE: int = 64 * 1024 * 1024  # 64MB blocks for incremental diffing
+
+
+# pyre-fixme[24]: Generic type `memoryview` expects 1 type parameter.
+def block_hashes(data_mv: memoryview, block_size: int = HASH_BLOCK_SIZE) -> list[str]:
+    """Compute xxh64 per block of a packed memoryview."""
+    return list(block_hashes_py(data_mv, block_size))
+
+
+def pack_directory_chunked(
+    source_path: str,
+    chunk_size: int | None = None,
+    # pyre-fixme[24]: Generic type `memoryview` expects 1 type parameter.
+) -> tuple[dict[str, Any], memoryview | None, list[memoryview], list[str]]:
+    """Walk a directory, pack all files into contiguous mmap chunks.
+
+    Returns (fs_metadata, staging_mv, chunks, block_hashes_list)
+    where:
+    - fs_metadata: dict mapping virtual paths to stat/offset metadata
+    - staging_mv: memoryview over the packed data
+    - chunks: list of chunk-sized memoryview slices
+    - block_hashes_list: list of xxh64 hex digest strings per block
+    """
+    if chunk_size is None:
+        chunk_size = CHUNK_SIZE
+
+    fs_metadata: dict[str, Any] = {}
+    file_list: list[tuple[str, int, int]] = []
+
+    # Tracks the virtual address of the filesystem
+    current_global_offset = 0
+
+    source_path = os.path.abspath(source_path)
+
+    for root, dirs, files in os.walk(source_path):
+        rel_path = root[len(source_path) :]
+        if rel_path == "":
+            rel_path = "/"
+
+        # Directory Metadata
+        st = os.stat(root)
+        fs_metadata[rel_path] = {
+            "attr": {
+                key: getattr(st, key)
+                for key in (
+                    "st_atime",
+                    "st_ctime",
+                    "st_gid",
+                    "st_mode",
+                    "st_mtime",
+                    "st_nlink",
+                    "st_size",
+                    "st_uid",
+                )
+            },
+            "children": dirs + files,
+        }
+
+        for f in files:
+            full_path = os.path.join(root, f)
+            virtual_path = (rel_path + "/" + f) if rel_path != "/" else ("/" + f)
+
+            lst = os.lstat(full_path)
+            is_symlink = (lst.st_mode & 0o170000) == 0o120000
+
+            if is_symlink:
+                fs_metadata[virtual_path] = {
+                    "attr": {
+                        key: getattr(lst, key)
+                        for key in (
+                            "st_atime",
+                            "st_ctime",
+                            "st_gid",
+                            "st_mode",
+                            "st_mtime",
+                            "st_nlink",
+                            "st_size",
+                            "st_uid",
+                        )
+                    },
+                    "link_target": os.readlink(full_path),
+                }
+            else:
+                file_len = lst.st_size
+                attr = {
+                    key: getattr(lst, key)
+                    for key in (
+                        "st_atime",
+                        "st_ctime",
+                        "st_gid",
+                        "st_mode",
+                        "st_mtime",
+                        "st_nlink",
+                        "st_size",
+                        "st_uid",
+                    )
+                }
+                attr["st_size"] = file_len
+
+                fs_metadata[virtual_path] = {
+                    "attr": attr,
+                    "global_offset": current_global_offset,
+                    "file_len": file_len,
+                }
+
+                file_list.append((full_path, current_global_offset, file_len))
+                # Tracks the virtual address of the filesystem
+                current_global_offset += file_len
+
+    total_size = current_global_offset
+    logger.info(f"Packing {total_size // (1024**2)}MiB, {len(file_list)} files")
+
+    if total_size == 0:
+        return fs_metadata, None, [], []
+
+    buf, hashes = pack_files_with_offsets(file_list, total_size)
+    staging_mv = memoryview(buf)
+    chunks = [
+        staging_mv[i : i + chunk_size] for i in range(0, len(staging_mv), chunk_size)
+    ]
+
+    return fs_metadata, staging_mv, chunks, list(hashes)

--- a/python/tests/test_remotemount.py
+++ b/python/tests/test_remotemount.py
@@ -1,0 +1,417 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from __future__ import annotations
+
+import gc
+import math
+import mmap
+import os
+import tempfile
+
+import pytest
+from monarch._rust_bindings.monarch_extension.fast_pack import (
+    load_file_and_hash,
+    pack_files_with_offsets,
+)
+from monarch.remotemount.fast_pack import block_hashes, pack_directory_chunked
+
+
+class TestPackDirectoryChunked:
+    def test_empty_directory(self) -> None:
+        with tempfile.TemporaryDirectory() as d:
+            meta, _staging_mv, chunks, hashes = pack_directory_chunked(d)
+            assert chunks == []
+            assert hashes == []
+            assert "/" in meta
+            assert "children" in meta["/"]
+            assert meta["/"]["children"] == []
+
+    def test_single_file(self) -> None:
+        with tempfile.TemporaryDirectory() as d:
+            content = b"hello world"
+            with open(os.path.join(d, "a.txt"), "wb") as f:
+                f.write(content)
+
+            meta, _staging_mv, chunks, hashes = pack_directory_chunked(d)
+
+            assert "/a.txt" in meta
+            file_meta = meta["/a.txt"]
+            assert file_meta["global_offset"] == 0
+            assert file_meta["file_len"] == len(content)
+
+            packed = b"".join(bytes(c) for c in chunks)
+            assert packed == content
+            assert len(hashes) == 1
+
+    def test_multiple_files_contiguous_offsets(self) -> None:
+        with tempfile.TemporaryDirectory() as d:
+            files = {"a.txt": b"aaa", "b.txt": b"bbbbbb", "c.txt": b"c"}
+            for name, content in files.items():
+                with open(os.path.join(d, name), "wb") as f:
+                    f.write(content)
+
+            meta, _staging_mv, chunks, _hashes = pack_directory_chunked(d)
+            packed = b"".join(bytes(c) for c in chunks)
+
+            # Verify each file's content at its offset
+            for name, content in files.items():
+                path = f"/{name}"
+                assert path in meta
+                off = meta[path]["global_offset"]
+                length = meta[path]["file_len"]
+                assert length == len(content)
+                assert packed[off : off + length] == content
+
+            # Verify offsets are contiguous
+            file_entries = sorted(
+                (
+                    (m["global_offset"], m["file_len"])
+                    for m in meta.values()
+                    if "global_offset" in m
+                ),
+                key=lambda x: x[0],
+            )
+            for i in range(1, len(file_entries)):
+                prev_off, prev_len = file_entries[i - 1]
+                curr_off, _ = file_entries[i]
+                assert curr_off == prev_off + prev_len
+
+    def test_symlink(self) -> None:
+        with tempfile.TemporaryDirectory() as d:
+            target = os.path.join(d, "target.txt")
+            with open(target, "w") as f:
+                f.write("target")
+            os.symlink(target, os.path.join(d, "link.txt"))
+
+            meta, _staging_mv, chunks, _hashes = pack_directory_chunked(d)
+
+            assert "/link.txt" in meta
+            link_meta = meta["/link.txt"]
+            assert "link_target" in link_meta
+            assert link_meta["link_target"] == target
+            assert "global_offset" not in link_meta
+
+    def test_directory_metadata(self) -> None:
+        with tempfile.TemporaryDirectory() as d:
+            os.makedirs(os.path.join(d, "sub"))
+            with open(os.path.join(d, "sub", "f.txt"), "w") as f:
+                f.write("x")
+
+            meta, _, _, _ = pack_directory_chunked(d)
+
+            assert "/" in meta
+            assert "sub" in meta["/"]["children"]
+            assert "/sub" in meta
+            assert "f.txt" in meta["/sub"]["children"]
+            assert "st_mode" in meta["/"]["attr"]
+
+    def test_custom_chunk_size(self) -> None:
+        with tempfile.TemporaryDirectory() as d:
+            content = b"x" * 1000
+            with open(os.path.join(d, "big.txt"), "wb") as f:
+                f.write(content)
+
+            chunk_size = 300
+            meta, _staging_mv, chunks, _hashes = pack_directory_chunked(
+                d, chunk_size=chunk_size
+            )
+
+            assert len(chunks) == math.ceil(len(content) / chunk_size)
+            packed = b"".join(bytes(c) for c in chunks)
+            assert packed == content
+
+    def test_hashes_deterministic(self) -> None:
+        with tempfile.TemporaryDirectory() as d:
+            with open(os.path.join(d, "f.bin"), "wb") as f:
+                f.write(os.urandom(500))
+
+            _, _, _, h1 = pack_directory_chunked(d)
+            _, _, _, h2 = pack_directory_chunked(d)
+            assert h1 == h2
+            assert len(h1) > 0
+
+    def test_hashes_change_on_content_change(self) -> None:
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, "f.bin")
+            with open(path, "wb") as f:
+                f.write(b"\x00" * 500)
+            _, _, _, h1 = pack_directory_chunked(d)
+
+            with open(path, "wb") as f:
+                f.write(b"\xff" * 500)
+            _, _, _, h2 = pack_directory_chunked(d)
+
+            assert h1 != h2
+
+
+class TestBlockHashes:
+    def test_deterministic(self) -> None:
+        data = os.urandom(500)
+        mv = memoryview(data)
+        assert block_hashes(mv, block_size=200) == block_hashes(mv, block_size=200)
+
+    def test_different_data(self) -> None:
+        a = memoryview(b"\x00" * 500)
+        b = memoryview(b"\xff" * 500)
+        assert block_hashes(a, block_size=200) != block_hashes(b, block_size=200)
+
+    def test_block_count(self) -> None:
+        data = memoryview(os.urandom(500))
+        hashes = block_hashes(data, block_size=200)
+        assert len(hashes) == 3  # 200 + 200 + 100
+
+    def test_empty(self) -> None:
+        assert block_hashes(memoryview(b""), block_size=100) == []
+
+
+class TestShmRoundTrip:
+    """Test /tmp/ create/write/collect round-trip (no actors)."""
+
+    def test_create_write_collect(self) -> None:
+        pid = os.getpid()
+        data = os.urandom(1024)
+        num_shards = 4
+        shard_size = len(data) // num_shards
+        paths = []
+
+        # Create shm files.
+        for i in range(num_shards):
+            path = f"/tmp/monarch_test_{pid}_{i}"
+            fd = os.open(path, os.O_CREAT | os.O_RDWR, 0o600)
+            os.ftruncate(fd, shard_size)
+            os.close(fd)
+            paths.append(path)
+
+        # Write shard data.
+        for i, path in enumerate(paths):
+            fd = os.open(path, os.O_RDWR)
+            mm = mmap.mmap(fd, shard_size)
+            start = i * shard_size
+            mm[:] = data[start : start + shard_size]
+            mm.close()
+            os.close(fd)
+
+        # Collect: mmap and unlink.
+        collected = bytearray()
+        for path in paths:
+            fd = os.open(path, os.O_RDONLY)
+            mm = mmap.mmap(fd, shard_size, mmap.MAP_PRIVATE, mmap.PROT_READ)
+            os.close(fd)
+            collected.extend(mm[:])
+            mm.close()
+            os.unlink(path)
+
+        assert bytes(collected) == data
+
+    def test_unlink_after_mmap(self) -> None:
+        """Data persists after unlink as long as mmap is alive."""
+        path = f"/tmp/monarch_test_{os.getpid()}_unlink"
+        data = b"hello shm"
+        fd = os.open(path, os.O_CREAT | os.O_RDWR, 0o600)
+        os.ftruncate(fd, len(data))
+        mm = mmap.mmap(fd, len(data))
+        mm[:] = data
+        os.close(fd)
+
+        # Unlink while mmap is still open.
+        os.unlink(path)
+        assert not os.path.exists(path)
+
+        # Data still accessible via mmap.
+        assert bytes(mm[:]) == data
+        mm.close()
+
+
+class TestHashBlockSizeConsistency:
+    """Verify Rust and Python hash block sizes match."""
+
+    def test_default_block_sizes_match(self) -> None:
+        """Rust and Python should produce identical hashes with their defaults."""
+        with tempfile.TemporaryDirectory() as d:
+            # Create data larger than 100MB to get multiple blocks.
+            # Use a small amount for speed — just verify the constants agree.
+            data = os.urandom(1024)
+            path = os.path.join(d, "f.bin")
+            with open(path, "wb") as f:
+                f.write(data)
+
+            # Rust default hashes (via pack_files_with_offsets).
+            buf, rust_hashes = pack_files_with_offsets(
+                [(path, 0, len(data))], len(data)
+            )
+            # Python default hashes.
+            py_hashes = block_hashes(memoryview(buf))
+
+            assert list(rust_hashes) == py_hashes
+
+
+class TestMmapBufferOwnership:
+    """Verify MmapBuffer owns mmap memory and supports zero-copy access."""
+
+    def test_memoryview_zero_copy(self) -> None:
+        """memoryview(buf) should be zero-copy: writes through mv are visible."""
+        with tempfile.TemporaryDirectory() as d:
+            data = b"AAAA"
+            path = os.path.join(d, "f.bin")
+            with open(path, "wb") as f:
+                f.write(data)
+
+            buf, _hashes = pack_files_with_offsets([(path, 0, len(data))], len(data))
+            mv = memoryview(buf)
+
+            assert bytes(mv) == b"AAAA"
+            mv[0] = ord("Z")
+            assert bytes(memoryview(buf)[:1]) == b"Z"
+
+    def test_gc_frees_mmap(self) -> None:
+        """MmapBuffer should be GC-collectable without leaking."""
+        with tempfile.TemporaryDirectory() as d:
+            data = b"x" * 4096
+            path = os.path.join(d, "f.bin")
+            with open(path, "wb") as f:
+                f.write(data)
+
+            buf, _hashes = pack_files_with_offsets([(path, 0, len(data))], len(data))
+            # Create a memoryview, then release both.
+            mv = memoryview(buf)
+            assert len(mv) == 4096
+            del mv, buf
+            gc.collect()
+            # If we get here without segfault, cleanup worked.
+
+    def test_empty_buffer(self) -> None:
+        """Empty packing returns a zero-length MmapBuffer."""
+        buf, hashes = pack_files_with_offsets([], 0)
+        assert len(buf) == 0
+        assert list(hashes) == []
+
+    def test_load_file_and_hash_returns_buffer(self) -> None:
+        """load_file_and_hash should return an MmapBuffer, not raw memoryview."""
+        with tempfile.TemporaryDirectory() as d:
+            data = b"hello world" * 100
+            path = os.path.join(d, "f.bin")
+            with open(path, "wb") as f:
+                f.write(data)
+
+            buf, hashes = load_file_and_hash(path)
+            mv = memoryview(buf)
+            assert bytes(mv[: len(data)]) == data
+            assert len(hashes) > 0
+
+
+BLOCK_SIZE: int = 64 * 1024 * 1024  # Must match Rust HASH_BLOCK_SIZE / READ_CHUNK_SIZE
+
+
+class TestBlockBoundary:
+    """Test files that straddle the 64MB block/chunk boundary."""
+
+    def test_file_spanning_two_blocks(self) -> None:
+        """A single file larger than one block should produce correct hashes."""
+        size = BLOCK_SIZE + 1024  # Just over one block boundary.
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, "big.bin")
+            with open(path, "wb") as f:
+                f.write(os.urandom(size))
+
+            buf, hashes = pack_files_with_offsets([(path, 0, size)], size)
+            mv = memoryview(buf)
+
+            assert len(mv) == size
+            assert len(hashes) == 2  # ceil(size / 64MB) = 2
+
+            # Verify hashes match Python-computed hashes.
+            py_hashes = block_hashes(mv, block_size=BLOCK_SIZE)
+            assert list(hashes) == py_hashes
+
+            # Verify content matches the file.
+            with open(path, "rb") as f:
+                expected = f.read()
+            assert bytes(mv) == expected
+
+    def test_file_exactly_one_block(self) -> None:
+        """A file exactly equal to block size should produce one hash."""
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, "exact.bin")
+            with open(path, "wb") as f:
+                f.write(os.urandom(BLOCK_SIZE))
+
+            buf, hashes = pack_files_with_offsets([(path, 0, BLOCK_SIZE)], BLOCK_SIZE)
+            assert len(hashes) == 1
+            assert len(memoryview(buf)) == BLOCK_SIZE
+
+    def test_multiple_files_across_block_boundary(self) -> None:
+        """Multiple small files whose total spans a block boundary."""
+        # File A fills most of block 0, file B straddles into block 1.
+        size_a = BLOCK_SIZE - 100
+        size_b = 200  # Straddles: 100 bytes in block 0, 100 in block 1.
+        total = size_a + size_b
+
+        with tempfile.TemporaryDirectory() as d:
+            path_a = os.path.join(d, "a.bin")
+            path_b = os.path.join(d, "b.bin")
+            data_a = os.urandom(size_a)
+            data_b = os.urandom(size_b)
+
+            with open(path_a, "wb") as f:
+                f.write(data_a)
+            with open(path_b, "wb") as f:
+                f.write(data_b)
+
+            file_list = [(path_a, 0, size_a), (path_b, size_a, size_b)]
+            buf, hashes = pack_files_with_offsets(file_list, total)
+            mv = memoryview(buf)
+
+            assert len(mv) == total
+            assert len(hashes) == 2  # Spans two blocks.
+
+            # Verify content of both files at their offsets.
+            assert bytes(mv[:size_a]) == data_a
+            assert bytes(mv[size_a : size_a + size_b]) == data_b
+
+    def test_pack_directory_large_file(self) -> None:
+        """pack_directory_chunked with a file larger than the block size."""
+        size = BLOCK_SIZE + 512
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, "big.bin")
+            data = os.urandom(size)
+            with open(path, "wb") as f:
+                f.write(data)
+
+            meta, staging_mv, chunks, hashes = pack_directory_chunked(d)
+
+            packed = b"".join(bytes(c) for c in chunks)
+            assert packed == data
+            assert len(hashes) == 2
+
+            assert staging_mv is not None
+            py_hashes = block_hashes(staging_mv, block_size=BLOCK_SIZE)
+            assert hashes == py_hashes
+
+
+class TestPreadErrorHandling:
+    """Verify that pread errors are detected, not silently swallowed."""
+
+    def test_truncated_file_panics(self) -> None:
+        """If a file is truncated between stat and read, packing should fail."""
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, "f.bin")
+            with open(path, "wb") as f:
+                f.write(b"x" * 1000)
+
+            # Tell pack_files_with_offsets the file is 1000 bytes,
+            # but truncate it to 500 before packing.
+            os.truncate(path, 500)
+
+            with pytest.raises(BaseException, match="panicked"):  # noqa: B017
+                pack_files_with_offsets([(path, 0, 1000)], 1000)
+
+    def test_missing_file_panics(self) -> None:
+        """Packing a nonexistent file should fail, not silently zero-fill."""
+        with pytest.raises(BaseException, match="panicked"):  # noqa: B017
+            pack_files_with_offsets([("/nonexistent/path/to/file.bin", 0, 100)], 100)


### PR DESCRIPTION
Summary:

Add `fast_pack.rs`, a Rust module that packs files into contiguous mmap
buffers using parallel I/O. Three Python-facing functions:

- `pack_files_with_offsets`: packs multiple files into anonymous mmap
- `load_file_and_hash`: loads a single file into mmap with hashes
- `load_file_into_buffer`: loads into a pre-existing buffer (for RDMA MR reuse)

All functions use parallel pread and compute xxh64 block hashes (64 MB
blocks) in a single pass. Thread count defaults to
`min(available_parallelism(), 16)` — on this 46-CPU machine that means
16 threads. Callers can override via the `max_threads` parameter.

Memory management: `MmapBuffer` pyclass owns the mmap region, implements
the buffer protocol for zero-copy `memoryview()` access, and calls
`munmap` on drop.

Also adds the Python `monarch.remotemount` package with:
- `pack_directory_chunked`: walks a directory, collects stat metadata,
  packs all files via the Rust fast_pack module
- `block_hashes`: per-block xxhash for incremental diffing

Throughput benchmark (46 CPUs, default 16 threads, warm page cache):

  Size   | Files | Mean file size | Best GB/s
  -------|-------|----------------|----------
  0.5 GB |     3 |       170.7 MB |      9.0
  1.0 GB |    10 |       102.4 MB |     11.9
  4.0 GB |    41 |        99.9 MB |     15.6
  16  GB |   133 |       123.2 MB |     18.4
  64  GB |   501 |       130.8 MB |     14.0

CPU scaling (4 GB, CPU affinity restricted):

  Cores | Best GB/s | Speedup
  ------|-----------|--------
      1 |       2.0 |    1.0x
      2 |       3.5 |    1.8x
      4 |       6.0 |    3.0x
      8 |      10.2 |    5.1x
     16 |      15.2 |    7.6x
ghstack-source-id: 354480983
exported-using-ghexport

Reviewed By: zdevito

Differential Revision: D96067974
