### PR TITLE
Surface attach/simplex distinction at the link layer (#3660)

### DIFF
--- a/hyperactor/src/channel.rs
+++ b/hyperactor/src/channel.rs
@@ -30,6 +30,7 @@ use tokio::sync::mpsc;
 use tokio::sync::oneshot;
 use tokio::sync::watch;
 use tokio::time::Instant;
+use tokio_util::sync::CancellationToken;
 
 use crate as hyperactor;
 use crate::RemoteMessage;
@@ -462,8 +463,33 @@ impl ChannelTransport {
         }
     }
 
+    /// Returns true if this transport is served by the `net` module
+    /// (i.e., a kernel-level socket: TCP, Unix, or a TLS variant
+    /// thereof). The only non-net transport is the in-process
+    /// [`Local`](ChannelTransport::Local) channel.
+    pub fn is_net(&self) -> bool {
+        match self {
+            ChannelTransport::Tcp(_) => true,
+            ChannelTransport::MetaTls(_) => true,
+            ChannelTransport::Tls => true,
+            ChannelTransport::Quic => false,
+            ChannelTransport::MetaQuic(_) => false,
+            ChannelTransport::Unix => true,
+            ChannelTransport::Local => false,
+        }
+    }
+
+    /// Returns true if this transport uses TLS encryption.
+    pub fn is_tls(&self) -> bool {
+        matches!(self, ChannelTransport::Tls | ChannelTransport::MetaTls(_))
+    }
+
     /// Returns true if this transport can carry the duplex byte-stream
-    /// protocol (see [`crate::channel::net::duplex`]).
+    /// protocol (see [`crate::channel::net::duplex`]). This is a
+    /// distinct predicate from [`is_net`](Self::is_net): the in-process
+    /// [`Local`](ChannelTransport::Local) transport is not a kernel
+    /// socket (so `is_net` is false) yet is still served over the net
+    /// stack and carries duplex.
     pub fn supports_duplex(&self) -> bool {
         match self {
             ChannelTransport::Tcp(_) => true,
@@ -1183,6 +1209,7 @@ pub fn dial<M: RemoteMessage>(addr: ChannelAddr) -> Result<ChannelTx<M>, Channel
         addr,
         net::SessionId::random(),
         0,
+        net::ProtocolKind::Simplex,
     )?))
 }
 
@@ -1244,7 +1271,14 @@ pub mod unordered {
         let addr = addr.into_dial_addr();
         let session_id = net::SessionId::random();
         let links: Vec<net::NetLink> = (1..=num_streams)
-            .map(|i| net::link(addr.clone(), session_id, i as u8))
+            .map(|i| {
+                net::link(
+                    addr.clone(),
+                    session_id,
+                    i as u8,
+                    net::ProtocolKind::Simplex,
+                )
+            })
             .collect::<Result<_, _>>()?;
         Ok(net::spawn_unordered::<M>(links))
     }
@@ -1300,6 +1334,238 @@ pub fn serve_with_listener<M: RemoteMessage>(
         );
         (addr, rx)
     })
+}
+
+/// Serve a muxed listener on `addr`. Simplex clients (dialed via
+/// [`channel::dial`](dial)) deliver into the bundled [`ChannelRx<M>`];
+/// duplex clients (dialed via [`channel::duplex::dial`](net::duplex::dial))
+/// populate the bundled [`DuplexServer<In, Out>`]. Only net transports
+/// are supported; the caller picks transports that implement both
+/// protocol styles.
+///
+/// The returned [`MuxServer`] owns both halves and a shared
+/// [`MuxShutdown`]. Dropping or stopping any of these tears down the
+/// listener and the other half together — see [`MuxServer`] for the
+/// full lifecycle contract.
+#[track_caller]
+pub fn serve_mux<M: RemoteMessage, In: RemoteMessage, Out: RemoteMessage>(
+    addr: ChannelAddr,
+    prebound_listener: Option<std::net::TcpListener>,
+) -> Result<MuxServer<M, In, Out>, ChannelError> {
+    if !addr.transport().is_net() {
+        return Err(ChannelError::InvalidAddress(format!(
+            "serve_mux requires a net transport; got {}",
+            addr
+        )));
+    }
+    let parts = net::mux::serve::<M, In, Out>(addr, prebound_listener)?;
+    Ok(MuxServer {
+        addr: parts.addr,
+        simplex: parts.simplex,
+        duplex: parts.duplex,
+        shutdown: MuxShutdown {
+            join_handle: parts.join_handle,
+            cancel: parts.cancel,
+        },
+    })
+}
+
+/// A muxed server bundling a simplex receiver, a duplex accept
+/// server, and the shared shutdown signal that ties them together.
+///
+/// All three components share one underlying listener. Lifecycle:
+///
+/// - Dropping the [`MuxServer`] cancels the shared shutdown and
+///   tears down the listener and any in-flight sessions.
+/// - [`MuxServer::stop`] does the same explicitly.
+/// - [`MuxServer::split`] hands out the address, simplex half,
+///   duplex half, and a [`MuxShutdown`] separately. After splitting,
+///   dropping the simplex half, the duplex half, or the
+///   [`MuxShutdown`] guard cancels the shared shutdown. The address
+///   is a plain value and does not own any resources.
+///
+/// The simplex half is a [`ChannelRx<M>`] you `recv()` on; the duplex
+/// half is a [`DuplexServer<In, Out>`] you `accept()` on. Neither is
+/// `join()`-able — there is no separate per-half task to await.
+pub struct MuxServer<M: RemoteMessage, In: RemoteMessage, Out: RemoteMessage> {
+    addr: ChannelAddr,
+    simplex: ChannelRx<M>,
+    duplex: net::duplex::DuplexServer<In, Out>,
+    shutdown: MuxShutdown,
+}
+
+impl<M: RemoteMessage, In: RemoteMessage, Out: RemoteMessage> MuxServer<M, In, Out> {
+    /// The address the muxed listener is bound to.
+    pub fn addr(&self) -> &ChannelAddr {
+        &self.addr
+    }
+
+    /// Borrow the simplex receiver.
+    pub fn simplex_mut(&mut self) -> &mut ChannelRx<M> {
+        &mut self.simplex
+    }
+
+    /// Borrow the duplex accept server.
+    pub fn duplex_mut(&mut self) -> &mut net::duplex::DuplexServer<In, Out> {
+        &mut self.duplex
+    }
+
+    /// Cancel the shared shutdown and tear down both halves.
+    pub fn stop(&self, reason: &str) {
+        self.shutdown.stop(reason);
+    }
+
+    /// Move the bound address, simplex half, duplex half, and a
+    /// [`MuxShutdown`] guard out of this wrapper. After splitting,
+    /// dropping the simplex half, the duplex half, or the
+    /// [`MuxShutdown`] guard cancels the shared shutdown and tears
+    /// the rest down. The address is a plain value and does not own
+    /// any resources.
+    pub fn split(
+        self,
+    ) -> (
+        ChannelAddr,
+        ChannelRx<M>,
+        net::duplex::DuplexServer<In, Out>,
+        MuxShutdown,
+    ) {
+        (self.addr, self.simplex, self.duplex, self.shutdown)
+    }
+
+    /// Wire up handlers for both halves, spawn a background task that
+    /// owns the orderly shutdown (duplex drain → simplex pump → listener),
+    /// and return a [`MailboxServerHandle`](crate::mailbox::MailboxServerHandle).
+    /// Calling `.stop()` on the handle drives the drain.
+    ///
+    /// `simplex_handler` consumes the simplex receiver and produces
+    /// the simplex pump's `MailboxServerHandle` (typically by calling
+    /// [`MailboxServer::serve`](crate::mailbox::MailboxServer::serve)
+    /// on a forwarder). `duplex_handler` receives the
+    /// [`DuplexServer`](net::duplex::DuplexServer) and a stop signal,
+    /// and returns the future driving the duplex pump.
+    ///
+    /// **Shutdown ordering.** On stop, the coordinator awaits
+    /// `duplex_task` first so the duplex handler can drive its own
+    /// internal drain (e.g., the host's per-connection forwarder
+    /// pumps stop and drop their `AttachSender`s, which lets
+    /// `send_connected` flush queued outbound naturally as
+    /// `SendLoopError::AppClosed`, before the handler's terminal
+    /// `duplex_server.stop` signals listener shutdown and `join`
+    /// waits for it). Stopping the simplex pump and listener happens
+    /// after the duplex drain to avoid cascading cancellation through
+    /// `dispatch_duplex_stream`'s `select!` while the duplex side
+    /// still has queued sends.
+    ///
+    /// Mirrors [`MailboxServer::serve`](crate::mailbox::MailboxServer::serve)'s
+    /// shape: take the work to do, return a `MailboxServerHandle`.
+    pub fn serve<SH, DH, DF>(
+        self,
+        simplex_handler: SH,
+        duplex_handler: DH,
+    ) -> crate::mailbox::MailboxServerHandle
+    where
+        SH: FnOnce(ChannelRx<M>) -> crate::mailbox::MailboxServerHandle,
+        DH: FnOnce(net::duplex::DuplexServer<In, Out>, tokio::sync::watch::Receiver<bool>) -> DF,
+        DF: std::future::Future<Output = ()> + Send + 'static,
+    {
+        let (stopped_tx, mut stopped_rx) = tokio::sync::watch::channel(false);
+        let duplex_stop = stopped_rx.clone();
+        let simplex_handle = simplex_handler(self.simplex);
+        let duplex_task = tokio::spawn(duplex_handler(self.duplex, duplex_stop));
+        let shutdown = self.shutdown;
+        let join_handle = tokio::spawn(async move {
+            // Pend forever if `stopped_tx` is silently dropped (caller
+            // discarded the handle without `stop()`). Mirrors the
+            // existing `MailboxServer::serve` behavior of holding the
+            // server open absent an explicit stop signal — otherwise
+            // we'd tear down the mux as soon as the handle drops.
+            let ok = stopped_rx.wait_for(|stopped| *stopped).await.is_ok();
+            if !ok {
+                std::future::pending::<()>().await;
+            }
+            const REASON: &str = "MuxServer shutdown";
+            // 1. Wait for the duplex handler to complete its own drain.
+            //    The handler already saw `duplex_stop` (a clone of our
+            //    `stopped_rx`) at the same instant we did, so it is
+            //    already winding down. Awaiting before any cancel fires
+            //    preserves the natural app-closed path through
+            //    `send_connected` so queued outbound is not abandoned.
+            let _ = duplex_task.await;
+            // 2. The duplex handler's drop fires `cancel_token`, which
+            //    cascades to simplex per-session cancels and closes
+            //    `simplex_rx`; the simplex pump then exits naturally
+            //    via its `rx.recv()` returning `Closed`. We only need
+            //    to await it. Calling `simplex_handle.stop` here would
+            //    race the natural exit and panic on the watch send if
+            //    the pump's receiver has already dropped.
+            let _ = simplex_handle.await;
+            // 3. Backstop: cancel the listener explicitly (idempotent
+            //    if already cancelled), then await the accept-loop's
+            //    full drain.
+            shutdown.stop(REASON);
+            let _ = shutdown.await;
+            Ok::<(), crate::mailbox::MailboxServerError>(())
+        });
+        crate::mailbox::MailboxServerHandle::from_parts(join_handle, stopped_tx)
+    }
+}
+
+/// Awaitable shutdown handle for a [`MuxServer`]. Wraps the muxed
+/// listener's accept-loop [`JoinHandle`](tokio::task::JoinHandle); the
+/// caller signals teardown with [`stop`](Self::stop) and then `.await`s
+/// the handle to confirm the listener task has fully exited. Drop
+/// cancels the shared signal as a backstop, so a forgotten handle does
+/// not leak the listener.
+///
+/// Mirrors the [`MailboxServerHandle`](crate::mailbox::MailboxServerHandle)
+/// shape: signal stop, then await the handle.
+pub struct MuxShutdown {
+    join_handle: tokio::task::JoinHandle<Result<(), net::ServerError>>,
+    cancel: CancellationToken,
+}
+
+impl MuxShutdown {
+    /// Signal the muxed listener to stop accepting new connections and
+    /// tear down. The caller should subsequently `.await` the handle
+    /// to confirm shutdown.
+    pub fn stop(&self, reason: &str) {
+        tracing::info!(
+            name = "MuxServerStatus",
+            status = "Stop::Sent",
+            reason,
+            "muxed frontend stop signalled",
+        );
+        self.cancel.cancel();
+    }
+
+    /// Resolve when the shared shutdown has been cancelled (without
+    /// awaiting the listener task itself). Useful for outer tasks that
+    /// drive per-half pumps and need to wake on teardown.
+    pub async fn cancelled(&self) {
+        self.cancel.cancelled().await;
+    }
+}
+
+impl std::future::Future for MuxShutdown {
+    type Output =
+        <tokio::task::JoinHandle<Result<(), net::ServerError>> as std::future::Future>::Output;
+
+    fn poll(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Self::Output> {
+        // `JoinHandle` is `Unpin`, so we can re-pin a mutable borrow of
+        // it without unsafe pin projection. `MuxShutdown` is `Unpin` by
+        // virtue of its `Unpin` fields, which lets us reach through the
+        // outer `Pin`.
+        std::pin::Pin::new(&mut self.join_handle).poll(cx)
+    }
+}
+
+impl Drop for MuxShutdown {
+    fn drop(&mut self) {
+        self.cancel.cancel();
+    }
 }
 
 fn serve_inner<M: RemoteMessage>(

--- a/hyperactor/src/channel/local.rs
+++ b/hyperactor/src/channel/local.rs
@@ -111,6 +111,7 @@ pub(crate) mod stream {
     use crate::channel::net::ClientError;
     use crate::channel::net::Link;
     use crate::channel::net::Listener;
+    use crate::channel::net::ProtocolKind;
     use crate::channel::net::ServerError;
     use crate::channel::net::SessionId;
     use crate::channel::net::write_link_init;
@@ -120,14 +121,21 @@ pub(crate) mod stream {
         port: u64,
         session_id: SessionId,
         stream_id: u8,
+        kind: ProtocolKind,
     }
 
     impl LocalLink {
-        pub(crate) fn new(port: u64, session_id: SessionId, stream_id: u8) -> Self {
+        pub(crate) fn new(
+            port: u64,
+            session_id: SessionId,
+            stream_id: u8,
+            kind: ProtocolKind,
+        ) -> Self {
             Self {
                 port,
                 session_id,
                 stream_id,
+                kind,
             }
         }
 
@@ -199,7 +207,7 @@ pub(crate) mod stream {
         async fn next(&mut self) -> Result<Self::Stream, ClientError> {
             let (mut client, server) = self.pair()?;
             self.connect(server)?;
-            write_link_init(&mut client, self.session_id, self.stream_id)
+            write_link_init(&mut client, self.session_id, self.stream_id, self.kind)
                 .await
                 .map_err(|err| ClientError::Io(self.dest(), err))?;
             Ok(client)
@@ -270,8 +278,13 @@ pub(crate) mod stream {
         Ok((LocalListener { accept_rx, port }, addr))
     }
 
-    pub(crate) fn link(port: u64, session_id: SessionId, stream_id: u8) -> LocalLink {
-        LocalLink::new(port, session_id, stream_id)
+    pub(crate) fn link(
+        port: u64,
+        session_id: SessionId,
+        stream_id: u8,
+        kind: ProtocolKind,
+    ) -> LocalLink {
+        LocalLink::new(port, session_id, stream_id, kind)
     }
 }
 

--- a/hyperactor/src/channel/net.rs
+++ b/hyperactor/src/channel/net.rs
@@ -71,6 +71,7 @@ use crate::RemoteMessage;
 
 pub mod duplex;
 mod framed;
+pub(super) mod mux;
 pub(crate) mod quic;
 pub(super) mod server;
 pub(super) mod session;
@@ -107,15 +108,29 @@ pub(crate) const INITIATOR_TO_ACCEPTOR: u8 = 0;
 /// Logical channel tag for acceptor→initiator traffic.
 pub(crate) const ACCEPTOR_TO_INITIATOR: u8 = 1;
 
+/// Wire-level protocol kind carried by [`ProtocolKind`] in the
+/// [`LinkInit`](write_link_init) header. Distinguishes simplex
+/// (one-direction byte stream carrying tag `0x00` frames) from
+/// duplex (bidirectional byte stream carrying both `0x00` and
+/// `0x01` frames) so a server listening on a single address can
+/// demultiplex both styles without peeking at application payloads.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ProtocolKind {
+    Simplex,
+    Duplex,
+}
+
+const SIMPLEX_MAGIC: [u8; 4] = *b"SMP\0";
+const DUPLEX_MAGIC: [u8; 4] = *b"DPX\0";
+
 /// Fixed-size header sent at the start of every physical connection.
-/// This is written/read directly on the wire (not framed), before
-/// any session framing begins.
+/// Written/read directly on the wire (not framed), before any session
+/// framing begins.
 ///
 /// Wire format (13 bytes, big-endian):
 /// ```text
-/// [magic: 4B "LNK\0"] [session_id: 8B u64 BE] [stream_id: 1B u8]
+/// [magic: 4B ("SMP\0" | "DPX\0")] [session_id: 8B u64 BE] [stream_id: 1B u8]
 /// ```
-const LINK_INIT_MAGIC: [u8; 4] = *b"LNK\0";
 const LINK_INIT_SIZE: usize = 4 + 8 + 1;
 
 /// Parsed LinkInit header.
@@ -123,37 +138,119 @@ const LINK_INIT_SIZE: usize = 4 + 8 + 1;
 pub(crate) struct LinkInit {
     pub session_id: SessionId,
     pub stream_id: u8,
+    pub kind: ProtocolKind,
 }
 
-/// Write a LinkInit header to the stream.
+/// Write a LinkInit header to the stream, tagged by `kind`.
 pub(crate) async fn write_link_init<S: AsyncWrite + Unpin>(
     stream: &mut S,
     session_id: SessionId,
     stream_id: u8,
+    kind: ProtocolKind,
 ) -> Result<(), std::io::Error> {
     let mut buf = [0u8; LINK_INIT_SIZE];
-    buf[0..4].copy_from_slice(&LINK_INIT_MAGIC);
+    let magic = match kind {
+        ProtocolKind::Simplex => &SIMPLEX_MAGIC,
+        ProtocolKind::Duplex => &DUPLEX_MAGIC,
+    };
+    buf[0..4].copy_from_slice(magic);
     buf[4..12].copy_from_slice(&session_id.0.to_be_bytes());
     buf[12] = stream_id;
     stream.write_all(&buf).await
 }
 
-/// Read a LinkInit header from the stream.
+/// Read a LinkInit header from the stream, recovering the session
+/// id and protocol kind the client wrote.
 async fn read_link_init<S: AsyncRead + Unpin>(stream: &mut S) -> Result<LinkInit, std::io::Error> {
     let mut buf = [0u8; LINK_INIT_SIZE];
     stream.read_exact(&mut buf).await?;
-    if buf[0..4] != LINK_INIT_MAGIC {
-        return Err(std::io::Error::new(
-            std::io::ErrorKind::InvalidData,
-            format!("invalid LinkInit magic: expected LNK, got {:?}", &buf[0..4]),
-        ));
-    }
+    let kind = match &buf[0..4] {
+        m if m == SIMPLEX_MAGIC => ProtocolKind::Simplex,
+        m if m == DUPLEX_MAGIC => ProtocolKind::Duplex,
+        other => {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!(
+                    "invalid LinkInit magic: expected {:?} or {:?}, got {:?}",
+                    SIMPLEX_MAGIC, DUPLEX_MAGIC, other
+                ),
+            ));
+        }
+    };
     let session_id = SessionId(u64::from_be_bytes(buf[4..12].try_into().unwrap()));
     let stream_id = buf[12];
     Ok(LinkInit {
         session_id,
         stream_id,
+        kind,
     })
+}
+
+/// Prepare an accepted byte stream for dispatch: optionally negotiate
+/// TLS for TLS transports, read the [`LinkInit`] header, and (when
+/// `expected_kind` is set) validate the client's [`ProtocolKind`].
+///
+/// Shared by the simplex, duplex, and muxed accept loops so each
+/// `prepare` closure stays a thin wrapper over this function. Pass
+/// `expected_kind = None` to accept either kind (used by the mux
+/// listener, which dispatches by kind after the header is read).
+pub(super) async fn prepare_accepted_stream(
+    stream: Box<dyn Stream>,
+    source: ChannelAddr,
+    dest: ChannelAddr,
+    expected_kind: Option<ProtocolKind>,
+) -> Result<(LinkInit, Box<dyn Stream>), anyhow::Error> {
+    let is_tls = dest.transport().is_tls();
+    let (link_init, stream): (LinkInit, Box<dyn Stream>) = if is_tls {
+        let tls_acceptor = match dest.transport() {
+            ChannelTransport::Tls => tls::tls_acceptor()?,
+            _ => meta::tls_acceptor(true)?,
+        };
+        let mut tls_stream = tls_acceptor.accept(stream).await?;
+        let link_init = read_link_init(&mut tls_stream)
+            .await
+            .map_err(|e| anyhow::anyhow!("LinkInit read failed from {}: {}", source, e))?;
+        (link_init, Box::new(tls_stream))
+    } else {
+        let mut stream = stream;
+        let link_init = read_link_init(&mut stream)
+            .await
+            .map_err(|e| anyhow::anyhow!("LinkInit read failed from {}: {}", source, e))?;
+        (link_init, stream)
+    };
+    if let Some(expected) = expected_kind
+        && link_init.kind != expected
+    {
+        return Err(anyhow::anyhow!(
+            "{:?} server received {:?} client from {}",
+            expected,
+            link_init.kind,
+            source
+        ));
+    }
+    Ok((link_init, stream))
+}
+
+/// Future type produced by [`preparer_for`]'s closure.
+type PreparedStreamFut = std::pin::Pin<
+    Box<
+        dyn std::future::Future<Output = Result<(LinkInit, Box<dyn Stream>), anyhow::Error>> + Send,
+    >,
+>;
+
+/// Build a `prepare` closure suitable for [`server::accept_loop`] that
+/// wraps [`prepare_accepted_stream`] with the given destination address
+/// and expected [`ProtocolKind`]. Pass `expected_kind = None` for the
+/// muxed listener path, which dispatches on `link_init.kind` after the
+/// header is read instead of validating up front.
+pub(super) fn preparer_for(
+    dest: ChannelAddr,
+    expected_kind: Option<ProtocolKind>,
+) -> impl Fn(Box<dyn Stream>, ChannelAddr) -> PreparedStreamFut + Clone + Send + 'static {
+    move |stream, source| {
+        let dest = dest.clone();
+        Box::pin(prepare_accepted_stream(stream, source, dest, expected_kind))
+    }
 }
 
 /// Link represents a network link through which connections may be
@@ -758,39 +855,48 @@ pub(crate) enum NetLink {
 /// Create a link for the given channel address with the given
 /// `session_id` and `stream_id`. Single-stream callers pass a fresh
 /// `SessionId::random()` and `stream_id = 0`.
+/// Tagged with the protocol kind the client intends to speak.
 pub(crate) fn link(
     addr: ChannelAddr,
     session_id: SessionId,
     stream_id: u8,
+    kind: ProtocolKind,
 ) -> Result<NetLink, ClientError> {
     match addr {
-        ChannelAddr::Tcp(socket_addr) => {
-            Ok(NetLink::Tcp(tcp::link(socket_addr, session_id, stream_id)))
-        }
-        ChannelAddr::Unix(unix_addr) => {
-            Ok(NetLink::Unix(unix::link(unix_addr, session_id, stream_id)))
-        }
+        ChannelAddr::Tcp(socket_addr) => Ok(NetLink::Tcp(tcp::link(
+            socket_addr,
+            session_id,
+            stream_id,
+            kind,
+        ))),
+        ChannelAddr::Unix(unix_addr) => Ok(NetLink::Unix(unix::link(
+            unix_addr, session_id, stream_id, kind,
+        ))),
         ChannelAddr::Local(port) => {
             local::stream::check(port)?;
             Ok(NetLink::Local(local::stream::link(
-                port, session_id, stream_id,
+                port, session_id, stream_id, kind,
             )))
         }
-        ChannelAddr::Tls(tls_addr) => Ok(NetLink::Tls(tls::link(tls_addr, session_id, stream_id)?)),
-        ChannelAddr::MetaTls(meta_addr) => {
-            Ok(NetLink::Tls(meta::link(meta_addr, session_id, stream_id)?))
-        }
+        ChannelAddr::Tls(tls_addr) => Ok(NetLink::Tls(tls::link(
+            tls_addr, session_id, stream_id, kind,
+        )?)),
+        ChannelAddr::MetaTls(meta_addr) => Ok(NetLink::Tls(meta::link(
+            meta_addr, session_id, stream_id, kind,
+        )?)),
         ChannelAddr::Quic(quic_addr) => Ok(NetLink::Quic(quic::link(
             quic_addr,
             quic::QuicAddrType::Quic,
             session_id,
             stream_id,
+            kind,
         )?)),
         ChannelAddr::MetaQuic(meta_addr) => Ok(NetLink::Quic(quic::link(
             meta_addr,
             quic::QuicAddrType::MetaQuic,
             session_id,
             stream_id,
+            kind,
         )?)),
         other => Err(ClientError::Connect(
             other,
@@ -1124,6 +1230,7 @@ pub(crate) mod unix {
         pub(super) addr: SocketAddr,
         pub(super) session_id: SessionId,
         pub(super) stream_id: u8,
+        pub(super) kind: ProtocolKind,
     }
 
     #[async_trait]
@@ -1159,7 +1266,7 @@ pub(crate) mod unix {
                             .map_err(|err| ClientError::Io(self.dest(), err))?;
                         let mut stream = UnixStream::from_std(std_stream)
                             .map_err(|err| ClientError::Io(self.dest(), err))?;
-                        write_link_init(&mut stream, session_id, self.stream_id)
+                        write_link_init(&mut stream, session_id, self.stream_id, self.kind)
                             .await
                             .map_err(|err| ClientError::Io(self.dest(), err))?;
                         return Ok(stream);
@@ -1199,11 +1306,17 @@ pub(crate) mod unix {
     }
 
     /// Create a unix link to the given socket address.
-    pub(crate) fn link(addr: SocketAddr, session_id: SessionId, stream_id: u8) -> UnixLink {
+    pub(crate) fn link(
+        addr: SocketAddr,
+        session_id: SessionId,
+        stream_id: u8,
+        kind: ProtocolKind,
+    ) -> UnixLink {
         UnixLink {
             addr,
             session_id,
             stream_id,
+            kind,
         }
     }
 
@@ -1417,6 +1530,7 @@ pub(crate) mod tcp {
         pub(super) addr: SocketAddr,
         pub(super) session_id: SessionId,
         pub(super) stream_id: u8,
+        pub(super) kind: ProtocolKind,
     }
 
     #[async_trait]
@@ -1453,7 +1567,7 @@ pub(crate) mod tcp {
                             )
                         })?;
                         set_tcp_keepalive(&stream);
-                        write_link_init(&mut stream, session_id, self.stream_id)
+                        write_link_init(&mut stream, session_id, self.stream_id, self.kind)
                             .await
                             .map_err(|err| ClientError::Io(self.dest(), err))?;
                         return Ok(stream);
@@ -1502,11 +1616,17 @@ pub(crate) mod tcp {
     }
 
     /// Create a TCP link to the given socket address.
-    pub(crate) fn link(addr: SocketAddr, session_id: SessionId, stream_id: u8) -> TcpLink {
+    pub(crate) fn link(
+        addr: SocketAddr,
+        session_id: SessionId,
+        stream_id: u8,
+        kind: ProtocolKind,
+    ) -> TcpLink {
         TcpLink {
             addr,
             session_id,
             stream_id,
+            kind,
         }
     }
 }
@@ -1619,6 +1739,7 @@ pub(crate) mod meta {
         addr: TlsAddr,
         session_id: SessionId,
         stream_id: u8,
+        kind: ProtocolKind,
     ) -> Result<tls::TlsLink, ClientError> {
         let connector = tls_connector().map_err(|e| {
             ClientError::Connect(
@@ -1635,6 +1756,7 @@ pub(crate) mod meta {
             addr_type: tls::TlsAddrType::MetaTls,
             session_id,
             stream_id,
+            kind,
         })
     }
 }
@@ -1823,6 +1945,7 @@ pub(crate) mod tls {
         pub(crate) addr_type: TlsAddrType,
         pub(crate) session_id: SessionId,
         pub(crate) stream_id: u8,
+        pub(crate) kind: ProtocolKind,
     }
 
     impl std::fmt::Debug for TlsLink {
@@ -1900,7 +2023,7 @@ pub(crate) mod tls {
                                     format!("cannot establish TLS connection to {:?}", server_name),
                                 )
                             })?;
-                        write_link_init(&mut tls_stream, session_id, self.stream_id)
+                        write_link_init(&mut tls_stream, session_id, self.stream_id, self.kind)
                             .await
                             .map_err(|err| ClientError::Io(self.dest(), err))?;
                         return Ok(tls_stream);
@@ -1928,6 +2051,7 @@ pub(crate) mod tls {
         addr: TlsAddr,
         session_id: SessionId,
         stream_id: u8,
+        kind: ProtocolKind,
     ) -> Result<TlsLink, ClientError> {
         let connector = tls_connector().map_err(|e| {
             ClientError::Connect(
@@ -1944,6 +2068,7 @@ pub(crate) mod tls {
             addr_type: TlsAddrType::Tls,
             session_id,
             stream_id,
+            kind,
         })
     }
 
@@ -2070,6 +2195,7 @@ u19txmtkiMEH+aNmekk=
                     },
                     SessionId::random(),
                     0,
+                    super::ProtocolKind::Simplex,
                 )
                 .expect("failed to create link"),
             );
@@ -2157,6 +2283,7 @@ u19txmtkiMEH+aNmekk=
                     },
                     SessionId::random(),
                     0,
+                    super::ProtocolKind::Simplex,
                 )
                 .expect("failed to create link"),
             );
@@ -2375,6 +2502,7 @@ mod tests {
     use rand::distr::Alphanumeric;
     use rand::rngs::SysRng;
     use timed_test::async_timed_test;
+    use tokio::io::AsyncRead;
     use tokio::io::AsyncWrite;
     use tokio::io::DuplexStream;
     use tokio::io::ReadHalf;
@@ -2939,7 +3067,7 @@ mod tests {
             // Write LinkInit on server_relay so it's readable from `server`.
             // This simulates the client sending LinkInit over the wire before
             // the frame-level relay begins.
-            write_link_init(&mut server_relay, session_id, 0)
+            write_link_init(&mut server_relay, session_id, 0, ProtocolKind::Simplex)
                 .await
                 .map_err(|err| ClientError::Io(self.dest(), err))?;
 
@@ -3974,7 +4102,12 @@ mod tests {
             ChannelAddr::Tcp(a) => a,
             _ => panic!("unexpected channel type"),
         };
-        let tx: ChannelTx<u64> = spawn(tcp::link(socket_addr, SessionId::random(), 0));
+        let tx: ChannelTx<u64> = spawn(tcp::link(
+            socket_addr,
+            SessionId::random(),
+            0,
+            ProtocolKind::Simplex,
+        ));
         // ChannelTx will not establish a connection until it sends the 1st message.
         // Without a live connection, ChannelTx cannot received the Closed message
         // from ChannelRx. Therefore, we need to send a message to establish the
@@ -4017,6 +4150,106 @@ mod tests {
         }
     }
 
+    /// Stream wrapper that gates writes (server-side terminal cleanup)
+    /// until the test releases the gate. Reads pass through. Used by
+    /// the mux drain-aware regression tests to make the dispatch's
+    /// final ack/Closed write blockable, so a cancel-only handle's
+    /// "join returns before cleanup" race is observable.
+    #[derive(Debug)]
+    pub(super) struct GatedWriteStream {
+        inner: DuplexStream,
+        gate: Arc<GateState>,
+    }
+
+    #[derive(Debug)]
+    pub(super) struct GateState {
+        open: AtomicBool,
+        waker: std::sync::Mutex<Option<std::task::Waker>>,
+    }
+
+    impl GateState {
+        pub(super) fn new() -> Arc<Self> {
+            Arc::new(Self {
+                open: AtomicBool::new(false),
+                waker: std::sync::Mutex::new(None),
+            })
+        }
+
+        /// Open the gate so any pending writes can proceed.
+        pub(super) fn open(&self) {
+            self.open.store(true, Ordering::Release);
+            if let Some(w) = self.waker.lock().unwrap().take() {
+                w.wake();
+            }
+        }
+    }
+
+    impl GatedWriteStream {
+        pub(super) fn new(inner: DuplexStream, gate: Arc<GateState>) -> Self {
+            Self { inner, gate }
+        }
+    }
+
+    impl AsyncRead for GatedWriteStream {
+        fn poll_read(
+            mut self: std::pin::Pin<&mut Self>,
+            cx: &mut std::task::Context<'_>,
+            buf: &mut tokio::io::ReadBuf<'_>,
+        ) -> std::task::Poll<std::io::Result<()>> {
+            std::pin::Pin::new(&mut self.inner).poll_read(cx, buf)
+        }
+    }
+
+    impl AsyncWrite for GatedWriteStream {
+        fn poll_write(
+            mut self: std::pin::Pin<&mut Self>,
+            cx: &mut std::task::Context<'_>,
+            buf: &[u8],
+        ) -> std::task::Poll<std::io::Result<usize>> {
+            if !self.gate.open.load(Ordering::Acquire) {
+                *self.gate.waker.lock().unwrap() = Some(cx.waker().clone());
+                if !self.gate.open.load(Ordering::Acquire) {
+                    return std::task::Poll::Pending;
+                }
+            }
+            std::pin::Pin::new(&mut self.inner).poll_write(cx, buf)
+        }
+
+        fn poll_flush(
+            mut self: std::pin::Pin<&mut Self>,
+            cx: &mut std::task::Context<'_>,
+        ) -> std::task::Poll<std::io::Result<()>> {
+            std::pin::Pin::new(&mut self.inner).poll_flush(cx)
+        }
+
+        fn poll_shutdown(
+            mut self: std::pin::Pin<&mut Self>,
+            cx: &mut std::task::Context<'_>,
+        ) -> std::task::Poll<std::io::Result<()>> {
+            std::pin::Pin::new(&mut self.inner).poll_shutdown(cx)
+        }
+    }
+
+    /// `Listener` over a single pre-prepared `GatedWriteStream`. Used
+    /// to drive the mux drain-aware regression tests with a stream
+    /// whose terminal write is blockable.
+    struct GatedQueueListener {
+        streams: std::collections::VecDeque<GatedWriteStream>,
+        addr: ChannelAddr,
+    }
+
+    #[async_trait]
+    impl super::Listener for GatedQueueListener {
+        type Stream = GatedWriteStream;
+
+        async fn accept(&mut self) -> Result<(GatedWriteStream, ChannelAddr), ServerError> {
+            match self.streams.pop_front() {
+                Some(s) => Ok((s, self.addr.clone())),
+                None => std::future::pending().await,
+            }
+        }
+    }
+
     /// In-memory connection: server end goes into the listener; the
     /// test reads from `client_r`.
     struct PreparedConnection {
@@ -4029,16 +4262,20 @@ mod tests {
     }
 
     /// Write `LinkInit` and the framed `Frame::Message(seq, value)`
-    /// payloads on the client side; return both halves.
+    /// payloads on the client side; return both halves. The caller
+    /// chooses the [`ProtocolKind`] so simplex tests can stamp
+    /// `Simplex` and duplex tests can stamp `Duplex`, matching
+    /// production handshake validation.
     async fn prepare_connection(
         session_id: SessionId,
         stream_id: u8,
+        kind: super::ProtocolKind,
         messages: &[(u64, u64)],
     ) -> PreparedConnection {
         let (client_side, server_side) = tokio::io::duplex(8192);
         let (client_r, mut client_w) = tokio::io::split(client_side);
 
-        super::write_link_init(&mut client_w, session_id, stream_id)
+        super::write_link_init(&mut client_w, session_id, stream_id, kind)
             .await
             .unwrap();
         let max_len = hyperactor_config::global::get(config::CODEC_MAX_FRAME_LENGTH);
@@ -4096,7 +4333,15 @@ mod tests {
                 expected_messages.insert(*value);
             }
             expected_acks.push(plan.messages.iter().map(|(s, _)| *s).max().unwrap());
-            conns.push(prepare_connection(plan.session_id, plan.stream_id, &plan.messages).await);
+            conns.push(
+                prepare_connection(
+                    plan.session_id,
+                    plan.stream_id,
+                    super::ProtocolKind::Simplex,
+                    &plan.messages,
+                )
+                .await,
+            );
         }
 
         let addr = ChannelAddr::Local(u64::MAX);
@@ -4258,7 +4503,15 @@ mod tests {
             for (_, v) in &messages {
                 expected_messages.insert(*v);
             }
-            conns.push(prepare_connection(session_id, stream_id, &messages).await);
+            conns.push(
+                prepare_connection(
+                    session_id,
+                    stream_id,
+                    super::ProtocolKind::Simplex,
+                    &messages,
+                )
+                .await,
+            );
         }
         let highest_seq = num_streams as u64 * msgs_per_stream - 1;
 
@@ -4360,6 +4613,32 @@ mod tests {
         );
     }
 
+    /// `duplex::serve_with_listener` (the test-only duplex server)
+    /// must enforce the same `ProtocolKind::Duplex` handshake check as
+    /// production `duplex::serve`. Otherwise the duplex ack-flush
+    /// tests below could pass with a wire header that the real server
+    /// would reject — weakening coverage exactly where shutdown
+    /// behavior is most sensitive.
+    #[async_timed_test(timeout_secs = 30)]
+    async fn duplex_test_listener_rejects_simplex_link_init() {
+        let conn =
+            prepare_connection(SessionId(1), 0, super::ProtocolKind::Simplex, &[(0, 123)]).await;
+        let addr = ChannelAddr::Local(u64::MAX);
+        let listener = QueueListener {
+            streams: std::collections::VecDeque::from([conn.server_side]),
+            addr: addr.clone(),
+        };
+
+        let mut server = super::duplex::serve_with_listener::<u64, u64, _>(listener, addr).unwrap();
+
+        assert!(
+            tokio::time::timeout(Duration::from_millis(500), server.accept())
+                .await
+                .is_err(),
+            "duplex test server accepted a simplex LinkInit",
+        );
+    }
+
     /// Duplex analog of `rx_join_flushes_pending_ack_single_stream`.
     /// Three independent duplex sessions, each with three framed
     /// messages. Verifies every `dispatch_duplex_stream`'s terminal
@@ -4387,7 +4666,9 @@ mod tests {
                 expected_messages.insert(*v);
             }
             expected_acks.push(messages.iter().map(|(s, _)| *s).max().unwrap());
-            conns.push(prepare_connection(SessionId(sid), 0, &messages).await);
+            conns.push(
+                prepare_connection(SessionId(sid), 0, super::ProtocolKind::Duplex, &messages).await,
+            );
         }
 
         let addr = ChannelAddr::Local(u64::MAX);
@@ -4539,9 +4820,14 @@ mod tests {
         async fn next(&mut self) -> Result<DuplexStream, ClientError> {
             match self.streams.pop_front() {
                 Some(mut stream) => {
-                    super::write_link_init(&mut stream, self.session_id, 0)
-                        .await
-                        .map_err(|err| ClientError::Io(self.dest(), err))?;
+                    super::write_link_init(
+                        &mut stream,
+                        self.session_id,
+                        0,
+                        super::ProtocolKind::Duplex,
+                    )
+                    .await
+                    .map_err(|err| ClientError::Io(self.dest(), err))?;
                     Ok(stream)
                 }
                 None => Err(ClientError::Connect(
@@ -4571,7 +4857,7 @@ mod tests {
         let session_id = SessionId(1);
         let messages: Vec<(u64, u64)> = vec![(0, 100), (1, 200), (2, 300)];
         let expected_ack: u64 = 2;
-        let conn = prepare_connection(session_id, 0, &messages).await;
+        let conn = prepare_connection(session_id, 0, super::ProtocolKind::Duplex, &messages).await;
 
         let addr = ChannelAddr::Local(u64::MAX);
         let listener = QueueListener {
@@ -4648,13 +4934,276 @@ mod tests {
         server.join().await;
     }
 
-    /// [`DuplexClient::join`] cancels the recv/send loop's
-    /// cancellation token. The `select!`s observe cancel and the
-    /// loop exits via the flush + `Closed` + break path. Verifies
-    /// the cumulative ack and the terminal `Closed` are written on
+    /// Wire-level regression for the mux per-half drain-aware
+    /// `ServerHandle`. After `DuplexServer::stop()` is called on the
+    /// mux's duplex half, `DuplexServer::join()` must wait for every
+    /// dispatched session's terminal cleanup (final ack flush +
+    /// `Closed` emit) to reach the wire — not merely for the
+    /// cancellation token to fire. Adversarial test #4 from the AI
+    /// review's coverage gap. Prior to the drain-aware handle
+    /// (`cancel_only_handle`), `join` could report shutdown complete
+    /// before the dispatch's flush reached the wire.
+    #[async_timed_test(timeout_secs = 30)]
+    async fn mux_duplex_join_flushes_pending_ack_for_session() {
+        let config = hyperactor_config::global::lock();
+        let _g_msg = config.override_key(config::MESSAGE_ACK_EVERY_N_MESSAGES, 1_000_000);
+        let _g_time =
+            config.override_key(config::MESSAGE_ACK_TIME_INTERVAL, Duration::from_secs(3600));
+
+        let session_id = SessionId(1);
+        let messages: Vec<(u64, u64)> = vec![(0, 100), (1, 200), (2, 300)];
+        let expected_ack: u64 = 2;
+        let conn = prepare_connection(session_id, 0, super::ProtocolKind::Duplex, &messages).await;
+
+        let addr = ChannelAddr::Local(u64::MAX);
+        let listener = QueueListener {
+            streams: std::collections::VecDeque::from([conn.server_side]),
+            addr: addr.clone(),
+        };
+
+        let mut parts =
+            super::mux::serve_with_listener::<u64, u64, u64, _>(listener, addr).unwrap();
+
+        // Accept the duplex session and drain the inbound messages.
+        // Hold `_server_tx` alive across the shutdown so the dispatch
+        // is parked on the cancel branch (not `AppClosed`); the
+        // adversarial path is precisely the cancel-driven cleanup.
+        let (mut server_rx, _server_tx) = parts.duplex.accept().await.unwrap();
+        for _ in &messages {
+            server_rx.recv().await.unwrap();
+        }
+
+        // No spontaneous ack expected before shutdown.
+        let max_len = hyperactor_config::global::get(config::CODEC_MAX_FRAME_LENGTH);
+        let mut reader = FrameReader::new(conn.client_r, max_len);
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        match tokio::time::timeout(Duration::from_millis(10), reader.next()).await {
+            Err(_) => {} // timeout expected.
+            Ok(Err(e)) => panic!("mux: frame reader error before shutdown: {e}"),
+            Ok(Ok(None)) => panic!("mux: wire closed before shutdown"),
+            Ok(Ok(Some((_, bytes)))) => {
+                let resp = super::deserialize_response(bytes).unwrap();
+                panic!("mux: unexpectedly received {resp:?} before shutdown");
+            }
+        }
+
+        // `DuplexServer::stop` fires the shared cancel; `join`
+        // awaits the per-half handle's join_handle. With the
+        // drain-aware handle, that resolves only after the
+        // coordinator signals `drained` — i.e., after the
+        // dispatch's terminal cleanup has reached the wire.
+        parts.duplex.stop("test mux duplex join flush");
+        parts.duplex.join().await;
+
+        let bytes = tokio::time::timeout(Duration::from_millis(100), reader.next())
+            .await
+            .unwrap_or_else(|_| panic!("mux: produced no Ack frame within 100ms after join"))
+            .expect("frame reader error")
+            .expect("frame reader returned None");
+        let acked = super::deserialize_response(bytes.1)
+            .unwrap()
+            .into_ack()
+            .unwrap_or_else(|other| panic!("mux: expected Ack, got {other:?}"));
+        assert_eq!(
+            acked, expected_ack,
+            "mux: ack should cover the highest seq received"
+        );
+
+        let bytes = tokio::time::timeout(Duration::from_millis(100), reader.next())
+            .await
+            .unwrap_or_else(|_| panic!("mux: produced no Closed frame within 100ms after join"))
+            .expect("frame reader error")
+            .expect("frame reader returned None");
+        assert!(
+            super::deserialize_response(bytes.1).unwrap().is_closed(),
+            "mux: expected Closed terminal frame after Ack"
+        );
+
+        // Tear down the listener after asserting on the wire.
+        let _ = parts.simplex;
+        let _ = parts.join_handle.await;
+    }
+
+    /// Strict adversarial regression for the mux per-half drain-aware
+    /// `ServerHandle`. Uses a [`GatedWriteStream`] to block the
+    /// dispatch's terminal write so that — under the old
+    /// `cancel_only_handle` behavior — `DuplexServer::join()` after
+    /// `DuplexServer::stop()` would return *before* the Ack reached
+    /// the wire. With the drain-aware handle, `join` waits for the
+    /// listener's accept-loop to drain, which awaits the dispatch's
+    /// blocked write; thus `join` is pinned `Pending` until the test
+    /// opens the gate.
+    #[async_timed_test(timeout_secs = 30)]
+    async fn mux_duplex_join_blocks_until_terminal_write_completes() {
+        let config = hyperactor_config::global::lock();
+        let _g_msg = config.override_key(config::MESSAGE_ACK_EVERY_N_MESSAGES, 1_000_000);
+        let _g_time =
+            config.override_key(config::MESSAGE_ACK_TIME_INTERVAL, Duration::from_secs(3600));
+
+        let session_id = SessionId(1);
+        let messages: Vec<(u64, u64)> = vec![(0, 100), (1, 200), (2, 300)];
+        let expected_ack: u64 = 2;
+        let conn = prepare_connection(session_id, 0, super::ProtocolKind::Duplex, &messages).await;
+
+        // Wrap the server side so its writes (the dispatch's terminal
+        // ack/Closed) are gated.
+        let gate = GateState::new();
+        let server_side_gated = GatedWriteStream::new(conn.server_side, gate.clone());
+
+        let addr = ChannelAddr::Local(u64::MAX);
+        let listener = GatedQueueListener {
+            streams: std::collections::VecDeque::from([server_side_gated]),
+            addr: addr.clone(),
+        };
+
+        let mut parts =
+            super::mux::serve_with_listener::<u64, u64, u64, _>(listener, addr).unwrap();
+
+        let (mut server_rx, _server_tx) = parts.duplex.accept().await.unwrap();
+        for _ in &messages {
+            server_rx.recv().await.unwrap();
+        }
+
+        // Stop + spawn join. With the drain-aware handle, join
+        // should be pinned Pending until the gate opens. With a
+        // `cancel_only_handle`, join would return immediately on
+        // cancel — observable here as a non-Pending poll despite
+        // the blocked write.
+        parts
+            .duplex
+            .stop("test mux duplex join blocks until terminal write");
+        let mut join_task = tokio::spawn(async move { parts.duplex.join().await });
+
+        let blocked = tokio::time::timeout(Duration::from_millis(200), &mut join_task).await;
+        assert!(
+            blocked.is_err(),
+            "duplex.join() returned before the gated terminal write could complete"
+        );
+
+        // Open the gate so dispatch's Ack/Closed writes proceed; join
+        // should resolve once the accept loop drains.
+        gate.open();
+
+        tokio::time::timeout(Duration::from_secs(5), join_task)
+            .await
+            .expect("duplex.join() did not resolve after gate opened")
+            .expect("join task panicked");
+
+        // Verify the wire actually received Ack and Closed.
+        let max_len = hyperactor_config::global::get(config::CODEC_MAX_FRAME_LENGTH);
+        let mut reader = FrameReader::new(conn.client_r, max_len);
+
+        let bytes = tokio::time::timeout(Duration::from_millis(200), reader.next())
+            .await
+            .expect("no Ack frame")
+            .expect("frame reader error")
+            .expect("frame reader returned None");
+        let acked = super::deserialize_response(bytes.1)
+            .unwrap()
+            .into_ack()
+            .unwrap_or_else(|other| panic!("expected Ack, got {other:?}"));
+        assert_eq!(acked, expected_ack);
+
+        let bytes = tokio::time::timeout(Duration::from_millis(200), reader.next())
+            .await
+            .expect("no Closed frame")
+            .expect("frame reader error")
+            .expect("frame reader returned None");
+        assert!(super::deserialize_response(bytes.1).unwrap().is_closed());
+    }
+
+    /// Wire-level regression for the per-half `ServerHandle`'s
+    /// drain-aware contract. Calling `ChannelRx::join()` on the mux's
+    /// simplex half must wait for the dispatch's terminal cleanup
+    /// (final ack flush + `Closed` emit) to reach the wire — not
+    /// merely for the cancellation token to fire. Adversarial test
+    /// #2 from the AI review.
+    #[async_timed_test(timeout_secs = 30)]
+    async fn mux_split_simplex_join_flushes_final_ack() {
+        let config = hyperactor_config::global::lock();
+        let _g_msg = config.override_key(config::MESSAGE_ACK_EVERY_N_MESSAGES, 1_000_000);
+        let _g_time =
+            config.override_key(config::MESSAGE_ACK_TIME_INTERVAL, Duration::from_secs(3600));
+
+        let session_id = SessionId(1);
+        let messages: Vec<(u64, u64)> = vec![(0, 100), (1, 200), (2, 300)];
+        let expected_ack: u64 = 2;
+        let conn = prepare_connection(session_id, 0, super::ProtocolKind::Simplex, &messages).await;
+
+        let addr = ChannelAddr::Local(u64::MAX);
+        let listener = QueueListener {
+            streams: std::collections::VecDeque::from([conn.server_side]),
+            addr: addr.clone(),
+        };
+
+        let mut parts =
+            super::mux::serve_with_listener::<u64, u64, u64, _>(listener, addr).unwrap();
+
+        // Drain inbound through the simplex half.
+        for _ in &messages {
+            parts.simplex.recv().await.unwrap();
+        }
+
+        // No spontaneous ack expected.
+        let max_len = hyperactor_config::global::get(config::CODEC_MAX_FRAME_LENGTH);
+        let mut reader = FrameReader::new(conn.client_r, max_len);
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        match tokio::time::timeout(Duration::from_millis(10), reader.next()).await {
+            Err(_) => {}
+            Ok(Err(e)) => panic!("mux split: frame reader error before join: {e}"),
+            Ok(Ok(None)) => panic!("mux split: wire closed before join"),
+            Ok(Ok(Some((_, bytes)))) => {
+                let resp = super::deserialize_response(bytes).unwrap();
+                panic!("mux split: unexpectedly received {resp:?} before join");
+            }
+        }
+
+        // `ChannelRx::join` consumes the `ChannelRx`; with the drain-aware
+        // handle it must wait for the dispatch's terminal cleanup.
+        // Once join returns, the Ack and Closed frames must already
+        // be on the wire.
+        parts.simplex.join().await;
+
+        let bytes = tokio::time::timeout(Duration::from_millis(100), reader.next())
+            .await
+            .unwrap_or_else(|_| panic!("mux split: produced no Ack frame within 100ms after join"))
+            .expect("frame reader error")
+            .expect("frame reader returned None");
+        let acked = super::deserialize_response(bytes.1)
+            .unwrap()
+            .into_ack()
+            .unwrap_or_else(|other| panic!("mux split: expected Ack, got {other:?}"));
+        assert_eq!(
+            acked, expected_ack,
+            "mux split: simplex.join must flush the final ack before returning"
+        );
+
+        let bytes = tokio::time::timeout(Duration::from_millis(100), reader.next())
+            .await
+            .unwrap_or_else(|_| {
+                panic!("mux split: produced no Closed frame within 100ms after join")
+            })
+            .expect("frame reader error")
+            .expect("frame reader returned None");
+        assert!(
+            super::deserialize_response(bytes.1).unwrap().is_closed(),
+            "mux split: expected Closed terminal frame after Ack"
+        );
+
+        // Tear down the listener after asserting on the wire.
+        let _ = parts.duplex;
+        parts.cancel.cancel();
+        let _ = parts.join_handle.await;
+    }
+
+    /// [`DuplexClient::stop`] cancels the recv/send loop's
+    /// cancellation token, and [`DuplexClient::join`] waits for the
+    /// spawned task to finish. The `select!`s observe cancel and the
+    /// loop exits via the flush + `Closed` + break path. Verifies the
+    /// cumulative ack and the terminal `Closed` are written on
     /// `ACCEPTOR_TO_INITIATOR` before the spawned task ends.
     #[async_timed_test(timeout_secs = 30)]
-    async fn duplex_client_join_flushes_pending_ack() {
+    async fn duplex_client_stop_then_join_flushes_pending_ack() {
         let config = hyperactor_config::global::lock();
         let _g_msg = config.override_key(config::MESSAGE_ACK_EVERY_N_MESSAGES, 1_000_000);
         let _g_time =
@@ -4724,11 +5273,10 @@ mod tests {
             }
         }
 
-        // Trigger graceful shutdown via the structured-concurrency
-        // join handle. Cancel propagates into the spawn loop's
-        // `select!`s; the loop exits via Cancelled (terminal) and
-        // the flush logic writes the cumulative ack and the
-        // `Closed` terminal frame before the task ends.
+        // Trigger graceful shutdown. `stop` propagates cancellation
+        // into the spawn loop's `select!`s; `join` waits until the
+        // loop exits via Cancelled (terminal) and the flush logic
+        // writes the cumulative ack and the `Closed` terminal frame.
         dial_client.join().await;
 
         let bytes = tokio::time::timeout(Duration::from_millis(100), reader.next())
@@ -4764,12 +5312,13 @@ mod tests {
 
     /// Verifies that an in-progress [`DuplexRx::recv`] on the
     /// receiver returned by [`DuplexClient::take_rx`] resolves with
-    /// [`ChannelError::Closed`] when [`DuplexClient::join`] is
-    /// called concurrently. Structured concurrency guarantees the
-    /// spawned task drops `inbound_tx` before `join` returns, so
-    /// the receiver observes the close deterministically.
+    /// [`ChannelError::Closed`] when [`DuplexClient::stop`] is called
+    /// and [`DuplexClient::join`] waits concurrently. Structured
+    /// concurrency guarantees the spawned task drops `inbound_tx`
+    /// before `join` returns, so the receiver observes the close
+    /// deterministically.
     #[async_timed_test(timeout_secs = 30)]
-    async fn duplex_client_join_terminates_in_progress_recv() {
+    async fn duplex_client_stop_then_join_terminates_in_progress_recv() {
         let session_id = SessionId(123);
         let (client_side, server_side) = tokio::io::duplex(8192);
         let (mut test_r, _test_w) = tokio::io::split(server_side);
@@ -4788,8 +5337,8 @@ mod tests {
 
         // Park a recv() in a separate task; the dial-side hasn't
         // forwarded any inbound frames so this future will sit in
-        // `inbound_rx.recv().await` indefinitely until `join`
-        // drops the spawned task's `inbound_tx`.
+        // `inbound_rx.recv().await` indefinitely until stop/join
+        // makes the spawned task drop its `inbound_tx`.
         let recv_handle: tokio::task::JoinHandle<Result<u64, ChannelError>> =
             tokio::spawn(async move { dial_rx.recv().await });
 

--- a/hyperactor/src/channel/net/duplex.rs
+++ b/hyperactor/src/channel/net/duplex.rs
@@ -14,14 +14,15 @@
 //! ## Wire protocol
 //!
 //! Each connection starts with a unified `LinkInit` header (13 bytes,
-//! unframed) containing only the `session_id`:
+//! unframed) carrying the protocol kind, session id, and stream id:
 //!
 //! ```text
-//! [magic: 4B "LNK\0"] [session_id: 8B u64 BE]
+//! [magic: 4B ("SMP\0" | "DPX\0")] [session_id: 8B u64 BE] [stream_id: 1B u8]
 //! ```
 //!
-//! After the init, the standard tagged frame format is used. The tag
-//! byte in the 8-byte header distinguishes logical channels:
+//! Duplex servers expect `DPX\0`; mismatched magics are rejected at
+//! handshake. After the init, the standard tagged frame format is used.
+//! The tag byte in the 8-byte header distinguishes logical channels:
 //!
 //! - `INITIATOR_TO_ACCEPTOR = 0x00`
 //! - `ACCEPTOR_TO_INITIATOR = 0x01`
@@ -44,6 +45,7 @@ use super::LinkStatus;
 use super::ServerError;
 use super::SessionId;
 use super::log_send_error;
+#[cfg(test)]
 use super::read_link_init;
 use super::server::AcceptorLink;
 use super::server::ServerHandle;
@@ -53,7 +55,6 @@ use super::session::Session;
 use crate::RemoteMessage;
 use crate::channel::ChannelAddr;
 use crate::channel::ChannelError;
-use crate::channel::ChannelTransport;
 use crate::channel::CloseReason;
 use crate::channel::Rx;
 use crate::channel::SendError;
@@ -61,8 +62,6 @@ use crate::channel::SendErrorReason;
 use crate::channel::Tx;
 use crate::channel::TxStatus;
 use crate::channel::net::Stream;
-use crate::channel::net::meta;
-use crate::channel::net::tls;
 use crate::metrics;
 
 /// Public duplex server that yields `(DuplexRx<In>, DuplexTx<Out>)` pairs.
@@ -83,6 +82,16 @@ impl<In: RemoteMessage, Out: RemoteMessage> DuplexServer<In, Out> {
         &self.addr
     }
 
+    /// Signal the duplex server to stop accepting new connections and
+    /// tear down its listener. Returns immediately; await
+    /// [`join`](Self::join) to confirm shutdown has completed. Forwards
+    /// to the underlying [`ServerHandle::stop`]; `join` also stops the
+    /// handle, so an explicit `stop` is only needed to signal teardown
+    /// without (yet) awaiting it.
+    pub fn stop(&self, reason: &str) {
+        self.handle.stop(reason);
+    }
+
     /// Gracefully shut down the duplex server. Cancels the listener
     /// and awaits its task; structured concurrency in
     /// [`dispatch_duplex_stream`] guarantees every in-flight session
@@ -94,6 +103,21 @@ impl<In: RemoteMessage, Out: RemoteMessage> DuplexServer<In, Out> {
             self.addr
         ));
         let _ = (&mut self.handle).await;
+    }
+
+    /// Build a [`DuplexServer`] from an accept channel, server handle,
+    /// and bind address. Used by the muxed-listener path where the
+    /// accept queue is driven by a shared accept loop.
+    pub(super) fn from_parts(
+        accept_rx: mpsc::Receiver<(DuplexRx<In>, DuplexTx<Out>)>,
+        handle: ServerHandle,
+        addr: ChannelAddr,
+    ) -> Self {
+        Self {
+            accept_rx,
+            handle,
+            addr,
+        }
     }
 }
 
@@ -262,33 +286,21 @@ pub fn serve<In: RemoteMessage, Out: RemoteMessage>(
     let cancel_token = CancellationToken::new();
     let child_token = cancel_token.child_token();
 
-    let is_tls = matches!(
-        channel_addr.transport(),
-        ChannelTransport::Tls | ChannelTransport::MetaTls(_)
-    );
-    let dest = channel_addr.clone();
-    let prepare = move |stream: Box<dyn Stream>, source: ChannelAddr| {
-        let dest = dest.clone();
-        async move {
-            if is_tls {
-                let tls_acceptor = match dest.transport() {
-                    ChannelTransport::Tls => tls::tls_acceptor()?,
-                    _ => meta::tls_acceptor(true)?,
-                };
-                let mut tls_stream = tls_acceptor.accept(stream).await?;
-                let link_init = read_link_init(&mut tls_stream)
-                    .await
-                    .map_err(|e| anyhow::anyhow!("LinkInit read failed from {}: {}", source, e))?;
-                Ok((link_init, Box::new(tls_stream) as Box<dyn Stream>))
-            } else {
-                let mut stream = stream;
-                let link_init = read_link_init(&mut stream)
-                    .await
-                    .map_err(|e| anyhow::anyhow!("LinkInit read failed from {}: {}", source, e))?;
-                Ok((link_init, stream))
-            }
-        }
+    // A duplex server only enforces the duplex protocol kind when a mux
+    // could be demultiplexing simplex traffic off the same address — i.e.
+    // on net (kernel-socket) transports, where `serve_mux` dispatches
+    // simplex and duplex separately and a plain duplex endpoint should
+    // reject stray simplex dials. The in-process `Local` transport has no
+    // mux, yet gateways still route to Local duplex endpoints via simplex
+    // `channel::dial` (e.g. an in-process host's frontend). Accept either
+    // kind there, matching the pre-link-layer behavior; the dispatch reads
+    // sessions by `session_id`, not by kind.
+    let expected_kind = if channel_addr.transport().is_net() {
+        Some(super::ProtocolKind::Duplex)
+    } else {
+        None
     };
+    let prepare = super::preparer_for(channel_addr.clone(), expected_kind);
 
     let sessions: Arc<DashMap<SessionId, mpsc::UnboundedSender<Box<dyn Stream>>>> =
         Arc::new(DashMap::new());
@@ -356,6 +368,13 @@ where
         let link_init = read_link_init(&mut boxed)
             .await
             .map_err(|e| anyhow::anyhow!("LinkInit read failed from {}: {}", source, e))?;
+        if link_init.kind != super::ProtocolKind::Duplex {
+            return Err(anyhow::anyhow!(
+                "duplex server received {:?} client from {}",
+                link_init.kind,
+                source
+            ));
+        }
         Ok((link_init, boxed))
     };
 
@@ -417,7 +436,7 @@ enum Either {
 /// finishes only after every recv/send loop has finished — same
 /// contract as the simplex [`dispatch_stream`](super::server::dispatch_stream).
 #[tracing::instrument(level = "debug", skip_all)]
-async fn dispatch_duplex_stream<In: RemoteMessage, Out: RemoteMessage>(
+pub(super) async fn dispatch_duplex_stream<In: RemoteMessage, Out: RemoteMessage>(
     session_id: SessionId,
     stream: Box<dyn Stream>,
     sessions: Arc<DashMap<SessionId, mpsc::UnboundedSender<Box<dyn Stream>>>>,
@@ -620,7 +639,7 @@ async fn dispatch_duplex_stream<In: RemoteMessage, Out: RemoteMessage>(
 /// Returns a [`DuplexClient`] wrapping the send/recv halves and the
 /// spawned recv/send task; the client owns a cancellation token so
 /// callers can deterministically tear the session down via
-/// [`DuplexClient::join`].
+/// [`DuplexClient::stop`] followed by [`DuplexClient::join`].
 #[tracing::instrument(level = "debug", skip_all)]
 pub(crate) fn spawn<Out: RemoteMessage, In: RemoteMessage>(
     link: impl Link,
@@ -653,9 +672,9 @@ pub(crate) fn spawn<Out: RemoteMessage, In: RemoteMessage>(
         let mut link_status = LinkStatus::NeverConnected;
 
         loop {
-            // Race connect against cancel so a `DuplexClient::join`
-            // call mid-dial doesn't have to wait for the dial
-            // backoff to elapse.
+            // Race connect against cancel so a `DuplexClient::stop`
+            // call mid-dial doesn't have to wait for the dial backoff
+            // to elapse.
             let connected = tokio::select! {
                 result = session.connect() => match result {
                     Ok(s) => s,
@@ -847,13 +866,18 @@ pub(crate) fn spawn<Out: RemoteMessage, In: RemoteMessage>(
 /// Connect to a duplex server. Returns a [`DuplexClient`] wrapping
 /// the send/recv halves and the spawned recv/send task; callers use
 /// [`DuplexClient::tx`] / [`DuplexClient::take_rx`] to extract the
-/// halves and [`DuplexClient::join`] to deterministically shut the
-/// session down.
+/// halves and [`DuplexClient::stop`] followed by [`DuplexClient::join`]
+/// to deterministically shut the session down.
 pub fn dial<Out: RemoteMessage, In: RemoteMessage>(
     addr: ChannelAddr,
 ) -> Result<DuplexClient<Out, In>, ClientError> {
     let addr = addr.into_dial_addr();
-    Ok(spawn(super::link(addr, super::SessionId::random(), 0)?))
+    Ok(spawn(super::link(
+        addr,
+        super::SessionId::random(),
+        0,
+        super::ProtocolKind::Duplex,
+    )?))
 }
 
 #[cfg(test)]

--- a/hyperactor/src/channel/net/mux.rs
+++ b/hyperactor/src/channel/net/mux.rs
@@ -1,0 +1,671 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+//! A single listener that accepts both simplex and duplex clients on
+//! the same address. Incoming connections are demultiplexed by the
+//! [`ProtocolKind`] byte in the `LinkInit` header; simplex sessions
+//! feed a [`ChannelRx<M>`], duplex sessions feed a [`DuplexServer<In, Out>`].
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use dashmap::DashMap;
+use tokio::sync::mpsc;
+use tokio::sync::watch;
+use tokio::task::JoinHandle;
+use tokio_util::sync::CancellationToken;
+
+use super::ChannelAddr;
+use super::ProtocolKind;
+use super::ServerError;
+use super::ServerHandle;
+use super::SessionId;
+use super::Stream;
+use super::duplex::DuplexServer;
+use super::duplex::dispatch_duplex_stream;
+use super::server::StreamState;
+use super::server::accept_loop;
+use super::server::dispatch_stream;
+use super::server::resolve_stream;
+use crate::RemoteMessage;
+use crate::channel::ChannelRx;
+
+/// Parts produced by [`serve`]: the bound address, the per-kind halves,
+/// the accept-loop join handle, and the shared cancellation token.
+pub(crate) struct MuxServeParts<M, In, Out>
+where
+    M: RemoteMessage,
+    In: RemoteMessage,
+    Out: RemoteMessage,
+{
+    pub addr: ChannelAddr,
+    pub simplex: ChannelRx<M>,
+    pub duplex: DuplexServer<In, Out>,
+    pub join_handle: JoinHandle<Result<(), ServerError>>,
+    pub cancel: CancellationToken,
+}
+
+/// Start a muxed server on `addr`. The accept-loop's [`JoinHandle`] is
+/// returned alongside the per-kind halves and the shared cancellation
+/// token so callers can build a true awaitable shutdown handle on top
+/// — see [`MuxServer`](super::super::MuxServer) for the public
+/// wrapper.
+pub(crate) fn serve<M, In, Out>(
+    addr: ChannelAddr,
+    prebound_listener: Option<std::net::TcpListener>,
+) -> Result<MuxServeParts<M, In, Out>, ServerError>
+where
+    M: RemoteMessage,
+    In: RemoteMessage,
+    Out: RemoteMessage,
+{
+    let (listener, channel_addr) = super::listen_with_prebound(addr, prebound_listener)?;
+    // None: the muxed listener accepts both kinds and dispatches by
+    // `link_init.kind` after the header is read.
+    let prepare = super::preparer_for(channel_addr.clone(), None);
+    serve_with_prepare(listener, channel_addr, prepare)
+}
+
+/// Shared implementation for the muxed listener. Wires up the
+/// per-kind state, the dispatch closure, the accept loop, and the
+/// drain-aware coordinator that exposes `drained` to the per-half
+/// handles. Production [`serve`] passes a [`super::preparer_for`]
+/// closure; tests pass an inline prepare closure that boxes
+/// in-memory streams (see [`serve_with_listener`]).
+fn serve_with_prepare<M, In, Out, L, F, Fut>(
+    mut listener: L,
+    channel_addr: ChannelAddr,
+    prepare: F,
+) -> Result<MuxServeParts<M, In, Out>, ServerError>
+where
+    M: RemoteMessage,
+    In: RemoteMessage,
+    Out: RemoteMessage,
+    L: super::Listener + 'static,
+    F: Fn(L::Stream, ChannelAddr) -> Fut + Clone + Send + 'static,
+    Fut: std::future::Future<Output = Result<(super::LinkInit, Box<dyn Stream>), anyhow::Error>>
+        + Send
+        + 'static,
+{
+    let (simplex_tx, simplex_rx) = mpsc::channel::<M>(1024);
+    let (duplex_accept_tx, duplex_accept_rx) = mpsc::channel(16);
+
+    let simplex_sessions: Arc<DashMap<SessionId, mpsc::UnboundedSender<Box<dyn Stream>>>> =
+        Arc::new(DashMap::new());
+    let simplex_stream_state: Arc<
+        std::sync::Mutex<HashMap<SessionId, Arc<StreamState<Box<dyn Stream>>>>>,
+    > = Arc::new(std::sync::Mutex::new(HashMap::new()));
+    let duplex_sessions: Arc<DashMap<SessionId, mpsc::UnboundedSender<Box<dyn Stream>>>> =
+        Arc::new(DashMap::new());
+
+    // Accept-loop cancel. Cloned into both halves' `ServerHandle`s
+    // and returned to the caller so dropping any of the parts (or the
+    // returned token) tears down the shared listener.
+    let cancel_token = CancellationToken::new();
+    let child_token = cancel_token.child_token();
+
+    // Per-session cancellation propagated into dispatched sessions.
+    // These are children of `cancel_token` so cancelling the parent
+    // immediately propagates to in-flight sessions; without that, the
+    // accept loop's `connections.join_next()` drain would block on
+    // session tasks whose cancel tokens never fire, and shutdown would
+    // hang. Mirrors the simplex (`server::serve`) and duplex
+    // (`duplex::serve`) shapes, which also derive the dispatch cancel
+    // from the listener's parent token.
+    let simplex_child_cancel = cancel_token.child_token();
+    let duplex_child_cancel = cancel_token.child_token();
+
+    let dispatch = {
+        let simplex_tx = simplex_tx.clone();
+        let simplex_sessions = Arc::clone(&simplex_sessions);
+        let simplex_stream_state = Arc::clone(&simplex_stream_state);
+        let duplex_sessions = Arc::clone(&duplex_sessions);
+        let duplex_accept_tx = duplex_accept_tx.clone();
+        let simplex_cancel = simplex_child_cancel.clone();
+        let duplex_cancel = duplex_child_cancel.clone();
+        let dest = channel_addr.clone();
+        move |link_init: super::LinkInit, stream: Box<dyn Stream>| {
+            let simplex_tx = simplex_tx.clone();
+            let simplex_sessions = Arc::clone(&simplex_sessions);
+            let simplex_stream_state = Arc::clone(&simplex_stream_state);
+            let duplex_sessions = Arc::clone(&duplex_sessions);
+            let duplex_accept_tx = duplex_accept_tx.clone();
+            let s_cancel = simplex_cancel.child_token();
+            let d_cancel = duplex_cancel.child_token();
+            let dest = dest.clone();
+            async move {
+                match link_init.kind {
+                    ProtocolKind::Simplex => {
+                        let streams = resolve_stream(&simplex_stream_state, &link_init);
+                        dispatch_stream(
+                            link_init.session_id,
+                            streams,
+                            stream,
+                            &simplex_sessions,
+                            dest,
+                            simplex_tx,
+                            s_cancel,
+                        )
+                        .await;
+                    }
+                    ProtocolKind::Duplex => {
+                        dispatch_duplex_stream::<In, Out>(
+                            link_init.session_id,
+                            stream,
+                            duplex_sessions,
+                            dest,
+                            &duplex_accept_tx,
+                            d_cancel,
+                        )
+                        .await;
+                    }
+                }
+            }
+        }
+    };
+
+    let accept_ca = channel_addr.clone();
+    let cancel_after = cancel_token.clone();
+    // Real accept-loop task. Wrapped in a coordinator below that
+    // surfaces the listener's drain as a watch signal so the per-half
+    // `ServerHandle`s can honor `Rx::join`'s "all pending acks
+    // flushed" contract.
+    let inner_accept = tokio::spawn(async move {
+        let result = accept_loop(&mut listener, &accept_ca, &child_token, prepare, dispatch).await;
+        // If `accept_loop` returned for a reason other than parent
+        // cancellation (e.g., listener error), cancelling here cascades
+        // to the per-session children and tears any survivors down.
+        cancel_after.cancel();
+        result
+    });
+
+    // `drained_tx` flips to `true` once the accept loop has joined
+    // every per-session task — i.e., every dispatch's terminal cleanup
+    // (final ack flush + `Closed` emit) has finished. Per-half
+    // `ServerHandle::join` waits on this signal so `ChannelRx::join` and
+    // `DuplexServer::join` actually observe the drain rather than
+    // returning on bare cancellation.
+    let (drained_tx, drained_rx) = watch::channel(false);
+    let coord_addr = channel_addr.clone();
+    let join_handle = tokio::spawn(async move {
+        let result = match inner_accept.await {
+            Ok(r) => r,
+            Err(e) => Err(ServerError::Internal(coord_addr, anyhow::anyhow!(e))),
+        };
+        let _ = drained_tx.send(true);
+        result
+    });
+
+    // Each half gets a drain-aware `ServerHandle` whose `stop` cancels
+    // the shared listener and whose `await` resolves only after the
+    // accept loop has fully drained. Drop on either half also cancels
+    // (via [`ChannelRx::Drop`] / [`DuplexServer::Drop`]).
+    let simplex_handle = drain_aware_handle(
+        cancel_token.clone(),
+        drained_rx.clone(),
+        channel_addr.clone(),
+    );
+    let duplex_handle = drain_aware_handle(cancel_token.clone(), drained_rx, channel_addr.clone());
+
+    let net_rx = ChannelRx {
+        receiver: simplex_rx,
+        dest: channel_addr.clone(),
+        server: simplex_handle,
+    };
+    let duplex_server =
+        DuplexServer::from_parts(duplex_accept_rx, duplex_handle, channel_addr.clone());
+
+    Ok(MuxServeParts {
+        addr: channel_addr,
+        simplex: net_rx,
+        duplex: duplex_server,
+        join_handle,
+        cancel: cancel_token,
+    })
+}
+
+/// Build a [`ServerHandle`] for a muxed half. `stop` cancels the
+/// shared listener; `await` resolves only after both the cancel fires
+/// and the accept-loop coordinator has signaled `drained` — i.e.,
+/// every dispatch's terminal cleanup (final ack flush + `Closed` emit)
+/// has finished. This honors the [`Rx::join`](super::Rx::join)
+/// contract for [`ChannelRx`] and the equivalent contract for
+/// [`DuplexServer::join`](DuplexServer::join), neither of which would
+/// be satisfied by a bare cancel-only handle.
+fn drain_aware_handle(
+    cancel: CancellationToken,
+    drained: watch::Receiver<bool>,
+    addr: ChannelAddr,
+) -> ServerHandle {
+    let cancel_wait = cancel.clone();
+    let mut drained = drained;
+    let join = tokio::spawn(async move {
+        cancel_wait.cancelled().await;
+        let _ = drained.wait_for(|d| *d).await;
+        Ok::<(), ServerError>(())
+    });
+    ServerHandle::new(join, cancel, addr)
+}
+
+/// Test-only variant of [`serve`] that accepts an arbitrary `Listener`.
+/// Mirrors [`server::serve_with_listener`](super::server::serve_with_listener)
+/// and [`duplex::serve_with_listener`](super::duplex::serve_with_listener):
+/// used by mock-link tests that drive the mux through in-memory
+/// `DuplexStream`s instead of going through `net::listen_with_prebound`.
+///
+/// The returned [`MuxServeParts`] expose the same shape as production
+/// `serve`, including drain-aware per-half handles and the coordinator's
+/// drained-watch signal — so wire-level tests can exercise the
+/// `Rx::join` ack-flush contract and the shutdown ordering.
+#[cfg(test)]
+pub(super) fn serve_with_listener<M, In, Out, L>(
+    listener: L,
+    channel_addr: ChannelAddr,
+) -> Result<MuxServeParts<M, In, Out>, ServerError>
+where
+    M: RemoteMessage,
+    In: RemoteMessage,
+    Out: RemoteMessage,
+    L: super::Listener + 'static,
+    L::Stream: Unpin + std::fmt::Debug + 'static,
+{
+    // Box the test stream and read the LinkInit; mirrors production
+    // `preparer_for(_, None)` but without the TLS branches that
+    // `preparer_for` carries for real transports.
+    let prepare = |stream: L::Stream, source: ChannelAddr| async move {
+        let mut boxed: Box<dyn Stream> = Box::new(stream);
+        let link_init = super::read_link_init(&mut boxed)
+            .await
+            .map_err(|e| anyhow::anyhow!("LinkInit read failed from {}: {}", source, e))?;
+        Ok((link_init, boxed))
+    };
+    serve_with_prepare(listener, channel_addr, prepare)
+}
+
+#[cfg(test)]
+mod tests {
+    use timed_test::async_timed_test;
+
+    use crate::channel;
+    use crate::channel::ChannelAddr;
+    use crate::channel::ChannelTransport;
+    use crate::channel::Rx;
+    use crate::channel::Tx;
+
+    /// A simplex client dialing a muxed listener delivers into the
+    /// frontend's simplex half.
+    #[async_timed_test(timeout_secs = 30)]
+    async fn test_mux_routes_simplex_to_net_rx() {
+        let mut frontend =
+            channel::serve_mux::<u64, u64, u64>(ChannelAddr::any(ChannelTransport::Unix), None)
+                .unwrap();
+
+        let tx = channel::dial::<u64>(frontend.addr().clone()).unwrap();
+        tx.post(42);
+
+        let received = tokio::time::timeout(Duration::from_secs(5), frontend.simplex_mut().recv())
+            .await
+            .expect("simplex recv timed out")
+            .expect("simplex recv failed");
+        assert_eq!(received, 42);
+    }
+
+    /// A duplex client dialing a muxed listener pops out of the
+    /// frontend's duplex half and round-trips messages on both halves
+    /// of the link.
+    #[async_timed_test(timeout_secs = 30)]
+    async fn test_mux_routes_duplex_to_duplex_server() {
+        let mut frontend =
+            channel::serve_mux::<u64, u64, String>(ChannelAddr::any(ChannelTransport::Unix), None)
+                .unwrap();
+
+        // Client side: dials as duplex.
+        let mut client = channel::duplex::dial::<u64, String>(frontend.addr().clone()).unwrap();
+        let client_tx = client.tx();
+        let mut client_rx = client.take_rx().unwrap();
+
+        // Server side: accept the new session.
+        let (mut server_rx, server_tx) =
+            tokio::time::timeout(Duration::from_secs(5), frontend.duplex_mut().accept())
+                .await
+                .expect("accept timed out")
+                .expect("accept failed");
+
+        // Client → server.
+        client_tx.post(7);
+        let got = tokio::time::timeout(Duration::from_secs(5), server_rx.recv())
+            .await
+            .expect("server recv timed out")
+            .expect("server recv failed");
+        assert_eq!(got, 7);
+
+        // Server → client.
+        server_tx.post("hello".to_string());
+        let got = tokio::time::timeout(Duration::from_secs(5), client_rx.recv())
+            .await
+            .expect("client recv timed out")
+            .expect("client recv failed");
+        assert_eq!(got, "hello");
+    }
+
+    /// A muxed listener handles concurrent simplex and duplex traffic
+    /// on the same address, with each kind dispatched to the correct
+    /// half by [`ProtocolKind`].
+    #[async_timed_test(timeout_secs = 30)]
+    async fn test_mux_simplex_and_duplex_share_address() {
+        let mut frontend =
+            channel::serve_mux::<u64, u64, u64>(ChannelAddr::any(ChannelTransport::Unix), None)
+                .unwrap();
+
+        let simplex_tx = channel::dial::<u64>(frontend.addr().clone()).unwrap();
+        simplex_tx.post(1);
+
+        let mut duplex_client = channel::duplex::dial::<u64, u64>(frontend.addr().clone()).unwrap();
+        let duplex_tx = duplex_client.tx();
+        let _duplex_rx = duplex_client.take_rx().unwrap();
+        duplex_tx.post(2);
+
+        let from_simplex =
+            tokio::time::timeout(Duration::from_secs(5), frontend.simplex_mut().recv())
+                .await
+                .expect("simplex recv timed out")
+                .expect("simplex recv failed");
+        assert_eq!(from_simplex, 1);
+
+        let (mut server_rx, _server_tx) =
+            tokio::time::timeout(Duration::from_secs(5), frontend.duplex_mut().accept())
+                .await
+                .expect("duplex accept timed out")
+                .expect("duplex accept failed");
+        let from_duplex = tokio::time::timeout(Duration::from_secs(5), server_rx.recv())
+            .await
+            .expect("duplex recv timed out")
+            .expect("duplex recv failed");
+        assert_eq!(from_duplex, 2);
+    }
+
+    /// Splitting a [`MuxServer`] hands out the parts; dropping the
+    /// returned [`MuxShutdown`] cancels the shared listener and
+    /// terminates the simplex half's `recv`.
+    #[async_timed_test(timeout_secs = 30)]
+    async fn test_mux_split_shutdown_drops_listener() {
+        let frontend =
+            channel::serve_mux::<u64, u64, u64>(ChannelAddr::any(ChannelTransport::Unix), None)
+                .unwrap();
+        let (_addr, mut simplex, _duplex, shutdown) = frontend.split();
+
+        // Drop the shutdown guard; the simplex receiver should observe
+        // a closed channel rather than hang forever.
+        drop(shutdown);
+
+        let result = tokio::time::timeout(Duration::from_secs(5), simplex.recv()).await;
+        assert!(
+            matches!(result, Ok(Err(_))),
+            "simplex recv should fail with channel closed after shutdown",
+        );
+    }
+
+    /// Mismatched protocols are rejected at the (non-muxed) sibling
+    /// servers: a duplex client dialing a simplex-only [`channel::serve`]
+    /// fails (and vice versa). The muxed listener accepts both; this
+    /// guards the per-kind enforcement that the mux design relies on.
+    #[async_timed_test(timeout_secs = 30)]
+    async fn test_mismatched_protocol_kinds_are_rejected() {
+        // Simplex server, duplex client — should not produce a usable session.
+        let (simplex_addr, _simplex_rx) =
+            channel::serve::<u64>(ChannelAddr::any(ChannelTransport::Unix)).unwrap();
+        let mut duplex_client = channel::duplex::dial::<u64, u64>(simplex_addr).unwrap();
+        let duplex_tx = duplex_client.tx();
+        let mut duplex_rx = duplex_client.take_rx().unwrap();
+        duplex_tx.post(99);
+        let result = tokio::time::timeout(Duration::from_secs(2), duplex_rx.recv()).await;
+        assert!(
+            !matches!(result, Ok(Ok(_))),
+            "duplex dial against simplex server should not deliver",
+        );
+
+        // Duplex server, simplex client — same shape.
+        let mut duplex_server =
+            channel::net::duplex::serve::<u64, u64>(ChannelAddr::any(ChannelTransport::Unix), None)
+                .unwrap();
+        let duplex_addr = duplex_server.addr().clone();
+        let simplex_tx = channel::dial::<u64>(duplex_addr).unwrap();
+        simplex_tx.post(99);
+        let result = tokio::time::timeout(Duration::from_secs(2), duplex_server.accept()).await;
+        assert!(
+            !matches!(result, Ok(Ok(_))),
+            "simplex dial against duplex server should not produce an accepted session",
+        );
+    }
+
+    /// Regression test for the shutdown deadlock: with simplex and
+    /// duplex sessions actively dispatched (their per-connection tasks
+    /// blocked in `tokio::select!` on the session cancel), calling
+    /// [`MuxShutdown::stop`] must propagate cancellation through the
+    /// per-session children so the accept loop's `connections`
+    /// drain completes and the listener task exits promptly.
+    ///
+    /// If the per-session cancel tokens were independent of
+    /// `cancel_token`, the accept loop would wait on connections that
+    /// are themselves waiting on tokens that never fire — an unbounded
+    /// hang.
+    #[async_timed_test(timeout_secs = 30)]
+    async fn test_mux_shutdown_completes_with_active_sessions() {
+        let mut frontend =
+            channel::serve_mux::<u64, u64, u64>(ChannelAddr::any(ChannelTransport::Unix), None)
+                .unwrap();
+        let addr = frontend.addr().clone();
+
+        // Open both kinds of sessions and route at least one message
+        // through each so the dispatch tasks are spawned and parked on
+        // their session cancels.
+        let simplex_tx = channel::dial::<u64>(addr.clone()).unwrap();
+        simplex_tx.post(1);
+        let mut duplex_client = channel::duplex::dial::<u64, u64>(addr).unwrap();
+        let duplex_tx = duplex_client.tx();
+        let _duplex_rx = duplex_client.take_rx().unwrap();
+        duplex_tx.post(2);
+
+        tokio::time::timeout(Duration::from_secs(5), frontend.simplex_mut().recv())
+            .await
+            .expect("simplex recv timed out")
+            .expect("simplex recv failed");
+        let (_server_rx, _server_tx) =
+            tokio::time::timeout(Duration::from_secs(5), frontend.duplex_mut().accept())
+                .await
+                .expect("duplex accept timed out")
+                .expect("duplex accept failed");
+
+        // Hold the client tx ends across shutdown so the server-side
+        // dispatch tasks remain blocked on their cancel branches —
+        // without the deadlock fix, the listener cannot drain.
+        let (_addr, _simplex, _duplex, shutdown) = frontend.split();
+        shutdown.stop("test shutdown");
+        let result = tokio::time::timeout(Duration::from_secs(5), shutdown).await;
+        assert!(
+            result.is_ok(),
+            "muxed listener shutdown hung with active sessions",
+        );
+
+        drop(simplex_tx);
+        drop(duplex_tx);
+    }
+
+    /// After [`MuxServer::split`], dropping the simplex half cancels
+    /// the shared shutdown via `ChannelRx`'s `Drop` impl, which calls
+    /// `ServerHandle::stop` on the cloned cancel token. The shutdown
+    /// handle then completes promptly.
+    #[async_timed_test(timeout_secs = 30)]
+    async fn test_mux_drop_simplex_cancels_shutdown() {
+        let frontend =
+            channel::serve_mux::<u64, u64, u64>(ChannelAddr::any(ChannelTransport::Unix), None)
+                .unwrap();
+        let (_addr, simplex, _duplex, shutdown) = frontend.split();
+
+        drop(simplex);
+
+        let result = tokio::time::timeout(Duration::from_secs(5), shutdown).await;
+        assert!(
+            result.is_ok(),
+            "shutdown should complete after dropping simplex half",
+        );
+    }
+
+    /// After [`MuxServer::split`], dropping the duplex half cancels
+    /// the shared shutdown via `DuplexServer`'s `Drop` impl, which
+    /// calls `handle.stop()` on the cloned cancel token. The shutdown
+    /// handle then completes promptly.
+    #[async_timed_test(timeout_secs = 30)]
+    async fn test_mux_drop_duplex_cancels_shutdown() {
+        let frontend =
+            channel::serve_mux::<u64, u64, u64>(ChannelAddr::any(ChannelTransport::Unix), None)
+                .unwrap();
+        let (_addr, _simplex, duplex, shutdown) = frontend.split();
+
+        drop(duplex);
+
+        let result = tokio::time::timeout(Duration::from_secs(5), shutdown).await;
+        assert!(
+            result.is_ok(),
+            "shutdown should complete after dropping duplex half",
+        );
+    }
+
+    /// After [`MuxServer::split`], dropping the address alone has no
+    /// effect on the listener — `ChannelAddr` is a plain value type
+    /// with no resource ownership. Both halves remain usable.
+    #[async_timed_test(timeout_secs = 30)]
+    async fn test_mux_drop_addr_alone_does_not_shut_down() {
+        let frontend =
+            channel::serve_mux::<u64, u64, u64>(ChannelAddr::any(ChannelTransport::Unix), None)
+                .unwrap();
+        let (addr, mut simplex, _duplex, shutdown) = frontend.split();
+
+        let dial_addr = addr.clone();
+        drop(addr);
+
+        // The listener should still accept simplex traffic.
+        let tx = channel::dial::<u64>(dial_addr).unwrap();
+        tx.post(123);
+        let received = tokio::time::timeout(Duration::from_secs(5), simplex.recv())
+            .await
+            .expect("simplex recv timed out")
+            .expect("simplex recv failed");
+        assert_eq!(received, 123);
+
+        // Tear down explicitly to confirm the shutdown still resolves.
+        shutdown.stop("test shutdown");
+        let result = tokio::time::timeout(Duration::from_secs(5), shutdown).await;
+        assert!(result.is_ok(), "shutdown should complete after stop");
+    }
+
+    /// Coverage gap from the AI review: the existing mux tests check
+    /// that shutdown completes, but did not assert that the duplex
+    /// peer actually observes a clean session close (driven by the
+    /// dispatch's terminal `Closed` frame) after the mux is stopped.
+    /// This complements the deeper wire-level ack/Closed test in
+    /// `channel/net.rs`'s frame-flush suite, which would need a
+    /// `mux::serve_with_listener` test helper to exercise; here we
+    /// pin the public-API contract that survives the shutdown
+    /// reorder.
+    #[async_timed_test(timeout_secs = 30)]
+    async fn test_mux_shutdown_signals_clean_close_to_duplex_peer() {
+        use crate::mailbox::MailboxServerError;
+        use crate::mailbox::MailboxServerHandle;
+
+        async fn wait_for_stop(mut stopped_rx: tokio::sync::watch::Receiver<bool>) {
+            let ok = stopped_rx.wait_for(|stopped| *stopped).await.is_ok();
+            if !ok {
+                std::future::pending::<()>().await;
+            }
+        }
+
+        fn passthrough_mailbox_handle(mut rx: channel::ChannelRx<u64>) -> MailboxServerHandle {
+            let (stopped_tx, mut stopped_rx) = tokio::sync::watch::channel(false);
+            let join_handle = tokio::spawn(async move {
+                loop {
+                    tokio::select! {
+                        result = rx.recv() => {
+                            if result.is_err() { break; }
+                        }
+                        _ = stopped_rx.changed() => {
+                            if *stopped_rx.borrow() { break; }
+                        }
+                    }
+                }
+                Ok::<(), MailboxServerError>(())
+            });
+            MailboxServerHandle::from_parts(join_handle, stopped_tx)
+        }
+
+        let frontend =
+            channel::serve_mux::<u64, u64, u64>(ChannelAddr::any(ChannelTransport::Unix), None)
+                .unwrap();
+        let addr = frontend.addr().clone();
+
+        let mut client = channel::duplex::dial::<u64, u64>(addr).unwrap();
+        let client_tx = client.tx();
+        let mut client_rx = client.take_rx().unwrap();
+
+        let (accepted_tx, accepted_rx) = tokio::sync::oneshot::channel();
+        let (delivered_tx, delivered_rx) = tokio::sync::oneshot::channel();
+
+        let mut accepted_tx = Some(accepted_tx);
+        let mut delivered_tx = Some(delivered_tx);
+        let handle = frontend.serve(
+            passthrough_mailbox_handle,
+            move |mut duplex_server, stop_rx| async move {
+                let (mut server_rx, _server_tx) = duplex_server.accept().await.unwrap();
+                accepted_tx.take().unwrap().send(()).unwrap();
+
+                // Drain inbound messages until stop fires; this proves
+                // the recv-side path was active up to the shutdown
+                // point so any Closed frame is the result of the
+                // shutdown drain, not a starved session.
+                tokio::select! {
+                    _ = wait_for_stop(stop_rx) => {}
+                    msg = server_rx.recv() => {
+                        let _ = msg;
+                        delivered_tx.take().unwrap().send(()).unwrap();
+                    }
+                }
+
+                duplex_server.stop("test mux clean close");
+                duplex_server.join().await;
+            },
+        );
+
+        accepted_rx.await.unwrap();
+
+        // Drive at least one message through so the session is live.
+        client_tx.post(7);
+        tokio::time::timeout(Duration::from_secs(5), delivered_rx)
+            .await
+            .expect("server did not see inbound message before stop")
+            .unwrap();
+
+        handle.stop("test mux clean close");
+        tokio::time::timeout(Duration::from_secs(5), handle)
+            .await
+            .expect("mux handle did not stop")
+            .expect("mux task panicked")
+            .expect("mux task failed");
+
+        // After the mux fully stops, the duplex peer's recv side must
+        // observe a terminal close (`ChannelError::Closed`) rather
+        // than hang. This is the application-visible consequence of
+        // the dispatch's terminal `Closed` frame being delivered
+        // during shutdown drain.
+        let result = tokio::time::timeout(Duration::from_secs(5), client_rx.recv()).await;
+        assert!(
+            matches!(result, Ok(Err(_))),
+            "client_rx should observe a terminal close after mux shutdown, got {:?}",
+            result,
+        );
+    }
+}

--- a/hyperactor/src/channel/net/quic.rs
+++ b/hyperactor/src/channel/net/quic.rs
@@ -90,6 +90,7 @@ pub(crate) struct QuicLink {
     addr_type: QuicAddrType,
     session_id: SessionId,
     stream_id: u8,
+    kind: ProtocolKind,
 }
 
 impl std::fmt::Debug for QuicLink {
@@ -146,7 +147,7 @@ impl Link for QuicLink {
                 Ok(connecting) => match connecting.await {
                     Ok(connection) => match connection.open_bi().await {
                         Ok((mut send, recv)) => {
-                            write_link_init(&mut send, self.session_id, self.stream_id)
+                            write_link_init(&mut send, self.session_id, self.stream_id, self.kind)
                                 .await
                                 .map_err(|err| ClientError::Io(self.dest(), err))?;
                             return Ok(QuicStream::new(send, recv));
@@ -240,6 +241,7 @@ pub(crate) fn link(
     addr_type: QuicAddrType,
     session_id: SessionId,
     stream_id: u8,
+    kind: ProtocolKind,
 ) -> Result<QuicLink, ClientError> {
     let client_config = client_config(addr_type).map_err(|e| {
         ClientError::Connect(
@@ -256,6 +258,7 @@ pub(crate) fn link(
         addr_type,
         session_id,
         stream_id,
+        kind,
     })
 }
 

--- a/hyperactor/src/channel/net/server.rs
+++ b/hyperactor/src/channel/net/server.rs
@@ -26,6 +26,7 @@ use tokio_util::sync::CancellationToken;
 use super::ClientError;
 use super::Link;
 use super::SessionId;
+#[cfg(test)]
 use super::read_link_init;
 use super::session;
 use super::session::Next;
@@ -33,11 +34,8 @@ use super::session::Session;
 use crate::RemoteMessage;
 use crate::channel::ChannelAddr;
 use crate::channel::ChannelRx;
-use crate::channel::ChannelTransport;
 use crate::channel::net::ServerError;
 use crate::channel::net::Stream;
-use crate::channel::net::meta;
-use crate::channel::net::tls;
 use crate::config;
 use crate::metrics;
 
@@ -126,7 +124,7 @@ impl<S: Stream> StreamState<S> {
 /// If `link_init` is for a multi-stream connection (`stream_id > 0`),
 /// resolve (or create) the shared per-session state and return
 /// `Some((stream_id, state))`. Otherwise return `None`.
-fn resolve_stream<S: Stream>(
+pub(super) fn resolve_stream<S: Stream>(
     stream_state: &std::sync::Mutex<HashMap<SessionId, Arc<StreamState<S>>>>,
     link_init: &super::LinkInit,
 ) -> Option<(u8, Arc<StreamState<S>>)> {
@@ -481,7 +479,7 @@ pub(super) async fn accept_loop<S, L, F, Fut, D, DFut>(
     dispatch: D,
 ) -> Result<(), ServerError>
 where
-    S: Stream,
+    S: Send + 'static,
     L: super::Listener,
     F: Fn(L::Stream, ChannelAddr) -> Fut + Clone + Send + 'static,
     Fut: Future<Output = Result<(super::LinkInit, S), anyhow::Error>> + Send + 'static,
@@ -654,33 +652,7 @@ pub(in crate::channel) fn serve<M: RemoteMessage>(
     let cancel_token = CancellationToken::new();
     let child_token = cancel_token.child_token();
 
-    let is_tls = matches!(
-        channel_addr.transport(),
-        ChannelTransport::Tls | ChannelTransport::MetaTls(_)
-    );
-    let dest = channel_addr.clone();
-    let prepare = move |stream: Box<dyn Stream>, source: ChannelAddr| {
-        let dest = dest.clone();
-        async move {
-            if is_tls {
-                let tls_acceptor = match dest.transport() {
-                    ChannelTransport::Tls => tls::tls_acceptor()?,
-                    _ => meta::tls_acceptor(true)?,
-                };
-                let mut tls_stream = tls_acceptor.accept(stream).await?;
-                let link_init = read_link_init(&mut tls_stream)
-                    .await
-                    .map_err(|e| anyhow::anyhow!("LinkInit read failed from {}: {}", source, e))?;
-                Ok((link_init, Box::new(tls_stream) as Box<dyn Stream>))
-            } else {
-                let mut stream = stream;
-                let link_init = read_link_init(&mut stream)
-                    .await
-                    .map_err(|e| anyhow::anyhow!("LinkInit read failed from {}: {}", source, e))?;
-                Ok((link_init, stream))
-            }
-        }
-    };
+    let prepare = super::preparer_for(channel_addr.clone(), Some(super::ProtocolKind::Simplex));
 
     let sessions: Arc<DashMap<SessionId, mpsc::UnboundedSender<Box<dyn Stream>>>> =
         Arc::new(DashMap::new());
@@ -737,7 +709,7 @@ pub(in crate::channel) fn serve<M: RemoteMessage>(
 }
 
 /// Test-only variant that accepts an arbitrary `Listener`. Used by
-/// mock-link tests that cannot go through `net::listen()`.
+/// mock-link tests that cannot go through `net::listen_with_prebound`.
 #[cfg(test)]
 #[tracing::instrument(level = "debug", skip_all)]
 pub(super) fn serve_with_listener<M, L>(
@@ -757,6 +729,13 @@ where
         let link_init = read_link_init(&mut stream)
             .await
             .map_err(|e| anyhow::anyhow!("LinkInit read failed from {}: {}", source, e))?;
+        if link_init.kind != super::ProtocolKind::Simplex {
+            return Err(anyhow::anyhow!(
+                "simplex server received {:?} client from {}",
+                link_init.kind,
+                source
+            ));
+        }
         Ok((link_init, stream))
     };
 

--- a/hyperactor/src/gateway.rs
+++ b/hyperactor/src/gateway.rs
@@ -669,6 +669,20 @@ impl Gateway {
                 "serve_duplex requires a duplex-capable transport, but {addr} does not support duplex"
             )));
         }
+        // A gateway duplex endpoint doubles as a relay: peers attach over
+        // duplex (see `serve_via`), while a third party with no peer
+        // relationship reaches via-addressed refs by dialing the raw
+        // address with a plain *simplex* channel. Now that the link layer
+        // distinguishes the two protocols on the wire, a strict duplex
+        // server would reject those simplex dials. Serve net endpoints
+        // through the mux instead, so one address accepts both protocols:
+        // simplex posts are dispatched into the gateway, duplex attaches
+        // run the shared `AttachWire` accept loop. The in-process `Local`
+        // transport is not a kernel socket and cannot be muxed, so it
+        // keeps the plain duplex accept path.
+        if addr.transport().is_net() {
+            return self.serve_mux_with_listener(addr, listener);
+        }
         let server = PreboundAcceptServer::duplex(addr, listener)
             .map_err(|e| ChannelError::Other(anyhow::anyhow!("{e}")))?;
         Ok(self.serve_duplex_with_server(server))
@@ -705,6 +719,60 @@ impl Gateway {
                 cancel_token,
             },
         }
+    }
+
+    /// Serve this gateway on `addr` (optionally with a pre-bound TCP
+    /// listener) using a *muxed* listener: simplex clients (dialed via
+    /// [`channel::dial`]) and duplex attach clients (dialed via
+    /// [`channel::duplex::dial`]) share one address, demultiplexed at
+    /// the link layer by [`channel::serve_mux`].
+    ///
+    /// Simplex traffic is served straight into this gateway; duplex
+    /// connections run the *same* [`AttachWire`] accept path as
+    /// [`serve_duplex`](Self::serve_duplex) — i.e. there is a single
+    /// attach protocol regardless of whether a frontend is muxed or a
+    /// plain duplex endpoint. Requires a net transport (`serve_mux`
+    /// rejects non-net addresses).
+    ///
+    /// Like [`serve_with_listener`](Self::serve_with_listener), this
+    /// registers the bound address as an active serve location (so the
+    /// gateway delivers frontend-addressed traffic in-process and adopts
+    /// it as the default location).
+    pub fn serve_mux_with_listener(
+        &self,
+        addr: ChannelAddr,
+        listener: Option<std::net::TcpListener>,
+    ) -> Result<GatewayServeHandle, ChannelError> {
+        let mux =
+            channel::serve_mux::<MessageEnvelope, MessageEnvelope, AttachWire>(addr, listener)?;
+        let bound_addr = mux.addr().clone();
+        let simplex_gateway = self.clone();
+        let duplex_gateway = self.clone();
+        let duplex_addr = bound_addr.clone();
+        let raw = mux.serve(
+            move |rx| simplex_gateway.serve(rx),
+            move |duplex_server, mut stop_rx| async move {
+                // The mux signals shutdown through a watch channel, but
+                // `duplex_accept_loop` drains on a `CancellationToken`.
+                // Bridge the two: cancel only on an explicit stop, and
+                // pend (leaving the token uncancelled) if the watch
+                // sender is dropped without stopping, matching the
+                // detach-on-drop convention of the serve handles.
+                let cancel_token = CancellationToken::new();
+                let loop_token = cancel_token.clone();
+                tokio::spawn(async move {
+                    if stop_rx.wait_for(|stopped| *stopped).await.is_ok() {
+                        cancel_token.cancel();
+                    }
+                });
+                duplex_accept_loop(duplex_server, duplex_addr, duplex_gateway, loop_token).await;
+            },
+        );
+        Ok(GatewayServeHandle::from_mailbox_handle(
+            self.clone(),
+            bound_addr,
+            raw,
+        ))
     }
 
     /// Serve this gateway on `addr`, optionally using an already-bound
@@ -1006,6 +1074,23 @@ impl GatewayServeHandle {
         }
     }
 
+    /// Wrap an externally-produced [`MailboxServerHandle`] — e.g. a
+    /// host's muxed frontend accept loop driven outside the gateway —
+    /// as a gateway serve handle. Registers `addr` as an active serve
+    /// location (via [`add_server`](Gateway::add_server)) so the gateway
+    /// delivers traffic addressed to the frontend in-process instead of
+    /// dialing it, and advertises it as the default location — mirroring
+    /// [`Gateway::serve_with_listener`]. The active-serve entry is removed
+    /// when the handle is stopped.
+    pub fn from_mailbox_handle(
+        gateway: Gateway,
+        addr: ChannelAddr,
+        handle: MailboxServerHandle,
+    ) -> Self {
+        let serve_id = gateway.add_server(Location::from(addr));
+        Self::from_simplex(gateway, handle, Some(serve_id))
+    }
+
     /// Signal the underlying server to stop and run the flavor-specific
     /// cleanup: remove the active-serve entry for `Serve`, `ServeDuplex`,
     /// or `ServeVia`. Idempotent: later calls are no-ops. Call
@@ -1127,6 +1212,15 @@ async fn duplex_accept_loop(
     }
 
     while tasks.join_next().await.is_some() {}
+    // Tear down the server now that the accept loop has exited. The loop
+    // broke on its own `cancel_token`, which is distinct from the server's
+    // listener cancel, so we must signal the listener explicitly: `stop`
+    // cancels it (for a muxed frontend that is the shared listener, so it
+    // also closes the simplex half and lets simplex peers observe a clean
+    // `Closed`), then `join` awaits the teardown. Stopping before joining
+    // — rather than relying on `join` to cancel — keeps the teardown
+    // correct regardless of how the underlying handle implements `join`.
+    duplex_server.stop("duplex accept loop draining");
     duplex_server.join().await;
 }
 

--- a/hyperactor/src/proc.rs
+++ b/hyperactor/src/proc.rs
@@ -376,6 +376,7 @@ fn account_cancel_enqueue(queue_depth: &AtomicU64, proc_stats: &ProcQueueStats, 
         hyperactor_telemetry::kv_pairs!("actor_id" => actor_id.to_owned()),
     );
 }
+
 use crate::ordering::SEQ_INFO;
 use crate::ordering::SeqInfo;
 use crate::ordering::Sequencer;

--- a/hyperactor_mesh/src/host.rs
+++ b/hyperactor_mesh/src/host.rs
@@ -232,7 +232,22 @@ impl<M: ProcManager> Host<M> {
         let mut backend_handle = Gateway::serve(&gateway, ChannelAddr::any(manager.transport()))?;
         let backend_addr = gateway.default_location().addr().clone();
 
-        let mut frontend_handle = match gateway.serve_with_listener(addr, listener) {
+        // Serve the frontend. Kernel-socket (net) transports use a muxed
+        // listener so simplex clients and duplex attach clients share one
+        // address; the gateway owns both the simplex and (`AttachWire`)
+        // duplex accept paths, so there is a single attach protocol whether
+        // a frontend is muxed or a plain duplex endpoint. `serve_mux`
+        // requires a net transport, so we branch on `is_net()` rather than
+        // `supports_duplex()` (the in-process `Local` transport supports
+        // duplex but is not a kernel socket). Both paths register the bound
+        // address as the gateway's active serve location.
+        let frontend_result: Result<GatewayServeHandle, ChannelError> = if addr.transport().is_net()
+        {
+            gateway.serve_mux_with_listener(addr, listener)
+        } else {
+            gateway.serve_with_listener(addr, listener)
+        };
+        let mut frontend_handle = match frontend_result {
             Ok(handle) => handle,
             Err(error) => {
                 backend_handle.stop("host setup failed");


### PR DESCRIPTION
Summary:

Move the simplex/duplex distinction from a body-peek into the LinkInit header so the host can demultiplex at connection time, before any application payload is seen.

Wire change: LinkInit's 4-byte magic becomes `SMP\0` (simplex) or `DPX\0` (duplex). `write_link_init` and `read_link_init` carry a `ProtocolKind`. Per-transport Link impls stamp the kind on connect; simplex and duplex servers verify the kind and reject mismatched clients with a clear handshake error.

A new muxed listener (`channel::net::mux::serve`, exposed as `channel::serve_mux`) opens one listener and routes connections by kind: simplex clients deliver into a `ChannelRx<M>`; duplex clients populate a `DuplexServer<In, Out>`. Both halves share the listener's lifecycle.

`Host::new_with_gateway` serves net-transport frontends through `serve_mux` (`Gateway::serve_mux_with_listener`), and `Gateway::serve_duplex` does the same for any net duplex endpoint. The branch is on `is_net()`, not `supports_duplex()`: the in-process `Local` transport is duplex-capable but is not a kernel socket, so it keeps the plain duplex accept path. The attach protocol itself is unchanged — a peer still dials duplex, posts an `AttachRequest`, and receives an `AttachWire::Ack(AttachAck::Accepted { location })`, and muxed and plain-duplex frontends run the same `duplex_accept_loop`. What the mux buys is that one net address now serves both simplex posts and duplex attaches, so a strict-duplex frontend no longer rejects the simplex dials that gateways use to reach via-addressed refs.

### Public API

`MuxServer` is exposed in three shapes:

- `MuxServer::serve(simplex_handler, duplex_handler) -> MailboxServerHandle` mirrors `MailboxServer::serve`: spawn an outer task that drains in the order duplex pump → simplex pump → listener.
- The `MuxServer` value itself: hold it to `recv()` on the simplex half and `accept()` on the duplex half; drop it to tear down the listener.
- `MuxServer::split() -> (ChannelAddr, ChannelRx<M>, DuplexServer<In, Out>, MuxShutdown)` for low-level control. Dropping the simplex half, the duplex half, or the `MuxShutdown` guard cancels the shared shutdown. `MuxShutdown` is awaitable: `stop()` then `.await`.

### Shutdown contract

Per-session cancel tokens in `mux::serve` are children of the shared `cancel_token`, mirroring the simplex (`server::serve`) and duplex (`duplex::serve`) shapes. Cancelling the listener immediately propagates to in-flight sessions so the accept loop's connection drain completes and shutdown does not hang.

`MuxServer::serve` awaits the duplex handler before stopping the simplex pump or firing the listener cancel. The duplex handler's own internal drain (e.g., the host's `duplex_accept_loop`) gets to drop its `AttachSender`s naturally so `send_connected` flushes queued outbound as `SendLoopError::AppClosed` rather than abandoning it via the cancel branch.

Per-half `ServerHandle`s (`NetRx`, `DuplexServer`) wait on a `drained` watch signal that fires only after the accept loop has joined every per-session task — its terminal cleanup (final ack flush + `Closed` emit) has run. This honors `Rx::join`'s "all pending acks flushed" contract for muxed split halves.

### Test fidelity

`prepare_connection` (the shared in-memory test helper for the ack-flush suite) takes a `ProtocolKind` parameter; the duplex tests pass `Duplex`. `duplex::serve_with_listener` validates `ProtocolKind::Duplex` like production `duplex::serve`, so duplex shutdown coverage exercises the production handshake path.

`mux::serve_with_listener` (test-only) accepts an arbitrary `Listener`, mirroring the simplex and duplex test helpers. It exposes the same `MuxServeParts` shape (drain-aware per-half handles, coordinator's `drained` watch) so wire-level tests can drive the mux through in-memory `DuplexStream`s and a `GatedWriteStream` to gate the dispatch's terminal write — pinning the drain-aware contract counterfactually.

Reviewed By: mariusae

Differential Revision: D102077571


