### PR TITLE
fix benchmarks

### DIFF
--- a/hyperactor/benches/main.rs
+++ b/hyperactor/benches/main.rs
@@ -347,13 +347,14 @@ fn bench_mailbox_message_rates(c: &mut Criterion) {
     group.finish();
 }
 
-criterion_group!(
-    benches,
-    bench_message_sizes,
+criterion_group! {
+    name = benches;
+    config = Criterion::default().without_plots();
+    targets = bench_message_sizes,
     bench_message_rates,
     bench_mailbox_message_sizes,
     bench_mailbox_message_rates,
     bench_channel_ping_pong,
-);
+}
 
 criterion_main!(benches);


### PR DESCRIPTION
Summary:
all benchmarks are currently failing with no font error
```
thread 'main' (441898) panicked at third-party/rust/vendor/criterion-0.5.1/src/plot/plotters_backend/pdf.rs:222:10:
called `Result::unwrap()` on an `Err` value: BackendError(FontError(FontUnavailable))
stack backtrace:
   0: __rustc::rust_begin_unwind
             at ./xplat/rust/toolchain/sysroot/1.94.1/library/std/src/panicking.rs:689:5
   1: core::panicking::panic_fmt
             at ./xplat/rust/toolchain/sysroot/1.94.1/library/core/src/panicking.rs:80:14
   2: core::result::unwrap_failed
             at ./xplat/rust/toolchain/sysroot/1.94.1/library/core/src/result.rs:1867:5
   3: criterion::plot::plotters_backend::pdf::pdf
             at ./xplat/rust/toolchain/sysroot/1.94.1/library/core/src/result.rs:1233:23
   4: <criterion::plot::plotters_backend::PlottersBackend as criterion::plot::Plotter>::pdf
             at ./third-party/rust/vendor/criterion-0.5.1/src/plot/plotters_backend/mod.rs:70:13
   5: <criterion::html::Html as criterion::report::Report>::measurement_complete
             at ./third-party/rust/vendor/criterion-0.5.1/src/html/mod.rs:645:35
   6: criterion::analysis::common::<criterion::measurement::WallTime, ()>
             at ./third-party/rust/vendor/criterion-0.5.1/src/analysis/mod.rs:233:22
   7: <criterion::benchmark_group::BenchmarkGroup<criterion::measurement::WallTime>>::bench_function::<criterion::benchmark_group::BenchmarkId, channel_benchmarks::bench_message_sizes::{closure#0}>
             at ./third-party/rust/vendor/criterion-0.5.1/src/benchmark_group.rs:320:21
   8: channel_benchmarks::main
             at ./fbcode/monarch/hyperactor/benches/main.rs:77:19
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
```

Since we don't use HTML/SVG report generation. Execute benchmark without plots

discovered this from servicelab failure T261150776

Differential Revision: D98326756


