### PR TITLE
[hyperactor] multi-stream sender with exp_dial_unordered API

### DIFF
--- a/hyperactor/Cargo.toml
+++ b/hyperactor/Cargo.toml
@@ -36,6 +36,7 @@ path = "benches/main.rs"
 [dependencies]
 algebra = { version = "0.0.0", path = "../algebra" }
 anyhow = "1.0.102"
+async-channel = "1.9.0"
 async-trait = "0.1.86"
 backoff = { version = "0.4.0", features = ["futures", "tokio"] }
 bincode = "1.3.3"

--- a/hyperactor/src/channel.rs
+++ b/hyperactor/src/channel.rs
@@ -1052,9 +1052,67 @@ pub fn dial<M: RemoteMessage>(addr: ChannelAddr) -> Result<ChannelTx<M>, Channel
         ChannelAddr::Tcp(_)
         | ChannelAddr::Unix(_)
         | ChannelAddr::Tls(_)
-        | ChannelAddr::MetaTls(_) => ChannelTxKind::Net(net::spawn(net::link(addr)?)),
+        | ChannelAddr::MetaTls(_) => {
+            ChannelTxKind::Net(net::spawn(net::link(addr, net::SessionId::random(), 0)?))
+        }
         ChannelAddr::Alias { dial_to, .. } => dial(*dial_to)?.inner,
     };
+    Ok(ChannelTx { inner })
+}
+
+/// Experimental: dial with out-of-order delivery and N parallel streams.
+///
+/// Opens N TCP connections sharing a single `SessionId` (distinct
+/// `stream_id` in `1..=num_streams` so the server routes them through
+/// the multi-stream receive path). Frames are load-balanced across
+/// streams via a shared MPMC work queue — idle writers pull next.
+/// API may change.
+///
+/// # Semantics (how this differs from [`dial`])
+///
+/// Multi-stream trades several of [`dial`]'s delivery guarantees for
+/// aggregate bandwidth. Use [`dial`] when any of these matter:
+///
+/// - **Ordering.** Messages are delivered to the receiver in *arrival
+///   order across streams*, not send order. Two messages posted back
+///   to back on the sender may reach the receiver out of order when
+///   they're carried on different TCP streams. [`dial`] is strictly
+///   in-order.
+///
+/// - **Retransmission on reconnect.** If a writer's TCP connection
+///   drops after the bytes of a message have been written but before
+///   the peer acks, that message is **not retransmitted** on the new
+///   connection. It may be silently lost. [`dial`] re-sends all
+///   unacked messages on reconnect.
+///
+/// - **Delivery timeouts.** No delivery timeout is enforced. On
+///   sustained peer outage, writers reconnect indefinitely (backoff
+///   capped at 5s); senders block in `send().await` with no bound.
+///   [`dial`] fails unacked sends after
+///   `MESSAGE_DELIVERY_TIMEOUT`.
+///
+/// - **`Tx::send` return semantics.** On session shutdown, messages
+///   still in the unacked buffer have their `return_channel` dropped.
+///   Per the [`Tx::send`] contract, this makes `send().await` return
+///   `Ok(())` for messages that may never have been delivered — i.e.
+///   a "success" return does not actually confirm delivery here.
+///   [`dial`] delivers a structured `SendError` instead.
+///
+/// # Ack semantics
+///
+/// Receivers ack a cumulative watermark: the highest `N` such that
+/// all of `0..=N` have been observed across all streams. Acks may
+/// stall behind a single missing seq on a slow stream.
+pub fn exp_dial_unordered<M: RemoteMessage>(
+    addr: ChannelAddr,
+    num_streams: usize,
+) -> Result<ChannelTx<M>, ChannelError> {
+    assert!(num_streams > 0);
+    let session_id = net::SessionId::random();
+    let links: Vec<net::NetLink> = (1..=num_streams)
+        .map(|i| net::link(addr.clone(), session_id, i as u8))
+        .collect::<Result<_, _>>()?;
+    let inner = ChannelTxKind::Net(net::spawn_unordered(links));
     Ok(ChannelTx { inner })
 }
 

--- a/hyperactor/src/channel/net.rs
+++ b/hyperactor/src/channel/net.rs
@@ -47,6 +47,7 @@
 //!   when EOF occurs exactly on a frame boundary. If EOF happens
 //!   mid-frame, it returns `Err(io::ErrorKind::UnexpectedEof)`.
 
+use std::collections::VecDeque;
 use std::fmt;
 use std::fmt::Debug;
 use std::net::ToSocketAddrs;
@@ -278,6 +279,236 @@ fn log_send_error(
 
 /// Establish a simplex (send-only) session over the given link. Returns a send handle.
 pub(crate) fn spawn<M: RemoteMessage>(link: impl Link) -> NetTx<M> {
+    spawn_inner(link)
+}
+
+/// Establish a multi-stream (unordered) simplex session over N
+/// links sharing the same `SessionId`. Returns a single send handle
+/// that distributes frames across streams.
+pub(crate) fn spawn_unordered<M: RemoteMessage>(links: Vec<impl Link + 'static>) -> NetTx<M> {
+    assert!(!links.is_empty());
+    if links.len() == 1 {
+        return spawn(links.into_iter().next().unwrap());
+    }
+
+    let (sender, mut receiver) = tokio::sync::mpsc::unbounded_channel();
+    let dest = links[0].dest();
+    let session_id = links[0].link_id();
+    let (notify, status) = watch::channel(TxStatus::Active);
+    let tx = NetTx {
+        sender,
+        dest: dest.clone(),
+        status,
+    };
+
+    let num_streams = links.len();
+
+    crate::init::get_runtime().spawn(async move {
+        // Shared MPMC work queue. The dispatcher enqueues *unserialized*
+        // messages; each writer serializes its own pulls before writing.
+        // This spreads serialization cost across all N writer tasks
+        // instead of bottlenecking on the dispatcher.
+        let (queue_tx, queue_rx) =
+            async_channel::bounded::<session::PendingMessage<M>>(num_streams * 8);
+
+        // Shared unacked buffer: any writer's ack reader can prune it.
+        // BTreeMap keyed by seq — writers insert out of order
+        // (multiple streams, interleaved), so not a VecDeque.
+        let unacked: Arc<
+            tokio::sync::Mutex<std::collections::BTreeMap<u64, session::QueuedMessage<M>>>,
+        > = Arc::new(tokio::sync::Mutex::new(std::collections::BTreeMap::new()));
+
+        let mut writer_handles: Vec<tokio::task::JoinHandle<()>> = Vec::with_capacity(num_streams);
+        let log_id = format!("session {}.{:016x}", dest, session_id.0);
+
+        for (i, link) in links.into_iter().enumerate() {
+            let dest = dest.clone();
+            let unacked = unacked.clone();
+            let queue_rx = queue_rx.clone();
+            let log_id = log_id.clone();
+
+            writer_handles.push(tokio::spawn(async move {
+                let mut session = Session::new(link);
+                let mut reconnect_backoff = ExponentialBackoffBuilder::new()
+                    .with_initial_interval(Duration::from_millis(10))
+                    .with_multiplier(2.0)
+                    .with_randomization_factor(0.1)
+                    .with_max_interval(Duration::from_secs(5))
+                    .with_max_elapsed_time(None)
+                    .build();
+
+                loop {
+                    let connected = match session.connect().await {
+                        Ok(s) => s,
+                        Err(_) => {
+                            tracing::info!(
+                                dest = %dest, stream = i,
+                                "multi-stream writer {} connect failed", i
+                            );
+                            break;
+                        }
+                    };
+                    tracing::info!(
+                        dest = %dest, stream = i, "multi-stream writer {} connected", i
+                    );
+
+                    let stream = connected.stream(INITIATOR_TO_ACCEPTOR);
+                    let connected_at = tokio::time::Instant::now();
+
+                    // Pull from the shared queue; serialize locally; write; interleave ack reads.
+                    let result: Result<(), session::SendLoopError> = async {
+                        loop {
+                            tokio::select! {
+                                biased;
+
+                                ack_result = stream.next() => {
+                                    match ack_result {
+                                        Ok(Some(buffer)) => {
+                                            let response = deserialize_response(buffer)
+                                                .map_err(|e| session::SendLoopError::Io(e.into()))?;
+                                            match response {
+                                                NetRxResponse::Ack(ack) => {
+                                                    let mut guard = unacked.lock().await;
+                                                    // Remove all entries with seq <= ack.
+                                                    let retain: std::collections::BTreeMap<u64, session::QueuedMessage<M>> = guard.split_off(&(ack + 1));
+                                                    drop(std::mem::replace(&mut *guard, retain));
+                                                }
+                                                NetRxResponse::Reject(reason) => {
+                                                    return Err(session::SendLoopError::Rejected(reason));
+                                                }
+                                                NetRxResponse::Closed => {
+                                                    return Err(session::SendLoopError::ServerClosed);
+                                                }
+                                            }
+                                        }
+                                        Ok(None) => return Ok(()),
+                                        Err(e) => return Err(session::SendLoopError::Io(e.into())),
+                                    }
+                                }
+
+                                msg = queue_rx.recv() => {
+                                    let pending = match msg {
+                                        Ok(m) => m,
+                                        // Dispatcher closed the queue: clean shutdown.
+                                        Err(_) => return Ok(()),
+                                    };
+                                    let session::PendingMessage {
+                                        seq,
+                                        message,
+                                        received_at,
+                                        return_channel,
+                                    } = pending;
+                                    let frame = Frame::Message(seq, message);
+                                    let serialized = match serde_multipart::serialize_bincode(&frame) {
+                                        Ok(m) => m,
+                                        Err(e) => {
+                                            tracing::error!(
+                                                "{log_id}: serialization error: {e}"
+                                            );
+                                            // Drops return_channel; sender perceives success
+                                            // (preserving prior behavior of the dispatcher-side
+                                            // serialize path).
+                                            continue;
+                                        }
+                                    };
+                                    let mut queued = session::QueuedMessage {
+                                        seq,
+                                        message: serialized,
+                                        received_at,
+                                        sent_at: None,
+                                        return_channel,
+                                    };
+                                    let framed = queued.message.clone().framed();
+                                    stream.write(framed).drive().await.map_err(|e| {
+                                        session::SendLoopError::Io(e.into())
+                                    })?;
+                                    queued.sent_at = Some(tokio::time::Instant::now());
+                                    unacked.lock().await.insert(queued.seq, queued);
+                                }
+                            }
+                        }
+                    }
+                    .await;
+
+                    session = connected.release();
+
+                    if connected_at.elapsed() > Duration::from_secs(1) {
+                        reconnect_backoff.reset();
+                    }
+
+                    match result {
+                        Ok(()) => {
+                            if queue_rx.is_closed() {
+                                // Dispatcher is gone and queue is drained.
+                                break;
+                            }
+                            if let Some(delay) = reconnect_backoff.next_backoff() {
+                                tokio::time::sleep(delay).await;
+                            }
+                        }
+                        Err(ref e) => {
+                            if log_send_error(e, &dest, session_id.0, "multi-stream", &LinkStatus::NeverConnected) {
+                                break;
+                            }
+                            if let Some(delay) = reconnect_backoff.next_backoff() {
+                                tokio::time::sleep(delay).await;
+                            }
+                        }
+                    }
+                }
+
+                tracing::info!(
+                    dest = %dest,
+                    stream = i,
+                    "multi-stream writer {} shutting down",
+                    i,
+                );
+            }));
+        }
+
+        // Drop our local receiver clone so the queue closes once the
+        // dispatcher's sender (queue_tx) is dropped at shutdown.
+        drop(queue_rx);
+
+        // Dispatcher: receive from app and enqueue for writers — no
+        // serialization here; the writer that pulls the item serializes
+        // it before writing.
+        let mut next_seq = 0u64;
+
+        tracing::info!(
+            %dest, session = %log_id, num_streams,
+            "multi-stream dispatcher started"
+        );
+
+        while let Some((message, return_channel, received_at)) = receiver.recv().await {
+            let pending = session::PendingMessage {
+                seq: next_seq,
+                message,
+                received_at,
+                return_channel,
+            };
+            next_seq += 1;
+
+            if queue_tx.send(pending).await.is_err() {
+                // All writers are gone.
+                break;
+            }
+        }
+
+        // Shutdown: close the shared queue and wait for writers to drain.
+        drop(queue_tx);
+        for handle in writer_handles {
+            let _ = handle.await;
+        }
+
+        let reason = format!("{log_id}: dispatcher closed");
+        let _ = notify.send(TxStatus::Closed(reason.into()));
+    });
+
+    tx
+}
+
+fn spawn_inner<M: RemoteMessage>(link: impl Link) -> NetTx<M> {
     let (sender, receiver) = tokio::sync::mpsc::unbounded_channel();
     let dest = link.dest();
     let session_id = link.link_id();
@@ -457,13 +688,25 @@ pub(crate) enum NetLink {
     Tls(tls::TlsLink),
 }
 
-/// Create a link for the given channel address.
-pub(crate) fn link(addr: ChannelAddr) -> Result<NetLink, ClientError> {
+/// Create a link for the given channel address with the given
+/// `session_id` and `stream_id`. Single-stream callers pass a fresh
+/// `SessionId::random()` and `stream_id = 0`.
+pub(crate) fn link(
+    addr: ChannelAddr,
+    session_id: SessionId,
+    stream_id: u8,
+) -> Result<NetLink, ClientError> {
     match addr {
-        ChannelAddr::Tcp(socket_addr) => Ok(NetLink::Tcp(tcp::link(socket_addr))),
-        ChannelAddr::Unix(unix_addr) => Ok(NetLink::Unix(unix::link(unix_addr))),
-        ChannelAddr::Tls(tls_addr) => Ok(NetLink::Tls(tls::link(tls_addr)?)),
-        ChannelAddr::MetaTls(meta_addr) => Ok(NetLink::Tls(meta::link(meta_addr)?)),
+        ChannelAddr::Tcp(socket_addr) => {
+            Ok(NetLink::Tcp(tcp::link(socket_addr, session_id, stream_id)))
+        }
+        ChannelAddr::Unix(unix_addr) => {
+            Ok(NetLink::Unix(unix::link(unix_addr, session_id, stream_id)))
+        }
+        ChannelAddr::Tls(tls_addr) => Ok(NetLink::Tls(tls::link(tls_addr, session_id, stream_id)?)),
+        ChannelAddr::MetaTls(meta_addr) => {
+            Ok(NetLink::Tls(meta::link(meta_addr, session_id, stream_id)?))
+        }
         other => Err(ClientError::Connect(
             other,
             std::io::Error::other("unsupported transport"),
@@ -801,6 +1044,7 @@ pub(crate) mod unix {
     pub(crate) struct UnixLink {
         pub(super) addr: SocketAddr,
         pub(super) session_id: SessionId,
+        pub(super) stream_id: u8,
     }
 
     #[async_trait]
@@ -836,7 +1080,7 @@ pub(crate) mod unix {
                             .map_err(|err| ClientError::Io(self.dest(), err))?;
                         let mut stream = UnixStream::from_std(std_stream)
                             .map_err(|err| ClientError::Io(self.dest(), err))?;
-                        write_link_init(&mut stream, session_id, 0)
+                        write_link_init(&mut stream, session_id, self.stream_id)
                             .await
                             .map_err(|err| ClientError::Io(self.dest(), err))?;
                         return Ok(stream);
@@ -876,10 +1120,11 @@ pub(crate) mod unix {
     }
 
     /// Create a unix link to the given socket address.
-    pub(crate) fn link(addr: SocketAddr) -> UnixLink {
+    pub(crate) fn link(addr: SocketAddr, session_id: SessionId, stream_id: u8) -> UnixLink {
         UnixLink {
             addr,
-            session_id: SessionId::random(),
+            session_id,
+            stream_id,
         }
     }
 
@@ -1092,6 +1337,7 @@ pub(crate) mod tcp {
     pub(crate) struct TcpLink {
         pub(super) addr: SocketAddr,
         pub(super) session_id: SessionId,
+        pub(super) stream_id: u8,
     }
 
     #[async_trait]
@@ -1125,7 +1371,7 @@ pub(crate) mod tcp {
                                 "cannot disable Nagle algorithm".to_string(),
                             )
                         })?;
-                        write_link_init(&mut stream, session_id, 0)
+                        write_link_init(&mut stream, session_id, self.stream_id)
                             .await
                             .map_err(|err| ClientError::Io(self.dest(), err))?;
                         return Ok(stream);
@@ -1166,10 +1412,11 @@ pub(crate) mod tcp {
     }
 
     /// Create a TCP link to the given socket address.
-    pub(crate) fn link(addr: SocketAddr) -> TcpLink {
+    pub(crate) fn link(addr: SocketAddr, session_id: SessionId, stream_id: u8) -> TcpLink {
         TcpLink {
             addr,
-            session_id: SessionId::random(),
+            session_id,
+            stream_id,
         }
     }
 }
@@ -1283,7 +1530,11 @@ pub(crate) mod meta {
     }
 
     /// Create a MetaTLS link to the given address.
-    pub fn link(addr: TlsAddr) -> Result<tls::TlsLink, ClientError> {
+    pub fn link(
+        addr: TlsAddr,
+        session_id: SessionId,
+        stream_id: u8,
+    ) -> Result<tls::TlsLink, ClientError> {
         let connector = tls_connector().map_err(|e| {
             ClientError::Connect(
                 ChannelAddr::MetaTls(addr.clone()),
@@ -1297,7 +1548,8 @@ pub(crate) mod meta {
             port,
             connector,
             addr_type: tls::TlsAddrType::MetaTls,
-            session_id: SessionId::random(),
+            session_id,
+            stream_id,
         })
     }
 }
@@ -1455,6 +1707,7 @@ pub(crate) mod tls {
         pub(crate) connector: TlsConnector,
         pub(crate) addr_type: TlsAddrType,
         pub(crate) session_id: SessionId,
+        pub(crate) stream_id: u8,
     }
 
     impl std::fmt::Debug for TlsLink {
@@ -1529,7 +1782,7 @@ pub(crate) mod tls {
                                     format!("cannot establish TLS connection to {:?}", server_name),
                                 )
                             })?;
-                        write_link_init(&mut tls_stream, session_id, 0)
+                        write_link_init(&mut tls_stream, session_id, self.stream_id)
                             .await
                             .map_err(|err| ClientError::Io(self.dest(), err))?;
                         return Ok(tls_stream);
@@ -1546,7 +1799,11 @@ pub(crate) mod tls {
     }
 
     /// Create a TLS link to the given address.
-    pub fn link(addr: TlsAddr) -> Result<TlsLink, ClientError> {
+    pub fn link(
+        addr: TlsAddr,
+        session_id: SessionId,
+        stream_id: u8,
+    ) -> Result<TlsLink, ClientError> {
         let connector = tls_connector().map_err(|e| {
             ClientError::Connect(
                 ChannelAddr::Tls(addr.clone()),
@@ -1560,7 +1817,8 @@ pub(crate) mod tls {
             port,
             connector,
             addr_type: TlsAddrType::Tls,
-            session_id: SessionId::random(),
+            session_id,
+            stream_id,
         })
     }
 
@@ -1675,10 +1933,14 @@ u19txmtkiMEH+aNmekk=
 
             // Dial the server
             let tx: super::NetTx<u64> = super::spawn(
-                link(match &local_addr {
-                    ChannelAddr::Tls(addr) => addr.clone(),
-                    _ => panic!("unexpected address type"),
-                })
+                link(
+                    match &local_addr {
+                        ChannelAddr::Tls(addr) => addr.clone(),
+                        _ => panic!("unexpected address type"),
+                    },
+                    SessionId::random(),
+                    0,
+                )
                 .expect("failed to create link"),
             );
 
@@ -1708,10 +1970,14 @@ u19txmtkiMEH+aNmekk=
             let (local_addr, mut rx) =
                 server::serve::<String>(ChannelAddr::Tls(addr)).expect("failed to serve");
             let tx: super::NetTx<String> = super::spawn(
-                link(match &local_addr {
-                    ChannelAddr::Tls(addr) => addr.clone(),
-                    _ => panic!("unexpected address type"),
-                })
+                link(
+                    match &local_addr {
+                        ChannelAddr::Tls(addr) => addr.clone(),
+                        _ => panic!("unexpected address type"),
+                    },
+                    SessionId::random(),
+                    0,
+                )
                 .expect("failed to create link"),
             );
 
@@ -3479,7 +3745,7 @@ mod tests {
             ChannelAddr::Tcp(a) => a,
             _ => panic!("unexpected channel type"),
         };
-        let tx: NetTx<u64> = spawn(tcp::link(socket_addr));
+        let tx: NetTx<u64> = spawn(tcp::link(socket_addr, SessionId::random(), 0));
         // NetTx will not establish a connection until it sends the 1st message.
         // Without a live connection, NetTx cannot received the Closed message
         // from NetRx. Therefore, we need to send a message to establish the

--- a/hyperactor/src/channel/net/duplex.rs
+++ b/hyperactor/src/channel/net/duplex.rs
@@ -538,7 +538,7 @@ pub(crate) fn spawn<Out: RemoteMessage, In: RemoteMessage>(
 pub fn dial<Out: RemoteMessage, In: RemoteMessage>(
     addr: ChannelAddr,
 ) -> Result<(DuplexTx<Out>, DuplexRx<In>), ClientError> {
-    Ok(spawn(super::link(addr)?))
+    Ok(spawn(super::link(addr, super::SessionId::random(), 0)?))
 }
 
 #[cfg(test)]

--- a/hyperactor/src/channel/net/session.rs
+++ b/hyperactor/src/channel/net/session.rs
@@ -323,12 +323,23 @@ impl<R: AsyncRead + Unpin + Send, W> Mux<R, W> {
     }
 }
 
+/// A message queued for dispatch to a writer but not yet serialized.
+/// Used in the multi-stream sender to shift serialization cost off the
+/// single dispatcher task and onto the per-stream writer tasks, which
+/// can serialize in parallel.
+pub(super) struct PendingMessage<M: RemoteMessage> {
+    pub(super) seq: u64,
+    pub(super) message: M,
+    pub(super) received_at: Instant,
+    pub(super) return_channel: oneshot::Sender<SendError<M>>,
+}
+
 pub(super) struct QueuedMessage<M: RemoteMessage> {
-    seq: u64,
-    message: serde_multipart::Message,
-    received_at: Instant,
-    sent_at: Option<Instant>,
-    return_channel: oneshot::Sender<SendError<M>>,
+    pub(super) seq: u64,
+    pub(super) message: serde_multipart::Message,
+    pub(super) received_at: Instant,
+    pub(super) sent_at: Option<tokio::time::Instant>,
+    pub(super) return_channel: oneshot::Sender<SendError<M>>,
 }
 
 impl<M: RemoteMessage> fmt::Display for QueuedMessage<M> {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #3558
* __->__ #3557
* #3556
* #3555

Adds `spawn_unordered`, which creates N writer tasks sharing a single `SessionId`. A dispatcher receives messages from the app, assigns global sequence numbers, and enqueues unserialized `PendingMessage`s onto a single shared MPMC work queue (`async-channel`). All writer tasks pull from the same queue — whichever writer is idle recv()s next, giving natural least-loaded load balancing without an explicit picker. Each writer serializes its own pulls (so serialization scales with `num_streams` instead of bottlenecking on a single dispatcher), writes frames, and prunes a shared unacked BTreeMap as acks come in.

Adds `exp_dial_unordered(addr, num_streams)` (experimental — API may change) which creates N links with a shared `SessionId` and distinct `stream_id`s and uses `spawn_unordered` to distribute frames across them. The doc comment spells out the semantic regressions vs `dial`: out-of-order delivery, no retransmit-on-reconnect, no delivery timeout, and `Tx::send` returning `Ok(())` for messages that may not have been delivered.

Also adds `stream_id` field to `TcpLink`, `UnixLink`, and `TlsLink` (and threads an explicit `SessionId` through the transport-level `link()` constructors), and adds `PendingMessage<M>` alongside `QueuedMessage<M>` in `session.rs` for the pre-serialize queue entry.

128GB total, 3 runs
================================================================================
  Chunk MB    Channels   Med GB/s   Avg GB/s    Avg us    P50 us    P99 us   Errors
----------  ----------  ---------  ---------  --------  --------  --------  -------
        64           1      22.40      22.42         0         0         0        0
```

Differential Revision: [D102021501](https://our.internmc.facebook.com/intern/diff/D102021501/)