### PR TITLE
[hyperactor_mesh] clamp proc status to host agent state

### DIFF
--- a/hyperactor_mesh/src/host_mesh/host_agent.rs
+++ b/hyperactor_mesh/src/host_mesh/host_agent.rs
@@ -34,14 +34,12 @@ use hyperactor::Proc;
 use hyperactor::RefClient;
 use hyperactor::channel::ChannelTransport;
 use hyperactor::context;
-use hyperactor::context::Mailbox as _;
 use hyperactor::host::Host;
 use hyperactor::host::HostError;
 use hyperactor::host::LOCAL_PROC_NAME;
 use hyperactor::host::LocalProcManager;
 use hyperactor::host::SERVICE_PROC_NAME;
 use hyperactor::mailbox::MailboxServerHandle;
-use hyperactor::mailbox::PortSender as _;
 use hyperactor::reference as hyperactor_reference;
 use hyperactor_config::Flattrs;
 use hyperactor_config::attrs::Attrs;
@@ -363,6 +361,17 @@ impl HostAgent {
             proc_status_port: None,
             local_mesh_agent: OnceLock::new(),
             mailbox_handle: None,
+        }
+    }
+
+    /// Minimum status floor derived from the host agent's lifecycle.
+    /// Procs on this host cannot be healthier than this.
+    fn min_proc_status(&self) -> resource::Status {
+        match &self.state {
+            HostAgentState::Running(_) => resource::Status::Running, // no constraint
+            HostAgentState::Stopping => resource::Status::Stopping,
+            HostAgentState::Stopped(_) => resource::Status::Stopped,
+            HostAgentState::Shutdown => resource::Status::Stopped,
         }
     }
 
@@ -708,11 +717,11 @@ impl Handler<resource::GetRankStatus> for HostAgent {
                 rank,
                 created: Ok((proc_id, _mesh_agent)),
             }) => {
-                let status = match self.host() {
+                let raw_status = match self.host() {
                     Some(host) => host.proc_status(proc_id).await.0,
-                    None => Status::Stopped,
+                    None => resource::Status::Unknown,
                 };
-                (*rank, status)
+                (*rank, raw_status.clamp_min(self.min_proc_status()))
             }
             Some(ProcCreationState {
                 rank,
@@ -974,11 +983,7 @@ wirevalue::register_type!(TerminateProcs);
 
 #[async_trait]
 impl Handler<TerminateProcs> for HostAgent {
-    async fn handle(
-        &mut self,
-        cx: &Context<Self>,
-        msg: TerminateProcs,
-    ) -> anyhow::Result<()> {
+    async fn handle(&mut self, cx: &Context<Self>, msg: TerminateProcs) -> anyhow::Result<()> {
         // Only proceed if Running.
         let host = match std::mem::replace(&mut self.state, HostAgentState::Shutdown) {
             HostAgentState::Running(h) => h,
@@ -989,7 +994,13 @@ impl Handler<TerminateProcs> for HostAgent {
                 return Ok(());
             }
         };
-        self.created.clear();
+        // Do NOT clear `self.created` here: the TerminationWorker
+        // terminates procs asynchronously, and concurrent GetState /
+        // GetRankStatus queries must still find the entries.  With the
+        // host in Stopping state (`self.host()` returns None), those
+        // handlers already report Status::Stopped for every known
+        // proc, which is the correct answer while termination is
+        // in progress.
 
         self.state = HostAgentState::Stopping;
 
@@ -1030,6 +1041,23 @@ impl Handler<StopHost> for HostAgent {
         if !self.created.is_empty() {
             self.terminate_children_and_clear(cx, msg.timeout, msg.max_in_flight)
                 .await;
+        }
+
+        // Reset to Running so the host is ready for new spawn requests.
+        // TerminateProcs may have moved us to Stopped(host); StopHost's
+        // contract is to leave the host alive and re-usable.
+        match &self.state {
+            HostAgentState::Stopped(_) => {
+                // Take ownership of the host out of Stopped and wrap it
+                // back in Running.
+                let host = match std::mem::replace(&mut self.state, HostAgentState::Shutdown) {
+                    HostAgentState::Stopped(h) => h,
+                    _ => unreachable!(),
+                };
+                self.state = HostAgentState::Running(host);
+            }
+            HostAgentState::Running(_) => {} // already fine
+            _ => {}
         }
 
         // Ack after children are terminated so the caller does not
@@ -1111,13 +1139,14 @@ impl Handler<resource::GetState<ProcState>> for HostAgent {
                 rank,
                 created: Ok((proc_id, mesh_agent)),
             }) => {
-                let (status, proc_status, bootstrap_command) = match self.host() {
+                let (raw_status, proc_status, bootstrap_command) = match self.host() {
                     Some(host) => {
                         let (status, proc_status) = host.proc_status(proc_id).await;
                         (status, proc_status, host.bootstrap_command())
                     }
-                    None => (resource::Status::Stopped, None, None),
+                    None => (resource::Status::Unknown, None, None),
                 };
+                let status = raw_status.clamp_min(self.min_proc_status());
                 resource::State {
                     name: get_state.name.clone(),
                     status,
@@ -1294,9 +1323,9 @@ impl Handler<GetLocalProc> for HostAgent {
         let host = self
             .host()
             .ok_or_else(|| anyhow::anyhow!("HostAgent has already shut down"))?;
-        let agent = self.local_mesh_agent.get_or_init(|| {
-            ProcAgent::boot_v1(host.local_proc().clone(), None)
-        });
+        let agent = self
+            .local_mesh_agent
+            .get_or_init(|| ProcAgent::boot_v1(host.local_proc().clone(), None));
 
         match agent {
             Err(e) => anyhow::bail!("error booting local proc: {}", e),

--- a/hyperactor_mesh/src/resource.rs
+++ b/hyperactor_mesh/src/resource.rs
@@ -117,6 +117,20 @@ impl Status {
     pub fn is_healthy(&self) -> bool {
         matches!(self, Status::Initializing | Status::Running)
     }
+
+    /// Ensure this status is at least as terminal as `floor`.
+    ///
+    /// If `floor` is a terminating status (Stopping, Stopped, Failed,
+    /// Timeout) and `self` is not, returns `floor`. Otherwise returns
+    /// `self` unchanged. This is used to prevent a child resource
+    /// from appearing healthier than its parent.
+    pub fn clamp_min(self, floor: Status) -> Status {
+        if floor.is_terminating() && !self.is_terminating() {
+            floor
+        } else {
+            self
+        }
+    }
 }
 
 impl From<bootstrap::ProcStatus> for Status {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #3272
* #3271
* #3270
* #3269
* #3268
* #3267
* #3266
* #3265
* #3264

When the host agent transitions to Stopping or Shutdown, individual
proc statuses can become stale (e.g. Unknown when terminate_all
drains the manager's children map, or Running if the query races).

Add Status::clamp_min(floor) which ensures a child resource never
appears healthier than its parent: if the floor is terminating and
the raw status is not, the floor wins.

Replace the ad-hoc status_when_no_host() with min_proc_status(),
which returns a status floor for every host agent state, and apply
clamp_min uniformly in both GetState and GetRankStatus handlers.
This covers the Stopped(host) case where host.proc_status() returns
Unknown for drained procs — previously unclamped, now clamped to
Stopped.

Differential Revision: [D98406322](https://our.internmc.facebook.com/intern/diff/D98406322/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D98406322/)!