### PR TITLE
Re-add deprecated is_rdma_available function

### DIFF
--- a/docs/source/api/monarch.rdma.rst
+++ b/docs/source/api/monarch.rdma.rst
@@ -28,4 +28,6 @@ Utility Functions
 
 .. autofunction:: is_ibverbs_available
 
+.. autofunction:: is_rdma_available
+
 .. autofunction:: get_rdma_backend

--- a/python/monarch/_src/rdma/rdma.py
+++ b/python/monarch/_src/rdma/rdma.py
@@ -65,6 +65,25 @@ def is_ibverbs_available() -> bool:
     return _is_ibverbs_available()
 
 
+def is_rdma_available() -> bool:
+    """Whether RDMA over ibverbs is available on this system.
+
+    .. deprecated::
+        Monarch now supports multiple RDMA backends, so `is_rdma_available`
+        is ambiguous and will be removed in a future release. Use
+        :func:`is_ibverbs_available` or :func:`get_rdma_backend` instead.
+    """
+    warnings.warn(
+        "is_rdma_available is deprecated because Monarch now supports multiple "
+        "RDMA backends, making this function ambiguous. For now it indicates "
+        "whether RDMA over ibverbs is available. Use is_ibverbs_available() or "
+        "get_rdma_backend() instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return is_ibverbs_available()
+
+
 def get_rdma_backend() -> str:
     """Return available RDMA backend.
 

--- a/python/monarch/rdma/__init__.py
+++ b/python/monarch/rdma/__init__.py
@@ -13,6 +13,7 @@ Monarch RDMA API - Public interface for RDMA functionality.
 from monarch._src.rdma.rdma import (
     get_rdma_backend,
     is_ibverbs_available,
+    is_rdma_available,
     RDMAAction,
     RDMABuffer,
     RDMAReadTransferWarning,
@@ -23,6 +24,7 @@ from monarch._src.rdma.rdma import (
 __all__ = [
     "get_rdma_backend",
     "is_ibverbs_available",
+    "is_rdma_available",
     "RDMABuffer",
     "RDMAAction",
     "RDMAReadTransferWarning",


### PR DESCRIPTION
Summary:
Monarch renamed is_rdma_available to is_ibverbs_available when adding
support for multiple RDMA backends, which broke some callers. This
re-adds is_rdma_available as a thin wrapper around is_ibverbs_available
with a DeprecationWarning explaining the ambiguity and directing users
to is_ibverbs_available() or get_rdma_backend().

Differential Revision: D98750497


