### PR TITLE
Direct ActorId-based discovery for pyspy dump in DistributedTelemetryActor (#3275)

### DIFF
--- a/python/monarch/distributed_telemetry/actor.py
+++ b/python/monarch/distributed_telemetry/actor.py
@@ -21,15 +21,22 @@ variable and used by the DistributedTelemetryActor when it initializes.
 
 import functools
 import logging
-from typing import Any, Callable, Dict, List, NamedTuple, Optional
+from typing import Any, Callable, Dict, List, Optional
 
 from monarch._rust_bindings.monarch_distributed_telemetry.database_scanner import (
     DatabaseScanner,
+)
+from monarch._rust_bindings.monarch_hyperactor.actor import (
+    MethodSpecifier,
+    PythonMessage,
+    PythonMessageKind,
 )
 from monarch._rust_bindings.monarch_hyperactor.mailbox import (
     PortId,
     UndeliverableMessageEnvelope,
 )
+from monarch._rust_bindings.monarch_hyperactor.pickle import pickle as monarch_pickle
+from monarch._rust_bindings.monarch_hyperactor.proc import ActorId
 from monarch._rust_bindings.monarch_hyperactor.supervision import MeshFailure
 from monarch._src.actor.proc_mesh import (
     ProcMesh,
@@ -42,13 +49,6 @@ from monarch.monarch_dashboard.server.app import start_dashboard
 from monarch.monarch_dashboard.server.query_engine_adapter import QueryEngineAdapter
 
 logger: logging.Logger = logging.getLogger(__name__)
-
-
-class _ChildEntry(NamedTuple):
-    """Index entry mapping a proc_id to the child mesh and its rank kwargs."""
-
-    mesh: Any  # ActorMesh
-    rank_kwargs: Dict[str, int]
 
 
 # Module-level scanner created at process startup to avoid race conditions.
@@ -95,6 +95,26 @@ def _register_scanner(
         _spawn_callback_registered = True
 
 
+def _build_telemetry_actor_id(proc_ref: str) -> Optional[ActorId]:
+    """Parse a proc_ref string into an ActorId targeting the telemetry actor.
+
+    Uses ``ActorId.from_string`` with a synthetic actor suffix to avoid
+    fragile comma-splitting (addr can contain commas in complex formats
+    like ``tcp![::1]:2345``).
+    """
+    try:
+        parsed = ActorId.from_string(f"{proc_ref},_parse[0]")
+        return ActorId(
+            addr=parsed.addr,
+            proc_name=parsed.proc_name,
+            actor_name="telemetry",
+            pid=0,
+        )
+    except Exception:
+        logger.debug("failed to parse proc_ref %r into ActorId", proc_ref)
+        return None
+
+
 class DistributedTelemetryActor(Actor):
     """
     Distributed telemetry actor that wraps a local DatabaseScanner.
@@ -112,9 +132,6 @@ class DistributedTelemetryActor(Actor):
         self._children: Dict[str, Any] = {}
         self._num_procs_processed: int = 0
         self._proc_id: str = context().actor_instance.proc_id
-        # Lazily built index: proc_id → _ChildEntry for targeted routing
-        # in store_pyspy_dump.
-        self._proc_id_index: Dict[str, _ChildEntry] = {}
 
     def __supervise__(self, failure: MeshFailure) -> bool:
         """Handle child mesh failures gracefully.
@@ -126,16 +143,7 @@ class DistributedTelemetryActor(Actor):
         Note: stopping a ProcMesh loses process-local telemetry data from
         those children.
         """
-        removed = self._children.pop(failure.mesh_name, None)
-        if removed is not None:
-            # Purge stale proc_id_index entries for the dead child.
-            stale = [
-                pid
-                for pid, entry in self._proc_id_index.items()
-                if entry.mesh is removed
-            ]
-            for pid in stale:
-                del self._proc_id_index[pid]
+        self._children.pop(failure.mesh_name, None)
         logger.info("child mesh failed: %s", failure.mesh_name)
         return True
 
@@ -156,17 +164,6 @@ class DistributedTelemetryActor(Actor):
             mesh_name: str = actor_mesh._name.get()
             self._children[mesh_name] = actor_mesh
             self._num_procs_processed += 1
-            self._index_child(actor_mesh)
-
-    def _index_child(self, child_mesh: Any) -> None:
-        """Query child mesh proc_ids and populate ``_proc_id_index``."""
-        try:
-            # pyre-ignore[29]: child_mesh is an ActorMesh
-            proc_ids = child_mesh.get_proc_id.call().get()
-            for point, pid in proc_ids.items():
-                self._proc_id_index[pid] = _ChildEntry(child_mesh, dict(point))
-        except Exception:
-            logger.warning("failed to index child proc_ids, skipping")
 
     @endpoint
     def ready(self) -> None:
@@ -194,7 +191,6 @@ class DistributedTelemetryActor(Actor):
         # pyre-ignore[16]: children is an ActorMesh with _name
         mesh_name: str = children._name.get()
         self._children[mesh_name] = children
-        self._index_child(children)
 
     @endpoint
     def apply_retention(self, table_name: str, where_clause: str) -> None:
@@ -207,48 +203,39 @@ class DistributedTelemetryActor(Actor):
             except Exception:
                 logger.info("child apply_retention failed, skipping")
 
-    def _route_to_children(
-        self, dump_id: str, proc_ref: str, pyspy_result_json: str
+    def _try_direct_store(
+        self,
+        actor_id: ActorId,
+        dump_id: str,
+        proc_ref: str,
+        pyspy_result_json: str,
     ) -> bool:
-        """Route pyspy dump to the matching child. Returns True if a child stored it."""
-        self._spawn_missing_children()
+        """Send a store message directly to an actor via its ActorId.
 
-        entry = self._proc_id_index.get(proc_ref)
-        if entry is not None:
-            try:
-                # pyre-ignore[29]: entry.mesh is an ActorMesh
-                result = (
-                    entry.mesh.slice(**entry.rank_kwargs)
-                    .try_store_pyspy_dump.call_one(dump_id, proc_ref, pyspy_result_json)
-                    .get()
-                )
-                if result:
-                    return True
-            except Exception:
-                logger.info("targeted store_pyspy_dump failed for %s", proc_ref)
+        Opens a once-port for the response so we can confirm the target
+        actually stored the data. Times out after 5 seconds to avoid
+        blocking indefinitely if the target actor does not exist.
+        """
+        try:
+            self._spawn_missing_children()
 
-        # Fallback: fan out to all children concurrently (e.g. index stale
-        # after mesh topology change).
-        futures = []
-        for child_mesh in self._children.values():
-            try:
-                # pyre-ignore[29]: child_mesh is an ActorMesh
-                futures.append(
-                    child_mesh.try_store_pyspy_dump.call(
-                        dump_id, proc_ref, pyspy_result_json
-                    )
-                )
-            except Exception:
-                logger.info("child store_pyspy_dump call failed, skipping")
+            mailbox = context().actor_instance._mailbox
+            handle, receiver = mailbox.open_once_port()
+            port_ref = handle.bind()
 
-        for fut in futures:
-            try:
-                if any(fut.get().values()):
-                    return True
-            except Exception:
-                logger.info("child store_pyspy_dump failed, skipping")
+            state = monarch_pickle(((dump_id, proc_ref, pyspy_result_json), {}))
+            kind = PythonMessageKind.CallMethod(
+                MethodSpecifier.ReturnsResponse("try_store_pyspy_dump"), port_ref
+            )
+            msg = PythonMessage(kind, state.buffer())
+            mailbox.post(actor_id, msg)
 
-        return False
+            from monarch._src.actor.actor_mesh import PortReceiver
+
+            return PortReceiver(mailbox, receiver).recv().get(timeout=5.0)
+        except Exception:
+            logger.debug("direct store to %s failed", actor_id, exc_info=True)
+            return False
 
     @endpoint
     def store_pyspy_dump(
@@ -257,21 +244,23 @@ class DistributedTelemetryActor(Actor):
         """Store py-spy dump data in the pyspy DataFusion tables on the target proc.
 
         If ``proc_ref`` matches this actor's proc, stores locally.
-        Otherwise routes to the matching child. If no child in the
-        tree matches, the root coordinator stores it so data is not lost.
-
-        Returns True if this actor or a descendant stored the dump.
+        Otherwise sends directly to the target telemetry actor via ActorId.
+        Falls back to root coordinator storage if the direct send fails.
         """
         if proc_ref == self._proc_id:
             self._scanner.store_pyspy_dump_py(dump_id, proc_ref, pyspy_result_json)
             return True
 
-        if self._route_to_children(dump_id, proc_ref, pyspy_result_json):
+        # Try direct ActorId-based send, bypassing the mesh hierarchy.
+        target = _build_telemetry_actor_id(proc_ref)
+        if target is not None and self._try_direct_store(
+            target, dump_id, proc_ref, pyspy_result_json
+        ):
             return True
 
-        # No proc in the tree matched; store on this (root) coordinator
-        # so the data is not lost.
-        logger.info("no child matched proc_ref %s, storing on root", proc_ref)
+        # Direct send failed or could not parse; store on this (root)
+        # coordinator so the data is not lost.
+        logger.info("direct store failed for proc_ref %s, storing on root", proc_ref)
         self._scanner.store_pyspy_dump_py(dump_id, proc_ref, pyspy_result_json)
         return True
 
@@ -279,16 +268,15 @@ class DistributedTelemetryActor(Actor):
     def try_store_pyspy_dump(
         self, dump_id: str, proc_ref: str, pyspy_result_json: str
     ) -> bool:
-        """Try to store the dump on the matching proc. Returns True if stored.
+        """Try to store the dump if proc_ref matches this actor's proc.
 
         Unlike ``store_pyspy_dump``, this does not fall back to root storage.
-        Used for recursive child routing.
+        Called via direct ActorId-based messaging from the root coordinator.
         """
         if proc_ref == self._proc_id:
             self._scanner.store_pyspy_dump_py(dump_id, proc_ref, pyspy_result_json)
             return True
-
-        return self._route_to_children(dump_id, proc_ref, pyspy_result_json)
+        return False
 
     @endpoint
     def scan(

--- a/python/tests/test_distributed_telemetry.py
+++ b/python/tests/test_distributed_telemetry.py
@@ -25,6 +25,48 @@ from monarch.distributed_telemetry.actor import start_telemetry
 from monarch.job import ProcessJob
 
 
+def _make_pyspy_json(
+    pid: int = 1234,
+    func_name: str = "test_fn",
+    filename: str = "test.py",
+    line: int = 1,
+    os_thread_id: int = 100,
+    owns_gil: bool = True,
+) -> str:
+    """Build a minimal pyspy JSON payload with a single frame for testing."""
+    module = filename.removesuffix(".py")
+    return json.dumps(
+        {
+            "Ok": {
+                "pid": pid,
+                "binary": "python3",
+                "stack_traces": [
+                    {
+                        "pid": pid,
+                        "thread_id": 1,
+                        "thread_name": "MainThread",
+                        "os_thread_id": os_thread_id,
+                        "active": True,
+                        "owns_gil": owns_gil,
+                        "frames": [
+                            {
+                                "name": func_name,
+                                "filename": filename,
+                                "module": module,
+                                "short_filename": filename,
+                                "line": line,
+                                "locals": [],
+                                "is_entry": True,
+                            }
+                        ],
+                    }
+                ],
+                "warnings": [],
+            }
+        }
+    )
+
+
 class WorkerActor(Actor):
     """Simple worker actor that can spawn child processes."""
 
@@ -1297,8 +1339,8 @@ def test_pyspy_tables_in_information_schema(cleanup_callbacks) -> None:
 
 @pytest.mark.timeout(120)
 @isolate_in_subprocess
-def test_try_store_pyspy_dump_routes_to_child(cleanup_callbacks) -> None:
-    """try_store_pyspy_dump routes to the correct child proc via _proc_id_index."""
+def test_store_pyspy_dump_routes_to_child(cleanup_callbacks) -> None:
+    """store_pyspy_dump sends directly to the correct child proc via ActorId."""
     engine, _ = start_telemetry(batch_size=10, include_dashboard=False)
 
     job = ProcessJob({"hosts": 1})
@@ -1322,40 +1364,12 @@ def test_try_store_pyspy_dump_routes_to_child(cleanup_callbacks) -> None:
     assert len(child_proc_refs) > 0, f"Expected child proc_refs, got: {proc_agents}"
     child_proc_ref = child_proc_refs[0]
 
-    pyspy_json = json.dumps(
-        {
-            "Ok": {
-                "pid": 9999,
-                "binary": "python3",
-                "stack_traces": [
-                    {
-                        "pid": 9999,
-                        "thread_id": 1,
-                        "thread_name": "MainThread",
-                        "os_thread_id": 200,
-                        "active": True,
-                        "owns_gil": True,
-                        "frames": [
-                            {
-                                "name": "child_fn",
-                                "filename": "child.py",
-                                "module": "child",
-                                "short_filename": "child.py",
-                                "line": 42,
-                                "locals": [],
-                                "is_entry": True,
-                            }
-                        ],
-                    }
-                ],
-                "warnings": [],
-            }
-        }
+    pyspy_json = _make_pyspy_json(
+        pid=9999, func_name="child_fn", filename="child.py", line=42, os_thread_id=200
     )
 
-    # Store a pyspy dump targeting the child proc_ref.
-    # Use 'try_store_pyspy_dump' to avoid fallback to root coordinator.
-    result = engine._actor.try_store_pyspy_dump.call_one(
+    # Store a pyspy dump targeting the child proc_ref via direct ActorId send.
+    result = engine._actor.store_pyspy_dump.call_one(
         "child-dump-1", child_proc_ref, pyspy_json
     ).get()
     assert result
@@ -1378,6 +1392,36 @@ def test_try_store_pyspy_dump_routes_to_child(cleanup_callbacks) -> None:
     hosts.shutdown().get()
 
 
+@pytest.mark.timeout(60)
+def test_store_pyspy_dump_on_coordinator(cleanup_callbacks) -> None:
+    """store_pyspy_dump stores locally when proc_ref matches the coordinator."""
+    engine, _ = start_telemetry(batch_size=10, include_dashboard=False)
+
+    coordinator_proc_id = engine._actor.get_proc_id.call_one().get()
+
+    pyspy_json = _make_pyspy_json(
+        func_name="coordinator_fn", filename="coordinator.py", line=10
+    )
+
+    # Use try_store_pyspy_dump since engine is in the same process as the coordinator.
+    result = engine._actor.try_store_pyspy_dump.call_one(
+        "coord-dump-1", coordinator_proc_id, pyspy_json
+    ).get()
+    assert result
+
+    frames = engine.query(
+        "SELECT name, line FROM pyspy_frames WHERE dump_id = 'coord-dump-1'"
+    )
+    frames_dict = frames.to_pydict()
+    assert frames_dict["name"] == ["coordinator_fn"]
+    assert frames_dict["line"] == [10]
+
+    dumps = engine.query(
+        "SELECT proc_ref FROM pyspy_dumps WHERE dump_id = 'coord-dump-1'"
+    )
+    assert dumps.to_pydict()["proc_ref"] == [coordinator_proc_id]
+
+
 @pytest.mark.timeout(120)
 @isolate_in_subprocess
 def test_store_pyspy_dump_unknown_proc_falls_back_to_root(cleanup_callbacks) -> None:
@@ -1395,35 +1439,13 @@ def test_store_pyspy_dump_unknown_proc_falls_back_to_root(cleanup_callbacks) -> 
     # Trigger child spawning.
     engine.query("SELECT COUNT(*) AS cnt FROM actors")
 
-    pyspy_json = json.dumps(
-        {
-            "Ok": {
-                "pid": 7777,
-                "binary": "python3",
-                "stack_traces": [
-                    {
-                        "pid": 7777,
-                        "thread_id": 1,
-                        "thread_name": "MainThread",
-                        "os_thread_id": 300,
-                        "active": True,
-                        "owns_gil": False,
-                        "frames": [
-                            {
-                                "name": "orphan_fn",
-                                "filename": "orphan.py",
-                                "module": "orphan",
-                                "short_filename": "orphan.py",
-                                "line": 99,
-                                "locals": [],
-                                "is_entry": True,
-                            }
-                        ],
-                    }
-                ],
-                "warnings": [],
-            }
-        }
+    pyspy_json = _make_pyspy_json(
+        pid=7777,
+        func_name="orphan_fn",
+        filename="orphan.py",
+        line=99,
+        os_thread_id=300,
+        owns_gil=False,
     )
 
     # Store with a proc_ref that doesn't exist in the tree.


### PR DESCRIPTION
Summary:

Replace the tree-hierarchy routing in `store_pyspy_dump` which complicates the system. This mimics what we already do in mesh admin for getting py-spy dump.

Differential Revision: D98437165
