### PR TITLE
upgrading which to 8.0.2 (#3476)

### DIFF
--- a/build_utils/Cargo.toml
+++ b/build_utils/Cargo.toml
@@ -15,4 +15,4 @@ doctest = false
 cc = "1.2.57"
 glob = "0.3.2"
 pyo3-build-config = "0.26"
-which = "4.2.4"
+which = "8.0.2"


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookexperimental/rust-shed/pull/72


X-link: https://github.com/facebook/sapling/pull/1286

Upgrading `which` from `4.2.4` to `8.0.2`.
- Major version jump (4→8). Key changes: `Sys` trait for filesystem abstraction, `tracing` support, removed `either`/`rustix`/`winsafe` deps. Basic `which::which()` API is unchanged.
- All downstream consumers checked with arc rust-check — 0 errors.

Reviewed By: dtolnay

Differential Revision: D101291181
