### PR TITLE
Remove MockMast and MockMastAllocator (#3317)

### DIFF
--- a/monarch_extension/src/lib.rs
+++ b/monarch_extension/src/lib.rs
@@ -295,10 +295,6 @@ pub fn mod_init(module: &Bound<'_, PyModule>) -> PyResult<()> {
             module,
             "monarch_hyperactor.meta.alloc",
         )?)?;
-        monarch_hyperactor::meta::alloc_mock::register_python_bindings(&get_or_add_new_module(
-            module,
-            "monarch_hyperactor.meta.alloc_mock",
-        )?)?;
     }
     // Add feature detection function
     module.add_function(wrap_pyfunction!(has_tensor_engine, module)?)?;


### PR DESCRIPTION
Summary:

Remove `MockMastAllocator` from Python and `MockMast` (along with its Python binding `PyMockMast`) from Rust. Also remove the `local_mock_mast_mesh` helper and associated mock-based tests that depended on these.

Reviewed By: thedavekwon

Differential Revision: D98806269


