### PR TITLE
[hyperactor_mesh] non-blocking TerminateChildren via child actor

### DIFF
--- a/hyperactor_mesh/src/comm.rs
+++ b/hyperactor_mesh/src/comm.rs
@@ -1446,7 +1446,7 @@ mod tests {
         let _ = setup.host_mesh.shutdown(setup.instance).await;
     }
 
-    #[async_timed_test(timeout_secs = 120)]
+    #[async_timed_test(timeout_secs = 60)]
     async fn test_cast_and_reply_v1_retrofit() {
         let config = hyperactor_config::global::lock();
         let _guard = config.override_key(ENABLE_NATIVE_V1_CASTING, false);
@@ -1457,7 +1457,7 @@ mod tests {
         execute_cast_and_reply_v1().await
     }
 
-    #[async_timed_test(timeout_secs = 120)]
+    #[async_timed_test(timeout_secs = 60)]
     async fn test_cast_and_reply_v1_native() {
         let config = hyperactor_config::global::lock();
         let _guard = config.override_key(ENABLE_NATIVE_V1_CASTING, true);
@@ -1480,7 +1480,7 @@ mod tests {
         let _ = setup.host_mesh.shutdown(setup.instance).await;
     }
 
-    #[async_timed_test(timeout_secs = 120)]
+    #[async_timed_test(timeout_secs = 60)]
     async fn test_cast_and_accum_v1_retrofit() {
         let config = hyperactor_config::global::lock();
         let _guard = config.override_key(ENABLE_NATIVE_V1_CASTING, false);
@@ -1491,7 +1491,7 @@ mod tests {
         execute_cast_and_accum_v1(&config).await
     }
 
-    #[async_timed_test(timeout_secs = 120)]
+    #[async_timed_test(timeout_secs = 60)]
     async fn test_cast_and_accum_v1_native() {
         let config = hyperactor_config::global::lock();
         let _guard = config.override_key(ENABLE_NATIVE_V1_CASTING, true);
@@ -1581,7 +1581,7 @@ mod tests {
         }
     }
 
-    #[async_timed_test(timeout_secs = 120)]
+    #[async_timed_test(timeout_secs = 60)]
     async fn test_cast_and_reply_once_v1() {
         // Test OncePort without accumulator - port is NOT split.
         // All destinations receive the same original port.
@@ -1603,7 +1603,7 @@ mod tests {
         let _ = setup.host_mesh.shutdown(setup.instance).await;
     }
 
-    #[async_timed_test(timeout_secs = 120)]
+    #[async_timed_test(timeout_secs = 60)]
     async fn test_cast_and_accum_once_v1() {
         // Test OncePort splitting with sum accumulator.
         // Each destination actor replies with its rank.
@@ -1624,7 +1624,7 @@ mod tests {
         let _ = setup.host_mesh.shutdown(setup.instance).await;
     }
 
-    #[async_timed_test(timeout_secs = 120)]
+    #[async_timed_test(timeout_secs = 60)]
     async fn test_unsplit_port_not_split() {
         let instance = crate::testing::instance();
         let mut host_mesh = local_host_mesh(8).await;
@@ -1674,7 +1674,6 @@ mod tests {
             let val = reply_rx.recv().await.unwrap();
             assert_eq!(val, 42);
         }
-
         let _ = host_mesh.shutdown(instance).await;
     }
 }

--- a/hyperactor_mesh/src/host_mesh.rs
+++ b/hyperactor_mesh/src/host_mesh.rs
@@ -62,7 +62,7 @@ use crate::host_mesh::host_agent::SetClientConfigClient;
 use crate::host_mesh::host_agent::ShutdownHostClient;
 use crate::host_mesh::host_agent::SpawnMeshAdminClient;
 use crate::host_mesh::host_agent::StopHostClient;
-use crate::host_mesh::host_agent::TerminateChildrenClient;
+use crate::host_mesh::host_agent::TerminateProcsClient;
 use crate::mesh_controller::HostMeshController;
 use crate::mesh_controller::ProcMeshController;
 use crate::proc_agent::ProcAgent;
@@ -192,7 +192,7 @@ impl HostRef {
         let max_in_flight =
             hyperactor_config::global::get(crate::bootstrap::MESH_TERMINATE_CONCURRENCY);
         agent
-            .terminate_children(cx, terminate_timeout, max_in_flight.clamp(1, 256))
+            .terminate_procs(cx, terminate_timeout, max_in_flight.clamp(1, 256))
             .await?;
         Ok(())
     }
@@ -675,6 +675,7 @@ impl HostMesh {
     ///    timeouts.
     #[hyperactor::instrument(fields(host_mesh=self.name.to_string()))]
     pub async fn shutdown(&mut self, cx: &impl hyperactor::context::Actor) -> anyhow::Result<()> {
+        let t0 = std::time::Instant::now();
         tracing::info!(name = "HostMeshStatus", status = "Shutdown::Attempt");
 
         // Phase 1: terminate all user procs while service infrastructure
@@ -685,6 +686,7 @@ impl HostMesh {
                 .map(|host| async move { host.terminate_children(cx).await }),
         )
         .await;
+        let phase1_ms = t0.elapsed().as_millis();
         for result in &results {
             if let Err(e) = result {
                 tracing::warn!(
@@ -697,6 +699,7 @@ impl HostMesh {
         }
 
         // Phase 2: shut down hosts concurrently. No user procs remain.
+        let t1 = std::time::Instant::now();
         let results = futures::future::join_all(self.current_ref.values().map(|host| {
             async move {
                 let result = host.shutdown(cx).await;
@@ -704,6 +707,8 @@ impl HostMesh {
             }
         }))
         .await;
+        let phase2_ms = t1.elapsed().as_millis();
+        let total_ms = t0.elapsed().as_millis();
         let mut failed_hosts = vec![];
         for (host, result) in &results {
             if let Err(e) = result {
@@ -718,11 +723,20 @@ impl HostMesh {
             }
         }
         if failed_hosts.is_empty() {
-            tracing::info!(name = "HostMeshStatus", status = "Shutdown::Success");
+            tracing::info!(
+                name = "HostMeshStatus",
+                status = "Shutdown::Success",
+                phase1_ms,
+                phase2_ms,
+                total_ms,
+            );
         } else {
             tracing::error!(
                 name = "HostMeshStatus",
                 status = "Shutdown::Failed",
+                phase1_ms,
+                phase2_ms,
+                total_ms,
                 "host mesh shutdown failed; check the logs of the failed hosts for details: {:?}",
                 failed_hosts
             );
@@ -755,6 +769,7 @@ impl HostMesh {
     /// [`HostMesh::attach`] to create a new mesh.
     #[hyperactor::instrument(fields(host_mesh=self.name.to_string()))]
     pub async fn stop(&mut self, cx: &impl hyperactor::context::Actor) -> anyhow::Result<()> {
+        let t0 = std::time::Instant::now();
         tracing::info!(name = "HostMeshStatus", status = "Stop::Attempt");
 
         // Phase 1: terminate all user procs while service infrastructure
@@ -765,6 +780,7 @@ impl HostMesh {
                 .map(|host| async move { host.terminate_children(cx).await }),
         )
         .await;
+        let phase1_ms = t0.elapsed().as_millis();
         for result in &results {
             if let Err(e) = result {
                 tracing::warn!(
@@ -777,6 +793,7 @@ impl HostMesh {
         }
 
         // Phase 2: stop hosts concurrently. No user procs remain.
+        let t1 = std::time::Instant::now();
         let results = futures::future::join_all(self.current_ref.values().map(|host| {
             async move {
                 let result = host.stop(cx).await;
@@ -784,6 +801,8 @@ impl HostMesh {
             }
         }))
         .await;
+        let phase2_ms = t1.elapsed().as_millis();
+        let total_ms = t0.elapsed().as_millis();
         let mut failed_hosts = vec![];
         for (host, result) in &results {
             if let Err(e) = result {
@@ -798,11 +817,20 @@ impl HostMesh {
             }
         }
         if failed_hosts.is_empty() {
-            tracing::info!(name = "HostMeshStatus", status = "Stop::Success");
+            tracing::info!(
+                name = "HostMeshStatus",
+                status = "Stop::Success",
+                phase1_ms,
+                phase2_ms,
+                total_ms,
+            );
         } else {
             tracing::error!(
                 name = "HostMeshStatus",
                 status = "Stop::Failed",
+                phase1_ms,
+                phase2_ms,
+                total_ms,
                 "host mesh stop failed; check the logs of the failed hosts for details: {:?}",
                 failed_hosts
             );

--- a/hyperactor_mesh/src/host_mesh/host_agent.rs
+++ b/hyperactor_mesh/src/host_mesh/host_agent.rs
@@ -217,6 +217,18 @@ pub(crate) struct ProcCreationState {
 /// Actor name used when spawning the host mesh agent on the system proc.
 pub const HOST_MESH_AGENT_ACTOR_NAME: &str = "host_agent";
 
+/// Lifecycle state of the host managed by [`HostAgent`].
+enum HostAgentState {
+    /// Normal operation — can spawn procs, handle messages.
+    Running(HostAgentMode),
+    /// Children being terminated by a TerminationWorker.
+    Stopping,
+    /// Children terminated, host still alive for shutdown.
+    Stopped(HostAgentMode),
+    /// Host fully shut down (after ShutdownHost).
+    Shutdown,
+}
+
 /// A mesh agent is responsible for managing a host in a [`HostMesh`],
 /// through the resource behaviors defined in [`crate::resource`].
 /// Self-notification sent by bridge tasks when a proc's status changes.
@@ -224,6 +236,72 @@ pub const HOST_MESH_AGENT_ACTOR_NAME: &str = "host_agent";
 #[derive(Debug, Serialize, Deserialize, Named)]
 struct ProcStatusChanged {
     name: Name,
+}
+
+/// Sent by TerminationWorker back to HostAgent when termination completes.
+/// Not exported — delivered locally via PortHandle (no serialization).
+struct TerminationDone {
+    host: HostAgentMode,
+}
+
+/// Child actor whose only job is to run `host.terminate_children()` in
+/// its `init()`, send the ack reply, return the host to the parent
+/// via TerminationDone, and exit. Runs on the same proc as the host
+/// agent so it gets its own `Instance` (required by `terminate_children`).
+#[hyperactor::export(handlers = [])]
+struct TerminationWorker {
+    host: Option<HostAgentMode>,
+    timeout: Duration,
+    max_in_flight: usize,
+    ack: hyperactor_reference::PortRef<()>,
+    done_notify: PortHandle<TerminationDone>,
+}
+
+#[async_trait]
+impl Actor for TerminationWorker {
+    async fn init(&mut self, this: &Instance<Self>) -> Result<(), anyhow::Error> {
+        if let Some(host) = self.host.as_mut() {
+            match host {
+                HostAgentMode::Process { host, .. } => {
+                    host.terminate_children(
+                        this,
+                        self.timeout,
+                        self.max_in_flight.clamp(1, 256),
+                        "terminate children",
+                    )
+                    .await;
+                }
+                HostAgentMode::Local(host) => {
+                    host.terminate_children(
+                        this,
+                        self.timeout,
+                        self.max_in_flight,
+                        "terminate children",
+                    )
+                    .await;
+                }
+            }
+        }
+
+        // Reply ack to the caller.
+        self.ack.send(this, ())?;
+
+        // Return host to parent.
+        if let Some(host) = self.host.take() {
+            let _ = self.done_notify.send(this, TerminationDone { host });
+        }
+
+        Ok(())
+    }
+}
+
+impl fmt::Debug for TerminationWorker {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("TerminationWorker")
+            .field("timeout", &self.timeout)
+            .field("max_in_flight", &self.max_in_flight)
+            .finish()
+    }
 }
 
 #[hyperactor::export(
@@ -236,7 +314,7 @@ struct ProcStatusChanged {
         resource::List,
         ShutdownHost,
         StopHost,
-        TerminateChildren,
+        TerminateProcs,
         SpawnMeshAdmin,
         SetClientConfig,
         ProcStatusChanged,
@@ -245,7 +323,7 @@ struct ProcStatusChanged {
     ]
 )]
 pub struct HostAgent {
-    pub(crate) host: Option<HostAgentMode>,
+    state: HostAgentState,
     pub(crate) created: HashMap<Name, ProcCreationState>,
     /// Pending `WaitRankStatus` waiters, keyed by resource name.
     /// Each entry is `(min_status, rank, reply_port)`. Only touched
@@ -278,13 +356,27 @@ impl HostAgent {
     /// Create a new host mesh agent running in the provided mode.
     pub fn new(host: HostAgentMode) -> Self {
         Self {
-            host: Some(host),
+            state: HostAgentState::Running(host),
             created: HashMap::new(),
             pending_proc_waiters: HashMap::new(),
             watching: HashSet::new(),
             proc_status_port: None,
             local_mesh_agent: OnceLock::new(),
             mailbox_handle: None,
+        }
+    }
+
+    fn host(&self) -> Option<&HostAgentMode> {
+        match &self.state {
+            HostAgentState::Running(h) | HostAgentState::Stopped(h) => Some(h),
+            _ => None,
+        }
+    }
+
+    fn host_mut(&mut self) -> Option<&mut HostAgentMode> {
+        match &mut self.state {
+            HostAgentState::Running(h) | HostAgentState::Stopped(h) => Some(h),
+            _ => None,
         }
     }
 
@@ -299,7 +391,7 @@ impl HostAgent {
         timeout: std::time::Duration,
         max_in_flight: usize,
     ) {
-        if let Some(host_mode) = self.host.as_mut() {
+        if let Some(host_mode) = self.host_mut() {
             match host_mode {
                 HostAgentMode::Process { host, .. } => {
                     let summary = host
@@ -322,9 +414,9 @@ impl HostAgent {
     /// introspection. Called from init and after each state change
     /// (proc created/stopped).
     fn publish_introspect_properties(&self, cx: &Instance<Self>) {
-        let host = match self.host.as_ref() {
+        let host = match self.host() {
             Some(h) => h,
-            None => return, // host shut down
+            None => return, // host shut down or stopping
         };
 
         let addr = host.addr().to_string();
@@ -364,7 +456,7 @@ impl Actor for HostAgent {
         // Serve the host now that the agent is initialized. Make sure our port is
         // bound before serving.
         this.bind::<Self>();
-        match self.host.as_mut().unwrap() {
+        match self.host_mut().unwrap() {
             HostAgentMode::Process { host, .. } => {
                 self.mailbox_handle = host.serve();
                 let (directory, file) = hyperactor_telemetry::log_file_path(
@@ -388,7 +480,7 @@ impl Actor for HostAgent {
 
         // Register callback for QueryChild — resolves system procs
         // that are not independently addressable actors.
-        let host = self.host.as_ref().expect("host present");
+        let host = self.host().expect("host present");
         let system_proc = host.system_proc().clone();
         let local_proc = host.local_proc().clone();
         let self_id = this.self_id().clone();
@@ -499,7 +591,7 @@ impl Handler<resource::CreateOrUpdate<ProcSpec>> for HostAgent {
             return Ok(());
         }
 
-        let host = self.host.as_mut().expect("host present");
+        let host = self.host_mut().expect("host present");
         let created = match host {
             HostAgentMode::Process { host, .. } => {
                 host.spawn(
@@ -578,8 +670,7 @@ impl Handler<resource::Stop> for HostAgent {
             "stopping proc"
         );
         let host = self
-            .host
-            .as_ref()
+            .host()
             .ok_or(anyhow::anyhow!("HostAgent has already shut down"))?;
         let timeout = hyperactor_config::global::get(hyperactor::config::PROCESS_EXIT_TIMEOUT);
 
@@ -615,7 +706,7 @@ impl Handler<resource::GetRankStatus> for HostAgent {
                 rank,
                 created: Ok((proc_id, _mesh_agent)),
             }) => {
-                let status = match self.host.as_ref() {
+                let status = match self.host() {
                     Some(host) => host.proc_status(proc_id).await.0,
                     None => Status::Stopped,
                 };
@@ -667,7 +758,7 @@ impl Handler<resource::WaitRankStatus> for HostAgent {
                 created: Ok((proc_id, _)),
             }) => {
                 let rank = *rank;
-                let status = match self.host.as_ref() {
+                let status = match self.host() {
                     Some(host) => host.proc_status(proc_id).await.0,
                     None => Status::Stopped,
                 };
@@ -727,7 +818,7 @@ impl Handler<ProcStatusChanged> for HostAgent {
             Some(ProcCreationState {
                 created: Ok((proc_id, _)),
                 ..
-            }) => match self.host.as_ref() {
+            }) => match self.host() {
                 Some(host) => host.proc_status(proc_id).await.0,
                 None => Status::Stopped,
             },
@@ -789,7 +880,7 @@ impl HostAgent {
             None => return,
         };
 
-        match self.host.as_ref() {
+        match self.host() {
             Some(HostAgentMode::Process { host, .. }) => {
                 if let Some(rx) = host.manager().watch(proc_id).await {
                     start_proc_watch(port, rx, name.clone(), |s| s.clone().into());
@@ -871,24 +962,56 @@ wirevalue::register_type!(StopHost);
 /// proc, and networking alive.  Used as phase 1 of a two-phase mesh
 /// shutdown so that forwarder flushes can still reach remote hosts.
 #[derive(Serialize, Deserialize, Debug, Named, Handler, RefClient, HandleClient)]
-pub struct TerminateChildren {
+pub struct TerminateProcs {
     pub timeout: std::time::Duration,
     pub max_in_flight: usize,
     #[reply]
     pub ack: hyperactor::reference::PortRef<()>,
 }
-wirevalue::register_type!(TerminateChildren);
+wirevalue::register_type!(TerminateProcs);
 
 #[async_trait]
-impl Handler<TerminateChildren> for HostAgent {
+impl Handler<TerminateProcs> for HostAgent {
     async fn handle(
         &mut self,
         cx: &Context<Self>,
-        msg: TerminateChildren,
+        msg: TerminateProcs,
     ) -> anyhow::Result<()> {
-        self.terminate_children_and_clear(cx, msg.timeout, msg.max_in_flight)
-            .await;
-        msg.ack.send(cx, ())?;
+        // Only proceed if Running.
+        let host = match std::mem::replace(&mut self.state, HostAgentState::Shutdown) {
+            HostAgentState::Running(h) => h,
+            other => {
+                // Already stopping/stopped — put state back, ack immediately.
+                self.state = other;
+                msg.ack.send(cx, ())?;
+                return Ok(());
+            }
+        };
+        self.created.clear();
+
+        self.state = HostAgentState::Stopping;
+
+        let done_port = cx.port::<TerminationDone>();
+
+        cx.spawn_with_name(
+            "termination_worker",
+            TerminationWorker {
+                host: Some(host),
+                timeout: msg.timeout,
+                max_in_flight: msg.max_in_flight,
+                ack: msg.ack,
+                done_notify: done_port,
+            },
+        )?;
+
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl Handler<TerminationDone> for HostAgent {
+    async fn handle(&mut self, _cx: &Context<Self>, msg: TerminationDone) -> anyhow::Result<()> {
+        self.state = HostAgentState::Stopped(msg.host);
         Ok(())
     }
 }
@@ -902,8 +1025,10 @@ impl Handler<StopHost> for HostAgent {
         // the host proc's networking while children are still running,
         // causing their forwarder flushes to hang until
         // MESSAGE_DELIVERY_TIMEOUT expires.
-        self.terminate_children_and_clear(cx, msg.timeout, msg.max_in_flight)
-            .await;
+        if !self.created.is_empty() {
+            self.terminate_children_and_clear(cx, msg.timeout, msg.max_in_flight)
+                .await;
+        }
 
         // Ack after children are terminated so the caller does not
         // tear down the host's networking prematurely.
@@ -926,8 +1051,10 @@ impl Handler<ShutdownHost> for HostAgent {
         // the host proc's networking while children are still running,
         // causing their forwarder flushes to hang until
         // MESSAGE_DELIVERY_TIMEOUT expires.
-        self.terminate_children_and_clear(cx, msg.timeout, msg.max_in_flight)
-            .await;
+        if !self.created.is_empty() {
+            self.terminate_children_and_clear(cx, msg.timeout, msg.max_in_flight)
+                .await;
+        }
 
         // Ack after children are terminated so the caller does not
         // tear down the host's networking prematurely.
@@ -935,19 +1062,25 @@ impl Handler<ShutdownHost> for HostAgent {
 
         // Drop the host and signal the bootstrap loop to drain the
         // mailbox and exit.
-        if let Some(HostAgentMode::Process {
-            shutdown_tx: Some(tx),
-            ..
-        }) = self.host.take()
-        {
-            tracing::info!(
-                proc_id = %cx.self_id().proc_id(),
-                actor_id = %cx.self_id(),
-                "host is shut down, sending mailbox handle to bootstrap for draining"
-            );
-            if let Some(handle) = self.mailbox_handle.take() {
-                let _ = tx.send(handle);
+        match std::mem::replace(&mut self.state, HostAgentState::Shutdown) {
+            HostAgentState::Running(HostAgentMode::Process {
+                shutdown_tx: Some(tx),
+                ..
+            })
+            | HostAgentState::Stopped(HostAgentMode::Process {
+                shutdown_tx: Some(tx),
+                ..
+            }) => {
+                tracing::info!(
+                    proc_id = %cx.self_id().proc_id(),
+                    actor_id = %cx.self_id(),
+                    "host is shut down, sending mailbox handle to bootstrap for draining"
+                );
+                if let Some(handle) = self.mailbox_handle.take() {
+                    let _ = tx.send(handle);
+                }
             }
+            _ => {}
         }
 
         Ok(())
@@ -976,7 +1109,7 @@ impl Handler<resource::GetState<ProcState>> for HostAgent {
                 rank,
                 created: Ok((proc_id, mesh_agent)),
             }) => {
-                let (status, proc_status, bootstrap_command) = match self.host.as_ref() {
+                let (status, proc_status, bootstrap_command) = match self.host() {
                     Some(host) => {
                         let (status, proc_status) = host.proc_status(proc_id).await;
                         (status, proc_status, host.bootstrap_command())
@@ -1074,8 +1207,7 @@ impl Handler<SpawnMeshAdmin> for HostAgent {
     /// address.
     async fn handle(&mut self, cx: &Context<Self>, msg: SpawnMeshAdmin) -> anyhow::Result<()> {
         let proc = self
-            .host
-            .as_ref()
+            .host()
             .ok_or_else(|| anyhow::anyhow!("host is not available"))?
             .system_proc();
 
@@ -1153,7 +1285,7 @@ impl Handler<GetLocalProc> for HostAgent {
         GetLocalProc { proc_mesh_agent }: GetLocalProc,
     ) -> anyhow::Result<()> {
         let agent = self.local_mesh_agent.get_or_init(|| {
-            ProcAgent::boot_v1(self.host.as_ref().unwrap().local_proc().clone(), None)
+            ProcAgent::boot_v1(self.host().unwrap().local_proc().clone(), None)
         });
 
         match agent {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #3251
* #3250
* #3249
* #3248
* #3247
* #3246
* #3245
* __->__ #3244
* #3243
* #3242

System actors shouldn't block: they need to stay responsive so we
can observe their status.

This change makes child termination nonblocking.

- Add HostAgentState enum (Running/Stopping/Shutdown) replacing
  Option<HostAgentMode>
- Add TerminationWorker child actor that runs terminate_children in
  init(), sends the ack, and returns the host via oneshot channel
- Add TerminationDone handler to recover the host after termination
- StopHost/ShutdownHost skip redundant termination when created is empty

Differential Revision: [D98222465](https://our.internmc.facebook.com/intern/diff/D98222465/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D98222465/)!