### PR TITLE
[monarch] add process lifecycle logging to ProcessJob

### DIFF
--- a/python/monarch/_src/job/process.py
+++ b/python/monarch/_src/job/process.py
@@ -13,6 +13,7 @@ import signal
 import subprocess
 import sys
 import tempfile
+import threading
 from typing import Dict, List, Optional, Union
 
 from monarch._src.actor.bootstrap import attach_to_workers
@@ -97,9 +98,60 @@ class ProcessJob(JobTrait):
                         start_new_session=True,
                     )
                     self._host_to_pid[host_key] = ProcessState(proc.pid, addr)
+                    logger.info(
+                        "ProcessJob: spawned worker pid=%d mesh=%s rank=%d addr=%s",
+                        proc.pid,
+                        mesh_name,
+                        i,
+                        addr,
+                    )
+                    self._watch_process(proc, mesh_name, i, addr)
         except Exception:
             self._kill()
             raise
+
+    @staticmethod
+    def _watch_process(
+        proc: subprocess.Popen,
+        mesh_name: str,
+        rank: int,
+        addr: str,
+    ) -> None:
+        def _waiter() -> None:
+            pid = proc.pid
+            try:
+                proc.wait()
+                code = proc.returncode
+            except Exception:
+                logger.exception(
+                    "ProcessJob: error waiting on pid=%d mesh=%s rank=%d addr=%s",
+                    pid,
+                    mesh_name,
+                    rank,
+                    addr,
+                )
+                return
+            if code == 0 or code == -signal.SIGTERM:
+                logger.info(
+                    "ProcessJob: worker exited pid=%d exit_code=%d mesh=%s rank=%d addr=%s",
+                    pid,
+                    code,
+                    mesh_name,
+                    rank,
+                    addr,
+                )
+            else:
+                logger.warning(
+                    "ProcessJob: worker died unexpectedly pid=%d exit_code=%d mesh=%s rank=%d addr=%s",
+                    pid,
+                    code,
+                    mesh_name,
+                    rank,
+                    addr,
+                )
+
+        t = threading.Thread(target=_waiter, daemon=True, name=f"watch-{mesh_name}_{rank}")
+        t.start()
 
     def _state(self) -> JobState:
         if not self._pids_active():


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #3251
* #3250
* #3249
* #3248
* #3247
* #3246
* __->__ #3245
* #3244
* #3243
* #3242

Log each worker process spawn (pid, mesh, rank, address) and monitor
for unexpected death via a per-process waitpid thread that reports
exit codes at warning level.

This can be useful in debugging failing python tests that use ProcessJob.

Differential Revision: [D98222464](https://our.internmc.facebook.com/intern/diff/D98222464/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D98222464/)!