### PR TITLE
add supervsision structured attribution foundation (#3494)

### DIFF
--- a/hyperactor/src/actor.rs
+++ b/hyperactor/src/actor.rs
@@ -155,6 +155,33 @@ pub trait Actor: Sized + Send + 'static {
     fn display_name(&self) -> Option<String> {
         None
     }
+
+    /// Structured attribution for supervision events synthesized on
+    /// behalf of this actor. Substrate-local hook: when an
+    /// event-synthesis site in `hyperactor` (for example, the
+    /// worker-actor failure path in `proc.rs`) constructs an
+    /// `ActorSupervisionEvent`, it calls this and stores the result
+    /// in the event's `attribution` field.
+    ///
+    /// Default is `None`. Language-binding or mesh-integration actors
+    /// override this to return their in-scope structured attribution
+    /// (mesh name, actor class, display name, rank) so that consumers
+    /// reading the event's `attribution` field see real data without
+    /// a lookup at observation time.
+    ///
+    /// Named narrowly (`supervision_attribution`) rather than a
+    /// broader `attribution()` because this hook exists solely for
+    /// supervision-event synthesis; it should not be repurposed as a
+    /// general-purpose attribution surface.
+    ///
+    /// FA-2 invariant: when this returns `Some(a)` and
+    /// `a.actor_display_name` is `Some`, it must equal this actor's
+    /// `display_name()` output. Implementations that want both
+    /// populated should source them from the same underlying value to
+    /// avoid divergence.
+    fn supervision_attribution(&self) -> Option<crate::supervision::Attribution> {
+        None
+    }
 }
 
 /// Default implementation of [`Actor::handle_undeliverable_message`]. Defined

--- a/hyperactor/src/introspect.rs
+++ b/hyperactor/src/introspect.rs
@@ -1200,6 +1200,7 @@ mod tests {
             Some("proc_agent".into()),
             ActorStatus::Stopped("host died".into()),
             None,
+            None,
         );
         let parent_event = ActorSupervisionEvent::new(
             parent_id.clone(),
@@ -1207,6 +1208,7 @@ mod tests {
             ActorStatus::Failed(ActorErrorKind::UnhandledSupervisionEvent(Box::new(
                 child_event,
             ))),
+            None,
             None,
         );
 

--- a/hyperactor/src/proc.rs
+++ b/hyperactor/src/proc.rs
@@ -1844,11 +1844,23 @@ impl<A: Actor> Instance<A> {
             Ok(stop_reason) => {
                 let status = ActorStatus::Stopped(stop_reason);
                 self.mailbox().close(status.clone());
+                // If the actor supplies structured `Attribution`
+                // whose `actor_display_name` is populated, reuse it
+                // as the event's `display_name` rather than calling
+                // `actor.display_name()` a second time (FA-2: the
+                // two carriers must not diverge, so a single source
+                // also avoids the extra call on the failure path).
+                let attribution = actor.supervision_attribution();
+                let display_name = attribution
+                    .as_ref()
+                    .and_then(|a| a.actor_display_name.clone())
+                    .or_else(|| actor.display_name());
                 let event = ActorSupervisionEvent::new(
                     self.inner.cell.actor_id().clone(),
-                    actor.display_name(),
+                    display_name,
                     status.clone(),
                     None,
+                    attribution,
                 );
                 // FI-1: store supervision_event BEFORE change_status.
                 *self.inner.cell.inner.supervision_event.lock().unwrap() = Some(event.clone());
@@ -1871,11 +1883,21 @@ impl<A: Actor> Instance<A> {
                         let error_kind = ActorErrorKind::Generic(err.kind.to_string());
                         let status = ActorStatus::Failed(error_kind);
                         self.mailbox().close(status.clone());
+                        // Same pattern as the Ok branch: prefer
+                        // `actor_display_name` from the structured
+                        // attribution when present, fall back to
+                        // `actor.display_name()` otherwise.
+                        let attribution = actor.supervision_attribution();
+                        let display_name = attribution
+                            .as_ref()
+                            .and_then(|a| a.actor_display_name.clone())
+                            .or_else(|| actor.display_name());
                         let event = ActorSupervisionEvent::new(
                             self.inner.cell.actor_id().clone(),
-                            actor.display_name(),
+                            display_name,
                             status.clone(),
                             None,
+                            attribution,
                         );
                         // FI-1: store supervision_event BEFORE change_status.
                         *self.inner.cell.inner.supervision_event.lock().unwrap() =

--- a/hyperactor/src/supervision.rs
+++ b/hyperactor/src/supervision.rs
@@ -19,56 +19,60 @@
 //!
 //! ## Failure-attribution invariants (FA-*)
 //!
-//! These invariants govern the supervision-path rendering contract
-//! at the hyperactor substrate level. They describe how
+//! These invariants govern the supervision-path rendering contract at
+//! the hyperactor substrate level. They describe how
 //! `ActorSupervisionEvent` and its renderer must behave, and what
 //! higher-level crates (for example, crates that add friendly
-//! attribution fields such as a mesh name or a language-binding
-//! class name) must do when they plug data into this substrate.
-//! Hyperactor itself does not define mesh-level or binding-level
-//! concepts; those interpretations live alongside the types that
-//! introduce them (for mesh-specific interpretation, see
+//! attribution fields such as a mesh name or a language-binding class
+//! name) must do when they plug data into this substrate. Hyperactor
+//! itself does not define mesh-level or binding-level concepts; those
+//! interpretations live alongside the types that introduce them (for
+//! mesh-specific interpretation, see
 //! `hyperactor_mesh/src/supervision.rs`; for Python-binding
 //! interpretation, see the spawn path in
 //! `monarch_hyperactor/src/actor.rs`).
 //!
-//! - **FA-1 (no lookup at construction).** When a higher-level
-//!   crate attaches friendly-attribution data to an
-//!   `ActorSupervisionEvent` — or to a wrapper that carries one —
-//!   the value must come from structured context already in scope
-//!   at the construction site. Construction sites do not perform a
-//!   lookup to obtain attribution. If the value is not locally
-//!   available, `None` is correct; lookups are not a permitted
-//!   workaround.
+//! - **FA-1 (no lookup at construction).** When a higher-level crate
+//!   attaches friendly-attribution data to an `ActorSupervisionEvent`
+//!   — or to a wrapper that carries one — the value must come from
+//!   structured context already in scope at the construction site.
+//!   Construction sites do not perform a lookup to obtain
+//!   attribution. If the value is not locally available, `None` is
+//!   correct; lookups are not a permitted workaround.
 //!
 //! - **FA-2 (`display_name` is presentation-only).**
-//!   `ActorSupervisionEvent.display_name` is a
-//!   rendered-presentation string carried for display. Downstream
-//!   code MUST NOT parse it to recover structured attribution. If
-//!   a consumer needs a programmatic attribution field, that field
-//!   travels on its own structured carrier — never on
-//!   `display_name`.
+//!   `ActorSupervisionEvent.display_name` is a rendered-presentation
+//!   string carried for display. Downstream code MUST NOT parse it to
+//!   recover structured attribution. If a consumer needs a
+//!   programmatic attribution field, that field travels on its own
+//!   structured carrier — never on `display_name`.
 //!
-//! - **FA-3 (rendering falls back to stable ids).**
+//! - **FA-3 (rendering preference order, with stable-id fallback).**
 //!   `ActorSupervisionEvent::Display` and the helpers it uses
-//!   (notably `actor_name()`) render `display_name` when present
-//!   and fall back to `actor_id.to_string()` otherwise. This means
-//!   a given actor mention renders **either** the friendly
-//!   display name **or** the stable id, not both. Ensuring both
-//!   appear at every mention is follow-on work outside the scope
-//!   of this invariant. FA-3 is independent of the specific text
-//!   format used by `ActorId::Display` — it describes the
-//!   render-chain fallback contract, not the id format.
+//!   (notably `actor_name()`) render, at a given actor mention,
+//!   the first of the following that is `Some`:
+//!     1. `attribution.actor_display_name`
+//!     2. `attribution.actor_class`
+//!     3. `display_name`
+//!     4. `actor_id.to_string()` (stable-id fallback)
+//!
+//!   A given actor mention renders exactly one of those tiers — the
+//!   friendly name and the stable id are not shown together at that
+//!   mention. Ensuring both appear at every mention is follow-on
+//!   work outside the scope of this invariant. FA-3 is independent
+//!   of the specific text format used by `ActorId::Display` — it
+//!   describes the render-chain preference contract, not the id
+//!   format.
 //!
 //! - **FA-4 (no rendered-output parsing back into attribution).**
 //!   Structured attribution must not be recovered at runtime by
 //!   parsing formatted `display_name` strings, identifier text, or
-//!   other rendered output from this path. Higher-level crates
-//!   that add supervision-path attribution do so via structured
-//!   carriers, not by inversion of rendered text. Consumers that
-//!   sit outside this path (for example, generic telemetry that
-//!   happens to read a rendered string) are outside this
-//!   invariant's scope; their own contracts govern what they do.
+//!   other rendered output from this path. Higher-level crates that
+//!   add supervision-path attribution do so via structured carriers,
+//!   not by inversion of rendered text. Consumers that sit outside
+//!   this path (for example, generic telemetry that happens to read a
+//!   rendered string) are outside this invariant's scope; their own
+//!   contracts govern what they do.
 
 use std::fmt;
 use std::fmt::Debug;
@@ -85,13 +89,38 @@ use crate::actor::ActorErrorKind;
 use crate::actor::ActorStatus;
 use crate::reference;
 
+/// Structured attribution carrier for supervision events. Distinct
+/// from `display_name`, which remains presentation-only. Consumers
+/// that need programmatic attribution read this directly rather than
+/// parsing rendered output.
+///
+/// Producers MUST maintain the invariant that when
+/// `ActorSupervisionEvent.attribution` is `Some` and
+/// `attribution.actor_display_name` is `Some`, the legacy
+/// `ActorSupervisionEvent.display_name` field is either `None` or
+/// equal to `attribution.actor_display_name`.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct Attribution {
+    /// Friendly container/context name, when available.
+    pub mesh_name: Option<String>,
+    /// Structured actor-class/type token, when available.
+    pub actor_class: Option<String>,
+    /// Free-form rendered actor display name, when available.
+    pub actor_display_name: Option<String>,
+    /// Per-rank rank, when available.
+    pub rank: Option<usize>,
+}
+
 /// This is the local actor supervision event. Child actor will propagate this event to its parent.
 #[derive(Clone, Debug, Derivative, Serialize, Deserialize, typeuri::Named)]
 #[derivative(PartialEq, Eq)]
 pub struct ActorSupervisionEvent {
     /// The actor id of the child actor where the event is triggered.
     pub actor_id: reference::ActorId,
-    /// Friendly display name, if the actor class customized it.
+    /// Friendly rendered display name, if customized by the actor.
+    /// Presentation-only per FA-2. When
+    /// `attribution.actor_display_name` is `Some`, this field must be
+    /// `None` or equal to it.
     pub display_name: Option<String>,
     /// The time when the event is triggered.
     #[derivative(PartialEq = "ignore")]
@@ -101,27 +130,66 @@ pub struct ActorSupervisionEvent {
     /// If this event is associated with a message, the message headers.
     #[derivative(PartialEq = "ignore")]
     pub message_headers: Option<Flattrs>,
+    /// Structured programmatic attribution for this supervision
+    /// event. Downstream code reads this carrier directly instead of
+    /// parsing `display_name` or rendered output. May be `None` at
+    /// construction sites that do not have structured attribution
+    /// locally in scope — lookups are not used as a workaround
+    /// (FA-1).
+    pub attribution: Option<Attribution>,
 }
 wirevalue::register_type!(ActorSupervisionEvent);
 
 impl ActorSupervisionEvent {
-    /// Create a new supervision event. Timestamp is set to the current time.
+    /// Create a new supervision event. Timestamp is set to the
+    /// current time.
+    ///
+    /// Preserves the FA-2 single-source-of-truth invariant: when
+    /// `attribution` carries a `Some(actor_display_name)` value,
+    /// the `display_name` parameter must either be `None` or equal
+    /// to that value. Enforced by a debug assertion.
     pub fn new(
         actor_id: reference::ActorId,
         display_name: Option<String>,
         actor_status: ActorStatus,
         message_headers: Option<Flattrs>,
+        attribution: Option<Attribution>,
     ) -> Self {
+        debug_assert!(
+            match (
+                &display_name,
+                attribution
+                    .as_ref()
+                    .and_then(|a| a.actor_display_name.as_ref()),
+            ) {
+                (Some(d), Some(a)) => d == a,
+                _ => true,
+            },
+            "ActorSupervisionEvent.display_name and attribution.actor_display_name must not diverge"
+        );
         Self {
             actor_id,
             display_name,
             occurred_at: std::time::SystemTime::now(),
             actor_status,
             message_headers,
+            attribution,
         }
     }
 
+    /// Render the human-facing name for this actor mention.
+    /// Preference order (FA-3):
+    /// `attribution.actor_display_name` → `attribution.actor_class`
+    /// → `display_name` → stable `actor_id.to_string()` fallback.
     fn actor_name(&self) -> String {
+        if let Some(a) = &self.attribution {
+            if let Some(n) = &a.actor_display_name {
+                return n.clone();
+            }
+            if let Some(c) = &a.actor_class {
+                return c.clone();
+            }
+        }
         self.display_name
             .clone()
             .unwrap_or_else(|| self.actor_id.to_string())
@@ -279,6 +347,7 @@ mod tests {
             Some(name.to_string()),
             status,
             None,
+            None,
         )
     }
 
@@ -288,7 +357,7 @@ mod tests {
         status: ActorStatus,
     ) -> ActorSupervisionEvent {
         let proc_id = reference::ProcId::with_name(addr, "test_proc");
-        ActorSupervisionEvent::new(proc_id.actor_id(name, 0), None, status, None)
+        ActorSupervisionEvent::new(proc_id.actor_id(name, 0), None, status, None, None)
     }
 
     fn generic(name: &str, msg: &str) -> ActorSupervisionEvent {
@@ -610,6 +679,7 @@ mod tests {
             Some("proc_agent".into()),
             ActorStatus::Stopped("host died".into()),
             None,
+            None,
         );
         let parent_event = ActorSupervisionEvent::new(
             parent_id,
@@ -617,6 +687,7 @@ mod tests {
             ActorStatus::Failed(ActorErrorKind::UnhandledSupervisionEvent(Box::new(
                 child_event,
             ))),
+            None,
             None,
         );
 
@@ -629,6 +700,80 @@ mod tests {
             matches!(root.actor_status, ActorStatus::Stopped(_)),
             "root cause should be the stopped child, got: {:?}",
             root.actor_status,
+        );
+    }
+
+    /// FA-3: `ActorSupervisionEvent::actor_name()` renders with
+    /// preference order
+    /// `attribution.actor_display_name` →
+    /// `attribution.actor_class` →
+    /// `display_name` →
+    /// `actor_id.to_string()`.
+    ///
+    /// This locks the rendering contract so any future regression
+    /// (e.g. swapping the order or skipping a tier) surfaces as a
+    /// unit-test failure.
+    #[test]
+    fn test_fa3_actor_name_preference_order() {
+        let proc_id = reference::ProcId::with_name(ChannelAddr::Local(0), "p");
+        let actor_id = proc_id.actor_id("a", 0);
+
+        // Build events that differ only in which tiers are populated.
+        let mk = |display_name: Option<String>, attribution: Option<Attribution>| {
+            ActorSupervisionEvent::new(
+                actor_id.clone(),
+                display_name,
+                ActorStatus::Failed(ActorErrorKind::Generic("boom".into())),
+                None,
+                attribution,
+            )
+        };
+        let raw_id = actor_id.to_string();
+
+        // Tier 4 — all carriers absent: fall back to stable id.
+        assert_eq!(mk(None, None).actor_name(), raw_id);
+
+        // Tier 3 — display_name present, attribution absent.
+        assert_eq!(mk(Some("dn".into()), None).actor_name(), "dn",);
+
+        // Tier 2 — attribution.actor_class present, no display_name.
+        let attr_class_only = Attribution {
+            mesh_name: None,
+            actor_class: Some("CLS".into()),
+            actor_display_name: None,
+            rank: None,
+        };
+        assert_eq!(mk(None, Some(attr_class_only)).actor_name(), "CLS",);
+
+        // Tier 1 — attribution.actor_display_name wins over
+        // everything below it. FA-2 invariant requires
+        // display_name to be None or equal; use equal here.
+        let attr_display = Attribution {
+            mesh_name: Some("m".into()),
+            actor_class: Some("CLS".into()),
+            actor_display_name: Some("DN".into()),
+            rank: Some(7),
+        };
+        assert_eq!(
+            mk(Some("DN".into()), Some(attr_display.clone())).actor_name(),
+            "DN",
+        );
+
+        // Tier 1 also wins when display_name is None.
+        assert_eq!(mk(None, Some(attr_display)).actor_name(), "DN",);
+
+        // Tier 2 beats Tier 3: attribution.actor_class wins even
+        // when display_name is also set, because attribution is
+        // authoritative when present.
+        let attr_class_with_dn = Attribution {
+            mesh_name: None,
+            actor_class: Some("CLS".into()),
+            actor_display_name: None,
+            rank: None,
+        };
+        assert_eq!(
+            mk(Some("dn".into()), Some(attr_class_with_dn)).actor_name(),
+            "CLS",
         );
     }
 }

--- a/hyperactor/src/supervision.rs
+++ b/hyperactor/src/supervision.rs
@@ -16,6 +16,59 @@
 //!   for structured failure attribution. In particular, if a
 //!   failed parent wraps a stopped child event, the stopped child
 //!   remains the root cause.
+//!
+//! ## Failure-attribution invariants (FA-*)
+//!
+//! These invariants govern the supervision-path rendering contract
+//! at the hyperactor substrate level. They describe how
+//! `ActorSupervisionEvent` and its renderer must behave, and what
+//! higher-level crates (for example, crates that add friendly
+//! attribution fields such as a mesh name or a language-binding
+//! class name) must do when they plug data into this substrate.
+//! Hyperactor itself does not define mesh-level or binding-level
+//! concepts; those interpretations live alongside the types that
+//! introduce them (for mesh-specific interpretation, see
+//! `hyperactor_mesh/src/supervision.rs`; for Python-binding
+//! interpretation, see the spawn path in
+//! `monarch_hyperactor/src/actor.rs`).
+//!
+//! - **FA-1 (no lookup at construction).** When a higher-level
+//!   crate attaches friendly-attribution data to an
+//!   `ActorSupervisionEvent` — or to a wrapper that carries one —
+//!   the value must come from structured context already in scope
+//!   at the construction site. Construction sites do not perform a
+//!   lookup to obtain attribution. If the value is not locally
+//!   available, `None` is correct; lookups are not a permitted
+//!   workaround.
+//!
+//! - **FA-2 (`display_name` is presentation-only).**
+//!   `ActorSupervisionEvent.display_name` is a
+//!   rendered-presentation string carried for display. Downstream
+//!   code MUST NOT parse it to recover structured attribution. If
+//!   a consumer needs a programmatic attribution field, that field
+//!   travels on its own structured carrier — never on
+//!   `display_name`.
+//!
+//! - **FA-3 (rendering falls back to stable ids).**
+//!   `ActorSupervisionEvent::Display` and the helpers it uses
+//!   (notably `actor_name()`) render `display_name` when present
+//!   and fall back to `actor_id.to_string()` otherwise. This means
+//!   a given actor mention renders **either** the friendly
+//!   display name **or** the stable id, not both. Ensuring both
+//!   appear at every mention is follow-on work outside the scope
+//!   of this invariant. FA-3 is independent of the specific text
+//!   format used by `ActorId::Display` — it describes the
+//!   render-chain fallback contract, not the id format.
+//!
+//! - **FA-4 (no rendered-output parsing back into attribution).**
+//!   Structured attribution must not be recovered at runtime by
+//!   parsing formatted `display_name` strings, identifier text, or
+//!   other rendered output from this path. Higher-level crates
+//!   that add supervision-path attribution do so via structured
+//!   carriers, not by inversion of rendered text. Consumers that
+//!   sit outside this path (for example, generic telemetry that
+//!   happens to read a rendered string) are outside this
+//!   invariant's scope; their own contracts govern what they do.
 
 use std::fmt;
 use std::fmt::Debug;

--- a/hyperactor_mesh/src/actor_mesh.rs
+++ b/hyperactor_mesh/src/actor_mesh.rs
@@ -210,6 +210,7 @@ impl<A: Referable> ActorMesh<A> {
                     None,
                     ActorStatus::Stopped("mesh stopped".to_string()),
                     None,
+                    None,
                 ),
                 crashed_ranks: vec![],
             }));
@@ -782,6 +783,7 @@ impl<A: Referable> ActorMeshRef<A> {
                                 controller.actor_id(),
                                 self.name()
                             )),
+                            None,
                             None,
                         ),
                         crashed_ranks: vec![],

--- a/hyperactor_mesh/src/comm.rs
+++ b/hyperactor_mesh/src/comm.rs
@@ -1350,7 +1350,7 @@ mod tests {
         // This test is verifying the whole comm tree, so we want fewer actors
         // involved.
         let actor_mesh = proc_mesh
-            .spawn_with_name(&instance, actor_name, &params, None, true)
+            .spawn_with_name(&instance, actor_name, &params, None, None, true)
             .await
             .unwrap();
         let actor_mesh_ref: crate::ActorMeshRef<TestActor> = actor_mesh.deref().clone();
@@ -1530,7 +1530,7 @@ mod tests {
         let actor_name = crate::Name::new("test").expect("valid test name");
         // Make this actor a "system" actor to avoid spawning a controller actor.
         let actor_mesh: crate::ActorMesh<TestActor> = proc_mesh
-            .spawn_with_name(&instance, actor_name, &params, None, true)
+            .spawn_with_name(&instance, actor_name, &params, None, None, true)
             .await
             .unwrap();
         let actor_mesh_ref = actor_mesh.deref().clone();
@@ -1639,7 +1639,7 @@ mod tests {
         };
         let actor_name = Name::new("test").expect("valid test name");
         let actor_mesh: ActorMesh<TestActor> = proc_mesh
-            .spawn_with_name(&instance, actor_name, &params, None, true)
+            .spawn_with_name(&instance, actor_name, &params, None, None, true)
             .await
             .unwrap();
         let (reply_port_handle, mut reply_rx) = open_port::<u64>(instance);

--- a/hyperactor_mesh/src/global_context.rs
+++ b/hyperactor_mesh/src/global_context.rs
@@ -223,6 +223,7 @@ impl GlobalClientActor {
                         Some("testclient".into()),
                         status,
                         None,
+                        None,
                     )
                 }
             };
@@ -278,6 +279,7 @@ impl Actor for GlobalClientActor {
             None,
             ActorStatus::generic_failure(format!("message not delivered: {}", env)),
             Some(headers),
+            None,
         );
 
         match get_global_supervision_sink() {

--- a/hyperactor_mesh/src/host_mesh.rs
+++ b/hyperactor_mesh/src/host_mesh.rs
@@ -549,6 +549,7 @@ impl HostMesh {
                 trampoline_name,
                 &(transport, mesh_agents.bind(), bootstrap_params, is_local),
                 None,
+                None,
                 // The trampoline is a system actor and does not need a controller.
                 true,
             )

--- a/hyperactor_mesh/src/mesh_controller.rs
+++ b/hyperactor_mesh/src/mesh_controller.rs
@@ -523,6 +523,7 @@ impl<A: Referable> Handler<resource::Stop> for ActorMeshController<A> {
             None,
             ActorStatus::Stopped("ActorMeshController received explicit stop request".to_string()),
             None,
+            None,
         );
         let failure_message = MeshFailure {
             actor_mesh_name: Some(mesh_name.to_string()),
@@ -703,6 +704,7 @@ fn actor_state_to_supervision_events(
                         .to_string(),
                     ),
                     None,
+                    None,
                 )]
             }
         }
@@ -854,6 +856,7 @@ impl<A: Referable> Handler<CheckState> for ActorMeshController<A> {
                         e
                     )),
                     None,
+                    None,
                 ),
                 mesh.name(),
                 false,
@@ -884,6 +887,7 @@ impl<A: Referable> Handler<CheckState> for ActorMeshController<A> {
                         Some(display_name),
                         actor_status,
                         None,
+                        None,
                     ),
                     mesh.name(),
                     true,
@@ -913,6 +917,7 @@ impl<A: Referable> Handler<CheckState> for ActorMeshController<A> {
                         "unable to query for actor states: {:?}",
                         e
                     )),
+                    None,
                     None,
                 ),
                 mesh.name(),
@@ -1114,7 +1119,7 @@ mod tests {
         // control keepalive messages directly without the controller
         // interfering.
         let actor_mesh: ActorMesh<testactor::TestActor> = proc_mesh
-            .spawn_with_name(instance, actor_name.clone(), &(), None, true)
+            .spawn_with_name(instance, actor_name.clone(), &(), None, None, true)
             .await
             .unwrap();
         assert!(

--- a/hyperactor_mesh/src/proc_mesh.rs
+++ b/hyperactor_mesh/src/proc_mesh.rs
@@ -1387,6 +1387,21 @@ impl view::RankedSliceable for ProcMeshRef {
 ///
 /// The supervision display name format is `{instance}.<{module}.{ClassName} {mesh_name}>`.
 /// Returns `"Python<ClassName>"` if the format matches, `None` otherwise.
+///
+/// Scope note: this function sits outside FA-4 (which is
+/// supervision-path attribution only — see
+/// `hyperactor/src/supervision.rs`). Its sole production caller is
+/// the `MeshEvent.class` telemetry field, which needs the Python
+/// class as a structured string and has no structured carrier
+/// today.
+///
+/// TODO: retained only because the telemetry path needs a
+/// structured Python-class string and this is the only available
+/// source. This path is **out of scope for the first increment**
+/// of the failure-attribution work. The follow-up increment
+/// should add a structured carrier (e.g. `actor_class` on
+/// `ActorSupervisionEvent`, or a dedicated telemetry-side field)
+/// and delete this function.
 fn python_class_from_supervision_name(sdn: &str) -> Option<String> {
     let inner = sdn.rsplit_once('<')?.1.strip_suffix('>')?;
     let qualified = inner.split_whitespace().next()?;

--- a/hyperactor_mesh/src/proc_mesh.rs
+++ b/hyperactor_mesh/src/proc_mesh.rs
@@ -269,7 +269,7 @@ impl ProcMesh {
             // spawned and safely referenced via ActorRef<CommActor>.
             // It is a system actor that should not have a controller managing it.
             let comm_actor_mesh: ActorMesh<CommActor> = proc_mesh
-                .spawn_with_name(cx, comm_actor_name, &Default::default(), None, true)
+                .spawn_with_name(cx, comm_actor_name, &Default::default(), None, None, true)
                 .await?;
             let address_book: HashMap<_, _> = comm_actor_mesh
                 .iter()
@@ -894,6 +894,7 @@ impl ProcMeshRef {
                                         name,
                                     )),
                                     None,
+                                    None,
                                 )],
                             }),
                         },
@@ -956,7 +957,7 @@ impl ProcMeshRef {
         C::A: Handler<MeshFailure>,
     {
         // Spawning from a string is never a system actor.
-        self.spawn_with_name(cx, Name::new(name)?, params, None, false)
+        self.spawn_with_name(cx, Name::new(name)?, params, None, None, false)
             .await
     }
 
@@ -977,7 +978,7 @@ impl ProcMeshRef {
         A::Params: RemoteMessage,
         C::A: Handler<MeshFailure>,
     {
-        self.spawn_with_name(cx, Name::new_reserved(name)?, params, None, false)
+        self.spawn_with_name(cx, Name::new_reserved(name)?, params, None, None, false)
             .await
     }
 
@@ -1005,6 +1006,13 @@ impl ProcMeshRef {
         name: Name,
         params: &A::Params,
         supervision_display_name: Option<String>,
+        // Structured actor-class token (Python class name or
+        // equivalent) used for the mesh-creation telemetry event
+        // and for attribution on the direct actor-handled
+        // supervision path. Distinct from
+        // `supervision_display_name`, which is a rendered
+        // presentation string.
+        actor_class: Option<String>,
         is_system_actor: bool,
     ) -> crate::Result<ActorMesh<A>>
     where
@@ -1017,7 +1025,14 @@ impl ProcMeshRef {
         );
         tracing::info!(name = "ActorMeshStatus", status = "Spawn::Attempt");
         let result = self
-            .spawn_with_name_inner(cx, name, params, supervision_display_name, is_system_actor)
+            .spawn_with_name_inner(
+                cx,
+                name,
+                params,
+                supervision_display_name,
+                actor_class,
+                is_system_actor,
+            )
             .await;
         match &result {
             Ok(_) => {
@@ -1041,6 +1056,7 @@ impl ProcMeshRef {
         name: Name,
         params: &A::Params,
         supervision_display_name: Option<String>,
+        actor_class: Option<String>,
         is_system_actor: bool,
     ) -> crate::Result<ActorMesh<A>>
     where
@@ -1192,10 +1208,12 @@ impl ProcMeshRef {
             hyperactor_telemetry::notify_mesh_created(hyperactor_telemetry::MeshEvent {
                 id: mesh_id_hash,
                 timestamp: std::time::SystemTime::now(),
-                class: supervision_display_name
-                    .as_deref()
-                    .and_then(python_class_from_supervision_name)
-                    .unwrap_or(actor_type),
+                // Read the structured class token directly from
+                // the caller-supplied `actor_class` rather than
+                // reverse-parsing `supervision_display_name` with
+                // a regex. If no structured class was supplied,
+                // fall back to the Rust `actor_type` name.
+                class: actor_class.clone().unwrap_or_else(|| actor_type.clone()),
                 given_name: mesh.name().name().to_string(),
                 full_name: name_str,
                 shape_json: serde_json::to_string(&self.region().extent()).unwrap_or_default(),
@@ -1383,32 +1401,6 @@ impl view::RankedSliceable for ProcMeshRef {
     }
 }
 
-/// Extract a Python class display name from a supervision display name.
-///
-/// The supervision display name format is `{instance}.<{module}.{ClassName} {mesh_name}>`.
-/// Returns `"Python<ClassName>"` if the format matches, `None` otherwise.
-///
-/// Scope note: this function sits outside FA-4 (which is
-/// supervision-path attribution only — see
-/// `hyperactor/src/supervision.rs`). Its sole production caller is
-/// the `MeshEvent.class` telemetry field, which needs the Python
-/// class as a structured string and has no structured carrier
-/// today.
-///
-/// TODO: retained only because the telemetry path needs a
-/// structured Python-class string and this is the only available
-/// source. This path is **out of scope for the first increment**
-/// of the failure-attribution work. The follow-up increment
-/// should add a structured carrier (e.g. `actor_class` on
-/// `ActorSupervisionEvent`, or a dedicated telemetry-side field)
-/// and delete this function.
-fn python_class_from_supervision_name(sdn: &str) -> Option<String> {
-    let inner = sdn.rsplit_once('<')?.1.strip_suffix('>')?;
-    let qualified = inner.split_whitespace().next()?;
-    let class_name = qualified.rsplit_once('.')?.1;
-    Some(format!("Python<{class_name}>"))
-}
-
 #[cfg(test)]
 mod tests {
     use hyperactor::Instance;
@@ -1487,28 +1479,5 @@ mod tests {
         );
 
         let _ = hm.shutdown(instance).await;
-    }
-
-    #[test]
-    fn test_python_class_from_supervision_name() {
-        use super::python_class_from_supervision_name;
-
-        assert_eq!(
-            python_class_from_supervision_name("instance0.<my_module.MyWorker test_mesh>"),
-            Some("Python<MyWorker>".to_string()),
-        );
-        assert_eq!(
-            python_class_from_supervision_name(
-                "instance0.<package.submodule.TrainingActor mesh_0>"
-            ),
-            Some("Python<TrainingActor>".to_string()),
-        );
-        // No angle brackets — not a Python supervision name.
-        assert_eq!(python_class_from_supervision_name("plain_name"), None,);
-        // Malformed: missing dot-qualified class name.
-        assert_eq!(
-            python_class_from_supervision_name("instance0.<NoModule mesh>"),
-            None,
-        );
     }
 }

--- a/hyperactor_mesh/src/supervision.rs
+++ b/hyperactor_mesh/src/supervision.rs
@@ -72,6 +72,7 @@ impl MeshFailure {
                 self.event.clone(),
             ))),
             None,
+            None,
         )));
         Err(anyhow::Error::new(err))
     }
@@ -142,6 +143,7 @@ mod tests {
             proc_id.actor_id(name, 0),
             display_name,
             ActorStatus::Failed(ActorErrorKind::Generic("boom".to_string())),
+            None,
             None,
         )
     }
@@ -219,6 +221,7 @@ mod tests {
                  error: broken link: message returned to global root client"
                     .to_string(),
             ),
+            None,
             None,
         )
     }
@@ -329,6 +332,7 @@ mod tests {
                     "IndexError: list index out of range".to_string(),
                 )),
                 None,
+                None,
             )
         };
         let before = MeshFailure {
@@ -389,6 +393,7 @@ mod tests {
                         .to_string(),
                 ),
                 None,
+                None,
             )
         };
         // Both before and after have actor_mesh_name populated, and
@@ -418,4 +423,16 @@ mod tests {
         // construction site at `actor_mesh.rs:773-787` has no
         // PythonActor context — follow-on work for this class.
     }
+
+    // Note: the helper-level mapping test for
+    // `build_direct_handled_attribution` lives in
+    // `monarch_hyperactor/src/actor.rs` as
+    // `tests::test_build_direct_handled_attribution_mapping`
+    // because the helper is defined there. End-to-end coverage on
+    // the direct actor-handled path — spawn a Python actor, trigger
+    // a supervision failure, and read the structured attributes
+    // off the raised `SupervisionError` — lives in
+    // `fbcode//monarch/python/tests:test_actor_error` as
+    // `test_supervision_error_structured_attributes`. This module
+    // tests `MeshFailure` rendering only.
 }

--- a/hyperactor_mesh/src/supervision.rs
+++ b/hyperactor_mesh/src/supervision.rs
@@ -7,6 +7,27 @@
  */
 
 //! Messages used in supervision of actor meshes.
+//!
+//! The substrate-level failure-attribution invariants (FA-*) live
+//! in `hyperactor/src/supervision.rs`. This module layers the
+//! mesh-specific interpretation of those invariants on top.
+//!
+//! ## Mesh-specific FA-1 (mesh-name propagation).
+//!
+//! When a `MeshFailure` is constructed for a supervision event
+//! whose constructing site has the mesh name locally in scope, the
+//! mesh name is carried on `MeshFailure.actor_mesh_name`. The
+//! constructing site does not perform a lookup to obtain the mesh
+//! name; if the mesh name is not locally available at the site,
+//! `None` is correct (consistent with FA-1 in
+//! `hyperactor/src/supervision.rs`). `MeshFailure::Display`
+//! surfaces the mesh name as an `on mesh "{name}"` segment when
+//! `actor_mesh_name` is populated; stable identifiers continue to
+//! appear in detail segments where the renderer already includes
+//! them (consistent with FA-3). Python-binding-specific plumbing
+//! for this carrier — how a Python-spawned actor ends up with a
+//! mesh base-name string to supply — lives in
+//! `monarch_hyperactor/src/actor.rs` (`PythonActorParams.mesh_base_name`).
 
 use hyperactor::Bind;
 use hyperactor::Unbind;
@@ -81,4 +102,320 @@ impl std::fmt::Display for MeshFailure {
 pub(crate) enum Unhealthy {
     StreamClosed(MeshFailure), // Event stream closed
     Crashed(MeshFailure),      // Bad health event received
+}
+
+#[cfg(test)]
+mod tests {
+    //! Tests covering the FA-* invariants (see
+    //! `hyperactor/src/supervision.rs`). The tests named
+    //! `proof_*` capture exact before/after rendered `MeshFailure`
+    //! strings for three supervision-path shapes so they can be
+    //! cited as concrete evidence — not just assertions — that the
+    //! first increment materially improves the user-visible output
+    //! on the claimed paths, and honestly reports where it does
+    //! not.
+    //!
+    //! The "before" shape in each proof is the MeshFailure as it
+    //! would have been constructed prior to this increment (with
+    //! `actor_mesh_name = None` on paths that did not populate it).
+    //! The "after" shape is what the same path produces under the
+    //! first-increment plumbing.
+    //!
+    //! Note: the exact `assert_eq!` literals in the `proof_*` tests
+    //! capture the `ActorId::Display` output of the checkout the
+    //! tests were generated against. If the identifier encoding
+    //! changes (e.g. a reference-stack refactor lands in the same
+    //! tree), the proof literals need to be regenerated on the new
+    //! baseline — the attribution improvement itself is independent
+    //! of the id encoding.
+
+    use hyperactor::actor::ActorErrorKind;
+    use hyperactor::actor::ActorStatus;
+    use hyperactor::channel::ChannelAddr;
+    use hyperactor::reference;
+
+    use super::*;
+
+    fn test_event(name: &str, display_name: Option<String>) -> ActorSupervisionEvent {
+        let proc_id = reference::ProcId::with_name(ChannelAddr::Local(0), "test_proc");
+        ActorSupervisionEvent::new(
+            proc_id.actor_id(name, 0),
+            display_name,
+            ActorStatus::Failed(ActorErrorKind::Generic("boom".to_string())),
+            None,
+        )
+    }
+
+    // FA-3: MeshFailure::Display renders the mesh name in its prose
+    // when `actor_mesh_name` is Some, producing the "on mesh \"{name}\""
+    // segment alongside the stable id-bearing event.
+    #[test]
+    fn mesh_failure_display_renders_mesh_name_when_populated() {
+        let failure = MeshFailure {
+            actor_mesh_name: Some("training".to_string()),
+            event: test_event("actor_a", None),
+            crashed_ranks: vec![],
+        };
+        let rendered = format!("{}", failure);
+        assert!(
+            rendered.contains("on mesh \"training\""),
+            "expected rendered output to contain `on mesh \"training\"`; got: {rendered}"
+        );
+    }
+
+    // FA-3 degradation: when `actor_mesh_name` is None, the formatter
+    // omits the mesh segment — i.e., the invariant accommodates absent
+    // friendly fields without changing surrounding prose.
+    #[test]
+    fn mesh_failure_display_omits_mesh_segment_when_none() {
+        let failure = MeshFailure {
+            actor_mesh_name: None,
+            event: test_event("actor_a", None),
+            crashed_ranks: vec![],
+        };
+        let rendered = format!("{}", failure);
+        assert!(
+            !rendered.contains("on mesh"),
+            "expected no `on mesh` segment when actor_mesh_name is None; got: {rendered}"
+        );
+    }
+
+    // FA-3: when both mesh name and the event's Python-class
+    // display_name are populated, the rendered prose includes both,
+    // producing a user-readable attribution alongside the stable
+    // identifier carried in the event.
+    #[test]
+    fn mesh_failure_display_renders_mesh_and_python_class() {
+        let failure = MeshFailure {
+            actor_mesh_name: Some("training".to_string()),
+            event: test_event(
+                "actor_a",
+                Some("instance0.<my_module.Philosopher training>".to_string()),
+            ),
+            crashed_ranks: vec![],
+        };
+        let rendered = format!("{}", failure);
+        assert!(
+            rendered.contains("on mesh \"training\""),
+            "expected mesh name segment; got: {rendered}"
+        );
+        assert!(
+            rendered.contains("my_module.Philosopher"),
+            "expected Python-class segment from display_name; got: {rendered}"
+        );
+    }
+
+    // Shared fixture for the proofs: the exact synthesized event shape
+    // that `GlobalClientActor::handle_undeliverable_message` produces
+    // (`hyperactor_mesh/src/global_context.rs:278`): display_name =
+    // None, actor_status = generic_failure("message not delivered: ...").
+    fn undeliverable_synthesized_event() -> ActorSupervisionEvent {
+        let proc_id = reference::ProcId::with_name(ChannelAddr::Local(0), "worker_proc");
+        ActorSupervisionEvent::new(
+            proc_id.actor_id("dead_actor", 0),
+            None, // synthesized site has no PythonActor context; display_name stays None
+            ActorStatus::generic_failure(
+                "message not delivered: undeliverable message error: ... \
+                 error: broken link: message returned to global root client"
+                    .to_string(),
+            ),
+            None,
+        )
+    }
+
+    // --- Proof 1: motivating incident (root-client undeliverable) ---
+    //
+    // Path: transport bounces an undeliverable back to the root
+    // client; `GlobalClientActor::handle_undeliverable_message` at
+    // `global_context.rs:278` synthesizes an `ActorSupervisionEvent`
+    // with display_name = None and "message not delivered: ..."
+    // status. That event then propagates until it lands on a
+    // PythonActor's `handle_supervision_event`, where
+    // `PythonActor::handle_supervision_event` wraps it in a
+    // `MeshFailure`.
+    //
+    // Before the first increment: `MeshFailure.actor_mesh_name` on
+    // this direct-handle path was None (the site passed None).
+    //
+    // After the first increment (mesh-specific FA-1 in this
+    // module): `actor_mesh_name` is populated from
+    // `self.mesh_base_name` — Some("training") when the
+    // observing PythonActor was spawned with mesh base name
+    // "training".
+    //
+    // Limit of this increment: the synthesized event's display_name
+    // is still None because `global_context.rs:278` has no
+    // PythonActor context. That means the inner actor continues to
+    // render via raw ActorId text, even after the first increment.
+    // This is explicitly follow-on work (plan sections 8, 10 —
+    // requires Flattrs or lookup).
+    #[test]
+    fn proof_motivating_incident_root_client_undeliverable() {
+        let before = MeshFailure {
+            actor_mesh_name: None, // pre-increment direct-handle default
+            event: undeliverable_synthesized_event(),
+            crashed_ranks: vec![],
+        };
+        let after = MeshFailure {
+            actor_mesh_name: Some("training".to_string()), // post-increment: observing
+            // PythonActor's mesh_name
+            event: undeliverable_synthesized_event(),
+            crashed_ranks: vec![],
+        };
+        // Exact captured rendered strings — the user-visible prose
+        // produced on the supervision path for the motivating class,
+        // before and after the first increment. These are permanent
+        // evidence for the follow-up article; any regression on
+        // `MeshFailure::Display`, `ActorSupervisionEvent::Display`,
+        // or `actor_mesh_name` population on the direct-handle path
+        // will surface here.
+        let expected_before = "failure with event: Supervision event: \
+                               actor local:0,worker_proc,dead_actor[0] failed:\n  \
+                               message not delivered: undeliverable message error: \
+                               ... error: broken link: message returned to global \
+                               root client";
+        let expected_after = "failure on mesh \"training\" with event: \
+                              Supervision event: actor \
+                              local:0,worker_proc,dead_actor[0] failed:\n  \
+                              message not delivered: undeliverable message error: \
+                              ... error: broken link: message returned to global \
+                              root client";
+        assert_eq!(format!("{}", before), expected_before);
+        assert_eq!(format!("{}", after), expected_after);
+
+        // Observable improvement: the wrapper names the observer's
+        // mesh. Observable limit: the inner event actor still renders
+        // by raw id because `global_context.rs:278` synthesizes with
+        // display_name = None and has no PythonActor context to
+        // populate it. Fixing the inner render is explicitly
+        // follow-on work (Flattrs propagation or lookup-backed
+        // enrichment).
+    }
+
+    // --- Proof 2: direct actor-handled supervision (actor panic) ---
+    //
+    // Path: a PythonActor panics in a handler. `Proc::stop_actor`
+    // at `hyperactor/src/proc.rs:1642` constructs the
+    // ActorSupervisionEvent using `actor.display_name()`. For a
+    // PythonActor, that returns the Python-class-bearing
+    // `str(PyInstance)`. That event reaches a supervising
+    // PythonActor through the propagation chain, which wraps it in
+    // a MeshFailure via `handle_supervision_event` at
+    // `monarch_hyperactor/src/actor.rs:1072`.
+    //
+    // Before the first increment: `MeshFailure.actor_mesh_name`
+    // was None on the direct-handle path. Inner event display_name
+    // was already populated (existing behavior).
+    //
+    // After the first increment (FA-1 + already-consistent FA-2):
+    // `actor_mesh_name` carries the observing PythonActor's mesh
+    // name; the inner event continues to carry the Python-class
+    // display_name.
+    //
+    // This is the path that the first increment materially
+    // improves: both mesh name and Python-class attribution appear
+    // in the rendered prose.
+    #[test]
+    fn proof_direct_actor_handled_panic() {
+        let panicked_event = {
+            let proc_id = reference::ProcId::with_name(ChannelAddr::Local(0), "worker_proc");
+            ActorSupervisionEvent::new(
+                proc_id.actor_id("philosopher_1", 0),
+                // `Proc::stop_actor` populates this via
+                // `actor.display_name()` on a PythonActor — which
+                // returns the Python-class-bearing `str(PyInstance)`.
+                Some("instance0.<monarch_examples.dining.Philosopher training>".to_string()),
+                ActorStatus::Failed(ActorErrorKind::Generic(
+                    "IndexError: list index out of range".to_string(),
+                )),
+                None,
+            )
+        };
+        let before = MeshFailure {
+            actor_mesh_name: None, // pre-increment direct-handle default
+            event: panicked_event.clone(),
+            crashed_ranks: vec![],
+        };
+        let after = MeshFailure {
+            actor_mesh_name: Some("training".to_string()),
+            event: panicked_event,
+            crashed_ranks: vec![],
+        };
+        // Exact captured rendered strings — the user-visible prose
+        // for an actor-panic supervision event on the direct-handle
+        // path, before and after the first increment.
+        let expected_before = "failure with event: Supervision event: actor \
+                               instance0.<monarch_examples.dining.Philosopher \
+                               training> failed:\n  \
+                               IndexError: list index out of range";
+        let expected_after = "failure on mesh \"training\" with event: \
+                              Supervision event: actor \
+                              instance0.<monarch_examples.dining.Philosopher \
+                              training> failed:\n  \
+                              IndexError: list index out of range";
+        assert_eq!(format!("{}", before), expected_before);
+        assert_eq!(format!("{}", after), expected_after);
+
+        // Observable improvement: mesh name on the wrapper. Python
+        // class was already populated pre-increment by
+        // `Proc::stop_actor` via `actor.display_name()`; the first
+        // increment preserves it and adds the mesh segment.
+    }
+
+    // --- Proof 3: controller-unreachable ---
+    //
+    // Path: the controller for a mesh becomes unreachable. Code at
+    // `actor_mesh.rs:773-787` synthesizes a `MeshFailure` with
+    // `actor_mesh_name: Some(self.id().to_string())`. That slot is
+    // already populated on this path, so FA-1 is a no-op here.
+    // The inner event's display_name is None because the
+    // construction site has no PythonActor context — a gap that is
+    // explicitly follow-on per the FA-2 audit.
+    //
+    // This proof is included to be honest about where the
+    // increment does NOT improve output. The controller-unreachable
+    // path already benefited from the mesh-name slot; the
+    // display_name gap on the synthesized event remains for
+    // follow-on work.
+    #[test]
+    fn proof_controller_unreachable() {
+        let controller_timeout_event = {
+            let proc_id = reference::ProcId::with_name(ChannelAddr::Local(0), "controller_proc");
+            ActorSupervisionEvent::new(
+                proc_id.actor_id("training_controller", 0),
+                None, // synthesized site has no PythonActor context
+                ActorStatus::generic_failure(
+                    "timed out reaching controller ... Assuming controller's proc is dead"
+                        .to_string(),
+                ),
+                None,
+            )
+        };
+        // Both before and after have actor_mesh_name populated, and
+        // both have display_name = None — this path is unchanged by
+        // the first increment.
+        let unchanged = MeshFailure {
+            actor_mesh_name: Some("training".to_string()),
+            event: controller_timeout_event,
+            crashed_ranks: vec![],
+        };
+
+        // Exact captured rendered string — the user-visible prose
+        // for the controller-unreachable path, which is unchanged by
+        // the first increment. Recorded here so any future regression
+        // or improvement on this path surfaces explicitly.
+        let expected = "failure on mesh \"training\" with event: \
+                        Supervision event: actor \
+                        local:0,controller_proc,training_controller[0] \
+                        failed:\n  \
+                        timed out reaching controller ... Assuming \
+                        controller's proc is dead";
+        assert_eq!(format!("{}", unchanged), expected);
+
+        // No improvement in this increment: the mesh-name slot was
+        // already populated pre-increment (FA-1 is a no-op here),
+        // and the inner event's display_name is None because the
+        // construction site at `actor_mesh.rs:773-787` has no
+        // PythonActor context — follow-on work for this class.
+    }
 }

--- a/hyperactor_mesh/src/testactor.rs
+++ b/hyperactor_mesh/src/testactor.rs
@@ -369,7 +369,7 @@ impl Actor for WrapperActor {
     async fn init(&mut self, this: &Instance<Self>) -> anyhow::Result<()> {
         self.mesh = Some(
             self.proc_mesh
-                .spawn_with_name(this, self.test_name.clone(), &(), None, false)
+                .spawn_with_name(this, self.test_name.clone(), &(), None, None, false)
                 .await?,
         );
         Ok(())

--- a/hyperactor_mesh/src/testing.rs
+++ b/hyperactor_mesh/src/testing.rs
@@ -106,6 +106,7 @@ impl TestRootClient {
                         Some("testclient".into()),
                         status,
                         None,
+                        None,
                     )
                 }
             };

--- a/hyperactor_telemetry/src/lib.rs
+++ b/hyperactor_telemetry/src/lib.rs
@@ -356,7 +356,12 @@ pub struct MeshEvent {
     pub id: u64,
     /// Timestamp when the mesh was created
     pub timestamp: SystemTime,
-    /// Mesh class (e.g., "Proc", "Host", "Python<SomeUserDefinedActor>")
+    /// Mesh class. For user-level actor meshes this is the
+    /// structured actor-class token supplied at spawn time (for
+    /// Python actors, the qualified class name, e.g.
+    /// `"monarch_examples.dining.Philosopher"`). When the caller
+    /// supplies no structured class, this falls back to the Rust
+    /// actor type name (e.g. `"Proc"`, `"Host"`).
     pub class: String,
     /// User-provided name for this mesh
     pub given_name: String,

--- a/monarch_extension/src/mesh_controller.rs
+++ b/monarch_extension/src/mesh_controller.rs
@@ -1010,6 +1010,7 @@ impl Handler<MeshFailure> for MeshControllerActor {
                 message.event.clone(),
             ))),
             None,
+            None,
         )));
         Err(anyhow::Error::new(err))
     }

--- a/monarch_hyperactor/src/actor.rs
+++ b/monarch_hyperactor/src/actor.rs
@@ -545,6 +545,18 @@ pub struct PythonActor {
     spawn_point: OnceLock<Option<Point>>,
     /// Initial message to process during PythonActor::init.
     init_message: Option<PythonMessage>,
+    /// User-provided mesh base-name string plumbed from
+    /// `PythonActorParams`. This is mesh-name data — the base name the
+    /// caller supplied when the mesh was spawned — and is narrowly used
+    /// to populate `MeshFailure.actor_mesh_name` on the direct
+    /// actor-handle supervision path without a lookup
+    /// (mesh-specific FA-1 interpretation in
+    /// `hyperactor_mesh/src/supervision.rs`). It is NOT actor display
+    /// text (see FA-2 in `hyperactor/src/supervision.rs` for the rules
+    /// governing `display_name`) and it is NOT a general attribution
+    /// side channel; downstream code must not consume this field for
+    /// any other purpose.
+    mesh_base_name: Option<String>,
 }
 
 impl PythonActor {
@@ -552,6 +564,7 @@ impl PythonActor {
         actor_type: PickledPyObject,
         init_message: Option<PythonMessage>,
         spawn_point: Option<Point>,
+        mesh_base_name: Option<String>,
     ) -> Result<Self, anyhow::Error> {
         let use_queue_dispatch = hyperactor_config::global::get(ACTOR_QUEUE_DISPATCH);
 
@@ -585,6 +598,7 @@ impl PythonActor {
                     dispatch_mode,
                     spawn_point: OnceLock::from(spawn_point),
                     init_message,
+                    mesh_base_name,
                 })
             },
         )?)
@@ -648,6 +662,7 @@ impl PythonActor {
             actor_type,
             Some(init_message),
             Some(extent!().point_of_rank(0).unwrap()),
+            None, // root client actor has no user-facing mesh name
         )
         .expect("create client PythonActor");
 
@@ -1070,7 +1085,10 @@ impl Actor for PythonActor {
         self.handle(
             &cx,
             MeshFailure {
-                actor_mesh_name: None,
+                // Mesh-specific FA-1 (see hyperactor_mesh/src/supervision.rs):
+                // populate the mesh name from the base-name string plumbed
+                // through PythonActorParams at spawn time — no lookup.
+                actor_mesh_name: self.mesh_base_name.clone(),
                 event: event.clone(),
                 crashed_ranks: vec![],
             },
@@ -1086,13 +1104,32 @@ pub struct PythonActorParams {
     actor_type: PickledPyObject,
     // Python message to process as part of the actor initialization.
     init_message: Option<PythonMessage>,
+    // User-provided mesh base-name string under which this actor was
+    // spawned. This is mesh-name data — the base name the caller passed
+    // when the mesh was spawned — and is plumbed through `PythonActor`
+    // narrowly to populate `MeshFailure.actor_mesh_name` on the direct
+    // actor-handle supervision path without a lookup (mesh-specific
+    // FA-1 interpretation in `hyperactor_mesh/src/supervision.rs`).
+    // It is NOT actor display text (see FA-2 in
+    // `hyperactor/src/supervision.rs` for the rules governing
+    // `display_name`) and it is NOT a general attribution side
+    // channel; downstream code must not consume this field for any
+    // other purpose. Kept separate from `supervision_display_name`,
+    // which is a rendered supervision display string passed through
+    // `spawn_with_name(...)`.
+    mesh_base_name: Option<String>,
 }
 
 impl PythonActorParams {
-    pub(crate) fn new(actor_type: PickledPyObject, init_message: Option<PythonMessage>) -> Self {
+    pub(crate) fn new(
+        actor_type: PickledPyObject,
+        init_message: Option<PythonMessage>,
+        mesh_base_name: Option<String>,
+    ) -> Self {
         Self {
             actor_type,
             init_message,
+            mesh_base_name,
         }
     }
 }
@@ -1105,11 +1142,12 @@ impl RemoteSpawn for PythonActor {
         PythonActorParams {
             actor_type,
             init_message,
+            mesh_base_name,
         }: PythonActorParams,
         environment: Flattrs,
     ) -> Result<Self, anyhow::Error> {
         let spawn_point = environment.get(CAST_POINT);
-        Self::new(actor_type, init_message, spawn_point)
+        Self::new(actor_type, init_message, spawn_point, mesh_base_name)
     }
 }
 

--- a/monarch_hyperactor/src/actor.rs
+++ b/monarch_hyperactor/src/actor.rs
@@ -556,7 +556,15 @@ pub struct PythonActor {
     /// governing `display_name`) and it is NOT a general attribution
     /// side channel; downstream code must not consume this field for
     /// any other purpose.
-    mesh_base_name: Option<String>,
+    pub(crate) mesh_base_name: Option<String>,
+    /// Python actor class token (qualified class name, e.g.
+    /// `"monarch_examples.dining.Philosopher"`) plumbed from
+    /// `PythonActorParams`. Used to populate
+    /// `ActorSupervisionEvent.attribution.actor_class` on the direct
+    /// actor-handle supervision path. This is the structured class
+    /// carrier consumed by telemetry and consumers that previously
+    /// had to regex the rendered display-name string.
+    pub(crate) actor_class: Option<String>,
 }
 
 impl PythonActor {
@@ -565,6 +573,7 @@ impl PythonActor {
         init_message: Option<PythonMessage>,
         spawn_point: Option<Point>,
         mesh_base_name: Option<String>,
+        actor_class: Option<String>,
     ) -> Result<Self, anyhow::Error> {
         let use_queue_dispatch = hyperactor_config::global::get(ACTOR_QUEUE_DISPATCH);
 
@@ -599,6 +608,7 @@ impl PythonActor {
                     spawn_point: OnceLock::from(spawn_point),
                     init_message,
                     mesh_base_name,
+                    actor_class,
                 })
             },
         )?)
@@ -663,6 +673,7 @@ impl PythonActor {
             Some(init_message),
             Some(extent!().point_of_rank(0).unwrap()),
             None, // root client actor has no user-facing mesh name
+            None, // root client actor has no attribution actor_class
         )
         .expect("create client PythonActor");
 
@@ -834,6 +845,40 @@ impl PythonActor {
     }
 }
 
+/// Build the structured `Attribution` carrier for supervision events
+/// synthesized on a `PythonActor`'s behalf, from the three fields
+/// locally in scope on that `PythonActor`. Extracted so the mapping
+/// can be unit-tested without constructing a full `PythonActor`
+/// (which requires Python runtime).
+///
+/// Production callers are:
+/// - `actor_error_to_event` on the root-client error loop, and
+/// - `PythonActor::supervision_attribution`, which hyperactor's
+///   `proc.rs` invokes at worker-actor failure synthesis sites via
+///   `Actor::supervision_attribution`.
+///
+/// Both pass the three fields read off `PythonActor` at the moment of
+/// synthesis and return an `Attribution` for the event.
+///
+/// `actor_display_name` on the returned `Attribution` mirrors the
+/// `display_name` argument to satisfy FA-2: when both are `Some`,
+/// they must be equal; the producer here guarantees that by copying.
+///
+/// Rank is `None` — per-instance rank is not in scope at either
+/// synthesis site.
+fn build_direct_handled_attribution(
+    mesh_base_name: Option<String>,
+    actor_class: Option<String>,
+    display_name: Option<String>,
+) -> hyperactor::supervision::Attribution {
+    hyperactor::supervision::Attribution {
+        mesh_name: mesh_base_name,
+        actor_class,
+        actor_display_name: display_name,
+        rank: None,
+    }
+}
+
 fn actor_error_to_event(
     instance: &Instance<PythonActor>,
     actor: &PythonActor,
@@ -843,11 +888,18 @@ fn actor_error_to_event(
         ActorErrorKind::UnhandledSupervisionEvent(event) => *event,
         _ => {
             let status = ActorStatus::generic_failure(err.kind.to_string());
+            let display_name = actor.display_name();
+            let attribution = build_direct_handled_attribution(
+                actor.mesh_base_name.clone(),
+                actor.actor_class.clone(),
+                display_name.clone(),
+            );
             ActorSupervisionEvent::new(
                 instance.self_id().clone(),
-                actor.display_name(),
+                display_name,
                 status,
                 None,
+                Some(attribution),
             )
         }
     }
@@ -1003,6 +1055,20 @@ impl Actor for PythonActor {
         })
     }
 
+    /// Substrate-local hook: supply structured supervision
+    /// attribution for events synthesized on this actor's behalf (see
+    /// `hyperactor/src/actor.rs`'s `Actor::supervision_attribution`).
+    /// Reuses the `build_direct_handled_attribution` helper so the
+    /// field mapping is identical to the monarch_hyperactor-side
+    /// `actor_error_to_event` path.
+    fn supervision_attribution(&self) -> Option<hyperactor::supervision::Attribution> {
+        Some(build_direct_handled_attribution(
+            self.mesh_base_name.clone(),
+            self.actor_class.clone(),
+            self.display_name(),
+        ))
+    }
+
     async fn handle_undeliverable_message(
         &mut self,
         ins: &Instance<Self>,
@@ -1098,26 +1164,42 @@ impl Actor for PythonActor {
     }
 }
 
+/// Spawn-time parameters for constructing a `PythonActor`.
+///
+/// This bundle carries the pickled actor type plus the narrow
+/// structured attribution inputs that are locally available at spawn
+/// time and needed later on the direct actor-handled supervision
+/// path. The fields here are intentionally kept distinct:
+/// `mesh_base_name` is mesh-name data and `actor_class` is structured
+/// class attribution.
 #[derive(Debug, Clone, Serialize, Deserialize, Named)]
 pub struct PythonActorParams {
-    // The pickled actor class to instantiate.
+    /// The pickled actor class to instantiate.
     actor_type: PickledPyObject,
-    // Python message to process as part of the actor initialization.
+    /// Python message to process as part of the actor initialization.
     init_message: Option<PythonMessage>,
-    // User-provided mesh base-name string under which this actor was
-    // spawned. This is mesh-name data — the base name the caller passed
-    // when the mesh was spawned — and is plumbed through `PythonActor`
-    // narrowly to populate `MeshFailure.actor_mesh_name` on the direct
-    // actor-handle supervision path without a lookup (mesh-specific
-    // FA-1 interpretation in `hyperactor_mesh/src/supervision.rs`).
-    // It is NOT actor display text (see FA-2 in
-    // `hyperactor/src/supervision.rs` for the rules governing
-    // `display_name`) and it is NOT a general attribution side
-    // channel; downstream code must not consume this field for any
-    // other purpose. Kept separate from `supervision_display_name`,
-    // which is a rendered supervision display string passed through
-    // `spawn_with_name(...)`.
+    /// User-provided mesh base-name string under which this actor was
+    /// spawned. This is mesh-name data — the base name the caller passed
+    /// when the mesh was spawned — and is plumbed through `PythonActor`
+    /// narrowly to populate `MeshFailure.actor_mesh_name` on the direct
+    /// actor-handle supervision path without a lookup (mesh-specific
+    /// FA-1 interpretation in `hyperactor_mesh/src/supervision.rs`).
+    /// It is NOT actor display text (see FA-2 in
+    /// `hyperactor/src/supervision.rs` for the rules governing
+    /// `display_name`) and it is NOT a general attribution side
+    /// channel; downstream code must not consume this field for any
+    /// other purpose. Kept separate from `supervision_display_name`,
+    /// which is a rendered supervision display string passed through
+    /// `spawn_with_name(...)`.
     mesh_base_name: Option<String>,
+    /// Python actor class token (qualified class name plumbed from
+    /// Python at spawn time). This is the structured class carrier
+    /// used to populate
+    /// `ActorSupervisionEvent.attribution.actor_class` on the direct
+    /// actor-handle supervision path. Distinct from `mesh_base_name`
+    /// (which describes the mesh) and from `supervision_display_name`
+    /// (which is rendered presentation).
+    actor_class: Option<String>,
 }
 
 impl PythonActorParams {
@@ -1125,11 +1207,13 @@ impl PythonActorParams {
         actor_type: PickledPyObject,
         init_message: Option<PythonMessage>,
         mesh_base_name: Option<String>,
+        actor_class: Option<String>,
     ) -> Self {
         Self {
             actor_type,
             init_message,
             mesh_base_name,
+            actor_class,
         }
     }
 }
@@ -1143,11 +1227,18 @@ impl RemoteSpawn for PythonActor {
             actor_type,
             init_message,
             mesh_base_name,
+            actor_class,
         }: PythonActorParams,
         environment: Flattrs,
     ) -> Result<Self, anyhow::Error> {
         let spawn_point = environment.get(CAST_POINT);
-        Self::new(actor_type, init_message, spawn_point, mesh_base_name)
+        Self::new(
+            actor_type,
+            init_message,
+            spawn_point,
+            mesh_base_name,
+            actor_class,
+        )
     }
 }
 
@@ -1437,6 +1528,7 @@ impl Handler<MeshFailure> for PythonActor {
                                     Box::new(message.event.clone()),
                                 )),
                                 None,
+                                None,
                             ),
                         ));
                         Err(anyhow::Error::new(err))
@@ -1486,6 +1578,7 @@ impl Handler<MeshFailure> for PythonActor {
                                 err.to_string(),
                                 Box::new(message.event.clone()),
                             )),
+                            None,
                             None,
                         ),
                     ));
@@ -1839,5 +1932,55 @@ mod tests {
             // 3) Starts with the expected prefix
             assert!(py_msg.starts_with(&expected_prefix));
         });
+    }
+
+    // Mapping proof for `build_direct_handled_attribution`: given
+    // the three inputs in scope on `PythonActor`, the builder
+    // produces an `Attribution` with the expected field mapping.
+    //
+    // Scope limit: this test exercises the extracted builder only.
+    // It does NOT prove that `actor_error_to_event` continues to
+    // call this builder; if a future refactor inlines or bypasses
+    // the builder, this test still passes. End-to-end coverage on
+    // the direct actor-handled path — including that the populated
+    // structured attributes survive through to the raised
+    // `SupervisionError` — lives in
+    // `fbcode//monarch/python/tests:test_actor_error` as
+    // `test_supervision_error_structured_attributes`.
+    #[test]
+    fn test_build_direct_handled_attribution_mapping() {
+        // Neutral tokens: the helper does not parse or validate these
+        // strings, so the test uses placeholders rather than
+        // production-shape values. The assertions are about the
+        // mapping from inputs to output fields, not about any string
+        // format.
+
+        // All three inputs present.
+        let a = super::build_direct_handled_attribution(
+            Some("MESH_NAME".to_string()),
+            Some("ACTOR_CLASS".to_string()),
+            Some("DISPLAY_NAME".to_string()),
+        );
+        assert_eq!(a.mesh_name.as_deref(), Some("MESH_NAME"));
+        assert_eq!(a.actor_class.as_deref(), Some("ACTOR_CLASS"));
+        assert_eq!(a.actor_display_name.as_deref(), Some("DISPLAY_NAME"));
+        // The helper always sets rank to None.
+        assert_eq!(a.rank, None);
+
+        // All inputs absent — the helper does not fabricate values.
+        let empty = super::build_direct_handled_attribution(None, None, None);
+        assert_eq!(empty.mesh_name, None);
+        assert_eq!(empty.actor_class, None);
+        assert_eq!(empty.actor_display_name, None);
+        assert_eq!(empty.rank, None);
+
+        // `display_name` is copied into `actor_display_name` verbatim
+        // — the helper never transforms it. Callers that pass the
+        // same value to both `ActorSupervisionEvent::new` and to this
+        // helper therefore satisfy the FA-2 no-divergence invariant
+        // by construction.
+        let mirrored =
+            super::build_direct_handled_attribution(None, None, Some("DISPLAY_NAME".to_string()));
+        assert_eq!(mirrored.actor_display_name.as_deref(), Some("DISPLAY_NAME"),);
     }
 }

--- a/monarch_hyperactor/src/actor_mesh.rs
+++ b/monarch_hyperactor/src/actor_mesh.rs
@@ -893,7 +893,7 @@ mod tests {
             .spawn::<PythonActor, _>(
                 instance,
                 "test_actors",
-                &PythonActorParams::new(pickled_type, None),
+                &PythonActorParams::new(pickled_type, None, None),
             )
             .await
             .unwrap();

--- a/monarch_hyperactor/src/actor_mesh.rs
+++ b/monarch_hyperactor/src/actor_mesh.rs
@@ -893,7 +893,7 @@ mod tests {
             .spawn::<PythonActor, _>(
                 instance,
                 "test_actors",
-                &PythonActorParams::new(pickled_type, None, None),
+                &PythonActorParams::new(pickled_type, None, None, None),
             )
             .await
             .unwrap();

--- a/monarch_hyperactor/src/proc.rs
+++ b/monarch_hyperactor/src/proc.rs
@@ -99,7 +99,7 @@ impl PyProc {
             Ok(PythonActorHandle {
                 inner: proc.spawn(
                     name.as_deref().unwrap_or("anon"),
-                    PythonActor::new(pickled_type, None, None)?,
+                    PythonActor::new(pickled_type, None, None, None)?,
                 )?,
             })
         })
@@ -118,7 +118,7 @@ impl PyProc {
             inner: signal_safe_block_on(py, async move {
                 proc.spawn(
                     name.as_deref().unwrap_or("anon"),
-                    PythonActor::new(pickled_type, None, None)?,
+                    PythonActor::new(pickled_type, None, None, None)?,
                 )
             })
             .map_err(|e| PyRuntimeError::new_err(e.to_string()))??,

--- a/monarch_hyperactor/src/proc.rs
+++ b/monarch_hyperactor/src/proc.rs
@@ -99,7 +99,7 @@ impl PyProc {
             Ok(PythonActorHandle {
                 inner: proc.spawn(
                     name.as_deref().unwrap_or("anon"),
-                    PythonActor::new(pickled_type, None, None, None)?,
+                    PythonActor::new(pickled_type, None, None, None, None)?,
                 )?,
             })
         })
@@ -118,7 +118,7 @@ impl PyProc {
             inner: signal_safe_block_on(py, async move {
                 proc.spawn(
                     name.as_deref().unwrap_or("anon"),
-                    PythonActor::new(pickled_type, None, None, None)?,
+                    PythonActor::new(pickled_type, None, None, None, None)?,
                 )
             })
             .map_err(|e| PyRuntimeError::new_err(e.to_string()))??,

--- a/monarch_hyperactor/src/proc_mesh.rs
+++ b/monarch_hyperactor/src/proc_mesh.rs
@@ -68,8 +68,22 @@ impl PyProcMesh {
 
 #[pymethods]
 impl PyProcMesh {
+    /// Spawn a Python actor mesh asynchronously.
+    ///
+    /// `name` is the user-provided mesh base name.
+    /// `supervision_display_name` is the rendered display string for
+    /// the spawned actor on the supervision path, i.e. the string
+    /// that may appear in `ActorSupervisionEvent.display_name` and in
+    /// supervision failure rendering.
+    /// `actor_class` is the qualified Python class name used as the
+    /// structured class-attribution carrier on the direct
+    /// actor-handled supervision path.
+    ///
+    /// These are intentionally separate carriers: mesh-name data,
+    /// rendered presentation, and structured class attribution are
+    /// not interchangeable.
     #[staticmethod]
-    #[pyo3(signature = (proc_mesh, instance, name, actor, init_message, emulated, supervision_display_name = None))]
+    #[pyo3(signature = (proc_mesh, instance, name, actor, init_message, emulated, supervision_display_name = None, actor_class = None))]
     fn spawn_async(
         proc_mesh: &mut PyShared,
         instance: &PyInstance,
@@ -78,6 +92,7 @@ impl PyProcMesh {
         init_message: &mut PendingMessage,
         emulated: bool,
         supervision_display_name: Option<String>,
+        actor_class: Option<String>,
     ) -> PyResult<Py<PyAny>> {
         let init_message = init_message.take()?;
         let task = proc_mesh.task()?.take_task()?;
@@ -93,20 +108,12 @@ impl PyProcMesh {
                 let pickled_type = PickledPyObject::pickle(actor.bind(py).as_any())?;
                 Ok((
                     slf.mesh_ref()?.clone(),
-                    // Plumb the user-provided mesh base-name string (the
-                    // `name` argument the caller passed to
-                    // `spawn_async`) into the actor as
-                    // `PythonActorParams.mesh_base_name`. The direct
-                    // actor-handle supervision path uses it to populate
-                    // `MeshFailure.actor_mesh_name` without a lookup
-                    // (mesh-specific FA-1 interpretation in
-                    // `hyperactor_mesh/src/supervision.rs`). This
-                    // carrier is mesh-name data only; it is NOT actor
-                    // display text and is kept deliberately separate
-                    // from `supervision_display_name` below, which is
-                    // the rendered supervision display string passed
-                    // through `spawn_with_name(...)`.
-                    PythonActorParams::new(pickled_type, Some(init_message), Some(name.clone())),
+                    PythonActorParams::new(
+                        pickled_type,
+                        Some(init_message),
+                        Some(name.clone()),
+                        actor_class.clone(),
+                    ),
                 ))
             })
             .await?;
@@ -117,14 +124,8 @@ impl PyProcMesh {
                     instance.deref(),
                     full_name,
                     &params,
-                    // `supervision_display_name` is the rendered
-                    // supervision display string. It is distinct from
-                    // `mesh_base_name` above: the latter is the mesh
-                    // base-name carrier used for
-                    // `MeshFailure.actor_mesh_name`; this is the
-                    // presentation-layer display name handed to
-                    // `spawn_with_name(...)` for supervision rendering.
                     supervision_display_name,
+                    actor_class,
                     false,
                 )
                 .await

--- a/monarch_hyperactor/src/proc_mesh.rs
+++ b/monarch_hyperactor/src/proc_mesh.rs
@@ -93,7 +93,20 @@ impl PyProcMesh {
                 let pickled_type = PickledPyObject::pickle(actor.bind(py).as_any())?;
                 Ok((
                     slf.mesh_ref()?.clone(),
-                    PythonActorParams::new(pickled_type, Some(init_message)),
+                    // Plumb the user-provided mesh base-name string (the
+                    // `name` argument the caller passed to
+                    // `spawn_async`) into the actor as
+                    // `PythonActorParams.mesh_base_name`. The direct
+                    // actor-handle supervision path uses it to populate
+                    // `MeshFailure.actor_mesh_name` without a lookup
+                    // (mesh-specific FA-1 interpretation in
+                    // `hyperactor_mesh/src/supervision.rs`). This
+                    // carrier is mesh-name data only; it is NOT actor
+                    // display text and is kept deliberately separate
+                    // from `supervision_display_name` below, which is
+                    // the rendered supervision display string passed
+                    // through `spawn_with_name(...)`.
+                    PythonActorParams::new(pickled_type, Some(init_message), Some(name.clone())),
                 ))
             })
             .await?;
@@ -104,6 +117,13 @@ impl PyProcMesh {
                     instance.deref(),
                     full_name,
                     &params,
+                    // `supervision_display_name` is the rendered
+                    // supervision display string. It is distinct from
+                    // `mesh_base_name` above: the latter is the mesh
+                    // base-name carrier used for
+                    // `MeshFailure.actor_mesh_name`; this is the
+                    // presentation-layer display name handed to
+                    // `spawn_with_name(...)` for supervision rendering.
                     supervision_display_name,
                     false,
                 )

--- a/monarch_hyperactor/src/supervision.rs
+++ b/monarch_hyperactor/src/supervision.rs
@@ -6,6 +6,15 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+//! Python-facing supervision boundary.
+//!
+//! See FA-* (failure-attribution invariants) in
+//! `hyperactor/src/supervision.rs` for the user-facing contract on
+//! supervision-path rendering. `SupervisionError`'s pyclass shape is
+//! unchanged by the first-increment plumbing; improvements come
+//! from the upstream `Display` chain having populated mesh name and
+//! Python-class `display_name`.
+
 use async_trait::async_trait;
 use hyperactor::Instance;
 use hyperactor_mesh::supervision::MeshFailure;

--- a/monarch_hyperactor/src/supervision.rs
+++ b/monarch_hyperactor/src/supervision.rs
@@ -9,11 +9,19 @@
 //! Python-facing supervision boundary.
 //!
 //! See FA-* (failure-attribution invariants) in
-//! `hyperactor/src/supervision.rs` for the user-facing contract on
-//! supervision-path rendering. `SupervisionError`'s pyclass shape is
-//! unchanged by the first-increment plumbing; improvements come
-//! from the upstream `Display` chain having populated mesh name and
-//! Python-class `display_name`.
+//! `hyperactor/src/supervision.rs` for the substrate contract on
+//! supervision-path rendering. This module adds additive structured
+//! attribution fields to `SupervisionError` (`mesh_name`,
+//! `actor_class`, `actor_display_name`, `rank`) that project
+//! directly from `failure.event.attribution`. Consumers read those
+//! fields programmatically instead of parsing `message` or the
+//! rendered prose.
+//!
+//! Invariant: `SupervisionError::set_endpoint_on_err(...)` must
+//! preserve the structured attribution fields when grafting an
+//! endpoint onto an existing supervision error. Endpoint grafting
+//! is a presentation-layer concern; it must not drop the
+//! structured carriers.
 
 use async_trait::async_trait;
 use hyperactor::Instance;
@@ -47,14 +55,54 @@ pub struct SupervisionError {
     #[pyo3(set)]
     pub endpoint: Option<String>,
     pub message: String,
+    /// Mesh name of the destination actor, when known at send or
+    /// synthesis time. Additive structured field populated from
+    /// `failure.event.attribution.mesh_name`; callers that want a
+    /// programmatic handle read this instead of parsing `message`.
+    #[pyo3(get)]
+    pub mesh_name: Option<String>,
+    /// Python actor class token, when known. Additive structured field
+    /// populated from `failure.event.attribution.actor_class`.
+    #[pyo3(get)]
+    pub actor_class: Option<String>,
+    /// Free-form rendered display name for the destination actor,
+    /// when known. Additive structured field populated from
+    /// `failure.event.attribution.actor_display_name`.
+    #[pyo3(get)]
+    pub actor_display_name: Option<String>,
+    /// Per-rank rank when the failure is per-rank. Additive structured
+    /// field populated from `failure.event.attribution.rank`.
+    #[pyo3(get)]
+    pub rank: Option<usize>,
 }
 
 #[pymethods]
 impl SupervisionError {
     #[new]
-    #[pyo3(signature = (message, endpoint=None))]
-    fn new(message: String, endpoint: Option<String>) -> Self {
-        SupervisionError { endpoint, message }
+    #[pyo3(signature = (
+        message,
+        endpoint=None,
+        mesh_name=None,
+        actor_class=None,
+        actor_display_name=None,
+        rank=None,
+    ))]
+    fn new(
+        message: String,
+        endpoint: Option<String>,
+        mesh_name: Option<String>,
+        actor_class: Option<String>,
+        actor_display_name: Option<String>,
+        rank: Option<usize>,
+    ) -> Self {
+        SupervisionError {
+            endpoint,
+            message,
+            mesh_name,
+            actor_class,
+            actor_display_name,
+            rank,
+        }
     }
 
     #[staticmethod]
@@ -85,22 +133,68 @@ impl SupervisionError {
 }
 
 impl SupervisionError {
-    // Not From<MeshFailure> because the return type needs to be PyErr.
-    #[allow(dead_code)]
+    /// Build a `PyErr` wrapping a `SupervisionError` populated from
+    /// a `MeshFailure`. Structured attribution fields are copied
+    /// from the root-cause event's `attribution` (via
+    /// `ActorSupervisionEvent::caused_by`, matching SV-1) so
+    /// consumers can read `e.mesh_name` / `e.actor_class` / etc.
+    /// without parsing `message` or the rendered prose.
+    ///
+    /// The chain walk is necessary because intermediate supervisor
+    /// synthesis sites wrap the root-cause event in a new
+    /// `ActorSupervisionEvent` whose own `attribution` is `None`;
+    /// reading `attribution` only on the top-level event would
+    /// miss the data the producer attached at the originating
+    /// site. Whether the structured fields are populated after the
+    /// walk depends on whether the originating site had the
+    /// attribution in scope when it constructed the event; callers
+    /// should treat these fields as best-effort and tolerate
+    /// `None`.
     pub(crate) fn new_err_from(failure: MeshFailure) -> PyErr {
         let event = failure.event;
         let message = event
             .failure_report()
             .unwrap_or_else(|| format!("{}", event));
-        Self::new_err(message)
+        // Walk to the root-cause event (SV-1) before reading
+        // attribution. Intermediate wrappers typically carry
+        // `attribution: None`; the data the producer attached
+        // lives on the leaf.
+        let source = event.caused_by();
+        let (mesh_name, actor_class, actor_display_name, rank) = match &source.attribution {
+            Some(a) => (
+                a.mesh_name.clone(),
+                a.actor_class.clone(),
+                a.actor_display_name.clone(),
+                a.rank,
+            ),
+            None => (None, None, None, None),
+        };
+        PyErr::new::<Self, _>((
+            message,
+            None::<String>,
+            mesh_name,
+            actor_class,
+            actor_display_name,
+            rank,
+        ))
     }
+
     /// Set the endpoint on a PyErr containing a SupervisionError.
     ///
-    /// If the error is a SupervisionError, sets its endpoint field and returns a new
-    /// error with the endpoint prefix. If not a SupervisionError, returns the original error.
+    /// If the error is a SupervisionError, sets its endpoint field
+    /// while preserving the structured attribution fields, and
+    /// returns a new error with the endpoint prefix. If not a
+    /// SupervisionError, returns the original error.
     pub fn set_endpoint_on_err(py: Python<'_>, err: PyErr, endpoint: String) -> PyErr {
         if let Ok(supervision_err) = err.value(py).extract::<SupervisionError>() {
-            Self::new_err_from_endpoint(supervision_err.message, endpoint)
+            PyErr::new::<Self, _>((
+                supervision_err.message,
+                Some(endpoint),
+                supervision_err.mesh_name,
+                supervision_err.actor_class,
+                supervision_err.actor_display_name,
+                supervision_err.rank,
+            ))
         } else {
             err
         }
@@ -177,4 +271,60 @@ pub fn register_python_bindings(module: &Bound<'_, PyModule>) -> PyResult<()> {
     module.add("SupervisionError", py.get_type::<SupervisionError>())?;
     module.add("MeshFailure", py.get_type::<PyMeshFailure>())?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use pyo3::Python;
+
+    use super::*;
+
+    /// Endpoint grafting must not drop structured attribution fields.
+    /// `SupervisionError::set_endpoint_on_err` builds a new error
+    /// with an endpoint annotation; this test locks in that
+    /// `mesh_name`, `actor_class`, `actor_display_name`, and `rank`
+    /// survive the graft.
+    ///
+    /// This is a preservation test: it validates that input values
+    /// round-trip through `set_endpoint_on_err` unchanged. It does
+    /// not validate any string format, so the test uses neutral
+    /// tokens rather than production-shape strings.
+    #[test]
+    fn test_set_endpoint_on_err_preserves_structured_fields() {
+        Python::initialize();
+        Python::attach(|py| {
+            // Construct a SupervisionError with all four structured
+            // fields populated by invoking the pyclass constructor.
+            // Tokens are neutral placeholders; this test is about
+            // preservation, not format.
+            let err_py = PyErr::new::<SupervisionError, _>((
+                "MESSAGE".to_string(),
+                None::<String>,
+                Some("MESH_NAME".to_string()),
+                Some("ACTOR_CLASS".to_string()),
+                Some("DISPLAY_NAME".to_string()),
+                Some(7usize),
+            ));
+
+            let grafted = SupervisionError::set_endpoint_on_err(py, err_py, "ENDPOINT".to_string());
+
+            let extracted: SupervisionError = grafted
+                .value(py)
+                .extract()
+                .expect("grafted PyErr is a SupervisionError");
+
+            // Endpoint grafted as expected.
+            assert_eq!(extracted.endpoint.as_deref(), Some("ENDPOINT"));
+            // Structured fields preserved verbatim.
+            assert_eq!(extracted.mesh_name.as_deref(), Some("MESH_NAME"));
+            assert_eq!(extracted.actor_class.as_deref(), Some("ACTOR_CLASS"));
+            assert_eq!(
+                extracted.actor_display_name.as_deref(),
+                Some("DISPLAY_NAME"),
+            );
+            assert_eq!(extracted.rank, Some(7usize));
+            // Message passes through unchanged.
+            assert_eq!(extracted.message, "MESSAGE");
+        });
+    }
 }

--- a/python/monarch/_rust_bindings/monarch_hyperactor/proc_mesh.pyi
+++ b/python/monarch/_rust_bindings/monarch_hyperactor/proc_mesh.pyi
@@ -27,6 +27,12 @@ class ProcMesh:
         init_message: PendingMessage,
         emulated: bool,
         supervision_display_name: str | None = None,
+        # Qualified Python class name for the actor being spawned,
+        # used as the structured class carrier on the supervision
+        # and telemetry paths. Distinct from
+        # `supervision_display_name`, which is rendered-presentation
+        # text.
+        actor_class: str | None = None,
     ) -> PythonActorMesh: ...
     @property
     def region(self) -> Region:

--- a/python/monarch/_rust_bindings/monarch_hyperactor/supervision.pyi
+++ b/python/monarch/_rust_bindings/monarch_hyperactor/supervision.pyi
@@ -13,11 +13,28 @@ from monarch._rust_bindings.monarch_hyperactor.pytokio import Shared
 
 @final
 class SupervisionError(RuntimeError):
-    """
-    Custom exception for supervision-related errors in monarch_hyperactor.
+    """Custom exception for supervision-related errors in
+    monarch_hyperactor.
+
+    Structured attribution fields (``mesh_name``, ``actor_class``,
+    ``actor_display_name``, ``rank``) are populated from
+    ``ActorSupervisionEvent.attribution`` upstream. Consumers should
+    read these attributes directly instead of parsing the rendered
+    message or ``__str__``. These fields are populated only on the
+    supervision paths that have been wired to carry attribution; on
+    other paths they may be ``None``.
     """
 
     endpoint: str | None  # Settable attribute
+
+    @property
+    def mesh_name(self) -> str | None: ...
+    @property
+    def actor_class(self) -> str | None: ...
+    @property
+    def actor_display_name(self) -> str | None: ...
+    @property
+    def rank(self) -> int | None: ...
 
 # TODO: Make this an exception subclass
 @final

--- a/python/monarch/_src/actor/proc_mesh.py
+++ b/python/monarch/_src/actor/proc_mesh.py
@@ -596,6 +596,16 @@ class ProcMesh(MeshTrait):
             self,
         )
 
+        # Pass the qualified Python class name through as
+        # `actor_class` so the direct actor-handled supervision path
+        # can populate `ActorSupervisionEvent.attribution.actor_class`
+        # without a regex round-trip through
+        # `supervision_display_name`. This is the structured
+        # attribution carrier; `supervision_display_name` is the
+        # rendered-presentation carrier. They are deliberately
+        # separate.
+        actor_class = f"{Class.__module__}.{Class.__name__}"
+
         actor_mesh = HyProcMesh.spawn_async(
             pm,
             instance._as_rust(),
@@ -604,6 +614,7 @@ class ProcMesh(MeshTrait):
             init_message,
             emulated=False,
             supervision_display_name=supervision_display_name,
+            actor_class=actor_class,
         )
 
         mesh = ActorMesh(Class, name, actor_mesh, self._region.as_shape(), self)

--- a/python/tests/test_actor_error.py
+++ b/python/tests/test_actor_error.py
@@ -691,6 +691,81 @@ async def test_actor_mesh_supervision_handling() -> None:
     await proc.stop()
 
 
+@pytest.mark.timeout(30)
+@parametrize_config(actor_queue_dispatch={True, False})
+@isolate_in_subprocess
+async def test_supervision_error_structured_attributes() -> None:
+    """
+    Covers the direct actor-handled supervision path only:
+
+    An endpoint raises `ActorFailureError`, and the worker's actor
+    runtime in `hyperactor/src/proc.rs` synthesizes the supervision
+    event — populating `attribution` via the
+    `Actor::supervision_attribution` hook that `PythonActor`
+    overrides — before the caller receives a `SupervisionError`. The
+    structured attribution fields are sourced from `PythonActor`
+    state at event-synthesis time and surface on the raised error;
+    this test proves they are visible from Python.
+
+    Scope: direct actor-handled path, one rank. No root-client
+    undeliverable, no comm forwarding, no controller-unreachable.
+    """
+    # Keep the client process from crashing when the supervision
+    # failure lands.
+    monarch.actor.unhandled_fault_hook = lambda failure: None
+
+    mesh_name = "error"
+    proc = spawn_procs_on_this_host({"gpus": 1})
+    e = proc.spawn(mesh_name, ErrorActor)
+
+    try:
+        await e.fail_with_supervision_error.call_one()
+        raise AssertionError(
+            "expected fail_with_supervision_error to raise SupervisionError"
+        )
+    except SupervisionError as err:
+        # Mesh name: the `name` argument passed to
+        # `proc.spawn(...)` is plumbed through to
+        # `ActorSupervisionEvent.attribution.mesh_name` on the direct
+        # actor-handled path.
+        assert err.mesh_name == mesh_name, (
+            f"expected mesh_name={mesh_name!r}, got {err.mesh_name!r}"
+        )
+
+        # Actor class: the qualified
+        # `f"{Class.__module__}.{Class.__name__}"` is passed through
+        # the spawn path to `attribution.actor_class`. The module
+        # part depends on how the test module is imported and is not
+        # stable across test harnesses, so we assert on the class
+        # suffix only.
+        assert err.actor_class is not None, "actor_class should be populated"
+        assert err.actor_class.endswith(".ErrorActor"), (
+            f"expected actor_class to end with '.ErrorActor', got {err.actor_class!r}"
+        )
+
+        # Display name: `PythonActor::display_name()` returns
+        # `str(PyInstance)`. That string's exact format is
+        # presentation-only (FA-2) and not a contract, so we only
+        # assert that it is populated. A substring match on the
+        # actor class suffix is a light sanity check that the
+        # display name relates to this actor.
+        assert err.actor_display_name is not None, (
+            "actor_display_name should be populated on the direct actor-handled path"
+        )
+        assert "ErrorActor" in err.actor_display_name, (
+            f"expected actor_display_name to mention ErrorActor, "
+            f"got {err.actor_display_name!r}"
+        )
+
+        # Rank is None on the direct actor-handled path — per-
+        # instance rank is not in scope at the synthesis site.
+        # Rank propagation on other supervision paths is out of
+        # scope for this test.
+        assert err.rank is None, f"expected rank=None, got {err.rank!r}"
+
+    await proc.stop()
+
+
 class HealthyActor(Actor):
     @endpoint
     async def check(self):


### PR DESCRIPTION
Summary:

this is the first of a small series of diffs whose overall goal is to make monarch supervision failures tell the user, plainly and correctly, what actually failed. today, when something goes wrong, the surfaced error often gives you a stack of actor ids and supervision wrappers with weak or missing attribution, so it is difficult to tell which actor was the root cause, which mesh it belonged to, and what python actor class was actually involved. in practice, users end up chasing ids through logs to reconstruct what failed. this work is intended to make that substantially better.

the direction of the series is to carry friendly attribution as structured data alongside the existing stable identifiers, so user-facing error rendering and programmatic consumers can use real attribution instead of trying to recover meaning from rendered strings, identifier text, or whatever happened to be available at the observation site.

this diff lays the foundation for that model. it adds a structured Attribution carrier to ActorSupervisionEvent, adds a narrow Actor::supervision_attribution() hook so actor-local synthesis sites can populate that carrier from data already in scope, and wires the python actor implementation to provide mesh name, qualified python class, and display name without lookup or regex recovery. it also exposes those structured fields on the python SupervisionError surface, updates worker-side supervision synthesis to populate them, and removes the telemetry regex path by having mesh telemetry read the structured actor class directly.

the result of this diff is that normal python worker failures now produce supervision events and python SupervisionErrors with programmatic attribution fields populated from the originating actor state, while keeping display_name as presentation-only. this establishes the substrate contract and proves the direct worker-failure path end to end.

follow-up diffs will complete the remaining propagation work for paths that do not synthesize failures directly at the originating actor, in particular attribution transport on refs and message headers, cast/direct-send stamping, comm forwarding, root-client and controller-unreachable synthesis, and the end-to-end proof matrix for the user-visible undeliverable cases that motivated this work.

Differential Revision: D101717021
