### PR TITLE
Fix macOS no_torch build

### DIFF
--- a/.github/workflows/build-cpu.yml
+++ b/.github/workflows/build-cpu.yml
@@ -2,33 +2,40 @@ name: Build CPU
 
 on:
   workflow_call:
+    inputs:
+      artifact-name:
+        description: 'Wheel artifact name to upload'
+        type: string
+        default: 'monarch-cpu-py3.10'
+      python-version:
+        description: 'Python version to build with'
+        type: string
+        default: '3.10'
+      runner:
+        description: 'Runner to use for the build'
+        type: string
+        default: 'linux.4xlarge'
 
 concurrency:
   group: build-cpu-${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.run_number || github.ref }}
   cancel-in-progress: true
 
 jobs:
-  build-cpu:
+  build-cpu-linux:
+    if: ${{ startsWith(inputs.runner, 'linux') }}
     name: Build CPU - No Tensor Engine
     uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
-    strategy:
-      fail-fast: true
-      matrix:
-        python-version: ['3.10']
-        include:
-          - name: 4xlarge
-            runs-on: linux.4xlarge
     with:
       timeout: 60
-      runner: ${{ matrix.runs-on }}
+      runner: ${{ inputs.runner }}
       submodules: recursive
-      upload-artifact: monarch-cpu-${{ github.sha }}-py${{ matrix.python-version }}
+      upload-artifact: ${{ inputs.artifact-name }}
       script: |
         # Source common setup functions
         source scripts/common-setup.sh
 
         # Setup build environment (conda + system deps + rust + build deps)
-        setup_build_environment ${{ matrix.python-version }}
+        setup_build_environment ${{ inputs.python-version }}
 
         # Install torch nightly (CPU version)
         pip install --pre torch --extra-index-url https://download.pytorch.org/whl/nightly/cpu
@@ -40,3 +47,48 @@ jobs:
         echo "=== sccache stats ==="
         sccache --show-stats
         echo "=== end sccache stats ==="
+
+  build-cpu-macos:
+    if: ${{ startsWith(inputs.runner, 'macos') }}
+    name: Build CPU - No Tensor Engine (macOS)
+    runs-on: ${{ inputs.runner }}
+    timeout-minutes: 60
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ inputs.python-version }}
+
+      - name: Set up Rust nightly
+        uses: dtolnay/rust-toolchain@nightly
+
+      - name: Install macOS build dependencies
+        shell: bash
+        run: |
+          set -eux
+          export HOMEBREW_NO_AUTO_UPDATE=1
+          brew install protobuf
+
+      - name: Build CPU wheel
+        shell: bash
+        env:
+          CARGO_TARGET_DIR: ${{ runner.temp }}/cargo-target
+          USE_TENSOR_ENGINE: "0"
+        run: |
+          set -eux
+          python -m pip install --upgrade pip
+          python -m pip install -r build-requirements.txt
+          python -m pip install --pre torch --extra-index-url https://download.pytorch.org/whl/nightly/cpu
+          python setup.py bdist_wheel
+
+      - name: Upload wheel artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ inputs.artifact-name }}
+          path: dist/*.whl
+          if-no-files-found: error

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,8 @@ jobs:
   build-cpu:
     name: Build CPU
     uses: ./.github/workflows/build-cpu.yml
+    with:
+      artifact-name: monarch-cpu-${{ github.sha }}-py3.10
 
   test-cpu-python:
     name: Test CPU Python
@@ -33,6 +35,21 @@ jobs:
     uses: ./.github/workflows/test-cpu-python.yml
     with:
       artifact-name: monarch-cpu-${{ github.sha }}-py3.10
+
+  build-cpu-macos:
+    name: Build CPU (macOS)
+    uses: ./.github/workflows/build-cpu.yml
+    with:
+      artifact-name: monarch-cpu-macos-${{ github.sha }}-py3.10
+      runner: macos-latest
+
+  test-cpu-python-macos:
+    name: Test CPU Python (macOS)
+    needs: build-cpu-macos
+    uses: ./.github/workflows/test-cpu-python.yml
+    with:
+      artifact-name: monarch-cpu-macos-${{ github.sha }}-py3.10
+      runner: macos-latest
 
   test-gpu-python:
     name: Test GPU Python
@@ -70,12 +87,13 @@ jobs:
   status-check:
     name: Status Check
     runs-on: ubuntu-latest
-    needs: [test-cpu-python, test-gpu-python, test-cpu-rust, test-cpu-rust-arm64, test-gpu-rust]
+    needs: [test-cpu-python, test-cpu-python-macos, test-gpu-python, test-cpu-rust, test-cpu-rust-arm64, test-gpu-rust]
     if: always()
     steps:
       - name: Check all jobs status
         run: |
           if [[ "${{ needs.test-cpu-python.result }}" != "success" ]] ||
+             [[ "${{ needs.test-cpu-python-macos.result }}" != "success" ]] ||
              [[ "${{ needs.test-gpu-python.result }}" != "success" ]] ||
              [[ "${{ needs.test-cpu-rust.result }}" != "success" ]] ||
              [[ "${{ needs.test-cpu-rust-arm64.result }}" != "success" ]] ||

--- a/.github/workflows/test-cpu-python.yml
+++ b/.github/workflows/test-cpu-python.yml
@@ -7,18 +7,27 @@ on:
         description: 'Wheel artifact name from build workflow'
         required: true
         type: string
+      python-version:
+        description: 'Python version to test with'
+        type: string
+        default: '3.10'
+      runner:
+        description: 'Runner to use for the test'
+        type: string
+        default: 'linux.4xlarge'
 
 concurrency:
   group: test-cpu-python-${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.run_number || github.ref }}
   cancel-in-progress: true
 
 jobs:
-  test-cpu-python:
+  test-cpu-python-linux:
+    if: ${{ startsWith(inputs.runner, 'linux') }}
     name: Test CPU Python - No Tensor Engine
     uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
     with:
       timeout: 60
-      runner: linux.4xlarge
+      runner: ${{ inputs.runner }}
       submodules: recursive
       download-artifact: ${{ inputs.artifact-name }}
       script: |
@@ -49,3 +58,69 @@ jobs:
         # Run CPU Python tests (excluding GPU/tensor engine tests)
         # TODO: Add appropriate test filters for CPU-only Python tests
         echo "CPU Python tests would run here - currently placeholder"
+
+  test-cpu-python-macos:
+    if: ${{ startsWith(inputs.runner, 'macos') }}
+    name: Test CPU Python - No Tensor Engine (macOS)
+    runs-on: ${{ inputs.runner }}
+    timeout-minutes: 60
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ inputs.python-version }}
+
+      - name: Install macOS test dependencies
+        shell: bash
+        env:
+          HOMEBREW_NO_AUTO_UPDATE: "1"
+        run: |
+          set -eux
+          brew install protobuf
+          python -m pip install --upgrade pip
+          python -m pip install -r python/tests/requirements.txt
+          python -m pip install --pre torch --extra-index-url https://download.pytorch.org/whl/nightly/cpu
+
+      - name: Fetch disabled tests
+        shell: bash
+        run: |
+          set -eux
+          python3 scripts/fetch_disabled_tests.py
+
+      - name: Download wheel artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ inputs.artifact-name }}
+          path: ${{ runner.temp }}/wheel-artifact
+
+      - name: Install wheel
+        shell: bash
+        env:
+          CARGO_TARGET_DIR: ${{ runner.temp }}/cargo-target
+          USE_TENSOR_ENGINE: "0"
+        run: |
+          set -eux
+          python -m pip install "${{ runner.temp }}/wheel-artifact"/*.whl
+
+      - name: Verify import
+        shell: bash
+        run: |
+          set -eux
+          python -c "import monarch; import monarch.actor; print('Monarch imported successfully')"
+
+      - name: Run macOS CPU Python tests
+        shell: bash
+        env:
+          USE_TENSOR_ENGINE: "0"
+        run: |
+          set -eux
+          pytest -v -m "not oss_skip" --ignore-glob="**/meta/**" \
+            python/tests/test_python_actors.py \
+            python/tests/test_actor_error.py \
+            python/tests/test_client_shutdown.py \
+            python/tests/test_rdma_unsupported.py

--- a/monarch_extension/src/lib.rs
+++ b/monarch_extension/src/lib.rs
@@ -21,9 +21,11 @@ mod mesh_controller;
 mod tensor_worker;
 
 mod blocking;
+#[cfg(target_os = "linux")]
 mod chunked_fuse;
 mod fast_pack;
 mod panic;
+#[cfg(target_os = "linux")]
 mod readonly_fuse;
 mod tls_receiver;
 mod tls_sender;
@@ -245,11 +247,13 @@ pub fn mod_init(module: &Bound<'_, PyModule>) -> PyResult<()> {
         "monarch_extension.tls_sender",
     )?)?;
 
+    #[cfg(target_os = "linux")]
     crate::chunked_fuse::register_python_bindings(&get_or_add_new_module(
         module,
         "monarch_extension.chunked_fuse",
     )?)?;
 
+    #[cfg(target_os = "linux")]
     crate::readonly_fuse::register_python_bindings(&get_or_add_new_module(
         module,
         "monarch_extension.readonly_fuse",
@@ -289,7 +293,7 @@ pub fn mod_init(module: &Bound<'_, PyModule>) -> PyResult<()> {
         )?;
     }
 
-    #[cfg(fbcode_build)]
+    #[cfg(all(fbcode_build, target_os = "linux"))]
     {
         monarch_hyperactor::meta::alloc::register_python_bindings(&get_or_add_new_module(
             module,

--- a/monarch_hyperactor/src/lib.rs
+++ b/monarch_hyperactor/src/lib.rs
@@ -45,7 +45,7 @@ pub mod testing;
 mod testresource;
 pub mod value_mesh;
 
-#[cfg(fbcode_build)]
+#[cfg(all(fbcode_build, target_os = "linux"))]
 pub mod meta;
 
 // Register types from dependent crates that don't have wirevalue as a dependency


### PR DESCRIPTION
Summary:
Attempting to get the MacOS build working again when USE_TENSOR_ENGINE=0.
Adding a Github Action to keep this tested.
This is in preparation for maybe adding a published MacOS build to PyPI, although that
requires some further changes not in this PR.

Differential Revision: D99519773


