### PR TITLE
Add POST /v1/query and POST /v1/pyspy_dump routes (#3201)

### DIFF
--- a/hyperactor_mesh/examples/dining_philosophers.rs
+++ b/hyperactor_mesh/examples/dining_philosophers.rs
@@ -264,7 +264,7 @@ async fn main() -> Result<ExitCode> {
 
     // Start the mesh admin agent, which aggregates admin state
     // across all hosts and serves an HTTP API.
-    let mesh_admin_url = spawn_admin([&host_mesh], instance, None).await?;
+    let mesh_admin_url = spawn_admin([&host_mesh], instance, None, None).await?;
     let mtls_flags = if mesh_admin_url.starts_with("https") {
         "--cacert /var/facebook/rootcanal/ca.pem \
          --cert /var/facebook/x509_identities/server.pem \

--- a/hyperactor_mesh/examples/sieve.rs
+++ b/hyperactor_mesh/examples/sieve.rs
@@ -141,7 +141,7 @@ async fn main() -> Result<ExitCode> {
 
     // Start the mesh admin agent.
     let h = this_host().await;
-    let mesh_admin_url = spawn_admin([&h], instance, None).await?;
+    let mesh_admin_url = spawn_admin([&h], instance, None, None).await?;
     let mtls_flags = if mesh_admin_url.starts_with("https") {
         "--cacert /var/facebook/rootcanal/ca.pem \
          --cert /var/facebook/x509_identities/server.pem \

--- a/hyperactor_mesh/src/host_mesh.rs
+++ b/hyperactor_mesh/src/host_mesh.rs
@@ -1655,6 +1655,7 @@ pub async fn spawn_admin(
     meshes: impl IntoIterator<Item = impl AsRef<HostMeshRef>>,
     cx: &impl hyperactor::context::Actor,
     admin_addr: Option<std::net::SocketAddr>,
+    telemetry_url: Option<String>,
 ) -> anyhow::Result<String> {
     let meshes: Vec<_> = meshes.into_iter().collect();
     anyhow::ensure!(!meshes.is_empty(), "at least one mesh is required (SA-1)");
@@ -1673,7 +1674,7 @@ pub async fn spawn_admin(
     let root_client_id = cx.mailbox().actor_id().clone();
     let head_agent = meshes[0].as_ref().hosts()[0].mesh_agent();
     let addr = head_agent
-        .spawn_mesh_admin(cx, hosts, Some(root_client_id), admin_addr)
+        .spawn_mesh_admin(cx, hosts, Some(root_client_id), admin_addr, telemetry_url)
         .await?;
 
     Ok(addr)
@@ -2187,7 +2188,7 @@ mod tests {
     #[tokio::test]
     async fn test_sa1_empty_mesh_set_rejected() {
         let instance = testing::instance();
-        let result = spawn_admin(std::iter::empty::<&HostMeshRef>(), instance, None).await;
+        let result = spawn_admin(std::iter::empty::<&HostMeshRef>(), instance, None, None).await;
         let err = result.unwrap_err().to_string();
         assert!(err.contains("SA-1"), "expected SA-1 error, got: {err}");
     }
@@ -2196,7 +2197,7 @@ mod tests {
     async fn test_sa2_empty_hosts_rejected() {
         let instance = testing::instance();
         let mesh = HostMeshRef::from_hosts(Name::new("empty").unwrap(), vec![]);
-        let result = spawn_admin([&mesh], instance, None).await;
+        let result = spawn_admin([&mesh], instance, None, None).await;
         let err = result.unwrap_err().to_string();
         assert!(err.contains("SA-2"), "expected SA-2 error, got: {err}");
     }

--- a/hyperactor_mesh/src/host_mesh/host_agent.rs
+++ b/hyperactor_mesh/src/host_mesh/host_agent.rs
@@ -1045,6 +1045,10 @@ pub struct SpawnMeshAdmin {
     /// the server reads `MESH_ADMIN_ADDR` from config.
     pub admin_addr: Option<std::net::SocketAddr>,
 
+    /// Base URL of the Monarch dashboard for proxy routes. `None` if
+    /// the dashboard is not running.
+    pub telemetry_url: Option<String>,
+
     /// Reply port for the admin HTTP address string (e.g.
     /// `"myhost.facebook.com:8080"`).
     #[reply]
@@ -1070,6 +1074,7 @@ impl Handler<SpawnMeshAdmin> for HostAgent {
                 msg.hosts,
                 msg.root_client_actor_id,
                 msg.admin_addr,
+                msg.telemetry_url,
             ),
         )?;
         let response = agent_handle.get_admin_addr(cx).await?;

--- a/hyperactor_mesh/src/mesh_admin.rs
+++ b/hyperactor_mesh/src/mesh_admin.rs
@@ -298,6 +298,7 @@ use axum::extract::State;
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use axum::routing::get;
+use axum::routing::post;
 use hyperactor::Actor;
 use hyperactor::ActorHandle;
 use hyperactor::Context;
@@ -615,6 +616,11 @@ pub struct MeshAdminAgent {
     /// for the admin HTTP server. Returned via `GetAdminAddr`.
     admin_host: Option<String>,
 
+    /// Base URL of the Monarch dashboard. Passed explicitly via
+    /// `SpawnMeshAdmin`. Used by proxy routes that forward requests
+    /// to the dashboard's `/api/*` endpoints.
+    telemetry_url: Option<String>,
+
     /// When the mesh was started (ISO-8601 timestamp).
     started_at: String,
 
@@ -644,6 +650,7 @@ impl MeshAdminAgent {
         hosts: Vec<(String, hyperactor_reference::ActorRef<HostAgent>)>,
         root_client_actor_id: Option<hyperactor_reference::ActorId>,
         admin_addr: Option<std::net::SocketAddr>,
+        telemetry_url: Option<String>,
     ) -> Self {
         let host_agents_by_actor_id: HashMap<hyperactor_reference::ActorId, String> = hosts
             .iter()
@@ -664,6 +671,7 @@ impl MeshAdminAgent {
             admin_addr_override: admin_addr,
             admin_addr: None,
             admin_host: None,
+            telemetry_url,
             started_at,
             started_by,
         }
@@ -711,6 +719,14 @@ struct BridgeState {
     resolve_semaphore: tokio::sync::Semaphore,
     /// Keep the handle alive so the bridge mailbox is not dropped.
     _bridge_handle: ActorHandle<()>,
+    /// Base URL of the Monarch dashboard (e.g.
+    /// `"http://localhost:5000"`). Passed from `MeshAdminAgent` at
+    /// init time. Used by proxy routes that forward requests to the
+    /// dashboard's `/api/*` endpoints.
+    telemetry_url: Option<String>,
+    /// Shared HTTP client for outbound proxy requests to the
+    /// dashboard. Reuses connection pool across requests.
+    http_client: reqwest::Client,
 }
 
 /// A TCP listener that performs a TLS handshake on each accepted
@@ -835,6 +851,8 @@ impl Actor for MeshAdminAgent {
                 crate::config::MESH_ADMIN_MAX_CONCURRENT_RESOLVES,
             )),
             _bridge_handle: bridge_handle,
+            telemetry_url: self.telemetry_url.clone(),
+            http_client: reqwest::Client::new(),
         });
         let router = create_mesh_admin_router(bridge_state);
 
@@ -1382,7 +1400,9 @@ impl MeshAdminAgent {
 /// - `GET /v1/schema/error` — JSON Schema for `ApiErrorEnvelope`.
 /// - `GET /v1/openapi.json` — OpenAPI 3.1 spec (embeds JSON Schemas).
 /// - `GET /v1/tree` — ASCII topology dump.
+/// - `POST /v1/query` — proxy SQL query to the dashboard server.
 /// - `GET /v1/pyspy/{*proc_reference}` — py-spy stack dump for a proc.
+/// - `POST /v1/pyspy_dump/{*proc_reference}` — py-spy dump + store in Datafusion.
 /// - `GET /v1/config/{*proc_reference}` — config snapshot for a proc.
 /// - `GET /v1/{*reference}` — JSON `NodePayload` for a single reference.
 /// - `GET /SKILL.md` — agent-facing API documentation (markdown).
@@ -1394,7 +1414,12 @@ fn create_mesh_admin_router(bridge_state: Arc<BridgeState>) -> Router {
         .route("/v1/schema/error", get(serve_error_schema))
         .route("/v1/openapi.json", get(serve_openapi))
         .route("/v1/tree", get(tree_dump))
+        .route("/v1/query", post(query_proxy))
         .route("/v1/pyspy/{*proc_reference}", get(pyspy_bridge))
+        .route(
+            "/v1/pyspy_dump/{*proc_reference}",
+            post(pyspy_dump_and_store),
+        )
         .route("/v1/config/{*proc_reference}", get(config_bridge))
         .route("/v1/{*reference}", get(resolve_reference_bridge))
         .with_state(bridge_state)
@@ -1520,6 +1545,13 @@ pub fn build_openapi_spec() -> serde_json::Value {
         .expect("ApiErrorEnvelope schema must be serializable");
     let mut pyspy_schema = serde_json::to_value(schemars::schema_for!(PySpyResult))
         .expect("PySpyResult schema must be serializable");
+    let mut query_request_schema = serde_json::to_value(schemars::schema_for!(QueryRequest))
+        .expect("QueryRequest schema must be serializable");
+    let mut query_response_schema = serde_json::to_value(schemars::schema_for!(QueryResponse))
+        .expect("QueryResponse schema must be serializable");
+    let mut pyspy_dump_response_schema =
+        serde_json::to_value(schemars::schema_for!(PyspyDumpAndStoreResponse))
+            .expect("PyspyDumpAndStoreResponse schema must be serializable");
 
     // Hoist $defs into a shared components/schemas map so
     // OpenAPI tools can resolve references.
@@ -1527,9 +1559,18 @@ pub fn build_openapi_spec() -> serde_json::Value {
     hoist_defs(&mut node_schema, &mut shared_schemas);
     hoist_defs(&mut error_schema, &mut shared_schemas);
     hoist_defs(&mut pyspy_schema, &mut shared_schemas);
+    hoist_defs(&mut query_request_schema, &mut shared_schemas);
+    hoist_defs(&mut query_response_schema, &mut shared_schemas);
+    hoist_defs(&mut pyspy_dump_response_schema, &mut shared_schemas);
     shared_schemas.insert("NodePayload".into(), node_schema);
     shared_schemas.insert("ApiErrorEnvelope".into(), error_schema);
     shared_schemas.insert("PySpyResult".into(), pyspy_schema);
+    shared_schemas.insert("QueryRequest".into(), query_request_schema);
+    shared_schemas.insert("QueryResponse".into(), query_response_schema);
+    shared_schemas.insert(
+        "PyspyDumpAndStoreResponse".into(),
+        pyspy_dump_response_schema,
+    );
 
     // Rewrite any remaining $defs refs in the hoisted component schemas.
     for value in shared_schemas.values_mut() {
@@ -1705,6 +1746,63 @@ pub fn build_openapi_spec() -> serde_json::Value {
                         "504": error_response("Gateway timeout")
                     }
                 }
+            },
+            "/v1/query": {
+                "post": {
+                    "summary": "Proxy SQL query to the telemetry dashboard",
+                    "operationId": "queryProxy",
+                    "description": "Forwards a SQL query to the Monarch dashboard's DataFusion engine. Requires telemetry_url to be configured.",
+                    "requestBody": {
+                        "required": true,
+                        "content": {
+                            "application/json": {
+                                "schema": { "$ref": "#/components/schemas/QueryRequest" }
+                            }
+                        }
+                    },
+                    "responses": {
+                        "200": {
+                            "description": "Query results",
+                            "content": {
+                                "application/json": {
+                                    "schema": { "$ref": "#/components/schemas/QueryResponse" }
+                                }
+                            }
+                        },
+                        "400": error_response("Bad request (invalid SQL or missing sql field)"),
+                        "404": error_response("Dashboard not configured"),
+                        "500": error_response("Internal error"),
+                        "504": error_response("Gateway timeout")
+                    }
+                }
+            },
+            "/v1/pyspy_dump/{proc_reference}": {
+                "post": {
+                    "summary": "Trigger py-spy dump and store in telemetry",
+                    "operationId": "pyspyDumpAndStore",
+                    "description": "Runs py-spy against the target process, stores the result in the dashboard's DataFusion pyspy tables, and returns the dump_id.",
+                    "parameters": [{
+                        "name": "proc_reference",
+                        "in": "path",
+                        "required": true,
+                        "description": "URL-encoded proc reference (ProcId)",
+                        "schema": { "type": "string" }
+                    }],
+                    "responses": {
+                        "200": {
+                            "description": "Dump stored successfully",
+                            "content": {
+                                "application/json": {
+                                    "schema": { "$ref": "#/components/schemas/PyspyDumpAndStoreResponse" }
+                                }
+                            }
+                        },
+                        "400": error_response("Bad request (malformed proc reference)"),
+                        "404": error_response("Proc or dashboard not found"),
+                        "500": error_response("Internal error"),
+                        "504": error_response("Gateway timeout")
+                    }
+                }
             }
         },
         "components": {
@@ -1795,17 +1893,17 @@ async fn probe_actor(
     }
 }
 
-/// HTTP bridge for py-spy stack dump requests.
+/// Core py-spy dump logic shared by `pyspy_bridge` and
+/// `pyspy_dump_and_store`.
 ///
-/// Parses the proc reference, routes to the appropriate actor
-/// (ProcAgent on worker procs, HostAgent on the service proc),
-/// probes for reachability, and sends `PySpyDump` directly.
-/// See PS-12, PS-13 in `introspect` module doc.
-async fn pyspy_bridge(
-    State(state): State<Arc<BridgeState>>,
-    AxumPath(proc_reference): AxumPath<String>,
-) -> Result<Json<PySpyResult>, ApiError> {
-    let (proc_reference, proc_id) = parse_pyspy_proc_reference(&proc_reference)?;
+/// Parses the proc reference, routes to the appropriate actor,
+/// probes for reachability, sends `PySpyDump`, and returns the
+/// result.
+async fn do_pyspy_dump(
+    state: &BridgeState,
+    raw_proc_reference: &str,
+) -> Result<PySpyResult, ApiError> {
+    let (proc_reference, proc_id) = parse_pyspy_proc_reference(raw_proc_reference)?;
 
     // PS-12: route by proc name — service proc → HostAgent, all others → ProcAgent.
     let agent_id = if proc_id.base_name() == SERVICE_PROC_NAME {
@@ -1860,7 +1958,7 @@ async fn pyspy_bridge(
         details: None,
     })?;
 
-    let wire_result = tokio::time::timeout(
+    tokio::time::timeout(
         hyperactor_config::global::get(crate::config::MESH_ADMIN_PYSPY_BRIDGE_TIMEOUT),
         reply_rx.recv(),
     )
@@ -1880,9 +1978,169 @@ async fn pyspy_bridge(
         code: "internal_error".to_string(),
         message: format!("failed to receive PySpyResult: {}", e),
         details: None,
+    })
+}
+
+/// HTTP bridge for py-spy stack dump requests.
+///
+/// Parses the proc reference, routes to the appropriate actor
+/// (ProcAgent on worker procs, HostAgent on the service proc),
+/// probes for reachability, and sends `PySpyDump` directly.
+/// See PS-12, PS-13 in `introspect` module doc.
+async fn pyspy_bridge(
+    State(state): State<Arc<BridgeState>>,
+    AxumPath(proc_reference): AxumPath<String>,
+) -> Result<Json<PySpyResult>, ApiError> {
+    Ok(Json(do_pyspy_dump(&state, &proc_reference).await?))
+}
+
+/// Request body for `POST /v1/query`.
+#[derive(Debug, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct QueryRequest {
+    /// SQL query string.
+    pub sql: String,
+}
+
+/// Response body from `POST /v1/query`.
+#[derive(Debug, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct QueryResponse {
+    /// Query result rows.
+    pub rows: serde_json::Value,
+}
+
+/// Request body sent to the dashboard's `/api/pyspy_dump` endpoint.
+#[derive(Debug, Serialize)]
+struct StorePyspyDumpRequest {
+    dump_id: String,
+    proc_ref: String,
+    pyspy_result_json: String,
+}
+
+/// Response body from `POST /v1/pyspy_dump/{*proc_reference}`.
+#[derive(Debug, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct PyspyDumpAndStoreResponse {
+    /// Unique identifier for the stored dump.
+    pub dump_id: String,
+}
+
+/// Resolve the telemetry URL from bridge state, returning an
+/// `ApiError` if not configured.
+fn require_telemetry_url(state: &BridgeState) -> Result<&str, ApiError> {
+    state.telemetry_url.as_deref().ok_or_else(|| {
+        ApiError::not_found("dashboard not configured (no telemetry_url provided)", None)
+    })
+}
+
+/// Proxy SQL queries to the Monarch dashboard's `/api/query`
+/// endpoint.
+///
+/// Requires `telemetry_url` to be set. The request body must
+/// contain a `sql` field. The dashboard response rows are returned
+/// verbatim.
+async fn query_proxy(
+    State(state): State<Arc<BridgeState>>,
+    axum::Json(body): axum::Json<QueryRequest>,
+) -> Result<axum::Json<QueryResponse>, ApiError> {
+    let telemetry_url = require_telemetry_url(&state)?;
+
+    let resp = state
+        .http_client
+        .post(format!("{}/api/query", telemetry_url))
+        .json(&body)
+        .send()
+        .await
+        .map_err(|e| ApiError {
+            code: "proxy_error".to_string(),
+            message: format!("failed to proxy query to dashboard: {}", e),
+            details: None,
+        })?;
+
+    let status = resp.status();
+    let resp_body = resp.bytes().await.map_err(|e| ApiError {
+        code: "proxy_error".to_string(),
+        message: format!("failed to read dashboard response: {}", e),
+        details: None,
     })?;
 
-    Ok(Json(wire_result))
+    if !status.is_success() {
+        // Try to extract error message from dashboard response.
+        let msg = serde_json::from_slice::<serde_json::Value>(&resp_body)
+            .ok()
+            .and_then(|v| v.get("error")?.as_str().map(String::from))
+            .unwrap_or_else(|| format!("dashboard returned HTTP {status}"));
+        let code = if status.is_client_error() {
+            "bad_request"
+        } else {
+            "proxy_error"
+        };
+        return Err(ApiError {
+            code: code.to_string(),
+            message: msg,
+            details: None,
+        });
+    }
+
+    let result: QueryResponse = serde_json::from_slice(&resp_body).map_err(|e| ApiError {
+        code: "proxy_error".to_string(),
+        message: format!("failed to parse dashboard response: {}", e),
+        details: None,
+    })?;
+
+    Ok(axum::Json(result))
+}
+
+/// Trigger a py-spy dump and store the result in the dashboard's
+/// DataFusion pyspy tables.
+///
+/// 1. Performs a py-spy dump via `do_pyspy_dump` (same as
+///    `pyspy_bridge`).
+/// 2. POSTs the serialized result to the dashboard's
+///    `/api/pyspy_dump` endpoint for persistent storage.
+/// 3. Returns the generated dump id.
+async fn pyspy_dump_and_store(
+    State(state): State<Arc<BridgeState>>,
+    AxumPath(proc_reference): AxumPath<String>,
+) -> Result<axum::Json<PyspyDumpAndStoreResponse>, ApiError> {
+    let telemetry_url = require_telemetry_url(&state)?;
+    let pyspy_result = do_pyspy_dump(&state, &proc_reference).await?;
+
+    let dump_id = uuid::Uuid::new_v4().to_string();
+    let pyspy_json = serde_json::to_string(&pyspy_result).map_err(|e| ApiError {
+        code: "internal_error".to_string(),
+        message: format!("failed to serialize PySpyResult: {}", e),
+        details: None,
+    })?;
+
+    let store_body = StorePyspyDumpRequest {
+        dump_id: dump_id.clone(),
+        proc_ref: proc_reference,
+        pyspy_result_json: pyspy_json,
+    };
+
+    let store_resp = state
+        .http_client
+        .post(format!("{}/api/pyspy_dump", telemetry_url))
+        .json(&store_body)
+        .send()
+        .await
+        .map_err(|e| ApiError {
+            code: "proxy_error".to_string(),
+            message: format!("failed to store pyspy dump in dashboard: {}", e),
+            details: None,
+        })?;
+
+    if !store_resp.status().is_success() {
+        return Err(ApiError {
+            code: "proxy_error".to_string(),
+            message: format!(
+                "dashboard rejected pyspy dump store: HTTP {}",
+                store_resp.status()
+            ),
+            details: None,
+        });
+    }
+
+    Ok(axum::Json(PyspyDumpAndStoreResponse { dump_id }))
 }
 
 /// HTTP bridge for config dump requests.
@@ -2522,6 +2780,7 @@ mod tests {
             vec![("host_a".to_string(), ref1), ("host_b".to_string(), ref2)],
             None,
             None,
+            None,
         );
 
         let payload = agent.build_root_payload();
@@ -2608,6 +2867,7 @@ mod tests {
                     vec![(host_addr_str.clone(), host_agent_ref.clone())],
                     None,
                     Some("[::]:0".parse().unwrap()),
+                    None,
                 ),
             )
             .unwrap();
@@ -2764,6 +3024,7 @@ mod tests {
                     vec![(host_addr_str.clone(), host_agent_ref.clone())],
                     None,
                     Some("[::]:0".parse().unwrap()),
+                    None,
                 ),
             )
             .unwrap();
@@ -2849,6 +3110,7 @@ mod tests {
             vec![("host_a".to_string(), ref1)],
             Some(client_actor_id.clone()),
             None,
+            None,
         );
 
         let payload = agent.build_root_payload();
@@ -2919,6 +3181,7 @@ mod tests {
                     vec![(host_addr_str.clone(), host_agent_ref.clone())],
                     Some(root_client_actor_id.clone()),
                     Some("[::]:0".parse().unwrap()),
+                    None,
                 ),
             )
             .unwrap();
@@ -3072,6 +3335,7 @@ mod tests {
                     vec![(host_addr_str, host_agent_ref)],
                     None,
                     Some("[::]:0".parse().unwrap()),
+                    None,
                 ),
             )
             .unwrap();
@@ -3170,6 +3434,7 @@ mod tests {
                     vec![(host_addr_str.clone(), host_agent_ref.clone())],
                     None,
                     Some("[::]:0".parse().unwrap()),
+                    None,
                 ),
             )
             .unwrap();
@@ -3636,6 +3901,7 @@ mod tests {
                     vec![(user_proc_addr, host_agent_ref.clone())],
                     None,
                     Some("[::]:0".parse().unwrap()),
+                    None,
                 ),
             )
             .unwrap();

--- a/hyperactor_mesh/src/testdata/openapi.json
+++ b/hyperactor_mesh/src/testdata/openapi.json
@@ -588,6 +588,47 @@
           "frames"
         ],
         "type": "object"
+      },
+      "PyspyDumpAndStoreResponse": {
+        "description": "Response body from `POST /v1/pyspy_dump/{*proc_reference}`.",
+        "properties": {
+          "dump_id": {
+            "description": "Unique identifier for the stored dump.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "dump_id"
+        ],
+        "title": "PyspyDumpAndStoreResponse",
+        "type": "object"
+      },
+      "QueryRequest": {
+        "description": "Request body for `POST /v1/query`.",
+        "properties": {
+          "sql": {
+            "description": "SQL query string.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "sql"
+        ],
+        "title": "QueryRequest",
+        "type": "object"
+      },
+      "QueryResponse": {
+        "description": "Response body from `POST /v1/query`.",
+        "properties": {
+          "rows": {
+            "description": "Query result rows."
+          }
+        },
+        "required": [
+          "rows"
+        ],
+        "title": "QueryResponse",
+        "type": "object"
       }
     }
   },
@@ -760,6 +801,145 @@
           }
         },
         "summary": "Py-spy stack dump for a proc"
+      }
+    },
+    "/v1/pyspy_dump/{proc_reference}": {
+      "post": {
+        "description": "Runs py-spy against the target process, stores the result in the dashboard's DataFusion pyspy tables, and returns the dump_id.",
+        "operationId": "pyspyDumpAndStore",
+        "parameters": [
+          {
+            "description": "URL-encoded proc reference (ProcId)",
+            "in": "path",
+            "name": "proc_reference",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PyspyDumpAndStoreResponse"
+                }
+              }
+            },
+            "description": "Dump stored successfully"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorEnvelope"
+                }
+              }
+            },
+            "description": "Bad request (malformed proc reference)"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorEnvelope"
+                }
+              }
+            },
+            "description": "Proc or dashboard not found"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorEnvelope"
+                }
+              }
+            },
+            "description": "Internal error"
+          },
+          "504": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorEnvelope"
+                }
+              }
+            },
+            "description": "Gateway timeout"
+          }
+        },
+        "summary": "Trigger py-spy dump and store in telemetry"
+      }
+    },
+    "/v1/query": {
+      "post": {
+        "description": "Forwards a SQL query to the Monarch dashboard's DataFusion engine. Requires telemetry_url to be configured.",
+        "operationId": "queryProxy",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/QueryRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/QueryResponse"
+                }
+              }
+            },
+            "description": "Query results"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorEnvelope"
+                }
+              }
+            },
+            "description": "Bad request (invalid SQL or missing sql field)"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorEnvelope"
+                }
+              }
+            },
+            "description": "Dashboard not configured"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorEnvelope"
+                }
+              }
+            },
+            "description": "Internal error"
+          },
+          "504": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorEnvelope"
+                }
+              }
+            },
+            "description": "Gateway timeout"
+          }
+        },
+        "summary": "Proxy SQL query to the telemetry dashboard"
       }
     },
     "/v1/root": {

--- a/hyperactor_mesh/test/mesh_admin_integration/harness.rs
+++ b/hyperactor_mesh/test/mesh_admin_integration/harness.rs
@@ -126,6 +126,43 @@ impl WorkloadFixture {
             .with_context(|| format!("deserialize response from GET {url} (HTTP {status}): {body}"))
     }
 
+    /// POST a path with a JSON body relative to the admin URL.
+    pub(crate) async fn post(&self, path: &str, body: &impl serde::Serialize) -> Result<Response> {
+        let url = format!("{}{}", self.admin_url, path);
+        let resp = self
+            .client
+            .post(&url)
+            .json(body)
+            .send()
+            .await
+            .with_context(|| format!("POST {url}"))?;
+        Ok(resp)
+    }
+
+    /// POST a path with a JSON body and deserialize the JSON response.
+    pub(crate) async fn post_json<T: DeserializeOwned>(
+        &self,
+        path: &str,
+        body: &impl serde::Serialize,
+    ) -> Result<T> {
+        let url = format!("{}{}", self.admin_url, path);
+        let resp = self
+            .client
+            .post(&url)
+            .json(body)
+            .send()
+            .await
+            .with_context(|| format!("POST {url}"))?;
+        let status = resp.status();
+        let text = resp.text().await?;
+        if !status.is_success() {
+            bail!("POST {url}: HTTP {status}: {text}");
+        }
+        serde_json::from_str(&text).with_context(|| {
+            format!("deserialize response from POST {url} (HTTP {status}): {text}")
+        })
+    }
+
     /// Walk root → hosts → procs → actors and classify service vs
     /// worker procs. MIT-7 (proc-classification).
     ///

--- a/hyperactor_mesh/test/mesh_admin_integration/main.rs
+++ b/hyperactor_mesh/test/mesh_admin_integration/main.rs
@@ -255,6 +255,29 @@
 //!
 //! - **MIT-62 (pyspy-content-type):** Both success and error
 //!   responses use `application/json` media type.
+//!
+//! ### Telemetry proxy endpoints
+//!
+//! - **MIT-63 (query-proxy-success):** `POST /v1/query` with valid
+//!   SQL returns a `QueryResponse` with non-empty rows.
+//! - **MIT-64 (query-proxy-invalid-sql):** `POST /v1/query` with
+//!   invalid SQL returns a non-success HTTP status.
+//! - **MIT-65 (query-proxy-telemetry-tables):** `POST /v1/query` can
+//!   query live telemetry tables (`meshes`, `actors`) populated by
+//!   the workload.
+//! - **MIT-66 (pyspy-dump-bogus-ref):** `POST /v1/pyspy_dump` with a
+//!   bogus proc reference returns `ApiErrorEnvelope`.
+//! - **MIT-67 (pyspy-dump-end-to-end):** Discover a proc via SQL
+//!   query, trigger a py-spy dump via `/v1/pyspy_dump`, then verify
+//!   the dump is stored and queryable via SQL.
+//! - **MIT-68 (query-no-dashboard-404):** `POST /v1/query` without a
+//!   configured dashboard returns 404 with `not_found` error code.
+//! - **MIT-69 (pyspy-dump-no-dashboard-404):** `POST /v1/pyspy_dump`
+//!   without a configured dashboard returns 404 with `not_found`
+//!   error code.
+//! - **MIT-70 (query-malformed-body):** `POST /v1/query` with a
+//!   malformed JSON body (missing required `sql` field) returns a
+//!   non-success status.
 
 mod auth;
 mod config;
@@ -264,6 +287,7 @@ mod openapi;
 mod pyspy;
 mod ref_check;
 mod ref_edge;
+mod telemetry;
 mod tree;
 
 // --- dining family ---
@@ -353,4 +377,48 @@ async fn test_auth_failures_rust() {
 #[tokio::test]
 async fn test_openapi_conformance_rust() {
     dining::run_openapi_conformance_rust().await;
+}
+
+// --- telemetry proxy family ---
+
+/// MIT-63: query proxy returns rows for valid SQL.
+#[tokio::test]
+async fn test_query_proxy_success() {
+    telemetry::run_query_success().await;
+}
+
+/// MIT-64: query proxy returns error for invalid SQL.
+#[tokio::test]
+async fn test_query_proxy_invalid_sql() {
+    telemetry::run_query_invalid_sql().await;
+}
+
+/// MIT-65: query proxy can query live telemetry tables.
+#[tokio::test]
+async fn test_query_proxy_telemetry_tables() {
+    telemetry::run_query_telemetry_tables().await;
+}
+
+/// MIT-66: pyspy_dump with bogus proc ref returns error envelope.
+#[tokio::test]
+async fn test_pyspy_dump_bogus_ref() {
+    telemetry::run_pyspy_dump_bogus_ref().await;
+}
+
+/// MIT-67: end-to-end SQL → pyspy dump → SQL verify.
+#[tokio::test]
+async fn test_pyspy_dump_and_query() {
+    telemetry::run_pyspy_dump_and_query().await;
+}
+
+/// MIT-68, MIT-69: /v1/query and /v1/pyspy_dump return 404 without dashboard.
+#[tokio::test]
+async fn test_no_dashboard_returns_404() {
+    telemetry::run_no_dashboard_returns_404().await;
+}
+
+/// MIT-70: /v1/query with malformed body returns error.
+#[tokio::test]
+async fn test_query_malformed_body() {
+    telemetry::run_query_malformed_body().await;
 }

--- a/hyperactor_mesh/test/mesh_admin_integration/openapi.rs
+++ b/hyperactor_mesh/test/mesh_admin_integration/openapi.rs
@@ -69,6 +69,8 @@ impl OpenApiValidator {
             "/v1/{reference}",
             "/v1/config/{proc_reference}",
             "/v1/pyspy/{proc_reference}",
+            "/v1/query",
+            "/v1/pyspy_dump/{proc_reference}",
             "/v1/tree",
             "/v1/schema",
             "/v1/schema/error",
@@ -100,15 +102,17 @@ impl OpenApiValidator {
     /// MIT-48: path parameters match declared contract (type: string,
     /// required: true).
     fn check_path_params(&self) {
-        for path in [
-            "/v1/{reference}",
-            "/v1/config/{proc_reference}",
-            "/v1/pyspy/{proc_reference}",
-        ] {
+        let cases: &[(&str, &str)] = &[
+            ("/v1/{reference}", "get"),
+            ("/v1/config/{proc_reference}", "get"),
+            ("/v1/pyspy/{proc_reference}", "get"),
+            ("/v1/pyspy_dump/{proc_reference}", "post"),
+        ];
+        for &(path, method) in cases {
             let params = self
                 .doc
                 .pointer(&format!(
-                    "/paths/{}/get/parameters",
+                    "/paths/{}/{method}/parameters",
                     escape_pointer_segment(path)
                 ))
                 .and_then(|v| v.as_array())

--- a/hyperactor_mesh/test/mesh_admin_integration/telemetry.rs
+++ b/hyperactor_mesh/test/mesh_admin_integration/telemetry.rs
@@ -1,0 +1,295 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+//! Integration tests for `POST /v1/query` and
+//! `POST /v1/pyspy_dump/{*proc_reference}`.
+//!
+//! These routes proxy to the Monarch dashboard and require
+//! `telemetry_url` to be configured. The Python dining_philosophers
+//! binary is launched with `--dashboard` so that `start_telemetry`
+//! starts the dashboard and passes `telemetry_url` to `_spawn_admin`.
+
+use std::time::Duration;
+
+use hyperactor_mesh::mesh_admin::ApiErrorEnvelope;
+use hyperactor_mesh::mesh_admin::PyspyDumpAndStoreResponse;
+use hyperactor_mesh::mesh_admin::QueryRequest;
+use hyperactor_mesh::mesh_admin::QueryResponse;
+
+use crate::harness;
+use crate::harness::WorkloadFixture;
+
+/// Pick an ephemeral port for the dashboard by binding to `:0` and
+/// reading back the OS-assigned port.
+fn pick_dashboard_port() -> u16 {
+    let listener = std::net::TcpListener::bind("0.0.0.0:0").expect("bind :0");
+    listener.local_addr().expect("local_addr").port()
+}
+
+/// Start the Python dining_philosophers binary with dashboard enabled.
+async fn start_with_dashboard() -> WorkloadFixture {
+    let bin = harness::dining_philosophers_python_binary();
+    let port = pick_dashboard_port().to_string();
+    harness::start_workload(
+        &bin,
+        &["--dashboard", "--dashboard-port", &port],
+        Duration::from_secs(90),
+    )
+    .await
+    .expect("failed to start dining_philosophers with --dashboard")
+}
+
+/// MIT-63: `/v1/query` returns rows for a valid SQL query against DataFusion.
+pub async fn run_query_success() {
+    let fixture = start_with_dashboard().await;
+
+    let req = QueryRequest {
+        sql: "SELECT 1 AS n".to_string(),
+    };
+    let resp: QueryResponse = fixture
+        .post_json("/v1/query", &req)
+        .await
+        .expect("query proxy should return rows");
+    let rows = resp.rows.as_array().expect("rows should be an array");
+    assert!(!rows.is_empty(), "expected at least one row");
+
+    fixture.shutdown().await;
+}
+
+/// MIT-64: `/v1/query` returns 400 with `ApiErrorEnvelope` for invalid SQL.
+pub async fn run_query_invalid_sql() {
+    let fixture = start_with_dashboard().await;
+
+    let req = QueryRequest {
+        sql: "NOT VALID SQL".to_string(),
+    };
+    let resp = fixture
+        .post("/v1/query", &req)
+        .await
+        .expect("transport should succeed");
+    assert_eq!(
+        resp.status().as_u16(),
+        400,
+        "invalid SQL should return 400, got {}",
+        resp.status()
+    );
+    let body = resp.text().await.unwrap();
+    let envelope: ApiErrorEnvelope =
+        serde_json::from_str(&body).expect("response should be ApiErrorEnvelope");
+    assert_eq!(envelope.error.code, "bad_request");
+    assert!(
+        !envelope.error.message.is_empty(),
+        "error message should be non-empty"
+    );
+
+    fixture.shutdown().await;
+}
+
+/// MIT-65: `/v1/query` can query telemetry tables populated by the workload.
+pub async fn run_query_telemetry_tables() {
+    let fixture = start_with_dashboard().await;
+
+    // Wait for topology to settle.
+    fixture
+        .classify_procs()
+        .await
+        .expect("procs should be classifiable");
+
+    let req = QueryRequest {
+        sql: "SELECT COUNT(*) AS cnt FROM meshes".to_string(),
+    };
+    let resp: QueryResponse = fixture
+        .post_json("/v1/query", &req)
+        .await
+        .expect("meshes query should succeed");
+    let rows = resp.rows.as_array().expect("rows should be an array");
+    assert!(!rows.is_empty(), "expected mesh count row");
+
+    fixture.shutdown().await;
+}
+
+/// MIT-67: End-to-end: discover a proc via SQL, dump its py-spy stacks via
+/// `/v1/pyspy_dump`, then verify the dump exists via SQL query.
+pub async fn run_pyspy_dump_and_query() {
+    let fixture = start_with_dashboard().await;
+
+    // Wait for topology to settle so actors table is populated.
+    fixture
+        .classify_procs()
+        .await
+        .expect("procs should be classifiable");
+
+    // 1. Use SQL to discover a worker proc_ref from ProcAgent actors.
+    //    ProcAgent full_name = "{proc_id},proc_agent[0]"
+    let resp: QueryResponse = fixture
+        .post_json(
+            "/v1/query",
+            &QueryRequest {
+                sql: "SELECT full_name FROM actors WHERE full_name LIKE '%,proc_agent[0]'"
+                    .to_string(),
+            },
+        )
+        .await
+        .expect("proc_agent query should succeed");
+    let rows = resp.rows.as_array().expect("rows should be an array");
+    assert!(!rows.is_empty(), "expected at least one proc_agent actor");
+    let full_name = rows[0]["full_name"]
+        .as_str()
+        .expect("full_name should be a string");
+    let proc_ref = full_name
+        .strip_suffix(",proc_agent[0]")
+        .expect("full_name should end with ,proc_agent[0]");
+
+    // 2. Trigger py-spy dump via /v1/pyspy_dump/{proc_ref}.
+    let encoded = urlencoding::encode(proc_ref);
+    let pyspy_path = format!("/v1/pyspy_dump/{encoded}");
+
+    let mut dump_id = String::new();
+    let resp = fixture
+        .post(&pyspy_path, &serde_json::json!(null))
+        .await
+        .expect("transport should succeed");
+    if resp.status().is_success() {
+        let body = resp.text().await.unwrap();
+        let result: PyspyDumpAndStoreResponse =
+            serde_json::from_str(&body).expect("should deserialize as PyspyDumpAndStoreResponse");
+        dump_id = result.dump_id;
+    }
+    assert!(!dump_id.is_empty(), "dump_id should be set");
+
+    // 3. Verify the dump exists in the pyspy_dumps table via SQL.
+    let resp: QueryResponse = fixture
+        .post_json(
+            "/v1/query",
+            &QueryRequest {
+                sql: format!(
+                    "SELECT dump_id, proc_ref FROM pyspy_dumps WHERE dump_id = '{dump_id}'"
+                ),
+            },
+        )
+        .await
+        .expect("pyspy_dumps query should succeed");
+    let rows = resp.rows.as_array().expect("rows should be an array");
+    assert!(
+        !rows.is_empty(),
+        "expected dump_id '{dump_id}' in pyspy_dumps table"
+    );
+    assert_eq!(
+        rows[0]["proc_ref"].as_str().unwrap(),
+        proc_ref,
+        "proc_ref should match the queried proc"
+    );
+
+    fixture.shutdown().await;
+}
+
+/// MIT-66: `/v1/pyspy_dump/{*proc_reference}` with a bogus proc reference
+/// returns a non-success status with a structured error envelope.
+pub async fn run_pyspy_dump_bogus_ref() {
+    let fixture = start_with_dashboard().await;
+
+    let bogus = "unix:@nonexistent_bogus_socket_xyz,bogus-ffffffffffffffff";
+    let encoded = urlencoding::encode(bogus);
+    let resp = fixture
+        .post(
+            &format!("/v1/pyspy_dump/{encoded}"),
+            &serde_json::json!(null),
+        )
+        .await
+        .expect("transport should succeed");
+    let status = resp.status();
+    assert!(
+        !status.is_success(),
+        "expected error for bogus proc ref, got {}",
+        status
+    );
+    let body = resp.text().await.unwrap();
+    let envelope: ApiErrorEnvelope =
+        serde_json::from_str(&body).expect("response should be ApiErrorEnvelope");
+    assert!(
+        !envelope.error.code.is_empty(),
+        "error code should be non-empty"
+    );
+    assert!(
+        !envelope.error.message.is_empty(),
+        "error message should be non-empty"
+    );
+
+    fixture.shutdown().await;
+}
+
+/// MIT-68, MIT-69: `/v1/query` and `/v1/pyspy_dump` return 404 when no
+/// dashboard is configured.
+pub async fn run_no_dashboard_returns_404() {
+    let bin = harness::dining_philosophers_python_binary();
+    let fixture = harness::start_workload(&bin, &[], Duration::from_secs(60))
+        .await
+        .expect("failed to start dining_philosophers without --dashboard");
+
+    // MIT-68: POST /v1/query without dashboard → 404.
+    let req = QueryRequest {
+        sql: "SELECT 1".to_string(),
+    };
+    let resp = fixture
+        .post("/v1/query", &req)
+        .await
+        .expect("transport should succeed");
+    assert_eq!(
+        resp.status().as_u16(),
+        404,
+        "/v1/query without dashboard should return 404, got {}",
+        resp.status()
+    );
+    let body = resp.text().await.unwrap();
+    let envelope: ApiErrorEnvelope =
+        serde_json::from_str(&body).expect("response should be ApiErrorEnvelope");
+    assert_eq!(envelope.error.code, "not_found");
+
+    // MIT-69: POST /v1/pyspy_dump/{ref} without dashboard → 404.
+    let encoded = urlencoding::encode("unix:@fake,fake-0000000000000000");
+    let resp = fixture
+        .post(
+            &format!("/v1/pyspy_dump/{encoded}"),
+            &serde_json::json!(null),
+        )
+        .await
+        .expect("transport should succeed");
+    assert_eq!(
+        resp.status().as_u16(),
+        404,
+        "/v1/pyspy_dump without dashboard should return 404, got {}",
+        resp.status()
+    );
+    let body = resp.text().await.unwrap();
+    let envelope: ApiErrorEnvelope =
+        serde_json::from_str(&body).expect("response should be ApiErrorEnvelope");
+    assert_eq!(envelope.error.code, "not_found");
+
+    fixture.shutdown().await;
+}
+
+/// MIT-70: `/v1/query` with malformed JSON body (missing `sql` field)
+/// returns a non-success status with an error body.
+pub async fn run_query_malformed_body() {
+    let fixture = start_with_dashboard().await;
+
+    // Send `{}` — missing the required `sql` field.
+    let resp = fixture
+        .post("/v1/query", &serde_json::json!({}))
+        .await
+        .expect("transport should succeed");
+
+    // Axum's Json extractor returns 422 for deserialization errors.
+    assert!(
+        !resp.status().is_success(),
+        "malformed body should return error, got {}",
+        resp.status()
+    );
+
+    fixture.shutdown().await;
+}

--- a/monarch_hyperactor/src/host_mesh.rs
+++ b/monarch_hyperactor/src/host_mesh.rs
@@ -514,6 +514,7 @@ fn _spawn_admin(
     host_meshes: Vec<PyRef<'_, PyHostMesh>>,
     instance: &PyInstance,
     admin_addr: Option<String>,
+    telemetry_url: Option<String>,
 ) -> PyResult<PyPythonTask> {
     if host_meshes.is_empty() {
         return Err(PyException::new_err("at least one mesh is required"));
@@ -533,7 +534,7 @@ fn _spawn_admin(
 
     let instance = instance.clone();
     PyPythonTask::new(async move {
-        let addr = host_mesh::spawn_admin(&mesh_refs, instance.deref(), admin_addr)
+        let addr = host_mesh::spawn_admin(&mesh_refs, instance.deref(), admin_addr, telemetry_url)
             .await
             .map_err(|e| PyException::new_err(e.to_string()))?;
         Ok(addr)

--- a/python/examples/dining_philosophers.py
+++ b/python/examples/dining_philosophers.py
@@ -159,6 +159,7 @@ async def async_main(
     dashboard_port: int = 8265,
     kill_waiter_after: float | None = None,
 ) -> None:
+    telemetry_url = None
     if dashboard:
         _, telemetry_url = start_telemetry(
             include_dashboard=True, dashboard_port=dashboard_port
@@ -168,7 +169,7 @@ async def async_main(
     host = this_host()
 
     # Spawn the admin agent so the TUI can attach.
-    admin_url = await _spawn_admin([host])
+    admin_url = await _spawn_admin([host], telemetry_url=telemetry_url)
     mtls_flags = (
         "--cacert /var/facebook/rootcanal/ca.pem "
         "--cert /var/facebook/x509_identities/server.pem "

--- a/python/monarch/_rust_bindings/monarch_hyperactor/host_mesh.pyi
+++ b/python/monarch/_rust_bindings/monarch_hyperactor/host_mesh.pyi
@@ -152,6 +152,7 @@ def _spawn_admin(
     host_meshes: list[HostMesh],
     instance: Instance,
     admin_addr: str | None = None,
+    telemetry_url: str | None = None,
 ) -> PythonTask[str]:
     """
     Spawn a MeshAdminAgent aggregating topology across one or more meshes.
@@ -165,5 +166,6 @@ def _spawn_admin(
     - `instance`: The actor instance used to spawn the admin agent.
     - `admin_addr`: Optional socket address (e.g. ``"[::]:1729"``).
       When ``None``, reads ``MESH_ADMIN_ADDR`` from config.
+    - `telemetry_url`: Optional base URL of the Monarch telemetry dashboard.
     """
     ...

--- a/python/monarch/_src/actor/host_mesh.py
+++ b/python/monarch/_src/actor/host_mesh.py
@@ -437,6 +437,7 @@ class HostMesh(MeshTrait):
 def _spawn_admin(
     host_meshes: list["HostMesh"],
     admin_addr: Optional[str] = None,
+    telemetry_url: Optional[str] = None,
 ) -> "Future[str]":
     """
     Spawn a MeshAdminAgent aggregating topology across one or more HostMeshes.
@@ -455,6 +456,9 @@ def _spawn_admin(
             Must not be empty.
         admin_addr: Optional socket address for the admin HTTP server.
             When ``None``, reads ``MESH_ADMIN_ADDR`` from config.
+        telemetry_url: Optional base URL of the Monarch telemetry dashboard.
+            When provided, the admin exposes proxy routes (``/v1/query``,
+            ``/v1/pyspy_dump``) that forward to the dashboard.
 
     Returns:
         Future[str]: The admin HTTP URL (for example
@@ -469,7 +473,7 @@ def _spawn_admin(
     async def task() -> str:
         hy_meshes = [await m._hy_host_mesh for m in host_meshes]
         return await _hy_spawn_admin(
-            hy_meshes, context().actor_instance._as_rust(), admin_addr
+            hy_meshes, context().actor_instance._as_rust(), admin_addr, telemetry_url
         )
 
     return Future(coro=task())


### PR DESCRIPTION
Summary:

Wire up two new HTTP routes in the mesh admin server:

- `POST /v1/query`: proxy SQL queries to the dashboard server
  (requires MONARCH_DASHBOARD_URL)
- `POST /v1/pyspy_dump/{proc_reference}`: trigger a py-spy dump and
  store the result in the dashboard's DataFusion pyspy tables

Add `telemetry_url` field to BridgeState, `do_pyspy_dump` helper
extraction, and route registrations in create_mesh_admin_router.

Reviewed By: shayne-fletcher

Differential Revision: D98173885


