### PR TITLE
bound forwarder flush during teardown with configurable timeout (#3104)

### DIFF
--- a/hyperactor/src/config.rs
+++ b/hyperactor/src/config.rs
@@ -230,6 +230,16 @@ declare_attrs! {
     ))
     pub attr SERVER_HEARTBEAT_INTERVAL: Duration = Duration::from_secs(1);
 
+    /// Timeout for best-effort forwarder flush during proc/actor
+    /// teardown. If the remote side has already torn down its
+    /// networking, acks may never arrive; this timeout prevents the
+    /// flush from hanging indefinitely.
+    @meta(CONFIG = ConfigAttr::new(
+        Some("HYPERACTOR_FORWARDER_FLUSH_TIMEOUT".to_string()),
+        Some("forwarder_flush_timeout".to_string()),
+    ))
+    pub attr FORWARDER_FLUSH_TIMEOUT: Duration = Duration::from_secs(5);
+
     /// Path to TLS certificate file for the 'tls' transport.
     @meta(CONFIG = ConfigAttr::new(
         Some("HYPERACTOR_TLS_CERT".to_string()),

--- a/hyperactor/src/proc.rs
+++ b/hyperactor/src/proc.rs
@@ -844,13 +844,26 @@ impl Proc {
 
         // Flush the forwarder so that any messages posted during
         // teardown (e.g. supervision events) are wire-delivered
-        // before we tear down the proc's networking.
-        if let Err(err) = self.state().forwarder.flush().await {
-            tracing::warn!(
-                "{}: forwarder flush failed during proc exit: {:?}",
-                self.proc_id(),
-                err
-            );
+        // before we tear down the proc's networking. The flush is
+        // best-effort: if the remote side has already torn down its
+        // networking, acks may never arrive and flush would hang
+        // indefinitely, so we bound it with a configurable timeout.
+        let flush_timeout = hyperactor_config::global::get(crate::config::FORWARDER_FLUSH_TIMEOUT);
+        match tokio::time::timeout(flush_timeout, self.state().forwarder.flush()).await {
+            Ok(Err(err)) => {
+                tracing::warn!(
+                    "{}: forwarder flush failed during proc exit: {:?}",
+                    self.proc_id(),
+                    err
+                );
+            }
+            Err(_elapsed) => {
+                tracing::warn!(
+                    "{}: forwarder flush timed out during proc exit",
+                    self.proc_id(),
+                );
+            }
+            Ok(Ok(())) => {}
         }
 
         if let Some(this_handle) = this_handle

--- a/hyperactor_mesh/src/bootstrap.rs
+++ b/hyperactor_mesh/src/bootstrap.rs
@@ -3507,6 +3507,15 @@ mod tests {
         // messages.
         let instance = testing::instance();
 
+        // Set an absurdly high flush timeout to prove the flush
+        // completes naturally (host networking stays alive during
+        // worker teardown) and never relies on the timeout.
+        let config = hyperactor_config::global::lock();
+        let _flush_guard = config.override_key(
+            hyperactor::config::FORWARDER_FLUSH_TIMEOUT,
+            std::time::Duration::from_secs(600),
+        );
+
         // Configure a ProcessAllocator with the bootstrap binary.
         let mut allocator = ProcessAllocator::new(Command::new(crate::testresource::get(
             "monarch/hyperactor_mesh/bootstrap",

--- a/hyperactor_mesh/src/proc_agent.rs
+++ b/hyperactor_mesh/src/proc_agent.rs
@@ -491,8 +491,16 @@ impl ProcAgent {
         let has_errors = self.actor_states.values().any(|state| state.has_errors());
         let exit_code = if has_errors { 1 } else { 0 };
 
-        if let Err(err) = self.proc.flush().await {
-            tracing::warn!("failed to flush forwarder during shutdown: {}", err);
+        let flush_timeout =
+            hyperactor_config::global::get(hyperactor::config::FORWARDER_FLUSH_TIMEOUT);
+        match tokio::time::timeout(flush_timeout, self.proc.flush()).await {
+            Ok(Err(err)) => {
+                tracing::warn!("forwarder flush failed during shutdown: {}", err);
+            }
+            Err(_elapsed) => {
+                tracing::warn!("forwarder flush timed out during shutdown");
+            }
+            Ok(Ok(())) => {}
         }
 
         tracing::info!(


### PR DESCRIPTION
Summary:

 the bootstrap_canonical_simple_systemd_launcher test has been failing since D96760755 landed — https://www.internalfb.com/intern/test/844425219851362?ref_report_id=0. the failure has been tracked to two unbounded forwarder.flush() calls introduced in this stack.

the flush implementation (MailboxSender::flush) spins waiting for completed >= submitted — every outbound message must receive a wire ack before flush returns. during proc teardown, the remote host may have already torn down its networking. acks never arrive, the flush hangs indefinitely, and the proc process never exits. systemd keeps the unit in active/running, and the test's 10s polling window expires.

two call sites are affected:

1. proc.rs destroy_and_wait (D96760755)
2. proc_agent.rs ProcAgent::shutdown (child commit, "expose flush() on Proc and call it during ProcAgent shutdown")

this diff adds a configurable FORWARDER_FLUSH_TIMEOUT (default 5s, env HYPERACTOR_FORWARDER_FLUSH_TIMEOUT) and wraps both flush calls with tokio::time::timeout. on expiry the flush is abandoned with a warning log. this is consistent with the flush's documented intent as best-effort — failures were already logged as warnings and did not fail the shutdown.

bisection confirms: passes at D96760755^1, fails at D96760755 without timeout, passes with timeout, fails again at the child commit (second flush site), passes with both timeouts, passes on master with both timeouts (3/3 runs).

this is a containment fix. the flush was added to guarantee delivery of supervision events during teardown. a flush that times out means that guarantee is not being met — events are silently dropped. we have not yet determined why networking is unavailable at flush time. if the timeout fires routinely in production, ~~the underlying cause needs investigation~~ update: root cause fixed next in stack (D97416522).

Differential Revision: D97407501


