### PR TITLE
surface operation in undeliverable error rendering (was [hyperactor] bound user-visible undeliverable error rendering) (#3596)

### DIFF
--- a/hyperactor/src/mailbox.rs
+++ b/hyperactor/src/mailbox.rs
@@ -66,6 +66,31 @@
 //! While this complicates the interface somewhat, it allows the
 //! implementation to avoid a serialization roundtrip when passing
 //! messages locally.
+//!
+//! ## Undeliverable-message log invariants (UM-*)
+//!
+//! The `undelivered_message_abandoned` log at
+//! `UndeliverableMailboxSender::post_unchecked` is a user-facing
+//! surface: it fires when a message could not be delivered *and*
+//! could not be returned to its sender. The following invariants
+//! govern its shape so the log stays scannable and its downstream
+//! consumers (Scuba, alerts) stay stable.
+//!
+//! - **UM-1 (bounded abandoned-message log).** The log must not emit
+//!   unbounded `envelope.headers().to_string()` or
+//!   `envelope.data().to_string()`. Payload observability is provided
+//!   by `message_type` (`data.typename()`) and `data_len`
+//!   (`data.len()`) — cheap, bounded, and type-safe.
+//!
+//! - **UM-2 (stable compatibility fields).** The `actor_name` and
+//!   `actor_id` fields stay on the log with their current values and
+//!   types. Readability improvements are strictly additive on this
+//!   surface; renames or removals require a separate migration diff
+//!   that coordinates with downstream consumers.
+//!
+//! - **UM-3 (destination naming).** The human-facing format string
+//!   names the transport destination: `"message not delivered to
+//!   <dest>"`.
 
 use std::any::Any;
 use std::collections::BTreeMap;
@@ -845,18 +870,23 @@ impl MailboxSender for UndeliverableMailboxSender {
             .label()
             .map_or("?".to_string(), |l| l.to_string());
         let error_str = envelope.error_msg().unwrap_or("".to_string());
-        // The undeliverable message was unable to be delivered back to the
-        // sender for some reason
+        // The undeliverable message was unable to be delivered back
+        // to the sender for some reason. See UM-1..UM-3 in the
+        // module docs: `headers` / `data` are deliberately not
+        // rendered (UM-1); `actor_name` / `actor_id` are preserved
+        // as-is (UM-2); the format string names the destination
+        // (UM-3).
         tracing::error!(
             name = "undelivered_message_abandoned",
             actor_name = sender_name,
             actor_id = envelope.sender.to_string(),
             dest = envelope.dest.to_string(),
-            headers = envelope.headers().to_string(), // todo: implement tracing::Value for Flattrs
-            data = envelope.data().to_string(),
+            message_type = envelope.data().typename().unwrap_or("unknown"),
+            data_len = envelope.data().len(),
             return_handle = %return_handle,
-            "message not delivered, {}",
-            error_str,
+            error = %error_str,
+            "message not delivered to {}",
+            envelope.dest,
         );
     }
 }
@@ -4515,5 +4545,113 @@ mod tests {
 
         serve_handle.stop("test done");
         serve_handle.await.unwrap().unwrap();
+    }
+
+    /// Helper: build a `MessageEnvelope` with a recognizable payload
+    /// and non-empty headers, then feed it through
+    /// `UndeliverableMailboxSender::post_unchecked`. Returns the
+    /// sender + destination so tests can assert against the values we
+    /// know will end up on the log.
+    fn drive_abandonment_log(payload_sentinel: &str) -> (reference::ActorId, reference::PortId) {
+        use hyperactor_config::declare_attrs;
+
+        declare_attrs! {
+            // Any non-empty entry works; UM-1 only asserts the log
+            // does not dump `headers` inline.
+            attr UM_TEST_HEADER: u64;
+        }
+
+        let sender = test_actor_id("um_proc", "um_sender");
+        let dest = test_port_id("um_dest_proc", "um_dest", 42);
+
+        let mut headers = Flattrs::new();
+        headers.set(UM_TEST_HEADER, 0xC0FFEEu64);
+
+        let envelope = MessageEnvelope::new(
+            sender.clone(),
+            dest.clone(),
+            wirevalue::Any::serialize(&payload_sentinel.to_string()).unwrap(),
+            headers,
+        );
+
+        let (return_handle, _rx) = crate::mailbox::undeliverable::new_undeliverable_port();
+        UndeliverableMailboxSender.post_unchecked(envelope, return_handle);
+        (sender, dest)
+    }
+
+    /// UM-1: the log does not render unbounded `headers` or `data`
+    /// fields, and reports bounded `message_type` + `data_len`
+    /// summaries instead.
+    #[tracing_test::traced_test]
+    #[test]
+    fn test_um1_bounded_fields() {
+        let payload_sentinel = "um1_payload_sentinel_5b7a9c3d";
+        let (_sender, _dest) = drive_abandonment_log(payload_sentinel);
+
+        let buf = tracing_test::internal::global_buf().lock().unwrap();
+        let logs = std::str::from_utf8(&buf).expect("logs are utf-8");
+
+        // Bounded summaries are present.
+        assert!(
+            logs.contains("message_type="),
+            "UM-1: expected message_type field, got:\n{logs}"
+        );
+        assert!(
+            logs.contains("data_len="),
+            "UM-1: expected data_len field, got:\n{logs}"
+        );
+        // The payload body must not appear (no `data=<full body>`
+        // dump).
+        assert!(
+            !logs.contains(payload_sentinel),
+            "UM-1: payload body leaked into the log:\n{logs}"
+        );
+        // The `headers=` field must not appear. Use a space-prefixed
+        // match to avoid matching e.g. the word "headers" in free
+        // prose.
+        assert!(
+            !logs.contains(" headers="),
+            "UM-1: unbounded headers field leaked into the log:\n{logs}"
+        );
+    }
+
+    /// UM-2: the `actor_name` and `actor_id` fields are preserved
+    /// on the log for downstream Scuba / alert compatibility — same
+    /// field names, same values, same types as the prior shape.
+    #[tracing_test::traced_test]
+    #[test]
+    fn test_um2_compat_fields_preserved() {
+        let (sender, _dest) = drive_abandonment_log("um2_payload");
+
+        let buf = tracing_test::internal::global_buf().lock().unwrap();
+        let logs = std::str::from_utf8(&buf).expect("logs are utf-8");
+
+        // Decouple field-presence from value-presence so the test
+        // does not depend on the tracing formatter's quoting rules.
+        let actor_name = sender.log_name();
+        let actor_id = sender.to_string();
+        assert!(
+            logs.contains("actor_name=") && logs.contains(actor_name),
+            "UM-2: expected actor_name={actor_name} on the log, got:\n{logs}"
+        );
+        assert!(
+            logs.contains("actor_id=") && logs.contains(&actor_id),
+            "UM-2: expected actor_id={actor_id} on the log, got:\n{logs}"
+        );
+    }
+
+    /// UM-3: the format string names the transport destination.
+    #[tracing_test::traced_test]
+    #[test]
+    fn test_um3_destination_format() {
+        let (_sender, dest) = drive_abandonment_log("um3_payload");
+
+        let buf = tracing_test::internal::global_buf().lock().unwrap();
+        let logs = std::str::from_utf8(&buf).expect("logs are utf-8");
+
+        assert!(
+            logs.contains(&format!("message not delivered to {}", dest)),
+            "UM-3: expected destination-naming format string, got:\n{logs}"
+        );
     }
 }

--- a/hyperactor/src/mailbox.rs
+++ b/hyperactor/src/mailbox.rs
@@ -88,9 +88,19 @@
 //!   surface; renames or removals require a separate migration diff
 //!   that coordinates with downstream consumers.
 //!
-//! - **UM-3 (destination naming).** The human-facing format string
-//!   names the transport destination: `"message not delivered to
-//!   <dest>"`.
+//! - **UM-3a (destination naming).** When the envelope carries no
+//!   `OPERATION_ENDPOINT`, the format string names the transport
+//!   destination: `"message not delivered to <dest>"`.
+//!
+//! - **UM-3b (operation naming).** When the envelope carries
+//!   `OPERATION_ENDPOINT`, the format string names the operation:
+//!   `"abandoned message for <endpoint>"`.
+//!
+//!   `OPERATION_*` keys live in `hyperactor::mailbox::headers`
+//!   because the readers (this log, the undeliverable formatter)
+//!   live in `hyperactor` and can't depend upward on
+//!   `monarch_hyperactor`. Keys whose consumers are not at this
+//!   layer don't belong here.
 
 use std::any::Any;
 use std::collections::BTreeMap;
@@ -863,31 +873,42 @@ impl MailboxSender for UndeliverableMailboxSender {
     fn post_unchecked(
         &self,
         envelope: MessageEnvelope,
-        return_handle: PortHandle<Undeliverable<MessageEnvelope>>,
+        _return_handle: PortHandle<Undeliverable<MessageEnvelope>>,
     ) {
         let sender_name = envelope
             .sender
             .label()
             .map_or("?".to_string(), |l| l.to_string());
         let error_str = envelope.error_msg().unwrap_or("".to_string());
-        // The undeliverable message was unable to be delivered back
-        // to the sender for some reason. See UM-1..UM-3 in the
-        // module docs: `headers` / `data` are deliberately not
-        // rendered (UM-1); `actor_name` / `actor_id` are preserved
-        // as-is (UM-2); the format string names the destination
-        // (UM-3).
-        tracing::error!(
-            name = "undelivered_message_abandoned",
-            actor_name = sender_name,
-            actor_id = envelope.sender.to_string(),
-            dest = envelope.dest.to_string(),
-            message_type = envelope.data().typename().unwrap_or("unknown"),
-            data_len = envelope.data().len(),
-            return_handle = %return_handle,
-            error = %error_str,
-            "message not delivered to {}",
-            envelope.dest,
-        );
+        let operation_endpoint = envelope.headers().get(headers::OPERATION_ENDPOINT);
+        let operation_adverb = envelope.headers().get(headers::OPERATION_ADVERB);
+        // See UM-1..UM-3b in module docs.
+        match &operation_endpoint {
+            Some(endpoint) => tracing::error!(
+                name = "undelivered_message_abandoned",
+                actor_name = sender_name,
+                actor_id = envelope.sender.to_string(),
+                dest = envelope.dest.to_string(),
+                message_type = envelope.data().typename().unwrap_or("unknown"),
+                data_len = envelope.data().len(),
+                endpoint = %endpoint,
+                adverb = operation_adverb.as_deref().unwrap_or(""),
+                error = %error_str,
+                "abandoned message for {}",
+                endpoint,
+            ),
+            None => tracing::error!(
+                name = "undelivered_message_abandoned",
+                actor_name = sender_name,
+                actor_id = envelope.sender.to_string(),
+                dest = envelope.dest.to_string(),
+                message_type = envelope.data().typename().unwrap_or("unknown"),
+                data_len = envelope.data().len(),
+                error = %error_str,
+                "message not delivered to {}",
+                envelope.dest,
+            ),
+        }
     }
 }
 
@@ -4652,6 +4673,55 @@ mod tests {
         assert!(
             logs.contains(&format!("message not delivered to {}", dest)),
             "UM-3: expected destination-naming format string, got:\n{logs}"
+        );
+    }
+
+    /// UM-3b: when the envelope carries operation-context headers, the
+    /// format string names the user operation and the log carries
+    /// the structured `endpoint` / `adverb` fields.
+    #[tracing_test::traced_test]
+    #[test]
+    fn test_um3b_operation_format_with_operation_context() {
+        let sender = test_actor_id("um_proc", "um_sender");
+        let dest = test_port_id("um_dest_proc", "um_dest", 42);
+
+        let mut headers = Flattrs::new();
+        headers.set(
+            headers::OPERATION_ENDPOINT,
+            "training.buffer.sample()".to_string(),
+        );
+        headers.set(headers::OPERATION_ADVERB, "call_one".to_string());
+
+        let envelope = MessageEnvelope::new(
+            sender,
+            dest,
+            wirevalue::Any::serialize(&"um3b_payload".to_string()).unwrap(),
+            headers,
+        );
+
+        let (return_handle, _rx) = crate::mailbox::undeliverable::new_undeliverable_port();
+        UndeliverableMailboxSender.post_unchecked(envelope, return_handle);
+
+        let buf = tracing_test::internal::global_buf().lock().unwrap();
+        let logs = std::str::from_utf8(&buf).expect("logs are utf-8");
+
+        assert!(
+            logs.contains("abandoned message for training.buffer.sample()"),
+            "UM-3b: expected operation-naming format string, got:\n{logs}"
+        );
+        assert!(
+            logs.contains("endpoint=") && logs.contains("training.buffer.sample()"),
+            "UM-3b: expected endpoint field with the caller's operation, got:\n{logs}"
+        );
+        assert!(
+            logs.contains("adverb=") && logs.contains("call_one"),
+            "UM-3b: expected adverb field, got:\n{logs}"
+        );
+        // The UM-3a destination-naming shape must not appear when
+        // operation-context headers are stamped on the envelope.
+        assert!(
+            !logs.contains("message not delivered to"),
+            "UM-3b: unexpected destination-naming format string:\n{logs}"
         );
     }
 }

--- a/hyperactor/src/mailbox/headers.rs
+++ b/hyperactor/src/mailbox/headers.rs
@@ -15,6 +15,7 @@ use std::any::type_name;
 use std::time::SystemTime;
 
 use hyperactor_config::Flattrs;
+use hyperactor_config::attrs::OPERATION_CONTEXT_HEADER;
 use hyperactor_config::attrs::declare_attrs;
 use hyperactor_config::global;
 
@@ -35,6 +36,33 @@ declare_attrs! {
 
     /// Port index the message was delivered to, injected in post_unchecked().
     pub attr TELEMETRY_PORT_ID: u64;
+
+    // Operation-context headers (see `OPERATION_CONTEXT_HEADER` in
+    // `hyperactor_config::attrs`). Carried from the caller's outgoing
+    // request onto the reply envelope by a consumer-side helper that
+    // filters on `OPERATION_CONTEXT_HEADER`. Read at the
+    // undeliverable-abandonment log site in
+    // `hyperactor/src/mailbox.rs` to name the user operation a
+    // dropped reply belonged to (UM-3b).
+    //
+    // Layering note: these keys belong semantically to a higher layer
+    // (Monarch endpoint / adverb / method). They live in `hyperactor`
+    // as a tactical compromise because the log reader lives here and
+    // cannot depend upward on `monarch_hyperactor`. Scope narrowly;
+    // do not grow this vocabulary without revisiting whether the
+    // reader should move up a layer or a generic substrate-owned
+    // operation-context abstraction should replace these keys.
+
+    /// Qualified endpoint name of the caller's operation, e.g.
+    /// "<mesh>.<method>()". Stamped by the request-send site.
+    @meta(OPERATION_CONTEXT_HEADER = true)
+    pub attr OPERATION_ENDPOINT: String;
+
+    /// Endpoint adverb describing the call shape. Typical values from
+    /// current Monarch producers: "call", "call_one", "choose",
+    /// "stream".
+    @meta(OPERATION_CONTEXT_HEADER = true)
+    pub attr OPERATION_ADVERB: String;
 }
 
 /// Set the send timestamp for latency tracking if timestamp not already set.

--- a/hyperactor/src/mailbox/undeliverable.rs
+++ b/hyperactor/src/mailbox/undeliverable.rs
@@ -6,6 +6,27 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+//! Undeliverable-message port helpers and the user-visible
+//! `UndeliverableMessageError` type.
+//!
+//! ## Undeliverable-error text invariants (UE-*)
+//!
+//! - **UE-1 (bounded rendering).** `UndeliverableMessageError`
+//!   `Display` must not render `envelope.headers()` or
+//!   `envelope.data()` via their `Display` impls.
+//!
+//! - **UE-2 (core diagnostics preserved).** The rendered text keeps
+//!   `sender`, `dest`, `message type`, `data_len`, and `error`.
+//!
+//! - **UE-3 (operation context names the top line).** When the
+//!   envelope carries operation-context headers, the top line names
+//!   that operation instead of falling back to the neutral
+//!   `"undeliverable message error"` prefix.
+//!
+//! - **UE-4 (neutral wording).** Top-line wording remains neutral
+//!   (`"undeliverable message for ..."`); presence of operation
+//!   context does not classify the envelope as request or reply.
+
 use std::sync::OnceLock;
 
 use serde::Deserialize;
@@ -23,6 +44,8 @@ use crate::mailbox::MessageEnvelope;
 use crate::mailbox::PortHandle;
 use crate::mailbox::PortReceiver;
 use crate::mailbox::UndeliverableMailboxSender;
+use crate::mailbox::headers::OPERATION_ADVERB;
+use crate::mailbox::headers::OPERATION_ENDPOINT;
 
 /// An undeliverable `M`-typed message (in practice `M` is
 /// [MessageEnvelope]).
@@ -128,51 +151,200 @@ pub enum UndeliverableMessageError {
     },
 }
 
+/// Compute the top-line prefix for a bounced envelope (UE-3, UE-4).
+///
+/// When `OPERATION_ENDPOINT` is present, name the operation;
+/// otherwise fall back to a neutral prefix.
+fn undeliverable_prefix(envelope: &MessageEnvelope) -> String {
+    if let Some(endpoint) = envelope.headers().get(OPERATION_ENDPOINT) {
+        let adverb = envelope
+            .headers()
+            .get(OPERATION_ADVERB)
+            .unwrap_or_else(|| "?".to_string());
+        return format!("undeliverable message for {} ({})", endpoint, adverb);
+    }
+    "undeliverable message error".to_string()
+}
+
 impl std::fmt::Display for UndeliverableMessageError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            UndeliverableMessageError::DeliveryFailure { envelope } => {
-                writeln!(f, "undeliverable message error:")?;
-                writeln!(
-                    f,
-                    "\tdescription: delivery of message from sender to dest failed"
-                )?;
-                writeln!(f, "\tsender: {}", envelope.sender())?;
-                writeln!(f, "\tdest: {}", envelope.dest())?;
-                writeln!(
-                    f,
-                    "\tmessage type: {}",
-                    envelope.data().typename().unwrap_or("unknown")
-                )?;
-                writeln!(f, "\theaders: {}", envelope.headers())?;
-                writeln!(f, "\tdata: {}", envelope.data())?;
-                writeln!(
-                    f,
-                    "\terror: {}",
-                    envelope.error_msg().unwrap_or("<none>".to_string())
-                )
-            }
-            UndeliverableMessageError::ReturnFailure { envelope } => {
-                writeln!(f, "undeliverable message error:")?;
-                writeln!(
-                    f,
-                    "\tdescription: returning undeliverable message to original sender failed"
-                )?;
-                writeln!(f, "\toriginal sender: {}", envelope.sender())?;
-                writeln!(f, "\toriginal dest: {}", envelope.dest())?;
-                writeln!(
-                    f,
-                    "\tmessage type: {}",
-                    envelope.data().typename().unwrap_or("unknown")
-                )?;
-                writeln!(f, "\theaders: {}", envelope.headers())?;
-                writeln!(f, "\tdata: {}", envelope.data())?;
-                writeln!(
-                    f,
-                    "\terror: {}",
-                    envelope.error_msg().unwrap_or("<none>".to_string())
-                )
-            }
-        }
+        // For `DeliveryFailure`, the sender/dest fields describe the
+        // failing hop. For `ReturnFailure`, they describe the
+        // *original* envelope — the return hop failed, but the
+        // identity fields still refer to the original delivery. Keep
+        // the labels distinct so readers know which one they're
+        // looking at.
+        let (envelope, description, sender_label, dest_label) = match self {
+            UndeliverableMessageError::DeliveryFailure { envelope } => (
+                envelope,
+                "delivery of message from sender to dest failed",
+                "sender",
+                "dest",
+            ),
+            UndeliverableMessageError::ReturnFailure { envelope } => (
+                envelope,
+                "returning undeliverable message to original sender failed",
+                "original sender",
+                "original dest",
+            ),
+        };
+
+        writeln!(f, "{}:", undeliverable_prefix(envelope))?;
+        writeln!(f, "\tdescription: {}", description)?;
+        writeln!(f, "\t{}: {}", sender_label, envelope.sender())?;
+        writeln!(f, "\t{}: {}", dest_label, envelope.dest())?;
+        writeln!(
+            f,
+            "\tmessage type: {}",
+            envelope.data().typename().unwrap_or("unknown")
+        )?;
+        writeln!(f, "\tdata_len: {}", envelope.data().len())?;
+        writeln!(
+            f,
+            "\terror: {}",
+            envelope.error_msg().unwrap_or("<none>".to_string())
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use hyperactor_config::Flattrs;
+
+    use super::*;
+    use crate::mailbox::MessageEnvelope;
+    use crate::testing::ids::test_actor_id;
+    use crate::testing::ids::test_port_id;
+
+    fn make_envelope(payload: &str, headers: Flattrs) -> MessageEnvelope {
+        let sender = test_actor_id("ue_proc", "ue_sender");
+        let dest = test_port_id("ue_dest_proc", "ue_dest", 42);
+        let data = wirevalue::Any::serialize(&payload.to_string()).unwrap();
+        MessageEnvelope::new(sender, dest, data, headers)
+    }
+
+    /// UE-1: `DeliveryFailure` Display is bounded — no unbounded
+    /// `headers: ...` or `data: ...` dumps. `data_len` replaces
+    /// the payload body.
+    #[test]
+    fn test_ue1_delivery_failure_bounded() {
+        let payload: String = std::iter::repeat_n('x', 10_000).collect();
+        let mut headers = Flattrs::new();
+        headers.set(OPERATION_ENDPOINT, "training.buffer.sample()".to_string());
+        let envelope = make_envelope(&payload, headers);
+        let rendered = format!(
+            "{}",
+            UndeliverableMessageError::DeliveryFailure { envelope }
+        );
+
+        assert!(
+            rendered.contains("message type:"),
+            "UE-1: message type field must be present, got:\n{rendered}"
+        );
+        assert!(
+            rendered.contains("data_len:"),
+            "UE-1: data_len field must be present, got:\n{rendered}"
+        );
+        assert!(
+            rendered.contains("sender:"),
+            "UE-2: sender field must be preserved, got:\n{rendered}"
+        );
+        assert!(
+            rendered.contains("dest:"),
+            "UE-2: dest field must be preserved, got:\n{rendered}"
+        );
+        assert!(
+            rendered.contains("error:"),
+            "UE-2: error field must be preserved, got:\n{rendered}"
+        );
+        // UE-1: the unbounded raw dumps must not appear.
+        assert!(
+            !rendered.contains("\theaders: "),
+            "UE-1: raw headers dump leaked, got:\n{rendered}"
+        );
+        assert!(
+            !rendered.contains("\tdata: "),
+            "UE-1: raw data dump leaked, got:\n{rendered}"
+        );
+        // The 10_000-byte payload body must not appear verbatim.
+        assert!(
+            !rendered.contains(&payload),
+            "UE-1: payload body leaked into rendered text"
+        );
+    }
+
+    /// UE-1: `ReturnFailure` Display is bounded — same rule as
+    /// `DeliveryFailure`. Covers the other match arm.
+    #[test]
+    fn test_ue1_return_failure_bounded() {
+        let payload: String = std::iter::repeat_n('y', 10_000).collect();
+        let envelope = make_envelope(&payload, Flattrs::new());
+        let rendered = format!("{}", UndeliverableMessageError::ReturnFailure { envelope });
+
+        assert!(
+            rendered.contains("data_len:"),
+            "UE-1: data_len field must be present, got:\n{rendered}"
+        );
+        assert!(
+            !rendered.contains("\theaders: "),
+            "UE-1: raw headers dump leaked, got:\n{rendered}"
+        );
+        assert!(
+            !rendered.contains("\tdata: "),
+            "UE-1: raw data dump leaked, got:\n{rendered}"
+        );
+        assert!(
+            !rendered.contains(&payload),
+            "UE-1: payload body leaked into rendered text"
+        );
+    }
+
+    /// UE-3 / UE-4: when the envelope carries an operation endpoint,
+    /// the top line is `"undeliverable message for <endpoint>
+    /// (<adverb>)"`. Neutral wording — no claim about send vs reply
+    /// kind.
+    #[test]
+    fn test_ue3_operation_endpoint_names_top_line() {
+        let mut headers = Flattrs::new();
+        headers.set(OPERATION_ENDPOINT, "training.buffer.sample()".to_string());
+        headers.set(OPERATION_ADVERB, "call_one".to_string());
+        let envelope = make_envelope("payload", headers);
+        let rendered = format!(
+            "{}",
+            UndeliverableMessageError::DeliveryFailure { envelope }
+        );
+
+        let expected_line = "undeliverable message for training.buffer.sample() (call_one):";
+        assert!(
+            rendered.starts_with(expected_line),
+            "UE-3/UE-4: expected top line `{expected_line}`, got:\n{rendered}"
+        );
+        // UE-4 specifically: the wording must be neutral — it must
+        // not claim "reply" or "send" when we only know that
+        // operation context is present.
+        assert!(
+            !rendered.contains("undeliverable reply"),
+            "UE-4: must not claim reply-kind from header presence alone, got:\n{rendered}"
+        );
+        assert!(
+            !rendered.contains("undeliverable send"),
+            "UE-4: must not claim send-kind from header presence alone, got:\n{rendered}"
+        );
+    }
+
+    /// UE-3 / UE-4: envelope with no operation context falls back to
+    /// the neutral prefix.
+    #[test]
+    fn test_ue3_no_context_neutral_prefix() {
+        let envelope = make_envelope("payload", Flattrs::new());
+        let rendered = format!(
+            "{}",
+            UndeliverableMessageError::DeliveryFailure { envelope }
+        );
+
+        assert!(
+            rendered.starts_with("undeliverable message error:"),
+            "UE-3: no context → neutral prefix, got:\n{rendered}"
+        );
     }
 }

--- a/hyperactor_config/src/attrs.rs
+++ b/hyperactor_config/src/attrs.rs
@@ -179,6 +179,21 @@ pub fn lookup_key_info_by_name(name: &str) -> Option<&'static AttrKeyInfo> {
     KEYS_BY_NAME.get(name).copied()
 }
 
+declare_attrs! {
+    /// Meta-attribute marker for operation context carried on
+    /// envelope headers. Attrs declared with
+    /// `@meta(OPERATION_CONTEXT_HEADER = true)` are stamped onto
+    /// outgoing request envelopes and copied onto reply envelopes
+    /// by the marker-driven helpers
+    /// (`stamp_marked_attrs_into_flattrs`, `copy_marked_flattrs`).
+    ///
+    /// The vocabulary describes which user operation a message
+    /// belongs to, so consumers such as the undeliverable-
+    /// abandonment log can name the operation. `OPERATION_*` names
+    /// the operation; it does not imply request/reply direction.
+    pub attr OPERATION_CONTEXT_HEADER: bool;
+}
+
 /// Returns `Some(true)` when the declared attribute key with this
 /// name carries the given bool meta marker with value `true`,
 /// `Some(false)` when it carries the marker with value `false`, and

--- a/hyperactor_config/src/attrs.rs
+++ b/hyperactor_config/src/attrs.rs
@@ -116,6 +116,8 @@ use serde::de::Visitor;
 use serde::ser::SerializeMap;
 use typeuri::Named;
 
+use crate::flattrs::Flattrs;
+
 // Information about an attribute key, used for automatic registration.
 // This needs to be public to be accessible from other crates, but it is
 // not part of the public API.
@@ -160,6 +162,99 @@ pub fn lookup_key_info(key_hash: u64) -> Option<&'static AttrKeyInfo> {
                 .collect()
         });
     KEYS_BY_HASH.get(&key_hash).copied()
+}
+
+/// Look up a key info by name using the global registry.
+///
+/// Returns `None` if no key with this name is registered.
+/// Uses a lazy-initialized hash map for O(1) lookup after first access.
+pub fn lookup_key_info_by_name(name: &str) -> Option<&'static AttrKeyInfo> {
+    static KEYS_BY_NAME: std::sync::LazyLock<
+        std::collections::HashMap<&'static str, &'static AttrKeyInfo>,
+    > = std::sync::LazyLock::new(|| {
+        inventory::iter::<AttrKeyInfo>()
+            .map(|info| (info.name, info))
+            .collect()
+    });
+    KEYS_BY_NAME.get(name).copied()
+}
+
+/// Returns `Some(true)` when the declared attribute key with this
+/// name carries the given bool meta marker with value `true`,
+/// `Some(false)` when it carries the marker with value `false`, and
+/// `None` for unknown names or declared keys that do not carry the
+/// marker at all.
+///
+/// Generic "is this attr a member of the category declared by this
+/// marker?" primitive. The lower layer does not know what category
+/// the marker names — the caller supplies the category marker that
+/// defines its vocabulary (e.g. `ATTRIBUTION_HEADER` for attribution
+/// data carried on envelope headers).
+pub fn is_attr_marked_with(name: &str, marker: Key<bool>) -> Option<bool> {
+    let info = lookup_key_info_by_name(name)?;
+    info.meta.get(marker).copied()
+}
+
+/// Copy every entry from `attrs` onto `dst` whose declared
+/// attribute key carries the bool meta marker `marker` with value
+/// `true`. Overwrite semantics (see `Flattrs::set_serialized`) — a
+/// later write for the same `key_hash` is the value returned by
+/// `Flattrs::get`. Entries whose declared key lacks the marker are
+/// silently skipped; entries whose key is not declared are also
+/// silently skipped.
+///
+/// Generic category-filter stamp. The lower layer does not know what
+/// category the marker names; callers pass the marker key that
+/// defines their vocabulary (e.g. `ATTRIBUTION_HEADER`). This is
+/// the single mechanism every `Attrs → Flattrs` stamp for a category
+/// should go through, so category membership is declared in one
+/// place (the meta annotation on each key) and enforced in one
+/// place (this helper).
+pub fn stamp_marked_attrs_into_flattrs(dst: &mut Flattrs, attrs: &Attrs, marker: Key<bool>) {
+    for (name, value) in attrs.iter() {
+        if is_attr_marked_with(name, marker) != Some(true) {
+            continue;
+        }
+        dst.set_serialized(fnv1a_hash(name.as_bytes()), &value.serialize_bincode());
+    }
+}
+
+/// Copy every entry from `src` to `dst` whose declared attribute
+/// key carries the bool meta marker `marker` with value `true`.
+/// Overwrite semantics (see `Flattrs::set_serialized`). Entries
+/// whose declared key lacks the marker — or whose key_hash does
+/// not resolve to a declared key in the current binary's
+/// inventory — are silently skipped.
+///
+/// Generic category-filter `Flattrs → Flattrs` copy. The companion
+/// of `stamp_marked_attrs_into_flattrs` for callers that already
+/// have a source `Flattrs` in hand (forwarding, hoisting) rather
+/// than an in-memory `Attrs`.
+pub fn copy_marked_flattrs(dst: &mut Flattrs, src: &Flattrs, marker: Key<bool>) {
+    for (key_hash, value) in src.iter() {
+        let Some(info) = lookup_key_info(key_hash) else {
+            continue;
+        };
+        if info.meta.get(marker).copied() != Some(true) {
+            continue;
+        }
+        dst.set_serialized(key_hash, value);
+    }
+}
+
+/// Returns the set of all declared attribute key names that carry
+/// the given bool meta marker (set to `true`) in the attrs
+/// inventory linked into the current binary.
+///
+/// Generic category-membership enumeration. Used by consumers that
+/// maintain explicit hard-coded category sets (for auditability)
+/// to validate the set matches the declaration-driven vocabulary;
+/// drift between the two is a bug.
+pub fn marked_attr_names(marker: Key<bool>) -> std::collections::HashSet<&'static str> {
+    inventory::iter::<AttrKeyInfo>()
+        .filter(|info| info.meta.get(marker).copied() == Some(true))
+        .map(|info| info.name)
+        .collect()
 }
 
 /// A typed key for the attribute dictionary.
@@ -1451,5 +1546,105 @@ mod tests {
         let displayed = AttrValue::display(&original);
         let parsed: Vec<String> = AttrValue::parse(&displayed).unwrap();
         assert_eq!(parsed, original);
+    }
+
+    declare_attrs! {
+        /// Test-local marker for the generic mechanism's
+        /// membership / stamp / copy / enumeration tests. Scoped to
+        /// the test module so the mechanism's coverage does not
+        /// depend on any caller-defined marker vocabulary.
+        pub attr TEST_GENERIC_MARKER: bool;
+
+        /// Declared attr carrying the test-local marker.
+        @meta(TEST_GENERIC_MARKER = true)
+        pub attr TEST_MARKED_ATTR: String;
+
+        /// Declared attr NOT carrying the test-local marker.
+        pub attr TEST_UNMARKED_ATTR: String;
+    }
+
+    // Generic marker-parameterized membership check: the helper
+    // does not know about any specific category; callers supply
+    // the marker. Validates that declared keys with
+    // `@meta(TEST_GENERIC_MARKER = true)` match and keys without
+    // do not.
+    #[test]
+    fn test_is_attr_marked_with() {
+        assert_eq!(
+            is_attr_marked_with(TEST_MARKED_ATTR.name(), TEST_GENERIC_MARKER),
+            Some(true),
+            "marked key must report Some(true)",
+        );
+        assert_eq!(
+            is_attr_marked_with(TEST_UNMARKED_ATTR.name(), TEST_GENERIC_MARKER),
+            None,
+            "unmarked key must report None (marker not present on its meta)",
+        );
+        assert_eq!(
+            is_attr_marked_with(
+                "hyperactor_config::attrs::tests::no_such_key_declared_anywhere",
+                TEST_GENERIC_MARKER,
+            ),
+            None,
+            "unknown names must report None",
+        );
+    }
+
+    // Generic marker-parameterized Attrs → Flattrs stamp. Builds
+    // an `Attrs` with one marked and one unmarked entry; stamps
+    // via the generic helper with `TEST_GENERIC_MARKER`; asserts
+    // only the marked entry lands on headers.
+    #[test]
+    fn test_stamp_marked_attrs_into_flattrs() {
+        use crate::flattrs::Flattrs;
+
+        let mut attrs = Attrs::new();
+        attrs.set(TEST_MARKED_ATTR, "marked_value".to_string());
+        attrs.set(TEST_UNMARKED_ATTR, "unmarked_value".to_string());
+
+        let mut headers = Flattrs::new();
+        stamp_marked_attrs_into_flattrs(&mut headers, &attrs, TEST_GENERIC_MARKER);
+
+        assert_eq!(
+            headers.get(TEST_MARKED_ATTR),
+            Some("marked_value".to_string()),
+        );
+        assert_eq!(headers.get::<String>(TEST_UNMARKED_ATTR), None);
+    }
+
+    // Generic marker-parameterized Flattrs → Flattrs copy. The
+    // source Flattrs gets populated with both marked and unmarked
+    // values via typed `set` (by-key-hash stamping); the generic
+    // copy resolves each key_hash through the inventory, filters by
+    // marker, and copies only the marked entry.
+    #[test]
+    fn test_copy_marked_flattrs() {
+        use crate::flattrs::Flattrs;
+
+        let mut src = Flattrs::new();
+        src.set(TEST_MARKED_ATTR, "marked".to_string());
+        src.set(TEST_UNMARKED_ATTR, "unmarked".to_string());
+
+        let mut dst = Flattrs::new();
+        copy_marked_flattrs(&mut dst, &src, TEST_GENERIC_MARKER);
+
+        assert_eq!(dst.get(TEST_MARKED_ATTR), Some("marked".to_string()),);
+        assert_eq!(dst.get::<String>(TEST_UNMARKED_ATTR), None);
+    }
+
+    // Generic marker-parameterized enumeration. The test-local
+    // `TEST_MARKED_ATTR` is marked, so it must appear; the
+    // unmarked test attr must not.
+    #[test]
+    fn test_marked_attr_names_enumeration() {
+        let names = marked_attr_names(TEST_GENERIC_MARKER);
+        assert!(
+            names.contains(TEST_MARKED_ATTR.name()),
+            "marked test attr must appear in the vocabulary enumeration",
+        );
+        assert!(
+            !names.contains(TEST_UNMARKED_ATTR.name()),
+            "unmarked test attr must not appear in the vocabulary enumeration",
+        );
     }
 }

--- a/hyperactor_config/src/flattrs.rs
+++ b/hyperactor_config/src/flattrs.rs
@@ -114,13 +114,30 @@ impl Flattrs {
         let key_hash = key.key_hash();
         let serialized = bincode::serde::encode_to_vec(&value, bincode::config::legacy())
             .expect("serialization failed");
+        self.set_serialized(key_hash, &serialized);
+    }
 
-        // If key exists, either overwrite in place or compact + append
+    /// Set an entry by its `(key_hash, serialized_value)` pair,
+    /// replacing any existing entry under the same `key_hash`.
+    /// Collision semantics match [`set`]: in-place overwrite when
+    /// the new value is the same size, otherwise compact-and-append.
+    /// A later write under the same key hash is the value returned
+    /// by [`get`].
+    ///
+    /// This is the lower-level companion to the typed [`set`] API,
+    /// intended for callers that already have a key hash and
+    /// pre-serialized bytes in hand — for example, copying
+    /// entries across `Flattrs` buffers without re-deserializing,
+    /// or stamping typed `Attrs` entries through a crate boundary
+    /// where the concrete `Key<T>` is out of scope. Most callers
+    /// should prefer [`set`].
+    pub fn set_serialized(&mut self, key_hash: u64, serialized: &[u8]) {
+        // If key exists, either overwrite in place or compact + append.
         if let Some((offset, old_len)) = self.find_entry_location(key_hash) {
             if serialized.len() == old_len {
                 // Same size - overwrite value in place
                 let value_start = offset + ENTRY_HEADER_SIZE;
-                self.buffer[value_start..value_start + old_len].copy_from_slice(&serialized);
+                self.buffer[value_start..value_start + old_len].copy_from_slice(serialized);
                 return;
             }
 
@@ -138,7 +155,7 @@ impl Flattrs {
             self.buffer[0..2].copy_from_slice(&((count - 1) as u16).to_le_bytes());
         }
 
-        self.append_entry(key_hash, &serialized);
+        self.append_entry(key_hash, serialized);
     }
 
     /// Get a value, deserializing from the buffer.
@@ -183,6 +200,22 @@ impl Flattrs {
             flattrs.append_entry(key_hash, &serialized);
         }
         flattrs
+    }
+
+    /// Iterate over all entries as `(key_hash, value_bytes)` pairs.
+    ///
+    /// The byte slice is borrowed from the buffer — the caller must
+    /// not hold the returned slice across a mutation of this
+    /// `Flattrs`. Intended for generic copy paths that need to
+    /// transfer entries without knowing their typed schema (e.g.
+    /// filter-and-copy helpers keyed by meta marker). Callers that
+    /// need typed access should use the typed [`get`] API.
+    pub fn iter(&self) -> FlattrsIter<'_> {
+        FlattrsIter {
+            buffer: &self.buffer,
+            remaining: self.len(),
+            offset: HEADER_SIZE,
+        }
     }
 
     /// Find the value bytes for a given key_hash by scanning entries.
@@ -266,6 +299,47 @@ impl Flattrs {
         self.buffer
             .extend_from_slice(&(value.len() as u32).to_le_bytes());
         self.buffer.extend_from_slice(value);
+    }
+}
+
+/// Iterator over `Flattrs` entries as `(key_hash, value_bytes)`.
+///
+/// Produced by [`Flattrs::iter`].
+pub struct FlattrsIter<'a> {
+    buffer: &'a [u8],
+    remaining: usize,
+    offset: usize,
+}
+
+impl<'a> Iterator for FlattrsIter<'a> {
+    type Item = (u64, &'a [u8]);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.remaining == 0 {
+            return None;
+        }
+        if self.offset + ENTRY_HEADER_SIZE > self.buffer.len() {
+            return None;
+        }
+        let key_hash = u64::from_le_bytes(
+            self.buffer[self.offset..self.offset + 8]
+                .try_into()
+                .unwrap_or([0; 8]),
+        );
+        let entry_len = u32::from_le_bytes(
+            self.buffer[self.offset + 8..self.offset + 12]
+                .try_into()
+                .unwrap_or([0; 4]),
+        ) as usize;
+        let value_start = self.offset + ENTRY_HEADER_SIZE;
+        let value_end = value_start + entry_len;
+        if value_end > self.buffer.len() {
+            return None;
+        }
+        let value = &self.buffer[value_start..value_end];
+        self.offset = value_end;
+        self.remaining -= 1;
+        Some((key_hash, value))
     }
 }
 
@@ -387,6 +461,92 @@ mod tests {
             Some("a much longer string".to_string())
         );
         assert_eq!(attrs.len(), 1);
+    }
+
+    // Same-key re-set, same serialized size: later value wins,
+    // entry count stays at 1.
+    #[test]
+    fn test_set_serialized_overwrites_existing_same_size() {
+        let mut attrs = Flattrs::new();
+        let key_hash = TEST_U64.key_hash();
+        let first = bincode::serde::encode_to_vec(42u64, bincode::config::legacy()).unwrap();
+        attrs.set_serialized(key_hash, &first);
+        assert_eq!(attrs.get(TEST_U64), Some(42u64));
+        assert_eq!(attrs.len(), 1);
+
+        let second = bincode::serde::encode_to_vec(100u64, bincode::config::legacy()).unwrap();
+        assert_eq!(first.len(), second.len(), "same-size precondition");
+        attrs.set_serialized(key_hash, &second);
+
+        assert_eq!(attrs.get(TEST_U64), Some(100u64));
+        assert_eq!(attrs.len(), 1);
+    }
+
+    // Same-key re-set, different serialized size: later value
+    // wins, entry count stays at 1.
+    #[test]
+    fn test_set_serialized_overwrites_existing_different_size() {
+        let mut attrs = Flattrs::new();
+        let key_hash = TEST_STRING.key_hash();
+        let short =
+            bincode::serde::encode_to_vec("short".to_string(), bincode::config::legacy()).unwrap();
+        attrs.set_serialized(key_hash, &short);
+        assert_eq!(attrs.get(TEST_STRING), Some("short".to_string()));
+        assert_eq!(attrs.len(), 1);
+
+        let long = bincode::serde::encode_to_vec(
+            "a much longer string".to_string(),
+            bincode::config::legacy(),
+        )
+        .unwrap();
+        assert_ne!(short.len(), long.len(), "different-size precondition");
+        attrs.set_serialized(key_hash, &long);
+
+        assert_eq!(
+            attrs.get(TEST_STRING),
+            Some("a much longer string".to_string())
+        );
+        assert_eq!(attrs.len(), 1);
+    }
+
+    // `set<T>` and `set_serialized` observe each other's writes
+    // under the same key hash.
+    #[test]
+    fn test_set_serialized_interops_with_typed_set() {
+        let mut attrs = Flattrs::new();
+        attrs.set(TEST_U64, 1u64);
+        attrs.set_serialized(
+            TEST_U64.key_hash(),
+            &bincode::serde::encode_to_vec(2u64, bincode::config::legacy()).unwrap(),
+        );
+        assert_eq!(attrs.get(TEST_U64), Some(2u64));
+        assert_eq!(attrs.len(), 1);
+
+        let mut attrs = Flattrs::new();
+        attrs.set_serialized(
+            TEST_U64.key_hash(),
+            &bincode::serde::encode_to_vec(1u64, bincode::config::legacy()).unwrap(),
+        );
+        attrs.set(TEST_U64, 2u64);
+        assert_eq!(attrs.get(TEST_U64), Some(2u64));
+        assert_eq!(attrs.len(), 1);
+    }
+
+    // `set_serialized` on a novel key appends a new entry.
+    #[test]
+    fn test_set_serialized_new_key_appends() {
+        let mut attrs = Flattrs::new();
+        attrs.set_serialized(
+            TEST_U64.key_hash(),
+            &bincode::serde::encode_to_vec(7u64, bincode::config::legacy()).unwrap(),
+        );
+        attrs.set_serialized(
+            TEST_STRING.key_hash(),
+            &bincode::serde::encode_to_vec("x".to_string(), bincode::config::legacy()).unwrap(),
+        );
+        assert_eq!(attrs.get(TEST_U64), Some(7u64));
+        assert_eq!(attrs.get(TEST_STRING), Some("x".to_string()));
+        assert_eq!(attrs.len(), 2);
     }
 
     #[test]

--- a/hyperactor_mesh/src/actor_mesh.rs
+++ b/hyperactor_mesh/src/actor_mesh.rs
@@ -443,7 +443,27 @@ impl<A: Referable> ActorMeshRef<A> {
         A: RemoteHandles<M> + RemoteHandles<IndexedErasedUnbound<M>>,
         M: Castable + RemoteMessage + Clone, // Clone is required until we are fully onto comm actor
     {
-        self.cast_with_selection(cx, sel!(*), message)
+        self.cast_with_selection(cx, sel!(*), message, &Flattrs::new())
+    }
+
+    /// Cast a message to all the actors in this mesh, merging
+    /// caller-supplied `caller_headers` into the per-rank envelope
+    /// headers before send. Used to propagate caller-known context
+    /// (e.g. operation-context keys marked with `OPERATION_CONTEXT_HEADER`)
+    /// onto the outgoing request so receivers can project it back
+    /// onto replies.
+    #[allow(clippy::result_large_err)]
+    pub fn cast_with_headers<M>(
+        &self,
+        cx: &impl context::Actor,
+        caller_headers: &Flattrs,
+        message: M,
+    ) -> crate::Result<()>
+    where
+        A: RemoteHandles<M> + RemoteHandles<IndexedErasedUnbound<M>>,
+        M: Castable + RemoteMessage + Clone,
+    {
+        self.cast_with_selection(cx, sel!(*), message, caller_headers)
     }
 
     /// Cast a message to the actors in this mesh according to the provided selection.
@@ -461,7 +481,7 @@ impl<A: Referable> ActorMeshRef<A> {
         A: RemoteHandles<M> + RemoteHandles<IndexedErasedUnbound<M>>,
         M: Castable + RemoteMessage + Clone, // Clone is required until we are fully onto comm actor
     {
-        self.cast_with_selection(cx, sel, message)
+        self.cast_with_selection(cx, sel, message, &Flattrs::new())
     }
 
     #[allow(clippy::result_large_err)]
@@ -470,6 +490,7 @@ impl<A: Referable> ActorMeshRef<A> {
         cx: &impl context::Actor,
         sel: Selection,
         message: M,
+        caller_headers: &Flattrs,
     ) -> crate::Result<()>
     where
         A: RemoteHandles<M> + RemoteHandles<IndexedErasedUnbound<M>>,
@@ -499,11 +520,14 @@ impl<A: Referable> ActorMeshRef<A> {
 
         // Now that we know these ranks are active, send out the actual messages.
         if let Some(root_comm_actor) = self.proc_mesh.root_comm_actor() {
-            self.cast_v0(cx, message, sel, root_comm_actor)
+            self.cast_v0(cx, message, sel, root_comm_actor, caller_headers)
         } else {
             for (point, actor) in self.iter() {
                 let create_rank = point.rank();
-                let mut headers = Flattrs::new();
+                // Caller-known headers ride first; cast-info is
+                // stamped afterward and wins on collision because
+                // those keys are owned by this layer.
+                let mut headers = caller_headers.clone();
                 multicast::set_cast_info_on_headers(
                     &mut headers,
                     point,
@@ -538,6 +562,7 @@ impl<A: Referable> ActorMeshRef<A> {
         message: M,
         sel: Selection,
         root_comm_actor: &hyperactor_reference::ActorRef<CommActor>,
+        caller_headers: &Flattrs,
     ) -> crate::Result<()>
     where
         A: RemoteHandles<IndexedErasedUnbound<M>>,
@@ -556,6 +581,7 @@ impl<A: Referable> ActorMeshRef<A> {
                     message,
                     &cast_mesh_shape,
                     &root_mesh_shape,
+                    caller_headers,
                 )
                 .map_err(|e| Error::CastingError(self.id.clone(), e.into()))
             }
@@ -567,6 +593,7 @@ impl<A: Referable> ActorMeshRef<A> {
                 &cast_mesh_shape,
                 &cast_mesh_shape,
                 message,
+                caller_headers,
             )
             .map_err(|e| Error::CastingError(self.id.clone(), e.into())),
         }

--- a/hyperactor_mesh/src/casting.rs
+++ b/hyperactor_mesh/src/casting.rs
@@ -71,7 +71,11 @@ pub fn update_undeliverable_envelope_for_casting(
 }
 
 /// Common implementation for `ActorMesh`s and `ActorMeshRef`s to cast
-/// an `M`-typed message
+/// an `M`-typed message.
+///
+/// `caller_headers` are caller-supplied envelope headers (e.g.
+/// operation-context keys) merged into the inner envelope headers so
+/// receivers see them on `cx.headers()`.
 #[allow(clippy::result_large_err)] // TODO: Consider reducing the size of `CastError`.
 #[tracing::instrument(level = "debug", skip_all)]
 pub(crate) fn actor_mesh_cast<A, M>(
@@ -82,6 +86,7 @@ pub(crate) fn actor_mesh_cast<A, M>(
     root_mesh_shape: &Shape,
     cast_mesh_shape: &Shape,
     message: M,
+    caller_headers: &Flattrs,
 ) -> Result<(), CastError>
 where
     A: Referable + RemoteHandles<IndexedErasedUnbound<M>>,
@@ -92,7 +97,10 @@ where
         "message_variant" => message.arm().unwrap_or_default(),
     ));
 
-    let mut headers = Flattrs::new();
+    // Caller-known headers ride first; cast-info (timestamp,
+    // message type, mesh id) is stamped afterward and wins on
+    // collision because those keys are owned by this layer.
+    let mut headers = caller_headers.clone();
     mailbox::headers::set_send_timestamp(&mut headers);
     mailbox::headers::set_rust_message_type::<M>(&mut headers);
     headers.set(CAST_ACTOR_MESH_ID, actor_mesh_id.clone());
@@ -138,8 +146,10 @@ where
         message,
     };
 
-    // TEMPORARY: remove with v0 support
-    let mut headers = Flattrs::new();
+    // TEMPORARY: remove with v0 support. Same ownership rule as
+    // the inner envelope: caller-known headers ride first, cast-info
+    // wins on collision.
+    let mut headers = caller_headers.clone();
     headers.set(CAST_ACTOR_MESH_ID, actor_mesh_id);
 
     comm_actor_ref
@@ -158,6 +168,7 @@ pub(crate) fn cast_to_sliced_mesh<A, M>(
     message: M,
     sliced_shape: &Shape,
     root_mesh_shape: &Shape,
+    caller_headers: &Flattrs,
 ) -> Result<(), CastError>
 where
     A: Referable + RemoteHandles<IndexedErasedUnbound<M>>,
@@ -186,6 +197,7 @@ where
         root_mesh_shape,
         sliced_shape,
         message,
+        caller_headers,
     )
 }
 

--- a/monarch_hyperactor/src/actor.rs
+++ b/monarch_hyperactor/src/actor.rs
@@ -412,13 +412,34 @@ impl PythonMessage {
                 name,
                 response_port,
             } => {
+                let method_name = name.name().to_string();
                 let response_port = response_port.map_or(ResponsePort::Dropping, |port_ref| {
                     let point = cx.cast_point();
-                    ResponsePort::Port(Port {
+                    // Carry operation context onto the reply: copy
+                    // OPERATION_*-marked keys from the inbound
+                    // envelope, falling back to the method name when
+                    // the caller didn't stamp.
+                    let mut reply_headers = hyperactor_config::Flattrs::new();
+                    hyperactor_config::attrs::copy_marked_flattrs(
+                        &mut reply_headers,
+                        cx.headers(),
+                        hyperactor_config::attrs::OPERATION_CONTEXT_HEADER,
+                    );
+                    if reply_headers
+                        .get(hyperactor::mailbox::headers::OPERATION_ENDPOINT)
+                        .is_none()
+                    {
+                        reply_headers.set(
+                            hyperactor::mailbox::headers::OPERATION_ENDPOINT,
+                            format!("{}()", method_name),
+                        );
+                    }
+                    ResponsePort::Port(Port::with_reply_headers(
                         port_ref,
-                        instance: cx.instance().clone_for_py(),
-                        rank: Some(point.rank()),
-                    })
+                        cx.instance().clone_for_py(),
+                        Some(point.rank()),
+                        reply_headers,
+                    ))
                 });
                 Ok(ResolvedCallMethod {
                     method: name,
@@ -1651,6 +1672,10 @@ pub struct Port {
     port_ref: EitherPortRef,
     instance: Instance<PythonActor>,
     rank: Option<usize>,
+    /// Operation-context headers captured from the inbound request,
+    /// re-emitted on every reply so failure surfaces can name the
+    /// operation.
+    reply_headers: hyperactor_config::Flattrs,
 }
 
 #[pymethods]
@@ -1665,6 +1690,7 @@ impl Port {
             port_ref,
             instance: instance.clone().into_instance(),
             rank,
+            reply_headers: hyperactor_config::Flattrs::new(),
         }
     }
 
@@ -1695,7 +1721,7 @@ impl Port {
         );
 
         self.port_ref
-            .send(&self.instance, message)
+            .send_with_headers(&self.instance, self.reply_headers.clone(), message)
             .map_err(|e| PyRuntimeError::new_err(e.to_string()))
     }
 
@@ -1706,8 +1732,27 @@ impl Port {
         );
 
         self.port_ref
-            .send(&self.instance, message)
+            .send_with_headers(&self.instance, self.reply_headers.clone(), message)
             .map_err(|e| PyRuntimeError::new_err(e.to_string()))
+    }
+}
+
+impl Port {
+    /// Constructor that attaches operation-context headers captured
+    /// from the inbound request. The Python `#[new]` constructor
+    /// defaults to empty headers.
+    pub(crate) fn with_reply_headers(
+        port_ref: EitherPortRef,
+        instance: Instance<PythonActor>,
+        rank: Option<usize>,
+        reply_headers: hyperactor_config::Flattrs,
+    ) -> Self {
+        Self {
+            port_ref,
+            instance,
+            rank,
+            reply_headers,
+        }
     }
 }
 

--- a/monarch_hyperactor/src/actor_mesh.rs
+++ b/monarch_hyperactor/src/actor_mesh.rs
@@ -79,6 +79,22 @@ pub(crate) trait ActorMeshProtocol: Send + Sync {
         instance: &Instance<PythonActor>,
     ) -> PyResult<()>;
 
+    /// Cast a message, merging caller-supplied envelope headers into
+    /// the outbound request. Implementations that reach the real
+    /// envelope emission site override this to thread `caller_headers`
+    /// through `hyperactor_mesh::ActorMeshRef::cast_with_headers`;
+    /// the default collapses to the non-headers path for impls that
+    /// have no envelope access.
+    fn cast_with_headers(
+        &self,
+        message: PythonMessage,
+        selection: Selection,
+        instance: &Instance<PythonActor>,
+        _caller_headers: hyperactor_config::Flattrs,
+    ) -> PyResult<()> {
+        self.cast(message, selection, instance)
+    }
+
     /// Cast a pending message (which may contain unresolved async values) to actors.
     ///
     /// The default implementation blocks on resolving the message and then calls cast.
@@ -91,6 +107,21 @@ pub(crate) trait ActorMeshProtocol: Send + Sync {
     ) -> PyResult<()> {
         let message = get_tokio_runtime().block_on(message.resolve())?;
         self.cast(message, selection, instance)
+    }
+
+    /// Async counterpart of `cast_with_headers`. The default
+    /// resolves the pending message synchronously and delegates;
+    /// `AsyncActorMesh` overrides this to resolve asynchronously
+    /// and route through `cast_with_headers`.
+    fn cast_unresolved_with_headers(
+        &self,
+        message: PendingMessage,
+        selection: Selection,
+        instance: &Instance<PythonActor>,
+        caller_headers: hyperactor_config::Flattrs,
+    ) -> PyResult<()> {
+        let message = get_tokio_runtime().block_on(message.resolve())?;
+        self.cast_with_headers(message, selection, instance, caller_headers)
     }
 
     fn __reduce__<'py>(&self, py: Python<'py>) -> PyResult<(Bound<'py, PyAny>, Bound<'py, PyAny>)>;
@@ -315,6 +346,21 @@ impl ActorMeshProtocol for AsyncActorMesh {
         selection: Selection,
         instance: &Instance<PythonActor>,
     ) -> PyResult<()> {
+        self.cast_unresolved_with_headers(
+            message,
+            selection,
+            instance,
+            hyperactor_config::Flattrs::new(),
+        )
+    }
+
+    fn cast_unresolved_with_headers(
+        &self,
+        message: PendingMessage,
+        selection: Selection,
+        instance: &Instance<PythonActor>,
+        caller_headers: hyperactor_config::Flattrs,
+    ) -> PyResult<()> {
         let mesh = self.mesh.clone();
         let instance = instance.clone_for_py();
         let port = match &message.kind {
@@ -324,7 +370,8 @@ impl ActorMeshProtocol for AsyncActorMesh {
         self.push(async move {
             let result = async {
                 let resolved = message.resolve().await?;
-                mesh.await?.cast(resolved, selection, &instance)
+                mesh.await?
+                    .cast_with_headers(resolved, selection, &instance, caller_headers)
             }
             .await;
             if let (Some(mut port_ref), Err(pyerr)) = (port, result) {
@@ -527,6 +574,22 @@ impl ActorMeshProtocol for PythonActorMeshImpl {
         )
     }
 
+    fn cast_with_headers(
+        &self,
+        message: PythonMessage,
+        selection: Selection,
+        instance: &Instance<PythonActor>,
+        caller_headers: hyperactor_config::Flattrs,
+    ) -> PyResult<()> {
+        <ActorMeshRef<PythonActor> as ActorMeshProtocol>::cast_with_headers(
+            self.mesh_ref(),
+            message,
+            selection,
+            instance,
+            caller_headers,
+        )
+    }
+
     fn stop(&self, instance: &PyInstance, reason: String) -> PyResult<PyPythonTask> {
         let (slf, instance) = monarch_with_gil_blocking(|_py| (self.clone(), instance.clone()));
         match slf {
@@ -578,9 +641,30 @@ impl ActorMeshProtocol for ActorMeshRef<PythonActor> {
         selection: Selection,
         instance: &Instance<PythonActor>,
     ) -> PyResult<()> {
+        <Self as ActorMeshProtocol>::cast_with_headers(
+            self,
+            message,
+            selection,
+            instance,
+            hyperactor_config::Flattrs::new(),
+        )
+    }
+
+    fn cast_with_headers(
+        &self,
+        message: PythonMessage,
+        selection: Selection,
+        instance: &Instance<PythonActor>,
+        caller_headers: hyperactor_config::Flattrs,
+    ) -> PyResult<()> {
         if structurally_equal(&selection, &Selection::All(Box::new(Selection::True))) {
-            self.cast(instance, message.clone())
-                .map_err(cast_error_to_py_error)?;
+            ActorMeshRef::<PythonActor>::cast_with_headers(
+                self,
+                instance,
+                &caller_headers,
+                message.clone(),
+            )
+            .map_err(cast_error_to_py_error)?;
         } else if structurally_equal(&selection, &Selection::Any(Box::new(Selection::True))) {
             let region = Ranked::region(self);
             let random_rank = fastrand::usize(0..region.num_ranks());
@@ -592,9 +676,13 @@ impl ActorMeshProtocol for ActorMeshRef<PythonActor> {
                 Vec::new(),
                 Slice::new(offset, Vec::new(), Vec::new()).map_err(anyhow::Error::from)?,
             );
-            self.sliced(singleton_region)
-                .cast(instance, message.clone())
-                .map_err(cast_error_to_py_error)?;
+            ActorMeshRef::<PythonActor>::cast_with_headers(
+                &self.sliced(singleton_region),
+                instance,
+                &caller_headers,
+                message.clone(),
+            )
+            .map_err(cast_error_to_py_error)?;
         } else {
             return Err(PyRuntimeError::new_err(format!(
                 "invalid selection: {:?}",

--- a/monarch_hyperactor/src/endpoint.rs
+++ b/monarch_hyperactor/src/endpoint.rs
@@ -537,6 +537,47 @@ pub(crate) trait Endpoint {
         instance: &Instance<PythonActor>,
     ) -> PyResult<()>;
 
+    /// Like `send_message` but stamps `caller_headers` onto the
+    /// outgoing request envelope. Implementations that can carry
+    /// headers override this; the default delegates to `send_message`
+    /// and drops them.
+    fn send_message_with_headers<'py>(
+        &self,
+        py: Python<'py>,
+        args: &Bound<'py, PyTuple>,
+        kwargs: Option<&Bound<'py, PyDict>>,
+        port_ref: Option<EitherPortRef>,
+        selection: Selection,
+        instance: &Instance<PythonActor>,
+        _caller_headers: hyperactor_config::Flattrs,
+    ) -> PyResult<()> {
+        self.send_message(py, args, kwargs, port_ref, selection, instance)
+    }
+
+    /// Build the operation-context envelope headers to stamp on an
+    /// outgoing request for this endpoint invocation. The result is
+    /// empty when the endpoint cannot supply a qualified name
+    /// (e.g. `RemoteEndpoint`'s `get_qualified_name` returns `None`),
+    /// in which case callers see the unchanged dispatch surface.
+    fn build_operation_context_headers(
+        &self,
+        adverb: EndpointAdverb,
+    ) -> hyperactor_config::Flattrs {
+        let adverb_str = match adverb {
+            EndpointAdverb::Call => "call",
+            EndpointAdverb::CallOne => "call_one",
+            EndpointAdverb::Choose => "choose",
+            EndpointAdverb::Stream => "stream",
+        };
+        let attrs = crate::operation_context::build_operation_context_attrs(
+            self.get_qualified_name(),
+            Some(adverb_str),
+        );
+        let mut headers = hyperactor_config::Flattrs::new();
+        crate::operation_context::stamp_operation_context(&mut headers, &attrs);
+        headers
+    }
+
     /// Get the supervision_monitor for this endpoint (if any).
     fn get_supervision_monitor(&self) -> Option<Arc<dyn Supervisable>>;
 
@@ -592,13 +633,15 @@ pub(crate) trait Endpoint {
         let supervision_monitor = self.get_supervision_monitor();
         let qualified_endpoint_name = self.get_qualified_name();
 
-        self.send_message(
+        let caller_headers = self.build_operation_context_headers(EndpointAdverb::Call);
+        self.send_message_with_headers(
             py,
             args,
             kwargs,
             Some(EitherPortRef::Once(port_ref)),
             sel!(*),
             &instance,
+            caller_headers,
         )?;
 
         let instance_for_task = instance.clone_for_py();
@@ -630,13 +673,15 @@ pub(crate) trait Endpoint {
         let span_guard = self.enter_endpoint_span(EndpointAdverb::Choose, instance.self_id());
         let (port_ref, receiver) = self.open_response_port(&instance);
 
-        self.send_message(
+        let caller_headers = self.build_operation_context_headers(EndpointAdverb::Choose);
+        self.send_message_with_headers(
             py,
             args,
             kwargs,
             Some(EitherPortRef::Unbounded(port_ref)),
             sel!(?),
             &instance,
+            caller_headers,
         )?;
 
         let task = value_collector(
@@ -672,13 +717,15 @@ pub(crate) trait Endpoint {
         let span_guard = self.enter_endpoint_span(EndpointAdverb::CallOne, instance.self_id());
         let (port_ref, receiver) = self.open_response_port(&instance);
 
-        self.send_message(
+        let caller_headers = self.build_operation_context_headers(EndpointAdverb::CallOne);
+        self.send_message_with_headers(
             py,
             args,
             kwargs,
             Some(EitherPortRef::Unbounded(port_ref)),
             sel!(*),
             &instance,
+            caller_headers,
         )?;
 
         let task = value_collector(
@@ -707,13 +754,15 @@ pub(crate) trait Endpoint {
         let instance = self.get_current_instance(py)?;
         let (port_ref, receiver) = self.open_response_port(&instance);
 
-        self.send_message(
+        let caller_headers = self.build_operation_context_headers(EndpointAdverb::Stream);
+        self.send_message_with_headers(
             py,
             args,
             kwargs,
             Some(EitherPortRef::Unbounded(port_ref)),
             sel!(*),
             &instance,
+            caller_headers,
         )?;
 
         let actor_count = extent.num_ranks();
@@ -834,6 +883,21 @@ impl Endpoint for ActorEndpoint {
     ) -> PyResult<()> {
         let message = self.create_message(py, args, kwargs, port_ref)?;
         self.inner.cast_unresolved(message, selection, instance)
+    }
+
+    fn send_message_with_headers<'py>(
+        &self,
+        py: Python<'py>,
+        args: &Bound<'py, PyTuple>,
+        kwargs: Option<&Bound<'py, PyDict>>,
+        port_ref: Option<EitherPortRef>,
+        selection: Selection,
+        instance: &Instance<PythonActor>,
+        caller_headers: hyperactor_config::Flattrs,
+    ) -> PyResult<()> {
+        let message = self.create_message(py, args, kwargs, port_ref)?;
+        self.inner
+            .cast_unresolved_with_headers(message, selection, instance, caller_headers)
     }
 
     fn get_supervision_monitor(&self) -> Option<Arc<dyn Supervisable>> {
@@ -1411,5 +1475,100 @@ impl Accumulator for PythonResponseMessageAccumulator {
             typehash: <PythonResponseMessageReducer as Named>::typehash(),
             builder_params: None,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use hyperactor::mailbox::headers::OPERATION_ADVERB;
+    use hyperactor::mailbox::headers::OPERATION_ENDPOINT;
+
+    use super::*;
+
+    /// Minimal `Endpoint` impl that only serves `get_qualified_name`.
+    /// The default `build_operation_context_headers` consults no other
+    /// method, so the rest are unreachable.
+    struct TestEndpoint {
+        qualified_name: Option<String>,
+    }
+
+    impl Endpoint for TestEndpoint {
+        fn get_extent(&self, _py: Python<'_>) -> PyResult<Extent> {
+            unreachable!()
+        }
+        fn get_method_name(&self) -> &str {
+            unreachable!()
+        }
+        fn send_message<'py>(
+            &self,
+            _py: Python<'py>,
+            _args: &Bound<'py, PyTuple>,
+            _kwargs: Option<&Bound<'py, PyDict>>,
+            _port_ref: Option<EitherPortRef>,
+            _selection: Selection,
+            _instance: &Instance<PythonActor>,
+        ) -> PyResult<()> {
+            unreachable!()
+        }
+        fn get_supervision_monitor(&self) -> Option<Arc<dyn Supervisable>> {
+            None
+        }
+        fn get_qualified_name(&self) -> Option<String> {
+            self.qualified_name.clone()
+        }
+        fn enter_endpoint_span(&self, _adverb: EndpointAdverb, _actor_id: &ActorRef) -> SpanGuard {
+            unreachable!()
+        }
+    }
+
+    /// OC-1 request-side producer: each `EndpointAdverb` maps to the
+    /// expected wire adverb string, and the qualified endpoint name
+    /// from `get_qualified_name()` flows through to `OPERATION_ENDPOINT`.
+    #[test]
+    fn test_rc1_build_operation_context_headers_stamps_each_adverb() {
+        let ep = TestEndpoint {
+            qualified_name: Some("training.Philosopher.ping()".to_string()),
+        };
+        for (adverb, expected_adverb) in [
+            (EndpointAdverb::Call, "call"),
+            (EndpointAdverb::CallOne, "call_one"),
+            (EndpointAdverb::Choose, "choose"),
+            (EndpointAdverb::Stream, "stream"),
+        ] {
+            let headers = ep.build_operation_context_headers(adverb);
+            assert_eq!(
+                headers.get(OPERATION_ENDPOINT).as_deref(),
+                Some("training.Philosopher.ping()"),
+                "adverb {:?}: OPERATION_ENDPOINT",
+                adverb,
+            );
+            assert_eq!(
+                headers.get(OPERATION_ADVERB).as_deref(),
+                Some(expected_adverb),
+                "adverb {:?}: OPERATION_ADVERB",
+                adverb,
+            );
+        }
+    }
+
+    /// OC-1 request-side producer: when the endpoint has no
+    /// qualified name (e.g. `Remote::get_qualified_name` returns
+    /// `None`), `OPERATION_ENDPOINT` is omitted while `OPERATION_ADVERB`
+    /// is still stamped.
+    #[test]
+    fn test_rc1_build_operation_context_headers_omits_endpoint_when_no_qualified_name() {
+        let ep = TestEndpoint {
+            qualified_name: None,
+        };
+        let headers = ep.build_operation_context_headers(EndpointAdverb::CallOne);
+        assert!(
+            headers.get(OPERATION_ENDPOINT).is_none(),
+            "OPERATION_ENDPOINT must be absent when endpoint has no qualified name",
+        );
+        assert_eq!(
+            headers.get(OPERATION_ADVERB).as_deref(),
+            Some("call_one"),
+            "OPERATION_ADVERB should still be stamped",
+        );
     }
 }

--- a/monarch_hyperactor/src/lib.rs
+++ b/monarch_hyperactor/src/lib.rs
@@ -25,6 +25,7 @@ pub mod logging;
 pub mod mailbox;
 pub mod metrics;
 pub mod ndslice;
+pub mod operation_context;
 pub mod pickle;
 pub mod proc;
 pub mod proc_launcher;

--- a/monarch_hyperactor/src/mailbox.rs
+++ b/monarch_hyperactor/src/mailbox.rs
@@ -626,6 +626,31 @@ impl EitherPortRef {
         }
         Ok(())
     }
+
+    /// Send a message through this port reference with
+    /// caller-supplied envelope headers. Delegates to the underlying
+    /// `PortRef::send_with_headers` /
+    /// `OncePortRef::send_with_headers`.
+    pub fn send_with_headers(
+        &mut self,
+        cx: &impl hyperactor::context::Actor,
+        headers: hyperactor_config::Flattrs,
+        message: crate::actor::PythonMessage,
+    ) -> anyhow::Result<()> {
+        match self {
+            EitherPortRef::Unbounded(port_ref) => {
+                port_ref.inner.send_with_headers(cx, headers, message)?
+            }
+            EitherPortRef::Once(once_port_ref) => {
+                let port = once_port_ref
+                    .inner
+                    .take()
+                    .ok_or_else(|| anyhow::anyhow!("OncePortRef already used"))?;
+                port.send_with_headers(cx, headers, message)?;
+            }
+        }
+        Ok(())
+    }
 }
 
 #[derive(Debug, Named)]

--- a/monarch_hyperactor/src/operation_context.rs
+++ b/monarch_hyperactor/src/operation_context.rs
@@ -1,0 +1,150 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+//! Operation-context carrier for the Python endpoint machinery.
+//!
+//! Stamps `OPERATION_ENDPOINT` / `OPERATION_ADVERB` on outgoing
+//! requests so failure surfaces (mailbox log, undeliverable
+//! formatter) can name the operation.
+//!
+//! ## Operation-context invariants (OC-*)
+//!
+//! - **OC-1 (request-originated).** Stamped at the caller's
+//!   request-send site. Only the caller knows the qualified
+//!   endpoint and adverb.
+//!
+//! - **OC-2 (filtered carry).** Only keys marked
+//!   `@meta(OPERATION_CONTEXT_HEADER = true)` ride this path.
+//!   Adding another `OPERATION_*` key joins the vocabulary by
+//!   declaration alone.
+//!
+//! - **OC-3 (carry continuity).** Captured headers are preserved
+//!   onto the reply envelope at the `Port` capture site via
+//!   `send_with_headers`.
+
+use hyperactor::mailbox::headers::OPERATION_ADVERB;
+use hyperactor::mailbox::headers::OPERATION_ENDPOINT;
+use hyperactor_config::Attrs;
+use hyperactor_config::Flattrs;
+use hyperactor_config::attrs::OPERATION_CONTEXT_HEADER;
+use hyperactor_config::attrs::stamp_marked_attrs_into_flattrs;
+
+/// Build an `Attrs` carrier populated with the operation-context keys
+/// an endpoint-send site wants to stamp onto its outgoing request.
+///
+/// Callers supply the values they know in scope at the send site
+/// (qualified endpoint name, adverb token). Any `None` is simply
+/// omitted — the marker-driven stamp filters on presence.
+pub fn build_operation_context_attrs(
+    endpoint: Option<String>,
+    adverb: Option<&'static str>,
+) -> Attrs {
+    let mut attrs = Attrs::new();
+    if let Some(ep) = endpoint {
+        attrs.set(OPERATION_ENDPOINT, ep);
+    }
+    if let Some(a) = adverb {
+        attrs.set(OPERATION_ADVERB, a.to_string());
+    }
+    attrs
+}
+
+/// Stamp the operation-context subset of `attrs` onto `headers` using
+/// the shared marker-driven mechanism. Only entries whose declared
+/// key carries `@meta(OPERATION_CONTEXT_HEADER = true)` are written;
+/// anything else in `attrs` is silently skipped (OC-2).
+pub fn stamp_operation_context(headers: &mut Flattrs, attrs: &Attrs) {
+    stamp_marked_attrs_into_flattrs(headers, attrs, OPERATION_CONTEXT_HEADER);
+}
+
+#[cfg(test)]
+mod tests {
+    use hyperactor_config::attrs::copy_marked_flattrs;
+
+    use super::*;
+
+    /// OC-2: the shared marker-driven copy propagates exactly the
+    /// `OPERATION_CONTEXT_HEADER`-marked keys from the source headers
+    /// onto the destination. Unrelated declared `Flattrs` entries
+    /// (e.g. `SEND_TIMESTAMP`) are excluded even though they're
+    /// present on the source.
+    #[test]
+    fn test_oc2_filter_rejects_unmarked_keys() {
+        let mut src = Flattrs::new();
+        src.set(OPERATION_ENDPOINT, "training.buffer.sample()".to_string());
+        src.set(
+            hyperactor::mailbox::headers::SEND_TIMESTAMP,
+            std::time::SystemTime::UNIX_EPOCH,
+        );
+
+        let mut dst = Flattrs::new();
+        copy_marked_flattrs(&mut dst, &src, OPERATION_CONTEXT_HEADER);
+
+        assert_eq!(
+            dst.get(OPERATION_ENDPOINT),
+            Some("training.buffer.sample()".to_string()),
+            "OC-2: marked key must cross the carry"
+        );
+        assert!(
+            dst.get(hyperactor::mailbox::headers::SEND_TIMESTAMP)
+                .is_none(),
+            "OC-2: unmarked key must not cross the carry"
+        );
+    }
+
+    /// OC-1: the caller-side helper assembles the operation-context
+    /// attrs from values known at the request-send site, rather
+    /// than synthesized at the reply site. `build_operation_context_attrs`
+    /// is the vehicle for that origination step.
+    #[test]
+    fn test_oc1_build_attrs_populates_supplied_fields() {
+        let attrs = build_operation_context_attrs(
+            Some("training.buffer.sample()".to_string()),
+            Some("call_one"),
+        );
+        assert_eq!(
+            attrs.get(OPERATION_ENDPOINT),
+            Some(&"training.buffer.sample()".to_string())
+        );
+        assert_eq!(attrs.get(OPERATION_ADVERB), Some(&"call_one".to_string()));
+    }
+
+    /// OC-1: fields the request site cannot supply must not be
+    /// fabricated downstream. `build_operation_context_attrs` omits
+    /// them when the caller passes `None`.
+    #[test]
+    fn test_oc1_build_attrs_omits_none_fields() {
+        let attrs =
+            build_operation_context_attrs(Some("training.buffer.sample()".to_string()), None);
+        assert_eq!(
+            attrs.get(OPERATION_ENDPOINT),
+            Some(&"training.buffer.sample()".to_string())
+        );
+        assert!(attrs.get(OPERATION_ADVERB).is_none());
+    }
+
+    /// OC-2: the stamp helper writes only the
+    /// `OPERATION_CONTEXT_HEADER`-marked keys onto the outgoing
+    /// headers. Same mechanism as the OC-2 copy test above, on the
+    /// `Attrs -> Flattrs` direction.
+    #[test]
+    fn test_oc2_stamp_writes_marked_keys_to_headers() {
+        let attrs = build_operation_context_attrs(
+            Some("training.buffer.sample()".to_string()),
+            Some("call_one"),
+        );
+        let mut headers = Flattrs::new();
+        stamp_operation_context(&mut headers, &attrs);
+
+        assert_eq!(
+            headers.get(OPERATION_ENDPOINT),
+            Some("training.buffer.sample()".to_string())
+        );
+        assert_eq!(headers.get(OPERATION_ADVERB), Some("call_one".to_string()));
+    }
+}


### PR DESCRIPTION
Summary:

this diff improves the user-visible text for undeliverable-message failures by changing UndeliverableMessageError's Display rendering in hyperactor/src/mailbox/undeliverable.rs.

today the log looks like this:

```lang=txt,counterexample
Unhandled monarch error on the root actor, hostname=twshared15151.01.nha5.facebook.com, PID=1797 at time 2026-04-16 13:54:14.809990:
The actor <monarch._src.actor.actor_mesh.RootClientActor client> and all its descendants have failed:
  undeliverable message error:
      description: delivery of message from sender to dest failed
      sender: metatls:twshared15151.01.nha5.facebook.com:33817,local,client[0]
      dest: metatls:twshared15151.01.nha5.facebook.com:33817,anon_0-1oHHDB4iz1zM,comm-16so5LJZR19x[0][13147652568889606402<hyperactor_mesh::comm::multicast::CastMessage>]
      message type: hyperactor_mesh::comm::multicast::CastMessage
      headers: hyperactor_mesh::casting::cast_actor_mesh_id=Service_TNTTrainer-1DwVV95K7L4H,hyperactor::mailbox::headers::send_timestamp=2026-04-16T20:53:44.027533837+00:00,hyperactor::mailbox::headers::rust_message_type=hyperactor_mesh::comm::multicast::CastMessage,hyperactor::ordering::seq_info=019d97fd-8699-7c63-8b4d-394a1f01e1bc:15966
      data: CastMessage{"dest":{"selection":"True","slice":{"offset":0,"sizes":[1],"strides":[1]}},"message":{"actor_mesh_id":"Service_[...31 chars] CRC:a29abdc6 53 65 72 76 69 63 65 5f [...23 bytes]","data":{"bindings":"[[119644[...382 chars] CRC:87d13846 5b 5b 31 31 39 36 34 34 [...374 bytes]","message":{"encoded":{"Multipart":{"body":"[0,0,0,0[...334 chars] CRC:ade548f0 5b 30 2c 30 2c 30 2c 30 [...326 bytes]","parts":"[[128,5,[...34108999 chars] CRC:d612ee90 5b 5b 31 32 38 2c 35 2c [...34108991 bytes]"}},"typehash":6233861156521327611}},"dest_port":{"actor_name":"Service_[...31 chars] CRC:a29abdc6 53 65 72 76 69 63 65 5f [...23 bytes]","port":14818936840262076595},"headers":"[3,0,181[...437 chars] CRC:f930d812 5b 33 2c 30 2c 31 38 31 [...429 bytes]","sender":"[[{\"Meta[...97 chars] CRC:7373a1f1 5b 5b 7b 22 4d 65 74 61 [...89 bytes]","shape":{"labels":"[\"procs\"[...9 chars] CRC:d1f1d7de 5b 22 70 72 6f 63 73 22 [...1 bytes]","slice":{"offset":0,"sizes":[1],"strides":[1]}}}}
      error: broken link: failed to enqueue in MailboxClient when processing buffer: channel closed with reason Some("session unix:/tmp/.tmpkAw2e8/anon_0-1oHHDB4iz1zM.1ca9034d70d79a14: failed to deliver message within timeout 30s; last connected 1281.3s ago, disconnected for 9.7s")
```

after this diff, the same class of failure is surfaced as:

```lang=txt,counterexample
Unhandled monarch error on the root actor, hostname=twshared15151.01.nha5.facebook.com, PID=1797 at time 2026-04-16 13:54:14.809990:
The actor <monarch._src.actor.actor_mesh.RootClientActor client> and all its descendants have failed:
    undeliverable message for trainer.step() (call_one):
        description: delivery of message from sender to dest failed
        sender: metatls:twshared15151.01.nha5.facebook.com:33817,local,client[0]
        dest: metatls:twshared15151.01.nha5.facebook.com:33817,anon_0-1oHHDB4iz1zM,comm-16so5LJZR19x[0][13147652568889606402<hyperactor_mesh::comm::multicast::CastMessage>]
        message type: hyperactor_mesh::comm::multicast::CastMessage
        data_len: 34109000
        error: broken link: failed to enqueue in MailboxClient when processing buffer: channel closed with reason Some("session unix:/tmp/.tmpkAw2e8/anon_0-1oHHDB4iz1zM.1ca9034d70d79a14: failed to deliver message within timeout 30s; last connected 1281.3s ago, disconnected for 9.7s")
```

the practical change is that the user now sees the operation-relevant top-line cue, trainer.step() (call_one). the 34 MB CastMessage body is replaced by bounded observability via message type and data_len.

this diff is intentionally tactical. it does not deserialize CastMessage, does not redesign supervision, does not touch MessageEnvelope::Display. it fixes the exact formatter that dominates this user-visible failure surface.

Reviewed By: mariusae

Differential Revision: D102369319


