### PR TITLE
Add clap to hyperactor_mesh Cargo test dependencies (#3642)

### DIFF
--- a/hyperactor_mesh/Cargo.toml
+++ b/hyperactor_mesh/Cargo.toml
@@ -62,6 +62,7 @@ zbus = { version = "5.14.0", features = ["async-executor", "async-fs", "async-io
 
 [dev-dependencies]
 buck-resources = "1"
+clap = { version = "4.6.0", features = ["derive", "env", "string", "unicode", "wrap_help"] }
 criterion = { version = "0.5.1", features = ["async_tokio", "csv_output"] }
 inventory = "0.3.24"
 jsonschema = "0.17.0"


### PR DESCRIPTION
Summary:

Fix the OSS Cargo manifest for `hyperactor_mesh` so example binaries built by `cargo test` and `cargo nextest` can resolve `clap`. Add `clap` to the Buck test deps and regenerate the internal and public autocargo manifests.

Reviewed By: shayne-fletcher

Differential Revision: D102645395


