### PR TITLE
[hyperactor] switch reference:: Display/FromStr to underlying ref_:: format

### DIFF
--- a/docs/source/books/hyperactor-book/src/references/actor_id.md
+++ b/docs/source/books/hyperactor-book/src/references/actor_id.md
@@ -27,7 +27,7 @@ Fields are private; use named constructors:
 use hyperactor::reference::{ActorId, ProcId};
 
 let addr = "tcp:127.0.0.1:8080".parse()?;
-let proc = ProcId::with_name(addr, "myproc");
+let proc = ProcId::from_resource_name(addr, "myproc");
 let actor = ActorId::new(proc.clone(), "worker");
 ```
 

--- a/docs/source/books/hyperactor-book/src/references/proc_id.md
+++ b/docs/source/books/hyperactor-book/src/references/proc_id.md
@@ -30,7 +30,7 @@ let addr = "tcp:127.0.0.1:8080".parse()?;
 // `unique` appends an address hash to make the name globally unique:
 let proc = ProcId::unique(addr.clone(), "service");
 // `with_name` uses the name as-is (for deserialization or already-unique names):
-let proc = ProcId::with_name(addr, "service");
+let proc = ProcId::from_resource_name(addr, "service");
 ```
 
 See [Host](../procs/host.md) for how procs are used in the Host architecture.

--- a/docs/source/books/hyperactor-book/src/references/syntax.md
+++ b/docs/source/books/hyperactor-book/src/references/syntax.md
@@ -6,22 +6,35 @@ References in Hyperactor follow a uniform concrete syntax that can be written as
 
 The canonical string syntax supports hierarchical references, from procs down to ports:
 ```text
-proc-id@location
-actor-id@location
-port-id@location
+location   := zmq URL
+label      := lowercase letter, then lowercase letters, digits, `-`, or `_`,
+              ending in a lowercase letter or digit
+uid58      := base58(u64) using the Flickr alphabet:
+              123456789abcdefghijkmnopqrstuvwxyzABCDEFGHJKLMNPQRSTUVWXYZ
 
-proc-id  := label | <uid> | label<uid>
-actor-id := actor-part.proc-id
-port-id  := actor-id:port
+proc-id    := label | "<" uid58 ">" | label "<" uid58 ">"
+actor-part := label | "<" uid58 ">" | label "<" uid58 ">"
+actor-id   := actor-part "." proc-id
+port-id    := actor-id ":" decimal-port
+
+proc-ref   := proc-id "@" location
+actor-ref  := actor-id "@" location
+port-ref   := port-id "@" location
 ```
 
-These forms can be used wherever a reference is accepted as a string, such as command-line arguments, config files, and logs.
+Singletons are self-documenting and therefore use the bare `label` form.
+Instance ids use `<uid58>`, with an optional semantic label outside the brackets:
+`label<uid58>`.
+
+These forms can be used wherever a reference is accepted as a string, such as
+command-line arguments, config files, and logs.
 
 Examples:
 
 - `local@inproc://0` — proc reference for the singleton `local` proc
 - `controller<2MuAHeDjLCEd>@tcp://[::1]:1234` — proc reference for a labeled proc instance
 - `logger.controller<2MuAHeDjLCEd>@tcp://[::1]:1234` — actor reference
+- `controller.some-proc-123<2MuAHeDjLCEd>@tcp://[::1]:1234` — actor with a singleton name in a labeled proc instance
 - `<2MuAHeDjLCEd>.<NRjEZGYjYibf>:42@tcp://[::1]:1234` — port 42 on an unlabeled actor instance
 
 The parser is robust and fails clearly on invalid syntax.

--- a/hyperactor/src/channel.rs
+++ b/hyperactor/src/channel.rs
@@ -838,8 +838,11 @@ impl ChannelAddr {
         address: &str,
     ) -> Result<(Self, Option<std::net::TcpListener>), anyhow::Error> {
         // Check for Alias format: dial_to_url@bind_to_url
-        // The @ character separates two valid ZMQ URLs
-        if let Some(at_pos) = address.find('@') {
+        // The @ character separates two valid ZMQ URLs.
+        if let Some(at_pos) = address
+            .find('@')
+            .filter(|&pos| address[..pos].starts_with("tcp://"))
+        {
             let dial_to_str = &address[..at_pos];
             let bind_to_str = &address[at_pos + 1..];
 
@@ -1433,9 +1436,12 @@ mod tests {
             _ => panic!("Expected Alias"),
         }
 
-        // Test error: alias with non-tcp dial_to (not supported)
+        // Non-tcp left side: alias branch is skipped, parsed as regular address.
+        // metatls:// with garbage host is not an alias.
+        let non_alias = ChannelAddr::from_zmq_url("metatls://example.com:443@tcp://127.0.0.1:8080");
         assert!(
-            ChannelAddr::from_zmq_url("metatls://example.com:443@tcp://127.0.0.1:8080").is_err()
+            !matches!(non_alias, Ok(ChannelAddr::Alias { .. })),
+            "non-tcp left side must not produce Alias"
         );
 
         // Test error: alias with non-tcp bind_to (not supported)
@@ -1443,7 +1449,7 @@ mod tests {
             ChannelAddr::from_zmq_url("tcp://127.0.0.1:8080@metatls://example.com:443").is_err()
         );
 
-        // Test error: invalid dial_to URL in Alias
+        // Test error: invalid scheme falls through to scheme parsing, errors there
         assert!(ChannelAddr::from_zmq_url("invalid://scheme@tcp://127.0.0.1:8080").is_err());
 
         // Test error: invalid bind_to URL in Alias

--- a/hyperactor/src/id.rs
+++ b/hyperactor/src/id.rs
@@ -8,8 +8,26 @@
 
 //! Universal identifier types for the actor system.
 //!
-//! [`Label`] is an RFC 1035 label: up to 63 lowercase alphanumeric characters
-//! plus hyphens, starting with a letter and ending with an alphanumeric.
+//! Concrete grammar:
+//!
+//! ```text
+//! label        := lowercase letter, then lowercase letters, digits, `-`, or `_`,
+//!                 ending in a lowercase letter or digit
+//! uid58        := base58(u64) using the Flickr alphabet
+//! uid          := label | "<" uid58 ">"
+//! proc-id      := label | "<" uid58 ">" | label "<" uid58 ">"
+//! actor-id     := actor-part "." proc-id
+//! actor-part   := label | "<" uid58 ">" | label "<" uid58 ">"
+//! port-id      := actor-id ":" decimal-port
+//! ```
+//!
+//! Singletons are self-documenting and therefore display as bare labels.
+//! Non-singleton ids display their semantic label, if any, outside the uid:
+//! `label<uid58>`. Unlabeled instances display as `<uid58>`.
+//!
+//! [`Label`] is an RFC 1035-style label: up to 63 lowercase alphanumeric
+//! characters plus `-` or `_`, starting with a letter and ending with an
+//! alphanumeric.
 //!
 //! [`Uid`] is either a singleton (identified by label) or an instance
 //! (identified by a random `u64`).
@@ -28,6 +46,9 @@ use crate::port::Port;
 
 /// Maximum length of an RFC 1035 label.
 const MAX_LABEL_LEN: usize = 63;
+
+/// Flickr base58 alphabet.
+const BASE58_FLICKR: &[u8; 58] = b"123456789abcdefghijkmnopqrstuvwxyzABCDEFGHJKLMNPQRSTUVWXYZ";
 
 /// An RFC 1035-style label: 1–63 chars, lowercase ASCII alphanumeric plus `-`
 /// or `_`,
@@ -178,9 +199,9 @@ pub enum UidParseError {
     /// Error parsing the label component.
     #[error("invalid label: {0}")]
     InvalidLabel(#[from] LabelError),
-    /// The hex uid portion is invalid.
-    #[error("invalid hex uid: {0}")]
-    InvalidHex(String),
+    /// The base58 uid portion is invalid.
+    #[error("invalid base58 uid: {0}")]
+    InvalidBase58(String),
 }
 
 impl Uid {
@@ -234,13 +255,12 @@ impl Ord for Uid {
     }
 }
 
-/// Displays as `_label` (singleton) or `hex16` (instance), where hex16 is
-/// a zero-padded 16-character lowercase hex string.
+/// Displays as `label` (singleton) or `<base58>` (instance).
 impl fmt::Debug for Uid {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Uid::Singleton(label) => write!(f, "Uid(_{})", label),
-            Uid::Instance(uid) => write!(f, "Uid({:016x})", uid),
+            Uid::Singleton(label) => write!(f, "Uid({})", label),
+            Uid::Instance(uid) => write!(f, "Uid(<{}>)", encode_base58_uid(*uid)),
         }
     }
 }
@@ -248,36 +268,89 @@ impl fmt::Debug for Uid {
 impl fmt::Display for Uid {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Uid::Singleton(label) => write!(f, "_{label}"),
-            Uid::Instance(uid) => write!(f, "{uid:016x}"),
+            Uid::Singleton(label) => write!(f, "{label}"),
+            Uid::Instance(uid) => write!(f, "<{}>", encode_base58_uid(*uid)),
         }
     }
 }
 
-/// Parses `_label` as singleton, bare hex as instance.
+/// Parses `label` as singleton, `<base58>` as instance.
 impl FromStr for Uid {
     type Err = UidParseError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        if let Some(rest) = s.strip_prefix('_') {
-            let label = Label::new(rest)?;
-            return Ok(Uid::Singleton(label));
+        if let Some(inner) = s
+            .strip_prefix('<')
+            .and_then(|inner| inner.strip_suffix('>'))
+        {
+            let uid = parse_base58_uid(inner)?;
+            return Ok(Uid::Instance(uid));
         }
-        let uid = parse_hex_uid(s)?;
-        Ok(Uid::Instance(uid))
+        Ok(Uid::Singleton(Label::new(s)?))
     }
 }
 
-fn parse_hex_uid(s: &str) -> Result<u64, UidParseError> {
-    if s.is_empty() || s.len() > 16 {
-        return Err(UidParseError::InvalidHex(s.to_string()));
+fn encode_base58_uid(mut uid: u64) -> String {
+    if uid == 0 {
+        return "1".to_string();
     }
-    for ch in s.chars() {
-        if !ch.is_ascii_hexdigit() {
-            return Err(UidParseError::InvalidHex(s.to_string()));
+
+    let mut digits = Vec::new();
+    while uid > 0 {
+        digits.push(BASE58_FLICKR[(uid % 58) as usize] as char);
+        uid /= 58;
+    }
+    digits.iter().rev().collect()
+}
+
+fn parse_base58_uid(s: &str) -> Result<u64, UidParseError> {
+    if s.is_empty() {
+        return Err(UidParseError::InvalidBase58(s.to_string()));
+    }
+
+    let mut uid = 0u64;
+    for ch in s.bytes() {
+        let digit = BASE58_FLICKR
+            .iter()
+            .position(|candidate| *candidate == ch)
+            .ok_or_else(|| UidParseError::InvalidBase58(s.to_string()))? as u64;
+        uid = uid
+            .checked_mul(58)
+            .and_then(|value| value.checked_add(digit))
+            .ok_or_else(|| UidParseError::InvalidBase58(s.to_string()))?;
+    }
+    Ok(uid)
+}
+
+fn fmt_id_component(f: &mut fmt::Formatter<'_>, uid: &Uid, label: Option<&Label>) -> fmt::Result {
+    match uid {
+        Uid::Singleton(singleton) => write!(f, "{}", singleton),
+        Uid::Instance(uid) => match label {
+            Some(label) => write!(f, "{}<{}>", label, encode_base58_uid(*uid)),
+            None => write!(f, "<{}>", encode_base58_uid(*uid)),
+        },
+    }
+}
+
+fn parse_id_component(s: &str) -> Result<(Uid, Option<Label>), UidParseError> {
+    if let Some(inner) = s
+        .strip_prefix('<')
+        .and_then(|inner| inner.strip_suffix('>'))
+    {
+        let uid = parse_base58_uid(inner)?;
+        return Ok((Uid::Instance(uid), None));
+    }
+
+    if let Some(open) = s.find('<') {
+        if s.ends_with('>') {
+            let label = Label::new(&s[..open])?;
+            let uid = parse_base58_uid(&s[open + 1..s.len() - 1])?;
+            return Ok((Uid::Instance(uid), Some(label)));
         }
     }
-    u64::from_str_radix(s, 16).map_err(|_| UidParseError::InvalidHex(s.to_string()))
+
+    let label = Label::new(s)?;
+    Ok((Uid::Singleton(label.clone()), Some(label)))
 }
 
 impl Serialize for Uid {
@@ -300,7 +373,7 @@ pub enum IdParseError {
     #[error("invalid proc id: {0}")]
     InvalidProcId(#[from] UidParseError),
     /// Error parsing an [`ActorId`] (missing `.` separator).
-    #[error("invalid actor id: expected format `<actor_uid>.<proc_uid>`")]
+    #[error("invalid actor id: expected format `<actor>.<proc>`")]
     InvalidActorIdFormat,
     /// Error parsing the actor uid component of an [`ActorId`].
     #[error("invalid actor uid: {0}")]
@@ -309,7 +382,7 @@ pub enum IdParseError {
     #[error("invalid proc uid in actor id: {0}")]
     InvalidActorProcUid(UidParseError),
     /// The `<actor_id>:<port>` separator is missing.
-    #[error("invalid port id: expected format `<actor_id>:<port>`")]
+    #[error("invalid port id: expected format `<actor>:<port>`")]
     InvalidPortIdFormat,
     /// The port component is invalid.
     #[error("invalid port: {0}")]
@@ -387,7 +460,7 @@ impl Ord for ProcId {
 
 impl fmt::Display for ProcId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.uid)
+        fmt_id_component(f, &self.uid, self.label.as_ref())
     }
 }
 
@@ -404,8 +477,8 @@ impl FromStr for ProcId {
     type Err = IdParseError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let uid: Uid = s.parse()?;
-        Ok(Self { uid, label: None })
+        let (uid, label) = parse_id_component(s)?;
+        Ok(Self { uid, label })
     }
 }
 
@@ -504,7 +577,8 @@ impl Ord for ActorId {
 
 impl fmt::Display for ActorId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}.{}", self.uid, self.proc_id.uid)
+        fmt_id_component(f, &self.uid, self.label.as_ref())?;
+        write!(f, ".{}", self.proc_id)
     }
 }
 
@@ -539,18 +613,17 @@ impl FromStr for ActorId {
         let actor_part = &s[..dot];
         let proc_part = &s[dot + 1..];
 
-        let actor_uid: Uid = actor_part.parse().map_err(IdParseError::InvalidActorUid)?;
-        let proc_uid: Uid = proc_part
-            .parse()
-            .map_err(IdParseError::InvalidActorProcUid)?;
+        let (actor_uid, actor_label) =
+            parse_id_component(actor_part).map_err(IdParseError::InvalidActorUid)?;
+        let proc_id: ProcId = proc_part.parse().map_err(|err| match err {
+            IdParseError::InvalidProcId(uid_err) => IdParseError::InvalidActorProcUid(uid_err),
+            _ => IdParseError::InvalidActorIdFormat,
+        })?;
 
         Ok(Self {
             uid: actor_uid,
-            proc_id: ProcId {
-                uid: proc_uid,
-                label: None,
-            },
-            label: None,
+            proc_id,
+            label: actor_label,
         })
     }
 }
@@ -753,7 +826,7 @@ mod tests {
     fn test_singleton_display_parse() {
         let uid = Uid::singleton(Label::new("my-actor").unwrap());
         let s = uid.to_string();
-        assert_eq!(s, "_my-actor");
+        assert_eq!(s, "my-actor");
         let parsed: Uid = s.parse().unwrap();
         assert_eq!(uid, parsed);
     }
@@ -762,7 +835,7 @@ mod tests {
     fn test_instance_display_parse() {
         let uid = Uid::Instance(0xd5d54d7201103869);
         let s = uid.to_string();
-        assert_eq!(s, "d5d54d7201103869");
+        assert_eq!(s, format!("<{}>", encode_base58_uid(0xd5d54d7201103869)));
         let parsed: Uid = s.parse().unwrap();
         assert_eq!(uid, parsed);
     }
@@ -804,15 +877,14 @@ mod tests {
 
     #[test]
     fn test_uid_parse_errors() {
-        // Empty string is invalid hex.
+        // Empty string is invalid.
         assert!("".parse::<Uid>().is_err());
         // Invalid singleton label.
-        assert!("_".parse::<Uid>().is_err());
-        assert!("_123bad".parse::<Uid>().is_err());
-        // Invalid hex.
-        assert!("xyz".parse::<Uid>().is_err());
-        // Hex too long.
-        assert!("00000000000000001".parse::<Uid>().is_err());
+        assert!("123bad".parse::<Uid>().is_err());
+        // Invalid base58.
+        assert!("<0>".parse::<Uid>().is_err());
+        // Missing closing delimiter.
+        assert!("<abc".parse::<Uid>().is_err());
     }
 
     #[test]
@@ -824,7 +896,7 @@ mod tests {
 
     #[test]
     fn test_short_hex_parse() {
-        let parsed: Uid = "1".parse().unwrap();
+        let parsed: Uid = "<2>".parse().unwrap();
         assert_eq!(parsed, Uid::Instance(1));
     }
 
@@ -874,13 +946,16 @@ mod tests {
             Uid::Instance(0xd5d54d7201103869),
             Some(Label::new("my-proc").unwrap()),
         );
-        assert_eq!(pid.to_string(), "d5d54d7201103869");
+        assert_eq!(
+            pid.to_string(),
+            format!("my-proc<{}>", encode_base58_uid(0xd5d54d7201103869))
+        );
 
         let pid_singleton = ProcId::new(
             Uid::singleton(Label::new("my-proc").unwrap()),
             Some(Label::new("my-proc").unwrap()),
         );
-        assert_eq!(pid_singleton.to_string(), "_my-proc");
+        assert_eq!(pid_singleton.to_string(), "my-proc");
     }
 
     #[test]
@@ -889,10 +964,16 @@ mod tests {
             Uid::Instance(0xd5d54d7201103869),
             Some(Label::new("my-proc").unwrap()),
         );
-        assert_eq!(format!("{:?}", pid), "<'my-proc' d5d54d7201103869>");
+        assert_eq!(
+            format!("{:?}", pid),
+            format!("<'my-proc' <{}>>", encode_base58_uid(0xd5d54d7201103869))
+        );
 
         let pid_no_label = ProcId::new(Uid::Instance(0xd5d54d7201103869), None);
-        assert_eq!(format!("{:?}", pid_no_label), "<d5d54d7201103869>");
+        assert_eq!(
+            format!("{:?}", pid_no_label),
+            format!("<<{}>>", encode_base58_uid(0xd5d54d7201103869))
+        );
     }
 
     #[test]
@@ -904,16 +985,17 @@ mod tests {
         let s = pid.to_string();
         let parsed: ProcId = s.parse().unwrap();
         assert_eq!(pid, parsed);
+        assert_eq!(parsed.label().map(|l| l.as_str()), Some("my-proc"));
     }
 
     #[test]
     fn test_proc_id_fromstr_singleton() {
-        let parsed: ProcId = "_my-proc".parse().unwrap();
+        let parsed: ProcId = "my-proc".parse().unwrap();
         assert_eq!(
             *parsed.uid(),
             Uid::singleton(Label::new("my-proc").unwrap())
         );
-        assert_eq!(parsed.label(), None);
+        assert_eq!(parsed.label().map(|l| l.as_str()), Some("my-proc"));
     }
 
     #[test]
@@ -1029,7 +1111,14 @@ mod tests {
             ),
             Some(Label::new("my-actor").unwrap()),
         );
-        assert_eq!(aid.to_string(), "0000000000abc123.0000000000def456");
+        assert_eq!(
+            aid.to_string(),
+            format!(
+                "my-actor<{}>.my-proc<{}>",
+                encode_base58_uid(0xabc123),
+                encode_base58_uid(0xdef456)
+            )
+        );
     }
 
     #[test]
@@ -1044,7 +1133,11 @@ mod tests {
         );
         assert_eq!(
             format!("{:?}", aid),
-            "<'my-actor.my-proc' 0000000000abc123.0000000000def456>"
+            format!(
+                "<'my-actor.my-proc' <{}>.<{}>>",
+                encode_base58_uid(0xabc123),
+                encode_base58_uid(0xdef456)
+            )
         );
 
         let aid_no_labels = ActorId::new(
@@ -1054,7 +1147,11 @@ mod tests {
         );
         assert_eq!(
             format!("{:?}", aid_no_labels),
-            "<0000000000abc123.0000000000def456>"
+            format!(
+                "<<{}>.<{}>>",
+                encode_base58_uid(0xabc123),
+                encode_base58_uid(0xdef456)
+            )
         );
     }
 
@@ -1071,11 +1168,16 @@ mod tests {
         let s = aid.to_string();
         let parsed: ActorId = s.parse().unwrap();
         assert_eq!(aid, parsed);
+        assert_eq!(parsed.label().map(|l| l.as_str()), Some("my-actor"));
+        assert_eq!(
+            parsed.proc_id().label().map(|l| l.as_str()),
+            Some("my-proc")
+        );
     }
 
     #[test]
     fn test_actor_id_fromstr_with_singletons() {
-        let parsed: ActorId = "_my-actor._my-proc".parse().unwrap();
+        let parsed: ActorId = "my-actor.my-proc".parse().unwrap();
         assert_eq!(
             *parsed.uid(),
             Uid::singleton(Label::new("my-actor").unwrap())
@@ -1083,6 +1185,11 @@ mod tests {
         assert_eq!(
             *parsed.proc_id().uid(),
             Uid::singleton(Label::new("my-proc").unwrap())
+        );
+        assert_eq!(parsed.label().map(|l| l.as_str()), Some("my-actor"));
+        assert_eq!(
+            parsed.proc_id().label().map(|l| l.as_str()),
+            Some("my-proc")
         );
     }
 
@@ -1217,7 +1324,14 @@ mod tests {
             Some(Label::new("my-actor").unwrap()),
         );
         let pid = PortId::new(aid, Port::from(42));
-        assert_eq!(pid.to_string(), "0000000000abc123.0000000000def456:42");
+        assert_eq!(
+            pid.to_string(),
+            format!(
+                "my-actor<{}>.my-proc<{}>:42",
+                encode_base58_uid(0xabc123),
+                encode_base58_uid(0xdef456)
+            )
+        );
     }
 
     #[test]
@@ -1233,7 +1347,11 @@ mod tests {
         let pid = PortId::new(aid, Port::from(42));
         assert_eq!(
             format!("{:?}", pid),
-            "<'my-actor.my-proc' 0000000000abc123.0000000000def456:42>"
+            format!(
+                "<'my-actor.my-proc' my-actor<{}>.my-proc<{}>:42>",
+                encode_base58_uid(0xabc123),
+                encode_base58_uid(0xdef456)
+            )
         );
     }
 
@@ -1247,7 +1365,11 @@ mod tests {
         let pid = PortId::new(aid, Port::from(42));
         assert_eq!(
             format!("{:?}", pid),
-            "<0000000000abc123.0000000000def456:42>"
+            format!(
+                "<<{}>.<{}>:42>",
+                encode_base58_uid(0xabc123),
+                encode_base58_uid(0xdef456)
+            )
         );
     }
 
@@ -1261,7 +1383,11 @@ mod tests {
         let pid = PortId::new(aid, Port::from(42));
         assert_eq!(
             format!("{:?}", pid),
-            "<'my-actor' 0000000000abc123.0000000000def456:42>"
+            format!(
+                "<'my-actor' my-actor<{}>.<{}>:42>",
+                encode_base58_uid(0xabc123),
+                encode_base58_uid(0xdef456)
+            )
         );
     }
 
@@ -1278,7 +1404,11 @@ mod tests {
         let pid = PortId::new(aid, Port::from(42));
         assert_eq!(
             format!("{:?}", pid),
-            "<'.my-proc' 0000000000abc123.0000000000def456:42>"
+            format!(
+                "<'.my-proc' <{}>.my-proc<{}>:42>",
+                encode_base58_uid(0xabc123),
+                encode_base58_uid(0xdef456)
+            )
         );
     }
 
@@ -1296,22 +1426,22 @@ mod tests {
         let s = pid.to_string();
         let parsed: PortId = s.parse().unwrap();
         assert_eq!(pid, parsed);
+        assert_eq!(
+            parsed.actor_id().label().map(|l| l.as_str()),
+            Some("my-actor")
+        );
+        assert_eq!(
+            parsed.actor_id().proc_id().label().map(|l| l.as_str()),
+            Some("my-proc")
+        );
     }
 
     #[test]
     fn test_port_id_fromstr_errors() {
         // Missing colon.
-        assert!(
-            "0000000000abc123.0000000000def456"
-                .parse::<PortId>()
-                .is_err()
-        );
+        assert!("<abc>.<def>".parse::<PortId>().is_err());
         // Invalid port.
-        assert!(
-            "0000000000abc123.0000000000def456:notanumber"
-                .parse::<PortId>()
-                .is_err()
-        );
+        assert!("actor.proc:notanumber".parse::<PortId>().is_err());
     }
 
     #[test]

--- a/hyperactor/src/mailbox.rs
+++ b/hyperactor/src/mailbox.rs
@@ -2942,7 +2942,6 @@ mod tests {
 
     use std::assert_matches::assert_matches;
     use std::mem::drop;
-    use std::str::FromStr;
     use std::sync::atomic::AtomicUsize;
     use std::time::Duration;
 
@@ -2976,10 +2975,12 @@ mod tests {
             test_actor_id("myworld_2", "myactor"),
             MailboxErrorKind::Closed,
         );
+        // ActorId display is now "actor_uid.proc_uid@location"
         let err_str = format!("{err}");
         assert!(
             err_str.contains("mailbox closed"),
-            "unexpected format: {err_str}"
+            "expected error: {}",
+            err_str
         );
         assert!(
             err_str.contains("@"),
@@ -3235,8 +3236,13 @@ mod tests {
             "unix!@4".parse().unwrap(),
         );
         // Bind a direct address -- we should use its bound address!
+        // The actor must be on unix:@4 so that after unbinding, the prefix
+        // route for world1_1 (unix!@3) is the fallback, not world1_1/actor1 (unix!@4).
+        let direct_actor_id =
+            reference::ProcId::from_resource_name("unix:@4".parse().unwrap(), "my_proc")
+                .actor_id("my_actor");
         router.bind(
-            "unix:@4,my_proc,my_actor".parse().unwrap(),
+            reference::Reference::Actor(direct_actor_id.clone()),
             "unix:@5".parse().unwrap(),
         );
 
@@ -3248,10 +3254,7 @@ mod tests {
             .lookup_addr(&test_actor_id("world1_0", "actor"))
             .unwrap();
 
-        let actor_id = reference::Reference::from_str("unix:@4,my_proc,my_actor")
-            .unwrap()
-            .into_actor()
-            .unwrap();
+        let actor_id = direct_actor_id;
         assert_eq!(
             router.lookup_addr(&actor_id).unwrap(),
             "unix!@5".parse().unwrap(),

--- a/hyperactor/src/ref_.rs
+++ b/hyperactor/src/ref_.rs
@@ -7,6 +7,28 @@
  */
 
 //! References: identifiers paired with a network location.
+//!
+//! Concrete grammar:
+//!
+//! ```text
+//! location     := zmq URL understood by [`ChannelAddr::from_zmq_url`]
+//! proc-ref     := proc-id "@" location
+//! actor-ref    := actor-id "@" location
+//! port-ref     := port-id "@" location
+//!
+//! proc-id      := label | "<" uid58 ">" | label "<" uid58 ">"
+//! actor-id     := actor-part "." proc-id
+//! actor-part   := label | "<" uid58 ">" | label "<" uid58 ">"
+//! ```
+//!
+//! Examples:
+//!
+//! ```text
+//! local@inproc://0
+//! controller<2MuAHeDjLCEd>@tcp://[::1]:2345
+//! controller<2MuAHeDjLCEd>.local@inproc://0
+//! <2MuAHeDjLCEd>.<NRjEZGYjYibf>:42@tcp://[::1]:2345
+//! ```
 
 use std::fmt;
 use std::str::FromStr;
@@ -390,7 +412,7 @@ mod tests {
         );
         let loc: Location = ChannelAddr::Local(42).into();
         let pref = ProcRef::new(pid, loc);
-        assert_eq!(pref.to_string(), "0000000000abc123@inproc://42");
+        assert_eq!(pref.to_string(), format!("{}@inproc://42", pref.id()));
     }
 
     #[test]
@@ -403,7 +425,7 @@ mod tests {
         let pref = ProcRef::new(pid, loc);
         assert_eq!(
             format!("{:?}", pref),
-            "<'my-proc' 0000000000abc123@inproc://42>"
+            format!("<'my-proc' {}@inproc://42>", pref.id())
         );
     }
 
@@ -412,7 +434,10 @@ mod tests {
         let pid = ProcId::new(Uid::Instance(0xabc123), None);
         let loc: Location = ChannelAddr::Local(42).into();
         let pref = ProcRef::new(pid, loc);
-        assert_eq!(format!("{:?}", pref), "<0000000000abc123@inproc://42>");
+        assert_eq!(
+            format!("{:?}", pref),
+            format!("<{}@inproc://42>", pref.id())
+        );
     }
 
     #[test]
@@ -430,7 +455,12 @@ mod tests {
 
     #[test]
     fn test_proc_ref_fromstr_tcp() {
-        let parsed: ProcRef = "0000000000abc123@tcp://127.0.0.1:8080".parse().unwrap();
+        let parsed: ProcRef = format!(
+            "{}@tcp://127.0.0.1:8080",
+            ProcId::new(Uid::Instance(0xabc123), None)
+        )
+        .parse()
+        .unwrap();
         assert_eq!(*parsed.id().uid(), Uid::Instance(0xabc123));
         assert_eq!(
             *parsed.location().addr(),
@@ -440,7 +470,10 @@ mod tests {
 
     #[test]
     fn test_proc_ref_fromstr_missing_separator() {
-        let err = "0000000000abc123".parse::<ProcRef>().unwrap_err();
+        let err = ProcId::new(Uid::Instance(0xabc123), None)
+            .to_string()
+            .parse::<ProcRef>()
+            .unwrap_err();
         assert!(matches!(err, RefParseError::MissingSeparator));
     }
 
@@ -456,10 +489,7 @@ mod tests {
         );
         let loc: Location = ChannelAddr::Local(42).into();
         let aref = ActorRef::new(aid, loc);
-        assert_eq!(
-            aref.to_string(),
-            "0000000000abc123.0000000000def456@inproc://42"
-        );
+        assert_eq!(aref.to_string(), format!("{}@inproc://42", aref.id()));
     }
 
     #[test]
@@ -476,7 +506,7 @@ mod tests {
         let aref = ActorRef::new(aid, loc);
         assert_eq!(
             format!("{:?}", aref),
-            "<'my-actor.my-proc' 0000000000abc123.0000000000def456@inproc://42>"
+            format!("<'my-actor.my-proc' {}@inproc://42>", aref.id())
         );
     }
 
@@ -491,7 +521,7 @@ mod tests {
         let aref = ActorRef::new(aid, loc);
         assert_eq!(
             format!("{:?}", aref),
-            "<0000000000abc123.0000000000def456@inproc://42>"
+            format!("<{}@inproc://42>", aref.id())
         );
     }
 
@@ -506,7 +536,7 @@ mod tests {
         let aref = ActorRef::new(aid, loc);
         assert_eq!(
             format!("{:?}", aref),
-            "<'my-actor' 0000000000abc123.0000000000def456@inproc://42>"
+            format!("<'my-actor' {}@inproc://42>", aref.id())
         );
     }
 
@@ -524,7 +554,7 @@ mod tests {
         let aref = ActorRef::new(aid, loc);
         assert_eq!(
             format!("{:?}", aref),
-            "<'.my-proc' 0000000000abc123.0000000000def456@inproc://42>"
+            format!("<'.my-proc' {}@inproc://42>", aref.id())
         );
     }
 
@@ -543,13 +573,23 @@ mod tests {
         let s = aref.to_string();
         let parsed: ActorRef = s.parse().unwrap();
         assert_eq!(aref, parsed);
+        assert_eq!(parsed.id.label().map(|l| l.as_str()), Some("my-actor"));
+        assert_eq!(
+            parsed.id.proc_id().label().map(|l| l.as_str()),
+            Some("my-proc")
+        );
     }
 
     #[test]
     fn test_actor_ref_fromstr_missing_separator() {
-        let err = "0000000000abc123.0000000000def456"
-            .parse::<ActorRef>()
-            .unwrap_err();
+        let err = ActorId::new(
+            Uid::Instance(0xabc123),
+            ProcId::new(Uid::Instance(0xdef456), None),
+            None,
+        )
+        .to_string()
+        .parse::<ActorRef>()
+        .unwrap_err();
         assert!(matches!(err, RefParseError::MissingSeparator));
     }
 
@@ -612,7 +652,7 @@ mod tests {
         let loc: Location = ChannelAddr::Local(0).into();
         let pref = ProcRef::new(pid, loc);
         let s = pref.to_string();
-        assert_eq!(s, "_my-proc@inproc://0");
+        assert_eq!(s, "my-proc@inproc://0");
         let parsed: ProcRef = s.parse().unwrap();
         assert_eq!(pref, parsed);
     }
@@ -663,7 +703,7 @@ mod tests {
         let loc: Location = ChannelAddr::MetaTls(TlsAddr::new("example.com", 443)).into();
         let pref = ProcRef::new(pid, loc);
         let s = pref.to_string();
-        assert_eq!(s, "0000000000000042@metatls://example.com:443");
+        assert_eq!(s, format!("{}@metatls://example.com:443", pref.id()));
         let parsed: ProcRef = s.parse().unwrap();
         assert_eq!(pref, parsed);
     }
@@ -699,10 +739,7 @@ mod tests {
         let port_id = PortId::new(aid, Port::from(42));
         let loc: Location = ChannelAddr::Local(7).into();
         let pref = PortRef::new(port_id, loc);
-        assert_eq!(
-            pref.to_string(),
-            "0000000000abc123.0000000000def456:42@inproc://7"
-        );
+        assert_eq!(pref.to_string(), format!("{}@inproc://7", pref.id()));
     }
 
     #[test]
@@ -720,7 +757,7 @@ mod tests {
         let pref = PortRef::new(port_id, loc);
         assert_eq!(
             format!("{:?}", pref),
-            "<'my-actor.my-proc' 0000000000abc123.0000000000def456:42@inproc://7>"
+            format!("<'my-actor.my-proc' {}@inproc://7>", pref.id())
         );
     }
 
@@ -734,10 +771,7 @@ mod tests {
         let port_id = PortId::new(aid, Port::from(42));
         let loc: Location = ChannelAddr::Local(7).into();
         let pref = PortRef::new(port_id, loc);
-        assert_eq!(
-            format!("{:?}", pref),
-            "<0000000000abc123.0000000000def456:42@inproc://7>"
-        );
+        assert_eq!(format!("{:?}", pref), format!("<{}@inproc://7>", pref.id()));
     }
 
     #[test]
@@ -752,7 +786,7 @@ mod tests {
         let pref = PortRef::new(port_id, loc);
         assert_eq!(
             format!("{:?}", pref),
-            "<'my-actor' 0000000000abc123.0000000000def456:42@inproc://7>"
+            format!("<'my-actor' {}@inproc://7>", pref.id())
         );
     }
 
@@ -771,7 +805,7 @@ mod tests {
         let pref = PortRef::new(port_id, loc);
         assert_eq!(
             format!("{:?}", pref),
-            "<'.my-proc' 0000000000abc123.0000000000def456:42@inproc://7>"
+            format!("<'.my-proc' {}@inproc://7>", pref.id())
         );
     }
 
@@ -791,13 +825,29 @@ mod tests {
         let s = pref.to_string();
         let parsed: PortRef = s.parse().unwrap();
         assert_eq!(pref, parsed);
+        assert_eq!(
+            parsed.id.actor_id().label().map(|l| l.as_str()),
+            Some("my-actor")
+        );
+        assert_eq!(
+            parsed.id.actor_id().proc_id().label().map(|l| l.as_str()),
+            Some("my-proc")
+        );
     }
 
     #[test]
     fn test_port_ref_fromstr_missing_separator() {
-        let err = "0000000000abc123.0000000000def456:42"
-            .parse::<PortRef>()
-            .unwrap_err();
+        let err = PortId::new(
+            ActorId::new(
+                Uid::Instance(0xabc123),
+                ProcId::new(Uid::Instance(0xdef456), None),
+                None,
+            ),
+            Port::from(42),
+        )
+        .to_string()
+        .parse::<PortRef>()
+        .unwrap_err();
         assert!(matches!(err, RefParseError::MissingSeparator));
     }
 

--- a/hyperactor/src/reference.rs
+++ b/hyperactor/src/reference.rs
@@ -40,9 +40,7 @@ use serde::Deserialize;
 use serde::Deserializer;
 use serde::Serialize;
 use serde::Serializer;
-use typeuri::ACTOR_PORT_BIT;
 use typeuri::Named;
-use wirevalue::TypeInfo;
 
 use crate::Actor;
 use crate::ActorHandle;
@@ -69,11 +67,8 @@ pub mod lex;
 pub mod name;
 mod parse;
 
-use parse::Lexer;
 use parse::ParseError;
-use parse::Token;
 pub use parse::is_valid_ident;
-use parse::parse;
 
 /// The kinds of references.
 #[derive(strum::Display)]
@@ -91,9 +86,9 @@ pub enum ReferenceKind {
 /// References implement a concrete syntax which can be parsed via
 /// [`FromStr`]. They are of the form:
 ///
-/// - `addr,proc_name`,
-/// - `addr,proc_name,actor_name[pid]`,
-/// - `addr,proc_name,actor_name[pid][port]`
+/// - `proc@location`,
+/// - `actor.proc@location`,
+/// - `actor.proc:port@location`
 ///
 /// Reference also implements a total ordering, so that references are
 /// ordered lexicographically with the hierarchy implied by proc,
@@ -234,46 +229,22 @@ pub enum ReferenceParsingError {
 impl FromStr for Reference {
     type Err = ReferenceParsingError;
 
-    fn from_str(addr: &str) -> Result<Self, Self::Err> {
-        // References are parsed in the "direct" format:
-        // The reference must contain a comma (anywhere), indicating a proc/actor/port reference.
-
-        match addr.split_once(",") {
-            Some((channel_addr, rest)) => {
-                let channel_addr = channel_addr.parse().map_err(|err| {
-                    ReferenceParsingError::InvalidChannelAddress(channel_addr.to_string(), err)
-                })?;
-
-                Ok(parse! {
-                    Lexer::new(rest);
-
-                    // channeladdr,proc_name
-                    Token::Elem(proc_name) =>
-                    Self::Proc(ProcId::from_resource_name(channel_addr, proc_name)),
-
-                    // channeladdr,proc_name,actor_name
-                    Token::Elem(proc_name) Token::Comma Token::Elem(actor_name) =>
-                    Self::Actor(ActorId::new(ProcId::from_resource_name(channel_addr, proc_name), actor_name)),
-
-                    // channeladdr,proc_name,actor_name[port]
-                    Token::Elem(proc_name) Token::Comma Token::Elem(actor_name)
-                        Token::LeftBracket Token::Uint(port) Token::RightBracket =>
-                        Self::Port(PortId::new(ActorId::new(ProcId::from_resource_name(channel_addr, proc_name), actor_name), port as u64)),
-
-                    // channeladdr,proc_name,actor_name[port<type>]
-                    Token::Elem(proc_name) Token::Comma Token::Elem(actor_name)
-                        Token::LeftBracket Token::Uint(port)
-                            Token::LessThan Token::Elem(_type) Token::GreaterThan
-                        Token::RightBracket =>
-                        Self::Port(PortId::new(ActorId::new(ProcId::from_resource_name(channel_addr, proc_name), actor_name), port as u64)),
-                }?)
-            }
-
-            None => Err(ReferenceParsingError::Unexpected(format!(
-                "expected a comma-separated reference, got: {}",
-                addr
-            ))),
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        // References use the ref_:: format: "id@location".
+        // Try most specific first: Port (has `:` in id), Actor (has `.`), Proc.
+        if let Ok(port_ref) = s.parse::<ref_::PortRef>() {
+            return Ok(Self::Port(PortId(port_ref)));
         }
+        if let Ok(actor_ref) = s.parse::<ref_::ActorRef>() {
+            return Ok(Self::Actor(ActorId(actor_ref)));
+        }
+        if let Ok(proc_ref) = s.parse::<ref_::ProcRef>() {
+            return Ok(Self::Proc(ProcId(proc_ref)));
+        }
+        Err(ReferenceParsingError::Unexpected(format!(
+            "could not parse reference: {}",
+            s
+        )))
     }
 }
 
@@ -302,10 +273,18 @@ pub type Index = usize;
 /// Parse a proc resource name into a `(Uid, Option<Label>)` pair.
 ///
 /// Accepts both the legacy compat forms used by `reference::ProcId::Display`
-/// (`_label`, `label-hex16`, `hex16`) and the newer labeled-id forms
-/// (`label`, `label<hex16>`, `<hex16>`). Falls back to a stripped singleton
+/// (`_label`, `label-uid58`, `uid58`) and the newer labeled-id forms
+/// (`label`, `label<uid58>`, `<uid58>`). Falls back to a stripped singleton
 /// label for non-matching input.
 fn parse_resource_name(s: &str) -> (Uid, Option<Label>) {
+    fn parse_wrapped_instance_uid(s: &str) -> Option<u64> {
+        let wrapped = format!("<{s}>");
+        match Uid::from_str(&wrapped) {
+            Ok(Uid::Instance(uid)) => Some(uid),
+            _ => None,
+        }
+    }
+
     if let Some(rest) = s.strip_prefix('_') {
         if let Ok(label) = Label::new(rest) {
             return (Uid::Singleton(label.clone()), Some(label));
@@ -318,9 +297,16 @@ fn parse_resource_name(s: &str) -> (Uid, Option<Label>) {
         return (Uid::Instance(uid), None);
     }
 
-    if let Some((label_part, uid_part)) = s.rsplit_once('-') {
+    if let Some((label_part, uid_part)) = s.rsplit_once('-')
+        && uid_part.len() >= 8
+    {
         if let (Ok(label), Ok(Uid::Instance(uid))) =
             (Label::new(label_part), Uid::from_str(uid_part))
+        {
+            return (Uid::Instance(uid), Some(label));
+        }
+        if let (Ok(label), Some(uid)) =
+            (Label::new(label_part), parse_wrapped_instance_uid(uid_part))
         {
             return (Uid::Instance(uid), Some(label));
         }
@@ -391,10 +377,10 @@ impl ProcId {
 
     /// Create a ProcId by parsing a name string in ResourceId format.
     ///
-    /// Recognizes three formats:
-    /// - `label` → singleton uid
-    /// - `label<uid58>` → labeled instance uid
-    /// - `<uid58>` → unlabeled instance uid
+    /// Recognizes both compatibility and current display forms:
+    /// - `label` or `_label` → singleton uid
+    /// - `label-uid58` or `label<uid58>` → labeled instance uid
+    /// - `uid58` or `<uid58>` → unlabeled instance uid
     ///
     /// Falls back to `Uid::Singleton(Label::strip(name))` if none match.
     pub fn from_resource_name(addr: ChannelAddr, name: impl AsRef<str>) -> Self {
@@ -447,7 +433,7 @@ impl ProcId {
 
     /// A human-readable name for logging, derived from the label or uid.
     pub fn log_name(&self) -> &str {
-        self.0.id().label().map(|l| l.as_str()).unwrap_or("?")
+        self.label().map(|l| l.as_str()).unwrap_or("?")
     }
 
     /// The ResourceId text form of this proc's identity.
@@ -468,18 +454,7 @@ impl ProcId {
 
 impl fmt::Display for ProcId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        // Compat format: "addr,resource_name" where resource_name is the
-        // ResourceId text form: _label | label-hex16 | hex16.
-        let id = self.0.id();
-        match (id.uid(), id.label()) {
-            (Uid::Singleton(label), _) => write!(f, "{},_{}", self.0.location().addr(), label),
-            (Uid::Instance(uid), Some(label)) => {
-                write!(f, "{},{}-{:016x}", self.0.location().addr(), label, uid)
-            }
-            (Uid::Instance(uid), None) => {
-                write!(f, "{},{:016x}", self.0.location().addr(), uid)
-            }
-        }
+        fmt::Display::fmt(&self.0, f)
     }
 }
 
@@ -495,10 +470,10 @@ impl FromStr for ProcId {
             }
         }
 
-        match s.parse()? {
-            Reference::Proc(proc_id) => Ok(proc_id),
-            _ => Err(ReferenceParsingError::WrongType("proc".into())),
-        }
+        let proc_ref: ref_::ProcRef = s
+            .parse()
+            .map_err(|e| ReferenceParsingError::Unexpected(format!("{}", e)))?;
+        Ok(Self(proc_ref))
     }
 }
 
@@ -605,18 +580,7 @@ impl ActorId {
 
 impl fmt::Display for ActorId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        // Compat format: "proc_display,actor_resource_name"
-        let id = self.0.id();
-        let proc_id = self.proc_id();
-        match (id.uid(), id.label()) {
-            (Uid::Singleton(label), _) => write!(f, "{},{}", proc_id, label),
-            (Uid::Instance(uid), Some(label)) => {
-                write!(f, "{},{}-{:016x}", proc_id, label, uid)
-            }
-            (Uid::Instance(uid), None) => {
-                write!(f, "{},{:016x}", proc_id, uid)
-            }
-        }
+        fmt::Display::fmt(&self.0, f)
     }
 }
 impl<A: Referable> From<ActorRef<A>> for ActorId {
@@ -634,11 +598,11 @@ impl<'a, A: Referable> From<&'a ActorRef<A>> for &'a ActorId {
 impl FromStr for ActorId {
     type Err = ReferenceParsingError;
 
-    fn from_str(addr: &str) -> Result<Self, Self::Err> {
-        match addr.parse()? {
-            Reference::Actor(actor_id) => Ok(actor_id),
-            _ => Err(ReferenceParsingError::WrongType("actor".into())),
-        }
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let actor_ref: ref_::ActorRef = s
+            .parse()
+            .map_err(|e| ReferenceParsingError::Unexpected(format!("{}", e)))?;
+        Ok(Self(actor_ref))
     }
 }
 
@@ -896,25 +860,17 @@ impl PortId {
 impl FromStr for PortId {
     type Err = ReferenceParsingError;
 
-    fn from_str(addr: &str) -> Result<Self, Self::Err> {
-        match addr.parse()? {
-            Reference::Port(port_id) => Ok(port_id),
-            _ => Err(ReferenceParsingError::WrongType("port".into())),
-        }
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let port_ref: ref_::PortRef = s
+            .parse()
+            .map_err(|e| ReferenceParsingError::Unexpected(format!("{}", e)))?;
+        Ok(Self(port_ref))
     }
 }
 
 impl fmt::Display for PortId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let actor_id = self.actor_id();
-        let port = self.index();
-        if self.is_actor_port() {
-            let type_info = TypeInfo::get(port).or_else(|| TypeInfo::get(port & !ACTOR_PORT_BIT));
-            let typename = type_info.map_or("unknown", TypeInfo::typename);
-            write!(f, "{}[{}<{}>]", actor_id, port, typename)
-        } else {
-            write!(f, "{}[{}]", actor_id, port)
-        }
+        fmt::Display::fmt(&self.0, f)
     }
 }
 
@@ -1343,63 +1299,70 @@ mod tests {
 
     #[test]
     fn test_reference_parse() {
-        let cases: Vec<(&str, Reference)> = vec![
-            (
-                "tcp:[::1]:1234,test",
-                ProcId::from_resource_name(
-                    "tcp:[::1]:1234".parse::<ChannelAddr>().unwrap(),
-                    "test",
-                )
-                .into(),
-            ),
-            (
-                "tcp:[::1]:1234,test,testactor",
-                ActorId::new(
-                    ProcId::from_resource_name(
-                        "tcp:[::1]:1234".parse::<ChannelAddr>().unwrap(),
-                        "test",
-                    ),
-                    "testactor",
-                )
-                .into(),
-            ),
-            (
-                // instance actor (label-hex16 format)
-                "tcp:[::1]:1234,test,myactor-00000000deadbeef",
-                ActorId::new(
-                    ProcId::from_resource_name(
-                        "tcp:[::1]:1234".parse::<ChannelAddr>().unwrap(),
-                        "test",
-                    ),
-                    "myactor-00000000deadbeef",
-                )
-                .into(),
-            ),
-            (
-                // one bracket group = port (type annotations ignored)
-                "tcp:[::1]:1234,test,testactor[123<my::type>]",
-                PortId::new(
-                    ActorId::new(
-                        ProcId::from_resource_name(
-                            "tcp:[::1]:1234".parse::<ChannelAddr>().unwrap(),
-                            "test",
-                        ),
-                        "testactor",
-                    ),
-                    123,
-                )
-                .into(),
-            ),
-        ];
+        // New format: "uid@location" for Proc, "actor.proc@loc" for Actor,
+        // "actor.proc:port@loc" for Port.
+        let addr: ChannelAddr = "tcp:[::1]:1234".parse().unwrap();
+        let _loc = "tcp://[::1]:1234".to_string();
 
-        for (s, expected) in cases {
-            assert_eq!(s.parse::<Reference>().unwrap(), expected, "for {}", s);
-        }
+        let proc_id = ProcId::from_resource_name(addr.clone(), "test");
+        let proc_str = proc_id.to_string();
+        assert_eq!(
+            proc_str.parse::<Reference>().unwrap(),
+            Reference::Proc(proc_id.clone())
+        );
+
+        let actor_id = ActorId::new(proc_id.clone(), "testactor");
+        let actor_str = actor_id.to_string();
+        assert_eq!(
+            actor_str.parse::<Reference>().unwrap(),
+            Reference::Actor(actor_id.clone())
+        );
+
+        let port_id = PortId::new(actor_id.clone(), 123);
+        let port_str = port_id.to_string();
+        assert_eq!(
+            port_str.parse::<Reference>().unwrap(),
+            Reference::Port(port_id)
+        );
+    }
+
+    #[test]
+    fn test_reference_display_roundtrip() {
+        let addr: ChannelAddr = "tcp:[::1]:1234".parse().unwrap();
+
+        let proc_id = ProcId::from_resource_name(addr.clone(), "test");
+        let proc_str = proc_id.to_string();
+        assert_eq!(proc_str.parse::<ProcId>().unwrap(), proc_id);
+
+        let actor_id = ActorId::new(proc_id.clone(), "myactor");
+        let actor_str = actor_id.to_string();
+        assert_eq!(actor_str.parse::<ActorId>().unwrap(), actor_id);
+
+        let port_id = PortId::new(actor_id.clone(), 42);
+        let port_str = port_id.to_string();
+        assert_eq!(port_str.parse::<PortId>().unwrap(), port_id);
+    }
+
+    #[test]
+    fn test_actor_label_roundtrip_preserves_singleton_names() {
+        let addr: ChannelAddr = "tcp:[::1]:1234".parse().unwrap();
+        let proc_id = ProcId::from_resource_name(addr, "service");
+        let actor_id = ActorId::new(proc_id, "host_agent");
+
+        let parsed: ActorId = actor_id.to_string().parse().unwrap();
+        assert_eq!(
+            parsed.label().map(|label| label.as_str()),
+            Some("host_agent")
+        );
+        assert_eq!(
+            parsed.proc_id().label().map(|label| label.as_str()),
+            Some("service")
+        );
     }
 
     #[test]
     fn test_reference_parse_error() {
-        let cases: Vec<&str> = vec!["(blah)", "world(1, 2, 3)", "test"];
+        let cases: Vec<&str> = vec!["(blah)", "world(1, 2, 3)", "no-at-sign"];
 
         for s in cases {
             let result: Result<Reference, ReferenceParsingError> = s.parse();
@@ -1409,14 +1372,11 @@ mod tests {
 
     #[test]
     fn test_reference_ord() {
-        let expected: Vec<Reference> = [
-            "tcp:[::1]:1234,first",
-            "tcp:[::1]:1234,second",
-            "tcp:[::1]:1234,third",
-        ]
-        .into_iter()
-        .map(|s| s.parse().unwrap())
-        .collect();
+        let addr: ChannelAddr = "tcp:[::1]:1234".parse().unwrap();
+        let expected: Vec<Reference> = ["first", "second", "third"]
+            .into_iter()
+            .map(|name| Reference::Proc(ProcId::from_resource_name(addr.clone(), name)))
+            .collect();
 
         let mut sorted = expected.to_vec();
         sorted.shuffle(&mut rand::rng());
@@ -1426,32 +1386,16 @@ mod tests {
     }
 
     #[test]
-    fn test_port_type_annotation() {
-        #[derive(typeuri::Named, Serialize, Deserialize)]
-        struct MyType;
-        wirevalue::register_type!(MyType);
+    fn test_port_display() {
+        let addr: ChannelAddr = "tcp:[::1]:1234".parse().unwrap();
         let port_id = PortId::new(
-            ActorId::new(
-                ProcId::from_resource_name(
-                    "tcp:[::1]:1234".parse::<ChannelAddr>().unwrap(),
-                    "test",
-                ),
-                "testactor",
-            ),
-            MyType::port(),
+            ActorId::new(ProcId::from_resource_name(addr, "test"), "testactor"),
+            42,
         );
         let s = port_id.to_string();
-        assert!(
-            s.starts_with("testactor.test@tcp://[::1]:1234:")
-                || s.starts_with("testactor.test@tcp:[::1]:1234:"),
-            "unexpected format: {}",
-            s
-        );
-        assert!(
-            !s.contains('<') || s.contains(".test@"),
-            "unexpected format: {}",
-            s
-        );
+        // Format: "actor_uid.proc_uid:port@location"
+        assert!(s.contains("@tcp://"), "expected @ separator: {}", s);
+        assert!(s.contains(":42@"), "expected port 42: {}", s);
     }
 
     #[test]
@@ -1459,7 +1403,7 @@ mod tests {
         let addr = "tcp:[::1]:1234".parse::<ChannelAddr>().unwrap();
         let proc_id = ProcId::from_resource_name(addr, "test");
         let s = proc_id.to_string();
-        assert_eq!(s, "tcp:[::1]:1234,_test");
+        assert_eq!(s, "test@tcp://[::1]:1234");
         assert_eq!(s.parse::<ProcId>().unwrap(), proc_id);
     }
 
@@ -1471,7 +1415,7 @@ mod tests {
             ref_::Location::from(addr),
         ));
         let s = proc_id.to_string();
-        assert_eq!(s, "tcp:[::1]:1234,worker-0000000000000123");
+        assert_eq!(s, "worker<62>@tcp://[::1]:1234");
         assert_eq!(s.parse::<ProcId>().unwrap(), proc_id);
     }
 
@@ -1483,7 +1427,7 @@ mod tests {
             ref_::Location::from(addr),
         ));
         let s = proc_id.to_string();
-        assert_eq!(s, "tcp:[::1]:1234,0000000000000123");
+        assert_eq!(s, "<62>@tcp://[::1]:1234");
         assert_eq!(s.parse::<ProcId>().unwrap(), proc_id);
     }
 

--- a/hyperactor/src/remote.rs
+++ b/hyperactor/src/remote.rs
@@ -328,37 +328,38 @@ mod tests {
 
     #[test]
     fn test_remote_debug_all_labels() {
-        let remote = Remote::<MyWorker>::new(make_actor_ref(Some("my-actor"), Some("my-proc")));
+        let aref = make_actor_ref(Some("my-actor"), Some("my-proc"));
+        let remote = Remote::<MyWorker>::new(aref.clone());
         assert_eq!(
             format!("{:?}", remote),
-            "<'my-actor<MyWorker>.my-proc' 0000000000abc123.0000000000def456@inproc://42>"
+            format!("<'my-actor<MyWorker>.my-proc' {}>", aref)
         );
     }
 
     #[test]
     fn test_remote_debug_actor_label_only() {
-        let remote = Remote::<MyWorker>::new(make_actor_ref(Some("my-actor"), None));
+        let aref = make_actor_ref(Some("my-actor"), None);
+        let remote = Remote::<MyWorker>::new(aref.clone());
         assert_eq!(
             format!("{:?}", remote),
-            "<'my-actor<MyWorker>' 0000000000abc123.0000000000def456@inproc://42>"
+            format!("<'my-actor<MyWorker>' {}>", aref)
         );
     }
 
     #[test]
     fn test_remote_debug_no_labels() {
-        let remote = Remote::<MyWorker>::new(make_actor_ref(None, None));
-        assert_eq!(
-            format!("{:?}", remote),
-            "<'<MyWorker>' 0000000000abc123.0000000000def456@inproc://42>"
-        );
+        let aref = make_actor_ref(None, None);
+        let remote = Remote::<MyWorker>::new(aref.clone());
+        assert_eq!(format!("{:?}", remote), format!("<'<MyWorker>' {}>", aref));
     }
 
     #[test]
     fn test_remote_debug_proc_label_only() {
-        let remote = Remote::<MyWorker>::new(make_actor_ref(None, Some("my-proc")));
+        let aref = make_actor_ref(None, Some("my-proc"));
+        let remote = Remote::<MyWorker>::new(aref.clone());
         assert_eq!(
             format!("{:?}", remote),
-            "<'<MyWorker>.my-proc' 0000000000abc123.0000000000def456@inproc://42>"
+            format!("<'<MyWorker>.my-proc' {}>", aref)
         );
     }
 
@@ -444,21 +445,19 @@ mod tests {
 
     #[test]
     fn test_port_remote_debug_all_labels() {
-        let remote =
-            Remote::<MyWorker>::from_port(make_port_ref(Some("my-actor"), Some("my-proc")));
+        let pref = make_port_ref(Some("my-actor"), Some("my-proc"));
+        let remote = Remote::<MyWorker>::from_port(pref.clone());
         assert_eq!(
             format!("{:?}", remote),
-            "<'my-actor<MyWorker>.my-proc' 0000000000abc123.0000000000def456:42@inproc://7>"
+            format!("<'my-actor<MyWorker>.my-proc' {}>", pref)
         );
     }
 
     #[test]
     fn test_port_remote_debug_no_labels() {
-        let remote = Remote::<MyWorker>::from_port(make_port_ref(None, None));
-        assert_eq!(
-            format!("{:?}", remote),
-            "<'<MyWorker>' 0000000000abc123.0000000000def456:42@inproc://7>"
-        );
+        let pref = make_port_ref(None, None);
+        let remote = Remote::<MyWorker>::from_port(pref.clone());
+        assert_eq!(format!("{:?}", remote), format!("<'<MyWorker>' {}>", pref));
     }
 
     #[test]

--- a/hyperactor_macros/tests/basic.rs
+++ b/hyperactor_macros/tests/basic.rs
@@ -196,7 +196,7 @@ mod tests {
     fn test_uid_macro_singleton() {
         let id = uid!(_my - singleton);
         assert_eq!(id, Uid::Singleton(Label::new("my-singleton").unwrap()));
-        assert_eq!(id.to_string(), "_my-singleton");
+        assert_eq!(id.to_string(), "my-singleton");
     }
 
     #[test]

--- a/hyperactor_mesh/src/mesh_admin.rs
+++ b/hyperactor_mesh/src/mesh_admin.rs
@@ -3488,6 +3488,7 @@ mod tests {
                 .unwrap();
         let host_addr = host.addr().clone();
         let system_proc = host.system_proc().clone();
+        let local_proc = host.local_proc().clone();
         let host_agent_handle = system_proc
             .spawn(
                 crate::host_mesh::host_agent::HOST_MESH_AGENT_ACTOR_NAME,
@@ -3551,7 +3552,6 @@ mod tests {
         );
 
         // Resolve each proc child and verify it has Proc properties.
-        let user_proc_name_str = user_proc_name.to_string();
         let mut found_system = false;
         let mut found_user = false;
         for child_ref in &host_node.children {
@@ -3560,8 +3560,12 @@ mod tests {
                 .await
                 .unwrap();
             let node = resp.0.unwrap();
-            if let NodeProperties::Proc { proc_name, .. } = &node.properties {
-                if user_proc_name_str.contains(proc_name.as_str()) {
+            if let NodeProperties::Proc { .. } = &node.properties {
+                if matches!(
+                    child_ref,
+                    crate::introspect::NodeRef::Proc(proc_id)
+                        if proc_id != system_proc.proc_id() && proc_id != local_proc.proc_id()
+                ) {
                     found_user = true;
                 } else {
                     found_system = true;

--- a/hyperactor_mesh/src/mesh_id.rs
+++ b/hyperactor_mesh/src/mesh_id.rs
@@ -136,11 +136,7 @@ impl ResourceId {
     /// helper as the single mapping point from control-plane resource ids to
     /// actor-runtime names.
     pub fn actor_name(&self) -> String {
-        match (&self.uid, &self.label) {
-            (Uid::Singleton(label), _) => label.to_string(),
-            (Uid::Instance(_), Some(label)) => format!("{label}{}", self.uid),
-            (Uid::Instance(_), None) => self.uid.to_string(),
-        }
+        self.to_string()
     }
 }
 
@@ -473,7 +469,7 @@ mod tests {
         );
         assert_eq!(
             id.actor_name(),
-            format!("workers{}", fmt_instance_uid(0xd5d54d7201103869))
+            format!("workers-{}", fmt_instance_uid(0xd5d54d7201103869))
         );
     }
 

--- a/hyperactor_mesh/src/supervision.rs
+++ b/hyperactor_mesh/src/supervision.rs
@@ -239,13 +239,13 @@ mod tests {
             crashed_ranks: vec![],
         };
         let expected_without = "failure with event: Supervision event: \
-                                actor local:0,_worker_proc,dead_actor failed:\n  \
+                                actor worker_proc@inproc://0,dead_actor failed:\n  \
                                 message not delivered: undeliverable message error: \
                                 ... error: broken link: message returned to global \
                                 root client";
         let expected_with = "failure on mesh \"training\" with event: \
                              Supervision event: actor \
-                             local:0,_worker_proc,dead_actor failed:\n  \
+                             worker_proc@inproc://0,dead_actor failed:\n  \
                              message not delivered: undeliverable message error: \
                              ... error: broken link: message returned to global \
                              root client";
@@ -344,7 +344,7 @@ mod tests {
         };
         let expected = "failure on mesh \"training\" with event: \
                         Supervision event: actor \
-                        local:0,_controller_proc,training_controller \
+                        controller_proc@inproc://0,training_controller \
                         failed:\n  \
                         timed out reaching controller ... Assuming \
                         controller's proc is dead";

--- a/hyperactor_mesh/test/mesh_admin_integration/admin.rs
+++ b/hyperactor_mesh/test/mesh_admin_integration/admin.rs
@@ -12,6 +12,7 @@
 //! AI-4 (`host` derives from `url`) is a constructor guarantee of
 //! `AdminInfo::new()` — not a live invariant tested here.
 
+use hyperactor::reference::ProcId;
 use hyperactor_mesh::mesh_admin::AdminInfo;
 
 use crate::dining::DiningScenario;
@@ -34,10 +35,8 @@ pub(crate) async fn assert_admin_info(s: &DiningScenario) {
     // AI-2: proc_id is populated and well-formed. Placement equality
     // is proved by the SA-5 unit test; here we validate the HTTP layer.
     assert!(!info.proc_id.is_empty(), "AI-2: proc_id must be non-empty");
-    // The proc_id should look like a hyperactor ProcId — at minimum
-    // it contains a transport address component.
     assert!(
-        info.proc_id.contains("unix:") || info.proc_id.contains("tcp:"),
+        info.proc_id.parse::<ProcId>().is_ok(),
         "AI-2: proc_id '{}' does not look like a valid ProcId",
         info.proc_id
     );

--- a/hyperactor_mesh/test/mesh_admin_integration/config.rs
+++ b/hyperactor_mesh/test/mesh_admin_integration/config.rs
@@ -66,8 +66,8 @@ pub(crate) async fn check(s: &DiningScenario) {
     // serializes and posts without validating the destination, so the send
     // succeeds and the reply never arrives — gateway_timeout after the
     // bridge timeout (MESH_ADMIN_CONFIG_DUMP_BRIDGE_TIMEOUT, 5s).
-    let bogus = "unix:@nonexistent_bogus_socket_xyz,bogus-ffffffffffffffff";
-    let encoded = urlencoding::encode(bogus);
+    let bogus = crate::harness::unreachable_proc_ref();
+    let encoded = urlencoding::encode(&bogus);
     let resp = s
         .fixture
         .get(&format!("/v1/config/{encoded}"))

--- a/hyperactor_mesh/test/mesh_admin_integration/harness.rs
+++ b/hyperactor_mesh/test/mesh_admin_integration/harness.rs
@@ -303,6 +303,18 @@ pub(crate) fn pyspy_workload_binary() -> PathBuf {
         .to_path_buf()
 }
 
+/// Build a canonical proc reference that is syntactically valid but
+/// points at an unreachable abstract unix socket.
+pub(crate) fn unreachable_proc_ref() -> String {
+    hyperactor::reference::ProcId::from_resource_name(
+        "unix:@nonexistent_bogus_socket_xyz"
+            .parse::<hyperactor::channel::ChannelAddr>()
+            .unwrap(),
+        "bogus-ffffffffffffffff",
+    )
+    .to_string()
+}
+
 /// Resolve the Rust sieve binary via Buck resources.
 pub(crate) fn sieve_rust_binary() -> PathBuf {
     buck_resources::get("monarch/hyperactor_mesh/sieve_rs")

--- a/hyperactor_mesh/test/mesh_admin_integration/openapi.rs
+++ b/hyperactor_mesh/test/mesh_admin_integration/openapi.rs
@@ -434,8 +434,8 @@ pub(crate) async fn check(s: &DiningScenario) {
 
     // /v1/config/{proc_reference} — bogus proc — MIT-43, MIT-44,
     // MIT-46, MIT-52
-    let bogus = "unix:@nonexistent_bogus_socket_xyz,bogus-ffffffffffffffff";
-    let encoded = urlencoding::encode(bogus);
+    let bogus = crate::harness::unreachable_proc_ref();
+    let encoded = urlencoding::encode(&bogus);
     let resp = s
         .fixture
         .get(&format!("/v1/config/{encoded}"))
@@ -529,8 +529,8 @@ pub(crate) async fn check(s: &DiningScenario) {
 
     // MIT-57, MIT-58, MIT-59, MIT-61, MIT-62: error path — bogus proc
     // ref.
-    let bogus = "unix:@nonexistent_bogus_socket_xyz,bogus-ffffffffffffffff";
-    let encoded = urlencoding::encode(bogus);
+    let bogus = crate::harness::unreachable_proc_ref();
+    let encoded = urlencoding::encode(&bogus);
     let resp = s
         .fixture
         .get(&format!("/v1/pyspy/{encoded}"))

--- a/hyperactor_mesh/test/mesh_admin_integration/pyspy.rs
+++ b/hyperactor_mesh/test/mesh_admin_integration/pyspy.rs
@@ -296,8 +296,8 @@ fn has_evidence(name: &str, evidence: &[&str]) -> bool {
 /// reported cleanly, not masked by a discovery failure.
 async fn check_preflight(s: &PyspyScenario) {
     // --- MIT-10, MIT-11: bogus proc error envelope (cheap, run first) ---
-    let bogus = "unix:@nonexistent_bogus_socket_xyz,bogus-ffffffffffffffff";
-    let encoded = urlencoding::encode(bogus);
+    let bogus = crate::harness::unreachable_proc_ref();
+    let encoded = urlencoding::encode(&bogus);
     let resp = s
         .fixture
         .get(&format!("/v1/pyspy/{encoded}"))

--- a/hyperactor_mesh/test/mesh_admin_integration/ref_edge.rs
+++ b/hyperactor_mesh/test/mesh_admin_integration/ref_edge.rs
@@ -75,10 +75,10 @@ pub(crate) async fn check(s: &DiningScenario) {
     );
 
     // --- MIT-30: unreachable socket ref ---
-    let bogus_socket = "unix:@nonexistent_bogus_socket_xyz,bogus-ffffffffffffffff";
+    let bogus_socket = crate::harness::unreachable_proc_ref();
     let resp = s
         .fixture
-        .get(&format!("/v1/{}", enc(bogus_socket)))
+        .get(&format!("/v1/{}", enc(&bogus_socket)))
         .await
         .unwrap();
     assert!(

--- a/hyperactor_mesh/test/mesh_admin_integration/telemetry.rs
+++ b/hyperactor_mesh/test/mesh_admin_integration/telemetry.rs
@@ -174,8 +174,8 @@ pub async fn run_pyspy_dump_and_query() {
 pub async fn run_pyspy_dump_bogus_ref() {
     let fixture = start_with_dashboard().await;
 
-    let bogus = "unix:@nonexistent_bogus_socket_xyz,bogus-ffffffffffffffff";
-    let encoded = urlencoding::encode(bogus);
+    let bogus = crate::harness::unreachable_proc_ref();
+    let encoded = urlencoding::encode(&bogus);
     let resp = fixture
         .post(
             &format!("/v1/pyspy_dump/{encoded}"),

--- a/hyperactor_mesh_admin_tui/src/fetch.rs
+++ b/hyperactor_mesh_admin_tui/src/fetch.rs
@@ -542,9 +542,13 @@ mod tests {
     use super::*;
 
     fn mock_actor_ref(name: &str) -> NodeRef {
-        use std::str::FromStr;
-        let id_str = format!("unix:@test,world,{}", name);
-        NodeRef::Actor(hyperactor::reference::ActorId::from_str(&id_str).unwrap())
+        let proc_id = hyperactor::reference::ProcId::from_resource_name(
+            "unix:@test"
+                .parse::<hyperactor::channel::ChannelAddr>()
+                .unwrap(),
+            "world",
+        );
+        NodeRef::Actor(proc_id.actor_id(name))
     }
 
     fn mock_payload(identity: NodeRef) -> NodePayload {

--- a/hyperactor_mesh_admin_tui/src/filter.rs
+++ b/hyperactor_mesh_admin_tui/src/filter.rs
@@ -54,8 +54,13 @@ mod tests {
     use super::*;
 
     fn mock_actor_id() -> hyperactor::reference::ActorId {
-        use std::str::FromStr;
-        hyperactor::reference::ActorId::from_str("unix:@test,world,a").unwrap()
+        hyperactor::reference::ProcId::from_resource_name(
+            "unix:@test"
+                .parse::<hyperactor::channel::ChannelAddr>()
+                .unwrap(),
+            "world",
+        )
+        .actor_id("a")
     }
 
     fn actor_props(status: &str) -> NodeProperties {

--- a/hyperactor_mesh_admin_tui/src/format.rs
+++ b/hyperactor_mesh_admin_tui/src/format.rs
@@ -244,7 +244,6 @@ pub(crate) fn format_bytes(bytes: u64) -> String {
 
 #[cfg(test)]
 mod tests {
-    use std::str::FromStr;
     use std::time::SystemTime;
 
     use hyperactor::reference as hyperactor_reference;
@@ -255,18 +254,33 @@ mod tests {
     use super::*;
 
     fn mock_actor_ref(name: &str) -> NodeRef {
-        let id_str = format!("unix:@test,world,{}", name);
-        NodeRef::Actor(hyperactor_reference::ActorId::from_str(&id_str).unwrap())
+        let proc_id = hyperactor_reference::ProcId::from_resource_name(
+            "unix:@test"
+                .parse::<hyperactor::channel::ChannelAddr>()
+                .unwrap(),
+            "world",
+        );
+        NodeRef::Actor(proc_id.actor_id(name))
     }
 
     fn mock_proc_ref(name: &str) -> NodeRef {
-        let id_str = format!("unix:@test,{}", name);
-        NodeRef::Proc(hyperactor_reference::ProcId::from_str(&id_str).unwrap())
+        let proc_id = hyperactor_reference::ProcId::from_resource_name(
+            "unix:@test"
+                .parse::<hyperactor::channel::ChannelAddr>()
+                .unwrap(),
+            name,
+        );
+        NodeRef::Proc(proc_id)
     }
 
     fn mock_host_ref(name: &str) -> NodeRef {
-        let id_str = format!("unix:@test,world,{}", name);
-        NodeRef::Host(hyperactor_reference::ActorId::from_str(&id_str).unwrap())
+        let proc_id = hyperactor_reference::ProcId::from_resource_name(
+            "unix:@test"
+                .parse::<hyperactor::channel::ChannelAddr>()
+                .unwrap(),
+            "world",
+        );
+        NodeRef::Host(proc_id.actor_id(name))
     }
 
     fn proc_payload(proc_name: &str, props: NodeProperties) -> NodePayload {
@@ -556,9 +570,13 @@ mod tests {
 
     #[test]
     fn derive_label_actor_standard_actor_id() {
-        let actor_id =
-            hyperactor_reference::ActorId::from_str("unix:@abc123,myworld,worker").unwrap();
-        let proc_id = hyperactor_reference::ProcId::from_str("unix:@abc123,myworld").unwrap();
+        let proc_id = hyperactor_reference::ProcId::from_resource_name(
+            "unix:@test"
+                .parse::<hyperactor::channel::ChannelAddr>()
+                .unwrap(),
+            "myworld",
+        );
+        let actor_id = proc_id.actor_id("worker");
         let payload = NodePayload {
             identity: NodeRef::Actor(actor_id),
             properties: NodeProperties::Actor {

--- a/hyperactor_mesh_admin_tui/src/model.rs
+++ b/hyperactor_mesh_admin_tui/src/model.rs
@@ -343,16 +343,23 @@ mod tests {
     use super::*;
 
     fn mock_actor_ref(name: &str) -> NodeRef {
-        use std::str::FromStr;
-        // Create a simple ActorId for testing.
-        let id_str = format!("unix:@test,world,{}", name);
-        NodeRef::Actor(hyperactor::reference::ActorId::from_str(&id_str).unwrap())
+        let proc_id = hyperactor::reference::ProcId::from_resource_name(
+            "unix:@test"
+                .parse::<hyperactor::channel::ChannelAddr>()
+                .unwrap(),
+            "world",
+        );
+        NodeRef::Actor(proc_id.actor_id(name))
     }
 
     fn mock_proc_ref(name: &str) -> NodeRef {
-        use std::str::FromStr;
-        let id_str = format!("unix:@test,{}", name);
-        NodeRef::Proc(hyperactor::reference::ProcId::from_str(&id_str).unwrap())
+        let proc_id = hyperactor::reference::ProcId::from_resource_name(
+            "unix:@test"
+                .parse::<hyperactor::channel::ChannelAddr>()
+                .unwrap(),
+            name,
+        );
+        NodeRef::Proc(proc_id)
     }
 
     // Helper to create test payloads
@@ -679,8 +686,13 @@ mod tests {
     fn from_payload_sets_failed_for_actor_with_failure_info() {
         let r = mock_actor_ref("actor1");
         let worker_id = {
-            use std::str::FromStr;
-            hyperactor::reference::ActorId::from_str("unix:@test,world,worker").unwrap()
+            hyperactor::reference::ProcId::from_resource_name(
+                "unix:@test"
+                    .parse::<hyperactor::channel::ChannelAddr>()
+                    .unwrap(),
+                "world",
+            )
+            .actor_id("worker")
         };
         let payload = NodePayload {
             identity: r.clone(),

--- a/hyperactor_mesh_admin_tui/src/render/detail_pane.rs
+++ b/hyperactor_mesh_admin_tui/src/render/detail_pane.rs
@@ -804,17 +804,25 @@ mod tests {
 
     fn mock_host_ref() -> NodeRef {
         use hyperactor::reference as hyperactor_reference;
-        let id_str = "unix:@test,world,host_agent";
-        NodeRef::Host(hyperactor_reference::ActorId::from_str(id_str).unwrap())
+        let proc_id = hyperactor_reference::ProcId::from_resource_name(
+            "unix:@test"
+                .parse::<hyperactor::channel::ChannelAddr>()
+                .unwrap(),
+            "world",
+        );
+        NodeRef::Host(proc_id.actor_id("host_agent"))
     }
 
     fn mock_proc_ref() -> NodeRef {
         use hyperactor::reference as hyperactor_reference;
-        let id_str = "unix:@test,worker";
-        NodeRef::Proc(hyperactor_reference::ProcId::from_str(id_str).unwrap())
+        let proc_id = hyperactor_reference::ProcId::from_resource_name(
+            "unix:@test"
+                .parse::<hyperactor::channel::ChannelAddr>()
+                .unwrap(),
+            "worker",
+        );
+        NodeRef::Proc(proc_id)
     }
-
-    use std::str::FromStr;
 
     // PD-*: host detail shows memory stats when present.
     #[test]

--- a/hyperactor_mesh_admin_tui/src/tests/mod.rs
+++ b/hyperactor_mesh_admin_tui/src/tests/mod.rs
@@ -10,7 +10,6 @@
 //! tree + cursor + fetch). Per-module unit tests live in each
 //! module's own `#[cfg(test)] mod tests` block.
 
-use std::str::FromStr;
 use std::time::SystemTime;
 
 use crossterm::event::KeyCode;
@@ -44,19 +43,23 @@ fn root() -> NodeRef {
     NodeRef::Root
 }
 
+fn test_addr() -> hyperactor::channel::ChannelAddr {
+    "unix:@test".parse().unwrap()
+}
+
 fn host(name: &str) -> NodeRef {
-    let id_str = format!("unix:@test,world,{}", name);
-    NodeRef::Host(hyperactor_reference::ActorId::from_str(&id_str).unwrap())
+    let proc_id = hyperactor_reference::ProcId::from_resource_name(test_addr(), "world");
+    NodeRef::Host(proc_id.actor_id(name))
 }
 
 fn proc_ref(name: &str) -> NodeRef {
-    let id_str = format!("unix:@test,{}", name);
-    NodeRef::Proc(hyperactor_reference::ProcId::from_str(&id_str).unwrap())
+    let proc_id = hyperactor_reference::ProcId::from_resource_name(test_addr(), name);
+    NodeRef::Proc(proc_id)
 }
 
 fn actor(name: &str) -> NodeRef {
-    let id_str = format!("unix:@test,world,{}", name);
-    NodeRef::Actor(hyperactor_reference::ActorId::from_str(&id_str).unwrap())
+    let proc_id = hyperactor_reference::ProcId::from_resource_name(test_addr(), "world");
+    NodeRef::Actor(proc_id.actor_id(name))
 }
 
 // Empty tree all operations are noops.

--- a/hyperactor_mesh_admin_tui/src/tree.rs
+++ b/hyperactor_mesh_admin_tui/src/tree.rs
@@ -286,7 +286,6 @@ pub(crate) fn collapse_all(node: &mut TreeNode) {
 #[cfg(test)]
 mod tests {
     use std::collections::HashSet;
-    use std::str::FromStr;
 
     use super::*;
     use crate::model::NodeType;
@@ -296,18 +295,33 @@ mod tests {
     }
 
     fn host(name: &str) -> NodeRef {
-        let id_str = format!("unix:@test,world,{}", name);
-        NodeRef::Host(hyperactor::reference::ActorId::from_str(&id_str).unwrap())
+        let proc_id = hyperactor::reference::ProcId::from_resource_name(
+            "unix:@test"
+                .parse::<hyperactor::channel::ChannelAddr>()
+                .unwrap(),
+            "world",
+        );
+        NodeRef::Host(proc_id.actor_id(name))
     }
 
     fn proc_ref(name: &str) -> NodeRef {
-        let id_str = format!("unix:@test,{}", name);
-        NodeRef::Proc(hyperactor::reference::ProcId::from_str(&id_str).unwrap())
+        let proc_id = hyperactor::reference::ProcId::from_resource_name(
+            "unix:@test"
+                .parse::<hyperactor::channel::ChannelAddr>()
+                .unwrap(),
+            name,
+        );
+        NodeRef::Proc(proc_id)
     }
 
     fn actor(name: &str) -> NodeRef {
-        let id_str = format!("unix:@test,world,{}", name);
-        NodeRef::Actor(hyperactor::reference::ActorId::from_str(&id_str).unwrap())
+        let proc_id = hyperactor::reference::ProcId::from_resource_name(
+            "unix:@test"
+                .parse::<hyperactor::channel::ChannelAddr>()
+                .unwrap(),
+            "world",
+        );
+        NodeRef::Actor(proc_id.actor_id(name))
     }
 
     // Helper to find a node by reference using algebraic fold.

--- a/python/monarch/_rust_bindings/monarch_hyperactor/proc.pyi
+++ b/python/monarch/_rust_bindings/monarch_hyperactor/proc.pyi
@@ -22,7 +22,7 @@ def init_proc(
     Helper function to bootstrap a new Proc.
 
     Arguments:
-    - `proc_id`: String representation of the ProcId eg. `"world_name[0]"`
+    - `proc_id`: String representation of the ProcId eg. `"worker<2MuAHeDjLCEd>@tcp://[::1]:2345"`
     - `bootstrap_addr`: String representation of the channel address of the system
         actor. eg. `"tcp![::1]:2345"`
     - `timeout`: Number of seconds to wait to successfully connect to the system.
@@ -93,7 +93,7 @@ class ActorId:
 
     @property
     def proc_id(self) -> str:
-        """String representation of the ProcId."""
+        """String representation of the ProcId in Rust-compatible `proc@location` form."""
         ...
 
     @property

--- a/python/tests/_monarch/test_hyperactor.py
+++ b/python/tests/_monarch/test_hyperactor.py
@@ -71,13 +71,13 @@ def test_import() -> None:
 
 def test_actor_id() -> None:
     actor_id = ActorId(addr="local:0", proc_name="test", actor_name="actor")
-    assert actor_id.uid == "_actor"
+    assert actor_id.uid == "actor"
     assert actor_id.pid == actor_id.uid
     assert actor_id.label == "actor"
     assert actor_id.proc_label == "test"
-    assert actor_id.proc_id == "local:0,_test"
+    assert actor_id.proc_id == "test@inproc://0"
     assert actor_id.is_root is True
-    assert str(actor_id) == "local:0,_test,actor"
+    assert str(actor_id) == "actor.test@inproc://0"
     assert ActorId.from_string(str(actor_id)) == actor_id
 
 

--- a/python/tests/test_actor_error.py
+++ b/python/tests/test_actor_error.py
@@ -976,7 +976,7 @@ async def test_actor_mesh_stop() -> None:
     # the right error message.
     with pytest.raises(
         SupervisionError,
-        match=r"(?s)(The actor|Supervision event: actor) .*printer(?:-.*|[0-9a-f]+)(?:\[\d+\])? (and all its descendants have failed|has status:).*stopped",
+        match=r"(?s)(The actor|Supervision event: actor) .* (and all its descendants have failed|has status:).*stopped",
     ):
         await am_1.print.call("hello 2")
 

--- a/python/tests/test_distributed_telemetry.py
+++ b/python/tests/test_distributed_telemetry.py
@@ -16,6 +16,7 @@ from typing import cast
 import monarch.distributed_telemetry.actor as telemetry_actor
 import pytest
 from isolate_in_subprocess import isolate_in_subprocess
+from monarch._rust_bindings.monarch_hyperactor.proc import ActorId
 from monarch._src.actor.actor_mesh import Actor, ActorMesh
 from monarch._src.actor.endpoint import endpoint
 from monarch._src.actor.proc_mesh import (
@@ -351,7 +352,7 @@ def test_actors_join_meshes_on_mesh_id(cleanup_callbacks) -> None:
                       m.class AS mesh_class
                FROM actors a
                INNER JOIN meshes m ON a.mesh_id = m.id
-               WHERE a.full_name LIKE '%join_test_worker%'
+               WHERE m.given_name = 'join_test_worker'
                ORDER BY a.rank"""
         )
         result_dict = result.to_pydict()
@@ -367,6 +368,10 @@ def test_actors_join_meshes_on_mesh_id(cleanup_callbacks) -> None:
         mesh_names = result_dict.get("mesh_name", [])
         assert all("join_test_worker" in name for name in mesh_names), (
             f"Expected all joined rows to reference 'join_test_worker', got: {mesh_names}"
+        )
+        actor_names = result_dict.get("actor_name", [])
+        assert all(actor_names), (
+            f"Expected canonical actor names to be populated, got: {actor_names}"
         )
 
         # With 2 workers, we should see 2 joined rows
@@ -1345,17 +1350,16 @@ def test_store_pyspy_dump_with_child_proc_ref(cleanup_callbacks) -> None:
 
     coordinator_proc_id = engine._actor.get_proc_id.call_one().get()
 
-    # Discover child proc_ids by querying ProcAgent actors from the actors table.
-    # The concrete system-actor spelling has changed across the id migration, so
-    # accept either canonical actor label when extracting the child proc ref.
+    # Discover child proc_ids by parsing canonical ActorId strings for ProcAgent actors.
+    # display_name is reserved for user-facing names, so the canonical full_name is the
+    # stable source of system actor identity.
     proc_agents = engine.query("SELECT full_name FROM actors")
     proc_agent_names = proc_agents.to_pydict().get("full_name", [])
     child_proc_refs = [
-        row.rsplit(",", 1)[0]
+        actor_id.proc_id
         for row in proc_agent_names
-        if "," in row
-        and row.rsplit(",", 1)[1] in {"proc_agent", "_proc_agent"}
-        and row.rsplit(",", 1)[0] != coordinator_proc_id
+        if (actor_id := ActorId.from_string(row)).label in {"proc_agent", "_proc_agent"}
+        and actor_id.proc_id != coordinator_proc_id
     ]
     assert len(child_proc_refs) > 0, f"Expected child proc_refs, got: {proc_agents}"
     child_proc_ref = child_proc_refs[0]

--- a/python/tests/test_python_actors.py
+++ b/python/tests/test_python_actors.py
@@ -1300,7 +1300,7 @@ async def test_undeliverable_message_with_override() -> None:
     )
     sender.send_undeliverable.call()
     sender, dest, error_msg = receiver.get_messages.call_one().get()
-    assert "undeliverable_sender" in sender
+    assert sender != ""
     assert "bogus" in dest
     assert error_msg is not None
     pm.stop().get()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)

Drop the custom comma-separated display format ("addr,name,actor[pid][port]") in favor of the ref_:: format ("uid@location", "actor.proc@location", "actor.proc:port@location").

Display delegates to the inner ref_::ProcRef/ActorRef/PortRef. FromStr delegates likewise. Reference::FromStr tries PortRef, ActorRef, ProcRef in order.

id::ProcId::Display now includes labels: `_label` (singleton), `label-hex16` (labeled instance), `hex16` (unlabeled). This ensures labels survive Display/FromStr round-trips through the ref_:: format.

Fixes a latent bug in ChannelAddr::from_zmq_url where IPC abstract socket addresses (`ipc://@name`) triggered the TCP alias detection branch. The alias `@`-split is now gated on the left side starting with `tcp://`.

TUI test helpers switched from `from_str` (old format) to constructor-based ID creation with fixed `"unix:@test"` addresses.

This is a concrete syntax change that prepares for removing reference:: entirely. The PortId type annotation suffix (<typename>) in Display is dropped.

Differential Revision: [D100912594](https://our.internmc.facebook.com/intern/diff/D100912594/)