### PR TITLE
Convert shared_ptr<Node> to intrusive_ptr<Node>

### DIFF
--- a/python/monarch/gradient/_gradient_generator.cpp
+++ b/python/monarch/gradient/_gradient_generator.cpp
@@ -608,7 +608,10 @@ typedef struct {
   PyObject_HEAD GradientGenerator* obj;
 } PyGradientGenerator;
 
-static int convertNode(PyObject* obj, std::shared_ptr<Node>* node) {
+// shared_ptr<Node> in older PyTorch, intrusive_ptr<Node> in newer PyTorch
+using node_ptr_t = decltype(std::declval<THPCppFunction>().cdata);
+
+static int convertNode(PyObject* obj, node_ptr_t* node) {
   if (THPFunction_Check(obj)) {
     *node = ((THPFunction*)obj)->cdata.lock();
     return 1;
@@ -621,7 +624,7 @@ static int convertNode(PyObject* obj, std::shared_ptr<Node>* node) {
 }
 
 std::optional<Edge> parseEdge(PyObject* obj) {
-  std::shared_ptr<Node> node;
+  node_ptr_t node;
   int input_nr;
   if (THPVariable_Check(obj)) {
     auto tensor = THPVariable_Unpack(obj);


### PR DESCRIPTION
Summary:
Replace std::shared_ptr<Node> with c10::intrusive_ptr<Node> throughout the autograd system. Node now inherits from c10::intrusive_ptr_target instead of std::enable_shared_from_this<Node>.

Authored with Claude.

X-link: https://github.com/pytorch/pytorch/pull/181139

Differential Revision: D102013962

Pulled By: colesbury


