### PR TITLE
[monarch] Use Actor name as thread track for user perfetto

### DIFF
--- a/hyperactor_telemetry/src/sinks/perfetto.rs
+++ b/hyperactor_telemetry/src/sinks/perfetto.rs
@@ -86,6 +86,7 @@ pub const USER_TELEMETRY_PREFIX: &str = "monarch_hyperactor::telemetry";
 /// display name synthesized as `{method}.{span_name}`, where `span_name`
 /// is the adverb (e.g., "call", "call_one", "choose").
 pub const ENDPOINT_TELEMETRY_TARGET: &str = "monarch_hyperactor::telemetry::endpoint";
+const ACTOR_ID_FIELD: &str = "actor_id";
 
 /// Controls what events are captured in Perfetto traces.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
@@ -183,6 +184,7 @@ struct SpanInfo {
     fields: TraceFields,
     file: Option<&'static str>,
     line: Option<u32>,
+    prefer_actor_track: bool,
 }
 
 /// String interning for Perfetto trace compression.
@@ -224,8 +226,8 @@ pub struct PerfettoFileSink {
     event_names: InternedStrings,
     annotation_names: InternedStrings,
     span_info: HashMap<u64, SpanInfo>,
-    /// Maps thread names to track ids
-    thread_tracks: HashMap<String, u64>,
+    /// Maps logical track names (thread names or actor ids) to track ids.
+    named_tracks: HashMap<String, u64>,
     /// Maps span id to the track it entered on, so that certain Exit/Close events
     /// are emitted on the same track even when they fire from a different thread.
     span_tracks: HashMap<u64, u64>,
@@ -282,7 +284,7 @@ impl PerfettoFileSink {
             event_names: InternedStrings::default(),
             annotation_names: InternedStrings::default(),
             span_info: HashMap::new(),
-            thread_tracks: HashMap::new(),
+            named_tracks: HashMap::new(),
             span_tracks: HashMap::new(),
             process_track: 0,
             pid,
@@ -347,23 +349,23 @@ impl PerfettoFileSink {
         track_id
     }
 
-    fn get_or_create_thread_track(&mut self, thread_name: &str) -> u64 {
-        if let Some(&track) = self.thread_tracks.get(thread_name) {
+    fn get_or_create_named_track(&mut self, track_name: &str) -> u64 {
+        if let Some(&track) = self.named_tracks.get(track_name) {
             return track;
         }
 
         let track_id = self.next_track_id();
-        let tid = self.thread_tracks.len() as i32 + 1;
+        let tid = self.named_tracks.len() as i32 + 1;
 
         let packet = TracePacket {
             data: Some(Data::TrackDescriptor(TrackDescriptor {
                 uuid: Some(track_id),
                 parent_uuid: Some(self.process_track),
-                static_or_dynamic_name: Some(StaticOrDynamicName::Name(thread_name.to_string())),
+                static_or_dynamic_name: Some(StaticOrDynamicName::Name(track_name.to_string())),
                 thread: Some(ThreadDescriptor {
                     pid: Some(self.pid),
                     tid: Some(tid),
-                    thread_name: Some(thread_name.to_string()),
+                    thread_name: Some(track_name.to_string()),
                     ..Default::default()
                 }),
                 ..Default::default()
@@ -375,9 +377,39 @@ impl PerfettoFileSink {
         };
         self.write_packet(&packet);
 
-        self.thread_tracks.insert(thread_name.to_string(), track_id);
+        self.named_tracks.insert(track_name.to_string(), track_id);
 
         track_id
+    }
+
+    fn actor_track_name<'a>(fields: &'a TraceFields) -> Option<&'a str> {
+        match get_field(fields, ACTOR_ID_FIELD) {
+            Some(FieldValue::Str(actor_id) | FieldValue::Debug(actor_id))
+                if !actor_id.is_empty() =>
+            {
+                Some(Self::short_actor_track_name(actor_id))
+            }
+            _ => None,
+        }
+    }
+
+    fn short_actor_track_name(actor_id: &str) -> &str {
+        actor_id
+            .rsplit_once(',')
+            .map(|(_, actor_name_and_pid)| actor_name_and_pid)
+            .unwrap_or(actor_id)
+    }
+
+    fn preferred_track_name<'a>(
+        prefer_actor_track: bool,
+        fields: &'a TraceFields,
+        thread_name: &'a str,
+    ) -> &'a str {
+        if prefer_actor_track {
+            Self::actor_track_name(fields).unwrap_or(thread_name)
+        } else {
+            thread_name
+        }
     }
 
     fn write_packet(&mut self, packet: &TracePacket) {
@@ -611,6 +643,7 @@ impl TraceEventSink for PerfettoFileSink {
                         fields: fields.clone(),
                         file: *file,
                         line: *line,
+                        prefer_actor_track: target.starts_with(USER_TELEMETRY_PREFIX),
                     },
                 );
             }
@@ -625,7 +658,11 @@ impl TraceEventSink for PerfettoFileSink {
                     let fields = info.fields.clone();
                     let file = info.file;
                     let line = info.line;
-                    let track = self.get_or_create_thread_track(thread_name);
+                    let prefer_actor_track = info.prefer_actor_track;
+                    let track_name =
+                        Self::preferred_track_name(prefer_actor_track, &fields, thread_name)
+                            .to_string();
+                    let track = self.get_or_create_named_track(&track_name);
                     self.span_tracks.insert(*id, track);
                     self.write_slice_begin(track, *timestamp, &fq_name, &fields, file, line);
                 }
@@ -636,11 +673,16 @@ impl TraceEventSink for PerfettoFileSink {
                 timestamp,
                 thread_name,
             } => {
-                if self.span_info.contains_key(id) {
+                if let Some(info) = self.span_info.get(id) {
+                    let fields = info.fields.clone();
+                    let prefer_actor_track = info.prefer_actor_track;
+                    let track_name =
+                        Self::preferred_track_name(prefer_actor_track, &fields, thread_name)
+                            .to_string();
                     let track = self
                         .span_tracks
                         .remove(id)
-                        .unwrap_or_else(|| self.get_or_create_thread_track(thread_name));
+                        .unwrap_or_else(|| self.get_or_create_named_track(&track_name));
                     self.write_slice_end(track, *timestamp);
                 }
             }
@@ -674,7 +716,11 @@ impl TraceEventSink for PerfettoFileSink {
                     format!("{}::{}", target, name)
                 };
 
-                let track = self.get_or_create_thread_track(thread_name);
+                let track = self.get_or_create_named_track(Self::preferred_track_name(
+                    target.starts_with(USER_TELEMETRY_PREFIX),
+                    fields,
+                    thread_name,
+                ));
                 self.write_instant(track, *timestamp, &display_name, fields);
             }
         }

--- a/monarch_hyperactor/src/endpoint.rs
+++ b/monarch_hyperactor/src/endpoint.rs
@@ -18,6 +18,7 @@ use hyperactor::accum::ReducerFactory;
 use hyperactor::accum::ReducerSpec;
 use hyperactor::mailbox::OncePortReceiver;
 use hyperactor::mailbox::PortReceiver;
+use hyperactor::reference::ActorId;
 use hyperactor_mesh::sel;
 use hyperactor_mesh::value_mesh::ValueOverlay;
 use hyperactor_mesh::value_mesh::rle;
@@ -545,9 +546,10 @@ pub(crate) trait Endpoint {
     /// Open an OTEL-style span for an endpoint invocation. Each impl attaches
     /// the fields the perfetto sink needs to synthesize the display name
     /// (`{mesh}.{method}.{adverb}` for ActorEndpoint, `{call_name}.{adverb}`
-    /// for Remote). The adverb is the span name, so no formatting happens at
-    /// the call site — the sink formats only when it renders the slice.
-    fn enter_endpoint_span(&self, adverb: EndpointAdverb) -> SpanGuard;
+    /// for Remote) and route the slice to an actor-specific track. The adverb is the span name,
+    /// so no formatting happens at the call site and the sink formats only when
+    /// it renders the slice.
+    fn enter_endpoint_span(&self, adverb: EndpointAdverb, actor_id: &ActorId) -> SpanGuard;
 
     fn get_current_instance(&self, py: Python<'_>) -> PyResult<Instance<PythonActor>> {
         let context = get_context(py).call0()?;
@@ -580,12 +582,11 @@ pub(crate) trait Endpoint {
         args: &Bound<'py, PyTuple>,
         kwargs: Option<&Bound<'py, PyDict>>,
     ) -> PyResult<Py<PyAny>> {
-        let span_guard = self.enter_endpoint_span(EndpointAdverb::Call);
+        let instance = self.get_current_instance(py)?;
+        let span_guard = self.enter_endpoint_span(EndpointAdverb::Call, instance.self_id());
 
         let extent = self.get_extent(py)?;
         let method_name = self.get_method_name().to_string();
-
-        let instance = self.get_current_instance(py)?;
         let (port_ref, receiver) = self.open_reduce_response_port(&instance);
 
         let supervision_monitor = self.get_supervision_monitor();
@@ -625,9 +626,8 @@ pub(crate) trait Endpoint {
         args: &Bound<'py, PyTuple>,
         kwargs: Option<&Bound<'py, PyDict>>,
     ) -> PyResult<Py<PyAny>> {
-        let span_guard = self.enter_endpoint_span(EndpointAdverb::Choose);
-
         let instance = self.get_current_instance(py)?;
+        let span_guard = self.enter_endpoint_span(EndpointAdverb::Choose, instance.self_id());
         let (port_ref, receiver) = self.open_response_port(&instance);
 
         self.send_message(
@@ -659,8 +659,6 @@ pub(crate) trait Endpoint {
         args: &Bound<'py, PyTuple>,
         kwargs: Option<&Bound<'py, PyDict>>,
     ) -> PyResult<Py<PyAny>> {
-        let span_guard = self.enter_endpoint_span(EndpointAdverb::CallOne);
-
         let extent = self.get_extent(py)?;
 
         if extent.num_ranks() != 1 {
@@ -671,6 +669,7 @@ pub(crate) trait Endpoint {
         }
 
         let instance = self.get_current_instance(py)?;
+        let span_guard = self.enter_endpoint_span(EndpointAdverb::CallOne, instance.self_id());
         let (port_ref, receiver) = self.open_response_port(&instance);
 
         self.send_message(
@@ -845,7 +844,7 @@ impl Endpoint for ActorEndpoint {
         Some(format!("{}.{}()", self.mesh_name, self.method.name()))
     }
 
-    fn enter_endpoint_span(&self, adverb: EndpointAdverb) -> SpanGuard {
+    fn enter_endpoint_span(&self, adverb: EndpointAdverb, actor_id: &ActorId) -> SpanGuard {
         let mesh = self.mesh_name.as_str();
         let method = self.method.name();
         let span = match adverb {
@@ -854,24 +853,28 @@ impl Endpoint for ActorEndpoint {
                 "call",
                 mesh = mesh,
                 method = method,
+                actor_id = %actor_id,
             ),
             EndpointAdverb::CallOne => tracing::info_span!(
                 target: "monarch_hyperactor::telemetry::endpoint",
                 "call_one",
                 mesh = mesh,
                 method = method,
+                actor_id = %actor_id,
             ),
             EndpointAdverb::Choose => tracing::info_span!(
                 target: "monarch_hyperactor::telemetry::endpoint",
                 "choose",
                 mesh = mesh,
                 method = method,
+                actor_id = %actor_id,
             ),
             EndpointAdverb::Stream => tracing::info_span!(
                 target: "monarch_hyperactor::telemetry::endpoint",
                 "stream",
                 mesh = mesh,
                 method = method,
+                actor_id = %actor_id,
             ),
         };
         SpanGuard::enter(span)
@@ -1136,7 +1139,7 @@ impl Endpoint for Remote {
         None // Remote endpoints don't have qualified names
     }
 
-    fn enter_endpoint_span(&self, adverb: EndpointAdverb) -> SpanGuard {
+    fn enter_endpoint_span(&self, adverb: EndpointAdverb, actor_id: &ActorId) -> SpanGuard {
         let call_name = Python::attach(|py| {
             self.inner
                 .call_method0(py, "_call_name")
@@ -1149,21 +1152,25 @@ impl Endpoint for Remote {
                 target: "monarch_hyperactor::telemetry::endpoint",
                 "call",
                 call_name = call_name,
+                actor_id = %actor_id,
             ),
             EndpointAdverb::CallOne => tracing::info_span!(
                 target: "monarch_hyperactor::telemetry::endpoint",
                 "call_one",
                 call_name = call_name,
+                actor_id = %actor_id,
             ),
             EndpointAdverb::Choose => tracing::info_span!(
                 target: "monarch_hyperactor::telemetry::endpoint",
                 "choose",
                 call_name = call_name,
+                actor_id = %actor_id,
             ),
             EndpointAdverb::Stream => tracing::info_span!(
                 target: "monarch_hyperactor::telemetry::endpoint",
                 "stream",
                 call_name = call_name,
+                actor_id = %actor_id,
             ),
         };
         SpanGuard::enter(span)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #3539
* __->__ #3538
* #3537
* #3536

This makes a lot more sense for users who just want to know what their Actors are up to

Differential Revision: [D101569866](https://our.internmc.facebook.com/intern/diff/D101569866/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D101569866/)!