### PR TITLE
Allow IPv6 loopback in rsync daemon hosts

### DIFF
--- a/monarch_hyperactor/src/code_sync/rsync.rs
+++ b/monarch_hyperactor/src/code_sync/rsync.rs
@@ -258,7 +258,7 @@ impl RsyncDaemon {
     read only = true
     write only = false
     uid = {uid}
-    hosts allow = localhost
+    hosts allow = localhost ip6-localhost
 "#,
             workspace = workspace.display(),
             uid = nix::unistd::getuid().as_raw(),


### PR DESCRIPTION
Summary:
This is from AlirezaShamsoshoara.

## Symptom

await host.sync_workspace(workspace) hangs indefinitely on lightning node but works on internal dev_gpu node. No error message is produced — the call simply never returns.

## Investigation

Verified rsync is installed and functional on the affected node
Verified IPv4 and IPv6 loopback bind/connect works

`ERROR: access denied to workspace from ip6-localhost (::1)`

```
127.0.0.1   localhost
::1         ip6-localhost ip6-loopback
```

## Root Cause
In monarch_hyperactor/src/code_sync/rsync.rs (line 261), the rsync daemon config is written with:

```
hosts allow = localhost
```

The daemon binds to [::1]:0 (IPv6 loopback). When the rsync client connects from ::1, rsync does a reverse DNS lookup using /etc/hosts. On lightning node(Ubuntu, cloud VMs), ::1 maps to ip6-localhost, not localhost. rsync checks the resolved hostname against hosts allow, finds no match, and rejects the connection.
https://www.internalfb.com/code/fbsource/[e39d8460d7b35ec0dcc725527629c851a3b6a264]/fbcode/monarch/monarch_hyperactor/src/code_sync/rsync.rs?lines=261

## Fix

```
// Before:
hosts allow = localhost

// After:
hosts allow = localhost ip6-localhost
```

This covers both /etc/hosts naming conventions across Linux distributions.

Differential Revision: D97785807


