### PR TITLE
Fix stop_actor_by_name returning immediately without waiting for actor termination

### DIFF
--- a/hyperactor_mesh/src/proc_mesh.rs
+++ b/hyperactor_mesh/src/proc_mesh.rs
@@ -1288,10 +1288,14 @@ impl ProcMeshRef {
                 initial_update_interval: None,
             },
         );
+        // Use WaitRankStatus instead of GetRankStatus so agents defer
+        // their reply until the actor reaches terminal state, rather
+        // than replying immediately with Stopping.
         agent_mesh.cast(
             cx,
-            resource::GetRankStatus {
+            resource::WaitRankStatus {
                 name: mesh_name,
+                min_status: Status::Stopped,
                 reply: port.bind(),
             },
         )?;


### PR DESCRIPTION
Summary:
Use `WaitRankStatus { min_status: Stopped }` instead of `GetRankStatus`
so agents defer their reply until actors actually terminate or the idle
timeout fires.

Differential Revision: D98945201


