### PR TITLE
Add bootstrap_command kwarg to HostMesh.spawn_procs (#3463)

### DIFF
--- a/docs/source/actors.md
+++ b/docs/source/actors.md
@@ -10,7 +10,8 @@
 7. [Error Handling in Meshes](#error-handling-in-meshes)
 8. [Advanced Patterns](#advanced-patterns)
 9. [CPU/NUMA Binding](#cpunuma-binding)
-10. [Best Practices](#best-practices)
+10. [Bootstrap Command Customization](#bootstrap-command-customization)
+11. [Best Practices](#best-practices)
 
 ---
 
@@ -941,6 +942,137 @@ procs = host.spawn_procs(per_host={"gpus": 4}, proc_bind=bindings)
 - Custom proc launchers receive the binding configuration in
   `LaunchOptions.proc_bind` and may apply it using backend-appropriate
   mechanisms (e.g., systemd unit properties, Docker `--cpuset-cpus`).
+
+---
+
+## Bootstrap Command Customization
+
+When spawning processes, you can customize the bootstrap command used to launch each proc using the `bootstrap_command` parameter on `HostMesh.spawn_procs()`. This is useful for setting environment variables like `CUDA_VISIBLE_DEVICES`, `RANK`, `LOCAL_RANK`, or customizing the program and arguments.
+
+### Uniform BootstrapCommand
+
+Pass a `BootstrapCommand` to use the same command for all spawned processes:
+
+```python
+from monarch._rust_bindings.monarch_hyperactor.host_mesh import BootstrapCommand
+from monarch.actor import this_host
+
+host = this_host()
+
+# Custom BootstrapCommand for all procs
+cmd = BootstrapCommand(
+    program="/custom/python",
+    arg0=None,
+    args=["-m", "monarch._src.actor.bootstrap_main"],
+    env={"CUDA_VISIBLE_DEVICES": "0,1,2,3", "MY_VAR": "value"},
+)
+procs = host.spawn_procs(
+    per_host={"gpus": 4},
+    bootstrap_command=cmd
+)
+```
+
+### Per-Coordinate BootstrapCommand
+
+Pass a callable to customize the bootstrap command per process. The callable receives a `Point` representing the combined coordinate across host and per_host dimensions:
+
+```python
+from monarch.actor import this_host
+from monarch._rust_bindings.monarch_hyperactor.host_mesh import BootstrapCommand
+
+host = this_host()
+
+# Set CUDA_VISIBLE_DEVICES based on coordinate
+def make_bootstrap(point):
+    return BootstrapCommand(
+        program="/usr/bin/python3",
+        arg0=None,
+        args=["-m", "monarch._src.actor.bootstrap_main"],
+        env={"CUDA_VISIBLE_DEVICES": str(point["gpus"])},
+    )
+
+procs = host.spawn_procs(
+    per_host={"gpus": 4},
+    bootstrap_command=make_bootstrap
+)
+
+# point["gpus"] is the GPU index within each host
+# point["hosts"] is the host index (if host mesh has multiple hosts)
+```
+
+This is particularly useful for:
+- Setting `CUDA_VISIBLE_DEVICES` to restrict each proc to specific GPUs
+- Configuring `RANK` and `LOCAL_RANK` for distributed training
+- Assigning different configurations based on host or device position
+- Using different Python executables or arguments per coordinate
+
+### Using with_env for Ergonomic Customization
+
+The `BootstrapCommand.with_env()` method makes it easy to create modified copies of a base command with additional environment variables. Use `default_bootstrap_cmd()` to get the default command for the current environment:
+
+```python
+from monarch.actor import this_host
+from monarch._src.actor.host_mesh import default_bootstrap_cmd
+
+host = this_host()
+
+# Start with the default bootstrap command
+base = default_bootstrap_cmd()
+
+# Customize per coordinate using with_env
+def make_bootstrap(point):
+    return base.with_env({
+        "CUDA_VISIBLE_DEVICES": str(point["gpus"]),
+        "RANK": str(point["hosts"] * 4 + point["gpus"]),
+    })
+
+procs = host.spawn_procs(
+    per_host={"gpus": 4},
+    bootstrap_command=make_bootstrap
+)
+```
+
+> **Note:** `default_bootstrap_cmd()` returns the default for the *local* (client) environment. It is not guaranteed to match the bootstrap command that the actual remote hosts would use on their own — those may differ in program path, args, or env. When you pass the result of `default_bootstrap_cmd().with_env(...)` as `bootstrap_command`, the client-side default is what gets sent to the hosts, replacing whatever default they would have used. In most setups the client and host environments are equivalent, so this is usually what you want; if your hosts run with a different default, supply an explicit `BootstrapCommand` instead of starting from `default_bootstrap_cmd()`.
+
+### Non-Mutating Behavior
+
+The `bootstrap_command` parameter only affects the specific `spawn_procs` call. The original `HostMesh` is not modified, so subsequent spawns on the same mesh use the original bootstrap command:
+
+```python
+host = this_host()
+
+# First spawn with custom bootstrap command
+cmd1 = BootstrapCommand(...)
+procs1 = host.spawn_procs(
+    per_host={"gpus": 2},
+    bootstrap_command=cmd1
+)
+
+# Second spawn without bootstrap_command uses the mesh's default
+procs2 = host.spawn_procs(per_host={"gpus": 2})
+# procs2 uses the default bootstrap command
+```
+
+### Combining with with_python_executable
+
+Bootstrap commands work with other HostMesh customization methods:
+
+```python
+host = this_host()
+
+# Customize Python executable and bootstrap command
+custom_host = host.with_python_executable("/path/to/python")
+cmd = BootstrapCommand(
+    program="/path/to/python",
+    arg0=None,
+    args=["-m", "monarch._src.actor.bootstrap_main"],
+    env={"CUDA_VISIBLE_DEVICES": "0,1,2,3"},
+)
+procs = custom_host.spawn_procs(
+    per_host={"gpus": 4},
+    bootstrap_command=cmd
+)
+```
 
 ---
 

--- a/hyperactor_mesh/benches/main.rs
+++ b/hyperactor_mesh/benches/main.rs
@@ -54,7 +54,7 @@ fn bench_actor_scaling(c: &mut Criterion) {
                 let instance = cx.actor_instance;
                 let mut host_mesh = test_utils::local_host_mesh(host_count).await;
                 let mut proc_mesh = host_mesh
-                    .spawn(instance, "bench", extent!(gpus = gpus), None)
+                    .spawn(instance, "bench", extent!(gpus = gpus), None, None)
                     .await
                     .unwrap();
                 let actor_mesh: ActorMesh<BenchActor> = proc_mesh
@@ -144,7 +144,7 @@ fn bench_actor_mesh_message_sizes(c: &mut Criterion) {
                         let instance = cx.actor_instance;
                         let mut host_mesh = test_utils::local_host_mesh(1).await;
                         let mut proc_mesh = host_mesh
-                            .spawn(instance, "bench", extent!(gpus = actor_count), None)
+                            .spawn(instance, "bench", extent!(gpus = actor_count), None, None)
                             .await
                             .unwrap();
                         let actor_mesh: ActorMesh<BenchActor> = proc_mesh

--- a/hyperactor_mesh/examples/dining_philosophers.rs
+++ b/hyperactor_mesh/examples/dining_philosophers.rs
@@ -311,6 +311,7 @@ async fn main() -> Result<ExitCode> {
             "philosophers",
             extent!(replica = group_size),
             None,
+            None,
         )
         .await?;
 

--- a/hyperactor_mesh/examples/test_bench.rs
+++ b/hyperactor_mesh/examples/test_bench.rs
@@ -71,7 +71,7 @@ async fn main() {
     let instance = cx.actor_instance;
 
     let proc_mesh = host_mesh
-        .spawn(instance, "test", extent!(procs = 2), None)
+        .spawn(instance, "test", extent!(procs = 2), None, None)
         .await
         .unwrap();
 

--- a/hyperactor_mesh/src/actor_mesh.rs
+++ b/hyperactor_mesh/src/actor_mesh.rs
@@ -1024,7 +1024,7 @@ mod tests {
         // cross a boundary
         let mut hm = testing::host_mesh(3).await;
         let pm: ProcMesh = hm
-            .spawn(instance, "test", extent!(gpus = 2), None)
+            .spawn(instance, "test", extent!(gpus = 2), None, None)
             .await
             .unwrap();
         let am: ActorMesh<testactor::TestActor> = pm.spawn(instance, "test", &()).await.unwrap();
@@ -1126,7 +1126,7 @@ mod tests {
         let num_replicas = 4;
         let mut hm = testing::host_mesh(num_replicas).await;
         let proc_mesh = hm
-            .spawn(instance, "test", Extent::unity(), None)
+            .spawn(instance, "test", Extent::unity(), None, None)
             .await
             .unwrap();
         let child_name = ActorMeshId::unique(Label::new("child").unwrap());
@@ -1227,12 +1227,12 @@ mod tests {
         let num_replicas = 4;
         let mut hm = testing::host_mesh(num_replicas).await;
         let proc_mesh = hm
-            .spawn(instance, "test", Extent::unity(), None)
+            .spawn(instance, "test", Extent::unity(), None, None)
             .await
             .unwrap();
         let mut second_hm = testing::host_mesh(num_replicas).await;
         let second_proc_mesh = second_hm
-            .spawn(instance, "test2", Extent::unity(), None)
+            .spawn(instance, "test2", Extent::unity(), None, None)
             .await
             .unwrap();
         let child_name = ActorMeshId::unique(Label::new("child").unwrap());
@@ -1323,7 +1323,7 @@ mod tests {
         let num_replicas = 4;
         let mut hm = testing::host_mesh(num_replicas).await;
         let proc_mesh = hm
-            .spawn(instance, "test", Extent::unity(), None)
+            .spawn(instance, "test", Extent::unity(), None, None)
             .await
             .unwrap();
         let child_name = ActorMeshId::unique(Label::new("child").unwrap());
@@ -1389,7 +1389,7 @@ mod tests {
         let instance = testing::instance();
         let mut host_mesh = testing::host_mesh(4).await;
         let proc_mesh = host_mesh
-            .spawn(instance, "test", Extent::unity(), None)
+            .spawn(instance, "test", Extent::unity(), None, None)
             .await
             .unwrap();
         let actor_mesh: ActorMesh<testactor::TestActor> =
@@ -1441,7 +1441,7 @@ mod tests {
         // Create a proc mesh with 2 hosts.
         let mut hm = testing::host_mesh(2).await;
         let proc_mesh = hm
-            .spawn(instance, "test", Extent::unity(), None)
+            .spawn(instance, "test", Extent::unity(), None, None)
             .await
             .unwrap();
 
@@ -1566,7 +1566,7 @@ mod tests {
         // Create proc mesh with 2 procs
         let mut hm = testing::host_mesh(2).await;
         let proc_mesh = hm
-            .spawn(instance, "test", Extent::unity(), None)
+            .spawn(instance, "test", Extent::unity(), None, None)
             .await
             .unwrap();
 
@@ -1652,7 +1652,7 @@ mod tests {
         // Create proc mesh with 2 procs
         let mut hm = testing::host_mesh(2).await;
         let proc_mesh = hm
-            .spawn(instance, "test", Extent::unity(), None)
+            .spawn(instance, "test", Extent::unity(), None, None)
             .await
             .unwrap();
 

--- a/hyperactor_mesh/src/comm.rs
+++ b/hyperactor_mesh/src/comm.rs
@@ -1327,7 +1327,7 @@ mod tests {
         // can collect paths from the same process.
         let host_mesh = local_host_mesh(8).await;
         let proc_mesh = host_mesh
-            .spawn(instance, "test", extent!(gpu = 8), None)
+            .spawn(instance, "test", extent!(gpu = 8), None, None)
             .await
             .unwrap();
 
@@ -1526,7 +1526,7 @@ mod tests {
         // can collect paths from the same process.
         let host_mesh = local_host_mesh(8).await;
         let proc_mesh = host_mesh
-            .spawn(instance, "test", extent!(gpu = 8), None)
+            .spawn(instance, "test", extent!(gpu = 8), None, None)
             .await
             .unwrap();
 
@@ -1645,7 +1645,7 @@ mod tests {
         let instance = crate::testing::instance();
         let mut host_mesh = local_host_mesh(8).await;
         let proc_mesh = host_mesh
-            .spawn(instance, "test", extent!(gpu = 8), None)
+            .spawn(instance, "test", extent!(gpu = 8), None, None)
             .await
             .unwrap();
 

--- a/hyperactor_mesh/src/global_context.rs
+++ b/hyperactor_mesh/src/global_context.rs
@@ -557,7 +557,7 @@ mod tests {
         let instance = testing::instance();
         let mut hm = testing::host_mesh(2).await;
         let _mesh = hm
-            .spawn(instance, "test", Extent::unity(), None)
+            .spawn(instance, "test", Extent::unity(), None, None)
             .await
             .unwrap();
         assert!(

--- a/hyperactor_mesh/src/host_mesh.rs
+++ b/hyperactor_mesh/src/host_mesh.rs
@@ -974,11 +974,20 @@ pub struct HostMeshRef {
     id: HostMeshId,
     region: Region,
     ranks: Arc<Vec<HostRef>>,
-    /// Bootstrap command to use when spawning procs on this mesh.
-    /// When `None`, each host agent uses its own default command.
+    /// Uniform bootstrap command to use when spawning procs on this
+    /// mesh. When `None`, each host agent uses its own default
+    /// command. Per-proc overrides are supplied at spawn time via the
+    /// `per_rank_bootstrap` parameter on [`HostMeshRef::spawn`].
     #[serde(default)]
     pub bootstrap_command: Option<BootstrapCommand>,
 }
+
+/// A function that produces a per-rank [`BootstrapCommand`], called
+/// once per proc during spawn with that proc's [`view::Point`] over
+/// the combined `host_extent ⊕ per_host` extent. Returning an error
+/// aborts the spawn with that error surfaced as a configuration
+/// failure.
+pub type PerRankBootstrapFn = dyn Fn(view::Point) -> anyhow::Result<BootstrapCommand> + Send + Sync;
 wirevalue::register_type!(HostMeshRef);
 
 impl HostMeshRef {
@@ -1126,6 +1135,12 @@ impl HostMeshRef {
     /// `membind`, `physcpubind`, `cpus`) to their values.
     /// Only takes effect when running on Linux.
     ///
+    /// `per_rank_bootstrap`, when provided, is a function called once
+    /// per proc to produce that proc's [`BootstrapCommand`]. The
+    /// function receives a [`view::Point`] over the combined
+    /// `host_extent ⊕ per_host` extent. Its return value takes
+    /// precedence over `self.bootstrap_command` for that proc only.
+    ///
     /// Currently, spawn issues direct calls to each host agent. This will be fixed by
     /// maintaining a comm actor on the host service procs themselves.
     #[allow(clippy::result_large_err)]
@@ -1135,6 +1150,7 @@ impl HostMeshRef {
         name: &str,
         per_host: Extent,
         proc_bind: Option<Vec<ProcBind>>,
+        per_rank_bootstrap: Option<Box<PerRankBootstrapFn>>,
     ) -> crate::Result<ProcMesh>
     where
         C::A: Handler<MeshFailure>,
@@ -1144,6 +1160,7 @@ impl HostMeshRef {
             ProcMeshId::unique(Label::strip(name)),
             per_host,
             proc_bind,
+            per_rank_bootstrap,
         )
         .await
     }
@@ -1155,6 +1172,7 @@ impl HostMeshRef {
         proc_mesh_id: ProcMeshId,
         per_host: Extent,
         proc_bind: Option<Vec<ProcBind>>,
+        per_rank_bootstrap: Option<Box<PerRankBootstrapFn>>,
     ) -> crate::Result<ProcMesh>
     where
         C::A: Handler<MeshFailure>,
@@ -1162,7 +1180,7 @@ impl HostMeshRef {
         tracing::info!(name = "HostMeshStatus", status = "ProcMesh::Spawn::Attempt");
         tracing::info!(name = "ProcMeshStatus", status = "Spawn::Attempt",);
         let result = self
-            .spawn_inner_inner(cx, proc_mesh_id, per_host, proc_bind)
+            .spawn_inner_inner(cx, proc_mesh_id, per_host, proc_bind, per_rank_bootstrap)
             .await;
         match &result {
             Ok(_) => {
@@ -1183,6 +1201,7 @@ impl HostMeshRef {
         proc_mesh_id: ProcMeshId,
         per_host: Extent,
         proc_bind: Option<Vec<ProcBind>>,
+        per_rank_bootstrap: Option<Box<PerRankBootstrapFn>>,
     ) -> crate::Result<ProcMesh>
     where
         C::A: Handler<MeshFailure>,
@@ -1254,9 +1273,18 @@ impl HostMeshRef {
                 )));
                 proc_names.push(proc_name.clone());
                 let bind = proc_bind.as_ref().map(|v| v[per_host_rank].clone());
+                let bootstrap_command = match per_rank_bootstrap.as_ref() {
+                    Some(f) => Some(
+                        f(extent
+                            .point_of_rank(create_rank)
+                            .expect("rank in combined extent"))
+                        .map_err(crate::Error::ConfigurationError)?,
+                    ),
+                    None => self.bootstrap_command.clone(),
+                };
                 let proc_spec = resource::ProcSpec {
                     client_config_override: client_config_override.clone(),
-                    bootstrap_command: self.bootstrap_command.clone(),
+                    bootstrap_command,
                     proc_bind: bind,
                     host_mesh_id: Some(self.id.clone()),
                 };
@@ -1948,7 +1976,7 @@ mod tests {
             HostMeshRef::from_hosts(HostMeshId::singleton(Label::new("test").unwrap()), hosts);
 
         let proc_mesh = host_mesh
-            .spawn(&testing::instance(), "test", Extent::unity(), None)
+            .spawn(&testing::instance(), "test", Extent::unity(), None, None)
             .await
             .unwrap();
 
@@ -2012,7 +2040,7 @@ mod tests {
         let instance = testing::instance();
 
         let err = host_mesh
-            .spawn(&instance, "test", Extent::unity(), None)
+            .spawn(&instance, "test", Extent::unity(), None, None)
             .await
             .unwrap_err();
         assert_matches!(
@@ -2060,7 +2088,7 @@ mod tests {
         let instance = testing::instance();
 
         let err = host_mesh
-            .spawn(&instance, "test", Extent::unity(), None)
+            .spawn(&instance, "test", Extent::unity(), None, None)
             .await
             .unwrap_err();
         let statuses = err.into_proc_spawn_error().unwrap();
@@ -2097,7 +2125,7 @@ mod tests {
 
         let mut hm = testing::host_mesh(2).await;
         let proc_mesh = hm
-            .spawn(instance, "test", Extent::unity(), None)
+            .spawn(instance, "test", Extent::unity(), None, None)
             .await
             .unwrap();
 

--- a/hyperactor_mesh/src/mesh_controller.rs
+++ b/hyperactor_mesh/src/mesh_controller.rs
@@ -1105,7 +1105,7 @@ mod tests {
         let instance = testing::instance();
         let host_mesh = local_host_mesh(2).await;
         let proc_mesh = host_mesh
-            .spawn(instance, "test", Extent::unity(), None)
+            .spawn(instance, "test", Extent::unity(), None, None)
             .await
             .unwrap();
 
@@ -1230,14 +1230,14 @@ mod tests {
         // MESH_ORPHAN_TIMEOUT=2s and start the SelfCheck loop.
         let mut actor_hm = host_mesh_with_config(num_replicas).await;
         let actor_proc_mesh = actor_hm
-            .spawn(instance, "actors", Extent::unity(), None)
+            .spawn(instance, "actors", Extent::unity(), None, None)
             .await
             .unwrap();
 
         // Host mesh for the wrapper + controller (will be killed).
         let mut controller_hm = host_mesh_with_config(1).await;
         let controller_proc_mesh = controller_hm
-            .spawn(instance, "controller", Extent::unity(), None)
+            .spawn(instance, "controller", Extent::unity(), None, None)
             .await
             .unwrap();
 

--- a/hyperactor_mesh/src/proc_mesh.rs
+++ b/hyperactor_mesh/src/proc_mesh.rs
@@ -1048,7 +1048,7 @@ mod tests {
 
         let mut hm = testing::host_mesh(4).await;
         let proc_mesh = hm
-            .spawn(&instance, "test", extent!(gpus = 2), None)
+            .spawn(&instance, "test", extent!(gpus = 2), None, None)
             .await
             .unwrap();
         let actor_mesh = proc_mesh.spawn(instance, "test", &()).await.unwrap();
@@ -1067,7 +1067,7 @@ mod tests {
 
         let mut hm = testing::host_mesh(4).await;
         let proc_mesh = hm
-            .spawn(&instance, "test", extent!(gpus = 2), None)
+            .spawn(&instance, "test", extent!(gpus = 2), None, None)
             .await
             .unwrap();
         let err = proc_mesh

--- a/hyperactor_mesh/test/hyperactor_mesh_proxy_test.rs
+++ b/hyperactor_mesh/test/hyperactor_mesh_proxy_test.rs
@@ -126,7 +126,7 @@ impl Actor for ProxyActor {
         let host_mesh = HostMesh::process(extent! { hosts = 1 }, command).await?;
         let proc_mesh = Arc::new(
             host_mesh
-                .spawn(this, "proxy", extent! { replica = 1 }, None)
+                .spawn(this, "proxy", extent! { replica = 1 }, None, None)
                 .await?,
         );
         self.actor_mesh = Some(proc_mesh.spawn(this, "echo", &()).await?);
@@ -190,7 +190,7 @@ async fn run_client(exe_path: PathBuf, keep_alive: bool) -> Result<(), anyhow::E
 
     let mut host_mesh = HostMesh::process(extent! { hosts = 1 }, command).await?;
     let proc_mesh = host_mesh
-        .spawn(instance, "client", extent! { replica = 1 }, None)
+        .spawn(instance, "client", extent! { replica = 1 }, None, None)
         .await?;
     let actor_mesh: ActorMesh<ProxyActor> = proc_mesh
         .spawn(instance, "proxy", &exe_path.to_str().unwrap().to_string())

--- a/monarch_hyperactor/src/actor_mesh.rs
+++ b/monarch_hyperactor/src/actor_mesh.rs
@@ -944,7 +944,7 @@ mod tests {
 
         let mut host_mesh = HostMesh::local_in_process().await.unwrap();
         let proc_mesh = host_mesh
-            .spawn(instance, "test", extent!(replicas = 2), None)
+            .spawn(instance, "test", extent!(replicas = 2), None, None)
             .await
             .unwrap();
 

--- a/monarch_hyperactor/src/code_sync/manager.rs
+++ b/monarch_hyperactor/src/code_sync/manager.rs
@@ -615,7 +615,13 @@ mod tests {
         // Set up actor mesh with CodeSyncManager actors
         let mut host_mesh = test_utils::local_host_mesh(2).await;
         let proc_mesh = host_mesh
-            .spawn(instance, "code_sync_test", ndslice::Extent::unity(), None)
+            .spawn(
+                instance,
+                "code_sync_test",
+                ndslice::Extent::unity(),
+                None,
+                None,
+            )
             .await
             .unwrap();
 

--- a/monarch_hyperactor/src/code_sync/rsync.rs
+++ b/monarch_hyperactor/src/code_sync/rsync.rs
@@ -504,7 +504,7 @@ mod tests {
         let instance = cx.actor_instance;
         let mut host_mesh = test_utils::local_host_mesh(1).await;
         let proc_mesh = host_mesh
-            .spawn(instance, "rsync_test", ndslice::Extent::unity(), None)
+            .spawn(instance, "rsync_test", ndslice::Extent::unity(), None, None)
             .await
             .unwrap();
         // Spawn actor mesh with RsyncActors

--- a/monarch_hyperactor/src/host_mesh.rs
+++ b/monarch_hyperactor/src/host_mesh.rs
@@ -204,6 +204,26 @@ impl PyHostMesh {
         }
     }
 
+    /// Return a new `HostMesh` (as a `Ref`) whose bootstrap command
+    /// is derived from the existing one (or the Python default when
+    /// none is set) with `env` merged on top. Keys in `env` override
+    /// any conflicting keys in the base environment. Does not mutate
+    /// the original mesh.
+    fn with_env(&self, py: Python<'_>, env: HashMap<String, String>) -> PyResult<Self> {
+        let mesh_ref = self.mesh_ref()?;
+        let base = match mesh_ref.bootstrap_command.clone() {
+            Some(cmd) => cmd,
+            None => PyBootstrapCommand::default(py)?.borrow().to_rust(),
+        };
+        let mut merged_env = base.env.clone();
+        merged_env.extend(env);
+        let new_cmd = BootstrapCommand {
+            env: merged_env,
+            ..base
+        };
+        Ok(Self::new_ref(mesh_ref.with_bootstrap(new_cmd)))
+    }
+
     fn sliced(&self, region: &PyRegion) -> PyResult<Self> {
         Ok(Self::new_ref(
             self.mesh_ref()?.sliced(region.as_inner().clone()),

--- a/monarch_hyperactor/src/host_mesh.rs
+++ b/monarch_hyperactor/src/host_mesh.rs
@@ -23,6 +23,7 @@ use hyperactor_mesh::bootstrap::host;
 use hyperactor_mesh::host_mesh;
 use hyperactor_mesh::host_mesh::HostMesh;
 use hyperactor_mesh::host_mesh::HostMeshRef;
+use hyperactor_mesh::host_mesh::PerRankBootstrapFn;
 use hyperactor_mesh::host_mesh::host_agent::GetLocalProcClient;
 use hyperactor_mesh::host_mesh::host_agent::HostAgent;
 use hyperactor_mesh::host_mesh::host_agent::ShutdownHost;
@@ -49,6 +50,7 @@ use crate::proc_mesh::PyProcMesh;
 use crate::pytokio::PyPythonTask;
 use crate::runtime::monarch_with_gil;
 use crate::shape::PyExtent;
+use crate::shape::PyPoint;
 use crate::shape::PyRegion;
 
 #[pyclass(
@@ -90,6 +92,20 @@ impl PyBootstrapCommand {
             self.program, self.args, self.env
         )
     }
+
+    /// Return a copy of this command with `env` merged on top of its
+    /// environment. Keys in `env` override any conflicting keys in the
+    /// existing environment.
+    fn with_env(&self, env: HashMap<String, String>) -> Self {
+        let mut new_env = self.env.clone();
+        new_env.extend(env);
+        Self {
+            program: self.program.clone(),
+            arg0: self.arg0.clone(),
+            args: self.args.clone(),
+            env: new_env,
+        }
+    }
 }
 
 impl PyBootstrapCommand {
@@ -100,15 +116,6 @@ impl PyBootstrapCommand {
             args: self.args.clone(),
             env: self.env.clone(),
         }
-    }
-
-    pub fn default<'py>(py: Python<'py>) -> PyResult<Bound<'py, Self>> {
-        py.import("monarch._src.actor.host_mesh")?
-            .getattr("_bootstrap_cmd")?
-            .call0()?
-            .downcast::<PyBootstrapCommand>()
-            .cloned()
-            .map_err(to_py_error)
     }
 }
 
@@ -140,21 +147,51 @@ impl PyHostMesh {
 
 #[pymethods]
 impl PyHostMesh {
-    #[pyo3(signature = (instance, name, per_host, proc_bind = None))]
+    #[pyo3(signature = (instance, name, per_host, proc_bind = None, per_rank_bootstrap = None))]
     fn spawn_nonblocking(
         &self,
+        _py: Python<'_>,
         instance: &PyInstance,
         name: String,
         per_host: &PyExtent,
         proc_bind: Option<Vec<HashMap<String, String>>>,
+        per_rank_bootstrap: Option<Py<PyAny>>,
     ) -> PyResult<PyPythonTask> {
         let host_mesh = self.mesh_ref()?.clone();
+        let per_rank_bootstrap: Option<Box<PerRankBootstrapFn>> = per_rank_bootstrap
+            .map(|callable| -> PyResult<Box<PerRankBootstrapFn>> {
+                Ok(Box::new(move |point| {
+                    Python::attach(|py| {
+                        let result =
+                            callable
+                                .bind(py)
+                                .call1((PyPoint::from(point),))
+                                .map_err(|e| {
+                                    anyhow::anyhow!("per-rank bootstrap callable raised: {}", e)
+                                })?;
+                        let cmd: PyBootstrapCommand = result.extract().map_err(|e| {
+                            anyhow::anyhow!(
+                                "per-rank bootstrap callable did not return BootstrapCommand: {}",
+                                e
+                            )
+                        })?;
+                        Ok(cmd.to_rust())
+                    })
+                }))
+            })
+            .transpose()?;
         let instance = instance.clone();
         let per_host = per_host.clone().into();
         let proc_bind = proc_bind.map(|v| v.into_iter().map(ProcBind::from).collect());
         let mesh_impl = async move {
             let proc_mesh = host_mesh
-                .spawn(instance.deref(), &name, per_host, proc_bind)
+                .spawn(
+                    instance.deref(),
+                    &name,
+                    per_host,
+                    proc_bind,
+                    per_rank_bootstrap,
+                )
                 .await
                 .map_err(to_py_error)?;
             Ok(PyProcMesh::new_owned(proc_mesh))

--- a/monarch_hyperactor/src/logging.rs
+++ b/monarch_hyperactor/src/logging.rs
@@ -613,7 +613,7 @@ mod tests {
         .expect("failed to bootstrap HostMesh");
 
         let proc_mesh = host_mesh
-            .spawn(&instance, "p0", Extent::unity(), None)
+            .spawn(&instance, "p0", Extent::unity(), None, None)
             .await
             .expect("failed to spawn ProcMesh");
 

--- a/monarch_hyperactor/tests/code_sync/auto_reload.rs
+++ b/monarch_hyperactor/tests/code_sync/auto_reload.rs
@@ -47,7 +47,13 @@ CONSTANT = "initial_constant"
     let instance = cx.actor_instance;
     let mut host_mesh = test_utils::local_host_mesh(1).await;
     let proc_mesh = host_mesh
-        .spawn(instance, "auto_reload_test", ndslice::Extent::unity(), None)
+        .spawn(
+            instance,
+            "auto_reload_test",
+            ndslice::Extent::unity(),
+            None,
+            None,
+        )
         .await
         .unwrap();
     let params = AutoReloadParams {};

--- a/monarch_introspection_snapshot/test/snapshot_integration_test.rs
+++ b/monarch_introspection_snapshot/test/snapshot_integration_test.rs
@@ -137,7 +137,7 @@ async fn test_snapshot_sql_queries() -> Result<()> {
 
     // Step 2: Spawn two worker procs, each with one test actor.
     let proc_mesh = host_mesh
-        .spawn(&instance, "worker", extent!(replica = 2), None)
+        .spawn(&instance, "worker", extent!(replica = 2), None, None)
         .await?;
     let actor_mesh = proc_mesh
         .spawn::<SnapshotTestActor, _>(&instance, "test_actor", &())

--- a/monarch_rdma/examples/cuda_ping_pong/src/cuda_ping_pong.rs
+++ b/monarch_rdma/examples/cuda_ping_pong/src/cuda_ping_pong.rs
@@ -762,10 +762,10 @@ pub async fn run() -> Result<(), anyhow::Error> {
 
     // Create proc meshes (one proc per host mesh)
     let device_1_proc_mesh: ProcMesh = host_mesh_1
-        .spawn(&instance, "procs", Extent::unity(), None)
+        .spawn(&instance, "procs", Extent::unity(), None, None)
         .await?;
     let device_2_proc_mesh: ProcMesh = host_mesh_2
-        .spawn(&instance, "procs", Extent::unity(), None)
+        .spawn(&instance, "procs", Extent::unity(), None, None)
         .await?;
 
     // Create RDMA manager for the first device

--- a/monarch_rdma/examples/parameter_server/src/parameter_server.rs
+++ b/monarch_rdma/examples/parameter_server/src/parameter_server.rs
@@ -489,7 +489,7 @@ pub async fn run(num_workers: usize, num_steps: usize) -> Result<(), anyhow::Err
         vec![host_addr],
     );
     let ps_proc_mesh = host_mesh
-        .spawn(instance, "ps", extent!(gpu = 1), None)
+        .spawn(instance, "ps", extent!(gpu = 1), None, None)
         .await?;
 
     tracing::info!(
@@ -509,7 +509,7 @@ pub async fn run(num_workers: usize, num_steps: usize) -> Result<(), anyhow::Err
     // Create a proc mesh for workers, where each worker is assigned to its own GPU.
     tracing::info!("creating worker proc mesh ({} workers)...", num_workers);
     let worker_proc_mesh = host_mesh
-        .spawn(instance, "workers", extent!(gpu = num_workers), None)
+        .spawn(instance, "workers", extent!(gpu = num_workers), None, None)
         .await?;
 
     tracing::info!(

--- a/monarch_rdma/src/backend/ibverbs/mlx5dv_tests.rs
+++ b/monarch_rdma/src/backend/ibverbs/mlx5dv_tests.rs
@@ -63,6 +63,7 @@ async fn test_indirect_mkey_read_at_large_offset() -> Result<(), anyhow::Error> 
             "mkey_test_procs",
             hyperactor_mesh::extent!(procs = 2),
             None,
+            None,
         )
         .await?;
 

--- a/monarch_rdma/tests/multi_pd_test.rs
+++ b/monarch_rdma/tests/multi_pd_test.rs
@@ -82,6 +82,7 @@ async fn test_multi_pd_segment_registration() -> Result<(), anyhow::Error> {
             "multi_pd_procs",
             hyperactor_mesh::extent!(procs = 3),
             None,
+            None,
         )
         .await?;
 

--- a/python/monarch/_rust_bindings/monarch_hyperactor/host_mesh.pyi
+++ b/python/monarch/_rust_bindings/monarch_hyperactor/host_mesh.pyi
@@ -62,6 +62,19 @@ class HostMesh:
         """
         ...
 
+    def with_env(self, env: dict[str, str]) -> "HostMesh":
+        """
+        Return a new HostMesh (as a reference) whose bootstrap command is
+        the existing bootstrap command (or the Python default when none
+        is set) with the given env merged on top. Keys in ``env`` override
+        any conflicting keys in the base environment. Does not mutate the
+        original mesh.
+
+        Arguments:
+        - `env`: Additional environment variables to merge.
+        """
+        ...
+
     def sliced(self, region: Region) -> "HostMesh":
         """
         Slice this mesh into a new mesh with the given region.

--- a/python/monarch/_rust_bindings/monarch_hyperactor/host_mesh.pyi
+++ b/python/monarch/_rust_bindings/monarch_hyperactor/host_mesh.pyi
@@ -6,12 +6,12 @@
 
 # pyre-strict
 
-from typing import Any, final
+from typing import Any, Callable, final
 
 from monarch._rust_bindings.monarch_hyperactor.context import Instance
 from monarch._rust_bindings.monarch_hyperactor.proc_mesh import ProcMesh
 from monarch._rust_bindings.monarch_hyperactor.pytokio import PythonTask
-from monarch._rust_bindings.monarch_hyperactor.shape import Extent, Region
+from monarch._rust_bindings.monarch_hyperactor.shape import Extent, Point, Region
 
 @final
 class HostMesh:
@@ -21,6 +21,7 @@ class HostMesh:
         name: str,
         per_host: Extent,
         proc_bind: list[dict[str, str]] | None = None,
+        per_rank_bootstrap: Callable[[Point], BootstrapCommand] | None = None,
     ) -> PythonTask[ProcMesh]:
         """
         Spawn a new actor on this mesh.
@@ -29,6 +30,11 @@ class HostMesh:
         - `instance`: The instance to use to spawn the mesh.
         - `name`: Name of the proc mesh
         - `per_host`: Extent describing the shape of the proc mesh on each host.
+        - `proc_bind`: Optional per-process CPU/NUMA binding config.
+        - `per_rank_bootstrap`: Optional callable invoked once per proc with
+          that proc's ``Point`` over the combined ``host ⊕ per_host``
+          extent; its returned ``BootstrapCommand`` is used for that proc.
+          Scoped to this spawn; the mesh itself is not mutated.
         """
         ...
 
@@ -102,6 +108,16 @@ class BootstrapCommand:
         ...
 
     def __repr__(self) -> str: ...
+    def with_env(self, env: dict[str, str]) -> "BootstrapCommand":
+        """
+        Return a copy of this command with `env` merged on top of its
+        environment. Keys in `env` override any conflicting keys in the
+        existing environment.
+
+        Arguments:
+        - `env`: Additional environment variables to merge.
+        """
+        ...
 
 def bootstrap_host(
     bootstrap_cmd: BootstrapCommand | None,

--- a/python/monarch/_src/actor/actor_mesh.py
+++ b/python/monarch/_src/actor/actor_mesh.py
@@ -410,11 +410,11 @@ def _init_client_context() -> Context:
     import atexit
 
     from monarch._rust_bindings.monarch_hyperactor.host_mesh import bootstrap_host
-    from monarch._src.actor.host_mesh import _bootstrap_cmd, HostMesh
+    from monarch._src.actor.host_mesh import default_bootstrap_cmd, HostMesh
     from monarch._src.actor.proc_mesh import ProcMesh
 
     hy_host_mesh, hy_proc_mesh, hy_instance = bootstrap_host(
-        _bootstrap_cmd()
+        default_bootstrap_cmd()
     ).block_on()
 
     ctx = Context._from_instance(cast(Instance, hy_instance))  # type: ignore

--- a/python/monarch/_src/actor/host_mesh.py
+++ b/python/monarch/_src/actor/host_mesh.py
@@ -140,6 +140,7 @@ class HostMesh(MeshTrait):
         bootstrap: Callable[[], None] | Callable[[], Awaitable[None]] | None = None,
         name: str | None = None,
         proc_bind: list[dict[str, str]] | None = None,
+        env: dict[str, str] | None = None,
     ) -> "ProcMesh":
         """Spawn a ProcMesh onto this host mesh.
 
@@ -151,6 +152,9 @@ class HostMesh(MeshTrait):
                 Length must equal ``math.prod(per_host.values())``.
                 Each dict maps binding keys (``cpunodebind``,
                 ``membind``, ``physcpubind``, ``cpus``) to values.
+            env: optional additional environment variables to set on spawned
+                procs. These supplement (and override on key conflicts) the
+                bootstrap command's existing environment.
         """
         if not per_host:
             per_host = {}
@@ -173,6 +177,7 @@ class HostMesh(MeshTrait):
             bootstrap,
             True,
             proc_bind,
+            env,
         )
 
     def _spawn_nonblocking(
@@ -182,6 +187,7 @@ class HostMesh(MeshTrait):
         setup: Callable[[], None] | Callable[[], Awaitable[None]] | None,
         _attach_controller_controller: bool,
         proc_bind: list[dict[str, str]] | None = None,
+        env: dict[str, str] | None = None,
     ) -> "ProcMesh":
         if set(per_host.labels) & set(self._labels):
             # The rust side will catch this too, but this lets us fail fast
@@ -195,6 +201,8 @@ class HostMesh(MeshTrait):
 
         async def task() -> HyProcMesh:
             hy_host_mesh = await self._hy_host_mesh
+            if env:
+                hy_host_mesh = hy_host_mesh.with_env(env)
             return await hy_host_mesh.spawn_nonblocking(
                 context().actor_instance._as_rust(), name, per_host, proc_bind
             )

--- a/python/monarch/_src/actor/host_mesh.py
+++ b/python/monarch/_src/actor/host_mesh.py
@@ -20,7 +20,7 @@ from monarch._rust_bindings.monarch_hyperactor.host_mesh import (
 )
 from monarch._rust_bindings.monarch_hyperactor.proc_mesh import ProcMesh as HyProcMesh
 from monarch._rust_bindings.monarch_hyperactor.pytokio import PythonTask, Shared
-from monarch._rust_bindings.monarch_hyperactor.shape import Extent, Region
+from monarch._rust_bindings.monarch_hyperactor.shape import Extent, Point, Region
 from monarch._src.actor.actor_mesh import _Lazy, context
 from monarch._src.actor.future import Future
 from monarch._src.actor.proc_mesh import _get_bootstrap_args, ProcMesh
@@ -28,7 +28,16 @@ from monarch._src.actor.shape import MeshTrait, NDSlice, Shape
 from monarch.tools.config.workspace import Workspace
 
 
-def _bootstrap_cmd() -> BootstrapCommand:
+def default_bootstrap_cmd() -> BootstrapCommand:
+    """Get the default bootstrap command for the current environment.
+
+    Returns a BootstrapCommand configured with the current Python executable
+    and environment. This can be used as a base for customization with
+    ``with_env()`` or by modifying its attributes directly.
+
+    Returns:
+        BootstrapCommand: The default bootstrap command.
+    """
     cmd, args, bootstrap_env = _get_bootstrap_args()
     return BootstrapCommand(
         cmd,
@@ -95,6 +104,9 @@ class HostMesh(MeshTrait):
         bootstrap: Callable[[], None] | Callable[[], Awaitable[None]] | None = None,
         name: str | None = None,
         proc_bind: list[dict[str, str]] | None = None,
+        bootstrap_command: (
+            BootstrapCommand | Callable[[Point], BootstrapCommand] | None
+        ) = None,
     ) -> "ProcMesh":
         """Spawn a ProcMesh onto this host mesh.
 
@@ -106,6 +118,11 @@ class HostMesh(MeshTrait):
                 Length must equal ``math.prod(per_host.values())``.
                 Each dict maps binding keys (``cpunodebind``,
                 ``membind``, ``physcpubind``, ``cpus``) to values.
+            bootstrap_command: optional BootstrapCommand or callable that
+                returns a BootstrapCommand for each coordinate. The callable
+                receives a ``Point`` (combined coordinate across host and
+                per_host dimensions). This allows full customization of the
+                bootstrap command per coordinate.
         """
         if not per_host:
             per_host = {}
@@ -128,6 +145,7 @@ class HostMesh(MeshTrait):
             bootstrap,
             True,
             proc_bind,
+            bootstrap_command,
         )
 
     def _spawn_nonblocking(
@@ -137,6 +155,9 @@ class HostMesh(MeshTrait):
         setup: Callable[[], None] | Callable[[], Awaitable[None]] | None,
         _attach_controller_controller: bool,
         proc_bind: list[dict[str, str]] | None = None,
+        bootstrap_command: (
+            BootstrapCommand | Callable[[Point], BootstrapCommand] | None
+        ) = None,
     ) -> "ProcMesh":
         if set(per_host.labels) & set(self._labels):
             # The rust side will catch this too, but this lets us fail fast
@@ -148,10 +169,32 @@ class HostMesh(MeshTrait):
         if self._inner_host_mesh is None:
             raise RuntimeError("HostMesh has already been shut down")
 
+        per_rank_bootstrap: Callable[[Point], BootstrapCommand] | None = None
+
+        if bootstrap_command is not None:
+            if isinstance(bootstrap_command, BootstrapCommand):
+                # Uniform BootstrapCommand - convert to callable
+                def make_uniform_bootstrap(
+                    cmd: BootstrapCommand,
+                ) -> Callable[[Point], BootstrapCommand]:
+                    def bootstrap_callable(point: Point) -> BootstrapCommand:
+                        return cmd
+
+                    return bootstrap_callable
+
+                per_rank_bootstrap = make_uniform_bootstrap(bootstrap_command)
+            else:
+                # Callable that returns BootstrapCommand
+                per_rank_bootstrap = bootstrap_command
+
         async def task() -> HyProcMesh:
             hy_host_mesh = await self._hy_host_mesh
             return await hy_host_mesh.spawn_nonblocking(
-                context().actor_instance._as_rust(), name, per_host, proc_bind
+                context().actor_instance._as_rust(),
+                name,
+                per_host,
+                proc_bind,
+                per_rank_bootstrap,
             )
 
         spawn_shared = PythonTask.from_coroutine(task()).spawn()

--- a/python/tests/test_host_mesh.py
+++ b/python/tests/test_host_mesh.py
@@ -464,6 +464,28 @@ def _make_python_wrapper() -> str:
     return wrapper_path
 
 
+class CudaVisibleDevicesActor(Actor):
+    @endpoint
+    def get_cuda_visible_devices(self) -> str:
+        return os.environ.get("CUDA_VISIBLE_DEVICES", "")
+
+
+@pytest.mark.timeout(60)
+@isolate_in_subprocess
+def test_spawn_procs_with_env() -> None:
+    hm = this_host()
+
+    pm = hm.spawn_procs(per_host={"gpus": 1}, env={"CUDA_VISIBLE_DEVICES": "3"})
+    am = pm.spawn("cuda_marker", CudaVisibleDevicesActor)
+    assert am.get_cuda_visible_devices.call_one().get() == "3"
+
+    # A second spawn without env must not inherit the previous spawn's env,
+    # confirming that with_env is non-mutating on the HostMesh.
+    pm_no_env = hm.spawn_procs(per_host={"gpus": 1})
+    am_no_env = pm_no_env.spawn("cuda_marker_default", CudaVisibleDevicesActor)
+    assert am_no_env.get_cuda_visible_devices.call_one().get() != "3"
+
+
 @pytest.mark.timeout(60)
 @isolate_in_subprocess
 def test_with_python_executable() -> None:

--- a/python/tests/test_host_mesh.py
+++ b/python/tests/test_host_mesh.py
@@ -21,7 +21,7 @@ from unittest.mock import patch
 import cloudpickle
 import pytest
 from isolate_in_subprocess import isolate_in_subprocess
-from monarch._rust_bindings.monarch_hyperactor.shape import Shape, Slice
+from monarch._rust_bindings.monarch_hyperactor.shape import Point, Shape, Slice
 from monarch._src.actor.actor_mesh import _client_context, Actor, context
 from monarch._src.actor.endpoint import endpoint
 from monarch._src.actor.host_mesh import HostMesh, this_host
@@ -470,6 +470,52 @@ def _make_python_wrapper() -> str:
         )
     os.chmod(wrapper_path, stat.S_IRWXU | stat.S_IRGRP | stat.S_IXGRP)
     return wrapper_path
+
+
+class CudaVisibleDevicesActor(Actor):
+    @endpoint
+    def get_cuda_visible_devices(self) -> str:
+        return os.environ.get("CUDA_VISIBLE_DEVICES", "")
+
+
+@pytest.mark.timeout(60)
+@isolate_in_subprocess
+def test_spawn_procs_with_bootstrap_command() -> None:
+    from monarch._src.actor.host_mesh import default_bootstrap_cmd
+
+    hm = this_host()
+
+    # Use with_env to customize the bootstrap command
+    base = default_bootstrap_cmd()
+    cmd = base.with_env({"CUDA_VISIBLE_DEVICES": "3"})
+
+    pm = hm.spawn_procs(per_host={"gpus": 1}, bootstrap_command=cmd)
+    am = pm.spawn("cuda_marker", CudaVisibleDevicesActor)
+    assert am.get_cuda_visible_devices.call_one().get() == "3"
+
+    # A second spawn without bootstrap_command must not inherit the previous
+    # spawn's env, confirming that with_env is non-mutating on the HostMesh.
+    pm_no_env = hm.spawn_procs(per_host={"gpus": 1})
+    am_no_env = pm_no_env.spawn("cuda_marker_default", CudaVisibleDevicesActor)
+    assert am_no_env.get_cuda_visible_devices.call_one().get() != "3"
+
+
+@pytest.mark.timeout(60)
+@isolate_in_subprocess
+def test_spawn_procs_with_bootstrap_command_callable() -> None:
+    from monarch._rust_bindings.monarch_hyperactor.host_mesh import BootstrapCommand
+    from monarch._src.actor.host_mesh import default_bootstrap_cmd
+
+    hm = this_host()
+
+    def per_rank_bootstrap(point: Point) -> BootstrapCommand:
+        base = default_bootstrap_cmd()
+        return base.with_env({"CUDA_VISIBLE_DEVICES": str(point["gpus"])})
+
+    pm = hm.spawn_procs(per_host={"gpus": 2}, bootstrap_command=per_rank_bootstrap)
+    am = pm.spawn("cuda_per_rank", CudaVisibleDevicesActor)
+    observed = sorted(am.get_cuda_visible_devices.call().get().values())
+    assert observed == ["0", "1"]
 
 
 @pytest.mark.timeout(60)


### PR DESCRIPTION
Summary:

Adds an optional `bootstrap_command` kwarg to `HostMesh.spawn_procs`. When provided, this is the bootstrap command used to launch the spawned procs, overriding the host agent's default. Accepts either a single `BootstrapCommand` applied uniformly to all procs, or a callable `Point -> BootstrapCommand` invoked once per rank over the combined `host ⊕ per_host` extent to produce a distinct command per proc.

For ergonomic customization, adds `BootstrapCommand.with_env(env)`, which returns a copy with `env` merged on top (user-supplied keys override existing ones), and `default_bootstrap_cmd()`, a factory exposing the default bootstrap command for the *local* (client) environment. Together they make per-rank patching concise:

```lang=py
base = default_bootstrap_cmd()
def per_rank(point):
    return base.with_env({"CUDA_VISIBLE_DEVICES": str(point["gpus"])})

procs = host.spawn_procs(per_host={"gpus": 4}, bootstrap_command=per_rank)
```

The override is non-mutating: it affects only the current `spawn_procs` call, not subsequent spawns on the same mesh, and the mesh's own `bootstrap_command` is preserved.

Implementation: on the Python side, both forms (uniform and callable) are normalized to a `Callable[[Point], BootstrapCommand]` and threaded through the new `per_rank_bootstrap` kwarg on `HostMesh.spawn_nonblocking`. In the pyo3 binding the callable is wrapped in a `Box<PerRankBootstrapFn>` (which calls back into Python with each rank's `Point`) and forwarded to `HostMeshRef::spawn`. On the Rust side, `HostMeshRef::spawn` invokes the function once per proc during the spawn loop and uses its return value in `ProcSpec` for that proc; if absent, the mesh's uniform `bootstrap_command` is used. Keeping the per-rank override out of `HostMeshRef` makes dimension mismatch unrepresentable on the ref type — a per-rank override exists only for the duration of a single `spawn` call.

Note on `default_bootstrap_cmd()`: this returns the default for the *local* (client) environment and is not guaranteed to match what the actual remote hosts would use on their own. In setups where client and host environments are equivalent this is fine; otherwise pass an explicit `BootstrapCommand`. Documented in `actors.md`.

Walkthrough:
- `hyperactor_mesh/src/bootstrap.rs`: remove `BootstrapCommandMesh` (an earlier per-rank approach).
- `hyperactor_mesh/src/host_mesh.rs`: keep `bootstrap_command`/`with_bootstrap`/`set_bootstrap` as uniform `BootstrapCommand`; add `per_rank_bootstrap: Option<Box<PerRankBootstrapFn>>` parameter to `spawn`/`spawn_inner`/`spawn_inner_inner` and use it inside the per-proc loop; new `PerRankBootstrapFn` type alias.
- `monarch_hyperactor/src/host_mesh.rs`: new `BootstrapCommand.with_env` PyMethod; new `per_rank_bootstrap` callable kwarg on `spawn_nonblocking` wrapping a Python callable as a `Box<PerRankBootstrapFn>` that calls back through the GIL.
- `.pyi` stub: `per_rank_bootstrap` callable param on `HostMesh.spawn_nonblocking`; `BootstrapCommand.with_env`.
- `python/monarch/_src/actor/host_mesh.py`: new `default_bootstrap_cmd()` factory; new `bootstrap_command` kwarg on `spawn_procs`; both forms normalized into a callable forwarded to the Rust binding.
- `python/monarch/_src/actor/actor_mesh.py`: import-rename `_bootstrap_cmd` → `default_bootstrap_cmd`.
- 23 `HostMeshRef::spawn` call sites across `hyperactor_mesh`, `monarch_hyperactor`, `monarch_rdma`, and `monarch_introspection_snapshot` pass `None` for the new parameter.

Reviewed By: mariusae

Differential Revision: D100436348


