### PR TITLE
Add clap to hyperactor_mesh Cargo test dependencies

### DIFF
--- a/hyperactor_mesh/Cargo.toml
+++ b/hyperactor_mesh/Cargo.toml
@@ -62,6 +62,7 @@ zbus = { version = "5.14.0", features = ["async-executor", "async-fs", "async-io
 
 [dev-dependencies]
 buck-resources = "1"
+clap = { version = "4.6.0", features = ["derive", "env", "string", "unicode", "wrap_help"] }
 criterion = { version = "0.5.1", features = ["async_tokio", "csv_output"] }
 inventory = "0.3.24"
 jsonschema = "0.17.0"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #3632

Fix the OSS Cargo manifest for `hyperactor_mesh` so example binaries built by `cargo test` and `cargo nextest` can resolve `clap`. Add `clap` to the Buck test deps and regenerate the internal and public autocargo manifests.

Differential Revision: [D102645395](https://our.internmc.facebook.com/intern/diff/D102645395/)