### PR TITLE
generalize spawn_admin over a set of host meshes for multi-mesh admin aggregation

### DIFF
--- a/docs/source/books/hyperactor-mesh-book/src/SUMMARY.md
+++ b/docs/source/books/hyperactor-mesh-book/src/SUMMARY.md
@@ -11,6 +11,7 @@
   - [Proc meshes & ProcAgent](meshes/proc-mesh-and-agent.md)
   - [Process-backed hosts: BootstrapProcManager](meshes/bootstrap-proc-manager.md)
   - [Error Handling & Recovery](meshes/mesh-supervision.md)
+  - [Mesh Introspection & Admin](meshes/mesh-introspection-and-admin.md)
   - [Appendix: `bootstrap_canonical_simple`](meshes/bootstrapping-appendix-canonical-test.md)
   - [Appendix: pytokio (Python/Rust async bridge)](meshes/pytokio-appendix.md)
 - [Logging](logging/index.md)

--- a/docs/source/books/hyperactor-mesh-book/src/meshes/mesh-introspection-and-admin.md
+++ b/docs/source/books/hyperactor-mesh-book/src/meshes/mesh-introspection-and-admin.md
@@ -1,0 +1,404 @@
+# Mesh introspection & mesh-admin
+
+This chapter is the "page me back in" overview of how mesh introspection works and how the mesh admin TUI sits on top of it.
+
+The short version is:
+
+- the mesh exposes a **reference-walking** API,
+- every successful lookup returns a uniform `NodePayload`,
+- `MeshAdminAgent` is the mesh-wide resolver and HTTP bridge,
+- `HostAgent` and `ProcAgent` provide the proc-level and host-level facts,
+- ordinary actors provide their own actor-level introspection through the blanket `IntrospectMessage` handler,
+- and the TUI is "just" a lazy client of `GET /v1/{reference}` plus a couple of proc-oriented side endpoints.
+
+If you remember only one idea, remember this one:
+
+```text
+root
+  -> host refs
+    -> proc refs
+      -> actor refs
+```
+
+The TUI does not have privileged topology knowledge. It starts at `root`, follows `children`, and asks the server to resolve whatever opaque reference string it was given next.
+
+## The data model: `NodePayload`
+
+The entire mesh-admin surface is built around one response type:
+
+```rust
+pub struct NodePayload {
+    pub identity: String,
+    pub properties: NodeProperties,
+    pub children: Vec<String>,
+    pub parent: Option<String>,
+    pub as_of: String,
+}
+```
+
+This is the key simplification. Clients do not get separate "host response", "proc response", and "actor response" endpoints with different shapes. Instead they always ask for "resolve this reference" and receive:
+
+- `identity`: the canonical reference string for this node,
+- `properties`: one of `Root`, `Host`, `Proc`, `Actor`, or `Error`,
+- `children`: the next reference strings the client can walk,
+- `parent`: a navigation hint for upward movement,
+- `as_of`: when the data was captured.
+
+`NodeProperties` is the typed payload:
+
+- `Root` is synthetic and records high-level mesh metadata,
+- `Host` describes a `HostAgent` and its proc children,
+- `Proc` describes a proc node and its actor children,
+- `Actor` describes an individual actor instance,
+- `Error` is the sentinel shape used when resolution/decode fails in a controlled way.
+
+The `introspect` module is the translation layer. Internally the runtime produces `IntrospectResult { attrs, children, ... }`; `derive_properties` decodes attrs into `NodeProperties`; `to_node_payload` wraps that into the API shape.
+
+So the stack is:
+
+```text
+published attrs / IntrospectResult
+    -> derive_properties(...)
+    -> NodeProperties
+    -> NodePayload
+```
+
+## The mental model: what is actually introspectable?
+
+The runtime rule is not "everything that exists is visible." The rule is "everything the routing layer can actually reach via actor messaging is visible."
+
+That is why the module docs talk about **routable**, **introspectable**, and **opaque** nodes:
+
+- if an actor can receive `IntrospectMessage`, it is introspectable,
+- if a proc has at least one such actor, the admin layer can synthesize a proc node for it,
+- infrastructure pieces with no routable mailbox sender are intentionally opaque and do not appear as first-class nodes.
+
+This explains two important design choices:
+
+1. procs are mostly **synthetic nodes** assembled from agent knowledge rather than directly introspected runtime objects;
+2. the admin tree is a **navigation projection** of what the routing layer can actually observe, not a dump of every implementation detail in the process.
+
+## Who provides what
+
+There are three layers involved in a normal lookup.
+
+### 1. `MeshAdminAgent`: mesh-wide resolver and HTTP bridge target
+
+`MeshAdminAgent` owns:
+
+- the map of host address -> `ActorRef<HostAgent>`,
+- the reverse map of `HostAgent ActorId` -> host address,
+- the synthetic root node,
+- the `ResolveReferenceMessage` handler,
+- the background Axum server started from `init`.
+
+It does **not** directly know every actor in the mesh. Instead it is the orchestrator that decides which downstream actor to ask next.
+
+The core resolver is:
+
+```text
+resolve_reference(reference_string)
+  "root"                   -> build_root_payload()
+  "host:<actor_id>"        -> resolve_host_node(...)
+  ProcId                   -> resolve_proc_node(...)
+  ActorId                  -> resolve_actor_node(...)
+```
+
+So `MeshAdminAgent` is the place where opaque references become typed navigation.
+
+### 2. `HostAgent`: host nodes and system/local proc resolution
+
+`HostAgent` publishes host attrs such as:
+
+- `node_type = "host"`
+- `addr`
+- `num_procs`
+- `children`
+- `system_children`
+
+More importantly, in `init` it registers a `QueryChild` callback for proc references that are **not** independently represented by a user `ProcAgent` path, notably:
+
+- the service proc,
+- the local proc.
+
+That callback synthesizes a proc-level `IntrospectResult` for those system procs by enumerating actors in the proc and marking which are system actors.
+
+So if `MeshAdminAgent` asks a `HostAgent` "tell me about this proc child", the host can answer directly for system/local procs.
+
+### 3. `ProcAgent`: user proc nodes, terminated snapshots, proc-local services
+
+`ProcAgent` does the corresponding job for user procs.
+
+It publishes proc attrs such as:
+
+- `node_type = "proc"`
+- `proc_name`
+- `num_actors`
+- `system_children`
+- `stopped_children`
+- `stopped_retention_cap`
+- `is_poisoned`
+- `failed_actor_count`
+
+In `init` it also registers a `QueryChild` callback with two especially important behaviors:
+
+1. `QueryChild(Reference::Proc(proc_id))` builds a **fresh proc node from live proc state**, not from stale published snapshots. This is why a directly spawned actor can appear in the next admin query without waiting for a separate republish path.
+2. `QueryChild(Reference::Actor(actor_id))` can return a **terminated snapshot** for dead actors, which lets the admin UI continue to resolve recently stopped actors by reference.
+
+`ProcAgent` is also where the proc-oriented side services live today:
+
+- `PySpyDump` is handled by delegating to a one-shot `PySpyWorker`,
+- `ConfigDump` returns current CONFIG-marked settings for the proc.
+
+## How a normal tree walk works
+
+The runtime walk that underlies the TUI looks like this.
+
+### Step 1: root
+
+The client asks for `root`.
+
+`MeshAdminAgent::build_root_payload()` returns a synthetic node whose children are host references:
+
+```text
+root
+  children = ["host:<host_agent_actor_id_0>", "host:<host_agent_actor_id_1>", ...]
+```
+
+The root is not a real actor or proc. It is purely a navigation anchor.
+
+### Step 2: host
+
+The client picks a host child and resolves it.
+
+`MeshAdminAgent::resolve_host_node()` sends `IntrospectMessage::Query(Entity)` directly to that `HostAgent` and converts the returned attrs/children into `NodePayload`.
+
+At that point the client sees:
+
+- host metadata,
+- system and user proc references under that host.
+
+### Step 3: proc
+
+The client picks a proc child and resolves it.
+
+`MeshAdminAgent::resolve_proc_node()` does a two-stage attempt:
+
+1. ask the owning `HostAgent` via `QueryChild(Reference::Proc(proc_id))`,
+2. if that comes back as an error payload, fall back to the proc's `proc_agent[0]`.
+
+Why the two stages?
+
+- service/local/system procs are host-managed and answered by `HostAgent`,
+- user procs are answered by `ProcAgent`,
+- the client does not need to know the difference.
+
+That is a recurring theme in this subsystem: the server hides topology quirks behind a single reference API.
+
+### Step 4: actor
+
+The client picks an actor child and resolves it.
+
+`MeshAdminAgent::resolve_actor_node()` usually sends `IntrospectMessage::Query(Actor)` directly to that actor's introspection port.
+
+There are some important special cases:
+
+- if the actor being resolved is the admin actor itself, the agent snapshots itself directly to avoid self-deadlock;
+- before querying a live user actor, it checks for a terminated snapshot via the proc agent, so recently dead actors remain queryable;
+- if the actor lives on a standalone proc, parent handling is adjusted accordingly.
+
+The end result is still a plain `NodePayload::Actor`, so the client sees a normal actor node.
+
+## Why `QueryChild` matters so much
+
+The reference API would be awkward without `QueryChild`.
+
+The admin layer needs answers to questions like:
+
+- "tell me about proc `P` under host `H`",
+- "tell me about recently terminated actor `A` on proc `P`",
+- "enumerate the children of this system proc even though it is not a user proc with its own agent path".
+
+`QueryChild` is the escape hatch that lets a parent-ish actor answer these structural questions even when the child is synthetic, recently terminated, or otherwise not a normal live actor lookup.
+
+That is why both `HostAgent` and `ProcAgent` install `set_query_child_handler(...)` callbacks during `init`.
+
+Without those handlers, the admin layer could still introspect live actors directly, but proc-level navigation would be much poorer and much more special-cased.
+
+## The HTTP layer is deliberately thin
+
+The mesh admin HTTP server is not where the topology logic lives.
+
+`MeshAdminAgent::init()`:
+
+- binds its ports,
+- binds a TCP listener,
+- configures TLS/mTLS,
+- creates a dedicated bridge `Instance<()>` mailbox,
+- starts an Axum server in the background.
+
+The important detail is the **bridge instance**. The HTTP handlers do not share `MeshAdminAgent`'s own actor mailbox. Instead they use a dedicated introspectable client mailbox so they can:
+
+- open reply ports,
+- send `ResolveReferenceMessage`, `PySpyDump`, and `ConfigDump`,
+- await responses on Tokio tasks without hijacking the admin actor's own message loop.
+
+So the HTTP server is really an actor-message bridge:
+
+```text
+HTTP request
+  -> Axum handler
+  -> actor message / oneshot reply port
+  -> MeshAdminAgent / HostAgent / ProcAgent / target actor
+  -> response
+```
+
+The core routes today are:
+
+- `GET /v1/schema`
+- `GET /v1/schema/error`
+- `GET /v1/openapi.json`
+- `GET /v1/tree`
+- `GET /v1/config/{proc_reference}`
+- `GET /v1/pyspy/{proc_reference}`
+- `GET /v1/{reference}`
+- `GET /SKILL.md`
+
+The navigation route the TUI cares about is `GET /v1/{reference}`.
+
+## The TUI is a lazy reference walker
+
+The admin TUI is intentionally not a "push the whole mesh over HTTP" client. It is a **lazy tree walker**.
+
+Its core fetch path is in `fetch.rs`:
+
+- `fetch_node_raw(client, base_url, reference)` issues `GET /v1/{urlencode(reference)}`,
+- results are cached as `FetchState<NodePayload>`,
+- cache updates go through `fetch_with_join`,
+- `build_tree_node(...)` recursively builds the visible tree from cached payloads and follow-up fetches.
+
+Two details matter when reading the TUI after time away:
+
+### 1. It is reference-driven, not type-driven
+
+The TUI does not infer topology from local heuristics. It trusts:
+
+- `identity`
+- `parent`
+- `children`
+- `properties`
+
+That is why the navigation identity invariants in `mesh_admin.rs` matter so much: if `identity` and `parent` are wrong, the TUI cannot keep its tree coherent.
+
+### 2. It is lazy
+
+Proc and actor children are fetched when the user expands into them, not preloaded wholesale.
+
+That is why the TUI code talks so much about:
+
+- explicit tree recursion,
+- placeholders,
+- refresh generations,
+- join semantics,
+- cycle safety.
+
+The TUI is not a mirror of server state. It is a cached, incrementally refreshed projection of the reference graph.
+
+## Proc-oriented side endpoints
+
+The TUI also uses two proc-oriented endpoints:
+
+- `GET /v1/pyspy/{proc_reference}`
+- `GET /v1/config/{proc_reference}`
+
+These are intentionally **not** general reference-resolution endpoints. They require a proc reference because the server needs to decide whether to route the request to:
+
+- `HostAgent` for the service proc,
+- `ProcAgent` for non-service procs.
+
+For py-spy, the flow is:
+
+```text
+HTTP /v1/pyspy/{proc}
+  -> choose HostAgent or ProcAgent by proc name
+  -> probe reachability
+  -> send PySpyDump
+  -> ProcAgent/HostAgent delegates to PySpyWorker
+  -> return structured PySpyResult
+```
+
+For config dump, the flow is analogous but simpler: send `ConfigDump` and await `ConfigDumpResult`.
+
+These side endpoints are separate because they are operations on a proc, not tree navigation over `NodePayload`.
+
+## Why this design is nice to work with
+
+Three properties make this subsystem easier to reason about than it first appears.
+
+### 1. Uniform API shape
+
+Everything navigational becomes "resolve a reference to `NodePayload`". The client never has to switch protocols as it moves from host to proc to actor.
+
+### 2. Topology knowledge stays server-side
+
+The client does not need to know:
+
+- which procs are system procs,
+- which proc is answered by `HostAgent` versus `ProcAgent`,
+- how terminated actor snapshots are recovered,
+- how parent/identity normalization is done.
+
+That logic sits in `MeshAdminAgent`, `HostAgent`, and `ProcAgent`.
+
+### 3. It reuses the actor system instead of bypassing it
+
+The HTTP surface is not a side database or a separate control plane. It is a projection built by sending actor messages through the same routing model the mesh already uses.
+
+That is why the docs keep emphasizing "if you can send it a message, you can introspect it."
+
+## Practical reading order in the code
+
+When you need to page this back in after a few days, read in this order:
+
+1. `hyperactor_mesh/src/introspect.rs`
+   This gives you the attrs keys, `NodePayload`, `NodeProperties`, and the decode rules.
+
+2. `hyperactor_mesh/src/mesh_admin.rs`
+   This gives you the reference resolver, the router, and the HTTP bridge.
+
+3. `hyperactor_mesh/src/host_mesh/host_agent.rs`
+   This shows how host nodes and system/local proc nodes are synthesized.
+
+4. `hyperactor_mesh/src/proc_agent.rs`
+   This shows how user proc nodes, terminated snapshots, py-spy, and config dump work.
+
+5. `hyperactor_mesh_admin_tui/src/fetch.rs` and `.../src/lib.rs`
+   This shows how the TUI lazily walks the reference graph and turns responses into a visible tree.
+
+That sequence maps cleanly onto the runtime layering:
+
+```text
+attrs -> NodePayload -> resolve reference -> HTTP bridge -> TUI walker
+```
+
+## A compact end-to-end call flow
+
+This is the full "what happens when I expand a node in the TUI?" summary:
+
+```text
+TUI
+  -> GET /v1/{reference}
+  -> resolve_reference_bridge
+  -> MeshAdminAgent::resolve_reference
+      root       -> build_root_payload
+      host ref   -> HostAgent introspect query
+      proc ref   -> HostAgent QueryChild, else ProcAgent QueryChild
+      actor ref  -> direct actor introspect query, maybe via terminated snapshot
+  -> IntrospectResult / attrs
+  -> derive_properties -> NodeProperties
+  -> NodePayload
+  -> TUI cache / tree builder
+  -> visible row in the tree
+```
+
+That is the subsystem in one page.

--- a/hyperactor_mesh/examples/dining_philosophers.rs
+++ b/hyperactor_mesh/examples/dining_philosophers.rs
@@ -30,6 +30,7 @@ use hyperactor_mesh::ActorMeshRef;
 use hyperactor_mesh::comm::multicast::CastInfo;
 use hyperactor_mesh::context;
 use hyperactor_mesh::host_mesh::HostMesh;
+use hyperactor_mesh::host_mesh::spawn_admin;
 use ndslice::ViewExt;
 use ndslice::extent;
 use serde::Deserialize;
@@ -263,7 +264,7 @@ async fn main() -> Result<ExitCode> {
 
     // Start the mesh admin agent, which aggregates admin state
     // across all hosts and serves an HTTP API.
-    let mesh_admin_url = host_mesh.spawn_admin(instance, None).await?;
+    let mesh_admin_url = spawn_admin([&host_mesh], instance, None).await?;
     let mtls_flags = if mesh_admin_url.starts_with("https") {
         "--cacert /var/facebook/rootcanal/ca.pem \
          --cert /var/facebook/x509_identities/server.pem \

--- a/hyperactor_mesh/examples/sieve.rs
+++ b/hyperactor_mesh/examples/sieve.rs
@@ -26,6 +26,7 @@ use hyperactor::RemoteSpawn;
 use hyperactor::reference;
 use hyperactor_config::Flattrs;
 use hyperactor_mesh::context;
+use hyperactor_mesh::host_mesh::spawn_admin;
 use hyperactor_mesh::this_host;
 use hyperactor_mesh::this_proc;
 use ndslice::View;
@@ -139,7 +140,8 @@ async fn main() -> Result<ExitCode> {
     let instance = cx.actor_instance;
 
     // Start the mesh admin agent.
-    let mesh_admin_url = this_host().await.spawn_admin(instance, None).await?;
+    let h = this_host().await;
+    let mesh_admin_url = spawn_admin([&h], instance, None).await?;
     let mtls_flags = if mesh_admin_url.starts_with("https") {
         "--cacert /var/facebook/rootcanal/ca.pem \
          --cert /var/facebook/x509_identities/server.pem \

--- a/hyperactor_mesh/src/host_mesh.rs
+++ b/hyperactor_mesh/src/host_mesh.rs
@@ -745,6 +745,18 @@ impl Deref for HostMesh {
     }
 }
 
+impl AsRef<HostMeshRef> for HostMesh {
+    fn as_ref(&self) -> &HostMeshRef {
+        self
+    }
+}
+
+impl AsRef<HostMeshRef> for HostMeshRef {
+    fn as_ref(&self) -> &HostMeshRef {
+        self
+    }
+}
+
 /// Wrapper around HostMesh that runs shutdown on Drop.
 pub struct HostMeshShutdownGuard(pub HostMesh);
 
@@ -1381,49 +1393,6 @@ impl HostMeshRef {
         &self.ranks
     }
 
-    /// Spawn a [`MeshAdminAgent`] on the head host's system proc and
-    /// return its HTTP address.
-    ///
-    /// Sends a `SpawnMeshAdmin` message to `ranks[0]`'s
-    /// `HostAgent`, which spawns the admin agent on that host's
-    /// system proc. When `admin_addr` is `Some`, the HTTP server
-    /// binds to that address; otherwise it reads `MESH_ADMIN_ADDR`
-    /// from config.
-    pub async fn spawn_admin(
-        &self,
-        cx: &impl hyperactor::context::Actor,
-        admin_addr: Option<std::net::SocketAddr>,
-    ) -> anyhow::Result<String> {
-        let mut hosts: Vec<(String, hyperactor_reference::ActorRef<HostAgent>)> = self
-            .ranks
-            .iter()
-            .map(|h| (h.0.to_string(), h.mesh_agent()))
-            .collect();
-
-        // CH-1: see mesh_admin module doc. Include C (the client
-        // host) so the admin can introspect it. Dedup for C in A.
-        if let Some(client_host) = crate::global_context::try_this_host() {
-            for (addr, agent_ref) in client_host.host_entries() {
-                let agent_id = agent_ref.actor_id();
-                if !hosts
-                    .iter()
-                    .any(|(_, existing)| existing.actor_id() == agent_id)
-                {
-                    hosts.push((addr, agent_ref));
-                }
-            }
-        }
-
-        let root_client_id = cx.mailbox().actor_id().clone();
-
-        let head_agent = self.ranks[0].mesh_agent();
-        let addr = head_agent
-            .spawn_mesh_admin(cx, hosts, Some(root_client_id), admin_addr)
-            .await?;
-
-        Ok(addr)
-    }
-
     #[hyperactor::instrument(fields(host_mesh=self.name.to_string(), proc_mesh=proc_mesh_name.to_string()))]
     pub(crate) async fn stop_proc_mesh(
         &self,
@@ -1639,6 +1608,75 @@ impl HostMeshRef {
             .collect_mesh::<ValueMesh<_>>(region)?;
         Ok(vm)
     }
+}
+
+/// Ordered union of hosts from meshes and optional client host
+/// entries, deduplicated by `HostAgent` `ActorId` in first-seen
+/// order.
+///
+/// This is the SA-3 aggregation step, extracted for testability.
+fn aggregate_hosts(
+    meshes: &[impl AsRef<HostMeshRef>],
+    client_host_entries: Option<Vec<(String, hyperactor_reference::ActorRef<HostAgent>)>>,
+) -> Vec<(String, hyperactor_reference::ActorRef<HostAgent>)> {
+    let mut seen = HashSet::new();
+    let mut hosts = Vec::new();
+
+    for mesh in meshes {
+        for h in mesh.as_ref().hosts() {
+            let agent_ref = h.mesh_agent();
+            if seen.insert(agent_ref.actor_id().clone()) {
+                hosts.push((h.0.to_string(), agent_ref));
+            }
+        }
+    }
+
+    // CH-1 / SA-6: client host dedup against the aggregated set.
+    if let Some(entries) = client_host_entries {
+        for (addr, agent_ref) in entries {
+            if seen.insert(agent_ref.actor_id().clone()) {
+                hosts.push((addr, agent_ref));
+            }
+        }
+    }
+
+    hosts
+}
+
+/// Spawn a [`MeshAdminAgent`] that aggregates hosts from multiple
+/// meshes.
+///
+/// The admin agent runs on the first mesh's `hosts()[0]`'s system
+/// proc. Hosts are deduplicated by actor ID across all meshes.
+///
+/// See the `mesh_admin` module doc for the SA-* (spawn/aggregation)
+/// and CH-* (client host) invariants.
+pub async fn spawn_admin(
+    meshes: impl IntoIterator<Item = impl AsRef<HostMeshRef>>,
+    cx: &impl hyperactor::context::Actor,
+    admin_addr: Option<std::net::SocketAddr>,
+) -> anyhow::Result<String> {
+    let meshes: Vec<_> = meshes.into_iter().collect();
+    anyhow::ensure!(!meshes.is_empty(), "at least one mesh is required (SA-1)");
+    for (i, mesh) in meshes.iter().enumerate() {
+        anyhow::ensure!(
+            !mesh.as_ref().hosts().is_empty(),
+            "mesh at index {} has no hosts (SA-2)",
+            i,
+        );
+    }
+
+    let client_entries =
+        crate::global_context::try_this_host().map(|client_host| client_host.host_entries());
+    let hosts = aggregate_hosts(&meshes, client_entries);
+
+    let root_client_id = cx.mailbox().actor_id().clone();
+    let head_agent = meshes[0].as_ref().hosts()[0].mesh_agent();
+    let addr = head_agent
+        .spawn_mesh_admin(cx, hosts, Some(root_client_id), admin_addr)
+        .await?;
+
+    Ok(addr)
 }
 
 impl view::Ranked for HostMeshRef {
@@ -2142,5 +2180,78 @@ mod tests {
         );
 
         let _ = hm.shutdown(instance).await;
+    }
+
+    // ---- SA-* invariant tests ----
+
+    #[tokio::test]
+    async fn test_sa1_empty_mesh_set_rejected() {
+        let instance = testing::instance();
+        let result = spawn_admin(std::iter::empty::<&HostMeshRef>(), instance, None).await;
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("SA-1"), "expected SA-1 error, got: {err}");
+    }
+
+    #[tokio::test]
+    async fn test_sa2_empty_hosts_rejected() {
+        let instance = testing::instance();
+        let mesh = HostMeshRef::from_hosts(Name::new("empty").unwrap(), vec![]);
+        let result = spawn_admin([&mesh], instance, None).await;
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("SA-2"), "expected SA-2 error, got: {err}");
+    }
+
+    #[test]
+    fn test_sa3_aggregate_hosts_dedup() {
+        let addr_a: ChannelAddr = "tcp:127.0.0.1:1001".parse().unwrap();
+        let addr_b: ChannelAddr = "tcp:127.0.0.1:1002".parse().unwrap();
+        let addr_c: ChannelAddr = "tcp:127.0.0.1:1003".parse().unwrap();
+
+        // mesh_a: hosts a, b
+        let mesh_a = HostMeshRef::from_hosts(
+            Name::new("mesh_a").unwrap(),
+            vec![addr_a.clone(), addr_b.clone()],
+        );
+        // mesh_b: hosts b, c  (b overlaps with mesh_a)
+        let mesh_b = HostMeshRef::from_hosts(
+            Name::new("mesh_b").unwrap(),
+            vec![addr_b.clone(), addr_c.clone()],
+        );
+
+        let result = aggregate_hosts(&[&mesh_a, &mesh_b], None);
+
+        // 3 unique hosts: a, b, c — b is deduplicated.
+        assert_eq!(result.len(), 3, "expected 3 hosts, got {:?}", result);
+
+        // First-seen order: a (mesh_a[0]), b (mesh_a[1]), c (mesh_b[1]).
+        let addrs: Vec<String> = result.iter().map(|(a, _)| a.clone()).collect();
+        assert_eq!(addrs[0], addr_a.to_string());
+        assert_eq!(addrs[1], addr_b.to_string());
+        assert_eq!(addrs[2], addr_c.to_string());
+    }
+
+    /// SA-6 / CH-1: client host entries are deduplicated against the
+    /// already-aggregated mesh host set.
+    #[test]
+    fn test_sa6_ch1_client_host_dedup() {
+        let addr_a: ChannelAddr = "tcp:127.0.0.1:1001".parse().unwrap();
+        let addr_b: ChannelAddr = "tcp:127.0.0.1:1002".parse().unwrap();
+
+        let mesh = HostMeshRef::from_hosts(
+            Name::new("mesh").unwrap(),
+            vec![addr_a.clone(), addr_b.clone()],
+        );
+
+        // Client host entry overlaps with addr_a.
+        let client_ref = HostRef(addr_a.clone()).mesh_agent();
+        let client_entries = vec![("client_addr".to_string(), client_ref)];
+
+        let result = aggregate_hosts(&[&mesh], Some(client_entries));
+
+        // addr_a already in mesh — client entry is deduplicated.
+        assert_eq!(result.len(), 2, "expected 2 hosts, got {:?}", result);
+        let addrs: Vec<String> = result.iter().map(|(a, _)| a.clone()).collect();
+        assert_eq!(addrs[0], addr_a.to_string());
+        assert_eq!(addrs[1], addr_b.to_string());
     }
 }

--- a/hyperactor_mesh/src/mesh_admin.rs
+++ b/hyperactor_mesh/src/mesh_admin.rs
@@ -198,10 +198,12 @@
 //!
 //! ## Client host invariants (CH-*)
 //!
-//! Let **A** denote the observed host mesh (the host mesh for which
-//! this `MeshAdminAgent` was spawned), and let **C** denote the
-//! process-global singleton client host mesh in the caller process
-//! (whose local proc hosts the root client actor).
+//! Let **A** denote the aggregated host set (the union of hosts
+//! from all meshes passed to [`host_mesh::spawn_admin`],
+//! deduplicated by `HostAgent` `ActorId` — see SA-3), and let
+//! **C** denote the process-global singleton client host mesh in
+//! the caller process (whose local proc hosts the root client
+//! actor).
 //!
 //! - **CH-1 (deduplication):** When C ∈ A, the client host appears
 //!   exactly once in the admin host list (deduplicated by `HostAgent`
@@ -212,17 +214,52 @@
 //! - **CH-2 (reachability):** In both cases, the root client actor
 //!   is reachable through the standard host → proc → actor walk.
 //!
-//! - **CH-3 (ordering):** `spawn_admin` requires `cx: &impl
-//!   context::Actor` (the caller's root client instance). Constructing
-//!   that instance initializes C. Therefore C is available when
-//!   `spawn_admin` executes. Any refactor must preserve this ordering.
+//! - **CH-3 (ordering):** C must be initialized before
+//!   `spawn_admin` executes. In Rust, calling `context()` /
+//!   `this_host()` / `this_proc()` triggers `GLOBAL_CONTEXT`
+//!   bootstrap, which initializes C. In Python, `bootstrap_host()`
+//!   calls `register_client_host()` before any actor code runs.
+//!   Either path ensures C is available by the time `spawn_admin`
+//!   reads it via `try_this_host()`. Any refactor must preserve
+//!   this ordering.
 //!
-//! **Mechanism:** [`HostMeshRef::spawn_admin`] reads C from the
-//! caller process (via `try_this_host()`), merges it with A's host
-//! list, deduplicates by `HostAgent` `ActorId`, and sends the merged
+//! - **CH-4 (runtime-agnostic client-host discovery):** `spawn_admin`
+//!   discovers C via `try_this_host()`, which checks two sources
+//!   in order: the Rust `GLOBAL_CONTEXT` (initialized via
+//!   `context()` / `this_host()` / `this_proc()`) and the
+//!   externally registered client host (set by
+//!   `register_client_host()` from Python's `bootstrap_host()`).
+//!   Aggregation logic must not branch on which source provided C.
+//!
+//! **Mechanism:** [`host_mesh::spawn_admin`] aggregates hosts from
+//! all input meshes (SA-3), reads C from the caller process (via
+//! `try_this_host()`), merges it with the aggregated set (SA-6),
+//! deduplicates by `HostAgent` `ActorId`, and sends the merged
 //! list in `SpawnMeshAdmin`. This works for same-process and
-//! cross-process setups because merge+dedeup happens in the caller
+//! cross-process setups because merge+dedup happens in the caller
 //! process before sending the spawn request.
+//!
+//! ## Spawn/aggregation invariants (SA-*)
+//!
+//! [`host_mesh::spawn_admin`] aggregates hosts from one or more
+//! meshes into a single admin host set.
+//!
+//! - **SA-1 (non-empty mesh set):** The input must yield at least
+//!   one mesh.
+//! - **SA-2 (non-empty hosts):** Every input mesh must contain at
+//!   least one host.
+//! - **SA-3 (host-agent identity dedup):** The admin host set is
+//!   the ordered union of host agents from all input meshes,
+//!   deduplicated by `HostAgent` `ActorId` in first-seen order.
+//! - **SA-4 (single-mesh degeneracy):** `spawn_admin([mesh], ...)`
+//!   is behaviorally equivalent to the former `mesh.spawn_admin(...)`.
+//!   Established by existing single-mesh integration tests (e.g.
+//!   `dining_philosophers`); no dedicated unit test.
+//! - **SA-5 (placement determinism):** The admin is spawned on the
+//!   first input mesh's first host.
+//! - **SA-6 (client-host merge after aggregation):** Client-host
+//!   inclusion/dedup (CH-1) operates on the already-aggregated host
+//!   set, not per-mesh independently.
 //!
 //! ## MAST resolution invariants (MC-*)
 //!

--- a/monarch_hyperactor/src/host_mesh.rs
+++ b/monarch_hyperactor/src/host_mesh.rs
@@ -19,6 +19,7 @@ use hyperactor_mesh::ProcMeshRef;
 use hyperactor_mesh::bootstrap::BootstrapCommand;
 use hyperactor_mesh::bootstrap::ProcBind;
 use hyperactor_mesh::bootstrap::host;
+use hyperactor_mesh::host_mesh;
 use hyperactor_mesh::host_mesh::HostMesh;
 use hyperactor_mesh::host_mesh::HostMeshRef;
 use hyperactor_mesh::host_mesh::host_agent::GetLocalProcClient;
@@ -190,34 +191,6 @@ impl PyHostMesh {
         Ok(Self::new_ref(
             self.mesh_ref()?.with_bootstrap(bootstrap_command.to_rust()),
         ))
-    }
-
-    /// Spawn a MeshAdminAgent on the head host's system proc and
-    /// return its HTTP address as a string.
-    ///
-    /// When `admin_addr` is provided (as a `"host:port"` string), the
-    /// HTTP server binds to that address; otherwise it reads
-    /// `MESH_ADMIN_ADDR` from config.
-    fn _spawn_admin(
-        &self,
-        instance: &PyInstance,
-        admin_addr: Option<String>,
-    ) -> PyResult<PyPythonTask> {
-        let admin_addr = admin_addr
-            .map(|s| {
-                s.parse::<std::net::SocketAddr>()
-                    .map_err(|e| PyException::new_err(format!("invalid admin_addr '{}': {}", s, e)))
-            })
-            .transpose()?;
-        let host_mesh = self.mesh_ref()?.clone();
-        let instance = instance.clone();
-        PyPythonTask::new(async move {
-            let addr = host_mesh
-                .spawn_admin(instance.deref(), admin_addr)
-                .await
-                .map_err(|e| PyException::new_err(e.to_string()))?;
-            Ok(addr)
-        })
     }
 
     fn sliced(&self, region: &PyRegion) -> PyResult<Self> {
@@ -527,6 +500,46 @@ fn shutdown_local_host_mesh() -> PyResult<PyPythonTask> {
     })
 }
 
+/// Spawn a MeshAdminAgent aggregating topology across one or more meshes.
+///
+/// The admin runs on the first mesh's head host system proc and serves
+/// the mesh-admin HTTP API. Returns the admin HTTP URL. When
+/// `admin_addr` is `None`, the bind address is read from
+/// `MESH_ADMIN_ADDR` config.
+///
+/// Python-facing wrapper around
+/// [`hyperactor_mesh::host_mesh::spawn_admin`].
+#[pyfunction]
+fn _spawn_admin(
+    host_meshes: Vec<PyRef<'_, PyHostMesh>>,
+    instance: &PyInstance,
+    admin_addr: Option<String>,
+) -> PyResult<PyPythonTask> {
+    if host_meshes.is_empty() {
+        return Err(PyException::new_err("at least one mesh is required"));
+    }
+
+    let admin_addr = admin_addr
+        .map(|s| {
+            s.parse::<std::net::SocketAddr>()
+                .map_err(|e| PyException::new_err(format!("invalid admin_addr '{}': {}", s, e)))
+        })
+        .transpose()?;
+
+    let mesh_refs = host_meshes
+        .iter()
+        .map(|m| -> PyResult<HostMeshRef> { Ok(m.mesh_ref()?.clone()) })
+        .collect::<PyResult<Vec<HostMeshRef>>>()?;
+
+    let instance = instance.clone();
+    PyPythonTask::new(async move {
+        let addr = host_mesh::spawn_admin(&mesh_refs, instance.deref(), admin_addr)
+            .await
+            .map_err(|e| PyException::new_err(e.to_string()))?;
+        Ok(addr)
+    })
+}
+
 pub fn register_python_bindings(hyperactor_mod: &Bound<'_, PyModule>) -> PyResult<()> {
     let f = wrap_pyfunction!(py_host_mesh_from_bytes, hyperactor_mod)?;
     f.setattr(
@@ -548,6 +561,13 @@ pub fn register_python_bindings(hyperactor_mod: &Bound<'_, PyModule>) -> PyResul
         "monarch._rust_bindings.monarch_hyperactor.host_mesh",
     )?;
     hyperactor_mod.add_function(f3)?;
+
+    let f4 = wrap_pyfunction!(_spawn_admin, hyperactor_mod)?;
+    f4.setattr(
+        "__module__",
+        "monarch._rust_bindings.monarch_hyperactor.host_mesh",
+    )?;
+    hyperactor_mod.add_function(f4)?;
 
     hyperactor_mod.add_class::<PyHostMesh>()?;
     hyperactor_mod.add_class::<PyBootstrapCommand>()?;

--- a/python/examples/dining_philosophers.py
+++ b/python/examples/dining_philosophers.py
@@ -45,6 +45,7 @@ from enum import auto, Enum
 from typing import Any, cast
 
 from monarch._src.actor.actor_mesh import ActorMesh
+from monarch._src.actor.host_mesh import _spawn_admin
 from monarch.actor import Actor, current_rank, endpoint, this_host
 from monarch.distributed_telemetry.actor import start_telemetry
 
@@ -164,7 +165,7 @@ async def async_main(
     host = this_host()
 
     # Spawn the admin agent so the TUI can attach.
-    admin_url = await host._spawn_admin()
+    admin_url = await _spawn_admin([host])
     mtls_flags = (
         "--cacert /var/facebook/rootcanal/ca.pem "
         "--cert /var/facebook/x509_identities/server.pem "

--- a/python/examples/poisoned_mesh.py
+++ b/python/examples/poisoned_mesh.py
@@ -37,6 +37,7 @@ import asyncio
 import sys
 
 import monarch.actor
+from monarch._src.actor.host_mesh import _spawn_admin
 from monarch.actor import Actor, current_rank, endpoint, this_host
 
 
@@ -84,7 +85,7 @@ class Worker(Actor):
 async def async_main(num_procs: int) -> None:
     host = this_host()
 
-    admin_url = await host._spawn_admin()
+    admin_url = await _spawn_admin([host])
     mtls_flags = (
         "--cacert /var/facebook/rootcanal/ca.pem "
         "--cert /var/facebook/x509_identities/server.pem "

--- a/python/examples/pyspy_workload.py
+++ b/python/examples/pyspy_workload.py
@@ -39,6 +39,7 @@ import argparse
 import asyncio
 import time
 
+from monarch._src.actor.host_mesh import _spawn_admin
 from monarch.actor import Actor, endpoint, this_host
 
 
@@ -130,7 +131,7 @@ async def async_main() -> None:
     args = parse_args()
     host = this_host()
 
-    admin_url = await host._spawn_admin()
+    admin_url = await _spawn_admin([host])
     mtls_flags = (
         "--cacert /var/facebook/rootcanal/ca.pem "
         "--cert /var/facebook/x509_identities/server.pem "

--- a/python/examples/rapid_spawn_exit_stress.py
+++ b/python/examples/rapid_spawn_exit_stress.py
@@ -20,6 +20,7 @@ import asyncio
 import time
 
 import monarch.actor
+from monarch._src.actor.host_mesh import _spawn_admin
 from monarch._src.job.process import ProcessJob
 from monarch.actor import Actor, endpoint, this_host
 from monarch.mesh_controller import spawn_tensor_engine
@@ -68,7 +69,7 @@ async def main():
     host = this_host()
 
     # Spawn the admin agent so the TUI can attach.
-    admin_url = await host._spawn_admin()
+    admin_url = await _spawn_admin([host])
     mtls_flags = (
         "--cacert /var/facebook/rootcanal/ca.pem "
         "--cert /var/facebook/x509_identities/server.pem "

--- a/python/examples/sleep_actors.py
+++ b/python/examples/sleep_actors.py
@@ -30,6 +30,7 @@ import argparse
 import asyncio
 import random
 
+from monarch._src.actor.host_mesh import _spawn_admin
 from monarch.actor import Actor, context, current_rank, endpoint, this_host
 
 
@@ -59,7 +60,7 @@ async def async_main(num_procs: int) -> None:
     host = this_host()
 
     # Spawn the admin agent so the TUI can attach.
-    admin_url = await host._spawn_admin()
+    admin_url = await _spawn_admin([host])
     mtls_flags = (
         "--cacert /var/facebook/rootcanal/ca.pem "
         "--cert /var/facebook/x509_identities/server.pem "

--- a/python/examples/stop_mesh.py
+++ b/python/examples/stop_mesh.py
@@ -30,6 +30,7 @@ Press Ctrl+C in this terminal to exit.
 import argparse
 import asyncio
 
+from monarch._src.actor.host_mesh import _spawn_admin
 from monarch.actor import Actor, current_rank, endpoint, this_host
 
 
@@ -45,7 +46,7 @@ class Worker(Actor):
 async def async_main(num_procs: int) -> None:
     host = this_host()
 
-    admin_url = await host._spawn_admin()
+    admin_url = await _spawn_admin([host])
     mtls_flags = (
         "--cacert /var/facebook/rootcanal/ca.pem "
         "--cert /var/facebook/x509_identities/server.pem "

--- a/python/monarch/_rust_bindings/monarch_hyperactor/host_mesh.pyi
+++ b/python/monarch/_rust_bindings/monarch_hyperactor/host_mesh.pyi
@@ -62,29 +62,6 @@ class HostMesh:
         """
         ...
 
-    def _spawn_admin(
-        self,
-        instance: Instance,
-        admin_addr: str | None = None,
-    ) -> PythonTask[str]:
-        """
-        Spawn a MeshAdminAgent on the head host's system proc and
-        return its HTTP URL (including scheme).
-
-        The admin agent aggregates topology across all hosts and
-        serves an HTTP API. When ``admin_addr`` is provided, the
-        server binds to that socket address; otherwise it reads
-        ``MESH_ADMIN_ADDR`` from config.
-
-        Arguments:
-
-        - `instance`: The actor instance used to spawn the admin
-            agent.
-        - `admin_addr`: Optional socket address (e.g. ``"[::]:1729"``).
-
-        """
-        ...
-
     def sliced(self, region: Region) -> "HostMesh":
         """
         Slice this mesh into a new mesh with the given region.
@@ -168,5 +145,25 @@ def shutdown_local_host_mesh() -> PythonTask[None]:
 
     Raises:
         RuntimeError: If no local host mesh exists (bootstrap_host not called)
+    """
+    ...
+
+def _spawn_admin(
+    host_meshes: list[HostMesh],
+    instance: Instance,
+    admin_addr: str | None = None,
+) -> PythonTask[str]:
+    """
+    Spawn a MeshAdminAgent aggregating topology across one or more meshes.
+
+    The admin runs on the first mesh's head host system proc and serves
+    the mesh-admin HTTP API. Returns the admin HTTP URL.
+
+    Arguments:
+    - `host_meshes`: One or more HostMeshes. The first element is the
+      placement mesh. Must not be empty.
+    - `instance`: The actor instance used to spawn the admin agent.
+    - `admin_addr`: Optional socket address (e.g. ``"[::]:1729"``).
+      When ``None``, reads ``MESH_ADMIN_ADDR`` from config.
     """
     ...

--- a/python/monarch/_src/actor/host_mesh.py
+++ b/python/monarch/_src/actor/host_mesh.py
@@ -16,6 +16,7 @@ from typing import Any, Awaitable, Callable, Dict, Literal, Optional, Tuple
 
 from monarch._rust_bindings.monarch_hyperactor.alloc import AllocConstraints, AllocSpec
 from monarch._rust_bindings.monarch_hyperactor.host_mesh import (
+    _spawn_admin as _hy_spawn_admin,
     BootstrapCommand,
     HostMesh as HyHostMesh,
 )
@@ -170,34 +171,6 @@ class HostMesh(MeshTrait):
             True,
             proc_bind,
         )
-
-    def _spawn_admin(self, admin_addr: Optional[str] = None) -> "Future[str]":
-        """
-        Spawn a MeshAdminAgent on the head host's system proc and
-        return its HTTP address.
-
-        The admin agent aggregates topology across all hosts and serves
-        an HTTP API. Use the returned address to connect an admin client::
-
-            head = host_mesh.slice(hosts=0)
-            addr = head._spawn_admin(admin_addr="[::]:1729").get()
-
-        Args:
-            admin_addr: Optional socket address for the admin HTTP server
-                (e.g. ``"[::]:1729"``). When ``None``, reads
-                ``MESH_ADMIN_ADDR`` from config.
-
-        Returns:
-            Future[str]: The admin HTTP URL (e.g. ``"https://myhost.facebook.com:1729"``).
-        """
-
-        async def task() -> str:
-            hy_mesh = await self._hy_host_mesh
-            return await hy_mesh._spawn_admin(
-                context().actor_instance._as_rust(), admin_addr
-            )
-
-        return Future(coro=task())
 
     def _spawn_nonblocking(
         self,
@@ -459,6 +432,47 @@ class HostMesh(MeshTrait):
         if self._inner_host_mesh is None:
             raise RuntimeError("HostMesh has already been shut down")
         return self._inner_host_mesh
+
+
+def _spawn_admin(
+    host_meshes: list["HostMesh"],
+    admin_addr: Optional[str] = None,
+) -> "Future[str]":
+    """
+    Spawn a MeshAdminAgent aggregating topology across one or more HostMeshes.
+
+    The admin runs on the first mesh's head host system proc and serves the
+    mesh-admin HTTP API.
+
+    Use a single-element list for the degenerate single-mesh case::
+
+        host = this_host()
+        admin_url = await _spawn_admin([host], admin_addr="[::]:1729")
+
+    Args:
+        host_meshes: One or more HostMeshes. The first element is the
+            placement mesh (the admin is spawned on its head host).
+            Must not be empty.
+        admin_addr: Optional socket address for the admin HTTP server.
+            When ``None``, reads ``MESH_ADMIN_ADDR`` from config.
+
+    Returns:
+        Future[str]: The admin HTTP URL (for example
+            ``"https://myhost.facebook.com:1729"``).
+
+    Raises:
+        ValueError: If host_meshes is empty.
+    """
+    if not host_meshes:
+        raise ValueError("_spawn_admin requires at least one HostMesh")
+
+    async def task() -> str:
+        hy_meshes = [await m._hy_host_mesh for m in host_meshes]
+        return await _hy_spawn_admin(
+            hy_meshes, context().actor_instance._as_rust(), admin_addr
+        )
+
+    return Future(coro=task())
 
 
 def hosts_from_config(name: str) -> HostMesh:

--- a/python/tests/test_failure_introspection.py
+++ b/python/tests/test_failure_introspection.py
@@ -24,7 +24,7 @@ import urllib.request
 import monarch.actor
 import pytest
 from isolate_in_subprocess import isolate_in_subprocess
-from monarch._src.actor.host_mesh import this_host
+from monarch._src.actor.host_mesh import _spawn_admin, this_host
 from monarch.actor import Actor, endpoint
 from monarch.config import parametrize_config
 
@@ -93,7 +93,7 @@ async def test_failed_actor_has_failure_info() -> None:
     monarch.actor.unhandled_fault_hook = lambda failure: faulted.set()
     try:
         host = this_host()
-        base = _to_loopback(await host._spawn_admin(admin_addr="[::]:0"))
+        base = _to_loopback(await _spawn_admin([host], admin_addr="[::]:0"))
 
         procs = host.spawn_procs(per_host={"replica": 2})
         workers = procs.spawn("worker", FailWorker)
@@ -165,7 +165,7 @@ async def test_healthy_procs_not_poisoned() -> None:
     monarch.actor.unhandled_fault_hook = lambda failure: faulted.set()
     try:
         host = this_host()
-        base = _to_loopback(await host._spawn_admin(admin_addr="[::]:0"))
+        base = _to_loopback(await _spawn_admin([host], admin_addr="[::]:0"))
 
         procs = host.spawn_procs(per_host={"replica": 3})
         workers = procs.spawn("worker", FailWorker)

--- a/python/tests/test_python_actors.py
+++ b/python/tests/test_python_actors.py
@@ -44,7 +44,7 @@ from monarch._rust_bindings.monarch_hyperactor.proc import ActorId
 from monarch._rust_bindings.monarch_hyperactor.pytokio import PythonTask, Shared
 from monarch._src.actor.actor_mesh import ActorMesh, Channel, context, Port
 from monarch._src.actor.future import Future
-from monarch._src.actor.host_mesh import HostMesh, this_host, this_proc
+from monarch._src.actor.host_mesh import _spawn_admin, HostMesh, this_host, this_proc
 from monarch._src.actor.proc_mesh import get_or_spawn_controller, HyProcMesh
 from monarch._src.job.job import LoginJob, ProcessState
 from monarch._src.job.process import ProcessJob
@@ -1485,7 +1485,7 @@ def test_config_propagates_to_host_agent():
         # spawns MeshAdminAgent on the host's system proc. The admin
         # agent reads MESH_ADMIN_ADDR from the host process's config.
         head = hosts.slice(hosts=0)
-        admin_addr = head._spawn_admin().get()
+        admin_addr = _spawn_admin([head]).get()
 
         assert ":9999" in admin_addr, (
             f"Expected :9999 in admin addr '{admin_addr}', "


### PR DESCRIPTION
Summary:
generalize mesh-admin spawn over a set of host meshes instead of a single HostMeshRef. this replaces the old instance method with a free spawn_admin(...) API in hyperactor_mesh, aggregates hosts across one or more meshes, deduplicates by HostAgent actor identity, preserves client-host inclusion via try_this_host(), and keeps the single-mesh case as the degenerate form.

update the Rust, PyO3, Python wrapper, stub, examples, and tests to use the new module-level _spawn_admin([host_meshes], ...) path. remove the old Python/Rust instance _spawn_admin method, migrate all remaining callers, add direct SA-1/SA-2/SA-3/SA-6 invariant tests for empty input and host aggregation/dedup behavior, and tighten the mesh-admin invariant docs to describe the aggregated host-set model and runtime-agnostic client-host discovery. also add the mesh-admin/introspection documentation chapter to the Hyperactor Mesh book summary.

Differential Revision: D98221991


