### PR TITLE
Fix stale documentation across docs/source/ (25 files)

### DIFF
--- a/docs/source/actors.md
+++ b/docs/source/actors.md
@@ -348,8 +348,9 @@ with procs.activate():
 Stream responses as they arrive.
 
 ```python
-# Process responses as they come
-async for result in workers.compute.stream(data):
+# Process responses as they arrive (stream returns Iterator[Future])
+for future in workers.compute.stream(data):
+    result = future.get()
     print(f"Got result: {result}")
     process_result(result)
 ```
@@ -415,8 +416,8 @@ class ContextAwareActor(Actor):
         # Get actor instance
         actor_inst = ctx.actor_instance
 
-        # Get process reference
-        proc = ctx.proc
+        # Get process reference (via actor instance)
+        proc = actor_inst.proc
 
         return {
             "rank": rank,
@@ -435,7 +436,7 @@ The position in the mesh for the current message.
 @endpoint
 def process(self):
     rank = context().message_rank
-    # rank is a dict: {"hosts": 0, "gpus": 3}
+    # rank is a Point (dict-like): {"hosts": 0, "gpus": 3}
 
     if rank["gpus"] == 0:
         print("I'm the first GPU!")
@@ -478,8 +479,8 @@ Reference to the process hosting this actor.
 ```python
 @endpoint
 def spawn_sibling(self):
-    # Get our process
-    proc = context().proc
+    # Get our process (via actor instance)
+    proc = context().actor_instance.proc
 
     # Spawn sibling actor on same process
     sibling = proc.spawn("sibling", SiblingActor)
@@ -492,14 +493,13 @@ def spawn_sibling(self):
 graph TD
     A[context] --> B[message_rank]
     A --> C[actor_instance]
-    A --> D[proc]
 
     C --> C1[actor_id]
     C --> C2[rank]
     C --> C3[proc_id]
+    C --> D[proc]
 
     D --> D1[spawn]
-    D --> D2[host_mesh]
 
     style A fill:#007c88,stroke:#333,stroke-width:2px
 ```
@@ -685,7 +685,7 @@ From these principles, we can also derive that ownership follows a strict hierar
 We can always draw a single path from any mesh to some "root" owner. This makes
 the supervision hierarchy a tree. There are no orphan (managed) objects in the system: all failures must propagate.
 
-The following is a further axiomitization, separating actor supervision from mesh lifecycle management:
+The following is a further axiomatization, separating actor supervision from mesh lifecycle management:
 
 #### Actors
 Actors form a strict hierarchy of ownership. Typically the root of the hierarchy is the main script's client actor. We say that an actor is owned by its parent. A root actor is not owned.
@@ -784,21 +784,19 @@ class SupervisorActor(Actor):
     def __init__(self):
         self.children = []
 
-    def __supervise__(self, event):
-        print(f"Supervision event: {event}")
+    def __supervise__(self, failure: MeshFailure) -> bool:
+        # failure.report() returns a human-readable error string
+        # failure.mesh_name identifies which owned mesh failed
+        print(f"Supervision event for {failure.mesh_name}: {failure.report()}")
 
-        if event.is_recoverable():
-            # Restart failed actor
-            self.restart_child(event.actor_id)
-            return True  # Handled
-        else:
-            # Propagate to parent
-            return False
+        # Return True to mark the failure as handled,
+        # or False to propagate it up the ownership hierarchy.
+        return False
 
     @endpoint
     def spawn_worker(self):
-        # Spawn supervised child
-        worker = context().proc.spawn("worker", WorkerActor)
+        # Spawn supervised child (proc accessed via actor instance)
+        worker = context().actor_instance.proc.spawn("worker", WorkerActor)
         self.children.append(worker)
         return worker
 ```
@@ -846,6 +844,7 @@ Share readonly state across actor mesh:
 
 ```python
 from monarch.actor import ValueMesh
+from monarch._rust_bindings.monarch_hyperactor.shape import Shape, Slice
 
 class ConfigActor(Actor):
     def __init__(self, config_mesh: ValueMesh[dict]):
@@ -857,9 +856,10 @@ class ConfigActor(Actor):
     def get_config(self):
         return self.config
 
-# Create value mesh
+# Create value mesh: build a Shape, then pass values
 configs = [{"id": i, "param": i * 10} for i in range(8)]
-config_mesh = ValueMesh.from_list(configs, extent={"gpus": 8})
+shape = Shape(["gpus"], Slice(offset=0, sizes=[8], strides=[1]))
+config_mesh = ValueMesh(shape, configs)
 
 # Spawn actors with value mesh
 actors = procs.spawn("actors", ConfigActor, config_mesh)
@@ -1149,7 +1149,7 @@ from monarch.actor import context
 def my_endpoint(self):
     ctx = context()
     rank = ctx.message_rank
-    proc = ctx.proc
+    proc = ctx.actor_instance.proc
 ```
 
 ### Supervision

--- a/docs/source/api/monarch.actor.rst
+++ b/docs/source/api/monarch.actor.rst
@@ -10,7 +10,7 @@ Creating Actors
 ===============
 
 Actors are created on multidimensional meshes of processes that
-are launch across hosts. HostMesh represents a mesh of hosts. ProcMesh is a mesh of processes.
+are launched across hosts. HostMesh represents a mesh of hosts. ProcMesh is a mesh of processes.
 
 .. autoclass:: HostMesh
    :members:
@@ -28,6 +28,8 @@ are launch across hosts. HostMesh represents a mesh of hosts. ProcMesh is a mesh
 .. autofunction:: get_or_spawn_controller
 
 .. autofunction:: this_host
+
+.. autofunction:: this_proc
 
 
 Defining Actors
@@ -148,3 +150,13 @@ Use these functions to look up what actor is running the currently executing cod
    :inherited-members:
    :show-inheritance:
    :exclude-members: from_bytes, labels, sizes
+
+
+Supervision
+===========
+Types used for error handling and supervision in actor meshes.
+
+.. autoclass:: MeshFailure
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api/monarch.job.rst
+++ b/docs/source/api/monarch.job.rst
@@ -69,6 +69,15 @@ LocalJob
    :show-inheritance:
    :exclude-members: __init__
 
+ProcessJob
+----------
+
+.. autoclass:: ProcessJob
+   :members:
+   :undoc-members:
+   :show-inheritance:
+   :exclude-members: __init__
+
 SlurmJob
 --------
 

--- a/docs/source/api/monarch.rdma.rst
+++ b/docs/source/api/monarch.rdma.rst
@@ -27,3 +27,5 @@ Utility Functions
 =================
 
 .. autofunction:: is_ibverbs_available
+
+.. autofunction:: get_rdma_backend

--- a/docs/source/books/hyperactor-book/src/actors/actor_lifecycle.md
+++ b/docs/source/books/hyperactor-book/src/actors/actor_lifecycle.md
@@ -45,14 +45,14 @@ pub enum ActorStatus {
 `Signal` is used to control actor lifecycle transitions externally. These messages are sent internally by the runtime (or explicitly by users) to initiate operations like shutdown.
 ```rust
 pub enum Signal {
-    DrainAndStop,
-    Stop,
+    DrainAndStop(String),
+    Stop(String),
     ChildStopped(Index),
 }
 ```
 Variants
-- `DrainAndStop`: Gracefully stops the actor by first draining all queued messages.
-- `Stop`: Immediately halts the actor, even if messages remain in its mailbox.
+- `DrainAndStop(reason)`: Gracefully stops the actor by first draining all queued messages. The reason string describes why the stop was requested.
+- `Stop(reason)`: Immediately halts the actor, even if messages remain in its mailbox.
 - `ChildStopped`: Internal signal sent when a direct child with the given index was stopped.
 
 These signals are routed like any other message, typically sent using `ActorHandle::send` or by the runtime during supervision and recovery procedures.

--- a/docs/source/books/hyperactor-book/src/channels/transports/index.md
+++ b/docs/source/books/hyperactor-book/src/channels/transports/index.md
@@ -4,7 +4,7 @@ Channels abstract over multiple underlying transports. Each transport implements
 
 All transports share the same **framing and acknowledgement semantics** (length-prefixed frames, `seq`/`ack` for exactly-once delivery), except the **Local** transport which uses a plain in-process `mpsc` and does not involve network acks.
 
-tcp, unix, and metatls are built on the shared **net** stack (`NetTx` / `NetRx`) which handles outbox management, seq/ack, retransmission, and reconnection with backoff. local and sim implement the traits directly.
+tcp, unix, and metatls are built on the shared **net** stack (`NetTx` / `NetRx`) which handles outbox management, seq/ack, retransmission, and reconnection with backoff. local implements the traits directly.
 
 Available transports:
 
@@ -12,6 +12,5 @@ Available transports:
 - [TCP](tcp.md) — length-prefixed over sockets
 - [Unix](unix.md) — Unix domain sockets
 - [MetaTLS](metatls.md) — TCP wrapped in TLS
-- [Sim](sim.md) — simulation for testing
 
 _see also_: [tx/rx api](../channels/tx_rx.md), [frames](../channels/frames.md)

--- a/docs/source/books/hyperactor-book/src/channels/tx_rx.md
+++ b/docs/source/books/hyperactor-book/src/channels/tx_rx.md
@@ -119,7 +119,4 @@ Concrete channel implementations that satisfy `Tx<M>` / `Rx<M>`:
 - **MetaTLS** — TCP wrapped in TLS via `tokio-rustls`; same framing/ack semantics; Meta cert plumbing.
   _Dial/serve:_ `metatls:HOST:PORT`.
 
-- **Sim** — simulation transport for tests; exercises the same channel semantics without real sockets.
-  _Dial/serve:_ `sim:<inner-addr>`.
-
 <!-- ## Integration with Transports -->

--- a/docs/source/books/hyperactor-book/src/mailboxes/delivery.md
+++ b/docs/source/books/hyperactor-book/src/mailboxes/delivery.md
@@ -42,7 +42,10 @@ impl MessageEnvelope {
 ```rust
 impl MessageEnvelope {
   fn new_unknown(dest: PortId, data: Serialized) -> Self {
-    Self::new(id!(unknown[0].unknown), dest, data)
+    let unknown_addr = ChannelAddr::any(ChannelTransport::Local);
+    let unknown_proc_id = ProcId::unique(unknown_addr, "unknown");
+    let unknown_actor_id = ActorId::root(unknown_proc_id, "unknown".to_string());
+    Self::new(unknown_actor_id, dest, data)
   }
 }
 ```

--- a/docs/source/books/hyperactor-book/src/mailboxes/reconfigurable_sender.md
+++ b/docs/source/books/hyperactor-book/src/mailboxes/reconfigurable_sender.md
@@ -1,12 +1,12 @@
 # Reconfigurable Senders
 
 Some actors are constructed before the full messaging graph is available.
-For example, the `ReconfigurableMailboxSender` is used during `MeshAgent::bootstrap` to allow early creation of the `Proc` and agent before outbound routing is available.
+For example, the `ReconfigurableMailboxSender` is used during `HostAgent::bootstrap` to allow early creation of the `Proc` and agent before outbound routing is available.
 The `.configure(...)` method installs the actual router later, once mesh wiring is complete.
 
 ## Motivation
 
-Actors like `mesh_agent` are created before remote routing infrastructure is established. These actors need to send messages during setup, but the concrete `MailboxSender` they will use hasn't been determined yet.
+Actors like `HostAgent` are created before remote routing infrastructure is established. These actors need to send messages during setup, but the concrete `MailboxSender` they will use hasn't been determined yet.
 
 To solve this, `ReconfigurableMailboxSender` implements [`MailboxSender`] and supports **deferred configuration**: it starts by queueing messages in memory, then later transitions to forwarding once a real sender is available.
 

--- a/docs/source/books/hyperactor-book/src/procs/host.md
+++ b/docs/source/books/hyperactor-book/src/procs/host.md
@@ -71,15 +71,15 @@ impl<M: ProcManager> Host<M> {
 
         let router = DialMailboxRouter::new();
 
-        let service_proc_id = ProcId(
+        let service_proc_id = ProcId::unique(
             frontend_addr.clone(),
-            "service".to_string()
+            "service",
         );
         let service_proc = Proc::configured(service_proc_id.clone(), router.boxed());
 
-        let local_proc_id = ProcId(
+        let local_proc_id = ProcId::unique(
             frontend_addr.clone(),
-            "local".to_string()
+            "local",
         );
         let local_proc = Proc::configured(local_proc_id.clone(), router.boxed());
 

--- a/docs/source/books/hyperactor-book/src/references/actor_id.md
+++ b/docs/source/books/hyperactor-book/src/references/actor_id.md
@@ -15,27 +15,27 @@ An `ActorId` uniquely identifies an actor within a proc. It combines the proc th
     Ord,
     Named
 )]
-pub struct ActorId(pub ProcId, pub String, pub usize);
+pub struct ActorId(ProcId, String, Index);
 ```
 - The first field is the actor's `ProcId`.
 - The second is the actor's name (used for grouping and logging).
-- The third is the pid, which distinguishes multiple instances with the same name.
+- The third is the pid (`Index`), which distinguishes multiple instances with the same name.
 
 ### Construction
 
-Construct an actor ID directly:
+Fields are private; use named constructors:
 ```rust
 use hyperactor::reference::{ActorId, ProcId};
 
 let addr = "tcp:127.0.0.1:8080".parse()?;
-let proc = ProcId(addr, "myproc".to_string());
-let actor = ActorId(proc, "worker".into(), 1);
+let proc = ProcId::with_name(addr, "myproc");
+let actor = ActorId::new(proc.clone(), "worker", 1);
 ```
 
 To refer to the root actor (the canonical instance), use:
 ```rust
 let root = ActorId::root(proc, "worker".into());
-// Equivalent to ActorId(proc, "worker".into(), 0)
+// Equivalent to ActorId::new(proc, "worker", 0)
 ```
 
 ### Methods

--- a/docs/source/books/hyperactor-book/src/references/port_id.md
+++ b/docs/source/books/hyperactor-book/src/references/port_id.md
@@ -15,24 +15,18 @@ A `PortId` identifies a specific port on a particular actor. Ports are the entry
     Ord,
     Named
 )]
-pub struct PortId(pub ActorId, pub u64);
+pub struct PortId(ActorId, u64);
 ```
 - The first field is the owning `ActorId`.
 - The second field is the port number (`u64`), typically derived from the message type’s registered port.
 
 ## Construction
 
+Fields are private; use a named constructor or derive from an `ActorId`:
 ```rust
 use hyperactor::reference::{PortId, ActorId};
 
-let port = PortId(actor, 42);
-```
-Or via the `id!` macro:
-```rust
-use hyperactor::id;
-
-let port = id!(training[0].logger[1][42]);
-// Equivalent to PortId(ActorId(...), 42)
+let port = PortId::new(actor.clone(), 42);
 ```
 You can also construct a PortId from an `ActorId` using `.port_id(...)`:
 ```rust
@@ -55,7 +49,7 @@ impl PortId {
 ## Traits
 
 `PortId` implements:
-- `Display` — formatted as `world[rank].actor[pid][port]`
-- `FromStr` — parses from strings like `"training[0].logger[1][42]"`
+- `Display` — formatted as `addr,proc_name,actor_name[pid][port]`
+- `FromStr` — parses from strings like `"tcp:[::1]:1234,myproc,logger[1][42]"`
 - `Ord`, `Eq`, `Hash` — usable as map keys or for dispatch
 - `Named` — supports reflection and typed messaging

--- a/docs/source/books/hyperactor-book/src/references/proc_id.md
+++ b/docs/source/books/hyperactor-book/src/references/proc_id.md
@@ -17,17 +17,20 @@ Procs are identified by a direct channel address and name:
     Ord,
     Named,
 )]
-pub struct ProcId(pub ChannelAddr, pub String);
+pub struct ProcId(ChannelAddr, String);
 ```
 
 ## Construction
 
-Construct a `ProcId` with a channel address and proc name:
+Construct a `ProcId` with a channel address and proc name. Fields are private; use a named constructor:
 ```rust
 use hyperactor::reference::ProcId;
 
 let addr = "tcp:127.0.0.1:8080".parse()?;
-let proc = ProcId(addr, "service".to_string());
+// `unique` appends an address hash to make the name globally unique:
+let proc = ProcId::unique(addr.clone(), "service");
+// `with_name` uses the name as-is (for deserialization or already-unique names):
+let proc = ProcId::with_name(addr, "service");
 ```
 
 See [Host](../procs/host.md) for how procs are used in the Host architecture.

--- a/docs/source/books/hyperactor-book/src/references/typed_refs.md
+++ b/docs/source/books/hyperactor-book/src/references/typed_refs.md
@@ -55,7 +55,7 @@ This allows the port to be sent across the network or passed into other messages
 pub struct PortRef<M> {
     port_id: PortId,
     reducer_spec: Option<ReducerSpec>,
-    reducer_opts: Option<ReducerOpts>,
+    streaming_opts: StreamingReducerOpts,
     phantom: PhantomData<M>,
     return_undeliverable: bool,
 }

--- a/docs/source/books/hyperactor-mesh-book/README.md
+++ b/docs/source/books/hyperactor-mesh-book/README.md
@@ -4,60 +4,16 @@ This is the development documentation for hyperactor-mesh, built using [`mdBook`
 
 ## Running the Book
 
-### On the **Server**
-
-To run the book on a remote server (e.g., `devgpu004`):
+Install [mdBook](https://rust-lang.github.io/mdBook/guide/installation.html), then:
 
 ```bash
-x2ssh devgpu004.rva5.facebook.com
-tmux new -s hyperactor-mesh-mdbook
-cd ~/fbsource/fbcode/scripts/shaynefletcher/hyperactor-mesh-book
+cd docs/source/books/hyperactor-mesh-book
 mdbook serve --port 3001
 ```
-Then detach with Ctrl+b, then d.
 
-### On the **Client**
-
-To access the remote book from your local browser:
-```bash
-autossh -M 0 -N -L 3001:localhost:3001 devgpu004.rva5.facebook.com
-```
-Then open http://localhost:3001 in your browser.
-
-**Note**: If you don’t have autossh installed, you can install it with:
-```bash
-brew install autossh
-```
+Open http://localhost:3001 in your browser.
 
 ### Notes
 
 - The source is located in src/, with structure defined in SUMMARY.md.
 - The book will auto-reload in the browser on edits.
-
-## Cleaning Up
-
-To shut down the book server:
-
-### Option 1: Reattach and stop
-
-```bash
-x2ssh devgpu004.rva5.facebook.com
-tmux attach -t hyperactor-mesh-mdbook
-```
-Inside the session:
-- Press Ctrl+C to stop mdbook serve
-- Then type exit to close the shell and terminate the tmux session
-
-### Option 2: Kill the session directly
-
-If you don’t want to reattach, you can kill the session from a new shell:
-```bash
-x2ssh devgpu004.rva5.facebook.com
-tmux kill-session -t hyperactor-mesh-mdbook
-```
-
-### Optional: View active tmux sessions
-```bash
-tmux ls
-```
-Use this to check whether the mdbook session is still running.

--- a/docs/source/books/hyperactor-mesh-book/src/SUMMARY.md
+++ b/docs/source/books/hyperactor-mesh-book/src/SUMMARY.md
@@ -6,7 +6,7 @@
       - [2. Process allocator & v0 bootstrap](meshes/bootstrapping-process-allocator.md)
       - [3. HostMesh from an allocation](meshes/bootstrapping-hostmesh-from-allocation.md)
       - [4. Doing real work (hosts → procs → actors)](meshes/bootstrapping-doing-real-work.md)
-      - [Boostrapping from Python](meshes/bootstrapping-from-python.md)
+      - [Bootstrapping from Python](meshes/bootstrapping-from-python.md)
   - [Host & agents (control plane & mux)](meshes/host-and-agents.md)
   - [Proc meshes & ProcAgent](meshes/proc-mesh-and-agent.md)
   - [Process-backed hosts: BootstrapProcManager](meshes/bootstrap-proc-manager.md)

--- a/docs/source/books/hyperactor-mesh-book/src/meshes/bootstrapping-appendix-canonical-test.md
+++ b/docs/source/books/hyperactor-mesh-book/src/meshes/bootstrapping-appendix-canonical-test.md
@@ -13,7 +13,6 @@ async fn bootstrap_canonical_simple() {
 
     // 1) Create a "root" direct-addressed proc.
     let proc = Proc::direct(ChannelTransport::Unix.any(), "root".to_string())
-        .await
         .unwrap();
 
     // 2) Create an actor instance we'll use to send and receive messages.

--- a/docs/source/books/hyperactor-mesh-book/src/meshes/bootstrapping-hostmesh-from-allocation.md
+++ b/docs/source/books/hyperactor-mesh-book/src/meshes/bootstrapping-hostmesh-from-allocation.md
@@ -22,7 +22,7 @@ This is the step that turns "I have OS processes that can run a proc" into "I ha
 The function is:
 
 ```rust
-// from hyperactor_mesh/src/v1/host_mesh.rs
+// from hyperactor_mesh/src/host_mesh.rs
 pub async fn allocate(
     cx: &impl context::Actor,
     alloc: Box<dyn Alloc + Send + Sync>,
@@ -43,7 +43,7 @@ So this function **consumes** an allocation; it doesn't spawn OS processes by it
 The first real work `HostMesh::allocate(...)` does is to **consume** the `Alloc` you handed it and turn it into a `ProcMesh`:
 
 ```rust
-// from hyperactor_mesh/src/v1/host_mesh.rs (`fn HostMesh::allocate`)
+// from hyperactor_mesh/src/host_mesh.rs (`fn HostMesh::allocate`)
 let transport = alloc.transport();
 let extent = alloc.extent().clone();
 let is_local = alloc.is_local();
@@ -131,7 +131,7 @@ what we mean concretely is:
 Right after turning the allocation into a `ProcMesh`, the code does:
 
 ```rust
-// from hyperactor_mesh/src/v1/host_mesh.rs `HostMesh::allocate()`
+// from hyperactor_mesh/src/host_mesh.rs `HostMesh::allocate()`
 let (mesh_agents, mut mesh_agents_rx) = cx.mailbox().open_port();
 let _trampoline_actor_mesh = proc_mesh
     .spawn::<HostMeshAgentProcMeshTrampoline>(
@@ -144,12 +144,12 @@ let _trampoline_actor_mesh = proc_mesh
 
 This is the key hop: we now have **one remote proc per rank**, but we want **one host per remote proc**. Rather than building the host from the parent, we send a tiny actor *to* each remote proc that will build the host *there*.
 
-The long doc comment above `HostMesh::allocate()` in `hyperactor_mesh/src/v1/host_mesh.rs` explains the pattern. The short version:
+The long doc comment above `HostMesh::allocate()` in `hyperactor_mesh/src/host_mesh.rs` explains the pattern. The short version:
 
 1. we open a port locally (`open_port()`) so that the remote side can send back "I'm your host, here is my agent";
 2. we ask **every proc in the proc-mesh** to spawn `HostMeshAgentProcMeshTrampoline`;
 3. that trampoline (running *in the remote proc*) does:
-   - `Host::serve(...)` in that process, using a `BootstrapProcManager`, so this host can later spawn procs as new OS children,
+   - `Host::new(...)` in that process, using a `BootstrapProcManager`, so this host can later spawn procs as new OS children,
    - `host.system_proc().spawn::<HostAgent>(...)` to put a `HostAgent` on the host's service proc,
    - and finally `send(mesh_agents_port, that_host_agent_ref)` back to us.
 
@@ -205,14 +205,12 @@ After this, the parent just waits on `mesh_agents_rx.recv()` once per rank (see 
 After spawning those trampolines, `HostMesh::allocate()` does:
 
 ```rust
-// from hyperactor_mesh/src/v1/host_mesh.rs `HostMesh::allocate()`
+// from hyperactor_mesh/src/host_mesh.rs `HostMesh::allocate()`
 let mut hosts = Vec::new();
 for _rank in 0..extent.num_ranks() {
     let mesh_agent = mesh_agents_rx.recv().await?;
 
-    let Some((addr, _)) = mesh_agent.actor_id().proc_id().as_direct() else {
-        return Err(...);
-    };
+    let addr = mesh_agent.actor_id().proc_id().addr();
 
     let host_ref = HostRef(addr.clone());
     if host_ref.mesh_agent() != mesh_agent {
@@ -226,7 +224,7 @@ That means:
 
 - it expects **exactly one** reply per rank
 - each reply is the remote host's agent
-- it checks that the agent is **direct-addressed** (host listens on a channel) and that the id matches what it would derive from the host address
+- it extracts the host address from the agent's proc id and checks that the id matches what it would derive from the host address
 
 And this line:
 ```rust
@@ -241,10 +239,10 @@ At the end of that loop we have a `Vec<HostRef>` — one per remote OS process w
 
 ### 3.5 What the trampoline actually does (remote side)
 
-This is the bit from `hyperactor_mesh/src/v1/host_mesh.rs` right after we opened the port and before we start collecting agents:
+This is the bit from `hyperactor_mesh/src/host_mesh.rs` right after we opened the port and before we start collecting agents:
 
 ```rust
-// from hyperactor_mesh/src/v1/host_mesh.rs `HostMesh::allocate()`
+// from hyperactor_mesh/src/host_mesh.rs `HostMesh::allocate()`
 let (mesh_agents, mut mesh_agents_rx) = cx.mailbox().open_port();
 let _trampoline_actor_mesh = proc_mesh
     .spawn::<HostMeshAgentProcMeshTrampoline>(
@@ -261,8 +259,8 @@ We've already said "we spawn a trampoline on every allocated proc," but here's w
    Remember: `proc_mesh.spawn::<...>(...)` sends a spawn to *each* of the procs that came from the allocator. So the code above is not running locally — it's telling each remote proc "please run this actor."
 
 2. **Its job is to finish turning ‘bare proc' into ‘host'**
-   At this point the remote OS process is only running a proc (the thing the allocator told it to start). That proc is reachable and can run actors, but it is not yet a *host* in the v1 sense. The trampoline actor's whole purpose is:
-   - call `Host::serve(...)` **inside that remote process**
+   At this point the remote OS process is only running a proc (the thing the allocator told it to start). That proc is reachable and can run actors, but it is not yet a *host*. The trampoline actor's whole purpose is:
+   - call `Host::new(...)` **inside that remote process**
    - give it a `BootstrapProcManager` so it can later spawn *more* OS processes for procs
    - spawn the real `HostAgent` on the host's service proc
    - report back to the parent with an `ActorRef<HostAgent>`
@@ -288,7 +286,7 @@ So the trampoline is the "last mile" that runs *inside the child process* and up
 
 ### 3.6 Assemble the `HostMesh`
 
-At this point in `hyperactor_mesh/src/v1/host_mesh.rs` (inside `HostMesh::allocate(...)`) we've already:
+At this point in `hyperactor_mesh/src/host_mesh.rs` (inside `HostMesh::allocate(...)`) we've already:
 
 - turned the `Alloc` into a `ProcMesh` (one proc per rank, running in the OS processes the allocator started),
 - spawned a `HostMeshAgentProcMeshTrampoline` on each of those procs,
@@ -299,7 +297,7 @@ At this point in `hyperactor_mesh/src/v1/host_mesh.rs` (inside `HostMesh::alloca
 The function then just packages all of that into an owned `HostMesh`:
 
 ```rust
-// from hyperactor_mesh/src/v1/host_mesh.rs `HostMesh::allocate(...)`
+// from hyperactor_mesh/src/host_mesh.rs `HostMesh::allocate(...)`
 Ok(Self {
     name: name.clone(),
     extent: extent.clone(),

--- a/docs/source/books/hyperactor-mesh-book/src/meshes/bootstrapping-proc-and-instance.md
+++ b/docs/source/books/hyperactor-mesh-book/src/meshes/bootstrapping-proc-and-instance.md
@@ -4,7 +4,6 @@ We begin in a process that can already run hyperactor code and create an instanc
 
 ```rust
 let proc = Proc::direct(ChannelTransport::Unix.any(), "root".to_string())
-    .await
     .unwrap();
 let (instance, _handle) = proc.instance("client").unwrap();
 ```
@@ -23,7 +22,7 @@ Under the hood it does (cf. `Proc::direct` in the source):
    - a receiver for incoming messages.
 
 2. **Name the proc**
-   It builds a `ProcId(bound_addr, name)`. That's just how this proc identifies itself to the rest of the world: "I am this channel, and my human-ish name is `root`."
+   It builds a `ProcId::unique(bound_addr, name)`. That's just how this proc identifies itself to the rest of the world: "I am this channel, and my human-ish name is `root`."
 
 3. **Create a proc with a dial-able forwarder**
    It does `Proc::configured(proc_id, DialMailboxRouter::new().into_boxed())`. That "dial mailbox router" is the bit that lets this proc send to other procs later — it knows how to connect out.

--- a/docs/source/books/hyperactor-mesh-book/src/meshes/bootstrapping-process-allocator.md
+++ b/docs/source/books/hyperactor-mesh-book/src/meshes/bootstrapping-process-allocator.md
@@ -2,7 +2,7 @@
 
 ## 2. Get something that can spawn processes
 
-In the canonical v1 flow we need a *thing in the parent* that can say "start another OS process that will come up as a hyperactor proc/host and talk back to me." In this codebase that "thing" is the **process allocator**, implemented as `hyperactor::alloc::ProcessAllocator` defined in `hyperactor/src/process.rs`.
+In the canonical flow we need a *thing in the parent* that can say "start another OS process that will come up as a hyperactor proc/host and talk back to me." In this codebase that "thing" is the **process allocator**, implemented as `hyperactor_mesh::alloc::ProcessAllocator` defined in `hyperactor_mesh/src/alloc/process.rs`.
 
 In the unit-test version (`bootstrap_canonical_simple`) it looks like this:
 

--- a/docs/source/books/hyperactor-mesh-book/src/meshes/host-and-agents.md
+++ b/docs/source/books/hyperactor-mesh-book/src/meshes/host-and-agents.md
@@ -65,7 +65,7 @@ So the host-mesh agent can receive a "create proc" request over the mesh protoco
 At the control plane we have the mesh-facing actor:
 
 ```rust
-// hyperactor_mesh/src/v1/host_mesh/mesh_agent.rs
+// hyperactor_mesh/src/host_mesh/host_agent.rs
 pub struct HostAgent {
   host: Option<HostAgentMode>,
   created: HashMap<Name, ProcCreationState>,
@@ -208,7 +208,7 @@ What the `HostAgent` actually does matches this shape:
 
 Here is the bit of real code that does exactly that (abridged to just the decision):
 ```rust
-// from hyperactor_mesh/src/v1/host_mesh/mesh_agent.rs (`impl Handler<resource::CreateOrUpdate<ProcSpec>> for HostAgent`)
+// from hyperactor_mesh/src/host_mesh/host_agent.rs (`impl Handler<resource::CreateOrUpdate<ProcSpec>> for HostAgent`)
 
 let created = match host {
     HostAgentMode::Process(host) => {

--- a/docs/source/examples/distributed_tensors.py
+++ b/docs/source/examples/distributed_tensors.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env -S grimaldi --kernel monarch_demo_local
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 # All rights reserved.
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
-
-# FILE_UID: f083db77-6303-4fbf-a9ec-8be986f0926a
-# NOTEBOOK_NUMBER: N6185324 (8543474375772761)
 
 """
 Distributed Tensors in Monarch
@@ -250,7 +246,6 @@ def simulate():
         simulator.display()
 
 
-# Make sure pop-ups are enabled in your browser for internalfb.com
 simulate()
 
 # %%
@@ -265,13 +260,15 @@ main = monarch.get_active_stream()
 comms = monarch.Stream("comms")
 
 # %%
-# <img src="https://lookaside.internalfb.com/intern/pixelcloudnew/asset/?id=468246752388474" width=500>
+# The ``main`` stream runs computation sequentially, while the ``comms`` stream
+# runs communication (e.g. allreduce) in parallel on the same device.
 
 # %%
-# To use a tensor from one stream on another we borrow it. The borrow API ensures determinstic memory usage,
+# To use a tensor from one stream on another we borrow it. The borrow API ensures deterministic memory usage,
 # and eliminates the race conditions in the torch.cuda.stream API.
 #
-# <img src="https://lookaside.internalfb.com/intern/pixelcloudnew/asset/?id=556746733733298" width=500>
+# A borrow transfers a tensor from one stream to another. The original stream
+# cannot use the tensor until ``borrow.drop()`` is called, ensuring no races.
 
 # %%
 # The DDP example again, but using multiple streams.
@@ -304,17 +301,13 @@ simulate()
 
 # %%
 # The simulation result showed the results did not overlap much
-# due to wherethe borrow.drop was placed.
-#
-# <img src="https://lookaside.internalfb.com/intern/pixelcloudnew/asset/?id=1282606659410255" width=500>
+# due to where the borrow.drop was placed. The reduce on the comms stream
+# completed before the next backward step started on the main stream.
 
 # %%
-# The goal is to get overlap like so:
-#
-# <img src="https://lookaside.internalfb.com/intern/pixelcloudnew/asset/?id=1110575440645591" width=500>
-#
-# We can achieve this by ending the borrow after the grad step but before
-# we update the param.
+# The goal is to overlap the reduce (comms stream) with the next backward
+# step (main stream). We can achieve this by ending the borrow after the
+# grad step but before we update the param.
 
 
 def train(model, input, target):

--- a/docs/source/examples/getting_started.py
+++ b/docs/source/examples/getting_started.py
@@ -189,9 +189,12 @@ print(trainers.step.call().get())
 # ---------------------
 # Since we're talking about having multiple hosts now, it's worth briefly covering how Monarch handles distributed logging.
 # User logs from a Monarch job are routed to stdout and stderr of the corresponding process.
-# In distributed runs, you can stream all worker logs to the client and aggregate them to reduce verbosity:
+# In distributed runs, you can stream all worker logs to the client and aggregate them to reduce verbosity.
+# ``logging_option`` is an async method, so it must be awaited:
 
-procs.logging_option(stream_to_client=True, aggregate_window_sec=3)
+import asyncio
+
+asyncio.run(procs.logging_option(stream_to_client=True, aggregate_window_sec=3))
 
 
 # %%
@@ -512,8 +515,8 @@ print(c.get_context_info.call().get())
 
 
 # %%
-# ranks are always multidimension and reported as dictionaries of the dimension names
-# and the point within that dimension.
+# Ranks are always multidimensional and reported as Point objects (dict-like mappings)
+# of the dimension names to the index within that dimension.
 
 
 # %%
@@ -541,11 +544,11 @@ with trainer_procs.activate():
 # ================================
 # It is sometimes useful to establish direct channels between two points,
 # or forward the handling of some messages from one actor to another.
-# To enable this, all messaging in monarch is build out of port objects.
+# To enable this, all messaging in monarch is built out of port objects.
 
 # %%
 # An actor can create a new channel, which provides a Port for sending and
-# a PortReceiver for receiving messages. The Port object can then be send
+# a PortReceiver for receiving messages. The Port object can then be sent
 # to any endpoint.
 
 from monarch.actor import Channel, Port

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -25,7 +25,7 @@ Monarch code imperatively describes how to create processes and actors using a s
     # create the trainers
     trainers = training_procs.spawn("trainers", Trainer)
 
-    # tell all the trainers to to take a step
+    # tell all the trainers to take a step
     fut = trainers.train.call(step=0)
 
     # wait for all trainers to complete
@@ -45,7 +45,7 @@ Note: Monarch is currently only supported on Linux systems
 Here are some suggested steps to get started with Monarch:
 
 1. **Installation**: Check out the [Install guide](installation) for getting monarch installed.
-2. **Getting Started**: The [getting started](./generated/examples/getting_started) provides an introduction to monarchs core API
+2. **Getting Started**: The [getting started](./generated/examples/getting_started) provides an introduction to Monarch's core API
 3. **Explore Examples**: Review the [Examples](./generated/examples/index) to see Monarch in action
 4. **Dive Deeper**: Explore the API Documentation for more detailed information:
     - [Python API](api/index)

--- a/docs/source/rust-api.md
+++ b/docs/source/rust-api.md
@@ -11,25 +11,32 @@ The Monarch project consists of several Rust crates, each with specialized funct
 ### Core Framework
 - <a id="link-hyperactor" href="rust-api/hyperactor/index.html">**hyperactor**</a><span id="desc-hyperactor"> - Core actor framework for distributed computing</span>
 - <a id="link-hyperactor_macros" href="rust-api/hyperactor_macros/index.html">**hyperactor_macros**</a><span id="desc-hyperactor_macros"> - Procedural macros for the hyperactor framework</span>
-- <a id="link-hyperactor_multiprocess" href="rust-api/hyperactor_multiprocess/index.html">**hyperactor_multiprocess**</a><span id="desc-hyperactor_multiprocess"> - Multi-process support for hyperactor</span>
 - <a id="link-hyperactor_mesh" href="rust-api/hyperactor_mesh/index.html">**hyperactor_mesh**</a><span id="desc-hyperactor_mesh"> - Mesh networking for hyperactor clusters</span>
 - <a id="link-hyperactor_mesh_macros" href="rust-api/hyperactor_mesh_macros/index.html">**hyperactor_mesh_macros**</a><span id="desc-hyperactor_mesh_macros"> - Macros for hyperactor mesh functionality</span>
+- <a id="link-hyperactor_config" href="rust-api/hyperactor_config/index.html">**hyperactor_config**</a><span id="desc-hyperactor_config"> - Configuration framework for hyperactor</span>
+- <a id="link-hyperactor_telemetry" href="rust-api/hyperactor_telemetry/index.html">**hyperactor_telemetry**</a><span id="desc-hyperactor_telemetry"> - Telemetry and monitoring for hyperactor</span>
 
 ### CUDA and GPU Computing
-- <a id="link-cuda-sys" href="rust-api/cuda_sys/index.html">**cuda-sys**</a><span id="desc-cuda-sys"> - Low-level CUDA FFI bindings</span>
 - <a id="link-nccl-sys" href="rust-api/nccl_sys/index.html">**nccl-sys**</a><span id="desc-nccl-sys"> - NCCL (NVIDIA Collective Communications Library) bindings</span>
 - <a id="link-torch-sys2" href="rust-api/torch_sys2/index.html">**torch-sys2**</a><span id="desc-torch-sys2"> - Simplified PyTorch Python API bindings for Rust</span>
+- <a id="link-torch-sys-cuda" href="rust-api/torch_sys_cuda/index.html">**torch-sys-cuda**</a><span id="desc-torch-sys-cuda"> - CUDA-specific PyTorch FFI bindings</span>
 - <a id="link-monarch_tensor_worker" href="rust-api/monarch_tensor_worker/index.html">**monarch_tensor_worker**</a><span id="desc-monarch_tensor_worker"> - High-performance tensor processing worker</span>
 
 ### RDMA and High-Performance Networking
 - <a id="link-monarch_rdma" href="rust-api/monarch_rdma/index.html">**monarch_rdma**</a><span id="desc-monarch_rdma"> - Remote Direct Memory Access (RDMA) support for high-speed networking</span>
 - <a id="link-rdmaxcel-sys" href="rust-api/rdmaxcel_sys/index.html">**rdmaxcel-sys**</a><span id="desc-rdmaxcel-sys"> - Low-level RDMA acceleration bindings</span>
 
-### System and Utilities
-- <a id="link-controller" href="rust-api/controller/index.html">**controller**</a><span id="desc-controller"> - System controller and orchestration</span>
-- <a id="link-hyper" href="rust-api/hyper/index.html">**hyper**</a><span id="desc-hyper"> - HTTP utilities and web service support</span>
-- <a id="link-ndslice" href="rust-api/ndslice/index.html">**ndslice**</a><span id="desc-ndslice"> - N-dimensional array slicing and manipulation</span>
+### Monarch Python Integration
+- <a id="link-monarch_hyperactor" href="rust-api/monarch_hyperactor/index.html">**monarch_hyperactor**</a><span id="desc-monarch_hyperactor"> - Python bindings bridging hyperactor to Monarch's Python API</span>
 - <a id="link-monarch_extension" href="rust-api/monarch_extension/index.html">**monarch_extension**</a><span id="desc-monarch_extension"> - Python extension module for Monarch functionality</span>
+- <a id="link-monarch_messages" href="rust-api/monarch_messages/index.html">**monarch_messages**</a><span id="desc-monarch_messages"> - Message types for Monarch actor communication</span>
+
+### System and Utilities
+- <a id="link-hyper" href="rust-api/hyper/index.html">**hyper**</a><span id="desc-hyper"> - Mesh admin CLI and HTTP utilities</span>
+- <a id="link-ndslice" href="rust-api/ndslice/index.html">**ndslice**</a><span id="desc-ndslice"> - N-dimensional array slicing and manipulation</span>
+- <a id="link-typeuri" href="rust-api/typeuri/index.html">**typeuri**</a><span id="desc-typeuri"> - Type URI system for message serialization</span>
+- <a id="link-wirevalue" href="rust-api/wirevalue/index.html">**wirevalue**</a><span id="desc-wirevalue"> - Wire-level value serialization for actor messages</span>
+- <a id="link-serde_multipart" href="rust-api/serde_multipart/index.html">**serde_multipart**</a><span id="desc-serde_multipart"> - Zero-copy multipart serialization</span>
 
 <!-- Static links are shown by default since documentation exists -->
 


### PR DESCRIPTION
Python docs & API RST:
- Fix context().proc -> context().actor_instance.proc (Context has no .proc)
- Fix ValueMesh.from_list() -> ValueMesh(shape, values) (from_list doesn't exist)
- Fix MeshFailure.is_recoverable() (doesn't exist), use .report()/.mesh_name
- Fix stream() example: returns Iterator[Future], not async iterable
- Fix PortRef reducer_opts -> streaming_opts: StreamingReducerOpts
- Add missing public APIs: this_proc, MeshFailure, ProcessJob, get_rdma_backend
- Remove nonexistent Rust crates from rust-api.md (hyperactor_multiprocess, cuda-sys, controller); add real ones (hyperactor_config, hyperactor_telemetry, monarch_hyperactor, typeuri, wirevalue, serde_multipart, etc.)
- Typo fixes throughout

Examples:
- Fix logging_option() called without await (async method, was silently no-op)
- Remove internal Meta URLs (lookaside.internalfb.com) and grimaldi shebang from distributed_tensors.py; replace with text descriptions
- Typo fixes (build->built, send->sent, determinstic, wherethe)

Hyperactor book:
- Fix ProcId/ActorId/PortId: fields are private, use named constructors (ProcId::unique/with_name, ActorId::new, PortId::new)
- Remove id! macro references (macro was deleted)
- Fix PortId Display format (old world[rank] format from removed ProcId::Ranked)
- Remove Sim transport (simnet module was deleted)
- Fix Signal enum: DrainAndStop/Stop now take String reason
- Fix MeshAgent -> HostAgent rename

Hyperactor-mesh book:
- Replace all v1/ module paths (v1 directory removed)
- Fix ProcId::as_direct() -> ProcId::addr() (ProcId is now always direct)
- Fix Proc::direct() from async to sync (remove .await)
- Fix ProcessAllocator crate path: hyperactor -> hyperactor_mesh
- Fix Host::serve() -> Host::new()
- Replace internal Meta SSH/fbsource paths in README with generic instructions
- Fix "Boostrapping" typo