### PR TITLE
Export MONARCH_ADMIN_URL from _spawn_admin

### DIFF
--- a/python/monarch/_src/actor/host_mesh.py
+++ b/python/monarch/_src/actor/host_mesh.py
@@ -495,9 +495,13 @@ def _spawn_admin(
 
     async def task() -> str:
         hy_meshes = [await m._hy_host_mesh for m in host_meshes]
-        return await _hy_spawn_admin(
+        url = await _hy_spawn_admin(
             hy_meshes, context().actor_instance._as_rust(), admin_addr, telemetry_url
         )
+        # Export admin URL so the dashboard can discover system actors
+        # and build TUI-style DAG hierarchies.
+        os.environ["MONARCH_ADMIN_URL"] = url
+        return url
 
     return Future(coro=task())
 


### PR DESCRIPTION
Summary:
Check if this is still needed; it likely is but touches things outside the dashboard folder.

-----

Export ``MONARCH_ADMIN_URL`` as an environment variable when the admin
agent is spawned via ``_spawn_admin()``. This allows the Monarch
Dashboard's ``admin_dag.py`` to discover the admin HTTP endpoint and use it.

The env var is set in the async task that calls the Rust
``_hy_spawn_admin``, so it's available to all code in the same process
after the future resolves.

Differential Revision: D98692078


