### PR TITLE
Frontend: align types with DataFusion schema + code quality

### DIFF
--- a/python/monarch/monarch_dashboard/frontend/src/App.css
+++ b/python/monarch/monarch_dashboard/frontend/src/App.css
@@ -24,14 +24,26 @@
   --accent-glow: rgba(232, 122, 47, 0.15);
   --accent-glow-strong: rgba(232, 122, 47, 0.3);
 
-  /* Status colors */
-  --status-healthy: #2ecc71;
+  /* Status colors — one per ActorStatus enum variant */
+  --status-idle: #2ecc71;
+  --status-client: #27ae60;
   --status-processing: #3498db;
-  --status-transitional: #f39c12;
+  --status-saving: #2980b9;
+  --status-loading: #1abc9c;
+  --status-created: #f1c40f;
+  --status-initializing: #f39c12;
+  --status-stopping: #e67e22;
   --status-failed: #e74c3c;
   --status-stopped: #8e44ad;
   --status-unknown: #7f8c8d;
-  --status-neutral: #5b7a99;
+
+  /* Message status colors — matches hyperactor telemetry emission */
+  --msg-status-queued: #f39c12;
+  --msg-status-active: #3498db;
+  --msg-status-complete: #2ecc71;
+
+  /* Legacy aliases used elsewhere in CSS */
+  --status-healthy: #2ecc71;
 
   /* Text */
   --text-primary: #e8eaed;
@@ -277,7 +289,6 @@ body::after {
   text-transform: uppercase;
   letter-spacing: 0.08em;
   margin-bottom: var(--space-md);
-  padding-left: var(--space-xs);
   border-left: 3px solid var(--accent-primary);
   padding-left: var(--space-sm);
 }
@@ -367,6 +378,55 @@ body::after {
   box-shadow: inset 3px 0 0 var(--accent-primary);
 }
 
+/* Message status expanded row */
+.msg-status-expanded-row td {
+  background: var(--bg-secondary);
+  padding: 8px 12px !important;
+  border-top: 1px solid var(--border-subtle);
+}
+
+.msg-status-timeline {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+}
+
+.msg-status-step {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.msg-status-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.msg-status-label {
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.msg-status-time {
+  font-size: 11px;
+  color: var(--text-secondary);
+}
+
+.msg-status-arrow {
+  color: var(--text-muted);
+  margin: 0 2px;
+}
+
+.msg-status-timeline-loading,
+.msg-status-timeline-empty {
+  font-size: 12px;
+  color: var(--text-secondary);
+  padding: 4px 0;
+}
+
 .clickable-row:active {
   background: var(--bg-active);
 }
@@ -429,9 +489,12 @@ body::after {
   flex-shrink: 0;
 }
 
-/* Status dot colors by data-status attribute */
-.status-badge[data-status="idle"] { color: var(--status-healthy); }
-.status-badge[data-status="idle"] .status-dot { background: var(--status-healthy); box-shadow: 0 0 6px var(--status-healthy); }
+/* Status dot colors by data-status attribute — one per ActorStatus variant */
+.status-badge[data-status="idle"] { color: var(--status-idle); }
+.status-badge[data-status="idle"] .status-dot { background: var(--status-idle); box-shadow: 0 0 6px var(--status-idle); }
+
+.status-badge[data-status="client"] { color: var(--status-client); }
+.status-badge[data-status="client"] .status-dot { background: var(--status-client); box-shadow: 0 0 6px var(--status-client); }
 
 .status-badge[data-status="processing"] { color: var(--status-processing); }
 .status-badge[data-status="processing"] .status-dot {
@@ -440,20 +503,38 @@ body::after {
   animation: pulse 2s ease-in-out infinite;
 }
 
-.status-badge[data-status="created"],
-.status-badge[data-status="initializing"],
-.status-badge[data-status="saving"],
-.status-badge[data-status="loading"],
-.status-badge[data-status="stopping"] {
-  color: var(--status-transitional);
+.status-badge[data-status="saving"] { color: var(--status-saving); }
+.status-badge[data-status="saving"] .status-dot {
+  background: var(--status-saving);
+  box-shadow: 0 0 6px var(--status-saving);
+  animation: pulse 2s ease-in-out infinite;
 }
-.status-badge[data-status="created"] .status-dot,
-.status-badge[data-status="initializing"] .status-dot,
-.status-badge[data-status="saving"] .status-dot,
-.status-badge[data-status="loading"] .status-dot,
+
+.status-badge[data-status="loading"] { color: var(--status-loading); }
+.status-badge[data-status="loading"] .status-dot {
+  background: var(--status-loading);
+  box-shadow: 0 0 6px var(--status-loading);
+  animation: pulse 2s ease-in-out infinite;
+}
+
+.status-badge[data-status="created"] { color: var(--status-created); }
+.status-badge[data-status="created"] .status-dot {
+  background: var(--status-created);
+  box-shadow: 0 0 6px var(--status-created);
+  animation: pulse 1.5s ease-in-out infinite;
+}
+
+.status-badge[data-status="initializing"] { color: var(--status-initializing); }
+.status-badge[data-status="initializing"] .status-dot {
+  background: var(--status-initializing);
+  box-shadow: 0 0 6px var(--status-initializing);
+  animation: pulse 1.5s ease-in-out infinite;
+}
+
+.status-badge[data-status="stopping"] { color: var(--status-stopping); }
 .status-badge[data-status="stopping"] .status-dot {
-  background: var(--status-transitional);
-  box-shadow: 0 0 6px var(--status-transitional);
+  background: var(--status-stopping);
+  box-shadow: 0 0 6px var(--status-stopping);
   animation: pulse 1.5s ease-in-out infinite;
 }
 
@@ -466,12 +547,8 @@ body::after {
 .status-badge[data-status="stopped"] { color: var(--status-stopped); }
 .status-badge[data-status="stopped"] .status-dot { background: var(--status-stopped); }
 
-.status-badge[data-status="unknown"],
-.status-badge[data-status="client"] {
-  color: var(--status-unknown);
-}
-.status-badge[data-status="unknown"] .status-dot,
-.status-badge[data-status="client"] .status-dot {
+.status-badge[data-status="unknown"] { color: var(--status-unknown); }
+.status-badge[data-status="unknown"] .status-dot {
   background: var(--status-unknown);
 }
 
@@ -1135,6 +1212,7 @@ button:focus:not(:focus-visible) {
 }
 
 .summary-error-item {
+  position: relative;
   padding: var(--space-sm);
   border-left: 3px solid var(--status-failed);
   margin-bottom: var(--space-xs);
@@ -1155,11 +1233,46 @@ button:focus:not(:focus-visible) {
   margin-top: 2px;
 }
 
+.summary-error-reason-wrap {
+  max-width: 300px;
+  cursor: default;
+}
+
 .summary-error-reason {
   font-family: var(--font-mono);
   font-size: 11px;
   color: var(--status-failed);
   font-style: italic;
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.summary-error-popover {
+  display: none;
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 100%;
+  z-index: 10;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-primary);
+  border-radius: var(--radius-sm);
+  padding: var(--space-sm) var(--space-md);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-style: italic;
+  color: var(--status-failed);
+  white-space: pre-wrap;
+  word-break: break-word;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+  user-select: text;
+  cursor: text;
+}
+
+.summary-error-reason-wrap:hover .summary-error-popover {
+  display: block;
 }
 
 .summary-error-time {
@@ -1183,13 +1296,24 @@ button:focus:not(:focus-visible) {
   background: var(--bg-tertiary);
   border-radius: 4px;
   overflow: hidden;
+  display: flex;
 }
 
-.summary-delivery-bar-fill {
+.summary-delivery-bar-segment {
   height: 100%;
-  background: var(--status-healthy);
-  border-radius: 4px;
   transition: width 0.6s ease;
+}
+
+.summary-delivery-bar-segment:first-child {
+  border-radius: 4px 0 0 4px;
+}
+
+.summary-delivery-bar-segment:last-child {
+  border-radius: 0 4px 4px 0;
+}
+
+.summary-delivery-bar-segment:only-child {
+  border-radius: 4px;
 }
 
 .summary-delivery-label {

--- a/python/monarch/monarch_dashboard/frontend/src/App.tsx
+++ b/python/monarch/monarch_dashboard/frontend/src/App.tsx
@@ -14,6 +14,7 @@ import { ActorDetail } from "./components/ActorDetail";
 import { DagView } from "./components/DagView";
 import { SummaryView } from "./components/SummaryView";
 import { NavItem } from "./types";
+import { leafName } from "./utils/status";
 import "./App.css";
 
 const TABS = [
@@ -24,13 +25,12 @@ const TABS = [
 
 const MESH_COLUMNS = [
   { key: "given_name", label: "Name" },
+  { key: "class", label: "Type" },
   { key: "shape_json", label: "Shape" },
-  { key: "full_name", label: "Full Name" },
 ];
 
 const AGENT_COLUMNS = [
   { key: "full_name", label: "Name" },
-  { key: "mesh_class", label: "Class" },
   { key: "rank", label: "Rank" },
   { key: "latest_status", label: "Status" },
 ];
@@ -42,6 +42,18 @@ const ACTOR_COLUMNS = [
   { key: "status_timestamp_us", label: "Last Updated" },
 ];
 
+/** True if actor name looks like a HostAgent (system agent for hosts). */
+const _isHostAgent = (name: string): boolean => {
+  const low = name.toLowerCase();
+  return low.includes("hostagent") || low.includes("host_agent");
+};
+
+/** True if actor name looks like a ProcAgent (system agent for procs). */
+const _isProcAgent = (name: string): boolean => {
+  const low = name.toLowerCase();
+  return low.includes("procagent") || low.includes("proc_agent");
+};
+
 /** Navigation graph: for each level, what comes next and how to label it. */
 const LEVELS: Partial<Record<NavItem["level"], {
   next: NavItem["level"];
@@ -49,12 +61,12 @@ const LEVELS: Partial<Record<NavItem["level"], {
   idField: "meshId" | "actorId";
   idKey: string;
 }>> = {
-  host_meshes:  { next: "host_units",   label: (r) => r.given_name,                              idField: "meshId",  idKey: "id" },
-  host_units:   { next: "proc_meshes",  label: (r) => r.mesh_name ?? "Host",                       idField: "meshId",  idKey: "mesh_id" },
-  proc_meshes:  { next: "proc_units",   label: (r) => r.given_name,                              idField: "meshId",  idKey: "id" },
-  proc_units:   { next: "actor_meshes", label: (r) => r.mesh_name ?? "Proc",                     idField: "meshId",  idKey: "mesh_id" },
-  actor_meshes: { next: "actors",       label: (r) => r.given_name,                              idField: "meshId",  idKey: "id" },
-  actors:       { next: "actor_detail", label: (r) => r.full_name?.split("/").pop() ?? "Actor",  idField: "actorId", idKey: "id" },
+  host_meshes:  { next: "host_units",   label: (r) => r.given_name,       idField: "meshId",  idKey: "id" },
+  host_units:   { next: "proc_meshes",  label: (r) => leafName(r.full_name), idField: "meshId",  idKey: "mesh_id" },
+  proc_meshes:  { next: "proc_units",   label: (r) => r.given_name,       idField: "meshId",  idKey: "id" },
+  proc_units:   { next: "actor_meshes", label: (r) => leafName(r.full_name), idField: "meshId",  idKey: "mesh_id" },
+  actor_meshes: { next: "actors",       label: (r) => r.given_name,       idField: "meshId",  idKey: "id" },
+  actors:       { next: "actor_detail", label: (r) => leafName(r.full_name), idField: "actorId", idKey: "id" },
 };
 
 /** MeshTable config per hierarchy level. */
@@ -62,13 +74,14 @@ const LEVEL_CONFIG: Partial<Record<NavItem["level"], {
   apiPath: (n: NavItem) => string;
   columns: Array<{ key: string; label: string }>;
   title: string;
+  clientFilter?: (rows: any[]) => any[];
 }>> = {
-  host_meshes:  { apiPath: ()  => "/meshes?class=Host",            columns: MESH_COLUMNS,  title: "Host Meshes" },
-  host_units:   { apiPath: (n) => `/actors?mesh_id=${n.meshId}`,   columns: AGENT_COLUMNS, title: "Host Units" },
-  proc_meshes:  { apiPath: (n) => `/meshes/${n.meshId}/children`,  columns: MESH_COLUMNS,  title: "Proc Meshes" },
-  proc_units:   { apiPath: (n) => `/actors?mesh_id=${n.meshId}`,   columns: AGENT_COLUMNS, title: "Proc Units" },
-  actor_meshes: { apiPath: (n) => `/meshes/${n.meshId}/children`,  columns: MESH_COLUMNS,  title: "Actor Meshes" },
-  actors:       { apiPath: (n) => `/actors?mesh_id=${n.meshId}`,   columns: ACTOR_COLUMNS, title: "Actors" },
+  host_meshes:  { apiPath: ()  => "/meshes?class=Host",                                          columns: MESH_COLUMNS,  title: "Host Meshes" },
+  host_units:   { apiPath: (n) => `/actors?mesh_id=${n.meshId}`,                                 columns: AGENT_COLUMNS, title: "Host Units",    clientFilter: (rows) => rows.filter(r => _isHostAgent(r.full_name ?? "")) },
+  proc_meshes:  { apiPath: (n) => `/meshes/${n.meshId}/children?mesh_class=Proc`,                columns: MESH_COLUMNS,  title: "Proc Meshes" },
+  proc_units:   { apiPath: (n) => `/actors?mesh_id=${n.meshId}`,                                 columns: AGENT_COLUMNS, title: "Proc Units",    clientFilter: (rows) => rows.filter(r => _isProcAgent(r.full_name ?? "")) },
+  actor_meshes: { apiPath: (n) => `/meshes/${n.meshId}/children?exclude_classes=Host,Proc`,      columns: MESH_COLUMNS,  title: "Actor Meshes" },
+  actors:       { apiPath: (n) => `/actors?mesh_id=${n.meshId}`,                                 columns: ACTOR_COLUMNS, title: "Actors" },
 };
 
 function App() {
@@ -116,6 +129,7 @@ function App() {
           columns={cfg.columns}
           onRowClick={handleRowClick}
           title={cfg.title}
+          clientFilter={cfg.clientFilter}
         />
       );
     }

--- a/python/monarch/monarch_dashboard/frontend/src/__tests__/App.test.tsx
+++ b/python/monarch/monarch_dashboard/frontend/src/__tests__/App.test.tsx
@@ -46,7 +46,7 @@ const MOCK_SUMMARY = {
   mesh_counts: { total: 10 },
   hierarchy_counts: { host_meshes: 2, proc_meshes: 4, actor_meshes: 4 },
   actor_counts: { total: 10, by_status: { idle: 5, failed: 1, stopped: 4 } },
-  message_counts: { total: 82, by_status: { delivered: 77 }, by_endpoint: { train_step: 18 }, delivery_rate: 0.939 },
+  message_counts: { total: 82, by_status: { complete: 77 }, by_endpoint: { train_step: 18 }, delivery_rate: 0.939 },
   errors: { failed_actors: [], stopped_actors: [], failed_messages: 0 },
   timeline: { start_us: 1700000000000000, end_us: 1700000300000000, failure_onset_us: null, total_status_events: 207, total_message_events: 246 },
   health_score: 64,

--- a/python/monarch/monarch_dashboard/frontend/src/__tests__/DagComponents.test.tsx
+++ b/python/monarch/monarch_dashboard/frontend/src/__tests__/DagComponents.test.tsx
@@ -23,12 +23,17 @@ describe("DagLegend", () => {
 
   it("shows all status labels", () => {
     render(<DagLegend />);
-    expect(screen.getByText("Idle / Active")).toBeInTheDocument();
-    expect(screen.getByText("Processing / Running")).toBeInTheDocument();
+    expect(screen.getByText("Idle")).toBeInTheDocument();
+    expect(screen.getByText("Client")).toBeInTheDocument();
+    expect(screen.getByText("Processing")).toBeInTheDocument();
+    expect(screen.getByText("Saving")).toBeInTheDocument();
+    expect(screen.getByText("Loading")).toBeInTheDocument();
+    expect(screen.getByText("Created")).toBeInTheDocument();
+    expect(screen.getByText("Initializing")).toBeInTheDocument();
+    expect(screen.getByText("Stopping")).toBeInTheDocument();
     expect(screen.getByText("Failed")).toBeInTheDocument();
     expect(screen.getByText("Stopped")).toBeInTheDocument();
-    expect(screen.getByText("Transitional")).toBeInTheDocument();
-    expect(screen.getByText("Neutral (n/a)")).toBeInTheDocument();
+    expect(screen.getByText("Unknown")).toBeInTheDocument();
   });
 
   it("shows node type labels", () => {

--- a/python/monarch/monarch_dashboard/frontend/src/__tests__/SummaryView.test.tsx
+++ b/python/monarch/monarch_dashboard/frontend/src/__tests__/SummaryView.test.tsx
@@ -26,7 +26,7 @@ const MOCK_SUMMARY = {
   },
   message_counts: {
     total: 82,
-    by_status: { delivered: 77, failed: 5 },
+    by_status: { complete: 77 },
     by_endpoint: {
       train_step: 18,
       aggregate_gradients: 15,
@@ -55,7 +55,7 @@ const MOCK_SUMMARY = {
         mesh_id: 4,
       },
     ],
-    failed_messages: 5,
+    failed_messages: 0,
   },
   timeline: {
     start_us: 1700000000000000,
@@ -195,11 +195,12 @@ describe("SummaryView", () => {
     });
   });
 
-  it("shows failed messages count", async () => {
+  it("does not show undelivered messages when count is zero", async () => {
     render(<SummaryView />);
     await waitFor(() => {
-      expect(screen.getByText("5 messages failed delivery")).toBeInTheDocument();
+      expect(screen.getByTestId("error-panel")).toBeInTheDocument();
     });
+    expect(screen.queryByText(/messages? not delivered/)).toBeNull();
   });
 
   it("renders message traffic section", async () => {

--- a/python/monarch/monarch_dashboard/frontend/src/__tests__/status.test.ts
+++ b/python/monarch/monarch_dashboard/frontend/src/__tests__/status.test.ts
@@ -11,29 +11,23 @@ import {
   formatTimestamp,
   formatShape,
   messageStatusColor,
+  leafName,
+  splitMessages,
 } from "../utils/status";
 
 describe("statusColor", () => {
-  test("returns green for idle", () => {
-    expect(statusColor("idle")).toBe("var(--status-healthy)");
-  });
-
-  test("returns blue for processing", () => {
+  test("returns distinct color for each ActorStatus variant", () => {
+    expect(statusColor("idle")).toBe("var(--status-idle)");
+    expect(statusColor("client")).toBe("var(--status-client)");
     expect(statusColor("processing")).toBe("var(--status-processing)");
-  });
-
-  test("returns amber for transitional statuses", () => {
-    for (const s of ["created", "initializing", "saving", "loading", "stopping"]) {
-      expect(statusColor(s)).toBe("var(--status-transitional)");
-    }
-  });
-
-  test("returns red for failed", () => {
+    expect(statusColor("saving")).toBe("var(--status-saving)");
+    expect(statusColor("loading")).toBe("var(--status-loading)");
+    expect(statusColor("created")).toBe("var(--status-created)");
+    expect(statusColor("initializing")).toBe("var(--status-initializing)");
+    expect(statusColor("stopping")).toBe("var(--status-stopping)");
     expect(statusColor("failed")).toBe("var(--status-failed)");
-  });
-
-  test("returns gray for stopped", () => {
     expect(statusColor("stopped")).toBe("var(--status-stopped)");
+    expect(statusColor("unknown")).toBe("var(--status-unknown)");
   });
 
   test("returns muted for null/undefined", () => {
@@ -75,19 +69,67 @@ describe("formatShape", () => {
 });
 
 describe("messageStatusColor", () => {
-  test("delivered is green", () => {
-    expect(messageStatusColor("delivered")).toBe("var(--status-healthy)");
-  });
-
-  test("failed is red", () => {
-    expect(messageStatusColor("failed")).toBe("var(--status-failed)");
-  });
-
   test("queued is amber", () => {
-    expect(messageStatusColor("queued")).toBe("var(--status-transitional)");
+    expect(messageStatusColor("queued")).toBe("var(--msg-status-queued)");
   });
 
-  test("sent is blue", () => {
-    expect(messageStatusColor("sent")).toBe("var(--status-processing)");
+  test("active is blue", () => {
+    expect(messageStatusColor("active")).toBe("var(--msg-status-active)");
+  });
+
+  test("complete is green", () => {
+    expect(messageStatusColor("complete")).toBe("var(--msg-status-complete)");
+  });
+
+  test("unknown status falls back to muted", () => {
+    expect(messageStatusColor("failed")).toBe("var(--text-muted)");
+    expect(messageStatusColor("delivered")).toBe("var(--text-muted)");
+    expect(messageStatusColor("unknown_status")).toBe("var(--text-muted)");
+  });
+});
+
+describe("leafName", () => {
+  test("extracts last segment from slash-separated name", () => {
+    expect(leafName("host_mesh_0/proc_mesh_0/Trainer")).toBe("Trainer");
+  });
+
+  test("extracts last segment from comma-separated name", () => {
+    expect(leafName("host,proc,Trainer")).toBe("Trainer");
+  });
+
+  test("handles mixed separators", () => {
+    expect(leafName("host/proc,unit")).toBe("unit");
+  });
+
+  test("returns dash for null/undefined", () => {
+    expect(leafName(null)).toBe("—");
+    expect(leafName(undefined)).toBe("—");
+  });
+
+  test("returns name as-is when no separators", () => {
+    expect(leafName("Trainer")).toBe("Trainer");
+  });
+});
+
+describe("splitMessages", () => {
+  const msgs = [
+    { id: 1, from_actor_id: 10, to_actor_id: 20 },
+    { id: 2, from_actor_id: 20, to_actor_id: 10 },
+    { id: 3, from_actor_id: 10, to_actor_id: 30 },
+  ];
+
+  test("splits by actor id", () => {
+    const { incoming, outgoing } = splitMessages(msgs, 10);
+    expect(incoming).toHaveLength(1);
+    expect(incoming[0].id).toBe(2);
+    expect(outgoing).toHaveLength(2);
+  });
+
+  test("handles string actor ids", () => {
+    const { incoming, outgoing } = splitMessages(msgs, "20");
+    expect(incoming).toHaveLength(1);
+    expect(incoming[0].id).toBe(1);
+    expect(outgoing).toHaveLength(1);
+    expect(outgoing[0].id).toBe(2);
   });
 });

--- a/python/monarch/monarch_dashboard/frontend/src/components/ActorDetail.tsx
+++ b/python/monarch/monarch_dashboard/frontend/src/components/ActorDetail.tsx
@@ -6,14 +6,14 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from "react";
-import { Actor, ActorStatusEvent, Message } from "../types";
+import React, { useState } from "react";
+import { Actor, ActorStatusEvent, EntityId, Message, MessageStatusEvent } from "../types";
 import { StatusBadge } from "./StatusBadge";
-import { formatTimestamp, messageStatusColor } from "../utils/status";
+import { formatTimestamp, messageStatusColor, splitMessages } from "../utils/status";
 import { useApi } from "../hooks/useApi";
 
 interface ActorDetailProps {
-  actorId: number;
+  actorId: EntityId;
 }
 
 /** Actor detail view: metadata, status timeline, incoming/outgoing messages. */
@@ -33,8 +33,7 @@ export function ActorDetail({ actorId }: ActorDetailProps) {
     return <div className="error-state">Actor not found</div>;
   }
 
-  const incoming = (messages ?? []).filter((m) => m.to_actor_id === actorId);
-  const outgoing = (messages ?? []).filter((m) => m.from_actor_id === actorId);
+  const { incoming, outgoing } = splitMessages(messages ?? [], actorId);
 
   return (
     <div className="actor-detail">
@@ -124,6 +123,12 @@ function MessageTable({
   directionLabel: string;
   directionKey: "from_actor_id" | "to_actor_id";
 }) {
+  const [expandedId, setExpandedId] = useState<EntityId | null>(null);
+
+  const toggleExpand = (id: EntityId) => {
+    setExpandedId((prev) => (prev === id ? null : id));
+  };
+
   return (
     <div className="detail-card">
       <h2 className="detail-card-title">
@@ -145,30 +150,81 @@ function MessageTable({
             </thead>
             <tbody>
               {messages.map((msg) => (
-                <tr key={msg.id}>
-                  <td>Actor #{(msg as any)[directionKey]}</td>
-                  <td>
-                    <span className="endpoint-tag">{msg.endpoint ?? "—"}</span>
-                  </td>
-                  <td>
-                    <span
-                      className="msg-status"
-                      style={{ color: messageStatusColor(msg.status) }}
-                    >
-                      {msg.status}
-                    </span>
-                  </td>
-                  <td>
-                    <span className="mono-cell">
-                      {formatTimestamp(msg.timestamp_us)}
-                    </span>
-                  </td>
-                </tr>
+                <React.Fragment key={msg.id}>
+                  <tr
+                    className="clickable-row"
+                    onClick={() => toggleExpand(msg.id)}
+                  >
+                    <td>Actor #{msg[directionKey]}</td>
+                    <td>
+                      <span className="endpoint-tag">{msg.endpoint ?? "—"}</span>
+                    </td>
+                    <td>
+                      {msg.latest_status ? (
+                        <span
+                          style={{ color: messageStatusColor(msg.latest_status) }}
+                        >
+                          {msg.latest_status}
+                        </span>
+                      ) : "—"}
+                    </td>
+                    <td>
+                      <span className="mono-cell">
+                        {formatTimestamp(msg.timestamp_us)}
+                      </span>
+                    </td>
+                  </tr>
+                  {expandedId === msg.id && (
+                    <tr className="msg-status-expanded-row">
+                      <td colSpan={4}>
+                        <MessageStatusTimeline messageId={msg.id} />
+                      </td>
+                    </tr>
+                  )}
+                </React.Fragment>
               ))}
             </tbody>
           </table>
         </div>
       )}
+    </div>
+  );
+}
+
+/** Fetches and displays the full status event timeline for a single message. */
+function MessageStatusTimeline({ messageId }: { messageId: EntityId }) {
+  const { data: events, loading } = useApi<MessageStatusEvent[]>(
+    `/message_status_events?message_id=${messageId}`,
+    0,
+  );
+
+  if (loading) {
+    return <div className="msg-status-timeline-loading">Loading events...</div>;
+  }
+  if (!events || events.length === 0) {
+    return <div className="msg-status-timeline-empty">No status events</div>;
+  }
+
+  return (
+    <div className="msg-status-timeline">
+      {events.map((evt, i) => (
+        <div key={evt.id} className="msg-status-step">
+          <span
+            className="msg-status-dot"
+            style={{ background: messageStatusColor(evt.status) }}
+          />
+          <span
+            className="msg-status-label"
+            style={{ color: messageStatusColor(evt.status) }}
+          >
+            {evt.status}
+          </span>
+          <span className="mono-cell msg-status-time">
+            {formatTimestamp(evt.timestamp_us)}
+          </span>
+          {i < events.length - 1 && <span className="msg-status-arrow">→</span>}
+        </div>
+      ))}
     </div>
   );
 }

--- a/python/monarch/monarch_dashboard/frontend/src/components/DagLegend.tsx
+++ b/python/monarch/monarch_dashboard/frontend/src/components/DagLegend.tsx
@@ -7,15 +7,12 @@
  */
 
 import React from "react";
+import { STATUS_COLORS } from "../utils/status";
 
-const LEGEND_ITEMS = [
-  { color: "var(--status-healthy)", label: "Idle / Active" },
-  { color: "var(--status-processing)", label: "Processing / Running" },
-  { color: "var(--status-transitional)", label: "Transitional" },
-  { color: "var(--status-failed)", label: "Failed" },
-  { color: "var(--status-stopped)", label: "Stopped" },
-  { color: "var(--status-unknown)", label: "Neutral (n/a)" },
-];
+const LEGEND_ITEMS = Object.entries(STATUS_COLORS).map(([status, color]) => ({
+  color,
+  label: status.charAt(0).toUpperCase() + status.slice(1),
+}));
 
 const TIER_ITEMS = [
   { radius: 14, label: "Host Mesh" },

--- a/python/monarch/monarch_dashboard/frontend/src/components/MeshTable.tsx
+++ b/python/monarch/monarch_dashboard/frontend/src/components/MeshTable.tsx
@@ -8,7 +8,7 @@
 
 import React, { useState } from "react";
 import { StatusBadge } from "./StatusBadge";
-import { formatTimestamp } from "../utils/status";
+import { formatTimestamp, formatShape, leafName } from "../utils/status";
 import { useApi } from "../hooks/useApi";
 
 interface EntityTableProps {
@@ -20,6 +20,8 @@ interface EntityTableProps {
   onRowClick: (entity: any) => void;
   /** Label for the table section. */
   title: string;
+  /** Optional client-side filter applied to rows after fetch. */
+  clientFilter?: (rows: any[]) => any[];
 }
 
 interface ColumnDef {
@@ -30,8 +32,9 @@ interface ColumnDef {
 type SortDir = "asc" | "desc";
 
 /** Reusable sortable table for any entity at any hierarchy level. */
-export function MeshTable({ apiPath, columns, onRowClick, title }: EntityTableProps) {
-  const { data: entities, loading, error } = useApi<any[]>(apiPath);
+export function MeshTable({ apiPath, columns, onRowClick, title, clientFilter }: EntityTableProps) {
+  const { data: rawEntities, loading, error } = useApi<any[]>(apiPath);
+  const entities = clientFilter && rawEntities ? clientFilter(rawEntities) : rawEntities;
   const [sortCol, setSortCol] = useState<string>("id");
   const [sortDir, setSortDir] = useState<SortDir>("asc");
 
@@ -110,9 +113,9 @@ function renderCell(key: string, entity: any): React.ReactNode {
     case "mesh_class":
       return val ?? "\u2014";
     case "full_name":
-      return val ? <span className="mono-cell">{val.split("/").pop()}</span> : "\u2014";
+      return <span className="mono-cell">{leafName(val)}</span>;
     case "shape_json":
-      return <span className="mono-cell">{val}</span>;
+      return <span className="mono-cell">{formatShape(val)}</span>;
     case "status":
     case "latest_status":
       return <StatusBadge status={val} />;

--- a/python/monarch/monarch_dashboard/frontend/src/components/NodeDetail.tsx
+++ b/python/monarch/monarch_dashboard/frontend/src/components/NodeDetail.tsx
@@ -8,9 +8,9 @@
 
 import React from "react";
 import { DagNode } from "../utils/dagLayout";
-import { Actor, ActorStatusEvent, Mesh, Message } from "../types";
+import { Actor, ActorStatusEvent, EntityId, Mesh, Message } from "../types";
 import { StatusBadge } from "./StatusBadge";
-import { formatTimestamp } from "../utils/status";
+import { formatTimestamp, messageStatusColor, splitMessages } from "../utils/status";
 import { useApi } from "../hooks/useApi";
 
 interface NodeDetailProps {
@@ -65,7 +65,7 @@ function MetaRow({ label, value }: { label: string; value: string }) {
 }
 
 /** Actor-specific details: status timeline + messages. */
-function ActorDetails({ actorId }: { actorId: number }) {
+function ActorDetails({ actorId }: { actorId: EntityId }) {
   const { data: events } = useApi<ActorStatusEvent[]>(
     `/actors/${actorId}/status_events`
   );
@@ -73,8 +73,7 @@ function ActorDetails({ actorId }: { actorId: number }) {
     `/actors/${actorId}/messages`
   );
 
-  const incoming = (messages ?? []).filter((m) => m.to_actor_id === actorId);
-  const outgoing = (messages ?? []).filter((m) => m.from_actor_id === actorId);
+  const { incoming, outgoing } = splitMessages(messages ?? [], actorId);
 
   return (
     <>
@@ -128,7 +127,7 @@ function ActorDetails({ actorId }: { actorId: number }) {
                     <td style={{ color: "var(--status-processing)" }}>&larr; in</td>
                     <td>#{m.from_actor_id}</td>
                     <td><span className="endpoint-tag">{m.endpoint ?? "\u2014"}</span></td>
-                    <td>{m.status}</td>
+                    <td>{m.latest_status ? <span style={{ color: messageStatusColor(m.latest_status) }}>{m.latest_status}</span> : "\u2014"}</td>
                   </tr>
                 ))}
                 {outgoing.slice(0, 10).map((m) => (
@@ -136,7 +135,7 @@ function ActorDetails({ actorId }: { actorId: number }) {
                     <td style={{ color: "var(--accent-secondary)" }}>&rarr; out</td>
                     <td>#{m.to_actor_id}</td>
                     <td><span className="endpoint-tag">{m.endpoint ?? "\u2014"}</span></td>
-                    <td>{m.status}</td>
+                    <td>{m.latest_status ? <span style={{ color: messageStatusColor(m.latest_status) }}>{m.latest_status}</span> : "\u2014"}</td>
                   </tr>
                 ))}
               </tbody>
@@ -149,7 +148,7 @@ function ActorDetails({ actorId }: { actorId: number }) {
 }
 
 /** Mesh-specific details: show child meshes and actors. */
-function MeshDetails({ meshId }: { meshId: number }) {
+function MeshDetails({ meshId }: { meshId: EntityId }) {
   const { data: mesh } = useApi<Mesh>(`/meshes/${meshId}`);
   const { data: children } = useApi<Mesh[]>(`/meshes/${meshId}/children`);
   const { data: actors } = useApi<Actor[]>(`/actors?mesh_id=${meshId}`);

--- a/python/monarch/monarch_dashboard/frontend/src/components/SummaryView.tsx
+++ b/python/monarch/monarch_dashboard/frontend/src/components/SummaryView.tsx
@@ -8,7 +8,7 @@
 
 import React from "react";
 import { useApi } from "../hooks/useApi";
-import { Summary } from "../types";
+import { EntityId, Summary } from "../types";
 import { statusColor, formatTimestamp, messageStatusColor } from "../utils/status";
 import { StatusBadge } from "./StatusBadge";
 
@@ -81,10 +81,11 @@ function ActorErrorGroup({
   title,
 }: {
   actors: Array<{
-    actor_id: number;
+    actor_id: EntityId;
     full_name: string;
     reason: string | null;
     timestamp_us: number;
+    mesh_id?: EntityId;
   }>;
   title: string;
 }) {
@@ -101,8 +102,13 @@ function ActorErrorGroup({
             {a.full_name.split("/").pop()}
           </div>
           <div className="summary-error-detail">
-            <span className="summary-error-reason">
-              {a.reason ?? title.toLowerCase().replace(" actors", "")}
+            <span className="summary-error-reason-wrap">
+              <span className="summary-error-reason">
+                {a.reason ?? title.toLowerCase().replace(" actors", "")}
+              </span>
+              <span className="summary-error-popover">
+                {a.reason ?? title.toLowerCase().replace(" actors", "")}
+              </span>
             </span>
             <span className="summary-error-time">
               {formatTimestamp(a.timestamp_us)}
@@ -143,10 +149,10 @@ function ErrorPanel({ errors }: { errors: Summary["errors"] }) {
 
       {errors.failed_messages > 0 && (
         <div className="summary-error-group">
-          <h4 className="summary-error-heading">Failed Messages</h4>
+          <h4 className="summary-error-heading">Undelivered Messages</h4>
           <div className="summary-error-item">
             <div className="summary-error-name">
-              {errors.failed_messages} message{errors.failed_messages !== 1 ? "s" : ""} failed delivery
+              {errors.failed_messages} message{errors.failed_messages !== 1 ? "s" : ""} not delivered
             </div>
           </div>
         </div>
@@ -160,27 +166,36 @@ function MessageTraffic({ counts }: { counts: Summary["message_counts"] }) {
     (a, b) => b[1] - a[1]
   );
   const maxCount = Math.max(...endpoints.map(([, c]) => c));
+  const statusEntries = Object.entries(counts.by_status);
+  const total = counts.total || 1;
 
   return (
     <div className="summary-section" data-testid="message-traffic">
       <h3 className="summary-section-title">Message Traffic</h3>
 
-      {/* Delivery rate gauge */}
+      {/* Segmented status bar */}
       <div className="summary-delivery-rate">
         <div className="summary-delivery-bar-bg">
-          <div
-            className="summary-delivery-bar-fill"
-            style={{ width: `${counts.delivery_rate * 100}%` }}
-          />
+          {statusEntries.map(([status, count]) => (
+            <div
+              key={status}
+              className="summary-delivery-bar-segment"
+              style={{
+                width: `${(count / total) * 100}%`,
+                background: messageStatusColor(status),
+              }}
+              title={`${status}: ${count} (${((count / total) * 100).toFixed(1)}%)`}
+            />
+          ))}
         </div>
         <span className="summary-delivery-label">
           {(counts.delivery_rate * 100).toFixed(1)}% delivery rate
         </span>
       </div>
 
-      {/* Status breakdown */}
+      {/* Status legend */}
       <div className="summary-msg-statuses">
-        {Object.entries(counts.by_status).map(([status, count]) => (
+        {statusEntries.map(([status, count]) => (
           <div key={status} className="summary-msg-status-chip">
             <span
               className="status-dot"

--- a/python/monarch/monarch_dashboard/frontend/src/types/index.ts
+++ b/python/monarch/monarch_dashboard/frontend/src/types/index.ts
@@ -8,59 +8,67 @@
 
 /** Data contract types matching the Monarch Dashboard API. */
 
+/**
+ * Entity IDs may be 64-bit integers which exceed JavaScript's
+ * Number.MAX_SAFE_INTEGER.  The server serializes these as strings
+ * to preserve precision; small IDs remain numeric.
+ */
+export type EntityId = number | string;
+
 /** A mesh in the hierarchy (Host, Proc, or actor mesh). */
 export interface Mesh {
-  id: number;
+  id: EntityId;
   timestamp_us: number;
   class: string;
   given_name: string;
   full_name: string;
   shape_json: string;
-  parent_mesh_id: number | null;
+  parent_mesh_id: EntityId | null;
   parent_view_json: string | null;
 }
 
 /** An actor (regular actors + system agents like HostAgent, ProcAgent). */
 export interface Actor {
-  id: number;
+  id: EntityId;
   timestamp_us: number;
-  mesh_id: number;
+  mesh_id: EntityId;
   rank: number;
   full_name: string;
+  display_name?: string | null;
   latest_status?: string | null;
   status_timestamp_us?: number | null;
 }
 
 export interface ActorStatusEvent {
-  id: number;
+  id: EntityId;
   timestamp_us: number;
-  actor_id: number;
+  actor_id: EntityId;
   new_status: string;
   reason: string | null;
 }
 
 export interface Message {
-  id: number;
+  id: EntityId;
   timestamp_us: number;
-  from_actor_id: number;
-  to_actor_id: number;
-  status: string;
+  from_actor_id: EntityId;
+  to_actor_id: EntityId;
   endpoint: string | null;
-  port_id: number | null;
+  port_id: EntityId | null;
+  latest_status?: string | null;
 }
 
 export interface MessageStatusEvent {
-  id: number;
+  id: EntityId;
   timestamp_us: number;
-  message_id: number;
+  message_id: EntityId;
   status: string;
 }
 
 export interface SentMessage {
-  id: number;
+  id: EntityId;
   timestamp_us: number;
-  sender_actor_id: number;
-  mesh_id: number;
+  sender_actor_id: EntityId;
+  actor_mesh_id: EntityId;
   view_json: string;
   shape_json: string;
 }
@@ -76,8 +84,8 @@ export interface NavItem {
     | "actor_meshes"
     | "actors"
     | "actor_detail";
-  meshId?: number;
-  actorId?: number;
+  meshId?: EntityId;
+  actorId?: EntityId;
 }
 
 /** Aggregate summary returned by GET /api/summary. */
@@ -102,18 +110,18 @@ export interface Summary {
   };
   errors: {
     failed_actors: Array<{
-      actor_id: number;
+      actor_id: EntityId;
       full_name: string;
       reason: string | null;
       timestamp_us: number;
-      mesh_id: number;
+      mesh_id: EntityId;
     }>;
     stopped_actors: Array<{
-      actor_id: number;
+      actor_id: EntityId;
       full_name: string;
       reason: string | null;
       timestamp_us: number;
-      mesh_id: number;
+      mesh_id: EntityId;
     }>;
     failed_messages: number;
   };

--- a/python/monarch/monarch_dashboard/frontend/src/utils/dagLayout.ts
+++ b/python/monarch/monarch_dashboard/frontend/src/utils/dagLayout.ts
@@ -25,7 +25,7 @@ export type DagTier = "host_mesh" | "host_unit" | "proc_mesh" | "proc_unit" | "a
 /** A node from the /api/dag response (before positioning). */
 export interface ApiDagNode {
   id: string;
-  entity_id: number;
+  entity_id: number | string;
   tier: DagTier;
   label: string;
   subtitle: string;
@@ -56,7 +56,7 @@ export interface DagNode {
   radius: number;
   tier: DagTier;
   status: string;
-  entityId: number;
+  entityId: number | string;
 }
 
 /** An edge connecting two nodes (camelCase for frontend use). */

--- a/python/monarch/monarch_dashboard/frontend/src/utils/status.ts
+++ b/python/monarch/monarch_dashboard/frontend/src/utils/status.ts
@@ -8,21 +8,18 @@
 
 /** Status color and label utilities for Monarch actor statuses. */
 
-const STATUS_COLORS: Record<string, string> = {
-  idle: "var(--status-healthy)",
+export const STATUS_COLORS: Record<string, string> = {
+  idle: "var(--status-idle)",
+  client: "var(--status-client)",
   processing: "var(--status-processing)",
-  created: "var(--status-transitional)",
-  initializing: "var(--status-transitional)",
-  saving: "var(--status-transitional)",
-  loading: "var(--status-transitional)",
-  stopping: "var(--status-transitional)",
+  saving: "var(--status-saving)",
+  loading: "var(--status-loading)",
+  created: "var(--status-created)",
+  initializing: "var(--status-initializing)",
+  stopping: "var(--status-stopping)",
   failed: "var(--status-failed)",
   stopped: "var(--status-stopped)",
   unknown: "var(--status-unknown)",
-  client: "var(--status-unknown)",
-  "n/a": "var(--status-neutral)",
-  active: "var(--status-healthy)",
-  running: "var(--status-processing)",
 };
 
 /** Map a status string to its CSS color variable. */
@@ -32,9 +29,11 @@ export function statusColor(status: string | null | undefined): string {
 }
 
 /** Format a microsecond timestamp to a readable string. */
-export function formatTimestamp(us: number): string {
+export function formatTimestamp(us: number | null | undefined): string {
+  if (us == null || isNaN(us)) return "—";
   const ms = us / 1000;
   const d = new Date(ms);
+  if (isNaN(d.getTime())) return "—";
   return d.toISOString().replace("T", " ").replace("Z", "").slice(0, 23);
 }
 
@@ -49,13 +48,33 @@ export function formatShape(shapeJson: string): string {
   }
 }
 
-/** Message status color. */
+/** Extract the last segment from a hierarchical name.
+ *  Handles both ``/`` (fake data) and ``,`` (real data) separators.
+ *  e.g. "host_mesh_0/proc_mesh_0/Trainer" → "Trainer"
+ */
+export function leafName(name: string | null | undefined): string {
+  if (!name) return "—";
+  return name.split("/").pop()!.split(",").pop()!;
+}
+
+/** Split messages into incoming and outgoing for a given actor. */
+export function splitMessages<T extends { from_actor_id: any; to_actor_id: any }>(
+  messages: T[],
+  actorId: number | string,
+): { incoming: T[]; outgoing: T[] } {
+  const id = String(actorId);
+  return {
+    incoming: messages.filter((m) => String(m.to_actor_id) === id),
+    outgoing: messages.filter((m) => String(m.from_actor_id) === id),
+  };
+}
+
+/** Message status color (queued/active/complete lifecycle). */
 export function messageStatusColor(status: string): string {
   switch (status.toLowerCase()) {
-    case "delivered": return "var(--status-healthy)";
-    case "sent": return "var(--status-processing)";
-    case "queued": return "var(--status-transitional)";
-    case "failed": return "var(--status-failed)";
+    case "queued": return "var(--msg-status-queued)";
+    case "active": return "var(--msg-status-active)";
+    case "complete": return "var(--msg-status-complete)";
     default: return "var(--text-muted)";
   }
 }


### PR DESCRIPTION
Summary:
## Type alignment (entity_dispatcher.rs RecordBatchRow structs)

- EntityId = number | string — 64-bit IDs from DataFusion may exceed
  JS Number.MAX_SAFE_INTEGER; server serializes large IDs as strings.
- Message type: remove `status` field, add `latest_status?: string | null`
  (derived server-side from message_status_events JOIN).
- SentMessage type: `mesh_id` → `actor_mesh_id` to match
  entity_dispatcher.rs `SentMessage::actor_mesh_id: u64`.
- Actor type: add `display_name?: string | null` to match
  entity_dispatcher.rs `Actor::display_name: Option<String>`.
- Message.port_id: `number | null` → `EntityId | null` for 64-bit safety.
- Message statuses: only "queued", "active", "complete" — "failed" removed
  entirely (hyperactor telemetry never emits it).

## Code quality

- Extract `leafName()` utility in status.ts — replaces 4 duplicate
  `.split("/").pop()!.split(",").pop()` patterns in App.tsx and MeshTable.
- Extract `splitMessages()` utility in status.ts — replaces duplicate
  incoming/outgoing filter logic in ActorDetail and NodeDetail.
- Export `STATUS_COLORS` from status.ts; DagLegend now derives LEGEND_ITEMS
  from it instead of duplicating all 11 color/label entries.
- MeshTable: call `formatShape()` for shape_json column rendering.
- Remove `as any` cast in ActorDetail.tsx message table.
- Remove dead CSS: duplicate padding-left on .table-title, unused
  --status-transitional / --status-neutral / --msg-status-failed variables.

## Components

- ActorDetail/NodeDetail: String() coercion for EntityId comparisons,
  use splitMessages() helper, expandable message status timeline.
- App.tsx: 6-tier hierarchy navigation (host_meshes → host_units →
  proc_meshes → proc_units → actor_meshes → actors → actor_detail).
  Client-side _isHostAgent/_isProcAgent filters for host/proc unit levels.
  Uses leafName() for breadcrumb labels.
- SummaryView: health score gauge, status breakdown, error panel,
  message traffic with delivery rate, timeline with error notches.
- DagView/dagLayout: 6-tier deterministic layout engine, EntityId types.

## Tests

- status.test.ts: "failed" message status now falls through to muted,
  new tests for leafName() and splitMessages().
- SummaryView.test.tsx: mock data updated (failed_messages: 0,
  by_status uses "complete" not "delivered").
- App.test.tsx: mock data aligned with schema changes.

Reviewed By: thedavekwon

Differential Revision: D97136501


