### PR TITLE
fix teardown ordering: ack ShutdownHost after terminate_children, not before (#3106)

### DIFF
--- a/hyperactor_mesh/src/bootstrap.rs
+++ b/hyperactor_mesh/src/bootstrap.rs
@@ -3503,10 +3503,6 @@ mod tests {
     #[tokio::test]
     #[cfg(all(fbcode_build, target_os = "linux"))]
     async fn bootstrap_canonical_simple_systemd_launcher() {
-        // Acquire exclusive config lock and select systemd launcher.
-        let config = hyperactor_config::global::lock();
-        let _guard = config.override_key(MESH_PROC_LAUNCHER_KIND, "systemd".to_string());
-
         // Create an actor instance we'll use to send and receive
         // messages.
         let instance = testing::instance();

--- a/hyperactor_mesh/src/host_mesh/host_agent.rs
+++ b/hyperactor_mesh/src/host_mesh/host_agent.rs
@@ -815,11 +815,12 @@ wirevalue::register_type!(ShutdownHost);
 #[async_trait]
 impl Handler<ShutdownHost> for HostAgent {
     async fn handle(&mut self, cx: &Context<Self>, msg: ShutdownHost) -> anyhow::Result<()> {
-        // Ack immediately so caller can stop waiting.
-        let (return_handle, mut return_receiver) = cx.mailbox().open_port();
-        cx.mailbox()
-            .serialize_and_send(&msg.ack, (), return_handle)?;
-
+        // Terminate children BEFORE acking, so the caller's networking
+        // stays alive while children flush their forwarders during
+        // teardown. If we ack first, the caller proceeds to tear down
+        // the host proc's networking while children are still running,
+        // causing their forwarder flushes to hang until
+        // MESSAGE_DELIVERY_TIMEOUT expires.
         let mut shutdown_tx = None;
         if let Some(host_mode) = self.host.take() {
             match host_mode {
@@ -847,7 +848,13 @@ impl Handler<ShutdownHost> for HostAgent {
             }
         }
 
-        // If message is returned, it means it ack was not sent successfully.
+        // Ack after children are terminated so the caller does not
+        // tear down the host's networking prematurely.
+        let (return_handle, mut return_receiver) = cx.mailbox().open_port();
+        cx.mailbox()
+            .serialize_and_send(&msg.ack, (), return_handle)?;
+
+        // If message is returned, it means the ack was not sent successfully.
         if return_receiver.recv().await.is_ok() {
             tracing::warn!("failed to send ack");
         }


### PR DESCRIPTION
Summary:


the `bootstrap_canonical_simple_systemd_launcher` test has been failing since D96760755 introduced unbounded `forwarder.flush()` calls during proc teardown. D97407501 mitigated this with a 5-second flush timeout, but noted the root cause was unknown: "we have not yet determined why networking is unavailable at flush time."

this diff fixes the root cause.

the `ShutdownHost` handler in `HostAgent` was acking the RPC **before** calling `terminate_children`. the comment read: "Ack immediately so caller can stop waiting." this violated the documented contract on `HostRef::shutdown`, which states: "This call returns `Ok(())` only after the agent has finished the termination pass."

the early ack allowed `HostMesh::shutdown` to proceed to `proc_mesh.stop()` — tearing down the host's networking — while worker processes were still alive. workers trying to flush supervision events back to the host found the socket gone, entered the transport's reconnect loop (bounded by `MESSAGE_DELIVERY_TIMEOUT`, 30s default), and hung. the test's 10s polling window expired first.

the fix moves the ack to after `terminate_children` completes. the host's networking now stays alive during worker teardown, so forwarder flushes complete naturally.

the `FORWARDER_FLUSH_TIMEOUT` from D97407501 is ~~no longer load-bearing for this bug but remains as defense-in-depth.~~ in review

full root cause analysis: https://www.internalfb.com/phabricator/paste/view/P2244540048?view=markdown

Reviewed By: dulinriley

Differential Revision: D97416522


