### PR TITLE
Add 10s timeout to child scan futures to prevent slow-child blocking

### DIFF
--- a/python/monarch/distributed_telemetry/actor.py
+++ b/python/monarch/distributed_telemetry/actor.py
@@ -46,6 +46,8 @@ from monarch.monarch_dashboard.server.query_engine_adapter import QueryEngineAda
 
 logger: logging.Logger = logging.getLogger(__name__)
 
+_SCAN_CHILD_TIMEOUT_SECS: float = 10.0
+
 
 # Module-level scanner created at process startup to avoid race conditions.
 _scanner: Optional[DatabaseScanner] = None
@@ -223,10 +225,14 @@ class DistributedTelemetryActor(Actor):
         total_count = local_count
         for fut in child_futures:
             try:
-                child_results = fut.get()
+                child_results = fut.get(timeout=_SCAN_CHILD_TIMEOUT_SECS)
                 # pyre-ignore[16]: child_results is iterable of tuples
                 for _rank, count in child_results:
                     total_count += count
+            except TimeoutError:
+                logger.warning(
+                    "child scan timed out after %ss", _SCAN_CHILD_TIMEOUT_SECS
+                )
             except Exception:
                 logger.info("child scan failed, skipping")
 

--- a/python/monarch/monarch_dashboard/frontend/src/hooks/useApi.ts
+++ b/python/monarch/monarch_dashboard/frontend/src/hooks/useApi.ts
@@ -22,13 +22,13 @@ export interface ApiState<T> {
  * Hook for fetching data from the dashboard API.
  *
  * Triggers a fetch on mount and whenever `path` changes.  Automatically
- * re-fetches every `pollIntervalMs` milliseconds (default 1000).
+ * re-fetches every `pollIntervalMs` milliseconds (default 2000).
  * Set `pollIntervalMs` to 0 to disable polling.
  *
  * Only the initial fetch sets loading=true; subsequent polls update
  * data silently to avoid flashing a loading state.
  */
-export function useApi<T>(path: string, pollIntervalMs: number = 1000): ApiState<T> {
+export function useApi<T>(path: string, pollIntervalMs: number = 2000): ApiState<T> {
   const [data, setData] = useState<T | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);

--- a/python/monarch/monarch_dashboard/server/admin_dag.py
+++ b/python/monarch/monarch_dashboard/server/admin_dag.py
@@ -18,7 +18,6 @@ for infrastructure actors that aren't flagged (e.g. telemetry, setup).
 import logging
 import os
 import re
-import time
 import urllib.parse
 from typing import Any, Dict, List, Optional, Set, Tuple
 
@@ -27,11 +26,6 @@ import requests
 from . import db
 
 logger = logging.getLogger(__name__)
-
-# Cache the built DAG to avoid re-walking on every poll.
-_dag_cache: Optional[Dict[str, Any]] = None
-_dag_cache_time: float = 0.0
-_DAG_CACHE_TTL = 2.0  # seconds
 
 # Max walk depth: Root(0) -> Host(1) -> Proc(2) -> Actor(3).
 _MAX_TREE_DEPTH = 4
@@ -234,17 +228,9 @@ def build_admin_dag(hide_system: bool = True) -> Dict[str, Any]:
 
     Returns ``{"nodes": [...], "edges": [...]}``.
     """
-    global _dag_cache, _dag_cache_time
-
     admin_url = _get_admin_url()
     if not admin_url:
         return {"nodes": [], "edges": []}
-
-    now = time.monotonic()
-    cached = _dag_cache
-    if cached is not None and now - _dag_cache_time < _DAG_CACHE_TTL:
-        if cached.get("_hide_system") == hide_system:
-            return cached
 
     session = requests.Session()
     configure_tls(session)
@@ -380,10 +366,7 @@ def build_admin_dag(hide_system: bool = True) -> Dict[str, Any]:
     # Add message edges from telemetry.
     _add_message_edges(nodes, edges)
 
-    result = {"nodes": nodes, "edges": edges, "_hide_system": hide_system}
-    _dag_cache = result
-    _dag_cache_time = now
-    return result
+    return {"nodes": nodes, "edges": edges}
 
 
 def _add_message_edges(

--- a/python/monarch/monarch_dashboard/server/cache.py
+++ b/python/monarch/monarch_dashboard/server/cache.py
@@ -1,0 +1,31 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Simple TTL cache shared by dashboard route handlers.
+
+Telemetry data is inherently slightly stale (scanners batch at intervals),
+so a short cache avoids redundant distributed scans when the dashboard
+polls multiple endpoints concurrently.
+"""
+
+import time
+from typing import Any, Callable
+
+_cache: dict[str, tuple[float, Any]] = {}
+
+# Default TTL in seconds.
+CACHE_TTL = 2.0
+
+
+def cached(key: str, fn: Callable[[], Any], ttl: float = CACHE_TTL) -> Any:
+    """Return a cached result for *key*, or compute via *fn* and cache it."""
+    now = time.monotonic()
+    entry = _cache.get(key)
+    if entry is not None and now - entry[0] < ttl:
+        return entry[1]
+    result = fn()
+    _cache[key] = (now, result)
+    return result

--- a/python/monarch/monarch_dashboard/server/db.py
+++ b/python/monarch/monarch_dashboard/server/db.py
@@ -830,43 +830,51 @@ def get_summary() -> dict[str, Any]:
 
     # -- Error details --
     # Use LOWER() so both fake data ("failed") and real telemetry ("Failed") match.
+    # Single query for both failed and stopped actors.
     _error_actor_sql = (
-        "SELECT ase.actor_id, a.full_name, ase.reason, ase.timestamp_us, a.mesh_id"
+        "SELECT ase.actor_id, a.full_name, ase.reason, ase.timestamp_us, a.mesh_id,"
+        " ase.new_status"
         " FROM actor_status_events ase"
         " JOIN actors a ON ase.actor_id = a.id"
         f" INNER JOIN ({_LATEST_ACTOR_STATUS_SQL}) latest"
         " ON ase.actor_id = latest.actor_id"
         "   AND ase.timestamp_us = latest.max_ts"
-        " WHERE LOWER(ase.new_status) = ?"
+        " WHERE LOWER(ase.new_status) IN ('failed', 'stopped')"
         " ORDER BY ase.timestamp_us"
     )
-    failed_actors = _query(_error_actor_sql, ("failed",))
-    stopped_actors = _query(_error_actor_sql, ("stopped",))
+    error_actors = _query(_error_actor_sql)
+    failed_actors = []
+    stopped_actors = []
+    for r in error_actors:
+        status = (r.pop("new_status", None) or "").lower()
+        if status == "failed":
+            failed_actors.append(r)
+        elif status == "stopped":
+            stopped_actors.append(r)
 
     # Hyperactor telemetry doesn't track message delivery failures.
     # Actor failures from undeliverable messages are already surfaced in
     # failed_actors above (the failure reason contains the delivery error).
     failed_messages = 0
 
-    # -- Timeline --
-    time_range = _query_one(
-        "SELECT MIN(timestamp_us) AS start_us, MAX(timestamp_us) AS end_us "
-        "FROM actor_status_events"
+    # -- Timeline (single query instead of four) --
+    timeline_row = _query_one(
+        "SELECT MIN(timestamp_us) AS start_us,"
+        " MAX(timestamp_us) AS end_us,"
+        " MIN(CASE WHEN LOWER(new_status) = 'failed'"
+        "   THEN timestamp_us END) AS failure_onset_us,"
+        " COUNT(*) AS total_status_events"
+        " FROM actor_status_events"
     )
-    start_us = time_range["start_us"] if time_range else 0
-    end_us = time_range["end_us"] if time_range else 0
-
-    failure_onset_row = _query_one(
-        "SELECT MIN(timestamp_us) AS ts FROM actor_status_events "
-        "WHERE LOWER(new_status) = 'failed'"
-    )
+    start_us = timeline_row["start_us"] if timeline_row else 0
+    end_us = timeline_row["end_us"] if timeline_row else 0
     failure_onset_us = (
-        failure_onset_row["ts"]
-        if failure_onset_row and failure_onset_row["ts"]
+        timeline_row["failure_onset_us"]
+        if timeline_row and timeline_row["failure_onset_us"]
         else None
     )
+    total_status_events = timeline_row["total_status_events"] if timeline_row else 0
 
-    total_status_events = _count("SELECT COUNT(*) AS n FROM actor_status_events")
     total_message_events = _count("SELECT COUNT(*) AS n FROM message_status_events")
 
     # -- Health score (0-100) --

--- a/python/monarch/monarch_dashboard/server/routes.py
+++ b/python/monarch/monarch_dashboard/server/routes.py
@@ -18,6 +18,7 @@ from flask import Blueprint, jsonify, request
 
 from . import db
 from .admin_dag import build_admin_dag
+from .cache import cached
 from .system_actors import get_system_actor_names
 
 api = Blueprint("api", __name__, url_prefix="/api")
@@ -62,7 +63,7 @@ def health():
 @api.route("/summary")
 def summary():
     """Aggregate metrics for the summary dashboard."""
-    return jsonify(_sanitize_for_js(db.get_summary()))
+    return jsonify(cached("summary", lambda: _sanitize_for_js(db.get_summary())))
 
 
 @api.route("/dag")
@@ -79,24 +80,26 @@ def dag():
     Optional: ?hide_system=true (default) to filter system actors.
     """
     hide_system = request.args.get("hide_system", "true").lower() != "false"
+    cache_key = f"dag:hide_system={hide_system}"
     try:
-        # Prefer the admin API for a clean TUI-like hierarchy.
-        if os.environ.get("MONARCH_ADMIN_URL"):
-            result = build_admin_dag(hide_system=hide_system)
-            if result.get("nodes"):
-                # Strip internal cache keys before returning.
-                return jsonify(
-                    _sanitize_for_js(
+
+        def _compute_dag():
+            # Prefer the admin API for a clean TUI-like hierarchy.
+            if os.environ.get("MONARCH_ADMIN_URL"):
+                result = build_admin_dag(hide_system=hide_system)
+                if result.get("nodes"):
+                    return _sanitize_for_js(
                         {
                             "nodes": result["nodes"],
                             "edges": result["edges"],
                         }
                     )
-                )
 
-        # Fallback: telemetry SQL layer.
-        system_names = get_system_actor_names() if hide_system else set()
-        return jsonify(_sanitize_for_js(db.get_dag_data(system_names=system_names)))
+            # Fallback: telemetry SQL layer.
+            system_names = get_system_actor_names() if hide_system else set()
+            return _sanitize_for_js(db.get_dag_data(system_names=system_names))
+
+        return jsonify(cached(cache_key, _compute_dag))
     except Exception as exc:
         return jsonify({"error": str(exc), "nodes": [], "edges": []}), 500
 
@@ -120,13 +123,17 @@ def list_meshes():
     parent_mesh_id = request.args.get("parent_mesh_id", type=int)
     exclude_raw = request.args.get("exclude_classes", type=str)
     exclude_classes = exclude_raw.split(",") if exclude_raw else None
+    cache_key = f"meshes:{class_filter}:{parent_mesh_id}:{exclude_raw}"
     return jsonify(
-        _sanitize_for_js(
-            db.list_meshes(
-                class_filter=class_filter,
-                parent_mesh_id=parent_mesh_id,
-                exclude_classes=exclude_classes,
-            )
+        cached(
+            cache_key,
+            lambda: _sanitize_for_js(
+                db.list_meshes(
+                    class_filter=class_filter,
+                    parent_mesh_id=parent_mesh_id,
+                    exclude_classes=exclude_classes,
+                )
+            ),
         )
     )
 
@@ -167,7 +174,10 @@ def get_mesh_children(mesh_id):
 def list_actors():
     """List all actors.  Optional: ?mesh_id=1"""
     mesh_id = request.args.get("mesh_id", type=int)
-    return jsonify(_sanitize_for_js(db.list_actors(mesh_id=mesh_id)))
+    cache_key = f"actors:mesh_id={mesh_id}"
+    return jsonify(
+        cached(cache_key, lambda: _sanitize_for_js(db.list_actors(mesh_id=mesh_id)))
+    )
 
 
 @api.route("/actors/<int:actor_id>")

--- a/python/monarch/monarch_dashboard/server/tests/test_cache.py
+++ b/python/monarch/monarch_dashboard/server/tests/test_cache.py
@@ -1,0 +1,90 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Unit tests for the TTL cache module."""
+
+import time
+import unittest
+
+from monarch.monarch_dashboard.server import cache
+
+
+class CacheTest(unittest.TestCase):
+    def setUp(self):
+        cache._cache.clear()
+
+    def test_cache_miss_calls_fn(self):
+        calls = []
+
+        def fn():
+            calls.append(1)
+            return {"data": 42}
+
+        result = cache.cached("key1", fn)
+        self.assertEqual(result, {"data": 42})
+        self.assertEqual(len(calls), 1)
+
+    def test_cache_hit_returns_cached_value(self):
+        calls = []
+
+        def fn():
+            calls.append(1)
+            return len(calls)
+
+        first = cache.cached("key1", fn)
+        second = cache.cached("key1", fn)
+        self.assertEqual(first, 1)
+        self.assertEqual(second, 1)
+        self.assertEqual(len(calls), 1)
+
+    def test_different_keys_are_independent(self):
+        result_a = cache.cached("a", lambda: "alpha")
+        result_b = cache.cached("b", lambda: "beta")
+        self.assertEqual(result_a, "alpha")
+        self.assertEqual(result_b, "beta")
+
+    def test_expired_entry_recomputes(self):
+        calls = []
+
+        def fn():
+            calls.append(1)
+            return len(calls)
+
+        cache.cached("key1", fn, ttl=0.05)
+        self.assertEqual(len(calls), 1)
+
+        time.sleep(0.06)
+
+        result = cache.cached("key1", fn, ttl=0.05)
+        self.assertEqual(result, 2)
+        self.assertEqual(len(calls), 2)
+
+    def test_fn_exception_propagates(self):
+        def fn():
+            raise ValueError("boom")
+
+        with self.assertRaises(ValueError):
+            cache.cached("key1", fn)
+
+        # Failed call should not cache anything
+        self.assertNotIn("key1", cache._cache)
+
+    def test_fn_exception_does_not_cache(self):
+        """After a failed fn, a subsequent call should retry."""
+        calls = []
+
+        def fn():
+            calls.append(1)
+            if len(calls) == 1:
+                raise RuntimeError("first call fails")
+            return "success"
+
+        with self.assertRaises(RuntimeError):
+            cache.cached("key1", fn)
+
+        result = cache.cached("key1", fn)
+        self.assertEqual(result, "success")
+        self.assertEqual(len(calls), 2)

--- a/python/tests/test_distributed_telemetry.py
+++ b/python/tests/test_distributed_telemetry.py
@@ -9,6 +9,8 @@
 """Tests for distributed telemetry with automatic callback registration."""
 
 import json
+import time
+import unittest.mock
 from typing import cast
 
 import monarch.distributed_telemetry.actor as telemetry_actor
@@ -1543,7 +1545,6 @@ def test_json_columns_are_valid_json() -> None:
 @isolate_in_subprocess
 def test_per_table_row_retention(cleanup_callbacks) -> None:
     """Test that time-based retention deletes old rows from message tables."""
-    import time
 
     # Use a 1-second retention window so rows expire quickly.
     with scoped_state(
@@ -1576,6 +1577,62 @@ def test_per_table_row_retention(cleanup_callbacks) -> None:
         assert after_count < before_count, (
             f"Expected fewer rows after retention, got {after_count} vs {before_count}"
         )
+
+
+@pytest.mark.timeout(60)
+@isolate_in_subprocess
+def test_scan_timeout_on_dead_child(cleanup_callbacks) -> None:
+    """Test that scan completes with partial results when a child times out.
+
+    Stops a child proc mesh and patches the scan timeout to a short value,
+    then verifies the query completes within a bounded time instead of hanging.
+    """
+    with scoped_state(
+        ProcessJob({"hosts": 1}).enable_telemetry(TelemetryConfig(batch_size=10)),
+        cached_path=None,
+    ) as state:
+        engine = state.query_engine
+        assert engine is not None
+        hosts = state.hosts
+        worker_procs = hosts.spawn_procs(
+            per_host={"workers": 2}, name="timeout_test_procs"
+        )
+
+        workers = worker_procs.spawn("timeout_test_worker", WorkerActor)
+        workers.initialized.get()
+        workers.ping.call().get()
+
+        # Verify data exists before stopping
+        result = engine.query(
+            "SELECT full_name FROM actors WHERE full_name LIKE '%timeout_test_worker%'"
+        )
+        pre_count = len(result.to_pydict().get("full_name", []))
+        assert pre_count > 0, "Expected timeout_test_worker actors before stopping"
+
+        # Stop the proc mesh to kill child telemetry actors
+        worker_procs.stop().get()
+
+        # Patch the timeout to a short value so the test doesn't wait 10s
+        with unittest.mock.patch.object(
+            telemetry_actor, "_SCAN_CHILD_TIMEOUT_SECS", 1.0
+        ):
+            start = time.monotonic()
+            result = engine.query("SELECT * FROM actors")
+            elapsed = time.monotonic() - start
+
+            # The query should complete — not hang forever
+            result_dict = result.to_pydict()
+            actor_count = len(result_dict.get("id", []))
+            assert actor_count > 0, (
+                f"Expected actors in result after child timeout, got {actor_count}"
+            )
+
+            # Should complete well within the test timeout (60s).
+            # With a 1s scan timeout, expect completion in a few seconds.
+            assert elapsed < 15, (
+                f"Query took {elapsed:.1f}s — expected it to complete quickly "
+                f"with 1s child scan timeout"
+            )
 
 
 # --- Snapshot integration tests ---


### PR DESCRIPTION
Summary: Previously fut.get() blocked indefinitely on each child in the scan endpoint. A slow or dead child would hang the entire scan and eventually the dashboard. Now child scans time out after 10 seconds, log a warning, and return partial results.

Differential Revision: D100886229


