### PR TITLE
[monarch] Caller side endpoint spans

### DIFF
--- a/hyperactor_telemetry/src/sinks/perfetto.rs
+++ b/hyperactor_telemetry/src/sinks/perfetto.rs
@@ -82,6 +82,11 @@ use crate::trace_dispatcher::get_field;
 /// The target prefix for user-facing telemetry spans.
 pub const USER_TELEMETRY_PREFIX: &str = "monarch_hyperactor::telemetry";
 
+/// Dedicated target for endpoint spans. Spans with this target get their
+/// display name synthesized as `{method}.{span_name}`, where `span_name`
+/// is the adverb (e.g., "call", "call_one", "choose").
+pub const ENDPOINT_TELEMETRY_TARGET: &str = "monarch_hyperactor::telemetry::endpoint";
+
 /// Controls what events are captured in Perfetto traces.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
 pub enum PerfettoTraceMode {
@@ -221,6 +226,9 @@ pub struct PerfettoFileSink {
     span_info: HashMap<u64, SpanInfo>,
     /// Maps thread names to track ids
     thread_tracks: HashMap<String, u64>,
+    /// Maps span id to the track it entered on, so that certain Exit/Close events
+    /// are emitted on the same track even when they fire from a different thread.
+    span_tracks: HashMap<u64, u64>,
     /// track_id of this process
     process_track: u64,
     pid: i32,
@@ -275,6 +283,7 @@ impl PerfettoFileSink {
             annotation_names: InternedStrings::default(),
             span_info: HashMap::new(),
             thread_tracks: HashMap::new(),
+            span_tracks: HashMap::new(),
             process_track: 0,
             pid,
             process_name: process_name.to_string(),
@@ -563,13 +572,33 @@ impl TraceEventSink for PerfettoFileSink {
                     return Ok(());
                 }
 
-                // In user mode, prefer the "name" field if present for display
-                // In dev mode, use the fully qualified name
-                let display_name = if *target == USER_TELEMETRY_PREFIX {
-                    if let Some(FieldValue::Str(n)) = get_field(fields, "name") {
-                        n.clone()
-                    } else {
-                        name.to_string()
+                // In user mode, synthesize a friendly display name.
+                // - endpoint target (ActorEndpoint): "{mesh}.{method}.{span_name}"
+                // - endpoint target (Remote):       "{call_name}.{span_name}"
+                // - generic telemetry target: "name" field, else static span name
+                // In dev mode, use the fully qualified name.
+                let display_name = if *target == ENDPOINT_TELEMETRY_TARGET {
+                    let mesh = match get_field(fields, "mesh") {
+                        Some(FieldValue::Str(m)) => Some(m.as_str()),
+                        _ => None,
+                    };
+                    let method = match get_field(fields, "method") {
+                        Some(FieldValue::Str(m)) => Some(m.as_str()),
+                        _ => None,
+                    };
+                    let call_name = match get_field(fields, "call_name") {
+                        Some(FieldValue::Str(c)) if !c.is_empty() => Some(c.as_str()),
+                        _ => None,
+                    };
+                    match (mesh, method, call_name) {
+                        (Some(mesh), Some(method), _) => format!("{}.{}.{}()", mesh, method, name),
+                        (_, _, Some(call_name)) => format!("{}.{}()", call_name, name),
+                        _ => name.to_string(),
+                    }
+                } else if *target == USER_TELEMETRY_PREFIX {
+                    match get_field(fields, "name") {
+                        Some(FieldValue::Str(n)) => n.clone(),
+                        _ => name.to_string(),
                     }
                 } else {
                     format!("{}::{}", target, name)
@@ -597,6 +626,7 @@ impl TraceEventSink for PerfettoFileSink {
                     let file = info.file;
                     let line = info.line;
                     let track = self.get_or_create_thread_track(thread_name);
+                    self.span_tracks.insert(*id, track);
                     self.write_slice_begin(track, *timestamp, &fq_name, &fields, file, line);
                 }
             }
@@ -607,13 +637,17 @@ impl TraceEventSink for PerfettoFileSink {
                 thread_name,
             } => {
                 if self.span_info.contains_key(id) {
-                    let track = self.get_or_create_thread_track(thread_name);
+                    let track = self
+                        .span_tracks
+                        .remove(id)
+                        .unwrap_or_else(|| self.get_or_create_thread_track(thread_name));
                     self.write_slice_end(track, *timestamp);
                 }
             }
 
             TraceEvent::SpanClose { id, .. } => {
                 self.span_info.remove(id);
+                self.span_tracks.remove(id);
             }
 
             TraceEvent::Event {

--- a/monarch_hyperactor/src/endpoint.rs
+++ b/monarch_hyperactor/src/endpoint.rs
@@ -94,7 +94,7 @@ fn unpickle_from_part<'py>(py: Python<'py>, part: Part) -> PyResult<Bound<'py, P
 ///
 /// Used to select the appropriate telemetry metrics for each operation type.
 #[derive(Clone, Copy, Debug)]
-enum EndpointAdverb {
+pub(crate) enum EndpointAdverb {
     Call,
     CallOne,
     Choose,
@@ -193,6 +193,38 @@ impl Drop for RecordEndpointGuard {
                     ENDPOINT_STREAM_ERROR.add(1, attributes);
                 }
             }
+        }
+    }
+}
+
+/// Send-safe RAII guard for an OTEL-style endpoint span.
+///
+/// `tracing::Span::enter()` returns a `!Send` `Entered<'_>` guard that cannot
+/// cross `.await` points. We need the span to open on the Python thread (at
+/// call site) and close on whatever tokio thread delivers the response. To
+/// achieve that, we drive the `Layer::on_enter`/`on_exit` callbacks directly
+/// through the global dispatcher instead of holding an `Entered` guard.
+///
+/// The perfetto sink remembers which track a span entered on and replays the
+/// matching exit on that same track, so slices render on the originating
+/// (Python) thread regardless of where `Drop` fires.
+pub(crate) struct SpanGuard {
+    span: tracing::Span,
+}
+
+impl SpanGuard {
+    fn enter(span: tracing::Span) -> Self {
+        if let Some(id) = span.id() {
+            tracing::dispatcher::get_default(|d| d.enter(&id));
+        }
+        Self { span }
+    }
+}
+
+impl Drop for SpanGuard {
+    fn drop(&mut self) {
+        if let Some(id) = self.span.id() {
+            tracing::dispatcher::get_default(|d| d.exit(&id));
         }
     }
 }
@@ -375,8 +407,10 @@ fn value_collector(
     instance: Instance<PythonActor>,
     qualified_endpoint_name: Option<String>,
     adverb: EndpointAdverb,
+    span_guard: SpanGuard,
 ) -> PyResult<PyPythonTask> {
     Ok(PythonTask::new(async move {
+        let _span_guard = span_guard;
         let start = tokio::time::Instant::now();
 
         let record_guard = RecordEndpointGuard::new(start, method_name, 1, adverb);
@@ -508,6 +542,13 @@ pub(crate) trait Endpoint {
     /// Get the qualified endpoint name for error messages (if any).
     fn get_qualified_name(&self) -> Option<String>;
 
+    /// Open an OTEL-style span for an endpoint invocation. Each impl attaches
+    /// the fields the perfetto sink needs to synthesize the display name
+    /// (`{mesh}.{method}.{adverb}` for ActorEndpoint, `{call_name}.{adverb}`
+    /// for Remote). The adverb is the span name, so no formatting happens at
+    /// the call site — the sink formats only when it renders the slice.
+    fn enter_endpoint_span(&self, adverb: EndpointAdverb) -> SpanGuard;
+
     fn get_current_instance(&self, py: Python<'_>) -> PyResult<Instance<PythonActor>> {
         let context = get_context(py).call0()?;
         let py_instance: PyRef<PyInstance> = context.getattr("actor_instance")?.extract()?;
@@ -539,6 +580,8 @@ pub(crate) trait Endpoint {
         args: &Bound<'py, PyTuple>,
         kwargs: Option<&Bound<'py, PyDict>>,
     ) -> PyResult<Py<PyAny>> {
+        let span_guard = self.enter_endpoint_span(EndpointAdverb::Call);
+
         let extent = self.get_extent(py)?;
         let method_name = self.get_method_name().to_string();
 
@@ -559,6 +602,7 @@ pub(crate) trait Endpoint {
 
         let instance_for_task = instance.clone_for_py();
         let task: PyPythonTask = PythonTask::new(async move {
+            let _span_guard = span_guard;
             collect_valuemesh(
                 extent,
                 receiver,
@@ -581,7 +625,7 @@ pub(crate) trait Endpoint {
         args: &Bound<'py, PyTuple>,
         kwargs: Option<&Bound<'py, PyDict>>,
     ) -> PyResult<Py<PyAny>> {
-        let method_name = self.get_method_name();
+        let span_guard = self.enter_endpoint_span(EndpointAdverb::Choose);
 
         let instance = self.get_current_instance(py)?;
         let (port_ref, receiver) = self.open_response_port(&instance);
@@ -597,11 +641,12 @@ pub(crate) trait Endpoint {
 
         let task = value_collector(
             receiver,
-            method_name.to_string(),
+            self.get_method_name().to_string(),
             self.get_supervision_monitor(),
             instance.clone_for_py(),
             self.get_qualified_name(),
             EndpointAdverb::Choose,
+            span_guard,
         )?;
 
         wrap_in_future(py, task)
@@ -614,8 +659,9 @@ pub(crate) trait Endpoint {
         args: &Bound<'py, PyTuple>,
         kwargs: Option<&Bound<'py, PyDict>>,
     ) -> PyResult<Py<PyAny>> {
+        let span_guard = self.enter_endpoint_span(EndpointAdverb::CallOne);
+
         let extent = self.get_extent(py)?;
-        let method_name = self.get_method_name();
 
         if extent.num_ranks() != 1 {
             return Err(pyo3::exceptions::PyValueError::new_err(format!(
@@ -638,11 +684,12 @@ pub(crate) trait Endpoint {
 
         let task = value_collector(
             receiver,
-            method_name.to_string(),
+            self.get_method_name().to_string(),
             self.get_supervision_monitor(),
             instance.clone_for_py(),
             self.get_qualified_name(),
             EndpointAdverb::CallOne,
+            span_guard,
         )?;
 
         wrap_in_future(py, task)
@@ -796,6 +843,38 @@ impl Endpoint for ActorEndpoint {
 
     fn get_qualified_name(&self) -> Option<String> {
         Some(format!("{}.{}()", self.mesh_name, self.method.name()))
+    }
+
+    fn enter_endpoint_span(&self, adverb: EndpointAdverb) -> SpanGuard {
+        let mesh = self.mesh_name.as_str();
+        let method = self.method.name();
+        let span = match adverb {
+            EndpointAdverb::Call => tracing::info_span!(
+                target: "monarch_hyperactor::telemetry::endpoint",
+                "call",
+                mesh = mesh,
+                method = method,
+            ),
+            EndpointAdverb::CallOne => tracing::info_span!(
+                target: "monarch_hyperactor::telemetry::endpoint",
+                "call_one",
+                mesh = mesh,
+                method = method,
+            ),
+            EndpointAdverb::Choose => tracing::info_span!(
+                target: "monarch_hyperactor::telemetry::endpoint",
+                "choose",
+                mesh = mesh,
+                method = method,
+            ),
+            EndpointAdverb::Stream => tracing::info_span!(
+                target: "monarch_hyperactor::telemetry::endpoint",
+                "stream",
+                mesh = mesh,
+                method = method,
+            ),
+        };
+        SpanGuard::enter(span)
     }
 }
 
@@ -1055,6 +1134,39 @@ impl Endpoint for Remote {
 
     fn get_qualified_name(&self) -> Option<String> {
         None // Remote endpoints don't have qualified names
+    }
+
+    fn enter_endpoint_span(&self, adverb: EndpointAdverb) -> SpanGuard {
+        let call_name = Python::attach(|py| {
+            self.inner
+                .call_method0(py, "_call_name")
+                .ok()
+                .and_then(|v| v.extract::<String>(py).ok())
+        });
+        let call_name = call_name.as_deref().unwrap_or("");
+        let span = match adverb {
+            EndpointAdverb::Call => tracing::info_span!(
+                target: "monarch_hyperactor::telemetry::endpoint",
+                "call",
+                call_name = call_name,
+            ),
+            EndpointAdverb::CallOne => tracing::info_span!(
+                target: "monarch_hyperactor::telemetry::endpoint",
+                "call_one",
+                call_name = call_name,
+            ),
+            EndpointAdverb::Choose => tracing::info_span!(
+                target: "monarch_hyperactor::telemetry::endpoint",
+                "choose",
+                call_name = call_name,
+            ),
+            EndpointAdverb::Stream => tracing::info_span!(
+                target: "monarch_hyperactor::telemetry::endpoint",
+                "stream",
+                call_name = call_name,
+            ),
+        };
+        SpanGuard::enter(span)
     }
 }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #3539
* #3538
* #3537
* __->__ #3536

Currently we only instrument when an actor is running a user defined endpoint, but it is also useful for the caller to instrument that it is currently waiting for an endpoint

{F1988435200}

Differential Revision: [D101362276](https://our.internmc.facebook.com/intern/diff/D101362276/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D101362276/)!