### PR TITLE
[monarch] auto-detect TLS mode via TlsMode::Auto

### DIFF
--- a/hyperactor/src/channel.rs
+++ b/hyperactor/src/channel.rs
@@ -303,6 +303,10 @@ pub enum TcpMode {
     strum::EnumString
 )]
 pub enum TlsMode {
+    /// Auto-detect TLS mode from TW container metadata.
+    /// If the container has IP-per-task networking, uses IpV6.
+    /// Otherwise, uses Hostname.
+    Auto,
     /// Use IpV6 address for TLS connections.
     IpV6,
     /// Use host domain name for TLS connections.
@@ -679,6 +683,10 @@ impl ChannelAddr {
                 };
                 Self::Tcp(SocketAddr::new(ip, 0))
             }
+            ChannelTransport::MetaTls(TlsMode::Auto) => {
+                let resolved = resolve_tls_mode();
+                return Self::any(ChannelTransport::MetaTls(resolved));
+            }
             ChannelTransport::MetaTls(mode) => {
                 let host_address = match mode {
                     TlsMode::Hostname => hostname::get()
@@ -688,6 +696,7 @@ impl ChannelAddr {
                     TlsMode::IpV6 => {
                         get_host_ipv6_address().expect("failed to retrieve ipv6 address")
                     }
+                    TlsMode::Auto => unreachable!(),
                 };
                 Self::MetaTls(TlsAddr::new(host_address, 0))
             }
@@ -737,6 +746,47 @@ fn get_host_ipv6_address() -> anyhow::Result<String> {
 #[cfg(not(fbcode_build))]
 fn get_host_ipv6_address() -> anyhow::Result<String> {
     Ok(local_ip_address::local_ipv6()?.to_string())
+}
+
+/// Resolve `TlsMode::Auto` into a concrete `TlsMode` by inspecting TW
+/// container metadata.
+///
+/// The heuristic: read `taskIp` from `/etc/tw/api/metadata.json` and
+/// check whether it falls in a Facebook SVC IP range (`2803:6080::/29`
+/// or `2a03:83e4:5000::/40`).  Only SVC-range containers get TLS
+/// certificates with IP SANs; all other containers get hostname-based
+/// certificates.
+#[cfg(fbcode_build)]
+fn resolve_tls_mode() -> TlsMode {
+    use crate::meta::host_ip::TwTaskIp;
+    use crate::meta::host_ip::is_facebook_svc;
+
+    match crate::meta::host_ip::tw_task_ip() {
+        TwTaskIp::Ip(v6) if is_facebook_svc(v6) => {
+            tracing::info!("Auto TLS: SVC IP-per-task container detected ({v6}), using IpV6 mode");
+            TlsMode::IpV6
+        }
+        TwTaskIp::Ip(v6) => {
+            tracing::info!(
+                "Auto TLS: non-SVC task IP ({v6}), using Hostname mode"
+            );
+            TlsMode::Hostname
+        }
+        TwTaskIp::NotTwTask => {
+            tracing::info!("Auto TLS: not a TW task, using Hostname mode");
+            TlsMode::Hostname
+        }
+        TwTaskIp::Error(msg) => {
+            tracing::warn!("Auto TLS: TW metadata error: {msg}, defaulting to Hostname");
+            TlsMode::Hostname
+        }
+    }
+}
+
+#[cfg(not(fbcode_build))]
+fn resolve_tls_mode() -> TlsMode {
+    tracing::info!("Auto TLS: non-fbcode build, using Hostname mode");
+    TlsMode::Hostname
 }
 
 impl fmt::Display for ChannelAddr {
@@ -871,11 +921,12 @@ impl ChannelAddr {
                 let (host, port) = Self::split_host_port(address)?;
 
                 if host == "*" {
-                    // Wildcard binding - use IPv6 unspecified address directly without hostname resolution
-                    Ok(Self::MetaTls(TlsAddr::new(
-                        std::net::Ipv6Addr::UNSPECIFIED.to_string(),
-                        port,
-                    )))
+                    // Wildcard binding - auto-detect TLS mode from container metadata
+                    let mut addr = Self::any(ChannelTransport::MetaTls(TlsMode::Auto));
+                    if let Self::MetaTls(ref mut tls_addr) = addr {
+                        tls_addr.port = port;
+                    }
+                    Ok(addr)
                 } else {
                     Ok(Self::MetaTls(TlsAddr::new(host, port)))
                 }
@@ -1221,11 +1272,17 @@ mod tests {
             ChannelAddr::MetaTls(TlsAddr::new("192.168.1.1", 443))
         );
 
-        // Test metatls with wildcard (should use IPv6 unspecified address)
-        assert_eq!(
-            ChannelAddr::from_zmq_url("metatls://*:8443").unwrap(),
-            ChannelAddr::MetaTls(TlsAddr::new("::", 8443))
-        );
+        // Test metatls with wildcard (auto-detects TLS mode from container metadata).
+        // On a devserver (not a TW task) this resolves to Hostname mode.
+        let wildcard_addr = ChannelAddr::from_zmq_url("metatls://*:8443").unwrap();
+        match &wildcard_addr {
+            ChannelAddr::MetaTls(tls_addr) => {
+                assert_eq!(tls_addr.port, 8443);
+                // On a devserver, hostname is used; on a TW task, IPv6 would be used.
+                assert!(!tls_addr.hostname.is_empty());
+            }
+            other => panic!("expected MetaTls, got {:?}", other),
+        }
 
         // Test TCP hostname resolution (should resolve hostname to IP)
         // Note: This test may fail in environments without proper DNS resolution

--- a/monarch_hyperactor/src/channel.rs
+++ b/monarch_hyperactor/src/channel.rs
@@ -33,6 +33,7 @@ use pyo3::prelude::*;
 pub enum PyChannelTransport {
     TcpWithLocalhost,
     TcpWithHostname,
+    MetaTls,
     MetaTlsWithHostname,
     MetaTlsWithIpV6,
     Tls,
@@ -52,6 +53,7 @@ impl PyChannelTransport {
         let variant_name = match self {
             PyChannelTransport::TcpWithLocalhost => "TcpWithLocalhost",
             PyChannelTransport::TcpWithHostname => "TcpWithHostname",
+            PyChannelTransport::MetaTls => "MetaTls",
             PyChannelTransport::MetaTlsWithHostname => "MetaTlsWithHostname",
             PyChannelTransport::MetaTlsWithIpV6 => "MetaTlsWithIpV6",
             PyChannelTransport::Tls => "Tls",
@@ -73,6 +75,7 @@ impl TryFrom<ChannelTransport> for PyChannelTransport {
         match transport {
             ChannelTransport::Tcp(TcpMode::Localhost) => Ok(PyChannelTransport::TcpWithLocalhost),
             ChannelTransport::Tcp(TcpMode::Hostname) => Ok(PyChannelTransport::TcpWithHostname),
+            ChannelTransport::MetaTls(TlsMode::Auto) => Ok(PyChannelTransport::MetaTls),
             ChannelTransport::MetaTls(TlsMode::Hostname) => {
                 Ok(PyChannelTransport::MetaTlsWithHostname)
             }
@@ -214,6 +217,7 @@ impl PyChannelAddr {
                 TcpMode::Hostname => Ok(PyChannelTransport::TcpWithHostname),
             },
             ChannelTransport::MetaTls(mode) => match mode {
+                TlsMode::Auto => Ok(PyChannelTransport::MetaTls),
                 TlsMode::Hostname => Ok(PyChannelTransport::MetaTlsWithHostname),
                 TlsMode::IpV6 => Ok(PyChannelTransport::MetaTlsWithIpV6),
             },
@@ -229,6 +233,7 @@ impl From<PyChannelTransport> for ChannelTransport {
         match val {
             PyChannelTransport::TcpWithLocalhost => ChannelTransport::Tcp(TcpMode::Localhost),
             PyChannelTransport::TcpWithHostname => ChannelTransport::Tcp(TcpMode::Hostname),
+            PyChannelTransport::MetaTls => ChannelTransport::MetaTls(TlsMode::Auto),
             PyChannelTransport::MetaTlsWithHostname => ChannelTransport::MetaTls(TlsMode::Hostname),
             PyChannelTransport::MetaTlsWithIpV6 => ChannelTransport::MetaTls(TlsMode::IpV6),
             PyChannelTransport::Tls => ChannelTransport::Tls,
@@ -258,6 +263,7 @@ mod tests {
             PyChannelTransport::TcpWithLocalhost,
             PyChannelTransport::TcpWithHostname,
             PyChannelTransport::Unix,
+            PyChannelTransport::MetaTls,
             PyChannelTransport::MetaTlsWithHostname,
             PyChannelTransport::MetaTlsWithIpV6,
             PyChannelTransport::Tls,

--- a/python/monarch/_rust_bindings/monarch_hyperactor/channel.pyi
+++ b/python/monarch/_rust_bindings/monarch_hyperactor/channel.pyi
@@ -16,6 +16,7 @@ class ChannelTransport(Enum):
 
     TcpWithLocalhost = "tcp(localhost)"
     TcpWithHostname = "tcp(hostname)"
+    MetaTls = "metatls(auto)"
     MetaTlsWithHostname = "metatls(hostname)"
     MetaTlsWithIpV6 = "metatls(ipv6)"
     Tls = "tls"

--- a/python/monarch/_src/actor/actor_mesh.py
+++ b/python/monarch/_src/actor/actor_mesh.py
@@ -524,8 +524,9 @@ def enable_transport(transport: "ChannelTransport | str") -> None:
         resolved = {
             "tcp": ChannelTransport.TcpWithHostname,
             "ipc": ChannelTransport.Unix,
-            "metatls": ChannelTransport.MetaTlsWithIpV6,
+            "metatls": ChannelTransport.MetaTls,
             "metatls-hostname": ChannelTransport.MetaTlsWithHostname,
+            "metatls-ipv6": ChannelTransport.MetaTlsWithIpV6,
             "tls": ChannelTransport.Tls,
         }.get(transport)
         if resolved is not None:

--- a/python/monarch/_src/job/spmd.py
+++ b/python/monarch/_src/job/spmd.py
@@ -174,7 +174,7 @@ def _get_worker_addr(scheduler: str, hostname: str) -> str:
 def _get_channel_transport(scheduler: str) -> ChannelTransport:
     """Get channel transport for the given scheduler."""
     if scheduler.startswith("mast"):
-        return ChannelTransport.MetaTlsWithHostname
+        return ChannelTransport.MetaTls
     else:
         return ChannelTransport.TcpWithHostname
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #3213

Meta has two TLS cert provisioning models depending on whether the
Tupperware container is in a Facebook SVC IP range:

1. **SVC containers** (`2803:6080::/29`, `2a03:83e4:5000::/40`):
   certs have IP SANs → use IPv6-based addressing.
2. **All other containers**: certs have DNS SANs matching the
   hostname → use hostname-based addressing.

Previously, choosing the right mode required a manual
`use_ipv6_transport` config flag plumbed through agent_tune's
`LauncherConfig`. This diff replaces it with automatic detection.

## Detection: `resolve_tls_mode()` and `is_facebook_svc()`

`resolve_tls_mode()` reads `taskIp` from TW metadata
(`/etc/tw/api/metadata.json`, cached via `OnceLock`) and checks
whether it falls in a Facebook SVC IP range.  The SVC check is a
pure-Rust CIDR prefix match (`is_facebook_svc()`), equivalent to the
C++ `FBAddressUtil::isFacebookSvc()`.  SVC IP → IpV6 mode; anything
else → Hostname mode.

On the controller side, `mast.py` applies the same SVC check
(`_is_facebook_svc()`) to each worker's `hostaddr` from TorchX to
decide whether to connect via IPv6 or hostname.

## Worker flow

1. Python launcher selects `SIMPLE_BOOTSTRAP_ARGS_AUTO`, baking
   `metatls://*:{port}` into the bootstrap command.
2. Rust parses `metatls://*:26600` → `ChannelAddr::any(MetaTls(Auto))`
   → `resolve_tls_mode()` reads TW metadata and checks SVC range.
3. Resolves to the correct `TlsAddr`: IPv6 for SVC containers,
   FQDN hostname otherwise.

## Controller flow

1. `MASTJob._state()` iterates each worker's `hostaddr`.
2. For `ChannelTransport.MetaTls` (Auto), tries parsing as IPv6.
   If it parses **and** is in the SVC range → `metatls://{ipv6}:port`.
   Otherwise → `metatls://{hostname}.facebook.com:port`.
3. Sets `HYPERACTOR_MESH_DEFAULT_TRANSPORT=metatls(Auto)`.

## MAST allocator (Rust-native path)

`get_meta_tls_transport()` returns `MetaTls(Auto)` directly.
Resolution happens lazily when `ChannelAddr::any()` is called.

## agent_tune cleanup

Removes the now-unnecessary manual plumbing:
- `LauncherConfig.use_ipv6_transport` field
- `create_monarch_mast_job()` parameter and if/else branching
- `_build_appdef()` / `procs.py` call sites
- `on_device/rl_experiments.py` override (`use_ipv6_transport=False`)
- `host_mesh_conda()` `use_ipv6_transport` parameter (now always
  uses `SIMPLE_BOOTSTRAP_ARGS_AUTO`)

Note: this still feels way too complicated and magical,
but I think it's robust.

Differential Revision: [D98191453](https://our.internmc.facebook.com/intern/diff/D98191453/)