### PR TITLE
[monarch] Automatically set execution id

### DIFF
--- a/monarch_extension/src/lib.rs
+++ b/monarch_extension/src/lib.rs
@@ -69,6 +69,13 @@ fn get_or_add_new_module<'py>(
 #[pyo3(name = "_rust_bindings")]
 pub fn mod_init(module: &Bound<'_, PyModule>) -> PyResult<()> {
     hyperactor_telemetry::trace::get_or_create_trace_id();
+
+    let py = module.py();
+    py.import("os")?.getattr("environ")?.set_item(
+        hyperactor_telemetry::env::HYPERACTOR_EXECUTION_ID_ENV,
+        hyperactor_telemetry::env::execution_id(),
+    )?;
+
     monarch_hyperactor::runtime::initialize(module.py())?;
     let runtime = monarch_hyperactor::runtime::get_tokio_runtime();
     ::hyperactor::initialize_with_log_prefix(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #3539
* #3538
* __->__ #3537
* #3536

We want the user to always be able to just run `expanse` and ensure that every monarch child process is captured in the trace by having the same execution id.

We do not want to have the user manually set this.

We also need to make a call to update the Python os.environ dict

Differential Revision: [D101370171](https://our.internmc.facebook.com/intern/diff/D101370171/)