### PR TITLE
Move test_default_component to meta-only test file

### DIFF
--- a/python/tests/tools/config/test_defaults.py
+++ b/python/tests/tools/config/test_defaults.py
@@ -12,7 +12,6 @@ from monarch.tools.config import (  # @manual=//monarch/python/monarch/tools/con
     NOT_SET,
 )
 from torchx.specs import AppDef
-from torchx.specs.builders import _create_args_parser
 
 
 class TestDefaults(unittest.TestCase):
@@ -47,15 +46,3 @@ class TestDefaults(unittest.TestCase):
         # just make sure the common schedulers are present
         self.assertIn("local_cwd", defaults.scheduler_factories())
         self.assertIn("slurm", defaults.scheduler_factories())
-
-    def test_default_component(self) -> None:
-        # just make sure there exists a default component for each configured scheduler
-        # and that the returned default component is a valid component
-
-        for scheduler in defaults.scheduler_factories():
-            with self.subTest(scheduler=scheduler):
-                component_fn = defaults.component_fn(scheduler)
-
-                # the following will fail if the component_fn is not a valid torchx component
-                with self.assertRaises(SystemExit):
-                    _create_args_parser(component_fn).parse_args(["--help"])


### PR DESCRIPTION
Summary:
After D102096298, OSS `defaults.component_fn` raises `NotImplementedError` for any scheduler. The existing `test_default_component` in `python/tests/tools/config/test_defaults.py` iterates over `defaults.scheduler_factories()` and expects a valid TorchX component for each, so it now fails in OSS for `local_cwd`, `local_docker`, `slurm`, and `k8s`.

In fbcode the test passes because the Buck `defaults_oss` library redirects to `meta/defaults.py`, whose `component_fn` returns `hyperactor.host_mesh` for any unmapped scheduler.

The behavior the test exercises (a default `component_fn` mapping for arbitrary schedulers) now exists only on the Meta side, so move the test to `python/tests/tools/config/meta/test_meta_defaults.py`. The OSS test runner already excludes that path via `--ignore-glob="**/meta/**"` in `scripts/common-setup.sh`.

No production code changes; the OSS `NotImplementedError` contract is intentional per D102096298.

Differential Revision: D102798911


