### PR TITLE
Add is_system column to telemetry actors table

### DIFF
--- a/hyperactor_mesh/src/host_mesh.rs
+++ b/hyperactor_mesh/src/host_mesh.rs
@@ -268,6 +268,7 @@ impl HostMesh {
                 rank: rank as u64,
                 full_name: actor.actor_id().to_string(),
                 display_name: None,
+                is_system: true,
             });
         }
     }

--- a/hyperactor_mesh/src/proc_mesh.rs
+++ b/hyperactor_mesh/src/proc_mesh.rs
@@ -225,6 +225,7 @@ impl ProcMesh {
                     rank: rank.create_rank as u64,
                     full_name: actor_id.to_string(),
                     display_name: None,
+                    is_system: true,
                 });
             }
         }
@@ -916,6 +917,7 @@ impl ProcMeshRef {
                     rank: rank as u64,
                     full_name: actor_id.to_string(),
                     display_name,
+                    is_system: is_system_actor,
                 });
             }
         }

--- a/hyperactor_telemetry/src/lib.rs
+++ b/hyperactor_telemetry/src/lib.rs
@@ -339,6 +339,9 @@ pub struct ActorEvent {
     pub full_name: String,
     /// User-facing name for this actor
     pub display_name: Option<String>,
+    /// Whether this is a system/infrastructure actor (hidden by default
+    /// in the dashboard and TUI).
+    pub is_system: bool,
 }
 
 /// Notify the registered dispatcher that an actor was created.

--- a/monarch_distributed_telemetry/src/entity_dispatcher.rs
+++ b/monarch_distributed_telemetry/src/entity_dispatcher.rs
@@ -43,6 +43,8 @@ pub struct Actor {
     pub full_name: String,
     /// User-facing name for this actor
     pub display_name: Option<String>,
+    /// Whether this is a system/infrastructure actor
+    pub is_system: bool,
 }
 
 /// Row data for the meshes table.
@@ -299,6 +301,7 @@ impl EntityEventDispatcher for EntityDispatcher {
                     rank: actor_event.rank,
                     full_name: actor_event.full_name,
                     display_name: actor_event.display_name,
+                    is_system: actor_event.is_system,
                 });
                 inner.flush_actors_if_full()?;
             }

--- a/monarch_hyperactor/src/host_mesh.rs
+++ b/monarch_hyperactor/src/host_mesh.rs
@@ -393,6 +393,7 @@ fn bootstrap_host(bootstrap_cmd: Option<PyBootstrapCommand>) -> PyResult<PyPytho
                 rank: 0,
                 full_name: host_agent_id.to_string(),
                 display_name: None,
+                is_system: true,
             });
 
             let proc_id_str = proc_mesh.id().to_string();
@@ -421,6 +422,7 @@ fn bootstrap_host(bootstrap_cmd: Option<PyBootstrapCommand>) -> PyResult<PyPytho
                 rank: 0,
                 full_name: proc_agent_id.to_string(),
                 display_name: None,
+                is_system: true,
             });
 
             let client_mesh_name = format!("{}/client", proc_mesh.id());
@@ -443,6 +445,7 @@ fn bootstrap_host(bootstrap_cmd: Option<PyBootstrapCommand>) -> PyResult<PyPytho
                 rank: 0,
                 full_name: instance.self_id().to_string(),
                 display_name: Some("<root>".to_string()),
+                is_system: false,
             });
         }
 


### PR DESCRIPTION
Summary:
Add an `is_system: bool` field to `ActorEvent` and the telemetry
`Actor` row struct so that system/infrastructure actors are classified
at creation time in the `actors` table.

This enables the dashboard to filter system actors with a simple
`SELECT full_name FROM actors WHERE is_system = true` instead of
requiring snapshot tables or HTTP calls to the mesh admin API.

Changes:
- `hyperactor_telemetry/src/lib.rs`: Add `is_system: bool` to
  `ActorEvent`.
- `monarch_distributed_telemetry/src/entity_dispatcher.rs`: Add
  `is_system: bool` to the `Actor` row struct (Arrow column
  auto-generated by `RecordBatchRow` derive).
- `hyperactor_mesh/src/proc_mesh.rs`: Pass `is_system: true` for
  ProcAgent (site A), pass `is_system_actor` param for user/system
  actors spawned via `spawn_with_name_inner` (site B).
- `hyperactor_mesh/src/host_mesh.rs`: Pass `is_system: true` for
  HostAgent (site C).
- `monarch_hyperactor/src/host_mesh.rs`: Pass `is_system: true` for
  bootstrap HostAgent (site D) and ProcAgent (site E), `is_system:
  false` for client[0] (site F).

Differential Revision: D102645433
