### PR TITLE
Use parent_view_json for precise proc-unit to actor-mesh linking

### DIFF
--- a/python/monarch/monarch_dashboard/fake_data/generate.py
+++ b/python/monarch/monarch_dashboard/fake_data/generate.py
@@ -243,7 +243,9 @@ def _generate_hierarchy() -> tuple[
                 "class": "Host",
                 "given_name": host_given,
                 "full_name": host_full,
-                "shape_json": json.dumps({"dims": [1]}),
+                "shape_json": json.dumps(
+                    {"inner": {"labels": ["hosts"], "sizes": [1]}}
+                ),
                 "parent_mesh_id": None,
                 "parent_view_json": None,
             }
@@ -285,9 +287,16 @@ def _generate_hierarchy() -> tuple[
                     "class": "Proc",
                     "given_name": pm_given,
                     "full_name": pm_full,
-                    "shape_json": json.dumps({"dims": [1]}),
+                    "shape_json": json.dumps(
+                        {"inner": {"labels": ["replica"], "sizes": [1]}}
+                    ),
                     "parent_mesh_id": host_mesh_id,
-                    "parent_view_json": json.dumps({"offset": [0], "sizes": [1]}),
+                    "parent_view_json": json.dumps(
+                        {
+                            "labels": ["replica"],
+                            "slice": {"offset": 0, "sizes": [1], "strides": [1]},
+                        }
+                    ),
                 }
             )
 
@@ -322,9 +331,16 @@ def _generate_hierarchy() -> tuple[
                         "class": am_class,
                         "given_name": am_given,
                         "full_name": am_full,
-                        "shape_json": json.dumps({"dims": [2]}),
+                        "shape_json": json.dumps(
+                            {"inner": {"labels": ["replica"], "sizes": [2]}}
+                        ),
                         "parent_mesh_id": proc_mesh_id,
-                        "parent_view_json": json.dumps({"offset": [0], "sizes": [1]}),
+                        "parent_view_json": json.dumps(
+                            {
+                                "labels": ["replica"],
+                                "slice": {"offset": 0, "sizes": [1], "strides": [1]},
+                            }
+                        ),
                     }
                 )
 
@@ -668,8 +684,8 @@ def _generate_messages(
                     "timestamp_us": ts_msg,
                     "sender_actor_id": sender_id,
                     "actor_mesh_id": sender_actor["mesh_id"],
-                    "view_json": '{"offset": [0], "sizes": [1]}',
-                    "shape_json": '{"dims": [1]}',
+                    "view_json": '{"labels": ["replica"], "slice": {"offset": 0, "sizes": [1], "strides": [1]}}',
+                    "shape_json": '{"inner": {"labels": ["replica"], "sizes": [1]}}',
                 }
             )
 

--- a/python/monarch/monarch_dashboard/fake_data/tests/test_generate.py
+++ b/python/monarch/monarch_dashboard/fake_data/tests/test_generate.py
@@ -238,13 +238,32 @@ class HierarchyTest(unittest.TestCase):
             self.assertEqual(count, 2, f"host mesh {hid} should have 2 proc children")
 
     def test_shape_json_is_valid(self):
-        """shape_json should be parseable and contain a 'dims' key."""
+        """shape_json should be parseable ndslice Extent format."""
         import json
 
         rows = self.conn.execute("SELECT shape_json FROM meshes").fetchall()
         for row in rows:
             data = json.loads(row["shape_json"])
-            self.assertIn("dims", data)
+            self.assertIn("inner", data)
+            self.assertIn("labels", data["inner"])
+            self.assertIn("sizes", data["inner"])
+
+    def test_parent_view_json_is_valid_region(self):
+        """Non-null parent_view_json should be parseable ndslice Region."""
+        import json
+
+        rows = self.conn.execute(
+            "SELECT parent_view_json FROM meshes WHERE parent_view_json IS NOT NULL"
+        ).fetchall()
+        self.assertGreater(len(rows), 0)
+        for row in rows:
+            data = json.loads(row["parent_view_json"])
+            self.assertIn("labels", data)
+            self.assertIn("slice", data)
+            sl = data["slice"]
+            self.assertIn("offset", sl)
+            self.assertIn("sizes", sl)
+            self.assertIn("strides", sl)
 
 
 class ActorTest(unittest.TestCase):

--- a/python/monarch/monarch_dashboard/frontend/src/__tests__/status.test.ts
+++ b/python/monarch/monarch_dashboard/frontend/src/__tests__/status.test.ts
@@ -51,19 +51,23 @@ describe("formatTimestamp", () => {
 });
 
 describe("formatShape", () => {
-  test("formats dims array", () => {
-    expect(formatShape('{"dims": [2, 4]}')).toBe("[2, 4]");
+  test("formats ndslice Extent format", () => {
+    expect(formatShape('{"inner": {"labels": ["workers", "gpu"], "sizes": [2, 4]}}')).toBe("[2, 4]");
   });
 
-  test("formats single dim", () => {
-    expect(formatShape('{"dims": [1]}')).toBe("[1]");
+  test("formats single dim ndslice Extent", () => {
+    expect(formatShape('{"inner": {"labels": ["replica"], "sizes": [1]}}')).toBe("[1]");
+  });
+
+  test("formats legacy dims array", () => {
+    expect(formatShape('{"dims": [2, 4]}')).toBe("[2, 4]");
   });
 
   test("returns raw on invalid JSON", () => {
     expect(formatShape("not json")).toBe("not json");
   });
 
-  test("returns raw when no dims key", () => {
+  test("returns raw when no recognized key", () => {
     expect(formatShape('{"foo": 1}')).toBe('{"foo": 1}');
   });
 });

--- a/python/monarch/monarch_dashboard/frontend/src/utils/status.ts
+++ b/python/monarch/monarch_dashboard/frontend/src/utils/status.ts
@@ -37,10 +37,15 @@ export function formatTimestamp(us: number | null | undefined): string {
   return d.toISOString().replace("T", " ").replace("Z", "").slice(0, 23);
 }
 
-/** Parse shape_json into a readable dims string like "[2, 4]". */
+/** Parse shape_json into a readable dims string like "[2, 4]".
+ *  Handles both the real ndslice Extent format
+ *  ``{"inner": {"labels": ["workers"], "sizes": [2]}}`` and the legacy
+ *  ``{"dims": [2]}`` format.
+ */
 export function formatShape(shapeJson: string): string {
   try {
     const parsed = JSON.parse(shapeJson);
+    if (parsed.inner?.sizes) return `[${parsed.inner.sizes.join(", ")}]`;
     if (parsed.dims) return `[${parsed.dims.join(", ")}]`;
     return shapeJson;
   } catch {

--- a/python/monarch/monarch_dashboard/server/db.py
+++ b/python/monarch/monarch_dashboard/server/db.py
@@ -15,6 +15,7 @@ Module-level functions (init, _query, etc.) provide backward compatibility
 by delegating to a module-level SQLiteAdapter instance.
 """
 
+import json
 import sqlite3
 from abc import ABC, abstractmethod
 from typing import Any
@@ -162,6 +163,75 @@ def _dedup_rows(rows: list[dict[str, Any]], key: str = "id") -> list[dict[str, A
             seen.add(val)
             result.append(r)
     return result
+
+
+# ---------------------------------------------------------------------------
+# ndslice Region → proc rank mapping
+# ---------------------------------------------------------------------------
+
+
+def _parse_region(
+    parent_view_json: str | None,
+) -> tuple[int, list[int], list[int]] | None:
+    """Parse a serialized ndslice Region into (offset, sizes, strides).
+
+    Accepts the real DataFusion format::
+
+        {"labels": ["workers"], "slice": {"offset": 0, "sizes": [2], "strides": [1]}}
+
+    Returns None if *parent_view_json* is null or unparseable.
+    """
+    if not parent_view_json:
+        return None
+    try:
+        parsed = json.loads(parent_view_json)
+    except (json.JSONDecodeError, TypeError):
+        return None
+    sl = parsed.get("slice")
+    if not sl or "offset" not in sl or "sizes" not in sl or "strides" not in sl:
+        return None
+    return (sl["offset"], sl["sizes"], sl["strides"])
+
+
+def _actor_rank_to_proc_rank(
+    actor_rank: int,
+    offset: int,
+    sizes: list[int],
+    strides: list[int],
+) -> int:
+    """Map an actor mesh rank to a proc mesh rank via the parent Region.
+
+    The actor mesh is spawned on a view (Region) of the proc mesh.  Actors
+    are enumerated in row-major order over the Region.  Given the Region
+    R = (offset, sizes, strides), actor rank *r* maps to::
+
+        proc_rank = offset + Σ_{k} i_k · strides_k
+
+    where (i_0, ..., i_{d-1}) is the row-major decomposition of *r* over
+    *sizes*.  O(d) per call where d = len(sizes).
+    """
+    proc_rank = offset
+    remainder = actor_rank
+    for k in range(len(sizes)):
+        suffix = 1
+        for j in range(k + 1, len(sizes)):
+            suffix *= sizes[j]
+        i_k = (remainder // suffix) % sizes[k]
+        proc_rank += i_k * strides[k]
+        remainder %= suffix
+    return proc_rank
+
+
+def _proc_ranks_for_region(
+    offset: int,
+    sizes: list[int],
+    strides: list[int],
+) -> set[int]:
+    """Return the set of all proc mesh ranks covered by a Region.  O(|R|)."""
+    total = 1
+    for s in sizes:
+        total *= s
+    return {_actor_rank_to_proc_rank(r, offset, sizes, strides) for r in range(total)}
 
 
 # Reusable SQL fragments for latest-status subqueries.
@@ -599,10 +669,22 @@ def get_dag_data() -> dict[str, Any]:
             )
 
     # Proc unit -> actor mesh
+    # Use parent_view_json (ndslice Region) to determine which proc ranks
+    # the actor mesh spans, then connect only the matching proc agents.
+    # Falls back to connecting all proc agents if parent_view_json is absent.
     for am in actor_meshes:
         if am["parent_mesh_id"] is None:
             continue
-        for agent in proc_agents_by_mesh.get(am["parent_mesh_id"], []):
+        proc_agents = proc_agents_by_mesh.get(am["parent_mesh_id"], [])
+        region = _parse_region(am.get("parent_view_json"))
+        if region is not None and proc_agents:
+            covered_ranks = _proc_ranks_for_region(*region)
+            matching = [a for a in proc_agents if a.get("rank") in covered_ranks]
+            # Fall back to all agents if no rank matches (e.g. rank data missing).
+            targets = matching if matching else proc_agents
+        else:
+            targets = proc_agents
+        for agent in targets:
             edges.append(
                 {
                     "id": f"hier-proc_unit-{agent['id']}-actor_mesh-{am['id']}",

--- a/python/monarch/monarch_dashboard/server/tests/test_db.py
+++ b/python/monarch/monarch_dashboard/server/tests/test_db.py
@@ -423,5 +423,73 @@ class GetSummaryTest(_DbTestBase):
         self.assertLess(summary["health_score"], 100)
 
 
+class RegionMappingTest(unittest.TestCase):
+    """Tests for ndslice Region → proc rank mapping helpers."""
+
+    def test_parse_region_valid(self):
+        region_json = '{"labels": ["workers"], "slice": {"offset": 2, "sizes": [3], "strides": [1]}}'
+        result = db._parse_region(region_json)
+        self.assertEqual(result, (2, [3], [1]))
+
+    def test_parse_region_none(self):
+        self.assertIsNone(db._parse_region(None))
+        self.assertIsNone(db._parse_region(""))
+
+    def test_parse_region_invalid_json(self):
+        self.assertIsNone(db._parse_region("not json"))
+
+    def test_parse_region_missing_slice(self):
+        self.assertIsNone(db._parse_region('{"labels": ["x"]}'))
+
+    def test_1d_contiguous(self):
+        # offset=2, sizes=[3], strides=[1] → ranks 2, 3, 4
+        self.assertEqual(db._actor_rank_to_proc_rank(0, 2, [3], [1]), 2)
+        self.assertEqual(db._actor_rank_to_proc_rank(1, 2, [3], [1]), 3)
+        self.assertEqual(db._actor_rank_to_proc_rank(2, 2, [3], [1]), 4)
+
+    def test_1d_strided(self):
+        # offset=1, sizes=[2], strides=[2] → ranks 1, 3
+        self.assertEqual(db._actor_rank_to_proc_rank(0, 1, [2], [2]), 1)
+        self.assertEqual(db._actor_rank_to_proc_rank(1, 1, [2], [2]), 3)
+
+    def test_2d(self):
+        # 2D: offset=0, sizes=[2, 3], strides=[3, 1]
+        # Row-major: (0,0)=0, (0,1)=1, (0,2)=2, (1,0)=3, (1,1)=4, (1,2)=5
+        self.assertEqual(db._actor_rank_to_proc_rank(0, 0, [2, 3], [3, 1]), 0)
+        self.assertEqual(db._actor_rank_to_proc_rank(1, 0, [2, 3], [3, 1]), 1)
+        self.assertEqual(db._actor_rank_to_proc_rank(2, 0, [2, 3], [3, 1]), 2)
+        self.assertEqual(db._actor_rank_to_proc_rank(3, 0, [2, 3], [3, 1]), 3)
+        self.assertEqual(db._actor_rank_to_proc_rank(5, 0, [2, 3], [3, 1]), 5)
+
+    def test_2d_with_offset(self):
+        # offset=6, sizes=[2, 3], strides=[3, 1] → 6,7,8,9,10,11
+        self.assertEqual(db._actor_rank_to_proc_rank(0, 6, [2, 3], [3, 1]), 6)
+        self.assertEqual(db._actor_rank_to_proc_rank(5, 6, [2, 3], [3, 1]), 11)
+
+    def test_proc_ranks_for_region(self):
+        ranks = db._proc_ranks_for_region(2, [3], [1])
+        self.assertEqual(ranks, {2, 3, 4})
+
+    def test_proc_ranks_for_region_2d(self):
+        ranks = db._proc_ranks_for_region(0, [2, 3], [3, 1])
+        self.assertEqual(ranks, {0, 1, 2, 3, 4, 5})
+
+
+class DagRegionEdgesTest(_DbTestBase):
+    """Test that get_dag_data uses parent_view_json for proc→actor_mesh edges."""
+
+    def test_dag_has_proc_unit_to_actor_mesh_edges(self):
+        dag = db.get_dag_data()
+        hier_edges = [
+            e
+            for e in dag["edges"]
+            if e["type"] == "hierarchy"
+            and e["source_id"].startswith("proc_unit-")
+            and e["target_id"].startswith("actor_mesh-")
+        ]
+        # Fake data has 4 proc meshes × 1 actor mesh each = 4 edges
+        self.assertGreaterEqual(len(hier_edges), 4)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Summary:
Use the ndslice Region from parent_view_json to determine exactly which proc mesh ranks an actor mesh spans, replacing the previous approach that connected every proc agent to every actor mesh.

  Why parent_view_json is required (shape_json is insufficient)

  shape_json stores the ndslice Extent — dimension sizes only, no positional information.
  Example: {"inner": {"labels": ["workers"], "sizes": [2]}}

  parent_view_json stores the ndslice Region — sizes + offset + strides.
  Example: {"labels": ["workers"], "slice": {"offset": 1, "sizes": [2], "strides": [1]}}

  The offset is critical. Consider a proc mesh with 4 workers and two actor meshes spawned on different slices:
  - Actor mesh A on procs.slice(workers=slice(0,2)): offset=0
  - Actor mesh B on procs.slice(workers=slice(2,4)): offset=2

  Both have shape_json sizes=[2] — identical. Without the offset from parent_view_json, there is no way to determine which proc ranks each actor mesh covers.

  Mapping algorithm and correctness (O(d) per actor)

  Given Region R = (offset, sizes, strides), actor rank r maps to:

  proc_rank(r) = offset + Σ_k i_k(r) · strides_k

  where i_k(r) = ⌊r / Π_{j>k} sizes_j⌋ mod sizes_k (row-major decomposition).

  Correctness: Actor rank r decomposes into multi-index (i_0, ..., i_{d-1}) via standard row-major unraveling — a bijection from [0, Π sizes_k) to the Cartesian product [0,sizes_0) × ... × [0,sizes_{d-1}). The ndslice Region definition maps this
   multi-index to flat rank offset + Σ_k i_k · strides_k, which is exactly the formula above. Therefore {proc_rank(r) : r ∈ [0, Π sizes_k)} is precisely the set of proc ranks covered by the Region. QED.

  For the common 1D contiguous case this simplifies to proc_rank(r) = offset + r.

  Fallback when parent_view_json is absent

  parent_view_json is currently Optional in the telemetry schema. The mapping falls back to connecting all proc agents when it is absent. The active code path (hyperactor_mesh/src/proc_mesh.rs) already always provides it for non-root meshes.

Reviewed By: thedavekwon

Differential Revision: D97343203


