### PR TITLE
Change default multiprocessing mode to forkserver on Linux (#3529)

### DIFF
--- a/python/monarch/_src/actor/bootstrap_main.py
+++ b/python/monarch/_src/actor/bootstrap_main.py
@@ -15,6 +15,7 @@ import importlib.resources
 import logging
 import multiprocessing
 import os
+import platform
 import sys
 
 
@@ -90,5 +91,10 @@ def invoke_main() -> None:
 if __name__ == "__main__":
     # Ensure that processes started via `multiprocessing` are spawned, not forked.
     # forking is a terrible default, see: https://github.com/python/cpython/issues/84559
-    multiprocessing.set_start_method("spawn", force=True)
+    # forkserver is mostly as safe as spawn because it forks from a special process
+    # without threads, but it's much faster than spawn.
+    if platform.system() == "Linux":
+        multiprocessing.set_start_method("forkserver", force=True)
+    else:
+        multiprocessing.set_start_method("spawn", force=True)
     invoke_main()  # pragma: no cover


### PR DESCRIPTION
Summary:

forkserver is an available multiprocessing start method on Linux only, which combines some of the
speed of forking with the safety of spawning new processes.
It's the new default start method in Python 3.14, and it should avoid the issues that normal "fork"
has with forking our Rust threads.
We can't use "fork" because it is unsafe to fork a process with multiple threads, and our
bootstrap_main.py entrypoint initializes a tokio runtime with many threads.

Some classes, such as the torch DataLoader, create subprocesses to do work every epoch by default,
and then using monarch causes an unexpected slowdown. While libraries like these are probably making
bad assumptions about the speed of process creation,
we should meet users where they're at, and especially not cause unexplainable performance differences
when switching to "no monarch" to "with monarch".

forkserver is not available on MacOS / Windows / other non-POSIX, so we still need "spawn" on
those platforms. I believe 99+% of worker machines will be running a POSIX operating system though,
so effectively forkserver will be the real default.

Reviewed By: thedavekwon

Differential Revision: D101819987


