### PR TITLE
Migrate monarch

### DIFF
--- a/algebra/Cargo.toml
+++ b/algebra/Cargo.toml
@@ -15,4 +15,4 @@ serde = { version = "1.0.219", features = ["derive", "rc"] }
 typeuri = { version = "0.0.0", path = "../typeuri" }
 
 [dev-dependencies]
-bincode = "1.3.3"
+bincode = { version = "2", features = ["serde"] }

--- a/algebra/src/crdt.rs
+++ b/algebra/src/crdt.rs
@@ -226,8 +226,11 @@ mod tests {
     #[test]
     fn lww_serde_roundtrip() {
         let v = LWW::new(42, 12345, 99);
-        let encoded = bincode::serialize(&v).unwrap();
-        let decoded: LWW<i32> = bincode::deserialize(&encoded).unwrap();
+        let encoded = bincode::serde::encode_to_vec(v, bincode::config::legacy()).unwrap();
+        let decoded: LWW<i32> =
+            bincode::serde::decode_from_slice(&encoded, bincode::config::legacy())
+                .map(|(v, _)| v)
+                .unwrap();
         assert_eq!(decoded, v);
     }
 }

--- a/algebra/src/join_semilattice.rs
+++ b/algebra/src/join_semilattice.rs
@@ -768,28 +768,40 @@ mod tests {
     #[test]
     fn max_serde_roundtrip() {
         let original = Max(42i64);
-        let encoded = bincode::serialize(&original).unwrap();
-        let decoded: Max<i64> = bincode::deserialize(&encoded).unwrap();
+        let encoded = bincode::serde::encode_to_vec(original, bincode::config::legacy()).unwrap();
+        let decoded: Max<i64> =
+            bincode::serde::decode_from_slice(&encoded, bincode::config::legacy())
+                .map(|(v, _)| v)
+                .unwrap();
         assert_eq!(original, decoded);
 
         // Also test with bottom value
         let bottom = Max::<i64>::bottom();
-        let encoded = bincode::serialize(&bottom).unwrap();
-        let decoded: Max<i64> = bincode::deserialize(&encoded).unwrap();
+        let encoded = bincode::serde::encode_to_vec(bottom, bincode::config::legacy()).unwrap();
+        let decoded: Max<i64> =
+            bincode::serde::decode_from_slice(&encoded, bincode::config::legacy())
+                .map(|(v, _)| v)
+                .unwrap();
         assert_eq!(bottom, decoded);
     }
 
     #[test]
     fn min_serde_roundtrip() {
         let original = Min(42i64);
-        let encoded = bincode::serialize(&original).unwrap();
-        let decoded: Min<i64> = bincode::deserialize(&encoded).unwrap();
+        let encoded = bincode::serde::encode_to_vec(original, bincode::config::legacy()).unwrap();
+        let decoded: Min<i64> =
+            bincode::serde::decode_from_slice(&encoded, bincode::config::legacy())
+                .map(|(v, _)| v)
+                .unwrap();
         assert_eq!(original, decoded);
 
         // Also test with bottom value
         let bottom = Min::<i64>::bottom();
-        let encoded = bincode::serialize(&bottom).unwrap();
-        let decoded: Min<i64> = bincode::deserialize(&encoded).unwrap();
+        let encoded = bincode::serde::encode_to_vec(bottom, bincode::config::legacy()).unwrap();
+        let decoded: Min<i64> =
+            bincode::serde::decode_from_slice(&encoded, bincode::config::legacy())
+                .map(|(v, _)| v)
+                .unwrap();
         assert_eq!(bottom, decoded);
     }
 
@@ -797,15 +809,21 @@ mod tests {
     fn any_serde_roundtrip() {
         for value in [true, false] {
             let original = Any(value);
-            let encoded = bincode::serialize(&original).unwrap();
-            let decoded: Any = bincode::deserialize(&encoded).unwrap();
+            let encoded =
+                bincode::serde::encode_to_vec(original, bincode::config::legacy()).unwrap();
+            let decoded: Any =
+                bincode::serde::decode_from_slice(&encoded, bincode::config::legacy())
+                    .map(|(v, _)| v)
+                    .unwrap();
             assert_eq!(original, decoded);
         }
 
         // Also test bottom
         let bottom = Any::bottom();
-        let encoded = bincode::serialize(&bottom).unwrap();
-        let decoded: Any = bincode::deserialize(&encoded).unwrap();
+        let encoded = bincode::serde::encode_to_vec(bottom, bincode::config::legacy()).unwrap();
+        let decoded: Any = bincode::serde::decode_from_slice(&encoded, bincode::config::legacy())
+            .map(|(v, _)| v)
+            .unwrap();
         assert_eq!(bottom, decoded);
     }
 
@@ -813,15 +831,21 @@ mod tests {
     fn all_serde_roundtrip() {
         for value in [true, false] {
             let original = All(value);
-            let encoded = bincode::serialize(&original).unwrap();
-            let decoded: All = bincode::deserialize(&encoded).unwrap();
+            let encoded =
+                bincode::serde::encode_to_vec(original, bincode::config::legacy()).unwrap();
+            let decoded: All =
+                bincode::serde::decode_from_slice(&encoded, bincode::config::legacy())
+                    .map(|(v, _)| v)
+                    .unwrap();
             assert_eq!(original, decoded);
         }
 
         // Also test bottom
         let bottom = All::bottom();
-        let encoded = bincode::serialize(&bottom).unwrap();
-        let decoded: All = bincode::deserialize(&encoded).unwrap();
+        let encoded = bincode::serde::encode_to_vec(bottom, bincode::config::legacy()).unwrap();
+        let decoded: All = bincode::serde::decode_from_slice(&encoded, bincode::config::legacy())
+            .map(|(v, _)| v)
+            .unwrap();
         assert_eq!(bottom, decoded);
     }
 
@@ -932,8 +956,11 @@ mod tests {
         original.insert(1, Min(10));
         original.insert(2, Min(20));
 
-        let encoded = bincode::serialize(&original).unwrap();
-        let decoded: LatticeMap<u32, Min<i64>> = bincode::deserialize(&encoded).unwrap();
+        let encoded = bincode::serde::encode_to_vec(&original, bincode::config::legacy()).unwrap();
+        let decoded: LatticeMap<u32, Min<i64>> =
+            bincode::serde::decode_from_slice(&encoded, bincode::config::legacy())
+                .map(|(v, _)| v)
+                .unwrap();
 
         assert_eq!(original, decoded);
     }

--- a/hyperactor/Cargo.toml
+++ b/hyperactor/Cargo.toml
@@ -38,7 +38,7 @@ algebra = { version = "0.0.0", path = "../algebra" }
 anyhow = "1.0.102"
 async-trait = "0.1.86"
 backoff = { version = "0.4.0", features = ["futures", "tokio"] }
-bincode = "1.3.3"
+bincode = { version = "2", features = ["serde"] }
 bytes = { version = "1.11.1", features = ["serde"] }
 clap = { version = "4.6.0", features = ["derive", "env", "string", "unicode", "wrap_help"] }
 dashmap = { version = "5.5.3", features = ["rayon", "serde"] }

--- a/hyperactor/src/actor.rs
+++ b/hyperactor/src/actor.rs
@@ -292,7 +292,9 @@ pub trait RemoteSpawn: Actor + Referable + Binds<Self> {
         let proc = proc.clone();
         let name = name.to_string();
         Box::pin(async move {
-            let params = bincode::deserialize(&serialized_params)?;
+            let params =
+                bincode::serde::decode_from_slice(&serialized_params, bincode::config::legacy())
+                    .map(|(v, _)| v)?;
             let actor = Self::new(params, environment).await?;
             let handle = proc.spawn(&name, actor)?;
             // We return only the ActorId, not a typed ActorRef.

--- a/hyperactor/src/actor/remote.rs
+++ b/hyperactor/src/actor/remote.rs
@@ -192,7 +192,7 @@ mod tests {
                 &Proc::local(),
                 "hyperactor::actor::remote::tests::MyActor",
                 "actor",
-                bincode::serialize(&true).unwrap(),
+                bincode::serde::encode_to_vec(true, bincode::config::legacy()).unwrap(),
                 Flattrs::default(),
             )
             .await
@@ -203,7 +203,7 @@ mod tests {
                 &Proc::local(),
                 "hyperactor::actor::remote::tests::MyActor",
                 "actor",
-                bincode::serialize(&false).unwrap(),
+                bincode::serde::encode_to_vec(false, bincode::config::legacy()).unwrap(),
                 Flattrs::default(),
             )
             .await

--- a/hyperactor/src/channel.rs
+++ b/hyperactor/src/channel.rs
@@ -72,9 +72,13 @@ pub enum ChannelError {
     #[error(transparent)]
     Server(#[from] net::ServerError),
 
-    /// A bincode serialization or deserialization error occurred.
+    /// A bincode encoding error occurred.
     #[error(transparent)]
-    Bincode(#[from] Box<bincode::ErrorKind>),
+    BincodeEncode(#[from] bincode::error::EncodeError),
+
+    /// A bincode decoding error occurred.
+    #[error(transparent)]
+    BincodeDecode(#[from] bincode::error::DecodeError),
 
     /// Data encoding errors.
     #[error(transparent)]

--- a/hyperactor/src/channel/local.rs
+++ b/hyperactor/src/channel/local.rs
@@ -73,7 +73,7 @@ pub struct LocalTx<M: RemoteMessage> {
 #[async_trait]
 impl<M: RemoteMessage> Tx<M> for LocalTx<M> {
     fn do_post(&self, message: M, return_channel: Option<oneshot::Sender<SendError<M>>>) {
-        let data: Data = match bincode::serialize(&message) {
+        let data: Data = match bincode::serde::encode_to_vec(&message, bincode::config::legacy()) {
             Ok(data) => data,
             Err(err) => {
                 if let Some(return_channel) = return_channel {
@@ -121,7 +121,9 @@ pub struct LocalRx<M: RemoteMessage> {
 impl<M: RemoteMessage> Rx<M> for LocalRx<M> {
     async fn recv(&mut self) -> Result<M, ChannelError> {
         let data = self.data_rx.recv().await.ok_or(ChannelError::Closed)?;
-        bincode::deserialize(&data).map_err(ChannelError::from)
+        bincode::serde::decode_from_slice(&data, bincode::config::legacy())
+            .map(|(v, _)| v)
+            .map_err(ChannelError::from)
     }
 
     fn addr(&self) -> ChannelAddr {

--- a/hyperactor/src/channel/net.rs
+++ b/hyperactor/src/channel/net.rs
@@ -653,12 +653,16 @@ pub(super) enum NetRxResponse {
     Closed,
 }
 
-pub(super) fn serialize_response(response: NetRxResponse) -> Result<Bytes, bincode::Error> {
-    bincode::serialize(&response).map(|bytes| bytes.into())
+pub(super) fn serialize_response(
+    response: NetRxResponse,
+) -> Result<Bytes, bincode::error::EncodeError> {
+    bincode::serde::encode_to_vec(&response, bincode::config::legacy()).map(|bytes| bytes.into())
 }
 
-pub(super) fn deserialize_response(data: Bytes) -> Result<NetRxResponse, bincode::Error> {
-    bincode::deserialize(&data)
+pub(super) fn deserialize_response(
+    data: Bytes,
+) -> Result<NetRxResponse, bincode::error::DecodeError> {
+    bincode::serde::decode_from_slice(&data, bincode::config::legacy()).map(|(v, _)| v)
 }
 
 /// A Tx implemented on top of a Link. The Tx manages the link state,
@@ -757,7 +761,7 @@ pub enum ClientError {
     #[error("io: {0} {1}")]
     Io(ChannelAddr, std::io::Error),
     #[error("send {0}: serialize: {1}")]
-    Serialize(ChannelAddr, bincode::ErrorKind),
+    Serialize(ChannelAddr, bincode::error::EncodeError),
     #[error("invalid address: {0}")]
     InvalidAddress(String),
 }
@@ -2401,7 +2405,7 @@ mod tests {
                             let is_sampled = debug_log_sampling_rate.is_some_and(|sample_rate| send_count % sample_rate == 1);
                             if is_sampled {
                                 if is_from_client {
-                                    if let Ok(Frame::Message(_seq, _msg)) = bincode::deserialize::<Frame<M>>(&data) {
+                                    if let Ok((Frame::Message(_seq, _msg), _)) = bincode::serde::decode_from_slice::<Frame<M>, _>(&data, bincode::config::legacy()) {
                                         tracing::debug!("MockLink relays a msg from client. msg type: {}", std::any::type_name::<M>());
                                     }
                                 } else {

--- a/hyperactor_config/Cargo.toml
+++ b/hyperactor_config/Cargo.toml
@@ -12,7 +12,7 @@ license = "BSD-3-Clause"
 [dependencies]
 anyhow = "1.0.102"
 arc-swap = { version = "1.9.0", features = ["weak"] }
-bincode = "1.3.3"
+bincode = { version = "2", features = ["serde"] }
 bytes = { version = "1.11.1", features = ["serde"] }
 chrono = { version = "0.4.44", features = ["clock", "serde", "std"], default-features = false }
 erased-serde = "0.4.10"

--- a/hyperactor_config/src/attrs.rs
+++ b/hyperactor_config/src/attrs.rs
@@ -132,7 +132,7 @@ pub struct AttrKeyInfo {
         fn(&mut dyn ErasedDeserializer) -> Result<Box<dyn SerializableValue>, erased_serde::Error>,
     /// Deserializer function for bincode bytes (used by Flattrs)
     pub deserialize_bincode:
-        fn(&[u8]) -> Result<Box<dyn SerializableValue>, Box<bincode::ErrorKind>>,
+        fn(&[u8]) -> Result<Box<dyn SerializableValue>, bincode::error::DecodeError>,
     /// Meta-attributes.
     pub meta: &'static LazyLock<Attrs>,
     /// Display an attribute value using AttrValue::display.
@@ -533,7 +533,8 @@ impl<T: AttrValue> SerializableValue for T {
     }
 
     fn serialize_bincode(&self) -> Vec<u8> {
-        bincode::serialize(self).expect("bincode serialization failed")
+        bincode::serde::encode_to_vec(self, bincode::config::legacy())
+            .expect("bincode serialization failed")
     }
 }
 
@@ -995,7 +996,7 @@ macro_rules! declare_attrs {
                     Ok(Box::new(value) as Box<dyn $crate::attrs::SerializableValue>)
                 },
                 deserialize_bincode: |bytes| {
-                    let value: $type = $crate::bincode::deserialize(bytes)?;
+                    let value: $type = $crate::bincode::serde::decode_from_slice(bytes, $crate::bincode::config::legacy()).map(|(v, _)| v)?;
                     Ok(Box::new(value) as Box<dyn $crate::attrs::SerializableValue>)
                 },
                 meta: $crate::paste! { &[<$name _META_ATTRS>] },
@@ -1057,7 +1058,7 @@ macro_rules! declare_attrs {
                     Ok(Box::new(value) as Box<dyn $crate::attrs::SerializableValue>)
                 },
                 deserialize_bincode: |bytes| {
-                    let value: $type = $crate::bincode::deserialize(bytes)?;
+                    let value: $type = $crate::bincode::serde::decode_from_slice(bytes, $crate::bincode::config::legacy()).map(|(v, _)| v)?;
                     Ok(Box::new(value) as Box<dyn $crate::attrs::SerializableValue>)
                 },
                 meta: $crate::paste! { &[<$name _META_ATTRS>] },
@@ -1405,12 +1406,14 @@ mod tests {
 
         // Serialize this Attrs using bincode (same codec we use on
         // the wire).
-        let wire_bytes = bincode::serialize(&attrs).unwrap();
+        let wire_bytes = bincode::serde::encode_to_vec(&attrs, bincode::config::legacy()).unwrap();
 
         // Now try to decode those bytes back into Attrs. This should
         // hit the unknown-key branch and return Err.
-        let err = bincode::deserialize::<Attrs>(&wire_bytes)
-            .expect_err("should error on unknown attr key");
+        let err =
+            bincode::serde::decode_from_slice::<Attrs, _>(&wire_bytes, bincode::config::legacy())
+                .map(|(v, _)| v)
+                .expect_err("should error on unknown attr key");
 
         let exe_str = std::env::current_exe()
             .ok()

--- a/hyperactor_config/src/flattrs.rs
+++ b/hyperactor_config/src/flattrs.rs
@@ -112,7 +112,8 @@ impl Flattrs {
     /// - Different size: remove old entry and append new one
     pub fn set<T: Serialize>(&mut self, key: Key<T>, value: T) {
         let key_hash = key.key_hash();
-        let serialized = bincode::serialize(&value).expect("serialization failed");
+        let serialized = bincode::serde::encode_to_vec(&value, bincode::config::legacy())
+            .expect("serialization failed");
 
         // If key exists, either overwrite in place or compact + append
         if let Some((offset, old_len)) = self.find_entry_location(key_hash) {
@@ -147,7 +148,9 @@ impl Flattrs {
     pub fn get<T: AttrValue + DeserializeOwned>(&self, key: Key<T>) -> Option<T> {
         let key_hash = key.key_hash();
         let value_bytes = self.find_value(key_hash)?;
-        bincode::deserialize(value_bytes).ok()
+        bincode::serde::decode_from_slice(value_bytes, bincode::config::legacy())
+            .map(|(v, _)| v)
+            .ok()
     }
 
     /// Check if a key exists.
@@ -401,8 +404,12 @@ mod tests {
         attrs.set(TEST_U64, 42u64);
         attrs.set(TEST_STRING, "hello".to_string());
 
-        let serialized = bincode::serialize(&attrs).expect("serialize");
-        let deserialized: Flattrs = bincode::deserialize(&serialized).expect("deserialize");
+        let serialized =
+            bincode::serde::encode_to_vec(&attrs, bincode::config::legacy()).expect("serialize");
+        let deserialized: Flattrs =
+            bincode::serde::decode_from_slice(&serialized, bincode::config::legacy())
+                .map(|(v, _)| v)
+                .expect("deserialize");
 
         assert_eq!(deserialized.get(TEST_U64), Some(42u64));
         assert_eq!(deserialized.get(TEST_STRING), Some("hello".to_string()));

--- a/hyperactor_mesh/Cargo.toml
+++ b/hyperactor_mesh/Cargo.toml
@@ -40,7 +40,7 @@ anyhow = "1.0.102"
 async-trait = "0.1.86"
 axum = { version = "0.8", features = ["macros", "multipart", "ws"] }
 base64 = { version = "0.22.1", features = ["alloc"] }
-bincode = "1.3.3"
+bincode = { version = "2", features = ["serde"] }
 bitmaps = "3.2.1"
 buck-resources = "1"
 chrono = { version = "0.4.44", features = ["clock", "serde", "std"], default-features = false }

--- a/hyperactor_mesh/src/alloc.rs
+++ b/hyperactor_mesh/src/alloc.rs
@@ -802,7 +802,7 @@ pub(crate) mod testing {
                 cx,
                 actor_type,
                 "Stuck".to_string(),
-                bincode::serialize(params).unwrap(),
+                bincode::serde::encode_to_vec(params, bincode::config::legacy()).unwrap(),
                 completed_handle.bind(),
             )
             .await

--- a/hyperactor_mesh/src/casting.rs
+++ b/hyperactor_mesh/src/casting.rs
@@ -211,7 +211,10 @@ pub enum CastError {
     SliceError(#[from] SliceError),
 
     #[error(transparent)]
-    SerializationError(#[from] bincode::Error),
+    SerializationEncodeError(#[from] bincode::error::EncodeError),
+
+    #[error(transparent)]
+    SerializationDecodeError(#[from] bincode::error::DecodeError),
 
     #[error(transparent)]
     Other(#[from] anyhow::Error),

--- a/hyperactor_mesh/src/host_mesh.rs
+++ b/hyperactor_mesh/src/host_mesh.rs
@@ -2273,7 +2273,10 @@ mod tests {
         actor_mesh
             .cast(
                 instance,
-                SetConfigAttrs(bincode::serialize(&attrs_override).unwrap()),
+                SetConfigAttrs(
+                    bincode::serde::encode_to_vec(&attrs_override, bincode::config::legacy())
+                        .unwrap(),
+                ),
             )
             .unwrap();
 
@@ -2282,7 +2285,10 @@ mod tests {
             .cast(instance, GetConfigAttrs(tx.bind()))
             .unwrap();
         let actual_attrs = rx.recv().await.unwrap();
-        let actual_attrs = bincode::deserialize::<Attrs>(&actual_attrs).unwrap();
+        let actual_attrs =
+            bincode::serde::decode_from_slice::<Attrs, _>(&actual_attrs, bincode::config::legacy())
+                .map(|(v, _)| v)
+                .unwrap();
 
         assert_eq!(
             *actual_attrs

--- a/hyperactor_mesh/src/lib.rs
+++ b/hyperactor_mesh/src/lib.rs
@@ -224,7 +224,9 @@ pub enum Error {
 #[derive(Debug, thiserror::Error)]
 pub enum CodecError {
     #[error(transparent)]
-    BincodeError(#[from] Box<bincode::Error>),
+    BincodeEncodeError(#[from] Box<bincode::error::EncodeError>),
+    #[error(transparent)]
+    BincodeDecodeError(#[from] Box<bincode::error::DecodeError>),
     #[error(transparent)]
     JsonError(#[from] Box<serde_json::Error>),
     #[error(transparent)]
@@ -233,8 +235,14 @@ pub enum CodecError {
     Utf8Error(#[from] Box<std::str::Utf8Error>),
 }
 
-impl From<bincode::Error> for Error {
-    fn from(e: bincode::Error) -> Self {
+impl From<bincode::error::EncodeError> for Error {
+    fn from(e: bincode::error::EncodeError) -> Self {
+        Error::CodecError(Box::new(e).into())
+    }
+}
+
+impl From<bincode::error::DecodeError> for Error {
+    fn from(e: bincode::error::DecodeError) -> Self {
         Error::CodecError(Box::new(e).into())
     }
 }

--- a/hyperactor_mesh/src/proc_agent.rs
+++ b/hyperactor_mesh/src/proc_agent.rs
@@ -1977,7 +1977,8 @@ mod tests {
             .name_of::<ExtraActor>()
             .unwrap()
             .to_string();
-        let actor_params = bincode::serialize(&ExtraActor).unwrap();
+        let actor_params =
+            bincode::serde::encode_to_vec(&ExtraActor, bincode::config::legacy()).unwrap();
         let actor_name = Name::Reserved("test_actor".to_string());
 
         // 1. Spawn an actor via CreateOrUpdate.

--- a/hyperactor_mesh/src/proc_mesh.rs
+++ b/hyperactor_mesh/src/proc_mesh.rs
@@ -1055,7 +1055,7 @@ impl ProcMeshRef {
             .ok_or(Error::ActorTypeNotRegistered(type_name::<A>().to_string()))?
             .to_string();
 
-        let serialized_params = bincode::serialize(params)?;
+        let serialized_params = bincode::serde::encode_to_vec(params, bincode::config::legacy())?;
         let agent_mesh = self.agent_mesh();
 
         agent_mesh.cast(

--- a/hyperactor_mesh/src/resource/mesh.rs
+++ b/hyperactor_mesh/src/resource/mesh.rs
@@ -137,8 +137,12 @@ mod test {
             statuses: ValueMesh::new(region, vec![Status::Running; num_ranks]).unwrap(),
             state: 0,
         };
-        let encoded = bincode::serialize(&data).expect("serialization failed");
-        let decoded: State<i32> = bincode::deserialize(&encoded).expect("deserialization failed");
+        let encoded = bincode::serde::encode_to_vec(&data, bincode::config::legacy())
+            .expect("serialization failed");
+        let decoded: State<i32> =
+            bincode::serde::decode_from_slice(&encoded, bincode::config::legacy())
+                .map(|(v, _)| v)
+                .expect("deserialization failed");
         assert_eq!(decoded.state, data.state);
         assert_eq!(decoded.statuses, data.statuses);
     }

--- a/hyperactor_mesh/src/testactor.rs
+++ b/hyperactor_mesh/src/testactor.rs
@@ -295,7 +295,8 @@ impl Handler<SetConfigAttrs> for TestActor {
         _cx: &Context<Self>,
         SetConfigAttrs(attrs): SetConfigAttrs,
     ) -> Result<(), anyhow::Error> {
-        let attrs = bincode::deserialize(&attrs)?;
+        let attrs =
+            bincode::serde::decode_from_slice(&attrs, bincode::config::legacy()).map(|(v, _)| v)?;
         hyperactor_config::global::set(Source::Runtime, attrs);
         Ok(())
     }
@@ -311,7 +312,10 @@ impl Handler<GetConfigAttrs> for TestActor {
         cx: &Context<Self>,
         GetConfigAttrs(reply): GetConfigAttrs,
     ) -> Result<(), anyhow::Error> {
-        let attrs = bincode::serialize(&hyperactor_config::global::attrs())?;
+        let attrs = bincode::serde::encode_to_vec(
+            hyperactor_config::global::attrs(),
+            bincode::config::legacy(),
+        )?;
         reply.send(cx, attrs)?;
         Ok(())
     }

--- a/hyperactor_mesh/src/value_mesh.rs
+++ b/hyperactor_mesh/src/value_mesh.rs
@@ -1731,8 +1731,11 @@ mod tests {
         let region: Region = extent!(x = 5).into();
         let dense = ValueMesh::new(region.clone(), vec![1, 2, 3, 4, 5]).unwrap();
 
-        let encoded = bincode::serialize(&dense).unwrap();
-        let restored: ValueMesh<i32> = bincode::deserialize(&encoded).unwrap();
+        let encoded = bincode::serde::encode_to_vec(&dense, bincode::config::legacy()).unwrap();
+        let restored: ValueMesh<i32> =
+            bincode::serde::decode_from_slice(&encoded, bincode::config::legacy())
+                .map(|(v, _)| v)
+                .unwrap();
 
         assert_eq!(dense, restored);
         // Dense meshes should stay dense on the wire.
@@ -1768,8 +1771,11 @@ mod tests {
         let mut mesh = ValueMesh::new(region.clone(), vec![1, 1, 1, 2, 2, 3, 3, 3, 3, 3]).unwrap();
         mesh.compress_adjacent_in_place();
 
-        let encoded = bincode::serialize(&mesh).unwrap();
-        let restored: ValueMesh<i32> = bincode::deserialize(&encoded).unwrap();
+        let encoded = bincode::serde::encode_to_vec(&mesh, bincode::config::legacy()).unwrap();
+        let restored: ValueMesh<i32> =
+            bincode::serde::decode_from_slice(&encoded, bincode::config::legacy())
+                .map(|(v, _)| v)
+                .unwrap();
 
         // Logical equality preserved.
         assert_eq!(mesh, restored);

--- a/monarch_conda/Cargo.toml
+++ b/monarch_conda/Cargo.toml
@@ -15,7 +15,7 @@ path = "src/main.rs"
 aho-corasick = "1.1.4"
 anyhow = "1.0.102"
 async-tempfile = "0.7.0"
-bincode = "1.3.3"
+bincode = { version = "2", features = ["serde"] }
 clap = { version = "4.6.0", features = ["derive", "env", "string", "unicode", "wrap_help"] }
 dashmap = { version = "5.5.3", features = ["rayon", "serde"] }
 digest = { version = "0.10", features = ["rand_core"] }

--- a/monarch_conda/src/diff.rs
+++ b/monarch_conda/src/diff.rs
@@ -63,7 +63,10 @@ impl PackMetaFingerprint {
         let contents = fs::read_to_string(pack_meta.join("offsets.jsonl")).await?;
         let offsets = Offsets::from_contents(&contents)?;
         for ent in offsets.entries {
-            let contents = bincode::serialize(&(ent.path, ent.mode, ent.offsets.len()))?;
+            let contents = bincode::serde::encode_to_vec(
+                &(ent.path, ent.mode, ent.offsets.len()),
+                bincode::config::legacy(),
+            )?;
             hasher.update(contents.len().to_le_bytes());
             hasher.update(&contents);
         }

--- a/monarch_conda/src/sync.rs
+++ b/monarch_conda/src/sync.rs
@@ -326,7 +326,7 @@ pub async fn sender(
             // Send conda env fingerprint
             let src_env = CondaFingerprint::from_env(src).await?;
             to_receiver
-                .send(bincode::serialize(&src_env)?.into())
+                .send(bincode::serde::encode_to_vec(&src_env, bincode::config::legacy())?.into())
                 .await
                 .context("sending src conda fingerprint")?;
             to_receiver.flush().await?;
@@ -334,12 +334,21 @@ pub async fn sender(
             // Send file lists.
             while let Some((path, metadata)) = ent_rx.recv().await {
                 to_receiver
-                    .send(bincode::serialize(&FileList::Entry(path, metadata))?.into())
+                    .send(
+                        bincode::serde::encode_to_vec(
+                            FileList::Entry(path, metadata),
+                            bincode::config::legacy(),
+                        )?
+                        .into(),
+                    )
                     .await
                     .context("sending file ent")?;
             }
             to_receiver
-                .send(bincode::serialize(&FileList::Done)?.into())
+                .send(
+                    bincode::serde::encode_to_vec(FileList::Done, bincode::config::legacy())?
+                        .into(),
+                )
                 .await
                 .context("sending file list end")?;
             to_receiver.flush().await?;
@@ -352,18 +361,24 @@ pub async fn sender(
     to_receiver.flush().await?;
     let mut to_receiver = to_receiver.into_inner();
 
-    let hdr: FileSectionHeader =
-        bincode::deserialize(&from_receiver.next().await.context("header")??)?;
+    let hdr: FileSectionHeader = bincode::serde::decode_from_slice(
+        &from_receiver.next().await.context("header")??,
+        bincode::config::legacy(),
+    )
+    .map(|(v, _)| v)?;
     for _ in 0..hdr.num {
-        let FileHeader { path, symlink } =
-            bincode::deserialize(&from_receiver.next().await.context("signature")??)?;
+        let FileHeader { path, symlink } = bincode::serde::decode_from_slice(
+            &from_receiver.next().await.context("signature")??,
+            bincode::config::legacy(),
+        )
+        .map(|(v, _)| v)?;
         let fpath = src.join(&path);
         if symlink {
             let header = FileContentsHeader {
                 path,
                 contents: FileContents::Symlink(fs::read_link(&fpath).await?),
             };
-            let header = bincode::serialize(&header)?;
+            let header = bincode::serde::encode_to_vec(&header, bincode::config::legacy())?;
             to_receiver.write_all(&header.len().to_le_bytes()).await?;
             to_receiver
                 .write_all(&header)
@@ -375,7 +390,7 @@ pub async fn sender(
                 path,
                 contents: FileContents::File(base.metadata().await?.len()),
             };
-            let header = bincode::serialize(&header)?;
+            let header = bincode::serde::encode_to_vec(&header, bincode::config::legacy())?;
             to_receiver.write_all(&header.len().to_le_bytes()).await?;
             to_receiver
                 .write_all(&header)
@@ -449,8 +464,11 @@ pub async fn receiver(
     // Get the conda env fingerprint for the src and dst, and use that to create a
     // comparator we can use to compare the mtimes between them.
     let dst_env = CondaFingerprint::from_env(dst).await?;
-    let src_env: CondaFingerprint =
-        bincode::deserialize(&from_sender.next().await.context("fingerprint")??)?;
+    let src_env: CondaFingerprint = bincode::serde::decode_from_slice(
+        &from_sender.next().await.context("fingerprint")??,
+        bincode::config::legacy(),
+    )
+    .map(|(v, _)| v)?;
     let comparator = CondaFingerprint::mtime_comparator(&src_env, &dst_env)?;
     let ignores = GlobSetBuilder::new()
         .add(Glob::new("**/*.pyc")?)
@@ -477,8 +495,11 @@ pub async fn receiver(
         },
         // Process file list sent from sender.
         async {
-            while let FileList::Entry(path, metadata) =
-                bincode::deserialize(&from_sender.next().await.context("file list")??)?
+            while let FileList::Entry(path, metadata) = bincode::serde::decode_from_slice(
+                &from_sender.next().await.context("file list")??,
+                bincode::config::legacy(),
+            )
+            .map(|(v, _): (FileList, _)| v)?
             {
                 actions_builder
                     .process_src(path.clone(), metadata)
@@ -565,7 +586,9 @@ pub async fn receiver(
                 let mut buf = vec![0u8; len as usize];
                 from_sender.read_exact(&mut buf).await?;
                 let FileContentsHeader { path, contents } =
-                    bincode::deserialize(&buf).context("delta header")?;
+                    bincode::serde::decode_from_slice(&buf, bincode::config::legacy())
+                        .map(|(v, _)| v)
+                        .context("delta header")?;
                 let fpath = dst.join(&path);
                 match (contents, files.get(&path).context("missing file")?) {
                     // Read file contents and write to a tempfile.
@@ -617,16 +640,25 @@ pub async fn receiver(
         },
         async {
             to_sender
-                .send(bincode::serialize(&FileSectionHeader { num: files.len() })?.into())
+                .send(
+                    bincode::serde::encode_to_vec(
+                        &FileSectionHeader { num: files.len() },
+                        bincode::config::legacy(),
+                    )?
+                    .into(),
+                )
                 .await
                 .context("sending sig section header")?;
             for (path, (_, recv)) in files.iter() {
                 to_sender
                     .send(
-                        bincode::serialize(&FileHeader {
-                            path: path.clone(),
-                            symlink: matches!(recv, Receive::Symlink),
-                        })?
+                        bincode::serde::encode_to_vec(
+                            &FileHeader {
+                                path: path.clone(),
+                                symlink: matches!(recv, Receive::Symlink),
+                            },
+                            bincode::config::legacy(),
+                        )?
                         .into(),
                     )
                     .await

--- a/monarch_extension/Cargo.toml
+++ b/monarch_extension/Cargo.toml
@@ -16,7 +16,7 @@ crate-type = ["cdylib"]
 [dependencies]
 anyhow = "1.0.102"
 async-trait = "0.1.86"
-bincode = "1.3.3"
+bincode = { version = "2", features = ["serde"] }
 bytes = { version = "1.11.1", features = ["serde"] }
 fuse3 = { version = "0.8.1", features = ["tokio-runtime", "unprivileged"] }
 futures = { version = "0.3.31", features = ["async-await", "compat"] }

--- a/monarch_extension/src/code_sync.rs
+++ b/monarch_extension/src/code_sync.rs
@@ -65,14 +65,15 @@ impl From<PyWorkspaceLocation> for WorkspaceLocation {
 impl PyWorkspaceLocation {
     #[staticmethod]
     fn from_bytes(bytes: &Bound<'_, PyBytes>) -> PyResult<Self> {
-        bincode::deserialize(bytes.as_bytes())
+        bincode::serde::decode_from_slice(bytes.as_bytes(), bincode::config::legacy())
+            .map(|(v, _)| v)
             .map_err(|e| PyErr::new::<PyValueError, _>(e.to_string()))
     }
 
     fn __reduce__<'py>(
         slf: &Bound<'py, Self>,
     ) -> PyResult<(Bound<'py, PyAny>, (Bound<'py, PyBytes>,))> {
-        let bytes = bincode::serialize(&*slf.borrow())
+        let bytes = bincode::serde::encode_to_vec(&*slf.borrow(), bincode::config::legacy())
             .map_err(|e| PyErr::new::<PyValueError, _>(e.to_string()))?;
         let py_bytes = PyBytes::new(slf.py(), &bytes);
         Ok((slf.as_any().getattr("from_bytes")?, (py_bytes,)))
@@ -179,14 +180,15 @@ impl From<PyCodeSyncMethod> for CodeSyncMethod {
 impl PyCodeSyncMethod {
     #[staticmethod]
     fn from_bytes(bytes: &Bound<'_, PyBytes>) -> PyResult<Self> {
-        bincode::deserialize(bytes.as_bytes())
+        bincode::serde::decode_from_slice(bytes.as_bytes(), bincode::config::legacy())
+            .map(|(v, _)| v)
             .map_err(|e| PyErr::new::<PyValueError, _>(e.to_string()))
     }
 
     fn __reduce__<'py>(
         slf: &Bound<'py, Self>,
     ) -> PyResult<(Bound<'py, PyAny>, (Bound<'py, PyBytes>,))> {
-        let bytes = bincode::serialize(&*slf.borrow())
+        let bytes = bincode::serde::encode_to_vec(&*slf.borrow(), bincode::config::legacy())
             .map_err(|e| PyErr::new::<PyValueError, _>(e.to_string()))?;
         let py_bytes = PyBytes::new(slf.py(), &bytes);
         Ok((slf.as_any().getattr("from_bytes")?, (py_bytes,)))

--- a/monarch_hyperactor/Cargo.toml
+++ b/monarch_hyperactor/Cargo.toml
@@ -19,7 +19,7 @@ path = "tests/lib.rs"
 anyhow = "1.0.102"
 async-once-cell = "0.4.4"
 async-trait = "0.1.86"
-bincode = "1.3.3"
+bincode = { version = "2", features = ["serde"] }
 bytes = { version = "1.11.1", features = ["serde"] }
 clap = { version = "4.6.0", features = ["derive", "env", "string", "unicode", "wrap_help"] }
 erased-serde = "0.4.10"

--- a/monarch_hyperactor/src/actor_mesh.rs
+++ b/monarch_hyperactor/src/actor_mesh.rs
@@ -613,7 +613,8 @@ impl ActorMeshProtocol for ActorMeshRef<PythonActor> {
     }
 
     fn __reduce__<'py>(&self, py: Python<'py>) -> PyResult<(Bound<'py, PyAny>, Bound<'py, PyAny>)> {
-        let bytes = bincode::serialize(self).map_err(|e| PyValueError::new_err(e.to_string()))?;
+        let bytes = bincode::serde::encode_to_vec(self, bincode::config::legacy())
+            .map_err(|e| PyValueError::new_err(e.to_string()))?;
         let py_bytes = (PyBytes::new(py, &bytes),).into_bound_py_any(py).unwrap();
         let module = py
             .import("monarch._rust_bindings.monarch_hyperactor.actor_mesh")
@@ -646,7 +647,9 @@ impl PythonActorMeshImpl {
 #[pyfunction]
 fn py_actor_mesh_from_bytes(bytes: &Bound<'_, PyBytes>) -> PyResult<PythonActorMesh> {
     let r: PyResult<ActorMeshRef<PythonActor>> =
-        bincode::deserialize(bytes.as_bytes()).map_err(|e| PyValueError::new_err(e.to_string()));
+        bincode::serde::decode_from_slice(bytes.as_bytes(), bincode::config::legacy())
+            .map(|(v, _)| v)
+            .map_err(|e| PyValueError::new_err(e.to_string()));
     r.map(|r| AsyncActorMesh::from_impl(Arc::new(PythonActorMeshImpl::new_ref(r))))
         .map(|r| PythonActorMesh::from_impl(Arc::from(r)))
 }

--- a/monarch_hyperactor/src/host_mesh.rs
+++ b/monarch_hyperactor/src/host_mesh.rs
@@ -216,7 +216,7 @@ impl PyHostMesh {
     }
 
     fn __reduce__<'py>(&self, py: Python<'py>) -> PyResult<(Bound<'py, PyAny>, Bound<'py, PyAny>)> {
-        let bytes = bincode::serialize(&self.mesh_ref()?)
+        let bytes = bincode::serde::encode_to_vec(&self.mesh_ref()?, bincode::config::legacy())
             .map_err(|e| PyErr::new::<PyValueError, _>(e.to_string()))?;
         let py_bytes = (PyBytes::new(py, &bytes),).into_bound_py_any(py).unwrap();
         let from_bytes =
@@ -472,8 +472,10 @@ fn bootstrap_host(bootstrap_cmd: Option<PyBootstrapCommand>) -> PyResult<PyPytho
 
 #[pyfunction]
 fn py_host_mesh_from_bytes(bytes: &Bound<'_, PyBytes>) -> PyResult<PyHostMesh> {
-    let r: PyResult<HostMeshRef> = bincode::deserialize(bytes.as_bytes())
-        .map_err(|e| PyErr::new::<PyValueError, _>(e.to_string()));
+    let r: PyResult<HostMeshRef> =
+        bincode::serde::decode_from_slice(bytes.as_bytes(), bincode::config::legacy())
+            .map(|(v, _)| v)
+            .map_err(|e| PyErr::new::<PyValueError, _>(e.to_string()));
     r.map(PyHostMesh::new_ref)
 }
 

--- a/monarch_hyperactor/src/proc_mesh.rs
+++ b/monarch_hyperactor/src/proc_mesh.rs
@@ -136,7 +136,7 @@ impl PyProcMesh {
     }
 
     fn __reduce__<'py>(&self, py: Python<'py>) -> PyResult<(Bound<'py, PyAny>, Bound<'py, PyAny>)> {
-        let bytes = bincode::serialize(&self.mesh_ref()?)
+        let bytes = bincode::serde::encode_to_vec(&self.mesh_ref()?, bincode::config::legacy())
             .map_err(|e| PyErr::new::<PyValueError, _>(e.to_string()))?;
         let py_bytes = (PyBytes::new(py, &bytes),).into_bound_py_any(py).unwrap();
         let from_bytes =
@@ -220,8 +220,10 @@ impl PyProcMeshRefImpl {
 
 #[pyfunction]
 fn py_proc_mesh_from_bytes(bytes: &Bound<'_, PyBytes>) -> PyResult<PyProcMesh> {
-    let r: PyResult<ProcMeshRef> = bincode::deserialize(bytes.as_bytes())
-        .map_err(|e| PyErr::new::<PyValueError, _>(e.to_string()));
+    let r: PyResult<ProcMeshRef> =
+        bincode::serde::decode_from_slice(bytes.as_bytes(), bincode::config::legacy())
+            .map(|(v, _)| v)
+            .map_err(|e| PyErr::new::<PyValueError, _>(e.to_string()));
     r.map(PyProcMesh::new_ref)
 }
 

--- a/monarch_hyperactor/src/shape.rs
+++ b/monarch_hyperactor/src/shape.rs
@@ -60,15 +60,17 @@ impl PyExtent {
 
     #[staticmethod]
     fn from_bytes(bytes: &Bound<'_, PyBytes>) -> PyResult<Self> {
-        let extent: PyExtent = bincode::deserialize(bytes.as_bytes())
-            .map_err(|e| PyErr::new::<PyValueError, _>(e.to_string()))?;
+        let extent: PyExtent =
+            bincode::serde::decode_from_slice(bytes.as_bytes(), bincode::config::legacy())
+                .map(|(v, _)| v)
+                .map_err(|e| PyErr::new::<PyValueError, _>(e.to_string()))?;
         Ok(extent)
     }
 
     fn __reduce__<'py>(
         slf: &Bound<'py, Self>,
     ) -> PyResult<(Bound<'py, PyAny>, (Bound<'py, PyBytes>,))> {
-        let bytes = bincode::serialize(&*slf.borrow())
+        let bytes = bincode::serde::encode_to_vec(&*slf.borrow(), bincode::config::legacy())
             .map_err(|e| PyErr::new::<PyValueError, _>(e.to_string()))?;
         let py_bytes = PyBytes::new(slf.py(), &bytes);
         Ok((slf.getattr("from_bytes")?, (py_bytes,)))
@@ -165,7 +167,7 @@ impl PyRegion {
     }
 
     fn __reduce__<'py>(&self, py: Python<'py>) -> PyResult<(Bound<'py, PyAny>, Bound<'py, PyAny>)> {
-        let bytes = bincode::serialize(&self.inner)
+        let bytes = bincode::serde::encode_to_vec(&self.inner, bincode::config::legacy())
             .map_err(|e| PyErr::new::<PyValueError, _>(e.to_string()))?;
         let py_bytes = (PyBytes::new(py, &bytes),).into_bound_py_any(py).unwrap();
         let from_bytes = py
@@ -177,9 +179,13 @@ impl PyRegion {
 
     #[staticmethod]
     fn from_bytes(bytes: &Bound<'_, PyBytes>) -> PyResult<Self> {
-        Ok(bincode::deserialize::<Region>(bytes.as_bytes())
-            .map_err(|e| PyErr::new::<PyValueError, _>(e.to_string()))?
-            .into())
+        Ok(bincode::serde::decode_from_slice::<Region, _>(
+            bytes.as_bytes(),
+            bincode::config::legacy(),
+        )
+        .map(|(v, _)| v)
+        .map_err(|e| PyErr::new::<PyValueError, _>(e.to_string()))?
+        .into())
     }
 
     fn point_of_base_rank(&self, rank: usize) -> PyResult<PyPoint> {
@@ -309,15 +315,17 @@ impl PyShape {
 
     #[staticmethod]
     fn from_bytes(bytes: &Bound<'_, PyBytes>) -> PyResult<Self> {
-        let shape: Shape = bincode::deserialize(bytes.as_bytes())
-            .map_err(|e| PyErr::new::<PyValueError, _>(e.to_string()))?;
+        let shape: Shape =
+            bincode::serde::decode_from_slice(bytes.as_bytes(), bincode::config::legacy())
+                .map(|(v, _)| v)
+                .map_err(|e| PyErr::new::<PyValueError, _>(e.to_string()))?;
         Ok(PyShape::from(shape))
     }
 
     fn __reduce__<'py>(
         slf: &Bound<'py, Self>,
     ) -> PyResult<(Bound<'py, PyAny>, (Bound<'py, PyBytes>,))> {
-        let bytes = bincode::serialize(&slf.borrow().inner)
+        let bytes = bincode::serde::encode_to_vec(&slf.borrow().inner, bincode::config::legacy())
             .map_err(|e| PyErr::new::<PyValueError, _>(e.to_string()))?;
         let py_bytes = PyBytes::new(slf.py(), &bytes);
         Ok((slf.getattr("from_bytes")?, (py_bytes,)))
@@ -412,15 +420,17 @@ impl PyPoint {
 
     #[staticmethod]
     fn from_bytes(bytes: &Bound<'_, PyBytes>) -> PyResult<Self> {
-        let point: PyPoint = bincode::deserialize(bytes.as_bytes())
-            .map_err(|e| PyErr::new::<PyValueError, _>(e.to_string()))?;
+        let point: PyPoint =
+            bincode::serde::decode_from_slice(bytes.as_bytes(), bincode::config::legacy())
+                .map(|(v, _)| v)
+                .map_err(|e| PyErr::new::<PyValueError, _>(e.to_string()))?;
         Ok(point)
     }
 
     fn __reduce__<'py>(
         slf: &Bound<'py, Self>,
     ) -> PyResult<(Bound<'py, PyAny>, (Bound<'py, PyBytes>,))> {
-        let bytes = bincode::serialize(&*slf.borrow())
+        let bytes = bincode::serde::encode_to_vec(&*slf.borrow(), bincode::config::legacy())
             .map_err(|e| PyErr::new::<PyValueError, _>(e.to_string()))?;
         let py_bytes = PyBytes::new(slf.py(), &bytes);
         Ok((slf.getattr("from_bytes")?, (py_bytes,)))

--- a/wirevalue/Cargo.toml
+++ b/wirevalue/Cargo.toml
@@ -11,7 +11,7 @@ license = "BSD-3-Clause"
 
 [dependencies]
 anyhow = "1.0.102"
-bincode = "1.3.3"
+bincode = { version = "2", features = ["serde"] }
 bytes = { version = "1.11.1", features = ["serde"] }
 crc32fast = "1.4"
 enum-as-inner = "0.6.1"

--- a/wirevalue/src/lib.rs
+++ b/wirevalue/src/lib.rs
@@ -290,9 +290,13 @@ impl std::fmt::Debug for Encoded {
 /// The type of error returned by operations on [`Any`].
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
-    /// Errors returned from serde bincode.
+    /// Errors returned from serde bincode encoding.
     #[error(transparent)]
-    Bincode(#[from] bincode::Error),
+    BincodeEncode(#[from] bincode::error::EncodeError),
+
+    /// Errors returned from serde bincode decoding.
+    #[error(transparent)]
+    BincodeDecode(#[from] bincode::error::DecodeError),
 
     /// Errors returned from serde JSON.
     #[error(transparent)]
@@ -398,11 +402,14 @@ impl Any {
     ) -> Result<Self> {
         Ok(Self {
             encoded: match encoding {
-                Encoding::Bincode => Encoded::Bincode(bincode::serialize(value)?.into()),
+                Encoding::Bincode => Encoded::Bincode(
+                    bincode::serde::encode_to_vec(value, bincode::config::legacy())?.into(),
+                ),
                 Encoding::Json => Encoded::Json(serde_json::to_vec(value)?.into()),
-                Encoding::Multipart => {
-                    Encoded::Multipart(serde_multipart::serialize_bincode(value)?)
-                }
+                Encoding::Multipart => Encoded::Multipart(
+                    serde_multipart::serialize_bincode(value)
+                        .map_err(|e| Error::InvalidEncoding(e.to_string()))?,
+                ),
             },
             typehash: T::typehash(),
         })
@@ -441,10 +448,15 @@ impl Any {
     /// not needed.
     pub fn deserialized_unchecked<T: DeserializeOwned>(&self) -> Result<T> {
         match &self.encoded {
-            Encoded::Bincode(data) => Ok(bincode::deserialize(data)?),
+            Encoded::Bincode(data) => Ok(bincode::serde::decode_from_slice(
+                data,
+                bincode::config::legacy(),
+            )
+            .map(|(v, _)| v)?),
             Encoded::Json(data) => Ok(serde_json::from_slice(data)?),
             Encoded::Multipart(message) => {
-                Ok(serde_multipart::deserialize_bincode(message.clone())?)
+                Ok(serde_multipart::deserialize_bincode(message.clone())
+                    .map_err(|e| Error::InvalidEncoding(e.to_string()))?)
             }
         }
     }
@@ -508,7 +520,11 @@ impl Any {
     // serialization, and generalize it to other codecs as well.
     pub fn prefix<T: DeserializeOwned>(&self) -> Result<T> {
         match &self.encoded {
-            Encoded::Bincode(data) => Ok(bincode::deserialize(data)?),
+            Encoded::Bincode(data) => Ok(bincode::serde::decode_from_slice(
+                data,
+                bincode::config::legacy(),
+            )
+            .map(|(v, _)| v)?),
             _ => Err(Error::PrefixNotSupported),
         }
     }
@@ -526,10 +542,11 @@ impl Any {
         // This is safe because we know that the prefix is the first thing
         // in the serialized value, and that the serialization format is stable.
         let mut cursor = Cursor::new(data.clone());
-        let _prefix: T = bincode::deserialize_from(&mut cursor).unwrap();
+        let _prefix: T =
+            bincode::serde::decode_from_std_read(&mut cursor, bincode::config::legacy()).unwrap();
         let position = cursor.position() as usize;
         let suffix = &cursor.into_inner()[position..];
-        let mut data = bincode::serialize(&prefix)?;
+        let mut data = bincode::serde::encode_to_vec(&prefix, bincode::config::legacy())?;
         data.extend_from_slice(suffix);
         self.encoded = Encoded::Bincode(data.into());
 


### PR DESCRIPTION
Summary:
Migrate bincode dependency from v1 (rust:bincode) to v2 (rust:bincode-2).
Using bincode::config::legacy() for wire compatibility with v1 format.

Reviewed By: dtolnay

Differential Revision: D101307540
