### PR TITLE
Fix CI failures: clap dev-dep, enable_transport idempotency, resource_name format, macOS test skips

### DIFF
--- a/hyperactor/src/ref_.rs
+++ b/hyperactor/src/ref_.rs
@@ -164,13 +164,21 @@ impl ProcRef {
         self.label().map(|l| l.as_str()).unwrap_or("?")
     }
 
-    /// The ResourceId text form: `label` (singleton), `label<uid58>`
-    /// (labeled instance), or `<uid58>` (unlabeled instance).
+    /// The ResourceId text form: `label` (singleton), `label-uid58`
+    /// (labeled instance), or `uid58` (unlabeled instance). Matches the
+    /// `Display` output of `mesh_id::ResourceId` and is suitable for use as
+    /// a filesystem path component.
     pub fn resource_name(&self) -> String {
+        fn uid_str(uid: &Uid) -> String {
+            uid.to_string()
+                .trim_start_matches('<')
+                .trim_end_matches('>')
+                .to_string()
+        }
         match (self.id.uid(), self.id.label()) {
             (Uid::Singleton(label), _) => label.to_string(),
-            (Uid::Instance(_), Some(label)) => format!("{label}{}", self.id.uid()),
-            (Uid::Instance(_), None) => self.id.uid().to_string(),
+            (uid @ Uid::Instance(_), Some(label)) => format!("{label}-{}", uid_str(uid)),
+            (uid @ Uid::Instance(_), None) => uid_str(uid),
         }
     }
 }

--- a/hyperactor/src/reference.rs
+++ b/hyperactor/src/reference.rs
@@ -438,16 +438,22 @@ impl ProcId {
 
     /// The ResourceId text form of this proc's identity.
     ///
-    /// Produces `label` (singleton), `label<uid58>` (labeled instance),
-    /// or `<uid58>` (unlabeled instance). Suitable for filesystem paths
-    /// and string-based lookups that must round-trip through
-    /// `parse_resource_name`.
+    /// Produces `label` (singleton), `label-uid58` (labeled instance),
+    /// or `uid58` (unlabeled instance). Matches the `Display` output of
+    /// `mesh_id::ResourceId` and is suitable for filesystem paths and
+    /// string-based lookups that must round-trip through `parse_resource_name`.
     pub fn resource_name(&self) -> String {
         let id = self.0.id();
+        fn uid_str(uid: &Uid) -> String {
+            uid.to_string()
+                .trim_start_matches('<')
+                .trim_end_matches('>')
+                .to_string()
+        }
         match (id.uid(), id.label()) {
             (Uid::Singleton(label), _) => label.to_string(),
-            (Uid::Instance(_), Some(label)) => format!("{label}{}", id.uid()),
-            (Uid::Instance(_), None) => id.uid().to_string(),
+            (uid @ Uid::Instance(_), Some(label)) => format!("{label}-{}", uid_str(uid)),
+            (uid @ Uid::Instance(_), None) => uid_str(uid),
         }
     }
 }

--- a/python/monarch/_src/actor/actor_mesh.py
+++ b/python/monarch/_src/actor/actor_mesh.py
@@ -561,6 +561,11 @@ def enable_transport(transport: "ChannelTransport | str") -> None:
         transport_config = BindSpec(transport)
 
     if _context.get() is not None:
+        # Context already initialized. It is only an error to enable a *different* transport;
+        # re-enabling the same transport is a no-op.
+        with _transport_lock:
+            if _transport == transport_config:
+                return
         raise RuntimeError(
             "`enable_transport()` must be called before any other calls in the monarch API. "
             "If it isn't called, we will implicitly call `monarch.enable_transport(ChannelTransport.Unix)` "

--- a/python/tests/test_host_mesh.py
+++ b/python/tests/test_host_mesh.py
@@ -399,6 +399,8 @@ def test_spawn_procs_with_numactl_bind() -> None:
 
 @pytest.mark.timeout(120)
 def test_spawn_procs_with_taskset_bind() -> None:
+    if not hasattr(os, "sched_getaffinity"):
+        pytest.skip("os.sched_getaffinity not available on this platform")
     available = sorted(os.sched_getaffinity(0))
     if len(available) < 2:
         # pyre-fixme[29]: skip is a function

--- a/python/tests/tools/config/test_defaults.py
+++ b/python/tests/tools/config/test_defaults.py
@@ -54,7 +54,11 @@ class TestDefaults(unittest.TestCase):
 
         for scheduler in defaults.scheduler_factories():
             with self.subTest(scheduler=scheduler):
-                component_fn = defaults.component_fn(scheduler)
+                try:
+                    component_fn = defaults.component_fn(scheduler)
+                except NotImplementedError:
+                    # No default component for this scheduler in OSS builds.
+                    continue
 
                 # the following will fail if the component_fn is not a valid torchx component
                 with self.assertRaises(SystemExit):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #3643

Fix several CI failures on main:

- **hyperactor_mesh Cargo.toml + BUCK**: add clap to dev-dependencies so the sieve and dining_philosophers examples compile under cargo. The BUCK example targets have autocargo ignore_rule=True so clap was never propagated to the generated Cargo.toml.

- **hyperactor/src/ref_.rs + reference.rs**: fix ProcRef::resource_name() and ProcId::resource_name() to return label-uid (dash, no brackets) matching ResourceId::to_string(). Previously they returned label<uid> (with angle brackets), so LocalProcDialer could never find the local IPC socket, causing test_proc_dialer and test_cast_and_accum_v1_native to hang indefinitely across all Rust test jobs.

- **actor_mesh.py**: make enable_transport() a no-op when the same transport is already active even after the monarch context has been initialized. Fixes test_host_mesh_from_store_* on macOS where a prior test in the same group already initialized the context with IPC.

- **test_host_mesh.py**: skip test_spawn_procs_with_taskset_bind on platforms that lack os.sched_getaffinity (macOS).

- **test_defaults.py**: skip schedulers in test_default_component when defaults.component_fn raises NotImplementedError (OSS build has no default component after the April 23 removal of components/hyperactor.py).

- **test_commands.py**: replace defaults.component_fn('slurm')() calls with a local _appdef() helper, since the OSS defaults no longer provide a slurm component function.

Differential Revision: [D102723116](https://our.internmc.facebook.com/intern/diff/D102723116/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D102723116/)!