### PR TITLE
[hyperactor_mesh] simplify MeshFailure to use crashed_ranks only

### DIFF
--- a/hyperactor_mesh/src/actor_mesh.rs
+++ b/hyperactor_mesh/src/actor_mesh.rs
@@ -201,7 +201,6 @@ impl<A: Referable> ActorMesh<A> {
             let health_state = entry.get_mut();
             health_state.unhealthy_event = Some(Unhealthy::StreamClosed(MeshFailure {
                 actor_mesh_name: Some(self.name().to_string()),
-                rank: None,
                 event: ActorSupervisionEvent::new(
                     // Use an actor id from the mesh.
                     ndslice::view::Ranked::get(&self.current_ref, 0)
@@ -212,6 +211,7 @@ impl<A: Referable> ActorMesh<A> {
                     ActorStatus::Stopped("mesh stopped".to_string()),
                     None,
                 ),
+                crashed_ranks: vec![],
             }));
         }
         // Also take the controller from the ref, since that is used for
@@ -725,11 +725,14 @@ impl<A: Referable> ActorMeshRef<A> {
                     // whole mesh.
                     if let MessageOrFailure::Message(message) = message {
                         if let Some(message) = &message {
-                            if let Some(rank) = &message.rank {
-                                ndslice::view::Ranked::region(self).slice().contains(*rank)
-                            } else {
-                                // If rank is None, it applies to the whole mesh.
+                            let region = ndslice::view::Ranked::region(self).slice();
+                            if message.crashed_ranks.is_empty() {
+                                // Whole-mesh event (e.g. mesh stop).
                                 true
+                            } else {
+                                // Accept if any crashed rank overlaps with
+                                // this slice's region.
+                                message.crashed_ranks.iter().any(|r| region.contains(*r))
                             }
                         } else {
                             // Filter out messages that are not failures. These are used
@@ -771,7 +774,6 @@ impl<A: Referable> ActorMeshRef<A> {
                     // the controller is unreachable.
                     Ok(MeshFailure {
                         actor_mesh_name: Some(self.name().to_string()),
-                        rank: None,
                         event: ActorSupervisionEvent::new(
                             controller.actor_id().clone(),
                             None,
@@ -782,18 +784,20 @@ impl<A: Referable> ActorMeshRef<A> {
                             )),
                             None,
                         ),
+                        crashed_ranks: vec![],
                     })
                 }
             }?
         };
         // Update the health state now that we have received a message.
-        let rank = message.rank.unwrap_or_default();
         let event = &message.event;
         // Make sure not to hold this lock across an await point.
         let mut entry = self.health_state.entry(cx).or_default();
         let health_state = entry.get_mut();
         if let ActorStatus::Failed(_) = event.actor_status {
-            health_state.crashed_ranks.insert(rank, event.clone());
+            for &rank in &message.crashed_ranks {
+                health_state.crashed_ranks.insert(rank, event.clone());
+            }
         }
         health_state.unhealthy_event = match &event.actor_status {
             ActorStatus::Failed(_) => Some(Unhealthy::Crashed(message.clone())),

--- a/hyperactor_mesh/src/mesh_controller.rs
+++ b/hyperactor_mesh/src/mesh_controller.rs
@@ -382,17 +382,19 @@ impl<A: Referable> Handler<Subscribe> for ActorMeshController<A> {
         // If we can't send a message to a subscriber, the subscriber might be gone.
         // That shouldn't cause this actor to exit.
         // This is handled by the handle_undeliverable_message method.
-        match &self.health_state.unhealthy_event {
-            None => {}
-            // For an adverse event like stopped or crashed, send a notification
-            // immediately. This represents an initial bad state, if subscribing
-            // to an already-dead mesh.
-            Some(Unhealthy::StreamClosed(msg)) => {
-                send_subscriber_message(cx, &message.0, msg.clone());
-            }
-            Some(Unhealthy::Crashed(msg)) => {
-                send_subscriber_message(cx, &message.0, msg.clone());
-            }
+        // If there are any crashed ranks, replay a failure event so the new
+        // subscriber learns about the current health state. We send a single
+        // message with all crashed ranks so the subscriber's filter can check
+        // overlap with its slice region. This avoids the watch-channel
+        // coalescing problem (sending per-rank messages would lose all but
+        // the last one).
+        if let Some(unhealthy) = &self.health_state.unhealthy_event {
+            let msg = match unhealthy {
+                Unhealthy::StreamClosed(msg) | Unhealthy::Crashed(msg) => msg,
+            };
+            let mut replay_msg = msg.clone();
+            replay_msg.crashed_ranks = self.health_state.crashed_ranks.keys().copied().collect();
+            send_subscriber_message(cx, &message.0, replay_msg);
         }
         let port_id = message.0.port_id().clone();
         if self.health_state.subscribers.insert(message.0) {
@@ -522,9 +524,8 @@ impl<A: Referable> Handler<resource::Stop> for ActorMeshController<A> {
         );
         let failure_message = MeshFailure {
             actor_mesh_name: Some(mesh_name.to_string()),
-            // Rank = none means it affects the whole mesh.
-            rank: None,
             event,
+            crashed_ranks: vec![],
         };
         self.health_state.unhealthy_event = Some(Unhealthy::StreamClosed(failure_message.clone()));
         // We don't send a message to the owner on stops, because only the owner
@@ -633,8 +634,8 @@ fn send_state_change(
 
     let failure_message = MeshFailure {
         actor_mesh_name: Some(mesh_name.to_string()),
-        rank: Some(rank),
         event: event.clone(),
+        crashed_ranks: vec![rank],
     };
     health_state.crashed_ranks.insert(rank, event.clone());
     health_state.unhealthy_event = Some(if is_proc_stopped {

--- a/hyperactor_mesh/src/supervision.rs
+++ b/hyperactor_mesh/src/supervision.rs
@@ -24,15 +24,21 @@ use typeuri::Named;
 pub struct MeshFailure {
     /// Name of the mesh which the event originated from.
     pub actor_mesh_name: Option<String>,
-    /// Rank of the mesh from which the event originated.
-    /// TODO: Point instead?
-    pub rank: Option<usize>,
     /// The supervision event on an actor located at mesh + rank.
     pub event: ActorSupervisionEvent,
+    /// The set of crashed ranks in the mesh. Empty means the event
+    /// applies to the whole mesh (e.g. mesh stop, controller timeout).
+    pub crashed_ranks: Vec<usize>,
 }
 wirevalue::register_type!(MeshFailure);
 
 impl MeshFailure {
+    /// Returns true if the given rank is part of this failure.
+    /// A whole-mesh event (empty crashed_ranks) contains every rank.
+    pub fn contains_rank(&self, rank: usize) -> bool {
+        self.crashed_ranks.is_empty() || self.crashed_ranks.contains(&rank)
+    }
+
     /// Helper function to handle a message to an actor that just wants to forward
     /// it to the next owner.
     pub fn default_handler(&self, cx: &impl context::Actor) -> Result<(), anyhow::Error> {
@@ -57,15 +63,15 @@ impl std::fmt::Display for MeshFailure {
             .as_ref()
             .map(|m| format!(" on mesh \"{}\"", m))
             .unwrap_or("".to_string());
-        let rank = self
-            .rank
-            .as_ref()
-            .map(|r| format!(" at rank {}", r))
-            .unwrap_or("".to_string());
+        let ranks = if self.crashed_ranks.is_empty() {
+            String::new()
+        } else {
+            format!(" at ranks {:?}", self.crashed_ranks)
+        };
         write!(
             f,
             "failure{}{} with event: {}",
-            actor_mesh_name, rank, self.event
+            actor_mesh_name, ranks, self.event
         )
     }
 }

--- a/monarch_hyperactor/src/actor.rs
+++ b/monarch_hyperactor/src/actor.rs
@@ -987,8 +987,8 @@ impl Actor for PythonActor {
             &cx,
             MeshFailure {
                 actor_mesh_name: None,
-                rank: None,
                 event: event.clone(),
+                crashed_ranks: vec![],
             },
         )
         .await

--- a/monarch_hyperactor/src/supervision.rs
+++ b/monarch_hyperactor/src/supervision.rs
@@ -124,12 +124,12 @@ impl std::fmt::Display for PyMeshFailure {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "MeshFailure(mesh_name={}, rank={}, event={})",
+            "MeshFailure(mesh_name={}, crashed_ranks={:?}, event={})",
             self.inner
                 .actor_mesh_name
                 .clone()
                 .unwrap_or("<none>".into()),
-            self.inner.rank.map_or("<none>".into(), |r| r.to_string()),
+            self.inner.crashed_ranks,
             self.inner.event
         )
     }

--- a/python/tests/test_actor_error.py
+++ b/python/tests/test_actor_error.py
@@ -1319,7 +1319,7 @@ async def test_supervise_callback_with_mesh_ref():
     # Supervision events may arrive out of order; check that each rank
     # appears somewhere in the list.
     for rank in range(len(r)):
-        assert any(f"rank={rank}" in msg for msg in r), (
+        assert any(f"crashed_ranks=[{rank}]" in msg for msg in r), (
             f"rank={rank} not found in any message"
         )
     for msg in r:
@@ -1349,7 +1349,7 @@ async def test_supervise_callback_when_procs_killed():
     # Supervision events may arrive out of order; check that each rank
     # appears somewhere in the list.
     for rank in range(len(result)):
-        assert any(f"rank={rank}" in msg for msg in result), (
+        assert any(f"crashed_ranks=[{rank}]" in msg for msg in result), (
             f"rank={rank} not found in any message"
         )
     for msg in result:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #3000
* #3194
* __->__ #3193

Simplifies `MeshFailure` by removing the `rank: Option<usize>` field
and replacing `crashed_ranks: Option<Vec<usize>>` with a
non-optional `crashed_ranks: Vec<usize>` that always represents the
current failure state:

- Non-empty: specific ranks that crashed (single rank for live events,
  multiple for replay).
- Empty: whole-mesh event (mesh stop, controller timeout).

This eliminates the dual rank/crashed_ranks representation and the
`Option` layering. A new `MeshFailure::contains_rank(rank)` helper
returns true if the failure applies to a given rank (empty = all ranks).

The watch-channel coalescing fix is preserved: during `Subscribe`
replay, the controller sends a single message with all crashed rank
indices, and the subscriber's `wait_for` filter checks overlap with
its slice region.

Changes:
- `supervision.rs`: remove `rank` field, flatten `crashed_ranks` to
  `Vec<usize>`, add `contains_rank()`, update `Display`.
- `mesh_controller.rs`: update all `MeshFailure` construction sites —
  `send_state_change` uses `vec![rank]`, stop uses `vec![]`, replay
  copies crashed_ranks directly.
- `actor_mesh.rs`: simplify filter to single branch (empty = accept
  all, else check overlap), update health state to iterate
  `crashed_ranks`.
- `monarch_hyperactor/src/actor.rs`: update construction.
- `monarch_hyperactor/src/supervision.rs`: update `PyMeshFailure`
  display to show `crashed_ranks`.

Differential Revision: [D98019212](https://our.internmc.facebook.com/intern/diff/D98019212/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D98019212/)!