### PR TITLE
Move docs deploy to specific branch

### DIFF
--- a/.github/workflows/doc_build.yml
+++ b/.github/workflows/doc_build.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - 'docs/**'
   pull_request:
   workflow_dispatch:
 
@@ -12,8 +13,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build-and-deploy:
-    name: Build and Deploy Documentation
+  build:
+    name: Build Documentation
     uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
     with:
       timeout: 120
@@ -75,8 +76,8 @@ jobs:
         cp -r docs/build/html ${RUNNER_ARTIFACT_DIR}/docs-html
 
   deploy:
-    needs: build-and-deploy
-    if: github.ref == 'refs/heads/main'
+    needs: build
+    if: startsWith(github.ref, 'refs/heads/docs/')
     permissions:
       pages: write
       id-token: write

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -112,3 +112,18 @@ jobs:
           build-args: |
             PYTORCH_TAG=2.11.0-cuda12.8-cudnn9-runtime
             MONARCH_VERSION=${{ github.event.inputs.version }}
+
+  create-docs-branch:
+    name: Create docs release branch
+    needs: publish
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Create docs/v${{ github.event.inputs.version }} branch
+        run: |
+          git checkout -b "docs/v${{ github.event.inputs.version }}"
+          git push origin "docs/v${{ github.event.inputs.version }}"


### PR DESCRIPTION
Summary:
Instead of deploying docs on every push to main, we want documentation to be tied to
the stable release.
However, documentation is a bit special in that we will likely need to make small corrections
like typos and broken links without wanting to make a whole PyPI release.

To this end, we will make a new series of git branches, `docs/v*` like `docs/v0.4.0` and `docs/v0.3.0`. These branches will be on the same commit as the public release and will
be created automatically. Documentation deployments are done off these branches
(which will be protected).

If we need to make a minor correction, we can just cherry pick a commit into these branches.
This preserves versioned documentation while also making it easy to put out new changes.

Reviewed By: zhangrmatthew

Differential Revision: D98161350


