### PR TITLE
Fix mesh_controller to send accumulated responses for OncePort (#3352)

### DIFF
--- a/monarch_extension/src/mesh_controller.rs
+++ b/monarch_extension/src/mesh_controller.rs
@@ -37,8 +37,10 @@ use hyperactor::supervision::ActorSupervisionEvent;
 use hyperactor_mesh::ActorMesh;
 use hyperactor_mesh::ProcMeshRef;
 use hyperactor_mesh::supervision::MeshFailure;
+use hyperactor_mesh::value_mesh::ValueOverlay;
 use monarch_hyperactor::actor::PythonMessage;
 use monarch_hyperactor::actor::PythonMessageKind;
+use monarch_hyperactor::actor::PythonResponseMessage;
 use monarch_hyperactor::context::PyInstance;
 use monarch_hyperactor::local_state_broker::LocalStateBrokerActor;
 use monarch_hyperactor::mailbox::PyPortId;
@@ -142,7 +144,7 @@ impl _Controller {
         self.broker_id.clone()
     }
 
-    #[pyo3(signature = (instance, seq, defs, uses, response_port, tracebacks))]
+    #[pyo3(signature = (instance, seq, defs, uses, response_port, tracebacks, accumulate=false))]
     fn _node<'py>(
         &mut self,
         instance: &PyInstance,
@@ -151,10 +153,12 @@ impl _Controller {
         uses: Bound<'py, PyAny>,
         response_port: Option<(PyPortId, PySlice)>,
         tracebacks: Py<PyAny>,
+        accumulate: bool,
     ) -> PyResult<()> {
         let response_port: Option<PortInfo> = response_port.map(|(port, ranks)| PortInfo {
             port: reference::PortRef::attest(port.into()),
             ranks: ranks.into(),
+            accumulate,
         });
         let msg = ClientToControllerMessage::Node {
             seq: seq.into(),
@@ -349,10 +353,30 @@ impl Invocation {
         let old_status = std::mem::replace(&mut self.status, Status::Complete {});
         match old_status {
             Status::Incomplete { results, .. } => match &self.response_port {
-                Some(PortInfo { port, ranks }) => {
+                Some(PortInfo {
+                    port,
+                    ranks,
+                    accumulate,
+                }) => {
                     assert!(ranks.len() == results.iter().len());
-                    for result in results.into_iter() {
-                        port.send(sender, result)?;
+                    if *accumulate {
+                        let mut overlay = ValueOverlay::new();
+                        for result in results {
+                            for (range, value) in result
+                                .into_overlay()
+                                .expect("complete result should convert to overlay")
+                                .into_runs()
+                            {
+                                overlay
+                                    .push_run(range, value)
+                                    .expect("complete runs should not overlap");
+                            }
+                        }
+                        port.send(sender, overlay.into())?;
+                    } else {
+                        for result in results {
+                            port.send(sender, result)?;
+                        }
                     }
                 }
                 None => {}
@@ -383,11 +407,32 @@ impl Invocation {
                 match old_status {
                     Status::Incomplete { users, .. } => {
                         match &invocation.response_port {
-                            Some(PortInfo { port, ranks }) => {
+                            Some(PortInfo {
+                                port,
+                                ranks,
+                                accumulate,
+                            }) => {
                                 *unreported_exception = None;
-                                for rank in ranks.iter() {
-                                    let msg = exception.as_ref().clone().into_rank(rank);
-                                    port.send(sender, msg)?;
+                                if *accumulate {
+                                    let mut overlay = ValueOverlay::new();
+                                    for rank in ranks.iter() {
+                                        overlay
+                                            .push_run(
+                                                rank..rank + 1,
+                                                PythonResponseMessage::Exception(
+                                                    exception.as_ref().message.clone(),
+                                                ),
+                                            )
+                                            .expect("exception runs should not overlap");
+                                    }
+                                    port.send(sender, overlay.into())?;
+                                } else {
+                                    for rank in ranks.iter() {
+                                        port.send(
+                                            sender,
+                                            exception.as_ref().clone().into_rank(rank),
+                                        )?;
+                                    }
                                 }
                             }
                             None => {}
@@ -649,6 +694,9 @@ struct PortInfo {
     // the slice of ranks expected to respond
     // to the port. used for error reporting.
     ranks: Slice,
+    // when true, results are accumulated into a single
+    // ValueOverlay<PythonResponseMessage> message (for OncePort callers).
+    accumulate: bool,
 }
 
 #[derive(Debug, Handler, HandleClient)]

--- a/monarch_hyperactor/src/actor.rs
+++ b/monarch_hyperactor/src/actor.rs
@@ -269,7 +269,7 @@ impl PythonMessage {
     ///
     /// Handles both already-collected responses and leaf `Result`/`Exception`
     /// messages by wrapping them in a single-run overlay.
-    pub(crate) fn into_overlay(self) -> anyhow::Result<ValueOverlay<PythonResponseMessage>> {
+    pub fn into_overlay(self) -> anyhow::Result<ValueOverlay<PythonResponseMessage>> {
         match self.kind {
             PythonMessageKind::AccumulatedResponses(overlay) => Ok(overlay.0),
             PythonMessageKind::Result { rank, .. } => {

--- a/python/monarch/_rust_bindings/monarch_extension/mesh_controller.pyi
+++ b/python/monarch/_rust_bindings/monarch_extension/mesh_controller.pyi
@@ -26,6 +26,7 @@ class _Controller:
         uses: Sequence[object],
         port: Tuple[PortId, NDSlice] | None,
         tracebacks: List[List[FrameSummary]],
+        accumulate: bool = False,
     ) -> None: ...
     def _drop_refs(self, instance: Instance, refs: Sequence[object]) -> None: ...
     def _send(

--- a/python/monarch/mesh_controller.py
+++ b/python/monarch/mesh_controller.py
@@ -200,6 +200,7 @@ class Controller(_Controller):
         uses: Sequence[object],
         port: Tuple[PortId, NDSlice] | None,
         tracebacks: List[List[FrameSummary]],
+        accumulate: bool = False,
     ) -> None:
         actor_instance = context().actor_instance
         self._node(
@@ -209,6 +210,7 @@ class Controller(_Controller):
             uses,
             port,
             tracebacks,
+            accumulate,
         )
 
     def drop_refs(self, refs: Sequence[object]) -> None:
@@ -377,11 +379,15 @@ class MeshClient(Client):
         for d in defs:
             d._seq = seq
         response_port = None
+        accumulate = False
         if future is not None:
             # method annotation is a lie to make Client happy
             port_ref, slice = cast("Tuple[PortRef | OncePortRef, NDSlice]", future)
             response_port = (port_ref.port_id, slice)
-        self._mesh_controller.node(seq, defs, uses, response_port, tracebacks)
+            accumulate = isinstance(port_ref, OncePortRef)
+        self._mesh_controller.node(
+            seq, defs, uses, response_port, tracebacks, accumulate
+        )
         return seq
 
     def handle_next_message(self, timeout: Optional[float]) -> bool:

--- a/python/tests/test_remote_functions.py
+++ b/python/tests/test_remote_functions.py
@@ -499,6 +499,6 @@ class TestMeshSpecific(RemoteFunctionsTestBase):
             y = device_mesh.rank("gpu")
             r = return_them.call(x, y).get()
 
-            for p, (h, g) in r:
-                assert p["host"] == h.item()
-                assert p["gpu"] == g.item()
+        for p, (h, g) in r:
+            assert p["host"] == h.item()
+            assert p["gpu"] == g.item()


### PR DESCRIPTION
Summary:

D96180137 changed `call()` to use a `OncePortRef` with an accumulating
reducer, expecting a single `AccumulatedResponses` message. However,
`mesh_controller.rs` was not updated — it still sent individual messages
per rank in a loop, so only the first message arrived and the rest failed
silently.

Fix both `Invocation::complete()` and `Invocation::set_exception()` to
build a `ValueOverlay<PythonResponseMessage>` and send a single
accumulated `PythonMessage` instead of N individual messages.

Also make `PythonMessage::into_overlay()` `pub` (was `pub(crate)`) so it
can be used from `monarch_extension`.

Reviewed By: pzhan9

Differential Revision: D98927729
