### PR TITLE
fix bootstrap runtime_dir to fall back when XDG_RUNTIME_DIR directory does not exist

### DIFF
--- a/hyperactor_mesh/src/bootstrap.rs
+++ b/hyperactor_mesh/src/bootstrap.rs
@@ -2539,15 +2539,16 @@ impl Write for Debug {
 }
 
 /// Create a new runtime [`TempDir`]. The directory is created in
-/// `$XDG_RUNTIME_DIR`, otherwise falling back to the system tempdir.
+/// `$XDG_RUNTIME_DIR` if set and the directory exists, otherwise
+/// falling back to the system tempdir.
 fn runtime_dir() -> io::Result<TempDir> {
-    match std::env::var_os("XDG_RUNTIME_DIR") {
-        Some(runtime_dir) => {
-            let path = PathBuf::from(runtime_dir);
-            tempfile::tempdir_in(path)
+    if let Some(runtime_dir) = std::env::var_os("XDG_RUNTIME_DIR") {
+        let path = PathBuf::from(runtime_dir);
+        if path.is_dir() {
+            return tempfile::tempdir_in(path);
         }
-        None => tempfile::tempdir(),
     }
+    tempfile::tempdir()
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Summary:
let's start here:
- this continuous run failed https://www.internalfb.com/intern/testinfra/diagnostics/13792274024009467.281475288933721.1776125933/
- the sandcastle job is https://www.internalfb.com/sandcastle/workflow/4030721666512423202
- the stdout log says https://www.internalfb.com/sandcastle/workflow/4030721666512423202/artifact/actionlog.4030721666762450476.stdout.1
- there are many failures including the mesh admin integration tests
```
21 TESTS FAILED
  ✗ fbcode//monarch/python/monarch:test_wheel_from_exploded_pythonpath - main
  ✗ fbcode//monarch/python/monarch/meta/tests:test_torch_distributed - test_torch_distributed.py::test_pg_init_with_addr_and_port
  ✗ fbcode//monarch/python/monarch/meta/tests:test_torch_distributed - test_torch_distributed.py::test_pg_init
  ✗ fbcode//monarch/hyperactor_mesh:mesh_admin_integration_test - test_dining_endpoints_rust
  ✗ fbcode//monarch/hyperactor_mesh:mesh_admin_integration_test - test_auth_failures_rust
  ✗ fbcode//monarch/hyperactor_mesh:mesh_admin_integration_test - test_ref_traversal_rust
  ✗ fbcode//monarch/hyperactor_mesh:mesh_admin_integration_test - test_ref_edge_cases_rust
  ✗ fbcode//monarch/hyperactor_mesh:mesh_admin_integration_test - test_openapi_conformance_rust
  ✗ fbcode//monarch/hyperactor_mesh:mesh_admin_integration_test - test_dining_endpoints_python
  ✗ fbcode//monarch/hyperactor_mesh:mesh_admin_integration_test - test_query_proxy_success
```
- there are 9 occurences of this kind of message
  - `E       Exception: No such file or directory (os error 2) at path "/run/user/0/.tmpcLkojp"`
- `test_pg_init` attributes this as its cause of failure

the theory is CI sets `XDG_RUNTIME_DIR=/run/user/0` in the environment. the directory doesn't exist in the container. runtime_dir() trusts the env var blindly, calls tempfile::tempdir_in("/run/user/0"), gets "No such file or directory", and BootstrapProcManager::new() fails.

Differential Revision: D100730589


