### PR TITLE
Integrate telemetry/dashboard with Job API (#3291)

### DIFF
--- a/examples/distributed_telemetry.py
+++ b/examples/distributed_telemetry.py
@@ -37,7 +37,7 @@ import time
 import pyarrow as pa
 from monarch.actor import Actor, endpoint
 from monarch.distributed_telemetry.actor import start_telemetry
-from monarch.job import ProcessJob
+from monarch.job import ProcessJob, TelemetryConfig
 
 
 class ComputeActor(Actor):
@@ -473,15 +473,24 @@ def run_workload(job, summary=False, interactive=False):
 
     Args:
         job: JobTrait whose state has a "workers" HostMesh.
+            If the job was created with ``telemetry=TelemetryConfig()``, the
+            query engine is available via ``state.query_engine`` and
+            ``start_telemetry()`` does not need to be called separately.
         summary: If True, print summary output instead of full tables.
         interactive: If True, pause after setup so the dashboard can be browsed.
     """
     print("=" * 50)
     print()
 
-    engine, _ = start_telemetry()
+    state = job.state(cached_path=None)
 
-    hosts = job.state(cached_path=None).hosts
+    # Use engine from JobState if available (telemetry configured on job),
+    # otherwise fall back to manual start_telemetry() for backward compat.
+    engine = state.query_engine
+    if engine is None:
+        engine, _ = start_telemetry()
+
+    hosts = state.hosts
 
     procs = hosts.spawn_procs(per_host={"workers": 2}, name="workers")
 
@@ -565,7 +574,7 @@ def run_workload(job, summary=False, interactive=False):
 
 def main(summary: bool = False, interactive: bool = False) -> None:
     run_workload(
-        ProcessJob({"hosts": 2}),
+        ProcessJob({"hosts": 2}, telemetry=TelemetryConfig()),
         summary=summary,
         interactive=interactive,
     )

--- a/python/examples/dining_philosophers.py
+++ b/python/examples/dining_philosophers.py
@@ -40,14 +40,13 @@ so the full dashboard UI is available out of the box.
 
 import argparse
 import asyncio
-import os
 from enum import auto, Enum
 from typing import Any, cast
 
 from monarch._src.actor.actor_mesh import ActorMesh
 from monarch._src.actor.host_mesh import _spawn_admin
-from monarch.actor import Actor, current_rank, endpoint, this_host
-from monarch.distributed_telemetry.actor import start_telemetry
+from monarch.actor import Actor, current_rank, endpoint
+from monarch.job import ProcessJob, TelemetryConfig
 
 
 class ChopstickStatus(Enum):
@@ -159,14 +158,19 @@ async def async_main(
     dashboard_port: int = 8265,
     kill_waiter_after: float | None = None,
 ) -> None:
-    telemetry_url = None
+    telemetry = None
     if dashboard:
-        _, telemetry_url = start_telemetry(
+        telemetry = TelemetryConfig(
             include_dashboard=True, dashboard_port=dashboard_port
         )
-        print(f"  - Dashboard:     {telemetry_url}")
 
-    host = this_host()
+    job = ProcessJob({"hosts": 1}, telemetry=telemetry)
+    state = job.state(cached_path=None)
+    host = state.hosts
+
+    telemetry_url = state.telemetry_url
+    if telemetry_url is not None:
+        print(f"  - Dashboard:     {telemetry_url}")
 
     # Spawn the admin agent so the TUI can attach.
     admin_url = await _spawn_admin([host], telemetry_url=telemetry_url)

--- a/python/monarch/_src/job/job.py
+++ b/python/monarch/_src/job/job.py
@@ -15,6 +15,7 @@ import subprocess
 import sys
 import tempfile
 from abc import ABC, abstractmethod
+from dataclasses import dataclass
 from typing import Dict, List, Literal, NamedTuple, Optional, Sequence
 
 from monarch._src.actor.bootstrap import attach_to_workers
@@ -22,6 +23,29 @@ from monarch._src.actor.bootstrap import attach_to_workers
 # note: the jobs api is intended as a library so it should
 # only be importing _public_ monarch API functions.
 from monarch.actor import enable_transport, HostMesh, this_host
+from monarch.distributed_telemetry.actor import start_telemetry
+from monarch.distributed_telemetry.engine import QueryEngine
+
+
+@dataclass
+class TelemetryConfig:
+    """Configuration for automatic telemetry startup.
+
+    When passed to a job constructor, telemetry (and optionally a dashboard)
+    is started automatically when ``state()`` is called.
+
+    Args:
+        batch_size: Number of rows to buffer before flushing to a RecordBatch.
+        retention_secs: Retention window in seconds for message tables.
+            0 disables retention.
+        include_dashboard: Whether to start the monarch dashboard web server.
+        dashboard_port: Preferred port for the dashboard.
+    """
+
+    batch_size: int = 1000
+    retention_secs: int = 600
+    include_dashboard: bool = False
+    dashboard_port: int = 8265
 
 
 class JobState:
@@ -38,8 +62,15 @@ class JobState:
         state.dataloaders # HostMesh for the "dataloaders" mesh
     """
 
-    def __init__(self, hosts: Dict[str, HostMesh]):
+    def __init__(
+        self,
+        hosts: Dict[str, HostMesh],
+        query_engine: Optional[QueryEngine] = None,
+        telemetry_url: Optional[str] = None,
+    ):
         self._hosts = hosts
+        self.query_engine = query_engine
+        self.telemetry_url = telemetry_url
 
     def __getattr__(self, attr: str) -> HostMesh:
         try:
@@ -98,9 +129,32 @@ class JobTrait(ABC):
         ``apply()`` set the status after ``_create()`` returns.
     """
 
-    def __init__(self):
+    def __init__(self, telemetry: Optional[TelemetryConfig] = None):
         super().__init__()
         self._status: Literal["running", "not_running"] | CachedRunning = "not_running"
+        self._telemetry = telemetry
+        self._query_engine: Optional[QueryEngine] = None
+        self._telemetry_url: Optional[str] = None
+
+    def _start_telemetry_if_configured(self) -> None:
+        """Start telemetry if configured and not already running."""
+        if self._telemetry is None or self._query_engine is not None:
+            return
+
+        cfg = self._telemetry
+        self._query_engine, self._telemetry_url = start_telemetry(
+            batch_size=cfg.batch_size,
+            retention_secs=cfg.retention_secs,
+            include_dashboard=cfg.include_dashboard,
+            dashboard_port=cfg.dashboard_port,
+        )
+
+    def _wrap_state(self, job_state: JobState) -> JobState:
+        """Attach telemetry fields to a JobState."""
+        if self._query_engine is not None:
+            job_state.query_engine = self._query_engine
+            job_state.telemetry_url = self._telemetry_url
+        return job_state
 
     @property
     def _running(self) -> "Optional[JobTrait]":
@@ -157,17 +211,20 @@ class JobTrait(ABC):
         running_job = self._running
         if running_job is not None:
             logger.info("Job is running, returning current state")
-            return running_job._state()
+            self._start_telemetry_if_configured()
+            return self._wrap_state(running_job._state())
 
         cached = self._load_cached(cached_path)
         if cached is not None:
             self._status = CachedRunning(cached)
             logger.info("Connecting to cached job")
-            return cached._state()
+            self._start_telemetry_if_configured()
+            return self._wrap_state(cached._state())
         logger.info("Applying current job")
         self.apply()
         logger.info("Job has started, connecting to current state")
-        result = self._state()
+        self._start_telemetry_if_configured()
+        result = self._wrap_state(self._state())
         if cached_path is not None:
             # Create the directory for cached_path if it doesn't exist
             cache_dir = os.path.dirname(cached_path)
@@ -200,6 +257,15 @@ class JobTrait(ABC):
             os.remove(cached_path)
             return None
         return job
+
+    def __getstate__(self):
+        state = self.__dict__.copy()
+        # QueryEngine holds Rust bindings / network connections and is not
+        # picklable.  Drop it so deserialized jobs re-initialize telemetry
+        # on the next state() call.
+        state["_query_engine"] = None
+        state["_telemetry_url"] = None
+        return state
 
     def dump(self, filename: str):
         """
@@ -292,17 +358,22 @@ class LocalJob(JobTrait):
     execution by changing the job configuration.
     """
 
-    def __init__(self, hosts: Sequence["str"] = ("hosts",)):
+    def __init__(
+        self,
+        hosts: Sequence["str"] = ("hosts",),
+        telemetry: Optional[TelemetryConfig] = None,
+    ):
         """
         Args:
             hosts: Names of the host meshes to create.
+            telemetry: Optional telemetry configuration.
         """
         self._host_names = hosts
         # if launched with client_script, the proc corresponding to the
         # locally running client, and the log_dir it is writing to.
         self._proc: Optional[subprocess.Popen] = None
         self._log_dir: Optional[str] = None
-        super().__init__()
+        super().__init__(telemetry=telemetry)
 
     def _kill(self):
         pass
@@ -386,7 +457,7 @@ class BatchJob(JobTrait):
     """
 
     def __init__(self, job: JobTrait):
-        super().__init__()
+        super().__init__(telemetry=job._telemetry)
         self._job = job
 
     def can_run(self, spec: JobTrait):
@@ -422,8 +493,8 @@ class LoginJob(JobTrait):
     Makes a connections directly to hosts via an explicit list.
     """
 
-    def __init__(self):
-        super().__init__()
+    def __init__(self, telemetry: Optional[TelemetryConfig] = None):
+        super().__init__(telemetry=telemetry)
         self._meshes: Dict[str, List[str]] = {}
         self._host_to_pid: Dict[str, ProcessState] = {}
 
@@ -493,12 +564,13 @@ class SSHJob(LoginJob):
         python_exe: str = "python",
         ssh_args: Sequence[str] = (),
         monarch_port: int = 22222,
+        telemetry: Optional[TelemetryConfig] = None,
     ):
         enable_transport("tcp")
         self._python_exe = python_exe
         self._ssh_args = ssh_args
         self._port = monarch_port
-        super().__init__()
+        super().__init__(telemetry=telemetry)
 
     def _start_host(self, host: str) -> ProcessState:
         addr = f"tcp://{host}:{self._port}"

--- a/python/monarch/_src/job/kubernetes.py
+++ b/python/monarch/_src/job/kubernetes.py
@@ -23,7 +23,7 @@ except ImportError:
 from monarch._rust_bindings.monarch_hyperactor.channel import ChannelTransport
 from monarch._rust_bindings.monarch_hyperactor.config import configure
 from monarch._src.actor.bootstrap import attach_to_workers
-from monarch._src.job.job import JobState, JobTrait
+from monarch._src.job.job import JobState, JobTrait, TelemetryConfig
 
 
 logger: logging.Logger = logging.getLogger(__name__)
@@ -101,6 +101,7 @@ class KubernetesJob(JobTrait):
         self,
         namespace: str,
         timeout: int | None = None,
+        telemetry: TelemetryConfig | None = None,
     ) -> None:
         """
         Initialize a KubernetesJob.
@@ -108,12 +109,13 @@ class KubernetesJob(JobTrait):
         Args:
             namespace: Kubernetes namespace for all meshes
             timeout: Maximum seconds to wait for pods to be ready for each mesh (default: None, wait indefinitely)
+            telemetry: Optional telemetry configuration.
         """
         configure(default_transport=ChannelTransport.TcpWithHostname)
         self._namespace = namespace
         self._timeout = timeout
         self._meshes: Dict[str, Dict[str, Any]] = {}
-        super().__init__()
+        super().__init__(telemetry=telemetry)
 
     # TODO: Consider adding monarch-rank label instead of relying on StatefulSet index by default if using MonarchMesh CRD.
     def add_mesh(

--- a/python/monarch/_src/job/process.py
+++ b/python/monarch/_src/job/process.py
@@ -17,7 +17,7 @@ from typing import Dict, List, Optional, Union
 
 from monarch._src.actor.bootstrap import attach_to_workers
 from monarch._src.actor.future import Future
-from monarch._src.job.job import JobState, JobTrait, ProcessState
+from monarch._src.job.job import JobState, JobTrait, ProcessState, TelemetryConfig
 
 logger = logging.getLogger(__name__)
 
@@ -47,14 +47,18 @@ class ProcessJob(JobTrait):
     """
 
     def __init__(
-        self, meshes: Dict[str, int], env: Optional[Dict[str, str]] = None
+        self,
+        meshes: Dict[str, int],
+        env: Optional[Dict[str, str]] = None,
+        telemetry: Optional[TelemetryConfig] = None,
     ) -> None:
         """
         Args:
             meshes: Mapping from mesh name to number of hosts.
             env: Extra environment variables for worker subprocesses.
+            telemetry: Optional telemetry configuration.
         """
-        super().__init__()
+        super().__init__(telemetry=telemetry)
         self._meshes = meshes
         self._env = env
         self._host_to_pid: Dict[str, ProcessState] = {}

--- a/python/monarch/_src/job/slurm.py
+++ b/python/monarch/_src/job/slurm.py
@@ -16,7 +16,7 @@ from typing import Any, Dict, FrozenSet, List, Optional, Sequence
 from monarch._rust_bindings.monarch_hyperactor.channel import ChannelTransport
 from monarch._rust_bindings.monarch_hyperactor.config import configure
 from monarch._src.actor.bootstrap import attach_to_workers
-from monarch._src.job.job import JobState, JobTrait
+from monarch._src.job.job import JobState, JobTrait, TelemetryConfig
 
 
 logger: logging.Logger = logging.getLogger(__name__)
@@ -56,6 +56,7 @@ class SlurmJob(JobTrait):
         cpus_per_task: Optional[int] = None,
         mem: Optional[str] = None,
         job_start_timeout: Optional[int] = None,
+        telemetry: Optional[TelemetryConfig] = None,
     ) -> None:
         """
         Args:
@@ -93,7 +94,7 @@ class SlurmJob(JobTrait):
         # Track the single SLURM job ID and all allocated hostnames
         self._slurm_job_id: Optional[str] = None
         self._all_hostnames: List[str] = []
-        super().__init__()
+        super().__init__(telemetry=telemetry)
 
     def add_mesh(self, name: str, num_nodes: int) -> None:
         self._meshes[name] = num_nodes

--- a/python/monarch/_src/job/spmd.py
+++ b/python/monarch/_src/job/spmd.py
@@ -23,7 +23,7 @@ from monarch._rust_bindings.monarch_hyperactor.channel import ChannelTransport
 from monarch._rust_bindings.monarch_hyperactor.config import configure
 from monarch._src.actor.bootstrap import attach_to_workers
 from monarch._src.actor.host_mesh import this_host
-from monarch._src.job.job import JobState, JobTrait
+from monarch._src.job.job import JobState, JobTrait, TelemetryConfig
 from monarch._src.spmd.actor import SPMDActor
 from monarch._src.tools.commands import torchx_runner
 from torchx.runner import Runner
@@ -378,8 +378,9 @@ class SPMDJob(JobTrait):
         scheduler: str,
         workspace: Optional[str] = None,
         original_roles: Optional[List[Dict[str, Any]]] = None,
+        telemetry: Optional[TelemetryConfig] = None,
     ):
-        super().__init__()
+        super().__init__(telemetry=telemetry)
         self._app_handle = handle
         self._scheduler = scheduler
         self._workspace = workspace

--- a/python/monarch/job/__init__.py
+++ b/python/monarch/job/__init__.py
@@ -5,7 +5,14 @@
 # LICENSE file in the root directory of this source tree.
 
 # Re-export the job module directly
-from monarch._src.job.job import job_load, job_loads, JobState, JobTrait, LocalJob
+from monarch._src.job.job import (
+    job_load,
+    job_loads,
+    JobState,
+    JobTrait,
+    LocalJob,
+    TelemetryConfig,
+)
 from monarch._src.job.process import ProcessJob
 from monarch._src.job.slurm import SlurmJob
 
@@ -18,4 +25,5 @@ __all__ = [
     "LocalJob",
     "ProcessJob",
     "SlurmJob",
+    "TelemetryConfig",
 ]

--- a/python/tests/test_distributed_telemetry.py
+++ b/python/tests/test_distributed_telemetry.py
@@ -22,7 +22,7 @@ from monarch._src.actor.proc_mesh import (
     unregister_proc_mesh_spawn_callback,
 )
 from monarch.distributed_telemetry.actor import start_telemetry
-from monarch.job import ProcessJob
+from monarch.job import ProcessJob, TelemetryConfig
 
 
 class WorkerActor(Actor):
@@ -112,12 +112,15 @@ def test_record_batch_tracing(cleanup_callbacks) -> None:
 @isolate_in_subprocess
 def test_actors_table() -> None:
     """Test that the actors table is populated when actors are spawned."""
-    # Start telemetry with real data (not fake) so RecordBatchSink receives events
-    engine, _ = start_telemetry(batch_size=10, include_dashboard=False)
-
     # Spawn some worker actors - this should trigger notify_actor_created
-    job = ProcessJob({"hosts": 1})
-    hosts = job.state(cached_path=None).hosts
+    job = ProcessJob(
+        {"hosts": 1},
+        telemetry=TelemetryConfig(batch_size=10),
+    )
+    state = job.state(cached_path=None)
+    engine = state.query_engine
+    assert engine is not None
+    hosts = state.hosts
     worker_procs = hosts.spawn_procs(per_host={"workers": 2})
     workers = worker_procs.spawn("test_worker", WorkerActor)
     workers.initialized.get()
@@ -166,12 +169,15 @@ def test_actors_table() -> None:
 @isolate_in_subprocess
 def test_meshes_table() -> None:
     """Test that the meshes table is populated when actor meshes are spawned."""
-    # Start telemetry with real data (not fake) so RecordBatchSink receives events
-    engine, _ = start_telemetry(batch_size=10, include_dashboard=False)
-
     # Spawn some worker actors - this should trigger notify_mesh_created
-    job = ProcessJob({"hosts": 1})
-    hosts = job.state(cached_path=None).hosts
+    job = ProcessJob(
+        {"hosts": 1},
+        telemetry=TelemetryConfig(batch_size=10),
+    )
+    state = job.state(cached_path=None)
+    engine = state.query_engine
+    assert engine is not None
+    hosts = state.hosts
     worker_procs = hosts.spawn_procs(per_host={"workers": 2})
     workers = worker_procs.spawn("test_mesh_worker", WorkerActor)
     workers.initialized.get()
@@ -262,11 +268,15 @@ def test_meshes_table() -> None:
 @isolate_in_subprocess
 def test_proc_mesh_in_meshes_table() -> None:
     """Test that ProcMesh creation is recorded in the meshes table with class 'Proc'."""
-    engine, _ = start_telemetry(batch_size=10, include_dashboard=False)
-
     # Spawn a named proc mesh — this should emit a mesh event with class "Proc"
-    job = ProcessJob({"hosts": 1})
-    hosts = job.state(cached_path=None).hosts
+    job = ProcessJob(
+        {"hosts": 1},
+        telemetry=TelemetryConfig(batch_size=10),
+    )
+    state = job.state(cached_path=None)
+    engine = state.query_engine
+    assert engine is not None
+    hosts = state.hosts
     worker_procs = hosts.spawn_procs(per_host={"workers": 2}, name="proc_mesh_test")
     workers = worker_procs.spawn("proc_mesh_test_worker", WorkerActor)
     workers.initialized.get()
@@ -325,11 +335,15 @@ def test_proc_mesh_in_meshes_table() -> None:
 @isolate_in_subprocess
 def test_actors_join_meshes_on_mesh_id(cleanup_callbacks) -> None:
     """Test that actors.mesh_id matches meshes.id, enabling joins."""
-    engine, _ = start_telemetry(batch_size=10, include_dashboard=False)
-
     # Spawn actors — this populates both the actors and meshes tables
-    job = ProcessJob({"hosts": 1})
-    hosts = job.state(cached_path=None).hosts
+    job = ProcessJob(
+        {"hosts": 1},
+        telemetry=TelemetryConfig(batch_size=10),
+    )
+    state = job.state(cached_path=None)
+    engine = state.query_engine
+    assert engine is not None
+    hosts = state.hosts
     worker_procs = hosts.spawn_procs(per_host={"workers": 2})
     workers = worker_procs.spawn("join_test_worker", WorkerActor)
     workers.initialized.get()
@@ -374,11 +388,15 @@ def test_actors_join_meshes_on_mesh_id(cleanup_callbacks) -> None:
 @isolate_in_subprocess
 def test_all_actors_in_proc_mesh(cleanup_callbacks) -> None:
     """Test that all actor meshes within a proc mesh have actors in the actors table."""
-    engine, _ = start_telemetry(batch_size=10, include_dashboard=False)
-
     # Spawn a named proc mesh and user actors
-    job = ProcessJob({"hosts": 1})
-    hosts = job.state(cached_path=None).hosts
+    job = ProcessJob(
+        {"hosts": 1},
+        telemetry=TelemetryConfig(batch_size=10),
+    )
+    state = job.state(cached_path=None)
+    engine = state.query_engine
+    assert engine is not None
+    hosts = state.hosts
     worker_procs = hosts.spawn_procs(per_host={"workers": 2}, name="workers_procs")
     workers = worker_procs.spawn("worker_actors", WorkerActor)
     workers.initialized.get()
@@ -435,11 +453,15 @@ def test_all_actors_in_proc_mesh(cleanup_callbacks) -> None:
 @isolate_in_subprocess
 def test_all_actors_in_host_mesh(cleanup_callbacks) -> None:
     """Test that all actor meshes within a proc mesh have actors in the actors table."""
-    engine, _ = start_telemetry(batch_size=10, include_dashboard=False)
-
     # Spawn a named proc mesh and user actors
-    job = ProcessJob({"hosts": 2})
-    hosts = job.state(cached_path=None).hosts
+    job = ProcessJob(
+        {"hosts": 2},
+        telemetry=TelemetryConfig(batch_size=10),
+    )
+    state = job.state(cached_path=None)
+    engine = state.query_engine
+    assert engine is not None
+    hosts = state.hosts
     worker_procs = hosts.spawn_procs(per_host={"workers": 2}, name="workers_procs")
     workers = worker_procs.spawn("worker_actors", WorkerActor)
     workers.initialized.get()
@@ -511,11 +533,15 @@ def test_all_actors_in_host_mesh(cleanup_callbacks) -> None:
 @isolate_in_subprocess
 def test_actor_status_events_table() -> None:
     """Test that the actor_status_events table is populated when actors change status."""
-    engine, _ = start_telemetry(batch_size=10, include_dashboard=False)
-
     # Spawn worker actors — actors go through status transitions during spawn
-    job = ProcessJob({"hosts": 1})
-    hosts = job.state(cached_path=None).hosts
+    job = ProcessJob(
+        {"hosts": 1},
+        telemetry=TelemetryConfig(batch_size=10),
+    )
+    state = job.state(cached_path=None)
+    engine = state.query_engine
+    assert engine is not None
+    hosts = state.hosts
     worker_procs = hosts.spawn_procs(per_host={"workers": 2})
     workers = worker_procs.spawn("status_test_worker", WorkerActor)
     workers.initialized.get()
@@ -571,11 +597,15 @@ def test_actor_status_events_table() -> None:
 @isolate_in_subprocess
 def test_sliced_vs_full_view_rank(cleanup_callbacks) -> None:
     """Test that rank and parent_view_json are correct for sliced and full actor meshes."""
-    engine, _ = start_telemetry(batch_size=10, include_dashboard=False)
-
     # Spawn 3 workers so we can slice a subset
-    job = ProcessJob({"hosts": 1})
-    hosts = job.state(cached_path=None).hosts
+    job = ProcessJob(
+        {"hosts": 1},
+        telemetry=TelemetryConfig(batch_size=10),
+    )
+    state = job.state(cached_path=None)
+    engine = state.query_engine
+    assert engine is not None
+    hosts = state.hosts
     worker_procs = hosts.spawn_procs(per_host={"workers": 3}, name="rank_test_procs")
 
     # Full view: spawn on the unsliced proc mesh (all 3 workers)
@@ -677,10 +707,14 @@ def test_sent_messages_table(
       - view_json: serialized ndslice::Region of the current view
       - shape_json: serialized ndslice::Shape (converted from the Region)
     """
-    engine, _ = start_telemetry(batch_size=10, include_dashboard=False)
-
-    job = ProcessJob({"hosts": 1})
-    hosts = job.state(cached_path=None).hosts
+    job = ProcessJob(
+        {"hosts": 1},
+        telemetry=TelemetryConfig(batch_size=10),
+    )
+    state = job.state(cached_path=None)
+    engine = state.query_engine
+    assert engine is not None
+    hosts = state.hosts
     worker_procs = hosts.spawn_procs(per_host={"workers": 2})
     mesh_name = f"sent_msg_{send_path}_worker"
     workers = worker_procs.spawn(mesh_name, WorkerActor)
@@ -759,10 +793,14 @@ def test_sent_messages_table(
 @isolate_in_subprocess
 def test_messages_table(cleanup_callbacks) -> None:
     """Test that the messages table is populated when messages are received."""
-    engine, _ = start_telemetry(batch_size=10, include_dashboard=False)
-
-    job = ProcessJob({"hosts": 1})
-    hosts = job.state(cached_path=None).hosts
+    job = ProcessJob(
+        {"hosts": 1},
+        telemetry=TelemetryConfig(batch_size=10),
+    )
+    state = job.state(cached_path=None)
+    engine = state.query_engine
+    assert engine is not None
+    hosts = state.hosts
     worker_procs = hosts.spawn_procs(per_host={"workers": 2}, name="msg_workers_procs")
     workers = worker_procs.spawn("msg_test_worker", WorkerActor)
     workers.initialized.get()
@@ -813,10 +851,14 @@ def test_messages_table(cleanup_callbacks) -> None:
 @isolate_in_subprocess
 def test_messages_endpoint(cleanup_callbacks) -> None:
     """Test that the messages table endpoint column is populated with the method name."""
-    engine, _ = start_telemetry(batch_size=10, include_dashboard=False)
-
-    job = ProcessJob({"hosts": 1})
-    hosts = job.state(cached_path=None).hosts
+    job = ProcessJob(
+        {"hosts": 1},
+        telemetry=TelemetryConfig(batch_size=10),
+    )
+    state = job.state(cached_path=None)
+    engine = state.query_engine
+    assert engine is not None
+    hosts = state.hosts
     worker_procs = hosts.spawn_procs(per_host={"workers": 2}, name="ep_workers_procs")
     workers = worker_procs.spawn("ep_test_worker", WorkerActor)
     workers.initialized.get()
@@ -851,10 +893,14 @@ def test_messages_endpoint(cleanup_callbacks) -> None:
 @isolate_in_subprocess
 def test_message_status_events_table(cleanup_callbacks) -> None:
     """Test that message_status_events captures queued/active/complete transitions."""
-    engine, _ = start_telemetry(batch_size=10, include_dashboard=False)
-
-    job = ProcessJob({"hosts": 1})
-    hosts = job.state(cached_path=None).hosts
+    job = ProcessJob(
+        {"hosts": 1},
+        telemetry=TelemetryConfig(batch_size=10),
+    )
+    state = job.state(cached_path=None)
+    engine = state.query_engine
+    assert engine is not None
+    hosts = state.hosts
     worker_procs = hosts.spawn_procs(
         per_host={"workers": 1}, name="status_workers_procs"
     )
@@ -904,10 +950,14 @@ def test_message_status_events_table(cleanup_callbacks) -> None:
 @isolate_in_subprocess
 def test_sent_messages_with_sliced_mesh(cleanup_callbacks) -> None:
     """Test that sent_messages view_json/shape_json reflect sliced vs full actor mesh casts."""
-    engine, _ = start_telemetry(batch_size=10, include_dashboard=False)
-
-    job = ProcessJob({"hosts": 1})
-    hosts = job.state(cached_path=None).hosts
+    job = ProcessJob(
+        {"hosts": 1},
+        telemetry=TelemetryConfig(batch_size=10),
+    )
+    state = job.state(cached_path=None)
+    engine = state.query_engine
+    assert engine is not None
+    hosts = state.hosts
     worker_procs = hosts.spawn_procs(per_host={"workers": 4}, name="sm_slice_procs")
 
     # Spawn actors on the full proc mesh
@@ -961,10 +1011,14 @@ def test_sent_messages_with_sliced_mesh(cleanup_callbacks) -> None:
 def test_sent_messages_sender_actor_id(cleanup_callbacks) -> None:
     """Test that sender_actor_id identifies the actor that initiated the cast,
     not the target actor, when one actor casts to another actor mesh."""
-    engine, _ = start_telemetry(batch_size=10, include_dashboard=False)
-
-    job = ProcessJob({"hosts": 1})
-    hosts = job.state(cached_path=None).hosts
+    job = ProcessJob(
+        {"hosts": 1},
+        telemetry=TelemetryConfig(batch_size=10),
+    )
+    state = job.state(cached_path=None)
+    engine = state.query_engine
+    assert engine is not None
+    hosts = state.hosts
     worker_procs = hosts.spawn_procs(per_host={"workers": 2}, name="sender_test_procs")
 
     # Spawn target actors on the full proc mesh
@@ -1028,10 +1082,14 @@ def test_sent_messages_sender_actor_id(cleanup_callbacks) -> None:
 @isolate_in_subprocess
 def test_query_after_stopping_proc_mesh(cleanup_callbacks) -> None:
     """Test that query still works after a user-spawned actor's proc mesh is stopped."""
-    engine, _ = start_telemetry(batch_size=10, include_dashboard=False)
-
-    job = ProcessJob({"hosts": 1})
-    hosts = job.state(cached_path=None).hosts
+    job = ProcessJob(
+        {"hosts": 1},
+        telemetry=TelemetryConfig(batch_size=10),
+    )
+    state = job.state(cached_path=None)
+    engine = state.query_engine
+    assert engine is not None
+    hosts = state.hosts
     worker_procs = hosts.spawn_procs(per_host={"workers": 2}, name="stop_test_procs")
 
     # Spawn and initialize a user actor
@@ -1112,10 +1170,14 @@ def test_query_after_stopping_actor_mesh(cleanup_callbacks) -> None:
     ProcMesh remain alive, so all data (including process-local tables like
     messages) is still queryable.
     """
-    engine, _ = start_telemetry(batch_size=10, include_dashboard=False)
-
-    job = ProcessJob({"hosts": 1})
-    hosts = job.state(cached_path=None).hosts
+    job = ProcessJob(
+        {"hosts": 1},
+        telemetry=TelemetryConfig(batch_size=10),
+    )
+    state = job.state(cached_path=None)
+    engine = state.query_engine
+    assert engine is not None
+    hosts = state.hosts
     worker_procs = hosts.spawn_procs(
         per_host={"workers": 2}, name="actor_stop_test_procs"
     )
@@ -1299,10 +1361,14 @@ def test_pyspy_tables_in_information_schema(cleanup_callbacks) -> None:
 @isolate_in_subprocess
 def test_try_store_pyspy_dump_routes_to_child(cleanup_callbacks) -> None:
     """try_store_pyspy_dump routes to the correct child proc via _proc_id_index."""
-    engine, _ = start_telemetry(batch_size=10, include_dashboard=False)
-
-    job = ProcessJob({"hosts": 1})
-    hosts = job.state(cached_path=None).hosts
+    job = ProcessJob(
+        {"hosts": 1},
+        telemetry=TelemetryConfig(batch_size=10),
+    )
+    state = job.state(cached_path=None)
+    engine = state.query_engine
+    assert engine is not None
+    hosts = state.hosts
     worker_procs = hosts.spawn_procs(per_host={"workers": 2}, name="pyspy_route_procs")
     workers = worker_procs.spawn("pyspy_route_worker", WorkerActor)
     workers.initialized.get()
@@ -1382,10 +1448,14 @@ def test_try_store_pyspy_dump_routes_to_child(cleanup_callbacks) -> None:
 @isolate_in_subprocess
 def test_store_pyspy_dump_unknown_proc_falls_back_to_root(cleanup_callbacks) -> None:
     """store_pyspy_dump stores on root coordinator when proc_ref matches no child."""
-    engine, _ = start_telemetry(batch_size=10, include_dashboard=False)
-
-    job = ProcessJob({"hosts": 1})
-    hosts = job.state(cached_path=None).hosts
+    job = ProcessJob(
+        {"hosts": 1},
+        telemetry=TelemetryConfig(batch_size=10),
+    )
+    state = job.state(cached_path=None)
+    engine = state.query_engine
+    assert engine is not None
+    hosts = state.hosts
     worker_procs = hosts.spawn_procs(
         per_host={"workers": 2}, name="pyspy_fallback_procs"
     )
@@ -1488,7 +1558,7 @@ def test_store_pyspy_dump_returns_true(cleanup_callbacks) -> None:
 @isolate_in_subprocess
 def test_json_columns_are_valid_json() -> None:
     """Test that all view_json and shape_json columns contain valid JSON."""
-    engine, _ = start_telemetry(batch_size=10, include_dashboard=False)
+    engine, _ = start_telemetry(batch_size=10)
 
     # Spawn actors and send messages to populate all tables that have JSON columns:
     # - meshes: shape_json, parent_view_json
@@ -1570,10 +1640,14 @@ def test_per_table_row_retention(cleanup_callbacks) -> None:
     import time
 
     # Use a 1-second retention window so rows expire quickly.
-    engine, _ = start_telemetry(batch_size=2, retention_secs=1, include_dashboard=False)
-
-    job = ProcessJob({"hosts": 1})
-    hosts = job.state(cached_path=None).hosts
+    job = ProcessJob(
+        {"hosts": 1},
+        telemetry=TelemetryConfig(batch_size=2, retention_secs=1),
+    )
+    state = job.state(cached_path=None)
+    engine = state.query_engine
+    assert engine is not None
+    hosts = state.hosts
     worker_procs = hosts.spawn_procs(per_host={"workers": 8}, name="worker_procs")
     workers = worker_procs.spawn("workers", WorkerActor)
     workers.initialized.get()

--- a/python/tests/test_job.py
+++ b/python/tests/test_job.py
@@ -11,11 +11,19 @@ import subprocess
 import sys
 import tempfile
 from typing import cast, Dict, Optional, Sequence
+from unittest.mock import MagicMock, patch
 
 import pytest
 
 # Import directly from _src since job module isn't properly exposed
-from monarch._src.job.job import job_load, job_loads, JobState, JobTrait, LocalJob
+from monarch._src.job.job import (
+    job_load,
+    job_loads,
+    JobState,
+    JobTrait,
+    LocalJob,
+    TelemetryConfig,
+)
 from monarch.actor import HostMesh
 
 
@@ -24,15 +32,21 @@ class MockJobTrait(JobTrait):
     Mock implementation of JobTrait for testing purposes.
     """
 
-    def __init__(self, host_names: Sequence[str] = ("default",), compatible_specs=None):
+    def __init__(
+        self,
+        host_names: Sequence[str] = ("default",),
+        compatible_specs=None,
+        telemetry: Optional[TelemetryConfig] = None,
+    ):
         """
         Initialize a mock job trait.
 
         Args:
             host_names: Names of host meshes to create in the state
             compatible_specs: List of specs this job is compatible with, or None if compatible with all
+            telemetry: Optional telemetry configuration.
         """
-        super().__init__()
+        super().__init__(telemetry=telemetry)
         self._host_names = host_names
         self._compatible_specs = compatible_specs
         # Track mock state for testing
@@ -297,6 +311,61 @@ def test_kill():
 
     # kill_called should now be True
     assert job.kill_called
+
+
+def test_state_query_engine_none_without_telemetry():
+    """Test that query_engine is None when no telemetry is configured."""
+    job = MockJobTrait()
+    state = job.state(cached_path=None)
+    assert state.query_engine is None
+    assert state.telemetry_url is None
+
+
+@patch("monarch._src.job.job.start_telemetry")
+def test_state_query_engine_set_with_telemetry(mock_start):
+    """Test that query_engine is set when telemetry is configured."""
+    mock_engine = MagicMock()
+    mock_url = "http://localhost:8265"
+    mock_start.return_value = (mock_engine, mock_url)
+
+    job = MockJobTrait(telemetry=TelemetryConfig())
+    state = job.state(cached_path=None)
+
+    assert state.query_engine is not None
+    assert state.query_engine is mock_engine
+    assert state.telemetry_url == mock_url
+
+
+@patch("monarch._src.job.job.start_telemetry")
+def test_telemetry_started_only_once(mock_start):
+    """Test that telemetry is not restarted on subsequent state() calls."""
+    mock_start.return_value = (MagicMock(), "http://localhost:8265")
+
+    job = MockJobTrait(telemetry=TelemetryConfig())
+    job.state(cached_path=None)
+    job.state(cached_path=None)
+
+    mock_start.assert_called_once()
+
+
+@patch("monarch._src.job.job.start_telemetry")
+def test_telemetry_dropped_on_pickle(mock_start):
+    """Test that query_engine is dropped during pickling and restored after."""
+    mock_start.return_value = (MagicMock(), "http://localhost:8265")
+
+    job = MockJobTrait(telemetry=TelemetryConfig())
+    job.state(cached_path=None)
+    assert mock_start.call_count == 1
+
+    # Serialize and deserialize — query_engine should be dropped
+    loaded_job = job_loads(job.dumps())
+    assert loaded_job._query_engine is None
+    assert loaded_job._telemetry_url is None
+
+    # Getting state again should re-initialize telemetry
+    state = loaded_job.state(cached_path=None)
+    assert mock_start.call_count == 2
+    assert state.query_engine is not None
 
 
 # Tests for LocalJob implementation


### PR DESCRIPTION
Summary:

Add TelemetryConfig dataclass to make telemetry configurable directly on
JobTrait, so all job types get automatic telemetry startup when state() is
called. Previously, start_telemetry() had to be called manually before job
usage. Now users can pass telemetry=TelemetryConfig() to any job constructor.

- Add TelemetryConfig dataclass with batch_size, retention_secs,
  include_dashboard, dashboard_port fields
- Extend JobState with optional query_engine and telemetry_url attributes
- Add _start_telemetry_if_configured() and _wrap_state() helpers to JobTrait
- Update all job subclass constructors (LocalJob, LoginJob, SSHJob,
  ProcessJob, SlurmJob, KubernetesJob, SPMDJob, MASTJob) to accept and
  pass through telemetry kwarg
- Export TelemetryConfig from monarch.job
- Update distributed_telemetry example to use new API

Note, since we don't persist telemetry data, every attach will have a clean memtable.

Differential Revision: D98575231
