### PR TITLE
snapshot service: add spawn_periodic_capture with overlap guard and deterministic PT-* tests

### DIFF
--- a/monarch_introspection_snapshot/Cargo.toml
+++ b/monarch_introspection_snapshot/Cargo.toml
@@ -19,6 +19,9 @@ monarch_distributed_telemetry = { version = "0.0.0", path = "../monarch_distribu
 monarch_record_batch = { version = "0.0.0", path = "../monarch_record_batch" }
 serde = { version = "1.0.219", features = ["derive", "rc"] }
 serde_json = { version = "1.0.140", features = ["alloc", "float_roundtrip", "raw_value", "unbounded_depth"] }
+tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio-util = { version = "0.7.18", features = ["full"] }
+tracing = { version = "0.1.41", features = ["attributes", "valuable"] }
 uuid = { version = "1.22.0", features = ["rng-getrandom", "serde", "v4", "v5", "v6", "v7", "v8"] }
 
 [dev-dependencies]
@@ -26,6 +29,5 @@ async-trait = "0.1.86"
 hyperactor = { version = "0.0.0", path = "../hyperactor" }
 ndslice = { version = "0.0.0", path = "../ndslice" }
 tempfile = "3.27.0"
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
 typeuri = { version = "0.0.0", path = "../typeuri" }
 wirevalue = { version = "0.0.0", path = "../wirevalue" }

--- a/monarch_introspection_snapshot/src/service.rs
+++ b/monarch_introspection_snapshot/src/service.rs
@@ -16,6 +16,77 @@
 //! once via [`drain_to_batches`], and publishes the same batches to
 //! whichever sinks are active.
 //!
+//! # Usage
+//!
+//! Both [`SnapshotService::capture`] and [`spawn_periodic_capture`]
+//! take a *resolver* — a closure `Fn(&NodeRef) ->
+//! Future<Result<NodePayload>>` that resolves a single node reference
+//! via the mesh admin. In production this calls
+//! `MeshAdminAgent::resolve`; in tests it can be a stub backed by a
+//! `HashMap`.
+//!
+//! For [`spawn_periodic_capture`], a *resolver factory* `Fn() ->
+//! resolver` is passed instead, producing a fresh resolver per tick.
+//!
+//! **One-shot capture** — capture a mesh snapshot on demand:
+//!
+//! ```ignore
+//! // Build a resolver that calls MeshAdminAgent::resolve for
+//! // each NodeRef.
+//! let resolve = |node_ref: &NodeRef| {
+//!     let admin_ref = admin_ref.clone();
+//!     let ref_string = node_ref.to_string();
+//!     async move {
+//!         let resp = admin_ref.resolve(instance, ref_string).await?;
+//!         resp.0.map_err(|e| anyhow::anyhow!("{}", e))
+//!     }
+//! };
+//!
+//! let service = SnapshotService::new(Some(table_store));
+//! let result = service.capture(resolve, None).await?;
+//! println!("{} nodes captured", result.node_counts.nodes);
+//! ```
+//!
+//! [`capture`](SnapshotService::capture) is the full pipeline: BFS
+//! traversal, drain to `RecordBatch` pairs, publish to all active
+//! sinks. At least one sink (`table_store` or `export_root`) must be
+//! active.
+//!
+//! **Periodic capture** — run the capture pipeline on a timer:
+//!
+//! ```ignore
+//! // Factory produces a fresh resolver per tick.
+//! let make_resolve = || {
+//!     let admin_ref = admin_ref.clone();
+//!     move |node_ref: &NodeRef| {
+//!         let admin_ref = admin_ref.clone();
+//!         let ref_string = node_ref.to_string();
+//!         async move {
+//!             let resp = admin_ref.resolve(instance, ref_string).await?;
+//!             resp.0.map_err(|e| anyhow::anyhow!("{}", e))
+//!         }
+//!     }
+//! };
+//!
+//! let service = SnapshotService::new(Some(table_store));
+//! let cancel = CancellationToken::new();
+//! let handle = spawn_periodic_capture(
+//!     service.clone(),
+//!     Duration::from_secs(30),
+//!     cancel.clone(),
+//!     make_resolve,
+//! )?;
+//!
+//! // ... later, shut down:
+//! cancel.cancel();
+//! handle.await?;
+//! ```
+//!
+//! [`spawn_periodic_capture`] reuses the same capture pipeline but is
+//! live-ingest only (`export_root` is always `None`). Overlapping
+//! ticks are skipped, not queued. Capture errors are logged and do
+//! not stop the timer.
+//!
 //! # Service invariants (SV-*)
 //!
 //! - **SV-1 (sink required):** `capture` returns `Err` when both
@@ -42,12 +113,30 @@
 //!   succeeds and bundle writing fails (or vice versa), you have
 //!   partial success. The sinks are independent and the service
 //!   reports the error.
+//!
+//! # Periodic-trigger invariants (PT-*)
+//!
+//! - **PT-1 (positive interval):** Zero interval rejected before
+//!   spawn.
+//! - **PT-2 (live sink required):** `table_store.is_some()` required.
+//! - **PT-3 (delayed first fire):** First capture after one full
+//!   interval.
+//! - **PT-4 (single in-flight):** Overlapping ticks skipped via CAS.
+//!   `in_flight` is consulted only by the periodic loop; on-demand
+//!   `capture` calls do not check it.
+//! - **PT-5 (cancellation boundary):** Stops future ticks; does not
+//!   interrupt in-flight capture.
+//! - **PT-6 (failure resilience):** Capture `Err` logged, loop
+//!   continues.
+//! - **PT-7 (live-ingest only):** Always `export_root = None`.
 
 use std::future::Future;
 use std::path::Path;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
+use std::sync::atomic::Ordering;
+use std::time::Duration;
 use std::time::Instant;
 
 use hyperactor_mesh::introspect::NodePayload;
@@ -55,6 +144,9 @@ use hyperactor_mesh::introspect::NodeRef;
 use monarch_distributed_telemetry::database_scanner::TableStore;
 use serde::Deserialize;
 use serde::Serialize;
+use tokio::task::JoinHandle;
+use tokio::time::MissedTickBehavior;
+use tokio_util::sync::CancellationToken;
 use uuid::Uuid;
 
 use crate::bundle::write_bundle;
@@ -66,6 +158,7 @@ use crate::push::drain_to_batches;
 ///
 /// Owns the capture-and-publish pipeline. Captures once per call and
 /// publishes to configured sinks.
+#[derive(Clone)]
 pub struct SnapshotService {
     /// `None` before telemetry integration, `Some` after. When
     /// present, captures are ingested into live storage.
@@ -86,11 +179,6 @@ impl SnapshotService {
             table_store,
             in_flight: Arc::new(AtomicBool::new(false)),
         }
-    }
-
-    /// Returns the in-flight guard for use by the periodic trigger.
-    pub fn in_flight(&self) -> &Arc<AtomicBool> {
-        &self.in_flight
     }
 
     /// Capture a mesh snapshot and publish to configured sinks.
@@ -156,6 +244,171 @@ impl SnapshotService {
             bundle_path,
         })
     }
+}
+
+/// Private drop guard that resets `in_flight` to `false` on all exit
+/// paths (success, error, or early return).
+struct InFlightGuard<'a>(&'a AtomicBool);
+
+impl Drop for InFlightGuard<'_> {
+    fn drop(&mut self) {
+        self.0.store(false, Ordering::Release);
+    }
+}
+
+/// Execute one periodic capture tick.
+///
+/// Owns the CAS overlap check (PT-4), drop guard, capture call
+/// (PT-7: always `export_root = None`), and error logging (PT-6).
+/// Returns `true` if a capture was attempted (CAS succeeded),
+/// `false` if skipped due to overlap.
+///
+/// This is the unit of per-tick behavior, factored out of the
+/// spawned timer loop so it can be tested deterministically.
+async fn run_periodic_tick<F, Fut>(service: &SnapshotService, resolve: F) -> bool
+where
+    F: Fn(&NodeRef) -> Fut,
+    Fut: Future<Output = anyhow::Result<NodePayload>>,
+{
+    // PT-4: CAS to acquire overlap guard.
+    if service
+        .in_flight
+        .compare_exchange(false, true, Ordering::Acquire, Ordering::Relaxed)
+        .is_err()
+    {
+        tracing::warn!("periodic capture skipped: previous capture still in flight");
+        return false;
+    }
+    let _guard = InFlightGuard(&service.in_flight);
+
+    // PT-7: always None for export_root.
+    match service.capture(resolve, None).await {
+        Ok(_result) => {}
+        // PT-6: log and continue.
+        Err(e) => tracing::warn!("periodic capture failed: {:#}", e),
+    }
+    true
+}
+
+/// Tick source for the periodic capture loop.
+///
+/// Production uses [`IntervalTick`]; tests use [`NotifyTick`].
+trait TickSource {
+    /// Wait for the next tick.
+    fn tick(&mut self) -> std::pin::Pin<Box<dyn Future<Output = ()> + Send + '_>>;
+}
+
+/// Production tick source backed by `tokio::time::Interval`.
+struct IntervalTick {
+    interval: tokio::time::Interval,
+}
+
+impl TickSource for IntervalTick {
+    fn tick(&mut self) -> std::pin::Pin<Box<dyn Future<Output = ()> + Send + '_>> {
+        Box::pin(async {
+            self.interval.tick().await;
+        })
+    }
+}
+
+/// Per-tick completion callback.
+///
+/// Called after each tick is fully processed (capture completed or
+/// skipped). Production passes [`NoOpDone`]; tests pass
+/// [`NotifyDone`] to synchronize without `yield_now`.
+trait OnTickDone {
+    fn done(&self);
+}
+
+/// Production no-op completion signal.
+struct NoOpDone;
+impl OnTickDone for NoOpDone {
+    fn done(&self) {}
+}
+
+/// Private loop driver for periodic capture.
+///
+/// Separates tick scheduling from tick handling so tests can drive
+/// ticks manually. Production passes an [`IntervalTick`]; tests
+/// pass a [`NotifyTick`]. The `on_tick_done` callback fires after
+/// each tick is fully processed.
+///
+/// The loop uses `biased` select with cancellation first (PT-5).
+async fn run_periodic_loop<MkResolve, F, Fut>(
+    service: SnapshotService,
+    cancel: CancellationToken,
+    make_resolve: MkResolve,
+    mut ticks: impl TickSource,
+    on_tick_done: impl OnTickDone,
+) where
+    MkResolve: Fn() -> F,
+    F: Fn(&NodeRef) -> Fut,
+    Fut: Future<Output = anyhow::Result<NodePayload>>,
+{
+    loop {
+        tokio::select! {
+            biased;
+
+            // PT-5: cancellation checked first via biased select.
+            _ = cancel.cancelled() => {
+                break;
+            }
+
+            _ = ticks.tick() => {
+                run_periodic_tick(&service, make_resolve()).await;
+                on_tick_done.done();
+            }
+        }
+    }
+}
+
+/// Spawn a periodic snapshot capture timer.
+///
+/// Returns `Err` immediately if `interval` is zero (PT-1) or the
+/// service has no `table_store` (PT-2). On success, returns a
+/// `JoinHandle` for the spawned timer task. The task owns a cloned
+/// `SnapshotService` by value and shares the same `in_flight` guard
+/// and `TableStore` as the original.
+pub fn spawn_periodic_capture<MkResolve, F, Fut>(
+    service: SnapshotService,
+    interval: Duration,
+    cancel: CancellationToken,
+    make_resolve: MkResolve,
+) -> anyhow::Result<JoinHandle<()>>
+where
+    MkResolve: Fn() -> F + Send + Sync + 'static,
+    F: Fn(&NodeRef) -> Fut + Send + Sync + 'static,
+    Fut: Future<Output = anyhow::Result<NodePayload>> + Send + 'static,
+{
+    // PT-1: reject zero interval.
+    anyhow::ensure!(
+        !interval.is_zero(),
+        "periodic capture interval must be non-zero"
+    );
+
+    // PT-2: reject if no table_store.
+    anyhow::ensure!(
+        service.table_store.is_some(),
+        "periodic capture requires a table_store"
+    );
+
+    let handle = tokio::spawn(async move {
+        // PT-3: first fire after one full interval.
+        let start = tokio::time::Instant::now() + interval;
+        let mut timer = tokio::time::interval_at(start, interval);
+        timer.set_missed_tick_behavior(MissedTickBehavior::Skip);
+
+        run_periodic_loop(
+            service,
+            cancel,
+            make_resolve,
+            IntervalTick { interval: timer },
+            NoOpDone,
+        )
+        .await;
+    });
+
+    Ok(handle)
 }
 
 /// Result metadata from a snapshot capture operation.
@@ -592,5 +845,399 @@ mod tests {
         let raw = std::fs::read_to_string(bundle_path.join("manifest.json")).unwrap();
         let manifest: crate::bundle::BundleManifest = serde_json::from_str(&raw).unwrap();
         assert_eq!(manifest.snapshot_id, result.snapshot_id);
+    }
+
+    // --- Periodic trigger tests (PT-*) ---
+    //
+    // Test split:
+    // - PT-1, PT-2: direct spawn_periodic_capture precondition tests
+    // - PT-3, PT-5: deterministic loop tests via run_periodic_loop
+    //   with NotifyTick (manual tick source)
+    // - PT-4, PT-6, PT-7: direct run_periodic_tick tests
+
+    type PinFut = std::pin::Pin<Box<dyn Future<Output = anyhow::Result<NodePayload>> + Send>>;
+
+    /// Test tick source backed by `tokio::sync::Notify`.
+    /// Each `notify_one()` on the held `Arc<Notify>` fires one tick.
+    struct NotifyTick(Arc<tokio::sync::Notify>);
+
+    impl TickSource for NotifyTick {
+        fn tick(&mut self) -> std::pin::Pin<Box<dyn Future<Output = ()> + Send + '_>> {
+            let n = self.0.clone();
+            Box::pin(async move { n.notified().await })
+        }
+    }
+
+    /// Test completion signal. The loop calls `done()` after each
+    /// tick is fully processed; tests await `done_signal.notified()`
+    /// to synchronize deterministically.
+    struct NotifyDone(Arc<tokio::sync::Notify>);
+
+    impl OnTickDone for NotifyDone {
+        fn done(&self) {
+            self.0.notify_one();
+        }
+    }
+
+    /// Build a resolver factory for tests that exercise
+    /// spawn_periodic_capture with a real timer (production timer
+    /// PT-3 test) and for the PT-5 in-flight cancellation test.
+    fn periodic_resolver_factory(
+        payloads: HashMap<NodeRef, NodePayload>,
+        counter: Arc<std::sync::atomic::AtomicUsize>,
+        gate: Option<Arc<tokio::sync::Notify>>,
+    ) -> impl Fn() -> Box<dyn Fn(&NodeRef) -> PinFut + Send + Sync> + Send + Sync + 'static {
+        move || {
+            let payloads = payloads.clone();
+            let counter = counter.clone();
+            let gate = gate.clone();
+            Box::new(move |node_ref: &NodeRef| {
+                let result = payloads
+                    .get(node_ref)
+                    .cloned()
+                    .ok_or_else(|| anyhow::anyhow!("unknown ref: {}", node_ref));
+                let is_root = *node_ref == NodeRef::Root;
+                let counter = counter.clone();
+                let gate = gate.clone();
+                Box::pin(async move {
+                    if is_root {
+                        counter.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                        if let Some(g) = gate {
+                            g.notified().await;
+                        }
+                    }
+                    result
+                })
+            })
+        }
+    }
+
+    // --- PT-1, PT-2: spawn precondition tests (sync) ---
+
+    /// Dummy resolver for precondition tests where the resolver is
+    /// never called.
+    fn unused_resolver(_: &NodeRef) -> std::future::Ready<anyhow::Result<NodePayload>> {
+        std::future::ready(Err(anyhow::anyhow!("unused")))
+    }
+
+    // PT-1: zero interval rejected.
+    #[test]
+    fn test_periodic_rejects_zero_interval() {
+        let store = TableStore::new_empty();
+        let service = SnapshotService::new(Some(store));
+        let cancel = CancellationToken::new();
+
+        let err = spawn_periodic_capture(service, Duration::ZERO, cancel, || unused_resolver);
+        assert!(err.is_err(), "PT-1: should reject zero interval");
+        assert!(
+            err.unwrap_err().to_string().contains("non-zero"),
+            "PT-1: error should mention non-zero",
+        );
+    }
+
+    // PT-2: no table_store rejected.
+    #[test]
+    fn test_periodic_rejects_no_store() {
+        let service = SnapshotService::new(None);
+        let cancel = CancellationToken::new();
+
+        let err =
+            spawn_periodic_capture(service, Duration::from_secs(1), cancel, || unused_resolver);
+        assert!(err.is_err(), "PT-2: should reject no store");
+        assert!(
+            err.unwrap_err().to_string().contains("table_store"),
+            "PT-2: error should mention table_store",
+        );
+    }
+
+    // PT-3: no capture before a tick is sent; exactly one after. Uses
+    // run_periodic_loop with NotifyTick and NotifyDone for
+    // deterministic synchronization.
+    #[tokio::test]
+    async fn test_periodic_delayed_first_fire() {
+        let store = TableStore::new_empty();
+        let service = SnapshotService::new(Some(store.clone()));
+        let cancel = CancellationToken::new();
+        let payloads = minimal_mesh_payloads();
+
+        let tick_signal = Arc::new(tokio::sync::Notify::new());
+        let done_signal = Arc::new(tokio::sync::Notify::new());
+
+        let handle = tokio::spawn({
+            let cancel = cancel.clone();
+            let payloads = payloads.clone();
+            let tick_signal = tick_signal.clone();
+            let done_signal = done_signal.clone();
+            async move {
+                run_periodic_loop(
+                    service,
+                    cancel,
+                    || stub_resolver(payloads.clone()),
+                    NotifyTick(tick_signal),
+                    NotifyDone(done_signal),
+                )
+                .await;
+            }
+        });
+
+        // No tick sent yet — no capture should have occurred. The
+        // loop is blocked on NotifyTick, so the store is empty.
+        assert_eq!(
+            store.table_names().unwrap().len(),
+            0,
+            "PT-3: no capture before tick"
+        );
+
+        // Send one tick and await the completion signal.
+        tick_signal.notify_one();
+        done_signal.notified().await;
+
+        assert_eq!(
+            store.table_names().unwrap().len(),
+            9,
+            "PT-3: one capture after tick"
+        );
+
+        cancel.cancel();
+        handle.await.unwrap();
+    }
+
+    // PT-3 (production timer): spawn_periodic_capture with a real
+    // interval does not fire before one full interval. This is the
+    // one test that exercises the interval_at(now + interval,
+    // interval) construction in spawn_periodic_capture itself.
+    #[tokio::test]
+    async fn test_periodic_production_timer_delay() {
+        let store = TableStore::new_empty();
+        let service = SnapshotService::new(Some(store.clone()));
+        let cancel = CancellationToken::new();
+        let payloads = minimal_mesh_payloads();
+        let counter = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let factory = periodic_resolver_factory(payloads, counter.clone(), None);
+        let interval = Duration::from_millis(200);
+
+        let handle = spawn_periodic_capture(service, interval, cancel.clone(), factory).unwrap();
+
+        // Well before the first interval — no capture.
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        assert_eq!(
+            counter.load(std::sync::atomic::Ordering::Relaxed),
+            0,
+            "PT-3: no capture before first interval (production timer)",
+        );
+
+        // Wait long enough for the first tick to fire and capture
+        // to complete.
+        tokio::time::sleep(Duration::from_millis(300)).await;
+        assert!(
+            counter.load(std::sync::atomic::Ordering::Relaxed) >= 1,
+            "PT-3: at least one capture after interval (production timer)",
+        );
+
+        cancel.cancel();
+        handle.await.unwrap();
+    }
+
+    // --- PT-4, PT-6, PT-7: direct run_periodic_tick tests ---
+    //
+    // These test the per-tick helper directly — no tokio::spawn, no
+    // timers, fully deterministic.
+
+    // PT-4: CAS skip when in_flight is already set.
+    #[tokio::test]
+    async fn test_periodic_tick_skips_when_in_flight() {
+        let store = TableStore::new_empty();
+        let service = SnapshotService::new(Some(store.clone()));
+        let payloads = minimal_mesh_payloads();
+        let resolve = stub_resolver(payloads);
+
+        // Pre-set in_flight to simulate an ongoing capture.
+        service.in_flight.store(true, Ordering::Release);
+
+        let attempted = run_periodic_tick(&service, resolve).await;
+        assert!(!attempted, "PT-4: tick should be skipped when in_flight");
+
+        // Store should be empty — no capture ran.
+        assert_eq!(store.table_names().unwrap().len(), 0);
+
+        // in_flight should still be true (guard did not run).
+        assert!(service.in_flight.load(Ordering::Acquire));
+    }
+
+    // PT-4: CAS succeeds and guard resets in_flight after capture.
+    #[tokio::test]
+    async fn test_periodic_tick_captures_and_resets_guard() {
+        let store = TableStore::new_empty();
+        let service = SnapshotService::new(Some(store.clone()));
+        let payloads = minimal_mesh_payloads();
+        let resolve = stub_resolver(payloads);
+
+        let attempted = run_periodic_tick(&service, resolve).await;
+        assert!(attempted, "PT-4: tick should attempt capture");
+
+        // Store should be populated.
+        assert_eq!(store.table_names().unwrap().len(), 9);
+
+        // in_flight should be reset to false.
+        assert!(!service.in_flight.load(Ordering::Acquire));
+    }
+
+    // PT-6: resolver error does not prevent the tick from completing
+    // and the guard is still reset.
+    #[tokio::test]
+    async fn test_periodic_tick_survives_resolver_error() {
+        let store = TableStore::new_empty();
+        let service = SnapshotService::new(Some(store.clone()));
+
+        let resolve = |_: &NodeRef| std::future::ready(Err(anyhow::anyhow!("simulated failure")));
+
+        let attempted = run_periodic_tick(&service, resolve).await;
+        assert!(
+            attempted,
+            "PT-6: tick should attempt capture even if it fails",
+        );
+
+        // in_flight should be reset to false despite the error.
+        assert!(!service.in_flight.load(Ordering::Acquire));
+
+        // Store should be empty — capture failed before ingestion.
+        assert_eq!(store.table_names().unwrap().len(), 0);
+
+        // PT-6 continued: a later tick on the same service succeeds
+        // after an earlier failure.
+        let payloads = minimal_mesh_payloads();
+        let resolve = stub_resolver(payloads);
+        let attempted = run_periodic_tick(&service, resolve).await;
+        assert!(attempted, "PT-6: second tick should succeed");
+        assert_eq!(store.table_names().unwrap().len(), 9);
+    }
+
+    // PT-7: run_periodic_tick always passes export_root = None.
+    #[tokio::test]
+    async fn test_periodic_tick_no_bundle_export() {
+        let store = TableStore::new_empty();
+        let service = SnapshotService::new(Some(store.clone()));
+        let payloads = minimal_mesh_payloads();
+        let resolve = stub_resolver(payloads);
+
+        run_periodic_tick(&service, resolve).await;
+
+        // Verify store was populated (live ingest happened).
+        assert_eq!(store.table_names().unwrap().len(), 9);
+
+        // PT-7 is structural: run_periodic_tick calls
+        // service.capture(resolve, None). No bundle directory
+        // was created.
+    }
+
+    // --- PT-5: deterministic loop tests via run_periodic_loop ---
+
+    // PT-5 (idle): cancel before any tick, loop exits, zero captures.
+    #[tokio::test]
+    async fn test_periodic_cancel_while_idle() {
+        let store = TableStore::new_empty();
+        let service = SnapshotService::new(Some(store.clone()));
+        let cancel = CancellationToken::new();
+        let payloads = minimal_mesh_payloads();
+        let tick_signal = Arc::new(tokio::sync::Notify::new());
+
+        // Cancel immediately — before any tick is sent.
+        cancel.cancel();
+
+        run_periodic_loop(
+            service,
+            cancel,
+            || stub_resolver(payloads.clone()),
+            NotifyTick(tick_signal),
+            NoOpDone,
+        )
+        .await;
+
+        assert_eq!(
+            store.table_names().unwrap().len(),
+            0,
+            "PT-5: no captures after cancel while idle",
+        );
+    }
+
+    // PT-5 (in-flight): cancel during a gated capture, capture
+    // finishes, then the loop exits. No second capture.
+    //
+    // Synchronization:
+    // - started_signal: resolver notifies when root resolution begins
+    // - resolver_gate: test releases to let the capture finish
+    // - done_signal: loop notifies when tick is fully processed
+    #[tokio::test]
+    async fn test_periodic_cancel_during_inflight() {
+        let store = TableStore::new_empty();
+        let service = SnapshotService::new(Some(store.clone()));
+        let cancel = CancellationToken::new();
+        let payloads = minimal_mesh_payloads();
+        let started_signal = Arc::new(tokio::sync::Notify::new());
+        let resolver_gate = Arc::new(tokio::sync::Notify::new());
+        let tick_signal = Arc::new(tokio::sync::Notify::new());
+        let done_signal = Arc::new(tokio::sync::Notify::new());
+
+        let handle = tokio::spawn({
+            let cancel = cancel.clone();
+            let payloads = payloads.clone();
+            let started_signal = started_signal.clone();
+            let resolver_gate = resolver_gate.clone();
+            let tick_signal = tick_signal.clone();
+            let done_signal = done_signal.clone();
+            async move {
+                run_periodic_loop(
+                    service,
+                    cancel,
+                    move || {
+                        let payloads = payloads.clone();
+                        let started_signal = started_signal.clone();
+                        let resolver_gate = resolver_gate.clone();
+                        move |node_ref: &NodeRef| {
+                            let result = payloads
+                                .get(node_ref)
+                                .cloned()
+                                .ok_or_else(|| anyhow::anyhow!("unknown ref: {}", node_ref));
+                            let is_root = *node_ref == NodeRef::Root;
+                            let started_signal = started_signal.clone();
+                            let resolver_gate = resolver_gate.clone();
+                            Box::pin(async move {
+                                if is_root {
+                                    started_signal.notify_one();
+                                    resolver_gate.notified().await;
+                                }
+                                result
+                            }) as PinFut
+                        }
+                    },
+                    NotifyTick(tick_signal),
+                    NotifyDone(done_signal),
+                )
+                .await;
+            }
+        });
+
+        // Send one tick — capture starts, blocks on resolver_gate.
+        tick_signal.notify_one();
+        // Wait for the resolver to signal that root resolution began.
+        started_signal.notified().await;
+
+        // Cancel while capture is in-flight.
+        cancel.cancel();
+
+        // Task should not have exited — capture is blocked on gate.
+        assert!(
+            !handle.is_finished(),
+            "PT-5: task still running while gated"
+        );
+
+        // Release the capture. The loop completes the tick (fires
+        // done_signal), then sees cancellation and exits.
+        resolver_gate.notify_one();
+        done_signal.notified().await;
+        handle.await.unwrap();
+
+        // Verify the capture actually ingested data.
+        assert_eq!(store.table_names().unwrap().len(), 9);
     }
 }


### PR DESCRIPTION
Summary:
adds periodic snapshot capture to monarch_introspection_snapshot via spawn_periodic_capture, with a factored private loop, per-tick overlap control through the shared in_flight CAS guard, cancellation via CancellationToken, and error logging without terminating the loop.

tightens the service module documentation to explain one-shot versus periodic capture and the resolver shapes they require, and adds PT-* coverage for zero-interval rejection, missing live sink rejection, delayed first fire, overlap skipping, cancellation boundaries, failure resilience, and live-ingest-only behavior. the test suite is now deterministic for the loop-driven cases through explicit notify-based synchronization, with one narrow real-timer test retained to cover the actual interval_at(now + interval, interval) behavior.

Differential Revision: D100024224


