### PR TITLE
[monarch] fix shutdown resource leak in rapid spawn/exit cycles

### DIFF
--- a/hyperactor_mesh/src/actor_mesh.rs
+++ b/hyperactor_mesh/src/actor_mesh.rs
@@ -175,9 +175,9 @@ impl<A: Referable> ActorMesh<A> {
 
             let statuses = rx.recv().await?;
             if let Some(state) = &statuses.state {
-                // Check that all actors are in some terminal state.
-                // Failed is ok, because one of these actors may have failed earlier
-                // and we're trying to stop the others.
+                // Check that all actors are in a terminating state (Stopping
+                // or beyond). The actual wait for full cleanup (terminal)
+                // happens in _drain_and_stop via the controller's status watch.
                 let all_stopped = state.statuses.values().all(|s| s.is_terminating());
                 if all_stopped {
                     Ok(())

--- a/hyperactor_mesh/src/mesh_controller.rs
+++ b/hyperactor_mesh/src/mesh_controller.rs
@@ -118,6 +118,8 @@ impl HealthState {
         match self.statuses.entry(point) {
             Entry::Occupied(mut entry) => {
                 let (old_status, old_gen) = entry.get();
+                // Once a resource enters a terminating state (including Stopping),
+                // its status is frozen — later updates are ignored.
                 if old_status.is_terminating() || *old_gen > generation {
                     return false;
                 }
@@ -766,6 +768,8 @@ impl<A: Referable> Handler<resource::State<ActorState>> for ActorMeshController<
             );
         }
 
+        // Once every rank has begun terminating (Stopping or beyond),
+        // the monitor is no longer needed.
         if self
             .health_state
             .statuses
@@ -917,9 +921,9 @@ impl<A: Referable> Handler<CheckState> for ActorMeshController<A> {
         }
         // If there was any state change, we don't need to send a heartbeat.
         let mut did_send_state_change = false;
-        // True if any rank is in a terminal status. Once that is true, no more
-        // heartbeats are sent.
-        let mut is_terminal = false;
+        // True if any rank is terminating (Stopping or beyond). Once set,
+        // no more heartbeats are sent.
+        let mut any_terminating = false;
         // This returned point is the created rank, *not* the rank of
         // the possibly sliced input mesh.
         for (point, state) in events.unwrap().iter() {
@@ -928,12 +932,10 @@ impl<A: Referable> Handler<CheckState> for ActorMeshController<A> {
                 state.status.clone(),
                 state.generation,
             );
-            // If the status of any rank is terminal, we don't want to send
-            // a heartbeat message.
-            if !is_terminal {
+            if !any_terminating {
                 if let Some((s, _)) = self.health_state.statuses.get(&point) {
                     if s.is_terminating() {
-                        is_terminal = true;
+                        any_terminating = true;
                     }
                 }
             }
@@ -954,7 +956,7 @@ impl<A: Referable> Handler<CheckState> for ActorMeshController<A> {
                 &mut self.health_state,
             );
         }
-        if !did_send_state_change && !is_terminal {
+        if !did_send_state_change && !any_terminating {
             // No state change, but subscribers need to be sent a message
             // every so often so they know the controller is still alive.
             // Send a "no state change" message.
@@ -962,20 +964,19 @@ impl<A: Referable> Handler<CheckState> for ActorMeshController<A> {
             send_heartbeat(cx, &self.health_state);
         }
 
-        // If all ranks are in a terminal state, we don't need to continue checking,
-        // as statuses cannot change.
-        // Any new subscribers will get an immediate message saying the mesh is stopped.
-        let all_ranks_terminal = self
+        // Once every rank has begun terminating, no further state changes
+        // are possible — stop polling and drop the monitor.
+        let all_terminating = self
             .health_state
             .statuses
             .values()
             .all(|(s, _)| s.is_terminating());
-        if !all_ranks_terminal {
+        if !all_terminating {
             // Schedule a self send after a waiting period.
             self.self_check_state_message(cx)?;
         } else {
-            // There's no need to send a stop message during cleanup if all the
-            // ranks are already terminal.
+            // There's no need to send a stop message during cleanup if all
+            // ranks are already terminating.
             self.monitor.take();
         }
         return Ok(());

--- a/hyperactor_mesh/src/proc_mesh.rs
+++ b/hyperactor_mesh/src/proc_mesh.rs
@@ -1308,9 +1308,9 @@ impl ProcMeshRef {
         .await
         {
             Ok(statuses) => {
-                // Check that all actors are in some terminal state.
-                // Failed is ok, because one of these actors may have failed earlier
-                // and we're trying to stop the others.
+                // Check that all actors are in a terminating state (Stopping
+                // or beyond). Failed is ok, because one of these actors may
+                // have failed earlier and we're trying to stop the others.
                 let all_stopped = statuses.values().all(|s| s.is_terminating());
                 if all_stopped {
                     Ok(statuses)

--- a/hyperactor_mesh/src/resource.rs
+++ b/hyperactor_mesh/src/resource.rs
@@ -90,7 +90,7 @@ pub enum Status {
 }
 
 impl Status {
-    /// Returns whether the status is a terminating status.
+    /// Returns whether the status is a terminating status (includes `Stopping`).
     pub fn is_terminating(&self) -> bool {
         matches!(
             self,

--- a/monarch_extension/src/mesh_controller.rs
+++ b/monarch_extension/src/mesh_controller.rs
@@ -234,10 +234,25 @@ impl _Controller {
         signal_safe_block_on(py, async move { stop_worker_receiver.recv().await })?
             .map_err(to_py_error)?
             .map_err(PyRuntimeError::new_err)?;
+
+        // Get status watch before sending drain_and_stop so we can
+        // wait for the actor to fully terminate.
+        let mut status_rx = self.controller_handle.blocking_lock().status();
+
         self.controller_handle
             .blocking_lock()
             .drain_and_stop("mesh controller shutdown")
-            .map_err(to_py_error)
+            .map_err(to_py_error)?;
+
+        // Wait for the MeshControllerActor to reach terminal status.
+        // This ensures all resources (mailbox, IPC sessions, etc.) are
+        // fully cleaned up before we return, preventing accumulation of
+        // stale state across rapid spawn/exit cycles.
+        signal_safe_block_on(py, async move {
+            let _ = status_rx.wait_for(ActorStatus::is_terminal).await;
+        })?;
+
+        Ok(())
     }
 }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #3000
* __->__ #3194
* #3193

`_drain_and_stop` was fire-and-forget: it sent `Signal::DrainAndStop`
to the MeshControllerActor but returned immediately without waiting
for the actor to fully terminate. Over rapid spawn/exit cycles, this
allowed old actors' cleanup tasks (stopping children, closing
mailboxes, tearing down IPC sessions) to overlap with new actors
being spawned, accumulating background work on the tokio runtime.

This could overwhelm the IPC channel's bounded deliver buffer
(capacity 1024), causing `recv_connected` to block on
`deliver_tx.send().await`, which prevents ack sending. After 30s
without an ack, the sender declares the link broken and all pending
messages fail — including the `sync_at_exit` reply that Python is
blocking on.

Fix: `_drain_and_stop` now awaits the MeshControllerActor reaching
terminal status via `status_rx.wait_for(ActorStatus::is_terminal)`,
ensuring full cleanup before returning.

Also clarifies `is_terminating` usage throughout the stop path:
`ActorMesh::stop` and `ProcMesh::stop` check `is_terminating`
(includes `Stopping`) intentionally — they confirm the stop has been
initiated, not that cleanup is complete. Renames variables and updates
comments in `MeshControllerActor` to reflect this.

Differential Revision: [D98019214](https://our.internmc.facebook.com/intern/diff/D98019214/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D98019214/)!