### PR TITLE
Fix mlx5dv segment registration mr_addr

### DIFF
--- a/rdmaxcel-sys/src/rdmaxcel.cpp
+++ b/rdmaxcel-sys/src/rdmaxcel.cpp
@@ -464,7 +464,8 @@ int register_segments(
     }
     seg.registration->mrs = std::move(all_mrs);
     seg.registration->mr_size = seg.phys_size;
-    seg.registration->mr_addr = seg.phys_address;
+    // Memory regions are always registered at address 0.
+    seg.registration->mr_addr = 0;
     seg.registration->mkey = mkey;
     seg.registration->pd = static_cast<void*>(pd);
   }


### PR DESCRIPTION
Summary: D96404481 introduced a bug in the mlx5dv path where `mr_addr` was set to the physical address of the registered segment rather than 0, which is what the correct value always should be. This fixes the issue.

Differential Revision: D98648882


