### PR TITLE
fetch_disabled_tests.py: skip overwrite if files exist; add --force and report fetched skips

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,6 +333,29 @@ Closing the issue re-enables the test on the next run.
 - **Python (pytest):** use the test function name, e.g.
   `DISABLED test_my_function`
 
+### Overriding skips locally
+
+To run a test that is currently disabled via a GitHub issue, you can override
+the fetched skip lists by creating the files before running
+`scripts/fetch_disabled_tests.py`. The script will not overwrite files that
+already exist:
+
+- **`disabled_tests.txt`** — controls which Python tests are skipped. Create
+  this file with only the tests you want to skip (or leave it empty to skip
+  none).
+- **`.config/nextest-filter.txt`** — controls which Rust tests are skipped.
+  Write a nextest filter expression here (e.g. `all()` to run all tests, or
+  `not (test(some_test))` to skip only specific ones).
+
+For example, to run all tests locally regardless of open issues:
+
+```sh
+echo -n "" > disabled_tests.txt
+echo "all()" > .config/nextest-filter.txt
+uv run python scripts/fetch_disabled_tests.py   # will skip both writes
+uv run pytest python/tests/ -v -m "not oss_skip"
+```
+
 ## License
 
 Monarch is BSD-3 licensed, as found in the [LICENSE](LICENSE) file.

--- a/scripts/fetch_disabled_tests.py
+++ b/scripts/fetch_disabled_tests.py
@@ -21,6 +21,7 @@ Outputs:
 
 from __future__ import annotations
 
+import argparse
 import json
 import os
 import sys
@@ -58,7 +59,12 @@ def fetch_disabled_test_names() -> list[str]:
     ]
 
 
-def write_disabled_tests(names: list[str]) -> None:
+def write_disabled_tests(names: list[str], *, force: bool = False) -> None:
+    if _DISABLED_TESTS_FILE.exists() and not force:
+        print(
+            f"Skipping write: {_DISABLED_TESTS_FILE} already exists (override active)."
+        )
+        return
     _DISABLED_TESTS_FILE.write_text("\n".join(names) + ("\n" if names else ""))
     if names:
         print(f"Wrote {len(names)} disabled test(s) to {_DISABLED_TESTS_FILE}:")
@@ -87,13 +93,18 @@ def _nextest_predicate(name: str) -> str:
     return f"test({name})"
 
 
-def write_nextest_filter(names: list[str]) -> None:
+def write_nextest_filter(names: list[str], *, force: bool = False) -> None:
     """Write the nextest -E filter expression to .config/nextest-filter.txt.
 
     CI scripts read this file and pass the value to `cargo nextest run -E`.
     When there are no disabled tests the file contains "all()" so the -E
     flag can be unconditional.
     """
+    if _NEXTEST_FILTER_FILE.exists() and not force:
+        print(
+            f"Skipping write: {_NEXTEST_FILTER_FILE} already exists (override active)."
+        )
+        return
     if names:
         predicates = " | ".join(_nextest_predicate(n) for n in names)
         expr = f"not ({predicates})"
@@ -105,9 +116,23 @@ def write_nextest_filter(names: list[str]) -> None:
 
 
 def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Overwrite existing override files instead of skipping them.",
+    )
+    args = parser.parse_args()
+
     names = fetch_disabled_test_names()
-    write_disabled_tests(names)
-    write_nextest_filter(names)
+    if names:
+        print(f"Found {len(names)} disabled test(s) from GitHub issues:")
+        for name in names:
+            print(f"  {name}")
+    else:
+        print("No disabled tests found in GitHub issues.")
+    write_disabled_tests(names, force=args.force)
+    write_nextest_filter(names, force=args.force)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #3188
* #3157

If disabled_tests.txt or .config/nextest-filter.txt already exist when
fetch_disabled_tests.py runs, the script now leaves them untouched so
local overrides are preserved.  Use --force to overwrite them anyway.

The script also prints the list of tests it found in GitHub issues at
the start of every run, regardless of whether it writes any files.

Differential Revision: [D97990695](https://our.internmc.facebook.com/intern/diff/D97990695/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D97990695/)!