### PR TITLE
[hyperactor] propagate close reason through TxStatus::Closed

### DIFF
--- a/hyperactor/src/channel.rs
+++ b/hyperactor/src/channel.rs
@@ -17,8 +17,10 @@ use std::net::Ipv6Addr;
 use std::os::linux::net::SocketAddrExt;
 use std::panic::Location;
 use std::str::FromStr;
+use std::sync::Arc;
 
 use async_trait::async_trait;
+use enum_as_inner::EnumAsInner;
 use hyperactor_config::attrs::AttrValue;
 use serde::Deserialize;
 use serde::Serialize;
@@ -107,12 +109,12 @@ impl<M: RemoteMessage> From<SendError<M>> for ChannelError {
 }
 
 /// The possible states of a `Tx`.
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, EnumAsInner)]
 pub enum TxStatus {
     /// The tx is good.
     Active,
     /// The tx cannot be used for message delivery.
-    Closed,
+    Closed(Arc<str>),
 }
 
 /// The transmit end of an M-typed channel.
@@ -252,7 +254,9 @@ impl<M: RemoteMessage> MpscRx<M> {
 
 impl<M: RemoteMessage> Drop for MpscRx<M> {
     fn drop(&mut self) {
-        let _ = self.status_sender.send(TxStatus::Closed);
+        let _ = self
+            .status_sender
+            .send(TxStatus::Closed("receiver dropped".into()));
     }
 }
 

--- a/hyperactor/src/channel/local.rs
+++ b/hyperactor/src/channel/local.rs
@@ -133,7 +133,9 @@ impl<M: RemoteMessage> Rx<M> for LocalRx<M> {
 
 impl<M: RemoteMessage> Drop for LocalRx<M> {
     fn drop(&mut self) {
-        let _ = self.status_tx.send(TxStatus::Closed);
+        let _ = self
+            .status_tx
+            .send(TxStatus::Closed("receiver dropped".into()));
         PORTS.lock().unwrap().free(self.port);
     }
 }

--- a/hyperactor/src/channel/net.rs
+++ b/hyperactor/src/channel/net.rs
@@ -297,12 +297,12 @@ pub(crate) fn spawn<M: RemoteMessage>(link: impl Link) -> NetTx<M> {
                         error = %err,
                         "failed to push message to outbox"
                     );
-                    let _ = notify.send(TxStatus::Closed);
+                    let _ = notify.send(TxStatus::Closed("failed to push to outbox".into()));
                     return;
                 }
             }
             None => {
-                let _ = notify.send(TxStatus::Closed);
+                let _ = notify.send(TxStatus::Closed("sender dropped".into()));
                 return;
             }
         }
@@ -434,7 +434,7 @@ pub(crate) fn spawn<M: RemoteMessage>(link: impl Link) -> NetTx<M> {
             });
         }
 
-        let _ = notify.send(TxStatus::Closed);
+        let _ = notify.send(TxStatus::Closed(reason.into()));
     });
     tx
 }
@@ -691,10 +691,11 @@ impl<M: RemoteMessage> Tx<M> for NetTx<M> {
             self.sender
                 .send((message, return_channel, tokio::time::Instant::now()))
         {
+            let reason = self.status.borrow().as_closed().map(|r| r.to_string());
             let _ = return_channel.send(SendError {
                 error: ChannelError::Closed,
                 message,
-                reason: None,
+                reason,
             });
         }
     }
@@ -2747,8 +2748,8 @@ mod tests {
     async fn verify_tx_closed(tx_status: &mut watch::Receiver<TxStatus>, expected_log: &str) {
         match tokio::time::timeout(Duration::from_secs(5), tx_status.changed()).await {
             Ok(Ok(())) => {
-                let current_status = *tx_status.borrow();
-                assert_eq!(current_status, TxStatus::Closed);
+                let current_status = tx_status.borrow().clone();
+                assert!(current_status.is_closed());
                 logs_assert_unscoped(|logs| {
                     if logs.iter().any(|log| log.contains(expected_log)) {
                         Ok(())
@@ -3484,10 +3485,10 @@ mod tests {
         tx.post(101);
         let mut watcher = tx.status().clone();
         // When NetRx exits, it should notify NetTx to exit as well.
-        let _ = watcher.wait_for(|val| *val == TxStatus::Closed).await;
+        let _ = watcher.wait_for(|val| val.is_closed()).await;
         // wait_for could return Err due to race between when watch's sender was
         // dropped and when wait_for was called. So we still need to do an
         // equality check.
-        assert_eq!(*watcher.borrow(), TxStatus::Closed);
+        assert!(watcher.borrow().is_closed());
     }
 }

--- a/hyperactor/src/channel/net/duplex.rs
+++ b/hyperactor/src/channel/net/duplex.rs
@@ -130,10 +130,11 @@ impl<M: RemoteMessage> Tx<M> for DuplexTx<M> {
             self.tx
                 .send((message, return_channel, tokio::time::Instant::now()))
         {
+            let reason = self.status.borrow().as_closed().map(|r| r.to_string());
             let _ = return_channel.send(SendError {
                 error: ChannelError::Closed,
                 message,
-                reason: None,
+                reason,
             });
         }
     }
@@ -358,7 +359,7 @@ async fn dispatch_duplex_stream<In: RemoteMessage, Out: RemoteMessage>(
                         }
                     }
 
-                    let _ = notify.send(TxStatus::Closed);
+                    let _ = notify.send(TxStatus::Closed("duplex session ended".into()));
                 });
 
                 e.insert(mvar.clone());
@@ -520,7 +521,7 @@ pub(crate) fn spawn<Out: RemoteMessage, In: RemoteMessage>(
             }
         }
 
-        let _ = notify.send(TxStatus::Closed);
+        let _ = notify.send(TxStatus::Closed("duplex session ended".into()));
     });
     (
         DuplexTx::new(outbound_tx, addr.clone(), status),

--- a/hyperactor/src/mailbox.rs
+++ b/hyperactor/src/mailbox.rs
@@ -1198,8 +1198,9 @@ impl MailboxClient {
             loop {
                 tokio::select! {
                     changed = rx.changed() => {
-                        if changed.is_err() || *rx.borrow() == TxStatus::Closed {
-                            tracing::warn!("connection to {} lost", addr);
+                        if changed.is_err() || rx.borrow().is_closed() {
+                            let reason = rx.borrow().as_closed().map(|r| r.to_string()).unwrap_or_else(|| "unknown".to_string());
+                            tracing::warn!("connection to {} lost: {}", addr, reason);
                             // TODO: Potential for supervision event
                             // interaction here.
                             break;

--- a/hyperactor_mesh/src/alloc/process.rs
+++ b/hyperactor_mesh/src/alloc/process.rs
@@ -25,7 +25,6 @@ use hyperactor::channel::ChannelTransport;
 use hyperactor::channel::ChannelTx;
 use hyperactor::channel::Rx;
 use hyperactor::channel::Tx;
-use hyperactor::channel::TxStatus;
 use hyperactor::reference as hyperactor_reference;
 use hyperactor::sync::flag;
 use hyperactor::sync::monitor;
@@ -323,9 +322,7 @@ impl Child {
                 // Monitor the channel, killing the process if it becomes unavailable
                 // (fails keepalive).
                 self.group.spawn(async move {
-                    let _ = status
-                        .wait_for(|status| matches!(status, TxStatus::Closed))
-                        .await;
+                    let _ = status.wait_for(|status| status.is_closed()).await;
                     Result::<(), ()>::Err(())
                 });
             }

--- a/hyperactor_mesh/src/alloc/remoteprocess.rs
+++ b/hyperactor_mesh/src/alloc/remoteprocess.rs
@@ -417,8 +417,8 @@ impl RemoteProcessAllocator {
                 }
                 status = tx_watcher.next(), if running => {
                     match status  {
-                        Some(TxStatus::Closed) => {
-                            tracing::error!("upstream channel state closed");
+                        Some(TxStatus::Closed(reason)) => {
+                            tracing::error!("upstream channel state closed: {}", reason);
                             break;
                         },
                         _ => {
@@ -723,7 +723,7 @@ impl RemoteProcessAlloc {
                 };
                 if let Some(tx_status) = tx_status {
                     tracing::debug!("host {} channel event: {:?}", host_id, tx_status);
-                    if tx_status == TxStatus::Closed {
+                    if tx_status.is_closed() {
                         if tx.send(host_id.clone()).is_err() {
                             // other side closed
                             break;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #3285
* #3284
* #3283
* #3282
* #3281
* __->__ #3280
* #3279
* #3278
* #3277
* #3276

When a send loop exits (e.g. remote peer closed connection, delivery
timeout), the reason string was available inside the loop but lost when
do_post failed on an already-closed mpsc channel — producing unhelpful
errors like "channel closed with reason None".

Change TxStatus::Closed to carry an Arc<str> with the actual reason
(e.g. "connection closed by remote peer", "failed to deliver message
within timeout"). do_post now reads the reason from the watch channel
when the mpsc send fails, so callers get the real close reason in
SendError.

Derive EnumAsInner on TxStatus so all comparison sites use the
ergonomic .is_closed() / .as_closed() pattern.

Differential Revision: [D98223530](https://our.internmc.facebook.com/intern/diff/D98223530/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D98223530/)!