### PR TITLE
[monarch] reduce config test frame-size allocations

### DIFF
--- a/python/tests/test_config.py
+++ b/python/tests/test_config.py
@@ -89,66 +89,45 @@ def test_get_set_multiple() -> None:
     assert config["default_transport"] == BindSpec(ChannelTransport.Unix)
 
 
-# This test tries to allocate too much memory for the GitHub actions
-# environment.
-@pytest.mark.oss_skip
 @isolate_in_subprocess
 def test_codec_max_frame_length_exceeds_default() -> None:
-    """Test that sending 10 chunks of 1GiB fails with default 10 GiB
-    limit."""
+    """Test that sending 4 chunks of 256KiB fails with a 1 MiB limit."""
 
-    oneGiB = 1024 * 1024 * 1024
-    tenGiB = 10 * oneGiB
+    oneMiB = 1024 * 1024
+    chunk_size = oneMiB // 4
 
-    # Verify default is 10 GiB
-    config = get_global_config()
-    assert config["codec_max_frame_length"] == tenGiB
+    with configured(codec_max_frame_length=oneMiB):
+        config = get_global_config()
+        assert config["codec_max_frame_length"] == oneMiB
 
-    monarch.actor.unhandled_fault_hook = lambda failure: None
-    # Try to send 10 chunks of 1GiB each with default 10 GiB limit
-    # This should fail due to serialization overhead.
-    # Spawn in separate proc so messages are serialized via Unix
-    # sockets
-    proc = this_host().spawn_procs()
-
-    # Create 10 chunks, 1GiB each (total 10GiB)
-    chunks = [bytes(oneGiB) for _ in range(10)]
-
-    # Spawn actor and send chunks - should fail with SupervisionError
-    chunker = proc.spawn("chunker", Chunker)
-    with pytest.raises(SupervisionError):
-        chunker.process_chunks.call_one(chunks).get()
-
-
-# This test tries to allocate too much memory for the GitHub actions
-# environment.
-@pytest.mark.oss_skip
-def test_codec_max_frame_length_with_increased_limit() -> None:
-    """Test that we can successfully send 10 chunks of 1GiB each with
-    100 GiB limit."""
-
-    oneGiB = 1024 * 1024 * 1024
-    tenGiB = 10 * oneGiB
-    oneHundredGiB = 10 * tenGiB
-
-    # Verify default is 10 GiB
-    config = get_global_config()
-    assert config["codec_max_frame_length"] == tenGiB
-
-    # Set the frame limit to confidently handle 10GiB
-    with configured(codec_max_frame_length=oneHundredGiB):
-        # Spawn in separate proc so messages are serialized via Unix
-        # sockets
+        monarch.actor.unhandled_fault_hook = lambda failure: None
+        # The raw chunk data totals 1 MiB, so serialization overhead should
+        # push the frame over the configured limit.
         proc = this_host().spawn_procs()
+        chunks = [bytes(chunk_size) for _ in range(4)]
 
-        # Create 10 chunks, 1GiB each (total 10GiB)
-        chunks = [bytes(oneGiB) for _ in range(10)]
+        chunker = proc.spawn("chunker", Chunker)
+        with pytest.raises(SupervisionError):
+            chunker.process_chunks.call_one(chunks).get()
 
-        # Spawn actor and send chunks - should succeed
+
+def test_codec_max_frame_length_with_increased_limit() -> None:
+    """Test that increasing the limit allows the same payload through."""
+
+    oneMiB = 1024 * 1024
+    chunk_size = oneMiB // 4
+    increased_limit = 2 * oneMiB
+
+    with configured(codec_max_frame_length=increased_limit):
+        config = get_global_config()
+        assert config["codec_max_frame_length"] == increased_limit
+
+        proc = this_host().spawn_procs()
+        chunks = [bytes(chunk_size) for _ in range(4)]
         chunker = proc.spawn("chunker", Chunker)
         result = chunker.process_chunks.call_one(chunks).get()
 
-        assert result == 10
+        assert result == 4
 
 
 def test_duration_config_basic() -> None:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #3419

Lower the frame-size boundary in the Python config tests by overriding `codec_max_frame_length` to 1 MiB inside the tests instead of allocating payloads sized around the 10 GiB default. Keep the same boundary coverage with small payloads, and remove the `oss_skip` annotations now that the tests no longer require excessive memory.

Differential Revision: [D100731676](https://our.internmc.facebook.com/intern/diff/D100731676/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D100731676/)!