### PR TITLE
[monarch] flush pending actor spawns before ProcMesh shutdown

### DIFF
--- a/python/monarch/_src/actor/host_mesh.py
+++ b/python/monarch/_src/actor/host_mesh.py
@@ -90,6 +90,7 @@ class HostMesh(MeshTrait):
         self._is_fake_in_process = is_fake_in_process
         self._code_sync_proc_mesh: Optional["_Lazy[ProcMesh]"] = code_sync_proc_mesh
         self._pending_spawns: list[Shared[HyProcMesh]] = []
+        self._proc_meshes: list["ProcMesh"] = []
 
     @classmethod
     def _allocate_nonblocking(
@@ -200,7 +201,7 @@ class HostMesh(MeshTrait):
         spawn_shared = PythonTask.from_coroutine(task()).spawn()
         self._pending_spawns.append(spawn_shared)
 
-        return ProcMesh.from_host_mesh(
+        pm = ProcMesh.from_host_mesh(
             self,
             spawn_shared,
             Extent(
@@ -210,6 +211,8 @@ class HostMesh(MeshTrait):
             setup,
             _attach_controller_controller,
         )
+        self._proc_meshes.append(pm)
+        return pm
 
     @property
     def _ndslice(self) -> NDSlice:
@@ -343,6 +346,12 @@ class HostMesh(MeshTrait):
             except Exception:
                 pass
         self._pending_spawns.clear()
+        for pm in self._proc_meshes:
+            await pm._flush_pending_actor_spawns()
+            try:
+                await pm._logging_manager.flush_async()
+            except Exception:
+                pass
 
     def shutdown(self) -> Future[None]:
         """

--- a/python/monarch/_src/actor/proc_mesh.py
+++ b/python/monarch/_src/actor/proc_mesh.py
@@ -286,12 +286,13 @@ class ProcMesh(MeshTrait):
         self._logging_manager = LoggingManager()
         self._controller_controller: Optional["_ControllerController"] = None
         self._code_sync_client: Optional[CodeSyncMeshClient] = None
+        self._pending_actor_spawns: list = []
 
     @property
     def initialized(self) -> Future[Literal[True]]:
         """
         Future completes with 'True' when the ProcMesh has initialized.
-        Because ProcMesh are remote objects, there is no guarentee that the ProcMesh is
+        Because ProcMesh are remote objects, there is no guarantee that the ProcMesh is
         still usable after this completes, only that at some point in the past it was usable.
         """
         pm: Shared[HyProcMesh] = self._proc_mesh
@@ -500,6 +501,7 @@ class ProcMesh(MeshTrait):
         )
 
         mesh = ActorMesh(Class, name, actor_mesh, self._region.as_shape(), self)
+        self._pending_actor_spawns.append(mesh)
 
         # We don't start the supervision polling loop until the first call to
         # supervision_event, which needs an Instance. Initialize here so events
@@ -579,6 +581,14 @@ class ProcMesh(MeshTrait):
             raise RuntimeError("`ProcMesh` has already been stopped")
         return self
 
+    async def _flush_pending_actor_spawns(self) -> None:
+        for mesh in self._pending_actor_spawns:
+            try:
+                await mesh.initialized
+            except Exception:
+                pass
+        self._pending_actor_spawns.clear()
+
     def stop(self, reason: str = "stopped by client") -> Future[None]:
         """
         This will stop all processes (and actors) in the mesh and
@@ -588,6 +598,7 @@ class ProcMesh(MeshTrait):
         instance = context().actor_instance._as_rust()
 
         async def _stop_nonblocking(instance: HyInstance) -> None:
+            await self._flush_pending_actor_spawns()
             pm = await self._proc_mesh
             await self._logging_manager.flush_async()
             await pm.stop_nonblocking(instance, reason)

--- a/python/tests/test_proc_mesh.py
+++ b/python/tests/test_proc_mesh.py
@@ -326,6 +326,7 @@ def test_root_client_does_not_leak_proc_meshes() -> None:
 
 
 @pytest.mark.timeout(60)
+@isolate_in_subprocess
 def test_actor_spawn_does_not_block_on_proc_mesh_init() -> None:
     async def sleep_then_mesh(pm: Shared[HyProcMesh]) -> HyProcMesh:
         time.sleep(15)
@@ -355,6 +356,17 @@ def test_raw_proc_mesh_pickle_blocks_on_proc_mesh_init() -> None:
     assert proc_mesh._proc_mesh.poll() is None
     cloudpickle.dumps(proc_mesh)
     assert proc_mesh._proc_mesh.poll() is not None
+
+
+@pytest.mark.timeout(60)
+@isolate_in_subprocess
+async def test_actor_spawn_then_immediate_shutdown() -> None:
+    state = ProcessJob({"hosts": 1}).state(cached_path=None)
+    proc_mesh = state.hosts.spawn_procs(name="test")
+    await proc_mesh.initialized
+    # spawn actor but do NOT await initialized — immediately shutdown
+    proc_mesh.spawn("test_actor", TestActor, 42)
+    state.hosts.shutdown().get()
 
 
 @pytest.mark.timeout(60)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #3285
* #3284
* __->__ #3283
* #3282
* #3281
* #3280
* #3279
* #3278
* #3277
* #3276

Same race as the HostMesh/ProcMesh fix earlier in the stack. ProcMesh.spawn()
chains the actual actor spawn onto a Shared[HyProcMesh]. If ProcMesh.stop()
runs before the deferred spawn completes, the actor init messages hit a
stopped proc mesh.

Track spawned actor meshes in ProcMesh._pending_actor_spawns and flush
them (await initialized) at the start of stop(), mirroring the
HostMesh._pending_spawns pattern.

Differential Revision: [D98248748](https://our.internmc.facebook.com/intern/diff/D98248748/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D98248748/)!