### PR TITLE
python: mark SetupActor as a system actor

### DIFF
--- a/python/monarch/_src/actor/proc_mesh.py
+++ b/python/monarch/_src/actor/proc_mesh.py
@@ -204,6 +204,12 @@ class SetupActor(Actor):
     with fake_sync_state() to properly handle the async context.
     """
 
+    # PY-SYS-2 (context.rs): actors with this attribute are marked as
+    # system/infrastructure during init and hidden by default in the
+    # TUI. TODO: replace with a @system_actor decorator (also
+    # _ControllerController).
+    _is_system_actor: bool = True
+
     # List of startup functions that are called when spawning a SetupActor.
     # Each function returns Optional[Callable[[], None]] - a callable to run on
     # the remote process. The callable handles its own serialization via __reduce_ex__.


### PR DESCRIPTION
Summary:
marks SetupActor in proc_mesh.py as a system actor by setting _is_system_actor = True under the existing PY-SYS-2 convention.

this causes setup actors to be treated as infrastructure during initialization and hidden by default in the TUI, and adds an inline note that this should eventually be replaced with a system_actor decorator.

Differential Revision: D101279450


