### PR TITLE
mesh_admin: add wave 2 integration tests: /v1/{ref} traversal, malformed-ref edge cases, and mTLS auth failures (MIT-20..MIT-36) (#3126)

### DIFF
--- a/hyperactor_mesh/test/mesh_admin_integration/auth.rs
+++ b/hyperactor_mesh/test/mesh_admin_integration/auth.rs
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+//! Auth failure assertion helpers.
+//!
+//! TLS-level assertions executed against a real dining fixture for
+//! endpoint parity and harness reuse.
+//!
+//! See MIT-32, MIT-33, MIT-34, MIT-35, MIT-36 in `main` module doc.
+
+use crate::dining::DiningScenario;
+use crate::harness;
+
+/// MIT-32, MIT-33, MIT-34, MIT-35, MIT-36: auth failure edge cases.
+pub(crate) async fn check(s: &DiningScenario) {
+    // --- MIT-32: no client cert — parity across all 4 endpoints ---
+    let no_cert = s.fixture.build_unauthenticated_client().unwrap();
+    let worker_encoded = urlencoding::encode(&s.worker);
+    let endpoints = [
+        "/v1/root".to_string(),
+        "/v1/tree".to_string(),
+        format!("/v1/config/{worker_encoded}"),
+        format!("/v1/pyspy/{worker_encoded}"),
+    ];
+    for ep in &endpoints {
+        let result = no_cert
+            .get(format!("{}{ep}", s.fixture.admin_url))
+            .send()
+            .await;
+        assert!(
+            result.is_err(),
+            "MIT-32: {ep} should reject unauthenticated client"
+        );
+    }
+
+    // --- MIT-33: wrong CA cert — client presents cert signed by foreign CA ---
+    let foreign_dir = tempfile::tempdir().unwrap();
+    let foreign_pki = harness::generate_pki(foreign_dir.path()).unwrap();
+    let wrong_ca = harness::build_tls_client(
+        s.fixture.ca_pem(),
+        Some(&foreign_pki.cert_pem),
+        Some(&foreign_pki.key_pem),
+    )
+    .unwrap();
+    let result = wrong_ca
+        .get(format!("{}/v1/root", s.fixture.admin_url))
+        .send()
+        .await;
+    assert!(
+        result.is_err(),
+        "MIT-33: foreign-CA cert should be rejected"
+    );
+
+    // --- MIT-34: client trusts wrong CA — TLS handshake fails client-side ---
+    let wrong_trust = harness::build_tls_client(
+        &foreign_pki.ca_pem,
+        Some(&foreign_pki.cert_pem),
+        Some(&foreign_pki.key_pem),
+    )
+    .unwrap();
+    let result = wrong_trust
+        .get(format!("{}/v1/root", s.fixture.admin_url))
+        .send()
+        .await;
+    assert!(
+        result.is_err(),
+        "MIT-34: wrong-CA trust should fail handshake"
+    );
+
+    // --- MIT-35: corrupt PEM — TLS setup rejects invalid CA PEM ---
+    let (_, ok) = hyperactor_mesh::mesh_admin_client::add_tls(
+        reqwest::Client::builder(),
+        b"not-valid-pem",
+        None,
+        None,
+    );
+    assert!(!ok, "MIT-35: add_tls must reject corrupt CA PEM");
+
+    // --- MIT-36: auth failure is TLS-level, not HTTP-level ---
+    // Demonstrated by MIT-32: result.is_err() means the request never
+    // reached the server. If it were HTTP 401/403, result would be Ok.
+}

--- a/hyperactor_mesh/test/mesh_admin_integration/dining.rs
+++ b/hyperactor_mesh/test/mesh_admin_integration/dining.rs
@@ -153,16 +153,82 @@ async fn check_dining_endpoints(bin: &Path) {
     .await;
 }
 
-/// MIT-9, MIT-13, MIT-14, MIT-6, MIT-10, MIT-11, MIT-12, MIT-15: All
+/// MIT-9, MIT-10, MIT-11, MIT-12, MIT-13, MIT-14, MIT-15:
 /// dining-based endpoint assertions — Rust binary.
 pub async fn run_dining_endpoints_rust() {
     let bin = harness::dining_philosophers_rust_binary();
     check_dining_endpoints(&bin).await;
 }
 
-/// MIT-9, MIT-13, MIT-14, MIT-6, MIT-10, MIT-11, MIT-12, MIT-15:
-/// All dining-based endpoint assertions — Python binary.
+/// MIT-9, MIT-10, MIT-11, MIT-12, MIT-13, MIT-14, MIT-15:
+/// dining-based endpoint assertions — Python binary.
 pub async fn run_dining_endpoints_python() {
     let bin = harness::dining_philosophers_python_binary();
     check_dining_endpoints(&bin).await;
+}
+
+// --- traversal family ---
+
+/// MIT-20, MIT-21, MIT-22, MIT-23, MIT-24: /v1/{ref} topology
+/// traversal — Rust binary.
+pub async fn run_ref_traversal_rust() {
+    let bin = harness::dining_philosophers_rust_binary();
+    DiningScenario::run(&bin, |s| {
+        Box::pin(async move {
+            crate::ref_check::check(s).await;
+        })
+    })
+    .await;
+}
+
+/// MIT-20, MIT-21, MIT-22, MIT-23, MIT-24: /v1/{ref} topology
+/// traversal — Python binary.
+pub async fn run_ref_traversal_python() {
+    let bin = harness::dining_philosophers_python_binary();
+    DiningScenario::run(&bin, |s| {
+        Box::pin(async move {
+            crate::ref_check::check(s).await;
+        })
+    })
+    .await;
+}
+
+// --- malformed-ref family ---
+
+/// MIT-25, MIT-26, MIT-27, MIT-28, MIT-29, MIT-30, MIT-31:
+/// malformed/encoded reference edge cases — Rust binary.
+pub async fn run_ref_edge_cases_rust() {
+    let bin = harness::dining_philosophers_rust_binary();
+    DiningScenario::run(&bin, |s| {
+        Box::pin(async move {
+            crate::ref_edge::check(s).await;
+        })
+    })
+    .await;
+}
+
+/// MIT-25, MIT-26, MIT-27, MIT-28, MIT-29, MIT-30, MIT-31:
+/// malformed/encoded reference edge cases — Python binary.
+pub async fn run_ref_edge_cases_python() {
+    let bin = harness::dining_philosophers_python_binary();
+    DiningScenario::run(&bin, |s| {
+        Box::pin(async move {
+            crate::ref_edge::check(s).await;
+        })
+    })
+    .await;
+}
+
+// --- auth family ---
+
+/// MIT-32, MIT-33, MIT-34, MIT-35, MIT-36: auth failure coverage —
+/// Rust binary.
+pub async fn run_auth_failures_rust() {
+    let bin = harness::dining_philosophers_rust_binary();
+    DiningScenario::run(&bin, |s| {
+        Box::pin(async move {
+            crate::auth::check(s).await;
+        })
+    })
+    .await;
 }

--- a/hyperactor_mesh/test/mesh_admin_integration/harness.rs
+++ b/hyperactor_mesh/test/mesh_admin_integration/harness.rs
@@ -84,6 +84,11 @@ impl WorkloadFixture {
         Ok(builder.build()?)
     }
 
+    /// The fixture's CA PEM, for building custom TLS clients.
+    pub(crate) fn ca_pem(&self) -> &[u8] {
+        &self.ca_pem
+    }
+
     /// GET a path relative to the admin URL.
     pub(crate) async fn get(&self, path: &str) -> Result<Response> {
         let url = format!("{}{}", self.admin_url, path);
@@ -341,10 +346,10 @@ fn install_pyspy() -> Result<(Option<PathBuf>, Option<TempDir>)> {
 // PKI generation
 
 /// Generated PEM material from ephemeral PKI. MIT-4 (ephemeral-pki).
-struct PkiMaterial {
-    ca_pem: Vec<u8>,
-    cert_pem: Vec<u8>,
-    key_pem: Vec<u8>,
+pub(crate) struct PkiMaterial {
+    pub(crate) ca_pem: Vec<u8>,
+    pub(crate) cert_pem: Vec<u8>,
+    pub(crate) key_pem: Vec<u8>,
 }
 
 /// Generate ephemeral CA + server cert with rcgen. MIT-4
@@ -353,7 +358,7 @@ struct PkiMaterial {
 /// Returns separate CA, cert, and key PEM buffers. Also writes ca.crt
 /// and combined.pem to the cert_dir (the combined file is what the
 /// workload process reads via HYPERACTOR_TLS_CERT/KEY).
-fn generate_pki(cert_dir: &Path) -> Result<PkiMaterial> {
+pub(crate) fn generate_pki(cert_dir: &Path) -> Result<PkiMaterial> {
     use rcgen::BasicConstraints;
     use rcgen::CertificateParams;
     use rcgen::DnType;
@@ -439,6 +444,28 @@ fn build_client(ca_pem: &[u8], cert_pem: &[u8], key_pem: &[u8]) -> Result<Client
     );
     if !ok {
         bail!("MIT-5: failed to configure TLS on reqwest client");
+    }
+    Ok(builder.build()?)
+}
+
+/// Build a client with explicit trust root and optional client
+/// identity. Covers both "wrong client cert" (trust fixture CA,
+/// present foreign cert) and "wrong trust root" (trust foreign CA,
+/// present foreign cert).
+pub(crate) fn build_tls_client(
+    trusted_ca_pem: &[u8],
+    cert_pem: Option<&[u8]>,
+    key_pem: Option<&[u8]>,
+) -> Result<Client> {
+    let builder = Client::builder().timeout(Duration::from_secs(30));
+    let (builder, ok) = hyperactor_mesh::mesh_admin_client::add_tls(
+        builder,
+        trusted_ca_pem,
+        cert_pem.map(|b| b.to_vec()),
+        key_pem.map(|b| b.to_vec()),
+    );
+    if !ok {
+        bail!("failed to configure TLS on custom client");
     }
     Ok(builder.build()?)
 }

--- a/hyperactor_mesh/test/mesh_admin_integration/main.rs
+++ b/hyperactor_mesh/test/mesh_admin_integration/main.rs
@@ -113,34 +113,135 @@
 //!   logged as warnings, not failures. Mixed mode is a
 //!   startup/topology smoke test and does not enforce evidence or
 //!   threshold checks.
+//!
+//! ### /v1/{ref} traversal
+//!
+//! - **MIT-20 (round-trip):** Child references returned by a parent
+//!   node are fetchable via `/v1/{ref}`.
+//! - **MIT-21 (node-kind-typing):** Root returns `Root`, host returns
+//!   `Host`, proc returns `Proc`, actor returns `Actor` variant.
+//! - **MIT-22 (identity-consistency):** `node.identity` matches the
+//!   reference string used to fetch it.
+//! - **MIT-23 (child-link-consistency):** Root, first host, classified
+//!   service proc, classified worker proc, and known actor refs are
+//!   fetchable.
+//! - **MIT-24 (known-actors):** Among each proc node's children,
+//!   actors named `host_agent` or `proc_agent` are present and
+//!   fetchable, returning `Actor` variant.
+//!
+//! ### Malformed/encoded ref edge cases
+//!
+//! - **MIT-25 (empty-ref):** `/v1/` returns a non-success status.
+//! - **MIT-26 (garbage-ref):** Random garbage strings return
+//!   `not_found` error envelope.
+//! - **MIT-27 (truncated-ref):** Prefix of a valid reference returns
+//!   a non-success status.
+//! - **MIT-29 (long-ref):** A 10KB string returns a structured error,
+//!   not a crash or timeout.
+//! - **MIT-30 (unreachable-socket-ref):** Valid transport address with
+//!   nonexistent socket returns `not_found` or `gateway_timeout`.
+//! - **MIT-31 (url-encoded-round-trip):** A valid reference containing
+//!   commas/brackets (which all hyperactor refs do) round-trips
+//!   correctly through URL encoding.
+//!
+//! ### Auth failure cases
+//!
+//! - **MIT-32 (no-client-cert):** Unauthenticated client is rejected
+//!   across all 4 endpoints (`/v1/root`, `/v1/tree`,
+//!   `/v1/config/{ref}`, `/v1/pyspy/{ref}`).
+//! - **MIT-33 (wrong-ca-cert):** Client presents a cert signed by an
+//!   independent CA → TLS-level failure.
+//! - **MIT-34 (wrong-client-ca):** Client trusts a different CA than
+//!   the server's → TLS-level failure.
+//! - **MIT-35 (corrupt-pem):** Passing corrupt PEM material to
+//!   `add_tls` → TLS setup rejects invalid CA PEM deterministically
+//!   (returns `ok == false`).
+//! - **MIT-36 (auth-vs-app-error):** Auth failures are TLS-level
+//!   (`result.is_err()`), not HTTP-level 4xx/5xx.
 
+mod auth;
 mod config;
 mod dining;
 mod harness;
 mod pyspy;
+mod ref_check;
+mod ref_edge;
 mod tree;
 
+// --- dining family ---
+
+/// MIT-9, MIT-10, MIT-11, MIT-12, MIT-13, MIT-14, MIT-15: dining-based
+/// endpoint assertions — Rust binary.
 #[tokio::test]
 async fn test_dining_endpoints_rust() {
     dining::run_dining_endpoints_rust().await;
 }
 
+/// MIT-9, MIT-10, MIT-11, MIT-12, MIT-13, MIT-14, MIT-15: dining-based
+/// endpoint assertions — Python binary.
 #[tokio::test]
 async fn test_dining_endpoints_python() {
     dining::run_dining_endpoints_python().await;
 }
 
+// --- pyspy family ---
+
+/// MIT-16, MIT-17, MIT-18, MIT-19: py-spy integration — cpu mode.
 #[tokio::test]
 async fn test_pyspy_integration_cpu() {
     pyspy::run_pyspy_integration_cpu().await;
 }
 
+/// MIT-16, MIT-17, MIT-18, MIT-19: py-spy integration — block mode.
 #[tokio::test]
 async fn test_pyspy_integration_block() {
     pyspy::run_pyspy_integration_block().await;
 }
 
+/// MIT-16, MIT-18, MIT-19: py-spy integration — mixed mode (smoke
+/// test, no evidence check).
 #[tokio::test]
 async fn test_pyspy_integration_mixed() {
     pyspy::run_pyspy_integration_mixed().await;
+}
+
+// --- traversal family ---
+
+/// MIT-20, MIT-21, MIT-22, MIT-23, MIT-24: /v1/{ref} topology
+/// traversal — Rust binary.
+#[tokio::test]
+async fn test_ref_traversal_rust() {
+    dining::run_ref_traversal_rust().await;
+}
+
+/// MIT-20, MIT-21, MIT-22, MIT-23, MIT-24: /v1/{ref} topology
+/// traversal — Python binary.
+#[tokio::test]
+async fn test_ref_traversal_python() {
+    dining::run_ref_traversal_python().await;
+}
+
+// --- malformed-ref family ---
+
+/// MIT-25, MIT-26, MIT-27, MIT-28, MIT-29, MIT-30, MIT-31:
+/// malformed/encoded reference edge cases — Rust binary.
+#[tokio::test]
+async fn test_ref_edge_cases_rust() {
+    dining::run_ref_edge_cases_rust().await;
+}
+
+/// MIT-25, MIT-26, MIT-27, MIT-28, MIT-29, MIT-30, MIT-31:
+/// malformed/encoded reference edge cases — Python binary.
+#[tokio::test]
+async fn test_ref_edge_cases_python() {
+    dining::run_ref_edge_cases_python().await;
+}
+
+// --- auth family ---
+
+/// MIT-32, MIT-33, MIT-34, MIT-35, MIT-36: auth failure coverage —
+/// Rust binary.
+#[tokio::test]
+async fn test_auth_failures_rust() {
+    dining::run_auth_failures_rust().await;
 }

--- a/hyperactor_mesh/test/mesh_admin_integration/ref_check.rs
+++ b/hyperactor_mesh/test/mesh_admin_integration/ref_check.rs
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+//! /v1/{ref} topology traversal assertion helpers.
+//!
+//! Single-shot assertions, no retry loops. All refs discovered from
+//! the tree, never constructed.
+//!
+//! See MIT-20, MIT-21, MIT-22, MIT-23, MIT-24 in `main` module doc.
+
+use hyperactor_mesh::introspect::NodePayload;
+use hyperactor_mesh::introspect::NodeProperties;
+
+use crate::dining::DiningScenario;
+use crate::harness::WorkloadFixture;
+
+/// Extract the base actor name from a full actor reference string.
+/// Matches the harness's `classify_procs` parsing: take the last
+/// comma-separated segment, strip the `[index]` suffix.
+fn actor_base_name(actor_ref: &str) -> &str {
+    let name = actor_ref.rsplit(',').next().unwrap_or(actor_ref);
+    name.split('[').next().unwrap_or(name)
+}
+
+fn enc(s: &str) -> String {
+    urlencoding::encode(s).into_owned()
+}
+
+/// MIT-20, MIT-21, MIT-22, MIT-23, MIT-24: /v1/{ref} topology
+/// traversal (V1 scope).
+pub(crate) async fn check(s: &DiningScenario) {
+    // MIT-20, MIT-21: root fetchable, typed correctly.
+    let root: NodePayload = s.fixture.get_json("/v1/root").await.unwrap();
+    assert!(
+        matches!(root.properties, NodeProperties::Root { .. }),
+        "MIT-21: expected Root variant"
+    );
+    assert_eq!(root.identity, "root", "MIT-22");
+
+    // MIT-20, MIT-21: first host fetchable.
+    let host_ref = root
+        .children
+        .first()
+        .expect("root should have at least one host child");
+    let host: NodePayload = s
+        .fixture
+        .get_json(&format!("/v1/{}", enc(host_ref)))
+        .await
+        .unwrap();
+    assert!(
+        matches!(host.properties, NodeProperties::Host { .. }),
+        "MIT-21"
+    );
+    assert_eq!(host.identity, *host_ref, "MIT-22");
+
+    // MIT-23 V1: classified service and worker procs fetchable.
+    let service: NodePayload = s
+        .fixture
+        .get_json(&format!("/v1/{}", enc(&s.service)))
+        .await
+        .unwrap();
+    assert!(
+        matches!(service.properties, NodeProperties::Proc { .. }),
+        "MIT-21"
+    );
+    assert_eq!(service.identity, s.service, "MIT-22");
+
+    let worker: NodePayload = s
+        .fixture
+        .get_json(&format!("/v1/{}", enc(&s.worker)))
+        .await
+        .unwrap();
+    assert!(
+        matches!(worker.properties, NodeProperties::Proc { .. }),
+        "MIT-21"
+    );
+    assert_eq!(worker.identity, s.worker, "MIT-22");
+
+    // MIT-24: service proc must expose host_agent, worker proc must
+    // expose proc_agent.
+    check_known_actors(&s.fixture, &service, "service", "host_agent").await;
+    check_known_actors(&s.fixture, &worker, "worker", "proc_agent").await;
+}
+
+async fn check_known_actors(
+    fixture: &WorkloadFixture,
+    proc_node: &NodePayload,
+    label: &str,
+    expected_agent: &str,
+) {
+    let mut found = false;
+    for actor_ref in &proc_node.children {
+        let actor: NodePayload = fixture
+            .get_json(&format!("/v1/{}", enc(actor_ref)))
+            .await
+            .unwrap();
+        assert!(
+            matches!(actor.properties, NodeProperties::Actor { .. }),
+            "MIT-21"
+        );
+        assert_eq!(actor.identity, *actor_ref, "MIT-22");
+
+        if actor_base_name(actor_ref) == expected_agent {
+            found = true;
+        }
+    }
+    assert!(
+        found,
+        "MIT-24: {label} proc should contain {expected_agent}",
+    );
+}

--- a/hyperactor_mesh/test/mesh_admin_integration/ref_edge.rs
+++ b/hyperactor_mesh/test/mesh_admin_integration/ref_edge.rs
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+//! Malformed/encoded reference edge case assertion helpers.
+//!
+//! Purely syntactic — no actor interaction. Tests the
+//! `resolve_reference_bridge` handler's input validation.
+//!
+//! See MIT-25, MIT-26, MIT-27, MIT-29, MIT-30, MIT-31 in
+//! `main` module doc.
+
+use hyperactor_mesh::introspect::NodePayload;
+use hyperactor_mesh::mesh_admin::ApiErrorEnvelope;
+
+use crate::dining::DiningScenario;
+
+fn enc(s: &str) -> String {
+    urlencoding::encode(s).into_owned()
+}
+
+/// MIT-25, MIT-26, MIT-27, MIT-29, MIT-30, MIT-31:
+/// malformed/encoded reference edge cases.
+pub(crate) async fn check(s: &DiningScenario) {
+    // --- MIT-25: empty ref (trailing slash only) ---
+    // Axum's catch-all `{*reference}` does not match when the wildcard
+    // segment is empty, so `/v1/` hits the router's built-in 404 before
+    // `resolve_reference_bridge` runs.  Assert non-success only.
+    let resp = s.fixture.get("/v1/").await.unwrap();
+    assert!(
+        !resp.status().is_success(),
+        "MIT-25: empty ref should not succeed (got {})",
+        resp.status()
+    );
+
+    // --- MIT-26: garbage refs ---
+    for garbage in ["xyzzy", "not-a-reference", "12345", "null", "true"] {
+        let resp = s.fixture.get(&format!("/v1/{garbage}")).await.unwrap();
+        assert!(
+            !resp.status().is_success(),
+            "MIT-26: {garbage} should not succeed"
+        );
+        let body = resp.text().await.unwrap();
+        let envelope: ApiErrorEnvelope = serde_json::from_str(&body)
+            .unwrap_or_else(|e| panic!("MIT-26: {garbage}: not an error envelope: {e}: {body}"));
+        assert_eq!(
+            envelope.error.code, "not_found",
+            "MIT-26: {garbage}: expected not_found, got {}",
+            envelope.error.code
+        );
+    }
+
+    // --- MIT-27: truncated ref ---
+    let truncated = &s.worker[..s.worker.len() / 2];
+    let resp = s
+        .fixture
+        .get(&format!("/v1/{}", enc(truncated)))
+        .await
+        .unwrap();
+    assert!(
+        !resp.status().is_success(),
+        "MIT-27: truncated ref should not succeed"
+    );
+
+    // --- MIT-29: extremely long ref ---
+    let long_ref = "a".repeat(10_000);
+    let resp = s.fixture.get(&format!("/v1/{long_ref}")).await.unwrap();
+    assert!(
+        !resp.status().is_success(),
+        "MIT-29: 10KB ref should not succeed"
+    );
+
+    // --- MIT-30: unreachable socket ref ---
+    let bogus_socket = "unix:@nonexistent_bogus_socket_xyz,bogus-ffffffffffffffff";
+    let resp = s
+        .fixture
+        .get(&format!("/v1/{}", enc(bogus_socket)))
+        .await
+        .unwrap();
+    assert!(
+        !resp.status().is_success(),
+        "MIT-30: unreachable socket ref should not succeed"
+    );
+
+    // --- MIT-31: valid ref round-trips through URL encoding ---
+    let encoded = urlencoding::encode(&s.worker);
+    let node: NodePayload = s.fixture.get_json(&format!("/v1/{encoded}")).await.unwrap();
+    assert_eq!(node.identity, s.worker, "MIT-31");
+}

--- a/hyperactor_mesh/test/mesh_admin_integration/tree.rs
+++ b/hyperactor_mesh/test/mesh_admin_integration/tree.rs
@@ -6,13 +6,13 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-//! Tree, root, and mTLS rejection assertion helpers.
+//! Tree and root assertion helpers.
 //!
 //! These are assertion functions, not tests. They are called from
 //! `dining::test_dining_endpoints` so that all dining-based assertions
 //! share one scenario.
 //!
-//! See MIT-6, MIT-9, MIT-13, MIT-14 in `main` module doc.
+//! See MIT-9, MIT-13, MIT-14 in `main` module doc.
 
 use std::time::Duration;
 
@@ -62,21 +62,8 @@ async fn topology_has_dining_actors(s: &DiningScenario) -> bool {
     false
 }
 
-/// MIT-6, MIT-9, MIT-13, MIT-14: All tree and mTLS assertions.
-///
-/// Order: mTLS rejection (cheap, no server state) → root → tree (polls).
+/// MIT-9, MIT-13, MIT-14: Tree and root assertions.
 pub(crate) async fn check(s: &DiningScenario) {
-    // --- MIT-6: mTLS rejection (cheap, run first) ---
-    let client = s.fixture.build_unauthenticated_client().unwrap();
-    let result = client
-        .get(format!("{}/v1/root", s.fixture.admin_url))
-        .send()
-        .await;
-    assert!(
-        result.is_err(),
-        "MIT-6: connection without client cert should be rejected"
-    );
-
     // --- MIT-13: /v1/root contract ---
     let root: NodePayload = s
         .fixture


### PR DESCRIPTION
Summary:

this diff extends the Rust mesh-admin integration suite with three new test families for the generic /v1/{ref} handler and TLS failure modes. it adds auth.rs for mTLS failure coverage, ref_edge.rs for malformed and encoded reference handling, and ref_check.rs for typed /v1/{ref} traversal checks. the new coverage is added as separate family-level tests in main.rs and dining.rs rather than being folded into the existing dining endpoint tests, so the existing config/tree and py-spy families remain isolated.

the harness is extended only as needed for this coverage. PkiMaterial and generate_pki are exposed within the test crate, WorkloadFixture now exposes its CA PEM, and a small build_tls_client helper was added for custom trust-root and client-identity combinations. The old unauthenticated-client check was moved out of tree.rs into the dedicated auth family, and the invariant registry in main.rs was extended with MIT-20 through MIT-36 so each new test entrypoint explicitly states which invariants it enforces.

the /v1/{ref} tests cover empty references, garbage references, truncated references, double-encoded references, long references, unreachable socket references, URL-encoded round-trips, typed node resolution, identity consistency, and fetchability of the classified service and worker procs plus their known actor refs. the auth family covers missing client certs across all four endpoints and foreign-CA, wrong-trust-root, and corrupt-PEM cases as TLS-level failures.

Reviewed By: allenwang28

Differential Revision: D97671602


