### PR TITLE
[hyperactor] add LinkStatus to send loop error messages

### DIFF
--- a/hyperactor/src/channel/net.rs
+++ b/hyperactor/src/channel/net.rs
@@ -170,6 +170,56 @@ use session::Session;
 use crate::config;
 use crate::metrics;
 
+pub(crate) enum LinkStatus {
+    NeverConnected,
+    Connected(tokio::time::Instant),
+    Disconnected {
+        last_connected: tokio::time::Instant,
+        since: tokio::time::Instant,
+    },
+}
+
+impl LinkStatus {
+    fn connected(&mut self) {
+        *self = LinkStatus::Connected(tokio::time::Instant::now());
+    }
+
+    fn disconnected(&mut self) {
+        match *self {
+            LinkStatus::Connected(at) => {
+                *self = LinkStatus::Disconnected {
+                    last_connected: at,
+                    since: tokio::time::Instant::now(),
+                };
+            }
+            // Already disconnected or never connected — leave as is.
+            _ => {}
+        }
+    }
+}
+
+impl std::fmt::Display for LinkStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            LinkStatus::NeverConnected => write!(f, "never connected"),
+            LinkStatus::Connected(at) => {
+                write!(f, "connected for {:.1}s", at.elapsed().as_secs_f64())
+            }
+            LinkStatus::Disconnected {
+                last_connected,
+                since,
+            } => {
+                write!(
+                    f,
+                    "last connected {:.1}s ago, disconnected for {:.1}s",
+                    last_connected.elapsed().as_secs_f64(),
+                    since.elapsed().as_secs_f64(),
+                )
+            }
+        }
+    }
+}
+
 /// Log a send-loop error and return `true` if the error is terminal
 /// (caller should exit), `false` if recoverable (caller should reconnect).
 fn log_send_error(
@@ -177,10 +227,11 @@ fn log_send_error(
     dest: &ChannelAddr,
     session_id: u64,
     mode: &str,
+    link_status: &LinkStatus,
 ) -> bool {
     match error {
         session::SendLoopError::Io(err) => {
-            tracing::info!(dest = %dest, session_id, error = %err, mode, "send error");
+            tracing::info!(dest = %dest, session_id, error = %err, mode, "send error; {link_status}");
             metrics::CHANNEL_ERRORS.add(
                 1,
                 hyperactor_telemetry::kv_pairs!(
@@ -194,23 +245,23 @@ fn log_send_error(
         }
         session::SendLoopError::AppClosed => true,
         session::SendLoopError::Rejected(reason) => {
-            tracing::error!(dest = %dest, session_id, mode, "server rejected connection: {reason}");
+            tracing::error!(dest = %dest, session_id, mode, "server rejected connection: {reason}; {link_status}");
             true
         }
         session::SendLoopError::ServerClosed => {
-            tracing::info!(dest = %dest, session_id, mode, "server closed the channel");
+            tracing::info!(dest = %dest, session_id, mode, "server closed the channel; {link_status}");
             true
         }
         session::SendLoopError::DeliveryTimeout => {
             let timeout = hyperactor_config::global::get(config::MESSAGE_DELIVERY_TIMEOUT);
             tracing::error!(
                 dest = %dest, session_id, mode,
-                "failed to receive ack within timeout {timeout:?}; link is currently connected"
+                "failed to receive ack within timeout {timeout:?}; link is currently connected; {link_status}"
             );
             true
         }
         session::SendLoopError::OversizedFrame(reason) => {
-            tracing::error!(dest = %dest, session_id, mode, "oversized frame: {reason}");
+            tracing::error!(dest = %dest, session_id, mode, "oversized frame: {reason}; {link_status}");
             true
         }
     }
@@ -264,6 +315,8 @@ pub(crate) fn spawn<M: RemoteMessage>(link: impl Link) -> NetTx<M> {
             .with_max_elapsed_time(None)
             .build();
 
+        let mut link_status = LinkStatus::NeverConnected;
+
         let reason: String = 'outer: loop {
             let connected = match deliveries.expiry_time() {
                 Some(deadline) => match session.connect_by(deadline).await {
@@ -272,11 +325,11 @@ pub(crate) fn spawn<M: RemoteMessage>(link: impl Link) -> NetTx<M> {
                         let timeout =
                             hyperactor_config::global::get(config::MESSAGE_DELIVERY_TIMEOUT);
                         let error_msg = if deliveries.outbox.is_expired(timeout) {
-                            format!("failed to deliver message within timeout {timeout:?}",)
+                            format!("failed to deliver message within timeout {timeout:?}; {link_status}")
                         } else {
                             format!(
                                 "failed to receive ack within timeout {timeout:?}; \
-                                 link is currently broken",
+                                 link is currently broken; {link_status}",
                             )
                         };
                         tracing::error!(
@@ -313,12 +366,16 @@ pub(crate) fn spawn<M: RemoteMessage>(link: impl Link) -> NetTx<M> {
             }
             deliveries.requeue_unacked();
 
+            link_status.connected();
             let connected_at = tokio::time::Instant::now();
+
             let result = {
                 let stream = connected.stream(INITIATOR_TO_ACCEPTOR);
                 session::send_connected(&stream, &mut deliveries, &mut receiver).await
             };
             session = connected.release();
+
+            link_status.disconnected();
 
             // Reset backoff if the connection was alive long enough to have
             // been useful (i.e. not an immediate EOF/error).
@@ -334,13 +391,13 @@ pub(crate) fn spawn<M: RemoteMessage>(link: impl Link) -> NetTx<M> {
                             dest = %dest,
                             session_id = session_id.0,
                             delay_ms = delay.as_millis() as u64,
-                            "send_connected returned EOF, reconnecting after backoff"
+                            "send_connected returned EOF, reconnecting after backoff; {link_status}"
                         );
                         tokio::time::sleep(delay).await;
                     }
                 }
                 Err(ref e) => {
-                    if log_send_error(e, &dest, session_id.0, "simplex") {
+                    if log_send_error(e, &dest, session_id.0, "simplex", &link_status) {
                         break 'outer format!("{log_id}: {e}");
                     }
                     // Recoverable error — reconnect after backoff.
@@ -350,7 +407,7 @@ pub(crate) fn spawn<M: RemoteMessage>(link: impl Link) -> NetTx<M> {
                             session_id = session_id.0,
                             delay_ms = delay.as_millis() as u64,
                             error = %e,
-                            "send_connected returned recoverable error, reconnecting after backoff"
+                            "send_connected returned recoverable error, reconnecting after backoff; {link_status}"
                         );
                         tokio::time::sleep(delay).await;
                     }

--- a/hyperactor/src/channel/net/duplex.rs
+++ b/hyperactor/src/channel/net/duplex.rs
@@ -40,6 +40,7 @@ use tokio_util::sync::CancellationToken;
 
 use super::ClientError;
 use super::Link;
+use super::LinkStatus;
 use super::ServerError;
 use super::SessionId;
 use super::log_send_error;
@@ -397,6 +398,8 @@ pub(crate) fn spawn<Out: RemoteMessage, In: RemoteMessage>(
             .with_max_elapsed_time(None)
             .build();
 
+        let mut link_status = LinkStatus::NeverConnected;
+
         loop {
             let connected = match session.connect().await {
                 Ok(s) => s,
@@ -425,7 +428,9 @@ pub(crate) fn spawn<Out: RemoteMessage, In: RemoteMessage>(
             }
             deliveries.requeue_unacked();
 
+            link_status.connected();
             let connected_at = tokio::time::Instant::now();
+
             let result = {
                 let send_stream = connected.stream(super::INITIATOR_TO_ACCEPTOR);
                 let recv_stream = connected.stream(super::ACCEPTOR_TO_INITIATOR);
@@ -439,6 +444,8 @@ pub(crate) fn spawn<Out: RemoteMessage, In: RemoteMessage>(
                 }
             };
 
+            link_status.disconnected();
+
             if connected_at.elapsed() > tokio::time::Duration::from_secs(1) {
                 reconnect_backoff.reset();
             }
@@ -450,14 +457,14 @@ pub(crate) fn spawn<Out: RemoteMessage, In: RemoteMessage>(
                             dest = %dest,
                             session_id = session_id.0,
                             delay_ms = delay.as_millis() as u64,
-                            "duplex send_connected returned EOF, reconnecting after backoff"
+                            "duplex send_connected returned EOF, reconnecting after backoff; {link_status}"
                         );
                         tokio::time::sleep(delay).await;
                     }
                     false
                 }
                 Err(Either::Send(e)) => {
-                    let terminal = log_send_error(e, &dest, session_id.0, "duplex");
+                    let terminal = log_send_error(e, &dest, session_id.0, "duplex", &link_status);
                     if !terminal {
                         // Recoverable send error — reconnect after backoff.
                         if let Some(delay) = reconnect_backoff.next_backoff() {
@@ -467,7 +474,7 @@ pub(crate) fn spawn<Out: RemoteMessage, In: RemoteMessage>(
                                 error = %e,
                                 delay_ms = delay.as_millis() as u64,
                                 mode = "duplex",
-                                "send error (recoverable), reconnecting after backoff",
+                                "send error (recoverable), reconnecting after backoff; {link_status}",
                             );
                             tokio::time::sleep(delay).await;
                         }
@@ -482,7 +489,7 @@ pub(crate) fn spawn<Out: RemoteMessage, In: RemoteMessage>(
                             error = %err,
                             delay_ms = delay.as_millis() as u64,
                             mode = "duplex",
-                            "recv error (recoverable), reconnecting after backoff",
+                            "recv error (recoverable), reconnecting after backoff; {link_status}",
                         );
                         tokio::time::sleep(delay).await;
                     }
@@ -502,7 +509,7 @@ pub(crate) fn spawn<Out: RemoteMessage, In: RemoteMessage>(
                         dest = %dest,
                         session_id = session_id.0,
                         error = %e,
-                        "duplex recv terminal error"
+                        "duplex recv terminal error; {link_status}"
                     );
                     true
                 }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #3260
* #3259
* #3258
* #3257
* #3256
* __->__ #3255
* #3254
* #3253
* #3252

Track connection state (never connected, connected, disconnected) in
both simplex and duplex send loops, and include it in all error/info
log messages for easier debugging of link issues.

Differential Revision: [D98196095](https://our.internmc.facebook.com/intern/diff/D98196095/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D98196095/)!