### PR TITLE
[monarch] flush pending spawns before HostMesh shutdown

### DIFF
--- a/python/monarch/_src/actor/host_mesh.py
+++ b/python/monarch/_src/actor/host_mesh.py
@@ -88,6 +88,7 @@ class HostMesh(MeshTrait):
         self._stream_logs = stream_logs
         self._is_fake_in_process = is_fake_in_process
         self._code_sync_proc_mesh: Optional["_Lazy[ProcMesh]"] = code_sync_proc_mesh
+        self._pending_spawns: list[Shared[HyProcMesh]] = []
 
     @classmethod
     def _allocate_nonblocking(
@@ -223,9 +224,12 @@ class HostMesh(MeshTrait):
                 context().actor_instance._as_rust(), name, per_host, proc_bind
             )
 
+        spawn_shared = PythonTask.from_coroutine(task()).spawn()
+        self._pending_spawns.append(spawn_shared)
+
         return ProcMesh.from_host_mesh(
             self,
-            PythonTask.from_coroutine(task()).spawn(),
+            spawn_shared,
             Extent(
                 self._labels + tuple(per_host.labels),
                 self.region.slice().sizes + list(per_host.sizes),
@@ -359,6 +363,14 @@ class HostMesh(MeshTrait):
     def _initialized_mesh(self) -> HyHostMesh:
         return self._hy_host_mesh.poll() or self._hy_host_mesh.block_on()
 
+    async def _flush_pending_spawns(self) -> None:
+        for shared in self._pending_spawns:
+            try:
+                await shared
+            except Exception:
+                pass
+        self._pending_spawns.clear()
+
     def shutdown(self) -> Future[None]:
         """
         Shutdown the host mesh and all of its processes. It will throw an exception
@@ -377,6 +389,7 @@ class HostMesh(MeshTrait):
         """
 
         async def task() -> None:
+            await self._flush_pending_spawns()
             hy_mesh = await self._hy_host_mesh
             await hy_mesh.shutdown(context().actor_instance._as_rust())
             # Remove the inner host mesh to clean up associated memory.
@@ -398,6 +411,7 @@ class HostMesh(MeshTrait):
         """
 
         async def task() -> None:
+            await self._flush_pending_spawns()
             hy_mesh = await self._hy_host_mesh
             await hy_mesh.stop(context().actor_instance._as_rust())
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #3260
* #3259
* #3258
* __->__ #3257
* #3256
* #3255
* #3254
* #3253
* #3252

The Python API uses pytokio to spawn background tasks to simulate
asynchronous (proc, actor) mesh spawns. This means that it is possible
for a proc mesh spawn to not yet be executed before we perform a shutdown
of the underlying host mesh.

This violates the API: the spawn *should* establish a happens-before
relationship per the ordering guarantees; however, because pytokio is
in the mix, we don't directly control the message ordering.

This violation is the cause of some test failures on Python GPU, where
proc spawns could arrive *after* a host was shut down (or in the middle
of shutting down).

We fix this by recording the creation events, and then flushing them
before performing shutdown, establishing the missing happens-before
relationship.

However, this problem is deeper still: any time we mix pytokio tasks
with other messaging, we risk violating ordering guarantees. For example,
a user might spawn two proc meshes in quick succession, and rely on the
order in which they were spawned.

Luckily, these scenarios are currently limited to (proc and actor) spawns,
where a user is not guaranteed a correspondence between messaging and
spawning, but this seems like something worth repairing as it makes the
system as a whole much harder to reason about.

Differential Revision: [D98243075](https://our.internmc.facebook.com/intern/diff/D98243075/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D98243075/)!