### PR TITLE
reduce flakiness in mesh_admin_integration_test pyspy worker discovery

### DIFF
--- a/hyperactor_mesh/test/mesh_admin_integration/pyspy.rs
+++ b/hyperactor_mesh/test/mesh_admin_integration/pyspy.rs
@@ -188,8 +188,17 @@ impl Drop for ShutdownGuard<'_> {
 /// Discover workload procs that contain actors matching
 /// `pyspy_worker`. Retries until count ≥ `expected`. MIT-8
 /// (pyspy-worker-discovery).
+///
+/// The retry budget must absorb concurrent workload startup: when this
+/// integration test runs in parallel with other scenarios, multiple
+/// workloads spawn dozens of procs at once and pyspy_worker actor
+/// registration can lag well past a minute under that contention.
 async fn discover_pyspy_workers(fixture: &WorkloadFixture, expected: usize) -> Result<Vec<String>> {
-    for _attempt in 1..=60 {
+    const MAX_ATTEMPTS: usize = 180;
+    let mut last_seen_procs: usize = 0;
+    let mut last_seen_pyspy: usize = 0;
+
+    for _attempt in 1..=MAX_ATTEMPTS {
         let root: NodePayload = match fixture.get_node_payload("/v1/root").await {
             Ok(r) => r,
             Err(_) => {
@@ -198,6 +207,7 @@ async fn discover_pyspy_workers(fixture: &WorkloadFixture, expected: usize) -> R
             }
         };
         let mut procs = Vec::new();
+        let mut total_procs_seen = 0usize;
 
         for host_ref in &root.children {
             let host_str = host_ref.to_string();
@@ -209,6 +219,7 @@ async fn discover_pyspy_workers(fixture: &WorkloadFixture, expected: usize) -> R
             };
 
             for proc_ref in &host.children {
+                total_procs_seen += 1;
                 let proc_str = proc_ref.to_string();
                 let encoded = urlencoding::encode(&proc_str);
                 let proc_node: NodePayload =
@@ -233,10 +244,14 @@ async fn discover_pyspy_workers(fixture: &WorkloadFixture, expected: usize) -> R
         if procs.len() >= expected {
             return Ok(procs);
         }
+        last_seen_procs = total_procs_seen;
+        last_seen_pyspy = procs.len();
         tokio::time::sleep(Duration::from_secs(1)).await;
     }
 
-    bail!("MIT-8: pyspy worker procs not found after 60 attempts (expected {expected})");
+    bail!(
+        "MIT-8: pyspy worker procs not found after {MAX_ATTEMPTS} attempts (expected {expected}, last saw {last_seen_pyspy} pyspy procs out of {last_seen_procs} total procs)"
+    );
 }
 
 // Mode-specific evidence (ported from verify_pyspy.py)


### PR DESCRIPTION
Summary:
The pyspy integration tests in `mesh_admin_integration_test` were flaking on the first run with `MIT-8: pyspy worker procs not found after 60 attempts`. The 60-attempt (~60s) budget in `discover_pyspy_workers` was insufficient when many `#[tokio::test]` cases run in parallel — each test spawns a Python workload that itself launches multiple sub-procs, so concurrent startups regularly delay `pyspy_worker` actor registration past the original budget.

Two changes:

- Bump the retry budget from 60 to 180 attempts. Inner loop is unchanged (~1s sleep + a few HTTP calls per attempt), so successful runs still return promptly; only failure cases wait longer.
- On exhaustion, include the last observed counts (pyspy procs vs. total procs) in the panic message. Distinguishing "0 procs out of 0 total" (workload tree never appeared) from "0 pyspy procs out of N total" (procs spawned but actor never registered) makes future flake reports actionable instead of opaque.

I also experimented with capping `RUST_TEST_THREADS` in the BUCK rule to reduce contention, but the data did not support it: dropping from default to 4 or 2 threads moved the flake rate only marginally, and the residual failures showed the same workload-side actor-registration race that the retry budget already absorbs. Left out to keep wall-clock fast.

Differential Revision: D102733344


