### PR TITLE
add host_mesh_from_store (#3559)

### DIFF
--- a/python/monarch/_src/spmd/_worker_entry.py
+++ b/python/monarch/_src/spmd/_worker_entry.py
@@ -1,0 +1,75 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+"""
+Child-side entry point for workers spawned by
+:func:`monarch._src.spmd.host_mesh._spawn_worker_process`.
+
+Reads the listen address from ``_MONARCH_WORKER_ADDR`` and spawns a
+daemon thread that blocks reading the parent pipe, exiting the worker on
+EOF — which the kernel delivers when the parent process closes its end,
+i.e. when the parent exits. Then delegates to ``run_worker_loop_forever``.
+
+Invoked either as ``python -m monarch._src.spmd._worker_entry`` under
+standard Python, or via ``PAR_MAIN_OVERRIDE`` under PAR/XAR.
+"""
+
+import os
+import sys
+import threading
+
+from monarch._src.spmd.host_mesh import _ADDR_ENV, _PARENT_WATCH_FD_ENV
+from monarch.actor import run_worker_loop_forever
+
+
+def _wait_for_parent_death(fd: int) -> None:
+    """Block reading ``fd`` until the parent closes its end, then exit.
+
+    The parent never writes to the other end of the pipe, so ``os.read``
+    blocks indefinitely without consuming CPU. When the parent process
+    exits the kernel closes its write end, ``os.read`` returns ``b""``,
+    and we exit the worker via ``os._exit`` — even if
+    ``run_worker_loop_forever`` is blocked in native code.
+    """
+    while True:
+        try:
+            data = os.read(fd, 4096)
+        except OSError as e:
+            print(
+                f"monarch worker: reading from parent pipe failed ({e}); exiting",
+                file=sys.stderr,
+                flush=True,
+            )
+            os._exit(1)
+            return
+        if not data:
+            # Parent closed the pipe — parent process exited. Our job is done.
+            os._exit(0)
+
+
+def main() -> None:
+    """Entry point for the worker subprocess.
+
+    Reads the listen address from ``_MONARCH_WORKER_ADDR`` and spawns
+    :func:`_wait_for_parent_death` as a daemon thread before handing off
+    to ``run_worker_loop_forever``.
+    """
+    addr = os.environ[_ADDR_ENV]
+    fd_str = os.environ.get(_PARENT_WATCH_FD_ENV)
+    if fd_str is not None:
+        threading.Thread(
+            target=_wait_for_parent_death,
+            args=(int(fd_str),),
+            daemon=True,
+            name="monarch-worker-parent-watch",
+        ).start()
+    run_worker_loop_forever(address=addr, ca="trust_all_connections")
+
+
+if __name__ == "__main__":
+    main()

--- a/python/monarch/_src/spmd/host_mesh.py
+++ b/python/monarch/_src/spmd/host_mesh.py
@@ -1,0 +1,336 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+"""
+Stand up a Monarch host mesh from a torchrun/torchx-style SPMD entry point,
+without going through the Monarch job API.
+
+:func:`host_mesh_from_store` is the public entry point: called collectively
+on every rank, it spawns a worker subprocess on each local rank 0, publishes
+the worker addresses through the caller-supplied store, and on global rank 0
+calls :func:`monarch.actor.attach_to_workers` to build the host mesh. Non-
+primary ranks return ``None``.
+
+Worker subprocesses are fire-and-forget. Each child inherits the read end
+of an ``os.pipe()`` whose write end stays open in the parent for the
+lifetime of the process; the parent never writes. The kernel closes the
+write end when the parent dies by *any* means — clean exit, segfault,
+SIGKILL — which delivers EOF to the child's blocking read and lets it
+``os._exit`` on its own.
+
+IPC transport places the socket inside a per-worker tmpdir under
+``tempfile.gettempdir()``. The tmpdir is intentionally left behind — the
+OS's temp reaper cleans it up, matching hyperactor's own behavior
+(hyperactor doesn't ``unlink`` path-based sockets either; see the
+``// TODO: we just leak these`` comment in ``hyperactor/src/channel/net.rs``).
+Linux abstract sockets (``ipc://@...``) would avoid the leak entirely,
+but hyperactor's ``from_zmq_url`` parser currently interprets ``@`` as
+the TCP alias separator and rejects abstract-socket URLs.
+
+The child-side entry point lives in :mod:`monarch._src.spmd._worker_entry`.
+"""
+
+import logging
+import os
+import socket
+import subprocess
+import sys
+import tempfile
+import threading
+from collections.abc import Mapping
+from typing import Final, Protocol
+
+from monarch._src.actor.host_mesh import HostMesh
+from monarch.actor import attach_to_workers, enable_transport
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+try:
+    from __manifest__ import fbmake  # noqa
+
+    _IN_PAR: bool = bool(fbmake.get("par_style"))
+except ImportError:
+    _IN_PAR = False
+
+_WORKER_ENTRY_MODULE: Final[str] = "monarch._src.spmd._worker_entry"
+_ADDR_ENV: Final[str] = "_MONARCH_WORKER_ADDR"
+_PARENT_WATCH_FD_ENV: Final[str] = "_MONARCH_WORKER_PARENT_WATCH_FD"
+
+
+class _StoreLike(Protocol):
+    """Subset of ``torch.distributed.Store`` used by :func:`host_mesh_from_store`."""
+
+    def set(self, key: str, value: str | bytes) -> None: ...
+    def get(self, key: str) -> bytes: ...
+
+
+def _worker_address(
+    transport: str,
+    *,
+    monarch_port: int,
+    name: str,
+    ipc_dir: str | None,
+) -> str:
+    """Build a ZMQ-style listen address for ``run_worker_loop_forever``.
+
+    ``monarch_port == 0`` is rejected for TCP and metatls transports: the
+    kernel would assign a free port at bind time, but the caller can't
+    learn that port without a round-trip from the worker, so reserving
+    the port pre-spawn via a short-lived socket races against other
+    listeners on the host. Forcing an explicit port keeps the parent's
+    pre-computed address honest.
+    """
+    if transport == "ipc":
+        assert ipc_dir is not None
+        return f"ipc://{ipc_dir}/{name}"
+    if transport in ("tcp", "metatls", "metatls-hostname"):
+        if monarch_port == 0:
+            raise ValueError(
+                f"monarch_port must be an explicit non-zero port for "
+                f"transport {transport!r}"
+            )
+        if transport == "tcp":
+            return f"tcp://{socket.getfqdn()}:{monarch_port}"
+        return f"metatls://{socket.getfqdn()}:{monarch_port}"
+    raise ValueError(
+        f"unsupported transport {transport!r}; expected one of "
+        "'tcp', 'metatls', 'metatls-hostname', 'ipc'"
+    )
+
+
+def _watch_worker(
+    proc: subprocess.Popen[bytes],
+    name: str,
+    addr: str,
+) -> None:
+    """Daemon thread that waits on the worker and logs its exit status.
+
+    ``proc.wait`` inside the thread also reaps the zombie so dead workers
+    don't pile up during the parent's lifetime. The thread holds the only
+    reference to ``proc``, which keeps the ``Popen`` alive (avoiding the
+    ``ResourceWarning`` that ``__del__`` would otherwise emit on an
+    unwaited live child).
+    """
+
+    def _waiter() -> None:
+        pid = proc.pid
+        try:
+            proc.wait()
+            code = proc.returncode
+        except Exception as e:
+            logger.exception(
+                "monarch worker %s (pid=%d addr=%s) errored while waiting: %s",
+                name,
+                pid,
+                addr,
+                e,
+            )
+            return
+        if code == 0:
+            logger.info(
+                "monarch worker %s exited pid=%d exit_code=%d addr=%s",
+                name,
+                pid,
+                code,
+                addr,
+            )
+        else:
+            logger.warning(
+                "monarch worker %s died unexpectedly pid=%d exit_code=%d addr=%s",
+                name,
+                pid,
+                code,
+                addr,
+            )
+
+    threading.Thread(
+        target=_waiter, daemon=True, name=f"monarch-worker-watch-{name}"
+    ).start()
+
+
+def _worker_addr_key(group_rank: int) -> str:
+    return f"monarch/spmd/workers/{group_rank}"
+
+
+def _resolve_topology_field(override: int | None, env_name: str) -> int:
+    """Pick a torchelastic topology value from an override or from the env."""
+    if override is not None:
+        return override
+    value = os.environ.get(env_name)
+    if value is None:
+        raise RuntimeError(
+            f"host_mesh_from_store requires the {env_name} env var "
+            "(torchelastic: RANK, LOCAL_RANK, WORLD_SIZE, LOCAL_WORLD_SIZE) "
+            "or the matching keyword argument"
+        )
+    return int(value)
+
+
+def host_mesh_from_store(
+    store: _StoreLike,
+    *,
+    monarch_port: int = 0,
+    name: str = "monarch_worker",
+    transport: str = "ipc",
+    rank: int | None = None,
+    local_rank: int | None = None,
+    world_size: int | None = None,
+    local_world_size: int | None = None,
+) -> HostMesh | None:
+    """Stand up a Monarch host mesh from a torchrun/torchx-style SPMD context.
+
+    Must be called collectively on every rank of an SPMD job. Each local
+    rank 0 spawns a ``run_worker_loop_forever`` subprocess on its host via
+    :func:`_spawn_worker_process` and publishes the worker's listen address
+    into ``store``. Global rank 0 then reads every address out of the store
+    and calls :func:`monarch.actor.attach_to_workers` to build the host
+    mesh, which it returns. Non-primary ranks return ``None``.
+
+    Rank topology defaults to the standard torchelastic env vars
+    (``RANK``, ``LOCAL_RANK``, ``WORLD_SIZE``, ``LOCAL_WORLD_SIZE``). Any
+    of the four can be overridden via the matching keyword argument.
+
+    Worker subprocesses are fire-and-forget: they exit on their own when
+    this process exits via the parent-watch pipe (see module docstring).
+    Callers who need to tear a worker down early can ``os.kill`` it by PID
+    — the watcher thread logs the exit.
+
+    Args:
+        store: A ``torch.distributed.Store`` (or any object with matching
+            ``set(key, value)`` / ``get(key) -> bytes``) shared across
+            ranks. Used to broadcast worker addresses from each local
+            rank 0 to global rank 0.
+        monarch_port: Port the worker binds on for TCP/metatls transports.
+            Must be an explicit non-zero port; ignored for IPC. ``0`` is
+            rejected because the kernel would assign a port at bind time
+            that the parent can't learn pre-spawn without racing other
+            listeners.
+        name: Prefix for the host mesh and per-host worker names; the
+            worker on group rank ``g`` is named ``f"{name}_{g}"``.
+        transport: Worker listen scheme — one of ``"ipc"`` (default),
+            ``"tcp"``, ``"metatls"``, or ``"metatls-hostname"``. ``"ipc"``
+            is single-host only but the default so we don't silently open
+            arbitrary TCP ports on user machines; multi-host callers must
+            explicitly opt into a network transport and supply a
+            ``monarch_port``.
+        rank: Overrides ``RANK`` when set.
+        local_rank: Overrides ``LOCAL_RANK`` when set.
+        world_size: Overrides ``WORLD_SIZE`` when set.
+        local_world_size: Overrides ``LOCAL_WORLD_SIZE`` when set.
+    """
+    env_rank = _resolve_topology_field(rank, "RANK")
+    env_local_rank = _resolve_topology_field(local_rank, "LOCAL_RANK")
+    env_world_size = _resolve_topology_field(world_size, "WORLD_SIZE")
+    env_local_world_size = _resolve_topology_field(local_world_size, "LOCAL_WORLD_SIZE")
+    if env_world_size % env_local_world_size != 0:
+        raise ValueError(
+            f"WORLD_SIZE ({env_world_size}) must be divisible by "
+            f"LOCAL_WORLD_SIZE ({env_local_world_size})"
+        )
+    num_hosts = env_world_size // env_local_world_size
+    group_rank = env_rank // env_local_world_size
+
+    enable_transport(transport)
+
+    if env_local_rank == 0:
+        addr, _pid = _spawn_worker_process(
+            transport=transport,
+            monarch_port=monarch_port,
+            name=f"{name}_{group_rank}",
+        )
+        store.set(_worker_addr_key(group_rank), addr.encode())
+
+    if env_rank != 0:
+        return None
+
+    worker_addrs = [store.get(_worker_addr_key(i)).decode() for i in range(num_hosts)]
+    return attach_to_workers(
+        name=name,
+        # Currently "trust_all_connections" is the only supported option.
+        ca="trust_all_connections",
+        workers=list(worker_addrs),
+    )
+
+
+def _spawn_worker_process(
+    *,
+    transport: str = "ipc",
+    monarch_port: int = 0,
+    name: str = "monarch_worker",
+    env: Mapping[str, str] | None = None,
+) -> tuple[str, int]:
+    """Spawn a ``run_worker_loop_forever`` subprocess.
+
+    Returns ``(addr, pid)``. The subprocess is fire-and-forget: a daemon
+    watcher thread holds the ``Popen`` and ``wait()``s on it (reaping the
+    zombie), and the parent-watch pipe ensures the child exits when the
+    parent does. Callers who want early teardown can ``os.kill(pid, …)``.
+
+    ``monarch_port`` must be an explicit non-zero port for TCP/metatls
+    transports (see :func:`_worker_address`).
+    """
+    ipc_dir: str | None = None
+    if transport == "ipc":
+        # Per-worker tmpdir under the system temp dir. Left behind on exit
+        # — we can't rely on ``atexit`` because abnormal exits (segfault,
+        # SIGKILL) wouldn't trigger it, and hyperactor itself doesn't
+        # ``unlink`` path-based sockets.
+        ipc_dir = tempfile.mkdtemp(prefix="monarch_worker_")
+
+    addr = _worker_address(
+        transport, monarch_port=monarch_port, name=name, ipc_dir=ipc_dir
+    )
+
+    # The parent never writes to parent_watch_write_fd; it holds the fd
+    # open so the child's read blocks indefinitely. Kernel closes the fd
+    # when this process exits — cleanly or otherwise — delivering EOF to
+    # the child's read. The fd is intentionally leaked: we want it to
+    # survive for the full lifetime of the process and only close when
+    # the kernel reaps us.
+    parent_watch_read_fd, parent_watch_write_fd = os.pipe()
+
+    child_env: dict[str, str] = {
+        **os.environ,
+        _ADDR_ENV: addr,
+        _PARENT_WATCH_FD_ENV: str(parent_watch_read_fd),
+        "HYPERACTOR_PROCESS_NAME": name,
+    }
+    if env is not None:
+        child_env.update(env)
+
+    if _IN_PAR:
+        # sys.executable in PAR/XAR is the bare interpreter and cannot import
+        # archive-bundled modules. Re-invoke the PAR with PAR_MAIN_OVERRIDE to
+        # dispatch to the worker entry module.
+        child_env["PAR_MAIN_OVERRIDE"] = _WORKER_ENTRY_MODULE
+        cmd = [sys.argv[0]]
+    else:
+        cmd = [sys.executable, "-m", _WORKER_ENTRY_MODULE]
+
+    try:
+        proc = subprocess.Popen(
+            cmd,
+            env=child_env,
+            start_new_session=True,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            pass_fds=(parent_watch_read_fd,),
+        )
+    except Exception:
+        os.close(parent_watch_read_fd)
+        os.close(parent_watch_write_fd)
+        raise
+
+    # The parent only holds the write end; the child owns the read end.
+    os.close(parent_watch_read_fd)
+
+    logger.info("monarch worker %s spawned pid=%d addr=%s", name, proc.pid, addr)
+    _watch_worker(proc, name, addr)
+
+    return addr, proc.pid

--- a/python/tests/spmd_host_mesh_parent_helper.py
+++ b/python/tests/spmd_host_mesh_parent_helper.py
@@ -1,0 +1,29 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+"""
+Entry point invoked by ``test_parent_death_kills_worker_via_pipe_eof``
+via ``PAR_MAIN_OVERRIDE``.
+
+Spawns a worker, prints its PID, and exits. Exiting closes our end of
+the parent-watch pipe; the worker's parent-watch thread should see EOF
+and exit on its own, which is what the test verifies. This file is not
+a test module — pytest ignores it because its name does not start with
+``test_``.
+"""
+
+from monarch._src.spmd.host_mesh import _spawn_worker_process
+
+
+def main() -> None:
+    _addr, pid = _spawn_worker_process(transport="ipc")
+    print(pid, flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/python/tests/test_spmd_host_mesh.py
+++ b/python/tests/test_spmd_host_mesh.py
@@ -1,0 +1,195 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import os
+import shutil
+import signal
+import subprocess
+import sys
+import time
+from typing import Callable
+
+import pytest
+from monarch._src.spmd.host_mesh import (
+    _spawn_worker_process,
+    _worker_addr_key,
+    host_mesh_from_store,
+)
+
+
+def _pid_alive(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+    except OSError:
+        return False
+    return True
+
+
+def _wait_for(
+    predicate: Callable[[], bool], timeout: float = 5.0, interval: float = 0.05
+) -> bool:
+    """Poll ``predicate`` until it returns truthy or ``timeout`` elapses."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(interval)
+    return False
+
+
+class _InMemoryStore:
+    """Minimal store with the subset of ``torch.distributed.Store`` that
+    :func:`host_mesh_from_store` consumes."""
+
+    def __init__(self) -> None:
+        self._values: dict[str, bytes] = {}
+
+    def set(self, key: str, value: str | bytes) -> None:
+        self._values[key] = value.encode() if isinstance(value, str) else value
+
+    def get(self, key: str) -> bytes:
+        return self._values[key]
+
+
+def test_spawn_ipc_returns_addr_and_live_pid() -> None:
+    addr, pid = _spawn_worker_process(transport="ipc", name="test_worker")
+    try:
+        assert addr.startswith("ipc://")
+        socket_path = addr.removeprefix("ipc://")
+        assert "/monarch_worker_" in socket_path
+        assert os.path.basename(socket_path) == "test_worker"
+        assert pid > 0
+        assert _pid_alive(pid)
+    finally:
+        # Don't rely on parent-exit cleanup for tests: SIGKILL the worker
+        # directly and drop its tmpdir so the test host stays tidy.
+        try:
+            os.kill(pid, signal.SIGKILL)
+        except OSError:
+            pass
+        ipc_dir = os.path.dirname(addr.removeprefix("ipc://"))
+        shutil.rmtree(ipc_dir, ignore_errors=True)
+
+
+def test_invalid_transport_raises_value_error() -> None:
+    with pytest.raises(ValueError, match="unsupported transport"):
+        _spawn_worker_process(transport="bogus")
+
+
+def test_net_transports_require_explicit_port() -> None:
+    # Port 0 means "kernel assigns at bind time," which the parent can't
+    # learn without racing — so we reject it up front rather than silently
+    # pre-reserving a free port. Applies to every port-using transport.
+    for transport in ("tcp", "metatls", "metatls-hostname"):
+        with pytest.raises(ValueError, match="monarch_port must be an explicit"):
+            _spawn_worker_process(transport=transport, monarch_port=0)
+
+
+@pytest.mark.parametrize(
+    "missing", ["RANK", "LOCAL_RANK", "WORLD_SIZE", "LOCAL_WORLD_SIZE"]
+)
+def test_host_mesh_from_store_requires_torchelastic_env(
+    monkeypatch: pytest.MonkeyPatch, missing: str
+) -> None:
+    # Every torchelastic env var must be present when no keyword override
+    # is supplied. Baseline-set all four, then unset the one under test
+    # and verify we get a targeted error.
+    monkeypatch.setenv("RANK", "0")
+    monkeypatch.setenv("LOCAL_RANK", "0")
+    monkeypatch.setenv("WORLD_SIZE", "1")
+    monkeypatch.setenv("LOCAL_WORLD_SIZE", "1")
+    monkeypatch.delenv(missing, raising=False)
+    with pytest.raises(RuntimeError, match=missing):
+        host_mesh_from_store(_InMemoryStore())
+
+
+def test_host_mesh_from_store_kwargs_override_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Unset every env var, then pass all four topology values via
+    # keyword arguments. Use a rank 3 / local_rank 1 layout so we hit the
+    # non-primary passive branch without spawning anything.
+    for var in ("RANK", "LOCAL_RANK", "WORLD_SIZE", "LOCAL_WORLD_SIZE"):
+        monkeypatch.delenv(var, raising=False)
+
+    store = _InMemoryStore()
+    assert (
+        host_mesh_from_store(
+            store,
+            transport="ipc",
+            rank=3,
+            local_rank=1,
+            world_size=4,
+            local_world_size=2,
+        )
+        is None
+    )
+
+
+def test_host_mesh_from_store_validates_world_size(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("RANK", "0")
+    monkeypatch.setenv("LOCAL_RANK", "0")
+    monkeypatch.setenv("WORLD_SIZE", "3")
+    monkeypatch.setenv("LOCAL_WORLD_SIZE", "2")
+    with pytest.raises(ValueError, match="divisible"):
+        host_mesh_from_store(_InMemoryStore())
+
+
+def test_host_mesh_from_store_non_local_rank_zero_is_passive(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Rank with LOCAL_RANK != 0 and RANK != 0 spawns nothing and returns
+    # None. Use rank 3 so group_rank = 3 // 2 = 1, letting us assert the
+    # key this rank's group would have published if local rank 0 had
+    # incorrectly invoked us is absent.
+    monkeypatch.setenv("RANK", "3")
+    monkeypatch.setenv("LOCAL_RANK", "1")
+    monkeypatch.setenv("WORLD_SIZE", "4")
+    monkeypatch.setenv("LOCAL_WORLD_SIZE", "2")
+
+    store = _InMemoryStore()
+    assert host_mesh_from_store(store, transport="ipc") is None
+    # This rank did not spawn; nobody published for group 1.
+    assert _worker_addr_key(1) not in store._values
+
+
+def test_parent_death_kills_worker_via_pipe_eof() -> None:
+    # End-to-end check for the parent-death safety net:
+    #   pytest runner (this PAR) -> intermediate parent -> worker
+    # The intermediate parent is launched by re-invoking this test's own
+    # PAR binary with PAR_MAIN_OVERRIDE pointing at
+    # tests.spmd_host_mesh_parent_helper. That helper calls
+    # _spawn_worker_process(...) and exits; the worker's only lifeline is
+    # the parent-watch pipe, so when the intermediate parent exits the
+    # kernel closes its write end and the worker's blocking os.read
+    # returns EOF, triggering os._exit(0).
+    env = {
+        **os.environ,
+        "PAR_MAIN_OVERRIDE": "tests.spmd_host_mesh_parent_helper",
+    }
+    result = subprocess.run(
+        [sys.argv[0]],
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=30,
+    )
+    assert result.returncode == 0, result.stderr
+    worker_pid = int(result.stdout.strip())
+
+    exited = _wait_for(lambda: not _pid_alive(worker_pid), timeout=10.0)
+    if not exited:
+        # Safety net failed to fire — kill the worker ourselves so the test
+        # harness doesn't leak it, then report the failure.
+        try:
+            os.kill(worker_pid, signal.SIGKILL)
+        except OSError:
+            pass
+    assert exited, f"worker pid={worker_pid} still alive after parent exit"


### PR DESCRIPTION
Summary:

Adds a reusable SPMD primitive for callers that want to stand up a Monarch host mesh from a torchrun/torchx-style entry point without going through the Monarch job API (SSHJob, ProcessJob, etc.). `host_mesh_from_store(store, *, monarch_port, name, transport, rank, local_rank, world_size, local_world_size)` is the public entry point: called collectively on every rank, it reads the torchelastic env vars (RANK/LOCAL_RANK/WORLD_SIZE/LOCAL_WORLD_SIZE) or the matching keyword overrides, spawns a worker subprocess on each local rank 0, publishes the worker addresses through the caller-supplied store, and on global rank 0 calls `attach_to_workers` to return a `HostMesh`. Non-primary ranks return `None`.

Default transport is `ipc` so that importing the helper doesn't silently open arbitrary TCP ports on user machines; multi-host callers explicitly opt into `tcp` / `metatls` / `metatls-hostname` and must supply a non-zero `monarch_port` (`0` is rejected to avoid the pre-reserve-then-bind race that a kernel-assigned port would introduce). IPC sockets live under a per-worker `tempfile.mkdtemp` tmpdir; the tmpdir is intentionally left for the OS's temp reaper, matching hyperactor's own path-based-socket behavior (`// TODO: we just leak these` in `hyperactor/src/channel/net.rs`).

Worker subprocesses are fire-and-forget. Each child inherits the read end of an `os.pipe()` whose write end stays open in the parent for the lifetime of the process; the parent never writes. The kernel closes the write end when the parent dies by any means — clean exit, segfault, SIGKILL — delivering EOF to the child's blocking `os.read` and letting it `os._exit(0)`. No `atexit` cleanup, because the interesting cases (crash, forced kill) wouldn't trigger one. A daemon watcher thread per worker waits on the Popen so zombies are reaped during parent lifetime and logs the exit status.

The child-side entry module is used under both standard Python (`python -m`) and PAR/XAR (via `PAR_MAIN_OVERRIDE`), and the listen address is always passed via `_MONARCH_WORKER_ADDR` rather than interpolated into a `-c` script, closing off the injection vector an AI reviewer flagged earlier.

Motivated by reviewer feedback on D101934196 (torchstore shouldn't manage Monarch subprocesses directly) and on D102049686 (ask for a higher-level API, pipe-EOF instead of heartbeats, let callers override torchelastic env vars). The downstream `torchstore.spmd` refactor onto `host_mesh_from_store` is the next diff in this stack.

Reviewed By: zdevito

Differential Revision: D102049686
