### PR TITLE
factor RDMA test helpers and drop oss_skip (#3608)

### DIFF
--- a/hyperactor/example/pingpong.rs
+++ b/hyperactor/example/pingpong.rs
@@ -292,7 +292,9 @@ async fn run_local_duplex(
         }
     });
 
-    let (client_tx, mut client_rx) = duplex::dial::<Message, Message>(server_addr.clone()).unwrap();
+    let mut client = duplex::dial::<Message, Message>(server_addr.clone()).unwrap();
+    let client_tx = client.tx();
+    let mut client_rx = client.take_rx().unwrap();
 
     println!("Client connected to {server_addr} (duplex)");
 
@@ -352,6 +354,11 @@ async fn run_local_duplex(
     println!("Total bytes transferred: {total_bytes} bytes");
     println!("Bandwidth: {bw_bps:.0} bytes/sec ({bw_mbps:.2} Mbps)");
 
+    // Gracefully shut the dial-side recv/send loop down via the
+    // structured-concurrency join. The application's `client_tx` /
+    // `client_rx` halves stay alive but become dead handles after
+    // the spawn task drops its peer ends.
+    client.join().await;
     server_handle.abort();
     Ok(())
 }
@@ -372,7 +379,9 @@ async fn bench_ping_pong_duplex(
         }
     });
 
-    let (client_tx, mut client_rx) = duplex::dial::<Message, Message>(server_addr).unwrap();
+    let mut client = duplex::dial::<Message, Message>(server_addr).unwrap();
+    let client_tx = client.tx();
+    let mut client_rx = client.take_rx().unwrap();
 
     let message = Message::Echo(serde_multipart::Part::from(vec![0u8; message_size]));
 
@@ -389,6 +398,7 @@ async fn bench_ping_pong_duplex(
     }
     let elapsed = start.elapsed();
 
+    client.join().await;
     server_handle.abort();
     Ok(elapsed)
 }

--- a/hyperactor/src/channel.rs
+++ b/hyperactor/src/channel.rs
@@ -44,6 +44,7 @@ pub use net::try_tls_pem_bundle;
 
 /// Duplex channel API: a single connection carries messages in both directions.
 pub mod duplex {
+    pub use super::net::duplex::DuplexClient;
     pub use super::net::duplex::DuplexRx;
     pub use super::net::duplex::DuplexServer;
     pub use super::net::duplex::DuplexTx;

--- a/hyperactor/src/channel/net.rs
+++ b/hyperactor/src/channel/net.rs
@@ -47,7 +47,6 @@
 //!   when EOF occurs exactly on a frame boundary. If EOF happens
 //!   mid-frame, it returns `Err(io::ErrorKind::UnexpectedEof)`.
 
-use std::collections::VecDeque;
 use std::fmt;
 use std::fmt::Debug;
 use std::net::ToSocketAddrs;
@@ -172,7 +171,7 @@ pub(crate) trait Link: Send + Sync + Debug + 'static {
 
     /// Acquire the next usable connection. For initiator links this
     /// dials; for acceptor links this waits on a dispatch channel.
-    async fn next(&self) -> Result<Self::Stream, ClientError>;
+    async fn next(&mut self) -> Result<Self::Stream, ClientError>;
 }
 
 use session::Session;
@@ -735,7 +734,7 @@ impl Link for NetLink {
         }
     }
 
-    async fn next(&self) -> Result<Box<dyn Stream>, ClientError> {
+    async fn next(&mut self) -> Result<Box<dyn Stream>, ClientError> {
         match self {
             Self::Tcp(l) => Ok(Box::new(l.next().await?)),
             Self::Unix(l) => Ok(Box::new(l.next().await?)),
@@ -1079,7 +1078,7 @@ pub(crate) mod unix {
             self.session_id
         }
 
-        async fn next(&self) -> Result<Self::Stream, ClientError> {
+        async fn next(&mut self) -> Result<Self::Stream, ClientError> {
             let session_id = self.session_id;
             let sock_addr = match &self.addr {
                 SocketAddr::Bound(a) => a,
@@ -1372,7 +1371,7 @@ pub(crate) mod tcp {
             self.session_id
         }
 
-        async fn next(&self) -> Result<Self::Stream, ClientError> {
+        async fn next(&mut self) -> Result<Self::Stream, ClientError> {
             let session_id = self.session_id;
             let mut backoff = ExponentialBackoffBuilder::new()
                 .with_initial_interval(Duration::from_millis(1))
@@ -1756,7 +1755,7 @@ pub(crate) mod tls {
             self.session_id
         }
 
-        async fn next(&self) -> Result<Self::Stream, ClientError> {
+        async fn next(&mut self) -> Result<Self::Stream, ClientError> {
             let session_id = self.session_id;
             let server_name = ServerName::try_from(self.hostname.clone()).map_err(|e| {
                 ClientError::Connect(
@@ -2612,7 +2611,7 @@ mod tests {
             self.session_id
         }
 
-        async fn next(&self) -> Result<Self::Stream, ClientError> {
+        async fn next(&mut self) -> Result<Self::Stream, ClientError> {
             let session_id = self.session_id;
             tracing::debug!("MockLink starts to connect.");
             if self.fail_connects.load(Ordering::Acquire) {
@@ -2806,22 +2805,22 @@ mod tests {
     }
 
     /// Create an AcceptorLink-based server test rig. Returns the
-    /// session task handle, an MVar for dispatching streams,
-    /// the message receiver, and a cancellation token.
+    /// session task handle, the channel sender for dispatching
+    /// streams, the message receiver, and a cancellation token.
     fn serve_acceptor_test<M: RemoteMessage>(
         session_id: SessionId,
     ) -> (
         JoinHandle<()>,
-        crate::sync::mvar::MVar<DuplexStream>,
+        mpsc::UnboundedSender<DuplexStream>,
         mpsc::Receiver<M>,
         CancellationToken,
     ) {
-        let mvar = crate::sync::mvar::MVar::empty();
+        let (acceptor_tx, acceptor_rx) = mpsc::unbounded_channel::<DuplexStream>();
         let cancel_token = CancellationToken::new();
         let link = AcceptorLink {
             dest: ChannelAddr::Local(u64::MAX),
             session_id,
-            stream: mvar.clone(),
+            stream: acceptor_rx,
             cancel: cancel_token.clone(),
         };
         let (tx, rx) = mpsc::channel::<M>(1024);
@@ -2885,7 +2884,7 @@ mod tests {
                 break;
             }
         });
-        (handle, mvar, rx, cancel_token)
+        (handle, acceptor_tx, rx, cancel_token)
     }
 
     async fn write_stream<M, W>(
@@ -2940,12 +2939,12 @@ mod tests {
         }
 
         let session_id = SessionId(123);
-        let (_handle, mvar, mut rx, cancel_token) = serve_acceptor_test::<u64>(session_id);
+        let (_handle, acceptor_tx, mut rx, cancel_token) = serve_acceptor_test::<u64>(session_id);
 
         // First connection: send messages, verify delivery and ack.
         {
             let (sender, receiver) = tokio::io::duplex(5000);
-            mvar.put(receiver).await;
+            acceptor_tx.send(receiver).unwrap();
 
             let (r, writer) = tokio::io::split(sender);
             let mut reader = FrameReader::new(
@@ -2978,7 +2977,7 @@ mod tests {
         // Second connection (reconnection): retransmitted messages are deduped.
         {
             let (sender2, receiver2) = tokio::io::duplex(5000);
-            mvar.put(receiver2).await;
+            acceptor_tx.send(receiver2).unwrap();
 
             let (r2, writer2) = tokio::io::split(sender2);
             let mut reader2 = FrameReader::new(
@@ -3014,10 +3013,10 @@ mod tests {
         let config = hyperactor_config::global::lock();
         let _guard = config.override_key(config::MESSAGE_ACK_EVERY_N_MESSAGES, 1);
         let session_id = SessionId(123);
-        let (_handle, mvar, mut rx, cancel_token) = serve_acceptor_test::<u64>(session_id);
+        let (_handle, acceptor_tx, mut rx, cancel_token) = serve_acceptor_test::<u64>(session_id);
 
         let (sender, receiver) = tokio::io::duplex(5000);
-        mvar.put(receiver).await;
+        acceptor_tx.send(receiver).unwrap();
         let (r, mut writer) = tokio::io::split(sender);
         let mut reader = FrameReader::new(
             r,
@@ -3731,10 +3730,10 @@ mod tests {
         let config = hyperactor_config::global::lock();
         let _guard = config.override_key(config::MESSAGE_ACK_EVERY_N_MESSAGES, 1);
         let session_id = SessionId(123);
-        let (_handle, mvar, mut rx, _cancel_token) = serve_acceptor_test::<u64>(session_id);
+        let (_handle, acceptor_tx, mut rx, _cancel_token) = serve_acceptor_test::<u64>(session_id);
 
         let (sender, receiver) = tokio::io::duplex(5000);
-        mvar.put(receiver).await;
+        acceptor_tx.send(receiver).unwrap();
         let (r, writer) = tokio::io::split(sender);
         let mut reader = FrameReader::new(
             r,
@@ -3789,5 +3788,368 @@ mod tests {
         // dropped and when wait_for was called. So we still need to do an
         // equality check.
         assert!(watcher.borrow().is_closed());
+    }
+
+    /// Yields pre-built `DuplexStream`s to the accept loop and
+    /// blocks once drained. Lets the `rx_join_flushes_pending_ack_*`
+    /// tests inspect the wire from the other end.
+    struct QueueListener {
+        streams: std::collections::VecDeque<DuplexStream>,
+        addr: ChannelAddr,
+    }
+
+    #[async_trait]
+    impl super::Listener for QueueListener {
+        type Stream = DuplexStream;
+
+        async fn accept(&mut self) -> Result<(DuplexStream, ChannelAddr), ServerError> {
+            match self.streams.pop_front() {
+                Some(s) => Ok((s, self.addr.clone())),
+                None => std::future::pending().await,
+            }
+        }
+    }
+
+    /// In-memory connection: server end goes into the listener; the
+    /// test reads from `client_r`.
+    struct PreparedConnection {
+        server_side: DuplexStream,
+        // Kept alive so the server's recv-loop stays in its `select!`
+        // on cancellation rather than exiting on EOF. Tests must
+        // exercise the cancel-flush path.
+        _client_w: tokio::io::WriteHalf<DuplexStream>,
+        client_r: ReadHalf<DuplexStream>,
+    }
+
+    /// Write `LinkInit` and the framed `Frame::Message(seq, value)`
+    /// payloads on the client side; return both halves.
+    async fn prepare_connection(
+        session_id: SessionId,
+        stream_id: u8,
+        messages: &[(u64, u64)],
+    ) -> PreparedConnection {
+        let (client_side, server_side) = tokio::io::duplex(8192);
+        let (client_r, mut client_w) = tokio::io::split(client_side);
+
+        super::write_link_init(&mut client_w, session_id, stream_id)
+            .await
+            .unwrap();
+        let max_len = hyperactor_config::global::get(config::CODEC_MAX_FRAME_LENGTH);
+        for (seq, value) in messages {
+            let payload =
+                serde_multipart::serialize_bincode(&Frame::<u64>::Message(*seq, *value)).unwrap();
+            let mut fw = FrameWrite::new(client_w, payload.framed(), max_len, 0)
+                .map_err(|(_w, e)| e)
+                .unwrap();
+            fw.send().await.unwrap();
+            client_w = fw.complete();
+        }
+
+        PreparedConnection {
+            server_side,
+            _client_w: client_w,
+            client_r,
+        }
+    }
+
+    /// Test plan for `run_separate_sessions_flush_test`: each entry
+    /// describes one connection that lives on its own session.
+    struct SeparateSessionPlan {
+        session_id: SessionId,
+        stream_id: u8,
+        messages: Vec<(u64, u64)>,
+    }
+
+    /// Drive the rx.join flush test across multiple connections,
+    /// each on its own session. Verifies:
+    ///
+    /// 1. Every message sent reaches the application via `rx.recv()`.
+    /// 2. After application delivery completes, *no* ack frames have
+    ///    been emitted on any connection's read side — the policy
+    ///    thresholds are out of reach.
+    /// 3. After `rx.join()` returns, every connection has exactly
+    ///    one `NetRxResponse::Ack(highest_seq)` frame on its read
+    ///    side, followed by a `NetRxResponse::Closed` terminal frame.
+    async fn run_separate_sessions_flush_test(
+        plans: Vec<SeparateSessionPlan>,
+        stream_id_label: &str,
+    ) {
+        let config = hyperactor_config::global::lock();
+        let _g_msg = config.override_key(config::MESSAGE_ACK_EVERY_N_MESSAGES, 1_000_000);
+        let _g_time =
+            config.override_key(config::MESSAGE_ACK_TIME_INTERVAL, Duration::from_secs(3600));
+
+        // Build all connections and stage them into a `QueueListener`.
+        let mut conns: Vec<PreparedConnection> = Vec::with_capacity(plans.len());
+        let mut expected_messages: std::collections::HashSet<u64> =
+            std::collections::HashSet::new();
+        let mut expected_acks: Vec<u64> = Vec::with_capacity(plans.len());
+        for plan in &plans {
+            for (_seq, value) in &plan.messages {
+                expected_messages.insert(*value);
+            }
+            expected_acks.push(plan.messages.iter().map(|(s, _)| *s).max().unwrap());
+            conns.push(prepare_connection(plan.session_id, plan.stream_id, &plan.messages).await);
+        }
+
+        let addr = ChannelAddr::Local(u64::MAX);
+        let listener = QueueListener {
+            streams: conns
+                .iter_mut()
+                .map(|c| {
+                    // Move server_side out of each PreparedConnection by replacing it with a placeholder.
+                    std::mem::replace(&mut c.server_side, tokio::io::duplex(1).0)
+                })
+                .collect(),
+            addr: addr.clone(),
+        };
+        let (_addr, mut rx) = super::server::serve_with_listener::<u64, _>(listener, addr).unwrap();
+
+        // Drain every expected message off the application channel.
+        let mut received: std::collections::HashSet<u64> = std::collections::HashSet::new();
+        for _ in 0..expected_messages.len() {
+            received.insert(rx.recv().await.unwrap());
+        }
+        assert_eq!(
+            received, expected_messages,
+            "{stream_id_label}: every produced message should reach the application"
+        );
+
+        // Give any policy-driven ack timer a generous grace period to
+        // fire. Because `MESSAGE_ACK_EVERY_N_MESSAGES` and
+        // `MESSAGE_ACK_TIME_INTERVAL` are out of reach, no ack should
+        // be emitted yet — but if a regression makes them reachable
+        // (or adds a new spontaneous emission path), this sleep gives
+        // it room to do so before the assertion below.
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        let max_len = hyperactor_config::global::get(config::CODEC_MAX_FRAME_LENGTH);
+        let mut readers: Vec<FrameReader<ReadHalf<DuplexStream>>> = conns
+            .into_iter()
+            .map(|c| FrameReader::new(c.client_r, max_len))
+            .collect();
+        for (idx, reader) in readers.iter_mut().enumerate() {
+            match tokio::time::timeout(Duration::from_millis(10), reader.next()).await {
+                Err(_) => {} // timeout — no frame, expected.
+                Ok(Err(e)) => panic!(
+                    "{stream_id_label}: connection {idx} frame reader error before rx.join: {e}"
+                ),
+                Ok(Ok(None)) => {
+                    panic!("{stream_id_label}: connection {idx} closed before rx.join()")
+                }
+                Ok(Ok(Some((_, bytes)))) => {
+                    let resp = super::deserialize_response(bytes).unwrap();
+                    panic!(
+                        "{stream_id_label}: connection {idx} unexpectedly received {resp:?} \
+                         before rx.join()"
+                    );
+                }
+            }
+        }
+
+        rx.join().await;
+
+        // After rx.join() returns, every connection must have its
+        // terminal cleanup frames already written: an `Ack` covering
+        // the highest seq it sent, then a `Closed`.
+        for (idx, (reader, expected_ack)) in readers.iter_mut().zip(&expected_acks).enumerate() {
+            let bytes = tokio::time::timeout(Duration::from_millis(50), reader.next())
+                .await
+                .unwrap_or_else(|_| {
+                    panic!(
+                        "{stream_id_label}: connection {idx} produced no Ack frame within 50ms \
+                         after rx.join()"
+                    )
+                })
+                .expect("frame reader error")
+                .expect("frame reader returned None");
+            let acked = super::deserialize_response(bytes.1)
+                .unwrap()
+                .into_ack()
+                .unwrap_or_else(|other| {
+                    panic!("{stream_id_label}: connection {idx} expected Ack, got {other:?}")
+                });
+            assert_eq!(
+                acked, *expected_ack,
+                "{stream_id_label}: connection {idx} ack mismatch"
+            );
+
+            let bytes = tokio::time::timeout(Duration::from_millis(50), reader.next())
+                .await
+                .unwrap_or_else(|_| {
+                    panic!(
+                        "{stream_id_label}: connection {idx} produced no Closed frame within 50ms"
+                    )
+                })
+                .expect("frame reader error")
+                .expect("frame reader returned None");
+            assert!(
+                super::deserialize_response(bytes.1).unwrap().is_closed(),
+                "{stream_id_label}: connection {idx} expected Closed terminal frame"
+            );
+        }
+    }
+
+    #[async_timed_test(timeout_secs = 30)]
+    async fn rx_join_flushes_pending_ack_single_stream() {
+        // Three independent single-stream sessions, each with three
+        // framed messages. Verifies every recv-loop's terminal flush
+        // ran by the time `rx.join()` returns.
+        let plans = (1u64..=3)
+            .map(|sid| SeparateSessionPlan {
+                session_id: SessionId(sid),
+                stream_id: 0,
+                messages: (0u64..3).map(|seq| (seq, sid * 100 + seq)).collect(),
+            })
+            .collect();
+        run_separate_sessions_flush_test(plans, "single-stream").await;
+    }
+
+    #[async_timed_test(timeout_secs = 30)]
+    async fn rx_join_flushes_pending_ack_multi_stream() {
+        // Three independent multi-stream sessions, each with three
+        // framed messages, each on its own session_id with a single
+        // stream_id of 1. Exercises `dispatch_multi_stream`'s terminal
+        // cleanup once per session.
+        let plans = (1u64..=3)
+            .map(|sid| SeparateSessionPlan {
+                session_id: SessionId(sid),
+                stream_id: 1,
+                messages: (0u64..3).map(|seq| (seq, sid * 100 + seq)).collect(),
+            })
+            .collect();
+        run_separate_sessions_flush_test(plans, "multi-stream").await;
+    }
+
+    /// One session, multiple stream_ids — exercises `AckWatermark`'s
+    /// shared-watermark path. Three streams in the same session each
+    /// send three messages with disjoint seqs filling the contiguous
+    /// range 0..=8. Each stream's cleanup reads `highest_uncommitted`
+    /// and emits `Ack(8)` on its own wire so the peer's per-wire
+    /// NetTx sees an ack for messages it sent there; the receiver
+    /// discards duplicates. Every stream also emits its own `Closed`.
+    #[async_timed_test(timeout_secs = 30)]
+    async fn rx_join_flushes_pending_ack_shared_multi_stream_session() {
+        let config = hyperactor_config::global::lock();
+        let _g_msg = config.override_key(config::MESSAGE_ACK_EVERY_N_MESSAGES, 1_000_000);
+        let _g_time =
+            config.override_key(config::MESSAGE_ACK_TIME_INTERVAL, Duration::from_secs(3600));
+
+        let session_id = SessionId(99);
+        let num_streams = 3u8;
+        let msgs_per_stream = 3u64;
+        let mut conns: Vec<PreparedConnection> = Vec::with_capacity(num_streams as usize);
+        let mut expected_messages: std::collections::HashSet<u64> =
+            std::collections::HashSet::new();
+        for stream_id in 1..=num_streams {
+            let messages: Vec<(u64, u64)> = (0u64..msgs_per_stream)
+                .map(|i| {
+                    let seq = (stream_id as u64 - 1) * msgs_per_stream + i;
+                    (seq, 1000 + seq)
+                })
+                .collect();
+            for (_, v) in &messages {
+                expected_messages.insert(*v);
+            }
+            conns.push(prepare_connection(session_id, stream_id, &messages).await);
+        }
+        let highest_seq = num_streams as u64 * msgs_per_stream - 1;
+
+        let addr = ChannelAddr::Local(u64::MAX);
+        let listener = QueueListener {
+            streams: conns
+                .iter_mut()
+                .map(|c| std::mem::replace(&mut c.server_side, tokio::io::duplex(1).0))
+                .collect(),
+            addr: addr.clone(),
+        };
+        let (_addr, mut rx) = super::server::serve_with_listener::<u64, _>(listener, addr).unwrap();
+
+        let mut received: std::collections::HashSet<u64> = std::collections::HashSet::new();
+        for _ in 0..expected_messages.len() {
+            received.insert(rx.recv().await.unwrap());
+        }
+        assert_eq!(
+            received, expected_messages,
+            "shared-session multi-stream: every message reaches the application"
+        );
+
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        let max_len = hyperactor_config::global::get(config::CODEC_MAX_FRAME_LENGTH);
+        let mut readers: Vec<FrameReader<ReadHalf<DuplexStream>>> = conns
+            .into_iter()
+            .map(|c| FrameReader::new(c.client_r, max_len))
+            .collect();
+        for (idx, reader) in readers.iter_mut().enumerate() {
+            match tokio::time::timeout(Duration::from_millis(10), reader.next()).await {
+                Err(_) | Ok(Ok(None)) => {} // timeout / EOF — no early ack, good.
+                Ok(Err(e)) => {
+                    panic!("shared-session multi-stream: stream {idx} frame reader error: {e}")
+                }
+                Ok(Ok(Some((_, bytes)))) => {
+                    let resp = super::deserialize_response(bytes).unwrap();
+                    panic!(
+                        "shared-session multi-stream: stream {idx} unexpectedly received \
+                         {resp:?} before rx.join()"
+                    );
+                }
+            }
+        }
+
+        rx.join().await;
+
+        // Drain every frame on every reader. Terminal cleanup may emit
+        // `Ack(highest_seq)` on one or more wires before `Closed`, but
+        // once one cleanup commits the shared watermark, later streams
+        // may emit only `Closed`.
+        let mut ack_count = 0;
+        let mut closed_count = 0;
+        for (idx, reader) in readers.iter_mut().enumerate() {
+            loop {
+                match tokio::time::timeout(Duration::from_millis(50), reader.next()).await {
+                    Err(_) => panic!(
+                        "shared-session multi-stream: stream {idx} did not yield expected \
+                         frames within 50ms after rx.join()"
+                    ),
+                    Ok(Err(e)) => panic!("frame reader error: {e}"),
+                    Ok(Ok(None)) => break,
+                    Ok(Ok(Some((_, bytes)))) => {
+                        let resp = super::deserialize_response(bytes).unwrap();
+                        match resp {
+                            NetRxResponse::Ack(seq) => {
+                                assert_eq!(
+                                    seq, highest_seq,
+                                    "shared-session multi-stream: ack should cover the full \
+                                     contiguous range 0..={highest_seq}"
+                                );
+                                ack_count += 1;
+                            }
+                            NetRxResponse::Closed => {
+                                closed_count += 1;
+                                break;
+                            }
+                            other => panic!(
+                                "shared-session multi-stream: stream {idx} unexpected {other:?}"
+                            ),
+                        }
+                    }
+                }
+            }
+        }
+        assert!(
+            ack_count >= 1,
+            "shared-session multi-stream: expected at least one Ack({highest_seq}); \
+             got {ack_count}"
+        );
+        assert!(
+            ack_count <= num_streams as usize,
+            "shared-session multi-stream: expected at most {num_streams} Ack({highest_seq}) \
+             frames; got {ack_count}"
+        );
+        assert_eq!(
+            closed_count, num_streams as usize,
+            "shared-session multi-stream: every stream should emit its own Closed frame"
+        );
     }
 }

--- a/hyperactor/src/channel/net.rs
+++ b/hyperactor/src/channel/net.rs
@@ -4152,4 +4152,452 @@ mod tests {
             "shared-session multi-stream: every stream should emit its own Closed frame"
         );
     }
+
+    /// Duplex analog of `rx_join_flushes_pending_ack_single_stream`.
+    /// Three independent duplex sessions, each with three framed
+    /// messages. Verifies every `dispatch_duplex_stream`'s terminal
+    /// flush ran by the time `DuplexServer::join()` returns —
+    /// structured concurrency makes the listener task await every
+    /// inline recv/send loop before resolving.
+    #[async_timed_test(timeout_secs = 30)]
+    async fn server_join_flushes_pending_ack_duplex_session() {
+        let config = hyperactor_config::global::lock();
+        let _g_msg = config.override_key(config::MESSAGE_ACK_EVERY_N_MESSAGES, 1_000_000);
+        let _g_time =
+            config.override_key(config::MESSAGE_ACK_TIME_INTERVAL, Duration::from_secs(3600));
+
+        let session_count = 3u64;
+        let msgs_per_session = 3u64;
+        let mut conns: Vec<PreparedConnection> = Vec::with_capacity(session_count as usize);
+        let mut expected_messages: std::collections::HashSet<u64> =
+            std::collections::HashSet::new();
+        let mut expected_acks: Vec<u64> = Vec::with_capacity(session_count as usize);
+        for sid in 1..=session_count {
+            let messages: Vec<(u64, u64)> = (0u64..msgs_per_session)
+                .map(|seq| (seq, sid * 100 + seq))
+                .collect();
+            for (_, v) in &messages {
+                expected_messages.insert(*v);
+            }
+            expected_acks.push(messages.iter().map(|(s, _)| *s).max().unwrap());
+            conns.push(prepare_connection(SessionId(sid), 0, &messages).await);
+        }
+
+        let addr = ChannelAddr::Local(u64::MAX);
+        let listener = QueueListener {
+            streams: conns
+                .iter_mut()
+                .map(|c| std::mem::replace(&mut c.server_side, tokio::io::duplex(1).0))
+                .collect(),
+            addr: addr.clone(),
+        };
+        let mut server = super::duplex::serve_with_listener::<u64, u64, _>(listener, addr).unwrap();
+
+        // Accept one (rx, tx) pair per session. Hold the tx halves
+        // alive so the server's send-loop stays parked in `select!`
+        // (it never sees an `AppClosed` terminal) — the test must
+        // exercise the cancel-driven flush path, not an
+        // app-disconnect one.
+        let mut all_rx: Vec<super::duplex::DuplexRx<u64>> =
+            Vec::with_capacity(session_count as usize);
+        let mut all_tx: Vec<super::duplex::DuplexTx<u64>> =
+            Vec::with_capacity(session_count as usize);
+        for _ in 0..session_count {
+            let (rx, tx) = server.accept().await.unwrap();
+            all_rx.push(rx);
+            all_tx.push(tx);
+        }
+
+        // Drain the messages each session sent. Each session's
+        // dispatch task delivers exactly its own `msgs_per_session`
+        // values to its own `rx`, but the order in which sessions
+        // are accepted is non-deterministic — collect into a set.
+        let mut received: std::collections::HashSet<u64> = std::collections::HashSet::new();
+        for rx in all_rx.iter_mut() {
+            for _ in 0..msgs_per_session {
+                received.insert(rx.recv().await.unwrap());
+            }
+        }
+        assert_eq!(
+            received, expected_messages,
+            "duplex: every produced message should reach the application"
+        );
+
+        // Policy thresholds are out of reach, so no ack should fire
+        // spontaneously. The sleep gives any regression that adds a
+        // new emission path room to surface.
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        let max_len = hyperactor_config::global::get(config::CODEC_MAX_FRAME_LENGTH);
+        let mut readers: Vec<FrameReader<ReadHalf<DuplexStream>>> = conns
+            .into_iter()
+            .map(|c| FrameReader::new(c.client_r, max_len))
+            .collect();
+        for (idx, reader) in readers.iter_mut().enumerate() {
+            match tokio::time::timeout(Duration::from_millis(10), reader.next()).await {
+                Err(_) => {} // timeout — no frame, expected.
+                Ok(Err(e)) => {
+                    panic!("duplex: connection {idx} frame reader error before join: {e}")
+                }
+                Ok(Ok(None)) => {
+                    panic!("duplex: connection {idx} closed before server.join()")
+                }
+                Ok(Ok(Some((_, bytes)))) => {
+                    let resp = super::deserialize_response(bytes).unwrap();
+                    panic!(
+                        "duplex: connection {idx} unexpectedly received {resp:?} \
+                         before server.join()"
+                    );
+                }
+            }
+        }
+
+        // Trigger graceful shutdown. Holding `all_tx` / `all_rx`
+        // alive keeps the send-loop parked and `inbound_tx` valid,
+        // so the dispatch task only exits via the cancel branch of
+        // its `select!` — exercising the structured-concurrency
+        // flush-on-cancel path.
+        server.join().await;
+
+        // After server.join() returns, every connection must have
+        // its terminal cleanup frames already on the wire: an
+        // `Ack(highest_seq)` covering the messages it sent, then a
+        // `Closed`.
+        for (idx, (reader, expected_ack)) in readers.iter_mut().zip(&expected_acks).enumerate() {
+            let bytes = tokio::time::timeout(Duration::from_millis(50), reader.next())
+                .await
+                .unwrap_or_else(|_| {
+                    panic!(
+                        "duplex: connection {idx} produced no Ack frame within 50ms after \
+                         server.join()"
+                    )
+                })
+                .expect("frame reader error")
+                .expect("frame reader returned None");
+            let acked = super::deserialize_response(bytes.1)
+                .unwrap()
+                .into_ack()
+                .unwrap_or_else(|other| {
+                    panic!("duplex: connection {idx} expected Ack, got {other:?}")
+                });
+            assert_eq!(
+                acked, *expected_ack,
+                "duplex: connection {idx} ack mismatch"
+            );
+
+            let bytes = tokio::time::timeout(Duration::from_millis(50), reader.next())
+                .await
+                .unwrap_or_else(|_| {
+                    panic!("duplex: connection {idx} produced no Closed frame within 50ms")
+                })
+                .expect("frame reader error")
+                .expect("frame reader returned None");
+            assert!(
+                super::deserialize_response(bytes.1).unwrap().is_closed(),
+                "duplex: connection {idx} expected Closed terminal frame"
+            );
+        }
+    }
+
+    /// Test-only [`Link`] that yields each pre-built `DuplexStream`
+    /// once. Writes `LinkInit` on the stream before returning it so
+    /// the test (which holds the other end) sees the same wire
+    /// format a real `TcpLink` produces.
+    struct DuplexDialMockLink {
+        session_id: SessionId,
+        streams: std::collections::VecDeque<DuplexStream>,
+    }
+
+    impl fmt::Debug for DuplexDialMockLink {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            f.debug_struct("DuplexDialMockLink")
+                .field("session_id", &self.session_id)
+                .field("remaining_streams", &self.streams.len())
+                .finish()
+        }
+    }
+
+    #[async_trait]
+    impl super::Link for DuplexDialMockLink {
+        type Stream = DuplexStream;
+
+        fn dest(&self) -> ChannelAddr {
+            ChannelAddr::Local(u64::MAX)
+        }
+
+        fn link_id(&self) -> SessionId {
+            self.session_id
+        }
+
+        async fn next(&mut self) -> Result<DuplexStream, ClientError> {
+            match self.streams.pop_front() {
+                Some(mut stream) => {
+                    super::write_link_init(&mut stream, self.session_id, 0)
+                        .await
+                        .map_err(|err| ClientError::Io(self.dest(), err))?;
+                    Ok(stream)
+                }
+                None => Err(ClientError::Connect(
+                    self.dest(),
+                    std::io::Error::other("mock link exhausted"),
+                    "no more streams".into(),
+                )),
+            }
+        }
+    }
+
+    /// Acceptor-side counterpart of
+    /// [`duplex_dial_flushes_pending_ack_on_app_closed`]. The
+    /// application drops its `DuplexTx`, the dispatch task's
+    /// `send_connected` returns `SendLoopError::AppClosed` —
+    /// terminal — so `dispatch_duplex_stream`'s loop exits via the
+    /// flush + `Closed` + break path. Verifies the cumulative ack
+    /// and the terminal `Closed` are written on
+    /// `INITIATOR_TO_ACCEPTOR` before the dispatch task ends.
+    #[async_timed_test(timeout_secs = 30)]
+    async fn duplex_serve_flushes_pending_ack_on_app_closed() {
+        let config = hyperactor_config::global::lock();
+        let _g_msg = config.override_key(config::MESSAGE_ACK_EVERY_N_MESSAGES, 1_000_000);
+        let _g_time =
+            config.override_key(config::MESSAGE_ACK_TIME_INTERVAL, Duration::from_secs(3600));
+
+        let session_id = SessionId(1);
+        let messages: Vec<(u64, u64)> = vec![(0, 100), (1, 200), (2, 300)];
+        let expected_ack: u64 = 2;
+        let conn = prepare_connection(session_id, 0, &messages).await;
+
+        let addr = ChannelAddr::Local(u64::MAX);
+        let listener = QueueListener {
+            streams: std::collections::VecDeque::from([conn.server_side]),
+            addr: addr.clone(),
+        };
+
+        let mut server = super::duplex::serve_with_listener::<u64, u64, _>(listener, addr).unwrap();
+
+        let (mut server_rx, server_tx) = server.accept().await.unwrap();
+
+        // Drain the messages the test wrote on `INITIATOR_TO_ACCEPTOR`.
+        let mut received: Vec<u64> = Vec::with_capacity(messages.len());
+        for _ in &messages {
+            received.push(server_rx.recv().await.unwrap());
+        }
+        let expected_values: Vec<u64> = messages.iter().map(|(_, v)| *v).collect();
+        assert_eq!(
+            received, expected_values,
+            "duplex serve: every message should reach the application"
+        );
+
+        // Policy thresholds are unreachable, so no ack should fire
+        // spontaneously.
+        let max_len = hyperactor_config::global::get(config::CODEC_MAX_FRAME_LENGTH);
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        let mut reader = FrameReader::new(conn.client_r, max_len);
+        match tokio::time::timeout(Duration::from_millis(10), reader.next()).await {
+            Err(_) => {} // timeout — expected.
+            Ok(Err(e)) => panic!("duplex serve: frame reader error before app close: {e}"),
+            Ok(Ok(None)) => panic!("duplex serve: wire closed before app close"),
+            Ok(Ok(Some((_, bytes)))) => {
+                let resp = super::deserialize_response(bytes).unwrap();
+                panic!("duplex serve: unexpectedly received {resp:?} before app close");
+            }
+        }
+
+        // Drop the application's `DuplexTx` to trigger `AppClosed`
+        // in `send_connected` — terminal — so the dispatch task
+        // exits. The flush logic must write the cumulative ack on
+        // `INITIATOR_TO_ACCEPTOR` and the terminal `Closed` before
+        // the loop breaks.
+        drop(server_tx);
+
+        let bytes = tokio::time::timeout(Duration::from_millis(100), reader.next())
+            .await
+            .unwrap_or_else(|_| panic!("duplex serve: produced no Ack frame within 100ms"))
+            .expect("frame reader error")
+            .expect("frame reader returned None");
+        let acked = super::deserialize_response(bytes.1)
+            .unwrap()
+            .into_ack()
+            .unwrap_or_else(|other| panic!("duplex serve: expected Ack, got {other:?}"));
+        assert_eq!(
+            acked, expected_ack,
+            "duplex serve: ack should cover the highest seq received"
+        );
+
+        let bytes = tokio::time::timeout(Duration::from_millis(100), reader.next())
+            .await
+            .unwrap_or_else(|_| panic!("duplex serve: produced no Closed frame within 100ms"))
+            .expect("frame reader error")
+            .expect("frame reader returned None");
+        assert!(
+            super::deserialize_response(bytes.1).unwrap().is_closed(),
+            "duplex serve: expected Closed terminal frame after Ack"
+        );
+
+        drop(server_rx);
+        // `server.join()` triggers the listener-task cancel so the
+        // outer `accept_loop` returns. The dispatch task already
+        // exited via `AppClosed` and was drained from the JoinSet,
+        // so this just stops the listener.
+        server.join().await;
+    }
+
+    /// [`DuplexClient::join`] cancels the recv/send loop's
+    /// cancellation token. The `select!`s observe cancel and the
+    /// loop exits via the flush + `Closed` + break path. Verifies
+    /// the cumulative ack and the terminal `Closed` are written on
+    /// `ACCEPTOR_TO_INITIATOR` before the spawned task ends.
+    #[async_timed_test(timeout_secs = 30)]
+    async fn duplex_client_join_flushes_pending_ack() {
+        let config = hyperactor_config::global::lock();
+        let _g_msg = config.override_key(config::MESSAGE_ACK_EVERY_N_MESSAGES, 1_000_000);
+        let _g_time =
+            config.override_key(config::MESSAGE_ACK_TIME_INTERVAL, Duration::from_secs(3600));
+
+        let session_id = SessionId(123);
+        let (client_side, server_side) = tokio::io::duplex(8192);
+        let (mut test_r, mut test_w) = tokio::io::split(server_side);
+
+        let link = DuplexDialMockLink {
+            session_id,
+            streams: std::collections::VecDeque::from([client_side]),
+        };
+
+        let mut dial_client = super::duplex::spawn::<u64, u64>(link);
+        let _dial_tx = dial_client.tx();
+        let mut dial_rx = dial_client.take_rx().unwrap();
+
+        // Drain the LinkInit the dial-side wrote on connect.
+        super::read_link_init(&mut test_r).await.unwrap();
+
+        // Test acts as the acceptor: write framed `Frame::Message`s
+        // on `ACCEPTOR_TO_INITIATOR` so the dial-side recv-loop
+        // reads them and forwards to the application via
+        // `inbound_tx`.
+        let max_len = hyperactor_config::global::get(config::CODEC_MAX_FRAME_LENGTH);
+        let messages: Vec<(u64, u64)> = vec![(0, 100), (1, 200), (2, 300)];
+        let expected_ack: u64 = 2;
+        for (seq, value) in &messages {
+            let payload =
+                serde_multipart::serialize_bincode(&Frame::<u64>::Message(*seq, *value)).unwrap();
+            let mut fw = FrameWrite::new(
+                test_w,
+                payload.framed(),
+                max_len,
+                super::ACCEPTOR_TO_INITIATOR,
+            )
+            .map_err(|(_w, e)| e)
+            .unwrap();
+            fw.send().await.unwrap();
+            test_w = fw.complete();
+        }
+
+        // Drain the messages on the dial-side rx so the dial-side's
+        // `recv_next.seq` advances past every seq.
+        let mut received: Vec<u64> = Vec::with_capacity(messages.len());
+        for _ in &messages {
+            received.push(dial_rx.recv().await.unwrap());
+        }
+        let expected_values: Vec<u64> = messages.iter().map(|(_, v)| *v).collect();
+        assert_eq!(
+            received, expected_values,
+            "dial: every message should reach the application"
+        );
+
+        // Policy thresholds are unreachable, so no ack should fire
+        // spontaneously.
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        let mut reader = FrameReader::new(test_r, max_len);
+        match tokio::time::timeout(Duration::from_millis(10), reader.next()).await {
+            Err(_) => {} // timeout — expected.
+            Ok(Err(e)) => panic!("dial: frame reader error before join: {e}"),
+            Ok(Ok(None)) => panic!("dial: wire closed before join"),
+            Ok(Ok(Some((_, bytes)))) => {
+                let resp = super::deserialize_response(bytes).unwrap();
+                panic!("dial: unexpectedly received {resp:?} before join");
+            }
+        }
+
+        // Trigger graceful shutdown via the structured-concurrency
+        // join handle. Cancel propagates into the spawn loop's
+        // `select!`s; the loop exits via Cancelled (terminal) and
+        // the flush logic writes the cumulative ack and the
+        // `Closed` terminal frame before the task ends.
+        dial_client.join().await;
+
+        let bytes = tokio::time::timeout(Duration::from_millis(100), reader.next())
+            .await
+            .unwrap_or_else(|_| panic!("dial: produced no Ack frame within 100ms after join"))
+            .expect("frame reader error")
+            .expect("frame reader returned None");
+        let acked = super::deserialize_response(bytes.1)
+            .unwrap()
+            .into_ack()
+            .unwrap_or_else(|other| panic!("dial: expected Ack, got {other:?}"));
+        assert_eq!(
+            acked, expected_ack,
+            "dial: ack should cover the highest seq received"
+        );
+
+        // After the ack, the dial-side writes the terminal
+        // `Closed` response on `ACCEPTOR_TO_INITIATOR` (mirrors
+        // `dispatch_duplex_stream`), then releases the connection.
+        let bytes = tokio::time::timeout(Duration::from_millis(100), reader.next())
+            .await
+            .unwrap_or_else(|_| panic!("dial: produced no Closed frame within 100ms after join"))
+            .expect("frame reader error")
+            .expect("frame reader returned None");
+        assert!(
+            super::deserialize_response(bytes.1).unwrap().is_closed(),
+            "dial: expected Closed terminal frame after Ack"
+        );
+
+        drop(dial_rx);
+        drop(test_w);
+    }
+
+    /// Verifies that an in-progress [`DuplexRx::recv`] on the
+    /// receiver returned by [`DuplexClient::take_rx`] resolves with
+    /// [`ChannelError::Closed`] when [`DuplexClient::join`] is
+    /// called concurrently. Structured concurrency guarantees the
+    /// spawned task drops `inbound_tx` before `join` returns, so
+    /// the receiver observes the close deterministically.
+    #[async_timed_test(timeout_secs = 30)]
+    async fn duplex_client_join_terminates_in_progress_recv() {
+        let session_id = SessionId(123);
+        let (client_side, server_side) = tokio::io::duplex(8192);
+        let (mut test_r, _test_w) = tokio::io::split(server_side);
+
+        let link = DuplexDialMockLink {
+            session_id,
+            streams: std::collections::VecDeque::from([client_side]),
+        };
+
+        let mut dial_client = super::duplex::spawn::<u64, u64>(link);
+        let mut dial_rx = dial_client.take_rx().unwrap();
+
+        // Drain the LinkInit so the dial-side has finished its
+        // setup before we kick off the recv() under test.
+        super::read_link_init(&mut test_r).await.unwrap();
+
+        // Park a recv() in a separate task; the dial-side hasn't
+        // forwarded any inbound frames so this future will sit in
+        // `inbound_rx.recv().await` indefinitely until `join`
+        // drops the spawned task's `inbound_tx`.
+        let recv_handle: tokio::task::JoinHandle<Result<u64, ChannelError>> =
+            tokio::spawn(async move { dial_rx.recv().await });
+
+        // `join` cancels the spawned task; on exit the task drops
+        // its `inbound_tx`, which closes `inbound_rx` and resolves
+        // the recv() with `ChannelError::Closed`.
+        dial_client.join().await;
+
+        let result = tokio::time::timeout(Duration::from_millis(100), recv_handle)
+            .await
+            .expect("parked recv should resolve within 100ms after join")
+            .expect("recv task should not panic");
+        assert!(
+            matches!(result, Err(ChannelError::Closed)),
+            "in-progress recv should resolve with ChannelError::Closed after join, got {result:?}"
+        );
+    }
 }

--- a/hyperactor/src/channel/net/duplex.rs
+++ b/hyperactor/src/channel/net/duplex.rs
@@ -62,7 +62,6 @@ use crate::channel::net::Stream;
 use crate::channel::net::meta;
 use crate::channel::net::tls;
 use crate::metrics;
-use crate::sync::mvar::MVar;
 
 /// Public duplex server that yields `(DuplexRx<In>, DuplexTx<Out>)` pairs.
 pub struct DuplexServer<In: RemoteMessage, Out: RemoteMessage> {
@@ -205,7 +204,8 @@ pub fn serve<In: RemoteMessage, Out: RemoteMessage>(
         }
     };
 
-    let sessions: Arc<DashMap<SessionId, MVar<Box<dyn Stream>>>> = Arc::new(DashMap::new());
+    let sessions: Arc<DashMap<SessionId, mpsc::UnboundedSender<Box<dyn Stream>>>> =
+        Arc::new(DashMap::new());
     let child_cancel = CancellationToken::new();
     let dispatch_dest = channel_addr.clone();
     let dispatch = {
@@ -222,7 +222,7 @@ pub fn serve<In: RemoteMessage, Out: RemoteMessage>(
                 dispatch_duplex_stream::<In, Out>(
                     link_init.session_id,
                     stream,
-                    &sessions,
+                    sessions,
                     dest,
                     &accept_tx,
                     cancel,
@@ -260,21 +260,21 @@ enum Either {
 async fn dispatch_duplex_stream<In: RemoteMessage, Out: RemoteMessage>(
     session_id: SessionId,
     stream: Box<dyn Stream>,
-    sessions: &DashMap<SessionId, MVar<Box<dyn Stream>>>,
+    sessions: Arc<DashMap<SessionId, mpsc::UnboundedSender<Box<dyn Stream>>>>,
     addr: ChannelAddr,
     accept_tx: &mpsc::Sender<(DuplexRx<In>, DuplexTx<Out>)>,
     cancel: CancellationToken,
 ) {
-    let mvar = {
+    let sender = {
         let entry = sessions.entry(session_id);
         match entry {
             dashmap::mapref::entry::Entry::Occupied(e) => e.get().clone(),
             dashmap::mapref::entry::Entry::Vacant(e) => {
-                let mvar: MVar<Box<dyn Stream>> = MVar::empty();
+                let (sender, receiver) = mpsc::unbounded_channel::<Box<dyn Stream>>();
                 let link = AcceptorLink {
                     dest: addr.clone(),
                     session_id,
-                    stream: mvar.clone(),
+                    stream: receiver,
                     cancel: cancel.clone(),
                 };
 
@@ -292,6 +292,7 @@ async fn dispatch_duplex_stream<In: RemoteMessage, Out: RemoteMessage>(
 
                 let session_ct = cancel.clone();
                 let dest = addr.clone();
+                let cleanup_sessions = Arc::clone(&sessions);
                 tokio::spawn(async move {
                     let mut session = Session::new(link);
                     let mut recv_next = Next { seq: 0, ack: 0 };
@@ -421,16 +422,26 @@ async fn dispatch_duplex_stream<In: RemoteMessage, Out: RemoteMessage>(
                         }
                     }
 
+                    // Recv-loop is finished — no further conns will
+                    // be drained. Drop the session entry so a later
+                    // reconnect for the same session_id starts a
+                    // fresh dispatch task instead of feeding a dead
+                    // channel; any in-flight feeder's send fails
+                    // after the link's receiver above is dropped.
+                    cleanup_sessions.remove(&session_id);
+
                     let _ = notify.send(TxStatus::Closed("duplex session ended".into()));
                 });
 
-                e.insert(mvar.clone());
-                mvar
+                e.insert(sender.clone());
+                sender
             }
         }
     };
 
-    mvar.put(stream).await;
+    // Send returns Err if the spawned recv-loop task exited and
+    // dropped the receiver — drop the conn in that case.
+    let _ = sender.send(stream);
 }
 
 /// Establish a duplex (bidirectional) session over the given link.

--- a/hyperactor/src/channel/net/duplex.rs
+++ b/hyperactor/src/channel/net/duplex.rs
@@ -66,7 +66,7 @@ use crate::metrics;
 /// Public duplex server that yields `(DuplexRx<In>, DuplexTx<Out>)` pairs.
 pub struct DuplexServer<In: RemoteMessage, Out: RemoteMessage> {
     accept_rx: mpsc::Receiver<(DuplexRx<In>, DuplexTx<Out>)>,
-    _handle: ServerHandle,
+    handle: ServerHandle,
     addr: ChannelAddr,
 }
 
@@ -79,6 +79,19 @@ impl<In: RemoteMessage, Out: RemoteMessage> DuplexServer<In, Out> {
     /// The address this server is listening on.
     pub fn addr(&self) -> &ChannelAddr {
         &self.addr
+    }
+
+    /// Gracefully shut down the duplex server. Cancels the listener
+    /// and awaits its task; structured concurrency in
+    /// [`dispatch_duplex_stream`] guarantees every in-flight session
+    /// has finished its terminal cleanup (final ack flush + `Closed`
+    /// emit) before this returns.
+    pub async fn join(mut self) {
+        self.handle.stop(&format!(
+            "DuplexServer joined; channel address: {}",
+            self.addr
+        ));
+        let _ = (&mut self.handle).await;
     }
 }
 
@@ -102,6 +115,64 @@ impl<M: RemoteMessage> Rx<M> for DuplexRx<M> {
     }
 
     async fn join(self) {}
+}
+
+/// A handle to a duplex client session: wraps the send/recv halves
+/// and the spawned task driving the connection. Owns a cancellation
+/// token so callers can deterministically stop the recv/send loop
+/// via [`DuplexClient::join`].
+///
+/// Dropping a `DuplexClient` does *not* cancel — that would tear
+/// down sessions whose tx/rx halves the application has handed off
+/// elsewhere (e.g., into a mailbox). Call [`join`](Self::join) for
+/// orderly shutdown.
+pub struct DuplexClient<Out: RemoteMessage, In: RemoteMessage> {
+    tx: DuplexTx<Out>,
+    rx: Option<DuplexRx<In>>,
+    join_handle: tokio::task::JoinHandle<()>,
+    cancel_token: CancellationToken,
+    addr: ChannelAddr,
+}
+
+impl<Out: RemoteMessage, In: RemoteMessage> DuplexClient<Out, In> {
+    /// Get a new clone of the [`DuplexTx`] for sending messages to
+    /// the peer.
+    pub fn tx(&self) -> DuplexTx<Out> {
+        self.tx.clone()
+    }
+
+    /// Take the [`DuplexRx`] out of the client. Returns `None` on
+    /// subsequent calls — the receiver is single-consumer.
+    pub fn take_rx(&mut self) -> Option<DuplexRx<In>> {
+        self.rx.take()
+    }
+
+    /// The peer address this client dialed.
+    pub fn addr(&self) -> &ChannelAddr {
+        &self.addr
+    }
+
+    /// Gracefully shut down the duplex client session. Cancels the
+    /// recv/send loop's cancellation token (which the spawned task
+    /// observes in its `select!`s) and awaits the spawned task. On
+    /// return, the task has finished its terminal cleanup (final
+    /// ack flush on `ACCEPTOR_TO_INITIATOR`) and dropped its
+    /// [`inbound_tx`](super::session) / outbound receiver halves —
+    /// so any in-progress [`DuplexRx::recv`](super::Rx::recv) on
+    /// the receiver half resolves with [`ChannelError::Closed`].
+    pub async fn join(self) {
+        self.cancel_token.cancel();
+        let _ = self.join_handle.await;
+    }
+}
+
+impl<Out: RemoteMessage, In: RemoteMessage> std::fmt::Debug for DuplexClient<Out, In> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DuplexClient")
+            .field("addr", &self.addr)
+            .field("rx_taken", &self.rx.is_none())
+            .finish()
+    }
 }
 
 /// Sender half of a duplex channel.
@@ -206,17 +277,16 @@ pub fn serve<In: RemoteMessage, Out: RemoteMessage>(
 
     let sessions: Arc<DashMap<SessionId, mpsc::UnboundedSender<Box<dyn Stream>>>> =
         Arc::new(DashMap::new());
-    let child_cancel = CancellationToken::new();
     let dispatch_dest = channel_addr.clone();
+    let dispatch_cancel = child_token.clone();
     let dispatch = {
         let sessions = Arc::clone(&sessions);
         let accept_tx = accept_tx.clone();
-        let child_cancel = child_cancel.clone();
         let dest = dispatch_dest;
         move |link_init: super::LinkInit, stream: Box<dyn Stream>| {
             let sessions = Arc::clone(&sessions);
             let accept_tx = accept_tx.clone();
-            let cancel = child_cancel.child_token();
+            let cancel = dispatch_cancel.clone();
             let dest = dest.clone();
             async move {
                 dispatch_duplex_stream::<In, Out>(
@@ -234,17 +304,82 @@ pub fn serve<In: RemoteMessage, Out: RemoteMessage>(
 
     let ca = channel_addr.clone();
     let join_handle = tokio::spawn(async move {
-        let result =
-            super::server::accept_loop(&mut listener, &ca, &child_token, prepare, dispatch).await;
-        child_cancel.cancel();
-        result
+        super::server::accept_loop(&mut listener, &ca, &child_token, prepare, dispatch).await
     });
 
     let server_handle = ServerHandle::new(join_handle, cancel_token, channel_addr.clone());
 
     Ok(DuplexServer {
         accept_rx,
-        _handle: server_handle,
+        handle: server_handle,
+        addr: channel_addr,
+    })
+}
+
+/// Test-only variant that accepts an arbitrary [`super::Listener`].
+/// Mirrors [`super::server::serve_with_listener`] but for duplex
+/// servers; lets wire-level tests stage `DuplexStream`s via a
+/// custom listener so they can inspect terminal-flush behavior on
+/// the read side.
+#[cfg(test)]
+pub(super) fn serve_with_listener<In, Out, L>(
+    mut listener: L,
+    channel_addr: ChannelAddr,
+) -> Result<DuplexServer<In, Out>, ServerError>
+where
+    In: RemoteMessage,
+    Out: RemoteMessage,
+    L: super::Listener + 'static,
+    L::Stream: Unpin + std::fmt::Debug + 'static,
+{
+    let (accept_tx, accept_rx) = mpsc::channel(16);
+    let cancel_token = CancellationToken::new();
+    let child_token = cancel_token.child_token();
+
+    let prepare = |stream: L::Stream, source: ChannelAddr| async move {
+        let mut boxed: Box<dyn Stream> = Box::new(stream);
+        let link_init = read_link_init(&mut boxed)
+            .await
+            .map_err(|e| anyhow::anyhow!("LinkInit read failed from {}: {}", source, e))?;
+        Ok((link_init, boxed))
+    };
+
+    let sessions: Arc<DashMap<SessionId, mpsc::UnboundedSender<Box<dyn Stream>>>> =
+        Arc::new(DashMap::new());
+    let dispatch_cancel = child_token.clone();
+    let dispatch = {
+        let sessions = Arc::clone(&sessions);
+        let accept_tx = accept_tx.clone();
+        let dest = channel_addr.clone();
+        move |link_init: super::LinkInit, stream: Box<dyn Stream>| {
+            let sessions = Arc::clone(&sessions);
+            let accept_tx = accept_tx.clone();
+            let cancel = dispatch_cancel.clone();
+            let dest = dest.clone();
+            async move {
+                dispatch_duplex_stream::<In, Out>(
+                    link_init.session_id,
+                    stream,
+                    sessions,
+                    dest,
+                    &accept_tx,
+                    cancel,
+                )
+                .await;
+            }
+        }
+    };
+
+    let ca = channel_addr.clone();
+    let join_handle = tokio::spawn(async move {
+        super::server::accept_loop(&mut listener, &ca, &child_token, prepare, dispatch).await
+    });
+
+    let server_handle = ServerHandle::new(join_handle, cancel_token, channel_addr.clone());
+
+    Ok(DuplexServer {
+        accept_rx,
+        handle: server_handle,
         addr: channel_addr,
     })
 }
@@ -257,6 +392,15 @@ enum Either {
 
 /// Dispatch a stream to the appropriate duplex session, creating one
 /// if this is the first connection for the given session ID.
+///
+/// Structured concurrency: the first dispatch for a session runs the
+/// recv/send loop inline and only returns after its terminal cleanup
+/// (flush any pending recv ack, emit `Closed` on cancellation).
+/// Reconnects hand the connection off via the per-session channel
+/// and return immediately. [`accept_loop`](super::server::accept_loop)
+/// joins every dispatch in its `connections` `JoinSet`, so it
+/// finishes only after every recv/send loop has finished — same
+/// contract as the simplex [`dispatch_stream`](super::server::dispatch_stream).
 async fn dispatch_duplex_stream<In: RemoteMessage, Out: RemoteMessage>(
     session_id: SessionId,
     stream: Box<dyn Stream>,
@@ -265,197 +409,212 @@ async fn dispatch_duplex_stream<In: RemoteMessage, Out: RemoteMessage>(
     accept_tx: &mpsc::Sender<(DuplexRx<In>, DuplexTx<Out>)>,
     cancel: CancellationToken,
 ) {
-    let sender = {
+    // Insert into the session map and drop the DashMap shard guard
+    // before any await. Vacant inserts the sender side; occupied
+    // returns the existing sender so this dispatch acts as a feeder.
+    // Unbounded so this task can publish the sender before draining
+    // the first conn without deadlocking a concurrent feeder for
+    // the same session_id.
+    let entry_result = {
         let entry = sessions.entry(session_id);
         match entry {
-            dashmap::mapref::entry::Entry::Occupied(e) => e.get().clone(),
+            dashmap::mapref::entry::Entry::Occupied(e) => Err(e.get().clone()),
             dashmap::mapref::entry::Entry::Vacant(e) => {
                 let (sender, receiver) = mpsc::unbounded_channel::<Box<dyn Stream>>();
-                let link = AcceptorLink {
-                    dest: addr.clone(),
-                    session_id,
-                    stream: receiver,
-                    cancel: cancel.clone(),
-                };
-
-                let (inbound_tx, inbound_rx) = mpsc::channel::<In>(1024);
-                let (outbound_tx, outbound_rx) =
-                    mpsc::unbounded_channel::<(Out, oneshot::Sender<SendError<Out>>, Instant)>();
-                let (notify, status) = watch::channel(TxStatus::Active);
-                let net_rx = DuplexRx(inbound_rx, addr.clone());
-                let net_tx = DuplexTx {
-                    tx: outbound_tx,
-                    addr: addr.clone(),
-                    status,
-                };
-                let _ = accept_tx.send((net_rx, net_tx)).await;
-
-                let session_ct = cancel.clone();
-                let dest = addr.clone();
-                let cleanup_sessions = Arc::clone(&sessions);
-                tokio::spawn(async move {
-                    let mut session = Session::new(link);
-                    let mut recv_next = Next { seq: 0, ack: 0 };
-                    let log_id = format!("duplex server {:016x}", session_id.0);
-                    let mut deliveries = session::Deliveries {
-                        outbox: session::Outbox::new(log_id.clone(), dest, session_id.0),
-                        unacked: session::Unacked::new(None, log_id),
-                    };
-                    let mut outbound_rx = outbound_rx;
-
-                    loop {
-                        let connected = match session.connect().await {
-                            Ok(s) => s,
-                            Err(_) => break,
-                        };
-                        deliveries.requeue_unacked();
-                        let result = {
-                            let recv_stream = connected.stream(super::INITIATOR_TO_ACCEPTOR);
-                            let send_stream = connected.stream(super::ACCEPTOR_TO_INITIATOR);
-                            tokio::select! {
-                                r = session::recv_connected::<In, _, _>(
-                                    &recv_stream,
-                                    &inbound_tx,
-                                    &mut recv_next,
-                                ) => r.map_err(Either::Recv),
-                                r = session::send_connected(
-                                    &send_stream,
-                                    &mut deliveries,
-                                    &mut outbound_rx,
-                                ) => r.map_err(Either::Send),
-                                _ = session_ct.cancelled() => Err(Either::Recv(session::RecvLoopError::Cancelled)),
-                            }
-                        };
-
-                        let terminal = match &result {
-                            Ok(()) => {
-                                tracing::info!(
-                                    session_id = session_id.0,
-                                    "duplex recv_connected returned EOF, awaiting reconnect"
-                                );
-                                false
-                            }
-                            Err(Either::Send(session::SendLoopError::Io(err))) => {
-                                tracing::info!(
-                                    session_id = session_id.0,
-                                    error = %err,
-                                    "duplex send error (recoverable)",
-                                );
-                                false
-                            }
-                            Err(Either::Recv(session::RecvLoopError::Io(err))) => {
-                                tracing::info!(
-                                    session_id = session_id.0,
-                                    error = %err,
-                                    "duplex recv error (recoverable)",
-                                );
-                                false
-                            }
-                            Err(Either::Send(e)) => {
-                                tracing::info!(
-                                    session_id = session_id.0,
-                                    error = %e,
-                                    "duplex send terminal error"
-                                );
-                                true
-                            }
-                            Err(Either::Recv(e)) => {
-                                tracing::info!(
-                                    session_id = session_id.0,
-                                    error = %e,
-                                    "duplex recv terminal error"
-                                );
-                                true
-                            }
-                        };
-
-                        // Flush any pending recv ack so the peer's
-                        // unacked queue clears cleanly before this
-                        // connection goes away. Mirrors the simplex
-                        // server's drain logic (see
-                        // `dispatch_stream`); without it, peers
-                        // retry-loop until `MESSAGE_DELIVERY_TIMEOUT`.
-                        if recv_next.ack < recv_next.seq {
-                            let recv_stream = connected.stream(super::INITIATOR_TO_ACCEPTOR);
-                            let ack = super::serialize_response(super::NetRxResponse::Ack(
-                                recv_next.seq - 1,
-                            ))
-                            .expect("serialize ack");
-                            let mut completion = recv_stream.write(ack);
-                            match completion.drive().await {
-                                Ok(()) => {
-                                    recv_next.ack = recv_next.seq;
-                                }
-                                Err(e) => {
-                                    tracing::debug!(
-                                        session_id = session_id.0,
-                                        error = %e,
-                                        "duplex: failed to flush acks during cleanup"
-                                    );
-                                }
-                            }
-                        }
-
-                        // On terminal exit, tell the peer we're
-                        // closing so it stops trying to reconnect.
-                        let terminal_response = match &result {
-                            Err(Either::Recv(session::RecvLoopError::SequenceError(reason))) => {
-                                Some(super::NetRxResponse::Reject(reason.clone()))
-                            }
-                            Err(Either::Recv(session::RecvLoopError::Cancelled))
-                            | Err(Either::Send(session::SendLoopError::AppClosed)) => {
-                                Some(super::NetRxResponse::Closed)
-                            }
-                            _ => None,
-                        };
-                        if let Some(rsp) = terminal_response {
-                            let recv_stream = connected.stream(super::INITIATOR_TO_ACCEPTOR);
-                            let data = super::serialize_response(rsp)
-                                .expect("serialize terminal response");
-                            let mut completion = recv_stream.write(data);
-                            let _ = completion.drive().await;
-                        }
-
-                        session = connected.release();
-                        if terminal {
-                            break;
-                        }
-                    }
-
-                    // Recv-loop is finished — no further conns will
-                    // be drained. Drop the session entry so a later
-                    // reconnect for the same session_id starts a
-                    // fresh dispatch task instead of feeding a dead
-                    // channel; any in-flight feeder's send fails
-                    // after the link's receiver above is dropped.
-                    cleanup_sessions.remove(&session_id);
-
-                    let _ = notify.send(TxStatus::Closed("duplex session ended".into()));
-                });
-
                 e.insert(sender.clone());
-                sender
+                Ok((sender, receiver))
             }
         }
     };
 
-    // Send returns Err if the spawned recv-loop task exited and
-    // dropped the receiver — drop the conn in that case.
+    let (sender, receiver) = match entry_result {
+        Err(sender) => {
+            // Feeder: forward the conn through the existing channel.
+            // Send returns Err if the processor task exited and
+            // dropped the receiver — drop the conn in that case.
+            let _ = sender.send(stream);
+            return;
+        }
+        Ok(pair) => pair,
+    };
+
+    // First dispatch for this session_id: set up the duplex
+    // application-facing handles and yield them to the server.
+    let (inbound_tx, inbound_rx) = mpsc::channel::<In>(1024);
+    let (outbound_tx, mut outbound_rx) =
+        mpsc::unbounded_channel::<(Out, oneshot::Sender<SendError<Out>>, Instant)>();
+    let (notify, status) = watch::channel(TxStatus::Active);
+    let net_rx = DuplexRx(inbound_rx, addr.clone());
+    let net_tx = DuplexTx {
+        tx: outbound_tx,
+        addr: addr.clone(),
+        status,
+    };
+    let _ = accept_tx.send((net_rx, net_tx)).await;
+
+    // Hand the first connection off through the channel; the loop
+    // below picks it up via `session.connect().await`.
     let _ = sender.send(stream);
+    drop(sender);
+
+    let link = AcceptorLink {
+        dest: addr.clone(),
+        session_id,
+        stream: receiver,
+        cancel: cancel.clone(),
+    };
+    let session_ct = cancel;
+    let dest = addr;
+    let log_id = format!("duplex server {:016x}", session_id.0);
+    let mut deliveries = session::Deliveries {
+        outbox: session::Outbox::new(log_id.clone(), dest.clone(), session_id.0),
+        unacked: session::Unacked::new(None, log_id),
+    };
+    let mut session = Session::new(link);
+    let mut recv_next = Next { seq: 0, ack: 0 };
+
+    loop {
+        let connected = match session.connect().await {
+            Ok(s) => s,
+            Err(_) => break,
+        };
+        deliveries.requeue_unacked();
+        let result = {
+            let recv_stream = connected.stream(super::INITIATOR_TO_ACCEPTOR);
+            let send_stream = connected.stream(super::ACCEPTOR_TO_INITIATOR);
+            tokio::select! {
+                r = session::recv_connected::<In, _, _>(
+                    &recv_stream,
+                    &inbound_tx,
+                    &mut recv_next,
+                ) => r.map_err(Either::Recv),
+                r = session::send_connected(
+                    &send_stream,
+                    &mut deliveries,
+                    &mut outbound_rx,
+                ) => r.map_err(Either::Send),
+                _ = session_ct.cancelled() => Err(Either::Recv(session::RecvLoopError::Cancelled)),
+            }
+        };
+
+        let terminal = match &result {
+            Ok(()) => {
+                tracing::info!(
+                    session_id = session_id.0,
+                    "duplex recv_connected returned EOF, awaiting reconnect"
+                );
+                false
+            }
+            Err(Either::Send(session::SendLoopError::Io(err))) => {
+                tracing::info!(
+                    session_id = session_id.0,
+                    error = %err,
+                    "duplex send error (recoverable)",
+                );
+                false
+            }
+            Err(Either::Recv(session::RecvLoopError::Io(err))) => {
+                tracing::info!(
+                    session_id = session_id.0,
+                    error = %err,
+                    "duplex recv error (recoverable)",
+                );
+                false
+            }
+            Err(Either::Send(e)) => {
+                tracing::info!(
+                    session_id = session_id.0,
+                    error = %e,
+                    "duplex send terminal error"
+                );
+                true
+            }
+            Err(Either::Recv(e)) => {
+                tracing::info!(
+                    session_id = session_id.0,
+                    error = %e,
+                    "duplex recv terminal error"
+                );
+                true
+            }
+        };
+
+        // Flush any pending recv ack so the peer's
+        // unacked queue clears cleanly before this
+        // connection goes away. Mirrors the simplex
+        // server's drain logic (see
+        // `dispatch_stream`); without it, peers
+        // retry-loop until `MESSAGE_DELIVERY_TIMEOUT`.
+        if recv_next.ack < recv_next.seq {
+            let recv_stream = connected.stream(super::INITIATOR_TO_ACCEPTOR);
+            let ack = super::serialize_response(super::NetRxResponse::Ack(recv_next.seq - 1))
+                .expect("serialize ack");
+            let mut completion = recv_stream.write(ack);
+            match completion.drive().await {
+                Ok(()) => {
+                    recv_next.ack = recv_next.seq;
+                }
+                Err(e) => {
+                    tracing::debug!(
+                        session_id = session_id.0,
+                        error = %e,
+                        "duplex: failed to flush acks during cleanup"
+                    );
+                }
+            }
+        }
+
+        // On terminal exit, tell the peer we're
+        // closing so it stops trying to reconnect.
+        let terminal_response = match &result {
+            Err(Either::Recv(session::RecvLoopError::SequenceError(reason))) => {
+                Some(super::NetRxResponse::Reject(reason.clone()))
+            }
+            Err(Either::Recv(session::RecvLoopError::Cancelled))
+            | Err(Either::Send(session::SendLoopError::AppClosed)) => {
+                Some(super::NetRxResponse::Closed)
+            }
+            _ => None,
+        };
+        if let Some(rsp) = terminal_response {
+            let recv_stream = connected.stream(super::INITIATOR_TO_ACCEPTOR);
+            let data = super::serialize_response(rsp).expect("serialize terminal response");
+            let mut completion = recv_stream.write(data);
+            let _ = completion.drive().await;
+        }
+
+        session = connected.release();
+        if terminal {
+            break;
+        }
+    }
+
+    // Recv/send loop is finished — drop the session entry so a later
+    // reconnect for the same session_id starts a fresh dispatch task
+    // instead of feeding a dead channel; any in-flight feeder's send
+    // fails after the link's receiver above is dropped.
+    sessions.remove(&session_id);
+
+    let _ = notify.send(TxStatus::Closed("duplex session ended".into()));
 }
 
 /// Establish a duplex (bidirectional) session over the given link.
-/// Returns send and receive handles.
+/// Returns a [`DuplexClient`] wrapping the send/recv halves and the
+/// spawned recv/send task; the client owns a cancellation token so
+/// callers can deterministically tear the session down via
+/// [`DuplexClient::join`].
 pub(crate) fn spawn<Out: RemoteMessage, In: RemoteMessage>(
     link: impl Link,
-) -> (DuplexTx<Out>, DuplexRx<In>) {
+) -> DuplexClient<Out, In> {
     let addr = link.dest();
     let session_id = link.link_id();
     let (outbound_tx, outbound_rx) = tokio::sync::mpsc::unbounded_channel();
     let (inbound_tx, inbound_rx) = tokio::sync::mpsc::channel::<In>(1024);
     let (notify, status) = watch::channel(TxStatus::Active);
+    let cancel_token = CancellationToken::new();
+    let task_cancel = cancel_token.clone();
     let dest = addr.clone();
-    crate::init::get_runtime().spawn(async move {
+    let join_handle = crate::init::get_runtime().spawn(async move {
         let mut session = Session::new(link);
         let log_id = format!("session {}.{:016x}", dest, session_id.0);
         let mut deliveries = session::Deliveries {
@@ -475,9 +634,15 @@ pub(crate) fn spawn<Out: RemoteMessage, In: RemoteMessage>(
         let mut link_status = LinkStatus::NeverConnected;
 
         loop {
-            let connected = match session.connect().await {
-                Ok(s) => s,
-                Err(_) => break,
+            // Race connect against cancel so a `DuplexClient::join`
+            // call mid-dial doesn't have to wait for the dial
+            // backoff to elapse.
+            let connected = tokio::select! {
+                result = session.connect() => match result {
+                    Ok(s) => s,
+                    Err(_) => break,
+                },
+                _ = task_cancel.cancelled() => break,
             };
 
             metrics::CHANNEL_CONNECTIONS.add(
@@ -515,6 +680,7 @@ pub(crate) fn spawn<Out: RemoteMessage, In: RemoteMessage>(
                     r = session::recv_connected::<In, _, _>(
                         &recv_stream, &inbound_tx, &mut recv_next,
                     ) => r.map_err(Either::Recv),
+                    _ = task_cancel.cancelled() => Err(Either::Recv(session::RecvLoopError::Cancelled)),
                 }
             };
 
@@ -588,6 +754,56 @@ pub(crate) fn spawn<Out: RemoteMessage, In: RemoteMessage>(
                     true
                 }
             };
+
+            // Flush any pending recv ack so the peer's send-side
+            // unacked queue clears cleanly before this connection
+            // goes away. Mirrors the cleanup in
+            // `dispatch_duplex_stream` but on the other tag — the
+            // initiator reads data on `ACCEPTOR_TO_INITIATOR`, so
+            // its acks travel back on that same tag.
+            if recv_next.ack < recv_next.seq {
+                let recv_stream = connected.stream(super::ACCEPTOR_TO_INITIATOR);
+                let ack = super::serialize_response(super::NetRxResponse::Ack(recv_next.seq - 1))
+                    .expect("serialize ack");
+                let mut completion = recv_stream.write(ack);
+                match completion.drive().await {
+                    Ok(()) => {
+                        recv_next.ack = recv_next.seq;
+                    }
+                    Err(e) => {
+                        tracing::debug!(
+                            dest = %dest,
+                            session_id = session_id.0,
+                            error = %e,
+                            "duplex client: failed to flush acks during cleanup"
+                        );
+                    }
+                }
+            }
+
+            // On terminal exit, tell the peer we're closing (or
+            // rejecting) on the same tag we read data on. Mirrors
+            // `dispatch_duplex_stream`; without it, the peer's
+            // server-side dispatch keeps awaiting a reconnect that
+            // will never come.
+            let terminal_response = match &result {
+                Err(Either::Recv(session::RecvLoopError::SequenceError(reason))) => {
+                    Some(super::NetRxResponse::Reject(reason.clone()))
+                }
+                Err(Either::Recv(session::RecvLoopError::Cancelled))
+                | Err(Either::Send(session::SendLoopError::AppClosed)) => {
+                    Some(super::NetRxResponse::Closed)
+                }
+                _ => None,
+            };
+            if let Some(rsp) = terminal_response {
+                let recv_stream = connected.stream(super::ACCEPTOR_TO_INITIATOR);
+                let data =
+                    super::serialize_response(rsp).expect("serialize terminal response");
+                let mut completion = recv_stream.write(data);
+                let _ = completion.drive().await;
+            }
+
             session = connected.release();
             if terminal {
                 break;
@@ -596,16 +812,25 @@ pub(crate) fn spawn<Out: RemoteMessage, In: RemoteMessage>(
 
         let _ = notify.send(TxStatus::Closed("duplex session ended".into()));
     });
-    (
-        DuplexTx::new(outbound_tx, addr.clone(), status),
-        DuplexRx::new(inbound_rx, addr),
-    )
+    let tx = DuplexTx::new(outbound_tx, addr.clone(), status);
+    let rx = DuplexRx::new(inbound_rx, addr.clone());
+    DuplexClient {
+        tx,
+        rx: Some(rx),
+        join_handle,
+        cancel_token,
+        addr,
+    }
 }
 
-/// Connect to a duplex server, returning tx and rx handles.
+/// Connect to a duplex server. Returns a [`DuplexClient`] wrapping
+/// the send/recv halves and the spawned recv/send task; callers use
+/// [`DuplexClient::tx`] / [`DuplexClient::take_rx`] to extract the
+/// halves and [`DuplexClient::join`] to deterministically shut the
+/// session down.
 pub fn dial<Out: RemoteMessage, In: RemoteMessage>(
     addr: ChannelAddr,
-) -> Result<(DuplexTx<Out>, DuplexRx<In>), ClientError> {
+) -> Result<DuplexClient<Out, In>, ClientError> {
     Ok(spawn(super::link(addr, super::SessionId::random(), 0)?))
 }
 
@@ -625,7 +850,9 @@ mod tests {
         let server_addr = server.addr().clone();
 
         // Client: sends u64, receives String.
-        let (client_tx, mut client_rx) = dial::<u64, String>(server_addr).unwrap();
+        let mut client = dial::<u64, String>(server_addr).unwrap();
+        let client_tx = client.tx();
+        let mut client_rx = client.take_rx().unwrap();
 
         // Server: receives u64, sends String.
         let (mut server_rx, server_tx) = server.accept().await.unwrap();
@@ -658,10 +885,14 @@ mod tests {
         let server_addr = server.addr().clone();
 
         // Two independent clients.
-        let (tx1, mut rx1) = dial::<u64, u64>(server_addr.clone()).unwrap();
+        let mut client1 = dial::<u64, u64>(server_addr.clone()).unwrap();
+        let tx1 = client1.tx();
+        let mut rx1 = client1.take_rx().unwrap();
         let (mut srx1, stx1) = server.accept().await.unwrap();
 
-        let (tx2, mut rx2) = dial::<u64, u64>(server_addr).unwrap();
+        let mut client2 = dial::<u64, u64>(server_addr).unwrap();
+        let tx2 = client2.tx();
+        let mut rx2 = client2.take_rx().unwrap();
         let (mut srx2, stx2) = server.accept().await.unwrap();
 
         // Send on link 1.
@@ -693,7 +924,9 @@ mod tests {
             }
         });
 
-        let (client_tx, mut client_rx) = dial::<u64, u64>(server_addr).unwrap();
+        let mut client = dial::<u64, u64>(server_addr).unwrap();
+        let client_tx = client.tx();
+        let mut client_rx = client.take_rx().unwrap();
 
         // Warmup.
         for i in 0..10u64 {

--- a/hyperactor/src/channel/net/server.rs
+++ b/hyperactor/src/channel/net/server.rs
@@ -40,15 +40,19 @@ use crate::channel::net::meta;
 use crate::channel::net::tls;
 use crate::config;
 use crate::metrics;
-use crate::sync::mvar::MVar;
 
 /// Server-side link that receives pre-established streams from the
-/// dispatcher via an MVar. Implements [`Link`] so it can be used
-/// with [`Session::new`].
+/// dispatcher via an unbounded mpsc channel. Implements [`Link`] so
+/// it can be used with [`Session::new`]. Dropping the link drops
+/// the receiver, which causes any feeder's later `send` to fail
+/// with `SendError` (the conn is dropped). The channel is unbounded
+/// so the dispatch task can publish its sender to the session map
+/// before draining the first connection without risking a deadlock
+/// against a concurrent feeder for the same session_id.
 pub(super) struct AcceptorLink<S: Stream> {
     pub(super) dest: ChannelAddr,
     pub(super) session_id: SessionId,
-    pub(super) stream: MVar<S>,
+    pub(super) stream: mpsc::UnboundedReceiver<S>,
     pub(super) cancel: CancellationToken,
 }
 
@@ -73,29 +77,33 @@ impl<S: Stream> Link for AcceptorLink<S> {
         self.session_id
     }
 
-    async fn next(&self) -> Result<S, ClientError> {
-        tokio::select! {
-            stream = self.stream.take() => Ok(stream),
-            _ = self.cancel.cancelled() => Err(ClientError::Connect(
-                self.dest.clone(),
+    async fn next(&mut self) -> Result<S, ClientError> {
+        let dest = self.dest.clone();
+        let make_err = move || {
+            ClientError::Connect(
+                dest.clone(),
                 std::io::Error::other("acceptor closed"),
                 "acceptor channel closed".into(),
-            )),
+            )
+        };
+        tokio::select! {
+            result = self.stream.recv() => result.ok_or_else(&make_err),
+            _ = self.cancel.cancelled() => Err(make_err()),
         }
     }
 }
 
 /// Shared state for multi-stream sessions. Each additional stream
-/// (stream_id > 0) gets its own MVar for connection handoff. The
+/// (stream_id > 0) gets its own connection-handoff channel. The
 /// [`AckWatermark`] is shared across all streams so cumulative acks
 /// reflect the global sequence space.
 pub(super) struct StreamState<S: Stream> {
-    /// Per-stream MVars for connection handoff. Keyed by stream_id.
+    /// Per-stream connection-handoff senders. Keyed by stream_id.
     /// Accessed concurrently from multiple accept-loop dispatch tasks
     /// (one per incoming connection for the same session), but only
     /// for a brief `entry().or_insert_with()` — a plain std Mutex is
     /// cheaper than DashMap here.
-    streams: std::sync::Mutex<HashMap<u8, MVar<S>>>,
+    streams: std::sync::Mutex<HashMap<u8, mpsc::UnboundedSender<S>>>,
     /// Shared ack tracker: each stream records its received seqs here.
     ack_watermark: tokio::sync::Mutex<session::AckWatermark>,
 }
@@ -136,147 +144,172 @@ fn resolve_stream<S: Stream>(
 
 /// Dispatch a newly accepted connection to the right session.
 ///
-/// When `streams` is `None`, this is a single-stream (strictly
-/// in-order) session, and the MVar to hand the connection to is
-/// looked up in `sessions` (creating a fresh session reader on first
-/// use).
+/// `streams = None` is a single-stream (strictly in-order) session;
+/// `Some((stream_id, state))` is the `stream_id`-th stream of a
+/// multi-stream session sharing `state`.
 ///
-/// When `streams` is `Some((stream_id, state))`, this is the
-/// `stream_id`-th stream of a multi-stream session sharing `state`
-/// (the caller resolves the per-session state from its own map). The
-/// connection is handed to a per-`stream_id` MVar inside `state`.
+/// Structured concurrency: the first dispatch for a session runs the
+/// recv-loop inline and only returns after its terminal cleanup
+/// (flush any pending ack, emit `Closed` on cancellation).
+/// Reconnects hand the connection off via the per-session
+/// channel and return immediately. [`accept_loop`] joins every
+/// dispatch in its `connections` `JoinSet`, so it finishes only
+/// after every recv-loop has finished.
 pub(super) async fn dispatch_stream<M: RemoteMessage, S: Stream>(
     session_id: SessionId,
     streams: Option<(u8, Arc<StreamState<S>>)>,
     conn: S,
-    sessions: &DashMap<SessionId, MVar<S>>,
+    sessions: &DashMap<SessionId, mpsc::UnboundedSender<S>>,
     dest: ChannelAddr,
     tx: mpsc::Sender<M>,
     cancel: CancellationToken,
 ) {
     if let Some((stream_id, state)) = streams {
-        // Multi-stream: route to a per-stream reader task.
+        // Multi-stream: route to the per-stream dispatch handler.
         dispatch_multi_stream::<M, S>(session_id, stream_id, conn, state, dest, tx, cancel).await;
         return;
     }
 
-    // Single-stream: existing logic.
-    let stream = {
+    // Single-stream: insert into the session map and drop the
+    // DashMap shard guard before any await. Vacant inserts the
+    // sender side; occupied returns the existing sender so this
+    // dispatch acts as a feeder. Unbounded so this task can publish
+    // the sender before draining the first conn without deadlocking
+    // a concurrent feeder for the same session_id.
+    let entry_result = {
         let entry = sessions.entry(session_id);
         match entry {
-            dashmap::mapref::entry::Entry::Occupied(e) => e.get().clone(),
+            dashmap::mapref::entry::Entry::Occupied(e) => Err(e.get().clone()),
             dashmap::mapref::entry::Entry::Vacant(e) => {
-                let stream: MVar<S> = MVar::empty();
-                let link = AcceptorLink {
-                    dest: dest.clone(),
-                    session_id,
-                    stream: stream.clone(),
-                    cancel: cancel.clone(),
-                };
-                let deliver_tx = tx;
-                let ct = cancel.clone();
-                tokio::spawn(async move {
-                    let mut session = Session::new(link);
-                    let mut next = Next { seq: 0, ack: 0 };
-
-                    loop {
-                        let connected = match session.connect().await {
-                            Ok(s) => s,
-                            Err(_) => break,
-                        };
-
-                        let result = {
-                            let conn = connected.stream(super::INITIATOR_TO_ACCEPTOR);
-                            tokio::select! {
-                                r = session::recv_connected::<M, _, _>(
-                                    &conn,
-                                    &deliver_tx,
-                                    &mut next,
-                                ) => r,
-                                _ = ct.cancelled() => Err(session::RecvLoopError::Cancelled),
-                            }
-                        };
-
-                        // Flush remaining ack if behind.
-                        if next.ack < next.seq {
-                            let ack =
-                                super::serialize_response(super::NetRxResponse::Ack(next.seq - 1))
-                                    .unwrap();
-                            let conn = connected.stream(super::INITIATOR_TO_ACCEPTOR);
-                            let mut completion = conn.write(ack);
-                            match completion.drive().await {
-                                Ok(()) => {
-                                    next.ack = next.seq;
-                                }
-                                Err(e) => {
-                                    tracing::debug!(
-                                        error = %e,
-                                        "failed to flush acks during cleanup"
-                                    );
-                                }
-                            }
-                        }
-
-                        // Send reject or closed response if appropriate.
-                        let terminal_response = match &result {
-                            Err(session::RecvLoopError::SequenceError(reason)) => {
-                                Some(super::NetRxResponse::Reject(reason.clone()))
-                            }
-                            Err(session::RecvLoopError::Cancelled) => {
-                                Some(super::NetRxResponse::Closed)
-                            }
-                            _ => None,
-                        };
-                        if let Some(rsp) = terminal_response {
-                            let data = super::serialize_response(rsp).unwrap();
-                            let conn = connected.stream(super::INITIATOR_TO_ACCEPTOR);
-                            let mut completion = conn.write(data);
-                            let _ = completion.drive().await;
-                        }
-
-                        let recoverable =
-                            matches!(&result, Ok(()) | Err(session::RecvLoopError::Io(_)));
-
-                        match &result {
-                            Ok(()) => {
-                                tracing::info!(
-                                    %dest,
-                                    %session_id,
-                                    "recv_connected returned EOF, awaiting reconnect"
-                                );
-                            }
-                            Err(e) => {
-                                tracing::info!(
-                                    %dest,
-                                    %session_id,
-                                    error = %e,
-                                    recoverable,
-                                    "recv_connected returned error"
-                                );
-                            }
-                        }
-
-                        session = connected.release();
-
-                        if recoverable {
-                            continue;
-                        }
-                        break; // SequenceError or Cancelled
-                    }
-                });
-                e.insert(stream.clone());
-                stream
+                let (sender, receiver) = mpsc::unbounded_channel::<S>();
+                e.insert(sender.clone());
+                Ok((sender, receiver))
             }
         }
     };
 
-    stream.put(conn).await;
+    let (sender, receiver) = match entry_result {
+        Err(sender) => {
+            // Feeder: forward the conn through the existing channel.
+            // Send returns Err if the processor task exited and
+            // dropped the receiver — drop the conn in that case.
+            let _ = sender.send(conn);
+            return;
+        }
+        Ok(pair) => pair,
+    };
+
+    let link = AcceptorLink {
+        dest: dest.clone(),
+        session_id,
+        stream: receiver,
+        cancel: cancel.clone(),
+    };
+    let deliver_tx = tx;
+    let ct = cancel;
+
+    // Hand the first connection off through the channel; the
+    // recv-loop below picks it up via `session.connect().await`.
+    let _ = sender.send(conn);
+    drop(sender);
+
+    let mut session = Session::new(link);
+    let mut next = Next { seq: 0, ack: 0 };
+
+    loop {
+        let connected = match session.connect().await {
+            Ok(s) => s,
+            Err(_) => break,
+        };
+
+        let result = {
+            let conn = connected.stream(super::INITIATOR_TO_ACCEPTOR);
+            tokio::select! {
+                r = session::recv_connected::<M, _, _>(
+                    &conn,
+                    &deliver_tx,
+                    &mut next,
+                ) => r,
+                _ = ct.cancelled() => Err(session::RecvLoopError::Cancelled),
+            }
+        };
+
+        // Flush a final ack if behind.
+        if next.ack < next.seq {
+            let ack = super::serialize_response(super::NetRxResponse::Ack(next.seq - 1)).unwrap();
+            let conn = connected.stream(super::INITIATOR_TO_ACCEPTOR);
+            let mut completion = conn.write(ack);
+            match completion.drive().await {
+                Ok(()) => {
+                    next.ack = next.seq;
+                }
+                Err(e) => {
+                    tracing::debug!(
+                        error = %e,
+                        "failed to flush acks during cleanup"
+                    );
+                }
+            }
+        }
+
+        // Send reject or closed response if appropriate.
+        let terminal_response = match &result {
+            Err(session::RecvLoopError::SequenceError(reason)) => {
+                Some(super::NetRxResponse::Reject(reason.clone()))
+            }
+            Err(session::RecvLoopError::Cancelled) => Some(super::NetRxResponse::Closed),
+            _ => None,
+        };
+        if let Some(rsp) = terminal_response {
+            let data = super::serialize_response(rsp).unwrap();
+            let conn = connected.stream(super::INITIATOR_TO_ACCEPTOR);
+            let mut completion = conn.write(data);
+            let _ = completion.drive().await;
+        }
+
+        let recoverable = matches!(&result, Ok(()) | Err(session::RecvLoopError::Io(_)));
+
+        match &result {
+            Ok(()) => {
+                tracing::info!(
+                    %dest,
+                    %session_id,
+                    "recv_connected returned EOF, awaiting reconnect"
+                );
+            }
+            Err(e) => {
+                tracing::info!(
+                    %dest,
+                    %session_id,
+                    error = %e,
+                    recoverable,
+                    "recv_connected returned error"
+                );
+            }
+        }
+
+        session = connected.release();
+
+        if recoverable {
+            continue;
+        }
+        break;
+    }
+
+    // Recv-loop is finished — no further conns will be drained.
+    // Drop the session entry so a later reconnect for the same
+    // session_id starts a fresh dispatch task instead of feeding a
+    // dead channel; any in-flight feeder's send fails after the
+    // receiver above is dropped.
+    sessions.remove(&session_id);
 }
 
-/// Handle a multi-stream connection (stream_id > 0). Spawns a per-stream
-/// reader task that reads frames, deserializes, delivers to the shared
-/// mpsc, and sends acks. Uses an AckWatermark shared across all streams
-/// of the same session for cumulative out-of-order acking.
+/// Handle a multi-stream connection (stream_id > 0). All streams of
+/// a session share an `AckWatermark` for cumulative out-of-order
+/// acking. Same structured-concurrency contract as
+/// [`dispatch_stream`]: first dispatch for a given (`session_id`,
+/// `stream_id`) runs the recv-loop inline; reconnects hand off via
+/// the per-stream channel and return.
 async fn dispatch_multi_stream<M: RemoteMessage, S: Stream>(
     session_id: SessionId,
     stream_id: u8,
@@ -291,86 +324,148 @@ async fn dispatch_multi_stream<M: RemoteMessage, S: Stream>(
         "dispatch_multi_stream: new connection"
     );
 
-    // Get or create an MVar for this stream_id.
-    let stream_mvar = {
+    // Insert into the per-session map and drop the std::sync::Mutex
+    // guard before any await — its guard is !Send. Vacant inserts
+    // the sender side; occupied returns the existing sender so this
+    // dispatch acts as a feeder. Unbounded so this task can publish
+    // the sender before draining the first conn without deadlocking
+    // a concurrent feeder for the same (session_id, stream_id).
+    let entry_result = {
         use std::collections::hash_map::Entry;
         let mut streams = state.streams.lock().unwrap();
         match streams.entry(stream_id) {
-            Entry::Occupied(e) => e.get().clone(),
+            Entry::Occupied(e) => Err(e.get().clone()),
             Entry::Vacant(e) => {
-                let mvar: MVar<S> = MVar::empty();
-                let link = AcceptorLink {
-                    dest: dest.clone(),
-                    session_id,
-                    stream: mvar.clone(),
-                    cancel: cancel.clone(),
-                };
-                let deliver_tx = tx;
-                let ct = cancel.clone();
-                let shared_state = state.clone();
-
-                // Spawn a reader task for this stream.
-                tokio::spawn(async move {
-                    let mut session = Session::new(link);
-
-                    loop {
-                        let connected = match session.connect().await {
-                            Ok(s) => s,
-                            Err(_) => break,
-                        };
-
-                        let result = {
-                            let conn = connected.stream(super::INITIATOR_TO_ACCEPTOR);
-                            tokio::select! {
-                                r = session::multi_stream_recv_connected::<M, _, _>(
-                                    &conn,
-                                    &shared_state.ack_watermark,
-                                    &deliver_tx,
-                                ) => r,
-                                _ = ct.cancelled() => Err(session::RecvLoopError::Cancelled),
-                            }
-                        };
-
-                        let recoverable =
-                            matches!(&result, Ok(()) | Err(session::RecvLoopError::Io(_)));
-
-                        match &result {
-                            Ok(()) => {
-                                tracing::info!(
-                                    %dest,
-                                    %session_id,
-                                    stream_id,
-                                    "multi-stream recv EOF, awaiting reconnect"
-                                );
-                            }
-                            Err(e) => {
-                                tracing::info!(
-                                    %dest,
-                                    %session_id,
-                                    stream_id,
-                                    error = %e,
-                                    recoverable,
-                                    "multi-stream recv error"
-                                );
-                            }
-                        }
-
-                        session = connected.release();
-
-                        if recoverable {
-                            continue;
-                        }
-                        break;
-                    }
-                });
-
-                e.insert(mvar.clone());
-                mvar
+                let (sender, receiver) = mpsc::unbounded_channel::<S>();
+                e.insert(sender.clone());
+                Ok((sender, receiver))
             }
         }
     };
 
-    stream_mvar.put(conn).await;
+    let (sender, receiver) = match entry_result {
+        Err(sender) => {
+            // Feeder: forward the conn through the existing channel.
+            // Send returns Err if the processor task exited and
+            // dropped the receiver — drop the conn in that case.
+            let _ = sender.send(conn);
+            return;
+        }
+        Ok(pair) => pair,
+    };
+
+    let link = AcceptorLink {
+        dest: dest.clone(),
+        session_id,
+        stream: receiver,
+        cancel: cancel.clone(),
+    };
+    let deliver_tx = tx;
+    let ct = cancel;
+    let shared_state = state;
+
+    // Hand the first connection off through the channel; the
+    // recv-loop below picks it up via `session.connect().await`.
+    let _ = sender.send(conn);
+    drop(sender);
+
+    let mut session = Session::new(link);
+
+    loop {
+        let connected = match session.connect().await {
+            Ok(s) => s,
+            Err(_) => break,
+        };
+
+        let result = {
+            let conn = connected.stream(super::INITIATOR_TO_ACCEPTOR);
+            tokio::select! {
+                r = session::multi_stream_recv_connected::<M, _, _>(
+                    &conn,
+                    &shared_state.ack_watermark,
+                    &deliver_tx,
+                ) => r,
+                _ = ct.cancelled() => Err(session::RecvLoopError::Cancelled),
+            }
+        };
+
+        // Each stream emits the cumulative watermark on its own wire
+        // so the peer's per-wire NetTx sees an ack for messages it
+        // sent on this connection.
+        let pending_ack = shared_state
+            .ack_watermark
+            .lock()
+            .await
+            .highest_uncommitted();
+        if let Some(ack_val) = pending_ack {
+            let ack = super::serialize_response(super::NetRxResponse::Ack(ack_val)).unwrap();
+            let conn = connected.stream(super::INITIATOR_TO_ACCEPTOR);
+            let mut completion = conn.write(ack);
+            match completion.drive().await {
+                Ok(()) => {
+                    shared_state.ack_watermark.lock().await.commit(ack_val);
+                }
+                Err(e) => {
+                    tracing::debug!(
+                        error = %e,
+                        stream_id,
+                        "failed to flush multi-stream ack during cleanup"
+                    );
+                }
+            }
+        }
+
+        // Send reject or closed response if appropriate.
+        let terminal_response = match &result {
+            Err(session::RecvLoopError::SequenceError(reason)) => {
+                Some(super::NetRxResponse::Reject(reason.clone()))
+            }
+            Err(session::RecvLoopError::Cancelled) => Some(super::NetRxResponse::Closed),
+            _ => None,
+        };
+        if let Some(rsp) = terminal_response {
+            let data = super::serialize_response(rsp).unwrap();
+            let conn = connected.stream(super::INITIATOR_TO_ACCEPTOR);
+            let mut completion = conn.write(data);
+            let _ = completion.drive().await;
+        }
+
+        let recoverable = matches!(&result, Ok(()) | Err(session::RecvLoopError::Io(_)));
+
+        match &result {
+            Ok(()) => {
+                tracing::info!(
+                    %dest,
+                    %session_id,
+                    stream_id,
+                    "multi-stream recv EOF, awaiting reconnect"
+                );
+            }
+            Err(e) => {
+                tracing::info!(
+                    %dest,
+                    %session_id,
+                    stream_id,
+                    error = %e,
+                    recoverable,
+                    "multi-stream recv error"
+                );
+            }
+        }
+
+        session = connected.release();
+
+        if recoverable {
+            continue;
+        }
+        break;
+    }
+
+    // Recv-loop is finished — no further conns will be drained for
+    // this (session_id, stream_id). Drop the per-stream sender entry
+    // so a later reconnect starts a fresh dispatch task instead of
+    // feeding a dead channel.
+    shared_state.streams.lock().unwrap().remove(&stream_id);
 }
 
 /// Generic accept loop. Accepts connections from `listener`, transforms
@@ -584,22 +679,22 @@ pub(in crate::channel) fn serve<M: RemoteMessage>(
         }
     };
 
-    let sessions: Arc<DashMap<SessionId, MVar<Box<dyn Stream>>>> = Arc::new(DashMap::new());
+    let sessions: Arc<DashMap<SessionId, mpsc::UnboundedSender<Box<dyn Stream>>>> =
+        Arc::new(DashMap::new());
     let stream_state: Arc<std::sync::Mutex<HashMap<SessionId, Arc<StreamState<Box<dyn Stream>>>>>> =
         Arc::new(std::sync::Mutex::new(HashMap::new()));
-    let child_cancel = CancellationToken::new();
     let dispatch_dest = channel_addr.clone();
+    let dispatch_cancel = child_token.clone();
     let dispatch = {
         let sessions = Arc::clone(&sessions);
         let stream_state = Arc::clone(&stream_state);
         let tx = tx.clone();
-        let child_cancel = child_cancel.clone();
         let dest = dispatch_dest;
         move |link_init: super::LinkInit, stream: Box<dyn Stream>| {
             let sessions = Arc::clone(&sessions);
             let stream_state = Arc::clone(&stream_state);
             let tx = tx.clone();
-            let cancel = child_cancel.child_token();
+            let cancel = dispatch_cancel.clone();
             let dest = dest.clone();
             async move {
                 let streams = resolve_stream(&stream_state, &link_init);
@@ -619,9 +714,7 @@ pub(in crate::channel) fn serve<M: RemoteMessage>(
 
     let ca: ChannelAddr = channel_addr.clone();
     let join_handle = tokio::spawn(async move {
-        let result = accept_loop(&mut listener, &ca, &child_token, prepare, dispatch).await;
-        child_cancel.cancel();
-        result
+        accept_loop(&mut listener, &ca, &child_token, prepare, dispatch).await
     });
 
     let server_handle = ServerHandle {
@@ -659,21 +752,21 @@ where
         Ok((link_init, stream))
     };
 
-    let sessions: Arc<DashMap<SessionId, MVar<L::Stream>>> = Arc::new(DashMap::new());
+    let sessions: Arc<DashMap<SessionId, mpsc::UnboundedSender<L::Stream>>> =
+        Arc::new(DashMap::new());
     let stream_state: Arc<std::sync::Mutex<HashMap<SessionId, Arc<StreamState<L::Stream>>>>> =
         Arc::new(std::sync::Mutex::new(HashMap::new()));
-    let child_cancel = CancellationToken::new();
+    let dispatch_cancel = child_token.clone();
     let dispatch = {
         let sessions = Arc::clone(&sessions);
         let stream_state = Arc::clone(&stream_state);
         let tx = tx.clone();
-        let child_cancel = child_cancel.clone();
         let dest = channel_addr.clone();
         move |link_init: super::LinkInit, stream: L::Stream| {
             let sessions = Arc::clone(&sessions);
             let stream_state = Arc::clone(&stream_state);
             let tx = tx.clone();
-            let cancel = child_cancel.child_token();
+            let cancel = dispatch_cancel.clone();
             let dest = dest.clone();
             async move {
                 let streams = resolve_stream(&stream_state, &link_init);
@@ -693,9 +786,7 @@ where
 
     let ca = channel_addr.clone();
     let join_handle = tokio::spawn(async move {
-        let result = accept_loop(&mut listener, &ca, &child_token, prepare, dispatch).await;
-        child_cancel.cancel();
-        result
+        accept_loop(&mut listener, &ca, &child_token, prepare, dispatch).await
     });
 
     let server_handle = ServerHandle {

--- a/hyperactor/src/channel/net/session.rs
+++ b/hyperactor/src/channel/net/session.rs
@@ -859,6 +859,9 @@ pub(super) async fn multi_stream_recv_connected<
     deliver_tx: &mpsc::Sender<M>,
 ) -> Result<(), RecvLoopError> {
     let mut pending_ack: Option<Completion<W, Bytes>> = None;
+    // Tracked alongside `pending_ack` so we can `commit` on
+    // successful write.
+    let mut pending_ack_val: Option<u64> = None;
 
     loop {
         // Consolidated watermark access: decide whether to emit an ack
@@ -877,6 +880,7 @@ pub(super) async fn multi_stream_recv_connected<
             let ack = serialize_response(NetRxResponse::Ack(ack_val))
                 .map_err(|e| RecvLoopError::Io(e.into()))?;
             pending_ack = Some(stream.write(ack));
+            pending_ack_val = Some(ack_val);
         }
 
         tokio::select! {
@@ -886,7 +890,12 @@ pub(super) async fn multi_stream_recv_connected<
             result = async { pending_ack.as_mut().unwrap().drive().await },
                 if pending_ack.is_some() => {
                 match result {
-                    Ok(()) => pending_ack = None,
+                    Ok(()) => {
+                        if let Some(val) = pending_ack_val.take() {
+                            ack_watermark.lock().await.commit(val);
+                        }
+                        pending_ack = None;
+                    }
                     Err(e) => return Err(RecvLoopError::Io(e.into())),
                 }
             }
@@ -996,9 +1005,14 @@ pub(super) struct AckWatermark {
     /// Last ack value [`poll`](Self::poll) handed out, or `None` if no
     /// ack has been emitted yet.
     last_reported: Option<u64>,
+    /// Highest ack value the caller confirmed via
+    /// [`commit`](Self::commit) was written to the wire. Gates
+    /// [`highest_uncommitted`](Self::highest_uncommitted) so a poll
+    /// whose write failed gets retried on cleanup.
+    last_committed: Option<u64>,
     /// Messages recorded since the last emission.
     msgs_since_report: u64,
-    /// When the last emission was committed.
+    /// When the last emission was claimed.
     last_report_time: Instant,
 }
 
@@ -1010,6 +1024,7 @@ impl AckWatermark {
             ack_msg_interval,
             ack_time_interval,
             last_reported: None,
+            last_committed: None,
             msgs_since_report: 0,
             last_report_time: Instant::now(),
         }
@@ -1065,6 +1080,41 @@ impl AckWatermark {
         self.msgs_since_report = 0;
         self.last_report_time = Instant::now();
         Some(watermark)
+    }
+
+    /// Record that an ack covering up to `seq` has been written to
+    /// the wire. Monotonic; idempotent on same-value calls.
+    /// Advances [`highest_uncommitted`](Self::highest_uncommitted)'s
+    /// gate so cleanup paths skip work already on the wire.
+    pub fn commit(&mut self, seq: u64) {
+        if self.last_committed.is_none_or(|c| seq > c) {
+            self.last_committed = Some(seq);
+        }
+    }
+
+    /// The highest seq observed but not yet committed, or `None` if
+    /// nothing observed since the last commit. Pure read: every
+    /// concurrent caller sees the same value, so each multi-stream
+    /// stream emits a covering ack on its own wire. Gates on
+    /// `last_committed` (not `last_reported`) so a value handed out
+    /// by a `poll` whose write failed is still surfaced. The value
+    /// is `max(max(received), highest_contiguous)`, which can exceed
+    /// the contiguous frontier when there are gaps — at terminal
+    /// cleanup the session is tearing down anyway, so acking past
+    /// gaps is acceptable.
+    pub fn highest_uncommitted(&self) -> Option<u64> {
+        let max_seen = self
+            .received
+            .iter()
+            .next_back()
+            .copied()
+            .into_iter()
+            .chain(self.highest_contiguous)
+            .max()?;
+        if self.last_committed.is_some_and(|c| max_seen <= c) {
+            return None;
+        }
+        Some(max_seen)
     }
 
     /// Duration until [`poll`](Self::poll) should next be invoked to
@@ -1168,6 +1218,89 @@ mod ack_watermark_tests {
         assert_eq!(t.poll(), None);
         t.record(1);
         assert_eq!(t.poll(), Some(1));
+    }
+
+    #[test]
+    fn highest_uncommitted_emits_below_policy_threshold() {
+        // High threshold so `poll` returns None; cleanup surfaces
+        // the watermark anyway since nothing was committed.
+        let mut t = AckWatermark::new(1000, Duration::from_secs(3600));
+        t.record(0);
+        t.record(1);
+        assert_eq!(t.poll(), None);
+        assert_eq!(t.highest_uncommitted(), Some(1));
+    }
+
+    #[test]
+    fn highest_uncommitted_returns_none_when_nothing_recorded() {
+        let t = watermark();
+        assert_eq!(t.highest_uncommitted(), None);
+    }
+
+    #[test]
+    fn highest_uncommitted_surfaces_out_of_order_frames() {
+        // No contiguous run yet, but seq 5 was received. At cleanup
+        // we still surface it so the wire emits a covering ack.
+        let mut t = watermark();
+        t.record(5);
+        assert_eq!(t.highest_uncommitted(), Some(5));
+    }
+
+    #[test]
+    fn highest_uncommitted_returns_none_when_already_committed() {
+        let mut t = watermark();
+        t.record(0);
+        t.record(1);
+        t.commit(1);
+        assert_eq!(t.highest_uncommitted(), None);
+    }
+
+    #[test]
+    fn highest_uncommitted_surfaces_uncommitted_after_failed_poll() {
+        // `poll` advances `last_reported` but not `last_committed`.
+        // If the caller's write failed (no `commit`), cleanup must
+        // still surface the watermark.
+        let mut t = AckWatermark::new(1, Duration::from_secs(3600));
+        t.record(0);
+        assert_eq!(t.poll(), Some(0));
+        // No commit happened.
+        assert_eq!(t.highest_uncommitted(), Some(0));
+    }
+
+    #[test]
+    fn highest_uncommitted_returns_value_to_every_caller() {
+        // Pure read: concurrent cleanups all see the same value, so
+        // every stream emits a covering ack on its own wire.
+        let mut t = watermark();
+        t.record(0);
+        t.record(1);
+        assert_eq!(t.highest_uncommitted(), Some(1));
+        assert_eq!(t.highest_uncommitted(), Some(1));
+    }
+
+    #[test]
+    fn highest_uncommitted_surfaces_when_received_has_uncommitted_seqs() {
+        // `last_committed` covers the contiguous frontier, but a new
+        // out-of-order seq has arrived since the commit. Surface its
+        // value so the wire emits a covering ack on cleanup.
+        let mut t = watermark();
+        t.record(0);
+        t.commit(0);
+        t.record(5);
+        assert_eq!(t.highest_uncommitted(), Some(5));
+    }
+
+    #[test]
+    fn commit_is_idempotent_and_monotonic() {
+        let mut t = watermark();
+        t.record(0);
+        t.record(1);
+        t.commit(1);
+        // Older values do not regress `last_committed`.
+        t.commit(0);
+        // Same-value commits are no-ops.
+        t.commit(1);
+        assert_eq!(t.highest_uncommitted(), None);
     }
 }
 
@@ -1328,7 +1461,7 @@ impl<L: Link> Session<L, Disconnected> {
         >,
     > {
         Box::pin(async move {
-            let Session { link, state: _ } = self;
+            let Session { mut link, state: _ } = self;
             match link.next().await {
                 Ok(stream) => {
                     let max = hyperactor_config::global::get(config::CODEC_MAX_FRAME_LENGTH);
@@ -1359,7 +1492,7 @@ impl<L: Link> Session<L, Disconnected> {
         >,
     > {
         Box::pin(async move {
-            let Session { link, state: _ } = self;
+            let Session { mut link, state: _ } = self;
             let sleep = tokio::time::sleep_until(deadline);
             tokio::pin!(sleep);
             let mut consecutive_failures: u32 = 0;

--- a/hyperactor/src/host.rs
+++ b/hyperactor/src/host.rs
@@ -93,7 +93,6 @@ use crate::mailbox::MailboxServer;
 use crate::mailbox::MailboxServerError;
 use crate::mailbox::MailboxServerHandle;
 use crate::mailbox::MessageEnvelope;
-use crate::mailbox::Undeliverable;
 use crate::ref_;
 use crate::reference;
 
@@ -354,7 +353,11 @@ impl<M: ProcManager> Host<M> {
             frontend: Some(frontend),
         };
 
-        // Serve the same router on the backend address.
+        // Serve the same router on the backend address. We don't ever need
+        // to join this handle because the server is used only to receive
+        // messages from procs spawned by this host -- if the host is shutting down,
+        // then all its procs should have shut down first, and we don't have to worry
+        // about any unacked messages.
         let _backend_handle = host.forwarder().serve(backend_rx);
 
         Ok(host)
@@ -646,6 +649,14 @@ async fn duplex_accept_loop(
     }
 
     while tasks.join_next().await.is_some() {}
+
+    // Drain the duplex server's listener task so every in-flight
+    // dispatch (one per session) finishes its terminal cleanup —
+    // final ack flush + `Closed` emit — before the host exits.
+    // Without this, simply dropping `duplex_server` would detach the
+    // listener and skip the flush, surfacing as undeliverable
+    // message errors on the peer's send-side after `process::exit`.
+    duplex_server.join().await;
 }
 
 /// Error returned by [`ProcHandle::ready`].

--- a/hyperactor/src/proc.rs
+++ b/hyperactor/src/proc.rs
@@ -479,8 +479,11 @@ impl Proc {
         use crate::host::AttachRequest;
         use crate::host::AttachRx;
         use crate::host::Host2Client;
-        let (duplex_tx, mut duplex_rx) =
-            channel::duplex::dial::<MessageEnvelope, Host2Client>(addr)?;
+        let mut duplex_client = channel::duplex::dial::<MessageEnvelope, Host2Client>(addr)?;
+        let duplex_tx = duplex_client.tx();
+        let mut duplex_rx = duplex_client
+            .take_rx()
+            .expect("dial returns a fresh DuplexClient with rx present");
         // Send an AttachRequest envelope to signal attach intent.
         // The host deserializes the first message and enters the
         // attach protocol when it finds an AttachRequest. The
@@ -516,7 +519,19 @@ impl Proc {
             assignment.proc_id,
             MailboxClient::new(duplex_tx).into_boxed(),
         );
-        let handle = proc.clone().serve(AttachRx(duplex_rx));
+        // Wrap the inner mailbox server handle so that stopping/
+        // joining the outer handle also joins the dial-side
+        // `DuplexClient`.
+        let inner_handle = proc.clone().serve(AttachRx(duplex_rx));
+        let (stopped_tx, mut stopped_rx) = tokio::sync::watch::channel(false);
+        let wrapped_join = tokio::spawn(async move {
+            let _ = stopped_rx.wait_for(|stopped| *stopped).await;
+            inner_handle.stop("proc shutting down");
+            let _ = inner_handle.await;
+            duplex_client.join().await;
+            Ok(())
+        });
+        let handle = crate::mailbox::MailboxServerHandle::from_parts(wrapped_join, stopped_tx);
         *proc.inner.mailbox_server_handle.lock().unwrap() = Some(handle);
         Ok(proc)
     }

--- a/hyperactor_mesh/src/proc_agent.rs
+++ b/hyperactor_mesh/src/proc_agent.rs
@@ -352,6 +352,11 @@ impl ProcAgent {
             Ok(Ok(())) => {}
         }
 
+        // Stop and join the mailbox server (no-op if this proc was
+        // not created with one). Pending receive-side acks are
+        // flushed before the underlying channel server is torn down.
+        self.proc.join_mailbox_server().await;
+
         tracing::info!(
             "shutting down process after all actors reached terminal state (exit_code={})",
             exit_code,

--- a/python/tests/proc_mesh_test_utils.py
+++ b/python/tests/proc_mesh_test_utils.py
@@ -27,14 +27,24 @@ async def stop_all_proc_meshes():
     on the Rust side, are not visible through ``actor_instance._children`` and
     must be cleaned up by their owners.
 
+    ``actor_instance._children`` is shared across the entire pytest session,
+    so we restrict teardown to ProcMeshes added during this test. Stopping
+    pre-existing children would attack ProcMeshes leaked by earlier tests
+    whose hosts may already be dead, raising spurious teardown errors.
+
     The ``configured`` scope caps actor / mesh teardown so a misbehaving test
     cannot hang the suite.
     """
     with configured(stop_actor_timeout="5s", mesh_terminate_timeout="15s"):
-        yield
         instance = context().actor_instance
+        preexisting = {id(c) for c in instance._children or []}
+        yield
         children = instance._children or []
+        remaining = []
         for child in children:
+            if id(child) in preexisting:
+                remaining.append(child)
+                continue
             if isinstance(child, ProcMesh):
                 await child.stop()
-        instance._children = None
+        instance._children = remaining or None

--- a/python/tests/rdma_test_utils.py
+++ b/python/tests/rdma_test_utils.py
@@ -1,0 +1,36 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-unsafe
+"""
+Shared helpers for the RDMA test modules.
+
+``rdma_backends`` is a decorator that runs a test once per available RDMA
+backend. ``ibverbs`` is only collected when the host has compatible hardware;
+``tcp`` always runs, and is forced even on RDMA-capable hosts via
+``rdma_disable_ibverbs=True``.
+"""
+
+from monarch.config import parametrize_config_pointwise
+from monarch.rdma import is_ibverbs_available
+
+
+RDMA_BACKENDS: list[str] = []
+if is_ibverbs_available():
+    RDMA_BACKENDS.append("ibverbs")
+RDMA_BACKENDS.append("tcp")
+
+
+if is_ibverbs_available():
+    rdma_backends = parametrize_config_pointwise(
+        rdma_disable_ibverbs=[True, False],
+        rdma_allow_tcp_fallback=[True, False],
+    )
+else:
+    rdma_backends = parametrize_config_pointwise(
+        rdma_disable_ibverbs=[True],
+        rdma_allow_tcp_fallback=[True],
+    )

--- a/python/tests/test_rdma.py
+++ b/python/tests/test_rdma.py
@@ -5,7 +5,6 @@
 # LICENSE file in the root directory of this source tree.
 
 # pyre-unsafe
-import inspect
 import os
 
 # required to enable RDMA support
@@ -13,73 +12,16 @@ os.environ["PYTORCH_CUDA_ALLOC_CONF"] = "expandable_segments:True"
 
 import pytest
 import torch
-from monarch.actor import Actor, context, current_rank, endpoint, ProcMesh, this_host
-from monarch.config import configured
+from monarch.actor import Actor, current_rank, endpoint, this_host
 from monarch.rdma import get_rdma_backend, is_ibverbs_available, RDMAAction, RDMABuffer
-
-
-# TODO(slurye): Enable these tests in OSS once the shutdown hang issue is fixed.
-pytestmark = pytest.mark.oss_skip
+from proc_mesh_test_utils import stop_all_proc_meshes  # noqa: F401
+from rdma_test_utils import rdma_backends
 
 
 needs_cuda = pytest.mark.skipif(
     not torch.cuda.is_available(),
     reason="CUDA not available",
 )
-
-# Backend parametrization for tests that work on both ibverbs and TCP.
-# ibverbs tests are only collected when hardware is present; TCP tests always run.
-RDMA_BACKENDS = []
-if is_ibverbs_available():
-    RDMA_BACKENDS.append("ibverbs")
-RDMA_BACKENDS.append("tcp")
-
-
-def rdma_backends(func):
-    """Parametrize a test on RDMA backend (ibverbs, tcp).
-
-    ibverbs variant is only collected when hardware is present.
-    TCP variant sets rdma_disable_ibverbs=True so the manager
-    falls back to TCP even on RDMA-capable machines.
-    """
-
-    if inspect.iscoroutinefunction(func):
-
-        @pytest.mark.parametrize("rdma_backend", RDMA_BACKENDS)
-        async def wrapper(*args, rdma_backend, **kwargs):
-            if rdma_backend == "tcp":
-                cm = configured(rdma_disable_ibverbs=True)
-            else:
-                cm = configured(rdma_allow_tcp_fallback=False)
-            with cm:
-                return await func(*args, **kwargs)
-
-    else:
-
-        @pytest.mark.parametrize("rdma_backend", RDMA_BACKENDS)
-        def wrapper(*args, rdma_backend, **kwargs):
-            if rdma_backend == "tcp":
-                cm = configured(rdma_disable_ibverbs=True)
-            else:
-                cm = configured(rdma_allow_tcp_fallback=False)
-            with cm:
-                return func(*args, **kwargs)
-
-    wrapper.__name__ = func.__name__
-    wrapper.__module__ = func.__module__
-    return wrapper
-
-
-@pytest.fixture(autouse=True)
-async def stop_all_proc_meshes():
-    with configured(stop_actor_timeout="5s", mesh_terminate_timeout="15s"):
-        yield
-        instance = context().actor_instance
-        children = instance._children or []
-        for child in children:
-            if isinstance(child, ProcMesh):
-                await child.stop()
-        instance._children = None
 
 
 # ---------------------------------------------------------------------------

--- a/python/tests/test_rdma_cpu_no_torch.py
+++ b/python/tests/test_rdma_cpu_no_torch.py
@@ -12,15 +12,8 @@ import pytest
 from isolate_in_subprocess import isolate_in_subprocess
 from monarch.actor import Actor, endpoint, this_host
 from monarch.config import configured
-from monarch.rdma import is_ibverbs_available, RDMABuffer
-
-# TODO(slurye): Enable these tests in OSS once the shutdown hang issue is fixed.
-pytestmark = pytest.mark.oss_skip
-
-RDMA_BACKENDS = []
-if is_ibverbs_available():
-    RDMA_BACKENDS.append("ibverbs")
-RDMA_BACKENDS.append("tcp")
+from monarch.rdma import RDMABuffer
+from rdma_test_utils import RDMA_BACKENDS
 
 
 class CpuActor(Actor):

--- a/python/tests/test_rdma_unit.py
+++ b/python/tests/test_rdma_unit.py
@@ -84,13 +84,10 @@ from typing import Callable
 import numpy as np
 import pytest
 import torch
-from monarch.actor import Actor, context, endpoint, ProcMesh, this_host
-from monarch.config import configured
-from monarch.rdma import is_ibverbs_available, RDMABuffer
-
-
-# TODO(slurye): Enable these tests in OSS once the shutdown hang issue is fixed.
-pytestmark = pytest.mark.oss_skip
+from monarch.actor import Actor, endpoint, this_host
+from monarch.rdma import RDMABuffer
+from proc_mesh_test_utils import stop_all_proc_meshes  # noqa: F401
+from rdma_test_utils import rdma_backends
 
 
 TIMEOUT = 60  # 60 seconds
@@ -113,25 +110,6 @@ needs_cuda = pytest.mark.skipif(
     not torch.cuda.is_available(),
     reason="CUDA not available",
 )
-
-# Backend parametrization: ibverbs only collected when hardware is present;
-# TCP always runs.
-RDMA_BACKENDS = []
-if is_ibverbs_available():
-    RDMA_BACKENDS.append("ibverbs")
-RDMA_BACKENDS.append("tcp")
-
-
-@pytest.fixture(autouse=True)
-async def stop_all_proc_meshes():
-    with configured(stop_actor_timeout="5s", mesh_terminate_timeout="15s"):
-        yield
-        instance = context().actor_instance
-        children = instance._children or []
-        for child in children:
-            if isinstance(child, ProcMesh):
-                await child.stop()
-        instance._children = None
 
 
 def _assert_value_error(func) -> None:
@@ -540,64 +518,49 @@ CONTROLLER_DEVICES = ["cpu"]
 RECEIVER_DEVICES = ["cpu"]
 
 
-async def _do_test(
-    func, dtype, data_getter, controller_device, receiver_device, rdma_backend
-):
-    if rdma_backend == "tcp":
-        cm = configured(rdma_disable_ibverbs=True)
-    else:
-        cm = configured(rdma_allow_tcp_fallback=False)
-    with cm:
-        controller, receiver = await _spawn_controller_and_receiver(
-            controller_device=controller_device,
-            receiver_device=receiver_device,
-            data_getter=partial(data_getter, device=controller_device, dtype=dtype),
-            receiver_actor=None,
-        )
-        error = await func(controller)
-        if error is not None:
-            raise error
+async def _do_test(func, dtype, data_getter, controller_device, receiver_device):
+    controller, receiver = await _spawn_controller_and_receiver(
+        controller_device=controller_device,
+        receiver_device=receiver_device,
+        data_getter=partial(data_getter, device=controller_device, dtype=dtype),
+        receiver_actor=None,
+    )
+    error = await func(controller)
+    if error is not None:
+        raise error
 
 
 def _test_with_all_data(func):
+    @rdma_backends
     @needs_cuda
-    @pytest.mark.parametrize("rdma_backend", RDMA_BACKENDS)
     @pytest.mark.parametrize("dtype", TEST_DTYPES)
     @pytest.mark.parametrize("data_getter", [_nothing])
     @pytest.mark.parametrize("controller_device", CONTROLLER_DEVICES)
     @pytest.mark.parametrize("receiver_device", RECEIVER_DEVICES)
     @pytest.mark.asyncio
-    async def marked(
-        dtype, data_getter, controller_device, receiver_device, rdma_backend
-    ):
-        return await func(
-            dtype, data_getter, controller_device, receiver_device, rdma_backend
-        )
+    async def marked(dtype, data_getter, controller_device, receiver_device):
+        return await func(dtype, data_getter, controller_device, receiver_device)
 
     return marked
 
 
 def _test_with_no_data(func):
+    @rdma_backends
     @needs_cuda
-    @pytest.mark.parametrize("rdma_backend", RDMA_BACKENDS)
     @pytest.mark.parametrize("dtype", TEST_DTYPES)
     @pytest.mark.parametrize("data_getter", ALL_DATA_GETTERS)
     @pytest.mark.parametrize("controller_device", CONTROLLER_DEVICES)
     @pytest.mark.parametrize("receiver_device", RECEIVER_DEVICES)
     @pytest.mark.asyncio
-    async def marked(
-        dtype, data_getter, controller_device, receiver_device, rdma_backend
-    ):
-        return await func(
-            dtype, data_getter, controller_device, receiver_device, rdma_backend
-        )
+    async def marked(dtype, data_getter, controller_device, receiver_device):
+        return await func(dtype, data_getter, controller_device, receiver_device)
 
     return marked
 
 
 @_test_with_no_data
 async def test_rdma_buffer_init_with_zero_size_raises_error(
-    dtype, data_getter, controller_device, receiver_device, rdma_backend
+    dtype, data_getter, controller_device, receiver_device
 ):
     await _do_test(
         lambda controller: controller.test_rdma_buffer_init_with_zero_size_raises_error.call_one(),
@@ -605,13 +568,12 @@ async def test_rdma_buffer_init_with_zero_size_raises_error(
         data_getter,
         controller_device,
         receiver_device,
-        rdma_backend,
     )
 
 
 @_test_with_all_data
 async def test_rdma_buffer_init_with_memoryview(
-    dtype, data_getter, controller_device, receiver_device, rdma_backend
+    dtype, data_getter, controller_device, receiver_device
 ):
     """Test that RDMABuffer initialization with memoryview works correctly."""
     await _do_test(
@@ -620,13 +582,12 @@ async def test_rdma_buffer_init_with_memoryview(
         data_getter,
         controller_device,
         receiver_device,
-        rdma_backend,
     )
 
 
 @_test_with_no_data
 async def test_rdma_buffer_read_into_non_contiguous_tensor_raises_error(
-    dtype, data_getter, controller_device, receiver_device, rdma_backend
+    dtype, data_getter, controller_device, receiver_device
 ):
     await _do_test(
         lambda controller: controller.test_rdma_buffer_read_into_non_contiguous_tensor_raises_error.call_one(),
@@ -634,13 +595,12 @@ async def test_rdma_buffer_read_into_non_contiguous_tensor_raises_error(
         data_getter,
         controller_device,
         receiver_device,
-        rdma_backend,
     )
 
 
 @_test_with_no_data
 async def test_rdma_buffer_write_from_non_contiguous_tensor_raises_error(
-    dtype, data_getter, controller_device, receiver_device, rdma_backend
+    dtype, data_getter, controller_device, receiver_device
 ):
     await _do_test(
         lambda controller: controller.test_rdma_buffer_write_from_non_contiguous_tensor_raises_error.call_one(),
@@ -648,13 +608,12 @@ async def test_rdma_buffer_write_from_non_contiguous_tensor_raises_error(
         data_getter,
         controller_device,
         receiver_device,
-        rdma_backend,
     )
 
 
 @_test_with_no_data
 async def test_rdma_buffer_read_into_smaller_size_raises_error(
-    dtype, data_getter, controller_device, receiver_device, rdma_backend
+    dtype, data_getter, controller_device, receiver_device
 ):
     await _do_test(
         lambda controller: controller.test_rdma_buffer_read_into_smaller_size_raises_error.call_one(),
@@ -662,13 +621,12 @@ async def test_rdma_buffer_read_into_smaller_size_raises_error(
         data_getter,
         controller_device,
         receiver_device,
-        rdma_backend,
     )
 
 
 @_test_with_no_data
 async def test_rdma_buffer_write_from_larger_size_raises_error(
-    dtype, data_getter, controller_device, receiver_device, rdma_backend
+    dtype, data_getter, controller_device, receiver_device
 ):
     await _do_test(
         lambda controller: controller.test_rdma_buffer_write_from_larger_size_raises_error.call_one(),
@@ -676,13 +634,12 @@ async def test_rdma_buffer_write_from_larger_size_raises_error(
         data_getter,
         controller_device,
         receiver_device,
-        rdma_backend,
     )
 
 
 @_test_with_all_data
 async def test_rdma_buffer_write_from(
-    dtype, data_getter, controller_device, receiver_device, rdma_backend
+    dtype, data_getter, controller_device, receiver_device
 ):
     await _do_test(
         lambda controller: controller.test_rdma_buffer_write_from.call_one(),
@@ -690,13 +647,12 @@ async def test_rdma_buffer_write_from(
         data_getter,
         controller_device,
         receiver_device,
-        rdma_backend,
     )
 
 
 @_test_with_all_data
 async def test_rdma_buffer_read_into(
-    dtype, data_getter, controller_device, receiver_device, rdma_backend
+    dtype, data_getter, controller_device, receiver_device
 ):
     await _do_test(
         lambda controller: controller.test_rdma_buffer_read_into.call_one(),
@@ -704,7 +660,6 @@ async def test_rdma_buffer_read_into(
         data_getter,
         controller_device,
         receiver_device,
-        rdma_backend,
     )
 
 


### PR DESCRIPTION
Summary:

Pulls the RDMA-backend pytest decorator out of `test_rdma.py` so the same fixture is shared by `test_rdma.py`, `test_rdma_unit.py`, and `test_rdma_cpu_no_torch.py`. While here, the modules switch to the new `parametrize_config_pointwise` API and stop pinning themselves with `pytestmark = pytest.mark.oss_skip`; the original shutdown-hang issue that motivated the skip is fixed.

Walkthrough:

- `python/tests/rdma_test_utils.py` (new) exports `RDMA_BACKENDS` (the list of backends to attempt) and `rdma_backends`, a `parametrize_config_pointwise(...)` decorator. On a host without ibverbs hardware it collapses to a single TCP run; on an RDMA-capable host it runs both `(rdma_disable_ibverbs=False, rdma_allow_tcp_fallback=False)` and `(True, True)` so both backends are exercised. The pointwise variant matters here because the two flags must move together — the cartesian product `parametrize_config` would generate would be redundant.
- `python/tests/test_rdma.py` deletes its in-file copy of `RDMA_BACKENDS` / `rdma_backends` / `stop_all_proc_meshes`, imports them from the shared modules, and drops `pytestmark = pytest.mark.oss_skip`.
- `python/tests/test_rdma_unit.py` does the same. `_do_test` no longer manages the `configured(...)` context manually since `rdma_backends` already wraps the test body in one. The per-test signatures lose the now-redundant `rdma_backend` parameter that used to be threaded through purely for backend dispatch.
- `python/tests/test_rdma_cpu_no_torch.py` imports `RDMA_BACKENDS` from the new util and drops its inline copy. We can't use `rdma_backends` here because it isn't compatible with the `isolate_in_subprocess` decorator.
- `python/tests/BUCK` adds the new `:rdma_test_utils` library, threads it (and `:proc_mesh_test_utils`) into the existing rdma test targets, and removes the now-unneeded `monarch/config` direct dep where it was only used for the `configured` import that lives behind the helpers.

Reviewed By: thomasywang

Differential Revision: D102533329


