### PR TITLE
Change HYPERACTOR_MESH_MAX_CAST_DIMENSION_SIZE default to 16

### DIFF
--- a/docs/source/api/monarch.config.rst
+++ b/docs/source/api/monarch.config.rst
@@ -457,7 +457,7 @@ Mesh Configuration
     Maximum dimension size for cast operations.
 
     - **Type**: ``int``
-    - **Default**: ``usize::MAX`` (platform-dependent)
+    - **Default**: ``16``
     - **Environment**: ``HYPERACTOR_MESH_MAX_CAST_DIMENSION_SIZE``
 
 

--- a/hyperactor_mesh/src/config.rs
+++ b/hyperactor_mesh/src/config.rs
@@ -108,7 +108,7 @@ declare_attrs! {
         Some("HYPERACTOR_MESH_MAX_CAST_DIMENSION_SIZE".to_string()),
         Some("max_cast_dimension_size".to_string()),
     ))
-    pub attr MAX_CAST_DIMENSION_SIZE: usize = usize::MAX;
+    pub attr MAX_CAST_DIMENSION_SIZE: usize = 16;
 
     /// Which builtin process launcher backend to use.
     /// Accepted values: "native" (default), "systemd".

--- a/python/tests/test_config.py
+++ b/python/tests/test_config.py
@@ -292,6 +292,7 @@ def test_duration_params(param_name, test_value, expected_value, default_value):
         # Runtime and buffering
         ("small_write_threshold", 512, 256),
         # Mesh config (usize::MAX doesn't have a fixed value, skip default check)
+        ("max_cast_dimension_size", 32, 16),
         # Logging config
         ("read_log_buffer", 16384, 100),
     ],
@@ -491,7 +492,7 @@ def test_all_params_together():
     assert config["mesh_terminate_timeout"] == "10s"
     assert config["shared_asyncio_runtime"] is False
     assert config["small_write_threshold"] == 256
-    # max_cast_dimension_size is usize::MAX, skip checking it
+    assert config["max_cast_dimension_size"] == 16
     assert config["read_log_buffer"] == 100
     assert config["force_file_log"] is False
     assert config["prefix_with_rank"] is True


### PR DESCRIPTION
Summary:
Changes the default value of `MAX_CAST_DIMENSION_SIZE` from `usize::MAX` (effectively no limit) to `16`.

Previously the ideal value for this approached 2 as the mesh got larger, but since the implementation of accumulation, a larger fanout with less layers was found to be ideal, which also does not impact small mesh sizes (less than 16 hosts)

Files changed:
- `fbcode/monarch/hyperactor_mesh/src/config.rs`: Default value changed from `usize::MAX` to `16`
- `fbcode/monarch/docs/source/api/monarch.config.rst`: Documentation updated to reflect new default
- `fbcode/monarch/python/tests/test_config.py`: Updated tests to verify the new default of 16 and added `max_cast_dimension_size` to the parametrized integer test

Reviewed By: dulinriley

Differential Revision: D98182865


