### PR TITLE
add actor as subject on recording_span

### DIFF
--- a/hyperactor/src/proc.rs
+++ b/hyperactor/src/proc.rs
@@ -1603,9 +1603,14 @@ impl<A: Actor> Instance<A> {
     }
 
     /// Return a fresh tracing span bound to this actor's flight
-    /// recorder. See FR-1, FR-2, FR-3 in module doc.
+    /// recorder, with this actor as the subject. See FR-1, FR-2, FR-3
+    /// in module doc.
     pub fn recording_span(&self) -> tracing::Span {
-        self.inner.cell.recording().span()
+        use crate::subject::AsSubject;
+        self.inner
+            .cell
+            .recording()
+            .span(&self.self_id().subject().to_string())
     }
 
     /// Publish domain-specific properties for introspection.


### PR DESCRIPTION
Summary:
Pass the actor's id, formatted via AsSubject, as the `subject`
argument to `Recording::span` so events recorded on the actor's
flight-recorder span are prefixed with `<actor ...>` in glog output.

This fixes the build.

Reviewed By: shayne-fletcher, johnwhumphreys

Differential Revision: D101807697


