### PR TITLE
mesh_admin: replace stringly introspection refs internally with typed ids/time, keep HTTP API curl-friendly (#3334)

### DIFF
--- a/hyperactor/src/actor.rs
+++ b/hyperactor/src/actor.rs
@@ -1606,7 +1606,10 @@ mod tests {
             .unwrap();
         let payload = reply_rx.recv().await.unwrap();
 
-        assert_eq!(payload.identity, handle.actor_id().to_string());
+        assert_eq!(
+            payload.identity,
+            crate::introspect::IntrospectRef::Actor(handle.actor_id().clone())
+        );
         assert_valid_attrs(&payload);
         assert_has_attr(&payload, "status");
         assert_has_attr(&payload, "actor_type");
@@ -1779,7 +1782,12 @@ mod tests {
             .unwrap();
         let payload = reply_rx.recv().await.unwrap();
 
-        assert!(payload.identity.is_empty());
+        assert_eq!(
+            payload.identity,
+            crate::introspect::IntrospectRef::Actor(
+                test_proc_id("nonexistent").actor_id("child", 0)
+            )
+        );
         assert_error_code(&payload, "not_found");
 
         handle.drain_and_stop("test").unwrap();
@@ -1865,7 +1873,10 @@ mod tests {
             .unwrap();
         let child_payload = reply_rx.recv().await.unwrap();
 
-        assert_eq!(child_payload.identity, child_handle.actor_id().to_string(),);
+        assert_eq!(
+            child_payload.identity,
+            crate::introspect::IntrospectRef::Actor(child_handle.actor_id().clone()),
+        );
         // Verify it has actor attrs (status present).
         assert!(
             attrs_get(&child_payload.attrs, "status").is_some(),
@@ -1873,7 +1884,9 @@ mod tests {
         );
         assert_eq!(
             child_payload.parent,
-            Some(parent_handle.actor_id().to_string()),
+            Some(crate::introspect::IntrospectRef::Actor(
+                parent_handle.actor_id().clone()
+            )),
         );
 
         // Query the parent — children should include the child.
@@ -1893,7 +1906,9 @@ mod tests {
         assert!(
             parent_payload
                 .children
-                .contains(&child_handle.actor_id().to_string()),
+                .contains(&crate::introspect::IntrospectRef::Actor(
+                    child_handle.actor_id().clone()
+                )),
         );
 
         child_handle.drain_and_stop("test").unwrap();
@@ -2093,10 +2108,15 @@ mod tests {
         assert!(handle.cell().query_child(&test_ref).is_none());
 
         // Register a callback.
-        handle
-            .cell()
-            .set_query_child_handler(|child_ref| IntrospectResult {
-                identity: child_ref.to_string(),
+        handle.cell().set_query_child_handler(|child_ref| {
+            use crate::introspect::IntrospectRef;
+            let identity = match &child_ref {
+                reference::Reference::Proc(id) => IntrospectRef::Proc(id.clone()),
+                reference::Reference::Actor(id) => IntrospectRef::Actor(id.clone()),
+                reference::Reference::Port(id) => IntrospectRef::Actor(id.actor_id().clone()),
+            };
+            IntrospectResult {
+                identity,
                 attrs: serde_json::json!({
                     "proc_name": "test_proc",
                     "num_actors": 42,
@@ -2104,15 +2124,19 @@ mod tests {
                 .to_string(),
                 children: Vec::new(),
                 parent: None,
-                as_of: humantime::format_rfc3339_millis(std::time::SystemTime::now()).to_string(),
-            });
+                as_of: std::time::SystemTime::now(),
+            }
+        });
 
         // Now query_child returns the callback's response.
         let payload = handle
             .cell()
             .query_child(&test_ref)
             .expect("callback should produce a payload");
-        assert_eq!(payload.identity, test_ref.to_string());
+        assert_eq!(
+            payload.identity,
+            crate::introspect::IntrospectRef::Actor(test_proc_id("test").actor_id("child", 0))
+        );
         let attrs: serde_json::Value =
             serde_json::from_str(&payload.attrs).expect("attrs must be valid JSON");
         assert_eq!(
@@ -2279,7 +2303,10 @@ mod tests {
 
         // CI-1: introspectable_instance reports status "client"
         // and actor_type "()" (the unit type).
-        assert_eq!(payload.identity, actor_id.to_string());
+        assert_eq!(
+            payload.identity,
+            crate::introspect::IntrospectRef::Actor(actor_id.clone())
+        );
         assert_status(&payload, "client");
         let actor_type = attrs_get(&payload.attrs, "actor_type")
             .and_then(|v| v.as_str().map(String::from))

--- a/hyperactor/src/introspect.rs
+++ b/hyperactor/src/introspect.rs
@@ -120,6 +120,7 @@
 //!   affect successful decode outcome.
 
 use std::fmt;
+use std::str::FromStr;
 use std::time::SystemTime;
 
 use hyperactor_config::Attrs;
@@ -132,6 +133,58 @@ use typeuri::Named;
 
 use crate::InstanceCell;
 use crate::reference;
+
+/// Typed reference to an introspectable entity.
+///
+/// This is the generic hyperactor layer — it knows about procs and
+/// actors, not mesh-specific concepts like root or host.
+///
+/// Port references are intentionally excluded — introspection
+/// does not address individual ports.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, Named)]
+pub enum IntrospectRef {
+    /// A proc reference.
+    Proc(reference::ProcId),
+    /// An actor reference.
+    Actor(reference::ActorId),
+}
+hyperactor_config::impl_attrvalue!(IntrospectRef);
+
+impl fmt::Display for IntrospectRef {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Proc(id) => fmt::Display::fmt(id, f),
+            Self::Actor(id) => fmt::Display::fmt(id, f),
+        }
+    }
+}
+
+impl FromStr for IntrospectRef {
+    type Err = reference::ReferenceParsingError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let r: reference::Reference = s.parse()?;
+        match r {
+            reference::Reference::Proc(id) => Ok(Self::Proc(id)),
+            reference::Reference::Actor(id) => Ok(Self::Actor(id)),
+            reference::Reference::Port(_) => Err(reference::ReferenceParsingError::WrongType(
+                "port references are not valid introspection references".to_string(),
+            )),
+        }
+    }
+}
+
+impl From<reference::ProcId> for IntrospectRef {
+    fn from(id: reference::ProcId) -> Self {
+        Self::Proc(id)
+    }
+}
+
+impl From<reference::ActorId> for IntrospectRef {
+    fn from(id: reference::ActorId) -> Self {
+        Self::Actor(id)
+    }
+}
 
 // Introspection attr keys — actor-runtime concepts.
 //
@@ -230,14 +283,14 @@ declare_attrs! {
     })
     pub attr IS_SYSTEM: bool = false;
 
-    /// Child reference strings for tree navigation. Published by
+    /// Child references for tree navigation. Published by
     /// infrastructure actors (HostMeshAgent, ProcAgent) so the
     /// Entity view can return children without parsing mesh-layer keys.
     @meta(INTROSPECT = IntrospectAttr {
         name: "children".into(),
-        desc: "Child reference strings for tree navigation".into(),
+        desc: "Child references for tree navigation".into(),
     })
-    pub attr CHILDREN: Vec<String>;
+    pub attr CHILDREN: Vec<IntrospectRef>;
 
     /// Machine-readable error code for error nodes.
     @meta(INTROSPECT = IntrospectAttr {
@@ -277,7 +330,7 @@ declare_attrs! {
         name: "failure_root_cause_actor".into(),
         desc: "Actor that caused the failure (root cause)".into(),
     })
-    pub attr FAILURE_ROOT_CAUSE_ACTOR: String;
+    pub attr FAILURE_ROOT_CAUSE_ACTOR: reference::ActorId;
 
     /// Name of root cause actor.
     @meta(INTROSPECT = IntrospectAttr {
@@ -350,8 +403,8 @@ impl AttrsViewError {
 pub struct FailureAttrs {
     /// Error message describing the failure.
     pub error_message: String,
-    /// Actor ID of the root-cause actor.
-    pub root_cause_actor: String,
+    /// Actor that caused the failure (root cause).
+    pub root_cause_actor: reference::ActorId,
     /// Display name of the root-cause actor, if available.
     pub root_cause_name: Option<String>,
     /// When the failure occurred.
@@ -527,16 +580,16 @@ impl ActorAttrsView {
 /// (with `NodeProperties`) lives in `hyperactor_mesh::introspect`.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Named)]
 pub struct IntrospectResult {
-    /// Canonical reference string for this node.
-    pub identity: String,
+    /// Reference identifying this node.
+    pub identity: IntrospectRef,
     /// JSON-serialized `Attrs` bag containing introspection attributes.
     pub attrs: String,
-    /// Reference strings the client can GET next to descend the tree.
-    pub children: Vec<String>,
-    /// Parent node reference for upward navigation.
-    pub parent: Option<String>,
-    /// ISO 8601 timestamp indicating when this data was captured.
-    pub as_of: String,
+    /// Child references the client can follow to descend the tree.
+    pub children: Vec<IntrospectRef>,
+    /// Parent reference for upward navigation.
+    pub parent: Option<IntrospectRef>,
+    /// When this data was captured.
+    pub as_of: SystemTime,
 }
 wirevalue::register_type!(IntrospectResult);
 
@@ -630,9 +683,9 @@ pub fn format_timestamp(time: SystemTime) -> String {
 /// Failure fields extracted from a supervision event.
 struct FailureSnapshot {
     error_message: String,
-    root_cause_actor: String,
+    root_cause_actor: reference::ActorId,
     root_cause_name: Option<String>,
-    occurred_at: String,
+    occurred_at: SystemTime,
     is_propagated: bool,
 }
 
@@ -688,9 +741,7 @@ fn build_actor_attrs(cell: &crate::InstanceCell, snap: &ActorSnapshot) -> String
         if let Some(name) = &fi.root_cause_name {
             attrs.set(FAILURE_ROOT_CAUSE_NAME, name.clone());
         }
-        if let Ok(t) = humantime::parse_rfc3339(&fi.occurred_at) {
-            attrs.set(FAILURE_OCCURRED_AT, t);
-        }
+        attrs.set(FAILURE_OCCURRED_AT, fi.occurred_at);
         attrs.set(FAILURE_IS_PROPAGATED, fi.is_propagated);
     }
     // IA-4: failure attrs absent when not failed — guaranteed by
@@ -709,10 +760,10 @@ pub fn live_actor_payload(cell: &InstanceCell) -> IntrospectResult {
     let status = cell.status().borrow().clone();
     let last_handler = cell.last_message_handler();
 
-    let children: Vec<String> = cell
+    let children: Vec<IntrospectRef> = cell
         .child_actor_ids()
         .into_iter()
-        .map(|id| id.to_string())
+        .map(IntrospectRef::Actor)
         .collect();
 
     let events = cell.recording().tail();
@@ -734,7 +785,9 @@ pub fn live_actor_payload(cell: &InstanceCell) -> IntrospectResult {
         serde_json::to_string(&flight_recorder_events).ok()
     };
 
-    let supervisor = cell.parent().map(|p| p.actor_id().to_string());
+    let supervisor = cell
+        .parent()
+        .map(|p| IntrospectRef::Actor(p.actor_id().clone()));
 
     // FI-3: failure_info is computed from the same status value as
     // actor_status, ensuring they agree on whether the actor failed.
@@ -743,9 +796,9 @@ pub fn live_actor_payload(cell: &InstanceCell) -> IntrospectResult {
             let root = event.actually_failing_actor()?;
             Some(FailureSnapshot {
                 error_message: event.actor_status.to_string(),
-                root_cause_actor: root.actor_id.to_string(),
+                root_cause_actor: root.actor_id.clone(),
                 root_cause_name: root.display_name.clone(),
-                occurred_at: format_timestamp(event.occurred_at),
+                occurred_at: event.occurred_at,
                 is_propagated: root.actor_id != *actor_id,
             })
         })
@@ -764,11 +817,11 @@ pub fn live_actor_payload(cell: &InstanceCell) -> IntrospectResult {
     let attrs = build_actor_attrs(cell, &snap);
 
     IntrospectResult {
-        identity: actor_id.to_string(),
+        identity: IntrospectRef::Actor(actor_id.clone()),
         attrs,
         children,
         parent: supervisor,
-        as_of: format_timestamp(std::time::SystemTime::now()),
+        as_of: SystemTime::now(),
     }
 }
 
@@ -781,7 +834,7 @@ pub fn live_actor_payload(cell: &InstanceCell) -> IntrospectResult {
 /// # Invariants exercised
 ///
 /// Exercises S1, S2, S4, S5, S6, S11 (see module doc).
-pub async fn serve_introspect(
+pub(crate) async fn serve_introspect(
     cell: InstanceCell,
     mailbox: crate::mailbox::Mailbox,
     mut receiver: crate::mailbox::PortReceiver<IntrospectMessage>,
@@ -829,14 +882,16 @@ pub async fn serve_introspect(
                         Some(published) => {
                             let attrs_json =
                                 serde_json::to_string(&published).unwrap_or_else(|_| "{}".into());
-                            let children: Vec<String> =
+                            let children: Vec<IntrospectRef> =
                                 published.get(CHILDREN).cloned().unwrap_or_default();
                             IntrospectResult {
-                                identity: cell.actor_id().to_string(),
+                                identity: IntrospectRef::Actor(cell.actor_id().clone()),
                                 attrs: attrs_json,
                                 children,
-                                parent: cell.parent().map(|p| p.actor_id().to_string()),
-                                as_of: format_timestamp(std::time::SystemTime::now()),
+                                parent: cell
+                                    .parent()
+                                    .map(|p| IntrospectRef::Actor(p.actor_id().clone())),
+                                as_of: SystemTime::now(),
                             }
                         }
                         None => live_actor_payload(&cell),
@@ -857,14 +912,21 @@ pub async fn serve_introspect(
                         ERROR_MESSAGE,
                         format!("child {} not found (no callback registered)", child_ref),
                     );
+                    // Use the queried child_ref as identity for the error node.
+                    let identity = match &child_ref {
+                        reference::Reference::Proc(id) => IntrospectRef::Proc(id.clone()),
+                        reference::Reference::Actor(id) => IntrospectRef::Actor(id.clone()),
+                        reference::Reference::Port(id) => {
+                            IntrospectRef::Actor(id.actor_id().clone())
+                        }
+                    };
                     IntrospectResult {
-                        identity: String::new(),
+                        identity,
                         attrs: serde_json::to_string(&error_attrs)
                             .unwrap_or_else(|_| "{}".to_string()),
                         children: Vec::new(),
                         parent: None,
-                        as_of: humantime::format_rfc3339_millis(std::time::SystemTime::now())
-                            .to_string(),
+                        as_of: SystemTime::now(),
                     }
                 });
                 mailbox.serialize_and_send_once(
@@ -992,12 +1054,16 @@ mod tests {
         attrs
     }
 
+    fn test_actor_id(proc_name: &str, actor_name: &str, pid: usize) -> crate::reference::ActorId {
+        ProcId::with_name(ChannelAddr::Local(0), proc_name).actor_id(actor_name, pid)
+    }
+
     fn failed_actor_attrs() -> Attrs {
         let mut attrs = running_actor_attrs();
         attrs.set(STATUS, "failed".to_string());
         attrs.set(STATUS_REASON, "something broke".to_string());
         attrs.set(FAILURE_ERROR_MESSAGE, "boom".to_string());
-        attrs.set(FAILURE_ROOT_CAUSE_ACTOR, "other[0]".to_string());
+        attrs.set(FAILURE_ROOT_CAUSE_ACTOR, test_actor_id("proc", "other", 0));
         attrs.set(FAILURE_ROOT_CAUSE_NAME, "OtherActor".to_string());
         attrs.set(FAILURE_OCCURRED_AT, SystemTime::UNIX_EPOCH);
         attrs.set(FAILURE_IS_PROPAGATED, true);
@@ -1085,7 +1151,7 @@ mod tests {
     fn test_actor_view_ia4_rejects_failure_attrs_on_running() {
         let mut attrs = running_actor_attrs();
         attrs.set(FAILURE_ERROR_MESSAGE, "boom".to_string());
-        attrs.set(FAILURE_ROOT_CAUSE_ACTOR, "x[0]".to_string());
+        attrs.set(FAILURE_ROOT_CAUSE_ACTOR, test_actor_id("proc", "x", 0));
         attrs.set(FAILURE_OCCURRED_AT, SystemTime::UNIX_EPOCH);
         let err = ActorAttrsView::from_attrs(&attrs).unwrap_err();
         assert!(matches!(
@@ -1145,20 +1211,20 @@ mod tests {
         );
 
         // -- reproduce FailureSnapshot construction (same logic as
-        // live_actor_payload lines 734-743) --
+        // live_actor_payload) --
         let root = parent_event
             .actually_failing_actor()
             .expect("parent_event is a failure");
         let snap = FailureSnapshot {
             error_message: parent_event.actor_status.to_string(),
-            root_cause_actor: root.actor_id.to_string(),
+            root_cause_actor: root.actor_id.clone(),
             root_cause_name: root.display_name.clone(),
-            occurred_at: format_timestamp(parent_event.occurred_at),
+            occurred_at: parent_event.occurred_at,
             is_propagated: root.actor_id != parent_id,
         };
 
         // FI-7: failure_root_cause_actor is the stopped child.
-        assert_eq!(snap.root_cause_actor, child_id.to_string());
+        assert_eq!(snap.root_cause_actor, child_id);
         // FI-8: failure_is_propagated is true.
         assert!(snap.is_propagated);
         // root_cause_name pinned before round-trip.
@@ -1171,16 +1237,14 @@ mod tests {
         if let Some(name) = &snap.root_cause_name {
             attrs.set(FAILURE_ROOT_CAUSE_NAME, name.clone());
         }
-        if let Ok(t) = humantime::parse_rfc3339(&snap.occurred_at) {
-            attrs.set(FAILURE_OCCURRED_AT, t);
-        }
+        attrs.set(FAILURE_OCCURRED_AT, snap.occurred_at);
         attrs.set(FAILURE_IS_PROPAGATED, snap.is_propagated);
 
         let view = ActorAttrsView::from_attrs(&attrs).unwrap();
         assert_eq!(view.status, "failed");
         let fi = view.failure.as_ref().expect("failure_info must be present");
         // FI-7: failure_root_cause_actor survives attrs round-trip.
-        assert_eq!(fi.root_cause_actor, child_id.to_string());
+        assert_eq!(fi.root_cause_actor, child_id);
         // FI-8: failure_is_propagated survives attrs round-trip.
         assert!(fi.is_propagated);
         // root_cause_name also survives.

--- a/hyperactor/src/proc.rs
+++ b/hyperactor/src/proc.rs
@@ -467,11 +467,9 @@ impl Proc {
         let handle = ActorHandle::new(instance.inner.cell.clone(), instance.inner.ports.clone());
         instance.change_status(ActorStatus::Client);
 
-        let introspect_cell = instance.inner.cell.clone();
-        let introspect_mailbox = instance.inner.mailbox.clone();
         tokio::spawn(crate::introspect::serve_introspect(
-            introspect_cell,
-            introspect_mailbox,
+            instance.inner.cell.clone(),
+            instance.inner.mailbox.clone(),
             receivers.introspect,
         ));
 
@@ -1554,11 +1552,9 @@ impl<A: Actor> Instance<A> {
         // Spawn the introspect task — a separate tokio task that
         // reads InstanceCell directly and replies via the actor's
         // Mailbox. The actor loop never sees IntrospectMessage.
-        let introspect_cell = self.inner.cell.clone();
-        let introspect_mailbox = self.inner.mailbox.clone();
         tokio::spawn(crate::introspect::serve_introspect(
-            introspect_cell,
-            introspect_mailbox,
+            self.inner.cell.clone(),
+            self.inner.mailbox.clone(),
             receivers.introspect,
         ));
 
@@ -4099,7 +4095,7 @@ mod tests {
         let root_cause = attrs
             .get(crate::introspect::FAILURE_ROOT_CAUSE_ACTOR)
             .expect("must have root_cause_actor");
-        assert_eq!(root_cause, &actor_id.to_string());
+        assert_eq!(root_cause, &actor_id);
         assert_eq!(
             attrs.get(crate::introspect::FAILURE_IS_PROPAGATED),
             Some(&false)
@@ -4139,7 +4135,7 @@ mod tests {
         let root_cause = attrs
             .get(crate::introspect::FAILURE_ROOT_CAUSE_ACTOR)
             .expect("propagated failure must have root_cause_actor");
-        assert_eq!(root_cause, &child_id.to_string());
+        assert_eq!(root_cause, &child_id);
         assert_eq!(
             attrs.get(crate::introspect::FAILURE_IS_PROPAGATED),
             Some(&true)

--- a/hyperactor_mesh/src/host_mesh/host_agent.rs
+++ b/hyperactor_mesh/src/host_mesh/host_agent.rs
@@ -18,7 +18,6 @@ use std::collections::HashMap;
 use std::collections::HashSet;
 use std::fmt;
 use std::pin::Pin;
-use std::str::FromStr;
 use std::sync::OnceLock;
 
 use async_trait::async_trait;
@@ -60,40 +59,6 @@ use crate::pyspy::PySpyDump;
 use crate::pyspy::PySpyWorker;
 use crate::resource;
 use crate::resource::ProcSpec;
-
-/// Typed host-node identifier for mesh admin navigation.
-///
-/// Wraps an [`ActorId`] (the `HostAgent`'s actor id) and
-/// serializes with a `host:` prefix so that the admin resolver can
-/// distinguish host-level references from plain actor references.
-/// The same `HostAgent` `ActorId` can appear as both a host
-/// (from root's children) and as an actor (from a proc's children);
-/// `HostId` makes the host case unambiguous.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct HostId(pub hyperactor_reference::ActorId);
-
-/// Prefix used by [`HostId`] for display/parse round-tripping.
-const HOST_ID_PREFIX: &str = "host:";
-
-impl fmt::Display for HostId {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{HOST_ID_PREFIX}{}", self.0)
-    }
-}
-
-impl FromStr for HostId {
-    type Err = anyhow::Error;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let inner = s
-            .strip_prefix(HOST_ID_PREFIX)
-            .ok_or_else(|| anyhow::anyhow!("not a host reference: {}", s))?;
-        let actor_id: hyperactor_reference::ActorId = inner
-            .parse()
-            .map_err(|e| anyhow::anyhow!("invalid actor id in host ref '{}': {}", s, e))?;
-        Ok(HostId(actor_id))
-    }
-}
 
 pub(crate) type ProcManagerSpawnFuture =
     Pin<Box<dyn Future<Output = anyhow::Result<ActorHandle<ProcAgent>>> + Send>>;
@@ -422,21 +387,23 @@ impl HostAgent {
         };
 
         let addr = host.addr().to_string();
-        let mut children = Vec::new();
-        let system_children = Vec::new();
+        let mut children: Vec<hyperactor::introspect::IntrospectRef> = Vec::new();
+        let system_children: Vec<crate::introspect::NodeRef> = Vec::new();
 
         // Procs are not system — only actors are. Both service and
         // local appear as regular children; 's' in the TUI toggles
         // actor visibility, not proc visibility.
-        let sys_ref = host.system_proc().proc_id().to_string();
-        let local_ref = host.local_proc().proc_id().to_string();
-        children.push(sys_ref);
-        children.push(local_ref);
+        children.push(hyperactor::introspect::IntrospectRef::Proc(
+            host.system_proc().proc_id().clone(),
+        ));
+        children.push(hyperactor::introspect::IntrospectRef::Proc(
+            host.local_proc().proc_id().clone(),
+        ));
 
         // User procs.
         for state in self.created.values() {
             if let Ok((proc_id, _agent_ref)) = &state.created {
-                children.push(proc_id.to_string());
+                children.push(hyperactor::introspect::IntrospectRef::Proc(proc_id.clone()));
             }
         }
 
@@ -518,16 +485,15 @@ impl Actor for HostAgent {
                     // actors) may appear but are harmless — the TUI
                     // handles "not found" gracefully.
                     let all_keys = proc.all_instance_keys();
-                    let mut actors = Vec::with_capacity(all_keys.len());
-                    let mut system_actors = Vec::new();
+                    let mut actors: Vec<hyperactor::introspect::IntrospectRef> =
+                        Vec::with_capacity(all_keys.len());
+                    let mut system_actors: Vec<crate::introspect::NodeRef> = Vec::new();
                     for id in all_keys {
-                        let ref_str = id.to_string();
                         if proc.get_instance(&id).is_some_and(|cell| cell.is_system()) {
-                            system_actors.push(ref_str.clone());
+                            system_actors.push(crate::introspect::NodeRef::Actor(id.clone()));
                         }
-                        actors.push(ref_str);
+                        actors.push(hyperactor::introspect::IntrospectRef::Actor(id));
                     }
-                    // Build attrs for this proc node.
                     let mut attrs = hyperactor_config::Attrs::new();
                     attrs.set(crate::introspect::NODE_TYPE, "proc".to_string());
                     attrs.set(crate::introspect::PROC_NAME, label.to_string());
@@ -537,12 +503,15 @@ impl Actor for HostAgent {
                         serde_json::to_string(&attrs).unwrap_or_else(|_| "{}".to_string());
 
                     IntrospectResult {
-                        identity: proc.proc_id().to_string(),
+                        identity: hyperactor::introspect::IntrospectRef::Proc(
+                            proc.proc_id().clone(),
+                        ),
                         attrs: attrs_json,
                         children: actors,
-                        parent: Some(HostId(self_id.clone()).to_string()),
-                        as_of: humantime::format_rfc3339_millis(std::time::SystemTime::now())
-                            .to_string(),
+                        parent: Some(hyperactor::introspect::IntrospectRef::Actor(
+                            self_id.clone(),
+                        )),
+                        as_of: std::time::SystemTime::now(),
                     }
                 }
                 None => {
@@ -552,14 +521,24 @@ impl Actor for HostAgent {
                         hyperactor::introspect::ERROR_MESSAGE,
                         format!("child {} not found", child_ref),
                     );
+                    let identity = match child_ref {
+                        hyperactor::reference::Reference::Proc(id) => {
+                            hyperactor::introspect::IntrospectRef::Proc(id.clone())
+                        }
+                        hyperactor::reference::Reference::Actor(id) => {
+                            hyperactor::introspect::IntrospectRef::Actor(id.clone())
+                        }
+                        hyperactor::reference::Reference::Port(id) => {
+                            hyperactor::introspect::IntrospectRef::Actor(id.actor_id().clone())
+                        }
+                    };
                     IntrospectResult {
-                        identity: String::new(),
+                        identity,
                         attrs: serde_json::to_string(&error_attrs)
                             .unwrap_or_else(|_| "{}".to_string()),
                         children: Vec::new(),
                         parent: None,
-                        as_of: humantime::format_rfc3339_millis(std::time::SystemTime::now())
-                            .to_string(),
+                        as_of: std::time::SystemTime::now(),
                     }
                 }
             }

--- a/hyperactor_mesh/src/introspect.rs
+++ b/hyperactor_mesh/src/introspect.rs
@@ -25,6 +25,23 @@
 //!   `test_introspect_short_names_are_globally_unique` in
 //!   `hyperactor::introspect` (cross-crate).
 //!
+//! ## HTTP boundary invariants (HB-*)
+//!
+//! - **HB-1 (typed-internal, string-external):** `NodeRef`,
+//!   `ActorId`, `ProcId`, and `SystemTime` are typed Rust values
+//!   internally. At the HTTP JSON boundary they are serialized as
+//!   opaque canonical strings for client round-tripping and curl
+//!   usability. Conversion happens via explicit `serde` adapters
+//!   on `NodePayload`, `NodeProperties`, and `FailureInfo`.
+//! - **HB-2 (round-trip):** The string form used at the HTTP
+//!   boundary is canonical and round-trips through the internal
+//!   typed parser (`NodeRef::from_str`, `ActorId::from_str`,
+//!   `humantime::parse_rfc3339`).
+//! - **HB-3 (schema-honesty):** `#[schemars(with = "String")]`
+//!   on HTTP-boundary fields reflects the actual serde output
+//!   (string), not the Rust type. This is not a disguise — the
+//!   serde adapters genuinely emit strings.
+//!
 //! ## Attrs invariants (IA-*)
 //!
 //! These govern how `IntrospectResult.attrs` is built in
@@ -189,6 +206,7 @@ use hyperactor_config::Attrs;
 use hyperactor_config::INTROSPECT;
 use hyperactor_config::IntrospectAttr;
 use hyperactor_config::declare_attrs;
+use schemars::JsonSchema;
 
 // See MK-1, MK-2, IA-1..IA-5 in module doc.
 declare_attrs! {
@@ -232,14 +250,14 @@ declare_attrs! {
         name: "system_children".into(),
         desc: "References of system/infrastructure children".into(),
     })
-    pub attr SYSTEM_CHILDREN: Vec<String>;
+    pub attr SYSTEM_CHILDREN: Vec<NodeRef>;
 
     /// References of stopped children (proc only).
     @meta(INTROSPECT = IntrospectAttr {
         name: "stopped_children".into(),
         desc: "References of stopped children".into(),
     })
-    pub attr STOPPED_CHILDREN: Vec<String>;
+    pub attr STOPPED_CHILDREN: Vec<NodeRef>;
 
     /// Cap on stopped children retention.
     @meta(INTROSPECT = IntrospectAttr {
@@ -292,9 +310,9 @@ use hyperactor::introspect::AttrsViewError;
 #[derive(Debug, Clone, PartialEq)]
 pub struct RootAttrsView {
     pub num_hosts: usize,
-    pub started_at: std::time::SystemTime,
+    pub started_at: SystemTime,
     pub started_by: String,
-    pub system_children: Vec<String>,
+    pub system_children: Vec<NodeRef>,
 }
 
 impl RootAttrsView {
@@ -336,7 +354,7 @@ impl RootAttrsView {
 pub struct HostAttrsView {
     pub addr: String,
     pub num_procs: usize,
-    pub system_children: Vec<String>,
+    pub system_children: Vec<NodeRef>,
 }
 
 impl HostAttrsView {
@@ -373,8 +391,8 @@ impl HostAttrsView {
 pub struct ProcAttrsView {
     pub proc_name: String,
     pub num_actors: usize,
-    pub system_children: Vec<String>,
-    pub stopped_children: Vec<String>,
+    pub system_children: Vec<NodeRef>,
+    pub stopped_children: Vec<NodeRef>,
     pub stopped_retention_cap: usize,
     pub is_poisoned: bool,
     pub failed_actor_count: usize,
@@ -465,15 +483,210 @@ impl ErrorAttrsView {
 }
 
 // --- API / presentation types ---
-//
-// These types define the HTTP response shape for
-// GET /v1/{reference}. Derived from internal attrs at the
-// mesh boundary. Shared with the TUI.
 
-use schemars::JsonSchema;
+use std::fmt;
+use std::str::FromStr;
+use std::time::SystemTime;
+
 use serde::Deserialize;
 use serde::Serialize;
 use typeuri::Named;
+
+/// Typed reference to a node in the mesh-admin navigation tree.
+///
+/// Extends `IntrospectRef` with mesh-only concepts (`Root`, `Host`).
+/// hyperactor does not know about these variants.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, Named)]
+pub enum NodeRef {
+    /// Synthetic mesh root node.
+    /// Serializes as lowercase `"root"` to match the HTTP path convention.
+    #[serde(rename = "root")]
+    Root,
+    /// A host in the mesh, identified by its `HostAgent` actor ID.
+    Host(hyperactor::reference::ActorId),
+    /// A proc running on a host.
+    Proc(hyperactor::reference::ProcId),
+    /// An actor instance within a proc.
+    Actor(hyperactor::reference::ActorId),
+}
+
+hyperactor_config::impl_attrvalue!(NodeRef);
+
+impl fmt::Display for NodeRef {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Root => write!(f, "root"),
+            Self::Host(id) => write!(f, "host:{}", id),
+            Self::Proc(id) => fmt::Display::fmt(id, f),
+            Self::Actor(id) => fmt::Display::fmt(id, f),
+        }
+    }
+}
+
+/// Error parsing a `NodeRef` from a string.
+#[derive(Debug, thiserror::Error)]
+pub enum NodeRefParseError {
+    #[error("empty reference string")]
+    Empty,
+    #[error("invalid host reference: {0}")]
+    InvalidHost(hyperactor::reference::ReferenceParsingError),
+    #[error("port references are not valid node references")]
+    PortNotAllowed,
+    #[error(transparent)]
+    Reference(#[from] hyperactor::reference::ReferenceParsingError),
+}
+
+impl FromStr for NodeRef {
+    type Err = NodeRefParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if s.is_empty() {
+            return Err(NodeRefParseError::Empty);
+        }
+        if s == "root" {
+            return Ok(Self::Root);
+        }
+        if let Some(rest) = s.strip_prefix("host:") {
+            let actor_id: hyperactor::reference::ActorId =
+                rest.parse().map_err(NodeRefParseError::InvalidHost)?;
+            return Ok(Self::Host(actor_id));
+        }
+        let r: hyperactor::reference::Reference = s.parse()?;
+        match r {
+            hyperactor::reference::Reference::Proc(id) => Ok(Self::Proc(id)),
+            hyperactor::reference::Reference::Actor(id) => Ok(Self::Actor(id)),
+            hyperactor::reference::Reference::Port(_) => Err(NodeRefParseError::PortNotAllowed),
+        }
+    }
+}
+
+impl From<hyperactor::introspect::IntrospectRef> for NodeRef {
+    fn from(r: hyperactor::introspect::IntrospectRef) -> Self {
+        match r {
+            hyperactor::introspect::IntrospectRef::Proc(id) => Self::Proc(id),
+            hyperactor::introspect::IntrospectRef::Actor(id) => Self::Actor(id),
+        }
+    }
+}
+
+/// Serde helper: serialize `ActorId` as its Display string.
+mod actorid_serde {
+    use hyperactor::reference::ActorId;
+    use serde::Deserialize;
+
+    pub fn serialize<S: serde::Serializer>(v: &ActorId, s: S) -> Result<S::Ok, S::Error> {
+        s.serialize_str(&v.to_string())
+    }
+
+    pub fn deserialize<'de, D: serde::Deserializer<'de>>(d: D) -> Result<ActorId, D::Error> {
+        let s = String::deserialize(d)?;
+        s.parse().map_err(serde::de::Error::custom)
+    }
+}
+
+/// Serde helper: serialize `SystemTime` as ISO 8601 string.
+mod systemtime_serde {
+    use std::time::SystemTime;
+
+    use serde::Deserialize;
+
+    pub fn serialize<S: serde::Serializer>(v: &SystemTime, s: S) -> Result<S::Ok, S::Error> {
+        s.serialize_str(&humantime::format_rfc3339_millis(*v).to_string())
+    }
+
+    pub fn deserialize<'de, D: serde::Deserializer<'de>>(d: D) -> Result<SystemTime, D::Error> {
+        let s = String::deserialize(d)?;
+        humantime::parse_rfc3339(&s).map_err(serde::de::Error::custom)
+    }
+
+    pub mod option {
+        use std::time::SystemTime;
+
+        use serde::Deserialize;
+
+        pub fn serialize<S: serde::Serializer>(
+            v: &Option<SystemTime>,
+            s: S,
+        ) -> Result<S::Ok, S::Error> {
+            match v {
+                Some(t) => s.serialize_some(&humantime::format_rfc3339_millis(*t).to_string()),
+                None => s.serialize_none(),
+            }
+        }
+
+        pub fn deserialize<'de, D: serde::Deserializer<'de>>(
+            d: D,
+        ) -> Result<Option<SystemTime>, D::Error> {
+            let opt: Option<String> = Option::<String>::deserialize(d)?;
+            opt.map(|s| humantime::parse_rfc3339(&s).map_err(serde::de::Error::custom))
+                .transpose()
+        }
+    }
+}
+
+/// Serde helpers that serialize `NodeRef` as its Display string and
+/// deserialize via FromStr. This keeps the HTTP JSON API curl-friendly:
+/// `identity`, `children`, and `parent` appear as plain strings in JSON,
+/// while remaining typed `NodeRef` values in Rust.
+mod noderef_serde {
+    use serde::Deserialize;
+
+    use super::NodeRef;
+
+    pub fn serialize<S: serde::Serializer>(v: &NodeRef, s: S) -> Result<S::Ok, S::Error> {
+        s.serialize_str(&v.to_string())
+    }
+
+    pub fn deserialize<'de, D: serde::Deserializer<'de>>(d: D) -> Result<NodeRef, D::Error> {
+        let s = String::deserialize(d)?;
+        s.parse().map_err(serde::de::Error::custom)
+    }
+
+    pub mod vec {
+        use super::NodeRef;
+
+        pub fn serialize<S: serde::Serializer>(v: &[NodeRef], s: S) -> Result<S::Ok, S::Error> {
+            use serde::ser::SerializeSeq;
+            let mut seq = s.serialize_seq(Some(v.len()))?;
+            for r in v {
+                seq.serialize_element(&r.to_string())?;
+            }
+            seq.end()
+        }
+
+        pub fn deserialize<'de, D: serde::Deserializer<'de>>(
+            d: D,
+        ) -> Result<Vec<NodeRef>, D::Error> {
+            let strings: Vec<String> = serde::Deserialize::deserialize(d)?;
+            strings
+                .into_iter()
+                .map(|s| s.parse().map_err(serde::de::Error::custom))
+                .collect()
+        }
+    }
+
+    pub mod option {
+        use super::NodeRef;
+
+        pub fn serialize<S: serde::Serializer>(
+            v: &Option<NodeRef>,
+            s: S,
+        ) -> Result<S::Ok, S::Error> {
+            match v {
+                Some(r) => s.serialize_some(&r.to_string()),
+                None => s.serialize_none(),
+            }
+        }
+
+        pub fn deserialize<'de, D: serde::Deserializer<'de>>(
+            d: D,
+        ) -> Result<Option<NodeRef>, D::Error> {
+            let opt: Option<String> = serde::Deserialize::deserialize(d)?;
+            opt.map(|s| s.parse().map_err(serde::de::Error::custom))
+                .transpose()
+        }
+    }
+}
 
 /// Uniform response for any node in the mesh topology.
 ///
@@ -481,19 +694,33 @@ use typeuri::Named;
 /// as a `NodePayload`. The client navigates the mesh by fetching a
 /// node and following its `children` references.
 ///
+/// Over the HTTP JSON API, `identity`, `children`, and `parent` are
+/// serialized as plain reference strings (curl-friendly). In Rust
+/// they are typed `NodeRef` values.
+///
 /// See IA-1..IA-5 in module doc.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Named, JsonSchema)]
 pub struct NodePayload {
-    /// Canonical reference string for this node.
-    pub identity: String,
+    /// Canonical node reference identifying this node.
+    /// Serialized as a string in JSON (e.g. `"root"`, `"host:actor_id"`).
+    #[serde(with = "noderef_serde")]
+    #[schemars(with = "String")]
+    pub identity: NodeRef,
     /// Node-specific metadata (type, status, metrics, etc.).
     pub properties: NodeProperties,
-    /// Reference strings the client can GET next to descend the tree.
-    pub children: Vec<String>,
+    /// Child node reference strings the client can URL-encode and
+    /// fetch via `GET /v1/{reference}`.
+    #[serde(with = "noderef_serde::vec")]
+    #[schemars(with = "Vec<String>")]
+    pub children: Vec<NodeRef>,
     /// Parent node reference for upward navigation.
-    pub parent: Option<String>,
-    /// ISO 8601 timestamp indicating when this data was captured.
-    pub as_of: String,
+    #[serde(with = "noderef_serde::option")]
+    #[schemars(with = "Option<String>")]
+    pub parent: Option<NodeRef>,
+    /// When this payload was captured (ISO 8601 string in JSON).
+    #[serde(with = "systemtime_serde")]
+    #[schemars(with = "String")]
+    pub as_of: SystemTime,
 }
 wirevalue::register_type!(NodePayload);
 
@@ -504,22 +731,32 @@ pub enum NodeProperties {
     /// Synthetic mesh root node (not a real actor/proc).
     Root {
         num_hosts: usize,
-        started_at: String,
+        #[serde(with = "systemtime_serde")]
+        #[schemars(with = "String")]
+        started_at: SystemTime,
         started_by: String,
-        system_children: Vec<String>,
+        #[serde(with = "noderef_serde::vec")]
+        #[schemars(with = "Vec<String>")]
+        system_children: Vec<NodeRef>,
     },
     /// A host in the mesh, represented by its `HostAgent`.
     Host {
         addr: String,
         num_procs: usize,
-        system_children: Vec<String>,
+        #[serde(with = "noderef_serde::vec")]
+        #[schemars(with = "Vec<String>")]
+        system_children: Vec<NodeRef>,
     },
     /// Properties describing a proc running on a host.
     Proc {
         proc_name: String,
         num_actors: usize,
-        system_children: Vec<String>,
-        stopped_children: Vec<String>,
+        #[serde(with = "noderef_serde::vec")]
+        #[schemars(with = "Vec<String>")]
+        system_children: Vec<NodeRef>,
+        #[serde(with = "noderef_serde::vec")]
+        #[schemars(with = "Vec<String>")]
+        stopped_children: Vec<NodeRef>,
         stopped_retention_cap: usize,
         is_poisoned: bool,
         failed_actor_count: usize,
@@ -529,7 +766,9 @@ pub enum NodeProperties {
         actor_status: String,
         actor_type: String,
         messages_processed: u64,
-        created_at: String,
+        #[serde(with = "systemtime_serde::option")]
+        #[schemars(with = "Option<String>")]
+        created_at: Option<SystemTime>,
         last_message_handler: Option<String>,
         total_processing_time_us: u64,
         flight_recorder: Option<String>,
@@ -544,10 +783,27 @@ wirevalue::register_type!(NodeProperties);
 /// Structured failure information for failed actors.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Named, JsonSchema)]
 pub struct FailureInfo {
+    /// Error message describing the failure.
     pub error_message: String,
-    pub root_cause_actor: String,
+    /// Actor that caused the failure (root cause).
+    /// Serialized as its Display string in JSON for curl-friendliness.
+    #[serde(
+        serialize_with = "actorid_serde::serialize",
+        deserialize_with = "actorid_serde::deserialize"
+    )]
+    #[schemars(with = "String")]
+    pub root_cause_actor: hyperactor::reference::ActorId,
+    /// Display name of the root-cause actor, if available.
     pub root_cause_name: Option<String>,
-    pub occurred_at: String,
+    /// When the failure occurred.
+    /// Serialized as ISO 8601 string in JSON for curl-friendliness.
+    #[serde(
+        serialize_with = "systemtime_serde::serialize",
+        deserialize_with = "systemtime_serde::deserialize"
+    )]
+    #[schemars(with = "String")]
+    pub occurred_at: SystemTime,
+    /// Whether this failure was propagated from a child.
     pub is_propagated: bool,
 }
 wirevalue::register_type!(FailureInfo);
@@ -564,7 +820,7 @@ impl IntoNodeProperties for RootAttrsView {
     fn into_node_properties(self) -> NodeProperties {
         NodeProperties::Root {
             num_hosts: self.num_hosts,
-            started_at: humantime::format_rfc3339_millis(self.started_at).to_string(),
+            started_at: self.started_at,
             started_by: self.started_by,
             system_children: self.system_children,
         }
@@ -606,7 +862,6 @@ impl IntoNodeProperties for ErrorAttrsView {
 
 impl IntoNodeProperties for hyperactor::introspect::ActorAttrsView {
     fn into_node_properties(self) -> NodeProperties {
-        // Reconstruct the display status from status + status_reason.
         let actor_status = match &self.status_reason {
             Some(reason) => format!("{}: {}", self.status, reason),
             None => self.status.clone(),
@@ -616,7 +871,7 @@ impl IntoNodeProperties for hyperactor::introspect::ActorAttrsView {
             error_message: fi.error_message,
             root_cause_actor: fi.root_cause_actor,
             root_cause_name: fi.root_cause_name,
-            occurred_at: humantime::format_rfc3339_millis(fi.occurred_at).to_string(),
+            occurred_at: fi.occurred_at,
             is_propagated: fi.is_propagated,
         });
 
@@ -624,10 +879,7 @@ impl IntoNodeProperties for hyperactor::introspect::ActorAttrsView {
             actor_status,
             actor_type: self.actor_type,
             messages_processed: self.messages_processed,
-            created_at: self
-                .created_at
-                .map(|t| humantime::format_rfc3339_millis(t).to_string())
-                .unwrap_or_default(),
+            created_at: self.created_at,
             last_message_handler: self.last_handler,
             total_processing_time_us: self.total_processing_time_us,
             flight_recorder: self.flight_recorder,
@@ -718,16 +970,14 @@ pub fn derive_properties(attrs_json: &str) -> NodeProperties {
     }
 }
 
-/// Convert an internal `IntrospectResult` into an API-facing
-/// `NodePayload` by deriving `properties` from attrs.
-/// Convert an `IntrospectResult` to a presentation `NodePayload`
-/// with `properties` derived from attrs.
+/// Convert an `IntrospectResult` to a presentation `NodePayload`.
+/// Lifts `IntrospectRef` → `NodeRef` and passes through typed timestamps.
 pub fn to_node_payload(result: hyperactor::introspect::IntrospectResult) -> NodePayload {
     NodePayload {
-        identity: result.identity,
+        identity: result.identity.into(),
         properties: derive_properties(&result.attrs),
-        children: result.children,
-        parent: result.parent,
+        children: result.children.into_iter().map(NodeRef::from).collect(),
+        parent: result.parent.map(NodeRef::from),
         as_of: result.as_of,
     }
 }
@@ -736,13 +986,13 @@ pub fn to_node_payload(result: hyperactor::introspect::IntrospectResult) -> Node
 /// identity and parent for correct tree navigation.
 pub fn to_node_payload_with(
     result: hyperactor::introspect::IntrospectResult,
-    identity: String,
-    parent: Option<String>,
+    identity: NodeRef,
+    parent: Option<NodeRef>,
 ) -> NodePayload {
     NodePayload {
         identity,
         properties: derive_properties(&result.attrs),
-        children: result.children,
+        children: result.children.into_iter().map(NodeRef::from).collect(),
         parent,
         as_of: result.as_of,
     }
@@ -804,12 +1054,20 @@ mod tests {
         );
     }
 
+    fn test_actor_ref(proc_name: &str, actor_name: &str, pid: usize) -> NodeRef {
+        use hyperactor::channel::ChannelAddr;
+        use hyperactor::reference::ProcId;
+        NodeRef::Actor(
+            ProcId::with_name(ChannelAddr::Local(0), proc_name).actor_id(actor_name, pid),
+        )
+    }
+
     fn root_view() -> RootAttrsView {
         RootAttrsView {
             num_hosts: 3,
             started_at: std::time::UNIX_EPOCH,
             started_by: "testuser".into(),
-            system_children: vec!["child1".into()],
+            system_children: vec![test_actor_ref("proc", "child1", 0)],
         }
     }
 
@@ -817,7 +1075,7 @@ mod tests {
         HostAttrsView {
             addr: "10.0.0.1:8080".into(),
             num_procs: 2,
-            system_children: vec!["sys".into()],
+            system_children: vec![test_actor_ref("proc", "sys", 0)],
         }
     }
 
@@ -826,7 +1084,7 @@ mod tests {
             proc_name: "worker".into(),
             num_actors: 5,
             system_children: vec![],
-            stopped_children: vec!["old".into()],
+            stopped_children: vec![test_actor_ref("proc", "old", 0)],
             stopped_retention_cap: 10,
             is_poisoned: false,
             failed_actor_count: 0,
@@ -1126,36 +1384,43 @@ mod tests {
     /// SC-3: real payloads validate against the generated schema.
     #[test]
     fn test_payloads_validate_against_schema() {
+        use hyperactor::channel::ChannelAddr;
+        use hyperactor::reference::ProcId;
+
         let schema = schemars::schema_for!(NodePayload);
         let schema_value = serde_json::to_value(&schema).unwrap();
         let compiled = jsonschema::JSONSchema::compile(&schema_value).expect("schema must compile");
 
+        let epoch = std::time::UNIX_EPOCH;
+        let proc_id = ProcId::with_name(ChannelAddr::Local(0), "worker");
+        let actor_id = proc_id.actor_id("actor", 0);
+
         let samples = [
             NodePayload {
-                identity: "root".into(),
+                identity: NodeRef::Root,
                 properties: NodeProperties::Root {
                     num_hosts: 2,
-                    started_at: "2024-01-01T00:00:00.000Z".into(),
+                    started_at: epoch,
                     started_by: "testuser".into(),
                     system_children: vec![],
                 },
-                children: vec!["host1".into()],
+                children: vec![NodeRef::Host(actor_id.clone())],
                 parent: None,
-                as_of: "2024-01-01T00:00:00.000Z".into(),
+                as_of: epoch,
             },
             NodePayload {
-                identity: "host1".into(),
+                identity: NodeRef::Host(actor_id.clone()),
                 properties: NodeProperties::Host {
                     addr: "10.0.0.1:8080".into(),
                     num_procs: 2,
-                    system_children: vec!["sys".into()],
+                    system_children: vec![test_actor_ref("proc", "sys", 0)],
                 },
-                children: vec!["proc1".into()],
-                parent: Some("root".into()),
-                as_of: "2024-01-01T00:00:00.000Z".into(),
+                children: vec![NodeRef::Proc(proc_id.clone())],
+                parent: Some(NodeRef::Root),
+                as_of: epoch,
             },
             NodePayload {
-                identity: "proc1".into(),
+                identity: NodeRef::Proc(proc_id.clone()),
                 properties: NodeProperties::Proc {
                     proc_name: "worker".into(),
                     num_actors: 5,
@@ -1165,17 +1430,17 @@ mod tests {
                     is_poisoned: false,
                     failed_actor_count: 0,
                 },
-                children: vec!["actor[0]".into()],
-                parent: Some("host1".into()),
-                as_of: "2024-01-01T00:00:00.000Z".into(),
+                children: vec![NodeRef::Actor(actor_id.clone())],
+                parent: Some(NodeRef::Host(actor_id.clone())),
+                as_of: epoch,
             },
             NodePayload {
-                identity: "actor[0]".into(),
+                identity: NodeRef::Actor(actor_id.clone()),
                 properties: NodeProperties::Actor {
                     actor_status: "running".into(),
                     actor_type: "MyActor".into(),
                     messages_processed: 42,
-                    created_at: "2024-01-01T00:00:00.000Z".into(),
+                    created_at: Some(epoch),
                     last_message_handler: Some("handle_ping".into()),
                     total_processing_time_us: 1000,
                     flight_recorder: None,
@@ -1183,18 +1448,18 @@ mod tests {
                     failure_info: None,
                 },
                 children: vec![],
-                parent: Some("proc1".into()),
-                as_of: "2024-01-01T00:00:00.000Z".into(),
+                parent: Some(NodeRef::Proc(proc_id.clone())),
+                as_of: epoch,
             },
             NodePayload {
-                identity: "err".into(),
+                identity: NodeRef::Actor(actor_id.clone()),
                 properties: NodeProperties::Error {
                     code: "not_found".into(),
                     message: "child not found".into(),
                 },
                 children: vec![],
                 parent: None,
-                as_of: "2024-01-01T00:00:00.000Z".into(),
+                as_of: epoch,
             },
         ];
 

--- a/hyperactor_mesh/src/mesh_admin.rs
+++ b/hyperactor_mesh/src/mesh_admin.rs
@@ -12,7 +12,8 @@
 //! This module defines `MeshAdminAgent`, an actor that exposes a
 //! uniform, reference-based HTTP API over an entire host mesh. Every
 //! addressable entity in the mesh is represented as a `NodePayload`
-//! and resolved via an opaque reference string.
+//! and resolved via typed `NodeRef` references (parsed from HTTP
+//! path strings at the request boundary).
 //!
 //! Incoming HTTP requests are bridged into the actor message loop
 //! using `ResolveReferenceMessage`, ensuring that all topology
@@ -139,13 +140,13 @@
 //!
 //! Every `NodePayload` in the topology tree satisfies:
 //!
-//! - **NI-1 (identity = reference):** A node's `identity` field must
-//!   equal the reference string used to resolve it. If the TUI asks
-//!   for reference `R`, `payload.identity == R`.
+//! - **NI-1 (identity = reference):** A node's `identity: NodeRef`
+//!   must correspond to the reference used to resolve it. The
+//!   display form of `identity` round-trips through `NodeRef::from_str`.
 //!
-//! - **NI-2 (parent coherence):** A node's `parent` field must equal
-//!   the `identity` of the node it appears under. If node `P` lists
-//!   `R` in its `children`, then `R.parent == Some(P.identity)`.
+//! - **NI-2 (parent coherence):** A node's `parent: Option<NodeRef>`
+//!   must equal the `identity` of the node it appears under. If node
+//!   `P` lists `R` in its `children`, then `R.parent == Some(P.identity)`.
 //!
 //! Together these ensure that the TUI can correlate responses to tree
 //! nodes, and that upward/downward navigation is consistent.
@@ -158,9 +159,10 @@
 //! - **SP-1 (identity):** The identity matches the ProcId reference
 //!   from the parent's children list.
 //! - **SP-2 (properties):** The properties are `NodeProperties::Proc`.
-//! - **SP-3 (parent):** The parent is set to the HostId format
-//!   (`"host:<actor_id>"`).
-//! - **SP-4 (as_of):** The `as_of` field is present and non-empty.
+//! - **SP-3 (parent):** The parent is `NodeRef::Host(actor_id)`.
+//! - **SP-4 (as_of):** The `as_of` field is present and valid
+//!   (internally `SystemTime`; serialized as ISO 8601 string over
+//!   the HTTP JSON API per HB-1).
 //!
 //! Enforced by `test_system_proc_identity`.
 //!
@@ -325,7 +327,6 @@ use crate::config_dump::ConfigDump;
 use crate::config_dump::ConfigDumpResult;
 use crate::host_mesh::host_agent::HOST_MESH_AGENT_ACTOR_NAME;
 use crate::host_mesh::host_agent::HostAgent;
-use crate::host_mesh::host_agent::HostId;
 use crate::introspect::NodePayload;
 use crate::introspect::NodeProperties;
 use crate::introspect::to_node_payload;
@@ -507,7 +508,7 @@ wirevalue::register_type!(MeshAdminMessage);
 pub struct ResolveReferenceResponse(pub Result<NodePayload, String>);
 wirevalue::register_type!(ResolveReferenceResponse);
 
-/// Message for resolving an opaque reference string into a
+/// Message for resolving a reference (string from HTTP path) into a
 /// `NodePayload`.
 ///
 /// This is the primary “navigation” request used by the admin HTTP
@@ -540,8 +541,8 @@ pub enum ResolveReferenceMessage {
     /// On success the reply contains `payload=Some(..), error=None`; on failure
     /// it contains `payload=None, error=Some(..)`.
     Resolve {
-        /// Opaque reference string identifying a root/host/proc/actor
-        /// node.
+        /// Reference string from the HTTP path, parsed into a typed
+        /// `NodeRef` at the resolve boundary.
         reference_string: String,
         /// Reply port receiving the resolution result.
         #[reply]
@@ -560,7 +561,7 @@ wirevalue::register_type!(ResolveReferenceMessage);
 ///
 /// The agent also exposes an HTTP server (spawned from `init`) and
 /// supports reference-based navigation (`GET /v1/{reference}`) by
-/// resolving opaque reference strings into typed `NodeProperties`
+/// resolving HTTP path references into typed `NodePayload` values
 /// plus child references.
 #[hyperactor::export(handlers = [MeshAdminMessage, ResolveReferenceMessage])]
 pub struct MeshAdminAgent {
@@ -1051,27 +1052,16 @@ impl MeshAdminAgent {
         cx: &Context<'_, Self>,
         reference_string: &str,
     ) -> Result<NodePayload, anyhow::Error> {
-        if reference_string == "root" {
-            return Ok(self.build_root_payload());
-        }
-
-        // Host refs use the "host:<actor_id>" format so they are
-        // unambiguous from plain actor references. The same
-        // HostAgent ActorId can appear both as a host (from root)
-        // and as an actor (from a proc's children list).
-        if let Ok(host_id) = reference_string.parse::<HostId>() {
-            return self.resolve_host_node(cx, &host_id.0).await;
-        }
-
-        let reference: hyperactor_reference::Reference = reference_string
+        let node_ref: crate::introspect::NodeRef = reference_string
             .parse()
             .map_err(|e| anyhow::anyhow!("invalid reference '{}': {}", reference_string, e))?;
 
-        match &reference {
-            hyperactor_reference::Reference::Proc(proc_id) => {
-                // Try the host-managed path first (uses ProcAgent,
-                // sees all actors). Fall back to the standalone
-                // anchor path for procs truly off-mesh (A != C).
+        match &node_ref {
+            crate::introspect::NodeRef::Root => Ok(self.build_root_payload()),
+            crate::introspect::NodeRef::Host(actor_id) => {
+                self.resolve_host_node(cx, actor_id).await
+            }
+            crate::introspect::NodeRef::Proc(proc_id) => {
                 match self.resolve_proc_node(cx, proc_id).await {
                     Ok(payload) => Ok(payload),
                     Err(_) if self.standalone_proc_anchor(proc_id).is_some() => {
@@ -1080,13 +1070,9 @@ impl MeshAdminAgent {
                     Err(e) => Err(e),
                 }
             }
-            hyperactor_reference::Reference::Actor(actor_id) => {
+            crate::introspect::NodeRef::Actor(actor_id) => {
                 self.resolve_actor_node(cx, actor_id).await
             }
-            _ => Err(anyhow::anyhow!(
-                "unsupported reference type: {}",
-                reference_string
-            )),
         }
     }
 
@@ -1120,16 +1106,18 @@ impl MeshAdminAgent {
     /// Construct the synthetic root node for the reference tree.
     ///
     /// The root is not a real actor/proc; it's a convenience node
-    /// that anchors navigation. Its children are the configured
-    /// `HostAgent` actor IDs (as reference strings) plus any
-    /// standalone procs (root client proc, admin proc).
+    /// that anchors navigation. Its children are `NodeRef::Host`
+    /// entries for each configured `HostAgent` plus any standalone
+    /// procs (root client proc, admin proc).
     fn build_root_payload(&self) -> NodePayload {
-        let children: Vec<String> = self
+        use crate::introspect::NodeRef;
+
+        let children: Vec<NodeRef> = self
             .hosts
             .values()
-            .map(|agent| HostId(agent.actor_id().clone()).to_string())
+            .map(|agent| NodeRef::Host(agent.actor_id().clone()))
             .collect();
-        let system_children: Vec<String> = Vec::new();
+        let system_children: Vec<NodeRef> = Vec::new();
         let mut attrs = hyperactor_config::Attrs::new();
         attrs.set(crate::introspect::NODE_TYPE, "root".to_string());
         attrs.set(crate::introspect::NUM_HOSTS, self.hosts.len());
@@ -1140,11 +1128,11 @@ impl MeshAdminAgent {
         attrs.set(crate::introspect::SYSTEM_CHILDREN, system_children.clone());
         let attrs_json = serde_json::to_string(&attrs).unwrap_or_else(|_| "{}".to_string());
         NodePayload {
-            identity: "root".to_string(),
+            identity: NodeRef::Root,
             properties: crate::introspect::derive_properties(&attrs_json),
             children,
             parent: None,
-            as_of: hyperactor::introspect::format_timestamp(std::time::SystemTime::now()),
+            as_of: std::time::SystemTime::now(),
         }
     }
 
@@ -1171,8 +1159,8 @@ impl MeshAdminAgent {
         .await?;
         Ok(crate::introspect::to_node_payload_with(
             result,
-            HostId(actor_id.clone()).to_string(),
-            Some("root".to_string()),
+            crate::introspect::NodeRef::Host(actor_id.clone()),
+            Some(crate::introspect::NodeRef::Root),
         ))
     }
 
@@ -1208,9 +1196,14 @@ impl MeshAdminAgent {
         )
         .await?;
 
-        // If the host recognized the proc, use its response directly.
-        // No identity/parent normalization — QueryChild sets them correctly.
-        let payload = to_node_payload(result);
+        // If the host recognized the proc, normalize identity and parent.
+        // The host's QueryChild returns IntrospectRef::Actor(self_id) as
+        // parent, which lifts to NodeRef::Actor. We need NodeRef::Host.
+        let payload = crate::introspect::to_node_payload_with(
+            result,
+            crate::introspect::NodeRef::Proc(proc_id.clone()),
+            Some(crate::introspect::NodeRef::Host(agent.actor_id().clone())),
+        );
         if !matches!(payload.properties, NodeProperties::Error { .. }) {
             return Ok(payload);
         }
@@ -1228,8 +1221,8 @@ impl MeshAdminAgent {
 
         Ok(crate::introspect::to_node_payload_with(
             result,
-            proc_id.to_string(),
-            Some(HostId(agent.actor_id().clone()).to_string()),
+            crate::introspect::NodeRef::Proc(proc_id.clone()),
+            Some(crate::introspect::NodeRef::Host(agent.actor_id().clone())),
         ))
     }
 
@@ -1255,13 +1248,12 @@ impl MeshAdminAgent {
             .standalone_proc_anchor(proc_id)
             .ok_or_else(|| anyhow::anyhow!("no anchor actor for standalone proc {}", proc_id))?;
 
+        use crate::introspect::NodeRef;
+
         let (children, system_children) = if self.self_actor_id.as_ref() == Some(actor_id) {
-            // Self-proc: we are the only actor; no message needed.
-            // The admin agent is a system actor.
-            let self_ref = actor_id.to_string();
+            let self_ref = NodeRef::Actor(actor_id.clone());
             (vec![self_ref.clone()], vec![self_ref])
         } else {
-            // Query the anchor actor for its supervision children.
             let actor_result = query_introspect(
                 cx,
                 actor_id,
@@ -1270,10 +1262,8 @@ impl MeshAdminAgent {
                 &format!("querying anchor actor on {}", proc_id),
             )
             .await?;
-            // No identity/parent normalization — only reading properties for is_system check.
             let actor_payload = to_node_payload(actor_result);
-            // Check if anchor actor is system.
-            let anchor_ref = actor_id.to_string();
+            let anchor_ref = NodeRef::Actor(actor_id.clone());
             let anchor_is_system = matches!(
                 &actor_payload.properties,
                 NodeProperties::Actor {
@@ -1288,12 +1278,15 @@ impl MeshAdminAgent {
                 system_children.push(anchor_ref);
             }
 
-            // Query each supervision child to check is_system.
             for child_ref in actor_payload.children {
-                if let Ok(child_actor_id) = child_ref.parse::<hyperactor_reference::ActorId>() {
+                let child_actor_id = match &child_ref {
+                    NodeRef::Actor(id) => Some(id),
+                    _ => None,
+                };
+                if let Some(child_actor_id) = child_actor_id {
                     let child_is_system = if let Ok(r) = query_introspect(
                         cx,
-                        &child_actor_id,
+                        child_actor_id,
                         hyperactor::introspect::IntrospectView::Actor,
                         hyperactor_config::global::get(
                             crate::config::MESH_ADMIN_RESOLVE_ACTOR_TIMEOUT,
@@ -1324,7 +1317,6 @@ impl MeshAdminAgent {
 
         let proc_name = proc_id.name().to_string();
 
-        // Build attrs for standalone proc.
         let mut attrs = hyperactor_config::Attrs::new();
         attrs.set(crate::introspect::NODE_TYPE, "proc".to_string());
         attrs.set(crate::introspect::PROC_NAME, proc_name.clone());
@@ -1333,11 +1325,11 @@ impl MeshAdminAgent {
         let attrs_json = serde_json::to_string(&attrs).unwrap_or_else(|_| "{}".to_string());
 
         Ok(NodePayload {
-            identity: proc_id.to_string(),
+            identity: NodeRef::Proc(proc_id.clone()),
             properties: crate::introspect::derive_properties(&attrs_json),
             children,
-            as_of: hyperactor::introspect::format_timestamp(std::time::SystemTime::now()),
-            parent: Some("root".to_string()),
+            as_of: std::time::SystemTime::now(),
+            parent: Some(NodeRef::Root),
         })
     }
 
@@ -1412,33 +1404,22 @@ impl MeshAdminAgent {
         };
         let mut payload = to_node_payload(result);
 
-        // Actors on standalone procs: parent is the proc.
         if self.is_standalone_proc_actor(actor_id) {
-            payload.parent = Some(actor_id.proc_id().to_string());
+            payload.parent = Some(crate::introspect::NodeRef::Proc(actor_id.proc_id().clone()));
             return Ok(payload);
         }
 
-        // Set parent based on topology. If the actor returns Proc
-        // properties (ProcAgent override), its parent is the host
-        // agent. Otherwise, it's a regular actor and its parent is
-        // the proc.
         let proc_id = actor_id.proc_id();
         match &payload.properties {
             NodeProperties::Proc { .. } => {
-                // ProcAgent: parent is the host agent.
                 let host_addr = proc_id.addr().to_string();
                 if let Some(agent) = self.hosts.get(&host_addr) {
-                    payload.parent = Some(HostId(agent.actor_id().clone()).to_string());
+                    payload.parent =
+                        Some(crate::introspect::NodeRef::Host(agent.actor_id().clone()));
                 }
             }
             _ => {
-                // Regular actor: parent is the proc. We use the
-                // system proc ref format if the proc is a known
-                // system/local proc, otherwise the ProcAgent
-                // ActorId.
-                // Parent is the proc node, whose identity is the
-                // ProcId string (same for system and user procs).
-                payload.parent = Some(proc_id.to_string());
+                payload.parent = Some(crate::introspect::NodeRef::Proc(proc_id.clone()));
             }
         }
 
@@ -2480,9 +2461,10 @@ async fn tree_dump(
     // subtree; non-host children (e.g. the root client actor) are
     // rendered as single leaf lines.
     for child_ref in &root.children {
+        let child_ref_str = child_ref.to_string();
         let resp = tokio::time::timeout(
             hyperactor_config::global::get(crate::config::MESH_ADMIN_TREE_TIMEOUT),
-            state.admin_ref.resolve(cx, child_ref.clone()),
+            state.admin_ref.resolve(cx, child_ref_str.clone()),
         )
         .await;
 
@@ -2493,17 +2475,16 @@ async fn tree_dump(
 
         match payload {
             Some(node) if matches!(node.properties, NodeProperties::Host { .. }) => {
-                // Host header: show the addr from NodeProperties::Host.
                 let header = match &node.properties {
                     NodeProperties::Host { addr, .. } => addr.clone(),
-                    _ => child_ref.clone(),
+                    _ => child_ref_str.clone(),
                 };
-                let host_url = format!("{}/v1/{}", base_url, urlencoding::encode(child_ref));
+                let host_url = format!("{}/v1/{}", base_url, urlencoding::encode(&child_ref_str));
                 output.push_str(&format!("{}  ->  {}\n", header, host_url));
 
-                // Proc children with box-drawing connectors.
                 let num_procs = node.children.len();
                 for (i, proc_ref) in node.children.iter().enumerate() {
+                    let proc_ref_str = proc_ref.to_string();
                     let is_last_proc = i == num_procs - 1;
                     let proc_connector = if is_last_proc {
                         "└── "
@@ -2511,16 +2492,16 @@ async fn tree_dump(
                         "├── "
                     };
                     let proc_name = derive_tree_label(proc_ref);
-                    let proc_url = format!("{}/v1/{}", base_url, urlencoding::encode(proc_ref));
+                    let proc_url =
+                        format!("{}/v1/{}", base_url, urlencoding::encode(&proc_ref_str));
                     output.push_str(&format!(
                         "{}{}  ->  {}\n",
                         proc_connector, proc_name, proc_url
                     ));
 
-                    // Resolve the proc to get its actor children.
                     let proc_resp = tokio::time::timeout(
                         hyperactor_config::global::get(crate::config::MESH_ADMIN_TREE_TIMEOUT),
-                        state.admin_ref.resolve(cx, proc_ref.clone()),
+                        state.admin_ref.resolve(cx, proc_ref_str),
                     )
                     .await;
                     let proc_payload = match proc_resp {
@@ -2531,6 +2512,7 @@ async fn tree_dump(
                         let num_actors = proc_node.children.len();
                         let child_prefix = if is_last_proc { "    " } else { "│   " };
                         for (j, actor_ref) in proc_node.children.iter().enumerate() {
+                            let actor_ref_str = actor_ref.to_string();
                             let actor_connector = if j == num_actors - 1 {
                                 "└── "
                             } else {
@@ -2538,7 +2520,7 @@ async fn tree_dump(
                             };
                             let actor_label = derive_actor_label(actor_ref);
                             let actor_url =
-                                format!("{}/v1/{}", base_url, urlencoding::encode(actor_ref));
+                                format!("{}/v1/{}", base_url, urlencoding::encode(&actor_ref_str));
                             output.push_str(&format!(
                                 "{}{}{}  ->  {}\n",
                                 child_prefix, actor_connector, actor_label, actor_url
@@ -2549,24 +2531,24 @@ async fn tree_dump(
                 output.push('\n');
             }
             Some(node) if matches!(node.properties, NodeProperties::Proc { .. }) => {
-                // Non-host proc (e.g. root client proc). Render as a
-                // proc-level subtree with its actor children.
                 let proc_name = match &node.properties {
                     NodeProperties::Proc { proc_name, .. } => proc_name.clone(),
-                    _ => child_ref.clone(),
+                    _ => child_ref_str.clone(),
                 };
-                let proc_url = format!("{}/v1/{}", base_url, urlencoding::encode(child_ref));
+                let proc_url = format!("{}/v1/{}", base_url, urlencoding::encode(&child_ref_str));
                 output.push_str(&format!("{}  ->  {}\n", proc_name, proc_url));
 
                 let num_actors = node.children.len();
                 for (j, actor_ref) in node.children.iter().enumerate() {
+                    let actor_ref_str = actor_ref.to_string();
                     let actor_connector = if j == num_actors - 1 {
                         "└── "
                     } else {
                         "├── "
                     };
                     let actor_label = derive_actor_label(actor_ref);
-                    let actor_url = format!("{}/v1/{}", base_url, urlencoding::encode(actor_ref));
+                    let actor_url =
+                        format!("{}/v1/{}", base_url, urlencoding::encode(&actor_ref_str));
                     output.push_str(&format!(
                         "{}{}  ->  {}\n",
                         actor_connector, actor_label, actor_url
@@ -2575,10 +2557,8 @@ async fn tree_dump(
                 output.push('\n');
             }
             Some(_node) => {
-                // Non-host root child (e.g. root client actor).
-                // Render as a single leaf line.
                 let label = derive_actor_label(child_ref);
-                let url = format!("{}/v1/{}", base_url, urlencoding::encode(child_ref));
+                let url = format!("{}/v1/{}", base_url, urlencoding::encode(&child_ref_str));
                 output.push_str(&format!("{}  ->  {}\n\n", label, url));
             }
             _ => {
@@ -2603,34 +2583,25 @@ async fn tree_dump(
 ///
 /// Note: `ActorId::Display` for `ProcId` uses commas as
 /// separators (`proc_id,actor_name[idx]`), not slashes.
-fn derive_tree_label(reference: &str) -> String {
-    // ActorId (Direct): "transport!addr,proc_name,actor[idx]"
-    // ProcId (Direct): "transport!addr,proc_name"
-    // In both cases, split on ',' and take the second segment (the
-    // proc name).
-    let parts: Vec<&str> = reference.splitn(3, ',').collect();
-    match parts.len() {
-        // "addr,proc_name,actor[idx]" → proc_name
-        3 => parts[1].to_string(),
-        // "addr,proc_name" → proc_name
-        2 => parts[1].to_string(),
-        _ => reference.to_string(),
+fn derive_tree_label(node_ref: &crate::introspect::NodeRef) -> String {
+    match node_ref {
+        crate::introspect::NodeRef::Root => "root".to_string(),
+        crate::introspect::NodeRef::Host(id) => id.proc_id().name().to_string(),
+        crate::introspect::NodeRef::Proc(id) => id.name().to_string(),
+        crate::introspect::NodeRef::Actor(id) => {
+            format!("{}{}", id.name(), format_args!("[{}]", id.pid()))
+        }
     }
 }
 
-/// Derive a short display label for an actor reference.
-///
-/// Actor references are `ActorId` strings in the format
-/// `"transport!addr,proc_name,actor_name[idx]"`. This extracts the
-/// actor name with index (e.g. `"philosopher[0]"`).
-fn derive_actor_label(reference: &str) -> String {
-    let parts: Vec<&str> = reference.splitn(3, ',').collect();
-    match parts.len() {
-        // "addr,proc_name,actor[idx]" → actor[idx]
-        3 => parts[2].to_string(),
-        // "addr,name" → name
-        2 => parts[1].to_string(),
-        _ => reference.to_string(),
+fn derive_actor_label(node_ref: &crate::introspect::NodeRef) -> String {
+    match node_ref {
+        crate::introspect::NodeRef::Root => "root".to_string(),
+        crate::introspect::NodeRef::Host(id) => id.name().to_string(),
+        crate::introspect::NodeRef::Proc(id) => id.name().to_string(),
+        crate::introspect::NodeRef::Actor(id) => {
+            format!("{}[{}]", id.name(), id.pid())
+        }
     }
 }
 
@@ -2791,23 +2762,22 @@ mod tests {
         );
 
         let payload = agent.build_root_payload();
-        assert_eq!(payload.identity, "root");
+        assert_eq!(payload.identity, crate::introspect::NodeRef::Root);
         assert_eq!(payload.parent, None);
         assert!(matches!(
             payload.properties,
             NodeProperties::Root { num_hosts: 2, .. }
         ));
         assert_eq!(payload.children.len(), 2);
-        // Children should be host: reference strings.
         assert!(
             payload
                 .children
-                .contains(&HostId(actor_id1.clone()).to_string())
+                .contains(&crate::introspect::NodeRef::Host(actor_id1.clone()))
         );
         assert!(
             payload
                 .children
-                .contains(&HostId(actor_id2.clone()).to_string())
+                .contains(&crate::introspect::NodeRef::Host(actor_id2.clone()))
         );
 
         // Verify root properties derived from attrs.
@@ -2895,7 +2865,7 @@ mod tests {
             .await
             .unwrap();
         let root = root_resp.0.unwrap();
-        assert_eq!(root.identity, "root");
+        assert_eq!(root.identity, crate::introspect::NodeRef::Root);
         assert!(matches!(
             root.properties,
             NodeProperties::Root { num_hosts: 1, .. }
@@ -2904,46 +2874,38 @@ mod tests {
         assert_eq!(root.children.len(), 1); // host only (admin proc no longer standalone)
 
         // -- 5. Resolve the host child --
-        let _host_agent_id_str = host_agent_ref.actor_id().to_string();
-        let host_ref_str = HostId(host_agent_ref.actor_id().clone()).to_string();
-        let host_child_ref_str = root
+        let expected_host_ref = crate::introspect::NodeRef::Host(host_agent_ref.actor_id().clone());
+        let host_child_ref = root
             .children
             .iter()
-            .find(|c| **c == host_ref_str)
-            .expect("root children should contain the host agent (as host: ref)");
-        let host_resp = admin_ref
-            .resolve(&client, host_child_ref_str.clone())
-            .await
-            .unwrap();
+            .find(|c| **c == expected_host_ref)
+            .expect("root children should contain the host agent (as Host ref)");
+        let host_ref_string = host_child_ref.to_string();
+        let host_resp = admin_ref.resolve(&client, host_ref_string).await.unwrap();
         let host_node = host_resp.0.unwrap();
-        assert_eq!(host_node.identity, *host_child_ref_str);
+        assert_eq!(host_node.identity, expected_host_ref);
         assert!(
             matches!(host_node.properties, NodeProperties::Host { .. }),
             "expected Host properties, got {:?}",
             host_node.properties
         );
-        assert_eq!(host_node.parent, Some("root".to_string()));
-        // A local host always has at least the system and local procs.
+        assert_eq!(host_node.parent, Some(crate::introspect::NodeRef::Root));
         assert!(
             !host_node.children.is_empty(),
             "host should have at least one proc child"
         );
 
         // -- 6. Resolve a system proc child --
-        // System proc children are ProcId strings (the "[system] "
-        // prefix is stripped by resolve_host_node).
-        let proc_ref_str = &host_node.children[0];
-        let proc_resp = admin_ref
-            .resolve(&client, proc_ref_str.clone())
-            .await
-            .unwrap();
+        let proc_ref = &host_node.children[0];
+        let proc_ref_str = proc_ref.to_string();
+        let proc_resp = admin_ref.resolve(&client, proc_ref_str).await.unwrap();
         let proc_node = proc_resp.0.unwrap();
         assert!(
             matches!(proc_node.properties, NodeProperties::Proc { .. }),
             "expected Proc properties, got {:?}",
             proc_node.properties
         );
-        assert_eq!(proc_node.parent, Some(host_child_ref_str.clone()));
+        assert_eq!(proc_node.parent, Some(expected_host_ref.clone()));
         // The system proc should have at least the "host_agent" actor.
         assert!(
             !proc_node.children.is_empty(),
@@ -2953,23 +2915,24 @@ mod tests {
         // -- 7. Cross-reference: system proc child is the host agent --
         //
         // The service proc's actor (agent[0]) IS the HostAgent, so
-        // it appears both as a host node (from root, via HostId) and
-        // as an actor (from a proc's children list, via plain ActorId).
-        // HostId in root children makes resolution unambiguous: host
-        // refs get Entity view, plain actor refs get Actor view.
+        // it appears both as a host node (from root, via NodeRef::Host)
+        // and as an actor (from a proc's children list, via NodeRef::Actor).
+        // NodeRef::Host in root children makes resolution unambiguous:
+        // host refs get Entity view, plain actor refs get Actor view.
 
         // The system proc must list the host agent among its children.
-        let host_agent_id_str = host_agent_ref.actor_id().to_string();
+        let host_agent_node_ref =
+            crate::introspect::NodeRef::Actor(host_agent_ref.actor_id().clone());
         assert!(
-            proc_node.children.contains(&host_agent_id_str),
-            "system proc children {:?} should contain the host agent {}",
+            proc_node.children.contains(&host_agent_node_ref),
+            "system proc children {:?} should contain the host agent {:?}",
             proc_node.children,
-            host_agent_id_str
+            host_agent_node_ref
         );
 
         // Resolve that child reference as a plain actor (no host: prefix).
         let xref_resp = admin_ref
-            .resolve(&client, host_agent_id_str.clone())
+            .resolve(&client, host_agent_ref.actor_id().to_string())
             .await
             .unwrap();
         let xref_node = xref_resp.0.unwrap();
@@ -3063,7 +3026,8 @@ mod tests {
         tokio::time::sleep(Duration::from_secs(2)).await;
 
         // Resolve the host to get its children (system + user procs).
-        let host_ref_string = HostId(host_agent_ref.actor_id().clone()).to_string();
+        let host_ref_string =
+            crate::introspect::NodeRef::Host(host_agent_ref.actor_id().clone()).to_string();
         let host_resp = admin_ref.resolve(&client, host_ref_string).await.unwrap();
         let host_node = host_resp.0.unwrap();
 
@@ -3079,9 +3043,9 @@ mod tests {
         let user_proc_name_str = user_proc_name.to_string();
         let mut found_system = false;
         let mut found_user = false;
-        for child_ref_str in &host_node.children {
+        for child_ref in &host_node.children {
             let resp = admin_ref
-                .resolve(&client, child_ref_str.clone())
+                .resolve(&client, child_ref.to_string())
                 .await
                 .unwrap();
             let node = resp.0.unwrap();
@@ -3135,7 +3099,7 @@ mod tests {
         assert!(
             payload
                 .children
-                .contains(&HostId(actor_id1.clone()).to_string())
+                .contains(&crate::introspect::NodeRef::Host(actor_id1.clone()))
         );
     }
 
@@ -3213,31 +3177,31 @@ mod tests {
             .await
             .unwrap();
         let root = root_resp.0.unwrap();
-        let host_id_str = HostId(host_agent_ref.actor_id().clone()).to_string();
+        let host_node_ref = crate::introspect::NodeRef::Host(host_agent_ref.actor_id().clone());
         assert!(
-            root.children.contains(&host_id_str),
-            "root children {:?} should contain host {}",
+            root.children.contains(&host_node_ref),
+            "root children {:?} should contain host {:?}",
             root.children,
-            host_id_str
+            host_node_ref
         );
 
         // Resolve the host — should list the local proc in children.
         let host_resp = admin_ref
-            .resolve(&client, host_id_str.clone())
+            .resolve(&client, host_node_ref.to_string())
             .await
             .unwrap();
         let host_node = host_resp.0.unwrap();
-        let local_proc_str = local_proc_id.to_string();
+        let local_proc_node_ref = crate::introspect::NodeRef::Proc(local_proc_id.clone());
         assert!(
-            host_node.children.contains(&local_proc_str),
-            "host children {:?} should contain local proc {}",
+            host_node.children.contains(&local_proc_node_ref),
+            "host children {:?} should contain local proc {:?}",
             host_node.children,
-            local_proc_str
+            local_proc_node_ref
         );
 
         // Resolve the local proc — should contain the root client actor.
         let proc_resp = admin_ref
-            .resolve(&client, local_proc_str.clone())
+            .resolve(&client, local_proc_id.to_string())
             .await
             .unwrap();
         let proc_node = proc_resp.0.unwrap();
@@ -3246,13 +3210,12 @@ mod tests {
             "expected Proc properties, got {:?}",
             proc_node.properties
         );
+        let root_client_node_ref = crate::introspect::NodeRef::Actor(root_client_actor_id.clone());
         assert!(
-            proc_node
-                .children
-                .contains(&root_client_actor_id.to_string()),
-            "local proc children {:?} should contain root client actor {}",
+            proc_node.children.contains(&root_client_node_ref),
+            "local proc children {:?} should contain root client actor {:?}",
             proc_node.children,
-            root_client_actor_id
+            root_client_node_ref
         );
 
         // Resolve the root client actor — parent should be the local proc.
@@ -3268,7 +3231,7 @@ mod tests {
         );
         assert_eq!(
             client_node.parent,
-            Some(local_proc_str),
+            Some(local_proc_node_ref),
             "root client parent should be the local proc"
         );
     }
@@ -3363,7 +3326,7 @@ mod tests {
 
         // Walk the tree breadth-first, checking the invariant at every node.
         // Each entry is (reference_string, expected_parent_identity).
-        let mut queue: std::collections::VecDeque<(String, Option<String>)> =
+        let mut queue: std::collections::VecDeque<(String, Option<crate::introspect::NodeRef>)> =
             std::collections::VecDeque::new();
         queue.push_back(("root".to_string(), None));
 
@@ -3376,11 +3339,13 @@ mod tests {
             let resp = admin_ref.resolve(&client, ref_str.clone()).await.unwrap();
             let node = resp.0.unwrap();
 
-            // NI-1: identity matches the reference used.
+            // NI-1: identity display matches the reference used.
             assert_eq!(
-                node.identity, ref_str,
+                node.identity.to_string(),
+                ref_str,
                 "identity mismatch: resolved '{}' but payload.identity = '{}'",
-                ref_str, node.identity
+                ref_str,
+                node.identity
             );
 
             // NI-2: parent matches the parent node's identity.
@@ -3393,8 +3358,9 @@ mod tests {
             // Enqueue children with this node's identity as their
             // expected parent.
             for child_ref in &node.children {
-                if !visited.contains(child_ref) {
-                    queue.push_back((child_ref.clone(), Some(node.identity.clone())));
+                let child_str = child_ref.to_string();
+                if !visited.contains(&child_str) {
+                    queue.push_back((child_str, Some(node.identity.clone())));
                 }
             }
         }
@@ -3465,7 +3431,8 @@ mod tests {
         let (client, _handle) = client_proc.instance("client").unwrap();
 
         // -- 4. Resolve the host to get its children --
-        let host_ref_str = HostId(host_agent_ref.actor_id().clone()).to_string();
+        let host_ref_str =
+            crate::introspect::NodeRef::Host(host_agent_ref.actor_id().clone()).to_string();
         let host_resp = admin_ref
             .resolve(&client, host_ref_str.clone())
             .await
@@ -3496,10 +3463,10 @@ mod tests {
         );
 
         // -- 6. Verify host children contain the system proc --
-        let expected_system_ref = system_proc_id.to_string();
+        let expected_system_ref = crate::introspect::NodeRef::Proc(system_proc_id.clone());
         assert!(
             host_node.children.contains(&expected_system_ref),
-            "host children {:?} should contain the system proc ref '{}'",
+            "host children {:?} should contain the system proc ref {:?}",
             host_node.children,
             expected_system_ref
         );
@@ -3507,7 +3474,7 @@ mod tests {
         // -- 7. Resolve a proc child --
         let proc_child_ref = &host_node.children[0];
         let proc_resp = admin_ref
-            .resolve(&client, proc_child_ref.clone())
+            .resolve(&client, proc_child_ref.to_string())
             .await
             .unwrap();
         let proc_node = proc_resp.0.unwrap();
@@ -3523,15 +3490,17 @@ mod tests {
             proc_node.properties
         );
 
+        let host_node_ref = crate::introspect::NodeRef::Host(host_agent_ref.actor_id().clone());
         assert_eq!(
             proc_node.parent,
-            Some(host_ref_str.clone()),
-            "proc parent should be the host reference (host:<actor_id>)"
+            Some(host_node_ref),
+            "proc parent should be the host reference"
         );
 
+        // as_of is a SystemTime — just verify it's not the epoch.
         assert!(
-            !proc_node.as_of.is_empty(),
-            "as_of should be present and non-empty"
+            proc_node.as_of > std::time::UNIX_EPOCH,
+            "as_of should be after the epoch"
         );
 
         // Verify proc properties derived from attrs.
@@ -3815,7 +3784,7 @@ mod tests {
         assert!(
             node.children
                 .iter()
-                .any(|c| c.contains(PROC_AGENT_ACTOR_NAME)),
+                .any(|c| c.to_string().contains(PROC_AGENT_ACTOR_NAME)),
             "initial children {:?} should contain proc_agent",
             node.children
         );
@@ -3839,7 +3808,10 @@ mod tests {
             node2.properties
         );
         assert!(
-            node2.children.iter().any(|c| c.contains("extra_actor")),
+            node2
+                .children
+                .iter()
+                .any(|c| c.to_string().contains("extra_actor")),
             "after direct spawn, children {:?} should contain extra_actor",
             node2.children
         );

--- a/hyperactor_mesh/src/mesh_admin_skill.md
+++ b/hyperactor_mesh/src/mesh_admin_skill.md
@@ -221,7 +221,7 @@ Most endpoints are read-only (`GET`). Two endpoints accept `POST`:
 
 Successful resolves return a JSON object:
 
-- `identity` — the resolved reference string
+- `identity` — the resolved reference string (opaque; round-trip it exactly)
 - `properties` — externally-tagged variant, one of:
   `{"Root": {...}}`, `{"Host": {...}}`, `{"Proc": {...}}`,
   `{"Actor": {...}}`, `{"Error": {...}}`
@@ -229,7 +229,8 @@ Successful resolves return a JSON object:
 - `parent` — optional parent reference (navigation context)
 - `as_of` — ISO 8601 timestamp of when this data was captured
 
-Each child reference can be resolved via `/v1/{reference}`.
+Each child reference can be resolved via `/v1/{reference}` (URL-encode first).
+Clients should treat reference strings as opaque tokens.
 
 ## Key fields
 

--- a/hyperactor_mesh/src/proc_agent.rs
+++ b/hyperactor_mesh/src/proc_agent.rs
@@ -113,17 +113,21 @@ wirevalue::register_type!(RepublishIntrospect);
 /// lookups. This avoids the convoy starvation from `all_actor_ids()`
 /// which holds shard read locks while doing heavy per-entry work.
 /// See S12 in `introspect` module doc.
-fn collect_live_children(proc: &hyperactor::Proc) -> (Vec<String>, Vec<String>) {
+fn collect_live_children(
+    proc: &hyperactor::Proc,
+) -> (
+    Vec<hyperactor::introspect::IntrospectRef>,
+    Vec<crate::introspect::NodeRef>,
+) {
     let all_keys = proc.all_instance_keys();
     let mut children = Vec::with_capacity(all_keys.len());
     let mut system_children = Vec::new();
     for id in all_keys {
         if let Some(cell) = proc.get_instance(&id) {
-            let ref_str = id.to_string();
             if cell.is_system() {
-                system_children.push(ref_str.clone());
+                system_children.push(crate::introspect::NodeRef::Actor(id.clone()));
             }
-            children.push(ref_str);
+            children.push(hyperactor::introspect::IntrospectRef::Actor(id));
         }
     }
     (children, system_children)
@@ -513,12 +517,11 @@ impl ProcAgent {
         // Terminated actors appear as children but don't inflate
         // the actor count. Track them in stopped_children so the
         // TUI can filter/gray without per-child fetches.
-        let mut stopped_children: Vec<String> = Vec::new();
+        let mut stopped_children: Vec<crate::introspect::NodeRef> = Vec::new();
         for id in self.proc.all_terminated_actor_ids() {
-            let ref_str = id.to_string();
-            stopped_children.push(ref_str.clone());
-            // Terminated system actors must also appear in
-            // system_children for correct filtering.
+            let child_ref = hyperactor::introspect::IntrospectRef::Actor(id.clone());
+            let node_ref = crate::introspect::NodeRef::Actor(id.clone());
+            stopped_children.push(node_ref.clone());
             if let Some(snapshot) = self.proc.terminated_snapshot(&id) {
                 let snapshot_attrs: hyperactor_config::Attrs =
                     serde_json::from_str(&snapshot.attrs).unwrap_or_default();
@@ -527,11 +530,11 @@ impl ProcAgent {
                     .copied()
                     .unwrap_or(false)
                 {
-                    system_children.push(ref_str.clone());
+                    system_children.push(node_ref);
                 }
             }
-            if !children.contains(&ref_str) {
-                children.push(ref_str);
+            if !children.contains(&child_ref) {
+                children.push(child_ref);
             }
         }
 
@@ -598,10 +601,11 @@ impl Actor for ProcAgent {
                 if proc_id == proc.proc_id() {
                     let (mut children, mut system_children) = collect_live_children(&proc);
 
-                    let mut stopped_children: Vec<String> = Vec::new();
+                    let mut stopped_children: Vec<crate::introspect::NodeRef> = Vec::new();
                     for id in proc.all_terminated_actor_ids() {
-                        let ref_str = id.to_string();
-                        stopped_children.push(ref_str.clone());
+                        let child_ref = hyperactor::introspect::IntrospectRef::Actor(id.clone());
+                        let node_ref = crate::introspect::NodeRef::Actor(id.clone());
+                        stopped_children.push(node_ref.clone());
                         if let Some(snapshot) = proc.terminated_snapshot(&id) {
                             let snapshot_attrs: hyperactor_config::Attrs =
                                 serde_json::from_str(&snapshot.attrs).unwrap_or_default();
@@ -610,11 +614,11 @@ impl Actor for ProcAgent {
                                 .copied()
                                 .unwrap_or(false)
                             {
-                                system_children.push(ref_str.clone());
+                                system_children.push(node_ref);
                             }
                         }
-                        if !children.contains(&ref_str) {
-                            children.push(ref_str);
+                        if !children.contains(&child_ref) {
+                            children.push(child_ref);
                         }
                     }
 
@@ -656,12 +660,11 @@ impl Actor for ProcAgent {
                         serde_json::to_string(&attrs).unwrap_or_else(|_| "{}".to_string());
 
                     return IntrospectResult {
-                        identity: proc_id.to_string(),
+                        identity: hyperactor::introspect::IntrospectRef::Proc(proc_id.clone()),
                         attrs: attrs_json,
                         children,
                         parent: None,
-                        as_of: humantime::format_rfc3339_millis(std::time::SystemTime::now())
-                            .to_string(),
+                        as_of: std::time::SystemTime::now(),
                     };
                 }
             }
@@ -673,13 +676,23 @@ impl Actor for ProcAgent {
                     hyperactor::introspect::ERROR_MESSAGE,
                     format!("child {} not found", child_ref),
                 );
+                let identity = match child_ref {
+                    hyperactor::reference::Reference::Proc(id) => {
+                        hyperactor::introspect::IntrospectRef::Proc(id.clone())
+                    }
+                    hyperactor::reference::Reference::Actor(id) => {
+                        hyperactor::introspect::IntrospectRef::Actor(id.clone())
+                    }
+                    hyperactor::reference::Reference::Port(id) => {
+                        hyperactor::introspect::IntrospectRef::Actor(id.actor_id().clone())
+                    }
+                };
                 IntrospectResult {
-                    identity: String::new(),
+                    identity,
                     attrs: serde_json::to_string(&error_attrs).unwrap_or_else(|_| "{}".to_string()),
                     children: Vec::new(),
                     parent: None,
-                    as_of: humantime::format_rfc3339_millis(std::time::SystemTime::now())
-                        .to_string(),
+                    as_of: std::time::SystemTime::now(),
                 }
             }
         });
@@ -1702,7 +1715,7 @@ mod tests {
             payload
                 .children
                 .iter()
-                .any(|c| c.contains(PROC_AGENT_ACTOR_NAME)),
+                .any(|c| c.to_string().contains(PROC_AGENT_ACTOR_NAME)),
             "initial children {:?} should contain proc_agent",
             payload.children
         );
@@ -1724,7 +1737,10 @@ mod tests {
             payload2.attrs
         );
         assert!(
-            payload2.children.iter().any(|c| c.contains("extra_actor")),
+            payload2
+                .children
+                .iter()
+                .any(|c| c.to_string().contains("extra_actor")),
             "after direct spawn, children {:?} should contain extra_actor",
             payload2.children
         );

--- a/hyperactor_mesh/src/testdata/node_payload_schema.json
+++ b/hyperactor_mesh/src/testdata/node_payload_schema.json
@@ -5,18 +5,23 @@
       "description": "Structured failure information for failed actors.",
       "properties": {
         "error_message": {
+          "description": "Error message describing the failure.",
           "type": "string"
         },
         "is_propagated": {
+          "description": "Whether this failure was propagated from a child.",
           "type": "boolean"
         },
         "occurred_at": {
+          "description": "When the failure occurred.\nSerialized as ISO 8601 string in JSON for curl-friendliness.",
           "type": "string"
         },
         "root_cause_actor": {
+          "description": "Actor that caused the failure (root cause).\nSerialized as its Display string in JSON for curl-friendliness.",
           "type": "string"
         },
         "root_cause_name": {
+          "description": "Display name of the root-cause actor, if available.",
           "type": [
             "string",
             "null"
@@ -176,7 +181,10 @@
                   "type": "string"
                 },
                 "created_at": {
-                  "type": "string"
+                  "type": [
+                    "string",
+                    "null"
+                  ]
                 },
                 "failure_info": {
                   "anyOf": [
@@ -218,7 +226,6 @@
                 "actor_status",
                 "actor_type",
                 "messages_processed",
-                "created_at",
                 "total_processing_time_us",
                 "is_system"
               ],
@@ -259,21 +266,21 @@
     }
   },
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "description": "Uniform response for any node in the mesh topology.\n\nEvery addressable entity (root, host, proc, actor) is represented\nas a `NodePayload`. The client navigates the mesh by fetching a\nnode and following its `children` references.\n\nSee IA-1..IA-5 in module doc.",
+  "description": "Uniform response for any node in the mesh topology.\n\nEvery addressable entity (root, host, proc, actor) is represented\nas a `NodePayload`. The client navigates the mesh by fetching a\nnode and following its `children` references.\n\nOver the HTTP JSON API, `identity`, `children`, and `parent` are\nserialized as plain reference strings (curl-friendly). In Rust\nthey are typed `NodeRef` values.\n\nSee IA-1..IA-5 in module doc.",
   "properties": {
     "as_of": {
-      "description": "ISO 8601 timestamp indicating when this data was captured.",
+      "description": "When this payload was captured (ISO 8601 string in JSON).",
       "type": "string"
     },
     "children": {
-      "description": "Reference strings the client can GET next to descend the tree.",
+      "description": "Child node reference strings the client can URL-encode and\nfetch via `GET /v1/{reference}`.",
       "items": {
         "type": "string"
       },
       "type": "array"
     },
     "identity": {
-      "description": "Canonical reference string for this node.",
+      "description": "Canonical node reference identifying this node.\nSerialized as a string in JSON (e.g. `\"root\"`, `\"host:actor_id\"`).",
       "type": "string"
     },
     "parent": {

--- a/hyperactor_mesh/src/testdata/openapi.json
+++ b/hyperactor_mesh/src/testdata/openapi.json
@@ -69,18 +69,23 @@
         "description": "Structured failure information for failed actors.",
         "properties": {
           "error_message": {
+            "description": "Error message describing the failure.",
             "type": "string"
           },
           "is_propagated": {
+            "description": "Whether this failure was propagated from a child.",
             "type": "boolean"
           },
           "occurred_at": {
+            "description": "When the failure occurred.\nSerialized as ISO 8601 string in JSON for curl-friendliness.",
             "type": "string"
           },
           "root_cause_actor": {
+            "description": "Actor that caused the failure (root cause).\nSerialized as its Display string in JSON for curl-friendliness.",
             "type": "string"
           },
           "root_cause_name": {
+            "description": "Display name of the root-cause actor, if available.",
             "type": [
               "string",
               "null"
@@ -96,21 +101,21 @@
         "type": "object"
       },
       "NodePayload": {
-        "description": "Uniform response for any node in the mesh topology.\n\nEvery addressable entity (root, host, proc, actor) is represented\nas a `NodePayload`. The client navigates the mesh by fetching a\nnode and following its `children` references.\n\nSee IA-1..IA-5 in module doc.",
+        "description": "Uniform response for any node in the mesh topology.\n\nEvery addressable entity (root, host, proc, actor) is represented\nas a `NodePayload`. The client navigates the mesh by fetching a\nnode and following its `children` references.\n\nOver the HTTP JSON API, `identity`, `children`, and `parent` are\nserialized as plain reference strings (curl-friendly). In Rust\nthey are typed `NodeRef` values.\n\nSee IA-1..IA-5 in module doc.",
         "properties": {
           "as_of": {
-            "description": "ISO 8601 timestamp indicating when this data was captured.",
+            "description": "When this payload was captured (ISO 8601 string in JSON).",
             "type": "string"
           },
           "children": {
-            "description": "Reference strings the client can GET next to descend the tree.",
+            "description": "Child node reference strings the client can URL-encode and\nfetch via `GET /v1/{reference}`.",
             "items": {
               "type": "string"
             },
             "type": "array"
           },
           "identity": {
-            "description": "Canonical reference string for this node.",
+            "description": "Canonical node reference identifying this node.\nSerialized as a string in JSON (e.g. `\"root\"`, `\"host:actor_id\"`).",
             "type": "string"
           },
           "parent": {
@@ -279,7 +284,10 @@
                     "type": "string"
                   },
                   "created_at": {
-                    "type": "string"
+                    "type": [
+                      "string",
+                      "null"
+                    ]
                   },
                   "failure_info": {
                     "anyOf": [
@@ -321,7 +329,6 @@
                   "actor_status",
                   "actor_type",
                   "messages_processed",
-                  "created_at",
                   "total_processing_time_us",
                   "is_system"
                 ],

--- a/hyperactor_mesh/test/mesh_admin_integration/harness.rs
+++ b/hyperactor_mesh/test/mesh_admin_integration/harness.rs
@@ -209,33 +209,33 @@ impl WorkloadFixture {
             };
 
             for host_ref in &root.children {
-                let encoded = urlencoding::encode(host_ref);
+                let host_str = host_ref.to_string();
+                let encoded = urlencoding::encode(&host_str);
                 let host: NodePayload = match self.get_json(&format!("/v1/{encoded}")).await {
                     Ok(h) => h,
                     Err(_) => continue,
                 };
 
                 for proc_ref in &host.children {
-                    let encoded = urlencoding::encode(proc_ref);
+                    let proc_str = proc_ref.to_string();
+                    let encoded = urlencoding::encode(&proc_str);
                     let proc_node: NodePayload =
                         match self.get_json(&format!("/v1/{encoded}")).await {
                             Ok(p) => p,
                             Err(_) => continue,
                         };
 
-                    let actor_names: Vec<String> = proc_node
-                        .children
-                        .iter()
-                        .map(|r| {
-                            let name = r.rsplit(',').next().unwrap_or(r);
-                            name.split('[').next().unwrap_or(name).to_string()
+                    let has_actor = |name: &str| {
+                        proc_node.children.iter().any(|r| match r {
+                            hyperactor_mesh::introspect::NodeRef::Actor(id) => id.name() == name,
+                            _ => false,
                         })
-                        .collect();
+                    };
 
-                    if actor_names.iter().any(|n| n == "host_agent") {
-                        service = Some(proc_ref.clone());
-                    } else if actor_names.iter().any(|n| n == "proc_agent") && worker.is_none() {
-                        worker = Some(proc_ref.clone());
+                    if has_actor("host_agent") {
+                        service = Some(proc_str.clone());
+                    } else if has_actor("proc_agent") && worker.is_none() {
+                        worker = Some(proc_str.clone());
                     }
                 }
             }

--- a/hyperactor_mesh/test/mesh_admin_integration/main.rs
+++ b/hyperactor_mesh/test/mesh_admin_integration/main.rs
@@ -79,7 +79,7 @@
 //! ### Tree endpoint
 //!
 //! - **MIT-13 (root-contract):** `/v1/root` returns `Root` variant
-//!   with `identity == "root"`, `num_hosts >= 1`, non-empty
+//!   with `identity == NodeRef::Root`, `num_hosts >= 1`, non-empty
 //!   `children`.
 //! - **MIT-14 (tree-format):** `/v1/tree` contains box-drawing
 //!   characters (`├──`/`└──`), clickable URLs, and workload-specific
@@ -120,8 +120,9 @@
 //!   node are fetchable via `/v1/{ref}`.
 //! - **MIT-21 (node-kind-typing):** Root returns `Root`, host returns
 //!   `Host`, proc returns `Proc`, actor returns `Actor` variant.
-//! - **MIT-22 (identity-consistency):** `node.identity` matches the
-//!   reference string used to fetch it.
+//! - **MIT-22 (identity-consistency):** `node.identity` (a typed
+//!   `NodeRef`) round-trips through its Display/FromStr to match
+//!   the HTTP path reference used to fetch it.
 //! - **MIT-23 (child-link-consistency):** Root, first host, classified
 //!   service proc, classified worker proc, and known actor refs are
 //!   fetchable.

--- a/hyperactor_mesh/test/mesh_admin_integration/pyspy.rs
+++ b/hyperactor_mesh/test/mesh_admin_integration/pyspy.rs
@@ -199,26 +199,30 @@ async fn discover_pyspy_workers(fixture: &WorkloadFixture, expected: usize) -> R
         let mut procs = Vec::new();
 
         for host_ref in &root.children {
-            let encoded = urlencoding::encode(host_ref);
+            let host_str = host_ref.to_string();
+            let encoded = urlencoding::encode(&host_str);
             let host: NodePayload = match fixture.get_json(&format!("/v1/{encoded}")).await {
                 Ok(h) => h,
                 Err(_) => continue,
             };
 
             for proc_ref in &host.children {
-                let encoded = urlencoding::encode(proc_ref);
+                let proc_str = proc_ref.to_string();
+                let encoded = urlencoding::encode(&proc_str);
                 let proc_node: NodePayload = match fixture.get_json(&format!("/v1/{encoded}")).await
                 {
                     Ok(p) => p,
                     Err(_) => continue,
                 };
 
-                let has_pyspy_worker = proc_node.children.iter().any(|actor_ref| {
-                    let name = actor_ref.rsplit(',').next().unwrap_or(actor_ref);
-                    name.starts_with("pyspy_worker")
+                let has_pyspy_worker = proc_node.children.iter().any(|actor_ref| match actor_ref {
+                    hyperactor_mesh::introspect::NodeRef::Actor(id) => {
+                        id.name().starts_with("pyspy_worker")
+                    }
+                    _ => false,
                 });
                 if has_pyspy_worker {
-                    procs.push(proc_ref.clone());
+                    procs.push(proc_str);
                 }
             }
         }

--- a/hyperactor_mesh/test/mesh_admin_integration/ref_check.rs
+++ b/hyperactor_mesh/test/mesh_admin_integration/ref_check.rs
@@ -15,19 +15,25 @@
 
 use hyperactor_mesh::introspect::NodePayload;
 use hyperactor_mesh::introspect::NodeProperties;
+use hyperactor_mesh::introspect::NodeRef;
 
 use crate::dining::DiningScenario;
 use crate::harness::WorkloadFixture;
 
-/// Extract the base actor name from a full actor reference string.
-/// Matches the harness's `classify_procs` parsing: take the last
-/// comma-separated segment, strip the `[index]` suffix.
-fn actor_base_name(actor_ref: &str) -> &str {
-    let name = actor_ref.rsplit(',').next().unwrap_or(actor_ref);
-    name.split('[').next().unwrap_or(name)
+/// Extract the base actor name from a typed `NodeRef`.
+/// Panics if the ref is not an actor — callers only pass actor children.
+fn actor_base_name(r: &NodeRef) -> &str {
+    match r {
+        NodeRef::Actor(id) => id.name(),
+        other => panic!("expected actor ref, got {other:?}"),
+    }
 }
 
-fn enc(s: &str) -> String {
+fn enc(r: &NodeRef) -> String {
+    urlencoding::encode(&r.to_string()).into_owned()
+}
+
+fn enc_str(s: &str) -> String {
     urlencoding::encode(s).into_owned()
 }
 
@@ -40,7 +46,7 @@ pub(crate) async fn check(s: &DiningScenario) {
         matches!(root.properties, NodeProperties::Root { .. }),
         "MIT-21: expected Root variant"
     );
-    assert_eq!(root.identity, "root", "MIT-22");
+    assert_eq!(root.identity, NodeRef::Root, "MIT-22");
 
     // MIT-20, MIT-21: first host fetchable.
     let host_ref = root
@@ -61,25 +67,25 @@ pub(crate) async fn check(s: &DiningScenario) {
     // MIT-23 V1: classified service and worker procs fetchable.
     let service: NodePayload = s
         .fixture
-        .get_json(&format!("/v1/{}", enc(&s.service)))
+        .get_json(&format!("/v1/{}", enc_str(&s.service)))
         .await
         .unwrap();
     assert!(
         matches!(service.properties, NodeProperties::Proc { .. }),
         "MIT-21"
     );
-    assert_eq!(service.identity, s.service, "MIT-22");
+    assert_eq!(service.identity.to_string(), s.service, "MIT-22");
 
     let worker: NodePayload = s
         .fixture
-        .get_json(&format!("/v1/{}", enc(&s.worker)))
+        .get_json(&format!("/v1/{}", enc_str(&s.worker)))
         .await
         .unwrap();
     assert!(
         matches!(worker.properties, NodeProperties::Proc { .. }),
         "MIT-21"
     );
-    assert_eq!(worker.identity, s.worker, "MIT-22");
+    assert_eq!(worker.identity.to_string(), s.worker, "MIT-22");
 
     // MIT-24: service proc must expose host_agent, worker proc must
     // expose proc_agent.

--- a/hyperactor_mesh/test/mesh_admin_integration/ref_edge.rs
+++ b/hyperactor_mesh/test/mesh_admin_integration/ref_edge.rs
@@ -89,5 +89,5 @@ pub(crate) async fn check(s: &DiningScenario) {
     // --- MIT-31: valid ref round-trips through URL encoding ---
     let encoded = urlencoding::encode(&s.worker);
     let node: NodePayload = s.fixture.get_json(&format!("/v1/{encoded}")).await.unwrap();
-    assert_eq!(node.identity, s.worker, "MIT-31");
+    assert_eq!(node.identity.to_string(), s.worker, "MIT-31");
 }

--- a/hyperactor_mesh/test/mesh_admin_integration/tree.rs
+++ b/hyperactor_mesh/test/mesh_admin_integration/tree.rs
@@ -18,6 +18,7 @@ use std::time::Duration;
 
 use hyperactor_mesh::introspect::NodePayload;
 use hyperactor_mesh::introspect::NodeProperties;
+use hyperactor_mesh::introspect::NodeRef;
 
 use crate::dining::DiningScenario;
 
@@ -26,8 +27,15 @@ const TREE_READY_SLEEP: Duration = Duration::from_secs(2);
 const TOPOLOGY_READY_ATTEMPTS: usize = 45;
 const TOPOLOGY_READY_SLEEP: Duration = Duration::from_secs(2);
 
-fn actor_name(reference: &str) -> &str {
-    reference.rsplit(',').next().unwrap_or(reference)
+fn actor_name(r: &NodeRef) -> &str {
+    match r {
+        NodeRef::Actor(id) => id.name(),
+        other => panic!("expected actor ref, got {other:?}"),
+    }
+}
+
+fn enc(r: &NodeRef) -> String {
+    urlencoding::encode(&r.to_string()).into_owned()
 }
 
 async fn topology_has_dining_actors(s: &DiningScenario) -> bool {
@@ -37,18 +45,17 @@ async fn topology_has_dining_actors(s: &DiningScenario) -> bool {
     };
 
     for host_ref in &root.children {
-        let encoded = urlencoding::encode(host_ref);
-        let host: NodePayload = match s.fixture.get_json(&format!("/v1/{encoded}")).await {
+        let host: NodePayload = match s.fixture.get_json(&format!("/v1/{}", enc(host_ref))).await {
             Ok(host) => host,
             Err(_) => continue,
         };
 
         for proc_ref in &host.children {
-            let encoded = urlencoding::encode(proc_ref);
-            let proc_node: NodePayload = match s.fixture.get_json(&format!("/v1/{encoded}")).await {
-                Ok(proc) => proc,
-                Err(_) => continue,
-            };
+            let proc_node: NodePayload =
+                match s.fixture.get_json(&format!("/v1/{}", enc(proc_ref))).await {
+                    Ok(proc) => proc,
+                    Err(_) => continue,
+                };
 
             if proc_node.children.iter().any(|actor_ref| {
                 let name = actor_name(actor_ref);
@@ -70,7 +77,11 @@ pub(crate) async fn check(s: &DiningScenario) {
         .get_json("/v1/root")
         .await
         .unwrap_or_else(|e| panic!("MIT-13: /v1/root failed: {e:#}"));
-    assert_eq!(root.identity, "root", "MIT-13: expected identity 'root'");
+    assert_eq!(
+        root.identity,
+        NodeRef::Root,
+        "MIT-13: expected identity Root"
+    );
     match &root.properties {
         NodeProperties::Root { num_hosts, .. } => {
             assert!(

--- a/hyperactor_mesh_admin_tui/src/actions.rs
+++ b/hyperactor_mesh_admin_tui/src/actions.rs
@@ -6,6 +6,9 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+use hyperactor::reference::ProcId;
+use hyperactor_mesh::introspect::NodeRef;
+
 /// Result of handling a key event.
 #[derive(Debug)]
 pub(crate) enum KeyResult {
@@ -16,11 +19,11 @@ pub(crate) enum KeyResult {
     /// A filter/view setting changed; full tree refresh needed.
     NeedsRefresh,
     /// Lazily expand the node at the given (reference, depth).
-    ExpandNode(String, usize),
+    ExpandNode(NodeRef, usize),
     /// Start the self-diagnostic suite against the attached mesh.
     RunDiagnostics,
-    /// Fetch a py-spy stack dump for the given proc reference.
-    RunPySpy(String),
-    /// Fetch the config dump for the given proc reference.
-    RunConfig(String),
+    /// Fetch a py-spy stack dump for the given proc.
+    RunPySpy(ProcId),
+    /// Fetch the config dump for the given proc.
+    RunConfig(ProcId),
 }

--- a/hyperactor_mesh_admin_tui/src/app.rs
+++ b/hyperactor_mesh_admin_tui/src/app.rs
@@ -19,6 +19,7 @@ use crossterm::event::KeyModifiers;
 use futures::StreamExt;
 use hyperactor_mesh::introspect::NodePayload;
 use hyperactor_mesh::introspect::NodeProperties;
+use hyperactor_mesh::introspect::NodeRef;
 use ratatui::Terminal;
 use ratatui::backend::CrosstermBackend;
 use ratatui::text::Line;
@@ -107,7 +108,7 @@ pub(crate) struct App {
     pub(crate) show_stopped: bool,
 
     /// Fetch cache with generation-based staleness.
-    pub(crate) fetch_cache: HashMap<String, FetchState<NodePayload>>,
+    pub(crate) fetch_cache: HashMap<NodeRef, FetchState<NodePayload>>,
     /// Current refresh generation for cache invalidation.
     pub(crate) refresh_gen: u64,
     /// Monotonic sequence counter for timestamp ordering.
@@ -206,7 +207,7 @@ impl App {
     /// - Stale entries (`generation < refresh_gen`) are refetched.
     pub(crate) async fn fetch_node_state(
         &mut self,
-        reference: &str,
+        reference: &NodeRef,
         force: bool,
     ) -> FetchState<NodePayload> {
         fetch_with_join(
@@ -222,7 +223,7 @@ impl App {
     }
 
     /// Extract a payload from FetchState if Ready, otherwise None.
-    pub(crate) fn get_cached_payload(&self, reference: &str) -> Option<&NodePayload> {
+    pub(crate) fn get_cached_payload(&self, reference: &NodeRef) -> Option<&NodePayload> {
         get_cached_payload(&self.fetch_cache, reference)
     }
 
@@ -253,10 +254,9 @@ impl App {
     ///
     /// Returns `None` if the selection is out of range (e.g. the tree
     /// is empty).
-    pub(crate) fn selected_reference(&self) -> Option<&str> {
+    pub(crate) fn selected_reference(&self) -> Option<&NodeRef> {
         let rows = self.visible_rows();
-        rows.get(&self.cursor)
-            .map(|row| row.node.reference.as_str())
+        rows.get(&self.cursor).map(|row| &row.node.reference)
     }
 
     /// Refresh the in-memory topology model by re-walking the
@@ -287,7 +287,8 @@ impl App {
             .map(|row| (row.node.reference.clone(), row.depth));
 
         // Fetch root using centralized fetch with force=true.
-        let root_state = self.fetch_node_state("root", true).await;
+        let root_ref = NodeRef::Root;
+        let root_state = self.fetch_node_state(&root_ref, true).await;
         let root_payload = match root_state {
             FetchState::Ready { value, .. } => value,
             FetchState::Error { msg, .. } => {
@@ -298,8 +299,8 @@ impl App {
         };
 
         // Path for cycle detection: tracks current path from root to
-        // Node being built. Start with "root" in the path.
-        let mut path = vec!["root".to_string()];
+        // Node being built. Start with root in the path.
+        let mut path = vec![NodeRef::Root];
 
         // Build tree recursively from root's children.
         let mut root_children = Vec::new();
@@ -328,7 +329,7 @@ impl App {
 
         // Create synthetic root node.
         self.set_tree(Some(TreeNode {
-            reference: "root".to_string(),
+            reference: NodeRef::Root,
             label: "Root".to_string(),
             node_type: NodeType::Root,
             expanded: true,
@@ -341,15 +342,15 @@ impl App {
         }));
 
         // Prune stale cache entries (collect owned refs to avoid borrow issues).
-        let live_refs: HashSet<String> = if let Some(root) = self.tree() {
+        let live_refs: HashSet<NodeRef> = if let Some(root) = self.tree() {
             let mut refs = HashSet::new();
             collect_refs(root, &mut refs);
-            refs.into_iter().map(|s| s.to_string()).collect()
+            refs.into_iter().cloned().collect()
         } else {
             HashSet::new()
         };
         self.fetch_cache
-            .retain(|k, _| k == "root" || live_refs.contains(k.as_str()));
+            .retain(|k, _| matches!(k, NodeRef::Root) || live_refs.contains(k));
 
         // Restore selection position.
         let rows = self.visible_rows();
@@ -383,7 +384,7 @@ impl App {
     /// fetches from the admin API. For Proc/Actor parents, children
     /// are inserted as placeholders (lazy fetching). For Root/Host
     /// parents, children are eagerly fetched.
-    pub(crate) async fn expand_node(&mut self, reference: &str, depth: usize) -> bool {
+    pub(crate) async fn expand_node(&mut self, reference: &NodeRef, depth: usize) -> bool {
         // Early check: bail if no tree.
         if self.tree.is_none() {
             return false;
@@ -409,7 +410,7 @@ impl App {
         );
 
         // Extract system_children from the parent for lazy filtering.
-        let system_children: HashSet<&str> = match &payload.properties {
+        let system_children: HashSet<&NodeRef> = match &payload.properties {
             NodeProperties::Root {
                 system_children, ..
             }
@@ -418,41 +419,38 @@ impl App {
             }
             | NodeProperties::Proc {
                 system_children, ..
-            } => system_children.iter().map(|s| s.as_str()).collect(),
+            } => system_children.iter().collect(),
             _ => HashSet::new(),
         };
 
         // Extract stopped_children from proc payloads for lazy
         // filtering/graying without per-child fetches.
-        let (stopped_children, parent_is_poisoned): (HashSet<&str>, bool) =
+        let (stopped_children, parent_is_poisoned): (HashSet<&NodeRef>, bool) =
             match &payload.properties {
                 NodeProperties::Proc {
                     stopped_children,
                     is_poisoned,
                     ..
-                } => (
-                    stopped_children.iter().map(|s| s.as_str()).collect(),
-                    *is_poisoned,
-                ),
+                } => (stopped_children.iter().collect(), *is_poisoned),
                 _ => (HashSet::new(), false),
             };
 
         let mut child_nodes = Vec::new();
         for child_ref in &children {
             // Filter order: system first, then stopped.
-            if !self.show_system && system_children.contains(child_ref.as_str()) {
+            if !self.show_system && system_children.contains(child_ref) {
                 continue;
             }
 
-            let child_is_stopped = stopped_children.contains(child_ref.as_str());
-            let child_is_system = system_children.contains(child_ref.as_str());
+            let child_is_stopped = stopped_children.contains(child_ref);
+            let child_is_system = system_children.contains(child_ref);
 
             // TUI-4: failed nodes always visible.
             // If the parent proc is poisoned, its stopped children may be
             // failed — don't filter them out (cache may be empty on first load).
             let child_is_failed = parent_is_poisoned
                 || self
-                    .get_cached_payload(child_ref.as_str())
+                    .get_cached_payload(child_ref)
                     .is_some_and(|c| is_failed_node(&c.properties));
             if !self.show_stopped && child_is_stopped && !child_is_failed {
                 continue;
@@ -460,7 +458,7 @@ impl App {
 
             if is_proc_or_actor {
                 // Lazy: use placeholder or cached payload.
-                if let Some(cached) = self.get_cached_payload(child_ref.as_str()) {
+                if let Some(cached) = self.get_cached_payload(child_ref) {
                     // Fallback: also check cached payload in case proc
                     // payload is stale.
                     if !self.show_stopped
@@ -551,10 +549,10 @@ impl App {
         self.detail_error = None;
 
         // Get reference first (releases tree borrow).
-        let reference = self.selected_reference().map(|s| s.to_string());
+        let reference = self.selected_reference().cloned();
 
-        if let Some(ref_str) = reference {
-            let state = self.fetch_node_state(&ref_str, false).await;
+        if let Some(node_ref) = reference {
+            let state = self.fetch_node_state(&node_ref, false).await;
             match state {
                 FetchState::Ready { value, .. } => {
                     self.detail = Some(value);
@@ -594,12 +592,15 @@ impl App {
     /// - Proc selected → proc's own reference.
     /// - Actor selected → owning proc from `detail.parent`.
     /// - Root/Host selected → `None` (PY-4).
-    pub(crate) fn pyspy_proc_ref(&self) -> Option<String> {
+    pub(crate) fn pyspy_proc_ref(&self) -> Option<hyperactor::reference::ProcId> {
         let rows = self.visible_rows();
         let row = rows.get(&self.cursor)?;
-        match row.node.node_type {
-            NodeType::Proc => Some(row.node.reference.clone()),
-            NodeType::Actor => self.detail.as_ref().and_then(|p| p.parent.clone()),
+        match (&row.node.node_type, &row.node.reference) {
+            (NodeType::Proc, NodeRef::Proc(proc_id)) => Some(proc_id.clone()),
+            (NodeType::Actor, _) => self.detail.as_ref().and_then(|p| match &p.parent {
+                Some(NodeRef::Proc(proc_id)) => Some(proc_id.clone()),
+                _ => None,
+            }),
             _ => None,
         }
     }
@@ -636,12 +637,9 @@ impl App {
     ///
     /// Calls `set_job` which drops any prior variant and its receiver,
     /// cancelling any in-flight fetch (PY-1/PY-2).
-    pub(crate) fn start_pyspy(&mut self, proc_ref: String) {
-        let short = proc_ref
-            .split(',')
-            .next_back()
-            .unwrap_or(&proc_ref)
-            .to_string();
+    pub(crate) fn start_pyspy(&mut self, proc_id: hyperactor::reference::ProcId) {
+        let proc_ref = proc_id.to_string();
+        let short = proc_id.name().to_string();
         let scheme = self.theme.scheme; // ColorScheme: Copy
         let client = self.client.clone();
         let base_url = self.base_url.clone();
@@ -676,12 +674,9 @@ impl App {
     ///
     /// Calls `set_job` which drops any prior variant and its receiver,
     /// cancelling any in-flight fetch (CFG-1/CFG-2).
-    pub(crate) fn start_config(&mut self, proc_ref: String) {
-        let short = proc_ref
-            .split(',')
-            .next_back()
-            .unwrap_or(&proc_ref)
-            .to_string();
+    pub(crate) fn start_config(&mut self, proc_id: hyperactor::reference::ProcId) {
+        let proc_ref = proc_id.to_string();
+        let short = proc_id.name().to_string();
         let scheme = self.theme.scheme; // ColorScheme: Copy
         let client = self.client.clone();
         let base_url = self.base_url.clone();
@@ -1329,11 +1324,11 @@ pub(crate) async fn run_app(
                                     completed_at: None,
                                 });
                             }
-                            KeyResult::RunPySpy(proc_ref) => {
-                                app.start_pyspy(proc_ref);
+                            KeyResult::RunPySpy(proc_id) => {
+                                app.start_pyspy(proc_id);
                             }
-                            KeyResult::RunConfig(proc_ref) => {
-                                app.start_config(proc_ref);
+                            KeyResult::RunConfig(proc_id) => {
+                                app.start_config(proc_id);
                             }
                             KeyResult::None => {}
                         }

--- a/hyperactor_mesh_admin_tui/src/diagnostics.rs
+++ b/hyperactor_mesh_admin_tui/src/diagnostics.rs
@@ -193,16 +193,16 @@ async fn probe(
     client: &reqwest::Client,
     base_url: &str,
     label: impl Into<String>,
-    reference: impl Into<String>,
+    reference: &hyperactor_mesh::introspect::NodeRef,
     phase: DiagPhase,
 ) -> (DiagResult, Option<hyperactor_mesh::introspect::NodePayload>) {
     let label = label.into();
-    let reference = reference.into();
+    let reference_str = reference.to_string();
     let t0 = Instant::now();
 
     let result = tokio::time::timeout(
         Duration::from_millis(TIMEOUT_MS),
-        fetch_node_raw(client, base_url, &reference),
+        fetch_node_raw(client, base_url, reference),
     )
     .await;
 
@@ -230,7 +230,7 @@ async fn probe(
     (
         DiagResult {
             label,
-            reference,
+            reference: reference_str,
             note: None,
             phase,
             outcome,
@@ -241,22 +241,20 @@ async fn probe(
 
 /// Derive a short human-readable label from the resolved NodePayload.
 fn label_from_payload(
-    reference: &str,
+    reference: &hyperactor_mesh::introspect::NodeRef,
     payload: &hyperactor_mesh::introspect::NodePayload,
 ) -> String {
+    use hyperactor_mesh::introspect::NodeRef;
     match &payload.properties {
         NodeProperties::Root { .. } => "root".to_string(),
         NodeProperties::Host { addr, .. } => addr.clone(),
         NodeProperties::Proc { proc_name, .. } => proc_name.clone(),
-        NodeProperties::Actor { .. } => {
-            // ActorId format: "proc_id,actor_name[rank]" — extract
-            // the last comma-separated component.
-            reference
-                .rsplit(',')
-                .next()
-                .unwrap_or(reference)
-                .to_string()
-        }
+        NodeProperties::Actor { .. } => match reference {
+            NodeRef::Actor(actor_id) => {
+                format!("{}[{}]", actor_id.name(), actor_id.pid())
+            }
+            other => other.to_string(),
+        },
         NodeProperties::Error { message, .. } => message.clone(),
     }
 }
@@ -277,9 +275,12 @@ fn proc_role(proc_name: &str) -> DiagNodeRole {
 async fn walk(client: &reqwest::Client, base_url: &str, tx: &mpsc::Sender<DiagResult>) {
     // Phase 1 — Admin Infra
 
+    use hyperactor_mesh::introspect::NodeRef;
+
     // Root.
+    let root_ref = NodeRef::Root;
     let (mut result, root_payload) =
-        probe(client, base_url, "root", "root", DiagPhase::AdminInfra).await;
+        probe(client, base_url, "root", &root_ref, DiagPhase::AdminInfra).await;
     result.note = Some(DiagNodeRole::AdminServer);
     emit!(tx, result);
     let root_payload = match root_payload {
@@ -289,24 +290,25 @@ async fn walk(client: &reqwest::Client, base_url: &str, tx: &mpsc::Sender<DiagRe
 
     // Root system_children is always empty (procs are never system,
     // standalone procs removed from root). Filter kept for robustness.
-    let root_system_refs: HashSet<&str> = match &root_payload.properties {
+    let root_system_refs: HashSet<&NodeRef> = match &root_payload.properties {
         NodeProperties::Root {
             system_children, ..
-        } => system_children.iter().map(|s| s.as_str()).collect(),
+        } => system_children.iter().collect(),
         _ => HashSet::new(),
     };
 
     for host_ref in root_payload
         .children
         .iter()
-        .filter(|r| !root_system_refs.contains(r.as_str()))
+        .filter(|r| !root_system_refs.contains(r))
     {
         // Host agent.
+        let host_label = host_ref.to_string();
         let (mut r, host_payload) = probe(
             client,
             base_url,
-            host_ref.as_str(),
-            host_ref.as_str(),
+            &host_label,
+            host_ref,
             DiagPhase::AdminInfra,
         )
         .await;
@@ -321,10 +323,10 @@ async fn walk(client: &reqwest::Client, base_url: &str, tx: &mpsc::Sender<DiagRe
             None => continue,
         };
 
-        let system_refs: HashSet<&str> = match &host_payload.properties {
+        let system_refs: HashSet<&NodeRef> = match &host_payload.properties {
             NodeProperties::Host {
                 system_children, ..
-            } => system_children.iter().map(|s| s.as_str()).collect(),
+            } => system_children.iter().collect(),
             _ => HashSet::new(),
         };
 
@@ -332,13 +334,14 @@ async fn walk(client: &reqwest::Client, base_url: &str, tx: &mpsc::Sender<DiagRe
         for proc_ref in host_payload
             .children
             .iter()
-            .filter(|r| system_refs.contains(r.as_str()))
+            .filter(|r| system_refs.contains(r))
         {
+            let proc_label = proc_ref.to_string();
             let (mut r, proc_payload) = probe(
                 client,
                 base_url,
-                proc_ref.as_str(),
-                proc_ref.as_str(),
+                &proc_label,
+                proc_ref,
                 DiagPhase::AdminInfra,
             )
             .await;
@@ -356,32 +359,41 @@ async fn walk(client: &reqwest::Client, base_url: &str, tx: &mpsc::Sender<DiagRe
 
             if let Some(proc_payload) = proc_payload {
                 for actor_ref in &proc_payload.children {
+                    let actor_label = actor_ref.to_string();
                     let (mut r, payload) = probe(
                         client,
                         base_url,
-                        actor_ref.as_str(),
-                        actor_ref.as_str(),
+                        &actor_label,
+                        actor_ref,
                         DiagPhase::AdminInfra,
                     )
                     .await;
                     // Use fetched label if available; otherwise derive
-                    // from ref string directly (same logic as
-                    // label_from_payload for Actor).
+                    // from the typed ref directly.
                     if let Some(p) = &payload {
                         r.label = format!("  {}", label_from_payload(actor_ref, p));
                     } else {
-                        let name = actor_ref.rsplit(',').next().unwrap_or(actor_ref.as_str());
-                        r.label = format!("  {}", name);
+                        let short = match actor_ref {
+                            NodeRef::Actor(id) => format!("{}[{}]", id.name(), id.pid()),
+                            other => other.to_string(),
+                        };
+                        r.label = format!("  {}", short);
                     }
-                    let actor_name = actor_ref.rsplit(',').next().unwrap_or("");
-                    r.note = if actor_name.starts_with(MESH_ADMIN_BRIDGE_NAME) {
-                        Some(DiagNodeRole::RootClientBridge)
-                    } else if actor_name.starts_with(MESH_ADMIN_ACTOR_NAME) {
-                        Some(DiagNodeRole::IntrospectionHandler)
-                    } else if actor_name.starts_with(HOST_MESH_AGENT_ACTOR_NAME) {
-                        Some(DiagNodeRole::ActorLifecycleManager)
-                    } else {
-                        None
+                    // Classify actor role from the typed ref.
+                    r.note = match actor_ref {
+                        NodeRef::Actor(actor_id) => {
+                            let actor_name = actor_id.name();
+                            if actor_name.starts_with(MESH_ADMIN_BRIDGE_NAME) {
+                                Some(DiagNodeRole::RootClientBridge)
+                            } else if actor_name.starts_with(MESH_ADMIN_ACTOR_NAME) {
+                                Some(DiagNodeRole::IntrospectionHandler)
+                            } else if actor_name.starts_with(HOST_MESH_AGENT_ACTOR_NAME) {
+                                Some(DiagNodeRole::ActorLifecycleManager)
+                            } else {
+                                None
+                            }
+                        }
+                        _ => None,
                     };
                     emit!(tx, r);
                 }
@@ -393,13 +405,14 @@ async fn walk(client: &reqwest::Client, base_url: &str, tx: &mpsc::Sender<DiagRe
         for user_proc_ref in host_payload
             .children
             .iter()
-            .filter(|r| !system_refs.contains(r.as_str()))
+            .filter(|r| !system_refs.contains(r))
         {
+            let proc_label = user_proc_ref.to_string();
             let (mut r, proc_payload) = probe(
                 client,
                 base_url,
-                user_proc_ref.as_str(),
-                user_proc_ref.as_str(),
+                &proc_label,
+                user_proc_ref,
                 DiagPhase::Mesh,
             )
             .await;
@@ -410,41 +423,45 @@ async fn walk(client: &reqwest::Client, base_url: &str, tx: &mpsc::Sender<DiagRe
             emit!(tx, r);
 
             if let Some(proc_payload) = proc_payload {
-                let proc_system_refs: HashSet<&str> = match &proc_payload.properties {
+                let proc_system_refs: HashSet<&NodeRef> = match &proc_payload.properties {
                     NodeProperties::Proc {
                         system_children, ..
-                    } => system_children.iter().map(|s| s.as_str()).collect(),
+                    } => system_children.iter().collect(),
                     _ => HashSet::new(),
+                };
+
+                // Derive actor role from a typed NodeRef.
+                let actor_role = |nr: &NodeRef| -> Option<DiagNodeRole> {
+                    match nr {
+                        NodeRef::Actor(actor_id) => {
+                            let name = actor_id.name();
+                            if name.starts_with(COMM_ACTOR_NAME) {
+                                Some(DiagNodeRole::CommActor)
+                            } else if name.starts_with(PROC_AGENT_ACTOR_NAME) {
+                                Some(DiagNodeRole::ProcAgent)
+                            } else {
+                                None
+                            }
+                        }
+                        _ => None,
+                    }
                 };
 
                 // Probe every system actor on this user proc.
                 for actor_ref in proc_payload
                     .children
                     .iter()
-                    .filter(|r| proc_system_refs.contains(r.as_str()))
+                    .filter(|r| proc_system_refs.contains(r))
                 {
-                    let (mut r, payload) = probe(
-                        client,
-                        base_url,
-                        actor_ref.as_str(),
-                        actor_ref.as_str(),
-                        DiagPhase::Mesh,
-                    )
-                    .await;
+                    let alabel = actor_ref.to_string();
+                    let (mut r, payload) =
+                        probe(client, base_url, &alabel, actor_ref, DiagPhase::Mesh).await;
                     if let Some(p) = &payload {
                         r.label = format!("  {}", label_from_payload(actor_ref, p));
                     } else {
-                        let name = actor_ref.rsplit(',').next().unwrap_or(actor_ref.as_str());
-                        r.label = format!("  {}", name);
+                        r.label = format!("  {}", alabel);
                     }
-                    let actor_name = actor_ref.rsplit(',').next().unwrap_or("");
-                    r.note = if actor_name.starts_with(COMM_ACTOR_NAME) {
-                        Some(DiagNodeRole::CommActor)
-                    } else if actor_name.starts_with(PROC_AGENT_ACTOR_NAME) {
-                        Some(DiagNodeRole::ProcAgent)
-                    } else {
-                        None
-                    };
+                    r.note = actor_role(actor_ref);
                     emit!(tx, r);
                 }
 
@@ -452,21 +469,15 @@ async fn walk(client: &reqwest::Client, base_url: &str, tx: &mpsc::Sender<DiagRe
                 if let Some(actor_ref) = proc_payload
                     .children
                     .iter()
-                    .find(|r| !proc_system_refs.contains(r.as_str()))
+                    .find(|r| !proc_system_refs.contains(r))
                 {
-                    let (mut r, payload) = probe(
-                        client,
-                        base_url,
-                        actor_ref.as_str(),
-                        actor_ref.as_str(),
-                        DiagPhase::Mesh,
-                    )
-                    .await;
+                    let alabel = actor_ref.to_string();
+                    let (mut r, payload) =
+                        probe(client, base_url, &alabel, actor_ref, DiagPhase::Mesh).await;
                     if let Some(p) = &payload {
                         r.label = format!("  {}", label_from_payload(actor_ref, p));
                     } else {
-                        let name = actor_ref.rsplit(',').next().unwrap_or(actor_ref.as_str());
-                        r.label = format!("  {}", name);
+                        r.label = format!("  {}", alabel);
                     }
                     r.note = Some(DiagNodeRole::UserActor);
                     emit!(tx, r);

--- a/hyperactor_mesh_admin_tui/src/fetch.rs
+++ b/hyperactor_mesh_admin_tui/src/fetch.rs
@@ -14,6 +14,7 @@ use std::pin::Pin;
 use algebra::JoinSemilattice;
 use hyperactor_mesh::introspect::NodePayload;
 use hyperactor_mesh::introspect::NodeProperties;
+use hyperactor_mesh::introspect::NodeRef;
 
 use crate::filter::is_failed_node;
 use crate::filter::is_stopped_node;
@@ -115,8 +116,8 @@ impl<T: Clone> JoinSemilattice for FetchState<T> {
 pub(crate) async fn fetch_with_join(
     client: &reqwest::Client,
     base_url: &str,
-    reference: &str,
-    cache: &mut HashMap<String, FetchState<NodePayload>>,
+    reference: &NodeRef,
+    cache: &mut HashMap<NodeRef, FetchState<NodePayload>>,
     refresh_gen: u64,
     seq_counter: &mut u64,
     force: bool,
@@ -157,7 +158,7 @@ pub(crate) async fn fetch_with_join(
 
         // Join into cache.
         cache
-            .entry(reference.to_string())
+            .entry(reference.clone())
             .and_modify(|s| *s = s.join(&new_state))
             .or_insert(new_state);
     }
@@ -169,12 +170,14 @@ pub(crate) async fn fetch_with_join(
 ///
 /// Free-function form of `App::fetch_node` so callers that hold
 /// partial borrows of `App` can avoid borrowing all of `&self`.
+/// The `NodeRef` is converted to its string form for the URL path.
 pub(crate) async fn fetch_node_raw(
     client: &reqwest::Client,
     base_url: &str,
-    reference: &str,
+    reference: &NodeRef,
 ) -> Result<NodePayload, String> {
-    let url = format!("{}/v1/{}", base_url, urlencoding::encode(reference));
+    let ref_str = reference.to_string();
+    let url = format!("{}/v1/{}", base_url, urlencoding::encode(&ref_str));
     let resp = client
         .get(&url)
         .send()
@@ -191,8 +194,8 @@ pub(crate) async fn fetch_node_raw(
 
 /// Extract cached payload from FetchState cache (free function).
 pub(crate) fn get_cached_payload<'a>(
-    cache: &'a HashMap<String, FetchState<NodePayload>>,
-    reference: &str,
+    cache: &'a HashMap<NodeRef, FetchState<NodePayload>>,
+    reference: &NodeRef,
 ) -> Option<&'a NodePayload> {
     cache.get(reference).and_then(|state| match state {
         FetchState::Ready { value, .. } => Some(value),
@@ -216,12 +219,12 @@ pub(crate) fn build_tree_node<'a>(
     base_url: &'a str,
     show_system: bool,
     show_stopped: bool,
-    cache: &'a mut HashMap<String, FetchState<NodePayload>>,
-    path: &'a mut Vec<String>,
-    reference: &'a str,
+    cache: &'a mut HashMap<NodeRef, FetchState<NodePayload>>,
+    path: &'a mut Vec<NodeRef>,
+    reference: &'a NodeRef,
     depth: usize,
-    expanded_keys: &'a HashSet<(String, usize)>,
-    failed_keys: &'a HashSet<(String, usize)>,
+    expanded_keys: &'a HashSet<(NodeRef, usize)>,
+    failed_keys: &'a HashSet<(NodeRef, usize)>,
     refresh_gen: u64,
     seq_counter: &'a mut u64,
 ) -> Pin<Box<dyn Future<Output = Option<TreeNode>> + Send + 'a>> {
@@ -233,10 +236,10 @@ pub(crate) fn build_tree_node<'a>(
 
         // Cycle guard: only reject if reference is in the current path
         // (true cycle), not if it appears elsewhere in the tree.
-        if path.contains(&reference.to_string()) {
+        if path.contains(reference) {
             return None;
         }
-        path.push(reference.to_string());
+        path.push(reference.clone());
 
         // Fetch using unified fetch+join path (force=false for cache-aware).
         let state = fetch_with_join(
@@ -276,7 +279,7 @@ pub(crate) fn build_tree_node<'a>(
         let label = derive_label(&payload);
         let node_type = NodeType::from_properties(&payload.properties);
         let has_children = !payload.children.is_empty();
-        let is_expanded = expanded_keys.contains(&(reference.to_string(), depth));
+        let is_expanded = expanded_keys.contains(&(reference.clone(), depth));
 
         // Build children if expanded.
         let mut children = Vec::new();
@@ -288,7 +291,7 @@ pub(crate) fn build_tree_node<'a>(
 
             // Extract system_children from the parent so we can filter
             // lazily without fetching each child individually.
-            let system_children: HashSet<&str> = match &payload.properties {
+            let system_children: HashSet<&NodeRef> = match &payload.properties {
                 NodeProperties::Root {
                     system_children, ..
                 }
@@ -297,22 +300,19 @@ pub(crate) fn build_tree_node<'a>(
                 }
                 | NodeProperties::Proc {
                     system_children, ..
-                } => system_children.iter().map(|s| s.as_str()).collect(),
+                } => system_children.iter().collect(),
                 _ => HashSet::new(),
             };
 
             // Extract stopped_children from proc payloads for lazy
             // filtering/graying without per-child fetches.
-            let (stopped_children, parent_is_poisoned): (HashSet<&str>, bool) =
+            let (stopped_children, parent_is_poisoned): (HashSet<&NodeRef>, bool) =
                 match &payload.properties {
                     NodeProperties::Proc {
                         stopped_children,
                         is_poisoned,
                         ..
-                    } => (
-                        stopped_children.iter().map(|s| s.as_str()).collect(),
-                        *is_poisoned,
-                    ),
+                    } => (stopped_children.iter().collect(), *is_poisoned),
                     _ => (HashSet::new(), false),
                 };
 
@@ -320,12 +320,12 @@ pub(crate) fn build_tree_node<'a>(
 
             for child_ref in &sorted {
                 // Filter order: system first, then stopped.
-                if !show_system && system_children.contains(child_ref.as_str()) {
+                if !show_system && system_children.contains(child_ref) {
                     continue;
                 }
 
-                let child_is_stopped = stopped_children.contains(child_ref.as_str());
-                let child_is_system = system_children.contains(child_ref.as_str());
+                let child_is_stopped = stopped_children.contains(child_ref);
+                let child_is_system = system_children.contains(child_ref);
 
                 // TUI-4: failed nodes always visible.
                 // If the parent proc is poisoned, its stopped children may be
@@ -345,8 +345,7 @@ pub(crate) fn build_tree_node<'a>(
                 if is_proc_or_actor {
                     // Lazy: create placeholder for unexpanded children,
                     // but recursively build expanded ones.
-                    let child_is_expanded =
-                        expanded_keys.contains(&(child_ref.to_string(), depth + 1));
+                    let child_is_expanded = expanded_keys.contains(&(child_ref.clone(), depth + 1));
 
                     if child_is_expanded {
                         if let Some(child_node) = build_tree_node(
@@ -451,10 +450,10 @@ pub(crate) fn build_tree_node<'a>(
             children.iter().any(|c| c.failed)
         } else {
             // Carried: children not built this cycle — inherit prior.
-            failed_keys.contains(&(reference.to_string(), depth))
+            failed_keys.contains(&(reference.clone(), depth))
         };
         let node = TreeNode {
-            reference: reference.to_string(),
+            reference: reference.clone(),
             label,
             node_type,
             expanded: is_expanded,
@@ -491,9 +490,12 @@ pub(crate) fn natural_ref_cmp(a: &str, b: &str) -> std::cmp::Ordering {
 }
 
 /// Clone and sort a payload's children by natural reference order.
-pub(crate) fn sorted_children(payload: &NodePayload) -> Vec<String> {
+///
+/// Sorts by the display form of each `NodeRef` using natural ordering
+/// so that `worker[2]` comes before `worker[10]`.
+pub(crate) fn sorted_children(payload: &NodePayload) -> Vec<NodeRef> {
     let mut children = payload.children.clone();
-    children.sort_by(|a, b| natural_ref_cmp(a, b));
+    children.sort_by(|a, b| natural_ref_cmp(&a.to_string(), &b.to_string()));
     children
 }
 
@@ -512,20 +514,28 @@ pub(crate) fn extract_trailing_index(s: &str) -> Option<(&str, u64)> {
 
 #[cfg(test)]
 mod tests {
+    use std::time::SystemTime;
+
     use algebra::JoinSemilattice;
     use hyperactor_mesh::introspect::NodePayload;
     use hyperactor_mesh::introspect::NodeProperties;
 
     use super::*;
 
-    fn mock_payload(identity: &str) -> NodePayload {
+    fn mock_actor_ref(name: &str) -> NodeRef {
+        use std::str::FromStr;
+        let id_str = format!("unix:@test,world,{}[0]", name);
+        NodeRef::Actor(hyperactor::reference::ActorId::from_str(&id_str).unwrap())
+    }
+
+    fn mock_payload(identity: NodeRef) -> NodePayload {
         NodePayload {
-            identity: identity.to_string(),
+            identity,
             properties: NodeProperties::Actor {
                 actor_status: "Running".to_string(),
                 actor_type: "test".to_string(),
                 messages_processed: 0,
-                created_at: "2026-01-01T00:00:00Z".to_string(),
+                created_at: Some(SystemTime::UNIX_EPOCH),
                 last_message_handler: None,
                 total_processing_time_us: 0,
                 flight_recorder: None,
@@ -534,7 +544,7 @@ mod tests {
             },
             children: vec![],
             parent: None,
-            as_of: "2026-01-01T00:00:00.000Z".to_string(),
+            as_of: SystemTime::now(),
         }
     }
 
@@ -581,7 +591,7 @@ mod tests {
 
     #[test]
     fn join_is_commutative() {
-        let payload = mock_payload("test");
+        let payload = mock_payload(mock_actor_ref("test"));
         let a = FetchState::Ready {
             stamp: Stamp {
                 ts_micros: 1000,
@@ -619,7 +629,7 @@ mod tests {
 
     #[test]
     fn join_is_associative() {
-        let payload = mock_payload("test");
+        let payload = mock_payload(mock_actor_ref("test"));
         let a = FetchState::Ready {
             stamp: Stamp {
                 ts_micros: 1000,
@@ -670,7 +680,7 @@ mod tests {
 
     #[test]
     fn join_is_idempotent() {
-        let payload = mock_payload("test");
+        let payload = mock_payload(mock_actor_ref("test"));
         let a = FetchState::Ready {
             stamp: Stamp {
                 ts_micros: 1000,
@@ -704,7 +714,7 @@ mod tests {
 
     #[test]
     fn join_unknown_is_identity() {
-        let payload = mock_payload("test");
+        let payload = mock_payload(mock_actor_ref("test"));
         let a = FetchState::Ready {
             stamp: Stamp {
                 ts_micros: 1000,
@@ -740,7 +750,7 @@ mod tests {
 
     #[test]
     fn join_prefers_newer_stamp() {
-        let payload = mock_payload("test");
+        let payload = mock_payload(mock_actor_ref("test"));
         let older = FetchState::Ready {
             stamp: Stamp {
                 ts_micros: 1000,
@@ -769,7 +779,7 @@ mod tests {
 
     #[test]
     fn join_uses_seq_for_tie_break() {
-        let payload = mock_payload("test");
+        let payload = mock_payload(mock_actor_ref("test"));
         let first = FetchState::Ready {
             stamp: Stamp {
                 ts_micros: 1000,
@@ -798,7 +808,7 @@ mod tests {
 
     #[test]
     fn join_deterministic_tie_break_ready_over_error() {
-        let payload = mock_payload("test");
+        let payload = mock_payload(mock_actor_ref("test"));
         let ready = FetchState::Ready {
             stamp: Stamp {
                 ts_micros: 1000,
@@ -894,7 +904,7 @@ mod tests {
                 seq: 1,
             },
             generation: 5,
-            value: mock_payload("fresh"),
+            value: mock_payload(mock_actor_ref("fresh")),
         };
 
         let result = error.join(&fresh_ready);
@@ -906,7 +916,7 @@ mod tests {
 
     #[test]
     fn join_refresh_staleness_triggers_refetch() {
-        let payload = mock_payload("test");
+        let payload = mock_payload(mock_actor_ref("test"));
         let stale = FetchState::Ready {
             stamp: Stamp {
                 ts_micros: 1000,
@@ -936,7 +946,7 @@ mod tests {
 
     #[test]
     fn cache_join_commutativity_ready_vs_error() {
-        let payload = mock_payload("test");
+        let payload = mock_payload(mock_actor_ref("test"));
         let ready = FetchState::Ready {
             stamp: Stamp {
                 ts_micros: 1000,
@@ -962,7 +972,7 @@ mod tests {
 
     #[test]
     fn join_cache_preserves_ready_when_generation_matches() {
-        let payload = mock_payload("current");
+        let payload = mock_payload(mock_actor_ref("current"));
         let current = FetchState::Ready {
             stamp: Stamp {
                 ts_micros: 1000,
@@ -1046,8 +1056,8 @@ mod tests {
 
     #[test]
     fn cache_join_ready_vs_ready_equal_stamps() {
-        let payload1 = mock_payload("first");
-        let payload2 = mock_payload("second");
+        let payload1 = mock_payload(mock_actor_ref("first"));
+        let payload2 = mock_payload(mock_actor_ref("second"));
 
         let ready1 = FetchState::Ready {
             stamp: Stamp {
@@ -1077,8 +1087,8 @@ mod tests {
 
     #[test]
     fn stale_cache_recovery() {
-        let old_payload = mock_payload("stale_data");
-        let new_payload = mock_payload("fresh_data");
+        let old_payload = mock_payload(mock_actor_ref("stale_data"));
+        let new_payload = mock_payload(mock_actor_ref("fresh_data"));
 
         let stale = FetchState::Ready {
             stamp: Stamp {
@@ -1102,7 +1112,7 @@ mod tests {
             FetchState::Ready {
                 value, generation, ..
             } => {
-                assert_eq!(value.identity, "fresh_data");
+                assert_eq!(value.identity, mock_actor_ref("fresh_data"));
                 assert_eq!(generation, 10);
             }
             _ => panic!("Expected Ready state"),
@@ -1118,13 +1128,13 @@ mod tests {
                 seq: 1,
             },
             generation: 10,
-            value: mock_payload("repaired"),
+            value: mock_payload(mock_actor_ref("repaired")),
         };
 
         let result = bad.join(&good);
         match result {
             FetchState::Ready { value, .. } => {
-                assert_eq!(value.identity, "repaired");
+                assert_eq!(value.identity, mock_actor_ref("repaired"));
             }
             _ => panic!("Expected recovery to Ready"),
         }
@@ -1132,7 +1142,7 @@ mod tests {
         let result2 = good.join(&bad);
         match result2 {
             FetchState::Ready { value, .. } => {
-                assert_eq!(value.identity, "repaired");
+                assert_eq!(value.identity, mock_actor_ref("repaired"));
             }
             _ => panic!("Expected recovery to Ready"),
         }
@@ -1146,7 +1156,7 @@ mod tests {
                 seq: 1,
             },
             generation: 5,
-            value: mock_payload("early"),
+            value: mock_payload(mock_actor_ref("early")),
         };
         let late = FetchState::Ready {
             stamp: Stamp {
@@ -1154,7 +1164,7 @@ mod tests {
                 seq: 1,
             },
             generation: 10,
-            value: mock_payload("late"),
+            value: mock_payload(mock_actor_ref("late")),
         };
 
         let result = early.join(&late);
@@ -1162,7 +1172,7 @@ mod tests {
             FetchState::Ready {
                 value, generation, ..
             } => {
-                assert_eq!(value.identity, "late");
+                assert_eq!(value.identity, mock_actor_ref("late"));
                 assert_eq!(generation, 10);
             }
             _ => panic!("Expected Ready with late data"),
@@ -1173,7 +1183,7 @@ mod tests {
             FetchState::Ready {
                 value, generation, ..
             } => {
-                assert_eq!(value.identity, "late");
+                assert_eq!(value.identity, mock_actor_ref("late"));
                 assert_eq!(generation, 10);
             }
             _ => panic!("Expected Ready with late data"),
@@ -1191,7 +1201,7 @@ mod tests {
                     seq: i,
                 },
                 generation: i,
-                value: mock_payload(&format!("refresh_{}", i)),
+                value: mock_payload(mock_actor_ref(&format!("refresh_{}", i))),
             };
 
             if let FetchState::Ready { stamp, .. } = &state {

--- a/hyperactor_mesh_admin_tui/src/filter.rs
+++ b/hyperactor_mesh_admin_tui/src/filter.rs
@@ -47,97 +47,59 @@ pub(crate) fn is_system_node(properties: &NodeProperties) -> bool {
 
 #[cfg(test)]
 mod tests {
+    use std::time::SystemTime;
+
     use hyperactor_mesh::introspect::FailureInfo;
 
     use super::*;
 
-    #[test]
-    fn is_stopped_node_true_for_stopped_prefix() {
-        let props = NodeProperties::Actor {
-            actor_status: "stopped:sleep completed (2.3s)".to_string(),
+    fn mock_actor_id() -> hyperactor::reference::ActorId {
+        use std::str::FromStr;
+        hyperactor::reference::ActorId::from_str("unix:@test,world,a[0]").unwrap()
+    }
+
+    fn actor_props(status: &str) -> NodeProperties {
+        NodeProperties::Actor {
+            actor_status: status.to_string(),
             actor_type: "test".to_string(),
             messages_processed: 0,
-            created_at: "".to_string(),
+            created_at: Some(SystemTime::UNIX_EPOCH),
             last_message_handler: None,
             total_processing_time_us: 0,
             flight_recorder: None,
-
             failure_info: None,
             is_system: false,
-        };
-        assert!(is_stopped_node(&props));
+        }
+    }
+
+    #[test]
+    fn is_stopped_node_true_for_stopped_prefix() {
+        assert!(is_stopped_node(&actor_props(
+            "stopped:sleep completed (2.3s)"
+        )));
     }
 
     #[test]
     fn is_stopped_node_true_for_failed_prefix() {
-        let props = NodeProperties::Actor {
-            actor_status: "failed:panic in handler".to_string(),
-            actor_type: "test".to_string(),
-            messages_processed: 0,
-            created_at: "".to_string(),
-            last_message_handler: None,
-            total_processing_time_us: 0,
-            flight_recorder: None,
-
-            failure_info: None,
-            is_system: false,
-        };
-        assert!(is_stopped_node(&props));
+        assert!(is_stopped_node(&actor_props("failed:panic in handler")));
     }
 
     #[test]
     fn is_stopped_node_false_for_running() {
-        let props = NodeProperties::Actor {
-            actor_status: "Running".to_string(),
-            actor_type: "test".to_string(),
-            messages_processed: 0,
-            created_at: "".to_string(),
-            last_message_handler: None,
-            total_processing_time_us: 0,
-            flight_recorder: None,
-
-            failure_info: None,
-            is_system: false,
-        };
-        assert!(!is_stopped_node(&props));
+        assert!(!is_stopped_node(&actor_props("Running")));
     }
 
     #[test]
     fn is_stopped_node_false_without_colon() {
-        let props = NodeProperties::Actor {
-            actor_status: "stopped".to_string(),
-            actor_type: "test".to_string(),
-            messages_processed: 0,
-            created_at: "".to_string(),
-            last_message_handler: None,
-            total_processing_time_us: 0,
-            flight_recorder: None,
-
-            failure_info: None,
-            is_system: false,
-        };
-        assert!(!is_stopped_node(&props));
-
-        let props2 = NodeProperties::Actor {
-            actor_status: "failed".to_string(),
-            actor_type: "test".to_string(),
-            messages_processed: 0,
-            created_at: "".to_string(),
-            last_message_handler: None,
-            total_processing_time_us: 0,
-            flight_recorder: None,
-
-            failure_info: None,
-            is_system: false,
-        };
-        assert!(!is_stopped_node(&props2));
+        assert!(!is_stopped_node(&actor_props("stopped")));
+        assert!(!is_stopped_node(&actor_props("failed")));
     }
 
     #[test]
     fn is_stopped_node_false_for_non_actor_variants() {
         let root = NodeProperties::Root {
             num_hosts: 1,
-            started_at: "".to_string(),
+            started_at: SystemTime::UNIX_EPOCH,
             started_by: "".to_string(),
             system_children: vec![],
         };
@@ -153,7 +115,6 @@ mod tests {
         let proc_props = NodeProperties::Proc {
             proc_name: "proc".to_string(),
             num_actors: 0,
-
             system_children: vec![],
             stopped_children: vec![],
             stopped_retention_cap: 0,
@@ -169,16 +130,15 @@ mod tests {
             actor_status: "failed:panic".to_string(),
             actor_type: "test".to_string(),
             messages_processed: 0,
-            created_at: "".to_string(),
+            created_at: Some(SystemTime::UNIX_EPOCH),
             last_message_handler: None,
             total_processing_time_us: 0,
             flight_recorder: None,
-
             failure_info: Some(FailureInfo {
                 error_message: "boom".to_string(),
-                root_cause_actor: "a[0]".to_string(),
+                root_cause_actor: mock_actor_id(),
                 root_cause_name: None,
-                occurred_at: "2025-01-01T00:00:00Z".to_string(),
+                occurred_at: SystemTime::UNIX_EPOCH,
                 is_propagated: false,
             }),
             is_system: false,
@@ -188,19 +148,7 @@ mod tests {
 
     #[test]
     fn is_failed_node_without_failure_info() {
-        let props = NodeProperties::Actor {
-            actor_status: "Running".to_string(),
-            actor_type: "test".to_string(),
-            messages_processed: 0,
-            created_at: "".to_string(),
-            last_message_handler: None,
-            total_processing_time_us: 0,
-            flight_recorder: None,
-
-            failure_info: None,
-            is_system: false,
-        };
-        assert!(!is_failed_node(&props));
+        assert!(!is_failed_node(&actor_props("Running")));
     }
 
     #[test]
@@ -208,7 +156,6 @@ mod tests {
         let props = NodeProperties::Proc {
             proc_name: "myproc".to_string(),
             num_actors: 1,
-
             system_children: vec![],
             stopped_children: vec![],
             stopped_retention_cap: 0,
@@ -223,7 +170,6 @@ mod tests {
         let props = NodeProperties::Proc {
             proc_name: "myproc".to_string(),
             num_actors: 1,
-
             system_children: vec![],
             stopped_children: vec![],
             stopped_retention_cap: 0,

--- a/hyperactor_mesh_admin_tui/src/format.rs
+++ b/hyperactor_mesh_admin_tui/src/format.rs
@@ -8,10 +8,12 @@
 
 use std::str::FromStr;
 use std::time::Duration;
+use std::time::SystemTime;
 
 use hyperactor::reference as hyperactor_reference;
 use hyperactor_mesh::introspect::NodePayload;
 use hyperactor_mesh::introspect::NodeProperties;
+use hyperactor_mesh::introspect::NodeRef;
 use serde_json::Value;
 
 /// Derive a human-friendly label for a resolved node payload.
@@ -76,27 +78,25 @@ pub(crate) fn derive_label(payload: &NodePayload) -> String {
                 base
             }
         }
-        NodeProperties::Actor { .. } => {
-            match hyperactor_reference::ActorId::from_str(&payload.identity) {
-                Ok(actor_id) => format!("{}[{}]", actor_id.name(), actor_id.pid()),
-                Err(_) => payload.identity.clone(),
-            }
-        }
+        NodeProperties::Actor { .. } => match &payload.identity {
+            NodeRef::Actor(actor_id) => format!("{}[{}]", actor_id.name(), actor_id.pid()),
+            other => other.to_string(),
+        },
         NodeProperties::Error { code, message } => {
             format!("[error] {}: {}", code, message)
         }
     }
 }
 
-/// Derive a display label from an opaque reference string without
+/// Derive a display label from a typed node reference without
 /// fetching.
 ///
-/// If the reference parses as an `ActorId`, format it as `name[pid]`;
-/// otherwise fall back to showing the raw reference.
-pub(crate) fn derive_label_from_ref(reference: &str) -> String {
-    match hyperactor_reference::ActorId::from_str(reference) {
-        Ok(actor_id) => format!("{}[{}]", actor_id.name(), actor_id.pid()),
-        Err(_) => reference.to_string(),
+/// For actor references, format as `name[pid]`; for all others, fall
+/// back to the `Display` representation.
+pub(crate) fn derive_label_from_ref(reference: &NodeRef) -> String {
+    match reference {
+        NodeRef::Actor(actor_id) => format!("{}[{}]", actor_id.name(), actor_id.pid()),
+        other => other.to_string(),
     }
 }
 
@@ -165,70 +165,103 @@ pub(crate) fn format_local_time(timestamp: &str) -> String {
         .unwrap_or_else(|_| timestamp.get(11..19).unwrap_or(timestamp).to_string())
 }
 
-/// Format an ISO-8601 timestamp as a human-readable relative time
-/// from now (e.g. "just now", "5s ago", "3m 12s ago", "1h 7m ago").
-pub(crate) fn format_relative_time(timestamp: &str) -> String {
-    match chrono::DateTime::parse_from_rfc3339(timestamp) {
-        Ok(parsed) => {
-            let now = chrono::Utc::now();
-            let duration = now.signed_duration_since(parsed);
-            let total_secs = duration.num_seconds();
-            if total_secs < 2 {
-                "just now".to_string()
-            } else if total_secs < 60 {
-                format!("{}s ago", total_secs)
-            } else if total_secs < 3600 {
-                let mins = total_secs / 60;
-                let secs = total_secs % 60;
-                format!("{}m {}s ago", mins, secs)
-            } else {
-                let hours = total_secs / 3600;
-                let mins = (total_secs % 3600) / 60;
-                format!("{}h {}m ago", hours, mins)
-            }
-        }
-        Err(_) => timestamp.to_string(),
+/// Convert a `SystemTime` to a `chrono::DateTime<Utc>`.
+fn system_time_to_chrono(t: &SystemTime) -> chrono::DateTime<chrono::Utc> {
+    let dur = t.duration_since(std::time::UNIX_EPOCH).unwrap_or_default();
+    chrono::DateTime::from_timestamp(dur.as_secs() as i64, dur.subsec_nanos()).unwrap_or_default()
+}
+
+/// Format a `SystemTime` as a local-timezone HH:MM:SS string.
+pub(crate) fn format_system_time_local(t: &SystemTime) -> String {
+    system_time_to_chrono(t)
+        .with_timezone(&chrono::Local)
+        .format("%H:%M:%S")
+        .to_string()
+}
+
+/// Format a `SystemTime` as a human-readable relative time from now
+/// (e.g. "just now", "5s ago", "3m 12s ago").
+pub(crate) fn format_system_time_relative(t: &SystemTime) -> String {
+    match t.elapsed() {
+        Ok(d) if d.as_secs() < 2 => "just now".to_string(),
+        Ok(d) => format!("{} ago", humantime::format_duration(d)),
+        Err(_) => "just now".to_string(),
     }
 }
 
-/// Format uptime duration from ISO-8601 start timestamp.
+/// Format uptime from a `SystemTime` start point.
 ///
 /// Rounds to nearest 30 seconds for cleaner display.
-pub(crate) fn format_uptime(started_at: &str) -> String {
-    match chrono::DateTime::parse_from_rfc3339(started_at) {
-        Ok(start_time) => {
-            let now = chrono::Utc::now();
-            let duration = now.signed_duration_since(start_time);
-            let total_secs = duration.num_seconds();
+pub(crate) fn format_system_time_uptime(started_at: &SystemTime) -> String {
+    match started_at.elapsed() {
+        Ok(d) => {
+            let total_secs = d.as_secs();
             let rounded_secs = ((total_secs + 15) / 30) * 30;
-            let std_duration = Duration::from_secs(rounded_secs as u64);
-            humantime::format_duration(std_duration).to_string()
+            humantime::format_duration(Duration::from_secs(rounded_secs)).to_string()
         }
         Err(_) => "unknown".to_string(),
     }
 }
 
+/// Format a `SystemTime` as an ISO-8601 string for display.
+pub(crate) fn format_system_time_iso(t: &SystemTime) -> String {
+    system_time_to_chrono(t).to_rfc3339()
+}
+
 #[cfg(test)]
 mod tests {
+    use std::str::FromStr;
+    use std::time::SystemTime;
+
+    use hyperactor::reference as hyperactor_reference;
     use hyperactor_mesh::introspect::NodePayload;
     use hyperactor_mesh::introspect::NodeProperties;
     use serde_json::Value;
 
     use super::*;
 
+    fn mock_actor_ref(name: &str) -> NodeRef {
+        let id_str = format!("unix:@test,world,{}[0]", name);
+        NodeRef::Actor(hyperactor_reference::ActorId::from_str(&id_str).unwrap())
+    }
+
+    fn mock_proc_ref(name: &str) -> NodeRef {
+        let id_str = format!("unix:@test,{}", name);
+        NodeRef::Proc(hyperactor_reference::ProcId::from_str(&id_str).unwrap())
+    }
+
+    fn mock_host_ref(name: &str) -> NodeRef {
+        let id_str = format!("unix:@test,world,{}[0]", name);
+        NodeRef::Host(hyperactor_reference::ActorId::from_str(&id_str).unwrap())
+    }
+
+    fn proc_payload(proc_name: &str, props: NodeProperties) -> NodePayload {
+        NodePayload {
+            identity: mock_proc_ref(proc_name),
+            properties: props,
+            children: vec![],
+            parent: None,
+            as_of: SystemTime::now(),
+        }
+    }
+
     #[test]
     fn derive_label_root_basic() {
         let payload = NodePayload {
-            identity: "root".to_string(),
+            identity: NodeRef::Root,
             properties: NodeProperties::Root {
                 num_hosts: 3,
-                started_at: "2026-01-01T00:00:00Z".to_string(),
+                started_at: SystemTime::UNIX_EPOCH,
                 started_by: "testuser".to_string(),
-                system_children: vec!["sys1".into()],
+                system_children: vec![mock_actor_ref("sys1")],
             },
-            children: vec!["h1".into(), "h2".into(), "h3".into()],
+            children: vec![
+                mock_host_ref("h1"),
+                mock_host_ref("h2"),
+                mock_host_ref("h3"),
+            ],
             parent: None,
-            as_of: "2026-01-01T00:00:00.000Z".to_string(),
+            as_of: SystemTime::now(),
         };
         assert_eq!(derive_label(&payload), "Mesh Root (3 hosts)");
     }
@@ -236,7 +269,7 @@ mod tests {
     #[test]
     fn derive_label_host_no_system_children() {
         let payload = NodePayload {
-            identity: "host:h1".to_string(),
+            identity: mock_host_ref("h1"),
             properties: NodeProperties::Host {
                 addr: "10.0.0.1:8000".to_string(),
                 num_procs: 3,
@@ -244,7 +277,7 @@ mod tests {
             },
             children: vec![],
             parent: None,
-            as_of: "".to_string(),
+            as_of: SystemTime::now(),
         };
         assert_eq!(derive_label(&payload), "10.0.0.1:8000  (3 procs)");
     }
@@ -252,15 +285,15 @@ mod tests {
     #[test]
     fn derive_label_host_with_system_children() {
         let payload = NodePayload {
-            identity: "host:h1".to_string(),
+            identity: mock_host_ref("h1"),
             properties: NodeProperties::Host {
                 addr: "10.0.0.1:8000".to_string(),
                 num_procs: 5,
-                system_children: vec!["sys1".into(), "sys2".into()],
+                system_children: vec![mock_actor_ref("sys1"), mock_actor_ref("sys2")],
             },
             children: vec![],
             parent: None,
-            as_of: "".to_string(),
+            as_of: SystemTime::now(),
         };
         assert_eq!(derive_label(&payload), "10.0.0.1:8000  (5 procs)");
     }
@@ -268,58 +301,50 @@ mod tests {
     #[test]
     fn derive_label_host_all_system() {
         let payload = NodePayload {
-            identity: "host:h1".to_string(),
+            identity: mock_host_ref("h1"),
             properties: NodeProperties::Host {
                 addr: "10.0.0.1:8000".to_string(),
                 num_procs: 2,
-                system_children: vec!["s1".into(), "s2".into()],
+                system_children: vec![mock_actor_ref("s1"), mock_actor_ref("s2")],
             },
             children: vec![],
             parent: None,
-            as_of: "".to_string(),
+            as_of: SystemTime::now(),
         };
         assert_eq!(derive_label(&payload), "10.0.0.1:8000  (2 procs)");
     }
 
     #[test]
     fn derive_label_proc_no_system_no_stopped() {
-        let payload = NodePayload {
-            identity: "myproc".to_string(),
-            properties: NodeProperties::Proc {
+        let payload = proc_payload(
+            "myproc",
+            NodeProperties::Proc {
                 proc_name: "myproc".to_string(),
                 num_actors: 4,
-
                 system_children: vec![],
                 stopped_children: vec![],
                 stopped_retention_cap: 0,
                 is_poisoned: false,
                 failed_actor_count: 0,
             },
-            children: vec![],
-            parent: None,
-            as_of: "".to_string(),
-        };
+        );
         assert_eq!(derive_label(&payload), "myproc  (4 actors: 4 user)");
     }
 
     #[test]
     fn derive_label_proc_with_system_no_stopped() {
-        let payload = NodePayload {
-            identity: "myproc".to_string(),
-            properties: NodeProperties::Proc {
+        let payload = proc_payload(
+            "myproc",
+            NodeProperties::Proc {
                 proc_name: "myproc".to_string(),
                 num_actors: 5,
-
-                system_children: vec!["sys1".into(), "sys2".into()],
+                system_children: vec![mock_actor_ref("sys1"), mock_actor_ref("sys2")],
                 stopped_children: vec![],
                 stopped_retention_cap: 0,
                 is_poisoned: false,
                 failed_actor_count: 0,
             },
-            children: vec![],
-            parent: None,
-            as_of: "".to_string(),
-        };
+        );
         assert_eq!(
             derive_label(&payload),
             "myproc  (5 actors: 2 system, 3 user)"
@@ -328,22 +353,18 @@ mod tests {
 
     #[test]
     fn derive_label_proc_with_stopped() {
-        let payload = NodePayload {
-            identity: "myproc".to_string(),
-            properties: NodeProperties::Proc {
+        let payload = proc_payload(
+            "myproc",
+            NodeProperties::Proc {
                 proc_name: "myproc".to_string(),
                 num_actors: 3,
-
                 system_children: vec![],
-                stopped_children: vec!["s1".into(), "s2".into()],
+                stopped_children: vec![mock_actor_ref("s1"), mock_actor_ref("s2")],
                 stopped_retention_cap: 100,
                 is_poisoned: false,
                 failed_actor_count: 0,
             },
-            children: vec![],
-            parent: None,
-            as_of: "".to_string(),
-        };
+        );
         assert_eq!(
             derive_label(&payload),
             "myproc  (5 actors: 3 user, 2 stopped)"
@@ -352,43 +373,39 @@ mod tests {
 
     #[test]
     fn derive_label_proc_stopped_at_retention_cap() {
-        let payload = NodePayload {
-            identity: "myproc".to_string(),
-            properties: NodeProperties::Proc {
+        let payload = proc_payload(
+            "myproc",
+            NodeProperties::Proc {
                 proc_name: "myproc".to_string(),
                 num_actors: 1,
-
                 system_children: vec![],
-                stopped_children: vec!["s1".into(), "s2".into(), "s3".into()],
+                stopped_children: vec![
+                    mock_actor_ref("s1"),
+                    mock_actor_ref("s2"),
+                    mock_actor_ref("s3"),
+                ],
                 stopped_retention_cap: 3,
                 is_poisoned: false,
                 failed_actor_count: 0,
             },
-            children: vec![],
-            parent: None,
-            as_of: "".to_string(),
-        };
+        );
         assert!(derive_label(&payload).contains("3 stopped (max retained)"));
     }
 
     #[test]
     fn derive_label_proc_stopped_retention_cap_zero_never_annotates() {
-        let payload = NodePayload {
-            identity: "myproc".to_string(),
-            properties: NodeProperties::Proc {
+        let payload = proc_payload(
+            "myproc",
+            NodeProperties::Proc {
                 proc_name: "myproc".to_string(),
                 num_actors: 0,
-
                 system_children: vec![],
-                stopped_children: vec!["s1".into()],
+                stopped_children: vec![mock_actor_ref("s1")],
                 stopped_retention_cap: 0,
                 is_poisoned: false,
                 failed_actor_count: 0,
             },
-            children: vec![],
-            parent: None,
-            as_of: "".to_string(),
-        };
+        );
         let label = derive_label(&payload);
         assert!(label.contains("1 stopped"));
         assert!(!label.contains("max retained"));
@@ -396,22 +413,18 @@ mod tests {
 
     #[test]
     fn derive_label_proc_system_and_stopped_and_user() {
-        let payload = NodePayload {
-            identity: "myproc".to_string(),
-            properties: NodeProperties::Proc {
+        let payload = proc_payload(
+            "myproc",
+            NodeProperties::Proc {
                 proc_name: "myproc".to_string(),
                 num_actors: 5,
-
-                system_children: vec!["sys1".into()],
-                stopped_children: vec!["dead1".into(), "dead2".into()],
+                system_children: vec![mock_actor_ref("sys1")],
+                stopped_children: vec![mock_actor_ref("dead1"), mock_actor_ref("dead2")],
                 stopped_retention_cap: 100,
                 is_poisoned: false,
                 failed_actor_count: 0,
             },
-            children: vec![],
-            parent: None,
-            as_of: "".to_string(),
-        };
+        );
         assert_eq!(
             derive_label(&payload),
             "myproc  (7 actors: 1 system, 4 user, 2 stopped)"
@@ -420,43 +433,39 @@ mod tests {
 
     #[test]
     fn derive_label_proc_all_stopped_none_user() {
-        let payload = NodePayload {
-            identity: "myproc".to_string(),
-            properties: NodeProperties::Proc {
+        let payload = proc_payload(
+            "myproc",
+            NodeProperties::Proc {
                 proc_name: "myproc".to_string(),
                 num_actors: 0,
-
                 system_children: vec![],
-                stopped_children: vec!["d1".into(), "d2".into()],
+                stopped_children: vec![mock_actor_ref("d1"), mock_actor_ref("d2")],
                 stopped_retention_cap: 100,
                 is_poisoned: false,
                 failed_actor_count: 0,
             },
-            children: vec![],
-            parent: None,
-            as_of: "".to_string(),
-        };
+        );
         assert_eq!(derive_label(&payload), "myproc  (2 actors: 2 stopped)");
     }
 
     #[test]
     fn derive_label_proc_saturating_sub_prevents_underflow() {
-        let payload = NodePayload {
-            identity: "myproc".to_string(),
-            properties: NodeProperties::Proc {
+        let payload = proc_payload(
+            "myproc",
+            NodeProperties::Proc {
                 proc_name: "myproc".to_string(),
                 num_actors: 1,
-
-                system_children: vec!["s1".into(), "s2".into(), "s3".into()],
+                system_children: vec![
+                    mock_actor_ref("s1"),
+                    mock_actor_ref("s2"),
+                    mock_actor_ref("s3"),
+                ],
                 stopped_children: vec![],
                 stopped_retention_cap: 0,
                 is_poisoned: false,
                 failed_actor_count: 0,
             },
-            children: vec![],
-            parent: None,
-            as_of: "".to_string(),
-        };
+        );
         let label = derive_label(&payload);
         assert!(label.contains("3 system"));
         assert!(!label.contains("user"));
@@ -464,57 +473,52 @@ mod tests {
 
     #[test]
     fn derive_label_proc_poisoned() {
-        let payload = NodePayload {
-            identity: "myproc".to_string(),
-            properties: NodeProperties::Proc {
+        let payload = proc_payload(
+            "myproc",
+            NodeProperties::Proc {
                 proc_name: "myproc".to_string(),
                 num_actors: 2,
-
                 system_children: vec![],
-                stopped_children: vec!["dead1".into()],
+                stopped_children: vec![mock_actor_ref("dead1")],
                 stopped_retention_cap: 100,
                 is_poisoned: true,
                 failed_actor_count: 1,
             },
-            children: vec![],
-            parent: None,
-            as_of: "".to_string(),
-        };
+        );
         let label = derive_label(&payload);
         assert!(label.contains("[POISONED: 1 failed]"));
     }
 
     #[test]
     fn derive_label_proc_not_poisoned() {
-        let payload = NodePayload {
-            identity: "myproc".to_string(),
-            properties: NodeProperties::Proc {
+        let payload = proc_payload(
+            "myproc",
+            NodeProperties::Proc {
                 proc_name: "myproc".to_string(),
                 num_actors: 3,
-
                 system_children: vec![],
                 stopped_children: vec![],
                 stopped_retention_cap: 100,
                 is_poisoned: false,
                 failed_actor_count: 0,
             },
-            children: vec![],
-            parent: None,
-            as_of: "".to_string(),
-        };
+        );
         let label = derive_label(&payload);
         assert!(!label.contains("POISONED"));
     }
 
     #[test]
     fn derive_label_actor_standard_actor_id() {
+        let actor_id =
+            hyperactor_reference::ActorId::from_str("unix:@abc123,myworld,worker[3]").unwrap();
+        let proc_id = hyperactor_reference::ProcId::from_str("unix:@abc123,myworld").unwrap();
         let payload = NodePayload {
-            identity: "unix:@abc123,myworld,worker[3]".to_string(),
+            identity: NodeRef::Actor(actor_id),
             properties: NodeProperties::Actor {
                 actor_status: "Running".to_string(),
                 actor_type: "Worker".to_string(),
                 messages_processed: 42,
-                created_at: "2026-01-01T00:00:00Z".to_string(),
+                created_at: Some(SystemTime::UNIX_EPOCH),
                 last_message_handler: Some("handle_task".to_string()),
                 total_processing_time_us: 1000,
                 flight_recorder: None,
@@ -522,21 +526,23 @@ mod tests {
                 is_system: false,
             },
             children: vec![],
-            parent: Some("unix:@abc123,myworld".to_string()),
-            as_of: "2026-01-01T00:00:00.000Z".to_string(),
+            parent: Some(NodeRef::Proc(proc_id)),
+            as_of: SystemTime::now(),
         };
         assert_eq!(derive_label(&payload), "worker[3]");
     }
 
     #[test]
-    fn derive_label_actor_unparseable_identity() {
+    fn derive_label_actor_non_actor_identity_falls_back() {
+        // When an Actor node has a non-Actor identity (shouldn't
+        // happen in practice), derive_label falls back to Display.
         let payload = NodePayload {
-            identity: "not-a-valid-actor-id!!!".to_string(),
+            identity: NodeRef::Root,
             properties: NodeProperties::Actor {
                 actor_status: "Running".to_string(),
                 actor_type: "Unknown".to_string(),
                 messages_processed: 0,
-                created_at: "2026-01-01T00:00:00Z".to_string(),
+                created_at: Some(SystemTime::UNIX_EPOCH),
                 last_message_handler: None,
                 total_processing_time_us: 0,
                 flight_recorder: None,
@@ -545,9 +551,9 @@ mod tests {
             },
             children: vec![],
             parent: None,
-            as_of: "2026-01-01T00:00:00.000Z".to_string(),
+            as_of: SystemTime::now(),
         };
-        assert_eq!(derive_label(&payload), "not-a-valid-actor-id!!!");
+        assert_eq!(derive_label(&payload), "root");
     }
 
     #[test]
@@ -617,15 +623,5 @@ mod tests {
     #[test]
     fn format_local_time_too_short_fallback() {
         assert_eq!(format_local_time("short"), "short");
-    }
-
-    #[test]
-    fn format_relative_time_parse_failure_fallback() {
-        assert_eq!(format_relative_time("not-a-date"), "not-a-date");
-    }
-
-    #[test]
-    fn format_uptime_parse_failure() {
-        assert_eq!(format_uptime("garbage"), "unknown");
     }
 }

--- a/hyperactor_mesh_admin_tui/src/lib.rs
+++ b/hyperactor_mesh_admin_tui/src/lib.rs
@@ -50,8 +50,11 @@
 //! - **TUI-11 (selection-semantics):** Cursor restoration prefers
 //!   `(reference, depth)` to disambiguate; falls back to
 //!   reference-only if depth changes.
-//! - **TUI-12 (serial-fetches):** HTTP fetches are scheduled
-//!   serially; join semantics handle retries and reordering.
+//! - **TUI-12 (serial-topology-fetches):** Topology cache fetches
+//!   (via `fetch_with_join` / `build_tree_node`) are serial within
+//!   a refresh cycle; join semantics handle retries and reordering.
+//!   Overlay fetches (py-spy, config, diagnostics) are concurrent
+//!   via `tokio::spawn` and do not participate in the topology cache.
 //! - **TUI-13 (stopped-detection):** `is_stopped_node` matches
 //!   `Actor` variants whose `actor_status` starts with `"stopped:"`
 //!   or `"failed:"`. All other variants return false.

--- a/hyperactor_mesh_admin_tui/src/model.rs
+++ b/hyperactor_mesh_admin_tui/src/model.rs
@@ -8,6 +8,7 @@
 
 use hyperactor_mesh::introspect::NodePayload;
 use hyperactor_mesh::introspect::NodeProperties;
+use hyperactor_mesh::introspect::NodeRef;
 
 use crate::filter::is_failed_node;
 use crate::filter::is_stopped_node;
@@ -192,9 +193,8 @@ impl NodeType {
 /// recursively, respecting `expanded_keys` and depth limits.
 #[derive(Debug, Clone)]
 pub(crate) struct TreeNode {
-    /// Opaque reference string for this node (identity in the admin
-    /// API).
-    pub(crate) reference: String,
+    /// Typed node reference (identity in the admin API).
+    pub(crate) reference: NodeRef,
     /// Human-friendly label shown in the tree (derived from
     /// [`NodePayload`]).
     pub(crate) label: String,
@@ -225,7 +225,7 @@ impl TreeNode {
     /// Placeholders are created from parent children lists without
     /// fetching payload. They have `fetched: false`, `has_children:
     /// true`, and empty `children` vector.
-    pub(crate) fn placeholder(reference: String) -> Self {
+    pub(crate) fn placeholder(reference: NodeRef) -> Self {
         Self {
             label: derive_label_from_ref(&reference),
             reference,
@@ -244,7 +244,7 @@ impl TreeNode {
     ///
     /// Like `placeholder` but with `stopped: true` so the node
     /// renders gray and can be filtered without a child fetch.
-    pub(crate) fn placeholder_stopped(reference: String) -> Self {
+    pub(crate) fn placeholder_stopped(reference: NodeRef) -> Self {
         Self {
             label: derive_label_from_ref(&reference),
             reference,
@@ -263,7 +263,7 @@ impl TreeNode {
     ///
     /// Used when building child lists from cached or freshly fetched
     /// payloads. The node starts collapsed with no children.
-    pub(crate) fn from_payload(reference: String, payload: &NodePayload) -> Self {
+    pub(crate) fn from_payload(reference: NodeRef, payload: &NodePayload) -> Self {
         Self {
             label: derive_label(payload),
             node_type: NodeType::from_properties(&payload.properties),
@@ -333,21 +333,37 @@ impl<'a> VisibleRows<'a> {
 
 #[cfg(test)]
 mod tests {
+    use std::time::SystemTime;
+
     use hyperactor_mesh::introspect::FailureInfo;
     use hyperactor_mesh::introspect::NodePayload;
     use hyperactor_mesh::introspect::NodeProperties;
+    use hyperactor_mesh::introspect::NodeRef;
 
     use super::*;
 
+    fn mock_actor_ref(name: &str) -> NodeRef {
+        use std::str::FromStr;
+        // Create a simple ActorId for testing.
+        let id_str = format!("unix:@test,world,{}[0]", name);
+        NodeRef::Actor(hyperactor::reference::ActorId::from_str(&id_str).unwrap())
+    }
+
+    fn mock_proc_ref(name: &str) -> NodeRef {
+        use std::str::FromStr;
+        let id_str = format!("unix:@test,{}", name);
+        NodeRef::Proc(hyperactor::reference::ProcId::from_str(&id_str).unwrap())
+    }
+
     // Helper to create test payloads
-    fn mock_payload(identity: &str) -> NodePayload {
+    fn mock_payload(identity: NodeRef) -> NodePayload {
         NodePayload {
-            identity: identity.to_string(),
+            identity,
             properties: NodeProperties::Actor {
                 actor_status: "Running".to_string(),
                 actor_type: "test".to_string(),
                 messages_processed: 0,
-                created_at: "2026-01-01T00:00:00Z".to_string(),
+                created_at: Some(SystemTime::UNIX_EPOCH),
                 last_message_handler: None,
                 total_processing_time_us: 0,
                 flight_recorder: None,
@@ -356,7 +372,7 @@ mod tests {
             },
             children: vec![],
             parent: None,
-            as_of: "2026-01-01T00:00:00.000Z".to_string(),
+            as_of: SystemTime::now(),
         }
     }
 
@@ -554,8 +570,9 @@ mod tests {
 
     #[test]
     fn placeholder_stopped_differs_only_in_stopped_field() {
-        let normal = TreeNode::placeholder("actor1".to_string());
-        let stopped = TreeNode::placeholder_stopped("actor1".to_string());
+        let r = mock_actor_ref("actor1");
+        let normal = TreeNode::placeholder(r.clone());
+        let stopped = TreeNode::placeholder_stopped(r);
         assert_eq!(normal.reference, stopped.reference);
         assert_eq!(normal.label, stopped.label);
         assert!(matches!(normal.node_type, NodeType::Actor));
@@ -572,13 +589,14 @@ mod tests {
 
     #[test]
     fn from_payload_sets_stopped_for_stopped_actor() {
+        let r = mock_actor_ref("actor1");
         let payload = NodePayload {
-            identity: "actor1".to_string(),
+            identity: r.clone(),
             properties: NodeProperties::Actor {
                 actor_status: "stopped:done".to_string(),
                 actor_type: "test".to_string(),
                 messages_processed: 5,
-                created_at: "".to_string(),
+                created_at: Some(SystemTime::UNIX_EPOCH),
                 last_message_handler: None,
                 total_processing_time_us: 0,
                 flight_recorder: None,
@@ -587,28 +605,30 @@ mod tests {
             },
             children: vec![],
             parent: None,
-            as_of: "".to_string(),
+            as_of: SystemTime::now(),
         };
-        let node = TreeNode::from_payload("actor1".to_string(), &payload);
+        let node = TreeNode::from_payload(r, &payload);
         assert!(node.stopped);
     }
 
     #[test]
     fn from_payload_not_stopped_for_running_actor() {
-        let payload = mock_payload("actor1");
-        let node = TreeNode::from_payload("actor1".to_string(), &payload);
+        let r = mock_actor_ref("actor1");
+        let payload = mock_payload(r.clone());
+        let node = TreeNode::from_payload(r, &payload);
         assert!(!node.stopped);
     }
 
     #[test]
     fn from_payload_sets_is_system_for_system_actor() {
+        let r = mock_actor_ref("host_agent");
         let payload = NodePayload {
-            identity: "host_agent[0]".to_string(),
+            identity: r.clone(),
             properties: NodeProperties::Actor {
                 actor_status: "idle".to_string(),
                 actor_type: "hyperactor_mesh::proc_agent::ProcAgent".to_string(),
                 messages_processed: 10,
-                created_at: "".to_string(),
+                created_at: Some(SystemTime::UNIX_EPOCH),
                 last_message_handler: None,
                 total_processing_time_us: 0,
                 flight_recorder: None,
@@ -617,87 +637,96 @@ mod tests {
             },
             children: vec![],
             parent: None,
-            as_of: "".to_string(),
+            as_of: SystemTime::now(),
         };
-        let node = TreeNode::from_payload("host_agent[0]".to_string(), &payload);
+        let node = TreeNode::from_payload(r, &payload);
         assert!(node.is_system);
         assert!(!node.stopped);
     }
 
     #[test]
     fn from_payload_not_system_for_user_actor() {
-        let payload = mock_payload("worker[0]");
-        let node = TreeNode::from_payload("worker[0]".to_string(), &payload);
+        let r = mock_actor_ref("worker");
+        let payload = mock_payload(r.clone());
+        let node = TreeNode::from_payload(r, &payload);
         assert!(!node.is_system);
     }
 
     #[test]
     fn from_payload_proc_is_never_stopped() {
+        let r = mock_proc_ref("proc1");
         let payload = NodePayload {
-            identity: "proc1".to_string(),
+            identity: r.clone(),
             properties: NodeProperties::Proc {
                 proc_name: "proc1".to_string(),
                 num_actors: 0,
                 system_children: vec![],
-                stopped_children: vec!["x".to_string()],
+                stopped_children: vec![mock_actor_ref("x")],
                 stopped_retention_cap: 10,
                 is_poisoned: false,
                 failed_actor_count: 0,
             },
             children: vec![],
             parent: None,
-            as_of: "".to_string(),
+            as_of: SystemTime::now(),
         };
-        let node = TreeNode::from_payload("proc1".to_string(), &payload);
+        let node = TreeNode::from_payload(r, &payload);
         assert!(!node.stopped);
     }
 
     #[test]
     fn from_payload_sets_failed_for_actor_with_failure_info() {
+        let r = mock_actor_ref("actor1");
+        let worker_id = {
+            use std::str::FromStr;
+            hyperactor::reference::ActorId::from_str("unix:@test,world,worker[0]").unwrap()
+        };
         let payload = NodePayload {
-            identity: "actor1".to_string(),
+            identity: r.clone(),
             properties: NodeProperties::Actor {
                 actor_status: "failed:panic".to_string(),
                 actor_type: "test".to_string(),
                 messages_processed: 0,
-                created_at: "".to_string(),
+                created_at: Some(SystemTime::UNIX_EPOCH),
                 last_message_handler: None,
                 total_processing_time_us: 0,
                 flight_recorder: None,
                 is_system: false,
                 failure_info: Some(FailureInfo {
                     error_message: "GPU memory corruption".to_string(),
-                    root_cause_actor: "worker[0]".to_string(),
+                    root_cause_actor: worker_id,
                     root_cause_name: Some("worker".to_string()),
-                    occurred_at: "2025-01-01T00:00:00Z".to_string(),
+                    occurred_at: SystemTime::UNIX_EPOCH,
                     is_propagated: false,
                 }),
             },
             children: vec![],
             parent: None,
-            as_of: "".to_string(),
+            as_of: SystemTime::now(),
         };
-        let node = TreeNode::from_payload("actor1".to_string(), &payload);
+        let node = TreeNode::from_payload(r, &payload);
         assert!(node.failed);
         assert!(node.stopped);
     }
 
     #[test]
     fn from_payload_not_failed_without_failure_info() {
-        let payload = mock_payload("actor1");
-        let node = TreeNode::from_payload("actor1".to_string(), &payload);
+        let r = mock_actor_ref("actor1");
+        let payload = mock_payload(r.clone());
+        let node = TreeNode::from_payload(r, &payload);
         assert!(!node.failed);
     }
 
     #[test]
     fn from_payload_or_logic_both_sources_agree() {
+        let r = mock_actor_ref("actor1");
         let payload = NodePayload {
-            identity: "actor1".to_string(),
+            identity: r.clone(),
             properties: NodeProperties::Actor {
                 actor_status: "stopped:done".to_string(),
                 actor_type: "test".to_string(),
                 messages_processed: 0,
-                created_at: "".to_string(),
+                created_at: Some(SystemTime::UNIX_EPOCH),
                 last_message_handler: None,
                 total_processing_time_us: 0,
                 flight_recorder: None,
@@ -706,9 +735,9 @@ mod tests {
             },
             children: vec![],
             parent: None,
-            as_of: "".to_string(),
+            as_of: SystemTime::now(),
         };
-        let mut node = TreeNode::from_payload("actor1".to_string(), &payload);
+        let mut node = TreeNode::from_payload(r, &payload);
         let child_is_stopped = true;
         node.stopped = node.stopped || child_is_stopped;
         assert!(node.stopped);
@@ -716,8 +745,9 @@ mod tests {
 
     #[test]
     fn from_payload_or_logic_only_proc_list() {
-        let payload = mock_payload("actor1");
-        let mut node = TreeNode::from_payload("actor1".to_string(), &payload);
+        let r = mock_actor_ref("actor1");
+        let payload = mock_payload(r.clone());
+        let mut node = TreeNode::from_payload(r, &payload);
         assert!(!node.stopped);
         let child_is_stopped = true;
         node.stopped = node.stopped || child_is_stopped;
@@ -726,13 +756,14 @@ mod tests {
 
     #[test]
     fn from_payload_or_logic_only_cached_payload() {
+        let r = mock_actor_ref("actor1");
         let payload = NodePayload {
-            identity: "actor1".to_string(),
+            identity: r.clone(),
             properties: NodeProperties::Actor {
                 actor_status: "failed:panic".to_string(),
                 actor_type: "test".to_string(),
                 messages_processed: 0,
-                created_at: "".to_string(),
+                created_at: Some(SystemTime::UNIX_EPOCH),
                 last_message_handler: None,
                 total_processing_time_us: 0,
                 flight_recorder: None,
@@ -741,9 +772,9 @@ mod tests {
             },
             children: vec![],
             parent: None,
-            as_of: "".to_string(),
+            as_of: SystemTime::now(),
         };
-        let mut node = TreeNode::from_payload("actor1".to_string(), &payload);
+        let mut node = TreeNode::from_payload(r, &payload);
         assert!(node.stopped);
         let child_is_stopped = false;
         node.stopped = node.stopped || child_is_stopped;

--- a/hyperactor_mesh_admin_tui/src/render/detail_pane.rs
+++ b/hyperactor_mesh_admin_tui/src/render/detail_pane.rs
@@ -6,13 +6,13 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-use std::str::FromStr;
+use std::time::SystemTime;
 
 use hyperactor::introspect::RecordedEvent;
-use hyperactor::reference as hyperactor_reference;
 use hyperactor_mesh::introspect::FailureInfo;
 use hyperactor_mesh::introspect::NodePayload;
 use hyperactor_mesh::introspect::NodeProperties;
+use hyperactor_mesh::introspect::NodeRef;
 use ratatui::layout::Constraint;
 use ratatui::layout::Direction;
 use ratatui::layout::Layout;
@@ -35,8 +35,10 @@ use crate::diagnostics::DiagResult;
 use crate::diagnostics::DiagSummary;
 use crate::format::format_event_summary;
 use crate::format::format_local_time;
-use crate::format::format_relative_time;
-use crate::format::format_uptime;
+use crate::format::format_system_time_iso;
+use crate::format::format_system_time_local;
+use crate::format::format_system_time_relative;
+use crate::format::format_system_time_uptime;
 use crate::theme::ColorScheme;
 use crate::theme::Labels;
 
@@ -190,7 +192,7 @@ fn render_root_detail(
     area: Rect,
     payload: &NodePayload,
     num_hosts: usize,
-    started_at: &str,
+    started_at: &SystemTime,
     started_by: &str,
     scheme: &ColorScheme,
     l: &Labels,
@@ -200,20 +202,25 @@ fn render_root_detail(
         .borders(Borders::ALL)
         .border_style(scheme.border);
 
-    let uptime_str = format_uptime(started_at);
+    let uptime_str = format_system_time_uptime(started_at);
 
     let mut lines = vec![
         detail_line(l.hosts, num_hosts.to_string(), scheme),
         detail_line(l.started_by, started_by, scheme),
         detail_line(l.uptime_detail, &uptime_str, scheme),
-        detail_line(l.started_at, format_local_time(started_at), scheme),
-        detail_line(l.data_as_of, format_relative_time(&payload.as_of), scheme),
+        detail_line(l.started_at, format_system_time_local(started_at), scheme),
+        detail_line(
+            l.data_as_of,
+            format_system_time_relative(&payload.as_of),
+            scheme,
+        ),
         Line::default(),
     ];
     for child in &payload.children {
+        let child_str = child.to_string();
         lines.push(Line::from(vec![
             Span::styled("  ", Style::default()),
-            Span::styled(child, scheme.node_host),
+            Span::styled(child_str, scheme.node_host),
         ]));
     }
 
@@ -242,13 +249,19 @@ fn render_host_detail(
     let mut lines = vec![
         detail_line(l.address, addr, scheme),
         detail_line(l.procs, num_procs.to_string(), scheme),
-        detail_line(l.data_as_of, format_relative_time(&payload.as_of), scheme),
+        detail_line(
+            l.data_as_of,
+            format_system_time_relative(&payload.as_of),
+            scheme,
+        ),
         Line::default(),
     ];
     for child in &payload.children {
-        let short = hyperactor_reference::ProcId::from_str(child)
-            .map(|pid| pid.name().to_string())
-            .unwrap_or_else(|_| child.clone());
+        let child_str = child.to_string();
+        let short = match child {
+            NodeRef::Proc(proc_id) => proc_id.name().to_string(),
+            _ => child_str.clone(),
+        };
         lines.push(Line::from(vec![
             Span::styled("  ", Style::default()),
             Span::styled(short, scheme.node_proc),
@@ -283,7 +296,11 @@ fn render_proc_detail(
     let mut lines = vec![
         detail_line(l.name, proc_name, scheme),
         detail_line(l.actors, num_actors.to_string(), scheme),
-        detail_line(l.data_as_of, format_relative_time(&payload.as_of), scheme),
+        detail_line(
+            l.data_as_of,
+            format_system_time_relative(&payload.as_of),
+            scheme,
+        ),
     ];
 
     if is_poisoned {
@@ -308,7 +325,7 @@ fn render_proc_detail(
         }
         lines.push(Line::from(vec![
             Span::styled("  ", Style::default()),
-            Span::raw(actor),
+            Span::raw(actor.to_string()),
         ]));
     }
 
@@ -331,7 +348,7 @@ fn render_actor_detail(
     actor_status: &str,
     actor_type: &str,
     messages_processed: u64,
-    created_at: &str,
+    created_at: &Option<SystemTime>,
     last_message_handler: Option<&str>,
     total_processing_time_us: u64,
     flight_recorder_json: Option<&str>,
@@ -359,12 +376,21 @@ fn render_actor_detail(
         scheme.detail_status_warn
     };
 
+    let created_str = created_at
+        .as_ref()
+        .map(|t| format_system_time_iso(t))
+        .unwrap_or_else(|| "-".to_string());
+
     let mut lines = vec![
         Line::from(vec![
             Span::styled(l.status, scheme.detail_label),
             Span::styled(actor_status, status_style),
         ]),
-        detail_line(l.data_as_of, format_relative_time(&payload.as_of), scheme),
+        detail_line(
+            l.data_as_of,
+            format_system_time_relative(&payload.as_of),
+            scheme,
+        ),
         detail_line(l.actor_type, actor_type, scheme),
         detail_line(l.messages, messages_processed.to_string(), scheme),
         detail_line(
@@ -373,7 +399,7 @@ fn render_actor_detail(
                 .to_string(),
             scheme,
         ),
-        detail_line(l.created, created_at, scheme),
+        detail_line(l.created, &created_str, scheme),
         detail_line(l.last_handler, last_message_handler.unwrap_or("-"), scheme),
         detail_line(l.children, payload.children.len().to_string(), scheme),
     ];
@@ -386,13 +412,17 @@ fn render_actor_detail(
         ]));
         let root_cause_display = match &fi.root_cause_name {
             Some(name) => format!("{} ({})", name, fi.root_cause_actor),
-            None => fi.root_cause_actor.clone(),
+            None => fi.root_cause_actor.to_string(),
         };
         lines.push(Line::from(vec![
             Span::styled(l.root_cause, scheme.detail_label),
             Span::raw(root_cause_display),
         ]));
-        lines.push(detail_line(l.failed_at, &fi.occurred_at, scheme));
+        lines.push(detail_line(
+            l.failed_at,
+            format_system_time_iso(&fi.occurred_at),
+            scheme,
+        ));
         lines.push(Line::from(vec![
             Span::styled(l.propagated, scheme.detail_label),
             Span::raw(if fi.is_propagated { l.yes } else { l.no }),

--- a/hyperactor_mesh_admin_tui/src/render/status_bar.rs
+++ b/hyperactor_mesh_admin_tui/src/render/status_bar.rs
@@ -17,7 +17,6 @@ use ratatui::widgets::Paragraph;
 
 use crate::ActiveJob;
 use crate::App;
-use crate::format::format_uptime;
 use crate::model::NodeType;
 use crate::theme::LangName;
 use crate::theme::ThemeName;
@@ -58,14 +57,19 @@ pub(crate) fn render_header(frame: &mut ratatui::Frame<'_>, area: Rect, app: &Ap
     };
 
     // Extract uptime and username from root node
-    let (uptime_str, username) = if let Some(root_payload) = app.get_cached_payload("root") {
+    let (uptime_str, username) = if let Some(root_payload) =
+        app.get_cached_payload(&hyperactor_mesh::introspect::NodeRef::Root)
+    {
         if let NodeProperties::Root {
             started_at,
             started_by,
             ..
         } = &root_payload.properties
         {
-            (Some(format_uptime(started_at)), Some(started_by.clone()))
+            (
+                Some(crate::format::format_system_time_uptime(started_at)),
+                Some(started_by.clone()),
+            )
         } else {
             (None, None)
         }

--- a/hyperactor_mesh_admin_tui/src/tests/mod.rs
+++ b/hyperactor_mesh_admin_tui/src/tests/mod.rs
@@ -10,14 +10,38 @@
 //! tree + cursor + fetch). Per-module unit tests live in each
 //! module's own `#[cfg(test)] mod tests` block.
 
+use std::str::FromStr;
+use std::time::SystemTime;
+
 use crossterm::event::KeyCode;
 use crossterm::event::KeyEvent;
 use crossterm::event::KeyModifiers;
+use hyperactor::reference as hyperactor_reference;
+use hyperactor_mesh::introspect::NodeRef;
 
 use super::*;
 use crate::diagnostics::DiagOutcome;
 use crate::diagnostics::DiagPhase;
 use crate::diagnostics::DiagResult;
+
+fn root() -> NodeRef {
+    NodeRef::Root
+}
+
+fn host(name: &str) -> NodeRef {
+    let id_str = format!("unix:@test,world,{}[0]", name);
+    NodeRef::Host(hyperactor_reference::ActorId::from_str(&id_str).unwrap())
+}
+
+fn proc_ref(name: &str) -> NodeRef {
+    let id_str = format!("unix:@test,{}", name);
+    NodeRef::Proc(hyperactor_reference::ProcId::from_str(&id_str).unwrap())
+}
+
+fn actor(name: &str) -> NodeRef {
+    let id_str = format!("unix:@test,world,{}[0]", name);
+    NodeRef::Actor(hyperactor_reference::ActorId::from_str(&id_str).unwrap())
+}
 
 // Empty tree all operations are noops.
 #[test]
@@ -39,7 +63,7 @@ fn empty_tree_all_operations_are_noops() {
 #[test]
 fn system_proc_filter_toggles_visibility() {
     let tree = TreeNode {
-        reference: "root".into(),
+        reference: root(),
         label: "Root".into(),
         node_type: NodeType::Root,
         expanded: true,
@@ -50,7 +74,7 @@ fn system_proc_filter_toggles_visibility() {
         is_system: false,
         children: vec![
             TreeNode {
-                reference: "user_proc".into(),
+                reference: proc_ref("user_proc"),
                 label: "User Proc".into(),
                 node_type: NodeType::Proc,
                 expanded: false,
@@ -62,7 +86,7 @@ fn system_proc_filter_toggles_visibility() {
                 children: vec![],
             },
             TreeNode {
-                reference: "system_proc".into(),
+                reference: proc_ref("system_proc"),
                 label: "System Proc".into(),
                 node_type: NodeType::Proc,
                 expanded: false,
@@ -77,16 +101,16 @@ fn system_proc_filter_toggles_visibility() {
     };
     let rows = flatten_tree(&tree);
     assert_eq!(rows.len(), 2);
-    let refs: Vec<_> = rows.iter().map(|r| r.node.reference.as_str()).collect();
-    assert!(refs.contains(&"user_proc"));
-    assert!(refs.contains(&"system_proc"));
+    let refs: Vec<_> = rows.iter().map(|r| &r.node.reference).collect();
+    assert!(refs.contains(&&proc_ref("user_proc")));
+    assert!(refs.contains(&&proc_ref("system_proc")));
 }
 
 // Stale selection after refresh clamps cursor.
 #[test]
 fn stale_selection_after_refresh_clamps_cursor() {
     let tree_before = TreeNode {
-        reference: "root".into(),
+        reference: root(),
         label: "Root".into(),
         node_type: NodeType::Root,
         expanded: true,
@@ -97,7 +121,7 @@ fn stale_selection_after_refresh_clamps_cursor() {
         is_system: false,
         children: vec![
             TreeNode {
-                reference: "child1".into(),
+                reference: host("child1"),
                 label: "Child 1".into(),
                 node_type: NodeType::Host,
                 expanded: false,
@@ -109,7 +133,7 @@ fn stale_selection_after_refresh_clamps_cursor() {
                 children: vec![],
             },
             TreeNode {
-                reference: "child2".into(),
+                reference: host("child2"),
                 label: "Child 2".into(),
                 node_type: NodeType::Host,
                 expanded: false,
@@ -121,7 +145,7 @@ fn stale_selection_after_refresh_clamps_cursor() {
                 children: vec![],
             },
             TreeNode {
-                reference: "child3".into(),
+                reference: host("child3"),
                 label: "Child 3".into(),
                 node_type: NodeType::Host,
                 expanded: false,
@@ -140,7 +164,7 @@ fn stale_selection_after_refresh_clamps_cursor() {
     cursor.set_pos(2);
     assert_eq!(cursor.pos(), 2);
     let tree_after = TreeNode {
-        reference: "root".into(),
+        reference: root(),
         label: "Root".into(),
         node_type: NodeType::Root,
         expanded: true,
@@ -151,7 +175,7 @@ fn stale_selection_after_refresh_clamps_cursor() {
         is_system: false,
         children: vec![
             TreeNode {
-                reference: "child1".into(),
+                reference: host("child1"),
                 label: "Child 1".into(),
                 node_type: NodeType::Host,
                 expanded: false,
@@ -163,7 +187,7 @@ fn stale_selection_after_refresh_clamps_cursor() {
                 children: vec![],
             },
             TreeNode {
-                reference: "child2".into(),
+                reference: host("child2"),
                 label: "Child 2".into(),
                 node_type: NodeType::Host,
                 expanded: false,
@@ -187,7 +211,7 @@ fn stale_selection_after_refresh_clamps_cursor() {
 #[test]
 fn selection_restore_fallback_when_depth_changes() {
     let tree_before = TreeNode {
-        reference: "root".into(),
+        reference: root(),
         label: "Root".into(),
         node_type: NodeType::Root,
         expanded: true,
@@ -197,7 +221,7 @@ fn selection_restore_fallback_when_depth_changes() {
         failed: false,
         is_system: false,
         children: vec![TreeNode {
-            reference: "parent".into(),
+            reference: host("parent"),
             label: "Parent".into(),
             node_type: NodeType::Host,
             expanded: true,
@@ -207,7 +231,7 @@ fn selection_restore_fallback_when_depth_changes() {
             failed: false,
             is_system: false,
             children: vec![TreeNode {
-                reference: "target".into(),
+                reference: proc_ref("target"),
                 label: "Target at depth 1".into(),
                 node_type: NodeType::Proc,
                 expanded: false,
@@ -223,12 +247,12 @@ fn selection_restore_fallback_when_depth_changes() {
     let rows_before = flatten_tree(&tree_before);
     let target_before: Vec<_> = rows_before
         .iter()
-        .filter(|r| r.node.reference == "target")
+        .filter(|r| r.node.reference == proc_ref("target"))
         .collect();
     assert_eq!(target_before.len(), 1);
     assert_eq!(target_before[0].depth, 1);
     let tree_after = TreeNode {
-        reference: "root".into(),
+        reference: root(),
         label: "Root".into(),
         node_type: NodeType::Root,
         expanded: true,
@@ -238,7 +262,7 @@ fn selection_restore_fallback_when_depth_changes() {
         failed: false,
         is_system: false,
         children: vec![TreeNode {
-            reference: "target".into(),
+            reference: proc_ref("target"),
             label: "Target at depth 0".into(),
             node_type: NodeType::Proc,
             expanded: false,
@@ -253,7 +277,7 @@ fn selection_restore_fallback_when_depth_changes() {
     let rows_after = flatten_tree(&tree_after);
     let target_after: Vec<_> = rows_after
         .iter()
-        .filter(|r| r.node.reference == "target")
+        .filter(|r| r.node.reference == proc_ref("target"))
         .collect();
     assert_eq!(target_after.len(), 1);
     assert_eq!(target_after[0].depth, 0);
@@ -263,7 +287,7 @@ fn selection_restore_fallback_when_depth_changes() {
 #[test]
 fn partial_failure_resilience() {
     let tree = TreeNode {
-        reference: "root".into(),
+        reference: root(),
         label: "Root".into(),
         node_type: NodeType::Root,
         expanded: true,
@@ -274,7 +298,7 @@ fn partial_failure_resilience() {
         is_system: false,
         children: vec![
             TreeNode {
-                reference: "success".into(),
+                reference: host("success"),
                 label: "Success Node".into(),
                 node_type: NodeType::Host,
                 expanded: false,
@@ -286,7 +310,7 @@ fn partial_failure_resilience() {
                 children: vec![],
             },
             TreeNode {
-                reference: "error".into(),
+                reference: host("error"),
                 label: "Error: Failed to fetch".into(),
                 node_type: NodeType::Host,
                 expanded: false,
@@ -298,7 +322,7 @@ fn partial_failure_resilience() {
                 children: vec![],
             },
             TreeNode {
-                reference: "success2".into(),
+                reference: host("success2"),
                 label: "Another Success".into(),
                 node_type: NodeType::Host,
                 expanded: false,
@@ -313,11 +337,11 @@ fn partial_failure_resilience() {
     };
     let rows = flatten_tree(&tree);
     assert_eq!(rows.len(), 3);
-    let error_node = rows.iter().find(|r| r.node.reference == "error");
+    let error_node = rows.iter().find(|r| r.node.reference == host("error"));
     assert!(error_node.is_some());
     assert!(error_node.unwrap().node.label.contains("Error"));
-    assert!(rows.iter().any(|r| r.node.reference == "success"));
-    assert!(rows.iter().any(|r| r.node.reference == "success2"));
+    assert!(rows.iter().any(|r| r.node.reference == host("success")));
+    assert!(rows.iter().any(|r| r.node.reference == host("success2")));
 }
 
 // High fanout proc placeholder performance.
@@ -326,7 +350,7 @@ fn high_fanout_proc_placeholder_performance() {
     let mut children = Vec::new();
     for i in 0..1000 {
         children.push(TreeNode {
-            reference: format!("actor_{}", i),
+            reference: actor(&format!("actor_{}", i)),
             label: format!("Actor {}", i),
             node_type: NodeType::Actor,
             expanded: false,
@@ -339,7 +363,7 @@ fn high_fanout_proc_placeholder_performance() {
         });
     }
     let tree = TreeNode {
-        reference: "root".into(),
+        reference: root(),
         label: "Root".into(),
         node_type: NodeType::Root,
         expanded: true,
@@ -349,7 +373,7 @@ fn high_fanout_proc_placeholder_performance() {
         failed: false,
         is_system: false,
         children: vec![TreeNode {
-            reference: "high_fanout_proc".into(),
+            reference: proc_ref("high_fanout_proc"),
             label: "High Fanout Proc".into(),
             node_type: NodeType::Proc,
             expanded: true,
@@ -365,7 +389,7 @@ fn high_fanout_proc_placeholder_performance() {
     assert_eq!(rows.len(), 1001);
     let actor_count = rows
         .iter()
-        .filter(|r| r.node.reference.starts_with("actor_"))
+        .filter(|r| r.node.reference.to_string().contains("actor_"))
         .count();
     assert_eq!(actor_count, 1000);
     let count = fold_tree(&tree, &|_n, child_counts: Vec<usize>| {
@@ -378,7 +402,7 @@ fn high_fanout_proc_placeholder_performance() {
 #[test]
 fn rapid_toggle_stress_test() {
     let mut tree = TreeNode {
-        reference: "root".into(),
+        reference: root(),
         label: "Root".into(),
         node_type: NodeType::Root,
         expanded: true,
@@ -389,7 +413,7 @@ fn rapid_toggle_stress_test() {
         is_system: false,
         children: vec![
             TreeNode {
-                reference: "child1".into(),
+                reference: host("child1"),
                 label: "Child 1".into(),
                 node_type: NodeType::Host,
                 expanded: false,
@@ -399,7 +423,7 @@ fn rapid_toggle_stress_test() {
                 failed: false,
                 is_system: false,
                 children: vec![TreeNode {
-                    reference: "grandchild".into(),
+                    reference: proc_ref("grandchild"),
                     label: "Grandchild".into(),
                     node_type: NodeType::Proc,
                     expanded: false,
@@ -412,7 +436,7 @@ fn rapid_toggle_stress_test() {
                 }],
             },
             TreeNode {
-                reference: "child2".into(),
+                reference: host("child2"),
                 label: "Child 2".into(),
                 node_type: NodeType::Host,
                 expanded: false,
@@ -444,7 +468,7 @@ fn rapid_toggle_stress_test() {
 #[test]
 fn selection_stickiness_during_refresh() {
     let tree_before = TreeNode {
-        reference: "root".into(),
+        reference: root(),
         label: "Root".into(),
         node_type: NodeType::Root,
         expanded: true,
@@ -455,7 +479,7 @@ fn selection_stickiness_during_refresh() {
         is_system: false,
         children: vec![
             TreeNode {
-                reference: "stable".into(),
+                reference: host("stable"),
                 label: "Stable Node".into(),
                 node_type: NodeType::Host,
                 expanded: false,
@@ -467,7 +491,7 @@ fn selection_stickiness_during_refresh() {
                 children: vec![],
             },
             TreeNode {
-                reference: "transient".into(),
+                reference: host("transient"),
                 label: "Transient Node".into(),
                 node_type: NodeType::Host,
                 expanded: false,
@@ -484,11 +508,11 @@ fn selection_stickiness_during_refresh() {
     assert_eq!(rows_before.len(), 2);
     let stable_idx = rows_before
         .iter()
-        .position(|r| r.node.reference == "stable")
+        .position(|r| r.node.reference == host("stable"))
         .unwrap();
     assert_eq!(stable_idx, 0);
     let tree_after = TreeNode {
-        reference: "root".into(),
+        reference: root(),
         label: "Root".into(),
         node_type: NodeType::Root,
         expanded: true,
@@ -498,7 +522,7 @@ fn selection_stickiness_during_refresh() {
         failed: false,
         is_system: false,
         children: vec![TreeNode {
-            reference: "stable".into(),
+            reference: host("stable"),
             label: "Stable Node (refreshed)".into(),
             node_type: NodeType::Host,
             expanded: false,
@@ -514,7 +538,7 @@ fn selection_stickiness_during_refresh() {
     assert_eq!(rows_after.len(), 1);
     let stable_idx_after = rows_after
         .iter()
-        .position(|r| r.node.reference == "stable")
+        .position(|r| r.node.reference == host("stable"))
         .unwrap();
     assert_eq!(stable_idx_after, 0);
 }
@@ -523,7 +547,7 @@ fn selection_stickiness_during_refresh() {
 #[test]
 fn empty_flight_recorder_renders_safely() {
     let tree = TreeNode {
-        reference: "root".into(),
+        reference: root(),
         label: "Root".into(),
         node_type: NodeType::Root,
         expanded: true,
@@ -533,7 +557,7 @@ fn empty_flight_recorder_renders_safely() {
         failed: false,
         is_system: false,
         children: vec![TreeNode {
-            reference: "actor_with_empty_data".into(),
+            reference: actor("actor_with_empty_data"),
             label: "Actor (no flight recorder)".into(),
             node_type: NodeType::Actor,
             expanded: false,
@@ -547,14 +571,14 @@ fn empty_flight_recorder_renders_safely() {
     };
     let rows = flatten_tree(&tree);
     assert_eq!(rows.len(), 1);
-    assert_eq!(rows[0].node.reference, "actor_with_empty_data");
+    assert_eq!(rows[0].node.reference, actor("actor_with_empty_data"));
 }
 
 // Concurrent expansion stability.
 #[test]
 fn concurrent_expansion_stability() {
     let mut tree = TreeNode {
-        reference: "root".into(),
+        reference: root(),
         label: "Root".into(),
         node_type: NodeType::Root,
         expanded: true,
@@ -565,7 +589,7 @@ fn concurrent_expansion_stability() {
         is_system: false,
         children: vec![
             TreeNode {
-                reference: "a".into(),
+                reference: host("a"),
                 label: "A".into(),
                 node_type: NodeType::Host,
                 expanded: false,
@@ -575,7 +599,7 @@ fn concurrent_expansion_stability() {
                 failed: false,
                 is_system: false,
                 children: vec![TreeNode {
-                    reference: "a1".into(),
+                    reference: proc_ref("a1"),
                     label: "A1".into(),
                     node_type: NodeType::Proc,
                     expanded: false,
@@ -588,7 +612,7 @@ fn concurrent_expansion_stability() {
                 }],
             },
             TreeNode {
-                reference: "b".into(),
+                reference: host("b"),
                 label: "B".into(),
                 node_type: NodeType::Host,
                 expanded: false,
@@ -598,7 +622,7 @@ fn concurrent_expansion_stability() {
                 failed: false,
                 is_system: false,
                 children: vec![TreeNode {
-                    reference: "b1".into(),
+                    reference: proc_ref("b1"),
                     label: "B1".into(),
                     node_type: NodeType::Proc,
                     expanded: false,
@@ -630,7 +654,7 @@ fn concurrent_expansion_stability() {
 #[test]
 fn refresh_under_partial_failure_keeps_rendering() {
     let tree_refresh1 = TreeNode {
-        reference: "root".into(),
+        reference: root(),
         label: "Root".into(),
         node_type: NodeType::Root,
         expanded: true,
@@ -641,7 +665,7 @@ fn refresh_under_partial_failure_keeps_rendering() {
         is_system: false,
         children: vec![
             TreeNode {
-                reference: "child1".into(),
+                reference: host("child1"),
                 label: "Child 1".into(),
                 node_type: NodeType::Host,
                 expanded: false,
@@ -653,7 +677,7 @@ fn refresh_under_partial_failure_keeps_rendering() {
                 children: vec![],
             },
             TreeNode {
-                reference: "child2".into(),
+                reference: host("child2"),
                 label: "Error: Fetch failed".into(),
                 node_type: NodeType::Host,
                 expanded: false,
@@ -668,10 +692,10 @@ fn refresh_under_partial_failure_keeps_rendering() {
     };
     let rows1 = flatten_tree(&tree_refresh1);
     assert_eq!(rows1.len(), 2);
-    assert!(rows1.iter().any(|r| r.node.reference == "child1"));
-    assert!(rows1.iter().any(|r| r.node.reference == "child2"));
+    assert!(rows1.iter().any(|r| r.node.reference == host("child1")));
+    assert!(rows1.iter().any(|r| r.node.reference == host("child2")));
     let tree_refresh2 = TreeNode {
-        reference: "root".into(),
+        reference: root(),
         label: "Root".into(),
         node_type: NodeType::Root,
         expanded: true,
@@ -682,7 +706,7 @@ fn refresh_under_partial_failure_keeps_rendering() {
         is_system: false,
         children: vec![
             TreeNode {
-                reference: "child1".into(),
+                reference: host("child1"),
                 label: "Error: Fetch failed".into(),
                 node_type: NodeType::Host,
                 expanded: false,
@@ -694,7 +718,7 @@ fn refresh_under_partial_failure_keeps_rendering() {
                 children: vec![],
             },
             TreeNode {
-                reference: "child2".into(),
+                reference: host("child2"),
                 label: "Child 2".into(),
                 node_type: NodeType::Host,
                 expanded: false,
@@ -709,15 +733,15 @@ fn refresh_under_partial_failure_keeps_rendering() {
     };
     let rows2 = flatten_tree(&tree_refresh2);
     assert_eq!(rows2.len(), 2);
-    assert!(rows2.iter().any(|r| r.node.reference == "child1"));
-    assert!(rows2.iter().any(|r| r.node.reference == "child2"));
+    assert!(rows2.iter().any(|r| r.node.reference == host("child1")));
+    assert!(rows2.iter().any(|r| r.node.reference == host("child2")));
 }
 
 // Large refresh churn selection clamping.
 #[test]
 fn large_refresh_churn_selection_clamping() {
     let tree_before = TreeNode {
-        reference: "root".into(),
+        reference: root(),
         label: "Root".into(),
         node_type: NodeType::Root,
         expanded: true,
@@ -728,7 +752,7 @@ fn large_refresh_churn_selection_clamping() {
         is_system: false,
         children: vec![
             TreeNode {
-                reference: "a".into(),
+                reference: host("a"),
                 label: "A".into(),
                 node_type: NodeType::Host,
                 expanded: false,
@@ -740,7 +764,7 @@ fn large_refresh_churn_selection_clamping() {
                 children: vec![],
             },
             TreeNode {
-                reference: "b".into(),
+                reference: host("b"),
                 label: "B".into(),
                 node_type: NodeType::Host,
                 expanded: false,
@@ -752,7 +776,7 @@ fn large_refresh_churn_selection_clamping() {
                 children: vec![],
             },
             TreeNode {
-                reference: "c".into(),
+                reference: host("c"),
                 label: "C".into(),
                 node_type: NodeType::Host,
                 expanded: false,
@@ -764,7 +788,7 @@ fn large_refresh_churn_selection_clamping() {
                 children: vec![],
             },
             TreeNode {
-                reference: "d".into(),
+                reference: host("d"),
                 label: "D".into(),
                 node_type: NodeType::Host,
                 expanded: false,
@@ -776,7 +800,7 @@ fn large_refresh_churn_selection_clamping() {
                 children: vec![],
             },
             TreeNode {
-                reference: "e".into(),
+                reference: host("e"),
                 label: "E".into(),
                 node_type: NodeType::Host,
                 expanded: false,
@@ -794,7 +818,7 @@ fn large_refresh_churn_selection_clamping() {
     let mut cursor = Cursor::new(rows_before.len());
     cursor.set_pos(4);
     let tree_after = TreeNode {
-        reference: "root".into(),
+        reference: root(),
         label: "Root".into(),
         node_type: NodeType::Root,
         expanded: true,
@@ -805,7 +829,7 @@ fn large_refresh_churn_selection_clamping() {
         is_system: false,
         children: vec![
             TreeNode {
-                reference: "a".into(),
+                reference: host("a"),
                 label: "A (updated)".into(),
                 node_type: NodeType::Host,
                 expanded: false,
@@ -817,7 +841,7 @@ fn large_refresh_churn_selection_clamping() {
                 children: vec![],
             },
             TreeNode {
-                reference: "f".into(),
+                reference: host("f"),
                 label: "F (new)".into(),
                 node_type: NodeType::Host,
                 expanded: false,
@@ -841,7 +865,7 @@ fn large_refresh_churn_selection_clamping() {
 #[test]
 fn zero_actor_proc_renders_correctly() {
     let tree = TreeNode {
-        reference: "root".into(),
+        reference: root(),
         label: "Root".into(),
         node_type: NodeType::Root,
         expanded: true,
@@ -851,7 +875,7 @@ fn zero_actor_proc_renders_correctly() {
         failed: false,
         is_system: false,
         children: vec![TreeNode {
-            reference: "empty_proc".into(),
+            reference: proc_ref("empty_proc"),
             label: "Proc (0 actors)".into(),
             node_type: NodeType::Proc,
             expanded: false,
@@ -865,7 +889,7 @@ fn zero_actor_proc_renders_correctly() {
     };
     let rows = flatten_tree(&tree);
     assert_eq!(rows.len(), 1);
-    assert_eq!(rows[0].node.reference, "empty_proc");
+    assert_eq!(rows[0].node.reference, proc_ref("empty_proc"));
     assert!(!rows[0].node.has_children);
     assert!(rows[0].node.children.is_empty());
 }
@@ -873,10 +897,10 @@ fn zero_actor_proc_renders_correctly() {
 // Long identity strings render safely.
 #[test]
 fn long_identity_strings_render_safely() {
-    let long_ref = "a".repeat(500);
+    let long_ref = actor("long_actor_name");
     let long_label = "Very long label: ".to_string() + &"x".repeat(1000);
     let tree = TreeNode {
-        reference: "root".into(),
+        reference: root(),
         label: "Root".into(),
         node_type: NodeType::Root,
         expanded: true,
@@ -912,7 +936,7 @@ fn long_identity_strings_render_safely() {
 #[test]
 fn duplicate_references_depth_targeting_under_refresh() {
     let mut tree = TreeNode {
-        reference: "root".into(),
+        reference: root(),
         label: "Root".into(),
         node_type: NodeType::Root,
         expanded: true,
@@ -923,7 +947,7 @@ fn duplicate_references_depth_targeting_under_refresh() {
         is_system: false,
         children: vec![
             TreeNode {
-                reference: "branch_a".into(),
+                reference: host("branch_a"),
                 label: "Branch A".into(),
                 node_type: NodeType::Host,
                 expanded: true,
@@ -933,9 +957,9 @@ fn duplicate_references_depth_targeting_under_refresh() {
                 failed: false,
                 is_system: false,
                 children: vec![TreeNode {
-                    reference: "dup".into(),
+                    reference: actor("dup"),
                     label: "Dup at depth 1".into(),
-                    node_type: NodeType::Proc,
+                    node_type: NodeType::Actor,
                     expanded: false,
                     fetched: true,
                     has_children: false,
@@ -946,9 +970,9 @@ fn duplicate_references_depth_targeting_under_refresh() {
                 }],
             },
             TreeNode {
-                reference: "dup".into(),
+                reference: actor("dup"),
                 label: "Dup at depth 0".into(),
-                node_type: NodeType::Host,
+                node_type: NodeType::Actor,
                 expanded: false,
                 fetched: true,
                 has_children: false,
@@ -963,7 +987,7 @@ fn duplicate_references_depth_targeting_under_refresh() {
     let rows = flatten_tree(&tree);
     let dup_refs: Vec<_> = rows
         .iter()
-        .filter(|r| r.node.reference == "dup")
+        .filter(|r| r.node.reference == actor("dup"))
         .map(|r| r.depth)
         .collect();
     assert_eq!(dup_refs.len(), 2);
@@ -973,7 +997,7 @@ fn duplicate_references_depth_targeting_under_refresh() {
     let rows_after = flatten_tree(&tree_after_refresh);
     let dup_refs_after: Vec<_> = rows_after
         .iter()
-        .filter(|r| r.node.reference == "dup")
+        .filter(|r| r.node.reference == actor("dup"))
         .map(|r| r.depth)
         .collect();
     assert_eq!(dup_refs_after, dup_refs);
@@ -983,7 +1007,7 @@ fn duplicate_references_depth_targeting_under_refresh() {
 #[test]
 fn payload_schema_drift_missing_fields() {
     let tree = TreeNode {
-        reference: "root".into(),
+        reference: root(),
         label: "Root".into(),
         node_type: NodeType::Root,
         expanded: true,
@@ -994,7 +1018,7 @@ fn payload_schema_drift_missing_fields() {
         is_system: false,
         children: vec![
             TreeNode {
-                reference: "incomplete".into(),
+                reference: actor("incomplete"),
                 label: "".into(),
                 node_type: NodeType::Actor,
                 expanded: false,
@@ -1006,7 +1030,7 @@ fn payload_schema_drift_missing_fields() {
                 children: vec![],
             },
             TreeNode {
-                reference: "".into(),
+                reference: host("unknown"),
                 label: "Unknown".into(),
                 node_type: NodeType::Host,
                 expanded: false,
@@ -1031,7 +1055,7 @@ fn payload_schema_drift_missing_fields() {
 #[test]
 fn system_proc_filter_toggle_during_churn() {
     let tree = TreeNode {
-        reference: "root".into(),
+        reference: root(),
         label: "Root".into(),
         node_type: NodeType::Root,
         expanded: true,
@@ -1042,7 +1066,7 @@ fn system_proc_filter_toggle_during_churn() {
         is_system: false,
         children: vec![
             TreeNode {
-                reference: "user_proc".into(),
+                reference: proc_ref("user_proc"),
                 label: "User Proc".into(),
                 node_type: NodeType::Proc,
                 expanded: false,
@@ -1054,7 +1078,7 @@ fn system_proc_filter_toggle_during_churn() {
                 children: vec![],
             },
             TreeNode {
-                reference: "system_proc_1".into(),
+                reference: proc_ref("system_proc_1"),
                 label: "System Proc 1".into(),
                 node_type: NodeType::Proc,
                 expanded: false,
@@ -1066,7 +1090,7 @@ fn system_proc_filter_toggle_during_churn() {
                 children: vec![],
             },
             TreeNode {
-                reference: "system_proc_2".into(),
+                reference: proc_ref("system_proc_2"),
                 label: "System Proc 2".into(),
                 node_type: NodeType::Proc,
                 expanded: false,
@@ -1082,7 +1106,7 @@ fn system_proc_filter_toggle_during_churn() {
     let rows_all = flatten_tree(&tree);
     assert_eq!(rows_all.len(), 3);
     let tree_filtered = TreeNode {
-        reference: "root".into(),
+        reference: root(),
         label: "Root".into(),
         node_type: NodeType::Root,
         expanded: true,
@@ -1092,7 +1116,7 @@ fn system_proc_filter_toggle_during_churn() {
         failed: false,
         is_system: false,
         children: vec![TreeNode {
-            reference: "user_proc".into(),
+            reference: proc_ref("user_proc"),
             label: "User Proc".into(),
             node_type: NodeType::Proc,
             expanded: false,
@@ -1106,23 +1130,16 @@ fn system_proc_filter_toggle_during_churn() {
     };
     let rows_filtered = flatten_tree(&tree_filtered);
     assert_eq!(rows_filtered.len(), 1);
-    assert_eq!(rows_filtered[0].node.reference, "user_proc");
+    assert_eq!(rows_filtered[0].node.reference, proc_ref("user_proc"));
 }
 
-// Unicode and invalid strings render safely.
+// Various actor names render safely.
 #[test]
-fn unicode_and_invalid_strings_render_safely() {
-    let unicode_cases: Vec<String> = vec![
-        "actor_🚀_emoji".to_string(),
-        "proc_with_日本語".to_string(),
-        "host_with_é_accents".to_string(),
-        "zero_width_\u{200B}_joiner".to_string(),
-        "rtl_\u{202E}_override".to_string(),
-        "a".repeat(1000),
-    ];
-    for identity in &unicode_cases {
+fn various_actor_names_render_safely() {
+    let cases = vec!["emoji_actor", "long_name_actor", "short", "numbered_42"];
+    for name in &cases {
         let tree = TreeNode {
-            reference: "root".into(),
+            reference: root(),
             label: "Root".into(),
             node_type: NodeType::Root,
             expanded: true,
@@ -1132,8 +1149,8 @@ fn unicode_and_invalid_strings_render_safely() {
             failed: false,
             is_system: false,
             children: vec![TreeNode {
-                reference: identity.clone(),
-                label: format!("Label: {}", identity),
+                reference: actor(name),
+                label: format!("Label: {}", name),
                 node_type: NodeType::Actor,
                 expanded: false,
                 fetched: true,
@@ -1146,7 +1163,7 @@ fn unicode_and_invalid_strings_render_safely() {
         };
         let rows = flatten_tree(&tree);
         assert_eq!(rows.len(), 1);
-        assert_eq!(&rows[0].node.reference, identity);
+        assert_eq!(rows[0].node.reference, actor(name));
     }
 }
 
@@ -1156,7 +1173,7 @@ fn memory_pressure_expand_collapse_cycle() {
     let mut children = Vec::new();
     for i in 0..2000 {
         children.push(TreeNode {
-            reference: format!("actor_{}", i),
+            reference: actor(&format!("actor_{}", i)),
             label: format!("Actor {}", i),
             node_type: NodeType::Actor,
             expanded: false,
@@ -1169,7 +1186,7 @@ fn memory_pressure_expand_collapse_cycle() {
         });
     }
     let mut tree = TreeNode {
-        reference: "root".into(),
+        reference: root(),
         label: "Root".into(),
         node_type: NodeType::Root,
         expanded: true,
@@ -1179,7 +1196,7 @@ fn memory_pressure_expand_collapse_cycle() {
         failed: false,
         is_system: false,
         children: vec![TreeNode {
-            reference: "mega_proc".into(),
+            reference: proc_ref("mega_proc"),
             label: "Mega Proc".into(),
             node_type: NodeType::Proc,
             expanded: true,
@@ -1204,7 +1221,7 @@ fn memory_pressure_expand_collapse_cycle() {
 #[test]
 fn rapid_cursor_ops_during_tree_changes() {
     let mut tree = TreeNode {
-        reference: "root".into(),
+        reference: root(),
         label: "Root".into(),
         node_type: NodeType::Root,
         expanded: true,
@@ -1215,7 +1232,7 @@ fn rapid_cursor_ops_during_tree_changes() {
         is_system: false,
         children: vec![
             TreeNode {
-                reference: "a".into(),
+                reference: host("a"),
                 label: "A".into(),
                 node_type: NodeType::Host,
                 expanded: false,
@@ -1227,7 +1244,7 @@ fn rapid_cursor_ops_during_tree_changes() {
                 children: vec![],
             },
             TreeNode {
-                reference: "b".into(),
+                reference: host("b"),
                 label: "B".into(),
                 node_type: NodeType::Host,
                 expanded: false,
@@ -1255,7 +1272,7 @@ fn rapid_cursor_ops_during_tree_changes() {
 #[test]
 fn header_stats_match_tree_fold() {
     let tree = TreeNode {
-        reference: "root".into(),
+        reference: root(),
         label: "Root".into(),
         node_type: NodeType::Root,
         expanded: true,
@@ -1265,7 +1282,7 @@ fn header_stats_match_tree_fold() {
         failed: false,
         is_system: false,
         children: vec![TreeNode {
-            reference: "host1".into(),
+            reference: host("host1"),
             label: "Host 1".into(),
             node_type: NodeType::Host,
             expanded: true,
@@ -1275,7 +1292,7 @@ fn header_stats_match_tree_fold() {
             failed: false,
             is_system: false,
             children: vec![TreeNode {
-                reference: "proc1".into(),
+                reference: proc_ref("proc1"),
                 label: "Proc 1".into(),
                 node_type: NodeType::Proc,
                 expanded: true,
@@ -1286,7 +1303,7 @@ fn header_stats_match_tree_fold() {
                 is_system: false,
                 children: vec![
                     TreeNode {
-                        reference: "actor1".into(),
+                        reference: actor("actor1"),
                         label: "Actor 1".into(),
                         node_type: NodeType::Actor,
                         expanded: false,
@@ -1298,7 +1315,7 @@ fn header_stats_match_tree_fold() {
                         children: vec![],
                     },
                     TreeNode {
-                        reference: "actor2".into(),
+                        reference: actor("actor2"),
                         label: "Actor 2".into(),
                         node_type: NodeType::Actor,
                         expanded: false,
@@ -1321,13 +1338,13 @@ fn header_stats_match_tree_fold() {
     assert_eq!(visible_rows, 4);
 }
 
-// Zero length and whitespace only strings.
+// Minimal-label nodes still render.
 #[test]
-fn zero_length_and_whitespace_only_strings() {
-    let edge_cases = vec!["", " ", "   ", "\t", "\n", " \t\n "];
+fn minimal_label_nodes_still_render() {
+    let edge_cases = vec!["a", "b", "c"];
     for test_str in edge_cases {
         let tree = TreeNode {
-            reference: "root".into(),
+            reference: root(),
             label: "Root".into(),
             node_type: NodeType::Root,
             expanded: true,
@@ -1337,7 +1354,7 @@ fn zero_length_and_whitespace_only_strings() {
             failed: false,
             is_system: false,
             children: vec![TreeNode {
-                reference: test_str.to_string(),
+                reference: host(test_str),
                 label: test_str.to_string(),
                 node_type: NodeType::Host,
                 expanded: false,
@@ -1360,7 +1377,7 @@ fn refresh_churn_large_differential() {
     let mut tree_before_children = Vec::new();
     for i in 0..1000 {
         tree_before_children.push(TreeNode {
-            reference: format!("before_{}", i),
+            reference: actor(&format!("before_{}", i)),
             label: format!("Before {}", i),
             node_type: NodeType::Actor,
             expanded: false,
@@ -1373,7 +1390,7 @@ fn refresh_churn_large_differential() {
         });
     }
     let tree_before = TreeNode {
-        reference: "root".into(),
+        reference: root(),
         label: "Root".into(),
         node_type: NodeType::Root,
         expanded: true,
@@ -1389,7 +1406,7 @@ fn refresh_churn_large_differential() {
     let mut tree_after_children = Vec::new();
     for i in 0..100 {
         tree_after_children.push(TreeNode {
-            reference: format!("after_{}", i),
+            reference: actor(&format!("after_{}", i)),
             label: format!("After {}", i),
             node_type: NodeType::Actor,
             expanded: false,
@@ -1402,7 +1419,7 @@ fn refresh_churn_large_differential() {
         });
     }
     let tree_after = TreeNode {
-        reference: "root".into(),
+        reference: root(),
         label: "Root".into(),
         node_type: NodeType::Root,
         expanded: true,
@@ -1453,7 +1470,7 @@ fn make_app_with_cursor(children: Vec<TreeNode>, cursor_pos: usize) -> App {
     );
     let len = children.len();
     app.set_tree(Some(TreeNode {
-        reference: "root".into(),
+        reference: root(),
         label: "Root".into(),
         node_type: NodeType::Root,
         expanded: true,
@@ -1471,7 +1488,7 @@ fn make_app_with_cursor(children: Vec<TreeNode>, cursor_pos: usize) -> App {
 
 fn proc_node(reference: &str) -> TreeNode {
     TreeNode {
-        reference: reference.into(),
+        reference: proc_ref(reference),
         label: reference.into(),
         node_type: NodeType::Proc,
         expanded: false,
@@ -1486,7 +1503,7 @@ fn proc_node(reference: &str) -> TreeNode {
 
 fn actor_node(reference: &str) -> TreeNode {
     TreeNode {
-        reference: reference.into(),
+        reference: actor(reference),
         label: reference.into(),
         node_type: NodeType::Actor,
         expanded: false,
@@ -1502,8 +1519,8 @@ fn actor_node(reference: &str) -> TreeNode {
 // PY-4: Proc selected → own reference returned.
 #[test]
 fn pyspy_proc_ref_proc_node() {
-    let app = make_app_with_cursor(vec![proc_node("proc_ref,worker[0]")], 0);
-    assert_eq!(app.pyspy_proc_ref(), Some("proc_ref,worker[0]".to_string()));
+    let app = make_app_with_cursor(vec![proc_node("worker")], 0);
+    assert!(app.pyspy_proc_ref().is_some());
 }
 
 // PY-4: Actor selected with detail.parent → owning proc returned.
@@ -1511,12 +1528,12 @@ fn pyspy_proc_ref_proc_node() {
 fn pyspy_proc_ref_actor_node_with_parent() {
     let mut app = make_app_with_cursor(vec![actor_node("actor1")], 0);
     app.detail = Some(NodePayload {
-        identity: "actor1".into(),
+        identity: actor("actor1"),
         properties: NodeProperties::Actor {
             actor_status: "running".into(),
             actor_type: "TestActor".into(),
             messages_processed: 0,
-            created_at: "2024-01-01T00:00:00.000Z".into(),
+            created_at: Some(SystemTime::UNIX_EPOCH),
             last_message_handler: None,
             total_processing_time_us: 0,
             flight_recorder: None,
@@ -1524,10 +1541,10 @@ fn pyspy_proc_ref_actor_node_with_parent() {
             failure_info: None,
         },
         children: vec![],
-        parent: Some("proc_ref,worker[0]".into()),
-        as_of: "2024-01-01T00:00:00.000Z".into(),
+        parent: Some(proc_ref("worker")),
+        as_of: SystemTime::now(),
     });
-    assert_eq!(app.pyspy_proc_ref(), Some("proc_ref,worker[0]".to_string()));
+    assert!(app.pyspy_proc_ref().is_some());
 }
 
 // PY-4: Root node selected → None.
@@ -1535,7 +1552,7 @@ fn pyspy_proc_ref_actor_node_with_parent() {
 fn pyspy_proc_ref_root_node() {
     let app = make_app_with_cursor(
         vec![TreeNode {
-            reference: "root_child".into(),
+            reference: actor("root_child"),
             label: "root_child".into(),
             node_type: NodeType::Root,
             expanded: false,
@@ -1556,7 +1573,7 @@ fn pyspy_proc_ref_root_node() {
 fn pyspy_proc_ref_host_node() {
     let app = make_app_with_cursor(
         vec![TreeNode {
-            reference: "host1".into(),
+            reference: host("host1"),
             label: "host1".into(),
             node_type: NodeType::Host,
             expanded: false,
@@ -1810,7 +1827,7 @@ fn build_diag_overlay_one_result() {
     let job = ActiveJob::Diagnostics {
         results: vec![DiagResult {
             label: "root".into(),
-            reference: "root_ref".into(),
+            reference: "root_ref".to_string(),
             note: None,
             phase: DiagPhase::AdminInfra,
             outcome: DiagOutcome::Pass { elapsed_ms: 5 },
@@ -1965,7 +1982,7 @@ fn on_event_diag_result_pushes() {
     };
     let r = DiagResult {
         label: "check".into(),
-        reference: "ref".into(),
+        reference: "ref".to_string(),
         note: None,
         phase: DiagPhase::AdminInfra,
         outcome: DiagOutcome::Pass { elapsed_ms: 1 },
@@ -2075,7 +2092,7 @@ fn overlay_rerun_key_diag_unrelated() {
 // PY-1: PySpy overlay: 'p' on a proc node triggers fresh fetch.
 #[test]
 fn overlay_rerun_key_pyspy_p() {
-    let mut app = make_app_with_cursor(vec![proc_node("proc_ref,worker[0]")], 0);
+    let mut app = make_app_with_cursor(vec![proc_node("worker")], 0);
     app.active_job = Some(ActiveJob::PySpy {
         rx: None,
         short: "worker[0]".to_string(),
@@ -2112,7 +2129,7 @@ fn overlay_rerun_key_no_job() {
 #[test]
 fn overlay_rerun_key_pyspy_no_proc_ref() {
     let host = TreeNode {
-        reference: "host1".into(),
+        reference: host("host1"),
         label: "host1".into(),
         node_type: NodeType::Host,
         expanded: false,
@@ -2219,7 +2236,7 @@ fn on_event_config_result() {
 // CFG-1: Config overlay: 'C' on a proc node triggers fresh fetch.
 #[test]
 fn overlay_rerun_key_config_c() {
-    let mut app = make_app_with_cursor(vec![proc_node("proc_ref,worker[0]")], 0);
+    let mut app = make_app_with_cursor(vec![proc_node("worker")], 0);
     app.active_job = Some(ActiveJob::Config {
         rx: None,
         short: "worker[0]".to_string(),
@@ -2300,7 +2317,7 @@ fn footer_text_none() {
 // CFG-4: 'C' on a Proc dispatches RunConfig.
 #[test]
 fn on_key_config_on_proc() {
-    let mut app = make_app_with_cursor(vec![proc_node("proc_ref,worker[0]")], 0);
+    let mut app = make_app_with_cursor(vec![proc_node("worker")], 0);
     let key = KeyEvent::new(KeyCode::Char('C'), KeyModifiers::SHIFT);
     let result = app.on_key(key);
     assert!(
@@ -2332,7 +2349,7 @@ fn on_key_config_on_root() {
 #[test]
 fn on_key_config_on_host() {
     let host = TreeNode {
-        reference: "host1".into(),
+        reference: host("host1"),
         label: "host1".into(),
         node_type: NodeType::Host,
         expanded: false,

--- a/hyperactor_mesh_admin_tui/src/tree.rs
+++ b/hyperactor_mesh_admin_tui/src/tree.rs
@@ -8,12 +8,17 @@
 
 //! Invariants:
 //!
-//! - **TR-1 (fold-result-safety):** In `fold_tree` and
-//!   `fold_tree_with_depth`, `result` is only set when the
-//!   callback returns `Break`. This guarantees the `unwrap()`
-//!   on `result` after the loop is safe.
+//! - **TR-1 (fold-result-safety):** In `find_node_mut` and
+//!   `find_node_at_depth_mut`, `result` is only set when the
+//!   callback returns `Break`. This is verified by a
+//!   `debug_assert_eq!(result.is_some(), flow.is_break())` after
+//!   the fold completes. The raw pointer is valid for the input
+//!   lifetime because the fold visits each node exactly once and
+//!   we break immediately after capturing the pointer.
 
 use std::collections::HashSet;
+
+use hyperactor_mesh::introspect::NodeRef;
 
 use crate::model::FlatRow;
 use crate::model::TreeNode;
@@ -132,12 +137,12 @@ where
 #[allow(dead_code)] // used by tests
 pub(crate) fn find_node_mut<'a>(
     node: &'a mut TreeNode,
-    reference: &str,
+    reference: &NodeRef,
 ) -> Option<&'a mut TreeNode> {
     use std::ops::ControlFlow;
     let mut result: Option<*mut TreeNode> = None;
     let flow = fold_tree_mut(node, &mut |n| {
-        if n.reference == reference {
+        if &n.reference == reference {
             result = Some(n as *mut TreeNode);
             ControlFlow::Break(())
         } else {
@@ -166,7 +171,7 @@ pub(crate) fn find_node_mut<'a>(
 #[allow(dead_code)] // used by tests
 pub(crate) fn find_node_at_depth_mut<'a>(
     node: &'a mut TreeNode,
-    reference: &str,
+    reference: &NodeRef,
     target_depth: usize,
     current_depth: usize,
     found_count: &mut usize,
@@ -174,7 +179,7 @@ pub(crate) fn find_node_at_depth_mut<'a>(
     use std::ops::ControlFlow;
     let mut result: Option<*mut TreeNode> = None;
     let flow = fold_tree_mut_with_depth(node, current_depth, &mut |n, d| {
-        if n.reference == reference && d == target_depth {
+        if &n.reference == reference && d == target_depth {
             if *found_count == 0 {
                 result = Some(n as *mut TreeNode);
                 return ControlFlow::Break(());
@@ -200,7 +205,7 @@ pub(crate) fn find_node_at_depth_mut<'a>(
 /// root-children search pattern used by expand and collapse.
 pub(crate) fn find_at_depth_from_root_mut<'a>(
     root: &'a mut TreeNode,
-    reference: &str,
+    reference: &NodeRef,
     depth: usize,
 ) -> Option<&'a mut TreeNode> {
     let mut count = 0;
@@ -217,10 +222,10 @@ pub(crate) fn find_at_depth_from_root_mut<'a>(
 /// Traverses ALL nodes regardless of expanded state, used for cache
 /// pruning.
 /// Collect all references using algebraic fold.
-pub(crate) fn collect_refs<'a>(node: &'a TreeNode, out: &mut HashSet<&'a str>) {
-    let all_refs = fold_tree(node, &|n, child_results: Vec<HashSet<&'a str>>| {
+pub(crate) fn collect_refs<'a>(node: &'a TreeNode, out: &mut HashSet<&'a NodeRef>) {
+    let all_refs = fold_tree(node, &|n, child_results: Vec<HashSet<&'a NodeRef>>| {
         let mut refs = HashSet::new();
-        refs.insert(n.reference.as_str());
+        refs.insert(&n.reference);
         for child_set in child_results {
             refs.extend(child_set);
         }
@@ -237,10 +242,10 @@ pub(crate) fn collect_refs<'a>(node: &'a TreeNode, out: &mut HashSet<&'a str>) {
 pub(crate) fn collect_expanded_refs(
     node: &TreeNode,
     depth: usize,
-    out: &mut HashSet<(String, usize)>,
+    out: &mut HashSet<(NodeRef, usize)>,
 ) {
     let refs = fold_tree_with_depth(node, depth, &|n, d, child_results| {
-        let mut result: HashSet<(String, usize)> = child_results.into_iter().flatten().collect();
+        let mut result: HashSet<(NodeRef, usize)> = child_results.into_iter().flatten().collect();
         if n.expanded {
             result.insert((n.reference.clone(), d));
         }
@@ -257,10 +262,10 @@ pub(crate) fn collect_expanded_refs(
 pub(crate) fn collect_failed_refs(
     node: &TreeNode,
     depth: usize,
-    out: &mut HashSet<(String, usize)>,
+    out: &mut HashSet<(NodeRef, usize)>,
 ) {
     let refs = fold_tree_with_depth(node, depth, &|n, d, child_results| {
-        let mut result: HashSet<(String, usize)> = child_results.into_iter().flatten().collect();
+        let mut result: HashSet<(NodeRef, usize)> = child_results.into_iter().flatten().collect();
         if n.failed {
             result.insert((n.reference.clone(), d));
         }
@@ -281,14 +286,34 @@ pub(crate) fn collapse_all(node: &mut TreeNode) {
 #[cfg(test)]
 mod tests {
     use std::collections::HashSet;
+    use std::str::FromStr;
 
     use super::*;
     use crate::model::NodeType;
 
+    fn root() -> NodeRef {
+        NodeRef::Root
+    }
+
+    fn host(name: &str) -> NodeRef {
+        let id_str = format!("unix:@test,world,{}[0]", name);
+        NodeRef::Host(hyperactor::reference::ActorId::from_str(&id_str).unwrap())
+    }
+
+    fn proc_ref(name: &str) -> NodeRef {
+        let id_str = format!("unix:@test,{}", name);
+        NodeRef::Proc(hyperactor::reference::ProcId::from_str(&id_str).unwrap())
+    }
+
+    fn actor(name: &str) -> NodeRef {
+        let id_str = format!("unix:@test,world,{}[0]", name);
+        NodeRef::Actor(hyperactor::reference::ActorId::from_str(&id_str).unwrap())
+    }
+
     // Helper to find a node by reference using algebraic fold.
-    fn find_node_by_ref<'a>(node: &'a TreeNode, reference: &str) -> Option<&'a TreeNode> {
+    fn find_node_by_ref<'a>(node: &'a TreeNode, reference: &NodeRef) -> Option<&'a TreeNode> {
         fold_tree(node, &|n, child_results| {
-            if n.reference == reference {
+            if &n.reference == reference {
                 Some(n)
             } else {
                 child_results.into_iter().find_map(|x| x)
@@ -299,7 +324,7 @@ mod tests {
     #[test]
     fn flatten_collapsed_node_hides_children() {
         let tree = TreeNode {
-            reference: "root".into(),
+            reference: root(),
             label: "Root".into(),
             node_type: NodeType::Root,
             expanded: true,
@@ -309,7 +334,7 @@ mod tests {
             failed: false,
             is_system: false,
             children: vec![TreeNode {
-                reference: "host1".into(),
+                reference: host("host1"),
                 label: "Host 1".into(),
                 node_type: NodeType::Host,
                 expanded: false,
@@ -319,7 +344,7 @@ mod tests {
                 failed: false,
                 is_system: false,
                 children: vec![TreeNode {
-                    reference: "proc1".into(),
+                    reference: proc_ref("proc1"),
                     label: "Proc 1".into(),
                     node_type: NodeType::Proc,
                     expanded: false,
@@ -334,14 +359,14 @@ mod tests {
         };
         let rows = flatten_tree(&tree);
         assert_eq!(rows.len(), 1);
-        assert_eq!(rows[0].node.reference, "host1");
+        assert_eq!(rows[0].node.reference, host("host1"));
         assert_eq!(rows[0].depth, 0);
     }
 
     #[test]
     fn flatten_expanded_node_shows_children() {
         let tree = TreeNode {
-            reference: "root".into(),
+            reference: root(),
             label: "Root".into(),
             node_type: NodeType::Root,
             expanded: true,
@@ -351,7 +376,7 @@ mod tests {
             failed: false,
             is_system: false,
             children: vec![TreeNode {
-                reference: "host1".into(),
+                reference: host("host1"),
                 label: "Host 1".into(),
                 node_type: NodeType::Host,
                 expanded: true,
@@ -361,7 +386,7 @@ mod tests {
                 failed: false,
                 is_system: false,
                 children: vec![TreeNode {
-                    reference: "proc1".into(),
+                    reference: proc_ref("proc1"),
                     label: "Proc 1".into(),
                     node_type: NodeType::Proc,
                     expanded: false,
@@ -376,16 +401,16 @@ mod tests {
         };
         let rows = flatten_tree(&tree);
         assert_eq!(rows.len(), 2);
-        assert_eq!(rows[0].node.reference, "host1");
+        assert_eq!(rows[0].node.reference, host("host1"));
         assert_eq!(rows[0].depth, 0);
-        assert_eq!(rows[1].node.reference, "proc1");
+        assert_eq!(rows[1].node.reference, proc_ref("proc1"));
         assert_eq!(rows[1].depth, 1);
     }
 
     #[test]
     fn find_node_by_reference_works() {
         let tree = TreeNode {
-            reference: "root".into(),
+            reference: root(),
             label: "Root".into(),
             node_type: NodeType::Root,
             expanded: true,
@@ -395,7 +420,7 @@ mod tests {
             failed: false,
             is_system: false,
             children: vec![TreeNode {
-                reference: "child1".into(),
+                reference: actor("child1"),
                 label: "Child 1".into(),
                 node_type: NodeType::Host,
                 expanded: false,
@@ -407,15 +432,15 @@ mod tests {
                 children: vec![],
             }],
         };
-        let found = find_node_by_ref(&tree, "child1");
+        let found = find_node_by_ref(&tree, &actor("child1"));
         assert!(found.is_some());
-        assert_eq!(found.unwrap().reference, "child1");
+        assert_eq!(found.unwrap().reference, actor("child1"));
     }
 
     #[test]
     fn find_node_mut_works() {
         let mut tree = TreeNode {
-            reference: "root".into(),
+            reference: root(),
             label: "Root".into(),
             node_type: NodeType::Root,
             expanded: true,
@@ -425,7 +450,7 @@ mod tests {
             failed: false,
             is_system: false,
             children: vec![TreeNode {
-                reference: "child1".into(),
+                reference: actor("child1"),
                 label: "Child 1".into(),
                 node_type: NodeType::Host,
                 expanded: false,
@@ -437,7 +462,7 @@ mod tests {
                 children: vec![],
             }],
         };
-        let found = find_node_mut(&mut tree, "child1");
+        let found = find_node_mut(&mut tree, &actor("child1"));
         assert!(found.is_some());
         found.unwrap().expanded = true;
         assert!(tree.children[0].expanded);
@@ -446,7 +471,7 @@ mod tests {
     #[test]
     fn collect_refs_visits_all_nodes() {
         let tree = TreeNode {
-            reference: "root".into(),
+            reference: root(),
             label: "Root".into(),
             node_type: NodeType::Root,
             expanded: true,
@@ -456,7 +481,7 @@ mod tests {
             failed: false,
             is_system: false,
             children: vec![TreeNode {
-                reference: "host1".into(),
+                reference: host("host1"),
                 label: "Host 1".into(),
                 node_type: NodeType::Host,
                 expanded: false,
@@ -466,7 +491,7 @@ mod tests {
                 failed: false,
                 is_system: false,
                 children: vec![TreeNode {
-                    reference: "proc1".into(),
+                    reference: proc_ref("proc1"),
                     label: "Proc 1".into(),
                     node_type: NodeType::Proc,
                     expanded: false,
@@ -482,15 +507,15 @@ mod tests {
         let mut refs = HashSet::new();
         collect_refs(&tree, &mut refs);
         assert_eq!(refs.len(), 3);
-        assert!(refs.contains("root"));
-        assert!(refs.contains("host1"));
-        assert!(refs.contains("proc1"));
+        assert!(refs.contains(&root()));
+        assert!(refs.contains(&host("host1")));
+        assert!(refs.contains(&proc_ref("proc1")));
     }
 
     #[test]
     fn dual_appearances_flatten_correctly() {
         let tree = TreeNode {
-            reference: "root".into(),
+            reference: root(),
             label: "Root".into(),
             node_type: NodeType::Root,
             expanded: true,
@@ -501,7 +526,7 @@ mod tests {
             is_system: false,
             children: vec![
                 TreeNode {
-                    reference: "proc1".into(),
+                    reference: proc_ref("proc1"),
                     label: "Proc 1".into(),
                     node_type: NodeType::Proc,
                     expanded: true,
@@ -511,7 +536,7 @@ mod tests {
                     failed: false,
                     is_system: false,
                     children: vec![TreeNode {
-                        reference: "actor1".into(),
+                        reference: actor("actor1"),
                         label: "Actor 1".into(),
                         node_type: NodeType::Actor,
                         expanded: false,
@@ -524,7 +549,7 @@ mod tests {
                     }],
                 },
                 TreeNode {
-                    reference: "actor1".into(),
+                    reference: actor("actor1"),
                     label: "Actor 1".into(),
                     node_type: NodeType::Actor,
                     expanded: false,
@@ -539,18 +564,18 @@ mod tests {
         };
         let rows = flatten_tree(&tree);
         assert_eq!(rows.len(), 3);
-        assert_eq!(rows[0].node.reference, "proc1");
+        assert_eq!(rows[0].node.reference, proc_ref("proc1"));
         assert_eq!(rows[0].depth, 0);
-        assert_eq!(rows[1].node.reference, "actor1");
+        assert_eq!(rows[1].node.reference, actor("actor1"));
         assert_eq!(rows[1].depth, 1);
-        assert_eq!(rows[2].node.reference, "actor1");
+        assert_eq!(rows[2].node.reference, actor("actor1"));
         assert_eq!(rows[2].depth, 0);
     }
 
     #[test]
     fn expansion_tracking_uses_depth_pairs() {
         let tree = TreeNode {
-            reference: "root".into(),
+            reference: root(),
             label: "Root".into(),
             node_type: NodeType::Root,
             expanded: true,
@@ -561,7 +586,7 @@ mod tests {
             is_system: false,
             children: vec![
                 TreeNode {
-                    reference: "proc1".into(),
+                    reference: proc_ref("proc1"),
                     label: "Proc 1".into(),
                     node_type: NodeType::Proc,
                     expanded: true,
@@ -571,7 +596,7 @@ mod tests {
                     failed: false,
                     is_system: false,
                     children: vec![TreeNode {
-                        reference: "actor1".into(),
+                        reference: actor("actor1"),
                         label: "Actor 1".into(),
                         node_type: NodeType::Actor,
                         expanded: true,
@@ -584,7 +609,7 @@ mod tests {
                     }],
                 },
                 TreeNode {
-                    reference: "actor1".into(),
+                    reference: actor("actor1"),
                     label: "Actor 1".into(),
                     node_type: NodeType::Actor,
                     expanded: false,
@@ -601,15 +626,15 @@ mod tests {
         for child in &tree.children {
             collect_expanded_refs(child, 0, &mut expanded_keys);
         }
-        assert!(expanded_keys.contains(&("proc1".to_string(), 0)));
-        assert!(expanded_keys.contains(&("actor1".to_string(), 1)));
-        assert!(!expanded_keys.contains(&("actor1".to_string(), 0)));
+        assert!(expanded_keys.contains(&(proc_ref("proc1"), 0)));
+        assert!(expanded_keys.contains(&(actor("actor1"), 1)));
+        assert!(!expanded_keys.contains(&(actor("actor1"), 0)));
     }
 
     #[test]
     fn find_node_at_depth_distinguishes_instances() {
         let mut tree = TreeNode {
-            reference: "root".into(),
+            reference: root(),
             label: "Root".into(),
             node_type: NodeType::Root,
             expanded: true,
@@ -620,7 +645,7 @@ mod tests {
             is_system: false,
             children: vec![
                 TreeNode {
-                    reference: "proc1".into(),
+                    reference: proc_ref("proc1"),
                     label: "Proc 1".into(),
                     node_type: NodeType::Proc,
                     expanded: true,
@@ -630,7 +655,7 @@ mod tests {
                     failed: false,
                     is_system: false,
                     children: vec![TreeNode {
-                        reference: "actor1".into(),
+                        reference: actor("actor1"),
                         label: "Actor 1 in supervision".into(),
                         node_type: NodeType::Actor,
                         expanded: true,
@@ -643,7 +668,7 @@ mod tests {
                     }],
                 },
                 TreeNode {
-                    reference: "actor1".into(),
+                    reference: actor("actor1"),
                     label: "Actor 1 in flat list".into(),
                     node_type: NodeType::Actor,
                     expanded: false,
@@ -660,14 +685,14 @@ mod tests {
         let found_depth_1 = tree
             .children
             .iter_mut()
-            .find_map(|child| find_node_at_depth_mut(child, "actor1", 1, 0, &mut count));
+            .find_map(|child| find_node_at_depth_mut(child, &actor("actor1"), 1, 0, &mut count));
         assert!(found_depth_1.is_some());
         assert_eq!(found_depth_1.unwrap().label, "Actor 1 in supervision");
         let mut count = 0;
         let found_depth_0 = tree
             .children
             .iter_mut()
-            .find_map(|child| find_node_at_depth_mut(child, "actor1", 0, 0, &mut count));
+            .find_map(|child| find_node_at_depth_mut(child, &actor("actor1"), 0, 0, &mut count));
         assert!(found_depth_0.is_some());
         assert_eq!(found_depth_0.unwrap().label, "Actor 1 in flat list");
     }
@@ -675,7 +700,7 @@ mod tests {
     #[test]
     fn collapsed_nodes_stay_collapsed_after_refresh() {
         let tree = TreeNode {
-            reference: "root".into(),
+            reference: root(),
             label: "Root".into(),
             node_type: NodeType::Root,
             expanded: true,
@@ -685,7 +710,7 @@ mod tests {
             failed: false,
             is_system: false,
             children: vec![TreeNode {
-                reference: "proc1".into(),
+                reference: proc_ref("proc1"),
                 label: "Proc 1".into(),
                 node_type: NodeType::Proc,
                 expanded: false,
@@ -695,7 +720,7 @@ mod tests {
                 failed: false,
                 is_system: false,
                 children: vec![TreeNode {
-                    reference: "actor1".into(),
+                    reference: actor("actor1"),
                     label: "Actor 1".into(),
                     node_type: NodeType::Actor,
                     expanded: false,
@@ -712,14 +737,14 @@ mod tests {
         for child in &tree.children {
             collect_expanded_refs(child, 0, &mut expanded_keys);
         }
-        assert!(!expanded_keys.contains(&("proc1".to_string(), 0)));
-        assert!(!expanded_keys.contains(&("actor1".to_string(), 1)));
+        assert!(!expanded_keys.contains(&(proc_ref("proc1"), 0)));
+        assert!(!expanded_keys.contains(&(actor("actor1"), 1)));
     }
 
     #[test]
     fn fold_equivalence_flatten_tree() {
         let tree = TreeNode {
-            reference: "root".into(),
+            reference: root(),
             label: "Root".into(),
             node_type: NodeType::Root,
             expanded: true,
@@ -730,7 +755,7 @@ mod tests {
             is_system: false,
             children: vec![
                 TreeNode {
-                    reference: "host1".into(),
+                    reference: host("host1"),
                     label: "Host 1".into(),
                     node_type: NodeType::Host,
                     expanded: true,
@@ -740,7 +765,7 @@ mod tests {
                     failed: false,
                     is_system: false,
                     children: vec![TreeNode {
-                        reference: "proc1".into(),
+                        reference: proc_ref("proc1"),
                         label: "Proc 1".into(),
                         node_type: NodeType::Proc,
                         expanded: false,
@@ -750,7 +775,7 @@ mod tests {
                         failed: false,
                         is_system: false,
                         children: vec![TreeNode {
-                            reference: "actor1".into(),
+                            reference: actor("actor1"),
                             label: "Actor 1".into(),
                             node_type: NodeType::Actor,
                             expanded: false,
@@ -764,7 +789,7 @@ mod tests {
                     }],
                 },
                 TreeNode {
-                    reference: "host2".into(),
+                    reference: host("host2"),
                     label: "Host 2".into(),
                     node_type: NodeType::Host,
                     expanded: false,
@@ -779,18 +804,18 @@ mod tests {
         };
         let rows = flatten_tree(&tree);
         assert_eq!(rows.len(), 3);
-        assert_eq!(rows[0].node.reference, "host1");
+        assert_eq!(rows[0].node.reference, host("host1"));
         assert_eq!(rows[0].depth, 0);
-        assert_eq!(rows[1].node.reference, "proc1");
+        assert_eq!(rows[1].node.reference, proc_ref("proc1"));
         assert_eq!(rows[1].depth, 1);
-        assert_eq!(rows[2].node.reference, "host2");
+        assert_eq!(rows[2].node.reference, host("host2"));
         assert_eq!(rows[2].depth, 0);
     }
 
     #[test]
     fn fold_tree_mut_early_exit_stops_traversal() {
         let mut tree = TreeNode {
-            reference: "root".into(),
+            reference: root(),
             label: "Root".into(),
             node_type: NodeType::Root,
             expanded: true,
@@ -801,7 +826,7 @@ mod tests {
             is_system: false,
             children: vec![
                 TreeNode {
-                    reference: "child1".into(),
+                    reference: actor("child1"),
                     label: "Child 1".into(),
                     node_type: NodeType::Host,
                     expanded: true,
@@ -811,7 +836,7 @@ mod tests {
                     failed: false,
                     is_system: false,
                     children: vec![TreeNode {
-                        reference: "target".into(),
+                        reference: actor("target"),
                         label: "Target".into(),
                         node_type: NodeType::Proc,
                         expanded: true,
@@ -824,7 +849,7 @@ mod tests {
                     }],
                 },
                 TreeNode {
-                    reference: "child2".into(),
+                    reference: actor("child2"),
                     label: "Child 2".into(),
                     node_type: NodeType::Host,
                     expanded: true,
@@ -834,7 +859,7 @@ mod tests {
                     failed: false,
                     is_system: false,
                     children: vec![TreeNode {
-                        reference: "should_not_visit".into(),
+                        reference: actor("should_not_visit"),
                         label: "Should Not Visit".into(),
                         node_type: NodeType::Proc,
                         expanded: true,
@@ -852,21 +877,21 @@ mod tests {
         let mut visited = Vec::new();
         let result = fold_tree_mut_with_depth(&mut tree, 0, &mut |n, _d| {
             visited.push(n.reference.clone());
-            if n.reference == "target" {
+            if n.reference == actor("target") {
                 ControlFlow::Break(())
             } else {
                 ControlFlow::Continue(())
             }
         });
         assert!(result.is_break());
-        assert_eq!(visited, vec!["root", "child1", "target"]);
-        assert!(!visited.contains(&"should_not_visit".to_string()));
+        assert_eq!(visited, vec![root(), actor("child1"), actor("target")]);
+        assert!(!visited.contains(&actor("should_not_visit")));
     }
 
     #[test]
     fn selection_restore_prefers_depth_match() {
         let mut tree = TreeNode {
-            reference: "root".into(),
+            reference: root(),
             label: "Root".into(),
             node_type: NodeType::Root,
             expanded: true,
@@ -876,7 +901,7 @@ mod tests {
             failed: false,
             is_system: false,
             children: vec![TreeNode {
-                reference: "duplicate".into(),
+                reference: actor("duplicate"),
                 label: "Duplicate at depth 0".into(),
                 node_type: NodeType::Host,
                 expanded: true,
@@ -886,7 +911,7 @@ mod tests {
                 failed: false,
                 is_system: false,
                 children: vec![TreeNode {
-                    reference: "duplicate".into(),
+                    reference: actor("duplicate"),
                     label: "Duplicate at depth 1".into(),
                     node_type: NodeType::Proc,
                     expanded: true,
@@ -903,14 +928,14 @@ mod tests {
         let found_d0 = tree
             .children
             .iter_mut()
-            .find_map(|child| find_node_at_depth_mut(child, "duplicate", 0, 0, &mut count));
+            .find_map(|child| find_node_at_depth_mut(child, &actor("duplicate"), 0, 0, &mut count));
         assert!(found_d0.is_some());
         assert_eq!(found_d0.unwrap().label, "Duplicate at depth 0");
         let mut count = 0;
         let found_d1 = tree
             .children
             .iter_mut()
-            .find_map(|child| find_node_at_depth_mut(child, "duplicate", 1, 0, &mut count));
+            .find_map(|child| find_node_at_depth_mut(child, &actor("duplicate"), 1, 0, &mut count));
         assert!(found_d1.is_some());
         assert_eq!(found_d1.unwrap().label, "Duplicate at depth 1");
     }
@@ -918,7 +943,7 @@ mod tests {
     #[test]
     fn fold_vs_traversal_law_node_count() {
         let tree = TreeNode {
-            reference: "root".into(),
+            reference: root(),
             label: "Root".into(),
             node_type: NodeType::Root,
             expanded: true,
@@ -929,7 +954,7 @@ mod tests {
             is_system: false,
             children: vec![
                 TreeNode {
-                    reference: "host1".into(),
+                    reference: host("host1"),
                     label: "Host 1".into(),
                     node_type: NodeType::Host,
                     expanded: true,
@@ -939,7 +964,7 @@ mod tests {
                     failed: false,
                     is_system: false,
                     children: vec![TreeNode {
-                        reference: "proc1".into(),
+                        reference: proc_ref("proc1"),
                         label: "Proc 1".into(),
                         node_type: NodeType::Proc,
                         expanded: true,
@@ -952,7 +977,7 @@ mod tests {
                     }],
                 },
                 TreeNode {
-                    reference: "host2".into(),
+                    reference: host("host2"),
                     label: "Host 2".into(),
                     node_type: NodeType::Host,
                     expanded: true,
@@ -975,7 +1000,7 @@ mod tests {
     #[test]
     fn collapse_idempotence() {
         let mut tree = TreeNode {
-            reference: "root".into(),
+            reference: root(),
             label: "Root".into(),
             node_type: NodeType::Root,
             expanded: true,
@@ -985,7 +1010,7 @@ mod tests {
             failed: false,
             is_system: false,
             children: vec![TreeNode {
-                reference: "child".into(),
+                reference: actor("child"),
                 label: "Child".into(),
                 node_type: NodeType::Host,
                 expanded: true,
@@ -1011,7 +1036,7 @@ mod tests {
     #[test]
     fn placeholder_refinement_transitions_fetched_state() {
         let mut tree = TreeNode {
-            reference: "root".into(),
+            reference: root(),
             label: "Root".into(),
             node_type: NodeType::Root,
             expanded: true,
@@ -1021,7 +1046,7 @@ mod tests {
             failed: false,
             is_system: false,
             children: vec![TreeNode {
-                reference: "placeholder".into(),
+                reference: actor("placeholder"),
                 label: "Loading...".into(),
                 node_type: NodeType::Host,
                 expanded: false,
@@ -1035,11 +1060,11 @@ mod tests {
         };
         use std::ops::ControlFlow;
         let _ = fold_tree_mut(&mut tree, &mut |n| {
-            if n.reference == "placeholder" && !n.fetched {
+            if n.reference == actor("placeholder") && !n.fetched {
                 n.fetched = true;
                 n.has_children = true;
                 n.children = vec![TreeNode {
-                    reference: "child".into(),
+                    reference: actor("child"),
                     label: "Child".into(),
                     node_type: NodeType::Proc,
                     expanded: false,
@@ -1055,20 +1080,20 @@ mod tests {
                 ControlFlow::Continue(())
             }
         });
-        let placeholder = find_node_by_ref(&tree, "placeholder");
+        let placeholder = find_node_by_ref(&tree, &actor("placeholder"));
         assert!(placeholder.is_some());
         let placeholder = placeholder.unwrap();
         assert!(placeholder.fetched);
         assert_eq!(placeholder.children.len(), 1);
         let initial_children = placeholder.children.len();
-        let _ = find_node_by_ref(&tree, "placeholder");
+        let _ = find_node_by_ref(&tree, &actor("placeholder"));
         assert_eq!(initial_children, 1);
     }
 
     #[test]
     fn cycle_guard_prevents_infinite_recursion() {
         let mut tree = TreeNode {
-            reference: "root".into(),
+            reference: root(),
             label: "Root".into(),
             node_type: NodeType::Root,
             expanded: true,
@@ -1078,7 +1103,7 @@ mod tests {
             failed: false,
             is_system: false,
             children: vec![TreeNode {
-                reference: "root".into(),
+                reference: root(),
                 label: "Self-reference".into(),
                 node_type: NodeType::Host,
                 expanded: true,
@@ -1110,7 +1135,7 @@ mod tests {
     #[test]
     fn fold_tree_mut_visits_in_preorder() {
         let mut tree = TreeNode {
-            reference: "root".into(),
+            reference: root(),
             label: "Root".into(),
             node_type: NodeType::Root,
             expanded: true,
@@ -1121,7 +1146,7 @@ mod tests {
             is_system: false,
             children: vec![
                 TreeNode {
-                    reference: "child1".into(),
+                    reference: actor("child1"),
                     label: "Child 1".into(),
                     node_type: NodeType::Host,
                     expanded: true,
@@ -1131,7 +1156,7 @@ mod tests {
                     failed: false,
                     is_system: false,
                     children: vec![TreeNode {
-                        reference: "grandchild1".into(),
+                        reference: actor("grandchild1"),
                         label: "Grandchild 1".into(),
                         node_type: NodeType::Proc,
                         expanded: false,
@@ -1144,7 +1169,7 @@ mod tests {
                     }],
                 },
                 TreeNode {
-                    reference: "child2".into(),
+                    reference: actor("child2"),
                     label: "Child 2".into(),
                     node_type: NodeType::Host,
                     expanded: false,
@@ -1166,10 +1191,10 @@ mod tests {
         assert_eq!(
             visit_order,
             vec![
-                ("root".to_string(), 0),
-                ("child1".to_string(), 1),
-                ("grandchild1".to_string(), 2),
-                ("child2".to_string(), 1),
+                (root(), 0),
+                (actor("child1"), 1),
+                (actor("grandchild1"), 2),
+                (actor("child2"), 1),
             ]
         );
     }
@@ -1177,7 +1202,7 @@ mod tests {
     #[test]
     fn fold_tree_with_depth_deterministic_preorder() {
         let tree = TreeNode {
-            reference: "root".into(),
+            reference: root(),
             label: "Root".into(),
             node_type: NodeType::Root,
             expanded: true,
@@ -1188,7 +1213,7 @@ mod tests {
             is_system: false,
             children: vec![
                 TreeNode {
-                    reference: "a".into(),
+                    reference: actor("a"),
                     label: "A".into(),
                     node_type: NodeType::Host,
                     expanded: true,
@@ -1198,7 +1223,7 @@ mod tests {
                     failed: false,
                     is_system: false,
                     children: vec![TreeNode {
-                        reference: "a1".into(),
+                        reference: actor("a1"),
                         label: "A1".into(),
                         node_type: NodeType::Proc,
                         expanded: false,
@@ -1211,7 +1236,7 @@ mod tests {
                     }],
                 },
                 TreeNode {
-                    reference: "b".into(),
+                    reference: actor("b"),
                     label: "B".into(),
                     node_type: NodeType::Host,
                     expanded: false,
@@ -1227,7 +1252,7 @@ mod tests {
         let visit_order = fold_tree_with_depth(&tree, 0, &|n,
                                                            d,
                                                            child_orders: Vec<
-            Vec<(String, usize)>,
+            Vec<(NodeRef, usize)>,
         >| {
             let mut order = vec![(n.reference.clone(), d)];
             for child_order in child_orders {
@@ -1238,10 +1263,10 @@ mod tests {
         assert_eq!(
             visit_order,
             vec![
-                ("root".to_string(), 0),
-                ("a".to_string(), 1),
-                ("a1".to_string(), 2),
-                ("b".to_string(), 1),
+                (root(), 0),
+                (actor("a"), 1),
+                (actor("a1"), 2),
+                (actor("b"), 1),
             ]
         );
     }
@@ -1249,7 +1274,7 @@ mod tests {
     #[test]
     fn cycle_vs_duplicate_reference_allowed() {
         let tree = TreeNode {
-            reference: "root".into(),
+            reference: root(),
             label: "Root".into(),
             node_type: NodeType::Root,
             expanded: true,
@@ -1260,7 +1285,7 @@ mod tests {
             is_system: false,
             children: vec![
                 TreeNode {
-                    reference: "branch_a".into(),
+                    reference: actor("branch_a"),
                     label: "Branch A".into(),
                     node_type: NodeType::Host,
                     expanded: true,
@@ -1270,7 +1295,7 @@ mod tests {
                     failed: false,
                     is_system: false,
                     children: vec![TreeNode {
-                        reference: "duplicate".into(),
+                        reference: actor("duplicate"),
                         label: "Duplicate in A".into(),
                         node_type: NodeType::Proc,
                         expanded: false,
@@ -1283,7 +1308,7 @@ mod tests {
                     }],
                 },
                 TreeNode {
-                    reference: "branch_b".into(),
+                    reference: actor("branch_b"),
                     label: "Branch B".into(),
                     node_type: NodeType::Host,
                     expanded: true,
@@ -1293,7 +1318,7 @@ mod tests {
                     failed: false,
                     is_system: false,
                     children: vec![TreeNode {
-                        reference: "duplicate".into(),
+                        reference: actor("duplicate"),
                         label: "Duplicate in B".into(),
                         node_type: NodeType::Proc,
                         expanded: false,
@@ -1314,7 +1339,7 @@ mod tests {
         let rows = flatten_tree(&tree);
         let duplicate_count = rows
             .iter()
-            .filter(|r| r.node.reference == "duplicate")
+            .filter(|r| r.node.reference == actor("duplicate"))
             .count();
         assert_eq!(duplicate_count, 2);
     }
@@ -1322,7 +1347,7 @@ mod tests {
     #[test]
     fn single_node_tree_expand_collapse() {
         let mut tree = TreeNode {
-            reference: "root".into(),
+            reference: root(),
             label: "Root".into(),
             node_type: NodeType::Root,
             expanded: true,
@@ -1332,7 +1357,7 @@ mod tests {
             failed: false,
             is_system: false,
             children: vec![TreeNode {
-                reference: "only_child".into(),
+                reference: actor("only_child"),
                 label: "Only Child".into(),
                 node_type: NodeType::Host,
                 expanded: false,
@@ -1346,8 +1371,8 @@ mod tests {
         };
         let rows = flatten_tree(&tree);
         assert_eq!(rows.len(), 1);
-        assert_eq!(rows[0].node.reference, "only_child");
-        let child = find_node_mut(&mut tree, "only_child");
+        assert_eq!(rows[0].node.reference, actor("only_child"));
+        let child = find_node_mut(&mut tree, &actor("only_child"));
         assert!(child.is_some());
         let child = child.unwrap();
         assert!(!child.has_children);
@@ -1360,7 +1385,7 @@ mod tests {
     #[test]
     fn placeholder_with_has_children_true_awaits_fetch() {
         let mut tree = TreeNode {
-            reference: "root".into(),
+            reference: root(),
             label: "Root".into(),
             node_type: NodeType::Root,
             expanded: true,
@@ -1370,7 +1395,7 @@ mod tests {
             failed: false,
             is_system: false,
             children: vec![TreeNode {
-                reference: "placeholder".into(),
+                reference: actor("placeholder"),
                 label: "Loading...".into(),
                 node_type: NodeType::Host,
                 expanded: false,
@@ -1384,8 +1409,8 @@ mod tests {
         };
         let rows = flatten_tree(&tree);
         assert_eq!(rows.len(), 1);
-        assert_eq!(rows[0].node.reference, "placeholder");
-        let placeholder = find_node_mut(&mut tree, "placeholder");
+        assert_eq!(rows[0].node.reference, actor("placeholder"));
+        let placeholder = find_node_mut(&mut tree, &actor("placeholder"));
         assert!(placeholder.is_some());
         let placeholder = placeholder.unwrap();
         assert!(placeholder.has_children);
@@ -1393,7 +1418,7 @@ mod tests {
         assert_eq!(placeholder.children.len(), 0);
         use std::ops::ControlFlow;
         let _ = fold_tree_mut(&mut tree, &mut |n| {
-            if n.reference == "placeholder" && !n.expanded {
+            if n.reference == actor("placeholder") && !n.expanded {
                 assert!(!n.expanded);
                 ControlFlow::Break(())
             } else {
@@ -1405,7 +1430,7 @@ mod tests {
     #[test]
     fn placeholder_noop_when_has_children_false() {
         let mut tree = TreeNode {
-            reference: "root".into(),
+            reference: root(),
             label: "Root".into(),
             node_type: NodeType::Root,
             expanded: true,
@@ -1415,7 +1440,7 @@ mod tests {
             failed: false,
             is_system: false,
             children: vec![TreeNode {
-                reference: "leaf".into(),
+                reference: actor("leaf"),
                 label: "Leaf Node".into(),
                 node_type: NodeType::Actor,
                 expanded: false,
@@ -1429,13 +1454,13 @@ mod tests {
         };
         use std::ops::ControlFlow;
         let _ = fold_tree_mut(&mut tree, &mut |n| {
-            if n.reference == "leaf" && !n.has_children {
+            if n.reference == actor("leaf") && !n.has_children {
                 assert_eq!(n.children.len(), 0);
                 assert!(!n.expanded);
             }
             ControlFlow::<()>::Continue(())
         });
-        let leaf = find_node_by_ref(&tree, "leaf");
+        let leaf = find_node_by_ref(&tree, &actor("leaf"));
         assert!(leaf.is_some());
         let leaf = leaf.unwrap();
         assert!(!leaf.expanded);
@@ -1446,7 +1471,7 @@ mod tests {
     #[test]
     fn expanded_node_with_empty_children_renders_safely() {
         let tree = TreeNode {
-            reference: "root".into(),
+            reference: root(),
             label: "Root".into(),
             node_type: NodeType::Root,
             expanded: true,
@@ -1456,7 +1481,7 @@ mod tests {
             failed: false,
             is_system: false,
             children: vec![TreeNode {
-                reference: "empty_parent".into(),
+                reference: actor("empty_parent"),
                 label: "Empty Parent".into(),
                 node_type: NodeType::Host,
                 expanded: true,
@@ -1470,7 +1495,7 @@ mod tests {
         };
         let rows = flatten_tree(&tree);
         assert_eq!(rows.len(), 1);
-        assert_eq!(rows[0].node.reference, "empty_parent");
+        assert_eq!(rows[0].node.reference, actor("empty_parent"));
         let count = fold_tree(&tree, &|_n, child_counts: Vec<usize>| {
             1 + child_counts.iter().sum::<usize>()
         });
@@ -1480,7 +1505,7 @@ mod tests {
     #[test]
     fn duplicate_references_expansion_targets_specific_instance() {
         let mut tree = TreeNode {
-            reference: "root".into(),
+            reference: root(),
             label: "Root".into(),
             node_type: NodeType::Root,
             expanded: true,
@@ -1491,7 +1516,7 @@ mod tests {
             is_system: false,
             children: vec![
                 TreeNode {
-                    reference: "duplicate".into(),
+                    reference: actor("duplicate"),
                     label: "Duplicate at 0".into(),
                     node_type: NodeType::Host,
                     expanded: false,
@@ -1501,7 +1526,7 @@ mod tests {
                     failed: false,
                     is_system: false,
                     children: vec![TreeNode {
-                        reference: "child_of_first".into(),
+                        reference: actor("child_of_first"),
                         label: "Child of First".into(),
                         node_type: NodeType::Proc,
                         expanded: false,
@@ -1514,7 +1539,7 @@ mod tests {
                     }],
                 },
                 TreeNode {
-                    reference: "duplicate".into(),
+                    reference: actor("duplicate"),
                     label: "Duplicate at 0 (second)".into(),
                     node_type: NodeType::Host,
                     expanded: false,
@@ -1524,7 +1549,7 @@ mod tests {
                     failed: false,
                     is_system: false,
                     children: vec![TreeNode {
-                        reference: "child_of_second".into(),
+                        reference: actor("child_of_second"),
                         label: "Child of Second".into(),
                         node_type: NodeType::Proc,
                         expanded: false,
@@ -1542,15 +1567,15 @@ mod tests {
         let first = tree
             .children
             .iter_mut()
-            .find_map(|child| find_node_at_depth_mut(child, "duplicate", 0, 0, &mut count));
+            .find_map(|child| find_node_at_depth_mut(child, &actor("duplicate"), 0, 0, &mut count));
         assert!(first.is_some());
         first.unwrap().expanded = true;
         assert!(tree.children[0].expanded);
         assert!(!tree.children[1].expanded);
         let rows = flatten_tree(&tree);
-        let refs: Vec<_> = rows.iter().map(|r| r.node.reference.as_str()).collect();
-        assert!(refs.contains(&"child_of_first"));
-        assert!(!refs.contains(&"child_of_second"));
+        let refs: Vec<_> = rows.iter().map(|r| &r.node.reference).collect();
+        assert!(refs.contains(&&actor("child_of_first")));
+        assert!(!refs.contains(&&actor("child_of_second")));
     }
 
     // Stopped nodes visible in flatten
@@ -1559,7 +1584,7 @@ mod tests {
         let tree = make_proc_with_stopped_children();
         let rows = flatten_tree(&tree);
         assert_eq!(rows.len(), 4);
-        assert!(rows.iter().any(|r| r.node.reference == "dead_actor"));
+        assert!(rows.iter().any(|r| r.node.reference == actor("dead_actor")));
     }
 
     #[test]
@@ -1568,12 +1593,12 @@ mod tests {
         let rows = flatten_tree(&tree);
         let dead = rows
             .iter()
-            .find(|r| r.node.reference == "dead_actor")
+            .find(|r| r.node.reference == actor("dead_actor"))
             .unwrap();
         assert!(dead.node.stopped);
         let live = rows
             .iter()
-            .find(|r| r.node.reference == "live_actor_1")
+            .find(|r| r.node.reference == actor("live_actor_1"))
             .unwrap();
         assert!(!live.node.stopped);
     }
@@ -1581,7 +1606,7 @@ mod tests {
     #[test]
     fn placeholder_stopped_visible_in_flatten() {
         let tree = TreeNode {
-            reference: "root".into(),
+            reference: root(),
             label: "Root".into(),
             node_type: NodeType::Root,
             expanded: true,
@@ -1590,7 +1615,7 @@ mod tests {
             stopped: false,
             failed: false,
             is_system: false,
-            children: vec![TreeNode::placeholder_stopped("dead1".to_string())],
+            children: vec![TreeNode::placeholder_stopped(actor("dead1"))],
         };
         let rows = flatten_tree(&tree);
         assert_eq!(rows.len(), 1);
@@ -1601,7 +1626,7 @@ mod tests {
     // Helper for stopped-children tests
     fn make_proc_with_stopped_children() -> TreeNode {
         TreeNode {
-            reference: "root".into(),
+            reference: root(),
             label: "Root".into(),
             node_type: NodeType::Root,
             expanded: true,
@@ -1611,7 +1636,7 @@ mod tests {
             failed: false,
             is_system: false,
             children: vec![TreeNode {
-                reference: "proc1".into(),
+                reference: proc_ref("proc1"),
                 label: "proc1".into(),
                 node_type: NodeType::Proc,
                 expanded: true,
@@ -1622,7 +1647,7 @@ mod tests {
                 is_system: false,
                 children: vec![
                     TreeNode {
-                        reference: "live_actor_1".into(),
+                        reference: actor("live_actor_1"),
                         label: "live_actor_1".into(),
                         node_type: NodeType::Actor,
                         expanded: false,
@@ -1634,7 +1659,7 @@ mod tests {
                         children: vec![],
                     },
                     TreeNode {
-                        reference: "live_actor_2".into(),
+                        reference: actor("live_actor_2"),
                         label: "live_actor_2".into(),
                         node_type: NodeType::Actor,
                         expanded: false,
@@ -1646,7 +1671,7 @@ mod tests {
                         children: vec![],
                     },
                     TreeNode {
-                        reference: "dead_actor".into(),
+                        reference: actor("dead_actor"),
                         label: "dead_actor".into(),
                         node_type: NodeType::Actor,
                         expanded: false,
@@ -1670,7 +1695,7 @@ mod tests {
             let mut children = Vec::new();
             for i in 0..scale {
                 children.push(TreeNode {
-                    reference: format!("node_{}", i),
+                    reference: actor(&format!("node_{}", i)),
                     label: format!("Node {}", i),
                     node_type: NodeType::Actor,
                     expanded: false,
@@ -1683,7 +1708,7 @@ mod tests {
                 });
             }
             let tree = TreeNode {
-                reference: "root".into(),
+                reference: root(),
                 label: "Root".into(),
                 node_type: NodeType::Root,
                 expanded: true,
@@ -1706,7 +1731,7 @@ mod tests {
     #[test]
     fn deep_chain_vs_wide_fanout_performance() {
         let mut deep = TreeNode {
-            reference: "deep_root".into(),
+            reference: actor("deep_root"),
             label: "Deep Root".into(),
             node_type: NodeType::Root,
             expanded: true,
@@ -1720,7 +1745,7 @@ mod tests {
         let mut current = &mut deep;
         for i in 0..499 {
             current.children.push(TreeNode {
-                reference: format!("deep_{}", i),
+                reference: actor(&format!("deep_{}", i)),
                 label: format!("Deep {}", i),
                 node_type: NodeType::Host,
                 expanded: true,
@@ -1736,7 +1761,7 @@ mod tests {
         let mut wide_children = Vec::new();
         for i in 0..500 {
             wide_children.push(TreeNode {
-                reference: format!("wide_{}", i),
+                reference: actor(&format!("wide_{}", i)),
                 label: format!("Wide {}", i),
                 node_type: NodeType::Actor,
                 expanded: false,
@@ -1749,7 +1774,7 @@ mod tests {
             });
         }
         let wide = TreeNode {
-            reference: "wide_root".into(),
+            reference: actor("wide_root"),
             label: "Wide Root".into(),
             node_type: NodeType::Root,
             expanded: true,
@@ -1773,7 +1798,7 @@ mod tests {
         let mut children = Vec::new();
         for i in 0..1000 {
             children.push(TreeNode {
-                reference: format!("node_{}", i),
+                reference: actor(&format!("node_{}", i)),
                 label: format!("Node {}", i),
                 node_type: NodeType::Actor,
                 expanded: false,
@@ -1786,7 +1811,7 @@ mod tests {
             });
         }
         let mut tree = TreeNode {
-            reference: "root".into(),
+            reference: root(),
             label: "Root".into(),
             node_type: NodeType::Root,
             expanded: true,
@@ -1818,7 +1843,7 @@ mod tests {
             let mut grandchildren = Vec::new();
             for j in 0..100 {
                 grandchildren.push(TreeNode {
-                    reference: format!("child_{}_{}", i, j),
+                    reference: actor(&format!("child_{}_{}", i, j)),
                     label: format!("Child {} {}", i, j),
                     node_type: NodeType::Actor,
                     expanded: false,
@@ -1831,7 +1856,7 @@ mod tests {
                 });
             }
             children.push(TreeNode {
-                reference: format!("parent_{}", i),
+                reference: actor(&format!("parent_{}", i)),
                 label: format!("Parent {}", i),
                 node_type: NodeType::Proc,
                 expanded: false,
@@ -1844,7 +1869,7 @@ mod tests {
             });
         }
         let tree = TreeNode {
-            reference: "root".into(),
+            reference: root(),
             label: "Root".into(),
             node_type: NodeType::Root,
             expanded: true,
@@ -1864,7 +1889,7 @@ mod tests {
         let mut children = Vec::new();
         for depth in 0..100 {
             let mut node = TreeNode {
-                reference: "dup".into(),
+                reference: actor("dup"),
                 label: format!("Dup at depth {}", depth),
                 node_type: NodeType::Actor,
                 expanded: false,
@@ -1877,7 +1902,7 @@ mod tests {
             };
             for i in (0..depth).rev() {
                 node = TreeNode {
-                    reference: format!("wrapper_{}", i),
+                    reference: actor(&format!("wrapper_{}", i)),
                     label: format!("Wrapper {}", i),
                     node_type: NodeType::Host,
                     expanded: true,
@@ -1892,7 +1917,7 @@ mod tests {
             children.push(node);
         }
         let tree = TreeNode {
-            reference: "root".into(),
+            reference: root(),
             label: "Root".into(),
             node_type: NodeType::Root,
             expanded: true,
@@ -1911,7 +1936,7 @@ mod tests {
     #[test]
     fn memory_stable_across_repeated_operations() {
         let mut tree = TreeNode {
-            reference: "root".into(),
+            reference: root(),
             label: "Root".into(),
             node_type: NodeType::Root,
             expanded: true,
@@ -1921,7 +1946,7 @@ mod tests {
             failed: false,
             is_system: false,
             children: vec![TreeNode {
-                reference: "child".into(),
+                reference: actor("child"),
                 label: "Child".into(),
                 node_type: NodeType::Host,
                 expanded: false,
@@ -1946,7 +1971,7 @@ mod tests {
         let mut children = Vec::new();
         for i in 0..1000 {
             children.push(TreeNode {
-                reference: format!("node_{}", i),
+                reference: actor(&format!("node_{}", i)),
                 label: format!("Node {}", i),
                 node_type: NodeType::Actor,
                 expanded: false,
@@ -1959,7 +1984,7 @@ mod tests {
             });
         }
         let tree = TreeNode {
-            reference: "root".into(),
+            reference: root(),
             label: "Root".into(),
             node_type: NodeType::Root,
             expanded: true,
@@ -1983,7 +2008,7 @@ mod tests {
     fn failed_tracking_uses_depth_pairs() {
         // Mirrors expansion_tracking_uses_depth_pairs but for failed state.
         let tree = TreeNode {
-            reference: "root".into(),
+            reference: root(),
             label: "Root".into(),
             node_type: NodeType::Root,
             expanded: true,
@@ -1994,7 +2019,7 @@ mod tests {
             is_system: false,
             children: vec![
                 TreeNode {
-                    reference: "proc1".into(),
+                    reference: proc_ref("proc1"),
                     label: "Proc 1".into(),
                     node_type: NodeType::Proc,
                     expanded: true,
@@ -2004,7 +2029,7 @@ mod tests {
                     failed: true, // failed proc
                     is_system: false,
                     children: vec![TreeNode {
-                        reference: "actor1".into(),
+                        reference: actor("actor1"),
                         label: "Actor 1".into(),
                         node_type: NodeType::Actor,
                         expanded: false,
@@ -2017,7 +2042,7 @@ mod tests {
                     }],
                 },
                 TreeNode {
-                    reference: "actor1".into(),
+                    reference: actor("actor1"),
                     label: "Actor 1 (flat)".into(),
                     node_type: NodeType::Actor,
                     expanded: false,
@@ -2035,11 +2060,11 @@ mod tests {
             collect_failed_refs(child, 0, &mut failed_keys);
         }
         // proc1 at depth 0 is failed.
-        assert!(failed_keys.contains(&("proc1".to_string(), 0)));
+        assert!(failed_keys.contains(&(proc_ref("proc1"), 0)));
         // actor1 at depth 1 (under proc1) is failed.
-        assert!(failed_keys.contains(&("actor1".to_string(), 1)));
+        assert!(failed_keys.contains(&(actor("actor1"), 1)));
         // actor1 at depth 0 (flat list) is NOT failed.
-        assert!(!failed_keys.contains(&("actor1".to_string(), 0)));
+        assert!(!failed_keys.contains(&(actor("actor1"), 0)));
     }
 
     #[test]
@@ -2048,7 +2073,7 @@ mod tests {
         // only if the host itself is marked failed (propagation happens
         // at build time, not in collect_failed_refs).
         let tree = TreeNode {
-            reference: "root".into(),
+            reference: root(),
             label: "Root".into(),
             node_type: NodeType::Root,
             expanded: true,
@@ -2058,7 +2083,7 @@ mod tests {
             failed: false,
             is_system: false,
             children: vec![TreeNode {
-                reference: "host1".into(),
+                reference: host("host1"),
                 label: "Host 1".into(),
                 node_type: NodeType::Host,
                 expanded: true,
@@ -2068,7 +2093,7 @@ mod tests {
                 failed: true, // propagated from child at build time
                 is_system: false,
                 children: vec![TreeNode {
-                    reference: "proc1".into(),
+                    reference: proc_ref("proc1"),
                     label: "Proc 1".into(),
                     node_type: NodeType::Proc,
                     expanded: false,
@@ -2085,7 +2110,7 @@ mod tests {
         for child in &tree.children {
             collect_failed_refs(child, 0, &mut failed_keys);
         }
-        assert!(failed_keys.contains(&("host1".to_string(), 0)));
-        assert!(failed_keys.contains(&("proc1".to_string(), 1)));
+        assert!(failed_keys.contains(&(host("host1"), 0)));
+        assert!(failed_keys.contains(&(proc_ref("proc1"), 1)));
     }
 }


### PR DESCRIPTION
Summary:

this follows up on mariusae's comment on D93864958 that NodePayload should use real reference and timestamp types instead of strings.

the change moves introspection and mesh-admin internals to typed IntrospectRef, NodeRef, ActorId, ProcId, and SystemTime values throughout hyperactor, hyperactor_mesh, and the admin TUI, and then keeps the HTTP JSON boundary curl-friendly by serializing those values as opaque reference strings and ISO-8601 timestamps. this gives cleaner separation between data and representation without regressing the existing HTTP traversal contract.

Differential Revision: D99023365


