### PR TITLE
Fix CUDA 13 build errors

### DIFF
--- a/rdmaxcel-sys/src/driver_api.cpp
+++ b/rdmaxcel-sys/src/driver_api.cpp
@@ -59,6 +59,13 @@
 #define SYM_DEVICE_GET cuDeviceGet
 #define SYM_DEVICE_GET_COUNT cuDeviceGetCount
 #define SYM_DEVICE_GET_ATTRIBUTE cuDeviceGetAttribute
+// CUDA 13.x removed cuCtxCreate_v2 from headers, but libcuda.so still
+// exports it for backward compatibility. Provide our own declaration so
+// decltype and STRINGIFY resolve correctly.
+#if CUDA_VERSION >= 13000
+CUresult CUDAAPI
+cuCtxCreate_v2(CUcontext* pctx, unsigned int flags, CUdevice dev);
+#endif
 #define SYM_CTX_CREATE cuCtxCreate_v2
 #define SYM_DEVICE_PRIMARY_CTX_RETAIN cuDevicePrimaryCtxRetain
 #define SYM_CTX_SET_CURRENT cuCtxSetCurrent


### PR DESCRIPTION
Summary:
CUDA 13 removes the header for `cuCtxCreate_v2` . It's still available in the library, but otherwise
the symbol doesn't exist. It was changed to `cuCtxCreate_v4` which has a new option. We don't need
to use that yet, so just fix the incompatibility.

Doing a conditional forward declare is sufficient to fix the build error.

Differential Revision: D99158624


