### PR TITLE
monarch: make inherited slice supervision deterministic

### DIFF
--- a/hyperactor_mesh/src/actor_mesh.rs
+++ b/hyperactor_mesh/src/actor_mesh.rs
@@ -286,6 +286,30 @@ struct HealthState {
     crashed_ranks: HashMap<usize, ActorSupervisionEvent>,
 }
 
+impl HealthState {
+    fn failure_for_region(&self, region: &Region) -> Option<MeshFailure> {
+        let unhealthy = self.unhealthy_event.as_ref()?;
+        let mut failure = match unhealthy {
+            Unhealthy::StreamClosed(failure) | Unhealthy::Crashed(failure) => failure.clone(),
+        };
+        if failure.crashed_ranks.is_empty() {
+            return Some(failure);
+        }
+        let mut crashed_ranks = self
+            .crashed_ranks
+            .keys()
+            .copied()
+            .filter(|rank| region.slice().contains(*rank))
+            .collect::<Vec<_>>();
+        crashed_ranks.sort_unstable();
+        if crashed_ranks.is_empty() {
+            return None;
+        }
+        failure.crashed_ranks = crashed_ranks;
+        Some(failure)
+    }
+}
+
 impl std::fmt::Debug for HealthState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("HealthState")
@@ -406,6 +430,13 @@ pub struct ActorMeshRef<A: Referable> {
 }
 
 impl<A: Referable> ActorMeshRef<A> {
+    fn cached_failure(&self, cx: &impl context::Actor) -> Option<MeshFailure> {
+        let health_state = self.health_state.entry(cx).or_default();
+        health_state
+            .get()
+            .failure_for_region(ndslice::view::Ranked::region(self))
+    }
+
     /// Cast a message to all the actors in this mesh
     #[allow(clippy::result_large_err)]
     pub fn cast<M>(&self, cx: &impl context::Actor, message: M) -> crate::Result<()>
@@ -447,22 +478,13 @@ impl<A: Referable> ActorMeshRef<A> {
     {
         // First check if the mesh is already dead before sending out any messages
         // to a possibly undeliverable actor.
-        {
-            let health_state = self.health_state.entry(cx).or_default();
-            let health_state = health_state.get();
-            match &health_state.unhealthy_event {
-                Some(Unhealthy::StreamClosed(failure)) => {
-                    return Err(crate::Error::Supervision(Box::new(failure.clone())));
-                }
-                Some(Unhealthy::Crashed(failure)) => {
-                    return Err(crate::Error::Supervision(Box::new(failure.clone())));
-                }
-                None => {
-                    // If crashed ranks has any entries, then unhealthy_event should be set.
-                    // This is because all slices get a distinct health state.
-                    assert!(health_state.crashed_ranks.is_empty());
-                }
-            }
+        if let Some(failure) = self.cached_failure(cx) {
+            tracing::debug!(
+                actor_mesh = %self.name,
+                crashed_ranks = ?failure.crashed_ranks,
+                "rejecting cast due to cached supervision failure"
+            );
+            return Err(crate::Error::Supervision(Box::new(failure)));
         }
 
         hyperactor_telemetry::notify_sent_message(hyperactor_telemetry::SentMessageEvent {
@@ -691,18 +713,20 @@ impl<A: Referable> ActorMeshRef<A> {
         &self,
         cx: &impl context::Actor,
     ) -> Result<MeshFailure, anyhow::Error> {
+        if let Some(failure) = self.cached_failure(cx) {
+            tracing::debug!(
+                actor_mesh = %self.name,
+                crashed_ranks = ?failure.crashed_ranks,
+                "returning cached supervision failure"
+            );
+            return Ok(failure);
+        }
         let controller = if let Some(c) = self.controller() {
             c
         } else {
-            let health_state = self.health_state.entry(cx).or_default();
-            let health_state = health_state.get();
-            return match &health_state.unhealthy_event {
-                Some(Unhealthy::StreamClosed(f)) => Ok(f.clone()),
-                Some(Unhealthy::Crashed(f)) => Ok(f.clone()),
-                None => Err(anyhow::anyhow!(
-                    "unexpected healthy state while controller is gone"
-                )),
-            };
+            return Err(anyhow::anyhow!(
+                "unexpected healthy state while controller is gone"
+            ));
         };
         let rx = {
             // Make sure to create only one PortReceiver per context.
@@ -917,16 +941,21 @@ impl<A: Referable> view::Ranked for ActorMeshRef<A> {
 
 impl<A: Referable> view::RankedSliceable for ActorMeshRef<A> {
     fn sliced(&self, region: Region) -> Self {
-        // The sliced ref will not share the same health state or receiver.
-        // TODO: share to reduce open ports and tasks?
+        // Slices inherit cached failures that were already observed on the parent
+        // mesh ref so new sub-slices do not race the controller replay path.
+        // The supervision receiver stays independent because each slice applies
+        // its own region filter to future updates.
         debug_assert!(region.is_subset(view::Ranked::region(self)));
         let proc_mesh = self.proc_mesh.subset(region).unwrap();
-        Self::with_page_size(
-            self.name.clone(),
+        Self {
             proc_mesh,
-            self.page_size,
-            self.controller.clone(),
-        )
+            name: self.name.clone(),
+            controller: self.controller.clone(),
+            health_state: self.health_state.clone(),
+            receiver: ActorLocal::new(),
+            pages: OnceCell::new(),
+            page_size: self.page_size,
+        }
     }
 }
 

--- a/python/tests/test_actor_error.py
+++ b/python/tests/test_actor_error.py
@@ -26,7 +26,7 @@ from monarch._rust_bindings.monarch_hyperactor.mailbox import (
     UndeliverableMessageEnvelope,
 )
 from monarch._rust_bindings.monarch_hyperactor.supervision import SupervisionError
-from monarch._src.actor.actor_mesh import ActorMesh, context
+from monarch._src.actor.actor_mesh import ActorMesh, context, current_rank
 from monarch._src.actor.host_mesh import this_host
 from monarch._src.actor.proc_mesh import ProcMesh
 from monarch.actor import (
@@ -583,8 +583,13 @@ class SyncErrorActor(Actor):
 
 
 class ErrorActor(Actor):
+    def __init__(self) -> None:
+        self._root_gpu_rank = current_rank()["gpus"]
+
     @endpoint
-    async def fail_with_supervision_error(self) -> None:
+    async def fail_with_supervision_error(self, rank: int | None = None) -> None:
+        if rank is not None and self._root_gpu_rank != rank:
+            return
         raise ActorFailureError("Simulated actor failure for supervision testing")
 
     @endpoint
@@ -1122,12 +1127,14 @@ async def test_mesh_slices_inherit_parent_errors() -> None:
     error_mesh = pm.spawn("error", ErrorActor)
     slice_1 = error_mesh.slice(gpus=slice(2, 4))
 
-    # Trigger supervision error on gpus=2, 3, 4
+    # Trigger supervision error on root gpu=3 via the parent slice.
+    # We induce the failure on rank=3 alone because this ensures that are no
+    # races between the various failures and the subsequent call to the sliced mesh.
     with pytest.raises(SupervisionError):
-        await slice_1.fail_with_supervision_error.call()
+        await slice_1.fail_with_supervision_error.call(rank=3)
 
-    # Newly created slice containing gpu=3 is unhealthy
-    slice_2 = error_mesh.slice(gpus=3)
+    # Newly created child slice containing root gpu=3 is unhealthy.
+    slice_2 = slice_1.slice(gpus=1)
     with pytest.raises(SupervisionError):
         await slice_2.check.call()
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #3531

The OSS flake in test_mesh_slices_inherit_parent_errors was caused by the
test setup itself.

The test triggered failures on multiple ranks through a parent slice and then
immediately checked rank 3. If rank 2 failed first, the parent call could
already have completed while rank 3 had not yet processed its failure message,
so the next step could still observe rank 3 as healthy. That made the test
assert a stronger ordering guarantee than the setup actually established.

Fix that test bug by failing only root gpu 3 through the parent slice, then
checking a child slice derived from that parent. This removes the multi-rank
ordering race while still testing the parent/child slice relationship.

The health_state changes are not the root fix for the flake. They are a
follow-on semantic tightening: once a parent slice has already observed a
supervision failure, a newly-created child slice from that parent can inherit
that cached unhealthy state immediately instead of waiting for controller
replay. That makes inherited failure visibility deterministic and avoids an
extra round-trip, but the original OSS failure was the test's multi-rank race.

Implement that by treating health_state as cached mesh health for the ref
lineage, not as subscriber-local state. Derived slices share health_state with
the parent, while still getting their own supervision receiver. Sharing the
receiver would be incorrect because each slice filters future supervision
updates by region, but sharing cached health is safe because cached_failure()
and failure_for_region() project the inherited crash set onto the current
region before reporting it.

Walkthrough:
- let the test helper fail a selected root rank
- update the test to assert on a child slice of the failed parent slice
- add region-filtered cached failure lookup for ActorMeshRef
- share health_state, but not the supervision receiver, across sliced refs

Differential Revision: [D101822524](https://our.internmc.facebook.com/intern/diff/D101822524/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D101822524/)!