### PR TITLE
Unify hyperactor::instrument and instrument_infallible via proc macro

### DIFF
--- a/hyperactor/src/actor.rs
+++ b/hyperactor/src/actor.rs
@@ -120,7 +120,7 @@ pub trait Actor: Sized + Send + 'static {
     /// This method is used by the runtime to spawn the actor server. It can be
     /// used by actors that require customized runtime setups
     /// (e.g., dedicated actor threads), or want to use a custom tokio runtime.
-    #[hyperactor::instrument_infallible]
+    #[hyperactor::instrument]
     fn spawn_server_task<F>(future: F) -> JoinHandle<F::Output>
     where
         F: Future + Send + 'static,

--- a/hyperactor/src/channel.rs
+++ b/hyperactor/src/channel.rs
@@ -143,7 +143,7 @@ pub trait Tx<M: RemoteMessage> {
     }
 
     /// Enqueue a message to be sent on the channel.
-    #[hyperactor::instrument_infallible]
+    #[hyperactor::instrument]
     fn post(&self, message: M) {
         self.do_post(message, None);
     }

--- a/hyperactor/src/lib.rs
+++ b/hyperactor/src/lib.rs
@@ -130,8 +130,6 @@ pub use hyperactor_macros::export;
 pub use hyperactor_macros::handle;
 #[doc(inline)]
 pub use hyperactor_macros::instrument;
-#[doc(inline)]
-pub use hyperactor_macros::instrument_infallible;
 pub use hyperactor_macros::observe_async;
 pub use hyperactor_macros::observe_result;
 #[doc(inline)]

--- a/hyperactor_macros/src/lib.rs
+++ b/hyperactor_macros/src/lib.rs
@@ -1178,16 +1178,24 @@ pub fn handle(attr: TokenStream, item: TokenStream) -> TokenStream {
     TokenStream::from(expanded)
 }
 
-/// Use this macro in place of tracing::instrument to prevent spamming our tracing table.
-/// We set a default level of INFO while always setting ERROR if the function returns Result::Err giving us
-/// consistent and high quality structured logs. Because this wraps around tracing::instrument, all parameters
-/// mentioned in https://fburl.com/9jlkb5q4 should be valid. For functions that don't return a [`Result`] type, use
-/// [`instrument_infallible`]
+/// Use this macro in place of `tracing::instrument` to prevent spamming our tracing table.
+/// We set a default level of INFO while always setting ERROR if the function returns
+/// `Result::Err`, giving us consistent and high-quality structured logs. Because this wraps
+/// around `tracing::instrument`, all parameters mentioned in https://fburl.com/9jlkb5q4
+/// should be valid.
+///
+/// This macro auto-detects whether the function returns a `Result` type and, if so, adds the
+/// `err` flag to `tracing::instrument` so that errors are logged automatically.
 ///
 /// ```
 /// #[telemetry::instrument]
-/// async fn yolo() -> anyhow::Result<i32> {
+/// async fn fallible() -> anyhow::Result<i32> {
 ///     Ok(420)
+/// }
+///
+/// #[telemetry::instrument]
+/// async fn infallible() -> i32 {
+///     420
 /// }
 /// ```
 #[proc_macro_attribute]
@@ -1195,36 +1203,38 @@ pub fn instrument(args: TokenStream, input: TokenStream) -> TokenStream {
     let args =
         parse_macro_input!(args with Punctuated::<syn::Expr, syn::Token![,]>::parse_terminated);
     let input = parse_macro_input!(input as ItemFn);
-    let output = quote! {
-        #[hyperactor::internal_macro_support::tracing::instrument(err, skip_all, #args)]
-        #input
+
+    let output = if returns_result(&input) {
+        quote! {
+            #[hyperactor::internal_macro_support::tracing::instrument(err, skip_all, #args)]
+            #input
+        }
+    } else {
+        quote! {
+            #[hyperactor::internal_macro_support::tracing::instrument(skip_all, #args)]
+            #input
+        }
     };
 
     TokenStream::from(output)
 }
 
-/// Use this macro in place of tracing::instrument to prevent spamming our tracing table.
-/// Because this wraps around tracing::instrument, all parameters mentioned in
-/// https://fburl.com/9jlkb5q4 should be valid.
-///
-/// ```
-/// #[telemetry::instrument]
-/// async fn yolo() -> i32 {
-///     420
-/// }
-/// ```
-#[proc_macro_attribute]
-pub fn instrument_infallible(args: TokenStream, input: TokenStream) -> TokenStream {
-    let args =
-        parse_macro_input!(args with Punctuated::<syn::Expr, syn::Token![,]>::parse_terminated);
-    let input = parse_macro_input!(input as ItemFn);
+fn returns_result(func: &ItemFn) -> bool {
+    if let syn::ReturnType::Type(_, ty) = &func.sig.output {
+        return type_is_result(ty);
+    }
+    false
+}
 
-    let output = quote! {
-        #[hyperactor::internal_macro_support::tracing::instrument(skip_all, #args)]
-        #input
-    };
-
-    TokenStream::from(output)
+fn type_is_result(ty: &syn::Type) -> bool {
+    match ty {
+        syn::Type::Path(type_path) => type_path
+            .path
+            .segments
+            .last()
+            .is_some_and(|seg| seg.ident == "Result"),
+        _ => false,
+    }
 }
 
 struct HandlerSpec {

--- a/hyperactor_macros/tests/basic.rs
+++ b/hyperactor_macros/tests/basic.rs
@@ -21,7 +21,6 @@ use hyperactor::Handler;
 use hyperactor::RefClient;
 use hyperactor::handle;
 use hyperactor::instrument;
-use hyperactor::instrument_infallible;
 use hyperactor::reference;
 use serde::Deserialize;
 use serde::Serialize;
@@ -125,7 +124,7 @@ async fn yolo() -> Result<i32, i32> {
     Ok(10)
 }
 
-#[instrument_infallible(fields(crow = "black"))]
+#[instrument(fields(crow = "black"))]
 async fn yeet() -> String {
     String::from("cawwww")
 }

--- a/hyperactor_mesh/src/alloc/process.rs
+++ b/hyperactor_mesh/src/alloc/process.rs
@@ -304,7 +304,7 @@ impl Child {
         }
     }
 
-    #[hyperactor::instrument_infallible]
+    #[hyperactor::instrument]
     fn stop(&self, reason: ProcStopReason) {
         let _ = self.stop_reason.set(reason); // first stop wins
         self.group.fail();
@@ -354,7 +354,7 @@ impl Child {
         });
     }
 
-    #[hyperactor::instrument_infallible]
+    #[hyperactor::instrument]
     fn post(&mut self, message: Allocator2Process) {
         if let ChannelState::Connected(channel) = &mut self.channel {
             channel.post(message);
@@ -395,7 +395,7 @@ impl ProcessAlloc {
     // Currently procs and processes are 1:1, so this just fully exits
     // the process.
 
-    #[hyperactor::instrument_infallible]
+    #[hyperactor::instrument]
     fn stop(
         &mut self,
         proc_id: &hyperactor_reference::ProcId,
@@ -449,7 +449,7 @@ impl ProcessAlloc {
             .map_err(|e| anyhow::anyhow!("failed to parse index from proc name '{}': {}", name, e))
     }
 
-    #[hyperactor::instrument_infallible]
+    #[hyperactor::instrument]
     async fn maybe_spawn(&mut self) -> Option<ProcState> {
         if self.active.len() >= self.spec.extent.num_ranks() {
             return None;
@@ -576,7 +576,7 @@ impl ProcessAlloc {
 
 #[async_trait]
 impl Alloc for ProcessAlloc {
-    #[hyperactor::instrument_infallible]
+    #[hyperactor::instrument]
     async fn next(&mut self) -> Option<ProcState> {
         if !self.running && self.active.is_empty() {
             return None;


### PR DESCRIPTION
Summary:
The `instrument` macro now auto-detects whether the annotated function returns a `Result` type and conditionally adds the `err` flag to `tracing::instrument`. This eliminates the need for a separate `instrument_infallible` macro.

- Modified `instrument` to inspect the return type at compile time using `syn`, checking if the last path segment is `Result`
- If the function returns `Result`, `err` is added (matching old `instrument` behavior)
- If not, only `skip_all` is used (matching old `instrument_infallible` behavior)
- Removed `instrument_infallible` entirely and its re-export from `hyperactor`
- Migrated all existing `instrument_infallible` call sites to `instrument`

Differential Revision: D102027869


