### PR TITLE
[hyperactor] switch reference:: Display/FromStr to underlying ref_:: format

### DIFF
--- a/docs/source/books/hyperactor-book/src/references/actor_id.md
+++ b/docs/source/books/hyperactor-book/src/references/actor_id.md
@@ -27,7 +27,7 @@ Fields are private; use named constructors:
 use hyperactor::reference::{ActorId, ProcId};
 
 let addr = "tcp:127.0.0.1:8080".parse()?;
-let proc = ProcId::with_name(addr, "myproc");
+let proc = ProcId::from_resource_name(addr, "myproc");
 let actor = ActorId::new(proc.clone(), "worker");
 ```
 

--- a/docs/source/books/hyperactor-book/src/references/proc_id.md
+++ b/docs/source/books/hyperactor-book/src/references/proc_id.md
@@ -30,7 +30,7 @@ let addr = "tcp:127.0.0.1:8080".parse()?;
 // `unique` appends an address hash to make the name globally unique:
 let proc = ProcId::unique(addr.clone(), "service");
 // `with_name` uses the name as-is (for deserialization or already-unique names):
-let proc = ProcId::with_name(addr, "service");
+let proc = ProcId::from_resource_name(addr, "service");
 ```
 
 See [Host](../procs/host.md) for how procs are used in the Host architecture.

--- a/hyperactor/src/channel.rs
+++ b/hyperactor/src/channel.rs
@@ -813,8 +813,11 @@ impl ChannelAddr {
     ///   Note: Alias format is currently only supported for TCP addresses
     pub fn from_zmq_url(address: &str) -> Result<Self, anyhow::Error> {
         // Check for Alias format: dial_to_url@bind_to_url
-        // The @ character separates two valid ZMQ URLs
-        if let Some(at_pos) = address.find('@') {
+        // The @ character separates two valid ZMQ URLs.
+        if let Some(at_pos) = address
+            .find('@')
+            .filter(|&pos| address[..pos].starts_with("tcp://"))
+        {
             let dial_to_str = &address[..at_pos];
             let bind_to_str = &address[at_pos + 1..];
 
@@ -1329,9 +1332,12 @@ mod tests {
             _ => panic!("Expected Alias"),
         }
 
-        // Test error: alias with non-tcp dial_to (not supported)
+        // Non-tcp left side: alias branch is skipped, parsed as regular address.
+        // metatls:// with garbage host is not an alias.
+        let non_alias = ChannelAddr::from_zmq_url("metatls://example.com:443@tcp://127.0.0.1:8080");
         assert!(
-            ChannelAddr::from_zmq_url("metatls://example.com:443@tcp://127.0.0.1:8080").is_err()
+            !matches!(non_alias, Ok(ChannelAddr::Alias { .. })),
+            "non-tcp left side must not produce Alias"
         );
 
         // Test error: alias with non-tcp bind_to (not supported)
@@ -1339,7 +1345,7 @@ mod tests {
             ChannelAddr::from_zmq_url("tcp://127.0.0.1:8080@metatls://example.com:443").is_err()
         );
 
-        // Test error: invalid dial_to URL in Alias
+        // Test error: invalid scheme falls through to scheme parsing, errors there
         assert!(ChannelAddr::from_zmq_url("invalid://scheme@tcp://127.0.0.1:8080").is_err());
 
         // Test error: invalid bind_to URL in Alias

--- a/hyperactor/src/id.rs
+++ b/hyperactor/src/id.rs
@@ -385,7 +385,11 @@ impl Ord for ProcId {
 
 impl fmt::Display for ProcId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.uid)
+        match (&self.uid, &self.label) {
+            (Uid::Singleton(label), _) => write!(f, "_{}", label),
+            (Uid::Instance(uid), Some(label)) => write!(f, "{}-{:016x}", label, uid),
+            (Uid::Instance(uid), None) => write!(f, "{:016x}", uid),
+        }
     }
 }
 
@@ -402,6 +406,36 @@ impl FromStr for ProcId {
     type Err = IdParseError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
+        // Singleton: _label
+        if let Some(rest) = s.strip_prefix('_') {
+            if let Ok(label) = Label::new(rest) {
+                return Ok(Self {
+                    uid: Uid::Singleton(label),
+                    label: None,
+                });
+            }
+        }
+
+        // Labeled instance: label-hex16 (exactly 16 hex digits after last dash at len-17)
+        if s.len() >= 18 {
+            let dash_pos = s.len() - 17;
+            if s.as_bytes()[dash_pos] == b'-' {
+                let hex_part = &s[dash_pos + 1..];
+                let label_part = &s[..dash_pos];
+                if hex_part.len() == 16 && hex_part.chars().all(|c| c.is_ascii_hexdigit()) {
+                    if let (Ok(uid), Ok(label)) =
+                        (u64::from_str_radix(hex_part, 16), Label::new(label_part))
+                    {
+                        return Ok(Self {
+                            uid: Uid::Instance(uid),
+                            label: Some(label),
+                        });
+                    }
+                }
+            }
+        }
+
+        // Unlabeled instance: bare uid
         let uid: Uid = s.parse()?;
         Ok(Self { uid, label: None })
     }
@@ -872,7 +906,7 @@ mod tests {
             Uid::Instance(0xd5d54d7201103869),
             Some(Label::new("my-proc").unwrap()),
         );
-        assert_eq!(pid.to_string(), "d5d54d7201103869");
+        assert_eq!(pid.to_string(), "my-proc-d5d54d7201103869");
 
         let pid_singleton = ProcId::new(
             Uid::singleton(Label::new("my-proc").unwrap()),

--- a/hyperactor/src/mailbox.rs
+++ b/hyperactor/src/mailbox.rs
@@ -2942,7 +2942,6 @@ mod tests {
 
     use std::assert_matches::assert_matches;
     use std::mem::drop;
-    use std::str::FromStr;
     use std::sync::atomic::AtomicUsize;
     use std::time::Duration;
 
@@ -2976,8 +2975,13 @@ mod tests {
             test_actor_id("myworld_2", "myactor"),
             MailboxErrorKind::Closed,
         );
-        // The format is: "{proc_id},{actor_resource_name}: {error}"
-        assert!(format!("{}", err).ends_with(",_test_myworld_2,_myactor: mailbox closed"));
+        // ActorId display is now "actor_uid.proc_uid@location"
+        let err_str = format!("{}", err);
+        assert!(
+            err_str.contains("mailbox closed"),
+            "expected error: {}",
+            err_str
+        );
     }
 
     #[tokio::test]
@@ -3228,8 +3232,13 @@ mod tests {
             "unix!@4".parse().unwrap(),
         );
         // Bind a direct address -- we should use its bound address!
+        // The actor must be on unix:@4 so that after unbinding, the prefix
+        // route for world1_1 (unix!@3) is the fallback, not world1_1/actor1 (unix!@4).
+        let direct_actor_id =
+            reference::ProcId::from_resource_name("unix:@4".parse().unwrap(), "my_proc")
+                .actor_id("my_actor");
         router.bind(
-            "unix:@4,my_proc,my_actor".parse().unwrap(),
+            reference::Reference::Actor(direct_actor_id.clone()),
             "unix:@5".parse().unwrap(),
         );
 
@@ -3241,10 +3250,7 @@ mod tests {
             .lookup_addr(&test_actor_id("world1_0", "actor"))
             .unwrap();
 
-        let actor_id = reference::Reference::from_str("unix:@4,my_proc,my_actor")
-            .unwrap()
-            .into_actor()
-            .unwrap();
+        let actor_id = direct_actor_id;
         assert_eq!(
             router.lookup_addr(&actor_id).unwrap(),
             "unix!@5".parse().unwrap(),

--- a/hyperactor/src/ref_.rs
+++ b/hyperactor/src/ref_.rs
@@ -390,7 +390,7 @@ mod tests {
         );
         let loc: Location = ChannelAddr::Local(42).into();
         let pref = ProcRef::new(pid, loc);
-        assert_eq!(pref.to_string(), "0000000000abc123@inproc://42");
+        assert_eq!(pref.to_string(), "my-proc-0000000000abc123@inproc://42");
     }
 
     #[test]
@@ -403,7 +403,7 @@ mod tests {
         let pref = ProcRef::new(pid, loc);
         assert_eq!(
             format!("{:?}", pref),
-            "<'my-proc' 0000000000abc123@inproc://42>"
+            "<'my-proc' my-proc-0000000000abc123@inproc://42>"
         );
     }
 

--- a/hyperactor/src/reference.rs
+++ b/hyperactor/src/reference.rs
@@ -40,9 +40,7 @@ use serde::Deserialize;
 use serde::Deserializer;
 use serde::Serialize;
 use serde::Serializer;
-use typeuri::ACTOR_PORT_BIT;
 use typeuri::Named;
-use wirevalue::TypeInfo;
 
 use crate::Actor;
 use crate::ActorHandle;
@@ -69,11 +67,8 @@ pub mod lex;
 pub mod name;
 mod parse;
 
-use parse::Lexer;
 use parse::ParseError;
-use parse::Token;
 pub use parse::is_valid_ident;
-use parse::parse;
 
 /// The kinds of references.
 #[derive(strum::Display)]
@@ -234,46 +229,22 @@ pub enum ReferenceParsingError {
 impl FromStr for Reference {
     type Err = ReferenceParsingError;
 
-    fn from_str(addr: &str) -> Result<Self, Self::Err> {
-        // References are parsed in the "direct" format:
-        // The reference must contain a comma (anywhere), indicating a proc/actor/port reference.
-
-        match addr.split_once(",") {
-            Some((channel_addr, rest)) => {
-                let channel_addr = channel_addr.parse().map_err(|err| {
-                    ReferenceParsingError::InvalidChannelAddress(channel_addr.to_string(), err)
-                })?;
-
-                Ok(parse! {
-                    Lexer::new(rest);
-
-                    // channeladdr,proc_name
-                    Token::Elem(proc_name) =>
-                    Self::Proc(ProcId::from_resource_name(channel_addr, proc_name)),
-
-                    // channeladdr,proc_name,actor_name
-                    Token::Elem(proc_name) Token::Comma Token::Elem(actor_name) =>
-                    Self::Actor(ActorId::new(ProcId::from_resource_name(channel_addr, proc_name), actor_name)),
-
-                    // channeladdr,proc_name,actor_name[port]
-                    Token::Elem(proc_name) Token::Comma Token::Elem(actor_name)
-                        Token::LeftBracket Token::Uint(port) Token::RightBracket =>
-                        Self::Port(PortId::new(ActorId::new(ProcId::from_resource_name(channel_addr, proc_name), actor_name), port as u64)),
-
-                    // channeladdr,proc_name,actor_name[port<type>]
-                    Token::Elem(proc_name) Token::Comma Token::Elem(actor_name)
-                        Token::LeftBracket Token::Uint(port)
-                            Token::LessThan Token::Elem(_type) Token::GreaterThan
-                        Token::RightBracket =>
-                        Self::Port(PortId::new(ActorId::new(ProcId::from_resource_name(channel_addr, proc_name), actor_name), port as u64)),
-                }?)
-            }
-
-            None => Err(ReferenceParsingError::Unexpected(format!(
-                "expected a comma-separated reference, got: {}",
-                addr
-            ))),
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        // References use the ref_:: format: "id@location".
+        // Try most specific first: Port (has `:` in id), Actor (has `.`), Proc.
+        if let Ok(port_ref) = s.parse::<ref_::PortRef>() {
+            return Ok(Self::Port(PortId(port_ref)));
         }
+        if let Ok(actor_ref) = s.parse::<ref_::ActorRef>() {
+            return Ok(Self::Actor(ActorId(actor_ref)));
+        }
+        if let Ok(proc_ref) = s.parse::<ref_::ProcRef>() {
+            return Ok(Self::Proc(ProcId(proc_ref)));
+        }
+        Err(ReferenceParsingError::Unexpected(format!(
+            "could not parse reference: {}",
+            s
+        )))
     }
 }
 
@@ -446,29 +417,18 @@ impl ProcId {
 
 impl fmt::Display for ProcId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        // Compat format: "addr,resource_name" where resource_name is the
-        // ResourceId text form: _label | label-hex16 | hex16.
-        let id = self.0.id();
-        match (id.uid(), id.label()) {
-            (Uid::Singleton(label), _) => write!(f, "{},_{}", self.0.location().addr(), label),
-            (Uid::Instance(uid), Some(label)) => {
-                write!(f, "{},{}-{:016x}", self.0.location().addr(), label, uid)
-            }
-            (Uid::Instance(uid), None) => {
-                write!(f, "{},{:016x}", self.0.location().addr(), uid)
-            }
-        }
+        fmt::Display::fmt(&self.0, f)
     }
 }
 
 impl FromStr for ProcId {
     type Err = ReferenceParsingError;
 
-    fn from_str(addr: &str) -> Result<Self, Self::Err> {
-        match addr.parse()? {
-            Reference::Proc(proc_id) => Ok(proc_id),
-            _ => Err(ReferenceParsingError::WrongType("proc".into())),
-        }
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let proc_ref: ref_::ProcRef = s
+            .parse()
+            .map_err(|e| ReferenceParsingError::Unexpected(format!("{}", e)))?;
+        Ok(Self(proc_ref))
     }
 }
 
@@ -572,18 +532,7 @@ impl ActorId {
 
 impl fmt::Display for ActorId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        // Compat format: "proc_display,actor_resource_name"
-        let id = self.0.id();
-        let proc_id = self.proc_id();
-        match (id.uid(), id.label()) {
-            (Uid::Singleton(label), _) => write!(f, "{},_{}", proc_id, label),
-            (Uid::Instance(uid), Some(label)) => {
-                write!(f, "{},{}-{:016x}", proc_id, label, uid)
-            }
-            (Uid::Instance(uid), None) => {
-                write!(f, "{},{:016x}", proc_id, uid)
-            }
-        }
+        fmt::Display::fmt(&self.0, f)
     }
 }
 impl<A: Referable> From<ActorRef<A>> for ActorId {
@@ -601,11 +550,11 @@ impl<'a, A: Referable> From<&'a ActorRef<A>> for &'a ActorId {
 impl FromStr for ActorId {
     type Err = ReferenceParsingError;
 
-    fn from_str(addr: &str) -> Result<Self, Self::Err> {
-        match addr.parse()? {
-            Reference::Actor(actor_id) => Ok(actor_id),
-            _ => Err(ReferenceParsingError::WrongType("actor".into())),
-        }
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let actor_ref: ref_::ActorRef = s
+            .parse()
+            .map_err(|e| ReferenceParsingError::Unexpected(format!("{}", e)))?;
+        Ok(Self(actor_ref))
     }
 }
 
@@ -863,25 +812,17 @@ impl PortId {
 impl FromStr for PortId {
     type Err = ReferenceParsingError;
 
-    fn from_str(addr: &str) -> Result<Self, Self::Err> {
-        match addr.parse()? {
-            Reference::Port(port_id) => Ok(port_id),
-            _ => Err(ReferenceParsingError::WrongType("port".into())),
-        }
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let port_ref: ref_::PortRef = s
+            .parse()
+            .map_err(|e| ReferenceParsingError::Unexpected(format!("{}", e)))?;
+        Ok(Self(port_ref))
     }
 }
 
 impl fmt::Display for PortId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let actor_id = self.actor_id();
-        let port = self.index();
-        if self.is_actor_port() {
-            let type_info = TypeInfo::get(port).or_else(|| TypeInfo::get(port & !ACTOR_PORT_BIT));
-            let typename = type_info.map_or("unknown", TypeInfo::typename);
-            write!(f, "{}[{}<{}>]", actor_id, port, typename)
-        } else {
-            write!(f, "{}[{}]", actor_id, port)
-        }
+        fmt::Display::fmt(&self.0, f)
     }
 }
 
@@ -1306,63 +1247,53 @@ mod tests {
 
     #[test]
     fn test_reference_parse() {
-        let cases: Vec<(&str, Reference)> = vec![
-            (
-                "tcp:[::1]:1234,test",
-                ProcId::from_resource_name(
-                    "tcp:[::1]:1234".parse::<ChannelAddr>().unwrap(),
-                    "test",
-                )
-                .into(),
-            ),
-            (
-                "tcp:[::1]:1234,test,testactor",
-                ActorId::new(
-                    ProcId::from_resource_name(
-                        "tcp:[::1]:1234".parse::<ChannelAddr>().unwrap(),
-                        "test",
-                    ),
-                    "testactor",
-                )
-                .into(),
-            ),
-            (
-                // instance actor (label-hex16 format)
-                "tcp:[::1]:1234,test,myactor-00000000deadbeef",
-                ActorId::new(
-                    ProcId::from_resource_name(
-                        "tcp:[::1]:1234".parse::<ChannelAddr>().unwrap(),
-                        "test",
-                    ),
-                    "myactor-00000000deadbeef",
-                )
-                .into(),
-            ),
-            (
-                // one bracket group = port (type annotations ignored)
-                "tcp:[::1]:1234,test,testactor[123<my::type>]",
-                PortId::new(
-                    ActorId::new(
-                        ProcId::from_resource_name(
-                            "tcp:[::1]:1234".parse::<ChannelAddr>().unwrap(),
-                            "test",
-                        ),
-                        "testactor",
-                    ),
-                    123,
-                )
-                .into(),
-            ),
-        ];
+        // New format: "uid@location" for Proc, "actor.proc@loc" for Actor,
+        // "actor.proc:port@loc" for Port.
+        let addr: ChannelAddr = "tcp:[::1]:1234".parse().unwrap();
+        let loc = "tcp://[::1]:1234".to_string();
 
-        for (s, expected) in cases {
-            assert_eq!(s.parse::<Reference>().unwrap(), expected, "for {}", s);
-        }
+        let proc_id = ProcId::from_resource_name(addr.clone(), "test");
+        let proc_str = format!("_test@{}", loc);
+        assert_eq!(
+            proc_str.parse::<Reference>().unwrap(),
+            Reference::Proc(proc_id.clone())
+        );
+
+        let actor_id = ActorId::new(proc_id.clone(), "testactor");
+        let actor_str = format!("_testactor._test@{}", loc);
+        assert_eq!(
+            actor_str.parse::<Reference>().unwrap(),
+            Reference::Actor(actor_id.clone())
+        );
+
+        let port_id = PortId::new(actor_id.clone(), 123);
+        let port_str = format!("_testactor._test:123@{}", loc);
+        assert_eq!(
+            port_str.parse::<Reference>().unwrap(),
+            Reference::Port(port_id)
+        );
+    }
+
+    #[test]
+    fn test_reference_display_roundtrip() {
+        let addr: ChannelAddr = "tcp:[::1]:1234".parse().unwrap();
+
+        let proc_id = ProcId::from_resource_name(addr.clone(), "test");
+        let proc_str = proc_id.to_string();
+        assert_eq!(proc_str.parse::<ProcId>().unwrap(), proc_id);
+
+        let actor_id = ActorId::new(proc_id.clone(), "myactor");
+        let actor_str = actor_id.to_string();
+        assert_eq!(actor_str.parse::<ActorId>().unwrap(), actor_id);
+
+        let port_id = PortId::new(actor_id.clone(), 42);
+        let port_str = port_id.to_string();
+        assert_eq!(port_str.parse::<PortId>().unwrap(), port_id);
     }
 
     #[test]
     fn test_reference_parse_error() {
-        let cases: Vec<&str> = vec!["(blah)", "world(1, 2, 3)", "test"];
+        let cases: Vec<&str> = vec!["(blah)", "world(1, 2, 3)", "no-at-sign"];
 
         for s in cases {
             let result: Result<Reference, ReferenceParsingError> = s.parse();
@@ -1372,14 +1303,11 @@ mod tests {
 
     #[test]
     fn test_reference_ord() {
-        let expected: Vec<Reference> = [
-            "tcp:[::1]:1234,first",
-            "tcp:[::1]:1234,second",
-            "tcp:[::1]:1234,third",
-        ]
-        .into_iter()
-        .map(|s| s.parse().unwrap())
-        .collect();
+        let addr: ChannelAddr = "tcp:[::1]:1234".parse().unwrap();
+        let expected: Vec<Reference> = ["first", "second", "third"]
+            .into_iter()
+            .map(|name| Reference::Proc(ProcId::from_resource_name(addr.clone(), name)))
+            .collect();
 
         let mut sorted = expected.to_vec();
         sorted.shuffle(&mut rand::rng());
@@ -1389,31 +1317,16 @@ mod tests {
     }
 
     #[test]
-    fn test_port_type_annotation() {
-        #[derive(typeuri::Named, Serialize, Deserialize)]
-        struct MyType;
-        wirevalue::register_type!(MyType);
+    fn test_port_display() {
+        let addr: ChannelAddr = "tcp:[::1]:1234".parse().unwrap();
         let port_id = PortId::new(
-            ActorId::new(
-                ProcId::from_resource_name(
-                    "tcp:[::1]:1234".parse::<ChannelAddr>().unwrap(),
-                    "test",
-                ),
-                "testactor",
-            ),
-            MyType::port(),
+            ActorId::new(ProcId::from_resource_name(addr, "test"), "testactor"),
+            42,
         );
         let s = port_id.to_string();
-        assert!(
-            s.starts_with("tcp:[::1]:1234,_test,_testactor["),
-            "unexpected format: {}",
-            s
-        );
-        assert!(
-            s.contains("<hyperactor::reference::tests::MyType>"),
-            "missing type annotation: {}",
-            s
-        );
+        // Format: "actor_uid.proc_uid:port@location"
+        assert!(s.contains("@tcp://"), "expected @ separator: {}", s);
+        assert!(s.contains(":42@"), "expected port 42: {}", s);
     }
 
     #[tokio::test]

--- a/hyperactor_mesh_admin_tui/src/fetch.rs
+++ b/hyperactor_mesh_admin_tui/src/fetch.rs
@@ -542,9 +542,13 @@ mod tests {
     use super::*;
 
     fn mock_actor_ref(name: &str) -> NodeRef {
-        use std::str::FromStr;
-        let id_str = format!("unix:@test,world,{}", name);
-        NodeRef::Actor(hyperactor::reference::ActorId::from_str(&id_str).unwrap())
+        let proc_id = hyperactor::reference::ProcId::from_resource_name(
+            "unix:@test"
+                .parse::<hyperactor::channel::ChannelAddr>()
+                .unwrap(),
+            "world",
+        );
+        NodeRef::Actor(proc_id.actor_id(name))
     }
 
     fn mock_payload(identity: NodeRef) -> NodePayload {

--- a/hyperactor_mesh_admin_tui/src/filter.rs
+++ b/hyperactor_mesh_admin_tui/src/filter.rs
@@ -54,8 +54,13 @@ mod tests {
     use super::*;
 
     fn mock_actor_id() -> hyperactor::reference::ActorId {
-        use std::str::FromStr;
-        hyperactor::reference::ActorId::from_str("unix:@test,world,a").unwrap()
+        hyperactor::reference::ProcId::from_resource_name(
+            "unix:@test"
+                .parse::<hyperactor::channel::ChannelAddr>()
+                .unwrap(),
+            "world",
+        )
+        .actor_id("a")
     }
 
     fn actor_props(status: &str) -> NodeProperties {

--- a/hyperactor_mesh_admin_tui/src/format.rs
+++ b/hyperactor_mesh_admin_tui/src/format.rs
@@ -234,7 +234,6 @@ pub(crate) fn format_bytes(bytes: u64) -> String {
 
 #[cfg(test)]
 mod tests {
-    use std::str::FromStr;
     use std::time::SystemTime;
 
     use hyperactor::reference as hyperactor_reference;
@@ -245,18 +244,33 @@ mod tests {
     use super::*;
 
     fn mock_actor_ref(name: &str) -> NodeRef {
-        let id_str = format!("unix:@test,world,{}", name);
-        NodeRef::Actor(hyperactor_reference::ActorId::from_str(&id_str).unwrap())
+        let proc_id = hyperactor_reference::ProcId::from_resource_name(
+            "unix:@test"
+                .parse::<hyperactor::channel::ChannelAddr>()
+                .unwrap(),
+            "world",
+        );
+        NodeRef::Actor(proc_id.actor_id(name))
     }
 
     fn mock_proc_ref(name: &str) -> NodeRef {
-        let id_str = format!("unix:@test,{}", name);
-        NodeRef::Proc(hyperactor_reference::ProcId::from_str(&id_str).unwrap())
+        let proc_id = hyperactor_reference::ProcId::from_resource_name(
+            "unix:@test"
+                .parse::<hyperactor::channel::ChannelAddr>()
+                .unwrap(),
+            name,
+        );
+        NodeRef::Proc(proc_id)
     }
 
     fn mock_host_ref(name: &str) -> NodeRef {
-        let id_str = format!("unix:@test,world,{}", name);
-        NodeRef::Host(hyperactor_reference::ActorId::from_str(&id_str).unwrap())
+        let proc_id = hyperactor_reference::ProcId::from_resource_name(
+            "unix:@test"
+                .parse::<hyperactor::channel::ChannelAddr>()
+                .unwrap(),
+            "world",
+        );
+        NodeRef::Host(proc_id.actor_id(name))
     }
 
     fn proc_payload(proc_name: &str, props: NodeProperties) -> NodePayload {
@@ -546,9 +560,13 @@ mod tests {
 
     #[test]
     fn derive_label_actor_standard_actor_id() {
-        let actor_id =
-            hyperactor_reference::ActorId::from_str("unix:@abc123,myworld,worker").unwrap();
-        let proc_id = hyperactor_reference::ProcId::from_str("unix:@abc123,myworld").unwrap();
+        let proc_id = hyperactor_reference::ProcId::from_resource_name(
+            "unix:@test"
+                .parse::<hyperactor::channel::ChannelAddr>()
+                .unwrap(),
+            "myworld",
+        );
+        let actor_id = proc_id.actor_id("worker");
         let payload = NodePayload {
             identity: NodeRef::Actor(actor_id),
             properties: NodeProperties::Actor {

--- a/hyperactor_mesh_admin_tui/src/model.rs
+++ b/hyperactor_mesh_admin_tui/src/model.rs
@@ -343,16 +343,23 @@ mod tests {
     use super::*;
 
     fn mock_actor_ref(name: &str) -> NodeRef {
-        use std::str::FromStr;
-        // Create a simple ActorId for testing.
-        let id_str = format!("unix:@test,world,{}", name);
-        NodeRef::Actor(hyperactor::reference::ActorId::from_str(&id_str).unwrap())
+        let proc_id = hyperactor::reference::ProcId::from_resource_name(
+            "unix:@test"
+                .parse::<hyperactor::channel::ChannelAddr>()
+                .unwrap(),
+            "world",
+        );
+        NodeRef::Actor(proc_id.actor_id(name))
     }
 
     fn mock_proc_ref(name: &str) -> NodeRef {
-        use std::str::FromStr;
-        let id_str = format!("unix:@test,{}", name);
-        NodeRef::Proc(hyperactor::reference::ProcId::from_str(&id_str).unwrap())
+        let proc_id = hyperactor::reference::ProcId::from_resource_name(
+            "unix:@test"
+                .parse::<hyperactor::channel::ChannelAddr>()
+                .unwrap(),
+            name,
+        );
+        NodeRef::Proc(proc_id)
     }
 
     // Helper to create test payloads
@@ -679,8 +686,13 @@ mod tests {
     fn from_payload_sets_failed_for_actor_with_failure_info() {
         let r = mock_actor_ref("actor1");
         let worker_id = {
-            use std::str::FromStr;
-            hyperactor::reference::ActorId::from_str("unix:@test,world,worker").unwrap()
+            hyperactor::reference::ProcId::from_resource_name(
+                "unix:@test"
+                    .parse::<hyperactor::channel::ChannelAddr>()
+                    .unwrap(),
+                "world",
+            )
+            .actor_id("worker")
         };
         let payload = NodePayload {
             identity: r.clone(),

--- a/hyperactor_mesh_admin_tui/src/render/detail_pane.rs
+++ b/hyperactor_mesh_admin_tui/src/render/detail_pane.rs
@@ -804,17 +804,25 @@ mod tests {
 
     fn mock_host_ref() -> NodeRef {
         use hyperactor::reference as hyperactor_reference;
-        let id_str = "unix:@test,world,host_agent";
-        NodeRef::Host(hyperactor_reference::ActorId::from_str(id_str).unwrap())
+        let proc_id = hyperactor_reference::ProcId::from_resource_name(
+            "unix:@test"
+                .parse::<hyperactor::channel::ChannelAddr>()
+                .unwrap(),
+            "world",
+        );
+        NodeRef::Host(proc_id.actor_id("host_agent"))
     }
 
     fn mock_proc_ref() -> NodeRef {
         use hyperactor::reference as hyperactor_reference;
-        let id_str = "unix:@test,worker";
-        NodeRef::Proc(hyperactor_reference::ProcId::from_str(id_str).unwrap())
+        let proc_id = hyperactor_reference::ProcId::from_resource_name(
+            "unix:@test"
+                .parse::<hyperactor::channel::ChannelAddr>()
+                .unwrap(),
+            "worker",
+        );
+        NodeRef::Proc(proc_id)
     }
-
-    use std::str::FromStr;
 
     // PD-*: host detail shows memory stats when present.
     #[test]

--- a/hyperactor_mesh_admin_tui/src/tests/mod.rs
+++ b/hyperactor_mesh_admin_tui/src/tests/mod.rs
@@ -10,7 +10,6 @@
 //! tree + cursor + fetch). Per-module unit tests live in each
 //! module's own `#[cfg(test)] mod tests` block.
 
-use std::str::FromStr;
 use std::time::SystemTime;
 
 use crossterm::event::KeyCode;
@@ -44,19 +43,23 @@ fn root() -> NodeRef {
     NodeRef::Root
 }
 
+fn test_addr() -> hyperactor::channel::ChannelAddr {
+    "unix:@test".parse().unwrap()
+}
+
 fn host(name: &str) -> NodeRef {
-    let id_str = format!("unix:@test,world,{}", name);
-    NodeRef::Host(hyperactor_reference::ActorId::from_str(&id_str).unwrap())
+    let proc_id = hyperactor_reference::ProcId::from_resource_name(test_addr(), "world");
+    NodeRef::Host(proc_id.actor_id(name))
 }
 
 fn proc_ref(name: &str) -> NodeRef {
-    let id_str = format!("unix:@test,{}", name);
-    NodeRef::Proc(hyperactor_reference::ProcId::from_str(&id_str).unwrap())
+    let proc_id = hyperactor_reference::ProcId::from_resource_name(test_addr(), name);
+    NodeRef::Proc(proc_id)
 }
 
 fn actor(name: &str) -> NodeRef {
-    let id_str = format!("unix:@test,world,{}", name);
-    NodeRef::Actor(hyperactor_reference::ActorId::from_str(&id_str).unwrap())
+    let proc_id = hyperactor_reference::ProcId::from_resource_name(test_addr(), "world");
+    NodeRef::Actor(proc_id.actor_id(name))
 }
 
 // Empty tree all operations are noops.

--- a/hyperactor_mesh_admin_tui/src/tree.rs
+++ b/hyperactor_mesh_admin_tui/src/tree.rs
@@ -286,7 +286,6 @@ pub(crate) fn collapse_all(node: &mut TreeNode) {
 #[cfg(test)]
 mod tests {
     use std::collections::HashSet;
-    use std::str::FromStr;
 
     use super::*;
     use crate::model::NodeType;
@@ -296,18 +295,33 @@ mod tests {
     }
 
     fn host(name: &str) -> NodeRef {
-        let id_str = format!("unix:@test,world,{}", name);
-        NodeRef::Host(hyperactor::reference::ActorId::from_str(&id_str).unwrap())
+        let proc_id = hyperactor::reference::ProcId::from_resource_name(
+            "unix:@test"
+                .parse::<hyperactor::channel::ChannelAddr>()
+                .unwrap(),
+            "world",
+        );
+        NodeRef::Host(proc_id.actor_id(name))
     }
 
     fn proc_ref(name: &str) -> NodeRef {
-        let id_str = format!("unix:@test,{}", name);
-        NodeRef::Proc(hyperactor::reference::ProcId::from_str(&id_str).unwrap())
+        let proc_id = hyperactor::reference::ProcId::from_resource_name(
+            "unix:@test"
+                .parse::<hyperactor::channel::ChannelAddr>()
+                .unwrap(),
+            name,
+        );
+        NodeRef::Proc(proc_id)
     }
 
     fn actor(name: &str) -> NodeRef {
-        let id_str = format!("unix:@test,world,{}", name);
-        NodeRef::Actor(hyperactor::reference::ActorId::from_str(&id_str).unwrap())
+        let proc_id = hyperactor::reference::ProcId::from_resource_name(
+            "unix:@test"
+                .parse::<hyperactor::channel::ChannelAddr>()
+                .unwrap(),
+            "world",
+        );
+        NodeRef::Actor(proc_id.actor_id(name))
     }
 
     // Helper to find a node by reference using algebraic fold.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #3504
* #3503
* __->__ #3502
* #3501
* #3500
* #3499
* #3498
* #3497

Drop the custom comma-separated display format ("addr,name,actor[pid][port]") in favor of the ref_:: format ("uid@location", "actor.proc@location", "actor.proc:port@location").

Display delegates to the inner ref_::ProcRef/ActorRef/PortRef. FromStr delegates likewise. Reference::FromStr tries PortRef, ActorRef, ProcRef in order.

id::ProcId::Display now includes labels: `_label` (singleton), `label-hex16` (labeled instance), `hex16` (unlabeled). This ensures labels survive Display/FromStr round-trips through the ref_:: format.

Fixes a latent bug in ChannelAddr::from_zmq_url where IPC abstract socket addresses (`ipc://@name`) triggered the TCP alias detection branch. The alias `@`-split is now gated on the left side starting with `tcp://`.

TUI test helpers switched from `from_str` (old format) to constructor-based ID creation with fixed `"unix:@test"` addresses.

This is a concrete syntax change that prepares for removing reference:: entirely. The PortId type annotation suffix (<typename>) in Display is dropped.

Differential Revision: [D100912594](https://our.internmc.facebook.com/intern/diff/D100912594/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D100912594/)!