### PR TITLE
Fix Dockerfile to use specified version for pre-release, and not tag as latest

### DIFF
--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -6,6 +6,11 @@ on:
       version:
         description: "Version string (e.g. 0.1.0rc1 or 0.1.0)"
         required: true
+      is_prerelease:
+        description: "Is this a pre-release? (If false, tags as latest)"
+        type: boolean
+        required: false
+        default: false
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.run_number || github.ref }}
@@ -29,7 +34,7 @@ jobs:
       python-versions: '["3.10", "3.11", "3.12", "3.13"]'
       runner: linux.arm64.2xlarge
       docker-image: 'pytorch/manylinuxaarch64-builder:cuda12.8'
-      torch-spec: '--pre torch --extra-index-url https://download.pytorch.org/whl/nightly/cu128'
+      torch-spec: 'torch==2.10.0 --extra-index-url https://download.pytorch.org/whl/cu128'
       gpu-arch-type: cuda
       gpu-arch-version: '12.8'
       version: ${{ github.event.inputs.version }}
@@ -86,13 +91,24 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      - name: Determine Docker Tags
+        id: determine-tags
+        run: |
+          VERSION="${{ github.event.inputs.version }}"
+          PRERELEASE="${{ github.event.inputs.is_prerelease }}"
+          TAGS="ghcr.io/${{ github.repository }}:${VERSION}-cuda12.8"
+          if [[ "$PRERELEASE" == "false" ]]; then
+            TAGS="$TAGS,ghcr.io/${{ github.repository }}:latest"
+          fi
+          echo "tags=$TAGS" >> "$GITHUB_OUTPUT"
+
       - name: Build and push Docker image
         uses: docker/build-push-action@v6
         with:
           context: . # Build context is the root directory
           file: ./Dockerfile
           push: true # Push the image to the registry
-          tags: |
-            ghcr.io/${{ github.repository }}:${{ github.event.inputs.version }}-cuda12.8
-            ghcr.io/${{ github.repository }}:latest
-          build-args: PYTORCH_TAG=2.10.0-cuda12.8-cudnn9-runtime
+          tags: ${{ steps.determine-tags.outputs.tags }}
+          build-args: |
+            PYTORCH_TAG=2.10.0-cuda12.8-cudnn9-runtime
+            MONARCH_VERSION=${{ github.event.inputs.version }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ ARG PYTORCH_TAG=2.10.0-cuda12.8-cudnn9-runtime
 # Build from latest pytorch stable image; should be relatively in sync with torchmonarch and pytorch.
 FROM ghcr.io/pytorch/pytorch:${PYTORCH_TAG}
 
+ARG MONARCH_VERSION
 SHELL ["/bin/bash", "-c"]
 
 # System dependencies.
@@ -11,7 +12,7 @@ RUN apt-get update -y && \
     apt-get install curl clang liblzma-dev libunwind-dev libibverbs-dev librdmacm-dev protobuf-compiler -y
 
 # Install monarch w/ kubernetes.
-RUN pip install torchmonarch[kubernetes] --break-system-packages
+RUN pip install "torchmonarch[kubernetes]==${MONARCH_VERSION}" --break-system-packages
 
 # Install torchx-nightly w/ kubernetes.
 RUN pip install torchx-nightly[kubernetes] --break-system-packages


### PR DESCRIPTION
The publish_release.yml had a few issues:
- Used wrong pytorch version for aarch64
- Tagged pre-release docker image versions as "latest" incorrectly, it should only be for true production releases
- Dockerfile didn't specify the version of torchmonarch to pip install, so it picked up the older production version instead of the pre-release

Test plan:
```
podman build -f Dockerfile --format docker -t ghcr.io/meta-pytorch/monarch:0.4.0rc1-cuda12.8 --build-arg PYTORCH_TAG=2.10.0-cuda12.8-cudnn9-runtime --build-arg MONARCH_VERSION=0.4.0rc1 .
``` 
Produced the correct result:
```
podman run --rm -it ghcr.io/meta-pytorch/monarch:0.4.0rc1-cuda12.8 /bin/sh -c 'head /usr/local/lib/python3.12/dist-packages/torchmonarch-0.4.0rc1.dist-info/METADATA'
Metadata-Version: 2.4
Name: torchmonarch
Version: 0.4.0rc1
Summary: Monarch: Single controller library
Author-email: Meta <oncall+monarch@xmail.facebook.com>
License-Expression: BSD-3-Clause
Requires-Python: >=3.10
Description-Content-Type: text/markdown
License-File: LICENSE
Requires-Dist: pyzmq
```
Testing the release publisher isn't possible except with a manual switch, but I'll make another prerelease soon which should handle this