### PR TITLE
Delete unused upper command classes from tools/cli.py

### DIFF
--- a/python/monarch/tools/cli.py
+++ b/python/monarch/tools/cli.py
@@ -7,7 +7,6 @@
 # pyre-strict
 import argparse
 import importlib.resources
-import json
 import os
 import sys
 from pathlib import Path
@@ -15,142 +14,14 @@ from pathlib import Path
 from monarch.actor import shutdown_context
 from monarch.tools.commands import (
     apply_job,
-    bounce,
-    component_args_from_cli,
     context_create,
     context_ls,
     context_rm,
     context_use,
-    create,
     debug,
     exec_on_job,
-    info,
-    kill,
-    stop,
-    torchx_runner,  # noqa: F401
-)
-from monarch.tools.config import (  # @manual=//monarch/python/monarch/tools/config/meta:defaults
-    Config,
-    defaults,
 )
 from monarch.tools.debug_env import _get_debug_server_host, _get_debug_server_port
-from torchx.specs.finder import get_component
-
-
-def config_from_cli_args(args: argparse.Namespace) -> Config:
-    config = defaults.config(args.scheduler, args.workspace)
-
-    if args.scheduler_args:
-        with torchx_runner() as runner:
-            opts = runner.scheduler_run_opts(config.scheduler)
-            for cfg_str in args.scheduler_args:
-                parsed_cfg = opts.cfg_from_str(cfg_str)
-                config.scheduler_args.update(parsed_cfg)
-
-    config.dryrun = args.dryrun
-    return config
-
-
-class CreateCmd:
-    def add_arguments(self, subparser: argparse.ArgumentParser) -> None:
-        subparser.add_argument(
-            "-s",
-            "--scheduler",
-            type=str,
-            help="Scheduler to submit to",
-        )
-        subparser.add_argument(
-            "-cfg",
-            "--scheduler_args",
-            default=[],
-            action="append",
-            help="Scheduler args (e.g. `-cfg cluster=foo -cfg user=bar`)",
-        )
-        subparser.add_argument(
-            "--dryrun",
-            action="store_true",
-            default=False,
-            help="Just prints the scheduler request",
-        )
-        subparser.add_argument(
-            "--workspace",
-            help="The local directory to build into the job's image and make available on the job."
-            " Pass --workspace='' to disable any default workspaces configured for the scheduler",
-        )
-        subparser.add_argument(
-            "--component",
-            help="A custom TorchX component to use",
-        )
-        subparser.add_argument(
-            "-arg",
-            "--component_args",
-            default=[],
-            action="append",
-            help="Arguments to the component fn (e.g. `-arg a=b -arg c=d` to pass as `component_fn(a=b, c=d)`)",
-        )
-
-    def run(self, args: argparse.Namespace) -> None:
-        config = config_from_cli_args(args)
-
-        component_fn = (
-            get_component(args.component).fn
-            if args.component
-            else defaults.component_fn(config.scheduler)
-        )
-        component_args = component_args_from_cli(component_fn, args.component_args)
-        config.appdef = component_fn(**component_args)
-
-        handle = create(config)
-        print(handle)
-
-
-class CommonArguments:
-    @staticmethod
-    def add_server_handle(subparser: argparse.ArgumentParser) -> None:
-        subparser.add_argument(
-            "server_handle",
-            type=str,
-            help="monarch server handle (e.g. slurm:///job_id)",
-        )
-
-
-class InfoCmd:
-    def add_arguments(self, subparser: argparse.ArgumentParser) -> None:
-        CommonArguments.add_server_handle(subparser)
-
-    def run(self, args: argparse.Namespace) -> None:
-        server_spec = info(args.server_handle)
-        if server_spec is None:
-            print(
-                f"Server: {args.server_handle} does not exist",
-                file=sys.stderr,
-            )
-        else:
-            json.dump(server_spec.to_json(), indent=2, fp=sys.stdout)
-
-
-class OldKillCmd:
-    def add_arguments(self, subparser: argparse.ArgumentParser) -> None:
-        CommonArguments.add_server_handle(subparser)
-
-    def run(self, args: argparse.Namespace) -> None:
-        kill(args.server_handle)
-
-
-class BounceCmd:
-    def add_arguments(self, subparser: argparse.ArgumentParser) -> None:
-        CommonArguments.add_server_handle(subparser)
-
-    def run(self, args: argparse.Namespace) -> None:
-        bounce(args.server_handle)
-
-
-class StopCmd:
-    def add_arguments(self, subparser: argparse.ArgumentParser) -> None:
-        CommonArguments.add_server_handle(subparser)
-
-    def run(self, args: argparse.Namespace) -> None:
-        stop(args.server_handle)
 
 
 class DebugCmd:


### PR DESCRIPTION
Summary: AFAICT, no one is using this CLI to create/kill a job, since we have moved on to `JobTrait`. Delete them from the CLI.

Reviewed By: shayne-fletcher

Differential Revision: D102655612


