### PR TITLE
[monarch] Fix clap dependency

### DIFF
--- a/hyperactor_mesh/Cargo.toml
+++ b/hyperactor_mesh/Cargo.toml
@@ -62,6 +62,7 @@ zbus = { version = "5.14.0", features = ["async-executor", "async-fs", "async-io
 
 [dev-dependencies]
 buck-resources = "1"
+clap = { version = "4.6.0", features = ["derive"] }
 criterion = { version = "0.5.1", features = ["async_tokio", "csv_output"] }
 inventory = "0.3.24"
 jsonschema = "0.17.0"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #3636

hyperactor_mesh fails to compile in oss because of dining_philosophers needs clap

Differential Revision: [D102659777](https://our.internmc.facebook.com/intern/diff/D102659777/)