### PR TITLE
Fix agentDisplayName null/undefined crash

### DIFF
--- a/python/monarch/monarch_dashboard/frontend/src/__tests__/status.test.ts
+++ b/python/monarch/monarch_dashboard/frontend/src/__tests__/status.test.ts
@@ -140,6 +140,12 @@ describe("agentDisplayName", () => {
     expect(agentDisplayName("PythonActor<Trainer>[0]", 0)).toBeNull();
     expect(agentDisplayName("Python<_SMPD>", 0)).toBeNull();
   });
+
+  test("returns null for null/undefined fullName", () => {
+    expect(agentDisplayName(null)).toBeNull();
+    expect(agentDisplayName(undefined)).toBeNull();
+    expect(agentDisplayName(null, 0)).toBeNull();
+  });
 });
 
 describe("splitMessages", () => {

--- a/python/monarch/monarch_dashboard/frontend/src/utils/status.ts
+++ b/python/monarch/monarch_dashboard/frontend/src/utils/status.ts
@@ -66,7 +66,8 @@ export function leafName(name: string | null | undefined): string {
  *  Returns null if the name doesn't match a host/proc agent pattern,
  *  so the caller can fall back to the default display.
  */
-export function agentDisplayName(fullName: string, rank?: number | string | null): string | null {
+export function agentDisplayName(fullName: string | null | undefined, rank?: number | string | null): string | null {
+  if (!fullName) return null;
   const low = fullName.toLowerCase();
   const isHost = low.includes("hostagent") || low.includes("host_agent");
   const isProcAgent = low.includes("procagent") || low.includes("proc_agent");


### PR DESCRIPTION
Summary: The `agentDisplayName` function (introduced in D98258522) did not handle null/undefined `fullName` parameter. If `fullName` is null or undefined, calling `.toLowerCase()` throws a runtime error, preventing the `?? leafName(val)` fallback in callers from executing. This adds a null guard consistent with the existing `leafName` function.

Differential Revision: D98412951


