### PR TITLE
Fix host mesh shutdown race with actor mesh controller (#3663)

### DIFF
--- a/hyperactor_mesh/src/host_mesh.rs
+++ b/hyperactor_mesh/src/host_mesh.rs
@@ -1431,7 +1431,12 @@ impl HostMeshRef {
             // If this proc dies or some other issue renders the reply undeliverable,
             // the reply does not need to be returned to the sender.
             reply.return_undeliverable(false);
-            host.mesh_agent()
+            let mut send_port = host.mesh_agent().port();
+            // If the message is undeliverable, the timeout below will catch the issue, and the caller
+            // can handle the error as it pleases. Set this so an undeliverable message doesn't cause
+            // a supervision crash.
+            send_port.return_undeliverable(false);
+            send_port
                 .send(
                     cx,
                     resource::GetState {


### PR DESCRIPTION
Summary:

Host mesh shutdown can race with the actor mesh controller's supervision loop in the following scenario:

1. User calls `host_mesh.shutdown()`.
2. Actor mesh controller sends `GetState<ProcState>` to each host in its `CheckState` handler.
3. If the host mesh is already gone, step 2 generates an undeliverable crash.

The fix is to set `return_undeliverable = false` on the *send* port in addition to the reply port when querying each host for proc states. If the message is undeliverable, a timeout later in the same function will catch the issue.

Reviewed By: dulinriley

Differential Revision: D102838239


