### PR TITLE
Add chunked_fuse: read-only FUSE filesystem for packed data (#3103)

### DIFF
--- a/monarch_extension/Cargo.toml
+++ b/monarch_extension/Cargo.toml
@@ -17,6 +17,8 @@ crate-type = ["cdylib"]
 anyhow = "1.0.102"
 async-trait = "0.1.86"
 bincode = "1.3.3"
+bytes = { version = "1.11.1", features = ["serde"] }
+fuse3 = { version = "0.8.1", features = ["tokio-runtime", "unprivileged"] }
 futures = { version = "0.3.31", features = ["async-await", "compat"] }
 hyperactor = { version = "0.0.0", path = "../hyperactor" }
 hyperactor_mesh = { version = "0.0.0", path = "../hyperactor_mesh" }
@@ -35,6 +37,7 @@ rdmaxcel-sys = { path = "../rdmaxcel-sys", optional = true }
 serde = { version = "1.0.219", features = ["derive", "rc"] }
 tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
 torch-sys-cuda = { version = "0.0.0", path = "../torch-sys-cuda", optional = true }
+tracing = { version = "0.1.41", features = ["attributes", "valuable"] }
 wirevalue = { version = "0.0.0", path = "../wirevalue" }
 xxhash-rust = { version = "0.8.15", features = ["xxh3", "xxh64"] }
 

--- a/monarch_extension/src/chunked_fuse.rs
+++ b/monarch_extension/src/chunked_fuse.rs
@@ -1,0 +1,687 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+//! Read-only FUSE filesystem backed by packed metadata and byte chunks.
+//!
+//! Replaces the Python fusepy-based ChunkedFS with a Rust implementation
+//! using the `fuse3` crate (libfuse3, async/tokio). Exposed to Python
+//! via PyO3.
+
+use std::collections::HashMap;
+use std::ffi::OsStr;
+use std::ffi::OsString;
+use std::num::NonZeroU32;
+use std::time::Duration;
+use std::time::SystemTime;
+use std::time::UNIX_EPOCH;
+
+use bytes::Bytes;
+use fuse3::Errno;
+use fuse3::FileType;
+use fuse3::MountOptions;
+use fuse3::Result as FuseResult;
+use fuse3::path::prelude::*;
+use futures::stream;
+use pyo3::exceptions::PyRuntimeError;
+use pyo3::prelude::*;
+use pyo3::types::PyDict;
+use tokio::sync::oneshot;
+use tracing::warn;
+
+const TTL: Duration = Duration::from_secs(3600);
+
+enum FsEntry {
+    Dir {
+        attr: FileAttr,
+        children: Vec<String>,
+    },
+    File {
+        attr: FileAttr,
+        global_offset: usize,
+        file_len: usize,
+    },
+    Symlink {
+        attr: FileAttr,
+        link_target: OsString,
+    },
+}
+
+impl FsEntry {
+    fn attr(&self) -> &FileAttr {
+        match self {
+            FsEntry::Dir { attr, .. } => attr,
+            FsEntry::File { attr, .. } => attr,
+            FsEntry::Symlink { attr, .. } => attr,
+        }
+    }
+}
+
+fn f64_to_system_time(ts: f64) -> SystemTime {
+    if ts >= 0.0 {
+        UNIX_EPOCH + Duration::from_secs_f64(ts)
+    } else {
+        UNIX_EPOCH
+    }
+}
+
+fn required_key<'py, T: pyo3::FromPyObject<'py>>(
+    dict: &Bound<'py, PyDict>,
+    key: &str,
+) -> PyResult<T> {
+    dict.get_item(key)?
+        .ok_or_else(|| PyRuntimeError::new_err(format!("missing required attr key: {key}")))?
+        .extract()
+}
+
+fn extract_attr(dict: &Bound<'_, PyDict>, kind: FileType) -> PyResult<FileAttr> {
+    let st_size: u64 = required_key(dict, "st_size")?;
+    Ok(FileAttr {
+        size: st_size,
+        blocks: st_size.div_ceil(512),
+        atime: f64_to_system_time(required_key(dict, "st_atime")?),
+        mtime: f64_to_system_time(required_key(dict, "st_mtime")?),
+        ctime: f64_to_system_time(required_key(dict, "st_ctime")?),
+        kind,
+        perm: (required_key::<u32>(dict, "st_mode")? & 0o7777) as u16,
+        nlink: required_key(dict, "st_nlink")?,
+        uid: required_key(dict, "st_uid")?,
+        gid: required_key(dict, "st_gid")?,
+        rdev: 0,
+        blksize: 4096,
+    })
+}
+
+fn extract_metadata(dict: &Bound<'_, PyDict>) -> PyResult<HashMap<OsString, FsEntry>> {
+    let mut entries = HashMap::with_capacity(dict.len());
+    for (key, value) in dict.iter() {
+        let path: String = key.extract()?;
+        let entry_dict: &Bound<'_, PyDict> = value.downcast()?;
+        let attr_obj = entry_dict.get_item("attr")?.ok_or_else(|| {
+            PyRuntimeError::new_err(format!("missing 'attr' key for path: {path}"))
+        })?;
+        let attr_dict: &Bound<'_, PyDict> = attr_obj.downcast()?;
+
+        let fs_entry = if let Some(link_target) = entry_dict.get_item("link_target")? {
+            let target: String = link_target.extract()?;
+            FsEntry::Symlink {
+                attr: extract_attr(attr_dict, FileType::Symlink)?,
+                link_target: OsString::from(target),
+            }
+        } else if let Some(children_obj) = entry_dict.get_item("children")? {
+            let children: Vec<String> = children_obj.extract()?;
+            FsEntry::Dir {
+                attr: extract_attr(attr_dict, FileType::Directory)?,
+                children,
+            }
+        } else {
+            let global_offset: usize = entry_dict
+                .get_item("global_offset")?
+                .map(|v| v.extract())
+                .transpose()?
+                .unwrap_or(0);
+            let file_len: usize = entry_dict
+                .get_item("file_len")?
+                .map(|v| v.extract())
+                .transpose()?
+                .unwrap_or(0);
+            FsEntry::File {
+                attr: extract_attr(attr_dict, FileType::RegularFile)?,
+                global_offset,
+                file_len,
+            }
+        };
+        entries.insert(OsString::from(path), fs_entry);
+    }
+    Ok(entries)
+}
+
+// --- FUSE filesystem ---
+
+struct ChunkedFuseFs {
+    metadata: HashMap<OsString, FsEntry>,
+    chunks: Vec<Bytes>,
+    chunk_size: usize,
+}
+
+impl ChunkedFuseFs {
+    fn lookup_entry(&self, path: &OsStr) -> Option<&FsEntry> {
+        self.metadata.get(path)
+    }
+
+    fn read_data(
+        &self,
+        global_offset: usize,
+        file_len: usize,
+        offset: u64,
+        size: u32,
+    ) -> Result<Bytes, libc::c_int> {
+        let offset = offset as usize;
+        if offset >= file_len {
+            return Ok(Bytes::new());
+        }
+        let len = std::cmp::min(size as usize, file_len - offset);
+        let start = global_offset + offset;
+        let end = start + len;
+
+        let chunk_size = self.chunk_size;
+        let start_chunk = start / chunk_size;
+        let end_chunk = (end.saturating_sub(1)) / chunk_size;
+
+        if start_chunk == end_chunk && start_chunk < self.chunks.len() {
+            // Fast path: single chunk
+            let chunk_offset = start % chunk_size;
+            Ok(self.chunks[start_chunk].slice(chunk_offset..chunk_offset + len))
+        } else {
+            // Multi-chunk: assemble
+            let mut buf = Vec::with_capacity(len);
+            let mut pos = start;
+            while pos < end {
+                let ci = pos / chunk_size;
+                if ci >= self.chunks.len() {
+                    break;
+                }
+                let off_in_chunk = pos % chunk_size;
+                let avail = self.chunks[ci].len() - off_in_chunk;
+                let take = std::cmp::min(avail, end - pos);
+                buf.extend_from_slice(&self.chunks[ci][off_in_chunk..off_in_chunk + take]);
+                pos += take;
+            }
+            if buf.len() != len {
+                warn!(
+                    "multi-chunk read: expected {len} bytes but assembled {}, \
+                     chunks may be truncated or corrupted",
+                    buf.len()
+                );
+                return Err(libc::EIO);
+            }
+            Ok(Bytes::from(buf))
+        }
+    }
+
+    fn join_path(parent: &OsStr, name: &OsStr) -> OsString {
+        let parent_s = parent.to_string_lossy();
+        let name_s = name.to_string_lossy();
+        if parent_s == "/" {
+            OsString::from(format!("/{name_s}"))
+        } else {
+            OsString::from(format!("{parent_s}/{name_s}"))
+        }
+    }
+
+    fn parent_path(path: &OsStr) -> OsString {
+        let s = path.to_string_lossy();
+        match s.rfind('/') {
+            Some(0) | None => OsString::from("/"),
+            Some(i) => OsString::from(&s[..i]),
+        }
+    }
+}
+
+impl PathFilesystem for ChunkedFuseFs {
+    type DirEntryStream<'a> = stream::Iter<std::vec::IntoIter<FuseResult<DirectoryEntry>>>;
+    type DirEntryPlusStream<'a> = stream::Iter<std::vec::IntoIter<FuseResult<DirectoryEntryPlus>>>;
+
+    async fn init(&self, _req: Request) -> FuseResult<ReplyInit> {
+        Ok(ReplyInit {
+            max_write: NonZeroU32::new(16 * 1024).expect("16KB is non-zero"),
+        })
+    }
+
+    async fn destroy(&self, _req: Request) {}
+
+    async fn lookup(&self, _req: Request, parent: &OsStr, name: &OsStr) -> FuseResult<ReplyEntry> {
+        let path = Self::join_path(parent, name);
+        let entry = self.lookup_entry(&path).ok_or_else(Errno::new_not_exist)?;
+        Ok(ReplyEntry {
+            ttl: TTL,
+            attr: *entry.attr(),
+        })
+    }
+
+    async fn getattr(
+        &self,
+        _req: Request,
+        path: Option<&OsStr>,
+        _fh: Option<u64>,
+        _flags: u32,
+    ) -> FuseResult<ReplyAttr> {
+        let path = path.ok_or_else(Errno::new_not_exist)?;
+        let entry = self.lookup_entry(path).ok_or_else(Errno::new_not_exist)?;
+        Ok(ReplyAttr {
+            ttl: TTL,
+            attr: *entry.attr(),
+        })
+    }
+
+    async fn readlink(&self, _req: Request, path: &OsStr) -> FuseResult<ReplyData> {
+        let entry = self.lookup_entry(path).ok_or_else(Errno::new_not_exist)?;
+        match entry {
+            FsEntry::Symlink { link_target, .. } => Ok(ReplyData {
+                data: Bytes::copy_from_slice(link_target.as_encoded_bytes()),
+            }),
+            _ => Err(libc::EINVAL.into()),
+        }
+    }
+
+    async fn open(&self, _req: Request, path: &OsStr, flags: u32) -> FuseResult<ReplyOpen> {
+        let entry = self.lookup_entry(path).ok_or_else(Errno::new_not_exist)?;
+        if matches!(entry, FsEntry::Dir { .. }) {
+            return Err(Errno::new_is_dir());
+        }
+        Ok(ReplyOpen { fh: 0, flags })
+    }
+
+    async fn read(
+        &self,
+        _req: Request,
+        path: Option<&OsStr>,
+        _fh: u64,
+        offset: u64,
+        size: u32,
+    ) -> FuseResult<ReplyData> {
+        let path = path.ok_or_else(Errno::new_not_exist)?;
+        let entry = self.lookup_entry(path).ok_or_else(Errno::new_not_exist)?;
+        match entry {
+            FsEntry::File {
+                global_offset,
+                file_len,
+                ..
+            } => {
+                let data = self
+                    .read_data(*global_offset, *file_len, offset, size)
+                    .map_err(Errno::from)?;
+                Ok(ReplyData { data })
+            }
+            _ => Err(libc::EINVAL.into()),
+        }
+    }
+
+    async fn opendir(&self, _req: Request, path: &OsStr, flags: u32) -> FuseResult<ReplyOpen> {
+        let entry = self.lookup_entry(path).ok_or_else(Errno::new_not_exist)?;
+        if !matches!(entry, FsEntry::Dir { .. }) {
+            return Err(Errno::new_is_not_dir());
+        }
+        Ok(ReplyOpen { fh: 0, flags })
+    }
+
+    async fn readdir<'a>(
+        &'a self,
+        _req: Request,
+        parent: &'a OsStr,
+        _fh: u64,
+        offset: i64,
+    ) -> FuseResult<ReplyDirectory<Self::DirEntryStream<'a>>> {
+        let entry = self.lookup_entry(parent).ok_or_else(Errno::new_not_exist)?;
+        let children = match entry {
+            FsEntry::Dir { children, .. } => children,
+            _ => return Err(Errno::new_is_not_dir()),
+        };
+
+        let offset = offset as u64;
+        let mut entries: Vec<FuseResult<DirectoryEntry>> = Vec::new();
+        let mut idx: u64 = 1;
+
+        if offset < idx {
+            entries.push(Ok(DirectoryEntry {
+                kind: FileType::Directory,
+                name: OsString::from("."),
+                offset: idx as i64,
+            }));
+        }
+        idx += 1;
+
+        if offset < idx {
+            entries.push(Ok(DirectoryEntry {
+                kind: FileType::Directory,
+                name: OsString::from(".."),
+                offset: idx as i64,
+            }));
+        }
+        idx += 1;
+
+        for child_name in children {
+            if offset < idx {
+                let child_path = Self::join_path(parent, OsStr::new(child_name));
+                if let Some(child_entry) = self.lookup_entry(&child_path) {
+                    entries.push(Ok(DirectoryEntry {
+                        kind: child_entry.attr().kind,
+                        name: OsString::from(child_name),
+                        offset: idx as i64,
+                    }));
+                }
+            }
+            idx += 1;
+        }
+
+        Ok(ReplyDirectory {
+            entries: stream::iter(entries),
+        })
+    }
+
+    async fn readdirplus<'a>(
+        &'a self,
+        _req: Request,
+        parent: &'a OsStr,
+        _fh: u64,
+        offset: u64,
+        _lock_owner: u64,
+    ) -> FuseResult<ReplyDirectoryPlus<Self::DirEntryPlusStream<'a>>> {
+        let entry = self.lookup_entry(parent).ok_or_else(Errno::new_not_exist)?;
+        let children = match entry {
+            FsEntry::Dir { children, .. } => children,
+            _ => return Err(Errno::new_is_not_dir()),
+        };
+
+        let mut entries: Vec<FuseResult<DirectoryEntryPlus>> = Vec::new();
+        let mut idx: u64 = 1;
+
+        // "." entry
+        if offset < idx {
+            entries.push(Ok(DirectoryEntryPlus {
+                kind: FileType::Directory,
+                name: OsString::from("."),
+                offset: idx as i64,
+                attr: *entry.attr(),
+                entry_ttl: TTL,
+                attr_ttl: TTL,
+            }));
+        }
+        idx += 1;
+
+        // ".." entry
+        if offset < idx {
+            let parent_key = Self::parent_path(parent);
+            let dotdot_attr = match self.lookup_entry(&parent_key) {
+                Some(e) => *e.attr(),
+                None => {
+                    warn!(
+                        "readdirplus: parent path {:?} not found in metadata, \
+                         falling back to current dir attrs",
+                        parent_key
+                    );
+                    *entry.attr()
+                }
+            };
+            entries.push(Ok(DirectoryEntryPlus {
+                kind: FileType::Directory,
+                name: OsString::from(".."),
+                offset: idx as i64,
+                attr: dotdot_attr,
+                entry_ttl: TTL,
+                attr_ttl: TTL,
+            }));
+        }
+        idx += 1;
+
+        for child_name in children {
+            if offset < idx {
+                let child_path = Self::join_path(parent, OsStr::new(child_name));
+                if let Some(child_entry) = self.lookup_entry(&child_path) {
+                    entries.push(Ok(DirectoryEntryPlus {
+                        kind: child_entry.attr().kind,
+                        name: OsString::from(child_name),
+                        offset: idx as i64,
+                        attr: *child_entry.attr(),
+                        entry_ttl: TTL,
+                        attr_ttl: TTL,
+                    }));
+                }
+            }
+            idx += 1;
+        }
+
+        Ok(ReplyDirectoryPlus {
+            entries: stream::iter(entries),
+        })
+    }
+
+    async fn access(&self, _req: Request, path: &OsStr, _mask: u32) -> FuseResult<()> {
+        if self.lookup_entry(path).is_some() {
+            Ok(())
+        } else {
+            Err(Errno::new_not_exist())
+        }
+    }
+
+    async fn release(
+        &self,
+        _req: Request,
+        _path: Option<&OsStr>,
+        _fh: u64,
+        _flags: u32,
+        _lock_owner: u64,
+        _flush: bool,
+    ) -> FuseResult<()> {
+        Ok(())
+    }
+
+    async fn flush(
+        &self,
+        _req: Request,
+        _path: Option<&OsStr>,
+        _fh: u64,
+        _lock_owner: u64,
+    ) -> FuseResult<()> {
+        Ok(())
+    }
+
+    async fn fsync(
+        &self,
+        _req: Request,
+        _path: Option<&OsStr>,
+        _fh: u64,
+        _datasync: bool,
+    ) -> FuseResult<()> {
+        Ok(())
+    }
+}
+
+// --- PyO3 bindings ---
+
+/// Handle to a running FUSE mount. Call `unmount()` to stop it.
+#[pyclass(
+    name = "FuseMountHandle",
+    module = "monarch._rust_bindings.monarch_extension.chunked_fuse"
+)]
+struct PyMountHandle {
+    unmount_tx: Option<oneshot::Sender<()>>,
+    mount_point: String,
+}
+
+#[pymethods]
+impl PyMountHandle {
+    /// Unmount the FUSE filesystem.
+    ///
+    /// Cleanup of the background FUSE session task is asynchronous: this
+    /// method returns once `fusermount3 -u` completes, but the tokio task
+    /// may still be winding down.
+    fn unmount(&mut self, py: Python<'_>) -> PyResult<()> {
+        if self.unmount_tx.take().is_none() {
+            return Ok(());
+        }
+        let mount_point = self.mount_point.clone();
+        py.detach(|| {
+            match std::process::Command::new("fusermount3")
+                .arg("-u")
+                .arg(&mount_point)
+                .output()
+            {
+                Ok(o) if !o.status.success() => {
+                    let stderr = String::from_utf8_lossy(&o.stderr);
+                    Err(PyRuntimeError::new_err(format!(
+                        "fusermount3 -u {mount_point} failed: {stderr}"
+                    )))
+                }
+                Err(e) => Err(PyRuntimeError::new_err(format!(
+                    "failed to run fusermount3: {e}"
+                ))),
+                _ => Ok(()),
+            }
+        })
+    }
+}
+
+/// Mount a read-only FUSE filesystem from packed metadata and chunks.
+///
+/// Args:
+///     metadata: dict mapping paths to entry dicts (as produced by
+///         `pack_directory_chunked`).
+///     chunks: list of memoryview/bytes chunks.
+///     chunk_size: size of each chunk in bytes.
+///     mount_point: path to mount the filesystem.
+///
+/// Returns a FuseMountHandle. Call handle.unmount() to unmount.
+#[pyfunction]
+fn mount_chunked_fuse(
+    py: Python<'_>,
+    metadata: &Bound<'_, PyDict>,
+    chunks: Vec<pyo3::buffer::PyBuffer<u8>>,
+    chunk_size: usize,
+    mount_point: String,
+) -> PyResult<PyMountHandle> {
+    if chunk_size == 0 {
+        return Err(PyRuntimeError::new_err("chunk_size must be > 0"));
+    }
+    if !mount_point.starts_with('/') {
+        return Err(PyRuntimeError::new_err(
+            "mount_point must be an absolute path",
+        ));
+    }
+
+    let metadata = extract_metadata(metadata)?;
+    // Copy each Python buffer into owned Bytes. We intentionally avoid
+    // zero-copy (Bytes::from_owner wrapping PyBuffer) because PyBuffer::drop
+    // calls PyBuffer_Release which requires the GIL. If a FUSE task is still
+    // alive when the tokio runtime shuts down via atexit, the PyBuffer would
+    // be dropped on a tokio worker thread during interpreter finalization,
+    // causing a segfault in module_from_spec/Python::attach.
+    let chunks: Vec<Bytes> = chunks
+        .into_iter()
+        .map(|buf| {
+            // SAFETY: buf is a live PyBuffer and we hold the GIL (py:
+            // Python<'_> is in scope). buf_ptr() is valid for len_bytes()
+            // bytes for the lifetime of `buf`. Bytes::copy_from_slice on
+            // the next line performs a full memcpy before this closure
+            // iteration ends and `buf` is dropped, so the slice does not
+            // outlive the source buffer.
+            let slice =
+                unsafe { std::slice::from_raw_parts(buf.buf_ptr() as *const u8, buf.len_bytes()) };
+            Bytes::copy_from_slice(slice)
+        })
+        .collect();
+
+    let fs = ChunkedFuseFs {
+        metadata,
+        chunks,
+        chunk_size,
+    };
+
+    let mount_path = mount_point.clone();
+    let (unmount_tx, unmount_rx) = oneshot::channel::<()>();
+    let (mount_result_tx, mount_result_rx) = oneshot::channel::<Result<(), String>>();
+
+    // The FUSE session task runs on the shared tokio runtime. We do not
+    // retain the JoinHandle because the task's lifetime is governed by
+    // fusermount3 -u (called in unmount()). If the Python interpreter
+    // exits without calling unmount(), the runtime's atexit shutdown will
+    // drop the task. This is acceptable: the kernel automatically cleans
+    // up the FUSE mount when the process exits.
+    let runtime = monarch_hyperactor::runtime::get_tokio_runtime();
+    runtime.spawn(async move {
+        let mut opts = MountOptions::default();
+        opts.read_only(true).force_readdir_plus(true);
+
+        let mount_result = fuse3::path::Session::new(opts)
+            .mount_with_unprivileged(fs, &mount_path)
+            .await;
+
+        match mount_result {
+            Ok(mount_handle) => {
+                let _ = mount_result_tx.send(Ok(()));
+                // Run the FUSE session until unmount() calls fusermount3 -u,
+                // which causes the session future to complete.
+                if let Err(e) = mount_handle.await {
+                    warn!("fuse session error: {e}");
+                }
+            }
+            Err(e) => {
+                warn!("fuse mount failed: {e}");
+                let _ = mount_result_tx.send(Err(format!("{e}")));
+            }
+        }
+        drop(unmount_rx);
+    });
+
+    // Poll until mount appears in /proc/mounts or the task signals
+    // failure. Releases the GIL while waiting. We use blocking
+    // std::thread::sleep because this is a synchronous PyO3 context.
+    //
+    // NOTE: Polling /proc/mounts has an inherent TOCTOU race: the mount
+    // could theoretically appear and disappear between our check and the
+    // caller's first filesystem access. In practice this doesn't happen
+    // because nothing else unmounts the path, but inotify on /proc/mounts
+    // would be a more robust alternative if needed.
+    #[allow(clippy::disallowed_methods)]
+    py.detach(|| {
+        let start = std::time::Instant::now();
+        let mut mount_result_rx = Some(mount_result_rx);
+        while start.elapsed() < Duration::from_secs(50) {
+            // Check if the mount task reported an early failure.
+            if let Some(rx) = mount_result_rx.as_mut() {
+                match rx.try_recv() {
+                    Ok(Err(e)) => {
+                        return Err(PyRuntimeError::new_err(format!("fuse mount failed: {e}")));
+                    }
+                    Ok(Ok(())) => {
+                        // Mount succeeded; stop checking the channel but
+                        // still wait for /proc/mounts visibility.
+                        mount_result_rx = None;
+                    }
+                    Err(oneshot::error::TryRecvError::Closed) => {
+                        return Err(PyRuntimeError::new_err(
+                            "fuse mount task exited without reporting status \
+                             (possible panic, tokio runtime shutdown, or \
+                             task cancellation)",
+                        ));
+                    }
+                    Err(oneshot::error::TryRecvError::Empty) => {}
+                }
+            }
+
+            // Check /proc/mounts directly (authoritative source).
+            if let Ok(mounts) = std::fs::read_to_string("/proc/mounts") {
+                for line in mounts.lines() {
+                    if let Some(mp) = line.split_whitespace().nth(1) {
+                        if mp == mount_point {
+                            return Ok(());
+                        }
+                    }
+                }
+            }
+
+            std::thread::sleep(Duration::from_millis(100));
+        }
+        Err(PyRuntimeError::new_err("timed out waiting for FUSE mount"))
+    })?;
+
+    Ok(PyMountHandle {
+        unmount_tx: Some(unmount_tx),
+        mount_point,
+    })
+}
+
+pub fn register_python_bindings(module: &Bound<'_, PyModule>) -> PyResult<()> {
+    module.add_class::<PyMountHandle>()?;
+    let f = wrap_pyfunction!(mount_chunked_fuse, module)?;
+    f.setattr(
+        "__module__",
+        "monarch._rust_bindings.monarch_extension.chunked_fuse",
+    )?;
+    module.add_function(f)?;
+    Ok(())
+}

--- a/monarch_extension/src/lib.rs
+++ b/monarch_extension/src/lib.rs
@@ -21,6 +21,7 @@ mod mesh_controller;
 mod tensor_worker;
 
 mod blocking;
+mod chunked_fuse;
 mod fast_pack;
 mod panic;
 mod trace;
@@ -229,6 +230,11 @@ pub fn mod_init(module: &Bound<'_, PyModule>) -> PyResult<()> {
     crate::fast_pack::register_python_bindings(&get_or_add_new_module(
         module,
         "monarch_extension.fast_pack",
+    )?)?;
+
+    crate::chunked_fuse::register_python_bindings(&get_or_add_new_module(
+        module,
+        "monarch_extension.chunked_fuse",
     )?)?;
 
     monarch_hyperactor::logging::register_python_bindings(&get_or_add_new_module(

--- a/monarch_hyperactor/src/runtime.rs
+++ b/monarch_hyperactor/src/runtime.rs
@@ -152,6 +152,13 @@ pub fn is_main_thread() -> bool {
 }
 
 pub fn initialize(py: Python) -> Result<()> {
+    // Eagerly initialize the main thread ID while we're on the main thread
+    // with the GIL held. If this were lazily initialized on a background
+    // tokio thread during shutdown, the `py.import("threading")` call inside
+    // get_main_thread_native_id() would trigger module_from_spec on a
+    // partially-finalized interpreter, causing a segfault.
+    let _ = get_main_thread_native_id();
+
     let atexit = py.import("atexit")?;
     let shutdown_fn = wrap_pyfunction!(shutdown_tokio_runtime, py)?;
     atexit.call_method1("register", (shutdown_fn,))?;

--- a/python/benches/remotemount/bench_metadata_encoding.py
+++ b/python/benches/remotemount/bench_metadata_encoding.py
@@ -1,0 +1,243 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+"""Benchmark metadata encoding for chunked_fuse mount.
+
+Measures the cost of json.dumps() for the metadata dict passed from
+Python to Rust at mount time. Helps decide whether JSON is the right
+serialization format or if we should pass the dict directly via PyO3.
+
+Usage:
+    buck run fbcode//monarch/python/benches:bench_metadata_encoding
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+import os
+import tempfile
+import time
+
+
+def make_synthetic_metadata(num_files: int, num_dirs: int = 0) -> dict[str, Any]:
+    """Build a metadata dict similar to what pack_directory_chunked produces."""
+    meta = {}
+    now = time.time()
+    base_attr = {
+        "st_atime": now,
+        "st_ctime": now,
+        "st_gid": 1000,
+        "st_mode": 0o40755,
+        "st_mtime": now,
+        "st_nlink": 2,
+        "st_size": 4096,
+        "st_uid": 1000,
+    }
+
+    # Root directory
+    children = []
+    for i in range(num_dirs):
+        children.append(f"dir_{i}")
+    for i in range(num_files):
+        children.append(f"file_{i}.bin")
+    meta["/"] = {"attr": base_attr.copy(), "children": children}
+
+    # Subdirectories
+    for i in range(num_dirs):
+        dir_children = [f"sub_file_{j}.txt" for j in range(5)]
+        meta[f"/dir_{i}"] = {"attr": base_attr.copy(), "children": dir_children}
+        offset = num_files * 1024 + i * 5 * 256
+        for j in range(5):
+            file_attr = base_attr.copy()
+            file_attr["st_mode"] = 0o100644
+            file_attr["st_size"] = 256
+            file_attr["st_nlink"] = 1
+            meta[f"/dir_{i}/sub_file_{j}.txt"] = {
+                "attr": file_attr,
+                "global_offset": offset + j * 256,
+                "file_len": 256,
+            }
+
+    # Top-level files
+    offset = 0
+    for i in range(num_files):
+        file_size = 1024  # 1KB each
+        file_attr = base_attr.copy()
+        file_attr["st_mode"] = 0o100644
+        file_attr["st_size"] = file_size
+        file_attr["st_nlink"] = 1
+        meta[f"/file_{i}.bin"] = {
+            "attr": file_attr,
+            "global_offset": offset,
+            "file_len": file_size,
+        }
+        offset += file_size
+
+    return meta
+
+
+def bench_json_encode(meta: dict[str, Any], iterations: int = 100) -> tuple[float, int]:
+    """Return (avg_seconds, json_size_bytes)."""
+    # Warm up
+    json_str = json.dumps(meta)
+    json_size = len(json_str.encode("utf-8"))
+
+    start = time.perf_counter()
+    for _ in range(iterations):
+        json.dumps(meta)
+    elapsed = time.perf_counter() - start
+    return elapsed / iterations, json_size
+
+
+def bench_json_decode(json_str: str, iterations: int = 100) -> float:
+    """Return avg_seconds for json.loads."""
+    # Warm up
+    json.loads(json_str)
+
+    start = time.perf_counter()
+    for _ in range(iterations):
+        json.loads(json_str)
+    elapsed = time.perf_counter() - start
+    return elapsed / iterations
+
+
+def bench_mount_metadata(
+    meta: dict[str, Any], chunks: list[Any], chunk_size: int, iterations: int = 20
+) -> float:
+    """Time mount_chunked_fuse with direct dict (no JSON). Returns avg seconds."""
+    from monarch._rust_bindings.monarch_extension.chunked_fuse import mount_chunked_fuse
+
+    # Warm up
+    with tempfile.TemporaryDirectory() as mnt:
+        handle = mount_chunked_fuse(meta, chunks, chunk_size, mnt)
+        handle.unmount()
+
+    elapsed = 0.0
+    for _ in range(iterations):
+        with tempfile.TemporaryDirectory() as mnt:
+            start = time.perf_counter()
+            handle = mount_chunked_fuse(meta, chunks, chunk_size, mnt)
+            elapsed += time.perf_counter() - start
+            handle.unmount()
+    return elapsed / iterations
+
+
+def bench_real_pack(num_files: int, file_size: int = 1024) -> tuple[float, float, int]:
+    """Create real files, pack them, and time pack vs json.dumps.
+
+    Returns (pack_seconds, json_dumps_seconds, json_size).
+    """
+    from monarch.remotemount.fast_pack import pack_directory_chunked
+
+    with tempfile.TemporaryDirectory() as d:
+        # Create files
+        data = os.urandom(file_size)
+        for i in range(num_files):
+            with open(os.path.join(d, f"file_{i}.bin"), "wb") as f:
+                f.write(data)
+
+        # Time pack
+        start = time.perf_counter()
+        meta, _staging_mv, _chunks, _shm_path = pack_directory_chunked(d)
+        pack_time = time.perf_counter() - start
+
+        # Time json.dumps
+        start = time.perf_counter()
+        json_str = json.dumps(meta)
+        json_time = time.perf_counter() - start
+
+        return pack_time, json_time, len(json_str.encode("utf-8"))
+
+
+def format_size(nbytes: int) -> str:
+    if nbytes < 1024:
+        return f"{nbytes} B"
+    elif nbytes < 1024 * 1024:
+        return f"{nbytes / 1024:.1f} KB"
+    else:
+        return f"{nbytes / (1024 * 1024):.1f} MB"
+
+
+def format_time(seconds: float) -> str:
+    if seconds < 0.001:
+        return f"{seconds * 1_000_000:.0f} us"
+    elif seconds < 1.0:
+        return f"{seconds * 1000:.1f} ms"
+    else:
+        return f"{seconds:.2f} s"
+
+
+def main() -> None:
+    print("=" * 72)
+    print("Metadata JSON encoding benchmark")
+    print("=" * 72)
+
+    # --- Synthetic metadata ---
+    print("\n--- Synthetic metadata (json.dumps + json.loads) ---")
+    print(
+        f"{'Files':>10}  {'Entries':>8}  {'JSON size':>10}  {'dumps':>10}  {'loads':>10}"
+    )
+    print("-" * 60)
+
+    for num_files in [100, 1_000, 10_000, 100_000]:
+        num_dirs = num_files // 20
+        meta = make_synthetic_metadata(num_files, num_dirs)
+        num_entries = len(meta)
+
+        iters = max(10, 1000 // (num_files // 100))
+        dumps_time, json_size = bench_json_encode(meta, iterations=iters)
+        json_str = json.dumps(meta)
+        loads_time = bench_json_decode(json_str, iterations=iters)
+
+        print(
+            f"{num_files:>10,}  {num_entries:>8,}  {format_size(json_size):>10}  "
+            f"{format_time(dumps_time):>10}  {format_time(loads_time):>10}"
+        )
+
+    # --- Direct dict extraction (PyO3) ---
+    print("\n--- Direct dict extraction via PyO3 (mount_chunked_fuse) ---")
+    print(f"{'Files':>10}  {'Entries':>8}  {'mount (dict)':>14}  {'json.dumps':>12}")
+    print("-" * 55)
+
+    for num_files in [100, 1_000, 10_000]:
+        num_dirs = num_files // 20
+        meta = make_synthetic_metadata(num_files, num_dirs)
+        num_entries = len(meta)
+        # Create minimal chunks for mounting
+        chunks = [memoryview(b"\x00" * 4096)]
+        chunk_size = 4096
+
+        iters = max(5, 200 // (num_files // 100))
+        mount_time = bench_mount_metadata(meta, chunks, chunk_size, iterations=iters)
+        dumps_time, _ = bench_json_encode(meta, iterations=iters)
+        print(
+            f"{num_files:>10,}  {num_entries:>8,}  {format_time(mount_time):>14}  "
+            f"{format_time(dumps_time):>12}"
+        )
+
+    # --- Real pack + json.dumps comparison ---
+    print("\n--- Real pack_directory_chunked vs json.dumps ---")
+    print(
+        f"{'Files':>10}  {'pack()':>12}  {'json.dumps':>12}  {'JSON size':>10}  {'json/pack':>10}"
+    )
+    print("-" * 65)
+
+    for num_files in [100, 1_000, 10_000]:
+        pack_time, json_time, json_size = bench_real_pack(num_files, file_size=1024)
+        ratio = json_time / pack_time if pack_time > 0 else float("inf")
+        print(
+            f"{num_files:>10,}  {format_time(pack_time):>12}  {format_time(json_time):>12}  "
+            f"{format_size(json_size):>10}  {ratio:>9.1%}"
+        )
+
+    print()
+
+
+if __name__ == "__main__":
+    main()

--- a/python/monarch/_rust_bindings/monarch_extension/chunked_fuse.pyi
+++ b/python/monarch/_rust_bindings/monarch_extension/chunked_fuse.pyi
@@ -1,0 +1,20 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-unsafe
+
+from collections.abc import Buffer, Sequence
+from typing import Any
+
+class FuseMountHandle:
+    def unmount(self) -> None: ...
+
+def mount_chunked_fuse(
+    metadata: dict[str, Any],
+    chunks: Sequence[Buffer],
+    chunk_size: int,
+    mount_point: str,
+) -> FuseMountHandle: ...

--- a/python/tests/test_remotemount.py
+++ b/python/tests/test_remotemount.py
@@ -8,13 +8,19 @@
 
 from __future__ import annotations
 
+import contextlib
 import gc
+from collections.abc import Generator
 import math
 import mmap
 import os
+import shutil
+import stat
 import tempfile
+import time
 
 import pytest
+from monarch._rust_bindings.monarch_extension.chunked_fuse import mount_chunked_fuse
 from monarch._rust_bindings.monarch_extension.fast_pack import (
     load_file_and_hash,
     pack_files_with_offsets,
@@ -415,3 +421,407 @@ class TestPreadErrorHandling:
         """Packing a nonexistent file should fail, not silently zero-fill."""
         with pytest.raises(BaseException, match="panicked"):  # noqa: B017
             pack_files_with_offsets([("/nonexistent/path/to/file.bin", 0, 100)], 100)
+
+
+def _check_fuse_available() -> bool:
+    """Check if FUSE mounts actually work, not just that the binary exists."""
+    if shutil.which("fusermount3") is None or not os.path.exists("/dev/fuse"):
+        return False
+    # /dev/fuse may exist but be unusable (e.g. Docker without CAP_SYS_ADMIN).
+    # Probe by checking if we can open it.
+    try:
+        fd = os.open("/dev/fuse", os.O_RDWR)
+        os.close(fd)
+        return True
+    except OSError:
+        return False
+
+
+_fuse_available: bool = _check_fuse_available()
+
+
+def _make_attr(
+    mode: int = 0o100644,
+    size: int = 0,
+    nlink: int = 1,
+) -> dict[str, object]:
+    now = time.time()
+    return {
+        "st_atime": now,
+        "st_ctime": now,
+        "st_gid": os.getgid(),
+        "st_mode": mode,
+        "st_mtime": now,
+        "st_nlink": nlink,
+        "st_size": size,
+        "st_uid": os.getuid(),
+    }
+
+
+def _dir_attr(size: int = 4096, nlink: int = 2) -> dict[str, object]:
+    return _make_attr(mode=0o40755, size=size, nlink=nlink)
+
+
+def _file_attr(size: int) -> dict[str, object]:
+    return _make_attr(mode=0o100644, size=size)
+
+
+def _symlink_attr(target_len: int) -> dict[str, object]:
+    return _make_attr(mode=0o120777, size=target_len)
+
+
+@contextlib.contextmanager
+def _fuse_mount(
+    metadata: dict[str, object],
+    # pyre-ignore[24]: memoryview is not generic in Pyre
+    chunks: list[memoryview],
+    chunk_size: int,
+    mount_point: str,
+) -> Generator[object, None, None]:
+    """Mount a FUSE filesystem and unmount on exit for test isolation."""
+    handle = mount_chunked_fuse(metadata, chunks, chunk_size, mount_point)
+    yield handle
+    handle.unmount()
+
+
+@pytest.mark.skipif(
+    not _fuse_available,
+    reason="FUSE not available (missing fusermount3, /dev/fuse, or permissions)",
+)
+class TestFuseMount:
+    """Comprehensive tests for the chunked_fuse FUSE filesystem."""
+
+    def test_single_file_read(self) -> None:
+        """Mount a single file and read its content back."""
+        content = b"hello fuse world"
+        metadata: dict[str, object] = {
+            "/": {"attr": _dir_attr(), "children": ["a.txt"]},
+            "/a.txt": {
+                "attr": _file_attr(len(content)),
+                "global_offset": 0,
+                "file_len": len(content),
+            },
+        }
+        with (
+            tempfile.TemporaryDirectory() as mnt,
+            _fuse_mount(metadata, [memoryview(content)], len(content), mnt),
+        ):
+            with open(os.path.join(mnt, "a.txt"), "rb") as f:
+                assert f.read() == content
+
+    def test_multiple_files(self) -> None:
+        """Mount multiple files and verify each has correct content."""
+        files = {
+            "a.txt": b"aaa",
+            "b.txt": b"bbbbbb",
+            "c.txt": b"c",
+        }
+        packed = b"".join(files.values())
+        metadata: dict[str, object] = {
+            "/": {"attr": _dir_attr(), "children": list(files.keys())},
+        }
+        offset = 0
+        for name, content in files.items():
+            metadata[f"/{name}"] = {
+                "attr": _file_attr(len(content)),
+                "global_offset": offset,
+                "file_len": len(content),
+            }
+            offset += len(content)
+
+        with (
+            tempfile.TemporaryDirectory() as mnt,
+            _fuse_mount(metadata, [memoryview(packed)], len(packed), mnt),
+        ):
+            for name, expected in files.items():
+                with open(os.path.join(mnt, name), "rb") as f:
+                    assert f.read() == expected
+
+    def test_subdirectory(self) -> None:
+        """Files in a subdirectory are accessible."""
+        content = b"nested content"
+        metadata: dict[str, object] = {
+            "/": {"attr": _dir_attr(nlink=3), "children": ["sub"]},
+            "/sub": {"attr": _dir_attr(), "children": ["f.txt"]},
+            "/sub/f.txt": {
+                "attr": _file_attr(len(content)),
+                "global_offset": 0,
+                "file_len": len(content),
+            },
+        }
+        with (
+            tempfile.TemporaryDirectory() as mnt,
+            _fuse_mount(metadata, [memoryview(content)], len(content), mnt),
+        ):
+            with open(os.path.join(mnt, "sub", "f.txt"), "rb") as f:
+                assert f.read() == content
+            assert stat.S_ISDIR(os.stat(os.path.join(mnt, "sub")).st_mode)
+
+    def test_listdir(self) -> None:
+        """os.listdir returns the correct children."""
+        metadata: dict[str, object] = {
+            "/": {
+                "attr": _dir_attr(),
+                "children": ["x.bin", "y.bin", "sub"],
+            },
+            "/x.bin": {
+                "attr": _file_attr(1),
+                "global_offset": 0,
+                "file_len": 1,
+            },
+            "/y.bin": {
+                "attr": _file_attr(1),
+                "global_offset": 1,
+                "file_len": 1,
+            },
+            "/sub": {"attr": _dir_attr(), "children": []},
+        }
+        with (
+            tempfile.TemporaryDirectory() as mnt,
+            _fuse_mount(metadata, [memoryview(b"\x00\x00")], 2, mnt),
+        ):
+            assert sorted(os.listdir(mnt)) == ["sub", "x.bin", "y.bin"]
+            assert os.listdir(os.path.join(mnt, "sub")) == []
+
+    def test_symlink(self) -> None:
+        """Symlinks are readable via readlink."""
+        target = "/some/target/path"
+        metadata: dict[str, object] = {
+            "/": {"attr": _dir_attr(), "children": ["link"]},
+            "/link": {
+                "attr": _symlink_attr(len(target)),
+                "link_target": target,
+            },
+        }
+        with (
+            tempfile.TemporaryDirectory() as mnt,
+            _fuse_mount(metadata, [memoryview(b"\x00")], 1, mnt),
+        ):
+            assert os.readlink(os.path.join(mnt, "link")) == target
+            assert stat.S_ISLNK(os.lstat(os.path.join(mnt, "link")).st_mode)
+
+    def test_small_chunk_size(self) -> None:
+        """File spanning multiple chunks is read correctly."""
+        content = b"A" * 10 + b"B" * 10 + b"C" * 5
+        chunk_size = 10
+        chunk_list = [
+            memoryview(content[i : i + chunk_size])
+            for i in range(0, len(content), chunk_size)
+        ]
+        metadata: dict[str, object] = {
+            "/": {"attr": _dir_attr(), "children": ["f.bin"]},
+            "/f.bin": {
+                "attr": _file_attr(len(content)),
+                "global_offset": 0,
+                "file_len": len(content),
+            },
+        }
+        with (
+            tempfile.TemporaryDirectory() as mnt,
+            _fuse_mount(metadata, chunk_list, chunk_size, mnt),
+        ):
+            with open(os.path.join(mnt, "f.bin"), "rb") as f:
+                assert f.read() == content
+
+    def test_partial_read(self) -> None:
+        """Reading a slice of a file returns the correct bytes."""
+        content = b"0123456789abcdef"
+        metadata: dict[str, object] = {
+            "/": {"attr": _dir_attr(), "children": ["f.bin"]},
+            "/f.bin": {
+                "attr": _file_attr(len(content)),
+                "global_offset": 0,
+                "file_len": len(content),
+            },
+        }
+        with (
+            tempfile.TemporaryDirectory() as mnt,
+            _fuse_mount(metadata, [memoryview(content)], len(content), mnt),
+        ):
+            with open(os.path.join(mnt, "f.bin"), "rb") as f:
+                f.seek(4)
+                assert f.read(4) == b"4567"
+                f.seek(10)
+                assert f.read() == b"abcdef"
+                f.seek(100)
+                assert f.read() == b""
+
+    def test_dotdot_has_parent_attrs(self) -> None:
+        """stat('sub/..') should return root's attrs, not sub's."""
+        metadata: dict[str, object] = {
+            "/": {"attr": _dir_attr(size=4096, nlink=3), "children": ["sub"]},
+            "/sub": {"attr": _dir_attr(size=80), "children": []},
+        }
+        with (
+            tempfile.TemporaryDirectory() as mnt,
+            _fuse_mount(metadata, [memoryview(b"\x00" * 64)], 64, mnt),
+        ):
+            sub_stat = os.stat(os.path.join(mnt, "sub"))
+            dotdot_stat = os.stat(os.path.join(mnt, "sub", ".."))
+            root_stat = os.stat(mnt)
+
+            assert dotdot_stat.st_size == root_stat.st_size
+            assert dotdot_stat.st_nlink == root_stat.st_nlink
+            assert stat.S_IMODE(dotdot_stat.st_mode) == stat.S_IMODE(root_stat.st_mode)
+            assert sub_stat.st_size != root_stat.st_size
+
+    def test_end_to_end_pack_mount_read(self) -> None:
+        """Full round-trip: create files, pack, mount, read back."""
+        with tempfile.TemporaryDirectory() as src:
+            os.makedirs(os.path.join(src, "sub"))
+            files = {
+                "hello.txt": b"hello world",
+                "binary.bin": os.urandom(2048),
+                os.path.join("sub", "nested.txt"): b"nested content here",
+            }
+            for name, content in files.items():
+                with open(os.path.join(src, name), "wb") as f:
+                    f.write(content)
+
+            meta, _staging_mv, chunks, _hashes = pack_directory_chunked(src)
+
+            with tempfile.TemporaryDirectory() as mnt:
+                chunk_size = len(bytes(chunks[0])) if chunks else 1
+                with _fuse_mount(meta, chunks, chunk_size, mnt):
+                    for name, expected in files.items():
+                        with open(os.path.join(mnt, name), "rb") as f:
+                            assert f.read() == expected, f"content mismatch for {name}"
+
+    def test_file_permissions(self) -> None:
+        """File and directory permissions are preserved."""
+        metadata: dict[str, object] = {
+            "/": {"attr": _dir_attr(), "children": ["rw.txt", "ro.txt"]},
+            "/rw.txt": {
+                "attr": _make_attr(mode=0o100666, size=1),
+                "global_offset": 0,
+                "file_len": 1,
+            },
+            "/ro.txt": {
+                "attr": _make_attr(mode=0o100444, size=1),
+                "global_offset": 1,
+                "file_len": 1,
+            },
+        }
+        with (
+            tempfile.TemporaryDirectory() as mnt,
+            _fuse_mount(metadata, [memoryview(b"\x00\x00")], 2, mnt),
+        ):
+            rw = os.stat(os.path.join(mnt, "rw.txt"))
+            ro = os.stat(os.path.join(mnt, "ro.txt"))
+            assert stat.S_IMODE(rw.st_mode) == 0o666
+            assert stat.S_IMODE(ro.st_mode) == 0o444
+
+    def test_nonexistent_file(self) -> None:
+        """Accessing a nonexistent path raises FileNotFoundError."""
+        metadata: dict[str, object] = {
+            "/": {"attr": _dir_attr(), "children": []},
+        }
+        with (
+            tempfile.TemporaryDirectory() as mnt,
+            _fuse_mount(metadata, [memoryview(b"\x00")], 1, mnt),
+        ):
+            with pytest.raises(FileNotFoundError):
+                open(os.path.join(mnt, "nope.txt"), "rb")
+            with pytest.raises(FileNotFoundError):
+                os.stat(os.path.join(mnt, "nope.txt"))
+
+    def test_zero_chunk_size_rejected(self) -> None:
+        """chunk_size=0 should raise immediately."""
+        metadata: dict[str, object] = {
+            "/": {"attr": _dir_attr(), "children": []},
+        }
+        with tempfile.TemporaryDirectory() as mnt:
+            with pytest.raises(RuntimeError, match="chunk_size must be > 0"):
+                mount_chunked_fuse(metadata, [], 0, mnt)
+
+    def test_relative_mount_point_rejected(self) -> None:
+        """Relative mount point should raise immediately."""
+        metadata: dict[str, object] = {
+            "/": {"attr": _dir_attr(), "children": []},
+        }
+        with pytest.raises(RuntimeError, match="absolute path"):
+            mount_chunked_fuse(metadata, [], 1, "relative/path")
+
+    def test_mount_nonexistent_directory(self) -> None:
+        """Mounting on a path that doesn't exist should fail."""
+        metadata: dict[str, object] = {
+            "/": {"attr": _dir_attr(), "children": []},
+        }
+        with pytest.raises(RuntimeError):
+            mount_chunked_fuse(metadata, [], 1, "/tmp/nonexistent_fuse_test_dir")
+
+    def test_many_files(self) -> None:
+        """Mount with many files and read all of them."""
+        num_files = 200
+        file_size = 128
+        packed = os.urandom(num_files * file_size)
+        children = [f"f_{i}.bin" for i in range(num_files)]
+        metadata: dict[str, object] = {
+            "/": {"attr": _dir_attr(), "children": children},
+        }
+        for i in range(num_files):
+            metadata[f"/f_{i}.bin"] = {
+                "attr": _file_attr(file_size),
+                "global_offset": i * file_size,
+                "file_len": file_size,
+            }
+
+        with (
+            tempfile.TemporaryDirectory() as mnt,
+            _fuse_mount(metadata, [memoryview(packed)], len(packed), mnt),
+        ):
+            for i in range(num_files):
+                with open(os.path.join(mnt, f"f_{i}.bin"), "rb") as f:
+                    expected = packed[i * file_size : (i + 1) * file_size]
+                    assert f.read() == expected
+
+    def test_repeated_reads(self) -> None:
+        """Reading the same file repeatedly returns consistent data."""
+        content = os.urandom(4096)
+        metadata: dict[str, object] = {
+            "/": {"attr": _dir_attr(), "children": ["data.bin"]},
+            "/data.bin": {
+                "attr": _file_attr(len(content)),
+                "global_offset": 0,
+                "file_len": len(content),
+            },
+        }
+        with (
+            tempfile.TemporaryDirectory() as mnt,
+            _fuse_mount(metadata, [memoryview(content)], len(content), mnt),
+        ):
+            path = os.path.join(mnt, "data.bin")
+            for _ in range(50):
+                with open(path, "rb") as f:
+                    assert f.read() == content
+
+    def test_mount_unmount_remount(self) -> None:
+        """Mount, unmount, then mount again on the same directory."""
+        content = b"round-trip"
+        metadata: dict[str, object] = {
+            "/": {"attr": _dir_attr(), "children": ["f.txt"]},
+            "/f.txt": {
+                "attr": _file_attr(len(content)),
+                "global_offset": 0,
+                "file_len": len(content),
+            },
+        }
+        with tempfile.TemporaryDirectory() as mnt:
+            # First mount/unmount cycle.
+            with _fuse_mount(metadata, [memoryview(content)], len(content), mnt):
+                with open(os.path.join(mnt, "f.txt"), "rb") as f:
+                    assert f.read() == content
+
+            # Second mount on the same directory.
+            content2 = b"second time"
+            metadata2: dict[str, object] = {
+                "/": {"attr": _dir_attr(), "children": ["g.txt"]},
+                "/g.txt": {
+                    "attr": _file_attr(len(content2)),
+                    "global_offset": 0,
+                    "file_len": len(content2),
+                },
+            }
+            with _fuse_mount(metadata2, [memoryview(content2)], len(content2), mnt):
+                with open(os.path.join(mnt, "g.txt"), "rb") as f:
+                    assert f.read() == content2


### PR DESCRIPTION
Summary:

Add `chunked_fuse.rs`, a Rust implementation of a read-only FUSE
filesystem backed by pre-packed metadata and byte chunks. Implements
`fuse3::path::PathFilesystem` with handlers for lookup, getattr, read,
readdir, readdirplus, readlink, open, and access.

Key features:
- Zero-copy chunk reads via `Bytes::slice` for single-chunk files
- Multi-chunk assembly for files spanning chunk boundaries
- 1-hour TTL on cached attributes
- Unprivileged mounting via `fusermount3`
- Python bindings: `mount_chunked_fuse()` returns a `FuseMountHandle`
  with `unmount()` method

Reviewed By: zdevito

Differential Revision: D96067978


