### PR TITLE
Fix OSS test_commands tests broken by D102096298 (#3635)

### DIFF
--- a/python/tests/_src/tools/test_commands.py
+++ b/python/tests/_src/tools/test_commands.py
@@ -16,10 +16,7 @@ from unittest.mock import MagicMock
 
 from monarch._src.tools import commands
 from monarch._src.tools.commands import component_args_from_cli, server_ready
-from monarch.tools.config import (  # @manual=//monarch/python/monarch/tools/config/meta:defaults
-    Config,
-    defaults,
-)
+from monarch.tools.config import Config
 from monarch.tools.config.workspace import Workspace
 from monarch.tools.mesh_spec import MeshSpec, ServerSpec
 from torchx.specs import AppDef, AppDryRunInfo, AppState, AppStatus, Role, RoleStatus
@@ -28,6 +25,13 @@ from torchx.specs.api import ReplicaState, ReplicaStatus
 CMD_INFO = "monarch._src.tools.commands.info"
 CMD_CREATE = "monarch._src.tools.commands.create"
 CMD_KILL = "monarch._src.tools.commands.kill"
+
+
+def _appdef() -> AppDef:
+    return AppDef(
+        name="__unused__",
+        roles=[Role(name="trainer", image="__unused__", entrypoint="echo")],
+    )
 
 
 class TestCommands(unittest.TestCase):
@@ -46,7 +50,7 @@ class TestCommands(unittest.TestCase):
         config = Config(
             scheduler,
             dryrun=True,
-            appdef=defaults.component_fn(scheduler)(),
+            appdef=_appdef(),
         )
 
         dryrun_info = commands.create(config)
@@ -64,7 +68,7 @@ class TestCommands(unittest.TestCase):
             config = Config(
                 scheduler,
                 dryrun=True,
-                appdef=defaults.component_fn(scheduler)(),
+                appdef=_appdef(),
                 workspace=Workspace(
                     dirs=[
                         tmpdir / "github" / "torch",
@@ -90,7 +94,7 @@ class TestCommands(unittest.TestCase):
     def test_create(self, mock_schedule: mock.MagicMock) -> None:
         scheduler = "slurm"
         config = Config(scheduler)
-        config.appdef = defaults.component_fn(scheduler)()
+        config.appdef = _appdef()
         server_handle = commands.create(config)
 
         mock_schedule.assert_called_once()
@@ -357,7 +361,7 @@ class TestCommandsAsync(unittest.IsolatedAsyncioTestCase):
         config = Config(
             scheduler=scheduler,
             scheduler_args={},
-            appdef=defaults.component_fn(scheduler)(),
+            appdef=_appdef(),
         )
         server_info = await commands.get_or_create(name="123", config=config)
         self.assertEqual(server_info.server_handle, "slurm:///123")
@@ -386,7 +390,7 @@ class TestCommandsAsync(unittest.IsolatedAsyncioTestCase):
                     config = Config(
                         scheduler="slurm",
                         scheduler_args={},
-                        appdef=defaults.component_fn("slurm")(),
+                        appdef=_appdef(),
                     )
                     server_info = await commands.get_or_create(
                         name="123",
@@ -424,7 +428,7 @@ class TestCommandsAsync(unittest.IsolatedAsyncioTestCase):
         config = Config(
             scheduler="slurm",
             scheduler_args={},
-            appdef=defaults.component_fn("slurm")(),
+            appdef=_appdef(),
         )
         with self.assertRaises(RuntimeError):
             _ = await commands.get_or_create(
@@ -451,7 +455,7 @@ class TestCommandsAsync(unittest.IsolatedAsyncioTestCase):
         config = Config(
             scheduler="slurm",
             scheduler_args={},
-            appdef=defaults.component_fn("slurm")(),
+            appdef=_appdef(),
         )
         with self.assertRaises(RuntimeError):
             _ = await commands.get_or_create(
@@ -481,7 +485,7 @@ class TestCommandsAsync(unittest.IsolatedAsyncioTestCase):
             config = Config(
                 scheduler="slurm",
                 scheduler_args={},
-                appdef=defaults.component_fn("slurm")(),
+                appdef=_appdef(),
             )
             server_info = await commands.get_or_create(
                 name="123",


### PR DESCRIPTION
Summary:

D102096298 made OSS `defaults.component_fn(scheduler)` raise `NotImplementedError`. Several tests in `test_commands.py` were calling `defaults.component_fn(scheduler)()` to construct an `AppDef` for `Config`; they now fail with `NotImplementedError: no default component_fn for scheduler 'slurm'`.

Replace those calls with a local `_appdef()` helper that returns a minimal valid `AppDef`, drop the now-unused `defaults` import, and prune the `meta:defaults` BUCK dep.

Reviewed By: mariusae

Differential Revision: D102652144


