### PR TITLE
[tool-fetch] add managed diagnostic tool provisioning with py-spy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ members = [
     "timed_test",
     "torch-sys2",
     "torch-sys-cuda",
+    "tool_fetch",
     "wirevalue",
 ]
 default-members = [
@@ -66,5 +67,6 @@ default-members = [
     "struct_diff_patch_macros",
     "timed_test",
     "torch-sys2",
+    "tool_fetch",
     "wirevalue",
 ]

--- a/hyperactor_mesh/Cargo.toml
+++ b/hyperactor_mesh/Cargo.toml
@@ -51,6 +51,7 @@ thiserror = "2.0.18"
 tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }
 tokio-rustls = { version = "0.26.4", features = ["logging", "ring", "tls12"], default-features = false }
 tokio-util = { version = "0.7.18", features = ["full"] }
+tool_fetch = { version = "0.0.0", path = "../tool_fetch" }
 tracing = { version = "0.1.41", features = ["attributes", "valuable"] }
 typeuri = { version = "0.0.0", path = "../typeuri" }
 url = "2.5.8"

--- a/hyperactor_mesh/Cargo.toml
+++ b/hyperactor_mesh/Cargo.toml
@@ -64,10 +64,12 @@ zbus = { version = "5.14.0", features = ["async-executor", "async-fs", "async-io
 [dev-dependencies]
 buck-resources = "1"
 criterion = { version = "0.5.1", features = ["async_tokio", "csv_output"] }
+hex = "0.4.3"
 inventory = "0.3.24"
 jsonschema = "0.17.0"
 maplit = "1.0"
 proptest = "1.11.0"
+sha2 = "0.10.9"
 timed_test = { version = "0.0.0", path = "../timed_test" }
 
 [lints]

--- a/hyperactor_mesh/src/config.rs
+++ b/hyperactor_mesh/src/config.rs
@@ -203,6 +203,16 @@ declare_attrs! {
     ))
     pub attr MESH_ADMIN_CONFIG_DUMP_BRIDGE_TIMEOUT: Duration = Duration::from_secs(5);
 
+    /// Timeout for host-local diagnostic tool inventory/provisioning
+    /// bridge requests. This is intentionally independent from
+    /// config-dump because provisioning may perform provider I/O,
+    /// artifact verification, archive extraction, and cache locking.
+    @meta(CONFIG = ConfigAttr::new(
+        Some("HYPERACTOR_MESH_ADMIN_TOOL_PROVISION_BRIDGE_TIMEOUT".to_string()),
+        Some("mesh_admin_tool_provision_bridge_timeout".to_string()),
+    ))
+    pub attr MESH_ADMIN_TOOL_PROVISION_BRIDGE_TIMEOUT: Duration = Duration::from_secs(60);
+
     /// Timeout for py-spy dump requests. See PS-5 in `introspect`
     /// module doc. With `--native --native-all`, py-spy unwinds native
     /// stacks via libunwind which is significantly slower than

--- a/hyperactor_mesh/src/config.rs
+++ b/hyperactor_mesh/src/config.rs
@@ -213,6 +213,14 @@ declare_attrs! {
     ))
     pub attr MESH_ADMIN_TOOL_PROVISION_BRIDGE_TIMEOUT: Duration = Duration::from_secs(60);
 
+    /// Timeout for resolving an already-provisioned diagnostic tool
+    /// before running an operator workflow such as py-spy.
+    @meta(CONFIG = ConfigAttr::new(
+        Some("HYPERACTOR_MESH_ADMIN_TOOL_RESOLVE_TIMEOUT".to_string()),
+        Some("mesh_admin_tool_resolve_timeout".to_string()),
+    ))
+    pub attr MESH_ADMIN_TOOL_RESOLVE_TIMEOUT: Duration = Duration::from_secs(1);
+
     /// Timeout for py-spy dump requests. See PS-5 in `introspect`
     /// module doc. With `--native --native-all`, py-spy unwinds native
     /// stacks via libunwind which is significantly slower than

--- a/hyperactor_mesh/src/host_mesh/host_agent.rs
+++ b/hyperactor_mesh/src/host_mesh/host_agent.rs
@@ -58,6 +58,7 @@ use crate::pyspy::PySpyDump;
 use crate::pyspy::PySpyProfile;
 use crate::pyspy::PySpyProfileWorker;
 use crate::pyspy::PySpyWorker;
+use crate::pyspy::managed_pyspy_candidate;
 use crate::resource;
 use crate::resource::ProcSpec;
 use crate::tool_provision::ProvisionResult;
@@ -361,6 +362,44 @@ impl HostAgent {
         match &mut self.state {
             HostAgentState::Detached(h) | HostAgentState::Attached(h) => Some(h),
             _ => None,
+        }
+    }
+
+    async fn managed_pyspy_candidates(&self, cx: &Context<'_, Self>) -> Vec<(String, String)> {
+        let Some(tool_provision) = &self.tool_provision else {
+            return Vec::new();
+        };
+
+        let (reply_handle, reply_rx) = hyperactor::mailbox::open_once_port::<ResolveResult>(cx);
+        let mut reply = reply_handle.bind();
+        reply.return_undeliverable(false);
+        if let Err(err) = tool_provision.send(
+            cx,
+            ResolveTool {
+                tool: "py-spy".to_string(),
+                version: None,
+                reply,
+            },
+        ) {
+            tracing::debug!("HostAgent: managed py-spy resolve send failed: {err}");
+            return Vec::new();
+        }
+
+        match tokio::time::timeout(
+            hyperactor_config::global::get(crate::config::MESH_ADMIN_TOOL_RESOLVE_TIMEOUT),
+            reply_rx.recv(),
+        )
+        .await
+        {
+            Ok(Ok(result)) => managed_pyspy_candidate(result).into_iter().collect(),
+            Ok(Err(err)) => {
+                tracing::debug!("HostAgent: managed py-spy resolve receive failed: {err}");
+                Vec::new()
+            }
+            Err(_) => {
+                tracing::debug!("HostAgent: managed py-spy resolve timed out");
+                Vec::new()
+            }
         }
     }
 
@@ -1351,7 +1390,8 @@ impl Handler<PySpyDump> for HostAgent {
         cx: &Context<Self>,
         message: PySpyDump,
     ) -> Result<(), anyhow::Error> {
-        PySpyWorker::spawn_and_forward(cx, message.opts, message.result)
+        let managed_candidates = self.managed_pyspy_candidates(cx).await;
+        PySpyWorker::spawn_and_forward(cx, message.opts, managed_candidates, message.result)
     }
 }
 
@@ -1362,7 +1402,13 @@ impl Handler<PySpyProfile> for HostAgent {
         cx: &Context<Self>,
         message: PySpyProfile,
     ) -> Result<(), anyhow::Error> {
-        PySpyProfileWorker::spawn_and_forward(cx, message.request, message.result)
+        let managed_candidates = self.managed_pyspy_candidates(cx).await;
+        PySpyProfileWorker::spawn_and_forward(
+            cx,
+            message.request,
+            managed_candidates,
+            message.result,
+        )
     }
 }
 

--- a/hyperactor_mesh/src/host_mesh/host_agent.rs
+++ b/hyperactor_mesh/src/host_mesh/host_agent.rs
@@ -60,6 +60,14 @@ use crate::pyspy::PySpyProfileWorker;
 use crate::pyspy::PySpyWorker;
 use crate::resource;
 use crate::resource::ProcSpec;
+use crate::tool_provision::ProvisionResult;
+use crate::tool_provision::ProvisionTool;
+use crate::tool_provision::QueryToolInventory;
+use crate::tool_provision::ResolveResult;
+use crate::tool_provision::ResolveTool;
+use crate::tool_provision::TOOL_PROVISION_ACTOR_NAME;
+use crate::tool_provision::ToolInventory;
+use crate::tool_provision::ToolProvisionActor;
 
 pub(crate) type ProcManagerSpawnFuture =
     Pin<Box<dyn Future<Output = anyhow::Result<ActorHandle<ProcAgent>>> + Send>>;
@@ -280,6 +288,9 @@ impl fmt::Debug for DrainWorker {
         PySpyDump,
         PySpyProfile,
         ConfigDump,
+        ProvisionTool,
+        ResolveTool,
+        QueryToolInventory,
     ]
 )]
 pub struct HostAgent {
@@ -304,6 +315,8 @@ pub struct HostAgent {
     /// Boots on first [`GetLocalProc`] (LP-1 — see
     /// `hyperactor::host::LOCAL_PROC_NAME`).
     local_mesh_agent: OnceLock<anyhow::Result<ActorHandle<ProcAgent>>>,
+    /// Host-local diagnostic tool provisioner.
+    tool_provision: Option<ActorHandle<ToolProvisionActor>>,
     /// Handle to the host's frontend mailbox server, set during `init` after
     /// `this.bind::<Self>()` ensures the actor port is registered before the
     /// mailbox starts routing messages. Sent back to the bootstrap loop via
@@ -322,6 +335,7 @@ impl HostAgent {
             watching: HashSet::new(),
             proc_status_port: None,
             local_mesh_agent: OnceLock::new(),
+            tool_provision: None,
             mailbox_handle: None,
         }
     }
@@ -508,6 +522,8 @@ impl Actor for HostAgent {
             }
         };
         this.set_system();
+        self.tool_provision =
+            Some(ToolProvisionActor::new().spawn_with_name(this, TOOL_PROVISION_ACTOR_NAME)?);
         self.publish_introspect_properties(this);
 
         // Register callback for QueryChild — resolves system procs
@@ -1362,6 +1378,86 @@ impl Handler<ConfigDump> for HostAgent {
         // the once-port.  That must not crash this actor.
         if let Err(e) = message.result.send(cx, ConfigDumpResult { entries }) {
             tracing::warn!("HostAgent: ConfigDump reply undeliverable (caller timed out): {e}",);
+        }
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl Handler<ProvisionTool> for HostAgent {
+    async fn handle(
+        &mut self,
+        cx: &Context<Self>,
+        message: ProvisionTool,
+    ) -> Result<(), anyhow::Error> {
+        if let Some(tool_provision) = &self.tool_provision {
+            let fallback = ProvisionResult::Failed {
+                name: message.spec.name.clone(),
+                version: message.spec.version.clone(),
+                error: "tool provision actor unavailable".to_string(),
+            };
+            let reply = message.reply.clone();
+            if let Err(err) = tool_provision.send(cx, message) {
+                tracing::warn!("HostAgent: ProvisionTool forward failed: {err}");
+                let _ = reply.send(cx, fallback);
+            }
+        } else {
+            let reply = ProvisionResult::Failed {
+                name: message.spec.name,
+                version: message.spec.version,
+                error: "tool provision actor not initialized".to_string(),
+            };
+            let _ = message.reply.send(cx, reply);
+        }
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl Handler<ResolveTool> for HostAgent {
+    async fn handle(
+        &mut self,
+        cx: &Context<Self>,
+        message: ResolveTool,
+    ) -> Result<(), anyhow::Error> {
+        if let Some(tool_provision) = &self.tool_provision {
+            let fallback = ResolveResult::Failed {
+                name: message.tool.clone(),
+                version: message.version.clone().unwrap_or_default(),
+                error: "tool provision actor unavailable".to_string(),
+            };
+            let reply = message.reply.clone();
+            if let Err(err) = tool_provision.send(cx, message) {
+                tracing::warn!("HostAgent: ResolveTool forward failed: {err}");
+                let _ = reply.send(cx, fallback);
+            }
+        } else {
+            let reply = ResolveResult::Failed {
+                name: message.tool,
+                version: message.version.unwrap_or_default(),
+                error: "tool provision actor not initialized".to_string(),
+            };
+            let _ = message.reply.send(cx, reply);
+        }
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl Handler<QueryToolInventory> for HostAgent {
+    async fn handle(
+        &mut self,
+        cx: &Context<Self>,
+        message: QueryToolInventory,
+    ) -> Result<(), anyhow::Error> {
+        if let Some(tool_provision) = &self.tool_provision {
+            let reply = message.reply.clone();
+            if let Err(err) = tool_provision.send(cx, message) {
+                tracing::warn!("HostAgent: QueryToolInventory forward failed: {err}");
+                let _ = reply.send(cx, ToolInventory { tools: Vec::new() });
+            }
+        } else {
+            let _ = message.reply.send(cx, ToolInventory { tools: Vec::new() });
         }
         Ok(())
     }

--- a/hyperactor_mesh/src/introspect.rs
+++ b/hyperactor_mesh/src/introspect.rs
@@ -139,12 +139,13 @@
 //! - **PS-2 (deterministic failure shape):** Execution failures are
 //!   classified into `BinaryNotFound { searched }` vs
 //!   `Failed { pid, binary, exit_code, stderr }`, never collapsed.
-//! - **PS-3 (binary resolution order):** Resolution order is exactly:
-//!   `PYSPY_BIN` config attr (if non-empty) then `"py-spy"` on PATH.
-//!   The attr is read via `hyperactor_config::global::get_cloned`;
-//!   env var `PYSPY_BIN` feeds in through the config layer.
-//!   If the first attempt is not found, the fallback attempt is
-//!   required.
+//! - **PS-3 (binary resolution order):** Resolution order is
+//!   managed `py-spy` candidate (when HostAgent can resolve one),
+//!   then `PYSPY_BIN` config attr (if non-empty), then `"py-spy"`
+//!   on PATH. The attr is read via
+//!   `hyperactor_config::global::get_cloned`; env var `PYSPY_BIN`
+//!   feeds in through the config layer. If one attempt is not found,
+//!   the fallback attempt is required.
 //! - **PS-4 (structured JSON output):** py-spy runs with `--json`;
 //!   output is parsed into `Vec<PySpyStackTrace>`. Parse failure
 //!   maps to `PySpyResult::Failed`.
@@ -211,7 +212,11 @@
 //!   infrastructure failure). Cases (b) and (c) fast-fail
 //!   instead of waiting the full 13s
 //!   `MESH_ADMIN_PYSPY_BRIDGE_TIMEOUT`.
-//! - **PS-14 (reachability-based capability):** A proc supports
+//! - **PS-14 (managed-candidate-best-effort):** HostAgent resolves
+//!   managed `py-spy` through `ToolProvisionActor` before spawning
+//!   `PySpyWorker`. Failure, timeout, or `NotProvisioned` produces
+//!   no managed candidate and falls back to PS-3 legacy candidates.
+//! - **PS-15 (reachability-based capability):** A proc supports
 //!   py-spy iff its stable handler actor is reachable: the
 //!   service proc requires a reachable `host_agent`; non-service
 //!   procs require a reachable `proc_agent[0]`. `PySpyWorker` is

--- a/hyperactor_mesh/src/lib.rs
+++ b/hyperactor_mesh/src/lib.rs
@@ -53,6 +53,7 @@ pub mod test_utils;
 pub mod testactor;
 pub mod testing;
 mod testresource;
+pub mod tool_provision;
 pub mod transport;
 pub mod value_mesh;
 

--- a/hyperactor_mesh/src/mesh_admin.rs
+++ b/hyperactor_mesh/src/mesh_admin.rs
@@ -3308,12 +3308,22 @@ mod advertised_host {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
     use std::net::SocketAddr;
+    use std::sync::Arc;
+    use std::sync::atomic::AtomicUsize;
+    use std::sync::atomic::Ordering;
 
+    use hyperactor::actor::ActorStatus;
     use hyperactor::channel::ChannelAddr;
     use hyperactor::testing::ids::test_proc_id_with_addr;
+    use sha2::Digest;
+    use sha2::Sha256;
+    use tokio::io::AsyncReadExt;
+    use tokio::io::AsyncWriteExt;
 
     use super::*;
+    use crate::tool_provision::ToolInventoryState;
 
     // Integration tests that spawn MeshAdminAgent must pass
     // `Some("[::]:0".parse().unwrap())` as the admin_addr to get an
@@ -3329,6 +3339,57 @@ mod tests {
     #[hyperactor::export(handlers = [])]
     struct TestIntrospectableActor;
     impl Actor for TestIntrospectableActor {}
+
+    async fn serve_bytes(bytes: Vec<u8>) -> (String, Arc<AtomicUsize>) {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let requests = Arc::new(AtomicUsize::new(0));
+        let request_count = requests.clone();
+
+        tokio::spawn(async move {
+            loop {
+                let Ok((mut socket, _)) = listener.accept().await else {
+                    break;
+                };
+                request_count.fetch_add(1, Ordering::SeqCst);
+                let bytes = bytes.clone();
+                tokio::spawn(async move {
+                    let mut buffer = [0_u8; 1024];
+                    let _ = socket.read(&mut buffer).await;
+                    let headers = format!(
+                        "HTTP/1.1 200 OK\r\ncontent-length: {}\r\nconnection: close\r\n\r\n",
+                        bytes.len()
+                    );
+                    socket.write_all(headers.as_bytes()).await.unwrap();
+                    socket.write_all(&bytes).await.unwrap();
+                });
+            }
+        });
+
+        (format!("http://{addr}/artifact"), requests)
+    }
+
+    fn digest(bytes: &[u8]) -> String {
+        hex::encode(Sha256::digest(bytes))
+    }
+
+    fn plain_tool_spec(name: &str, version: &str, bytes: &[u8], url: String) -> ToolSpec {
+        ToolSpec {
+            name: name.to_string(),
+            version: version.to_string(),
+            platforms: HashMap::from([(
+                tool_fetch::current_platform().expect("test platform supported by tool_fetch"),
+                tool_fetch::PlatformEntry {
+                    size: bytes.len() as u64,
+                    hash_algorithm: tool_fetch::HashAlgorithm::Sha256,
+                    digest: digest(bytes),
+                    format: tool_fetch::ArtifactFormat::Plain,
+                    executable_path: None,
+                    providers: vec![tool_fetch::Provider::Http { url }],
+                },
+            )]),
+        }
+    }
 
     // Verifies that MeshAdminAgent::build_root_payload constructs the
     // expected root node: identity/root metadata, correct Root
@@ -4282,6 +4343,172 @@ mod tests {
         assert!(
             !admin_url.is_empty(),
             "spawn_admin ref must yield a non-empty URL"
+        );
+    }
+
+    async fn local_host_tool_handler(
+        test_name: &str,
+    ) -> (
+        ResolvedProcHandler,
+        hyperactor::Instance<()>,
+        hyperactor::ActorHandle<()>,
+    ) {
+        use hyperactor::Proc;
+        use hyperactor::channel::ChannelTransport;
+        use hyperactor::host::Host;
+        use hyperactor::host::LocalProcManager;
+
+        use crate::host_mesh::host_agent::HOST_MESH_AGENT_ACTOR_NAME;
+        use crate::host_mesh::host_agent::HostAgentMode;
+        use crate::host_mesh::host_agent::ProcManagerSpawnFn;
+        use crate::proc_agent::ProcAgent;
+
+        let spawn: ProcManagerSpawnFn =
+            Box::new(|proc| Box::pin(std::future::ready(ProcAgent::boot_v1(proc, None))));
+        let manager: LocalProcManager<ProcManagerSpawnFn> = LocalProcManager::new(spawn);
+        let host: Host<LocalProcManager<ProcManagerSpawnFn>> =
+            Host::new(manager, ChannelTransport::Unix.any())
+                .await
+                .unwrap();
+        let system_proc = host.system_proc().clone();
+        let service_proc_id = system_proc.proc_id().clone();
+        let host_agent = system_proc
+            .spawn(
+                HOST_MESH_AGENT_ACTOR_NAME,
+                HostAgent::new(HostAgentMode::Local(host)),
+            )
+            .unwrap();
+        host_agent
+            .status()
+            .wait_for(|s| matches!(s, ActorStatus::Idle))
+            .await
+            .unwrap();
+
+        let client_proc =
+            Proc::direct(ChannelTransport::Unix.any(), format!("{test_name}_client")).unwrap();
+        let (client, client_handle) = client_proc.instance("client").unwrap();
+        let handler = route_proc_handler(&service_proc_id.to_string()).unwrap();
+        (handler, client, client_handle)
+    }
+
+    #[tokio::test]
+    async fn managed_pyspy_dump_uses_provisioned_executable() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let log_path = temp.path().join("managed-pyspy.log");
+        let script = format!(
+            r#"#!/bin/sh
+echo "$@" >> "{}"
+echo '[]'
+exit 0
+"#,
+            log_path.display()
+        )
+        .into_bytes();
+        let (url, requests) = serve_bytes(script.clone()).await;
+        let spec = plain_tool_spec("py-spy", "mesh-admin-fake", &script, url);
+        let (handler, client, _client_handle) =
+            local_host_tool_handler("managed_pyspy_dump").await;
+
+        let provision = handler
+            .provision_tool(&client, spec, std::time::Duration::from_secs(10))
+            .await
+            .unwrap();
+        let executable = match provision {
+            ProvisionResult::Available { executable, .. } => executable,
+            other => panic!("expected py-spy provisioned, got {other:?}"),
+        };
+
+        let result = handler
+            .pyspy_dump(
+                &client,
+                PySpyOpts {
+                    threads: false,
+                    native: false,
+                    native_all: false,
+                    nonblocking: false,
+                },
+                std::time::Duration::from_secs(10),
+            )
+            .await
+            .unwrap();
+
+        match result {
+            PySpyResult::Ok {
+                binary,
+                stack_traces,
+                ..
+            } => {
+                assert_eq!(binary, executable.display().to_string());
+                assert!(stack_traces.is_empty());
+            }
+            other => panic!("expected managed fake py-spy success, got {other:?}"),
+        }
+        let log = std::fs::read_to_string(&log_path).expect("fake py-spy must run");
+        assert!(
+            log.contains("dump") && log.contains("--json"),
+            "managed py-spy invocation log: {log:?}"
+        );
+        assert_eq!(
+            requests.load(Ordering::SeqCst),
+            1,
+            "artifact should be fetched once by provisioning"
+        );
+    }
+
+    #[tokio::test]
+    #[ignore = "downloads the real py-spy wheel and executes the managed binary"]
+    async fn provision_real_pyspy_through_mesh_admin_and_run_version() {
+        let spec: ToolSpec =
+            serde_json::from_str(include_str!("../../tool_fetch/specs/py-spy.json"))
+                .expect("valid py-spy spec");
+        let (handler, client, _client_handle) = local_host_tool_handler("real_pyspy").await;
+
+        let provision = handler
+            .provision_tool(&client, spec, std::time::Duration::from_secs(60))
+            .await
+            .unwrap();
+        let executable = match provision {
+            ProvisionResult::Available {
+                name,
+                version,
+                executable,
+                ..
+            } => {
+                assert_eq!(name, "py-spy");
+                assert_eq!(version, "0.4.1");
+                executable
+            }
+            other => panic!("expected real py-spy provisioned, got {other:?}"),
+        };
+
+        let inventory = handler
+            .tool_inventory(&client, std::time::Duration::from_secs(5))
+            .await
+            .unwrap();
+        assert!(inventory.tools.iter().any(|entry| {
+            entry.name == "py-spy"
+                && entry.version == "0.4.1"
+                && matches!(entry.state, ToolInventoryState::Available { .. })
+        }));
+
+        let output = tokio::process::Command::new(&executable)
+            .arg("--version")
+            .output()
+            .await
+            .expect("managed py-spy should execute");
+        assert!(
+            output.status.success(),
+            "py-spy --version failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let combined = format!(
+            "{}{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert!(
+            combined.contains("py-spy") && combined.contains("0.4.1"),
+            "unexpected py-spy version output: {combined:?}"
         );
     }
 

--- a/hyperactor_mesh/src/mesh_admin.rs
+++ b/hyperactor_mesh/src/mesh_admin.rs
@@ -386,6 +386,11 @@ use crate::pyspy::PySpyProfileOpts;
 use crate::pyspy::PySpyProfileResult;
 use crate::pyspy::PySpyResult;
 use crate::pyspy::ValidatedProfileRequest;
+use crate::tool_provision::ProvisionResult;
+use crate::tool_provision::ProvisionTool;
+use crate::tool_provision::QueryToolInventory;
+use crate::tool_provision::ToolInventory;
+use tool_fetch::ToolSpec;
 
 /// Send an `IntrospectMessage` to an actor and receive the reply.
 /// Encapsulates open_once_port + send + timeout + error handling.
@@ -1539,6 +1544,8 @@ impl MeshAdminAgent {
 /// - `POST /v1/pyspy_dump/{*proc_reference}` — py-spy dump + store in Datafusion.
 /// - `POST /v1/pyspy_profile_svg/{*proc_reference}` — py-spy profile → SVG flamegraph.
 /// - `GET /v1/config/{*proc_reference}` — config snapshot for a proc.
+/// - `GET /v1/tools/{*host_reference}` — host-local diagnostic tool inventory.
+/// - `POST /v1/tools_provision/{*host_reference}` — provision one host-local diagnostic tool.
 /// - `GET /v1/admin` — admin self-identification (`AdminInfo`).
 /// - `GET /v1/{*reference}` — JSON `NodePayload` for a single reference.
 /// - `GET /SKILL.md` — agent-facing API documentation (markdown).
@@ -1563,6 +1570,11 @@ fn create_mesh_admin_router(bridge_state: Arc<BridgeState>) -> Router {
             post(pyspy_profile_svg),
         )
         .route("/v1/config/{*proc_reference}", get(config_bridge))
+        .route("/v1/tools/{*host_reference}", get(tools_inventory_bridge))
+        .route(
+            "/v1/tools_provision/{*host_reference}",
+            post(tools_provision_bridge),
+        )
         .route("/v1/{*reference}", get(resolve_reference_bridge))
         .with_state(bridge_state)
 }
@@ -2250,6 +2262,77 @@ impl ResolvedProcHandler {
                 details: None,
             })
     }
+
+    async fn tool_inventory(
+        &self,
+        cx: &impl hyperactor::context::Actor,
+        timeout: std::time::Duration,
+    ) -> Result<ToolInventory, ApiError> {
+        let Self::Host(host) = self else {
+            return Err(ApiError::bad_request(
+                "tool inventory is only available on host/service proc references",
+                None,
+            ));
+        };
+
+        let (reply_handle, reply_rx) = open_once_port::<ToolInventory>(cx);
+        let mut reply_ref = reply_handle.bind();
+        reply_ref.return_undeliverable(false);
+        host.send(cx, QueryToolInventory { reply: reply_ref })
+            .map_err(|e| ApiError {
+                code: "internal_error".to_string(),
+                message: format!("failed to send QueryToolInventory: {}", e),
+                details: None,
+            })?;
+        tokio::time::timeout(timeout, reply_rx.recv())
+            .await
+            .map_err(|_| ApiError {
+                code: "gateway_timeout".to_string(),
+                message: "timed out waiting for tool inventory".to_string(),
+                details: None,
+            })?
+            .map_err(|e| ApiError {
+                code: "internal_error".to_string(),
+                message: format!("failed to receive ToolInventory: {}", e),
+                details: None,
+            })
+    }
+
+    async fn provision_tool(
+        &self,
+        cx: &impl hyperactor::context::Actor,
+        spec: ToolSpec,
+        timeout: std::time::Duration,
+    ) -> Result<ProvisionResult, ApiError> {
+        let Self::Host(host) = self else {
+            return Err(ApiError::bad_request(
+                "tool provisioning is only available on host/service proc references",
+                None,
+            ));
+        };
+
+        let (reply_handle, reply_rx) = open_once_port::<ProvisionResult>(cx);
+        let mut reply_ref = reply_handle.bind();
+        reply_ref.return_undeliverable(false);
+        host.send(cx, ProvisionTool { spec, reply: reply_ref })
+            .map_err(|e| ApiError {
+                code: "internal_error".to_string(),
+                message: format!("failed to send ProvisionTool: {}", e),
+                details: None,
+            })?;
+        tokio::time::timeout(timeout, reply_rx.recv())
+            .await
+            .map_err(|_| ApiError {
+                code: "gateway_timeout".to_string(),
+                message: "timed out waiting for tool provisioning".to_string(),
+                details: None,
+            })?
+            .map_err(|e| ApiError {
+                code: "internal_error".to_string(),
+                message: format!("failed to receive ProvisionResult: {}", e),
+                details: None,
+            })
+    }
 }
 
 /// Parse + route + attest. No probe. The single `ActorRef::attest`
@@ -2577,6 +2660,33 @@ async fn config_bridge(
     let timeout =
         hyperactor_config::global::get(crate::config::MESH_ADMIN_CONFIG_DUMP_BRIDGE_TIMEOUT);
     let result = handler.config_dump(&state.bridge_cx, timeout).await?;
+    Ok(Json(result))
+}
+
+/// HTTP bridge for host-local diagnostic tool inventory.
+async fn tools_inventory_bridge(
+    State(state): State<Arc<BridgeState>>,
+    AxumPath(host_reference): AxumPath<String>,
+) -> Result<Json<ToolInventory>, ApiError> {
+    let handler = route_proc_handler(&host_reference)?;
+    let timeout =
+        hyperactor_config::global::get(crate::config::MESH_ADMIN_TOOL_PROVISION_BRIDGE_TIMEOUT);
+    let result = handler.tool_inventory(&state.bridge_cx, timeout).await?;
+    Ok(Json(result))
+}
+
+/// HTTP bridge for provisioning one host-local diagnostic tool.
+async fn tools_provision_bridge(
+    State(state): State<Arc<BridgeState>>,
+    AxumPath(host_reference): AxumPath<String>,
+    Json(spec): Json<ToolSpec>,
+) -> Result<Json<ProvisionResult>, ApiError> {
+    let handler = route_proc_handler(&host_reference)?;
+    let timeout =
+        hyperactor_config::global::get(crate::config::MESH_ADMIN_TOOL_PROVISION_BRIDGE_TIMEOUT);
+    let result = handler
+        .provision_tool(&state.bridge_cx, spec, timeout)
+        .await?;
     Ok(Json(result))
 }
 

--- a/hyperactor_mesh/src/proc_agent.rs
+++ b/hyperactor_mesh/src/proc_agent.rs
@@ -731,7 +731,7 @@ impl Handler<PySpyDump> for ProcAgent {
         cx: &Context<Self>,
         message: PySpyDump,
     ) -> Result<(), anyhow::Error> {
-        PySpyWorker::spawn_and_forward(cx, message.opts, message.result)
+        PySpyWorker::spawn_and_forward(cx, message.opts, Vec::new(), message.result)
     }
 }
 
@@ -742,7 +742,7 @@ impl Handler<PySpyProfile> for ProcAgent {
         cx: &Context<Self>,
         message: PySpyProfile,
     ) -> Result<(), anyhow::Error> {
-        PySpyProfileWorker::spawn_and_forward(cx, message.request, message.result)
+        PySpyProfileWorker::spawn_and_forward(cx, message.request, Vec::new(), message.result)
     }
 }
 

--- a/hyperactor_mesh/src/pyspy.rs
+++ b/hyperactor_mesh/src/pyspy.rs
@@ -23,6 +23,7 @@ use typeuri::Named;
 
 use crate::config::MESH_ADMIN_PYSPY_TIMEOUT;
 use crate::config::PYSPY_BIN;
+use crate::tool_provision::ResolveResult;
 
 /// Result of a py-spy stack dump request.
 ///
@@ -476,13 +477,18 @@ impl PySpyRunner {
     /// field, and this method hardcodes `std::process::id()`. There
     /// is no code path that could substitute a different PID.
     pub async fn dump_self(&self, opts: &PySpyOpts) -> PySpyResult {
+        self.dump_self_with_candidates(opts, Vec::new()).await
+    }
+
+    /// Dump Python stacks using managed candidates before legacy
+    /// environment/PATH resolution. See PS-3 and PS-14.
+    pub(crate) async fn dump_self_with_candidates(
+        &self,
+        opts: &PySpyOpts,
+        managed_candidates: Vec<(String, String)>,
+    ) -> PySpyResult {
         let pid = std::process::id();
-        let pyspy_bin: String = hyperactor_config::global::get_cloned(PYSPY_BIN);
-        let candidates = resolve_candidates(if pyspy_bin.is_empty() {
-            None
-        } else {
-            Some(pyspy_bin)
-        });
+        let candidates = resolve_candidates_with_managed(managed_candidates);
         let mut searched = vec![];
 
         for (binary, label) in &candidates {
@@ -502,19 +508,15 @@ impl PySpyRunner {
         PySpyResult::BinaryNotFound { searched }
     }
 
-    /// Profile Python stacks for this process over a duration.
-    /// See PP-3, PP-4.
-    pub(crate) async fn profile_self(
+    /// Profile Python stacks using managed candidates before legacy
+    /// environment/PATH resolution. See PP-4 and PS-14.
+    pub(crate) async fn profile_self_with_candidates(
         &self,
         request: &ValidatedProfileRequest,
+        managed_candidates: Vec<(String, String)>,
     ) -> ProfileExecOutcome {
         let pid = std::process::id();
-        let pyspy_bin: String = hyperactor_config::global::get_cloned(PYSPY_BIN);
-        let candidates = resolve_candidates(if pyspy_bin.is_empty() {
-            None
-        } else {
-            Some(pyspy_bin)
-        });
+        let candidates = resolve_candidates_with_managed(managed_candidates);
         let mut searched = vec![];
 
         for (binary, label) in &candidates {
@@ -534,6 +536,9 @@ impl PySpyRunner {
 #[derive(Debug, Serialize, Deserialize, Named)]
 pub struct RunPySpyDump {
     pub opts: PySpyOpts,
+    /// Managed tool candidates resolved by the parent actor before
+    /// the worker is spawned. Tried before PYSPY_BIN/PATH fallback.
+    pub managed_candidates: Vec<(String, String)>,
     /// The original caller's reply port, forwarded from PySpyDump.
     pub reply_port: hyperactor::reference::OncePortRef<PySpyResult>,
 }
@@ -555,6 +560,7 @@ impl PySpyWorker {
     pub(crate) fn spawn_and_forward(
         cx: &impl hyperactor::context::Actor,
         opts: PySpyOpts,
+        managed_candidates: Vec<(String, String)>,
         reply_port: hyperactor::reference::OncePortRef<PySpyResult>,
     ) -> Result<(), anyhow::Error> {
         let worker = match Self.spawn(cx) {
@@ -574,7 +580,14 @@ impl PySpyWorker {
         // MailboxSenderError does not carry the unsent message, so
         // on send failure the caller will observe a timeout rather
         // than an explicit Failed reply.
-        if let Err(e) = worker.send(cx, RunPySpyDump { opts, reply_port }) {
+        if let Err(e) = worker.send(
+            cx,
+            RunPySpyDump {
+                opts,
+                managed_candidates,
+                reply_port,
+            },
+        ) {
             tracing::error!("failed to send to pyspy worker: {}", e);
         }
         Ok(())
@@ -588,7 +601,9 @@ impl Handler<RunPySpyDump> for PySpyWorker {
         cx: &Context<Self>,
         message: RunPySpyDump,
     ) -> Result<(), anyhow::Error> {
-        let result = PySpyRunner.dump_self(&message.opts).await;
+        let result = PySpyRunner
+            .dump_self_with_candidates(&message.opts, message.managed_candidates)
+            .await;
         message.reply_port.send(cx, result)?;
         cx.stop("pyspy dump complete")?;
         Ok(())
@@ -600,6 +615,7 @@ impl Handler<RunPySpyDump> for PySpyWorker {
 #[derive(Debug, Serialize, Deserialize, Named)]
 pub struct RunPySpyProfile {
     pub request: ValidatedProfileRequest,
+    pub managed_candidates: Vec<(String, String)>,
     pub reply_port: hyperactor::reference::OncePortRef<PySpyProfileResult>,
 }
 wirevalue::register_type!(RunPySpyProfile);
@@ -617,6 +633,7 @@ impl PySpyProfileWorker {
     pub(crate) fn spawn_and_forward(
         cx: &impl hyperactor::context::Actor,
         request: ValidatedProfileRequest,
+        managed_candidates: Vec<(String, String)>,
         reply_port: hyperactor::reference::OncePortRef<PySpyProfileResult>,
     ) -> Result<(), anyhow::Error> {
         let worker = match Self.spawn(cx) {
@@ -637,6 +654,7 @@ impl PySpyProfileWorker {
             cx,
             RunPySpyProfile {
                 request,
+                managed_candidates,
                 reply_port,
             },
         ) {
@@ -653,7 +671,9 @@ impl Handler<RunPySpyProfile> for PySpyProfileWorker {
         cx: &Context<Self>,
         message: RunPySpyProfile,
     ) -> Result<(), anyhow::Error> {
-        let outcome = PySpyRunner.profile_self(&message.request).await;
+        let outcome = PySpyRunner
+            .profile_self_with_candidates(&message.request, message.managed_candidates)
+            .await;
         message
             .reply_port
             .send(cx, PySpyProfileResult::from(outcome))?;
@@ -674,6 +694,37 @@ fn resolve_candidates(pyspy_bin_env: Option<String>) -> Vec<(String, String)> {
     }
     candidates.push(("py-spy".to_string(), "py-spy on PATH".to_string()));
     candidates
+}
+
+/// Build candidates with managed-tool paths before legacy fallback.
+/// PS-14: provisioned tools are preferred but do not remove PYSPY_BIN
+/// or PATH compatibility.
+pub(crate) fn resolve_candidates_with_managed(
+    managed_candidates: Vec<(String, String)>,
+) -> Vec<(String, String)> {
+    let pyspy_bin: String = hyperactor_config::global::get_cloned(PYSPY_BIN);
+    let mut candidates = managed_candidates;
+    candidates.extend(resolve_candidates(if pyspy_bin.is_empty() {
+        None
+    } else {
+        Some(pyspy_bin)
+    }));
+    candidates
+}
+
+/// Convert a tool-plane resolve result into a py-spy candidate.
+pub(crate) fn managed_pyspy_candidate(result: ResolveResult) -> Option<(String, String)> {
+    match result {
+        ResolveResult::Available {
+            version,
+            executable,
+            ..
+        } => Some((
+            executable.display().to_string(),
+            format!("managed py-spy@{version}: {}", executable.display()),
+        )),
+        ResolveResult::NotProvisioned { .. } | ResolveResult::Failed { .. } => None,
+    }
 }
 
 /// Build the py-spy command for a given binary path.
@@ -1140,6 +1191,18 @@ mod tests {
         let candidates = resolve_candidates(Some(String::new()));
         assert_eq!(candidates.len(), 1);
         assert_eq!(candidates[0].0, "py-spy");
+    }
+
+    #[test]
+    fn managed_candidate_precedes_legacy_fallbacks() {
+        // PS-14: managed py-spy is tried first, with PATH preserved as
+        // compatibility fallback.
+        let candidates = resolve_candidates_with_managed(vec![(
+            "/cache/py-spy".to_string(),
+            "managed py-spy@test".to_string(),
+        )]);
+        assert_eq!(candidates[0].0, "/cache/py-spy");
+        assert_eq!(candidates[1].0, "py-spy");
     }
 
     #[test]

--- a/hyperactor_mesh/src/tool_provision.rs
+++ b/hyperactor_mesh/src/tool_provision.rs
@@ -1,0 +1,638 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+//! Per-host diagnostic tool provisioning actor.
+//!
+//! `ToolProvisionActor` is the mesh-facing owner for host-local
+//! diagnostic tool state. It wraps the standalone `tool_fetch` crate in
+//! actor messages so mesh admin routes and future workflows can
+//! provision, resolve, and inspect tools without knowing cache layout.
+//!
+//! # Invariants
+//!
+//! - **TP-1 (host-local-state):** One actor owns tool state for one
+//!   host/service proc.
+//! - **TP-2 (desired-gates-resolve):** `ResolveTool` returns only the
+//!   currently desired registered version of a tool. Cache entries
+//!   discovered by scan but not registered are inventory only.
+//! - **TP-3 (provision-registers-desired):** Successful or failed
+//!   provision attempts record desired state for the requested tool.
+//! - **TP-4 (cache-scan-inventory):** Actor init scans the persistent
+//!   cache and exposes discovered artifacts as
+//!   `CachedButNotRegistered`.
+//! - **TP-5 (reply-best-effort):** Handlers send typed replies via
+//!   caller-provided once ports. If the caller timed out, the actor logs
+//!   and continues rather than failing.
+//! - **TP-6 (tool-fetch-boundary):** Fetch, verification, extraction,
+//!   and executable resolution are delegated to `tool_fetch`.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::time::SystemTime;
+
+use async_trait::async_trait;
+use hyperactor::Actor;
+use hyperactor::Context;
+use hyperactor::HandleClient;
+use hyperactor::Handler;
+use hyperactor::Instance;
+use hyperactor::RefClient;
+use hyperactor::context::Actor as ActorContext;
+use hyperactor_config::INTROSPECT;
+use hyperactor_config::IntrospectAttr;
+use hyperactor_config::declare_attrs;
+use serde::Deserialize;
+use serde::Serialize;
+use tool_fetch::ProvisionError;
+use tool_fetch::ToolCache;
+use tool_fetch::ToolSpec;
+use typeuri::Named;
+
+/// Actor name used when spawning the per-host tool provisioner.
+pub const TOOL_PROVISION_ACTOR_NAME: &str = "tool_provision";
+
+declare_attrs! {
+    /// Number of known tool entries in this host's inventory.
+    @meta(INTROSPECT = IntrospectAttr {
+        name: "tool_count".into(),
+        desc: "Number of known tool entries in host-local inventory".into(),
+    })
+    pub attr TOOL_COUNT: usize = 0;
+
+    /// Registered tools whose executable is available.
+    @meta(INTROSPECT = IntrospectAttr {
+        name: "tools_available".into(),
+        desc: "Registered tool versions available on this host".into(),
+    })
+    pub attr TOOLS_AVAILABLE: Vec<String>;
+
+    /// Registered tools whose last provision attempt failed.
+    @meta(INTROSPECT = IntrospectAttr {
+        name: "tools_failed".into(),
+        desc: "Registered tool versions with failed provisioning on this host".into(),
+    })
+    pub attr TOOLS_FAILED: Vec<String>;
+}
+
+/// Request to provision a tool on the host.
+#[derive(Debug, Serialize, Deserialize, Named, Handler, HandleClient, RefClient)]
+pub struct ProvisionTool {
+    /// Declarative tool spec to provision.
+    pub spec: ToolSpec,
+    /// Reply port receiving the provisioning result.
+    #[reply]
+    pub reply: hyperactor::reference::OncePortRef<ProvisionResult>,
+}
+wirevalue::register_type!(ProvisionTool);
+
+/// Request to resolve a tool name/version to an executable path.
+#[derive(Debug, Serialize, Deserialize, Named, Handler, HandleClient, RefClient)]
+pub struct ResolveTool {
+    /// Tool name, e.g. `py-spy`.
+    pub tool: String,
+    /// Optional version. `None` means the actor's currently desired
+    /// registered version.
+    pub version: Option<String>,
+    /// Reply port receiving the resolve result.
+    #[reply]
+    pub reply: hyperactor::reference::OncePortRef<ResolveResult>,
+}
+wirevalue::register_type!(ResolveTool);
+
+/// Request the full per-host tool inventory.
+#[derive(Debug, Serialize, Deserialize, Named, Handler, HandleClient, RefClient)]
+pub struct QueryToolInventory {
+    /// Reply port receiving the inventory snapshot.
+    #[reply]
+    pub reply: hyperactor::reference::OncePortRef<ToolInventory>,
+}
+wirevalue::register_type!(QueryToolInventory);
+
+/// Result of a `ProvisionTool` request.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Named, schemars::JsonSchema)]
+pub enum ProvisionResult {
+    /// The tool is available at the returned executable path.
+    Available {
+        /// Tool name.
+        name: String,
+        /// Tool version.
+        version: String,
+        /// Resolved executable path.
+        executable: PathBuf,
+        /// Downloaded artifact digest.
+        artifact_digest: String,
+    },
+    /// Provisioning failed.
+    Failed {
+        /// Tool name.
+        name: String,
+        /// Tool version.
+        version: String,
+        /// Structured error string.
+        error: String,
+    },
+}
+wirevalue::register_type!(ProvisionResult);
+
+/// Result of a `ResolveTool` request.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Named, schemars::JsonSchema)]
+pub enum ResolveResult {
+    /// Tool resolved successfully.
+    Available {
+        /// Tool name.
+        name: String,
+        /// Tool version.
+        version: String,
+        /// Resolved executable path.
+        executable: PathBuf,
+    },
+    /// Tool exists in cache but is not registered as desired.
+    NotProvisioned {
+        /// Tool name requested by the caller.
+        tool: String,
+        /// Optional version requested by the caller.
+        version: Option<String>,
+    },
+    /// Tool provisioning failed for the desired version.
+    Failed {
+        /// Tool name.
+        name: String,
+        /// Tool version.
+        version: String,
+        /// Last observed error.
+        error: String,
+    },
+}
+wirevalue::register_type!(ResolveResult);
+
+/// Inventory snapshot for a host.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Named, schemars::JsonSchema)]
+pub struct ToolInventory {
+    /// Tool states known to this host.
+    pub tools: Vec<ToolInventoryEntry>,
+}
+wirevalue::register_type!(ToolInventory);
+
+/// One tool entry in host inventory.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct ToolInventoryEntry {
+    /// Tool name.
+    pub name: String,
+    /// Tool version.
+    pub version: String,
+    /// Human-readable state.
+    pub state: ToolInventoryState,
+}
+
+/// Serializable inventory state.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, schemars::JsonSchema)]
+pub enum ToolInventoryState {
+    /// Tool is registered and available.
+    Available {
+        /// Executable path.
+        executable: PathBuf,
+        /// Downloaded artifact digest.
+        artifact_digest: String,
+    },
+    /// Provisioning is in progress.
+    Fetching,
+    /// Last provision attempt failed.
+    Failed {
+        /// Error string.
+        error: String,
+    },
+    /// Artifact exists in cache but no desired spec registered it.
+    CachedButNotRegistered {
+        /// Executable path.
+        executable: PathBuf,
+        /// Downloaded artifact digest.
+        artifact_digest: String,
+    },
+}
+
+#[derive(Debug, Clone)]
+struct DesiredTool {
+    version: String,
+    _spec: ToolSpec,
+}
+
+#[derive(Debug, Clone)]
+enum ObservedToolState {
+    Fetching { _started_at: SystemTime },
+    Available {
+        executable: PathBuf,
+        artifact_digest: String,
+        _provisioned_at: String,
+    },
+    Failed {
+        error: String,
+        _last_attempt: SystemTime,
+    },
+    CachedButNotRegistered {
+        executable: PathBuf,
+        artifact_digest: String,
+        _provisioned_at: String,
+    },
+}
+
+/// Per-host actor that provisions and resolves diagnostic tools.
+#[hyperactor::export(handlers = [ProvisionTool, ResolveTool, QueryToolInventory])]
+pub struct ToolProvisionActor {
+    cache: ToolCache,
+    desired: HashMap<String, DesiredTool>,
+    observed: HashMap<String, ObservedToolState>,
+}
+
+impl ToolProvisionActor {
+    /// Construct an actor using the default cache directory.
+    pub fn new() -> Self {
+        Self::with_cache(ToolCache::default())
+    }
+
+    /// Construct an actor with an explicit cache.
+    pub fn with_cache(cache: ToolCache) -> Self {
+        Self {
+            cache,
+            desired: HashMap::new(),
+            observed: HashMap::new(),
+        }
+    }
+
+    fn inventory(&self) -> ToolInventory {
+        let mut tools: Vec<_> = self
+            .observed
+            .iter()
+            .map(|(key, state)| {
+                let (name, version) = split_key(key);
+                ToolInventoryEntry {
+                    name,
+                    version,
+                    state: state.to_inventory_state(),
+                }
+            })
+            .collect();
+        tools.sort_by(|a, b| a.name.cmp(&b.name).then(a.version.cmp(&b.version)));
+        ToolInventory { tools }
+    }
+
+    fn resolve(&self, tool: &str, requested_version: Option<&str>) -> ResolveResult {
+        let version = match requested_version {
+            Some(version) => Some(version.to_string()),
+            None => self.desired.get(tool).map(|desired| desired.version.clone()),
+        };
+
+        if let Some(version) = version {
+            let key = tool_key(tool, &version);
+            match self.observed.get(&key) {
+                Some(ObservedToolState::Available { executable, .. }) => ResolveResult::Available {
+                    name: tool.to_string(),
+                    version,
+                    executable: executable.clone(),
+                },
+                Some(ObservedToolState::Failed { error, .. }) => ResolveResult::Failed {
+                    name: tool.to_string(),
+                    version,
+                    error: error.clone(),
+                },
+                _ => ResolveResult::NotProvisioned {
+                    tool: tool.to_string(),
+                    version: Some(version),
+                },
+            }
+        } else {
+            ResolveResult::NotProvisioned {
+                tool: tool.to_string(),
+                version: requested_version.map(ToString::to_string),
+            }
+        }
+    }
+
+    fn publish_attrs(&self, cx: &Instance<Self>) {
+        let inventory = self.inventory();
+        let mut attrs = hyperactor_config::Attrs::new();
+        attrs.set(crate::introspect::NODE_TYPE, "tool_provision".to_string());
+        attrs.set(TOOL_COUNT, inventory.tools.len());
+        attrs.set(
+            TOOLS_AVAILABLE,
+            inventory
+                .tools
+                .iter()
+                .filter_map(|tool| match tool.state {
+                    ToolInventoryState::Available { .. } => {
+                        Some(format!("{}@{}", tool.name, tool.version))
+                    }
+                    _ => None,
+                })
+                .collect::<Vec<_>>(),
+        );
+        attrs.set(
+            TOOLS_FAILED,
+            inventory
+                .tools
+                .iter()
+                .filter_map(|tool| match tool.state {
+                    ToolInventoryState::Failed { .. } => {
+                        Some(format!("{}@{}", tool.name, tool.version))
+                    }
+                    _ => None,
+                })
+                .collect::<Vec<_>>(),
+        );
+        cx.publish_attrs(attrs);
+    }
+}
+
+impl Default for ToolProvisionActor {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl Actor for ToolProvisionActor {
+    async fn init(&mut self, this: &Instance<Self>) -> Result<(), anyhow::Error> {
+        this.bind::<Self>();
+        this.set_system();
+
+        for artifact in self.cache.scan() {
+            let key = tool_key(&artifact.name, &artifact.version);
+            self.observed.insert(
+                key,
+                ObservedToolState::CachedButNotRegistered {
+                    executable: artifact.executable,
+                    artifact_digest: artifact.digest,
+                    _provisioned_at: artifact.provisioned_at,
+                },
+            );
+        }
+        self.publish_attrs(this);
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl Handler<ProvisionTool> for ToolProvisionActor {
+    async fn handle(
+        &mut self,
+        cx: &Context<Self>,
+        message: ProvisionTool,
+    ) -> Result<(), anyhow::Error> {
+        let spec = message.spec;
+        let key = tool_key(&spec.name, &spec.version);
+        self.desired.insert(
+            spec.name.clone(),
+            DesiredTool {
+                version: spec.version.clone(),
+                _spec: spec.clone(),
+            },
+        );
+        self.observed.insert(
+            key.clone(),
+            ObservedToolState::Fetching {
+                _started_at: SystemTime::now(),
+            },
+        );
+        self.publish_attrs(cx.instance());
+
+        let platform = tool_fetch::current_platform();
+        let result = match platform {
+            Ok(platform) => {
+                let digest = spec
+                    .platforms
+                    .get(&platform)
+                    .map(|entry| entry.digest.clone())
+                    .unwrap_or_default();
+                (digest, self.cache.provision(&spec, platform).await)
+            }
+            Err(err) => (String::new(), Err(err)),
+        };
+
+        let reply = match result.1 {
+            Ok(executable) => {
+                let digest = result.0;
+                self.observed.insert(
+                    key,
+                    ObservedToolState::Available {
+                        executable: executable.clone(),
+                        artifact_digest: digest.clone(),
+                        _provisioned_at: timestamp_now(),
+                    },
+                );
+                ProvisionResult::Available {
+                    name: spec.name,
+                    version: spec.version,
+                    executable,
+                    artifact_digest: digest,
+                }
+            }
+            Err(err) => {
+                let error = error_string(&err);
+                self.observed.insert(
+                    key,
+                    ObservedToolState::Failed {
+                        error: error.clone(),
+                        _last_attempt: SystemTime::now(),
+                    },
+                );
+                ProvisionResult::Failed {
+                    name: spec.name,
+                    version: spec.version,
+                    error,
+                }
+            }
+        };
+        self.publish_attrs(cx.instance());
+        if let Err(e) = message.reply.send(cx, reply) {
+            tracing::debug!("ProvisionTool reply failed (caller gone?): {e}");
+        }
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl Handler<ResolveTool> for ToolProvisionActor {
+    async fn handle(
+        &mut self,
+        cx: &Context<Self>,
+        message: ResolveTool,
+    ) -> Result<(), anyhow::Error> {
+        let reply = self.resolve(&message.tool, message.version.as_deref());
+
+        if let Err(e) = message.reply.send(cx, reply) {
+            tracing::debug!("ResolveTool reply failed (caller gone?): {e}");
+        }
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl Handler<QueryToolInventory> for ToolProvisionActor {
+    async fn handle(
+        &mut self,
+        cx: &Context<Self>,
+        message: QueryToolInventory,
+    ) -> Result<(), anyhow::Error> {
+        if let Err(e) = message.reply.send(cx, self.inventory()) {
+            tracing::debug!("QueryToolInventory reply failed (caller gone?): {e}");
+        }
+        Ok(())
+    }
+}
+
+impl ObservedToolState {
+    fn to_inventory_state(&self) -> ToolInventoryState {
+        match self {
+            Self::Fetching { .. } => ToolInventoryState::Fetching,
+            Self::Available {
+                executable,
+                artifact_digest,
+                ..
+            } => ToolInventoryState::Available {
+                executable: executable.clone(),
+                artifact_digest: artifact_digest.clone(),
+            },
+            Self::Failed { error, .. } => ToolInventoryState::Failed {
+                error: error.clone(),
+            },
+            Self::CachedButNotRegistered {
+                executable,
+                artifact_digest,
+                ..
+            } => ToolInventoryState::CachedButNotRegistered {
+                executable: executable.clone(),
+                artifact_digest: artifact_digest.clone(),
+            },
+        }
+    }
+}
+
+fn tool_key(name: &str, version: &str) -> String {
+    format!("{name}@{version}")
+}
+
+fn split_key(key: &str) -> (String, String) {
+    match key.split_once('@') {
+        Some((name, version)) => (name.to_string(), version.to_string()),
+        None => (key.to_string(), String::new()),
+    }
+}
+
+fn timestamp_now() -> String {
+    chrono::Utc::now().to_rfc3339()
+}
+
+fn error_string(err: &ProvisionError) -> String {
+    err.to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+    use std::path::PathBuf;
+
+    use tool_fetch::ToolSpec;
+
+    use super::*;
+
+    fn empty_spec(name: &str, version: &str) -> ToolSpec {
+        ToolSpec {
+            name: name.to_string(),
+            version: version.to_string(),
+            platforms: HashMap::new(),
+        }
+    }
+
+    #[test]
+    fn inventory_projects_observed_states_in_stable_order() {
+        let mut actor = ToolProvisionActor::new();
+        actor.observed.insert(
+            tool_key("z-tool", "2.0.0"),
+            ObservedToolState::Failed {
+                error: "boom".to_string(),
+                _last_attempt: SystemTime::UNIX_EPOCH,
+            },
+        );
+        actor.observed.insert(
+            tool_key("a-tool", "1.0.0"),
+            ObservedToolState::Available {
+                executable: PathBuf::from("/tmp/a-tool"),
+                artifact_digest: "abc".to_string(),
+                _provisioned_at: "now".to_string(),
+            },
+        );
+
+        // TP-4: inventory is a deterministic projection of observed
+        // cache/provision state.
+        let inventory = actor.inventory();
+
+        assert_eq!(inventory.tools.len(), 2);
+        assert_eq!(inventory.tools[0].name, "a-tool");
+        assert_eq!(inventory.tools[1].name, "z-tool");
+        assert_eq!(
+            inventory.tools[0].state,
+            ToolInventoryState::Available {
+                executable: PathBuf::from("/tmp/a-tool"),
+                artifact_digest: "abc".to_string(),
+            }
+        );
+        assert_eq!(
+            inventory.tools[1].state,
+            ToolInventoryState::Failed {
+                error: "boom".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn resolve_ignores_cache_only_entries_until_desired() {
+        let mut actor = ToolProvisionActor::new();
+        actor.observed.insert(
+            tool_key("py-spy", "0.4.1"),
+            ObservedToolState::CachedButNotRegistered {
+                executable: PathBuf::from("/tmp/py-spy"),
+                artifact_digest: "digest".to_string(),
+                _provisioned_at: "now".to_string(),
+            },
+        );
+
+        // TP-2: scan-discovered artifacts are inventory only until a
+        // provision request registers desired state.
+        assert_eq!(
+            actor.resolve("py-spy", Some("0.4.1")),
+            ResolveResult::NotProvisioned {
+                tool: "py-spy".to_string(),
+                version: Some("0.4.1".to_string()),
+            }
+        );
+
+        actor.desired.insert(
+            "py-spy".to_string(),
+            DesiredTool {
+                version: "0.4.1".to_string(),
+                _spec: empty_spec("py-spy", "0.4.1"),
+            },
+        );
+        actor.observed.insert(
+            tool_key("py-spy", "0.4.1"),
+            ObservedToolState::Available {
+                executable: PathBuf::from("/tmp/py-spy"),
+                artifact_digest: "digest".to_string(),
+                _provisioned_at: "now".to_string(),
+            },
+        );
+
+        assert_eq!(
+            actor.resolve("py-spy", None),
+            ResolveResult::Available {
+                name: "py-spy".to_string(),
+                version: "0.4.1".to_string(),
+                executable: PathBuf::from("/tmp/py-spy"),
+            }
+        );
+    }
+}

--- a/hyperactor_mesh/src/tool_provision.rs
+++ b/hyperactor_mesh/src/tool_provision.rs
@@ -30,6 +30,10 @@
 //!   and continues rather than failing.
 //! - **TP-6 (tool-fetch-boundary):** Fetch, verification, extraction,
 //!   and executable resolution are delegated to `tool_fetch`.
+//! - **TP-7 (flight-recorder-observability):** Every operator-visible
+//!   tool state transition emits a structured tracing event from inside
+//!   the actor handler, so the actor-local flight recorder explains
+//!   provisioning and resolution history in mesh-admin.
 
 use std::collections::HashMap;
 use std::path::PathBuf;
@@ -114,7 +118,15 @@ pub struct QueryToolInventory {
 wirevalue::register_type!(QueryToolInventory);
 
 /// Result of a `ProvisionTool` request.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Named, schemars::JsonSchema)]
+#[derive(
+    Debug,
+    Clone,
+    PartialEq,
+    Serialize,
+    Deserialize,
+    Named,
+    schemars::JsonSchema
+)]
 pub enum ProvisionResult {
     /// The tool is available at the returned executable path.
     Available {
@@ -140,7 +152,15 @@ pub enum ProvisionResult {
 wirevalue::register_type!(ProvisionResult);
 
 /// Result of a `ResolveTool` request.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Named, schemars::JsonSchema)]
+#[derive(
+    Debug,
+    Clone,
+    PartialEq,
+    Serialize,
+    Deserialize,
+    Named,
+    schemars::JsonSchema
+)]
 pub enum ResolveResult {
     /// Tool resolved successfully.
     Available {
@@ -171,7 +191,15 @@ pub enum ResolveResult {
 wirevalue::register_type!(ResolveResult);
 
 /// Inventory snapshot for a host.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Named, schemars::JsonSchema)]
+#[derive(
+    Debug,
+    Clone,
+    PartialEq,
+    Serialize,
+    Deserialize,
+    Named,
+    schemars::JsonSchema
+)]
 pub struct ToolInventory {
     /// Tool states known to this host.
     pub tools: Vec<ToolInventoryEntry>,
@@ -223,7 +251,9 @@ struct DesiredTool {
 
 #[derive(Debug, Clone)]
 enum ObservedToolState {
-    Fetching { _started_at: SystemTime },
+    Fetching {
+        _started_at: SystemTime,
+    },
     Available {
         executable: PathBuf,
         artifact_digest: String,
@@ -283,7 +313,10 @@ impl ToolProvisionActor {
     fn resolve(&self, tool: &str, requested_version: Option<&str>) -> ResolveResult {
         let version = match requested_version {
             Some(version) => Some(version.to_string()),
-            None => self.desired.get(tool).map(|desired| desired.version.clone()),
+            None => self
+                .desired
+                .get(tool)
+                .map(|desired| desired.version.clone()),
         };
 
         if let Some(version) = version {
@@ -359,8 +392,19 @@ impl Actor for ToolProvisionActor {
         this.bind::<Self>();
         this.set_system();
 
+        let mut scanned = 0usize;
         for artifact in self.cache.scan() {
+            scanned += 1;
             let key = tool_key(&artifact.name, &artifact.version);
+            tracing::info!(
+                name = "ToolProvisionStatus",
+                status = "CacheScan::Discovered",
+                tool = %artifact.name,
+                version = %artifact.version,
+                executable = %artifact.executable.display(),
+                artifact_digest = %artifact.digest,
+                provisioned_at = %artifact.provisioned_at,
+            );
             self.observed.insert(
                 key,
                 ObservedToolState::CachedButNotRegistered {
@@ -370,6 +414,11 @@ impl Actor for ToolProvisionActor {
                 },
             );
         }
+        tracing::info!(
+            name = "ToolProvisionStatus",
+            status = "CacheScan::Complete",
+            scanned,
+        );
         self.publish_attrs(this);
         Ok(())
     }
@@ -384,6 +433,12 @@ impl Handler<ProvisionTool> for ToolProvisionActor {
     ) -> Result<(), anyhow::Error> {
         let spec = message.spec;
         let key = tool_key(&spec.name, &spec.version);
+        tracing::info!(
+            name = "ToolProvisionStatus",
+            status = "Provision::Requested",
+            tool = %spec.name,
+            version = %spec.version,
+        );
         self.desired.insert(
             spec.name.clone(),
             DesiredTool {
@@ -407,14 +462,39 @@ impl Handler<ProvisionTool> for ToolProvisionActor {
                     .get(&platform)
                     .map(|entry| entry.digest.clone())
                     .unwrap_or_default();
+                tracing::info!(
+                    name = "ToolProvisionStatus",
+                    status = "Provision::FetchStart",
+                    tool = %spec.name,
+                    version = %spec.version,
+                    platform = ?platform,
+                    artifact_digest = %digest,
+                );
                 (digest, self.cache.provision(&spec, platform).await)
             }
-            Err(err) => (String::new(), Err(err)),
+            Err(err) => {
+                tracing::warn!(
+                    name = "ToolProvisionStatus",
+                    status = "Provision::PlatformUnsupported",
+                    tool = %spec.name,
+                    version = %spec.version,
+                    error = %err,
+                );
+                (String::new(), Err(err))
+            }
         };
 
         let reply = match result.1 {
             Ok(executable) => {
                 let digest = result.0;
+                tracing::info!(
+                    name = "ToolProvisionStatus",
+                    status = "Provision::Available",
+                    tool = %spec.name,
+                    version = %spec.version,
+                    executable = %executable.display(),
+                    artifact_digest = %digest,
+                );
                 self.observed.insert(
                     key,
                     ObservedToolState::Available {
@@ -432,6 +512,13 @@ impl Handler<ProvisionTool> for ToolProvisionActor {
             }
             Err(err) => {
                 let error = error_string(&err);
+                tracing::warn!(
+                    name = "ToolProvisionStatus",
+                    status = "Provision::Failed",
+                    tool = %spec.name,
+                    version = %spec.version,
+                    error = %error,
+                );
                 self.observed.insert(
                     key,
                     ObservedToolState::Failed {
@@ -448,7 +535,12 @@ impl Handler<ProvisionTool> for ToolProvisionActor {
         };
         self.publish_attrs(cx.instance());
         if let Err(e) = message.reply.send(cx, reply) {
-            tracing::debug!("ProvisionTool reply failed (caller gone?): {e}");
+            tracing::debug!(
+                name = "ToolProvisionStatus",
+                status = "Provision::ReplyDropped",
+                error = %e,
+                "ProvisionTool reply failed (caller gone?)",
+            );
         }
         Ok(())
     }
@@ -462,9 +554,17 @@ impl Handler<ResolveTool> for ToolProvisionActor {
         message: ResolveTool,
     ) -> Result<(), anyhow::Error> {
         let reply = self.resolve(&message.tool, message.version.as_deref());
+        log_resolve_result(&reply);
 
         if let Err(e) = message.reply.send(cx, reply) {
-            tracing::debug!("ResolveTool reply failed (caller gone?): {e}");
+            tracing::debug!(
+                name = "ToolProvisionStatus",
+                status = "Resolve::ReplyDropped",
+                tool = %message.tool,
+                requested_version = ?message.version,
+                error = %e,
+                "ResolveTool reply failed (caller gone?)",
+            );
         }
         Ok(())
     }
@@ -477,8 +577,19 @@ impl Handler<QueryToolInventory> for ToolProvisionActor {
         cx: &Context<Self>,
         message: QueryToolInventory,
     ) -> Result<(), anyhow::Error> {
-        if let Err(e) = message.reply.send(cx, self.inventory()) {
-            tracing::debug!("QueryToolInventory reply failed (caller gone?): {e}");
+        let inventory = self.inventory();
+        tracing::info!(
+            name = "ToolProvisionStatus",
+            status = "Inventory::Queried",
+            tool_count = inventory.tools.len(),
+        );
+        if let Err(e) = message.reply.send(cx, inventory) {
+            tracing::debug!(
+                name = "ToolProvisionStatus",
+                status = "Inventory::ReplyDropped",
+                error = %e,
+                "QueryToolInventory reply failed (caller gone?)",
+            );
         }
         Ok(())
     }
@@ -528,6 +639,45 @@ fn timestamp_now() -> String {
 
 fn error_string(err: &ProvisionError) -> String {
     err.to_string()
+}
+
+fn log_resolve_result(result: &ResolveResult) {
+    match result {
+        ResolveResult::Available {
+            name,
+            version,
+            executable,
+        } => {
+            tracing::info!(
+                name = "ToolProvisionStatus",
+                status = "Resolve::Available",
+                tool = %name,
+                version = %version,
+                executable = %executable.display(),
+            );
+        }
+        ResolveResult::NotProvisioned { tool, version } => {
+            tracing::info!(
+                name = "ToolProvisionStatus",
+                status = "Resolve::NotProvisioned",
+                tool = %tool,
+                requested_version = ?version,
+            );
+        }
+        ResolveResult::Failed {
+            name,
+            version,
+            error,
+        } => {
+            tracing::warn!(
+                name = "ToolProvisionStatus",
+                status = "Resolve::Failed",
+                tool = %name,
+                version = %version,
+                error = %error,
+            );
+        }
+    }
 }
 
 #[cfg(test)]

--- a/hyperactor_mesh_admin_tui/src/actions.rs
+++ b/hyperactor_mesh_admin_tui/src/actions.rs
@@ -24,6 +24,8 @@ pub(crate) enum KeyResult {
     RunDiagnostics,
     /// Fetch a py-spy stack dump for the given proc.
     RunPySpy(ProcId),
+    /// Provision managed py-spy on the given service proc reference.
+    ProvisionPySpy(String),
     /// Fetch the config dump for the given proc.
     RunConfig(ProcId),
 }

--- a/hyperactor_mesh_admin_tui/src/app.rs
+++ b/hyperactor_mesh_admin_tui/src/app.rs
@@ -16,6 +16,7 @@ use crossterm::event::KeyCode;
 use crossterm::event::KeyEvent;
 use crossterm::event::KeyModifiers;
 use futures::StreamExt;
+use hyperactor::host::SERVICE_PROC_NAME;
 use hyperactor_mesh::introspect::NodePayload;
 use hyperactor_mesh::introspect::NodeProperties;
 use hyperactor_mesh::introspect::NodeRef;
@@ -33,6 +34,9 @@ use crate::FetchState;
 use crate::KeyResult;
 use crate::LangName;
 use crate::NodeType;
+use crate::ProvisionOutcome;
+use crate::ProvisionState;
+use crate::PySpyJobResult;
 use crate::Theme;
 use crate::ThemeName;
 use crate::TreeNode;
@@ -657,6 +661,11 @@ impl App {
     pub(crate) fn start_pyspy(&mut self, proc_id: hyperactor::reference::ProcId) {
         let proc_ref = proc_id.to_string();
         let short = proc_id.name().to_string();
+        let service_proc_ref = if proc_id.base_name() == SERVICE_PROC_NAME {
+            Some(proc_ref.clone())
+        } else {
+            None
+        };
         let scheme = self.theme.scheme; // ColorScheme: Copy
         let client = self.client.clone();
         let base_url = self.base_url.clone();
@@ -669,6 +678,8 @@ impl App {
             short,
             lines: vec![],
             completed_at: None,
+            service_proc_ref,
+            provision_state: ProvisionState::Idle,
         });
         // TP-9: timeout covers the full request lifecycle (send +
         // body + parse) at the operation boundary.
@@ -682,27 +693,110 @@ impl App {
                     .map_err(|e| format!("request failed: {e}"))?;
                 if !resp.status().is_success() {
                     let status = resp.status();
-                    let lines = match resp.json::<serde_json::Value>().await {
-                        Ok(json) => parse_error_envelope(&json),
-                        Err(_) => vec![Line::from(format!("HTTP {status}"))],
+                    let result = match resp.json::<serde_json::Value>().await {
+                        Ok(json) => PySpyJobResult {
+                            lines: parse_error_envelope(&json),
+                            binary_not_found: false,
+                        },
+                        Err(_) => PySpyJobResult {
+                            lines: vec![Line::from(format!("HTTP {status}"))],
+                            binary_not_found: false,
+                        },
                     };
-                    return Ok::<_, String>(lines);
+                    return Ok::<_, String>(result);
                 }
                 match resp.json::<serde_json::Value>().await {
-                    Err(e) => Ok(vec![Line::from(format!("parse error: {e}"))]),
+                    Err(e) => Ok(PySpyJobResult {
+                        lines: vec![Line::from(format!("parse error: {e}"))],
+                        binary_not_found: false,
+                    }),
                     Ok(json) => Ok(pyspy_json_to_lines(&json, &scheme)),
                 }
             })
             .await;
-            let lines: Vec<Line<'static>> = match result {
-                Err(_) => vec![Line::from(format!(
-                    "request timed out after {}s",
-                    timeout.as_secs()
-                ))],
-                Ok(Ok(l)) => l,
-                Ok(Err(e)) => vec![Line::from(e)],
+            let result = match result {
+                Err(_) => PySpyJobResult {
+                    lines: vec![Line::from(format!(
+                        "request timed out after {}s",
+                        timeout.as_secs()
+                    ))],
+                    binary_not_found: false,
+                },
+                Ok(Ok(result)) => result,
+                Ok(Err(e)) => PySpyJobResult {
+                    lines: vec![Line::from(e)],
+                    binary_not_found: false,
+                },
             };
-            let _ = tx.send(lines);
+            let _ = tx.send(result);
+        });
+    }
+
+    /// Provision managed py-spy for the current service-proc py-spy
+    /// overlay without replacing the overlay content.
+    pub(crate) fn start_pyspy_provision(&mut self, service_proc_ref: String) {
+        let client = self.client.clone();
+        let base_url = self.base_url.clone();
+        let timeout = self
+            .policy
+            .request_timeout(crate::timeouts::RequestOp::ToolProvision);
+        let (tx, rx) = oneshot::channel();
+
+        let Some(ActiveJob::PySpy {
+            provision_state, ..
+        }) = &mut self.active_job
+        else {
+            return;
+        };
+        *provision_state = ProvisionState::Provisioning { rx };
+        self.rebuild_overlay();
+
+        tokio::spawn(async move {
+            let spec: serde_json::Value =
+                match serde_json::from_str(include_str!("../../tool_fetch/specs/py-spy.json")) {
+                    Ok(spec) => spec,
+                    Err(err) => {
+                        let _ = tx.send(ProvisionOutcome::Err(format!(
+                            "invalid bundled py-spy spec: {err}"
+                        )));
+                        return;
+                    }
+                };
+            let url = format!(
+                "{}/v1/tools_provision/{}",
+                base_url,
+                urlencoding::encode(&service_proc_ref)
+            );
+            let result = tokio::time::timeout(timeout, async {
+                let resp = client
+                    .post(&url)
+                    .json(&spec)
+                    .send()
+                    .await
+                    .map_err(|e| format!("request failed: {e}"))?;
+                if !resp.status().is_success() {
+                    let status = resp.status();
+                    return match resp.json::<serde_json::Value>().await {
+                        Ok(json) => Err(line_vec_text(parse_error_envelope(&json))),
+                        Err(_) => Err(format!("HTTP {status}")),
+                    };
+                }
+                let json = resp
+                    .json::<serde_json::Value>()
+                    .await
+                    .map_err(|e| format!("parse error: {e}"))?;
+                provision_json_to_outcome(&json)
+            })
+            .await;
+
+            let outcome = match result {
+                Err(_) => {
+                    ProvisionOutcome::Err(format!("request timed out after {}s", timeout.as_secs()))
+                }
+                Ok(Ok(outcome)) => outcome,
+                Ok(Err(error)) => ProvisionOutcome::Err(error),
+            };
+            let _ = tx.send(outcome);
         });
     }
 
@@ -979,13 +1073,23 @@ impl App {
                 KeyCode::Char('r') | KeyCode::Char('d') => KeyResult::RunDiagnostics,
                 _ => KeyResult::None,
             },
-            Some(ActiveJob::PySpy { .. }) => match key.code {
+            Some(ActiveJob::PySpy {
+                service_proc_ref,
+                provision_state,
+                ..
+            }) => match key.code {
                 KeyCode::Char('p') => {
                     if let Some(proc_ref) = self.pyspy_proc_ref() {
                         KeyResult::RunPySpy(proc_ref)
                     } else {
                         KeyResult::None
                     }
+                }
+                KeyCode::Char('P') if matches!(provision_state, ProvisionState::CanProvision) => {
+                    service_proc_ref
+                        .clone()
+                        .map(KeyResult::ProvisionPySpy)
+                        .unwrap_or(KeyResult::None)
                 }
                 _ => KeyResult::None,
             },
@@ -1022,6 +1126,41 @@ pub(crate) fn parse_error_envelope(json: &serde_json::Value) -> Vec<Line<'static
     vec![Line::from(format!("{code}: {msg}"))]
 }
 
+fn line_vec_text(lines: Vec<Line<'static>>) -> String {
+    lines
+        .into_iter()
+        .map(|line| {
+            line.spans
+                .into_iter()
+                .map(|span| span.content.into_owned())
+                .collect::<String>()
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+pub(crate) fn provision_json_to_outcome(
+    json: &serde_json::Value,
+) -> Result<ProvisionOutcome, String> {
+    if let Some(available) = json.get("Available") {
+        let executable = available
+            .get("executable")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| format!("unexpected provision response: {json}"))?;
+        return Ok(ProvisionOutcome::Ok {
+            executable: executable.to_string(),
+        });
+    }
+    if let Some(failed) = json.get("Failed") {
+        let error = failed
+            .get("error")
+            .and_then(|v| v.as_str())
+            .unwrap_or("tool provisioning failed");
+        return Ok(ProvisionOutcome::Err(error.to_string()));
+    }
+    Err(format!("unexpected provision response: {json}"))
+}
+
 /// Format a py-spy JSON response into styled display lines.
 ///
 /// ## Ok variant
@@ -1032,7 +1171,7 @@ pub(crate) fn parse_error_envelope(json: &serde_json::Value) -> Vec<Line<'static
 pub(crate) fn pyspy_json_to_lines(
     json: &serde_json::Value,
     scheme: &ColorScheme,
-) -> Vec<Line<'static>> {
+) -> PySpyJobResult {
     if let Some(ok) = json.get("Ok") {
         let pid = ok.get("pid").and_then(|v| v.as_u64());
         let binary = ok
@@ -1069,7 +1208,10 @@ pub(crate) fn pyspy_json_to_lines(
 
         if traces.is_empty() {
             lines.push(Line::from("(empty stack)"));
-            return lines;
+            return PySpyJobResult {
+                lines,
+                binary_not_found: false,
+            };
         }
 
         for trace in traces {
@@ -1147,7 +1289,10 @@ pub(crate) fn pyspy_json_to_lines(
             }
         }
 
-        return lines;
+        return PySpyJobResult {
+            lines,
+            binary_not_found: false,
+        };
     }
     if let Some(nf) = json.get("BinaryNotFound") {
         let mut lines = vec![Line::from(Span::styled(
@@ -1164,7 +1309,10 @@ pub(crate) fn pyspy_json_to_lines(
                 }
             }
         }
-        return lines;
+        return PySpyJobResult {
+            lines,
+            binary_not_found: true,
+        };
     }
     if let Some(failed) = json.get("Failed") {
         let mut lines = vec![];
@@ -1198,9 +1346,15 @@ pub(crate) fn pyspy_json_to_lines(
         if lines.is_empty() {
             lines.push(Line::from("(py-spy failed, no output)"));
         }
-        return lines;
+        return PySpyJobResult {
+            lines,
+            binary_not_found: false,
+        };
     }
-    vec![Line::from(format!("unexpected response: {json}"))]
+    PySpyJobResult {
+        lines: vec![Line::from(format!("unexpected response: {json}"))],
+        binary_not_found: false,
+    }
 }
 
 /// Format a `ConfigDumpResult` JSON response into styled `Line`s.
@@ -1297,11 +1451,24 @@ async fn recv_active_job(job: &mut Option<ActiveJob>) -> ActiveJobEvent {
         Some(ActiveJob::PySpy {
             rx: Some(inner), ..
         }) => {
-            let lines = match inner.await {
-                Ok(l) => l,
-                Err(_) => vec![Line::from("(fetch task dropped)")],
+            let result = match inner.await {
+                Ok(result) => result,
+                Err(_) => PySpyJobResult {
+                    lines: vec![Line::from("(fetch task dropped)")],
+                    binary_not_found: false,
+                },
             };
-            ActiveJobEvent::PySpyResult(lines)
+            ActiveJobEvent::PySpyResult(result)
+        }
+        Some(ActiveJob::PySpy {
+            provision_state: ProvisionState::Provisioning { rx },
+            ..
+        }) => {
+            let outcome = match rx.await {
+                Ok(outcome) => outcome,
+                Err(_) => ProvisionOutcome::Err("(provision task dropped)".to_string()),
+            };
+            ActiveJobEvent::ProvisionResult(outcome)
         }
         Some(ActiveJob::Config {
             rx: Some(inner), ..
@@ -1412,6 +1579,9 @@ pub(crate) async fn run_app(
                             }
                             KeyResult::RunPySpy(proc_id) => {
                                 app.start_pyspy(proc_id);
+                            }
+                            KeyResult::ProvisionPySpy(service_proc_ref) => {
+                                app.start_pyspy_provision(service_proc_ref);
                             }
                             KeyResult::RunConfig(proc_id) => {
                                 app.start_config(proc_id);

--- a/hyperactor_mesh_admin_tui/src/job.rs
+++ b/hyperactor_mesh_admin_tui/src/job.rs
@@ -44,12 +44,18 @@ pub(crate) enum ActiveJob {
     PySpy {
         /// `Some` while the HTTP fetch is in flight; `None` after the
         /// oneshot fires.
-        rx: Option<oneshot::Receiver<Vec<Line<'static>>>>,
+        rx: Option<oneshot::Receiver<PySpyJobResult>>,
         short: String,
         /// Populated when the oneshot result arrives.
         lines: Vec<Line<'static>>,
         /// Set to a formatted timestamp when the result arrives.
         completed_at: Option<String>,
+        /// Service proc reference used for managed py-spy
+        /// provisioning. Set only when the target itself is the
+        /// service proc.
+        service_proc_ref: Option<String>,
+        /// Operator-facing provisioning state for managed py-spy.
+        provision_state: ProvisionState,
     },
     /// A single config dump HTTP fetch.
     ///
@@ -82,6 +88,8 @@ impl ActiveJob {
                 short,
                 lines,
                 completed_at,
+                provision_state,
+                ..
             } => {
                 let scheme = &theme.scheme;
                 let labels = &theme.labels;
@@ -128,10 +136,13 @@ impl ActiveJob {
                     None
                 };
 
+                let mut overlay_lines = lines.clone();
+                append_provision_lines(&mut overlay_lines, provision_state, scheme);
+
                 Overlay {
                     title,
                     status_line,
-                    lines: lines.clone(),
+                    lines: overlay_lines,
                     loading,
                     scroll: Cell::new(0),
                     max_scroll: Cell::new(u16::MAX),
@@ -208,7 +219,16 @@ impl ActiveJob {
                 labels.footer_diag_running_help_text
             }
             Some(ActiveJob::Diagnostics { .. }) => labels.footer_diag_completed_help_text,
-            Some(ActiveJob::PySpy { .. }) => labels.footer_pyspy_help_text,
+            Some(ActiveJob::PySpy {
+                provision_state, ..
+            }) => match provision_state {
+                ProvisionState::CanProvision => labels.footer_pyspy_can_provision_help_text,
+                ProvisionState::Provisioning { .. } => labels.footer_pyspy_provisioning_help_text,
+                ProvisionState::Provisioned { .. } => labels.footer_pyspy_provisioned_help_text,
+                ProvisionState::Idle | ProvisionState::Failed { .. } => {
+                    labels.footer_pyspy_help_text
+                }
+            },
             Some(ActiveJob::Config { .. }) => labels.footer_config_help_text,
             None => labels.footer_help_text,
         }
@@ -240,19 +260,41 @@ impl ActiveJob {
                     debug_assert!(false, "DiagResult(None) delivered to non-Diagnostics job");
                 }
             }
-            ActiveJobEvent::PySpyResult(new_lines) => {
+            ActiveJobEvent::PySpyResult(result) => {
                 if let ActiveJob::PySpy {
                     rx,
                     lines,
                     completed_at,
+                    service_proc_ref,
+                    provision_state,
                     ..
                 } = self
                 {
                     *rx = None;
-                    *lines = new_lines;
+                    *lines = result.lines;
                     *completed_at = Some(Local::now().format("%H:%M:%S").to_string());
+                    if result.binary_not_found && service_proc_ref.is_some() {
+                        *provision_state = ProvisionState::CanProvision;
+                    } else {
+                        *provision_state = ProvisionState::Idle;
+                    }
                 } else {
                     debug_assert!(false, "PySpyResult delivered to non-PySpy job");
+                }
+            }
+            ActiveJobEvent::ProvisionResult(outcome) => {
+                if let ActiveJob::PySpy {
+                    provision_state, ..
+                } = self
+                {
+                    *provision_state = match outcome {
+                        ProvisionOutcome::Ok { executable } => {
+                            ProvisionState::Provisioned { executable }
+                        }
+                        ProvisionOutcome::Err(error) => ProvisionState::Failed { error },
+                    };
+                } else {
+                    debug_assert!(false, "ProvisionResult delivered to non-PySpy job");
                 }
             }
             ActiveJobEvent::ConfigResult(new_lines) => {
@@ -277,6 +319,105 @@ impl ActiveJob {
 /// Result of the active overlay-producing job completing one event.
 pub(crate) enum ActiveJobEvent {
     DiagResult(Option<DiagResult>),
-    PySpyResult(Vec<Line<'static>>),
+    PySpyResult(PySpyJobResult),
     ConfigResult(Vec<Line<'static>>),
+    ProvisionResult(ProvisionOutcome),
+}
+
+/// TUI-level py-spy fetch result.
+///
+/// This is a rendering envelope, not the backend `PySpyResult` wire
+/// type. It carries both display lines and the single semantic bit the
+/// TUI needs for PY-6/PY-7: whether the backend reported that py-spy
+/// was missing.
+pub(crate) struct PySpyJobResult {
+    /// Styled lines to render in the py-spy overlay.
+    pub(crate) lines: Vec<Line<'static>>,
+    /// True only for backend `BinaryNotFound` responses.
+    pub(crate) binary_not_found: bool,
+}
+
+/// Managed py-spy provisioning state attached to the py-spy overlay.
+pub(crate) enum ProvisionState {
+    /// No provisioning affordance is currently visible.
+    Idle,
+    /// The current service-proc py-spy result is eligible for
+    /// explicit operator-triggered provisioning (PY-6/PY-7).
+    CanProvision,
+    /// A provisioning POST is in flight. The receiver lives in the
+    /// active py-spy job so stale results are dropped if the overlay
+    /// is replaced (PY-5/PY-8).
+    Provisioning {
+        /// Completion channel for the async provisioning request.
+        rx: oneshot::Receiver<ProvisionOutcome>,
+    },
+    /// Provisioning succeeded and the resolved executable path is
+    /// available for display before the operator retries py-spy.
+    Provisioned {
+        /// Host-local executable path returned by the tool
+        /// provisioning actor.
+        executable: String,
+    },
+    /// Provisioning failed with an operator-readable error.
+    Failed {
+        /// Error text rendered in the existing py-spy overlay.
+        error: String,
+    },
+}
+
+/// Result of the async provisioning request.
+pub(crate) enum ProvisionOutcome {
+    /// The tool is available on the host.
+    Ok {
+        /// Host-local executable path returned by the backend.
+        executable: String,
+    },
+    /// Provisioning failed before an executable could be resolved.
+    Err(String),
+}
+
+fn append_provision_lines(
+    lines: &mut Vec<Line<'static>>,
+    provision_state: &ProvisionState,
+    scheme: &crate::theme::ColorScheme,
+) {
+    match provision_state {
+        ProvisionState::Idle => {}
+        ProvisionState::CanProvision => {
+            lines.push(Line::from(""));
+            lines.push(Line::from(Span::styled(
+                "press P to provision managed py-spy on this host",
+                scheme.info,
+            )));
+        }
+        ProvisionState::Provisioning { .. } => {
+            lines.push(Line::from(""));
+            lines.push(Line::from(Span::styled(
+                "provisioning py-spy 0.4.1...",
+                scheme.info,
+            )));
+        }
+        ProvisionState::Provisioned { executable } => {
+            lines.push(Line::from(""));
+            lines.push(Line::from(Span::styled(
+                "managed py-spy provisioned",
+                scheme.detail_status_ok,
+            )));
+            lines.push(Line::from(vec![
+                Span::styled("executable: ", scheme.detail_label),
+                Span::raw(executable.clone()),
+            ]));
+            lines.push(Line::from(Span::styled(
+                "press p to retry dump",
+                scheme.info,
+            )));
+        }
+        ProvisionState::Failed { error } => {
+            lines.push(Line::from(""));
+            lines.push(Line::from(Span::styled(
+                format!("managed py-spy provision failed: {error}"),
+                scheme.error,
+            )));
+        }
+    }
 }

--- a/hyperactor_mesh_admin_tui/src/lib.rs
+++ b/hyperactor_mesh_admin_tui/src/lib.rs
@@ -120,6 +120,19 @@
 //!   `Diagnostics` variant (dropping any live `PySpy` receiver);
 //!   Esc calls `dismiss_job`; `recv_active_job` fires only for the
 //!   variant currently stored.
+//! - **PY-6 (service-proc-managed-provisioning):** The managed
+//!   py-spy provisioning prompt is offered only for py-spy results
+//!   from the service proc. Worker proc py-spy still goes through
+//!   `ProcAgent`, so it must not offer a host-level provisioning
+//!   action that cannot affect the retry path.
+//! - **PY-7 (explicit-provisioning-action):** Missing py-spy never
+//!   triggers automatic provisioning. The TUI preserves the failed
+//!   overlay and dispatches provisioning only when the operator
+//!   presses uppercase `P`.
+//! - **PY-8 (provisioning-overlay-continuity):** Provisioning mutates
+//!   the active py-spy overlay in place. It appends provisioning
+//!   status to the existing binary-not-found output rather than
+//!   replacing the diagnostic context.
 //!
 //! Config overlay invariants:
 //!

--- a/hyperactor_mesh_admin_tui/src/render/status_bar.rs
+++ b/hyperactor_mesh_admin_tui/src/render/status_bar.rs
@@ -251,6 +251,8 @@ mod tests {
             short: "my_proc".to_string(),
             lines: vec![],
             completed_at: None,
+            service_proc_ref: None,
+            provision_state: crate::ProvisionState::Idle,
         });
         assert_eq!(
             ActiveJob::footer_text(&job, &labels),

--- a/hyperactor_mesh_admin_tui/src/tests/mod.rs
+++ b/hyperactor_mesh_admin_tui/src/tests/mod.rs
@@ -40,6 +40,13 @@ fn test_policy() -> TuiTimeoutPolicy {
     })
 }
 
+fn pyspy_result(lines: Vec<ratatui::text::Line<'static>>) -> PySpyJobResult {
+    PySpyJobResult {
+        lines,
+        binary_not_found: false,
+    }
+}
+
 fn root() -> NodeRef {
     NodeRef::Root
 }
@@ -1675,7 +1682,9 @@ fn pyspy_json_to_lines_ok_with_stack() {
         }]
     }});
     let scheme = ColorScheme::nord();
-    let lines = pyspy_json_to_lines(&json, &scheme);
+    let result = pyspy_json_to_lines(&json, &scheme);
+    let lines = result.lines;
+    assert!(!result.binary_not_found);
     // header + blank + thread header + frame + trailing blank
     assert_eq!(lines.len(), 5);
     assert_eq!(line_text(&lines[0]), "pid: 1  binary: py-spy");
@@ -1691,7 +1700,9 @@ fn pyspy_json_to_lines_ok_with_stack() {
 fn pyspy_json_to_lines_ok_empty_stack() {
     let json = serde_json::json!({"Ok": {"pid": 1, "binary": "py-spy", "stack_traces": []}});
     let scheme = ColorScheme::nord();
-    let lines = pyspy_json_to_lines(&json, &scheme);
+    let result = pyspy_json_to_lines(&json, &scheme);
+    let lines = result.lines;
+    assert!(!result.binary_not_found);
     assert_eq!(lines.len(), 3); // header + blank + sentinel
     assert_eq!(line_text(&lines[0]), "pid: 1  binary: py-spy");
     assert_eq!(line_text(&lines[1]), "");
@@ -1706,7 +1717,9 @@ fn pyspy_json_to_lines_binary_not_found() {
     let json =
         serde_json::json!({"BinaryNotFound": {"searched": ["PYSPY_BIN=/x", "py-spy on PATH"]}});
     let scheme = ColorScheme::nord();
-    let lines = pyspy_json_to_lines(&json, &scheme);
+    let result = pyspy_json_to_lines(&json, &scheme);
+    let lines = result.lines;
+    assert!(result.binary_not_found);
     assert_eq!(lines.len(), 3);
     assert_eq!(line_text(&lines[0]), "py-spy binary not found");
     assert_eq!(line_text(&lines[1]), "  searched: PYSPY_BIN=/x");
@@ -1719,7 +1732,9 @@ fn pyspy_json_to_lines_binary_not_found() {
 fn pyspy_json_to_lines_failed_null_exit_code() {
     let json = serde_json::json!({"Failed": {"pid": 1, "binary": "py-spy", "exit_code": null, "stderr": "ptrace denied"}});
     let scheme = ColorScheme::nord();
-    let lines = pyspy_json_to_lines(&json, &scheme);
+    let result = pyspy_json_to_lines(&json, &scheme);
+    let lines = result.lines;
+    assert!(!result.binary_not_found);
     assert_eq!(lines.len(), 4);
     assert_eq!(line_text(&lines[0]), "pid: 1");
     assert_eq!(line_text(&lines[1]), "binary: py-spy");
@@ -1735,7 +1750,9 @@ fn pyspy_json_to_lines_failed_numeric_exit_code_empty_stderr() {
     let json =
         serde_json::json!({"Failed": {"pid": 1, "binary": "py-spy", "exit_code": 1, "stderr": ""}});
     let scheme = ColorScheme::nord();
-    let lines = pyspy_json_to_lines(&json, &scheme);
+    let result = pyspy_json_to_lines(&json, &scheme);
+    let lines = result.lines;
+    assert!(!result.binary_not_found);
     assert_eq!(lines.len(), 3);
     assert_eq!(line_text(&lines[0]), "pid: 1");
     assert_eq!(line_text(&lines[1]), "binary: py-spy");
@@ -1747,7 +1764,9 @@ fn pyspy_json_to_lines_failed_numeric_exit_code_empty_stderr() {
 fn pyspy_json_to_lines_failed_no_exit_code_no_stderr() {
     let json = serde_json::json!({"Failed": {"stderr": ""}});
     let scheme = ColorScheme::nord();
-    let lines = pyspy_json_to_lines(&json, &scheme);
+    let result = pyspy_json_to_lines(&json, &scheme);
+    let lines = result.lines;
+    assert!(!result.binary_not_found);
     assert_eq!(lines.len(), 1);
     assert_eq!(line_text(&lines[0]), "(py-spy failed, no output)");
 }
@@ -1758,7 +1777,9 @@ fn pyspy_json_to_lines_failed_no_exit_code_no_stderr() {
 fn pyspy_json_to_lines_unknown_variant() {
     let json = serde_json::json!({"SomeUnknownVariant": {}});
     let scheme = ColorScheme::nord();
-    let lines = pyspy_json_to_lines(&json, &scheme);
+    let result = pyspy_json_to_lines(&json, &scheme);
+    let lines = result.lines;
+    assert!(!result.binary_not_found);
     assert_eq!(lines.len(), 1);
     assert!(
         line_text(&lines[0]).starts_with("unexpected response"),
@@ -1796,7 +1817,9 @@ fn pyspy_json_to_lines_ok_thread_name_and_flags() {
         }
     });
     let scheme = ColorScheme::nord();
-    let lines = pyspy_json_to_lines(&json, &scheme);
+    let result = pyspy_json_to_lines(&json, &scheme);
+    let lines = result.lines;
+    assert!(!result.binary_not_found);
     // header + blank + thread header + frame + trailing blank
     assert_eq!(lines.len(), 5);
     assert_eq!(line_text(&lines[0]), "pid: 123  binary: pyspy_workload");
@@ -1807,6 +1830,31 @@ fn pyspy_json_to_lines_ok_thread_name_and_flags() {
     );
     assert_eq!(line_text(&lines[3]), "  #0   foo (foo.py:1)");
     assert_eq!(line_text(&lines[4]), "");
+}
+
+// PY-8: ProvisionTool Available response yields an executable path
+// for the in-place overlay status.
+#[test]
+fn provision_json_to_outcome_available() {
+    let json = serde_json::json!({"Available": {"executable": "/tmp/tools/py-spy"}});
+    let outcome = provision_json_to_outcome(&json).unwrap();
+    match outcome {
+        ProvisionOutcome::Ok { executable } => {
+            assert_eq!(executable, "/tmp/tools/py-spy");
+        }
+        ProvisionOutcome::Err(error) => panic!("unexpected error: {error}"),
+    }
+}
+
+// PY-8: ProvisionTool Failed response keeps the backend error text.
+#[test]
+fn provision_json_to_outcome_failed() {
+    let json = serde_json::json!({"Failed": {"error": "hash mismatch"}});
+    let outcome = provision_json_to_outcome(&json).unwrap();
+    match outcome {
+        ProvisionOutcome::Ok { executable } => panic!("unexpected executable: {executable}"),
+        ProvisionOutcome::Err(error) => assert_eq!(error, "hash mismatch"),
+    }
 }
 
 // ── TUI-21 build_diag_overlay tests ────────────────────────────────────────
@@ -1927,12 +1975,14 @@ fn dismiss_job_clears_both() {
 #[test]
 fn build_overlay_pyspy_loading() {
     let theme = Theme::new(ThemeName::Nord, LangName::En);
-    let (_, rx) = tokio::sync::oneshot::channel::<Vec<ratatui::text::Line<'static>>>();
+    let (_, rx) = tokio::sync::oneshot::channel::<PySpyJobResult>();
     let job = ActiveJob::PySpy {
         rx: Some(rx),
         short: "worker[0]".to_string(),
         lines: vec![],
         completed_at: None,
+        service_proc_ref: None,
+        provision_state: ProvisionState::Idle,
     };
     let overlay = job.build_overlay(&theme);
     assert!(overlay.loading, "rx is Some → loading");
@@ -1956,6 +2006,8 @@ fn build_overlay_pyspy_completed() {
         short: "worker[0]".to_string(),
         lines: vec![ratatui::text::Line::from("frame 0")],
         completed_at: Some("14:30:00".to_string()),
+        service_proc_ref: None,
+        provision_state: ProvisionState::Idle,
     };
     let overlay = job.build_overlay(&theme);
     assert!(!overlay.loading, "rx is None → not loading");
@@ -1981,6 +2033,8 @@ fn build_overlay_pyspy_completed_empty() {
         short: "worker[0]".to_string(),
         lines: vec![],
         completed_at: Some("14:30:00".to_string()),
+        service_proc_ref: None,
+        provision_state: ProvisionState::Idle,
     };
     let overlay = job.build_overlay(&theme);
     assert!(
@@ -1988,6 +2042,82 @@ fn build_overlay_pyspy_completed_empty() {
         "empty lines with rx None is completed, not loading"
     );
     assert!(overlay.lines.is_empty());
+}
+
+// PY-8: provisioning affordance appends to the existing missing-binary output.
+#[test]
+fn build_overlay_pyspy_can_provision_appends_prompt() {
+    let theme = Theme::new(ThemeName::Nord, LangName::En);
+    let job = ActiveJob::PySpy {
+        rx: None,
+        short: "service[0]".to_string(),
+        lines: vec![ratatui::text::Line::from("py-spy binary not found")],
+        completed_at: Some("14:30:00".to_string()),
+        service_proc_ref: Some("unix:@test,service[0]".to_string()),
+        provision_state: ProvisionState::CanProvision,
+    };
+    let overlay = job.build_overlay(&theme);
+    assert_eq!(
+        line_text(&overlay.lines[0]),
+        "py-spy binary not found",
+        "existing diagnostic context should remain visible"
+    );
+    assert_eq!(
+        line_text(overlay.lines.last().unwrap()),
+        "press P to provision managed py-spy on this host"
+    );
+}
+
+// PY-8: successful provisioning shows the executable and retry hint.
+#[test]
+fn build_overlay_pyspy_provisioned_shows_executable_and_retry() {
+    let theme = Theme::new(ThemeName::Nord, LangName::En);
+    let job = ActiveJob::PySpy {
+        rx: None,
+        short: "service[0]".to_string(),
+        lines: vec![ratatui::text::Line::from("py-spy binary not found")],
+        completed_at: Some("14:30:00".to_string()),
+        service_proc_ref: Some("unix:@test,service[0]".to_string()),
+        provision_state: ProvisionState::Provisioned {
+            executable: "/tmp/tools/py-spy".to_string(),
+        },
+    };
+    let overlay = job.build_overlay(&theme);
+    assert!(
+        overlay
+            .lines
+            .iter()
+            .any(|line| line_text(line) == "executable: /tmp/tools/py-spy")
+    );
+    assert!(
+        overlay
+            .lines
+            .iter()
+            .any(|line| line_text(line) == "press p to retry dump")
+    );
+}
+
+// PY-8: failed provisioning renders the structured error in-place.
+#[test]
+fn build_overlay_pyspy_provision_failed_shows_error() {
+    let theme = Theme::new(ThemeName::Nord, LangName::En);
+    let job = ActiveJob::PySpy {
+        rx: None,
+        short: "service[0]".to_string(),
+        lines: vec![ratatui::text::Line::from("py-spy binary not found")],
+        completed_at: Some("14:30:00".to_string()),
+        service_proc_ref: Some("unix:@test,service[0]".to_string()),
+        provision_state: ProvisionState::Failed {
+            error: "hash mismatch".to_string(),
+        },
+    };
+    let overlay = job.build_overlay(&theme);
+    assert!(
+        overlay
+            .lines
+            .iter()
+            .any(|line| line_text(line) == "managed py-spy provision failed: hash mismatch")
+    );
 }
 
 // ── ActiveJob::on_event tests ──────────────────────────────────────────────
@@ -2048,15 +2178,17 @@ fn on_event_diag_stream_end() {
 // PY-2/PY-3: on_event PySpyResult populates lines, clears rx, sets timestamp.
 #[test]
 fn on_event_pyspy_result() {
-    let (_, rx) = tokio::sync::oneshot::channel::<Vec<ratatui::text::Line<'static>>>();
+    let (_, rx) = tokio::sync::oneshot::channel::<PySpyJobResult>();
     let mut job = ActiveJob::PySpy {
         rx: Some(rx),
         short: "w".to_string(),
         lines: vec![],
         completed_at: None,
+        service_proc_ref: None,
+        provision_state: ProvisionState::Idle,
     };
     let result_lines = vec![ratatui::text::Line::from("frame")];
-    job.on_event(ActiveJobEvent::PySpyResult(result_lines));
+    job.on_event(ActiveJobEvent::PySpyResult(pyspy_result(result_lines)));
     if let ActiveJob::PySpy {
         rx,
         lines,
@@ -2067,6 +2199,60 @@ fn on_event_pyspy_result() {
         assert!(rx.is_none(), "rx should be cleared");
         assert_eq!(lines.len(), 1);
         assert!(completed_at.is_some(), "should have a completion timestamp");
+    } else {
+        panic!("job variant changed");
+    }
+}
+
+// PY-6/PY-7: BinaryNotFound from the service proc enables explicit
+// managed provisioning.
+#[test]
+fn on_event_pyspy_binary_not_found_service_can_provision() {
+    let (_, rx) = tokio::sync::oneshot::channel::<PySpyJobResult>();
+    let mut job = ActiveJob::PySpy {
+        rx: Some(rx),
+        short: "service[0]".to_string(),
+        lines: vec![],
+        completed_at: None,
+        service_proc_ref: Some("unix:@test,service[0]".to_string()),
+        provision_state: ProvisionState::Idle,
+    };
+    job.on_event(ActiveJobEvent::PySpyResult(PySpyJobResult {
+        lines: vec![ratatui::text::Line::from("py-spy binary not found")],
+        binary_not_found: true,
+    }));
+    if let ActiveJob::PySpy {
+        provision_state, ..
+    } = &job
+    {
+        assert!(matches!(provision_state, ProvisionState::CanProvision));
+    } else {
+        panic!("job variant changed");
+    }
+}
+
+// PY-6: BinaryNotFound from a worker proc does not expose host-level
+// provisioning because the retry still routes through ProcAgent.
+#[test]
+fn on_event_pyspy_binary_not_found_worker_stays_idle() {
+    let (_, rx) = tokio::sync::oneshot::channel::<PySpyJobResult>();
+    let mut job = ActiveJob::PySpy {
+        rx: Some(rx),
+        short: "worker[0]".to_string(),
+        lines: vec![],
+        completed_at: None,
+        service_proc_ref: None,
+        provision_state: ProvisionState::Idle,
+    };
+    job.on_event(ActiveJobEvent::PySpyResult(PySpyJobResult {
+        lines: vec![ratatui::text::Line::from("py-spy binary not found")],
+        binary_not_found: true,
+    }));
+    if let ActiveJob::PySpy {
+        provision_state, ..
+    } = &job
+    {
+        assert!(matches!(provision_state, ProvisionState::Idle));
     } else {
         panic!("job variant changed");
     }
@@ -2119,9 +2305,50 @@ fn overlay_rerun_key_pyspy_p() {
         short: "worker[0]".to_string(),
         lines: vec![],
         completed_at: None,
+        service_proc_ref: None,
+        provision_state: ProvisionState::Idle,
     });
     let key = KeyEvent::new(KeyCode::Char('p'), KeyModifiers::NONE);
     assert!(matches!(app.overlay_rerun_key(key), KeyResult::RunPySpy(_)));
+}
+
+// PY-7: uppercase P dispatches provisioning only from the explicit
+// CanProvision state.
+#[test]
+fn overlay_rerun_key_pyspy_uppercase_p_provisions_when_allowed() {
+    let mut app = make_app_with_cursor(vec![proc_node("service")], 0);
+    app.active_job = Some(ActiveJob::PySpy {
+        rx: None,
+        short: "service[0]".to_string(),
+        lines: vec![ratatui::text::Line::from("py-spy binary not found")],
+        completed_at: Some("14:30:00".to_string()),
+        service_proc_ref: Some("unix:@test,service[0]".to_string()),
+        provision_state: ProvisionState::CanProvision,
+    });
+    let key = KeyEvent::new(KeyCode::Char('P'), KeyModifiers::SHIFT);
+    let result = app.overlay_rerun_key(key);
+    match result {
+        KeyResult::ProvisionPySpy(proc_ref) => {
+            assert_eq!(proc_ref, "unix:@test,service[0]");
+        }
+        other => panic!("expected ProvisionPySpy, got {other:?}"),
+    }
+}
+
+// PY-7: uppercase P is ignored when the py-spy overlay has not opted in.
+#[test]
+fn overlay_rerun_key_pyspy_uppercase_p_idle_is_noop() {
+    let mut app = make_app_with_cursor(vec![proc_node("service")], 0);
+    app.active_job = Some(ActiveJob::PySpy {
+        rx: None,
+        short: "service[0]".to_string(),
+        lines: vec![],
+        completed_at: None,
+        service_proc_ref: Some("unix:@test,service[0]".to_string()),
+        provision_state: ProvisionState::Idle,
+    });
+    let key = KeyEvent::new(KeyCode::Char('P'), KeyModifiers::SHIFT);
+    assert!(matches!(app.overlay_rerun_key(key), KeyResult::None));
 }
 
 // PY-5: PySpy overlay: unrelated key is not dispatched.
@@ -2133,6 +2360,8 @@ fn overlay_rerun_key_pyspy_unrelated() {
         short: "w".to_string(),
         lines: vec![],
         completed_at: None,
+        service_proc_ref: None,
+        provision_state: ProvisionState::Idle,
     });
     let key = KeyEvent::new(KeyCode::Char('x'), KeyModifiers::NONE);
     assert!(matches!(app.overlay_rerun_key(key), KeyResult::None));
@@ -2167,6 +2396,8 @@ fn overlay_rerun_key_pyspy_no_proc_ref() {
         short: "w".to_string(),
         lines: vec![],
         completed_at: None,
+        service_proc_ref: None,
+        provision_state: ProvisionState::Idle,
     });
     let key = KeyEvent::new(KeyCode::Char('p'), KeyModifiers::NONE);
     assert!(
@@ -2322,9 +2553,45 @@ fn footer_text_pyspy() {
         short: "w".to_string(),
         lines: vec![],
         completed_at: None,
+        service_proc_ref: None,
+        provision_state: ProvisionState::Idle,
     });
     let text = ActiveJob::footer_text(&job, &labels);
     assert_eq!(text, labels.footer_pyspy_help_text);
+}
+
+// PY-7/PY-8: footer advertises provisioning and retry only in the
+// corresponding py-spy provisioning states.
+#[test]
+fn footer_text_pyspy_provisioning_states() {
+    let labels = Labels::en();
+    let can_provision = Some(ActiveJob::PySpy {
+        rx: None,
+        short: "service[0]".to_string(),
+        lines: vec![],
+        completed_at: Some("14:30:00".to_string()),
+        service_proc_ref: Some("unix:@test,service[0]".to_string()),
+        provision_state: ProvisionState::CanProvision,
+    });
+    assert_eq!(
+        ActiveJob::footer_text(&can_provision, &labels),
+        labels.footer_pyspy_can_provision_help_text
+    );
+
+    let provisioned = Some(ActiveJob::PySpy {
+        rx: None,
+        short: "service[0]".to_string(),
+        lines: vec![],
+        completed_at: Some("14:30:00".to_string()),
+        service_proc_ref: Some("unix:@test,service[0]".to_string()),
+        provision_state: ProvisionState::Provisioned {
+            executable: "/tmp/tools/py-spy".to_string(),
+        },
+    });
+    assert_eq!(
+        ActiveJob::footer_text(&provisioned, &labels),
+        labels.footer_pyspy_provisioned_help_text
+    );
 }
 
 // CFG-5: Footer text when no job is active.
@@ -2417,12 +2684,14 @@ fn refresh_policy_diagnostics() {
 // TP-10: py-spy in flight → Suspend.
 #[test]
 fn refresh_policy_pyspy_in_flight() {
-    let (_tx, rx) = tokio::sync::oneshot::channel::<Vec<ratatui::text::Line<'static>>>();
+    let (_tx, rx) = tokio::sync::oneshot::channel::<PySpyJobResult>();
     let job = Some(ActiveJob::PySpy {
         rx: Some(rx),
         short: "w".to_string(),
         lines: vec![],
         completed_at: None,
+        service_proc_ref: None,
+        provision_state: ProvisionState::Idle,
     });
     assert_eq!(refresh_policy_for_job(&job), RefreshPolicy::Suspend);
 }
@@ -2435,6 +2704,8 @@ fn refresh_policy_pyspy_completed() {
         short: "w".to_string(),
         lines: vec![],
         completed_at: Some("14:30:00".to_string()),
+        service_proc_ref: None,
+        provision_state: ProvisionState::Idle,
     });
     assert_eq!(refresh_policy_for_job(&job), RefreshPolicy::Suspend);
 }

--- a/hyperactor_mesh_admin_tui/src/theme.rs
+++ b/hyperactor_mesh_admin_tui/src/theme.rs
@@ -152,6 +152,9 @@ pub(crate) struct Labels {
     pub(crate) footer_diag_running_help_text: &'static str,
     pub(crate) footer_diag_completed_help_text: &'static str,
     pub(crate) footer_pyspy_help_text: &'static str,
+    pub(crate) footer_pyspy_can_provision_help_text: &'static str,
+    pub(crate) footer_pyspy_provisioning_help_text: &'static str,
+    pub(crate) footer_pyspy_provisioned_help_text: &'static str,
     pub(crate) footer_config_help_text: &'static str,
 }
 
@@ -235,6 +238,9 @@ impl Labels {
             footer_diag_running_help_text: "q: quit | Esc: cancel | j/k: scroll",
             footer_diag_completed_help_text: "q: quit | Esc: back to topology | j/k: scroll | r: rerun",
             footer_pyspy_help_text: "q: quit | Esc: back to topology | j/k: scroll | p: refresh",
+            footer_pyspy_can_provision_help_text: "q: quit | Esc: back to topology | j/k: scroll | p: retry | P: provision py-spy",
+            footer_pyspy_provisioning_help_text: "q: quit | Esc: back to topology | j/k: scroll | provisioning...",
+            footer_pyspy_provisioned_help_text: "q: quit | Esc: back to topology | j/k: scroll | p: retry dump",
             footer_config_help_text: "q: quit | Esc: back to topology | j/k: scroll | C: refresh",
         }
     }
@@ -318,6 +324,9 @@ impl Labels {
             footer_diag_running_help_text: "q: 退出 | Esc: 取消 | j/k: 滚动",
             footer_diag_completed_help_text: "q: 退出 | Esc: 返回拓扑 | j/k: 滚动 | r: 重新运行",
             footer_pyspy_help_text: "q: 退出 | Esc: 返回拓扑 | j/k: 滚动 | p: 刷新",
+            footer_pyspy_can_provision_help_text: "q: 退出 | Esc: 返回拓扑 | j/k: 滚动 | p: 重试 | P: 配置 py-spy",
+            footer_pyspy_provisioning_help_text: "q: 退出 | Esc: 返回拓扑 | j/k: 滚动 | 配置中...",
+            footer_pyspy_provisioned_help_text: "q: 退出 | Esc: 返回拓扑 | j/k: 滚动 | p: 重试转储",
             footer_config_help_text: "q: 退出 | Esc: 返回拓扑 | j/k: 滚动 | C: 刷新",
         }
     }

--- a/hyperactor_mesh_admin_tui/src/timeouts.rs
+++ b/hyperactor_mesh_admin_tui/src/timeouts.rs
@@ -47,6 +47,8 @@ pub(crate) enum RequestOp {
     ConfigDump,
     /// `GET /v1/pyspy/{proc_reference}`.
     PySpyDump,
+    /// `POST /v1/tools_provision/{proc_reference}`.
+    ToolProvision,
 }
 
 /// All [`RequestOp`] variants, for iteration in law-based tests.
@@ -55,6 +57,7 @@ pub(crate) const ALL_REQUEST_OPS: &[RequestOp] = &[
     RequestOp::InteractiveFetch,
     RequestOp::ConfigDump,
     RequestOp::PySpyDump,
+    RequestOp::ToolProvision,
 ];
 
 /// Per-probe budgets, applied via `tokio::time::timeout` inside the
@@ -91,6 +94,7 @@ pub(crate) struct TuiTimeoutPolicy {
     interactive_fetch: Duration,
     config_dump: Duration,
     pyspy_dump: Duration,
+    tool_provision: Duration,
     diagnostics_probe: Duration,
     diagnostics_run: Duration,
 }
@@ -116,6 +120,9 @@ impl TuiTimeoutPolicy {
             pyspy_dump: hyperactor_config::global::get(
                 hyperactor_mesh::config::MESH_ADMIN_PYSPY_CLIENT_TIMEOUT,
             ),
+            tool_provision: hyperactor_config::global::get(
+                hyperactor_mesh::config::MESH_ADMIN_TOOL_PROVISION_BRIDGE_TIMEOUT,
+            ),
             diagnostics_probe: Duration::from_secs(5),
             diagnostics_run: Duration::from_secs(120),
         }
@@ -127,6 +134,7 @@ impl TuiTimeoutPolicy {
             RequestOp::InteractiveFetch => self.interactive_fetch,
             RequestOp::ConfigDump => self.config_dump,
             RequestOp::PySpyDump => self.pyspy_dump,
+            RequestOp::ToolProvision => self.tool_provision,
         }
     }
 
@@ -220,6 +228,17 @@ mod tests {
             hyperactor_mesh::config::MESH_ADMIN_PYSPY_CLIENT_TIMEOUT,
         );
         assert_eq!(policy.request_timeout(RequestOp::PySpyDump), expected);
+    }
+
+    // TP-6/TP-9: tool provisioning has its own budget and does not
+    // reuse py-spy or config dump timeouts.
+    #[test]
+    fn from_config_request_budget_tool_provision() {
+        let policy = TuiTimeoutPolicy::from_config(&default_config());
+        let expected = hyperactor_config::global::get(
+            hyperactor_mesh::config::MESH_ADMIN_TOOL_PROVISION_BRIDGE_TIMEOUT,
+        );
+        assert_eq!(policy.request_timeout(RequestOp::ToolProvision), expected);
     }
 
     // TP-6: probe budget.

--- a/tool_fetch/Cargo.toml
+++ b/tool_fetch/Cargo.toml
@@ -17,6 +17,7 @@ tar = "0.4.44"
 tempfile = "3.27.0"
 thiserror = "2.0.18"
 tokio = { version = "1.52.1", features = ["fs", "io-util", "macros", "process", "rt-multi-thread", "time"] }
+tracing = "0.1.41"
 zip = { version = "2.4.2", default-features = false, features = ["deflate"] }
 
 [dev-dependencies]

--- a/tool_fetch/Cargo.toml
+++ b/tool_fetch/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "tool_fetch"
+version = "0.0.0"
+authors = ["Meta"]
+edition = "2024"
+license = "BSD-3-Clause"
+
+[dependencies]
+flate2 = "1.1.9"
+fs2 = "0.4.3"
+hex = "0.4.3"
+reqwest = { version = "0.13.2", features = ["rustls", "stream"], default-features = false }
+serde = { version = "1.0.219", features = ["derive"] }
+serde_json = "1.0.140"
+sha2 = "0.10.9"
+tar = "0.4.44"
+tempfile = "3.27.0"
+thiserror = "2.0.18"
+tokio = { version = "1.52.1", features = ["fs", "io-util", "macros", "process", "rt-multi-thread", "time"] }
+zip = { version = "2.4.2", default-features = false, features = ["deflate"] }
+
+[dev-dependencies]
+tokio = { version = "1.52.1", features = ["full", "test-util"] }

--- a/tool_fetch/specs/py-spy.json
+++ b/tool_fetch/specs/py-spy.json
@@ -1,0 +1,34 @@
+{
+  "name": "py-spy",
+  "version": "0.4.1",
+  "platforms": {
+    "macos-aarch64": {
+      "size": 1796395,
+      "hash_algorithm": "sha256",
+      "digest": "1fb8bf71ab8df95a95cc387deed6552934c50feef2cf6456bc06692a5508fd0c",
+      "format": "zip",
+      "executable_path": "py_spy-0.4.1.data/scripts/py-spy",
+      "providers": [
+        {
+          "Http": {
+            "url": "https://files.pythonhosted.org/packages/4f/bf/e4d280e9e0bec71d39fc646654097027d4bbe8e04af18fb68e49afcff404/py_spy-0.4.1-py2.py3-none-macosx_11_0_arm64.whl"
+          }
+        }
+      ]
+    },
+    "linux-x86_64": {
+      "size": 2763338,
+      "hash_algorithm": "sha256",
+      "digest": "6a80ec05eb8a6883863a367c6a4d4f2d57de68466f7956b6367d4edd5c61bb29",
+      "format": "zip",
+      "executable_path": "py_spy-0.4.1.data/scripts/py-spy",
+      "providers": [
+        {
+          "Http": {
+            "url": "https://files.pythonhosted.org/packages/68/fb/bc7f639aed026bca6e7beb1e33f6951e16b7d315594e7635a4f7d21d63f4/py_spy-0.4.1-py2.py3-none-manylinux_2_5_x86_64.manylinux1_x86_64.whl"
+          }
+        }
+      ]
+    }
+  }
+}

--- a/tool_fetch/src/cache.rs
+++ b/tool_fetch/src/cache.rs
@@ -33,6 +33,10 @@
 //! - **TF-SPEC-1 (spec-selects-platform):** [`ToolCache::provision`]
 //!   accepts a full spec plus platform and performs entry selection
 //!   internally.
+//! - **TF-CACHE-7 (operator-observability):** Cache decisions emit
+//!   structured tracing events so callers running inside actor
+//!   recording spans can explain whether provisioning downloaded,
+//!   reused a blob, reused an install, or extracted from cache.
 
 /*
  * Copyright (c) Meta Platforms, Inc. and affiliates.
@@ -197,15 +201,52 @@ impl ToolCache {
         entry: &PlatformEntry,
     ) -> Result<PathBuf, ProvisionError> {
         if let Some(path) = self.lookup(entry) {
+            tracing::info!(
+                name = "ToolFetchStatus",
+                status = "InstallCache::Hit",
+                tool = %spec.name,
+                version = %spec.version,
+                platform = ?platform,
+                artifact_digest = %entry.digest,
+                executable = %path.display(),
+            );
             return Ok(path);
         }
 
         let blob = self.blob_path(&entry.digest);
         if blob.is_file() && !verify_blob(&blob, entry)? {
+            tracing::warn!(
+                name = "ToolFetchStatus",
+                status = "BlobCache::Invalid",
+                tool = %spec.name,
+                version = %spec.version,
+                platform = ?platform,
+                artifact_digest = %entry.digest,
+                blob = %blob.display(),
+            );
             fs::remove_file(&blob)?;
         }
         if !blob.is_file() {
+            tracing::info!(
+                name = "ToolFetchStatus",
+                status = "BlobCache::Miss",
+                tool = %spec.name,
+                version = %spec.version,
+                platform = ?platform,
+                artifact_digest = %entry.digest,
+                blob = %blob.display(),
+            );
             fetch::fetch_verified_blob(entry, &blob).await?;
+        } else {
+            tracing::info!(
+                name = "ToolFetchStatus",
+                status = "BlobCache::Hit",
+                tool = %spec.name,
+                version = %spec.version,
+                platform = ?platform,
+                artifact_digest = %entry.digest,
+                blob = %blob.display(),
+            );
         }
 
         let extracted_dir = self.extracted_path(&entry.digest);
@@ -213,6 +254,16 @@ impl ToolCache {
             .prefix("extract-")
             .tempdir_in(self.extracted_parent(&entry.digest))?;
 
+        tracing::info!(
+            name = "ToolFetchStatus",
+            status = "Extract::Start",
+            tool = %spec.name,
+            version = %spec.version,
+            platform = ?platform,
+            artifact_format = ?entry.format,
+            artifact_digest = %entry.digest,
+            destination = %extracted_dir.display(),
+        );
         let executable = match entry.format {
             ArtifactFormat::Plain => extract::install_plain(&blob, temp_dir.path(), &spec.name)?,
             ArtifactFormat::TarGz => {
@@ -254,6 +305,15 @@ impl ToolCache {
             .ok_or_else(|| ProvisionError::ExecutableMissing {
                 expected_path: extracted_dir.join(executable_path),
             })?;
+        tracing::info!(
+            name = "ToolFetchStatus",
+            status = "Extract::Complete",
+            tool = %spec.name,
+            version = %spec.version,
+            platform = ?platform,
+            artifact_digest = %entry.digest,
+            executable = %executable.display(),
+        );
         Ok(executable)
     }
 

--- a/tool_fetch/src/cache.rs
+++ b/tool_fetch/src/cache.rs
@@ -1,0 +1,405 @@
+//! Content-addressed cache for verified tool artifacts.
+//!
+//! The cache separates verified downloaded bytes (`blobs/`) from
+//! executable install trees (`extracted/`). Higher layers should expose
+//! paths from the install tree only.
+//!
+//! # Layout
+//!
+//! ```text
+//! {cache_dir}/
+//!   blobs/{digest[0..2]}/{digest}
+//!   extracted/{digest[0..2]}/{digest}/
+//!     .tool-fetch-metadata.json
+//!   locks/{digest[0..2]}/{digest}.lock
+//! ```
+//!
+//! # Invariants
+//!
+//! - **TF-CACHE-1 (content-addressed-blob):** Verified artifact bytes
+//!   are stored under the artifact digest.
+//! - **TF-CACHE-2 (executable-not-blob):** [`ToolCache::lookup`] and
+//!   [`ToolCache::provision`] return paths from `extracted/`, never
+//!   direct blob paths.
+//! - **TF-CACHE-3 (cache-hit-no-download):** A complete install with
+//!   metadata and executable is reused without contacting providers.
+//! - **TF-CACHE-4 (metadata-gates-scan):** [`ToolCache::scan`] reports
+//!   only entries with parseable metadata and an existing executable.
+//! - **TF-CACHE-5 (blob-reverify):** Existing blobs are rechecked
+//!   against size and digest before reuse.
+//! - **TF-CACHE-6 (metadata-contained-path):** Metadata executable
+//!   paths must be relative paths contained by their extracted artifact
+//!   directory.
+//! - **TF-SPEC-1 (spec-selects-platform):** [`ToolCache::provision`]
+//!   accepts a full spec plus platform and performs entry selection
+//!   internally.
+
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+use std::fs;
+use std::io::Read;
+use std::path::Component;
+use std::path::Path;
+use std::path::PathBuf;
+
+use fs2::FileExt;
+use serde::Deserialize;
+use serde::Serialize;
+use sha2::Digest;
+use sha2::Sha256;
+
+use crate::ArtifactFormat;
+use crate::Platform;
+use crate::PlatformEntry;
+use crate::ProvisionError;
+use crate::ToolSpec;
+use crate::extract;
+use crate::fetch;
+
+const METADATA_FILE: &str = ".tool-fetch-metadata.json";
+
+/// Content-addressed cache rooted at a caller-provided directory.
+///
+/// The cache is safe to share between independent handles in the same
+/// process or host; per-digest advisory locks serialize provisioning.
+#[derive(Debug, Clone)]
+pub struct ToolCache {
+    cache_dir: PathBuf,
+}
+
+/// Artifact discovered from cache metadata.
+///
+/// This is the durable inventory representation used by the future
+/// mesh-facing actor after restart recovery.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CachedArtifact {
+    /// Tool name recorded at provision time.
+    pub name: String,
+    /// Tool version recorded at provision time.
+    pub version: String,
+    /// Platform entry used to provision the artifact.
+    pub platform: Platform,
+    /// Digest of the downloaded artifact bytes.
+    pub digest: String,
+    /// Resolved executable path under `extracted/`.
+    pub executable: PathBuf,
+    /// Provision timestamp as a simple string suitable for JSON metadata.
+    pub provisioned_at: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct CacheMetadata {
+    name: String,
+    version: String,
+    platform: Platform,
+    digest: String,
+    executable_path: PathBuf,
+    provisioned_at: String,
+}
+
+impl ToolCache {
+    /// Create a cache rooted at `cache_dir`.
+    ///
+    /// Tests pass a tempdir here; production actors use
+    /// [`ToolCache::default_dir`].
+    pub fn new(cache_dir: impl Into<PathBuf>) -> Self {
+        Self {
+            cache_dir: cache_dir.into(),
+        }
+    }
+
+    /// Default OSS cache directory.
+    ///
+    /// Uses `${XDG_CACHE_HOME}/monarch/tools` when set, otherwise
+    /// `$HOME/.cache/monarch/tools`, with a tempdir fallback only when
+    /// no home directory is available.
+    pub fn default_dir() -> PathBuf {
+        if let Some(xdg) = std::env::var_os("XDG_CACHE_HOME") {
+            return PathBuf::from(xdg).join("monarch").join("tools");
+        }
+        if let Some(home) = std::env::var_os("HOME") {
+            return PathBuf::from(home)
+                .join(".cache")
+                .join("monarch")
+                .join("tools");
+        }
+        std::env::temp_dir().join("monarch").join("tools")
+    }
+
+    /// Return the root cache directory.
+    pub fn cache_dir(&self) -> &Path {
+        &self.cache_dir
+    }
+
+    /// Return the cached executable path for `entry`, if fully installed.
+    ///
+    /// TF-CACHE-2 and TF-CACHE-4: this succeeds only when metadata is
+    /// present and the executable exists under `extracted/`.
+    pub fn lookup(&self, entry: &PlatformEntry) -> Option<PathBuf> {
+        let extracted_dir = self.extracted_path(&entry.digest);
+        let metadata = read_metadata(&extracted_dir).ok()?;
+        if metadata.digest != entry.digest || !is_safe_relative_path(&metadata.executable_path) {
+            return None;
+        }
+        let executable = extracted_dir.join(metadata.executable_path);
+        executable.is_file().then_some(executable)
+    }
+
+    /// Fetch, verify, install/extract, write metadata, and resolve a tool.
+    ///
+    /// TF-SPEC-1: platform entry selection happens inside this method.
+    /// TF-FETCH-1: downloaded bytes are verified before extraction.
+    /// TF-CACHE-3: completed installs return without redownloading.
+    pub async fn provision(
+        &self,
+        spec: &ToolSpec,
+        platform: Platform,
+    ) -> Result<PathBuf, ProvisionError> {
+        let entry =
+            spec.platforms
+                .get(&platform)
+                .ok_or_else(|| ProvisionError::UnsupportedPlatform {
+                    os: format!("{platform:?}"),
+                    arch: "not in spec".to_string(),
+                })?;
+
+        fs::create_dir_all(self.blobs_dir(&entry.digest))?;
+        fs::create_dir_all(self.extracted_parent(&entry.digest))?;
+        fs::create_dir_all(self.locks_dir(&entry.digest))?;
+
+        let lock_path = self.lock_path(&entry.digest);
+        let lock = fs::OpenOptions::new()
+            .create(true)
+            .truncate(false)
+            .write(true)
+            .open(lock_path)?;
+        lock.lock_exclusive()?;
+
+        let result = self.provision_locked(spec, platform, entry).await;
+        let unlock_result = lock.unlock();
+        match (result, unlock_result) {
+            (Ok(path), Ok(())) => Ok(path),
+            (Err(err), _) => Err(err),
+            (Ok(_), Err(err)) => Err(ProvisionError::IoError(err)),
+        }
+    }
+
+    async fn provision_locked(
+        &self,
+        spec: &ToolSpec,
+        platform: Platform,
+        entry: &PlatformEntry,
+    ) -> Result<PathBuf, ProvisionError> {
+        if let Some(path) = self.lookup(entry) {
+            return Ok(path);
+        }
+
+        let blob = self.blob_path(&entry.digest);
+        if blob.is_file() && !verify_blob(&blob, entry)? {
+            fs::remove_file(&blob)?;
+        }
+        if !blob.is_file() {
+            fetch::fetch_verified_blob(entry, &blob).await?;
+        }
+
+        let extracted_dir = self.extracted_path(&entry.digest);
+        let temp_dir = tempfile::Builder::new()
+            .prefix("extract-")
+            .tempdir_in(self.extracted_parent(&entry.digest))?;
+
+        let executable = match entry.format {
+            ArtifactFormat::Plain => extract::install_plain(&blob, temp_dir.path(), &spec.name)?,
+            ArtifactFormat::TarGz => {
+                extract::extract_tar_gz(&blob, temp_dir.path())?;
+                resolve_archive_executable(temp_dir.path(), entry)?
+            }
+            ArtifactFormat::Zip => {
+                extract::extract_zip(&blob, temp_dir.path())?;
+                resolve_archive_executable(temp_dir.path(), entry)?
+            }
+        };
+        extract::make_executable(&executable)?;
+
+        let executable_path = executable.strip_prefix(temp_dir.path()).map_err(|e| {
+            ProvisionError::ExtractionFailed {
+                error: e.to_string(),
+            }
+        })?;
+        write_metadata(
+            temp_dir.path(),
+            &CacheMetadata {
+                name: spec.name.clone(),
+                version: spec.version.clone(),
+                platform,
+                digest: entry.digest.clone(),
+                executable_path: executable_path.to_path_buf(),
+                provisioned_at: current_timestamp(),
+            },
+        )?;
+
+        if extracted_dir.exists() {
+            fs::remove_dir_all(&extracted_dir)?;
+        }
+        let temp_path = temp_dir.keep();
+        fs::rename(&temp_path, &extracted_dir)?;
+
+        let executable = self
+            .lookup(entry)
+            .ok_or_else(|| ProvisionError::ExecutableMissing {
+                expected_path: extracted_dir.join(executable_path),
+            })?;
+        Ok(executable)
+    }
+
+    /// Scan installed cache entries.
+    ///
+    /// TF-CACHE-4: directories without valid metadata or executable are
+    /// ignored, so callers never receive anonymous digest directories as
+    /// inventory.
+    pub fn scan(&self) -> Vec<CachedArtifact> {
+        let mut artifacts = Vec::new();
+        let extracted = self.cache_dir.join("extracted");
+        let Ok(prefixes) = fs::read_dir(extracted) else {
+            return artifacts;
+        };
+
+        for prefix in prefixes.flatten() {
+            let Ok(entries) = fs::read_dir(prefix.path()) else {
+                continue;
+            };
+            for entry in entries.flatten() {
+                let Ok(metadata) = read_metadata(&entry.path()) else {
+                    continue;
+                };
+                if !is_safe_relative_path(&metadata.executable_path) {
+                    continue;
+                }
+                let executable = entry.path().join(&metadata.executable_path);
+                if executable.is_file() {
+                    artifacts.push(CachedArtifact {
+                        name: metadata.name,
+                        version: metadata.version,
+                        platform: metadata.platform,
+                        digest: metadata.digest,
+                        executable,
+                        provisioned_at: metadata.provisioned_at,
+                    });
+                }
+            }
+        }
+
+        artifacts
+    }
+
+    fn blob_path(&self, digest: &str) -> PathBuf {
+        self.blobs_dir(digest).join(digest)
+    }
+
+    fn blobs_dir(&self, digest: &str) -> PathBuf {
+        self.cache_dir.join("blobs").join(prefix(digest))
+    }
+
+    fn extracted_parent(&self, digest: &str) -> PathBuf {
+        self.cache_dir.join("extracted").join(prefix(digest))
+    }
+
+    fn extracted_path(&self, digest: &str) -> PathBuf {
+        self.extracted_parent(digest).join(digest)
+    }
+
+    fn locks_dir(&self, digest: &str) -> PathBuf {
+        self.cache_dir.join("locks").join(prefix(digest))
+    }
+
+    fn lock_path(&self, digest: &str) -> PathBuf {
+        self.locks_dir(digest).join(format!("{digest}.lock"))
+    }
+}
+
+impl Default for ToolCache {
+    /// Construct a cache rooted at [`ToolCache::default_dir`].
+    fn default() -> Self {
+        Self::new(Self::default_dir())
+    }
+}
+
+fn prefix(digest: &str) -> &str {
+    digest.get(..2).unwrap_or(digest)
+}
+
+fn resolve_archive_executable(
+    extracted_dir: &Path,
+    entry: &PlatformEntry,
+) -> Result<PathBuf, ProvisionError> {
+    let executable_path =
+        entry
+            .executable_path
+            .as_ref()
+            .ok_or_else(|| ProvisionError::ExecutableMissing {
+                expected_path: extracted_dir.join("<missing executable_path>"),
+            })?;
+    let executable = extracted_dir.join(executable_path);
+    if executable.is_file() {
+        Ok(executable)
+    } else {
+        Err(ProvisionError::ExecutableMissing {
+            expected_path: executable,
+        })
+    }
+}
+
+fn write_metadata(path: &Path, metadata: &CacheMetadata) -> Result<(), ProvisionError> {
+    let data = serde_json::to_vec_pretty(metadata)?;
+    fs::write(path.join(METADATA_FILE), data)?;
+    Ok(())
+}
+
+fn read_metadata(path: &Path) -> Result<CacheMetadata, ProvisionError> {
+    let data = fs::read(path.join(METADATA_FILE))?;
+    Ok(serde_json::from_slice(&data)?)
+}
+
+fn is_safe_relative_path(path: &Path) -> bool {
+    !path.is_absolute()
+        && path
+            .components()
+            .all(|component| matches!(component, Component::Normal(_) | Component::CurDir))
+}
+
+fn verify_blob(path: &Path, entry: &PlatformEntry) -> Result<bool, ProvisionError> {
+    let mut file = fs::File::open(path)?;
+    let mut hasher = Sha256::new();
+    let mut size = 0_u64;
+    let mut buffer = [0_u8; 8192];
+
+    loop {
+        let n = file.read(&mut buffer)?;
+        if n == 0 {
+            break;
+        }
+        size += n as u64;
+        hasher.update(&buffer[..n]);
+    }
+
+    if size != entry.size {
+        return Ok(false);
+    }
+    let actual = hex::encode(hasher.finalize());
+    Ok(actual.eq_ignore_ascii_case(&entry.digest))
+}
+
+fn current_timestamp() -> String {
+    use std::time::SystemTime;
+    use std::time::UNIX_EPOCH;
+
+    let duration = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default();
+    duration.as_secs().to_string()
+}

--- a/tool_fetch/src/error.rs
+++ b/tool_fetch/src/error.rs
@@ -1,0 +1,96 @@
+//! Structured provisioning errors.
+//!
+//! These errors form the boundary that future mesh/admin layers will
+//! map into operator-facing inventory states such as "unsupported
+//! platform", "hash mismatch", or "unsafe archive".
+//!
+//! # Invariants
+//!
+//! - **TF-ERR-1 (structured-failures):** Expected provisioning failure
+//!   classes have explicit variants rather than opaque strings.
+//! - **TF-ERR-2 (operator-context):** Variants carry the path, URL,
+//!   digest, or platform detail needed to explain the failure.
+
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+use std::path::PathBuf;
+
+/// Error returned while fetching, verifying, extracting, or resolving a tool.
+///
+/// TF-ERR-1: each variant is a stable failure class that higher layers
+/// can translate into mesh inventory state.
+#[derive(Debug, thiserror::Error)]
+pub enum ProvisionError {
+    /// The host OS/architecture pair has no supported platform mapping.
+    #[error("unsupported platform: {os}-{arch}")]
+    UnsupportedPlatform {
+        /// Runtime OS string from `std::env::consts::OS`, or a spec-selection
+        /// context string when no platform entry exists.
+        os: String,
+        /// Runtime architecture string from `std::env::consts::ARCH`, or
+        /// explanatory context when no platform entry exists.
+        arch: String,
+    },
+
+    /// Provider download failed or returned bytes with the wrong size.
+    #[error("download failed from {url}: {error}")]
+    DownloadFailed {
+        /// Provider URL that failed.
+        url: String,
+        /// Human-readable download or size error.
+        error: String,
+    },
+
+    /// Downloaded bytes did not match the expected digest.
+    #[error("hash mismatch: expected {expected}, actual {actual}")]
+    HashMismatch {
+        /// Expected hex digest from the spec.
+        expected: String,
+        /// Actual hex digest computed from downloaded bytes.
+        actual: String,
+    },
+
+    /// Archive extraction failed for an I/O or format reason.
+    #[error("extraction failed: {error}")]
+    ExtractionFailed {
+        /// Human-readable extraction error.
+        error: String,
+    },
+
+    /// Archive entry failed safety validation.
+    #[error("unsafe archive entry {path}: {reason}")]
+    UnsafeArchiveEntry {
+        /// Archive path that was rejected.
+        path: String,
+        /// Safety rule that rejected the path.
+        reason: String,
+    },
+
+    /// The expected executable path was not present after install/extract.
+    #[error("executable missing: {expected_path}")]
+    ExecutableMissing {
+        /// Fully qualified expected executable path.
+        expected_path: PathBuf,
+    },
+
+    /// A per-digest advisory lock could not be acquired.
+    #[error("lock contention for digest {digest}")]
+    LockContention {
+        /// Artifact digest whose lock could not be acquired.
+        digest: String,
+    },
+
+    /// Filesystem error.
+    #[error(transparent)]
+    IoError(#[from] std::io::Error),
+
+    /// Cache metadata JSON error.
+    #[error(transparent)]
+    JsonError(#[from] serde_json::Error),
+}

--- a/tool_fetch/src/extract.rs
+++ b/tool_fetch/src/extract.rs
@@ -1,0 +1,203 @@
+//! Safe archive extraction and plain-artifact installation.
+//!
+//! This module owns the filesystem safety boundary for archive
+//! contents. Fetching verifies artifact bytes; extraction ensures those
+//! bytes cannot write outside the intended install tree.
+//!
+//! # Invariants
+//!
+//! - **TF-EXTRACT-1 (archive-contained):** Every archive path is joined
+//!   through `safe_join`, rejecting absolute paths, roots/prefixes, and
+//!   `..`.
+//! - **TF-EXTRACT-2 (tar-links-rejected):** Tar symlinks and hardlinks
+//!   are rejected rather than followed.
+//! - **TF-EXTRACT-3 (zip-regular-only):** Zip extraction writes only
+//!   regular files and directories; symlink-like entries are rejected.
+//! - **TF-EXTRACT-4 (unix-executable):** Installed/resolved executables
+//!   get executable bits on Unix.
+
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+use std::fs;
+use std::io;
+use std::path::Component;
+use std::path::Path;
+use std::path::PathBuf;
+
+use crate::ProvisionError;
+
+fn safe_join(root: &Path, path: &Path) -> Result<PathBuf, ProvisionError> {
+    if path.is_absolute() {
+        return Err(ProvisionError::UnsafeArchiveEntry {
+            path: path.display().to_string(),
+            reason: "absolute paths are not allowed".to_string(),
+        });
+    }
+
+    let mut out = root.to_path_buf();
+    for component in path.components() {
+        match component {
+            Component::Normal(part) => out.push(part),
+            Component::CurDir => {}
+            Component::ParentDir => {
+                return Err(ProvisionError::UnsafeArchiveEntry {
+                    path: path.display().to_string(),
+                    reason: "parent directory traversal is not allowed".to_string(),
+                });
+            }
+            Component::Prefix(_) | Component::RootDir => {
+                return Err(ProvisionError::UnsafeArchiveEntry {
+                    path: path.display().to_string(),
+                    reason: "root or prefix components are not allowed".to_string(),
+                });
+            }
+        }
+    }
+    Ok(out)
+}
+
+/// Extract a gzip-compressed tar archive into `destination`.
+///
+/// Enforces TF-EXTRACT-1 and TF-EXTRACT-2.
+pub(crate) fn extract_tar_gz(blob: &Path, destination: &Path) -> Result<(), ProvisionError> {
+    let file = fs::File::open(blob)?;
+    let decoder = flate2::read::GzDecoder::new(file);
+    let mut archive = tar::Archive::new(decoder);
+
+    for entry in archive
+        .entries()
+        .map_err(|e| ProvisionError::ExtractionFailed {
+            error: e.to_string(),
+        })?
+    {
+        let mut entry = entry.map_err(|e| ProvisionError::ExtractionFailed {
+            error: e.to_string(),
+        })?;
+        let entry_type = entry.header().entry_type();
+        let path = entry.path().map_err(|e| ProvisionError::ExtractionFailed {
+            error: e.to_string(),
+        })?;
+        let path = path.as_ref().to_path_buf();
+
+        if entry_type.is_symlink() || entry_type.is_hard_link() {
+            return Err(ProvisionError::UnsafeArchiveEntry {
+                path: path.display().to_string(),
+                reason: "links are not allowed".to_string(),
+            });
+        }
+
+        let out = safe_join(destination, &path)?;
+        if entry_type.is_dir() {
+            fs::create_dir_all(&out)?;
+        } else if entry_type.is_file() {
+            if let Some(parent) = out.parent() {
+                fs::create_dir_all(parent)?;
+            }
+            let mut output = fs::File::create(&out)?;
+            io::copy(&mut entry, &mut output).map_err(|e| ProvisionError::ExtractionFailed {
+                error: e.to_string(),
+            })?;
+        } else {
+            return Err(ProvisionError::UnsafeArchiveEntry {
+                path: path.display().to_string(),
+                reason: format!("unsupported tar entry type {:?}", entry_type),
+            });
+        }
+    }
+
+    Ok(())
+}
+
+/// Extract a zip archive into `destination`.
+///
+/// Enforces TF-EXTRACT-1 and TF-EXTRACT-3.
+pub(crate) fn extract_zip(blob: &Path, destination: &Path) -> Result<(), ProvisionError> {
+    let file = fs::File::open(blob)?;
+    let mut archive = zip::ZipArchive::new(file).map_err(|e| ProvisionError::ExtractionFailed {
+        error: e.to_string(),
+    })?;
+
+    for i in 0..archive.len() {
+        let mut entry = archive
+            .by_index(i)
+            .map_err(|e| ProvisionError::ExtractionFailed {
+                error: e.to_string(),
+            })?;
+        let Some(enclosed_name) = entry.enclosed_name() else {
+            return Err(ProvisionError::UnsafeArchiveEntry {
+                path: entry.name().to_string(),
+                reason: "zip entry escapes extraction root".to_string(),
+            });
+        };
+        let out = safe_join(destination, &enclosed_name)?;
+
+        if is_zip_symlink(&entry) {
+            return Err(ProvisionError::UnsafeArchiveEntry {
+                path: entry.name().to_string(),
+                reason: "zip symlinks are not allowed".to_string(),
+            });
+        }
+
+        if entry.is_dir() {
+            fs::create_dir_all(&out)?;
+        } else if entry.is_file() {
+            if let Some(parent) = out.parent() {
+                fs::create_dir_all(parent)?;
+            }
+            let mut output = fs::File::create(&out)?;
+            io::copy(&mut entry, &mut output).map_err(|e| ProvisionError::ExtractionFailed {
+                error: e.to_string(),
+            })?;
+        } else {
+            return Err(ProvisionError::UnsafeArchiveEntry {
+                path: entry.name().to_string(),
+                reason: "zip entry is not a regular file or directory".to_string(),
+            });
+        }
+    }
+
+    Ok(())
+}
+
+fn is_zip_symlink(entry: &zip::read::ZipFile<'_>) -> bool {
+    entry
+        .unix_mode()
+        .is_some_and(|mode| (mode & 0o170000) == 0o120000)
+}
+
+/// Install a plain downloaded artifact as `bin/{name}`.
+///
+/// Enforces TF-CACHE-2 and TF-EXTRACT-4 for non-archive artifacts.
+pub(crate) fn install_plain(
+    blob: &Path,
+    destination: &Path,
+    name: &str,
+) -> Result<PathBuf, ProvisionError> {
+    let bin_dir = destination.join("bin");
+    fs::create_dir_all(&bin_dir)?;
+    let executable = bin_dir.join(name);
+    fs::copy(blob, &executable)?;
+    make_executable(&executable)?;
+    Ok(executable)
+}
+
+/// Mark `path` executable on Unix.
+///
+/// No-op on non-Unix platforms. Enforces TF-EXTRACT-4.
+pub(crate) fn make_executable(path: &Path) -> Result<(), ProvisionError> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+
+        let mut permissions = fs::metadata(path)?.permissions();
+        permissions.set_mode(permissions.mode() | 0o111);
+        fs::set_permissions(path, permissions)?;
+    }
+    Ok(())
+}

--- a/tool_fetch/src/fetch.rs
+++ b/tool_fetch/src/fetch.rs
@@ -1,0 +1,128 @@
+//! Provider download and byte verification.
+//!
+//! This module owns the trust transition from "bytes from a provider"
+//! to "verified blob that may be installed or extracted". Callers must
+//! not extract or execute artifacts until this module has verified size
+//! and digest.
+//!
+//! # Invariants
+//!
+//! - **TF-FETCH-1 (verify-before-use):** `fetch_verified_blob`
+//!   persists the destination only after size and digest verification.
+//! - **TF-FETCH-2 (downloaded-byte-hash):** SHA256 is computed over
+//!   the exact downloaded bytes.
+//! - **TF-FETCH-3 (provider-order):** Providers are tried in spec order
+//!   until one verifies successfully.
+//! - **TF-FETCH-4 (atomic-blob-placement):** Downloaded bytes are first
+//!   written to a temp file in the destination directory, then persisted
+//!   to the final blob path.
+
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+use std::io::Write;
+use std::path::Path;
+
+use sha2::Digest;
+use sha2::Sha256;
+
+use crate::HashAlgorithm;
+use crate::PlatformEntry;
+use crate::Provider;
+use crate::ProvisionError;
+
+/// Fetch and verify an artifact into `destination`.
+///
+/// TF-FETCH-1: success means `destination` exists and its bytes match
+/// the spec entry's size and digest.
+pub(crate) async fn fetch_verified_blob(
+    entry: &PlatformEntry,
+    destination: &Path,
+) -> Result<(), ProvisionError> {
+    let mut last_error = None;
+    for provider in &entry.providers {
+        match provider {
+            Provider::Http { url } => match fetch_http(entry, url, destination).await {
+                Ok(()) => return Ok(()),
+                Err(error) => last_error = Some(error),
+            },
+        }
+    }
+
+    Err(
+        last_error.unwrap_or_else(|| ProvisionError::DownloadFailed {
+            url: "<none>".to_string(),
+            error: "no providers configured".to_string(),
+        }),
+    )
+}
+
+async fn fetch_http(
+    entry: &PlatformEntry,
+    url: &str,
+    destination: &Path,
+) -> Result<(), ProvisionError> {
+    let response = reqwest::get(url)
+        .await
+        .map_err(|e| ProvisionError::DownloadFailed {
+            url: url.to_string(),
+            error: e.to_string(),
+        })?
+        .error_for_status()
+        .map_err(|e| ProvisionError::DownloadFailed {
+            url: url.to_string(),
+            error: e.to_string(),
+        })?;
+
+    let parent = destination
+        .parent()
+        .ok_or_else(|| ProvisionError::DownloadFailed {
+            url: url.to_string(),
+            error: format!("destination has no parent: {}", destination.display()),
+        })?;
+    std::fs::create_dir_all(parent)?;
+    let mut temp = tempfile::NamedTempFile::new_in(parent)?;
+    let mut hasher = Sha256::new();
+    let mut size = 0_u64;
+    let mut response = response;
+
+    while let Some(chunk) = response
+        .chunk()
+        .await
+        .map_err(|e| ProvisionError::DownloadFailed {
+            url: url.to_string(),
+            error: e.to_string(),
+        })?
+    {
+        size += chunk.len() as u64;
+        hasher.update(&chunk);
+        temp.write_all(&chunk)?;
+    }
+    temp.flush()?;
+
+    if size != entry.size {
+        return Err(ProvisionError::DownloadFailed {
+            url: url.to_string(),
+            error: format!("size mismatch: expected {}, actual {}", entry.size, size),
+        });
+    }
+
+    let actual = match entry.hash_algorithm {
+        HashAlgorithm::Sha256 => hex::encode(hasher.finalize()),
+    };
+    if !actual.eq_ignore_ascii_case(&entry.digest) {
+        return Err(ProvisionError::HashMismatch {
+            expected: entry.digest.clone(),
+            actual,
+        });
+    }
+
+    temp.persist(destination)
+        .map_err(|e| ProvisionError::IoError(e.error))?;
+    Ok(())
+}

--- a/tool_fetch/src/fetch.rs
+++ b/tool_fetch/src/fetch.rs
@@ -16,6 +16,8 @@
 //! - **TF-FETCH-4 (atomic-blob-placement):** Downloaded bytes are first
 //!   written to a temp file in the destination directory, then persisted
 //!   to the final blob path.
+//! - **TF-FETCH-5 (download-observability):** HTTP provider attempts
+//!   emit structured start/complete events, but never per-chunk events.
 
 /*
  * Copyright (c) Meta Platforms, Inc. and affiliates.
@@ -67,6 +69,19 @@ async fn fetch_http(
     url: &str,
     destination: &Path,
 ) -> Result<(), ProvisionError> {
+    tracing::info!(
+        name = "ToolFetchStatus",
+        status = "Download::Start",
+        message = %format!(
+            "download start: {} -> {}",
+            url,
+            destination.display(),
+        ),
+        url = %url,
+        expected_size = entry.size,
+        artifact_digest = %entry.digest,
+        destination = %destination.display(),
+    );
     let response = reqwest::get(url)
         .await
         .map_err(|e| ProvisionError::DownloadFailed {
@@ -124,5 +139,19 @@ async fn fetch_http(
 
     temp.persist(destination)
         .map_err(|e| ProvisionError::IoError(e.error))?;
+    tracing::info!(
+        name = "ToolFetchStatus",
+        status = "Download::Complete",
+        message = %format!(
+            "download complete: {} bytes={} -> {}",
+            url,
+            size,
+            destination.display(),
+        ),
+        url = %url,
+        actual_size = size,
+        artifact_digest = %entry.digest,
+        destination = %destination.display(),
+    );
     Ok(())
 }

--- a/tool_fetch/src/lib.rs
+++ b/tool_fetch/src/lib.rs
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+//! Verified fetch, cache, and install support for diagnostic tool artifacts.
+//!
+//! `tool_fetch` is the standalone substrate for Monarch's diagnostic
+//! capability plane: a declarative spec names an artifact, the cache
+//! fetches and verifies downloaded bytes, and callers receive a stable
+//! executable path that can be surfaced as mesh state by higher layers.
+//!
+//! # Invariant registry
+//!
+//! The module family uses `TF-*` labels for invariants that tests and
+//! higher-level mesh integrations can reference.
+//!
+//! ## Spec and platform invariants
+//!
+//! - **TF-SPEC-1 (spec-selects-platform):** Provisioning selects exactly
+//!   one [`PlatformEntry`] from a [`ToolSpec`] by [`Platform`]; callers do
+//!   not pass decomposed spec fields that can drift apart.
+//! - **TF-SPEC-2 (artifact-hash-contract):** `size`, `hash_algorithm`,
+//!   and `digest` describe the downloaded artifact bytes, not extracted
+//!   contents.
+//! - **TF-SPEC-3 (plain-has-no-inner-path):** Plain artifacts use
+//!   `executable_path = None` and are installed to `bin/{name}`.
+//! - **TF-PLAT-1 (known-platforms-only):** Runtime platform detection
+//!   returns one of the explicitly modeled [`Platform`] variants or a
+//!   structured unsupported-platform error.
+//!
+//! ## Fetch/cache invariants
+//!
+//! - **TF-FETCH-1 (verify-before-use):** Downloaded bytes are size- and
+//!   hash-verified before extraction or installation.
+//! - **TF-FETCH-2 (downloaded-byte-hash):** SHA256 is computed over the
+//!   downloaded bytes exactly as served by the provider.
+//! - **TF-CACHE-1 (content-addressed-blob):** Verified artifacts live at
+//!   `blobs/{digest[0..2]}/{digest}`.
+//! - **TF-CACHE-2 (executable-not-blob):** Resolved executables come from
+//!   the extracted/installed tree, never directly from `blobs/`.
+//! - **TF-CACHE-3 (cache-hit-no-download):** A complete verified install
+//!   is reused without contacting providers.
+//! - **TF-CACHE-4 (metadata-gates-scan):** `scan()` only reports
+//!   extracted directories with parseable `.tool-fetch-metadata.json` and
+//!   an existing executable.
+//! - **TF-CACHE-5 (blob-reverify):** Existing blobs are rechecked against
+//!   size and digest before reuse.
+//! - **TF-CACHE-6 (metadata-contained-path):** Cache metadata executable
+//!   paths must stay inside their extracted artifact directory.
+//! - **TF-CACHE-7 (managed-executable-runs):** The executable path
+//!   returned by provisioning is directly runnable by callers.
+//!
+//! ## Extraction invariants
+//!
+//! - **TF-EXTRACT-1 (archive-contained):** Archive entries must stay
+//!   within the extraction root.
+//! - **TF-EXTRACT-2 (tar-links-rejected):** Tar symlinks and hardlinks
+//!   are rejected rather than resolved.
+//! - **TF-EXTRACT-3 (zip-regular-only):** Zip extraction writes only
+//!   regular files and directories; symlink-like entries are rejected.
+//! - **TF-EXTRACT-4 (unix-executable):** Installed/resolved executables
+//!   are marked executable on Unix.
+//!
+//! ## Error invariants
+//!
+//! - **TF-ERR-1 (structured-failures):** Public failure modes are
+//!   represented by [`ProvisionError`] variants, preserving enough detail
+//!   for higher layers to map errors into operator-facing inventory.
+
+pub mod cache;
+pub mod error;
+pub mod extract;
+pub mod fetch;
+pub mod platform;
+pub mod spec;
+
+pub use cache::CachedArtifact;
+pub use cache::ToolCache;
+pub use error::ProvisionError;
+pub use platform::current_platform;
+pub use spec::ArtifactFormat;
+pub use spec::HashAlgorithm;
+pub use spec::Platform;
+pub use spec::PlatformEntry;
+pub use spec::Provider;
+pub use spec::ToolSpec;

--- a/tool_fetch/src/platform.rs
+++ b/tool_fetch/src/platform.rs
@@ -1,0 +1,41 @@
+//! Runtime platform detection for tool specs.
+//!
+//! Platform detection is deliberately small and explicit. The first
+//! spike supports the platform matrix needed for local macOS arm64
+//! development and Linux pickup at Meta; unsupported OS/architecture
+//! pairs fail as structured errors instead of guessing.
+//!
+//! # Invariants
+//!
+//! - **TF-PLAT-1 (known-platforms-only):** [`current_platform`]
+//!   returns an explicitly modeled [`crate::Platform`] or
+//!   [`crate::ProvisionError::UnsupportedPlatform`].
+//! - **TF-PLAT-2 (spec-key-alignment):** Returned platform variants
+//!   match the serde keys accepted by [`crate::ToolSpec`].
+
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+use crate::Platform;
+use crate::ProvisionError;
+
+/// Detect the current host platform.
+///
+/// TF-PLAT-1: only explicitly supported platforms are returned.
+pub fn current_platform() -> Result<Platform, ProvisionError> {
+    match (std::env::consts::OS, std::env::consts::ARCH) {
+        ("linux", "x86_64") => Ok(Platform::LinuxX86_64),
+        ("linux", "aarch64") => Ok(Platform::LinuxAarch64),
+        ("macos", "x86_64") => Ok(Platform::MacosX86_64),
+        ("macos", "aarch64") => Ok(Platform::MacosAarch64),
+        (os, arch) => Err(ProvisionError::UnsupportedPlatform {
+            os: os.to_string(),
+            arch: arch.to_string(),
+        }),
+    }
+}

--- a/tool_fetch/src/spec.rs
+++ b/tool_fetch/src/spec.rs
@@ -1,0 +1,112 @@
+//! Declarative tool specification types.
+//!
+//! Specs are data: they describe what artifact should exist for each
+//! platform and how to verify it. They do not encode Monarch behavior.
+//!
+//! # Invariants
+//!
+//! - **TF-SPEC-1 (spec-selects-platform):** [`ToolSpec::platforms`]
+//!   is the only place a platform artifact is selected from a spec.
+//! - **TF-SPEC-2 (artifact-hash-contract):** [`PlatformEntry::size`],
+//!   [`PlatformEntry::hash_algorithm`], and [`PlatformEntry::digest`]
+//!   describe downloaded bytes.
+//! - **TF-SPEC-3 (plain-has-no-inner-path):** [`ArtifactFormat::Plain`]
+//!   entries use `None` for [`PlatformEntry::executable_path`].
+
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+use serde::Deserialize;
+use serde::Serialize;
+
+/// Declarative description of a single tool version.
+///
+/// A `ToolSpec` is intentionally independent of Monarch actor types so
+/// the fetch/verify/cache layer can remain reusable.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ToolSpec {
+    /// Stable tool name used by inventory and resolution, e.g. `py-spy`.
+    pub name: String,
+    /// Tool version string shown to operators and stored in cache metadata.
+    pub version: String,
+    /// Per-platform artifact entries keyed by the normalized platform.
+    ///
+    /// TF-SPEC-1: provisioning selects from this map using the target
+    /// [`Platform`].
+    pub platforms: HashMap<Platform, PlatformEntry>,
+}
+
+/// Artifact metadata and providers for one platform.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PlatformEntry {
+    /// Size of the downloaded artifact in bytes.
+    ///
+    /// TF-SPEC-2: this is the compressed/downloaded size for archive
+    /// formats, not the extracted size.
+    pub size: u64,
+    /// Hash algorithm used to verify the downloaded artifact bytes.
+    pub hash_algorithm: HashAlgorithm,
+    /// Hex digest of the downloaded artifact bytes.
+    pub digest: String,
+    /// Artifact container format.
+    pub format: ArtifactFormat,
+    /// Path to the executable inside the extracted tree.
+    ///
+    /// TF-SPEC-3: `None` is valid only for [`ArtifactFormat::Plain`],
+    /// which installs to `bin/{ToolSpec::name}`.
+    pub executable_path: Option<PathBuf>,
+    /// Download providers tried in order.
+    pub providers: Vec<Provider>,
+}
+
+/// Artifact source.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum Provider {
+    /// HTTP(S) URL for the artifact bytes.
+    Http { url: String },
+}
+
+/// Normalized platform keys supported by the first spike.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum Platform {
+    /// Linux on x86_64.
+    #[serde(rename = "linux-x86_64")]
+    LinuxX86_64,
+    /// Linux on AArch64.
+    #[serde(rename = "linux-aarch64")]
+    LinuxAarch64,
+    /// macOS on x86_64.
+    #[serde(rename = "macos-x86_64")]
+    MacosX86_64,
+    /// macOS on Apple Silicon / AArch64.
+    #[serde(rename = "macos-aarch64")]
+    MacosAarch64,
+}
+
+/// Supported artifact hash algorithms.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum HashAlgorithm {
+    /// SHA-256 over downloaded artifact bytes.
+    Sha256,
+}
+
+/// Supported artifact container/install formats.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum ArtifactFormat {
+    /// Downloaded bytes are the executable artifact.
+    Plain,
+    /// Gzip-compressed tar archive.
+    TarGz,
+    /// Zip archive, including Python wheels.
+    Zip,
+}

--- a/tool_fetch/tests/provision_test.rs
+++ b/tool_fetch/tests/provision_test.rs
@@ -1,0 +1,491 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+use std::collections::HashMap;
+use std::io::Write;
+use std::path::Path;
+use std::sync::Arc;
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering;
+
+use flate2::Compression;
+use flate2::write::GzEncoder;
+use sha2::Digest;
+use sha2::Sha256;
+use tempfile::TempDir;
+use tokio::io::AsyncReadExt;
+use tokio::io::AsyncWriteExt;
+use tokio::net::TcpListener;
+use tool_fetch::ArtifactFormat;
+use tool_fetch::HashAlgorithm;
+use tool_fetch::Platform;
+use tool_fetch::PlatformEntry;
+use tool_fetch::Provider;
+use tool_fetch::ProvisionError;
+use tool_fetch::ToolCache;
+use tool_fetch::ToolSpec;
+use tool_fetch::current_platform;
+
+fn digest(bytes: &[u8]) -> String {
+    hex::encode(Sha256::digest(bytes))
+}
+
+fn spec_for(
+    format: ArtifactFormat,
+    bytes: &[u8],
+    executable_path: Option<&str>,
+    url: String,
+) -> ToolSpec {
+    ToolSpec {
+        name: "demo-tool".to_string(),
+        version: "1.0.0".to_string(),
+        platforms: HashMap::from([(
+            Platform::MacosAarch64,
+            PlatformEntry {
+                size: bytes.len() as u64,
+                hash_algorithm: HashAlgorithm::Sha256,
+                digest: digest(bytes),
+                format,
+                executable_path: executable_path.map(Into::into),
+                providers: vec![Provider::Http { url }],
+            },
+        )]),
+    }
+}
+
+async fn serve_bytes(bytes: Vec<u8>) -> (String, Arc<AtomicUsize>) {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let requests = Arc::new(AtomicUsize::new(0));
+    let request_count = requests.clone();
+
+    tokio::spawn(async move {
+        loop {
+            let Ok((mut socket, _)) = listener.accept().await else {
+                break;
+            };
+            request_count.fetch_add(1, Ordering::SeqCst);
+            let bytes = bytes.clone();
+            tokio::spawn(async move {
+                let mut buffer = [0_u8; 1024];
+                let _ = socket.read(&mut buffer).await;
+                let headers = format!(
+                    "HTTP/1.1 200 OK\r\ncontent-length: {}\r\nconnection: close\r\n\r\n",
+                    bytes.len()
+                );
+                socket.write_all(headers.as_bytes()).await.unwrap();
+                socket.write_all(&bytes).await.unwrap();
+            });
+        }
+    });
+
+    (format!("http://{addr}/artifact"), requests)
+}
+
+fn tar_gz(entries: &[(&str, &[u8])]) -> Vec<u8> {
+    let mut tar_bytes = Vec::new();
+    {
+        let mut builder = tar::Builder::new(&mut tar_bytes);
+        for (path, data) in entries {
+            let mut header = tar::Header::new_gnu();
+            header.set_path(path).unwrap();
+            header.set_size(data.len() as u64);
+            header.set_mode(0o755);
+            header.set_cksum();
+            builder.append(&header, *data).unwrap();
+        }
+        builder.finish().unwrap();
+    }
+
+    let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
+    encoder.write_all(&tar_bytes).unwrap();
+    encoder.finish().unwrap()
+}
+
+fn malicious_tar_symlink() -> Vec<u8> {
+    let mut tar_bytes = Vec::new();
+    {
+        let mut builder = tar::Builder::new(&mut tar_bytes);
+        let mut header = tar::Header::new_gnu();
+        header.set_entry_type(tar::EntryType::Symlink);
+        header.set_path("link").unwrap();
+        header.set_link_name("../outside").unwrap();
+        header.set_size(0);
+        header.set_cksum();
+        builder.append(&header, std::io::empty()).unwrap();
+        builder.finish().unwrap();
+    }
+
+    let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
+    encoder.write_all(&tar_bytes).unwrap();
+    encoder.finish().unwrap()
+}
+
+fn raw_tar_gz(path: &str, data: &[u8]) -> Vec<u8> {
+    let mut tar_bytes = Vec::new();
+    let mut header = [0_u8; 512];
+    let path_bytes = path.as_bytes();
+    header[..path_bytes.len()].copy_from_slice(path_bytes);
+    header[100..108].copy_from_slice(b"0000755\0");
+    header[108..116].copy_from_slice(b"0000000\0");
+    header[116..124].copy_from_slice(b"0000000\0");
+    let size = format!("{:011o}\0", data.len());
+    header[124..136].copy_from_slice(size.as_bytes());
+    header[136..148].copy_from_slice(b"00000000000\0");
+    header[148..156].fill(b' ');
+    header[156] = b'0';
+    header[257..263].copy_from_slice(b"ustar\0");
+    header[263..265].copy_from_slice(b"00");
+    let checksum: u32 = header.iter().map(|b| *b as u32).sum();
+    let checksum = format!("{:06o}\0 ", checksum);
+    header[148..156].copy_from_slice(checksum.as_bytes());
+
+    tar_bytes.extend_from_slice(&header);
+    tar_bytes.extend_from_slice(data);
+    let padding = (512 - (data.len() % 512)) % 512;
+    tar_bytes.extend(std::iter::repeat_n(0, padding));
+    tar_bytes.extend([0_u8; 1024]);
+
+    let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
+    encoder.write_all(&tar_bytes).unwrap();
+    encoder.finish().unwrap()
+}
+
+fn zip(entries: &[(&str, &[u8])]) -> Vec<u8> {
+    let cursor = std::io::Cursor::new(Vec::new());
+    let mut writer = zip::ZipWriter::new(cursor);
+    let options = zip::write::SimpleFileOptions::default().unix_permissions(0o755);
+    for (path, data) in entries {
+        writer.start_file(path, options).unwrap();
+        writer.write_all(data).unwrap();
+    }
+    writer.finish().unwrap().into_inner()
+}
+
+fn assert_executable(path: &Path) {
+    assert!(path.is_file());
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        assert_ne!(
+            std::fs::metadata(path).unwrap().permissions().mode() & 0o111,
+            0
+        );
+    }
+}
+
+#[tokio::test]
+async fn parses_bundled_pyspy_spec() {
+    // TF-SPEC-1, TF-PLAT-2: bundled specs deserialize into normalized
+    // platform keys used by provision().
+    let spec: ToolSpec = serde_json::from_str(include_str!("../specs/py-spy.json")).unwrap();
+    assert_eq!(spec.name, "py-spy");
+    assert_eq!(spec.version, "0.4.1");
+    assert!(spec.platforms.contains_key(&Platform::MacosAarch64));
+    assert!(spec.platforms.contains_key(&Platform::LinuxX86_64));
+}
+
+#[tokio::test]
+async fn provision_tar_gz_extracts_and_resolves() {
+    // TF-FETCH-1, TF-CACHE-2, TF-EXTRACT-1, TF-EXTRACT-4.
+    let artifact = tar_gz(&[("bin/demo-tool", b"#!/bin/sh\n")]);
+    let (url, _) = serve_bytes(artifact.clone()).await;
+    let spec = spec_for(ArtifactFormat::TarGz, &artifact, Some("bin/demo-tool"), url);
+    let temp = TempDir::new().unwrap();
+    let cache = ToolCache::new(temp.path());
+
+    let executable = cache
+        .provision(&spec, Platform::MacosAarch64)
+        .await
+        .unwrap();
+
+    assert!(executable.ends_with("bin/demo-tool"));
+    assert_executable(&executable);
+}
+
+#[tokio::test]
+async fn provision_zip_extracts_and_resolves() {
+    // TF-FETCH-1, TF-CACHE-2, TF-EXTRACT-1, TF-EXTRACT-3, TF-EXTRACT-4.
+    let artifact = zip(&[("bundle/bin/demo-tool", b"#!/bin/sh\n")]);
+    let (url, _) = serve_bytes(artifact.clone()).await;
+    let spec = spec_for(
+        ArtifactFormat::Zip,
+        &artifact,
+        Some("bundle/bin/demo-tool"),
+        url,
+    );
+    let temp = TempDir::new().unwrap();
+    let cache = ToolCache::new(temp.path());
+
+    let executable = cache
+        .provision(&spec, Platform::MacosAarch64)
+        .await
+        .unwrap();
+
+    assert!(executable.ends_with("bundle/bin/demo-tool"));
+    assert_executable(&executable);
+}
+
+#[tokio::test]
+async fn provision_plain_installs_to_bin() {
+    // TF-SPEC-3, TF-CACHE-2, TF-EXTRACT-4: plain artifacts install to
+    // extracted/.../bin/{name}; blobs are not returned as executables.
+    let artifact = b"#!/bin/sh\n".to_vec();
+    let (url, _) = serve_bytes(artifact.clone()).await;
+    let spec = spec_for(ArtifactFormat::Plain, &artifact, None, url);
+    let temp = TempDir::new().unwrap();
+    let cache = ToolCache::new(temp.path());
+
+    let executable = cache
+        .provision(&spec, Platform::MacosAarch64)
+        .await
+        .unwrap();
+
+    assert!(executable.ends_with("bin/demo-tool"));
+    assert_executable(&executable);
+}
+
+#[tokio::test]
+async fn provision_plain_managed_executable_runs() {
+    // TF-CACHE-2, TF-CACHE-7, TF-EXTRACT-4: the returned path is the
+    // managed executable under extracted/ and can be executed directly.
+    let artifact = b"#!/bin/sh\nprintf 'managed:%s\\n' \"$1\"\n".to_vec();
+    let (url, _) = serve_bytes(artifact.clone()).await;
+    let spec = spec_for(ArtifactFormat::Plain, &artifact, None, url);
+    let temp = TempDir::new().unwrap();
+    let cache = ToolCache::new(temp.path());
+
+    let executable = cache
+        .provision(&spec, Platform::MacosAarch64)
+        .await
+        .unwrap();
+    let output = tokio::process::Command::new(&executable)
+        .arg("ok")
+        .output()
+        .await
+        .unwrap();
+
+    assert!(output.status.success());
+    assert_eq!(String::from_utf8_lossy(&output.stdout), "managed:ok\n");
+}
+
+#[tokio::test]
+async fn cache_hit_does_not_redownload() {
+    // TF-CACHE-3: second provision resolves from metadata/extracted
+    // state without contacting the provider.
+    let artifact = zip(&[("bin/demo-tool", b"#!/bin/sh\n")]);
+    let (url, requests) = serve_bytes(artifact.clone()).await;
+    let spec = spec_for(ArtifactFormat::Zip, &artifact, Some("bin/demo-tool"), url);
+    let temp = TempDir::new().unwrap();
+    let cache = ToolCache::new(temp.path());
+
+    let first = cache
+        .provision(&spec, Platform::MacosAarch64)
+        .await
+        .unwrap();
+    let second = cache
+        .provision(&spec, Platform::MacosAarch64)
+        .await
+        .unwrap();
+
+    assert_eq!(first, second);
+    assert_eq!(requests.load(Ordering::SeqCst), 1);
+}
+
+#[tokio::test]
+async fn hash_mismatch_rejects_download() {
+    // TF-FETCH-1, TF-FETCH-2: same-sized wrong bytes fail digest
+    // verification before install/extract.
+    let artifact = b"AAAA".to_vec();
+    let (url, _) = serve_bytes(artifact).await;
+    let declared = b"BBBB".to_vec();
+    let spec = spec_for(ArtifactFormat::Plain, &declared, None, url);
+    let temp = TempDir::new().unwrap();
+    let cache = ToolCache::new(temp.path());
+
+    let error = cache
+        .provision(&spec, Platform::MacosAarch64)
+        .await
+        .unwrap_err();
+
+    assert!(matches!(error, ProvisionError::HashMismatch { .. }));
+}
+
+#[tokio::test]
+async fn missing_executable_path_errors() {
+    // TF-ERR-1: archive succeeds but missing executable maps to the
+    // structured ExecutableMissing variant.
+    let artifact = zip(&[("bin/other", b"#!/bin/sh\n")]);
+    let (url, _) = serve_bytes(artifact.clone()).await;
+    let spec = spec_for(ArtifactFormat::Zip, &artifact, Some("bin/demo-tool"), url);
+    let temp = TempDir::new().unwrap();
+    let cache = ToolCache::new(temp.path());
+
+    let error = cache
+        .provision(&spec, Platform::MacosAarch64)
+        .await
+        .unwrap_err();
+
+    assert!(matches!(error, ProvisionError::ExecutableMissing { .. }));
+}
+
+#[tokio::test]
+async fn malicious_tar_absolute_path_rejected() {
+    // TF-EXTRACT-1: absolute tar paths cannot escape the extraction root.
+    let artifact = raw_tar_gz("/tmp/evil", b"bad");
+    let (url, _) = serve_bytes(artifact.clone()).await;
+    let spec = spec_for(ArtifactFormat::TarGz, &artifact, Some("tmp/evil"), url);
+    let temp = TempDir::new().unwrap();
+    let cache = ToolCache::new(temp.path());
+
+    let error = cache
+        .provision(&spec, Platform::MacosAarch64)
+        .await
+        .unwrap_err();
+
+    assert!(matches!(error, ProvisionError::UnsafeArchiveEntry { .. }));
+}
+
+#[tokio::test]
+async fn malicious_tar_parent_traversal_rejected() {
+    // TF-EXTRACT-1: parent traversal is rejected before writing.
+    let artifact = raw_tar_gz("../evil", b"bad");
+    let (url, _) = serve_bytes(artifact.clone()).await;
+    let spec = spec_for(ArtifactFormat::TarGz, &artifact, Some("evil"), url);
+    let temp = TempDir::new().unwrap();
+    let cache = ToolCache::new(temp.path());
+
+    let error = cache
+        .provision(&spec, Platform::MacosAarch64)
+        .await
+        .unwrap_err();
+
+    assert!(matches!(error, ProvisionError::UnsafeArchiveEntry { .. }));
+}
+
+#[tokio::test]
+async fn malicious_tar_symlink_rejected() {
+    // TF-EXTRACT-2: tar links are rejected instead of resolved.
+    let artifact = malicious_tar_symlink();
+    let (url, _) = serve_bytes(artifact.clone()).await;
+    let spec = spec_for(ArtifactFormat::TarGz, &artifact, Some("link"), url);
+    let temp = TempDir::new().unwrap();
+    let cache = ToolCache::new(temp.path());
+
+    let error = cache
+        .provision(&spec, Platform::MacosAarch64)
+        .await
+        .unwrap_err();
+
+    assert!(matches!(error, ProvisionError::UnsafeArchiveEntry { .. }));
+}
+
+#[tokio::test]
+async fn malicious_zip_parent_traversal_rejected() {
+    // TF-EXTRACT-1, TF-EXTRACT-3: zip paths are constrained to the
+    // extraction root.
+    let artifact = zip(&[("../evil", b"bad")]);
+    let (url, _) = serve_bytes(artifact.clone()).await;
+    let spec = spec_for(ArtifactFormat::Zip, &artifact, Some("evil"), url);
+    let temp = TempDir::new().unwrap();
+    let cache = ToolCache::new(temp.path());
+
+    let error = cache
+        .provision(&spec, Platform::MacosAarch64)
+        .await
+        .unwrap_err();
+
+    assert!(matches!(error, ProvisionError::UnsafeArchiveEntry { .. }));
+}
+
+#[tokio::test]
+async fn metadata_sidecar_and_scan_work() {
+    // TF-CACHE-4: scan reports only metadata-backed installs with an
+    // existing executable.
+    let artifact = zip(&[("bin/demo-tool", b"#!/bin/sh\n")]);
+    let (url, _) = serve_bytes(artifact.clone()).await;
+    let spec = spec_for(ArtifactFormat::Zip, &artifact, Some("bin/demo-tool"), url);
+    let temp = TempDir::new().unwrap();
+    let cache = ToolCache::new(temp.path());
+
+    let executable = cache
+        .provision(&spec, Platform::MacosAarch64)
+        .await
+        .unwrap();
+    let artifacts = cache.scan();
+
+    assert_eq!(artifacts.len(), 1);
+    assert_eq!(artifacts[0].name, "demo-tool");
+    assert_eq!(artifacts[0].version, "1.0.0");
+    assert_eq!(artifacts[0].platform, Platform::MacosAarch64);
+    assert_eq!(artifacts[0].executable, executable);
+}
+
+#[tokio::test]
+async fn metadata_executable_path_must_stay_inside_extracted_tree() {
+    // TF-CACHE-6: metadata cannot redirect lookup/scan to an
+    // executable outside the managed extraction directory.
+    let artifact = zip(&[("bin/demo-tool", b"#!/bin/sh\n")]);
+    let (url, _) = serve_bytes(artifact.clone()).await;
+    let spec = spec_for(ArtifactFormat::Zip, &artifact, Some("bin/demo-tool"), url);
+    let entry = spec.platforms.get(&Platform::MacosAarch64).unwrap();
+    let temp = TempDir::new().unwrap();
+    let cache = ToolCache::new(temp.path());
+
+    cache
+        .provision(&spec, Platform::MacosAarch64)
+        .await
+        .unwrap();
+    let metadata_path = temp
+        .path()
+        .join("extracted")
+        .join(&entry.digest[..2])
+        .join(&entry.digest)
+        .join(".tool-fetch-metadata.json");
+    let mut metadata: serde_json::Value =
+        serde_json::from_slice(&std::fs::read(&metadata_path).unwrap()).unwrap();
+    metadata["executable_path"] = serde_json::Value::String("/bin/sh".to_string());
+    std::fs::write(
+        &metadata_path,
+        serde_json::to_vec_pretty(&metadata).unwrap(),
+    )
+    .unwrap();
+
+    assert_eq!(cache.lookup(entry), None);
+    assert!(cache.scan().is_empty());
+}
+
+#[tokio::test]
+#[ignore = "downloads the real py-spy wheel for the current platform"]
+async fn provision_real_pyspy_and_run_version() {
+    // End-to-end capstone for TF-FETCH-1, TF-CACHE-2, TF-EXTRACT-3,
+    // and TF-EXTRACT-4 against the real py-spy wheel for this host.
+    let spec: ToolSpec = serde_json::from_str(include_str!("../specs/py-spy.json")).unwrap();
+    let platform = current_platform().unwrap();
+    if !spec.platforms.contains_key(&platform) {
+        eprintln!("skipping: bundled py-spy spec has no entry for {platform:?}");
+        return;
+    }
+
+    let temp = TempDir::new().unwrap();
+    let cache = ToolCache::new(temp.path());
+    let executable = cache.provision(&spec, platform).await.unwrap();
+    let output = tokio::process::Command::new(&executable)
+        .arg("--version")
+        .output()
+        .await
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "py-spy --version failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("py-spy 0.4.1"), "stdout was {stdout:?}");
+}


### PR DESCRIPTION
## summary

this adds a host-local diagnostic tool provisioning plane and wires py-spy through it as the first vertical spike.

the new `tool_fetch` crate is the standalone substrate. it reads declarative tool specs, downloads artifacts over HTTP, verifies size and sha256, stores verified blobs in a content-addressed cache, safely extracts `tar.gz` and `zip` artifacts, and returns a runnable executable path. it has no dependencies on Monarch actor or mesh crates.

`hyperactor_mesh` now has a per-host `ToolProvisionActor`, spawned by `HostAgent`, with messages to provision a tool, resolve a registered tool, and query inventory. mesh admin exposes that through `/v1/tools/{host}` and `/v1/tools_provision/{host}`.

py-spy now uses this plane on the service proc path. `HostAgent` resolves a managed `py-spy` first, then falls back to `PYSPY_BIN`, then falls back to `py-spy` on `PATH`. existing proc-agent py-spy behavior remains compatible.

mesh-admin now has the operator recovery path for the common missing-binary case. when service-proc py-spy reports that the binary is missing, the TUI keeps the failure context visible and offers `P` to provision the managed py-spy artifact on that host. provisioning status is appended in place. on success, the overlay shows the resolved executable and prompts `p` to retry the dump.

the immediate win is that operators can move from "hope py-spy is installed on the host" to "provision a pinned, verified py-spy artifact and run that managed executable." the bundled `py-spy 0.4.1` spec covers macos-aarch64 and linux-x86_64 wheels from PyPI.

the cache is durable across TUI restarts. after provisioning once, restarting mesh-admin can still resolve and use the host-local managed executable from the tool cache.

## test plan

`cargo test -p tool_fetch`

`cargo test -p hyperactor_mesh tool_provision --lib`

`cargo test -p hyperactor_mesh managed_pyspy_dump_uses_provisioned_executable --lib`

`cargo test -p hyperactor_mesh managed_candidate_precedes_legacy_fallbacks --lib`

`cargo test -p hyperactor_mesh_admin_tui_lib`

`cargo check -p hyperactor_mesh`

`cargo test -p tool_fetch provision_real_pyspy_and_run_version -- --ignored`

`cargo test -p hyperactor_mesh provision_real_pyspy_through_mesh_admin_and_run_version --lib -- --ignored`

manual: launched mesh-admin with py-spy absent from `PATH`, used the service-proc missing-binary overlay to provision managed py-spy, retried the dump, restarted the TUI, retried again, and confirmed the restarted TUI resolved the cached managed executable.

manual workflow screenshot: service-proc py-spy reported a missing binary, `P` provisioned managed py-spy, and the TUI showed the resolved cache executable with `p` to retry.

![managed py-spy provisioned in mesh-admin](https://github.com/user-attachments/assets/1d9f3a35-a938-4f92-aba2-17a5bce2e164)

manual evidence screenshot: the tool provisioner flight recorder shows the PyPI wheel URL, verified byte count, cache blob path, and extraction path during first provision.

![tool provisioner flight recorder showing py-spy download and cache steps](https://github.com/user-attachments/assets/b490ee6b-1465-4a47-b763-feedf5300920)

note: `cargo clippy -p hyperactor_mesh --lib -- -D warnings` is currently blocked by pre-existing warnings in upstream workspace crates before it reaches this diff. `cargo clippy -p tool_fetch --all-targets -- -D warnings` passes.
