### PR TITLE
[hyperactor] extend LinkInit protocol with stream_id

### DIFF
--- a/hyperactor/src/channel/net.rs
+++ b/hyperactor/src/channel/net.rs
@@ -110,40 +110,49 @@ pub(crate) const ACCEPTOR_TO_INITIATOR: u8 = 1;
 /// This is written/read directly on the wire (not framed), before
 /// any session framing begins.
 ///
-/// Wire format (12 bytes, big-endian):
+/// Wire format (13 bytes, big-endian):
 /// ```text
-/// [magic: 4B "LNK\0"] [session_id: 8B u64 BE]
+/// [magic: 4B "LNK\0"] [session_id: 8B u64 BE] [stream_id: 1B u8]
 /// ```
 const LINK_INIT_MAGIC: [u8; 4] = *b"LNK\0";
-const LINK_INIT_SIZE: usize = 4 + 8;
+const LINK_INIT_SIZE: usize = 4 + 8 + 1;
+
+/// Parsed LinkInit header.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct LinkInit {
+    pub session_id: SessionId,
+    pub stream_id: u8,
+}
 
 /// Write a LinkInit header to the stream.
 async fn write_link_init<S: AsyncWrite + Unpin>(
     stream: &mut S,
     session_id: SessionId,
+    stream_id: u8,
 ) -> Result<(), std::io::Error> {
     let mut buf = [0u8; LINK_INIT_SIZE];
     buf[0..4].copy_from_slice(&LINK_INIT_MAGIC);
     buf[4..12].copy_from_slice(&session_id.0.to_be_bytes());
+    buf[12] = stream_id;
     stream.write_all(&buf).await
 }
 
 /// Read a LinkInit header from the stream.
-async fn read_link_init<S: AsyncRead + Unpin>(stream: &mut S) -> Result<SessionId, std::io::Error> {
+async fn read_link_init<S: AsyncRead + Unpin>(stream: &mut S) -> Result<LinkInit, std::io::Error> {
     let mut buf = [0u8; LINK_INIT_SIZE];
     stream.read_exact(&mut buf).await?;
     if buf[0..4] != LINK_INIT_MAGIC {
         return Err(std::io::Error::new(
             std::io::ErrorKind::InvalidData,
-            format!(
-                "invalid LinkInit magic: expected {:?}, got {:?}",
-                LINK_INIT_MAGIC,
-                &buf[0..4]
-            ),
+            format!("invalid LinkInit magic: expected LNK, got {:?}", &buf[0..4]),
         ));
     }
     let session_id = SessionId(u64::from_be_bytes(buf[4..12].try_into().unwrap()));
-    Ok(session_id)
+    let stream_id = buf[12];
+    Ok(LinkInit {
+        session_id,
+        stream_id,
+    })
 }
 
 /// Link represents a network link through which connections may be
@@ -827,7 +836,7 @@ pub(crate) mod unix {
                             .map_err(|err| ClientError::Io(self.dest(), err))?;
                         let mut stream = UnixStream::from_std(std_stream)
                             .map_err(|err| ClientError::Io(self.dest(), err))?;
-                        write_link_init(&mut stream, session_id)
+                        write_link_init(&mut stream, session_id, 0)
                             .await
                             .map_err(|err| ClientError::Io(self.dest(), err))?;
                         return Ok(stream);
@@ -1116,7 +1125,7 @@ pub(crate) mod tcp {
                                 "cannot disable Nagle algorithm".to_string(),
                             )
                         })?;
-                        write_link_init(&mut stream, session_id)
+                        write_link_init(&mut stream, session_id, 0)
                             .await
                             .map_err(|err| ClientError::Io(self.dest(), err))?;
                         return Ok(stream);
@@ -1520,7 +1529,7 @@ pub(crate) mod tls {
                                     format!("cannot establish TLS connection to {:?}", server_name),
                                 )
                             })?;
-                        write_link_init(&mut tls_stream, session_id)
+                        write_link_init(&mut tls_stream, session_id, 0)
                             .await
                             .map_err(|err| ClientError::Io(self.dest(), err))?;
                         return Ok(tls_stream);
@@ -2436,7 +2445,7 @@ mod tests {
             // Write LinkInit on server_relay so it's readable from `server`.
             // This simulates the client sending LinkInit over the wire before
             // the frame-level relay begins.
-            write_link_init(&mut server_relay, session_id)
+            write_link_init(&mut server_relay, session_id, 0)
                 .await
                 .map_err(|err| ClientError::Io(self.dest(), err))?;
 
@@ -2786,7 +2795,7 @@ mod tests {
     ) -> (FrameReader<ReadHalf<DuplexStream>>, WriteHalf<DuplexStream>) {
         let mut receiver = receiver_storage.take().await;
         // Read and discard the LinkInit header that MockLink::connect() writes.
-        let _session_id = read_link_init(&mut receiver).await.expect("read LinkInit");
+        let _link_init = read_link_init(&mut receiver).await.expect("read LinkInit");
         let (r, writer) = tokio::io::split(receiver);
         let reader = FrameReader::new(
             r,

--- a/hyperactor/src/channel/net/duplex.rs
+++ b/hyperactor/src/channel/net/duplex.rs
@@ -182,16 +182,16 @@ pub fn serve<In: RemoteMessage, Out: RemoteMessage>(
                     _ => meta::tls_acceptor(true)?,
                 };
                 let mut tls_stream = tls_acceptor.accept(stream).await?;
-                let session_id = read_link_init(&mut tls_stream)
+                let link_init = read_link_init(&mut tls_stream)
                     .await
                     .map_err(|e| anyhow::anyhow!("LinkInit read failed from {}: {}", source, e))?;
-                Ok((session_id, Box::new(tls_stream) as Box<dyn Stream>))
+                Ok((link_init, Box::new(tls_stream) as Box<dyn Stream>))
             } else {
                 let mut stream = stream;
-                let session_id = read_link_init(&mut stream)
+                let link_init = read_link_init(&mut stream)
                     .await
                     .map_err(|e| anyhow::anyhow!("LinkInit read failed from {}: {}", source, e))?;
-                Ok((session_id, stream))
+                Ok((link_init, stream))
             }
         }
     };
@@ -204,14 +204,19 @@ pub fn serve<In: RemoteMessage, Out: RemoteMessage>(
         let accept_tx = accept_tx.clone();
         let child_cancel = child_cancel.clone();
         let dest = dispatch_dest;
-        move |session_id: SessionId, stream: Box<dyn Stream>| {
+        move |link_init: super::LinkInit, stream: Box<dyn Stream>| {
             let sessions = Arc::clone(&sessions);
             let accept_tx = accept_tx.clone();
             let cancel = child_cancel.child_token();
             let dest = dest.clone();
             async move {
                 dispatch_duplex_stream::<In, Out>(
-                    session_id, stream, &sessions, dest, &accept_tx, cancel,
+                    link_init.session_id,
+                    stream,
+                    &sessions,
+                    dest,
+                    &accept_tx,
+                    cancel,
                 )
                 .await;
             }

--- a/hyperactor/src/channel/net/server.rs
+++ b/hyperactor/src/channel/net/server.rs
@@ -220,8 +220,8 @@ where
     S: Stream,
     L: super::Listener,
     F: Fn(L::Stream, ChannelAddr) -> Fut + Clone + Send + 'static,
-    Fut: Future<Output = Result<(SessionId, S), anyhow::Error>> + Send + 'static,
-    D: Fn(SessionId, S) -> DFut + Clone + Send + 'static,
+    Fut: Future<Output = Result<(super::LinkInit, S), anyhow::Error>> + Send + 'static,
+    D: Fn(super::LinkInit, S) -> DFut + Clone + Send + 'static,
     DFut: Future<Output = ()> + Send + 'static,
 {
     let mut connections: JoinSet<Result<(), anyhow::Error>> = JoinSet::new();
@@ -250,8 +250,8 @@ where
                         let prepare = prepare.clone();
                         let dispatch = dispatch.clone();
                         connections.spawn(async move {
-                            let (session_id, stream) = prepare(stream, source).await?;
-                            dispatch(session_id, stream).await;
+                            let (link_init, stream) = prepare(stream, source).await?;
+                            dispatch(link_init, stream).await;
                             Ok(())
                         });
                     }
@@ -400,16 +400,16 @@ pub(in crate::channel) fn serve<M: RemoteMessage>(
                     _ => meta::tls_acceptor(true)?,
                 };
                 let mut tls_stream = tls_acceptor.accept(stream).await?;
-                let session_id = read_link_init(&mut tls_stream)
+                let link_init = read_link_init(&mut tls_stream)
                     .await
                     .map_err(|e| anyhow::anyhow!("LinkInit read failed from {}: {}", source, e))?;
-                Ok((session_id, Box::new(tls_stream) as Box<dyn Stream>))
+                Ok((link_init, Box::new(tls_stream) as Box<dyn Stream>))
             } else {
                 let mut stream = stream;
-                let session_id = read_link_init(&mut stream)
+                let link_init = read_link_init(&mut stream)
                     .await
                     .map_err(|e| anyhow::anyhow!("LinkInit read failed from {}: {}", source, e))?;
-                Ok((session_id, stream))
+                Ok((link_init, stream))
             }
         }
     };
@@ -422,13 +422,13 @@ pub(in crate::channel) fn serve<M: RemoteMessage>(
         let tx = tx.clone();
         let child_cancel = child_cancel.clone();
         let dest = dispatch_dest;
-        move |session_id: SessionId, stream: Box<dyn Stream>| {
+        move |link_init: super::LinkInit, stream: Box<dyn Stream>| {
             let sessions = Arc::clone(&sessions);
             let tx = tx.clone();
             let cancel = child_cancel.child_token();
             let dest = dest.clone();
             async move {
-                dispatch_stream(session_id, stream, &sessions, dest, tx, cancel).await;
+                dispatch_stream(link_init.session_id, stream, &sessions, dest, tx, cancel).await;
             }
         }
     };
@@ -469,10 +469,10 @@ where
     let child_token = cancel_token.child_token();
 
     let prepare = |mut stream: L::Stream, source: ChannelAddr| async move {
-        let session_id = read_link_init(&mut stream)
+        let link_init = read_link_init(&mut stream)
             .await
             .map_err(|e| anyhow::anyhow!("LinkInit read failed from {}: {}", source, e))?;
-        Ok((session_id, stream))
+        Ok((link_init, stream))
     };
 
     let sessions: Arc<DashMap<SessionId, MVar<L::Stream>>> = Arc::new(DashMap::new());
@@ -482,13 +482,13 @@ where
         let tx = tx.clone();
         let child_cancel = child_cancel.clone();
         let dest = channel_addr.clone();
-        move |session_id: SessionId, stream: L::Stream| {
+        move |link_init: super::LinkInit, stream: L::Stream| {
             let sessions = Arc::clone(&sessions);
             let tx = tx.clone();
             let cancel = child_cancel.child_token();
             let dest = dest.clone();
             async move {
-                dispatch_stream(session_id, stream, &sessions, dest, tx, cancel).await;
+                dispatch_stream(link_init.session_id, stream, &sessions, dest, tx, cancel).await;
             }
         }
     };
@@ -511,3 +511,4 @@ where
         NetRx(rx, channel_addr, server_handle),
     ))
 }
+


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #3558
* #3557
* #3556
* __->__ #3555

Adds a `stream_id` field to the LinkInit wire header. Connections for the same logical session carry distinct `stream_id`s, letting the server route each connection to the appropriate per-stream reader (multi-stream) or through the legacy single-stream path when `stream_id == 0`.

Wire format (13 bytes, big-endian):

```
[magic: 4B "LNK\0"] [session_id: 8B u64 BE] [stream_id: 1B u8]
```

Single-stream callers pass `stream_id = 0`; multi-stream callers pass `1..=num_streams`.

128GB total, 3 runs
================================================================================
  Chunk MB    Channels   Med GB/s   Avg GB/s    Avg us    P50 us    P99 us   Errors
----------  ----------  ---------  ---------  --------  --------  --------  -------
        64           1      22.40      22.42         0         0         0        0
```

Differential Revision: [D102021342](https://our.internmc.facebook.com/intern/diff/D102021342/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D102021342/)!