### PR TITLE
forward_to_tracing: capture Python actor logs in per-actor flight recorder by entering recording span from _context

### DIFF
--- a/hyperactor/src/proc.rs
+++ b/hyperactor/src/proc.rs
@@ -35,6 +35,21 @@
 //!   under different parents get distinct pids but the same name
 //!   prefix.
 //!
+//! ## Flight recorder span invariants (FR-*)
+//!
+//! - **FR-1 (recording-span route equivalence):**
+//!   `Instance::recording_span()` returns a span bound to the same
+//!   actor-local `Recording` consumed by handler instrumentation and
+//!   introspection. Events emitted under that span land in the same
+//!   flight-recorder ring buffer returned by `introspect_payload()`.
+//! - **FR-2 (recording-span rootness):** Every span returned by
+//!   `Instance::recording_span()` is a fresh root span (`parent:
+//!   None`). Ambient tracing context does not cause events emitted
+//!   under that span to route into a parent actor's flight recorder.
+//! - **FR-3 (fresh-handle, stable-destination):** Repeated calls to
+//!   `Instance::recording_span()` return distinct span handles, but
+//!   all target the same underlying actor recording.
+//!
 //! ## Queue depth accounting invariants (PD-5*)
 //!
 //! - **PD-5a:** Per-actor queue depth counts work items enqueued for
@@ -1579,6 +1594,12 @@ impl<A: Actor> Instance<A> {
     /// requests, not for hot paths.
     pub fn introspect_payload(&self) -> crate::introspect::IntrospectResult {
         crate::introspect::live_actor_payload(&self.inner.cell)
+    }
+
+    /// Return a fresh tracing span bound to this actor's flight
+    /// recorder. See FR-1, FR-2, FR-3 in module doc.
+    pub fn recording_span(&self) -> tracing::Span {
+        self.inner.cell.recording().span()
     }
 
     /// Publish domain-specific properties for introspection.

--- a/monarch_hyperactor/src/context.rs
+++ b/monarch_hyperactor/src/context.rs
@@ -153,6 +153,11 @@ impl<I: context::Actor<A = PythonActor>> From<I> for PyInstance {
 pub struct PyContext {
     instance: Py<PyInstance>,
     rank: Point,
+    /// Cloneable handle to a span carrying the actor's recording key.
+    /// When entered, events emitted under this span are captured by
+    /// the per-actor flight recorder. `None` for bootstrap/client
+    /// contexts that are not actor handler execution paths.
+    recording_span: Option<tracing::Span>,
 }
 
 #[pymethods]
@@ -174,6 +179,7 @@ impl PyContext {
         Ok(PyContext {
             instance: instance.into_pyobject(py)?.into(),
             rank: Extent::unity().point_of_rank(0).unwrap(),
+            recording_span: None,
         })
     }
 
@@ -185,6 +191,7 @@ impl PyContext {
         Ok(PyContext {
             instance: instance.into_pyobject(py)?.into(),
             rank: Extent::unity().point_of_rank(0).unwrap(),
+            recording_span: None,
         })
     }
 }
@@ -197,7 +204,26 @@ impl PyContext {
         PyContext {
             instance,
             rank: cx.cast_point(),
+            recording_span: Some(cx.recording_span()),
         }
+    }
+
+    /// The actor's recording span, if this context is an actor handler
+    /// execution path. Used by `forward_to_tracing` to enter the
+    /// recording scope on the asyncio thread so that log events are
+    /// captured in the flight recorder.
+    pub(crate) fn recording_span(&self) -> Option<&tracing::Span> {
+        self.recording_span.as_ref()
+    }
+
+    /// Test-only: build a PyContext with a chosen recording span.
+    /// Uses the root client actor for the instance field (the test
+    /// only exercises the recording_span extraction path).
+    #[doc(hidden)]
+    pub fn for_test(py: Python<'_>, recording_span: Option<tracing::Span>) -> PyResult<PyContext> {
+        let mut ctx = Self::_root_client_context(py)?;
+        ctx.recording_span = recording_span;
+        Ok(ctx)
     }
 }
 

--- a/monarch_hyperactor/src/telemetry.rs
+++ b/monarch_hyperactor/src/telemetry.rs
@@ -36,6 +36,15 @@ pub fn forward_to_tracing(py: Python, record: Py<PyAny>) -> PyResult<()> {
         .ok()
         .and_then(|attr| attr.extract::<String>(py).ok());
 
+    // Enter the actor's recording span (if present) so RecorderLayer
+    // captures this event in the per-actor flight recorder. The span
+    // is entered synchronously for the duration of the tracing emit
+    // only — no cross-contamination in shared-asyncio mode.
+    //
+    // Gracefully falls back to plain tracing when _context is absent,
+    // None, or contains an unexpected type.
+    let _recording_guard = extract_recording_span(py);
+
     // Map level number to level name
     match level {
         40 | 50 => {
@@ -84,6 +93,31 @@ pub fn forward_to_tracing(py: Python, record: Py<PyAny>) -> PyResult<()> {
         }
     }
     Ok(())
+}
+
+/// Extract the recording span from the current Python actor context.
+///
+/// Looks up the `_context` ContextVar in
+/// `monarch._src.actor.actor_mesh`, downcasts to `PyContext`, and
+/// clones the recording span. Returns an entered span guard that
+/// routes tracing events to the actor's flight recorder.
+///
+/// Returns `None` on any failure — missing module, absent context,
+/// unexpected type, or no recording span. This function is called
+/// from arbitrary Python logging contexts (import-time, client-side,
+/// non-actor threads) and must never fail.
+fn extract_recording_span(py: Python) -> Option<tracing::span::EnteredSpan> {
+    let actor_mesh = py.import("monarch._src.actor.actor_mesh").ok()?;
+    let ctx_var = actor_mesh.getattr("_context").ok()?;
+    let ctx_obj = ctx_var.call_method1("get", (py.None(),)).ok()?;
+    if ctx_obj.is_none() {
+        return None;
+    }
+    let py_ctx = ctx_obj
+        .extract::<PyRef<'_, crate::context::PyContext>>()
+        .ok()?;
+    let span = py_ctx.recording_span()?.clone();
+    Some(span.entered())
 }
 
 /// Get the current execution ID
@@ -291,9 +325,6 @@ impl PySqliteTracing {
     }
 }
 
-use pyo3::Bound;
-use pyo3::types::PyModule;
-
 pub fn register_python_bindings(module: &Bound<'_, PyModule>) -> PyResult<()> {
     // Register the forward_to_tracing function
     let f = wrap_pyfunction!(forward_to_tracing, module)?;
@@ -331,4 +362,85 @@ pub fn register_python_bindings(module: &Bound<'_, PyModule>) -> PyResult<()> {
     module.add_class::<PyUpDownCounter>()?;
     module.add_class::<PySqliteTracing>()?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use pyo3::ffi::c_str;
+    use pyo3::prelude::*;
+
+    use super::*;
+
+    fn init_python() {
+        pyo3::Python::initialize();
+    }
+
+    /// Helper: create a Python logging.LogRecord with the given message.
+    fn make_log_record(py: Python, message: &str) -> Py<PyAny> {
+        let locals = pyo3::types::PyDict::new(py);
+        locals.set_item("msg", message).unwrap();
+        py.run(
+            c_str!(
+                "import logging\n\
+                 record = logging.LogRecord('test', logging.INFO, 'test.py', 1, msg, (), None)"
+            ),
+            None,
+            Some(&locals),
+        )
+        .unwrap();
+        locals.get_item("record").unwrap().unwrap().into()
+    }
+
+    /// forward_to_tracing returns Ok when _context is absent.
+    /// Must never crash in non-actor logging contexts.
+    #[test]
+    fn forward_to_tracing_without_context_does_not_crash() {
+        init_python();
+        Python::attach(|py| {
+            let record = make_log_record(py, "no context marker");
+            let result = forward_to_tracing(py, record);
+            assert!(result.is_ok());
+        });
+    }
+
+    /// When a recording span is entered on the current thread,
+    /// events emitted by forward_to_tracing are captured in the
+    /// recording's ring buffer.
+    #[test]
+    fn forward_to_tracing_captures_when_recording_span_entered() {
+        init_python();
+        hyperactor_telemetry::initialize_logging_for_test();
+
+        let recording = hyperactor_telemetry::recorder().record(64);
+        let span = recording.span();
+
+        Python::attach(|py| {
+            let record = make_log_record(py, "recorder marker");
+            let _guard = span.enter();
+            let result = forward_to_tracing(py, record);
+            assert!(result.is_ok());
+        });
+
+        let events = recording.tail();
+        assert!(
+            !events.is_empty(),
+            "expected at least one event in recording"
+        );
+        let last = events.last().unwrap();
+        let fields = format!("{:?}", last);
+        assert!(
+            fields.contains("recorder marker"),
+            "expected 'recorder marker' in event fields, got: {fields}"
+        );
+    }
+
+    /// extract_recording_span returns None when _context is absent.
+    #[test]
+    fn extract_recording_span_returns_none_without_context() {
+        init_python();
+        Python::attach(|py| {
+            let result = extract_recording_span(py);
+            assert!(result.is_none());
+        });
+    }
 }

--- a/monarch_hyperactor/tests/lib.rs
+++ b/monarch_hyperactor/tests/lib.rs
@@ -7,3 +7,4 @@
  */
 
 mod code_sync;
+mod telemetry;

--- a/monarch_hyperactor/tests/telemetry.rs
+++ b/monarch_hyperactor/tests/telemetry.rs
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+//! Integration test for the Python actor-context bridge used by
+//! `forward_to_tracing`.
+//!
+//! Verifies that when `_context` holds a real `PyContext`, the
+//! emitted tracing event is captured in that actor's flight recorder.
+//!
+//! Requires the real `monarch` Python package via `py_deps` on
+//! `test_monarch_hyperactor`.
+
+use anyhow::Result;
+use monarch_hyperactor::context::PyContext;
+use monarch_hyperactor::runtime::monarch_with_gil_blocking;
+use pyo3::ffi::c_str;
+use pyo3::prelude::*;
+
+/// Verifies that `forward_to_tracing` uses the current `PyContext`'s
+/// recording span, causing the emitted event to be captured in the
+/// actor's flight recorder.
+///
+/// Exercises the `_context -> PyContext -> recording_span` bridge.
+#[tokio::test]
+#[cfg_attr(not(fbcode_build), ignore)]
+async fn forward_to_tracing_captures_via_extract_recording_span() -> Result<()> {
+    pyo3::Python::initialize();
+    hyperactor_telemetry::initialize_logging_for_test();
+
+    monarch_with_gil_blocking(|py| py.run(c_str!("import monarch._rust_bindings"), None, None))?;
+
+    let recording = hyperactor_telemetry::recorder().record(64);
+    let span = recording.span();
+
+    monarch_with_gil_blocking(|py| -> PyResult<()> {
+        // Build a PyContext carrying our recording span.
+        let py_ctx = PyContext::for_test(py, Some(span))?;
+        let py_ctx_obj = Py::new(py, py_ctx)?;
+
+        // Set _context ContextVar to our test context.
+        let actor_mesh = py.import("monarch._src.actor.actor_mesh")?;
+        let ctx_var = actor_mesh.getattr("_context")?;
+        let token = ctx_var.call_method1("set", (py_ctx_obj,))?;
+
+        // Call forward_to_tracing through Python — exercises the
+        // full extract_recording_span path.
+        let locals = pyo3::types::PyDict::new(py);
+        py.run(
+            c_str!(
+                "import logging
+from monarch._rust_bindings.monarch_hyperactor.telemetry import forward_to_tracing
+record = logging.LogRecord('test', logging.INFO, 'test.py', 1, 'extract marker', (), None)
+forward_to_tracing(record)"
+            ),
+            None,
+            Some(&locals),
+        )?;
+
+        // Restore _context.
+        ctx_var.call_method1("reset", (token,))?;
+        Ok(())
+    })?;
+
+    let events = recording.tail();
+    assert!(
+        !events.is_empty(),
+        "expected at least one event in recording via extract_recording_span path"
+    );
+    let last = events.last().unwrap();
+    let fields = format!("{:?}", last);
+    assert!(
+        fields.contains("extract marker"),
+        "expected 'extract marker' in event fields, got: {fields}"
+    );
+    Ok(())
+}

--- a/python/examples/dining_philosophers.py
+++ b/python/examples/dining_philosophers.py
@@ -40,12 +40,18 @@ so the full dashboard UI is available out of the box.
 
 import argparse
 import asyncio
+import logging
 from enum import auto, Enum
 from typing import Any, cast
 
 from monarch._src.actor.actor_mesh import ActorMesh
+from monarch._src.actor.telemetry import TracingForwarder
 from monarch.actor import Actor, current_rank, endpoint
 from monarch.job import ProcessJob, TelemetryConfig
+
+logger = logging.getLogger("dining_philosophers")
+logger.addHandler(TracingForwarder())
+logger.setLevel(logging.INFO)
 
 
 class ChopstickStatus(Enum):
@@ -103,9 +109,8 @@ class Philosopher(Actor):
             and self.right_status == ChopstickStatus.GRANTED
         ):
             self.meals_eaten += 1
-            print(
-                f"philosopher {self.rank} is eating (meal {self.meals_eaten})",
-                flush=True,
+            logger.info(
+                "philosopher %d is eating (meal %d)", self.rank, self.meals_eaten
             )
             await asyncio.sleep(1)  # savor the meal
             await self._release_chopsticks()
@@ -128,14 +133,19 @@ class Waiter(Actor):
     def _try_grant(self, rank: int, chopstick: int) -> None:
         if chopstick not in self.assignments:
             self.assignments[chopstick] = rank
+            logger.info("granted chopstick %d to philosopher %d", chopstick, rank)
             self.philosophers.slice(replica=rank).grant_chopstick.broadcast(chopstick)
         else:
+            logger.info("chopstick %d busy, philosopher %d queued", chopstick, rank)
             self.requests[chopstick] = rank
 
     def _release(self, chopstick: int) -> None:
         self.assignments.pop(chopstick, None)
         if chopstick in self.requests:
             rank = self.requests.pop(chopstick)
+            logger.info(
+                "chopstick %d released, granting to philosopher %d", chopstick, rank
+            )
             self._try_grant(rank, chopstick)
 
     @endpoint

--- a/python/examples/pyspy_workload.py
+++ b/python/examples/pyspy_workload.py
@@ -37,10 +37,16 @@ Then verify with::
 
 import argparse
 import asyncio
+import logging
 import time
 
+from monarch._src.actor.telemetry import TracingForwarder
 from monarch.actor import Actor, endpoint
 from monarch.job import ProcessJob, TelemetryConfig
+
+logger = logging.getLogger("pyspy_workload")
+logger.addHandler(TracingForwarder())
+logger.setLevel(logging.INFO)
 
 
 # -- Work helpers with named frames for py-spy visibility ----------


### PR DESCRIPTION
Summary:
adds actor-local flight-recorder capture for python tracing events emitted through forward_to_tracing.

introduces Instance::recording_span() in hyperactor and documents the new flight-recorder span invariants. PyContext now carries an optional recording span that is populated for real actor handler execution paths and left unset for bootstrap/client contexts. forward_to_tracing now looks up the current python actor _context, extracts the PyContext recording span when available, enters it for the duration of the emit, and otherwise falls back cleanly to plain tracing.

adds unit coverage for the non-actor fallback path, the recorder mechanism when a recording span is already entered, and the no-context extraction case. adds an integration test under test_monarch_hyperactor that exercises the real _context -> PyContext -> recording_span -> forward_to_tracing bridge against the real monarch python package.

updates the python and mast dining philosophers and pyspy workload examples to attach TracingForwarder and emit logs through python logging so those events surface in actor flight recorders. updates buck deps accordingly, including the hyperactor_telemetry dependency for monarch_hyperactor and the python actor/config deps needed by the examples and integration test.

Differential Revision: D101274170


