### PR TITLE
Remove more files from docker images (#3305)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,8 +1,25 @@
 .git
 .github
+.ipynb_checkpoints
+.monarch
 .pyre
+.venv
+.vscode
+dist
 docs
 *_meta/**
 **/*_meta/**
 **/*_meta.rs
 **/meta/**
+*/.DS_Store
+
+# Rust stuff
+target/
+Cargo.lock
+
+# Sphinx build files
+build/**
+docs/_build/**
+docs/build/**
+docs/**/generated/**
+*/sg_execution_times.rst

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -24,24 +24,18 @@ jobs:
         uses: actions/checkout@v6
 
       # Use the already built and tested wheels.
+      # Download wheels outside the repo so they don't interfere with the
+      # Docker build context (dist/ is in .dockerignore).
       - name: Download wheel artifact
         uses: actions/download-artifact@v4
         with:
           name: ${{ inputs.artifact-name }}
-          path: dist
+          path: ${{ runner.temp }}/monarch_wheels
 
       - name: List downloaded artifacts
         run: |
-          echo "Current directory: $(pwd)"
-          echo ""
-          echo "Top-level contents:"
-          ls -la
-          echo ""
-          echo "Contents of dist directory:"
-          ls -la dist/ || echo "dist directory not found"
-          echo ""
-          echo "All wheel files in workspace:"
-          find . -name "*.whl" -type f 2>/dev/null || echo "No wheel files found"
+          echo "Contents of wheels directory:"
+          ls -la ${{ runner.temp }}/monarch_wheels/
 
       - name: Log in to the Container registry
         uses: docker/login-action@v3
@@ -61,7 +55,8 @@ jobs:
           push: false # Just building the image, not publishing
           build-args: |
             PYTORCH_TAG=2.12.0.dev20260324-cuda12.8-cudnn9-runtime
-            MONARCH_WHEELS=dist
+          build-contexts: |
+            monarch-wheels=${{ runner.temp }}/monarch_wheels
           outputs: type=docker,dest=${{ runner.temp }}/monarch_image.tar
 
       - name: Upload artifact

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -87,13 +87,14 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
-      # Use the already built and tested wheels.
+      # Download wheels outside the repo so they don't interfere with the
+      # Docker build context (dist/ is in .dockerignore).
       - name: Download all artifacts
         uses: actions/download-artifact@v4
         with:
           # Docker container only has python 3.12, so we need to use the x86_64 3.12 wheel.
           name: monarch-py3.12-cuda12.8-x86_64
-          path: dist
+          path: ${{ runner.temp }}/monarch_wheels
           merge-multiple: true
 
       - name: Log in to the Container registry
@@ -122,4 +123,5 @@ jobs:
           # TODO: find docker tag that gets updated automatically.
           build-args: |
             PYTORCH_TAG=2.12.0.dev20260324-cuda12.8-cudnn9-runtime
-            MONARCH_WHEELS=dist
+          build-contexts: |
+            monarch-wheels=${{ runner.temp }}/monarch_wheels

--- a/Dockerfile.nightly
+++ b/Dockerfile.nightly
@@ -4,11 +4,8 @@ ARG PYTORCH_TAG=2.12.0.dev20260324-cuda12.8-cudnn9-runtime
 # Build from latest pytorch nightly base image; should be relatively in sync with torchmonarch and pytorch-nightly.
 FROM ghcr.io/pytorch/pytorch-nightly:${PYTORCH_TAG}
 
-# Path to prebuilt wheels from github actions. This way they are built and tested
-# only once.
-ARG MONARCH_WHEELS
-# Add the prebuilt wheels to be installed from.
-COPY $MONARCH_WHEELS ./dist
+# Add prebuilt wheels from the "monarch-wheels" named build context.
+COPY --from=monarch-wheels . ./dist
 
 # Only compatible with docker format, not OCI.
 SHELL ["/bin/bash", "-c"]


### PR DESCRIPTION
Summary:

Some of these files were quite large, specifically `.venv` and `target`, and it made COPY lines
in dockerfiles take much longer than they needed to take.

Since `dist` had to be passed to Dockerfile.nightly, change it to be a different directory in Github
Actions and use multiple build contexts to pass it in.

Reviewed By: thedavekwon

Differential Revision: D98801103


