### PR TITLE
Store py-spy dumps on the root telemetry actor

### DIFF
--- a/python/monarch/distributed_telemetry/actor.py
+++ b/python/monarch/distributed_telemetry/actor.py
@@ -21,7 +21,7 @@ variable and used by the DistributedTelemetryActor when it initializes.
 
 import functools
 import logging
-from typing import Any, Callable, Dict, List, NamedTuple, Optional
+from typing import Any, Callable, Dict, List, Optional
 
 from monarch._rust_bindings.monarch_distributed_telemetry.database_scanner import (
     DatabaseScanner,
@@ -42,13 +42,6 @@ from monarch.monarch_dashboard.server.app import start_dashboard
 from monarch.monarch_dashboard.server.query_engine_adapter import QueryEngineAdapter
 
 logger: logging.Logger = logging.getLogger(__name__)
-
-
-class _ChildEntry(NamedTuple):
-    """Index entry mapping a proc_id to the child mesh and its rank kwargs."""
-
-    mesh: Any  # ActorMesh
-    rank_kwargs: Dict[str, int]
 
 
 # Module-level scanner created at process startup to avoid race conditions.
@@ -112,9 +105,6 @@ class DistributedTelemetryActor(Actor):
         self._children: Dict[str, Any] = {}
         self._num_procs_processed: int = 0
         self._proc_id: str = context().actor_instance.proc_id
-        # Lazily built index: proc_id → _ChildEntry for targeted routing
-        # in store_pyspy_dump.
-        self._proc_id_index: Dict[str, _ChildEntry] = {}
 
     def __supervise__(self, failure: MeshFailure) -> bool:
         """Handle child mesh failures gracefully.
@@ -126,16 +116,7 @@ class DistributedTelemetryActor(Actor):
         Note: stopping a ProcMesh loses process-local telemetry data from
         those children.
         """
-        removed = self._children.pop(failure.mesh_name, None)
-        if removed is not None:
-            # Purge stale proc_id_index entries for the dead child.
-            stale = [
-                pid
-                for pid, entry in self._proc_id_index.items()
-                if entry.mesh is removed
-            ]
-            for pid in stale:
-                del self._proc_id_index[pid]
+        self._children.pop(failure.mesh_name, None)
         logger.info("child mesh failed: %s", failure.mesh_name)
         return True
 
@@ -156,17 +137,6 @@ class DistributedTelemetryActor(Actor):
             mesh_name: str = actor_mesh._name.get()
             self._children[mesh_name] = actor_mesh
             self._num_procs_processed += 1
-            self._index_child(actor_mesh)
-
-    def _index_child(self, child_mesh: Any) -> None:
-        """Query child mesh proc_ids and populate ``_proc_id_index``."""
-        try:
-            # pyre-ignore[29]: child_mesh is an ActorMesh
-            proc_ids = child_mesh.get_proc_id.call().get()
-            for point, pid in proc_ids.items():
-                self._proc_id_index[pid] = _ChildEntry(child_mesh, dict(point))
-        except Exception:
-            logger.warning("failed to index child proc_ids, skipping")
 
     @endpoint
     def ready(self) -> None:
@@ -189,14 +159,6 @@ class DistributedTelemetryActor(Actor):
         return bytes(self._scanner.schema_for(table))
 
     @endpoint
-    def add_children(self, children: "DistributedTelemetryActor") -> None:
-        """Add a child actor mesh to scan when queries are executed."""
-        # pyre-ignore[16]: children is an ActorMesh with _name
-        mesh_name: str = children._name.get()
-        self._children[mesh_name] = children
-        self._index_child(children)
-
-    @endpoint
     def apply_retention(self, table_name: str, where_clause: str) -> None:
         """Apply a retention filter to a table, then fan out to children."""
         self._scanner.apply_retention(table_name, where_clause)
@@ -207,88 +169,13 @@ class DistributedTelemetryActor(Actor):
             except Exception:
                 logger.info("child apply_retention failed, skipping")
 
-    def _route_to_children(
-        self, dump_id: str, proc_ref: str, pyspy_result_json: str
-    ) -> bool:
-        """Route pyspy dump to the matching child. Returns True if a child stored it."""
-        self._spawn_missing_children()
-
-        entry = self._proc_id_index.get(proc_ref)
-        if entry is not None:
-            try:
-                # pyre-ignore[29]: entry.mesh is an ActorMesh
-                result = (
-                    entry.mesh.slice(**entry.rank_kwargs)
-                    .try_store_pyspy_dump.call_one(dump_id, proc_ref, pyspy_result_json)
-                    .get()
-                )
-                if result:
-                    return True
-            except Exception:
-                logger.info("targeted store_pyspy_dump failed for %s", proc_ref)
-
-        # Fallback: fan out to all children concurrently (e.g. index stale
-        # after mesh topology change).
-        futures = []
-        for child_mesh in self._children.values():
-            try:
-                # pyre-ignore[29]: child_mesh is an ActorMesh
-                futures.append(
-                    child_mesh.try_store_pyspy_dump.call(
-                        dump_id, proc_ref, pyspy_result_json
-                    )
-                )
-            except Exception:
-                logger.info("child store_pyspy_dump call failed, skipping")
-
-        for fut in futures:
-            try:
-                if any(fut.get().values()):
-                    return True
-            except Exception:
-                logger.info("child store_pyspy_dump failed, skipping")
-
-        return False
-
     @endpoint
     def store_pyspy_dump(
         self, dump_id: str, proc_ref: str, pyspy_result_json: str
     ) -> bool:
-        """Store py-spy dump data in the pyspy DataFusion tables on the target proc.
-
-        If ``proc_ref`` matches this actor's proc, stores locally.
-        Otherwise routes to the matching child. If no child in the
-        tree matches, the root coordinator stores it so data is not lost.
-
-        Returns True if this actor or a descendant stored the dump.
-        """
-        if proc_ref == self._proc_id:
-            self._scanner.store_pyspy_dump_py(dump_id, proc_ref, pyspy_result_json)
-            return True
-
-        if self._route_to_children(dump_id, proc_ref, pyspy_result_json):
-            return True
-
-        # No proc in the tree matched; store on this (root) coordinator
-        # so the data is not lost.
-        logger.info("no child matched proc_ref %s, storing on root", proc_ref)
+        """Store py-spy dump data in this actor's local tables."""
         self._scanner.store_pyspy_dump_py(dump_id, proc_ref, pyspy_result_json)
         return True
-
-    @endpoint
-    def try_store_pyspy_dump(
-        self, dump_id: str, proc_ref: str, pyspy_result_json: str
-    ) -> bool:
-        """Try to store the dump on the matching proc. Returns True if stored.
-
-        Unlike ``store_pyspy_dump``, this does not fall back to root storage.
-        Used for recursive child routing.
-        """
-        if proc_ref == self._proc_id:
-            self._scanner.store_pyspy_dump_py(dump_id, proc_ref, pyspy_result_json)
-            return True
-
-        return self._route_to_children(dump_id, proc_ref, pyspy_result_json)
 
     @endpoint
     def scan(

--- a/python/tests/test_distributed_telemetry.py
+++ b/python/tests/test_distributed_telemetry.py
@@ -1311,8 +1311,8 @@ def test_pyspy_tables_in_information_schema(cleanup_callbacks) -> None:
 
 @pytest.mark.timeout(120)
 @isolate_in_subprocess
-def test_try_store_pyspy_dump_routes_to_child(cleanup_callbacks) -> None:
-    """try_store_pyspy_dump routes to the correct child proc via _proc_id_index."""
+def test_store_pyspy_dump_with_child_proc_ref(cleanup_callbacks) -> None:
+    """store_pyspy_dump stores data with a child proc_ref."""
     job = ProcessJob({"hosts": 1}).enable_telemetry(TelemetryConfig(batch_size=10))
     state = job.state(cached_path=None)
     engine = state.query_engine
@@ -1368,9 +1368,8 @@ def test_try_store_pyspy_dump_routes_to_child(cleanup_callbacks) -> None:
         }
     )
 
-    # Store a pyspy dump targeting the child proc_ref.
-    # Use 'try_store_pyspy_dump' to avoid fallback to root coordinator.
-    result = engine._actor.try_store_pyspy_dump.call_one(
+    # Store a pyspy dump targeting the child proc_ref on the root actor.
+    result = engine._actor.store_pyspy_dump.call_one(
         "child-dump-1", child_proc_ref, pyspy_json
     ).get()
     assert result
@@ -1392,8 +1391,8 @@ def test_try_store_pyspy_dump_routes_to_child(cleanup_callbacks) -> None:
 
 @pytest.mark.timeout(120)
 @isolate_in_subprocess
-def test_store_pyspy_dump_unknown_proc_falls_back_to_root(cleanup_callbacks) -> None:
-    """store_pyspy_dump stores on root coordinator when proc_ref matches no child."""
+def test_store_pyspy_dump_with_unknown_proc_ref(cleanup_callbacks) -> None:
+    """store_pyspy_dump stores data even for unknown proc_ref values."""
     job = ProcessJob({"hosts": 1}).enable_telemetry(TelemetryConfig(batch_size=10))
     state = job.state(cached_path=None)
     engine = state.query_engine
@@ -1458,40 +1457,6 @@ def test_store_pyspy_dump_unknown_proc_falls_back_to_root(cleanup_callbacks) -> 
         "SELECT proc_ref FROM pyspy_dumps WHERE dump_id = 'orphan-dump-1'"
     )
     assert dumps.to_pydict()["proc_ref"] == ["nonexistent.proc[999]"]
-
-
-@pytest.mark.timeout(60)
-@isolate_in_subprocess
-def test_store_pyspy_dump_returns_true(cleanup_callbacks) -> None:
-    """try_store_pyspy_dump returns True for match and False for unknown proc."""
-    engine, _ = start_telemetry(include_dashboard=False)
-
-    pyspy_json = json.dumps(
-        {
-            "Ok": {
-                "pid": 1,
-                "binary": "python3",
-                "stack_traces": [],
-                "warnings": [],
-            }
-        }
-    )
-
-    coordinator_proc_id = engine._actor.get_proc_id.call_one().get()
-    result = engine._actor.try_store_pyspy_dump.call_one(
-        "ret-local", coordinator_proc_id, pyspy_json
-    ).get()
-    assert result
-
-    result = engine._actor.try_store_pyspy_dump.call_one(
-        "ret-unknown", "does.not.exist[0]", pyspy_json
-    ).get()
-    assert not result
-
-    result = engine._actor.store_pyspy_dump.call_one(
-        "ret-unknown", "does.not.exist[0]", pyspy_json
-    ).get()
-    assert result
 
 
 @pytest.mark.timeout(120)


### PR DESCRIPTION
Summary:
Store py-spy dump data directly in the root DistributedTelemetryActor.
Remove the child-routing and proc-id indexing logic that previously tried to forward dumps to child actors.
Update the distributed telemetry tests to reflect root storage semantics, and remove the duplicate return-value-only test.

Reviewed By: zdevito

Differential Revision: D99170143


