### PR TITLE
add ResourceId and mesh id types

### DIFF
--- a/hyperactor/src/id.rs
+++ b/hyperactor/src/id.rs
@@ -8,8 +8,9 @@
 
 //! Universal identifier types for the actor system.
 //!
-//! [`Label`] is an RFC 1035 label: up to 63 lowercase alphanumeric characters
-//! plus hyphens, starting with a letter and ending with an alphanumeric.
+//! [`Label`] is an RFC 1035-style label: up to 63 lowercase alphanumeric
+//! characters plus hyphens and underscores, starting with a letter and ending
+//! with an alphanumeric.
 //!
 //! [`Uid`] is either a singleton (identified by label) or an instance
 //! (identified by a random `u64`).
@@ -29,7 +30,8 @@ use crate::port::Port;
 /// Maximum length of an RFC 1035 label.
 const MAX_LABEL_LEN: usize = 63;
 
-/// An RFC 1035 label: 1–63 chars, lowercase ASCII alphanumeric plus `-`,
+/// An RFC 1035-style label: 1–63 chars, lowercase ASCII alphanumeric plus `-`
+/// or `_`,
 /// starting with a letter, ending with an alphanumeric character.
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Label(SmolStr);
@@ -49,7 +51,8 @@ pub enum LabelError {
     /// The last character is not alphanumeric.
     #[error("label must end with a lowercase letter or digit")]
     InvalidEnd,
-    /// The input contains a character that is not lowercase alphanumeric or `-`.
+    /// The input contains a character that is not lowercase alphanumeric, `-`,
+    /// or `_`.
     #[error("label contains invalid character '{0}'")]
     InvalidChar(char),
 }
@@ -72,7 +75,7 @@ impl Label {
             return Err(LabelError::InvalidEnd);
         }
         for ch in s.chars() {
-            if !ch.is_ascii_lowercase() && !ch.is_ascii_digit() && ch != '-' {
+            if !ch.is_ascii_lowercase() && !ch.is_ascii_digit() && ch != '-' && ch != '_' {
                 return Err(LabelError::InvalidChar(ch));
             }
         }
@@ -89,7 +92,7 @@ impl Label {
             .chars()
             .filter_map(|ch| {
                 let ch = ch.to_ascii_lowercase();
-                if ch.is_ascii_lowercase() || ch.is_ascii_digit() || ch == '-' {
+                if ch.is_ascii_lowercase() || ch.is_ascii_digit() || ch == '-' || ch == '_' {
                     Some(ch)
                 } else {
                     None
@@ -658,9 +661,15 @@ mod tests {
 
     #[test]
     fn test_label_invalid_char() {
-        assert_eq!(Label::new("ab_c"), Err(LabelError::InvalidChar('_')));
         assert_eq!(Label::new("ab.c"), Err(LabelError::InvalidChar('.')));
         assert_eq!(Label::new("aBc"), Err(LabelError::InvalidChar('B')));
+    }
+
+    #[test]
+    fn test_label_allows_underscores() {
+        assert!(Label::new("ab_c").is_ok());
+        assert!(Label::new("proc_agent").is_ok());
+        assert!(Label::new("host_agent").is_ok());
     }
 
     #[test]
@@ -670,7 +679,7 @@ mod tests {
         assert_eq!(Label::strip("---abc---").as_str(), "abc");
         assert_eq!(Label::strip("").as_str(), "nil");
         assert_eq!(Label::strip("123").as_str(), "nil");
-        assert_eq!(Label::strip("My_Service!").as_str(), "myservice");
+        assert_eq!(Label::strip("My_Service!").as_str(), "my_service");
     }
 
     #[test]

--- a/hyperactor_mesh/src/lib.rs
+++ b/hyperactor_mesh/src/lib.rs
@@ -36,6 +36,7 @@ pub mod mesh;
 pub mod mesh_admin;
 pub mod mesh_admin_client;
 pub mod mesh_controller;
+pub mod mesh_id;
 pub mod mesh_selection;
 mod metrics;
 pub mod proc_agent;

--- a/hyperactor_mesh/src/mesh_id.rs
+++ b/hyperactor_mesh/src/mesh_id.rs
@@ -1,0 +1,608 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+//! Mesh identity types.
+//!
+//! [`ResourceId`] is the common identity type for mesh resources: a uid
+//! for identity and an optional label for human readability. The mesh-specific
+//! newtypes [`ActorMeshId`], [`ProcMeshId`], and [`HostMeshId`] provide type
+//! safety at mesh struct boundaries while converting freely to [`ResourceId`]
+//! for resource message plumbing.
+
+use std::cmp::Ordering;
+use std::fmt;
+use std::hash::Hash;
+use std::hash::Hasher;
+use std::str::FromStr;
+
+use hyperactor::id::Label;
+use hyperactor::id::LabelError;
+use hyperactor::id::Uid;
+use hyperactor::id::UidParseError;
+use serde::Deserialize;
+use serde::Serialize;
+use typeuri::Named;
+
+use crate::Name;
+
+/// Errors that can occur when parsing a [`ResourceId`] from a string.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum ResourceIdParseError {
+    /// Error parsing the uid component.
+    #[error("invalid uid: {0}")]
+    InvalidUid(#[from] UidParseError),
+    /// Error parsing the label component.
+    #[error("invalid label: {0}")]
+    InvalidLabel(#[from] LabelError),
+}
+
+/// Identifies a resource in the mesh system.
+///
+/// Identity (Eq, Hash, Ord) is determined solely by `uid`; `label` is
+/// informational metadata excluded from comparisons.
+#[derive(Clone, Serialize, Deserialize, Named)]
+pub struct ResourceId {
+    uid: Uid,
+    label: Option<Label>,
+}
+wirevalue::register_type!(ResourceId);
+
+impl ResourceId {
+    /// Create a [`ResourceId`] with explicit uid and label.
+    pub fn new(uid: Uid, label: Option<Label>) -> Self {
+        Self { uid, label }
+    }
+
+    /// Create a singleton [`ResourceId`] identified by label.
+    /// The label becomes the uid; no separate label metadata is stored.
+    pub fn singleton(label: Label) -> Self {
+        Self {
+            uid: Uid::Singleton(label),
+            label: None,
+        }
+    }
+
+    /// Create a unique [`ResourceId`] with a random uid and the given label.
+    pub fn unique(label: Label) -> Self {
+        Self {
+            uid: Uid::instance(),
+            label: Some(label),
+        }
+    }
+
+    /// Returns the uid.
+    pub fn uid(&self) -> &Uid {
+        &self.uid
+    }
+
+    /// Returns the label.
+    pub fn label(&self) -> Option<&Label> {
+        self.label.as_ref()
+    }
+}
+
+impl PartialEq for ResourceId {
+    fn eq(&self, other: &Self) -> bool {
+        self.uid == other.uid
+    }
+}
+
+impl Eq for ResourceId {}
+
+impl Hash for ResourceId {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.uid.hash(state);
+    }
+}
+
+impl PartialOrd for ResourceId {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for ResourceId {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.uid.cmp(&other.uid)
+    }
+}
+
+fn fmt_instance_uid(uid: u64) -> String {
+    Uid::Instance(uid)
+        .to_string()
+        .trim_start_matches('<')
+        .trim_end_matches('>')
+        .to_string()
+}
+
+fn parse_instance_uid(s: &str) -> Result<u64, UidParseError> {
+    let mut last_err = None;
+    for candidate in [s.to_string(), format!("<{s}>")] {
+        match Uid::from_str(&candidate) {
+            Ok(Uid::Instance(uid)) => return Ok(uid),
+            Ok(Uid::Singleton(_)) => {}
+            Err(err) => last_err = Some(err),
+        }
+    }
+    Err(last_err
+        .expect("instance uid parse should yield an error when it does not yield an instance"))
+}
+
+fn fmt_id_component(f: &mut fmt::Formatter<'_>, uid: &Uid, label: Option<&Label>) -> fmt::Result {
+    match uid {
+        Uid::Singleton(singleton) => write!(f, "{singleton}"),
+        Uid::Instance(uid) => match label {
+            Some(label) => write!(f, "{label}<{}>", fmt_instance_uid(*uid)),
+            None => write!(f, "<{}>", fmt_instance_uid(*uid)),
+        },
+    }
+}
+
+impl fmt::Display for ResourceId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt_id_component(f, &self.uid, self.label.as_ref())
+    }
+}
+
+impl fmt::Debug for ResourceId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match (&self.uid, &self.label) {
+            (Uid::Singleton(label), _) => write!(f, "<{label}>"),
+            (Uid::Instance(uid), Some(label)) => {
+                write!(f, "<'{label}' <{}>>", fmt_instance_uid(*uid))
+            }
+            (Uid::Instance(uid), None) => write!(f, "<<{}>>", fmt_instance_uid(*uid)),
+        }
+    }
+}
+
+fn parse_id_component(s: &str) -> Result<(Uid, Option<Label>), ResourceIdParseError> {
+    if let Some(inner) = s
+        .strip_prefix('<')
+        .and_then(|inner| inner.strip_suffix('>'))
+    {
+        return Ok((Uid::Instance(parse_instance_uid(inner)?), None));
+    }
+
+    if let Some(open) = s.find('<') {
+        if s.ends_with('>') {
+            let label = Label::new(&s[..open])?;
+            let uid = parse_instance_uid(&s[open + 1..s.len() - 1])?;
+            return Ok((Uid::Instance(uid), Some(label)));
+        }
+    }
+
+    let label = Label::new(s)?;
+    Ok((Uid::Singleton(label), None))
+}
+
+impl FromStr for ResourceId {
+    type Err = ResourceIdParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let (uid, label) = parse_id_component(s)?;
+        Ok(Self { uid, label })
+    }
+}
+
+/// Converts a [`Name`] to a [`ResourceId`] for migration.
+///
+/// `Name::Suffixed` maps to an instance uid (preserving the `ShortUuid`'s
+/// inner u64) with a stripped label. `Name::Reserved` maps to a singleton
+/// uid with the name as the label.
+impl From<Name> for ResourceId {
+    fn from(name: Name) -> Self {
+        match name {
+            Name::Suffixed(s, uuid) => ResourceId {
+                uid: Uid::Instance(uuid.0),
+                label: Some(Label::strip(&s)),
+            },
+            Name::Reserved(s) => {
+                let label = Label::new(&s).unwrap_or_else(|_| Label::strip(&s));
+                ResourceId::singleton(label)
+            }
+        }
+    }
+}
+
+macro_rules! define_mesh_id {
+    ($(#[$meta:meta])* $name:ident) => {
+        $(#[$meta])*
+        #[derive(Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize, Named)]
+        #[serde(transparent)]
+        pub struct $name(ResourceId);
+        wirevalue::register_type!($name);
+
+        impl $name {
+            /// Create a mesh id with explicit uid and label.
+            pub fn new(uid: Uid, label: Option<Label>) -> Self {
+                Self(ResourceId::new(uid, label))
+            }
+
+            /// Create a singleton mesh id identified by label.
+            pub fn singleton(label: Label) -> Self {
+                Self(ResourceId::singleton(label))
+            }
+
+            /// Create a unique mesh id with a random uid and the given label.
+            pub fn unique(label: Label) -> Self {
+                Self(ResourceId::unique(label))
+            }
+
+            /// Returns the uid.
+            pub fn uid(&self) -> &Uid {
+                self.0.uid()
+            }
+
+            /// Returns the label.
+            pub fn label(&self) -> Option<&Label> {
+                self.0.label()
+            }
+
+            /// Returns the inner [`ResourceId`].
+            pub fn resource_id(&self) -> &ResourceId {
+                &self.0
+            }
+        }
+
+        impl From<$name> for ResourceId {
+            fn from(id: $name) -> Self {
+                id.0
+            }
+        }
+
+        impl From<ResourceId> for $name {
+            fn from(id: ResourceId) -> Self {
+                Self(id)
+            }
+        }
+
+        impl From<Name> for $name {
+            fn from(name: Name) -> Self {
+                Self(ResourceId::from(name))
+            }
+        }
+
+        impl fmt::Display for $name {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                fmt::Display::fmt(&self.0, f)
+            }
+        }
+
+        impl fmt::Debug for $name {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                fmt::Debug::fmt(&self.0, f)
+            }
+        }
+
+        impl FromStr for $name {
+            type Err = ResourceIdParseError;
+
+            fn from_str(s: &str) -> Result<Self, Self::Err> {
+                Ok(Self(s.parse()?))
+            }
+        }
+    };
+}
+
+define_mesh_id!(
+    /// Identifies a host mesh.
+    HostMeshId
+);
+
+define_mesh_id!(
+    /// Identifies a proc mesh.
+    ProcMeshId
+);
+
+define_mesh_id!(
+    /// Identifies an actor mesh.
+    ActorMeshId
+);
+
+#[cfg(test)]
+mod tests {
+    use std::collections::hash_map::DefaultHasher;
+
+    use super::*;
+
+    #[test]
+    fn test_resource_id_singleton() {
+        let id = ResourceId::singleton(Label::new("local").unwrap());
+        assert_eq!(*id.uid(), Uid::Singleton(Label::new("local").unwrap()));
+        assert_eq!(id.label(), None);
+        assert_eq!(id.to_string(), "local");
+    }
+
+    #[test]
+    fn test_resource_id_unique() {
+        let id = ResourceId::unique(Label::new("workers").unwrap());
+        assert!(matches!(id.uid(), Uid::Instance(_)));
+        assert_eq!(id.label().map(|l| l.as_str()), Some("workers"));
+    }
+
+    #[test]
+    fn test_resource_id_unlabeled() {
+        let id = ResourceId::new(Uid::Instance(0xabcdef), None);
+        assert_eq!(id.to_string(), format!("<{}>", fmt_instance_uid(0xabcdef)));
+        assert_eq!(id.label(), None);
+    }
+
+    #[test]
+    fn test_resource_id_eq_by_uid_only() {
+        let uid = Uid::Instance(0x42);
+        let a = ResourceId::new(uid.clone(), Some(Label::new("alpha").unwrap()));
+        let b = ResourceId::new(uid, Some(Label::new("beta").unwrap()));
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn test_resource_id_neq_different_uid() {
+        let a = ResourceId::new(Uid::Instance(1), Some(Label::new("same").unwrap()));
+        let b = ResourceId::new(Uid::Instance(2), Some(Label::new("same").unwrap()));
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn test_resource_id_hash_by_uid_only() {
+        let uid = Uid::Instance(0x42);
+        let a = ResourceId::new(uid.clone(), Some(Label::new("alpha").unwrap()));
+        let b = ResourceId::new(uid, Some(Label::new("beta").unwrap()));
+
+        let hash = |id: &ResourceId| {
+            let mut h = DefaultHasher::new();
+            id.hash(&mut h);
+            h.finish()
+        };
+        assert_eq!(hash(&a), hash(&b));
+    }
+
+    #[test]
+    fn test_resource_id_ord_by_uid_only() {
+        let a = ResourceId::new(Uid::Instance(1), Some(Label::new("zzz").unwrap()));
+        let b = ResourceId::new(Uid::Instance(2), Some(Label::new("aaa").unwrap()));
+        assert!(a < b);
+    }
+
+    #[test]
+    fn test_resource_id_display_singleton() {
+        let id = ResourceId::singleton(Label::new("local").unwrap());
+        assert_eq!(id.to_string(), "local");
+    }
+
+    #[test]
+    fn test_resource_id_display_labeled_instance() {
+        let id = ResourceId::new(
+            Uid::Instance(0xd5d54d7201103869),
+            Some(Label::new("workers").unwrap()),
+        );
+        assert_eq!(
+            id.to_string(),
+            format!("workers<{}>", fmt_instance_uid(0xd5d54d7201103869))
+        );
+    }
+
+    #[test]
+    fn test_resource_id_display_unlabeled_instance() {
+        let id = ResourceId::new(Uid::Instance(0xd5d54d7201103869), None);
+        assert_eq!(
+            id.to_string(),
+            format!("<{}>", fmt_instance_uid(0xd5d54d7201103869))
+        );
+    }
+
+    #[test]
+    fn test_resource_id_debug() {
+        let singleton = ResourceId::singleton(Label::new("local").unwrap());
+        assert_eq!(format!("{:?}", singleton), "<local>");
+
+        let labeled = ResourceId::new(
+            Uid::Instance(0xd5d54d7201103869),
+            Some(Label::new("workers").unwrap()),
+        );
+        assert_eq!(
+            format!("{:?}", labeled),
+            format!("<'workers' <{}>>", fmt_instance_uid(0xd5d54d7201103869))
+        );
+
+        let unlabeled = ResourceId::new(Uid::Instance(0xd5d54d7201103869), None);
+        assert_eq!(
+            format!("{:?}", unlabeled),
+            format!("<<{}>>", fmt_instance_uid(0xd5d54d7201103869))
+        );
+    }
+
+    #[test]
+    fn test_resource_id_fromstr_singleton() {
+        let parsed: ResourceId = "local".parse().unwrap();
+        assert_eq!(*parsed.uid(), Uid::Singleton(Label::new("local").unwrap()));
+        assert_eq!(parsed.label(), None);
+    }
+
+    #[test]
+    fn test_resource_id_fromstr_labeled_instance() {
+        let parsed: ResourceId = format!("workers<{}>", fmt_instance_uid(0xd5d54d7201103869))
+            .parse()
+            .unwrap();
+        assert_eq!(*parsed.uid(), Uid::Instance(0xd5d54d7201103869));
+        assert_eq!(parsed.label().map(|l| l.as_str()), Some("workers"));
+    }
+
+    #[test]
+    fn test_resource_id_fromstr_unlabeled_instance() {
+        let parsed: ResourceId = format!("<{}>", fmt_instance_uid(0xd5d54d7201103869))
+            .parse()
+            .unwrap();
+        assert_eq!(*parsed.uid(), Uid::Instance(0xd5d54d7201103869));
+        assert_eq!(parsed.label(), None);
+    }
+
+    #[test]
+    fn test_resource_id_fromstr_labeled_with_hyphens() {
+        let parsed: ResourceId = format!("my-service<{}>", fmt_instance_uid(0xd5d54d7201103869))
+            .parse()
+            .unwrap();
+        assert_eq!(*parsed.uid(), Uid::Instance(0xd5d54d7201103869));
+        assert_eq!(parsed.label().map(|l| l.as_str()), Some("my-service"));
+    }
+
+    #[test]
+    fn test_resource_id_display_fromstr_roundtrip() {
+        let cases = vec![
+            ResourceId::singleton(Label::new("local").unwrap()),
+            ResourceId::new(
+                Uid::Instance(0xd5d54d7201103869),
+                Some(Label::new("workers").unwrap()),
+            ),
+            ResourceId::new(Uid::Instance(0xd5d54d7201103869), None),
+            ResourceId::new(
+                Uid::Instance(0xd5d54d7201103869),
+                Some(Label::new("my-service").unwrap()),
+            ),
+            ResourceId::new(Uid::Instance(1), Some(Label::new("a").unwrap())),
+        ];
+        for id in cases {
+            let s = id.to_string();
+            let parsed: ResourceId = s.parse().unwrap();
+            assert_eq!(id, parsed, "round-trip failed for {s}");
+        }
+    }
+
+    #[test]
+    fn test_resource_id_serde_roundtrip() {
+        let cases = vec![
+            ResourceId::singleton(Label::new("local").unwrap()),
+            ResourceId::new(
+                Uid::Instance(0xabcdef),
+                Some(Label::new("workers").unwrap()),
+            ),
+            ResourceId::new(Uid::Instance(0xabcdef), None),
+        ];
+        for id in cases {
+            let json = serde_json::to_string(&id).unwrap();
+            let parsed: ResourceId = serde_json::from_str(&json).unwrap();
+            assert_eq!(id, parsed);
+            // Verify label is preserved through serde.
+            assert_eq!(
+                id.label().map(|l| l.as_str()),
+                parsed.label().map(|l| l.as_str())
+            );
+        }
+    }
+
+    #[test]
+    fn test_resource_id_from_name_suffixed() {
+        let name = Name::new("workers").unwrap();
+        let uuid_val = name.uuid().unwrap().0;
+        let id = ResourceId::from(name);
+        assert_eq!(*id.uid(), Uid::Instance(uuid_val));
+        assert_eq!(id.label().map(|l| l.as_str()), Some("workers"));
+    }
+
+    #[test]
+    fn test_resource_id_from_name_reserved() {
+        let name = Name::new_reserved("local").unwrap();
+        let id = ResourceId::from(name);
+        assert_eq!(*id.uid(), Uid::Singleton(Label::new("local").unwrap()));
+        assert_eq!(id.label(), None);
+    }
+
+    #[test]
+    fn test_resource_id_from_name_reserved_with_underscores() {
+        let name = Name::new_reserved("host_agent").unwrap();
+        let id = ResourceId::from(name);
+        assert_eq!(*id.uid(), Uid::Singleton(Label::new("host_agent").unwrap()));
+    }
+
+    #[test]
+    fn test_mesh_id_construction() {
+        let host = HostMeshId::singleton(Label::new("local").unwrap());
+        assert_eq!(host.to_string(), "local");
+        assert_eq!(*host.uid(), Uid::Singleton(Label::new("local").unwrap()));
+
+        let proc_ = ProcMeshId::unique(Label::new("workers").unwrap());
+        assert!(matches!(proc_.uid(), Uid::Instance(_)));
+        assert_eq!(proc_.label().map(|l| l.as_str()), Some("workers"));
+
+        let actor = ActorMeshId::unique(Label::new("trainers").unwrap());
+        assert!(matches!(actor.uid(), Uid::Instance(_)));
+        assert_eq!(actor.label().map(|l| l.as_str()), Some("trainers"));
+    }
+
+    #[test]
+    fn test_mesh_id_eq_by_uid_only() {
+        let uid = Uid::Instance(0x42);
+        let a = HostMeshId::new(uid.clone(), Some(Label::new("alpha").unwrap()));
+        let b = HostMeshId::new(uid, Some(Label::new("beta").unwrap()));
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn test_mesh_id_display_fromstr_roundtrip() {
+        let ids: Vec<HostMeshId> = vec![
+            HostMeshId::singleton(Label::new("local").unwrap()),
+            HostMeshId::new(
+                Uid::Instance(0xd5d54d7201103869),
+                Some(Label::new("workers").unwrap()),
+            ),
+            HostMeshId::new(Uid::Instance(0xd5d54d7201103869), None),
+        ];
+        for id in ids {
+            let s = id.to_string();
+            let parsed: HostMeshId = s.parse().unwrap();
+            assert_eq!(id, parsed, "round-trip failed for {s}");
+        }
+    }
+
+    #[test]
+    fn test_mesh_id_resource_id_conversion() {
+        let host = HostMeshId::unique(Label::new("test").unwrap());
+        let resource_id: ResourceId = host.clone().into();
+        assert_eq!(host.uid(), resource_id.uid());
+        assert_eq!(
+            host.label().map(|l| l.as_str()),
+            resource_id.label().map(|l| l.as_str())
+        );
+
+        let back: HostMeshId = resource_id.into();
+        assert_eq!(host, back);
+    }
+
+    #[test]
+    fn test_mesh_id_from_name() {
+        let name = Name::new("workers").unwrap();
+        let uuid_val = name.uuid().unwrap().0;
+        let id = ActorMeshId::from(name);
+        assert_eq!(*id.uid(), Uid::Instance(uuid_val));
+        assert_eq!(id.label().map(|l| l.as_str()), Some("workers"));
+    }
+
+    #[test]
+    fn test_mesh_id_serde_transparent() {
+        let host = HostMeshId::new(Uid::Instance(0xabcdef), Some(Label::new("test").unwrap()));
+        let resource = ResourceId::new(Uid::Instance(0xabcdef), Some(Label::new("test").unwrap()));
+
+        let host_json = serde_json::to_string(&host).unwrap();
+        let resource_json = serde_json::to_string(&resource).unwrap();
+        assert_eq!(host_json, resource_json);
+    }
+
+    #[test]
+    fn test_unique_ids_differ() {
+        let a = ResourceId::unique(Label::new("test").unwrap());
+        let b = ResourceId::unique(Label::new("test").unwrap());
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn test_singleton_ids_match() {
+        let a = ResourceId::singleton(Label::new("local").unwrap());
+        let b = ResourceId::singleton(Label::new("local").unwrap());
+        assert_eq!(a, b);
+    }
+}

--- a/hyperactor_mesh/src/shortuuid.rs
+++ b/hyperactor_mesh/src/shortuuid.rs
@@ -54,7 +54,7 @@ static FLICKR_BASE_58_ORD: LazyLock<[Option<usize>; 256]> = LazyLock::new(|| {
     PartialOrd,
     Ord
 )]
-pub struct ShortUuid(u64);
+pub struct ShortUuid(pub(crate) u64);
 
 impl ShortUuid {
     /// Generate a new UUID.

--- a/python/tests/test_rdma_cpu_no_torch.py
+++ b/python/tests/test_rdma_cpu_no_torch.py
@@ -7,62 +7,80 @@
 # pyre-unsafe
 import sys
 import time
+from typing import Any
 
 import pytest
 from isolate_in_subprocess import isolate_in_subprocess
-from monarch.actor import Actor, endpoint, this_host
-from monarch.config import configured
-from monarch.rdma import is_ibverbs_available, RDMABuffer
 
 # TODO(slurye): Enable these tests in OSS once the shutdown hang issue is fixed.
 pytestmark = pytest.mark.oss_skip
 
-RDMA_BACKENDS = []
-if is_ibverbs_available():
-    RDMA_BACKENDS.append("ibverbs")
-RDMA_BACKENDS.append("tcp")
+
+def _rdma_backends() -> list[str]:
+    from monarch.rdma import is_ibverbs_available
+
+    backends = ["tcp"]
+    if is_ibverbs_available():
+        backends.insert(0, "ibverbs")
+    return backends
 
 
-class CpuActor(Actor):
-    def __init__(self) -> None:
-        self.data = bytearray(range(256))
-        self.buf = None
+def _cpu_actor_type() -> Any:
+    from monarch.actor import Actor, endpoint
+    from monarch.rdma import RDMABuffer
 
-    @endpoint
-    async def ping(self) -> str:
-        return "pong"
+    class CpuActor(Actor):
+        def __init__(self) -> None:
+            self.data = bytearray(range(256))
+            self.buf = None
 
-    @endpoint
-    async def create_buffer(self) -> RDMABuffer:
-        import time as _time
+        @endpoint
+        async def ping(self) -> str:
+            return "pong"
 
-        t0 = _time.perf_counter()
-        self.buf = RDMABuffer(memoryview(self.data))
-        t1 = _time.perf_counter()
-        print(
-            f"[ACTOR TIMING] RDMABuffer() total: {(t1 - t0) * 1000:.1f}ms", flush=True
-        )
-        return self.buf
+        @endpoint
+        async def create_buffer(self) -> RDMABuffer:
+            import time as _time
 
-    @endpoint
-    async def read_buffer(self, buf: RDMABuffer) -> bytes:
-        import time as _time
+            t0 = _time.perf_counter()
+            self.buf = RDMABuffer(memoryview(self.data))
+            t1 = _time.perf_counter()
+            print(
+                f"[ACTOR TIMING] RDMABuffer() total: {(t1 - t0) * 1000:.1f}ms",
+                flush=True,
+            )
+            return self.buf
 
-        t0 = _time.perf_counter()
-        dst = bytearray(len(self.data))
-        await buf.read_into(memoryview(dst))
-        t1 = _time.perf_counter()
-        print(
-            f"[ACTOR TIMING] read_buffer: buf.read_into(): {(t1 - t0) * 1000:.1f}ms",
-            flush=True,
-        )
-        return bytes(dst)
+        @endpoint
+        async def read_buffer(self, buf: RDMABuffer) -> bytes:
+            import time as _time
+
+            t0 = _time.perf_counter()
+            dst = bytearray(len(self.data))
+            await buf.read_into(memoryview(dst))
+            t1 = _time.perf_counter()
+            print(
+                f"[ACTOR TIMING] read_buffer: buf.read_into(): {(t1 - t0) * 1000:.1f}ms",
+                flush=True,
+            )
+            return bytes(dst)
+
+    return CpuActor
 
 
-@pytest.mark.parametrize("rdma_backend", RDMA_BACKENDS)
+@pytest.mark.parametrize("rdma_backend", ["ibverbs", "tcp"])
 @isolate_in_subprocess
 async def test_rdma_buffer_cpu_memoryview(rdma_backend):
     """RDMABuffer works with bytearray/memoryview CPU buffers without importing torch."""
+    from monarch.actor import this_host
+    from monarch.config import configured
+    from monarch.rdma import is_ibverbs_available
+
+    if rdma_backend == "ibverbs" and not is_ibverbs_available():
+        pytest.skip("ibverbs backend is unavailable")
+
+    cpu_actor = _cpu_actor_type()
+
     if rdma_backend == "tcp":
         cm = configured(rdma_disable_ibverbs=True)
     else:
@@ -75,14 +93,15 @@ async def test_rdma_buffer_cpu_memoryview(rdma_backend):
         t1 = time.perf_counter()
         print(f"\n[TIMING] spawn_procs: {(t1 - t0) * 1000:.1f}ms")
 
-        sender = proc1.spawn("sender", CpuActor)
-        receiver = proc2.spawn("receiver", CpuActor)
+        sender = proc1.spawn("sender", cpu_actor)
+        receiver = proc2.spawn("receiver", cpu_actor)
         t2 = time.perf_counter()
         print(f"[TIMING] spawn actors: {(t2 - t1) * 1000:.1f}ms")
 
         pong = await sender.ping.call_one()
         t_ping = time.perf_counter()
         print(f"[TIMING] first ping (process startup): {(t_ping - t2) * 1000:.1f}ms")
+        assert pong == "pong"
 
         buf = await sender.create_buffer.call_one()
         t3 = time.perf_counter()

--- a/python/tests/test_remotemount.py
+++ b/python/tests/test_remotemount.py
@@ -18,23 +18,68 @@ import stat
 import tempfile
 import time
 from collections.abc import Generator
+from typing import Any, TYPE_CHECKING
 
 import pytest
 from isolate_in_subprocess import isolate_in_subprocess
-from monarch._rust_bindings.monarch_extension.chunked_fuse import (
-    FuseMountHandle,
-    mount_chunked_fuse,
-)
-from monarch._rust_bindings.monarch_extension.fast_pack import (
-    load_file_and_hash,
-    pack_files_with_offsets,
-)
-from monarch.remotemount.fast_pack import (
-    block_hashes,
-    HASH_BLOCK_SIZE,
-    pack_directory_chunked,
-)
-from monarch.remotemount.remotemount import classify_workers
+
+if TYPE_CHECKING:
+    from monarch._rust_bindings.monarch_extension.chunked_fuse import FuseMountHandle
+
+block_hashes: Any = None
+classify_workers: Any = None
+load_file_and_hash: Any = None
+mount_chunked_fuse: Any = None
+pack_directory_chunked: Any = None
+pack_files_with_offsets: Any = None
+HASH_BLOCK_SIZE: int = 64 * 1024 * 1024
+_RUNTIME_IMPORTS_LOADED: bool = False
+
+
+def _ensure_runtime_imports() -> None:
+    global _RUNTIME_IMPORTS_LOADED
+    global block_hashes
+    global classify_workers
+    global load_file_and_hash
+    global mount_chunked_fuse
+    global pack_directory_chunked
+    global pack_files_with_offsets
+    global HASH_BLOCK_SIZE
+
+    if _RUNTIME_IMPORTS_LOADED:
+        return
+
+    # Keep native Monarch imports out of pytest collection so --list-only does
+    # not load the extensions just to enumerate tests.
+    from monarch._rust_bindings.monarch_extension.chunked_fuse import (
+        mount_chunked_fuse as runtime_mount_chunked_fuse,
+    )
+    from monarch._rust_bindings.monarch_extension.fast_pack import (
+        load_file_and_hash as runtime_load_file_and_hash,
+        pack_files_with_offsets as runtime_pack_files_with_offsets,
+    )
+    from monarch.remotemount.fast_pack import (
+        block_hashes as runtime_block_hashes,
+        HASH_BLOCK_SIZE as runtime_hash_block_size,
+        pack_directory_chunked as runtime_pack_directory_chunked,
+    )
+    from monarch.remotemount.remotemount import (
+        classify_workers as runtime_classify_workers,
+    )
+
+    block_hashes = runtime_block_hashes
+    classify_workers = runtime_classify_workers
+    load_file_and_hash = runtime_load_file_and_hash
+    mount_chunked_fuse = runtime_mount_chunked_fuse
+    pack_directory_chunked = runtime_pack_directory_chunked
+    pack_files_with_offsets = runtime_pack_files_with_offsets
+    HASH_BLOCK_SIZE = runtime_hash_block_size
+    _RUNTIME_IMPORTS_LOADED = True
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _load_runtime_imports() -> None:
+    _ensure_runtime_imports()
 
 
 class TestPackDirectoryChunked:


### PR DESCRIPTION
Summary:
Add mesh identity types that separate uid from label, using `Uid` and `Label`
from `hyperactor::id`. This is the foundational diff for the mesh identity
migration.

## Walkthrough

`mesh_id.rs` introduces:

- `ResourceId { uid: Uid, label: Option<Label> }` — the common identity type
  for mesh resources. Eq/Hash/Ord are uid-only; label is metadata. Display
  format is `_label` (singleton), `label-hex16` (labeled instance), or `hex16`
  (unlabeled instance).

- `HostMeshId`, `ProcMeshId`, `ActorMeshId` — newtype wrappers around
  `ResourceId` generated by a `define_mesh_id!` macro. Each provides
  `singleton()`, `unique()`, and `new()` constructors, `uid()`/`label()`
  accessors, and `resource_id()` for converting to the common type.

- `From<Name> for ResourceId` — migration bridge that maps
  `Name::Suffixed(s, uuid)` to `Uid::Instance(uuid.0)` with a stripped label,
  and `Name::Reserved(s)` to `Uid::Singleton` (underscores become hyphens).

`shortuuid.rs`: `ShortUuid.0` made `pub(crate)` so the `From<Name>` conversion
can extract the inner u64.

No existing code is modified beyond wiring up the module.

Reviewed By: shayne-fletcher

Differential Revision: D100638123


