### PR TITLE
[monarch] Force TCP-only at runtime when rdmaxcel-sys is a stub build

### DIFF
--- a/monarch_rdma/src/backend/ibverbs/primitives.rs
+++ b/monarch_rdma/src/backend/ibverbs/primitives.rs
@@ -727,6 +727,14 @@ pub fn ibverbs_supported() -> bool {
 }
 
 fn ibverbs_supported_impl() -> bool {
+    // When rdmaxcel-sys was compiled in stub mode, CUDA driver calls and
+    // the `register_cuda_memory` helper return `NOT_INITIALIZED`, so
+    // ibverbs queue-pair initialization would fail even when hardware
+    // devices are present. Report ibverbs as unavailable so the manager
+    // actor cleanly falls through to the TCP backend.
+    if rdmaxcel_sys::IS_STUB_BUILD {
+        return false;
+    }
     // SAFETY: We are calling a C function from libibverbs.
     unsafe {
         let mut num_devices = 0;

--- a/rdmaxcel-sys/src/lib.rs
+++ b/rdmaxcel-sys/src/lib.rs
@@ -290,6 +290,14 @@ mod inner {
 
 pub use inner::*;
 
+/// `true` when this crate was compiled in stub mode (no CUDA/ROCm
+/// toolchain available). In stub mode every `rdmaxcel_cu*` wrapper
+/// returns `CUDA_ERROR_NOT_INITIALIZED`, and the ibverbs backend
+/// cannot actually drive hardware because `register_cuda_memory` is a
+/// no-op. Downstream crates should consult this flag to disable the
+/// ibverbs code path at runtime and fall through to the TCP transport.
+pub const IS_STUB_BUILD: bool = cfg!(rdmaxcel_stub);
+
 // Segment scanner callback type - type alias for the bindgen-generated type
 pub type RdmaxcelSegmentScannerFn = rdmaxcel_segment_scanner_fn;
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #3653
* __->__ #3652
* #3651
* #3650
* #3649
* #3648

In stub builds (`MONARCH_GPU_PLATFORM=none`), the rdma-core static archives are still linked into the final `.so` — `monarch_rdma`'s ibverbs code references `ibv_*`/`mlx5dv_*` symbols and cannot be torn out without feature-gating the whole backend. The unintended consequence: on a host that happens to have RDMA hardware, `ibv_get_device_list()` still returns real devices, `ibverbs_supported()` returns true, and `get_rdma_backend()` reports `"ibverbs"` even though the backend cannot actually work — its `IbvQueuePair::new` path calls the stubbed `register_cuda_memory` which returns `cudaErrorNotInitialized`. The manager actor would then log a confusing init error and fall through to TCP via `RDMA_ALLOW_TCP_FALLBACK`.

The user's expectation — and the simplest contract — is that a stub build guarantees TCP. Export a compile-time constant `rdmaxcel_sys::IS_STUB_BUILD` whose value is `cfg!(rdmaxcel_stub)` (set by the build script in stub mode), and short-circuit `ibverbs_supported()` on it so the manager actor skips ibverbs entirely. `get_rdma_backend()` now returns `"tcp"` unconditionally on stub wheels.

Buck builds are unaffected: they use `rust_bindgen_library` rather than the `build.rs`, never set `rdmaxcel_stub`, so `IS_STUB_BUILD` is `false` and the existing `ibv_get_device_list` path runs.

Differential Revision: [D102815338](https://our.internmc.facebook.com/intern/diff/D102815338/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D102815338/)!