### PR TITLE
fix broken test test_actor_mesh_stop_timeout

### DIFF
--- a/hyperactor_mesh/src/actor_mesh.rs
+++ b/hyperactor_mesh/src/actor_mesh.rs
@@ -1552,11 +1552,6 @@ mod tests {
             "Stop took {:?}, expected < 3s (actors should have been aborted, not waited for)",
             stop_duration
         );
-        assert!(
-            stop_duration >= std::time::Duration::from_millis(900),
-            "Stop took {:?}, expected >= 900ms (should have waited for timeout)",
-            stop_duration
-        );
 
         let _ = hm.shutdown(instance).await;
     }


### PR DESCRIPTION
Summary:
This test start to fail after D96760759:

```
thread '<unnamed>' (27024) panicked at fbcode/monarch/hyperactor_mesh/src/actor_mesh.rs:1555:9:
Stop took 5.137553ms, expected >= 900ms (should have waited for timeout)
stack backtrace:
```

I think this is because D96760759:

> sends a stop signal to the proc
without waiting for termination (callers never used the result).

which make the time spent on stop getting much shorter.

I do not get why this test need to assert on `>900ms`. The comment in the code did not explain that either. Remove it.

Differential Revision: D99285980


