### PR TITLE
fix(chunked_fuse): lazy fallback to st_ctime for macOS crtime field

### DIFF
--- a/monarch_extension/src/chunked_fuse.rs
+++ b/monarch_extension/src/chunked_fuse.rs
@@ -86,12 +86,22 @@ fn extract_attr(dict: &Bound<'_, PyDict>, kind: FileType) -> PyResult<FileAttr> 
         atime: f64_to_system_time(required_key(dict, "st_atime")?),
         mtime: f64_to_system_time(required_key(dict, "st_mtime")?),
         ctime: f64_to_system_time(required_key(dict, "st_ctime")?),
+        #[cfg(target_os = "macos")]
+        crtime: f64_to_system_time(
+            dict.get_item("st_birthtime")?
+                .map(|value| value.extract())
+                .transpose()?
+                .map(Ok)
+                .unwrap_or_else(|| required_key(dict, "st_ctime"))?,
+        ),
         kind,
         perm: (required_key::<u32>(dict, "st_mode")? & 0o7777) as u16,
         nlink: required_key(dict, "st_nlink")?,
         uid: required_key(dict, "st_uid")?,
         gid: required_key(dict, "st_gid")?,
         rdev: 0,
+        #[cfg(target_os = "macos")]
+        flags: 0,
         blksize: 4096,
     })
 }


### PR DESCRIPTION
Full disclosure: I'm not a rust guy, nor am I a mac person. An agent proposed this to resolve a build failure I was having, other agents agreed, and having made the change the build now succeeds. Below is a summary generated by one such agent.

## Summary
On macOS, fuse3's FileAttr struct requires two extra fields not present on Linux: crtime (file creation time) and flags. This PR adds both.

For crtime, the implementation prefers st_birthtime from the Python stat dict when available (e.g. on real macOS filesystems), and falls back to st_ctime when the key is absent (e.g. when the remote filesystem or Python stat implementation doesn't populate it). This avoids panics/errors when mounting a FUSE filesystem on macOS against a remote that doesn't expose birthtime.

flags is set to 0 as there are no relevant BSD file flags to propagate.

Both fields are gated with #[cfg(target_os = "macos")] so Linux builds are unaffected.

## Changes
chunked_fuse.rs: In extract_attr, conditionally populate crtime (with lazy st_ctime fallback) and flags on macOS.

## Testing
Compile-tested on macOS. The fallback path handles filesystems that don't expose st_birthtime without returning an error.

Note: `USE_TENSOR_ENGINE=0 uv sync` resulted in an updated `uv.lock` package entry for `name = "py-spy"`. I assume this is unrelated to these changes and is down to an outdated `uv.lock` file in the repo.