### PR TITLE
Small fix so kill works the same as apply

### DIFF
--- a/python/monarch/_src/job/job.py
+++ b/python/monarch/_src/job/job.py
@@ -737,9 +737,6 @@ def _import_job_from_spec(module_path: str) -> JobTrait:
 
     if "." not in module_path:
         raise ValueError(f"module_path must be 'module.attr', got {module_path!r}")
-    cwd = os.getcwd()
-    if cwd not in sys.path:
-        sys.path.insert(0, cwd)
     mod_name, attr_name = module_path.rsplit(".", 1)
     mod = importlib.import_module(mod_name)
     job = getattr(mod, attr_name, None)

--- a/python/monarch/tools/cli.py
+++ b/python/monarch/tools/cli.py
@@ -8,6 +8,7 @@
 import argparse
 import importlib.resources
 import json
+import os
 import sys
 
 from monarch.tools.commands import (
@@ -387,6 +388,9 @@ def get_parser() -> argparse.ArgumentParser:
 
 
 def main(argv: list[str] = sys.argv[1:]) -> None:
+    cwd = os.getcwd()
+    if cwd not in sys.path:
+        sys.path.insert(0, cwd)
     parser = get_parser()
     args = parser.parse_args(argv)
     if not hasattr(args, "func"):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #3360
* #3354

previously you could end up with a job where `apply` can find the Job object but `kill` could not because the `monarch` command does not naturally have `.` in its path. This just makes sure it does.

Differential Revision: [D99494215](https://our.internmc.facebook.com/intern/diff/D99494215/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D99494215/)!