### PR TITLE
Fix rsync daemon rejecting IPv6 loopback on hosts where ::1 maps to ip6-localhost

### DIFF
--- a/monarch_hyperactor/src/code_sync/rsync.rs
+++ b/monarch_hyperactor/src/code_sync/rsync.rs
@@ -258,7 +258,7 @@ impl RsyncDaemon {
     read only = true
     write only = false
     uid = {uid}
-    hosts allow = localhost
+    hosts allow = localhost ip6-localhost
 "#,
             workspace = workspace.display(),
             uid = nix::unistd::getuid().as_raw(),


### PR DESCRIPTION
On Linux systems where `/etc/hosts` maps `::1` to ip6-localhost (common on Ubuntu and cloud VMs), the rsync daemon rejects connections with "access denied" because `hosts allow = localhost` does not match `ip6-localhost`. This causes
  `sync_workspace` to hang indefinitely.

  Add `ip6-localhost` to the hosts allow directive so connections from `::1` are accepted regardless of the hostname mapping.