### PR TITLE
upgrading tokio to 1.52.1

### DIFF
--- a/hyperactor/Cargo.toml
+++ b/hyperactor/Cargo.toml
@@ -69,7 +69,7 @@ signal-hook-tokio = { version = "0.3.1", features = ["futures-v0_3"] }
 smol_str = "0.3.6"
 strum = { version = "0.27.1", features = ["derive"] }
 thiserror = "2.0.18"
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }
 tokio-rustls = { version = "0.26.4", features = ["logging", "ring", "tls12"], default-features = false }
 tokio-stream = { version = "0.1.18", features = ["fs", "io-util", "net", "signal", "sync", "time"] }
 tokio-util = { version = "0.7.18", features = ["full"] }

--- a/hyperactor_mesh/Cargo.toml
+++ b/hyperactor_mesh/Cargo.toml
@@ -72,7 +72,7 @@ serde_json = { version = "1.0.140", features = ["alloc", "float_roundtrip", "raw
 strum = { version = "0.27.1", features = ["derive"] }
 tempfile = "3.27.0"
 thiserror = "2.0.18"
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }
 tokio-rustls = { version = "0.26.4", features = ["logging", "ring", "tls12"], default-features = false }
 tokio-stream = { version = "0.1.18", features = ["fs", "io-util", "net", "signal", "sync", "time"] }
 tokio-util = { version = "0.7.18", features = ["full"] }

--- a/hyperactor_mesh_admin_tui/Cargo.toml
+++ b/hyperactor_mesh_admin_tui/Cargo.toml
@@ -29,7 +29,7 @@ ratatui = { version = "0.30", features = ["termion", "termwiz", "unstable-render
 reqwest = { version = "0.13.2", features = ["blocking", "charset", "cookies", "gzip", "http2", "json", "multipart", "rustls", "socks", "stream", "system-proxy"], default-features = false }
 serde = { version = "1.0.219", features = ["derive", "rc"] }
 serde_json = { version = "1.0.140", features = ["alloc", "float_roundtrip", "raw_value", "unbounded_depth"] }
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }
 urlencoding = "2.1.0"
 
 [lints]

--- a/hyperactor_telemetry/Cargo.toml
+++ b/hyperactor_telemetry/Cargo.toml
@@ -29,7 +29,7 @@ serde_json = { version = "1.0.140", features = ["alloc", "float_roundtrip", "raw
 serde_rusqlite = "0.40.1"
 smallvec = { version = "1.15", features = ["impl_bincode", "serde", "specialization", "union"] }
 smol_str = "0.3.6"
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }
 tracing = { version = "0.1.41", features = ["attributes", "valuable"] }
 tracing-appender = "0.2.4"
 tracing-core = { version = "0.1.33", features = ["valuable"] }

--- a/monarch_bench/Cargo.toml
+++ b/monarch_bench/Cargo.toml
@@ -9,4 +9,4 @@ license = "BSD-3-Clause"
 
 [dev-dependencies]
 criterion = { version = "0.5.1", features = ["async_tokio", "csv_output"] }
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }

--- a/monarch_conda/Cargo.toml
+++ b/monarch_conda/Cargo.toml
@@ -29,7 +29,7 @@ rattler_conda_types = "0.28.3"
 serde = { version = "1.0.219", features = ["derive", "rc"] }
 serde_json = { version = "1.0.140", features = ["alloc", "float_roundtrip", "raw_value", "unbounded_depth"] }
 sha2 = "0.10.6"
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }
 tokio-util = { version = "0.7.18", features = ["full"] }
 walkdir = "2.3"
 

--- a/monarch_distributed_telemetry/Cargo.toml
+++ b/monarch_distributed_telemetry/Cargo.toml
@@ -20,7 +20,7 @@ pyo3 = { version = "0.26", features = ["anyhow", "multiple-pymethods", "py-clone
 serde = { version = "1.0.219", features = ["derive", "rc"] }
 serde_json = { version = "1.0.140", features = ["alloc", "float_roundtrip", "raw_value", "unbounded_depth"] }
 serde_multipart = { version = "0.0.0", path = "../serde_multipart" }
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }
 tracing = { version = "0.1.41", features = ["attributes", "valuable"] }
 typeuri = { version = "0.0.0", path = "../typeuri" }
 

--- a/monarch_extension/Cargo.toml
+++ b/monarch_extension/Cargo.toml
@@ -37,7 +37,7 @@ pyo3 = { version = "0.26", features = ["anyhow", "multiple-pymethods", "py-clone
 pyo3-async-runtimes = { version = "0.26", features = ["attributes", "tokio-runtime"] }
 rdmaxcel-sys = { path = "../rdmaxcel-sys", optional = true }
 serde = { version = "1.0.219", features = ["derive", "rc"] }
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }
 torch-sys-cuda = { version = "0.0.0", path = "../torch-sys-cuda", optional = true }
 tracing = { version = "0.1.41", features = ["attributes", "valuable"] }
 wirevalue = { version = "0.0.0", path = "../wirevalue" }

--- a/monarch_hyperactor/Cargo.toml
+++ b/monarch_hyperactor/Cargo.toml
@@ -47,7 +47,7 @@ serde = { version = "1.0.219", features = ["derive", "rc"] }
 serde_json = { version = "1.0.140", features = ["alloc", "float_roundtrip", "raw_value", "unbounded_depth"] }
 serde_multipart = { version = "0.0.0", path = "../serde_multipart" }
 tempfile = "3.27.0"
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }
 tracing = { version = "0.1.41", features = ["attributes", "valuable"] }
 typeuri = { version = "0.0.0", path = "../typeuri" }
 wirevalue = { version = "0.0.0", path = "../wirevalue" }

--- a/monarch_introspection_snapshot/Cargo.toml
+++ b/monarch_introspection_snapshot/Cargo.toml
@@ -29,4 +29,4 @@ wirevalue = { version = "0.0.0", path = "../wirevalue" }
 [dev-dependencies]
 ndslice = { version = "0.0.0", path = "../ndslice" }
 tempfile = "3.27.0"
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }

--- a/monarch_rdma/Cargo.toml
+++ b/monarch_rdma/Cargo.toml
@@ -22,7 +22,7 @@ rdmaxcel-sys = { path = "../rdmaxcel-sys" }
 regex = "1.12.3"
 serde = { version = "1.0.219", features = ["derive", "rc"] }
 serde_multipart = { version = "0.0.0", path = "../serde_multipart" }
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }
 tokio-util = { version = "0.7.18", features = ["full"] }
 tracing = { version = "0.1.41", features = ["attributes", "valuable"] }
 typeuri = { version = "0.0.0", path = "../typeuri" }

--- a/monarch_rdma/examples/cuda_ping_pong/Cargo.toml
+++ b/monarch_rdma/examples/cuda_ping_pong/Cargo.toml
@@ -33,7 +33,7 @@ hyperactor_mesh = { version = "0.0.0", path = "../../../hyperactor_mesh" }
 monarch_rdma = { version = "0.0.0", path = "../.." }
 ndslice = { version = "0.0.0", path = "../../../ndslice" }
 serde = { version = "1.0.219", features = ["derive", "rc"] }
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }
 tracing = { version = "0.1.41", features = ["attributes", "valuable"] }
 tracing-subscriber = { version = "0.3.23", features = ["chrono", "env-filter", "json", "local-time", "parking_lot", "registry"] }
 typeuri = { version = "0.0.0", path = "../../../typeuri" }

--- a/monarch_rdma/examples/parameter_server/Cargo.toml
+++ b/monarch_rdma/examples/parameter_server/Cargo.toml
@@ -30,7 +30,7 @@ hyperactor_mesh = { version = "0.0.0", path = "../../../hyperactor_mesh" }
 monarch_rdma = { version = "0.0.0", path = "../.." }
 ndslice = { version = "0.0.0", path = "../../../ndslice" }
 serde = { version = "1.0.219", features = ["derive", "rc"] }
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }
 tracing = { version = "0.1.41", features = ["attributes", "valuable"] }
 tracing-subscriber = { version = "0.3.23", features = ["chrono", "env-filter", "json", "local-time", "parking_lot", "registry"] }
 typeuri = { version = "0.0.0", path = "../../../typeuri" }

--- a/monarch_tensor_worker/Cargo.toml
+++ b/monarch_tensor_worker/Cargo.toml
@@ -24,7 +24,7 @@ parking_lot = { version = "0.12.1", features = ["send_guard"] }
 pyo3 = { version = "0.26", features = ["anyhow", "multiple-pymethods", "py-clone"] }
 serde = { version = "1.0.219", features = ["derive", "rc"] }
 sorted-vec = "0.8.10"
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }
 torch-sys-cuda = { version = "0.0.0", path = "../torch-sys-cuda" }
 torch-sys2 = { version = "0.0.0", path = "../torch-sys2" }
 tracing = { version = "0.1.41", features = ["attributes", "valuable"] }

--- a/monarch_types/Cargo.toml
+++ b/monarch_types/Cargo.toml
@@ -17,7 +17,7 @@ typeuri = { version = "0.0.0", path = "../typeuri" }
 [dev-dependencies]
 anyhow = "1.0.102"
 timed_test = { version = "0.0.0", path = "../timed_test" }
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }
 
 [build-dependencies]
 build_utils = { path = "../build_utils" }

--- a/preempt_rwlock/Cargo.toml
+++ b/preempt_rwlock/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2024"
 license = "BSD-3-Clause"
 
 [dependencies]
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }
 
 [dev-dependencies]
 anyhow = "1.0.102"

--- a/struct_diff_patch/Cargo.toml
+++ b/struct_diff_patch/Cargo.toml
@@ -13,4 +13,4 @@ license = "BSD-3-Clause"
 paste = "1.0.14"
 struct_diff_patch_macros = { version = "0.0.0", path = "../struct_diff_patch_macros" }
 thiserror = "2.0.18"
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }

--- a/timed_test/Cargo.toml
+++ b/timed_test/Cargo.toml
@@ -21,4 +21,4 @@ quote = "1.0.45"
 syn = { version = "2.0.117", features = ["extra-traits", "fold", "full", "visit", "visit-mut"] }
 
 [dev-dependencies]
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }


### PR DESCRIPTION
Summary:
Upgrading `tokio` from `1.50.0` to `1.52.1`.
- All downstream consumers checked with arc rust-check — 0 errors.

Reviewed By: dtolnay

Differential Revision: D101580193
