### PR TITLE
Bump glog line truncation (#3388)

### DIFF
--- a/hyperactor_telemetry/src/sinks/glog.rs
+++ b/hyperactor_telemetry/src/sinks/glog.rs
@@ -25,7 +25,7 @@ use crate::trace_dispatcher::TraceEventSink;
 use crate::trace_dispatcher::TraceFields;
 use crate::trace_dispatcher::get_field;
 
-const MAX_LINE_SIZE: usize = 4096;
+const MAX_LINE_SIZE: usize = 65536;
 const TRUNCATION_SUFFIX_RESERVE: usize = 32;
 
 /// A string buffer that limits writes to a maximum size.


### PR DESCRIPTION
Summary:

In cases where we log a long line, sometimes we really need to see that value and not lose it. Bump this to be for only truly extremely long lines as a safeguard.

Reviewed By: shayne-fletcher

Differential Revision: D100222337


