### PR TITLE
pass test subject to recording.span in test callers

### DIFF
--- a/monarch_hyperactor/src/telemetry.rs
+++ b/monarch_hyperactor/src/telemetry.rs
@@ -412,7 +412,7 @@ mod tests {
         hyperactor_telemetry::initialize_logging_for_test();
 
         let recording = hyperactor_telemetry::recorder().record(64);
-        let span = recording.span();
+        let span = recording.span("test");
 
         Python::attach(|py| {
             let record = make_log_record(py, "recorder marker");

--- a/monarch_hyperactor/tests/telemetry.rs
+++ b/monarch_hyperactor/tests/telemetry.rs
@@ -35,7 +35,7 @@ async fn forward_to_tracing_captures_via_extract_recording_span() -> Result<()> 
     monarch_with_gil_blocking(|py| py.run(c_str!("import monarch._rust_bindings"), None, None))?;
 
     let recording = hyperactor_telemetry::recorder().record(64);
-    let span = recording.span();
+    let span = recording.span("test");
 
     monarch_with_gil_blocking(|py| -> PyResult<()> {
         // Build a PyContext carrying our recording span.


### PR DESCRIPTION
Summary: Recording::span now requires a &str subject (see D101364390 / PR #3461). Two test callers in monarch_hyperactor were missed by the original fix in D101807697 and still call `recording.span()` with no argument, breaking OSS Rust CI. Pass "test" as the subject.

Reviewed By: thedavekwon

Differential Revision: D101866661


