### PR TITLE
[hyperactor] fix shutdown race in final supervision-event delivery

### DIFF
--- a/hyperactor/src/proc.rs
+++ b/hyperactor/src/proc.rs
@@ -1043,9 +1043,11 @@ impl Proc {
             .collect();
         let mut aborted_actors = futures::future::join_all(aborted_actors).await;
 
-        // Phase 2: now that all other actors have stopped, stop the
-        // supervision coordinator so it had a chance to receive all
-        // supervision events.
+        // Phase 2: now that all other actors have stopped, request the
+        // supervision coordinator to stop. Their terminal supervision
+        // events have already been enqueued by this point, and the
+        // coordinator's DrainAndStop path drains queued supervision
+        // events before exiting.
         if let Some(ref coord_id) = coordinator_id
             && this_actor_id != Some(coord_id)
         {
@@ -1845,53 +1847,53 @@ impl<A: Actor> Instance<A> {
             .await;
 
         assert!(self.is_stopping());
-        let event = match result {
+        // Compute the terminal status and supervision event, but defer
+        // change_status until AFTER the event is delivered. If we flip
+        // the status to terminal first, a concurrent destroy_and_wait
+        // observer can release Phase 1 and stop the coordinator before
+        // the event lands in its mailbox — dropping the event.
+        let (terminal_status, event) = match result {
             Ok(stop_reason) => {
                 let status = ActorStatus::Stopped(stop_reason);
-                self.mailbox().close(status.clone());
                 let event = ActorSupervisionEvent::new(
                     self.inner.cell.actor_id().clone(),
                     actor.display_name(),
                     status.clone(),
                     None,
                 );
-                // FI-1: store supervision_event BEFORE change_status.
-                *self.inner.cell.inner.supervision_event.lock().unwrap() = Some(event.clone());
-                self.change_status(status);
-                Some(event)
+                (status, Some(event))
             }
-            Err(err) => {
-                match *err.kind {
-                    ActorErrorKind::UnhandledSupervisionEvent(box event) => {
-                        // We use the event's actor_status as this actor's terminal status.
-                        assert!(event.actor_status.is_terminal());
-                        self.mailbox().close(event.actor_status.clone());
-                        // FI-1: store supervision_event BEFORE change_status.
-                        *self.inner.cell.inner.supervision_event.lock().unwrap() =
-                            Some(event.clone());
-                        self.change_status(event.actor_status.clone());
-                        Some(event)
-                    }
-                    _ => {
-                        let error_kind = ActorErrorKind::Generic(err.kind.to_string());
-                        let status = ActorStatus::Failed(error_kind);
-                        self.mailbox().close(status.clone());
-                        let event = ActorSupervisionEvent::new(
-                            self.inner.cell.actor_id().clone(),
-                            actor.display_name(),
-                            status.clone(),
-                            None,
-                        );
-                        // FI-1: store supervision_event BEFORE change_status.
-                        *self.inner.cell.inner.supervision_event.lock().unwrap() =
-                            Some(event.clone());
-                        self.change_status(status);
-                        Some(event)
-                    }
+            Err(err) => match *err.kind {
+                ActorErrorKind::UnhandledSupervisionEvent(box event) => {
+                    // We use the event's actor_status as this actor's terminal status.
+                    assert!(event.actor_status.is_terminal());
+                    let status = event.actor_status.clone();
+                    (status, Some(event))
                 }
-            }
+                _ => {
+                    let error_kind = ActorErrorKind::Generic(err.kind.to_string());
+                    let status = ActorStatus::Failed(error_kind);
+                    let event = ActorSupervisionEvent::new(
+                        self.inner.cell.actor_id().clone(),
+                        actor.display_name(),
+                        status.clone(),
+                        None,
+                    );
+                    (status, Some(event))
+                }
+            },
         };
 
+        self.mailbox().close(terminal_status.clone());
+        // FI-1: store supervision_event BEFORE change_status.
+        if let Some(event) = &event {
+            *self.inner.cell.inner.supervision_event.lock().unwrap() = Some(event.clone());
+        }
+
+        // Deliver the supervision event to the parent/proc BEFORE
+        // change_status so that any observer waiting for this actor's
+        // terminal state can only see it once the event has been
+        // enqueued at its destination.
         if let Some(parent) = self.inner.cell.maybe_unlink_parent() {
             if let Some(event) = event {
                 // Parent exists, failure should be propagated to the parent.
@@ -1919,6 +1921,8 @@ impl<A: Actor> Instance<A> {
                     .handle_unhandled_supervision_event(&self, event);
             }
         }
+
+        self.change_status(terminal_status);
     }
 
     /// Runs the actor, and manages its supervision tree. When the function returns,
@@ -2110,6 +2114,13 @@ impl<A: Actor> Instance<A> {
         }
 
         if need_drain {
+            let mut supervision_events_drained = 0;
+            for supervision_event in supervision_event_receiver.drain() {
+                self.handle_supervision_event(actor, supervision_event)
+                    .await?;
+                supervision_events_drained += 1;
+            }
+
             let mut n = 0;
             while let Ok(work) = work_rx.try_recv() {
                 // PD-5c: drained work items must also be accounted.
@@ -2124,9 +2135,23 @@ impl<A: Actor> Instance<A> {
                         ActorErrorKind::processing(err),
                     ));
                 }
+                for supervision_event in supervision_event_receiver.drain() {
+                    self.handle_supervision_event(actor, supervision_event)
+                        .await?;
+                    supervision_events_drained += 1;
+                }
                 n += 1;
             }
-            tracing::debug!("drained {} messages", n);
+            for supervision_event in supervision_event_receiver.drain() {
+                self.handle_supervision_event(actor, supervision_event)
+                    .await?;
+                supervision_events_drained += 1;
+            }
+            tracing::debug!(
+                "drained {} messages and {} supervision events",
+                n,
+                supervision_events_drained
+            );
         }
         tracing::debug!(
             actor_id = %self.self_id(),


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #3527

This change fixes the shutdown race around final supervision-event delivery in `Instance::serve()` and `destroy_and_wait()`.

Before the change, an actor could compute its terminal supervision event, close its mailbox, store the event on the cell, call `change_status(terminal)`, and only then send the supervision event to its parent or to the proc's unhandled-supervision handler. That exposed terminal status to concurrent observers too early.

`destroy_and_wait()` Phase 1 waits only for `status.wait_for(is_terminal)` before it moves on to Phase 2 and stops the supervision coordinator. Because `change_status()` published terminal state before the supervision event had actually been handed off, a concurrent destroy path could observe the actor as terminal, conclude Phase 1 was complete, and then stop the coordinator before the event had been enqueued at its destination.

The first part of the fix is to compute the terminal status and event first, close the mailbox as part of terminal teardown so the actor stops accepting new deliveries, store `supervision_event` on the cell, dispatch the supervision event upstream, and only then call `change_status`. With this ordering, any observer that sees the actor as terminal is guaranteed that the final supervision event has already been enqueued at the parent or proc, and the mailbox has already been closed.

That ordering alone is not enough for the coordinator shutdown path, because `DrainAndStop` previously drained only the work queue after breaking out of the actor loop. The coordinator receives stop signals and supervision events on separate receivers, so it could still observe the stop signal first and exit without processing supervision events that were already queued.

The second part of the fix is therefore to drain queued supervision events during `DrainAndStop`, both before and after draining work items. This makes Phase 2 consistent with its intent: once all other roots are observed terminal, their final supervision events have already been enqueued, and the coordinator's stop path will process the queued supervision events before it exits.

Example bad trace before the full fix:
1. `destroy_and_wait()` starts Phase 1 and stops root actor `A` while keeping the supervision coordinator alive.
2. `A` finishes `run_actor_tree()`, builds `ActorStatus::Stopped(...)` and its supervision event.
3. Old code calls `change_status(Stopped)` before sending the event upstream.
4. Phase 1 observes `A` as terminal through `wait_for(is_terminal)` and considers `A` done.
5. `destroy_and_wait()` enters Phase 2 and sends `DrainAndStop` to the supervision coordinator.
6. `A` then tries to forward its final supervision event, or the event has already been enqueued but not yet processed.
7. The coordinator can observe the stop signal first and exit without handling the queued supervision event; for clean-stop events that means the event is effectively dropped, and for error paths this can escalate further.

This race shows up as a flake in `proc::tests::test_coordinator_shuts_down_last_during_destroy` under stress.

Differential Revision: [D101740217](https://our.internmc.facebook.com/intern/diff/D101740217/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D101740217/)!