### PR TITLE
[monarch] add point-to-point optimization for small v1 casts

### DIFF
--- a/hyperactor_mesh/src/actor_mesh.rs
+++ b/hyperactor_mesh/src/actor_mesh.rs
@@ -23,14 +23,18 @@ use std::time::Duration;
 use hyperactor::ActorLocal;
 use hyperactor::RemoteHandles;
 use hyperactor::RemoteMessage;
+use hyperactor::accum::ReducerMode;
 use hyperactor::actor::ActorStatus;
 use hyperactor::actor::Referable;
 use hyperactor::context;
 use hyperactor::mailbox::PortReceiver;
 use hyperactor::message::Castable;
+use hyperactor::message::ErasedUnbound;
 use hyperactor::message::IndexedErasedUnbound;
 use hyperactor::message::Unbound;
 use hyperactor::reference as hyperactor_reference;
+use hyperactor::reference::UnboundPort;
+use hyperactor::reference::UnboundPortKind;
 use hyperactor::supervision::ActorSupervisionEvent;
 use hyperactor_config::CONFIG;
 use hyperactor_config::ConfigAttr;
@@ -57,6 +61,7 @@ use crate::ValueMesh;
 use crate::casting;
 use crate::comm::multicast;
 use crate::comm::multicast::CastMessageV1;
+use crate::config::V1_CAST_POINT_TO_POINT_THRESHOLD;
 use crate::host_mesh::GET_PROC_STATE_MAX_IDLE;
 use crate::host_mesh::mesh_to_rankedvalues_with_default;
 use crate::mesh_controller::ActorMeshController;
@@ -617,11 +622,97 @@ impl<A: Referable> ActorMeshRef<A> {
         ));
 
         let actor_ids: ValueMesh<_> = self.proc_mesh.map_into(|proc| proc.actor_id(&self.name));
-        // This block is infallible so is okay to assign the sequence numbers
-        // without worrying about rollback.
-        {
+
+        let mut headers = Flattrs::new();
+        headers.set(
+            multicast::CAST_ORIGINATING_SENDER,
+            cx.instance().self_id().clone(),
+        );
+        // Set CAST_ACTOR_MESH_ID temporarily to support supervision's
+        // v0 transition. Should be removed once supervision is migrated
+        // and ActorMeshId is deleted.
+        let actor_mesh_id = ActorMeshId(self.name.clone());
+        headers.set(casting::CAST_ACTOR_MESH_ID, actor_mesh_id);
+
+        let region = view::Ranked::region(self).clone();
+        let num_ranks = region.num_ranks();
+        let threshold = hyperactor_config::global::get(V1_CAST_POINT_TO_POINT_THRESHOLD);
+
+        if threshold > 0 && num_ranks < threshold {
+            // Point-to-point: send directly to each destination actor,
+            // bypassing the comm actor tree for lower latency when fanout
+            // is small.
+            let sender = cx.instance().self_id().clone();
+            let dest_port = <IndexedErasedUnbound<M> as typeuri::Named>::port();
+
+            let mut data = ErasedUnbound::try_from_message(message)
+                .expect("cast message serialization should not fail");
+
+            // Split ports for N destinations, matching the comm tree's
+            // split_ports behavior.
+            data.visit_mut::<UnboundPort>(
+                |UnboundPort(port_id, reducer_spec, return_undeliverable, kind, unsplit)| {
+                    if *unsplit {
+                        return Ok(());
+                    }
+                    let reducer_mode = match kind {
+                        UnboundPortKind::Streaming(opts) => {
+                            ReducerMode::Streaming(opts.clone().unwrap_or_default())
+                        }
+                        UnboundPortKind::Once if reducer_spec.is_none() => {
+                            // Once ports without reducers pass through — same as
+                            // the comm tree's split_ports.
+                            return Ok(());
+                        }
+                        UnboundPortKind::Once => ReducerMode::Once(num_ranks),
+                    };
+                    let split = port_id.split(
+                        cx,
+                        reducer_spec.clone(),
+                        reducer_mode,
+                        *return_undeliverable,
+                    )?;
+                    *port_id = split;
+                    Ok(())
+                },
+            )
+            .expect("port splitting should not fail");
+
+            for rank in 0..num_ranks {
+                let mut rank_data = data.clone();
+
+                let cast_point = region
+                    .point_of_base_rank(rank)
+                    .expect("rank should be valid in region");
+
+                rank_data
+                    .visit_mut::<resource::Rank>(|resource::Rank(r)| {
+                        *r = Some(cast_point.rank());
+                        Ok(())
+                    })
+                    .expect("rank replacement should not fail");
+
+                let mut rank_headers = headers.clone();
+                multicast::set_cast_info_on_headers(&mut rank_headers, cast_point, sender.clone());
+
+                let port_id = actor_ids
+                    .get(rank)
+                    .expect("mismatched actor_ids and dest_region")
+                    .port_id(dest_port);
+
+                cx.instance().post(
+                    port_id,
+                    rank_headers,
+                    wirevalue::Any::serialize(&rank_data)
+                        .expect("cast message serialization should not fail"),
+                );
+            }
+        } else {
+            // Tree path: route through the comm actor tree.
+            // Pre-compute sequence numbers — this block is infallible so
+            // rollback is not a concern.
             let sequencer = cx.instance().sequencer();
-            let seqs = actor_ids.map_into(|actor_id| {
+            let seqs: ValueMesh<u64> = actor_ids.map_into(|actor_id| {
                 let hyperactor::ordering::SeqInfo::Session { seq, .. } =
                     sequencer.assign_seq(&actor_id.port_id(<M as typeuri::Named>::port()))
                 else {
@@ -630,20 +721,10 @@ impl<A: Referable> ActorMeshRef<A> {
                 seq
             });
 
-            let mut headers = Flattrs::new();
-            headers.set(
-                multicast::CAST_ORIGINATING_SENDER,
-                cx.instance().self_id().clone(),
-            );
-            // Set CAST_ACTOR_MESH_ID temporarily to support supervision's
-            // v0 transition. Should be removed once supervision is migrated
-            // and ActorMeshId is deleted.
-            let actor_mesh_id = ActorMeshId(self.name.clone());
-            headers.set(casting::CAST_ACTOR_MESH_ID, actor_mesh_id);
             let cast_message = CastMessageV1::new::<A, M>(
                 cx.instance().self_id().clone(),
                 &self.name,
-                view::Ranked::region(self).clone(),
+                region,
                 headers.clone(),
                 message,
                 sequencer.session_id(),
@@ -1419,10 +1500,8 @@ mod tests {
         let _ = hm.shutdown(instance).await;
     }
 
-    #[async_timed_test(timeout_secs = 30)]
     #[cfg(fbcode_build)]
-    async fn test_cast() {
-        let config = hyperactor_config::global::lock();
+    async fn execute_cast(config: &hyperactor_config::global::ConfigLock) {
         let _guard = config.override_key(crate::bootstrap::MESH_BOOTSTRAP_ENABLE_PDEATHSIG, false);
 
         let instance = testing::instance();
@@ -1518,6 +1597,21 @@ mod tests {
         assert_eq!(all_ranks, HashSet::from([0, 1, 2, 3]));
 
         let _ = host_mesh.shutdown(instance).await;
+    }
+
+    #[async_timed_test(timeout_secs = 30)]
+    #[cfg(fbcode_build)]
+    async fn test_cast() {
+        let config = hyperactor_config::global::lock();
+        execute_cast(&config).await;
+    }
+
+    #[async_timed_test(timeout_secs = 30)]
+    #[cfg(fbcode_build)]
+    async fn test_cast_p2p() {
+        let config = hyperactor_config::global::lock();
+        let _guard = config.override_key(crate::config::V1_CAST_POINT_TO_POINT_THRESHOLD, 1024);
+        execute_cast(&config).await;
     }
 
     /// Test that undeliverable messages are properly returned to the

--- a/hyperactor_mesh/src/comm.rs
+++ b/hyperactor_mesh/src/comm.rs
@@ -1388,11 +1388,17 @@ mod tests {
                     // port 0 is still the same as the original one because it
                     // is not included in MutVisitor.
                     assert_eq!(reply_to0, reply_port_ref0);
-                    // ports have been replaced by comm actor's split ports.
+                    // ports have been replaced by split ports.
                     assert_ne!(reply_to1, reply_port_ref1);
-                    assert!(reply_to1.port_id().actor_id().name().contains("comm"));
                     assert_ne!(reply_to2, reply_port_ref2);
-                    assert!(reply_to2.port_id().actor_id().name().contains("comm"));
+                    let p2p_threshold = hyperactor_config::global::get(
+                        crate::config::V1_CAST_POINT_TO_POINT_THRESHOLD,
+                    );
+                    if p2p_threshold == 0 {
+                        // Tree path: split ports belong to comm actors.
+                        assert!(reply_to1.port_id().actor_id().name().contains("comm"));
+                        assert!(reply_to2.port_id().actor_id().name().contains("comm"));
+                    }
                     reply_tos.push((reply_to1, reply_to2));
                 }
                 _ => {
@@ -1401,24 +1407,30 @@ mod tests {
             }
         }
 
-        // [collect_commactor_routing_tree] only returns ranks,So we need to
-        // map proc Ids collected in SPLIT_PORT_TREE to ranks.
-        let rank_lookup = proc_mesh
-            .ranks()
-            .iter()
-            .enumerate()
-            .map(|(i, r)| (r.proc_id().clone(), i))
-            .collect::<HashMap<hyperactor_reference::ProcId, usize>>();
+        // verify_split_port_paths only applies to the tree path;
+        // in point-to-point mode no comm actors are involved.
+        let p2p_threshold =
+            hyperactor_config::global::get(crate::config::V1_CAST_POINT_TO_POINT_THRESHOLD);
+        if p2p_threshold == 0 {
+            // [collect_commactor_routing_tree] only returns ranks, so we need
+            // to map proc IDs collected in SPLIT_PORT_TREE to ranks.
+            let rank_lookup = proc_mesh
+                .ranks()
+                .iter()
+                .enumerate()
+                .map(|(i, r)| (r.proc_id().clone(), i))
+                .collect::<HashMap<hyperactor_reference::ProcId, usize>>();
 
-        // v1 always uses sel!(*) when casting to a mesh.
-        let selection = sel!(*);
-        verify_split_port_paths(
-            &selection,
-            &proc_mesh.extent(),
-            &reply_port_ref1,
-            &reply_port_ref2,
-            &rank_lookup,
-        );
+            // v1 always uses sel!(*) when casting to a mesh.
+            let selection = sel!(*);
+            verify_split_port_paths(
+                &selection,
+                &proc_mesh.extent(),
+                &reply_port_ref1,
+                &reply_port_ref2,
+                &rank_lookup,
+            );
+        }
 
         MeshSetupV1 {
             instance,
@@ -1468,6 +1480,18 @@ mod tests {
         execute_cast_and_reply_v1().await
     }
 
+    #[async_timed_test(timeout_secs = 60)]
+    async fn test_cast_and_reply_v1_native_p2p() {
+        let config = hyperactor_config::global::lock();
+        let _guard = config.override_key(ENABLE_NATIVE_V1_CASTING, true);
+        let _guard2 = config.override_key(
+            hyperactor::config::ENABLE_DEST_ACTOR_REORDERING_BUFFER,
+            true,
+        );
+        let _guard3 = config.override_key(crate::config::V1_CAST_POINT_TO_POINT_THRESHOLD, 1024);
+        execute_cast_and_reply_v1().await
+    }
+
     async fn execute_cast_and_accum_v1(config: &hyperactor_config::global::ConfigLock) {
         // Use temporary config for this test
         let _guard1 = config.override_key(hyperactor::config::SPLIT_MAX_BUFFER_SIZE, 1);
@@ -1499,6 +1523,18 @@ mod tests {
             hyperactor::config::ENABLE_DEST_ACTOR_REORDERING_BUFFER,
             true,
         );
+        execute_cast_and_accum_v1(&config).await
+    }
+
+    #[async_timed_test(timeout_secs = 60)]
+    async fn test_cast_and_accum_v1_native_p2p() {
+        let config = hyperactor_config::global::lock();
+        let _guard = config.override_key(ENABLE_NATIVE_V1_CASTING, true);
+        let _guard2 = config.override_key(
+            hyperactor::config::ENABLE_DEST_ACTOR_REORDERING_BUFFER,
+            true,
+        );
+        let _guard3 = config.override_key(crate::config::V1_CAST_POINT_TO_POINT_THRESHOLD, 1024);
         execute_cast_and_accum_v1(&config).await
     }
 
@@ -1557,9 +1593,15 @@ mod tests {
                 TestMessage::CastAndReplyOnce { arg, reply_to } => {
                     assert_eq!(arg, "abc");
                     if has_reducer {
-                        // With reducer: port is split by comm actor.
+                        // With reducer: port is split.
                         assert_ne!(reply_to, reply_port_ref);
-                        assert!(reply_to.port_id().actor_id().name().contains("comm"));
+                        let p2p_threshold = hyperactor_config::global::get(
+                            crate::config::V1_CAST_POINT_TO_POINT_THRESHOLD,
+                        );
+                        if p2p_threshold == 0 {
+                            // Tree path: split port belongs to a comm actor.
+                            assert!(reply_to.port_id().actor_id().name().contains("comm"));
+                        }
                     } else {
                         // Without reducer: port is passed through unchanged.
                         assert_eq!(reply_to, reply_port_ref);
@@ -1581,8 +1623,7 @@ mod tests {
         }
     }
 
-    #[async_timed_test(timeout_secs = 60)]
-    async fn test_cast_and_reply_once_v1() {
+    async fn execute_cast_and_reply_once_v1() {
         // Test OncePort without accumulator - port is NOT split.
         // All destinations receive the same original port.
         // First reply is delivered, others fail at receiver (port closed).
@@ -1604,7 +1645,18 @@ mod tests {
     }
 
     #[async_timed_test(timeout_secs = 60)]
-    async fn test_cast_and_accum_once_v1() {
+    async fn test_cast_and_reply_once_v1() {
+        execute_cast_and_reply_once_v1().await
+    }
+
+    #[async_timed_test(timeout_secs = 60)]
+    async fn test_cast_and_reply_once_v1_p2p() {
+        let config = hyperactor_config::global::lock();
+        let _guard = config.override_key(crate::config::V1_CAST_POINT_TO_POINT_THRESHOLD, 1024);
+        execute_cast_and_reply_once_v1().await
+    }
+
+    async fn execute_cast_and_accum_once_v1() {
         // Test OncePort splitting with sum accumulator.
         // Each destination actor replies with its rank.
         // The sum of all ranks should be received at the original port.
@@ -1622,6 +1674,18 @@ mod tests {
         assert_eq!(result, expected_sum);
 
         let _ = setup.host_mesh.shutdown(setup.instance).await;
+    }
+
+    #[async_timed_test(timeout_secs = 60)]
+    async fn test_cast_and_accum_once_v1() {
+        execute_cast_and_accum_once_v1().await
+    }
+
+    #[async_timed_test(timeout_secs = 60)]
+    async fn test_cast_and_accum_once_v1_p2p() {
+        let config = hyperactor_config::global::lock();
+        let _guard = config.override_key(crate::config::V1_CAST_POINT_TO_POINT_THRESHOLD, 1024);
+        execute_cast_and_accum_once_v1().await
     }
 
     #[async_timed_test(timeout_secs = 60)]

--- a/hyperactor_mesh/src/config.rs
+++ b/hyperactor_mesh/src/config.rs
@@ -265,4 +265,13 @@ declare_attrs! {
         Some("pyspy_bin".to_string()),
     ))
     pub attr PYSPY_BIN: String = String::new();
+
+    /// When the cast domain has fewer ranks than this threshold,
+    /// v1 casting sends messages point-to-point instead of through the
+    /// comm actor tree. 0 disables the optimization.
+    @meta(CONFIG = ConfigAttr::new(
+        Some("HYPERACTOR_MESH_V1_CAST_POINT_TO_POINT_THRESHOLD".to_string()),
+        Some("v1_cast_point_to_point_threshold".to_string()),
+    ))
+    pub attr V1_CAST_POINT_TO_POINT_THRESHOLD: usize = 0;
 }

--- a/hyperactor_mesh/src/proc_mesh.rs
+++ b/hyperactor_mesh/src/proc_mesh.rs
@@ -1479,6 +1479,16 @@ mod tests {
 
     #[async_timed_test(timeout_secs = 30)]
     #[cfg(fbcode_build)]
+    async fn test_spawn_actor_v1_casting_p2p() {
+        let config = hyperactor_config::global::lock();
+        let _guard = config.override_key(ENABLE_NATIVE_V1_CASTING, true);
+        let _guard2 = config.override_key(ENABLE_DEST_ACTOR_REORDERING_BUFFER, true);
+        let _guard3 = config.override_key(crate::config::V1_CAST_POINT_TO_POINT_THRESHOLD, 1024);
+        execute_spawn_actor().await;
+    }
+
+    #[async_timed_test(timeout_secs = 30)]
+    #[cfg(fbcode_build)]
     async fn test_spawn_actor_v0_casting() {
         let config = hyperactor_config::global::lock();
         let _guard = config.override_key(ENABLE_NATIVE_V1_CASTING, false);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #3579
* #2850
* #2849
* #2848
* #2847

When the number of destination ranks is below a configurable threshold,
cast_v1 bypasses the comm actor tree and sends messages directly to each
destination actor. This reduces latency for small meshes by avoiding the
tree routing overhead.

The optimization is controlled by the new
HYPERACTOR_MESH_V1_CAST_POINT_TO_POINT_THRESHOLD config attr (default 0,
disabled). When enabled, messages are serialized once, ports are split
identically to the comm tree's split_ports behavior, and each rank
receives a copy with proper headers and sequence info.

Also removes vestigial crate::trace:: macro calls from mailbox.rs.

All existing V1 cast tests are parameterized to run with both the tree
path (threshold=0) and point-to-point path (threshold=1024) to verify
identical behavior.

Differential Revision: [D95833674](https://our.internmc.facebook.com/intern/diff/D95833674/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D95833674/)!