### PR TITLE
Remove deprecated _stop_instance method (#3303)

### DIFF
--- a/monarch_hyperactor/src/context.rs
+++ b/monarch_hyperactor/src/context.rs
@@ -97,12 +97,6 @@ impl PyInstance {
             .map_err(|e| PyRuntimeError::new_err(e.to_string()))
     }
 
-    /// Deprecated alias for `stop`.
-    #[pyo3(signature = (reason = None))]
-    fn _stop_instance(&self, reason: Option<&str>) -> PyResult<()> {
-        self.stop(reason)
-    }
-
     /// Mark this actor as system/infrastructure.
     ///
     /// **PY-SYS-2:** Python actors use the `_is_system_actor = True`

--- a/python/monarch/_src/actor/actor_mesh.py
+++ b/python/monarch/_src/actor/actor_mesh.py
@@ -268,10 +268,6 @@ class Instance(abc.ABC):
         """Mark this actor as system/infrastructure."""
         ...
 
-    def _stop_instance(self, reason: Optional[str] = None) -> None:
-        """Deprecated: use stop() instead."""
-        return self.stop(reason)
-
 
 @dataclass
 class CreatorInstance:
@@ -475,7 +471,7 @@ def shutdown_context() -> "Future[None]":
             pass
         # Stop the client actor after the host mesh shutdown completes.
         if c is not None:
-            c.actor_instance._stop_instance()
+            c.actor_instance.stop()
             _context.set(None)
 
     return Future(coro=_shutdown_sequence())


### PR DESCRIPTION
Summary:

Remove the deprecated `_stop_instance` method from both Python (`ActorInstance`) and Rust (`PyInstance`). All callers now use `stop()` directly.

Reviewed By: shayne-fletcher

Differential Revision: D98789172
