### PR TITLE
make undelivered mailbox logs bounded and readable (#3580)

### DIFF
--- a/hyperactor/src/mailbox.rs
+++ b/hyperactor/src/mailbox.rs
@@ -66,6 +66,31 @@
 //! While this complicates the interface somewhat, it allows the
 //! implementation to avoid a serialization roundtrip when passing
 //! messages locally.
+//!
+//! ## Undeliverable-message log invariants (UM-*)
+//!
+//! The `undelivered_message_abandoned` log at
+//! `UndeliverableMailboxSender::post_unchecked` is a user-facing
+//! surface: it fires when a message could not be delivered *and*
+//! could not be returned to its sender. The following invariants
+//! govern its shape so the log stays scannable and its downstream
+//! consumers (Scuba, alerts) stay stable.
+//!
+//! - **UM-1 (bounded abandoned-message log).** The log must not emit
+//!   unbounded `envelope.headers().to_string()` or
+//!   `envelope.data().to_string()`. Payload observability is provided
+//!   by `message_type` (`data.typename()`) and `data_len`
+//!   (`data.len()`) — cheap, bounded, and type-safe.
+//!
+//! - **UM-2 (stable compatibility fields).** The `actor_name` and
+//!   `actor_id` fields stay on the log with their current values and
+//!   types. Readability improvements are strictly additive on this
+//!   surface; renames or removals require a separate migration diff
+//!   that coordinates with downstream consumers.
+//!
+//! - **UM-3 (destination naming).** The human-facing format string
+//!   names the transport destination: `"message not delivered to
+//!   <dest>"`.
 
 use std::any::Any;
 use std::collections::BTreeMap;
@@ -845,18 +870,23 @@ impl MailboxSender for UndeliverableMailboxSender {
             .label()
             .map_or("?".to_string(), |l| l.to_string());
         let error_str = envelope.error_msg().unwrap_or("".to_string());
-        // The undeliverable message was unable to be delivered back to the
-        // sender for some reason
+        // The undeliverable message was unable to be delivered back
+        // to the sender for some reason. See UM-1..UM-3 in the
+        // module docs: `headers` / `data` are deliberately not
+        // rendered (UM-1); `actor_name` / `actor_id` are preserved
+        // as-is (UM-2); the format string names the destination
+        // (UM-3).
         tracing::error!(
             name = "undelivered_message_abandoned",
             actor_name = sender_name,
             actor_id = envelope.sender.to_string(),
             dest = envelope.dest.to_string(),
-            headers = envelope.headers().to_string(), // todo: implement tracing::Value for Flattrs
-            data = envelope.data().to_string(),
+            message_type = envelope.data().typename().unwrap_or("unknown"),
+            data_len = envelope.data().len(),
             return_handle = %return_handle,
-            "message not delivered, {}",
-            error_str,
+            error = %error_str,
+            "message not delivered to {}",
+            envelope.dest,
         );
     }
 }
@@ -4515,5 +4545,113 @@ mod tests {
 
         serve_handle.stop("test done");
         serve_handle.await.unwrap().unwrap();
+    }
+
+    /// Helper: build a `MessageEnvelope` with a recognizable payload
+    /// and non-empty headers, then feed it through
+    /// `UndeliverableMailboxSender::post_unchecked`. Returns the
+    /// sender + destination so tests can assert against the values we
+    /// know will end up on the log.
+    fn drive_abandonment_log(payload_sentinel: &str) -> (reference::ActorId, reference::PortId) {
+        use hyperactor_config::declare_attrs;
+
+        declare_attrs! {
+            // Any non-empty entry works; UM-1 only asserts the log
+            // does not dump `headers` inline.
+            attr UM_TEST_HEADER: u64;
+        }
+
+        let sender = test_actor_id("um_proc", "um_sender");
+        let dest = test_port_id("um_dest_proc", "um_dest", 42);
+
+        let mut headers = Flattrs::new();
+        headers.set(UM_TEST_HEADER, 0xC0FFEEu64);
+
+        let envelope = MessageEnvelope::new(
+            sender.clone(),
+            dest.clone(),
+            wirevalue::Any::serialize(&payload_sentinel.to_string()).unwrap(),
+            headers,
+        );
+
+        let (return_handle, _rx) = crate::mailbox::undeliverable::new_undeliverable_port();
+        UndeliverableMailboxSender.post_unchecked(envelope, return_handle);
+        (sender, dest)
+    }
+
+    /// UM-1: the log does not render unbounded `headers` or `data`
+    /// fields, and reports bounded `message_type` + `data_len`
+    /// summaries instead.
+    #[tracing_test::traced_test]
+    #[test]
+    fn test_um1_bounded_fields() {
+        let payload_sentinel = "um1_payload_sentinel_5b7a9c3d";
+        let (_sender, _dest) = drive_abandonment_log(payload_sentinel);
+
+        let buf = tracing_test::internal::global_buf().lock().unwrap();
+        let logs = std::str::from_utf8(&buf).expect("logs are utf-8");
+
+        // Bounded summaries are present.
+        assert!(
+            logs.contains("message_type="),
+            "UM-1: expected message_type field, got:\n{logs}"
+        );
+        assert!(
+            logs.contains("data_len="),
+            "UM-1: expected data_len field, got:\n{logs}"
+        );
+        // The payload body must not appear (no `data=<full body>`
+        // dump).
+        assert!(
+            !logs.contains(payload_sentinel),
+            "UM-1: payload body leaked into the log:\n{logs}"
+        );
+        // The `headers=` field must not appear. Use a space-prefixed
+        // match to avoid matching e.g. the word "headers" in free
+        // prose.
+        assert!(
+            !logs.contains(" headers="),
+            "UM-1: unbounded headers field leaked into the log:\n{logs}"
+        );
+    }
+
+    /// UM-2: the `actor_name` and `actor_id` fields are preserved
+    /// on the log for downstream Scuba / alert compatibility — same
+    /// field names, same values, same types as the prior shape.
+    #[tracing_test::traced_test]
+    #[test]
+    fn test_um2_compat_fields_preserved() {
+        let (sender, _dest) = drive_abandonment_log("um2_payload");
+
+        let buf = tracing_test::internal::global_buf().lock().unwrap();
+        let logs = std::str::from_utf8(&buf).expect("logs are utf-8");
+
+        // Decouple field-presence from value-presence so the test
+        // does not depend on the tracing formatter's quoting rules.
+        let actor_name = sender.log_name();
+        let actor_id = sender.to_string();
+        assert!(
+            logs.contains("actor_name=") && logs.contains(actor_name),
+            "UM-2: expected actor_name={actor_name} on the log, got:\n{logs}"
+        );
+        assert!(
+            logs.contains("actor_id=") && logs.contains(&actor_id),
+            "UM-2: expected actor_id={actor_id} on the log, got:\n{logs}"
+        );
+    }
+
+    /// UM-3: the format string names the transport destination.
+    #[tracing_test::traced_test]
+    #[test]
+    fn test_um3_destination_format() {
+        let (_sender, dest) = drive_abandonment_log("um3_payload");
+
+        let buf = tracing_test::internal::global_buf().lock().unwrap();
+        let logs = std::str::from_utf8(&buf).expect("logs are utf-8");
+
+        assert!(
+            logs.contains(&format!("message not delivered to {}", dest)),
+            "UM-3: expected destination-naming format string, got:\n{logs}"
+        );
     }
 }

--- a/hyperactor_config/src/attrs.rs
+++ b/hyperactor_config/src/attrs.rs
@@ -116,6 +116,8 @@ use serde::de::Visitor;
 use serde::ser::SerializeMap;
 use typeuri::Named;
 
+use crate::flattrs::Flattrs;
+
 // Information about an attribute key, used for automatic registration.
 // This needs to be public to be accessible from other crates, but it is
 // not part of the public API.
@@ -160,6 +162,99 @@ pub fn lookup_key_info(key_hash: u64) -> Option<&'static AttrKeyInfo> {
                 .collect()
         });
     KEYS_BY_HASH.get(&key_hash).copied()
+}
+
+/// Look up a key info by name using the global registry.
+///
+/// Returns `None` if no key with this name is registered.
+/// Uses a lazy-initialized hash map for O(1) lookup after first access.
+pub fn lookup_key_info_by_name(name: &str) -> Option<&'static AttrKeyInfo> {
+    static KEYS_BY_NAME: std::sync::LazyLock<
+        std::collections::HashMap<&'static str, &'static AttrKeyInfo>,
+    > = std::sync::LazyLock::new(|| {
+        inventory::iter::<AttrKeyInfo>()
+            .map(|info| (info.name, info))
+            .collect()
+    });
+    KEYS_BY_NAME.get(name).copied()
+}
+
+/// Returns `Some(true)` when the declared attribute key with this
+/// name carries the given bool meta marker with value `true`,
+/// `Some(false)` when it carries the marker with value `false`, and
+/// `None` for unknown names or declared keys that do not carry the
+/// marker at all.
+///
+/// Generic "is this attr a member of the category declared by this
+/// marker?" primitive. The lower layer does not know what category
+/// the marker names — the caller supplies the category marker that
+/// defines its vocabulary (e.g. `ATTRIBUTION_HEADER` for attribution
+/// data carried on envelope headers).
+pub fn is_attr_marked_with(name: &str, marker: Key<bool>) -> Option<bool> {
+    let info = lookup_key_info_by_name(name)?;
+    info.meta.get(marker).copied()
+}
+
+/// Copy every entry from `attrs` onto `dst` whose declared
+/// attribute key carries the bool meta marker `marker` with value
+/// `true`. Overwrite semantics (see `Flattrs::set_serialized`) — a
+/// later write for the same `key_hash` is the value returned by
+/// `Flattrs::get`. Entries whose declared key lacks the marker are
+/// silently skipped; entries whose key is not declared are also
+/// silently skipped.
+///
+/// Generic category-filter stamp. The lower layer does not know what
+/// category the marker names; callers pass the marker key that
+/// defines their vocabulary (e.g. `ATTRIBUTION_HEADER`). This is
+/// the single mechanism every `Attrs → Flattrs` stamp for a category
+/// should go through, so category membership is declared in one
+/// place (the meta annotation on each key) and enforced in one
+/// place (this helper).
+pub fn stamp_marked_attrs_into_flattrs(dst: &mut Flattrs, attrs: &Attrs, marker: Key<bool>) {
+    for (name, value) in attrs.iter() {
+        if is_attr_marked_with(name, marker) != Some(true) {
+            continue;
+        }
+        dst.set_serialized(fnv1a_hash(name.as_bytes()), &value.serialize_bincode());
+    }
+}
+
+/// Copy every entry from `src` to `dst` whose declared attribute
+/// key carries the bool meta marker `marker` with value `true`.
+/// Overwrite semantics (see `Flattrs::set_serialized`). Entries
+/// whose declared key lacks the marker — or whose key_hash does
+/// not resolve to a declared key in the current binary's
+/// inventory — are silently skipped.
+///
+/// Generic category-filter `Flattrs → Flattrs` copy. The companion
+/// of `stamp_marked_attrs_into_flattrs` for callers that already
+/// have a source `Flattrs` in hand (forwarding, hoisting) rather
+/// than an in-memory `Attrs`.
+pub fn copy_marked_flattrs(dst: &mut Flattrs, src: &Flattrs, marker: Key<bool>) {
+    for (key_hash, value) in src.iter() {
+        let Some(info) = lookup_key_info(key_hash) else {
+            continue;
+        };
+        if info.meta.get(marker).copied() != Some(true) {
+            continue;
+        }
+        dst.set_serialized(key_hash, value);
+    }
+}
+
+/// Returns the set of all declared attribute key names that carry
+/// the given bool meta marker (set to `true`) in the attrs
+/// inventory linked into the current binary.
+///
+/// Generic category-membership enumeration. Used by consumers that
+/// maintain explicit hard-coded category sets (for auditability)
+/// to validate the set matches the declaration-driven vocabulary;
+/// drift between the two is a bug.
+pub fn marked_attr_names(marker: Key<bool>) -> std::collections::HashSet<&'static str> {
+    inventory::iter::<AttrKeyInfo>()
+        .filter(|info| info.meta.get(marker).copied() == Some(true))
+        .map(|info| info.name)
+        .collect()
 }
 
 /// A typed key for the attribute dictionary.
@@ -1451,5 +1546,105 @@ mod tests {
         let displayed = AttrValue::display(&original);
         let parsed: Vec<String> = AttrValue::parse(&displayed).unwrap();
         assert_eq!(parsed, original);
+    }
+
+    declare_attrs! {
+        /// Test-local marker for the generic mechanism's
+        /// membership / stamp / copy / enumeration tests. Scoped to
+        /// the test module so the mechanism's coverage does not
+        /// depend on any caller-defined marker vocabulary.
+        pub attr TEST_GENERIC_MARKER: bool;
+
+        /// Declared attr carrying the test-local marker.
+        @meta(TEST_GENERIC_MARKER = true)
+        pub attr TEST_MARKED_ATTR: String;
+
+        /// Declared attr NOT carrying the test-local marker.
+        pub attr TEST_UNMARKED_ATTR: String;
+    }
+
+    // Generic marker-parameterized membership check: the helper
+    // does not know about any specific category; callers supply
+    // the marker. Validates that declared keys with
+    // `@meta(TEST_GENERIC_MARKER = true)` match and keys without
+    // do not.
+    #[test]
+    fn test_is_attr_marked_with() {
+        assert_eq!(
+            is_attr_marked_with(TEST_MARKED_ATTR.name(), TEST_GENERIC_MARKER),
+            Some(true),
+            "marked key must report Some(true)",
+        );
+        assert_eq!(
+            is_attr_marked_with(TEST_UNMARKED_ATTR.name(), TEST_GENERIC_MARKER),
+            None,
+            "unmarked key must report None (marker not present on its meta)",
+        );
+        assert_eq!(
+            is_attr_marked_with(
+                "hyperactor_config::attrs::tests::no_such_key_declared_anywhere",
+                TEST_GENERIC_MARKER,
+            ),
+            None,
+            "unknown names must report None",
+        );
+    }
+
+    // Generic marker-parameterized Attrs → Flattrs stamp. Builds
+    // an `Attrs` with one marked and one unmarked entry; stamps
+    // via the generic helper with `TEST_GENERIC_MARKER`; asserts
+    // only the marked entry lands on headers.
+    #[test]
+    fn test_stamp_marked_attrs_into_flattrs() {
+        use crate::flattrs::Flattrs;
+
+        let mut attrs = Attrs::new();
+        attrs.set(TEST_MARKED_ATTR, "marked_value".to_string());
+        attrs.set(TEST_UNMARKED_ATTR, "unmarked_value".to_string());
+
+        let mut headers = Flattrs::new();
+        stamp_marked_attrs_into_flattrs(&mut headers, &attrs, TEST_GENERIC_MARKER);
+
+        assert_eq!(
+            headers.get(TEST_MARKED_ATTR),
+            Some("marked_value".to_string()),
+        );
+        assert_eq!(headers.get::<String>(TEST_UNMARKED_ATTR), None);
+    }
+
+    // Generic marker-parameterized Flattrs → Flattrs copy. The
+    // source Flattrs gets populated with both marked and unmarked
+    // values via typed `set` (by-key-hash stamping); the generic
+    // copy resolves each key_hash through the inventory, filters by
+    // marker, and copies only the marked entry.
+    #[test]
+    fn test_copy_marked_flattrs() {
+        use crate::flattrs::Flattrs;
+
+        let mut src = Flattrs::new();
+        src.set(TEST_MARKED_ATTR, "marked".to_string());
+        src.set(TEST_UNMARKED_ATTR, "unmarked".to_string());
+
+        let mut dst = Flattrs::new();
+        copy_marked_flattrs(&mut dst, &src, TEST_GENERIC_MARKER);
+
+        assert_eq!(dst.get(TEST_MARKED_ATTR), Some("marked".to_string()),);
+        assert_eq!(dst.get::<String>(TEST_UNMARKED_ATTR), None);
+    }
+
+    // Generic marker-parameterized enumeration. The test-local
+    // `TEST_MARKED_ATTR` is marked, so it must appear; the
+    // unmarked test attr must not.
+    #[test]
+    fn test_marked_attr_names_enumeration() {
+        let names = marked_attr_names(TEST_GENERIC_MARKER);
+        assert!(
+            names.contains(TEST_MARKED_ATTR.name()),
+            "marked test attr must appear in the vocabulary enumeration",
+        );
+        assert!(
+            !names.contains(TEST_UNMARKED_ATTR.name()),
+            "unmarked test attr must not appear in the vocabulary enumeration",
+        );
     }
 }

--- a/hyperactor_config/src/flattrs.rs
+++ b/hyperactor_config/src/flattrs.rs
@@ -114,13 +114,30 @@ impl Flattrs {
         let key_hash = key.key_hash();
         let serialized = bincode::serde::encode_to_vec(&value, bincode::config::legacy())
             .expect("serialization failed");
+        self.set_serialized(key_hash, &serialized);
+    }
 
-        // If key exists, either overwrite in place or compact + append
+    /// Set an entry by its `(key_hash, serialized_value)` pair,
+    /// replacing any existing entry under the same `key_hash`.
+    /// Collision semantics match [`set`]: in-place overwrite when
+    /// the new value is the same size, otherwise compact-and-append.
+    /// A later write under the same key hash is the value returned
+    /// by [`get`].
+    ///
+    /// This is the lower-level companion to the typed [`set`] API,
+    /// intended for callers that already have a key hash and
+    /// pre-serialized bytes in hand — for example, copying
+    /// entries across `Flattrs` buffers without re-deserializing,
+    /// or stamping typed `Attrs` entries through a crate boundary
+    /// where the concrete `Key<T>` is out of scope. Most callers
+    /// should prefer [`set`].
+    pub fn set_serialized(&mut self, key_hash: u64, serialized: &[u8]) {
+        // If key exists, either overwrite in place or compact + append.
         if let Some((offset, old_len)) = self.find_entry_location(key_hash) {
             if serialized.len() == old_len {
                 // Same size - overwrite value in place
                 let value_start = offset + ENTRY_HEADER_SIZE;
-                self.buffer[value_start..value_start + old_len].copy_from_slice(&serialized);
+                self.buffer[value_start..value_start + old_len].copy_from_slice(serialized);
                 return;
             }
 
@@ -138,7 +155,7 @@ impl Flattrs {
             self.buffer[0..2].copy_from_slice(&((count - 1) as u16).to_le_bytes());
         }
 
-        self.append_entry(key_hash, &serialized);
+        self.append_entry(key_hash, serialized);
     }
 
     /// Get a value, deserializing from the buffer.
@@ -183,6 +200,22 @@ impl Flattrs {
             flattrs.append_entry(key_hash, &serialized);
         }
         flattrs
+    }
+
+    /// Iterate over all entries as `(key_hash, value_bytes)` pairs.
+    ///
+    /// The byte slice is borrowed from the buffer — the caller must
+    /// not hold the returned slice across a mutation of this
+    /// `Flattrs`. Intended for generic copy paths that need to
+    /// transfer entries without knowing their typed schema (e.g.
+    /// filter-and-copy helpers keyed by meta marker). Callers that
+    /// need typed access should use the typed [`get`] API.
+    pub fn iter(&self) -> FlattrsIter<'_> {
+        FlattrsIter {
+            buffer: &self.buffer,
+            remaining: self.len(),
+            offset: HEADER_SIZE,
+        }
     }
 
     /// Find the value bytes for a given key_hash by scanning entries.
@@ -266,6 +299,47 @@ impl Flattrs {
         self.buffer
             .extend_from_slice(&(value.len() as u32).to_le_bytes());
         self.buffer.extend_from_slice(value);
+    }
+}
+
+/// Iterator over `Flattrs` entries as `(key_hash, value_bytes)`.
+///
+/// Produced by [`Flattrs::iter`].
+pub struct FlattrsIter<'a> {
+    buffer: &'a [u8],
+    remaining: usize,
+    offset: usize,
+}
+
+impl<'a> Iterator for FlattrsIter<'a> {
+    type Item = (u64, &'a [u8]);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.remaining == 0 {
+            return None;
+        }
+        if self.offset + ENTRY_HEADER_SIZE > self.buffer.len() {
+            return None;
+        }
+        let key_hash = u64::from_le_bytes(
+            self.buffer[self.offset..self.offset + 8]
+                .try_into()
+                .unwrap_or([0; 8]),
+        );
+        let entry_len = u32::from_le_bytes(
+            self.buffer[self.offset + 8..self.offset + 12]
+                .try_into()
+                .unwrap_or([0; 4]),
+        ) as usize;
+        let value_start = self.offset + ENTRY_HEADER_SIZE;
+        let value_end = value_start + entry_len;
+        if value_end > self.buffer.len() {
+            return None;
+        }
+        let value = &self.buffer[value_start..value_end];
+        self.offset = value_end;
+        self.remaining -= 1;
+        Some((key_hash, value))
     }
 }
 
@@ -387,6 +461,92 @@ mod tests {
             Some("a much longer string".to_string())
         );
         assert_eq!(attrs.len(), 1);
+    }
+
+    // Same-key re-set, same serialized size: later value wins,
+    // entry count stays at 1.
+    #[test]
+    fn test_set_serialized_overwrites_existing_same_size() {
+        let mut attrs = Flattrs::new();
+        let key_hash = TEST_U64.key_hash();
+        let first = bincode::serde::encode_to_vec(42u64, bincode::config::legacy()).unwrap();
+        attrs.set_serialized(key_hash, &first);
+        assert_eq!(attrs.get(TEST_U64), Some(42u64));
+        assert_eq!(attrs.len(), 1);
+
+        let second = bincode::serde::encode_to_vec(100u64, bincode::config::legacy()).unwrap();
+        assert_eq!(first.len(), second.len(), "same-size precondition");
+        attrs.set_serialized(key_hash, &second);
+
+        assert_eq!(attrs.get(TEST_U64), Some(100u64));
+        assert_eq!(attrs.len(), 1);
+    }
+
+    // Same-key re-set, different serialized size: later value
+    // wins, entry count stays at 1.
+    #[test]
+    fn test_set_serialized_overwrites_existing_different_size() {
+        let mut attrs = Flattrs::new();
+        let key_hash = TEST_STRING.key_hash();
+        let short =
+            bincode::serde::encode_to_vec("short".to_string(), bincode::config::legacy()).unwrap();
+        attrs.set_serialized(key_hash, &short);
+        assert_eq!(attrs.get(TEST_STRING), Some("short".to_string()));
+        assert_eq!(attrs.len(), 1);
+
+        let long = bincode::serde::encode_to_vec(
+            "a much longer string".to_string(),
+            bincode::config::legacy(),
+        )
+        .unwrap();
+        assert_ne!(short.len(), long.len(), "different-size precondition");
+        attrs.set_serialized(key_hash, &long);
+
+        assert_eq!(
+            attrs.get(TEST_STRING),
+            Some("a much longer string".to_string())
+        );
+        assert_eq!(attrs.len(), 1);
+    }
+
+    // `set<T>` and `set_serialized` observe each other's writes
+    // under the same key hash.
+    #[test]
+    fn test_set_serialized_interops_with_typed_set() {
+        let mut attrs = Flattrs::new();
+        attrs.set(TEST_U64, 1u64);
+        attrs.set_serialized(
+            TEST_U64.key_hash(),
+            &bincode::serde::encode_to_vec(2u64, bincode::config::legacy()).unwrap(),
+        );
+        assert_eq!(attrs.get(TEST_U64), Some(2u64));
+        assert_eq!(attrs.len(), 1);
+
+        let mut attrs = Flattrs::new();
+        attrs.set_serialized(
+            TEST_U64.key_hash(),
+            &bincode::serde::encode_to_vec(1u64, bincode::config::legacy()).unwrap(),
+        );
+        attrs.set(TEST_U64, 2u64);
+        assert_eq!(attrs.get(TEST_U64), Some(2u64));
+        assert_eq!(attrs.len(), 1);
+    }
+
+    // `set_serialized` on a novel key appends a new entry.
+    #[test]
+    fn test_set_serialized_new_key_appends() {
+        let mut attrs = Flattrs::new();
+        attrs.set_serialized(
+            TEST_U64.key_hash(),
+            &bincode::serde::encode_to_vec(7u64, bincode::config::legacy()).unwrap(),
+        );
+        attrs.set_serialized(
+            TEST_STRING.key_hash(),
+            &bincode::serde::encode_to_vec("x".to_string(), bincode::config::legacy()).unwrap(),
+        );
+        assert_eq!(attrs.get(TEST_U64), Some(7u64));
+        assert_eq!(attrs.get(TEST_STRING), Some("x".to_string()));
+        assert_eq!(attrs.len(), 2);
     }
 
     #[test]


### PR DESCRIPTION
Summary:

this diff tightens the undelivered_message_abandoned log in hyperactor::mailbox.

today that log can dump raw envelope headers and the full serialized payload body into a single line. in the failure mode we are debugging, that produces a long transport-heavy message where the useful signal is buried inside headers: and data: output. this diff removes those unbounded inline dumps and replaces them with bounded summary fields. the log now reports the destination, compatibility identifiers, a compact message_type, data_len, and the transport error as a dedicated field.

this does not change delivery or supervision semantics. it only makes this existing failure surface bounded and easier to scan. the follow-up diff will add operation-context propagation so abandoned replies can be named in terms of the user operation that produced them.

Reviewed By: mariusae

Differential Revision: D102194014


