### PR TITLE
[hyperactor] begin internal migration from reference:: to ref_:: types

### DIFF
--- a/hyperactor/src/actor.rs
+++ b/hyperactor/src/actor.rs
@@ -49,6 +49,7 @@ use crate::proc::Instance;
 use crate::proc::InstanceCell;
 use crate::proc::Ports;
 use crate::proc::Proc;
+use crate::ref_;
 use crate::reference;
 use crate::supervision::ActorSupervisionEvent;
 
@@ -331,8 +332,8 @@ impl<A: Actor + Referable + Binds<Self> + Default> RemoteSpawn for A {
 /// with the ID of the actor being served.
 #[derive(Debug)]
 pub struct ActorError {
-    /// The ActorId for the actor that generated this error.
-    pub actor_id: Box<reference::ActorId>,
+    /// The ActorRef for the actor that generated this error.
+    pub actor_id: Box<ref_::ActorRef>,
     /// The kind of error that occurred.
     pub kind: Box<ActorErrorKind>,
 }
@@ -402,7 +403,7 @@ impl ActorErrorKind {
 
 impl ActorError {
     /// Create a new actor server error with the provided id and kind.
-    pub(crate) fn new(actor_id: &reference::ActorId, kind: ActorErrorKind) -> Self {
+    pub(crate) fn new(actor_id: &ref_::ActorRef, kind: ActorErrorKind) -> Self {
         Self {
             actor_id: Box::new(actor_id.clone()),
             kind: Box::new(kind),
@@ -435,7 +436,7 @@ impl From<MailboxError> for ActorError {
 impl From<MailboxSenderError> for ActorError {
     fn from(inner: MailboxSenderError) -> Self {
         Self {
-            actor_id: Box::new(inner.location().actor_id().clone()),
+            actor_id: Box::new(inner.location().actor_id()),
             kind: Box::new(ActorErrorKind::mailbox_sender(inner)),
         }
     }
@@ -651,8 +652,8 @@ impl<A: Actor> ActorHandle<A> {
         &self.cell
     }
 
-    /// The [`ActorId`] of the actor represented by this handle.
-    pub fn actor_id(&self) -> &reference::ActorId {
+    /// The [`ActorRef`] of the actor represented by this handle.
+    pub fn actor_id(&self) -> &ref_::ActorRef {
         self.cell.actor_id()
     }
 
@@ -1595,20 +1596,22 @@ mod tests {
         let handle = proc.spawn::<EchoActor>("echo_introspect", actor).unwrap();
 
         let (reply_port, reply_rx) = client.open_once_port::<IntrospectResult>();
-        reference::PortRef::<IntrospectMessage>::attest_message_port(handle.actor_id())
-            .send(
-                &client,
-                IntrospectMessage::Query {
-                    view: IntrospectView::Actor,
-                    reply: reply_port.bind(),
-                },
-            )
-            .unwrap();
+        reference::PortRef::<IntrospectMessage>::attest_message_port(
+            &handle.actor_id().clone().into(),
+        )
+        .send(
+            &client,
+            IntrospectMessage::Query {
+                view: IntrospectView::Actor,
+                reply: reply_port.bind(),
+            },
+        )
+        .unwrap();
         let payload = reply_rx.recv().await.unwrap();
 
         assert_eq!(
             payload.identity,
-            crate::introspect::IntrospectRef::Actor(handle.actor_id().clone())
+            crate::introspect::IntrospectRef::Actor(handle.actor_id().clone().into())
         );
         assert_valid_attrs(&payload);
         assert_has_attr(&payload, "status");
@@ -1770,15 +1773,17 @@ mod tests {
 
         let child_ref = reference::Reference::Actor(test_proc_id("nonexistent").actor_id("child"));
         let (reply_port, reply_rx) = client.open_once_port::<IntrospectResult>();
-        reference::PortRef::<IntrospectMessage>::attest_message_port(handle.actor_id())
-            .send(
-                &client,
-                IntrospectMessage::QueryChild {
-                    child_ref,
-                    reply: reply_port.bind(),
-                },
-            )
-            .unwrap();
+        reference::PortRef::<IntrospectMessage>::attest_message_port(
+            &handle.actor_id().clone().into(),
+        )
+        .send(
+            &client,
+            IntrospectMessage::QueryChild {
+                child_ref,
+                reply: reply_port.bind(),
+            },
+        )
+        .unwrap();
         let payload = reply_rx.recv().await.unwrap();
 
         assert_eq!(
@@ -1818,15 +1823,17 @@ mod tests {
             .unwrap();
 
         let (reply_port, reply_rx) = client.open_once_port::<IntrospectResult>();
-        reference::PortRef::<IntrospectMessage>::attest_message_port(handle.actor_id())
-            .send(
-                &client,
-                IntrospectMessage::Query {
-                    view: IntrospectView::Actor,
-                    reply: reply_port.bind(),
-                },
-            )
-            .unwrap();
+        reference::PortRef::<IntrospectMessage>::attest_message_port(
+            &handle.actor_id().clone().into(),
+        )
+        .send(
+            &client,
+            IntrospectMessage::Query {
+                view: IntrospectView::Actor,
+                reply: reply_port.bind(),
+            },
+        )
+        .unwrap();
         let payload = reply_rx.recv().await.unwrap();
 
         // The runtime task returns actor attrs (with status), NOT
@@ -1859,20 +1866,22 @@ mod tests {
 
         // Query the child — supervisor should be the parent.
         let (reply_port, reply_rx) = client.open_once_port::<IntrospectResult>();
-        reference::PortRef::<IntrospectMessage>::attest_message_port(child_handle.actor_id())
-            .send(
-                &client,
-                IntrospectMessage::Query {
-                    view: IntrospectView::Actor,
-                    reply: reply_port.bind(),
-                },
-            )
-            .unwrap();
+        reference::PortRef::<IntrospectMessage>::attest_message_port(
+            &child_handle.actor_id().clone().into(),
+        )
+        .send(
+            &client,
+            IntrospectMessage::Query {
+                view: IntrospectView::Actor,
+                reply: reply_port.bind(),
+            },
+        )
+        .unwrap();
         let child_payload = reply_rx.recv().await.unwrap();
 
         assert_eq!(
             child_payload.identity,
-            crate::introspect::IntrospectRef::Actor(child_handle.actor_id().clone()),
+            crate::introspect::IntrospectRef::Actor(child_handle.actor_id().clone().into()),
         );
         // Verify it has actor attrs (status present).
         assert!(
@@ -1882,21 +1891,23 @@ mod tests {
         assert_eq!(
             child_payload.parent,
             Some(crate::introspect::IntrospectRef::Actor(
-                parent_handle.actor_id().clone()
+                parent_handle.actor_id().clone().into()
             )),
         );
 
         // Query the parent — children should include the child.
         let (reply_port, reply_rx) = client.open_once_port::<IntrospectResult>();
-        reference::PortRef::<IntrospectMessage>::attest_message_port(parent_handle.actor_id())
-            .send(
-                &client,
-                IntrospectMessage::Query {
-                    view: IntrospectView::Actor,
-                    reply: reply_port.bind(),
-                },
-            )
-            .unwrap();
+        reference::PortRef::<IntrospectMessage>::attest_message_port(
+            &parent_handle.actor_id().clone().into(),
+        )
+        .send(
+            &client,
+            IntrospectMessage::Query {
+                view: IntrospectView::Actor,
+                reply: reply_port.bind(),
+            },
+        )
+        .unwrap();
         let parent_payload = reply_rx.recv().await.unwrap();
 
         assert!(parent_payload.parent.is_none());
@@ -1904,7 +1915,7 @@ mod tests {
             parent_payload
                 .children
                 .contains(&crate::introspect::IntrospectRef::Actor(
-                    child_handle.actor_id().clone()
+                    child_handle.actor_id().clone().into()
                 )),
         );
 
@@ -1934,15 +1945,17 @@ mod tests {
             .unwrap();
 
         let (reply_port, reply_rx) = client.open_once_port::<IntrospectResult>();
-        reference::PortRef::<IntrospectMessage>::attest_message_port(handle.actor_id())
-            .send(
-                &client,
-                IntrospectMessage::Query {
-                    view: IntrospectView::Actor,
-                    reply: reply_port.bind(),
-                },
-            )
-            .unwrap();
+        reference::PortRef::<IntrospectMessage>::attest_message_port(
+            &handle.actor_id().clone().into(),
+        )
+        .send(
+            &client,
+            IntrospectMessage::Query {
+                view: IntrospectView::Actor,
+                reply: reply_port.bind(),
+            },
+        )
+        .unwrap();
         let payload = reply_rx.recv().await.unwrap();
 
         assert_status(&payload, "idle");
@@ -1969,15 +1982,17 @@ mod tests {
         let _ = rx.recv().await.unwrap();
 
         let (reply_port, reply_rx) = client.open_once_port::<IntrospectResult>();
-        reference::PortRef::<IntrospectMessage>::attest_message_port(handle.actor_id())
-            .send(
-                &client,
-                IntrospectMessage::Query {
-                    view: IntrospectView::Actor,
-                    reply: reply_port.bind(),
-                },
-            )
-            .unwrap();
+        reference::PortRef::<IntrospectMessage>::attest_message_port(
+            &handle.actor_id().clone().into(),
+        )
+        .send(
+            &client,
+            IntrospectMessage::Query {
+                view: IntrospectView::Actor,
+                reply: reply_port.bind(),
+            },
+        )
+        .unwrap();
         let payload = reply_rx.recv().await.unwrap();
 
         assert_status(&payload, "idle");
@@ -2008,28 +2023,32 @@ mod tests {
 
         // First introspect query.
         let (reply_port, reply_rx) = client.open_once_port::<IntrospectResult>();
-        reference::PortRef::<IntrospectMessage>::attest_message_port(handle.actor_id())
-            .send(
-                &client,
-                IntrospectMessage::Query {
-                    view: IntrospectView::Actor,
-                    reply: reply_port.bind(),
-                },
-            )
-            .unwrap();
+        reference::PortRef::<IntrospectMessage>::attest_message_port(
+            &handle.actor_id().clone().into(),
+        )
+        .send(
+            &client,
+            IntrospectMessage::Query {
+                view: IntrospectView::Actor,
+                reply: reply_port.bind(),
+            },
+        )
+        .unwrap();
         let payload1 = reply_rx.recv().await.unwrap();
 
         // Second introspect query.
         let (reply_port2, reply_rx2) = client.open_once_port::<IntrospectResult>();
-        reference::PortRef::<IntrospectMessage>::attest_message_port(handle.actor_id())
-            .send(
-                &client,
-                IntrospectMessage::Query {
-                    view: IntrospectView::Actor,
-                    reply: reply_port2.bind(),
-                },
-            )
-            .unwrap();
+        reference::PortRef::<IntrospectMessage>::attest_message_port(
+            &handle.actor_id().clone().into(),
+        )
+        .send(
+            &client,
+            IntrospectMessage::Query {
+                view: IntrospectView::Actor,
+                reply: reply_port2.bind(),
+            },
+        )
+        .unwrap();
         let payload2 = reply_rx2.recv().await.unwrap();
 
         // Neither should show IntrospectMessage as the handler.
@@ -2101,16 +2120,17 @@ mod tests {
         let handle = proc.spawn::<EchoActor>("echo_qch", actor).unwrap();
 
         // Before registering, query_child returns None.
-        let test_ref = reference::Reference::Actor(test_proc_id("test").actor_id("child"));
+        let test_ref: ref_::Reference =
+            reference::Reference::Actor(test_proc_id("test").actor_id("child")).into();
         assert!(handle.cell().query_child(&test_ref).is_none());
 
         // Register a callback.
         handle.cell().set_query_child_handler(|child_ref| {
             use crate::introspect::IntrospectRef;
-            let identity = match &child_ref {
-                reference::Reference::Proc(id) => IntrospectRef::Proc(id.clone()),
-                reference::Reference::Actor(id) => IntrospectRef::Actor(id.clone()),
-                reference::Reference::Port(id) => IntrospectRef::Actor(id.actor_id().clone()),
+            let identity = match child_ref {
+                ref_::Reference::Proc(p) => IntrospectRef::Proc(p.clone().into()),
+                ref_::Reference::Actor(a) => IntrospectRef::Actor(a.clone().into()),
+                ref_::Reference::Port(p) => IntrospectRef::Actor(p.actor_ref().into()),
             };
             IntrospectResult {
                 identity,
@@ -2192,15 +2212,17 @@ mod tests {
 
         // Send introspect query via the dedicated introspect port.
         let (reply_port, reply_rx) = client.open_once_port::<IntrospectResult>();
-        reference::PortRef::<IntrospectMessage>::attest_message_port(handle.actor_id())
-            .send(
-                &client,
-                IntrospectMessage::Query {
-                    view: IntrospectView::Actor,
-                    reply: reply_port.bind(),
-                },
-            )
-            .unwrap();
+        reference::PortRef::<IntrospectMessage>::attest_message_port(
+            &handle.actor_id().clone().into(),
+        )
+        .send(
+            &client,
+            IntrospectMessage::Query {
+                view: IntrospectView::Actor,
+                reply: reply_port.bind(),
+            },
+        )
+        .unwrap();
 
         // Must not hang — the introspect task runs independently.
         let payload = tokio::time::timeout(Duration::from_secs(5), reply_rx.recv())
@@ -2237,28 +2259,32 @@ mod tests {
 
         // First introspect query.
         let (reply_port1, reply_rx1) = client.open_once_port::<IntrospectResult>();
-        reference::PortRef::<IntrospectMessage>::attest_message_port(handle.actor_id())
-            .send(
-                &client,
-                IntrospectMessage::Query {
-                    view: IntrospectView::Actor,
-                    reply: reply_port1.bind(),
-                },
-            )
-            .unwrap();
+        reference::PortRef::<IntrospectMessage>::attest_message_port(
+            &handle.actor_id().clone().into(),
+        )
+        .send(
+            &client,
+            IntrospectMessage::Query {
+                view: IntrospectView::Actor,
+                reply: reply_port1.bind(),
+            },
+        )
+        .unwrap();
         let payload1 = reply_rx1.recv().await.unwrap();
 
         // Second introspect query.
         let (reply_port2, reply_rx2) = client.open_once_port::<IntrospectResult>();
-        reference::PortRef::<IntrospectMessage>::attest_message_port(handle.actor_id())
-            .send(
-                &client,
-                IntrospectMessage::Query {
-                    view: IntrospectView::Actor,
-                    reply: reply_port2.bind(),
-                },
-            )
-            .unwrap();
+        reference::PortRef::<IntrospectMessage>::attest_message_port(
+            &handle.actor_id().clone().into(),
+        )
+        .send(
+            &client,
+            IntrospectMessage::Query {
+                view: IntrospectView::Actor,
+                reply: reply_port2.bind(),
+            },
+        )
+        .unwrap();
         let payload2 = reply_rx2.recv().await.unwrap();
 
         // Both should report the user message handler, not IntrospectMessage.
@@ -2284,7 +2310,7 @@ mod tests {
     async fn test_introspectable_instance_responds_to_query() {
         let proc = Proc::local();
         let (bridge, handle) = proc.introspectable_instance("bridge").unwrap();
-        let actor_id = handle.actor_id().clone();
+        let actor_id: reference::ActorId = handle.actor_id().clone().into();
 
         let (reply_port, reply_rx) = bridge.open_once_port::<IntrospectResult>();
         reference::PortRef::<IntrospectMessage>::attest_message_port(&actor_id)
@@ -2323,7 +2349,7 @@ mod tests {
         let proc = Proc::local();
         let (client, _client_handle) = proc.instance("client").unwrap();
         let (_mailbox, mailbox_handle) = proc.instance("mailbox").unwrap();
-        let mailbox_id = mailbox_handle.actor_id().clone();
+        let mailbox_id: reference::ActorId = mailbox_handle.actor_id().clone().into();
 
         let (reply_port, reply_rx) = client.open_once_port::<IntrospectResult>();
         reference::PortRef::<IntrospectMessage>::attest_message_port(&mailbox_id)

--- a/hyperactor/src/context.rs
+++ b/hyperactor/src/context.rs
@@ -35,7 +35,7 @@ use crate::mailbox;
 use crate::mailbox::MailboxSender;
 use crate::mailbox::MessageEnvelope;
 use crate::ordering::SEQ_INFO;
-use crate::reference;
+use crate::ref_;
 use crate::time::Alarm;
 
 /// Policy for handling SEQ_INFO in message headers.
@@ -73,7 +73,7 @@ pub(crate) trait MailboxExt: Mailbox {
     /// All messages posted from actors should use this implementation.
     fn post(
         &self,
-        dest: reference::PortId,
+        dest: ref_::PortRef,
         headers: Flattrs,
         data: wirevalue::Any,
         return_undeliverable: bool,
@@ -83,24 +83,24 @@ pub(crate) trait MailboxExt: Mailbox {
     /// Split a port, using a provided reducer spec, if provided.
     fn split(
         &self,
-        port_id: reference::PortId,
+        port_id: ref_::PortRef,
         reducer_spec: Option<ReducerSpec>,
         reducer_mode: ReducerMode,
         return_undeliverable: bool,
-    ) -> anyhow::Result<reference::PortId>;
+    ) -> anyhow::Result<ref_::PortRef>;
 }
 
 // Tracks mailboxes that have emitted a `CanSend::post` warning due to
 // missing an `Undeliverable<MessageEnvelope>` binding. In this
 // context, mailboxes are few and long-lived; unbounded growth is not
 // a realistic concern.
-static CAN_SEND_WARNED_MAILBOXES: OnceLock<DashSet<reference::ActorId>> = OnceLock::new();
+static CAN_SEND_WARNED_MAILBOXES: OnceLock<DashSet<ref_::ActorRef>> = OnceLock::new();
 
 /// Only actors CanSend because they need a return port.
 impl<T: Actor + Send + Sync> MailboxExt for T {
     fn post(
         &self,
-        dest: reference::PortId,
+        dest: ref_::PortRef,
         mut headers: Flattrs,
         data: wirevalue::Any,
         return_undeliverable: bool,
@@ -143,14 +143,14 @@ impl<T: Actor + Send + Sync> MailboxExt for T {
 
     fn split(
         &self,
-        port_id: reference::PortId,
+        port_id: ref_::PortRef,
         reducer_spec: Option<ReducerSpec>,
         reducer_mode: ReducerMode,
         return_undeliverable: bool,
-    ) -> anyhow::Result<reference::PortId> {
+    ) -> anyhow::Result<ref_::PortRef> {
         fn post(
             mailbox: &mailbox::Mailbox,
-            port_id: reference::PortId,
+            port_id: ref_::PortRef,
             msg: wirevalue::Any,
             return_undeliverable: bool,
         ) {
@@ -169,7 +169,10 @@ impl<T: Actor + Send + Sync> MailboxExt for T {
         }
 
         let port_index = self.mailbox().allocate_port();
-        let split_port = self.mailbox().actor_id().port_id(port_index);
+        let split_port = self
+            .mailbox()
+            .actor_id()
+            .port_ref(crate::port::Port::from(port_index));
         let mailbox = self.mailbox().clone();
         let reducer = reducer_spec
             .map(

--- a/hyperactor/src/host.rs
+++ b/hyperactor/src/host.rs
@@ -89,6 +89,7 @@ use crate::mailbox::MailboxServer;
 use crate::mailbox::MailboxServerHandle;
 use crate::mailbox::MessageEnvelope;
 use crate::mailbox::Undeliverable;
+use crate::ref_;
 use crate::reference;
 
 /// Name of the system service proc on a host — hosts the admin actor
@@ -118,15 +119,15 @@ pub enum HostError {
 
     /// Failures occuring while spawning a subprocess.
     #[error("proc '{0}' (command: {1}) failed to spawn process: {2}")]
-    ProcessSpawnFailure(reference::ProcId, String, #[source] std::io::Error),
+    ProcessSpawnFailure(ref_::ProcRef, String, #[source] std::io::Error),
 
     /// Failures occuring while configuring a subprocess.
     #[error("proc '{0}' failed to configure process: {1}")]
-    ProcessConfigurationFailure(reference::ProcId, #[source] anyhow::Error),
+    ProcessConfigurationFailure(ref_::ProcRef, #[source] anyhow::Error),
 
     /// Failures occuring while spawning a management actor in a proc.
     #[error("failed to spawn agent on proc '{0}': {1}")]
-    AgentSpawnFailure(reference::ProcId, #[source] anyhow::Error),
+    AgentSpawnFailure(ref_::ProcRef, #[source] anyhow::Error),
 
     /// An input parameter was missing.
     #[error("parameter '{0}' missing: {1}")]
@@ -255,12 +256,12 @@ impl<M: ProcManager> Host<M> {
         &mut self,
         name: String,
         config: M::Config,
-    ) -> Result<(reference::ProcId, reference::ActorRef<ManagerAgent<M>>), HostError> {
+    ) -> Result<(ref_::ProcRef, reference::ActorRef<ManagerAgent<M>>), HostError> {
         if self.procs.contains(&name) {
             return Err(HostError::ProcExists(name));
         }
 
-        let proc_id = reference::ProcId::from_resource_name(self.frontend_addr.clone(), &name);
+        let proc_id = ref_::ProcRef::from_resource_name(self.frontend_addr.clone(), &name);
         let handle = self
             .manager
             .spawn(proc_id.clone(), self.backend_addr.clone(), config)
@@ -281,7 +282,7 @@ impl<M: ProcManager> Host<M> {
         })?;
 
         self.router
-            .bind(proc_id.clone().into(), ready.addr().clone());
+            .bind(ref_::Reference::from(proc_id.clone()), ready.addr().clone());
         self.procs.insert(name.clone());
 
         Ok((proc_id, ready.agent_ref().clone()))
@@ -312,9 +313,10 @@ impl MailboxSender for ProcOrDial {
         envelope: MessageEnvelope,
         return_handle: PortHandle<Undeliverable<MessageEnvelope>>,
     ) {
-        if &envelope.dest().actor_id().proc_id() == self.service_proc.proc_id() {
+        let dest_proc = envelope.dest().actor_ref().proc_ref();
+        if &dest_proc == self.service_proc.proc_id() {
             self.service_proc.post_unchecked(envelope, return_handle);
-        } else if &envelope.dest().actor_id().proc_id() == self.local_proc.proc_id() {
+        } else if &dest_proc == self.local_proc.proc_id() {
             self.local_proc.post_unchecked(envelope, return_handle);
         } else {
             self.dialer.post_unchecked(envelope, return_handle)
@@ -485,10 +487,10 @@ pub trait SingleTerminate: Send + Sync {
     async fn terminate_proc(
         &self,
         cx: &impl context::Actor,
-        proc: &reference::ProcId,
+        proc: &ref_::ProcRef,
         timeout: std::time::Duration,
         reason: &str,
-    ) -> Result<(Vec<reference::ActorId>, Vec<reference::ActorId>), anyhow::Error>;
+    ) -> Result<(Vec<ref_::ActorRef>, Vec<ref_::ActorRef>), anyhow::Error>;
 }
 
 /// Trait for managers that can terminate many child **units** in
@@ -563,8 +565,8 @@ impl<M: ProcManager + BulkTerminate> Host<M> {
         // Unbind procs from the router so if new procs are made with the same
         // names, they can use the same slot.
         for name in self.procs.drain() {
-            let proc_id = reference::ProcId::from_resource_name(self.frontend_addr.clone(), &name);
-            self.router.unbind(&proc_id.into());
+            let proc_ref = ref_::ProcRef::from_resource_name(self.frontend_addr.clone(), &name);
+            self.router.unbind(&ref_::Reference::from(proc_ref));
         }
         summary
     }
@@ -575,10 +577,10 @@ impl<M: ProcManager + SingleTerminate> SingleTerminate for Host<M> {
     async fn terminate_proc(
         &self,
         cx: &impl context::Actor,
-        proc: &reference::ProcId,
+        proc: &ref_::ProcRef,
         timeout: Duration,
         reason: &str,
-    ) -> Result<(Vec<reference::ActorId>, Vec<reference::ActorId>), anyhow::Error> {
+    ) -> Result<(Vec<ref_::ActorRef>, Vec<ref_::ActorRef>), anyhow::Error> {
         self.manager.terminate_proc(cx, proc, timeout, reason).await
     }
 }
@@ -618,7 +620,7 @@ impl<'a, H: ProcHandle> ReadyProc<'a, H> {
     }
 
     /// The proc's logical identity.
-    pub fn proc_id(&self) -> &reference::ProcId {
+    pub fn proc_id(&self) -> &ref_::ProcRef {
         self.handle.proc_id()
     }
 
@@ -685,7 +687,7 @@ pub trait ProcHandle: Clone + Send + Sync + 'static {
     type TerminalStatus: std::fmt::Debug + Clone + Send + Sync + 'static;
 
     /// The proc's logical identity on this host.
-    fn proc_id(&self) -> &reference::ProcId;
+    fn proc_id(&self) -> &ref_::ProcRef;
 
     /// The proc's address (the one callers bind into the host
     /// router). May return `None` before `ready()` completes.
@@ -766,7 +768,7 @@ pub trait ProcManager {
     /// ref is returned.
     async fn spawn(
         &self,
-        proc_id: reference::ProcId,
+        proc_id: ref_::ProcRef,
         forwarder_addr: ChannelAddr,
         config: Self::Config,
     ) -> Result<Self::Handle, HostError>;
@@ -811,8 +813,8 @@ pub enum LocalProcStatus {
 ///
 ///   No OS signals are sent or required.
 pub struct LocalProcManager<S> {
-    procs: Arc<Mutex<HashMap<reference::ProcId, Proc>>>,
-    stopping: Arc<Mutex<HashMap<reference::ProcId, tokio::sync::watch::Sender<LocalProcStatus>>>>,
+    procs: Arc<Mutex<HashMap<ref_::ProcRef, Proc>>>,
+    stopping: Arc<Mutex<HashMap<ref_::ProcRef, tokio::sync::watch::Sender<LocalProcStatus>>>>,
     spawn: S,
 }
 
@@ -833,7 +835,7 @@ impl<S> LocalProcManager<S> {
     /// Status transitions through `Stopping` -> `Stopped` and is
     /// observable via [`local_proc_status`] and [`watch`]. Idempotent:
     /// no-ops if the proc is already stopping or stopped.
-    pub async fn request_stop(&self, proc: &reference::ProcId, timeout: Duration, reason: &str) {
+    pub async fn request_stop(&self, proc: &ref_::ProcRef, timeout: Duration, reason: &str) {
         {
             let guard = self.stopping.lock().await;
             if guard.contains_key(proc) {
@@ -849,9 +851,9 @@ impl<S> LocalProcManager<S> {
             }
         };
 
-        let proc_id = proc_handle.proc_id().clone();
+        let proc_ref: ref_::ProcRef = proc_handle.proc_id().clone();
         let (tx, _) = tokio::sync::watch::channel(LocalProcStatus::Stopping);
-        self.stopping.lock().await.insert(proc_id.clone(), tx);
+        self.stopping.lock().await.insert(proc_ref.clone(), tx);
 
         let stopping = Arc::clone(&self.stopping);
         let reason = reason.to_string();
@@ -862,7 +864,7 @@ impl<S> LocalProcManager<S> {
             {
                 tracing::warn!(error = %e, "request_stop(local): destroy_and_wait failed");
             }
-            if let Some(tx) = stopping.lock().await.get(&proc_id) {
+            if let Some(tx) = stopping.lock().await.get(&proc_ref) {
                 let _ = tx.send(LocalProcStatus::Stopped);
             }
         });
@@ -872,7 +874,7 @@ impl<S> LocalProcManager<S> {
     /// [`request_stop`].
     ///
     /// Returns `None` if the proc was never stopped through this path.
-    pub async fn local_proc_status(&self, proc: &reference::ProcId) -> Option<LocalProcStatus> {
+    pub async fn local_proc_status(&self, proc: &ref_::ProcRef) -> Option<LocalProcStatus> {
         self.stopping.lock().await.get(proc).map(|tx| *tx.borrow())
     }
 
@@ -882,7 +884,7 @@ impl<S> LocalProcManager<S> {
     /// Returns `None` if the proc was never stopped through this path.
     pub async fn watch(
         &self,
-        proc: &reference::ProcId,
+        proc: &ref_::ProcRef,
     ) -> Option<tokio::sync::watch::Receiver<LocalProcStatus>> {
         self.stopping
             .lock()
@@ -945,10 +947,10 @@ where
     async fn terminate_proc(
         &self,
         _cx: &impl context::Actor,
-        proc: &reference::ProcId,
+        proc: &ref_::ProcRef,
         timeout: std::time::Duration,
         reason: &str,
-    ) -> Result<(Vec<reference::ActorId>, Vec<reference::ActorId>), anyhow::Error> {
+    ) -> Result<(Vec<ref_::ActorRef>, Vec<ref_::ActorRef>), anyhow::Error> {
         // Snapshot procs so we don't hold the lock across awaits.
         let procs: Option<Proc> = {
             let mut guard = self.procs.lock().await;
@@ -980,10 +982,10 @@ where
 /// **Type parameter:** `A` is constrained by the `ProcHandle::Agent`
 /// bound (`Actor + Referable`).
 pub struct LocalHandle<A: Actor + Referable> {
-    proc_id: reference::ProcId,
+    proc_id: ref_::ProcRef,
     addr: ChannelAddr,
     agent_ref: reference::ActorRef<A>,
-    procs: Arc<Mutex<HashMap<reference::ProcId, Proc>>>,
+    procs: Arc<Mutex<HashMap<ref_::ProcRef, Proc>>>,
 }
 
 // Manual `Clone` to avoid requiring `A: Clone`.
@@ -1005,7 +1007,7 @@ impl<A: Actor + Referable> ProcHandle for LocalHandle<A> {
     type Agent = A;
     type TerminalStatus = ();
 
-    fn proc_id(&self) -> &reference::ProcId {
+    fn proc_id(&self) -> &ref_::ProcRef {
         &self.proc_id
     }
 
@@ -1107,7 +1109,7 @@ where
     #[crate::instrument(fields(proc_id=proc_id.to_string(), addr=forwarder_addr.to_string()))]
     async fn spawn(
         &self,
-        proc_id: reference::ProcId,
+        proc_id: ref_::ProcRef,
         forwarder_addr: ChannelAddr,
         _config: (),
     ) -> Result<Self::Handle, HostError> {
@@ -1160,7 +1162,7 @@ where
 /// protocol.
 pub struct ProcessProcManager<A> {
     program: std::path::PathBuf,
-    children: Arc<Mutex<HashMap<reference::ProcId, Child>>>,
+    children: Arc<Mutex<HashMap<ref_::ProcRef, Child>>>,
     _phantom: PhantomData<A>,
 }
 
@@ -1211,7 +1213,7 @@ impl<A> Drop for ProcessProcManager<A> {
 /// typed remote reference).
 #[derive(Debug)]
 pub struct ProcessHandle<A: Actor + Referable> {
-    proc_id: reference::ProcId,
+    proc_id: ref_::ProcRef,
     addr: ChannelAddr,
     agent_ref: reference::ActorRef<A>,
 }
@@ -1234,7 +1236,7 @@ impl<A: Actor + Referable> ProcHandle for ProcessHandle<A> {
     type Agent = A;
     type TerminalStatus = ();
 
-    fn proc_id(&self) -> &reference::ProcId {
+    fn proc_id(&self) -> &ref_::ProcRef {
         &self.proc_id
     }
 
@@ -1288,7 +1290,7 @@ where
     #[crate::instrument(fields(proc_id=proc_id.to_string(), addr=forwarder_addr.to_string()))]
     async fn spawn(
         &self,
-        proc_id: reference::ProcId,
+        proc_id: ref_::ProcRef,
         forwarder_addr: ChannelAddr,
         _config: (),
     ) -> Result<Self::Handle, HostError> {
@@ -1357,7 +1359,7 @@ where
         S: FnOnce(Proc) -> F,
         F: Future<Output = Result<ActorHandle<A>, anyhow::Error>>,
     {
-        let proc_id: reference::ProcId = Self::parse_env("HYPERACTOR_HOST_PROC_ID")?;
+        let proc_id: ref_::ProcRef = Self::parse_env("HYPERACTOR_HOST_PROC_ID")?;
         let backend_addr: ChannelAddr = Self::parse_env("HYPERACTOR_HOST_BACKEND_ADDR")?;
         let callback_addr: ChannelAddr = Self::parse_env("HYPERACTOR_HOST_CALLBACK_ADDR")?;
         spawn_proc(proc_id, backend_addr, callback_addr, spawn).await
@@ -1381,7 +1383,7 @@ where
 /// the provided `callback_addr`.
 #[crate::instrument(fields(proc_id=proc_id.to_string(), addr=backend_addr.to_string(), callback_addr=callback_addr.to_string()))]
 pub async fn spawn_proc<A, S, F>(
-    proc_id: reference::ProcId,
+    proc_id: ref_::ProcRef,
     backend_addr: ChannelAddr,
     callback_addr: ChannelAddr,
     spawn: S,
@@ -1441,7 +1443,7 @@ pub mod testing {
             cx: &Context<Self>,
             reply: reference::OncePortRef<reference::ActorId>,
         ) -> Result<(), anyhow::Error> {
-            reply.send(cx, cx.self_id().clone())?;
+            reply.send(cx, reference::ActorId::from(cx.self_id().clone()))?;
             Ok(())
         }
     }
@@ -1469,7 +1471,7 @@ mod tests {
         let (proc_id1, _ref) = host.spawn("proc1".to_string(), ()).await.unwrap();
         assert_eq!(
             proc_id1,
-            reference::ProcId::from_resource_name(host.addr().clone(), "proc1")
+            ref_::ProcRef::from_resource_name(host.addr().clone(), "proc1")
         );
         assert!(procs.lock().await.contains_key(&proc_id1));
 
@@ -1542,8 +1544,8 @@ mod tests {
         assert!(matches!(host.addr().transport(), ChannelTransport::Unix));
         let (proc1, echo1) = host.spawn("proc1".to_string(), ()).await.unwrap();
         let (proc2, echo2) = host.spawn("proc2".to_string(), ()).await.unwrap();
-        assert_eq!(echo1.actor_id().proc_id(), proc1);
-        assert_eq!(echo2.actor_id().proc_id(), proc2);
+        assert_eq!(*echo1.actor_id().proc_id(), proc1);
+        assert_eq!(*echo2.actor_id().proc_id(), proc2);
 
         // (2) Duplicate name rejection.
         let dup = host.spawn("proc1".to_string(), ()).await;
@@ -1608,10 +1610,11 @@ mod tests {
     async fn local_ready_and_wait_are_immediate() {
         // Build a LocalHandle directly.
         let addr = ChannelAddr::any(ChannelTransport::Local);
-        let proc_id = reference::ProcId::from_resource_name(addr.clone(), "p");
-        let agent_ref = reference::ActorRef::<()>::attest(proc_id.actor_id("host_agent"));
+        let proc_ref = ref_::ProcRef::from_resource_name(addr.clone(), "p");
+        let actor_ref = proc_ref.actor_ref("host_agent");
+        let agent_ref = reference::ActorRef::<()>::attest(actor_ref.into());
         let h = LocalHandle::<()> {
-            proc_id,
+            proc_id: proc_ref,
             addr,
             agent_ref,
             procs: Arc::new(Mutex::new(HashMap::new())),
@@ -1640,7 +1643,7 @@ mod tests {
 
     #[derive(Debug, Clone)]
     struct TestHandle {
-        id: reference::ProcId,
+        id: ref_::ProcRef,
         addr: ChannelAddr,
         agent: reference::ActorRef<()>,
         mode: ReadyMode,
@@ -1653,7 +1656,7 @@ mod tests {
         type Agent = ();
         type TerminalStatus = ();
 
-        fn proc_id(&self) -> &reference::ProcId {
+        fn proc_id(&self) -> &ref_::ProcRef {
             &self.id
         }
 
@@ -1735,11 +1738,11 @@ mod tests {
 
         async fn spawn(
             &self,
-            proc_id: reference::ProcId,
+            proc_id: ref_::ProcRef,
             forwarder_addr: ChannelAddr,
             _config: (),
         ) -> Result<Self::Handle, HostError> {
-            let agent = reference::ActorRef::<()>::attest(proc_id.actor_id("host_agent"));
+            let agent = reference::ActorRef::<()>::attest(proc_id.actor_ref("host_agent").into());
             Ok(TestHandle {
                 id: proc_id,
                 addr: forwarder_addr,
@@ -1786,7 +1789,7 @@ mod tests {
         .unwrap();
 
         let (pid, agent) = host.spawn("ok".into(), ()).await.expect("must succeed");
-        assert_eq!(agent.actor_id().proc_id(), pid);
+        assert_eq!(*agent.actor_id().proc_id(), pid);
         assert!(host.procs.contains("ok"));
     }
 

--- a/hyperactor/src/introspect.rs
+++ b/hyperactor/src/introspect.rs
@@ -132,6 +132,7 @@ use serde::Serialize;
 use typeuri::Named;
 
 use crate::InstanceCell;
+use crate::ref_;
 use crate::reference;
 
 /// Typed reference to an introspectable entity.
@@ -763,7 +764,7 @@ pub fn live_actor_payload(cell: &InstanceCell) -> IntrospectResult {
     let children: Vec<IntrospectRef> = cell
         .child_actor_ids()
         .into_iter()
-        .map(IntrospectRef::Actor)
+        .map(|a| IntrospectRef::Actor(a.into()))
         .collect();
 
     let events = cell.recording().tail();
@@ -787,7 +788,7 @@ pub fn live_actor_payload(cell: &InstanceCell) -> IntrospectResult {
 
     let supervisor = cell
         .parent()
-        .map(|p| IntrospectRef::Actor(p.actor_id().clone()));
+        .map(|p| IntrospectRef::Actor(p.actor_id().clone().into()));
 
     // FI-3: failure_info is computed from the same status value as
     // actor_status, ensuring they agree on whether the actor failed.
@@ -799,7 +800,7 @@ pub fn live_actor_payload(cell: &InstanceCell) -> IntrospectResult {
                 root_cause_actor: root.actor_id.clone(),
                 root_cause_name: root.display_name.clone(),
                 occurred_at: event.occurred_at,
-                is_propagated: root.actor_id != *actor_id,
+                is_propagated: root.actor_id != actor_id.clone(),
             })
         })
     } else {
@@ -817,7 +818,7 @@ pub fn live_actor_payload(cell: &InstanceCell) -> IntrospectResult {
     let attrs = build_actor_attrs(cell, &snap);
 
     IntrospectResult {
-        identity: IntrospectRef::Actor(actor_id.clone()),
+        identity: IntrospectRef::Actor(actor_id.clone().into()),
         attrs,
         children,
         parent: supervisor,
@@ -885,12 +886,12 @@ pub(crate) async fn serve_introspect(
                             let children: Vec<IntrospectRef> =
                                 published.get(CHILDREN).cloned().unwrap_or_default();
                             IntrospectResult {
-                                identity: IntrospectRef::Actor(cell.actor_id().clone()),
+                                identity: IntrospectRef::Actor(cell.actor_id().clone().into()),
                                 attrs: attrs_json,
                                 children,
                                 parent: cell
                                     .parent()
-                                    .map(|p| IntrospectRef::Actor(p.actor_id().clone())),
+                                    .map(|p| IntrospectRef::Actor(p.actor_id().clone().into())),
                                 as_of: SystemTime::now(),
                             }
                         }
@@ -905,7 +906,8 @@ pub(crate) async fn serve_introspect(
                 )
             }
             IntrospectMessage::QueryChild { child_ref, reply } => {
-                let payload = cell.query_child(&child_ref).unwrap_or_else(|| {
+                let child_ref_: ref_::Reference = child_ref.clone().into();
+                let payload = cell.query_child(&child_ref_).unwrap_or_else(|| {
                     let mut error_attrs = hyperactor_config::Attrs::new();
                     error_attrs.set(ERROR_CODE, "not_found".to_string());
                     error_attrs.set(

--- a/hyperactor/src/mailbox.rs
+++ b/hyperactor/src/mailbox.rs
@@ -22,7 +22,7 @@
 //! # tokio_test::block_on(async {
 //! # let proc = Proc::local();
 //! # let (client, _) = proc.instance("client").unwrap();
-//! # let actor_id = proc.proc_id().actor_id("actor");
+//! # let actor_id = proc.proc_id().actor_ref("actor");
 //! let mbox = Mailbox::new_detached(actor_id);
 //! let (port, mut receiver) = mbox.open_port::<u64>();
 //!
@@ -41,7 +41,7 @@
 //! # tokio_test::block_on(async {
 //! # let proc = Proc::local();
 //! # let (client, _) = proc.instance("client").unwrap();
-//! # let actor_id = proc.proc_id().actor_id("actor");
+//! # let actor_id = proc.proc_id().actor_ref("actor");
 //! let mbox = Mailbox::new_detached(actor_id);
 //!
 //! let (port, receiver) = mbox.open_once_port::<u64>();
@@ -122,6 +122,7 @@ use crate::context;
 use crate::metrics;
 use crate::ordering::SEQ_INFO;
 use crate::ordering::SeqInfo;
+use crate::ref_;
 use crate::reference;
 
 mod undeliverable;
@@ -192,10 +193,10 @@ pub enum DeliveryError {
 #[derive(Debug, Serialize, Deserialize, Clone, typeuri::Named)]
 pub struct MessageEnvelope {
     /// The sender of this message.
-    sender: reference::ActorId,
+    sender: ref_::ActorRef,
 
     /// The destination of the message.
-    dest: reference::PortId,
+    dest: ref_::PortRef,
 
     /// The serialized message.
     data: wirevalue::Any,
@@ -219,11 +220,13 @@ wirevalue::register_type!(MessageEnvelope);
 impl MessageEnvelope {
     /// Create a new envelope with the provided sender, destination, and message.
     pub fn new(
-        sender: reference::ActorId,
-        dest: reference::PortId,
+        sender: impl Into<ref_::ActorRef>,
+        dest: impl Into<ref_::PortRef>,
         data: wirevalue::Any,
         headers: Flattrs,
     ) -> Self {
+        let sender = sender.into();
+        let dest = dest.into();
         Self {
             sender,
             dest,
@@ -237,27 +240,27 @@ impl MessageEnvelope {
     }
 
     /// Create a new envelope whose sender ID is unknown.
-    pub(crate) fn new_unknown(dest: reference::PortId, data: wirevalue::Any) -> Self {
+    pub(crate) fn new_unknown(dest: impl Into<ref_::PortRef>, data: wirevalue::Any) -> Self {
         // Create a synthetic "unknown" actor ID for messages with no known sender
         let unknown_addr = ChannelAddr::any(ChannelTransport::Local);
-        let unknown_proc_id = crate::reference::ProcId::unique(unknown_addr, "unknown");
-        let unknown_actor_id =
-            crate::reference::ActorId::root(unknown_proc_id, crate::id::Label::strip("unknown"));
-        Self::new(unknown_actor_id, dest, data, Flattrs::new())
+        let unknown_proc_ref = ref_::ProcRef::unique(unknown_addr, "unknown");
+        let unknown_actor_ref =
+            ref_::ActorRef::root(unknown_proc_ref, crate::id::Label::strip("unknown"));
+        Self::new(unknown_actor_ref, dest, data, Flattrs::new())
     }
 
     /// Construct a new serialized value by serializing the provided T-typed value.
     pub fn serialize<T: Serialize + Named>(
-        source: reference::ActorId,
-        dest: reference::PortId,
+        source: impl Into<ref_::ActorRef>,
+        dest: impl Into<ref_::PortRef>,
         value: &T,
         headers: Flattrs,
     ) -> Result<Self, wirevalue::Error> {
         Ok(Self {
             headers,
             data: wirevalue::Any::serialize(value)?,
-            sender: source,
-            dest,
+            sender: source.into(),
+            dest: dest.into(),
             errors: Vec::new(),
             ttl: hyperactor_config::global::get(crate::config::MESSAGE_TTL_DEFAULT),
             // By default, all undeliverable messages should be returned to the sender.
@@ -315,12 +318,12 @@ impl MessageEnvelope {
     }
 
     /// The message sender.
-    pub fn sender(&self) -> &reference::ActorId {
+    pub fn sender(&self) -> &ref_::ActorRef {
         &self.sender
     }
 
     /// The destination of the message.
-    pub fn dest(&self) -> &reference::PortId {
+    pub fn dest(&self) -> &ref_::PortRef {
         &self.dest
     }
 
@@ -343,8 +346,8 @@ impl MessageEnvelope {
     /// Change the sender on the envelope in case it was set incorrectly. This
     /// should only be used by CommActor since it is forwarding from another
     /// sender.
-    pub fn update_sender(&mut self, sender: reference::ActorId) {
-        self.sender = sender;
+    pub fn update_sender(&mut self, sender: impl Into<ref_::ActorRef>) {
+        self.sender = sender.into();
     }
 
     /// Set to true if you want this message to be returned to sender if it cannot
@@ -481,8 +484,8 @@ impl fmt::Display for MessageEnvelope {
 /// Metadata about a message sent via a MessageEnvelope.
 #[derive(Clone)]
 pub struct MessageMetadata {
-    sender: reference::ActorId,
-    dest: reference::PortId,
+    sender: ref_::ActorRef,
+    dest: ref_::PortRef,
     errors: Vec<DeliveryError>,
     headers: Flattrs,
     ttl: u8,
@@ -493,7 +496,7 @@ pub struct MessageMetadata {
 /// with the mailbox's actor id.
 #[derive(Debug)]
 pub struct MailboxError {
-    actor_id: reference::ActorId,
+    actor_id: ref_::ActorRef,
     kind: MailboxErrorKind,
 }
 
@@ -508,28 +511,28 @@ pub enum MailboxErrorKind {
 
     /// The port associated with an operation was invalid.
     #[error("invalid port: {0}")]
-    InvalidPort(reference::PortId),
+    InvalidPort(ref_::PortRef),
 
     /// There was no sender associated with the port.
     #[error("no sender for port: {0}")]
-    NoSenderForPort(reference::PortId),
+    NoSenderForPort(ref_::PortRef),
 
     /// There was no local sender associated with the port.
     /// Returned by operations that require a local port.
     #[error("no local sender for port: {0}")]
-    NoLocalSenderForPort(reference::PortId),
+    NoLocalSenderForPort(ref_::PortRef),
 
     /// The port was closed.
     #[error("{0}: port closed")]
-    PortClosed(reference::PortId),
+    PortClosed(ref_::PortRef),
 
     /// An error occured during a send operation.
     #[error("send {0}: {1}")]
-    Send(reference::PortId, #[source] anyhow::Error),
+    Send(ref_::PortRef, #[source] anyhow::Error),
 
     /// An error occured during a receive operation.
     #[error("recv {0}: {1}")]
-    Recv(reference::PortId, #[source] anyhow::Error),
+    Recv(ref_::PortRef, #[source] anyhow::Error),
 
     /// There was a serialization failure.
     #[error("serialize: {0}")]
@@ -551,12 +554,15 @@ pub enum MailboxErrorKind {
 impl MailboxError {
     /// Create a new mailbox error associated with the provided actor
     /// id and of the given kind.
-    pub fn new(actor_id: reference::ActorId, kind: MailboxErrorKind) -> Self {
-        Self { actor_id, kind }
+    pub fn new(actor_id: impl Into<ref_::ActorRef>, kind: MailboxErrorKind) -> Self {
+        Self {
+            actor_id: actor_id.into(),
+            kind,
+        }
     }
 
     /// The ID of the mailbox producing this error.
-    pub fn actor_id(&self) -> &reference::ActorId {
+    pub fn actor_id(&self) -> &ref_::ActorRef {
         &self.actor_id
     }
 
@@ -585,26 +591,26 @@ impl std::error::Error for MailboxError {
 #[derive(Debug, Clone)]
 pub enum PortLocation {
     /// The port was bound: the location is its underlying bound ID.
-    Bound(reference::PortId),
+    Bound(ref_::PortRef),
     /// The port was not bound: we provide the actor ID and the message type.
-    Unbound(reference::ActorId, &'static str),
+    Unbound(ref_::ActorRef, &'static str),
 }
 
 impl PortLocation {
-    fn new_unbound<M: Message>(actor_id: reference::ActorId) -> Self {
+    fn new_unbound<M: Message>(actor_id: ref_::ActorRef) -> Self {
         PortLocation::Unbound(actor_id, std::any::type_name::<M>())
     }
 
     #[allow(dead_code)]
-    fn new_unbound_type(actor_id: reference::ActorId, ty: &'static str) -> Self {
+    fn new_unbound_type(actor_id: ref_::ActorRef, ty: &'static str) -> Self {
         PortLocation::Unbound(actor_id, ty)
     }
 
     /// The actor id of the location.
-    pub fn actor_id(&self) -> reference::ActorId {
+    pub fn actor_id(&self) -> ref_::ActorRef {
         match self {
-            PortLocation::Bound(port_id) => port_id.actor_id(),
-            PortLocation::Unbound(actor_id, _) => actor_id.clone(),
+            PortLocation::Bound(port_ref) => port_ref.actor_ref(),
+            PortLocation::Unbound(actor_ref, _) => actor_ref.clone(),
         }
     }
 }
@@ -612,8 +618,8 @@ impl PortLocation {
 impl fmt::Display for PortLocation {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            PortLocation::Bound(port_id) => write!(f, "{}", port_id),
-            PortLocation::Unbound(actor_id, name) => write!(f, "{}<{}>", actor_id, name),
+            PortLocation::Bound(port_ref) => write!(f, "{}", port_ref),
+            PortLocation::Unbound(actor_ref, name) => write!(f, "{}<{}>", actor_ref, name),
         }
     }
 }
@@ -665,29 +671,35 @@ pub enum MailboxSenderErrorKind {
 
 impl MailboxSenderError {
     /// Create a new mailbox sender error to an unbound port.
-    pub fn new_unbound<M>(actor_id: reference::ActorId, kind: MailboxSenderErrorKind) -> Self {
+    pub fn new_unbound<M>(
+        actor_id: impl Into<ref_::ActorRef>,
+        kind: MailboxSenderErrorKind,
+    ) -> Self {
         Self {
-            location: Box::new(PortLocation::Unbound(actor_id, std::any::type_name::<M>())),
+            location: Box::new(PortLocation::Unbound(
+                actor_id.into(),
+                std::any::type_name::<M>(),
+            )),
             kind: Box::new(kind),
         }
     }
 
     /// Create a new mailbox sender, manually providing the type.
     pub fn new_unbound_type(
-        actor_id: reference::ActorId,
+        actor_id: impl Into<ref_::ActorRef>,
         kind: MailboxSenderErrorKind,
         ty: &'static str,
     ) -> Self {
         Self {
-            location: Box::new(PortLocation::Unbound(actor_id, ty)),
+            location: Box::new(PortLocation::Unbound(actor_id.into(), ty)),
             kind: Box::new(kind),
         }
     }
 
     /// Create a new mailbox sender error with the provided port ID and kind.
-    pub fn new_bound(port_id: reference::PortId, kind: MailboxSenderErrorKind) -> Self {
+    pub fn new_bound(port_id: impl Into<ref_::PortRef>, kind: MailboxSenderErrorKind) -> Self {
         Self {
-            location: Box::new(PortLocation::Bound(port_id)),
+            location: Box::new(PortLocation::Bound(port_id.into())),
             kind: Box::new(kind),
         }
     }
@@ -981,7 +993,7 @@ pub trait MailboxServer: MailboxSender + Clone + Sized + 'static {
             static NEXT_RANK: AtomicUsize = AtomicUsize::new(0);
             let rank = NEXT_RANK.fetch_add(1, Ordering::Relaxed);
             let addr = ChannelAddr::any(ChannelTransport::Local);
-            let proc_id = reference::ProcId::unique(addr, format!("mailbox_server_{}", rank));
+            let proc_id = ref_::ProcRef::unique(addr, format!("mailbox_server_{}", rank));
             // Use this mailbox server as the forwarder, so we can use it to
             // return message back to the sender.
             let proc = Proc::configured(proc_id, BoxedMailboxSender::new(server));
@@ -997,9 +1009,10 @@ pub trait MailboxServer: MailboxSender + Clone + Sized + 'static {
                 envelope.set_error(DeliveryError::BrokenLink(
                     "message was undeliverable".to_owned(),
                 ));
+                let sender_id: reference::ActorId = envelope.sender().clone().into();
                 let return_port =
                     reference::PortRef::<Undeliverable<MessageEnvelope>>::attest_message_port(
-                        envelope.sender(),
+                        &sender_id,
                     );
                 return_port.send_serialized(
                     &client,
@@ -1294,21 +1307,24 @@ pub struct Mailbox {
 impl Mailbox {
     /// Create a new mailbox associated with the provided actor ID, using the provided
     /// forwarder for external destinations.
-    pub fn new(actor_id: reference::ActorId, forwarder: BoxedMailboxSender) -> Self {
+    pub fn new(actor_id: impl Into<ref_::ActorRef>, forwarder: BoxedMailboxSender) -> Self {
         Self {
-            inner: Arc::new(State::new(actor_id, forwarder)),
+            inner: Arc::new(State::new(actor_id.into(), forwarder)),
         }
     }
 
     /// Create a new detached mailbox associated with the provided actor ID.
-    pub fn new_detached(actor_id: reference::ActorId) -> Self {
+    pub fn new_detached(actor_id: impl Into<ref_::ActorRef>) -> Self {
         Self {
-            inner: Arc::new(State::new(actor_id, BOXED_PANICKING_MAILBOX_SENDER.clone())),
+            inner: Arc::new(State::new(
+                actor_id.into(),
+                BOXED_PANICKING_MAILBOX_SENDER.clone(),
+            )),
         }
     }
 
     /// The actor id associated with this mailbox.
-    pub fn actor_id(&self) -> &reference::ActorId {
+    pub fn actor_id(&self) -> &ref_::ActorRef {
         &self.inner.actor_id
     }
 
@@ -1319,7 +1335,10 @@ impl Mailbox {
     pub fn open_port<M: Message>(&self) -> (PortHandle<M>, PortReceiver<M>) {
         let port_index = self.inner.allocate_port();
         let (sender, receiver) = mpsc::unbounded_channel::<M>();
-        let port_id = reference::PortId::new(self.inner.actor_id.clone(), port_index);
+        let port_id = self
+            .inner
+            .actor_id
+            .port_ref(crate::port::Port::from(port_index));
         tracing::trace!(
             name = "open_port",
             "opening port for {} at {}",
@@ -1374,7 +1393,10 @@ impl Mailbox {
     {
         let port_index = self.inner.allocate_port();
         let (sender, receiver) = mpsc::unbounded_channel::<A::State>();
-        let port_id = reference::PortId::new(self.inner.actor_id.clone(), port_index);
+        let port_id = self
+            .inner
+            .actor_id
+            .port_ref(crate::port::Port::from(port_index));
         let state = Mutex::new(A::State::default());
         let reducer_spec = accum.reducer_spec();
         let enqueue = move |_, update: A::Update| {
@@ -1418,7 +1440,10 @@ impl Mailbox {
     /// receiver may receive a single message.
     pub fn open_once_port<M: Message>(&self) -> (OncePortHandle<M>, OncePortReceiver<M>) {
         let port_index = self.inner.allocate_port();
-        let port_id = reference::PortId::new(self.inner.actor_id.clone(), port_index);
+        let port_id = self
+            .inner
+            .actor_id
+            .port_ref(crate::port::Port::from(port_index));
         let (sender, receiver) = oneshot::channel::<M>();
         (
             OncePortHandle {
@@ -1459,7 +1484,10 @@ impl Mailbox {
     {
         let port_index = self.inner.allocate_port();
         let (sender, receiver) = oneshot::channel::<T>();
-        let port_id = reference::PortId::new(self.inner.actor_id.clone(), port_index);
+        let port_id = self
+            .inner
+            .actor_id
+            .port_ref(crate::port::Port::from(port_index));
         let reducer_spec = accum.reducer_spec();
         assert!(
             reducer_spec.is_some(),
@@ -1496,7 +1524,8 @@ impl Mailbox {
                 .map(|s| {
                     assert_eq!(
                         s.port_id,
-                        self.actor_id().port_id(port_index),
+                        self.actor_id()
+                            .port_ref(crate::port::Port::from(port_index)),
                         "port_id mismatch in downcasted UnboundedSender"
                     );
                     s.sender.clone()
@@ -1523,18 +1552,20 @@ impl Mailbox {
 
         // TODO: don't even allocate a port until the port is bound. Possibly
         // have handles explicitly staged (unbound, bound).
-        let port_id = self.actor_id().port_id(handle.port_index);
+        let port_ref = self
+            .actor_id()
+            .port_ref(crate::port::Port::from(handle.port_index));
         match self.inner.ports.entry(handle.port_index) {
             Entry::Vacant(entry) => {
                 entry.insert(Box::new(UnboundedSender::new(
                     handle.sender.clone(),
-                    port_id.clone(),
+                    port_ref.clone(),
                 )));
             }
             Entry::Occupied(_entry) => {}
         }
 
-        reference::PortRef::attest(port_id)
+        reference::PortRef::attest(port_ref.into())
     }
 
     fn bind_to_actor_port<M: RemoteMessage>(&self, handle: &PortHandle<M>) {
@@ -1545,15 +1576,17 @@ impl Mailbox {
         );
 
         let port_index = M::port();
-        let port_id = self.actor_id().port_id(port_index);
+        let port_ref = self
+            .actor_id()
+            .port_ref(crate::port::Port::from(port_index));
         match self.inner.ports.entry(port_index) {
             Entry::Vacant(entry) => {
                 entry.insert(Box::new(UnboundedSender::new(
                     handle.sender.clone(),
-                    port_id,
+                    port_ref,
                 )));
             }
-            Entry::Occupied(_entry) => panic!("port {} already bound", port_id),
+            Entry::Occupied(_entry) => panic!("port {} already bound", port_ref),
         }
     }
 
@@ -1567,9 +1600,9 @@ impl Mailbox {
         }
     }
 
-    pub(crate) fn bind_untyped(&self, port_id: &reference::PortId, sender: UntypedUnboundedSender) {
+    pub(crate) fn bind_untyped(&self, port_id: &ref_::PortRef, sender: UntypedUnboundedSender) {
         assert_eq!(
-            port_id.actor_id(),
+            port_id.actor_ref(),
             *self.actor_id(),
             "port does not belong to mailbox"
         );
@@ -1637,7 +1670,7 @@ impl MailboxSender for Mailbox {
             envelope.dest
         );
 
-        if envelope.dest().actor_id() != self.inner.actor_id {
+        if envelope.dest().actor_ref() != self.inner.actor_id {
             return self.inner.forwarder.post(envelope, return_handle);
         }
 
@@ -1782,7 +1815,7 @@ pub struct PortHandle<M: Message> {
     // making PortRef<M> valid for M: Message, but constructible only for
     // M: RemoteMessage, but the guarantees offered by the impossibilty of even
     // writing down the type are appealing.
-    bound: Arc<RwLock<Option<reference::PortId>>>,
+    bound: Arc<RwLock<Option<ref_::PortRef>>>,
     // Typehash of an optional reducer. When it's defined, we include it in port
     /// references to optionally enable incremental accumulation.
     reducer_spec: Option<ReducerSpec>,
@@ -1834,7 +1867,8 @@ impl<M: Message> PortHandle<M> {
         let bound_guard = self.bound.read().unwrap();
         if let Some(bound_port) = bound_guard.as_ref() {
             let sequencer = cx.instance().sequencer();
-            let seq_info = sequencer.assign_seq(bound_port);
+            let bound_ref: crate::ref_::PortRef = bound_port.clone();
+            let seq_info = sequencer.assign_seq(&bound_ref);
             headers.set(SEQ_INFO, seq_info);
         } else {
             // Because the port is not bound, messages can only be sent through
@@ -1884,14 +1918,14 @@ impl<M: Message> PortHandle<M> {
 impl<M: RemoteMessage> PortHandle<M> {
     /// Bind this port, making it accessible to remote actors.
     pub fn bind(&self) -> reference::PortRef<M> {
-        let port_id = {
+        let port_ref = {
             let mut guard = self.bound.write().unwrap();
             guard
-                .get_or_insert_with(|| self.mailbox.bind(self).port_id().clone())
+                .get_or_insert_with(|| self.mailbox.bind(self).port_id().clone().into())
                 .clone()
         };
         reference::PortRef::attest_reducible(
-            port_id,
+            port_ref.into(),
             self.reducer_spec.clone(),
             self.streaming_opts.clone(),
         )
@@ -1903,7 +1937,10 @@ impl<M: RemoteMessage> PortHandle<M> {
     /// This is used by [`actor::Binder`] implementations to bind actor refs.
     /// This is not intended for general use.
     pub(crate) fn bind_actor_port(&self) {
-        let port_id = self.mailbox.actor_id().port_id(M::port());
+        let port_id = self
+            .mailbox
+            .actor_id()
+            .port_ref(crate::port::Port::from(M::port()));
         {
             let mut guard = self.bound.write().unwrap();
             if guard.is_some() {
@@ -1942,7 +1979,7 @@ impl<M: Message> fmt::Display for PortHandle<M> {
 pub struct OncePortHandle<M: Message> {
     mailbox: Mailbox,
     port_index: u64,
-    port_id: reference::PortId,
+    port_id: ref_::PortRef,
     sender: oneshot::Sender<M>,
     reducer_spec: Option<ReducerSpec>,
 }
@@ -1950,7 +1987,7 @@ pub struct OncePortHandle<M: Message> {
 impl<M: Message> OncePortHandle<M> {
     /// This port's ID.
     // TODO: make value
-    pub fn port_id(&self) -> &reference::PortId {
+    pub fn port_id(&self) -> &ref_::PortRef {
         &self.port_id
     }
 
@@ -1984,7 +2021,7 @@ impl<M: RemoteMessage> OncePortHandle<M> {
     /// ref to send a message to the port. Creating a ref also
     /// binds the port, so that it is remotely writable.
     pub fn bind(self) -> reference::OncePortRef<M> {
-        let port_id = self.port_id().clone();
+        let port_id: reference::PortId = self.port_id().clone().into();
         let reducer_spec = self.reducer_spec.clone();
         self.mailbox.clone().bind_once(self);
         reference::OncePortRef::attest_reducible(port_id, reducer_spec)
@@ -2002,7 +2039,7 @@ impl<M: Message> fmt::Display for OncePortHandle<M> {
 #[derive(Debug)]
 pub struct PortReceiver<M> {
     receiver: mpsc::UnboundedReceiver<M>,
-    port_id: reference::PortId,
+    port_id: ref_::PortRef,
     /// When multiple messages are put in channel, only receive the latest one
     /// if coalesce is true. Other messages will be discarded.
     coalesce: bool,
@@ -2014,7 +2051,7 @@ pub struct PortReceiver<M> {
 impl<M> PortReceiver<M> {
     fn new(
         receiver: mpsc::UnboundedReceiver<M>,
-        port_id: reference::PortId,
+        port_id: ref_::PortRef,
         coalesce: bool,
         mailbox: Mailbox,
     ) -> Self {
@@ -2082,8 +2119,8 @@ impl<M> PortReceiver<M> {
         self.port_id.index()
     }
 
-    fn actor_id(&self) -> reference::ActorId {
-        self.port_id.actor_id()
+    fn actor_id(&self) -> ref_::ActorRef {
+        self.port_id.actor_ref()
     }
 }
 
@@ -2107,7 +2144,7 @@ impl<M> Stream for PortReceiver<M> {
 /// A receiver of M-typed messages from [`OncePort`]s.
 pub struct OncePortReceiver<M> {
     receiver: Option<oneshot::Receiver<M>>,
-    port_id: reference::PortId,
+    port_id: ref_::PortRef,
 
     /// Mailbox is used to remove the port from service when the receiver
     /// is dropped.
@@ -2134,8 +2171,8 @@ impl<M> OncePortReceiver<M> {
         self.port_id.index()
     }
 
-    fn actor_id(&self) -> reference::ActorId {
-        self.port_id.actor_id()
+    fn actor_id(&self) -> ref_::ActorRef {
+        self.port_id.actor_ref()
     }
 }
 
@@ -2226,13 +2263,13 @@ impl<M: Message> Debug for UnboundedPortSender<M> {
 
 struct UnboundedSender<M: Message> {
     sender: UnboundedPortSender<M>,
-    port_id: reference::PortId,
+    port_id: ref_::PortRef,
 }
 
 impl<M: Message> UnboundedSender<M> {
     /// Create a new UnboundedSender encapsulating the provided
     /// sender.
-    fn new(sender: UnboundedPortSender<M>, port_id: reference::PortId) -> Self {
+    fn new(sender: UnboundedPortSender<M>, port_id: ref_::PortRef) -> Self {
         Self { sender, port_id }
     }
 
@@ -2303,13 +2340,13 @@ impl<M: RemoteMessage> SerializedSender for UnboundedSender<M> {
 #[derive(Debug)]
 struct OnceSender<M: Message> {
     sender: Arc<Mutex<Option<oneshot::Sender<M>>>>,
-    port_id: reference::PortId,
+    port_id: ref_::PortRef,
 }
 
 impl<M: Message> OnceSender<M> {
     /// Create a new OnceSender encapsulating the provided one-shot
     /// sender.
-    fn new(sender: oneshot::Sender<M>, port_id: reference::PortId) -> Self {
+    fn new(sender: oneshot::Sender<M>, port_id: ref_::PortRef) -> Self {
         Self {
             sender: Arc::new(Mutex::new(Some(sender))),
             port_id,
@@ -2384,7 +2421,7 @@ impl<M: RemoteMessage> SerializedSender for OnceSender<M> {
 pub(crate) struct UntypedUnboundedSender {
     pub(crate) sender:
         Box<dyn Fn(wirevalue::Any) -> Result<bool, (wirevalue::Any, anyhow::Error)> + Send + Sync>,
-    pub(crate) port_id: reference::PortId,
+    pub(crate) port_id: ref_::PortRef,
 }
 
 impl SerializedSender for UntypedUnboundedSender {
@@ -2411,7 +2448,7 @@ impl SerializedSender for UntypedUnboundedSender {
 /// State is the internal state of the mailbox.
 struct State {
     /// The ID of the mailbox owner.
-    actor_id: reference::ActorId,
+    actor_id: ref_::ActorRef,
 
     // insert if it's serializable; otherwise don't.
     /// The set of active ports in the mailbox. All currently
@@ -2431,7 +2468,7 @@ struct State {
 
 impl State {
     /// Create a new state with the provided owning ActorId.
-    fn new(actor_id: reference::ActorId, forwarder: BoxedMailboxSender) -> Self {
+    fn new(actor_id: ref_::ActorRef, forwarder: BoxedMailboxSender) -> Self {
         Self {
             actor_id,
             ports: DashMap::new(),
@@ -2467,7 +2504,7 @@ impl fmt::Debug for State {
 /// different underlying senders.
 #[derive(Clone)]
 pub struct MailboxMuxer {
-    mailboxes: Arc<DashMap<reference::ActorId, Box<dyn MailboxSender + Send + Sync>>>,
+    mailboxes: Arc<DashMap<ref_::ActorRef, Box<dyn MailboxSender + Send + Sync>>>,
 }
 
 impl Default for MailboxMuxer {
@@ -2488,7 +2525,12 @@ impl MailboxMuxer {
     /// sender. Returns false if there is already a sender associated
     /// with the actor. In this case, the sender is not replaced, and
     /// the caller must [`MailboxMuxer::unbind`] it first.
-    pub fn bind(&self, actor_id: reference::ActorId, sender: impl MailboxSender + 'static) -> bool {
+    pub fn bind(
+        &self,
+        actor_id: impl Into<ref_::ActorRef>,
+        sender: impl MailboxSender + 'static,
+    ) -> bool {
+        let actor_id = actor_id.into();
         match self.mailboxes.entry(actor_id) {
             Entry::Occupied(_) => false,
             Entry::Vacant(entry) => {
@@ -2507,12 +2549,12 @@ impl MailboxMuxer {
     /// unbinding, the muxer will no longer be able to send messages to
     /// that actor.
     #[allow(dead_code)]
-    pub(crate) fn unbind(&self, actor_id: &reference::ActorId) {
+    pub(crate) fn unbind(&self, actor_id: &ref_::ActorRef) {
         self.mailboxes.remove(actor_id);
     }
 
     /// Returns a list of all actors bound to this muxer. Useful in debugging.
-    pub fn bound_actors(&self) -> Vec<reference::ActorId> {
+    pub fn bound_actors(&self) -> Vec<ref_::ActorRef> {
         self.mailboxes.iter().map(|e| e.key().clone()).collect()
     }
 }
@@ -2524,10 +2566,13 @@ impl MailboxSender for MailboxMuxer {
         envelope: MessageEnvelope,
         return_handle: PortHandle<Undeliverable<MessageEnvelope>>,
     ) {
-        let dest_actor_id = envelope.dest().actor_id();
-        match self.mailboxes.get(&dest_actor_id) {
+        let dest_actor_ref = envelope.dest().actor_ref();
+        match self.mailboxes.get(&dest_actor_ref) {
             None => {
-                let err = format!("no mailbox for actor {} registered in muxer", dest_actor_id);
+                let err = format!(
+                    "no mailbox for actor {} registered in muxer",
+                    dest_actor_ref
+                );
                 envelope.undeliverable(DeliveryError::Unroutable(err), return_handle)
             }
             Some(sender) => sender.post(envelope, return_handle),
@@ -2553,7 +2598,7 @@ impl MailboxSender for MailboxMuxer {
 /// nearest prefix.
 #[derive(Clone)]
 pub struct MailboxRouter {
-    entries: Arc<RwLock<BTreeMap<reference::Reference, Arc<dyn MailboxSender + Send + Sync>>>>,
+    entries: Arc<RwLock<BTreeMap<ref_::Reference, Arc<dyn MailboxSender + Send + Sync>>>>,
 }
 
 impl Default for MailboxRouter {
@@ -2588,26 +2633,23 @@ impl MailboxRouter {
     /// Bind the provided sender to the given reference. The destination
     /// is treated as a prefix to which messages can be routed, and
     /// messages are routed to their longest matching prefix.
-    pub fn bind(&self, dest: reference::Reference, sender: impl MailboxSender + 'static) {
+    pub fn bind(&self, dest: impl Into<ref_::Reference>, sender: impl MailboxSender + 'static) {
+        let dest = dest.into();
         let mut w = self.entries.write().unwrap();
         w.insert(dest, Arc::new(sender));
     }
 
-    fn sender(
-        &self,
-        actor_id: &reference::ActorId,
-    ) -> Option<Arc<dyn MailboxSender + Send + Sync>> {
+    fn sender(&self, actor_ref: &ref_::ActorRef) -> Option<Arc<dyn MailboxSender + Send + Sync>> {
+        let reference = ref_::Reference::from(actor_ref.clone());
         match self
             .entries
             .read()
             .unwrap()
-            .lower_bound(Excluded(&actor_id.clone().into()))
+            .lower_bound(Excluded(&reference))
             .prev()
         {
             None => None,
-            Some((key, sender)) if key.is_prefix_of(&actor_id.clone().into()) => {
-                Some(sender.clone())
-            }
+            Some((key, sender)) if key.is_prefix_of(&reference) => Some(sender.clone()),
             Some(_) => None,
         }
     }
@@ -2620,8 +2662,8 @@ impl MailboxSender for MailboxRouter {
         envelope: MessageEnvelope,
         return_handle: PortHandle<Undeliverable<MessageEnvelope>>,
     ) {
-        let dest_actor_id = envelope.dest().actor_id();
-        match self.sender(&dest_actor_id) {
+        let dest_actor_ref = envelope.dest().actor_ref();
+        match self.sender(&dest_actor_ref) {
             None => envelope.undeliverable(
                 DeliveryError::Unroutable(
                     "no destination found for actor in routing table".to_string(),
@@ -2653,8 +2695,8 @@ impl MailboxSender for FallbackMailboxRouter {
         envelope: MessageEnvelope,
         return_handle: PortHandle<Undeliverable<MessageEnvelope>>,
     ) {
-        let dest_actor_id = envelope.dest().actor_id();
-        match self.router.sender(&dest_actor_id) {
+        let dest_actor_ref = envelope.dest().actor_ref();
+        match self.router.sender(&dest_actor_ref) {
             Some(sender) => sender.post(envelope, return_handle),
             None => self.default.post(envelope, return_handle),
         }
@@ -2678,7 +2720,7 @@ impl MailboxSender for FallbackMailboxRouter {
 /// on a per-entry basis.
 #[derive(Debug, Clone)]
 pub struct WeakMailboxRouter(
-    Weak<RwLock<BTreeMap<reference::Reference, Arc<dyn MailboxSender + Send + Sync>>>>,
+    Weak<RwLock<BTreeMap<ref_::Reference, Arc<dyn MailboxSender + Send + Sync>>>>,
 );
 
 impl WeakMailboxRouter {
@@ -2727,7 +2769,7 @@ impl MailboxSender for WeakMailboxRouter {
 /// sender, if present.
 #[derive(Clone)]
 pub struct DialMailboxRouter {
-    address_book: Arc<RwLock<BTreeMap<reference::Reference, ChannelAddr>>>,
+    address_book: Arc<RwLock<BTreeMap<ref_::Reference, ChannelAddr>>>,
     sender_cache: Arc<DashMap<ChannelAddr, Arc<MailboxClient>>>,
 
     // The default sender, to which messages for unknown recipients
@@ -2782,7 +2824,8 @@ impl DialMailboxRouter {
     ///
     /// If the address changes, the old sender is evicted from the
     /// cache to ensure fresh routing on next use.
-    pub fn bind(&self, dest: reference::Reference, addr: ChannelAddr) {
+    pub fn bind(&self, dest: impl Into<ref_::Reference>, addr: ChannelAddr) {
+        let dest = dest.into();
         if let Ok(mut w) = self.address_book.write() {
             if let Some(old_addr) = w.insert(dest.clone(), addr.clone())
                 && old_addr != addr
@@ -2800,9 +2843,9 @@ impl DialMailboxRouter {
     ///
     /// Also evicts any corresponding cached senders to prevent reuse
     /// of stale connections.
-    pub fn unbind(&self, dest: &reference::Reference) {
+    pub fn unbind(&self, dest: &ref_::Reference) {
         if let Ok(mut w) = self.address_book.write() {
-            let to_remove: Vec<(reference::Reference, ChannelAddr)> = w
+            let to_remove: Vec<(ref_::Reference, ChannelAddr)> = w
                 .range(dest..)
                 .take_while(|(key, _)| dest.is_prefix_of(key))
                 .map(|(key, addr)| (key.clone(), addr.clone()))
@@ -2819,20 +2862,19 @@ impl DialMailboxRouter {
     }
 
     /// Lookup an actor's channel in the router's address bok.
-    pub fn lookup_addr(&self, actor_id: &reference::ActorId) -> Option<ChannelAddr> {
+    pub fn lookup_addr(&self, actor_ref: &ref_::ActorRef) -> Option<ChannelAddr> {
         let address_book = self.address_book.read().unwrap();
-        let found = address_book
-            .lower_bound(Excluded(&actor_id.clone().into()))
-            .prev();
+        let reference = ref_::Reference::from(actor_ref.clone());
+        let found = address_book.lower_bound(Excluded(&reference)).prev();
 
         // First try to look up the address in our address book; failing that,
-        // extract the address from the ProcId (all procs are direct-addressed now).
+        // extract the address from the ProcRef (all procs are direct-addressed now).
         if let Some((key, addr)) = found
-            && key.is_prefix_of(&actor_id.clone().into())
+            && key.is_prefix_of(&reference)
         {
             Some(addr.clone())
         } else {
-            let addr = actor_id.proc_id().addr().clone();
+            let addr = actor_ref.addr().clone();
             if self.direct_addressed_remote_only {
                 addr.transport().is_remote().then_some(addr)
             } else {
@@ -2843,9 +2885,9 @@ impl DialMailboxRouter {
 
     /// Return all covering prefixes of this router. That is, all references that are not
     /// prefixed by another reference in the routing table
-    pub fn prefixes(&self) -> BTreeSet<reference::Reference> {
+    pub fn prefixes(&self) -> BTreeSet<ref_::Reference> {
         let addrs = self.address_book.read().unwrap();
-        let mut prefixes: BTreeSet<reference::Reference> = BTreeSet::new();
+        let mut prefixes: BTreeSet<ref_::Reference> = BTreeSet::new();
         for (reference, _) in addrs.iter() {
             match prefixes.lower_bound(Excluded(reference)).peek_prev() {
                 Some(candidate) if candidate.is_prefix_of(reference) => (),
@@ -2861,7 +2903,7 @@ impl DialMailboxRouter {
     fn dial(
         &self,
         addr: &ChannelAddr,
-        actor_id: &reference::ActorId,
+        actor_ref: &ref_::ActorRef,
     ) -> Result<Arc<MailboxClient>, MailboxSenderError> {
         // Get the sender. Create it if needed. Do not send the
         // messages inside this block so we do not hold onto the
@@ -2871,7 +2913,7 @@ impl DialMailboxRouter {
             Entry::Vacant(entry) => {
                 let tx = channel::dial(addr.clone()).map_err(|err| {
                     MailboxSenderError::new_unbound_type(
-                        actor_id.clone(),
+                        actor_ref.clone(),
                         MailboxSenderErrorKind::Channel(err),
                         "unknown",
                     )
@@ -2890,13 +2932,13 @@ impl MailboxSender for DialMailboxRouter {
         envelope: MessageEnvelope,
         return_handle: PortHandle<Undeliverable<MessageEnvelope>>,
     ) {
-        let dest_actor_id = envelope.dest().actor_id();
-        let Some(addr) = self.lookup_addr(&dest_actor_id) else {
+        let dest_actor_ref = envelope.dest().actor_ref();
+        let Some(addr) = self.lookup_addr(&dest_actor_ref) else {
             self.default.post(envelope, return_handle);
             return;
         };
 
-        match self.dial(&addr, &dest_actor_id) {
+        match self.dial(&addr, &dest_actor_ref) {
             Err(err) => envelope.undeliverable(
                 DeliveryError::Unroutable(format!("cannot dial destination: {err}")),
                 return_handle,
@@ -2960,12 +3002,12 @@ mod tests {
     use crate::testing::ids::test_port_id;
     use crate::testing::ids::test_proc_id;
 
-    fn test_proc_ref(name: &str) -> reference::Reference {
-        reference::Reference::Proc(test_proc_id(name))
+    fn test_proc_ref(name: &str) -> ref_::Reference {
+        ref_::Reference::Proc(test_proc_id(name).into())
     }
 
-    fn test_actor_ref(proc_name: &str, actor_name: &str) -> reference::Reference {
-        reference::Reference::Actor(test_actor_id(proc_name, actor_name))
+    fn test_actor_ref(proc_name: &str, actor_name: &str) -> ref_::Reference {
+        ref_::Reference::Actor(test_actor_id(proc_name, actor_name).into())
     }
 
     #[test]
@@ -3101,7 +3143,7 @@ mod tests {
         };
 
         assert_matches!(err.kind(), MailboxSenderErrorKind::Closed);
-        assert_matches!(err.location(), PortLocation::Bound(bound) if bound == port.port_id());
+        assert_matches!(err.location(), PortLocation::Bound(bound) if *bound == **port.port_id());
     }
 
     #[tokio::test]
@@ -3188,10 +3230,10 @@ mod tests {
 
         let router = MailboxRouter::new();
 
-        router.bind(test_proc_id("world0_0").into(), mbox0);
-        router.bind(test_proc_id("world1_0").into(), mbox1);
-        router.bind(test_proc_id("world1_1").into(), mbox2);
-        router.bind(test_actor_id("world1_1", "actor1").into(), mbox3);
+        router.bind(test_proc_ref("world0_0"), mbox0);
+        router.bind(test_proc_ref("world1_0"), mbox1);
+        router.bind(test_proc_ref("world1_1"), mbox2);
+        router.bind(test_actor_ref("world1_1", "actor1"), mbox3);
 
         for (i, (port, receiver)) in comms.into_iter().enumerate() {
             router
@@ -3234,11 +3276,12 @@ mod tests {
         // Bind a direct address -- we should use its bound address!
         // The actor must be on unix:@4 so that after unbinding, the prefix
         // route for world1_1 (unix!@3) is the fallback, not world1_1/actor1 (unix!@4).
-        let direct_actor_id =
+        let direct_actor_ref: ref_::ActorRef =
             reference::ProcId::from_resource_name("unix:@4".parse().unwrap(), "my_proc")
-                .actor_id("my_actor");
+                .actor_id("my_actor")
+                .into();
         router.bind(
-            reference::Reference::Actor(direct_actor_id.clone()),
+            ref_::Reference::Actor(direct_actor_ref.clone()),
             "unix:@5".parse().unwrap(),
         );
 
@@ -3250,7 +3293,7 @@ mod tests {
             .lookup_addr(&test_actor_id("world1_0", "actor"))
             .unwrap();
 
-        let actor_id = direct_actor_id;
+        let actor_id = direct_actor_ref;
         assert_eq!(
             router.lookup_addr(&actor_id).unwrap(),
             "unix!@5".parse().unwrap(),
@@ -3320,13 +3363,13 @@ mod tests {
             eprintln!("{}: {}", mbox.actor_id(), addr);
             if mbox
                 .actor_id()
-                .proc_id()
+                .proc_ref()
                 .label()
                 .is_some_and(|l| l.as_str().starts_with("world0"))
             {
-                world0_router.bind(mbox.actor_id().clone().into(), addr);
+                world0_router.bind(ref_::Reference::from(mbox.actor_id().clone()), addr);
             } else {
-                world1_router.bind(mbox.actor_id().clone().into(), addr);
+                world1_router.bind(ref_::Reference::from(mbox.actor_id().clone()), addr);
             }
         }
 
@@ -3498,12 +3541,12 @@ mod tests {
         fn create_receiver<M>(coalesce: bool) -> (mpsc::UnboundedSender<M>, PortReceiver<M>) {
             // Create dummy state and port_id to create PortReceiver. They are
             // not used in the test.
-            let dummy_actor_id = test_actor_id("world_0", "actor");
+            let dummy_actor_ref: ref_::ActorRef = test_actor_id("world_0", "actor").into();
             let dummy_state = State::new(
-                dummy_actor_id.clone(),
+                dummy_actor_ref.clone(),
                 BOXED_PANICKING_MAILBOX_SENDER.clone(),
             );
-            let dummy_port_id = reference::PortId::new(dummy_actor_id, 0);
+            let dummy_port_id = dummy_actor_ref.port_ref(crate::port::Port::from(0));
             let (sender, receiver) = mpsc::unbounded_channel::<M>();
             let receiver = PortReceiver {
                 receiver,
@@ -3984,7 +4027,8 @@ mod tests {
                 .expect("receiver should not be closed");
 
         // Verify the undeliverable message has the correct destination
-        assert_eq!(undeliverable.0.dest(), &split_port_id);
+        let split_port_ref: ref_::PortRef = split_port_id.into();
+        assert_eq!(undeliverable.0.dest(), &split_port_ref);
 
         // Verify no additional messages arrived at the original receiver
         let msg = receiver.try_recv().unwrap();
@@ -4001,7 +4045,7 @@ mod tests {
         let router = DialMailboxRouter::new();
         router.bind(test_proc_ref("world0"), "unix!@1".parse().unwrap());
 
-        let prefixes: Vec<reference::Reference> = router.prefixes().into_iter().collect();
+        let prefixes: Vec<ref_::Reference> = router.prefixes().into_iter().collect();
         assert_eq!(prefixes.len(), 1);
         assert_eq!(prefixes[0], test_proc_ref("world0"));
     }
@@ -4013,7 +4057,7 @@ mod tests {
         router.bind(test_proc_ref("world1"), "unix!@2".parse().unwrap());
         router.bind(test_proc_ref("world2"), "unix!@3".parse().unwrap());
 
-        let mut prefixes: Vec<reference::Reference> = router.prefixes().into_iter().collect();
+        let mut prefixes: Vec<ref_::Reference> = router.prefixes().into_iter().collect();
         prefixes.sort();
 
         let mut expected = vec![
@@ -4036,7 +4080,7 @@ mod tests {
         router.bind(test_proc_ref("world1"), "unix!@4".parse().unwrap());
         router.bind(test_proc_ref("world1_0"), "unix!@5".parse().unwrap());
 
-        let mut prefixes: Vec<reference::Reference> = router.prefixes().into_iter().collect();
+        let mut prefixes: Vec<ref_::Reference> = router.prefixes().into_iter().collect();
         prefixes.sort();
 
         let mut expected = vec![
@@ -4068,7 +4112,7 @@ mod tests {
             "unix!@6".parse().unwrap(),
         );
 
-        let mut prefixes: Vec<reference::Reference> = router.prefixes().into_iter().collect();
+        let mut prefixes: Vec<ref_::Reference> = router.prefixes().into_iter().collect();
         prefixes.sort();
 
         // Covering prefixes:
@@ -4096,7 +4140,7 @@ mod tests {
         router.bind(test_proc_ref("world0_1"), "unix!@2".parse().unwrap());
         router.bind(test_proc_ref("world0_2"), "unix!@3".parse().unwrap());
 
-        let mut prefixes: Vec<reference::Reference> = router.prefixes().into_iter().collect();
+        let mut prefixes: Vec<ref_::Reference> = router.prefixes().into_iter().collect();
         prefixes.sort();
 
         // All should be covering prefixes since none is a prefix of another
@@ -4240,7 +4284,9 @@ mod tests {
     #[test]
     fn test_bind_port_handle_to_actor_port() {
         let mbox = Mailbox::new_detached(test_actor_id("0", "test"));
-        let default_port = mbox.actor_id().port_id(String::port());
+        let default_port = mbox
+            .actor_id()
+            .port_ref(crate::port::Port::from(String::port()));
         let (handle, _rx) = mbox.open_port::<String>();
         // Handle's port index is allocated by mailbox, not the actor port.
         assert_ne!(default_port.index(), handle.port_index);

--- a/hyperactor/src/mailbox/undeliverable.rs
+++ b/hyperactor/src/mailbox/undeliverable.rs
@@ -42,7 +42,7 @@ pub(crate) fn new_undeliverable_port() -> (
     PortReceiver<Undeliverable<MessageEnvelope>>,
 ) {
     let proc = Proc::local();
-    crate::mailbox::Mailbox::new_detached(proc.proc_id().actor_id("undeliverable"))
+    crate::mailbox::Mailbox::new_detached(proc.proc_id().actor_ref("undeliverable"))
         .open_port::<Undeliverable<MessageEnvelope>>()
 }
 

--- a/hyperactor/src/ordering.rs
+++ b/hyperactor/src/ordering.rs
@@ -25,7 +25,7 @@ use tokio::sync::mpsc::error::SendError;
 use typeuri::Named;
 use uuid::Uuid;
 
-use crate::reference;
+use crate::ref_;
 
 /// A client's re-ordering buffer state.
 struct BufferState<T> {
@@ -179,9 +179,9 @@ impl<T> OrderedSender<T> {
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
 enum SeqKey {
     /// Shared sequence for all actor ports of an actor
-    Actor(reference::ActorId),
+    Actor(ref_::ActorRef),
     /// Individual sequence for a specific non-actor port
-    Port(reference::PortId),
+    Port(ref_::PortRef),
 }
 
 /// A message's sequencer number infomation.
@@ -255,9 +255,9 @@ impl Sequencer {
     ///
     /// - Actor ports: share the same sequence scheme per actor (keyed by ActorId)
     /// - Non-actor ports: get individual sequence schemes (keyed by PortId)
-    pub fn assign_seq(&self, port_id: &reference::PortId) -> SeqInfo {
+    pub fn assign_seq(&self, port_id: &ref_::PortRef) -> SeqInfo {
         let key = if port_id.is_actor_port() {
-            SeqKey::Actor(port_id.actor_id().clone())
+            SeqKey::Actor(port_id.actor_ref().clone())
         } else {
             SeqKey::Port(port_id.clone())
         };
@@ -282,6 +282,7 @@ mod tests {
     use std::sync::Arc;
 
     use super::*;
+    use crate::port::Port;
     use crate::testing::ids::test_actor_id;
 
     /// Test message type 1 for actor port sequencing tests.
@@ -474,17 +475,17 @@ mod tests {
             last_seqs: Arc::new(Mutex::new(HashMap::new())),
         };
 
-        let actor_id = test_actor_id("test_0", "test");
-        let port_id = actor_id.port_id(1);
+        let actor_ref: crate::ref_::ActorRef = test_actor_id("test_0", "test").into();
+        let port_ref = actor_ref.port_ref(Port::from(1));
 
         // Modify original sequencer
-        sequencer.assign_seq(&port_id);
-        sequencer.assign_seq(&port_id);
+        sequencer.assign_seq(&port_ref);
+        sequencer.assign_seq(&port_ref);
 
         // Clone should share the same state
         let cloned_sequencer = sequencer.clone();
         assert_eq!(sequencer.session_id(), cloned_sequencer.session_id(),);
-        assert_eq!(get_seq(cloned_sequencer.assign_seq(&port_id)), 3);
+        assert_eq!(get_seq(cloned_sequencer.assign_seq(&port_ref)), 3);
     }
 
     #[test]
@@ -494,20 +495,20 @@ mod tests {
             last_seqs: Arc::new(Mutex::new(HashMap::new())),
         };
 
-        let actor_id = test_actor_id("worker_0", "worker");
+        let actor_ref: crate::ref_::ActorRef = test_actor_id("worker_0", "worker").into();
         // Two different actor ports for the same actor (using Named::port())
-        let actor_port_1 = actor_id.port_id(TestMsg1::port());
-        let actor_port_2 = actor_id.port_id(TestMsg2::port());
+        let actor_port_1 = actor_ref.port_ref(Port::from(TestMsg1::port()));
+        let actor_port_2 = actor_ref.port_ref(Port::from(TestMsg2::port()));
 
-        // Actor ports should share a sequence (keyed by ActorId)
+        // Actor ports should share a sequence (keyed by ActorRef)
         assert_eq!(get_seq(sequencer.assign_seq(&actor_port_1)), 1);
         assert_eq!(get_seq(sequencer.assign_seq(&actor_port_2)), 2); // continues from 1
         assert_eq!(get_seq(sequencer.assign_seq(&actor_port_1)), 3);
 
         // Actor ports from a different actor get their own shared sequence
-        let actor_id_2 = test_actor_id("worker_1", "worker");
-        let actor_port_3 = actor_id_2.port_id(TestMsg1::port());
-        assert_eq!(get_seq(sequencer.assign_seq(&actor_port_3)), 1); // independent from actor_id
+        let actor_ref_2: crate::ref_::ActorRef = test_actor_id("worker_1", "worker").into();
+        let actor_port_3 = actor_ref_2.port_ref(Port::from(TestMsg1::port()));
+        assert_eq!(get_seq(sequencer.assign_seq(&actor_port_3)), 1); // independent from actor_ref
     }
 
     #[test]
@@ -517,21 +518,21 @@ mod tests {
             last_seqs: Arc::new(Mutex::new(HashMap::new())),
         };
 
-        let actor_id_0 = test_actor_id("worker_0", "worker");
-        let actor_id_1 = test_actor_id("worker_1", "worker");
+        let actor_ref_0: crate::ref_::ActorRef = test_actor_id("worker_0", "worker").into();
+        let actor_ref_1: crate::ref_::ActorRef = test_actor_id("worker_1", "worker").into();
 
         // Non-actor ports from the same actor (without ACTOR_PORT_BIT)
-        let port_1 = actor_id_0.port_id(1);
-        let port_2 = actor_id_0.port_id(2);
+        let port_1 = actor_ref_0.port_ref(Port::from(1));
+        let port_2 = actor_ref_0.port_ref(Port::from(2));
 
-        // Non-actor ports should have independent sequences (keyed by PortId)
+        // Non-actor ports should have independent sequences (keyed by PortRef)
         assert_eq!(get_seq(sequencer.assign_seq(&port_1)), 1);
         assert_eq!(get_seq(sequencer.assign_seq(&port_2)), 1); // independent, starts at 1
         assert_eq!(get_seq(sequencer.assign_seq(&port_1)), 2);
         assert_eq!(get_seq(sequencer.assign_seq(&port_2)), 2);
 
         // Non-actor ports from different actors are also independent
-        let port_3 = actor_id_1.port_id(1);
+        let port_3 = actor_ref_1.port_ref(Port::from(1));
         assert_eq!(get_seq(sequencer.assign_seq(&port_3)), 1); // independent from port_1
         assert_eq!(get_seq(sequencer.assign_seq(&port_1)), 3);
         assert_eq!(get_seq(sequencer.assign_seq(&port_3)), 2);
@@ -544,15 +545,15 @@ mod tests {
             last_seqs: Arc::new(Mutex::new(HashMap::new())),
         };
 
-        let actor_id = test_actor_id("worker_0", "worker");
+        let actor_ref: crate::ref_::ActorRef = test_actor_id("worker_0", "worker").into();
 
         // Actor ports (share sequence per actor)
-        let actor_port_1 = actor_id.port_id(TestMsg1::port());
-        let actor_port_2 = actor_id.port_id(TestMsg2::port());
+        let actor_port_1 = actor_ref.port_ref(Port::from(TestMsg1::port()));
+        let actor_port_2 = actor_ref.port_ref(Port::from(TestMsg2::port()));
 
         // Non-actor ports (independent sequences per port)
-        let non_actor_port_1 = actor_id.port_id(1);
-        let non_actor_port_2 = actor_id.port_id(2);
+        let non_actor_port_1 = actor_ref.port_ref(Port::from(1));
+        let non_actor_port_2 = actor_ref.port_ref(Port::from(2));
 
         // Interleave sends to all port types
         assert_eq!(get_seq(sequencer.assign_seq(&actor_port_1)), 1);

--- a/hyperactor/src/proc.rs
+++ b/hyperactor/src/proc.rs
@@ -294,6 +294,7 @@ use crate::ordering::SeqInfo;
 use crate::ordering::Sequencer;
 use crate::ordering::ordered_channel;
 use crate::panic_handler;
+use crate::ref_;
 use crate::reference;
 use crate::supervision::ActorSupervisionEvent;
 
@@ -322,7 +323,7 @@ impl fmt::Debug for Proc {
 struct ProcState {
     /// The proc's id. This should be globally unique, but is not (yet)
     /// for local-only procs.
-    proc_id: reference::ProcId,
+    proc_id: ref_::ProcRef,
 
     /// A muxer instance that has entries for every actor managed by
     /// the proc.
@@ -337,7 +338,7 @@ struct ProcState {
     reserved_roots: DashSet<crate::id::Uid>,
 
     /// All actor instances in this proc.
-    instances: DashMap<reference::ActorId, WeakInstanceCell>,
+    instances: DashMap<ref_::ActorRef, WeakInstanceCell>,
 
     /// Proc-level queue-pressure accounting (PD-6 through PD-9).
     /// Runtime-driven — updated from `account_enqueue` /
@@ -349,7 +350,7 @@ struct ProcState {
     /// Populated by the introspect task just before it exits on
     /// terminal status. Bounded by
     /// [`config::TERMINATED_SNAPSHOT_RETENTION`].
-    terminated_snapshots: DashMap<reference::ActorId, crate::introspect::IntrospectResult>,
+    terminated_snapshots: DashMap<ref_::ActorRef, crate::introspect::IntrospectResult>,
 
     /// Used by root actors to send events to the actor coordinating
     /// supervision of root actors in this proc.
@@ -357,7 +358,7 @@ struct ProcState {
 
     /// The actor ID of the supervision coordinator, if it lives on this proc.
     /// Used to ensure the coordinator is shut down last during proc teardown.
-    supervision_coordinator_actor_id: OnceLock<reference::ActorId>,
+    supervision_coordinator_actor_id: OnceLock<ref_::ActorRef>,
 
     /// Handle to the mailbox server task, if this proc was created with
     /// `Proc::direct()` or had `serve()` called on it. Used to
@@ -398,7 +399,8 @@ pub struct ActorInstance<A: Actor> {
 
 impl Proc {
     /// Create a pre-configured proc with the given proc id and forwarder.
-    pub fn configured(proc_id: reference::ProcId, forwarder: BoxedMailboxSender) -> Self {
+    pub fn configured(proc_id: impl Into<ref_::ProcRef>, forwarder: BoxedMailboxSender) -> Self {
+        let proc_id = proc_id.into();
         tracing::info!(
             proc_id = %proc_id,
             name = "ProcStatus",
@@ -424,7 +426,7 @@ impl Proc {
     /// Create a new direct-addressed proc.
     pub fn direct(addr: ChannelAddr, name: String) -> Result<Self, ChannelError> {
         let (addr, rx) = channel::serve(addr)?;
-        let proc_id = reference::ProcId::from_resource_name(addr, name);
+        let proc_id = ref_::ProcRef::from_resource_name(addr, name);
         let proc = Self::configured(proc_id, DialMailboxRouter::new().into_boxed());
         let handle = proc.clone().serve(rx);
         *proc.inner.mailbox_server_handle.lock().unwrap() = Some(handle);
@@ -437,18 +439,18 @@ impl Proc {
         &self,
         port: PortHandle<ActorSupervisionEvent>,
     ) -> Result<(), anyhow::Error> {
-        let actor_id = port.location().actor_id().clone();
+        let actor_ref: ref_::ActorRef = port.location().actor_id();
         self.state()
             .supervision_coordinator_port
             .set(port)
             .map_err(|existing| anyhow::anyhow!("coordinator port is already set to {existing}"))?;
-        let _ = self.state().supervision_coordinator_actor_id.set(actor_id);
+        let _ = self.state().supervision_coordinator_actor_id.set(actor_ref);
         Ok(())
     }
 
     /// The actor ID of the supervision coordinator, if one is set and
     /// lives on this proc.
-    pub fn supervision_coordinator_actor_id(&self) -> Option<&reference::ActorId> {
+    pub fn supervision_coordinator_actor_id(&self) -> Option<&ref_::ActorRef> {
         self.state().supervision_coordinator_actor_id.get()
     }
 
@@ -501,12 +503,12 @@ impl Proc {
     pub fn local() -> Self {
         let rank = NEXT_LOCAL_RANK.fetch_add(1, Ordering::Relaxed);
         let addr = ChannelAddr::any(ChannelTransport::Local);
-        let proc_id = reference::ProcId::unique(addr, format!("local_{}", rank));
+        let proc_id = ref_::ProcRef::unique(addr, format!("local_{}", rank));
         Proc::configured(proc_id, BoxedMailboxSender::new(PanickingMailboxSender))
     }
 
     /// The proc's ID.
-    pub fn proc_id(&self) -> &reference::ProcId {
+    pub fn proc_id(&self) -> &ref_::ProcRef {
         &self.state().proc_id
     }
 
@@ -526,25 +528,25 @@ impl Proc {
         static RUNTIME_PROC: OnceLock<Proc> = OnceLock::new();
         RUNTIME_PROC.get_or_init(|| {
             let addr = ChannelAddr::any(ChannelTransport::Local);
-            let proc_id = reference::ProcId::unique(addr, "hyperactor_runtime");
+            let proc_id = ref_::ProcRef::unique(addr, "hyperactor_runtime");
             Proc::configured(proc_id, BoxedMailboxSender::new(PanickingMailboxSender))
         })
     }
 
     /// Attach a mailbox to the proc with the provided root name.
     pub fn attach(&self, name: &str) -> Result<Mailbox, anyhow::Error> {
-        let actor_id: reference::ActorId = self.allocate_root_id(name)?;
+        let actor_id: ref_::ActorRef = self.allocate_root_id(name)?;
         Ok(self.bind_mailbox(actor_id))
     }
 
     /// Attach a mailbox to the proc as a child actor.
-    pub fn attach_child(&self, parent_id: &reference::ActorId) -> Result<Mailbox, anyhow::Error> {
-        let actor_id: reference::ActorId = self.allocate_child_id(parent_id)?;
+    pub fn attach_child(&self, parent_id: &ref_::ActorRef) -> Result<Mailbox, anyhow::Error> {
+        let actor_id: ref_::ActorRef = self.allocate_child_id(parent_id)?;
         Ok(self.bind_mailbox(actor_id))
     }
 
     /// Bind a mailbox to the proc.
-    fn bind_mailbox(&self, actor_id: reference::ActorId) -> Mailbox {
+    fn bind_mailbox(&self, actor_id: ref_::ActorRef) -> Mailbox {
         let mbox = Mailbox::new(actor_id, BoxedMailboxSender::new(self.downgrade()));
 
         // TODO: T210748165 tie the muxer entry to the lifecycle of the mailbox held
@@ -565,14 +567,14 @@ impl Proc {
     {
         let (instance, _handle) = self.instance(name)?;
         let (_handle, rx) = instance.bind_actor_port::<M>();
-        let actor_ref = reference::ActorRef::attest(instance.self_id().clone());
+        let actor_ref = reference::ActorRef::attest(instance.self_id().clone().into());
         Ok((instance, actor_ref, rx))
     }
 
     /// Spawn a named (root) actor on this proc. The name of the actor must be
     /// unique.
     pub fn spawn<A: Actor>(&self, name: &str, actor: A) -> Result<ActorHandle<A>, anyhow::Error> {
-        let actor_id = self.allocate_root_id(name)?;
+        let actor_id: ref_::ActorRef = self.allocate_root_id(name)?;
         self.spawn_inner(actor_id, actor, None)
     }
 
@@ -581,7 +583,7 @@ impl Proc {
     #[hyperactor::instrument(fields(actor_id = actor_id.to_string(), actor_name = actor_id.log_name(), actor_type = std::any::type_name::<A>()))]
     fn spawn_inner<A: Actor>(
         &self,
-        actor_id: reference::ActorId,
+        actor_id: ref_::ActorRef,
         actor: A,
         parent: Option<InstanceCell>,
     ) -> Result<ActorHandle<A>, anyhow::Error> {
@@ -594,7 +596,7 @@ impl Proc {
     /// runtime — unlike [`actor_instance`], it never calls
     /// `tokio::spawn`.
     pub fn instance(&self, name: &str) -> Result<(Instance<()>, ActorHandle<()>), anyhow::Error> {
-        let actor_id = self.allocate_root_id(name)?;
+        let actor_id: ref_::ActorRef = self.allocate_root_id(name)?;
         let (instance, _receivers) = Instance::new(self.clone(), actor_id, false, None);
         let handle = ActorHandle::new(instance.inner.cell.clone(), instance.inner.ports.clone());
         instance.change_status(ActorStatus::Client);
@@ -617,7 +619,7 @@ impl Proc {
         &self,
         name: &str,
     ) -> Result<(Instance<()>, ActorHandle<()>), anyhow::Error> {
-        let actor_id = self.allocate_root_id(name)?;
+        let actor_id: ref_::ActorRef = self.allocate_root_id(name)?;
         let (instance, receivers) = Instance::new(self.clone(), actor_id, false, None);
         let handle = ActorHandle::new(instance.inner.cell.clone(), instance.inner.ports.clone());
         instance.change_status(ActorStatus::Client);
@@ -635,7 +637,7 @@ impl Proc {
     /// launch child actors, etc. The actor itself does not handle any
     /// messages unless driven by the caller.
     pub fn actor_instance<A: Actor>(&self, name: &str) -> Result<ActorInstance<A>, anyhow::Error> {
-        let actor_id = self.allocate_root_id(name)?;
+        let actor_id: ref_::ActorRef = self.allocate_root_id(name)?;
         let span = tracing::debug_span!(
             "actor_instance",
             actor_name = name,
@@ -700,7 +702,7 @@ impl Proc {
     }
 
     /// Look up an instance by ActorId.
-    pub fn get_instance(&self, actor_id: &reference::ActorId) -> Option<InstanceCell> {
+    pub fn get_instance(&self, actor_id: &ref_::ActorRef) -> Option<InstanceCell> {
         self.state()
             .instances
             .get(actor_id)
@@ -715,7 +717,7 @@ impl Proc {
     /// with concurrent writes. Prefer `all_instance_keys()` with a
     /// post-filter if this becomes a hot path. Currently unused in
     /// production code.
-    pub fn root_actor_ids(&self) -> Vec<reference::ActorId> {
+    pub fn root_actor_ids(&self) -> Vec<ref_::ActorRef> {
         self.state()
             .instances
             .iter()
@@ -732,7 +734,7 @@ impl Proc {
     /// actors whose `InstanceCell` has been dropped and actors that
     /// have stopped or failed but whose Arc is still held (e.g. by
     /// the introspect task during teardown).
-    pub fn all_actor_ids(&self) -> Vec<reference::ActorId> {
+    pub fn all_actor_ids(&self) -> Vec<ref_::ActorRef> {
         self.state()
             .instances
             .iter()
@@ -757,7 +759,7 @@ impl Proc {
     /// whose `WeakInstanceCell` no longer upgrades. Callers should
     /// tolerate stale entries (e.g. by handling "not found" on
     /// subsequent per-actor lookups).
-    pub fn all_instance_keys(&self) -> Vec<reference::ActorId> {
+    pub fn all_instance_keys(&self) -> Vec<ref_::ActorRef> {
         self.state()
             .instances
             .iter()
@@ -768,7 +770,7 @@ impl Proc {
     /// Look up a terminated actor's snapshot by ID.
     pub fn terminated_snapshot(
         &self,
-        actor_id: &reference::ActorId,
+        actor_id: &ref_::ActorRef,
     ) -> Option<crate::introspect::IntrospectResult> {
         self.state()
             .terminated_snapshots
@@ -777,7 +779,7 @@ impl Proc {
     }
 
     /// Return all terminated actor IDs currently retained.
-    pub fn all_terminated_actor_ids(&self) -> Vec<reference::ActorId> {
+    pub fn all_terminated_actor_ids(&self) -> Vec<ref_::ActorRef> {
         self.state()
             .terminated_snapshots
             .iter()
@@ -838,9 +840,9 @@ impl Proc {
     /// `None`.
     pub fn abort_root_actor(
         &self,
-        root: &reference::ActorId,
+        root: &ref_::ActorRef,
         this_handle: Option<&JoinHandle<()>>,
-    ) -> Option<impl Future<Output = reference::ActorId>> {
+    ) -> Option<impl Future<Output = ref_::ActorRef>> {
         self.state()
             .instances
             .get(root)
@@ -879,7 +881,7 @@ impl Proc {
     /// returning a status observer if successful.
     pub fn stop_actor(
         &self,
-        actor_id: &reference::ActorId,
+        actor_id: &ref_::ActorRef,
         reason: String,
     ) -> Option<watch::Receiver<ActorStatus>> {
         if let Some(entry) = self.state().instances.get(actor_id) {
@@ -918,7 +920,7 @@ impl Proc {
         timeout: Duration,
         cx: Option<&Context<'_, A>>,
         reason: &str,
-    ) -> Result<(Vec<reference::ActorId>, Vec<reference::ActorId>), anyhow::Error> {
+    ) -> Result<(Vec<ref_::ActorRef>, Vec<ref_::ActorRef>), anyhow::Error> {
         self.destroy_and_wait_except_current::<A>(timeout, cx, false, reason)
             .await
     }
@@ -939,7 +941,7 @@ impl Proc {
         cx: Option<&Context<'_, A>>,
         except_current: bool,
         reason: &str,
-    ) -> Result<(Vec<reference::ActorId>, Vec<reference::ActorId>), anyhow::Error> {
+    ) -> Result<(Vec<ref_::ActorRef>, Vec<ref_::ActorRef>), anyhow::Error> {
         tracing::debug!("{}: proc stopping", self.proc_id());
 
         let (this_handle, this_actor_id) = cx.map_or((None, None), |cx| {
@@ -1113,37 +1115,35 @@ impl Proc {
     /// Create a root allocation in the proc.
     ///
     /// Uses `reserved_roots` to prevent races between concurrent callers.
-    fn allocate_root_id(&self, name: &str) -> Result<reference::ActorId, anyhow::Error> {
-        let actor_id = reference::ActorId::new(self.state().proc_id.clone(), name);
-        let uid = actor_id.uid().clone();
+    fn allocate_root_id(&self, name: &str) -> Result<ref_::ActorRef, anyhow::Error> {
+        let actor_ref = self.state().proc_id.actor_ref(name);
+        let uid = actor_ref.uid().clone();
         if !self.state().reserved_roots.insert(uid) {
             anyhow::bail!("an actor with name '{}' has already been spawned", name)
         }
-        Ok(actor_id)
+        Ok(actor_ref)
     }
 
     /// Create a child allocation in the proc.
     pub(crate) fn allocate_child_id(
         &self,
-        parent_id: &reference::ActorId,
-    ) -> Result<reference::ActorId, anyhow::Error> {
-        assert_eq!(parent_id.proc_id(), self.state().proc_id);
-        Ok(parent_id.unique_child_id())
+        parent_id: &ref_::ActorRef,
+    ) -> Result<ref_::ActorRef, anyhow::Error> {
+        assert_eq!(parent_id.proc_ref(), self.state().proc_id);
+        Ok(parent_id.unique_child())
     }
 
     /// Allocate an actor ID with a custom name on this proc.
     pub(crate) fn allocate_named_child_id(
         &self,
-        parent_id: &reference::ActorId,
+        parent_id: &ref_::ActorRef,
         name: &str,
-    ) -> Result<reference::ActorId, anyhow::Error> {
-        assert_eq!(parent_id.proc_id(), self.state().proc_id);
+    ) -> Result<ref_::ActorRef, anyhow::Error> {
+        assert_eq!(parent_id.proc_ref(), self.state().proc_id);
         let label = crate::id::Label::strip(name);
         let actor_id =
-            crate::id::ActorId::instance_labeled(label, parent_id.proc_id().id().clone());
-        Ok(reference::ActorId::from_actor_ref(
-            crate::ref_::ActorRef::new(actor_id, parent_id.actor_ref().location().clone()),
-        ))
+            crate::id::ActorId::instance_labeled(label, parent_id.id().proc_id().clone());
+        Ok(ref_::ActorRef::new(actor_id, parent_id.location().clone()))
     }
 
     /// Downgrade to a weak reference that doesn't prevent the proc from being dropped.
@@ -1182,7 +1182,7 @@ impl MailboxSender for Proc {
         envelope: MessageEnvelope,
         return_handle: PortHandle<Undeliverable<MessageEnvelope>>,
     ) {
-        if envelope.dest().actor_id().proc_id() == self.state().proc_id {
+        if envelope.dest().actor_id().proc_id() == self.state().proc_id.id() {
             self.state().proc_muxer.post(envelope, return_handle)
         } else {
             self.state().forwarder.post(envelope, return_handle)
@@ -1344,7 +1344,7 @@ struct InstanceState<A: Actor> {
 }
 
 impl<A: Actor> InstanceState<A> {
-    fn self_id(&self) -> &reference::ActorId {
+    fn self_id(&self) -> &ref_::ActorRef {
         self.mailbox.actor_id()
     }
 }
@@ -1390,7 +1390,7 @@ impl<A: Actor> Instance<A> {
     /// Create a new actor instance in Created state.
     fn new(
         proc: Proc,
-        actor_id: reference::ActorId,
+        actor_id: ref_::ActorRef,
         detached: bool,
         parent: Option<InstanceCell>,
     ) -> (Self, InstanceReceivers<A>) {
@@ -1537,7 +1537,7 @@ impl<A: Actor> Instance<A> {
     }
 
     /// This instance's actor ID.
-    pub fn self_id(&self) -> &reference::ActorId {
+    pub fn self_id(&self) -> &ref_::ActorRef {
         self.inner.self_id()
     }
 
@@ -1631,7 +1631,7 @@ impl<A: Actor> Instance<A> {
     /// procs that have no independent `ProcAgent`.
     pub fn set_query_child_handler(
         &self,
-        handler: impl (Fn(&crate::reference::Reference) -> IntrospectResult) + Send + Sync + 'static,
+        handler: impl (Fn(&crate::ref_::Reference) -> IntrospectResult) + Send + Sync + 'static,
     ) {
         self.inner.cell.set_query_child_handler(handler);
     }
@@ -1679,7 +1679,13 @@ impl<A: Actor> Instance<A> {
     }
 
     /// Send a message to the actor running on the proc.
-    pub fn post(&self, port_id: reference::PortId, headers: Flattrs, message: wirevalue::Any) {
+    pub fn post(
+        &self,
+        port_id: impl Into<ref_::PortRef>,
+        headers: Flattrs,
+        message: wirevalue::Any,
+    ) {
+        let port_id: ref_::PortRef = port_id.into();
         <Self as context::MailboxExt>::post(
             self,
             port_id,
@@ -1698,13 +1704,13 @@ impl<A: Actor> Instance<A> {
     #[doc(hidden)]
     pub fn post_with_external_seq_info(
         &self,
-        port_id: reference::PortId,
+        port_id: impl Into<ref_::PortRef>,
         headers: Flattrs,
         message: wirevalue::Any,
     ) {
         <Self as context::MailboxExt>::post(
             self,
-            port_id,
+            port_id.into(),
             headers,
             message,
             true,
@@ -2414,7 +2420,7 @@ impl fmt::Debug for InstanceCell {
 
 struct InstanceCellState {
     /// The actor's id.
-    actor_id: reference::ActorId,
+    actor_id: ref_::ActorRef,
 
     /// Actor info contains the actor's type information.
     actor_type: ActorType,
@@ -2485,9 +2491,8 @@ struct InstanceCellState {
     /// `None` means `QueryChild` returns a "not_found" error.
     ///
     /// See S7 in `introspect` module doc.
-    query_child_handler: RwLock<
-        Option<Box<dyn (Fn(&crate::reference::Reference) -> IntrospectResult) + Send + Sync>>,
-    >,
+    query_child_handler:
+        RwLock<Option<Box<dyn (Fn(&crate::ref_::Reference) -> IntrospectResult) + Send + Sync>>>,
 
     /// The supervision event for this actor's failure, if any.
     /// See FI-1, FI-2 in `introspect` module doc.
@@ -2514,7 +2519,7 @@ impl InstanceCellState {
 
     /// Unlink this instance from a child.
     fn unlink(&self, child: &InstanceCellState) -> bool {
-        assert_eq!(self.actor_id.proc_id(), child.actor_id.proc_id());
+        assert_eq!(self.actor_id.proc_ref(), child.actor_id.proc_ref());
         self.children.remove(child.actor_id.uid()).is_some()
     }
 }
@@ -2532,11 +2537,11 @@ impl InstanceCellState {
 ///    newest-first (descending `occurred_at`), preserving the
 ///    earliest failures which are closest to the root cause.
 fn select_eviction_candidates(
-    entries: &[(reference::ActorId, Option<String>)],
+    entries: &[(ref_::ActorRef, Option<String>)],
     excess: usize,
-) -> Vec<reference::ActorId> {
-    let mut clean: Vec<&reference::ActorId> = Vec::new();
-    let mut failed: Vec<(&reference::ActorId, &str)> = Vec::new();
+) -> Vec<ref_::ActorRef> {
+    let mut clean: Vec<&ref_::ActorRef> = Vec::new();
+    let mut failed: Vec<(&ref_::ActorRef, &str)> = Vec::new();
     for (id, occurred_at) in entries {
         match occurred_at {
             Some(ts) => failed.push((id, ts.as_str())),
@@ -2544,7 +2549,7 @@ fn select_eviction_candidates(
         }
     }
 
-    let mut to_remove: Vec<reference::ActorId> = Vec::new();
+    let mut to_remove: Vec<ref_::ActorRef> = Vec::new();
     let mut remaining = excess;
 
     // Evict cleanly-stopped first.
@@ -2571,7 +2576,7 @@ impl InstanceCell {
     /// Creates a new instance cell with the provided internal state. If a parent
     /// is provided, it is linked to this cell.
     fn new(
-        actor_id: reference::ActorId,
+        actor_id: ref_::ActorRef,
         actor_type: ActorType,
         proc: Proc,
         actor_loop: Option<(PortHandle<Signal>, PortHandle<ActorSupervisionEvent>)>,
@@ -2617,7 +2622,7 @@ impl InstanceCell {
     }
 
     /// The actor's ID.
-    pub fn actor_id(&self) -> &reference::ActorId {
+    pub fn actor_id(&self) -> &ref_::ActorRef {
         &self.inner.actor_id
     }
 
@@ -2728,13 +2733,13 @@ impl InstanceCell {
 
     /// Link this instance to a new child.
     fn link(&self, child: InstanceCell) {
-        assert_eq!(self.actor_id().proc_id(), child.actor_id().proc_id());
+        assert_eq!(self.actor_id().proc_ref(), child.actor_id().proc_ref());
         self.inner.children.insert(child.uid().clone(), child);
     }
 
     /// Unlink this instance from a child.
     fn unlink(&self, child: &InstanceCell) {
-        assert_eq!(self.actor_id().proc_id(), child.actor_id().proc_id());
+        assert_eq!(self.actor_id().proc_ref(), child.actor_id().proc_ref());
         self.inner.children.remove(child.uid());
     }
 
@@ -2768,7 +2773,7 @@ impl InstanceCell {
     }
 
     /// Returns the ActorIds of this instance's direct children.
-    pub fn child_actor_ids(&self) -> Vec<reference::ActorId> {
+    pub fn child_actor_ids(&self) -> Vec<ref_::ActorRef> {
         self.inner
             .children
             .iter()
@@ -2855,13 +2860,13 @@ impl InstanceCell {
     /// Capture cloned `Proc` references, not `&mut self`.
     pub fn set_query_child_handler(
         &self,
-        handler: impl (Fn(&crate::reference::Reference) -> IntrospectResult) + Send + Sync + 'static,
+        handler: impl (Fn(&crate::ref_::Reference) -> IntrospectResult) + Send + Sync + 'static,
     ) {
         *self.inner.query_child_handler.write().unwrap() = Some(Box::new(handler));
     }
 
     /// Invoke the registered QueryChild handler, if any.
-    pub fn query_child(&self, child_ref: &crate::reference::Reference) -> Option<IntrospectResult> {
+    pub fn query_child(&self, child_ref: &crate::ref_::Reference) -> Option<IntrospectResult> {
         let guard = self.inner.query_child_handler.read().unwrap();
         guard.as_ref().map(|handler| handler(child_ref))
     }
@@ -2936,7 +2941,7 @@ impl InstanceCell {
                 .exported_named_ports
                 .insert(*entry.key(), entry.value());
         }
-        reference::ActorRef::attest(self.actor_id().clone())
+        reference::ActorRef::attest(self.actor_id().clone().into())
     }
 
     /// Attempt to downcast this cell to a concrete actor handle.
@@ -3403,7 +3408,7 @@ mod tests {
             !lookup_actor
                 .actor_exists(
                     &client,
-                    reference::ActorRef::attest(target_actor.actor_id().unique_child_id().clone())
+                    reference::ActorRef::attest(target_actor.actor_id().unique_child().into())
                 )
                 .await
                 .unwrap()
@@ -3413,7 +3418,7 @@ mod tests {
             !lookup_actor
                 .actor_exists(
                     &client,
-                    reference::ActorRef::attest(lookup_actor.actor_id().clone())
+                    reference::ActorRef::attest(lookup_actor.actor_id().clone().into())
                 )
                 .await
                 .unwrap()
@@ -3434,7 +3439,7 @@ mod tests {
     }
 
     fn validate_link(child: &InstanceCell, parent: &InstanceCell) {
-        assert_eq!(child.actor_id().proc_id(), parent.actor_id().proc_id());
+        assert_eq!(child.actor_id().proc_ref(), parent.actor_id().proc_ref());
         assert_eq!(
             child.inner.parent.upgrade().unwrap().actor_id(),
             parent.actor_id()
@@ -3485,9 +3490,9 @@ mod tests {
         ));
 
         // All actors are in the same proc:
-        assert_eq!(first.actor_id().proc_id(), proc.proc_id().clone());
-        assert_eq!(second.actor_id().proc_id(), proc.proc_id().clone());
-        assert_eq!(third.actor_id().proc_id(), proc.proc_id().clone());
+        assert_eq!(first.actor_id().proc_ref(), *proc.proc_id());
+        assert_eq!(second.actor_id().proc_ref(), *proc.proc_id());
+        assert_eq!(third.actor_id().proc_ref(), *proc.proc_id());
 
         // Supervision tree is constructed correctly.
         validate_link(third.cell(), second.cell());
@@ -4045,7 +4050,7 @@ mod tests {
     /// have stored the snapshot by the time `handle.await` returns.
     async fn wait_for_terminated_snapshot(
         proc: &Proc,
-        actor_id: &reference::ActorId,
+        actor_id: &ref_::ActorRef,
     ) -> crate::introspect::IntrospectResult {
         // Yield to let the introspect task run, then poll. Use a
         // combination of yields (for fast paths) and sleeps (to

--- a/hyperactor/src/ref_.rs
+++ b/hyperactor/src/ref_.rs
@@ -75,7 +75,7 @@ pub enum RefParseError {
 }
 
 /// A process identifier paired with a network location.
-#[derive(Clone, Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize, typeuri::Named)]
 pub struct ProcRef {
     id: ProcId,
     location: Location,
@@ -246,10 +246,24 @@ impl FromStr for ProcRef {
 }
 
 /// An actor identifier paired with a network location.
-#[derive(Clone, Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize, typeuri::Named)]
 pub struct ActorRef {
     id: ActorId,
     location: Location,
+}
+
+hyperactor_config::impl_attrvalue!(ActorRef);
+
+impl PartialEq<crate::reference::ActorId> for ActorRef {
+    fn eq(&self, other: &crate::reference::ActorId) -> bool {
+        *self == ActorRef::from(other.clone())
+    }
+}
+
+impl PartialEq<ActorRef> for crate::reference::ActorId {
+    fn eq(&self, other: &ActorRef) -> bool {
+        ActorRef::from(self.clone()) == *other
+    }
 }
 
 impl ActorRef {
@@ -403,7 +417,7 @@ impl FromStr for ActorRef {
 }
 
 /// A port identifier paired with a network location.
-#[derive(Clone, Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize, typeuri::Named)]
 pub struct PortRef {
     id: PortId,
     location: Location,
@@ -428,6 +442,16 @@ impl PortRef {
     /// Returns the actor id (delegates to port id).
     pub fn actor_id(&self) -> &ActorId {
         self.id.actor_id()
+    }
+
+    /// Whether this is a handler (actor-level) port.
+    pub(crate) fn is_actor_port(&self) -> bool {
+        self.id.port().is_handler()
+    }
+
+    /// The port index.
+    pub fn index(&self) -> u64 {
+        self.id.port().as_u64()
     }
 
     /// Reconstruct the parent ActorRef (with location preserved).

--- a/hyperactor/src/reference.rs
+++ b/hyperactor/src/reference.rs
@@ -421,6 +421,25 @@ impl fmt::Display for ProcId {
     }
 }
 
+impl From<ProcId> for ref_::ProcRef {
+    fn from(p: ProcId) -> Self {
+        p.0
+    }
+}
+
+impl From<ref_::ProcRef> for ProcId {
+    fn from(p: ref_::ProcRef) -> Self {
+        Self(p)
+    }
+}
+
+impl std::ops::Deref for ProcId {
+    type Target = ref_::ProcRef;
+    fn deref(&self) -> &ref_::ProcRef {
+        &self.0
+    }
+}
+
 impl FromStr for ProcId {
     type Err = ReferenceParsingError;
 
@@ -555,6 +574,25 @@ impl FromStr for ActorId {
             .parse()
             .map_err(|e| ReferenceParsingError::Unexpected(format!("{}", e)))?;
         Ok(Self(actor_ref))
+    }
+}
+
+impl From<ActorId> for ref_::ActorRef {
+    fn from(a: ActorId) -> Self {
+        a.0
+    }
+}
+
+impl From<ref_::ActorRef> for ActorId {
+    fn from(a: ref_::ActorRef) -> Self {
+        Self(a)
+    }
+}
+
+impl std::ops::Deref for ActorId {
+    type Target = ref_::ActorRef;
+    fn deref(&self) -> &ref_::ActorRef {
+        &self.0
     }
 }
 
@@ -764,7 +802,7 @@ impl PortId {
         let mut headers = Flattrs::new();
         crate::mailbox::headers::set_send_timestamp(&mut headers);
         cx.post(
-            self.clone(),
+            self.clone().into(),
             headers,
             serialized,
             true,
@@ -783,7 +821,7 @@ impl PortId {
     ) {
         crate::mailbox::headers::set_send_timestamp(&mut headers);
         cx.post(
-            self.clone(),
+            self.clone().into(),
             headers,
             serialized,
             true,
@@ -801,11 +839,12 @@ impl PortId {
         return_undeliverable: bool,
     ) -> anyhow::Result<PortId> {
         cx.split(
-            self.clone(),
+            self.clone().into(),
             reducer_spec,
             reducer_mode,
             return_undeliverable,
         )
+        .map(|p| p.into())
     }
 }
 
@@ -823,6 +862,46 @@ impl FromStr for PortId {
 impl fmt::Display for PortId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Display::fmt(&self.0, f)
+    }
+}
+
+impl From<PortId> for ref_::PortRef {
+    fn from(p: PortId) -> Self {
+        p.0
+    }
+}
+
+impl From<ref_::PortRef> for PortId {
+    fn from(p: ref_::PortRef) -> Self {
+        Self(p)
+    }
+}
+
+impl std::ops::Deref for PortId {
+    type Target = ref_::PortRef;
+    fn deref(&self) -> &ref_::PortRef {
+        &self.0
+    }
+}
+
+// Also bridge Reference <-> ref_::Reference.
+impl From<Reference> for ref_::Reference {
+    fn from(r: Reference) -> Self {
+        match r {
+            Reference::Proc(p) => ref_::Reference::Proc(p.0),
+            Reference::Actor(a) => ref_::Reference::Actor(a.0),
+            Reference::Port(p) => ref_::Reference::Port(p.0),
+        }
+    }
+}
+
+impl From<ref_::Reference> for Reference {
+    fn from(r: ref_::Reference) -> Self {
+        match r {
+            ref_::Reference::Proc(p) => Reference::Proc(ProcId(p)),
+            ref_::Reference::Actor(a) => Reference::Actor(ActorId(a)),
+            ref_::Reference::Port(p) => Reference::Port(PortId(p)),
+        }
     }
 }
 
@@ -963,7 +1042,7 @@ impl<M: RemoteMessage> PortRef<M> {
         crate::mailbox::headers::set_send_timestamp(&mut headers);
         crate::mailbox::headers::set_rust_message_type::<M>(&mut headers);
         cx.post(
-            self.port_id.clone(),
+            self.port_id.clone().into(),
             headers,
             message,
             self.return_undeliverable,
@@ -1149,7 +1228,7 @@ impl<M: RemoteMessage> OncePortRef<M> {
             )
         })?;
         cx.post(
-            self.port_id.clone(),
+            self.port_id.clone().into(),
             headers,
             serialized,
             self.return_undeliverable,
@@ -1345,12 +1424,12 @@ mod tests {
         assert_eq!(rx.try_recv().unwrap().unwrap(), SeqInfo::Direct);
 
         port_handle.bind_actor_port();
-        let port_id = match port_handle.location() {
-            PortLocation::Bound(port_id) => port_id,
+        let port_ref_val = match port_handle.location() {
+            PortLocation::Bound(port_ref) => port_ref,
             _ => panic!("port_handle should be bound"),
         };
-        assert!(port_id.is_actor_port());
-        let port_ref = PortRef::attest(port_id.clone());
+        assert!(port_ref_val.is_actor_port());
+        let port_ref = PortRef::attest(port_ref_val.clone().into());
 
         port_handle.send(&client, ()).unwrap();
         let SeqInfo::Session {
@@ -1392,9 +1471,10 @@ mod tests {
                 assert_seq_info(&mut rx, session_id, &mut seq);
             }
 
-            // From port_id
+            // From port_ref
+            let port_id_conv: PortId = port_ref_val.clone().into();
             for _ in 0..3 {
-                port_id.send(&client, wirevalue::Any::serialize(&()).unwrap());
+                port_id_conv.send(&client, wirevalue::Any::serialize(&()).unwrap());
                 assert_seq_info(&mut rx, session_id, &mut seq);
             }
         }
@@ -1419,12 +1499,12 @@ mod tests {
 
         // Bind to the allocated port.
         port_handle.bind();
-        let port_id = match port_handle.location() {
-            PortLocation::Bound(port_id) => port_id,
+        let port_ref_val = match port_handle.location() {
+            PortLocation::Bound(port_ref) => port_ref,
             _ => panic!("port_handle should be bound"),
         };
         // This is a non-actor port, but it still gets seq info (per-port sequence).
-        assert!(!port_id.is_actor_port());
+        assert!(!port_ref_val.is_actor_port());
 
         // After binding, non-actor ports get their own sequence.
         port_handle.send(&client, ()).unwrap();
@@ -1441,7 +1521,7 @@ mod tests {
         assert_eq!(seq1, 1);
         assert_eq!(session_id, client.sequencer().session_id());
 
-        let port_ref = PortRef::attest(port_id.clone());
+        let port_ref = PortRef::attest(port_ref_val.clone().into());
         port_ref.send(&client, ()).unwrap();
         let SeqInfo::Session { seq: seq2, .. } = rx
             .try_recv()
@@ -1452,7 +1532,8 @@ mod tests {
         };
         assert_eq!(seq2, 2);
 
-        port_id.send(&client, wirevalue::Any::serialize(&()).unwrap());
+        let port_id_conv: PortId = port_ref_val.clone().into();
+        port_id_conv.send(&client, wirevalue::Any::serialize(&()).unwrap());
         let SeqInfo::Session { seq: seq3, .. } = rx
             .try_recv()
             .unwrap()

--- a/hyperactor/src/spawn.rs
+++ b/hyperactor/src/spawn.rs
@@ -7,32 +7,26 @@
  */
 
 use std::sync::Arc;
-use std::sync::atomic::AtomicU64;
-use std::sync::atomic::Ordering;
 
 use async_trait::async_trait;
 
 use crate::actor::Actor;
 use crate::actor::ActorHandle;
 use crate::mailbox::BoxedMailboxSender;
-use crate::reference;
+use crate::ref_;
+
 #[derive(Debug)]
 struct LocalSpawnerState {
-    root: reference::ActorId,
+    root: ref_::ActorRef,
     sender: BoxedMailboxSender,
-    next_pid: AtomicU64,
 }
 
 #[derive(Clone, Debug)]
 pub(crate) struct LocalSpawner(Option<Arc<LocalSpawnerState>>);
 
 impl LocalSpawner {
-    pub(crate) fn new(root: reference::ActorId, sender: BoxedMailboxSender) -> Self {
-        Self(Some(Arc::new(LocalSpawnerState {
-            root,
-            sender,
-            next_pid: AtomicU64::new(1),
-        })))
+    pub(crate) fn new(root: ref_::ActorRef, sender: BoxedMailboxSender) -> Self {
+        Self(Some(Arc::new(LocalSpawnerState { root, sender })))
     }
 
     pub(crate) fn new_panicking() -> Self {
@@ -44,10 +38,16 @@ impl LocalSpawner {
 impl CanSpawn for LocalSpawner {
     async fn spawn<A: Actor>(&self, params: A::Params) -> ActorHandle<A::Message> {
         let state = self.0.as_ref().expect("invalid spawner");
-        let pid = state.next_pid.fetch_add(1, Ordering::Relaxed);
-        let actor_id = state.root.child_id(pid);
-        A::do_spawn(state.sender.clone(), actor_id, params, self.clone())
+        let actor_id = state.root.unique_child();
+        A::do_spawn(state.sender.clone(), actor_id.into(), params, self.clone())
             .await
             .unwrap()
     }
+}
+
+/// The trait for local spawning of actors.
+#[async_trait]
+pub(crate) trait CanSpawn: Clone + Send + Sync + 'static {
+    /// Spawn an actor with the given params.
+    async fn spawn<A: Actor>(&self, params: A::Params) -> ActorHandle<A::Message>;
 }

--- a/hyperactor/src/supervision.rs
+++ b/hyperactor/src/supervision.rs
@@ -54,13 +54,13 @@ wirevalue::register_type!(ActorSupervisionEvent);
 impl ActorSupervisionEvent {
     /// Create a new supervision event. Timestamp is set to the current time.
     pub fn new(
-        actor_id: reference::ActorId,
+        actor_id: impl Into<reference::ActorId>,
         display_name: Option<String>,
         actor_status: ActorStatus,
         message_headers: Option<Flattrs>,
     ) -> Self {
         Self {
-            actor_id,
+            actor_id: actor_id.into(),
             display_name,
             occurred_at: std::time::SystemTime::now(),
             actor_status,

--- a/hyperactor_macros/tests/export.rs
+++ b/hyperactor_macros/tests/export.rs
@@ -12,6 +12,7 @@ use hyperactor::Bind;
 use hyperactor::Context;
 use hyperactor::Handler;
 use hyperactor::Unbind;
+use hyperactor::port::Port;
 use hyperactor::reference;
 use serde::Deserialize;
 use serde::Serialize;
@@ -110,8 +111,11 @@ mod tests {
         // Verify that the ports can be gotten successfully.
         {
             // TestMessage type
-            let port_id = actor_handle.actor_id().port_id(TestMessage::port());
-            let port_ref: reference::PortRef<TestMessage> = reference::PortRef::attest(port_id);
+            let port_id = actor_handle
+                .actor_id()
+                .port_ref(Port::from(TestMessage::port()));
+            let port_ref: reference::PortRef<TestMessage> =
+                reference::PortRef::attest(port_id.into());
             port_ref
                 .send(&client, TestMessage("abc".to_string()))
                 .unwrap();
@@ -119,22 +123,25 @@ mod tests {
         }
         {
             // () type
-            let port_id = actor_handle.actor_id().port_id(<()>::port());
-            let port_ref: reference::PortRef<()> = reference::PortRef::attest(port_id);
+            let port_id = actor_handle.actor_id().port_ref(Port::from(<()>::port()));
+            let port_ref: reference::PortRef<()> = reference::PortRef::attest(port_id.into());
             port_ref.send(&client, ()).unwrap();
             assert_eq!(rx.recv().await.unwrap(), "()");
         }
         {
             // u64 type
-            let port_id = actor_handle.actor_id().port_id(<u64>::port());
-            let port_ref: reference::PortRef<u64> = reference::PortRef::attest(port_id);
+            let port_id = actor_handle.actor_id().port_ref(Port::from(<u64>::port()));
+            let port_ref: reference::PortRef<u64> = reference::PortRef::attest(port_id.into());
             port_ref.send(&client, 987654321).unwrap();
             assert_eq!(rx.recv().await.unwrap(), "u64: 987654321");
         }
         {
             // MyGeneric<()> type
-            let port_id = actor_handle.actor_id().port_id(MyGeneric::<()>::port());
-            let port_ref: reference::PortRef<MyGeneric<()>> = reference::PortRef::attest(port_id);
+            let port_id = actor_handle
+                .actor_id()
+                .port_ref(Port::from(MyGeneric::<()>::port()));
+            let port_ref: reference::PortRef<MyGeneric<()>> =
+                reference::PortRef::attest(port_id.into());
             port_ref.send(&client, MyGeneric(())).unwrap();
             assert_eq!(rx.recv().await.unwrap(), "MyGeneric<()>");
         }
@@ -146,9 +153,9 @@ mod tests {
             let indexed_msg = IndexedErasedUnbound::<TestMessage>::from(erased_msg);
             let port_id = actor_handle
                 .actor_id()
-                .port_id(<IndexedErasedUnbound<TestMessage>>::port());
+                .port_ref(Port::from(<IndexedErasedUnbound<TestMessage>>::port()));
             let port_ref: reference::PortRef<IndexedErasedUnbound<TestMessage>> =
-                reference::PortRef::attest(port_id);
+                reference::PortRef::attest(port_id.into());
             port_ref.send(&client, indexed_msg).unwrap();
             assert_eq!(rx.recv().await.unwrap(), "efg");
         }
@@ -159,9 +166,9 @@ mod tests {
             let indexed_msg = IndexedErasedUnbound::<()>::from(erased_msg);
             let port_id = actor_handle
                 .actor_id()
-                .port_id(<IndexedErasedUnbound<()>>::port());
+                .port_ref(Port::from(<IndexedErasedUnbound<()>>::port()));
             let port_ref: reference::PortRef<IndexedErasedUnbound<()>> =
-                reference::PortRef::attest(port_id);
+                reference::PortRef::attest(port_id.into());
             port_ref.send(&client, indexed_msg).unwrap();
             assert_eq!(rx.recv().await.unwrap(), "()");
         }
@@ -172,9 +179,9 @@ mod tests {
             let indexed_msg = IndexedErasedUnbound::<MyGeneric<()>>::from(erased_msg);
             let port_id = actor_handle
                 .actor_id()
-                .port_id(<IndexedErasedUnbound<MyGeneric<()>>>::port());
+                .port_ref(Port::from(<IndexedErasedUnbound<MyGeneric<()>>>::port()));
             let port_ref: reference::PortRef<IndexedErasedUnbound<MyGeneric<()>>> =
-                reference::PortRef::attest(port_id);
+                reference::PortRef::attest(port_id.into());
             port_ref.send(&client, indexed_msg).unwrap();
             assert_eq!(rx.recv().await.unwrap(), "MyGeneric<()>");
         }

--- a/hyperactor_mesh/src/actor_mesh.rs
+++ b/hyperactor_mesh/src/actor_mesh.rs
@@ -485,7 +485,7 @@ impl<A: Referable> ActorMeshRef<A> {
                 multicast::set_cast_info_on_headers(
                     &mut headers,
                     point,
-                    cx.instance().self_id().clone(),
+                    cx.instance().self_id().clone().into(),
                 );
 
                 // Make sure that we re-bind ranks, as these may be used for

--- a/hyperactor_mesh/src/alloc.rs
+++ b/hyperactor_mesh/src/alloc.rs
@@ -757,7 +757,8 @@ pub(crate) mod testing {
             BoxedMailboxSender::new(router.clone()),
         );
         client_proc.clone().serve(client_rx);
-        router.bind(client_proc_id.clone().into(), client_proc_addr);
+        let proc_ref: hyperactor::ref_::ProcRef = client_proc_id.clone().into();
+        router.bind(proc_ref, client_proc_addr);
         (
             router,
             client_proc.instance("test_proc").unwrap().0,

--- a/hyperactor_mesh/src/alloc/remoteprocess.rs
+++ b/hyperactor_mesh/src/alloc/remoteprocess.rs
@@ -437,14 +437,15 @@ impl RemoteProcessAllocator {
                                     // TODO(meriksen, direct addressing): disable remapping in direct addressing mode
                                     tracing::debug!("remapping mesh_agent {}: addr {} -> {}", mesh_agent, addr, forward_addr);
                                     mesh_agents_by_create_key.insert(create_key.clone(), mesh_agent.clone());
-                                    router.bind(mesh_agent.actor_id().proc_id().clone().into(), addr);
+                                    let proc_ref = mesh_agent.actor_id().proc_ref();
+                                    router.bind(hyperactor::ref_::Reference::from(proc_ref), addr);
                                     ProcState::Running { create_key, proc_id, mesh_agent, addr: forward_addr.clone() }
                                 },
                                 ProcState::Stopped { create_key, reason } => {
                                     match mesh_agents_by_create_key.remove(&create_key) {
                                         Some(mesh_agent) => {
                                             tracing::debug!("unmapping mesh_agent {}", mesh_agent);
-                                            let agent_ref: hyperactor::reference::Reference = mesh_agent.actor_id().proc_id().clone().into();
+                                            let agent_ref = hyperactor::ref_::Reference::from(mesh_agent.actor_id().proc_ref());
                                             router.unbind(&agent_ref);
                                         },
                                         None => {

--- a/hyperactor_mesh/src/bootstrap.rs
+++ b/hyperactor_mesh/src/bootstrap.rs
@@ -53,6 +53,7 @@ use hyperactor::mailbox::MailboxClient;
 use hyperactor::mailbox::MailboxServer;
 use hyperactor::mailbox::MailboxServerHandle;
 use hyperactor::proc::Proc;
+use hyperactor::ref_;
 use hyperactor::reference as hyperactor_reference;
 use hyperactor_config::CONFIG;
 use hyperactor_config::ConfigAttr;
@@ -585,7 +586,7 @@ impl Bootstrap {
 
                 let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<i32>();
                 let agent_handle = ProcAgent::boot_v1(proc.clone(), Some(shutdown_tx))
-                    .map_err(|e| HostError::AgentSpawnFailure(proc_id, e))?;
+                    .map_err(|e| HostError::AgentSpawnFailure(proc_id.into(), e))?;
 
                 let span = entered.exit();
 
@@ -834,7 +835,7 @@ impl std::error::Error for ReadyError {}
 #[derive(Clone)]
 pub struct BootstrapProcHandle {
     /// Logical identity of the proc in the mesh.
-    proc_id: hyperactor_reference::ProcId,
+    proc_id: ref_::ProcRef,
 
     /// Live lifecycle snapshot (see [`ProcStatus`]). Kept in a mutex
     /// so [`BootstrapProcHandle::status`] can return a synchronous
@@ -902,10 +903,7 @@ impl BootstrapProcHandle {
     /// This is the canonical entry point used by
     /// `BootstrapProcManager` when it launches a proc into a new
     /// process.
-    pub(crate) fn new(
-        proc_id: hyperactor_reference::ProcId,
-        launcher: Weak<dyn ProcLauncher>,
-    ) -> Self {
+    pub(crate) fn new(proc_id: ref_::ProcRef, launcher: Weak<dyn ProcLauncher>) -> Self {
         let (tx, rx) = watch::channel(ProcStatus::Starting);
         Self {
             proc_id,
@@ -920,7 +918,7 @@ impl BootstrapProcHandle {
 
     /// Return the logical proc identity in the mesh.
     #[inline]
-    pub fn proc_id(&self) -> &hyperactor_reference::ProcId {
+    pub fn proc_id(&self) -> &ref_::ProcRef {
         &self.proc_id
     }
 
@@ -1275,13 +1273,14 @@ impl BootstrapProcHandle {
         let _ = self.mark_stopping();
 
         if let Some(launcher) = self.launcher.upgrade() {
-            if let Err(e) = launcher.terminate(&self.proc_id, timeout).await {
+            let ref_proc_id: hyperactor_reference::ProcId = self.proc_id.clone().into();
+            if let Err(e) = launcher.terminate(&ref_proc_id, timeout).await {
                 tracing::warn!(
                     proc_id = %self.proc_id,
                     error = %e,
                     "wait_or_brutally_kill: launcher terminate failed, trying kill"
                 );
-                let _ = launcher.kill(&self.proc_id).await;
+                let _ = launcher.kill(&ref_proc_id).await;
             }
         }
 
@@ -1328,7 +1327,7 @@ impl hyperactor::host::ProcHandle for BootstrapProcHandle {
     type TerminalStatus = ProcStatus;
 
     #[inline]
-    fn proc_id(&self) -> &hyperactor_reference::ProcId {
+    fn proc_id(&self) -> &ref_::ProcRef {
         &self.proc_id
     }
 
@@ -1439,8 +1438,9 @@ impl hyperactor::host::ProcHandle for BootstrapProcHandle {
 
         // Delegate to launcher for SIGTERM/SIGKILL escalation.
         tracing::info!(proc_id = %self.proc_id, ?timeout, "terminate(): delegating to launcher");
+        let ref_proc_id: hyperactor_reference::ProcId = self.proc_id.clone().into();
         if let Some(launcher) = self.launcher.upgrade() {
-            if let Err(e) = launcher.terminate(&self.proc_id, timeout).await {
+            if let Err(e) = launcher.terminate(&ref_proc_id, timeout).await {
                 tracing::warn!(proc_id = %self.proc_id, error=%e, "terminate(): launcher termination failed");
                 return Err(hyperactor::host::TerminateError::Io(anyhow::anyhow!(
                     "launcher termination failed: {}",
@@ -1490,8 +1490,9 @@ impl hyperactor::host::ProcHandle for BootstrapProcHandle {
 
         // Delegate to launcher for kill.
         tracing::info!(proc_id = %self.proc_id, "kill(): delegating to launcher");
+        let ref_proc_id: hyperactor_reference::ProcId = self.proc_id.clone().into();
         if let Some(launcher) = self.launcher.upgrade() {
-            if let Err(e) = launcher.kill(&self.proc_id).await {
+            if let Err(e) = launcher.kill(&ref_proc_id).await {
                 tracing::warn!(proc_id = %self.proc_id, error=%e, "kill(): launcher kill failed");
                 return Err(hyperactor::host::TerminateError::Io(anyhow::anyhow!(
                     "launcher kill failed: {}",
@@ -1709,7 +1710,7 @@ pub struct BootstrapProcManager {
     /// Async registry of running children, keyed by [`ProcId`]. Holds
     /// [`BootstrapProcHandle`]s so callers can query or monitor
     /// status.
-    children: Arc<tokio::sync::Mutex<HashMap<hyperactor_reference::ProcId, BootstrapProcHandle>>>,
+    children: Arc<tokio::sync::Mutex<HashMap<ref_::ProcRef, BootstrapProcHandle>>>,
 
     /// FileMonitor that aggregates logs from all children. None if
     /// file monitor creation failed.
@@ -1807,7 +1808,7 @@ impl BootstrapProcManager {
     ///
     /// Returns `None` if the manager has no record of the proc (e.g.
     /// never spawned here, or entry already removed).
-    pub async fn status(&self, proc_id: &hyperactor_reference::ProcId) -> Option<ProcStatus> {
+    pub async fn status(&self, proc_id: &ref_::ProcRef) -> Option<ProcStatus> {
         self.children.lock().await.get(proc_id).map(|h| h.status())
     }
 
@@ -1815,7 +1816,7 @@ impl BootstrapProcManager {
     /// if the proc is known to this manager.
     pub async fn watch(
         &self,
-        proc_id: &hyperactor_reference::ProcId,
+        proc_id: &ref_::ProcRef,
     ) -> Option<tokio::sync::watch::Receiver<ProcStatus>> {
         self.children.lock().await.get(proc_id).map(|h| h.watch())
     }
@@ -1829,7 +1830,7 @@ impl BootstrapProcManager {
     pub(crate) async fn request_stop(
         &self,
         cx: &impl context::Actor,
-        proc: &hyperactor_reference::ProcId,
+        proc: &ref_::ProcRef,
         timeout: Duration,
         reason: &str,
     ) {
@@ -1864,7 +1865,7 @@ impl BootstrapProcManager {
 
     fn spawn_exit_monitor(
         &self,
-        proc_id: hyperactor_reference::ProcId,
+        proc_id: ref_::ProcRef,
         handle: BootstrapProcHandle,
         exit_rx: tokio::sync::oneshot::Receiver<ProcExitResult>,
     ) {
@@ -2017,7 +2018,7 @@ impl ProcManager for BootstrapProcManager {
     #[hyperactor::instrument(fields(proc_id=proc_id.to_string(), addr=backend_addr.to_string()))]
     async fn spawn(
         &self,
-        proc_id: hyperactor_reference::ProcId,
+        proc_id: ref_::ProcRef,
         backend_addr: ChannelAddr,
         config: BootstrapProcConfig,
     ) -> Result<Self::Handle, HostError> {
@@ -2034,7 +2035,7 @@ impl ProcManager for BootstrapProcManager {
         let need_stdio = enable_forwarding || enable_file_capture || tail_size > 0;
 
         let mode = Bootstrap::Proc {
-            proc_id: proc_id.clone(),
+            proc_id: proc_id.clone().into(),
             backend_addr,
             callback_addr,
             socket_dir_path: self.socket_dir.path().to_owned(),
@@ -2048,7 +2049,7 @@ impl ProcManager for BootstrapProcManager {
 
         let opts = LaunchOptions {
             bootstrap_payload,
-            process_name: format_process_name(&proc_id),
+            process_name: format_process_name(&proc_id.clone().into()),
             command: config
                 .bootstrap_command
                 .as_ref()
@@ -2066,9 +2067,10 @@ impl ProcManager for BootstrapProcManager {
 
         // Launch via the configured launcher backend.
         tracing::info!(proc_id = %proc_id, "launching proc with opts={opts:?}");
+        let ref_proc_id: hyperactor_reference::ProcId = proc_id.clone().into();
         let launch_result = self
             .launcher()
-            .launch(&proc_id, opts.clone())
+            .launch(&ref_proc_id, opts.clone())
             .await
             .map_err(|e| {
                 let io_err = match e {
@@ -2106,7 +2108,7 @@ impl ProcManager for BootstrapProcManager {
                     OutputTarget::Stdout,
                     tail_size,
                     opts.log_channel.clone(),
-                    &proc_id,
+                    &ref_proc_id,
                     config.create_rank,
                 );
                 let err = StreamFwder::start(
@@ -2115,7 +2117,7 @@ impl ProcManager for BootstrapProcManager {
                     OutputTarget::Stderr,
                     tail_size,
                     opts.log_channel.clone(),
-                    &proc_id,
+                    &ref_proc_id,
                     config.create_rank,
                 );
                 (Some(out), Some(err))
@@ -2179,16 +2181,10 @@ impl hyperactor::host::SingleTerminate for BootstrapProcManager {
     async fn terminate_proc(
         &self,
         cx: &impl context::Actor,
-        proc: &hyperactor_reference::ProcId,
+        proc: &ref_::ProcRef,
         timeout: Duration,
         reason: &str,
-    ) -> Result<
-        (
-            Vec<hyperactor_reference::ActorId>,
-            Vec<hyperactor_reference::ActorId>,
-        ),
-        anyhow::Error,
-    > {
+    ) -> Result<(Vec<ref_::ActorRef>, Vec<ref_::ActorRef>), anyhow::Error> {
         // Snapshot to avoid holding the lock across awaits.
         let proc_handle: Option<BootstrapProcHandle> = {
             let mut guard = self.children.lock().await;
@@ -2737,7 +2733,8 @@ mod tests {
             BoxedMailboxSender::new(router.clone()),
         );
         proc.clone().serve(proc_rx);
-        router.bind(test_proc_id("client_0").into(), proc_addr.clone());
+        let proc_ref: hyperactor::ref_::ProcRef = test_proc_id("client_0").into();
+        router.bind(proc_ref, proc_addr.clone());
         let (client, _handle) = proc.instance("client").unwrap();
 
         let (tap_tx, mut tap_rx) = tokio::sync::mpsc::unbounded_channel::<String>();
@@ -2848,7 +2845,7 @@ mod tests {
         // ensuring tests only exercise status transitions and not
         // actual process lifecycle.
         fn handle_for_test() -> BootstrapProcHandle {
-            let proc_id = test_proc_id("0");
+            let proc_id: hyperactor::ref_::ProcRef = test_proc_id("0").into();
             let launcher: Arc<dyn ProcLauncher> = Arc::new(TestProcLauncher);
             BootstrapProcHandle::new(proc_id, Arc::downgrade(&launcher))
         }
@@ -2941,7 +2938,9 @@ mod tests {
             // Build a consistent AgentRef for Ready using the
             // handle's ProcId.
             let proc_id = <BootstrapProcHandle as ProcHandle>::proc_id(&h);
-            let actor_id = proc_id.actor_id(crate::proc_agent::PROC_AGENT_ACTOR_NAME);
+            let actor_id = proc_id
+                .actor_ref(crate::proc_agent::PROC_AGENT_ACTOR_NAME)
+                .into();
             let agent_ref: hyperactor_reference::ActorRef<ProcAgent> =
                 hyperactor_reference::ActorRef::attest(actor_id);
             // Ready -> Stopping -> Stopped should be legal.
@@ -2960,7 +2959,9 @@ mod tests {
             // Build a consistent AgentRef for Ready using the
             // handle's ProcId.
             let proc_id = <BootstrapProcHandle as ProcHandle>::proc_id(&h);
-            let actor_id = proc_id.actor_id(crate::proc_agent::PROC_AGENT_ACTOR_NAME);
+            let actor_id = proc_id
+                .actor_ref(crate::proc_agent::PROC_AGENT_ACTOR_NAME)
+                .into();
             let agent: hyperactor_reference::ActorRef<ProcAgent> =
                 hyperactor_reference::ActorRef::attest(actor_id);
             // Running -> Ready
@@ -3025,7 +3026,7 @@ mod tests {
     fn test_handle(proc_id: hyperactor_reference::ProcId) -> BootstrapProcHandle {
         let launcher: std::sync::Arc<dyn crate::proc_launcher::ProcLauncher> =
             std::sync::Arc::new(TestLauncher);
-        BootstrapProcHandle::new(proc_id, std::sync::Arc::downgrade(&launcher))
+        BootstrapProcHandle::new(proc_id.into(), std::sync::Arc::downgrade(&launcher))
     }
 
     #[tokio::test]
@@ -3093,7 +3094,9 @@ mod tests {
         let started_at = std::time::SystemTime::now();
         assert!(handle.mark_running(started_at));
 
-        let actor_id = proc_id.actor_id(crate::proc_agent::PROC_AGENT_ACTOR_NAME);
+        let actor_id = proc_id
+            .actor_ref(crate::proc_agent::PROC_AGENT_ACTOR_NAME)
+            .into();
         let agent_ref: hyperactor_reference::ActorRef<ProcAgent> =
             hyperactor_reference::ActorRef::attest(actor_id);
 
@@ -3207,7 +3210,9 @@ mod tests {
         let addr = ChannelAddr::any(ChannelTransport::Unix);
         let agent: hyperactor_reference::ActorRef<ProcAgent> =
             hyperactor_reference::ActorRef::attest(
-                proc_id.actor_id(crate::proc_agent::PROC_AGENT_ACTOR_NAME),
+                proc_id
+                    .actor_ref(crate::proc_agent::PROC_AGENT_ACTOR_NAME)
+                    .into(),
             );
         assert!(handle.mark_ready(addr, agent));
 
@@ -3293,7 +3298,7 @@ mod tests {
         let (proc_id, backend_addr) = make_proc_id_and_backend_addr(&instance, "t_term").await;
         let handle = mgr
             .spawn(
-                proc_id.clone(),
+                proc_id.clone().into(),
                 backend_addr.clone(),
                 BootstrapProcConfig {
                     create_rank: 0,
@@ -3364,7 +3369,7 @@ mod tests {
         // Launch the child bootstrap process.
         let handle = mgr
             .spawn(
-                proc_id.clone(),
+                proc_id.clone().into(),
                 backend_addr.clone(),
                 BootstrapProcConfig {
                     create_rank: 0,

--- a/hyperactor_mesh/src/bootstrap/mailbox.rs
+++ b/hyperactor_mesh/src/bootstrap/mailbox.rs
@@ -59,14 +59,14 @@ impl MailboxSender for LocalProcDialer {
         envelope: MessageEnvelope,
         return_handle: PortHandle<Undeliverable<MessageEnvelope>>,
     ) {
-        let proc_id = envelope.dest().actor_id().proc_id();
-        let addr = proc_id.addr();
+        let proc_ref = envelope.dest().actor_ref().proc_ref();
+        let addr = proc_ref.addr();
         if addr == &self.local_addr
             // ...and only non-system procs on that address; the rest are directly
             // reachable through the backend address.
-            && matches!(proc_id.uid(), Uid::Instance(_))
+            && matches!(proc_ref.uid(), Uid::Instance(_))
         {
-            let key = proc_id.resource_name();
+            let key = proc_ref.resource_name();
             let senders = self.local_senders.read().unwrap();
             let senders = if senders.contains_key(&key) {
                 senders

--- a/hyperactor_mesh/src/casting.rs
+++ b/hyperactor_mesh/src/casting.rs
@@ -98,7 +98,7 @@ where
     headers.set(CAST_ACTOR_MESH_ID, actor_mesh_id.clone());
     let message = CastMessageEnvelope::new::<A, M>(
         actor_mesh_id.clone(),
-        cx.mailbox().actor_id().clone(),
+        cx.mailbox().actor_id().clone().into(),
         cast_mesh_shape.clone(),
         headers,
         message,

--- a/hyperactor_mesh/src/comm.rs
+++ b/hyperactor_mesh/src/comm.rs
@@ -335,9 +335,9 @@ impl CommActor {
         set_cast_info_on_headers(&mut headers, cast_point, message.sender().clone());
         cx.post_with_external_seq_info(
             cx.self_id()
-                .proc_id()
-                .actor_id(message.dest_port().actor_name())
-                .port_id(message.dest_port().port()),
+                .proc_ref()
+                .actor_ref(message.dest_port().actor_name())
+                .port_ref(hyperactor::port::Port::from(message.dest_port().port())),
             headers,
             wirevalue::Any::serialize(message.data())?,
         );
@@ -465,7 +465,7 @@ impl Handler<CastMessage> for CommActor {
 
         let fwd_message = ForwardMessage {
             dests: vec![frame],
-            sender: cx.self_id().clone(),
+            sender: cx.self_id().clone().into(),
             message: cast_message.message,
             seq: *seq,
             last_seq,
@@ -844,7 +844,7 @@ mod tests {
             let shape = ndslice::Shape::new(vec!["rank".to_string()], slice.clone()).unwrap();
             let envelope = multicast::CastMessageEnvelope::new::<TestActor, TestMessage>(
                 actor_mesh_id,
-                client.self_id().clone(),
+                client.self_id().clone().into(),
                 shape,
                 hyperactor_config::Flattrs::new(),
                 TestMessage::Forward(payload.to_string()),
@@ -873,7 +873,7 @@ mod tests {
             let shape = ndslice::Shape::new(vec!["rank".to_string()], slice.clone()).unwrap();
             let envelope = multicast::CastMessageEnvelope::new::<TestActor, TestMessage>(
                 actor_mesh_id,
-                client.self_id().clone(),
+                client.self_id().clone().into(),
                 shape,
                 hyperactor_config::Flattrs::new(),
                 TestMessage::Forward(payload.to_string()),
@@ -883,7 +883,7 @@ mod tests {
             let last_seq = next_seq;
             next_seq += 1;
             multicast::ForwardMessage {
-                sender: client.self_id().clone(),
+                sender: client.self_id().clone().into(),
                 dests: vec![frame],
                 seq: next_seq,
                 last_seq,
@@ -903,7 +903,7 @@ mod tests {
             let slice = Slice::new_row_major(vec![1]);
             let region = Region::new(vec!["rank".to_string()], slice.clone());
             let cast_msg = multicast::CastMessageV1::new::<TestActor, TestMessage>(
-                client.self_id().clone(),
+                client.self_id().clone().into(),
                 actor_mesh_id,
                 region.clone(),
                 hyperactor_config::Flattrs::new(),

--- a/hyperactor_mesh/src/connect.rs
+++ b/hyperactor_mesh/src/connect.rs
@@ -419,7 +419,7 @@ mod tests {
             cx: &Context<Self>,
             message: Connect,
         ) -> Result<(), anyhow::Error> {
-            let (mut rd, mut wr) = accept(cx, cx.self_id().clone(), message)
+            let (mut rd, mut wr) = accept(cx, cx.self_id().clone().into(), message)
                 .await?
                 .into_split();
             tokio::io::copy(&mut rd, &mut wr).await?;
@@ -432,7 +432,7 @@ mod tests {
     async fn test_simple_connection() -> Result<()> {
         let proc = Proc::local();
         let (client, _) = proc.instance("client")?;
-        let (connect, completer) = Connect::allocate(client.self_id().clone(), client);
+        let (connect, completer) = Connect::allocate(client.self_id().clone().into(), client);
         let actor = proc.spawn("actor", EchoActor {})?;
         actor.send(&completer.caps, connect)?;
         let (mut rd, mut wr) = completer.complete().await?.into_split();
@@ -459,10 +459,14 @@ mod tests {
         let (client, _client_handle) = proc.instance("client")?;
 
         let (connect, completer) =
-            Connect::allocate(client.self_id().clone(), client.clone_for_py());
-        let (mut rd, _) = accept(client.clone_for_py(), client.self_id().clone(), connect)
-            .await?
-            .into_split();
+            Connect::allocate(client.self_id().clone().into(), client.clone_for_py());
+        let (mut rd, _) = accept(
+            client.clone_for_py(),
+            client.self_id().clone().into(),
+            connect,
+        )
+        .await?
+        .into_split();
         let (_, mut wr) = completer.complete().await?.into_split();
 
         // Write some data
@@ -486,10 +490,14 @@ mod tests {
         let (client, _client_handle) = proc.instance("client")?;
 
         let (connect, completer) =
-            Connect::allocate(client.self_id().clone(), client.clone_for_py());
-        let (mut rd, _) = accept(client.clone_for_py(), client.self_id().clone(), connect)
-            .await?
-            .into_split();
+            Connect::allocate(client.self_id().clone().into(), client.clone_for_py());
+        let (mut rd, _) = accept(
+            client.clone_for_py(),
+            client.self_id().clone().into(),
+            connect,
+        )
+        .await?
+        .into_split();
         let (_, mut wr) = completer.complete().await?.into_split();
 
         // Write some data

--- a/hyperactor_mesh/src/global_context.rs
+++ b/hyperactor_mesh/src/global_context.rs
@@ -273,10 +273,10 @@ impl Actor for GlobalClientActor {
         env.set_error(DeliveryError::BrokenLink(
             "message returned to global root client".to_string(),
         ));
-        let actor_id = env.dest().actor_id().clone();
+        let actor_ref = env.dest().actor_ref();
         let headers = env.headers().clone();
         let event = ActorSupervisionEvent::new(
-            actor_id.clone(),
+            actor_ref.clone(),
             None,
             ActorStatus::generic_failure(format!("message not delivered: {}", env)),
             Some(headers),
@@ -287,14 +287,14 @@ impl Actor for GlobalClientActor {
                 if let Err(e) = sink.send(cx, event) {
                     tracing::warn!(
                         %e,
-                        actor=%actor_id,
+                        actor=%actor_ref,
                         "failed to forward supervision event from undeliverable"
                     );
                 }
             }
             None => {
                 tracing::warn!(
-                    actor=%actor_id,
+                    actor=%actor_ref,
                     error=?env.errors(),
                     "no supervision sink; undeliverable message logged but not forwarded"
                 );
@@ -397,7 +397,7 @@ async fn bootstrap_host() -> GlobalState {
     let proc_mesh = ProcMeshRef::new_singleton(
         ProcMeshId::singleton(Label::new("local").unwrap()),
         ProcRef::new(
-            local_proc_agent.actor_id().proc_id().clone(),
+            local_proc_agent.actor_id().proc_ref().into(),
             0,
             local_proc_agent.bind(),
         ),
@@ -541,9 +541,10 @@ mod tests {
             Flattrs::new(),
         );
         // Target the global root client's well-known Undeliverable port.
+        let client_actor_id: hyperactor_reference::ActorId = client.self_id().clone().into();
         let undeliverable_port =
             hyperactor_reference::PortRef::<Undeliverable<MessageEnvelope>>::attest_message_port(
-                client.self_id(),
+                &client_actor_id,
             );
         undeliverable_port
             .send(client, Undeliverable(env))

--- a/hyperactor_mesh/src/host_mesh.rs
+++ b/hyperactor_mesh/src/host_mesh.rs
@@ -583,7 +583,7 @@ impl HostMesh {
         for _rank in 0..extent.num_ranks() {
             let mesh_agent = mesh_agents_rx.recv().await?;
 
-            let addr = mesh_agent.actor_id().proc_id().addr().clone();
+            let addr = mesh_agent.actor_id().addr().clone();
 
             let host_ref = HostRef(addr);
             if host_ref.mesh_agent() != mesh_agent {
@@ -1829,7 +1829,7 @@ pub async fn spawn_admin(
         crate::mesh_admin::MESH_ADMIN_ACTOR_NAME,
         crate::mesh_admin::MeshAdminAgent::new(
             hosts,
-            Some(root_client_id),
+            Some(root_client_id.into()),
             admin_addr,
             telemetry_url,
         ),

--- a/hyperactor_mesh/src/host_mesh/host_agent.rs
+++ b/hyperactor_mesh/src/host_mesh/host_agent.rs
@@ -40,6 +40,7 @@ use hyperactor::host::LocalProcManager;
 use hyperactor::host::SERVICE_PROC_NAME;
 use hyperactor::host::SingleTerminate;
 use hyperactor::mailbox::MailboxServerHandle;
+use hyperactor::ref_;
 use hyperactor::reference as hyperactor_reference;
 use hyperactor_config::Flattrs;
 use hyperactor_config::attrs::Attrs;
@@ -120,7 +121,7 @@ impl HostAgentMode {
     async fn request_stop(
         &self,
         cx: &impl context::Actor,
-        proc: &hyperactor_reference::ProcId,
+        proc: &ref_::ProcRef,
         timeout: Duration,
         reason: &str,
     ) {
@@ -140,7 +141,7 @@ impl HostAgentMode {
     /// that need process-level detail such as PIDs or exit codes.
     async fn proc_status(
         &self,
-        proc_id: &hyperactor_reference::ProcId,
+        proc_id: &ref_::ProcRef,
     ) -> (resource::Status, Option<bootstrap::ProcStatus>) {
         match self {
             HostAgentMode::Process { host, .. } => match host.manager().status(proc_id).await {
@@ -171,13 +172,8 @@ impl HostAgentMode {
 pub(crate) struct ProcCreationState {
     pub(crate) rank: usize,
     pub(crate) host_mesh_id: Option<crate::mesh_id::HostMeshId>,
-    pub(crate) created: Result<
-        (
-            hyperactor_reference::ProcId,
-            hyperactor_reference::ActorRef<ProcAgent>,
-        ),
-        HostError,
-    >,
+    pub(crate) created:
+        Result<(ref_::ProcRef, hyperactor_reference::ActorRef<ProcAgent>), HostError>,
 }
 
 /// Actor name used when spawning the host mesh agent on the system proc.
@@ -453,16 +449,18 @@ impl HostAgent {
         // local appear as regular children; 's' in the TUI toggles
         // actor visibility, not proc visibility.
         children.push(hyperactor::introspect::IntrospectRef::Proc(
-            host.system_proc().proc_id().clone(),
+            host.system_proc().proc_id().clone().into(),
         ));
         children.push(hyperactor::introspect::IntrospectRef::Proc(
-            host.local_proc().proc_id().clone(),
+            host.local_proc().proc_id().clone().into(),
         ));
 
         // User procs.
         for state in self.created.values() {
             if let Ok((proc_id, _agent_ref)) = &state.created {
-                children.push(hyperactor::introspect::IntrospectRef::Proc(proc_id.clone()));
+                children.push(hyperactor::introspect::IntrospectRef::Proc(
+                    proc_id.clone().into(),
+                ));
             }
         }
 
@@ -522,10 +520,10 @@ impl Actor for HostAgent {
             use hyperactor::introspect::IntrospectResult;
 
             let proc = match child_ref {
-                hyperactor::reference::Reference::Proc(proc_id) => {
-                    if *proc_id == *system_proc.proc_id() {
+                hyperactor::ref_::Reference::Proc(proc_ref) => {
+                    if *proc_ref == *system_proc.proc_id() {
                         Some((&system_proc, SERVICE_PROC_NAME))
-                    } else if *proc_id == *local_proc.proc_id() {
+                    } else if *proc_ref == *local_proc.proc_id() {
                         Some((&local_proc, LOCAL_PROC_NAME))
                     } else {
                         None
@@ -555,9 +553,10 @@ impl Actor for HostAgent {
                     let mut system_actors: Vec<crate::introspect::NodeRef> = Vec::new();
                     for id in all_keys {
                         if proc.get_instance(&id).is_some_and(|cell| cell.is_system()) {
-                            system_actors.push(crate::introspect::NodeRef::Actor(id.clone()));
+                            system_actors
+                                .push(crate::introspect::NodeRef::Actor(id.clone().into()));
                         }
-                        actors.push(hyperactor::introspect::IntrospectRef::Actor(id));
+                        actors.push(hyperactor::introspect::IntrospectRef::Actor(id.into()));
                     }
                     let mut attrs = hyperactor_config::Attrs::new();
                     attrs.set(crate::introspect::NODE_TYPE, "proc".to_string());
@@ -594,12 +593,12 @@ impl Actor for HostAgent {
 
                     IntrospectResult {
                         identity: hyperactor::introspect::IntrospectRef::Proc(
-                            proc.proc_id().clone(),
+                            proc.proc_id().clone().into(),
                         ),
                         attrs: attrs_json,
                         children: actors,
                         parent: Some(hyperactor::introspect::IntrospectRef::Actor(
-                            self_id.clone(),
+                            self_id.clone().into(),
                         )),
                         as_of: std::time::SystemTime::now(),
                     }
@@ -612,14 +611,14 @@ impl Actor for HostAgent {
                         format!("child {} not found", child_ref),
                     );
                     let identity = match child_ref {
-                        hyperactor::reference::Reference::Proc(id) => {
-                            hyperactor::introspect::IntrospectRef::Proc(id.clone())
+                        hyperactor::ref_::Reference::Proc(p) => {
+                            hyperactor::introspect::IntrospectRef::Proc(p.clone().into())
                         }
-                        hyperactor::reference::Reference::Actor(id) => {
-                            hyperactor::introspect::IntrospectRef::Actor(id.clone())
+                        hyperactor::ref_::Reference::Actor(a) => {
+                            hyperactor::introspect::IntrospectRef::Actor(a.clone().into())
                         }
-                        hyperactor::reference::Reference::Port(id) => {
-                            hyperactor::introspect::IntrospectRef::Actor(id.actor_id().clone())
+                        hyperactor::ref_::Reference::Port(p) => {
+                            hyperactor::introspect::IntrospectRef::Actor(p.actor_ref().into())
                         }
                     };
                     IntrospectResult {
@@ -968,11 +967,7 @@ impl HostAgent {
 
     /// Start a bridge task that watches a proc's status channel and sends
     /// `ProcStatusChanged` to self on each change. At most one bridge per proc.
-    async fn start_watch_bridge(
-        &mut self,
-        id: &ResourceId,
-        proc_id: &hyperactor_reference::ProcId,
-    ) {
+    async fn start_watch_bridge(&mut self, id: &ResourceId, proc_id: &ref_::ProcRef) {
         if self.watching.contains(id) {
             return;
         }
@@ -1153,7 +1148,7 @@ impl Handler<ShutdownHost> for HostAgent {
                 ..
             }) => {
                 tracing::info!(
-                    proc_id = %cx.self_id().proc_id(),
+                    proc_id = %cx.self_id().proc_ref(),
                     actor_id = %cx.self_id(),
                     "host is shut down, sending mailbox handle to bootstrap for draining"
                 );
@@ -1203,7 +1198,7 @@ impl Handler<resource::GetState<ProcState>> for HostAgent {
                     id: get_state.id.clone(),
                     status,
                     state: Some(ProcState {
-                        proc_id: proc_id.clone(),
+                        proc_id: proc_id.clone().into(),
                         create_rank: *rank,
                         mesh_agent: mesh_agent.clone(),
                         bootstrap_command,
@@ -1912,7 +1907,8 @@ mod tests {
 
         // The host_agent has now processed messages on the service
         // proc. Query the service proc's introspection.
-        let agent_id = system_proc.proc_id().actor_id(HOST_MESH_AGENT_ACTOR_NAME);
+        let agent_ref = system_proc.proc_id().actor_ref(HOST_MESH_AGENT_ACTOR_NAME);
+        let agent_id: hyperactor_reference::ActorId = agent_ref.into();
         let port =
             hyperactor_reference::PortRef::<IntrospectMessage>::attest_message_port(&agent_id);
 
@@ -1924,7 +1920,9 @@ mod tests {
             port.send(
                 &client,
                 IntrospectMessage::QueryChild {
-                    child_ref: hyperactor_reference::Reference::Proc(system_proc.proc_id().clone()),
+                    child_ref: hyperactor_reference::Reference::Proc(
+                        system_proc.proc_id().clone().into(),
+                    ),
                     reply: reply_port.bind(),
                 },
             )

--- a/hyperactor_mesh/src/logging.rs
+++ b/hyperactor_mesh/src/logging.rs
@@ -1600,7 +1600,8 @@ mod tests {
             BoxedMailboxSender::new(router.clone()),
         );
         proc.clone().serve(client_rx);
-        router.bind(test_proc_id("client_0").into(), proc_addr.clone());
+        let proc_ref: hyperactor::ref_::ProcRef = test_proc_id("client_0").into();
+        router.bind(proc_ref, proc_addr.clone());
         let (client, _handle) = proc.instance("client").unwrap();
 
         // Spin up both the forwarder and the client

--- a/hyperactor_mesh/src/mesh_admin.rs
+++ b/hyperactor_mesh/src/mesh_admin.rs
@@ -928,7 +928,7 @@ impl Actor for MeshAdminAgent {
         // as soon as the admin is reachable.
         this.bind::<Self>();
         this.set_system();
-        self.self_actor_id = Some(this.self_id().clone());
+        self.self_actor_id = Some(this.self_id().clone().into());
 
         let bind_addr = match self.admin_addr_override {
             Some(addr) => addr,
@@ -995,7 +995,7 @@ impl Actor for MeshAdminAgent {
             .clone()
             .unwrap_or_else(|| "unknown".to_string());
         let bridge_state = Arc::new(BridgeState {
-            admin_ref: hyperactor_reference::ActorRef::attest(this.self_id().clone()),
+            admin_ref: hyperactor_reference::ActorRef::attest(this.self_id().clone().into()),
             bridge_cx,
             resolve_semaphore: tokio::sync::Semaphore::new(hyperactor_config::global::get(
                 crate::config::MESH_ADMIN_MAX_CONCURRENT_RESOLVES,
@@ -1005,7 +1005,7 @@ impl Actor for MeshAdminAgent {
             http_client: build_http_client(),
             admin_info: AdminInfo::new(
                 this.self_id().to_string(),
-                this.self_id().proc_id().to_string(),
+                this.self_id().proc_ref().to_string(),
                 admin_url,
             )?,
         });
@@ -3704,7 +3704,7 @@ mod tests {
             .await
             .unwrap();
         let host_node = host_resp.0.unwrap();
-        let local_proc_node_ref = crate::introspect::NodeRef::Proc(local_proc_id.clone());
+        let local_proc_node_ref = crate::introspect::NodeRef::Proc(local_proc_id.clone().into());
         assert!(
             host_node.children.contains(&local_proc_node_ref),
             "host children {:?} should contain local proc {:?}",
@@ -3976,7 +3976,7 @@ mod tests {
         );
 
         // -- 6. Verify host children contain the system proc --
-        let expected_system_ref = crate::introspect::NodeRef::Proc(system_proc_id.clone());
+        let expected_system_ref = crate::introspect::NodeRef::Proc(system_proc_id.clone().into());
         assert!(
             host_node.children.contains(&expected_system_ref),
             "host children {:?} should contain the system proc ref {:?}",

--- a/hyperactor_mesh/src/mesh_controller.rs
+++ b/hyperactor_mesh/src/mesh_controller.rs
@@ -308,7 +308,7 @@ impl<A: Referable> Actor for ActorMeshController<A> {
                 // but the longer-term fix is to clarify whether that
                 // bind path should be idempotent and eliminate the
                 // need for attestation here.
-                subscriber: hyperactor_reference::PortRef::<resource::State<ActorState>>::attest_message_port(this.self_id()).unsplit(),
+                subscriber: hyperactor_reference::PortRef::<resource::State<ActorState>>::attest_message_port(&this.self_id().clone().into()).unsplit(),
             },
         )?;
 
@@ -349,7 +349,8 @@ impl<A: Referable> Actor for ActorMeshController<A> {
             // NOTE: The only part of the port that is used for equality checks is
             // the port id, so create a new one just for the comparison.
             let dest_port_id = envelope.0.dest().clone();
-            let port = hyperactor_reference::PortRef::<Option<MeshFailure>>::attest(dest_port_id);
+            let port =
+                hyperactor_reference::PortRef::<Option<MeshFailure>>::attest(dest_port_id.into());
             let did_exist = self.health_state.subscribers.remove(&port);
             if did_exist {
                 tracing::debug!(

--- a/hyperactor_mesh/src/proc_agent.rs
+++ b/hyperactor_mesh/src/proc_agent.rs
@@ -127,9 +127,9 @@ fn collect_live_children(
     for id in all_keys {
         if let Some(cell) = proc.get_instance(&id) {
             if cell.is_system() {
-                system_children.push(crate::introspect::NodeRef::Actor(id.clone()));
+                system_children.push(crate::introspect::NodeRef::Actor(id.clone().into()));
             }
-            children.push(hyperactor::introspect::IntrospectRef::Actor(id));
+            children.push(hyperactor::introspect::IntrospectRef::Actor(id.into()));
         }
     }
     (children, system_children)
@@ -522,8 +522,8 @@ impl ProcAgent {
         // TUI can filter/gray without per-child fetches.
         let mut stopped_children: Vec<crate::introspect::NodeRef> = Vec::new();
         for id in self.proc.all_terminated_actor_ids() {
-            let child_ref = hyperactor::introspect::IntrospectRef::Actor(id.clone());
-            let node_ref = crate::introspect::NodeRef::Actor(id.clone());
+            let child_ref = hyperactor::introspect::IntrospectRef::Actor(id.clone().into());
+            let node_ref = crate::introspect::NodeRef::Actor(id.clone().into());
             stopped_children.push(node_ref.clone());
             if let Some(snapshot) = self.proc.terminated_snapshot(&id) {
                 let snapshot_attrs: hyperactor_config::Attrs =
@@ -622,8 +622,8 @@ impl Actor for ProcAgent {
         this.set_query_child_handler(move |child_ref| {
             use hyperactor::introspect::IntrospectResult;
 
-            if let hyperactor::reference::Reference::Actor(id) = child_ref {
-                if let Some(snapshot) = proc.terminated_snapshot(id) {
+            if let hyperactor::ref_::Reference::Actor(actor_ref) = child_ref {
+                if let Some(snapshot) = proc.terminated_snapshot(actor_ref) {
                     return snapshot;
                 }
             }
@@ -635,14 +635,15 @@ impl Actor for ProcAgent {
             // next QueryChild(Reference::Proc) response without an
             // extra publish event. See
             // test_query_child_proc_returns_live_children.
-            if let hyperactor::reference::Reference::Proc(proc_id) = child_ref {
-                if proc_id == proc.proc_id() {
+            if let hyperactor::ref_::Reference::Proc(proc_ref) = child_ref {
+                if *proc_ref == *proc.proc_id() {
                     let (mut children, mut system_children) = collect_live_children(&proc);
 
                     let mut stopped_children: Vec<crate::introspect::NodeRef> = Vec::new();
                     for id in proc.all_terminated_actor_ids() {
-                        let child_ref = hyperactor::introspect::IntrospectRef::Actor(id.clone());
-                        let node_ref = crate::introspect::NodeRef::Actor(id.clone());
+                        let child_ref =
+                            hyperactor::introspect::IntrospectRef::Actor(id.clone().into());
+                        let node_ref = crate::introspect::NodeRef::Actor(id.clone().into());
                         stopped_children.push(node_ref.clone());
                         if let Some(snapshot) = proc.terminated_snapshot(&id) {
                             let snapshot_attrs: hyperactor_config::Attrs =
@@ -686,10 +687,10 @@ impl Actor for ProcAgent {
                     attrs.set(crate::introspect::NODE_TYPE, "proc".to_string());
                     attrs.set(
                         crate::introspect::PROC_NAME,
-                        proc_id
+                        proc_ref
                             .label()
                             .map(|l| l.as_str().to_string())
-                            .unwrap_or_else(|| proc_id.id().to_string()),
+                            .unwrap_or_else(|| proc_ref.id().to_string()),
                     );
                     attrs.set(crate::introspect::NUM_ACTORS, num_live);
                     attrs.set(crate::introspect::SYSTEM_CHILDREN, system_children);
@@ -729,7 +730,9 @@ impl Actor for ProcAgent {
                         serde_json::to_string(&attrs).unwrap_or_else(|_| "{}".to_string());
 
                     return IntrospectResult {
-                        identity: hyperactor::introspect::IntrospectRef::Proc(proc_id.clone()),
+                        identity: hyperactor::introspect::IntrospectRef::Proc(
+                            proc_ref.clone().into(),
+                        ),
                         attrs: attrs_json,
                         children,
                         parent: None,
@@ -746,14 +749,14 @@ impl Actor for ProcAgent {
                     format!("child {} not found", child_ref),
                 );
                 let identity = match child_ref {
-                    hyperactor::reference::Reference::Proc(id) => {
-                        hyperactor::introspect::IntrospectRef::Proc(id.clone())
+                    hyperactor::ref_::Reference::Proc(p) => {
+                        hyperactor::introspect::IntrospectRef::Proc(p.clone().into())
                     }
-                    hyperactor::reference::Reference::Actor(id) => {
-                        hyperactor::introspect::IntrospectRef::Actor(id.clone())
+                    hyperactor::ref_::Reference::Actor(a) => {
+                        hyperactor::introspect::IntrospectRef::Actor(a.clone().into())
                     }
-                    hyperactor::reference::Reference::Port(id) => {
-                        hyperactor::introspect::IntrospectRef::Actor(id.actor_id().clone())
+                    hyperactor::ref_::Reference::Port(p) => {
+                        hyperactor::introspect::IntrospectRef::Actor(p.actor_ref().into())
                     }
                 };
                 IntrospectResult {
@@ -778,7 +781,7 @@ impl Actor for ProcAgent {
         envelope: Undeliverable<MessageEnvelope>,
     ) -> Result<(), anyhow::Error> {
         if let Some(true) = envelope.0.headers().get(STREAM_STATE_SUBSCRIBER) {
-            let dest_port_id = envelope.0.dest().clone();
+            let dest_port_id: hyperactor_reference::PortId = envelope.0.dest().clone().into();
             let port =
                 hyperactor_reference::PortRef::<resource::State<ActorState>>::attest(dest_port_id);
             // Remove this subscriber from whichever actor instance holds it.
@@ -816,7 +819,8 @@ impl MeshAgentMessageHandler for ProcAgent {
             DialMailboxRouter::new_with_default_direct_addressed_remote_only(client.into_boxed());
 
         for (proc_id, addr) in address_book {
-            router.bind(proc_id.into(), addr);
+            let proc_ref: hyperactor::ref_::ProcRef = proc_id.into();
+            router.bind(hyperactor::ref_::Reference::from(proc_ref), addr);
         }
 
         let sender = take(&mut self.state).into_unconfigured_v0().unwrap();
@@ -963,7 +967,7 @@ impl Handler<ActorSupervisionEvent> for ProcAgent {
             // the whole process on error events.
             tracing::error!(
                 name = "supervision_event_transmit_failed",
-                proc_id = %cx.self_id().proc_id(),
+                proc_id = %cx.self_id().proc_ref(),
                 %event,
                 "could not propagate supervision event, crashing",
             );
@@ -1755,7 +1759,8 @@ mod tests {
         let client_proc = Proc::direct(ChannelTransport::Unix.any(), "client".to_string()).unwrap();
         let (client, _client_handle) = client_proc.instance("client").unwrap();
 
-        let agent_id = proc.proc_id().actor_id(PROC_AGENT_ACTOR_NAME);
+        let agent_id: hyperactor_reference::ActorId =
+            proc.proc_id().actor_ref(PROC_AGENT_ACTOR_NAME).into();
         let port =
             hyperactor_reference::PortRef::<IntrospectMessage>::attest_message_port(&agent_id);
 
@@ -1766,7 +1771,7 @@ mod tests {
             port.send(
                 client,
                 IntrospectMessage::QueryChild {
-                    child_ref: hyperactor_reference::Reference::Proc(proc.proc_id().clone()),
+                    child_ref: hyperactor_reference::Reference::Proc(proc.proc_id().clone().into()),
                     reply: reply_port.bind(),
                 },
             )
@@ -1863,7 +1868,8 @@ mod tests {
         let client_proc = Proc::direct(ChannelTransport::Unix.any(), "client".to_string()).unwrap();
         let (client, _client_handle) = client_proc.instance("client").unwrap();
 
-        let agent_id = proc.proc_id().actor_id(PROC_AGENT_ACTOR_NAME);
+        let agent_id: hyperactor_reference::ActorId =
+            proc.proc_id().actor_ref(PROC_AGENT_ACTOR_NAME).into();
         let port =
             hyperactor_reference::PortRef::<IntrospectMessage>::attest_message_port(&agent_id);
 
@@ -1882,7 +1888,9 @@ mod tests {
                     .send(
                         &query_client,
                         IntrospectMessage::QueryChild {
-                            child_ref: hyperactor_reference::Reference::Proc(query_proc_id.clone()),
+                            child_ref: hyperactor_reference::Reference::Proc(
+                                query_proc_id.clone().into(),
+                            ),
                             reply: reply_port.bind(),
                         },
                     )
@@ -1943,7 +1951,7 @@ mod tests {
         port.send(
             &client,
             IntrospectMessage::QueryChild {
-                child_ref: hyperactor_reference::Reference::Proc(proc.proc_id().clone()),
+                child_ref: hyperactor_reference::Reference::Proc(proc.proc_id().clone().into()),
                 reply: reply_port.bind(),
             },
         )
@@ -2187,7 +2195,8 @@ mod tests {
 
         // QueryChild(Proc) — same aggregation logic as mesh-admin
         // resolution.
-        let agent_id = proc.proc_id().actor_id(PROC_AGENT_ACTOR_NAME);
+        let agent_id: hyperactor_reference::ActorId =
+            proc.proc_id().actor_ref(PROC_AGENT_ACTOR_NAME).into();
         let port =
             hyperactor_reference::PortRef::<IntrospectMessage>::attest_message_port(&agent_id);
 
@@ -2198,7 +2207,7 @@ mod tests {
             port.send(
                 &client,
                 IntrospectMessage::QueryChild {
-                    child_ref: hyperactor_reference::Reference::Proc(proc.proc_id().clone()),
+                    child_ref: hyperactor_reference::Reference::Proc(proc.proc_id().clone().into()),
                     reply: reply_port.bind(),
                 },
             )

--- a/hyperactor_mesh/src/proc_mesh.rs
+++ b/hyperactor_mesh/src/proc_mesh.rs
@@ -407,7 +407,8 @@ impl ProcMesh {
             // (which expects Allocator2Process, not MessageEnvelope).
             for AllocatedProc { proc_id, addr, .. } in running.iter() {
                 if proc_id.addr() != addr {
-                    router.bind(proc_id.clone().into(), addr.clone());
+                    let proc_ref: hyperactor::ref_::ProcRef = proc_id.clone().into();
+                    router.bind(proc_ref, addr.clone());
                 }
             }
         };
@@ -442,7 +443,7 @@ impl ProcMesh {
             .map(
                 |AllocatedProc {
                      addr, mesh_agent, ..
-                 }| { (mesh_agent.actor_id().proc_id().clone(), addr.clone()) },
+                 }| { (mesh_agent.actor_id().proc_ref().into(), addr.clone()) },
             )
             .collect();
 

--- a/hyperactor_mesh/src/testactor.rs
+++ b/hyperactor_mesh/src/testactor.rs
@@ -130,7 +130,7 @@ impl Handler<GetActorId> for TestActor {
         GetActorId(reply): GetActorId,
     ) -> Result<(), anyhow::Error> {
         let seq_info = cx.headers().get(SEQ_INFO);
-        reply.send(cx, (cx.self_id().clone(), seq_info))?;
+        reply.send(cx, (cx.self_id().clone().into(), seq_info))?;
         Ok(())
     }
 }

--- a/monarch_hyperactor/src/code_sync/conda_sync.rs
+++ b/monarch_hyperactor/src/code_sync/conda_sync.rs
@@ -85,7 +85,7 @@ impl Handler<CondaSyncMessage> for CondaSyncActor {
     ) -> Result<(), anyhow::Error> {
         let res = async {
             let workspace = workspace.resolve()?;
-            let (connect_msg, completer) = Connect::allocate(cx.self_id().clone(), cx);
+            let (connect_msg, completer) = Connect::allocate(cx.self_id().clone().into(), cx);
             connect.send(cx, connect_msg)?;
             let (mut read, mut write) = completer.complete().await?.into_split();
             let path_prefix_replacements = path_prefix_replacements
@@ -127,9 +127,10 @@ pub async fn conda_sync_mesh(
             .take(actor_mesh.region().slice().len())
             .err_into::<anyhow::Error>()
             .try_for_each_concurrent(None, |connect| async {
-                let (mut read, mut write) = accept(instance, instance.self_id().clone(), connect)
-                    .await?
-                    .into_split();
+                let (mut read, mut write) =
+                    accept(instance, instance.self_id().clone().into(), connect)
+                        .await?
+                        .into_split();
                 let res = sender(&local_workspace, &mut read, &mut write).await;
 
                 // Shutdown our end, then read from the other end till exhaustion to avoid undeliverable

--- a/monarch_hyperactor/src/code_sync/manager.rs
+++ b/monarch_hyperactor/src/code_sync/manager.rs
@@ -434,7 +434,7 @@ pub async fn code_sync_mesh(
                         .try_for_each_concurrent(None, |connect| async move {
                             let (mut local, mut stream) = try_join!(
                                 TcpStream::connect(daemon_addr.clone()).err_into(),
-                                accept(instance, instance.self_id().clone(), connect),
+                                accept(instance, instance.self_id().clone().into(), connect),
                             )?;
                             tokio::io::copy_bidirectional(&mut local, &mut stream).await?;
                             Ok(())
@@ -462,7 +462,7 @@ pub async fn code_sync_mesh(
                         .err_into::<anyhow::Error>()
                         .try_for_each_concurrent(None, |connect| async {
                             let (mut read, mut write) =
-                                accept(instance, instance.self_id().clone(), connect)
+                                accept(instance, instance.self_id().clone().into(), connect)
                                     .await?
                                     .into_split();
                             let res = sender(&local_workspace, &mut read, &mut write).await;

--- a/monarch_hyperactor/src/code_sync/rsync.rs
+++ b/monarch_hyperactor/src/code_sync/rsync.rs
@@ -358,7 +358,7 @@ impl Handler<RsyncMessage> for RsyncActor {
             let workspace = workspace
                 .resolve()
                 .context("resolving workspace location")?;
-            let (connect_msg, completer) = Connect::allocate(cx.self_id().clone(), cx);
+            let (connect_msg, completer) = Connect::allocate(cx.self_id().clone().into(), cx);
             connect.send(cx, connect_msg)?;
 
             // some machines (e.g. github CI) do not have ipv6, so try ipv6 then fallback to ipv4
@@ -406,7 +406,7 @@ pub async fn rsync_mesh<C: context::Actor + Copy + Unpin>(
             .try_for_each_concurrent(None, |connect| async move {
                 let (mut local, mut stream) = try_join!(
                     TcpStream::connect(daemon_addr.clone()).err_into(),
-                    accept(cx, cx.instance().self_id().clone(), connect),
+                    accept(cx, cx.instance().self_id().clone().into(), connect),
                 )?;
                 tokio::io::copy_bidirectional(&mut local, &mut stream).await?;
                 anyhow::Ok(())

--- a/monarch_hyperactor/src/context.rs
+++ b/monarch_hyperactor/src/context.rs
@@ -79,7 +79,8 @@ impl PyInstance {
 
     #[getter]
     pub fn actor_id(&self) -> PyActorId {
-        self.inner.self_id().clone().into()
+        let actor_id: hyperactor::reference::ActorId = self.inner.self_id().clone().into();
+        actor_id.into()
     }
 
     #[pyo3(signature = (reason = None))]

--- a/monarch_hyperactor/src/host_mesh.rs
+++ b/monarch_hyperactor/src/host_mesh.rs
@@ -376,7 +376,7 @@ fn bootstrap_host(bootstrap_cmd: Option<PyBootstrapCommand>) -> PyResult<PyPytho
                 hyperactor::id::Label::new("local").unwrap(),
             ),
             ProcRef::new(
-                local_proc_agent.actor_id().proc_id().clone(),
+                local_proc_agent.actor_id().proc_ref().into(),
                 0,
                 local_proc_agent.bind(),
             ),

--- a/monarch_hyperactor/src/local_state_broker.rs
+++ b/monarch_hyperactor/src/local_state_broker.rs
@@ -87,7 +87,7 @@ impl BrokerId {
         use std::time::Duration;
 
         let broker_name = format!("{:?}", self);
-        let actor_id = reference::ActorId::new(cx.proc().proc_id().clone(), self.0.clone());
+        let actor_id = reference::ActorId::new(cx.proc().proc_id().clone().into(), self.0.clone());
         let actor_ref: reference::ActorRef<LocalStateBrokerActor> =
             reference::ActorRef::attest(actor_id);
 

--- a/monarch_hyperactor/src/logging.rs
+++ b/monarch_hyperactor/src/logging.rs
@@ -635,7 +635,7 @@ mod tests {
             "should spawn exactly one proc"
         );
         assert_eq!(
-            instance.self_id().proc_id(),
+            instance.self_id().proc_ref(),
             proc.proc_id().clone(),
             "returned Instance<()> should be bound to the root Proc"
         );

--- a/monarch_hyperactor/src/mailbox.rs
+++ b/monarch_hyperactor/src/mailbox.rs
@@ -140,7 +140,7 @@ impl PyMailbox {
     #[getter]
     pub(super) fn actor_id(&self) -> PyActorId {
         PyActorId {
-            inner: self.inner.actor_id().clone(),
+            inner: self.inner.actor_id().clone().into(),
         }
     }
 
@@ -400,12 +400,13 @@ impl PythonUndeliverableMessageEnvelope {
 
     fn sender(&self) -> PyResult<PyActorId> {
         Ok(PyActorId {
-            inner: self.inner()?.0.sender().clone(),
+            inner: self.inner()?.0.sender().clone().into(),
         })
     }
 
     fn dest(&self) -> PyResult<PyPortId> {
-        Ok(self.inner()?.0.dest().clone().into())
+        let port_id: hyperactor::reference::PortId = self.inner()?.0.dest().clone().into();
+        Ok(port_id.into())
     }
 
     fn error_msg(&self) -> PyResult<String> {

--- a/monarch_hyperactor/src/proc.rs
+++ b/monarch_hyperactor/src/proc.rs
@@ -323,7 +323,7 @@ impl<M: RemoteMessage> InstanceWrapper<M> {
 
         let (_signal_port, signal_receiver) = instance.bind_actor_port::<Signal>();
 
-        let actor_id = instance.self_id().clone();
+        let actor_id = instance.self_id().clone().into();
 
         Ok(Self {
             instance,

--- a/monarch_introspection_snapshot/test/snapshot_integration_test.rs
+++ b/monarch_introspection_snapshot/test/snapshot_integration_test.rs
@@ -416,7 +416,7 @@ async fn test_pt3_immediate_first_capture() -> Result<()> {
     );
 
     // Stop the actor and clean up.
-    let actor_id = instance.proc().proc_id().actor_id("snapshot_capture");
+    let actor_id = instance.proc().proc_id().actor_ref("snapshot_capture");
     instance
         .proc()
         .stop_actor(&actor_id, "PT-3 test cleanup".to_string());
@@ -465,7 +465,7 @@ async fn test_pt5_drain_halts_future_captures() -> Result<()> {
 
     // Stop the snapshot actor directly. In production, job teardown
     // stops the proc which stops all actors on it.
-    let actor_id = instance.proc().proc_id().actor_id("snapshot_capture");
+    let actor_id = instance.proc().proc_id().actor_ref("snapshot_capture");
     let status_rx = instance
         .proc()
         .stop_actor(&actor_id, "PT-5 test shutdown".to_string());

--- a/monarch_rdma/src/rdma_manager_actor.rs
+++ b/monarch_rdma/src/rdma_manager_actor.rs
@@ -162,7 +162,7 @@ impl RdmaManagerActor {
     /// Construct an [`ActorHandle`] for the [`RdmaManagerActor`] co-located
     /// with the caller.
     pub fn local_handle(client: &impl context::Actor) -> ActorHandle<Self> {
-        let proc_id = client.mailbox().actor_id().proc_id().clone();
+        let proc_id = client.mailbox().actor_id().proc_ref().into();
         let actor_ref =
             reference::ActorRef::attest(reference::ActorId::new(proc_id, "rdma_manager"));
         actor_ref

--- a/monarch_tensor_worker/src/lib.rs
+++ b/monarch_tensor_worker/src/lib.rs
@@ -581,7 +581,7 @@ impl WorkerMessageHandler for WorkerActor {
             &self.controller_actor,
             cx,
             seq.next(),
-            cx.self_id().clone(),
+            cx.self_id().clone().into(),
             controller,
         )
         .await?;
@@ -771,7 +771,7 @@ impl WorkerMessageHandler for WorkerActor {
             .send_value(
                 cx,
                 seq,
-                cx.self_id().clone(),
+                cx.self_id().clone().into(),
                 mutates,
                 function,
                 args_kwargs,

--- a/monarch_tensor_worker/src/stream.rs
+++ b/monarch_tensor_worker/src/stream.rs
@@ -496,7 +496,7 @@ impl Actor for StreamActor {
         ROOT_ACTOR_ID.with(|root_actor_id| {
             root_actor_id
                 .set(reference::ActorId::root(
-                    cx.self_id().proc_id(),
+                    cx.self_id().proc_ref().clone().into(),
                     cx.self_id().label().unwrap().clone(),
                 ))
                 .ok()
@@ -638,7 +638,7 @@ impl StreamActor {
                 if self.active_recording.is_none() {
                     let worker_error = WorkerError {
                         backtrace: format!("{e}"),
-                        worker_actor_id: cx.self_id().clone(),
+                        worker_actor_id: cx.self_id().clone().into(),
                     };
                     tracing::info!("Propagating remote function error to client: {worker_error}");
                     self.controller_actor
@@ -1786,7 +1786,7 @@ impl StreamMessageHandler for StreamActor {
                             seq,
                             WorkerError {
                                 backtrace: format!("recording failed: {}", &seq_err),
-                                worker_actor_id: cx.self_id().clone(),
+                                worker_actor_id: cx.self_id().clone().into(),
                             },
                         )
                         .await?;
@@ -2089,7 +2089,7 @@ mod tests {
             .send_value(
                 cx,
                 seq,
-                stream_actor.actor_id().clone(),
+                stream_actor.actor_id().clone().into(),
                 Vec::new(),
                 None,
                 ArgsKwargs::from_wire_values(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #3504
* #3503
* #3502
* #3501
* #3500
* #3499
* #3498
* #3497

Start migrating hyperactor internals from reference:: to ref_:: types. This diff adds From conversions between the type families and migrates internal-only files (ordering.rs, spawn.rs) to use ref_:: types directly. Public-facing types (supervision, introspect) remain on reference:: to avoid cascading changes to downstream crates.

Also adds is_actor_port() and index() to ref_::PortRef, completing the method surface needed for the migration.

Walkthrough:
- ref_.rs: add is_actor_port(), index() to PortRef. Add Reference enum with is_prefix_of, Ord, From impls.
- reference.rs: add From<ProcId> for ProcRef, From<ActorId> for ActorRef, From<PortId> for PortRef (and reverse). Add From<Reference> for ref_::Reference (and reverse).
- ordering.rs: SeqKey and Sequencer::assign_seq use ref_::ActorRef and ref_::PortRef.
- spawn.rs: LocalSpawner uses ref_::ActorRef.
- context.rs: boundary conversion at assign_seq call site.
- mailbox.rs: boundary conversion at assign_seq call site.

Differential Revision: [D101700572](https://our.internmc.facebook.com/intern/diff/D101700572/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D101700572/)!