### PR TITLE
Exempt client[0] from system-actor filtering to restore message edges

### DIFF
--- a/python/monarch/monarch_dashboard/server/admin_dag.py
+++ b/python/monarch/monarch_dashboard/server/admin_dag.py
@@ -36,9 +36,20 @@ _SYSTEM_NAME_PATTERNS = re.compile(
     r"(telemetry|setup[-_]|SetupActor|comm[-_]|CommActor|"
     r"logger[-_]|LoggerActor|log_client|MeshAdminAgent|HostAgent|ProcAgent|"
     r"host_agent|proc_agent|mesh_admin|controller_controller|"
-    r"proc_mesh_controller|actor_mesh_controller|client\[)",
+    r"proc_mesh_controller|actor_mesh_controller)",
     re.IGNORECASE,
 )
+
+
+def _is_client_actor(ref: str) -> bool:
+    """The root client actor (client[0]) is the user's entrypoint.
+
+    It is marked ``is_system`` by the admin API and listed in
+    ``system_children``, but it sends all user-visible messages
+    (e.g. accumulate_gradients, get_status) to user actors. Keeping
+    it in the DAG preserves message edge visibility.
+    """
+    return ref.endswith(",client[0]")
 
 
 def _get_admin_url() -> Optional[str]:
@@ -266,8 +277,10 @@ def build_admin_dag(hide_system: bool = True) -> Dict[str, Any]:
             continue
 
         # Filter system actors — both API flag and name heuristic.
+        # The root client actor is exempt: it is the user's entrypoint
+        # and the source of all user-visible messages.
         label = _derive_label(payload)
-        if hide_system:
+        if hide_system and not _is_client_actor(ref):
             if _extract_is_system(props):
                 continue
             if ntype == "actor" and _is_system_by_name(label):
@@ -314,7 +327,11 @@ def build_admin_dag(hide_system: bool = True) -> Dict[str, Any]:
 
         if depth < _MAX_TREE_DEPTH:
             for child_ref in children_refs:
-                if hide_system and child_ref in system_children:
+                if (
+                    hide_system
+                    and child_ref in system_children
+                    and not _is_client_actor(child_ref)
+                ):
                     continue
                 queue.append((child_ref, ref, depth + 1))
 

--- a/python/monarch/monarch_dashboard/server/system_actors.py
+++ b/python/monarch/monarch_dashboard/server/system_actors.py
@@ -153,5 +153,11 @@ def get_system_info() -> SystemInfo:
 
 
 def get_system_actor_names() -> Set[str]:
-    """Convenience: return just the set of system actor full_names."""
-    return get_system_info().actor_names
+    """Convenience: return just the set of system actor full_names.
+
+    The root client actor (``client[0]``) is excluded even though the
+    admin API marks it ``is_system``.  It is the user's entrypoint and
+    the source of all user-visible messages; keeping it out of the
+    system set preserves message edge visibility in the DAG.
+    """
+    return {n for n in get_system_info().actor_names if not n.endswith(",client[0]")}


### PR DESCRIPTION
Summary:
## Problem
The Monarch Dashboard DAG view shows 0 message edges despite thousands of
messages existing in the telemetry database. This was observed on MAST job
at-avocado-rl-test_80m-d52d28.

## Root Cause
All user-visible messages (accumulate_gradients, apply_gradients, get_status,
snapshot_weights, ENDPOINT_sample, etc.) are sent from `client[0]` — the root
controller actor on the coordinator proc — to user actors (trainer, generator).

`client[0]` is classified as a system actor by three independent mechanisms:
1. The admin API sets `is_system: True`
2. The proc's `system_children` list includes it
3. The name-based heuristic `_SYSTEM_NAME_PATTERNS` matched `client\[`

Since `_add_message_edges()` requires both sender and receiver to be present
in the filtered DAG, and `client[0]` (always the sender) was always filtered
out, zero message edges were ever created.

## Debugging Steps
1. Queried the mesh admin API's `/v1/query` endpoint — confirmed 10,870+
   messages exist in the DataFusion telemetry tables with rich endpoints.
2. Queried the dashboard's `/api/summary` — confirmed it returns message
   counts correctly (data layer works).
3. Queried the dashboard's `/api/dag?hide_system=true` — confirmed 0
   message edges despite 24 nodes and 21 hierarchy edges.
4. Analyzed `SELECT DISTINCT from_actor_id, to_actor_id FROM messages` joined
   with the actors table — discovered every user-relevant message has
   `client[0]` as the sender.
5. Verified `client[0]` has `is_system: True` via the admin API.
6. Traced the three filtering mechanisms in `build_admin_dag()` that remove it.

## Fix
Exempt `client[0]` from system-actor filtering. Unlike infrastructure actors
(proc_agent, comm, telemetry), `client[0]` is the user's root entrypoint —
the code that runs in it is the user's orchestration logic. Keeping it visible
in the DAG restores all message edges and adds one meaningful node.

An alternative considered was remapping filtered system actors to their parent
proc/host node for message edges. This was rejected because it is more complex,
less accurate (implies the proc infrastructure sends messages rather than user
code), and conflates hierarchy levels.

Differential Revision: D102244910


