### PR TITLE
Delete the dead v0 ProcAgent state machine

### DIFF
--- a/hyperactor_mesh/src/proc_agent.rs
+++ b/hyperactor_mesh/src/proc_agent.rs
@@ -15,13 +15,9 @@
 #![allow(unused_assignments)]
 
 use std::collections::HashMap;
-use std::sync::Arc;
-use std::sync::Mutex;
-use std::sync::RwLock;
 use std::time::Duration;
 
 use async_trait::async_trait;
-use enum_as_inner::EnumAsInner;
 use hyperactor::Actor;
 use hyperactor::ActorHandle;
 use hyperactor::Bind;
@@ -33,8 +29,6 @@ use hyperactor::PortHandle;
 use hyperactor::Unbind;
 use hyperactor::actor::handle_undeliverable_message;
 use hyperactor::actor::remote::Remote;
-use hyperactor::mailbox::BoxedMailboxSender;
-use hyperactor::mailbox::MailboxSender;
 use hyperactor::mailbox::MessageEnvelope;
 use hyperactor::mailbox::Undeliverable;
 use hyperactor::proc::Proc;
@@ -73,16 +67,6 @@ declare_attrs! {
     /// of treating it as an error.
     attr STREAM_STATE_SUBSCRIBER: bool;
 }
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Named)]
-pub enum GspawnResult {
-    Success {
-        rank: usize,
-        actor_id: hyperactor_reference::ActorId,
-    },
-    Error(String),
-}
-wirevalue::register_type!(GspawnResult);
 
 /// Deferred republish of introspect properties.
 ///
@@ -124,41 +108,6 @@ fn collect_live_children(
         }
     }
     (children, system_children)
-}
-
-/// Internal configuration state of the mesh agent.
-#[derive(Debug, EnumAsInner, Default)]
-enum State {
-    UnconfiguredV0 {
-        sender: ReconfigurableMailboxSender,
-    },
-
-    ConfiguredV0 {
-        sender: ReconfigurableMailboxSender,
-        rank: usize,
-        supervisor: Option<hyperactor_reference::PortRef<ActorSupervisionEvent>>,
-    },
-
-    V1,
-
-    #[default]
-    Invalid,
-}
-
-impl State {
-    fn rank(&self) -> Option<usize> {
-        match self {
-            State::ConfiguredV0 { rank, .. } => Some(*rank),
-            _ => None,
-        }
-    }
-
-    fn supervisor(&self) -> Option<hyperactor_reference::PortRef<ActorSupervisionEvent>> {
-        match self {
-            State::ConfiguredV0 { supervisor, .. } => supervisor.clone(),
-            _ => None,
-        }
-    }
 }
 
 /// Actor state used for v1 API.
@@ -330,7 +279,6 @@ struct SelfCheck {}
 pub struct ProcAgent {
     proc: Proc,
     remote: Remote,
-    state: State,
     /// Actors created and tracked through the resource behavior.
     actor_states: HashMap<Name, ActorInstanceState>,
     /// If true, and supervisor is None, record supervision events to be reported
@@ -352,30 +300,6 @@ pub struct ProcAgent {
 }
 
 impl ProcAgent {
-    #[hyperactor::observe_result("MeshAgent")]
-    pub(crate) async fn bootstrap(
-        proc_id: hyperactor_reference::ProcId,
-    ) -> Result<(Proc, ActorHandle<Self>), anyhow::Error> {
-        let sender = ReconfigurableMailboxSender::new();
-        let proc = Proc::configured(proc_id.clone(), BoxedMailboxSender::new(sender.clone()));
-
-        let agent = ProcAgent {
-            proc: proc.clone(),
-            remote: Remote::collect(),
-            state: State::UnconfiguredV0 { sender },
-            actor_states: HashMap::new(),
-            record_supervision_events: false,
-            introspect_dirty: false,
-            shutdown_tx: None,
-            stopping_all: false,
-            // v0 procs don't have an owner they can check for, so they should
-            // never try to kill the children.
-            mesh_orphan_timeout: None,
-        };
-        let handle = proc.spawn::<Self>("mesh", agent)?;
-        Ok((proc, handle))
-    }
-
     pub(crate) fn boot_v1(
         proc: Proc,
         shutdown_tx: Option<tokio::sync::oneshot::Sender<i32>>,
@@ -392,7 +316,6 @@ impl ProcAgent {
         let agent = ProcAgent {
             proc: proc.clone(),
             remote: Remote::collect(),
-            state: State::V1,
             actor_states: HashMap::new(),
             record_supervision_events: true,
             introspect_dirty: false,
@@ -774,9 +697,7 @@ impl Handler<ActorSupervisionEvent> for ProcAgent {
                 self.shutdown().await;
             }
         }
-        if let Some(supervisor) = self.state.supervisor() {
-            supervisor.send(cx, event)?;
-        } else if !self.record_supervision_events && event.is_error() {
+        if !self.record_supervision_events && event.is_error() {
             // If there is no supervisor, and nothing is recording these, crash
             // the whole process on error events.
             tracing::error!(
@@ -1258,245 +1179,11 @@ impl Handler<SelfCheck> for ProcAgent {
     }
 }
 
-/// A mailbox sender that initially queues messages, and then relays them to
-/// an underlying sender once configured.
-#[derive(Clone)]
-pub(crate) struct ReconfigurableMailboxSender {
-    state: Arc<RwLock<ReconfigurableMailboxSenderState>>,
-}
-
-impl std::fmt::Debug for ReconfigurableMailboxSender {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        // Not super helpful, but we definitely don't wan to acquire any locks
-        // in a Debug formatter.
-        f.debug_struct("ReconfigurableMailboxSender").finish()
-    }
-}
-
-type Post = (MessageEnvelope, PortHandle<Undeliverable<MessageEnvelope>>);
-
-#[derive(EnumAsInner, Debug)]
-enum ReconfigurableMailboxSenderState {
-    Queueing(Mutex<Vec<Post>>),
-    Configured(BoxedMailboxSender),
-}
-
-impl ReconfigurableMailboxSender {
-    pub(crate) fn new() -> Self {
-        Self {
-            state: Arc::new(RwLock::new(ReconfigurableMailboxSenderState::Queueing(
-                Mutex::new(Vec::new()),
-            ))),
-        }
-    }
-
-    /// Configure this mailbox with the provided sender. This will first
-    /// enqueue any pending messages onto the sender; future messages are
-    /// posted directly to the configured sender.
-    pub(crate) fn configure(&self, sender: BoxedMailboxSender) -> bool {
-        // Hold the write lock until all queued messages are flushed.
-        let mut state = self.state.write().unwrap();
-        if state.is_configured() {
-            return false;
-        }
-
-        // Install the configured sender exactly once.
-        let queued = std::mem::replace(
-            &mut *state,
-            ReconfigurableMailboxSenderState::Configured(sender),
-        );
-
-        // Borrow the configured sender from the state (stable while
-        // we hold the lock).
-        let configured_sender = state.as_configured().expect("just configured");
-
-        // Flush the old queue while still holding the write lock.
-        for (envelope, return_handle) in queued.into_queueing().unwrap().into_inner().unwrap() {
-            configured_sender.post(envelope, return_handle);
-        }
-
-        true
-    }
-}
-
-#[async_trait]
-impl MailboxSender for ReconfigurableMailboxSender {
-    fn post(
-        &self,
-        envelope: MessageEnvelope,
-        return_handle: PortHandle<Undeliverable<MessageEnvelope>>,
-    ) {
-        match &*self.state.read().unwrap() {
-            ReconfigurableMailboxSenderState::Queueing(queue) => {
-                queue.lock().unwrap().push((envelope, return_handle));
-            }
-            ReconfigurableMailboxSenderState::Configured(sender) => {
-                sender.post(envelope, return_handle);
-            }
-        }
-    }
-
-    fn post_unchecked(
-        &self,
-        envelope: MessageEnvelope,
-        return_handle: PortHandle<Undeliverable<MessageEnvelope>>,
-    ) {
-        match &*self.state.read().unwrap() {
-            ReconfigurableMailboxSenderState::Queueing(queue) => {
-                queue.lock().unwrap().push((envelope, return_handle));
-            }
-            ReconfigurableMailboxSenderState::Configured(sender) => {
-                sender.post_unchecked(envelope, return_handle);
-            }
-        }
-    }
-
-    async fn flush(&self) -> Result<(), anyhow::Error> {
-        let sender = match &*self.state.read().unwrap() {
-            ReconfigurableMailboxSenderState::Queueing(_) => return Ok(()),
-            ReconfigurableMailboxSenderState::Configured(sender) => sender.clone(),
-        };
-        sender.flush().await
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use std::sync::Arc;
-    use std::sync::Mutex;
-
-    use hyperactor::mailbox::BoxedMailboxSender;
-    use hyperactor::mailbox::Mailbox;
-    use hyperactor::mailbox::MailboxSender;
-    use hyperactor::mailbox::MessageEnvelope;
-    use hyperactor::mailbox::PortHandle;
-    use hyperactor::mailbox::Undeliverable;
-    use hyperactor::testing::ids::test_actor_id;
-    use hyperactor::testing::ids::test_port_id;
-    use hyperactor_config::Flattrs;
 
     use super::*;
-
-    #[derive(Debug, Clone)]
-    struct QueueingMailboxSender {
-        messages: Arc<Mutex<Vec<MessageEnvelope>>>,
-    }
-
-    impl QueueingMailboxSender {
-        fn new() -> Self {
-            Self {
-                messages: Arc::new(Mutex::new(Vec::new())),
-            }
-        }
-
-        fn get_messages(&self) -> Vec<MessageEnvelope> {
-            self.messages.lock().unwrap().clone()
-        }
-    }
-
-    #[async_trait]
-    impl MailboxSender for QueueingMailboxSender {
-        fn post_unchecked(
-            &self,
-            envelope: MessageEnvelope,
-            _return_handle: PortHandle<Undeliverable<MessageEnvelope>>,
-        ) {
-            self.messages.lock().unwrap().push(envelope);
-        }
-    }
-
-    // Helper function to create a test message envelope
-    fn envelope(data: u64) -> MessageEnvelope {
-        MessageEnvelope::serialize(
-            test_actor_id("world_0", "sender"),
-            test_port_id("world_0", "receiver", 1),
-            &data,
-            Flattrs::new(),
-        )
-        .unwrap()
-    }
-
-    fn return_handle() -> PortHandle<Undeliverable<MessageEnvelope>> {
-        let mbox = Mailbox::new_detached(test_actor_id("0", "test"));
-        let (port, _receiver) = mbox.open_port::<Undeliverable<MessageEnvelope>>();
-        port
-    }
-
-    #[test]
-    fn test_queueing_before_configure() {
-        let sender = ReconfigurableMailboxSender::new();
-
-        let test_sender = QueueingMailboxSender::new();
-        let boxed_sender = BoxedMailboxSender::new(test_sender.clone());
-
-        let return_handle = return_handle();
-        sender.post(envelope(1), return_handle.clone());
-        sender.post(envelope(2), return_handle.clone());
-
-        assert_eq!(test_sender.get_messages().len(), 0);
-
-        sender.configure(boxed_sender);
-
-        let messages = test_sender.get_messages();
-        assert_eq!(messages.len(), 2);
-
-        assert_eq!(messages[0].deserialized::<u64>().unwrap(), 1);
-        assert_eq!(messages[1].deserialized::<u64>().unwrap(), 2);
-    }
-
-    #[test]
-    fn test_direct_delivery_after_configure() {
-        // Create a ReconfigurableMailboxSender
-        let sender = ReconfigurableMailboxSender::new();
-
-        let test_sender = QueueingMailboxSender::new();
-        let boxed_sender = BoxedMailboxSender::new(test_sender.clone());
-        sender.configure(boxed_sender);
-
-        let return_handle = return_handle();
-        sender.post(envelope(3), return_handle.clone());
-        sender.post(envelope(4), return_handle.clone());
-
-        let messages = test_sender.get_messages();
-        assert_eq!(messages.len(), 2);
-
-        assert_eq!(messages[0].deserialized::<u64>().unwrap(), 3);
-        assert_eq!(messages[1].deserialized::<u64>().unwrap(), 4);
-    }
-
-    #[test]
-    fn test_multiple_configurations() {
-        let sender = ReconfigurableMailboxSender::new();
-        let boxed_sender = BoxedMailboxSender::new(QueueingMailboxSender::new());
-
-        assert!(sender.configure(boxed_sender.clone()));
-        assert!(!sender.configure(boxed_sender));
-    }
-
-    #[test]
-    fn test_mixed_queueing_and_direct_delivery() {
-        let sender = ReconfigurableMailboxSender::new();
-
-        let test_sender = QueueingMailboxSender::new();
-        let boxed_sender = BoxedMailboxSender::new(test_sender.clone());
-
-        let return_handle = return_handle();
-        sender.post(envelope(5), return_handle.clone());
-        sender.post(envelope(6), return_handle.clone());
-
-        sender.configure(boxed_sender);
-
-        sender.post(envelope(7), return_handle.clone());
-        sender.post(envelope(8), return_handle.clone());
-
-        let messages = test_sender.get_messages();
-        assert_eq!(messages.len(), 4);
-
-        assert_eq!(messages[0].deserialized::<u64>().unwrap(), 5);
-        assert_eq!(messages[1].deserialized::<u64>().unwrap(), 6);
-        assert_eq!(messages[2].deserialized::<u64>().unwrap(), 7);
-        assert_eq!(messages[3].deserialized::<u64>().unwrap(), 8);
-    }
 
     // A no-op actor used to test direct proc-level spawning.
     #[derive(Debug, Default, Serialize, Deserialize)]

--- a/hyperactor_mesh/src/proc_agent.rs
+++ b/hyperactor_mesh/src/proc_agent.rs
@@ -15,7 +15,6 @@
 #![allow(unused_assignments)]
 
 use std::collections::HashMap;
-use std::mem::take;
 use std::sync::Arc;
 use std::sync::Mutex;
 use std::sync::RwLock;
@@ -28,20 +27,13 @@ use hyperactor::ActorHandle;
 use hyperactor::Bind;
 use hyperactor::Context;
 use hyperactor::Data;
-use hyperactor::HandleClient;
 use hyperactor::Handler;
 use hyperactor::Instance;
 use hyperactor::PortHandle;
-use hyperactor::RefClient;
 use hyperactor::Unbind;
 use hyperactor::actor::handle_undeliverable_message;
 use hyperactor::actor::remote::Remote;
-use hyperactor::channel;
-use hyperactor::channel::ChannelAddr;
 use hyperactor::mailbox::BoxedMailboxSender;
-use hyperactor::mailbox::DialMailboxRouter;
-use hyperactor::mailbox::IntoBoxedMailboxSender;
-use hyperactor::mailbox::MailboxClient;
 use hyperactor::mailbox::MailboxSender;
 use hyperactor::mailbox::MessageEnvelope;
 use hyperactor::mailbox::Undeliverable;
@@ -132,55 +124,6 @@ fn collect_live_children(
         }
     }
     (children, system_children)
-}
-
-#[derive(
-    Debug,
-    Clone,
-    PartialEq,
-    Serialize,
-    Deserialize,
-    Handler,
-    HandleClient,
-    RefClient,
-    Named
-)]
-pub(crate) enum MeshAgentMessage {
-    /// Configure the proc in the mesh.
-    Configure {
-        /// The rank of this proc in the mesh.
-        rank: usize,
-        /// The forwarder to send messages to unknown destinations.
-        forwarder: ChannelAddr,
-        /// The supervisor port to which the agent should report supervision events.
-        supervisor: Option<hyperactor_reference::PortRef<ActorSupervisionEvent>>,
-        /// An address book to use for direct dialing.
-        address_book: HashMap<hyperactor_reference::ProcId, ChannelAddr>,
-        /// The agent should write its rank to this port when it successfully
-        /// configured.
-        configured: hyperactor_reference::PortRef<usize>,
-        /// If true, and supervisor is None, record supervision events to be reported
-        record_supervision_events: bool,
-    },
-
-    Status {
-        /// The status of the proc.
-        /// To be replaced with fine-grained lifecycle status,
-        /// and to use aggregation.
-        status: hyperactor_reference::PortRef<(usize, bool)>,
-    },
-
-    /// Spawn an actor on the proc to the provided name.
-    Gspawn {
-        /// registered actor type
-        actor_type: String,
-        /// spawned actor name
-        actor_name: String,
-        /// serialized parameters
-        params_data: Data,
-        /// reply port; the proc should send its rank to indicated a spawned actor
-        status_port: hyperactor_reference::PortRef<GspawnResult>,
-    },
 }
 
 /// Internal configuration state of the mesh agent.
@@ -369,7 +312,6 @@ struct SelfCheck {}
 /// See GC-1 in `global_context` module doc.
 #[hyperactor::export(
     handlers=[
-        MeshAgentMessage,
         ActorSupervisionEvent,
         resource::CreateOrUpdate<ActorSpec> { cast = true },
         resource::Stop { cast = true },
@@ -777,119 +719,6 @@ impl Actor for ProcAgent {
             Ok(())
         } else {
             handle_undeliverable_message(cx, envelope)
-        }
-    }
-}
-
-#[async_trait]
-#[hyperactor::handle(MeshAgentMessage)]
-impl MeshAgentMessageHandler for ProcAgent {
-    async fn configure(
-        &mut self,
-        cx: &Context<Self>,
-        rank: usize,
-        forwarder: ChannelAddr,
-        supervisor: Option<hyperactor_reference::PortRef<ActorSupervisionEvent>>,
-        address_book: HashMap<hyperactor_reference::ProcId, ChannelAddr>,
-        configured: hyperactor_reference::PortRef<usize>,
-        record_supervision_events: bool,
-    ) -> Result<(), anyhow::Error> {
-        anyhow::ensure!(
-            self.state.is_unconfigured_v0(),
-            "mesh agent cannot be (re-)configured"
-        );
-        self.record_supervision_events = record_supervision_events;
-
-        let client = MailboxClient::new(channel::dial(forwarder)?);
-        let router =
-            DialMailboxRouter::new_with_default_direct_addressed_remote_only(client.into_boxed());
-
-        for (proc_id, addr) in address_book {
-            router.bind(proc_id.into(), addr);
-        }
-
-        let sender = take(&mut self.state).into_unconfigured_v0().unwrap();
-        assert!(sender.configure(router.into_boxed()));
-
-        // This is a bit suboptimal: ideally we'd set the supervisor first, to correctly report
-        // any errors that occur during configuration. However, these should anyway be correctly
-        // caught on process exit.
-        self.state = State::ConfiguredV0 {
-            sender,
-            rank,
-            supervisor,
-        };
-        configured.send(cx, rank)?;
-
-        Ok(())
-    }
-
-    async fn gspawn(
-        &mut self,
-        cx: &Context<Self>,
-        actor_type: String,
-        actor_name: String,
-        params_data: Data,
-        status_port: hyperactor_reference::PortRef<GspawnResult>,
-    ) -> Result<(), anyhow::Error> {
-        anyhow::ensure!(
-            self.state.is_configured_v0(),
-            "mesh agent is not v0 configured"
-        );
-        let actor_id = match self
-            .remote
-            .gspawn(
-                &self.proc,
-                &actor_type,
-                &actor_name,
-                params_data,
-                cx.headers().clone(),
-            )
-            .await
-        {
-            Ok(id) => id,
-            Err(err) => {
-                status_port.send(cx, GspawnResult::Error(format!("gspawn failed: {}", err)))?;
-                return Err(anyhow::anyhow!("gspawn failed"));
-            }
-        };
-        status_port.send(
-            cx,
-            GspawnResult::Success {
-                rank: self.state.rank().unwrap(),
-                actor_id,
-            },
-        )?;
-        self.publish_introspect_properties(cx);
-        Ok(())
-    }
-
-    async fn status(
-        &mut self,
-        cx: &Context<Self>,
-        status_port: hyperactor_reference::PortRef<(usize, bool)>,
-    ) -> Result<(), anyhow::Error> {
-        match &self.state {
-            State::ConfiguredV0 { rank, .. } => {
-                // v0 path: configured with a concrete rank
-                status_port.send(cx, (*rank, true))?;
-                Ok(())
-            }
-            State::UnconfiguredV0 { .. } => {
-                // v0 path but not configured yet
-                Err(anyhow::anyhow!(
-                    "status unavailable: v0 agent not configured (waiting for Configure)"
-                ))
-            }
-            State::V1 => {
-                // v1/owned path does not support status (no rank semantics)
-                Err(anyhow::anyhow!(
-                    "status unsupported in v1/owned path (no rank)"
-                ))
-            }
-            State::Invalid => Err(anyhow::anyhow!(
-                "status unavailable: agent in invalid state"
-            )),
         }
     }
 }

--- a/hyperactor_mesh/src/proc_mesh.rs
+++ b/hyperactor_mesh/src/proc_mesh.rs
@@ -33,7 +33,6 @@ use ndslice::Extent;
 use ndslice::ViewExt as _;
 use ndslice::view;
 use ndslice::view::CollectMeshExt;
-use ndslice::view::MapIntoExt;
 use ndslice::view::Ranked;
 use ndslice::view::Region;
 use serde::Deserialize;
@@ -53,7 +52,6 @@ use crate::host_mesh::mesh_to_rankedvalues_with_default;
 use crate::mesh_controller::ActorMeshController;
 use crate::proc_agent;
 use crate::proc_agent::ActorState;
-use crate::proc_agent::MeshAgentMessageClient;
 use crate::proc_agent::ProcAgent;
 use crate::resource;
 use crate::resource::GetRankStatus;
@@ -105,25 +103,6 @@ impl ProcRef {
             proc_id,
             create_rank,
             agent,
-        }
-    }
-
-    /// Pings the proc, returning whether it is alive. This will be replaced by a
-    /// finer-grained lifecycle status in the near future.
-    pub(crate) async fn status(&self, cx: &impl context::Actor) -> crate::Result<bool> {
-        let (port, mut rx) = cx.mailbox().open_port();
-        self.agent
-            .status(cx, port.bind())
-            .await
-            .map_err(|e| Error::CallError(self.agent.actor_id().clone(), e))?;
-        loop {
-            let (rank, status) = rx
-                .recv()
-                .await
-                .map_err(|e| Error::CallError(self.agent.actor_id().clone(), e.into()))?;
-            if rank == self.create_rank {
-                break Ok(status);
-            }
         }
     }
 
@@ -468,15 +447,6 @@ impl ProcMeshRef {
     /// Returns None if this ProcMeshRef is backed by an Alloc instead of a host mesh.
     pub fn hosts(&self) -> Option<&HostMeshRef> {
         self.host_mesh.as_ref()
-    }
-
-    /// The current statuses of procs in this mesh.
-    pub async fn status(&self, cx: &impl context::Actor) -> crate::Result<ValueMesh<bool>> {
-        let vm: ValueMesh<_> = self.map_into(|proc_ref| {
-            let proc_ref = proc_ref.clone();
-            async move { proc_ref.status(cx).await }
-        });
-        vm.join().await.transpose()
     }
 
     pub(crate) fn agent_mesh(&self) -> ActorMeshRef<ProcAgent> {

--- a/hyperactor_mesh/src/transport.rs
+++ b/hyperactor_mesh/src/transport.rs
@@ -24,19 +24,6 @@ declare_attrs! {
     pub attr DEFAULT_TRANSPORT: BindSpec = BindSpec::Any(ChannelTransport::Unix);
 }
 
-/// Temporary: used to support the legacy allocator-based V1 bootstrap. Should
-/// be removed once we fully migrate to simple bootstrap.
-///
-/// Get the default transport to use across the application. Panic if BindSpec::Addr
-/// is set as default transport. Since we expect BindSpec::Addr to be used only
-/// with simple bootstrap, we should not see this panic in production.
-pub fn default_transport() -> ChannelTransport {
-    match default_bind_spec() {
-        BindSpec::Any(transport) => transport,
-        BindSpec::Addr(addr) => panic!("default_bind_spec() returned BindSpec::Addr({addr})"),
-    }
-}
-
 /// Get the default bind spec to use across the application.
 pub fn default_bind_spec() -> BindSpec {
     global::get_cloned(DEFAULT_TRANSPORT)

--- a/monarch_rdma/src/backend/tcp/manager_actor.rs
+++ b/monarch_rdma/src/backend/tcp/manager_actor.rs
@@ -42,7 +42,7 @@ use hyperactor::context;
 use hyperactor::context::Actor as _;
 use hyperactor::reference;
 use hyperactor::reference::OncePortRef;
-use hyperactor_mesh::transport::default_transport;
+use hyperactor_mesh::transport::default_bind_spec;
 use serde::Deserialize;
 use serde::Serialize;
 use serde_multipart::Part;
@@ -385,7 +385,10 @@ impl Actor for TcpManagerActor {
         let parallelism =
             hyperactor_config::global::get(crate::config::RDMA_TCP_FALLBACK_PARALLELISM);
         if parallelism > 1 {
-            let addr = ChannelAddr::any(default_transport());
+            let addr = match default_bind_spec() {
+                channel::BindSpec::Any(transport) => ChannelAddr::any(transport),
+                channel::BindSpec::Addr(addr) => addr,
+            };
             let (bound_addr, mut rx) = channel::serve::<TcpDataChunk>(addr)?;
             self.channel_addr = Some(bound_addr);
 


### PR DESCRIPTION
Summary:
1. Delete unused `ProcAgent.bootstrap` function. After this function is gone,
2. `struct ProcAgent`'s `state` field is not meaningful anymore. Delete this field, and all the dead code coming with it.

Reviewed By: shayne-fletcher

Differential Revision: D102199011


