### PR TITLE
refresh policy: suspend background refresh during in-flight foreground operations via RefreshPolicy join-semilattice

### DIFF
--- a/examples/distributed_telemetry.py
+++ b/examples/distributed_telemetry.py
@@ -488,7 +488,7 @@ def run_workload(job, summary=False, interactive=False):
     # otherwise fall back to manual start_telemetry() for backward compat.
     engine = state.query_engine
     if engine is None:
-        engine, _ = start_telemetry()
+        engine, _, _scanner = start_telemetry()
 
     hosts = state.hosts
 

--- a/hyperactor_mesh/examples/dining_philosophers.rs
+++ b/hyperactor_mesh/examples/dining_philosophers.rs
@@ -31,6 +31,7 @@ use hyperactor_mesh::comm::multicast::CastInfo;
 use hyperactor_mesh::context;
 use hyperactor_mesh::host_mesh::HostMesh;
 use hyperactor_mesh::host_mesh::spawn_admin;
+use hyperactor_mesh::mesh_admin::MeshAdminMessageClient;
 use ndslice::ViewExt;
 use ndslice::extent;
 use serde::Deserialize;
@@ -264,7 +265,12 @@ async fn main() -> Result<ExitCode> {
 
     // Start the mesh admin agent, which aggregates admin state
     // across all hosts and serves an HTTP API.
-    let mesh_admin_url = spawn_admin([&host_mesh], instance, None, None).await?;
+    let admin_ref = spawn_admin([&host_mesh], instance, None, None).await?;
+    let mesh_admin_url = admin_ref
+        .get_admin_addr(instance)
+        .await?
+        .addr
+        .ok_or_else(|| anyhow::anyhow!("mesh admin did not report an address"))?;
     let mtls_flags = if mesh_admin_url.starts_with("https") {
         "--cacert /var/facebook/rootcanal/ca.pem \
          --cert /var/facebook/x509_identities/server.pem \

--- a/hyperactor_mesh/examples/sieve.rs
+++ b/hyperactor_mesh/examples/sieve.rs
@@ -27,6 +27,7 @@ use hyperactor::reference;
 use hyperactor_config::Flattrs;
 use hyperactor_mesh::context;
 use hyperactor_mesh::host_mesh::spawn_admin;
+use hyperactor_mesh::mesh_admin::MeshAdminMessageClient;
 use hyperactor_mesh::this_host;
 use hyperactor_mesh::this_proc;
 use ndslice::View;
@@ -141,7 +142,12 @@ async fn main() -> Result<ExitCode> {
 
     // Start the mesh admin agent.
     let h = this_host().await;
-    let mesh_admin_url = spawn_admin([&h], instance, None, None).await?;
+    let admin_ref = spawn_admin([&h], instance, None, None).await?;
+    let mesh_admin_url = admin_ref
+        .get_admin_addr(instance)
+        .await?
+        .addr
+        .ok_or_else(|| anyhow::anyhow!("mesh admin did not report an address"))?;
     let mtls_flags = if mesh_admin_url.starts_with("https") {
         "--cacert /var/facebook/rootcanal/ca.pem \
          --cert /var/facebook/x509_identities/server.pem \

--- a/hyperactor_mesh/src/config.rs
+++ b/hyperactor_mesh/src/config.rs
@@ -244,6 +244,15 @@ declare_attrs! {
     ))
     pub attr MESH_ADMIN_PYSPY_CLIENT_TIMEOUT: Duration = Duration::from_secs(20);
 
+    /// Maximum allowed profile duration. Requests exceeding this
+    /// are rejected with a 400. Protects against runaway profile
+    /// captures. See PP-1 in `introspect` module doc.
+    @meta(CONFIG = ConfigAttr::new(
+        Some("HYPERACTOR_MESH_ADMIN_PYSPY_MAX_PROFILE_DURATION".to_string()),
+        Some("mesh_admin_pyspy_max_profile_duration".to_string()),
+    ))
+    pub attr MESH_ADMIN_PYSPY_MAX_PROFILE_DURATION: Duration = Duration::from_secs(300);
+
     /// Path to the py-spy binary. When non-empty, tried before
     /// the fallback `"py-spy"` PATH lookup. See PS-3 in
     /// `introspect` module doc.

--- a/hyperactor_mesh/src/host_mesh.rs
+++ b/hyperactor_mesh/src/host_mesh.rs
@@ -18,6 +18,7 @@ use hyperactor_config::ConfigAttr;
 use hyperactor_config::attrs::declare_attrs;
 use ndslice::view::CollectMeshExt;
 
+use crate::mesh_admin::MeshAdminAgent;
 use crate::supervision::MeshFailure;
 
 pub mod host_agent;
@@ -61,7 +62,6 @@ use crate::host_mesh::host_agent::ProcManagerSpawnFn;
 use crate::host_mesh::host_agent::ProcState;
 use crate::host_mesh::host_agent::SetClientConfigClient;
 use crate::host_mesh::host_agent::ShutdownHostClient;
-use crate::mesh_admin::MeshAdminMessageClient;
 use crate::mesh_controller::HostMeshController;
 use crate::mesh_controller::ProcMeshController;
 use crate::proc_agent::ProcAgent;
@@ -1753,6 +1753,10 @@ fn aggregate_hosts(
 /// the actor context `cx`. Hosts are deduplicated by actor ID across
 /// all meshes.
 ///
+/// Spawn a `MeshAdminAgent` aggregating topology across one or more
+/// meshes. Returns a typed `ActorRef<MeshAdminAgent>`. Callers that
+/// need the admin URL query it via `get_admin_addr`.
+///
 /// See the `mesh_admin` module doc for the SA-* (spawn/aggregation),
 /// CH-* (client host), and AI-* (admin identity) invariants.
 pub async fn spawn_admin(
@@ -1760,7 +1764,7 @@ pub async fn spawn_admin(
     cx: &impl hyperactor::context::Actor,
     admin_addr: Option<std::net::SocketAddr>,
     telemetry_url: Option<String>,
-) -> anyhow::Result<String> {
+) -> anyhow::Result<hyperactor_reference::ActorRef<MeshAdminAgent>> {
     let meshes: Vec<_> = meshes.into_iter().collect();
     anyhow::ensure!(!meshes.is_empty(), "at least one mesh is required (SA-1)");
     for (i, mesh) in meshes.iter().enumerate() {
@@ -1789,12 +1793,8 @@ pub async fn spawn_admin(
             telemetry_url,
         ),
     )?;
-    let response = agent_handle.get_admin_addr(cx).await?;
-    let addr = response
-        .addr
-        .ok_or_else(|| anyhow::anyhow!("mesh admin agent did not report an address"))?;
-
-    Ok(addr)
+    let admin_ref = agent_handle.bind();
+    Ok(admin_ref)
 }
 
 impl view::Ranked for HostMeshRef {

--- a/hyperactor_mesh/src/host_mesh/host_agent.rs
+++ b/hyperactor_mesh/src/host_mesh/host_agent.rs
@@ -57,6 +57,8 @@ use crate::config_dump::ConfigDump;
 use crate::config_dump::ConfigDumpResult;
 use crate::proc_agent::ProcAgent;
 use crate::pyspy::PySpyDump;
+use crate::pyspy::PySpyProfile;
+use crate::pyspy::PySpyProfileWorker;
 use crate::pyspy::PySpyWorker;
 use crate::resource;
 use crate::resource::ProcSpec;
@@ -278,6 +280,7 @@ impl fmt::Debug for DrainWorker {
         SetClientConfig,
         ProcStatusChanged,
         PySpyDump,
+        PySpyProfile,
         ConfigDump,
     ]
 )]
@@ -1301,6 +1304,17 @@ impl Handler<PySpyDump> for HostAgent {
         message: PySpyDump,
     ) -> Result<(), anyhow::Error> {
         PySpyWorker::spawn_and_forward(cx, message.opts, message.result)
+    }
+}
+
+#[async_trait]
+impl Handler<PySpyProfile> for HostAgent {
+    async fn handle(
+        &mut self,
+        cx: &Context<Self>,
+        message: PySpyProfile,
+    ) -> Result<(), anyhow::Error> {
+        PySpyProfileWorker::spawn_and_forward(cx, message.request, message.result)
     }
 }
 

--- a/hyperactor_mesh/src/introspect.rs
+++ b/hyperactor_mesh/src/introspect.rs
@@ -206,6 +206,37 @@
 //!   added `warnings: Vec<String>`. Clients reading the old `stack`
 //!   field will see it absent; they must migrate to `stack_traces`.
 //!
+//! ## py-spy profiling (PP-*)
+//!
+//! Profile capture (`py-spy record`) is a separate contract from
+//! dump (`py-spy dump`). Types, messages, workers, and routes are
+//! independent — no shared state, no shared timeout budget.
+//!
+//! - **PP-1 (input validation):** `duration_s` (u32) must be
+//!   non-zero and at most `MESH_ADMIN_PYSPY_MAX_PROFILE_DURATION`.
+//!   `rate_hz` must be 1..1000. Violations → 400 before any
+//!   actor messaging.
+//! - **PP-2 (dynamic timeout cascade):** Subprocess timeout =
+//!   `duration_s + 15s`. Bridge timeout = subprocess + 5s.
+//!   Computed per-request from validated opts, not static config.
+//! - **PP-3 (temp file lifecycle):** `py-spy record` writes to a
+//!   temp file; the worker reads it after successful exit and
+//!   deletes via tempfile drop. On failure or timeout, stderr is
+//!   captured. On timeout, the child is explicitly killed and
+//!   reaped via `start_kill()` + `wait().await`. If the file is
+//!   missing, empty, or unreadable after successful exit, the
+//!   result is `OutputMissing`, `OutputEmpty`, or
+//!   `OutputReadFailure`, not `Ok`.
+//! - **PP-4 (target locality):** Inherits PS-1 — always targets
+//!   `std::process::id()`, never a caller-supplied PID.
+//! - **PP-5 (separate worker):** `PySpyProfileWorker` is a
+//!   distinct actor from `PySpyWorker`. Profile durations block
+//!   for seconds to minutes; isolation prevents starving dumps.
+//! - **PP-6 (wire projection):** `ProfileExecOutcome` maps to
+//!   `PySpyProfileResult` 1:1 via `From`. Every internal variant
+//!   has an identically-named wire variant. The only shape change
+//!   is `TimedOut.timeout: Duration` → `TimedOut.timeout_s: u64`.
+//!
 //! ## Mesh-admin config (MA-*)
 //!
 //! - **MA-C1 (timeout config centralization):** Mesh-admin timeout

--- a/hyperactor_mesh/src/mesh_admin.rs
+++ b/hyperactor_mesh/src/mesh_admin.rs
@@ -3708,7 +3708,7 @@ mod tests {
         let (caller_cx, _caller_handle) = caller_proc.instance("caller").unwrap();
 
         // 3. Call the real public entrypoint.
-        let admin_url = crate::host_mesh::spawn_admin(
+        let admin_ref = crate::host_mesh::spawn_admin(
             [&host_mesh],
             &caller_cx,
             Some("[::]:0".parse().unwrap()),
@@ -3717,23 +3717,18 @@ mod tests {
         .await
         .unwrap();
 
-        assert!(!admin_url.is_empty(), "spawn_admin must return a URL");
-
-        // 4. Prove the admin is on caller_proc: construct an ActorRef
-        //    targeting "mesh_admin[0]" on caller_proc and send it a
-        //    GetAdminAddr message. If the admin were on a different
-        //    proc, this message would be undeliverable.
-        let admin_ref: hyperactor_reference::ActorRef<MeshAdminAgent> =
-            hyperactor_reference::ActorRef::attest(
-                caller_proc.proc_id().actor_id(MESH_ADMIN_ACTOR_NAME, 0),
-            );
-        let probe_proc = Proc::direct(ChannelTransport::Unix.any(), "probe".to_string()).unwrap();
-        let (probe_cx, _probe_handle) = probe_proc.instance("probe").unwrap();
-        let resp = admin_ref.get_admin_addr(&probe_cx).await.unwrap();
-        assert_eq!(
-            resp.addr.as_deref(),
-            Some(admin_url.as_str()),
-            "SA-5: admin on caller_proc must respond to GetAdminAddr"
+        // 4. Prove the returned ActorRef is usable: fetch the URL
+        //    via get_admin_addr. This also proves the admin is on
+        //    caller_proc (undeliverable if not).
+        let admin_url = admin_ref
+            .get_admin_addr(&caller_cx)
+            .await
+            .unwrap()
+            .addr
+            .expect("SA-5: admin must report an address");
+        assert!(
+            !admin_url.is_empty(),
+            "spawn_admin ref must yield a non-empty URL"
         );
     }
 

--- a/hyperactor_mesh/src/mesh_admin.rs
+++ b/hyperactor_mesh/src/mesh_admin.rs
@@ -378,9 +378,14 @@ use crate::introspect::NodeProperties;
 use crate::introspect::dto::NodePayloadDto;
 use crate::introspect::to_node_payload;
 use crate::proc_agent::PROC_AGENT_ACTOR_NAME;
+use crate::proc_agent::ProcAgent;
 use crate::pyspy::PySpyDump;
 use crate::pyspy::PySpyOpts;
+use crate::pyspy::PySpyProfile;
+use crate::pyspy::PySpyProfileOpts;
+use crate::pyspy::PySpyProfileResult;
 use crate::pyspy::PySpyResult;
+use crate::pyspy::ValidatedProfileRequest;
 
 /// Send an `IntrospectMessage` to an actor and receive the reply.
 /// Encapsulates open_once_port + send + timeout + error handling.
@@ -1483,6 +1488,7 @@ impl MeshAdminAgent {
 /// - `POST /v1/query` — proxy SQL query to the dashboard server.
 /// - `GET /v1/pyspy/{*proc_reference}` — py-spy stack dump for a proc.
 /// - `POST /v1/pyspy_dump/{*proc_reference}` — py-spy dump + store in Datafusion.
+/// - `POST /v1/pyspy_profile_svg/{*proc_reference}` — py-spy profile → SVG flamegraph.
 /// - `GET /v1/config/{*proc_reference}` — config snapshot for a proc.
 /// - `GET /v1/admin` — admin self-identification (`AdminInfo`).
 /// - `GET /v1/{*reference}` — JSON `NodePayload` for a single reference.
@@ -1502,6 +1508,10 @@ fn create_mesh_admin_router(bridge_state: Arc<BridgeState>) -> Router {
         .route(
             "/v1/pyspy_dump/{*proc_reference}",
             post(pyspy_dump_and_store),
+        )
+        .route(
+            "/v1/pyspy_profile_svg/{*proc_reference}",
+            post(pyspy_profile_svg),
         )
         .route("/v1/config/{*proc_reference}", get(config_bridge))
         .route("/v1/{*reference}", get(resolve_reference_bridge))
@@ -1649,6 +1659,8 @@ pub fn build_openapi_spec() -> serde_json::Value {
             .expect("PyspyDumpAndStoreResponse schema must be serializable");
     let mut admin_info_schema = serde_json::to_value(schemars::schema_for!(AdminInfo))
         .expect("AdminInfo schema must be serializable");
+    let mut profile_opts_schema = serde_json::to_value(schemars::schema_for!(PySpyProfileOpts))
+        .expect("PySpyProfileOpts schema must be serializable");
 
     // Hoist $defs into a shared components/schemas map so
     // OpenAPI tools can resolve references.
@@ -1660,6 +1672,7 @@ pub fn build_openapi_spec() -> serde_json::Value {
     hoist_defs(&mut query_response_schema, &mut shared_schemas);
     hoist_defs(&mut pyspy_dump_response_schema, &mut shared_schemas);
     hoist_defs(&mut admin_info_schema, &mut shared_schemas);
+    hoist_defs(&mut profile_opts_schema, &mut shared_schemas);
     shared_schemas.insert("NodePayload".into(), node_schema);
     shared_schemas.insert("ApiErrorEnvelope".into(), error_schema);
     shared_schemas.insert("PySpyResult".into(), pyspy_schema);
@@ -1670,6 +1683,7 @@ pub fn build_openapi_spec() -> serde_json::Value {
         pyspy_dump_response_schema,
     );
     shared_schemas.insert("AdminInfo".into(), admin_info_schema);
+    shared_schemas.insert("PySpyProfileOpts".into(), profile_opts_schema);
 
     // Rewrite any remaining $defs refs in the hoisted component schemas.
     for value in shared_schemas.values_mut() {
@@ -1926,8 +1940,8 @@ pub fn build_openapi_spec() -> serde_json::Value {
         }
     });
 
-    // Insert /v1/schema/admin outside the json! macro to avoid
-    // hitting the serde_json recursion limit.
+    // Insert paths outside the json! macro to avoid hitting the
+    // serde_json recursion limit.
     if let Some(paths) = spec.pointer_mut("/paths").and_then(|v| v.as_object_mut()) {
         paths.insert(
             "/v1/schema/admin".into(),
@@ -1944,6 +1958,42 @@ pub fn build_openapi_spec() -> serde_json::Value {
                 }
             }),
         );
+        paths.insert(
+            "/v1/pyspy_profile_svg/{proc_reference}".into(),
+            serde_json::json!({
+                "post": {
+                    "summary": "Profile a proc and return SVG flamegraph",
+                    "operationId": "pyspyProfileSvg",
+                    "description": "Runs py-spy record against the target process for the requested duration and returns an SVG flamegraph. Timeout scales with duration_s.",
+                    "parameters": [{
+                        "name": "proc_reference",
+                        "in": "path",
+                        "required": true,
+                        "description": "URL-encoded proc reference (ProcId)",
+                        "schema": { "type": "string" }
+                    }],
+                    "requestBody": {
+                        "required": true,
+                        "content": {
+                            "application/json": {
+                                "schema": { "$ref": "#/components/schemas/PySpyProfileOpts" }
+                            }
+                        }
+                    },
+                    "responses": {
+                        "200": {
+                            "description": "SVG flamegraph",
+                            "content": { "image/svg+xml": {} }
+                        },
+                        "400": error_response("Bad request (invalid duration/rate or malformed proc reference)"),
+                        "404": error_response("Proc not found or handler not reachable"),
+                        "500": error_response("Internal error (profile failed or SVG generation failed)"),
+                        "503": error_response("Service unavailable (py-spy not available on target host)"),
+                        "504": error_response("Gateway timeout (subprocess timed out)")
+                    }
+                }
+            }),
+        );
     }
 
     spec
@@ -1956,9 +2006,7 @@ async fn serve_openapi() -> Result<axum::response::Json<serde_json::Value>, ApiE
 
 /// Validate and parse a raw proc reference path segment into a
 /// decoded reference string and `ProcId`. Extracted for testability.
-fn parse_pyspy_proc_reference(
-    raw: &str,
-) -> Result<(String, hyperactor_reference::ProcId), ApiError> {
+fn parse_proc_reference(raw: &str) -> Result<(String, hyperactor_reference::ProcId), ApiError> {
     let trimmed = raw.trim_start_matches('/');
     if trimmed.is_empty() {
         return Err(ApiError::bad_request("empty proc reference", None));
@@ -2034,89 +2082,183 @@ async fn probe_actor(
 /// Core py-spy dump logic shared by `pyspy_bridge` and
 /// `pyspy_dump_and_store`.
 ///
-/// Parses the proc reference, routes to the appropriate actor,
-/// probes for reachability, sends `PySpyDump`, and returns the
-/// result.
-async fn do_pyspy_dump(
+/// Typed proc-handler target. Private to this module. The single
+/// minting point is `route_proc_handler` via `ActorRef::attest`.
+/// After minting, all sends go through typed `ActorRef::send`.
+enum ResolvedProcHandler {
+    Host(hyperactor_reference::ActorRef<HostAgent>),
+    Proc(hyperactor_reference::ActorRef<ProcAgent>),
+}
+
+impl ResolvedProcHandler {
+    fn agent_id(&self) -> &hyperactor_reference::ActorId {
+        match self {
+            Self::Host(r) => r.actor_id(),
+            Self::Proc(r) => r.actor_id(),
+        }
+    }
+
+    async fn pyspy_dump(
+        &self,
+        cx: &impl hyperactor::context::Actor,
+        opts: PySpyOpts,
+        timeout: std::time::Duration,
+    ) -> Result<PySpyResult, ApiError> {
+        let (reply_handle, reply_rx) = open_once_port::<PySpyResult>(cx);
+        let mut reply_ref = reply_handle.bind();
+        reply_ref.return_undeliverable(false);
+        let msg = PySpyDump {
+            opts,
+            result: reply_ref,
+        };
+        match self {
+            Self::Host(r) => r.send(cx, msg),
+            Self::Proc(r) => r.send(cx, msg),
+        }
+        .map_err(|e| ApiError {
+            code: "internal_error".to_string(),
+            message: format!("failed to send PySpyDump: {}", e),
+            details: None,
+        })?;
+        tokio::time::timeout(timeout, reply_rx.recv())
+            .await
+            .map_err(|_| ApiError {
+                code: "gateway_timeout".to_string(),
+                message: "timed out waiting for py-spy dump".to_string(),
+                details: None,
+            })?
+            .map_err(|e| ApiError {
+                code: "internal_error".to_string(),
+                message: format!("failed to receive PySpyResult: {}", e),
+                details: None,
+            })
+    }
+
+    async fn pyspy_profile(
+        &self,
+        cx: &impl hyperactor::context::Actor,
+        request: ValidatedProfileRequest,
+        timeout: std::time::Duration,
+    ) -> Result<PySpyProfileResult, ApiError> {
+        let (reply_handle, reply_rx) = open_once_port::<PySpyProfileResult>(cx);
+        let mut reply_ref = reply_handle.bind();
+        reply_ref.return_undeliverable(false);
+        let msg = PySpyProfile {
+            request,
+            result: reply_ref,
+        };
+        match self {
+            Self::Host(r) => r.send(cx, msg),
+            Self::Proc(r) => r.send(cx, msg),
+        }
+        .map_err(|e| ApiError {
+            code: "internal_error".to_string(),
+            message: format!("failed to send PySpyProfile: {}", e),
+            details: None,
+        })?;
+        tokio::time::timeout(timeout, reply_rx.recv())
+            .await
+            .map_err(|_| ApiError {
+                code: "gateway_timeout".to_string(),
+                message: "timed out waiting for py-spy profile".to_string(),
+                details: None,
+            })?
+            .map_err(|e| ApiError {
+                code: "internal_error".to_string(),
+                message: format!("failed to receive PySpyProfileResult: {}", e),
+                details: None,
+            })
+    }
+
+    async fn config_dump(
+        &self,
+        cx: &impl hyperactor::context::Actor,
+        timeout: std::time::Duration,
+    ) -> Result<ConfigDumpResult, ApiError> {
+        let (reply_handle, reply_rx) = open_once_port::<ConfigDumpResult>(cx);
+        let mut reply_ref = reply_handle.bind();
+        reply_ref.return_undeliverable(false);
+        let msg = ConfigDump { result: reply_ref };
+        match self {
+            Self::Host(r) => r.send(cx, msg),
+            Self::Proc(r) => r.send(cx, msg),
+        }
+        .map_err(|e| ApiError {
+            code: "internal_error".to_string(),
+            message: format!("failed to send ConfigDump: {}", e),
+            details: None,
+        })?;
+        tokio::time::timeout(timeout, reply_rx.recv())
+            .await
+            .map_err(|_| ApiError {
+                code: "gateway_timeout".to_string(),
+                message: "timed out waiting for config dump".to_string(),
+                details: None,
+            })?
+            .map_err(|e| ApiError {
+                code: "internal_error".to_string(),
+                message: format!("failed to receive ConfigDumpResult: {}", e),
+                details: None,
+            })
+    }
+}
+
+/// Parse + route + attest. No probe. The single `ActorRef::attest`
+/// minting point. Used by `config_bridge` which intentionally skips
+/// the probe (CFG-4).
+fn route_proc_handler(raw_proc_reference: &str) -> Result<ResolvedProcHandler, ApiError> {
+    let (_proc_reference, proc_id) = parse_proc_reference(raw_proc_reference)?;
+    let is_service = proc_id.base_name() == SERVICE_PROC_NAME;
+    if is_service {
+        let agent_id = proc_id.actor_id(HOST_MESH_AGENT_ACTOR_NAME, 0);
+        Ok(ResolvedProcHandler::Host(
+            hyperactor_reference::ActorRef::attest(agent_id),
+        ))
+    } else {
+        let agent_id = proc_id.actor_id(PROC_AGENT_ACTOR_NAME, 0);
+        Ok(ResolvedProcHandler::Proc(
+            hyperactor_reference::ActorRef::attest(agent_id),
+        ))
+    }
+}
+
+/// Parse + route + attest + probe (PS-13).
+async fn resolve_proc_handler(
     state: &BridgeState,
     raw_proc_reference: &str,
-) -> Result<PySpyResult, ApiError> {
-    let (proc_reference, proc_id) = parse_pyspy_proc_reference(raw_proc_reference)?;
-
-    // PS-12: route by proc name — service proc → HostAgent, all others → ProcAgent.
-    let agent_id = if proc_id.base_name() == SERVICE_PROC_NAME {
-        proc_id.actor_id(HOST_MESH_AGENT_ACTOR_NAME, 0)
-    } else {
-        proc_id.actor_id(PROC_AGENT_ACTOR_NAME, 0)
-    };
-
-    // PS-13: defensive probe — verify the target actor is reachable
-    // before committing to the full py-spy timeout.
+) -> Result<ResolvedProcHandler, ApiError> {
+    let handler = route_proc_handler(raw_proc_reference)?;
     let cx = &state.bridge_cx;
-    if !probe_actor(cx, &agent_id).await? {
+    if !probe_actor(cx, handler.agent_id()).await? {
         return Err(ApiError::not_found(
             format!(
-                "proc {} does not have a reachable py-spy handler (expected {} actor)",
-                proc_reference,
-                if proc_id.base_name() == SERVICE_PROC_NAME {
-                    HOST_MESH_AGENT_ACTOR_NAME
-                } else {
-                    PROC_AGENT_ACTOR_NAME
-                },
+                "proc does not have a reachable handler ({})",
+                raw_proc_reference,
             ),
             None,
         ));
     }
+    Ok(handler)
+}
 
-    let port = hyperactor_reference::PortRef::<PySpyDump>::attest_message_port(&agent_id);
-    let (reply_handle, reply_rx) = open_once_port::<PySpyResult>(cx);
-    // Mark the reply port non-returnable. Same rationale as config_bridge:
-    // a timed-out admin client must not crash the observed actor.
-    let mut reply_ref = reply_handle.bind();
-    reply_ref.return_undeliverable(false);
-    // Native frames are essential for diagnosing hangs in C
-    // extensions and CUDA calls — the primary py-spy use case in
-    // Monarch. These defaults match the old hyperactor_multiprocess
-    // battle-tested diagnostics.
-    port.send(
-        cx,
-        PySpyDump {
-            opts: PySpyOpts {
+async fn do_pyspy_dump(
+    state: &BridgeState,
+    raw_proc_reference: &str,
+) -> Result<PySpyResult, ApiError> {
+    let handler = resolve_proc_handler(state, raw_proc_reference).await?;
+    let timeout = hyperactor_config::global::get(crate::config::MESH_ADMIN_PYSPY_BRIDGE_TIMEOUT);
+    handler
+        .pyspy_dump(
+            &state.bridge_cx,
+            PySpyOpts {
                 threads: false,
                 native: true,
                 native_all: true,
                 nonblocking: false,
             },
-            result: reply_ref,
-        },
-    )
-    .map_err(|e| ApiError {
-        code: "internal_error".to_string(),
-        message: format!("failed to send PySpyDump: {}", e),
-        details: None,
-    })?;
-
-    tokio::time::timeout(
-        hyperactor_config::global::get(crate::config::MESH_ADMIN_PYSPY_BRIDGE_TIMEOUT),
-        reply_rx.recv(),
-    )
-    .await
-    .map_err(|_| {
-        tracing::warn!(
-            proc_reference = %proc_reference,
-            "mesh admin: py-spy dump timed out (gateway_timeout)",
-        );
-        ApiError {
-            code: "gateway_timeout".to_string(),
-            message: format!("timed out waiting for py-spy dump from {}", proc_reference),
-            details: None,
-        }
-    })?
-    .map_err(|e| ApiError {
-        code: "internal_error".to_string(),
-        message: format!("failed to receive PySpyResult: {}", e),
-        details: None,
-    })
+            timeout,
+        )
+        .await
 }
 
 /// HTTP bridge for py-spy stack dump requests.
@@ -2130,6 +2272,99 @@ async fn pyspy_bridge(
     AxumPath(proc_reference): AxumPath<String>,
 ) -> Result<Json<PySpyResult>, ApiError> {
     Ok(Json(do_pyspy_dump(&state, &proc_reference).await?))
+}
+
+async fn do_pyspy_profile(
+    state: &BridgeState,
+    raw_proc_reference: &str,
+    opts: PySpyProfileOpts,
+) -> Result<PySpyProfileResult, ApiError> {
+    let max_duration =
+        hyperactor_config::global::get(crate::config::MESH_ADMIN_PYSPY_MAX_PROFILE_DURATION);
+    let request = ValidatedProfileRequest::try_new(&opts, max_duration)
+        .map_err(|msg| ApiError::bad_request(msg, None))?;
+    let bridge_timeout = request.bridge_timeout();
+    let handler = resolve_proc_handler(state, raw_proc_reference).await?;
+    handler
+        .pyspy_profile(&state.bridge_cx, request, bridge_timeout)
+        .await
+}
+
+/// HTTP bridge for py-spy profile SVG requests.
+///
+/// Accepts `PySpyProfileOpts` as JSON POST body, profiles the target
+/// process, and returns raw SVG.
+async fn pyspy_profile_svg(
+    State(state): State<Arc<BridgeState>>,
+    AxumPath(proc_reference): AxumPath<String>,
+    Json(opts): Json<PySpyProfileOpts>,
+) -> Result<axum::response::Response, ApiError> {
+    let result = do_pyspy_profile(&state, &proc_reference, opts).await?;
+    match result {
+        PySpyProfileResult::Ok { svg, .. } => Ok(axum::response::Response::builder()
+            .header("content-type", "image/svg+xml")
+            .body(axum::body::Body::from(svg))
+            .unwrap()),
+        PySpyProfileResult::BinaryNotFound { searched } => Err(ApiError {
+            code: "service_unavailable".to_string(),
+            message: format!(
+                "py-spy not available on target host; searched: {}",
+                searched.join(", ")
+            ),
+            details: None,
+        }),
+        PySpyProfileResult::TimedOut {
+            timeout_s, stderr, ..
+        } => Err(ApiError {
+            code: "gateway_timeout".to_string(),
+            message: format!(
+                "py-spy record subprocess timed out after {}s: {}",
+                timeout_s,
+                stderr.trim()
+            ),
+            details: None,
+        }),
+        PySpyProfileResult::ExitFailure { stderr, .. } => Err(ApiError {
+            code: "profile_failed".to_string(),
+            message: stderr,
+            details: None,
+        }),
+        PySpyProfileResult::OutputMissing { pid, binary } => Err(ApiError {
+            code: "profile_output_unusable".to_string(),
+            message: format!("py-spy exited 0 but SVG file is missing (pid {pid}, {binary})"),
+            details: None,
+        }),
+        PySpyProfileResult::OutputEmpty { pid, binary } => Err(ApiError {
+            code: "profile_output_unusable".to_string(),
+            message: format!("py-spy exited 0 but SVG output is empty (pid {pid}, {binary})"),
+            details: None,
+        }),
+        PySpyProfileResult::OutputReadFailure { error, .. } => Err(ApiError {
+            code: "internal_error".to_string(),
+            message: format!("failed to read SVG output: {error}"),
+            details: None,
+        }),
+        PySpyProfileResult::WorkerSpawnFailure { error } => Err(ApiError {
+            code: "internal_error".to_string(),
+            message: format!("failed to spawn profile worker actor: {error}"),
+            details: None,
+        }),
+        PySpyProfileResult::SubprocessSpawnFailure { error, .. } => Err(ApiError {
+            code: "internal_error".to_string(),
+            message: format!("failed to execute py-spy: {error}"),
+            details: None,
+        }),
+        PySpyProfileResult::WaitFailure { error, .. } => Err(ApiError {
+            code: "internal_error".to_string(),
+            message: format!("failed to wait for child: {error}"),
+            details: None,
+        }),
+        PySpyProfileResult::TempDirFailure { error, .. } => Err(ApiError {
+            code: "internal_error".to_string(),
+            message: format!("failed to create temp dir: {error}"),
+            details: None,
+        }),
+    }
 }
 
 /// Request body for `POST /v1/query`.
@@ -2283,71 +2518,17 @@ async fn pyspy_dump_and_store(
 
 /// HTTP bridge for config dump requests.
 ///
-/// Parses the proc reference, routes to the appropriate actor
-/// (ProcAgent on worker procs, HostAgent on the service proc),
-/// probes for reachability, and sends `ConfigDump` directly.
-/// See CFG-4 in `admin_tui/main.rs`.
+/// Config dump bridge. No preflight probe — the send + bridge
+/// timeout handles both absent and busy actors correctly (CFG-4).
 async fn config_bridge(
     State(state): State<Arc<BridgeState>>,
     AxumPath(proc_reference): AxumPath<String>,
 ) -> Result<Json<ConfigDumpResult>, ApiError> {
-    let (proc_reference, proc_id) = parse_pyspy_proc_reference(&proc_reference)?;
-
-    // Route by proc name — service proc → HostAgent, all others → ProcAgent.
-    let agent_id = if proc_id.base_name() == SERVICE_PROC_NAME {
-        proc_id.actor_id(HOST_MESH_AGENT_ACTOR_NAME, 0)
-    } else {
-        proc_id.actor_id(PROC_AGENT_ACTOR_NAME, 0)
-    };
-
-    // No preflight probe. The previous probe_actor() call used
-    // MESH_ADMIN_QUERY_CHILD_TIMEOUT (100ms) and mapped timeout to 404
-    // "not_found", which misclassifies a live but busy actor as absent.
-    // The ConfigDump send and its own bridge timeout handle both the
-    // absent and busy cases correctly.
-    let cx = &state.bridge_cx;
-
-    let port = hyperactor_reference::PortRef::<ConfigDump>::attest_message_port(&agent_id);
-    let (reply_handle, reply_rx) = open_once_port::<ConfigDumpResult>(cx);
-    // Mark the reply port non-returnable. If the bridge times out and
-    // drops the receiver, the late reply from HostAgent/ProcAgent is
-    // silently dropped instead of bouncing an Undeliverable back to
-    // the observed actor (which would crash it via the default fatal
-    // handle_undeliverable_message).
-    let mut reply_ref = reply_handle.bind();
-    reply_ref.return_undeliverable(false);
-
-    port.send(cx, ConfigDump { result: reply_ref })
-        .map_err(|e| ApiError {
-            code: "internal_error".to_string(),
-            message: format!("failed to send ConfigDump: {}", e),
-            details: None,
-        })?;
-
-    // Config dumps go through the actor message queue (not the introspection
-    // callback path). Use the dedicated bridge timeout.
-    let bridge_timeout =
+    let handler = route_proc_handler(&proc_reference)?;
+    let timeout =
         hyperactor_config::global::get(crate::config::MESH_ADMIN_CONFIG_DUMP_BRIDGE_TIMEOUT);
-    let wire_result = tokio::time::timeout(bridge_timeout, reply_rx.recv())
-        .await
-        .map_err(|_| {
-            tracing::warn!(
-                proc_reference = %proc_reference,
-                "mesh admin: config dump timed out (gateway_timeout)",
-            );
-            ApiError {
-                code: "gateway_timeout".to_string(),
-                message: format!("timed out waiting for config dump from {}", proc_reference),
-                details: None,
-            }
-        })?
-        .map_err(|e| ApiError {
-            code: "internal_error".to_string(),
-            message: format!("failed to receive ConfigDumpResult: {}", e),
-            details: None,
-        })?;
-
-    Ok(Json(wire_result))
+    let result = handler.config_dump(&state.bridge_cx, timeout).await?;
+    Ok(Json(result))
 }
 
 /// Resolve an opaque reference string to a `NodePayload` via the
@@ -3888,7 +4069,7 @@ mod tests {
     #[test]
     fn pyspy_parse_empty_reference() {
         // v1 contract: empty input → bad_request.
-        let err = parse_pyspy_proc_reference("").unwrap_err();
+        let err = parse_proc_reference("").unwrap_err();
         assert_eq!(err.code, "bad_request");
         assert!(err.message.contains("empty"));
     }
@@ -3896,7 +4077,7 @@ mod tests {
     #[test]
     fn pyspy_parse_slash_only() {
         // v1 contract: slash-only (axum wildcard artifact) → bad_request.
-        let err = parse_pyspy_proc_reference("/").unwrap_err();
+        let err = parse_proc_reference("/").unwrap_err();
         assert_eq!(err.code, "bad_request");
         assert!(err.message.contains("empty"));
     }
@@ -3905,7 +4086,7 @@ mod tests {
     fn pyspy_parse_malformed_percent_encoding() {
         // v1 contract: malformed encoding → bad_request.
         // %FF%FE is not valid UTF-8.
-        let err = parse_pyspy_proc_reference("%FF%FE").unwrap_err();
+        let err = parse_proc_reference("%FF%FE").unwrap_err();
         assert_eq!(err.code, "bad_request");
         assert!(err.message.contains("percent-encoding"));
     }
@@ -3913,7 +4094,7 @@ mod tests {
     #[test]
     fn pyspy_parse_invalid_proc_id() {
         // v1 contract: non-ProcId reference → bad_request.
-        let err = parse_pyspy_proc_reference("not-a-valid-proc-id").unwrap_err();
+        let err = parse_proc_reference("not-a-valid-proc-id").unwrap_err();
         assert_eq!(err.code, "bad_request");
         assert!(err.message.contains("invalid proc reference"));
     }
@@ -3925,7 +4106,7 @@ mod tests {
         let proc_id = test_proc_id_with_addr(ChannelAddr::Tcp(addr), "myproc");
         let proc_id_str = proc_id.to_string();
 
-        let (decoded, parsed) = parse_pyspy_proc_reference(&proc_id_str).unwrap();
+        let (decoded, parsed) = parse_proc_reference(&proc_id_str).unwrap();
         assert_eq!(decoded, proc_id_str);
         assert_eq!(parsed, proc_id);
     }
@@ -3937,7 +4118,34 @@ mod tests {
         let proc_id = test_proc_id_with_addr(ChannelAddr::Tcp(addr), "myproc");
         let with_slash = format!("/{}", proc_id);
 
-        let (_, parsed) = parse_pyspy_proc_reference(&with_slash).unwrap();
+        let (_, parsed) = parse_proc_reference(&with_slash).unwrap();
         assert_eq!(parsed, proc_id);
+    }
+
+    /// PS-12: service proc routes to HostAgent.
+    #[test]
+    fn route_proc_handler_service_proc_yields_host() {
+        use hyperactor::reference::ProcId;
+        let addr: SocketAddr = "127.0.0.1:9000".parse().unwrap();
+        // Use ProcId::with_name directly — test_proc_id_with_addr
+        // prepends "test_" which would not match SERVICE_PROC_NAME.
+        let proc_id = ProcId::with_name(ChannelAddr::Tcp(addr), SERVICE_PROC_NAME);
+        let handler = route_proc_handler(&proc_id.to_string()).unwrap();
+        assert!(
+            matches!(handler, ResolvedProcHandler::Host(_)),
+            "service proc should resolve to Host variant"
+        );
+    }
+
+    /// PS-12: non-service proc routes to ProcAgent.
+    #[test]
+    fn route_proc_handler_worker_proc_yields_proc() {
+        let addr: SocketAddr = "127.0.0.1:9000".parse().unwrap();
+        let proc_id = test_proc_id_with_addr(ChannelAddr::Tcp(addr), "worker_0");
+        let handler = route_proc_handler(&proc_id.to_string()).unwrap();
+        assert!(
+            matches!(handler, ResolvedProcHandler::Proc(_)),
+            "non-service proc should resolve to Proc variant"
+        );
     }
 }

--- a/hyperactor_mesh/src/mesh_admin_skill.md
+++ b/hyperactor_mesh/src/mesh_admin_skill.md
@@ -69,10 +69,12 @@ failed), `note` (role), `phase` (AdminInfra or Mesh), and `outcome`
 
 ## Endpoints
 
-Most endpoints are read-only (`GET`). Two endpoints accept `POST`:
-`/v1/query` (SQL queries) and `/v1/pyspy_dump/{proc_reference}`
-(dump-and-store). All endpoints return `application/json` except
-`/SKILL.md` (`text/markdown`).
+Most endpoints are read-only (`GET`). Three endpoints accept `POST`:
+`/v1/query` (SQL queries), `/v1/pyspy_dump/{proc_reference}`
+(dump-and-store), and `/v1/pyspy_profile_svg/{proc_reference}`
+(profile → SVG). All endpoints return `application/json` except
+`/SKILL.md` (`text/markdown`) and
+`/v1/pyspy_profile_svg/{proc_reference}` (`image/svg+xml`).
 
 - `GET {base}/v1/admin`
   Admin self-identification: returns `AdminInfo` with `actor_id`,
@@ -124,6 +126,32 @@ Most endpoints are read-only (`GET`). Two endpoints accept `POST`:
   returned.
 
   Timeout returns the standard `gateway_timeout` error envelope.
+
+- `POST {base}/v1/pyspy_profile_svg/{proc_reference}`
+  Profiles the process for a requested duration and returns an SVG
+  flamegraph. POST body is JSON `PySpyProfileOpts`:
+  `{"duration_s": 5, "rate_hz": 100, "native": true, "threads": false, "nonblocking": false}`
+
+  Returns `image/svg+xml` on success. Long-running — timeout scales
+  with `duration_s`. Max duration is configurable (default 300s).
+
+  Error responses:
+  - 400 — invalid `duration_s` or `rate_hz`
+  - 404 — proc not found or handler not reachable
+  - 503 — py-spy not available on target host
+  - 504 — py-spy record subprocess timed out
+
+  Agent note: `{encoded_proc_ref}` is the percent-encoded ProcId
+  string for the target process. If you save the
+  returned SVG on a remote host for browser viewing, tell the user
+  the remote file path, the serving port, the exact `ssh -L`
+  tunnel command, and the browser URL.
+
+  Example (adapt ports if already in use):
+  `curl {TLS} -X POST -H 'Content-Type: application/json' -d '{"duration_s":5,"rate_hz":100,"native":false,"threads":false,"nonblocking":false}' '{base}/v1/pyspy_profile_svg/{encoded_proc_ref}' -o /tmp/profile.svg`
+  `cd /tmp && python3 -m http.server 8888 --bind 127.0.0.1`
+  User tunnel: `ssh -L <local_port>:127.0.0.1:8888 {host}`
+  Browser: `http://localhost:<local_port>/profile.svg`
 
 - `GET {base}/v1/config/{proc_reference}`
   Returns the effective CONFIG-marked configuration entries from the

--- a/hyperactor_mesh/src/proc_agent.rs
+++ b/hyperactor_mesh/src/proc_agent.rs
@@ -554,7 +554,7 @@ impl ProcAgent {
         attrs.set(crate::introspect::NODE_TYPE, "proc".to_string());
         attrs.set(
             crate::introspect::PROC_NAME,
-            self.proc.proc_id().to_string(),
+            self.proc.proc_id().name().to_string(),
         );
         attrs.set(crate::introspect::NUM_ACTORS, num_live);
         attrs.set(hyperactor::introspect::CHILDREN, children);
@@ -646,7 +646,7 @@ impl Actor for ProcAgent {
                     let num_live = children.len();
                     let mut attrs = hyperactor_config::Attrs::new();
                     attrs.set(crate::introspect::NODE_TYPE, "proc".to_string());
-                    attrs.set(crate::introspect::PROC_NAME, proc_id.to_string());
+                    attrs.set(crate::introspect::PROC_NAME, proc_id.name().to_string());
                     attrs.set(crate::introspect::NUM_ACTORS, num_live);
                     attrs.set(crate::introspect::SYSTEM_CHILDREN, system_children);
                     attrs.set(crate::introspect::STOPPED_CHILDREN, stopped_children);

--- a/hyperactor_mesh/src/proc_agent.rs
+++ b/hyperactor_mesh/src/proc_agent.rs
@@ -61,6 +61,8 @@ use crate::Name;
 use crate::config_dump::ConfigDump;
 use crate::config_dump::ConfigDumpResult;
 use crate::pyspy::PySpyDump;
+use crate::pyspy::PySpyProfile;
+use crate::pyspy::PySpyProfileWorker;
 use crate::pyspy::PySpyWorker;
 use crate::resource;
 
@@ -380,6 +382,7 @@ struct SelfCheck {}
         resource::WaitRankStatus { cast = true },
         RepublishIntrospect { cast = true },
         PySpyDump,
+        PySpyProfile,
         ConfigDump,
     ]
 )]
@@ -926,6 +929,17 @@ impl Handler<PySpyDump> for ProcAgent {
         message: PySpyDump,
     ) -> Result<(), anyhow::Error> {
         PySpyWorker::spawn_and_forward(cx, message.opts, message.result)
+    }
+}
+
+#[async_trait]
+impl Handler<PySpyProfile> for ProcAgent {
+    async fn handle(
+        &mut self,
+        cx: &Context<Self>,
+        message: PySpyProfile,
+    ) -> Result<(), anyhow::Error> {
+        PySpyProfileWorker::spawn_and_forward(cx, message.request, message.result)
     }
 }
 

--- a/hyperactor_mesh/src/pyspy.rs
+++ b/hyperactor_mesh/src/pyspy.rs
@@ -6,9 +6,9 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-//! py-spy integration for remote Python stack dumps.
+//! py-spy integration for remote Python stack dumps and profiles.
 //!
-//! See PS-* invariants in `introspect` module doc.
+//! See PS-* and PP-* invariants in `introspect` module doc.
 
 use async_trait::async_trait;
 use hyperactor::Actor;
@@ -135,6 +135,297 @@ pub struct PySpyOpts {
     pub nonblocking: bool,
 }
 
+/// Public JSON-facing options for a py-spy profile capture.
+///
+/// Deserialized from the HTTP POST body. Validated and converted to
+/// `ValidatedProfileRequest` before any actor messaging.
+///
+/// See PP-1 in `introspect` module doc.
+#[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct PySpyProfileOpts {
+    /// Sampling duration in whole seconds. py-spy `--duration`
+    /// accepts integers only. Must be >= 1; upper bound enforced
+    /// at runtime by `MESH_ADMIN_PYSPY_MAX_PROFILE_DURATION`.
+    #[schemars(range(min = 1))]
+    pub duration_s: u32,
+    /// Sampling rate in Hz. Must be 1..=1000.
+    #[schemars(range(min = 1, max = 1000))]
+    pub rate_hz: u32,
+    /// Include native C/C++ frames.
+    pub native: bool,
+    /// Include per-thread stacks.
+    pub threads: bool,
+    /// Use nonblocking mode.
+    pub nonblocking: bool,
+}
+
+/// Validated profile duration. Guaranteed non-zero.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+pub(crate) struct ProfileDurationSecs(std::num::NonZeroU32);
+
+impl ProfileDurationSecs {
+    pub fn get(self) -> u32 {
+        self.0.get()
+    }
+}
+
+/// Validated sample rate. Guaranteed 1..=1000.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+pub(crate) struct SampleRateHz(std::num::NonZeroU32);
+
+impl SampleRateHz {
+    pub fn get(self) -> u32 {
+        self.0.get()
+    }
+}
+
+/// Validated profile request. If this exists, it is valid.
+/// Construct only via `try_new`. See PP-1, PP-2.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct ValidatedProfileRequest {
+    /// Sampling duration (guaranteed non-zero, within max).
+    duration: ProfileDurationSecs,
+    /// Sampling rate (guaranteed 1..=1000).
+    rate: SampleRateHz,
+    /// Include native C/C++ frames.
+    native: bool,
+    /// Include per-thread stacks.
+    threads: bool,
+    /// Use nonblocking mode.
+    nonblocking: bool,
+    /// Kill deadline for the py-spy subprocess.
+    subprocess_timeout: std::time::Duration,
+    /// Bridge reply wait deadline (subprocess + margin).
+    bridge_timeout: std::time::Duration,
+}
+
+impl ValidatedProfileRequest {
+    pub fn duration(&self) -> ProfileDurationSecs {
+        self.duration
+    }
+    pub fn rate(&self) -> SampleRateHz {
+        self.rate
+    }
+    pub fn native(&self) -> bool {
+        self.native
+    }
+    pub fn threads(&self) -> bool {
+        self.threads
+    }
+    pub fn nonblocking(&self) -> bool {
+        self.nonblocking
+    }
+    pub fn subprocess_timeout(&self) -> std::time::Duration {
+        self.subprocess_timeout
+    }
+    pub fn bridge_timeout(&self) -> std::time::Duration {
+        self.bridge_timeout
+    }
+
+    pub fn try_new(
+        opts: &PySpyProfileOpts,
+        max_duration: std::time::Duration,
+    ) -> Result<Self, String> {
+        let duration = std::num::NonZeroU32::new(opts.duration_s)
+            .map(ProfileDurationSecs)
+            .ok_or_else(|| "duration_s must be positive".to_string())?;
+        if std::time::Duration::from_secs(u64::from(duration.get())) > max_duration {
+            return Err(format!(
+                "duration_s {}s exceeds max {}s",
+                duration.get(),
+                max_duration.as_secs()
+            ));
+        }
+        let rate = std::num::NonZeroU32::new(opts.rate_hz)
+            .filter(|n| n.get() <= 1000)
+            .map(SampleRateHz)
+            .ok_or_else(|| format!("rate_hz must be 1..=1000, got {}", opts.rate_hz))?;
+        let subprocess_timeout = std::time::Duration::from_secs(u64::from(duration.get()) + 15);
+        let bridge_timeout = subprocess_timeout + std::time::Duration::from_secs(5);
+        Ok(Self {
+            duration,
+            rate,
+            native: opts.native,
+            threads: opts.threads,
+            nonblocking: opts.nonblocking,
+            subprocess_timeout,
+            bridge_timeout,
+        })
+    }
+}
+
+/// Wire result of a py-spy profile capture. The HTTP handler
+/// unwraps this to produce `image/svg+xml` or `ApiError`.
+/// Not a public JSON contract. See PP-2, PP-3.
+#[derive(Debug, Clone, Serialize, Deserialize, Named)]
+pub enum PySpyProfileResult {
+    Ok {
+        pid: u32,
+        binary: String,
+        svg: Vec<u8>,
+    },
+    BinaryNotFound {
+        searched: Vec<String>,
+    },
+    TimedOut {
+        pid: u32,
+        binary: String,
+        timeout_s: u64,
+        stderr: String,
+    },
+    ExitFailure {
+        pid: u32,
+        binary: String,
+        exit_code: Option<i32>,
+        stderr: String,
+    },
+    OutputMissing {
+        pid: u32,
+        binary: String,
+    },
+    OutputEmpty {
+        pid: u32,
+        binary: String,
+    },
+    OutputReadFailure {
+        pid: u32,
+        binary: String,
+        error: String,
+    },
+    WorkerSpawnFailure {
+        error: String,
+    },
+    SubprocessSpawnFailure {
+        pid: u32,
+        binary: String,
+        error: String,
+    },
+    WaitFailure {
+        pid: u32,
+        binary: String,
+        error: String,
+    },
+    TempDirFailure {
+        pid: u32,
+        binary: String,
+        error: String,
+    },
+}
+wirevalue::register_type!(PySpyProfileResult);
+
+/// Internal profile execution outcome. Converted to
+/// `PySpyProfileResult` at the actor reply boundary.
+#[derive(Debug)]
+pub(crate) enum ProfileExecOutcome {
+    Ok {
+        pid: u32,
+        binary: String,
+        svg: Vec<u8>,
+    },
+    BinaryNotFound {
+        searched: Vec<String>,
+    },
+    TimedOut {
+        pid: u32,
+        binary: String,
+        timeout: std::time::Duration,
+        stderr: String,
+    },
+    ExitFailure {
+        pid: u32,
+        binary: String,
+        exit_code: Option<i32>,
+        stderr: String,
+    },
+    OutputMissing {
+        pid: u32,
+        binary: String,
+    },
+    OutputEmpty {
+        pid: u32,
+        binary: String,
+    },
+    OutputReadFailure {
+        pid: u32,
+        binary: String,
+        error: String,
+    },
+    WorkerSpawnFailure {
+        error: String,
+    },
+    SubprocessSpawnFailure {
+        pid: u32,
+        binary: String,
+        error: String,
+    },
+    WaitFailure {
+        pid: u32,
+        binary: String,
+        error: String,
+    },
+    TempDirFailure {
+        pid: u32,
+        binary: String,
+        error: String,
+    },
+}
+
+impl From<ProfileExecOutcome> for PySpyProfileResult {
+    fn from(outcome: ProfileExecOutcome) -> Self {
+        match outcome {
+            ProfileExecOutcome::Ok { pid, binary, svg } => {
+                PySpyProfileResult::Ok { pid, binary, svg }
+            }
+            ProfileExecOutcome::BinaryNotFound { searched } => {
+                PySpyProfileResult::BinaryNotFound { searched }
+            }
+            ProfileExecOutcome::TimedOut {
+                pid,
+                binary,
+                timeout,
+                stderr,
+            } => PySpyProfileResult::TimedOut {
+                pid,
+                binary,
+                timeout_s: timeout.as_secs(),
+                stderr,
+            },
+            ProfileExecOutcome::ExitFailure {
+                pid,
+                binary,
+                exit_code,
+                stderr,
+            } => PySpyProfileResult::ExitFailure {
+                pid,
+                binary,
+                exit_code,
+                stderr,
+            },
+            ProfileExecOutcome::OutputMissing { pid, binary } => {
+                PySpyProfileResult::OutputMissing { pid, binary }
+            }
+            ProfileExecOutcome::OutputEmpty { pid, binary } => {
+                PySpyProfileResult::OutputEmpty { pid, binary }
+            }
+            ProfileExecOutcome::OutputReadFailure { pid, binary, error } => {
+                PySpyProfileResult::OutputReadFailure { pid, binary, error }
+            }
+            ProfileExecOutcome::WorkerSpawnFailure { error } => {
+                PySpyProfileResult::WorkerSpawnFailure { error }
+            }
+            ProfileExecOutcome::SubprocessSpawnFailure { pid, binary, error } => {
+                PySpyProfileResult::SubprocessSpawnFailure { pid, binary, error }
+            }
+            ProfileExecOutcome::WaitFailure { pid, binary, error } => {
+                PySpyProfileResult::WaitFailure { pid, binary, error }
+            }
+            ProfileExecOutcome::TempDirFailure { pid, binary, error } => {
+                PySpyProfileResult::TempDirFailure { pid, binary, error }
+            }
+        }
+    }
+}
+
 /// Request a py-spy stack dump from this process.
 ///
 /// Both ProcAgent and HostAgent handle this message. The handler
@@ -151,6 +442,23 @@ pub struct PySpyDump {
     pub result: hyperactor_reference::OncePortRef<PySpyResult>,
 }
 wirevalue::register_type!(PySpyDump);
+
+/// Request a py-spy profile capture from this process.
+///
+/// Runs `py-spy record` for the requested duration. Separate contract
+/// from `PySpyDump` — does not affect the existing dump pipeline.
+///
+/// See PP-4, PP-5 in `introspect` module doc.
+#[allow(private_interfaces)] // pub required by hyperactor macros; actual use is crate-internal
+#[derive(Debug, Serialize, Deserialize, Named, Handler, HandleClient, RefClient)]
+pub struct PySpyProfile {
+    /// Validated profile request (opts + derived timeouts).
+    pub request: ValidatedProfileRequest,
+    /// Reply port for the result.
+    #[reply]
+    pub result: hyperactor_reference::OncePortRef<PySpyProfileResult>,
+}
+wirevalue::register_type!(PySpyProfile);
 
 /// Runs py-spy against the current process.
 ///
@@ -192,6 +500,31 @@ impl PySpyRunner {
         }
 
         PySpyResult::BinaryNotFound { searched }
+    }
+
+    /// Profile Python stacks for this process over a duration.
+    /// See PP-3, PP-4.
+    pub(crate) async fn profile_self(
+        &self,
+        request: &ValidatedProfileRequest,
+    ) -> ProfileExecOutcome {
+        let pid = std::process::id();
+        let pyspy_bin: String = hyperactor_config::global::get_cloned(PYSPY_BIN);
+        let candidates = resolve_candidates(if pyspy_bin.is_empty() {
+            None
+        } else {
+            Some(pyspy_bin)
+        });
+        let mut searched = vec![];
+
+        for (binary, label) in &candidates {
+            searched.push(label.clone());
+            if let Some(result) = try_profile(binary, pid, request).await {
+                return result;
+            }
+        }
+
+        ProfileExecOutcome::BinaryNotFound { searched }
     }
 }
 
@@ -258,6 +591,73 @@ impl Handler<RunPySpyDump> for PySpyWorker {
         let result = PySpyRunner.dump_self(&message.opts).await;
         message.reply_port.send(cx, result)?;
         cx.stop("pyspy dump complete")?;
+        Ok(())
+    }
+}
+
+/// Internal forwarded message for profile capture.
+#[allow(private_interfaces)] // pub required by hyperactor macros; actual use is crate-internal
+#[derive(Debug, Serialize, Deserialize, Named)]
+pub struct RunPySpyProfile {
+    pub request: ValidatedProfileRequest,
+    pub reply_port: hyperactor::reference::OncePortRef<PySpyProfileResult>,
+}
+wirevalue::register_type!(RunPySpyProfile);
+
+/// Short-lived child actor for profile capture. Separate from
+/// `PySpyWorker` (PP-5).
+#[hyperactor::export(handlers = [RunPySpyProfile])]
+pub struct PySpyProfileWorker;
+
+impl Actor for PySpyProfileWorker {}
+
+impl PySpyProfileWorker {
+    /// Spawn a profile worker and forward the request. On spawn
+    /// failure, sends `WorkerSpawnFailure` back via `reply_port`.
+    pub(crate) fn spawn_and_forward(
+        cx: &impl hyperactor::context::Actor,
+        request: ValidatedProfileRequest,
+        reply_port: hyperactor::reference::OncePortRef<PySpyProfileResult>,
+    ) -> Result<(), anyhow::Error> {
+        let worker = match Self.spawn(cx) {
+            Ok(handle) => handle,
+            Err(e) => {
+                let fail = ProfileExecOutcome::WorkerSpawnFailure {
+                    error: e.to_string(),
+                };
+                reply_port.send(cx, PySpyProfileResult::from(fail))?;
+                return Ok(());
+            }
+        };
+        // Once reply_port moves into RunPySpyProfile, we lose it.
+        // MailboxSenderError does not carry the unsent message, so
+        // on send failure the caller observes a bridge timeout
+        // rather than a typed error. Same limitation as PySpyWorker.
+        if let Err(e) = worker.send(
+            cx,
+            RunPySpyProfile {
+                request,
+                reply_port,
+            },
+        ) {
+            tracing::error!("failed to send to profile worker: {}", e);
+        }
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl Handler<RunPySpyProfile> for PySpyProfileWorker {
+    async fn handle(
+        &mut self,
+        cx: &Context<Self>,
+        message: RunPySpyProfile,
+    ) -> Result<(), anyhow::Error> {
+        let outcome = PySpyRunner.profile_self(&message.request).await;
+        message
+            .reply_port
+            .send(cx, PySpyProfileResult::from(outcome))?;
+        cx.stop("pyspy profile complete")?;
         Ok(())
     }
 }
@@ -516,8 +916,170 @@ async fn collect_with_timeout(
     }
 }
 
+/// Build a `py-spy record --format flamegraph` command.
+fn build_record_command(
+    binary: &str,
+    pid: u32,
+    request: &ValidatedProfileRequest,
+    output_path: &std::path::Path,
+) -> tokio::process::Command {
+    let mut cmd = tokio::process::Command::new(binary);
+    cmd.arg("record")
+        .arg("--pid")
+        .arg(pid.to_string())
+        .arg("--duration")
+        .arg(request.duration().get().to_string())
+        .arg("--rate")
+        .arg(request.rate().get().to_string())
+        .arg("--format")
+        .arg("flamegraph")
+        .arg("--output")
+        .arg(output_path);
+    if request.native() {
+        cmd.arg("--native");
+    }
+    if request.threads() {
+        cmd.arg("--threads");
+    }
+    if request.nonblocking() {
+        cmd.arg("--nonblocking");
+    }
+    // py-spy record writes output to a file, not stdout. Do NOT
+    // pipe stdout — an undrained pipe can deadlock the child.
+    cmd.stdout(std::process::Stdio::null());
+    cmd.stderr(std::process::Stdio::piped());
+    cmd
+}
+
+/// Collect stderr and wait for exit, bounded by `timeout`. On
+/// expiry the child is explicitly killed and reaped. See PP-2, PP-3.
+async fn collect_profile_with_timeout(
+    mut child: tokio::process::Child,
+    pid: u32,
+    binary: &str,
+    timeout: std::time::Duration,
+) -> Result<(std::process::ExitStatus, String), ProfileExecOutcome> {
+    // Drain stderr on a separate task so it does not block the
+    // child.wait() path and so `child` stays in this scope for
+    // explicit kill/reap on timeout.
+    let stderr_handle = child.stderr.take();
+    let stderr_task = tokio::spawn(async move {
+        let mut buf = Vec::new();
+        if let Some(mut r) = stderr_handle {
+            let _ = tokio::io::AsyncReadExt::read_to_end(&mut r, &mut buf).await;
+        }
+        buf
+    });
+
+    match tokio::time::timeout(timeout, child.wait()).await {
+        Ok(Ok(status)) => {
+            let stderr_bytes = stderr_task.await.unwrap_or_default();
+            let stderr = String::from_utf8_lossy(&stderr_bytes).into_owned();
+            Ok((status, stderr))
+        }
+        Ok(Err(e)) => {
+            stderr_task.abort();
+            Err(ProfileExecOutcome::WaitFailure {
+                pid,
+                binary: binary.to_string(),
+                error: e.to_string(),
+            })
+        }
+        Err(_) => {
+            // Timeout — explicit kill and reap.
+            let _ = child.start_kill();
+            let _ = child.wait().await;
+            let stderr_bytes = stderr_task.await.unwrap_or_default();
+            let stderr = String::from_utf8_lossy(&stderr_bytes).into_owned();
+            Err(ProfileExecOutcome::TimedOut {
+                pid,
+                binary: binary.to_string(),
+                timeout,
+                stderr,
+            })
+        }
+    }
+}
+
+/// Try to run a profile capture with the given binary. Returns `None`
+/// if the binary was not found (caller tries next candidate).
+async fn try_profile(
+    binary: &str,
+    pid: u32,
+    request: &ValidatedProfileRequest,
+) -> Option<ProfileExecOutcome> {
+    let timeout = request.subprocess_timeout();
+    let tmp_dir = match tempfile::tempdir() {
+        Ok(d) => d,
+        Err(e) => {
+            return Some(ProfileExecOutcome::TempDirFailure {
+                pid,
+                binary: binary.to_string(),
+                error: e.to_string(),
+            });
+        }
+    };
+    let svg_path = tmp_dir.path().join("profile.svg");
+
+    let child = match build_record_command(binary, pid, request, &svg_path).spawn() {
+        Ok(c) => c,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return None,
+        Err(e) => {
+            return Some(ProfileExecOutcome::SubprocessSpawnFailure {
+                pid,
+                binary: binary.to_string(),
+                error: e.to_string(),
+            });
+        }
+    };
+
+    let (status, stderr) = match collect_profile_with_timeout(child, pid, binary, timeout).await {
+        Ok(pair) => pair,
+        Err(outcome) => return Some(outcome),
+    };
+
+    if !status.success() {
+        return Some(ProfileExecOutcome::ExitFailure {
+            pid,
+            binary: binary.to_string(),
+            exit_code: status.code(),
+            stderr,
+        });
+    }
+
+    match std::fs::read(&svg_path) {
+        Ok(bytes) if bytes.is_empty() => Some(ProfileExecOutcome::OutputEmpty {
+            pid,
+            binary: binary.to_string(),
+        }),
+        Ok(svg) => Some(ProfileExecOutcome::Ok {
+            pid,
+            binary: binary.to_string(),
+            svg,
+        }),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            Some(ProfileExecOutcome::OutputMissing {
+                pid,
+                binary: binary.to_string(),
+            })
+        }
+        Err(e) => Some(ProfileExecOutcome::OutputReadFailure {
+            pid,
+            binary: binary.to_string(),
+            error: e.to_string(),
+        }),
+    }
+}
+
 #[cfg(test)]
 mod tests {
+    use std::io::Write;
+    use std::os::unix::fs::PermissionsExt;
+    use std::os::unix::process::ExitStatusExt;
+    use std::time::Duration;
+
+    use tokio::process::Command;
+
     use super::*;
 
     #[test]
@@ -652,7 +1214,6 @@ mod tests {
     #[test]
     fn output_nonzero_exit_maps_to_failed() {
         // PS-2: nonzero exit → Failed with stderr.
-        use std::os::unix::process::ExitStatusExt;
         let status = std::process::ExitStatus::from_raw(256); // exit code 1
         let output = std::process::Output {
             status,
@@ -740,8 +1301,6 @@ mod tests {
     async fn collect_timeout_kills_child_and_returns_failed() {
         // PS-5: subprocess that hangs past timeout → Failed with
         // "timed out" message; child is killed and reaped.
-        use tokio::process::Command;
-
         let child = Command::new("sleep")
             .arg("100")
             .stdout(std::process::Stdio::piped())
@@ -802,9 +1361,6 @@ mod tests {
     /// closed before exec — Linux returns ETXTBSY if a file with an
     /// open write fd is executed.
     fn write_fake_pyspy(script_body: &str) -> tempfile::TempPath {
-        use std::io::Write;
-        use std::os::unix::fs::PermissionsExt;
-
         let mut f = tempfile::NamedTempFile::new().expect("create temp file");
         write!(f, "#!/bin/sh\n{script_body}").expect("write script");
         f.as_file().sync_all().expect("sync");
@@ -948,5 +1504,261 @@ exit 1
                 line
             );
         }
+    }
+
+    /// PP-2: subprocess timeout yields `TimedOut` with partial stderr.
+    #[tokio::test]
+    async fn profile_collect_timeout_returns_timed_out() {
+        let child = Command::new("sh")
+            .arg("-c")
+            .arg("echo diag >&2; sleep 60")
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::piped())
+            .spawn()
+            .expect("sh must be available");
+
+        let result = collect_profile_with_timeout(
+            child,
+            std::process::id(),
+            "sh",
+            std::time::Duration::from_millis(200),
+        )
+        .await;
+
+        match result {
+            Err(ProfileExecOutcome::TimedOut { stderr, .. }) => {
+                assert!(
+                    stderr.contains("diag"),
+                    "expected partial stderr captured after kill, got: {stderr}"
+                );
+            }
+            other => panic!("expected TimedOut, got: {other:?}"),
+        }
+    }
+
+    fn test_request() -> ValidatedProfileRequest {
+        ValidatedProfileRequest::try_new(
+            &PySpyProfileOpts {
+                duration_s: 1,
+                rate_hz: 100,
+                native: false,
+                threads: false,
+                nonblocking: false,
+            },
+            std::time::Duration::from_secs(300),
+        )
+        .unwrap()
+    }
+
+    /// PP-4, PS-3: missing binary yields `None` (try next candidate).
+    #[tokio::test]
+    async fn profile_try_missing_binary_returns_none() {
+        let result = try_profile("/definitely/not/a/real/binary", 1, &test_request()).await;
+        assert!(result.is_none(), "missing binary must return None");
+    }
+
+    /// PP-3: successful exit with empty output yields `OutputEmpty`.
+    #[tokio::test]
+    async fn profile_success_exit_empty_file_returns_output_empty() {
+        let script = write_fake_pyspy(
+            r#"
+output=""
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --output) shift; output="$1" ;;
+    esac
+    shift
+done
+touch "$output"
+exit 0
+"#,
+        );
+        let result = try_profile(script.to_str().unwrap(), 1, &test_request()).await;
+        assert!(
+            matches!(result, Some(ProfileExecOutcome::OutputEmpty { .. })),
+            "PP-3: expected OutputEmpty, got: {result:?}"
+        );
+    }
+
+    /// PP-3: successful exit with missing output yields `OutputMissing`.
+    #[tokio::test]
+    async fn profile_success_exit_missing_file_returns_output_missing() {
+        let script = write_fake_pyspy("exit 0\n");
+        let result = try_profile(script.to_str().unwrap(), 1, &test_request()).await;
+        assert!(
+            matches!(result, Some(ProfileExecOutcome::OutputMissing { .. })),
+            "PP-3: expected OutputMissing, got: {result:?}"
+        );
+    }
+
+    /// PP-1: zero duration rejected.
+    #[test]
+    fn validated_request_rejects_zero_duration() {
+        let opts = PySpyProfileOpts {
+            duration_s: 0,
+            rate_hz: 100,
+            native: false,
+            threads: false,
+            nonblocking: false,
+        };
+        let err = ValidatedProfileRequest::try_new(&opts, std::time::Duration::from_secs(300));
+        assert!(err.is_err());
+        assert!(err.unwrap_err().contains("positive"));
+    }
+
+    /// PP-1: over-max duration rejected.
+    #[test]
+    fn validated_request_rejects_over_max_duration() {
+        let opts = PySpyProfileOpts {
+            duration_s: 999,
+            rate_hz: 100,
+            native: false,
+            threads: false,
+            nonblocking: false,
+        };
+        let err = ValidatedProfileRequest::try_new(&opts, std::time::Duration::from_secs(300));
+        assert!(err.is_err());
+        assert!(err.unwrap_err().contains("exceeds max"));
+    }
+
+    /// PP-1: zero rate rejected.
+    #[test]
+    fn validated_request_rejects_zero_rate() {
+        let opts = PySpyProfileOpts {
+            duration_s: 5,
+            rate_hz: 0,
+            native: false,
+            threads: false,
+            nonblocking: false,
+        };
+        let err = ValidatedProfileRequest::try_new(&opts, std::time::Duration::from_secs(300));
+        assert!(err.is_err());
+        assert!(err.unwrap_err().contains("rate_hz"));
+    }
+
+    /// PP-1: excessive rate rejected.
+    #[test]
+    fn validated_request_rejects_excessive_rate() {
+        let opts = PySpyProfileOpts {
+            duration_s: 5,
+            rate_hz: 9999,
+            native: false,
+            threads: false,
+            nonblocking: false,
+        };
+        let err = ValidatedProfileRequest::try_new(&opts, std::time::Duration::from_secs(300));
+        assert!(err.is_err());
+        assert!(err.unwrap_err().contains("rate_hz"));
+    }
+
+    /// PP-2: timeout arithmetic is correct and deterministic.
+    #[test]
+    fn validated_request_computes_exact_timeouts() {
+        let opts = PySpyProfileOpts {
+            duration_s: 30,
+            rate_hz: 100,
+            native: true,
+            threads: false,
+            nonblocking: false,
+        };
+        let req =
+            ValidatedProfileRequest::try_new(&opts, std::time::Duration::from_secs(300)).unwrap();
+        assert_eq!(req.duration().get(), 30);
+        assert_eq!(req.rate().get(), 100);
+        assert!(req.native());
+        assert_eq!(req.subprocess_timeout(), std::time::Duration::from_secs(45));
+        assert_eq!(req.bridge_timeout(), std::time::Duration::from_secs(50));
+    }
+
+    /// PP-6: internal-to-wire conversion is near-identity.
+    #[test]
+    fn profile_exec_outcome_conversion_is_identity() {
+        // Each internal outcome maps to the identically-named wire variant.
+        let r = PySpyProfileResult::from(ProfileExecOutcome::Ok {
+            pid: 1,
+            binary: "b".into(),
+            svg: vec![1],
+        });
+        assert!(matches!(r, PySpyProfileResult::Ok { pid: 1, .. }));
+
+        let r = PySpyProfileResult::from(ProfileExecOutcome::BinaryNotFound {
+            searched: vec!["x".into()],
+        });
+        assert!(matches!(r, PySpyProfileResult::BinaryNotFound { .. }));
+
+        let r = PySpyProfileResult::from(ProfileExecOutcome::TimedOut {
+            pid: 1,
+            binary: "b".into(),
+            timeout: Duration::from_secs(10),
+            stderr: "s".into(),
+        });
+        assert!(matches!(
+            r,
+            PySpyProfileResult::TimedOut { timeout_s: 10, .. }
+        ));
+
+        let r = PySpyProfileResult::from(ProfileExecOutcome::ExitFailure {
+            pid: 1,
+            binary: "b".into(),
+            exit_code: Some(2),
+            stderr: "e".into(),
+        });
+        assert!(matches!(
+            r,
+            PySpyProfileResult::ExitFailure {
+                exit_code: Some(2),
+                ..
+            }
+        ));
+
+        let r = PySpyProfileResult::from(ProfileExecOutcome::OutputMissing {
+            pid: 1,
+            binary: "b".into(),
+        });
+        assert!(matches!(
+            r,
+            PySpyProfileResult::OutputMissing { pid: 1, .. }
+        ));
+
+        let r = PySpyProfileResult::from(ProfileExecOutcome::OutputEmpty {
+            pid: 1,
+            binary: "b".into(),
+        });
+        assert!(matches!(r, PySpyProfileResult::OutputEmpty { pid: 1, .. }));
+
+        let r = PySpyProfileResult::from(ProfileExecOutcome::OutputReadFailure {
+            pid: 1,
+            binary: "b".into(),
+            error: "permission denied".into(),
+        });
+        assert!(matches!(r, PySpyProfileResult::OutputReadFailure { .. }));
+
+        let r =
+            PySpyProfileResult::from(ProfileExecOutcome::WorkerSpawnFailure { error: "w".into() });
+        assert!(matches!(r, PySpyProfileResult::WorkerSpawnFailure { .. }));
+
+        let r = PySpyProfileResult::from(ProfileExecOutcome::SubprocessSpawnFailure {
+            pid: 1,
+            binary: "b".into(),
+            error: "s".into(),
+        });
+        assert!(matches!(
+            r,
+            PySpyProfileResult::SubprocessSpawnFailure { .. }
+        ));
+
+        let r = PySpyProfileResult::from(ProfileExecOutcome::WaitFailure {
+            pid: 1,
+            binary: "b".into(),
+            error: "w".into(),
+        });
+        assert!(matches!(r, PySpyProfileResult::WaitFailure { .. }));
+
+        let r = PySpyProfileResult::from(ProfileExecOutcome::TempDirFailure {
+            pid: 1,
+            binary: "b".into(),
+            error: "t".into(),
+        });
+        assert!(matches!(r, PySpyProfileResult::TempDirFailure { .. }));
     }
 }

--- a/hyperactor_mesh/src/testdata/openapi.json
+++ b/hyperactor_mesh/src/testdata/openapi.json
@@ -452,6 +452,45 @@
         ],
         "type": "object"
       },
+      "PySpyProfileOpts": {
+        "description": "Public JSON-facing options for a py-spy profile capture.\n\nDeserialized from the HTTP POST body. Validated and converted to\n`ValidatedProfileRequest` before any actor messaging.\n\nSee PP-1 in `introspect` module doc.",
+        "properties": {
+          "duration_s": {
+            "description": "Sampling duration in whole seconds. py-spy `--duration`\naccepts integers only. Must be >= 1; upper bound enforced\nat runtime by `MESH_ADMIN_PYSPY_MAX_PROFILE_DURATION`.",
+            "format": "uint32",
+            "minimum": 1,
+            "type": "integer"
+          },
+          "native": {
+            "description": "Include native C/C++ frames.",
+            "type": "boolean"
+          },
+          "nonblocking": {
+            "description": "Use nonblocking mode.",
+            "type": "boolean"
+          },
+          "rate_hz": {
+            "description": "Sampling rate in Hz. Must be 1..=1000.",
+            "format": "uint32",
+            "maximum": 1000,
+            "minimum": 1,
+            "type": "integer"
+          },
+          "threads": {
+            "description": "Include per-thread stacks.",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "duration_s",
+          "rate_hz",
+          "native",
+          "threads",
+          "nonblocking"
+        ],
+        "title": "PySpyProfileOpts",
+        "type": "object"
+      },
       "PySpyResult": {
         "description": "Result of a py-spy stack dump request.\n\nSee PS-2, PS-4 in `introspect` module doc.",
         "oneOf": [
@@ -926,6 +965,92 @@
           }
         },
         "summary": "Trigger py-spy dump and store in telemetry"
+      }
+    },
+    "/v1/pyspy_profile_svg/{proc_reference}": {
+      "post": {
+        "description": "Runs py-spy record against the target process for the requested duration and returns an SVG flamegraph. Timeout scales with duration_s.",
+        "operationId": "pyspyProfileSvg",
+        "parameters": [
+          {
+            "description": "URL-encoded proc reference (ProcId)",
+            "in": "path",
+            "name": "proc_reference",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PySpyProfileOpts"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "image/svg+xml": {}
+            },
+            "description": "SVG flamegraph"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorEnvelope"
+                }
+              }
+            },
+            "description": "Bad request (invalid duration/rate or malformed proc reference)"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorEnvelope"
+                }
+              }
+            },
+            "description": "Proc not found or handler not reachable"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorEnvelope"
+                }
+              }
+            },
+            "description": "Internal error (profile failed or SVG generation failed)"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorEnvelope"
+                }
+              }
+            },
+            "description": "Service unavailable (py-spy not available on target host)"
+          },
+          "504": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorEnvelope"
+                }
+              }
+            },
+            "description": "Gateway timeout (subprocess timed out)"
+          }
+        },
+        "summary": "Profile a proc and return SVG flamegraph"
       }
     },
     "/v1/query": {

--- a/hyperactor_mesh/test/mesh_admin_integration/main.rs
+++ b/hyperactor_mesh/test/mesh_admin_integration/main.rs
@@ -193,9 +193,9 @@
 //!   NodeProperties variant wrappers do); otherwise subsumed by
 //!   MIT-42.
 //! - **MIT-51 (success-content-type):** Successful responses use a
-//!   media type matching the declared type (`application/json` or
-//!   `text/plain`). Matching is by media type, not exact header
-//!   string.
+//!   media type matching the declared type (`application/json`,
+//!   `text/plain`, or `image/svg+xml`). Matching is by media type,
+//!   not exact header string.
 //!
 //! #### Error responses
 //!
@@ -281,6 +281,17 @@
 //!   malformed JSON body (missing required `sql` field) returns a
 //!   non-success status.
 //!
+//! ### Profile SVG endpoint
+//!
+//! - **MIT-73 (profile-input-validation):** `POST
+//!   /v1/pyspy_profile_svg/{proc}` rejects `duration_s == 0`,
+//!   `duration_s > max`, `rate_hz == 0`, and `rate_hz > 1000` with
+//!   HTTP 400 (PP-1).
+//! - **MIT-74 (profile-svg-success):** A 3-second CPU-mode profile
+//!   returns HTTP 200 with `Content-Type` starting with
+//!   `image/svg+xml` and a non-empty body starting with `<svg` or
+//!   `<?xml`.
+//!
 //! ### Supervision topology (sieve)
 //!
 //! - **MIT-71 (actor-child-parent-is-proc):** When actor A exposes
@@ -322,7 +333,8 @@ async fn test_dining_endpoints_python() {
 
 // --- pyspy family ---
 
-/// MIT-16, MIT-17, MIT-18, MIT-19: py-spy integration — cpu mode.
+/// MIT-16, MIT-17, MIT-18, MIT-19, MIT-73, MIT-74: py-spy
+/// integration — cpu mode + profile SVG.
 #[tokio::test]
 async fn test_pyspy_integration_cpu() {
     pyspy::run_pyspy_integration_cpu().await;

--- a/hyperactor_mesh/test/mesh_admin_integration/openapi.rs
+++ b/hyperactor_mesh/test/mesh_admin_integration/openapi.rs
@@ -72,6 +72,7 @@ impl OpenApiValidator {
             "/v1/pyspy/{proc_reference}",
             "/v1/query",
             "/v1/pyspy_dump/{proc_reference}",
+            "/v1/pyspy_profile_svg/{proc_reference}",
             "/v1/tree",
             "/v1/schema",
             "/v1/schema/admin",
@@ -109,6 +110,7 @@ impl OpenApiValidator {
             ("/v1/config/{proc_reference}", "get"),
             ("/v1/pyspy/{proc_reference}", "get"),
             ("/v1/pyspy_dump/{proc_reference}", "post"),
+            ("/v1/pyspy_profile_svg/{proc_reference}", "post"),
         ];
         for &(path, method) in cases {
             let params = self

--- a/hyperactor_mesh/test/mesh_admin_integration/pyspy.rs
+++ b/hyperactor_mesh/test/mesh_admin_integration/pyspy.rs
@@ -21,6 +21,7 @@ use anyhow::bail;
 use hyperactor_mesh::introspect::NodePayload;
 use hyperactor_mesh::mesh_admin::ApiErrorEnvelope;
 use hyperactor_mesh::pyspy::PySpyFrame;
+use hyperactor_mesh::pyspy::PySpyProfileOpts;
 use hyperactor_mesh::pyspy::PySpyResult;
 
 use crate::harness;
@@ -48,9 +49,9 @@ fn is_transient_pyspy_handler_not_ready(body: &str) -> bool {
                 && envelope
                     .error
                     .message
-                    .contains("does not have a reachable py-spy handler")
+                    .contains("does not have a reachable handler")
         })
-        .unwrap_or_else(|_| body.contains("does not have a reachable py-spy handler"))
+        .unwrap_or_else(|_| body.contains("does not have a reachable handler"))
 }
 
 async fn warm_worker_pyspy_endpoint(
@@ -491,6 +492,12 @@ pub async fn run_pyspy_integration_cpu() {
         Box::pin(async move {
             check_preflight(s).await;
             check_evidence(s).await;
+            // MIT-73, MIT-74: profile SVG tests share the CPU fixture.
+            check_profile_reject_zero_duration(s).await;
+            check_profile_reject_over_max_duration(s).await;
+            check_profile_reject_zero_rate(s).await;
+            check_profile_reject_excessive_rate(s).await;
+            check_profile_svg_success(s).await;
         })
     })
     .await;
@@ -524,4 +531,125 @@ pub async fn run_pyspy_integration_mixed() {
         })
     })
     .await;
+}
+
+// --- profile SVG tests ---
+
+fn profile_opts(duration_s: u32) -> PySpyProfileOpts {
+    PySpyProfileOpts {
+        duration_s,
+        rate_hz: 100,
+        native: false,
+        threads: false,
+        nonblocking: false,
+    }
+}
+
+/// PP-1: zero duration rejected.
+async fn check_profile_reject_zero_duration(s: &PyspyScenario) {
+    let encoded = urlencoding::encode(&s.workers[0]);
+    let resp = s
+        .fixture
+        .post(
+            &format!("/v1/pyspy_profile_svg/{encoded}"),
+            &profile_opts(0),
+        )
+        .await
+        .expect("POST must not fail at transport level");
+    assert_eq!(
+        resp.status().as_u16(),
+        400,
+        "PP-1: zero duration_s must be rejected"
+    );
+}
+
+/// PP-1: over-max duration rejected.
+async fn check_profile_reject_over_max_duration(s: &PyspyScenario) {
+    let encoded = urlencoding::encode(&s.workers[0]);
+    let mut opts = profile_opts(999);
+    opts.duration_s = 999;
+    let resp = s
+        .fixture
+        .post(&format!("/v1/pyspy_profile_svg/{encoded}"), &opts)
+        .await
+        .expect("POST must not fail at transport level");
+    assert_eq!(
+        resp.status().as_u16(),
+        400,
+        "PP-1: over-max duration_s must be rejected"
+    );
+    let body = resp.text().await.unwrap();
+    assert!(
+        body.contains("exceeds max"),
+        "PP-1: error should mention exceeds max, got: {body}"
+    );
+}
+
+/// PP-1: zero rate rejected.
+async fn check_profile_reject_zero_rate(s: &PyspyScenario) {
+    let encoded = urlencoding::encode(&s.workers[0]);
+    let mut opts = profile_opts(2);
+    opts.rate_hz = 0;
+    let resp = s
+        .fixture
+        .post(&format!("/v1/pyspy_profile_svg/{encoded}"), &opts)
+        .await
+        .expect("POST must not fail at transport level");
+    assert_eq!(
+        resp.status().as_u16(),
+        400,
+        "PP-1: zero rate_hz must be rejected"
+    );
+}
+
+/// PP-1: excessive rate rejected.
+async fn check_profile_reject_excessive_rate(s: &PyspyScenario) {
+    let encoded = urlencoding::encode(&s.workers[0]);
+    let mut opts = profile_opts(2);
+    opts.rate_hz = 9999;
+    let resp = s
+        .fixture
+        .post(&format!("/v1/pyspy_profile_svg/{encoded}"), &opts)
+        .await
+        .expect("POST must not fail at transport level");
+    assert_eq!(
+        resp.status().as_u16(),
+        400,
+        "PP-1: excessive rate_hz must be rejected"
+    );
+}
+
+/// Happy path: profile a CPU worker, get SVG back.
+async fn check_profile_svg_success(s: &PyspyScenario) {
+    let encoded = urlencoding::encode(&s.workers[0]);
+    let resp = s
+        .fixture
+        .post(
+            &format!("/v1/pyspy_profile_svg/{encoded}"),
+            &profile_opts(3),
+        )
+        .await
+        .expect("POST must not fail at transport level");
+    let status = resp.status().as_u16();
+    let content_type = resp
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("")
+        .to_string();
+    let body = resp.bytes().await.unwrap();
+    assert_eq!(
+        status, 200,
+        "profile must succeed on CPU worker, got {status}"
+    );
+    assert!(
+        content_type.starts_with("image/svg+xml"),
+        "content-type must be image/svg+xml, got: {content_type}"
+    );
+    assert!(!body.is_empty(), "SVG body must not be empty");
+    let prefix = String::from_utf8_lossy(&body[..body.len().min(100)]);
+    assert!(
+        prefix.contains("<svg") || prefix.contains("<?xml"),
+        "body must start with SVG content, got: {prefix}"
+    );
 }

--- a/hyperactor_mesh_admin_tui/src/app.rs
+++ b/hyperactor_mesh_admin_tui/src/app.rs
@@ -70,6 +70,8 @@ pub(crate) struct App {
     /// Shared HTTP client used for all `GET /v1/{reference}`
     /// requests.
     pub(crate) client: reqwest::Client,
+    /// Central timeout policy (TP-*). See `timeouts.rs`.
+    pub(crate) policy: crate::timeouts::TuiTimeoutPolicy,
     /// Set when the user requests exit (e.g. `q` / `Esc` / `Ctrl-C`).
     pub(crate) should_quit: bool,
 
@@ -141,10 +143,12 @@ impl App {
         client: reqwest::Client,
         theme_name: ThemeName,
         lang_name: LangName,
+        policy: crate::timeouts::TuiTimeoutPolicy,
     ) -> Self {
         Self {
             base_url,
             client,
+            policy,
             should_quit: false,
             tree: None,
             cursor: Cursor::new(0),
@@ -1267,11 +1271,11 @@ async fn recv_active_job(job: &mut Option<ActiveJob>) -> ActiveJobEvent {
 /// each tick, and processes keyboard input until the user exits.
 pub(crate) async fn run_app(
     terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
-    refresh_ms: u64,
     mut app: App,
 ) -> io::Result<()> {
-    let mut refresh_interval = tokio::time::interval(Duration::from_millis(refresh_ms));
-    app.refresh_interval_label = if refresh_ms >= 1000 && refresh_ms.is_multiple_of(1000) {
+    let refresh_ms = app.policy.refresh_interval.as_millis() as u64;
+    let mut refresh_interval = tokio::time::interval(app.policy.refresh_interval);
+    app.refresh_interval_label = if refresh_ms >= 1000 && refresh_ms % 1000 == 0 {
         format!("{}s", refresh_ms / 1000)
     } else {
         format!("{}ms", refresh_ms)
@@ -1315,6 +1319,7 @@ pub(crate) async fn run_app(
                                 let rx = run_diagnostics(
                                     app.client.clone(),
                                     app.base_url.clone(),
+                                    &app.policy,
                                 );
                                 // PY-5: set_job drops any prior PySpy variant.
                                 app.set_job(ActiveJob::Diagnostics {

--- a/hyperactor_mesh_admin_tui/src/app.rs
+++ b/hyperactor_mesh_admin_tui/src/app.rs
@@ -222,6 +222,8 @@ impl App {
             self.refresh_gen,
             &mut self.seq_counter,
             force,
+            self.policy
+                .request_timeout(crate::timeouts::RequestOp::InteractiveFetch),
         )
         .await
     }
@@ -324,6 +326,8 @@ impl App {
                 &failed_keys,
                 self.refresh_gen,
                 &mut self.seq_counter,
+                self.policy
+                    .request_timeout(crate::timeouts::RequestOp::InteractiveFetch),
             )
             .await
             {
@@ -647,6 +651,9 @@ impl App {
         let scheme = self.theme.scheme; // ColorScheme: Copy
         let client = self.client.clone();
         let base_url = self.base_url.clone();
+        let timeout = self
+            .policy
+            .request_timeout(crate::timeouts::RequestOp::PySpyDump);
         let (tx, rx) = oneshot::channel();
         self.set_job(ActiveJob::PySpy {
             rx: Some(rx),
@@ -654,21 +661,37 @@ impl App {
             lines: vec![],
             completed_at: None,
         });
+        // TP-9: timeout covers the full request lifecycle (send +
+        // body + parse) at the operation boundary.
         tokio::spawn(async move {
             let url = format!("{}/v1/pyspy/{}", base_url, urlencoding::encode(&proc_ref));
-            let lines: Vec<Line<'static>> = match client.get(&url).send().await {
-                Err(e) => vec![Line::from(format!("request failed: {e}"))],
-                Ok(resp) if !resp.status().is_success() => {
+            let result = tokio::time::timeout(timeout, async {
+                let resp = client
+                    .get(&url)
+                    .send()
+                    .await
+                    .map_err(|e| format!("request failed: {e}"))?;
+                if !resp.status().is_success() {
                     let status = resp.status();
-                    match resp.json::<serde_json::Value>().await {
+                    let lines = match resp.json::<serde_json::Value>().await {
                         Ok(json) => parse_error_envelope(&json),
                         Err(_) => vec![Line::from(format!("HTTP {status}"))],
-                    }
+                    };
+                    return Ok::<_, String>(lines);
                 }
-                Ok(resp) => match resp.json::<serde_json::Value>().await {
-                    Err(e) => vec![Line::from(format!("parse error: {e}"))],
-                    Ok(json) => pyspy_json_to_lines(&json, &scheme),
-                },
+                match resp.json::<serde_json::Value>().await {
+                    Err(e) => Ok(vec![Line::from(format!("parse error: {e}"))]),
+                    Ok(json) => Ok(pyspy_json_to_lines(&json, &scheme)),
+                }
+            })
+            .await;
+            let lines: Vec<Line<'static>> = match result {
+                Err(_) => vec![Line::from(format!(
+                    "request timed out after {}s",
+                    timeout.as_secs()
+                ))],
+                Ok(Ok(l)) => l,
+                Ok(Err(e)) => vec![Line::from(e)],
             };
             let _ = tx.send(lines);
         });
@@ -684,6 +707,9 @@ impl App {
         let scheme = self.theme.scheme; // ColorScheme: Copy
         let client = self.client.clone();
         let base_url = self.base_url.clone();
+        let timeout = self
+            .policy
+            .request_timeout(crate::timeouts::RequestOp::ConfigDump);
         let (tx, rx) = oneshot::channel();
         self.set_job(ActiveJob::Config {
             rx: Some(rx),
@@ -691,21 +717,37 @@ impl App {
             lines: vec![],
             completed_at: None,
         });
+        // TP-9: timeout covers the full request lifecycle (send +
+        // body + parse) at the operation boundary.
         tokio::spawn(async move {
             let url = format!("{}/v1/config/{}", base_url, urlencoding::encode(&proc_ref));
-            let lines: Vec<Line<'static>> = match client.get(&url).send().await {
-                Err(e) => vec![Line::from(format!("request failed: {e}"))],
-                Ok(resp) if !resp.status().is_success() => {
+            let result = tokio::time::timeout(timeout, async {
+                let resp = client
+                    .get(&url)
+                    .send()
+                    .await
+                    .map_err(|e| format!("request failed: {e}"))?;
+                if !resp.status().is_success() {
                     let status = resp.status();
-                    match resp.json::<serde_json::Value>().await {
+                    let lines = match resp.json::<serde_json::Value>().await {
                         Ok(json) => parse_error_envelope(&json),
                         Err(_) => vec![Line::from(format!("HTTP {status}"))],
-                    }
+                    };
+                    return Ok::<_, String>(lines);
                 }
-                Ok(resp) => match resp.json::<serde_json::Value>().await {
-                    Err(e) => vec![Line::from(format!("parse error: {e}"))],
-                    Ok(json) => config_json_to_lines(&json, &scheme),
-                },
+                match resp.json::<serde_json::Value>().await {
+                    Err(e) => Ok(vec![Line::from(format!("parse error: {e}"))]),
+                    Ok(json) => Ok(config_json_to_lines(&json, &scheme)),
+                }
+            })
+            .await;
+            let lines: Vec<Line<'static>> = match result {
+                Err(_) => vec![Line::from(format!(
+                    "request timed out after {}s",
+                    timeout.as_secs()
+                ))],
+                Ok(Ok(l)) => l,
+                Ok(Err(e)) => vec![Line::from(e)],
             };
             let _ = tx.send(lines);
         });

--- a/hyperactor_mesh_admin_tui/src/app.rs
+++ b/hyperactor_mesh_admin_tui/src/app.rs
@@ -1307,6 +1307,25 @@ async fn recv_active_job(job: &mut Option<ActiveJob>) -> ActiveJobEvent {
     }
 }
 
+/// TP-10: derive refresh policy from active job state.
+///
+/// Suspend refresh only while a foreground operation is in flight.
+/// Completed overlays (results displayed, waiting for Esc) do not
+/// suppress refresh — the user is reading results, not waiting for
+/// a network operation. The mapping is local to the app module so
+/// `timeouts::RefreshPolicy` stays independent of UI job types.
+pub(crate) fn refresh_policy_for_job(job: &Option<ActiveJob>) -> crate::timeouts::RefreshPolicy {
+    use crate::timeouts::RefreshPolicy;
+    match job {
+        None => RefreshPolicy::Baseline,
+        Some(ActiveJob::Diagnostics { running: true, .. }) => RefreshPolicy::Suspend,
+        Some(ActiveJob::PySpy { rx: Some(_), .. }) => RefreshPolicy::Suspend,
+        Some(ActiveJob::Config { rx: Some(_), .. }) => RefreshPolicy::Suspend,
+        // Completed overlays: operation finished, user is reading results.
+        Some(_) => RefreshPolicy::Baseline,
+    }
+}
+
 /// Drive the main event loop for the admin TUI.
 ///
 /// Periodically refreshes topology from the admin API, renders the UI
@@ -1334,7 +1353,21 @@ pub(crate) async fn run_app(
 
         tokio::select! {
             _ = refresh_interval.tick() => {
-                app.refresh().await;
+                // Phase 3a: the effective refresh policy is the
+                // join of all refresh-pressure sources. Currently
+                // there is one source (foreground job state); later
+                // sources extend by more joins, not by rewriting
+                // the branch. Refresh runs only when effective
+                // policy is Baseline. When the in-flight operation
+                // completes, refresh resumes on the next scheduled
+                // tick, not immediately.
+                use algebra::JoinSemilattice;
+                use crate::timeouts::RefreshPolicy;
+                let effective = RefreshPolicy::Baseline
+                    .join(&refresh_policy_for_job(&app.active_job));
+                if effective == RefreshPolicy::Baseline {
+                    app.refresh().await;
+                }
             }
             maybe_event = events.next() => {
                 match maybe_event {

--- a/hyperactor_mesh_admin_tui/src/client.rs
+++ b/hyperactor_mesh_admin_tui/src/client.rs
@@ -164,12 +164,15 @@ fn add_tls_from_bundle(
 ///
 /// Returns `(base_url, client)` where `base_url` always includes the
 /// scheme selected (`http://...` or `https://...`).
-pub(crate) fn build_client(config: &TuiConfig) -> (String, reqwest::Client) {
+pub(crate) fn build_client(
+    config: &TuiConfig,
+    policy: &crate::timeouts::TuiTimeoutPolicy,
+) -> (String, reqwest::Client) {
     let (explicit_scheme, host) = parse_addr(&config.addr);
 
-    let client_timeout =
-        hyperactor_config::global::get(hyperactor_mesh::config::MESH_ADMIN_PYSPY_CLIENT_TIMEOUT);
-    let mut builder = reqwest::Client::builder().timeout(client_timeout);
+    // TP-7: client timeout sourced from policy, not directly from
+    // mesh-admin config attrs.
+    let mut builder = reqwest::Client::builder().timeout(policy.shared_client_timeout());
     let mut use_tls = explicit_scheme == Some("https");
 
     // 1. Explicit CLI cert paths.

--- a/hyperactor_mesh_admin_tui/src/client.rs
+++ b/hyperactor_mesh_admin_tui/src/client.rs
@@ -164,15 +164,12 @@ fn add_tls_from_bundle(
 ///
 /// Returns `(base_url, client)` where `base_url` always includes the
 /// scheme selected (`http://...` or `https://...`).
-pub(crate) fn build_client(
-    config: &TuiConfig,
-    policy: &crate::timeouts::TuiTimeoutPolicy,
-) -> (String, reqwest::Client) {
+pub(crate) fn build_client(config: &TuiConfig) -> (String, reqwest::Client) {
     let (explicit_scheme, host) = parse_addr(&config.addr);
 
-    // TP-7: client timeout sourced from policy, not directly from
-    // mesh-admin config attrs.
-    let mut builder = reqwest::Client::builder().timeout(policy.shared_client_timeout());
+    // TP-7: no client-level timeout. All timeout enforcement is
+    // per-operation via tokio::time::timeout at the call boundary.
+    let mut builder = reqwest::Client::builder();
     let mut use_tls = explicit_scheme == Some("https");
 
     // 1. Explicit CLI cert paths.

--- a/hyperactor_mesh_admin_tui/src/diagnostics.rs
+++ b/hyperactor_mesh_admin_tui/src/diagnostics.rs
@@ -57,9 +57,9 @@ pub(crate) enum DiagPhase {
 /// Outcome of a single diagnostic probe.
 #[derive(Debug, Clone, Serialize)]
 pub(crate) enum DiagOutcome {
-    /// HTTP 200 received within [`SLOW_MS`] milliseconds.
+    /// HTTP 200 received below `diagnostics_probe_slow` threshold.
     Pass { elapsed_ms: u64 },
-    /// HTTP 200 received, but slower than [`SLOW_MS`].
+    /// HTTP 200 received, but at or above `diagnostics_probe_slow`.
     Slow { elapsed_ms: u64 },
     /// HTTP error, non-200 status, or timeout.
     Fail { elapsed_ms: u64, error: String },
@@ -111,13 +111,8 @@ pub(crate) struct DiagResult {
     pub(crate) outcome: DiagOutcome,
 }
 
-// Response latency above which a pass is reported as slow.
-const SLOW_MS: u64 = 500;
-
-// Per-probe timeout. Set above the server's SINGLE_HOST_TIMEOUT (3 s)
-// so server-side 504s are surfaced as Fail(error) rather than our own
-// timeout.
-const TIMEOUT_MS: u64 = 5000;
+// TP-4/TP-8: diagnostics thresholds are sourced from
+// TuiTimeoutPolicy, not file-local literals. See timeouts.rs.
 
 /// Aggregated pass/fail counts across both diagnostic phases.
 /// Computed from a completed (or in-progress) result slice.
@@ -172,10 +167,12 @@ impl DiagSummary {
 pub(crate) fn run_diagnostics(
     client: reqwest::Client,
     base_url: String,
+    policy: &crate::timeouts::TuiTimeoutPolicy,
 ) -> mpsc::Receiver<DiagResult> {
+    let policy = *policy; // Copy into the spawned task.
     let (tx, rx) = mpsc::channel(64);
     tokio::spawn(async move {
-        walk(&client, &base_url, &tx).await;
+        walk(&client, &base_url, &tx, &policy).await;
     });
     rx
 }
@@ -195,21 +192,25 @@ async fn probe(
     label: impl Into<String>,
     reference: &hyperactor_mesh::introspect::NodeRef,
     phase: DiagPhase,
+    policy: &crate::timeouts::TuiTimeoutPolicy,
 ) -> (DiagResult, Option<hyperactor_mesh::introspect::NodePayload>) {
     let label = label.into();
     let reference_str = reference.to_string();
+    let probe_timeout = policy.probe_timeout(crate::timeouts::ProbeOp::DiagnosticsProbe);
+    let slow_threshold = policy.diagnostics_probe_slow;
     let t0 = Instant::now();
 
-    let result = tokio::time::timeout(
-        Duration::from_millis(TIMEOUT_MS),
-        fetch_node_raw(client, base_url, reference),
-    )
-    .await;
+    // Per-probe timeout. Set above the server's SINGLE_HOST_TIMEOUT
+    // (3 s) so server-side 504s are surfaced as Fail(error) rather
+    // than our own timeout (TP-8).
+    let result =
+        tokio::time::timeout(probe_timeout, fetch_node_raw(client, base_url, reference)).await;
 
     let elapsed_ms = t0.elapsed().as_millis() as u64;
+    let slow_ms = slow_threshold.as_millis() as u64;
 
     let (outcome, payload) = match result {
-        Ok(Ok(p)) if elapsed_ms >= SLOW_MS => (DiagOutcome::Slow { elapsed_ms }, Some(p)),
+        Ok(Ok(p)) if elapsed_ms >= slow_ms => (DiagOutcome::Slow { elapsed_ms }, Some(p)),
         Ok(Ok(p)) => (DiagOutcome::Pass { elapsed_ms }, Some(p)),
         Ok(Err(e)) => (
             DiagOutcome::Fail {
@@ -221,7 +222,7 @@ async fn probe(
         Err(_) => (
             DiagOutcome::Fail {
                 elapsed_ms,
-                error: format!("timed out after {}ms", TIMEOUT_MS),
+                error: format!("timed out after {}ms", probe_timeout.as_millis()),
             },
             None,
         ),
@@ -272,15 +273,27 @@ fn proc_role(proc_name: &str) -> DiagNodeRole {
 }
 
 /// Full diagnostic walk. Probes in order and emits results.
-async fn walk(client: &reqwest::Client, base_url: &str, tx: &mpsc::Sender<DiagResult>) {
+async fn walk(
+    client: &reqwest::Client,
+    base_url: &str,
+    tx: &mpsc::Sender<DiagResult>,
+    policy: &crate::timeouts::TuiTimeoutPolicy,
+) {
     // Phase 1 — Admin Infra
 
     use hyperactor_mesh::introspect::NodeRef;
 
     // Root.
     let root_ref = NodeRef::Root;
-    let (mut result, root_payload) =
-        probe(client, base_url, "root", &root_ref, DiagPhase::AdminInfra).await;
+    let (mut result, root_payload) = probe(
+        client,
+        base_url,
+        "root",
+        &root_ref,
+        DiagPhase::AdminInfra,
+        policy,
+    )
+    .await;
     result.note = Some(DiagNodeRole::AdminServer);
     emit!(tx, result);
     let root_payload = match root_payload {
@@ -310,6 +323,7 @@ async fn walk(client: &reqwest::Client, base_url: &str, tx: &mpsc::Sender<DiagRe
             &host_label,
             host_ref,
             DiagPhase::AdminInfra,
+            policy,
         )
         .await;
         if let Some(p) = &host_payload {
@@ -343,6 +357,7 @@ async fn walk(client: &reqwest::Client, base_url: &str, tx: &mpsc::Sender<DiagRe
                 &proc_label,
                 proc_ref,
                 DiagPhase::AdminInfra,
+                policy,
             )
             .await;
             if let Some(p) = &proc_payload {
@@ -366,6 +381,7 @@ async fn walk(client: &reqwest::Client, base_url: &str, tx: &mpsc::Sender<DiagRe
                         &actor_label,
                         actor_ref,
                         DiagPhase::AdminInfra,
+                        policy,
                     )
                     .await;
                     // Use fetched label if available; otherwise derive
@@ -414,6 +430,7 @@ async fn walk(client: &reqwest::Client, base_url: &str, tx: &mpsc::Sender<DiagRe
                 &proc_label,
                 user_proc_ref,
                 DiagPhase::Mesh,
+                policy,
             )
             .await;
             if let Some(p) = &proc_payload {
@@ -454,8 +471,15 @@ async fn walk(client: &reqwest::Client, base_url: &str, tx: &mpsc::Sender<DiagRe
                     .filter(|r| proc_system_refs.contains(r))
                 {
                     let alabel = actor_ref.to_string();
-                    let (mut r, payload) =
-                        probe(client, base_url, &alabel, actor_ref, DiagPhase::Mesh).await;
+                    let (mut r, payload) = probe(
+                        client,
+                        base_url,
+                        &alabel,
+                        actor_ref,
+                        DiagPhase::Mesh,
+                        policy,
+                    )
+                    .await;
                     if let Some(p) = &payload {
                         r.label = format!("  {}", label_from_payload(actor_ref, p));
                     } else {
@@ -472,8 +496,15 @@ async fn walk(client: &reqwest::Client, base_url: &str, tx: &mpsc::Sender<DiagRe
                     .find(|r| !proc_system_refs.contains(r))
                 {
                     let alabel = actor_ref.to_string();
-                    let (mut r, payload) =
-                        probe(client, base_url, &alabel, actor_ref, DiagPhase::Mesh).await;
+                    let (mut r, payload) = probe(
+                        client,
+                        base_url,
+                        &alabel,
+                        actor_ref,
+                        DiagPhase::Mesh,
+                        policy,
+                    )
+                    .await;
                     if let Some(p) = &payload {
                         r.label = format!("  {}", label_from_payload(actor_ref, p));
                     } else {

--- a/hyperactor_mesh_admin_tui/src/diagnostics.rs
+++ b/hyperactor_mesh_admin_tui/src/diagnostics.rs
@@ -203,6 +203,7 @@ async fn probe(
     // Per-probe timeout. Set above the server's SINGLE_HOST_TIMEOUT
     // (3 s) so server-side 504s are surfaced as Fail(error) rather
     // than our own timeout (TP-8).
+    // TP-9: probe owns timeout semantics at the operation boundary.
     let result =
         tokio::time::timeout(probe_timeout, fetch_node_raw(client, base_url, reference)).await;
 

--- a/hyperactor_mesh_admin_tui/src/fetch.rs
+++ b/hyperactor_mesh_admin_tui/src/fetch.rs
@@ -122,6 +122,7 @@ pub(crate) async fn fetch_with_join(
     refresh_gen: u64,
     seq_counter: &mut u64,
     force: bool,
+    timeout: std::time::Duration,
 ) -> FetchState<NodePayload> {
     let cached_state = cache.get(reference);
     let should_fetch = if force {
@@ -147,14 +148,21 @@ pub(crate) async fn fetch_with_join(
             seq: *seq_counter,
         };
 
-        // Fetch and wrap in FetchState.
-        let new_state = match fetch_node_raw(client, base_url, reference).await {
-            Ok(payload) => FetchState::Ready {
+        // TP-9: timeout covers the full fetch lifecycle at the
+        // operation boundary.
+        let fetch_result =
+            tokio::time::timeout(timeout, fetch_node_raw(client, base_url, reference)).await;
+        let new_state = match fetch_result {
+            Err(_) => FetchState::Error {
+                stamp,
+                msg: format!("request timed out after {}s", timeout.as_secs()),
+            },
+            Ok(Ok(payload)) => FetchState::Ready {
                 stamp,
                 generation: refresh_gen,
                 value: payload,
             },
-            Err(e) => FetchState::Error { stamp, msg: e },
+            Ok(Err(e)) => FetchState::Error { stamp, msg: e },
         };
 
         // Join into cache.
@@ -172,6 +180,9 @@ pub(crate) async fn fetch_with_join(
 /// Free-function form of `App::fetch_node` so callers that hold
 /// partial borrows of `App` can avoid borrowing all of `&self`.
 /// The `NodeRef` is converted to its string form for the URL path.
+/// Pure fetch+parse helper. No timeout policy — callers own timeout
+/// semantics via `tokio::time::timeout` at the operation boundary
+/// (TP-9).
 pub(crate) async fn fetch_node_raw(
     client: &reqwest::Client,
     base_url: &str,
@@ -231,6 +242,7 @@ pub(crate) fn build_tree_node<'a>(
     failed_keys: &'a HashSet<(NodeRef, usize)>,
     refresh_gen: u64,
     seq_counter: &'a mut u64,
+    timeout: std::time::Duration,
 ) -> Pin<Box<dyn Future<Output = Option<TreeNode>> + Send + 'a>> {
     Box::pin(async move {
         // Depth guard.
@@ -254,6 +266,7 @@ pub(crate) fn build_tree_node<'a>(
             refresh_gen,
             seq_counter,
             false,
+            timeout,
         )
         .await;
 
@@ -365,6 +378,7 @@ pub(crate) fn build_tree_node<'a>(
                             failed_keys,
                             refresh_gen,
                             seq_counter,
+                            timeout,
                         )
                         .await
                         {
@@ -438,6 +452,7 @@ pub(crate) fn build_tree_node<'a>(
                         failed_keys,
                         refresh_gen,
                         seq_counter,
+                        timeout,
                     )
                     .await
                     {

--- a/hyperactor_mesh_admin_tui/src/lib.rs
+++ b/hyperactor_mesh_admin_tui/src/lib.rs
@@ -177,6 +177,7 @@ mod model;
 mod overlay;
 mod render;
 mod theme;
+pub(crate) mod timeouts;
 mod tree;
 
 #[cfg(test)]
@@ -259,20 +260,25 @@ fn restore_terminal(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>) -> io
     Ok(())
 }
 
-async fn run_diagnose(client: reqwest::Client, base_url: String) -> io::Result<()> {
+async fn run_diagnose(
+    client: reqwest::Client,
+    base_url: String,
+    policy: timeouts::TuiTimeoutPolicy,
+) -> io::Result<()> {
     use crate::diagnostics::DiagSummary;
     use crate::diagnostics::run_diagnostics;
 
-    const GLOBAL_TIMEOUT_SECS: u64 = 120;
-
-    let mut rx = run_diagnostics(client, base_url);
+    let mut rx = run_diagnostics(client, base_url, &policy);
     let mut results = Vec::new();
 
-    let timed_out = tokio::time::timeout(Duration::from_secs(GLOBAL_TIMEOUT_SECS), async {
-        while let Some(r) = rx.recv().await {
-            results.push(r);
-        }
-    })
+    let timed_out = tokio::time::timeout(
+        policy.workflow_timeout(timeouts::WorkflowOp::DiagnosticsRun),
+        async {
+            while let Some(r) = rx.recv().await {
+                results.push(r);
+            }
+        },
+    )
     .await
     .is_err();
 
@@ -308,10 +314,11 @@ async fn run_diagnose(client: reqwest::Client, base_url: String) -> io::Result<(
 /// Run the mesh admin TUI. Does not return until the user exits
 /// or diagnostics complete.
 pub async fn run(config: TuiConfig) -> io::Result<()> {
-    let (base_url, client) = client::build_client(&config);
+    let policy = timeouts::TuiTimeoutPolicy::from_config(&config);
+    let (base_url, client) = client::build_client(&config, &policy);
 
     if config.diagnose {
-        return run_diagnose(client, base_url).await;
+        return run_diagnose(client, base_url, policy).await;
     }
 
     if !io::stdout().is_terminal() {
@@ -319,7 +326,7 @@ pub async fn run(config: TuiConfig) -> io::Result<()> {
         return Ok(());
     }
 
-    let mut app = App::new(base_url, client, config.theme, config.lang);
+    let mut app = App::new(base_url, client, config.theme, config.lang, policy);
     let spinner = ProgressBar::new_spinner();
     spinner.set_style(
         ProgressStyle::default_spinner()
@@ -340,7 +347,7 @@ pub async fn run(config: TuiConfig) -> io::Result<()> {
     spinner.finish_and_clear();
 
     let mut terminal = setup_terminal()?;
-    let result = run_app(&mut terminal, config.refresh_ms, app).await;
+    let result = run_app(&mut terminal, app).await;
     restore_terminal(&mut terminal)?;
     result
 }

--- a/hyperactor_mesh_admin_tui/src/lib.rs
+++ b/hyperactor_mesh_admin_tui/src/lib.rs
@@ -315,7 +315,7 @@ async fn run_diagnose(
 /// or diagnostics complete.
 pub async fn run(config: TuiConfig) -> io::Result<()> {
     let policy = timeouts::TuiTimeoutPolicy::from_config(&config);
-    let (base_url, client) = client::build_client(&config, &policy);
+    let (base_url, client) = client::build_client(&config);
 
     if config.diagnose {
         return run_diagnose(client, base_url, policy).await;

--- a/hyperactor_mesh_admin_tui/src/tests/mod.rs
+++ b/hyperactor_mesh_admin_tui/src/tests/mod.rs
@@ -23,6 +23,22 @@ use super::*;
 use crate::diagnostics::DiagOutcome;
 use crate::diagnostics::DiagPhase;
 use crate::diagnostics::DiagResult;
+use crate::timeouts::TuiTimeoutPolicy;
+
+/// Test-only convenience policy with current production defaults.
+/// Not a `Default` impl — forces production code through `from_config`.
+fn test_policy() -> TuiTimeoutPolicy {
+    TuiTimeoutPolicy::from_config(&TuiConfig {
+        addr: "localhost:1729".to_string(),
+        refresh_ms: 2000,
+        theme: ThemeName::Nord,
+        lang: LangName::En,
+        tls_ca: None,
+        tls_cert: None,
+        tls_key: None,
+        diagnose: false,
+    })
+}
 
 fn root() -> NodeRef {
     NodeRef::Root
@@ -51,6 +67,7 @@ fn empty_tree_all_operations_are_noops() {
         reqwest::Client::new(),
         ThemeName::Nord,
         LangName::En,
+        test_policy(),
     );
     let rows = app.visible_rows();
     assert_eq!(rows.len(), 0);
@@ -1467,6 +1484,7 @@ fn make_app_with_cursor(children: Vec<TreeNode>, cursor_pos: usize) -> App {
         reqwest::Client::new(),
         ThemeName::Nord,
         LangName::En,
+        test_policy(),
     );
     let len = children.len();
     app.set_tree(Some(TreeNode {
@@ -1864,6 +1882,7 @@ fn set_job_establishes_overlay() {
         reqwest::Client::new(),
         ThemeName::Nord,
         LangName::En,
+        test_policy(),
     );
     assert!(app.active_job.is_none());
     assert!(app.overlay.is_none());
@@ -1885,6 +1904,7 @@ fn dismiss_job_clears_both() {
         reqwest::Client::new(),
         ThemeName::Nord,
         LangName::En,
+        test_policy(),
     );
     app.set_job(ActiveJob::Diagnostics {
         results: Vec::new(),
@@ -2336,6 +2356,7 @@ fn on_key_config_on_root() {
         reqwest::Client::new(),
         ThemeName::Nord,
         LangName::En,
+        test_policy(),
     );
     let key = KeyEvent::new(KeyCode::Char('C'), KeyModifiers::SHIFT);
     let result = app.on_key(key);

--- a/hyperactor_mesh_admin_tui/src/tests/mod.rs
+++ b/hyperactor_mesh_admin_tui/src/tests/mod.rs
@@ -2389,3 +2389,122 @@ fn on_key_config_on_host() {
         "C on Host should be None, got: {result:?}"
     );
 }
+
+// ── TP-10: refresh_policy_for_job mapping ─────────────────────────
+
+use crate::app::refresh_policy_for_job;
+use crate::timeouts::RefreshPolicy;
+
+// TP-10: no job → Baseline.
+#[test]
+fn refresh_policy_no_job() {
+    assert_eq!(refresh_policy_for_job(&None), RefreshPolicy::Baseline);
+}
+
+// TP-10: diagnostics → Suspend.
+#[test]
+fn refresh_policy_diagnostics() {
+    let job = Some(ActiveJob::Diagnostics {
+        results: vec![],
+        running: true,
+        rx: None,
+        completed_at: None,
+    });
+    assert_eq!(refresh_policy_for_job(&job), RefreshPolicy::Suspend);
+}
+
+// TP-10: py-spy in flight → Suspend.
+#[test]
+fn refresh_policy_pyspy_in_flight() {
+    let (_tx, rx) = tokio::sync::oneshot::channel::<Vec<ratatui::text::Line<'static>>>();
+    let job = Some(ActiveJob::PySpy {
+        rx: Some(rx),
+        short: "w".to_string(),
+        lines: vec![],
+        completed_at: None,
+    });
+    assert_eq!(refresh_policy_for_job(&job), RefreshPolicy::Suspend);
+}
+
+// TP-10: py-spy completed → Baseline (refresh resumes).
+#[test]
+fn refresh_policy_pyspy_completed() {
+    let job = Some(ActiveJob::PySpy {
+        rx: None,
+        short: "w".to_string(),
+        lines: vec![],
+        completed_at: Some("14:30:00".to_string()),
+    });
+    assert_eq!(refresh_policy_for_job(&job), RefreshPolicy::Baseline);
+}
+
+// TP-10: config in flight → Suspend.
+#[test]
+fn refresh_policy_config_in_flight() {
+    let (_tx, rx) = tokio::sync::oneshot::channel::<Vec<ratatui::text::Line<'static>>>();
+    let job = Some(ActiveJob::Config {
+        rx: Some(rx),
+        short: "w".to_string(),
+        lines: vec![],
+        completed_at: None,
+    });
+    assert_eq!(refresh_policy_for_job(&job), RefreshPolicy::Suspend);
+}
+
+// TP-10: config completed → Baseline (refresh resumes).
+#[test]
+fn refresh_policy_config_completed() {
+    let job = Some(ActiveJob::Config {
+        rx: None,
+        short: "w".to_string(),
+        lines: vec![],
+        completed_at: Some("14:30:00".to_string()),
+    });
+    assert_eq!(refresh_policy_for_job(&job), RefreshPolicy::Baseline);
+}
+
+// TP-10: diagnostics completed → Baseline (refresh resumes).
+#[test]
+fn refresh_policy_diagnostics_completed() {
+    let job = Some(ActiveJob::Diagnostics {
+        results: vec![],
+        running: false,
+        rx: None,
+        completed_at: Some("14:30:00".to_string()),
+    });
+    assert_eq!(refresh_policy_for_job(&job), RefreshPolicy::Baseline);
+}
+
+// TP-10: policy state transitions through set_job / dismiss_job.
+#[test]
+fn refresh_policy_transitions_with_job_lifecycle() {
+    let mut app = App::new(
+        "http://localhost:8080".to_string(),
+        reqwest::Client::new(),
+        ThemeName::Nord,
+        LangName::En,
+        test_policy(),
+    );
+    // No job → Baseline (refresh allowed).
+    assert_eq!(
+        refresh_policy_for_job(&app.active_job),
+        RefreshPolicy::Baseline,
+    );
+    // Set a foreground job → Suspend (refresh suppressed).
+    app.set_job(ActiveJob::Diagnostics {
+        results: Vec::new(),
+        running: true,
+        rx: None,
+        completed_at: None,
+    });
+    assert_eq!(
+        refresh_policy_for_job(&app.active_job),
+        RefreshPolicy::Suspend,
+    );
+    // Dismiss the job → Baseline again.
+    app.dismiss_job();
+    assert_eq!(
+        refresh_policy_for_job(&app.active_job),
+        RefreshPolicy::Baseline,
+    );
+}

--- a/hyperactor_mesh_admin_tui/src/timeouts.rs
+++ b/hyperactor_mesh_admin_tui/src/timeouts.rs
@@ -1,0 +1,285 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+//! Central timeout policy for the mesh admin TUI.
+//!
+//! # Timeout policy invariants (TP-*)
+//!
+//! - **TP-1:** Every networked TUI operation has a named policy
+//!   entry.
+//! - **TP-2:** Refresh cadence and request timeout are distinct
+//!   concepts.
+//! - **TP-3:** Phase 1 preserves all effective timeout values
+//!   exactly.
+//! - **TP-4:** Diagnostics thresholds are policy-backed, not
+//!   file-local.
+//! - **TP-5:** Phase 1 records timeout policy at operation
+//!   boundaries, even where enforcement still flows through the
+//!   shared client timeout.
+//! - **TP-6:** `TuiTimeoutPolicy::from_config` preserves current
+//!   effective values in Phase 1.
+//! - **TP-7:** `shared_client_timeout()` is derived only from
+//!   `RequestOp`. `ProbeOp` and `WorkflowOp` never contaminate the
+//!   client timeout. `build_client()` sources its timeout exclusively
+//!   from `TuiTimeoutPolicy`, not directly from mesh-admin config
+//!   attrs.
+//! - **TP-8:** Diagnostics uses only policy-provided thresholds and
+//!   budgets.
+
+use std::time::Duration;
+
+use crate::TuiConfig;
+
+/// Request-level operations. Only these participate in
+/// [`TuiTimeoutPolicy::shared_client_timeout`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum RequestOp {
+    /// Topology refresh, node detail, expand.
+    InteractiveFetch,
+    /// `GET /v1/config/{proc_reference}`.
+    ConfigDump,
+    /// `GET /v1/pyspy/{proc_reference}`.
+    PySpyDump,
+}
+
+/// All [`RequestOp`] variants, for iteration in laws and
+/// `shared_client_timeout`.
+pub(crate) const ALL_REQUEST_OPS: &[RequestOp] = &[
+    RequestOp::InteractiveFetch,
+    RequestOp::ConfigDump,
+    RequestOp::PySpyDump,
+];
+
+/// Per-probe budgets, applied via `tokio::time::timeout` inside the
+/// probe function.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ProbeOp {
+    /// Individual diagnostics health check.
+    DiagnosticsProbe,
+}
+
+/// Whole-job ceilings, applied via `tokio::time::timeout` around the
+/// entire job.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum WorkflowOp {
+    /// Full diagnostic suite ceiling.
+    DiagnosticsRun,
+}
+
+/// Central timeout policy for the TUI. Every timing decision flows
+/// through this struct.
+///
+/// `Copy + Clone` — pass by value at top-level, borrow internally. No
+/// `Default` impl; callers must go through `from_config`.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct TuiTimeoutPolicy {
+    /// Base refresh cadence from `--refresh-ms`.
+    /// Separation law: not used in any timeout accessor.
+    pub refresh_interval: Duration,
+    /// Latency classification threshold for successful diagnostics
+    /// probes: below this is `Pass`, at or above this is `Slow`.
+    /// This is not a timeout budget and does not cancel the probe.
+    pub diagnostics_probe_slow: Duration,
+    // Private fields; accessed via typed accessors.
+    interactive_fetch: Duration,
+    config_dump: Duration,
+    pyspy_dump: Duration,
+    diagnostics_probe: Duration,
+    diagnostics_run: Duration,
+}
+
+impl TuiTimeoutPolicy {
+    /// Construct timeout policy from TUI config plus selected global
+    /// mesh-admin config attrs.
+    ///
+    /// `refresh_interval` comes from `TuiConfig.refresh_ms`.
+    ///
+    /// Phase 1 intentionally preserves the current request-timeout
+    /// bug: interactive fetches, config dumps, and py-spy requests
+    /// all inherit the shared `MESH_ADMIN_PYSPY_CLIENT_TIMEOUT`
+    /// budget. Phase 2 splits these into operation-specific request
+    /// budgets.
+    ///
+    /// Diagnostics budgets preserve the existing effective values
+    /// from the pre-policy implementation.
+    pub fn from_config(config: &TuiConfig) -> Self {
+        let request_budget = hyperactor_config::global::get(
+            hyperactor_mesh::config::MESH_ADMIN_PYSPY_CLIENT_TIMEOUT,
+        );
+        Self {
+            refresh_interval: Duration::from_millis(config.refresh_ms),
+            diagnostics_probe_slow: Duration::from_millis(500),
+            interactive_fetch: request_budget,
+            config_dump: request_budget,
+            pyspy_dump: request_budget,
+            diagnostics_probe: Duration::from_secs(5),
+            diagnostics_run: Duration::from_secs(120),
+        }
+    }
+
+    /// Per-request timeout for an HTTP-backed operation.
+    pub fn request_timeout(&self, op: RequestOp) -> Duration {
+        match op {
+            RequestOp::InteractiveFetch => self.interactive_fetch,
+            RequestOp::ConfigDump => self.config_dump,
+            RequestOp::PySpyDump => self.pyspy_dump,
+        }
+    }
+
+    /// Per-probe timeout for a diagnostic probe.
+    pub fn probe_timeout(&self, op: ProbeOp) -> Duration {
+        match op {
+            ProbeOp::DiagnosticsProbe => self.diagnostics_probe,
+        }
+    }
+
+    /// Whole-job ceiling for a workflow operation.
+    pub fn workflow_timeout(&self, op: WorkflowOp) -> Duration {
+        match op {
+            WorkflowOp::DiagnosticsRun => self.diagnostics_run,
+        }
+    }
+
+    /// Phase 1 compatibility shim: the shared `reqwest::Client`
+    /// timeout, derived from request ops only so probe/workflow
+    /// ceilings do not contaminate it (TP-7).
+    ///
+    /// Phase 2 is expected to eliminate or demote this by enforcing
+    /// operation-specific request budgets at the call boundary
+    /// instead of relying on one shared client timeout.
+    pub fn shared_client_timeout(&self) -> Duration {
+        ALL_REQUEST_OPS
+            .iter()
+            .map(|op| self.request_timeout(*op))
+            .max()
+            .unwrap()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn default_config() -> TuiConfig {
+        TuiConfig {
+            addr: "localhost:1729".to_string(),
+            refresh_ms: 2000,
+            theme: crate::ThemeName::Nord,
+            lang: crate::theme::LangName::En,
+            tls_ca: None,
+            tls_cert: None,
+            tls_key: None,
+            diagnose: false,
+        }
+    }
+
+    // TP-3/TP-6: extensional preservation — each accessor returns
+    // today's effective timeout.
+    #[test]
+    fn from_config_preserves_request_timeouts() {
+        let policy = TuiTimeoutPolicy::from_config(&default_config());
+        let expected = hyperactor_config::global::get(
+            hyperactor_mesh::config::MESH_ADMIN_PYSPY_CLIENT_TIMEOUT,
+        );
+        assert_eq!(
+            policy.request_timeout(RequestOp::InteractiveFetch),
+            expected
+        );
+        assert_eq!(policy.request_timeout(RequestOp::ConfigDump), expected);
+        assert_eq!(policy.request_timeout(RequestOp::PySpyDump), expected);
+    }
+
+    // TP-3/TP-6: extensional preservation — probe budget.
+    #[test]
+    fn from_config_preserves_probe_timeout() {
+        let policy = TuiTimeoutPolicy::from_config(&default_config());
+        assert_eq!(
+            policy.probe_timeout(ProbeOp::DiagnosticsProbe),
+            Duration::from_secs(5),
+        );
+    }
+
+    // TP-3/TP-6: extensional preservation — workflow ceiling.
+    #[test]
+    fn from_config_preserves_workflow_timeout() {
+        let policy = TuiTimeoutPolicy::from_config(&default_config());
+        assert_eq!(
+            policy.workflow_timeout(WorkflowOp::DiagnosticsRun),
+            Duration::from_secs(120),
+        );
+    }
+
+    // TP-3/TP-6: extensional preservation — slow classification threshold.
+    #[test]
+    fn from_config_preserves_slow_threshold() {
+        let policy = TuiTimeoutPolicy::from_config(&default_config());
+        assert_eq!(policy.diagnostics_probe_slow, Duration::from_millis(500));
+    }
+
+    // TP-7: client law — shared_client_timeout derived only from
+    // RequestOp, never from ProbeOp or WorkflowOp.
+    #[test]
+    fn shared_client_timeout_ge_all_request_ops() {
+        let policy = TuiTimeoutPolicy::from_config(&default_config());
+        let client_t = policy.shared_client_timeout();
+        for op in ALL_REQUEST_OPS {
+            assert!(client_t >= policy.request_timeout(*op));
+        }
+    }
+
+    // TP-7: workflow ceilings do not contaminate client timeout.
+    #[test]
+    fn shared_client_timeout_does_not_include_workflow() {
+        let policy = TuiTimeoutPolicy::from_config(&default_config());
+        let expected_request_budget = hyperactor_config::global::get(
+            hyperactor_mesh::config::MESH_ADMIN_PYSPY_CLIENT_TIMEOUT,
+        );
+        assert_eq!(policy.shared_client_timeout(), expected_request_budget);
+        assert_eq!(
+            policy.workflow_timeout(WorkflowOp::DiagnosticsRun),
+            Duration::from_secs(120),
+        );
+        assert_ne!(
+            policy.shared_client_timeout(),
+            policy.workflow_timeout(WorkflowOp::DiagnosticsRun),
+        );
+    }
+
+    // TP-2: separation law — refresh_interval is independent of
+    // request timeouts.
+    #[test]
+    fn refresh_interval_independent_of_timeouts() {
+        let mut config = default_config();
+        config.refresh_ms = 500;
+        let policy = TuiTimeoutPolicy::from_config(&config);
+        assert_eq!(policy.refresh_interval, Duration::from_millis(500));
+        // All timeout accessors unchanged.
+        let default_policy = TuiTimeoutPolicy::from_config(&default_config());
+        for op in ALL_REQUEST_OPS {
+            assert_eq!(
+                policy.request_timeout(*op),
+                default_policy.request_timeout(*op),
+            );
+        }
+        assert_eq!(
+            policy.probe_timeout(ProbeOp::DiagnosticsProbe),
+            default_policy.probe_timeout(ProbeOp::DiagnosticsProbe),
+        );
+        assert_eq!(
+            policy.workflow_timeout(WorkflowOp::DiagnosticsRun),
+            default_policy.workflow_timeout(WorkflowOp::DiagnosticsRun),
+        );
+    }
+
+    // TP-2: default cadence from --refresh-ms.
+    #[test]
+    fn refresh_interval_default_cadence() {
+        let policy = TuiTimeoutPolicy::from_config(&default_config());
+        assert_eq!(policy.refresh_interval, Duration::from_secs(2));
+    }
+}

--- a/hyperactor_mesh_admin_tui/src/timeouts.rs
+++ b/hyperactor_mesh_admin_tui/src/timeouts.rs
@@ -18,25 +18,23 @@
 //!   exactly.
 //! - **TP-4:** Diagnostics thresholds are policy-backed, not
 //!   file-local.
-//! - **TP-5:** Phase 1 records timeout policy at operation
-//!   boundaries, even where enforcement still flows through the
-//!   shared client timeout.
-//! - **TP-6:** `TuiTimeoutPolicy::from_config` preserves current
-//!   effective values in Phase 1.
-//! - **TP-7:** `shared_client_timeout()` is derived only from
-//!   `RequestOp`. `ProbeOp` and `WorkflowOp` never contaminate the
-//!   client timeout. `build_client()` sources its timeout exclusively
-//!   from `TuiTimeoutPolicy`, not directly from mesh-admin config
-//!   attrs.
+//! - **TP-5:** Timeout policy is recorded at operation boundaries.
+//! - **TP-6:** `TuiTimeoutPolicy::from_config` produces
+//!   operation-specific request budgets.
+//! - **TP-7:** No client-level timeout. The `reqwest::Client` is
+//!   built without `.timeout()`. All timeout enforcement is
+//!   per-operation via `tokio::time::timeout` at the call boundary.
 //! - **TP-8:** Diagnostics uses only policy-provided thresholds and
 //!   budgets.
+//! - **TP-9:** Each request operation enforces its own budget via
+//!   `tokio::time::timeout` at the operation boundary.
 
 use std::time::Duration;
 
 use crate::TuiConfig;
 
-/// Request-level operations. Only these participate in
-/// [`TuiTimeoutPolicy::shared_client_timeout`].
+/// Request-level operations. Each has a per-operation timeout
+/// enforced via `tokio::time::timeout` at the call boundary (TP-9).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum RequestOp {
     /// Topology refresh, node detail, expand.
@@ -47,8 +45,7 @@ pub(crate) enum RequestOp {
     PySpyDump,
 }
 
-/// All [`RequestOp`] variants, for iteration in laws and
-/// `shared_client_timeout`.
+/// All [`RequestOp`] variants, for iteration in law-based tests.
 pub(crate) const ALL_REQUEST_OPS: &[RequestOp] = &[
     RequestOp::InteractiveFetch,
     RequestOp::ConfigDump,
@@ -99,24 +96,21 @@ impl TuiTimeoutPolicy {
     ///
     /// `refresh_interval` comes from `TuiConfig.refresh_ms`.
     ///
-    /// Phase 1 intentionally preserves the current request-timeout
-    /// bug: interactive fetches, config dumps, and py-spy requests
-    /// all inherit the shared `MESH_ADMIN_PYSPY_CLIENT_TIMEOUT`
-    /// budget. Phase 2 splits these into operation-specific request
-    /// budgets.
+    /// Request budgets are operation-specific (TP-9). There is no
+    /// shared client-level timeout; all enforcement is per-operation
+    /// via `tokio::time::timeout` at the call boundary (TP-7).
     ///
     /// Diagnostics budgets preserve the existing effective values
     /// from the pre-policy implementation.
     pub fn from_config(config: &TuiConfig) -> Self {
-        let request_budget = hyperactor_config::global::get(
-            hyperactor_mesh::config::MESH_ADMIN_PYSPY_CLIENT_TIMEOUT,
-        );
         Self {
             refresh_interval: Duration::from_millis(config.refresh_ms),
             diagnostics_probe_slow: Duration::from_millis(500),
-            interactive_fetch: request_budget,
-            config_dump: request_budget,
-            pyspy_dump: request_budget,
+            interactive_fetch: Duration::from_secs(5),
+            config_dump: Duration::from_secs(8),
+            pyspy_dump: hyperactor_config::global::get(
+                hyperactor_mesh::config::MESH_ADMIN_PYSPY_CLIENT_TIMEOUT,
+            ),
             diagnostics_probe: Duration::from_secs(5),
             diagnostics_run: Duration::from_secs(120),
         }
@@ -144,21 +138,6 @@ impl TuiTimeoutPolicy {
             WorkflowOp::DiagnosticsRun => self.diagnostics_run,
         }
     }
-
-    /// Phase 1 compatibility shim: the shared `reqwest::Client`
-    /// timeout, derived from request ops only so probe/workflow
-    /// ceilings do not contaminate it (TP-7).
-    ///
-    /// Phase 2 is expected to eliminate or demote this by enforcing
-    /// operation-specific request budgets at the call boundary
-    /// instead of relying on one shared client timeout.
-    pub fn shared_client_timeout(&self) -> Duration {
-        ALL_REQUEST_OPS
-            .iter()
-            .map(|op| self.request_timeout(*op))
-            .max()
-            .unwrap()
-    }
 }
 
 #[cfg(test)]
@@ -178,23 +157,37 @@ mod tests {
         }
     }
 
-    // TP-3/TP-6: extensional preservation — each accessor returns
-    // today's effective timeout.
+    // TP-6/TP-9: per-operation request budgets.
     #[test]
-    fn from_config_preserves_request_timeouts() {
+    fn from_config_request_budget_interactive_fetch() {
+        let policy = TuiTimeoutPolicy::from_config(&default_config());
+        assert_eq!(
+            policy.request_timeout(RequestOp::InteractiveFetch),
+            Duration::from_secs(5),
+        );
+    }
+
+    // TP-6/TP-9: config dump budget.
+    #[test]
+    fn from_config_request_budget_config_dump() {
+        let policy = TuiTimeoutPolicy::from_config(&default_config());
+        assert_eq!(
+            policy.request_timeout(RequestOp::ConfigDump),
+            Duration::from_secs(8),
+        );
+    }
+
+    // TP-6/TP-9: py-spy budget preserves MESH_ADMIN_PYSPY_CLIENT_TIMEOUT.
+    #[test]
+    fn from_config_request_budget_pyspy_dump() {
         let policy = TuiTimeoutPolicy::from_config(&default_config());
         let expected = hyperactor_config::global::get(
             hyperactor_mesh::config::MESH_ADMIN_PYSPY_CLIENT_TIMEOUT,
         );
-        assert_eq!(
-            policy.request_timeout(RequestOp::InteractiveFetch),
-            expected
-        );
-        assert_eq!(policy.request_timeout(RequestOp::ConfigDump), expected);
         assert_eq!(policy.request_timeout(RequestOp::PySpyDump), expected);
     }
 
-    // TP-3/TP-6: extensional preservation — probe budget.
+    // TP-6: probe budget.
     #[test]
     fn from_config_preserves_probe_timeout() {
         let policy = TuiTimeoutPolicy::from_config(&default_config());
@@ -204,7 +197,7 @@ mod tests {
         );
     }
 
-    // TP-3/TP-6: extensional preservation — workflow ceiling.
+    // TP-6: workflow ceiling.
     #[test]
     fn from_config_preserves_workflow_timeout() {
         let policy = TuiTimeoutPolicy::from_config(&default_config());
@@ -214,40 +207,11 @@ mod tests {
         );
     }
 
-    // TP-3/TP-6: extensional preservation — slow classification threshold.
+    // TP-6: slow classification threshold.
     #[test]
     fn from_config_preserves_slow_threshold() {
         let policy = TuiTimeoutPolicy::from_config(&default_config());
         assert_eq!(policy.diagnostics_probe_slow, Duration::from_millis(500));
-    }
-
-    // TP-7: client law — shared_client_timeout derived only from
-    // RequestOp, never from ProbeOp or WorkflowOp.
-    #[test]
-    fn shared_client_timeout_ge_all_request_ops() {
-        let policy = TuiTimeoutPolicy::from_config(&default_config());
-        let client_t = policy.shared_client_timeout();
-        for op in ALL_REQUEST_OPS {
-            assert!(client_t >= policy.request_timeout(*op));
-        }
-    }
-
-    // TP-7: workflow ceilings do not contaminate client timeout.
-    #[test]
-    fn shared_client_timeout_does_not_include_workflow() {
-        let policy = TuiTimeoutPolicy::from_config(&default_config());
-        let expected_request_budget = hyperactor_config::global::get(
-            hyperactor_mesh::config::MESH_ADMIN_PYSPY_CLIENT_TIMEOUT,
-        );
-        assert_eq!(policy.shared_client_timeout(), expected_request_budget);
-        assert_eq!(
-            policy.workflow_timeout(WorkflowOp::DiagnosticsRun),
-            Duration::from_secs(120),
-        );
-        assert_ne!(
-            policy.shared_client_timeout(),
-            policy.workflow_timeout(WorkflowOp::DiagnosticsRun),
-        );
     }
 
     // TP-2: separation law — refresh_interval is independent of

--- a/hyperactor_mesh_admin_tui/src/timeouts.rs
+++ b/hyperactor_mesh_admin_tui/src/timeouts.rs
@@ -14,8 +14,6 @@
 //!   entry.
 //! - **TP-2:** Refresh cadence and request timeout are distinct
 //!   concepts.
-//! - **TP-3:** Phase 1 preserves all effective timeout values
-//!   exactly.
 //! - **TP-4:** Diagnostics thresholds are policy-backed, not
 //!   file-local.
 //! - **TP-5:** Timeout policy is recorded at operation boundaries.
@@ -28,6 +26,10 @@
 //!   budgets.
 //! - **TP-9:** Each request operation enforces its own budget via
 //!   `tokio::time::timeout` at the operation boundary.
+//! - **TP-10:** The effective refresh policy is derived from active
+//!   job state. `RefreshPolicy` implements `JoinSemilattice` so
+//!   multiple sources can be combined when added. Background refresh
+//!   is suspended while a foreground operation is in flight.
 
 use std::time::Duration;
 
@@ -140,6 +142,36 @@ impl TuiTimeoutPolicy {
     }
 }
 
+/// Refresh interaction policy for background topology updates.
+///
+/// Phase 3a implements the minimal carrier:
+/// `Baseline < Suspend`.
+///
+/// The policy is a join-semilattice so refresh constraints can be
+/// combined compositionally rather than encoded as ad hoc event-loop
+/// conditionals. In this first version, foreground jobs contribute
+/// either `Baseline` or `Suspend`. Later phases may add additional
+/// sources or richer policies such as `Degrade(...)` without changing
+/// the combination model.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) enum RefreshPolicy {
+    /// Run at the user-configured refresh cadence.
+    Baseline,
+    /// Do not schedule background refresh.
+    Suspend,
+}
+
+impl algebra::JoinSemilattice for RefreshPolicy {
+    /// Join chooses the more restrictive refresh policy.
+    ///
+    /// This is intentionally defined in algebraic form so that future
+    /// extensions can combine multiple refresh-pressure sources by join
+    /// rather than bespoke branching.
+    fn join(&self, other: &Self) -> Self {
+        std::cmp::max(*self, *other)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -245,5 +277,43 @@ mod tests {
     fn refresh_interval_default_cadence() {
         let policy = TuiTimeoutPolicy::from_config(&default_config());
         assert_eq!(policy.refresh_interval, Duration::from_secs(2));
+    }
+
+    // TP-10: RefreshPolicy semilattice laws. Intentionally minimal
+    // because the carrier is intentionally minimal in Phase 3a.
+    // Extend when the carrier grows.
+
+    use algebra::JoinSemilattice;
+
+    #[test]
+    fn refresh_policy_join_baseline_suspend() {
+        assert_eq!(
+            RefreshPolicy::Baseline.join(&RefreshPolicy::Suspend),
+            RefreshPolicy::Suspend,
+        );
+    }
+
+    #[test]
+    fn refresh_policy_join_baseline_baseline() {
+        assert_eq!(
+            RefreshPolicy::Baseline.join(&RefreshPolicy::Baseline),
+            RefreshPolicy::Baseline,
+        );
+    }
+
+    #[test]
+    fn refresh_policy_join_suspend_baseline() {
+        assert_eq!(
+            RefreshPolicy::Suspend.join(&RefreshPolicy::Baseline),
+            RefreshPolicy::Suspend,
+        );
+    }
+
+    #[test]
+    fn refresh_policy_join_suspend_suspend() {
+        assert_eq!(
+            RefreshPolicy::Suspend.join(&RefreshPolicy::Suspend),
+            RefreshPolicy::Suspend,
+        );
     }
 }

--- a/monarch_extension/Cargo.toml
+++ b/monarch_extension/Cargo.toml
@@ -27,12 +27,14 @@ libc = "0.2.183"
 monarch_cpp_static_libs = { path = "../monarch_cpp_static_libs", optional = true }
 monarch_distributed_telemetry = { version = "0.0.0", path = "../monarch_distributed_telemetry", optional = true }
 monarch_hyperactor = { version = "0.0.0", path = "../monarch_hyperactor" }
+monarch_introspection_snapshot = { version = "0.0.0", path = "../monarch_introspection_snapshot", optional = true }
 monarch_messages = { version = "0.0.0", path = "../monarch_messages", optional = true }
 monarch_rdma_extension = { version = "0.0.0", path = "../monarch_rdma/extension", optional = true }
 monarch_tensor_worker = { version = "0.0.0", path = "../monarch_tensor_worker", optional = true }
 nccl-sys = { path = "../nccl-sys", optional = true }
 ndslice = { version = "0.0.0", path = "../ndslice" }
 pyo3 = { version = "0.26", features = ["anyhow", "multiple-pymethods", "py-clone"] }
+pyo3-async-runtimes = { version = "0.26", features = ["attributes", "tokio-runtime"] }
 rdmaxcel-sys = { path = "../rdmaxcel-sys", optional = true }
 rustls = "0.23.37"
 rustls-pemfile = "2.2.0"
@@ -49,6 +51,6 @@ monarch_cpp_static_libs = { path = "../monarch_cpp_static_libs", optional = true
 
 [features]
 default = ["tensor_engine"]
-distributed_sql_telemetry = ["dep:monarch_distributed_telemetry"]
+distributed_sql_telemetry = ["dep:monarch_distributed_telemetry", "dep:monarch_introspection_snapshot"]
 extension-module = ["pyo3/extension-module"]
 tensor_engine = ["dep:monarch_cpp_static_libs", "dep:monarch_messages", "dep:monarch_rdma_extension", "dep:monarch_tensor_worker", "dep:nccl-sys", "dep:rdmaxcel-sys", "dep:torch-sys-cuda"]

--- a/monarch_extension/src/lib.rs
+++ b/monarch_extension/src/lib.rs
@@ -25,6 +25,8 @@ mod chunked_fuse;
 mod fast_pack;
 mod panic;
 mod readonly_fuse;
+#[cfg(feature = "distributed_sql_telemetry")]
+pub mod snapshot_integration;
 mod tls_receiver;
 mod tls_sender;
 mod trace;
@@ -282,6 +284,10 @@ pub fn mod_init(module: &Bound<'_, PyModule>) -> PyResult<()> {
         monarch_distributed_telemetry::query_engine::register_python_bindings(
             &get_or_add_new_module(module, "monarch_distributed_telemetry.query_engine")?,
         )?;
+        crate::snapshot_integration::register_python_bindings(&get_or_add_new_module(
+            module,
+            "monarch_extension.snapshot_integration",
+        )?)?;
     }
 
     #[cfg(fbcode_build)]

--- a/monarch_extension/src/snapshot_integration.rs
+++ b/monarch_extension/src/snapshot_integration.rs
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+//! pyo3 wrappers for snapshot telemetry integration.
+//!
+//! Thin wrappers around the pure Rust helpers in
+//! `monarch_introspection_snapshot::integration`. Called from Python
+//! during telemetry/admin startup.
+
+use std::time::Duration;
+
+use monarch_distributed_telemetry::database_scanner::DatabaseScanner;
+use monarch_hyperactor::context::PyInstance;
+use monarch_hyperactor::host_mesh::PyMeshAdminRef;
+use monarch_introspection_snapshot::integration::register_snapshot_schemas;
+use monarch_introspection_snapshot::integration::start_periodic_snapshots;
+use pyo3::prelude::*;
+
+/// Pre-register the 9 snapshot table schemas in a `DatabaseScanner`.
+///
+/// Must be called after `DatabaseScanner` creation and before
+/// `QueryEngine` construction, because table discovery is static.
+/// Called unconditionally whenever telemetry starts (SI-6).
+#[pyfunction]
+#[pyo3(name = "_pre_register_snapshot_schemas")]
+fn pre_register_snapshot_schemas_py(py: Python<'_>, scanner: &DatabaseScanner) -> PyResult<()> {
+    let table_store = scanner.table_store();
+    py.detach(|| {
+        pyo3_async_runtimes::tokio::get_runtime()
+            .block_on(async { register_snapshot_schemas(&table_store).await })
+            .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(format!("{:#}", e)))
+    })
+}
+
+/// Spawn periodic snapshot capture as a `SnapshotCaptureActor`.
+///
+/// Fire-and-forget: the actor is spawned on the same proc as the
+/// mesh admin. Framework lifecycle (proc teardown) stops it.
+/// Returns nothing (SI-5).
+#[pyfunction]
+#[pyo3(name = "_start_periodic_snapshots")]
+fn start_periodic_snapshots_py(
+    scanner: &DatabaseScanner,
+    admin_ref: &PyMeshAdminRef,
+    instance: &PyInstance,
+    interval_secs: f64,
+) -> PyResult<()> {
+    let table_store = scanner.table_store();
+    let admin_ref = admin_ref.actor_ref();
+
+    if interval_secs <= 0.0 || !interval_secs.is_finite() {
+        return Err(pyo3::exceptions::PyValueError::new_err(format!(
+            "interval_secs must be a positive finite number, got {}",
+            interval_secs,
+        )));
+    }
+    let interval = Duration::from_secs_f64(interval_secs);
+
+    let _guard = pyo3_async_runtimes::tokio::get_runtime().enter();
+    start_periodic_snapshots(&**instance, table_store, admin_ref, interval)
+        .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(format!("{:#}", e)))
+}
+
+pub fn register_python_bindings(module: &Bound<'_, PyModule>) -> PyResult<()> {
+    module.add_function(wrap_pyfunction!(pre_register_snapshot_schemas_py, module)?)?;
+    module.add_function(wrap_pyfunction!(start_periodic_snapshots_py, module)?)?;
+    Ok(())
+}

--- a/monarch_hyperactor/src/host_mesh.rs
+++ b/monarch_hyperactor/src/host_mesh.rs
@@ -25,6 +25,7 @@ use hyperactor_mesh::host_mesh::HostMeshRef;
 use hyperactor_mesh::host_mesh::host_agent::GetLocalProcClient;
 use hyperactor_mesh::host_mesh::host_agent::HostAgent;
 use hyperactor_mesh::host_mesh::host_agent::ShutdownHost;
+use hyperactor_mesh::mesh_admin::MeshAdminMessageClient;
 use hyperactor_mesh::proc_agent::GetProcClient;
 use hyperactor_mesh::proc_mesh::ProcRef;
 use hyperactor_mesh::shared_cell::SharedCell;
@@ -526,11 +527,27 @@ fn shutdown_local_host_mesh() -> PyResult<PyPythonTask> {
     })
 }
 
-/// Spawn a MeshAdminAgent aggregating topology across one or more meshes.
-///
-/// The admin runs on the caller's local proc and serves the
-/// mesh-admin HTTP API. Returns the admin HTTP URL. When
-/// `admin_addr` is `None`, the bind address is read from
+/// Opaque capability token for `ActorRef<MeshAdminAgent>` across the
+/// Python boundary. No methods, no getters — Python never inspects
+/// this. It exists solely to transport the typed ref from
+/// `_spawn_admin` to `_start_periodic_snapshots`.
+#[pyclass(
+    name = "PyMeshAdminRef",
+    module = "monarch._rust_bindings.monarch_hyperactor.host_mesh"
+)]
+#[derive(Clone)]
+pub struct PyMeshAdminRef(
+    hyperactor::reference::ActorRef<hyperactor_mesh::mesh_admin::MeshAdminAgent>,
+);
+
+impl PyMeshAdminRef {
+    pub fn actor_ref(
+        &self,
+    ) -> hyperactor::reference::ActorRef<hyperactor_mesh::mesh_admin::MeshAdminAgent> {
+        self.0.clone()
+    }
+}
+
 /// `MESH_ADMIN_ADDR` config.
 ///
 /// Python-facing wrapper around
@@ -560,10 +577,17 @@ fn _spawn_admin(
 
     let instance = instance.clone();
     PyPythonTask::new(async move {
-        let addr = host_mesh::spawn_admin(&mesh_refs, instance.deref(), admin_addr, telemetry_url)
+        let admin_ref =
+            host_mesh::spawn_admin(&mesh_refs, instance.deref(), admin_addr, telemetry_url)
+                .await
+                .map_err(|e| PyException::new_err(e.to_string()))?;
+        let admin_url = admin_ref
+            .get_admin_addr(instance.deref())
             .await
-            .map_err(|e| PyException::new_err(e.to_string()))?;
-        Ok(addr)
+            .map_err(|e| PyException::new_err(e.to_string()))?
+            .addr
+            .ok_or_else(|| PyException::new_err("mesh admin agent did not report an address"))?;
+        Ok((admin_url, PyMeshAdminRef(admin_ref)))
     })
 }
 
@@ -598,5 +622,6 @@ pub fn register_python_bindings(hyperactor_mod: &Bound<'_, PyModule>) -> PyResul
 
     hyperactor_mod.add_class::<PyHostMesh>()?;
     hyperactor_mod.add_class::<PyBootstrapCommand>()?;
+    hyperactor_mod.add_class::<PyMeshAdminRef>()?;
     Ok(())
 }

--- a/monarch_introspection_snapshot/Cargo.toml
+++ b/monarch_introspection_snapshot/Cargo.toml
@@ -13,21 +13,20 @@ path = "test/snapshot_integration_test.rs"
 
 [dependencies]
 anyhow = "1.0.102"
+async-trait = "0.1.86"
 datafusion = "52.4.0"
+hyperactor = { version = "0.0.0", path = "../hyperactor" }
 hyperactor_mesh = { version = "0.0.0", path = "../hyperactor_mesh" }
 monarch_distributed_telemetry = { version = "0.0.0", path = "../monarch_distributed_telemetry" }
 monarch_record_batch = { version = "0.0.0", path = "../monarch_record_batch" }
 serde = { version = "1.0.219", features = ["derive", "rc"] }
 serde_json = { version = "1.0.140", features = ["alloc", "float_roundtrip", "raw_value", "unbounded_depth"] }
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
-tokio-util = { version = "0.7.18", features = ["full"] }
 tracing = { version = "0.1.41", features = ["attributes", "valuable"] }
+typeuri = { version = "0.0.0", path = "../typeuri" }
 uuid = { version = "1.23.0", features = ["rng-getrandom", "serde", "v4", "v5", "v6", "v7", "v8"] }
+wirevalue = { version = "0.0.0", path = "../wirevalue" }
 
 [dev-dependencies]
-async-trait = "0.1.86"
-hyperactor = { version = "0.0.0", path = "../hyperactor" }
 ndslice = { version = "0.0.0", path = "../ndslice" }
 tempfile = "3.27.0"
-typeuri = { version = "0.0.0", path = "../typeuri" }
-wirevalue = { version = "0.0.0", path = "../wirevalue" }
+tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }

--- a/monarch_introspection_snapshot/src/integration.rs
+++ b/monarch_introspection_snapshot/src/integration.rs
@@ -1,0 +1,182 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+//! Integration helpers for wiring snapshot capture into the live
+//! telemetry system.
+//!
+//! - [`register_snapshot_schemas`] pre-registers empty snapshot
+//!   tables so the `QueryEngine` discovers them at setup time.
+//! - [`start_periodic_snapshots`] spawns a
+//!   [`SnapshotCaptureActor`](crate::service::SnapshotCaptureActor)
+//!   on the given proc.
+//!
+//! # Snapshot integration invariants (SI-*)
+//!
+//! - **SI-1 (snapshot tables discoverable):** After
+//!   `register_snapshot_schemas`, the 9 snapshot table names appear
+//!   in `DatabaseScanner.table_names()` and are discoverable by
+//!   `QueryEngine.setup_tables()`.
+//! - **SI-2 (snapshot tables queryable):** After periodic capture
+//!   fires, snapshot rows are queryable through the live telemetry
+//!   query path.
+//! - **SI-3 (shared storage):** The `TableStore` handle used by
+//!   `SnapshotService` shares the same underlying storage as the
+//!   `DatabaseScanner`. Snapshot ingestion is visible to telemetry
+//!   queries immediately.
+//! - **SI-4 (startup ordering):** Schema pre-registration happens
+//!   after `DatabaseScanner` creation but before `QueryEngine`
+//!   construction. Periodic snapshots start only after both telemetry
+//!   and admin are running.
+//! - **SI-5 (shutdown):** The snapshot capture actor is stopped by
+//!   framework lifecycle (proc teardown via `DrainAndStop`). The
+//!   framework guarantees the current handler runs to completion.
+//!   After stop, snapshot count stabilizes. No Python code calls stop
+//!   explicitly.
+//! - **SI-6 (unconditional schemas):** Schema pre-registration runs
+//!   whenever telemetry starts, regardless of whether periodic
+//!   capture is enabled. The query schema does not depend on config.
+//! - **SI-7 (resolver provenance):** The resolver's
+//!   `ActorRef<MeshAdminAgent>` comes directly from `spawn_admin`'s
+//!   typed return value. It crosses the Python boundary only as an
+//!   opaque capability token (`PyMeshAdminRef`). It is not
+//!   reconstructed from actor identity.
+
+use std::time::Duration;
+
+use hyperactor_mesh::mesh_admin::MeshAdminAgent;
+use monarch_distributed_telemetry::database_scanner::TableStore;
+use monarch_record_batch::RecordBatchBuffer;
+
+use crate::schema::ActorFailureRowBuffer;
+use crate::schema::ActorNodeRowBuffer;
+use crate::schema::ChildRowBuffer;
+use crate::schema::HostNodeRowBuffer;
+use crate::schema::NodeRowBuffer;
+use crate::schema::ProcNodeRowBuffer;
+use crate::schema::ResolutionErrorRowBuffer;
+use crate::schema::RootNodeRowBuffer;
+use crate::schema::SnapshotRowBuffer;
+use crate::service::CaptureSnapshot;
+use crate::service::SnapshotCaptureActor;
+
+/// Pre-register the 9 snapshot table schemas into `table_store`.
+///
+/// Each table is registered with a zero-row `RecordBatch` carrying
+/// the correct Arrow schema. This must be called before the
+/// `QueryEngine` constructs its `SessionContext`, because table
+/// discovery is static (one-shot at construction time).
+///
+/// Uses the same pattern as pyspy table pre-registration in
+/// `DatabaseScanner::new()` (`database_scanner.rs:251`).
+pub async fn register_snapshot_schemas(table_store: &TableStore) -> anyhow::Result<()> {
+    // Order matches SNAPSHOT_TABLE_NAMES (sorted).
+    let batches = [
+        (
+            "actor_failures",
+            ActorFailureRowBuffer::default().drain_to_record_batch()?,
+        ),
+        (
+            "actor_nodes",
+            ActorNodeRowBuffer::default().drain_to_record_batch()?,
+        ),
+        (
+            "children",
+            ChildRowBuffer::default().drain_to_record_batch()?,
+        ),
+        (
+            "host_nodes",
+            HostNodeRowBuffer::default().drain_to_record_batch()?,
+        ),
+        ("nodes", NodeRowBuffer::default().drain_to_record_batch()?),
+        (
+            "proc_nodes",
+            ProcNodeRowBuffer::default().drain_to_record_batch()?,
+        ),
+        (
+            "resolution_errors",
+            ResolutionErrorRowBuffer::default().drain_to_record_batch()?,
+        ),
+        (
+            "root_nodes",
+            RootNodeRowBuffer::default().drain_to_record_batch()?,
+        ),
+        (
+            "snapshots",
+            SnapshotRowBuffer::default().drain_to_record_batch()?,
+        ),
+    ];
+
+    for (name, batch) in batches {
+        table_store.ingest_batch(name, batch).await?;
+    }
+
+    Ok(())
+}
+
+/// Spawn periodic snapshot capture as a `SnapshotCaptureActor`.
+///
+/// The actor is spawned on the given proc (same proc as the mesh
+/// admin). Lifecycle is framework-managed: proc teardown stops the
+/// actor via `DrainAndStop`. Fire-and-forget — returns `()`.
+///
+/// `cx` is any actor context for sending the initial
+/// `CaptureSnapshot` message to the spawned actor.
+pub fn start_periodic_snapshots(
+    cx: &impl hyperactor::context::Actor,
+    table_store: TableStore,
+    admin_ref: hyperactor::reference::ActorRef<MeshAdminAgent>,
+    interval: Duration,
+) -> anyhow::Result<()> {
+    anyhow::ensure!(
+        !interval.is_zero(),
+        "periodic capture interval must be non-zero"
+    );
+    let proc = cx.instance().proc();
+    let actor = SnapshotCaptureActor::new(table_store, admin_ref, interval);
+    let handle = proc.spawn("snapshot_capture", actor)?;
+    // PT-3: first capture fires at spawn time.
+    handle.send(cx, CaptureSnapshot)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::push::SNAPSHOT_TABLE_NAMES;
+
+    // SI-1: register_snapshot_schemas populates a TableStore with 9
+    // table names matching SNAPSHOT_TABLE_NAMES.
+    #[tokio::test]
+    async fn test_register_snapshot_schemas() {
+        let store = TableStore::new_empty();
+        register_snapshot_schemas(&store).await.unwrap();
+
+        let names = store.table_names().unwrap();
+        assert_eq!(names.len(), 9);
+
+        let expected: Vec<String> = SNAPSHOT_TABLE_NAMES.iter().map(|s| s.to_string()).collect();
+        assert_eq!(names, expected);
+    }
+
+    // SI-1: each pre-registered table has zero rows but a valid
+    // schema (non-zero columns).
+    #[tokio::test]
+    async fn test_register_snapshot_schemas_empty_but_valid() {
+        let store = TableStore::new_empty();
+        register_snapshot_schemas(&store).await.unwrap();
+
+        for name in SNAPSHOT_TABLE_NAMES {
+            let provider = store.table_provider(name).unwrap();
+            assert!(
+                provider.is_some(),
+                "table '{}' should have a provider",
+                name,
+            );
+        }
+    }
+}

--- a/monarch_introspection_snapshot/src/lib.rs
+++ b/monarch_introspection_snapshot/src/lib.rs
@@ -18,10 +18,12 @@
 //! - [`push`] — drain `SnapshotData` into `TableStore` tables
 //! - [`service`] — `SnapshotService` capture pipeline
 //! - [`bundle`] — durable snapshot bundle export/import
+//! - [`integration`] — wiring into live telemetry
 
 pub mod bundle;
 pub mod capture;
 pub mod convert;
+pub mod integration;
 pub mod push;
 pub mod schema;
 pub mod service;

--- a/monarch_introspection_snapshot/src/service.rs
+++ b/monarch_introspection_snapshot/src/service.rs
@@ -18,15 +18,11 @@
 //!
 //! # Usage
 //!
-//! Both [`SnapshotService::capture`] and [`spawn_periodic_capture`]
-//! take a *resolver* — a closure `Fn(&NodeRef) ->
-//! Future<Result<NodePayload>>` that resolves a single node reference
-//! via the mesh admin. In production this calls
+//! [`SnapshotService::capture`] takes a *resolver* — a closure
+//! `Fn(&NodeRef) -> Future<Result<NodePayload>>` that resolves a
+//! single node reference via the mesh admin. In production this calls
 //! `MeshAdminAgent::resolve`; in tests it can be a stub backed by a
 //! `HashMap`.
-//!
-//! For [`spawn_periodic_capture`], a *resolver factory* `Fn() ->
-//! resolver` is passed instead, producing a fresh resolver per tick.
 //!
 //! **One-shot capture** — capture a mesh snapshot on demand:
 //!
@@ -52,40 +48,21 @@
 //! sinks. At least one sink (`table_store` or `export_root`) must be
 //! active.
 //!
-//! **Periodic capture** — run the capture pipeline on a timer:
+//! **Periodic capture** — spawn a [`SnapshotCaptureActor`]:
 //!
 //! ```ignore
-//! // Factory produces a fresh resolver per tick.
-//! let make_resolve = || {
-//!     let admin_ref = admin_ref.clone();
-//!     move |node_ref: &NodeRef| {
-//!         let admin_ref = admin_ref.clone();
-//!         let ref_string = node_ref.to_string();
-//!         async move {
-//!             let resp = admin_ref.resolve(instance, ref_string).await?;
-//!             resp.0.map_err(|e| anyhow::anyhow!("{}", e))
-//!         }
-//!     }
-//! };
-//!
-//! let service = SnapshotService::new(Some(table_store));
-//! let cancel = CancellationToken::new();
-//! let handle = spawn_periodic_capture(
-//!     service.clone(),
+//! let actor = SnapshotCaptureActor::new(
+//!     table_store,
+//!     admin_ref,
 //!     Duration::from_secs(30),
-//!     cancel.clone(),
-//!     make_resolve,
-//! )?;
-//!
-//! // ... later, shut down:
-//! cancel.cancel();
-//! handle.await?;
+//! );
+//! proc.spawn("snapshot_capture", actor)?;
+//! // Actor is stopped by framework lifecycle on proc teardown.
 //! ```
 //!
-//! [`spawn_periodic_capture`] reuses the same capture pipeline but is
-//! live-ingest only (`export_root` is always `None`). Overlapping
-//! ticks are skipped, not queued. Capture errors are logged and do
-//! not stop the timer.
+//! The actor reuses the same capture pipeline but is live-ingest only
+//! (`export_root` is always `None`). Overlapping ticks are skipped,
+//! not queued. Capture errors are logged and do not stop the timer.
 //!
 //! # Service invariants (SV-*)
 //!
@@ -118,14 +95,21 @@
 //!
 //! - **PT-1 (positive interval):** Zero interval rejected before
 //!   spawn.
-//! - **PT-2 (live sink required):** `table_store.is_some()` required.
-//! - **PT-3 (delayed first fire):** First capture after one full
-//!   interval.
+//! - **PT-2 (live sink by construction):** The periodic path takes a
+//!   concrete `TableStore`, not an `Option`. A live sink is guaranteed
+//!   by the API shape.
+//! - **PT-3 (immediate first fire):** First capture fires at spawn
+//!   time. Subsequent captures fire after each interval.
 //! - **PT-4 (single in-flight):** Overlapping ticks skipped via CAS.
 //!   `in_flight` is consulted only by the periodic loop; on-demand
 //!   `capture` calls do not check it.
-//! - **PT-5 (cancellation boundary):** Stops future ticks; does not
-//!   interrupt in-flight capture.
+//! - **PT-5 (actor lifecycle):** The actor is stopped by framework
+//!   lifecycle (proc teardown via `DrainAndStop`). The framework
+//!   guarantees the current handler runs to completion before
+//!   stopping. At most one additional queued capture may execute
+//!   during drain. After stop, snapshot count stabilizes — no
+//!   unbounded reschedule tail. Tested by
+//!   `test_pt5_drain_halts_future_captures`.
 //! - **PT-6 (failure resilience):** Capture `Err` logged, loop
 //!   continues.
 //! - **PT-7 (live-ingest only):** Always `export_root = None`.
@@ -139,14 +123,22 @@ use std::sync::atomic::Ordering;
 use std::time::Duration;
 use std::time::Instant;
 
+use async_trait::async_trait;
+use hyperactor::Actor;
+use hyperactor::Context;
+use hyperactor::Handler;
+use hyperactor::Instance;
+use hyperactor::mailbox::MessageEnvelope;
+use hyperactor::mailbox::Undeliverable;
+use hyperactor::reference as hyperactor_reference;
 use hyperactor_mesh::introspect::NodePayload;
 use hyperactor_mesh::introspect::NodeRef;
+use hyperactor_mesh::mesh_admin::MeshAdminAgent;
+use hyperactor_mesh::mesh_admin::ResolveReferenceMessageClient;
 use monarch_distributed_telemetry::database_scanner::TableStore;
 use serde::Deserialize;
 use serde::Serialize;
-use tokio::task::JoinHandle;
-use tokio::time::MissedTickBehavior;
-use tokio_util::sync::CancellationToken;
+use typeuri::Named;
 use uuid::Uuid;
 
 use crate::bundle::write_bundle;
@@ -283,132 +275,133 @@ where
 
     // PT-7: always None for export_root.
     match service.capture(resolve, None).await {
-        Ok(_result) => {}
+        Ok(result) => {
+            let c = &result.node_counts;
+            let short_id = &result.snapshot_id[..6];
+            if c.resolution_errors > 0 {
+                tracing::warn!(
+                    "capture partial: {}/{} nodes ({} resolution errors) in {:.0}ms [snap_id={}]",
+                    c.nodes - c.resolution_errors,
+                    c.nodes,
+                    c.resolution_errors,
+                    result.capture_duration_ms,
+                    short_id,
+                );
+            } else {
+                tracing::info!(
+                    "capture ok: {} nodes ({} hosts, {} procs, {} actors) in {:.0}ms [snap_id={}]",
+                    c.nodes,
+                    c.host_nodes,
+                    c.proc_nodes,
+                    c.actor_nodes,
+                    result.capture_duration_ms,
+                    short_id,
+                );
+            }
+        }
         // PT-6: log and continue.
         Err(e) => tracing::warn!("periodic capture failed: {:#}", e),
     }
     true
 }
 
-/// Tick source for the periodic capture loop.
+/// Self-message that triggers one periodic capture cycle. See PT-3,
+/// PT-5.
+#[derive(Debug, Serialize, Deserialize, Named)]
+pub struct CaptureSnapshot;
+wirevalue::register_type!(CaptureSnapshot);
+
+/// Periodic snapshot capture actor. Owns scheduling and lifecycle;
+/// delegates per-tick execution to [`run_periodic_tick`].
 ///
-/// Production uses [`IntervalTick`]; tests use [`NotifyTick`].
-trait TickSource {
-    /// Wait for the next tick.
-    fn tick(&mut self) -> std::pin::Pin<Box<dyn Future<Output = ()> + Send + '_>>;
+/// The spawn site sends the first `CaptureSnapshot` (PT-3). The
+/// handler reschedules after each tick via `self_message_with_delay`.
+/// Stopped by framework lifecycle (`DrainAndStop` on proc teardown).
+#[hyperactor::export(handlers = [CaptureSnapshot])]
+pub struct SnapshotCaptureActor {
+    /// Shared snapshot capture pipeline and live-ingest sink.
+    service: SnapshotService,
+    /// Typed admin actor reference used to resolve `NodeRef`s during
+    /// capture.
+    admin_ref: hyperactor_reference::ActorRef<MeshAdminAgent>,
+    /// Delay between periodic capture ticks after the initial
+    /// immediate fire.
+    interval: Duration,
 }
 
-/// Production tick source backed by `tokio::time::Interval`.
-struct IntervalTick {
-    interval: tokio::time::Interval,
-}
+#[async_trait]
+impl Actor for SnapshotCaptureActor {
+    async fn init(&mut self, this: &Instance<Self>) -> Result<(), anyhow::Error> {
+        // Bind the mailbox before the first tick so outbound sends
+        // from this actor do not hit the generic "no
+        // Undeliverable<MessageEnvelope> bound" warning path.
+        this.bind::<Self>();
+        this.set_system();
+        Ok(())
+    }
 
-impl TickSource for IntervalTick {
-    fn tick(&mut self) -> std::pin::Pin<Box<dyn Future<Output = ()> + Send + '_>> {
-        Box::pin(async {
-            self.interval.tick().await;
-        })
+    // Defensive only: periodic capture is best-effort, so an
+    // unexpected undeliverable outbound message should be surfaced in
+    // logs but must not stop future ticks.
+    async fn handle_undeliverable_message(
+        &mut self,
+        _cx: &Instance<Self>,
+        envelope: Undeliverable<MessageEnvelope>,
+    ) -> Result<(), anyhow::Error> {
+        // Periodic capture is best-effort. A bounced outbound message
+        // should not fail the actor or stop future ticks; log it and
+        // continue.
+        tracing::error!(
+            sender = %envelope.0.sender(),
+            dest = %envelope.0.dest(),
+            error = envelope.0.error_msg().unwrap_or_default(),
+            "snapshot capture dropped undeliverable outbound message"
+        );
+        Ok(())
     }
 }
 
-/// Per-tick completion callback.
-///
-/// Called after each tick is fully processed (capture completed or
-/// skipped). Production passes [`NoOpDone`]; tests pass
-/// [`NotifyDone`] to synchronize without `yield_now`.
-trait OnTickDone {
-    fn done(&self);
+#[async_trait]
+impl Handler<CaptureSnapshot> for SnapshotCaptureActor {
+    async fn handle(
+        &mut self,
+        cx: &Context<Self>,
+        _message: CaptureSnapshot,
+    ) -> Result<(), anyhow::Error> {
+        let admin_ref = self.admin_ref.clone();
+        let resolve = |node_ref: &NodeRef| {
+            let admin_ref = admin_ref.clone();
+            let ref_string = node_ref.to_string();
+            async move {
+                let resp = admin_ref.resolve(cx, ref_string).await?;
+                resp.0.map_err(|e| anyhow::anyhow!("{}", e))
+            }
+        };
+        run_periodic_tick(&self.service, resolve).await;
+
+        // Reschedule. If the actor is stopping, this spawns a
+        // detached task whose eventual port.send() fails harmlessly.
+        if let Err(e) = cx.self_message_with_delay(CaptureSnapshot, self.interval) {
+            tracing::error!("snapshot capture actor failed to reschedule: {:#}", e);
+        }
+        Ok(())
+    }
 }
 
-/// Production no-op completion signal.
-struct NoOpDone;
-impl OnTickDone for NoOpDone {
-    fn done(&self) {}
-}
-
-/// Private loop driver for periodic capture.
-///
-/// Separates tick scheduling from tick handling so tests can drive
-/// ticks manually. Production passes an [`IntervalTick`]; tests
-/// pass a [`NotifyTick`]. The `on_tick_done` callback fires after
-/// each tick is fully processed.
-///
-/// The loop uses `biased` select with cancellation first (PT-5).
-async fn run_periodic_loop<MkResolve, F, Fut>(
-    service: SnapshotService,
-    cancel: CancellationToken,
-    make_resolve: MkResolve,
-    mut ticks: impl TickSource,
-    on_tick_done: impl OnTickDone,
-) where
-    MkResolve: Fn() -> F,
-    F: Fn(&NodeRef) -> Fut,
-    Fut: Future<Output = anyhow::Result<NodePayload>>,
-{
-    loop {
-        tokio::select! {
-            biased;
-
-            // PT-5: cancellation checked first via biased select.
-            _ = cancel.cancelled() => {
-                break;
-            }
-
-            _ = ticks.tick() => {
-                run_periodic_tick(&service, make_resolve()).await;
-                on_tick_done.done();
-            }
+impl SnapshotCaptureActor {
+    /// Create a new snapshot capture actor. Call `proc.spawn()` to
+    /// start it.
+    pub fn new(
+        table_store: TableStore,
+        admin_ref: hyperactor_reference::ActorRef<MeshAdminAgent>,
+        interval: Duration,
+    ) -> Self {
+        Self {
+            service: SnapshotService::new(Some(table_store)),
+            admin_ref,
+            interval,
         }
     }
-}
-
-/// Spawn a periodic snapshot capture timer.
-///
-/// Returns `Err` immediately if `interval` is zero (PT-1) or the
-/// service has no `table_store` (PT-2). On success, returns a
-/// `JoinHandle` for the spawned timer task. The task owns a cloned
-/// `SnapshotService` by value and shares the same `in_flight` guard
-/// and `TableStore` as the original.
-pub fn spawn_periodic_capture<MkResolve, F, Fut>(
-    service: SnapshotService,
-    interval: Duration,
-    cancel: CancellationToken,
-    make_resolve: MkResolve,
-) -> anyhow::Result<JoinHandle<()>>
-where
-    MkResolve: Fn() -> F + Send + Sync + 'static,
-    F: Fn(&NodeRef) -> Fut + Send + Sync + 'static,
-    Fut: Future<Output = anyhow::Result<NodePayload>> + Send + 'static,
-{
-    // PT-1: reject zero interval.
-    anyhow::ensure!(
-        !interval.is_zero(),
-        "periodic capture interval must be non-zero"
-    );
-
-    // PT-2: reject if no table_store.
-    anyhow::ensure!(
-        service.table_store.is_some(),
-        "periodic capture requires a table_store"
-    );
-
-    let handle = tokio::spawn(async move {
-        // PT-3: first fire after one full interval.
-        let start = tokio::time::Instant::now() + interval;
-        let mut timer = tokio::time::interval_at(start, interval);
-        timer.set_missed_tick_behavior(MissedTickBehavior::Skip);
-
-        run_periodic_loop(
-            service,
-            cancel,
-            make_resolve,
-            IntervalTick { interval: timer },
-            NoOpDone,
-        )
-        .await;
-    });
-
-    Ok(handle)
 }
 
 /// Result metadata from a snapshot capture operation.
@@ -847,197 +840,6 @@ mod tests {
         assert_eq!(manifest.snapshot_id, result.snapshot_id);
     }
 
-    // --- Periodic trigger tests (PT-*) ---
-    //
-    // Test split:
-    // - PT-1, PT-2: direct spawn_periodic_capture precondition tests
-    // - PT-3, PT-5: deterministic loop tests via run_periodic_loop
-    //   with NotifyTick (manual tick source)
-    // - PT-4, PT-6, PT-7: direct run_periodic_tick tests
-
-    type PinFut = std::pin::Pin<Box<dyn Future<Output = anyhow::Result<NodePayload>> + Send>>;
-
-    /// Test tick source backed by `tokio::sync::Notify`.
-    /// Each `notify_one()` on the held `Arc<Notify>` fires one tick.
-    struct NotifyTick(Arc<tokio::sync::Notify>);
-
-    impl TickSource for NotifyTick {
-        fn tick(&mut self) -> std::pin::Pin<Box<dyn Future<Output = ()> + Send + '_>> {
-            let n = self.0.clone();
-            Box::pin(async move { n.notified().await })
-        }
-    }
-
-    /// Test completion signal. The loop calls `done()` after each
-    /// tick is fully processed; tests await `done_signal.notified()`
-    /// to synchronize deterministically.
-    struct NotifyDone(Arc<tokio::sync::Notify>);
-
-    impl OnTickDone for NotifyDone {
-        fn done(&self) {
-            self.0.notify_one();
-        }
-    }
-
-    /// Build a resolver factory for tests that exercise
-    /// spawn_periodic_capture with a real timer (production timer
-    /// PT-3 test) and for the PT-5 in-flight cancellation test.
-    fn periodic_resolver_factory(
-        payloads: HashMap<NodeRef, NodePayload>,
-        counter: Arc<std::sync::atomic::AtomicUsize>,
-        gate: Option<Arc<tokio::sync::Notify>>,
-    ) -> impl Fn() -> Box<dyn Fn(&NodeRef) -> PinFut + Send + Sync> + Send + Sync + 'static {
-        move || {
-            let payloads = payloads.clone();
-            let counter = counter.clone();
-            let gate = gate.clone();
-            Box::new(move |node_ref: &NodeRef| {
-                let result = payloads
-                    .get(node_ref)
-                    .cloned()
-                    .ok_or_else(|| anyhow::anyhow!("unknown ref: {}", node_ref));
-                let is_root = *node_ref == NodeRef::Root;
-                let counter = counter.clone();
-                let gate = gate.clone();
-                Box::pin(async move {
-                    if is_root {
-                        counter.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-                        if let Some(g) = gate {
-                            g.notified().await;
-                        }
-                    }
-                    result
-                })
-            })
-        }
-    }
-
-    // --- PT-1, PT-2: spawn precondition tests (sync) ---
-
-    /// Dummy resolver for precondition tests where the resolver is
-    /// never called.
-    fn unused_resolver(_: &NodeRef) -> std::future::Ready<anyhow::Result<NodePayload>> {
-        std::future::ready(Err(anyhow::anyhow!("unused")))
-    }
-
-    // PT-1: zero interval rejected.
-    #[test]
-    fn test_periodic_rejects_zero_interval() {
-        let store = TableStore::new_empty();
-        let service = SnapshotService::new(Some(store));
-        let cancel = CancellationToken::new();
-
-        let err = spawn_periodic_capture(service, Duration::ZERO, cancel, || unused_resolver);
-        assert!(err.is_err(), "PT-1: should reject zero interval");
-        assert!(
-            err.unwrap_err().to_string().contains("non-zero"),
-            "PT-1: error should mention non-zero",
-        );
-    }
-
-    // PT-2: no table_store rejected.
-    #[test]
-    fn test_periodic_rejects_no_store() {
-        let service = SnapshotService::new(None);
-        let cancel = CancellationToken::new();
-
-        let err =
-            spawn_periodic_capture(service, Duration::from_secs(1), cancel, || unused_resolver);
-        assert!(err.is_err(), "PT-2: should reject no store");
-        assert!(
-            err.unwrap_err().to_string().contains("table_store"),
-            "PT-2: error should mention table_store",
-        );
-    }
-
-    // PT-3: no capture before a tick is sent; exactly one after. Uses
-    // run_periodic_loop with NotifyTick and NotifyDone for
-    // deterministic synchronization.
-    #[tokio::test]
-    async fn test_periodic_delayed_first_fire() {
-        let store = TableStore::new_empty();
-        let service = SnapshotService::new(Some(store.clone()));
-        let cancel = CancellationToken::new();
-        let payloads = minimal_mesh_payloads();
-
-        let tick_signal = Arc::new(tokio::sync::Notify::new());
-        let done_signal = Arc::new(tokio::sync::Notify::new());
-
-        let handle = tokio::spawn({
-            let cancel = cancel.clone();
-            let payloads = payloads.clone();
-            let tick_signal = tick_signal.clone();
-            let done_signal = done_signal.clone();
-            async move {
-                run_periodic_loop(
-                    service,
-                    cancel,
-                    || stub_resolver(payloads.clone()),
-                    NotifyTick(tick_signal),
-                    NotifyDone(done_signal),
-                )
-                .await;
-            }
-        });
-
-        // No tick sent yet — no capture should have occurred. The
-        // loop is blocked on NotifyTick, so the store is empty.
-        assert_eq!(
-            store.table_names().unwrap().len(),
-            0,
-            "PT-3: no capture before tick"
-        );
-
-        // Send one tick and await the completion signal.
-        tick_signal.notify_one();
-        done_signal.notified().await;
-
-        assert_eq!(
-            store.table_names().unwrap().len(),
-            9,
-            "PT-3: one capture after tick"
-        );
-
-        cancel.cancel();
-        handle.await.unwrap();
-    }
-
-    // PT-3 (production timer): spawn_periodic_capture with a real
-    // interval does not fire before one full interval. This is the
-    // one test that exercises the interval_at(now + interval,
-    // interval) construction in spawn_periodic_capture itself.
-    #[tokio::test]
-    async fn test_periodic_production_timer_delay() {
-        let store = TableStore::new_empty();
-        let service = SnapshotService::new(Some(store.clone()));
-        let cancel = CancellationToken::new();
-        let payloads = minimal_mesh_payloads();
-        let counter = Arc::new(std::sync::atomic::AtomicUsize::new(0));
-        let factory = periodic_resolver_factory(payloads, counter.clone(), None);
-        let interval = Duration::from_millis(200);
-
-        let handle = spawn_periodic_capture(service, interval, cancel.clone(), factory).unwrap();
-
-        // Well before the first interval — no capture.
-        tokio::time::sleep(Duration::from_millis(50)).await;
-        assert_eq!(
-            counter.load(std::sync::atomic::Ordering::Relaxed),
-            0,
-            "PT-3: no capture before first interval (production timer)",
-        );
-
-        // Wait long enough for the first tick to fire and capture
-        // to complete.
-        tokio::time::sleep(Duration::from_millis(300)).await;
-        assert!(
-            counter.load(std::sync::atomic::Ordering::Relaxed) >= 1,
-            "PT-3: at least one capture after interval (production timer)",
-        );
-
-        cancel.cancel();
-        handle.await.unwrap();
-    }
-
     // --- PT-4, PT-6, PT-7: direct run_periodic_tick tests ---
     //
     // These test the per-tick helper directly — no tokio::spawn, no
@@ -1128,116 +930,5 @@ mod tests {
         // PT-7 is structural: run_periodic_tick calls
         // service.capture(resolve, None). No bundle directory
         // was created.
-    }
-
-    // --- PT-5: deterministic loop tests via run_periodic_loop ---
-
-    // PT-5 (idle): cancel before any tick, loop exits, zero captures.
-    #[tokio::test]
-    async fn test_periodic_cancel_while_idle() {
-        let store = TableStore::new_empty();
-        let service = SnapshotService::new(Some(store.clone()));
-        let cancel = CancellationToken::new();
-        let payloads = minimal_mesh_payloads();
-        let tick_signal = Arc::new(tokio::sync::Notify::new());
-
-        // Cancel immediately — before any tick is sent.
-        cancel.cancel();
-
-        run_periodic_loop(
-            service,
-            cancel,
-            || stub_resolver(payloads.clone()),
-            NotifyTick(tick_signal),
-            NoOpDone,
-        )
-        .await;
-
-        assert_eq!(
-            store.table_names().unwrap().len(),
-            0,
-            "PT-5: no captures after cancel while idle",
-        );
-    }
-
-    // PT-5 (in-flight): cancel during a gated capture, capture
-    // finishes, then the loop exits. No second capture.
-    //
-    // Synchronization:
-    // - started_signal: resolver notifies when root resolution begins
-    // - resolver_gate: test releases to let the capture finish
-    // - done_signal: loop notifies when tick is fully processed
-    #[tokio::test]
-    async fn test_periodic_cancel_during_inflight() {
-        let store = TableStore::new_empty();
-        let service = SnapshotService::new(Some(store.clone()));
-        let cancel = CancellationToken::new();
-        let payloads = minimal_mesh_payloads();
-        let started_signal = Arc::new(tokio::sync::Notify::new());
-        let resolver_gate = Arc::new(tokio::sync::Notify::new());
-        let tick_signal = Arc::new(tokio::sync::Notify::new());
-        let done_signal = Arc::new(tokio::sync::Notify::new());
-
-        let handle = tokio::spawn({
-            let cancel = cancel.clone();
-            let payloads = payloads.clone();
-            let started_signal = started_signal.clone();
-            let resolver_gate = resolver_gate.clone();
-            let tick_signal = tick_signal.clone();
-            let done_signal = done_signal.clone();
-            async move {
-                run_periodic_loop(
-                    service,
-                    cancel,
-                    move || {
-                        let payloads = payloads.clone();
-                        let started_signal = started_signal.clone();
-                        let resolver_gate = resolver_gate.clone();
-                        move |node_ref: &NodeRef| {
-                            let result = payloads
-                                .get(node_ref)
-                                .cloned()
-                                .ok_or_else(|| anyhow::anyhow!("unknown ref: {}", node_ref));
-                            let is_root = *node_ref == NodeRef::Root;
-                            let started_signal = started_signal.clone();
-                            let resolver_gate = resolver_gate.clone();
-                            Box::pin(async move {
-                                if is_root {
-                                    started_signal.notify_one();
-                                    resolver_gate.notified().await;
-                                }
-                                result
-                            }) as PinFut
-                        }
-                    },
-                    NotifyTick(tick_signal),
-                    NotifyDone(done_signal),
-                )
-                .await;
-            }
-        });
-
-        // Send one tick — capture starts, blocks on resolver_gate.
-        tick_signal.notify_one();
-        // Wait for the resolver to signal that root resolution began.
-        started_signal.notified().await;
-
-        // Cancel while capture is in-flight.
-        cancel.cancel();
-
-        // Task should not have exited — capture is blocked on gate.
-        assert!(
-            !handle.is_finished(),
-            "PT-5: task still running while gated"
-        );
-
-        // Release the capture. The loop completes the tick (fires
-        // done_signal), then sees cancellation and exits.
-        resolver_gate.notify_one();
-        done_signal.notified().await;
-        handle.await.unwrap();
-
-        // Verify the capture actually ingested data.
-        assert_eq!(store.table_names().unwrap().len(), 9);
     }
 }

--- a/monarch_introspection_snapshot/test/snapshot_integration_test.rs
+++ b/monarch_introspection_snapshot/test/snapshot_integration_test.rs
@@ -17,6 +17,8 @@
 //! production than the in-process variant. The `mesh_admin.rs`
 //! white-box tests use `pub(crate)` shortcuts not available here.
 
+use std::time::Duration;
+
 use anyhow::Result;
 use async_trait::async_trait;
 use datafusion::arrow::array::BooleanArray;
@@ -25,18 +27,17 @@ use datafusion::arrow::array::StringArray;
 use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::prelude::SessionContext;
 use hyperactor::Actor;
-use hyperactor::ActorRef;
 use hyperactor::Context;
 use hyperactor::Handler;
 use hyperactor_mesh::global_context::context;
 use hyperactor_mesh::host_mesh::HostMesh;
 use hyperactor_mesh::host_mesh::spawn_admin;
 use hyperactor_mesh::introspect::NodeRef;
-use hyperactor_mesh::mesh_admin::MESH_ADMIN_ACTOR_NAME;
-use hyperactor_mesh::mesh_admin::MeshAdminAgent;
 use hyperactor_mesh::mesh_admin::ResolveReferenceMessageClient;
 use monarch_distributed_telemetry::database_scanner::TableStore;
 use monarch_introspection_snapshot::capture::capture_snapshot;
+use monarch_introspection_snapshot::integration::register_snapshot_schemas;
+use monarch_introspection_snapshot::integration::start_periodic_snapshots;
 use monarch_introspection_snapshot::push::push_snapshot;
 use ndslice::extent;
 use ndslice::view::Ranked;
@@ -142,9 +143,7 @@ async fn test_snapshot_sql_queries() -> Result<()> {
         .await?;
 
     // Step 3: Spawn admin on the caller-local proc.
-    let _admin_url = spawn_admin([&host_mesh], &instance, None, None).await?;
-    let admin_ref: ActorRef<MeshAdminAgent> =
-        ActorRef::attest(instance.proc().proc_id().actor_id(MESH_ADMIN_ACTOR_NAME, 0));
+    let admin_ref = spawn_admin([&host_mesh], &instance, Some("[::]:0".parse()?), None).await?;
 
     // Capture deterministic fixture-owned IDs via typed refs.
     let proc_0_ref = proc_mesh.get(0).expect("proc at rank 0");
@@ -358,6 +357,152 @@ async fn test_snapshot_sql_queries() -> Result<()> {
     // Cleanup: shutdown the mesh.
     let mut host_mesh = host_mesh;
     host_mesh.shutdown(&instance).await?;
+
+    Ok(())
+}
+
+/// PT-1: zero interval rejected at the `start_periodic_snapshots`
+/// boundary.
+#[tokio::test]
+async fn test_pt1_rejects_zero_interval() -> Result<()> {
+    let cx = context().await;
+    let instance = cx.actor_instance;
+    let host_mesh = HostMesh::local().await?;
+    let admin_ref = spawn_admin([&host_mesh], &instance, Some("[::]:0".parse()?), None).await?;
+    let table_store = TableStore::new_empty();
+
+    let err = start_periodic_snapshots(&instance, table_store, admin_ref.clone(), Duration::ZERO);
+    assert!(err.is_err(), "PT-1: zero interval must be rejected");
+    assert!(
+        err.unwrap_err().to_string().contains("non-zero"),
+        "PT-1: error must mention non-zero",
+    );
+
+    let mut host_mesh = host_mesh;
+    host_mesh.shutdown(&instance).await?;
+    Ok(())
+}
+
+/// PT-3: first capture fires at spawn time (immediate, not delayed).
+#[tokio::test]
+async fn test_pt3_immediate_first_capture() -> Result<()> {
+    let cx = context().await;
+    let instance = cx.actor_instance;
+    let host_mesh = HostMesh::local().await?;
+    let admin_ref = spawn_admin([&host_mesh], &instance, Some("[::]:0".parse()?), None).await?;
+
+    let table_store = TableStore::new_empty();
+    register_snapshot_schemas(&table_store).await?;
+
+    // Use a long interval so only the initial immediate capture fires.
+    start_periodic_snapshots(
+        &instance,
+        table_store.clone(),
+        admin_ref.clone(),
+        Duration::from_secs(600),
+    )?;
+
+    // Give the immediate capture time to complete.
+    tokio::time::sleep(Duration::from_secs(2)).await;
+
+    let ctx = SessionContext::new();
+    register_all(&table_store, &ctx).await?;
+    let batch = query_batch(&ctx, "SELECT COUNT(*) AS cnt FROM snapshots").await?;
+    let count = col_i64(&batch, "cnt", 0);
+    assert!(
+        count >= 1,
+        "PT-3: at least one capture should fire immediately, got {}",
+        count,
+    );
+
+    // Stop the actor and clean up.
+    let actor_id = instance.proc().proc_id().actor_id("snapshot_capture", 0);
+    instance
+        .proc()
+        .stop_actor(&actor_id, "PT-3 test cleanup".to_string());
+
+    let mut host_mesh = host_mesh;
+    host_mesh.shutdown(&instance).await?;
+    Ok(())
+}
+
+/// PT-5: after proc shutdown, snapshot count stabilizes. The actor
+/// may complete one in-flight or drained capture during DrainAndStop,
+/// but does not reschedule indefinitely.
+#[tokio::test]
+async fn test_pt5_drain_halts_future_captures() -> Result<()> {
+    let cx = context().await;
+    let instance = cx.actor_instance;
+    let host_mesh = HostMesh::local().await?;
+    let admin_ref = spawn_admin([&host_mesh], &instance, Some("[::]:0".parse()?), None).await?;
+
+    let table_store = TableStore::new_empty();
+    register_snapshot_schemas(&table_store).await?;
+
+    // Start periodic capture with a short interval.
+    start_periodic_snapshots(
+        &instance,
+        table_store.clone(),
+        admin_ref.clone(),
+        Duration::from_millis(200),
+    )?;
+
+    // Let a few captures run.
+    tokio::time::sleep(Duration::from_secs(2)).await;
+
+    // Verify captures actually ran before stopping.
+    let count_before_stop = {
+        let ctx = SessionContext::new();
+        register_all(&table_store, &ctx).await?;
+        let batch = query_batch(&ctx, "SELECT COUNT(*) AS cnt FROM snapshots").await?;
+        col_i64(&batch, "cnt", 0)
+    };
+    assert!(
+        count_before_stop > 0,
+        "PT-5: expected positive snapshot count before stop, got {}",
+        count_before_stop,
+    );
+
+    // Stop the snapshot actor directly. In production, job teardown
+    // stops the proc which stops all actors on it.
+    let actor_id = instance.proc().proc_id().actor_id("snapshot_capture", 0);
+    let status_rx = instance
+        .proc()
+        .stop_actor(&actor_id, "PT-5 test shutdown".to_string());
+    if let Some(mut rx) = status_rx {
+        // Wait for the actor to reach a terminal state.
+        while !rx.borrow().is_terminal() {
+            rx.changed().await.ok();
+        }
+    }
+    // Small headroom for any async cleanup.
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    // Record snapshot count after actor stop.
+    let count_at_shutdown = {
+        let ctx = SessionContext::new();
+        register_all(&table_store, &ctx).await?;
+        let batch = query_batch(&ctx, "SELECT COUNT(*) AS cnt FROM snapshots").await?;
+        col_i64(&batch, "cnt", 0)
+    };
+
+    // Wait to verify no further captures fire.
+    tokio::time::sleep(Duration::from_secs(2)).await;
+
+    let count_after_wait = {
+        let ctx = SessionContext::new();
+        register_all(&table_store, &ctx).await?;
+        let batch = query_batch(&ctx, "SELECT COUNT(*) AS cnt FROM snapshots").await?;
+        col_i64(&batch, "cnt", 0)
+    };
+
+    // PT-5: snapshot count must not keep increasing after shutdown.
+    assert_eq!(
+        count_at_shutdown, count_after_wait,
+        "PT-5: snapshot count should stabilize after shutdown \
+         (got {} at shutdown, {} after 2s wait)",
+        count_at_shutdown, count_after_wait,
+    );
 
     Ok(())
 }

--- a/python/examples/dining_philosophers.py
+++ b/python/examples/dining_philosophers.py
@@ -159,10 +159,13 @@ async def async_main(
 ) -> None:
     job = ProcessJob({"hosts": 1})
     job.enable_admin()
-    if dashboard:
-        job.enable_telemetry(
-            TelemetryConfig(include_dashboard=True, dashboard_port=dashboard_port)
+    job.enable_telemetry(
+        TelemetryConfig(
+            include_dashboard=dashboard,
+            dashboard_port=dashboard_port,
+            snapshot_interval_secs=30.0,
         )
+    )
     state = job.state(cached_path=None)
     host = state.hosts
 

--- a/python/examples/poisoned_mesh.py
+++ b/python/examples/poisoned_mesh.py
@@ -38,7 +38,7 @@ import sys
 
 import monarch.actor
 from monarch.actor import Actor, current_rank, endpoint
-from monarch.job import ProcessJob
+from monarch.job import ProcessJob, TelemetryConfig
 
 
 def _fault_hook(failure) -> None:
@@ -83,7 +83,11 @@ class Worker(Actor):
 
 
 async def async_main(num_procs: int) -> None:
-    job = ProcessJob({"hosts": 1}).enable_admin()
+    job = (
+        ProcessJob({"hosts": 1})
+        .enable_telemetry(TelemetryConfig(snapshot_interval_secs=30.0))
+        .enable_admin()
+    )
     state = job.state(cached_path=None)
     host = state.hosts
 

--- a/python/examples/pyspy_workload.py
+++ b/python/examples/pyspy_workload.py
@@ -40,7 +40,7 @@ import asyncio
 import time
 
 from monarch.actor import Actor, endpoint
-from monarch.job import ProcessJob
+from monarch.job import ProcessJob, TelemetryConfig
 
 
 # -- Work helpers with named frames for py-spy visibility ----------
@@ -130,7 +130,11 @@ def parse_args() -> argparse.Namespace:
 async def async_main() -> None:
     args = parse_args()
 
-    job = ProcessJob({"hosts": 1}).enable_admin()
+    job = (
+        ProcessJob({"hosts": 1})
+        .enable_telemetry(TelemetryConfig(snapshot_interval_secs=30.0))
+        .enable_admin()
+    )
     state = job.state(cached_path=None)
     host = state.hosts
 

--- a/python/examples/rapid_spawn_exit_stress.py
+++ b/python/examples/rapid_spawn_exit_stress.py
@@ -21,10 +21,14 @@ import time
 
 import monarch.actor
 from monarch.actor import Actor, endpoint
-from monarch.job import ProcessJob
+from monarch.job import ProcessJob, TelemetryConfig
 from monarch.mesh_controller import spawn_tensor_engine
 
-job = ProcessJob({"hosts": 1}).enable_admin()
+job = (
+    ProcessJob({"hosts": 1})
+    .enable_telemetry(TelemetryConfig(snapshot_interval_secs=30.0))
+    .enable_admin()
+)
 job_state = job.state(cached_path=None)
 proc_mesh = job_state.hosts.spawn_procs(per_host={"gpus": 1})
 

--- a/python/examples/sleep_actors.py
+++ b/python/examples/sleep_actors.py
@@ -31,7 +31,7 @@ import asyncio
 import random
 
 from monarch.actor import Actor, context, current_rank, endpoint
-from monarch.job import ProcessJob
+from monarch.job import ProcessJob, TelemetryConfig
 
 
 class Sleeper(Actor):
@@ -57,7 +57,11 @@ MAX_SLEEP = 5.0
 
 
 async def async_main(num_procs: int) -> None:
-    job = ProcessJob({"hosts": 1}).enable_admin()
+    job = (
+        ProcessJob({"hosts": 1})
+        .enable_telemetry(TelemetryConfig(snapshot_interval_secs=30.0))
+        .enable_admin()
+    )
     state = job.state(cached_path=None)
     host = state.hosts
 

--- a/python/examples/stop_mesh.py
+++ b/python/examples/stop_mesh.py
@@ -31,7 +31,7 @@ import argparse
 import asyncio
 
 from monarch.actor import Actor, current_rank, endpoint
-from monarch.job import ProcessJob
+from monarch.job import ProcessJob, TelemetryConfig
 
 
 class Worker(Actor):
@@ -44,7 +44,11 @@ class Worker(Actor):
 
 
 async def async_main(num_procs: int) -> None:
-    job = ProcessJob({"hosts": 1}).enable_admin()
+    job = (
+        ProcessJob({"hosts": 1})
+        .enable_telemetry(TelemetryConfig(snapshot_interval_secs=30.0))
+        .enable_admin()
+    )
     state = job.state(cached_path=None)
     host = state.hosts
 

--- a/python/monarch/_rust_bindings/monarch_extension/snapshot_integration.pyi
+++ b/python/monarch/_rust_bindings/monarch_extension/snapshot_integration.pyi
@@ -1,0 +1,21 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from monarch._rust_bindings.monarch_distributed_telemetry.database_scanner import (
+    DatabaseScanner,
+)
+from monarch._rust_bindings.monarch_hyperactor.context import Instance
+from monarch._rust_bindings.monarch_hyperactor.host_mesh import PyMeshAdminRef
+
+def _pre_register_snapshot_schemas(scanner: DatabaseScanner) -> None: ...
+def _start_periodic_snapshots(
+    scanner: DatabaseScanner,
+    admin_ref: PyMeshAdminRef,
+    instance: Instance,
+    interval_secs: float,
+) -> None: ...

--- a/python/monarch/_rust_bindings/monarch_hyperactor/host_mesh.pyi
+++ b/python/monarch/_rust_bindings/monarch_hyperactor/host_mesh.pyi
@@ -147,18 +147,25 @@ def shutdown_local_host_mesh() -> PythonTask[None]:
         RuntimeError: If no local host mesh exists (bootstrap_host not called)
     """
     ...
+@final
+class PyMeshAdminRef:
+    """Opaque capability token for ActorRef<MeshAdminAgent>.
+    No methods — used only to transport the typed ref across the
+    Python boundary from _spawn_admin to _start_periodic_snapshots."""
+
+    ...
 
 def _spawn_admin(
     host_meshes: list[HostMesh],
     instance: Instance,
     admin_addr: str | None = None,
     telemetry_url: str | None = None,
-) -> PythonTask[str]:
+) -> PythonTask[tuple[str, PyMeshAdminRef]]:
     """
     Spawn a MeshAdminAgent aggregating topology across one or more meshes.
 
-    The admin runs on the caller's local proc and serves the mesh-admin
-    HTTP API. Returns the admin HTTP URL.
+    Returns ``(admin_url, admin_ref)`` where ``admin_ref`` is an opaque
+    capability token for immediate use only.
 
     Arguments:
     - `host_meshes`: One or more HostMeshes whose hosts the admin will

--- a/python/monarch/_src/actor/host_mesh.py
+++ b/python/monarch/_src/actor/host_mesh.py
@@ -19,6 +19,7 @@ from monarch._rust_bindings.monarch_hyperactor.host_mesh import (
     _spawn_admin as _hy_spawn_admin,
     BootstrapCommand,
     HostMesh as HyHostMesh,
+    PyMeshAdminRef,
 )
 from monarch._rust_bindings.monarch_hyperactor.proc_mesh import ProcMesh as HyProcMesh
 from monarch._rust_bindings.monarch_hyperactor.pytokio import PythonTask, Shared
@@ -461,17 +462,12 @@ def _spawn_admin(
     host_meshes: list["HostMesh"],
     admin_addr: Optional[str] = None,
     telemetry_url: Optional[str] = None,
-) -> "Future[str]":
+) -> "Future[tuple[str, PyMeshAdminRef]]":
     """
     Spawn a MeshAdminAgent aggregating topology across one or more HostMeshes.
 
-    The admin runs on the caller's local proc and serves the
-    mesh-admin HTTP API.
-
-    Use a single-element list for the degenerate single-mesh case::
-
-        host = this_host()
-        admin_url = await _spawn_admin([host], admin_addr="[::]:1729")
+    Returns ``(admin_url, admin_ref)`` where ``admin_ref`` is an opaque
+    capability token for immediate use only.
 
     Args:
         host_meshes: One or more HostMeshes whose hosts the admin
@@ -479,12 +475,9 @@ def _spawn_admin(
         admin_addr: Optional socket address for the admin HTTP server.
             When ``None``, reads ``MESH_ADMIN_ADDR`` from config.
         telemetry_url: Optional base URL of the Monarch telemetry dashboard.
-            When provided, the admin exposes proxy routes (``/v1/query``,
-            ``/v1/pyspy_dump``) that forward to the dashboard.
 
     Returns:
-        Future[str]: The admin HTTP URL (for example
-            ``"https://myhost.facebook.com:1729"``).
+        Future[tuple[str, PyMeshAdminRef]]: (admin_url, admin_ref).
 
     Raises:
         ValueError: If host_meshes is empty.
@@ -492,15 +485,13 @@ def _spawn_admin(
     if not host_meshes:
         raise ValueError("_spawn_admin requires at least one HostMesh")
 
-    async def task() -> str:
+    async def task() -> tuple[str, PyMeshAdminRef]:
         hy_meshes = [await m._hy_host_mesh for m in host_meshes]
-        url = await _hy_spawn_admin(
+        admin_url, admin_ref = await _hy_spawn_admin(
             hy_meshes, context().actor_instance._as_rust(), admin_addr, telemetry_url
         )
-        # Export admin URL so the dashboard can discover system actors
-        # and build TUI-style DAG hierarchies.
-        os.environ["MONARCH_ADMIN_URL"] = url
-        return url
+        os.environ["MONARCH_ADMIN_URL"] = admin_url
+        return admin_url, admin_ref
 
     return Future(coro=task())
 

--- a/python/monarch/_src/job/job.py
+++ b/python/monarch/_src/job/job.py
@@ -22,6 +22,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, List, Literal, NamedTuple, Optional, Sequence
 
+from monarch._rust_bindings.monarch_hyperactor.host_mesh import PyMeshAdminRef
 from monarch._src.actor.bootstrap import attach_to_workers
 from monarch._src.actor.host_mesh import _spawn_admin
 from monarch._src.job.mount_config import Mounts
@@ -306,12 +307,18 @@ class TelemetryConfig:
             0 disables retention.
         include_dashboard: Whether to start the monarch dashboard web server.
         dashboard_port: Preferred port for the dashboard.
+        snapshot_interval_secs: Interval in seconds between periodic mesh
+            introspection snapshots. Snapshots capture the mesh topology
+            into the telemetry query surface. 0 disables periodic capture
+            (default). Snapshot table schemas are always pre-registered
+            regardless of this setting.
     """
 
     batch_size: int = 1000
     retention_secs: int = 600
     include_dashboard: bool = False
     dashboard_port: int = 8265
+    snapshot_interval_secs: float = 0  # 0 = disabled
 
 
 @dataclass
@@ -426,6 +433,8 @@ class JobTrait(ABC):
         self._query_engine: Optional[QueryEngine] = None
         self._telemetry_url: Optional[str] = None
         self._admin_url: Optional[str] = None
+        self._scanner = None  # DatabaseScanner, set by _start_telemetry_if_configured
+        self._snapshot_started: bool = False
         self._apply_id: Optional[str] = None
         self._mounts: Mounts = Mounts()
         # Per-mesh python executable overrides.  None key means "all meshes".
@@ -438,23 +447,64 @@ class JobTrait(ABC):
             return
 
         cfg = self._telemetry
-        self._query_engine, self._telemetry_url = start_telemetry(
+        self._query_engine, self._telemetry_url, self._scanner = start_telemetry(
             batch_size=cfg.batch_size,
             retention_secs=cfg.retention_secs,
             include_dashboard=cfg.include_dashboard,
             dashboard_port=cfg.dashboard_port,
         )
 
-    def _start_admin_if_configured(self, host_meshes: List[HostMesh]) -> None:
-        """Start the mesh admin agent if configured and not already running."""
-        if self._mesh_admin is None or self._admin_url is not None:
-            return
+    def _start_admin_if_configured(
+        self, host_meshes: List[HostMesh]
+    ) -> Optional[PyMeshAdminRef]:
+        """Start the mesh admin agent if configured and not already running.
 
-        self._admin_url = _spawn_admin(
+        Returns the opaque admin ref for immediate use by snapshot
+        startup, or None if admin is not configured or already running.
+        """
+        if self._mesh_admin is None or self._admin_url is not None:
+            return None
+
+        admin_url, admin_ref = _spawn_admin(
             host_meshes,
             admin_addr=self._mesh_admin.admin_addr,
             telemetry_url=self._telemetry_url,
         ).get()
+        self._admin_url = admin_url
+        return admin_ref
+
+    def _start_periodic_snapshots_if_configured(
+        self, admin_ref: Optional[PyMeshAdminRef]
+    ) -> None:
+        """Start periodic snapshots if configured and not already running.
+
+        Spawns a SnapshotCaptureActor on the local proc. The actor is
+        stopped by framework lifecycle on proc teardown — no manual
+        stop needed. The admin_ref is consumed here and not persisted.
+        """
+        if self._snapshot_started:
+            return
+        if self._telemetry is None or self._scanner is None:
+            return
+        if admin_ref is None:
+            return
+        telemetry = self._telemetry
+        assert telemetry is not None  # guarded above
+        if telemetry.snapshot_interval_secs <= 0:
+            return
+
+        from monarch._rust_bindings.monarch_extension.snapshot_integration import (
+            _start_periodic_snapshots,
+        )
+        from monarch.actor import context
+
+        _start_periodic_snapshots(
+            scanner=self._scanner,
+            admin_ref=admin_ref,
+            instance=context().actor_instance._as_rust(),
+            interval_secs=telemetry.snapshot_interval_secs,
+        )
+        self._snapshot_started = True
 
     def _wrap_state(self, job_state: JobState) -> JobState:
         """Attach telemetry and admin fields to a JobState."""
@@ -566,7 +616,8 @@ class JobTrait(ABC):
             logger.info("Job is running, returning current state")
             job_state = running_job._state()
             self._start_telemetry_if_configured()
-            self._start_admin_if_configured(list(job_state._hosts.values()))
+            admin_ref = self._start_admin_if_configured(list(job_state._hosts.values()))
+            self._start_periodic_snapshots_if_configured(admin_ref)
             return self._wrap_state(job_state)
 
         cached = self._load_cached(cached_path)
@@ -575,14 +626,16 @@ class JobTrait(ABC):
             logger.info("Connecting to cached job")
             job_state = cached._state()
             self._start_telemetry_if_configured()
-            self._start_admin_if_configured(list(job_state._hosts.values()))
+            admin_ref = self._start_admin_if_configured(list(job_state._hosts.values()))
+            self._start_periodic_snapshots_if_configured(admin_ref)
             return self._wrap_state(job_state)
         logger.info("Applying current job")
         self.apply()
         logger.info("Job has started, connecting to current state")
         job_state = self._state()
         self._start_telemetry_if_configured()
-        self._start_admin_if_configured(list(job_state._hosts.values()))
+        admin_ref = self._start_admin_if_configured(list(job_state._hosts.values()))
+        self._start_periodic_snapshots_if_configured(admin_ref)
         result = self._wrap_state(job_state)
         if cached_path is not None:
             # Create the directory for cached_path if it doesn't exist
@@ -657,6 +710,8 @@ class JobTrait(ABC):
         state["_query_engine"] = None
         state["_telemetry_url"] = None
         state["_admin_url"] = None
+        state["_scanner"] = None
+        state["_snapshot_started"] = False
         return state
 
     def dump(self, filename: str) -> None:

--- a/python/monarch/distributed_telemetry/__init__.py
+++ b/python/monarch/distributed_telemetry/__init__.py
@@ -17,7 +17,7 @@ Three-component architecture:
 Usage:
     from monarch.distributed_telemetry.actor import start_telemetry
 
-    engine, telemetry_url = start_telemetry()
+    engine, telemetry_url, scanner = start_telemetry()
     # ... spawn procs, they're automatically tracked ...
     result = engine.query("SELECT * FROM metrics")
 """

--- a/python/monarch/distributed_telemetry/actor.py
+++ b/python/monarch/distributed_telemetry/actor.py
@@ -26,6 +26,9 @@ from typing import Any, Callable, Dict, List, Optional
 from monarch._rust_bindings.monarch_distributed_telemetry.database_scanner import (
     DatabaseScanner,
 )
+from monarch._rust_bindings.monarch_extension.snapshot_integration import (
+    _pre_register_snapshot_schemas,
+)
 from monarch._rust_bindings.monarch_hyperactor.mailbox import (
     PortId,
     UndeliverableMessageEnvelope,
@@ -68,13 +71,15 @@ SetupActor.register_startup_function(_scanner_startup)
 def _register_scanner(
     batch_size: int,
     retention_secs: int = 600,
-) -> None:
+) -> DatabaseScanner:
     global _scanner, _scanner_startup_impl, _spawn_callback_registered, _spawned_procs
-    _scanner = DatabaseScanner(
+    scanner = DatabaseScanner(
         current_rank().rank,
         batch_size=batch_size,
         retention_secs=retention_secs,
     )
+    _scanner = scanner
+    # pyre-ignore[9]: startup function is called for side effects; return value discarded.
     _scanner_startup_impl = functools.partial(
         _register_scanner,
         batch_size=batch_size,
@@ -86,6 +91,8 @@ def _register_scanner(
     if not _spawn_callback_registered:
         register_proc_mesh_spawn_callback(_on_proc_mesh_spawned)
         _spawn_callback_registered = True
+
+    return scanner
 
 
 class DistributedTelemetryActor(Actor):
@@ -231,7 +238,7 @@ def start_telemetry(
     retention_secs: int = 600,
     include_dashboard: bool = True,
     dashboard_port: int = 8265,
-) -> "tuple[QueryEngine, str | None]":
+) -> "tuple[QueryEngine, str | None, DatabaseScanner]":
     """
     Start the distributed telemetry system.
 
@@ -247,12 +254,19 @@ def start_telemetry(
         dashboard_port: Preferred port for the dashboard (default 8265).
 
     Returns:
-        A tuple of (QueryEngine, telemetry_url). ``telemetry_url`` is the
-        base URL of the dashboard server (e.g. ``"http://localhost:8265"``)
-        when ``include_dashboard`` is True, otherwise None. Pass it to
-        ``host_mesh._spawn_admin(telemetry_url=...)`` to enable proxy routes.
+        A tuple of (QueryEngine, telemetry_url, scanner).
+        ``telemetry_url`` is the base URL of the dashboard server
+        (e.g. ``"http://localhost:8265"``) when ``include_dashboard``
+        is True, otherwise None. ``scanner`` is the ``DatabaseScanner``
+        for use by snapshot integration.
     """
-    _register_scanner(batch_size, retention_secs=retention_secs)
+    scanner = _register_scanner(batch_size, retention_secs=retention_secs)
+
+    # Pre-register snapshot table schemas unconditionally (SI-6).
+    # Must happen before QueryEngine construction because table
+    # discovery is static.
+    _pre_register_snapshot_schemas(scanner)
+
     coordinator = this_proc().spawn("telemetry_coordinator", DistributedTelemetryActor)
     query_engine = QueryEngine(coordinator)
 
@@ -267,4 +281,4 @@ def start_telemetry(
         logger.info("Monarch Dashboard: %s", telemetry_url)
         print(f"Monarch Dashboard: {telemetry_url}", flush=True)
 
-    return query_engine, telemetry_url
+    return query_engine, telemetry_url, scanner

--- a/python/monarch/monarch_dashboard/server/query_engine_adapter.py
+++ b/python/monarch/monarch_dashboard/server/query_engine_adapter.py
@@ -26,7 +26,7 @@ class QueryEngineAdapter(DBAdapter):
     Usage::
 
         from monarch.distributed_telemetry.actor import start_telemetry
-        engine = start_telemetry()
+        engine, _, _scanner = start_telemetry()
         adapter = QueryEngineAdapter(engine)
         rows = adapter.query("SELECT * FROM actors LIMIT 10")
     """

--- a/python/tests/test_distributed_telemetry.py
+++ b/python/tests/test_distributed_telemetry.py
@@ -22,12 +22,12 @@ from monarch._src.actor.proc_mesh import (
     unregister_proc_mesh_spawn_callback,
 )
 from monarch.distributed_telemetry.actor import start_telemetry
-from monarch.job import ProcessJob, TelemetryConfig
+from monarch.job import MeshAdminConfig, ProcessJob, TelemetryConfig
 from scoped_state import scoped_state
 
 
 class WorkerActor(Actor):
-    """Simple worker actor that can spawn child processes."""
+    """Simple test actor with a no-op ping endpoint."""
 
     @endpoint
     def ping(self) -> None:
@@ -1208,7 +1208,7 @@ def test_query_after_stopping_actor_mesh(cleanup_callbacks) -> None:
 @isolate_in_subprocess
 def test_store_pyspy_dump_and_query(cleanup_callbacks) -> None:
     """Store a py-spy dump via actor endpoint, query it back via SQL."""
-    engine, _ = start_telemetry(include_dashboard=False)
+    engine, _, _scanner = start_telemetry(include_dashboard=False)
 
     pyspy_json = json.dumps(
         {
@@ -1298,7 +1298,7 @@ def test_store_pyspy_dump_and_query(cleanup_callbacks) -> None:
 @isolate_in_subprocess
 def test_pyspy_tables_in_information_schema(cleanup_callbacks) -> None:
     """py-spy tables are visible in information_schema."""
-    engine, _ = start_telemetry(include_dashboard=False)
+    engine, _, _scanner = start_telemetry(include_dashboard=False)
     result = engine.query(
         "SELECT table_name FROM information_schema.tables ORDER BY table_name"
     )
@@ -1463,7 +1463,7 @@ def test_store_pyspy_dump_with_unknown_proc_ref(cleanup_callbacks) -> None:
 @isolate_in_subprocess
 def test_json_columns_are_valid_json() -> None:
     """Test that all view_json and shape_json columns contain valid JSON."""
-    engine, _ = start_telemetry(batch_size=10)
+    engine, _, _scanner = start_telemetry(batch_size=10)
 
     # Spawn actors and send messages to populate all tables that have JSON columns:
     # - meshes: shape_json, parent_view_json
@@ -1575,4 +1575,187 @@ def test_per_table_row_retention(cleanup_callbacks) -> None:
         after_count = after.to_pydict()["cnt"][0]
         assert after_count < before_count, (
             f"Expected fewer rows after retention, got {after_count} vs {before_count}"
+        )
+
+
+# --- Snapshot integration tests ---
+#
+# These tests verify that introspection snapshot tables are
+# pre-registered into the telemetry query surface and that
+# periodic capture populates them through the live query path.
+
+
+@pytest.mark.timeout(60)
+@isolate_in_subprocess
+def test_snapshot_schemas_pre_registered(cleanup_callbacks) -> None:
+    """Snapshot table schemas are always present in the query surface.
+
+    Even with default config (no periodic timer), the 9 snapshot
+    tables should be visible in information_schema and queryable
+    with 0 rows. This ensures the query schema does not depend on
+    whether periodic snapshots are enabled.
+
+    SI-1 (discoverable), SI-6 (unconditional schemas); see snapshot
+    integration invariants in monarch_introspection_snapshot::integration.
+    """
+    engine, _, _scanner = start_telemetry(include_dashboard=False)
+    result = engine.query(
+        "SELECT table_name FROM information_schema.tables ORDER BY table_name"
+    )
+    table_names = result.to_pydict().get("table_name", [])
+
+    expected_snapshot_tables = [
+        "actor_failures",
+        "actor_nodes",
+        "children",
+        "host_nodes",
+        "nodes",
+        "proc_nodes",
+        "resolution_errors",
+        "root_nodes",
+        "snapshots",
+    ]
+    for table in expected_snapshot_tables:
+        assert table in table_names, (
+            f"snapshot table '{table}' should be pre-registered"
+        )
+
+    # All snapshot tables should be queryable with 0 rows.
+    for table in expected_snapshot_tables:
+        count_result = engine.query(f"SELECT COUNT(*) AS cnt FROM {table}")
+        cnt = count_result.to_pydict()["cnt"][0]
+        assert cnt == 0, f"'{table}' should have 0 rows before any capture, got {cnt}"
+
+
+@pytest.mark.timeout(180)
+@isolate_in_subprocess
+def test_snapshot_periodic_capture_populates_tables(cleanup_callbacks) -> None:
+    """Periodic snapshots become queryable through the live query path.
+
+    With periodic capture enabled, the timer fires and the full
+    snapshot relational model (nodes, children, subtype tables)
+    becomes queryable via the QueryEngine. The test verifies this
+    by tracing the ancestry of a known actor through the snapshot
+    tables using a recursive CTE.
+
+    SI-1 (discoverable), SI-2 (queryable); see snapshot integration
+    invariants in monarch_introspection_snapshot::integration.
+    """
+    import time
+
+    with scoped_state(
+        ProcessJob({"hosts": 1})
+        .enable_telemetry(TelemetryConfig(batch_size=10, snapshot_interval_secs=5))
+        .enable_admin(
+            MeshAdminConfig(
+                # Use an ephemeral admin port so concurrent --stress-runs
+                # replicas do not contend on the default fixed mesh-admin
+                # port.
+                admin_addr="[::]:0",
+            )
+        ),
+        cached_path=None,
+    ) as state:
+        engine = state.query_engine
+        assert engine is not None
+
+        # Spawn a worker so the mesh has content to snapshot.
+        hosts = state.hosts
+        worker_procs = hosts.spawn_procs(per_host={"workers": 1}, name="snap_procs")
+        workers = worker_procs.spawn("snap_worker", WorkerActor)
+        workers.initialized.get()
+
+        # PT-3: first capture fires at spawn time, so there may
+        # already be a snapshot. Record the baseline count.
+        before = engine.query("SELECT COUNT(*) AS cnt FROM snapshots")
+        before_count = before.to_pydict()["cnt"][0]
+
+        # Wait for at least one more periodic capture (interval=5s).
+        time.sleep(8)
+
+        after = engine.query("SELECT COUNT(*) AS cnt FROM snapshots")
+        after_count = after.to_pydict()["cnt"][0]
+        assert after_count > before_count, (
+            f"expected more snapshots after timer fires, got {after_count} (was {before_count})"
+        )
+
+        # --- Relational coherence proof ---
+        #
+        # Find the snap_worker actor whose direct proc parent is
+        # snap_procs, from the most recent snapshot containing one.
+        # This proves the full snapshot model (nodes, children,
+        # actor_nodes, proc_nodes, host_nodes, root_nodes) is
+        # populated and relationally coherent through the live
+        # query path.
+
+        # Find the snap_worker actor whose direct proc parent is
+        # snap_procs. A single query avoids the false-positive where
+        # actor_mesh_controller_snap_worker (on the local proc) matches
+        # the loose LIKE pattern.  If the first snapshot was captured
+        # before the worker spawned, wait for a second capture.
+        snap_worker_query = (
+            "SELECT a.node_id AS actor_node_id, a.snapshot_id AS snapshot_id,"
+            " pn.proc_name AS proc_name"
+            " FROM actor_nodes a"
+            " JOIN children ch ON ch.snapshot_id = a.snapshot_id AND ch.child_id = a.node_id"
+            " JOIN nodes p ON p.snapshot_id = ch.snapshot_id AND p.node_id = ch.parent_id AND p.node_kind = 'proc'"
+            " JOIN proc_nodes pn ON pn.snapshot_id = p.snapshot_id AND pn.node_id = p.node_id"
+            " JOIN snapshots s ON s.snapshot_id = a.snapshot_id"
+            " WHERE a.node_id LIKE '%snap_worker%'"
+            " AND a.node_id NOT LIKE '%actor_mesh_controller_%'"
+            " AND pn.proc_name LIKE 'snap_procs_%'"
+            " ORDER BY s.snapshot_ts DESC"
+            " LIMIT 1"
+        )
+        rows = engine.query(snap_worker_query).to_pydict()
+        actor_ids = rows.get("actor_node_id", [])
+        if len(actor_ids) == 0:
+            # Wait for next capture and retry.
+            time.sleep(6)
+            rows = engine.query(snap_worker_query).to_pydict()
+            actor_ids = rows.get("actor_node_id", [])
+        assert len(actor_ids) >= 1, (
+            "expected snap_worker actor on snap_procs in snapshot"
+        )
+        actor_node_id = actor_ids[0]
+        snapshot_id = rows["snapshot_id"][0]
+        assert rows["proc_name"][0].startswith("snap_procs_")
+
+        # --- Ancestry coherence: actor → proc → host → root ---
+        #
+        # Walk up from the selected actor through children/nodes
+        # to verify the full snapshot graph is connected.
+        ancestry = engine.query(f"""
+            WITH RECURSIVE ancestors AS (
+                SELECT ch.parent_id AS node_id, 1 AS depth
+                FROM children ch
+                WHERE ch.snapshot_id = '{snapshot_id}'
+                  AND ch.child_id = '{actor_node_id}'
+                UNION ALL
+                SELECT ch.parent_id, a.depth + 1
+                FROM ancestors a
+                JOIN children ch
+                  ON ch.snapshot_id = '{snapshot_id}'
+                 AND ch.child_id = a.node_id
+                WHERE a.depth < 10
+            )
+            SELECT DISTINCT a.node_id, n.node_kind
+            FROM ancestors a
+            LEFT JOIN nodes n
+              ON n.snapshot_id = '{snapshot_id}'
+             AND n.node_id = a.node_id
+        """)
+        ancestor_rows = ancestry.to_pydict()
+        ancestor_kinds = set(ancestor_rows.get("node_kind", []))
+        ancestor_ids = ancestor_rows.get("node_id", [])
+
+        assert "proc" in ancestor_kinds, (
+            f"expected a proc ancestor for {actor_node_id}, "
+            f"got kinds={ancestor_kinds}, ids={ancestor_ids}"
+        )
+        assert "host" in ancestor_kinds or any(
+            "root" in str(nid) for nid in ancestor_ids
+        ), (
+            f"expected host or root ancestor for {actor_node_id}, "
+            f"got kinds={ancestor_kinds}, ids={ancestor_ids}"
         )

--- a/python/tests/test_failure_introspection.py
+++ b/python/tests/test_failure_introspection.py
@@ -93,7 +93,8 @@ async def test_failed_actor_has_failure_info() -> None:
     monarch.actor.unhandled_fault_hook = lambda failure: faulted.set()
     try:
         host = this_host()
-        base = _to_loopback(await _spawn_admin([host], admin_addr="[::]:0"))
+        admin_url, _admin_ref = await _spawn_admin([host], admin_addr="[::]:0")
+        base = _to_loopback(admin_url)
 
         procs = host.spawn_procs(per_host={"replica": 2})
         workers = procs.spawn("worker", FailWorker)
@@ -168,7 +169,8 @@ async def test_healthy_procs_not_poisoned() -> None:
     monarch.actor.unhandled_fault_hook = lambda failure: faulted.set()
     try:
         host = this_host()
-        base = _to_loopback(await _spawn_admin([host], admin_addr="[::]:0"))
+        admin_url, _admin_ref = await _spawn_admin([host], admin_addr="[::]:0")
+        base = _to_loopback(admin_url)
 
         procs = host.spawn_procs(per_host={"replica": 3})
         workers = procs.spawn("worker", FailWorker)

--- a/python/tests/test_job.py
+++ b/python/tests/test_job.py
@@ -325,7 +325,7 @@ def test_state_query_engine_set_with_telemetry(mock_start):
     """Test that query_engine is set when telemetry is configured."""
     mock_engine = MagicMock()
     mock_url = "http://localhost:8265"
-    mock_start.return_value = (mock_engine, mock_url)
+    mock_start.return_value = (mock_engine, mock_url, MagicMock())
 
     job = MockJobTrait().enable_telemetry(TelemetryConfig())
     state = job.state(cached_path=None)
@@ -338,7 +338,7 @@ def test_state_query_engine_set_with_telemetry(mock_start):
 @patch("monarch._src.job.job.start_telemetry")
 def test_telemetry_started_only_once(mock_start):
     """Test that telemetry is not restarted on subsequent state() calls."""
-    mock_start.return_value = (MagicMock(), "http://localhost:8265")
+    mock_start.return_value = (MagicMock(), "http://localhost:8265", MagicMock())
 
     job = MockJobTrait().enable_telemetry(TelemetryConfig())
     job.state(cached_path=None)
@@ -350,7 +350,7 @@ def test_telemetry_started_only_once(mock_start):
 @patch("monarch._src.job.job.start_telemetry")
 def test_telemetry_dropped_on_pickle(mock_start):
     """Test that query_engine is dropped during pickling and restored after."""
-    mock_start.return_value = (MagicMock(), "http://localhost:8265")
+    mock_start.return_value = (MagicMock(), "http://localhost:8265", MagicMock())
 
     job = MockJobTrait().enable_telemetry(TelemetryConfig())
     job.state(cached_path=None)
@@ -378,7 +378,8 @@ def test_state_admin_url_none_without_mesh_admin():
 def test_state_admin_url_set_with_mesh_admin(mock_spawn):
     """Test that admin_url is available on the first state() call."""
     mock_future = MagicMock()
-    mock_future.get.return_value = "http://localhost:1729"
+    mock_admin_ref = MagicMock()
+    mock_future.get.return_value = ("http://localhost:1729", mock_admin_ref)
     mock_spawn.return_value = mock_future
 
     job = MockJobTrait().enable_admin(MeshAdminConfig())
@@ -392,7 +393,8 @@ def test_state_admin_url_set_with_mesh_admin(mock_spawn):
 def test_mesh_admin_started_only_once(mock_spawn):
     """Test that mesh admin is not restarted on subsequent state() calls."""
     mock_future = MagicMock()
-    mock_future.get.return_value = "http://localhost:1729"
+    mock_admin_ref = MagicMock()
+    mock_future.get.return_value = ("http://localhost:1729", mock_admin_ref)
     mock_spawn.return_value = mock_future
 
     job = MockJobTrait().enable_admin(MeshAdminConfig())
@@ -406,7 +408,8 @@ def test_mesh_admin_started_only_once(mock_spawn):
 def test_mesh_admin_dropped_on_pickle(mock_spawn):
     """Test that admin_url is dropped during pickling and restored after."""
     mock_future = MagicMock()
-    mock_future.get.return_value = "http://localhost:1729"
+    mock_admin_ref = MagicMock()
+    mock_future.get.return_value = ("http://localhost:1729", mock_admin_ref)
     mock_spawn.return_value = mock_future
 
     job = MockJobTrait().enable_admin(MeshAdminConfig())
@@ -427,7 +430,8 @@ def test_mesh_admin_dropped_on_pickle(mock_spawn):
 def test_mesh_admin_receives_custom_addr(mock_spawn):
     """Test that MeshAdminConfig.admin_addr is forwarded to _spawn_admin."""
     mock_future = MagicMock()
-    mock_future.get.return_value = "http://myhost:9999"
+    mock_admin_ref = MagicMock()
+    mock_future.get.return_value = ("http://myhost:9999", mock_admin_ref)
     mock_spawn.return_value = mock_future
 
     job = MockJobTrait().enable_admin(MeshAdminConfig(admin_addr="myhost:9999"))

--- a/python/tests/test_python_actors.py
+++ b/python/tests/test_python_actors.py
@@ -1458,7 +1458,7 @@ def test_config_propagates_to_host_agent():
     from monarch.config import configure
 
     # Set a non-default admin address on the client side.
-    configure(mesh_admin_addr="[::]:9999")
+    configure(mesh_admin_addr="[::]:0")
 
     with TemporaryDirectory() as d:
         procs = []
@@ -1485,10 +1485,10 @@ def test_config_propagates_to_host_agent():
         # _spawn_admin() spawns MeshAdminAgent on the caller's local
         # proc. The admin agent reads MESH_ADMIN_ADDR from config.
         head = hosts.slice(hosts=0)
-        admin_addr = _spawn_admin([head]).get()
+        admin_addr, _admin_ref = _spawn_admin([head]).get()
 
-        assert ":9999" in admin_addr, (
-            f"Expected :9999 in admin addr '{admin_addr}', "
+        assert ":1729" not in admin_addr, (
+            f"Expected non-default port in admin addr '{admin_addr}', "
             "client config not propagated to host agent process"
         )
 


### PR DESCRIPTION
Summary:
add a minimal refresh-suspension policy for the mesh admin tui and apply it while foreground operations are in flight.

this introduces RefreshPolicy as a small join-semilattice with carrier Baseline | Suspend and uses it in the event loop to compute an effective refresh policy before running background topology refresh. phase 3a derives refresh pressure from foreground job state only. diagnostics suspend refresh while running, and py-spy/config suspend refresh while their request is in flight. completed overlays no longer suppress refresh; once the operation finishes, background refresh resumes on the next scheduled tick.

the change also adds tests for the RefreshPolicy join behavior and for the job-state mapping, including the distinction between in-flight and completed overlays.

Differential Revision: D100482856
