### PR TITLE
[monarch] surface scoped_state shutdown failures instead of swallowing them

### DIFF
--- a/python/tests/scoped_state.py
+++ b/python/tests/scoped_state.py
@@ -18,15 +18,23 @@ from monarch._src.job.job import JobState, JobTrait
 def scoped_state(
     job: JobTrait, cached_path: Optional[str] = ".monarch/job_state.pkl"
 ) -> Generator[JobState, None, None]:
-    """Context manager that yields the job state and kills the job on exit.
+    """Context manager that yields the job state and cleans up on exit.
 
-    On a clean exit, gracefully shuts down all host meshes. If shutdown
-    fails or an exception occurred, kills the job. Failures to kill are
-    silently ignored, as the job may already be in a broken state.
+    On a clean exit, gracefully shuts down all host meshes. If graceful
+    shutdown fails, kills the job to avoid leaking worker processes and
+    re-raises so the failure is visible: tests that exit without fully
+    cleaning up leak pending message acks and surface later as
+    ``Unhandled monarch error on the root actor`` on some other, unrelated
+    test. Making the failure loud and local beats the cross-test
+    misattribution.
 
-    Calling job.kill() after a successful shutdown causes the global monarch
-    error handler to fire (due to pending message acks), so we only kill on
-    failure paths.
+    If the body of the ``with`` raises, kills the job and propagates the
+    original exception. We do not attempt graceful shutdown in that case
+    because the mesh may already be in a broken state.
+
+    Calling ``job.kill()`` after a *successful* shutdown causes the global
+    monarch error handler to fire (due to pending message acks), so we
+    only kill on failure paths.
 
     Example::
 
@@ -35,21 +43,30 @@ def scoped_state(
             proc = host.spawn_procs(...)
     """
     state = job.state(cached_path=cached_path)
-    success = False
+    body_ok = False
+    shutdown_error: Optional[BaseException] = None
     try:
         yield state
-        success = True
+        body_ok = True
     finally:
-        shutdown_ok = False
-        if success:
+        if body_ok:
             try:
                 for host_mesh in state._hosts.values():
-                    host_mesh.shutdown().get(timeout=10.0)
-                shutdown_ok = True
-            except Exception:
-                pass
-        if not shutdown_ok:
+                    # Skip meshes the test body already shut down.
+                    if host_mesh._inner_host_mesh is None:
+                        continue
+                    host_mesh.shutdown().get(timeout=30.0)
+            except BaseException as e:
+                shutdown_error = e
+        if not body_ok or shutdown_error is not None:
             try:
                 job.kill()
             except Exception:
                 pass
+
+    if shutdown_error is not None:
+        raise RuntimeError(
+            "scoped_state: host_mesh.shutdown() did not complete within "
+            "30s; workers have been killed but pending message acks may "
+            "still surface as 'Unhandled monarch error' on the root client."
+        ) from shutdown_error

--- a/python/tests/test_python_actors.py
+++ b/python/tests/test_python_actors.py
@@ -1811,7 +1811,7 @@ class WrapperActor(Actor):
     # automatically stopped without needing to define one.
 
 
-@pytest.mark.timeout(300)
+@pytest.mark.timeout(600)
 @isolate_in_subprocess
 def test_proc_mesh_churn_no_leaked_undeliverables():
     """Regression test for cross-test cleanup races.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #3468
* #3467

`scoped_state` used to wrap `host_mesh.shutdown().get(timeout=10.0)` in
`try: ... except Exception: pass`. When shutdown timed out (10s is tight
for a ProcessJob with multiple hosts under load), the pending
`ShutdownHost` messages stayed in the client's outbox, the link broke
30s later with "failed to receive ack within timeout 30s", and the
"Unhandled monarch error on the root actor" banner fired
asynchronously on whatever test happened to be running next.

This is the second half of the misattributed-error diagnosis from the
previous diff in this stack: the logger-mesh race was the usual
culprit, but the `hosts_4` `ShutdownHost` variant in the original CI
report came from here.

Walkthrough:
- `python/tests/scoped_state.py`: Bump the shutdown timeout from 10s
  to 30s so routine cleanup fits comfortably. On timeout (or any other
  shutdown failure), kill the job to avoid leaking worker processes,
  then re-raise as a `RuntimeError` so the test fails loudly. Tests
  whose cleanup doesn't complete should fail themselves rather than
  silently poison the next test. If the body already shut a host mesh
  down explicitly (e.g. `test_shutdown_host_mesh`), we skip re-shutting
  it via a `_inner_host_mesh is None` check.
- `python/tests/test_python_actors.py`: Bump
  `test_proc_mesh_churn_no_leaked_undeliverables` pytest timeout from
  300s to 600s. After the drain barrier from the previous diff, the
  test runs ~230s on an idle host but can approach 300s under load.

Differential Revision: [D101389030](https://our.internmc.facebook.com/intern/diff/D101389030/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D101389030/)!