### PR TITLE
Add version switcher to docs with multi-version deployment (#3236)

### DIFF
--- a/.github/workflows/doc_build.yml
+++ b/.github/workflows/doc_build.yml
@@ -3,10 +3,19 @@ name: Docs
 on:
   push:
     branches:
-      - main
       - 'docs/**'
   pull_request:
+  # uncomment this to turn on scheduled deploys of nightly docs.
+  # for now, to secure the gh-pages branch, we require PRs to be accepted to
+  # make changes. So nightlies will have too much overhead of requiring accepts.
+  # schedule:
+  #   - cron: '17 8 * * *'  # Daily at ~8:17 AM UTC (nightly docs from main)
   workflow_dispatch:
+    inputs:
+      version:
+        description: "Docs version to build and deploy (e.g. v0.4.0, nightly). If empty, builds dev docs without deploying."
+        required: false
+        default: ""
 
 concurrency:
   group: docs-${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.run_number || github.ref }}
@@ -24,6 +33,18 @@ jobs:
       submodules: recursive
       upload-artifact: docs
       script: |
+        # Detect docs version from workflow input, branch name, or event type
+        if [[ -n "${{ inputs.version }}" ]]; then
+            export DOCS_VERSION="${{ inputs.version }}"
+        elif [[ "$GITHUB_REF" == refs/heads/docs/* ]]; then
+            export DOCS_VERSION="${GITHUB_REF#refs/heads/docs/}"
+        elif [[ "${{ github.event_name }}" == "schedule" ]]; then
+            export DOCS_VERSION="nightly"
+        else
+            export DOCS_VERSION="dev"
+        fi
+        echo "Building docs for version: $DOCS_VERSION"
+
         # Source common setup functions
         source scripts/common-setup.sh
 
@@ -77,26 +98,148 @@ jobs:
 
   deploy:
     needs: build
-    if: startsWith(github.ref, 'refs/heads/docs/')
+    if: inputs.version != '' || github.event_name == 'schedule' || startsWith(github.ref, 'refs/heads/docs/')
     permissions:
-      pages: write
-      id-token: write
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
+      contents: write
     runs-on: ubuntu-latest
+    # Add an environment for permissions checks to push.
+    environment: github-pages
     steps:
+      - name: Checkout gh-pages branch
+        uses: actions/checkout@v4
+        with:
+          ref: gh-pages
+          path: gh-pages
+          fetch-depth: 1
+        continue-on-error: true
+
+      - name: Create gh-pages branch if needed
+        run: |
+          if [ ! -d "gh-pages" ]; then
+            mkdir gh-pages
+            cd gh-pages
+            git init
+            git checkout -b gh-pages
+            git remote add origin "https://x-access-token:${{ github.token }}@github.com/${{ github.repository }}.git"
+          fi
+
       - name: Download build artifact
         uses: actions/download-artifact@v4
         with:
           name: docs
-          path: .
+          path: artifact
 
-      - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
-        with:
-          path: docs-html
+      - name: Determine version
+        id: version
+        run: |
+          if [[ -n "${{ inputs.version }}" ]]; then
+            VERSION="${{ inputs.version }}"
+          elif [[ "${{ github.event_name }}" == "schedule" ]]; then
+            VERSION="nightly"
+          else
+            VERSION="${GITHUB_REF#refs/heads/docs/}"
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
+      - name: Deploy versioned docs and update metadata
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          SITE_URL="https://meta-pytorch.org/monarch"
+
+          # Copy built docs into versioned subdirectory
+          rm -rf "gh-pages/${VERSION}"
+          cp -r artifact/docs-html "gh-pages/${VERSION}"
+
+          # Update versions.json
+          python3 - <<'PYEOF'
+          import json
+          import os
+          import re
+
+          version = os.environ["VERSION"]
+          site_url = os.environ["SITE_URL"]
+          versions_path = "gh-pages/versions.json"
+
+          # Load existing versions or start fresh
+          if os.path.exists(versions_path):
+              with open(versions_path) as f:
+                  versions = json.load(f)
+          else:
+              versions = []
+
+          # Remove existing entry for this version
+          versions = [v for v in versions if v["version"] != version]
+
+          # Add new entry
+          versions.append({
+              "name": version,
+              "version": version,
+              "url": f"{site_url}/{version}/",
+          })
+
+          # Sort by semver descending (versions like v0.4.0)
+          def sort_key(v):
+              m = re.match(r"v?(\d+)\.(\d+)\.(\d+)(.*)", v["version"])
+              if m:
+                  major, minor, patch = int(m.group(1)), int(m.group(2)), int(m.group(3))
+                  # Stable releases (no suffix) sort above pre-releases
+                  is_stable = 1 if m.group(4) == "" else 0
+                  return (1, major, minor, patch, is_stable)
+              return (0, 0, 0, 0, 0)
+
+          versions.sort(key=sort_key, reverse=True)
+
+          def is_stable_release(v):
+              return bool(re.match(r"v?\d+\.\d+\.\d+$", v["version"]))
+
+          # Mark the latest stable release (pre-releases are never "stable")
+          for i, v in enumerate(versions):
+              if i == 0 and is_stable_release(v):
+                  v["name"] = f"{v['version']} (stable)"
+                  v["preferred"] = True
+              elif v["version"] == "nightly":
+                  v["name"] = "nightly"
+              else:
+                  v["name"] = v["version"]
+                  v.pop("preferred", None)
+
+          with open(versions_path, "w") as f:
+              json.dump(versions, f, indent=2)
+              f.write("\n")
+          PYEOF
+
+          # Generate root index.html redirect to latest stable version
+          LATEST=$(python3 -c "
+          import json, re
+          versions = json.load(open('gh-pages/versions.json'))
+          stable = [v for v in versions if re.match(r'v?\d+\.\d+\.\d+$', v['version'])]
+          print(stable[0]['version'] if stable else 'dev')
+          ")
+
+          cat > gh-pages/index.html <<HTMLEOF
+          <!DOCTYPE html>
+          <html>
+          <head>
+              <meta charset="utf-8">
+              <title>Redirecting to Monarch docs</title>
+              <meta http-equiv="refresh" content="0; url=${LATEST}/">
+              <link rel="canonical" href="${SITE_URL}/${LATEST}/">
+          </head>
+          <body>
+              <p>Redirecting to <a href="${LATEST}/">Monarch ${LATEST} documentation</a>...</p>
+          </body>
+          </html>
+          HTMLEOF
+
+          # Add .nojekyll to prevent Jekyll processing
+          touch gh-pages/.nojekyll
+
+      - name: Push to gh-pages
+        run: |
+          cd gh-pages
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add -A
+          git diff --cached --quiet && echo "No changes to deploy" && exit 0
+          git commit -m "Deploy docs for ${{ steps.version.outputs.version }}"
+          git push origin gh-pages

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -116,6 +116,7 @@ jobs:
   create-docs-branch:
     name: Create docs release branch
     needs: publish
+    if: ${{ github.event.inputs.is_prerelease != 'true' }}
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -17,10 +17,14 @@ import pytorch_sphinx_theme2
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
+# Detect docs version from CI environment (set by doc_build workflow)
+docs_version = os.getenv("DOCS_VERSION", "dev")
+
 project = "Monarch"
 copyright = "2025"
 author = ""
-release = ""
+version = docs_version
+release = docs_version
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
@@ -105,6 +109,12 @@ html_theme_options = {
     ],
     "use_edit_page_button": True,
     "navbar_center": "navbar-nav",
+    "switcher": {
+        "json_url": "https://meta-pytorch.org/monarch/versions.json",
+        "version_match": docs_version,
+    },
+    "show_version_warning_banner": True,
+    "navbar_start": ["navbar-logo", "version-switcher"],
 }
 
 html_favicon = "_static/torch-monarch-icons.svg"


### PR DESCRIPTION
Summary:

Fixes: https://github.com/meta-pytorch/monarch/issues/2631

Configure pytorch_sphinx_theme2's built-in version switcher dropdown and
switch doc deployment from actions/deploy-pages to a gh-pages branch
strategy where each docs/vX.Y.Z branch deploys to its own subdirectory.

- conf.py: Read DOCS_VERSION env var, wire up switcher json_url/version_match
  and add version-switcher to navbar (same pattern as PyTorch core docs)
- doc_build.yml: Extract version from docs/* branch name, deploy built HTML
  to gh-pages/<version>/, auto-manage versions.json and root redirect
- doc_build.yml: Add daily scheduled nightly docs build from main, and
  workflow_dispatch with optional version input for manual deploys

The doc_build workflow now handles three deployment paths:

| Trigger | Version | Deploys? |
|---|---|---|
| Daily schedule | `nightly` | Yes |
| Push to `docs/v0.4.0` | `v0.4.0` | Yes |
| `workflow_dispatch` with version | input value | Yes |
| `workflow_dispatch` without version | `dev` | No |
| Pull request | `dev` | No |

The nightly version appears in the version switcher but is never marked as
preferred; the root URL always redirects to the latest stable semver release.

NOTE: Requires one-time repo settings change: GitHub Pages source from
"GitHub Actions" to "Deploy from branch: gh-pages".

Reviewed By: thedavekwon

Differential Revision: D98170433


