### PR TITLE
add POST /v1/query SQL endpoint with explicit QueryEngine handoff

### DIFF
--- a/hyperactor_mesh/Cargo.toml
+++ b/hyperactor_mesh/Cargo.toml
@@ -42,6 +42,7 @@ path = "benches/main.rs"
 [dependencies]
 algebra = { version = "0.0.0", path = "../algebra" }
 anyhow = "1.0.102"
+arrow = { version = "57.3.0", features = ["ffi", "json", "prettyprint", "pyarrow"] }
 async-trait = "0.1.86"
 axum = { version = "0.8", features = ["macros", "ws"] }
 base64 = { version = "0.22.1", features = ["alloc"] }
@@ -71,6 +72,7 @@ nix = { version = "0.30.1", features = ["dir", "event", "hostname", "inotify", "
 opentelemetry = "0.31"
 pin-project = "1.1.11"
 preempt_rwlock = { version = "0.0.0", path = "../preempt_rwlock" }
+pyo3 = { version = "0.26", features = ["anyhow", "multiple-pymethods", "py-clone"] }
 rand = { version = "0.9", features = ["small_rng"] }
 ratatui = { version = "0.29.0", features = ["termion", "termwiz", "unstable-rendered-line-info"] }
 reqwest = { version = "0.13.2", features = ["blocking", "charset", "cookies", "gzip", "http2", "json", "multipart", "rustls", "socks", "stream", "system-proxy"], default-features = false }

--- a/hyperactor_mesh/src/mesh_admin.rs
+++ b/hyperactor_mesh/src/mesh_admin.rs
@@ -261,6 +261,7 @@ use axum::extract::State;
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use axum::routing::get;
+use axum::routing::post;
 use hyperactor::Actor;
 use hyperactor::ActorHandle;
 use hyperactor::Context;
@@ -648,6 +649,25 @@ impl std::fmt::Debug for MeshAdminAgent {
     }
 }
 
+/// Process-level handoff slot for the Python `QueryEngine` object.
+///
+/// The PyO3 bridge sets this before sending `SpawnMeshAdmin` (which is
+/// a wire message and cannot carry `Py<PyAny>`). The admin actor's
+/// `init()` takes the value into `BridgeState.query_engine`.
+///
+/// **Design note:** We use a process-level `Mutex<Option<…>>` instead of
+/// embedding the engine in the spawn message because `SpawnMeshAdmin`
+/// must be serializable (it crosses actor boundaries as a wire message).
+/// `Py<PyAny>` is not `Serialize`.
+static PENDING_QUERY_ENGINE: std::sync::Mutex<Option<pyo3::Py<pyo3::PyAny>>> =
+    std::sync::Mutex::new(None);
+
+/// Set the pending query engine that the next `MeshAdminAgent::init()`
+/// will consume.
+pub fn set_pending_query_engine(engine: pyo3::Py<pyo3::PyAny>) {
+    *PENDING_QUERY_ENGINE.lock().expect("poisoned") = Some(engine);
+}
+
 /// Shared state for the reference-based `/v1/{*reference}` bridge
 /// route.
 ///
@@ -674,6 +694,14 @@ struct BridgeState {
     resolve_semaphore: tokio::sync::Semaphore,
     /// Keep the handle alive so the bridge mailbox is not dropped.
     _bridge_handle: ActorHandle<()>,
+    /// Python `QueryEngine` passed at spawn time. Used by
+    /// `query_bridge` and `pyspy_bridge` to avoid a GIL-heavy
+    /// module import on every HTTP request.
+    ///
+    /// `None` when the caller didn't start telemetry — the HTTP
+    /// handlers return a clear 500 with "telemetry not started"
+    /// rather than panicking.
+    query_engine: Option<pyo3::Py<pyo3::PyAny>>,
 }
 
 /// A TCP listener that performs a TLS handshake on each accepted
@@ -791,6 +819,7 @@ impl Actor for MeshAdminAgent {
             .proc()
             .introspectable_instance(MESH_ADMIN_BRIDGE_NAME)?;
         bridge_cx.set_system();
+        let query_engine = PENDING_QUERY_ENGINE.lock().expect("poisoned").take();
         let bridge_state = Arc::new(BridgeState {
             admin_ref: hyperactor_reference::ActorRef::attest(this.self_id().clone()),
             bridge_cx,
@@ -798,6 +827,7 @@ impl Actor for MeshAdminAgent {
                 crate::config::MESH_ADMIN_MAX_CONCURRENT_RESOLVES,
             )),
             _bridge_handle: bridge_handle,
+            query_engine,
         });
         let router = create_mesh_admin_router(bridge_state);
 
@@ -1348,6 +1378,7 @@ impl MeshAdminAgent {
 /// - `GET /v1/pyspy/{*proc_reference}` — py-spy stack dump for a proc.
 /// - `GET /v1/config/{*proc_reference}` — config snapshot for a proc.
 /// - `GET /v1/{*reference}` — JSON `NodePayload` for a single reference.
+/// - `POST /v1/query` — JSON `SqlQueryRequest` for a SQL query.
 /// - `GET /SKILL.md` — agent-facing API documentation (markdown).
 fn create_mesh_admin_router(bridge_state: Arc<BridgeState>) -> Router {
     Router::new()
@@ -1359,8 +1390,91 @@ fn create_mesh_admin_router(bridge_state: Arc<BridgeState>) -> Router {
         .route("/v1/tree", get(tree_dump))
         .route("/v1/pyspy/{*proc_reference}", get(pyspy_bridge))
         .route("/v1/config/{*proc_reference}", get(config_bridge))
+        .route("/v1/query", post(query_bridge))
         .route("/v1/{*reference}", get(resolve_reference_bridge))
         .with_state(bridge_state)
+}
+
+/// Convert Arrow IPC bytes to a JSON array of objects.
+///
+/// Each row is a self-describing `{"column": value, ...}` object.
+/// Uses `arrow::json::ArrayWriter` for type-correct serialization.
+fn arrow_ipc_to_json(data: &[u8]) -> anyhow::Result<Vec<u8>> {
+    use arrow::ipc::reader::StreamReader;
+    use arrow::json::ArrayWriter;
+
+    let mut reader = StreamReader::try_new(std::io::Cursor::new(data), None)?;
+    let mut buf = Vec::new();
+    let mut writer = ArrayWriter::new(&mut buf);
+    while let Some(batch) = reader.next().transpose()? {
+        writer.write(&batch)?;
+    }
+    writer.finish()?;
+    Ok(buf)
+}
+
+/// Request payload for SQL queries.
+#[derive(Deserialize)]
+struct SqlQueryRequest {
+    sql: String,
+}
+
+/// HTTP bridge for SQL queries against the telemetry query engine.
+///
+/// Bypasses `MeshAdminAgent` entirely — acquires the Python GIL via
+/// `spawn_blocking` and calls `query_engine.query_raw(sql)` on the
+/// engine passed at spawn time. Same direct-bypass pattern as
+/// `pyspy_bridge`.
+///
+/// Returns a JSON array of objects, one per row:
+/// `[{"col1": val1, "col2": val2}, ...]`
+async fn query_bridge(
+    State(state): State<Arc<BridgeState>>,
+    Json(req): Json<SqlQueryRequest>,
+) -> Result<impl axum::response::IntoResponse, ApiError> {
+    if state.query_engine.is_none() {
+        return Err(ApiError {
+            code: "internal_error".into(),
+            message: "telemetry not started (no query engine provided at spawn time)".into(),
+            details: None,
+        });
+    }
+    // Move the `Arc<BridgeState>` into `spawn_blocking` so we can
+    // clone the `Py<PyAny>` inside `Python::attach` — cloning a
+    // `Py<PyAny>` bumps the Python reference count and requires the
+    // current thread to be attached to the interpreter.
+    let ipc_bytes: Vec<u8> = tokio::task::spawn_blocking(move || {
+        pyo3::Python::attach(|py| -> pyo3::PyResult<Vec<u8>> {
+            use pyo3::prelude::*;
+            let engine = state.query_engine.as_ref().unwrap();
+            engine
+                .bind(py)
+                .call_method1("query_raw", (&req.sql,))?
+                .extract()
+        })
+    })
+    .await
+    .map_err(|e| ApiError {
+        code: "internal_error".into(),
+        message: format!("query task failed: {}", e),
+        details: None,
+    })?
+    .map_err(|e| ApiError {
+        code: "internal_error".into(),
+        message: format!("query failed: {}", e),
+        details: None,
+    })?;
+
+    let json_bytes = arrow_ipc_to_json(&ipc_bytes).map_err(|e| ApiError {
+        code: "internal_error".into(),
+        message: format!("failed to convert results: {}", e),
+        details: None,
+    })?;
+
+    Ok((
+        [(axum::http::header::CONTENT_TYPE, "application/json")],
+        json_bytes,
+    ))
 }
 
 /// Raw markdown template for the SKILL.md API document.
@@ -1666,6 +1780,46 @@ pub fn build_openapi_spec() -> serde_json::Value {
                         "404": error_response("Proc not found or handler not reachable"),
                         "500": error_response("Internal error"),
                         "504": error_response("Gateway timeout")
+                    }
+                }
+            },
+            "/v1/query": {
+                "post": {
+                    "summary": "Execute a SQL query against the telemetry query engine",
+                    "operationId": "postQuery",
+                    "requestBody": {
+                        "required": true,
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": ["sql"],
+                                    "properties": {
+                                        "sql": {
+                                            "type": "string",
+                                            "description": "SQL query string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "responses": {
+                        "200": {
+                            "description": "JSON array of row objects",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "object",
+                                            "additionalProperties": true
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "500": error_response("Internal error (query failed or telemetry not started)")
                     }
                 }
             }
@@ -3721,5 +3875,66 @@ mod tests {
 
         let (_, parsed) = parse_pyspy_proc_reference(&with_slash).unwrap();
         assert_eq!(parsed, proc_id);
+    }
+
+    #[test]
+    fn test_arrow_ipc_to_json_basic() {
+        use arrow::array::BooleanArray;
+        use arrow::array::Int64Array;
+        use arrow::array::StringArray;
+        use arrow::datatypes::DataType;
+        use arrow::datatypes::Field;
+        use arrow::datatypes::Schema;
+        use arrow::ipc::writer::StreamWriter;
+        use arrow::record_batch::RecordBatch;
+
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("name", DataType::Utf8, false),
+            Field::new("value", DataType::Int64, false),
+            Field::new("flag", DataType::Boolean, true),
+        ]));
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(StringArray::from(vec!["a", "b"])),
+                Arc::new(Int64Array::from(vec![1, 2])),
+                Arc::new(BooleanArray::from(vec![Some(true), None])),
+            ],
+        )
+        .unwrap();
+
+        let mut buf = Vec::new();
+        let mut writer = StreamWriter::try_new(&mut buf, &schema).unwrap();
+        writer.write(&batch).unwrap();
+        writer.finish().unwrap();
+
+        let json_bytes = arrow_ipc_to_json(&buf).unwrap();
+        let rows: Vec<serde_json::Value> = serde_json::from_slice(&json_bytes).unwrap();
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows[0]["name"], serde_json::json!("a"));
+        assert_eq!(rows[0]["value"], serde_json::json!(1));
+        assert_eq!(rows[0]["flag"], serde_json::json!(true));
+        assert!(rows[1]["flag"].is_null());
+    }
+
+    #[test]
+    fn test_arrow_ipc_to_json_empty() {
+        use arrow::datatypes::DataType;
+        use arrow::datatypes::Field;
+        use arrow::datatypes::Schema;
+        use arrow::ipc::writer::StreamWriter;
+        use arrow::record_batch::RecordBatch;
+
+        let schema = Arc::new(Schema::new(vec![Field::new("x", DataType::Int64, false)]));
+        let batch = RecordBatch::new_empty(schema.clone());
+
+        let mut buf = Vec::new();
+        let mut writer = StreamWriter::try_new(&mut buf, &schema).unwrap();
+        writer.write(&batch).unwrap();
+        writer.finish().unwrap();
+
+        let json_bytes = arrow_ipc_to_json(&buf).unwrap();
+        let rows: Vec<serde_json::Value> = serde_json::from_slice(&json_bytes).unwrap();
+        assert!(rows.is_empty());
     }
 }

--- a/hyperactor_mesh/src/testdata/openapi.json
+++ b/hyperactor_mesh/src/testdata/openapi.json
@@ -762,6 +762,57 @@
         "summary": "Py-spy stack dump for a proc"
       }
     },
+    "/v1/query": {
+      "post": {
+        "operationId": "postQuery",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "sql": {
+                    "description": "SQL query string",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "sql"
+                ],
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "additionalProperties": true,
+                    "type": "object"
+                  },
+                  "type": "array"
+                }
+              }
+            },
+            "description": "JSON array of row objects"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorEnvelope"
+                }
+              }
+            },
+            "description": "Internal error (query failed or telemetry not started)"
+          }
+        },
+        "summary": "Execute a SQL query against the telemetry query engine"
+      }
+    },
     "/v1/root": {
       "get": {
         "operationId": "getRoot",

--- a/hyperactor_mesh/test/mesh_admin_integration/main.rs
+++ b/hyperactor_mesh/test/mesh_admin_integration/main.rs
@@ -262,6 +262,7 @@ mod dining;
 mod harness;
 mod openapi;
 mod pyspy;
+mod query;
 mod ref_check;
 mod ref_edge;
 mod tree;
@@ -353,4 +354,13 @@ async fn test_auth_failures_rust() {
 #[tokio::test]
 async fn test_openapi_conformance_rust() {
     dining::run_openapi_conformance_rust().await;
+}
+
+// --- query family ---
+
+/// /v1/query endpoint: SQL queries return JSON rows from the
+/// telemetry query engine.
+#[tokio::test]
+async fn test_query_endpoint() {
+    query::run_query_endpoint().await;
 }

--- a/hyperactor_mesh/test/mesh_admin_integration/openapi.rs
+++ b/hyperactor_mesh/test/mesh_admin_integration/openapi.rs
@@ -69,6 +69,7 @@ impl OpenApiValidator {
             "/v1/{reference}",
             "/v1/config/{proc_reference}",
             "/v1/pyspy/{proc_reference}",
+            "/v1/query",
             "/v1/tree",
             "/v1/schema",
             "/v1/schema/error",

--- a/hyperactor_mesh/test/mesh_admin_integration/query.rs
+++ b/hyperactor_mesh/test/mesh_admin_integration/query.rs
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+//! `/v1/query` endpoint integration tests.
+//!
+//! Requires the `query_workload` binary, which starts telemetry and
+//! passes a `QueryEngine` to the admin server.
+
+use std::path::PathBuf;
+use std::time::Duration;
+
+use anyhow::Result;
+use serde_json::Value;
+
+use crate::harness;
+use crate::harness::WorkloadFixture;
+
+fn query_workload_binary() -> PathBuf {
+    buck_resources::get("monarch/hyperactor_mesh/query_workload")
+        .expect("query_workload resource not found")
+        .to_path_buf()
+}
+
+/// Start the query workload and wait for the admin URL sentinel.
+/// The sentinel is printed only after telemetry data is populated.
+async fn start_query_workload() -> Result<WorkloadFixture> {
+    let bin = query_workload_binary();
+    harness::start_workload(&bin, &[], Duration::from_secs(120)).await
+}
+
+/// POST a SQL query to `/v1/query` and return the raw response.
+async fn post_query_raw(
+    fixture: &WorkloadFixture,
+    sql: &str,
+) -> Result<reqwest::Response, reqwest::Error> {
+    let url = format!("{}/v1/query", fixture.admin_url);
+    let body = serde_json::json!({ "sql": sql });
+    fixture.client.post(&url).json(&body).send().await
+}
+
+/// POST a SQL query to `/v1/query` and return the parsed JSON rows.
+async fn post_query(fixture: &WorkloadFixture, sql: &str) -> Result<Vec<Value>> {
+    let resp = post_query_raw(fixture, sql)
+        .await
+        .map_err(|e| anyhow::anyhow!(e))?;
+    let status = resp.status();
+    let text = resp.text().await?;
+    if !status.is_success() {
+        anyhow::bail!("POST /v1/query: HTTP {status}: {text}");
+    }
+    let rows: Vec<Value> = serde_json::from_str(&text)?;
+    Ok(rows)
+}
+
+/// E2E: `/v1/query` returns actor rows as a JSON array.
+pub async fn check(fixture: &WorkloadFixture) {
+    // Basic SELECT * — should return at least the query_worker actors.
+    let rows = post_query(fixture, "SELECT * FROM actors")
+        .await
+        .expect("SELECT * FROM actors failed");
+    assert!(!rows.is_empty(), "expected at least one actor row");
+
+    // Each row should have the actors table columns.
+    let first = &rows[0];
+    for col in &["id", "full_name", "mesh_id", "rank", "timestamp_us"] {
+        assert!(
+            first.get(*col).is_some(),
+            "missing column '{col}' in response: {first}"
+        );
+    }
+
+    // Verify the test worker appears.
+    let has_worker = rows.iter().any(|r| {
+        r["full_name"]
+            .as_str()
+            .is_some_and(|n| n.contains("query_worker"))
+    });
+    assert!(has_worker, "expected 'query_worker' in actor names");
+
+    // Filtered query with WHERE clause.
+    let filtered = post_query(
+        fixture,
+        "SELECT full_name FROM actors WHERE full_name LIKE '%query_worker%'",
+    )
+    .await
+    .expect("filtered query failed");
+    assert!(!filtered.is_empty(), "filtered query returned no rows");
+    for row in &filtered {
+        let name = row["full_name"].as_str().unwrap_or("");
+        assert!(
+            name.contains("query_worker"),
+            "unexpected actor in filtered results: {name}"
+        );
+    }
+
+    // Empty result query.
+    let empty = post_query(
+        fixture,
+        "SELECT * FROM actors WHERE full_name = 'nonexistent_xyz'",
+    )
+    .await
+    .expect("empty query failed");
+    assert!(empty.is_empty(), "expected zero rows for nonexistent actor");
+
+    // Invalid SQL returns an error status.
+    let resp = post_query_raw(fixture, "NOT VALID SQL !!!")
+        .await
+        .expect("invalid SQL request failed to send");
+    assert!(
+        !resp.status().is_success(),
+        "expected error status for invalid SQL, got {}",
+        resp.status()
+    );
+}
+
+/// Run the full query endpoint test suite.
+pub async fn run_query_endpoint() {
+    let fixture = start_query_workload()
+        .await
+        .expect("failed to start query workload");
+    check(&fixture).await;
+    fixture.shutdown().await;
+}

--- a/monarch_hyperactor/src/host_mesh.rs
+++ b/monarch_hyperactor/src/host_mesh.rs
@@ -198,10 +198,16 @@ impl PyHostMesh {
     /// When `admin_addr` is provided (as a `"host:port"` string), the
     /// HTTP server binds to that address; otherwise it reads
     /// `MESH_ADMIN_ADDR` from config.
+    ///
+    /// When `query_engine` is provided, it is handed to the admin
+    /// agent so that `/v1/query` and `POST /v1/pyspy/…` can call into
+    /// the Python `QueryEngine` without a module-level global.
+    #[pyo3(signature = (instance, admin_addr=None, query_engine=None))]
     fn _spawn_admin(
         &self,
         instance: &PyInstance,
         admin_addr: Option<String>,
+        query_engine: Option<pyo3::Py<pyo3::PyAny>>,
     ) -> PyResult<PyPythonTask> {
         let admin_addr = admin_addr
             .map(|s| {
@@ -209,6 +215,12 @@ impl PyHostMesh {
                     .map_err(|e| PyException::new_err(format!("invalid admin_addr '{}': {}", s, e)))
             })
             .transpose()?;
+        // Set the pending engine *before* spawning, so that
+        // `MeshAdminAgent::init()` can `.take()` it synchronously.
+        // See `PENDING_QUERY_ENGINE` doc for concurrency caveats.
+        if let Some(engine) = query_engine {
+            hyperactor_mesh::mesh_admin::set_pending_query_engine(engine);
+        }
         let host_mesh = self.mesh_ref()?.clone();
         let instance = instance.clone();
         PyPythonTask::new(async move {

--- a/python/examples/query_workload.py
+++ b/python/examples/query_workload.py
@@ -1,0 +1,58 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-unsafe
+
+"""Minimal workload that starts telemetry and exposes /v1/query.
+
+Used by mesh_admin_integration tests to exercise the SQL query
+endpoint end-to-end.
+"""
+
+import asyncio
+
+from monarch._src.actor.host_mesh import this_host
+from monarch.actor import Actor, endpoint
+from monarch.distributed_telemetry.actor import start_telemetry
+
+
+class PingWorker(Actor):
+    """Trivial actor that populates the actors/messages tables."""
+
+    @endpoint
+    async def ping(self) -> None:
+        pass
+
+
+async def async_main() -> None:
+    engine = start_telemetry(batch_size=10, include_dashboard=False)
+
+    host = this_host()
+    admin_url = await host._spawn_admin(query_engine=engine)
+
+    # Spawn workers and populate data BEFORE printing the sentinel.
+    # The harness treats the sentinel as "ready to query", so all
+    # telemetry tables must be populated first.
+    procs = host.spawn_procs(per_host={"replica": 2})
+    workers = procs.spawn("query_worker", PingWorker)
+    await workers.initialized
+    await workers.ping.call()
+
+    print(f"Mesh admin server listening on {admin_url}", flush=True)
+
+    try:
+        await asyncio.sleep(float("inf"))
+    except (KeyboardInterrupt, asyncio.CancelledError):
+        pass
+    finally:
+        await procs.stop()
+
+
+def main() -> None:
+    try:
+        asyncio.run(async_main())
+    except KeyboardInterrupt:
+        pass

--- a/python/monarch/_rust_bindings/monarch_hyperactor/host_mesh.pyi
+++ b/python/monarch/_rust_bindings/monarch_hyperactor/host_mesh.pyi
@@ -66,6 +66,7 @@ class HostMesh:
         self,
         instance: Instance,
         admin_addr: str | None = None,
+        query_engine: Any | None = None,
     ) -> PythonTask[str]:
         """
         Spawn a MeshAdminAgent on the head host's system proc and

--- a/python/monarch/_src/actor/host_mesh.py
+++ b/python/monarch/_src/actor/host_mesh.py
@@ -171,7 +171,11 @@ class HostMesh(MeshTrait):
             proc_bind,
         )
 
-    def _spawn_admin(self, admin_addr: Optional[str] = None) -> "Future[str]":
+    def _spawn_admin(
+        self,
+        admin_addr: Optional[str] = None,
+        query_engine: Optional[Any] = None,
+    ) -> "Future[str]":
         """
         Spawn a MeshAdminAgent on the head host's system proc and
         return its HTTP address.
@@ -186,6 +190,8 @@ class HostMesh(MeshTrait):
             admin_addr: Optional socket address for the admin HTTP server
                 (e.g. ``"[::]:1729"``). When ``None``, reads
                 ``MESH_ADMIN_ADDR`` from config.
+            query_engine: Optional ``QueryEngine`` instance to pass to the
+                admin agent for ``/v1/query`` and py-spy dump storage.
 
         Returns:
             Future[str]: The admin HTTP URL (e.g. ``"https://myhost.facebook.com:1729"``).
@@ -194,7 +200,9 @@ class HostMesh(MeshTrait):
         async def task() -> str:
             hy_mesh = await self._hy_host_mesh
             return await hy_mesh._spawn_admin(
-                context().actor_instance._as_rust(), admin_addr
+                context().actor_instance._as_rust(),
+                admin_addr,
+                query_engine,
             )
 
         return Future(coro=task())


### PR DESCRIPTION
Summary:
Adds POST /v1/query route that executes SQL against distributed
telemetry DataFusion tables and returns JSON array of objects.

Introduces a process-level Mutex<Option<Py<PyAny>>> handoff for the
Python QueryEngine: the PyO3 bridge sets it before sending
SpawnMeshAdmin, and init() takes it into BridgeState.query_engine.
This replaces the GIL roundtrip on every HTTP request.

_spawn_admin now accepts an optional query_engine parameter
(Rust, Python wrapper, and type stub updated).

Differential Revision: D97898001


