### PR TITLE
Thread-safe Python wrapping for Node (#3595)

### DIFF
--- a/python/monarch/gradient/_gradient_generator.cpp
+++ b/python/monarch/gradient/_gradient_generator.cpp
@@ -616,9 +616,16 @@ typedef struct {
 // shared_ptr<Node> in older PyTorch, intrusive_ptr<Node> in newer PyTorch
 using node_ptr_t = decltype(std::declval<THPCppFunction>().cdata);
 
+template <typename T = THPFunction>
 static int convertNode(PyObject* obj, node_ptr_t* node) {
   if (THPFunction_Check(obj)) {
-    *node = ((THPFunction*)obj)->cdata.lock();
+    if constexpr (std::is_same_v<
+                      decltype(std::declval<T>().cdata),
+                      node_ptr_t>) {
+      *node = ((T*)obj)->cdata;
+    } else {
+      *node = ((T*)obj)->cdata.lock();
+    }
     return 1;
   } else if (THPCppFunction_Check(obj)) {
     *node = ((THPCppFunction*)obj)->cdata;
@@ -634,7 +641,7 @@ std::optional<Edge> parseEdge(PyObject* obj) {
   if (THPVariable_Check(obj)) {
     auto tensor = THPVariable_Unpack(obj);
     return torch::autograd::impl::gradient_edge(tensor);
-  } else if (PyArg_ParseTuple(obj, "O&i", &convertNode, &node, &input_nr)) {
+  } else if (PyArg_ParseTuple(obj, "O&i", &convertNode<>, &node, &input_nr)) {
     return Edge(std::move(node), input_nr);
   }
   return std::nullopt;


### PR DESCRIPTION
Summary:

Replace the raw PyObject* on Node with an atomic PyObjectSlot and use the same strategy that we already use for Tensor and Storage PyObject wrappers.

Use the same ownership pattern as THPCppFunction: THPFunction holds an owning intrusive_ptr<Node> and reads back via pyobj_slot(), with get_or_init managing the Python wrapper lifecycle. This replaces the previous scheme where PyNode owned THPFunction via a raw PyObject* and THPFunction held a weak_intrusive_ptr back.

Pass-by-value + move for intrusive_ptr parameters, remove an unnecessary temporary, and use try_emplace in NodeCalls::lookup.

Authored with Claude.

cc voznesenskym penguinwu EikanWang jgong5 Guobing-Chen XiaobingSuper zhuhaozhe blzheng wenzhe-nrv jiayisunx kadeng chauhang amjames Lucaskabela jataylo azahed98 xmfan aditvenk

X-link: https://github.com/pytorch/pytorch/pull/181390

Reviewed By: huydhn

Differential Revision: D102356827

Pulled By: colesbury


