### PR TITLE
DAG view improvements: admin API integration, collapse/expand, system filtering (#3302)

### DIFF
--- a/python/monarch/monarch_dashboard/frontend/src/App.css
+++ b/python/monarch/monarch_dashboard/frontend/src/App.css
@@ -201,7 +201,7 @@ body::after {
   padding: var(--space-sm) var(--space-md);
   border: none;
   background: transparent;
-  color: var(--text-secondary);
+  color: var(--text-primary);
   cursor: pointer;
   border-radius: var(--radius-sm) var(--radius-sm) 0 0;
   transition: all 0.2s ease;
@@ -790,6 +790,39 @@ button:focus:not(:focus-visible) {
   overflow: hidden;
 }
 
+.dag-toolbar {
+  position: absolute;
+  top: var(--space-sm);
+  left: var(--space-sm);
+  z-index: 10;
+  display: flex;
+  gap: var(--space-xs);
+}
+
+.dag-direction-toggle {
+  font-family: var(--font-display);
+  font-size: 12px;
+  font-weight: 600;
+  padding: 6px 14px;
+  border: 1px solid var(--text-muted);
+  border-radius: var(--radius-sm);
+  background: var(--bg-tertiary);
+  color: #fff;
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+
+.dag-direction-toggle:hover {
+  border-color: var(--accent-primary);
+  background: var(--bg-hover);
+}
+
+.dag-direction-toggle.active {
+  border-color: var(--accent-primary);
+  background: var(--accent-primary);
+  color: #fff;
+}
+
 .dag-svg {
   width: 100%;
   height: 100%;
@@ -871,18 +904,16 @@ button:focus:not(:focus-visible) {
 /* ---- DAG Legend ---- */
 
 .dag-legend {
-  position: absolute;
-  top: var(--space-md);
-  right: var(--space-md);
+  width: 140px;
+  flex-shrink: 0;
   background: var(--bg-secondary);
   border: 1px solid var(--border-subtle);
-  border-radius: var(--radius-md);
+  border-left: none;
+  border-radius: 0 var(--radius-md) var(--radius-md) 0;
   padding: var(--space-sm) var(--space-md);
   font-family: var(--font-display);
   font-size: 11px;
-  z-index: 10;
-  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.4);
-  max-width: 180px;
+  overflow-y: auto;
 }
 
 .dag-legend-title {

--- a/python/monarch/monarch_dashboard/frontend/src/components/DagEdge.tsx
+++ b/python/monarch/monarch_dashboard/frontend/src/components/DagEdge.tsx
@@ -7,48 +7,55 @@
  */
 
 import React, { useMemo } from "react";
-import { DagEdge as DagEdgeData, DagNode } from "../utils/dagLayout";
+import { DagEdge as DagEdgeData, DagNode, DagDirection } from "../utils/dagLayout";
 
 interface DagEdgeProps {
   edge: DagEdgeData;
   nodes: Map<string, DagNode>;
+  direction: DagDirection;
 }
 
-/** Mesh tiers render as rects (half-height = r * 0.7). */
-const RECT_TIERS = new Set(["host_mesh", "proc_mesh", "actor_mesh"]);
-
-function bottomY(node: DagNode): number {
-  return node.y + (RECT_TIERS.has(node.tier) ? node.radius * 0.7 : node.radius);
-}
-
-function topY(node: DagNode): number {
-  return node.y - (RECT_TIERS.has(node.tier) ? node.radius * 0.7 : node.radius);
+/** All nodes are now rects; extent = half the rect height. */
+function nodeExtent(node: DagNode): number {
+  // Parent tiers use r*1.8, actors use r*1.6
+  const isParent = ["host_mesh", "proc_mesh", "actor_mesh", "host", "proc"].includes(node.tier);
+  return node.radius * (isParent ? 0.9 : 0.8);
 }
 
 /**
  * Renders an SVG path between two nodes.
- * Hierarchy edges: solid gray curves exiting downward.
- * Message edges: dashed, colored arcs below the actor row.
+ * Hierarchy edges: solid gray curves flowing in the layout direction.
+ * Message edges: dashed, colored arcs offset from the main flow.
  */
-export function DagEdgeComponent({ edge, nodes }: DagEdgeProps) {
+export function DagEdgeComponent({ edge, nodes, direction }: DagEdgeProps) {
   const source = nodes.get(edge.sourceId);
   const target = nodes.get(edge.targetId);
   if (!source || !target) return null;
 
   const isMessage = edge.type === "message";
+  const isLR = direction === "LR";
 
   const path = useMemo(() => {
     if (!isMessage) {
-      // Hierarchy: exit bottom of source, enter top of target.
+      if (isLR) {
+        // Hierarchy LR: exit right side of source, enter left side of target.
+        const sx = source.x + nodeExtent(source);
+        const sy = source.y;
+        const tx = target.x - nodeExtent(target);
+        const ty = target.y;
+        const dx = tx - sx;
+        return `M ${sx} ${sy} C ${sx + dx * 0.4} ${sy}, ${tx - dx * 0.4} ${ty}, ${tx} ${ty}`;
+      }
+      // Hierarchy TB: exit bottom of source, enter top of target.
       const sx = source.x;
-      const sy = bottomY(source);
+      const sy = source.y + nodeExtent(source);
       const tx = target.x;
-      const ty = topY(target);
+      const ty = target.y - nodeExtent(target);
       const dy = ty - sy;
       return `M ${sx} ${sy} C ${sx} ${sy + dy * 0.4}, ${tx} ${ty - dy * 0.4}, ${tx} ${ty}`;
     }
 
-    // Message: smooth rounded arc below the actor row.
+    // Message: smooth rounded arc offset from the main flow.
     const dx = target.x - source.x;
     const dy = target.y - source.y;
     const angle = Math.atan2(dy, dx);
@@ -56,10 +63,16 @@ export function DagEdgeComponent({ edge, nodes }: DagEdgeProps) {
     const sy = source.y + Math.sin(angle) * source.radius;
     const tx = target.x - Math.cos(angle) * target.radius;
     const ty = target.y - Math.sin(angle) * target.radius;
+
+    if (isLR) {
+      const sag = Math.max(40, Math.abs(dy) * 0.35);
+      const rightX = Math.max(sx, tx) + sag;
+      return `M ${sx} ${sy} Q ${rightX} ${(sy + ty) / 2}, ${tx} ${ty}`;
+    }
     const sag = Math.max(40, Math.abs(dx) * 0.35);
     const belowY = Math.max(sy, ty) + sag;
     return `M ${sx} ${sy} Q ${(sx + tx) / 2} ${belowY}, ${tx} ${ty}`;
-  }, [source, target, isMessage]);
+  }, [source, target, isMessage, isLR]);
 
   if (isMessage) {
     return (
@@ -67,9 +80,9 @@ export function DagEdgeComponent({ edge, nodes }: DagEdgeProps) {
         d={path}
         fill="none"
         stroke="var(--accent-secondary)"
-        strokeWidth="1"
+        strokeWidth="1.5"
         strokeDasharray="5 4"
-        opacity="0.35"
+        opacity="0.5"
         className="dag-message-edge"
         data-testid={`dag-edge-${edge.id}`}
       />
@@ -80,9 +93,9 @@ export function DagEdgeComponent({ edge, nodes }: DagEdgeProps) {
     <path
       d={path}
       fill="none"
-      stroke="var(--border-subtle)"
+      stroke="var(--text-muted)"
       strokeWidth="1.5"
-      opacity="0.7"
+      opacity="0.8"
       data-testid={`dag-edge-${edge.id}`}
     />
   );

--- a/python/monarch/monarch_dashboard/frontend/src/components/DagLegend.tsx
+++ b/python/monarch/monarch_dashboard/frontend/src/components/DagLegend.tsx
@@ -14,14 +14,7 @@ const LEGEND_ITEMS = Object.entries(STATUS_COLORS).map(([status, color]) => ({
   label: status.charAt(0).toUpperCase() + status.slice(1),
 }));
 
-const TIER_ITEMS = [
-  { radius: 14, label: "Host Mesh" },
-  { radius: 11, label: "Proc Mesh" },
-  { radius: 9, label: "Actor Mesh" },
-  { radius: 6, label: "Actor" },
-];
-
-/** Top-right legend overlay for the DAG view. */
+/** Side-panel legend for the DAG view. */
 export function DagLegend() {
   return (
     <div className="dag-legend" data-testid="dag-legend">
@@ -41,25 +34,6 @@ export function DagLegend() {
       </div>
 
       <div className="dag-legend-section">
-        <div className="dag-legend-heading">Node Type</div>
-        {TIER_ITEMS.map((item) => (
-          <div key={item.label} className="dag-legend-item">
-            <svg width="28" height="28" viewBox="0 0 28 28">
-              <circle
-                cx="14"
-                cy="14"
-                r={item.radius}
-                fill="none"
-                stroke="var(--text-muted)"
-                strokeWidth="1.5"
-              />
-            </svg>
-            <span className="dag-legend-label">{item.label}</span>
-          </div>
-        ))}
-      </div>
-
-      <div className="dag-legend-section">
         <div className="dag-legend-heading">Edges</div>
         <div className="dag-legend-item">
           <svg width="28" height="12">
@@ -68,7 +42,7 @@ export function DagLegend() {
               y1="6"
               x2="26"
               y2="6"
-              stroke="var(--border-subtle)"
+              stroke="var(--text-muted)"
               strokeWidth="1.5"
             />
           </svg>
@@ -82,7 +56,7 @@ export function DagLegend() {
               x2="26"
               y2="6"
               stroke="var(--accent-secondary)"
-              strokeWidth="1"
+              strokeWidth="1.5"
               strokeDasharray="4 3"
               opacity="0.6"
             />

--- a/python/monarch/monarch_dashboard/frontend/src/components/DagNode.tsx
+++ b/python/monarch/monarch_dashboard/frontend/src/components/DagNode.tsx
@@ -15,6 +15,8 @@ interface DagNodeProps {
   selected: boolean;
   onSelect: (node: DagNodeData) => void;
   onHover: (node: DagNodeData | null) => void;
+  /** If set, shows a badge indicating this node has hidden children. */
+  hiddenChildCount?: number;
 }
 
 /** Border style by status category. */
@@ -41,32 +43,49 @@ function dashArray(status: string): string | undefined {
   return undefined;
 }
 
-/** Mesh tiers render as rounded rectangles; others as circles. */
-const RECT_TIERS = new Set(["host_mesh", "proc_mesh", "actor_mesh"]);
+/** Parent tiers that show subtitle on the node, label on hover. */
+const PARENT_TIERS = new Set(["host_mesh", "proc_mesh", "actor_mesh", "host", "proc"]);
 
-/** Single node rendered as an SVG group. */
+/** Single node rendered as an SVG group.
+ *
+ * All nodes render as rounded rectangles. Parent tiers (host, proc)
+ * show their tier name on the node with the label on hover only.
+ * Actor nodes show their full label on the node.
+ */
 export function DagNodeComponent({
   node,
   selected,
   onSelect,
   onHover,
+  hiddenChildCount,
 }: DagNodeProps) {
   const color = statusColor(node.status);
   const r = node.radius;
-  const isRect = RECT_TIERS.has(node.tier);
-  const isSmallNode = node.tier === "actor" || node.tier === "actor_mesh";
+  const isParent = PARENT_TIERS.has(node.tier);
 
-  // Truncate label for small nodes.
-  const maxChars = isSmallNode ? 12 : 14;
-  const displayLabel =
-    node.label.length > maxChars
-      ? node.label.slice(0, maxChars - 1) + "\u2026"
-      : node.label;
+  // Strip "-UUID" suffix from label to get a short name for parent nodes.
+  // e.g. "anon_0-13su5vJ2cg5v" -> "anon_0", "waiter_0-13nS21tyttpD" -> "waiter_0"
+  const shortName = isParent
+    ? node.label.replace(/-[A-Za-z0-9]{8,}(\[\d+\])?$/, "").replace(/\[\d+\]$/, "")
+    : "";
+  const shortNameMax = 10;
+  const shortNameDisplay = shortName.length > shortNameMax
+    ? shortName.slice(0, shortNameMax - 1) + "\u2026"
+    : shortName;
 
-  // Rectangle dimensions for mesh tiers.
-  const w = r * 2.2;
-  const h = r * 1.4;
+  // All nodes are rounded rectangles. Parents show tier + short name (2 lines),
+  // actors are sized to fit their label text.
+  const w = isParent ? Math.max(r * 2.2, shortNameDisplay.length * 6 + 20) : Math.max(r * 2.2, node.label.length * 6 + 24);
+  const h = isParent ? r * 1.8 : r * 1.6;
   const rx = 6;
+
+  // Actor tiers show their full label.
+  const displayText = isParent ? node.subtitle : node.label;
+  const maxChars = isParent ? 16 : 20;
+  const truncated =
+    displayText.length > maxChars
+      ? displayText.slice(0, maxChars - 1) + "\u2026"
+      : displayText;
 
   return (
     <g
@@ -79,76 +98,51 @@ export function DagNodeComponent({
       data-testid={`dag-node-${node.id}`}
     >
       {/* Glow ring for selected node */}
-      {selected &&
-        (isRect ? (
-          <rect
-            x={-(w + 12) / 2}
-            y={-(h + 12) / 2}
-            width={w + 12}
-            height={h + 12}
-            rx={rx + 2}
-            fill="none"
-            stroke={color}
-            strokeWidth="1.5"
-            opacity="0.4"
-            className="dag-node-glow"
-          />
-        ) : (
-          <circle
-            r={r + 6}
-            fill="none"
-            stroke={color}
-            strokeWidth="1.5"
-            opacity="0.4"
-            className="dag-node-glow"
-          />
-        ))}
+      {selected && (
+        <rect
+          x={-(w + 12) / 2}
+          y={-(h + 12) / 2}
+          width={w + 12}
+          height={h + 12}
+          rx={rx + 2}
+          fill="none"
+          stroke={color}
+          strokeWidth="1.5"
+          opacity="0.4"
+          className="dag-node-glow"
+        />
+      )}
 
       {/* Outer status ring */}
-      {isRect ? (
-        <rect
-          x={-w / 2}
-          y={-h / 2}
-          width={w}
-          height={h}
-          rx={rx}
-          fill="var(--bg-secondary)"
-          stroke={color}
-          strokeWidth={borderStyle(node.status)}
-          strokeDasharray={dashArray(node.status)}
-          className="dag-node-rect"
-        />
-      ) : (
-        <circle
-          r={r}
-          fill="var(--bg-secondary)"
-          stroke={color}
-          strokeWidth={borderStyle(node.status)}
-          strokeDasharray={dashArray(node.status)}
-          className="dag-node-circle"
-        />
-      )}
+      <rect
+        x={-w / 2}
+        y={-h / 2}
+        width={w}
+        height={h}
+        rx={rx}
+        fill="var(--bg-tertiary)"
+        stroke={color}
+        strokeWidth={borderStyle(node.status)}
+        strokeDasharray={dashArray(node.status)}
+        className="dag-node-rect"
+      />
 
-      {/* Inner fill - subtle tinted background */}
-      {isRect ? (
-        <rect
-          x={-(w - 6) / 2}
-          y={-(h - 6) / 2}
-          width={w - 6}
-          height={h - 6}
-          rx={rx - 1}
-          fill={color}
-          opacity="0.08"
-        />
-      ) : (
-        <circle r={r - 3} fill={color} opacity="0.08" />
-      )}
+      {/* Inner fill - tinted background */}
+      <rect
+        x={-(w - 6) / 2}
+        y={-(h - 6) / 2}
+        width={w - 6}
+        height={h - 6}
+        rx={rx - 1}
+        fill={color}
+        opacity="0.15"
+      />
 
       {/* Status dot at top-right (hidden for neutral n/a nodes) */}
       {node.status !== "n/a" && (
         <circle
-          cx={isRect ? w / 2 - 4 : r * 0.65}
-          cy={isRect ? -h / 2 + 4 : -r * 0.65}
+          cx={w / 2 - 4}
+          cy={-h / 2 + 4}
           r={4}
           fill={color}
           className={
@@ -159,29 +153,67 @@ export function DagNodeComponent({
         />
       )}
 
-      {/* Label */}
-      <text
-        textAnchor="middle"
-        dy={isSmallNode ? "0.35em" : "-0.15em"}
-        fill="var(--text-primary)"
-        fontSize={isSmallNode ? "9px" : "10px"}
-        fontFamily="var(--font-display)"
-        fontWeight="500"
-      >
-        {displayLabel}
-      </text>
-
-      {/* Subtitle (tier label) - only for non-small nodes */}
-      {!isSmallNode && (
+      {/* Primary text */}
+      {isParent ? (
+        <>
+          <text
+            textAnchor="middle"
+            dy="-0.2em"
+            fill="#fff"
+            fontSize="10px"
+            fontFamily="var(--font-display)"
+            fontWeight="600"
+          >
+            {truncated}
+          </text>
+          {shortNameDisplay && (
+            <text
+              textAnchor="middle"
+              dy="1.1em"
+              fill="var(--text-secondary)"
+              fontSize="8px"
+              fontFamily="var(--font-display)"
+              fontWeight="400"
+            >
+              {shortNameDisplay}
+            </text>
+          )}
+        </>
+      ) : (
         <text
           textAnchor="middle"
-          dy="1.3em"
-          fill="var(--text-muted)"
-          fontSize="8px"
-          fontFamily="var(--font-body)"
+          dy="0.35em"
+          fill="#fff"
+          fontSize="9px"
+          fontFamily="var(--font-display)"
+          fontWeight="500"
         >
-          {node.subtitle}
+          {truncated}
         </text>
+      )}
+
+      {/* Expand badge: shows hidden child count on collapsed nodes */}
+      {hiddenChildCount != null && hiddenChildCount > 0 && (
+        <g>
+          <circle
+            cx={w / 2 + 2}
+            cy={h / 2 + 2}
+            r={10}
+            fill="var(--accent-primary)"
+          />
+          <text
+            x={w / 2 + 2}
+            y={h / 2 + 2}
+            textAnchor="middle"
+            dominantBaseline="central"
+            fill="#fff"
+            fontSize="8px"
+            fontFamily="var(--font-display)"
+            fontWeight="700"
+          >
+            +{hiddenChildCount}
+          </text>
+        </g>
       )}
     </g>
   );

--- a/python/monarch/monarch_dashboard/frontend/src/components/DagView.tsx
+++ b/python/monarch/monarch_dashboard/frontend/src/components/DagView.tsx
@@ -8,7 +8,10 @@
 
 import React, { useState, useRef, useCallback, useMemo, useEffect } from "react";
 import { useApi } from "../hooks/useApi";
-import { computeLayout, ApiDagData, DagNode, DagGraph, TIER_Y, TIER_LABELS, DagTier } from "../utils/dagLayout";
+import {
+  computeLayout, ApiDagData, ApiDagEdge, DagNode, DagGraph,
+  DagDirection, TIER_POSITION, TIER_LABELS, DagTier,
+} from "../utils/dagLayout";
 import { DagNodeComponent } from "./DagNode";
 import { DagEdgeComponent } from "./DagEdge";
 import { DagLegend } from "./DagLegend";
@@ -22,31 +25,216 @@ interface Tooltip {
 }
 
 /**
+ * Build a parent→children map and a set of root IDs from hierarchy edges.
+ */
+function buildTree(data: ApiDagData) {
+  const children: Record<string, string[]> = {};
+  const hasParent = new Set<string>();
+  for (const e of data.edges) {
+    if (e.type !== "hierarchy") continue;
+    (children[e.source_id] ??= []).push(e.target_id);
+    hasParent.add(e.target_id);
+  }
+  const roots = data.nodes
+    .filter((n) => !hasParent.has(n.id))
+    .map((n) => n.id);
+  return { children, roots };
+}
+
+/**
+ * Compute the set of visible node IDs given the expanded set.
+ */
+function visibleNodes(
+  roots: string[],
+  children: Record<string, string[]>,
+  expanded: Set<string>,
+): Set<string> {
+  const visible = new Set<string>();
+  const queue = [...roots];
+  while (queue.length > 0) {
+    const id = queue.shift()!;
+    visible.add(id);
+    if (expanded.has(id)) {
+      for (const kid of children[id] ?? []) {
+        queue.push(kid);
+      }
+    }
+  }
+  return visible;
+}
+
+/**
+ * Count all descendants (recursively) of a node.
+ */
+function countDescendants(
+  id: string,
+  children: Record<string, string[]>,
+): number {
+  const kids = children[id] ?? [];
+  let count = kids.length;
+  for (const kid of kids) {
+    count += countDescendants(kid, children);
+  }
+  return count;
+}
+
+/**
+ * Compute a viewBox that fits nodes and message arcs into the container.
+ *
+ * Message arcs sag below (TB) or right (LR) of the bottom-most nodes.
+ * We estimate the sag to ensure arcs aren't clipped.
+ */
+function computeFitViewBox(
+  nodes: DagNode[],
+  containerRect: DOMRect,
+  graph?: DagGraph | null,
+): { x: number; y: number; w: number; h: number } | null {
+  if (nodes.length === 0 || containerRect.width === 0 || containerRect.height === 0) return null;
+  const containerAspect = containerRect.width / containerRect.height;
+  const isLR = graph?.direction === "LR";
+
+  let minX = Infinity, maxX = -Infinity, minY = Infinity, maxY = -Infinity;
+  for (const n of nodes) {
+    const r = n.radius + 10;
+    minX = Math.min(minX, n.x - r);
+    maxX = Math.max(maxX, n.x + r);
+    minY = Math.min(minY, n.y - r);
+    maxY = Math.max(maxY, n.y + r);
+  }
+
+  // Estimate message arc sag. Message arcs use:
+  //   TB: belowY = max(sy, ty) + max(40, |dx| * 0.35)
+  //   LR: rightX = max(sx, tx) + max(40, |dy| * 0.35)
+  if (graph) {
+    const nodeMap = new Map<string, DagNode>();
+    for (const n of nodes) nodeMap.set(n.id, n);
+    for (const e of graph.edges) {
+      if (e.type !== "message") continue;
+      const src = nodeMap.get(e.sourceId);
+      const tgt = nodeMap.get(e.targetId);
+      if (!src || !tgt) continue;
+      if (isLR) {
+        const sag = Math.max(40, Math.abs(tgt.y - src.y) * 0.35);
+        maxX = Math.max(maxX, Math.max(src.x, tgt.x) + src.radius + sag);
+      } else {
+        const sag = Math.max(40, Math.abs(tgt.x - src.x) * 0.35);
+        maxY = Math.max(maxY, Math.max(src.y, tgt.y) + src.radius + sag);
+      }
+    }
+  }
+
+  const contentW = maxX - minX;
+  const contentH = maxY - minY;
+  const contentAspect = contentW / contentH;
+  const margin = 40;
+
+  let vw: number, vh: number;
+  if (contentAspect > containerAspect) {
+    vw = contentW + margin * 2;
+    vh = vw / containerAspect;
+  } else {
+    vh = contentH + margin * 2;
+    vw = vh * containerAspect;
+  }
+
+  const cx = (minX + maxX) / 2;
+  const cy = (minY + maxY) / 2;
+  return { x: cx - vw / 2, y: cy - vh / 2, w: vw, h: vh };
+}
+
+/**
  * Full DAG visualization of the Monarch hierarchy.
  *
- * Fetches pre-classified nodes and edges from /api/dag, then uses
- * computeLayout to assign X/Y positions for SVG rendering.
+ * Supports collapse/expand: initially only roots + 1 level of children
+ * are shown. Click a node with children to expand/collapse.
  */
 export function DagView() {
-  const { data: dagData, loading } = useApi<ApiDagData>("/dag");
+  const [hideSystem, setHideSystem] = useState(true);
+  const dagPath = hideSystem ? "/dag?hide_system=true" : "/dag?hide_system=false";
+  const { data: dagData, loading } = useApi<ApiDagData>(dagPath);
 
+  const [direction, setDirection] = useState<DagDirection>("TB");
+  const [expanded, setExpanded] = useState<Set<string>>(new Set());
   const [selectedNode, setSelectedNode] = useState<DagNode | null>(null);
   const [tooltip, setTooltip] = useState<Tooltip | null>(null);
   const [viewBox, setViewBox] = useState({ x: 0, y: 0, w: 1300, h: 800 });
   const svgRef = useRef<SVGSVGElement>(null);
   const isPanning = useRef(false);
   const panStart = useRef({ x: 0, y: 0, vx: 0, vy: 0 });
+  const needsFit = useRef(false);
 
-  const graph: DagGraph | null = useMemo(() => {
+  // Build the full tree structure from API data.
+  const tree = useMemo(() => {
     if (!dagData) return null;
-    return computeLayout(dagData);
+    return buildTree(dagData);
   }, [dagData]);
 
-  const viewInitialized = useRef(false);
+  // Initialize expanded set: roots are expanded so we see 1 level of children.
+  const expandedInitialized = useRef(false);
   useEffect(() => {
-    if (graph && !viewInitialized.current) {
-      viewInitialized.current = true;
-      setViewBox({ x: -20, y: -20, w: graph.width + 40, h: Math.min(graph.height + 40, 800) });
+    if (tree && !expandedInitialized.current) {
+      expandedInitialized.current = true;
+      setExpanded(new Set(tree.roots));
+    }
+  }, [tree]);
+
+  // Fit whenever the expanded set changes. This runs before the graph fit
+  // effect, so needsFit will be true when the NEW graph (with the updated
+  // expanded nodes) triggers the fit effect on the next render.
+  const prevExpanded = useRef(expanded);
+  useEffect(() => {
+    if (expanded !== prevExpanded.current) {
+      prevExpanded.current = expanded;
+      needsFit.current = true;
+    }
+  }, [expanded]);
+
+  // Hidden children count for each node (for the badge).
+  const hiddenChildCounts = useMemo(() => {
+    if (!dagData || !tree) return new Map<string, number>();
+    const counts = new Map<string, number>();
+    for (const n of dagData.nodes) {
+      const kids = tree.children[n.id] ?? [];
+      if (kids.length > 0 && !expanded.has(n.id)) {
+        counts.set(n.id, countDescendants(n.id, tree.children));
+      }
+    }
+    return counts;
+  }, [dagData, tree, expanded]);
+
+  // Filter the API data to only visible nodes, then compute layout.
+  const graph: DagGraph | null = useMemo(() => {
+    if (!dagData || !tree) return null;
+    const visible = visibleNodes(tree.roots, tree.children, expanded);
+    const filteredNodes = dagData.nodes.filter((n) => visible.has(n.id));
+    const filteredEdges = dagData.edges.filter(
+      (e) => visible.has(e.source_id) && visible.has(e.target_id)
+    );
+    return computeLayout({ nodes: filteredNodes, edges: filteredEdges }, direction);
+  }, [dagData, tree, expanded, direction]);
+
+  // Auto-fit after user actions (expand/collapse, direction toggle).
+  // Retries until the container has real dimensions (handles initial mount race).
+  useEffect(() => {
+    if (graph && graph.nodes.length > 0 && needsFit.current) {
+      needsFit.current = false;
+      const nodes = graph.nodes;
+      let attempts = 0;
+      const tryFit = () => {
+        const container = svgRef.current?.parentElement;
+        if (!container) return;
+        const rect = container.getBoundingClientRect();
+        if ((rect.width === 0 || rect.height === 0) && attempts < 10) {
+          // Container not laid out yet — retry.
+          attempts++;
+          setTimeout(tryFit, 50);
+          return;
+        }
+        const fit = computeFitViewBox(nodes, rect, graph);
+        if (fit) setViewBox(fit);
+      };
+      // Kick off after a frame to let React commit.
+      requestAnimationFrame(tryFit);
     }
   }, [graph]);
 
@@ -63,6 +251,14 @@ export function DagView() {
     const m = new Map<string, DagNode>();
     for (const n of graph.nodes) m.set(n.id, n);
     return m;
+  }, [graph]);
+
+  const fitViewToGraph = useCallback(() => {
+    if (!graph || graph.nodes.length === 0) return;
+    const container = svgRef.current?.parentElement;
+    if (!container) return;
+    const fit = computeFitViewBox(graph.nodes, container.getBoundingClientRect(), graph);
+    if (fit) setViewBox(fit);
   }, [graph]);
 
   const handleWheel = useCallback(
@@ -108,18 +304,61 @@ export function DagView() {
 
   const handleMouseUp = useCallback(() => { isPanning.current = false; }, []);
 
-  const handleNodeSelect = useCallback((node: DagNode) => {
-    setSelectedNode((prev) => (prev?.id === node.id ? null : node));
-  }, []);
+  const handleNodeClick = useCallback((node: DagNode) => {
+    if (!tree) return;
+    const kids = tree.children[node.id] ?? [];
+    if (kids.length > 0) {
+      setExpanded((prev) => {
+        const next = new Set(prev);
+        if (next.has(node.id)) {
+          next.delete(node.id);
+        } else {
+          next.add(node.id);
+        }
+        return next;
+      });
+    } else {
+      setSelectedNode((prev) => (prev?.id === node.id ? null : node));
+    }
+  }, [tree]);
 
   const handleNodeHover = useCallback((node: DagNode | null) => {
     if (!node) { setTooltip(null); return; }
     setTooltip({ node, x: node.x, y: node.y - node.radius - 14 });
   }, []);
 
+  const toggleDirection = useCallback(() => {
+    needsFit.current = true;
+    setDirection((d) => (d === "TB" ? "LR" : "TB"));
+  }, []);
+
+  const toggleSystem = useCallback(() => {
+    setHideSystem((h) => !h);
+    // Reset expand state since the node set changes.
+    expandedInitialized.current = false;
+    setExpanded(new Set());
+  }, []);
+
+  const expandAll = useCallback(() => {
+    if (!dagData || !tree) return;
+    const all = new Set<string>();
+    for (const n of dagData.nodes) {
+      if ((tree.children[n.id] ?? []).length > 0) {
+        all.add(n.id);
+      }
+    }
+    setExpanded(all);
+  }, [dagData, tree]);
+
+  const collapseAll = useCallback(() => {
+    if (!tree) return;
+    setExpanded(new Set(tree.roots));
+  }, [tree]);
+
   if (loading) return <div className="loading-state">Loading DAG data...</div>;
   if (!graph || graph.nodes.length === 0) return <div className="empty-state">No data available</div>;
 
+  const isLR = direction === "LR";
   const hierEdges = graph.edges.filter((e) => e.type === "hierarchy");
   const msgEdges = graph.edges.filter((e) => e.type === "message");
   const tierEntries = Object.entries(TIER_LABELS) as Array<[DagTier, string]>;
@@ -127,6 +366,43 @@ export function DagView() {
   return (
     <div className="dag-container" data-testid="dag-container">
       <div className="dag-canvas-wrapper">
+        <div className="dag-toolbar">
+          <button
+            className="dag-direction-toggle"
+            onClick={toggleDirection}
+            title={isLR ? "Switch to top-down layout" : "Switch to left-right layout"}
+          >
+            {isLR ? "↓ Top-Down" : "→ Left-Right"}
+          </button>
+          <button
+            className="dag-direction-toggle"
+            onClick={fitViewToGraph}
+            title="Fit graph in view"
+          >
+            ⊡ Fit
+          </button>
+          <button
+            className="dag-direction-toggle"
+            onClick={expandAll}
+            title="Expand all nodes"
+          >
+            + Expand All
+          </button>
+          <button
+            className="dag-direction-toggle"
+            onClick={collapseAll}
+            title="Collapse to 1 level"
+          >
+            − Collapse
+          </button>
+          <button
+            className={`dag-direction-toggle ${hideSystem ? "active" : ""}`}
+            onClick={toggleSystem}
+            title={hideSystem ? "Show system actors" : "Hide system actors"}
+          >
+            {hideSystem ? "◉ System Hidden" : "○ Show All"}
+          </button>
+        </div>
         <svg
           ref={svgRef}
           className="dag-svg"
@@ -148,25 +424,42 @@ export function DagView() {
             </filter>
           </defs>
           <rect x={viewBox.x - 1000} y={viewBox.y - 1000} width={viewBox.w + 2000} height={viewBox.h + 2000} fill="url(#dag-grid)" />
-          {tierEntries.map(([tier, label]) => (
-            <text key={tier} x={15} y={TIER_Y[tier]} textAnchor="start" dominantBaseline="middle" fill="var(--text-muted)" fontSize="10" fontFamily="var(--font-display)" opacity="0.5">{label}</text>
-          ))}
-          <g className="dag-edges-hierarchy">{hierEdges.map((e) => <DagEdgeComponent key={e.id} edge={e} nodes={nodeMap} />)}</g>
-          <g className="dag-edges-messages">{msgEdges.map((e) => <DagEdgeComponent key={e.id} edge={e} nodes={nodeMap} />)}</g>
+{/* Tier labels removed — node subtitles already show the tier */}
+          <g className="dag-edges-hierarchy">{hierEdges.map((e) => <DagEdgeComponent key={e.id} edge={e} nodes={nodeMap} direction={direction} />)}</g>
+          <g className="dag-edges-messages">{msgEdges.map((e) => <DagEdgeComponent key={e.id} edge={e} nodes={nodeMap} direction={direction} />)}</g>
           <g className="dag-nodes">
-            {graph.nodes.map((node) => (
-              <DagNodeComponent key={node.id} node={node} selected={selectedNode?.id === node.id} onSelect={handleNodeSelect} onHover={handleNodeHover} />
-            ))}
+            {graph.nodes.map((node) => {
+              const hiddenCount = hiddenChildCounts.get(node.id);
+              return (
+                <DagNodeComponent
+                  key={node.id}
+                  node={node}
+                  selected={selectedNode?.id === node.id}
+                  onSelect={handleNodeClick}
+                  onHover={handleNodeHover}
+                  hiddenChildCount={hiddenCount}
+                />
+              );
+            })}
           </g>
         </svg>
-        {tooltip && !selectedNode && (
-          <div className="dag-tooltip" style={{ left: `${((tooltip.x - viewBox.x) / viewBox.w) * 100}%`, top: `${((tooltip.y - viewBox.y) / viewBox.h) * 100}%` }}>
-            <div className="dag-tooltip-name">{tooltip.node.label}</div>
-            <div className="dag-tooltip-info">{tooltip.node.subtitle} &middot; {tooltip.node.status}</div>
-          </div>
-        )}
-        <DagLegend />
+        {tooltip && !selectedNode && (() => {
+          const n = tooltip.node;
+          const isParent = ["host_mesh", "proc_mesh", "actor_mesh", "host", "proc"].includes(n.tier);
+          return (
+            <div className="dag-tooltip" style={{ left: `${((tooltip.x - viewBox.x) / viewBox.w) * 100}%`, top: `${((tooltip.y - viewBox.y) / viewBox.h) * 100}%` }}>
+              <div className="dag-tooltip-name">{isParent ? n.label : n.subtitle}</div>
+              <div className="dag-tooltip-info">
+                {n.status}
+                {hiddenChildCounts.has(n.id) && (
+                  <> &middot; click to expand ({hiddenChildCounts.get(n.id)} hidden)</>
+                )}
+              </div>
+            </div>
+          );
+        })()}
       </div>
+      <DagLegend />
       {selectedNode && <NodeDetail node={selectedNode} onClose={() => setSelectedNode(null)} />}
     </div>
   );

--- a/python/monarch/monarch_dashboard/frontend/src/components/NodeDetail.tsx
+++ b/python/monarch/monarch_dashboard/frontend/src/components/NodeDetail.tsx
@@ -48,7 +48,7 @@ export function NodeDetail({ node, onClose }: NodeDetailProps) {
           </div>
         </div>
 
-        {isActor && <ActorDetails actorId={String(node.entityId)} />}
+        {isActor && <ActorDetails actorId={String(node.telemetryActorId ?? node.entityId)} />}
         {!isActor && <MeshDetails meshId={String(node.entityId)} />}
       </div>
     </div>

--- a/python/monarch/monarch_dashboard/frontend/src/utils/dagLayout.ts
+++ b/python/monarch/monarch_dashboard/frontend/src/utils/dagLayout.ts
@@ -10,17 +10,27 @@
  * Pure layout engine for the DAG visualization.
  *
  * Accepts pre-classified nodes and edges from the /api/dag endpoint
- * and computes X/Y positions using a deterministic top-to-bottom
- * hierarchical layout with 6 tiers:
+ * and computes X/Y positions using a deterministic hierarchical layout
+ * with 6 tiers:
  *
  *   Host Mesh -> Host Unit -> Proc Mesh -> Proc Unit -> Actor Mesh -> Actor
+ *
+ * Supports two directions:
+ *   - "TB" (top-to-bottom): tiers flow downward, leaves spread horizontally
+ *   - "LR" (left-to-right): tiers flow rightward, leaves spread vertically
  *
  * All classification, status propagation, and edge construction is
  * done server-side. This module only adds positions and radii.
  */
 
-/** The 6 tiers in the Monarch hierarchy. */
-export type DagTier = "host_mesh" | "host_unit" | "proc_mesh" | "proc_unit" | "actor_mesh" | "actor";
+/** Layout direction. */
+export type DagDirection = "TB" | "LR";
+
+/** Tiers in the Monarch hierarchy.
+ *  6-tier (telemetry): host_mesh, host_unit, proc_mesh, proc_unit, actor_mesh, actor
+ *  3-tier (admin API): host, proc, actor
+ */
+export type DagTier = "host_mesh" | "host_unit" | "proc_mesh" | "proc_unit" | "actor_mesh" | "actor" | "host" | "proc";
 
 /** A node from the /api/dag response (before positioning). */
 export interface ApiDagNode {
@@ -31,6 +41,8 @@ export interface ApiDagNode {
   subtitle: string;
   status: string;
   rank?: number;
+  /** Telemetry actor ID for querying messages/status (admin DAG only). */
+  telemetry_actor_id?: number | string;
 }
 
 /** An edge from the /api/dag response. */
@@ -58,6 +70,8 @@ export interface DagNode {
   tier: DagTier;
   status: string;
   entityId: number | string;
+  /** Telemetry actor ID for querying messages/status (admin DAG only). */
+  telemetryActorId?: number | string;
 }
 
 /** An edge connecting two nodes (camelCase for frontend use). */
@@ -74,16 +88,21 @@ export interface DagGraph {
   edges: DagEdge[];
   width: number;
   height: number;
+  direction: DagDirection;
 }
 
-// Layout constants — 6 tiers spread top to bottom.
-const TIER_Y: Record<DagTier, number> = {
+/** Fixed position along the primary axis for each tier. */
+const TIER_POSITION: Record<DagTier, number> = {
+  // 6-tier (telemetry SQL)
   host_mesh: 60,
   host_unit: 180,
   proc_mesh: 300,
   proc_unit: 420,
   actor_mesh: 540,
   actor: 660,
+  // 3-tier (admin API) — spaced for 3 levels, not 6
+  host: 80,
+  proc: 260,
 };
 
 const NODE_RADIUS: Record<DagTier, number> = {
@@ -93,7 +112,26 @@ const NODE_RADIUS: Record<DagTier, number> = {
   proc_unit: 28,
   actor_mesh: 28,
   actor: 18,
+  host: 40,
+  proc: 32,
 };
+
+/** Parent tiers that show tier name instead of label. */
+const PARENT_TIERS = new Set<string>(["host_mesh", "proc_mesh", "actor_mesh", "host", "proc"]);
+
+/** Gap between adjacent nodes (in addition to their half-widths). */
+const NODE_GAP = 16;
+
+/** Compute the visual width of a node (matches DagNode.tsx rendering). */
+function nodeWidth(node: ApiDagNode): number {
+  const r = NODE_RADIUS[node.tier] ?? 18;
+  const isParent = PARENT_TIERS.has(node.tier);
+  if (isParent) {
+    return r * 2.2;
+  }
+  // Actor nodes: sized to fit label text.
+  return Math.max(r * 2.2, node.label.length * 6 + 24);
+}
 
 const TIER_LABELS: Record<DagTier, string> = {
   host_mesh: "HOST MESH",
@@ -102,23 +140,43 @@ const TIER_LABELS: Record<DagTier, string> = {
   proc_unit: "PROC",
   actor_mesh: "ACTOR MESH",
   actor: "ACTOR",
+  host: "HOST",
+  proc: "PROC",
 };
 
-const HORIZONTAL_SPACING = 100;
-const PADDING_X = 160;
+const PADDING = 80;
 
-export { TIER_Y, TIER_LABELS };
+// Keep backward-compatible exports (TIER_Y is used by DagView for tier labels).
+const TIER_Y = TIER_POSITION;
+export { TIER_Y, TIER_LABELS, TIER_POSITION };
 
 /**
  * Compute X/Y positions for pre-classified DAG nodes.
  *
- * Tiers are arranged top-to-bottom at fixed Y positions.
- * Leaf nodes are spread horizontally, parents centered above children.
+ * In TB mode: tiers get fixed Y, leaves spread along X.
+ * In LR mode: tiers get fixed X, leaves spread along Y.
+ *
+ * Each tier uses its own spacing so that small leaf nodes (actors)
+ * pack tightly while larger parent nodes (host meshes) stay roomy.
  */
-export function computeLayout(data: ApiDagData): DagGraph {
+export function computeLayout(data: ApiDagData, direction: DagDirection = "TB"): DagGraph {
   if (data.nodes.length === 0) {
-    return { nodes: [], edges: [], width: 0, height: 0 };
+    return { nodes: [], edges: [], width: 0, height: 0, direction };
   }
+
+  const isLR = direction === "LR";
+
+  // Determine unique tiers present and assign evenly-spaced positions
+  // if the data uses fewer than the full 6-tier layout.
+  const uniqueTiers = [...new Set(data.nodes.map((n) => n.tier))];
+  const tierOrder: DagTier[] = ["host_mesh", "host_unit", "host", "proc_mesh", "proc_unit", "proc", "actor_mesh", "actor"];
+  uniqueTiers.sort((a, b) => tierOrder.indexOf(a) - tierOrder.indexOf(b));
+
+  const dynamicTierPos: Record<string, number> = {};
+  const tierSpacing = uniqueTiers.length > 1 ? 500 / (uniqueTiers.length - 1) : 0;
+  uniqueTiers.forEach((tier, i) => {
+    dynamicTierPos[tier] = 80 + i * tierSpacing;
+  });
 
   // Index nodes by id.
   const nodeMap: Record<string, ApiDagNode> = {};
@@ -138,43 +196,117 @@ export function computeLayout(data: ApiDagData): DagGraph {
     .filter((n) => !hasParent.has(n.id))
     .map((n) => n.id);
 
-  // Recursively position: leaves get horizontal X positions,
-  // parents center horizontally above children.
-  let nextX = PADDING_X;
-  const positions: Record<string, { x: number; y: number }> = {};
+  // --- Two-pass layout ---
+  // Pass 1: Position leaves using tier-specific spacing, then
+  //         center each parent over its children.
+  // Pass 2: (implicit) Parents are already centered from the recursion.
 
-  function positionSubtree(id: string): number[] {
+  let nextLeafPos = PADDING;
+  // Track the spread positions assigned to each node (along the secondary axis).
+  const spreadPos: Record<string, number> = {};
+
+  function positionSubtree(id: string): { min: number; max: number } | null {
     const node = nodeMap[id];
-    if (!node) return [];
+    if (!node) return null;
 
+    const tierPos = dynamicTierPos[node.tier] ?? TIER_POSITION[node.tier];
     const kids = (children[id] ?? []).slice().sort((a, b) => {
       const ra = nodeMap[a]?.rank ?? 0;
       const rb = nodeMap[b]?.rank ?? 0;
       return ra - rb;
     });
     if (kids.length === 0) {
-      const x = nextX;
-      nextX += HORIZONTAL_SPACING;
-      positions[id] = { x, y: TIER_Y[node.tier] };
-      return [x];
+      // Leaf: position based on actual node width so nodes don't overlap.
+      const halfW = nodeWidth(node) / 2;
+      const pos = nextLeafPos + halfW;
+      nextLeafPos = pos + halfW + NODE_GAP;
+      spreadPos[id] = pos;
+      return { min: pos, max: pos };
     }
 
-    const childXs: number[] = [];
+    // Recurse into children.
+    let groupMin = Infinity;
+    let groupMax = -Infinity;
     for (const kid of kids) {
-      childXs.push(...positionSubtree(kid));
+      const range = positionSubtree(kid);
+      if (range) {
+        groupMin = Math.min(groupMin, range.min);
+        groupMax = Math.max(groupMax, range.max);
+      }
     }
 
-    const centerX =
-      childXs.length > 0
-        ? (childXs[0] + childXs[childXs.length - 1]) / 2
-        : nextX;
-    positions[id] = { x: centerX, y: TIER_Y[node.tier] };
-    return childXs;
+    // Center this parent over its children's span.
+    const center = (groupMin + groupMax) / 2;
+    spreadPos[id] = center;
+    return { min: groupMin, max: groupMax };
   }
 
   for (const root of roots) {
     positionSubtree(root);
-    nextX += HORIZONTAL_SPACING * 0.5;
+    // Small gap between independent subtrees.
+    nextLeafPos += NODE_GAP * 2;
+  }
+
+  // --- Overlap resolution pass ---
+  // For each tier, sort nodes by spread position and push any that
+  // overlap with their predecessor to the right.  When a parent is
+  // pushed, shift its entire subtree by the same delta.
+  const tierNodes: Record<string, string[]> = {};
+  for (const [id] of Object.entries(spreadPos)) {
+    const node = nodeMap[id];
+    if (!node) continue;
+    (tierNodes[node.tier] ??= []).push(id);
+  }
+
+  function shiftSubtree(id: string, delta: number) {
+    spreadPos[id] += delta;
+    for (const kid of children[id] ?? []) {
+      if (spreadPos[kid] !== undefined) {
+        shiftSubtree(kid, delta);
+      }
+    }
+  }
+
+  for (const ids of Object.values(tierNodes)) {
+    ids.sort((a, b) => spreadPos[a] - spreadPos[b]);
+    for (let i = 1; i < ids.length; i++) {
+      const prevNode = nodeMap[ids[i - 1]];
+      const currNode = nodeMap[ids[i]];
+      if (!prevNode || !currNode) continue;
+      const prevRight = spreadPos[ids[i - 1]] + nodeWidth(prevNode) / 2;
+      const currLeft = spreadPos[ids[i]] - nodeWidth(currNode) / 2;
+      const overlap = prevRight + NODE_GAP - currLeft;
+      if (overlap > 0) {
+        shiftSubtree(ids[i], overlap);
+      }
+    }
+  }
+
+  // Re-center parents over their (possibly shifted) children.
+  function recenter(id: string): void {
+    const kids = children[id] ?? [];
+    if (kids.length === 0) return;
+    for (const kid of kids) recenter(kid);
+    const childPositions = kids
+      .filter((k) => spreadPos[k] !== undefined)
+      .map((k) => spreadPos[k]);
+    if (childPositions.length > 0) {
+      spreadPos[id] = (Math.min(...childPositions) + Math.max(...childPositions)) / 2;
+    }
+  }
+  for (const root of roots) recenter(root);
+
+  // Convert spread positions to x/y based on direction.
+  const positions: Record<string, { x: number; y: number }> = {};
+  for (const [id, spread] of Object.entries(spreadPos)) {
+    const node = nodeMap[id];
+    if (!node) continue;
+    const tierPos = dynamicTierPos[node.tier] ?? TIER_POSITION[node.tier];
+    if (isLR) {
+      positions[id] = { x: tierPos, y: spread };
+    } else {
+      positions[id] = { x: spread, y: tierPos };
+    }
   }
 
   // Build positioned nodes.
@@ -190,6 +322,7 @@ export function computeLayout(data: ApiDagData): DagGraph {
       tier: n.tier,
       status: n.status,
       entityId: n.entity_id,
+      telemetryActorId: n.telemetry_actor_id,
     }));
 
   // Map edges from snake_case to camelCase.
@@ -200,10 +333,16 @@ export function computeLayout(data: ApiDagData): DagGraph {
     type: e.type,
   }));
 
+  // Compute the extent along the primary (tier) axis from actual positions.
+  const maxTierPos = data.nodes.reduce((max, n) => Math.max(max, dynamicTierPos[n.tier] ?? TIER_POSITION[n.tier] ?? 0), 0);
+  const lastTier = maxTierPos + 120;
+  const spreadExtent = nextLeafPos + PADDING;
+
   return {
     nodes,
     edges,
-    width: nextX + PADDING_X,
-    height: TIER_Y.actor + 120,
+    width: isLR ? lastTier : spreadExtent,
+    height: isLR ? spreadExtent : lastTier,
+    direction,
   };
 }

--- a/python/monarch/monarch_dashboard/server/admin_dag.py
+++ b/python/monarch/monarch_dashboard/server/admin_dag.py
@@ -1,0 +1,378 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Build a DAG by walking the Mesh Admin API.
+
+This mirrors the TUI's tree hierarchy (Root → Host → Proc → Actor)
+rather than the telemetry SQL layer's 6-tier mesh hierarchy.  The
+result is a simpler, more readable graph.
+
+System actors are filtered using the ``system_children`` list and
+``is_system`` flag from the Admin API, plus a name-based heuristic
+for infrastructure actors that aren't flagged (e.g. telemetry, setup).
+"""
+
+import logging
+import os
+import re
+import time
+import urllib.parse
+from typing import Any, Dict, List, Optional, Set, Tuple
+
+import requests
+
+from . import db
+
+logger = logging.getLogger(__name__)
+
+# Cache the built DAG to avoid re-walking on every poll.
+_dag_cache: Optional[Dict[str, Any]] = None
+_dag_cache_time: float = 0.0
+_DAG_CACHE_TTL = 2.0  # seconds
+
+# Max walk depth: Root(0) -> Host(1) -> Proc(2) -> Actor(3).
+_MAX_TREE_DEPTH = 4
+
+# Known system/infrastructure actor name patterns.
+# These actors are spawned by Monarch internals, not by user code.
+_SYSTEM_NAME_PATTERNS = re.compile(
+    r"(telemetry|setup[-_]|SetupActor|comm[-_]|CommActor|"
+    r"logger[-_]|LoggerActor|log_client|MeshAdminAgent|HostAgent|ProcAgent|"
+    r"host_agent|proc_agent|mesh_admin|controller_controller|"
+    r"proc_mesh_controller|actor_mesh_controller|client\[)",
+    re.IGNORECASE,
+)
+
+
+def _get_admin_url() -> Optional[str]:
+    return os.environ.get("MONARCH_ADMIN_URL")
+
+
+def configure_tls(session: requests.Session) -> None:
+    """Configure TLS client certs on a requests session.
+
+    Mirrors the cert detection logic in Rust's ``try_tls_connector``
+    (``hyperactor/src/channel/net.rs``):
+
+    1. **OSS** — ``HYPERACTOR_TLS_CA``, ``HYPERACTOR_TLS_CERT``,
+       ``HYPERACTOR_TLS_KEY`` environment variables.
+    2. **Meta** — ``/var/facebook/rootcanal/ca.pem`` (CA),
+       ``/var/facebook/x509_identities/server.pem`` (cert + key).
+    3. **Fallback** — no TLS configuration (plain HTTP only).
+    """
+    # OSS: explicit env vars take priority.
+    ca = os.environ.get("HYPERACTOR_TLS_CA")
+    cert = os.environ.get("HYPERACTOR_TLS_CERT")
+    key = os.environ.get("HYPERACTOR_TLS_KEY")
+    if ca and os.path.isfile(ca):
+        session.verify = ca
+        if cert and key and os.path.isfile(cert) and os.path.isfile(key):
+            session.cert = (cert, key)
+        return
+
+    # Meta: well-known certificate paths.
+    meta_ca = "/var/facebook/rootcanal/ca.pem"
+    meta_cert = "/var/facebook/x509_identities/server.pem"
+    if os.path.isfile(meta_ca) and os.path.isfile(meta_cert):
+        session.verify = meta_ca
+        session.cert = (meta_cert, meta_cert)  # PEM contains both cert and key
+        return
+
+    # No certs found; HTTPS requests will fail and fall back to the
+    # telemetry SQL layer in build_admin_dag.
+    logger.debug("No TLS certs found for admin API; HTTPS will not work")
+
+
+def _fetch_node(
+    session: requests.Session, admin_url: str, ref: str
+) -> Optional[Dict[str, Any]]:
+    """Fetch a single node from the admin API."""
+    encoded = urllib.parse.quote(ref, safe="")
+    try:
+        resp = session.get(f"{admin_url}/v1/{encoded}", timeout=2.0)
+        if resp.status_code == 200:
+            return resp.json()
+    except Exception:
+        logger.debug("Failed to fetch admin node %s", ref, exc_info=True)
+    return None
+
+
+def _extract_status(props: Dict[str, Any]) -> str:
+    """Extract a status string from node properties.
+
+    Actors have an explicit ``actor_status`` field.  Procs derive status
+    from ``is_poisoned`` and ``failed_actor_count``.  Hosts derive status
+    from their child procs (resolved later — default to "idle" here).
+    """
+    # Actor: explicit status.
+    actor = props.get("Actor", {})
+    if isinstance(actor, dict) and "actor_status" in actor:
+        status = actor["actor_status"]
+        if isinstance(status, str):
+            return status.split(":")[0].strip().lower() if status else "unknown"
+
+    # Proc: derive from health fields.
+    proc = props.get("Proc", {})
+    if isinstance(proc, dict):
+        if proc.get("is_poisoned"):
+            return "failed"
+        if proc.get("failed_actor_count", 0) > 0:
+            return "stopping"
+        return "idle"
+
+    # Host: healthy by default (no failure fields on Host).
+    host = props.get("Host", {})
+    if isinstance(host, dict):
+        return "idle"
+
+    return "n/a"
+
+
+def _extract_is_system(props: Dict[str, Any]) -> bool:
+    """Check if a node is a system actor via the API flag."""
+    actor = props.get("Actor", {})
+    return isinstance(actor, dict) and actor.get("is_system", False)
+
+
+def _extract_system_children(props: Dict[str, Any]) -> Set[str]:
+    """Get system_children refs from Root/Host/Proc properties."""
+    result: Set[str] = set()
+    for variant_data in props.values():
+        if isinstance(variant_data, dict):
+            for sc in variant_data.get("system_children", []):
+                result.add(sc)
+    return result
+
+
+def _node_type(props: Dict[str, Any]) -> str:
+    for key in ("Root", "Host", "Proc", "Actor", "Error"):
+        if key in props:
+            return key.lower()
+    return "unknown"
+
+
+def _is_system_by_name(label: str) -> bool:
+    """Heuristic: check if a node label looks like a system/infra actor."""
+    return bool(_SYSTEM_NAME_PATTERNS.search(label))
+
+
+def _derive_label(payload: Dict[str, Any]) -> str:
+    """Derive a short display label from a node payload."""
+    identity = payload.get("identity", "")
+    if "ActorId" in identity:
+        inner = identity.split("(", 1)[-1].rstrip(")")
+        parts = inner.split(",")
+        if len(parts) >= 3:
+            return f"{parts[1].strip()}[{parts[2].strip()}]"
+        return inner
+    if "ProcId" in identity:
+        inner = identity.split("(", 1)[-1].rstrip(")")
+        parts = inner.split(",")
+        if len(parts) >= 2:
+            return f"{parts[0].strip()}[{parts[1].strip()}]"
+        return inner
+    return identity.rsplit("/", 1)[-1].rsplit(",", 1)[-1] or identity
+
+
+def build_admin_dag(hide_system: bool = True) -> Dict[str, Any]:
+    """Walk the Admin API and build a DAG matching the TUI hierarchy.
+
+    Returns ``{"nodes": [...], "edges": [...]}``.
+    """
+    global _dag_cache, _dag_cache_time
+
+    admin_url = _get_admin_url()
+    if not admin_url:
+        return {"nodes": [], "edges": []}
+
+    now = time.monotonic()
+    cached = _dag_cache
+    if cached is not None and now - _dag_cache_time < _DAG_CACHE_TTL:
+        if cached.get("_hide_system") == hide_system:
+            return cached
+
+    session = requests.Session()
+    configure_tls(session)
+    nodes: List[Dict[str, Any]] = []
+    edges: List[Dict[str, Any]] = []
+    visited: Set[str] = set()
+    ref_to_node_id: Dict[str, str] = {}
+
+    queue: List[Tuple[str, Optional[str], int]] = [("root", None, 0)]
+
+    while queue:
+        ref, parent_ref, depth = queue.pop(0)
+        if ref in visited:
+            continue
+        visited.add(ref)
+
+        payload = _fetch_node(session, admin_url, ref)
+        if payload is None:
+            continue
+
+        props = payload.get("properties", {})
+        children_refs = payload.get("children", [])
+        ntype = _node_type(props)
+
+        # Skip root node itself.
+        if ntype == "root":
+            system_children = _extract_system_children(props) if hide_system else set()
+            for child_ref in children_refs:
+                if hide_system and child_ref in system_children:
+                    continue
+                queue.append((child_ref, None, depth))
+            continue
+
+        # Filter system actors — both API flag and name heuristic.
+        label = _derive_label(payload)
+        if hide_system:
+            if _extract_is_system(props):
+                continue
+            if ntype == "actor" and _is_system_by_name(label):
+                continue
+
+        system_children = _extract_system_children(props) if hide_system else set()
+
+        tier_map = {"host": "host", "proc": "proc", "actor": "actor"}
+        tier = tier_map.get(ntype, "actor")
+        status = _extract_status(props)
+
+        node_id = f"{tier}-{ref}"
+        ref_to_node_id[ref] = node_id
+
+        nodes.append(
+            {
+                "id": node_id,
+                "entity_id": ref,
+                "tier": tier,
+                "label": label,
+                "subtitle": tier.capitalize(),
+                "status": status,
+            }
+        )
+
+        if parent_ref is not None and parent_ref in ref_to_node_id:
+            parent_node_id = ref_to_node_id[parent_ref]
+            edges.append(
+                {
+                    "id": f"hier-{parent_node_id}-{node_id}",
+                    "source_id": parent_node_id,
+                    "target_id": node_id,
+                    "type": "hierarchy",
+                }
+            )
+
+        if depth < _MAX_TREE_DEPTH:
+            for child_ref in children_refs:
+                if hide_system and child_ref in system_children:
+                    continue
+                queue.append((child_ref, ref, depth + 1))
+
+    # Resolve telemetry actor IDs so the detail panel can query messages.
+    try:
+        tel_actors = db._query("SELECT id, full_name FROM actors")
+        if tel_actors:
+            name_to_tel_id: Dict[str, int] = {
+                a["full_name"]: a["id"] for a in tel_actors
+            }
+            for n in nodes:
+                if n["tier"] == "actor":
+                    tel_id = name_to_tel_id.get(n["entity_id"])
+                    if tel_id is not None:
+                        n["telemetry_actor_id"] = tel_id
+    except Exception:
+        logger.debug("Could not resolve telemetry actor IDs", exc_info=True)
+
+    # Prune procs that have no actor children after system filtering.
+    if hide_system:
+        actor_node_ids = {n["id"] for n in nodes if n["tier"] == "actor"}
+        # Find which procs have at least one actor child via edges.
+        procs_with_actors: Set[str] = set()
+        for e in edges:
+            if e["type"] == "hierarchy" and e["target_id"] in actor_node_ids:
+                procs_with_actors.add(e["source_id"])
+        # Remove procs with no actors and their edges.
+        proc_node_ids = {n["id"] for n in nodes if n["tier"] == "proc"}
+        empty_procs = proc_node_ids - procs_with_actors
+        if empty_procs:
+            nodes = [n for n in nodes if n["id"] not in empty_procs]
+            edges = [
+                e
+                for e in edges
+                if e["source_id"] not in empty_procs
+                and e["target_id"] not in empty_procs
+            ]
+
+    # Add message edges from telemetry.
+    _add_message_edges(nodes, edges)
+
+    result = {"nodes": nodes, "edges": edges, "_hide_system": hide_system}
+    _dag_cache = result
+    _dag_cache_time = now
+    return result
+
+
+def _add_message_edges(
+    nodes: List[Dict[str, Any]], edges: List[Dict[str, Any]]
+) -> None:
+    """Overlay message edges from the telemetry SQL layer.
+
+    Matching strategy: both the admin API references (entity_id) and
+    the telemetry actor full_names use the same format:
+        unix:@HASH,PROC_NAME,ACTOR_NAME[RANK]
+
+    So we match telemetry full_name against admin entity_id directly.
+    For each telemetry actor, if its full_name is a substring of (or
+    equal to) an admin node's entity_id, that's a match.
+    """
+    try:
+        messages = db._query("SELECT DISTINCT from_actor_id, to_actor_id FROM messages")
+        if not messages:
+            return
+
+        actors = db._query("SELECT id, full_name FROM actors")
+        if not actors:
+            return
+
+        # Map telemetry actor numeric ID -> full_name.
+        actor_id_to_name: Dict[int, str] = {a["id"]: a["full_name"] for a in actors}
+
+        # Build lookup: telemetry full_name -> admin node_id.
+        # Admin entity_ids are the full reference strings which contain
+        # the same actor identifier as the telemetry full_name.
+        # Strategy: for each admin actor node, its entity_id IS the same
+        # reference string as the telemetry full_name.
+        entity_to_node_id: Dict[str, str] = {}
+        for n in nodes:
+            if n["tier"] == "actor":
+                entity_to_node_id[n["entity_id"]] = n["id"]
+
+        def _match_node(telemetry_name: str) -> Optional[str]:
+            # Direct match: telemetry name == admin entity_id.
+            return entity_to_node_id.get(telemetry_name)
+
+        seen: Set[str] = set()
+        for m in messages:
+            src_name = actor_id_to_name.get(m["from_actor_id"], "")
+            tgt_name = actor_id_to_name.get(m["to_actor_id"], "")
+
+            src_node = _match_node(src_name)
+            tgt_node = _match_node(tgt_name)
+
+            if src_node and tgt_node and src_node != tgt_node:
+                edge_key = f"{src_node}-{tgt_node}"
+                if edge_key not in seen:
+                    seen.add(edge_key)
+                    edges.append(
+                        {
+                            "id": f"msg-{edge_key}",
+                            "source_id": src_node,
+                            "target_id": tgt_node,
+                            "type": "message",
+                        }
+                    )
+    except Exception as exc:
+        logger.debug("Could not add message edges: %s", exc)

--- a/python/monarch/monarch_dashboard/server/db.py
+++ b/python/monarch/monarch_dashboard/server/db.py
@@ -482,13 +482,18 @@ def list_sent_messages(
 # ---------------------------------------------------------------------------
 
 
-def get_dag_data() -> dict[str, Any]:
+def get_dag_data(system_names: set[str] | None = None) -> dict[str, Any]:
     """Return classified nodes and edges for the DAG visualization.
 
     Fetches all meshes, actors (with latest status), and messages in a single
     connection, then builds the 6-tier graph structure server-side:
 
       host_mesh -> host_unit -> proc_mesh -> proc_unit -> actor_mesh -> actor
+
+    Args:
+        system_names: If provided, actors whose ``full_name`` is in this set
+            are excluded from the DAG.  Meshes that become empty after
+            filtering are also pruned.
 
     Returns ``{"nodes": [...], "edges": [...]}``.
     """
@@ -526,6 +531,35 @@ def get_dag_data() -> dict[str, Any]:
             proc_agents_by_mesh.setdefault(a["mesh_id"], []).append(a)
         else:
             regular_actors.append(a)
+
+    # -- Filter system actors if requested --
+    # Strategy: remove actors whose full_name matches a system name,
+    # then prune actor meshes with no remaining actors, then prune
+    # proc meshes with no remaining actor meshes, keeping the host
+    # layer intact as structural context.
+    if system_names:
+        _system_names = system_names  # local binding for Pyre narrowing
+
+        def _is_system(name: str) -> bool:
+            return any(sn in name for sn in _system_names)
+
+        regular_actors = [a for a in regular_actors if not _is_system(a["full_name"])]
+
+        # Find actor mesh IDs that still have at least one non-system actor.
+        live_actor_mesh_ids = {a["mesh_id"] for a in regular_actors}
+        actor_meshes = [m for m in actor_meshes if m["id"] in live_actor_mesh_ids]
+
+        # Find proc mesh IDs that still have at least one non-system actor mesh child.
+        live_proc_mesh_ids = {
+            m["parent_mesh_id"] for m in actor_meshes if m["parent_mesh_id"] is not None
+        }
+        proc_meshes = [m for m in proc_meshes if m["id"] in live_proc_mesh_ids]
+
+        # Rebuild proc agents to only include procs that survived.
+        surviving_proc_mesh_ids = {m["id"] for m in proc_meshes}
+        proc_agents_by_mesh = {
+            k: v for k, v in proc_agents_by_mesh.items() if k in surviving_proc_mesh_ids
+        }
 
     # -- Actor statuses --
     actor_statuses: dict[int, str] = {}

--- a/python/monarch/monarch_dashboard/server/routes.py
+++ b/python/monarch/monarch_dashboard/server/routes.py
@@ -11,11 +11,14 @@ actors, status events, messages, and sent messages.  Every handler returns
 JSON and uses standard HTTP status codes (200, 404).
 """
 
+import os
 from typing import Any
 
 from flask import Blueprint, jsonify, request
 
 from . import db
+from .admin_dag import build_admin_dag
+from .system_actors import get_system_actor_names
 
 api = Blueprint("api", __name__, url_prefix="/api")
 
@@ -64,11 +67,45 @@ def summary():
 
 @api.route("/dag")
 def dag():
-    """Classified nodes and edges for the DAG visualization."""
+    """Classified nodes and edges for the DAG visualization.
+
+    When the Mesh Admin API is available (MONARCH_ADMIN_URL env var),
+    uses the admin tree directly — same hierarchy as the TUI:
+    Host → Proc → Actor.  System actors are filtered using the admin
+    API's authoritative ``is_system`` flag and ``system_children``.
+
+    Falls back to the telemetry SQL layer if the admin API is unavailable.
+
+    Optional: ?hide_system=true (default) to filter system actors.
+    """
+    hide_system = request.args.get("hide_system", "true").lower() != "false"
     try:
-        return jsonify(_sanitize_for_js(db.get_dag_data()))
+        # Prefer the admin API for a clean TUI-like hierarchy.
+        if os.environ.get("MONARCH_ADMIN_URL"):
+            result = build_admin_dag(hide_system=hide_system)
+            if result.get("nodes"):
+                # Strip internal cache keys before returning.
+                return jsonify(
+                    _sanitize_for_js(
+                        {
+                            "nodes": result["nodes"],
+                            "edges": result["edges"],
+                        }
+                    )
+                )
+
+        # Fallback: telemetry SQL layer.
+        system_names = get_system_actor_names() if hide_system else set()
+        return jsonify(_sanitize_for_js(db.get_dag_data(system_names=system_names)))
     except Exception as exc:
         return jsonify({"error": str(exc), "nodes": [], "edges": []}), 500
+
+
+@api.route("/system-actors")
+def list_system_actors():
+    """Return the set of system actor names from the Mesh Admin API."""
+    names = get_system_actor_names()
+    return jsonify({"system_actors": sorted(names), "count": len(names)})
 
 
 # ---------------------------------------------------------------------------

--- a/python/monarch/monarch_dashboard/server/system_actors.py
+++ b/python/monarch/monarch_dashboard/server/system_actors.py
@@ -1,0 +1,157 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Discover system actors by walking the Mesh Admin API.
+
+The Mesh Admin API exposes ``system_children`` on Root/Host/Proc nodes
+and ``is_system`` on Actor nodes.  This module walks the admin tree and
+collects:
+
+  1. System actor ``full_name`` strings (actors with ``is_system: true``)
+  2. System proc/mesh names (references listed in ``system_children``)
+
+The dashboard uses these to prune entire system subtrees from the DAG,
+not just individual actors.  Results are cached with a TTL.
+"""
+
+import logging
+import os
+import time
+import urllib.parse
+from dataclasses import dataclass, field
+from typing import Optional, Set
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class SystemInfo:
+    """Collected system actor/mesh classification from the admin API."""
+
+    # Actor full_names that are system actors.
+    actor_names: Set[str] = field(default_factory=set)
+    # References (opaque strings) that appear in system_children.
+    system_refs: Set[str] = field(default_factory=set)
+
+
+# Cache.
+_cache: SystemInfo = SystemInfo()
+_cache_time: float = 0.0
+_CACHE_TTL_SECS = 10.0
+
+
+def _get_admin_url() -> Optional[str]:
+    """Read the admin URL from the environment (set by the host application)."""
+    return os.environ.get("MONARCH_ADMIN_URL")
+
+
+def _walk_admin_tree(admin_url: str) -> SystemInfo:
+    """Walk the admin API tree and collect system classification info."""
+    from .admin_dag import configure_tls
+
+    info = SystemInfo()
+    session = requests.Session()
+    configure_tls(session)
+    visited: Set[str] = set()
+    queue = ["root"]
+
+    while queue:
+        ref = queue.pop(0)
+        if ref in visited:
+            continue
+        visited.add(ref)
+
+        encoded = urllib.parse.quote(ref, safe="")
+        try:
+            resp = session.get(f"{admin_url}/v1/{encoded}", timeout=2.0)
+            if resp.status_code != 200:
+                continue
+            payload = resp.json()
+        except Exception:
+            logger.debug("Failed to fetch node %s", ref, exc_info=True)
+            continue
+
+        props = payload.get("properties", {})
+        children = payload.get("children", [])
+
+        for variant_name, variant_data in props.items():
+            if not isinstance(variant_data, dict):
+                continue
+
+            # Actor: check is_system flag.
+            if variant_name == "Actor" and variant_data.get("is_system"):
+                name = variant_data.get("full_name") or payload.get("identity", "")
+                if name:
+                    info.actor_names.add(name)
+
+            # Root/Host/Proc: collect system_children refs.
+            for sc in variant_data.get("system_children", []):
+                info.system_refs.add(sc)
+
+        # Queue children for traversal.
+        for child_ref in children:
+            queue.append(child_ref)
+
+    # Also resolve system refs to get their actor names.
+    for ref in info.system_refs:
+        if ref in visited:
+            continue
+        encoded = urllib.parse.quote(ref, safe="")
+        try:
+            resp = session.get(f"{admin_url}/v1/{encoded}", timeout=2.0)
+            if resp.status_code != 200:
+                continue
+            payload = resp.json()
+            props = payload.get("properties", {})
+            actor_data = props.get("Actor", {})
+            name = actor_data.get("full_name") or payload.get("identity", "")
+            if name:
+                info.actor_names.add(name)
+        except Exception:
+            logger.debug("Failed to resolve system ref %s", ref, exc_info=True)
+            continue
+
+    logger.debug(
+        "Admin API: %d system actors, %d system refs",
+        len(info.actor_names),
+        len(info.system_refs),
+    )
+    return info
+
+
+def get_system_info() -> SystemInfo:
+    """Return system classification info, with caching.
+
+    Returns an empty SystemInfo if the admin URL is not configured or
+    unreachable.
+    """
+    global _cache, _cache_time
+
+    now = time.monotonic()
+    if now - _cache_time < _CACHE_TTL_SECS and (
+        _cache.actor_names or _cache.system_refs
+    ):
+        return _cache
+
+    admin_url = _get_admin_url()
+    if not admin_url:
+        return _cache
+
+    try:
+        info = _walk_admin_tree(admin_url)
+        _cache = info
+        _cache_time = now
+    except Exception:
+        logger.warning("Failed to walk admin API for system actors", exc_info=True)
+
+    return _cache
+
+
+def get_system_actor_names() -> Set[str]:
+    """Convenience: return just the set of system actor full_names."""
+    return get_system_info().actor_names


### PR DESCRIPTION
Summary:

Major improvements to the DAG visualization, now powered by the Mesh Admin API
for a clean TUI-style hierarchy (Host → Proc → Actor) instead of the old 6-tier
telemetry-based view.

**Admin API integration:**
- New `admin_dag.py` walks the Mesh Admin API tree (same data source as the TUI)
- 3-tier hierarchy: Host → Proc → Actor (no intermediate mesh/unit layers)
- Falls back to telemetry SQL DAG if admin API is unavailable
- Direct exact matching for message edges between telemetry and admin actor IDs

**System actor filtering:**
- New `system_actors.py` discovers system actors via `is_system` flag and `system_children`
- Name-based heuristic catches telemetry, setup, comm, logger, and other infra actors
- Empty procs (no user actors after filtering) are pruned automatically
- "System Hidden" / "Show All" toggle in the DAG toolbar (hidden by default)

**Collapse/expand:**
- DAG starts collapsed at 1 level; click nodes to expand and reveal children
- Orange "+N" badges show hidden descendant counts
- "Expand All" / "Collapse" toolbar buttons

**Layout & rendering:**
- TB/LR direction toggle for top-down vs left-right layouts
- All nodes render as rounded rectangles (actors sized to fit label text)
- Parent nodes (Host/Proc) show tier name + short name (UUID suffix stripped)
- Dynamic tier-proportional spacing prevents overlap
- Overlap resolution pass with parent re-centering
- Fit-to-view includes message arc sag estimation

**Visibility:**
- Brighter node fills and edge strokes for dark theme readability
- All node text is white; parent short names in lighter secondary color
- White header tab text
- Host/Proc status derived from `is_poisoned` and `failed_actor_count`

**Detail panel:**
- Actor detail resolves telemetry ID for message/status queries
- Messages and status timeline populate correctly for admin DAG nodes

**Legend:**
- Moved outside SVG to a sidebar panel (no more overlay on nodes)
- Removed "Node Type" section; kept Status and Edges

**BUCK:**
- Added `admin_dag` and `system_actors` library targets so `routes.py` can
  import them

Reviewed By: zhangrmatthew

Differential Revision: D98222265
