### PR TITLE
Add log for LaunchOptions to BootstrapProcManager (#3385)

### DIFF
--- a/hyperactor/src/host.rs
+++ b/hyperactor/src/host.rs
@@ -117,8 +117,8 @@ pub enum HostError {
     ProcExists(String),
 
     /// Failures occuring while spawning a subprocess.
-    #[error("proc '{0}' failed to spawn process: {1}")]
-    ProcessSpawnFailure(reference::ProcId, #[source] std::io::Error),
+    #[error("proc '{0}' (command: {1}) failed to spawn process: {2}")]
+    ProcessSpawnFailure(reference::ProcId, String, #[source] std::io::Error),
 
     /// Failures occuring while configuring a subprocess.
     #[error("proc '{0}' failed to configure process: {1}")]
@@ -1311,9 +1311,9 @@ where
         // Kill the child when its handle is dropped.
         cmd.kill_on_drop(true);
 
-        let child = cmd
-            .spawn()
-            .map_err(|e| HostError::ProcessSpawnFailure(proc_id.clone(), e))?;
+        let child = cmd.spawn().map_err(|e| {
+            HostError::ProcessSpawnFailure(proc_id.clone(), self.program.display().to_string(), e)
+        })?;
 
         // Retain the handle so it lives for the life of the
         // manager/host.

--- a/hyperactor_mesh/src/bootstrap.rs
+++ b/hyperactor_mesh/src/bootstrap.rs
@@ -2062,6 +2062,7 @@ impl ProcManager for BootstrapProcManager {
         };
 
         // Launch via the configured launcher backend.
+        tracing::info!(proc_id = %proc_id, "launching proc with opts={opts:?}");
         let launch_result = self
             .launcher()
             .launch(&proc_id, opts.clone())
@@ -2071,7 +2072,11 @@ impl ProcManager for BootstrapProcManager {
                     ProcLauncherError::Launch(io_err) => io_err,
                     other => std::io::Error::other(other.to_string()),
                 };
-                HostError::ProcessSpawnFailure(proc_id.clone(), io_err)
+                HostError::ProcessSpawnFailure(
+                    proc_id.clone(),
+                    format!("{:?}", opts.command),
+                    io_err,
+                )
             })?;
 
         // Wire up StreamFwders if stdio was captured.


### PR DESCRIPTION
Summary:

When spawning a bootstrap command, the command might not be found on the machine which
would produce exit code 127.
In this case, it's important to see what the command actually was.
Add it to an info log and to the error case.

Reviewed By: shayne-fletcher

Differential Revision: D100063075


