### PR TITLE
[hyperactor_mesh] two-phase shutdown for HostMesh

### DIFF
--- a/hyperactor_mesh/src/comm.rs
+++ b/hyperactor_mesh/src/comm.rs
@@ -1446,7 +1446,7 @@ mod tests {
         let _ = setup.host_mesh.shutdown(setup.instance).await;
     }
 
-    #[async_timed_test(timeout_secs = 60)]
+    #[async_timed_test(timeout_secs = 120)]
     async fn test_cast_and_reply_v1_retrofit() {
         let config = hyperactor_config::global::lock();
         let _guard = config.override_key(ENABLE_NATIVE_V1_CASTING, false);
@@ -1457,7 +1457,7 @@ mod tests {
         execute_cast_and_reply_v1().await
     }
 
-    #[async_timed_test(timeout_secs = 60)]
+    #[async_timed_test(timeout_secs = 120)]
     async fn test_cast_and_reply_v1_native() {
         let config = hyperactor_config::global::lock();
         let _guard = config.override_key(ENABLE_NATIVE_V1_CASTING, true);
@@ -1480,7 +1480,7 @@ mod tests {
         let _ = setup.host_mesh.shutdown(setup.instance).await;
     }
 
-    #[async_timed_test(timeout_secs = 60)]
+    #[async_timed_test(timeout_secs = 120)]
     async fn test_cast_and_accum_v1_retrofit() {
         let config = hyperactor_config::global::lock();
         let _guard = config.override_key(ENABLE_NATIVE_V1_CASTING, false);
@@ -1491,7 +1491,7 @@ mod tests {
         execute_cast_and_accum_v1(&config).await
     }
 
-    #[async_timed_test(timeout_secs = 60)]
+    #[async_timed_test(timeout_secs = 120)]
     async fn test_cast_and_accum_v1_native() {
         let config = hyperactor_config::global::lock();
         let _guard = config.override_key(ENABLE_NATIVE_V1_CASTING, true);
@@ -1581,7 +1581,7 @@ mod tests {
         }
     }
 
-    #[async_timed_test(timeout_secs = 60)]
+    #[async_timed_test(timeout_secs = 120)]
     async fn test_cast_and_reply_once_v1() {
         // Test OncePort without accumulator - port is NOT split.
         // All destinations receive the same original port.
@@ -1603,7 +1603,7 @@ mod tests {
         let _ = setup.host_mesh.shutdown(setup.instance).await;
     }
 
-    #[async_timed_test(timeout_secs = 60)]
+    #[async_timed_test(timeout_secs = 120)]
     async fn test_cast_and_accum_once_v1() {
         // Test OncePort splitting with sum accumulator.
         // Each destination actor replies with its rank.
@@ -1624,7 +1624,7 @@ mod tests {
         let _ = setup.host_mesh.shutdown(setup.instance).await;
     }
 
-    #[async_timed_test(timeout_secs = 60)]
+    #[async_timed_test(timeout_secs = 120)]
     async fn test_unsplit_port_not_split() {
         let instance = crate::testing::instance();
         let mut host_mesh = local_host_mesh(8).await;
@@ -1653,7 +1653,8 @@ mod tests {
         actor_mesh.cast(instance, message).unwrap();
 
         // Verify that all destinations received the original port (not split).
-        for _ in proc_mesh.extent().points() {
+        let num_points = proc_mesh.extent().points().count();
+        for _ in 0..num_points {
             let msg = rx.recv().await.expect("missing");
             match msg {
                 TestMessage::CastWithUnsplitPort { reply_to } => {

--- a/hyperactor_mesh/src/host_mesh.rs
+++ b/hyperactor_mesh/src/host_mesh.rs
@@ -62,6 +62,7 @@ use crate::host_mesh::host_agent::SetClientConfigClient;
 use crate::host_mesh::host_agent::ShutdownHostClient;
 use crate::host_mesh::host_agent::SpawnMeshAdminClient;
 use crate::host_mesh::host_agent::StopHostClient;
+use crate::host_mesh::host_agent::TerminateChildrenClient;
 use crate::mesh_controller::HostMeshController;
 use crate::mesh_controller::ProcMeshController;
 use crate::proc_agent::ProcAgent;
@@ -174,6 +175,24 @@ impl HostRef {
             hyperactor_config::global::get(crate::bootstrap::MESH_TERMINATE_CONCURRENCY);
         agent
             .stop_host(cx, terminate_timeout, max_in_flight.clamp(1, 256))
+            .await?;
+        Ok(())
+    }
+
+    /// Terminate all user procs on this host but keep the host, service
+    /// proc, and networking alive. Used as phase 1 of two-phase
+    /// shutdown so that forwarder flushes can still reach remote hosts.
+    pub(crate) async fn terminate_children(
+        &self,
+        cx: &impl hyperactor::context::Actor,
+    ) -> anyhow::Result<()> {
+        let agent = self.mesh_agent();
+        let terminate_timeout =
+            hyperactor_config::global::get(crate::bootstrap::MESH_TERMINATE_TIMEOUT);
+        let max_in_flight =
+            hyperactor_config::global::get(crate::bootstrap::MESH_TERMINATE_CONCURRENCY);
+        agent
+            .terminate_children(cx, terminate_timeout, max_in_flight.clamp(1, 256))
             .await?;
         Ok(())
     }
@@ -647,18 +666,47 @@ impl HostMesh {
     /// Request a clean shutdown of all hosts owned by this
     /// `HostMesh`.
     ///
-    /// For each host, this sends `ShutdownHost` to its
-    /// `HostAgent`. The agent takes and drops its `Host` (via
-    /// `Option::take()`), which in turn drops the embedded
-    /// `BootstrapProcManager`. On drop, the manager walks its PID
-    /// table and sends SIGKILL to any procs it spawned—tying proc
-    /// lifetimes to their hosts and preventing leaks.
+    /// Uses a two-phase approach:
+    /// 1. **Terminate children** on every host concurrently. Service
+    ///    infrastructure (host agent, comm proc, networking) stays
+    ///    alive so that forwarder flushes can still reach remote hosts.
+    /// 2. **Shut down hosts** concurrently. No user procs remain, so
+    ///    this is fast and cannot deadlock on cross-host flush
+    ///    timeouts.
     #[hyperactor::instrument(fields(host_mesh=self.name.to_string()))]
     pub async fn shutdown(&mut self, cx: &impl hyperactor::context::Actor) -> anyhow::Result<()> {
         tracing::info!(name = "HostMeshStatus", status = "Shutdown::Attempt");
+
+        // Phase 1: terminate all user procs while service infrastructure
+        // stays alive so forwarder flushes can complete across hosts.
+        let results = futures::future::join_all(
+            self.current_ref
+                .values()
+                .map(|host| async move { host.terminate_children(cx).await }),
+        )
+        .await;
+        for result in &results {
+            if let Err(e) = result {
+                tracing::warn!(
+                    name = "HostMeshStatus",
+                    status = "Shutdown::TerminateChildren::Failed",
+                    error = %e,
+                    "terminate_children failed on a host"
+                );
+            }
+        }
+
+        // Phase 2: shut down hosts concurrently. No user procs remain.
+        let results = futures::future::join_all(self.current_ref.values().map(|host| {
+            async move {
+                let result = host.shutdown(cx).await;
+                (host, result)
+            }
+        }))
+        .await;
         let mut failed_hosts = vec![];
-        for host in self.current_ref.values() {
-            if let Err(e) = host.shutdown(cx).await {
+        for (host, result) in &results {
+            if let Err(e) = result {
                 tracing::warn!(
                     name = "HostMeshStatus",
                     status = "Shutdown::Host::Failed",
@@ -699,18 +747,50 @@ impl HostMesh {
     /// but keeping worker processes and their sockets alive for
     /// reconnection.
     ///
+    /// Uses the same two-phase approach as [`shutdown`](Self::shutdown):
+    /// first terminate children across all hosts (while networking
+    /// stays alive), then stop hosts concurrently.
+    ///
     /// After `stop`, the same worker addresses can be passed to
     /// [`HostMesh::attach`] to create a new mesh.
     #[hyperactor::instrument(fields(host_mesh=self.name.to_string()))]
     pub async fn stop(&mut self, cx: &impl hyperactor::context::Actor) -> anyhow::Result<()> {
         tracing::info!(name = "HostMeshStatus", status = "Stop::Attempt");
+
+        // Phase 1: terminate all user procs while service infrastructure
+        // stays alive so forwarder flushes can complete across hosts.
+        let results = futures::future::join_all(
+            self.current_ref
+                .values()
+                .map(|host| async move { host.terminate_children(cx).await }),
+        )
+        .await;
+        for result in &results {
+            if let Err(e) = result {
+                tracing::warn!(
+                    name = "HostMeshStatus",
+                    status = "Stop::TerminateChildren::Failed",
+                    error = %e,
+                    "terminate_children failed on a host"
+                );
+            }
+        }
+
+        // Phase 2: stop hosts concurrently. No user procs remain.
+        let results = futures::future::join_all(self.current_ref.values().map(|host| {
+            async move {
+                let result = host.stop(cx).await;
+                (host, result)
+            }
+        }))
+        .await;
         let mut failed_hosts = vec![];
-        for host in self.current_ref.values() {
-            if let Err(e) = host.stop(cx).await {
+        for (host, result) in &results {
+            if let Err(e) = result {
                 tracing::warn!(
                     name = "HostMeshStatus",
                     status = "Stop::Host::Failed",
-                    %host,
+                    host = %host,
                     error = %e,
                     "host stop failed"
                 );

--- a/hyperactor_mesh/src/host_mesh/host_agent.rs
+++ b/hyperactor_mesh/src/host_mesh/host_agent.rs
@@ -236,6 +236,7 @@ struct ProcStatusChanged {
         resource::List,
         ShutdownHost,
         StopHost,
+        TerminateChildren,
         SpawnMeshAdmin,
         SetClientConfig,
         ProcStatusChanged,
@@ -866,6 +867,32 @@ pub struct StopHost {
 }
 wirevalue::register_type!(StopHost);
 
+/// Terminate all user procs on this host but keep the host, service
+/// proc, and networking alive.  Used as phase 1 of a two-phase mesh
+/// shutdown so that forwarder flushes can still reach remote hosts.
+#[derive(Serialize, Deserialize, Debug, Named, Handler, RefClient, HandleClient)]
+pub struct TerminateChildren {
+    pub timeout: std::time::Duration,
+    pub max_in_flight: usize,
+    #[reply]
+    pub ack: hyperactor::reference::PortRef<()>,
+}
+wirevalue::register_type!(TerminateChildren);
+
+#[async_trait]
+impl Handler<TerminateChildren> for HostAgent {
+    async fn handle(
+        &mut self,
+        cx: &Context<Self>,
+        msg: TerminateChildren,
+    ) -> anyhow::Result<()> {
+        self.terminate_children_and_clear(cx, msg.timeout, msg.max_in_flight)
+            .await;
+        msg.ack.send(cx, ())?;
+        Ok(())
+    }
+}
+
 #[async_trait]
 impl Handler<StopHost> for HostAgent {
     async fn handle(&mut self, cx: &Context<Self>, msg: StopHost) -> anyhow::Result<()> {
@@ -880,12 +907,7 @@ impl Handler<StopHost> for HostAgent {
 
         // Ack after children are terminated so the caller does not
         // tear down the host's networking prematurely.
-        let (return_handle, mut return_receiver) = cx.mailbox().open_port();
-        cx.mailbox()
-            .serialize_and_send(&msg.ack, (), return_handle)?;
-        if return_receiver.recv().await.is_ok() {
-            tracing::warn!("failed to send ack");
-        }
+        msg.ack.send(cx, ())?;
         tracing::info!(
             proc_id = %cx.self_id().proc_id(),
             actor_id = %cx.self_id(),
@@ -909,14 +931,7 @@ impl Handler<ShutdownHost> for HostAgent {
 
         // Ack after children are terminated so the caller does not
         // tear down the host's networking prematurely.
-        let (return_handle, mut return_receiver) = cx.mailbox().open_port();
-        cx.mailbox()
-            .serialize_and_send(&msg.ack, (), return_handle)?;
-
-        // If message is returned, it means the ack was not sent successfully.
-        if return_receiver.recv().await.is_ok() {
-            tracing::warn!("failed to send ack");
-        }
+        msg.ack.send(cx, ())?;
 
         // Drop the host and signal the bootstrap loop to drain the
         // mailbox and exit.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #3251
* #3250
* #3249
* #3248
* #3247
* #3246
* #3245
* #3244
* __->__ #3243
* #3242

HostMesh::shutdown and HostMesh::stop now use a two-phase approach:

1. Terminate all user procs concurrently across hosts via a new
   TerminateChildren message. Service infrastructure (host agent,
   comm proc, networking) stays alive so forwarder flushes can
   still reach remote hosts.
2. Shut down/stop hosts concurrently. No user procs remain, so
   this is fast and cannot deadlock on cross-host flush timeouts.

Previously, each host's ShutdownHost handler terminated children
and then tore down networking atomically. Under concurrent shutdown,
one host could destroy its networking while another host's dying
procs were still flushing forwarders to it, causing hangs until
MESSAGE_DELIVERY_TIMEOUT expired.

Also bumps comm test timeouts from 60s to 120s to accommodate
stress-run CPU contention.

Differential Revision: [D98222466](https://our.internmc.facebook.com/intern/diff/D98222466/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D98222466/)!