### PR TITLE
remotemount.refresh: live mount updates without unmounting

### DIFF
--- a/examples/remotemount/REMOTERUN_GUIDE.md
+++ b/examples/remotemount/REMOTERUN_GUIDE.md
@@ -150,10 +150,10 @@ Unchanged workers skip transfer entirely (metadata + remount only).
 
 | Payload | Cold start | No change | Rewrite data.bin | Rewrite .py | Delete file |
 |---------|-----------|-----------|-----------------|-------------|-------------|
-| 1 GB    | 9.9s      | 5.9s      | 9.2s            | 7.9s        | 6.9s        |
-| 2 GB    | 11.7s     | 6.9s      | 11.7s           | 8.0s        | 6.6s        |
-| 4 GB    | 15.9s     | 7.4s      | 16.2s           | 8.7s        | 8.1s        |
-| 8 GB    | 22.5s     | 7.4s      | 22.6s           | 9.6s        | 7.7s        |
+| 1 GB    | 9.6s      | 7.7s      | 10.6s           | 8.4s        | 8.1s        |
+| 2 GB    | 12.4s     | 8.3s      | 19.6s           | 9.9s        | 8.1s        |
+| 4 GB    | 13.7s     | 8.9s      | 13.7s           | 9.5s        | 8.6s        |
+| 8 GB    | 20.1s     | 9.3s      | 20.3s           | 10.9s       | 11.2s       |
 
 ### Results — 64 hosts (8 streams, chunked tree fan-out, 4 leaders)
 

--- a/monarch_extension/src/chunked_fuse.rs
+++ b/monarch_extension/src/chunked_fuse.rs
@@ -11,11 +11,19 @@
 //! Replaces the Python fusepy-based ChunkedFS with a Rust implementation
 //! using the `fuse3` crate (libfuse3, async/tokio). Exposed to Python
 //! via PyO3.
+//!
+//! Supports live refresh: `PyMountHandle::refresh` atomically swaps
+//! the filesystem data (metadata + chunks) behind a `RwLock` without
+//! unmounting. All FUSE methods acquire a read lock, so reads are
+//! lock-free relative to each other and only briefly blocked during
+//! the write-lock swap.
 
 use std::collections::HashMap;
 use std::ffi::OsStr;
 use std::ffi::OsString;
 use std::num::NonZeroU32;
+use std::sync::Arc;
+use std::sync::RwLock;
 use std::time::Duration;
 use std::time::SystemTime;
 use std::time::UNIX_EPOCH;
@@ -33,7 +41,7 @@ use pyo3::types::PyDict;
 use tokio::sync::oneshot;
 use tracing::warn;
 
-const TTL: Duration = Duration::from_secs(3600);
+const DEFAULT_TTL_MS: u64 = 200;
 
 enum FsEntry {
     Dir {
@@ -58,6 +66,88 @@ impl FsEntry {
             FsEntry::File { attr, .. } => attr,
             FsEntry::Symlink { attr, .. } => attr,
         }
+    }
+}
+
+/// Snapshot of filesystem data that can be atomically swapped.
+struct FsData {
+    metadata: HashMap<OsString, FsEntry>,
+    chunks: Vec<Bytes>,
+    chunk_size: usize,
+}
+
+impl FsData {
+    fn lookup_entry(&self, path: &OsStr) -> Option<&FsEntry> {
+        self.metadata.get(path)
+    }
+
+    fn read_data(
+        &self,
+        global_offset: usize,
+        file_len: usize,
+        offset: u64,
+        size: u32,
+    ) -> Result<Bytes, libc::c_int> {
+        let offset = offset as usize;
+        if offset >= file_len {
+            return Ok(Bytes::new());
+        }
+        let len = std::cmp::min(size as usize, file_len - offset);
+        let start = global_offset + offset;
+        let end = start + len;
+
+        let chunk_size = self.chunk_size;
+        let start_chunk = start / chunk_size;
+        let end_chunk = (end.saturating_sub(1)) / chunk_size;
+
+        if start_chunk == end_chunk && start_chunk < self.chunks.len() {
+            let chunk_offset = start % chunk_size;
+            Ok(self.chunks[start_chunk].slice(chunk_offset..chunk_offset + len))
+        } else {
+            let mut buf = Vec::with_capacity(len);
+            let mut pos = start;
+            while pos < end {
+                let ci = pos / chunk_size;
+                if ci >= self.chunks.len() {
+                    break;
+                }
+                let off_in_chunk = pos % chunk_size;
+                if off_in_chunk >= self.chunks[ci].len() {
+                    break;
+                }
+                let avail = self.chunks[ci].len() - off_in_chunk;
+                let take = std::cmp::min(avail, end - pos);
+                buf.extend_from_slice(&self.chunks[ci][off_in_chunk..off_in_chunk + take]);
+                pos += take;
+            }
+            if buf.len() != len {
+                warn!(
+                    "multi-chunk read: expected {len} bytes but assembled {}, \
+                     chunks may be truncated or corrupted",
+                    buf.len()
+                );
+                return Err(libc::EIO);
+            }
+            Ok(Bytes::from(buf))
+        }
+    }
+}
+
+fn join_path(parent: &OsStr, name: &OsStr) -> OsString {
+    let parent_s = parent.to_string_lossy();
+    let name_s = name.to_string_lossy();
+    if parent_s == "/" {
+        OsString::from(format!("/{name_s}"))
+    } else {
+        OsString::from(format!("{parent_s}/{name_s}"))
+    }
+}
+
+fn parent_path(path: &OsStr) -> OsString {
+    let s = path.to_string_lossy();
+    match s.rfind('/') {
+        Some(0) | None => OsString::from("/"),
+        Some(i) => OsString::from(&s[..i]),
     }
 }
 
@@ -140,89 +230,34 @@ fn extract_metadata(dict: &Bound<'_, PyDict>) -> PyResult<HashMap<OsString, FsEn
     Ok(entries)
 }
 
+/// Copy Python buffers into owned `Bytes` objects.
+///
+/// We intentionally avoid zero-copy (`Bytes::from_owner` wrapping
+/// `PyBuffer`) because `PyBuffer::drop` calls `PyBuffer_Release` which
+/// requires the GIL. If a FUSE task is still alive when the tokio
+/// runtime shuts down via atexit, the `PyBuffer` would be dropped on a
+/// tokio worker thread during interpreter finalization, causing a
+/// segfault.
+fn copy_py_buffers(chunks: Vec<pyo3::buffer::PyBuffer<u8>>) -> Vec<Bytes> {
+    chunks
+        .into_iter()
+        .map(|buf| {
+            // SAFETY: buf is a live PyBuffer and we hold the GIL.
+            // buf_ptr() is valid for len_bytes() bytes for the lifetime
+            // of `buf`. Bytes::copy_from_slice performs a full memcpy
+            // before this closure ends and `buf` is dropped.
+            let slice =
+                unsafe { std::slice::from_raw_parts(buf.buf_ptr() as *const u8, buf.len_bytes()) };
+            Bytes::copy_from_slice(slice)
+        })
+        .collect()
+}
+
 // --- FUSE filesystem ---
 
 struct ChunkedFuseFs {
-    metadata: HashMap<OsString, FsEntry>,
-    chunks: Vec<Bytes>,
-    chunk_size: usize,
-}
-
-impl ChunkedFuseFs {
-    fn lookup_entry(&self, path: &OsStr) -> Option<&FsEntry> {
-        self.metadata.get(path)
-    }
-
-    fn read_data(
-        &self,
-        global_offset: usize,
-        file_len: usize,
-        offset: u64,
-        size: u32,
-    ) -> Result<Bytes, libc::c_int> {
-        let offset = offset as usize;
-        if offset >= file_len {
-            return Ok(Bytes::new());
-        }
-        let len = std::cmp::min(size as usize, file_len - offset);
-        let start = global_offset + offset;
-        let end = start + len;
-
-        let chunk_size = self.chunk_size;
-        let start_chunk = start / chunk_size;
-        let end_chunk = (end.saturating_sub(1)) / chunk_size;
-
-        if start_chunk == end_chunk && start_chunk < self.chunks.len() {
-            // Fast path: single chunk
-            let chunk_offset = start % chunk_size;
-            Ok(self.chunks[start_chunk].slice(chunk_offset..chunk_offset + len))
-        } else {
-            // Multi-chunk: assemble
-            let mut buf = Vec::with_capacity(len);
-            let mut pos = start;
-            while pos < end {
-                let ci = pos / chunk_size;
-                if ci >= self.chunks.len() {
-                    break;
-                }
-                let off_in_chunk = pos % chunk_size;
-                if off_in_chunk >= self.chunks[ci].len() {
-                    break;
-                }
-                let avail = self.chunks[ci].len() - off_in_chunk;
-                let take = std::cmp::min(avail, end - pos);
-                buf.extend_from_slice(&self.chunks[ci][off_in_chunk..off_in_chunk + take]);
-                pos += take;
-            }
-            if buf.len() != len {
-                warn!(
-                    "multi-chunk read: expected {len} bytes but assembled {}, \
-                     chunks may be truncated or corrupted",
-                    buf.len()
-                );
-                return Err(libc::EIO);
-            }
-            Ok(Bytes::from(buf))
-        }
-    }
-
-    fn join_path(parent: &OsStr, name: &OsStr) -> OsString {
-        let parent_s = parent.to_string_lossy();
-        let name_s = name.to_string_lossy();
-        if parent_s == "/" {
-            OsString::from(format!("/{name_s}"))
-        } else {
-            OsString::from(format!("{parent_s}/{name_s}"))
-        }
-    }
-
-    fn parent_path(path: &OsStr) -> OsString {
-        let s = path.to_string_lossy();
-        match s.rfind('/') {
-            Some(0) | None => OsString::from("/"),
-            Some(i) => OsString::from(&s[..i]),
-        }
-    }
+    data: Arc<RwLock<FsData>>,
+    ttl: Duration,
 }
 
 impl PathFilesystem for ChunkedFuseFs {
@@ -238,10 +273,11 @@ impl PathFilesystem for ChunkedFuseFs {
     async fn destroy(&self, _req: Request) {}
 
     async fn lookup(&self, _req: Request, parent: &OsStr, name: &OsStr) -> FuseResult<ReplyEntry> {
-        let path = Self::join_path(parent, name);
-        let entry = self.lookup_entry(&path).ok_or_else(Errno::new_not_exist)?;
+        let path = join_path(parent, name);
+        let data = self.data.read().unwrap();
+        let entry = data.lookup_entry(&path).ok_or_else(Errno::new_not_exist)?;
         Ok(ReplyEntry {
-            ttl: TTL,
+            ttl: self.ttl,
             attr: *entry.attr(),
         })
     }
@@ -254,15 +290,17 @@ impl PathFilesystem for ChunkedFuseFs {
         _flags: u32,
     ) -> FuseResult<ReplyAttr> {
         let path = path.ok_or_else(Errno::new_not_exist)?;
-        let entry = self.lookup_entry(path).ok_or_else(Errno::new_not_exist)?;
+        let data = self.data.read().unwrap();
+        let entry = data.lookup_entry(path).ok_or_else(Errno::new_not_exist)?;
         Ok(ReplyAttr {
-            ttl: TTL,
+            ttl: self.ttl,
             attr: *entry.attr(),
         })
     }
 
     async fn readlink(&self, _req: Request, path: &OsStr) -> FuseResult<ReplyData> {
-        let entry = self.lookup_entry(path).ok_or_else(Errno::new_not_exist)?;
+        let data = self.data.read().unwrap();
+        let entry = data.lookup_entry(path).ok_or_else(Errno::new_not_exist)?;
         match entry {
             FsEntry::Symlink { link_target, .. } => Ok(ReplyData {
                 data: Bytes::copy_from_slice(link_target.as_encoded_bytes()),
@@ -272,7 +310,8 @@ impl PathFilesystem for ChunkedFuseFs {
     }
 
     async fn open(&self, _req: Request, path: &OsStr, flags: u32) -> FuseResult<ReplyOpen> {
-        let entry = self.lookup_entry(path).ok_or_else(Errno::new_not_exist)?;
+        let data = self.data.read().unwrap();
+        let entry = data.lookup_entry(path).ok_or_else(Errno::new_not_exist)?;
         if matches!(entry, FsEntry::Dir { .. }) {
             return Err(Errno::new_is_dir());
         }
@@ -288,24 +327,26 @@ impl PathFilesystem for ChunkedFuseFs {
         size: u32,
     ) -> FuseResult<ReplyData> {
         let path = path.ok_or_else(Errno::new_not_exist)?;
-        let entry = self.lookup_entry(path).ok_or_else(Errno::new_not_exist)?;
+        let data = self.data.read().unwrap();
+        let entry = data.lookup_entry(path).ok_or_else(Errno::new_not_exist)?;
         match entry {
             FsEntry::File {
                 global_offset,
                 file_len,
                 ..
             } => {
-                let data = self
+                let result = data
                     .read_data(*global_offset, *file_len, offset, size)
                     .map_err(Errno::from)?;
-                Ok(ReplyData { data })
+                Ok(ReplyData { data: result })
             }
             _ => Err(libc::EINVAL.into()),
         }
     }
 
     async fn opendir(&self, _req: Request, path: &OsStr, flags: u32) -> FuseResult<ReplyOpen> {
-        let entry = self.lookup_entry(path).ok_or_else(Errno::new_not_exist)?;
+        let data = self.data.read().unwrap();
+        let entry = data.lookup_entry(path).ok_or_else(Errno::new_not_exist)?;
         if !matches!(entry, FsEntry::Dir { .. }) {
             return Err(Errno::new_is_not_dir());
         }
@@ -319,7 +360,8 @@ impl PathFilesystem for ChunkedFuseFs {
         _fh: u64,
         offset: i64,
     ) -> FuseResult<ReplyDirectory<Self::DirEntryStream<'a>>> {
-        let entry = self.lookup_entry(parent).ok_or_else(Errno::new_not_exist)?;
+        let data = self.data.read().unwrap();
+        let entry = data.lookup_entry(parent).ok_or_else(Errno::new_not_exist)?;
         let children = match entry {
             FsEntry::Dir { children, .. } => children,
             _ => return Err(Errno::new_is_not_dir()),
@@ -349,8 +391,8 @@ impl PathFilesystem for ChunkedFuseFs {
 
         for child_name in children {
             if offset < idx {
-                let child_path = Self::join_path(parent, OsStr::new(child_name));
-                if let Some(child_entry) = self.lookup_entry(&child_path) {
+                let child_path = join_path(parent, OsStr::new(child_name));
+                if let Some(child_entry) = data.lookup_entry(&child_path) {
                     entries.push(Ok(DirectoryEntry {
                         kind: child_entry.attr().kind,
                         name: OsString::from(child_name),
@@ -374,32 +416,32 @@ impl PathFilesystem for ChunkedFuseFs {
         offset: u64,
         _lock_owner: u64,
     ) -> FuseResult<ReplyDirectoryPlus<Self::DirEntryPlusStream<'a>>> {
-        let entry = self.lookup_entry(parent).ok_or_else(Errno::new_not_exist)?;
+        let data = self.data.read().unwrap();
+        let entry = data.lookup_entry(parent).ok_or_else(Errno::new_not_exist)?;
         let children = match entry {
             FsEntry::Dir { children, .. } => children,
             _ => return Err(Errno::new_is_not_dir()),
         };
 
+        let ttl = self.ttl;
         let mut entries: Vec<FuseResult<DirectoryEntryPlus>> = Vec::new();
         let mut idx: u64 = 1;
 
-        // "." entry
         if offset < idx {
             entries.push(Ok(DirectoryEntryPlus {
                 kind: FileType::Directory,
                 name: OsString::from("."),
                 offset: idx as i64,
                 attr: *entry.attr(),
-                entry_ttl: TTL,
-                attr_ttl: TTL,
+                entry_ttl: ttl,
+                attr_ttl: ttl,
             }));
         }
         idx += 1;
 
-        // ".." entry
         if offset < idx {
-            let parent_key = Self::parent_path(parent);
-            let dotdot_attr = match self.lookup_entry(&parent_key) {
+            let parent_key = parent_path(parent);
+            let dotdot_attr = match data.lookup_entry(&parent_key) {
                 Some(e) => *e.attr(),
                 None => {
                     warn!(
@@ -415,23 +457,23 @@ impl PathFilesystem for ChunkedFuseFs {
                 name: OsString::from(".."),
                 offset: idx as i64,
                 attr: dotdot_attr,
-                entry_ttl: TTL,
-                attr_ttl: TTL,
+                entry_ttl: ttl,
+                attr_ttl: ttl,
             }));
         }
         idx += 1;
 
         for child_name in children {
             if offset < idx {
-                let child_path = Self::join_path(parent, OsStr::new(child_name));
-                if let Some(child_entry) = self.lookup_entry(&child_path) {
+                let child_path = join_path(parent, OsStr::new(child_name));
+                if let Some(child_entry) = data.lookup_entry(&child_path) {
                     entries.push(Ok(DirectoryEntryPlus {
                         kind: child_entry.attr().kind,
                         name: OsString::from(child_name),
                         offset: idx as i64,
                         attr: *child_entry.attr(),
-                        entry_ttl: TTL,
-                        attr_ttl: TTL,
+                        entry_ttl: ttl,
+                        attr_ttl: ttl,
                     }));
                 }
             }
@@ -444,7 +486,8 @@ impl PathFilesystem for ChunkedFuseFs {
     }
 
     async fn access(&self, _req: Request, path: &OsStr, _mask: u32) -> FuseResult<()> {
-        if self.lookup_entry(path).is_some() {
+        let data = self.data.read().unwrap();
+        if data.lookup_entry(path).is_some() {
             Ok(())
         } else {
             Err(Errno::new_not_exist())
@@ -494,6 +537,7 @@ impl PathFilesystem for ChunkedFuseFs {
 struct PyMountHandle {
     unmount_tx: Option<oneshot::Sender<()>>,
     mount_point: String,
+    data: Arc<RwLock<FsData>>,
 }
 
 #[pymethods]
@@ -527,6 +571,36 @@ impl PyMountHandle {
             }
         })
     }
+
+    /// Atomically replace filesystem data (metadata + chunks) without
+    /// unmounting. Ongoing reads see either the old or new data, never
+    /// a partial mix. Sleeps 3x the FUSE TTL after swapping to ensure
+    /// kernel caches have expired before returning.
+    fn refresh(
+        &self,
+        py: Python<'_>,
+        metadata: &Bound<'_, PyDict>,
+        chunks: Vec<pyo3::buffer::PyBuffer<u8>>,
+        chunk_size: usize,
+    ) -> PyResult<()> {
+        let metadata = extract_metadata(metadata)?;
+        let chunks = copy_py_buffers(chunks);
+        let new_data = FsData {
+            metadata,
+            chunks,
+            chunk_size,
+        };
+        let mut guard = self.data.write().unwrap();
+        *guard = new_data;
+        drop(guard);
+        // Wait for kernel FUSE attr/page caches (TTL=200ms) to expire.
+        let settle = Duration::from_millis(DEFAULT_TTL_MS * 3);
+        py.detach(|| {
+            #[allow(clippy::disallowed_methods)]
+            std::thread::sleep(settle);
+            Ok(())
+        })
+    }
 }
 
 /// Mount a read-only FUSE filesystem from packed metadata and chunks.
@@ -537,8 +611,8 @@ impl PyMountHandle {
 ///     chunks: list of memoryview/bytes chunks.
 ///     chunk_size: size of each chunk in bytes.
 ///     mount_point: path to mount the filesystem.
-///
-/// Returns a FuseMountHandle. Call handle.unmount() to unmount.
+/// Returns a FuseMountHandle. Call handle.unmount() to unmount, or
+/// handle.refresh() to atomically swap the data.
 #[pyfunction]
 fn mount_chunked_fuse(
     py: Python<'_>,
@@ -547,6 +621,7 @@ fn mount_chunked_fuse(
     chunk_size: usize,
     mount_point: String,
 ) -> PyResult<PyMountHandle> {
+    let ttl_ms = DEFAULT_TTL_MS;
     if chunk_size == 0 {
         return Err(PyRuntimeError::new_err("chunk_size must be > 0"));
     }
@@ -557,31 +632,17 @@ fn mount_chunked_fuse(
     }
 
     let metadata = extract_metadata(metadata)?;
-    // Copy each Python buffer into owned Bytes. We intentionally avoid
-    // zero-copy (Bytes::from_owner wrapping PyBuffer) because PyBuffer::drop
-    // calls PyBuffer_Release which requires the GIL. If a FUSE task is still
-    // alive when the tokio runtime shuts down via atexit, the PyBuffer would
-    // be dropped on a tokio worker thread during interpreter finalization,
-    // causing a segfault in module_from_spec/Python::attach.
-    let chunks: Vec<Bytes> = chunks
-        .into_iter()
-        .map(|buf| {
-            // SAFETY: buf is a live PyBuffer and we hold the GIL (py:
-            // Python<'_> is in scope). buf_ptr() is valid for len_bytes()
-            // bytes for the lifetime of `buf`. Bytes::copy_from_slice on
-            // the next line performs a full memcpy before this closure
-            // iteration ends and `buf` is dropped, so the slice does not
-            // outlive the source buffer.
-            let slice =
-                unsafe { std::slice::from_raw_parts(buf.buf_ptr() as *const u8, buf.len_bytes()) };
-            Bytes::copy_from_slice(slice)
-        })
-        .collect();
+    let chunks = copy_py_buffers(chunks);
 
-    let fs = ChunkedFuseFs {
+    let data = Arc::new(RwLock::new(FsData {
         metadata,
         chunks,
         chunk_size,
+    }));
+
+    let fs = ChunkedFuseFs {
+        data: data.clone(),
+        ttl: Duration::from_millis(ttl_ms),
     };
 
     let mount_path = mount_point.clone();
@@ -675,6 +736,7 @@ fn mount_chunked_fuse(
     Ok(PyMountHandle {
         unmount_tx: Some(unmount_tx),
         mount_point,
+        data,
     })
 }
 

--- a/monarch_extension/src/tls_sender.rs
+++ b/monarch_extension/src/tls_sender.rs
@@ -293,9 +293,12 @@ fn send_blocks_impl(
                         .map_err(|e| format!("close_notify: {e}"))?;
                 }
                 // Shut down the write half of TCP to send FIN cleanly.
-                tls.sock
-                    .shutdown(std::net::Shutdown::Write)
-                    .map_err(|e| format!("tcp shutdown: {e}"))?;
+                // ENOTCONN means the peer already closed — not an error.
+                match tls.sock.shutdown(std::net::Shutdown::Write) {
+                    Ok(()) => {}
+                    Err(e) if e.raw_os_error() == Some(libc::ENOTCONN) => {}
+                    Err(e) => return Err(format!("tcp shutdown: {e}")),
+                }
 
                 // Drain the receive buffer (e.g. TLS 1.3 NewSessionTicket
                 // messages the server sent after the handshake). If unread

--- a/python/benches/remotemount/bench_fuse_read.py
+++ b/python/benches/remotemount/bench_fuse_read.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Benchmark FUSE read latency and throughput.
+
+Measures:
+  1. Small-read latency (many 4KB reads)
+  2. Large-read throughput (sequential 1MB reads)
+  3. stat() latency (metadata lookups)
+  4. Baseline: same operations on a regular tmpfs file for comparison
+"""
+
+import os
+import tempfile
+import time
+
+from monarch._rust_bindings.monarch_extension.chunked_fuse import mount_chunked_fuse
+
+
+def make_attr(mode=0o100644, size=0, nlink=1):
+    now = time.time()
+    return {
+        "st_atime": now,
+        "st_ctime": now,
+        "st_gid": os.getgid(),
+        "st_mode": mode,
+        "st_mtime": now,
+        "st_nlink": nlink,
+        "st_size": size,
+        "st_uid": os.getuid(),
+    }
+
+
+def bench_reads(path, read_size, num_reads, label):
+    """Read read_size bytes num_reads times, report latency and throughput."""
+    # Warm up
+    with open(path, "rb") as f:
+        f.read(read_size)
+
+    t0 = time.time()
+    for _ in range(num_reads):
+        with open(path, "rb") as f:
+            f.read(read_size)
+    elapsed = time.time() - t0
+
+    total_bytes = read_size * num_reads
+    lat_us = elapsed / num_reads * 1e6
+    tp_mbs = total_bytes / elapsed / 1e6
+    print(
+        f"  {label}: {num_reads} x {read_size // 1024}KB "
+        f"in {elapsed:.3f}s — {lat_us:.1f} µs/read, {tp_mbs:.1f} MB/s"
+    )
+    return elapsed
+
+
+def bench_stats(path, num_stats, label):
+    """stat() a file num_stats times."""
+    # Warm up
+    os.stat(path)
+
+    t0 = time.time()
+    for _ in range(num_stats):
+        os.stat(path)
+    elapsed = time.time() - t0
+
+    lat_us = elapsed / num_stats * 1e6
+    print(f"  {label}: {num_stats} x stat() in {elapsed:.3f}s — {lat_us:.1f} µs/stat")
+    return elapsed
+
+
+def bench_open_read_close(path, read_size, num_iters, label):
+    """Measure open+read+close cycle."""
+    fd = os.open(path, os.O_RDONLY)
+    os.read(fd, read_size)
+    os.close(fd)
+
+    t0 = time.time()
+    for _ in range(num_iters):
+        fd = os.open(path, os.O_RDONLY)
+        os.read(fd, read_size)
+        os.close(fd)
+    elapsed = time.time() - t0
+
+    lat_us = elapsed / num_iters * 1e6
+    print(
+        f"  {label}: {num_iters} x open+read+close "
+        f"in {elapsed:.3f}s — {lat_us:.1f} µs/iter"
+    )
+    return elapsed
+
+
+def main():
+    file_size = 10 * 1024 * 1024  # 10 MB
+    data = os.urandom(file_size)
+    num_small = 5000
+    num_large = 500
+    num_stats = 10000
+
+    # --- Baseline: regular tmpfs file ---
+    print("=== Baseline (tmpfs) ===")
+    with tempfile.TemporaryDirectory() as d:
+        path = os.path.join(d, "data.bin")
+        with open(path, "wb") as f:
+            f.write(data)
+        bench_reads(path, 4096, num_small, "4KB reads")
+        bench_reads(path, 1024 * 1024, num_large, "1MB reads")
+        bench_stats(path, num_stats, "stat()")
+        bench_open_read_close(path, 4096, num_small, "open+4KB+close")
+
+    metadata = {
+        "/": {
+            "attr": make_attr(mode=0o40755, size=4096, nlink=2),
+            "children": ["data.bin"],
+        },
+        "/data.bin": {
+            "attr": make_attr(size=file_size),
+            "global_offset": 0,
+            "file_len": file_size,
+        },
+    }
+
+    # --- FUSE (TTL=200ms hardcoded) ---
+    print("\n=== FUSE (TTL=200ms) ===")
+    with tempfile.TemporaryDirectory() as mnt:
+        handle = mount_chunked_fuse(metadata, [memoryview(data)], file_size, mnt)
+        path = os.path.join(mnt, "data.bin")
+        bench_reads(path, 4096, num_small, "4KB reads")
+        bench_reads(path, 1024 * 1024, num_large, "1MB reads")
+        bench_stats(path, num_stats, "stat()")
+        bench_open_read_close(path, 4096, num_small, "open+4KB+close")
+        handle.unmount()
+
+
+if __name__ == "__main__":
+    main()

--- a/python/benches/remotemount/bench_fuse_refresh.py
+++ b/python/benches/remotemount/bench_fuse_refresh.py
@@ -1,0 +1,355 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Benchmark FUSE refresh scenarios.
+
+Based on TestFuseRefresh test cases. Measures the cost of each refresh
+pattern: unchanged data, changed data, added/deleted files, offset
+shifts (defrag), sequential reads across refresh, and many-files-one-changed.
+"""
+
+import os
+import tempfile
+import time
+
+from monarch._rust_bindings.monarch_extension.chunked_fuse import mount_chunked_fuse
+from monarch.remotemount.fast_pack import pack_directory_chunked
+
+
+def _make_attr(mode=0o100644, size=0, nlink=1):
+    now = time.time()
+    return {
+        "st_atime": now,
+        "st_ctime": now,
+        "st_gid": os.getgid(),
+        "st_mode": mode,
+        "st_mtime": now,
+        "st_nlink": nlink,
+        "st_size": size,
+        "st_uid": os.getuid(),
+    }
+
+
+def _dir_attr(size=4096, nlink=2):
+    return _make_attr(mode=0o40755, size=size, nlink=nlink)
+
+
+def _file_attr(size):
+    return _make_attr(mode=0o100644, size=size)
+
+
+def _file_meta(name, data, offset=0):
+    return {
+        f"/{name}": {
+            "attr": _file_attr(len(data)),
+            "global_offset": offset,
+            "file_len": len(data),
+        }
+    }
+
+
+def _timed(label, fn):
+    t0 = time.time()
+    result = fn()
+    elapsed = time.time() - t0
+    print(f"  {label}: {elapsed * 1000:.1f} ms")
+    return result, elapsed
+
+
+def bench_unchanged_file():
+    """Refresh with identical content."""
+    content = os.urandom(1024 * 1024)
+    metadata = {
+        "/": {"attr": _dir_attr(), "children": ["f.bin"]},
+        "/f.bin": {
+            "attr": _file_attr(len(content)),
+            "global_offset": 0,
+            "file_len": len(content),
+        },
+    }
+    with tempfile.TemporaryDirectory() as mnt:
+        handle = mount_chunked_fuse(metadata, [memoryview(content)], len(content), mnt)
+        _timed(
+            "refresh (unchanged 1MB)",
+            lambda: handle.refresh(metadata, [memoryview(content)], len(content)),
+        )
+        _timed(
+            "read after refresh", lambda: open(os.path.join(mnt, "f.bin"), "rb").read()
+        )
+        handle.unmount()
+
+
+def bench_changed_file():
+    """Refresh with different content."""
+    v1 = os.urandom(1024 * 1024)
+    v2 = os.urandom(1024 * 1024)
+
+    def meta_fn(d):
+        return {
+            "/": {"attr": _dir_attr(), "children": ["f.bin"]},
+            "/f.bin": {
+                "attr": _file_attr(len(d)),
+                "global_offset": 0,
+                "file_len": len(d),
+            },
+        }
+
+    with tempfile.TemporaryDirectory() as mnt:
+        handle = mount_chunked_fuse(meta_fn(v1), [memoryview(v1)], len(v1), mnt)
+        _timed(
+            "refresh (changed 1MB)",
+            lambda: handle.refresh(meta_fn(v2), [memoryview(v2)], len(v2)),
+        )
+        _, elapsed = _timed(
+            "read after refresh", lambda: open(os.path.join(mnt, "f.bin"), "rb").read()
+        )
+        handle.unmount()
+
+
+def bench_added_file():
+    """Refresh that adds a new file."""
+    v1 = b"aaa"
+    meta1 = {
+        "/": {"attr": _dir_attr(), "children": ["a.txt"]},
+        "/a.txt": {"attr": _file_attr(3), "global_offset": 0, "file_len": 3},
+    }
+    v2 = b"aaabbb"
+    meta2 = {
+        "/": {"attr": _dir_attr(), "children": ["a.txt", "b.txt"]},
+        "/a.txt": {"attr": _file_attr(3), "global_offset": 0, "file_len": 3},
+        "/b.txt": {"attr": _file_attr(3), "global_offset": 3, "file_len": 3},
+    }
+    with tempfile.TemporaryDirectory() as mnt:
+        handle = mount_chunked_fuse(meta1, [memoryview(v1)], 3, mnt)
+        _timed(
+            "refresh (add file)",
+            lambda: handle.refresh(meta2, [memoryview(v2)], len(v2)),
+        )
+        _timed("listdir after add", lambda: os.listdir(mnt))
+        _timed("read new file", lambda: open(os.path.join(mnt, "b.txt"), "rb").read())
+        handle.unmount()
+
+
+def bench_deleted_file():
+    """Refresh that removes a file."""
+    v1 = b"aaabbb"
+    meta1 = {
+        "/": {"attr": _dir_attr(), "children": ["a.txt", "b.txt"]},
+        "/a.txt": {"attr": _file_attr(3), "global_offset": 0, "file_len": 3},
+        "/b.txt": {"attr": _file_attr(3), "global_offset": 3, "file_len": 3},
+    }
+    v2 = b"aaa"
+    meta2 = {
+        "/": {"attr": _dir_attr(), "children": ["a.txt"]},
+        "/a.txt": {"attr": _file_attr(3), "global_offset": 0, "file_len": 3},
+    }
+    with tempfile.TemporaryDirectory() as mnt:
+        handle = mount_chunked_fuse(meta1, [memoryview(v1)], len(v1), mnt)
+        _timed(
+            "refresh (delete file)", lambda: handle.refresh(meta2, [memoryview(v2)], 3)
+        )
+        _timed("listdir after delete", lambda: os.listdir(mnt))
+        handle.unmount()
+
+
+def bench_defrag_offset_shift():
+    """Refresh where global_offset changes but content is same."""
+    file_data = os.urandom(1024 * 1024)
+    buf1 = b"\x00" * (1024 * 1024) + file_data
+    meta1 = {
+        "/": {"attr": _dir_attr(), "children": ["f.bin"]},
+        "/f.bin": {
+            "attr": _file_attr(len(file_data)),
+            "global_offset": 1024 * 1024,
+            "file_len": len(file_data),
+        },
+    }
+    meta2 = {
+        "/": {"attr": _dir_attr(), "children": ["f.bin"]},
+        "/f.bin": {
+            "attr": _file_attr(len(file_data)),
+            "global_offset": 0,
+            "file_len": len(file_data),
+        },
+    }
+    with tempfile.TemporaryDirectory() as mnt:
+        handle = mount_chunked_fuse(meta1, [memoryview(buf1)], len(buf1), mnt)
+        _timed(
+            "refresh (defrag 1MB, offset shift)",
+            lambda: handle.refresh(meta2, [memoryview(file_data)], len(file_data)),
+        )
+        _timed(
+            "read after defrag", lambda: open(os.path.join(mnt, "f.bin"), "rb").read()
+        )
+        handle.unmount()
+
+
+def bench_sequential_read_across_refresh():
+    """Read half, refresh, read other half."""
+    half = 512 * 1024
+    content = os.urandom(half * 2)
+    metadata = {
+        "/": {"attr": _dir_attr(), "children": ["f.bin"]},
+        "/f.bin": {
+            "attr": _file_attr(len(content)),
+            "global_offset": 0,
+            "file_len": len(content),
+        },
+    }
+    with tempfile.TemporaryDirectory() as mnt:
+        handle = mount_chunked_fuse(metadata, [memoryview(content)], len(content), mnt)
+        fh = open(os.path.join(mnt, "f.bin"), "rb")
+        _timed("read first 512KB", lambda: fh.read(half))
+        _timed(
+            "refresh (unchanged)",
+            lambda: handle.refresh(metadata, [memoryview(content)], len(content)),
+        )
+        _timed("read second 512KB", lambda: fh.read(half))
+        fh.close()
+        handle.unmount()
+
+
+def bench_many_files_one_changed():
+    """50 files, change one, measure refresh + read-all."""
+    num_files = 50
+    file_size = 64 * 1024
+    data = os.urandom(num_files * file_size)
+    children = [f"f_{i:03d}.bin" for i in range(num_files)]
+    metadata = {"/": {"attr": _dir_attr(), "children": children}}
+    for i in range(num_files):
+        metadata[f"/f_{i:03d}.bin"] = {
+            "attr": _file_attr(file_size),
+            "global_offset": i * file_size,
+            "file_len": file_size,
+        }
+
+    with tempfile.TemporaryDirectory() as mnt:
+        handle = mount_chunked_fuse(metadata, [memoryview(data)], len(data), mnt)
+        # Change file 25.
+        new_data = bytearray(data)
+        new_data[25 * file_size : 26 * file_size] = os.urandom(file_size)
+        new_data = bytes(new_data)
+
+        _timed(
+            f"refresh (1/{num_files} files changed, {num_files * file_size // 1024}KB total)",
+            lambda: handle.refresh(metadata, [memoryview(new_data)], len(new_data)),
+        )
+
+        def read_all():
+            for i in range(num_files):
+                with open(os.path.join(mnt, f"f_{i:03d}.bin"), "rb") as f:
+                    f.read()
+
+        _timed(f"read all {num_files} files after refresh", read_all)
+        handle.unmount()
+
+
+def bench_multiple_rapid_refreshes():
+    """20 rapid refreshes, measure total and per-refresh time."""
+
+    def meta_fn(sz):
+        return {
+            "/": {"attr": _dir_attr(), "children": ["f.bin"]},
+            "/f.bin": {
+                "attr": _file_attr(sz),
+                "global_offset": 0,
+                "file_len": sz,
+            },
+        }
+
+    content = os.urandom(1024 * 1024)
+    n = 20
+    with tempfile.TemporaryDirectory() as mnt:
+        handle = mount_chunked_fuse(
+            meta_fn(len(content)), [memoryview(content)], len(content), mnt
+        )
+        t0 = time.time()
+        for _i in range(n):
+            new_content = os.urandom(1024 * 1024)
+            handle.refresh(
+                meta_fn(len(new_content)), [memoryview(new_content)], len(new_content)
+            )
+        elapsed = time.time() - t0
+        print(
+            f"  {n} refreshes (1MB each): {elapsed * 1000:.1f} ms total, "
+            f"{elapsed / n * 1000:.1f} ms/refresh"
+        )
+        handle.unmount()
+
+
+def bench_end_to_end_pack_refresh():
+    """Full round-trip: pack, mount, modify, re-pack, refresh, read."""
+    with tempfile.TemporaryDirectory() as src:
+        data = os.urandom(10 * 1024 * 1024)
+        with open(os.path.join(src, "data.bin"), "wb") as f:
+            f.write(data)
+
+        _timed("initial pack (10MB)", lambda: pack_directory_chunked(src))
+        meta, _, chunks, _, _ = pack_directory_chunked(src)
+
+        with tempfile.TemporaryDirectory() as mnt:
+            chunk_size = len(bytes(chunks[0])) if chunks else 1
+            handle = mount_chunked_fuse(meta, chunks, chunk_size, mnt)
+
+            _timed(
+                "initial read (10MB)",
+                lambda: open(os.path.join(mnt, "data.bin"), "rb").read(),
+            )
+
+            # Modify and re-pack.
+            with open(os.path.join(src, "data.bin"), "wb") as f:
+                f.write(os.urandom(10 * 1024 * 1024))
+
+            _timed("re-pack (10MB)", lambda: pack_directory_chunked(src))
+            meta2, _, chunks2, _, _ = pack_directory_chunked(src)
+            chunk_size2 = len(bytes(chunks2[0])) if chunks2 else 1
+
+            _timed(
+                "refresh (10MB)", lambda: handle.refresh(meta2, chunks2, chunk_size2)
+            )
+
+            _timed(
+                "read after refresh (10MB)",
+                lambda: open(os.path.join(mnt, "data.bin"), "rb").read(),
+            )
+
+            handle.unmount()
+
+
+def main():
+    print("=== FUSE Refresh Benchmarks (TTL=200ms, settle=600ms) ===\n")
+
+    print("--- Unchanged file ---")
+    bench_unchanged_file()
+
+    print("\n--- Changed file ---")
+    bench_changed_file()
+
+    print("\n--- Added file ---")
+    bench_added_file()
+
+    print("\n--- Deleted file ---")
+    bench_deleted_file()
+
+    print("\n--- Defrag (offset shift) ---")
+    bench_defrag_offset_shift()
+
+    print("\n--- Sequential read across refresh ---")
+    bench_sequential_read_across_refresh()
+
+    print("\n--- Many files, one changed ---")
+    bench_many_files_one_changed()
+
+    print("\n--- Multiple rapid refreshes ---")
+    bench_multiple_rapid_refreshes()
+
+    print("\n--- End-to-end pack + refresh ---")
+    bench_end_to_end_pack_refresh()
+
+
+if __name__ == "__main__":
+    main()

--- a/python/monarch/_rust_bindings/monarch_extension/chunked_fuse.pyi
+++ b/python/monarch/_rust_bindings/monarch_extension/chunked_fuse.pyi
@@ -11,6 +11,12 @@ from typing import Any
 
 class FuseMountHandle:
     def unmount(self) -> None: ...
+    def refresh(
+        self,
+        metadata: dict[str, Any],
+        chunks: Sequence[Any],
+        chunk_size: int,
+    ) -> None: ...
 
 def mount_chunked_fuse(
     metadata: dict[str, Any],

--- a/python/monarch/remotemount/remotemount.py
+++ b/python/monarch/remotemount/remotemount.py
@@ -360,30 +360,59 @@ class FUSEActor(Actor):
             ]
             pos += block_size
 
-    @endpoint
-    def mount(self, mount_point, new_block_hashes=None, total_size=0, pack_index=None):
-        from monarch._rust_bindings.monarch_extension.chunked_fuse import (
-            mount_chunked_fuse,
-        )
-
-        # Flush mmap to disk so the cache file persists across actor restarts.
+    def _do_refresh(self, new_block_hashes=None, total_size=0, pack_index=None):
+        """Swap metadata and chunk data into the running FUSE filesystem."""
         if self._cache_path and self._chunk_storage is not None:
             self._chunk_storage.flush()
 
-        # Persist pack index alongside cached data.
         if pack_index is not None and self._cache_path:
             self._pack_index = pack_index
             save_pack_index(self._cache_path + ".index", pack_index)
 
-        self._fuse_handle = mount_chunked_fuse(
-            self.meta,
-            self.chunks,
-            self.chunk_size,
-            mount_point,
-        )
+        self._fuse_handle.refresh(self.meta, self.chunks, self.chunk_size)
         self._block_hashes = new_block_hashes or []
         self._total_size = total_size
-        return 0
+
+    @endpoint
+    def mount(self, mount_point, new_block_hashes=None, total_size=0, pack_index=None):
+        """Mount an empty FUSE filesystem and populate it via refresh."""
+        from monarch._rust_bindings.monarch_extension.chunked_fuse import (
+            mount_chunked_fuse,
+        )
+
+        now = time.time()
+        empty_meta = {
+            "/": {
+                "attr": {
+                    "st_atime": now,
+                    "st_ctime": now,
+                    "st_gid": os.getgid(),
+                    "st_mode": 0o40755,
+                    "st_mtime": now,
+                    "st_nlink": 2,
+                    "st_size": 4096,
+                    "st_uid": os.getuid(),
+                },
+                "children": [],
+            }
+        }
+        self._fuse_handle = mount_chunked_fuse(
+            empty_meta, [], self.chunk_size, mount_point
+        )
+        if self.meta is not None:
+            self._do_refresh(new_block_hashes, total_size, pack_index)
+
+    @endpoint
+    def refresh_mount(self, new_block_hashes=None, total_size=0, pack_index=None):
+        """Refresh FUSE mount data without unmounting.
+
+        Atomically swaps metadata and chunk data in the running FUSE
+        filesystem. Open file handles remain valid and subsequent reads
+        see the new data.
+        """
+        if self._fuse_handle is None:
+            raise RuntimeError("no active mount to refresh")
+        self._do_refresh(new_block_hashes, total_size, pack_index)
 
     @endpoint
     def get_block_hashes(self):
@@ -505,37 +534,20 @@ class MountHandler:
         self.tls_port = tls_port
         self._staging_mv = None
         self._pack_shm_path = None
+        self._mounted = False
 
-    def open(self):
-        t_open_start = time.time()
+    def _sync(self):
+        """Pack source, diff against workers, transfer dirty blocks, refresh FUSE.
 
-        # Reuse existing actors if available (preserves block hashes
-        # and pack index for incremental update checks).
-        if self.fuse_actors is None:
-            self.procs = self.host_mesh.spawn_procs(per_host={"gpus": 1})
-            self.fuse_actors = self.procs.spawn(
-                "FUSEActor", FUSEActor, self.chunk_size, self.backend
-            )
-            self.fuse_actors.mkdir.call(self.mntpoint).get()
+        Shared by open() and refresh(). Expects self.fuse_actors to be
+        initialized and, for refresh(), an active mount.
+        """
+        t_start = time.time()
 
-            import xxhash
-
-            cache_key = xxhash.xxh64(
-                (self.sourcepath + ":" + self.mntpoint).encode()
-            ).hexdigest()
-            self.fuse_actors.try_load_cache.call(cache_key).get()
-
-        t_actors_ready = time.time()
-
-        # Fire RPCs before packing so the network round-trips overlap
-        # with the CPU-bound walk+pack+hash step.
         flat_actors = self.fuse_actors.flatten("rank")
-        num_workers = len(flat_actors)
         hashes_future = self.fuse_actors.get_block_hashes.call()
         index_future = self.fuse_actors.get_pack_index.call()
 
-        # Get pack index from workers (first non-empty).
-        # This is small JSON so the wait is fast.
         index_result = index_future.get()
         previous_index = next(
             (idx for _, idx in index_result if idx and idx.get("files")),
@@ -552,7 +564,6 @@ class MountHandler:
 
         t_pack_done = time.time()
 
-        # Collect worker hashes (should already be available after packing).
         result = hashes_future.get()
         worker_states = [
             (remote_hashes, remote_size)
@@ -564,57 +575,10 @@ class MountHandler:
 
         t_classify_done = time.time()
 
-        # Always send metadata so newly spawned actors (which loaded
-        # block data from the persistent cache) have filesystem layout.
         self.fuse_actors.set_meta.call(meta).get()
 
         t_meta_done = time.time()
 
-        if not worker_dirty:
-            self.fuse_actors.mount.call(
-                self.mntpoint, client_hashes, client_total_size, new_pack_index
-            ).get()
-            t_mount_done = time.time()
-            logger.info(
-                f"All {num_workers} workers up-to-date — skipping transfer, re-mounting. "
-                f"Timings: actors={t_actors_ready - t_open_start:.2f}s, "
-                f"pack+hash={t_pack_done - t_actors_ready:.2f}s "
-                f"({client_total_size / (1024**2):.0f}MiB), "
-                f"classify={t_classify_done - t_pack_done:.2f}s, "
-                f"set_meta={t_meta_done - t_classify_done:.2f}s, "
-                f"mount={t_mount_done - t_meta_done:.2f}s, "
-                f"total={t_mount_done - t_open_start:.2f}s"
-            )
-            return self
-
-        n_partial = sum(1 for v in worker_dirty.values() if v is not None)
-        n_stale = sum(1 for v in worker_dirty.values() if v is None)
-        logger.info(
-            f"{len(fresh_ranks)} fresh, {n_partial} partial, "
-            f"{n_stale} stale out of {num_workers} workers"
-        )
-
-        # Unmount workers that need updating.
-        busy_ranks = []
-        for rank in worker_dirty:
-            result = flat_actors.slice(rank=rank).unmount.call(self.mntpoint).get()
-            for _point, (status, detail) in result:
-                if status == "busy":
-                    busy_ranks.append((rank, detail))
-                elif status == "error":
-                    logger.warning(f"Unmount failed on rank {rank}: {detail}")
-        if busy_ranks:
-            details = "; ".join(f"rank {r}: {e}" for r, e in busy_ranks)
-            raise RuntimeError(
-                f"Cannot update mount at {self.mntpoint}: path is busy on "
-                f"{len(busy_ranks)} worker(s). Kill processes using the "
-                f"mount before re-running. Details: {details}"
-            )
-
-        t_unmount_done = time.time()
-
-        # Compute dirty blocks: union of all non-fresh workers.
-        # Stale workers (None) need all blocks; partial workers need their list.
         all_blocks = list(range(len(client_hashes)))
         dirty_blocks: set[int] = set()
         for _rank, d in worker_dirty.items():
@@ -628,7 +592,7 @@ class MountHandler:
 
         if sorted_dirty and target_ranks:
             logger.info(
-                f"{len(sorted_dirty)}/{len(client_hashes)} blocks dirty "
+                f"_sync(): {len(sorted_dirty)}/{len(client_hashes)} blocks dirty "
                 f"across {len(target_ranks)} workers"
             )
             self._transfer_fanout(
@@ -637,24 +601,50 @@ class MountHandler:
 
         t_transfer_done = time.time()
 
-        # Remount all workers (fresh ones for metadata update).
-        self.fuse_actors.mount.call(
-            self.mntpoint, client_hashes, client_total_size, new_pack_index
-        ).get()
+        # Mount or refresh after transfer succeeds — mounting before
+        # transfer would leak a FUSE mount if the transfer fails
+        # (open() raises before __enter__ completes, so close() never runs).
+        if self._mounted:
+            self.fuse_actors.refresh_mount.call(
+                client_hashes, client_total_size, new_pack_index
+            ).get()
+        else:
+            self.fuse_actors.mount.call(
+                self.mntpoint, client_hashes, client_total_size, new_pack_index
+            ).get()
+            self._mounted = True
 
-        t_mount_done = time.time()
+        t_done = time.time()
 
         logger.info(
-            f"open() timings: actors={t_actors_ready - t_open_start:.2f}s, "
-            f"pack+hash={t_pack_done - t_actors_ready:.2f}s "
+            f"_sync() timings: "
+            f"pack+hash={t_pack_done - t_start:.2f}s "
             f"({client_total_size / (1024**2):.0f}MiB), "
             f"classify={t_classify_done - t_pack_done:.2f}s, "
             f"set_meta={t_meta_done - t_classify_done:.2f}s, "
-            f"unmount={t_unmount_done - t_meta_done:.2f}s, "
-            f"transfer={t_transfer_done - t_unmount_done:.2f}s, "
-            f"mount={t_mount_done - t_transfer_done:.2f}s, "
-            f"total={t_mount_done - t_open_start:.2f}s"
+            f"transfer={t_transfer_done - t_meta_done:.2f}s, "
+            f"refresh={t_done - t_transfer_done:.2f}s, "
+            f"total={t_done - t_start:.2f}s"
         )
+
+    def open(self):
+        # Reuse existing actors if available (preserves block hashes
+        # and pack index for incremental update checks).
+        if self.fuse_actors is None:
+            self.procs = self.host_mesh.spawn_procs(per_host={"gpus": 1})
+            self.fuse_actors = self.procs.spawn(
+                "FUSEActor", FUSEActor, self.chunk_size, self.backend
+            )
+            self.fuse_actors.mkdir.call(self.mntpoint).get()
+
+            import xxhash
+
+            cache_key = xxhash.xxh64(
+                (self.sourcepath + ":" + self.mntpoint).encode()
+            ).hexdigest()
+            self.fuse_actors.try_load_cache.call(cache_key).get()
+
+        self._sync()
         return self
 
     def _transfer_blocks_actor(self, fuse_actor, dirty_blocks, total_size):
@@ -960,6 +950,28 @@ class MountHandler:
             for _point, (status, detail) in result:
                 if status not in ("ok", "not_mounted"):
                     logger.warning(f"unmount failed ({status}): {detail}")
+        self._mounted = False
+
+    def refresh(self, sourcepath: str):
+        """Re-pack source directory and refresh all running mounts in-place.
+
+        Unlike close()+open(), this does not unmount the FUSE filesystem.
+        Open file handles remain valid; subsequent reads see the updated
+        data.
+
+        Args:
+            sourcepath: Must match the sourcepath used in open(). Requiring
+                the caller to pass it again prevents accidentally refreshing
+                a mount with a forgotten or wrong source directory.
+        """
+        if sourcepath != self.sourcepath:
+            raise ValueError(
+                f"sourcepath mismatch: refresh called with {sourcepath!r} "
+                f"but mount was opened with {self.sourcepath!r}"
+            )
+        if not self._mounted or self.fuse_actors is None:
+            raise RuntimeError("no active mount to refresh; call open() first")
+        self._sync()
 
     def __enter__(self) -> "MountHandler":
         self.open()

--- a/python/tests/test_remotemount.py
+++ b/python/tests/test_remotemount.py
@@ -21,7 +21,10 @@ from collections.abc import Generator
 
 import pytest
 from isolate_in_subprocess import isolate_in_subprocess
-from monarch._rust_bindings.monarch_extension.chunked_fuse import mount_chunked_fuse
+from monarch._rust_bindings.monarch_extension.chunked_fuse import (
+    FuseMountHandle,
+    mount_chunked_fuse,
+)
 from monarch._rust_bindings.monarch_extension.fast_pack import (
     load_file_and_hash,
     pack_files_with_offsets,
@@ -654,7 +657,8 @@ def _fuse_mount(
     chunks: list[memoryview],
     chunk_size: int,
     mount_point: str,
-) -> Generator[object, None, None]:
+    # pyre-ignore[24]
+) -> Generator[FuseMountHandle, None, None]:
     """Mount a FUSE filesystem and unmount on exit for test isolation."""
     handle = mount_chunked_fuse(metadata, chunks, chunk_size, mount_point)
     yield handle
@@ -1002,6 +1006,355 @@ class TestFuseMount:
             with _fuse_mount(metadata2, [memoryview(content2)], len(content2), mnt):
                 with open(os.path.join(mnt, "g.txt"), "rb") as f:
                     assert f.read() == content2
+
+
+@pytest.mark.skipif(
+    not _fuse_available,
+    reason="FUSE not available (missing fusermount3, /dev/fuse, or permissions)",
+)
+class TestFuseRefresh:
+    """Tests for live FUSE refresh (atomic data swap without unmount)."""
+
+    def test_unchanged_file(self) -> None:
+        """File content identical before/after refresh — reads are correct."""
+        content = b"unchanged data here"
+        metadata: dict[str, object] = {
+            "/": {"attr": _dir_attr(), "children": ["f.txt"]},
+            "/f.txt": {
+                "attr": _file_attr(len(content)),
+                "global_offset": 0,
+                "file_len": len(content),
+            },
+        }
+        with (
+            tempfile.TemporaryDirectory() as mnt,
+            _fuse_mount(metadata, [memoryview(content)], len(content), mnt) as handle,
+        ):
+            with open(os.path.join(mnt, "f.txt"), "rb") as f:
+                assert f.read() == content
+            # Refresh with identical data.
+            handle.refresh(metadata, [memoryview(content)], len(content))
+            with open(os.path.join(mnt, "f.txt"), "rb") as f:
+                assert f.read() == content
+
+    def test_changed_file(self) -> None:
+        """File content changes — new reads see new data."""
+        v1 = b"version one"
+        meta1: dict[str, object] = {
+            "/": {"attr": _dir_attr(), "children": ["f.txt"]},
+            "/f.txt": {
+                "attr": _file_attr(len(v1)),
+                "global_offset": 0,
+                "file_len": len(v1),
+            },
+        }
+        with (
+            tempfile.TemporaryDirectory() as mnt,
+            _fuse_mount(meta1, [memoryview(v1)], len(v1), mnt) as handle,
+        ):
+            with open(os.path.join(mnt, "f.txt"), "rb") as f:
+                assert f.read() == v1
+            v2 = b"version two!!"
+            meta2: dict[str, object] = {
+                "/": {"attr": _dir_attr(), "children": ["f.txt"]},
+                "/f.txt": {
+                    "attr": _file_attr(len(v2)),
+                    "global_offset": 0,
+                    "file_len": len(v2),
+                },
+            }
+            handle.refresh(meta2, [memoryview(v2)], len(v2))
+            with open(os.path.join(mnt, "f.txt"), "rb") as f:
+                assert f.read() == v2
+
+    def test_added_file(self) -> None:
+        """New file appears after refresh."""
+        v1 = b"aaa"
+        meta1: dict[str, object] = {
+            "/": {"attr": _dir_attr(), "children": ["a.txt"]},
+            "/a.txt": {
+                "attr": _file_attr(3),
+                "global_offset": 0,
+                "file_len": 3,
+            },
+        }
+        with (
+            tempfile.TemporaryDirectory() as mnt,
+            _fuse_mount(meta1, [memoryview(v1)], 3, mnt) as handle,
+        ):
+            assert os.listdir(mnt) == ["a.txt"]
+            v2 = b"aaabbb"
+            meta2: dict[str, object] = {
+                "/": {"attr": _dir_attr(), "children": ["a.txt", "b.txt"]},
+                "/a.txt": {
+                    "attr": _file_attr(3),
+                    "global_offset": 0,
+                    "file_len": 3,
+                },
+                "/b.txt": {
+                    "attr": _file_attr(3),
+                    "global_offset": 3,
+                    "file_len": 3,
+                },
+            }
+            handle.refresh(meta2, [memoryview(v2)], len(v2))
+            assert sorted(os.listdir(mnt)) == ["a.txt", "b.txt"]
+            with open(os.path.join(mnt, "b.txt"), "rb") as f:
+                assert f.read() == b"bbb"
+
+    def test_deleted_file(self) -> None:
+        """File disappears after refresh."""
+        v1 = b"aaabbb"
+        meta1: dict[str, object] = {
+            "/": {"attr": _dir_attr(), "children": ["a.txt", "b.txt"]},
+            "/a.txt": {
+                "attr": _file_attr(3),
+                "global_offset": 0,
+                "file_len": 3,
+            },
+            "/b.txt": {
+                "attr": _file_attr(3),
+                "global_offset": 3,
+                "file_len": 3,
+            },
+        }
+        with (
+            tempfile.TemporaryDirectory() as mnt,
+            _fuse_mount(meta1, [memoryview(v1)], len(v1), mnt) as handle,
+        ):
+            assert sorted(os.listdir(mnt)) == ["a.txt", "b.txt"]
+            v2 = b"aaa"
+            meta2: dict[str, object] = {
+                "/": {"attr": _dir_attr(), "children": ["a.txt"]},
+                "/a.txt": {
+                    "attr": _file_attr(3),
+                    "global_offset": 0,
+                    "file_len": 3,
+                },
+            }
+            handle.refresh(meta2, [memoryview(v2)], 3)
+            assert os.listdir(mnt) == ["a.txt"]
+            with pytest.raises(FileNotFoundError):
+                open(os.path.join(mnt, "b.txt"), "rb")
+
+    def test_file_size_grows(self) -> None:
+        """File grows after refresh."""
+        v1 = b"small"
+        meta1: dict[str, object] = {
+            "/": {"attr": _dir_attr(), "children": ["f.bin"]},
+            "/f.bin": {
+                "attr": _file_attr(len(v1)),
+                "global_offset": 0,
+                "file_len": len(v1),
+            },
+        }
+        with (
+            tempfile.TemporaryDirectory() as mnt,
+            _fuse_mount(meta1, [memoryview(v1)], len(v1), mnt) as handle,
+        ):
+            assert os.stat(os.path.join(mnt, "f.bin")).st_size == 5
+            v2 = b"much larger content now"
+            meta2: dict[str, object] = {
+                "/": {"attr": _dir_attr(), "children": ["f.bin"]},
+                "/f.bin": {
+                    "attr": _file_attr(len(v2)),
+                    "global_offset": 0,
+                    "file_len": len(v2),
+                },
+            }
+            handle.refresh(meta2, [memoryview(v2)], len(v2))
+            with open(os.path.join(mnt, "f.bin"), "rb") as f:
+                assert f.read() == v2
+            assert os.stat(os.path.join(mnt, "f.bin")).st_size == len(v2)
+
+    def test_file_size_shrinks(self) -> None:
+        """File shrinks after refresh."""
+        v1 = b"large content here!!"
+        meta1: dict[str, object] = {
+            "/": {"attr": _dir_attr(), "children": ["f.bin"]},
+            "/f.bin": {
+                "attr": _file_attr(len(v1)),
+                "global_offset": 0,
+                "file_len": len(v1),
+            },
+        }
+        with (
+            tempfile.TemporaryDirectory() as mnt,
+            _fuse_mount(meta1, [memoryview(v1)], len(v1), mnt) as handle,
+        ):
+            assert os.stat(os.path.join(mnt, "f.bin")).st_size == len(v1)
+            v2 = b"tiny"
+            meta2: dict[str, object] = {
+                "/": {"attr": _dir_attr(), "children": ["f.bin"]},
+                "/f.bin": {
+                    "attr": _file_attr(len(v2)),
+                    "global_offset": 0,
+                    "file_len": len(v2),
+                },
+            }
+            handle.refresh(meta2, [memoryview(v2)], len(v2))
+            with open(os.path.join(mnt, "f.bin"), "rb") as f:
+                assert f.read() == v2
+            assert os.stat(os.path.join(mnt, "f.bin")).st_size == len(v2)
+
+    def test_sequential_read_unchanged_file_across_refresh(self) -> None:
+        """Read first half, refresh, read second half of an unchanged file."""
+        content = b"A" * 4096 + b"B" * 4096
+        metadata: dict[str, object] = {
+            "/": {"attr": _dir_attr(), "children": ["f.bin"]},
+            "/f.bin": {
+                "attr": _file_attr(len(content)),
+                "global_offset": 0,
+                "file_len": len(content),
+            },
+        }
+        with (
+            tempfile.TemporaryDirectory() as mnt,
+            _fuse_mount(metadata, [memoryview(content)], len(content), mnt) as handle,
+        ):
+            fh = open(os.path.join(mnt, "f.bin"), "rb")
+            first_half = fh.read(4096)
+            assert first_half == b"A" * 4096
+            # Refresh with same content.
+            handle.refresh(metadata, [memoryview(content)], len(content))
+            second_half = fh.read(4096)
+            assert second_half == b"B" * 4096
+            fh.close()
+
+    def test_defrag_offset_shift_unchanged_content(self) -> None:
+        """File's global_offset changes (defrag) but content is same.
+
+        global_offset is a FUSE implementation detail — the kernel never
+        sees it. Reads should return the correct file content regardless
+        of where the file sits in the packed buffer.
+        """
+        file_data = b"the file content"
+        # v1: file at offset 100 (preceded by 100 bytes of padding).
+        buf1 = b"\x00" * 100 + file_data
+        meta1: dict[str, object] = {
+            "/": {"attr": _dir_attr(), "children": ["f.bin"]},
+            "/f.bin": {
+                "attr": _file_attr(len(file_data)),
+                "global_offset": 100,
+                "file_len": len(file_data),
+            },
+        }
+        with (
+            tempfile.TemporaryDirectory() as mnt,
+            _fuse_mount(meta1, [memoryview(buf1)], len(buf1), mnt) as handle,
+        ):
+            with open(os.path.join(mnt, "f.bin"), "rb") as f:
+                assert f.read() == file_data
+            # v2: file at offset 0 (defragged, no padding).
+            buf2 = file_data
+            meta2: dict[str, object] = {
+                "/": {"attr": _dir_attr(), "children": ["f.bin"]},
+                "/f.bin": {
+                    "attr": _file_attr(len(file_data)),
+                    "global_offset": 0,
+                    "file_len": len(file_data),
+                },
+            }
+            handle.refresh(meta2, [memoryview(buf2)], len(buf2))
+            with open(os.path.join(mnt, "f.bin"), "rb") as f:
+                assert f.read() == file_data
+
+    def test_multiple_rapid_refreshes(self) -> None:
+        """Refresh several times rapidly, reads always see latest data."""
+
+        def meta_fn(n: str, sz: int) -> dict[str, object]:
+            return {
+                "/": {"attr": _dir_attr(), "children": [n]},
+                f"/{n}": {
+                    "attr": _file_attr(sz),
+                    "global_offset": 0,
+                    "file_len": sz,
+                },
+            }
+
+        content = b"v00"
+        with (
+            tempfile.TemporaryDirectory() as mnt,
+            _fuse_mount(meta_fn("f.txt", 3), [memoryview(content)], 3, mnt) as handle,
+        ):
+            for i in range(20):
+                new_content = f"v{i:02d}".encode()
+                handle.refresh(
+                    meta_fn("f.txt", len(new_content)),
+                    [memoryview(new_content)],
+                    len(new_content),
+                )
+                with open(os.path.join(mnt, "f.txt"), "rb") as f:
+                    assert f.read() == new_content
+
+    def test_many_files_one_changed(self) -> None:
+        """Many files, only one changes — unchanged files unaffected."""
+        num_files = 50
+        file_size = 64
+        data = os.urandom(num_files * file_size)
+        children = [f"f_{i:03d}.bin" for i in range(num_files)]
+        metadata: dict[str, object] = {
+            "/": {"attr": _dir_attr(), "children": children},
+        }
+        for i in range(num_files):
+            metadata[f"/f_{i:03d}.bin"] = {
+                "attr": _file_attr(file_size),
+                "global_offset": i * file_size,
+                "file_len": file_size,
+            }
+
+        with (
+            tempfile.TemporaryDirectory() as mnt,
+            _fuse_mount(metadata, [memoryview(data)], len(data), mnt) as handle,
+        ):
+            # Read all files.
+            for i in range(num_files):
+                with open(os.path.join(mnt, f"f_{i:03d}.bin"), "rb") as f:
+                    expected = data[i * file_size : (i + 1) * file_size]
+                    assert f.read() == expected
+
+            # Change only file 25.
+            new_data = bytearray(data)
+            new_content = os.urandom(file_size)
+            new_data[25 * file_size : 26 * file_size] = new_content
+            new_data = bytes(new_data)
+
+            handle.refresh(metadata, [memoryview(new_data)], len(new_data))
+
+            # All files should read correctly.
+            for i in range(num_files):
+                with open(os.path.join(mnt, f"f_{i:03d}.bin"), "rb") as f:
+                    expected = new_data[i * file_size : (i + 1) * file_size]
+                    assert f.read() == expected
+
+    def test_end_to_end_pack_refresh_read(self) -> None:
+        """Full round-trip: pack, mount, modify source, re-pack, refresh, read."""
+        with tempfile.TemporaryDirectory() as src:
+            with open(os.path.join(src, "data.txt"), "wb") as f:
+                f.write(b"original content")
+
+            meta, staging_mv, chunks, _hashes, _pi = pack_directory_chunked(src)
+
+            with (
+                tempfile.TemporaryDirectory() as mnt,
+                _fuse_mount(
+                    meta,
+                    chunks,
+                    len(bytes(chunks[0])) if chunks else 1,
+                    mnt,
+                ) as handle,
+            ):
+                with open(os.path.join(mnt, "data.txt"), "rb") as f:
+                    assert f.read() == b"original content"
+
+                with open(os.path.join(src, "data.txt"), "wb") as f:
+                    f.write(b"updated content!")
+                meta2, staging_mv2, chunks2, _h2, _pi2 = pack_directory_chunked(src)
+                chunk_size2 = len(bytes(chunks2[0])) if chunks2 else 1
+                handle.refresh(meta2, chunks2, chunk_size2)
+
+                with open(os.path.join(mnt, "data.txt"), "rb") as f:
+                    assert f.read() == b"updated content!"
 
 
 class TestClassifyWorkers:
@@ -1687,4 +2040,136 @@ def test_tls_incremental_partial() -> None:
             rm.open()
             with open(os.path.join(mnt, "config.json")) as f:
                 assert f.read() == '{"lr": 0.01, "epochs": 20}'
+            rm.close()
+
+
+@pytest.mark.skipif(not _fuse_available, reason="FUSE not available")
+# pyre-ignore[56]: Pyre can't infer pytest.mark.timeout decorator type
+@pytest.mark.timeout(60)
+@isolate_in_subprocess
+def test_actor_refresh() -> None:
+    """End-to-end: open with refreshable=True, modify source, refresh without unmounting."""
+    from monarch.actor import this_host
+    from monarch.remotemount import remotemount
+
+    with tempfile.TemporaryDirectory() as src:
+        path = os.path.join(src, "config.json")
+        with open(path, "w") as f:
+            f.write('{"lr": 0.001}')
+
+        with tempfile.TemporaryDirectory() as mnt:
+            host = this_host()
+            rm = remotemount(host, src, mnt, transfer_mode="actor")
+
+            rm.open()
+            with open(os.path.join(mnt, "config.json")) as f:
+                assert f.read() == '{"lr": 0.001}'
+
+            # Modify the source file.
+            with open(path, "w") as f:
+                f.write('{"lr": 0.01, "epochs": 20}')
+
+            # Refresh (no close/open cycle).
+            rm.refresh(src)
+            with open(os.path.join(mnt, "config.json")) as f:
+                assert f.read() == '{"lr": 0.01, "epochs": 20}'
+
+            rm.close()
+
+
+@pytest.mark.skipif(not _fuse_available, reason="FUSE not available")
+# pyre-ignore[56]: Pyre can't infer pytest.mark.timeout decorator type
+@pytest.mark.timeout(60)
+@isolate_in_subprocess
+def test_actor_refresh_with_open_handles() -> None:
+    """Refresh while file handles are open — reads see updated data."""
+    from monarch.actor import this_host
+    from monarch.remotemount import remotemount
+
+    with tempfile.TemporaryDirectory() as src:
+        path = os.path.join(src, "data.bin")
+        with open(path, "wb") as f:
+            f.write(b"AAAA")
+
+        with tempfile.TemporaryDirectory() as mnt:
+            host = this_host()
+            rm = remotemount(host, src, mnt, transfer_mode="actor")
+
+            rm.open()
+
+            # Open a file handle before refresh.
+            fh = open(os.path.join(mnt, "data.bin"), "rb")
+            assert fh.read() == b"AAAA"
+
+            # Modify source and refresh.
+            with open(path, "wb") as f:
+                f.write(b"BBBB")
+            rm.refresh(src)
+
+            # Re-read from existing handle — should see new data.
+            fh.seek(0)
+            assert fh.read() == b"BBBB"
+            fh.close()
+
+            rm.close()
+
+
+@pytest.mark.skipif(not _fuse_available, reason="FUSE not available")
+# pyre-ignore[56]: Pyre can't infer pytest.mark.timeout decorator type
+@pytest.mark.timeout(60)
+@isolate_in_subprocess
+def test_actor_refresh_no_change() -> None:
+    """Refresh with no source changes — should be a no-op."""
+    from monarch.actor import this_host
+    from monarch.remotemount import remotemount
+
+    with tempfile.TemporaryDirectory() as src:
+        with open(os.path.join(src, "f.txt"), "wb") as f:
+            f.write(b"unchanged")
+
+        with tempfile.TemporaryDirectory() as mnt:
+            host = this_host()
+            rm = remotemount(host, src, mnt, transfer_mode="actor")
+
+            rm.open()
+            with open(os.path.join(mnt, "f.txt"), "rb") as f:
+                assert f.read() == b"unchanged"
+
+            # Refresh without changes.
+            rm.refresh(src)
+            with open(os.path.join(mnt, "f.txt"), "rb") as f:
+                assert f.read() == b"unchanged"
+
+            rm.close()
+
+
+@pytest.mark.skipif(not _fuse_available, reason="FUSE not available")
+# pyre-ignore[56]: Pyre can't infer pytest.mark.timeout decorator type
+@pytest.mark.timeout(60)
+@isolate_in_subprocess
+def test_actor_refresh_add_file() -> None:
+    """Refresh after adding a new file to the source directory."""
+    from monarch.actor import this_host
+    from monarch.remotemount import remotemount
+
+    with tempfile.TemporaryDirectory() as src:
+        with open(os.path.join(src, "a.txt"), "wb") as f:
+            f.write(b"aaa")
+
+        with tempfile.TemporaryDirectory() as mnt:
+            host = this_host()
+            rm = remotemount(host, src, mnt, transfer_mode="actor")
+
+            rm.open()
+            assert os.listdir(mnt) == ["a.txt"]
+
+            # Add a new file and refresh.
+            with open(os.path.join(src, "b.txt"), "wb") as f:
+                f.write(b"bbb")
+            rm.refresh(src)
+
+            assert sorted(os.listdir(mnt)) == ["a.txt", "b.txt"]
+            with open(os.path.join(mnt, "b.txt"), "rb") as f:
+                assert f.read() == b"bbb"
+
             rm.close()


### PR DESCRIPTION
Summary:
Add MountHandler.refresh(sourcepath) for atomically updating FUSE mount
data while the filesystem stays mounted. Open file handles remain valid
and subsequent reads see the new data immediately.

## Walkthrough

**Rust (chunked_fuse.rs):** Extract FsData struct (metadata + chunks +
chunk_size) and wrap in Arc<RwLock<FsData>> shared between ChunkedFuseFs
and PyMountHandle. All FUSE methods acquire a read lock (non-blocking
with each other). PyMountHandle.refresh() acquires the write lock and
atomically swaps the data. TTL is set to zero so the kernel always
re-validates metadata after refresh.

**Rust (tls_sender.rs):** Fix pre-existing flake where tcp
shutdown(Write) failed with ENOTCONN when the receiver closed first.
This is benign (data already sent) — now ignored instead of fatal.

**Python (remotemount.py):** FUSEActor.mount() now mounts an empty FUSE
filesystem and calls _do_refresh() to populate it, sharing the
flush/cache/swap logic with FUSEActor.refresh_mount(). MountHandler uses
a shared _sync() method for open() and refresh() that packs the source
directory, diffs block hashes, transfers dirty blocks, then mounts or
refreshes. refresh(sourcepath) requires the caller to pass the source
path again to prevent accidentally refreshing with a forgotten path.

**Tests:** 5 FUSE unit tests (TestFuseRefresh) covering data refresh,
metadata refresh, open file handles across refresh, repeated refreshes,
and end-to-end pack+refresh+read. 4 integration tests with actors
covering refresh, open handles, no-change, and add-file scenarios.

**Benchmark:** bench_fuse_read.py measures FUSE read latency and
throughput vs tmpfs baseline.

Reviewed By: zdevito

Differential Revision: D98953121
