### PR TITLE
[hyperactor] add convenience constructors to id:: types

### DIFF
--- a/hyperactor/src/id.rs
+++ b/hyperactor/src/id.rs
@@ -330,6 +330,22 @@ impl ProcId {
         Self { uid, label }
     }
 
+    /// Create a singleton [`ProcId`] identified by the given label.
+    pub fn singleton(label: Label) -> Self {
+        Self {
+            uid: Uid::Singleton(label.clone()),
+            label: Some(label),
+        }
+    }
+
+    /// Create an instance [`ProcId`] with a random uid and the given label.
+    pub fn instance(label: Label) -> Self {
+        Self {
+            uid: Uid::instance(),
+            label: Some(label),
+        }
+    }
+
     /// Returns the uid.
     pub fn uid(&self) -> &Uid {
         &self.uid
@@ -409,6 +425,33 @@ impl ActorId {
             uid,
             proc_id,
             label,
+        }
+    }
+
+    /// Create a singleton [`ActorId`] identified by the given label.
+    pub fn singleton(label: Label, proc_id: ProcId) -> Self {
+        Self {
+            uid: Uid::Singleton(label.clone()),
+            proc_id,
+            label: Some(label),
+        }
+    }
+
+    /// Create an instance [`ActorId`] with a random uid and no label.
+    pub fn instance(proc_id: ProcId) -> Self {
+        Self {
+            uid: Uid::instance(),
+            proc_id,
+            label: None,
+        }
+    }
+
+    /// Create an instance [`ActorId`] with a random uid and the given label.
+    pub fn instance_labeled(label: Label, proc_id: ProcId) -> Self {
+        Self {
+            uid: Uid::instance(),
+            proc_id,
+            label: Some(label),
         }
     }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #3515
* #3514
* #3513
* #3512
* #3511
* __->__ #3510
* #3509
* #3508

Add singleton and instance constructors to id::ProcId and id::ActorId, preparing for phase 2 of the id migration where reference:: types will become thin newtypes over ref_::.

ProcId gains singleton(label) and instance(label). ActorId gains singleton(label, proc_id), instance(proc_id), and instance_labeled(label, proc_id).

Differential Revision: [D100912593](https://our.internmc.facebook.com/intern/diff/D100912593/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D100912593/)!