### PR TITLE
Turn off undeliverable return for GetState<ActorState> messages used by the controllers

### DIFF
--- a/hyperactor_mesh/src/proc_mesh.rs
+++ b/hyperactor_mesh/src/proc_mesh.rs
@@ -810,11 +810,15 @@ impl ProcMeshRef {
     ) -> crate::Result<ValueMesh<resource::State<ActorState>>> {
         let agent_mesh = self.agent_mesh();
         let (port, mut rx) = cx.mailbox().open_port::<resource::State<ActorState>>();
+        let mut port = port.bind();
+        // If this proc dies or some other issue renders the reply undeliverable,
+        // the reply does not need to be returned to the sender.
+        port.return_undeliverable(false);
         // TODO: Use accumulation to get back a single value (representing whether
         // *any* of the actors failed) instead of a mesh.
         let get_state = resource::GetState::<ActorState> {
             name: name.clone(),
-            reply: port.bind(),
+            reply: port,
         };
         if let Some(expires_after) = keepalive {
             agent_mesh.cast(


### PR DESCRIPTION
Summary:
The ActorMeshController sends out periodic `GetState<ActorState>` queries to the ProcAgent
via `ProcMesh::actor_states`. If the ProcAgent is unable to send a reply, it shouldn't stop that actor,
as it's just an informational message.
This was already done for querying the HostAgent about Procs, same goes for querying the ProcAgent
about Actors.

Normally the ActorMeshController should be reachable and able to ack messages, so this case
should be rare. But if we encounter it we don't want more actors to fail that are otherwise healthy.

Also, the mesh controller already has a timeout mechanism to determine a failure when the proc agent
can't reply, so it's ok if the agent can't send a message back.

Reviewed By: shayne-fletcher

Differential Revision: D101062141


