### PR TITLE
Use npx for building frontend (#3181)

### DIFF
--- a/python/monarch/monarch_dashboard/frontend/package.json
+++ b/python/monarch/monarch_dashboard/frontend/package.json
@@ -11,7 +11,7 @@
     "esbuild": "^0.27.4"
   },
   "scripts": {
-    "build": "node node_modules/esbuild/bin/esbuild src/index.tsx --bundle --outfile=build/static/js/main.js --loader:.tsx=tsx --loader:.ts=ts --loader:.css=css --jsx=automatic --minify --target=es2020 --define:process.env.NODE_ENV=\\\"production\\\"",
+    "build": "npx esbuild src/index.tsx --bundle --outfile=build/static/js/main.js --loader:.tsx=tsx --loader:.ts=ts --loader:.css=css --jsx=automatic --minify --target=es2020 --define:process.env.NODE_ENV=\\\"production\\\"",
     "test": "echo \"no test runner configured\""
   },
   "proxy": "http://localhost:5199",


### PR DESCRIPTION
Summary:

CI currently fails with 
```
> monarch-dashboard@0.1.0 build
> node node_modules/esbuild/bin/esbuild src/index.tsx --bundle --outfile=build/static/js/main.js --loader:.tsx=tsx --loader:.ts=ts --loader:.css=css --jsx=automatic --minify --target=es2020 --define:process.env.NODE_ENV=\"production\"

/meta-pytorch/monarch/python/monarch/monarch_dashboard/frontend/node_modules/esbuild/bin/esbuild:1
ELF� �@�8@@@@PPxxxdd�8J�8JKLLXvHXvH��� �Q�td�(J}LK � k j�. ��:k�:j ��Hk�Hj��Hk�Hjx-) C��x ����!� ����B�  �� ��(� `)�`)��� P��$cxxd���SGodGqNPiwG-XY328GXWIIA/m1ThY8mdyPlGWiXz68oT/Gx8lnVZkuojmNr3DZ0C2/1Nh1i54Y1XBurF5Ar2MIGNU�Q+(��j7�s�S`����_��@��c0�iT������#�@ӛL�{�!�c@�_��T��T`@���_��B��_�|�`hd�b�A@���_��B��_�������� ��#9��E���#9�������@��_�\9 @��_� �\9!@�?DqaT @��_����_�@��_� �P@9�6\9c@�cD� �T4�!�;xc�`� ����@���
^
```
use `npx` instead of native esbuild binary

Differential Revision: D97981969


