### PR TITLE
[hyperactor_mesh] replace panics with errors in host agent handlers

### DIFF
--- a/hyperactor_mesh/src/host_mesh/host_agent.rs
+++ b/hyperactor_mesh/src/host_mesh/host_agent.rs
@@ -591,7 +591,9 @@ impl Handler<resource::CreateOrUpdate<ProcSpec>> for HostAgent {
             return Ok(());
         }
 
-        let host = self.host_mut().expect("host present");
+        let host = self
+            .host_mut()
+            .ok_or_else(|| anyhow::anyhow!("HostAgent has already shut down"))?;
         let created = match host {
             HostAgentMode::Process { host, .. } => {
                 host.spawn(
@@ -1284,8 +1286,11 @@ impl Handler<GetLocalProc> for HostAgent {
         cx: &Context<Self>,
         GetLocalProc { proc_mesh_agent }: GetLocalProc,
     ) -> anyhow::Result<()> {
+        let host = self
+            .host()
+            .ok_or_else(|| anyhow::anyhow!("HostAgent has already shut down"))?;
         let agent = self.local_mesh_agent.get_or_init(|| {
-            ProcAgent::boot_v1(self.host().unwrap().local_proc().clone(), None)
+            ProcAgent::boot_v1(host.local_proc().clone(), None)
         });
 
         match agent {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #3260
* #3259
* __->__ #3258
* #3257
* #3256
* #3255
* #3254
* #3253
* #3252

Replace .expect("host present") and .unwrap() with .ok_or_else() in
CreateOrUpdate and GetLocalProc handlers so a late-arriving message
after shutdown returns a more precise error.

Differential Revision: [D98243076](https://our.internmc.facebook.com/intern/diff/D98243076/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D98243076/)!