### PR TITLE
Fix FUSE non-empty mount and absolute path resolution for remote_mount

### DIFF
--- a/monarch_extension/src/chunked_fuse.rs
+++ b/monarch_extension/src/chunked_fuse.rs
@@ -658,7 +658,7 @@ fn mount_chunked_fuse(
     let runtime = monarch_hyperactor::runtime::get_tokio_runtime();
     runtime.spawn(async move {
         let mut opts = MountOptions::default();
-        opts.read_only(true).force_readdir_plus(true);
+        opts.read_only(true).force_readdir_plus(true).nonempty(true);
 
         let mount_result = fuse3::path::Session::new(opts)
             .mount_with_unprivileged(fs, &mount_path)

--- a/monarch_extension/src/readonly_fuse.rs
+++ b/monarch_extension/src/readonly_fuse.rs
@@ -568,7 +568,7 @@ fn mount_read_only_filesystem(
     let runtime = monarch_hyperactor::runtime::get_tokio_runtime();
     runtime.spawn(async move {
         let mut opts = MountOptions::default();
-        opts.read_only(true).force_readdir_plus(true);
+        opts.read_only(true).force_readdir_plus(true).nonempty(true);
 
         match fuse3::path::Session::new(opts)
             .mount_with_unprivileged(fs, &mount_path)

--- a/python/monarch/_src/job/job.py
+++ b/python/monarch/_src/job/job.py
@@ -592,13 +592,17 @@ class JobTrait(ABC):
             source=source, mntpoint=mntpoint, meshes=meshes, **kwargs
         )
         if python_exe is not None:
-            local_exe = os.path.join(source, python_exe)
+            abs_source = os.path.abspath(source)
+            local_exe = os.path.join(abs_source, python_exe)
             if not os.path.isfile(local_exe):
                 raise ValueError(
                     f"python_exe '{python_exe}' not found locally at '{local_exe}'. "
                     f"Ensure the virtual environment exists in '{source}' before calling remote_mount."
                 )
-            exe_path = os.path.join(mntpoint or source, python_exe)
+            abs_mntpoint = (
+                os.path.abspath(mntpoint) if mntpoint is not None else abs_source
+            )
+            exe_path = os.path.join(abs_mntpoint, python_exe)
             if meshes is None:
                 self._default_python_exe = exe_path
             else:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #3354

Two related fixes for the remote_mount / FUSE filesystem support:

1. **FUSE nonempty option** (chunked_fuse.rs, readonly_fuse.rs): Add `.nonempty(true)` to mount options so the FUSE filesystem can be mounted over directories that already contain files. Without this, mounting on a non-empty directory fails with ENOTEMPTY, which can happen if the mount point directory is pre-created or partially populated.

2. **Absolute path resolution** (job.py): Use `os.path.abspath()` to normalize `source` and `mntpoint` before constructing paths for `python_exe`. If the caller passes relative paths, the previous code could produce incorrect joined paths (e.g., if the CWD changed between when the path was set and when it is used). Resolving to absolute paths eagerly avoids this class of bug.

Differential Revision: [D99456532](https://our.internmc.facebook.com/intern/diff/D99456532/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D99456532/)!