### PR TITLE
Add missing ROCm compatibility aliases for CUDA constants

### DIFF
--- a/rdmaxcel-sys/src/lib.rs
+++ b/rdmaxcel-sys/src/lib.rs
@@ -52,6 +52,11 @@ mod inner {
         // Pointer attributes
         pub const CU_POINTER_ATTRIBUTE_MEMORY_TYPE: hipPointer_attribute =
             HIP_POINTER_ATTRIBUTE_MEMORY_TYPE;
+        pub const CU_POINTER_ATTRIBUTE_DEVICE_ORDINAL: hipPointer_attribute =
+            HIP_POINTER_ATTRIBUTE_DEVICE_ORDINAL;
+
+        // Memory types
+        pub const CU_MEMORYTYPE_DEVICE: u32 = 2; // hipMemoryTypeDevice = 2
 
         // Memory handle types
         pub const CU_MEM_RANGE_HANDLE_TYPE_DMA_BUF_FD: hipMemRangeHandleType =


### PR DESCRIPTION
Add two missing aliases to the rocm_compat module that were introduced after the initial ROCm support was merged:

- CU_POINTER_ATTRIBUTE_DEVICE_ORDINAL: Used in manager_actor.rs for per-device RDMA NIC mapping (added in PR #3043)
- CU_MEMORYTYPE_DEVICE: Used in local_memory.rs for detecting CUDA device pointers (added in PR #2856)

Without these aliases, ROCm builds fail with undefined symbol errors.

Functional CI on ROCm will catch these things in the future.