### PR TITLE
Controller label, tooltip improvements, and cosmetic fixes (#3315)

### DIFF
--- a/python/monarch/monarch_dashboard/frontend/src/App.css
+++ b/python/monarch/monarch_dashboard/frontend/src/App.css
@@ -897,7 +897,7 @@ button:focus:not(:focus-visible) {
 .dag-tooltip-info {
   font-family: var(--font-mono);
   font-size: 10px;
-  color: var(--text-muted);
+  color: #fff;
   margin-top: 2px;
 }
 

--- a/python/monarch/monarch_dashboard/frontend/src/components/DagNode.tsx
+++ b/python/monarch/monarch_dashboard/frontend/src/components/DagNode.tsx
@@ -56,16 +56,20 @@ export function DagNodeComponent({
   onHover,
   hiddenChildCount,
 }: DagNodeProps) {
-  const color = statusColor(node.status);
+  const isController = node.label.includes("(controller)");
+  const color = isController ? "#6b8afd" : statusColor(node.status);
   const r = node.radius;
 
   // Strip "-UUID" suffix and "[rank]" to get a short name.
   // e.g. "anon_0-13su5vJ2cg5v" -> "anon_0"
   //      "greeter-1yVhEBwKxr3i[0]" -> "greeter"
   //      "host_agent[0]" -> "host_agent"
-  const shortName = node.label
-    .replace(/-[A-Za-z0-9]{8,}(\[\d+\])?$/, "")
-    .replace(/\[\d+\]$/, "");
+  // Controller hosts show "Controller" instead of the IP.
+  const shortName = isController
+    ? "Controller"
+    : node.label
+        .replace(/-[A-Za-z0-9]{8,}(\[\d+\])?$/, "")
+        .replace(/\[\d+\]$/, "");
   const shortNameMax = 14;
   const shortNameDisplay = shortName.length > shortNameMax
     ? shortName.slice(0, shortNameMax - 1) + "\u2026"
@@ -164,10 +168,11 @@ export function DagNodeComponent({
         <text
           textAnchor="middle"
           dy="1.1em"
-          fill="var(--text-secondary)"
+          fill="#fff"
           fontSize="8px"
           fontFamily="var(--font-display)"
           fontWeight="400"
+          opacity={0.75}
         >
           {shortNameDisplay}
         </text>

--- a/python/monarch/monarch_dashboard/frontend/src/components/DagView.tsx
+++ b/python/monarch/monarch_dashboard/frontend/src/components/DagView.tsx
@@ -93,9 +93,10 @@ function computeFitViewBox(
   const containerAspect = containerRect.width / containerRect.height;
   const isLR = graph?.direction === "LR";
 
+  // Padding around nodes for comfortable fit.
   let minX = Infinity, maxX = -Infinity, minY = Infinity, maxY = -Infinity;
   for (const n of nodes) {
-    const r = n.radius + 10;
+    const r = n.radius + 12;
     minX = Math.min(minX, n.x - r);
     maxX = Math.max(maxX, n.x + r);
     minY = Math.min(minY, n.y - r);
@@ -123,10 +124,14 @@ function computeFitViewBox(
     }
   }
 
+  // Extra top margin for the toolbar overlay.
+  const toolbarSvgMargin = 35;
+  minY -= toolbarSvgMargin;
+
   const contentW = maxX - minX;
   const contentH = maxY - minY;
   const contentAspect = contentW / contentH;
-  const margin = 40;
+  const margin = 15;
 
   let vw: number, vh: number;
   if (contentAspect > containerAspect) {
@@ -324,8 +329,13 @@ export function DagView() {
 
   const handleNodeHover = useCallback((node: DagNode | null) => {
     if (!node) { setTooltip(null); return; }
-    setTooltip({ node, x: node.x, y: node.y - node.radius - 14 });
-  }, []);
+    // Place tooltip above the node; flip to below if too close to the top.
+    const aboveY = node.y - node.radius - 14;
+    const belowY = node.y + node.radius + 14;
+    const topPct = (aboveY - viewBox.y) / viewBox.h;
+    const y = topPct < 0.08 ? belowY : aboveY;
+    setTooltip({ node, x: node.x, y });
+  }, [viewBox]);
 
   const toggleDirection = useCallback(() => {
     needsFit.current = true;
@@ -400,7 +410,7 @@ export function DagView() {
             onClick={toggleSystem}
             title={hideSystem ? "Show system actors" : "Hide system actors"}
           >
-            {hideSystem ? "◉ System Hidden" : "○ Show All"}
+            {hideSystem ? "Show System" : "Hide System"}
           </button>
         </div>
         <svg
@@ -424,7 +434,6 @@ export function DagView() {
             </filter>
           </defs>
           <rect x={viewBox.x - 1000} y={viewBox.y - 1000} width={viewBox.w + 2000} height={viewBox.h + 2000} fill="url(#dag-grid)" />
-{/* Tier labels removed — node subtitles already show the tier */}
           <g className="dag-edges-hierarchy">{hierEdges.map((e) => <DagEdgeComponent key={e.id} edge={e} nodes={nodeMap} direction={direction} />)}</g>
           <g className="dag-edges-messages">{msgEdges.map((e) => <DagEdgeComponent key={e.id} edge={e} nodes={nodeMap} direction={direction} />)}</g>
           <g className="dag-nodes">
@@ -443,20 +452,23 @@ export function DagView() {
             })}
           </g>
         </svg>
-        {tooltip && !selectedNode && (() => {
+        {tooltip && (() => {
           const n = tooltip.node;
           const idParts = String(n.entityId).split(",");
           return (
-            <div className="dag-tooltip" style={{ left: `${((tooltip.x - viewBox.x) / viewBox.w) * 100}%`, top: `${((tooltip.y - viewBox.y) / viewBox.h) * 100}%` }}>
-              <div className="dag-tooltip-name">
+            <div className="dag-tooltip" style={{ left: `${((tooltip.x - viewBox.x) / viewBox.w) * 100}%`, top: `${((tooltip.y - viewBox.y) / viewBox.h) * 100}%`, color: "#fff" }}>
+              <div className="dag-tooltip-name" style={{ fontFamily: "var(--font-mono, monospace)", fontSize: "9px" }}>
                 {idParts.map((part, i) => (
-                  <div key={i}>{part}{i < idParts.length - 1 ? "," : ""}</div>
+                  <div key={i} style={i > 0 ? { paddingLeft: "2ch" } : undefined}>
+                    {i === 0 ? "ID: " : ""}{part}{i < idParts.length - 1 ? "," : ""}
+                  </div>
                 ))}
               </div>
-              <div className="dag-tooltip-info">
-                {n.status}
+              <div className="dag-tooltip-info" style={{ color: "#fff" }}>
+                <div>Status: {n.status}</div>
+                {n.meshName && <div>Mesh: {n.meshName}</div>}
                 {hiddenChildCounts.has(n.id) && (
-                  <> &middot; click to expand ({hiddenChildCounts.get(n.id)} hidden)</>
+                  <div>click to expand ({hiddenChildCounts.get(n.id)} hidden)</div>
                 )}
               </div>
             </div>

--- a/python/monarch/monarch_dashboard/frontend/src/utils/dagLayout.ts
+++ b/python/monarch/monarch_dashboard/frontend/src/utils/dagLayout.ts
@@ -43,6 +43,8 @@ export interface ApiDagNode {
   rank?: number;
   /** Telemetry actor ID for querying messages/status (admin DAG only). */
   telemetry_actor_id?: number | string;
+  /** Mesh name this node belongs to (proc/actor tiers). */
+  mesh_name?: string;
 }
 
 /** An edge from the /api/dag response. */
@@ -72,6 +74,8 @@ export interface DagNode {
   entityId: number | string;
   /** Telemetry actor ID for querying messages/status (admin DAG only). */
   telemetryActorId?: number | string;
+  /** Mesh name this node belongs to. */
+  meshName?: string;
 }
 
 /** An edge connecting two nodes (camelCase for frontend use). */
@@ -191,9 +195,16 @@ export function computeLayout(data: ApiDagData, direction: DagDirection = "TB"):
     hasParent.add(e.target_id);
   }
 
-  // Roots = nodes with no incoming hierarchy edge.
+  // Roots = nodes with no incoming hierarchy edge, sorted by mesh name
+  // so nodes in the same mesh are placed adjacent in the layout.
   const roots = data.nodes
     .filter((n) => !hasParent.has(n.id))
+    .sort((a, b) => {
+      const ma = a.mesh_name ?? "\uffff";
+      const mb = b.mesh_name ?? "\uffff";
+      if (ma !== mb) return ma < mb ? -1 : 1;
+      return (a.rank ?? 0) - (b.rank ?? 0);
+    })
     .map((n) => n.id);
 
   // --- Two-pass layout ---
@@ -211,6 +222,10 @@ export function computeLayout(data: ApiDagData, direction: DagDirection = "TB"):
 
     const tierPos = dynamicTierPos[node.tier] ?? TIER_POSITION[node.tier];
     const kids = (children[id] ?? []).slice().sort((a, b) => {
+      // Sort by mesh name so siblings in the same mesh are adjacent.
+      const ma = nodeMap[a]?.mesh_name ?? "\uffff";
+      const mb = nodeMap[b]?.mesh_name ?? "\uffff";
+      if (ma !== mb) return ma < mb ? -1 : 1;
       const ra = nodeMap[a]?.rank ?? 0;
       const rb = nodeMap[b]?.rank ?? 0;
       return ra - rb;
@@ -323,6 +338,7 @@ export function computeLayout(data: ApiDagData, direction: DagDirection = "TB"):
       status: n.status,
       entityId: n.entity_id,
       telemetryActorId: n.telemetry_actor_id,
+      meshName: n.mesh_name,
     }));
 
   // Map edges from snake_case to camelCase.

--- a/python/monarch/monarch_dashboard/server/admin_dag.py
+++ b/python/monarch/monarch_dashboard/server/admin_dag.py
@@ -193,6 +193,42 @@ def _derive_label(payload: Dict[str, Any]) -> str:
     return identity.rsplit("/", 1)[-1].rsplit(",", 1)[-1] or identity
 
 
+def _resolve_mesh_names(nodes: List[Dict[str, Any]]) -> None:
+    try:
+        # Get the full name of all actors and their meshes.
+        rows = db._query(
+            "SELECT a.full_name, m.full_name AS mesh_full_name"
+            " FROM actors a"
+            " LEFT JOIN meshes m ON a.mesh_id = m.id"
+        )
+        if not rows:
+            return
+
+        # Map actor full_name -> mesh full_name (includes unique suffix).
+        fname_to_mesh: Dict[str, str] = {}
+        for r in rows:
+            mname = r.get("mesh_full_name")
+            if mname:
+                fname_to_mesh[r["full_name"]] = mname
+
+        # Iterate over graph nodes and try to look up mesh names.
+        for n in nodes:
+            entity = n["entity_id"]
+            # Strip "host:" prefix — admin API uses it but telemetry doesn't.
+            bare = entity[5:] if entity.startswith("host:") else entity
+            # Direct match (actors, and host_agent actors).
+            if bare in fname_to_mesh:
+                n["mesh_name"] = fname_to_mesh[bare]
+                continue
+            # Procs: try appending proc_agent suffix.
+            agent_name = bare + ",proc_agent[0]"
+            if agent_name in fname_to_mesh:
+                n["mesh_name"] = fname_to_mesh[agent_name]
+
+    except Exception:
+        logger.debug("Could not resolve mesh names from telemetry", exc_info=True)
+
+
 def build_admin_dag(hide_system: bool = True) -> Dict[str, Any]:
     """Walk the Admin API and build a DAG matching the TUI hierarchy.
 
@@ -216,6 +252,7 @@ def build_admin_dag(hide_system: bool = True) -> Dict[str, Any]:
     edges: List[Dict[str, Any]] = []
     visited: Set[str] = set()
     ref_to_node_id: Dict[str, str] = {}
+    controller_host_ref: Optional[str] = None
 
     queue: List[Tuple[str, Optional[str], int]] = [("root", None, 0)]
 
@@ -259,16 +296,15 @@ def build_admin_dag(hide_system: bool = True) -> Dict[str, Any]:
         node_id = f"{tier}-{ref}"
         ref_to_node_id[ref] = node_id
 
-        nodes.append(
-            {
-                "id": node_id,
-                "entity_id": ref,
-                "tier": tier,
-                "label": label,
-                "subtitle": tier.capitalize(),
-                "status": status,
-            }
-        )
+        node_data: Dict[str, Any] = {
+            "id": node_id,
+            "entity_id": ref,
+            "tier": tier,
+            "label": label,
+            "subtitle": tier.capitalize(),
+            "status": status,
+        }
+        nodes.append(node_data)
 
         if parent_ref is not None and parent_ref in ref_to_node_id:
             parent_node_id = ref_to_node_id[parent_ref]
@@ -281,11 +317,27 @@ def build_admin_dag(hide_system: bool = True) -> Dict[str, Any]:
                 }
             )
 
+        # Detect the controller host by looking for the root client
+        # actor (client[0]) in proc children. Every Monarch process
+        # has exactly one client actor on its local proc, so this is
+        # a stable identifier. This can be removed once the admin API
+        # and telemetry SQL endpoints converge into a single schema
+        # that exposes host roles directly.
+        if ntype == "proc" and any(c.endswith(",client[0]") for c in children_refs):
+            controller_host_ref = parent_ref
+
         if depth < _MAX_TREE_DEPTH:
             for child_ref in children_refs:
                 if hide_system and child_ref in system_children:
                     continue
                 queue.append((child_ref, ref, depth + 1))
+
+    # Tag the controller host with "(controller)" in its label.
+    if controller_host_ref is not None:
+        for n in nodes:
+            if n["tier"] == "host" and n["entity_id"] == controller_host_ref:
+                n["label"] += " (controller)"
+                break
 
     # Resolve telemetry actor IDs so the detail panel can query messages.
     try:
@@ -301,6 +353,9 @@ def build_admin_dag(hide_system: bool = True) -> Dict[str, Any]:
                         n["telemetry_actor_id"] = tel_id
     except Exception:
         logger.debug("Could not resolve telemetry actor IDs", exc_info=True)
+
+    # Resolve mesh names (host mesh, proc mesh, actor mesh) from telemetry.
+    _resolve_mesh_names(nodes)
 
     # Prune procs that have no actor children after system filtering.
     if hide_system:


### PR DESCRIPTION
Summary:

Add controller identification, improved tooltips, and cosmetic fixes to the DAG view.

**Controller host identification** (admin_dag.py) — Detects the controller host by finding the `client[0]` actor in proc children during the admin API tree walk. The label shows "(controller)" and the frontend renders it with a distinct blue border and "Controller" as the short name.

**Mesh name extraction** (admin_dag.py) — New `_extract_mesh_name` function parses the node identity string to extract the mesh name. For actors (3+ comma-parts), this is the actor mesh name (e.g. `philosopher-1JaZMsFaUgEg`). For procs (2 comma-parts), this is the proc mesh name.

**Tooltip improvements** (DagView.tsx) — Tooltip now shows labeled fields: `ID:` prefix with comma-split continuation lines indented by 2 spaces; `Status:` label; `Mesh:` label showing the fully-qualified mesh name for procs and actors. Tooltip renders below the node when near the top edge and works even with the detail panel open. All text is white for readability on dark backgrounds.

**Cosmetic fixes** — "Show System"/"Hide System" toggle labels; tighter fit margins; white text in tooltips.

Differential Revision: D98635196


