### PR TITLE
proc debug stats: fix running_total overflow by accounting enqueue before send

### DIFF
--- a/hyperactor/src/proc.rs
+++ b/hyperactor/src/proc.rs
@@ -291,6 +291,24 @@ fn account_dequeue(queue_depth: &AtomicU64, proc_stats: &ProcQueueStats, actor_i
         hyperactor_telemetry::kv_pairs!("actor_id" => actor_id.to_owned()),
     );
 }
+
+/// Roll back an accounted enqueue when the underlying send fails.
+///
+/// Must be paired with a prior `account_enqueue` that has not yet
+/// been balanced by `account_dequeue`. Decrements per-actor
+/// `queue_depth`, proc-level `running_total`, and OTel
+/// `ACTOR_MESSAGE_QUEUE_SIZE` symmetrically. Leaves
+/// `high_water_mark` alone (monotonic by design) and does not
+/// touch `last_nonzero_epoch_ms` (best-effort observational
+/// timestamp; brief overcount on failed sends is acceptable).
+fn account_cancel_enqueue(queue_depth: &AtomicU64, proc_stats: &ProcQueueStats, actor_id: &str) {
+    queue_depth.fetch_sub(1, Ordering::Relaxed);
+    proc_stats.running_total.fetch_sub(1, Ordering::Relaxed);
+    ACTOR_MESSAGE_QUEUE_SIZE.add(
+        -1,
+        hyperactor_telemetry::kv_pairs!("actor_id" => actor_id.to_owned()),
+    );
+}
 use crate::ordering::OrderedSender;
 use crate::ordering::OrderedSenderError;
 use crate::ordering::SEQ_INFO;
@@ -3152,10 +3170,13 @@ impl<A: Actor> Ports<A> {
                             }
                         })
                     });
-                    // PD-5b: account enqueue only after the work item
-                    // is successfully accepted by the work queue. This
-                    // prevents queue_depth from drifting on send failure
-                    // (channel closed, invalid seq, etc.).
+                    // PD-5b: account the enqueue BEFORE handing the work
+                    // to the queue. Otherwise the consumer can race and
+                    // call `account_dequeue` before this thread accounts
+                    // the enqueue, underflowing `running_total`. On send
+                    // failure, `account_cancel_enqueue` rolls back the
+                    // counters so `queue_depth` does not drift.
+                    account_enqueue(&enqueue_depth, &enqueue_proc_stats, &actor_id);
                     let result = if workq.enable_buffering {
                         match seq_info {
                             Some(SeqInfo::Session { session_id, seq }) => {
@@ -3185,14 +3206,14 @@ impl<A: Actor> Ports<A> {
                                     std::any::type_name::<M>(),
                                     );
                                 tracing::error!(error_msg);
-                                anyhow::bail!(error_msg);
+                                Err(anyhow::anyhow!(error_msg))
                             }
                         }
                     } else {
                         workq.direct_send(work).map_err(anyhow::Error::from)
                     };
-                    if result.is_ok() {
-                        account_enqueue(&enqueue_depth, &enqueue_proc_stats, &actor_id);
+                    if result.is_err() {
+                        account_cancel_enqueue(&enqueue_depth, &enqueue_proc_stats, &actor_id);
                     }
                     result
                 });
@@ -4921,5 +4942,40 @@ mod tests {
 
         // Watermark retained.
         assert_eq!(stats.high_water_mark(), 2);
+    }
+
+    // account_cancel_enqueue must symmetrically reverse
+    // account_enqueue on queue_depth and running_total so that a
+    // send failure after accounting cannot leave the proc-wide
+    // counter at u64::MAX (which would panic the next enqueue via
+    // the `fetch_add(1) + 1` path).
+    #[test]
+    fn test_account_cancel_enqueue_restores_counters() {
+        let stats = ProcQueueStats::new();
+        let depth = Arc::new(AtomicU64::new(0));
+
+        account_enqueue(&depth, &stats, "a");
+        assert_eq!(stats.running_total(), 1);
+        assert_eq!(depth.load(Ordering::Relaxed), 1);
+
+        account_cancel_enqueue(&depth, &stats, "a");
+        assert_eq!(
+            stats.running_total(),
+            0,
+            "cancel must restore running_total"
+        );
+        assert_eq!(
+            depth.load(Ordering::Relaxed),
+            0,
+            "cancel must restore queue_depth"
+        );
+
+        // high_water_mark is monotonic by design; cancel does not reset it.
+        assert_eq!(stats.high_water_mark(), 1);
+
+        // A subsequent enqueue must not observe underflow: fetch_add(1) + 1
+        // would panic in debug builds if running_total had wrapped to u64::MAX.
+        account_enqueue(&depth, &stats, "a");
+        assert_eq!(stats.running_total(), 1);
     }
 }


### PR DESCRIPTION
Summary:
https://github.com/meta-pytorch/monarch/pull/3420 introduced `ProcQueueStats::running_total`, an `AtomicU64` incremented in `account_enqueue` and decremented in `account_dequeue`. The accounting was placed *after* `workq.send` / `workq.direct_send` on the theory that we should only count items successfully accepted by the queue. That ordering opens a race: the consumer actor loop (`work_rx.recv()` at proc.rs:2085) runs `account_dequeue` as soon as the message is delivered, which can happen before the producer reaches `account_enqueue`. When it does, `running_total.fetch_sub(1)` wraps 0 to `u64::MAX`, and the next `account_enqueue`'s `fetch_add(1) + 1` panics in debug builds with "attempt to add with overflow" at proc.rs:257.

This is the root cause of the sustained CI failures on main since 2026-04-16: Test CPU Rust (Linux x86), Test CPU Rust (ARM64), and Test CPU Rust (macOS) all fail on tests like hyperactor::actor::tests::test_sequencing_actor_handle_basic, hyperactor::proc::tests::test_actor_lookup, and hyperactor_macros::tests::test_binds — none of which touch the queue-stats code directly but all of which exercise the common enqueue path.

Fix: reorder Ports::get's enqueue closure so account_enqueue runs *before* workq.send / workq.direct_send, and introduce account_cancel_enqueue to symmetrically roll back queue_depth, running_total, and the OTel counter on send failure. high_water_mark is left alone (monotonic by design) and last_nonzero_epoch_ms is not touched on cancel — a brief overcount on failed sends is acceptable for best-effort observational telemetry. The PD-5b invariant (queue_depth does not drift on send failure) is preserved, now via symmetric rollback rather than skipped accounting.

Also converted anyhow::bail! in the None SEQ_INFO arm to Err(anyhow::anyhow!(...)) so the error flows through result and triggers the rollback, instead of early-returning from the closure and leaking the accounted enqueue.

Reviewed By: shayne-fletcher

Differential Revision: D101378610


