### PR TITLE
hyperactor parallel channel benchmark (#3156)

### DIFF
--- a/hyperactor/src/lib.rs
+++ b/hyperactor/src/lib.rs
@@ -88,7 +88,7 @@ pub mod testing;
 pub mod time;
 
 #[cfg(fbcode_build)]
-mod meta;
+pub mod meta;
 
 /// Re-exports of external crates used by hyperactor_macros codegen.
 /// This module is not part of the public API and should not be used directly.

--- a/monarch_extension/src/lib.rs
+++ b/monarch_extension/src/lib.rs
@@ -293,6 +293,10 @@ pub fn mod_init(module: &Bound<'_, PyModule>) -> PyResult<()> {
             module,
             "monarch_hyperactor.meta.alloc_mock",
         )?)?;
+        monarch_hyperactor::meta::bench::register_python_bindings(&get_or_add_new_module(
+            module,
+            "monarch_hyperactor.meta.bench",
+        )?)?;
     }
     // Add feature detection function
     module.add_function(wrap_pyfunction!(has_tensor_engine, module)?)?;

--- a/monarch_hyperactor/src/channel.rs
+++ b/monarch_hyperactor/src/channel.rs
@@ -160,6 +160,7 @@ impl From<BindSpec> for PyBindSpec {
     name = "ChannelAddr",
     module = "monarch._rust_bindings.monarch_hyperactor.channel"
 )]
+#[derive(Clone)]
 pub struct PyChannelAddr {
     inner: ChannelAddr,
 }
@@ -205,6 +206,23 @@ impl PyChannelAddr {
         }
     }
 
+    fn __str__(&self) -> String {
+        self.inner.to_string()
+    }
+
+    fn __repr__(&self) -> String {
+        format!("ChannelAddr.parse(\"{}\")", self.inner)
+    }
+
+    fn __reduce__<'py>(&self, py: Python<'py>) -> PyResult<(Bound<'py, PyAny>, Bound<'py, PyAny>)> {
+        let cls = py
+            .import("monarch._rust_bindings.monarch_hyperactor.channel")?
+            .getattr("ChannelAddr")?;
+        let parse = cls.getattr("parse")?;
+        let args = (self.inner.to_string(),).into_bound_py_any(py)?;
+        Ok((parse, args))
+    }
+
     /// Returns the channel transport of this channel address.
     pub fn get_transport(&self) -> PyResult<PyChannelTransport> {
         let transport = self.inner.transport();
@@ -221,6 +239,18 @@ impl PyChannelAddr {
             ChannelTransport::Local => Ok(PyChannelTransport::Local),
             ChannelTransport::Unix => Ok(PyChannelTransport::Unix),
         }
+    }
+}
+
+impl From<PyChannelAddr> for ChannelAddr {
+    fn from(val: PyChannelAddr) -> Self {
+        val.inner
+    }
+}
+
+impl From<ChannelAddr> for PyChannelAddr {
+    fn from(inner: ChannelAddr) -> Self {
+        PyChannelAddr { inner }
     }
 }
 


### PR DESCRIPTION
Summary:

Add a benchmark that opens N hyperactor channels in parallel across 2 hosts and writes the same chunk over and over again until a specified amount of bytes transferred has been reached. Runs on gpus or cpus.

64MB chunks, 16GB total, 3 runs
============================================================
  Channels   Median GB/s   Mean GB/s    P90 GB/s
----------  ------------  ----------  ----------
         1          0.13        0.13        0.13
         4          0.54        0.54        0.54
         8          1.07        1.07        1.07
        16          2.14        2.14        2.14
        32          4.28        4.25        4.28
        64          8.54        8.18        8.55
```

Reviewed By: shayne-fletcher

Differential Revision: D97817298
