### PR TITLE
[monarch] Let rdmaxcel-sys build without a CUDA/ROCm toolchain

### DIFF
--- a/build_utils/src/lib.rs
+++ b/build_utils/src/lib.rs
@@ -424,7 +424,27 @@ pub fn setup_cpp_static_libs() -> CppStaticLibsConfig {
 /// Detection order:
 /// 1. `MONARCH_GPU_PLATFORM` environment variable ("cuda", "rocm", or "none")
 /// 2. Auto-detect: one of CUDA or ROCm must be present; panic if both or neither are found
+///
+/// Panics if `MONARCH_GPU_PLATFORM=none` is set. Use
+/// [`detect_gpu_platform_allow_none`] from crates that support a stub
+/// mode.
 pub fn detect_gpu_platform() -> (bool, String) {
+    match detect_gpu_platform_allow_none() {
+        Some((is_rocm, home)) => (is_rocm, home),
+        None => panic!(
+            "MONARCH_GPU_PLATFORM=none but a GPU build target was requested; \
+             rebuild without the tensor_engine_gpu feature"
+        ),
+    }
+}
+
+/// Like [`detect_gpu_platform`] but returns `None` when the caller has
+/// opted into a no-GPU "stub" build via `MONARCH_GPU_PLATFORM=none`.
+///
+/// When no explicit platform is set and neither CUDA nor ROCm is
+/// detected, this still panics — silent stub builds mask configuration
+/// bugs. Callers that want a stub build must opt in explicitly.
+pub fn detect_gpu_platform_allow_none() -> Option<(bool, String)> {
     if let Ok(platform) = env::var("MONARCH_GPU_PLATFORM") {
         match platform.to_lowercase().as_str() {
             "" => {}
@@ -432,18 +452,20 @@ pub fn detect_gpu_platform() -> (bool, String) {
                 let rocm_home = rocm::validate_rocm_installation()
                     .expect("MONARCH_GPU_PLATFORM=rocm but ROCm installation not found");
                 println!("cargo:warning=Using ROCm from {} (explicit)", rocm_home);
-                return (true, rocm_home);
+                return Some((true, rocm_home));
             }
             "cuda" => {
                 let cuda_home = validate_cuda_installation()
                     .expect("MONARCH_GPU_PLATFORM=cuda but CUDA installation not found");
                 println!("cargo:warning=Using CUDA from {} (explicit)", cuda_home);
-                return (false, cuda_home);
+                return Some((false, cuda_home));
             }
-            "none" => panic!(
-                "MONARCH_GPU_PLATFORM=none but a GPU build target was requested; \
-                 rebuild without the tensor_engine_gpu feature"
-            ),
+            "none" => {
+                println!(
+                    "cargo:warning=MONARCH_GPU_PLATFORM=none; building without GPU support"
+                );
+                return None;
+            }
             _ => panic!(
                 "Invalid MONARCH_GPU_PLATFORM value: {}. Must be 'cuda', 'rocm', or 'none'",
                 platform
@@ -459,18 +481,20 @@ pub fn detect_gpu_platform() -> (bool, String) {
         (true, false) => {
             let rocm_home = rocm_result.unwrap();
             println!("cargo:warning=Using ROCm from {}", rocm_home);
-            (true, rocm_home)
+            Some((true, rocm_home))
         }
         (false, true) => {
             let cuda_home = cuda_result.unwrap();
             println!("cargo:warning=Using CUDA from {}", cuda_home);
-            (false, cuda_home)
+            Some((false, cuda_home))
         }
         (true, true) => {
             panic!("Both ROCm and CUDA detected. Set MONARCH_GPU_PLATFORM=cuda, =rocm, or =none.");
         }
         (false, false) => {
-            panic!("Neither CUDA nor ROCm installation found");
+            panic!(
+                "Neither CUDA nor ROCm installation found. To build without a GPU backend, set MONARCH_GPU_PLATFORM=none."
+            );
         }
     }
 }

--- a/rdmaxcel-sys/build.rs
+++ b/rdmaxcel-sys/build.rs
@@ -24,8 +24,9 @@ fn main() {
     let cpp_static_libs_config = build_utils::CppStaticLibsConfig::from_env();
     let rdma_include = &cpp_static_libs_config.rdma_include_dir;
 
-    // Detect platform: ROCm or CUDA
-    let (is_rocm, compute_home) = build_utils::detect_gpu_platform();
+    // Detect platform: ROCm, CUDA, or stub (no GPU toolchain).
+    let platform = build_utils::detect_gpu_platform_allow_none();
+    let stub_mode = platform.is_none();
 
     // Get the directory of the current crate
     let manifest_dir = env::var("CARGO_MANIFEST_DIR").unwrap_or_else(|_| {
@@ -45,6 +46,20 @@ fn main() {
     let out_dir = env::var("OUT_DIR").expect("OUT_DIR not set");
     let out_path = PathBuf::from(&out_dir);
     let src_dir = PathBuf::from(&manifest_dir).join("src");
+
+    println!("cargo:rustc-check-cfg=cfg(rdmaxcel_stub)");
+    if stub_mode {
+        // Static rdma-core archives still need to be linked in stub mode:
+        // monarch_rdma's ibverbs code calls `ibv_*`/`mlx5dv_*`/`efadv_*`
+        // even on CPU-only builds, and those symbols live in the static
+        // libraries that `monarch_cpp_static_libs` built.
+        cpp_static_libs_config.emit_link_directives();
+        build_stub(&src_dir, &out_path, rdma_include);
+        return;
+    }
+
+    // SAFETY: not stub_mode implies Some(...)
+    let (is_rocm, compute_home) = platform.unwrap();
 
     // Determine source directory based on platform
     let source_dir = if is_rocm {
@@ -291,6 +306,130 @@ fn main() {
         &out_dir,
         is_rocm,
     );
+}
+
+/// Build `rdmaxcel-sys` in stub mode for hosts without a CUDA or ROCm
+/// toolchain.
+///
+/// The stub build compiles a single C++ TU that provides every
+/// `rdmaxcel_*` extern "C" symbol as a failing no-op (CUDA wrappers
+/// return `CUDA_ERROR_NOT_INITIALIZED`; QP/segment helpers return
+/// `RDMAXCEL_INVALID_PARAMS`). This keeps `monarch_rdma` linkable; the
+/// TCP backend still works end-to-end because it does not call any of
+/// the stubbed functions. `ibverbs_supported()` returns false on hosts
+/// without RDMA hardware, which is the usual case in a CPU-only build.
+#[cfg(not(target_os = "macos"))]
+fn build_stub(src_dir: &Path, out_path: &Path, rdma_include: &str) {
+    println!("cargo:rustc-cfg=rdmaxcel_stub");
+    println!("cargo:rerun-if-changed=src/rdmaxcel.h");
+    println!("cargo:rerun-if-changed=src/driver_api.h");
+    println!("cargo:rerun-if-changed=src/stub.cpp");
+    println!("cargo:rerun-if-changed=src/stubs/cuda.h");
+    println!("cargo:rerun-if-changed=src/stubs/cuda_runtime.h");
+
+    println!("cargo:rustc-link-lib=dl");
+
+    let stubs_dir = src_dir.join("stubs");
+
+    // Bindgen against the real rdmaxcel.h, but with our stub cuda headers
+    // ahead of any system includes so `#include <cuda.h>` resolves to the
+    // stub.
+    let builder = bindgen::Builder::default()
+        .header(src_dir.join("rdmaxcel.h").to_string_lossy())
+        .clang_arg("-x")
+        .clang_arg("c++")
+        .clang_arg("-std=c++14")
+        .clang_arg(format!("-I{}", stubs_dir.display()))
+        .clang_arg(format!("-I{}", rdma_include))
+        .parse_callbacks(Box::new(bindgen::CargoCallbacks::new()))
+        .allowlist_function("ibv_.*")
+        .allowlist_function("mlx5dv_.*")
+        .allowlist_function("mlx5_wqe_.*")
+        .allowlist_function("create_qp")
+        .allowlist_function("create_mlx5dv_.*")
+        .allowlist_function("register_cuda_memory")
+        .allowlist_function("db_ring")
+        .allowlist_function("cqe_poll")
+        .allowlist_function("send_wqe")
+        .allowlist_function("recv_wqe")
+        .allowlist_function("launch_db_ring")
+        .allowlist_function("launch_cqe_poll")
+        .allowlist_function("launch_send_wqe")
+        .allowlist_function("launch_recv_wqe")
+        .allowlist_function("rdma_get_active_segment_count")
+        .allowlist_function("rdma_get_all_registered_segment_info")
+        .allowlist_function("register_segments")
+        .allowlist_function("deregister_segments")
+        .allowlist_function("rdmaxcel_cu.*")
+        .allowlist_function("get_cuda_pci_address_from_ptr")
+        .allowlist_function("rdmaxcel_print_device_info")
+        .allowlist_function("rdmaxcel_error_string")
+        .allowlist_function("rdmaxcel_qp_.*")
+        .allowlist_function("rdmaxcel_register_segment_scanner")
+        .allowlist_function("poll_cq_with_cache")
+        .allowlist_function("completion_cache_.*")
+        .allowlist_function("rdmaxcel_efa_.*")
+        .allowlist_function("rdmaxcel_is_efa_dev")
+        .allowlist_function("efadv_.*")
+        .allowlist_type("ibv_.*")
+        .allowlist_type("mlx5dv_.*")
+        .allowlist_type("mlx5_wqe_.*")
+        .allowlist_type("cqe_poll_.*")
+        .allowlist_type("wqe_params_t")
+        .allowlist_type("rdma_segment_info_t")
+        .allowlist_type("rdmaxcel_scanned_segment_t")
+        .allowlist_type("rdmaxcel_qp_t")
+        .allowlist_type("rdmaxcel_qp")
+        .allowlist_type("completion_cache_t")
+        .allowlist_type("completion_cache")
+        .allowlist_type("poll_context_t")
+        .allowlist_type("poll_context")
+        .allowlist_type("rdmaxcel_segment_scanner_fn")
+        .allowlist_type("efadv_.*")
+        .allowlist_type("CUmemorytype.*")
+        .allowlist_var("MLX5_.*")
+        .allowlist_var("IBV_.*")
+        .allowlist_var("EFADV_.*")
+        .allowlist_var("CUDA_SUCCESS")
+        .allowlist_var("CU_.*")
+        .blocklist_type("ibv_wc")
+        .blocklist_type("mlx5_wqe_ctrl_seg")
+        .bitfield_enum("ibv_access_flags")
+        .bitfield_enum("ibv_qp_attr_mask")
+        .bitfield_enum("ibv_wc_flags")
+        .bitfield_enum("ibv_send_flags")
+        .bitfield_enum("ibv_port_cap_flags")
+        .constified_enum_module("ibv_qp_type")
+        .constified_enum_module("ibv_qp_state")
+        .constified_enum_module("ibv_port_state")
+        .constified_enum_module("ibv_wc_opcode")
+        .constified_enum_module("ibv_wr_opcode")
+        .constified_enum_module("ibv_wc_status")
+        .derive_default(true)
+        .prepend_enum_name(false);
+
+    builder
+        .generate()
+        .expect("Unable to generate bindings (stub mode)")
+        .write_to_file(out_path.join("bindings.rs"))
+        .expect("Couldn't write bindings (stub mode)");
+
+    println!("cargo:out_dir={}", out_path.display());
+    println!("cargo:rustc-cfg=cargo");
+    println!("cargo:rustc-check-cfg=cfg(cargo)");
+    println!("cargo:rustc-check-cfg=cfg(use_rocm)");
+
+    cc::Build::new()
+        .file(src_dir.join("stub.cpp"))
+        .include(src_dir)
+        .include(&stubs_dir)
+        .include(rdma_include)
+        .flag("-fPIC")
+        .cpp(true)
+        .flag("-std=c++14")
+        .compile("rdmaxcel_stub");
+
+    build_utils::link_libstdcpp_static();
 }
 
 /// Find the main header file (rdmaxcel.h or rdmaxcel_hip.h)

--- a/rdmaxcel-sys/src/stub.cpp
+++ b/rdmaxcel-sys/src/stub.cpp
@@ -1,0 +1,425 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// Stub implementations of the rdmaxcel C API used when building without
+// a CUDA/ROCm toolchain (`MONARCH_GPU_PLATFORM=none`).
+//
+// Every wrapper simply fails fast — `rdmaxcel_cu*` drivers return
+// `CUDA_ERROR_NOT_INITIALIZED`, `rdmaxcel_*` helpers return an rdmaxcel
+// error code, and scanner/registration functions are no-ops. Callers
+// in `monarch_rdma` already handle these failure modes (see commit
+// "Catch exceptions at the rdmaxcel extern \"C\" FFI boundary"), so
+// the TCP backend works end-to-end while the ibverbs/CUDA paths cleanly
+// report "not initialized."
+
+#include "driver_api.h"
+#include "rdmaxcel.h"
+
+#include <stddef.h>
+#include <stdint.h>
+
+namespace {
+
+constexpr int kRdmaxcelNotInitialized = RDMAXCEL_INVALID_PARAMS;
+
+} // namespace
+
+extern "C" {
+
+// ---- driver_api.h: CUDA driver wrappers --------------------------------
+
+CUresult rdmaxcel_cuMemGetHandleForAddressRange(
+    int*,
+    CUdeviceptr,
+    size_t,
+    CUmemRangeHandleType,
+    unsigned long long) {
+  return CUDA_ERROR_NOT_INITIALIZED;
+}
+
+CUresult rdmaxcel_cuMemGetAllocationGranularity(
+    size_t*,
+    const CUmemAllocationProp*,
+    CUmemAllocationGranularity_flags) {
+  return CUDA_ERROR_NOT_INITIALIZED;
+}
+
+CUresult rdmaxcel_cuMemCreate(
+    CUmemGenericAllocationHandle*,
+    size_t,
+    const CUmemAllocationProp*,
+    unsigned long long) {
+  return CUDA_ERROR_NOT_INITIALIZED;
+}
+
+CUresult rdmaxcel_cuMemAddressReserve(
+    CUdeviceptr*,
+    size_t,
+    size_t,
+    CUdeviceptr,
+    unsigned long long) {
+  return CUDA_ERROR_NOT_INITIALIZED;
+}
+
+CUresult rdmaxcel_cuMemMap(
+    CUdeviceptr,
+    size_t,
+    size_t,
+    CUmemGenericAllocationHandle,
+    unsigned long long) {
+  return CUDA_ERROR_NOT_INITIALIZED;
+}
+
+CUresult rdmaxcel_cuMemSetAccess(
+    CUdeviceptr,
+    size_t,
+    const CUmemAccessDesc*,
+    size_t) {
+  return CUDA_ERROR_NOT_INITIALIZED;
+}
+
+CUresult rdmaxcel_cuMemUnmap(CUdeviceptr, size_t) {
+  return CUDA_ERROR_NOT_INITIALIZED;
+}
+
+CUresult rdmaxcel_cuMemAddressFree(CUdeviceptr, size_t) {
+  return CUDA_ERROR_NOT_INITIALIZED;
+}
+
+CUresult rdmaxcel_cuMemRelease(CUmemGenericAllocationHandle) {
+  return CUDA_ERROR_NOT_INITIALIZED;
+}
+
+CUresult rdmaxcel_cuMemcpyHtoD_v2(CUdeviceptr, const void*, size_t) {
+  return CUDA_ERROR_NOT_INITIALIZED;
+}
+
+CUresult rdmaxcel_cuMemcpyDtoH_v2(void*, CUdeviceptr, size_t) {
+  return CUDA_ERROR_NOT_INITIALIZED;
+}
+
+CUresult rdmaxcel_cuMemsetD8_v2(CUdeviceptr, unsigned char, size_t) {
+  return CUDA_ERROR_NOT_INITIALIZED;
+}
+
+CUresult
+rdmaxcel_cuPointerGetAttribute(void*, CUpointer_attribute, CUdeviceptr) {
+  return CUDA_ERROR_NOT_INITIALIZED;
+}
+
+CUresult rdmaxcel_cuInit(unsigned int) {
+  return CUDA_ERROR_NOT_INITIALIZED;
+}
+
+CUresult rdmaxcel_cuDeviceGet(CUdevice*, int) {
+  return CUDA_ERROR_NOT_INITIALIZED;
+}
+
+CUresult rdmaxcel_cuDeviceGetCount(int* count) {
+  if (count != nullptr) {
+    *count = 0;
+  }
+  return CUDA_SUCCESS;
+}
+
+CUresult rdmaxcel_cuDeviceGetAttribute(int*, CUdevice_attribute, CUdevice) {
+  return CUDA_ERROR_NOT_INITIALIZED;
+}
+
+CUresult rdmaxcel_cuCtxCreate_v2(CUcontext*, unsigned int, CUdevice) {
+  return CUDA_ERROR_NOT_INITIALIZED;
+}
+
+CUresult rdmaxcel_cuDevicePrimaryCtxRetain(CUcontext*, CUdevice) {
+  return CUDA_ERROR_NOT_INITIALIZED;
+}
+
+CUresult rdmaxcel_cuDevicePrimaryCtxRelease(CUdevice) {
+  return CUDA_ERROR_NOT_INITIALIZED;
+}
+
+CUresult rdmaxcel_cuCtxGetCurrent(CUcontext* pctx) {
+  if (pctx != nullptr) {
+    *pctx = nullptr;
+  }
+  return CUDA_SUCCESS;
+}
+
+CUresult rdmaxcel_cuCtxSetCurrent(CUcontext) {
+  return CUDA_ERROR_NOT_INITIALIZED;
+}
+
+CUresult rdmaxcel_cuCtxSynchronize(void) {
+  return CUDA_ERROR_NOT_INITIALIZED;
+}
+
+CUresult rdmaxcel_cuGetErrorString(CUresult, const char** pStr) {
+  if (pStr != nullptr) {
+    *pStr = "[rdmaxcel stub] CUDA not available in this build";
+  }
+  return CUDA_SUCCESS;
+}
+
+// ---- rdmaxcel.h: helper functions --------------------------------------
+
+void rdmaxcel_print_device_info(struct ibv_context*) {}
+
+const char* rdmaxcel_error_string(int) {
+  return "[rdmaxcel stub] build without GPU support";
+}
+
+int rdma_get_active_segment_count(struct ibv_pd*) {
+  return 0;
+}
+
+int rdma_get_all_registered_segment_info(
+    struct ibv_pd*,
+    rdma_segment_info_t*,
+    int) {
+  return 0;
+}
+
+int deregister_segments() {
+  return RDMAXCEL_SUCCESS;
+}
+
+void rdmaxcel_register_segment_scanner(rdmaxcel_segment_scanner_fn) {}
+
+int get_cuda_pci_address_from_ptr(CUdeviceptr, char*, size_t) {
+  return kRdmaxcelNotInitialized;
+}
+
+cudaError_t register_host_mem(void**, size_t) {
+  return cudaErrorNotInitialized;
+}
+
+// ---- QP lifecycle (never called at runtime in TCP-only builds) ---------
+
+rdmaxcel_qp_t* rdmaxcel_qp_create(
+    struct ibv_context*,
+    struct ibv_pd*,
+    int,
+    int,
+    int,
+    int,
+    int,
+    rdma_qp_type_t) {
+  return nullptr;
+}
+
+void rdmaxcel_qp_destroy(rdmaxcel_qp_t*) {}
+
+struct ibv_qp* rdmaxcel_qp_get_ibv_qp(rdmaxcel_qp_t*) {
+  return nullptr;
+}
+
+uint64_t rdmaxcel_qp_fetch_add_send_wqe_idx(rdmaxcel_qp_t*) {
+  return 0;
+}
+uint64_t rdmaxcel_qp_fetch_add_send_db_idx(rdmaxcel_qp_t*) {
+  return 0;
+}
+uint64_t rdmaxcel_qp_fetch_add_send_cq_idx(rdmaxcel_qp_t*) {
+  return 0;
+}
+uint64_t rdmaxcel_qp_fetch_add_recv_wqe_idx(rdmaxcel_qp_t*) {
+  return 0;
+}
+uint64_t rdmaxcel_qp_fetch_add_recv_db_idx(rdmaxcel_qp_t*) {
+  return 0;
+}
+uint64_t rdmaxcel_qp_fetch_add_recv_cq_idx(rdmaxcel_qp_t*) {
+  return 0;
+}
+
+uint64_t rdmaxcel_qp_load_send_wqe_idx(rdmaxcel_qp_t*) {
+  return 0;
+}
+uint64_t rdmaxcel_qp_load_send_db_idx(rdmaxcel_qp_t*) {
+  return 0;
+}
+uint64_t rdmaxcel_qp_load_recv_wqe_idx(rdmaxcel_qp_t*) {
+  return 0;
+}
+uint64_t rdmaxcel_qp_load_send_cq_idx(rdmaxcel_qp_t*) {
+  return 0;
+}
+uint64_t rdmaxcel_qp_load_recv_cq_idx(rdmaxcel_qp_t*) {
+  return 0;
+}
+uint64_t rdmaxcel_qp_load_rts_timestamp(rdmaxcel_qp_t*) {
+  return 0;
+}
+
+void rdmaxcel_qp_store_send_db_idx(rdmaxcel_qp_t*, uint64_t) {}
+void rdmaxcel_qp_store_rts_timestamp(rdmaxcel_qp_t*, uint64_t) {}
+
+completion_cache_t* rdmaxcel_qp_get_send_cache(rdmaxcel_qp_t*) {
+  return nullptr;
+}
+completion_cache_t* rdmaxcel_qp_get_recv_cache(rdmaxcel_qp_t*) {
+  return nullptr;
+}
+
+int register_segments(struct ibv_pd**, rdmaxcel_qp_t**, int) {
+  return kRdmaxcelNotInitialized;
+}
+
+void completion_cache_init(completion_cache_t*) {}
+void completion_cache_destroy(completion_cache_t*) {}
+int completion_cache_add(completion_cache_t*, struct ibv_wc*) {
+  return 0;
+}
+int completion_cache_find(
+    completion_cache_t*,
+    uint64_t,
+    uint32_t,
+    struct ibv_wc*) {
+  return 0;
+}
+
+int poll_cq_with_cache(poll_context_t*, struct ibv_wc*) {
+  return -1;
+}
+
+// ---- ibverbs/mlx5dv creation (stubbed for TCP-only builds) -------------
+
+struct ibv_qp* create_qp(
+    struct ibv_context*,
+    struct ibv_pd*,
+    int,
+    int,
+    int,
+    int,
+    int,
+    rdma_qp_type_t) {
+  return nullptr;
+}
+
+struct mlx5dv_qp* create_mlx5dv_qp(struct ibv_qp*) {
+  return nullptr;
+}
+struct mlx5dv_cq* create_mlx5dv_cq(struct ibv_qp*) {
+  return nullptr;
+}
+struct mlx5dv_cq* create_mlx5dv_send_cq(struct ibv_qp*) {
+  return nullptr;
+}
+struct mlx5dv_cq* create_mlx5dv_recv_cq(struct ibv_qp*) {
+  return nullptr;
+}
+
+cudaError_t register_cuda_memory(
+    struct mlx5dv_qp*,
+    struct mlx5dv_cq*,
+    struct mlx5dv_cq*) {
+  return cudaErrorNotInitialized;
+}
+
+// ---- Launch helpers (normally in .cu) ----------------------------------
+
+void launch_db_ring(void*, void*) {}
+cqe_poll_result_t launch_cqe_poll(void*, int32_t) {
+  return CQE_POLL_ERROR;
+}
+cqe_poll_result_t launch_send_cqe_poll(void*, int32_t) {
+  return CQE_POLL_ERROR;
+}
+cqe_poll_result_t launch_recv_cqe_poll(void*, int32_t) {
+  return CQE_POLL_ERROR;
+}
+void launch_send_wqe(wqe_params_t) {}
+void launch_recv_wqe(wqe_params_t) {}
+
+// ---- EFA ---------------------------------------------------------------
+
+int rdmaxcel_qp_post_op(
+    rdmaxcel_qp_t*,
+    void*,
+    uint32_t,
+    size_t,
+    void*,
+    uint32_t,
+    uint64_t,
+    int,
+    int) {
+  return kRdmaxcelNotInitialized;
+}
+
+int rdmaxcel_is_efa_dev(struct ibv_context*) {
+  return 0;
+}
+
+struct ibv_qp* create_efa_qp(
+    struct ibv_context*,
+    struct ibv_pd*,
+    struct ibv_cq*,
+    struct ibv_cq*,
+    int,
+    int,
+    int,
+    int) {
+  return nullptr;
+}
+
+int rdmaxcel_efa_post_write(
+    rdmaxcel_qp_t*,
+    struct ibv_ah*,
+    uint32_t,
+    uint32_t,
+    void*,
+    uint32_t,
+    size_t,
+    void*,
+    uint32_t,
+    uint64_t) {
+  return kRdmaxcelNotInitialized;
+}
+
+int rdmaxcel_efa_post_read(
+    rdmaxcel_qp_t*,
+    struct ibv_ah*,
+    uint32_t,
+    uint32_t,
+    void*,
+    uint32_t,
+    size_t,
+    void*,
+    uint32_t,
+    uint64_t) {
+  return kRdmaxcelNotInitialized;
+}
+
+int rdmaxcel_efa_connect(
+    rdmaxcel_qp_t*,
+    uint8_t,
+    uint16_t,
+    uint32_t,
+    uint32_t,
+    uint8_t,
+    const uint8_t*,
+    uint32_t) {
+  return kRdmaxcelNotInitialized;
+}
+
+int rdmaxcel_efa_post_op(
+    rdmaxcel_qp_t*,
+    struct ibv_ah*,
+    uint32_t,
+    uint32_t,
+    void*,
+    uint32_t,
+    size_t,
+    void*,
+    uint32_t,
+    uint64_t,
+    int) {
+  return kRdmaxcelNotInitialized;
+}
+
+} // extern "C"

--- a/rdmaxcel-sys/src/stubs/cuda.h
+++ b/rdmaxcel-sys/src/stubs/cuda.h
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// Stub replacement for <cuda.h> used in no-GPU builds.
+//
+// This header is picked up by bindgen and the stub compilation unit in
+// place of the real CUDA driver header when MONARCH_GPU_PLATFORM=none.
+// It declares only the handful of types and constants that are named
+// in `rdmaxcel.h`, `driver_api.h`, and the Rust code in `monarch_rdma`.
+//
+// The actual driver functions (cuInit, cuMemAlloc, ...) are NOT
+// declared here; callers go through `rdmaxcel_cu*` wrappers whose
+// stub implementations return CUDA_ERROR_NOT_INITIALIZED.
+
+#ifndef RDMAXCEL_STUB_CUDA_H
+#define RDMAXCEL_STUB_CUDA_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+// CUDA function-space keywords. `cuda_runtime.h` normally defines these;
+// repeat them here so headers that include only `<cuda.h>` still parse.
+#ifndef __host__
+#define __host__
+#endif
+#ifndef __device__
+#define __device__
+#endif
+#ifndef __global__
+#define __global__
+#endif
+#ifndef __forceinline__
+#define __forceinline__ inline
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef enum cudaError_enum {
+  CUDA_SUCCESS = 0,
+  CUDA_ERROR_INVALID_VALUE = 1,
+  CUDA_ERROR_NOT_INITIALIZED = 3,
+  CUDA_ERROR_DEINITIALIZED = 4,
+  CUDA_ERROR_NO_DEVICE = 100,
+  CUDA_ERROR_INVALID_DEVICE = 101,
+  CUDA_ERROR_UNKNOWN = 999,
+} CUresult;
+
+typedef int CUdevice;
+typedef unsigned long long CUdeviceptr;
+typedef struct CUctx_st* CUcontext;
+typedef unsigned long long CUmemGenericAllocationHandle;
+
+typedef enum CUpointer_attribute_enum {
+  CU_POINTER_ATTRIBUTE_CONTEXT = 1,
+  CU_POINTER_ATTRIBUTE_MEMORY_TYPE = 2,
+  CU_POINTER_ATTRIBUTE_DEVICE_ORDINAL = 9,
+} CUpointer_attribute;
+
+typedef enum CUmemorytype_enum {
+  CU_MEMORYTYPE_HOST = 0x01,
+  CU_MEMORYTYPE_DEVICE = 0x02,
+  CU_MEMORYTYPE_ARRAY = 0x03,
+  CU_MEMORYTYPE_UNIFIED = 0x04,
+} CUmemorytype;
+
+typedef enum CUdevice_attribute_enum {
+  CU_DEVICE_ATTRIBUTE_UNUSED = 0,
+} CUdevice_attribute;
+
+typedef enum CUmemAllocationType_enum {
+  CU_MEM_ALLOCATION_TYPE_INVALID = 0,
+  CU_MEM_ALLOCATION_TYPE_PINNED = 1,
+} CUmemAllocationType;
+
+typedef enum CUmemLocationType_enum {
+  CU_MEM_LOCATION_TYPE_INVALID = 0,
+  CU_MEM_LOCATION_TYPE_DEVICE = 1,
+} CUmemLocationType;
+
+typedef enum CUmemAllocationHandleType_enum {
+  CU_MEM_HANDLE_TYPE_NONE = 0,
+  CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR = 1,
+} CUmemAllocationHandleType;
+
+typedef enum CUmemAccess_flags_enum {
+  CU_MEM_ACCESS_FLAGS_PROT_NONE = 0,
+  CU_MEM_ACCESS_FLAGS_PROT_READ = 1,
+  CU_MEM_ACCESS_FLAGS_PROT_READWRITE = 3,
+} CUmemAccess_flags;
+
+typedef enum CUmemAllocationGranularity_flags_enum {
+  CU_MEM_ALLOC_GRANULARITY_MINIMUM = 0,
+  CU_MEM_ALLOC_GRANULARITY_RECOMMENDED = 1,
+} CUmemAllocationGranularity_flags;
+
+typedef enum CUmemRangeHandleType_enum {
+  CU_MEM_RANGE_HANDLE_TYPE_DMA_BUF_FD = 1,
+} CUmemRangeHandleType;
+
+typedef struct CUmemLocation_st {
+  CUmemLocationType type;
+  int id;
+} CUmemLocation;
+
+typedef struct CUmemAllocationProp_st {
+  CUmemAllocationType type;
+  CUmemAllocationHandleType requestedHandleTypes;
+  CUmemLocation location;
+  void* win32HandleMetaData;
+  struct {
+    unsigned char compressionType;
+    unsigned char gpuDirectRDMACapable;
+    unsigned short usage;
+    unsigned char reserved[4];
+  } allocFlags;
+} CUmemAllocationProp;
+
+typedef struct CUmemAccessDesc_st {
+  CUmemLocation location;
+  CUmemAccess_flags flags;
+} CUmemAccessDesc;
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
+#endif // RDMAXCEL_STUB_CUDA_H

--- a/rdmaxcel-sys/src/stubs/cuda_runtime.h
+++ b/rdmaxcel-sys/src/stubs/cuda_runtime.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// Stub replacement for <cuda_runtime.h> used in no-GPU builds. Declares
+// only the handful of CUDA runtime types that are named in `rdmaxcel.h`
+// and stubs out the CUDA function-space keywords so that headers
+// sprinkled with `__host__`/`__device__`/`__global__` still parse.
+
+#ifndef RDMAXCEL_STUB_CUDA_RUNTIME_H
+#define RDMAXCEL_STUB_CUDA_RUNTIME_H
+
+#include <stddef.h>
+
+#ifndef __host__
+#define __host__
+#endif
+#ifndef __device__
+#define __device__
+#endif
+#ifndef __global__
+#define __global__
+#endif
+#ifndef __forceinline__
+#define __forceinline__ inline
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef int cudaError_t;
+
+#define cudaSuccess ((cudaError_t)0)
+#define cudaErrorNotInitialized ((cudaError_t)3)
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
+#endif // RDMAXCEL_STUB_CUDA_RUNTIME_H

--- a/setup.py
+++ b/setup.py
@@ -181,7 +181,7 @@ if build_tensor_engine:
         elif build_rocm:
             print(f"  - ROCm: {rocm_home}")
     else:
-        print("✓ Building WITH tensor_engine (CPU-only, no GPU/NCCL/RDMA)")
+        print("✓ Building WITH tensor_engine (CPU-only, no GPU/NCCL; RDMA via TCP fallback)")
         print(f"  - PyTorch: {torch_config['lib_path']}")
     print(f"  - C++11 ABI: {'enabled' if torch_config['cxx11_abi'] else 'disabled'}")
 else:
@@ -217,6 +217,12 @@ if build_cuda:
     env_vars["CUDA_HOME"] = cuda_home
 elif build_rocm:
     env_vars["ROCM_PATH"] = rocm_home
+else:
+    # CPU-only tensor_engine build (or actors-only): tell rdmaxcel-sys
+    # to compile its stub implementation instead of linking against a
+    # non-existent CUDA/ROCm toolchain. This keeps the RDMA TCP
+    # fallback available when there is no GPU.
+    env_vars["MONARCH_GPU_PLATFORM"] = "none"
 
 os.environ.update(env_vars)
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #3653
* #3652
* #3651
* __->__ #3650
* #3649
* #3648

Building `monarch_rdma` previously required a working CUDA or ROCm SDK because `rdmaxcel-sys/build.rs` panics in `detect_gpu_platform()` when neither is present, and its C/C++/CUDA sources directly use CUDA driver and runtime headers. That meant OSS CPU-only `tensor_engine` builds could not ship the RDMA extension at all — `get_rdma_backend()` returned `"none"` and TCP fallback was unreachable on any host without CUDA headers installed.

Add a stub build mode. When `MONARCH_GPU_PLATFORM=none` is set, `rdmaxcel-sys/build.rs` skips the real `rdmaxcel.{c,cpp,cu}` and `driver_api.cpp` sources and compiles a single `src/stub.cpp` that provides every `rdmaxcel_*` extern "C" symbol as a failing no-op: CUDA wrappers return `CUDA_ERROR_NOT_INITIALIZED`, segment scanners and QP helpers return `RDMAXCEL_INVALID_PARAMS`, and the `deregister_segments`/`completion_cache_*` APIs return success on empty state. Bindgen still runs, but parses `rdmaxcel.h` against two minimal `src/stubs/{cuda.h,cuda_runtime.h}` headers that declare only the CUDA types and constants consumed by `monarch_rdma`. Rust code stays identical — every call site already handles `CUDA_ERROR_NOT_INITIALIZED` and an empty device list thanks to the earlier FFI-boundary fix.

At runtime this means `ibverbs_supported()` returns false (no ibv devices without the driver), `rdma_supported()` returns true via the `RDMA_ALLOW_TCP_FALLBACK` default, and `get_rdma_backend()` returns `"tcp"`. The TCP backend works end-to-end because it touches none of the stubbed symbols.

`setup.py` now exports `MONARCH_GPU_PLATFORM=none` whenever `build_tensor_engine=true` and no GPU is detected, so OSS CPU-only wheels pick up the stub automatically. `build_utils::detect_gpu_platform_allow_none()` is the new stub-aware entry point; the existing `detect_gpu_platform()` still panics on `none` for callers like `nccl-sys` that genuinely require a GPU toolchain.

A follow-up diff moves `monarch_rdma_extension` from the `tensor_engine_gpu` feature into `tensor_engine` so CPU-only wheels actually link it in.

Differential Revision: [D102407433](https://our.internmc.facebook.com/intern/diff/D102407433/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D102407433/)!