### PR TITLE
Add remotemount: parallel TLS transfer, FUSE integration, and examples (#3114)

### DIFF
--- a/examples/remotemount/REMOTERUN_GUIDE.md
+++ b/examples/remotemount/REMOTERUN_GUIDE.md
@@ -1,0 +1,184 @@
+# Remoterun on MAST: Setup Guide
+
+This guide covers how to set up and run `remoterun` on MAST with different hardware types.
+
+## Quick Start
+
+Use the automated setup script:
+
+```bash
+# Set up conda envs for GB300 (aarch64)
+bash examples/remotemount/setup_conda_env.sh gb300
+
+# Set up conda envs for GrandTeton/H100 (x86)
+bash examples/remotemount/setup_conda_env.sh grandteton
+```
+
+This creates `~/monarch_conda_envs/client/conda` (x86) and
+`~/monarch_conda_envs/worker/conda` (target arch). Then run:
+
+```bash
+bash examples/remotemount/remoterun.sh /tmp/myenv my_script.sh
+```
+
+---
+
+## Platform Notes
+
+### GrandTeton (x86, H100)
+
+- Default host type is `gtt_any` (8 GPUs per host). Our entitlement
+  (`msl_infra_pytorch_dev`) has **0 quota** on GrandTeton — scheduling
+  is opportunistic and may take a long time or fail.
+- GrandTeton has ibverbs RDMA hardware, so transfers use native RDMA
+  (significantly faster than TCP fallback).
+
+### GB300 (aarch64, Blackwell)
+
+- Our entitlement has **17 quota** on GB300 in the `lco` region —
+  scheduling takes ~2 minutes.
+- Must pass `--locality_constraints ""` to allow scheduling in all regions.
+- GB300 has ibverbs RDMA hardware (10 Mellanox ConnectX devices).
+  Client-to-worker transfer uses TCP fallback (client has no ibverbs),
+  but worker-to-worker fan-out uses native ibverbs.
+- The MAST preamble health checks (`toy_ddp`) fail with socket
+  timeouts on GB300 (ephemeral port firewall issue). Remoterun
+  automatically skips them via `MAST_PRECHECK_SKIP_TIME_CONSUMING_CHECKS=1`.
+
+---
+
+## Job Reuse
+
+By default, `remoterun` does not kill the MAST job when the script
+finishes. The next invocation will reconnect to the cached job
+instantly (~0.1s) instead of waiting for new allocation:
+
+```bash
+# First run: allocates workers (~2 min)
+... remoterun.py /tmp/myenv script1.sh --backend mast ...
+
+# Second run: reuses workers (instant)
+... remoterun.py /tmp/myenv script2.sh --backend mast ...
+
+# Kill the job when done
+... remoterun.py /tmp/myenv script.sh --backend mast --kill_job
+```
+
+The job state is cached in `.monarch/job_state.pkl`.
+
+---
+
+## Piping Scripts via stdin
+
+You can pipe a script directly into `remoterun` without creating a file:
+
+```bash
+CONDA_PREFIX=~/monarch_conda_envs/worker/conda \
+~/monarch_conda_envs/client/conda/bin/python3.12 \
+  examples/remotemount/remoterun.py /tmp/myenv stdin \
+  --backend mast --host_type gb200 <<'EOF'
+#!/bin/bash
+echo "Hello from $(hostname)"
+nvidia-smi -L
+python -c "import torch; print(f'torch {torch.__version__}, CUDA {torch.cuda.device_count()} GPUs')"
+EOF
+```
+
+The keyword `stdin` tells remoterun to read the script from standard input
+instead of a file. This is useful for quick one-off commands.
+
+---
+
+## Setting Up a venv with uv
+
+For custom Python environments (e.g. additional pip packages), use `uv` to
+create a venv, then pass it as the source directory to remoterun:
+
+```bash
+# Create a venv with uv and install packages.
+uv venv /tmp/myenv --python 3.12
+uv pip install --python /tmp/myenv/bin/python transformers datasets
+
+# Write a script that uses the venv.
+cat > /tmp/run.sh <<'EOF'
+#!/bin/bash
+export PYTHONPATH="/tmp/myenv/lib/python3.12/site-packages:$PYTHONPATH"
+python -c "
+from transformers import AutoTokenizer
+tok = AutoTokenizer.from_pretrained('gpt2')
+print(f'Vocab size: {tok.vocab_size}')
+"
+EOF
+
+# Run on MAST — remoterun transfers /tmp/myenv to workers and mounts it.
+CONDA_PREFIX=~/monarch_conda_envs/worker/conda \
+~/monarch_conda_envs/client/conda/bin/python3.12 \
+  examples/remotemount/remoterun.py /tmp/myenv /tmp/run.sh \
+  --backend mast --host_type gb200
+```
+
+The venv directory is packed and transferred to workers just like any other
+source directory. The FUSE mount makes it available at the mount point, and
+you set `PYTHONPATH` to point at the site-packages inside it.
+
+---
+
+## Incremental Update Performance
+
+Remotemount uses block-level hashing (64 MB blocks) for incremental
+updates. On re-open, only blocks whose hash changed are re-transferred.
+Unchanged workers skip transfer entirely (metadata + remount only).
+
+### Benchmark setup
+
+- 2 GB200 hosts, 8 parallel TLS streams, TCP fallback (no ibverbs from client)
+- Each payload contains 1000 small `.py` files (~330 KB total) plus a
+  `data.bin` file sized to reach the target payload
+- Warm-up step pre-spawns actors so cold start measures transfer time only
+
+### Scenarios
+
+| Scenario | Description |
+|----------|-------------|
+| Cold start | First transfer to fresh workers |
+| No change | Re-open with identical content — hash match, skip transfer |
+| Rewrite data.bin | Replace `data.bin` with new random content (same size) |
+| Rewrite .py | Rewrite all 1000 `.py` files — only the 64 MB block(s) containing them are re-transferred |
+| Delete file | Remove one `.py` file — partial transfer (only affected blocks) |
+
+### Results — 2 hosts (8 streams)
+
+| Payload | Cold start | No change | Rewrite data.bin | Rewrite .py | Delete file |
+|---------|-----------|-----------|-----------------|-------------|-------------|
+| 1 GB    | 9.9s      | 5.9s      | 9.2s            | 7.9s        | 6.9s        |
+| 2 GB    | 11.7s     | 6.9s      | 11.7s           | 8.0s        | 6.6s        |
+| 4 GB    | 15.9s     | 7.4s      | 16.2s           | 8.7s        | 8.1s        |
+| 8 GB    | 22.5s     | 7.4s      | 22.6s           | 9.6s        | 7.7s        |
+
+### Results — 64 hosts (8 streams, chunked tree fan-out, 4 leaders)
+
+| Payload | Cold start | No change | Rewrite data.bin | Rewrite .py | Delete file |
+|---------|-----------|-----------|-----------------|-------------|-------------|
+| 8 GB    | 46.2s     | 9.2s      | 45.6s           | 13.8s       | 13.2s       |
+
+Key observations:
+
+- **No change** is dominated by client-side packing + hash computation
+  (no network transfer). Time scales sub-linearly with payload size.
+- **Rewrite .py** only re-transfers the 64 MB block(s) containing the
+  ~330 KB of `.py` files; `data.bin` blocks are skipped via hash match.
+  Append-only packing keeps unchanged files at their original offsets,
+  minimizing dirty blocks.
+- **Rewrite data.bin** re-transfers the bulk of the payload since every
+  block changes.
+- **Delete file** uses partial transfer — only the block containing the
+  deleted file is re-transferred, not the entire payload.
+
+To run the benchmark yourself:
+
+```bash
+bash examples/remotemount/setup_conda_env.sh gb200
+CONDA_PREFIX=~/monarch_conda_envs/worker/conda \
+~/monarch_conda_envs/client/conda/bin/python3.12 \
+  examples/remotemount/bench_incremental.py --sizes 1 --hosts 2
+```

--- a/examples/remotemount/bench_incremental.py
+++ b/examples/remotemount/bench_incremental.py
@@ -1,0 +1,543 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Benchmark persistent chunk cache for remotemount across actor restarts.
+
+Calls remoterun.sh repeatedly with modifications between runs to
+exercise cache hit, partial update, and full transfer paths.
+Cache files persist in /tmp/monarch_remotemount_cache/ on worker
+hosts, so subsequent runs on the same hosts skip unchanged data.
+
+Each scenario spawns fresh actors (new subprocess) to simulate real
+restarts. The persistent cache on disk is the only state that carries
+over between scenarios.
+
+Scenarios:
+  1. Cold start (no cache on workers)
+  2. No change (cache hit -> skip transfer)
+  3. Rewrite data.bin same size (partial -> dirty blocks only)
+  4. Rewrite all .py files (partial -> many dirty blocks)
+  5. Delete one file (size change -> stale -> full transfer)
+
+Usage:
+  python3 examples/remotemount/bench_incremental.py --sizes 1 --hosts 2
+  python3 examples/remotemount/bench_incremental.py --sizes 1,2,4 --hosts 2,4,8
+"""
+
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+
+import fire
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+RUN_SCRIPT = os.path.join(SCRIPT_DIR, "remoterun.sh")
+NUM_PY = 1000
+SCENARIOS = [
+    "Cold start",
+    "No change",
+    "Rewrite data.bin",
+    "Rewrite .py",
+    "Delete file",
+]
+
+
+def _parse_list(value):
+    """Parse comma-separated string or numeric value into a list of ints."""
+    if isinstance(value, (int, float)):
+        return [int(value)]
+    if isinstance(value, (list, tuple)):
+        return [int(x) for x in value]
+    return [int(x) for x in str(value).split(",")]
+
+
+def _create_test_dir(base_dir, total_gb):
+    """Create test directory with a large data file and many .py files."""
+    shutil.rmtree(base_dir, ignore_errors=True)
+    os.makedirs(base_dir, exist_ok=True)
+
+    src_dir = os.path.join(base_dir, "src")
+    os.makedirs(src_dir, exist_ok=True)
+    for i in range(NUM_PY):
+        with open(os.path.join(src_dir, f"mod_{i}.py"), "w") as f:
+            f.write(f"# Module {i}\n" * 50 + f"def func_{i}(): return {i}\n")
+
+    py_size = sum(
+        os.path.getsize(os.path.join(src_dir, f)) for f in os.listdir(src_dir)
+    )
+    data_size = max(0, int(total_gb * 1024**3) - py_size)
+    data_path = os.path.join(base_dir, "data.bin")
+    with open(data_path, "wb") as f:
+        remaining = data_size
+        while remaining > 0:
+            chunk = min(remaining, 64 * 1024 * 1024)
+            f.write(os.urandom(chunk))
+            remaining -= chunk
+
+    total_mb = sum(
+        os.path.getsize(os.path.join(r, fn))
+        for r, _, fs in os.walk(base_dir)
+        for fn in fs
+    ) // (1024 * 1024)
+    print(f"  Created {total_mb}MB test directory ({NUM_PY} .py files)")
+
+
+def _run(
+    label, num_hosts, source_dir, script="#!/bin/bash\necho done\n", extra_args=None
+):
+    """Run remoterun via run.sh and return elapsed time."""
+    sys.stdout.write(f"  {label:.<40s}")
+    sys.stdout.flush()
+
+    cmd = [
+        "bash",
+        RUN_SCRIPT,
+        source_dir,
+        "stdin",
+        "--num_hosts",
+        str(num_hosts),
+        "--gpus_per_host",
+        "1",
+    ]
+    if extra_args:
+        cmd.extend(extra_args)
+
+    t0 = time.time()
+    result = subprocess.run(cmd, input=script, capture_output=True, text=True)
+    elapsed = time.time() - t0
+
+    # Extract classification from logs.
+    output = result.stdout + result.stderr
+    classification = ""
+    for line in output.splitlines():
+        m = re.search(
+            r"(\d+)\s+fresh.*?(\d+)\s+partial.*?(\d+)\s+stale",
+            line,
+            re.IGNORECASE,
+        )
+        if m:
+            classification = f"({m.group(1)}F/{m.group(2)}P/{m.group(3)}S)"
+            break
+        if re.search(r"up-to-date|skipping transfer", line, re.IGNORECASE):
+            classification = "(all fresh)"
+            break
+
+    status = "OK" if result.returncode == 0 else f"FAIL({result.returncode})"
+    print(f" {elapsed:7.1f}s  {classification}  {status}")
+
+    # Print timing breakdown lines from logs.
+    for line in output.splitlines():
+        if any(
+            k in line.lower()
+            for k in (
+                "timings:",
+                "pack_directory_chunked:",
+                "persistent block transfer",
+                "fan-out:",
+                "_transfer_group",
+                "open() timings:",
+                "cache_write",
+                "write_cache",
+            )
+        ):
+            # Strip log prefix to show just the timing info.
+            idx = -1
+            for marker in (
+                "pack_directory_chunked:",
+                "Persistent block transfer",
+                "Fan-out:",
+                "Timings:",
+                "timings:",
+                "_transfer_group_direct_tls:",
+                "_transfer_group:",
+                "open() timings:",
+                "open(): cache_write",
+                "[WORKER] write_cache",
+            ):
+                idx = line.find(marker)
+                if idx >= 0:
+                    break
+            if idx >= 0:
+                print(f"    {line[idx:]}")
+
+    if result.returncode != 0:
+        stderr_lines = result.stderr.strip().splitlines()
+        for line in stderr_lines[-5:]:
+            print(f"    {line}")
+
+    return elapsed
+
+
+def _run_with_dummy(label, num_hosts, warmup_dir, script, extra_args=None):
+    """Run a script on workers using a tiny dummy source directory."""
+    shutil.rmtree(warmup_dir, ignore_errors=True)
+    os.makedirs(warmup_dir, exist_ok=True)
+    with open(os.path.join(warmup_dir, "dummy.txt"), "w") as f:
+        f.write("x\n")
+    elapsed = _run(
+        label, num_hosts, source_dir=warmup_dir, script=script, extra_args=extra_args
+    )
+    shutil.rmtree(warmup_dir, ignore_errors=True)
+    return elapsed
+
+
+def _warmup(num_hosts, warmup_dir):
+    """Allocate MAST job and pre-spawn actors."""
+    print(f"\n  Allocating MAST job ({num_hosts} hosts)...")
+    t0 = time.time()
+    _run_with_dummy("warmup", num_hosts, warmup_dir, "#!/bin/bash\necho ready\n")
+    elapsed = time.time() - t0
+    print(f"  MAST job allocated in {elapsed:.0f}s\n")
+
+
+def _clear_worker_cache(num_hosts, warmup_dir):
+    """Clear persistent cache on all workers."""
+    _run_with_dummy(
+        "clear cache",
+        num_hosts,
+        warmup_dir,
+        "#!/bin/bash\nrm -rf /tmp/monarch_remotemount_cache/\necho cleared\n",
+    )
+
+
+def _kill_job():
+    """Kill MAST jobs and clear local state."""
+    print("  Killing MAST jobs...")
+    result = subprocess.run(
+        ["mast", "list-jobs", "--prefix", "monarch-", "--output", "json"],
+        capture_output=True,
+        text=True,
+    )
+    for line in result.stdout.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            data = json.loads(line)
+            jobs = data if isinstance(data, list) else [data]
+            for job in jobs:
+                name = job.get("name", job.get("job_name", ""))
+                if name:
+                    print(f"    Killing {name}...")
+                    subprocess.run(
+                        ["mast", "kill", name, "--comment", "bench cleanup"],
+                        capture_output=True,
+                        text=True,
+                    )
+        except (json.JSONDecodeError, TypeError):
+            pass
+    try:
+        os.remove(".monarch/job_state.pkl")
+    except FileNotFoundError:
+        pass
+    print("  Done.")
+
+
+def _hash_directory(path):
+    """Hash a directory tree deterministically."""
+    import xxhash
+
+    h = xxhash.xxh64()
+    for root, dirs, files in sorted(os.walk(path)):
+        dirs.sort()
+        for fname in sorted(files):
+            fpath = os.path.join(root, fname)
+            rel = os.path.relpath(fpath, path)
+            h.update(rel.encode())
+            with open(fpath, "rb") as f:
+                while True:
+                    chunk = f.read(1024 * 1024)
+                    if not chunk:
+                        break
+                    h.update(chunk)
+    return h.hexdigest()
+
+
+def _worker_hash_script(mount_path):
+    """Generate a bash script that hashes the FUSE-mounted directory."""
+    return f"""\
+#!/bin/bash
+python -c "
+import os, xxhash
+mount = '{mount_path}'
+h = xxhash.xxh64()
+for root, dirs, files in sorted(os.walk(mount)):
+    dirs.sort()
+    for fname in sorted(files):
+        fpath = os.path.join(root, fname)
+        rel = os.path.relpath(fpath, mount)
+        h.update(rel.encode())
+        with open(fpath, 'rb') as f:
+            while True:
+                chunk = f.read(1024 * 1024)
+                if not chunk:
+                    break
+                h.update(chunk)
+print('HASH:' + h.hexdigest())
+"
+"""
+
+
+def _verify_content(label, num_hosts, source_dir, extra_args=None):
+    """Verify mounted content matches client by comparing directory hashes."""
+    sys.stdout.write(f"  {label:.<40s}")
+    sys.stdout.flush()
+
+    # Hash on client (in-process, uses conda env's xxhash).
+    client_hash = _hash_directory(source_dir)
+
+    # Hash on workers (via remoterun).
+    cmd = [
+        "bash",
+        RUN_SCRIPT,
+        source_dir,
+        "stdin",
+        "--num_hosts",
+        str(num_hosts),
+        "--gpus_per_host",
+        "1",
+    ]
+    if extra_args:
+        cmd.extend(extra_args)
+
+    result = subprocess.run(
+        cmd, input=_worker_hash_script(source_dir), capture_output=True, text=True
+    )
+    output = result.stdout + result.stderr
+
+    worker_hashes = []
+    for line in output.splitlines():
+        if line.strip().startswith("HASH:"):
+            worker_hashes.append(line.strip().split("HASH:")[1])
+
+    if not worker_hashes:
+        print(f" FAIL (no worker hashes, rc={result.returncode})")
+        if result.returncode != 0:
+            for line in result.stderr.strip().splitlines()[-5:]:
+                print(f"    {line}")
+        return False
+
+    mismatches = [i for i, wh in enumerate(worker_hashes) if wh != client_hash]
+    if mismatches:
+        print(f" FAIL (mismatch on workers {mismatches})")
+        print(f"    client={client_hash}")
+        for i in mismatches:
+            print(f"    worker[{i}]={worker_hashes[i]}")
+        return False
+
+    print(f" OK ({len(worker_hashes)} workers, hash={client_hash[:12]})")
+    return True
+
+
+def _run_scenarios(num_hosts, size_gb, bench_dir, extra_args=None):
+    """Run all 5 scenarios for a given payload size, return dict of times."""
+    src_dir = os.path.join(bench_dir, "src")
+    data_path = os.path.join(bench_dir, "data.bin")
+    results = {}
+
+    # 1. Cold start (cache was cleared before this call)
+    results["Cold start"] = _run(
+        "Cold start", num_hosts, bench_dir, extra_args=extra_args
+    )
+    _verify_content("  verify cold start", num_hosts, bench_dir, extra_args)
+
+    # 2. No change (cache hit from cold start)
+    results["No change"] = _run(
+        "No change", num_hosts, bench_dir, extra_args=extra_args
+    )
+
+    # 3. Rewrite data.bin (same size -> partial update)
+    data_size = os.path.getsize(data_path)
+    with open(data_path, "wb") as f:
+        remaining = data_size
+        while remaining > 0:
+            chunk = min(remaining, 64 * 1024 * 1024)
+            f.write(os.urandom(chunk))
+            remaining -= chunk
+    results["Rewrite data.bin"] = _run(
+        "Rewrite data.bin", num_hosts, bench_dir, extra_args=extra_args
+    )
+    _verify_content("  verify rewrite data.bin", num_hosts, bench_dir, extra_args)
+
+    # 4. Rewrite all .py files (partial update)
+    # Use same-length prefix ("Modify" vs "Module" = 6 chars each) and
+    # same return value so total file size is unchanged → partial not stale.
+    for i in range(NUM_PY):
+        with open(os.path.join(src_dir, f"mod_{i}.py"), "w") as f:
+            f.write(f"# Modify {i}\n" * 50 + f"def func_{i}(): return {i}\n")
+    results["Rewrite .py"] = _run(
+        "Rewrite .py files", num_hosts, bench_dir, extra_args=extra_args
+    )
+    _verify_content("  verify rewrite .py", num_hosts, bench_dir, extra_args)
+
+    # 5. Delete file (total size changes -> stale -> full transfer)
+    os.remove(os.path.join(src_dir, "mod_0.py"))
+    results["Delete file"] = _run(
+        "Delete file", num_hosts, bench_dir, extra_args=extra_args
+    )
+    _verify_content("  verify delete file", num_hosts, bench_dir, extra_args)
+
+    return results
+
+
+def _print_table(all_results):
+    """Print markdown table of results."""
+    if not all_results:
+        return
+
+    host_counts = sorted({h for h, _ in all_results.keys()})
+    sizes = sorted({s for _, s in all_results.keys()})
+
+    for num_hosts in host_counts:
+        print(f"\n### {num_hosts} host{'s' if num_hosts > 1 else ''}\n")
+        print(
+            "| Payload | Cold start | No change | Rewrite data.bin "
+            "| Rewrite .py | Delete file |"
+        )
+        print(
+            "|---------|-----------|-----------|-----------------|"
+            "-------------|-------------|"
+        )
+        for size_gb in sizes:
+            key = (num_hosts, size_gb)
+            if key not in all_results:
+                continue
+            r = all_results[key]
+            cols = [f"{size_gb}GB"]
+            for scenario in SCENARIOS:
+                t = r.get(scenario, float("nan"))
+                cols.append(f"{t:.1f}s")
+            print("| " + " | ".join(cols) + " |")
+    print()
+
+
+def _run_host_count(num_hosts, size_list, work_dir, extra_args=None, reuse_job=False):
+    """Run all payload sizes for a single host count.
+
+    Uses work_dir for .monarch/job_state.pkl isolation and
+    per-host-count temp directories for bench/warmup data.
+    Returns dict mapping (num_hosts, size_gb) -> scenario results.
+    """
+    bench_dir = os.path.join(work_dir, "bench")
+    warmup_dir = os.path.join(work_dir, "warmup")
+    os.makedirs(work_dir, exist_ok=True)
+
+    # Run from work_dir so .monarch/job_state.pkl is isolated.
+    orig_cwd = os.getcwd()
+    os.chdir(work_dir)
+    os.makedirs(".monarch", exist_ok=True)
+
+    try:
+        print(f"\n{'=' * 60}")
+        print(f"  {num_hosts} host{'s' if num_hosts > 1 else ''}")
+        print(f"{'=' * 60}")
+
+        state_pkl = os.path.join(work_dir, ".monarch", "job_state.pkl")
+        if reuse_job and os.path.exists(state_pkl):
+            print(f"\n  Reusing existing MAST job (found {state_pkl})")
+        else:
+            if reuse_job:
+                print(f"\n  No cached job found at {state_pkl}, allocating new job...")
+            _warmup(num_hosts, warmup_dir)
+
+        host_results = {}
+        for size_gb in size_list:
+            print(f"\n--- {size_gb}GB payload, {num_hosts} hosts ---")
+            _create_test_dir(bench_dir, size_gb)
+            _clear_worker_cache(num_hosts, warmup_dir)
+
+            results = _run_scenarios(
+                num_hosts, size_gb, bench_dir, extra_args=extra_args
+            )
+            host_results[(num_hosts, size_gb)] = results
+
+            shutil.rmtree(bench_dir, ignore_errors=True)
+
+        _print_table(host_results)
+        if not reuse_job:
+            _kill_job()
+        else:
+            print("  (--reuse_job: keeping MAST job alive for reuse)")
+        return host_results
+    finally:
+        os.chdir(orig_cwd)
+
+
+def main(
+    host_type="gb200",
+    sizes="1",
+    hosts="2",
+    streams=8,
+    reuse_job=False,
+    work_dir="",
+):
+    """Run persistent cache benchmark across payload sizes and host counts.
+
+    Args:
+        host_type: MAST host type (default: gb200). Options: gb200, gb300, grandteton
+        sizes: Comma-separated GB values (e.g., "1,2,4,8,16,32,64,128")
+        hosts: Comma-separated host counts (e.g., "1,2,4,8,16")
+        streams: Number of parallel TLS streams per host (default: 8)
+        reuse_job: If True, keep the MAST job alive after the benchmark
+            so subsequent runs can reuse the same workers instantly.
+        work_dir: Persistent directory for job state. If empty, a temp dir
+            is created. Use with --reuse_job to reuse workers across runs.
+    """
+    size_list = _parse_list(sizes)
+    host_list = _parse_list(hosts)
+    streams = int(streams)
+
+    # Set host type for remoterun.sh.
+    os.environ["MONARCH_HOST_TYPE"] = host_type
+
+    print("=" * 60)
+    print("  Persistent Cache Benchmark")
+    print(f"  Sizes: {size_list} GB")
+    print(f"  Hosts: {host_list}")
+    print(f"  Streams: {streams}")
+    print(f"  Host type: {host_type}")
+    print("=" * 60)
+
+    base_work_dir = (
+        work_dir if work_dir else tempfile.mkdtemp(prefix="bench_incremental_")
+    )
+    os.makedirs(base_work_dir, exist_ok=True)
+
+    extra_args = ["--num_parallel_streams", str(streams)]
+
+    all_results = {}
+    for num_hosts in host_list:
+        work_dir = os.path.join(base_work_dir, f"h{num_hosts}")
+        try:
+            host_results = _run_host_count(
+                num_hosts,
+                size_list,
+                work_dir,
+                extra_args=extra_args,
+                reuse_job=reuse_job,
+            )
+            all_results.update(host_results)
+        except Exception as e:
+            print(f"\n  ERROR: {num_hosts} hosts failed: {e}")
+
+    shutil.rmtree(base_work_dir, ignore_errors=True)
+
+    # Final summary.
+    print(f"\n{'=' * 60}")
+    print("  Final Results")
+    print(f"{'=' * 60}")
+    _print_table(all_results)
+    print("Done.")
+
+
+if __name__ == "__main__":
+    fire.Fire(main)

--- a/examples/remotemount/remoterun.py
+++ b/examples/remotemount/remoterun.py
@@ -1,0 +1,323 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import time as _time_mod
+
+_t_import_start = _time_mod.time()
+
+import logging  # noqa: E402
+import os  # noqa: E402
+import subprocess  # noqa: E402
+import sys  # noqa: E402
+import tempfile  # noqa: E402
+import time  # noqa: E402
+from pathlib import Path  # noqa: E402
+
+import cloudpickle  # noqa: E402
+from monarch.actor import Actor, endpoint, this_host  # noqa: E402
+from monarch.config import configure  # noqa: E402
+from monarch.job import SlurmJob  # noqa: E402
+from monarch.remotemount import remotemount  # noqa: E402
+
+
+class BashActor(Actor):
+    @endpoint
+    def run(self, script: str):
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".sh", delete=True) as f:
+            f.write(script)
+            f.flush()
+            result = subprocess.run(["bash", f.name], capture_output=True, text=True)
+        return {
+            "returncode": result.returncode,
+            "stdout": result.stdout,
+            "stderr": result.stderr,
+        }
+
+
+def _get_mast_host_mesh(
+    num_hosts,
+    gpus_per_host,
+    hpc_identity,
+    hpc_job_oncall,
+    hpc_cluster_uuid,
+    rm_attribution,
+    locality_constraints,
+    host_type,
+):
+    t0 = time.time()
+    from monarch.actor import enable_transport
+    from monarch.job.meta import MASTJob
+
+    t1 = time.time()
+    enable_transport("metatls-hostname")
+    t2 = time.time()
+
+    if locality_constraints is None:
+        locality_constraints = []
+
+    job = MASTJob(
+        hpcIdentity=hpc_identity,
+        hpcJobOncall=hpc_job_oncall,
+        rmAttribution=rm_attribution,
+        hpcClusterUuid=hpc_cluster_uuid,
+        useStrictName=True,
+        localityConstraints=locality_constraints,
+        env={
+            "PYTHONDONTWRITEBYTECODE": "1",
+            # Skip preamble health checks on GB300 — toy_ddp TCP store
+            # connections time out between hosts on ephemeral ports.
+            "MAST_PRECHECK_SKIP_TIME_CONSUMING_CHECKS": "1",
+            # Disable conda activate hooks — run_activate_hooks.sh
+            # crashes bash with "pop_var_context" on some host images.
+            "HOOKS_DISABLED": "1",
+            "RUST_LOG": "info",
+        },
+    )
+    t3 = time.time()
+    job.add_mesh("workers", num_hosts, host_type=host_type)
+    # A workspace directory is required to trigger conda-packing of
+    # CONDA_PREFIX into an ephemeral fbpkg.  Without it the scheduler
+    # deploys the base image as-is, which fails on cross-arch hosts
+    # (e.g. aarch64 GB300 with an x86 base image).
+    job.add_directory(tempfile.mkdtemp())
+    t4 = time.time()
+    host_meshes = job.state()
+    t5 = time.time()
+    print(
+        f"remoterun timings: mast_import={t1 - t0:.2f}s, "
+        f"enable_transport={t2 - t1:.2f}s, MASTJob()={t3 - t2:.2f}s, "
+        f"add_mesh+dir={t4 - t3:.2f}s, job.state()={t5 - t4:.2f}s",
+        flush=True,
+    )
+    return host_meshes.workers, {"job": job}
+
+
+def _cleanup_mast_job(job_info, host_mesh, kill_job):
+    from monarch.actor import shutdown_context
+
+    host_mesh.shutdown().get()
+    job = job_info["job"]
+    if kill_job:
+        job.kill()
+        print("Killed MAST job", flush=True)
+
+    try:
+        shutdown_context().get()
+    except Exception:
+        pass
+
+
+def main(
+    source_dir: str,
+    script: str,
+    mount_point: str | None = None,
+    run_local=False,
+    verbose=False,
+    chunk_size_mb: int | None = None,
+    backend="slurm",
+    qos="h100_lowest",
+    hpc_identity="hyper_monarch",
+    hpc_job_oncall="monarch",
+    hpc_cluster_uuid="MastGenAICluster",
+    rm_attribution="msl_infra_pytorch_dev",
+    locality_constraints: str | None = None,
+    kill_job: bool = False,
+    num_hosts: int = 2,
+    gpus_per_host: int = 8,
+    host_type: str = "grandteton",
+    num_parallel_streams: int = 8,
+):
+    t_main_start = time.time()
+    if verbose:
+        logging.basicConfig(
+            level=logging.DEBUG,
+            format="%(asctime)s | %(levelname)s | %(message)s",
+            datefmt="%H:%M:%S",
+        )
+
+    # MAST workers have significant startup overhead before the
+    # hyperactor host_agent is ready: NCCL health checks (~25s),
+    # conda activate hooks, and Python/Rust runtime initialization.
+    # The MAST scheduler reports the job as RUNNING (container-level)
+    # well before the monarch worker process starts listening.  All
+    # timeouts that gate on worker readiness must account for this
+    # gap, including mesh_attach_config_timeout (the push_config ack
+    # during attach) and the spawn idle timeouts.
+    t_configure_start = time.time()
+    configure(
+        enable_log_forwarding=True,
+        tail_log_lines=100,
+        host_spawn_ready_timeout="300s",
+        mesh_attach_config_timeout="300s",
+        mesh_proc_spawn_max_idle="300s",
+        actor_spawn_max_idle="300s",
+        message_delivery_timeout="600s",
+        rdma_max_chunk_size_mb=256,
+    )
+    t_configure_done = time.time()
+    print(
+        f"remoterun timings: import={t_main_start - _t_import_start:.2f}s, "
+        f"configure={t_configure_done - t_configure_start:.2f}s",
+        flush=True,
+    )
+
+    mount_point = source_dir if mount_point is None else mount_point
+    mount_point = Path(mount_point).resolve()
+    source_dir = Path(source_dir).resolve()
+
+    if run_local and mount_point == source_dir:
+        raise ValueError(
+            f"If running locally mount_point and source_dir need to be different paths. Instead got source_dir {source_dir} and mount_point {mount_point}."
+        )
+
+    job_info = None
+
+    # # Spawn a process for each GPU
+    if run_local:
+        host_mesh = this_host()
+        procs = host_mesh.spawn_procs(per_host={"gpus": gpus_per_host})
+    elif backend == "slurm":
+        os.environ.pop("SLURM_CPU_BIND", None)
+        # Create a slurm job with 2 hosts
+        slurm_job = SlurmJob(
+            {"mesh1": num_hosts},
+            slurm_args=[f"--qos={qos}"],
+            exclusive=False,
+            gpus_per_node=gpus_per_host,
+            cpus_per_task=24,
+            time_limit="1:00:00",
+            log_dir=os.path.expanduser("~/monarch_slurm_logs"),
+            mem="100G",
+        )
+        host_meshes = slurm_job.state()
+        host_mesh = host_meshes.mesh1
+        procs = host_mesh.spawn_procs(per_host={"gpus": gpus_per_host})
+    elif backend == "mast":
+        lc = None
+        if locality_constraints is not None and locality_constraints != "":
+            lc = (
+                locality_constraints.split(";")
+                if ";" in locality_constraints
+                else [locality_constraints]
+            )
+
+        t_mast_start = time.time()
+        host_mesh, job_info = _get_mast_host_mesh(
+            num_hosts,
+            gpus_per_host,
+            hpc_identity,
+            hpc_job_oncall,
+            hpc_cluster_uuid,
+            rm_attribution,
+            lc,
+            host_type,
+        )
+        procs = host_mesh.spawn_procs(per_host={"gpus": gpus_per_host})
+        t_mast_done = time.time()
+        print(
+            f"remoterun timings: mast_reconnect={t_mast_done - t_mast_start:.2f}s",
+            flush=True,
+        )
+    else:
+        raise ValueError(f"Unknown backend: {backend}. Must be 'slurm' or 'mast'.")
+
+    if script == "stdin":
+        script = sys.stdin.read()
+    else:
+        with open(Path(script).resolve()) as f:
+            script = f.read()
+
+    if chunk_size_mb is None:
+        chunk_size_mb = 1024
+    chunk_size = chunk_size_mb * 1024 * 1024
+
+    t_rm_start = time.time()
+    rm = remotemount(
+        host_mesh,
+        str(source_dir),
+        str(mount_point),
+        chunk_size=chunk_size,
+        backend=backend,
+        num_parallel_streams=num_parallel_streams,
+    )
+    rm.open()
+    t_rm_open = time.time()
+
+    bash_actors = procs.spawn("BashActor", BashActor)
+    t_bash_spawn = time.time()
+    results = bash_actors.run.call(script).get()
+    t_bash_run = time.time()
+    # Print stdout for each rank in order
+    print(
+        "\n".join(
+            [f"== rank{i} stdout ==\n{r[1]['stdout']}" for i, r in enumerate(results)]
+        )
+    )
+    print(
+        "\n".join(
+            [f"== rank{i} stderr ==\n{r[1]['stderr']}" for i, r in enumerate(results)]
+        )
+    )
+
+    rm.close()
+    t_rm_close = time.time()
+    print(
+        f"remoterun timings: open={t_rm_open - t_rm_start:.2f}s, "
+        f"bash_spawn={t_bash_spawn - t_rm_open:.2f}s, "
+        f"bash_run={t_bash_run - t_bash_spawn:.2f}s, "
+        f"close={t_rm_close - t_bash_run:.2f}s, "
+        f"total={t_rm_close - t_rm_start:.2f}s",
+        flush=True,
+    )
+
+    if backend == "mast" and job_info is not None and kill_job:
+        _cleanup_mast_job(job_info, host_mesh, kill_job)
+
+
+# Register for pickle-by-value so BashActor is serialized to remote workers
+import sys as _sys  # noqa: E402
+
+cloudpickle.register_pickle_by_value(_sys.modules[__name__])
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="Mount a local directory on remote MAST/SLURM workers via remotemount."
+    )
+    parser.add_argument("source_dir", help="Local directory to mount on workers")
+    parser.add_argument(
+        "script",
+        help="Script to run on workers, or 'stdin' to read from stdin",
+    )
+    parser.add_argument(
+        "--mount_point",
+        default=None,
+        help="Mount path on workers (default: same as source_dir)",
+    )
+    parser.add_argument(
+        "--run_local", action="store_true", help="Run locally without MAST/SLURM"
+    )
+    parser.add_argument("--verbose", action="store_true")
+    parser.add_argument("--chunk_size_mb", type=int, default=None)
+    parser.add_argument(
+        "--backend", default="slurm", choices=["slurm", "mast", "local"]
+    )
+    parser.add_argument("--qos", default="h100_lowest")
+    parser.add_argument("--hpc_identity", default="hyper_monarch")
+    parser.add_argument("--hpc_job_oncall", default="monarch")
+    parser.add_argument("--hpc_cluster_uuid", default="MastGenAICluster")
+    parser.add_argument("--rm_attribution", default="msl_infra_pytorch_dev")
+    parser.add_argument("--locality_constraints", default=None)
+    parser.add_argument(
+        "--kill_job", action="store_true", help="Kill MAST job after script finishes"
+    )
+    parser.add_argument("--num_hosts", type=int, default=2)
+    parser.add_argument("--gpus_per_host", type=int, default=8)
+    parser.add_argument("--host_type", default="grandteton")
+    parser.add_argument("--num_parallel_streams", type=int, default=8)
+    args = parser.parse_args()
+    main(**vars(args))

--- a/examples/remotemount/remoterun.sh
+++ b/examples/remotemount/remoterun.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Run remoterun on MAST hosts using pre-built conda environments.
+#
+# Prerequisites:
+#   Run setup_conda_env.sh first to create the conda environments.
+#
+# Usage:
+#   bash examples/remotemount/remoterun.sh <source_dir> <script> [extra remoterun args...]
+#
+# Examples:
+#   bash examples/remotemount/remoterun.sh /tmp/mydir /tmp/myscript.sh
+#   bash examples/remotemount/remoterun.sh /tmp/mydir /tmp/myscript.sh --num_hosts 4
+#   bash examples/remotemount/remoterun.sh /tmp/mydir stdin <<< '#!/bin/bash\nhostname'
+#
+# Environment variables:
+#   MONARCH_HOST_TYPE   Host type to use (default: gb200). Options: gb200, gb300, grandteton
+#   MONARCH_CONDA_ENVS  Path to conda environments (default: ~/monarch_conda_envs)
+
+set -euo pipefail
+
+ENVS="${MONARCH_CONDA_ENVS:-$HOME/monarch_conda_envs}"
+
+if [ ! -d "$ENVS/client/conda" ] || [ ! -d "$ENVS/worker/conda" ]; then
+    echo "Error: conda environments not found at $ENVS"
+    echo "Run setup_conda_env.sh first:"
+    echo "  bash examples/remotemount/setup_conda_env.sh <target> $ENVS"
+    exit 1
+fi
+
+if [ $# -lt 2 ]; then
+    echo "Usage: remoterun.sh <source_dir> <script> [extra remoterun args...]"
+    exit 1
+fi
+
+SOURCE_DIR="$1"
+SCRIPT="$2"
+shift 2
+
+HOST_TYPE="${MONARCH_HOST_TYPE:-gb200}"
+
+CONDA_PREFIX="$ENVS/worker/conda" \
+exec "$ENVS/client/conda/bin/python3.12" \
+    "$(dirname "$0")/remoterun.py" \
+    "$SOURCE_DIR" "$SCRIPT" \
+    --backend mast \
+    --host_type "$HOST_TYPE" \
+    --locality_constraints "" \
+    --verbose \
+    "$@"

--- a/examples/remotemount/setup_conda_env.sh
+++ b/examples/remotemount/setup_conda_env.sh
@@ -1,0 +1,245 @@
+#!/bin/bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Set up conda environments for running remoterun on MAST hosts.
+#
+# Creates two conda environments:
+#   $DEST/client/conda  - x86 client env (runs on your devserver)
+#   $DEST/worker/conda  - worker env (deployed to MAST hosts)
+#
+# The four slowest operations (2 fbpkg fetches + 2 buck2 builds) run in
+# parallel, then installs happen sequentially after they complete.
+#
+# Usage:
+#   bash examples/setup_conda_env.sh <target> [DEST_DIR]
+#
+#   target:   "gb200"/"gb300" (aarch64) or "grandteton"/"h100" (x86)
+#   DEST_DIR: where to create the envs (default: ~/monarch_conda_envs)
+#
+# After setup, run remoterun with:
+#   CONDA_PREFIX=$DEST/worker/conda \
+#   $DEST/client/conda/bin/python3.12 \
+#     examples/remoterun.py <source_dir> <script> \
+#     --backend mast --host_type <target>
+
+set -euo pipefail
+
+TARGET="${1:?Usage: $0 <target> [dest_dir]  (target: gb200, gb300, grandteton, or h100)}"
+DEST="${2:-$HOME/monarch_conda_envs}"
+
+case "$TARGET" in
+    gb200|gb300)
+        WORKER_ARCH="aarch64"
+        WORKER_BASE_PKG="xlformers_gb200_conda:latest"
+        WORKER_WHL_TARGET="fbcode//monarch/python/monarch:monarch_nightly_torch_gb200_py3.12.whl"
+        WORKER_BUCK_ARGS="-c fbcode.arch=aarch64"
+        ;;
+    grandteton|h100)
+        WORKER_ARCH="x86_64"
+        WORKER_BASE_PKG="monarch_conda:latest_conveyor_build"
+        WORKER_WHL_TARGET="fbcode//monarch/python/monarch:monarch.whl"
+        WORKER_BUCK_ARGS=""
+        ;;
+    *)
+        echo "Unknown target: $TARGET (expected: gb200, gb300, grandteton, h100)"
+        exit 1
+        ;;
+esac
+
+echo "=== Setting up $TARGET remoterun environments at $DEST ==="
+
+# --- Launch all four slow operations in parallel ---
+echo ""
+echo "--- Fetching base envs + building wheels (parallel) ---"
+
+mkdir -p "$DEST/client" "$DEST/worker"
+
+# Temp files for capturing build outputs (stderr separate to avoid polluting paths).
+CLIENT_WHL_OUT=$(mktemp)
+CLIENT_WHL_ERR=$(mktemp)
+WORKER_WHL_OUT=$(mktemp)
+WORKER_WHL_ERR=$(mktemp)
+
+# 1. Fetch client base env
+fbpkg fetch monarch_conda:latest_conveyor_build -d "$DEST/client" &
+CLIENT_FETCH_PID=$!
+
+# 2. Fetch worker base env
+fbpkg fetch "$WORKER_BASE_PKG" -d "$DEST/worker" &
+WORKER_FETCH_PID=$!
+
+# 3. Build x86 client wheel
+buck2 build @fbcode//mode/opt \
+    --show-full-simple-output \
+    fbcode//monarch/python/monarch:monarch.whl \
+    > "$CLIENT_WHL_OUT" 2>"$CLIENT_WHL_ERR" &
+CLIENT_BUILD_PID=$!
+
+# 4. Build worker wheel (may be cross-arch)
+# shellcheck disable=SC2086
+buck2 build @fbcode//mode/opt $WORKER_BUCK_ARGS \
+    --show-full-simple-output \
+    "$WORKER_WHL_TARGET" \
+    > "$WORKER_WHL_OUT" 2>"$WORKER_WHL_ERR" &
+WORKER_BUILD_PID=$!
+
+echo "  Fetching client env (PID $CLIENT_FETCH_PID)"
+echo "  Fetching worker env (PID $WORKER_FETCH_PID)"
+echo "  Building x86 wheel (PID $CLIENT_BUILD_PID)"
+echo "  Building $WORKER_ARCH wheel (PID $WORKER_BUILD_PID)"
+
+# --- Wait for all background jobs ---
+FAILED=0
+for pid_var in CLIENT_FETCH_PID WORKER_FETCH_PID CLIENT_BUILD_PID WORKER_BUILD_PID; do
+    pid=${!pid_var}
+    if ! wait "$pid"; then
+        echo "Error: $pid_var (PID $pid) failed" >&2
+        FAILED=1
+    fi
+done
+if [ "$FAILED" -ne 0 ]; then
+    echo "Parallel step errors:" >&2
+    cat "$CLIENT_WHL_ERR" "$WORKER_WHL_ERR" >&2
+    rm -f "$CLIENT_WHL_OUT" "$CLIENT_WHL_ERR" "$WORKER_WHL_OUT" "$WORKER_WHL_ERR"
+    exit 1
+fi
+
+X86_WHL=$(cat "$CLIENT_WHL_OUT")
+WORKER_WHL=$(cat "$WORKER_WHL_OUT")
+rm -f "$CLIENT_WHL_OUT" "$CLIENT_WHL_ERR" "$WORKER_WHL_OUT" "$WORKER_WHL_ERR"
+
+echo ""
+echo "  Client wheel: $X86_WHL"
+echo "  Worker wheel: $WORKER_WHL"
+
+# --- Install client wheel ---
+echo ""
+echo "--- Installing client env ---"
+CLIENT_PIP="$DEST/client/conda/bin/python3.12 -m pip"
+$CLIENT_PIP install fire
+
+# Remove stale dist-info from previous installs — fbpkg fetch overwrites the
+# conda dir but leaves pip metadata behind, causing "No such file" errors
+# when pip tries to uninstall the old wheel.
+rm -rf "$DEST/client/conda/lib/python3.12/site-packages/torchmonarch"*.dist-info
+$CLIENT_PIP install --force-reinstall --no-deps "$X86_WHL"
+
+# --- Install worker wheel ---
+echo ""
+echo "--- Installing worker env ---"
+
+# Remove stale dist-info from previous installs (same fbpkg clobber issue).
+rm -rf "$DEST/worker/conda/lib/python3.12/site-packages/torchmonarch"*.dist-info
+
+if [ "$WORKER_ARCH" = "aarch64" ]; then
+    # Cross-arch: can't pip install directly, use --target
+    $CLIENT_PIP install \
+        --platform linux_aarch64 \
+        --target "$DEST/worker/conda/lib/python3.12/site-packages" \
+        --no-deps --only-binary :all: --force-reinstall \
+        "$WORKER_WHL"
+
+    # Extract entrypoint + bootstrap scripts from the wheel.
+    python3 -c "
+import zipfile, os
+with zipfile.ZipFile('$WORKER_WHL') as z:
+    for name in z.namelist():
+        if 'torchmonarch' in name and 'data/scripts/' in name:
+            dest = '$DEST/worker/conda/bin/' + os.path.basename(name)
+            with z.open(name) as src, open(dest, 'wb') as dst:
+                dst.write(src.read())
+            os.chmod(dest, 0o755)
+            print(f'  Installed {dest}')
+"
+
+    # Install xxhash for aarch64 (needed by remotemount persistent cache).
+    rm -rf /tmp/xxhash_wheels
+    $CLIENT_PIP download xxhash \
+        --platform manylinux2014_aarch64 \
+        --python-version 3.12 \
+        --only-binary :all: \
+        -d /tmp/xxhash_wheels 2>/dev/null
+    $CLIENT_PIP install \
+        --platform manylinux2014_aarch64 \
+        --target "$DEST/worker/conda/lib/python3.12/site-packages" \
+        --no-deps --only-binary :all: --force-reinstall \
+        /tmp/xxhash_wheels/xxhash-*.whl
+
+    # Fix permissions (pip --target doesn't preserve world-readable).
+    chmod -R a+rX "$DEST/worker/conda/lib/python3.12/site-packages/monarch/" 2>/dev/null || true
+    chmod -R a+rX "$DEST/worker/conda/lib/python3.12/site-packages/torchmonarch/" 2>/dev/null || true
+
+    # Copy libomp from fbcode aarch64 toolchain.
+    cp /usr/local/fbcode/platform010-aarch64/lib/libomp.so "$DEST/worker/conda/lib/" 2>/dev/null || true
+else
+    # Same-arch: direct pip install.
+    "$DEST/worker/conda/bin/python3.12" -m pip install --force-reinstall --no-deps "$WORKER_WHL"
+fi
+
+echo ""
+echo "--- Fixing worker entrypoint ---"
+cat > "$DEST/worker/conda/bin/entrypoint.sh" << 'ENTRY'
+#!/bin/bash
+set -eEx
+export PYTHONDONTWRITEBYTECODE=1
+export PATH="${CONDA_DIR}/bin:$PATH"
+
+# Find libcuda. On MAST containers the real driver is bind-mounted at
+# the platform010 path by Tupperware. We must NOT add this directory to
+# LD_LIBRARY_PATH (its libstdc++ conflicts with conda), so instead we
+# symlink just the CUDA/NVML libraries into conda's lib dir.
+LIBCUDA_DIR=""
+ARCH=$(uname -m)
+if [ "$ARCH" = "aarch64" ]; then
+    LIBCUDA_SEARCH="/usr/local/fbcode/platform010-aarch64/lib /usr/lib64 /usr/local/cuda/lib64"
+else
+    LIBCUDA_SEARCH="/usr/local/fbcode/platform010/lib /usr/lib64 /usr/local/cuda/lib64"
+fi
+for p in $LIBCUDA_SEARCH; do
+    if [ -f "$p/libcuda.so.1" ] || [ -f "$p/libcuda.so" ]; then
+        LIBCUDA_DIR="$p"
+        break
+    fi
+done
+CUDA_SHIM_DIR=""
+if [ -n "$LIBCUDA_DIR" ]; then
+    export TRITON_LIBCUDA_PATH="$LIBCUDA_DIR"
+    CUDA_SHIM_DIR=$(mktemp -d /tmp/cuda_shim.XXXXXX)
+    for lib in "$LIBCUDA_DIR"/libcuda.so* "$LIBCUDA_DIR"/libnvidia-ml.so*; do
+        [ -f "$lib" ] && ln -sf "$lib" "$CUDA_SHIM_DIR/" 2>/dev/null || true
+    done
+fi
+
+export LD_LIBRARY_PATH="${CONDA_DIR}/lib:${CONDA_DIR}/lib/python3.12/site-packages/torch/lib${CUDA_SHIM_DIR:+:$CUDA_SHIM_DIR}${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+export PYTHONPATH="${PYTHONPATH:+$PYTHONPATH:}$TORCHX_RUN_PYTHONPATH"
+
+if [ -f "${CONDA_DIR}/bin/activate" ]; then
+    source "${CONDA_DIR}/bin/activate"
+fi
+
+if [ -n "$WORKSPACE_DIR" ] && [ -d "$WORKSPACE_DIR" ]; then
+    cd "$WORKSPACE_DIR"
+fi
+
+exec "$@"
+ENTRY
+chmod +x "$DEST/worker/conda/bin/entrypoint.sh"
+
+# Also overwrite the copy in site-packages/bin/ that conda-pack may prefer.
+cp "$DEST/worker/conda/bin/entrypoint.sh" \
+   "$DEST/worker/conda/lib/python3.12/site-packages/bin/entrypoint.sh" 2>/dev/null || true
+
+echo ""
+echo "=== Done ==="
+echo "  Client env: $DEST/client/conda"
+echo "  Worker env: $DEST/worker/conda"
+echo ""
+echo "Run remoterun:"
+echo "  CONDA_PREFIX=$DEST/worker/conda \\"
+echo "  $DEST/client/conda/bin/python3.12 \\"
+echo "    examples/remotemount/remoterun.py <source_dir> <script> \\"
+echo "    --backend mast --host_type $TARGET"

--- a/monarch_extension/Cargo.toml
+++ b/monarch_extension/Cargo.toml
@@ -34,6 +34,8 @@ nccl-sys = { path = "../nccl-sys", optional = true }
 ndslice = { version = "0.0.0", path = "../ndslice" }
 pyo3 = { version = "0.26", features = ["anyhow", "multiple-pymethods", "py-clone"] }
 rdmaxcel-sys = { path = "../rdmaxcel-sys", optional = true }
+rustls = "0.23.37"
+rustls-pemfile = "2.2.0"
 serde = { version = "1.0.219", features = ["derive", "rc"] }
 tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
 torch-sys-cuda = { version = "0.0.0", path = "../torch-sys-cuda", optional = true }

--- a/monarch_extension/src/fast_pack.rs
+++ b/monarch_extension/src/fast_pack.rs
@@ -32,15 +32,15 @@ fn num_threads() -> usize {
         .map(|n| n.get().min(DEFAULT_MAX_THREADS))
         .unwrap_or(1)
 }
-const HASH_BLOCK_SIZE: usize = 64 * 1024 * 1024; // 64 MB
+pub(crate) const HASH_BLOCK_SIZE: usize = 64 * 1024 * 1024; // 64 MB
 /// Maximum bytes a single work unit reads. Large files are split into
 /// chunks of this size so multiple threads can read them in parallel.
 const READ_CHUNK_SIZE: usize = 64 * 1024 * 1024; // 64 MB
 
-struct FileInfo {
-    path: String,
-    offset: usize,
-    size: usize,
+pub(crate) struct FileInfo {
+    pub(crate) path: String,
+    pub(crate) offset: usize,
+    pub(crate) size: usize,
 }
 
 /// A unit of read work: read `size` bytes from `file_idx` at `file_offset`
@@ -59,7 +59,7 @@ struct ReadWork {
 /// Work units are distributed round-robin by descending size so that
 /// large chunks spread evenly across threads instead of piling up on
 /// thread 0.
-fn pack_files_into(buf_ptr: usize, files: &[FileInfo], max_threads: usize) {
+pub(crate) fn pack_files_into(buf_ptr: usize, files: &[FileInfo], max_threads: usize) {
     // Build work units: split large files into READ_CHUNK_SIZE pieces.
     let mut work_units: Vec<ReadWork> = Vec::new();
     for (file_idx, f) in files.iter().enumerate() {
@@ -152,7 +152,7 @@ fn pack_files_into(buf_ptr: usize, files: &[FileInfo], max_threads: usize) {
 /// Compute xxh64 block hashes over the buffer in parallel.
 ///
 /// Returns hex digest strings, one per `HASH_BLOCK_SIZE` block.
-fn compute_block_hashes(
+pub(crate) fn compute_block_hashes(
     buf_ptr: usize,
     total_size: usize,
     block_size: usize,
@@ -189,7 +189,7 @@ fn compute_block_hashes(
 }
 
 /// Allocate an anonymous mmap region.
-fn mmap_anonymous(total_size: usize) -> Result<*mut libc::c_void, std::io::Error> {
+pub(crate) fn mmap_anonymous(total_size: usize) -> Result<*mut libc::c_void, std::io::Error> {
     // SAFETY: mmap with MAP_PRIVATE | MAP_ANONYMOUS allocates zeroed pages
     // backed by swap, not a file descriptor.
     let ptr = unsafe {

--- a/monarch_extension/src/lib.rs
+++ b/monarch_extension/src/lib.rs
@@ -24,6 +24,8 @@ mod blocking;
 mod chunked_fuse;
 mod fast_pack;
 mod panic;
+mod tls_receiver;
+mod tls_sender;
 mod trace;
 
 use pyo3::prelude::*;
@@ -230,6 +232,16 @@ pub fn mod_init(module: &Bound<'_, PyModule>) -> PyResult<()> {
     crate::fast_pack::register_python_bindings(&get_or_add_new_module(
         module,
         "monarch_extension.fast_pack",
+    )?)?;
+
+    crate::tls_receiver::register_python_bindings(&get_or_add_new_module(
+        module,
+        "monarch_extension.tls_receiver",
+    )?)?;
+
+    crate::tls_sender::register_python_bindings(&get_or_add_new_module(
+        module,
+        "monarch_extension.tls_sender",
     )?)?;
 
     crate::chunked_fuse::register_python_bindings(&get_or_add_new_module(

--- a/monarch_extension/src/tls_receiver.rs
+++ b/monarch_extension/src/tls_receiver.rs
@@ -1,0 +1,327 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+//! Rust-native TLS receiver for remotemount.
+//!
+//! Accepts parallel TLS connections and writes received blocks directly
+//! into a caller-provided anonymous mmap buffer — no intermediate file,
+//! no Python SSL overhead.
+
+use std::io::BufReader;
+use std::io::Read;
+use std::net::TcpListener;
+use std::sync::Arc;
+use std::thread;
+
+use pyo3::exceptions::PyRuntimeError;
+use pyo3::ffi;
+use pyo3::prelude::*;
+
+const CERT_PATH: &str = "/var/facebook/x509_identities/server.pem";
+
+/// Build a `rustls::ServerConfig` matching the Python `_make_server_ssl_context`.
+fn make_server_tls_config() -> Result<Arc<rustls::ServerConfig>, String> {
+    let _ = rustls::crypto::ring::default_provider().install_default();
+
+    let cert_pem = std::fs::read(CERT_PATH).map_err(|e| format!("read {CERT_PATH} failed: {e}"))?;
+
+    let certs = rustls_pemfile::certs(&mut BufReader::new(&cert_pem[..]))
+        .filter_map(Result::ok)
+        .collect::<Vec<_>>();
+
+    let key = {
+        let mut reader = BufReader::new(&cert_pem[..]);
+        loop {
+            match rustls_pemfile::read_one(&mut reader) {
+                Ok(Some(rustls_pemfile::Item::Pkcs1Key(k))) => {
+                    break rustls::pki_types::PrivateKeyDer::Pkcs1(k);
+                }
+                Ok(Some(rustls_pemfile::Item::Pkcs8Key(k))) => {
+                    break rustls::pki_types::PrivateKeyDer::Pkcs8(k);
+                }
+                Ok(Some(rustls_pemfile::Item::Sec1Key(k))) => {
+                    break rustls::pki_types::PrivateKeyDer::Sec1(k);
+                }
+                Ok(Some(_)) => continue,
+                Ok(None) => return Err(format!("no private key found in {CERT_PATH}")),
+                Err(e) => return Err(format!("parse {CERT_PATH} failed: {e}")),
+            }
+        }
+    };
+
+    let config = rustls::ServerConfig::builder()
+        .with_no_client_auth()
+        .with_single_cert(certs, key)
+        .map_err(|e| format!("server cert failed: {e}"))?;
+
+    Ok(Arc::new(config))
+}
+
+/// Return a hostname that the TLS certificate is valid for.
+///
+/// `hostname -f` can return a name that doesn't match the cert's SAN
+/// (e.g. `.fbinfra.net` vs `.facebook.com` on Sandcastle).  We use
+/// `openssl x509 -text` to dump the cert and extract the first DNS
+/// SAN entry.  Falls back to `hostname -f` if extraction fails.
+fn get_tls_hostname() -> Result<String, String> {
+    // `openssl x509 -text` is supported since OpenSSL 0.9.x (unlike
+    // `-ext subjectAltName` which requires 1.1.1+).  The SAN section
+    // looks like:
+    //     X509v3 Subject Alternative Name:
+    //         DNS:host.facebook.com, IP Address:..., ...
+    if let Ok(output) = std::process::Command::new("openssl")
+        .args(["x509", "-in", CERT_PATH, "-noout", "-text"])
+        .output()
+    {
+        if output.status.success() {
+            let text = String::from_utf8_lossy(&output.stdout);
+            let mut in_san = false;
+            for line in text.lines() {
+                let trimmed = line.trim();
+                if trimmed.contains("Subject Alternative Name") {
+                    in_san = true;
+                    continue;
+                }
+                if in_san {
+                    // This line has the SAN values, comma-separated.
+                    for part in trimmed.split(',') {
+                        let part = part.trim();
+                        if let Some(dns) = part.strip_prefix("DNS:") {
+                            return Ok(dns.trim().to_string());
+                        }
+                    }
+                    break; // Only check the line immediately after the header.
+                }
+            }
+        }
+    }
+
+    // Fallback: hostname -f.
+    let output = std::process::Command::new("hostname")
+        .arg("-f")
+        .output()
+        .map_err(|e| format!("hostname -f failed: {e}"))?;
+    if !output.status.success() {
+        return Err(format!(
+            "hostname -f returned {}",
+            String::from_utf8_lossy(&output.stderr)
+        ));
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+}
+
+/// Return the FQDN of this host (for TCP connect address).
+fn get_fqdn() -> Result<String, String> {
+    let output = std::process::Command::new("hostname")
+        .arg("-f")
+        .output()
+        .map_err(|e| format!("hostname -f failed: {e}"))?;
+    if !output.status.success() {
+        return Err(format!(
+            "hostname -f returned {}",
+            String::from_utf8_lossy(&output.stderr)
+        ));
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+}
+
+/// Rust TLS receiver that writes directly into a caller-provided buffer.
+#[pyclass(module = "monarch._rust_bindings.monarch_extension.tls_receiver")]
+struct TlsReceiver {
+    /// "host:port" for the Rust sender to connect to.
+    #[pyo3(get)]
+    addr: String,
+    /// Hostname from the cert's SAN for TLS verification (may differ
+    /// from the connect hostname when DNS names diverge, e.g.
+    /// `.fbinfra.net` vs `.facebook.com`).
+    #[pyo3(get)]
+    tls_hostname: String,
+    listener: Option<TcpListener>,
+    tls_config: Arc<rustls::ServerConfig>,
+    num_streams: usize,
+}
+
+#[pymethods]
+impl TlsReceiver {
+    #[new]
+    #[pyo3(signature = (num_streams=1))]
+    fn new(num_streams: usize) -> PyResult<Self> {
+        let tls_config = make_server_tls_config().map_err(PyRuntimeError::new_err)?;
+
+        let listener = TcpListener::bind("[::]:0")
+            .map_err(|e| PyRuntimeError::new_err(format!("bind: {e}")))?;
+        let port = listener
+            .local_addr()
+            .map_err(|e| PyRuntimeError::new_err(format!("addr: {e}")))?
+            .port();
+
+        let tls_hostname = get_tls_hostname().map_err(PyRuntimeError::new_err)?;
+        let connect_hostname = get_fqdn().map_err(PyRuntimeError::new_err)?;
+
+        Ok(TlsReceiver {
+            addr: format!("{connect_hostname}:{port}"),
+            tls_hostname,
+            listener: Some(listener),
+            tls_config,
+            num_streams,
+        })
+    }
+
+    /// Accept connections and receive blocks into `buffer`.
+    ///
+    /// Blocks until all `num_streams` connections have completed.
+    /// The buffer must be a writable object supporting the buffer protocol
+    /// (e.g. a memoryview over an anonymous mmap).
+    fn wait(&mut self, py: Python<'_>, buffer: &Bound<'_, PyAny>) -> PyResult<()> {
+        // Extract raw pointer and length from the Python buffer protocol.
+        // SAFETY: Py_buffer is a POD struct; zeroing is valid initialization.
+        let mut buf_view: ffi::Py_buffer = unsafe { std::mem::zeroed() };
+        // SAFETY: buffer.as_ptr() is a valid Python object; we check rc != 0.
+        let rc = unsafe {
+            ffi::PyObject_GetBuffer(
+                buffer.as_ptr(),
+                &mut buf_view,
+                ffi::PyBUF_WRITABLE | ffi::PyBUF_SIMPLE,
+            )
+        };
+        if rc != 0 {
+            return Err(PyRuntimeError::new_err(
+                "buffer is not writable or does not support the buffer protocol",
+            ));
+        }
+        let buf_ptr = buf_view.buf as usize;
+        let buf_len = buf_view.len as usize;
+        // SAFETY: buf_view was successfully initialized by PyObject_GetBuffer.
+        unsafe { ffi::PyBuffer_Release(&mut buf_view) };
+
+        let listener = self
+            .listener
+            .take()
+            .ok_or_else(|| PyRuntimeError::new_err("wait() already called"))?;
+        let config = Arc::clone(&self.tls_config);
+        let num_streams = self.num_streams;
+
+        py.detach(move || {
+            thread::scope(|s| {
+                let mut handles = Vec::with_capacity(num_streams);
+                let listener_ref = &listener;
+
+                for _ in 0..num_streams {
+                    let cfg = Arc::clone(&config);
+
+                    handles.push(s.spawn(move || -> Result<usize, String> {
+                        let (tcp, _) = listener_ref.accept().map_err(|e| format!("accept: {e}"))?;
+                        tcp.set_nodelay(true).ok();
+
+                        // 4 MB receive buffer for high-bandwidth transfers.
+                        #[cfg(unix)]
+                        {
+                            use std::os::unix::io::AsRawFd;
+                            let bufsize: libc::c_int = 4 * 1024 * 1024;
+                            // SAFETY: setsockopt with SOL_SOCKET/SO_RCVBUF is safe;
+                            // bufsize is a valid c_int on the stack.
+                            unsafe {
+                                libc::setsockopt(
+                                    tcp.as_raw_fd(),
+                                    libc::SOL_SOCKET,
+                                    libc::SO_RCVBUF,
+                                    &bufsize as *const _ as *const libc::c_void,
+                                    std::mem::size_of::<libc::c_int>() as libc::socklen_t,
+                                );
+                            }
+                        }
+
+                        let conn = rustls::ServerConnection::new(cfg)
+                            .map_err(|e| format!("TLS accept: {e}"))?;
+                        let mut tls = rustls::StreamOwned::new(conn, tcp);
+
+                        // Read header: cache_path_len(u32) + cache_path + total_size(u64).
+                        // We read and discard cache_path (not needed for anonymous mmap).
+                        let mut hdr = [0u8; 4];
+                        tls.read_exact(&mut hdr)
+                            .map_err(|e| format!("read path_len: {e}"))?;
+                        let path_len = u32::from_be_bytes(hdr) as usize;
+                        let mut path_buf = vec![0u8; path_len];
+                        tls.read_exact(&mut path_buf)
+                            .map_err(|e| format!("read path: {e}"))?;
+                        let mut size_buf = [0u8; 8];
+                        tls.read_exact(&mut size_buf)
+                            .map_err(|e| format!("read size: {e}"))?;
+                        let total_size = u64::from_be_bytes(size_buf) as usize;
+                        if total_size != buf_len {
+                            return Err(format!(
+                                "protocol error: sender total_size={total_size} != \
+                                 receiver buf_len={buf_len}"
+                            ));
+                        }
+
+                        // Read blocks: offset(u64) + size(u64) + data.
+                        let mut blocks = 0usize;
+                        loop {
+                            let mut block_hdr = [0u8; 16];
+                            match tls.read_exact(&mut block_hdr) {
+                                Ok(()) => {}
+                                // EOF before any header byte means the sender is done
+                                // (can happen if sender closes after sentinel).
+                                Err(e) if e.kind() == std::io::ErrorKind::UnexpectedEof => {
+                                    break;
+                                }
+                                Err(e) => {
+                                    return Err(format!("read block header: {e}"));
+                                }
+                            }
+                            let offset =
+                                u64::from_be_bytes(block_hdr[..8].try_into().unwrap()) as usize;
+                            let size =
+                                u64::from_be_bytes(block_hdr[8..].try_into().unwrap()) as usize;
+                            if size == 0 {
+                                break; // sentinel
+                            }
+
+                            let end = offset.checked_add(size).ok_or_else(|| {
+                                format!("block offset {offset} + size {size} overflows usize")
+                            })?;
+                            if end > buf_len {
+                                return Err(format!(
+                                    "block at offset {offset} size {size} \
+                                     exceeds buffer length {buf_len}"
+                                ));
+                            }
+
+                            // SAFETY: offset + size <= buf_len, buffer is valid.
+                            let dst = unsafe {
+                                std::slice::from_raw_parts_mut((buf_ptr + offset) as *mut u8, size)
+                            };
+                            tls.read_exact(dst)
+                                .map_err(|e| format!("read block data: {e}"))?;
+                            blocks += 1;
+                        }
+                        Ok(blocks)
+                    }));
+                }
+
+                let mut errors = Vec::new();
+                for h in handles {
+                    if let Err(e) = h.join().expect("receiver thread panicked") {
+                        errors.push(e);
+                    }
+                }
+                if errors.is_empty() {
+                    Ok(())
+                } else {
+                    Err(PyRuntimeError::new_err(errors.join("; ")))
+                }
+            })
+        })
+    }
+}
+
+pub fn register_python_bindings(module: &Bound<'_, PyModule>) -> PyResult<()> {
+    module.add_class::<TlsReceiver>()?;
+    Ok(())
+}

--- a/monarch_extension/src/tls_sender.rs
+++ b/monarch_extension/src/tls_sender.rs
@@ -1,0 +1,397 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+//! Rust-native TLS sender for remotemount.
+//!
+//! Packs files into an anonymous mmap, computes block hashes, then sends
+//! dirty blocks over parallel TLS connections directly from the buffer —
+//! no `/tmp` file, no Python sender actor processes.
+
+use std::io::BufReader;
+use std::io::Read;
+use std::io::Write;
+use std::net::TcpStream;
+use std::sync::Arc;
+use std::thread;
+
+use pyo3::exceptions::PyOSError;
+use pyo3::exceptions::PyRuntimeError;
+use pyo3::prelude::*;
+use rustls::pki_types::ServerName;
+
+use crate::fast_pack::FileInfo;
+use crate::fast_pack::HASH_BLOCK_SIZE;
+use crate::fast_pack::compute_block_hashes;
+use crate::fast_pack::mmap_anonymous;
+use crate::fast_pack::pack_files_into;
+
+const CA_PATH: &str = "/var/facebook/rootcanal/ca.pem";
+const CERT_PATH: &str = "/var/facebook/x509_identities/server.pem";
+
+/// Build a `rustls::ClientConfig` with full certificate verification.
+fn make_tls_config() -> Result<Arc<rustls::ClientConfig>, String> {
+    let _ = rustls::crypto::ring::default_provider().install_default();
+
+    let ca_pem = std::fs::read(CA_PATH).map_err(|e| format!("read {CA_PATH} failed: {e}"))?;
+    let cert_pem = std::fs::read(CERT_PATH).map_err(|e| format!("read {CERT_PATH} failed: {e}"))?;
+
+    let mut root_store = rustls::RootCertStore::empty();
+    let ca_certs = rustls_pemfile::certs(&mut BufReader::new(&ca_pem[..]))
+        .filter_map(Result::ok)
+        .collect::<Vec<_>>();
+    root_store.add_parsable_certificates(ca_certs);
+
+    let certs = rustls_pemfile::certs(&mut BufReader::new(&cert_pem[..]))
+        .filter_map(Result::ok)
+        .collect::<Vec<_>>();
+
+    let key = {
+        let mut reader = BufReader::new(&cert_pem[..]);
+        loop {
+            match rustls_pemfile::read_one(&mut reader) {
+                Ok(Some(rustls_pemfile::Item::Pkcs1Key(k))) => {
+                    break rustls::pki_types::PrivateKeyDer::Pkcs1(k);
+                }
+                Ok(Some(rustls_pemfile::Item::Pkcs8Key(k))) => {
+                    break rustls::pki_types::PrivateKeyDer::Pkcs8(k);
+                }
+                Ok(Some(rustls_pemfile::Item::Sec1Key(k))) => {
+                    break rustls::pki_types::PrivateKeyDer::Sec1(k);
+                }
+                Ok(Some(_)) => continue,
+                Ok(None) => return Err(format!("no private key found in {CERT_PATH}")),
+                Err(e) => return Err(format!("parse {CERT_PATH} failed: {e}")),
+            }
+        }
+    };
+
+    let config = rustls::ClientConfig::builder()
+        .with_root_certificates(root_store)
+        .with_client_auth_cert(certs, key)
+        .map_err(|e| format!("client auth cert failed: {e}"))?;
+
+    Ok(Arc::new(config))
+}
+
+/// RAII wrapper for an anonymous mmap buffer with precomputed block hashes.
+#[pyclass(module = "monarch._rust_bindings.monarch_extension.tls_sender")]
+struct PackedBuffer {
+    ptr: *mut libc::c_void,
+    size: usize,
+    #[pyo3(get)]
+    hashes: Vec<String>,
+}
+
+// SAFETY: the mmap region is process-global memory accessible from any thread.
+// No thread-local state; all access is via raw pointer arithmetic on a
+// process-wide anonymous mapping that outlives any thread.
+unsafe impl Send for PackedBuffer {}
+// SAFETY: PackedBuffer is read-only after construction (ptr/size are immutable).
+// Concurrent readers access disjoint slices via offset-based indexing.
+unsafe impl Sync for PackedBuffer {}
+
+impl Drop for PackedBuffer {
+    fn drop(&mut self) {
+        if self.size > 0 {
+            // SAFETY: self.ptr was returned by mmap_anonymous(self.size) and
+            // has not been munmapped yet. Drop runs at most once.
+            unsafe {
+                libc::munmap(self.ptr, self.size);
+            }
+        }
+    }
+}
+
+/// Send dirty blocks from a buffer over parallel TLS connections.
+///
+/// Each address in `addresses` gets its own TCP+TLS stream. Blocks
+/// are distributed round-robin across streams.
+fn send_blocks_impl(
+    buf_ptr: usize,
+    total_size: usize,
+    dirty_blocks: &[usize],
+    addresses: &[String],
+    cache_path: &str,
+    block_size: usize,
+    tls_hostname: Option<&str>,
+) -> PyResult<()> {
+    let tls_config = make_tls_config().map_err(PyRuntimeError::new_err)?;
+
+    let num_streams = addresses.len();
+
+    // Partition blocks across streams round-robin.
+    let mut per_stream: Vec<Vec<(usize, usize)>> = vec![Vec::new(); num_streams];
+    for (i, &bi) in dirty_blocks.iter().enumerate() {
+        let offset = bi.checked_mul(block_size).ok_or_else(|| {
+            PyRuntimeError::new_err(format!("block {bi} * {block_size} overflows"))
+        })?;
+        if offset >= total_size {
+            return Err(PyRuntimeError::new_err(format!(
+                "block {bi} offset {offset} >= total_size {total_size}"
+            )));
+        }
+        let size = std::cmp::min(block_size, total_size - offset);
+        per_stream[i % num_streams].push((offset, size));
+    }
+
+    let cache_path_bytes = cache_path.as_bytes();
+
+    thread::scope(|s| {
+        let mut handles = Vec::with_capacity(num_streams);
+
+        for (stream_idx, blocks) in per_stream.into_iter().enumerate() {
+            let addr = &addresses[stream_idx];
+            let config = Arc::clone(&tls_config);
+            let cp_bytes = cache_path_bytes;
+            let tls_name = tls_hostname;
+
+            handles.push(s.spawn(move || -> Result<(), String> {
+                let (host, port_str) = addr
+                    .rsplit_once(':')
+                    .ok_or_else(|| format!("invalid address: {addr}"))?;
+                let port: u16 = port_str
+                    .parse()
+                    .map_err(|e| format!("invalid port in {addr}: {e}"))?;
+
+                let tcp =
+                    TcpStream::connect((host, port)).map_err(|e| format!("connect {addr}: {e}"))?;
+                tcp.set_nodelay(true)
+                    .map_err(|e| format!("set_nodelay: {e}"))?;
+
+                // 4 MB send buffer for high-bandwidth transfers.
+                #[cfg(unix)]
+                {
+                    use std::os::unix::io::AsRawFd;
+                    let bufsize: libc::c_int = 4 * 1024 * 1024;
+                    // SAFETY: setsockopt with SOL_SOCKET/SO_SNDBUF is safe;
+                    // bufsize is a valid c_int on the stack.
+                    unsafe {
+                        libc::setsockopt(
+                            tcp.as_raw_fd(),
+                            libc::SOL_SOCKET,
+                            libc::SO_SNDBUF,
+                            &bufsize as *const _ as *const libc::c_void,
+                            std::mem::size_of::<libc::c_int>() as libc::socklen_t,
+                        );
+                    }
+                }
+
+                let sni_host = tls_name.unwrap_or(host);
+                let server_name = ServerName::try_from(sni_host.to_string())
+                    .unwrap_or_else(|_| ServerName::try_from("localhost".to_string()).unwrap());
+
+                let conn = rustls::ClientConnection::new(config, server_name)
+                    .map_err(|e| format!("TLS handshake: {e}"))?;
+                let mut tls = rustls::StreamOwned::new(conn, tcp);
+
+                // Protocol header: cache_path_len(u32 BE) + cache_path + total_size(u64 BE)
+                let mut header = Vec::with_capacity(4 + cp_bytes.len() + 8);
+                header.extend_from_slice(&(cp_bytes.len() as u32).to_be_bytes());
+                header.extend_from_slice(cp_bytes);
+                header.extend_from_slice(&(total_size as u64).to_be_bytes());
+                tls.write_all(&header)
+                    .map_err(|e| format!("write header: {e}"))?;
+
+                // Send blocks: offset(u64 BE) + size(u64 BE) + data
+                for (offset, size) in &blocks {
+                    let mut block_header = [0u8; 16];
+                    block_header[..8].copy_from_slice(&(*offset as u64).to_be_bytes());
+                    block_header[8..].copy_from_slice(&(*size as u64).to_be_bytes());
+                    tls.write_all(&block_header)
+                        .map_err(|e| format!("write block header: {e}"))?;
+
+                    // SAFETY: offset + size <= total_size, buffer is valid.
+                    let data = unsafe {
+                        std::slice::from_raw_parts((buf_ptr + offset) as *const u8, *size)
+                    };
+                    tls.write_all(data)
+                        .map_err(|e| format!("write block data: {e}"))?;
+                }
+
+                // Done sentinel: offset=0, size=0
+                tls.write_all(&[0u8; 16])
+                    .map_err(|e| format!("write sentinel: {e}"))?;
+                // Flush all buffered TLS application data before closing.
+                tls.flush().map_err(|e| format!("flush: {e}"))?;
+                tls.conn.send_close_notify();
+                // Drain the close_notify record to TCP.
+                while tls.conn.wants_write() {
+                    tls.conn
+                        .write_tls(&mut tls.sock)
+                        .map_err(|e| format!("close_notify: {e}"))?;
+                }
+                // Shut down the write half of TCP to send FIN cleanly.
+                tls.sock
+                    .shutdown(std::net::Shutdown::Write)
+                    .map_err(|e| format!("tcp shutdown: {e}"))?;
+
+                // Drain the receive buffer (e.g. TLS 1.3 NewSessionTicket
+                // messages the server sent after the handshake). If unread
+                // data remains when close() is called, the kernel sends
+                // TCP RST instead of FIN, which can truncate in-flight
+                // application data at the receiver.
+                tls.sock
+                    .set_read_timeout(Some(std::time::Duration::from_millis(200)))
+                    .ok();
+                let mut drain = [0u8; 4096];
+                loop {
+                    match tls.sock.read(&mut drain) {
+                        Ok(0) => break,
+                        Ok(_) => continue,
+                        Err(_) => break,
+                    }
+                }
+
+                Ok(())
+            }));
+        }
+
+        let mut errors = Vec::new();
+        for h in handles {
+            if let Err(e) = h.join().expect("sender thread panicked") {
+                errors.push(e);
+            }
+        }
+        if errors.is_empty() {
+            Ok(())
+        } else {
+            Err(PyRuntimeError::new_err(errors.join("; ")))
+        }
+    })
+}
+
+#[pymethods]
+impl PackedBuffer {
+    /// Send dirty blocks over parallel TLS connections.
+    ///
+    /// Each address in `addresses` gets its own TCP+TLS stream. Blocks
+    /// are distributed round-robin across streams. The wire protocol
+    /// matches the Python `SenderShardActor` exactly.
+    #[pyo3(signature = (dirty_blocks, addresses, cache_path, hash_block_size=None, tls_hostname=None))]
+    fn send_blocks(
+        &self,
+        py: Python<'_>,
+        dirty_blocks: Vec<usize>,
+        addresses: Vec<String>,
+        cache_path: String,
+        hash_block_size: Option<usize>,
+        tls_hostname: Option<String>,
+    ) -> PyResult<()> {
+        let block_size = hash_block_size.unwrap_or(HASH_BLOCK_SIZE);
+        let buf_ptr = self.ptr as usize;
+        let total_size = self.size;
+
+        py.detach(move || {
+            send_blocks_impl(
+                buf_ptr,
+                total_size,
+                &dirty_blocks,
+                &addresses,
+                &cache_path,
+                block_size,
+                tls_hostname.as_deref(),
+            )
+        })
+    }
+}
+
+/// Send dirty blocks from an existing buffer over parallel TLS connections.
+///
+/// Like `PackedBuffer.send_blocks()` but operates on any buffer (e.g. a
+/// memoryview from `pack_directory_chunked`), avoiding a second pack step.
+#[pyfunction]
+#[pyo3(signature = (buffer, total_size, dirty_blocks, addresses, cache_path, hash_block_size=None, tls_hostname=None))]
+fn send_blocks_from_buffer(
+    py: Python<'_>,
+    buffer: pyo3::buffer::PyBuffer<u8>,
+    total_size: usize,
+    dirty_blocks: Vec<usize>,
+    addresses: Vec<String>,
+    cache_path: String,
+    hash_block_size: Option<usize>,
+    tls_hostname: Option<String>,
+) -> PyResult<()> {
+    let block_size = hash_block_size.unwrap_or(HASH_BLOCK_SIZE);
+    let buf_ptr = buffer.buf_ptr() as usize;
+
+    py.detach(move || {
+        send_blocks_impl(
+            buf_ptr,
+            total_size,
+            &dirty_blocks,
+            &addresses,
+            &cache_path,
+            block_size,
+            tls_hostname.as_deref(),
+        )
+    })
+}
+
+/// Pack files into anonymous mmap and compute block hashes.
+///
+/// Returns a `PackedBuffer` whose `.hashes` attribute holds hex-encoded
+/// xxh64 digests for each 100 MB block.
+#[pyfunction]
+#[pyo3(signature = (file_list, total_size, hash_block_size=None))]
+fn pack_and_hash(
+    py: Python<'_>,
+    file_list: Vec<(String, usize, usize)>,
+    total_size: usize,
+    hash_block_size: Option<usize>,
+) -> PyResult<PackedBuffer> {
+    let block_size = hash_block_size.unwrap_or(HASH_BLOCK_SIZE);
+
+    if file_list.is_empty() || total_size == 0 {
+        return Ok(PackedBuffer {
+            ptr: std::ptr::null_mut(),
+            size: 0,
+            hashes: Vec::new(),
+        });
+    }
+
+    let files: Vec<FileInfo> = file_list
+        .into_iter()
+        .map(|(path, offset, size)| FileInfo { path, offset, size })
+        .collect();
+
+    let buffer =
+        mmap_anonymous(total_size).map_err(|e| PyOSError::new_err(format!("mmap failed: {e}")))?;
+
+    let buf_ptr = buffer as usize;
+
+    let hashes = py.detach(move || {
+        let nthreads = std::thread::available_parallelism()
+            .map(|n| n.get().min(16))
+            .unwrap_or(1);
+        pack_files_into(buf_ptr, &files, nthreads);
+        compute_block_hashes(buf_ptr, total_size, block_size, nthreads)
+    });
+
+    Ok(PackedBuffer {
+        ptr: buffer,
+        size: total_size,
+        hashes,
+    })
+}
+
+pub fn register_python_bindings(module: &Bound<'_, PyModule>) -> PyResult<()> {
+    module.add_class::<PackedBuffer>()?;
+    let f = wrap_pyfunction!(pack_and_hash, module)?;
+    f.setattr(
+        "__module__",
+        "monarch._rust_bindings.monarch_extension.tls_sender",
+    )?;
+    module.add_function(f)?;
+    let f2 = wrap_pyfunction!(send_blocks_from_buffer, module)?;
+    f2.setattr(
+        "__module__",
+        "monarch._rust_bindings.monarch_extension.tls_sender",
+    )?;
+    module.add_function(f2)?;
+    Ok(())
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = [
     "opentelemetry-api",
     "clusterscope",
     "flask>=2.0",
+    "xxhash",
 ]
 
 # PyTorch nightly build indices for different platforms

--- a/python/benches/remotemount/README.md
+++ b/python/benches/remotemount/README.md
@@ -1,0 +1,97 @@
+# remotemount benchmark
+
+Benchmarks remotemount transfer throughput: cold transfer, no-change skip, and
+incremental re-transfer. Compares `actor` vs `rust_tls` transfer modes and
+sweeps parallel TLS stream counts.
+
+## Setup
+
+`setup_bench_env.sh` is a thin wrapper around `examples/remotemount/setup_conda_env.sh`.
+It creates matching client (x86) and worker (target arch) conda envs with
+monarch built from the current source. The four slow operations (2 fbpkg
+fetches + 2 buck2 builds) run in parallel.
+
+```bash
+bash python/benches/remotemount/setup_bench_env.sh [target] [DEST_DIR]
+```
+
+- `target`: `gb200`, `gb300` (aarch64) or `grandteton`, `h100` (x86). Default: `gb200`
+- `DEST_DIR`: where to create the envs. Default: `$HOME/monarch_conda_envs`
+
+## Running
+
+### Local (single host, no MAST)
+
+```bash
+buck run fbcode//monarch/python/benches/remotemount:bench_tls_packing
+```
+
+### MAST (multi-host, GB200)
+
+```bash
+CONDA_PREFIX=~/monarch_conda_envs/worker/conda \
+~/monarch_conda_envs/client/conda/bin/python3.12 \
+  python/benches/remotemount/bench_tls_packing.py \
+  --backend=mast --host_type=gb200 --num_hosts=2 --data_size_mb=1024
+```
+
+### Options
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--backend` | `local` | `local` or `mast` |
+| `--num_hosts` | `1` | Number of worker hosts |
+| `--gpus_per_host` | `1` | GPUs per host |
+| `--host_type` | `gb300` | MAST host type (`gb200`, `gb300`) |
+| `--data_size_mb` | `50` | Size of test payload in MB |
+| `--locality_constraints` | `""` | Semicolon-separated locality constraints |
+
+## Results
+
+### Benchmark setup
+
+- 2 GB200 hosts, 1024 MB payload, 8 parallel TLS streams
+- Client-to-worker transfer uses TCP (client has no ibverbs)
+- Worker-to-worker fan-out uses native ibverbs RDMA
+
+### Transfer mode comparison (cold transfer)
+
+| Mode | Streams | Cold | Throughput |
+|------|---------|------|------------|
+| actor | 1 | 8.06s | 127 MB/s |
+| rust_tls | 8 | 1.35s | 757 MB/s |
+
+### rust_tls stream count sweep (cold transfer)
+
+| Streams | Cold | Throughput |
+|---------|------|------------|
+| 1 | 1.32s | 778 MB/s |
+| 2 | 1.35s | 757 MB/s |
+| 4 | 1.47s | 697 MB/s |
+| 8 | 1.29s | 792 MB/s |
+| 16 | 1.30s | 788 MB/s |
+
+### Incremental cycle (cold / skip / re-transfer)
+
+| Mode | Cold | Skip | Retransfer | Throughput |
+|------|------|------|------------|------------|
+| actor | 1.31s | 0.42s | 7.21s | 784 MB/s |
+| rust_tls | 4.62s | 0.42s | 3.54s | 222 MB/s |
+
+Key observations:
+
+- **rust_tls is 6x faster** than actor for cold transfers (757 vs 127 MB/s)
+- **Stream count has minimal impact** — a single TLS stream already saturates
+  the link at ~780 MB/s
+- **No-change skip** is 0.42s for both modes (hash match, no network transfer)
+- **rust_tls re-transfer** is 2x faster than actor (3.54s vs 7.21s)
+
+## How it works
+
+The benchmark creates a temp directory with test files (`data.bin` + small
+Python/JSON files), then runs three sections:
+
+1. **Transfer mode comparison** — cold transfer with `actor` vs `rust_tls`
+2. **Stream count sweep** — `rust_tls` with 1, 2, 4, 8, 16 parallel streams
+3. **Incremental cycle** — cold transfer, no-change skip (hash match), and
+   modified re-transfer for each mode

--- a/python/benches/remotemount/bench_fast_pack.py
+++ b/python/benches/remotemount/bench_fast_pack.py
@@ -108,7 +108,7 @@ def bench_pack(total_gb: float, iterations: int = 3) -> None:
         # Warmup (first run populates page cache).
         print("  Warmup...", end=" ", flush=True)
         t0 = time.monotonic()
-        meta, staging_mv, chunks, hashes = pack_directory_chunked(base_dir)
+        meta, staging_mv, chunks, hashes, _pi = pack_directory_chunked(base_dir)
         warmup_time = time.monotonic() - t0
         warmup_gbs = actual_gb / warmup_time
         print(f"{warmup_time:.2f}s ({warmup_gbs:.2f} GB/s)")
@@ -118,7 +118,7 @@ def bench_pack(total_gb: float, iterations: int = 3) -> None:
         assert total_packed == actual, f"packed {total_packed} != actual {actual}"
         assert len(hashes) > 0, "expected at least one hash"
 
-        del meta, staging_mv, chunks, hashes
+        del meta, staging_mv, chunks, hashes, _pi
         gc.collect()
 
         # Timed runs.
@@ -126,11 +126,11 @@ def bench_pack(total_gb: float, iterations: int = 3) -> None:
         nhashes = 0
         for _i in range(iterations):
             t0 = time.monotonic()
-            meta, staging_mv, chunks, hashes = pack_directory_chunked(base_dir)
+            meta, staging_mv, chunks, hashes, _pi = pack_directory_chunked(base_dir)
             elapsed = time.monotonic() - t0
             times.append(elapsed)
             nhashes = len(hashes)
-            del meta, staging_mv, chunks, hashes
+            del meta, staging_mv, chunks, hashes, _pi
             gc.collect()
 
         avg = sum(times) / len(times)
@@ -160,8 +160,8 @@ def bench_scaling(size_gb: float = 4.0) -> None:
         print(f"  {file_size_stats(file_sizes)}")
 
         # Warmup.
-        meta, staging_mv, chunks, hashes = pack_directory_chunked(base_dir)
-        del meta, staging_mv, chunks, hashes
+        meta, staging_mv, chunks, hashes, _pi = pack_directory_chunked(base_dir)
+        del meta, staging_mv, chunks, hashes, _pi
         gc.collect()
 
         core_counts = [c for c in [1, 2, 4, 8, 16] if c <= available]
@@ -178,10 +178,10 @@ def bench_scaling(size_gb: float = 4.0) -> None:
             times = []
             for _i in range(3):
                 t0 = time.monotonic()
-                meta, staging_mv, chunks, hashes = pack_directory_chunked(base_dir)
+                meta, staging_mv, chunks, hashes, _pi = pack_directory_chunked(base_dir)
                 elapsed = time.monotonic() - t0
                 times.append(elapsed)
-                del meta, staging_mv, chunks, hashes
+                del meta, staging_mv, chunks, hashes, _pi
                 gc.collect()
 
             best = min(times)

--- a/python/benches/remotemount/bench_metadata_encoding.py
+++ b/python/benches/remotemount/bench_metadata_encoding.py
@@ -144,7 +144,7 @@ def bench_real_pack(num_files: int, file_size: int = 1024) -> tuple[float, float
 
         # Time pack
         start = time.perf_counter()
-        meta, _staging_mv, _chunks, _shm_path = pack_directory_chunked(d)
+        meta, _staging_mv, _chunks, _shm_path, _pi = pack_directory_chunked(d)
         pack_time = time.perf_counter() - start
 
         # Time json.dumps

--- a/python/benches/remotemount/bench_tls_packing.py
+++ b/python/benches/remotemount/bench_tls_packing.py
@@ -1,0 +1,336 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-unsafe
+
+"""Benchmark remotemount transfer throughput.
+
+Compares transfer modes (actor vs rust_tls) and varies TLS stream counts.
+Measures cold transfer, no-change skip, and incremental re-transfer.
+
+Usage:
+    buck run fbcode//monarch/python/benches/remotemount:bench_tls_packing
+    buck run fbcode//monarch/python/benches/remotemount:bench_tls_packing -- --backend mast --num_hosts 2
+    buck run fbcode//monarch/python/benches/remotemount:bench_tls_packing -- --data_size_mb 200
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import shutil
+import sys
+import tempfile
+import time
+
+import fire
+from monarch.actor import Actor, endpoint, this_host
+
+
+class TestActor(Actor):
+    @endpoint
+    def check_file(self, path):
+        """Read a file from the mount and return its contents."""
+        try:
+            with open(path) as f:
+                return f.read()
+        except Exception as e:
+            return f"ERROR: {e}"
+
+    @endpoint
+    def list_dir(self, path):
+        """List files in a directory."""
+        try:
+            return sorted(os.listdir(path))
+        except Exception as e:
+            return f"ERROR: {e}"
+
+
+CERT_PATH = "/var/facebook/x509_identities/server.pem"
+
+
+def _has_tls_certs():
+    return os.path.exists(CERT_PATH)
+
+
+def _format_throughput(nbytes, seconds):
+    if seconds <= 0:
+        return "inf"
+    mbps = nbytes / seconds / (1024 * 1024)
+    if mbps >= 1024:
+        return f"{mbps / 1024:.2f} GB/s"
+    return f"{mbps:.0f} MB/s"
+
+
+def bench_cold_transfer(
+    host_mesh,
+    test_dir,
+    backend,
+    transfer_mode,
+    num_parallel_streams=8,
+):
+    """Run a single cold transfer and return (open_time, data_size)."""
+    from monarch.remotemount import remotemount
+
+    mount_point = (
+        test_dir if backend == "mast" else tempfile.mkdtemp(prefix="remotemount_mnt_")
+    )
+
+    handler = remotemount(
+        host_mesh,
+        test_dir,
+        mount_point,
+        backend=backend,
+        transfer_mode=transfer_mode,
+        num_parallel_streams=num_parallel_streams,
+    )
+
+    t0 = time.time()
+    handler.open()
+    open_time = time.time() - t0
+
+    handler.close()
+
+    if mount_point != test_dir:
+        shutil.rmtree(mount_point, ignore_errors=True)
+
+    return open_time
+
+
+def bench_incremental_cycle(
+    host_mesh,
+    test_dir,
+    test_actors,
+    backend,
+    transfer_mode,
+    num_parallel_streams=8,
+):
+    """Run full open/skip/modify/re-transfer cycle. Returns dict of timings."""
+    from monarch.remotemount import remotemount
+
+    mount_point = (
+        test_dir if backend == "mast" else tempfile.mkdtemp(prefix="remotemount_mnt_")
+    )
+
+    handler = remotemount(
+        host_mesh,
+        test_dir,
+        mount_point,
+        backend=backend,
+        transfer_mode=transfer_mode,
+        num_parallel_streams=num_parallel_streams,
+    )
+
+    # Cold transfer.
+    t0 = time.time()
+    handler.open()
+    cold_time = time.time() - t0
+
+    # Verify content.
+    results = test_actors.check_file.call(
+        os.path.join(mount_point, "config.json")
+    ).get()
+    for point, content in results:
+        assert "ERROR" not in str(content), f"rank{point.rank}: {content}"
+
+    # No-change skip.
+    handler.close()
+    t0 = time.time()
+    handler.open()
+    skip_time = time.time() - t0
+
+    # Modify and re-transfer.
+    handler.close()
+    with open(os.path.join(test_dir, "config.json"), "w") as f:
+        f.write('{"lr": 0.01, "epochs": 20}\n')
+
+    t0 = time.time()
+    handler.open()
+    retransfer_time = time.time() - t0
+
+    # Verify updated content.
+    results = test_actors.check_file.call(
+        os.path.join(mount_point, "config.json")
+    ).get()
+    for point, content in results:
+        assert "0.01" in str(content), f"rank{point.rank}: {content}"
+
+    # Restore original content for next run.
+    handler.close()
+    with open(os.path.join(test_dir, "config.json"), "w") as f:
+        f.write('{"lr": 0.001, "epochs": 10}\n')
+
+    if mount_point != test_dir:
+        shutil.rmtree(mount_point, ignore_errors=True)
+
+    return {
+        "cold": cold_time,
+        "skip": skip_time,
+        "retransfer": retransfer_time,
+    }
+
+
+def main(
+    backend="local",
+    num_hosts=1,
+    gpus_per_host=1,
+    host_type="gb300",
+    locality_constraints="",
+    data_size_mb=50,
+    verbose=True,
+) -> None:
+    if verbose:
+        logging.basicConfig(
+            level=logging.INFO,
+            format="%(asctime)s | %(levelname)s | %(message)s",
+            datefmt="%H:%M:%S",
+        )
+
+    from monarch.config import configure
+
+    configure(
+        enable_log_forwarding=True,
+        tail_log_lines=100,
+        host_spawn_ready_timeout="120s",
+        mesh_proc_spawn_max_idle="120s",
+        message_delivery_timeout="600s",
+    )
+
+    # Create test directory.
+    test_dir = tempfile.mkdtemp(prefix="remotemount_bench_")
+    os.makedirs(os.path.join(test_dir, "src"), exist_ok=True)
+
+    for i in range(5):
+        with open(os.path.join(test_dir, "src", f"mod_{i}.py"), "w") as f:
+            f.write(f"# Module {i}\ndef func(): return {i}\n")
+
+    with open(os.path.join(test_dir, "config.json"), "w") as f:
+        f.write('{"lr": 0.001, "epochs": 10}\n')
+
+    with open(os.path.join(test_dir, "data.bin"), "wb") as f:
+        f.write(os.urandom(data_size_mb * 1024 * 1024))
+
+    total = sum(
+        os.path.getsize(os.path.join(r, f))
+        for r, _, fs in os.walk(test_dir)
+        for f in fs
+    )
+
+    print("=" * 78)
+    print(f"Remotemount benchmark — {total / (1024 * 1024):.0f} MB payload")
+    print("=" * 78)
+    print(f"Backend: {backend}, TLS certs: {_has_tls_certs()}\n")
+
+    # Set up host mesh.
+    job = None
+    if backend == "mast":
+        from monarch.actor import enable_transport
+        from monarch.job.meta import MASTJob
+
+        enable_transport("metatls-hostname")
+        lc = None
+        if locality_constraints and locality_constraints != "":
+            lc = locality_constraints.split(";")
+        job = MASTJob(
+            hpcIdentity="hyper_monarch",
+            hpcJobOncall="monarch",
+            rmAttribution="msl_infra_pytorch_dev",
+            hpcClusterUuid="MastGenAICluster",
+            useStrictName=True,
+            localityConstraints=lc,
+            env={
+                "PYTHONDONTWRITEBYTECODE": "1",
+                "MAST_PRECHECK_SKIP_TIME_CONSUMING_CHECKS": "1",
+            },
+        )
+        job.add_mesh("workers", num_hosts, host_type=host_type)
+        # A workspace directory triggers conda-packing of CONDA_PREFIX
+        # into an ephemeral fbpkg shipped to workers. Without this, the
+        # scheduler deploys the base image as-is (x86), which fails on
+        # aarch64 hosts like GB200/GB300.
+        job.add_directory(tempfile.mkdtemp())
+        host_meshes = job.state()
+        host_mesh = host_meshes.workers
+    else:
+        host_mesh = this_host()
+
+    procs = host_mesh.spawn_procs(per_host={"gpus": gpus_per_host})
+    test_actors = procs.spawn("TestActor", TestActor)
+
+    # ---- Section 1: actor vs rust_tls comparison ----
+    modes = ["actor"]
+    if _has_tls_certs() or backend == "mast":
+        modes.append("rust_tls")
+
+    print("--- Transfer mode comparison (cold transfer) ---")
+    print(f"{'Mode':>12}  {'Streams':>8}  {'Cold':>8}  {'Throughput':>12}")
+    print("-" * 48)
+
+    for mode in modes:
+        streams = 8 if mode == "rust_tls" else 1
+        t = bench_cold_transfer(
+            host_mesh, test_dir, backend, mode, num_parallel_streams=streams
+        )
+        print(
+            f"{mode:>12}  {streams:>8}  {t:>7.2f}s  {_format_throughput(total, t):>12}"
+        )
+
+    # ---- Section 2: rust_tls stream count sweep ----
+    if "rust_tls" in modes:
+        print("\n--- rust_tls stream count sweep (cold transfer) ---")
+        print(f"{'Streams':>8}  {'Cold':>8}  {'Throughput':>12}")
+        print("-" * 34)
+
+        for streams in [1, 2, 4, 8, 16]:
+            t = bench_cold_transfer(
+                host_mesh,
+                test_dir,
+                backend,
+                "rust_tls",
+                num_parallel_streams=streams,
+            )
+            print(f"{streams:>8}  {t:>7.2f}s  {_format_throughput(total, t):>12}")
+
+    # ---- Section 3: full incremental cycle for each mode ----
+    print("\n--- Incremental cycle (cold / skip / re-transfer) ---")
+    print(
+        f"{'Mode':>12}  {'Cold':>8}  {'Skip':>8}  {'Retransfer':>10}  {'Throughput':>12}"
+    )
+    print("-" * 60)
+
+    for mode in modes:
+        streams = 8 if mode == "rust_tls" else 1
+        timings = bench_incremental_cycle(
+            host_mesh,
+            test_dir,
+            test_actors,
+            backend,
+            mode,
+            num_parallel_streams=streams,
+        )
+        print(
+            f"{mode:>12}  {timings['cold']:>7.2f}s  {timings['skip']:>7.2f}s  "
+            f"{timings['retransfer']:>9.2f}s  "
+            f"{_format_throughput(total, timings['cold']):>12}"
+        )
+
+    print()
+
+    # Cleanup.
+    if job is not None:
+        job.kill()
+        print("MAST job killed.")
+    shutil.rmtree(test_dir, ignore_errors=True)
+    print("Done.")
+
+
+# Register for pickle-by-value so TestActor can be sent to remote workers.
+import cloudpickle  # noqa: E402
+
+cloudpickle.register_pickle_by_value(sys.modules[__name__])
+
+if __name__ == "__main__":
+    fire.Fire(main)

--- a/python/monarch/remotemount/__init__.py
+++ b/python/monarch/remotemount/__init__.py
@@ -3,3 +3,5 @@
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
+
+from .remotemount import remotemount  # noqa: F401

--- a/python/monarch/remotemount/fast_pack.py
+++ b/python/monarch/remotemount/fast_pack.py
@@ -8,6 +8,7 @@
 
 from __future__ import annotations
 
+import json
 import logging
 import os
 from typing import Any
@@ -21,6 +22,7 @@ logger: logging.Logger = logging.getLogger(__name__)
 
 CHUNK_SIZE: int = (1024 * 1024 * 1024) * 8
 HASH_BLOCK_SIZE: int = 64 * 1024 * 1024  # 64MB blocks for incremental diffing
+FRAG_THRESHOLD: float = 0.2  # max dead-space ratio before sequential repack
 
 
 # pyre-fixme[24]: Generic type `memoryview` expects 1 type parameter.
@@ -29,28 +31,110 @@ def block_hashes(data_mv: memoryview, block_size: int = HASH_BLOCK_SIZE) -> list
     return list(block_hashes_py(data_mv, block_size))
 
 
+def load_pack_index(path: str) -> dict[str, Any] | None:
+    """Load JSON pack index from disk. Returns None if the file doesn't exist."""
+    if not os.path.exists(path):
+        return None
+    with open(path) as f:
+        return json.load(f)  # pyre-ignore[7]
+
+
+def save_pack_index(path: str, index_data: dict[str, Any]) -> None:
+    """Write pack index as JSON."""
+    with open(path, "w") as f:
+        json.dump(index_data, f)
+
+
+def _compute_file_hashes(
+    # pyre-fixme[24]: Generic type `memoryview` expects 1 type parameter.
+    staging_mv: memoryview,
+    file_entries: list[tuple[str, str, int, int]],
+    offset_map: dict[str, int],
+) -> dict[str, str]:
+    """Compute xxh64 per file from packed buffer. Returns {vpath: hash_hex}."""
+    import xxhash
+
+    hashes: dict[str, str] = {}
+    for vpath, _full_path, file_len, _mtime_ns in file_entries:
+        offset = offset_map[vpath]
+        hashes[vpath] = xxhash.xxh64(staging_mv[offset : offset + file_len]).hexdigest()
+    return hashes
+
+
+def _assign_offsets(
+    file_entries: list[tuple[str, str, int, int]],
+    previous_index: dict[str, Any],
+) -> tuple[dict[str, int], int, int]:
+    """Append-only offset assignment.
+
+    Unchanged files keep their original offsets. Changed/new files are
+    appended after the previous total size.
+
+    Returns:
+        (offset_map, new_total_size, dead_space)
+    """
+    prev_files: dict[str, Any] = previous_index.get("files", {})
+    prev_total: int = previous_index.get("total_size", 0)
+
+    offset_map: dict[str, int] = {}
+    dead_space = 0
+    append_offset = prev_total
+
+    current_vpaths: set[str] = set()
+    for vpath, _full_path, file_len, mtime_ns in file_entries:
+        current_vpaths.add(vpath)
+        prev = prev_files.get(vpath)
+        if prev and prev["size"] == file_len and prev["mtime_ns"] == mtime_ns:
+            # File unchanged — keep old offset.
+            offset_map[vpath] = prev["offset"]
+        else:
+            # File changed or new — append at the end.
+            if prev:
+                dead_space += prev["size"]
+            offset_map[vpath] = append_offset
+            append_offset += file_len
+
+    # Deleted files contribute dead space.
+    for vpath, info in prev_files.items():
+        if vpath not in current_vpaths:
+            dead_space += info["size"]
+
+    return offset_map, append_offset, dead_space
+
+
 def pack_directory_chunked(
     source_path: str,
     chunk_size: int | None = None,
+    previous_index: dict[str, Any] | None = None,
     # pyre-fixme[24]: Generic type `memoryview` expects 1 type parameter.
-) -> tuple[dict[str, Any], memoryview | None, list[memoryview], list[str]]:
+) -> tuple[
+    dict[str, Any],
+    memoryview | None,
+    list[memoryview],
+    list[str],
+    dict[str, Any] | None,
+]:
     """Walk a directory, pack all files into contiguous mmap chunks.
 
-    Returns (fs_metadata, staging_mv, chunks, block_hashes_list)
+    When *previous_index* is provided (from a prior run's pack index), files
+    whose ``(mtime_ns, size)`` match the index keep their original offsets and
+    changed/new files are appended at the end of the buffer.  If the resulting
+    dead-space ratio exceeds ``FRAG_THRESHOLD``, the layout falls back to
+    sequential packing.
+
+    Returns (fs_metadata, staging_mv, chunks, block_hashes_list, pack_index)
     where:
     - fs_metadata: dict mapping virtual paths to stat/offset metadata
     - staging_mv: memoryview over the packed data
     - chunks: list of chunk-sized memoryview slices
     - block_hashes_list: list of xxh64 hex digest strings per block
+    - pack_index: dict with per-file offset/size/mtime/hash for incremental packing
     """
     if chunk_size is None:
         chunk_size = CHUNK_SIZE
 
     fs_metadata: dict[str, Any] = {}
-    file_list: list[tuple[str, int, int]] = []
-
-    # Tracks the virtual address of the filesystem
-    current_global_offset = 0
+    file_entries: list[tuple[str, str, int, int]] = []
 
     source_path = os.path.abspath(source_path)
 
@@ -104,6 +188,7 @@ def pack_directory_chunked(
                 }
             else:
                 file_len = lst.st_size
+                mtime_ns = lst.st_mtime_ns
                 attr = {
                     key: getattr(lst, key)
                     for key in (
@@ -119,21 +204,62 @@ def pack_directory_chunked(
                 }
                 attr["st_size"] = file_len
 
+                # Defer global_offset — assigned after offset-assignment phase.
                 fs_metadata[virtual_path] = {
                     "attr": attr,
-                    "global_offset": current_global_offset,
                     "file_len": file_len,
                 }
 
-                file_list.append((full_path, current_global_offset, file_len))
-                # Tracks the virtual address of the filesystem
-                current_global_offset += file_len
+                file_entries.append((virtual_path, full_path, file_len, mtime_ns))
 
-    total_size = current_global_offset
+    # --- Offset assignment phase ---
+    offset_map: dict[str, int] = {}
+    total_size: int = 0
+    use_append = False
+    if previous_index and previous_index.get("files"):
+        offset_map, total_size, dead_space = _assign_offsets(
+            file_entries, previous_index
+        )
+        if total_size == 0:
+            pass  # No files to pack.
+        elif dead_space / total_size > FRAG_THRESHOLD:
+            logger.info(
+                f"Fragmentation {dead_space / total_size:.1%} exceeds threshold "
+                f"{FRAG_THRESHOLD:.0%}, repacking sequentially"
+            )
+        else:
+            n_reused = sum(
+                1
+                for vpath, _, flen, mns in file_entries
+                if previous_index["files"].get(vpath, {}).get("size") == flen
+                and previous_index["files"].get(vpath, {}).get("mtime_ns") == mns
+            )
+            logger.info(
+                f"Append-only layout: {n_reused}/{len(file_entries)} files reused, "
+                f"dead_space={dead_space // 1024}KiB "
+                f"({dead_space / total_size:.1%} of {total_size // (1024**2)}MiB)"
+            )
+            use_append = True
+
+    if not use_append:
+        # Sequential offsets (default behavior).
+        offset_map = {}
+        current_offset = 0
+        for vpath, _full_path, file_len, _mtime_ns in file_entries:
+            offset_map[vpath] = current_offset
+            current_offset += file_len
+        total_size = current_offset
+
+    # Set global_offset in fs_metadata and build file_list for Rust packer.
+    file_list: list[tuple[str, int, int]] = []
+    for vpath, full_path, file_len, _mtime_ns in file_entries:
+        fs_metadata[vpath]["global_offset"] = offset_map[vpath]
+        file_list.append((full_path, offset_map[vpath], file_len))
+
     logger.info(f"Packing {total_size // (1024**2)}MiB, {len(file_list)} files")
 
     if total_size == 0:
-        return fs_metadata, None, [], []
+        return fs_metadata, None, [], [], None
 
     buf, hashes = pack_files_with_offsets(file_list, total_size)
     staging_mv = memoryview(buf)
@@ -141,4 +267,19 @@ def pack_directory_chunked(
         staging_mv[i : i + chunk_size] for i in range(0, len(staging_mv), chunk_size)
     ]
 
-    return fs_metadata, staging_mv, chunks, list(hashes)
+    # Compute per-file content hashes and build pack index.
+    file_hashes = _compute_file_hashes(staging_mv, file_entries, offset_map)
+    new_pack_index: dict[str, Any] = {
+        "total_size": total_size,
+        "files": {
+            vpath: {
+                "offset": offset_map[vpath],
+                "size": file_len,
+                "mtime_ns": mtime_ns,
+                "content_hash": file_hashes[vpath],
+            }
+            for vpath, _full_path, file_len, mtime_ns in file_entries
+        },
+    }
+
+    return fs_metadata, staging_mv, chunks, list(hashes), new_pack_index

--- a/python/monarch/remotemount/remotemount.py
+++ b/python/monarch/remotemount/remotemount.py
@@ -1,0 +1,947 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-ignore-all-errors
+
+from __future__ import annotations
+
+import logging
+import os
+import subprocess
+import time
+from typing import Optional
+
+from monarch.actor import Actor, endpoint
+from monarch.remotemount.fast_pack import (  # noqa: F401
+    block_hashes,
+    CHUNK_SIZE,
+    HASH_BLOCK_SIZE,
+    load_pack_index,
+    pack_directory_chunked,
+    save_pack_index,
+)
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+CACHE_DIR = "/tmp/monarch_remotemount_cache"
+RDMA_PARALLEL_TLS_THRESHOLD = (
+    8  # blocks <= this: TLS to all workers; above: RDMA fan-out
+)
+
+
+def classify_workers(
+    client_hashes: list[str],
+    client_total_size: int,
+    worker_states: list[tuple[list[str], int]],
+) -> tuple[list[int], dict[int, list[int] | None]]:
+    """Classify workers as fresh, partial, or stale.
+
+    Args:
+        client_hashes: list of block hash strings from client
+        client_total_size: total packed data size on client
+        worker_states: list of (remote_hashes, remote_size) tuples
+
+    Returns:
+        (fresh_ranks, worker_dirty) where:
+        - fresh_ranks: list of rank indices that are up-to-date
+        - worker_dirty: dict {rank: list[int] | None} — dirty block
+          indices for partial workers, or None for stale workers
+    """
+    fresh_ranks = []
+    worker_dirty = {}
+    for rank, (remote_hashes, remote_size) in enumerate(worker_states):
+        if remote_hashes == client_hashes and remote_size == client_total_size:
+            fresh_ranks.append(rank)
+        elif remote_hashes:
+            # Partial: compare overlapping blocks, mark new/changed as dirty.
+            min_blocks = min(len(remote_hashes), len(client_hashes))
+            dirty = [
+                i for i in range(min_blocks) if remote_hashes[i] != client_hashes[i]
+            ]
+            # Any blocks beyond the old count are new and need transfer.
+            dirty.extend(range(min_blocks, len(client_hashes)))
+            # If size changed, the last overlapping block likely changed
+            # (partial block at the boundary may have different content).
+            if remote_size != client_total_size and min_blocks > 0:
+                last = min_blocks - 1
+                if last not in dirty:
+                    dirty.append(last)
+                    dirty.sort()
+            worker_dirty[rank] = dirty
+        else:
+            worker_dirty[rank] = None
+    return fresh_ranks, worker_dirty
+
+
+class FUSEActor(Actor):
+    def __init__(self, chunk_size, backend="slurm"):
+        self.chunk_size = chunk_size
+        self.backend = backend
+        self.meta = None
+        self.chunks = []
+        self._chunk_storage = None
+        self._chunk_offsets = None
+        self._next_chunk_idx = 0
+        self._block_hashes = []
+        self._total_size = 0
+        self._fuse_handle = None
+        self._cache_path = None
+        self._tls_receiver = None
+        self._pack_index = {}
+        self._rdma_src_staging = None  # staging for get_blocks_rdma_buffer (source)
+        self._rdma_src_staging_mv = None
+        self._rdma_dst_staging = None  # staging for replace_blocks (destination)
+        self._rdma_dst_staging_mv = None
+
+    def _alloc_storage(self, total_size, truncate=False):
+        """Allocate or resize chunk storage (file-backed or anonymous mmap).
+
+        Args:
+            total_size: desired buffer size in bytes.
+            truncate: if True, wipe existing data (O_TRUNC). If False,
+                preserve existing cached blocks during resize.
+        """
+        import mmap as _mmap
+
+        self._chunk_storage_mv = None
+        self.chunks = []
+        self._chunk_offsets = None
+
+        if self._cache_path:
+            flags = os.O_RDWR | os.O_CREAT | (os.O_TRUNC if truncate else 0)
+            fd = os.open(self._cache_path, flags, 0o600)
+            os.ftruncate(fd, total_size)
+            if self._chunk_storage is not None:
+                self._chunk_storage.close()
+            self._chunk_storage = _mmap.mmap(fd, total_size)
+            os.close(fd)
+        else:
+            if self._chunk_storage is not None:
+                self._chunk_storage.close()
+            self._chunk_storage = _mmap.mmap(
+                -1, total_size, _mmap.MAP_PRIVATE | _mmap.MAP_ANONYMOUS
+            )
+
+        self._chunk_storage_mv = memoryview(self._chunk_storage)
+        self._total_size = total_size
+
+        # Build chunks list for mount().
+        self._chunk_offsets = []
+        remaining = total_size
+        off = 0
+        while remaining > 0:
+            sz = min(remaining, self.chunk_size)
+            self._chunk_offsets.append((off, sz))
+            self.chunks.append(self._chunk_storage_mv[off : off + sz])
+            off += sz
+            remaining -= sz
+        self._next_chunk_idx = len(self._chunk_offsets)
+
+    @endpoint
+    def try_load_cache(self, cache_key):
+        """Load cached chunk data from a previous run, if available.
+
+        Sets ``_cache_path`` so that subsequent ``init_chunk_storage`` and
+        ``collect_shards`` calls use file-backed mmap. If a cache file
+        already exists, mmaps it and computes block hashes so the client
+        can classify this worker as fresh or partial.
+        """
+        os.makedirs(CACHE_DIR, exist_ok=True)
+        self._cache_path = os.path.join(CACHE_DIR, cache_key)
+
+        if not os.path.exists(self._cache_path):
+            return
+
+        size = os.path.getsize(self._cache_path)
+        if size == 0:
+            return
+
+        self._alloc_storage(size)
+        self._block_hashes = block_hashes(self._chunk_storage_mv)
+        self._pack_index = load_pack_index(self._cache_path + ".index") or {}
+
+        logger.info(
+            f"[CACHE] Loaded {self._cache_path}: "
+            f"{size // (1024**2)}MiB, "
+            f"{len(self._block_hashes)} block hashes"
+        )
+
+    @endpoint
+    def set_meta(self, meta):
+        self.meta = meta
+
+    @endpoint
+    def init_chunk_storage(self, chunk_sizes):
+        self._alloc_storage(sum(chunk_sizes), truncate=True)
+        # Override uniform chunks with caller-specified sizes.
+        self._chunk_offsets = []
+        self.chunks = []
+        offset = 0
+        for size in chunk_sizes:
+            self._chunk_offsets.append((offset, size))
+            self.chunks.append(self._chunk_storage_mv[offset : offset + size])
+            offset += size
+        self._next_chunk_idx = 0
+
+        # TODO(cpuhrsch): Re-enable EFA init after testing on SLURM.
+        # EFA requires explicit initialization of its manager actor on each
+        # worker (EfaManagerActor) before workers can register destination
+        # buffers for RDMA transfers. Unlike ibverbs which lazily initializes.
+        # Code was:
+        #   if self.backend == "slurm":
+        #       from monarch.rdma import is_rdma_available
+        #       if not is_rdma_available():
+        #           from monarch._src.rdma.rdma import _ensure_init_efa_manager
+        #           _ensure_init_efa_manager().block_on()
+
+    @endpoint
+    def fetch_chunk_rdma(self, rdma_buffer, chunk_size: int, timeout: int = 300):
+        """Receive RDMABuffer (works with both ibverbs and EFA) and read from it."""
+        import mmap as _mmap
+
+        idx = self._next_chunk_idx
+
+        # Copy into pre-allocated mmap via RDMA (ibverbs or TCP fallback).
+        offset, _ = self._chunk_offsets[idx]
+        dst_mv = self._chunk_storage_mv[offset : offset + chunk_size]
+        t1 = time.time()
+
+        if self._cache_path:
+            # RDMA memory registration fails on file-backed MAP_SHARED pages.
+            # Receive into an anonymous buffer, then copy to the cache file.
+            # Don't explicitly close the anonymous mmap — it can raise
+            # BufferError if the Rust RDMABuffer still holds a reference.
+            anon = _mmap.mmap(-1, chunk_size, _mmap.MAP_PRIVATE | _mmap.MAP_ANONYMOUS)
+            anon_mv = memoryview(anon)
+            rdma_buffer.read_into(anon_mv, timeout=timeout).get()
+            dst_mv[:] = anon_mv
+        else:
+            rdma_buffer.read_into(dst_mv, timeout=timeout).get()
+
+        t2 = time.time()
+        self.chunks.append(dst_mv)
+        self._next_chunk_idx += 1
+        gbs = (chunk_size / 1e9) / max(t2 - t1, 1e-9)
+        logger.info(
+            f"[WORKER] fetch_chunk {idx}: {chunk_size / (1024**2):.0f}MiB "
+            f"in {t2 - t1:.3f}s ({gbs:.1f} GB/s)"
+        )
+
+    @endpoint
+    def fanout_chunk_rdma(
+        self, peer_actors, chunk_size: int, chunk_idx: int = -1, timeout: int = 300
+    ):
+        """Fan out a chunk to peer workers via RDMA.
+
+        Args:
+            peer_actors: Mesh of peer FUSEActors to receive the chunk.
+            chunk_size: Size of the chunk in bytes.
+            chunk_idx: Which chunk to fan out. Defaults to -1 (last received).
+            timeout: RDMA timeout in seconds.
+        """
+        import mmap
+
+        from monarch.rdma import RDMABuffer
+
+        t0 = time.time()
+        idx = chunk_idx if chunk_idx >= 0 else self._next_chunk_idx - 1
+        offset, _ = self._chunk_offsets[idx]
+        src_mv = self._chunk_storage_mv[offset : offset + chunk_size]
+
+        # RDMA memory registration (ibv_reg_mr) can fail on file-backed
+        # MAP_SHARED mmap pages.  Copy into an anonymous buffer so the
+        # RDMABuffer always uses anonymous memory.
+        anon = None
+        if self._cache_path:
+            anon = mmap.mmap(-1, chunk_size, mmap.MAP_PRIVATE | mmap.MAP_ANONYMOUS)
+            anon_mv = memoryview(anon)
+            anon_mv[:] = src_mv
+            rdma_buffer = RDMABuffer(anon_mv)
+        else:
+            rdma_buffer = RDMABuffer(src_mv)
+        flat_peers = peer_actors.flatten("rank")
+        t1 = time.time()
+        futures = []
+        for rank in range(len(flat_peers)):
+            peer = flat_peers.slice(rank=rank)
+            futures.append(peer.fetch_chunk_rdma.call(rdma_buffer, chunk_size, timeout))
+        t2 = time.time()
+        for f in futures:
+            f.get()
+        t3 = time.time()
+
+        # Anonymous mmap is reclaimed on GC; explicit close() can raise
+        # BufferError if the Rust RDMABuffer still holds a reference.
+
+        n = len(flat_peers)
+        gbs = (chunk_size * n / 1e9) / max(t3 - t1, 1e-9)
+        logger.info(
+            f"[WORKER] fanout_chunk {idx}: setup={t1 - t0:.3f}s, "
+            f"dispatch={t2 - t1:.3f}s, wait={t3 - t2:.3f}s, "
+            f"total={t3 - t0:.3f}s ({gbs:.1f} GB/s aggregate, {n} peers)"
+        )
+
+    @endpoint
+    def get_blocks_rdma_buffer(self, block_indices, total_size):
+        """Copy multiple blocks into a contiguous staging buffer, return RDMABuffer.
+
+        Blocks are packed contiguously (no gaps). The caller MUST wait for
+        all peers to finish reading before calling this again.
+        """
+        import mmap as _mmap
+
+        from monarch.rdma import RDMABuffer
+
+        staging_needed = 0
+        for bi in block_indices:
+            staging_needed += min(HASH_BLOCK_SIZE, total_size - bi * HASH_BLOCK_SIZE)
+
+        if (
+            self._rdma_src_staging is None
+            or len(self._rdma_src_staging) < staging_needed
+        ):
+            self._rdma_src_staging = _mmap.mmap(
+                -1, staging_needed, _mmap.MAP_PRIVATE | _mmap.MAP_ANONYMOUS
+            )
+            self._rdma_src_staging_mv = memoryview(self._rdma_src_staging)
+
+        pos = 0
+        for bi in block_indices:
+            block_size = min(HASH_BLOCK_SIZE, total_size - bi * HASH_BLOCK_SIZE)
+            offset = bi * HASH_BLOCK_SIZE
+            self._rdma_src_staging_mv[pos : pos + block_size] = self._chunk_storage_mv[
+                offset : offset + block_size
+            ]
+            pos += block_size
+
+        return RDMABuffer(self._rdma_src_staging_mv[:staging_needed])
+
+    @endpoint
+    def ensure_storage(self, total_size):
+        """Ensure storage is allocated at the given size for RDMA reception."""
+        if self._chunk_storage is not None and self._total_size == total_size:
+            return
+        self._alloc_storage(total_size)
+
+    @endpoint
+    def replace_blocks(
+        self,
+        block_indices,
+        total_size,
+        rdma_buffer,
+        staging_size: int,
+        timeout: int = 300,
+    ):
+        """Overwrite multiple hash blocks from a single contiguous RDMA buffer.
+
+        The rdma_buffer contains blocks packed contiguously (matching the
+        order in block_indices). This reduces RDMA round-trips vs per-block.
+        """
+        import mmap as _mmap
+
+        if self._rdma_dst_staging is None or len(self._rdma_dst_staging) < staging_size:
+            self._rdma_dst_staging = _mmap.mmap(
+                -1, staging_size, _mmap.MAP_PRIVATE | _mmap.MAP_ANONYMOUS
+            )
+            self._rdma_dst_staging_mv = memoryview(self._rdma_dst_staging)
+
+        staging_slice = self._rdma_dst_staging_mv[:staging_size]
+        rdma_buffer.read_into(staging_slice, timeout=timeout).get()
+
+        pos = 0
+        for bi in block_indices:
+            block_size = min(HASH_BLOCK_SIZE, total_size - bi * HASH_BLOCK_SIZE)
+            offset = bi * HASH_BLOCK_SIZE
+            self._chunk_storage_mv[offset : offset + block_size] = staging_slice[
+                pos : pos + block_size
+            ]
+            pos += block_size
+
+    @endpoint
+    def mount(self, mount_point, new_block_hashes=None, total_size=0, pack_index=None):
+        from monarch._rust_bindings.monarch_extension.chunked_fuse import (
+            mount_chunked_fuse,
+        )
+
+        # Flush mmap to disk so the cache file persists across actor restarts.
+        if self._cache_path and self._chunk_storage is not None:
+            self._chunk_storage.flush()
+
+        # Persist pack index alongside cached data.
+        if pack_index is not None and self._cache_path:
+            self._pack_index = pack_index
+            save_pack_index(self._cache_path + ".index", pack_index)
+
+        self._fuse_handle = mount_chunked_fuse(
+            self.meta,
+            self.chunks,
+            self.chunk_size,
+            mount_point,
+        )
+        self._block_hashes = new_block_hashes or []
+        self._total_size = total_size
+        return 0
+
+    @endpoint
+    def get_block_hashes(self):
+        """Return per-block hashes and total size of the mounted data."""
+        return (self._block_hashes, self._total_size)
+
+    @endpoint
+    def recompute_block_hashes(self):
+        """Recompute block hashes from the current chunk storage."""
+        return block_hashes(self._chunk_storage_mv)
+
+    @endpoint
+    def get_pack_index(self):
+        """Return the pack index for append-only packing."""
+        return self._pack_index
+
+    @endpoint
+    def prepare_receiver(self, num_streams, total_size):
+        """Create a Rust TLS receiver and return its address."""
+        from monarch._rust_bindings.monarch_extension.tls_receiver import TlsReceiver
+
+        if self._chunk_storage is None or self._total_size != total_size:
+            self._alloc_storage(total_size)
+
+        self._tls_receiver = TlsReceiver(num_streams)
+        return self._tls_receiver.addr, self._tls_receiver.tls_hostname, self._cache_path or ""
+
+    @endpoint
+    def receive_blocks(self):
+        """Block until the TLS receiver has finished receiving all blocks."""
+        if self._tls_receiver is None:
+            raise RuntimeError("prepare_receiver() not called")
+        self._tls_receiver.wait(self._chunk_storage_mv)
+        self._tls_receiver = None
+        return True
+
+    @endpoint
+    def receive_block(self, block_idx: int, data: bytes, total_size: int):
+        """Receive a single block via actor message passing.
+
+        Allocates storage on first call. Slower than TLS but works
+        without custom TLS certs (e.g. GitHub CI, local testing).
+        """
+        if self._chunk_storage is None or self._total_size != total_size:
+            self._alloc_storage(total_size)
+
+        offset = block_idx * HASH_BLOCK_SIZE
+        self._chunk_storage_mv[offset : offset + len(data)] = data
+
+    @endpoint
+    def mkdir(self, path):
+        """Create a directory on the worker."""
+        os.makedirs(path, exist_ok=True)
+
+    @endpoint
+    def unmount(self, mount_point):
+        """Unmount a FUSE filesystem. Returns (returncode, stderr)."""
+        result = subprocess.run(
+            ["fusermount3", "-u", mount_point], capture_output=True, text=True
+        )
+        return result.returncode, result.stderr
+
+
+class MountHandler:
+    def __init__(
+        self,
+        host_mesh,
+        sourcepath: str,
+        mntpoint: Optional[str] = None,
+        chunk_size=None,
+        backend: str = "slurm",
+        num_parallel_streams: int = 8,
+        transfer_mode: str = "rust_tls",
+    ):
+        self.sourcepath = sourcepath
+        if mntpoint is None:
+            mntpoint = sourcepath
+        self.mntpoint = mntpoint
+        self.fuse_actors = None
+        self.host_mesh = host_mesh
+        self.procs = None
+        self.chunk_size = chunk_size
+        self.backend = backend
+        if num_parallel_streams < 1:
+            raise ValueError(
+                f"num_parallel_streams must be >= 1, got {num_parallel_streams}"
+            )
+        self.num_parallel_streams = num_parallel_streams
+        if transfer_mode not in ("rust_tls", "actor"):
+            raise ValueError(
+                f"transfer_mode must be 'rust_tls' or 'actor', got {transfer_mode!r}"
+            )
+        self.transfer_mode = transfer_mode
+        self._staging_mv = None
+        self._pack_shm_path = None
+
+    def open(self):
+        t_open_start = time.time()
+
+        # Reuse existing actors if available (preserves block hashes
+        # and pack index for incremental update checks).
+        if self.fuse_actors is None:
+            self.procs = self.host_mesh.spawn_procs(per_host={"gpus": 1})
+            self.fuse_actors = self.procs.spawn(
+                "FUSEActor", FUSEActor, self.chunk_size, self.backend
+            )
+            self.fuse_actors.mkdir.call(self.mntpoint).get()
+
+            import xxhash
+
+            cache_key = xxhash.xxh64(
+                (self.sourcepath + ":" + self.mntpoint).encode()
+            ).hexdigest()
+            self.fuse_actors.try_load_cache.call(cache_key).get()
+
+        t_actors_ready = time.time()
+
+        # Fire RPCs before packing so the network round-trips overlap
+        # with the CPU-bound walk+pack+hash step.
+        flat_actors = self.fuse_actors.flatten("rank")
+        num_workers = len(flat_actors)
+        hashes_future = self.fuse_actors.get_block_hashes.call()
+        index_future = self.fuse_actors.get_pack_index.call()
+
+        # Get pack index from workers (first non-empty).
+        # This is small JSON so the wait is fast.
+        index_result = index_future.get()
+        previous_index = next(
+            (idx for _, idx in index_result if idx and idx.get("files")),
+            None,
+        )
+
+        meta, self._staging_mv, chunks, client_hashes, new_pack_index = (
+            pack_directory_chunked(
+                self.sourcepath, self.chunk_size, previous_index=previous_index
+            )
+        )
+        staging_mv = self._staging_mv
+        client_total_size = len(staging_mv) if staging_mv is not None else 0
+
+        t_pack_done = time.time()
+
+        # Collect worker hashes (should already be available after packing).
+        result = hashes_future.get()
+        worker_states = [
+            (remote_hashes, remote_size)
+            for _point, (remote_hashes, remote_size) in result
+        ]
+        fresh_ranks, worker_dirty = classify_workers(
+            client_hashes, client_total_size, worker_states
+        )
+
+        t_classify_done = time.time()
+
+        # Always send metadata so newly spawned actors (which loaded
+        # block data from the persistent cache) have filesystem layout.
+        self.fuse_actors.set_meta.call(meta).get()
+
+        t_meta_done = time.time()
+
+        if not worker_dirty:
+            self.fuse_actors.mount.call(
+                self.mntpoint, client_hashes, client_total_size, new_pack_index
+            ).get()
+            t_mount_done = time.time()
+            logger.info(
+                f"All {num_workers} workers up-to-date — skipping transfer, re-mounting. "
+                f"Timings: actors={t_actors_ready - t_open_start:.2f}s, "
+                f"pack+hash={t_pack_done - t_actors_ready:.2f}s "
+                f"({client_total_size / (1024**2):.0f}MiB), "
+                f"classify={t_classify_done - t_pack_done:.2f}s, "
+                f"set_meta={t_meta_done - t_classify_done:.2f}s, "
+                f"mount={t_mount_done - t_meta_done:.2f}s, "
+                f"total={t_mount_done - t_open_start:.2f}s"
+            )
+            return self
+
+        n_partial = sum(1 for v in worker_dirty.values() if v is not None)
+        n_stale = sum(1 for v in worker_dirty.values() if v is None)
+        logger.info(
+            f"{len(fresh_ranks)} fresh, {n_partial} partial, "
+            f"{n_stale} stale out of {num_workers} workers"
+        )
+
+        # Unmount workers that need updating.
+        for rank in worker_dirty:
+            result = flat_actors.slice(rank=rank).unmount.call(self.mntpoint).get()
+            for _point, (rc, stderr) in result:
+                if rc != 0:
+                    logger.warning(
+                        f"fusermount3 -u failed on rank {rank} (rc={rc}): {stderr.strip()}"
+                    )
+
+        t_unmount_done = time.time()
+
+        # Compute dirty blocks: union of all non-fresh workers.
+        # Stale workers (None) need all blocks; partial workers need their list.
+        all_blocks = list(range(len(client_hashes)))
+        dirty_blocks: set[int] = set()
+        for _rank, d in worker_dirty.items():
+            if d is None:
+                dirty_blocks = set(all_blocks)
+                break
+            dirty_blocks.update(d)
+        sorted_dirty = sorted(dirty_blocks)
+
+        target_ranks = sorted(worker_dirty.keys())
+
+        if sorted_dirty and target_ranks:
+            logger.info(
+                f"{len(sorted_dirty)}/{len(client_hashes)} blocks dirty "
+                f"across {len(target_ranks)} workers"
+            )
+            self._transfer_fanout(
+                flat_actors, target_ranks, sorted_dirty, client_total_size
+            )
+
+        t_transfer_done = time.time()
+
+        # Remount all workers (fresh ones for metadata update).
+        self.fuse_actors.mount.call(
+            self.mntpoint, client_hashes, client_total_size, new_pack_index
+        ).get()
+
+        t_mount_done = time.time()
+
+        logger.info(
+            f"open() timings: actors={t_actors_ready - t_open_start:.2f}s, "
+            f"pack+hash={t_pack_done - t_actors_ready:.2f}s "
+            f"({client_total_size / (1024**2):.0f}MiB), "
+            f"classify={t_classify_done - t_pack_done:.2f}s, "
+            f"set_meta={t_meta_done - t_classify_done:.2f}s, "
+            f"unmount={t_unmount_done - t_meta_done:.2f}s, "
+            f"transfer={t_transfer_done - t_unmount_done:.2f}s, "
+            f"mount={t_mount_done - t_transfer_done:.2f}s, "
+            f"total={t_mount_done - t_open_start:.2f}s"
+        )
+        return self
+
+    def _transfer_blocks_actor(self, fuse_actor, dirty_blocks, total_size):
+        """Transfer dirty blocks via actor message passing.
+
+        Sends each block as a bytes argument to the receive_block endpoint.
+        Slower than Rust TLS but works without custom TLS certs.
+        """
+        if not dirty_blocks:
+            return
+
+        t_start = time.time()
+        total_bytes = 0
+        for bi in dirty_blocks:
+            offset = bi * HASH_BLOCK_SIZE
+            size = min(HASH_BLOCK_SIZE, total_size - offset)
+            block_data = bytes(self._staging_mv[offset : offset + size])
+            fuse_actor.receive_block.call(bi, block_data, total_size).get()
+            total_bytes += size
+        t_done = time.time()
+
+        elapsed = max(t_done - t_start, 1e-9)
+        gbs = (total_bytes / 1e9) / elapsed
+        logger.info(
+            f"Actor block transfer ({len(dirty_blocks)} blocks): "
+            f"{total_bytes // (1024**2)}MiB in {elapsed:.1f}s ({gbs:.1f} GB/s)"
+        )
+
+    def _transfer_blocks_rust_tls(self, fuse_actor, dirty_blocks, total_size):
+        """Transfer dirty blocks to a single worker using Rust TLS.
+
+        Sends blocks directly from ``self._staging_mv`` (the buffer produced
+        by ``pack_directory_chunked``) so no second pack step is needed.
+
+        Flow:
+          1. Worker: prepare_receiver() → creates TlsReceiver, returns address
+          2. Client: send_blocks_from_buffer() → parallel TLS connections
+          3. Worker: receive_blocks() → waits for all data
+        """
+        if not dirty_blocks:
+            return
+
+        from monarch._rust_bindings.monarch_extension.tls_sender import (
+            send_blocks_from_buffer,
+        )
+
+        num_streams = self.num_parallel_streams
+
+        total_bytes = sum(
+            min(HASH_BLOCK_SIZE, total_size - bi * HASH_BLOCK_SIZE)
+            for bi in dirty_blocks
+        )
+
+        # 1. Start receiver on worker (returns address, tls_hostname, cache path).
+        t_start = time.time()
+        result = fuse_actor.prepare_receiver.call(num_streams, total_size).get()
+        addr, tls_hostname, cache_path = [v for _, v in result][0]
+        addresses = [addr] * num_streams
+
+        # 2. Fire receive_blocks (non-blocking) so worker starts waiting.
+        recv_future = fuse_actor.receive_blocks.call()
+
+        # 3. Send blocks directly from the staging buffer.
+        t_setup = time.time()
+        send_blocks_from_buffer(
+            self._staging_mv, total_size, dirty_blocks, addresses, cache_path,
+            tls_hostname=tls_hostname,
+        )
+        t_send = time.time()
+
+        # 4. Wait for receiver to finish.
+        recv_future.get()
+        t_done = time.time()
+
+        gbs = (total_bytes / 1e9) / max(t_send - t_setup, 1e-9)
+        logger.info(
+            f"Rust TLS block transfer ({len(dirty_blocks)} blocks, "
+            f"{num_streams} streams): {total_bytes // (1024**2)}MiB "
+            f"in {t_send - t_setup:.1f}s ({gbs:.1f} GB/s), "
+            f"setup={t_setup - t_start:.2f}s, "
+            f"total={t_done - t_start:.1f}s"
+        )
+
+    def _transfer_fanout(
+        self,
+        flat_actors: object,
+        target_ranks: list[int],
+        dirty_blocks: list[int],
+        total_size: int,
+    ) -> None:
+        """Transfer dirty blocks: TLS to leader, RDMA fan-out to peers.
+
+        Small incremental transfers (≤ RDMA_PARALLEL_TLS_THRESHOLD blocks)
+        go directly via TLS to each worker in parallel — faster than any
+        RDMA round-trip for small payloads.
+
+        Large transfers use TLS to the leader, then a single RDMA fan-out
+        to all peers (one staging + one RDMA read per peer).
+        """
+        t0 = time.time()
+
+        total_bytes = sum(
+            min(HASH_BLOCK_SIZE, total_size - bi * HASH_BLOCK_SIZE)
+            for bi in dirty_blocks
+        )
+
+        # Use multiple leaders for higher initial fan-out.
+        # TLS from client to each leader in parallel, then tree fan-out.
+        num_leaders = min(4, len(target_ranks))
+        leader_ranks = target_ranks[:num_leaders]
+        peer_ranks = target_ranks[num_leaders:]
+
+        transfer_fn = (
+            self._transfer_blocks_actor
+            if self.transfer_mode == "actor"
+            else self._transfer_blocks_rust_tls
+        )
+
+        # Small incremental: TLS/actor to every worker in parallel (no RDMA).
+        if len(dirty_blocks) <= RDMA_PARALLEL_TLS_THRESHOLD or not peer_ranks:
+            workers = [(rank, flat_actors.slice(rank=rank)) for rank in target_ranks]
+
+            # Ensure all workers have storage allocated.
+            ensure_futures = []
+            for _rank, worker in workers:
+                ensure_futures.append(worker.ensure_storage.call(total_size))
+            for f in ensure_futures:
+                f.get()
+
+            from concurrent.futures import ThreadPoolExecutor
+
+            with ThreadPoolExecutor(max_workers=len(workers)) as pool:
+                futures = {
+                    pool.submit(transfer_fn, worker, dirty_blocks, total_size): rank
+                    for rank, worker in workers
+                }
+                for future in futures:
+                    future.result()  # raises on first failure
+
+            t_done = time.time()
+            logger.info(
+                f"Parallel transfer to {len(target_ranks)} workers: "
+                f"{total_bytes // (1024**2)}MiB "
+                f"({len(dirty_blocks)} blocks) in {t_done - t0:.1f}s"
+            )
+            return
+
+        # Large transfer: TLS to leaders, then chunked tree RDMA fan-out.
+
+        # Step 1: TLS transfer to all leaders in parallel.
+        from concurrent.futures import ThreadPoolExecutor
+
+        with ThreadPoolExecutor(max_workers=num_leaders) as pool:
+            tls_futures = {
+                pool.submit(
+                    transfer_fn,
+                    flat_actors.slice(rank=r),
+                    dirty_blocks,
+                    total_size,
+                ): r
+                for r in leader_ranks
+            }
+            for f in tls_futures:
+                f.result()
+        t_tls = time.time()
+
+        # Step 2: Ensure peers have storage allocated.
+        for rank in peer_ranks:
+            flat_actors.slice(rank=rank).ensure_storage.call(total_size).get()
+
+        # Step 3: Chunked pipelined tree RDMA fan-out.
+        # Concurrent reads from the same RDMABuffer are not safe
+        # (see disabled test_rdma_buffer_read_into_concurrent in
+        # test_rdma_unit.py: "TODO: fix concurrency issues").
+        # Tree fan-out avoids this: each source sends to at most ONE
+        # destination per round. Source and destination use SEPARATE
+        # staging buffers (_rdma_src_staging vs _rdma_dst_staging),
+        # so a node CAN be both source and destination simultaneously.
+        #
+        # Chunking splits the payload into ~1GB pieces. Once a node
+        # receives chunk 0, it can forward chunk 0 while receiving
+        # chunk 1. Latency ≈ (tree_depth + num_chunks - 1) × chunk_time.
+        rdma_chunk_blocks = max(1, (1024 * 1024 * 1024) // HASH_BLOCK_SIZE)
+        block_chunks = [
+            dirty_blocks[i : i + rdma_chunk_blocks]
+            for i in range(0, len(dirty_blocks), rdma_chunk_blocks)
+        ]
+        num_chunks = len(block_chunks)
+        chunk_byte_sizes = [
+            sum(
+                min(HASH_BLOCK_SIZE, total_size - bi * HASH_BLOCK_SIZE) for bi in blocks
+            )
+            for blocks in block_chunks
+        ]
+
+        chunk_owners: dict[int, set[int]] = {
+            c: set(leader_ranks) for c in range(num_chunks)
+        }
+        completed_peers: set[int] = set()
+
+        while len(completed_peers) < len(peer_ranks):
+            # Schedule: each source sends one chunk to one destination.
+            # Sources may not send two chunks at once (overwrites staging).
+            # A node CAN be src for chunk A and dst for chunk B in the
+            # same round because they use separate staging buffers.
+            src_used: set[int] = set()
+            dst_used: set[int] = set()
+            pairs: list[tuple[int, int, int]] = []
+            for chunk_idx in range(num_chunks):
+                for src_rank in list(chunk_owners[chunk_idx]):
+                    if src_rank in src_used:
+                        continue
+                    dst_rank = None
+                    for c in peer_ranks:
+                        if (
+                            c not in completed_peers
+                            and c not in chunk_owners[chunk_idx]
+                            and c not in dst_used
+                        ):
+                            dst_rank = c
+                            break
+                    if dst_rank is None:
+                        continue
+                    src_used.add(src_rank)
+                    dst_used.add(dst_rank)
+                    pairs.append((src_rank, dst_rank, chunk_idx))
+
+            if not pairs:
+                break
+
+            # Fire all staging calls in parallel (different sources).
+            staging_futures = []
+            for src_rank, dst_rank, chunk_idx in pairs:
+                src = flat_actors.slice(rank=src_rank)
+                staging_futures.append(
+                    (
+                        src_rank,
+                        dst_rank,
+                        chunk_idx,
+                        src.get_blocks_rdma_buffer.call(
+                            block_chunks[chunk_idx], total_size
+                        ),
+                    )
+                )
+
+            # Collect staging results and fire transfers.
+            transfer_futures = []
+            for _src_rank, dst_rank, chunk_idx, staging_f in staging_futures:
+                rdma_result = staging_f.get()
+                rdma_buf = [v for _, v in rdma_result][0]
+                dst = flat_actors.slice(rank=dst_rank)
+                transfer_futures.append(
+                    (
+                        dst_rank,
+                        chunk_idx,
+                        dst.replace_blocks.call(
+                            block_chunks[chunk_idx],
+                            total_size,
+                            rdma_buf,
+                            chunk_byte_sizes[chunk_idx],
+                        ),
+                    )
+                )
+
+            for dst_rank, chunk_idx, f in transfer_futures:
+                f.get()
+                chunk_owners[chunk_idx].add(dst_rank)
+                if all(dst_rank in chunk_owners[c] for c in range(num_chunks)):
+                    completed_peers.add(dst_rank)
+
+        t_rdma = time.time()
+        tls_gbs = (total_bytes / 1e9) / max(t_tls - t0, 1e-9)
+        rdma_gbs = (total_bytes * len(peer_ranks) / 1e9) / max(t_rdma - t_tls, 1e-9)
+        logger.info(
+            f"TLS→{num_leaders} leaders: {total_bytes // (1024**2)}MiB in {t_tls - t0:.1f}s "
+            f"({tls_gbs:.1f} GB/s), "
+            f"RDMA fan-out: {len(dirty_blocks)} blocks to {len(peer_ranks)} "
+            f"peers in {t_rdma - t_tls:.1f}s ({rdma_gbs:.1f} GB/s)"
+        )
+
+    def close(self) -> None:
+        """Unmount FUSE but keep actors alive for incremental updates."""
+        if self.fuse_actors is not None:
+            result = self.fuse_actors.unmount.call(self.mntpoint).get()
+            for _point, (rc, stderr) in result:
+                if rc != 0:
+                    logger.warning(f"fusermount3 -u failed (rc={rc}): {stderr.strip()}")
+
+    def __enter__(self) -> "MountHandler":
+        self.open()
+        return self
+
+    def __exit__(self, exc_type: object, exc_val: object, exc_tb: object) -> bool:
+        self.close()
+        return False  # Don't suppress exceptions
+
+
+def remotemount(
+    host_mesh: object,
+    sourcepath: str,
+    mntpoint: Optional[str] = None,
+    chunk_size: Optional[int] = None,
+    backend: str = "slurm",
+    num_parallel_streams: int = 8,
+    transfer_mode: str = "rust_tls",
+) -> MountHandler:
+    """Mount a local directory on remote hosts via RDMA transfer and FUSE.
+
+    Args:
+        transfer_mode: "rust_tls" (default) uses custom Rust TLS sender/receiver
+            for maximum throughput. "actor" uses monarch's built-in actor message
+            passing — slower but works without Meta TLS certs (e.g. CI, local testing).
+    """
+    if chunk_size is None:
+        chunk_size = CHUNK_SIZE
+    return MountHandler(
+        host_mesh,
+        sourcepath,
+        mntpoint,
+        chunk_size,
+        backend,
+        num_parallel_streams,
+        transfer_mode,
+    )

--- a/python/tests/test_remotemount.py
+++ b/python/tests/test_remotemount.py
@@ -20,18 +20,24 @@ import time
 from collections.abc import Generator
 
 import pytest
+from isolate_in_subprocess import isolate_in_subprocess
 from monarch._rust_bindings.monarch_extension.chunked_fuse import mount_chunked_fuse
 from monarch._rust_bindings.monarch_extension.fast_pack import (
     load_file_and_hash,
     pack_files_with_offsets,
 )
-from monarch.remotemount.fast_pack import block_hashes, pack_directory_chunked
+from monarch.remotemount.fast_pack import (
+    block_hashes,
+    HASH_BLOCK_SIZE,
+    pack_directory_chunked,
+)
+from monarch.remotemount.remotemount import classify_workers
 
 
 class TestPackDirectoryChunked:
     def test_empty_directory(self) -> None:
         with tempfile.TemporaryDirectory() as d:
-            meta, _staging_mv, chunks, hashes = pack_directory_chunked(d)
+            meta, _staging_mv, chunks, hashes, _pi = pack_directory_chunked(d)
             assert chunks == []
             assert hashes == []
             assert "/" in meta
@@ -44,7 +50,7 @@ class TestPackDirectoryChunked:
             with open(os.path.join(d, "a.txt"), "wb") as f:
                 f.write(content)
 
-            meta, _staging_mv, chunks, hashes = pack_directory_chunked(d)
+            meta, _staging_mv, chunks, hashes, _pi = pack_directory_chunked(d)
 
             assert "/a.txt" in meta
             file_meta = meta["/a.txt"]
@@ -62,7 +68,7 @@ class TestPackDirectoryChunked:
                 with open(os.path.join(d, name), "wb") as f:
                     f.write(content)
 
-            meta, _staging_mv, chunks, _hashes = pack_directory_chunked(d)
+            meta, _staging_mv, chunks, _hashes, _pi = pack_directory_chunked(d)
             packed = b"".join(bytes(c) for c in chunks)
 
             # Verify each file's content at its offset
@@ -95,7 +101,7 @@ class TestPackDirectoryChunked:
                 f.write("target")
             os.symlink(target, os.path.join(d, "link.txt"))
 
-            meta, _staging_mv, chunks, _hashes = pack_directory_chunked(d)
+            meta, _staging_mv, chunks, _hashes, _pi = pack_directory_chunked(d)
 
             assert "/link.txt" in meta
             link_meta = meta["/link.txt"]
@@ -109,7 +115,7 @@ class TestPackDirectoryChunked:
             with open(os.path.join(d, "sub", "f.txt"), "w") as f:
                 f.write("x")
 
-            meta, _, _, _ = pack_directory_chunked(d)
+            meta, _, _, _, _ = pack_directory_chunked(d)
 
             assert "/" in meta
             assert "sub" in meta["/"]["children"]
@@ -124,7 +130,7 @@ class TestPackDirectoryChunked:
                 f.write(content)
 
             chunk_size = 300
-            meta, _staging_mv, chunks, _hashes = pack_directory_chunked(
+            meta, _staging_mv, chunks, _hashes, _pi = pack_directory_chunked(
                 d, chunk_size=chunk_size
             )
 
@@ -137,8 +143,8 @@ class TestPackDirectoryChunked:
             with open(os.path.join(d, "f.bin"), "wb") as f:
                 f.write(os.urandom(500))
 
-            _, _, _, h1 = pack_directory_chunked(d)
-            _, _, _, h2 = pack_directory_chunked(d)
+            _, _, _, h1, _ = pack_directory_chunked(d)
+            _, _, _, h2, _ = pack_directory_chunked(d)
             assert h1 == h2
             assert len(h1) > 0
 
@@ -147,13 +153,184 @@ class TestPackDirectoryChunked:
             path = os.path.join(d, "f.bin")
             with open(path, "wb") as f:
                 f.write(b"\x00" * 500)
-            _, _, _, h1 = pack_directory_chunked(d)
+            _, _, _, h1, _ = pack_directory_chunked(d)
 
             with open(path, "wb") as f:
                 f.write(b"\xff" * 500)
-            _, _, _, h2 = pack_directory_chunked(d)
+            _, _, _, h2, _ = pack_directory_chunked(d)
 
             assert h1 != h2
+
+
+class TestPackDirectoryAppendOnly:
+    """Tests for append-only packing with previous_index."""
+
+    def test_no_previous_index_sequential(self) -> None:
+        """Without previous_index, files are packed sequentially."""
+        with tempfile.TemporaryDirectory() as d:
+            for name in ["a.txt", "b.txt"]:
+                with open(os.path.join(d, name), "wb") as f:
+                    f.write(name.encode() * 100)
+            meta, _mv, _chunks, _hashes, pi = pack_directory_chunked(d)
+            assert pi is not None
+            assert "files" in pi
+            assert "total_size" in pi
+            # Sequential: offsets are contiguous.
+            offsets = sorted(pi["files"][k]["offset"] for k in pi["files"])
+            assert offsets[0] == 0
+
+    def test_unchanged_files_keep_offsets(self) -> None:
+        """Files with matching mtime_ns and size keep their original offsets."""
+        with tempfile.TemporaryDirectory() as d:
+            with open(os.path.join(d, "a.txt"), "wb") as f:
+                f.write(b"hello" * 100)
+            with open(os.path.join(d, "b.txt"), "wb") as f:
+                f.write(b"world" * 100)
+
+            _, _, _, _, pi1 = pack_directory_chunked(d)
+            assert pi1 is not None
+
+            # Pack again with previous_index — offsets should be reused.
+            _, _, _, _, pi2 = pack_directory_chunked(d, previous_index=pi1)
+            assert pi2 is not None
+            for vpath in pi1["files"]:
+                assert pi2["files"][vpath]["offset"] == pi1["files"][vpath]["offset"]
+
+    def test_changed_file_appended(self) -> None:
+        """A changed file gets appended at the end, not at its old offset."""
+        with tempfile.TemporaryDirectory() as d:
+            # Use many unchanged files so the dead space from one changed
+            # file stays below FRAG_THRESHOLD (20%).
+            for i in range(10):
+                with open(os.path.join(d, f"keep_{i:02d}.txt"), "wb") as f:
+                    f.write(os.urandom(500))
+            with open(os.path.join(d, "change_me.txt"), "wb") as f:
+                f.write(b"bbb" * 100)
+
+            _, _, _, _, pi1 = pack_directory_chunked(d)
+            assert pi1 is not None
+            old_total = pi1["total_size"]
+
+            # Modify change_me.txt and force a different mtime_ns.
+            change_path = os.path.join(d, "change_me.txt")
+            with open(change_path, "wb") as f:
+                f.write(b"BBB" * 100)
+            # Ensure mtime differs even on fast filesystems.
+            st = os.stat(change_path)
+            os.utime(change_path, ns=(st.st_atime_ns, st.st_mtime_ns + 1_000_000))
+
+            _, _, _, _, pi2 = pack_directory_chunked(d, previous_index=pi1)
+            assert pi2 is not None
+            # Unchanged files should keep their offsets.
+            for i in range(10):
+                vpath = f"/keep_{i:02d}.txt"
+                assert pi2["files"][vpath]["offset"] == pi1["files"][vpath]["offset"]
+            # Changed file should be appended after the old total.
+            assert pi2["files"]["/change_me.txt"]["offset"] >= old_total
+
+    def test_new_file_appended(self) -> None:
+        """A new file is appended at the end."""
+        with tempfile.TemporaryDirectory() as d:
+            with open(os.path.join(d, "a.txt"), "wb") as f:
+                f.write(b"aaa" * 100)
+
+            _, _, _, _, pi1 = pack_directory_chunked(d)
+            assert pi1 is not None
+            old_total = pi1["total_size"]
+
+            # Add a new file.
+            with open(os.path.join(d, "b.txt"), "wb") as f:
+                f.write(b"bbb" * 100)
+
+            _, _, _, _, pi2 = pack_directory_chunked(d, previous_index=pi1)
+            assert pi2 is not None
+            assert pi2["files"]["/a.txt"]["offset"] == pi1["files"]["/a.txt"]["offset"]
+            assert pi2["files"]["/b.txt"]["offset"] >= old_total
+
+    def test_high_fragmentation_falls_back(self) -> None:
+        """When dead space exceeds FRAG_THRESHOLD, repacks sequentially."""
+        with tempfile.TemporaryDirectory() as d:
+            # Create one large file.
+            with open(os.path.join(d, "big.txt"), "wb") as f:
+                f.write(b"x" * 1000)
+
+            _, _, _, _, pi1 = pack_directory_chunked(d)
+            assert pi1 is not None
+
+            # Replace with a much smaller file — old offset has huge dead space.
+            with open(os.path.join(d, "big.txt"), "wb") as f:
+                f.write(b"y" * 10)
+
+            _, _, _, _, pi2 = pack_directory_chunked(d, previous_index=pi1)
+            assert pi2 is not None
+            # With high fragmentation, should repack sequentially starting at 0.
+            assert pi2["files"]["/big.txt"]["offset"] == 0
+
+    def test_pack_index_has_content_hashes(self) -> None:
+        """Pack index includes per-file content hashes."""
+        with tempfile.TemporaryDirectory() as d:
+            with open(os.path.join(d, "a.txt"), "wb") as f:
+                f.write(b"hello")
+
+            _, _, _, _, pi = pack_directory_chunked(d)
+            assert pi is not None
+            assert "content_hash" in pi["files"]["/a.txt"]
+            assert len(pi["files"]["/a.txt"]["content_hash"]) == 16  # xxh64 hex
+
+    def test_unchanged_files_stay_in_same_blocks(self) -> None:
+        """Append-only keeps unchanged file data in the same block positions.
+
+        When a file is modified, sequential repacking shifts all subsequent
+        file offsets. Append-only keeps unchanged files at their original
+        offsets, so their block hashes remain stable.
+        """
+        with tempfile.TemporaryDirectory() as d:
+            # Create 100 small files that share blocks.
+            file_size = HASH_BLOCK_SIZE // 10
+            for i in range(100):
+                with open(os.path.join(d, f"file_{i:03d}.bin"), "wb") as f:
+                    f.write(os.urandom(file_size))
+
+            _, mv1, _, h1, pi1 = pack_directory_chunked(d)
+            assert pi1 is not None
+            assert mv1 is not None
+
+            # Modify one file (triggers mtime change).
+            with open(os.path.join(d, "file_050.bin"), "wb") as f:
+                f.write(os.urandom(file_size))
+
+            # With append-only: unchanged files keep their offsets.
+            _, mv_app, _, h_app, pi2 = pack_directory_chunked(d, previous_index=pi1)
+            assert pi2 is not None
+            # All unchanged files should have the same offset as before.
+            changed_count = 0
+            for vpath in pi1["files"]:
+                if vpath in pi2["files"]:
+                    if pi2["files"][vpath]["offset"] != pi1["files"][vpath]["offset"]:
+                        changed_count += 1
+            # Only file_050.bin should have moved.
+            assert changed_count == 1
+
+    def test_previous_index_all_files_deleted(self) -> None:
+        """Append-only with a previous_index but all files deleted must not crash."""
+        with tempfile.TemporaryDirectory() as d:
+            with open(os.path.join(d, "a.txt"), "wb") as f:
+                f.write(b"hello")
+            _meta, _mv, _chunks, _hashes, pi = pack_directory_chunked(d)
+            assert pi is not None
+
+            # Remove all files, repack with previous_index.
+            os.remove(os.path.join(d, "a.txt"))
+            meta2, mv2, chunks2, hashes2, pi2 = pack_directory_chunked(
+                d, previous_index=pi
+            )
+            # Empty directory: total_size=0, no buffer, no pack_index.
+            assert "/" in meta2
+            assert meta2["/"]["children"] == []
+            assert mv2 is None
+            assert chunks2 == []
+            assert hashes2 == []
+            assert pi2 is None
 
 
 class TestBlockHashes:
@@ -389,7 +566,7 @@ class TestBlockBoundary:
             with open(path, "wb") as f:
                 f.write(data)
 
-            meta, staging_mv, chunks, hashes = pack_directory_chunked(d)
+            meta, staging_mv, chunks, hashes, _pi = pack_directory_chunked(d)
 
             packed = b"".join(bytes(c) for c in chunks)
             assert packed == data
@@ -678,7 +855,7 @@ class TestFuseMount:
                 with open(os.path.join(src, name), "wb") as f:
                     f.write(content)
 
-            meta, _staging_mv, chunks, _hashes = pack_directory_chunked(src)
+            meta, _staging_mv, chunks, _hashes, _pi = pack_directory_chunked(src)
 
             with tempfile.TemporaryDirectory() as mnt:
                 chunk_size = len(bytes(chunks[0])) if chunks else 1
@@ -825,3 +1002,635 @@ class TestFuseMount:
             with _fuse_mount(metadata2, [memoryview(content2)], len(content2), mnt):
                 with open(os.path.join(mnt, "g.txt"), "rb") as f:
                     assert f.read() == content2
+
+
+class TestClassifyWorkers:
+    """Unit tests for the classify_workers function."""
+
+    def test_all_fresh(self) -> None:
+        hashes = ["h1", "h2", "h3"]
+        size = 300
+        states = [(hashes, size), (hashes, size)]
+        fresh, dirty = classify_workers(hashes, size, states)
+        assert fresh == [0, 1]
+        assert dirty == {}
+
+    def test_all_stale(self) -> None:
+        hashes = ["h1", "h2"]
+        size = 200
+        states: list[tuple[list[str], int]] = [([], 0), ([], 0)]
+        fresh, dirty = classify_workers(hashes, size, states)
+        assert fresh == []
+        assert dirty == {0: None, 1: None}
+
+    def test_partial(self) -> None:
+        hashes = ["h1", "h2", "h3"]
+        size = 300
+        states = [(["h1", "XX", "h3"], size)]
+        fresh, dirty = classify_workers(hashes, size, states)
+        assert fresh == []
+        assert dirty == {0: [1]}
+
+    def test_mixed(self) -> None:
+        hashes = ["h1", "h2", "h3"]
+        size = 300
+        states = [(hashes, size), (["h1", "XX", "h3"], size), ([], 0)]
+        fresh, dirty = classify_workers(hashes, size, states)
+        assert fresh == [0]
+        assert dirty == {1: [1], 2: None}
+
+    def test_size_changed_partial_overlap(self) -> None:
+        """Worker has 3 blocks at old size, client now has 4 blocks at new size.
+
+        Overlapping blocks that match should NOT be retransferred.
+        Only the new block and the boundary block should be dirty.
+        Without the fix, any size change marks the worker fully stale (None).
+        """
+        client_hashes = ["h1", "h2", "h3", "h4"]
+        client_size = 400
+        # Worker has first 3 blocks matching, but at the old size.
+        states = [(["h1", "h2", "h3"], 300)]
+        fresh, dirty = classify_workers(client_hashes, client_size, states)
+        assert fresh == []
+        # Block 3 is new (index 3), and block 2 (last overlap) is dirty
+        # because size changed.
+        assert dirty == {0: [2, 3]}
+
+    def test_size_shrunk_partial_overlap(self) -> None:
+        """Client now has fewer blocks than worker (e.g. file deleted)."""
+        client_hashes = ["h1", "h2"]
+        client_size = 200
+        states = [(["h1", "h2", "h3"], 300)]
+        fresh, dirty = classify_workers(client_hashes, client_size, states)
+        assert fresh == []
+        # Last overlapping block (1) is dirty due to size change.
+        assert dirty == {0: [1]}
+
+    def test_size_changed_all_hashes_match(self) -> None:
+        """All overlapping hashes match but size changed — boundary block dirty."""
+        client_hashes = ["h1", "h2", "h3", "h4"]
+        client_size = 450
+        states = [(["h1", "h2", "h3"], 300)]
+        fresh, dirty = classify_workers(client_hashes, client_size, states)
+        assert fresh == []
+        # Block 2 (boundary) + block 3 (new).
+        assert dirty == {0: [2, 3]}
+
+    def test_size_changed_with_content_change(self) -> None:
+        """Size changed AND some overlapping blocks differ."""
+        client_hashes = ["h1", "XX", "h3", "h4"]
+        client_size = 400
+        states = [(["h1", "h2", "h3"], 300)]
+        fresh, dirty = classify_workers(client_hashes, client_size, states)
+        assert fresh == []
+        # Block 1 (changed), block 2 (boundary), block 3 (new).
+        assert dirty == {0: [1, 2, 3]}
+
+
+class TestDirtyBlockUnion:
+    """Tests for the dirty-block union logic used in MountHandler.open().
+
+    When multiple workers have different dirty blocks, the transfer uses
+    the union of all dirty blocks so a single fanout covers everyone.
+    """
+
+    @staticmethod
+    def _compute_dirty_union(
+        worker_dirty: dict[int, list[int] | None],
+        num_blocks: int,
+    ) -> list[int]:
+        """Reproduce the dirty-block union logic from MountHandler.open()."""
+        all_blocks = list(range(num_blocks))
+        dirty_blocks: set[int] = set()
+        for _rank, d in worker_dirty.items():
+            if d is None:
+                dirty_blocks = set(all_blocks)
+                break
+            dirty_blocks.update(d)
+        return sorted(dirty_blocks)
+
+    def test_single_stale_worker(self) -> None:
+        """One stale worker (None) → all blocks dirty."""
+        dirty = self._compute_dirty_union({0: None}, num_blocks=5)
+        assert dirty == [0, 1, 2, 3, 4]
+
+    def test_single_partial_worker(self) -> None:
+        """One partial worker → only its dirty blocks."""
+        dirty = self._compute_dirty_union({0: [1, 3]}, num_blocks=5)
+        assert dirty == [1, 3]
+
+    def test_multiple_partial_workers_union(self) -> None:
+        """Two partial workers with different dirty blocks → union."""
+        dirty = self._compute_dirty_union({0: [1, 3], 1: [2, 3]}, num_blocks=5)
+        assert dirty == [1, 2, 3]
+
+    def test_stale_dominates_partial(self) -> None:
+        """One stale + one partial → all blocks (stale forces full transfer)."""
+        dirty = self._compute_dirty_union({0: [1], 1: None}, num_blocks=5)
+        assert dirty == [0, 1, 2, 3, 4]
+
+    def test_empty_dirty(self) -> None:
+        """No dirty workers → empty list."""
+        dirty = self._compute_dirty_union({}, num_blocks=5)
+        assert dirty == []
+
+    def test_overlapping_partial_deduped(self) -> None:
+        """Overlapping dirty blocks from multiple workers are deduplicated."""
+        dirty = self._compute_dirty_union(
+            {0: [0, 1, 2], 1: [1, 2, 3], 2: [2, 3, 4]}, num_blocks=5
+        )
+        assert dirty == [0, 1, 2, 3, 4]
+
+
+class TestTreeFanOut:
+    """Tests for the tree-based RDMA fan-out scheduling.
+
+    Concurrent reads from the same RDMABuffer are not safe (see disabled
+    test_rdma_buffer_read_into_concurrent in test_rdma_unit.py). The tree
+    fan-out ensures each source sends to at most ONE destination per level.
+    """
+
+    @staticmethod
+    def _simulate_tree(
+        leader_rank: int, peer_ranks: list[int]
+    ) -> list[list[tuple[int, int]]]:
+        """Reproduce the tree fan-out logic from _transfer_fanout.
+
+        Returns list of levels, each level is a list of (src, dst) pairs.
+        """
+        have_data = [leader_rank]
+        need_data = list(peer_ranks)
+        levels = []
+
+        while need_data:
+            pairs = []
+            for src_rank in have_data:
+                if not need_data:
+                    break
+                dst_rank = need_data.pop(0)
+                pairs.append((src_rank, dst_rank))
+            levels.append(pairs)
+            for _, dst in pairs:
+                have_data.append(dst)
+
+        return levels
+
+    def test_single_peer(self) -> None:
+        """One peer → one level, one pair."""
+        levels = self._simulate_tree(0, [1])
+        assert levels == [[(0, 1)]]
+
+    def test_two_peers(self) -> None:
+        """Two peers → level 1: [0]→1, level 2: [0,1]→2."""
+        levels = self._simulate_tree(0, [1, 2])
+        assert levels == [[(0, 1)], [(0, 2)]]
+
+    def test_seven_peers(self) -> None:
+        """7 peers → log2(7)≈3 levels, doubling each level."""
+        levels = self._simulate_tree(0, [1, 2, 3, 4, 5, 6, 7])
+        # Level 0: [0]→1               (1 pair)
+        # Level 1: [0,1]→2,3           (2 pairs)
+        # Level 2: [0,1,2,3]→4,5,6,7   (4 pairs)
+        assert len(levels) == 3
+        assert len(levels[0]) == 1
+        assert len(levels[1]) == 2
+        assert len(levels[2]) == 4
+
+    def test_no_concurrent_reads_from_same_source(self) -> None:
+        """No source appears twice in the same level."""
+        levels = self._simulate_tree(0, list(range(1, 64)))
+        for level_idx, level in enumerate(levels):
+            sources = [src for src, _dst in level]
+            assert len(sources) == len(set(sources)), (
+                f"Level {level_idx} has duplicate sources: {sources}"
+            )
+
+    def test_all_peers_receive_data(self) -> None:
+        """Every peer receives data exactly once."""
+        peer_ranks = list(range(1, 64))
+        levels = self._simulate_tree(0, peer_ranks)
+        received = set()
+        for level in levels:
+            for _src, dst in level:
+                assert dst not in received, f"Peer {dst} received data twice"
+                received.add(dst)
+        assert received == set(peer_ranks)
+
+    def test_sources_have_data_before_sending(self) -> None:
+        """Every source in a level must have received data in a prior level."""
+        levels = self._simulate_tree(0, list(range(1, 64)))
+        have_data = {0}  # leader starts with data
+        for level_idx, level in enumerate(levels):
+            for src, _dst in level:
+                assert src in have_data, (
+                    f"Level {level_idx}: source {src} doesn't have data yet"
+                )
+            for _, dst in level:
+                have_data.add(dst)
+
+    def test_logarithmic_depth(self) -> None:
+        """63 peers should complete in ~6 levels (log2(64))."""
+        levels = self._simulate_tree(0, list(range(1, 64)))
+        assert len(levels) <= 7  # ceil(log2(64)) = 6, allow 7 for rounding
+
+    @staticmethod
+    def _simulate_chunked_tree(
+        leader_rank: int, peer_ranks: list[int], num_chunks: int
+    ) -> list[list[tuple[int, int, int]]]:
+        """Simulate chunked pipelined tree fan-out.
+
+        Returns list of rounds, each round is a list of (src, dst, chunk_idx).
+        Mirrors the scheduling logic in _transfer_fanout.
+        """
+        chunk_owners: dict[int, set[int]] = {
+            c: {leader_rank} for c in range(num_chunks)
+        }
+        completed_peers: set[int] = set()
+        rounds = []
+
+        while len(completed_peers) < len(peer_ranks):
+            busy: set[int] = set()
+            pairs: list[tuple[int, int, int]] = []
+            for chunk_idx in range(num_chunks):
+                for src_rank in list(chunk_owners[chunk_idx]):
+                    if src_rank in busy:
+                        continue
+                    dst_rank = None
+                    for c in peer_ranks:
+                        if (
+                            c not in completed_peers
+                            and c not in chunk_owners[chunk_idx]
+                            and c not in busy
+                        ):
+                            dst_rank = c
+                            break
+                    if dst_rank is None:
+                        continue
+                    busy.add(src_rank)
+                    busy.add(dst_rank)
+                    pairs.append((src_rank, dst_rank, chunk_idx))
+
+            if not pairs:
+                break
+            rounds.append(pairs)
+            for _, dst, chunk_idx in pairs:
+                chunk_owners[chunk_idx].add(dst)
+                if all(dst in chunk_owners[c] for c in range(num_chunks)):
+                    completed_peers.add(dst)
+
+        return rounds
+
+    def test_chunked_no_node_both_src_and_dst_in_same_round(self) -> None:
+        """No node is both source and destination in the same round.
+
+        get_blocks_rdma_buffer (source) and replace_blocks (destination)
+        share _rdma_staging on the same actor. Using the same node as
+        both source and destination in one round causes data corruption.
+        """
+        rounds = self._simulate_chunked_tree(0, list(range(1, 64)), num_chunks=8)
+        for round_idx, round_pairs in enumerate(rounds):
+            sources = {src for src, _, _ in round_pairs}
+            destinations = {dst for _, dst, _ in round_pairs}
+            overlap = sources & destinations
+            assert not overlap, (
+                f"Round {round_idx}: nodes {overlap} are both source and "
+                f"destination — _rdma_staging would be corrupted"
+            )
+
+    def test_chunked_no_source_sends_twice_in_same_round(self) -> None:
+        """No source appears twice in the same round."""
+        rounds = self._simulate_chunked_tree(0, list(range(1, 64)), num_chunks=8)
+        for round_idx, round_pairs in enumerate(rounds):
+            sources = [src for src, _, _ in round_pairs]
+            assert len(sources) == len(set(sources)), (
+                f"Round {round_idx} has duplicate sources"
+            )
+
+    def test_chunked_all_peers_receive_all_chunks(self) -> None:
+        """Every peer receives every chunk."""
+        peer_ranks = list(range(1, 64))
+        rounds = self._simulate_chunked_tree(0, peer_ranks, num_chunks=8)
+        received: dict[int, set[int]] = {r: set() for r in peer_ranks}
+        for round_pairs in rounds:
+            for _, dst, chunk_idx in round_pairs:
+                received[dst].add(chunk_idx)
+        for rank in peer_ranks:
+            assert received[rank] == set(range(8)), (
+                f"Peer {rank} missing chunks: {set(range(8)) - received[rank]}"
+            )
+
+
+class TestEnsureStorageLogic:
+    """Tests for the ensure_storage allocation logic.
+
+    Since ensure_storage is an @endpoint (can't be called outside an actor
+    runtime), we test the equivalent mmap allocation/resize logic directly.
+    """
+
+    def test_anonymous_mmap_allocation(self) -> None:
+        """Anonymous mmap is allocated at the requested size."""
+        import mmap as _mmap
+
+        storage = _mmap.mmap(-1, 1024, _mmap.MAP_PRIVATE | _mmap.MAP_ANONYMOUS)
+        mv = memoryview(storage)
+        assert len(mv) == 1024
+        mv[:4] = b"test"
+        assert mv[:4] == b"test"
+
+    def test_file_backed_preserves_on_resize(self) -> None:
+        """File-backed mmap preserves data when resized (no O_TRUNC)."""
+        import mmap as _mmap
+
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, "cache.bin")
+            # Create and write initial data.
+            fd = os.open(path, os.O_RDWR | os.O_CREAT, 0o600)
+            os.ftruncate(fd, 1024)
+            m1 = _mmap.mmap(fd, 1024)
+            os.close(fd)
+            mv1 = memoryview(m1)
+            mv1[:4] = b"keep"
+            m1.flush()
+            # Release before resize.
+            del mv1
+            m1.close()
+            # Resize without O_TRUNC — data preserved.
+            fd = os.open(path, os.O_RDWR | os.O_CREAT, 0o600)
+            os.ftruncate(fd, 2048)
+            m2 = _mmap.mmap(fd, 2048)
+            os.close(fd)
+            mv2 = memoryview(m2)
+            assert mv2[:4] == b"keep"
+            assert len(mv2) == 2048
+
+    def test_chunk_building(self) -> None:
+        """Chunks are built correctly from a buffer."""
+        import mmap as _mmap
+
+        total_size = 1000
+        chunk_size = 400
+        storage = _mmap.mmap(-1, total_size, _mmap.MAP_PRIVATE | _mmap.MAP_ANONYMOUS)
+        mv = memoryview(storage)
+        chunks = []
+        remaining = total_size
+        off = 0
+        while remaining > 0:
+            sz = min(remaining, chunk_size)
+            chunks.append(mv[off : off + sz])
+            off += sz
+            remaining -= sz
+        assert len(chunks) == 3
+        assert len(chunks[0]) == 400
+        assert len(chunks[1]) == 400
+        assert len(chunks[2]) == 200
+
+
+class TestReceiveBlockPreservesCache:
+    """Tests that receive_block does not corrupt cached data on resize.
+
+    The critical bug: receive_block used O_TRUNC when reallocating storage
+    on size change, which wiped all existing cached blocks. Only dirty
+    blocks are retransferred, so non-dirty blocks became zeros.
+    """
+
+    def test_resize_preserves_existing_blocks(self) -> None:
+        """Simulates receive_block resize: existing data must survive."""
+        import mmap as _mmap
+
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, "cache.bin")
+
+            # Initial allocation — write data to first 1024 bytes.
+            fd = os.open(path, os.O_RDWR | os.O_CREAT, 0o600)
+            os.ftruncate(fd, 1024)
+            m1 = _mmap.mmap(fd, 1024)
+            os.close(fd)
+            mv1 = memoryview(m1)
+            mv1[:4] = b"ABCD"
+            mv1[512:516] = b"EFGH"
+            m1.flush()
+            del mv1
+            m1.close()
+
+            # Resize WITHOUT O_TRUNC (correct behavior).
+            fd = os.open(path, os.O_RDWR | os.O_CREAT, 0o600)
+            os.ftruncate(fd, 2048)
+            m2 = _mmap.mmap(fd, 2048)
+            os.close(fd)
+            mv2 = memoryview(m2)
+            assert mv2[:4] == b"ABCD", "First block data lost on resize"
+            assert mv2[512:516] == b"EFGH", "Second block data lost on resize"
+            assert len(mv2) == 2048
+
+    def test_otrunc_would_corrupt(self) -> None:
+        """Proves O_TRUNC destroys existing data — the bug we fixed."""
+        import mmap as _mmap
+
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, "cache.bin")
+
+            # Write initial data.
+            fd = os.open(path, os.O_RDWR | os.O_CREAT, 0o600)
+            os.ftruncate(fd, 1024)
+            m1 = _mmap.mmap(fd, 1024)
+            os.close(fd)
+            mv1 = memoryview(m1)
+            mv1[:4] = b"KEEP"
+            m1.flush()
+            del mv1
+            m1.close()
+
+            # Resize WITH O_TRUNC — data is destroyed.
+            fd = os.open(path, os.O_RDWR | os.O_CREAT | os.O_TRUNC, 0o600)
+            os.ftruncate(fd, 2048)
+            m2 = _mmap.mmap(fd, 2048)
+            os.close(fd)
+            mv2 = memoryview(m2)
+            assert mv2[:4] == b"\x00\x00\x00\x00", "O_TRUNC should zero the file"
+
+
+@pytest.mark.skipif(not _fuse_available, reason="FUSE not available")
+# pyre-ignore[56]: Pyre can't infer pytest.mark.timeout decorator type
+@pytest.mark.timeout(60)
+@isolate_in_subprocess
+def test_actor_cold_transfer() -> None:
+    """End-to-end: create files, transfer via actor mode, verify on FUSE mount."""
+    from monarch.actor import this_host
+    from monarch.remotemount import remotemount
+
+    with tempfile.TemporaryDirectory() as src:
+        os.makedirs(os.path.join(src, "sub"), exist_ok=True)
+        files = {
+            "hello.txt": b"hello world",
+            "data.bin": os.urandom(2048),
+            os.path.join("sub", "nested.txt"): b"nested content here",
+        }
+        for name, content in files.items():
+            with open(os.path.join(src, name), "wb") as f:
+                f.write(content)
+
+        with tempfile.TemporaryDirectory() as mnt:
+            host = this_host()
+            with remotemount(host, src, mnt, transfer_mode="actor"):
+                for name, expected in files.items():
+                    with open(os.path.join(mnt, name), "rb") as f:
+                        assert f.read() == expected, f"content mismatch for {name}"
+
+
+@pytest.mark.skipif(not _fuse_available, reason="FUSE not available")
+# pyre-ignore[56]: Pyre can't infer pytest.mark.timeout decorator type
+@pytest.mark.timeout(60)
+@isolate_in_subprocess
+def test_actor_incremental_no_change() -> None:
+    """Open, close, re-open without changes: workers should be fresh (skip transfer)."""
+    from monarch.actor import this_host
+    from monarch.remotemount import remotemount
+
+    with tempfile.TemporaryDirectory() as src:
+        with open(os.path.join(src, "f.txt"), "wb") as f:
+            f.write(b"unchanged content")
+
+        with tempfile.TemporaryDirectory() as mnt:
+            host = this_host()
+            rm = remotemount(host, src, mnt, transfer_mode="actor")
+
+            # First open: full transfer.
+            rm.open()
+            with open(os.path.join(mnt, "f.txt"), "rb") as f:
+                assert f.read() == b"unchanged content"
+            rm.close()
+
+            # Second open: no changes, should skip transfer.
+            rm.open()
+            with open(os.path.join(mnt, "f.txt"), "rb") as f:
+                assert f.read() == b"unchanged content"
+            rm.close()
+
+
+@pytest.mark.skipif(not _fuse_available, reason="FUSE not available")
+# pyre-ignore[56]: Pyre can't infer pytest.mark.timeout decorator type
+@pytest.mark.timeout(60)
+@isolate_in_subprocess
+def test_actor_incremental_partial() -> None:
+    """Open, close, modify a file, re-open: only dirty blocks transferred."""
+    from monarch.actor import this_host
+    from monarch.remotemount import remotemount
+
+    with tempfile.TemporaryDirectory() as src:
+        path = os.path.join(src, "config.json")
+        with open(path, "w") as f:
+            f.write('{"lr": 0.001}')
+
+        with tempfile.TemporaryDirectory() as mnt:
+            host = this_host()
+            rm = remotemount(host, src, mnt, transfer_mode="actor")
+
+            # First open: full transfer.
+            rm.open()
+            with open(os.path.join(mnt, "config.json")) as f:
+                assert f.read() == '{"lr": 0.001}'
+            rm.close()
+
+            # Modify the source file.
+            with open(path, "w") as f:
+                f.write('{"lr": 0.01, "epochs": 20}')
+
+            # Second open: should detect change and re-transfer.
+            rm.open()
+            with open(os.path.join(mnt, "config.json")) as f:
+                assert f.read() == '{"lr": 0.01, "epochs": 20}'
+            rm.close()
+
+
+_tls_certs_available: bool = os.path.exists("/var/facebook/x509_identities/server.pem")
+
+
+@pytest.mark.skipif(not _fuse_available, reason="FUSE not available")
+@pytest.mark.skipif(not _tls_certs_available, reason="TLS certs not available")
+# pyre-ignore[56]: Pyre can't infer pytest.mark.timeout decorator type
+@pytest.mark.timeout(60)
+@isolate_in_subprocess
+def test_tls_cold_transfer() -> None:
+    """End-to-end: create files, transfer via rust_tls mode, verify on FUSE mount."""
+    from monarch.actor import this_host
+    from monarch.remotemount import remotemount
+
+    with tempfile.TemporaryDirectory() as src:
+        os.makedirs(os.path.join(src, "sub"), exist_ok=True)
+        files = {
+            "hello.txt": b"hello world",
+            "data.bin": os.urandom(2048),
+            os.path.join("sub", "nested.txt"): b"nested content here",
+        }
+        for name, content in files.items():
+            with open(os.path.join(src, name), "wb") as f:
+                f.write(content)
+
+        with tempfile.TemporaryDirectory() as mnt:
+            host = this_host()
+            with remotemount(host, src, mnt, transfer_mode="rust_tls"):
+                for name, expected in files.items():
+                    with open(os.path.join(mnt, name), "rb") as f:
+                        assert f.read() == expected, f"content mismatch for {name}"
+
+
+@pytest.mark.skipif(not _fuse_available, reason="FUSE not available")
+@pytest.mark.skipif(not _tls_certs_available, reason="TLS certs not available")
+# pyre-ignore[56]: Pyre can't infer pytest.mark.timeout decorator type
+@pytest.mark.timeout(60)
+@isolate_in_subprocess
+def test_tls_incremental_no_change() -> None:
+    """rust_tls: open, close, re-open without changes — workers should be fresh."""
+    from monarch.actor import this_host
+    from monarch.remotemount import remotemount
+
+    with tempfile.TemporaryDirectory() as src:
+        with open(os.path.join(src, "f.txt"), "wb") as f:
+            f.write(b"unchanged content")
+
+        with tempfile.TemporaryDirectory() as mnt:
+            host = this_host()
+            rm = remotemount(host, src, mnt, transfer_mode="rust_tls")
+
+            rm.open()
+            with open(os.path.join(mnt, "f.txt"), "rb") as f:
+                assert f.read() == b"unchanged content"
+            rm.close()
+
+            rm.open()
+            with open(os.path.join(mnt, "f.txt"), "rb") as f:
+                assert f.read() == b"unchanged content"
+            rm.close()
+
+
+@pytest.mark.skipif(not _fuse_available, reason="FUSE not available")
+@pytest.mark.skipif(not _tls_certs_available, reason="TLS certs not available")
+# pyre-ignore[56]: Pyre can't infer pytest.mark.timeout decorator type
+@pytest.mark.timeout(60)
+@isolate_in_subprocess
+def test_tls_incremental_partial() -> None:
+    """rust_tls: open, close, modify a file, re-open — only dirty blocks transferred."""
+    from monarch.actor import this_host
+    from monarch.remotemount import remotemount
+
+    with tempfile.TemporaryDirectory() as src:
+        path = os.path.join(src, "config.json")
+        with open(path, "w") as f:
+            f.write('{"lr": 0.001}')
+
+        with tempfile.TemporaryDirectory() as mnt:
+            host = this_host()
+            rm = remotemount(host, src, mnt, transfer_mode="rust_tls")
+
+            rm.open()
+            with open(os.path.join(mnt, "config.json")) as f:
+                assert f.read() == '{"lr": 0.001}'
+            rm.close()
+
+            with open(path, "w") as f:
+                f.write('{"lr": 0.01, "epochs": 20}')
+
+            rm.open()
+            with open(os.path.join(mnt, "config.json")) as f:
+                assert f.read() == '{"lr": 0.01, "epochs": 20}'
+            rm.close()


### PR DESCRIPTION
Summary:

Add the full remotemount stack for distributing directory trees to
remote workers via parallel TLS transfer, RDMA fan-out, and FUSE.

**Rust TLS transport:**
- `tls_sender.rs`: parallel TLS client with SO_SNDBUF=4MB, full CA +
  hostname certificate verification, integer overflow protection
- `tls_receiver.rs`: parallel TLS server with SO_RCVBUF=4MB,
  total_size protocol validation, checked_add overflow protection.
  `get_tls_hostname()` extracts DnsName from the cert's SAN instead
  of trusting `hostname -f`, which can return a `.fbinfra.net` name
  that doesn't match the cert (e.g. on Sandcastle)

**Python remotemount (remotemount.py):**
- `FUSEActor`: worker-side actor with persistent cache, block-level
  incremental updates (xxhash), RDMA fan-out via separate source/
  destination staging buffers, specific mkdir/unmount endpoints
  (no generic shell execution)
- `MountHandler`: client-side orchestrator — classifies workers as
  fresh/partial/stale, supports incremental transfers when total
  size changes, parallel TLS for small updates (ThreadPoolExecutor),
  chunked pipelined tree RDMA fan-out for large transfers with
  multi-leader TLS (4 leaders by default)
- `_alloc_storage` helper eliminates 5 duplicated mmap allocation
  patterns

**Append-only packing (fast_pack.py):**
- Unchanged files keep their original offsets; changed/new files
  appended. Per-file xxhash content hashing. Fragmentation threshold
  fallback to sequential repacking.
- Guard against division by zero when all files are deleted between
  incremental packs

**RDMA fan-out correctness:**
- Concurrent reads from the same RDMABuffer are unsafe (see disabled
  test_rdma_buffer_read_into_concurrent in test_rdma_unit.py).
  Tree fan-out ensures each source sends to at most one destination.
  Separate _rdma_src_staging / _rdma_dst_staging buffers allow a
  node to be both source and destination simultaneously for chunked
  pipelining.

**Benchmarks and docs:**
- bench_tls_packing.py: transfer mode comparison and stream sweep
- bench_incremental.py: 5-scenario benchmark with xxhash content
  verification, --reuse_job and --work_dir flags
- REMOTERUN_GUIDE.md: 2-host and 64-host results, stdin piping,
  uv venv examples
- setup_conda_env.sh: parallelized setup (4 concurrent jobs)

**Performance (8 GB, 64 GB200 hosts):**
- Cold start: 46.2s (transfer 30.4s)
- No change: 9.2s
- Rewrite data.bin: 45.6s
- Rewrite .py: 13.8s
- Delete file: 13.2s
- All scenarios verified correct via xxhash content comparison

**Tests:** 85 tests covering classify_workers edge cases, append-only
packing (including all-files-deleted edge case), tree fan-out
scheduling, O_TRUNC corruption prevention, TLS cold/incremental/
partial e2e, dirty-block union, ensure_storage.

Reviewed By: zdevito

Differential Revision: D96072264
