### PR TITLE
Add pyspy dump routing and dashboard query/storage endpoints

### DIFF
--- a/python/monarch/distributed_telemetry/actor.py
+++ b/python/monarch/distributed_telemetry/actor.py
@@ -22,7 +22,7 @@ variable and used by the DistributedTelemetryActor when it initializes.
 import functools
 import logging
 import os
-from typing import Any, Callable, Dict, List, Optional
+from typing import Any, Callable, Dict, List, NamedTuple, Optional
 
 from monarch._rust_bindings.monarch_distributed_telemetry.database_scanner import (
     DatabaseScanner,
@@ -37,12 +37,20 @@ from monarch._src.actor.proc_mesh import (
     register_proc_mesh_spawn_callback,
     SetupActor,
 )
-from monarch.actor import Actor, current_rank, endpoint, this_proc
+from monarch.actor import Actor, context, current_rank, endpoint, this_proc
 from monarch.distributed_telemetry.engine import QueryEngine
 from monarch.monarch_dashboard.server.app import start_dashboard
 from monarch.monarch_dashboard.server.query_engine_adapter import QueryEngineAdapter
 
 logger: logging.Logger = logging.getLogger(__name__)
+
+
+class _ChildEntry(NamedTuple):
+    """Index entry mapping a proc_id to the child mesh and its rank kwargs."""
+
+    mesh: Any  # ActorMesh
+    rank_kwargs: Dict[str, int]
+
 
 # Module-level scanner created at process startup to avoid race conditions.
 _scanner: Optional[DatabaseScanner] = None
@@ -104,6 +112,10 @@ class DistributedTelemetryActor(Actor):
 
         self._children: Dict[str, Any] = {}
         self._num_procs_processed: int = 0
+        self._proc_id: str = context().actor_instance.proc_id
+        # Lazily built index: proc_id → _ChildEntry for targeted routing
+        # in store_pyspy_dump.
+        self._proc_id_index: Dict[str, _ChildEntry] = {}
 
     def __supervise__(self, failure: MeshFailure) -> bool:
         """Handle child mesh failures gracefully.
@@ -115,7 +127,16 @@ class DistributedTelemetryActor(Actor):
         Note: stopping a ProcMesh loses process-local telemetry data from
         those children.
         """
-        self._children.pop(failure.mesh_name, None)
+        removed = self._children.pop(failure.mesh_name, None)
+        if removed is not None:
+            # Purge stale proc_id_index entries for the dead child.
+            stale = [
+                pid
+                for pid, entry in self._proc_id_index.items()
+                if entry.mesh is removed
+            ]
+            for pid in stale:
+                del self._proc_id_index[pid]
         logger.info("child mesh failed: %s", failure.mesh_name)
         return True
 
@@ -136,11 +157,27 @@ class DistributedTelemetryActor(Actor):
             mesh_name: str = actor_mesh._name.get()
             self._children[mesh_name] = actor_mesh
             self._num_procs_processed += 1
+            self._index_child(actor_mesh)
+
+    def _index_child(self, child_mesh: Any) -> None:
+        """Query child mesh proc_ids and populate ``_proc_id_index``."""
+        try:
+            # pyre-ignore[29]: child_mesh is an ActorMesh
+            proc_ids = child_mesh.get_proc_id.call().get()
+            for point, pid in proc_ids.items():
+                self._proc_id_index[pid] = _ChildEntry(child_mesh, dict(point))
+        except Exception:
+            logger.warning("failed to index child proc_ids, skipping")
 
     @endpoint
     def ready(self) -> None:
         """No-op endpoint to confirm actor is initialized."""
         pass
+
+    @endpoint
+    def get_proc_id(self) -> str:
+        """Return the proc_id of this actor's proc."""
+        return self._proc_id
 
     @endpoint
     def table_names(self) -> List[str]:
@@ -158,6 +195,7 @@ class DistributedTelemetryActor(Actor):
         # pyre-ignore[16]: children is an ActorMesh with _name
         mesh_name: str = children._name.get()
         self._children[mesh_name] = children
+        self._index_child(children)
 
     @endpoint
     def apply_retention(self, table_name: str, where_clause: str) -> None:
@@ -170,12 +208,88 @@ class DistributedTelemetryActor(Actor):
             except Exception:
                 logger.info("child apply_retention failed, skipping")
 
+    def _route_to_children(
+        self, dump_id: str, proc_ref: str, pyspy_result_json: str
+    ) -> bool:
+        """Route pyspy dump to the matching child. Returns True if a child stored it."""
+        self._spawn_missing_children()
+
+        entry = self._proc_id_index.get(proc_ref)
+        if entry is not None:
+            try:
+                # pyre-ignore[29]: entry.mesh is an ActorMesh
+                result = (
+                    entry.mesh.slice(**entry.rank_kwargs)
+                    .try_store_pyspy_dump.call_one(dump_id, proc_ref, pyspy_result_json)
+                    .get()
+                )
+                if result:
+                    return True
+            except Exception:
+                logger.info("targeted store_pyspy_dump failed for %s", proc_ref)
+
+        # Fallback: fan out to all children concurrently (e.g. index stale
+        # after mesh topology change).
+        futures = []
+        for child_mesh in self._children.values():
+            try:
+                # pyre-ignore[29]: child_mesh is an ActorMesh
+                futures.append(
+                    child_mesh.try_store_pyspy_dump.call(
+                        dump_id, proc_ref, pyspy_result_json
+                    )
+                )
+            except Exception:
+                logger.info("child store_pyspy_dump call failed, skipping")
+
+        for fut in futures:
+            try:
+                if any(fut.get().values()):
+                    return True
+            except Exception:
+                logger.info("child store_pyspy_dump failed, skipping")
+
+        return False
+
     @endpoint
     def store_pyspy_dump(
         self, dump_id: str, proc_ref: str, pyspy_result_json: str
-    ) -> None:
-        """Store py-spy dump data in the normalized pyspy DataFusion tables."""
+    ) -> bool:
+        """Store py-spy dump data in the pyspy DataFusion tables on the target proc.
+
+        If ``proc_ref`` matches this actor's proc, stores locally.
+        Otherwise routes to the matching child. If no child in the
+        tree matches, the root coordinator stores it so data is not lost.
+
+        Returns True if this actor or a descendant stored the dump.
+        """
+        if proc_ref == self._proc_id:
+            self._scanner.store_pyspy_dump_py(dump_id, proc_ref, pyspy_result_json)
+            return True
+
+        if self._route_to_children(dump_id, proc_ref, pyspy_result_json):
+            return True
+
+        # No proc in the tree matched; store on this (root) coordinator
+        # so the data is not lost.
+        logger.info("no child matched proc_ref %s, storing on root", proc_ref)
         self._scanner.store_pyspy_dump_py(dump_id, proc_ref, pyspy_result_json)
+        return True
+
+    @endpoint
+    def try_store_pyspy_dump(
+        self, dump_id: str, proc_ref: str, pyspy_result_json: str
+    ) -> bool:
+        """Try to store the dump on the matching proc. Returns True if stored.
+
+        Unlike ``store_pyspy_dump``, this does not fall back to root storage.
+        Used for recursive child routing.
+        """
+        if proc_ref == self._proc_id:
+            self._scanner.store_pyspy_dump_py(dump_id, proc_ref, pyspy_result_json)
+            return True
+
+        return self._route_to_children(dump_id, proc_ref, pyspy_result_json)
 
     @endpoint
     def scan(

--- a/python/monarch/monarch_dashboard/server/db.py
+++ b/python/monarch/monarch_dashboard/server/db.py
@@ -48,6 +48,12 @@ class DBAdapter(ABC):
         rows = self.query(sql)
         return rows[0] if rows else None
 
+    def store_pyspy_dump(  # noqa: B027
+        self, dump_id: str, proc_ref: str, pyspy_result_json: str
+    ) -> None:
+        """Store a py-spy dump result. No-op by default."""
+        pass
+
 
 # ---------------------------------------------------------------------------
 # SQLite adapter — local dev/testing
@@ -109,6 +115,16 @@ def _get_adapter() -> DBAdapter:
     if _adapter is None:
         raise RuntimeError("db.init() or db.set_adapter() must be called first")
     return _adapter
+
+
+def raw_query(sql: str) -> list[dict[str, Any]]:
+    """Execute a raw SQL query (no placeholder substitution)."""
+    return _get_adapter().query(sql)
+
+
+def store_pyspy_dump(dump_id: str, proc_ref: str, pyspy_result_json: str) -> None:
+    """Store a py-spy dump result via the current adapter."""
+    _get_adapter().store_pyspy_dump(dump_id, proc_ref, pyspy_result_json)
 
 
 def _sql_literal(value: Any) -> str:

--- a/python/monarch/monarch_dashboard/server/query_engine_adapter.py
+++ b/python/monarch/monarch_dashboard/server/query_engine_adapter.py
@@ -42,3 +42,11 @@ class QueryEngineAdapter(DBAdapter):
     def table_names(self) -> list[str]:
         """Return available table names from the telemetry engine."""
         return self._engine._actor.table_names.call_one().get()
+
+    def store_pyspy_dump(
+        self, dump_id: str, proc_ref: str, pyspy_result_json: str
+    ) -> None:
+        """Store a py-spy dump result in the DataFusion pyspy tables."""
+        self._engine._actor.store_pyspy_dump.call_one(
+            dump_id, proc_ref, pyspy_result_json
+        ).get()

--- a/python/monarch/monarch_dashboard/server/routes.py
+++ b/python/monarch/monarch_dashboard/server/routes.py
@@ -201,3 +201,47 @@ def list_sent_messages():
     """List sent messages.  Optional: ?sender_actor_id=1"""
     sender_id = request.args.get("sender_actor_id", type=int)
     return jsonify(_sanitize_for_js(db.list_sent_messages(sender_id)))
+
+
+# ---------------------------------------------------------------------------
+# SQL query
+# ---------------------------------------------------------------------------
+
+
+@api.route("/query", methods=["POST"])
+def query():
+    """Execute an arbitrary SQL query against the DataFusion engine."""
+    data = request.get_json()
+    if not data or "sql" not in data:
+        return jsonify({"error": "missing 'sql' in request body"}), 400
+    sql = data["sql"]
+    try:
+        rows = db.raw_query(sql)
+        return jsonify({"rows": rows})
+    except Exception as exc:
+        return jsonify({"error": str(exc)}), 400
+
+
+# ---------------------------------------------------------------------------
+# Py-spy dump storage
+# ---------------------------------------------------------------------------
+
+
+@api.route("/pyspy_dump", methods=["POST"])
+def pyspy_dump():
+    """Store a py-spy dump result in the DataFusion pyspy tables."""
+    data = request.get_json()
+    if not data:
+        return jsonify({"error": "missing request body"}), 400
+    dump_id = data.get("dump_id")
+    proc_ref = data.get("proc_ref")
+    pyspy_result_json = data.get("pyspy_result_json")
+    if not all([dump_id, proc_ref, pyspy_result_json]):
+        return jsonify(
+            {"error": "missing dump_id, proc_ref, or pyspy_result_json"}
+        ), 400
+    try:
+        db.store_pyspy_dump(dump_id, proc_ref, pyspy_result_json)
+        return jsonify({"status": "ok"})
+    except Exception as exc:
+        return jsonify({"error": str(exc)}), 500

--- a/python/monarch/monarch_dashboard/server/tests/test_routes.py
+++ b/python/monarch/monarch_dashboard/server/tests/test_routes.py
@@ -359,5 +359,53 @@ class SummaryRoutesTest(_RouteTestBase):
         self.assertIn("actor_meshes", hc)
 
 
+# ---------------------------------------------------------------------------
+# SQL query
+# ---------------------------------------------------------------------------
+
+
+class QueryRouteTest(_RouteTestBase):
+    def test_query_returns_rows(self):
+        resp = self.client.post(
+            "/api/query", json={"sql": "SELECT * FROM meshes LIMIT 1"}
+        )
+        self.assertEqual(resp.status_code, 200)
+        data = resp.get_json()
+        self.assertIn("rows", data)
+        self.assertGreater(len(data["rows"]), 0)
+
+    def test_query_missing_sql(self):
+        resp = self.client.post("/api/query", json={})
+        self.assertEqual(resp.status_code, 400)
+
+    def test_query_invalid_sql(self):
+        resp = self.client.post("/api/query", json={"sql": "NOT VALID SQL"})
+        self.assertEqual(resp.status_code, 400)
+
+
+# ---------------------------------------------------------------------------
+# Py-spy dump storage
+# ---------------------------------------------------------------------------
+
+
+class PyspyDumpRouteTest(_RouteTestBase):
+    def test_pyspy_dump_missing_body(self):
+        resp = self.client.post("/api/pyspy_dump", content_type="application/json")
+        self.assertEqual(resp.status_code, 400)
+
+    def test_pyspy_dump_missing_fields(self):
+        resp = self.client.post("/api/pyspy_dump", json={"dump_id": "x"})
+        self.assertEqual(resp.status_code, 400)
+
+    def test_pyspy_dump_ok_sqlite(self):
+        # SQLite adapter has no-op store_pyspy_dump — should succeed
+        resp = self.client.post(
+            "/api/pyspy_dump",
+            json={"dump_id": "d1", "proc_ref": "p1", "pyspy_result_json": "{}"},
+        )
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.get_json()["status"], "ok")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/python/tests/test_distributed_telemetry.py
+++ b/python/tests/test_distributed_telemetry.py
@@ -1244,6 +1244,192 @@ def test_pyspy_tables_in_information_schema(cleanup_callbacks) -> None:
 
 
 @pytest.mark.timeout(120)
+def test_try_store_pyspy_dump_routes_to_child(cleanup_callbacks) -> None:
+    """try_store_pyspy_dump routes to the correct child proc via _proc_id_index."""
+    engine = start_telemetry(batch_size=10, include_dashboard=False)
+
+    job = ProcessJob({"hosts": 1})
+    hosts = job.state(cached_path=None).hosts
+    worker_procs = hosts.spawn_procs(per_host={"workers": 2}, name="pyspy_route_procs")
+    workers = worker_procs.spawn("pyspy_route_worker", WorkerActor)
+    workers.initialized.get()
+
+    coordinator_proc_id = engine._actor.get_proc_id.call_one().get()
+
+    # Discover child proc_ids by querying ProcAgent actors from the actors table.
+    # ProcAgent full_name = "{proc_id},proc_agent[0]"
+    proc_agents = engine.query(
+        "SELECT full_name FROM actors WHERE full_name LIKE '%,proc_agent[0]'"
+    )
+    child_proc_refs = [
+        row.rsplit(",proc_agent[0]", 1)[0]
+        for row in proc_agents.to_pydict()["full_name"]
+        if row.rsplit(",proc_agent[0]", 1)[0] != coordinator_proc_id
+    ]
+    assert len(child_proc_refs) > 0, f"Expected child proc_refs, got: {proc_agents}"
+    child_proc_ref = child_proc_refs[0]
+
+    pyspy_json = json.dumps(
+        {
+            "Ok": {
+                "pid": 9999,
+                "binary": "python3",
+                "stack_traces": [
+                    {
+                        "pid": 9999,
+                        "thread_id": 1,
+                        "thread_name": "MainThread",
+                        "os_thread_id": 200,
+                        "active": True,
+                        "owns_gil": True,
+                        "frames": [
+                            {
+                                "name": "child_fn",
+                                "filename": "child.py",
+                                "module": "child",
+                                "short_filename": "child.py",
+                                "line": 42,
+                                "locals": [],
+                                "is_entry": True,
+                            }
+                        ],
+                    }
+                ],
+                "warnings": [],
+            }
+        }
+    )
+
+    # Store a pyspy dump targeting the child proc_ref.
+    # Use 'try_store_pyspy_dump' to avoid fallback to root coordinator.
+    result = engine._actor.try_store_pyspy_dump.call_one(
+        "child-dump-1", child_proc_ref, pyspy_json
+    ).get()
+    assert result
+
+    # The dump should be queryable via distributed scan.
+    frames = engine.query(
+        "SELECT name, line FROM pyspy_frames WHERE dump_id = 'child-dump-1'"
+    )
+    frames_dict = frames.to_pydict()
+    assert frames_dict["name"] == ["child_fn"]
+    assert frames_dict["line"] == [42]
+
+    # Verify the dump's proc_ref is stored correctly.
+    dumps = engine.query(
+        "SELECT proc_ref FROM pyspy_dumps WHERE dump_id = 'child-dump-1'"
+    )
+    assert dumps.to_pydict()["proc_ref"] == [child_proc_ref]
+
+    # Clean up
+    hosts.shutdown().get()
+
+
+@pytest.mark.timeout(120)
+def test_store_pyspy_dump_unknown_proc_falls_back_to_root(cleanup_callbacks) -> None:
+    """store_pyspy_dump stores on root coordinator when proc_ref matches no child."""
+    engine = start_telemetry(batch_size=10, include_dashboard=False)
+
+    job = ProcessJob({"hosts": 1})
+    hosts = job.state(cached_path=None).hosts
+    worker_procs = hosts.spawn_procs(
+        per_host={"workers": 2}, name="pyspy_fallback_procs"
+    )
+    workers = worker_procs.spawn("pyspy_fallback_worker", WorkerActor)
+    workers.initialized.get()
+
+    # Trigger child spawning.
+    engine.query("SELECT COUNT(*) AS cnt FROM actors")
+
+    pyspy_json = json.dumps(
+        {
+            "Ok": {
+                "pid": 7777,
+                "binary": "python3",
+                "stack_traces": [
+                    {
+                        "pid": 7777,
+                        "thread_id": 1,
+                        "thread_name": "MainThread",
+                        "os_thread_id": 300,
+                        "active": True,
+                        "owns_gil": False,
+                        "frames": [
+                            {
+                                "name": "orphan_fn",
+                                "filename": "orphan.py",
+                                "module": "orphan",
+                                "short_filename": "orphan.py",
+                                "line": 99,
+                                "locals": [],
+                                "is_entry": True,
+                            }
+                        ],
+                    }
+                ],
+                "warnings": [],
+            }
+        }
+    )
+
+    # Store with a proc_ref that doesn't exist in the tree.
+    result = engine._actor.store_pyspy_dump.call_one(
+        "orphan-dump-1", "nonexistent.proc[999]", pyspy_json
+    ).get()
+    assert result
+
+    # The dump should be queryable (stored on root).
+    frames = engine.query(
+        "SELECT name, line FROM pyspy_frames WHERE dump_id = 'orphan-dump-1'"
+    )
+    frames_dict = frames.to_pydict()
+    assert frames_dict["name"] == ["orphan_fn"]
+    assert frames_dict["line"] == [99]
+
+    # Verify proc_ref is preserved even though it didn't match any proc.
+    dumps = engine.query(
+        "SELECT proc_ref FROM pyspy_dumps WHERE dump_id = 'orphan-dump-1'"
+    )
+    assert dumps.to_pydict()["proc_ref"] == ["nonexistent.proc[999]"]
+
+    # Clean up
+    hosts.shutdown().get()
+
+
+@pytest.mark.timeout(60)
+def test_store_pyspy_dump_returns_true(cleanup_callbacks) -> None:
+    """try_store_pyspy_dump returns True for match and False for unknown proc."""
+    engine = start_telemetry(include_dashboard=False)
+
+    pyspy_json = json.dumps(
+        {
+            "Ok": {
+                "pid": 1,
+                "binary": "python3",
+                "stack_traces": [],
+                "warnings": [],
+            }
+        }
+    )
+
+    coordinator_proc_id = engine._actor.get_proc_id.call_one().get()
+    result = engine._actor.try_store_pyspy_dump.call_one(
+        "ret-local", coordinator_proc_id, pyspy_json
+    ).get()
+    assert result
+
+    result = engine._actor.try_store_pyspy_dump.call_one(
+        "ret-unknown", "does.not.exist[0]", pyspy_json
+    ).get()
+    assert not result
+
+    result = engine._actor.store_pyspy_dump.call_one(
+        "ret-unknown", "does.not.exist[0]", pyspy_json
+    ).get()
+    assert result
+
+
+@pytest.mark.timeout(120)
 def test_per_table_row_retention(cleanup_callbacks) -> None:
     """Test that time-based retention deletes old rows from message tables."""
     import time


### PR DESCRIPTION
Summary:
Add targeted proc-level routing for py-spy dumps in the distributed telemetry
actor tree, plus new dashboard HTTP endpoints for SQL queries and pyspy storage.

**Telemetry actor changes (actor.py):**
- `store_pyspy_dump` now routes dumps to the correct child proc via a
  `_proc_id_index` (proc_id -> child mesh + rank). Falls back to root
  coordinator storage if no child matches, so data is never lost.
- `try_store_pyspy_dump` does the same without root fallback (used for
  recursive child routing).
- `_route_to_children` does targeted routing via index, then concurrent
  broadcast fallback if the index is stale.
- `get_proc_id` endpoint exposes the actor proc_id for index building.
- `__supervise__` purges stale index entries when a child mesh dies.

**Dashboard server changes:**
- `POST /api/query` -- execute arbitrary SQL against the DataFusion engine.
- `POST /api/pyspy_dump` -- store py-spy dump data via the adapter.
- `DBAdapter.store_pyspy_dump` -- concrete no-op base method; overridden by
  `QueryEngineAdapter` to route through the telemetry actor.
- `db.raw_query()` -- module-level function for direct SQL execution.

In next diff, admin endpoint wil send request to these end points for query and pyspy_dump

Differential Revision: D98091312


