### PR TITLE
Populate endpoint name in messages table

### DIFF
--- a/examples/distributed_telemetry.py
+++ b/examples/distributed_telemetry.py
@@ -390,6 +390,14 @@ QUERIES = [
         "SELECT * FROM message_status_events ORDER BY timestamp_us LIMIT 10",
     ),
     (
+        "Messages by endpoint",
+        """SELECT m.endpoint, COUNT(*) as cnt
+           FROM messages m
+           WHERE m.endpoint IS NOT NULL
+           GROUP BY m.endpoint
+           ORDER BY cnt DESC""",
+    ),
+    (
         "Lifecycle: sender -> compute messages",
         """SELECT sender.display_name AS from_actor,
                   receiver.display_name AS to_actor,

--- a/hyperactor/src/message.rs
+++ b/hyperactor/src/message.rs
@@ -187,6 +187,11 @@ impl ErasedUnbound {
         }
     }
 
+    /// Access the inner serialized message.
+    pub fn message(&self) -> &wirevalue::Any {
+        &self.message
+    }
+
     /// Create an object from a typed message.
     // Note: cannot implement TryFrom<T> due to conflict with core crate's blanket impl.
     // More can be found in this issue: https://github.com/rust-lang/rust/issues/50133
@@ -226,6 +231,11 @@ pub struct IndexedErasedUnbound<M>(ErasedUnbound, PhantomData<M>);
 impl<M: DeserializeOwned + Named> IndexedErasedUnbound<M> {
     pub(crate) fn downcast(self) -> anyhow::Result<Unbound<M>> {
         self.0.downcast()
+    }
+
+    /// Access the inner serialized message.
+    pub fn inner_any(&self) -> &wirevalue::Any {
+        self.0.message()
     }
 }
 

--- a/hyperactor/src/proc.rs
+++ b/hyperactor/src/proc.rs
@@ -1932,8 +1932,14 @@ impl<A: Actor> Instance<A> {
                 HandlerInfo::from_static(std::any::type_name::<M>(), None)
             }
         };
+
+        let endpoint = type_info.and_then(|info| {
+            // SAFETY: The caller promises to pass the correct type info.
+            unsafe { info.endpoint_name(&message as *const M as *const ()) }
+        });
+
         // Use a helper function for a better instrument log.
-        self.handle_message_with_handler_info(actor, handler_info, headers, message)
+        self.handle_message_with_handler_info(actor, handler_info, headers, message, endpoint)
             .await
     }
 
@@ -1945,6 +1951,7 @@ impl<A: Actor> Instance<A> {
         handler_info: HandlerInfo,
         headers: Flattrs,
         message: M,
+        endpoint: Option<String>,
     ) -> Result<(), anyhow::Error>
     where
         A: Handler<M>,
@@ -1971,8 +1978,7 @@ impl<A: Actor> Instance<A> {
                 id: message_id,
                 from_actor_id,
                 to_actor_id,
-                // TODO: populate endpoint
-                endpoint: None,
+                endpoint,
                 port_id,
             });
 

--- a/monarch_hyperactor/src/actor.rs
+++ b/monarch_hyperactor/src/actor.rs
@@ -31,6 +31,7 @@ use hyperactor::mailbox::MessageEnvelope;
 use hyperactor::mailbox::Undeliverable;
 use hyperactor::message::Bind;
 use hyperactor::message::Bindings;
+use hyperactor::message::IndexedErasedUnbound;
 use hyperactor::message::Unbind;
 use hyperactor::supervision::ActorSupervisionEvent;
 use hyperactor_config::Flattrs;
@@ -191,7 +192,61 @@ pub struct PythonMessage {
     pub message: Part,
 }
 
-wirevalue::register_type!(PythonMessage);
+/// Extract the endpoint method name from a [`PythonMessage`].
+fn python_message_endpoint_name(msg: &PythonMessage) -> Option<String> {
+    match &msg.kind {
+        PythonMessageKind::CallMethod { name, .. }
+        | PythonMessageKind::CallMethodIndirect { name, .. } => Some(name.name().to_string()),
+        _ => None,
+    }
+}
+
+// We use manual `submit!` instead of `register_type!` because PythonMessage is a
+// struct, so the default `endpoint_name` (which delegates to `arm_unchecked`)
+// always returns None. The custom implementation inspects `PythonMessageKind` to
+// extract the method name. This registration handles direct (non-cast) dispatch.
+wirevalue::submit! {
+    wirevalue::TypeInfo {
+        typename: <PythonMessage as wirevalue::Named>::typename,
+        typehash: <PythonMessage as wirevalue::Named>::typehash,
+        typeid: <PythonMessage as wirevalue::Named>::typeid,
+        port: <PythonMessage as wirevalue::Named>::port,
+        dump: Some(<PythonMessage as wirevalue::NamedDumpable>::dump),
+        arm_unchecked: <PythonMessage as wirevalue::Named>::arm_unchecked,
+        endpoint_name: |ptr| {
+            // SAFETY: ptr points to a PythonMessage.
+            let msg = unsafe { &*(ptr as *const PythonMessage) };
+            python_message_endpoint_name(msg)
+        },
+    }
+}
+
+// Cast messages arrive as IndexedErasedUnbound<PythonMessage>, which wraps a
+// serialized PythonMessage. This type has no `register_type!` by default (it
+// shares ErasedUnbound's wire format), so we register it explicitly. The
+// endpoint_name deserializes the inner payload to read the method name. This
+// costs one extra deserialization per message, but the Part payload uses
+// zero-copy Bytes refcounting, and Python actor throughput is GIL-bounded,
+// so the serde overhead is negligible relative to Python-side processing.
+wirevalue::submit! {
+    wirevalue::TypeInfo {
+        typename: <IndexedErasedUnbound<PythonMessage> as wirevalue::Named>::typename,
+        typehash: <IndexedErasedUnbound<PythonMessage> as wirevalue::Named>::typehash,
+        typeid: <IndexedErasedUnbound<PythonMessage> as wirevalue::Named>::typeid,
+        port: <IndexedErasedUnbound<PythonMessage> as wirevalue::Named>::port,
+        dump: None,
+        arm_unchecked: <IndexedErasedUnbound<PythonMessage> as wirevalue::Named>::arm_unchecked,
+        endpoint_name: |ptr| {
+            // SAFETY: ptr points to an IndexedErasedUnbound<PythonMessage>.
+            let erased = unsafe { &*(ptr as *const IndexedErasedUnbound<PythonMessage>) };
+            erased
+                .inner_any()
+                .deserialized_unchecked::<PythonMessage>()
+                .ok()
+                .and_then(|msg| python_message_endpoint_name(&msg))
+        },
+    }
+}
 
 impl From<ValueOverlay<PythonResponseMessage>> for PythonMessage {
     fn from(overlay: ValueOverlay<PythonResponseMessage>) -> Self {

--- a/python/tests/test_distributed_telemetry.py
+++ b/python/tests/test_distributed_telemetry.py
@@ -803,6 +803,43 @@ def test_messages_table(cleanup_callbacks) -> None:
 
 
 @pytest.mark.timeout(120)
+def test_messages_endpoint(cleanup_callbacks) -> None:
+    """Test that the messages table endpoint column is populated with the method name."""
+    engine, _ = start_telemetry(batch_size=10, include_dashboard=False)
+
+    job = ProcessJob({"hosts": 1})
+    hosts = job.state(cached_path=None).hosts
+    worker_procs = hosts.spawn_procs(per_host={"workers": 2}, name="ep_workers_procs")
+    workers = worker_procs.spawn("ep_test_worker", WorkerActor)
+    workers.initialized.get()
+
+    # Call the "ping" endpoint
+    for _ in range(3):
+        workers.ping.call().get()
+
+    # Query for messages with a non-null endpoint received by our workers
+    result = engine.query(
+        "SELECT m.endpoint FROM messages m "
+        "JOIN actors a ON m.to_actor_id = a.id "
+        "JOIN meshes mesh ON a.mesh_id = mesh.id "
+        "WHERE mesh.given_name = 'ep_test_worker' AND m.endpoint IS NOT NULL"
+    )
+    result_dict = result.to_pydict()
+    endpoints = result_dict.get("endpoint", [])
+
+    # 3 casts x 2 workers = 6 messages, all with endpoint "ping"
+    assert len(endpoints) == 6, (
+        f"Expected 6 messages with endpoint, got {len(endpoints)}"
+    )
+    assert all(ep == "ping" for ep in endpoints), (
+        f"Expected all endpoints to be 'ping', got {set(endpoints)}"
+    )
+
+    # Clean up
+    hosts.shutdown().get()
+
+
+@pytest.mark.timeout(120)
 def test_message_status_events_table(cleanup_callbacks) -> None:
     """Test that message_status_events captures queued/active/complete transitions."""
     engine, _ = start_telemetry(batch_size=10, include_dashboard=False)

--- a/wirevalue/src/lib.rs
+++ b/wirevalue/src/lib.rs
@@ -63,6 +63,12 @@ pub struct TypeInfo {
     pub dump: Option<fn(Any) -> Result<serde_json::Value>>,
     /// Return the arm for this type, if available.
     pub arm_unchecked: unsafe fn(*const ()) -> Option<&'static str>,
+    /// Return the endpoint name for this message, if available.
+    /// Separate from `arm_unchecked` because struct-typed messages (e.g.,
+    /// PythonMessage) have no enum arm but do carry an endpoint name inside
+    /// their payload. Types that use `register_type!` get a default that
+    /// delegates to `arm_unchecked`, which works for Rust enum handlers.
+    pub endpoint_name: unsafe fn(*const ()) -> Option<String>,
 }
 
 #[allow(dead_code)]
@@ -119,6 +125,15 @@ impl TypeInfo {
         // SAFETY: This isn't safe, we're passing it on.
         unsafe { (self.arm_unchecked)(value) }
     }
+
+    /// Get the endpoint name for a message value.
+    ///
+    /// # Safety
+    /// The caller must ensure the value pointer is valid for this type.
+    pub unsafe fn endpoint_name(&self, value: *const ()) -> Option<String> {
+        // SAFETY: This isn't safe, we're passing it on.
+        unsafe { (self.endpoint_name)(value) }
+    }
 }
 
 inventory::collect!(TypeInfo);
@@ -155,6 +170,10 @@ macro_rules! register_type {
                 port: <$type as $crate::Named>::port,
                 dump: Some(<$type as $crate::NamedDumpable>::dump),
                 arm_unchecked: <$type as $crate::Named>::arm_unchecked,
+                endpoint_name: |ptr| {
+                    // SAFETY: ptr points to a value of type $type, as guaranteed by the caller.
+                    unsafe { <$type as $crate::Named>::arm_unchecked(ptr).map(|s| s.to_string()) }
+                },
             }
         }
     };


### PR DESCRIPTION
Summary:
The `messages` telemetry table has an `endpoint` column that was always
`None`. Populate it with the Python `endpoint` method name (e.g.,
"ping", "compute") so users can query and filter messages by endpoint.

Add an `endpoint_name` function pointer to `TypeInfo`, separate from
`arm_unchecked` because struct-typed messages like `PythonMessage` have
no enum arm but carry an endpoint name inside their payload. The default
`register_type!` implementation delegates to `arm_unchecked`, which
works for Rust enum handlers.

For `PythonMessage` and `IndexedErasedUnbound<PythonMessage>`, register
custom `TypeInfo` via `wirevalue::submit!` that extracts the method name
from `PythonMessageKind::CallMethod`/`CallMethodIndirect`. The cast
wrapper path deserializes the inner payload; the cost is bounded by
Python GIL throughput.

Differential Revision: D98430933


