### PR TITLE
populate MeshFailure mesh name on direct actor-handled path

### DIFF
--- a/hyperactor/src/supervision.rs
+++ b/hyperactor/src/supervision.rs
@@ -16,6 +16,23 @@
 //!   for structured failure attribution. In particular, if a
 //!   failed parent wraps a stopped child event, the stopped child
 //!   remains the root cause.
+//!
+//! ## Supervision rendering invariants (SR-*)
+//!
+//! - **SR-1 (`display_name` is presentation-only).**
+//!   `ActorSupervisionEvent.display_name` is rendered display text.
+//!   Downstream code must not parse it to recover structured data.
+//!
+//! - **SR-2 (rendering falls back to stable ids).**
+//!   `ActorSupervisionEvent::Display` and its helpers render
+//!   `display_name` when present and otherwise fall back to
+//!   `actor_id.to_string()`. A given actor mention renders one or
+//!   the other, not both.
+//!
+//! - **SR-3 (no rendered-output parsing back into structure).**
+//!   Structured data must not be reconstructed by parsing formatted
+//!   `display_name`, identifier text, or other rendered output from
+//!   this path.
 
 use std::fmt;
 use std::fmt::Debug;

--- a/hyperactor_mesh/src/proc_mesh.rs
+++ b/hyperactor_mesh/src/proc_mesh.rs
@@ -1387,6 +1387,17 @@ impl view::RankedSliceable for ProcMeshRef {
 ///
 /// The supervision display name format is `{instance}.<{module}.{ClassName} {mesh_name}>`.
 /// Returns `"Python<ClassName>"` if the format matches, `None` otherwise.
+///
+/// Scope note: this function is used only by telemetry
+/// (`MeshEvent.class`), which needs the Python class as a
+/// structured string and has no structured carrier today. It is
+/// not on the supervision rendering path.
+///
+/// TODO: retained only because the telemetry path needs a
+/// structured Python-class string and this is the only available
+/// source. A follow-up should add a structured carrier (e.g. an
+/// `actor_class` field on `ActorSupervisionEvent`, or a dedicated
+/// telemetry-side field) and delete this function.
 fn python_class_from_supervision_name(sdn: &str) -> Option<String> {
     let inner = sdn.rsplit_once('<')?.1.strip_suffix('>')?;
     let qualified = inner.split_whitespace().next()?;

--- a/hyperactor_mesh/src/supervision.rs
+++ b/hyperactor_mesh/src/supervision.rs
@@ -7,6 +7,22 @@
  */
 
 //! Messages used in supervision of actor meshes.
+//!
+//! ## Mesh-name propagation
+//!
+//! When a `MeshFailure` is constructed for a supervision event
+//! whose constructing site has the mesh name locally in scope, the
+//! mesh name is carried on `MeshFailure.actor_mesh_name`. The
+//! constructing site does not perform a lookup to obtain the mesh
+//! name; if the mesh name is not locally available at the site,
+//! `None` is correct. `MeshFailure::Display` surfaces the mesh
+//! name as an `on mesh "{name}"` segment when `actor_mesh_name`
+//! is populated; stable identifiers continue to appear in detail
+//! segments where the renderer already includes them.
+//! Python-binding-specific plumbing for this carrier — how a
+//! Python-spawned actor ends up with a mesh base-name string to
+//! supply — lives in `monarch_hyperactor/src/actor.rs`
+//! (`PythonActorParams.mesh_base_name`).
 
 use hyperactor::Bind;
 use hyperactor::Unbind;
@@ -22,7 +38,11 @@ use typeuri::Named;
 /// actor.
 #[derive(Clone, Debug, Serialize, Deserialize, Named, PartialEq, Bind, Unbind)]
 pub struct MeshFailure {
-    /// Name of the mesh which the event originated from.
+    /// Mesh name carried by the `MeshFailure` construction site,
+    /// when locally available. On the direct actor-handled path
+    /// this is the observing PythonActor's mesh base name. On
+    /// controller-owned paths this is the monitored mesh name
+    /// supplied by the controller path.
     pub actor_mesh_name: Option<String>,
     /// The supervision event on an actor located at mesh + rank.
     pub event: ActorSupervisionEvent,
@@ -81,4 +101,251 @@ impl std::fmt::Display for MeshFailure {
 pub(crate) enum Unhealthy {
     StreamClosed(MeshFailure), // Event stream closed
     Crashed(MeshFailure),      // Bad health event received
+}
+
+#[cfg(test)]
+mod tests {
+    //! Tests that pin `MeshFailure::Display` rendering. The
+    //! `proof_*` tests capture exact rendered strings for three
+    //! supervision-path shapes, paired for each path as
+    //! `MeshFailure { actor_mesh_name: None, ... }` vs.
+    //! `MeshFailure { actor_mesh_name: Some(...), ... }`, so the
+    //! "with mesh name" and "without mesh name" rendered output is
+    //! locked down and any regression surfaces here.
+    //!
+    //! The `assert_eq!` literals capture the `ActorId::Display`
+    //! output of the checkout the tests were generated against. If
+    //! the identifier encoding changes (e.g. a reference-stack
+    //! refactor lands in the same tree), the literals need to be
+    //! regenerated on the new baseline — the mesh-name-rendering
+    //! behavior this module tests is independent of the id format.
+
+    use hyperactor::actor::ActorErrorKind;
+    use hyperactor::actor::ActorStatus;
+    use hyperactor::channel::ChannelAddr;
+    use hyperactor::reference;
+
+    use super::*;
+
+    fn test_event(name: &str, display_name: Option<String>) -> ActorSupervisionEvent {
+        let proc_id = reference::ProcId::with_name(ChannelAddr::Local(0), "test_proc");
+        ActorSupervisionEvent::new(
+            proc_id.actor_id(name, 0),
+            display_name,
+            ActorStatus::Failed(ActorErrorKind::Generic("boom".to_string())),
+            None,
+        )
+    }
+
+    // `MeshFailure::Display` renders the mesh name in its prose
+    // when `actor_mesh_name` is Some, producing the "on mesh \"{name}\""
+    // segment alongside the stable id-bearing event.
+    #[test]
+    fn mesh_failure_display_renders_mesh_name_when_populated() {
+        let failure = MeshFailure {
+            actor_mesh_name: Some("training".to_string()),
+            event: test_event("actor_a", None),
+            crashed_ranks: vec![],
+        };
+        let rendered = format!("{}", failure);
+        assert!(
+            rendered.contains("on mesh \"training\""),
+            "expected rendered output to contain `on mesh \"training\"`; got: {rendered}"
+        );
+    }
+
+    // When `actor_mesh_name` is None, the formatter omits the mesh
+    // segment entirely — the absence degrades gracefully without
+    // changing surrounding prose.
+    #[test]
+    fn mesh_failure_display_omits_mesh_segment_when_none() {
+        let failure = MeshFailure {
+            actor_mesh_name: None,
+            event: test_event("actor_a", None),
+            crashed_ranks: vec![],
+        };
+        let rendered = format!("{}", failure);
+        assert!(
+            !rendered.contains("on mesh"),
+            "expected no `on mesh` segment when actor_mesh_name is None; got: {rendered}"
+        );
+    }
+
+    // When both mesh name and the event's Python-class display_name
+    // are populated, the rendered prose includes both, producing a
+    // user-readable description alongside the stable identifier
+    // carried in the event.
+    #[test]
+    fn mesh_failure_display_renders_mesh_and_python_class() {
+        let failure = MeshFailure {
+            actor_mesh_name: Some("training".to_string()),
+            event: test_event(
+                "actor_a",
+                Some("instance0.<my_module.Philosopher training>".to_string()),
+            ),
+            crashed_ranks: vec![],
+        };
+        let rendered = format!("{}", failure);
+        assert!(
+            rendered.contains("on mesh \"training\""),
+            "expected mesh name segment; got: {rendered}"
+        );
+        assert!(
+            rendered.contains("my_module.Philosopher"),
+            "expected Python-class segment from display_name; got: {rendered}"
+        );
+    }
+
+    // Shared fixture for the proofs: the exact synthesized event shape
+    // that `GlobalClientActor::handle_undeliverable_message` produces
+    // (`hyperactor_mesh/src/global_context.rs:278`): display_name =
+    // None, actor_status = generic_failure("message not delivered: ...").
+    fn undeliverable_synthesized_event() -> ActorSupervisionEvent {
+        let proc_id = reference::ProcId::with_name(ChannelAddr::Local(0), "worker_proc");
+        ActorSupervisionEvent::new(
+            proc_id.actor_id("dead_actor", 0),
+            None, // synthesized site has no PythonActor context; display_name stays None
+            ActorStatus::generic_failure(
+                "message not delivered: undeliverable message error: ... \
+                 error: broken link: message returned to global root client"
+                    .to_string(),
+            ),
+            None,
+        )
+    }
+
+    // Root-client undeliverable path.
+    //
+    // Transport bounces an undeliverable back to the root client;
+    // `GlobalClientActor::handle_undeliverable_message` synthesizes
+    // an `ActorSupervisionEvent` with `display_name = None` and
+    // `"message not delivered: ..."` status. That event propagates
+    // to a `PythonActor::handle_supervision_event`, which wraps it
+    // in a `MeshFailure`. At the wrap site the observing
+    // `PythonActor`'s `mesh_base_name` is the mesh name locally
+    // available; this test pins what `MeshFailure::Display` renders
+    // when `actor_mesh_name` is `None` vs. `Some("training")` for
+    // that exact synthesized inner event shape.
+    #[test]
+    fn proof_motivating_incident_root_client_undeliverable() {
+        let without_mesh_name = MeshFailure {
+            actor_mesh_name: None,
+            event: undeliverable_synthesized_event(),
+            crashed_ranks: vec![],
+        };
+        let with_mesh_name = MeshFailure {
+            actor_mesh_name: Some("training".to_string()),
+            event: undeliverable_synthesized_event(),
+            crashed_ranks: vec![],
+        };
+        let expected_without = "failure with event: Supervision event: \
+                                actor local:0,worker_proc,dead_actor[0] failed:\n  \
+                                message not delivered: undeliverable message error: \
+                                ... error: broken link: message returned to global \
+                                root client";
+        let expected_with = "failure on mesh \"training\" with event: \
+                             Supervision event: actor \
+                             local:0,worker_proc,dead_actor[0] failed:\n  \
+                             message not delivered: undeliverable message error: \
+                             ... error: broken link: message returned to global \
+                             root client";
+        assert_eq!(format!("{}", without_mesh_name), expected_without);
+        assert_eq!(format!("{}", with_mesh_name), expected_with);
+
+        // Note: the inner event here has `display_name = None` (the
+        // synthesis site at `global_context.rs` has no PythonActor
+        // context to populate it), so the inner actor mention
+        // renders via raw `ActorId` text. That is a separate concern
+        // from mesh-name plumbing.
+    }
+
+    // Direct actor-handled panic path.
+    //
+    // A `PythonActor` panics in a handler. `Proc::stop_actor`
+    // constructs the `ActorSupervisionEvent` using
+    // `actor.display_name()`, which on a `PythonActor` is the
+    // Python-class-bearing `str(PyInstance)`. The event reaches a
+    // supervising `PythonActor` through the propagation chain,
+    // which wraps it in a `MeshFailure` at
+    // `monarch_hyperactor/src/actor.rs:1072`. At that wrap site the
+    // observing `PythonActor`'s `mesh_base_name` is the mesh name
+    // locally available; this test pins what
+    // `MeshFailure::Display` renders when `actor_mesh_name` is
+    // `None` vs. `Some("training")` for a panicked-event inner
+    // shape that already carries a Python-class `display_name`.
+    #[test]
+    fn proof_direct_actor_handled_panic() {
+        let panicked_event = {
+            let proc_id = reference::ProcId::with_name(ChannelAddr::Local(0), "worker_proc");
+            ActorSupervisionEvent::new(
+                proc_id.actor_id("philosopher_1", 0),
+                // `Proc::stop_actor` populates this via
+                // `actor.display_name()` on a PythonActor — which
+                // returns the Python-class-bearing `str(PyInstance)`.
+                Some("instance0.<monarch_examples.dining.Philosopher training>".to_string()),
+                ActorStatus::Failed(ActorErrorKind::Generic(
+                    "IndexError: list index out of range".to_string(),
+                )),
+                None,
+            )
+        };
+        let without_mesh_name = MeshFailure {
+            actor_mesh_name: None,
+            event: panicked_event.clone(),
+            crashed_ranks: vec![],
+        };
+        let with_mesh_name = MeshFailure {
+            actor_mesh_name: Some("training".to_string()),
+            event: panicked_event,
+            crashed_ranks: vec![],
+        };
+        let expected_without = "failure with event: Supervision event: actor \
+                                instance0.<monarch_examples.dining.Philosopher \
+                                training> failed:\n  \
+                                IndexError: list index out of range";
+        let expected_with = "failure on mesh \"training\" with event: \
+                             Supervision event: actor \
+                             instance0.<monarch_examples.dining.Philosopher \
+                             training> failed:\n  \
+                             IndexError: list index out of range";
+        assert_eq!(format!("{}", without_mesh_name), expected_without);
+        assert_eq!(format!("{}", with_mesh_name), expected_with);
+    }
+
+    // Controller-unreachable path.
+    //
+    // When the controller for a mesh becomes unreachable, code in
+    // `actor_mesh.rs` synthesizes a `MeshFailure` with
+    // `actor_mesh_name: Some(self.id().to_string())` — the slot is
+    // already populated on this path, and the inner event's
+    // `display_name` is `None` because the construction site has
+    // no `PythonActor` context. This test pins the rendered string
+    // for that exact shape.
+    #[test]
+    fn proof_controller_unreachable() {
+        let controller_timeout_event = {
+            let proc_id = reference::ProcId::with_name(ChannelAddr::Local(0), "controller_proc");
+            ActorSupervisionEvent::new(
+                proc_id.actor_id("training_controller", 0),
+                None,
+                ActorStatus::generic_failure(
+                    "timed out reaching controller ... Assuming controller's proc is dead"
+                        .to_string(),
+                ),
+                None,
+            )
+        };
+        let failure = MeshFailure {
+            actor_mesh_name: Some("training".to_string()),
+            event: controller_timeout_event,
+            crashed_ranks: vec![],
+        };
+        let expected = "failure on mesh \"training\" with event: \
+                        Supervision event: actor \
+                        local:0,controller_proc,training_controller[0] \
+                        failed:\n  \
+                        timed out reaching controller ... Assuming \
+                        controller's proc is dead";
+        assert_eq!(format!("{}", failure), expected);
+    }
 }

--- a/monarch_hyperactor/src/actor.rs
+++ b/monarch_hyperactor/src/actor.rs
@@ -545,6 +545,15 @@ pub struct PythonActor {
     spawn_point: OnceLock<Option<Point>>,
     /// Initial message to process during PythonActor::init.
     init_message: Option<PythonMessage>,
+    /// User-provided mesh base-name string plumbed from
+    /// `PythonActorParams`. This is the base name the caller
+    /// supplied when the mesh was spawned, narrowly used to populate
+    /// `MeshFailure.actor_mesh_name` on the direct actor-handled
+    /// supervision path without a lookup. It is not actor display
+    /// text (`display_name` handles that) and it is not a general
+    /// side channel; downstream code must not consume this field for
+    /// any other purpose.
+    mesh_base_name: Option<String>,
 }
 
 impl PythonActor {
@@ -552,6 +561,7 @@ impl PythonActor {
         actor_type: PickledPyObject,
         init_message: Option<PythonMessage>,
         spawn_point: Option<Point>,
+        mesh_base_name: Option<String>,
     ) -> Result<Self, anyhow::Error> {
         let use_queue_dispatch = hyperactor_config::global::get(ACTOR_QUEUE_DISPATCH);
 
@@ -585,6 +595,7 @@ impl PythonActor {
                     dispatch_mode,
                     spawn_point: OnceLock::from(spawn_point),
                     init_message,
+                    mesh_base_name,
                 })
             },
         )?)
@@ -648,6 +659,7 @@ impl PythonActor {
             actor_type,
             Some(init_message),
             Some(extent!().point_of_rank(0).unwrap()),
+            None, // root client actor has no user-facing mesh name
         )
         .expect("create client PythonActor");
 
@@ -1070,7 +1082,10 @@ impl Actor for PythonActor {
         self.handle(
             &cx,
             MeshFailure {
-                actor_mesh_name: None,
+                // Populate the mesh name from the base-name string
+                // plumbed through PythonActorParams at spawn time —
+                // no lookup.
+                actor_mesh_name: self.mesh_base_name.clone(),
                 event: event.clone(),
                 crashed_ranks: vec![],
             },
@@ -1086,13 +1101,29 @@ pub struct PythonActorParams {
     actor_type: PickledPyObject,
     // Python message to process as part of the actor initialization.
     init_message: Option<PythonMessage>,
+    // User-provided mesh base-name string under which this actor
+    // was spawned. The base name the caller passed when the mesh
+    // was spawned, plumbed through `PythonActor` narrowly to
+    // populate `MeshFailure.actor_mesh_name` on the direct
+    // actor-handled supervision path without a lookup. It is not
+    // actor display text (`display_name` handles that) and it is
+    // not a general side channel; downstream code must not consume
+    // this field for any other purpose. Kept separate from
+    // `supervision_display_name`, which is a rendered supervision
+    // display string passed through `spawn_with_name(...)`.
+    mesh_base_name: Option<String>,
 }
 
 impl PythonActorParams {
-    pub(crate) fn new(actor_type: PickledPyObject, init_message: Option<PythonMessage>) -> Self {
+    pub(crate) fn new(
+        actor_type: PickledPyObject,
+        init_message: Option<PythonMessage>,
+        mesh_base_name: Option<String>,
+    ) -> Self {
         Self {
             actor_type,
             init_message,
+            mesh_base_name,
         }
     }
 }
@@ -1105,11 +1136,12 @@ impl RemoteSpawn for PythonActor {
         PythonActorParams {
             actor_type,
             init_message,
+            mesh_base_name,
         }: PythonActorParams,
         environment: Flattrs,
     ) -> Result<Self, anyhow::Error> {
         let spawn_point = environment.get(CAST_POINT);
-        Self::new(actor_type, init_message, spawn_point)
+        Self::new(actor_type, init_message, spawn_point, mesh_base_name)
     }
 }
 

--- a/monarch_hyperactor/src/actor_mesh.rs
+++ b/monarch_hyperactor/src/actor_mesh.rs
@@ -893,7 +893,7 @@ mod tests {
             .spawn::<PythonActor, _>(
                 instance,
                 "test_actors",
-                &PythonActorParams::new(pickled_type, None),
+                &PythonActorParams::new(pickled_type, None, None),
             )
             .await
             .unwrap();

--- a/monarch_hyperactor/src/proc.rs
+++ b/monarch_hyperactor/src/proc.rs
@@ -99,7 +99,7 @@ impl PyProc {
             Ok(PythonActorHandle {
                 inner: proc.spawn(
                     name.as_deref().unwrap_or("anon"),
-                    PythonActor::new(pickled_type, None, None)?,
+                    PythonActor::new(pickled_type, None, None, None)?,
                 )?,
             })
         })
@@ -118,7 +118,7 @@ impl PyProc {
             inner: signal_safe_block_on(py, async move {
                 proc.spawn(
                     name.as_deref().unwrap_or("anon"),
-                    PythonActor::new(pickled_type, None, None)?,
+                    PythonActor::new(pickled_type, None, None, None)?,
                 )
             })
             .map_err(|e| PyRuntimeError::new_err(e.to_string()))??,

--- a/monarch_hyperactor/src/proc_mesh.rs
+++ b/monarch_hyperactor/src/proc_mesh.rs
@@ -69,11 +69,11 @@ impl PyProcMesh {
 #[pymethods]
 impl PyProcMesh {
     #[staticmethod]
-    #[pyo3(signature = (proc_mesh, instance, name, actor, init_message, emulated, supervision_display_name = None))]
+    #[pyo3(signature = (proc_mesh, instance, mesh_base_name, actor, init_message, emulated, supervision_display_name = None))]
     fn spawn_async(
         proc_mesh: &mut PyShared,
         instance: &PyInstance,
-        name: String,
+        mesh_base_name: String,
         actor: Py<PyType>,
         init_message: &mut PendingMessage,
         emulated: bool,
@@ -93,16 +93,26 @@ impl PyProcMesh {
                 let pickled_type = PickledPyObject::pickle(actor.bind(py).as_any())?;
                 Ok((
                     slf.mesh_ref()?.clone(),
-                    PythonActorParams::new(pickled_type, Some(init_message)),
+                    // Plumb `mesh_base_name` into the actor so the
+                    // direct actor-handled supervision path can
+                    // populate `MeshFailure.actor_mesh_name` without
+                    // a lookup. Kept separate from
+                    // `supervision_display_name` below (rendered
+                    // supervision display string).
+                    PythonActorParams::new(
+                        pickled_type,
+                        Some(init_message),
+                        Some(mesh_base_name.clone()),
+                    ),
                 ))
             })
             .await?;
 
-            let full_name = hyperactor_mesh::Name::new(name).unwrap();
+            let mesh_name = hyperactor_mesh::Name::new(mesh_base_name).unwrap();
             let actor_mesh = proc_mesh
                 .spawn_with_name(
                     instance.deref(),
-                    full_name,
+                    mesh_name,
                     &params,
                     supervision_display_name,
                     false,

--- a/monarch_hyperactor/src/supervision.rs
+++ b/monarch_hyperactor/src/supervision.rs
@@ -6,6 +6,13 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+//! Python-facing supervision boundary. `SupervisionError`'s
+//! pyclass shape is unchanged by the mesh-name plumbing in this
+//! diff; any rendered improvement users see in the Python
+//! exception comes from the upstream `Display` chain once mesh
+//! name and Python-class `display_name` are populated by their
+//! producer sites.
+
 use async_trait::async_trait;
 use hyperactor::Instance;
 use hyperactor_mesh::supervision::MeshFailure;

--- a/python/monarch/_rust_bindings/monarch_hyperactor/proc_mesh.pyi
+++ b/python/monarch/_rust_bindings/monarch_hyperactor/proc_mesh.pyi
@@ -22,7 +22,7 @@ class ProcMesh:
     def spawn_async(
         proc_mesh: Shared["ProcMesh"],
         instance: Instance,
-        name: str,
+        mesh_base_name: str,
         actor: Type["Actor"],
         init_message: PendingMessage,
         emulated: bool,


### PR DESCRIPTION
Summary:
this diff fills a narrow gap in `MeshFailure` on the direct actor-handled supervision path.

on that path, a `PythonActor` receives an `ActorSupervisionEvent` in `handle_supervision_event(...)` and directly wraps it in a `MeshFailure` for Python-facing handling. before this diff, that wrapper always carried `actor_mesh_name: None`, so the outer rendered message was just `failure with event: ...`.

this change threads the user-provided mesh base name from Python spawn through `PythonActorParams` into `PythonActor`, and uses that actor-local value to populate `MeshFailure.actor_mesh_name` at the direct wrap site without a lookup. as a result, the existing `MeshFailure::Display` chain can now render `failure on mesh "{name}" with event: ...` on that path. the inner `ActorSupervisionEvent` is otherwise unchanged.

scope is intentionally narrow. this diff does not introduce event-level attribution, does not change `SupervisionError`’s pyclass shape, does not change supervision ownership or routing, and does not attempt to improve mailbox logs or root-client bounce semantics. it only teaches the outer `MeshFailure` wrapper to name the observing mesh on the direct actor-handled path once that mesh base name has been plumbed into the actor.

the diff also tightens local documentation so `MeshFailure.actor_mesh_name` is described in terms of the construction site that supplies it, and adds rendering tests that pin the before/after `MeshFailure::Display` output for three concrete shapes: a root-client undeliverable wrapped by a supervising Python actor, a direct actor-handled panic, and the controller-unreachable baseline.

Differential Revision: D102011842


