### PR TITLE
Allow async __supervise__ (#3526)

### DIFF
--- a/docs/source/actors.md
+++ b/docs/source/actors.md
@@ -703,7 +703,8 @@ Thus, when a mesh fails in some way (for example, an actor failed), the owning a
 This is similar to exception handling mechanisms: one can choose to handle exceptions at the appropriate level in the hierarchy (call stack), and failure to handle an exception propagates the failure (and thus terminates the remainder of functions in the call stack).
 
 ### Supervision Python API
-Actors can handle failures by providing an implementation of the `__supervise__` method:
+Actors can handle failures by providing an implementation of the `__supervise__` method.
+It may be declared with either `def` or `async def`:
 ```py
 class ManagerActor(Actor):
   def __init__(self, worker_procs: ProcMesh):
@@ -725,6 +726,12 @@ class ManagerActor(Actor):
     return None
 ```
 
+An `async def` override is awaited on the actor's asyncio event loop -- the same
+loop that runs endpoint coroutines -- so it may `await` other endpoints or I/O.
+A sync override runs under `fake_sync_state` and cannot observe a running loop
+with `asyncio.get_running_loop`. Both forms receive the same arguments and obey
+the same truthy/falsey handled/unhandled contract.
+
 `__supervise__` is special: Because it handles "exceptions", we have to be able
 to invoke it at any (safe) point. This is because otherwise we might run into a
 deadlock: for example, an actor might be waiting for a result from a failed actor.
@@ -736,7 +743,7 @@ If `__supervise__` returns a truthy value, the failure will be considered handle
 and not delivered further up the chain. If it returns a falsey value (including None, if there is no return),
 the failure will be delivered to that Actor’s owner recursively until it reaches
 the original client. If it reaches the original client with no handling, it will crash.
-If `__supervise__` raises an Exception of any kind, it will be considered a new supervision event to be delivered to that Actor’s owner. Its cause will be set to the supervision event it was handling. This behavior matches the special method `__exit__` for context managers.
+If `__supervise__` raises an Exception of any kind, it will be considered a new supervision event to be delivered to that Actor’s owner. Its cause will be set to the supervision event it was handling. This behavior matches the special method `__exit__` for context managers. Both sync and async overrides observe this behavior.
 
 We make no guarantees about how many times `__supervise__` will be called.
 If you own a mesh of N actors, each of which generates a supervision error, it may be called anywhere between 1 and N times inclusive.

--- a/docs/source/books/hyperactor-mesh-book/src/meshes/mesh-supervision.md
+++ b/docs/source/books/hyperactor-mesh-book/src/meshes/mesh-supervision.md
@@ -41,7 +41,8 @@ Thus, when a mesh fails in some way (for example, an actor failed), the owning a
 This is similar to exception handling mechanisms: one can choose to handle exceptions at the appropriate level in the hierarchy (call stack), and failure to handle an exception propagates the failure (and thus terminates the remainder of functions in the call stack).
 
 ## Supervision Python API
-Actors can handle failures by providing an implementation of the `__supervise__` method:
+Actors can handle failures by providing an implementation of the `__supervise__` method.
+It may be declared with either `def` or `async def`:
 ```py
 class ManagerActor(Actor):
   def __init__(self, worker_procs: ProcMesh):
@@ -63,6 +64,12 @@ class ManagerActor(Actor):
     return None
 ```
 
+An `async def` override is awaited on the actor's asyncio event loop -- the same
+loop that runs endpoint coroutines -- so it may `await` other endpoints or I/O.
+A sync override runs under `fake_sync_state` and cannot observe a running loop
+with `asyncio.get_running_loop`. Both forms receive the same arguments and obey
+the same truthy/falsey handled/unhandled contract.
+
 `__supervise__` is special: Because it handles "exceptions", we have to be able
 to invoke it at any (safe) point. This is because otherwise we might run into a
 deadlock: for example, an actor might be waiting for a result from a failed actor.
@@ -74,7 +81,7 @@ If `__supervise__` returns a truthy value, the failure will be considered handle
 and not delivered further up the chain. If it returns a falsey value (including None, if there is no return),
 the failure will be delivered to that Actor’s owner recursively until it reaches
 the original client. If it reaches the original client with no handling, it will crash.
-If `__supervise__` raises an Exception of any kind, it will be considered a new supervision event to be delivered to that Actor’s owner. Its cause will be set to the supervision event it was handling. This behavior matches the special method `__exit__` for context managers.
+If `__supervise__` raises an Exception of any kind, it will be considered a new supervision event to be delivered to that Actor’s owner. Its cause will be set to the supervision event it was handling. This behavior matches the special method `__exit__` for context managers. Both sync and async overrides observe this behavior.
 
 We make no guarantees about how many times `__supervise__` will be called.
 If you own a mesh of N actors, each of which generates a supervision error, it may be called anywhere between 1 and N times inclusive.

--- a/docs/source/examples/getting_started.py
+++ b/docs/source/examples/getting_started.py
@@ -292,7 +292,9 @@ if False:
 # Sometimes fine-grained recovery is possible. For instance, if a data loader failed to
 # read a URL, perhaps it would work to just restart it. In these cases, we also offer a
 # different API. If an actor defines a `__supervise__` special method, then it will get
-# called to handle supervision events for meshes owned by the actor.
+# called to handle supervision events for meshes owned by the actor. It may be declared
+# with either `def` or `async def`; an `async def` override runs on the actor's asyncio
+# event loop and can `await` other endpoints or I/O.
 # If an error happens on an ActorMesh that is a reference, such as a slice, or
 # a mesh that is sent to another actor, then the recovery is done on the original
 # creator of that mesh, not the holder of the reference. There is currently
@@ -314,6 +316,13 @@ class SupervisorActor(Actor):
         # Otherwise, the event will be propagated to the creator of this actor.
         # That will be the Actor (or client) which called the spawn() method.
         return True
+
+    # `__supervise__` can also be declared `async def`, e.g. to await
+    # a restart endpoint:
+    #
+    #     async def __supervise__(self, failure: MeshFailure) -> bool:
+    #         await self.restart_failed_mesh(failure)
+    #         return True
 
 
 # %%

--- a/monarch_hyperactor/src/actor.rs
+++ b/monarch_hyperactor/src/actor.rs
@@ -1354,7 +1354,12 @@ impl Handler<MeshFailure> for PythonActor {
         // TODO: Consider routing supervision messages through the queue for Queue mode.
         // For now, supervision is always handled directly since it requires immediate response.
 
-        monarch_with_gil(|py| {
+        // `_Actor.__supervise__` is `async def`, so calling it returns a
+        // coroutine, which we schedule on the actor's asyncio event loop --
+        // the same loop that runs endpoint coroutines. A sync user
+        // `__supervise__` is dispatched under `fake_sync_state` inside
+        // `_Actor.__supervise__`, mirroring `__cleanup__`.
+        let (display_name, fut) = monarch_with_gil(|py| {
             let inst = self.instance.get_or_insert_with(|| {
                 let inst: crate::context::PyInstance = cx.into();
                 inst.into_pyobject(py).unwrap().into()
@@ -1370,96 +1375,55 @@ impl Handler<MeshFailure> for PythonActor {
                     actor_bound
                 ));
             }
-            let result = actor_bound.call_method(
+            let awaitable = actor_bound.call_method(
                 "__supervise__",
                 (
                     crate::context::PyContext::new(cx, inst.clone_ref(py)),
                     PyMeshFailure::from(message.clone()),
                 ),
                 None,
-            );
-            match result {
-                Ok(s) => {
-                    if s.is_truthy()? {
-                        // If the return value is truthy, then the exception was handled
-                        // and doesn't need to be propagated.
-                        // TODO: We also don't want to deliver multiple supervision
-                        // events from the same mesh if an earlier one is handled.
-                        tracing::info!(
-                            name = "ActorMeshStatus",
-                            status = "SupervisionError::Handled",
-                            // only care about the event sender when the message is handled
-                            actor_name = message.actor_mesh_name,
-                            event = %message.event,
-                            "__supervise__ on {} handled a supervision event, not reporting any further",
-                            cx.self_id(),
-                        );
-                        Ok(())
-                    } else {
-                        // For a falsey return value, we propagate the supervision event
-                        // to the next owning actor. We do this by returning a new
-                        // error. This will not set the causal chain for ActorSupervisionEvent,
-                        // so make sure to include the original event in the error message
-                        // to provide context.
+            )?;
+            let fut =
+                pyo3_async_runtimes::into_future_with_locals(self.get_task_locals(py), awaitable)?;
+            anyhow::Ok((display_name, fut))
+        })
+        .await?;
 
-                        // False -- we propagate the event onward, but update it with the fact that
-                        // this actor is now the event creator.
-                        for (actor_name, status) in [
-                            (
-                                message
-                                    .actor_mesh_name
-                                    .as_deref()
-                                    .unwrap_or_else(|| message.event.actor_id.name()),
-                                "SupervisionError::Unhandled",
-                            ),
-                            (cx.self_id().name(), "UnhandledSupervisionEvent"),
-                        ] {
-                            tracing::info!(
-                                name = "ActorMeshStatus",
-                                status,
-                                actor_name,
-                                event = %message.event,
-                                "__supervise__ on {} did not handle a supervision event, reporting to the next next owner",
-                                cx.self_id(),
-                            );
-                        }
-                        let err = ActorErrorKind::UnhandledSupervisionEvent(Box::new(
-                            ActorSupervisionEvent::new(
-                                cx.self_id().clone(),
-                                display_name.clone(),
-                                ActorStatus::Failed(ActorErrorKind::UnhandledSupervisionEvent(
-                                    Box::new(message.event.clone()),
-                                )),
-                                None,
-                            ),
-                        ));
-                        Err(anyhow::Error::new(err))
-                    }
-                }
-                Err(err) => {
-                    // If __supervise__ raised UnhandledFaultHookException,
-                    // return the PyErr directly without wrapping in
-                    // ActorErrorKind. The custom run loop detects this by
-                    // downcasting the anyhow::Error to PyErr.
-                    if err.is_instance(
-                        py,
-                        &unhandled_fault_hook_exception(py),
-                    ) {
-                        return Err(err.into());
-                    }
+        let awaited = fut.await;
 
-                    // Any other exception will supersede in the propagation chain,
-                    // and will become its own supervision failure.
-                    // Include the event it was handling in the error message.
+        monarch_with_gil(|py| match awaited {
+            Ok(s) => {
+                if s.bind(py).is_truthy()? {
+                    // If the return value is truthy, then the exception was handled
+                    // and doesn't need to be propagated.
+                    // TODO: We also don't want to deliver multiple supervision
+                    // events from the same mesh if an earlier one is handled.
+                    tracing::info!(
+                        name = "ActorMeshStatus",
+                        status = "SupervisionError::Handled",
+                        // only care about the event sender when the message is handled
+                        actor_name = message.actor_mesh_name,
+                        event = %message.event,
+                        "__supervise__ on {} handled a supervision event, not reporting any further",
+                        cx.self_id(),
+                    );
+                    Ok(())
+                } else {
+                    // For a falsey return value, we propagate the supervision event
+                    // to the next owning actor. We do this by returning a new
+                    // error. This will not set the causal chain for ActorSupervisionEvent,
+                    // so make sure to include the original event in the error message
+                    // to provide context.
 
-                    // Add to caused_by chain.
+                    // False -- we propagate the event onward, but update it with the fact that
+                    // this actor is now the event creator.
                     for (actor_name, status) in [
                         (
                             message
                                 .actor_mesh_name
                                 .as_deref()
                                 .unwrap_or_else(|| message.event.actor_id.name()),
-                            "SupervisionError::__supervise__::exception",
+                            "SupervisionError::Unhandled",
                         ),
                         (cx.self_id().name(), "UnhandledSupervisionEvent"),
                     ] {
@@ -1468,16 +1432,15 @@ impl Handler<MeshFailure> for PythonActor {
                             status,
                             actor_name,
                             event = %message.event,
-                            "__supervise__ on {} threw an exception",
+                            "__supervise__ on {} did not handle a supervision event, reporting to the next next owner",
                             cx.self_id(),
                         );
                     }
                     let err = ActorErrorKind::UnhandledSupervisionEvent(Box::new(
                         ActorSupervisionEvent::new(
                             cx.self_id().clone(),
-                            display_name,
-                            ActorStatus::Failed(ActorErrorKind::ErrorDuringHandlingSupervision(
-                                err.to_string(),
+                            display_name.clone(),
+                            ActorStatus::Failed(ActorErrorKind::UnhandledSupervisionEvent(
                                 Box::new(message.event.clone()),
                             )),
                             None,
@@ -1485,6 +1448,52 @@ impl Handler<MeshFailure> for PythonActor {
                     ));
                     Err(anyhow::Error::new(err))
                 }
+            }
+            Err(err) => {
+                // If __supervise__ raised UnhandledFaultHookException,
+                // return the PyErr directly without wrapping in
+                // ActorErrorKind. The custom run loop detects this by
+                // downcasting the anyhow::Error to PyErr.
+                if err.is_instance(py, &unhandled_fault_hook_exception(py)) {
+                    return Err(err.into());
+                }
+
+                // Any other exception will supersede in the propagation chain,
+                // and will become its own supervision failure.
+                // Include the event it was handling in the error message.
+
+                // Add to caused_by chain.
+                for (actor_name, status) in [
+                    (
+                        message
+                            .actor_mesh_name
+                            .as_deref()
+                            .unwrap_or_else(|| message.event.actor_id.name()),
+                        "SupervisionError::__supervise__::exception",
+                    ),
+                    (cx.self_id().name(), "UnhandledSupervisionEvent"),
+                ] {
+                    tracing::info!(
+                        name = "ActorMeshStatus",
+                        status,
+                        actor_name,
+                        event = %message.event,
+                        "__supervise__ on {} threw an exception",
+                        cx.self_id(),
+                    );
+                }
+                let err = ActorErrorKind::UnhandledSupervisionEvent(Box::new(
+                    ActorSupervisionEvent::new(
+                        cx.self_id().clone(),
+                        display_name,
+                        ActorStatus::Failed(ActorErrorKind::ErrorDuringHandlingSupervision(
+                            err.to_string(),
+                            Box::new(message.event.clone()),
+                        )),
+                        None,
+                    ),
+                ));
+                Err(anyhow::Error::new(err))
             }
         })
         .await

--- a/python/monarch/_src/actor/actor_mesh.py
+++ b/python/monarch/_src/actor/actor_mesh.py
@@ -1365,7 +1365,14 @@ class _Actor:
         else:
             return False
 
-    def __supervise__(self, cx: Context, *args: Any, **kwargs: Any) -> object:
+    async def __supervise__(self, cx: Context, *args: Any, **kwargs: Any) -> object:
+        """Dispatch the user's ``__supervise__``.
+
+        Mirrors ``__cleanup__``: both sync and async user methods are
+        supported. An ``async def`` user method is awaited on the actor's
+        asyncio event loop; a sync one runs under :func:`fake_sync_state` so
+        it cannot observe a running loop.
+        """
         _set_context(cx)
         instance = self.instance
         if instance is None:
@@ -1387,15 +1394,18 @@ class _Actor:
                 )
             raise AssertionError(error_message)
 
-        # Forward a call to supervise on this actor to the user-provided instance.
-        if hasattr(instance, "__supervise__"):
-            # pyre-fixme[16]: Caller needs to handle the case where instance is None.
-            return instance.__supervise__(*args, **kwargs)
-        else:
+        supervise = getattr(instance, "__supervise__", None)
+        if supervise is None:
             # If there is no __supervise__ method, the default would be to return
             # None. That means the supervision error is not handled and will be
             # propagated to the next owner.
             return None
+
+        if inspect.iscoroutinefunction(supervise):
+            return await supervise(*args, **kwargs)
+        else:
+            with fake_sync_state():
+                return supervise(*args, **kwargs)
 
     async def __cleanup__(self, cx: Context, exc: str | Exception | None) -> None:
         """Cleans up any resources owned by this Actor before stopping. Automatically
@@ -1520,6 +1530,15 @@ class Actor(MeshTrait):
         propagate any further. If a falsey value is returned, the failure will be
         further sent to the owner of this Actor.
         Note that this is *not* called for errors within this Actor.
+
+        Overrides may be declared with either ``def`` or ``async def``. An
+        ``async def`` override is awaited on the actor's asyncio event loop --
+        the same loop that runs endpoint coroutines -- so it can ``await``
+        other endpoints or I/O. A sync override runs under ``fake_sync_state``
+        and cannot call ``asyncio.get_running_loop``. If the override raises,
+        the exception is treated as a new supervision event chained to the
+        one being handled, matching the ``__exit__`` convention of context
+        managers.
         """
         return False
 

--- a/python/tests/test_actor_error.py
+++ b/python/tests/test_actor_error.py
@@ -1154,6 +1154,9 @@ class ErrorActorWithSupervise(ErrorActor):
         self.failures = []
         self.faulted = asyncio.Event()
         self.should_handle = should_handle
+        # Number of supervise callbacks expected before ``faulted`` fires.
+        # Tests that trigger concurrent failures raise this before waiting.
+        self.expected_failures = 1
 
     @endpoint
     async def self_fail(self) -> None:
@@ -1210,13 +1213,14 @@ class ErrorActorWithSupervise(ErrorActor):
         return self.mesh
 
     @endpoint
-    async def subworker_broadcast_fail(self) -> None:
+    async def subworker_broadcast_fail(self, expected: int = 1) -> None:
+        self.expected_failures = expected
         self.mesh.check.broadcast()
         # When not awaiting the result of an endpoint which experiences a
         # failure, it should still propagate back to __supervise__.
         self.mesh.fail_with_supervision_error.broadcast()
-        # Give time for the failure to occur before returning, so get_failures
-        # will have a non-empty result.
+        # Wait until every expected supervise callback has arrived, so
+        # ``get_failures`` sees the full set.
         await asyncio.wait_for(self.faulted.wait(), timeout=30)
 
     @endpoint
@@ -1233,9 +1237,64 @@ class ErrorActorWithSupervise(ErrorActor):
 
     def __supervise__(self, failure: MeshFailure) -> bool:
         self.failures.append(failure)
-        self.faulted.set()
+        if len(self.failures) >= self.expected_failures:
+            self.faulted.set()
         # Returning true suppresses the error.
         return self.should_handle
+
+
+class AsyncErrorActorWithSupervise(ErrorActorWithSupervise):
+    """Variant of `ErrorActorWithSupervise` with `async def __supervise__`.
+
+    Used to verify that an asynchronous user-defined `__supervise__` is awaited
+    on the actor's asyncio event loop -- the same loop endpoints run on.
+    """
+
+    def __init__(self, proc_mesh: ProcMesh, should_handle: bool = True) -> None:
+        super().__init__(proc_mesh, should_handle)
+        self.endpoint_loop_id: Optional[int] = None
+        self.supervise_loop_id: Optional[int] = None
+
+    @endpoint
+    async def record_endpoint_loop(self) -> None:
+        self.endpoint_loop_id = id(asyncio.get_running_loop())
+
+    @endpoint
+    async def get_loop_ids(self) -> tuple[Optional[int], Optional[int]]:
+        return (self.endpoint_loop_id, self.supervise_loop_id)
+
+    # pyre-ignore[15]: intentionally overrides the sync base with `async def`
+    # to exercise the async `__supervise__` dispatch path.
+    async def __supervise__(self, failure: MeshFailure) -> bool:
+        # Awaiting here proves we are running on a real asyncio loop, not
+        # dispatched synchronously on the tokio task.
+        await asyncio.sleep(0)
+        self.supervise_loop_id = id(asyncio.get_running_loop())
+        self.failures.append(failure)
+        if len(self.failures) >= self.expected_failures:
+            self.faulted.set()
+        return self.should_handle
+
+
+class RaisingSyncSuperviseActor(ErrorActorWithSupervise):
+    """Variant whose sync `__supervise__` raises, to verify the exception
+    chains into `ErrorDuringHandlingSupervision` for the client."""
+
+    SUPERVISE_MESSAGE = "boom from sync supervise"
+
+    def __supervise__(self, failure: MeshFailure) -> bool:
+        raise RuntimeError(self.SUPERVISE_MESSAGE)
+
+
+class RaisingAsyncSuperviseActor(ErrorActorWithSupervise):
+    """Async counterpart of `RaisingSyncSuperviseActor`."""
+
+    SUPERVISE_MESSAGE = "boom from async supervise"
+
+    # pyre-ignore[15]: intentionally overrides the sync base with `async def`.
+    async def __supervise__(self, failure: MeshFailure) -> bool:
+        await asyncio.sleep(0)
+        raise RuntimeError(self.SUPERVISE_MESSAGE)
 
 
 @pytest.mark.timeout(30)
@@ -1261,6 +1320,41 @@ async def test_supervise_callback_handled():
     for msg in r:
         assert "MeshFailure" in msg
         assert "error_actor" in msg
+
+    await pm.stop()
+    await second_mesh.stop()
+
+
+@pytest.mark.timeout(30)
+@parametrize_config(actor_queue_dispatch={True, False})
+@isolate_in_subprocess
+async def test_async_supervise_callback_handled():
+    """`async def __supervise__` runs on the same asyncio loop as endpoints."""
+    pm = spawn_procs_on_this_host({"gpus": 1})
+    second_mesh = spawn_procs_on_this_host({"gpus": 1})
+    supervisor = pm.spawn("supervisor", AsyncErrorActorWithSupervise, second_mesh)
+
+    await supervisor.record_endpoint_loop.call()
+    await supervisor.subworker_fail.call()
+
+    result = await supervisor.get_failures.call()
+    result = [f for _, f in result]
+    assert len(result) == 1
+    assert len(result[0]) >= 1, (
+        f"expected at least one supervision event, got {len(result[0])}"
+    )
+    for msg in result[0]:
+        assert "MeshFailure" in msg
+        assert "error_actor" in msg
+
+    loop_ids = await supervisor.get_loop_ids.call()
+    for _, (endpoint_id, supervise_id) in loop_ids:
+        assert endpoint_id is not None, "endpoint loop id was not recorded"
+        assert supervise_id is not None, "supervise loop id was not recorded"
+        assert endpoint_id == supervise_id, (
+            f"async __supervise__ must run on the same asyncio loop as "
+            f"endpoints: endpoint={endpoint_id} supervise={supervise_id}"
+        )
 
     await pm.stop()
     await second_mesh.stop()
@@ -1348,7 +1442,7 @@ async def test_supervise_callback_when_procs_killed():
     second_mesh = spawn_procs_on_this_host({"gpus": 4})
     supervisor = pm.spawn("supervisor", ErrorActorWithSupervise, second_mesh)
 
-    await supervisor.subworker_broadcast_fail.call()
+    await supervisor.subworker_broadcast_fail.call(expected=4)
     result = await supervisor.get_failures.call()
     result = [f for _, f in result]
     assert len(result) == 1
@@ -1397,6 +1491,34 @@ async def test_supervise_callback_unhandled():
     # Calling a second endpoint would also raise the same message.
     with pytest.raises(SupervisionError, match=message):
         await supervisor.subworker_fail.call(sleep=15)
+
+    await pm.stop()
+    await second_mesh.stop()
+
+
+@pytest.mark.timeout(60)
+@pytest.mark.parametrize(
+    "actor_cls",
+    [RaisingSyncSuperviseActor, RaisingAsyncSuperviseActor],
+    ids=["sync", "async"],
+)
+@parametrize_config(actor_queue_dispatch={True, False})
+@isolate_in_subprocess
+async def test_supervise_callback_raising(actor_cls):
+    """A `__supervise__` that raises chains into `ErrorDuringHandlingSupervision`
+    and propagates to the client as a `SupervisionError` regardless of whether
+    the user method is sync or async."""
+    monarch.actor.unhandled_fault_hook = lambda failure: None
+    pm = spawn_procs_on_this_host({"gpus": 1})
+    second_mesh = spawn_procs_on_this_host({"gpus": 1})
+    supervisor = pm.spawn("supervisor", actor_cls, second_mesh)
+
+    with pytest.raises(SupervisionError) as exc_info:
+        await supervisor.subworker_fail.call(sleep=15)
+    report = str(exc_info.value)
+    assert actor_cls.SUPERVISE_MESSAGE in report, (
+        f"expected supervise exception message in report, got: {report}"
+    )
 
     await pm.stop()
     await second_mesh.stop()


### PR DESCRIPTION
Summary:

Fixes: https://github.com/meta-pytorch/monarch/issues/3436

Previously, if a user defined `async def __supervise__`, the runtime called
it as if it were synchronous, producing a never-awaited coroutine and
silently treating the truthy coroutine object as "handled". This change
makes `__supervise__` work like `__cleanup__`: both sync and async user
methods are supported, and the user method runs on the actor's asyncio
event loop -- the same loop that runs endpoint coroutines.

- `_Actor.__supervise__` (python/monarch/_src/actor/actor_mesh.py) is now
  `async def`, mirroring `_Actor.__cleanup__`. If the user's `__supervise__`
  is an `async def`, it is awaited directly. If it is synchronous, it is
  invoked inside `fake_sync_state()` so it cannot observe a running asyncio
  loop, matching the sync/async dispatch contract of `__cleanup__`.
- `Handler<MeshFailure>` (monarch_hyperactor/src/actor.rs) schedules the
  coroutine returned by `_Actor.__supervise__` on the actor's `TaskLocals`
  via `pyo3_async_runtimes::into_future_with_locals` and awaits it --
  exactly the same pattern as the `cleanup()` handler. The previous
  `asyncio.iscoroutine` dual-path branching and the unused
  `futures::FutureExt` / `futures::future::BoxFuture` imports are removed.

Because sync user `__supervise__` now runs cooperatively on the actor's
asyncio loop (instead of directly on the tokio task), ordering between
supervise callbacks and endpoint resumption can differ from the prior
release. Running endpoints are never preempted, and supervise tasks run
at the next `await` point, the same as endpoints.

Reviewed By: shayne-fletcher

Differential Revision: D101750285


