### PR TITLE
[hyperactor] restructure ActorId/PortId as newtypes and collapse runtime tables

### DIFF
--- a/docs/source/books/hyperactor-book/src/references/actor_id.md
+++ b/docs/source/books/hyperactor-book/src/references/actor_id.md
@@ -1,6 +1,6 @@
 # `ActorId`
 
-An `ActorId` uniquely identifies an actor within a proc. It combines the proc the actor lives on, a string name, and a numeric pid (process-local instance index).
+An `ActorId` uniquely identifies an actor within a proc. It combines the proc the actor lives on and a string name.
 
 ```rust
 #[derive(
@@ -15,11 +15,10 @@ An `ActorId` uniquely identifies an actor within a proc. It combines the proc th
     Ord,
     Named
 )]
-pub struct ActorId(ProcId, String, Index);
+pub struct ActorId(ProcId, String);
 ```
 - The first field is the actor's `ProcId`.
 - The second is the actor's name (used for grouping and logging).
-- The third is the pid (`Index`), which distinguishes multiple instances with the same name.
 
 ### Construction
 
@@ -29,13 +28,7 @@ use hyperactor::reference::{ActorId, ProcId};
 
 let addr = "tcp:127.0.0.1:8080".parse()?;
 let proc = ProcId::with_name(addr, "myproc");
-let actor = ActorId::new(proc.clone(), "worker", 1);
-```
-
-To refer to the root actor (the canonical instance), use:
-```rust
-let root = ActorId::root(proc, "worker".into());
-// Equivalent to ActorId::new(proc, "worker", 0)
+let actor = ActorId::new(proc.clone(), "worker");
 ```
 
 ### Methods
@@ -44,34 +37,25 @@ let root = ActorId::root(proc, "worker".into());
 impl ActorId {
     pub fn proc_id(&self) -> &ProcId;
     pub fn name(&self) -> &str;
-    pub fn pid(&self) -> usize;
-    pub fn child_id(&self, pid: usize) -> Self;
     pub fn port_id(&self, port: u64) -> PortId;
-    pub fn root(proc: ProcId, name: String) -> Self;
 }
 ```
 
 - `.proc_id()` returns the ProcId that owns this actor.
 - `.name()` returns the logical name of the actor (e.g., "worker").
-- `.pid()` returns the actor's instance ID.
-- `.child_id(pid)` creates a new `ActorId` with the same name and proc but a different pid.
 - `.port_id(port)` returns a `PortId` representing a port on this actor.
-- `.root(proc, name)` constructs a new root actor (`pid = 0`) in the given proc.
 
 ### Traits
 
 `ActorId` implements:
 
-- `Display` — formats as `addr,proc_name,name[pid]`
-- `FromStr` — parses strings like `"tcp:[::1]:1234,myproc,logger[1]"`
+- `Display` — formats as `addr,proc_name,name`
+- `FromStr` — parses strings like `"tcp:[::1]:1234,myproc,logger"`
 - `Clone`, `Eq`, `Ord`, `Hash` — useful in maps, sets, and registries
 - `Named` — enables type-based routing, port lookup, and reflection
 
 ## Semantics
 
 - The `name` groups actors logically within a proc (e.g., `"worker"`, `"trainer"`).
-- The `pid` distinguishes physical instances:
-  - `pid = 0` represents the **root** actor instance.
-  - `pid > 0` typically corresponds to **child actors** spawned by the root.
-- Most routing and API surfaces operate on root actors by default.
+- Most routing and API surfaces operate on actors by name.
 - Port creation is always rooted in an `ActorId`, via `.port_id(...)`.

--- a/hyper/src/commands/list.rs
+++ b/hyper/src/commands/list.rs
@@ -38,7 +38,7 @@ impl ListCommand {
         // Codify obtaining a proc's agent in `hyperactor_mesh` somewhere.
         let agent: reference::ActorRef<HostAgent> = reference::ActorRef::attest(
             reference::ProcId::with_name(host, SERVICE_PROC_NAME)
-                .actor_id(HOST_MESH_AGENT_ACTOR_NAME, 0),
+                .actor_id(HOST_MESH_AGENT_ACTOR_NAME),
         );
 
         let resources = agent.list(&client).await?;

--- a/hyper/src/commands/show.rs
+++ b/hyper/src/commands/show.rs
@@ -32,7 +32,7 @@ impl ShowCommand {
                 // Codify obtaining a proc's agent in `hyperactor_mesh` somewhere.
                 let agent: reference::ActorRef<HostAgent> = reference::ActorRef::attest(
                     reference::ProcId::with_name(host, SERVICE_PROC_NAME)
-                        .actor_id(HOST_MESH_AGENT_ACTOR_NAME, 0),
+                        .actor_id(HOST_MESH_AGENT_ACTOR_NAME),
                 );
 
                 let state = agent.get_state(&client, proc.parse().unwrap()).await?;

--- a/hyperactor/src/actor.rs
+++ b/hyperactor/src/actor.rs
@@ -455,8 +455,8 @@ pub enum Signal {
     /// Stop the actor immediately.
     Stop(String),
 
-    /// The direct child with the given PID was stopped.
-    ChildStopped(reference::Index),
+    /// The direct child with the given uid was stopped.
+    ChildStopped(crate::id::Uid),
 
     /// Abort the actor. This will exit the actor loop with an error,
     /// causing a supervision event to propagate up the supervision
@@ -470,7 +470,7 @@ impl fmt::Display for Signal {
         match self {
             Signal::DrainAndStop(reason) => write!(f, "DrainAndStop({})", reason),
             Signal::Stop(reason) => write!(f, "Stop({})", reason),
-            Signal::ChildStopped(index) => write!(f, "ChildStopped({})", index),
+            Signal::ChildStopped(uid) => write!(f, "ChildStopped({})", uid),
             Signal::Abort(reason) => write!(f, "Abort({})", reason),
         }
     }
@@ -1768,8 +1768,7 @@ mod tests {
         let actor = EchoActor(tx.bind());
         let handle = proc.spawn::<EchoActor>("echo_qc", actor).unwrap();
 
-        let child_ref =
-            reference::Reference::Actor(test_proc_id("nonexistent").actor_id("child", 0));
+        let child_ref = reference::Reference::Actor(test_proc_id("nonexistent").actor_id("child"));
         let (reply_port, reply_rx) = client.open_once_port::<IntrospectResult>();
         reference::PortRef::<IntrospectMessage>::attest_message_port(handle.actor_id())
             .send(
@@ -1784,9 +1783,7 @@ mod tests {
 
         assert_eq!(
             payload.identity,
-            crate::introspect::IntrospectRef::Actor(
-                test_proc_id("nonexistent").actor_id("child", 0)
-            )
+            crate::introspect::IntrospectRef::Actor(test_proc_id("nonexistent").actor_id("child"))
         );
         assert_error_code(&payload, "not_found");
 
@@ -2104,7 +2101,7 @@ mod tests {
         let handle = proc.spawn::<EchoActor>("echo_qch", actor).unwrap();
 
         // Before registering, query_child returns None.
-        let test_ref = reference::Reference::Actor(test_proc_id("test").actor_id("child", 0));
+        let test_ref = reference::Reference::Actor(test_proc_id("test").actor_id("child"));
         assert!(handle.cell().query_child(&test_ref).is_none());
 
         // Register a callback.
@@ -2135,7 +2132,7 @@ mod tests {
             .expect("callback should produce a payload");
         assert_eq!(
             payload.identity,
-            crate::introspect::IntrospectRef::Actor(test_proc_id("test").actor_id("child", 0))
+            crate::introspect::IntrospectRef::Actor(test_proc_id("test").actor_id("child"))
         );
         let attrs: serde_json::Value =
             serde_json::from_str(&payload.attrs).expect("attrs must be valid JSON");

--- a/hyperactor/src/host.rs
+++ b/hyperactor/src/host.rs
@@ -311,9 +311,9 @@ impl MailboxSender for ProcOrDial {
         envelope: MessageEnvelope,
         return_handle: PortHandle<Undeliverable<MessageEnvelope>>,
     ) {
-        if envelope.dest().actor_id().proc_id() == self.service_proc.proc_id() {
+        if &envelope.dest().actor_id().proc_id() == self.service_proc.proc_id() {
             self.service_proc.post_unchecked(envelope, return_handle);
-        } else if envelope.dest().actor_id().proc_id() == self.local_proc.proc_id() {
+        } else if &envelope.dest().actor_id().proc_id() == self.local_proc.proc_id() {
             self.local_proc.post_unchecked(envelope, return_handle);
         } else {
             self.dialer.post_unchecked(envelope, return_handle)
@@ -1541,8 +1541,8 @@ mod tests {
         assert!(matches!(host.addr().transport(), ChannelTransport::Unix));
         let (proc1, echo1) = host.spawn("proc1".to_string(), ()).await.unwrap();
         let (proc2, echo2) = host.spawn("proc2".to_string(), ()).await.unwrap();
-        assert_eq!(echo1.actor_id().proc_id(), &proc1);
-        assert_eq!(echo2.actor_id().proc_id(), &proc2);
+        assert_eq!(echo1.actor_id().proc_id(), proc1);
+        assert_eq!(echo2.actor_id().proc_id(), proc2);
 
         // (2) Duplicate name rejection.
         let dup = host.spawn("proc1".to_string(), ()).await;
@@ -1608,7 +1608,7 @@ mod tests {
         // Build a LocalHandle directly.
         let addr = ChannelAddr::any(ChannelTransport::Local);
         let proc_id = reference::ProcId::from_resource_name(addr.clone(), "p");
-        let agent_ref = reference::ActorRef::<()>::attest(proc_id.actor_id("host_agent", 0));
+        let agent_ref = reference::ActorRef::<()>::attest(proc_id.actor_id("host_agent"));
         let h = LocalHandle::<()> {
             proc_id,
             addr,
@@ -1738,7 +1738,7 @@ mod tests {
             forwarder_addr: ChannelAddr,
             _config: (),
         ) -> Result<Self::Handle, HostError> {
-            let agent = reference::ActorRef::<()>::attest(proc_id.actor_id("host_agent", 0));
+            let agent = reference::ActorRef::<()>::attest(proc_id.actor_id("host_agent"));
             Ok(TestHandle {
                 id: proc_id,
                 addr: forwarder_addr,
@@ -1785,7 +1785,7 @@ mod tests {
         .unwrap();
 
         let (pid, agent) = host.spawn("ok".into(), ()).await.expect("must succeed");
-        assert_eq!(agent.actor_id().proc_id(), &pid);
+        assert_eq!(agent.actor_id().proc_id(), pid);
         assert!(host.procs.contains("ok"));
     }
 

--- a/hyperactor/src/introspect.rs
+++ b/hyperactor/src/introspect.rs
@@ -1054,8 +1054,8 @@ mod tests {
         attrs
     }
 
-    fn test_actor_id(proc_name: &str, actor_name: &str, pid: usize) -> crate::reference::ActorId {
-        ProcId::from_resource_name(ChannelAddr::Local(0), proc_name).actor_id(actor_name, pid)
+    fn test_actor_id(proc_name: &str, actor_name: &str) -> crate::reference::ActorId {
+        ProcId::from_resource_name(ChannelAddr::Local(0), proc_name).actor_id(actor_name)
     }
 
     fn failed_actor_attrs() -> Attrs {
@@ -1063,7 +1063,7 @@ mod tests {
         attrs.set(STATUS, "failed".to_string());
         attrs.set(STATUS_REASON, "something broke".to_string());
         attrs.set(FAILURE_ERROR_MESSAGE, "boom".to_string());
-        attrs.set(FAILURE_ROOT_CAUSE_ACTOR, test_actor_id("proc", "other", 0));
+        attrs.set(FAILURE_ROOT_CAUSE_ACTOR, test_actor_id("proc", "other"));
         attrs.set(FAILURE_ROOT_CAUSE_NAME, "OtherActor".to_string());
         attrs.set(FAILURE_OCCURRED_AT, SystemTime::UNIX_EPOCH);
         attrs.set(FAILURE_IS_PROPAGATED, true);
@@ -1151,7 +1151,7 @@ mod tests {
     fn test_actor_view_ia4_rejects_failure_attrs_on_running() {
         let mut attrs = running_actor_attrs();
         attrs.set(FAILURE_ERROR_MESSAGE, "boom".to_string());
-        attrs.set(FAILURE_ROOT_CAUSE_ACTOR, test_actor_id("proc", "x", 0));
+        attrs.set(FAILURE_ROOT_CAUSE_ACTOR, test_actor_id("proc", "x"));
         attrs.set(FAILURE_OCCURRED_AT, SystemTime::UNIX_EPOCH);
         let err = ActorAttrsView::from_attrs(&attrs).unwrap_err();
         assert!(matches!(
@@ -1192,8 +1192,8 @@ mod tests {
     #[test]
     fn test_fi7_fi8_propagated_stopped_child() {
         let proc_id = ProcId::from_resource_name(ChannelAddr::Local(0), "test_proc");
-        let child_id = proc_id.actor_id("proc_agent", 0);
-        let parent_id = proc_id.actor_id("mesh_actor", 0);
+        let child_id = proc_id.actor_id("proc_agent");
+        let parent_id = proc_id.actor_id("mesh_actor");
 
         let child_event = ActorSupervisionEvent::new(
             child_id.clone(),

--- a/hyperactor/src/mailbox.rs
+++ b/hyperactor/src/mailbox.rs
@@ -22,7 +22,7 @@
 //! # tokio_test::block_on(async {
 //! # let proc = Proc::local();
 //! # let (client, _) = proc.instance("client").unwrap();
-//! # let actor_id = proc.proc_id().actor_id("actor", 0);
+//! # let actor_id = proc.proc_id().actor_id("actor");
 //! let mbox = Mailbox::new_detached(actor_id);
 //! let (port, mut receiver) = mbox.open_port::<u64>();
 //!
@@ -41,7 +41,7 @@
 //! # tokio_test::block_on(async {
 //! # let proc = Proc::local();
 //! # let (client, _) = proc.instance("client").unwrap();
-//! # let actor_id = proc.proc_id().actor_id("actor", 0);
+//! # let actor_id = proc.proc_id().actor_id("actor");
 //! let mbox = Mailbox::new_detached(actor_id);
 //!
 //! let (port, receiver) = mbox.open_once_port::<u64>();
@@ -242,7 +242,7 @@ impl MessageEnvelope {
         let unknown_addr = ChannelAddr::any(ChannelTransport::Local);
         let unknown_proc_id = crate::reference::ProcId::unique(unknown_addr, "unknown");
         let unknown_actor_id =
-            crate::reference::ActorId::root(unknown_proc_id, "unknown".to_string());
+            crate::reference::ActorId::root(unknown_proc_id, crate::id::Label::strip("unknown"));
         Self::new(unknown_actor_id, dest, data, Flattrs::new())
     }
 
@@ -601,10 +601,10 @@ impl PortLocation {
     }
 
     /// The actor id of the location.
-    pub fn actor_id(&self) -> &reference::ActorId {
+    pub fn actor_id(&self) -> reference::ActorId {
         match self {
             PortLocation::Bound(port_id) => port_id.actor_id(),
-            PortLocation::Unbound(actor_id, _) => actor_id,
+            PortLocation::Unbound(actor_id, _) => actor_id.clone(),
         }
     }
 }
@@ -827,7 +827,10 @@ impl MailboxSender for UndeliverableMailboxSender {
         envelope: MessageEnvelope,
         return_handle: PortHandle<Undeliverable<MessageEnvelope>>,
     ) {
-        let sender_name = envelope.sender.name();
+        let sender_name = envelope
+            .sender
+            .label()
+            .map_or("?".to_string(), |l| l.to_string());
         let error_str = envelope.error_msg().unwrap_or("".to_string());
         // The undeliverable message was unable to be delivered back to the
         // sender for some reason
@@ -1567,7 +1570,7 @@ impl Mailbox {
     pub(crate) fn bind_untyped(&self, port_id: &reference::PortId, sender: UntypedUnboundedSender) {
         assert_eq!(
             port_id.actor_id(),
-            self.actor_id(),
+            *self.actor_id(),
             "port does not belong to mailbox"
         );
 
@@ -1628,13 +1631,13 @@ impl MailboxSender for Mailbox {
         );
         tracing::trace!(
             name = "post",
-            actor_name = envelope.sender.name(),
+            actor_name = envelope.sender.label().map_or("?", |l| l.as_str()),
             actor_id = envelope.sender.to_string(),
             "posting message to {}",
             envelope.dest
         );
 
-        if envelope.dest().actor_id() != &self.inner.actor_id {
+        if envelope.dest().actor_id() != self.inner.actor_id {
             return self.inner.forwarder.post(envelope, return_handle);
         }
 
@@ -2079,7 +2082,7 @@ impl<M> PortReceiver<M> {
         self.port_id.index()
     }
 
-    fn actor_id(&self) -> &reference::ActorId {
+    fn actor_id(&self) -> reference::ActorId {
         self.port_id.actor_id()
     }
 }
@@ -2131,7 +2134,7 @@ impl<M> OncePortReceiver<M> {
         self.port_id.index()
     }
 
-    fn actor_id(&self) -> &reference::ActorId {
+    fn actor_id(&self) -> reference::ActorId {
         self.port_id.actor_id()
     }
 }
@@ -2522,7 +2525,7 @@ impl MailboxSender for MailboxMuxer {
         return_handle: PortHandle<Undeliverable<MessageEnvelope>>,
     ) {
         let dest_actor_id = envelope.dest().actor_id();
-        match self.mailboxes.get(dest_actor_id) {
+        match self.mailboxes.get(&dest_actor_id) {
             None => {
                 let err = format!("no mailbox for actor {} registered in muxer", dest_actor_id);
                 envelope.undeliverable(DeliveryError::Unroutable(err), return_handle)
@@ -2617,7 +2620,8 @@ impl MailboxSender for MailboxRouter {
         envelope: MessageEnvelope,
         return_handle: PortHandle<Undeliverable<MessageEnvelope>>,
     ) {
-        match self.sender(envelope.dest().actor_id()) {
+        let dest_actor_id = envelope.dest().actor_id();
+        match self.sender(&dest_actor_id) {
             None => envelope.undeliverable(
                 DeliveryError::Unroutable(
                     "no destination found for actor in routing table".to_string(),
@@ -2649,7 +2653,8 @@ impl MailboxSender for FallbackMailboxRouter {
         envelope: MessageEnvelope,
         return_handle: PortHandle<Undeliverable<MessageEnvelope>>,
     ) {
-        match self.router.sender(envelope.dest().actor_id()) {
+        let dest_actor_id = envelope.dest().actor_id();
+        match self.router.sender(&dest_actor_id) {
             Some(sender) => sender.post(envelope, return_handle),
             None => self.default.post(envelope, return_handle),
         }
@@ -2885,12 +2890,13 @@ impl MailboxSender for DialMailboxRouter {
         envelope: MessageEnvelope,
         return_handle: PortHandle<Undeliverable<MessageEnvelope>>,
     ) {
-        let Some(addr) = self.lookup_addr(envelope.dest().actor_id()) else {
+        let dest_actor_id = envelope.dest().actor_id();
+        let Some(addr) = self.lookup_addr(&dest_actor_id) else {
             self.default.post(envelope, return_handle);
             return;
         };
 
-        match self.dial(&addr, envelope.dest().actor_id()) {
+        match self.dial(&addr, &dest_actor_id) {
             Err(err) => envelope.undeliverable(
                 DeliveryError::Unroutable(format!("cannot dial destination: {err}")),
                 return_handle,
@@ -2965,14 +2971,13 @@ mod tests {
 
     #[test]
     fn test_error() {
-        use crate::testing::ids::test_actor_id_with_pid;
+        use crate::testing::ids::test_actor_id;
         let err = MailboxError::new(
-            test_actor_id_with_pid("myworld_2", "myactor", 5),
+            test_actor_id("myworld_2", "myactor"),
             MailboxErrorKind::Closed,
         );
-        // The format is: "{proc_id},{actor_name}[{pid}]: {error}"
-        // proc_id = "{addr},{proc_name}" so overall: "{addr},{proc_name},{actor_name}[{pid}]"
-        assert!(format!("{}", err).ends_with(",_test_myworld_2,myactor[5]: mailbox closed"));
+        // The format is: "{proc_id},{actor_resource_name}: {error}"
+        assert!(format!("{}", err).ends_with(",_test_myworld_2,_myactor: mailbox closed"));
     }
 
     #[tokio::test]

--- a/hyperactor/src/mailbox/undeliverable.rs
+++ b/hyperactor/src/mailbox/undeliverable.rs
@@ -42,7 +42,7 @@ pub(crate) fn new_undeliverable_port() -> (
     PortReceiver<Undeliverable<MessageEnvelope>>,
 ) {
     let proc = Proc::local();
-    crate::mailbox::Mailbox::new_detached(proc.proc_id().actor_id("undeliverable", 0))
+    crate::mailbox::Mailbox::new_detached(proc.proc_id().actor_id("undeliverable"))
         .open_port::<Undeliverable<MessageEnvelope>>()
 }
 

--- a/hyperactor/src/message.rs
+++ b/hyperactor/src/message.rs
@@ -336,7 +336,7 @@ mod tests {
     use crate::Unbind;
     use crate::accum::ReducerSpec;
     use crate::accum::StreamingReducerOpts;
-    use crate::testing::ids::test_port_id_with_pid;
+    use crate::testing::ids::test_port_id;
 
     // Used to demonstrate a user defined reply type.
     #[derive(Debug, PartialEq, Serialize, Deserialize, typeuri::Named)]
@@ -364,10 +364,9 @@ mod tests {
 
     #[test]
     fn test_castable() {
-        let original_port0 =
-            reference::PortRef::attest(test_port_id_with_pid("world_0", "actor", 0, 123));
+        let original_port0 = reference::PortRef::attest(test_port_id("world_0", "actor", 123));
         let original_port1 = reference::PortRef::attest_reducible(
-            test_port_id_with_pid("world_1", "actor1", 0, 456),
+            test_port_id("world_1", "actor1", 456),
             Some(ReducerSpec {
                 typehash: 123,
                 builder_params: None,
@@ -413,9 +412,9 @@ mod tests {
         );
 
         // Modify the port in the erased
-        let new_port_id0 = test_port_id_with_pid("world_0", "comm", 0, 680);
+        let new_port_id0 = test_port_id("world_0", "comm", 680);
         assert_ne!(&new_port_id0, original_port0.port_id());
-        let new_port_id1 = test_port_id_with_pid("world_1", "comm", 0, 257);
+        let new_port_id1 = test_port_id("world_1", "comm", 257);
         assert_ne!(&new_port_id1, original_port1.port_id());
 
         let mut new_ports = vec![&new_port_id0, &new_port_id1].into_iter();

--- a/hyperactor/src/proc.rs
+++ b/hyperactor/src/proc.rs
@@ -26,14 +26,10 @@
 //!
 //! ## Actor identity invariants (AI-*)
 //!
-//! - **AI-1 (named-child pid):** The pid of a named child must
-//!   remain in the parent's sibling pid domain. The name is
-//!   presentation only; the numeric pid is allocated from the
-//!   parent's counter, preserving supervision linkage.
-//! - **AI-3 (controller ActorId uniqueness):** Callers must ensure
-//!   the name is unique proc-wide. Two children with the same name
-//!   under different parents get distinct pids but the same name
-//!   prefix.
+//! - **AI-1 (named-child uid):** Each child gets a globally unique
+//!   random uid. Named children carry a label for display purposes.
+//! - **AI-3 (controller ActorId uniqueness):** Each named child gets
+//!   a unique uid; the label is informational only.
 //!
 //! ## Queue depth accounting invariants (PD-5*)
 //!
@@ -99,6 +95,7 @@ use std::time::SystemTime;
 
 use async_trait::async_trait;
 use dashmap::DashMap;
+use dashmap::DashSet;
 use dashmap::mapref::entry::Entry;
 use dashmap::mapref::multiple::RefMulti;
 use futures::FutureExt;
@@ -334,11 +331,10 @@ struct ProcState {
     /// Sender used to forward messages outside of the proc.
     forwarder: BoxedMailboxSender,
 
-    /// Per-name atomic index allocator. Used by `allocate_root_id`
-    /// (index 0, counter starts at 1) and `allocate_child_id`
-    /// (increments the parent's counter). Each root name gets its
-    /// own independent counter.
-    roots: DashMap<String, AtomicUsize>,
+    /// Reserved root actor uids. Prevents races between concurrent
+    /// `allocate_root_id` callers — insert returns false if the uid
+    /// was already reserved.
+    reserved_roots: DashSet<crate::id::Uid>,
 
     /// All actor instances in this proc.
     instances: DashMap<reference::ActorId, WeakInstanceCell>,
@@ -414,7 +410,7 @@ impl Proc {
                 proc_id,
                 proc_muxer: MailboxMuxer::new(),
                 forwarder,
-                roots: DashMap::new(),
+                reserved_roots: DashSet::new(),
                 instances: DashMap::new(),
                 queue_stats: Arc::new(ProcQueueStats::new()),
                 terminated_snapshots: DashMap::new(),
@@ -582,7 +578,7 @@ impl Proc {
 
     /// Common spawn logic for both root and child actors.
     /// Creates a tracing span with the correct actor_id before starting the actor.
-    #[hyperactor::instrument(fields(actor_id = actor_id.to_string(), actor_name = actor_id.name(), actor_type = std::any::type_name::<A>()))]
+    #[hyperactor::instrument(fields(actor_id = actor_id.to_string(), actor_name = actor_id.log_name(), actor_type = std::any::type_name::<A>()))]
     fn spawn_inner<A: Actor>(
         &self,
         actor_id: reference::ActorId,
@@ -667,7 +663,7 @@ impl Proc {
         })
     }
 
-    /// Traverse all actor trees in this proc, starting from root actors (pid=0).
+    /// Traverse all actor trees in this proc, starting from root actors.
     ///
     /// **Caution:** This holds DashMap shard read locks while doing
     /// `Weak::upgrade()` and recursively walking the actor tree per
@@ -680,7 +676,7 @@ impl Proc {
         F: FnMut(&InstanceCell, usize),
     {
         for entry in self.state().instances.iter() {
-            if entry.key().pid() == 0 {
+            if entry.key().is_root() {
                 if let Some(cell) = entry.value().upgrade() {
                     cell.traverse(f);
                 }
@@ -711,7 +707,7 @@ impl Proc {
             .and_then(|weak| weak.upgrade())
     }
 
-    /// Returns the ActorIds of all root actors (pid=0) in this proc.
+    /// Returns the ActorIds of all root actors in this proc.
     ///
     /// **Caution:** This iterates the full DashMap under shard read
     /// locks. The per-entry work is lightweight (key filter + clone),
@@ -723,7 +719,7 @@ impl Proc {
         self.state()
             .instances
             .iter()
-            .filter(|entry| entry.key().pid() == 0)
+            .filter(|entry| entry.key().is_root())
             .map(|entry| entry.key().clone())
             .collect()
     }
@@ -893,9 +889,9 @@ impl Proc {
                     tracing::info!("sending stop signal to {}", cell.actor_id());
                     if let Err(err) = cell.signal(Signal::DrainAndStop(reason)) {
                         tracing::error!(
-                            "{}: failed to send stop signal to pid {}: {:?}",
+                            "{}: failed to send stop signal to uid {}: {:?}",
                             self.proc_id(),
-                            cell.pid(),
+                            cell.uid(),
                             err
                         );
                         None
@@ -962,7 +958,7 @@ impl Proc {
             .state()
             .instances
             .iter()
-            .filter(|entry| entry.key().pid() == 0)
+            .filter(|entry| entry.key().is_root())
             .map(|entry| entry.key().clone())
             .collect::<Vec<_>>()
         {
@@ -1115,55 +1111,38 @@ impl Proc {
     }
 
     /// Create a root allocation in the proc.
+    ///
+    /// Uses `reserved_roots` to prevent races between concurrent callers.
     fn allocate_root_id(&self, name: &str) -> Result<reference::ActorId, anyhow::Error> {
-        let name = name.to_string();
-        match self.state().roots.entry(name.to_string()) {
-            Entry::Vacant(entry) => {
-                entry.insert(AtomicUsize::new(1));
-            }
-            Entry::Occupied(_) => {
-                anyhow::bail!("an actor with name '{}' has already been spawned", name)
-            }
+        let actor_id = reference::ActorId::new(self.state().proc_id.clone(), name);
+        let uid = actor_id.uid().clone();
+        if !self.state().reserved_roots.insert(uid) {
+            anyhow::bail!("an actor with name '{}' has already been spawned", name)
         }
-        Ok(reference::ActorId::new(
-            self.state().proc_id.clone(),
-            name.to_string(),
-            0,
-        ))
+        Ok(actor_id)
     }
 
     /// Create a child allocation in the proc.
-    #[hyperactor::instrument(fields(actor_name=parent_id.name()))]
     pub(crate) fn allocate_child_id(
         &self,
         parent_id: &reference::ActorId,
     ) -> Result<reference::ActorId, anyhow::Error> {
-        assert_eq!(*parent_id.proc_id(), self.state().proc_id);
-        let pid = match self.state().roots.get(parent_id.name()) {
-            None => anyhow::bail!(
-                "no actor named {} in proc {}",
-                parent_id.name(),
-                self.state().proc_id
-            ),
-            Some(next_pid) => next_pid.fetch_add(1, Ordering::Relaxed),
-        };
-        Ok(parent_id.child_id(pid))
+        assert_eq!(parent_id.proc_id(), self.state().proc_id);
+        Ok(parent_id.unique_child_id())
     }
 
     /// Allocate an actor ID with a custom name on this proc.
-    ///
-    /// See AI-1 (named-child pid) and AI-3 (controller ActorId
-    /// uniqueness) in module doc.
     pub(crate) fn allocate_named_child_id(
         &self,
         parent_id: &reference::ActorId,
         name: &str,
     ) -> Result<reference::ActorId, anyhow::Error> {
-        let inherited = self.allocate_child_id(parent_id)?;
-        Ok(reference::ActorId::new(
-            inherited.proc_id().clone(),
-            name,
-            inherited.pid(),
+        assert_eq!(parent_id.proc_id(), self.state().proc_id);
+        let label = crate::id::Label::strip(name);
+        let actor_id =
+            crate::id::ActorId::instance_labeled(label, parent_id.proc_id().id().clone());
+        Ok(reference::ActorId::from_actor_ref(
+            crate::ref_::ActorRef::new(actor_id, parent_id.actor_ref().location().clone()),
         ))
     }
 
@@ -1203,7 +1182,7 @@ impl MailboxSender for Proc {
         envelope: MessageEnvelope,
         return_handle: PortHandle<Undeliverable<MessageEnvelope>>,
     ) {
-        if envelope.dest().actor_id().proc_id() == &self.state().proc_id {
+        if envelope.dest().actor_id().proc_id() == self.state().proc_id {
             self.state().proc_muxer.post(envelope, return_handle)
         } else {
             self.state().forwarder.post(envelope, return_handle)
@@ -1379,7 +1358,7 @@ impl<A: Actor> Drop for InstanceState<A> {
                 tracing::info!(
                     name = "ActorStatus",
                     actor_id = %self.self_id(),
-                    actor_name = self.self_id().name(),
+                    actor_name = self.self_id().log_name(),
                     status = "Stopped",
                     prev_status = status.arm().unwrap_or("unknown"),
                     "instance is dropped",
@@ -1528,7 +1507,7 @@ impl<A: Actor> Instance<A> {
             tracing::info!(
                 name = "ActorStatus",
                 actor_id = %self.self_id(),
-                actor_name = self.self_id().name(),
+                actor_name = self.self_id().log_name(),
                 status = new_status,
                 prev_status = old.arm().unwrap_or("unknown"),
                 caller = %Location::caller(),
@@ -1867,11 +1846,11 @@ impl<A: Actor> Instance<A> {
             }
             // TODO: we should get rid of this signal, and use *only* supervision events for
             // the purpose of conveying lifecycle changes
-            if let Err(err) = parent.signal(Signal::ChildStopped(self.inner.cell.pid())) {
+            if let Err(err) = parent.signal(Signal::ChildStopped(self.inner.cell.uid().clone())) {
                 tracing::error!(
-                    "{}: failed to send stop message to parent pid {}: {:?}",
+                    "{}: failed to send stop message to parent uid {}: {:?}",
                     self.self_id(),
-                    parent.pid(),
+                    parent.uid(),
                     err
                 );
             }
@@ -1953,8 +1932,8 @@ impl<A: Actor> Instance<A> {
         while self.inner.cell.child_count() > 0 {
             match tokio::time::timeout(Duration::from_millis(500), signal_receiver.recv()).await {
                 Ok(signal) => {
-                    if let Signal::ChildStopped(pid) = signal? {
-                        assert!(self.inner.cell.get_child(pid).is_none());
+                    if let Signal::ChildStopped(uid) = signal? {
+                        assert!(self.inner.cell.get_child(&uid).is_none());
                     }
                 }
                 Err(_) => {
@@ -2058,8 +2037,8 @@ impl<A: Actor> Instance<A> {
                             stop_reason = reason;
                             break 'messages;
                         },
-                        Signal::ChildStopped(pid) => {
-                            assert!(self.inner.cell.get_child(pid).is_none());
+                        Signal::ChildStopped(uid) => {
+                            assert!(self.inner.cell.get_child(&uid).is_none());
                         },
                         Signal::Abort(reason) => {
                             return Err(ActorError { actor_id: Box::new(self.self_id().clone()), kind: Box::new(ActorErrorKind::Aborted(reason)) });
@@ -2452,8 +2431,8 @@ struct InstanceCellState {
     /// A weak reference to this instance's parent.
     parent: WeakInstanceCell,
 
-    /// This instance's children by their PIDs.
-    children: DashMap<reference::Index, InstanceCell>,
+    /// This instance's children by their uids.
+    children: DashMap<crate::id::Uid, InstanceCell>,
 
     /// Access to the spawned actor's join handle.
     actor_task_handle: OnceLock<JoinHandle<()>>,
@@ -2536,7 +2515,7 @@ impl InstanceCellState {
     /// Unlink this instance from a child.
     fn unlink(&self, child: &InstanceCellState) -> bool {
         assert_eq!(self.actor_id.proc_id(), child.actor_id.proc_id());
-        self.children.remove(&child.actor_id.pid()).is_some()
+        self.children.remove(child.actor_id.uid()).is_some()
     }
 }
 
@@ -2642,9 +2621,9 @@ impl InstanceCell {
         &self.inner.actor_id
     }
 
-    /// The actor's PID.
-    pub(crate) fn pid(&self) -> reference::Index {
-        self.inner.actor_id.pid()
+    /// The actor's uid.
+    pub(crate) fn uid(&self) -> &crate::id::Uid {
+        self.inner.actor_id.uid()
     }
 
     /// The actor's join handle.
@@ -2750,13 +2729,13 @@ impl InstanceCell {
     /// Link this instance to a new child.
     fn link(&self, child: InstanceCell) {
         assert_eq!(self.actor_id().proc_id(), child.actor_id().proc_id());
-        self.inner.children.insert(child.pid(), child);
+        self.inner.children.insert(child.uid().clone(), child);
     }
 
     /// Unlink this instance from a child.
     fn unlink(&self, child: &InstanceCell) {
         assert_eq!(self.actor_id().proc_id(), child.actor_id().proc_id());
-        self.inner.children.remove(&child.pid());
+        self.inner.children.remove(child.uid());
     }
 
     /// Unlink this instance from all children.
@@ -2779,7 +2758,7 @@ impl InstanceCell {
 
     /// Return an iterator over this instance's children. This may deadlock if the
     /// caller already holds a reference to any item in map.
-    fn child_iter(&self) -> impl Iterator<Item = RefMulti<'_, reference::Index, InstanceCell>> {
+    fn child_iter(&self) -> impl Iterator<Item = RefMulti<'_, crate::id::Uid, InstanceCell>> {
         self.inner.children.iter()
     }
 
@@ -2797,9 +2776,9 @@ impl InstanceCell {
             .collect()
     }
 
-    /// Get a child by its PID.
-    fn get_child(&self, pid: reference::Index) -> Option<InstanceCell> {
-        self.inner.children.get(&pid).map(|child| child.clone())
+    /// Get a child by its uid.
+    fn get_child(&self, uid: &crate::id::Uid) -> Option<InstanceCell> {
+        self.inner.children.get(uid).map(|child| child.clone())
     }
 
     /// Access the flight recorder for this actor.
@@ -2981,9 +2960,9 @@ impl InstanceCell {
         F: FnMut(&InstanceCell, usize),
     {
         f(self, depth);
-        // Collect and sort children by pid for deterministic traversal order
+        // Collect and sort children by uid for deterministic traversal order
         let mut children: Vec<_> = self.child_iter().map(|r| r.value().clone()).collect();
-        children.sort_by_key(|c| c.pid());
+        children.sort_by_key(|c| c.uid().clone());
         for child in children {
             child.traverse_inner(depth + 1, f);
         }
@@ -3424,7 +3403,7 @@ mod tests {
             !lookup_actor
                 .actor_exists(
                     &client,
-                    reference::ActorRef::attest(target_actor.actor_id().child_id(123).clone())
+                    reference::ActorRef::attest(target_actor.actor_id().unique_child_id().clone())
                 )
                 .await
                 .unwrap()
@@ -3461,7 +3440,7 @@ mod tests {
             parent.actor_id()
         );
         assert_matches!(
-            parent.inner.children.get(&child.pid()),
+            parent.inner.children.get(child.uid()),
             Some(node) if node.actor_id() == child.actor_id()
         );
     }
@@ -3505,10 +3484,10 @@ mod tests {
             .as_str()
         ));
 
-        // These are allocated in sequence:
-        assert_eq!(first.actor_id().proc_id(), proc.proc_id());
-        assert_eq!(second.actor_id(), &first.actor_id().child_id(1));
-        assert_eq!(third.actor_id(), &first.actor_id().child_id(2));
+        // All actors are in the same proc:
+        assert_eq!(first.actor_id().proc_id(), proc.proc_id().clone());
+        assert_eq!(second.actor_id().proc_id(), proc.proc_id().clone());
+        assert_eq!(third.actor_id().proc_id(), proc.proc_id().clone());
 
         // Supervision tree is constructed correctly.
         validate_link(third.cell(), second.cell());
@@ -4432,8 +4411,8 @@ mod tests {
         let handle = proc
             .spawn_named_child(root.cell().clone(), "my_controller", TestActor)
             .unwrap();
-        assert_eq!(handle.actor_id().name(), "my_controller");
-        assert_eq!(handle.actor_id().pid(), 1);
+        assert_eq!(handle.actor_id().label().unwrap().as_str(), "my_controller");
+        assert!(!handle.actor_id().is_root());
     }
 
     /// Exercises AI-1 (see module doc).
@@ -4447,8 +4426,7 @@ mod tests {
         let second = proc
             .spawn_named_child(root.cell().clone(), "my_controller", TestActor)
             .unwrap();
-        assert_eq!(first.actor_id().pid(), 1);
-        assert_eq!(second.actor_id().pid(), 2);
+        assert_ne!(first.actor_id().uid(), second.actor_id().uid());
     }
 
     /// Exercises AI-1 (see module doc).
@@ -4471,7 +4449,7 @@ mod tests {
         let proc = Proc::local();
         let root = proc.spawn::<TestActor>("root", TestActor).unwrap();
         let child = proc.spawn_child(root.cell().clone(), TestActor).unwrap();
-        assert_eq!(child.actor_id().name(), root.actor_id().name());
+        assert!(!child.actor_id().is_root());
     }
 
     /// Exercises AI-1 (see module doc).
@@ -4485,9 +4463,9 @@ mod tests {
         let b = proc
             .spawn_named_child(root.cell().clone(), "controller_b", TestActor)
             .unwrap();
-        assert_ne!(a.actor_id().pid(), b.actor_id().pid());
-        assert_eq!(a.actor_id().name(), "controller_a");
-        assert_eq!(b.actor_id().name(), "controller_b");
+        assert_ne!(a.actor_id().uid(), b.actor_id().uid());
+        assert_eq!(a.actor_id().label().unwrap().as_str(), "controller_a");
+        assert_eq!(b.actor_id().label().unwrap().as_str(), "controller_b");
     }
 
     /// Exercises AI-1 (see module doc).

--- a/hyperactor/src/reference.rs
+++ b/hyperactor/src/reference.rs
@@ -130,38 +130,29 @@ impl Reference {
     }
 
     /// The proc id of the reference, if any.
-    pub fn proc_id(&self) -> Option<&ProcId> {
+    pub fn proc_id(&self) -> Option<ProcId> {
         match self {
-            Self::Proc(proc_id) => Some(proc_id),
+            Self::Proc(proc_id) => Some(proc_id.clone()),
             Self::Actor(actor_id) => Some(actor_id.proc_id()),
             Self::Port(port_id) => Some(port_id.actor_id().proc_id()),
         }
     }
 
     /// The actor id of the reference, if any.
-    pub fn actor_id(&self) -> Option<&ActorId> {
+    pub fn actor_id(&self) -> Option<ActorId> {
         match self {
             Self::Proc(_) => None,
-            Self::Actor(actor_id) => Some(actor_id),
+            Self::Actor(actor_id) => Some(actor_id.clone()),
             Self::Port(port_id) => Some(port_id.actor_id()),
         }
     }
 
-    /// The actor name of the reference, if any.
-    fn actor_name(&self) -> Option<&str> {
+    /// The actor uid of the reference, if any.
+    fn actor_uid(&self) -> Option<&Uid> {
         match self {
             Self::Proc(_) => None,
-            Self::Actor(actor_id) => Some(actor_id.name()),
-            Self::Port(port_id) => Some(port_id.actor_id().name()),
-        }
-    }
-
-    /// The pid of the reference, if any.
-    fn pid(&self) -> Option<Index> {
-        match self {
-            Self::Proc(_) => None,
-            Self::Actor(actor_id) => Some(actor_id.pid()),
-            Self::Port(port_id) => Some(port_id.actor_id().pid()),
+            Self::Actor(actor_id) => Some(actor_id.uid()),
+            Self::Port(port_id) => Some(port_id.0.id().actor_id().uid()),
         }
     }
 
@@ -192,11 +183,11 @@ impl PartialOrd for Reference {
 
 impl Ord for Reference {
     fn cmp(&self, other: &Self) -> Ordering {
-        // Order by: proc address/name, then actor_name, then pid, then port
-        (self.proc_id(), self.actor_name(), self.pid(), self.port()).cmp(&(
+        // Order by: proc id, then actor uid, then port.
+        // None < Some ensures Proc < Actor < Port for same proc.
+        (self.proc_id(), self.actor_uid(), self.port()).cmp(&(
             other.proc_id(),
-            other.actor_name(),
-            other.pid(),
+            other.actor_uid(),
             other.port(),
         ))
     }
@@ -262,26 +253,19 @@ impl FromStr for Reference {
 
                     // channeladdr,proc_name,actor_name
                     Token::Elem(proc_name) Token::Comma Token::Elem(actor_name) =>
-                    Self::Actor(ActorId::new(ProcId::from_resource_name(channel_addr, proc_name), actor_name, 0)),
+                    Self::Actor(ActorId::new(ProcId::from_resource_name(channel_addr, proc_name), actor_name)),
 
-                    // channeladdr,proc_name,actor_name[pid]
+                    // channeladdr,proc_name,actor_name[port]
                     Token::Elem(proc_name) Token::Comma Token::Elem(actor_name)
-                        Token::LeftBracket Token::Uint(pid) Token::RightBracket =>
-                        Self::Actor(ActorId::new(ProcId::from_resource_name(channel_addr, proc_name), actor_name, pid)),
+                        Token::LeftBracket Token::Uint(port) Token::RightBracket =>
+                        Self::Port(PortId::new(ActorId::new(ProcId::from_resource_name(channel_addr, proc_name), actor_name), port as u64)),
 
-                    // channeladdr,proc_name,actor_name[pid][port]
+                    // channeladdr,proc_name,actor_name[port<type>]
                     Token::Elem(proc_name) Token::Comma Token::Elem(actor_name)
-                        Token::LeftBracket Token::Uint(pid) Token::RightBracket
-                        Token::LeftBracket Token::Uint(index) Token::RightBracket  =>
-                        Self::Port(PortId::new(ActorId::new(ProcId::from_resource_name(channel_addr, proc_name), actor_name, pid), index as u64)),
-
-                    // channeladdr,proc_name,actor_name[pid][port<type>]
-                    Token::Elem(proc_name) Token::Comma Token::Elem(actor_name)
-                        Token::LeftBracket Token::Uint(pid) Token::RightBracket
-                        Token::LeftBracket Token::Uint(index)
+                        Token::LeftBracket Token::Uint(port)
                             Token::LessThan Token::Elem(_type) Token::GreaterThan
                         Token::RightBracket =>
-                        Self::Port(PortId::new(ActorId::new(ProcId::from_resource_name(channel_addr, proc_name), actor_name, pid), index as u64)),
+                        Self::Port(PortId::new(ActorId::new(ProcId::from_resource_name(channel_addr, proc_name), actor_name), port as u64)),
                 }?)
             }
 
@@ -323,7 +307,7 @@ fn parse_resource_name(s: &str) -> (Uid, Option<Label>) {
     // Singleton: _label
     if let Some(rest) = s.strip_prefix('_') {
         if let Ok(label) = Label::new(rest) {
-            return (Uid::Singleton(label), None);
+            return (Uid::Singleton(label.clone()), Some(label));
         }
     }
 
@@ -405,9 +389,9 @@ impl ProcId {
         Self(proc_ref)
     }
 
-    /// Create an actor ID with the provided name and pid within this proc.
-    pub fn actor_id(&self, name: impl Into<String>, pid: Index) -> ActorId {
-        ActorId(self.clone(), name.into(), pid)
+    /// Create an actor ID with the provided name within this proc.
+    pub fn actor_id(&self, name: impl AsRef<str>) -> ActorId {
+        ActorId::new(self.clone(), name)
     }
 
     /// The proc's channel address.
@@ -437,6 +421,26 @@ impl ProcId {
             Uid::Singleton(label) => Some(label),
             _ => None,
         })
+    }
+
+    /// A human-readable name for logging, derived from the label or uid.
+    pub fn log_name(&self) -> &str {
+        self.0.id().label().map(|l| l.as_str()).unwrap_or("?")
+    }
+
+    /// The ResourceId text form of this proc's identity.
+    ///
+    /// Produces `_label` (singleton), `label-hex16` (labeled instance),
+    /// or `hex16` (unlabeled instance). Suitable for filesystem paths
+    /// and string-based lookups that must round-trip through
+    /// `parse_resource_name`.
+    pub fn resource_name(&self) -> String {
+        let id = self.0.id();
+        match (id.uid(), id.label()) {
+            (Uid::Singleton(label), _) => format!("_{}", label),
+            (Uid::Instance(uid), Some(label)) => format!("{}-{:016x}", label, uid),
+            (Uid::Instance(uid), None) => format!("{:016x}", uid),
+        }
     }
 }
 
@@ -468,7 +472,8 @@ impl FromStr for ProcId {
     }
 }
 
-/// Actors are identified by their proc, their name, and pid.
+/// Actors are identified by a typed actor reference pairing an identity
+/// with a network location.
 #[derive(
     Debug,
     Serialize,
@@ -481,50 +486,104 @@ impl FromStr for ProcId {
     Ord,
     typeuri::Named
 )]
-pub struct ActorId(ProcId, String, Index);
+#[serde(transparent)]
+pub struct ActorId(ref_::ActorRef);
 
 hyperactor_config::impl_attrvalue!(ActorId);
 
 impl ActorId {
-    /// Create a new actor ID.
-    pub fn new(proc_id: ProcId, name: impl Into<String>, pid: Index) -> Self {
-        Self(proc_id, name.into(), pid)
+    /// Create a new actor ID from a proc and name string.
+    ///
+    /// Parses the name in ResourceId format to recover the uid deterministically.
+    /// Child actors with random uids are created via [`Self::unique_child_id`].
+    pub fn new(proc_id: ProcId, name: impl AsRef<str>) -> Self {
+        let s = name.as_ref();
+        let (uid, label) = parse_resource_name(s);
+        let actor_id = crate::id::ActorId::new(uid, proc_id.0.id().clone(), label);
+        Self(ref_::ActorRef::new(actor_id, proc_id.0.location().clone()))
     }
 
     /// Create a new port ID with the provided port for this actor.
     pub fn port_id(&self, port: u64) -> PortId {
-        PortId(self.clone(), port)
+        let port_id = crate::id::PortId::new(self.0.id().clone(), crate::port::Port::from(port));
+        PortId(ref_::PortRef::new(port_id, self.0.location().clone()))
     }
 
-    /// Create a child actor ID with the provided PID.
-    pub fn child_id(&self, pid: Index) -> Self {
-        Self(self.0.clone(), self.1.clone(), pid)
+    /// Create a child actor ID with a random uid.
+    pub fn unique_child_id(&self) -> Self {
+        let child = crate::id::ActorId::instance(self.0.id().proc_id().clone());
+        Self(ref_::ActorRef::new(child, self.0.location().clone()))
     }
 
-    /// Return the root actor ID for the provided proc and name.
-    pub fn root(proc_id: ProcId, name: String) -> Self {
-        Self(proc_id, name, 0)
+    /// Return the root actor ID for the provided proc and label.
+    pub fn root(proc_id: ProcId, label: Label) -> Self {
+        let actor_id = crate::id::ActorId::singleton(label, proc_id.0.id().clone());
+        Self(ref_::ActorRef::new(actor_id, proc_id.0.location().clone()))
+    }
+
+    /// Wrap an existing [`ref_::ActorRef`].
+    pub fn from_actor_ref(actor_ref: ref_::ActorRef) -> Self {
+        Self(actor_ref)
     }
 
     /// The proc ID of this actor ID.
-    pub fn proc_id(&self) -> &ProcId {
+    pub fn proc_id(&self) -> ProcId {
+        ProcId(ref_::ProcRef::new(
+            self.0.id().proc_id().clone(),
+            self.0.location().clone(),
+        ))
+    }
+
+    /// The underlying actor identity.
+    pub fn id(&self) -> &crate::id::ActorId {
+        self.0.id()
+    }
+
+    /// The underlying actor reference.
+    pub fn actor_ref(&self) -> &ref_::ActorRef {
         &self.0
     }
 
-    /// The actor's name.
-    pub fn name(&self) -> &str {
-        &self.1
+    /// The actor's uid.
+    pub fn uid(&self) -> &Uid {
+        self.0.id().uid()
     }
 
-    /// The actor's pid.
-    pub fn pid(&self) -> Index {
-        self.2
+    /// The actor's label.
+    pub fn label(&self) -> Option<&Label> {
+        self.0.id().label()
+    }
+
+    /// The actor's network address (same as proc's).
+    pub fn addr(&self) -> &ChannelAddr {
+        self.0.location().addr()
+    }
+
+    /// Whether this is a root (singleton) actor.
+    pub fn is_root(&self) -> bool {
+        matches!(self.0.id().uid(), Uid::Singleton(_))
+    }
+
+    /// A human-readable name for logging, derived from the label or uid.
+    pub fn log_name(&self) -> &str {
+        self.0.id().label().map(|l| l.as_str()).unwrap_or("?")
     }
 }
 
 impl fmt::Display for ActorId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{},{}[{}]", self.0, self.1, self.2)
+        // Compat format: "proc_display,actor_resource_name"
+        let id = self.0.id();
+        let proc_id = self.proc_id();
+        match (id.uid(), id.label()) {
+            (Uid::Singleton(label), _) => write!(f, "{},_{}", proc_id, label),
+            (Uid::Instance(uid), Some(label)) => {
+                write!(f, "{},{}-{:016x}", proc_id, label, uid)
+            }
+            (Uid::Instance(uid), None) => {
+                write!(f, "{},{:016x}", proc_id, uid)
+            }
+        }
     }
 }
 impl<A: Referable> From<ActorRef<A>> for ActorId {
@@ -704,9 +763,6 @@ impl<A: Referable> Hash for ActorRef<A> {
 }
 
 /// Port ids identify [`crate::mailbox::Port`]s of an actor.
-///
-/// TODO: consider moving [`crate::mailbox::Port`] to `PortRef` in this
-/// module for consistency with actors,
 #[derive(
     Debug,
     Serialize,
@@ -719,31 +775,37 @@ impl<A: Referable> Hash for ActorRef<A> {
     Ord,
     typeuri::Named
 )]
-pub struct PortId(ActorId, u64);
+#[serde(transparent)]
+pub struct PortId(ref_::PortRef);
 
 impl PortId {
     /// Create a new port ID.
     pub fn new(actor_id: ActorId, port: u64) -> Self {
-        Self(actor_id, port)
+        let port_id =
+            crate::id::PortId::new(actor_id.0.id().clone(), crate::port::Port::from(port));
+        Self(ref_::PortRef::new(port_id, actor_id.0.location().clone()))
     }
 
     /// The ID of the port's owning actor.
-    pub fn actor_id(&self) -> &ActorId {
-        &self.0
+    pub fn actor_id(&self) -> ActorId {
+        ActorId(ref_::ActorRef::new(
+            self.0.id().actor_id().clone(),
+            self.0.location().clone(),
+        ))
     }
 
     /// Convert this port ID into an actor ID.
     pub fn into_actor_id(self) -> ActorId {
-        self.0
+        self.actor_id()
     }
 
     /// This port's index.
     pub fn index(&self) -> u64 {
-        self.1
+        self.0.id().port().as_u64()
     }
 
     pub(crate) fn is_actor_port(&self) -> bool {
-        self.1 & ACTOR_PORT_BIT != 0
+        self.0.id().port().is_handler()
     }
 
     /// Send a serialized message to this port, provided a sending capability,
@@ -811,9 +873,10 @@ impl FromStr for PortId {
 
 impl fmt::Display for PortId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let PortId(actor_id, port) = self;
+        let actor_id = self.actor_id();
+        let port = self.index();
         if self.is_actor_port() {
-            let type_info = TypeInfo::get(*port).or_else(|| TypeInfo::get(*port & !ACTOR_PORT_BIT));
+            let type_info = TypeInfo::get(port).or_else(|| TypeInfo::get(port & !ACTOR_PORT_BIT));
             let typename = type_info.map_or("unknown", TypeInfo::typename);
             write!(f, "{}[{}<{}>]", actor_id, port, typename)
         } else {
@@ -1249,22 +1312,29 @@ mod tests {
                 ProcId::from_resource_name("tcp:[::1]:1234".parse::<ChannelAddr>().unwrap(), "test").into(),
             ),
             (
-                "tcp:[::1]:1234,test,testactor[123]",
+                "tcp:[::1]:1234,test,testactor",
                 ActorId::new(
                     ProcId::from_resource_name("tcp:[::1]:1234".parse::<ChannelAddr>().unwrap(), "test"),
                     "testactor",
-                    123,
                 )
                 .into(),
             ),
             (
-                // type annotations are ignored
-                "tcp:[::1]:1234,test,testactor[0][123<my::type>]",
+                // instance actor (label-hex16 format)
+                "tcp:[::1]:1234,test,myactor-00000000deadbeef",
+                ActorId::new(
+                    ProcId::with_name("tcp:[::1]:1234".parse::<ChannelAddr>().unwrap(), "test"),
+                    "myactor-00000000deadbeef",
+                )
+                .into(),
+            ),
+            (
+                // one bracket group = port (type annotations ignored)
+                "tcp:[::1]:1234,test,testactor[123<my::type>]",
                 PortId::new(
                     ActorId::new(
                         ProcId::from_resource_name("tcp:[::1]:1234".parse::<ChannelAddr>().unwrap(), "test"),
                         "testactor",
-                        0,
                     ),
                     123,
                 )
@@ -1314,13 +1384,19 @@ mod tests {
             ActorId::new(
                 ProcId::from_resource_name("tcp:[::1]:1234".parse::<ChannelAddr>().unwrap(), "test"),
                 "testactor",
-                1,
             ),
             MyType::port(),
         );
-        assert_eq!(
-            port_id.to_string(),
-            "tcp:[::1]:1234,_test,testactor[1][17867850292987402005<hyperactor::reference::tests::MyType>]"
+        let s = port_id.to_string();
+        assert!(
+            s.starts_with("tcp:[::1]:1234,_test,_testactor["),
+            "unexpected format: {}",
+            s
+        );
+        assert!(
+            s.contains("<hyperactor::reference::tests::MyType>"),
+            "missing type annotation: {}",
+            s
         );
     }
 

--- a/hyperactor/src/supervision.rs
+++ b/hyperactor/src/supervision.rs
@@ -193,7 +193,10 @@ impl fmt::Display for ActorSupervisionEvent {
                 write!(indented(f).with_str("  "), "{}", child)
             }
             ActorStatus::Stopped(_)
-                if self.actor_id.name() == "host_agent" || self.actor_id.name() == "proc_agent" =>
+                if self
+                    .actor_id
+                    .label()
+                    .is_some_and(|l| l.as_str() == "host_agent" || l.as_str() == "proc_agent") =>
             {
                 let addr = self.actor_id.proc_id().addr().to_string();
                 write!(
@@ -221,12 +224,7 @@ mod tests {
 
     fn test_event(name: &str, status: ActorStatus) -> ActorSupervisionEvent {
         let proc_id = reference::ProcId::from_resource_name(ChannelAddr::Local(0), "test_proc");
-        ActorSupervisionEvent::new(
-            proc_id.actor_id(name, 0),
-            Some(name.to_string()),
-            status,
-            None,
-        )
+        ActorSupervisionEvent::new(proc_id.actor_id(name), Some(name.to_string()), status, None)
     }
 
     fn test_event_with_addr(
@@ -235,7 +233,7 @@ mod tests {
         status: ActorStatus,
     ) -> ActorSupervisionEvent {
         let proc_id = reference::ProcId::from_resource_name(addr, "test_proc");
-        ActorSupervisionEvent::new(proc_id.actor_id(name, 0), None, status, None)
+        ActorSupervisionEvent::new(proc_id.actor_id(name), None, status, None)
     }
 
     fn generic(name: &str, msg: &str) -> ActorSupervisionEvent {
@@ -549,8 +547,8 @@ mod tests {
     #[test]
     fn test_sv1_actually_failing_actor_returns_stopped_child() {
         let proc_id = reference::ProcId::from_resource_name(ChannelAddr::Local(0), "test_proc");
-        let child_id = proc_id.actor_id("proc_agent", 0);
-        let parent_id = proc_id.actor_id("controller", 0);
+        let child_id = proc_id.actor_id("proc_agent");
+        let parent_id = proc_id.actor_id("controller");
 
         let child_event = ActorSupervisionEvent::new(
             child_id.clone(),

--- a/hyperactor/src/testing/ids.rs
+++ b/hyperactor/src/testing/ids.rs
@@ -28,27 +28,12 @@ pub fn test_proc_id_with_addr(addr: ChannelAddr, name: &str) -> reference::ProcI
     reference::ProcId::from_resource_name(addr, format!("test_{name}"))
 }
 
-/// Create a test `ActorId` with pid 0.
+/// Create a test `ActorId`.
 pub fn test_actor_id(proc_name: &str, actor_name: &str) -> reference::ActorId {
-    test_proc_id(proc_name).actor_id(actor_name, 0)
+    test_proc_id(proc_name).actor_id(actor_name)
 }
 
-/// Create a test `ActorId` with a custom pid.
-pub fn test_actor_id_with_pid(proc_name: &str, actor_name: &str, pid: usize) -> reference::ActorId {
-    test_proc_id(proc_name).actor_id(actor_name, pid)
-}
-
-/// Create a test `PortId` with pid 0.
+/// Create a test `PortId`.
 pub fn test_port_id(proc_name: &str, actor_name: &str, port: u64) -> reference::PortId {
     reference::PortId::new(test_actor_id(proc_name, actor_name), port)
-}
-
-/// Create a test `PortId` with a custom pid.
-pub fn test_port_id_with_pid(
-    proc_name: &str,
-    actor_name: &str,
-    pid: usize,
-    port: u64,
-) -> reference::PortId {
-    reference::PortId::new(test_actor_id_with_pid(proc_name, actor_name, pid), port)
 }

--- a/hyperactor_mesh/src/actor_mesh.rs
+++ b/hyperactor_mesh/src/actor_mesh.rs
@@ -1123,7 +1123,10 @@ mod tests {
             .expect("no supervision event found on ref from wrapper actor");
         let check_failure = move |failure: MeshFailure| {
             assert_eq!(failure.actor_mesh_name, Some(child_name.to_string()));
-            assert_eq!(failure.event.actor_id.name(), child_name.actor_name());
+            assert_eq!(
+                failure.event.actor_id.label().unwrap().as_str(),
+                child_name.label().unwrap().as_str()
+            );
             if let ActorStatus::Failed(ActorErrorKind::Generic(msg)) = &failure.event.actor_status {
                 assert!(msg.contains("panic"), "{}", msg);
                 assert!(msg.contains("for testing"), "{}", msg);
@@ -1216,7 +1219,10 @@ mod tests {
 
         let check_failure = move |failure: MeshFailure| {
             assert_eq!(failure.actor_mesh_name, Some(child_name.to_string()));
-            assert_eq!(failure.event.actor_id.name(), child_name.actor_name());
+            assert_eq!(
+                failure.event.actor_id.label().unwrap().as_str(),
+                child_name.label().unwrap().as_str()
+            );
             if let ActorStatus::Failed(ActorErrorKind::Generic(msg)) = &failure.event.actor_status {
                 assert!(msg.contains("exited with non-zero code 1"), "{}", msg);
             } else {
@@ -1289,7 +1295,10 @@ mod tests {
                     .expect("timeout")
                     .unwrap();
             let event = supervision_message.event;
-            assert_eq!(event.actor_id.name(), child_name.actor_name());
+            assert_eq!(
+                event.actor_id.label().unwrap().as_str(),
+                child_name.label().unwrap().as_str()
+            );
             if let ActorStatus::Failed(ActorErrorKind::Generic(msg)) = &event.actor_status {
                 assert!(msg.contains("panic"));
                 assert!(msg.contains("for testing"));

--- a/hyperactor_mesh/src/alloc/remoteprocess.rs
+++ b/hyperactor_mesh/src/alloc/remoteprocess.rs
@@ -1432,9 +1432,8 @@ mod test {
             .enumerate()
         {
             let proc_id = test_proc_id(&format!("{i}"));
-            let mesh_agent = hyperactor_reference::ActorRef::<ProcAgent>::attest(
-                proc_id.actor_id("mesh_agent", i),
-            );
+            let mesh_agent =
+                hyperactor_reference::ActorRef::<ProcAgent>::attest(proc_id.actor_id("mesh_agent"));
             alloc.expect_next().times(1).return_once(move || {
                 Some(ProcState::Running {
                     create_key,
@@ -1561,7 +1560,7 @@ mod test {
                     assert_eq!(create_key, create_keys[rank]);
                     let expected_proc_id = test_proc_id(&format!("{}", rank));
                     let expected_mesh_agent = hyperactor_reference::ActorRef::<ProcAgent>::attest(
-                        expected_proc_id.actor_id("mesh_agent", rank),
+                        expected_proc_id.actor_id("mesh_agent"),
                     );
                     assert_eq!(proc_id, expected_proc_id);
                     assert_eq!(mesh_agent, expected_mesh_agent);

--- a/hyperactor_mesh/src/bootstrap.rs
+++ b/hyperactor_mesh/src/bootstrap.rs
@@ -567,7 +567,7 @@ impl Bootstrap {
                 // TODO provide a direct way to construct these
                 let serve_addr = format!(
                     "unix:{}",
-                    socket_dir_path.join(proc_id.id().to_string()).display()
+                    socket_dir_path.join(proc_id.resource_name()).display()
                 );
                 let serve_addr = serve_addr.parse().unwrap();
 
@@ -2941,7 +2941,7 @@ mod tests {
             // Build a consistent AgentRef for Ready using the
             // handle's ProcId.
             let proc_id = <BootstrapProcHandle as ProcHandle>::proc_id(&h);
-            let actor_id = proc_id.actor_id(crate::proc_agent::PROC_AGENT_ACTOR_NAME, 0);
+            let actor_id = proc_id.actor_id(crate::proc_agent::PROC_AGENT_ACTOR_NAME);
             let agent_ref: hyperactor_reference::ActorRef<ProcAgent> =
                 hyperactor_reference::ActorRef::attest(actor_id);
             // Ready -> Stopping -> Stopped should be legal.
@@ -2960,7 +2960,7 @@ mod tests {
             // Build a consistent AgentRef for Ready using the
             // handle's ProcId.
             let proc_id = <BootstrapProcHandle as ProcHandle>::proc_id(&h);
-            let actor_id = proc_id.actor_id(crate::proc_agent::PROC_AGENT_ACTOR_NAME, 0);
+            let actor_id = proc_id.actor_id(crate::proc_agent::PROC_AGENT_ACTOR_NAME);
             let agent: hyperactor_reference::ActorRef<ProcAgent> =
                 hyperactor_reference::ActorRef::attest(actor_id);
             // Running -> Ready
@@ -3093,7 +3093,7 @@ mod tests {
         let started_at = std::time::SystemTime::now();
         assert!(handle.mark_running(started_at));
 
-        let actor_id = proc_id.actor_id(crate::proc_agent::PROC_AGENT_ACTOR_NAME, 0);
+        let actor_id = proc_id.actor_id(crate::proc_agent::PROC_AGENT_ACTOR_NAME);
         let agent_ref: hyperactor_reference::ActorRef<ProcAgent> =
             hyperactor_reference::ActorRef::attest(actor_id);
 
@@ -3139,7 +3139,7 @@ mod tests {
         let addr = ChannelAddr::any(ChannelTransport::Unix);
         let agent = hyperactor_reference::ActorRef::attest(
             test_proc_id_with_addr(addr.clone(), "proc")
-                .actor_id(crate::proc_agent::PROC_AGENT_ACTOR_NAME, 0),
+                .actor_id(crate::proc_agent::PROC_AGENT_ACTOR_NAME),
         );
 
         let st = ProcStatus::Ready {
@@ -3176,7 +3176,7 @@ mod tests {
                 addr: ChannelAddr::any(ChannelTransport::Unix),
                 agent: hyperactor_reference::ActorRef::attest(
                     test_proc_id_with_addr(ChannelAddr::any(ChannelTransport::Unix), "x")
-                        .actor_id(crate::proc_agent::PROC_AGENT_ACTOR_NAME, 0),
+                        .actor_id(crate::proc_agent::PROC_AGENT_ACTOR_NAME),
                 ),
             },
             ProcStatus::Killed {
@@ -3207,7 +3207,7 @@ mod tests {
         let addr = ChannelAddr::any(ChannelTransport::Unix);
         let agent: hyperactor_reference::ActorRef<ProcAgent> =
             hyperactor_reference::ActorRef::attest(
-                proc_id.actor_id(crate::proc_agent::PROC_AGENT_ACTOR_NAME, 0),
+                proc_id.actor_id(crate::proc_agent::PROC_AGENT_ACTOR_NAME),
             );
         assert!(handle.mark_ready(addr, agent));
 

--- a/hyperactor_mesh/src/bootstrap/mailbox.rs
+++ b/hyperactor_mesh/src/bootstrap/mailbox.rs
@@ -66,7 +66,7 @@ impl MailboxSender for LocalProcDialer {
             // reachable through the backend address.
             && matches!(proc_id.uid(), Uid::Instance(_))
         {
-            let key = proc_id.id().to_string();
+            let key = proc_id.resource_name();
             let senders = self.local_senders.read().unwrap();
             let senders = if senders.contains_key(&key) {
                 senders
@@ -154,13 +154,13 @@ mod tests {
         let local_addr: ChannelAddr = "tcp:3.4.5.6:123".parse().unwrap();
         let first_actor_id =
             hyperactor_reference::ProcId::from_resource_name(local_addr.clone(), first.to_string())
-                .actor_id("actor", 0);
+                .actor_id("actor");
         let second_actor_id =
             hyperactor_reference::ProcId::from_resource_name(local_addr.clone(), second.to_string())
-                .actor_id("actor", 0);
+                .actor_id("actor");
         let third_notexist_actor_id =
             hyperactor_reference::ProcId::from_resource_name(local_addr.clone(), third.to_string())
-                .actor_id("actor", 0);
+                .actor_id("actor");
         let proc_dialer = LocalProcDialer::new(
             local_addr.clone(),
             dir.path().to_owned(),
@@ -208,8 +208,8 @@ mod tests {
         assert_eq!(backend_rx.recv().await.unwrap().sender(), &second_actor_id);
 
         // System proc on the host (name must be exactly "system"):
-        let system_actor_id = hyperactor_reference::ProcId::from_resource_name(local_addr.clone(), "system")
-            .actor_id("actor", 0);
+        let system_actor_id =
+            hyperactor_reference::ProcId::from_resource_name(local_addr.clone(), "system").actor_id("actor");
         let envelope = MessageEnvelope::new(
             second_actor_id.clone(),
             hyperactor_reference::PortId::new(system_actor_id, 0),

--- a/hyperactor_mesh/src/comm.rs
+++ b/hyperactor_mesh/src/comm.rs
@@ -336,7 +336,7 @@ impl CommActor {
         cx.post_with_external_seq_info(
             cx.self_id()
                 .proc_id()
-                .actor_id(message.dest_port().actor_name(), 0)
+                .actor_id(message.dest_port().actor_name())
                 .port_id(message.dest_port().port()),
             headers,
             wirevalue::Any::serialize(message.data())?,
@@ -954,7 +954,7 @@ mod tests {
     ) -> usize {
         let proc_id = actor_id.proc_id();
         *rank_lookup
-            .get(proc_id)
+            .get(&proc_id)
             .unwrap_or_else(|| panic!("proc rank not found for {}", proc_id))
     }
 
@@ -1124,15 +1124,15 @@ mod tests {
                 assert_eq!(&first, client_reply);
                 // Other ports's actor ID must be dest[?].comm[0], where ? is
                 // the rank we want to extract here.
-                assert!(dst.actor_id().name().contains("comm"));
+                assert!(dst.actor_id().label().unwrap().as_str().contains("comm"));
                 let actor_path = path
                     .into_iter()
                     .map(|p| {
-                        assert!(p.actor_id().name().contains("comm"));
-                        lookup_rank(p.actor_id(), rank_lookup)
+                        assert!(p.actor_id().label().unwrap().as_str().contains("comm"));
+                        lookup_rank(&p.actor_id(), rank_lookup)
                     })
                     .collect();
-                (lookup_rank(dst.actor_id(), rank_lookup), actor_path)
+                (lookup_rank(&dst.actor_id(), rank_lookup), actor_path)
             })
             .collect();
         PathToLeaves(ranks)
@@ -1391,9 +1391,25 @@ mod tests {
                     assert_eq!(reply_to0, reply_port_ref0);
                     // ports have been replaced by comm actor's split ports.
                     assert_ne!(reply_to1, reply_port_ref1);
-                    assert!(reply_to1.port_id().actor_id().name().contains("comm"));
+                    assert!(
+                        reply_to1
+                            .port_id()
+                            .actor_id()
+                            .label()
+                            .unwrap()
+                            .as_str()
+                            .contains("comm")
+                    );
                     assert_ne!(reply_to2, reply_port_ref2);
-                    assert!(reply_to2.port_id().actor_id().name().contains("comm"));
+                    assert!(
+                        reply_to2
+                            .port_id()
+                            .actor_id()
+                            .label()
+                            .unwrap()
+                            .as_str()
+                            .contains("comm")
+                    );
                     reply_tos.push((reply_to1, reply_to2));
                 }
                 _ => {
@@ -1561,7 +1577,15 @@ mod tests {
                     if has_reducer {
                         // With reducer: port is split by comm actor.
                         assert_ne!(reply_to, reply_port_ref);
-                        assert!(reply_to.port_id().actor_id().name().contains("comm"));
+                        assert!(
+                            reply_to
+                                .port_id()
+                                .actor_id()
+                                .label()
+                                .unwrap()
+                                .as_str()
+                                .contains("comm")
+                        );
                     } else {
                         // Without reducer: port is passed through unchanged.
                         assert_eq!(reply_to, reply_port_ref);

--- a/hyperactor_mesh/src/host_mesh.rs
+++ b/hyperactor_mesh/src/host_mesh.rs
@@ -120,7 +120,7 @@ impl HostRef {
     fn mesh_agent(&self) -> hyperactor_reference::ActorRef<HostAgent> {
         hyperactor_reference::ActorRef::attest(
             self.service_proc()
-                .actor_id(host_agent::HOST_MESH_AGENT_ACTOR_NAME, 0),
+                .actor_id(host_agent::HOST_MESH_AGENT_ACTOR_NAME),
         )
     }
 
@@ -1373,7 +1373,7 @@ impl HostMeshRef {
                     // TODO: specify or retrieve from state instead, to avoid attestation.
                     hyperactor_reference::ActorRef::attest(
                         host.named_proc(&proc_name)
-                            .actor_id(crate::proc_agent::PROC_AGENT_ACTOR_NAME, 0),
+                            .actor_id(crate::proc_agent::PROC_AGENT_ACTOR_NAME),
                     ),
                 ));
             }

--- a/hyperactor_mesh/src/host_mesh/host_agent.rs
+++ b/hyperactor_mesh/src/host_mesh/host_agent.rs
@@ -1525,7 +1525,7 @@ mod tests {
                 ..
             } if id == resource_id
               && proc_id == hyperactor_reference::ProcId::from_resource_name(host_addr.clone(), id.to_string())
-              && mesh_agent == hyperactor_reference::ActorRef::attest(hyperactor_reference::ProcId::from_resource_name(host_addr.clone(), id.to_string()).actor_id(crate::proc_agent::PROC_AGENT_ACTOR_NAME, 0)) && bootstrap_command == Some(BootstrapCommand::test())
+              && mesh_agent == hyperactor_reference::ActorRef::attest(hyperactor_reference::ProcId::from_resource_name(host_addr.clone(), id.to_string()).actor_id(crate::proc_agent::PROC_AGENT_ACTOR_NAME)) && bootstrap_command == Some(BootstrapCommand::test())
               && mesh_agent == proc_status_mesh_agent
         );
     }
@@ -1914,7 +1914,7 @@ mod tests {
         // proc. Query the service proc's introspection.
         let agent_id = system_proc
             .proc_id()
-            .actor_id(HOST_MESH_AGENT_ACTOR_NAME, 0);
+            .actor_id(HOST_MESH_AGENT_ACTOR_NAME);
         let port =
             hyperactor_reference::PortRef::<IntrospectMessage>::attest_message_port(&agent_id);
 

--- a/hyperactor_mesh/src/introspect.rs
+++ b/hyperactor_mesh/src/introspect.rs
@@ -1253,12 +1253,10 @@ mod tests {
         );
     }
 
-    fn test_actor_ref(proc_name: &str, actor_name: &str, pid: usize) -> NodeRef {
+    fn test_actor_ref(proc_name: &str, actor_name: &str) -> NodeRef {
         use hyperactor::channel::ChannelAddr;
         use hyperactor::reference::ProcId;
-        NodeRef::Actor(
-            ProcId::from_resource_name(ChannelAddr::Local(0), proc_name).actor_id(actor_name, pid),
-        )
+        NodeRef::Actor(ProcId::from_resource_name(ChannelAddr::Local(0), proc_name).actor_id(actor_name))
     }
 
     fn root_view() -> RootAttrsView {
@@ -1266,7 +1264,7 @@ mod tests {
             num_hosts: 3,
             started_at: std::time::UNIX_EPOCH,
             started_by: "testuser".into(),
-            system_children: vec![test_actor_ref("proc", "child1", 0)],
+            system_children: vec![test_actor_ref("proc", "child1")],
         }
     }
 
@@ -1274,7 +1272,7 @@ mod tests {
         HostAttrsView {
             addr: "10.0.0.1:8080".into(),
             num_procs: 2,
-            system_children: vec![test_actor_ref("proc", "sys", 0)],
+            system_children: vec![test_actor_ref("proc", "sys")],
             memory: Default::default(),
         }
     }
@@ -1284,7 +1282,7 @@ mod tests {
             proc_name: "worker".into(),
             num_actors: 5,
             system_children: vec![],
-            stopped_children: vec![test_actor_ref("proc", "old", 0)],
+            stopped_children: vec![test_actor_ref("proc", "old")],
             stopped_retention_cap: 10,
             is_poisoned: false,
             failed_actor_count: 0,
@@ -1658,7 +1656,7 @@ mod tests {
 
         let epoch = std::time::UNIX_EPOCH;
         let proc_id = ProcId::from_resource_name(ChannelAddr::Local(0), "worker");
-        let actor_id = proc_id.actor_id("actor", 0);
+        let actor_id = proc_id.actor_id("actor");
 
         let samples = [
             NodePayload {
@@ -1678,7 +1676,7 @@ mod tests {
                 properties: NodeProperties::Host {
                     addr: "10.0.0.1:8080".into(),
                     num_procs: 2,
-                    system_children: vec![test_actor_ref("proc", "sys", 0)],
+                    system_children: vec![test_actor_ref("proc", "sys")],
                     memory: Default::default(),
                 },
                 children: vec![NodeRef::Proc(proc_id.clone())],

--- a/hyperactor_mesh/src/introspect/dto.rs
+++ b/hyperactor_mesh/src/introspect/dto.rs
@@ -470,11 +470,11 @@ mod tests {
     }
 
     fn test_actor_id() -> hyperactor::reference::ActorId {
-        test_proc_id().actor_id("actor", 0)
+        test_proc_id().actor_id("actor")
     }
 
     fn test_host_actor_id() -> hyperactor::reference::ActorId {
-        test_proc_id().actor_id("host_agent", 0)
+        test_proc_id().actor_id("host_agent")
     }
 
     fn test_time() -> SystemTime {

--- a/hyperactor_mesh/src/mesh_admin.rs
+++ b/hyperactor_mesh/src/mesh_admin.rs
@@ -1195,13 +1195,13 @@ impl MeshAdminAgent {
         proc_id: &hyperactor_reference::ProcId,
     ) -> Option<&hyperactor_reference::ActorId> {
         self.standalone_proc_actors()
-            .find(|actor_id| *actor_id.proc_id() == *proc_id)
+            .find(|actor_id| actor_id.proc_id() == *proc_id)
     }
 
     /// Returns true if `actor_id` lives on a standalone proc.
     fn is_standalone_proc_actor(&self, actor_id: &hyperactor_reference::ActorId) -> bool {
         self.standalone_proc_actors()
-            .any(|a| *a.proc_id() == *actor_id.proc_id())
+            .any(|a| a.proc_id() == actor_id.proc_id())
     }
 
     /// Construct the synthetic root node for the reference tree.
@@ -1309,7 +1309,7 @@ impl MeshAdminAgent {
         }
 
         // Fall back to querying the ProcAgent directly (user procs).
-        let mesh_agent_id = proc_id.actor_id(PROC_AGENT_ACTOR_NAME, 0);
+        let mesh_agent_id = proc_id.actor_id(PROC_AGENT_ACTOR_NAME);
         let result = query_child_introspect(
             cx,
             &mesh_agent_id,
@@ -1473,7 +1473,7 @@ impl MeshAdminAgent {
         } else {
             // Check terminated snapshots first — fast, no ambiguity.
             let proc_id = actor_id.proc_id();
-            let mesh_agent_id = proc_id.actor_id(PROC_AGENT_ACTOR_NAME, 0);
+            let mesh_agent_id = proc_id.actor_id(PROC_AGENT_ACTOR_NAME);
             let terminated = query_child_introspect(
                 cx,
                 &mesh_agent_id,
@@ -2264,12 +2264,12 @@ fn route_proc_handler(raw_proc_reference: &str) -> Result<ResolvedProcHandler, A
         .label()
         .is_some_and(|l| l.as_str() == SERVICE_PROC_NAME);
     if is_service {
-        let agent_id = proc_id.actor_id(HOST_MESH_AGENT_ACTOR_NAME, 0);
+        let agent_id = proc_id.actor_id(HOST_MESH_AGENT_ACTOR_NAME);
         Ok(ResolvedProcHandler::Host(
             hyperactor_reference::ActorRef::attest(agent_id),
         ))
     } else {
-        let agent_id = proc_id.actor_id(PROC_AGENT_ACTOR_NAME, 0);
+        let agent_id = proc_id.actor_id(PROC_AGENT_ACTOR_NAME);
         Ok(ResolvedProcHandler::Proc(
             hyperactor_reference::ActorRef::attest(agent_id),
         ))
@@ -2867,7 +2867,7 @@ fn derive_tree_label(node_ref: &crate::introspect::NodeRef) -> String {
         crate::introspect::NodeRef::Host(id) => id.proc_id().id().to_string(),
         crate::introspect::NodeRef::Proc(id) => id.id().to_string(),
         crate::introspect::NodeRef::Actor(id) => {
-            format!("{}{}", id.name(), format_args!("[{}]", id.pid()))
+            format!("{}[{}]", id.log_name(), id.uid())
         }
     }
 }
@@ -2875,10 +2875,10 @@ fn derive_tree_label(node_ref: &crate::introspect::NodeRef) -> String {
 fn derive_actor_label(node_ref: &crate::introspect::NodeRef) -> String {
     match node_ref {
         crate::introspect::NodeRef::Root => "root".to_string(),
-        crate::introspect::NodeRef::Host(id) => id.name().to_string(),
+        crate::introspect::NodeRef::Host(id) => id.log_name().to_string(),
         crate::introspect::NodeRef::Proc(id) => id.id().to_string(),
         crate::introspect::NodeRef::Actor(id) => {
-            format!("{}[{}]", id.name(), id.pid())
+            format!("{}[{}]", id.log_name(), id.uid())
         }
     }
 }
@@ -3206,6 +3206,7 @@ mod tests {
     use std::net::SocketAddr;
 
     use hyperactor::channel::ChannelAddr;
+    use hyperactor::id::Label;
     use hyperactor::testing::ids::test_proc_id_with_addr;
 
     use super::*;
@@ -3237,8 +3238,8 @@ mod tests {
         let proc1 = test_proc_id_with_addr(ChannelAddr::Tcp(addr1), "host1");
         let proc2 = test_proc_id_with_addr(ChannelAddr::Tcp(addr2), "host2");
 
-        let actor_id1 = proc1.actor_id("mesh_agent", 0);
-        let actor_id2 = proc2.actor_id("mesh_agent", 0);
+        let actor_id1 = proc1.actor_id("mesh_agent");
+        let actor_id2 = proc2.actor_id("mesh_agent");
 
         let ref1: hyperactor_reference::ActorRef<HostAgent> =
             hyperactor_reference::ActorRef::attest(actor_id1.clone());
@@ -3584,13 +3585,14 @@ mod tests {
     fn test_build_root_payload_with_root_client() {
         let addr1: SocketAddr = "127.0.0.1:9001".parse().unwrap();
         let proc1 = hyperactor_reference::ProcId::from_resource_name(ChannelAddr::Tcp(addr1), "host1");
-        let actor_id1 = hyperactor_reference::ActorId::root(proc1, "mesh_agent".to_string());
+        let actor_id1 =
+            hyperactor_reference::ActorId::root(proc1, Label::new("mesh_agent").unwrap());
         let ref1: hyperactor_reference::ActorRef<HostAgent> =
             hyperactor_reference::ActorRef::attest(actor_id1.clone());
 
         let client_proc_id =
             hyperactor_reference::ProcId::from_resource_name(ChannelAddr::Tcp(addr1), "local");
-        let client_actor_id = client_proc_id.actor_id("client", 0);
+        let client_actor_id = client_proc_id.actor_id("client");
 
         let agent = MeshAdminAgent::new(
             vec![("host_a".to_string(), ref1)],

--- a/hyperactor_mesh/src/proc_agent.rs
+++ b/hyperactor_mesh/src/proc_agent.rs
@@ -506,7 +506,7 @@ impl ProcAgent {
         tracing::info!(
             name = "StopActor",
             %actor_id,
-            actor_name = actor_id.name(),
+            actor_name = actor_id.log_name(),
             %reason,
         );
         self.proc.stop_actor(actor_id, reason.to_string());
@@ -1755,7 +1755,7 @@ mod tests {
         let client_proc = Proc::direct(ChannelTransport::Unix.any(), "client".to_string()).unwrap();
         let (client, _client_handle) = client_proc.instance("client").unwrap();
 
-        let agent_id = proc.proc_id().actor_id(PROC_AGENT_ACTOR_NAME, 0);
+        let agent_id = proc.proc_id().actor_id(PROC_AGENT_ACTOR_NAME);
         let port =
             hyperactor_reference::PortRef::<IntrospectMessage>::attest_message_port(&agent_id);
 
@@ -1863,7 +1863,7 @@ mod tests {
         let client_proc = Proc::direct(ChannelTransport::Unix.any(), "client".to_string()).unwrap();
         let (client, _client_handle) = client_proc.instance("client").unwrap();
 
-        let agent_id = proc.proc_id().actor_id(PROC_AGENT_ACTOR_NAME, 0);
+        let agent_id = proc.proc_id().actor_id(PROC_AGENT_ACTOR_NAME);
         let port =
             hyperactor_reference::PortRef::<IntrospectMessage>::attest_message_port(&agent_id);
 
@@ -2187,7 +2187,7 @@ mod tests {
 
         // QueryChild(Proc) — same aggregation logic as mesh-admin
         // resolution.
-        let agent_id = proc.proc_id().actor_id(PROC_AGENT_ACTOR_NAME, 0);
+        let agent_id = proc.proc_id().actor_id(PROC_AGENT_ACTOR_NAME);
         let port =
             hyperactor_reference::PortRef::<IntrospectMessage>::attest_message_port(&agent_id);
 

--- a/hyperactor_mesh/src/proc_mesh.rs
+++ b/hyperactor_mesh/src/proc_mesh.rs
@@ -151,7 +151,7 @@ impl ProcRef {
         &self,
         id: &crate::mesh_id::ActorMeshId,
     ) -> hyperactor_reference::ActorId {
-        self.proc_id.actor_id(&id.actor_name(), 0)
+        self.proc_id.actor_id(&id.actor_name())
     }
 
     /// Generic bound: `A: Referable` - required because we return
@@ -794,8 +794,16 @@ impl ProcMeshRef {
     }
 
     pub(crate) fn agent_mesh(&self) -> ActorMeshRef<ProcAgent> {
-        let agent_name = self.ranks.first().unwrap().agent.actor_id().name();
-        let id = crate::mesh_id::ActorMeshId::singleton(Label::strip(agent_name));
+        let agent_label = self
+            .ranks
+            .first()
+            .unwrap()
+            .agent
+            .actor_id()
+            .label()
+            .unwrap()
+            .clone();
+        let id = crate::mesh_id::ActorMeshId::singleton(agent_label);
         ActorMeshRef::new(id, self.clone(), None)
     }
 

--- a/hyperactor_mesh/test/mesh_admin_integration/harness.rs
+++ b/hyperactor_mesh/test/mesh_admin_integration/harness.rs
@@ -235,7 +235,9 @@ impl WorkloadFixture {
 
                     let has_actor = |name: &str| {
                         proc_node.children.iter().any(|r| match r {
-                            hyperactor_mesh::introspect::NodeRef::Actor(id) => id.name() == name,
+                            hyperactor_mesh::introspect::NodeRef::Actor(id) => {
+                                id.label().map(|l| l.as_str()) == Some(name)
+                            }
                             _ => false,
                         })
                     };

--- a/hyperactor_mesh/test/mesh_admin_integration/pyspy.rs
+++ b/hyperactor_mesh/test/mesh_admin_integration/pyspy.rs
@@ -218,9 +218,10 @@ async fn discover_pyspy_workers(fixture: &WorkloadFixture, expected: usize) -> R
                     };
 
                 let has_pyspy_worker = proc_node.children.iter().any(|actor_ref| match actor_ref {
-                    hyperactor_mesh::introspect::NodeRef::Actor(id) => {
-                        id.name().starts_with("pyspy_worker")
-                    }
+                    hyperactor_mesh::introspect::NodeRef::Actor(id) => id
+                        .label()
+                        .map(|l| l.as_str().starts_with("pyspy_worker"))
+                        .unwrap_or(false),
                     _ => false,
                 });
                 if has_pyspy_worker {

--- a/hyperactor_mesh/test/mesh_admin_integration/ref_check.rs
+++ b/hyperactor_mesh/test/mesh_admin_integration/ref_check.rs
@@ -24,7 +24,7 @@ use crate::harness::WorkloadFixture;
 /// Panics if the ref is not an actor — callers only pass actor children.
 fn actor_base_name(r: &NodeRef) -> &str {
     match r {
-        NodeRef::Actor(id) => id.name(),
+        NodeRef::Actor(id) => id.label().map(|l| l.as_str()).unwrap_or("?"),
         other => panic!("expected actor ref, got {other:?}"),
     }
 }

--- a/hyperactor_mesh/test/mesh_admin_integration/tree.rs
+++ b/hyperactor_mesh/test/mesh_admin_integration/tree.rs
@@ -14,11 +14,67 @@
 //!
 //! See MIT-9, MIT-13, MIT-14 in `main` module doc.
 
+use std::time::Duration;
+
 use hyperactor_mesh::introspect::NodePayload;
 use hyperactor_mesh::introspect::NodeProperties;
 use hyperactor_mesh::introspect::NodeRef;
 
 use crate::dining::DiningScenario;
+
+const TREE_READY_ATTEMPTS: usize = 30;
+const TREE_READY_SLEEP: Duration = Duration::from_secs(2);
+const TOPOLOGY_READY_ATTEMPTS: usize = 45;
+const TOPOLOGY_READY_SLEEP: Duration = Duration::from_secs(2);
+
+fn actor_name(r: &NodeRef) -> &str {
+    match r {
+        NodeRef::Actor(id) => id.label().map(|l| l.as_str()).unwrap_or("?"),
+        other => panic!("expected actor ref, got {other:?}"),
+    }
+}
+
+fn enc(r: &NodeRef) -> String {
+    urlencoding::encode(&r.to_string()).into_owned()
+}
+
+async fn topology_has_dining_actors(s: &DiningScenario) -> bool {
+    let root: NodePayload = match s.fixture.get_node_payload("/v1/root").await {
+        Ok(root) => root,
+        Err(_) => return false,
+    };
+
+    for host_ref in &root.children {
+        let host: NodePayload = match s
+            .fixture
+            .get_node_payload(&format!("/v1/{}", enc(host_ref)))
+            .await
+        {
+            Ok(host) => host,
+            Err(_) => continue,
+        };
+
+        for proc_ref in &host.children {
+            let proc_node: NodePayload = match s
+                .fixture
+                .get_node_payload(&format!("/v1/{}", enc(proc_ref)))
+                .await
+            {
+                Ok(proc) => proc,
+                Err(_) => continue,
+            };
+
+            if proc_node.children.iter().any(|actor_ref| {
+                let name = actor_name(actor_ref);
+                name.starts_with("philosopher") || name.starts_with("waiter")
+            }) {
+                return true;
+            }
+        }
+    }
+
+    false
+}
 
 /// MIT-9, MIT-13, MIT-14: Tree and root assertions.
 pub(crate) async fn check(s: &DiningScenario) {

--- a/hyperactor_mesh_admin_tui/src/diagnostics.rs
+++ b/hyperactor_mesh_admin_tui/src/diagnostics.rs
@@ -254,7 +254,7 @@ fn label_from_payload(
         NodeProperties::Proc { proc_name, .. } => proc_name.clone(),
         NodeProperties::Actor { .. } => match reference {
             NodeRef::Actor(actor_id) => {
-                format!("{}[{}]", actor_id.name(), actor_id.pid())
+                format!("{}[{}]", actor_id.log_name(), actor_id.uid())
             }
             other => other.to_string(),
         },
@@ -392,7 +392,9 @@ async fn walk(
                         r.label = format!("  {}", label_from_payload(actor_ref, p));
                     } else {
                         let short = match actor_ref {
-                            NodeRef::Actor(id) => format!("{}[{}]", id.name(), id.pid()),
+                            NodeRef::Actor(id) => {
+                                format!("{}[{}]", id.log_name(), id.uid())
+                            }
                             other => other.to_string(),
                         };
                         r.label = format!("  {}", short);
@@ -400,7 +402,7 @@ async fn walk(
                     // Classify actor role from the typed ref.
                     r.note = match actor_ref {
                         NodeRef::Actor(actor_id) => {
-                            let actor_name = actor_id.name();
+                            let actor_name = actor_id.log_name();
                             if actor_name.starts_with(MESH_ADMIN_BRIDGE_NAME) {
                                 Some(DiagNodeRole::RootClientBridge)
                             } else if actor_name.starts_with(MESH_ADMIN_ACTOR_NAME) {
@@ -453,7 +455,7 @@ async fn walk(
                 let actor_role = |nr: &NodeRef| -> Option<DiagNodeRole> {
                     match nr {
                         NodeRef::Actor(actor_id) => {
-                            let name = actor_id.name();
+                            let name = actor_id.log_name();
                             if name.starts_with(COMM_ACTOR_NAME) {
                                 Some(DiagNodeRole::CommActor)
                             } else if name.starts_with(PROC_AGENT_ACTOR_NAME) {

--- a/hyperactor_mesh_admin_tui/src/fetch.rs
+++ b/hyperactor_mesh_admin_tui/src/fetch.rs
@@ -543,7 +543,7 @@ mod tests {
 
     fn mock_actor_ref(name: &str) -> NodeRef {
         use std::str::FromStr;
-        let id_str = format!("unix:@test,world,{}[0]", name);
+        let id_str = format!("unix:@test,world,{}", name);
         NodeRef::Actor(hyperactor::reference::ActorId::from_str(&id_str).unwrap())
     }
 

--- a/hyperactor_mesh_admin_tui/src/filter.rs
+++ b/hyperactor_mesh_admin_tui/src/filter.rs
@@ -55,7 +55,7 @@ mod tests {
 
     fn mock_actor_id() -> hyperactor::reference::ActorId {
         use std::str::FromStr;
-        hyperactor::reference::ActorId::from_str("unix:@test,world,a[0]").unwrap()
+        hyperactor::reference::ActorId::from_str("unix:@test,world,a").unwrap()
     }
 
     fn actor_props(status: &str) -> NodeProperties {

--- a/hyperactor_mesh_admin_tui/src/format.rs
+++ b/hyperactor_mesh_admin_tui/src/format.rs
@@ -83,7 +83,9 @@ pub(crate) fn derive_label(payload: &NodePayload) -> String {
             }
         }
         NodeProperties::Actor { .. } => match &payload.identity {
-            NodeRef::Actor(actor_id) => format!("{}[{}]", actor_id.name(), actor_id.pid()),
+            NodeRef::Actor(actor_id) => {
+                format!("{}[{}]", actor_id.log_name(), actor_id.uid())
+            }
             other => other.to_string(),
         },
         NodeProperties::Error { code, message } => {
@@ -95,11 +97,13 @@ pub(crate) fn derive_label(payload: &NodePayload) -> String {
 /// Derive a display label from a typed node reference without
 /// fetching.
 ///
-/// For actor references, format as `name[pid]`; for all others, fall
+/// For actor references, format as `name[uid]`; for all others, fall
 /// back to the `Display` representation.
 pub(crate) fn derive_label_from_ref(reference: &NodeRef) -> String {
     match reference {
-        NodeRef::Actor(actor_id) => format!("{}[{}]", actor_id.name(), actor_id.pid()),
+        NodeRef::Actor(actor_id) => {
+            format!("{}[{}]", actor_id.log_name(), actor_id.uid())
+        }
         other => other.to_string(),
     }
 }
@@ -241,7 +245,7 @@ mod tests {
     use super::*;
 
     fn mock_actor_ref(name: &str) -> NodeRef {
-        let id_str = format!("unix:@test,world,{}[0]", name);
+        let id_str = format!("unix:@test,world,{}", name);
         NodeRef::Actor(hyperactor_reference::ActorId::from_str(&id_str).unwrap())
     }
 
@@ -251,7 +255,7 @@ mod tests {
     }
 
     fn mock_host_ref(name: &str) -> NodeRef {
-        let id_str = format!("unix:@test,world,{}[0]", name);
+        let id_str = format!("unix:@test,world,{}", name);
         NodeRef::Host(hyperactor_reference::ActorId::from_str(&id_str).unwrap())
     }
 
@@ -543,7 +547,7 @@ mod tests {
     #[test]
     fn derive_label_actor_standard_actor_id() {
         let actor_id =
-            hyperactor_reference::ActorId::from_str("unix:@abc123,myworld,worker[3]").unwrap();
+            hyperactor_reference::ActorId::from_str("unix:@abc123,myworld,worker").unwrap();
         let proc_id = hyperactor_reference::ProcId::from_str("unix:@abc123,myworld").unwrap();
         let payload = NodePayload {
             identity: NodeRef::Actor(actor_id),
@@ -562,7 +566,7 @@ mod tests {
             parent: Some(NodeRef::Proc(proc_id)),
             as_of: SystemTime::now(),
         };
-        assert_eq!(derive_label(&payload), "worker[3]");
+        assert_eq!(derive_label(&payload), "worker[_worker]");
     }
 
     #[test]

--- a/hyperactor_mesh_admin_tui/src/model.rs
+++ b/hyperactor_mesh_admin_tui/src/model.rs
@@ -345,7 +345,7 @@ mod tests {
     fn mock_actor_ref(name: &str) -> NodeRef {
         use std::str::FromStr;
         // Create a simple ActorId for testing.
-        let id_str = format!("unix:@test,world,{}[0]", name);
+        let id_str = format!("unix:@test,world,{}", name);
         NodeRef::Actor(hyperactor::reference::ActorId::from_str(&id_str).unwrap())
     }
 
@@ -680,7 +680,7 @@ mod tests {
         let r = mock_actor_ref("actor1");
         let worker_id = {
             use std::str::FromStr;
-            hyperactor::reference::ActorId::from_str("unix:@test,world,worker[0]").unwrap()
+            hyperactor::reference::ActorId::from_str("unix:@test,world,worker").unwrap()
         };
         let payload = NodePayload {
             identity: r.clone(),

--- a/hyperactor_mesh_admin_tui/src/render/detail_pane.rs
+++ b/hyperactor_mesh_admin_tui/src/render/detail_pane.rs
@@ -804,7 +804,7 @@ mod tests {
 
     fn mock_host_ref() -> NodeRef {
         use hyperactor::reference as hyperactor_reference;
-        let id_str = "unix:@test,world,host_agent[0]";
+        let id_str = "unix:@test,world,host_agent";
         NodeRef::Host(hyperactor_reference::ActorId::from_str(id_str).unwrap())
     }
 

--- a/hyperactor_mesh_admin_tui/src/tests/mod.rs
+++ b/hyperactor_mesh_admin_tui/src/tests/mod.rs
@@ -45,7 +45,7 @@ fn root() -> NodeRef {
 }
 
 fn host(name: &str) -> NodeRef {
-    let id_str = format!("unix:@test,world,{}[0]", name);
+    let id_str = format!("unix:@test,world,{}", name);
     NodeRef::Host(hyperactor_reference::ActorId::from_str(&id_str).unwrap())
 }
 
@@ -55,7 +55,7 @@ fn proc_ref(name: &str) -> NodeRef {
 }
 
 fn actor(name: &str) -> NodeRef {
-    let id_str = format!("unix:@test,world,{}[0]", name);
+    let id_str = format!("unix:@test,world,{}", name);
     NodeRef::Actor(hyperactor_reference::ActorId::from_str(&id_str).unwrap())
 }
 

--- a/hyperactor_mesh_admin_tui/src/tree.rs
+++ b/hyperactor_mesh_admin_tui/src/tree.rs
@@ -296,7 +296,7 @@ mod tests {
     }
 
     fn host(name: &str) -> NodeRef {
-        let id_str = format!("unix:@test,world,{}[0]", name);
+        let id_str = format!("unix:@test,world,{}", name);
         NodeRef::Host(hyperactor::reference::ActorId::from_str(&id_str).unwrap())
     }
 
@@ -306,7 +306,7 @@ mod tests {
     }
 
     fn actor(name: &str) -> NodeRef {
-        let id_str = format!("unix:@test,world,{}[0]", name);
+        let id_str = format!("unix:@test,world,{}", name);
         NodeRef::Actor(hyperactor::reference::ActorId::from_str(&id_str).unwrap())
     }
 

--- a/monarch_extension/src/mesh_controller.rs
+++ b/monarch_extension/src/mesh_controller.rs
@@ -892,7 +892,7 @@ impl MeshControllerActor {
     fn rank_of_worker(&self, actor_id: &reference::ActorId) -> usize {
         *self
             .rank_map
-            .get(actor_id.proc_id())
+            .get(&actor_id.proc_id())
             .expect("rank map should contain worker")
     }
 }

--- a/monarch_hyperactor/src/actor.rs
+++ b/monarch_hyperactor/src/actor.rs
@@ -1377,10 +1377,10 @@ impl Handler<MeshFailure> for PythonActor {
                                 message
                                     .actor_mesh_name
                                     .as_deref()
-                                    .unwrap_or_else(|| message.event.actor_id.name()),
+                                    .unwrap_or_else(|| message.event.actor_id.log_name()),
                                 "SupervisionError::Unhandled",
                             ),
-                            (cx.self_id().name(), "UnhandledSupervisionEvent"),
+                            (cx.self_id().log_name(), "UnhandledSupervisionEvent"),
                         ] {
                             tracing::info!(
                                 name = "ActorMeshStatus",
@@ -1426,10 +1426,10 @@ impl Handler<MeshFailure> for PythonActor {
                             message
                                 .actor_mesh_name
                                 .as_deref()
-                                .unwrap_or_else(|| message.event.actor_id.name()),
+                                .unwrap_or_else(|| message.event.actor_id.log_name()),
                             "SupervisionError::__supervise__::exception",
                         ),
-                        (cx.self_id().name(), "UnhandledSupervisionEvent"),
+                        (cx.self_id().log_name(), "UnhandledSupervisionEvent"),
                     ] {
                         tracing::info!(
                             name = "ActorMeshStatus",

--- a/monarch_hyperactor/src/local_state_broker.rs
+++ b/monarch_hyperactor/src/local_state_broker.rs
@@ -87,7 +87,7 @@ impl BrokerId {
         use std::time::Duration;
 
         let broker_name = format!("{:?}", self);
-        let actor_id = reference::ActorId::new(cx.proc().proc_id().clone(), self.0.clone(), self.1);
+        let actor_id = reference::ActorId::new(cx.proc().proc_id().clone(), self.0.clone());
         let actor_ref: reference::ActorRef<LocalStateBrokerActor> =
             reference::ActorRef::attest(actor_id);
 

--- a/monarch_hyperactor/src/logging.rs
+++ b/monarch_hyperactor/src/logging.rs
@@ -636,7 +636,7 @@ mod tests {
         );
         assert_eq!(
             instance.self_id().proc_id(),
-            proc.proc_id(),
+            proc.proc_id().clone(),
             "returned Instance<()> should be bound to the root Proc"
         );
 

--- a/monarch_hyperactor/src/proc.rs
+++ b/monarch_hyperactor/src/proc.rs
@@ -161,8 +161,13 @@ impl From<PyActorId> for reference::ActorId {
 #[pymethods]
 impl PyActorId {
     #[new]
-    #[pyo3(signature = (*, addr, proc_name, actor_name, pid = 0))]
-    fn new(addr: &str, proc_name: &str, actor_name: &str, pid: reference::Index) -> PyResult<Self> {
+    #[pyo3(signature = (*, addr, proc_name, actor_name, _pid = 0))]
+    fn new(
+        addr: &str,
+        proc_name: &str,
+        actor_name: &str,
+        _pid: reference::Index,
+    ) -> PyResult<Self> {
         let addr: ChannelAddr = addr.parse().map_err(|e| {
             PyValueError::new_err(format!("Failed to parse channel address '{}': {}", addr, e))
         })?;
@@ -170,7 +175,6 @@ impl PyActorId {
             inner: reference::ActorId::new(
                 reference::ProcId::from_resource_name(addr, proc_name),
                 actor_name,
-                pid,
             ),
         })
     }
@@ -203,12 +207,15 @@ impl PyActorId {
 
     #[getter]
     fn actor_name(&self) -> String {
-        self.inner.name().to_string()
+        self.inner
+            .label()
+            .map(|l| l.as_str().to_string())
+            .unwrap_or_else(|| "?".to_string())
     }
 
     #[getter]
-    fn pid(&self) -> reference::Index {
-        self.inner.pid()
+    fn pid(&self) -> String {
+        self.inner.uid().to_string()
     }
 
     #[getter]

--- a/monarch_introspection_snapshot/src/bundle.rs
+++ b/monarch_introspection_snapshot/src/bundle.rs
@@ -335,7 +335,7 @@ mod tests {
     }
 
     fn test_host_ref() -> NodeRef {
-        NodeRef::Host(test_proc_id().actor_id(HOST_MESH_AGENT_ACTOR_NAME, 0))
+        NodeRef::Host(test_proc_id().actor_id(HOST_MESH_AGENT_ACTOR_NAME))
     }
 
     fn test_proc_ref() -> NodeRef {
@@ -343,7 +343,7 @@ mod tests {
     }
 
     fn test_actor_ref() -> NodeRef {
-        NodeRef::Actor(test_proc_id().actor_id(ACTOR_TYPE, 0))
+        NodeRef::Actor(test_proc_id().actor_id(ACTOR_TYPE))
     }
 
     fn minimal_snapshot(id: &str) -> SnapshotData {

--- a/monarch_introspection_snapshot/src/capture.rs
+++ b/monarch_introspection_snapshot/src/capture.rs
@@ -193,12 +193,12 @@ mod tests {
         ProcId::with_name(ChannelAddr::Local(0), "worker")
     }
 
-    fn test_actor_id(name: &str, idx: usize) -> hyperactor::reference::ActorId {
-        test_proc_id().actor_id(name, idx)
+    fn test_actor_id(name: &str) -> hyperactor::reference::ActorId {
+        test_proc_id().actor_id(name)
     }
 
     fn test_host_actor_id() -> hyperactor::reference::ActorId {
-        test_proc_id().actor_id("host_agent", 0)
+        test_proc_id().actor_id("host_agent")
     }
 
     fn test_time() -> SystemTime {
@@ -292,8 +292,8 @@ mod tests {
     // CS-2, CS-7: each NodeRef resolved at most once.
     #[tokio::test]
     async fn test_capture_resolves_each_node_once() {
-        let actor_b = NodeRef::Actor(test_actor_id("b", 0));
-        let actor_a = NodeRef::Actor(test_actor_id("a", 0));
+        let actor_b = NodeRef::Actor(test_actor_id("b"));
+        let actor_a = NodeRef::Actor(test_actor_id("a"));
         let proc_ref = NodeRef::Proc(test_proc_id());
         let host_ref = NodeRef::Host(test_host_actor_id());
 
@@ -401,9 +401,9 @@ mod tests {
     // CS-3: child edges emitted in parent enumeration order.
     #[tokio::test]
     async fn test_capture_emits_edges_from_each_parent() {
-        let a0 = NodeRef::Actor(test_actor_id("a", 0));
-        let a1 = NodeRef::Actor(test_actor_id("b", 0));
-        let a2 = NodeRef::Actor(test_actor_id("c", 0));
+        let a0 = NodeRef::Actor(test_actor_id("a"));
+        let a1 = NodeRef::Actor(test_actor_id("b"));
+        let a2 = NodeRef::Actor(test_actor_id("c"));
         let proc_ref = NodeRef::Proc(test_proc_id());
         let host_ref = NodeRef::Host(test_host_actor_id());
 
@@ -530,8 +530,8 @@ mod tests {
     // one ChildRow per parent→child edge.
     #[tokio::test]
     async fn test_capture_dedupes_nodes_not_edges() {
-        let actor_b = NodeRef::Actor(test_actor_id("b", 0));
-        let actor_a = NodeRef::Actor(test_actor_id("a", 0));
+        let actor_b = NodeRef::Actor(test_actor_id("b"));
+        let actor_a = NodeRef::Actor(test_actor_id("a"));
         let proc_ref = NodeRef::Proc(test_proc_id());
         let host_ref = NodeRef::Host(test_host_actor_id());
 
@@ -825,7 +825,7 @@ mod tests {
     // row.
     #[tokio::test]
     async fn test_capture_keeps_domain_error_payloads() {
-        let error_ref = NodeRef::Actor(test_actor_id("err", 0));
+        let error_ref = NodeRef::Actor(test_actor_id("err"));
         let host_ref = NodeRef::Host(test_host_actor_id());
         let proc_ref = NodeRef::Proc(test_proc_id());
 

--- a/monarch_introspection_snapshot/src/convert.rs
+++ b/monarch_introspection_snapshot/src/convert.rs
@@ -341,11 +341,11 @@ mod tests {
     }
 
     fn test_actor_id() -> hyperactor::reference::ActorId {
-        test_proc_id().actor_id("actor", 0)
+        test_proc_id().actor_id("actor")
     }
 
     fn test_host_actor_id() -> hyperactor::reference::ActorId {
-        test_proc_id().actor_id("host_agent", 0)
+        test_proc_id().actor_id("host_agent")
     }
 
     fn test_time() -> SystemTime {
@@ -576,10 +576,10 @@ mod tests {
     // CV-5: Proc with mixed system/stopped/regular children.
     #[test]
     fn test_child_classification_mixed() {
-        let regular = test_proc_id().actor_id("regular", 0);
-        let sys_only = test_proc_id().actor_id("sys_actor", 0);
-        let stopped_only = test_proc_id().actor_id("stopped_actor", 0);
-        let sys_and_stopped = test_proc_id().actor_id("both", 0);
+        let regular = test_proc_id().actor_id("regular");
+        let sys_only = test_proc_id().actor_id("sys_actor");
+        let stopped_only = test_proc_id().actor_id("stopped_actor");
+        let sys_and_stopped = test_proc_id().actor_id("both");
 
         let children = vec![
             NodeRef::Actor(regular.clone()),
@@ -634,9 +634,9 @@ mod tests {
     // CV-4: child_sort_key is enumeration order.
     #[test]
     fn test_child_sort_key_is_enumeration_order() {
-        let a0 = test_proc_id().actor_id("a", 0);
-        let a1 = test_proc_id().actor_id("b", 0);
-        let a2 = test_proc_id().actor_id("c", 0);
+        let a0 = test_proc_id().actor_id("a");
+        let a1 = test_proc_id().actor_id("b");
+        let a2 = test_proc_id().actor_id("c");
 
         let payload = NodePayload {
             identity: NodeRef::Proc(test_proc_id()),

--- a/monarch_introspection_snapshot/src/push.rs
+++ b/monarch_introspection_snapshot/src/push.rs
@@ -172,7 +172,7 @@ mod tests {
     }
 
     fn test_host_ref() -> NodeRef {
-        NodeRef::Host(test_proc_id().actor_id(HOST_MESH_AGENT_ACTOR_NAME, 0))
+        NodeRef::Host(test_proc_id().actor_id(HOST_MESH_AGENT_ACTOR_NAME))
     }
 
     fn test_proc_ref() -> NodeRef {
@@ -180,7 +180,7 @@ mod tests {
     }
 
     fn test_actor_ref() -> NodeRef {
-        NodeRef::Actor(test_proc_id().actor_id(ACTOR_NAME, 0))
+        NodeRef::Actor(test_proc_id().actor_id(ACTOR_NAME))
     }
 
     /// Expected table names in sorted order (PS-1). Alias for the
@@ -242,9 +242,8 @@ mod tests {
         let host_id = test_host_ref().to_string();
         let proc_id = test_proc_ref().to_string();
         let actor_id = test_actor_ref().to_string();
-        let failed_actor_id =
-            NodeRef::Actor(test_proc_id().actor_id("failed_actor", 0)).to_string();
-        let error_id = NodeRef::Actor(test_proc_id().actor_id("missing", 0)).to_string();
+        let failed_actor_id = NodeRef::Actor(test_proc_id().actor_id("failed_actor")).to_string();
+        let error_id = NodeRef::Actor(test_proc_id().actor_id("missing")).to_string();
 
         SnapshotData {
             snapshot: SnapshotRow {

--- a/monarch_introspection_snapshot/src/service.rs
+++ b/monarch_introspection_snapshot/src/service.rs
@@ -467,8 +467,8 @@ mod tests {
     /// Build a minimal mesh topology: root → host → proc → actor.
     fn minimal_mesh_payloads() -> HashMap<NodeRef, NodePayload> {
         let proc_id = test_proc_id();
-        let host_actor_id = proc_id.actor_id(HOST_MESH_AGENT_ACTOR_NAME, 0);
-        let actor_id = proc_id.actor_id(ACTOR_TYPE, 0);
+        let host_actor_id = proc_id.actor_id(HOST_MESH_AGENT_ACTOR_NAME);
+        let actor_id = proc_id.actor_id(ACTOR_TYPE);
 
         let host_ref = NodeRef::Host(host_actor_id.clone());
         let proc_ref = NodeRef::Proc(proc_id.clone());

--- a/monarch_introspection_snapshot/test/snapshot_integration_test.rs
+++ b/monarch_introspection_snapshot/test/snapshot_integration_test.rs
@@ -416,7 +416,7 @@ async fn test_pt3_immediate_first_capture() -> Result<()> {
     );
 
     // Stop the actor and clean up.
-    let actor_id = instance.proc().proc_id().actor_id("snapshot_capture", 0);
+    let actor_id = instance.proc().proc_id().actor_id("snapshot_capture");
     instance
         .proc()
         .stop_actor(&actor_id, "PT-3 test cleanup".to_string());
@@ -465,7 +465,7 @@ async fn test_pt5_drain_halts_future_captures() -> Result<()> {
 
     // Stop the snapshot actor directly. In production, job teardown
     // stops the proc which stops all actors on it.
-    let actor_id = instance.proc().proc_id().actor_id("snapshot_capture", 0);
+    let actor_id = instance.proc().proc_id().actor_id("snapshot_capture");
     let status_rx = instance
         .proc()
         .stop_actor(&actor_id, "PT-5 test shutdown".to_string());

--- a/monarch_rdma/src/rdma_manager_actor.rs
+++ b/monarch_rdma/src/rdma_manager_actor.rs
@@ -164,7 +164,7 @@ impl RdmaManagerActor {
     pub fn local_handle(client: &impl context::Actor) -> ActorHandle<Self> {
         let proc_id = client.mailbox().actor_id().proc_id().clone();
         let actor_ref =
-            reference::ActorRef::attest(reference::ActorId::new(proc_id, "rdma_manager", 0));
+            reference::ActorRef::attest(reference::ActorId::new(proc_id, "rdma_manager"));
         actor_ref
             .downcast_handle(client)
             .expect("RdmaManagerActor is not in the local process")

--- a/monarch_tensor_worker/src/stream.rs
+++ b/monarch_tensor_worker/src/stream.rs
@@ -496,8 +496,8 @@ impl Actor for StreamActor {
         ROOT_ACTOR_ID.with(|root_actor_id| {
             root_actor_id
                 .set(reference::ActorId::root(
-                    cx.self_id().proc_id().clone(),
-                    cx.self_id().name().to_string(),
+                    cx.self_id().proc_id(),
+                    cx.self_id().label().unwrap().clone(),
                 ))
                 .ok()
         });


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #3493
* #3492
* #3491
* __->__ #3490
* #3489
* #3488
* #3487
* #3486

Make reference::ActorId a thin wrapper around ref_::ActorRef, and reference::PortId around ref_::PortRef. Remove .name(), .pid(), and the sequential pid counter. Eliminate ProcState::roots.

Walkthrough:
- reference.rs: ActorId and PortId become #[serde(transparent)] newtypes over ref_::ActorRef and ref_::PortRef. ActorId::new() uses parse_resource_name() for deterministic uid recovery. Display uses ResourceId text format. Reference::FromStr updated: bracket group `[n]` is now always a Port (actor [pid] syntax removed).
- actor.rs: Signal::ChildStopped carries Uid instead of Index.
- proc.rs: ProcState::roots eliminated. allocate_root_id uses ActorId::new() with instances.contains_key() for uniqueness. allocate_child_id returns parent.child_id() (random uid). InstanceCellState::children re-keyed from DashMap<Index, ...> to DashMap<Uid, ...>.
- supervision.rs: name checks ("host_agent", "proc_agent") changed to label checks.
- mailbox.rs: MailboxMuxer/Router/DialMailboxRouter handle ActorId/PortId by value.
- TUI tests: actor() helper updated to drop [pid] from id strings since ActorId no longer carries pid. All 223 TUI tests updated.
- All downstream crates: .name() → .label()/.log_name(), .pid() → .uid(), ActorId::root() takes Label.

Differential Revision: [D100912592](https://our.internmc.facebook.com/intern/diff/D100912592/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D100912592/)!