### PR TITLE
[hyperactor_mesh] introduce attachment lifecycle for HostAgent

### DIFF
--- a/hyperactor_mesh/src/bootstrap.rs
+++ b/hyperactor_mesh/src/bootstrap.rs
@@ -293,7 +293,7 @@ async fn halt<R>() -> R {
 /// the [`ShutdownHost`] handler sends back the mailbox server handle, drains
 /// it, and (if `exit_on_shutdown`) calls `process::exit`.
 ///
-/// Note: [`StopHost`] does **not** trigger this handle — a stopped host
+/// Note: [`DrainHost`] does **not** trigger this handle — a drained host
 /// keeps its mailbox server (and Unix socket) alive so new clients can
 /// reconnect to the same address.
 pub struct HostShutdownHandle {
@@ -349,7 +349,7 @@ pub async fn host(
     let host = Host::new(manager, addr).await?;
     let addr = host.addr().clone();
 
-    // The ShutdownHost/StopHost handler will call host.serve() inside
+    // The ShutdownHost handler will call host.serve() inside
     // HostAgent::init (after this.bind::<Self>(), so the actor port is bound
     // before the frontend starts routing messages), then send the resulting
     // MailboxServerHandle back here for draining.

--- a/hyperactor_mesh/src/host_mesh.rs
+++ b/hyperactor_mesh/src/host_mesh.rs
@@ -53,6 +53,7 @@ use crate::alloc::Alloc;
 use crate::bootstrap::BootstrapCommand;
 use crate::bootstrap::BootstrapProcManager;
 use crate::bootstrap::ProcBind;
+use crate::host_mesh::host_agent::DrainHostClient;
 pub use crate::host_mesh::host_agent::HostAgent;
 use crate::host_mesh::host_agent::HostAgentMode;
 use crate::host_mesh::host_agent::HostMeshAgentProcMeshTrampoline;
@@ -61,8 +62,6 @@ use crate::host_mesh::host_agent::ProcState;
 use crate::host_mesh::host_agent::SetClientConfigClient;
 use crate::host_mesh::host_agent::ShutdownHostClient;
 use crate::host_mesh::host_agent::SpawnMeshAdminClient;
-use crate::host_mesh::host_agent::StopHostClient;
-use crate::host_mesh::host_agent::TerminateProcsClient;
 use crate::mesh_controller::HostMeshController;
 use crate::mesh_controller::ProcMeshController;
 use crate::proc_agent::ProcAgent;
@@ -165,34 +164,17 @@ impl HostRef {
         Ok(())
     }
 
-    /// Request a stop of this host: tear down all resources but keep
-    /// the worker process alive for reconnection.
-    pub(crate) async fn stop(&self, cx: &impl hyperactor::context::Actor) -> anyhow::Result<()> {
+    /// Drain all user procs on this host but keep the host, service
+    /// proc, and networking alive. Used during mesh stop/shutdown so
+    /// that forwarder flushes can still reach remote hosts.
+    pub(crate) async fn drain(&self, cx: &impl hyperactor::context::Actor) -> anyhow::Result<()> {
         let agent = self.mesh_agent();
         let terminate_timeout =
             hyperactor_config::global::get(crate::bootstrap::MESH_TERMINATE_TIMEOUT);
         let max_in_flight =
             hyperactor_config::global::get(crate::bootstrap::MESH_TERMINATE_CONCURRENCY);
         agent
-            .stop_host(cx, terminate_timeout, max_in_flight.clamp(1, 256))
-            .await?;
-        Ok(())
-    }
-
-    /// Terminate all user procs on this host but keep the host, service
-    /// proc, and networking alive. Used as phase 1 of two-phase
-    /// shutdown so that forwarder flushes can still reach remote hosts.
-    pub(crate) async fn terminate_children(
-        &self,
-        cx: &impl hyperactor::context::Actor,
-    ) -> anyhow::Result<()> {
-        let agent = self.mesh_agent();
-        let terminate_timeout =
-            hyperactor_config::global::get(crate::bootstrap::MESH_TERMINATE_TIMEOUT);
-        let max_in_flight =
-            hyperactor_config::global::get(crate::bootstrap::MESH_TERMINATE_CONCURRENCY);
-        agent
-            .terminate_procs(cx, terminate_timeout, max_in_flight.clamp(1, 256))
+            .drain_host(cx, terminate_timeout, max_in_flight.clamp(1, 256))
             .await?;
         Ok(())
     }
@@ -683,7 +665,7 @@ impl HostMesh {
         let results = futures::future::join_all(
             self.current_ref
                 .values()
-                .map(|host| async move { host.terminate_children(cx).await }),
+                .map(|host| async move { host.drain(cx).await }),
         )
         .await;
         let phase1_ms = t0.elapsed().as_millis();
@@ -691,9 +673,9 @@ impl HostMesh {
             if let Err(e) = result {
                 tracing::warn!(
                     name = "HostMeshStatus",
-                    status = "Shutdown::TerminateChildren::Failed",
+                    status = "Shutdown::Drain::Failed",
                     error = %e,
-                    "terminate_children failed on a host"
+                    "drain failed on a host"
                 );
             }
         }
@@ -755,13 +737,9 @@ impl HostMesh {
         HostMeshShutdownGuard(self)
     }
 
-    /// Stop all hosts owned by this `HostMesh`, terminating user procs
+    /// Stop all hosts owned by this `HostMesh`, draining user procs
     /// but keeping worker processes and their sockets alive for
     /// reconnection.
-    ///
-    /// Uses the same two-phase approach as [`shutdown`](Self::shutdown):
-    /// first terminate children across all hosts (while networking
-    /// stays alive), then stop hosts concurrently.
     ///
     /// After `stop`, the same worker addresses can be passed to
     /// [`HostMesh::attach`] to create a new mesh.
@@ -770,62 +748,31 @@ impl HostMesh {
         let t0 = std::time::Instant::now();
         tracing::info!(name = "HostMeshStatus", status = "Stop::Attempt");
 
-        // Phase 1: terminate all user procs while service infrastructure
-        // stays alive so forwarder flushes can complete across hosts.
         let results = futures::future::join_all(
             self.current_ref
                 .values()
-                .map(|host| async move { host.terminate_children(cx).await }),
+                .map(|host| async move { host.drain(cx).await }),
         )
         .await;
-        let phase1_ms = t0.elapsed().as_millis();
-        for result in &results {
-            if let Err(e) = result {
-                tracing::warn!(
-                    name = "HostMeshStatus",
-                    status = "Stop::TerminateChildren::Failed",
-                    error = %e,
-                    "terminate_children failed on a host"
-                );
-            }
-        }
-
-        // Phase 2: stop hosts concurrently. No user procs remain.
-        let t1 = std::time::Instant::now();
-        let results = futures::future::join_all(self.current_ref.values().map(|host| async move {
-            let result = host.stop(cx).await;
-            (host, result)
-        }))
-        .await;
-        let phase2_ms = t1.elapsed().as_millis();
         let total_ms = t0.elapsed().as_millis();
         let mut failed_hosts = vec![];
-        for (host, result) in &results {
+        for (i, result) in results.iter().enumerate() {
             if let Err(e) = result {
                 tracing::warn!(
                     name = "HostMeshStatus",
-                    status = "Stop::Host::Failed",
-                    host = %host,
+                    status = "Stop::Drain::Failed",
                     error = %e,
-                    "host stop failed"
+                    "drain failed on a host"
                 );
-                failed_hosts.push(host);
+                failed_hosts.push(i);
             }
         }
         if failed_hosts.is_empty() {
-            tracing::info!(
-                name = "HostMeshStatus",
-                status = "Stop::Success",
-                phase1_ms,
-                phase2_ms,
-                total_ms,
-            );
+            tracing::info!(name = "HostMeshStatus", status = "Stop::Success", total_ms,);
         } else {
             tracing::error!(
                 name = "HostMeshStatus",
                 status = "Stop::Failed",
-                phase1_ms,
-                phase2_ms,
                 total_ms,
                 "host mesh stop failed; check the logs of the failed hosts for details: {:?}",
                 failed_hosts

--- a/hyperactor_mesh/src/host_mesh/host_agent.rs
+++ b/hyperactor_mesh/src/host_mesh/host_agent.rs
@@ -217,13 +217,16 @@ pub const HOST_MESH_AGENT_ACTOR_NAME: &str = "host_agent";
 
 /// Lifecycle state of the host managed by [`HostAgent`].
 enum HostAgentState {
-    /// Normal operation — can spawn procs, handle messages.
-    Running(HostAgentMode),
-    /// Children being terminated by a TerminationWorker.
-    Stopping,
-    /// Children terminated, host still alive for shutdown.
-    Stopped(HostAgentMode),
-    /// Host fully shut down (after ShutdownHost).
+    /// Waiting for a client to attach. The host is idle and ready
+    /// to accept new proc spawn requests.
+    Detached(HostAgentMode),
+    /// Actively running procs for an attached client.
+    Attached(HostAgentMode),
+    /// Procs are being drained by a DrainWorker. The host has been
+    /// temporarily moved to the worker. The host agent remains
+    /// responsive; min_proc_status() returns Stopping.
+    Draining,
+    /// Host fully shut down.
     Shutdown,
 }
 
@@ -236,27 +239,28 @@ struct ProcStatusChanged {
     name: Name,
 }
 
-/// Sent by TerminationWorker back to HostAgent when termination completes.
+/// Sent by DrainWorker back to HostAgent when draining completes.
 /// Not exported — delivered locally via PortHandle (no serialization).
-struct TerminationDone {
+struct DrainComplete {
     host: HostAgentMode,
+    ack: hyperactor_reference::PortRef<()>,
 }
 
 /// Child actor whose only job is to run `host.terminate_children()` in
-/// its `init()`, send the ack reply, return the host to the parent
-/// via TerminationDone, and exit. Runs on the same proc as the host
-/// agent so it gets its own `Instance` (required by `terminate_children`).
+/// its `init()`, return the host and ack to the parent via DrainComplete,
+/// and exit. Runs on the same proc as the host agent so it gets its
+/// own `Instance` (required by `terminate_children`).
 #[hyperactor::export(handlers = [])]
-struct TerminationWorker {
+struct DrainWorker {
     host: Option<HostAgentMode>,
     timeout: Duration,
     max_in_flight: usize,
-    ack: hyperactor_reference::PortRef<()>,
-    done_notify: PortHandle<TerminationDone>,
+    ack: Option<hyperactor_reference::PortRef<()>>,
+    done_notify: PortHandle<DrainComplete>,
 }
 
 #[async_trait]
-impl Actor for TerminationWorker {
+impl Actor for DrainWorker {
     async fn init(&mut self, this: &Instance<Self>) -> Result<(), anyhow::Error> {
         if let Some(host) = self.host.as_mut() {
             match host {
@@ -265,37 +269,30 @@ impl Actor for TerminationWorker {
                         this,
                         self.timeout,
                         self.max_in_flight.clamp(1, 256),
-                        "terminate children",
+                        "drain host",
                     )
                     .await;
                 }
                 HostAgentMode::Local(host) => {
-                    host.terminate_children(
-                        this,
-                        self.timeout,
-                        self.max_in_flight,
-                        "terminate children",
-                    )
-                    .await;
+                    host.terminate_children(this, self.timeout, self.max_in_flight, "drain host")
+                        .await;
                 }
             }
         }
 
-        // Reply ack to the caller.
-        self.ack.send(this, ())?;
-
-        // Return host to parent.
-        if let Some(host) = self.host.take() {
-            let _ = self.done_notify.send(this, TerminationDone { host });
+        // Bundle host + ack into DrainComplete so the parent sends the ack
+        // AFTER restoring state (prevents race with ShutdownHost).
+        if let (Some(host), Some(ack)) = (self.host.take(), self.ack.take()) {
+            let _ = self.done_notify.send(this, DrainComplete { host, ack });
         }
 
         Ok(())
     }
 }
 
-impl fmt::Debug for TerminationWorker {
+impl fmt::Debug for DrainWorker {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("TerminationWorker")
+        f.debug_struct("DrainWorker")
             .field("timeout", &self.timeout)
             .field("max_in_flight", &self.max_in_flight)
             .finish()
@@ -311,8 +308,7 @@ impl fmt::Debug for TerminationWorker {
         resource::WaitRankStatus { cast = true },
         resource::List,
         ShutdownHost,
-        StopHost,
-        TerminateProcs,
+        DrainHost,
         SpawnMeshAdmin,
         SetClientConfig,
         ProcStatusChanged,
@@ -354,7 +350,7 @@ impl HostAgent {
     /// Create a new host mesh agent running in the provided mode.
     pub fn new(host: HostAgentMode) -> Self {
         Self {
-            state: HostAgentState::Running(host),
+            state: HostAgentState::Detached(host),
             created: HashMap::new(),
             pending_proc_waiters: HashMap::new(),
             watching: HashSet::new(),
@@ -368,23 +364,22 @@ impl HostAgent {
     /// Procs on this host cannot be healthier than this.
     fn min_proc_status(&self) -> resource::Status {
         match &self.state {
-            HostAgentState::Running(_) => resource::Status::Running, // no constraint
-            HostAgentState::Stopping => resource::Status::Stopping,
-            HostAgentState::Stopped(_) => resource::Status::Stopped,
+            HostAgentState::Detached(_) | HostAgentState::Attached(_) => resource::Status::Running,
+            HostAgentState::Draining => resource::Status::Stopping,
             HostAgentState::Shutdown => resource::Status::Stopped,
         }
     }
 
     fn host(&self) -> Option<&HostAgentMode> {
         match &self.state {
-            HostAgentState::Running(h) | HostAgentState::Stopped(h) => Some(h),
+            HostAgentState::Detached(h) | HostAgentState::Attached(h) => Some(h),
             _ => None,
         }
     }
 
     fn host_mut(&mut self) -> Option<&mut HostAgentMode> {
         match &mut self.state {
-            HostAgentState::Running(h) | HostAgentState::Stopped(h) => Some(h),
+            HostAgentState::Detached(h) | HostAgentState::Attached(h) => Some(h),
             _ => None,
         }
     }
@@ -394,7 +389,7 @@ impl HostAgent {
     /// The host, system proc, mailbox server, and HostAgent all stay
     /// alive — only user procs are killed. After this returns the host
     /// is ready to accept new spawn requests with the same proc names.
-    async fn terminate_children_and_clear(
+    async fn drain(
         &mut self,
         cx: &Context<'_, Self>,
         timeout: std::time::Duration,
@@ -419,7 +414,7 @@ impl HostAgent {
         self.created.clear();
     }
 
-    /// Publish the current host properties and children list for
+    /// Publish the current host properties and child list for
     /// introspection. Called from init and after each state change
     /// (proc created/stopped).
     fn publish_introspect_properties(&self, cx: &Instance<Self>) {
@@ -630,10 +625,22 @@ impl Handler<resource::CreateOrUpdate<ProcSpec>> for HostAgent {
         if let Err(e) = &created {
             tracing::error!("failed to spawn proc {}: {}", create_or_update.name, e);
         }
+        let was_empty = self.created.is_empty();
         self.created.insert(
             create_or_update.name.clone(),
             ProcCreationState { rank, created },
         );
+
+        // Transition Detached → Attached on first proc creation.
+        if was_empty {
+            if let HostAgentState::Detached(_) = &self.state {
+                let host = match std::mem::replace(&mut self.state, HostAgentState::Shutdown) {
+                    HostAgentState::Detached(h) => h,
+                    _ => unreachable!(),
+                };
+                self.state = HostAgentState::Attached(host);
+            }
+        }
 
         // If any WaitRankStatus messages arrived before this proc
         // existed, their waiters were stashed with a sentinel rank.
@@ -953,66 +960,53 @@ pub struct ShutdownHost {
 }
 wirevalue::register_type!(ShutdownHost);
 
-/// Stop the host: tear down all resources (procs, host, router) but
-/// keep the worker process alive so a new client can re-bootstrap.
-/// TODO: consider generalizing resource::StopAll to use for this case.
+/// Drain all user procs on this host but keep the host, service
+/// proc, and networking alive. Used during mesh stop/shutdown so
+/// that forwarder flushes can still reach remote hosts.
 #[derive(Serialize, Deserialize, Debug, Named, Handler, RefClient, HandleClient)]
-pub struct StopHost {
-    /// Grace window: send SIGTERM and wait this long before
-    /// escalating.
-    pub timeout: std::time::Duration,
-    /// Max number of children to terminate concurrently on this host.
-    pub max_in_flight: usize,
-    /// Ack that the agent finished stop work (best-effort).
-    #[reply]
-    pub ack: hyperactor::reference::PortRef<()>,
-}
-wirevalue::register_type!(StopHost);
-
-/// Terminate all user procs on this host but keep the host, service
-/// proc, and networking alive.  Used as phase 1 of a two-phase mesh
-/// shutdown so that forwarder flushes can still reach remote hosts.
-#[derive(Serialize, Deserialize, Debug, Named, Handler, RefClient, HandleClient)]
-pub struct TerminateProcs {
+pub struct DrainHost {
     pub timeout: std::time::Duration,
     pub max_in_flight: usize,
     #[reply]
     pub ack: hyperactor::reference::PortRef<()>,
 }
-wirevalue::register_type!(TerminateProcs);
+wirevalue::register_type!(DrainHost);
 
 #[async_trait]
-impl Handler<TerminateProcs> for HostAgent {
-    async fn handle(&mut self, cx: &Context<Self>, msg: TerminateProcs) -> anyhow::Result<()> {
-        // Only proceed if Running.
-        let host = match std::mem::replace(&mut self.state, HostAgentState::Shutdown) {
-            HostAgentState::Running(h) => h,
-            other => {
-                // Already stopping/stopped — put state back, ack immediately.
+impl Handler<DrainHost> for HostAgent {
+    async fn handle(&mut self, cx: &Context<Self>, msg: DrainHost) -> anyhow::Result<()> {
+        let host = match std::mem::replace(&mut self.state, HostAgentState::Draining) {
+            HostAgentState::Attached(h) => h,
+            other @ (HostAgentState::Detached(_) | HostAgentState::Draining) => {
+                // Nothing to drain — ack immediately.
                 self.state = other;
                 msg.ack.send(cx, ())?;
                 return Ok(());
             }
+            HostAgentState::Shutdown => {
+                self.state = HostAgentState::Shutdown;
+                msg.ack.send(cx, ())?;
+                return Ok(());
+            }
         };
-        // Do NOT clear `self.created` here: the TerminationWorker
+
+        // Do NOT clear `self.created` here: the DrainWorker
         // terminates procs asynchronously, and concurrent GetState /
-        // GetRankStatus queries must still find the entries.  With the
-        // host in Stopping state (`self.host()` returns None), those
+        // GetRankStatus queries must still find the entries. With the
+        // host in Draining state (`self.host()` returns None), those
         // handlers already report Status::Stopped for every known
-        // proc, which is the correct answer while termination is
+        // proc, which is the correct answer while draining is
         // in progress.
 
-        self.state = HostAgentState::Stopping;
-
-        let done_port = cx.port::<TerminationDone>();
+        let done_port = cx.port::<DrainComplete>();
 
         cx.spawn_with_name(
-            "termination_worker",
-            TerminationWorker {
+            "drain_worker",
+            DrainWorker {
                 host: Some(host),
                 timeout: msg.timeout,
                 max_in_flight: msg.max_in_flight,
-                ack: msg.ack,
+                ack: Some(msg.ack),
                 done_notify: done_port,
             },
         )?;
@@ -1022,52 +1016,11 @@ impl Handler<TerminateProcs> for HostAgent {
 }
 
 #[async_trait]
-impl Handler<TerminationDone> for HostAgent {
-    async fn handle(&mut self, _cx: &Context<Self>, msg: TerminationDone) -> anyhow::Result<()> {
-        self.state = HostAgentState::Stopped(msg.host);
-        Ok(())
-    }
-}
-
-#[async_trait]
-impl Handler<StopHost> for HostAgent {
-    async fn handle(&mut self, cx: &Context<Self>, msg: StopHost) -> anyhow::Result<()> {
-        // Terminate children BEFORE acking, so the caller's networking
-        // stays alive while children flush their forwarders during
-        // teardown. If we ack first, the caller proceeds to tear down
-        // the host proc's networking while children are still running,
-        // causing their forwarder flushes to hang until
-        // MESSAGE_DELIVERY_TIMEOUT expires.
-        if !self.created.is_empty() {
-            self.terminate_children_and_clear(cx, msg.timeout, msg.max_in_flight)
-                .await;
-        }
-
-        // Reset to Running so the host is ready for new spawn requests.
-        // TerminateProcs may have moved us to Stopped(host); StopHost's
-        // contract is to leave the host alive and re-usable.
-        match &self.state {
-            HostAgentState::Stopped(_) => {
-                // Take ownership of the host out of Stopped and wrap it
-                // back in Running.
-                let host = match std::mem::replace(&mut self.state, HostAgentState::Shutdown) {
-                    HostAgentState::Stopped(h) => h,
-                    _ => unreachable!(),
-                };
-                self.state = HostAgentState::Running(host);
-            }
-            HostAgentState::Running(_) => {} // already fine
-            _ => {}
-        }
-
-        // Ack after children are terminated so the caller does not
-        // tear down the host's networking prematurely.
+impl Handler<DrainComplete> for HostAgent {
+    async fn handle(&mut self, cx: &Context<Self>, msg: DrainComplete) -> anyhow::Result<()> {
+        self.state = HostAgentState::Detached(msg.host);
+        self.created.clear();
         msg.ack.send(cx, ())?;
-        tracing::info!(
-            proc_id = %cx.self_id().proc_id(),
-            actor_id = %cx.self_id(),
-            "host stopped, ready for new client"
-        );
         Ok(())
     }
 }
@@ -1082,8 +1035,7 @@ impl Handler<ShutdownHost> for HostAgent {
         // causing their forwarder flushes to hang until
         // MESSAGE_DELIVERY_TIMEOUT expires.
         if !self.created.is_empty() {
-            self.terminate_children_and_clear(cx, msg.timeout, msg.max_in_flight)
-                .await;
+            self.drain(cx, msg.timeout, msg.max_in_flight).await;
         }
 
         // Ack after children are terminated so the caller does not
@@ -1093,11 +1045,11 @@ impl Handler<ShutdownHost> for HostAgent {
         // Drop the host and signal the bootstrap loop to drain the
         // mailbox and exit.
         match std::mem::replace(&mut self.state, HostAgentState::Shutdown) {
-            HostAgentState::Running(HostAgentMode::Process {
+            HostAgentState::Detached(HostAgentMode::Process {
                 shutdown_tx: Some(tx),
                 ..
             })
-            | HostAgentState::Stopped(HostAgentMode::Process {
+            | HostAgentState::Attached(HostAgentMode::Process {
                 shutdown_tx: Some(tx),
                 ..
             }) => {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #3285
* #3284
* #3283
* #3282
* #3281
* #3280
* #3279
* #3278
* #3277
* #3276

Replace the Running/Stopping/Stopped/Shutdown state machine with
Detached/Attached/Draining/Shutdown. A host starts Detached (idle),
becomes Attached when the first proc is created, transitions through
Draining back to Detached when procs are terminated, and enters
Shutdown for full teardown.

This separates the host's lifecycle from the proc lifecycle: the host
itself doesn't stop during a drain — only the procs do.

Concrete changes:
- Redefine HostAgentState: Detached/Attached/Draining/Shutdown.
- CreateOrUpdate transitions Detached → Attached on first proc.
- Rename TerminateProcs → DrainHost, TerminationWorker → DrainWorker,
  TerminationDone → DrainDone. DrainDone bundles the ack so it is sent
  after state is restored (prevents race with ShutdownHost).
- DrainDone handler restores Detached and clears created map.
- Remove StopHost message and handler (no longer needed).
- Rename terminate_children_and_clear → drain.
- Rename HostRef::terminate_children → HostRef::drain, remove
  HostRef::stop.
- Simplify HostMesh::stop() to a single drain phase.

Differential Revision: [D98526089](https://our.internmc.facebook.com/intern/diff/D98526089/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D98526089/)!