### PR TITLE
avoid double-binding mesh controller state port (#3124)

### DIFF
--- a/hyperactor_mesh/src/mesh_controller.rs
+++ b/hyperactor_mesh/src/mesh_controller.rs
@@ -291,7 +291,23 @@ impl<A: Referable> Actor for ActorMeshController<A> {
                 // All ProcAgents send updates directly to this port
                 // so that failures along the comm tree path does not
                 // affect clean shutdowns.
-                subscriber: this.port().bind().unsplit(),
+
+                // Avoid binding the handle here: the controller's
+                // exported ports are bound when proc_mesh installs the
+                // ActorRef after spawn. Binding the same handle twice
+                // panics.
+                //
+                // TODO(SF, 2026-03-32, T261106175): follow up in
+                // hyperactor on bind semantics here. `cx.port()` plus
+                // later actor-ref export currently hits `bind()` ->
+                // `bind_actor_port()` on the same handle, and
+                // `bind_actor_port()` still panics on an
+                // already-bound handle. This workaround uses
+                // `attest_message_port(...)` to avoid the eager bind,
+                // but the longer-term fix is to clarify whether that
+                // bind path should be idempotent and eliminate the
+                // need for attestation here.
+                subscriber: hyperactor_reference::PortRef::<resource::State<ActorState>>::attest_message_port(this.self_id()).unsplit(),
             },
         )?;
 


### PR DESCRIPTION
Summary:

ActorMeshController::init() subscribed to StreamState<ActorState> by calling this.port().bind().unsplit(), which eagerly bound the controller’s State<ActorState> port. later, when ProcMesh::spawn_with_name_inner() installed the controller ActorRef, it called controller.bind() on the same handle. that second bind could panic with resource::State<ActorState>: already bound.

under non-unity --stress-runs upstack, that double-bind could kill the controller during mesh startup and leave the mesh in a broken state. later mesh_admin failures were downstream symptoms of that startup bug.

the fix is to replace this.port().bind() with PortRef::attest_message_port(this.self_id()). the subscription only needs a typed reference telling ProcAgents where to send State<ActorState> updates; it does not need to consume the actual bind. unsplit() still gives the direct subscriber path, but the single real bind is left to the normal spawn path, which is what we want.

Reviewed By: mariusae

Differential Revision: D97646237


