### PR TITLE
[hyperactor_mesh] flush outgoing messages before bootstrap process::exit

### DIFF
--- a/hyperactor_mesh/src/host_mesh/host_agent.rs
+++ b/hyperactor_mesh/src/host_mesh/host_agent.rs
@@ -1144,6 +1144,15 @@ impl Handler<ShutdownHost> for HostAgent {
         // tear down the host's networking prematurely.
         msg.ack.send(cx, ())?;
 
+        // Flush outgoing messages so the ack is wire-delivered before
+        // we signal the bootstrap loop to exit. Without this, the
+        // bootstrap's process::exit(0) can kill the buffer drain task
+        // before the ack reaches the client, leaving it with a broken
+        // link and an undeliverable ShutdownHost 30 s later.
+        if let Err(e) = cx.proc().flush().await {
+            tracing::warn!("failed to flush outgoing messages after ShutdownHost ack: {e}");
+        }
+
         // Drop the host and signal the bootstrap loop to drain the
         // mailbox and exit.
         match std::mem::replace(&mut self.state, HostAgentState::Shutdown) {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #3469
* #3457

The ShutdownHost handler enqueues its ack via msg.ack.send(cx, ()), then signals the bootstrap loop via shutdown_tx.send(handle). The bootstrap loop drains the mailbox server (incoming side) and calls process::exit(0). But process::exit abruptly kills the background tokio task that drains the outgoing MailboxClient buffer, so the ack is never wire-delivered.

On the client side, the reply port for ShutdownHost stays open waiting for an ack that never arrives. After MESSAGE_DELIVERY_TIMEOUT (30s), the channel declares itself broken and an undeliverable message notification fires on the RootClientActor, killing the process via KeyboardInterrupt. In test suites without @isolate_in_subprocess, this cascades: one test's cleanup poisons all subsequent tests.

Fix by flushing the proc's forwarder after sending the ack and before signaling the bootstrap. cx.proc().flush().await waits until all previously posted messages have been wire-acked, so the ack is guaranteed delivered before process::exit runs.

## Trace

process::exit(0) is in HostShutdownHandle::join (hyperactor_mesh/src/bootstrap.rs:316):

```rust
pub async fn join(self) {
    match self.rx.await {                              // blocks until tx.send(handle)
        Ok(mailbox_handle) => {
            mailbox_handle.stop("host shutting down");
            let _ = mailbox_handle.await;
        }
        Err(_) => {}
    }
    if self.exit_on_shutdown {
        std::process::exit(0);                         // here
    }
}
```

The bootstrap task awaits on self.rx (the oneshot) and only wakes when tx.send(handle) fires. With this fix, the ShutdownHost handler order is:

1. msg.ack.send(cx, ()) — enqueue ack in the proc's forwarder
2. cx.proc().flush().await — await here; handler is still running
3. tx.send(handle) — only now does the bootstrap unblock
4. Handler returns

At step 2 the HostAgent handler is suspended on flush().await. The proc is fully alive because the HostAgent hasn't finished this handler, the system proc owns the forwarder (MailboxClient) whose drain task is still running, and the bootstrap task is still parked on self.rx.await — it hasn't touched the mailbox server yet. flush() waits until completed >= submitted (mailbox.rs:1240), so it specifically waits for the ack we just enqueued to be wire-acked. Only after that does tx.send(handle) let the bootstrap proceed to drain and exit.

Differential Revision: [D101389599](https://our.internmc.facebook.com/intern/diff/D101389599/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D101389599/)!