### PR TITLE
upload JUnit XML test results as artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,3 +85,33 @@ jobs:
           else
             echo "All jobs passed"
           fi
+
+  ci-summary:
+    if: always()
+    needs: [status-check]
+    runs-on: linux.2xlarge
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+      - run: pip install requests
+      - name: Download test result artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: 'test-reports-*'
+          path: test-artifacts/
+          merge-multiple: true
+        continue-on-error: true
+      - name: Generate CI summary
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_RUN_ID: ${{ github.run_id }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          TEST_RESULTS_DIR: test-artifacts
+        run: python scripts/ci_summary.py
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ci-summary
+          path: ci-summary.json
+          retention-days: 30

--- a/.github/workflows/test-cpu-rust.yml
+++ b/.github/workflows/test-cpu-rust.yml
@@ -25,6 +25,7 @@ jobs:
       runner: ${{ inputs.runner }}
       docker-image: ${{ inputs.docker-image }}
       submodules: recursive
+      upload-artifact: test-reports-cpu-rust
       script: |
         # Source common setup functions
         source scripts/common-setup.sh
@@ -61,3 +62,9 @@ jobs:
         echo "=== sccache stats ==="
         sccache --show-stats
         echo "=== end sccache stats ==="
+
+        # Copy nextest JUnit XML to the artifact dir so the ci-summary
+        # job can download and parse structured test results.
+        if [ -n "${RUNNER_ARTIFACT_DIR:-}" ]; then
+          cp target/nextest/ci/junit.xml "${RUNNER_ARTIFACT_DIR}/junit.xml" 2>/dev/null || true
+        fi

--- a/.github/workflows/test-gpu-python.yml
+++ b/.github/workflows/test-gpu-python.yml
@@ -32,6 +32,7 @@ jobs:
       gpu-arch-version: ${{ matrix.gpu-arch-version }}
       submodules: recursive
       download-artifact: ${{ inputs.artifact-name }}
+      upload-artifact: test-reports-gpu-python
       script: |
         # Source common setup functions
         source scripts/common-setup.sh
@@ -61,6 +62,12 @@ jobs:
         pip install pytest-split
 
         run_test_groups
+
+        # Copy JUnit XML to the artifact dir so the ci-summary job can
+        # download and parse structured test results.
+        if [ -n "${RUNNER_ARTIFACT_DIR:-}" ]; then
+          cp "${RUNNER_TEST_RESULTS_DIR:-test-results}"/*.xml "${RUNNER_ARTIFACT_DIR}/" 2>/dev/null || true
+        fi
 
         # TODO(meriksen): temporarily disabled to unblock lands while debugging
         # mock CUDA issues on the OSS setup

--- a/.github/workflows/test-gpu-rust.yml
+++ b/.github/workflows/test-gpu-rust.yml
@@ -32,6 +32,7 @@ jobs:
       gpu-arch-version: ${{ matrix.gpu-arch-version }}
       submodules: recursive
       download-artifact: ${{ inputs.artifact-name }}
+      upload-artifact: test-reports-gpu-rust
       script: |
         # Source common setup functions
         source scripts/common-setup.sh
@@ -74,8 +75,8 @@ jobs:
         sccache --show-stats
         echo "=== end sccache stats ==="
 
-        # Copy the test results to the expected location
-        # TODO: error in pytest-results-action, TypeError: results.testsuites.testsuite.testcase is not iterable
-        # Don't try to parse these results for now.
-        # mkdir -p "${RUNNER_TEST_RESULTS_DIR:-test-results}"
-        # cp target/nextest/ci/junit.xml "${RUNNER_TEST_RESULTS_DIR:-test-results}/junit.xml"
+        # Copy nextest JUnit XML to the artifact dir so the ci-summary
+        # job can download and parse structured test results.
+        if [ -n "${RUNNER_ARTIFACT_DIR:-}" ]; then
+          cp target/nextest/ci/junit.xml "${RUNNER_ARTIFACT_DIR}/junit.xml" 2>/dev/null || true
+        fi


### PR DESCRIPTION
Summary:
Copy JUnit XML from pytest and cargo-nextest into
RUNNER_ARTIFACT_DIR so the pytorch/test-infra reusable workflow
uploads them automatically. Add a ci-summary job that downloads
these artifacts for structured failure parsing.

Differential Revision: D97563559


