### PR TITLE
mesh admin: proc debug stats: add hosting-process memory and actor queue pressure to proc/host introspection surfaces (#3420)

### DIFF
--- a/hyperactor/src/proc.rs
+++ b/hyperactor/src/proc.rs
@@ -50,6 +50,30 @@
 //!   counter are two consumers of one accounting path. The
 //!   `account_enqueue` / `account_dequeue` helpers update both
 //!   together so they cannot drift.
+//!
+//! ## Retained queue-pressure invariants (PD-6 through PD-9)
+//!
+//! `ProcQueueStats` holds proc-level retained evidence of queue
+//! pressure. These are runtime-driven (not publish-time sampled)
+//! so they capture between-publish bursts.
+//!
+//! - **PD-6:** `high_water_mark >= running_total` eventually.
+//!   Because `running_total` is incremented before `high_water_mark`
+//!   is updated, a concurrent reader may transiently observe
+//!   `total > high_water_mark`. This is a sampling artifact, not
+//!   an accounting error.
+//! - **PD-7:** `last_nonzero_age_ms() == None` iff proc queue
+//!   depth has never been non-zero since startup. The timestamp
+//!   is updated on enqueue and on dequeue when the queue remains
+//!   non-zero, so it reflects the last observed non-zero state.
+//! - **PD-8:** transient bursts that drain before publish still
+//!   update both the high-water mark and the last-nonzero state.
+//! - **PD-9:** `last_nonzero_age_ms()` is expected to be
+//!   non-decreasing during quiet periods, but this is not a hard
+//!   guarantee — the implementation uses `SystemTime` (wall clock),
+//!   which can move backward on NTP adjustments. Callers should
+//!   treat the age as best-effort telemetry, not a monotonic
+//!   invariant.
 
 use std::any::Any;
 use std::any::TypeId;
@@ -138,20 +162,129 @@ use crate::metrics::ACTOR_MESSAGE_HANDLER_DURATION;
 use crate::metrics::ACTOR_MESSAGE_QUEUE_SIZE;
 use crate::metrics::ACTOR_MESSAGES_RECEIVED;
 
-/// Single accounting path for actor work-queue depth. Two consumers:
-/// introspection-readable `queue_depth` state and OTel telemetry
-/// export. Unifying the update in one helper ensures they cannot
-/// drift (PD-5b/PD-5c).
-fn account_enqueue(queue_depth: &AtomicU64, actor_id: &str) {
+/// Returns current epoch-millis from wall clock. Used by
+/// `ProcQueueStats` for timestamp recording. In tests, override
+/// via `ProcQueueStats::with_clock` to get deterministic behavior.
+fn wall_clock_epoch_ms() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as u64
+}
+
+/// Proc-level retained queue-pressure state (PD-6 through PD-9).
+///
+/// Runtime-driven and updated from the enqueue/dequeue accounting
+/// path, not from publish-time sampling. These metrics preserve
+/// between-publish queue-pressure evidence that instantaneous
+/// sampling misses.
+pub(crate) struct ProcQueueStats {
+    /// Proc-wide running total of queued work items. Incremented on
+    /// enqueue, decremented on dequeue. O(1) alternative to iterating
+    /// per-actor depths.
+    running_total: AtomicU64,
+    /// Maximum proc-wide queue depth observed since startup (PD-6).
+    high_water_mark: AtomicU64,
+    /// Epoch-millis of the most recent moment when proc-wide queue
+    /// depth was observed non-zero (PD-7). Sentinel 0 means never.
+    /// Updated on enqueue and on dequeue when the queue remains
+    /// non-zero, so the age reflects the last observed non-zero
+    /// state rather than merely the last enqueue.
+    last_nonzero_epoch_ms: AtomicU64,
+    /// Clock function for timestamps. Defaults to `wall_clock_epoch_ms`.
+    /// Tests can override via `with_clock` for deterministic behavior.
+    clock: fn() -> u64,
+}
+
+impl ProcQueueStats {
+    fn new() -> Self {
+        Self {
+            running_total: AtomicU64::new(0),
+            high_water_mark: AtomicU64::new(0),
+            last_nonzero_epoch_ms: AtomicU64::new(0),
+            clock: wall_clock_epoch_ms,
+        }
+    }
+
+    /// Create with a custom clock for testing.
+    #[cfg(test)]
+    fn with_clock(clock: fn() -> u64) -> Self {
+        Self {
+            running_total: AtomicU64::new(0),
+            high_water_mark: AtomicU64::new(0),
+            last_nonzero_epoch_ms: AtomicU64::new(0),
+            clock,
+        }
+    }
+
+    /// Current epoch-millis from this instance's clock.
+    fn now_ms(&self) -> u64 {
+        (self.clock)()
+    }
+
+    /// Current proc-wide running total.
+    pub(crate) fn running_total(&self) -> u64 {
+        self.running_total.load(Ordering::Relaxed)
+    }
+
+    /// Maximum proc-wide queue depth since startup (PD-6).
+    pub(crate) fn high_water_mark(&self) -> u64 {
+        self.high_water_mark.load(Ordering::Relaxed)
+    }
+
+    /// How long ago proc-wide queue depth was last observed non-zero
+    /// (PD-7). `None` means no counted actor work has traversed the
+    /// queue accounting path since startup. Uses the configured clock
+    /// (wall clock in production, injectable in tests).
+    pub(crate) fn last_nonzero_age_ms(&self) -> Option<u64> {
+        let ts = self.last_nonzero_epoch_ms.load(Ordering::Relaxed);
+        if ts == 0 {
+            return None;
+        }
+        Some(self.now_ms().saturating_sub(ts))
+    }
+}
+
+/// Single accounting path for actor work-queue enqueue.
+///
+/// Updates three consumers together: per-actor `queue_depth`,
+/// proc-level retained queue-pressure state (`ProcQueueStats`),
+/// and OTel `ACTOR_MESSAGE_QUEUE_SIZE`. Unifying the update
+/// here ensures they cannot drift.
+fn account_enqueue(queue_depth: &AtomicU64, proc_stats: &ProcQueueStats, actor_id: &str) {
     queue_depth.fetch_add(1, Ordering::Relaxed);
+    let new_total = proc_stats.running_total.fetch_add(1, Ordering::Relaxed) + 1;
+    // PD-6: update high-water mark.
+    proc_stats
+        .high_water_mark
+        .fetch_max(new_total, Ordering::Relaxed);
+    // PD-7: record that the proc is non-zero right now.
+    proc_stats
+        .last_nonzero_epoch_ms
+        .store(proc_stats.now_ms(), Ordering::Relaxed);
     ACTOR_MESSAGE_QUEUE_SIZE.add(
         1,
         hyperactor_telemetry::kv_pairs!("actor_id" => actor_id.to_owned()),
     );
 }
 
-fn account_dequeue(queue_depth: &AtomicU64, actor_id: &str) {
+/// Single accounting path for actor work-queue dequeue.
+///
+/// Updates per-actor `queue_depth`, proc-level running total,
+/// OTel `ACTOR_MESSAGE_QUEUE_SIZE`, and the last-nonzero
+/// timestamp when the proc-wide queue remains non-zero after
+/// this dequeue.
+fn account_dequeue(queue_depth: &AtomicU64, proc_stats: &ProcQueueStats, actor_id: &str) {
     queue_depth.fetch_sub(1, Ordering::Relaxed);
+    let prev_total = proc_stats.running_total.fetch_sub(1, Ordering::Relaxed);
+    // PD-7: if the queue is still non-zero after this dequeue,
+    // update the timestamp so last_nonzero_age_ms reflects
+    // "last observed non-zero state," not just "last enqueue."
+    if prev_total > 1 {
+        proc_stats
+            .last_nonzero_epoch_ms
+            .store(proc_stats.now_ms(), Ordering::Relaxed);
+    }
     ACTOR_MESSAGE_QUEUE_SIZE.add(
         -1,
         hyperactor_telemetry::kv_pairs!("actor_id" => actor_id.to_owned()),
@@ -209,6 +342,12 @@ struct ProcState {
 
     /// All actor instances in this proc.
     instances: DashMap<reference::ActorId, WeakInstanceCell>,
+
+    /// Proc-level queue-pressure accounting (PD-6 through PD-9).
+    /// Runtime-driven — updated from `account_enqueue` /
+    /// `account_dequeue`, not from publish-time sampling.
+    /// `Arc`-wrapped so `Ports<A>` enqueue closures can share it.
+    queue_stats: Arc<ProcQueueStats>,
 
     /// Snapshots of terminated actors for post-mortem introspection.
     /// Populated by the introspect task just before it exits on
@@ -277,6 +416,7 @@ impl Proc {
                 forwarder,
                 roots: DashMap::new(),
                 instances: DashMap::new(),
+                queue_stats: Arc::new(ProcQueueStats::new()),
                 terminated_snapshots: DashMap::new(),
                 supervision_coordinator_port: OnceLock::new(),
                 supervision_coordinator_actor_id: OnceLock::new(),
@@ -546,6 +686,21 @@ impl Proc {
                 }
             }
         }
+    }
+
+    /// Proc-wide running total of queued work items.
+    pub fn queue_depth_total(&self) -> u64 {
+        self.state().queue_stats.running_total()
+    }
+
+    /// Maximum proc-wide queue depth observed since startup (PD-6).
+    pub fn queue_depth_high_water_mark(&self) -> u64 {
+        self.state().queue_stats.high_water_mark()
+    }
+
+    /// How long ago proc-wide queue depth was last non-zero (PD-7).
+    pub fn last_nonzero_queue_depth_age_ms(&self) -> Option<u64> {
+        self.state().queue_stats.last_nonzero_age_ms()
     }
 
     /// Look up an instance by ActorId.
@@ -1267,10 +1422,12 @@ impl<A: Actor> Instance<A> {
             hyperactor_config::global::get(config::ENABLE_DEST_ACTOR_REORDERING_BUFFER),
         );
         let queue_depth = Arc::new(AtomicU64::new(0));
+        let proc_stats = Arc::clone(&proc.state().queue_stats);
         let ports: Arc<Ports<A>> = Arc::new(Ports::new(
             mailbox.clone(),
             work_tx,
             Arc::clone(&queue_depth),
+            proc_stats,
         ));
         proc.state().proc_muxer.bind_mailbox(mailbox.clone());
         let (status_tx, status_rx) = watch::channel(ActorStatus::Created);
@@ -1873,7 +2030,7 @@ impl<A: Actor> Instance<A> {
             tokio::select! {
                 work = work_rx.recv() => {
                     ACTOR_MESSAGES_RECEIVED.add(1, metric_pairs);
-                    account_dequeue(&self.inner.cell.inner.queue_depth, &actor_id_str);
+                    account_dequeue(&self.inner.cell.inner.queue_depth, &self.inner.proc.state().queue_stats, &actor_id_str);
                     let _ = ACTOR_MESSAGE_HANDLER_DURATION.start(metric_pairs);
                     let work = work.expect("inconsistent work queue state");
                     if let Err(err) = work.handle(actor, self).await {
@@ -1924,7 +2081,11 @@ impl<A: Actor> Instance<A> {
             let mut n = 0;
             while let Ok(work) = work_rx.try_recv() {
                 // PD-5c: drained work items must also be accounted.
-                account_dequeue(&self.inner.cell.inner.queue_depth, &actor_id_str);
+                account_dequeue(
+                    &self.inner.cell.inner.queue_depth,
+                    &self.inner.proc.state().queue_stats,
+                    &actor_id_str,
+                );
                 if let Err(err) = work.handle(actor, self).await {
                     return Err(ActorError::new(
                         self.self_id(),
@@ -2878,12 +3039,10 @@ pub struct Ports<A: Actor> {
     bound: DashMap<u64, &'static str>,
     mailbox: Mailbox,
     workq: OrderedSender<WorkCell<A>>,
-    /// Introspection-readable queue depth (PD-5). Shared leaf
-    /// state owned by both the send-side (`Ports`) and the
-    /// runtime-side (`InstanceCellState`) paths — no
-    /// cycle-breaking role. Updated via `account_enqueue` /
-    /// `account_dequeue` helpers alongside the OTel counter.
+    /// Per-actor queue depth (PD-5). Shared with `InstanceCellState`.
     queue_depth: Arc<AtomicU64>,
+    /// Proc-level queue-pressure stats (PD-6 through PD-9).
+    proc_stats: Arc<ProcQueueStats>,
 }
 
 impl<A: Actor> Ports<A> {
@@ -2891,6 +3050,7 @@ impl<A: Actor> Ports<A> {
         mailbox: Mailbox,
         workq: OrderedSender<WorkCell<A>>,
         queue_depth: Arc<AtomicU64>,
+        proc_stats: Arc<ProcQueueStats>,
     ) -> Self {
         Self {
             ports: DashMap::new(),
@@ -2898,6 +3058,7 @@ impl<A: Actor> Ports<A> {
             mailbox,
             workq,
             queue_depth,
+            proc_stats,
         }
     }
 
@@ -2925,6 +3086,7 @@ impl<A: Actor> Ports<A> {
                 let workq = self.workq.clone();
                 let actor_id = self.mailbox.actor_id().to_string();
                 let enqueue_depth = Arc::clone(&self.queue_depth);
+                let enqueue_proc_stats = Arc::clone(&self.proc_stats);
                 let port = self.mailbox.open_enqueue_port(move |headers, msg: M| {
                     let seq_info = headers.get(SEQ_INFO);
 
@@ -2978,7 +3140,7 @@ impl<A: Actor> Ports<A> {
                         workq.direct_send(work).map_err(anyhow::Error::from)
                     };
                     if result.is_ok() {
-                        account_enqueue(&enqueue_depth, &actor_id);
+                        account_enqueue(&enqueue_depth, &enqueue_proc_stats, &actor_id);
                     }
                     result
                 });
@@ -4569,5 +4731,139 @@ mod tests {
             );
             tokio::time::sleep(std::time::Duration::from_millis(10)).await;
         }
+    }
+
+    // ── PD-6 through PD-9: retained queue-pressure evidence ───
+
+    // PD-7: cold start — no queue traffic means last-nonzero is None
+    // and watermark is 0.
+    #[async_timed_test(timeout_secs = 5)]
+    async fn test_retained_queue_stats_cold_start() {
+        let proc = Proc::local();
+        assert_eq!(proc.queue_depth_total(), 0);
+        assert_eq!(proc.queue_depth_high_water_mark(), 0);
+        assert_eq!(proc.last_nonzero_queue_depth_age_ms(), None);
+    }
+
+    // PD-6/PD-8: after induced pressure drains, high-water mark
+    // retains the peak and last-nonzero is Some.
+    #[async_timed_test(timeout_secs = 10)]
+    async fn test_retained_queue_stats_burst_then_drain() {
+        let proc = Proc::local();
+        let (client, _) = proc.instance("client").unwrap();
+        let h = proc.spawn("ret_test", TestActor).unwrap();
+
+        // Block the actor.
+        let (ready_tx, ready_rx) = oneshot::channel();
+        let (gate_tx, gate_rx) = oneshot::channel::<()>();
+        h.wait(&client, ready_tx, gate_rx).await.unwrap();
+        ready_rx.await.unwrap();
+
+        // Queue work behind it.
+        h.noop(&client).await.unwrap();
+        h.noop(&client).await.unwrap();
+
+        // Poll until watermark is updated.
+        let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(5);
+        loop {
+            let hwm = proc.queue_depth_high_water_mark();
+            if hwm >= 2 {
+                // PD-6: watermark >= current total.
+                assert!(hwm >= proc.queue_depth_total());
+                // Active pressure: last-nonzero should be near zero.
+                let age = proc.last_nonzero_queue_depth_age_ms();
+                assert!(
+                    age.is_some(),
+                    "last-nonzero should be Some while pressure is active"
+                );
+                assert!(age.unwrap() < 2000, "last-nonzero age should be near zero");
+                break;
+            }
+            assert!(
+                tokio::time::Instant::now() < deadline,
+                "timed out waiting for watermark >= 2",
+            );
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+
+        // Unblock and drain.
+        let _ = gate_tx.send(());
+        let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(5);
+        loop {
+            if proc.queue_depth_total() == 0 {
+                break;
+            }
+            assert!(
+                tokio::time::Instant::now() < deadline,
+                "timed out waiting for total to drain",
+            );
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+
+        // PD-8: watermark retained after drain.
+        assert!(
+            proc.queue_depth_high_water_mark() >= 2,
+            "watermark should retain the peak after drain",
+        );
+
+        // PD-7: last-nonzero is Some (not None) after pressure.
+        let age = proc.last_nonzero_queue_depth_age_ms();
+        assert!(age.is_some(), "last-nonzero should be Some after pressure");
+    }
+
+    // PD-7: deterministic test of dequeue-side timestamp refresh
+    // using a fake clock. Proves "last observed non-zero" semantics
+    // without timing-dependent sleeps.
+    #[test]
+    fn test_last_nonzero_refreshed_on_dequeue_deterministic() {
+        use std::sync::atomic::AtomicU64;
+
+        static FAKE_NOW: AtomicU64 = AtomicU64::new(0);
+        fn fake_clock() -> u64 {
+            FAKE_NOW.load(Ordering::Relaxed)
+        }
+
+        let stats = ProcQueueStats::with_clock(fake_clock);
+        let depth = Arc::new(AtomicU64::new(0));
+
+        // Cold start: no activity.
+        assert_eq!(stats.last_nonzero_age_ms(), None);
+
+        // t=1000: enqueue two items.
+        FAKE_NOW.store(1000, Ordering::Relaxed);
+        account_enqueue(&depth, &stats, "a");
+        account_enqueue(&depth, &stats, "a");
+        assert_eq!(stats.running_total(), 2);
+        assert_eq!(stats.high_water_mark(), 2);
+
+        // t=2000: read age — should be 1000ms since last nonzero.
+        FAKE_NOW.store(2000, Ordering::Relaxed);
+        assert_eq!(stats.last_nonzero_age_ms(), Some(1000));
+
+        // t=3000: dequeue one item. Queue still non-zero (1 left).
+        // This should refresh the timestamp to 3000.
+        FAKE_NOW.store(3000, Ordering::Relaxed);
+        account_dequeue(&depth, &stats, "a");
+        assert_eq!(stats.running_total(), 1);
+
+        // t=4000: read age — should be 1000ms (4000 - 3000), not
+        // 3000ms (4000 - 1000). This proves the dequeue refreshed
+        // the timestamp.
+        FAKE_NOW.store(4000, Ordering::Relaxed);
+        assert_eq!(stats.last_nonzero_age_ms(), Some(1000));
+
+        // t=5000: dequeue last item. Queue is now zero.
+        // prev_total was 1, so prev_total > 1 is false — timestamp
+        // is NOT refreshed. It stays at 3000.
+        FAKE_NOW.store(5000, Ordering::Relaxed);
+        account_dequeue(&depth, &stats, "a");
+        assert_eq!(stats.running_total(), 0);
+
+        // t=6000: age should be 3000ms (6000 - 3000).
+        FAKE_NOW.store(6000, Ordering::Relaxed);
+        assert_eq!(stats.last_nonzero_age_ms(), Some(3000));
+
+        // Watermark retained.
+        assert_eq!(stats.high_water_mark(), 2);
     }
 }

--- a/hyperactor_mesh/src/host_mesh/host_agent.rs
+++ b/hyperactor_mesh/src/host_mesh/host_agent.rs
@@ -561,13 +561,31 @@ impl Actor for HostAgent {
                     attrs.set(crate::introspect::PROC_NAME, label.to_string());
                     attrs.set(crate::introspect::NUM_ACTORS, actors.len());
                     attrs.set(crate::introspect::SYSTEM_CHILDREN, system_actors.clone());
-                    // PD-*: include hosting-process memory so QueryChild
-                    // results match the publish path. HostAgent cannot
-                    // aggregate per-actor queue depth for these procs
-                    // (that requires ProcAgent), so queue stats default
-                    // to zero — acceptable for system procs.
+                    // PD-*: include proc debug stats so QueryChild
+                    // results carry real signal. Memory from procfs,
+                    // queue stats from the Proc's runtime accounting.
                     let memory = crate::introspect::ProcessMemoryStats::read_from_procfs();
                     memory.to_attrs(&mut attrs);
+                    attrs.set(
+                        crate::introspect::ACTOR_WORK_QUEUE_DEPTH_TOTAL,
+                        proc.queue_depth_total(),
+                    );
+                    // Per-actor max from the live actor scan.
+                    let mut queue_max: u64 = 0;
+                    for aid in proc.all_instance_keys() {
+                        if let Some(cell) = proc.get_instance(&aid) {
+                            queue_max = queue_max.max(cell.queue_depth());
+                        }
+                    }
+                    attrs.set(crate::introspect::ACTOR_WORK_QUEUE_DEPTH_MAX, queue_max);
+                    attrs.set(
+                        crate::introspect::ACTOR_WORK_QUEUE_DEPTH_HIGH_WATER_MARK,
+                        proc.queue_depth_high_water_mark(),
+                    );
+                    attrs.set(
+                        crate::introspect::LAST_NONZERO_QUEUE_DEPTH_AGE_MS,
+                        proc.last_nonzero_queue_depth_age_ms(),
+                    );
                     let attrs_json =
                         serde_json::to_string(&attrs).unwrap_or_else(|_| "{}".to_string());
 
@@ -1831,5 +1849,116 @@ mod tests {
                 ..
             }
         );
+    }
+
+    // PD-6/PD-8 regression: QueryChild(Proc) on the service proc
+    // returns non-zero queue stats after the host_agent has handled
+    // messages. Guards against the bug where the HostAgent closure
+    // defaulted queue stats to zero because it predated Proc-level
+    // queue accessors.
+    #[tokio::test]
+    #[cfg(fbcode_build)]
+    async fn test_service_proc_query_child_has_queue_stats() {
+        use hyperactor::actor::ActorStatus;
+        use hyperactor::introspect::IntrospectMessage;
+        use hyperactor::introspect::IntrospectResult;
+        use hyperactor::reference as hyperactor_reference;
+
+        let host = Host::new(
+            BootstrapProcManager::new(BootstrapCommand::test()).unwrap(),
+            ChannelTransport::Unix.any(),
+        )
+        .await
+        .unwrap();
+
+        let system_proc = host.system_proc().clone();
+        let host_agent = system_proc
+            .spawn(
+                HOST_MESH_AGENT_ACTOR_NAME,
+                HostAgent::new(HostAgentMode::Process {
+                    host,
+                    shutdown_tx: None,
+                }),
+            )
+            .unwrap();
+
+        // Wait for HostAgent to finish init.
+        host_agent
+            .status()
+            .wait_for(|s| matches!(s, ActorStatus::Idle))
+            .await
+            .unwrap();
+
+        let client_proc =
+            Proc::direct(ChannelTransport::Unix.any(), "qd_client".to_string()).unwrap();
+        let (client, _client_handle) = client_proc.instance("client").unwrap();
+
+        // Spawn a proc so the host_agent processes at least one
+        // CreateOrUpdate message, which goes through the work queue.
+        let name = Name::new("qd_test_proc").unwrap();
+        host_agent
+            .create_or_update(
+                &client,
+                name.clone(),
+                resource::Rank::new(0),
+                ProcSpec::default(),
+            )
+            .await
+            .unwrap();
+
+        // The host_agent has now processed messages on the service
+        // proc. Query the service proc's introspection.
+        let agent_id = system_proc
+            .proc_id()
+            .actor_id(HOST_MESH_AGENT_ACTOR_NAME, 0);
+        let port =
+            hyperactor_reference::PortRef::<IntrospectMessage>::attest_message_port(&agent_id);
+
+        // Poll until we see non-zero watermark (evidence of queue
+        // traffic since startup).
+        let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(10);
+        loop {
+            let (reply_port, reply_rx) = client.open_once_port::<IntrospectResult>();
+            port.send(
+                &client,
+                IntrospectMessage::QueryChild {
+                    child_ref: hyperactor_reference::Reference::Proc(system_proc.proc_id().clone()),
+                    reply: reply_port.bind(),
+                },
+            )
+            .unwrap();
+            let payload = tokio::time::timeout(std::time::Duration::from_secs(5), reply_rx.recv())
+                .await
+                .expect("QueryChild timed out")
+                .expect("reply channel closed");
+
+            let attrs: hyperactor_config::Attrs =
+                serde_json::from_str(&payload.attrs).expect("valid attrs JSON");
+
+            let hwm = attrs
+                .get(crate::introspect::ACTOR_WORK_QUEUE_DEPTH_HIGH_WATER_MARK)
+                .copied()
+                .unwrap_or(0);
+            let last_nonzero: Option<u64> = attrs
+                .get(crate::introspect::LAST_NONZERO_QUEUE_DEPTH_AGE_MS)
+                .copied()
+                .flatten();
+
+            if hwm > 0 {
+                // The service proc's watermark should reflect
+                // the messages the host_agent processed.
+                assert!(
+                    last_nonzero.is_some(),
+                    "last-nonzero should be Some when watermark is {hwm}",
+                );
+                break;
+            }
+
+            assert!(
+                tokio::time::Instant::now() < deadline,
+                "timed out waiting for service proc watermark > 0",
+            );
+            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        }
     }
 }

--- a/hyperactor_mesh/src/introspect.rs
+++ b/hyperactor_mesh/src/introspect.rs
@@ -410,6 +410,27 @@ declare_attrs! {
     })
     pub attr ACTOR_WORK_QUEUE_DEPTH_MAX: u64 = 0;
 
+    /// Maximum proc-wide queue depth observed since startup (PD-6).
+    /// Eventually consistent — concurrent readers may transiently
+    /// observe total > high_water_mark. Retained evidence — driven
+    /// from the runtime accounting path, not publish-time sampling.
+    @meta(INTROSPECT = IntrospectAttr {
+        name: "actor_work_queue_depth_high_water_mark".into(),
+        desc: "Maximum proc-wide queue depth since startup (eventually consistent)".into(),
+    })
+    pub attr ACTOR_WORK_QUEUE_DEPTH_HIGH_WATER_MARK: u64 = 0;
+
+    /// How long ago proc-wide queue depth was last observed non-zero
+    /// (PD-7). `None` means no counted actor work has traversed the
+    /// queue accounting path since startup. Uses wall clock, so the
+    /// age is best-effort telemetry and may not be strictly monotonic.
+    /// Retained evidence — driven from the runtime accounting path.
+    @meta(INTROSPECT = IntrospectAttr {
+        name: "last_nonzero_queue_depth_age_ms".into(),
+        desc: "Milliseconds since proc-wide queue depth was last observed non-zero (wall clock)".into(),
+    })
+    pub attr LAST_NONZERO_QUEUE_DEPTH_AGE_MS: Option<u64>;
+
 }
 
 use hyperactor::introspect::AttrsViewError;
@@ -578,6 +599,14 @@ pub struct ProcDebugStats {
     /// actors in this proc at publish time. Not a historical
     /// high-water mark.
     pub actor_work_queue_depth_max: u64,
+    /// Maximum proc-wide queue depth observed since startup (PD-6).
+    /// Eventually consistent — see PD-6 docs. Retained — driven
+    /// from the runtime accounting path.
+    pub actor_work_queue_depth_high_water_mark: u64,
+    /// How long ago proc-wide queue depth was last observed non-zero
+    /// (PD-7). `None` means never. Wall clock — see PD-9 docs.
+    /// Retained — driven from the runtime accounting path.
+    pub last_nonzero_queue_depth_age_ms: Option<u64>,
 }
 
 impl ProcDebugStats {
@@ -595,10 +624,23 @@ impl ProcDebugStats {
                 total,
             );
         }
+        let high_water = attrs
+            .get(ACTOR_WORK_QUEUE_DEPTH_HIGH_WATER_MARK)
+            .copied()
+            .unwrap_or(0);
+        // PD-6: high_water_mark >= total eventually, but concurrent
+        // readers may transiently see total > high_water_mark (a
+        // sampling artifact, not an accounting error).
+        let last_nonzero = attrs
+            .get(LAST_NONZERO_QUEUE_DEPTH_AGE_MS)
+            .copied()
+            .flatten();
         Self {
             memory: ProcessMemoryStats::from_attrs(attrs),
             actor_work_queue_depth_total: total,
             actor_work_queue_depth_max: max,
+            actor_work_queue_depth_high_water_mark: high_water,
+            last_nonzero_queue_depth_age_ms: last_nonzero,
         }
     }
 
@@ -609,6 +651,14 @@ impl ProcDebugStats {
             self.actor_work_queue_depth_total,
         );
         attrs.set(ACTOR_WORK_QUEUE_DEPTH_MAX, self.actor_work_queue_depth_max);
+        attrs.set(
+            ACTOR_WORK_QUEUE_DEPTH_HIGH_WATER_MARK,
+            self.actor_work_queue_depth_high_water_mark,
+        );
+        attrs.set(
+            LAST_NONZERO_QUEUE_DEPTH_AGE_MS,
+            self.last_nonzero_queue_depth_age_ms,
+        );
     }
 }
 
@@ -1161,6 +1211,14 @@ mod tests {
                 "actor_work_queue_depth_max",
                 ACTOR_WORK_QUEUE_DEPTH_MAX.attrs(),
             ),
+            (
+                "actor_work_queue_depth_high_water_mark",
+                ACTOR_WORK_QUEUE_DEPTH_HIGH_WATER_MARK.attrs(),
+            ),
+            (
+                "last_nonzero_queue_depth_age_ms",
+                LAST_NONZERO_QUEUE_DEPTH_AGE_MS.attrs(),
+            ),
         ];
 
         for (expected_name, meta) in &cases {
@@ -1299,6 +1357,8 @@ mod tests {
                 },
                 actor_work_queue_depth_total: 42,
                 actor_work_queue_depth_max: 7,
+                actor_work_queue_depth_high_water_mark: 100,
+                last_nonzero_queue_depth_age_ms: Some(5000),
             },
         };
         let rt = ProcAttrsView::from_attrs(&view.to_attrs()).unwrap();

--- a/hyperactor_mesh/src/introspect/dto.rs
+++ b/hyperactor_mesh/src/introspect/dto.rs
@@ -107,6 +107,10 @@ pub struct ProcDebugStatsDto {
     pub actor_work_queue_depth_total: u64,
     /// Max per-actor queue depth (live actors only).
     pub actor_work_queue_depth_max: u64,
+    /// Maximum proc-wide queue depth since startup (PD-6, eventually consistent).
+    pub actor_work_queue_depth_high_water_mark: u64,
+    /// Milliseconds since proc-wide queue depth was last observed non-zero (PD-7, wall clock).
+    pub last_nonzero_queue_depth_age_ms: Option<u64>,
 }
 
 /// Node-specific metadata. Externally-tagged enum — the JSON
@@ -260,6 +264,9 @@ impl From<NodeProperties> for NodePropertiesDto {
                     },
                     actor_work_queue_depth_total: debug.actor_work_queue_depth_total,
                     actor_work_queue_depth_max: debug.actor_work_queue_depth_max,
+                    actor_work_queue_depth_high_water_mark: debug
+                        .actor_work_queue_depth_high_water_mark,
+                    last_nonzero_queue_depth_age_ms: debug.last_nonzero_queue_depth_age_ms,
                 },
             },
             NodeProperties::Actor {
@@ -386,6 +393,9 @@ impl TryFrom<NodePropertiesDto> for NodeProperties {
                     },
                     actor_work_queue_depth_total: debug.actor_work_queue_depth_total,
                     actor_work_queue_depth_max: debug.actor_work_queue_depth_max,
+                    actor_work_queue_depth_high_water_mark: debug
+                        .actor_work_queue_depth_high_water_mark,
+                    last_nonzero_queue_depth_age_ms: debug.last_nonzero_queue_depth_age_ms,
                 },
             },
             NodePropertiesDto::Actor {

--- a/hyperactor_mesh/src/proc_agent.rs
+++ b/hyperactor_mesh/src/proc_agent.rs
@@ -577,18 +577,28 @@ impl ProcAgent {
         let memory = crate::introspect::ProcessMemoryStats::read_from_procfs();
         memory.to_attrs(&mut attrs);
 
-        // PD-4: aggregate queue depth over live actors only.
-        let mut queue_total: u64 = 0;
+        // Proc-wide total from runtime accounting path (O(1)).
+        let queue_total = self.proc.queue_depth_total();
+        attrs.set(crate::introspect::ACTOR_WORK_QUEUE_DEPTH_TOTAL, queue_total);
+
+        // Per-actor max still needs the per-actor scan (PD-4: live actors only).
         let mut queue_max: u64 = 0;
         for actor_id in self.proc.all_instance_keys() {
             if let Some(cell) = self.proc.get_instance(&actor_id) {
-                let depth = cell.queue_depth();
-                queue_total = queue_total.saturating_add(depth);
-                queue_max = queue_max.max(depth);
+                queue_max = queue_max.max(cell.queue_depth());
             }
         }
-        attrs.set(crate::introspect::ACTOR_WORK_QUEUE_DEPTH_TOTAL, queue_total);
         attrs.set(crate::introspect::ACTOR_WORK_QUEUE_DEPTH_MAX, queue_max);
+
+        // Retained queue-pressure evidence (PD-6, PD-7).
+        attrs.set(
+            crate::introspect::ACTOR_WORK_QUEUE_DEPTH_HIGH_WATER_MARK,
+            self.proc.queue_depth_high_water_mark(),
+        );
+        attrs.set(
+            crate::introspect::LAST_NONZERO_QUEUE_DEPTH_AGE_MS,
+            self.proc.last_nonzero_queue_depth_age_ms(),
+        );
 
         cx.instance().publish_attrs(attrs);
     }
@@ -685,17 +695,25 @@ impl Actor for ProcAgent {
                     // to prevent resolution drift from the publish path.
                     let memory = crate::introspect::ProcessMemoryStats::read_from_procfs();
                     memory.to_attrs(&mut attrs);
-                    let mut queue_total: u64 = 0;
+                    attrs.set(
+                        crate::introspect::ACTOR_WORK_QUEUE_DEPTH_TOTAL,
+                        proc.queue_depth_total(),
+                    );
                     let mut queue_max: u64 = 0;
                     for aid in proc.all_instance_keys() {
                         if let Some(cell) = proc.get_instance(&aid) {
-                            let depth = cell.queue_depth();
-                            queue_total = queue_total.saturating_add(depth);
-                            queue_max = queue_max.max(depth);
+                            queue_max = queue_max.max(cell.queue_depth());
                         }
                     }
-                    attrs.set(crate::introspect::ACTOR_WORK_QUEUE_DEPTH_TOTAL, queue_total);
                     attrs.set(crate::introspect::ACTOR_WORK_QUEUE_DEPTH_MAX, queue_max);
+                    attrs.set(
+                        crate::introspect::ACTOR_WORK_QUEUE_DEPTH_HIGH_WATER_MARK,
+                        proc.queue_depth_high_water_mark(),
+                    );
+                    attrs.set(
+                        crate::introspect::LAST_NONZERO_QUEUE_DEPTH_AGE_MS,
+                        proc.last_nonzero_queue_depth_age_ms(),
+                    );
 
                     let attrs_json =
                         serde_json::to_string(&attrs).unwrap_or_else(|_| "{}".to_string());

--- a/hyperactor_mesh/src/testdata/node_payload_schema.json
+++ b/hyperactor_mesh/src/testdata/node_payload_schema.json
@@ -277,6 +277,12 @@
     "ProcDebugStats": {
       "description": "Proc-level debug/operational stats (DTO mirror of\n`ProcDebugStats`).",
       "properties": {
+        "actor_work_queue_depth_high_water_mark": {
+          "description": "Maximum proc-wide queue depth since startup (PD-6, eventually consistent).",
+          "format": "uint64",
+          "minimum": 0,
+          "type": "integer"
+        },
         "actor_work_queue_depth_max": {
           "description": "Max per-actor queue depth (live actors only).",
           "format": "uint64",
@@ -289,6 +295,15 @@
           "minimum": 0,
           "type": "integer"
         },
+        "last_nonzero_queue_depth_age_ms": {
+          "description": "Milliseconds since proc-wide queue depth was last observed non-zero (PD-7, wall clock).",
+          "format": "uint64",
+          "minimum": 0,
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
         "memory": {
           "$ref": "#/$defs/ProcessMemoryStats",
           "description": "Hosting-process memory."
@@ -297,7 +312,8 @@
       "required": [
         "memory",
         "actor_work_queue_depth_total",
-        "actor_work_queue_depth_max"
+        "actor_work_queue_depth_max",
+        "actor_work_queue_depth_high_water_mark"
       ],
       "type": "object"
     },

--- a/hyperactor_mesh/src/testdata/openapi.json
+++ b/hyperactor_mesh/src/testdata/openapi.json
@@ -380,6 +380,12 @@
       "ProcDebugStats": {
         "description": "Proc-level debug/operational stats (DTO mirror of\n`ProcDebugStats`).",
         "properties": {
+          "actor_work_queue_depth_high_water_mark": {
+            "description": "Maximum proc-wide queue depth since startup (PD-6, eventually consistent).",
+            "format": "uint64",
+            "minimum": 0,
+            "type": "integer"
+          },
           "actor_work_queue_depth_max": {
             "description": "Max per-actor queue depth (live actors only).",
             "format": "uint64",
@@ -392,6 +398,15 @@
             "minimum": 0,
             "type": "integer"
           },
+          "last_nonzero_queue_depth_age_ms": {
+            "description": "Milliseconds since proc-wide queue depth was last observed non-zero (PD-7, wall clock).",
+            "format": "uint64",
+            "minimum": 0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
           "memory": {
             "$ref": "#/components/schemas/ProcessMemoryStats",
             "description": "Hosting-process memory."
@@ -400,7 +415,8 @@
         "required": [
           "memory",
           "actor_work_queue_depth_total",
-          "actor_work_queue_depth_max"
+          "actor_work_queue_depth_max",
+          "actor_work_queue_depth_high_water_mark"
         ],
         "type": "object"
       },

--- a/hyperactor_mesh_admin_tui/src/render/detail_pane.rs
+++ b/hyperactor_mesh_admin_tui/src/render/detail_pane.rs
@@ -347,6 +347,23 @@ fn render_proc_detail(
         ),
         scheme,
     ));
+    // Retained queue-pressure evidence (PD-6, PD-7).
+    if debug.actor_work_queue_depth_high_water_mark > 0 {
+        lines.push(detail_line(
+            l.peak_depth,
+            debug.actor_work_queue_depth_high_water_mark.to_string(),
+            scheme,
+        ));
+    }
+    lines.push(detail_line(
+        l.last_busy,
+        match debug.last_nonzero_queue_depth_age_ms {
+            None => "never".to_string(),
+            Some(ms) if ms < 1000 => format!("{}ms ago", ms),
+            Some(ms) => format!("{}s ago", ms / 1000),
+        },
+        scheme,
+    ));
     lines.push(detail_line(
         l.data_as_of,
         format_system_time_relative(&payload.as_of),
@@ -845,6 +862,8 @@ mod tests {
                     },
                     actor_work_queue_depth_total: 42,
                     actor_work_queue_depth_max: 7,
+                    actor_work_queue_depth_high_water_mark: 100,
+                    last_nonzero_queue_depth_age_ms: Some(3000),
                 },
             },
             children: vec![],

--- a/hyperactor_mesh_admin_tui/src/theme.rs
+++ b/hyperactor_mesh_admin_tui/src/theme.rs
@@ -97,6 +97,8 @@ pub(crate) struct Labels {
     pub(crate) rss: &'static str,
     pub(crate) vm_size: &'static str,
     pub(crate) queue_depth: &'static str,
+    pub(crate) peak_depth: &'static str,
+    pub(crate) last_busy: &'static str,
 
     // Failure detail labels
     pub(crate) error_message: &'static str,
@@ -188,6 +190,8 @@ impl Labels {
             rss: "RSS: ",
             vm_size: "VM Size: ",
             queue_depth: "Queue depth: ",
+            peak_depth: "Peak depth: ",
+            last_busy: "Last busy: ",
             error_message: "Error: ",
             root_cause: "Root cause: ",
             failed_at: "Failed at: ",
@@ -269,6 +273,8 @@ impl Labels {
             rss: "RSS: ",
             vm_size: "虚拟内存: ",
             queue_depth: "队列深度: ",
+            peak_depth: "峰值深度: ",
+            last_busy: "最近繁忙: ",
             error_message: "错误: ",
             root_cause: "根因: ",
             failed_at: "失败时间: ",


### PR DESCRIPTION
Summary:

adds retained proc queue-pressure metrics so the TUI and admin/introspection surfaces preserve evidence of recent queue activity that instantaneous sampling can miss. the runtime now maintains proc-level queue totals, a high-water mark, and last-nonzero age from the shared enqueue/dequeue accounting path in hyperactor::proc, exposes those fields through proc debug attrs, DTOs, and schema snapshots, renders peak depth and last busy in the detail pane, and adds coverage for cold-start, burst-then-drain, and service-proc HostAgent QueryChild(Proc) resolution so service-proc queue stats no longer default to zero.

peak depth tells you the worst backlog this proc has ever had. last busy tells you how long ago the proc last observed non-zero backlog:
- Peak depth 100, last busy 2ms ago: this proc has had serious pressure and still does, or only just drained.
- Peak depth 100, last busy 5min ago: this proc had serious pressure but has been idle since.
- Peak depth 2, last busy 30s ago: this proc has only ever had light backlog, last seen 30 seconds ago.
- Peak depth 0, last busy never: this proc has never had a message queued through the accounting path.

Differential Revision: D100736470


