### PR TITLE
flush channel acks before host process exits (#3637)

### DIFF
--- a/hyperactor/src/channel/net.rs
+++ b/hyperactor/src/channel/net.rs
@@ -47,7 +47,6 @@
 //!   when EOF occurs exactly on a frame boundary. If EOF happens
 //!   mid-frame, it returns `Err(io::ErrorKind::UnexpectedEof)`.
 
-use std::collections::VecDeque;
 use std::fmt;
 use std::fmt::Debug;
 use std::net::ToSocketAddrs;
@@ -172,7 +171,7 @@ pub(crate) trait Link: Send + Sync + Debug + 'static {
 
     /// Acquire the next usable connection. For initiator links this
     /// dials; for acceptor links this waits on a dispatch channel.
-    async fn next(&self) -> Result<Self::Stream, ClientError>;
+    async fn next(&mut self) -> Result<Self::Stream, ClientError>;
 }
 
 use session::Session;
@@ -735,7 +734,7 @@ impl Link for NetLink {
         }
     }
 
-    async fn next(&self) -> Result<Box<dyn Stream>, ClientError> {
+    async fn next(&mut self) -> Result<Box<dyn Stream>, ClientError> {
         match self {
             Self::Tcp(l) => Ok(Box::new(l.next().await?)),
             Self::Unix(l) => Ok(Box::new(l.next().await?)),
@@ -1079,7 +1078,7 @@ pub(crate) mod unix {
             self.session_id
         }
 
-        async fn next(&self) -> Result<Self::Stream, ClientError> {
+        async fn next(&mut self) -> Result<Self::Stream, ClientError> {
             let session_id = self.session_id;
             let sock_addr = match &self.addr {
                 SocketAddr::Bound(a) => a,
@@ -1372,7 +1371,7 @@ pub(crate) mod tcp {
             self.session_id
         }
 
-        async fn next(&self) -> Result<Self::Stream, ClientError> {
+        async fn next(&mut self) -> Result<Self::Stream, ClientError> {
             let session_id = self.session_id;
             let mut backoff = ExponentialBackoffBuilder::new()
                 .with_initial_interval(Duration::from_millis(1))
@@ -1756,7 +1755,7 @@ pub(crate) mod tls {
             self.session_id
         }
 
-        async fn next(&self) -> Result<Self::Stream, ClientError> {
+        async fn next(&mut self) -> Result<Self::Stream, ClientError> {
             let session_id = self.session_id;
             let server_name = ServerName::try_from(self.hostname.clone()).map_err(|e| {
                 ClientError::Connect(
@@ -2612,7 +2611,7 @@ mod tests {
             self.session_id
         }
 
-        async fn next(&self) -> Result<Self::Stream, ClientError> {
+        async fn next(&mut self) -> Result<Self::Stream, ClientError> {
             let session_id = self.session_id;
             tracing::debug!("MockLink starts to connect.");
             if self.fail_connects.load(Ordering::Acquire) {
@@ -2806,22 +2805,22 @@ mod tests {
     }
 
     /// Create an AcceptorLink-based server test rig. Returns the
-    /// session task handle, an MVar for dispatching streams,
-    /// the message receiver, and a cancellation token.
+    /// session task handle, the channel sender for dispatching
+    /// streams, the message receiver, and a cancellation token.
     fn serve_acceptor_test<M: RemoteMessage>(
         session_id: SessionId,
     ) -> (
         JoinHandle<()>,
-        crate::sync::mvar::MVar<DuplexStream>,
+        mpsc::UnboundedSender<DuplexStream>,
         mpsc::Receiver<M>,
         CancellationToken,
     ) {
-        let mvar = crate::sync::mvar::MVar::empty();
+        let (acceptor_tx, acceptor_rx) = mpsc::unbounded_channel::<DuplexStream>();
         let cancel_token = CancellationToken::new();
         let link = AcceptorLink {
             dest: ChannelAddr::Local(u64::MAX),
             session_id,
-            stream: mvar.clone(),
+            stream: acceptor_rx,
             cancel: cancel_token.clone(),
         };
         let (tx, rx) = mpsc::channel::<M>(1024);
@@ -2885,7 +2884,7 @@ mod tests {
                 break;
             }
         });
-        (handle, mvar, rx, cancel_token)
+        (handle, acceptor_tx, rx, cancel_token)
     }
 
     async fn write_stream<M, W>(
@@ -2940,12 +2939,12 @@ mod tests {
         }
 
         let session_id = SessionId(123);
-        let (_handle, mvar, mut rx, cancel_token) = serve_acceptor_test::<u64>(session_id);
+        let (_handle, acceptor_tx, mut rx, cancel_token) = serve_acceptor_test::<u64>(session_id);
 
         // First connection: send messages, verify delivery and ack.
         {
             let (sender, receiver) = tokio::io::duplex(5000);
-            mvar.put(receiver).await;
+            acceptor_tx.send(receiver).unwrap();
 
             let (r, writer) = tokio::io::split(sender);
             let mut reader = FrameReader::new(
@@ -2978,7 +2977,7 @@ mod tests {
         // Second connection (reconnection): retransmitted messages are deduped.
         {
             let (sender2, receiver2) = tokio::io::duplex(5000);
-            mvar.put(receiver2).await;
+            acceptor_tx.send(receiver2).unwrap();
 
             let (r2, writer2) = tokio::io::split(sender2);
             let mut reader2 = FrameReader::new(
@@ -3014,10 +3013,10 @@ mod tests {
         let config = hyperactor_config::global::lock();
         let _guard = config.override_key(config::MESSAGE_ACK_EVERY_N_MESSAGES, 1);
         let session_id = SessionId(123);
-        let (_handle, mvar, mut rx, cancel_token) = serve_acceptor_test::<u64>(session_id);
+        let (_handle, acceptor_tx, mut rx, cancel_token) = serve_acceptor_test::<u64>(session_id);
 
         let (sender, receiver) = tokio::io::duplex(5000);
-        mvar.put(receiver).await;
+        acceptor_tx.send(receiver).unwrap();
         let (r, mut writer) = tokio::io::split(sender);
         let mut reader = FrameReader::new(
             r,
@@ -3731,10 +3730,10 @@ mod tests {
         let config = hyperactor_config::global::lock();
         let _guard = config.override_key(config::MESSAGE_ACK_EVERY_N_MESSAGES, 1);
         let session_id = SessionId(123);
-        let (_handle, mvar, mut rx, _cancel_token) = serve_acceptor_test::<u64>(session_id);
+        let (_handle, acceptor_tx, mut rx, _cancel_token) = serve_acceptor_test::<u64>(session_id);
 
         let (sender, receiver) = tokio::io::duplex(5000);
-        mvar.put(receiver).await;
+        acceptor_tx.send(receiver).unwrap();
         let (r, writer) = tokio::io::split(sender);
         let mut reader = FrameReader::new(
             r,
@@ -3789,5 +3788,368 @@ mod tests {
         // dropped and when wait_for was called. So we still need to do an
         // equality check.
         assert!(watcher.borrow().is_closed());
+    }
+
+    /// Yields pre-built `DuplexStream`s to the accept loop and
+    /// blocks once drained. Lets the `rx_join_flushes_pending_ack_*`
+    /// tests inspect the wire from the other end.
+    struct QueueListener {
+        streams: std::collections::VecDeque<DuplexStream>,
+        addr: ChannelAddr,
+    }
+
+    #[async_trait]
+    impl super::Listener for QueueListener {
+        type Stream = DuplexStream;
+
+        async fn accept(&mut self) -> Result<(DuplexStream, ChannelAddr), ServerError> {
+            match self.streams.pop_front() {
+                Some(s) => Ok((s, self.addr.clone())),
+                None => std::future::pending().await,
+            }
+        }
+    }
+
+    /// In-memory connection: server end goes into the listener; the
+    /// test reads from `client_r`.
+    struct PreparedConnection {
+        server_side: DuplexStream,
+        // Kept alive so the server's recv-loop stays in its `select!`
+        // on cancellation rather than exiting on EOF. Tests must
+        // exercise the cancel-flush path.
+        _client_w: tokio::io::WriteHalf<DuplexStream>,
+        client_r: ReadHalf<DuplexStream>,
+    }
+
+    /// Write `LinkInit` and the framed `Frame::Message(seq, value)`
+    /// payloads on the client side; return both halves.
+    async fn prepare_connection(
+        session_id: SessionId,
+        stream_id: u8,
+        messages: &[(u64, u64)],
+    ) -> PreparedConnection {
+        let (client_side, server_side) = tokio::io::duplex(8192);
+        let (client_r, mut client_w) = tokio::io::split(client_side);
+
+        super::write_link_init(&mut client_w, session_id, stream_id)
+            .await
+            .unwrap();
+        let max_len = hyperactor_config::global::get(config::CODEC_MAX_FRAME_LENGTH);
+        for (seq, value) in messages {
+            let payload =
+                serde_multipart::serialize_bincode(&Frame::<u64>::Message(*seq, *value)).unwrap();
+            let mut fw = FrameWrite::new(client_w, payload.framed(), max_len, 0)
+                .map_err(|(_w, e)| e)
+                .unwrap();
+            fw.send().await.unwrap();
+            client_w = fw.complete();
+        }
+
+        PreparedConnection {
+            server_side,
+            _client_w: client_w,
+            client_r,
+        }
+    }
+
+    /// Test plan for `run_separate_sessions_flush_test`: each entry
+    /// describes one connection that lives on its own session.
+    struct SeparateSessionPlan {
+        session_id: SessionId,
+        stream_id: u8,
+        messages: Vec<(u64, u64)>,
+    }
+
+    /// Drive the rx.join flush test across multiple connections,
+    /// each on its own session. Verifies:
+    ///
+    /// 1. Every message sent reaches the application via `rx.recv()`.
+    /// 2. After application delivery completes, *no* ack frames have
+    ///    been emitted on any connection's read side — the policy
+    ///    thresholds are out of reach.
+    /// 3. After `rx.join()` returns, every connection has exactly
+    ///    one `NetRxResponse::Ack(highest_seq)` frame on its read
+    ///    side, followed by a `NetRxResponse::Closed` terminal frame.
+    async fn run_separate_sessions_flush_test(
+        plans: Vec<SeparateSessionPlan>,
+        stream_id_label: &str,
+    ) {
+        let config = hyperactor_config::global::lock();
+        let _g_msg = config.override_key(config::MESSAGE_ACK_EVERY_N_MESSAGES, 1_000_000);
+        let _g_time =
+            config.override_key(config::MESSAGE_ACK_TIME_INTERVAL, Duration::from_secs(3600));
+
+        // Build all connections and stage them into a `QueueListener`.
+        let mut conns: Vec<PreparedConnection> = Vec::with_capacity(plans.len());
+        let mut expected_messages: std::collections::HashSet<u64> =
+            std::collections::HashSet::new();
+        let mut expected_acks: Vec<u64> = Vec::with_capacity(plans.len());
+        for plan in &plans {
+            for (_seq, value) in &plan.messages {
+                expected_messages.insert(*value);
+            }
+            expected_acks.push(plan.messages.iter().map(|(s, _)| *s).max().unwrap());
+            conns.push(prepare_connection(plan.session_id, plan.stream_id, &plan.messages).await);
+        }
+
+        let addr = ChannelAddr::Local(u64::MAX);
+        let listener = QueueListener {
+            streams: conns
+                .iter_mut()
+                .map(|c| {
+                    // Move server_side out of each PreparedConnection by replacing it with a placeholder.
+                    std::mem::replace(&mut c.server_side, tokio::io::duplex(1).0)
+                })
+                .collect(),
+            addr: addr.clone(),
+        };
+        let (_addr, mut rx) = super::server::serve_with_listener::<u64, _>(listener, addr).unwrap();
+
+        // Drain every expected message off the application channel.
+        let mut received: std::collections::HashSet<u64> = std::collections::HashSet::new();
+        for _ in 0..expected_messages.len() {
+            received.insert(rx.recv().await.unwrap());
+        }
+        assert_eq!(
+            received, expected_messages,
+            "{stream_id_label}: every produced message should reach the application"
+        );
+
+        // Give any policy-driven ack timer a generous grace period to
+        // fire. Because `MESSAGE_ACK_EVERY_N_MESSAGES` and
+        // `MESSAGE_ACK_TIME_INTERVAL` are out of reach, no ack should
+        // be emitted yet — but if a regression makes them reachable
+        // (or adds a new spontaneous emission path), this sleep gives
+        // it room to do so before the assertion below.
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        let max_len = hyperactor_config::global::get(config::CODEC_MAX_FRAME_LENGTH);
+        let mut readers: Vec<FrameReader<ReadHalf<DuplexStream>>> = conns
+            .into_iter()
+            .map(|c| FrameReader::new(c.client_r, max_len))
+            .collect();
+        for (idx, reader) in readers.iter_mut().enumerate() {
+            match tokio::time::timeout(Duration::from_millis(10), reader.next()).await {
+                Err(_) => {} // timeout — no frame, expected.
+                Ok(Err(e)) => panic!(
+                    "{stream_id_label}: connection {idx} frame reader error before rx.join: {e}"
+                ),
+                Ok(Ok(None)) => {
+                    panic!("{stream_id_label}: connection {idx} closed before rx.join()")
+                }
+                Ok(Ok(Some((_, bytes)))) => {
+                    let resp = super::deserialize_response(bytes).unwrap();
+                    panic!(
+                        "{stream_id_label}: connection {idx} unexpectedly received {resp:?} \
+                         before rx.join()"
+                    );
+                }
+            }
+        }
+
+        rx.join().await;
+
+        // After rx.join() returns, every connection must have its
+        // terminal cleanup frames already written: an `Ack` covering
+        // the highest seq it sent, then a `Closed`.
+        for (idx, (reader, expected_ack)) in readers.iter_mut().zip(&expected_acks).enumerate() {
+            let bytes = tokio::time::timeout(Duration::from_millis(50), reader.next())
+                .await
+                .unwrap_or_else(|_| {
+                    panic!(
+                        "{stream_id_label}: connection {idx} produced no Ack frame within 50ms \
+                         after rx.join()"
+                    )
+                })
+                .expect("frame reader error")
+                .expect("frame reader returned None");
+            let acked = super::deserialize_response(bytes.1)
+                .unwrap()
+                .into_ack()
+                .unwrap_or_else(|other| {
+                    panic!("{stream_id_label}: connection {idx} expected Ack, got {other:?}")
+                });
+            assert_eq!(
+                acked, *expected_ack,
+                "{stream_id_label}: connection {idx} ack mismatch"
+            );
+
+            let bytes = tokio::time::timeout(Duration::from_millis(50), reader.next())
+                .await
+                .unwrap_or_else(|_| {
+                    panic!(
+                        "{stream_id_label}: connection {idx} produced no Closed frame within 50ms"
+                    )
+                })
+                .expect("frame reader error")
+                .expect("frame reader returned None");
+            assert!(
+                super::deserialize_response(bytes.1).unwrap().is_closed(),
+                "{stream_id_label}: connection {idx} expected Closed terminal frame"
+            );
+        }
+    }
+
+    #[async_timed_test(timeout_secs = 30)]
+    async fn rx_join_flushes_pending_ack_single_stream() {
+        // Three independent single-stream sessions, each with three
+        // framed messages. Verifies every recv-loop's terminal flush
+        // ran by the time `rx.join()` returns.
+        let plans = (1u64..=3)
+            .map(|sid| SeparateSessionPlan {
+                session_id: SessionId(sid),
+                stream_id: 0,
+                messages: (0u64..3).map(|seq| (seq, sid * 100 + seq)).collect(),
+            })
+            .collect();
+        run_separate_sessions_flush_test(plans, "single-stream").await;
+    }
+
+    #[async_timed_test(timeout_secs = 30)]
+    async fn rx_join_flushes_pending_ack_multi_stream() {
+        // Three independent multi-stream sessions, each with three
+        // framed messages, each on its own session_id with a single
+        // stream_id of 1. Exercises `dispatch_multi_stream`'s terminal
+        // cleanup once per session.
+        let plans = (1u64..=3)
+            .map(|sid| SeparateSessionPlan {
+                session_id: SessionId(sid),
+                stream_id: 1,
+                messages: (0u64..3).map(|seq| (seq, sid * 100 + seq)).collect(),
+            })
+            .collect();
+        run_separate_sessions_flush_test(plans, "multi-stream").await;
+    }
+
+    /// One session, multiple stream_ids — exercises `AckWatermark`'s
+    /// shared-watermark path. Three streams in the same session each
+    /// send three messages with disjoint seqs filling the contiguous
+    /// range 0..=8. Each stream's cleanup reads `highest_uncommitted`
+    /// and emits `Ack(8)` on its own wire so the peer's per-wire
+    /// NetTx sees an ack for messages it sent there; the receiver
+    /// discards duplicates. Every stream also emits its own `Closed`.
+    #[async_timed_test(timeout_secs = 30)]
+    async fn rx_join_flushes_pending_ack_shared_multi_stream_session() {
+        let config = hyperactor_config::global::lock();
+        let _g_msg = config.override_key(config::MESSAGE_ACK_EVERY_N_MESSAGES, 1_000_000);
+        let _g_time =
+            config.override_key(config::MESSAGE_ACK_TIME_INTERVAL, Duration::from_secs(3600));
+
+        let session_id = SessionId(99);
+        let num_streams = 3u8;
+        let msgs_per_stream = 3u64;
+        let mut conns: Vec<PreparedConnection> = Vec::with_capacity(num_streams as usize);
+        let mut expected_messages: std::collections::HashSet<u64> =
+            std::collections::HashSet::new();
+        for stream_id in 1..=num_streams {
+            let messages: Vec<(u64, u64)> = (0u64..msgs_per_stream)
+                .map(|i| {
+                    let seq = (stream_id as u64 - 1) * msgs_per_stream + i;
+                    (seq, 1000 + seq)
+                })
+                .collect();
+            for (_, v) in &messages {
+                expected_messages.insert(*v);
+            }
+            conns.push(prepare_connection(session_id, stream_id, &messages).await);
+        }
+        let highest_seq = num_streams as u64 * msgs_per_stream - 1;
+
+        let addr = ChannelAddr::Local(u64::MAX);
+        let listener = QueueListener {
+            streams: conns
+                .iter_mut()
+                .map(|c| std::mem::replace(&mut c.server_side, tokio::io::duplex(1).0))
+                .collect(),
+            addr: addr.clone(),
+        };
+        let (_addr, mut rx) = super::server::serve_with_listener::<u64, _>(listener, addr).unwrap();
+
+        let mut received: std::collections::HashSet<u64> = std::collections::HashSet::new();
+        for _ in 0..expected_messages.len() {
+            received.insert(rx.recv().await.unwrap());
+        }
+        assert_eq!(
+            received, expected_messages,
+            "shared-session multi-stream: every message reaches the application"
+        );
+
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        let max_len = hyperactor_config::global::get(config::CODEC_MAX_FRAME_LENGTH);
+        let mut readers: Vec<FrameReader<ReadHalf<DuplexStream>>> = conns
+            .into_iter()
+            .map(|c| FrameReader::new(c.client_r, max_len))
+            .collect();
+        for (idx, reader) in readers.iter_mut().enumerate() {
+            match tokio::time::timeout(Duration::from_millis(10), reader.next()).await {
+                Err(_) | Ok(Ok(None)) => {} // timeout / EOF — no early ack, good.
+                Ok(Err(e)) => {
+                    panic!("shared-session multi-stream: stream {idx} frame reader error: {e}")
+                }
+                Ok(Ok(Some((_, bytes)))) => {
+                    let resp = super::deserialize_response(bytes).unwrap();
+                    panic!(
+                        "shared-session multi-stream: stream {idx} unexpectedly received \
+                         {resp:?} before rx.join()"
+                    );
+                }
+            }
+        }
+
+        rx.join().await;
+
+        // Drain every frame on every reader. Terminal cleanup may emit
+        // `Ack(highest_seq)` on one or more wires before `Closed`, but
+        // once one cleanup commits the shared watermark, later streams
+        // may emit only `Closed`.
+        let mut ack_count = 0;
+        let mut closed_count = 0;
+        for (idx, reader) in readers.iter_mut().enumerate() {
+            loop {
+                match tokio::time::timeout(Duration::from_millis(50), reader.next()).await {
+                    Err(_) => panic!(
+                        "shared-session multi-stream: stream {idx} did not yield expected \
+                         frames within 50ms after rx.join()"
+                    ),
+                    Ok(Err(e)) => panic!("frame reader error: {e}"),
+                    Ok(Ok(None)) => break,
+                    Ok(Ok(Some((_, bytes)))) => {
+                        let resp = super::deserialize_response(bytes).unwrap();
+                        match resp {
+                            NetRxResponse::Ack(seq) => {
+                                assert_eq!(
+                                    seq, highest_seq,
+                                    "shared-session multi-stream: ack should cover the full \
+                                     contiguous range 0..={highest_seq}"
+                                );
+                                ack_count += 1;
+                            }
+                            NetRxResponse::Closed => {
+                                closed_count += 1;
+                                break;
+                            }
+                            other => panic!(
+                                "shared-session multi-stream: stream {idx} unexpected {other:?}"
+                            ),
+                        }
+                    }
+                }
+            }
+        }
+        assert!(
+            ack_count >= 1,
+            "shared-session multi-stream: expected at least one Ack({highest_seq}); \
+             got {ack_count}"
+        );
+        assert!(
+            ack_count <= num_streams as usize,
+            "shared-session multi-stream: expected at most {num_streams} Ack({highest_seq}) \
+             frames; got {ack_count}"
+        );
+        assert_eq!(
+            closed_count, num_streams as usize,
+            "shared-session multi-stream: every stream should emit its own Closed frame"
+        );
     }
 }

--- a/hyperactor/src/channel/net/duplex.rs
+++ b/hyperactor/src/channel/net/duplex.rs
@@ -62,7 +62,6 @@ use crate::channel::net::Stream;
 use crate::channel::net::meta;
 use crate::channel::net::tls;
 use crate::metrics;
-use crate::sync::mvar::MVar;
 
 /// Public duplex server that yields `(DuplexRx<In>, DuplexTx<Out>)` pairs.
 pub struct DuplexServer<In: RemoteMessage, Out: RemoteMessage> {
@@ -205,7 +204,8 @@ pub fn serve<In: RemoteMessage, Out: RemoteMessage>(
         }
     };
 
-    let sessions: Arc<DashMap<SessionId, MVar<Box<dyn Stream>>>> = Arc::new(DashMap::new());
+    let sessions: Arc<DashMap<SessionId, mpsc::UnboundedSender<Box<dyn Stream>>>> =
+        Arc::new(DashMap::new());
     let child_cancel = CancellationToken::new();
     let dispatch_dest = channel_addr.clone();
     let dispatch = {
@@ -222,7 +222,7 @@ pub fn serve<In: RemoteMessage, Out: RemoteMessage>(
                 dispatch_duplex_stream::<In, Out>(
                     link_init.session_id,
                     stream,
-                    &sessions,
+                    sessions,
                     dest,
                     &accept_tx,
                     cancel,
@@ -260,21 +260,21 @@ enum Either {
 async fn dispatch_duplex_stream<In: RemoteMessage, Out: RemoteMessage>(
     session_id: SessionId,
     stream: Box<dyn Stream>,
-    sessions: &DashMap<SessionId, MVar<Box<dyn Stream>>>,
+    sessions: Arc<DashMap<SessionId, mpsc::UnboundedSender<Box<dyn Stream>>>>,
     addr: ChannelAddr,
     accept_tx: &mpsc::Sender<(DuplexRx<In>, DuplexTx<Out>)>,
     cancel: CancellationToken,
 ) {
-    let mvar = {
+    let sender = {
         let entry = sessions.entry(session_id);
         match entry {
             dashmap::mapref::entry::Entry::Occupied(e) => e.get().clone(),
             dashmap::mapref::entry::Entry::Vacant(e) => {
-                let mvar: MVar<Box<dyn Stream>> = MVar::empty();
+                let (sender, receiver) = mpsc::unbounded_channel::<Box<dyn Stream>>();
                 let link = AcceptorLink {
                     dest: addr.clone(),
                     session_id,
-                    stream: mvar.clone(),
+                    stream: receiver,
                     cancel: cancel.clone(),
                 };
 
@@ -292,6 +292,7 @@ async fn dispatch_duplex_stream<In: RemoteMessage, Out: RemoteMessage>(
 
                 let session_ct = cancel.clone();
                 let dest = addr.clone();
+                let cleanup_sessions = Arc::clone(&sessions);
                 tokio::spawn(async move {
                     let mut session = Session::new(link);
                     let mut recv_next = Next { seq: 0, ack: 0 };
@@ -421,16 +422,26 @@ async fn dispatch_duplex_stream<In: RemoteMessage, Out: RemoteMessage>(
                         }
                     }
 
+                    // Recv-loop is finished — no further conns will
+                    // be drained. Drop the session entry so a later
+                    // reconnect for the same session_id starts a
+                    // fresh dispatch task instead of feeding a dead
+                    // channel; any in-flight feeder's send fails
+                    // after the link's receiver above is dropped.
+                    cleanup_sessions.remove(&session_id);
+
                     let _ = notify.send(TxStatus::Closed("duplex session ended".into()));
                 });
 
-                e.insert(mvar.clone());
-                mvar
+                e.insert(sender.clone());
+                sender
             }
         }
     };
 
-    mvar.put(stream).await;
+    // Send returns Err if the spawned recv-loop task exited and
+    // dropped the receiver — drop the conn in that case.
+    let _ = sender.send(stream);
 }
 
 /// Establish a duplex (bidirectional) session over the given link.

--- a/hyperactor/src/channel/net/server.rs
+++ b/hyperactor/src/channel/net/server.rs
@@ -40,15 +40,19 @@ use crate::channel::net::meta;
 use crate::channel::net::tls;
 use crate::config;
 use crate::metrics;
-use crate::sync::mvar::MVar;
 
 /// Server-side link that receives pre-established streams from the
-/// dispatcher via an MVar. Implements [`Link`] so it can be used
-/// with [`Session::new`].
+/// dispatcher via an unbounded mpsc channel. Implements [`Link`] so
+/// it can be used with [`Session::new`]. Dropping the link drops
+/// the receiver, which causes any feeder's later `send` to fail
+/// with `SendError` (the conn is dropped). The channel is unbounded
+/// so the dispatch task can publish its sender to the session map
+/// before draining the first connection without risking a deadlock
+/// against a concurrent feeder for the same session_id.
 pub(super) struct AcceptorLink<S: Stream> {
     pub(super) dest: ChannelAddr,
     pub(super) session_id: SessionId,
-    pub(super) stream: MVar<S>,
+    pub(super) stream: mpsc::UnboundedReceiver<S>,
     pub(super) cancel: CancellationToken,
 }
 
@@ -73,29 +77,33 @@ impl<S: Stream> Link for AcceptorLink<S> {
         self.session_id
     }
 
-    async fn next(&self) -> Result<S, ClientError> {
-        tokio::select! {
-            stream = self.stream.take() => Ok(stream),
-            _ = self.cancel.cancelled() => Err(ClientError::Connect(
-                self.dest.clone(),
+    async fn next(&mut self) -> Result<S, ClientError> {
+        let dest = self.dest.clone();
+        let make_err = move || {
+            ClientError::Connect(
+                dest.clone(),
                 std::io::Error::other("acceptor closed"),
                 "acceptor channel closed".into(),
-            )),
+            )
+        };
+        tokio::select! {
+            result = self.stream.recv() => result.ok_or_else(&make_err),
+            _ = self.cancel.cancelled() => Err(make_err()),
         }
     }
 }
 
 /// Shared state for multi-stream sessions. Each additional stream
-/// (stream_id > 0) gets its own MVar for connection handoff. The
+/// (stream_id > 0) gets its own connection-handoff channel. The
 /// [`AckWatermark`] is shared across all streams so cumulative acks
 /// reflect the global sequence space.
 pub(super) struct StreamState<S: Stream> {
-    /// Per-stream MVars for connection handoff. Keyed by stream_id.
+    /// Per-stream connection-handoff senders. Keyed by stream_id.
     /// Accessed concurrently from multiple accept-loop dispatch tasks
     /// (one per incoming connection for the same session), but only
     /// for a brief `entry().or_insert_with()` — a plain std Mutex is
     /// cheaper than DashMap here.
-    streams: std::sync::Mutex<HashMap<u8, MVar<S>>>,
+    streams: std::sync::Mutex<HashMap<u8, mpsc::UnboundedSender<S>>>,
     /// Shared ack tracker: each stream records its received seqs here.
     ack_watermark: tokio::sync::Mutex<session::AckWatermark>,
 }
@@ -136,147 +144,172 @@ fn resolve_stream<S: Stream>(
 
 /// Dispatch a newly accepted connection to the right session.
 ///
-/// When `streams` is `None`, this is a single-stream (strictly
-/// in-order) session, and the MVar to hand the connection to is
-/// looked up in `sessions` (creating a fresh session reader on first
-/// use).
+/// `streams = None` is a single-stream (strictly in-order) session;
+/// `Some((stream_id, state))` is the `stream_id`-th stream of a
+/// multi-stream session sharing `state`.
 ///
-/// When `streams` is `Some((stream_id, state))`, this is the
-/// `stream_id`-th stream of a multi-stream session sharing `state`
-/// (the caller resolves the per-session state from its own map). The
-/// connection is handed to a per-`stream_id` MVar inside `state`.
+/// Structured concurrency: the first dispatch for a session runs the
+/// recv-loop inline and only returns after its terminal cleanup
+/// (flush any pending ack, emit `Closed` on cancellation).
+/// Reconnects hand the connection off via the per-session
+/// channel and return immediately. [`accept_loop`] joins every
+/// dispatch in its `connections` `JoinSet`, so it finishes only
+/// after every recv-loop has finished.
 pub(super) async fn dispatch_stream<M: RemoteMessage, S: Stream>(
     session_id: SessionId,
     streams: Option<(u8, Arc<StreamState<S>>)>,
     conn: S,
-    sessions: &DashMap<SessionId, MVar<S>>,
+    sessions: &DashMap<SessionId, mpsc::UnboundedSender<S>>,
     dest: ChannelAddr,
     tx: mpsc::Sender<M>,
     cancel: CancellationToken,
 ) {
     if let Some((stream_id, state)) = streams {
-        // Multi-stream: route to a per-stream reader task.
+        // Multi-stream: route to the per-stream dispatch handler.
         dispatch_multi_stream::<M, S>(session_id, stream_id, conn, state, dest, tx, cancel).await;
         return;
     }
 
-    // Single-stream: existing logic.
-    let stream = {
+    // Single-stream: insert into the session map and drop the
+    // DashMap shard guard before any await. Vacant inserts the
+    // sender side; occupied returns the existing sender so this
+    // dispatch acts as a feeder. Unbounded so this task can publish
+    // the sender before draining the first conn without deadlocking
+    // a concurrent feeder for the same session_id.
+    let entry_result = {
         let entry = sessions.entry(session_id);
         match entry {
-            dashmap::mapref::entry::Entry::Occupied(e) => e.get().clone(),
+            dashmap::mapref::entry::Entry::Occupied(e) => Err(e.get().clone()),
             dashmap::mapref::entry::Entry::Vacant(e) => {
-                let stream: MVar<S> = MVar::empty();
-                let link = AcceptorLink {
-                    dest: dest.clone(),
-                    session_id,
-                    stream: stream.clone(),
-                    cancel: cancel.clone(),
-                };
-                let deliver_tx = tx;
-                let ct = cancel.clone();
-                tokio::spawn(async move {
-                    let mut session = Session::new(link);
-                    let mut next = Next { seq: 0, ack: 0 };
-
-                    loop {
-                        let connected = match session.connect().await {
-                            Ok(s) => s,
-                            Err(_) => break,
-                        };
-
-                        let result = {
-                            let conn = connected.stream(super::INITIATOR_TO_ACCEPTOR);
-                            tokio::select! {
-                                r = session::recv_connected::<M, _, _>(
-                                    &conn,
-                                    &deliver_tx,
-                                    &mut next,
-                                ) => r,
-                                _ = ct.cancelled() => Err(session::RecvLoopError::Cancelled),
-                            }
-                        };
-
-                        // Flush remaining ack if behind.
-                        if next.ack < next.seq {
-                            let ack =
-                                super::serialize_response(super::NetRxResponse::Ack(next.seq - 1))
-                                    .unwrap();
-                            let conn = connected.stream(super::INITIATOR_TO_ACCEPTOR);
-                            let mut completion = conn.write(ack);
-                            match completion.drive().await {
-                                Ok(()) => {
-                                    next.ack = next.seq;
-                                }
-                                Err(e) => {
-                                    tracing::debug!(
-                                        error = %e,
-                                        "failed to flush acks during cleanup"
-                                    );
-                                }
-                            }
-                        }
-
-                        // Send reject or closed response if appropriate.
-                        let terminal_response = match &result {
-                            Err(session::RecvLoopError::SequenceError(reason)) => {
-                                Some(super::NetRxResponse::Reject(reason.clone()))
-                            }
-                            Err(session::RecvLoopError::Cancelled) => {
-                                Some(super::NetRxResponse::Closed)
-                            }
-                            _ => None,
-                        };
-                        if let Some(rsp) = terminal_response {
-                            let data = super::serialize_response(rsp).unwrap();
-                            let conn = connected.stream(super::INITIATOR_TO_ACCEPTOR);
-                            let mut completion = conn.write(data);
-                            let _ = completion.drive().await;
-                        }
-
-                        let recoverable =
-                            matches!(&result, Ok(()) | Err(session::RecvLoopError::Io(_)));
-
-                        match &result {
-                            Ok(()) => {
-                                tracing::info!(
-                                    %dest,
-                                    %session_id,
-                                    "recv_connected returned EOF, awaiting reconnect"
-                                );
-                            }
-                            Err(e) => {
-                                tracing::info!(
-                                    %dest,
-                                    %session_id,
-                                    error = %e,
-                                    recoverable,
-                                    "recv_connected returned error"
-                                );
-                            }
-                        }
-
-                        session = connected.release();
-
-                        if recoverable {
-                            continue;
-                        }
-                        break; // SequenceError or Cancelled
-                    }
-                });
-                e.insert(stream.clone());
-                stream
+                let (sender, receiver) = mpsc::unbounded_channel::<S>();
+                e.insert(sender.clone());
+                Ok((sender, receiver))
             }
         }
     };
 
-    stream.put(conn).await;
+    let (sender, receiver) = match entry_result {
+        Err(sender) => {
+            // Feeder: forward the conn through the existing channel.
+            // Send returns Err if the processor task exited and
+            // dropped the receiver — drop the conn in that case.
+            let _ = sender.send(conn);
+            return;
+        }
+        Ok(pair) => pair,
+    };
+
+    let link = AcceptorLink {
+        dest: dest.clone(),
+        session_id,
+        stream: receiver,
+        cancel: cancel.clone(),
+    };
+    let deliver_tx = tx;
+    let ct = cancel;
+
+    // Hand the first connection off through the channel; the
+    // recv-loop below picks it up via `session.connect().await`.
+    let _ = sender.send(conn);
+    drop(sender);
+
+    let mut session = Session::new(link);
+    let mut next = Next { seq: 0, ack: 0 };
+
+    loop {
+        let connected = match session.connect().await {
+            Ok(s) => s,
+            Err(_) => break,
+        };
+
+        let result = {
+            let conn = connected.stream(super::INITIATOR_TO_ACCEPTOR);
+            tokio::select! {
+                r = session::recv_connected::<M, _, _>(
+                    &conn,
+                    &deliver_tx,
+                    &mut next,
+                ) => r,
+                _ = ct.cancelled() => Err(session::RecvLoopError::Cancelled),
+            }
+        };
+
+        // Flush a final ack if behind.
+        if next.ack < next.seq {
+            let ack = super::serialize_response(super::NetRxResponse::Ack(next.seq - 1)).unwrap();
+            let conn = connected.stream(super::INITIATOR_TO_ACCEPTOR);
+            let mut completion = conn.write(ack);
+            match completion.drive().await {
+                Ok(()) => {
+                    next.ack = next.seq;
+                }
+                Err(e) => {
+                    tracing::debug!(
+                        error = %e,
+                        "failed to flush acks during cleanup"
+                    );
+                }
+            }
+        }
+
+        // Send reject or closed response if appropriate.
+        let terminal_response = match &result {
+            Err(session::RecvLoopError::SequenceError(reason)) => {
+                Some(super::NetRxResponse::Reject(reason.clone()))
+            }
+            Err(session::RecvLoopError::Cancelled) => Some(super::NetRxResponse::Closed),
+            _ => None,
+        };
+        if let Some(rsp) = terminal_response {
+            let data = super::serialize_response(rsp).unwrap();
+            let conn = connected.stream(super::INITIATOR_TO_ACCEPTOR);
+            let mut completion = conn.write(data);
+            let _ = completion.drive().await;
+        }
+
+        let recoverable = matches!(&result, Ok(()) | Err(session::RecvLoopError::Io(_)));
+
+        match &result {
+            Ok(()) => {
+                tracing::info!(
+                    %dest,
+                    %session_id,
+                    "recv_connected returned EOF, awaiting reconnect"
+                );
+            }
+            Err(e) => {
+                tracing::info!(
+                    %dest,
+                    %session_id,
+                    error = %e,
+                    recoverable,
+                    "recv_connected returned error"
+                );
+            }
+        }
+
+        session = connected.release();
+
+        if recoverable {
+            continue;
+        }
+        break;
+    }
+
+    // Recv-loop is finished — no further conns will be drained.
+    // Drop the session entry so a later reconnect for the same
+    // session_id starts a fresh dispatch task instead of feeding a
+    // dead channel; any in-flight feeder's send fails after the
+    // receiver above is dropped.
+    sessions.remove(&session_id);
 }
 
-/// Handle a multi-stream connection (stream_id > 0). Spawns a per-stream
-/// reader task that reads frames, deserializes, delivers to the shared
-/// mpsc, and sends acks. Uses an AckWatermark shared across all streams
-/// of the same session for cumulative out-of-order acking.
+/// Handle a multi-stream connection (stream_id > 0). All streams of
+/// a session share an `AckWatermark` for cumulative out-of-order
+/// acking. Same structured-concurrency contract as
+/// [`dispatch_stream`]: first dispatch for a given (`session_id`,
+/// `stream_id`) runs the recv-loop inline; reconnects hand off via
+/// the per-stream channel and return.
 async fn dispatch_multi_stream<M: RemoteMessage, S: Stream>(
     session_id: SessionId,
     stream_id: u8,
@@ -291,86 +324,148 @@ async fn dispatch_multi_stream<M: RemoteMessage, S: Stream>(
         "dispatch_multi_stream: new connection"
     );
 
-    // Get or create an MVar for this stream_id.
-    let stream_mvar = {
+    // Insert into the per-session map and drop the std::sync::Mutex
+    // guard before any await — its guard is !Send. Vacant inserts
+    // the sender side; occupied returns the existing sender so this
+    // dispatch acts as a feeder. Unbounded so this task can publish
+    // the sender before draining the first conn without deadlocking
+    // a concurrent feeder for the same (session_id, stream_id).
+    let entry_result = {
         use std::collections::hash_map::Entry;
         let mut streams = state.streams.lock().unwrap();
         match streams.entry(stream_id) {
-            Entry::Occupied(e) => e.get().clone(),
+            Entry::Occupied(e) => Err(e.get().clone()),
             Entry::Vacant(e) => {
-                let mvar: MVar<S> = MVar::empty();
-                let link = AcceptorLink {
-                    dest: dest.clone(),
-                    session_id,
-                    stream: mvar.clone(),
-                    cancel: cancel.clone(),
-                };
-                let deliver_tx = tx;
-                let ct = cancel.clone();
-                let shared_state = state.clone();
-
-                // Spawn a reader task for this stream.
-                tokio::spawn(async move {
-                    let mut session = Session::new(link);
-
-                    loop {
-                        let connected = match session.connect().await {
-                            Ok(s) => s,
-                            Err(_) => break,
-                        };
-
-                        let result = {
-                            let conn = connected.stream(super::INITIATOR_TO_ACCEPTOR);
-                            tokio::select! {
-                                r = session::multi_stream_recv_connected::<M, _, _>(
-                                    &conn,
-                                    &shared_state.ack_watermark,
-                                    &deliver_tx,
-                                ) => r,
-                                _ = ct.cancelled() => Err(session::RecvLoopError::Cancelled),
-                            }
-                        };
-
-                        let recoverable =
-                            matches!(&result, Ok(()) | Err(session::RecvLoopError::Io(_)));
-
-                        match &result {
-                            Ok(()) => {
-                                tracing::info!(
-                                    %dest,
-                                    %session_id,
-                                    stream_id,
-                                    "multi-stream recv EOF, awaiting reconnect"
-                                );
-                            }
-                            Err(e) => {
-                                tracing::info!(
-                                    %dest,
-                                    %session_id,
-                                    stream_id,
-                                    error = %e,
-                                    recoverable,
-                                    "multi-stream recv error"
-                                );
-                            }
-                        }
-
-                        session = connected.release();
-
-                        if recoverable {
-                            continue;
-                        }
-                        break;
-                    }
-                });
-
-                e.insert(mvar.clone());
-                mvar
+                let (sender, receiver) = mpsc::unbounded_channel::<S>();
+                e.insert(sender.clone());
+                Ok((sender, receiver))
             }
         }
     };
 
-    stream_mvar.put(conn).await;
+    let (sender, receiver) = match entry_result {
+        Err(sender) => {
+            // Feeder: forward the conn through the existing channel.
+            // Send returns Err if the processor task exited and
+            // dropped the receiver — drop the conn in that case.
+            let _ = sender.send(conn);
+            return;
+        }
+        Ok(pair) => pair,
+    };
+
+    let link = AcceptorLink {
+        dest: dest.clone(),
+        session_id,
+        stream: receiver,
+        cancel: cancel.clone(),
+    };
+    let deliver_tx = tx;
+    let ct = cancel;
+    let shared_state = state;
+
+    // Hand the first connection off through the channel; the
+    // recv-loop below picks it up via `session.connect().await`.
+    let _ = sender.send(conn);
+    drop(sender);
+
+    let mut session = Session::new(link);
+
+    loop {
+        let connected = match session.connect().await {
+            Ok(s) => s,
+            Err(_) => break,
+        };
+
+        let result = {
+            let conn = connected.stream(super::INITIATOR_TO_ACCEPTOR);
+            tokio::select! {
+                r = session::multi_stream_recv_connected::<M, _, _>(
+                    &conn,
+                    &shared_state.ack_watermark,
+                    &deliver_tx,
+                ) => r,
+                _ = ct.cancelled() => Err(session::RecvLoopError::Cancelled),
+            }
+        };
+
+        // Each stream emits the cumulative watermark on its own wire
+        // so the peer's per-wire NetTx sees an ack for messages it
+        // sent on this connection.
+        let pending_ack = shared_state
+            .ack_watermark
+            .lock()
+            .await
+            .highest_uncommitted();
+        if let Some(ack_val) = pending_ack {
+            let ack = super::serialize_response(super::NetRxResponse::Ack(ack_val)).unwrap();
+            let conn = connected.stream(super::INITIATOR_TO_ACCEPTOR);
+            let mut completion = conn.write(ack);
+            match completion.drive().await {
+                Ok(()) => {
+                    shared_state.ack_watermark.lock().await.commit(ack_val);
+                }
+                Err(e) => {
+                    tracing::debug!(
+                        error = %e,
+                        stream_id,
+                        "failed to flush multi-stream ack during cleanup"
+                    );
+                }
+            }
+        }
+
+        // Send reject or closed response if appropriate.
+        let terminal_response = match &result {
+            Err(session::RecvLoopError::SequenceError(reason)) => {
+                Some(super::NetRxResponse::Reject(reason.clone()))
+            }
+            Err(session::RecvLoopError::Cancelled) => Some(super::NetRxResponse::Closed),
+            _ => None,
+        };
+        if let Some(rsp) = terminal_response {
+            let data = super::serialize_response(rsp).unwrap();
+            let conn = connected.stream(super::INITIATOR_TO_ACCEPTOR);
+            let mut completion = conn.write(data);
+            let _ = completion.drive().await;
+        }
+
+        let recoverable = matches!(&result, Ok(()) | Err(session::RecvLoopError::Io(_)));
+
+        match &result {
+            Ok(()) => {
+                tracing::info!(
+                    %dest,
+                    %session_id,
+                    stream_id,
+                    "multi-stream recv EOF, awaiting reconnect"
+                );
+            }
+            Err(e) => {
+                tracing::info!(
+                    %dest,
+                    %session_id,
+                    stream_id,
+                    error = %e,
+                    recoverable,
+                    "multi-stream recv error"
+                );
+            }
+        }
+
+        session = connected.release();
+
+        if recoverable {
+            continue;
+        }
+        break;
+    }
+
+    // Recv-loop is finished — no further conns will be drained for
+    // this (session_id, stream_id). Drop the per-stream sender entry
+    // so a later reconnect starts a fresh dispatch task instead of
+    // feeding a dead channel.
+    shared_state.streams.lock().unwrap().remove(&stream_id);
 }
 
 /// Generic accept loop. Accepts connections from `listener`, transforms
@@ -584,22 +679,22 @@ pub(in crate::channel) fn serve<M: RemoteMessage>(
         }
     };
 
-    let sessions: Arc<DashMap<SessionId, MVar<Box<dyn Stream>>>> = Arc::new(DashMap::new());
+    let sessions: Arc<DashMap<SessionId, mpsc::UnboundedSender<Box<dyn Stream>>>> =
+        Arc::new(DashMap::new());
     let stream_state: Arc<std::sync::Mutex<HashMap<SessionId, Arc<StreamState<Box<dyn Stream>>>>>> =
         Arc::new(std::sync::Mutex::new(HashMap::new()));
-    let child_cancel = CancellationToken::new();
     let dispatch_dest = channel_addr.clone();
+    let dispatch_cancel = child_token.clone();
     let dispatch = {
         let sessions = Arc::clone(&sessions);
         let stream_state = Arc::clone(&stream_state);
         let tx = tx.clone();
-        let child_cancel = child_cancel.clone();
         let dest = dispatch_dest;
         move |link_init: super::LinkInit, stream: Box<dyn Stream>| {
             let sessions = Arc::clone(&sessions);
             let stream_state = Arc::clone(&stream_state);
             let tx = tx.clone();
-            let cancel = child_cancel.child_token();
+            let cancel = dispatch_cancel.clone();
             let dest = dest.clone();
             async move {
                 let streams = resolve_stream(&stream_state, &link_init);
@@ -619,9 +714,7 @@ pub(in crate::channel) fn serve<M: RemoteMessage>(
 
     let ca: ChannelAddr = channel_addr.clone();
     let join_handle = tokio::spawn(async move {
-        let result = accept_loop(&mut listener, &ca, &child_token, prepare, dispatch).await;
-        child_cancel.cancel();
-        result
+        accept_loop(&mut listener, &ca, &child_token, prepare, dispatch).await
     });
 
     let server_handle = ServerHandle {
@@ -659,21 +752,21 @@ where
         Ok((link_init, stream))
     };
 
-    let sessions: Arc<DashMap<SessionId, MVar<L::Stream>>> = Arc::new(DashMap::new());
+    let sessions: Arc<DashMap<SessionId, mpsc::UnboundedSender<L::Stream>>> =
+        Arc::new(DashMap::new());
     let stream_state: Arc<std::sync::Mutex<HashMap<SessionId, Arc<StreamState<L::Stream>>>>> =
         Arc::new(std::sync::Mutex::new(HashMap::new()));
-    let child_cancel = CancellationToken::new();
+    let dispatch_cancel = child_token.clone();
     let dispatch = {
         let sessions = Arc::clone(&sessions);
         let stream_state = Arc::clone(&stream_state);
         let tx = tx.clone();
-        let child_cancel = child_cancel.clone();
         let dest = channel_addr.clone();
         move |link_init: super::LinkInit, stream: L::Stream| {
             let sessions = Arc::clone(&sessions);
             let stream_state = Arc::clone(&stream_state);
             let tx = tx.clone();
-            let cancel = child_cancel.child_token();
+            let cancel = dispatch_cancel.clone();
             let dest = dest.clone();
             async move {
                 let streams = resolve_stream(&stream_state, &link_init);
@@ -693,9 +786,7 @@ where
 
     let ca = channel_addr.clone();
     let join_handle = tokio::spawn(async move {
-        let result = accept_loop(&mut listener, &ca, &child_token, prepare, dispatch).await;
-        child_cancel.cancel();
-        result
+        accept_loop(&mut listener, &ca, &child_token, prepare, dispatch).await
     });
 
     let server_handle = ServerHandle {

--- a/hyperactor/src/channel/net/session.rs
+++ b/hyperactor/src/channel/net/session.rs
@@ -859,6 +859,9 @@ pub(super) async fn multi_stream_recv_connected<
     deliver_tx: &mpsc::Sender<M>,
 ) -> Result<(), RecvLoopError> {
     let mut pending_ack: Option<Completion<W, Bytes>> = None;
+    // Tracked alongside `pending_ack` so we can `commit` on
+    // successful write.
+    let mut pending_ack_val: Option<u64> = None;
 
     loop {
         // Consolidated watermark access: decide whether to emit an ack
@@ -877,6 +880,7 @@ pub(super) async fn multi_stream_recv_connected<
             let ack = serialize_response(NetRxResponse::Ack(ack_val))
                 .map_err(|e| RecvLoopError::Io(e.into()))?;
             pending_ack = Some(stream.write(ack));
+            pending_ack_val = Some(ack_val);
         }
 
         tokio::select! {
@@ -886,7 +890,12 @@ pub(super) async fn multi_stream_recv_connected<
             result = async { pending_ack.as_mut().unwrap().drive().await },
                 if pending_ack.is_some() => {
                 match result {
-                    Ok(()) => pending_ack = None,
+                    Ok(()) => {
+                        if let Some(val) = pending_ack_val.take() {
+                            ack_watermark.lock().await.commit(val);
+                        }
+                        pending_ack = None;
+                    }
                     Err(e) => return Err(RecvLoopError::Io(e.into())),
                 }
             }
@@ -996,9 +1005,14 @@ pub(super) struct AckWatermark {
     /// Last ack value [`poll`](Self::poll) handed out, or `None` if no
     /// ack has been emitted yet.
     last_reported: Option<u64>,
+    /// Highest ack value the caller confirmed via
+    /// [`commit`](Self::commit) was written to the wire. Gates
+    /// [`highest_uncommitted`](Self::highest_uncommitted) so a poll
+    /// whose write failed gets retried on cleanup.
+    last_committed: Option<u64>,
     /// Messages recorded since the last emission.
     msgs_since_report: u64,
-    /// When the last emission was committed.
+    /// When the last emission was claimed.
     last_report_time: Instant,
 }
 
@@ -1010,6 +1024,7 @@ impl AckWatermark {
             ack_msg_interval,
             ack_time_interval,
             last_reported: None,
+            last_committed: None,
             msgs_since_report: 0,
             last_report_time: Instant::now(),
         }
@@ -1065,6 +1080,41 @@ impl AckWatermark {
         self.msgs_since_report = 0;
         self.last_report_time = Instant::now();
         Some(watermark)
+    }
+
+    /// Record that an ack covering up to `seq` has been written to
+    /// the wire. Monotonic; idempotent on same-value calls.
+    /// Advances [`highest_uncommitted`](Self::highest_uncommitted)'s
+    /// gate so cleanup paths skip work already on the wire.
+    pub fn commit(&mut self, seq: u64) {
+        if self.last_committed.is_none_or(|c| seq > c) {
+            self.last_committed = Some(seq);
+        }
+    }
+
+    /// The highest seq observed but not yet committed, or `None` if
+    /// nothing observed since the last commit. Pure read: every
+    /// concurrent caller sees the same value, so each multi-stream
+    /// stream emits a covering ack on its own wire. Gates on
+    /// `last_committed` (not `last_reported`) so a value handed out
+    /// by a `poll` whose write failed is still surfaced. The value
+    /// is `max(max(received), highest_contiguous)`, which can exceed
+    /// the contiguous frontier when there are gaps — at terminal
+    /// cleanup the session is tearing down anyway, so acking past
+    /// gaps is acceptable.
+    pub fn highest_uncommitted(&self) -> Option<u64> {
+        let max_seen = self
+            .received
+            .iter()
+            .next_back()
+            .copied()
+            .into_iter()
+            .chain(self.highest_contiguous)
+            .max()?;
+        if self.last_committed.is_some_and(|c| max_seen <= c) {
+            return None;
+        }
+        Some(max_seen)
     }
 
     /// Duration until [`poll`](Self::poll) should next be invoked to
@@ -1168,6 +1218,89 @@ mod ack_watermark_tests {
         assert_eq!(t.poll(), None);
         t.record(1);
         assert_eq!(t.poll(), Some(1));
+    }
+
+    #[test]
+    fn highest_uncommitted_emits_below_policy_threshold() {
+        // High threshold so `poll` returns None; cleanup surfaces
+        // the watermark anyway since nothing was committed.
+        let mut t = AckWatermark::new(1000, Duration::from_secs(3600));
+        t.record(0);
+        t.record(1);
+        assert_eq!(t.poll(), None);
+        assert_eq!(t.highest_uncommitted(), Some(1));
+    }
+
+    #[test]
+    fn highest_uncommitted_returns_none_when_nothing_recorded() {
+        let t = watermark();
+        assert_eq!(t.highest_uncommitted(), None);
+    }
+
+    #[test]
+    fn highest_uncommitted_surfaces_out_of_order_frames() {
+        // No contiguous run yet, but seq 5 was received. At cleanup
+        // we still surface it so the wire emits a covering ack.
+        let mut t = watermark();
+        t.record(5);
+        assert_eq!(t.highest_uncommitted(), Some(5));
+    }
+
+    #[test]
+    fn highest_uncommitted_returns_none_when_already_committed() {
+        let mut t = watermark();
+        t.record(0);
+        t.record(1);
+        t.commit(1);
+        assert_eq!(t.highest_uncommitted(), None);
+    }
+
+    #[test]
+    fn highest_uncommitted_surfaces_uncommitted_after_failed_poll() {
+        // `poll` advances `last_reported` but not `last_committed`.
+        // If the caller's write failed (no `commit`), cleanup must
+        // still surface the watermark.
+        let mut t = AckWatermark::new(1, Duration::from_secs(3600));
+        t.record(0);
+        assert_eq!(t.poll(), Some(0));
+        // No commit happened.
+        assert_eq!(t.highest_uncommitted(), Some(0));
+    }
+
+    #[test]
+    fn highest_uncommitted_returns_value_to_every_caller() {
+        // Pure read: concurrent cleanups all see the same value, so
+        // every stream emits a covering ack on its own wire.
+        let mut t = watermark();
+        t.record(0);
+        t.record(1);
+        assert_eq!(t.highest_uncommitted(), Some(1));
+        assert_eq!(t.highest_uncommitted(), Some(1));
+    }
+
+    #[test]
+    fn highest_uncommitted_surfaces_when_received_has_uncommitted_seqs() {
+        // `last_committed` covers the contiguous frontier, but a new
+        // out-of-order seq has arrived since the commit. Surface its
+        // value so the wire emits a covering ack on cleanup.
+        let mut t = watermark();
+        t.record(0);
+        t.commit(0);
+        t.record(5);
+        assert_eq!(t.highest_uncommitted(), Some(5));
+    }
+
+    #[test]
+    fn commit_is_idempotent_and_monotonic() {
+        let mut t = watermark();
+        t.record(0);
+        t.record(1);
+        t.commit(1);
+        // Older values do not regress `last_committed`.
+        t.commit(0);
+        // Same-value commits are no-ops.
+        t.commit(1);
+        assert_eq!(t.highest_uncommitted(), None);
     }
 }
 
@@ -1328,7 +1461,7 @@ impl<L: Link> Session<L, Disconnected> {
         >,
     > {
         Box::pin(async move {
-            let Session { link, state: _ } = self;
+            let Session { mut link, state: _ } = self;
             match link.next().await {
                 Ok(stream) => {
                     let max = hyperactor_config::global::get(config::CODEC_MAX_FRAME_LENGTH);
@@ -1359,7 +1492,7 @@ impl<L: Link> Session<L, Disconnected> {
         >,
     > {
         Box::pin(async move {
-            let Session { link, state: _ } = self;
+            let Session { mut link, state: _ } = self;
             let sleep = tokio::time::sleep_until(deadline);
             tokio::pin!(sleep);
             let mut consecutive_failures: u32 = 0;


### PR DESCRIPTION
Summary:

`MailboxServer::rx.join()` is documented as flushing pending channel-level acks before the transport tears down (`mailbox.rs:1062-1064`), but the per-connection recv-loops that hold those acks were spawned detached and not awaited. After the listener cancelled, `rx.join()` returned and the bootstrap loop called `process::exit(0)`, killing the recv-loops mid-flush. Under load this surfaces as undeliverable message errors due to unacked messages and, downstream, real test failures (see "To repro" below).

This change makes the stream dispatch path structurally concurrent: the first dispatch for a given session+stream combo runs its recv-loop inline and only returns after the loop's terminal cleanup; reconnects just hand the connection off through a per-session unbounded channel and return. `accept_loop` joins every dispatch task in its `connections` JoinSet, so once it returns there are no orphaned recv-loops and `rx.join()` honors its contract. On recv-loop exit each dispatch flavor (`dispatch_stream`, `dispatch_multi_stream`, `dispatch_duplex_stream`) drops its session/stream entry from the map so a later reconnect for the same id starts a fresh dispatch task instead of feeding a dead channel.

Per-session connection handoff moves from `MVar<S>` to `tokio::sync::mpsc::unbounded_channel::<S>()`. The MVar variant could deadlock when multiple feeders queued behind the processor and the processor exited (e.g., non-recoverable error or cancellation): `MVar::put` had no cancel branch, so feeders parked at `put` lived forever and prevented `accept_loop` from draining. With the mpsc channel the processor's exit drops the receiver, which fails any pending `send` with `SendError`; feeders unblock and the JoinSet drains. The channel is unbounded so the dispatch task can publish its sender into the session map before draining the first conn — without that, a concurrent feeder for the same session_id could fill capacity-1 and stall the publisher's own first `send`.

`dispatch_multi_stream` previously had no terminal-cleanup logic; it now reads the shared watermark on every stream's cleanup path and emits a covering ack on its own wire. `AckWatermark` gains `commit` (records `last_committed` after a successful write) and `highest_uncommitted` (pure read; returns `max(max(received), highest_contiguous)` whenever that exceeds `last_committed`, so any seq observed since the last commit — including out-of-order ones — surfaces an ack).

**Repro of the original bug:** rebase on `cc8fd20d99cf42f121c11084787e60052498d1be`, shelve this diff, run `pytest --group=5 --splits=10` then `pytest --group=6 --splits=10` against `python/tests/` with no cleanup of `/tmp/monarch_process_job_*` between groups. Group 6 fails (`test_proc_mesh_sliced` aborts; `Unhandled monarch error: NotExist`).

Reviewed By: mariusae

Differential Revision: D102661335


