### PR TITLE
[hyperactor] restructure reference::ProcId as newtype over ref_::ProcRef

### DIFF
--- a/hyper/src/commands/list.rs
+++ b/hyper/src/commands/list.rs
@@ -37,7 +37,7 @@ impl ListCommand {
 
         // Codify obtaining a proc's agent in `hyperactor_mesh` somewhere.
         let agent: reference::ActorRef<HostAgent> = reference::ActorRef::attest(
-            reference::ProcId::with_name(host, SERVICE_PROC_NAME)
+            reference::ProcId::from_resource_name(host, SERVICE_PROC_NAME)
                 .actor_id(HOST_MESH_AGENT_ACTOR_NAME, 0),
         );
 

--- a/hyper/src/commands/show.rs
+++ b/hyper/src/commands/show.rs
@@ -25,13 +25,13 @@ impl ShowCommand {
         match self.reference {
             reference::Reference::Proc(proc_id) => {
                 let host = proc_id.addr().clone();
-                let proc = proc_id.name().to_string();
+                let proc = proc_id.id().to_string();
                 let cx = context().await;
                 let client = cx.actor_instance;
 
                 // Codify obtaining a proc's agent in `hyperactor_mesh` somewhere.
                 let agent: reference::ActorRef<HostAgent> = reference::ActorRef::attest(
-                    reference::ProcId::with_name(host, SERVICE_PROC_NAME)
+                    reference::ProcId::from_resource_name(host, SERVICE_PROC_NAME)
                         .actor_id(HOST_MESH_AGENT_ACTOR_NAME, 0),
                 );
 

--- a/hyperactor/src/host.rs
+++ b/hyperactor/src/host.rs
@@ -185,10 +185,11 @@ impl<M: ProcManager> Host<M> {
         // guaranteed by the ChannelAddr component, and the Name type's
         // '-' delimiter must not collide with a hash suffix.
         let service_proc_id =
-            reference::ProcId::with_name(frontend_addr.clone(), SERVICE_PROC_NAME);
+            reference::ProcId::from_resource_name(frontend_addr.clone(), SERVICE_PROC_NAME);
         let service_proc = Proc::configured(service_proc_id.clone(), router.boxed());
 
-        let local_proc_id = reference::ProcId::with_name(frontend_addr.clone(), LOCAL_PROC_NAME);
+        let local_proc_id =
+            reference::ProcId::from_resource_name(frontend_addr.clone(), LOCAL_PROC_NAME);
         let local_proc = Proc::configured(local_proc_id.clone(), router.boxed());
 
         tracing::info!(
@@ -259,7 +260,7 @@ impl<M: ProcManager> Host<M> {
             return Err(HostError::ProcExists(name));
         }
 
-        let proc_id = reference::ProcId::with_name(self.frontend_addr.clone(), &name);
+        let proc_id = reference::ProcId::from_resource_name(self.frontend_addr.clone(), &name);
         let handle = self
             .manager
             .spawn(proc_id.clone(), self.backend_addr.clone(), config)
@@ -562,7 +563,7 @@ impl<M: ProcManager + BulkTerminate> Host<M> {
         // Unbind procs from the router so if new procs are made with the same
         // names, they can use the same slot.
         for name in self.procs.drain() {
-            let proc_id = reference::ProcId::with_name(self.frontend_addr.clone(), &name);
+            let proc_id = reference::ProcId::from_resource_name(self.frontend_addr.clone(), &name);
             self.router.unbind(&proc_id.into());
         }
         summary
@@ -1468,7 +1469,7 @@ mod tests {
         let (proc_id1, _ref) = host.spawn("proc1".to_string(), ()).await.unwrap();
         assert_eq!(
             proc_id1,
-            reference::ProcId::with_name(host.addr().clone(), "proc1")
+            reference::ProcId::from_resource_name(host.addr().clone(), "proc1")
         );
         assert!(procs.lock().await.contains_key(&proc_id1));
 
@@ -1607,7 +1608,7 @@ mod tests {
     async fn local_ready_and_wait_are_immediate() {
         // Build a LocalHandle directly.
         let addr = ChannelAddr::any(ChannelTransport::Local);
-        let proc_id = reference::ProcId::with_name(addr.clone(), "p");
+        let proc_id = reference::ProcId::from_resource_name(addr.clone(), "p");
         let agent_ref = reference::ActorRef::<()>::attest(proc_id.actor_id("host_agent", 0));
         let h = LocalHandle::<()> {
             proc_id,

--- a/hyperactor/src/introspect.rs
+++ b/hyperactor/src/introspect.rs
@@ -1055,7 +1055,7 @@ mod tests {
     }
 
     fn test_actor_id(proc_name: &str, actor_name: &str, pid: usize) -> crate::reference::ActorId {
-        ProcId::with_name(ChannelAddr::Local(0), proc_name).actor_id(actor_name, pid)
+        ProcId::from_resource_name(ChannelAddr::Local(0), proc_name).actor_id(actor_name, pid)
     }
 
     fn failed_actor_attrs() -> Attrs {
@@ -1191,7 +1191,7 @@ mod tests {
     /// integration coverage.
     #[test]
     fn test_fi7_fi8_propagated_stopped_child() {
-        let proc_id = ProcId::with_name(ChannelAddr::Local(0), "test_proc");
+        let proc_id = ProcId::from_resource_name(ChannelAddr::Local(0), "test_proc");
         let child_id = proc_id.actor_id("proc_agent", 0);
         let parent_id = proc_id.actor_id("mesh_actor", 0);
 

--- a/hyperactor/src/mailbox.rs
+++ b/hyperactor/src/mailbox.rs
@@ -2972,7 +2972,7 @@ mod tests {
         );
         // The format is: "{proc_id},{actor_name}[{pid}]: {error}"
         // proc_id = "{addr},{proc_name}" so overall: "{addr},{proc_name},{actor_name}[{pid}]"
-        assert!(format!("{}", err).ends_with(",test_myworld_2,myactor[5]: mailbox closed"));
+        assert!(format!("{}", err).ends_with(",_test_myworld_2,myactor[5]: mailbox closed"));
     }
 
     #[tokio::test]
@@ -3307,7 +3307,12 @@ mod tests {
             handles.push(handle);
 
             eprintln!("{}: {}", mbox.actor_id(), addr);
-            if mbox.actor_id().proc_id().name().starts_with("world0") {
+            if mbox
+                .actor_id()
+                .proc_id()
+                .label()
+                .is_some_and(|l| l.as_str().starts_with("world0"))
+            {
                 world0_router.bind(mbox.actor_id().clone().into(), addr);
             } else {
                 world1_router.bind(mbox.actor_id().clone().into(), addr);

--- a/hyperactor/src/proc.rs
+++ b/hyperactor/src/proc.rs
@@ -428,7 +428,7 @@ impl Proc {
     /// Create a new direct-addressed proc.
     pub fn direct(addr: ChannelAddr, name: String) -> Result<Self, ChannelError> {
         let (addr, rx) = channel::serve(addr)?;
-        let proc_id = reference::ProcId::with_name(addr, name);
+        let proc_id = reference::ProcId::from_resource_name(addr, name);
         let proc = Self::configured(proc_id, DialMailboxRouter::new().into_boxed());
         let handle = proc.clone().serve(rx);
         *proc.inner.mailbox_server_handle.lock().unwrap() = Some(handle);

--- a/hyperactor/src/reference.rs
+++ b/hyperactor/src/reference.rs
@@ -55,12 +55,15 @@ use crate::actor::Referable;
 use crate::channel::ChannelAddr;
 use crate::context;
 use crate::context::MailboxExt;
+use crate::id::Label;
+use crate::id::Uid;
 use crate::mailbox::MailboxSenderError;
 use crate::mailbox::MailboxSenderErrorKind;
 use crate::mailbox::PortSink;
 use crate::message::Bind;
 use crate::message::Bindings;
 use crate::message::Unbind;
+use crate::ref_;
 
 pub mod lex;
 pub mod name;
@@ -255,22 +258,22 @@ impl FromStr for Reference {
 
                     // channeladdr,proc_name
                     Token::Elem(proc_name) =>
-                    Self::Proc(ProcId::with_name(channel_addr, proc_name)),
+                    Self::Proc(ProcId::from_resource_name(channel_addr, proc_name)),
 
                     // channeladdr,proc_name,actor_name
                     Token::Elem(proc_name) Token::Comma Token::Elem(actor_name) =>
-                    Self::Actor(ActorId::new(ProcId::with_name(channel_addr, proc_name), actor_name, 0)),
+                    Self::Actor(ActorId::new(ProcId::from_resource_name(channel_addr, proc_name), actor_name, 0)),
 
                     // channeladdr,proc_name,actor_name[pid]
                     Token::Elem(proc_name) Token::Comma Token::Elem(actor_name)
                         Token::LeftBracket Token::Uint(pid) Token::RightBracket =>
-                        Self::Actor(ActorId::new(ProcId::with_name(channel_addr, proc_name), actor_name, pid)),
+                        Self::Actor(ActorId::new(ProcId::from_resource_name(channel_addr, proc_name), actor_name, pid)),
 
                     // channeladdr,proc_name,actor_name[pid][port]
                     Token::Elem(proc_name) Token::Comma Token::Elem(actor_name)
                         Token::LeftBracket Token::Uint(pid) Token::RightBracket
                         Token::LeftBracket Token::Uint(index) Token::RightBracket  =>
-                        Self::Port(PortId::new(ActorId::new(ProcId::with_name(channel_addr, proc_name), actor_name, pid), index as u64)),
+                        Self::Port(PortId::new(ActorId::new(ProcId::from_resource_name(channel_addr, proc_name), actor_name, pid), index as u64)),
 
                     // channeladdr,proc_name,actor_name[pid][port<type>]
                     Token::Elem(proc_name) Token::Comma Token::Elem(actor_name)
@@ -278,7 +281,7 @@ impl FromStr for Reference {
                         Token::LeftBracket Token::Uint(index)
                             Token::LessThan Token::Elem(_type) Token::GreaterThan
                         Token::RightBracket =>
-                        Self::Port(PortId::new(ActorId::new(ProcId::with_name(channel_addr, proc_name), actor_name, pid), index as u64)),
+                        Self::Port(PortId::new(ActorId::new(ProcId::from_resource_name(channel_addr, proc_name), actor_name, pid), index as u64)),
                 }?)
             }
 
@@ -312,9 +315,49 @@ impl From<PortId> for Reference {
 /// into a sequence.
 pub type Index = usize;
 
-/// Procs are identified by a direct channel address and local name.
-/// Each proc represents an actor runtime that can locally route to all of its
-/// constituent actors.
+/// Parse a name in ResourceId format into a (Uid, Option<Label>) pair.
+///
+/// Formats: `_label` (singleton), `label-hex16` (labeled instance),
+/// `hex16` (unlabeled instance). Falls back to singleton from stripped name.
+fn parse_resource_name(s: &str) -> (Uid, Option<Label>) {
+    // Singleton: _label
+    if let Some(rest) = s.strip_prefix('_') {
+        if let Ok(label) = Label::new(rest) {
+            return (Uid::Singleton(label), None);
+        }
+    }
+
+    // Labeled instance: label-hex16 (exactly 16 hex digits after the last dash
+    // at position len-17).
+    if s.len() >= 18 {
+        let dash_pos = s.len() - 17;
+        if s.as_bytes()[dash_pos] == b'-' {
+            let hex_part = &s[dash_pos + 1..];
+            let label_part = &s[..dash_pos];
+            if hex_part.len() == 16 && hex_part.chars().all(|c| c.is_ascii_hexdigit()) {
+                if let (Ok(uid), Ok(label)) =
+                    (u64::from_str_radix(hex_part, 16), Label::new(label_part))
+                {
+                    return (Uid::Instance(uid), Some(label));
+                }
+            }
+        }
+    }
+
+    // Unlabeled instance: bare hex16
+    if s.len() <= 16 && !s.is_empty() && s.chars().all(|c| c.is_ascii_hexdigit()) {
+        if let Ok(uid) = u64::from_str_radix(s, 16) {
+            return (Uid::Instance(uid), None);
+        }
+    }
+
+    // Fallback: singleton from stripped name
+    let label = Label::strip(s);
+    (Uid::Singleton(label.clone()), Some(label))
+}
+
+/// Procs are identified by a process reference, which pairs a unique identity
+/// with a network location.
 #[derive(
     Debug,
     Serialize,
@@ -327,69 +370,90 @@ pub type Index = usize;
     Ord,
     typeuri::Named
 )]
-pub struct ProcId(ChannelAddr, String);
-
-/// Compute an 8-char hex hash suffix from a [`ChannelAddr`].
-fn addr_hash_suffix(addr: &ChannelAddr) -> String {
-    use std::collections::hash_map::DefaultHasher;
-    let mut hasher = DefaultHasher::new();
-    addr.hash(&mut hasher);
-    format!("{:08x}", hasher.finish() as u32)
-}
+#[serde(transparent)]
+pub struct ProcId(ref_::ProcRef);
 
 impl ProcId {
-    /// Create a ProcId with a globally-unique name: `"{base_name}-{hash_of_addr}"`.
-    ///
-    /// Use this for well-known / fixed proc names (e.g. `"service"`, `"local"`)
-    /// that are not already unique across hosts.
-    pub fn unique(addr: ChannelAddr, base_name: impl Into<String>) -> Self {
-        let base = base_name.into();
-        let suffix = addr_hash_suffix(&addr);
-        Self(addr, format!("{}-{}", base, suffix))
+    /// Create a ProcId with a unique (random) uid and the given label.
+    pub fn unique(addr: ChannelAddr, base_name: impl AsRef<str>) -> Self {
+        let label = Label::strip(base_name.as_ref());
+        Self(ref_::ProcRef::new(
+            crate::id::ProcId::instance(label),
+            ref_::Location::from(addr),
+        ))
     }
 
-    /// Create a ProcId with an already-unique name (no suffix added).
+    /// Create a ProcId by parsing a name string in ResourceId format.
     ///
-    /// Use this for deserialization, test helpers, and names that already
-    /// contain a UUID or other uniquifying component.
-    pub fn with_name(addr: ChannelAddr, name: impl Into<String>) -> Self {
-        Self(addr, name.into())
+    /// Recognizes three formats:
+    /// - `_label` → singleton uid
+    /// - `label-hex16` → labeled instance uid (hex16 = exactly 16 hex digits)
+    /// - `hex16` → unlabeled instance uid
+    ///
+    /// Falls back to `Uid::Singleton(Label::strip(name))` if none match.
+    pub fn from_resource_name(addr: ChannelAddr, name: impl AsRef<str>) -> Self {
+        let s = name.as_ref();
+        let (uid, label) = parse_resource_name(s);
+        Self(ref_::ProcRef::new(
+            crate::id::ProcId::new(uid, label),
+            ref_::Location::from(addr),
+        ))
     }
 
-    /// The base name before the `-{hash}` suffix, if present.
-    ///
-    /// If the name ends with `-XXXXXXXX` (8 hex chars), returns the part
-    /// before that suffix. Otherwise returns the full name.
-    pub fn base_name(&self) -> &str {
-        match self.1.rsplit_once('-') {
-            Some((base, suffix))
-                if suffix.len() == 8 && suffix.chars().all(|c| c.is_ascii_hexdigit()) =>
-            {
-                base
-            }
-            _ => &self.1,
-        }
+    /// Wrap an existing [`ref_::ProcRef`].
+    pub fn from_proc_ref(proc_ref: ref_::ProcRef) -> Self {
+        Self(proc_ref)
     }
 
-    /// Create an actor ID with the provided name, pid within this proc.
+    /// Create an actor ID with the provided name and pid within this proc.
     pub fn actor_id(&self, name: impl Into<String>, pid: Index) -> ActorId {
         ActorId(self.clone(), name.into(), pid)
     }
 
     /// The proc's channel address.
     pub fn addr(&self) -> &ChannelAddr {
+        self.0.location().addr()
+    }
+
+    /// The underlying process identity.
+    pub fn id(&self) -> &crate::id::ProcId {
+        self.0.id()
+    }
+
+    /// The underlying process reference.
+    pub fn proc_ref(&self) -> &ref_::ProcRef {
         &self.0
     }
 
-    /// The proc's name.
-    pub fn name(&self) -> &str {
-        &self.1
+    /// The proc's uid.
+    pub fn uid(&self) -> &Uid {
+        self.0.id().uid()
+    }
+
+    /// The proc's label: the explicit metadata label for instances,
+    /// or the singleton name for singletons.
+    pub fn label(&self) -> Option<&Label> {
+        self.0.id().label().or_else(|| match self.0.id().uid() {
+            Uid::Singleton(label) => Some(label),
+            _ => None,
+        })
     }
 }
 
 impl fmt::Display for ProcId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{},{}", self.0, self.1)
+        // Compat format: "addr,resource_name" where resource_name is the
+        // ResourceId text form: _label | label-hex16 | hex16.
+        let id = self.0.id();
+        match (id.uid(), id.label()) {
+            (Uid::Singleton(label), _) => write!(f, "{},_{}", self.0.location().addr(), label),
+            (Uid::Instance(uid), Some(label)) => {
+                write!(f, "{},{}-{:016x}", self.0.location().addr(), label, uid)
+            }
+            (Uid::Instance(uid), None) => {
+                write!(f, "{},{:016x}", self.0.location().addr(), uid)
+            }
+        }
     }
 }
 
@@ -1182,12 +1246,19 @@ mod tests {
         let cases: Vec<(&str, Reference)> = vec![
             (
                 "tcp:[::1]:1234,test",
-                ProcId::with_name("tcp:[::1]:1234".parse::<ChannelAddr>().unwrap(), "test").into(),
+                ProcId::from_resource_name(
+                    "tcp:[::1]:1234".parse::<ChannelAddr>().unwrap(),
+                    "test",
+                )
+                .into(),
             ),
             (
                 "tcp:[::1]:1234,test,testactor[123]",
                 ActorId::new(
-                    ProcId::with_name("tcp:[::1]:1234".parse::<ChannelAddr>().unwrap(), "test"),
+                    ProcId::from_resource_name(
+                        "tcp:[::1]:1234".parse::<ChannelAddr>().unwrap(),
+                        "test",
+                    ),
                     "testactor",
                     123,
                 )
@@ -1198,7 +1269,10 @@ mod tests {
                 "tcp:[::1]:1234,test,testactor[0][123<my::type>]",
                 PortId::new(
                     ActorId::new(
-                        ProcId::with_name("tcp:[::1]:1234".parse::<ChannelAddr>().unwrap(), "test"),
+                        ProcId::from_resource_name(
+                            "tcp:[::1]:1234".parse::<ChannelAddr>().unwrap(),
+                            "test",
+                        ),
                         "testactor",
                         0,
                     ),
@@ -1248,7 +1322,10 @@ mod tests {
         wirevalue::register_type!(MyType);
         let port_id = PortId::new(
             ActorId::new(
-                ProcId::with_name("tcp:[::1]:1234".parse::<ChannelAddr>().unwrap(), "test"),
+                ProcId::from_resource_name(
+                    "tcp:[::1]:1234".parse::<ChannelAddr>().unwrap(),
+                    "test",
+                ),
                 "testactor",
                 1,
             ),
@@ -1256,7 +1333,7 @@ mod tests {
         );
         assert_eq!(
             port_id.to_string(),
-            "tcp:[::1]:1234,test,testactor[1][17867850292987402005<hyperactor::reference::tests::MyType>]"
+            "tcp:[::1]:1234,_test,testactor[1][17867850292987402005<hyperactor::reference::tests::MyType>]"
         );
     }
 

--- a/hyperactor/src/supervision.rs
+++ b/hyperactor/src/supervision.rs
@@ -220,7 +220,7 @@ mod tests {
     use crate::channel::ChannelAddr;
 
     fn test_event(name: &str, status: ActorStatus) -> ActorSupervisionEvent {
-        let proc_id = reference::ProcId::with_name(ChannelAddr::Local(0), "test_proc");
+        let proc_id = reference::ProcId::from_resource_name(ChannelAddr::Local(0), "test_proc");
         ActorSupervisionEvent::new(
             proc_id.actor_id(name, 0),
             Some(name.to_string()),
@@ -234,7 +234,7 @@ mod tests {
         addr: ChannelAddr,
         status: ActorStatus,
     ) -> ActorSupervisionEvent {
-        let proc_id = reference::ProcId::with_name(addr, "test_proc");
+        let proc_id = reference::ProcId::from_resource_name(addr, "test_proc");
         ActorSupervisionEvent::new(proc_id.actor_id(name, 0), None, status, None)
     }
 
@@ -548,7 +548,7 @@ mod tests {
     /// root cause for structured failure attribution.
     #[test]
     fn test_sv1_actually_failing_actor_returns_stopped_child() {
-        let proc_id = reference::ProcId::with_name(ChannelAddr::Local(0), "test_proc");
+        let proc_id = reference::ProcId::from_resource_name(ChannelAddr::Local(0), "test_proc");
         let child_id = proc_id.actor_id("proc_agent", 0);
         let parent_id = proc_id.actor_id("controller", 0);
 

--- a/hyperactor/src/testing/ids.rs
+++ b/hyperactor/src/testing/ids.rs
@@ -17,7 +17,7 @@ use crate::reference;
 
 /// Create a test `ProcId` with a local channel address and name `"test_{name}"`.
 pub fn test_proc_id(name: &str) -> reference::ProcId {
-    reference::ProcId::with_name(
+    reference::ProcId::from_resource_name(
         ChannelAddr::any(ChannelTransport::Local),
         format!("test_{name}"),
     )
@@ -25,7 +25,7 @@ pub fn test_proc_id(name: &str) -> reference::ProcId {
 
 /// Create a test `ProcId` with a custom address and name `"test_{name}"`.
 pub fn test_proc_id_with_addr(addr: ChannelAddr, name: &str) -> reference::ProcId {
-    reference::ProcId::with_name(addr, format!("test_{name}"))
+    reference::ProcId::from_resource_name(addr, format!("test_{name}"))
 }
 
 /// Create a test `ActorId` with pid 0.

--- a/hyperactor_mesh/src/alloc.rs
+++ b/hyperactor_mesh/src/alloc.rs
@@ -716,8 +716,8 @@ pub(crate) mod testing {
             .keys()
             .filter_map(|proc_id| {
                 proc_id
-                    .name()
-                    .rsplit_once('_')
+                    .label()
+                    .and_then(|l| l.as_str().rsplit_once('_'))
                     .map(|(prefix, _)| prefix.to_string())
             })
             .collect();
@@ -747,7 +747,7 @@ pub(crate) mod testing {
             DialMailboxRouter::new_with_default((UndeliverableMailboxSender {}).into_boxed());
         router.clone().serve(router_rx);
 
-        let client_proc_id = hyperactor_reference::ProcId::with_name(
+        let client_proc_id = hyperactor_reference::ProcId::from_resource_name(
             ChannelAddr::any(ChannelTransport::Local),
             "test_stuck_0",
         );

--- a/hyperactor_mesh/src/alloc/local.rs
+++ b/hyperactor_mesh/src/alloc/local.rs
@@ -171,7 +171,8 @@ impl Alloc for LocalAlloc {
                         Some(name) => name.clone(),
                         None => format!("{}_{}", self.alloc_name.name(), rank),
                     };
-                    let proc_id = hyperactor_reference::ProcId::with_name(addr.clone(), proc_name);
+                    let proc_id =
+                        hyperactor_reference::ProcId::from_resource_name(addr.clone(), proc_name);
 
                     let bspan = tracing::info_span!("mesh_agent_bootstrap");
                     let (proc, mesh_agent) = match ProcAgent::bootstrap(proc_id.clone()).await {

--- a/hyperactor_mesh/src/alloc/process.rs
+++ b/hyperactor_mesh/src/alloc/process.rs
@@ -434,9 +434,12 @@ impl ProcessAlloc {
     }
 
     fn index(&self, proc_id: &hyperactor_reference::ProcId) -> Result<usize, anyhow::Error> {
-        // ProcId names have format "{alloc_name}_{index}" (e.g., "abc123_0")
-        let name = proc_id.name();
-        let expected_prefix = format!("{}_", self.name);
+        // Alloc proc labels have format "{stripped_alloc_name}_{index}" (e.g., "abc123_0").
+        // The alloc name (a ShortUuid) is normalized through Label::strip to match the
+        // label stored in the ProcId.
+        let name = proc_id.label().map(|l| l.as_str()).unwrap_or("");
+        let stripped_alloc = hyperactor::id::Label::strip(&self.name.to_string());
+        let expected_prefix = format!("{}_", stripped_alloc);
         anyhow::ensure!(
             name.starts_with(&expected_prefix),
             "proc {} does not belong to alloc {}",
@@ -541,9 +544,13 @@ impl ProcessAlloc {
                         // For spawned processes, we use a temporary placeholder ProcId.
                         // The actual ProcId will be set when the process calls Hello with its address.
                         let temp_addr = ChannelAddr::any(ChannelTransport::Local);
-                        let proc_id = hyperactor_reference::ProcId::with_name(
+                        let proc_id = hyperactor_reference::ProcId::from_resource_name(
                             temp_addr,
-                            format!("{}_{}", self.alloc_name.name(), rank),
+                            format!(
+                                "{}_{}",
+                                hyperactor::id::Label::strip(self.alloc_name.name()),
+                                rank
+                            ),
                         );
                         let (handle, monitor) =
                             Child::monitored(rank, process, log_channel, tail_size, proc_id);
@@ -612,10 +619,10 @@ impl Alloc for ProcessAlloc {
 
                             let proc_name = match &self.spec.proc_name {
                                 Some(name) => name.clone(),
-                                None => format!("{}_{}", self.name, index),
+                                None => format!("{}_{}", hyperactor::id::Label::strip(&self.name.to_string()), index),
                             };
                             child.post(Allocator2Process::StartProc(
-                                hyperactor_reference::ProcId::with_name(addr.clone(), proc_name),
+                                hyperactor_reference::ProcId::from_resource_name(addr.clone(), proc_name),
                                 transport,
                             ));
                         }

--- a/hyperactor_mesh/src/bootstrap.rs
+++ b/hyperactor_mesh/src/bootstrap.rs
@@ -563,9 +563,12 @@ impl Bootstrap {
                     eprintln!("(bootstrap) PDEATHSIG disabled via config");
                 }
 
-                let (local_addr, name) = (proc_id.addr().clone(), proc_id.name());
+                let local_addr = proc_id.addr().clone();
                 // TODO provide a direct way to construct these
-                let serve_addr = format!("unix:{}", socket_dir_path.join(name).display());
+                let serve_addr = format!(
+                    "unix:{}",
+                    socket_dir_path.join(proc_id.id().to_string()).display()
+                );
                 let serve_addr = serve_addr.parse().unwrap();
 
                 // The following is a modified host::spawn_proc to support direct

--- a/hyperactor_mesh/src/bootstrap/mailbox.rs
+++ b/hyperactor_mesh/src/bootstrap/mailbox.rs
@@ -61,22 +61,22 @@ impl MailboxSender for LocalProcDialer {
     ) {
         let proc_id = envelope.dest().actor_id().proc_id();
         let addr = proc_id.addr();
-        let name = proc_id.name();
         if addr == &self.local_addr
             // ...and only non-system procs on that address; the rest are directly
             // reachable through the backend address.
-            && name.parse::<crate::mesh_id::ResourceId>().is_ok_and(|id| matches!(id.uid(), Uid::Instance(_)))
+            && matches!(proc_id.uid(), Uid::Instance(_))
         {
+            let key = proc_id.id().to_string();
             let senders = self.local_senders.read().unwrap();
-            let senders = if senders.contains_key(name) {
+            let senders = if senders.contains_key(&key) {
                 senders
             } else {
                 drop(senders);
                 let mut senders = self.local_senders.write().unwrap();
-                senders.entry(name.to_string()).or_insert_with(|| {
-                    let socket_path = self.socket_dir.join(name);
+                senders.entry(key.clone()).or_insert_with(|| {
+                    let socket_path = self.socket_dir.join(&key);
                     if socket_path.exists() {
-                        let addr = format!("unix:{}", self.socket_dir.join(name).display());
+                        let addr = format!("unix:{}", socket_path.display());
                         let addr = addr.parse().unwrap();
                         MailboxClient::dial(addr)
                     } else {
@@ -90,7 +90,7 @@ impl MailboxSender for LocalProcDialer {
                 self.local_senders.read().unwrap()
             };
 
-            match senders.get(name).unwrap() {
+            match senders.get(&key).unwrap() {
                 Ok(sender) => sender.post_unchecked(envelope, return_handle),
                 Err(e) => {
                     let err = DeliveryError::BrokenLink(format!("failed to dial proc: {}", e));
@@ -153,13 +153,15 @@ mod tests {
         // construct the IDs directly rather than via test_proc_id.
         let local_addr: ChannelAddr = "tcp:3.4.5.6:123".parse().unwrap();
         let first_actor_id =
-            hyperactor_reference::ProcId::with_name(local_addr.clone(), first.to_string())
+            hyperactor_reference::ProcId::from_resource_name(local_addr.clone(), first.to_string())
                 .actor_id("actor", 0);
-        let second_actor_id =
-            hyperactor_reference::ProcId::with_name(local_addr.clone(), second.to_string())
-                .actor_id("actor", 0);
+        let second_actor_id = hyperactor_reference::ProcId::from_resource_name(
+            local_addr.clone(),
+            second.to_string(),
+        )
+        .actor_id("actor", 0);
         let third_notexist_actor_id =
-            hyperactor_reference::ProcId::with_name(local_addr.clone(), third.to_string())
+            hyperactor_reference::ProcId::from_resource_name(local_addr.clone(), third.to_string())
                 .actor_id("actor", 0);
         let proc_dialer = LocalProcDialer::new(
             local_addr.clone(),
@@ -209,7 +211,7 @@ mod tests {
 
         // System proc on the host (name must be exactly "system"):
         let system_actor_id =
-            hyperactor_reference::ProcId::with_name(local_addr.clone(), "system".to_string())
+            hyperactor_reference::ProcId::from_resource_name(local_addr.clone(), "system")
                 .actor_id("actor", 0);
         let envelope = MessageEnvelope::new(
             second_actor_id.clone(),

--- a/hyperactor_mesh/src/host_mesh.rs
+++ b/hyperactor_mesh/src/host_mesh.rs
@@ -126,12 +126,12 @@ impl HostRef {
 
     /// The ProcId for the proc with name `name` on this host.
     fn named_proc(&self, id: &ResourceId) -> hyperactor_reference::ProcId {
-        hyperactor_reference::ProcId::with_name(self.0.clone(), id.to_string())
+        hyperactor_reference::ProcId::from_resource_name(self.0.clone(), id.to_string())
     }
 
     /// The service proc on this host.
     fn service_proc(&self) -> hyperactor_reference::ProcId {
-        hyperactor_reference::ProcId::with_name(self.0.clone(), SERVICE_PROC_NAME)
+        hyperactor_reference::ProcId::from_resource_name(self.0.clone(), SERVICE_PROC_NAME)
     }
 
     /// Request an orderly teardown of this host and all procs it
@@ -1526,11 +1526,11 @@ impl HostMeshRef {
             },
         );
         for proc_id in procs.into_iter() {
-            let (addr, proc_name) = (proc_id.addr().clone(), proc_id.name().to_string());
+            let addr = proc_id.addr().clone();
             // The name stored in HostAgent is not the same as the
             // one stored in the ProcMesh. We instead take each proc id
             // and map it to that particular agent.
-            let proc_resource_id: ResourceId = proc_name.parse()?;
+            let proc_resource_id = ResourceId::new(proc_id.uid().clone(), proc_id.label().cloned());
             proc_names.push(proc_resource_id.clone());
 
             // Note that we don't send 1 message per host agent, we send 1 message
@@ -1634,12 +1634,12 @@ impl HostMeshRef {
         let mut proc_names = Vec::new();
         for proc_id in procs.iter() {
             num_ranks += 1;
-            let (addr, proc_name) = (proc_id.addr().clone(), proc_id.name().to_string());
+            let addr = proc_id.addr().clone();
 
             // Note that we don't send 1 message per host agent, we send 1 message
             // per proc.
             let host = HostRef(addr);
-            let proc_resource_id: ResourceId = proc_name.parse()?;
+            let proc_resource_id = ResourceId::new(proc_id.uid().clone(), proc_id.label().cloned());
             proc_names.push(proc_resource_id.clone());
             let mut reply = tx.bind();
             // If this proc dies or some other issue renders the reply undeliverable,

--- a/hyperactor_mesh/src/host_mesh/host_agent.rs
+++ b/hyperactor_mesh/src/host_mesh/host_agent.rs
@@ -1524,8 +1524,8 @@ mod tests {
                 }),
                 ..
             } if id == resource_id
-              && proc_id == hyperactor_reference::ProcId::with_name(host_addr.clone(), id.to_string())
-              && mesh_agent == hyperactor_reference::ActorRef::attest(hyperactor_reference::ProcId::with_name(host_addr.clone(), id.to_string()).actor_id(crate::proc_agent::PROC_AGENT_ACTOR_NAME, 0)) && bootstrap_command == Some(BootstrapCommand::test())
+              && proc_id == hyperactor_reference::ProcId::from_resource_name(host_addr.clone(), id.to_string())
+              && mesh_agent == hyperactor_reference::ActorRef::attest(hyperactor_reference::ProcId::from_resource_name(host_addr.clone(), id.to_string()).actor_id(crate::proc_agent::PROC_AGENT_ACTOR_NAME, 0)) && bootstrap_command == Some(BootstrapCommand::test())
               && mesh_agent == proc_status_mesh_agent
         );
     }

--- a/hyperactor_mesh/src/introspect.rs
+++ b/hyperactor_mesh/src/introspect.rs
@@ -1257,7 +1257,7 @@ mod tests {
         use hyperactor::channel::ChannelAddr;
         use hyperactor::reference::ProcId;
         NodeRef::Actor(
-            ProcId::with_name(ChannelAddr::Local(0), proc_name).actor_id(actor_name, pid),
+            ProcId::from_resource_name(ChannelAddr::Local(0), proc_name).actor_id(actor_name, pid),
         )
     }
 
@@ -1657,7 +1657,7 @@ mod tests {
         let compiled = jsonschema::JSONSchema::compile(&schema_value).expect("schema must compile");
 
         let epoch = std::time::UNIX_EPOCH;
-        let proc_id = ProcId::with_name(ChannelAddr::Local(0), "worker");
+        let proc_id = ProcId::from_resource_name(ChannelAddr::Local(0), "worker");
         let actor_id = proc_id.actor_id("actor", 0);
 
         let samples = [

--- a/hyperactor_mesh/src/introspect/dto.rs
+++ b/hyperactor_mesh/src/introspect/dto.rs
@@ -463,7 +463,7 @@ mod tests {
     // Test fixtures
 
     fn test_proc_id() -> hyperactor::reference::ProcId {
-        hyperactor::reference::ProcId::with_name(
+        hyperactor::reference::ProcId::from_resource_name(
             hyperactor::channel::ChannelAddr::Local(0),
             "worker",
         )

--- a/hyperactor_mesh/src/mesh_admin.rs
+++ b/hyperactor_mesh/src/mesh_admin.rs
@@ -1415,7 +1415,10 @@ impl MeshAdminAgent {
             (children, system_children)
         };
 
-        let proc_name = proc_id.name().to_string();
+        let proc_name = proc_id
+            .label()
+            .map(|l| l.as_str().to_string())
+            .unwrap_or_else(|| proc_id.id().to_string());
 
         let mut attrs = hyperactor_config::Attrs::new();
         attrs.set(crate::introspect::NODE_TYPE, "proc".to_string());
@@ -2257,7 +2260,9 @@ impl ResolvedProcHandler {
 /// the probe (CFG-4).
 fn route_proc_handler(raw_proc_reference: &str) -> Result<ResolvedProcHandler, ApiError> {
     let (_proc_reference, proc_id) = parse_proc_reference(raw_proc_reference)?;
-    let is_service = proc_id.base_name() == SERVICE_PROC_NAME;
+    let is_service = proc_id
+        .label()
+        .is_some_and(|l| l.as_str() == SERVICE_PROC_NAME);
     if is_service {
         let agent_id = proc_id.actor_id(HOST_MESH_AGENT_ACTOR_NAME, 0);
         Ok(ResolvedProcHandler::Host(
@@ -2859,8 +2864,8 @@ async fn tree_dump(
 fn derive_tree_label(node_ref: &crate::introspect::NodeRef) -> String {
     match node_ref {
         crate::introspect::NodeRef::Root => "root".to_string(),
-        crate::introspect::NodeRef::Host(id) => id.proc_id().name().to_string(),
-        crate::introspect::NodeRef::Proc(id) => id.name().to_string(),
+        crate::introspect::NodeRef::Host(id) => id.proc_id().id().to_string(),
+        crate::introspect::NodeRef::Proc(id) => id.id().to_string(),
         crate::introspect::NodeRef::Actor(id) => {
             format!("{}{}", id.name(), format_args!("[{}]", id.pid()))
         }
@@ -2871,7 +2876,7 @@ fn derive_actor_label(node_ref: &crate::introspect::NodeRef) -> String {
     match node_ref {
         crate::introspect::NodeRef::Root => "root".to_string(),
         crate::introspect::NodeRef::Host(id) => id.name().to_string(),
-        crate::introspect::NodeRef::Proc(id) => id.name().to_string(),
+        crate::introspect::NodeRef::Proc(id) => id.id().to_string(),
         crate::introspect::NodeRef::Actor(id) => {
             format!("{}[{}]", id.name(), id.pid())
         }
@@ -3555,7 +3560,7 @@ mod tests {
                 .unwrap();
             let node = resp.0.unwrap();
             if let NodeProperties::Proc { proc_name, .. } = &node.properties {
-                if proc_name.contains(&user_proc_name_str) {
+                if user_proc_name_str.contains(proc_name.as_str()) {
                     found_user = true;
                 } else {
                     found_system = true;
@@ -3578,13 +3583,14 @@ mod tests {
     #[test]
     fn test_build_root_payload_with_root_client() {
         let addr1: SocketAddr = "127.0.0.1:9001".parse().unwrap();
-        let proc1 = hyperactor_reference::ProcId::with_name(ChannelAddr::Tcp(addr1), "host1");
+        let proc1 =
+            hyperactor_reference::ProcId::from_resource_name(ChannelAddr::Tcp(addr1), "host1");
         let actor_id1 = hyperactor_reference::ActorId::root(proc1, "mesh_agent".to_string());
         let ref1: hyperactor_reference::ActorRef<HostAgent> =
             hyperactor_reference::ActorRef::attest(actor_id1.clone());
 
         let client_proc_id =
-            hyperactor_reference::ProcId::with_name(ChannelAddr::Tcp(addr1), "local");
+            hyperactor_reference::ProcId::from_resource_name(ChannelAddr::Tcp(addr1), "local");
         let client_actor_id = client_proc_id.actor_id("client", 0);
 
         let agent = MeshAdminAgent::new(
@@ -4390,9 +4396,9 @@ mod tests {
     fn route_proc_handler_service_proc_yields_host() {
         use hyperactor::reference::ProcId;
         let addr: SocketAddr = "127.0.0.1:9000".parse().unwrap();
-        // Use ProcId::with_name directly — test_proc_id_with_addr
+        // Use ProcId::from_resource_name directly — test_proc_id_with_addr
         // prepends "test_" which would not match SERVICE_PROC_NAME.
-        let proc_id = ProcId::with_name(ChannelAddr::Tcp(addr), SERVICE_PROC_NAME);
+        let proc_id = ProcId::from_resource_name(ChannelAddr::Tcp(addr), SERVICE_PROC_NAME);
         let handler = route_proc_handler(&proc_id.to_string()).unwrap();
         assert!(
             matches!(handler, ResolvedProcHandler::Host(_)),

--- a/hyperactor_mesh/src/proc_agent.rs
+++ b/hyperactor_mesh/src/proc_agent.rs
@@ -557,7 +557,11 @@ impl ProcAgent {
         attrs.set(crate::introspect::NODE_TYPE, "proc".to_string());
         attrs.set(
             crate::introspect::PROC_NAME,
-            self.proc.proc_id().name().to_string(),
+            self.proc
+                .proc_id()
+                .label()
+                .map(|l| l.as_str().to_string())
+                .unwrap_or_else(|| self.proc.proc_id().id().to_string()),
         );
         attrs.set(crate::introspect::NUM_ACTORS, num_live);
         attrs.set(hyperactor::introspect::CHILDREN, children);
@@ -680,7 +684,13 @@ impl Actor for ProcAgent {
                     let num_live = children.len();
                     let mut attrs = hyperactor_config::Attrs::new();
                     attrs.set(crate::introspect::NODE_TYPE, "proc".to_string());
-                    attrs.set(crate::introspect::PROC_NAME, proc_id.name().to_string());
+                    attrs.set(
+                        crate::introspect::PROC_NAME,
+                        proc_id
+                            .label()
+                            .map(|l| l.as_str().to_string())
+                            .unwrap_or_else(|| proc_id.id().to_string()),
+                    );
                     attrs.set(crate::introspect::NUM_ACTORS, num_live);
                     attrs.set(crate::introspect::SYSTEM_CHILDREN, system_children);
                     attrs.set(crate::introspect::STOPPED_CHILDREN, stopped_children);

--- a/hyperactor_mesh/src/proc_launcher.rs
+++ b/hyperactor_mesh/src/proc_launcher.rs
@@ -283,7 +283,10 @@ pub struct LaunchOptions {
 /// `HYPERACTOR_PROCESS_NAME`, falling back to the machine hostname.
 /// This groups procs under their host process in traces and logs.
 pub fn format_process_name(proc_id: &hyperactor_reference::ProcId) -> String {
-    let who = proc_id.name();
+    let who = proc_id
+        .label()
+        .map(|l| l.as_str().to_string())
+        .unwrap_or_else(|| proc_id.id().to_string());
 
     let host = std::env::var(bootstrap::PROCESS_NAME_ENV).unwrap_or_else(|_| {
         hostname::get()

--- a/hyperactor_mesh/src/proc_launcher/native.rs
+++ b/hyperactor_mesh/src/proc_launcher/native.rs
@@ -806,7 +806,7 @@ mod tests {
             // v0 bootstrap by default but it doesn't matter here.
             let bootstrap = Bootstrap::default();
             let proc_id =
-                hyperactor_reference::ProcId::with_name(any_unix_addr(), "stdio-captured");
+                hyperactor_reference::ProcId::from_resource_name(any_unix_addr(), "stdio-captured");
             let opts = LaunchOptions {
                 command: with_sh(script),
                 bootstrap_payload: bootstrap.to_env_safe_string().unwrap(),
@@ -840,8 +840,10 @@ mod tests {
             let launcher = NativeProcLauncher::new();
             // v0 bootstrap by default but it doesn't matter here.
             let bootstrap = Bootstrap::default();
-            let proc_id =
-                hyperactor_reference::ProcId::with_name(any_unix_addr(), "stdio-inherited");
+            let proc_id = hyperactor_reference::ProcId::from_resource_name(
+                any_unix_addr(),
+                "stdio-inherited",
+            );
             let opts = LaunchOptions {
                 command: with_sh(script),
                 bootstrap_payload: bootstrap.to_env_safe_string().unwrap(),
@@ -879,7 +881,7 @@ mod tests {
         let launcher = NativeProcLauncher::new();
         // v0 bootstrap by default but it doesn't matter here.
         let bootstrap = Bootstrap::default();
-        let proc_id = hyperactor_reference::ProcId::with_name(any_unix_addr(), "exit-7");
+        let proc_id = hyperactor_reference::ProcId::from_resource_name(any_unix_addr(), "exit-7");
         let opts = LaunchOptions {
             command: with_sh("exit 7"),
             bootstrap_payload: bootstrap.to_env_safe_string().unwrap(),
@@ -918,7 +920,7 @@ mod tests {
         let launcher = NativeProcLauncher::new();
         // v0 bootstrap by default but it doesn't matter here.
         let bootstrap = Bootstrap::default();
-        let proc_id = hyperactor_reference::ProcId::with_name(any_unix_addr(), "killed");
+        let proc_id = hyperactor_reference::ProcId::from_resource_name(any_unix_addr(), "killed");
         let opts = LaunchOptions {
             command: with_sh("sleep 30"),
             bootstrap_payload: bootstrap.to_env_safe_string().unwrap(),
@@ -990,7 +992,8 @@ mod tests {
 
         // v0 bootstrap by default but it doesn't matter here.
         let bootstrap = Bootstrap::default();
-        let proc_id = hyperactor_reference::ProcId::with_name(any_unix_addr(), "term-escalate");
+        let proc_id =
+            hyperactor_reference::ProcId::from_resource_name(any_unix_addr(), "term-escalate");
         let opts = LaunchOptions {
             command: with_sh(script),
             bootstrap_payload: bootstrap.to_env_safe_string().unwrap(),
@@ -1077,7 +1080,8 @@ while True:
         };
 
         let bootstrap = Bootstrap::default();
-        let proc_id = hyperactor_reference::ProcId::with_name(any_unix_addr(), "drop-cleanup-test");
+        let proc_id =
+            hyperactor_reference::ProcId::from_resource_name(any_unix_addr(), "drop-cleanup-test");
         let opts = LaunchOptions {
             command,
             bootstrap_payload: bootstrap.to_env_safe_string().unwrap(),

--- a/hyperactor_mesh/src/proc_launcher/systemd.rs
+++ b/hyperactor_mesh/src/proc_launcher/systemd.rs
@@ -1190,7 +1190,7 @@ mod tests {
 
         let launcher = SystemdProcLauncher::new();
 
-        let proc_id = hyperactor_reference::ProcId::with_name(any_unix_addr(), "env-vars");
+        let proc_id = hyperactor_reference::ProcId::from_resource_name(any_unix_addr(), "env-vars");
         // v0 bootstrap by default but it doesn't matter here.
         let bootstrap = Bootstrap::default();
         let opts = LaunchOptions {
@@ -1289,7 +1289,7 @@ mod tests {
 
         // v0 bootstrap by default but it doesn't matter here.
         let bootstrap = Bootstrap::default();
-        let proc_id = hyperactor_reference::ProcId::with_name(any_unix_addr(), "exit-7");
+        let proc_id = hyperactor_reference::ProcId::from_resource_name(any_unix_addr(), "exit-7");
         let opts = LaunchOptions {
             command: with_sh("exit 7"),
             bootstrap_payload: bootstrap.to_env_safe_string().unwrap(),
@@ -1331,7 +1331,7 @@ mod tests {
 
         // v0 bootstrap by default but it doesn't matter here.
         let bootstrap = Bootstrap::default();
-        let proc_id = hyperactor_reference::ProcId::with_name(any_unix_addr(), "killed");
+        let proc_id = hyperactor_reference::ProcId::from_resource_name(any_unix_addr(), "killed");
         let opts = LaunchOptions {
             command: with_sh("sleep 30"),
             bootstrap_payload: bootstrap.to_env_safe_string().unwrap(),
@@ -1393,7 +1393,8 @@ mod tests {
 
         // v0 bootstrap by default but it doesn't matter here.
         let bootstrap = Bootstrap::default();
-        let proc_id = hyperactor_reference::ProcId::with_name(any_unix_addr(), "terminated");
+        let proc_id =
+            hyperactor_reference::ProcId::from_resource_name(any_unix_addr(), "terminated");
         let opts = LaunchOptions {
             command: with_sh("sleep 30"),
             bootstrap_payload: bootstrap.to_env_safe_string().unwrap(),
@@ -1437,7 +1438,8 @@ mod tests {
 
         let launcher = SystemdProcLauncher::new();
 
-        let unknown_proc_id = hyperactor_reference::ProcId::with_name(any_unix_addr(), "unknown");
+        let unknown_proc_id =
+            hyperactor_reference::ProcId::from_resource_name(any_unix_addr(), "unknown");
 
         let result = launcher
             .terminate(&unknown_proc_id, Duration::from_secs(1))
@@ -1459,7 +1461,8 @@ mod tests {
 
         let launcher = SystemdProcLauncher::new();
 
-        let unknown_proc_id = hyperactor_reference::ProcId::with_name(any_unix_addr(), "unknown");
+        let unknown_proc_id =
+            hyperactor_reference::ProcId::from_resource_name(any_unix_addr(), "unknown");
 
         let result = launcher.kill(&unknown_proc_id).await;
 
@@ -1562,7 +1565,8 @@ mod tests {
         );
 
         let bootstrap = Bootstrap::default();
-        let proc_id = hyperactor_reference::ProcId::with_name(any_unix_addr(), "drop-cleanup-test");
+        let proc_id =
+            hyperactor_reference::ProcId::from_resource_name(any_unix_addr(), "drop-cleanup-test");
 
         let exit_rx;
 
@@ -1661,7 +1665,8 @@ mod tests {
 
         let launcher = SystemdProcLauncher::new();
 
-        let proc_id = hyperactor_reference::ProcId::with_name(any_unix_addr(), "long-running");
+        let proc_id =
+            hyperactor_reference::ProcId::from_resource_name(any_unix_addr(), "long-running");
         let bootstrap = Bootstrap::default();
         let opts = LaunchOptions {
             command: with_sh("sleep 60"),

--- a/hyperactor_mesh_admin_tui/src/app.rs
+++ b/hyperactor_mesh_admin_tui/src/app.rs
@@ -656,7 +656,10 @@ impl App {
     /// cancelling any in-flight fetch (PY-1/PY-2).
     pub(crate) fn start_pyspy(&mut self, proc_id: hyperactor::reference::ProcId) {
         let proc_ref = proc_id.to_string();
-        let short = proc_id.name().to_string();
+        let short = proc_id
+            .label()
+            .map(|l| l.as_str().to_string())
+            .unwrap_or_else(|| proc_id.id().to_string());
         let scheme = self.theme.scheme; // ColorScheme: Copy
         let client = self.client.clone();
         let base_url = self.base_url.clone();
@@ -712,7 +715,10 @@ impl App {
     /// cancelling any in-flight fetch (CFG-1/CFG-2).
     pub(crate) fn start_config(&mut self, proc_id: hyperactor::reference::ProcId) {
         let proc_ref = proc_id.to_string();
-        let short = proc_id.name().to_string();
+        let short = proc_id
+            .label()
+            .map(|l| l.as_str().to_string())
+            .unwrap_or_else(|| proc_id.id().to_string());
         let scheme = self.theme.scheme; // ColorScheme: Copy
         let client = self.client.clone();
         let base_url = self.base_url.clone();

--- a/hyperactor_mesh_admin_tui/src/format.rs
+++ b/hyperactor_mesh_admin_tui/src/format.rs
@@ -47,7 +47,11 @@ pub(crate) fn derive_label(payload: &NodePayload) -> String {
             ..
         } => {
             let short = hyperactor_reference::ProcId::from_str(proc_name)
-                .map(|pid| pid.name().to_string())
+                .map(|pid| {
+                    pid.label()
+                        .map(|l| l.as_str().to_string())
+                        .unwrap_or_else(|| pid.id().to_string())
+                })
                 .unwrap_or_else(|_| proc_name.clone());
             let num_system = system_children.len();
             let num_stopped = stopped_children.len();

--- a/hyperactor_mesh_admin_tui/src/render/detail_pane.rs
+++ b/hyperactor_mesh_admin_tui/src/render/detail_pane.rs
@@ -282,7 +282,7 @@ fn render_host_detail(
     for child in &payload.children {
         let child_str = child.to_string();
         let short = match child {
-            NodeRef::Proc(proc_id) => proc_id.name().to_string(),
+            NodeRef::Proc(proc_id) => proc_id.id().to_string(),
             _ => child_str.clone(),
         };
         lines.push(Line::from(vec![
@@ -445,7 +445,7 @@ fn render_actor_detail(
 
     let created_str = created_at
         .as_ref()
-        .map(|t| format_system_time_iso(t))
+        .map(format_system_time_iso)
         .unwrap_or_else(|| "-".to_string());
 
     let mut lines = vec![

--- a/monarch_hyperactor/src/proc.rs
+++ b/monarch_hyperactor/src/proc.rs
@@ -57,7 +57,11 @@ impl PyProc {
 
     #[getter]
     fn name(&self) -> String {
-        self.inner.proc_id().name().to_string()
+        self.inner
+            .proc_id()
+            .label()
+            .map(|l| l.as_str().to_string())
+            .unwrap_or_else(|| self.inner.proc_id().id().to_string())
     }
 
     #[getter]
@@ -164,7 +168,7 @@ impl PyActorId {
         })?;
         Ok(Self {
             inner: reference::ActorId::new(
-                reference::ProcId::with_name(addr, proc_name),
+                reference::ProcId::from_resource_name(addr, proc_name),
                 actor_name,
                 pid,
             ),
@@ -190,7 +194,11 @@ impl PyActorId {
 
     #[getter]
     fn proc_name(&self) -> String {
-        self.inner.proc_id().name().to_string()
+        self.inner
+            .proc_id()
+            .label()
+            .map(|l| l.as_str().to_string())
+            .unwrap_or_else(|| self.inner.proc_id().id().to_string())
     }
 
     #[getter]

--- a/monarch_introspection_snapshot/src/bundle.rs
+++ b/monarch_introspection_snapshot/src/bundle.rs
@@ -331,7 +331,7 @@ mod tests {
     const ACTOR_TYPE: &str = "test_actor";
 
     fn test_proc_id() -> ProcId {
-        ProcId::with_name(ChannelAddr::Local(0), PROC_NAME)
+        ProcId::from_resource_name(ChannelAddr::Local(0), PROC_NAME)
     }
 
     fn test_host_ref() -> NodeRef {

--- a/monarch_introspection_snapshot/src/capture.rs
+++ b/monarch_introspection_snapshot/src/capture.rs
@@ -190,7 +190,7 @@ mod tests {
     // Test fixtures
 
     fn test_proc_id() -> ProcId {
-        ProcId::with_name(ChannelAddr::Local(0), "worker")
+        ProcId::from_resource_name(ChannelAddr::Local(0), "worker")
     }
 
     fn test_actor_id(name: &str, idx: usize) -> hyperactor::reference::ActorId {

--- a/monarch_introspection_snapshot/src/convert.rs
+++ b/monarch_introspection_snapshot/src/convert.rs
@@ -337,7 +337,7 @@ mod tests {
     // Test fixtures
 
     fn test_proc_id() -> ProcId {
-        ProcId::with_name(ChannelAddr::Local(0), "worker")
+        ProcId::from_resource_name(ChannelAddr::Local(0), "worker")
     }
 
     fn test_actor_id() -> hyperactor::reference::ActorId {

--- a/monarch_introspection_snapshot/src/push.rs
+++ b/monarch_introspection_snapshot/src/push.rs
@@ -168,7 +168,7 @@ mod tests {
     const ACTOR_NAME: &str = "test_actor";
 
     fn test_proc_id() -> ProcId {
-        ProcId::with_name(ChannelAddr::Local(0), PROC_NAME)
+        ProcId::from_resource_name(ChannelAddr::Local(0), PROC_NAME)
     }
 
     fn test_host_ref() -> NodeRef {

--- a/monarch_introspection_snapshot/src/service.rs
+++ b/monarch_introspection_snapshot/src/service.rs
@@ -445,7 +445,7 @@ mod tests {
     const ACTOR_TYPE: &str = "test_actor";
 
     fn test_proc_id() -> ProcId {
-        ProcId::with_name(ChannelAddr::Local(0), PROC_NAME)
+        ProcId::from_resource_name(ChannelAddr::Local(0), PROC_NAME)
     }
 
     /// Build a stub resolver backed by a `HashMap`.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #3504
* #3503
* #3502
* #3501
* __->__ #3500
* #3499
* #3498
* #3497

Make reference::ProcId a thin wrapper around ref_::ProcRef, which pairs an id::ProcId (uid + label) with a Location (ChannelAddr). This is the first step of phase 2 of the id migration.

ProcId::unique() now generates a random Uid with a stripped label. ProcId::with_name() parses the name in ResourceId format to recover uid and label deterministically. .name() and .base_name() are removed; callers switch to .uid(), .label(), or .id().

ProcId::label() returns the human-readable label for both singletons (embedded in uid) and instances (separate field), matching ResourceId::display_label() semantics.

Walkthrough:
- reference.rs: ProcId struct changes from (ChannelAddr, String) to (ref_::ProcRef). Accessors updated. Display kept in old "addr,resource_name" compat format. label() returns the label from either uid (singleton) or metadata (instance).
- bootstrap/mailbox.rs: LocalProcDialer routes by Uid::Instance check instead of ResourceId::parse. Socket paths use proc id string.
- mesh_admin.rs: route_proc_handler uses label-based check against SERVICE_PROC_NAME. Tree labels use id().to_string(). test_proc_properties assertion reversed to account for label-only proc_name.
- host_mesh.rs: ResourceId constructed from uid+label instead of parsing proc name.
- alloc/process.rs: alloc name normalized through Label::strip on both construction and extraction to handle mixed-case ShortUuid.
- proc_launcher.rs: format_process_name uses label() for the process name.
- Python bindings, TUI, CLI: .name() replaced with .label() or .id().to_string().

Differential Revision: [D100912596](https://our.internmc.facebook.com/intern/diff/D100912596/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D100912596/)!