### PR TITLE
Fix CI failures: clap dev-dep, enable_transport idempotency, resource_name format, macOS test skips

### DIFF
--- a/hyperactor/src/ref_.rs
+++ b/hyperactor/src/ref_.rs
@@ -164,13 +164,22 @@ impl ProcRef {
         self.label().map(|l| l.as_str()).unwrap_or("?")
     }
 
-    /// The ResourceId text form: `label` (singleton), `label<uid58>`
-    /// (labeled instance), or `<uid58>` (unlabeled instance).
+    /// The ResourceId text form: `label` (singleton), `label-uid58`
+    /// (labeled instance), or `<uid58>` (unlabeled instance). Labeled
+    /// instances match the `Display` output of `mesh_id::ResourceId` and
+    /// are suitable for use as filesystem path components. All forms
+    /// round-trip through `parse_resource_name`.
     pub fn resource_name(&self) -> String {
+        fn uid_no_brackets(uid: &Uid) -> String {
+            uid.to_string()
+                .trim_start_matches('<')
+                .trim_end_matches('>')
+                .to_string()
+        }
         match (self.id.uid(), self.id.label()) {
             (Uid::Singleton(label), _) => label.to_string(),
-            (Uid::Instance(_), Some(label)) => format!("{label}{}", self.id.uid()),
-            (Uid::Instance(_), None) => self.id.uid().to_string(),
+            (uid @ Uid::Instance(_), Some(label)) => format!("{label}-{}", uid_no_brackets(uid)),
+            (uid @ Uid::Instance(_), None) => uid.to_string(),
         }
     }
 }

--- a/hyperactor/src/reference.rs
+++ b/hyperactor/src/reference.rs
@@ -438,16 +438,22 @@ impl ProcId {
 
     /// The ResourceId text form of this proc's identity.
     ///
-    /// Produces `label` (singleton), `label<uid58>` (labeled instance),
-    /// or `<uid58>` (unlabeled instance). Suitable for filesystem paths
-    /// and string-based lookups that must round-trip through
-    /// `parse_resource_name`.
+    /// Produces `label` (singleton), `label-uid58` (labeled instance),
+    /// or `<uid58>` (unlabeled instance). Labeled instances match the
+    /// `Display` output of `mesh_id::ResourceId` and are suitable for
+    /// filesystem paths. All forms round-trip through `parse_resource_name`.
     pub fn resource_name(&self) -> String {
         let id = self.0.id();
+        fn uid_no_brackets(uid: &Uid) -> String {
+            uid.to_string()
+                .trim_start_matches('<')
+                .trim_end_matches('>')
+                .to_string()
+        }
         match (id.uid(), id.label()) {
             (Uid::Singleton(label), _) => label.to_string(),
-            (Uid::Instance(_), Some(label)) => format!("{label}{}", id.uid()),
-            (Uid::Instance(_), None) => id.uid().to_string(),
+            (uid @ Uid::Instance(_), Some(label)) => format!("{label}-{}", uid_no_brackets(uid)),
+            (uid @ Uid::Instance(_), None) => uid.to_string(),
         }
     }
 }

--- a/python/monarch/_src/actor/actor_mesh.py
+++ b/python/monarch/_src/actor/actor_mesh.py
@@ -560,14 +560,19 @@ def enable_transport(transport: "ChannelTransport | str") -> None:
         # ChannelTransport enum
         transport_config = BindSpec(transport)
 
+    global _transport
+
     if _context.get() is not None:
+        # Context already initialized. It is only an error to enable a *different* transport;
+        # re-enabling the same transport is a no-op.
+        with _transport_lock:
+            if _transport == transport_config:
+                return
         raise RuntimeError(
             "`enable_transport()` must be called before any other calls in the monarch API. "
             "If it isn't called, we will implicitly call `monarch.enable_transport(ChannelTransport.Unix)` "
             "on the first monarch call."
         )
-
-    global _transport
     with _transport_lock:
         if _transport is not None and _transport != transport_config:
             raise RuntimeError(

--- a/python/tests/test_host_mesh.py
+++ b/python/tests/test_host_mesh.py
@@ -399,6 +399,9 @@ def test_spawn_procs_with_numactl_bind() -> None:
 
 @pytest.mark.timeout(120)
 def test_spawn_procs_with_taskset_bind() -> None:
+    if not hasattr(os, "sched_getaffinity"):
+        # pyre-fixme[29]: skip is a function
+        pytest.skip("os.sched_getaffinity not available on this platform")
     available = sorted(os.sched_getaffinity(0))
     if len(available) < 2:
         # pyre-fixme[29]: skip is a function


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #3655

Fix several CI failures on main:

- **hyperactor_mesh Cargo.toml + BUCK**: add clap to dev-dependencies so the sieve and dining_philosophers examples compile under cargo. The BUCK example targets have autocargo ignore_rule=True so clap was never propagated to the generated Cargo.toml.

- **hyperactor/src/ref_.rs + reference.rs**: fix ProcRef::resource_name() and ProcId::resource_name() to return label-uid (dash, no brackets) matching ResourceId::to_string(). Previously they returned label<uid> (with angle brackets), so LocalProcDialer could never find the local IPC socket, causing test_proc_dialer to hang indefinitely across all Rust test jobs.

- **actor_mesh.py**: make enable_transport() a no-op when the same transport is already active even after the monarch context has been initialized. Fixes test_host_mesh_from_store_* on macOS where a prior test in the same group already initialized the context with IPC.

- **test_host_mesh.py**: skip test_spawn_procs_with_taskset_bind on platforms that lack os.sched_getaffinity (macOS).

Differential Revision: [D102723116](https://our.internmc.facebook.com/intern/diff/D102723116/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D102723116/)!