### PR TITLE
[hyperactor] enrich ref_ with convenience methods from reference

### DIFF
--- a/hyperactor/src/ref_.rs
+++ b/hyperactor/src/ref_.rs
@@ -15,10 +15,13 @@ use serde::Deserialize;
 use serde::Serialize;
 
 use crate::channel::ChannelAddr;
+use crate::id;
 use crate::id::ActorId;
 use crate::id::IdParseError;
+use crate::id::Label;
 use crate::id::PortId;
 use crate::id::ProcId;
+use crate::id::Uid;
 
 /// A network location, wrapping a [`ChannelAddr`].
 #[derive(Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
@@ -93,6 +96,96 @@ impl ProcRef {
     pub fn location(&self) -> &Location {
         &self.location
     }
+
+    /// The proc's channel address.
+    pub fn addr(&self) -> &ChannelAddr {
+        self.location.addr()
+    }
+
+    /// The proc's uid.
+    pub fn uid(&self) -> &Uid {
+        self.id.uid()
+    }
+
+    /// The proc's label: the explicit metadata label for instances,
+    /// or the singleton name for singletons.
+    pub fn label(&self) -> Option<&Label> {
+        self.id.label().or_else(|| match self.id.uid() {
+            Uid::Singleton(label) => Some(label),
+            _ => None,
+        })
+    }
+
+    /// Create a ProcRef with a unique (random) uid and the given label.
+    pub fn unique(addr: ChannelAddr, base_name: impl AsRef<str>) -> Self {
+        let label = Label::strip(base_name.as_ref());
+        Self::new(id::ProcId::instance(label), Location::from(addr))
+    }
+
+    /// Create a ProcRef by parsing a name string in ResourceId format.
+    ///
+    /// Recognizes: `_label` (singleton), `label-hex16` (labeled instance),
+    /// `hex16` (unlabeled instance). Falls back to singleton from stripped name.
+    pub fn from_resource_name(addr: ChannelAddr, name: impl AsRef<str>) -> Self {
+        let (uid, label) = parse_resource_name(name.as_ref());
+        Self::new(id::ProcId::new(uid, label), Location::from(addr))
+    }
+
+    /// Create an ActorRef with the provided name within this proc.
+    pub fn actor_ref(&self, name: impl AsRef<str>) -> ActorRef {
+        ActorRef::new_from_name(self.clone(), name)
+    }
+
+    /// A human-readable name for logging.
+    pub fn log_name(&self) -> &str {
+        self.label().map(|l| l.as_str()).unwrap_or("?")
+    }
+
+    /// The ResourceId text form: `_label` (singleton), `label-hex16`
+    /// (labeled instance), or `hex16` (unlabeled instance).
+    pub fn resource_name(&self) -> String {
+        match (self.id.uid(), self.id.label()) {
+            (Uid::Singleton(label), _) => format!("_{}", label),
+            (Uid::Instance(uid), Some(label)) => format!("{}-{:016x}", label, uid),
+            (Uid::Instance(uid), None) => format!("{:016x}", uid),
+        }
+    }
+}
+
+/// Parse a name in ResourceId format into a (Uid, Option<Label>) pair.
+///
+/// Formats: `_label` (singleton), `label-hex16` (labeled instance),
+/// `hex16` (unlabeled instance). Falls back to singleton from stripped name.
+pub fn parse_resource_name(s: &str) -> (Uid, Option<Label>) {
+    if let Some(rest) = s.strip_prefix('_') {
+        if let Ok(label) = Label::new(rest) {
+            return (Uid::Singleton(label.clone()), Some(label));
+        }
+    }
+
+    if s.len() >= 18 {
+        let dash_pos = s.len() - 17;
+        if s.as_bytes()[dash_pos] == b'-' {
+            let hex_part = &s[dash_pos + 1..];
+            let label_part = &s[..dash_pos];
+            if hex_part.len() == 16 && hex_part.chars().all(|c| c.is_ascii_hexdigit()) {
+                if let (Ok(uid), Ok(label)) =
+                    (u64::from_str_radix(hex_part, 16), Label::new(label_part))
+                {
+                    return (Uid::Instance(uid), Some(label));
+                }
+            }
+        }
+    }
+
+    if s.len() <= 16 && !s.is_empty() && s.chars().all(|c| c.is_ascii_hexdigit()) {
+        if let Ok(uid) = u64::from_str_radix(s, 16) {
+            return (Uid::Instance(uid), None);
+        }
+    }
+
+    let label = Label::strip(s);
+    (Uid::Singleton(label.clone()), Some(label))
 }
 
 impl PartialEq for ProcRef {
@@ -165,6 +258,13 @@ impl ActorRef {
         Self { id, location }
     }
 
+    /// Create an ActorRef from a ProcRef and name string (parsed in ResourceId format).
+    pub fn new_from_name(proc_ref: ProcRef, name: impl AsRef<str>) -> Self {
+        let (uid, label) = parse_resource_name(name.as_ref());
+        let actor_id = id::ActorId::new(uid, proc_ref.id.clone(), label);
+        Self::new(actor_id, proc_ref.location)
+    }
+
     /// Returns the actor id.
     pub fn id(&self) -> &ActorId {
         &self.id
@@ -173,6 +273,61 @@ impl ActorRef {
     /// Returns the location.
     pub fn location(&self) -> &Location {
         &self.location
+    }
+
+    /// The actor's channel address.
+    pub fn addr(&self) -> &ChannelAddr {
+        self.location.addr()
+    }
+
+    /// The actor's uid.
+    pub fn uid(&self) -> &Uid {
+        self.id.uid()
+    }
+
+    /// The actor's label: explicit metadata label for instances,
+    /// or singleton name for singletons.
+    pub fn label(&self) -> Option<&Label> {
+        self.id.label().or_else(|| match self.id.uid() {
+            Uid::Singleton(label) => Some(label),
+            _ => None,
+        })
+    }
+
+    /// Reconstruct the parent ProcRef (with location preserved).
+    pub fn proc_ref(&self) -> ProcRef {
+        ProcRef::new(self.id.proc_id().clone(), self.location.clone())
+    }
+
+    /// Create a PortRef for a port on this actor.
+    pub fn port_ref(&self, port: crate::port::Port) -> PortRef {
+        PortRef::new(
+            id::PortId::new(self.id.clone(), port),
+            self.location.clone(),
+        )
+    }
+
+    /// Create an ActorRef for a root actor on a proc.
+    pub fn root(proc_ref: ProcRef, label: impl Into<Label>) -> Self {
+        let label = label.into();
+        let actor_id = id::ActorId::singleton(label, proc_ref.id.clone());
+        Self::new(actor_id, proc_ref.location)
+    }
+
+    /// Create an ActorRef for a child actor with a random uid.
+    pub fn unique_child(&self) -> Self {
+        let child_id = id::ActorId::instance(self.id.proc_id().clone());
+        Self::new(child_id, self.location.clone())
+    }
+
+    /// Whether this is a root actor (singleton uid).
+    pub fn is_root(&self) -> bool {
+        matches!(self.id.uid(), Uid::Singleton(_))
+    }
+
+    /// A human-readable name for logging.
+    pub fn log_name(&self) -> &str {
+        self.label().map(|l| l.as_str()).unwrap_or("?")
     }
 }
 
@@ -274,6 +429,11 @@ impl PortRef {
     pub fn actor_id(&self) -> &ActorId {
         self.id.actor_id()
     }
+
+    /// Reconstruct the parent ActorRef (with location preserved).
+    pub fn actor_ref(&self) -> ActorRef {
+        ActorRef::new(self.id.actor_id().clone(), self.location.clone())
+    }
 }
 
 impl PartialEq for PortRef {
@@ -347,6 +507,133 @@ impl FromStr for PortRef {
             .parse()
             .map_err(RefParseError::InvalidLocation)?;
         Ok(Self { id, location })
+    }
+}
+
+/// A polymorphic reference: proc, actor, or port.
+///
+/// Used for prefix-based routing in [`MailboxRouter`] and
+/// [`DialMailboxRouter`]. Ordering is lexicographic by
+/// (proc, actor uid, port).
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum Reference {
+    /// A process reference.
+    Proc(ProcRef),
+    /// An actor reference.
+    Actor(ActorRef),
+    /// A port reference.
+    Port(PortRef),
+}
+
+impl Reference {
+    /// Whether `self` is a prefix of `other`.
+    ///
+    /// - Proc is a prefix of any Actor or Port on the same proc.
+    /// - Actor is a prefix of any Port on the same actor.
+    pub fn is_prefix_of(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::Proc(p), Self::Actor(a)) => *p == a.proc_ref(),
+            (Self::Proc(p), Self::Port(pt)) => *p == pt.actor_ref().proc_ref(),
+            (Self::Actor(a), Self::Port(pt)) => *a == pt.actor_ref(),
+            (Self::Proc(p1), Self::Proc(p2)) => p1 == p2,
+            (Self::Actor(a1), Self::Actor(a2)) => a1 == a2,
+            (Self::Port(p1), Self::Port(p2)) => p1 == p2,
+            _ => false,
+        }
+    }
+
+    /// The proc ref of this reference.
+    pub fn proc_ref(&self) -> ProcRef {
+        match self {
+            Self::Proc(p) => p.clone(),
+            Self::Actor(a) => a.proc_ref(),
+            Self::Port(p) => p.actor_ref().proc_ref(),
+        }
+    }
+}
+
+impl PartialOrd for Reference {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for Reference {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        // Order by: proc, then actor uid (None < Some), then port (None < Some).
+        let proc_ord = self.proc_ref().cmp(&other.proc_ref());
+        if proc_ord != std::cmp::Ordering::Equal {
+            return proc_ord;
+        }
+        let self_actor_uid = match self {
+            Self::Proc(_) => None,
+            Self::Actor(a) => Some(a.uid()),
+            Self::Port(p) => Some(p.actor_id().uid()),
+        };
+        let other_actor_uid = match other {
+            Self::Proc(_) => None,
+            Self::Actor(a) => Some(a.uid()),
+            Self::Port(p) => Some(p.actor_id().uid()),
+        };
+        let actor_ord = self_actor_uid.cmp(&other_actor_uid);
+        if actor_ord != std::cmp::Ordering::Equal {
+            return actor_ord;
+        }
+        let self_port = match self {
+            Self::Port(p) => Some(p.id().port()),
+            _ => None,
+        };
+        let other_port = match other {
+            Self::Port(p) => Some(p.id().port()),
+            _ => None,
+        };
+        self_port.cmp(&other_port)
+    }
+}
+
+impl fmt::Display for Reference {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Proc(p) => fmt::Display::fmt(p, f),
+            Self::Actor(a) => fmt::Display::fmt(a, f),
+            Self::Port(p) => fmt::Display::fmt(p, f),
+        }
+    }
+}
+
+impl FromStr for Reference {
+    type Err = RefParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        // Try most specific first.
+        if let Ok(port_ref) = s.parse::<PortRef>() {
+            return Ok(Self::Port(port_ref));
+        }
+        if let Ok(actor_ref) = s.parse::<ActorRef>() {
+            return Ok(Self::Actor(actor_ref));
+        }
+        if let Ok(proc_ref) = s.parse::<ProcRef>() {
+            return Ok(Self::Proc(proc_ref));
+        }
+        Err(RefParseError::MissingSeparator)
+    }
+}
+
+impl From<ProcRef> for Reference {
+    fn from(p: ProcRef) -> Self {
+        Self::Proc(p)
+    }
+}
+
+impl From<ActorRef> for Reference {
+    fn from(a: ActorRef) -> Self {
+        Self::Actor(a)
+    }
+}
+
+impl From<PortRef> for Reference {
+    fn from(p: PortRef) -> Self {
+        Self::Port(p)
     }
 }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #3504
* __->__ #3503
* #3502
* #3501
* #3500
* #3499
* #3498
* #3497

Add navigation, constructors, and convenience accessors to ref_::ProcRef, ref_::ActorRef, and ref_::PortRef, preparing for the removal of the reference module. Also add parse_resource_name() to ref_ for ResourceId format parsing.

This is purely additive — no existing code is modified.

ProcRef gains: unique(), with_name(), actor_ref(), addr(), uid(), label()
ActorRef gains: new_from_name(), proc_ref(), port_ref(), addr(), uid(), label()
PortRef gains: actor_ref()

Differential Revision: [D101700573](https://our.internmc.facebook.com/intern/diff/D101700573/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D101700573/)!