### PR TITLE
route every test ProcessJob through scoped_state (#3664)

### DIFF
--- a/python/tests/test_debugger.py
+++ b/python/tests/test_debugger.py
@@ -46,7 +46,7 @@ from monarch._src.actor.debugger.debug_session import (
 )
 from monarch._src.actor.endpoint import endpoint
 from monarch._src.actor.host_mesh import this_host
-from monarch._src.actor.proc_mesh import get_or_spawn_controller, ProcMesh
+from monarch._src.actor.proc_mesh import get_or_spawn_controller
 from monarch._src.actor.source_loader import SourceLoaderController
 from monarch._src.job.process import ProcessJob
 from monarch.tools.debug_env import (
@@ -54,20 +54,10 @@ from monarch.tools.debug_env import (
     _MONARCH_DEBUG_SERVER_PORT_ENV_VAR,
 )
 from pyre_extensions import none_throws
+from scoped_state import scoped_state
 
 
 TActor = TypeVar("TActor", bound=Actor)
-
-
-def proc_mesh(
-    gpus: int = 1,
-    hosts: int = 1,
-) -> ProcMesh:
-    return (
-        ProcessJob({"hosts": hosts})
-        .state(cached_path=None)
-        .hosts.spawn_procs(per_host={"gpus": gpus})
-    )
 
 
 needs_cuda = pytest.mark.skipif(
@@ -166,174 +156,189 @@ async def _wait_for_breakpoints(
 
 
 async def _test_debug(nested: bool) -> None:
-    if not nested:
-        proc = proc_mesh(hosts=2, gpus=2)
-        debugee = proc.spawn("debugee", DebugeeActor)
-    else:
-        proc = ProcessJob({"hosts": 1}).state(cached_path=None).hosts.spawn_procs()
-        debugee = proc.spawn("debugee", DebugeeActor).nested.choose().get()
-    name = debugee.name.choose().get()
+    with scoped_state(
+        ProcessJob({"hosts": 1 if nested else 2}), cached_path=None
+    ) as state:
+        if not nested:
+            proc = state.hosts.spawn_procs(per_host={"gpus": 2})
+            debugee = proc.spawn("debugee", DebugeeActor)
+        else:
+            proc = state.hosts.spawn_procs()
+            debugee = proc.spawn("debugee", DebugeeActor).nested.choose().get()
+        name = debugee.name.choose().get()
 
-    input_mock = AsyncMock()
-    input_mock.side_effect = [
-        f"attach {name} 1",
-        "n",
-        "n",
-        "n",
-        "n",
-        "detach",
-        f"attach {name} 1",
-        "detach",
-        "quit",
-        f"cast {name} ranks(0,3) n",
-        f"cast {name} ranks(0,3) n",
-        # Attaching to 0 and 3 ensures that when we call "list"
-        # the next time, their function/lineno info will be
-        # up-to-date.
-        f"attach {name} 0",
-        "detach",
-        f"attach {name} 3",
-        "detach",
-        "quit",
-        f"attach {name} 2",
-        "c",
-        "detach",
-        "quit",
-        f"attach {name} 2",
-        "bt",
-        "c",
-        "quit",
-        "continue",
-        "quit",
-    ]
-
-    outputs = []
-
-    def _patch_output(msg):
-        nonlocal outputs
-        outputs.append(msg)
-
-    output_mock = AsyncMock()
-    output_mock.side_effect = _patch_output
-
-    with (
-        patch("monarch._src.actor.debugger.debug_io.DebugStdIO.input", new=input_mock),
-        patch(
-            "monarch._src.actor.debugger.debug_io.DebugStdIO.output", new=output_mock
-        ),
-    ):
-        debug_controller = await get_or_spawn_controller(
-            "debug_controller", DebugControllerForTesting
-        )
-
-        fut = debugee.to_debug.call()
-        await debug_controller.wait_pending_session.call_one()
-        # This can take a while during stress testing with many instances of the test
-        # running in parallel, so the timeout is set to 60 seconds.
-        breakpoints = await _wait_for_breakpoints(debug_controller, 4, timeout_sec=60)
-
-        initial_linenos = {}
-        for i in range(len(breakpoints)):
-            info = breakpoints[i]
-            initial_linenos[info.rank] = info.lineno
-            assert info.rank == i
-            assert info.coords == {"hosts": info.rank // 2, "gpus": info.rank % 2}
-            assert info.function == "test_debugger._debugee_actor_internal"
-            assert info.lineno == cast(int, breakpoints[0].lineno) + 5 * info.rank
-
-        await debug_controller.blocking_enter.call_one()
-
-        # Check that when detaching and re-attaching to a session, the last portion of the output is repeated
-        expected_last_output = [
-            r"--Return--",
-            r"\n",
-            r"> (/.*/)+test_debugger.py\(\d+\)to_debug\(\)->5\n-> return _debugee_actor_internal\(rank\)",
-            r"\n",
-            r"\(Pdb\) ",
-        ]
-        output_len = len(expected_last_output)
-        rev_outputs = outputs[::-1]
-        last_return = rev_outputs.index("--Return--")
-        second_to_last_return = rev_outputs.index("--Return--", last_return + 1)
-        last_return = len(rev_outputs) - last_return - 1
-        second_to_last_return = len(rev_outputs) - second_to_last_return - 1
-        assert (
-            outputs[second_to_last_return : second_to_last_return + output_len]  # noqa
-            == outputs[last_return : last_return + output_len]  # noqa
-        )
-        for real_output, expected_output in zip(
-            outputs[last_return : last_return + output_len],  # noqa
-            expected_last_output,
-        ):
-            assert re.match(expected_output, real_output) is not None
-
-        breakpoints = await debug_controller.list.call_one(print_output=False)
-        for i in range(len(breakpoints)):
-            if i == 1:
-                assert breakpoints[i].function == "test_debugger.to_debug"
-            else:
-                assert (
-                    breakpoints[i].function == "test_debugger._debugee_actor_internal"
-                )
-                assert breakpoints[i].lineno == initial_linenos[i]
-
-        await debug_controller.blocking_enter.call_one()
-
-        breakpoints = await debug_controller.list.call_one(print_output=False)
-        for i in range(len(breakpoints)):
-            if i == 1:
-                assert breakpoints[i].function == "test_debugger.to_debug"
-            elif i in (0, 3):
-                assert (
-                    breakpoints[i].function == "test_debugger._debugee_actor_internal"
-                )
-                assert breakpoints[i].lineno == initial_linenos[i] + 2
-            else:
-                assert (
-                    breakpoints[i].function == "test_debugger._debugee_actor_internal"
-                )
-                assert breakpoints[i].lineno == initial_linenos[i]
-
-        await debug_controller.blocking_enter.call_one()
-
-        breakpoints = await debug_controller.list.call_one(print_output=False)
-        assert len(breakpoints) == 4
-        # Expect post-mortem debugging for rank 2
-        assert breakpoints[2].function == "test_debugger._bad_rank"
-
-        await debug_controller.blocking_enter.call_one()
-
-        expected_last_output = [
-            r"\s*(/.*/)+test_debugger.py\(\d+\)_debugee_actor_internal\(\)\n-> _bad_rank\(\)",
-            r"\n",
-            r'> (/.*/)+test_debugger.py\(\d+\)_bad_rank\(\)\n-> raise ValueError\("bad rank"\)',
-            r"\n",
-            r"\(Pdb\) ",
+        input_mock = AsyncMock()
+        input_mock.side_effect = [
+            f"attach {name} 1",
+            "n",
+            "n",
+            "n",
+            "n",
+            "detach",
+            f"attach {name} 1",
+            "detach",
+            "quit",
+            f"cast {name} ranks(0,3) n",
+            f"cast {name} ranks(0,3) n",
+            # Attaching to 0 and 3 ensures that when we call "list"
+            # the next time, their function/lineno info will be
+            # up-to-date.
+            f"attach {name} 0",
+            "detach",
+            f"attach {name} 3",
+            "detach",
+            "quit",
+            f"attach {name} 2",
+            "c",
+            "detach",
+            "quit",
+            f"attach {name} 2",
+            "bt",
+            "c",
+            "quit",
+            "continue",
+            "quit",
         ]
 
-        rev_outputs = outputs[::-1]
-        output_index = len(outputs) - (
-            rev_outputs.index("(Pdb) ") + len(expected_last_output)
-        )
+        outputs = []
 
-        for output, expected_output in zip(
-            outputs[output_index : output_index + len(expected_last_output)],  # noqa
-            expected_last_output,
+        def _patch_output(msg):
+            nonlocal outputs
+            outputs.append(msg)
+
+        output_mock = AsyncMock()
+        output_mock.side_effect = _patch_output
+
+        with (
+            patch(
+                "monarch._src.actor.debugger.debug_io.DebugStdIO.input",
+                new=input_mock,
+            ),
+            patch(
+                "monarch._src.actor.debugger.debug_io.DebugStdIO.output",
+                new=output_mock,
+            ),
         ):
-            assert re.match(expected_output, output) is not None
+            debug_controller = await get_or_spawn_controller(
+                "debug_controller", DebugControllerForTesting
+            )
 
-        breakpoints = await debug_controller.list.call_one(print_output=False)
-        assert len(breakpoints) == 3
-        for i, rank in enumerate((0, 1, 3)):
-            assert breakpoints[i].rank == rank
+            fut = debugee.to_debug.call()
+            await debug_controller.wait_pending_session.call_one()
+            # This can take a while during stress testing with many instances of the test
+            # running in parallel, so the timeout is set to 60 seconds.
+            breakpoints = await _wait_for_breakpoints(
+                debug_controller, 4, timeout_sec=60
+            )
 
-        await debug_controller.blocking_enter.call_one()
-        await _wait_for_breakpoints(debug_controller, 0)
+            initial_linenos = {}
+            for i in range(len(breakpoints)):
+                info = breakpoints[i]
+                initial_linenos[info.rank] = info.lineno
+                assert info.rank == i
+                assert info.coords == {
+                    "hosts": info.rank // 2,
+                    "gpus": info.rank % 2,
+                }
+                assert info.function == "test_debugger._debugee_actor_internal"
+                assert info.lineno == cast(int, breakpoints[0].lineno) + 5 * info.rank
 
-        with pytest.raises(
-            monarch._src.actor.actor_mesh.ActorError, match="ValueError: bad rank"
-        ):
-            await fut
+            await debug_controller.blocking_enter.call_one()
+
+            # Check that when detaching and re-attaching to a session, the last portion of the output is repeated
+            expected_last_output = [
+                r"--Return--",
+                r"\n",
+                r"> (/.*/)+test_debugger.py\(\d+\)to_debug\(\)->5\n-> return _debugee_actor_internal\(rank\)",
+                r"\n",
+                r"\(Pdb\) ",
+            ]
+            output_len = len(expected_last_output)
+            rev_outputs = outputs[::-1]
+            last_return = rev_outputs.index("--Return--")
+            second_to_last_return = rev_outputs.index("--Return--", last_return + 1)
+            last_return = len(rev_outputs) - last_return - 1
+            second_to_last_return = len(rev_outputs) - second_to_last_return - 1
+            assert (
+                outputs[second_to_last_return : second_to_last_return + output_len]  # noqa
+                == outputs[last_return : last_return + output_len]  # noqa
+            )
+            for real_output, expected_output in zip(
+                outputs[last_return : last_return + output_len],  # noqa
+                expected_last_output,
+            ):
+                assert re.match(expected_output, real_output) is not None
+
+            breakpoints = await debug_controller.list.call_one(print_output=False)
+            for i in range(len(breakpoints)):
+                if i == 1:
+                    assert breakpoints[i].function == "test_debugger.to_debug"
+                else:
+                    assert (
+                        breakpoints[i].function
+                        == "test_debugger._debugee_actor_internal"
+                    )
+                    assert breakpoints[i].lineno == initial_linenos[i]
+
+            await debug_controller.blocking_enter.call_one()
+
+            breakpoints = await debug_controller.list.call_one(print_output=False)
+            for i in range(len(breakpoints)):
+                if i == 1:
+                    assert breakpoints[i].function == "test_debugger.to_debug"
+                elif i in (0, 3):
+                    assert (
+                        breakpoints[i].function
+                        == "test_debugger._debugee_actor_internal"
+                    )
+                    assert breakpoints[i].lineno == initial_linenos[i] + 2
+                else:
+                    assert (
+                        breakpoints[i].function
+                        == "test_debugger._debugee_actor_internal"
+                    )
+                    assert breakpoints[i].lineno == initial_linenos[i]
+
+            await debug_controller.blocking_enter.call_one()
+
+            breakpoints = await debug_controller.list.call_one(print_output=False)
+            assert len(breakpoints) == 4
+            # Expect post-mortem debugging for rank 2
+            assert breakpoints[2].function == "test_debugger._bad_rank"
+
+            await debug_controller.blocking_enter.call_one()
+
+            expected_last_output = [
+                r"\s*(/.*/)+test_debugger.py\(\d+\)_debugee_actor_internal\(\)\n-> _bad_rank\(\)",
+                r"\n",
+                r'> (/.*/)+test_debugger.py\(\d+\)_bad_rank\(\)\n-> raise ValueError\("bad rank"\)',
+                r"\n",
+                r"\(Pdb\) ",
+            ]
+
+            rev_outputs = outputs[::-1]
+            output_index = len(outputs) - (
+                rev_outputs.index("(Pdb) ") + len(expected_last_output)
+            )
+
+            for output, expected_output in zip(
+                outputs[output_index : output_index + len(expected_last_output)],  # noqa
+                expected_last_output,
+            ):
+                assert re.match(expected_output, output) is not None
+
+            breakpoints = await debug_controller.list.call_one(print_output=False)
+            assert len(breakpoints) == 3
+            for i, rank in enumerate((0, 1, 3)):
+                assert breakpoints[i].rank == rank
+
+            await debug_controller.blocking_enter.call_one()
+            await _wait_for_breakpoints(debug_controller, 0)
+
+            with pytest.raises(
+                monarch._src.actor.actor_mesh.ActorError, match="ValueError: bad rank"
+            ):
+                await fut
 
 
 # We have to run this test in a separate process because there is only one
@@ -368,84 +373,95 @@ async def test_debug_nested():
 )
 @pytest.mark.timeout(60)
 async def test_debug_multi_actor() -> None:
-    proc = proc_mesh(hosts=2, gpus=2)
-    debugee_1 = proc.spawn("debugee_1", DebugeeActor)
-    debugee_2 = proc.spawn("debugee_2", DebugeeActor)
-    name_1 = debugee_1.name.choose().get()
-    name_2 = debugee_2.name.choose().get()
+    with scoped_state(ProcessJob({"hosts": 2}), cached_path=None) as state:
+        proc = state.hosts.spawn_procs(per_host={"gpus": 2})
+        debugee_1 = proc.spawn("debugee_1", DebugeeActor)
+        debugee_2 = proc.spawn("debugee_2", DebugeeActor)
+        name_1 = debugee_1.name.choose().get()
+        name_2 = debugee_2.name.choose().get()
 
-    input_mock = AsyncMock()
-    input_mock.side_effect = [
-        f"attach {name_2} 2",
-        "n",
-        "detach",
-        f"attach {name_1} 1",
-        "n",
-        "detach",
-        "quit",
-        f"cast {name_1} ranks(:) c",
-        f"cast {name_2} ranks(:) c",
-        f"attach {name_2} 2",
-        "c",
-        "quit",
-        "continue",
-        "quit",
-    ]
+        input_mock = AsyncMock()
+        input_mock.side_effect = [
+            f"attach {name_2} 2",
+            "n",
+            "detach",
+            f"attach {name_1} 1",
+            "n",
+            "detach",
+            "quit",
+            f"cast {name_1} ranks(:) c",
+            f"cast {name_2} ranks(:) c",
+            f"attach {name_2} 2",
+            "c",
+            "quit",
+            "continue",
+            "quit",
+        ]
 
-    with patch(
-        "monarch._src.actor.debugger.debug_io.DebugStdIO.input", side_effect=input_mock
-    ):
-        debug_controller = await get_or_spawn_controller(
-            "debug_controller", DebugControllerForTesting
-        )
+        with patch(
+            "monarch._src.actor.debugger.debug_io.DebugStdIO.input",
+            side_effect=input_mock,
+        ):
+            debug_controller = await get_or_spawn_controller(
+                "debug_controller", DebugControllerForTesting
+            )
 
-        fut_1 = debugee_1.to_debug.call()
-        fut_2 = debugee_2.to_debug.call()
-        await debug_controller.wait_pending_session.call_one()
+            fut_1 = debugee_1.to_debug.call()
+            fut_2 = debugee_2.to_debug.call()
+            await debug_controller.wait_pending_session.call_one()
 
-        breakpoints = await _wait_for_breakpoints(debug_controller, 8)
+            breakpoints = await _wait_for_breakpoints(debug_controller, 8)
 
-        initial_linenos = {}
-        for i in range(len(breakpoints)):
-            info = breakpoints[i]
-            initial_linenos[info.rank] = info.lineno
-            assert info.rank == i % 4
-            assert info.actor_name == name_1 if i < 4 else name_2
-            assert info.coords == {"hosts": info.rank // 2, "gpus": info.rank % 2}
-            assert info.function == "test_debugger._debugee_actor_internal"
-            assert info.lineno == cast(int, breakpoints[0].lineno) + 5 * info.rank
+            initial_linenos = {}
+            for i in range(len(breakpoints)):
+                info = breakpoints[i]
+                initial_linenos[info.rank] = info.lineno
+                assert info.rank == i % 4
+                assert info.actor_name == name_1 if i < 4 else name_2
+                assert info.coords == {
+                    "hosts": info.rank // 2,
+                    "gpus": info.rank % 2,
+                }
+                assert info.function == "test_debugger._debugee_actor_internal"
+                assert info.lineno == cast(int, breakpoints[0].lineno) + 5 * info.rank
 
-        await debug_controller.blocking_enter.call_one()
+            await debug_controller.blocking_enter.call_one()
 
-        breakpoints = await _wait_for_breakpoints(debug_controller, 8)
-        for i in range(len(breakpoints)):
-            if i == 1:
-                assert breakpoints[i].actor_name == name_1
-                assert breakpoints[i].rank == 1
-                assert breakpoints[i].lineno == initial_linenos[breakpoints[i].rank] + 1
-            elif i == 6:
-                assert breakpoints[i].actor_name == name_2
-                assert breakpoints[i].rank == 2
-                assert breakpoints[i].lineno == initial_linenos[breakpoints[i].rank] + 1
-            else:
-                assert breakpoints[i].actor_name == name_1 if i < 4 else name_2
-                assert breakpoints[i].rank == i % 4
-                assert breakpoints[i].lineno == initial_linenos[breakpoints[i].rank]
+            breakpoints = await _wait_for_breakpoints(debug_controller, 8)
+            for i in range(len(breakpoints)):
+                if i == 1:
+                    assert breakpoints[i].actor_name == name_1
+                    assert breakpoints[i].rank == 1
+                    assert (
+                        breakpoints[i].lineno
+                        == initial_linenos[breakpoints[i].rank] + 1
+                    )
+                elif i == 6:
+                    assert breakpoints[i].actor_name == name_2
+                    assert breakpoints[i].rank == 2
+                    assert (
+                        breakpoints[i].lineno
+                        == initial_linenos[breakpoints[i].rank] + 1
+                    )
+                else:
+                    assert breakpoints[i].actor_name == name_1 if i < 4 else name_2
+                    assert breakpoints[i].rank == i % 4
+                    assert breakpoints[i].lineno == initial_linenos[breakpoints[i].rank]
 
-        await debug_controller.blocking_enter.call_one()
+            await debug_controller.blocking_enter.call_one()
 
-        breakpoints = await _wait_for_breakpoints(debug_controller, 1)
-        with pytest.raises(ActorError, match="ValueError: bad rank"):
-            await fut_2
-        assert breakpoints[0].actor_name == name_1
-        assert breakpoints[0].rank == 2
-        assert breakpoints[0].function == "test_debugger._bad_rank"
+            breakpoints = await _wait_for_breakpoints(debug_controller, 1)
+            with pytest.raises(ActorError, match="ValueError: bad rank"):
+                await fut_2
+            assert breakpoints[0].actor_name == name_1
+            assert breakpoints[0].rank == 2
+            assert breakpoints[0].function == "test_debugger._bad_rank"
 
-        await debug_controller.blocking_enter.call_one()
+            await debug_controller.blocking_enter.call_one()
 
-        breakpoints = await _wait_for_breakpoints(debug_controller, 0)
-        with pytest.raises(ActorError, match="ValueError: bad rank"):
-            await fut_1
+            breakpoints = await _wait_for_breakpoints(debug_controller, 0)
+            with pytest.raises(ActorError, match="ValueError: bad rank"):
+                await fut_1
 
 
 async def test_debug_sessions_insert_get_remove() -> None:
@@ -790,250 +806,257 @@ async def test_debug_command_parser_invalid_inputs(invalid_input):
 )
 @pytest.mark.timeout(60)
 async def test_debug_cli():
-    proc = proc_mesh(hosts=2, gpus=2)
-    debugee = proc.spawn("debugee", DebugeeActor)
-    name = debugee.name.choose().get()
-    debug_controller = get_or_spawn_controller(
-        "debug_controller", DebugControllerForTesting
-    ).get()
+    with scoped_state(ProcessJob({"hosts": 2}), cached_path=None) as state:
+        proc = state.hosts.spawn_procs(per_host={"gpus": 2})
+        debugee = proc.spawn("debugee", DebugeeActor)
+        name = debugee.name.choose().get()
+        debug_controller = get_or_spawn_controller(
+            "debug_controller", DebugControllerForTesting
+        ).get()
 
-    fut = debugee.to_debug.call()
-    # Stupidly high timeout because when CI tries to run many instances of this
-    # test in parallel, it can take a long time for breakpoints to actually show
-    # up.
-    breakpoints = await _wait_for_breakpoints(debug_controller, 4, timeout_sec=180)
+        fut = debugee.to_debug.call()
+        # Stupidly high timeout because when CI tries to run many instances of this
+        # test in parallel, it can take a long time for breakpoints to actually show
+        # up.
+        breakpoints = await _wait_for_breakpoints(debug_controller, 4, timeout_sec=180)
 
-    initial_linenos = {}
-    for i in range(len(breakpoints)):
-        info = breakpoints[i]
-        initial_linenos[info.rank] = info.lineno
-        assert info.rank == i
-        assert info.coords == {"hosts": info.rank // 2, "gpus": info.rank % 2}
-        assert info.function == "test_debugger._debugee_actor_internal"
-        assert info.lineno == cast(int, breakpoints[0].lineno) + 5 * info.rank
+        initial_linenos = {}
+        for i in range(len(breakpoints)):
+            info = breakpoints[i]
+            initial_linenos[info.rank] = info.lineno
+            assert info.rank == i
+            assert info.coords == {"hosts": info.rank // 2, "gpus": info.rank % 2}
+            assert info.function == "test_debugger._debugee_actor_internal"
+            assert info.lineno == cast(int, breakpoints[0].lineno) + 5 * info.rank
 
-    port = debug_controller.server_port.call_one().get()
+        port = debug_controller.server_port.call_one().get()
 
-    async def create_debug_cli_proc() -> Tuple[
-        Optional[asyncio.subprocess.Process],
-        asyncio.StreamWriter,
-        asyncio.StreamReader,
-    ]:
-        cmd = None
-        if IN_PAR:
-            cmd = [
-                os.environ["MONARCH_CLI_BIN"],
-                "debug",
-                "--host",
-                os.environ[_MONARCH_DEBUG_SERVER_HOST_ENV_VAR],
-                "--port",
-                str(port),
+        async def create_debug_cli_proc() -> Tuple[
+            Optional[asyncio.subprocess.Process],
+            asyncio.StreamWriter,
+            asyncio.StreamReader,
+        ]:
+            cmd = None
+            if IN_PAR:
+                cmd = [
+                    os.environ["MONARCH_CLI_BIN"],
+                    "debug",
+                    "--host",
+                    os.environ[_MONARCH_DEBUG_SERVER_HOST_ENV_VAR],
+                    "--port",
+                    str(port),
+                ]
+            elif any(shutil.which(nc_cmd) for nc_cmd in ["ncat", "nc", "netcat"]):
+                cmd = [
+                    "monarch",
+                    "debug",
+                    "--host",
+                    os.environ[_MONARCH_DEBUG_SERVER_HOST_ENV_VAR],
+                    "--port",
+                    str(port),
+                ]
+            if cmd:
+                debug_cli_proc = await asyncio.create_subprocess_exec(
+                    *cmd,
+                    stdin=subprocess.PIPE,
+                    stdout=subprocess.PIPE,
+                )
+                debug_cli_stdin = none_throws(debug_cli_proc.stdin)
+                debug_cli_stdout = none_throws(debug_cli_proc.stdout)
+                return debug_cli_proc, debug_cli_stdin, debug_cli_stdout
+            else:
+                # Netcat isn't available in our github CI environment, so we can't
+                # run the monarch.debug_cli module
+                reader, writer = await asyncio.open_connection(
+                    os.environ[_MONARCH_DEBUG_SERVER_HOST_ENV_VAR], port
+                )
+                return None, writer, reader
+
+        (
+            debug_cli_proc,
+            debug_cli_stdin,
+            debug_cli_stdout,
+        ) = await create_debug_cli_proc()
+
+        debug_cli_stdin.writelines(
+            [
+                f"attach {name} 1\n".encode(),
+                b"n\n",
+                b"n\n",
+                b"n\n",
+                b"n\n",
+                b"detach\n",
+                f"attach {name} 1\n".encode(),
+                b"print('test separator')\n",
+                b"detach\n",
             ]
-        elif any(shutil.which(nc_cmd) for nc_cmd in ["ncat", "nc", "netcat"]):
-            cmd = [
-                "monarch",
-                "debug",
-                "--host",
-                os.environ[_MONARCH_DEBUG_SERVER_HOST_ENV_VAR],
-                "--port",
-                str(port),
-            ]
-        if cmd:
-            debug_cli_proc = await asyncio.create_subprocess_exec(
-                *cmd,
-                stdin=subprocess.PIPE,
-                stdout=subprocess.PIPE,
-            )
-            debug_cli_stdin = none_throws(debug_cli_proc.stdin)
-            debug_cli_stdout = none_throws(debug_cli_proc.stdout)
-            return debug_cli_proc, debug_cli_stdin, debug_cli_stdout
-        else:
-            # Netcat isn't available in our github CI environment, so we can't
-            # run the monarch.debug_cli module
-            reader, writer = await asyncio.open_connection(
-                os.environ[_MONARCH_DEBUG_SERVER_HOST_ENV_VAR], port
-            )
-            return None, writer, reader
-
-    (
-        debug_cli_proc,
-        debug_cli_stdin,
-        debug_cli_stdout,
-    ) = await create_debug_cli_proc()
-
-    debug_cli_stdin.writelines(
-        [
-            f"attach {name} 1\n".encode(),
-            b"n\n",
-            b"n\n",
-            b"n\n",
-            b"n\n",
-            b"detach\n",
-            f"attach {name} 1\n".encode(),
-            b"print('test separator')\n",
-            b"detach\n",
-        ]
-    )
-    await debug_cli_stdin.drain()
-
-    # Check that when detaching and re-attaching to a session, the last portion of the output is repeated
-    expected_last_output = (
-        r"--Return--\n"
-        r"> (?:/.*/)+test_debugger.py\(\d+\)to_debug\(\)->5\n"
-        r"-> return _debugee_actor_internal\(rank\)\n"
-        r"\(Pdb\) "
-    )
-
-    outputs = (await debug_cli_stdout.readuntil(b"test separator")).decode()
-    assert len(re.findall(expected_last_output, outputs)) == 2
-    assert outputs[0] == outputs[1]
-
-    breakpoints = await debug_controller.list.call_one(print_output=False)
-    for i in range(len(breakpoints)):
-        if i == 1:
-            assert breakpoints[i].function == "test_debugger.to_debug"
-        else:
-            assert breakpoints[i].function == "test_debugger._debugee_actor_internal"
-            assert breakpoints[i].lineno == initial_linenos[i]
-
-    debug_cli_stdin.write(b"quit\n")
-    await debug_cli_stdin.drain()
-    # Yield and wait so that the debug controller has a chance to process the
-    # input before we close stdin.
-    await asyncio.sleep(1)
-    debug_cli_stdin.close()
-    await debug_cli_stdin.wait_closed()
-    if debug_cli_proc:
-        assert await debug_cli_proc.wait() == 0
-
-    (
-        debug_cli_proc,
-        debug_cli_stdin,
-        debug_cli_stdout,
-    ) = await create_debug_cli_proc()
-
-    debug_cli_stdin.writelines(
-        [
-            f"cast {name} ranks(0,3) n\n".encode(),
-            f"cast {name} ranks(0,3) n\n".encode(),
-            # Attaching to 0 and 3 ensures that when we call "list"
-            # the next time, their function/lineno info will be
-            # up-to-date.
-            f"attach {name} 0\n".encode(),
-            b"detach\n",
-            f"attach {name} 3\n".encode(),
-            b"detach\n",
-        ]
-    )
-    await debug_cli_stdin.drain()
-
-    # Make sure we have run all the commands before killing the CLI, otherwise
-    # the commands may not actually be sent to the debug controller.
-    await debug_cli_stdout.readuntil(
-        f"Detached from debug session for {name} 3".encode()
-    )
-    if debug_cli_proc:
-        # Even if we kill the proc using a signal, we should be able to reconnect
-        # without issue.
-        debug_cli_proc.send_signal(signal.SIGINT)
-        assert await debug_cli_proc.wait() != 0
-    else:
-        debug_cli_stdin.close()
-        await debug_cli_stdin.wait_closed()
-
-    breakpoints = await debug_controller.list.call_one(print_output=False)
-    for i in range(len(breakpoints)):
-        if i == 1:
-            assert breakpoints[i].function == "test_debugger.to_debug"
-        elif i in (0, 3):
-            assert breakpoints[i].function == "test_debugger._debugee_actor_internal"
-            assert breakpoints[i].lineno == initial_linenos[i] + 2
-        else:
-            assert breakpoints[i].function == "test_debugger._debugee_actor_internal"
-            assert breakpoints[i].lineno == initial_linenos[i]
-
-    (
-        debug_cli_proc,
-        debug_cli_stdin,
-        debug_cli_stdout,
-    ) = await create_debug_cli_proc()
-
-    debug_cli_stdin.writelines([f"attach {name} 2\n".encode(), b"c\n"])
-    await debug_cli_stdin.drain()
-
-    # Make sure we have run all the commands before killing the CLI, otherwise
-    # the commands may not actually be sent to the debug controller.
-    await debug_cli_stdout.readuntil(b"raise ValueError")
-    if debug_cli_proc:
-        # Even if we kill the proc using a signal while the debugger is attached to
-        # a specific rank, we should be able to reconnect to that rank later without
-        # issue.
-        debug_cli_proc.send_signal(signal.SIGINT)
-        assert await debug_cli_proc.wait() != 0
-    else:
-        debug_cli_stdin.close()
-        await debug_cli_stdin.wait_closed()
-
-    breakpoints = await debug_controller.list.call_one(print_output=False)
-    assert len(breakpoints) == 4
-    # Expect post-mortem debugging for rank 2
-    assert breakpoints[2].function == "test_debugger._bad_rank"
-
-    (
-        debug_cli_proc,
-        debug_cli_stdin,
-        debug_cli_stdout,
-    ) = await create_debug_cli_proc()
-
-    debug_cli_stdin.writelines([f"attach {name} 2\n".encode(), b"bt\n", b"c\n"])
-    await debug_cli_stdin.drain()
-
-    expected_output = (
-        r"(?:/.*/)+test_debugger.py\(\d+\)_debugee_actor_internal\(\)\n-> _bad_rank\(\)\n"
-        r'> (?:/.*/)+test_debugger.py\(\d+\)_bad_rank\(\)\n-> raise ValueError\("bad rank"\)\n'
-        r"\(Pdb\)"
-    )
-
-    output = (
-        await debug_cli_stdout.readuntil(
-            f"Detached from debug session for {name} 2".encode()
         )
-    ).decode()
-    assert len(re.findall(expected_output, output)) == 1
+        await debug_cli_stdin.drain()
 
-    debug_cli_stdin.writelines([b"quit\n"])
-    await debug_cli_stdin.drain()
-    debug_cli_stdin.close()
-    # Yield and wait so that the debug controller has a chance to process the
-    # input before we close stdin.
-    await asyncio.sleep(1)
-    await debug_cli_stdin.wait_closed()
-    if debug_cli_proc:
-        assert await debug_cli_proc.wait() == 0
+        # Check that when detaching and re-attaching to a session, the last portion of the output is repeated
+        expected_last_output = (
+            r"--Return--\n"
+            r"> (?:/.*/)+test_debugger.py\(\d+\)to_debug\(\)->5\n"
+            r"-> return _debugee_actor_internal\(rank\)\n"
+            r"\(Pdb\) "
+        )
 
-    breakpoints = await debug_controller.list.call_one(print_output=False)
-    assert len(breakpoints) == 3
-    for i, rank in enumerate((0, 1, 3)):
-        assert breakpoints[i].rank == rank
+        outputs = (await debug_cli_stdout.readuntil(b"test separator")).decode()
+        assert len(re.findall(expected_last_output, outputs)) == 2
+        assert outputs[0] == outputs[1]
 
-    debug_cli_proc, debug_cli_stdin, _ = await create_debug_cli_proc()
-    debug_cli_stdin.writelines([b"continue\n", b"quit\n"])
-    await debug_cli_stdin.drain()
-    # Yield and wait so that the debug controller has a chance to process the
-    # input before we close stdin.
-    await asyncio.sleep(1)
-    debug_cli_stdin.close()
-    await debug_cli_stdin.wait_closed()
-    if debug_cli_proc:
-        assert await debug_cli_proc.wait() == 0
+        breakpoints = await debug_controller.list.call_one(print_output=False)
+        for i in range(len(breakpoints)):
+            if i == 1:
+                assert breakpoints[i].function == "test_debugger.to_debug"
+            else:
+                assert (
+                    breakpoints[i].function == "test_debugger._debugee_actor_internal"
+                )
+                assert breakpoints[i].lineno == initial_linenos[i]
 
-    breakpoints = await _wait_for_breakpoints(debug_controller, 0)
-    assert len(breakpoints) == 0
+        debug_cli_stdin.write(b"quit\n")
+        await debug_cli_stdin.drain()
+        # Yield and wait so that the debug controller has a chance to process the
+        # input before we close stdin.
+        await asyncio.sleep(1)
+        debug_cli_stdin.close()
+        await debug_cli_stdin.wait_closed()
+        if debug_cli_proc:
+            assert await debug_cli_proc.wait() == 0
 
-    with pytest.raises(
-        monarch._src.actor.actor_mesh.ActorError, match="ValueError: bad rank"
-    ):
-        await fut
+        (
+            debug_cli_proc,
+            debug_cli_stdin,
+            debug_cli_stdout,
+        ) = await create_debug_cli_proc()
+
+        debug_cli_stdin.writelines(
+            [
+                f"cast {name} ranks(0,3) n\n".encode(),
+                f"cast {name} ranks(0,3) n\n".encode(),
+                # Attaching to 0 and 3 ensures that when we call "list"
+                # the next time, their function/lineno info will be
+                # up-to-date.
+                f"attach {name} 0\n".encode(),
+                b"detach\n",
+                f"attach {name} 3\n".encode(),
+                b"detach\n",
+            ]
+        )
+        await debug_cli_stdin.drain()
+
+        # Make sure we have run all the commands before killing the CLI, otherwise
+        # the commands may not actually be sent to the debug controller.
+        await debug_cli_stdout.readuntil(
+            f"Detached from debug session for {name} 3".encode()
+        )
+        if debug_cli_proc:
+            # Even if we kill the proc using a signal, we should be able to reconnect
+            # without issue.
+            debug_cli_proc.send_signal(signal.SIGINT)
+            assert await debug_cli_proc.wait() != 0
+        else:
+            debug_cli_stdin.close()
+            await debug_cli_stdin.wait_closed()
+
+        breakpoints = await debug_controller.list.call_one(print_output=False)
+        for i in range(len(breakpoints)):
+            if i == 1:
+                assert breakpoints[i].function == "test_debugger.to_debug"
+            elif i in (0, 3):
+                assert (
+                    breakpoints[i].function == "test_debugger._debugee_actor_internal"
+                )
+                assert breakpoints[i].lineno == initial_linenos[i] + 2
+            else:
+                assert (
+                    breakpoints[i].function == "test_debugger._debugee_actor_internal"
+                )
+                assert breakpoints[i].lineno == initial_linenos[i]
+
+        (
+            debug_cli_proc,
+            debug_cli_stdin,
+            debug_cli_stdout,
+        ) = await create_debug_cli_proc()
+
+        debug_cli_stdin.writelines([f"attach {name} 2\n".encode(), b"c\n"])
+        await debug_cli_stdin.drain()
+
+        # Make sure we have run all the commands before killing the CLI, otherwise
+        # the commands may not actually be sent to the debug controller.
+        await debug_cli_stdout.readuntil(b"raise ValueError")
+        if debug_cli_proc:
+            # Even if we kill the proc using a signal while the debugger is attached to
+            # a specific rank, we should be able to reconnect to that rank later without
+            # issue.
+            debug_cli_proc.send_signal(signal.SIGINT)
+            assert await debug_cli_proc.wait() != 0
+        else:
+            debug_cli_stdin.close()
+            await debug_cli_stdin.wait_closed()
+
+        breakpoints = await debug_controller.list.call_one(print_output=False)
+        assert len(breakpoints) == 4
+        # Expect post-mortem debugging for rank 2
+        assert breakpoints[2].function == "test_debugger._bad_rank"
+
+        (
+            debug_cli_proc,
+            debug_cli_stdin,
+            debug_cli_stdout,
+        ) = await create_debug_cli_proc()
+
+        debug_cli_stdin.writelines([f"attach {name} 2\n".encode(), b"bt\n", b"c\n"])
+        await debug_cli_stdin.drain()
+
+        expected_output = (
+            r"(?:/.*/)+test_debugger.py\(\d+\)_debugee_actor_internal\(\)\n-> _bad_rank\(\)\n"
+            r'> (?:/.*/)+test_debugger.py\(\d+\)_bad_rank\(\)\n-> raise ValueError\("bad rank"\)\n'
+            r"\(Pdb\)"
+        )
+
+        output = (
+            await debug_cli_stdout.readuntil(
+                f"Detached from debug session for {name} 2".encode()
+            )
+        ).decode()
+        assert len(re.findall(expected_output, output)) == 1
+
+        debug_cli_stdin.writelines([b"quit\n"])
+        await debug_cli_stdin.drain()
+        debug_cli_stdin.close()
+        # Yield and wait so that the debug controller has a chance to process the
+        # input before we close stdin.
+        await asyncio.sleep(1)
+        await debug_cli_stdin.wait_closed()
+        if debug_cli_proc:
+            assert await debug_cli_proc.wait() == 0
+
+        breakpoints = await debug_controller.list.call_one(print_output=False)
+        assert len(breakpoints) == 3
+        for i, rank in enumerate((0, 1, 3)):
+            assert breakpoints[i].rank == rank
+
+        debug_cli_proc, debug_cli_stdin, _ = await create_debug_cli_proc()
+        debug_cli_stdin.writelines([b"continue\n", b"quit\n"])
+        await debug_cli_stdin.drain()
+        # Yield and wait so that the debug controller has a chance to process the
+        # input before we close stdin.
+        await asyncio.sleep(1)
+        debug_cli_stdin.close()
+        await debug_cli_stdin.wait_closed()
+        if debug_cli_proc:
+            assert await debug_cli_proc.wait() == 0
+
+        breakpoints = await _wait_for_breakpoints(debug_controller, 0)
+        assert len(breakpoints) == 0
+
+        with pytest.raises(
+            monarch._src.actor.actor_mesh.ActorError, match="ValueError: bad rank"
+        ):
+            await fut
 
 
 class_closure_source = """class ClassClosure:
@@ -1152,127 +1175,134 @@ async def test_debug_with_pickle_by_value():
     The test unpickles these and sends them to an actor endpoint, in which
     breakpoints will be hit and we can test the special pdb handling logic.
     """
-    pm = proc_mesh(gpus=1, hosts=1)
-    debugee = pm.spawn("debugee", ClosureDebugeeActor)
-    name = debugee.name.choose().get()
+    with scoped_state(ProcessJob({"hosts": 1}), cached_path=None) as state:
+        pm = state.hosts.spawn_procs(per_host={"gpus": 1})
+        debugee = pm.spawn("debugee", ClosureDebugeeActor)
+        name = debugee.name.choose().get()
 
-    input_mock = AsyncMock()
-    input_mock.side_effect = [
-        f"attach {name} 0",
-        "c",
-        "quit",
-        f"attach {name} 0",
-        "bt",
-        "c",
-        "quit",
-        f"attach {name} 0",
-        "b /tmp/monarch_test/class_closure:10",
-        "c",
-        "detach",
-        "quit",
-        f"attach {name} 0",
-        "c",
-        "detach",
-        "quit",
-        "c",
-        "quit",
-    ]
-
-    outputs = []
-
-    def _patch_output(msg):
-        nonlocal outputs
-        outputs.append(msg)
-
-    output_mock = AsyncMock()
-    output_mock.side_effect = _patch_output
-
-    with (
-        patch("monarch._src.actor.debugger.debug_io.DebugStdIO.input", new=input_mock),
-        patch(
-            "monarch._src.actor.debugger.debug_io.DebugStdIO.output", new=output_mock
-        ),
-    ):
-        debug_controller = get_or_spawn_controller(
-            "debug_controller", DebugControllerForTesting
-        ).get()
-
-        # Spawn a special source loader that knows how to retrieve the source code
-        # for /tmp/monarch_test/class_closure.py and
-        # /tmp/monarch_test/function_closure.py
-        get_or_spawn_controller(
-            "source_loader", SourceLoaderControllerWithMockedSource
-        ).get()
-
-        class_closure = load_class_closure()
-        func_bp_true, func_bp_false = load_func_closure()
-
-        fut = debugee.debug_class_closure.call_one(class_closure)
-        breakpoints = await _wait_for_breakpoints(debug_controller, 1)
-        assert breakpoints[0].function == "class_closure.get_arg"
-        assert breakpoints[0].lineno == 14
-
-        debug_controller.blocking_enter.call_one().get()
-
-        assert (
-            "> /tmp/monarch_test/class_closure.py(14)get_arg()\n-> return self.arg"
-            in outputs
-        )
-
-        await fut
-
-        fut = debugee.debug_func.call_one(func_bp_false, class_closure)
-        breakpoints = await _wait_for_breakpoints(debug_controller, 1)
-        assert breakpoints[0].function == "class_closure.get_arg"
-        assert breakpoints[0].lineno == 14
-
-        debug_controller.blocking_enter.call_one().get()
-
-        expected_backtrace = [
-            (
-                "  /tmp/monarch_test/function_closure.py(5)func()\n"
-                "-> return internal().get_arg() + arg"
-            ),
-            "\n",
-            "> /tmp/monarch_test/class_closure.py(14)get_arg()\n-> return self.arg",
-            "\n",
-            "(Pdb) ",
+        input_mock = AsyncMock()
+        input_mock.side_effect = [
+            f"attach {name} 0",
+            "c",
+            "quit",
+            f"attach {name} 0",
+            "bt",
+            "c",
+            "quit",
+            f"attach {name} 0",
+            "b /tmp/monarch_test/class_closure:10",
+            "c",
+            "detach",
+            "quit",
+            f"attach {name} 0",
+            "c",
+            "detach",
+            "quit",
+            "c",
+            "quit",
         ]
-        start = outputs.index(expected_backtrace[0])
-        assert expected_backtrace == outputs[start : start + len(expected_backtrace)]  # noqa
 
-        await fut
+        outputs = []
 
-        fut = debugee.debug_func.call_one(func_bp_true, class_closure)
-        breakpoints = await _wait_for_breakpoints(debug_controller, 1)
-        assert breakpoints[0].function == "function_closure.func"
-        assert breakpoints[0].lineno == 5
+        def _patch_output(msg):
+            nonlocal outputs
+            outputs.append(msg)
 
-        debug_controller.blocking_enter.call_one().get()
+        output_mock = AsyncMock()
+        output_mock.side_effect = _patch_output
 
-        assert (
-            "> /tmp/monarch_test/function_closure.py(5)func()\n-> return internal().get_arg() + arg"
-            in outputs
-        )
-        assert "Breakpoint 1 at /tmp/monarch_test/class_closure.py:10" in outputs
-        assert (
-            "> /tmp/monarch_test/class_closure.py(10)__init__()\n-> self.arg = arg"
-            in outputs
-        )
+        with (
+            patch(
+                "monarch._src.actor.debugger.debug_io.DebugStdIO.input",
+                new=input_mock,
+            ),
+            patch(
+                "monarch._src.actor.debugger.debug_io.DebugStdIO.output",
+                new=output_mock,
+            ),
+        ):
+            debug_controller = get_or_spawn_controller(
+                "debug_controller", DebugControllerForTesting
+            ).get()
 
-        breakpoints = await _wait_for_breakpoints(debug_controller, 1)
-        assert breakpoints[0].function == "class_closure.__init__"
-        assert breakpoints[0].lineno == 10
+            # Spawn a special source loader that knows how to retrieve the source code
+            # for /tmp/monarch_test/class_closure.py and
+            # /tmp/monarch_test/function_closure.py
+            get_or_spawn_controller(
+                "source_loader", SourceLoaderControllerWithMockedSource
+            ).get()
 
-        debug_controller.blocking_enter.call_one().get()
+            class_closure = load_class_closure()
+            func_bp_true, func_bp_false = load_func_closure()
 
-        breakpoints = await _wait_for_breakpoints(debug_controller, 1)
-        assert breakpoints[0].function == "class_closure.get_arg"
-        assert breakpoints[0].lineno == 14
+            fut = debugee.debug_class_closure.call_one(class_closure)
+            breakpoints = await _wait_for_breakpoints(debug_controller, 1)
+            assert breakpoints[0].function == "class_closure.get_arg"
+            assert breakpoints[0].lineno == 14
 
-        debug_controller.blocking_enter.call_one().get()
+            debug_controller.blocking_enter.call_one().get()
 
-        await _wait_for_breakpoints(debug_controller, 0)
+            assert (
+                "> /tmp/monarch_test/class_closure.py(14)get_arg()\n-> return self.arg"
+                in outputs
+            )
 
-        await fut
-        await pm.stop()
+            await fut
+
+            fut = debugee.debug_func.call_one(func_bp_false, class_closure)
+            breakpoints = await _wait_for_breakpoints(debug_controller, 1)
+            assert breakpoints[0].function == "class_closure.get_arg"
+            assert breakpoints[0].lineno == 14
+
+            debug_controller.blocking_enter.call_one().get()
+
+            expected_backtrace = [
+                (
+                    "  /tmp/monarch_test/function_closure.py(5)func()\n"
+                    "-> return internal().get_arg() + arg"
+                ),
+                "\n",
+                "> /tmp/monarch_test/class_closure.py(14)get_arg()\n-> return self.arg",
+                "\n",
+                "(Pdb) ",
+            ]
+            start = outputs.index(expected_backtrace[0])
+            assert (
+                expected_backtrace == outputs[start : start + len(expected_backtrace)]
+            )  # noqa
+
+            await fut
+
+            fut = debugee.debug_func.call_one(func_bp_true, class_closure)
+            breakpoints = await _wait_for_breakpoints(debug_controller, 1)
+            assert breakpoints[0].function == "function_closure.func"
+            assert breakpoints[0].lineno == 5
+
+            debug_controller.blocking_enter.call_one().get()
+
+            assert (
+                "> /tmp/monarch_test/function_closure.py(5)func()\n-> return internal().get_arg() + arg"
+                in outputs
+            )
+            assert "Breakpoint 1 at /tmp/monarch_test/class_closure.py:10" in outputs
+            assert (
+                "> /tmp/monarch_test/class_closure.py(10)__init__()\n-> self.arg = arg"
+                in outputs
+            )
+
+            breakpoints = await _wait_for_breakpoints(debug_controller, 1)
+            assert breakpoints[0].function == "class_closure.__init__"
+            assert breakpoints[0].lineno == 10
+
+            debug_controller.blocking_enter.call_one().get()
+
+            breakpoints = await _wait_for_breakpoints(debug_controller, 1)
+            assert breakpoints[0].function == "class_closure.get_arg"
+            assert breakpoints[0].lineno == 14
+
+            debug_controller.blocking_enter.call_one().get()
+
+            await _wait_for_breakpoints(debug_controller, 0)
+
+            await fut
+            await pm.stop()

--- a/python/tests/test_distributed_telemetry.py
+++ b/python/tests/test_distributed_telemetry.py
@@ -839,36 +839,40 @@ def test_messages_table(cleanup_callbacks) -> None:
 @isolate_in_subprocess
 def test_messages_endpoint(cleanup_callbacks) -> None:
     """Test that the messages table endpoint column is populated with the method name."""
-    job = ProcessJob({"hosts": 1}).enable_telemetry(TelemetryConfig(batch_size=10))
-    state = job.state(cached_path=None)
-    engine = state.query_engine
-    assert engine is not None
-    hosts = state.hosts
-    worker_procs = hosts.spawn_procs(per_host={"workers": 2}, name="ep_workers_procs")
-    workers = worker_procs.spawn("ep_test_worker", WorkerActor)
-    workers.initialized.get()
+    with scoped_state(
+        ProcessJob({"hosts": 1}).enable_telemetry(TelemetryConfig(batch_size=10)),
+        cached_path=None,
+    ) as state:
+        engine = state.query_engine
+        assert engine is not None
+        hosts = state.hosts
+        worker_procs = hosts.spawn_procs(
+            per_host={"workers": 2}, name="ep_workers_procs"
+        )
+        workers = worker_procs.spawn("ep_test_worker", WorkerActor)
+        workers.initialized.get()
 
-    # Call the "ping" endpoint
-    for _ in range(3):
-        workers.ping.call().get()
+        # Call the "ping" endpoint
+        for _ in range(3):
+            workers.ping.call().get()
 
-    # Query for messages with a non-null endpoint received by our workers
-    result = engine.query(
-        "SELECT m.endpoint FROM messages m "
-        "JOIN actors a ON m.to_actor_id = a.id "
-        "JOIN meshes mesh ON a.mesh_id = mesh.id "
-        "WHERE mesh.given_name = 'ep_test_worker' AND m.endpoint IS NOT NULL"
-    )
-    result_dict = result.to_pydict()
-    endpoints = result_dict.get("endpoint", [])
+        # Query for messages with a non-null endpoint received by our workers
+        result = engine.query(
+            "SELECT m.endpoint FROM messages m "
+            "JOIN actors a ON m.to_actor_id = a.id "
+            "JOIN meshes mesh ON a.mesh_id = mesh.id "
+            "WHERE mesh.given_name = 'ep_test_worker' AND m.endpoint IS NOT NULL"
+        )
+        result_dict = result.to_pydict()
+        endpoints = result_dict.get("endpoint", [])
 
-    # 3 casts x 2 workers = 6 messages, all with endpoint "ping"
-    assert len(endpoints) == 6, (
-        f"Expected 6 messages with endpoint, got {len(endpoints)}"
-    )
-    assert all(ep == "ping" for ep in endpoints), (
-        f"Expected all endpoints to be 'ping', got {set(endpoints)}"
-    )
+        # 3 casts x 2 workers = 6 messages, all with endpoint "ping"
+        assert len(endpoints) == 6, (
+            f"Expected 6 messages with endpoint, got {len(endpoints)}"
+        )
+        assert all(ep == "ping" for ep in endpoints), (
+            f"Expected all endpoints to be 'ping', got {set(endpoints)}"
+        )
 
 
 @pytest.mark.timeout(120)
@@ -1339,151 +1343,159 @@ def test_pyspy_tables_in_information_schema(cleanup_callbacks) -> None:
 @isolate_in_subprocess
 def test_store_pyspy_dump_with_child_proc_ref(cleanup_callbacks) -> None:
     """store_pyspy_dump stores data with a child proc_ref."""
-    job = ProcessJob({"hosts": 1}).enable_telemetry(TelemetryConfig(batch_size=10))
-    state = job.state(cached_path=None)
-    engine = state.query_engine
-    assert engine is not None
-    hosts = state.hosts
-    worker_procs = hosts.spawn_procs(per_host={"workers": 2}, name="pyspy_route_procs")
-    workers = worker_procs.spawn("pyspy_route_worker", WorkerActor)
-    workers.initialized.get()
+    with scoped_state(
+        ProcessJob({"hosts": 1}).enable_telemetry(TelemetryConfig(batch_size=10)),
+        cached_path=None,
+    ) as state:
+        engine = state.query_engine
+        assert engine is not None
+        hosts = state.hosts
+        worker_procs = hosts.spawn_procs(
+            per_host={"workers": 2}, name="pyspy_route_procs"
+        )
+        workers = worker_procs.spawn("pyspy_route_worker", WorkerActor)
+        workers.initialized.get()
 
-    coordinator_proc_id = engine._actor.get_proc_id.call_one().get()
+        coordinator_proc_id = engine._actor.get_proc_id.call_one().get()
 
-    # Discover child proc_ids by parsing canonical ActorId strings for ProcAgent actors.
-    # display_name is reserved for user-facing names, so the canonical full_name is the
-    # stable source of system actor identity.
-    proc_agents = engine.query("SELECT full_name FROM actors")
-    proc_agent_names = proc_agents.to_pydict().get("full_name", [])
-    child_proc_refs = [
-        actor_id.proc_id
-        for row in proc_agent_names
-        if (actor_id := ActorId.from_string(row)).label in {"proc_agent", "_proc_agent"}
-        and actor_id.proc_id != coordinator_proc_id
-    ]
-    assert len(child_proc_refs) > 0, f"Expected child proc_refs, got: {proc_agents}"
-    child_proc_ref = child_proc_refs[0]
+        # Discover child proc_ids by parsing canonical ActorId strings for
+        # ProcAgent actors. display_name is reserved for user-facing names,
+        # so the canonical full_name is the stable source of system actor
+        # identity.
+        proc_agents = engine.query("SELECT full_name FROM actors")
+        proc_agent_names = proc_agents.to_pydict().get("full_name", [])
+        child_proc_refs = [
+            actor_id.proc_id
+            for row in proc_agent_names
+            if (actor_id := ActorId.from_string(row)).label
+            in {"proc_agent", "_proc_agent"}
+            and actor_id.proc_id != coordinator_proc_id
+        ]
+        assert len(child_proc_refs) > 0, f"Expected child proc_refs, got: {proc_agents}"
+        child_proc_ref = child_proc_refs[0]
 
-    pyspy_json = json.dumps(
-        {
-            "Ok": {
-                "pid": 9999,
-                "binary": "python3",
-                "stack_traces": [
-                    {
-                        "pid": 9999,
-                        "thread_id": 1,
-                        "thread_name": "MainThread",
-                        "os_thread_id": 200,
-                        "active": True,
-                        "owns_gil": True,
-                        "frames": [
-                            {
-                                "name": "child_fn",
-                                "filename": "child.py",
-                                "module": "child",
-                                "short_filename": "child.py",
-                                "line": 42,
-                                "locals": [],
-                                "is_entry": True,
-                            }
-                        ],
-                    }
-                ],
-                "warnings": [],
+        pyspy_json = json.dumps(
+            {
+                "Ok": {
+                    "pid": 9999,
+                    "binary": "python3",
+                    "stack_traces": [
+                        {
+                            "pid": 9999,
+                            "thread_id": 1,
+                            "thread_name": "MainThread",
+                            "os_thread_id": 200,
+                            "active": True,
+                            "owns_gil": True,
+                            "frames": [
+                                {
+                                    "name": "child_fn",
+                                    "filename": "child.py",
+                                    "module": "child",
+                                    "short_filename": "child.py",
+                                    "line": 42,
+                                    "locals": [],
+                                    "is_entry": True,
+                                }
+                            ],
+                        }
+                    ],
+                    "warnings": [],
+                }
             }
-        }
-    )
+        )
 
-    # Store a pyspy dump targeting the child proc_ref on the root actor.
-    result = engine._actor.store_pyspy_dump.call_one(
-        "child-dump-1", child_proc_ref, pyspy_json
-    ).get()
-    assert result
+        # Store a pyspy dump targeting the child proc_ref on the root actor.
+        result = engine._actor.store_pyspy_dump.call_one(
+            "child-dump-1", child_proc_ref, pyspy_json
+        ).get()
+        assert result
 
-    # The dump should be queryable via distributed scan.
-    frames = engine.query(
-        "SELECT name, line FROM pyspy_frames WHERE dump_id = 'child-dump-1'"
-    )
-    frames_dict = frames.to_pydict()
-    assert frames_dict["name"] == ["child_fn"]
-    assert frames_dict["line"] == [42]
+        # The dump should be queryable via distributed scan.
+        frames = engine.query(
+            "SELECT name, line FROM pyspy_frames WHERE dump_id = 'child-dump-1'"
+        )
+        frames_dict = frames.to_pydict()
+        assert frames_dict["name"] == ["child_fn"]
+        assert frames_dict["line"] == [42]
 
-    # Verify the dump's proc_ref is stored correctly.
-    dumps = engine.query(
-        "SELECT proc_ref FROM pyspy_dumps WHERE dump_id = 'child-dump-1'"
-    )
-    assert dumps.to_pydict()["proc_ref"] == [child_proc_ref]
+        # Verify the dump's proc_ref is stored correctly.
+        dumps = engine.query(
+            "SELECT proc_ref FROM pyspy_dumps WHERE dump_id = 'child-dump-1'"
+        )
+        assert dumps.to_pydict()["proc_ref"] == [child_proc_ref]
 
 
 @pytest.mark.timeout(120)
 @isolate_in_subprocess
 def test_store_pyspy_dump_with_unknown_proc_ref(cleanup_callbacks) -> None:
     """store_pyspy_dump stores data even for unknown proc_ref values."""
-    job = ProcessJob({"hosts": 1}).enable_telemetry(TelemetryConfig(batch_size=10))
-    state = job.state(cached_path=None)
-    engine = state.query_engine
-    assert engine is not None
-    hosts = state.hosts
-    worker_procs = hosts.spawn_procs(
-        per_host={"workers": 2}, name="pyspy_fallback_procs"
-    )
-    workers = worker_procs.spawn("pyspy_fallback_worker", WorkerActor)
-    workers.initialized.get()
+    with scoped_state(
+        ProcessJob({"hosts": 1}).enable_telemetry(TelemetryConfig(batch_size=10)),
+        cached_path=None,
+    ) as state:
+        engine = state.query_engine
+        assert engine is not None
+        hosts = state.hosts
+        worker_procs = hosts.spawn_procs(
+            per_host={"workers": 2}, name="pyspy_fallback_procs"
+        )
+        workers = worker_procs.spawn("pyspy_fallback_worker", WorkerActor)
+        workers.initialized.get()
 
-    # Trigger child spawning.
-    engine.query("SELECT COUNT(*) AS cnt FROM actors")
+        # Trigger child spawning.
+        engine.query("SELECT COUNT(*) AS cnt FROM actors")
 
-    pyspy_json = json.dumps(
-        {
-            "Ok": {
-                "pid": 7777,
-                "binary": "python3",
-                "stack_traces": [
-                    {
-                        "pid": 7777,
-                        "thread_id": 1,
-                        "thread_name": "MainThread",
-                        "os_thread_id": 300,
-                        "active": True,
-                        "owns_gil": False,
-                        "frames": [
-                            {
-                                "name": "orphan_fn",
-                                "filename": "orphan.py",
-                                "module": "orphan",
-                                "short_filename": "orphan.py",
-                                "line": 99,
-                                "locals": [],
-                                "is_entry": True,
-                            }
-                        ],
-                    }
-                ],
-                "warnings": [],
+        pyspy_json = json.dumps(
+            {
+                "Ok": {
+                    "pid": 7777,
+                    "binary": "python3",
+                    "stack_traces": [
+                        {
+                            "pid": 7777,
+                            "thread_id": 1,
+                            "thread_name": "MainThread",
+                            "os_thread_id": 300,
+                            "active": True,
+                            "owns_gil": False,
+                            "frames": [
+                                {
+                                    "name": "orphan_fn",
+                                    "filename": "orphan.py",
+                                    "module": "orphan",
+                                    "short_filename": "orphan.py",
+                                    "line": 99,
+                                    "locals": [],
+                                    "is_entry": True,
+                                }
+                            ],
+                        }
+                    ],
+                    "warnings": [],
+                }
             }
-        }
-    )
+        )
 
-    # Store with a proc_ref that doesn't exist in the tree.
-    result = engine._actor.store_pyspy_dump.call_one(
-        "orphan-dump-1", "nonexistent.proc[999]", pyspy_json
-    ).get()
-    assert result
+        # Store with a proc_ref that doesn't exist in the tree.
+        result = engine._actor.store_pyspy_dump.call_one(
+            "orphan-dump-1", "nonexistent.proc[999]", pyspy_json
+        ).get()
+        assert result
 
-    # The dump should be queryable (stored on root).
-    frames = engine.query(
-        "SELECT name, line FROM pyspy_frames WHERE dump_id = 'orphan-dump-1'"
-    )
-    frames_dict = frames.to_pydict()
-    assert frames_dict["name"] == ["orphan_fn"]
-    assert frames_dict["line"] == [99]
+        # The dump should be queryable (stored on root).
+        frames = engine.query(
+            "SELECT name, line FROM pyspy_frames WHERE dump_id = 'orphan-dump-1'"
+        )
+        frames_dict = frames.to_pydict()
+        assert frames_dict["name"] == ["orphan_fn"]
+        assert frames_dict["line"] == [99]
 
-    # Verify proc_ref is preserved even though it didn't match any proc.
-    dumps = engine.query(
-        "SELECT proc_ref FROM pyspy_dumps WHERE dump_id = 'orphan-dump-1'"
-    )
-    assert dumps.to_pydict()["proc_ref"] == ["nonexistent.proc[999]"]
+        # Verify proc_ref is preserved even though it didn't match any proc.
+        dumps = engine.query(
+            "SELECT proc_ref FROM pyspy_dumps WHERE dump_id = 'orphan-dump-1'"
+        )
+        assert dumps.to_pydict()["proc_ref"] == ["nonexistent.proc[999]"]
 
 
 @pytest.mark.timeout(120)

--- a/python/tests/test_gather_mount.py
+++ b/python/tests/test_gather_mount.py
@@ -117,6 +117,7 @@ class GatherMountBasicTest(unittest.TestCase):
         """Each shard gets its own sub-directory named by its mesh point."""
         from monarch._src.job.process import ProcessJob
         from monarch.gather_mount import gather_mount
+        from scoped_state import scoped_state
 
         base = self._tmpdir()
         for i in range(2):
@@ -128,15 +129,17 @@ class GatherMountBasicTest(unittest.TestCase):
         mnt = self._tmpdir()
         shutil.rmtree(mnt)
 
-        host_mesh = ProcessJob({"hosts": 2}).state(cached_path=None).hosts
-        with gather_mount(host_mesh, os.path.join(base, "$SUBDIR"), mnt):
-            subdirs = sorted(os.listdir(mnt))
-            self.assertEqual(subdirs, ["hosts_0", "hosts_1"])
+        with scoped_state(ProcessJob({"hosts": 2}), cached_path=None) as state:
+            host_mesh = state.hosts
+            with gather_mount(host_mesh, os.path.join(base, "$SUBDIR"), mnt):
+                subdirs = sorted(os.listdir(mnt))
+                self.assertEqual(subdirs, ["hosts_0", "hosts_1"])
 
     def test_ndim_per_shard_content(self) -> None:
         """Each shard sub-directory contains the correct remote files."""
         from monarch._src.job.process import ProcessJob
         from monarch.gather_mount import gather_mount
+        from scoped_state import scoped_state
 
         base = self._tmpdir()
         for i in range(2):
@@ -148,11 +151,12 @@ class GatherMountBasicTest(unittest.TestCase):
         mnt = self._tmpdir()
         shutil.rmtree(mnt)
 
-        host_mesh = ProcessJob({"hosts": 2}).state(cached_path=None).hosts
-        with gather_mount(host_mesh, os.path.join(base, "$SUBDIR"), mnt):
-            for i in range(2):
-                content = open(os.path.join(mnt, f"hosts_{i}", "data.txt")).read()
-                self.assertEqual(content, f"shard={i}\n")
+        with scoped_state(ProcessJob({"hosts": 2}), cached_path=None) as state:
+            host_mesh = state.hosts
+            with gather_mount(host_mesh, os.path.join(base, "$SUBDIR"), mnt):
+                for i in range(2):
+                    content = open(os.path.join(mnt, f"hosts_{i}", "data.txt")).read()
+                    self.assertEqual(content, f"shard={i}\n")
 
     # ── Caching and tail -f ───────────────────────────────────────────────
 
@@ -238,6 +242,7 @@ class GatherMountBasicTest(unittest.TestCase):
         """$SUBDIR in remote_mount_point is replaced with the host's shard key."""
         from monarch._src.job.process import ProcessJob
         from monarch.gather_mount import gather_mount
+        from scoped_state import scoped_state
 
         base = self._tmpdir()
         for i in range(2):
@@ -249,13 +254,14 @@ class GatherMountBasicTest(unittest.TestCase):
         mnt = self._tmpdir()
         shutil.rmtree(mnt)
 
-        host_mesh = ProcessJob({"hosts": 2}).state(cached_path=None).hosts
-        with gather_mount(host_mesh, os.path.join(base, "$SUBDIR"), mnt):
-            for i in range(2):
-                self.assertEqual(
-                    open(os.path.join(mnt, f"hosts_{i}", "info.txt")).read(),
-                    f"host {i}\n",
-                )
+        with scoped_state(ProcessJob({"hosts": 2}), cached_path=None) as state:
+            host_mesh = state.hosts
+            with gather_mount(host_mesh, os.path.join(base, "$SUBDIR"), mnt):
+                for i in range(2):
+                    self.assertEqual(
+                        open(os.path.join(mnt, f"hosts_{i}", "info.txt")).read(),
+                        f"host {i}\n",
+                    )
 
     # ── Context manager ───────────────────────────────────────────────────
 
@@ -303,6 +309,7 @@ class GatherMountProcessJobTest(unittest.TestCase):
         """Each ProcessJob host gets its own dir; gather_mount exposes sub-dirs."""
         from monarch._src.job.process import ProcessJob
         from monarch.gather_mount import gather_mount
+        from scoped_state import scoped_state
 
         num_hosts = 3
         base = self._tmpdir()
@@ -317,25 +324,27 @@ class GatherMountProcessJobTest(unittest.TestCase):
             with open(os.path.join(subdir, "data.bin"), "wb") as f:
                 f.write(bytes(range(i * 10, i * 10 + 10)))
 
-        host_mesh = ProcessJob({"hosts": num_hosts}).state(cached_path=None).hosts
+        with scoped_state(ProcessJob({"hosts": num_hosts}), cached_path=None) as state:
+            host_mesh = state.hosts
 
-        with gather_mount(host_mesh, os.path.join(base, "$SUBDIR"), mnt):
-            subdirs = sorted(os.listdir(mnt))
-            self.assertEqual(subdirs, [f"hosts_{i}" for i in range(num_hosts)])
+            with gather_mount(host_mesh, os.path.join(base, "$SUBDIR"), mnt):
+                subdirs = sorted(os.listdir(mnt))
+                self.assertEqual(subdirs, [f"hosts_{i}" for i in range(num_hosts)])
 
-            for i in range(num_hosts):
-                txt = open(os.path.join(mnt, f"hosts_{i}", "info.txt")).read()
-                self.assertEqual(txt, f"host={i}\n")
+                for i in range(num_hosts):
+                    txt = open(os.path.join(mnt, f"hosts_{i}", "info.txt")).read()
+                    self.assertEqual(txt, f"host={i}\n")
 
-                bin_data = open(
-                    os.path.join(mnt, f"hosts_{i}", "data.bin"), "rb"
-                ).read()
-                self.assertEqual(bin_data, bytes(range(i * 10, i * 10 + 10)))
+                    bin_data = open(
+                        os.path.join(mnt, f"hosts_{i}", "data.bin"), "rb"
+                    ).read()
+                    self.assertEqual(bin_data, bytes(range(i * 10, i * 10 + 10)))
 
     def test_multi_host_listdir(self) -> None:
         """os.listdir on each per-host sub-dir returns only that host's files."""
         from monarch._src.job.process import ProcessJob
         from monarch.gather_mount import gather_mount
+        from scoped_state import scoped_state
 
         base = self._tmpdir()
         mnt = self._tmpdir()
@@ -350,21 +359,25 @@ class GatherMountProcessJobTest(unittest.TestCase):
         for fname in ("c.txt", "d.txt"):
             open(os.path.join(host1, fname), "w").close()
 
-        host_mesh = ProcessJob({"hosts": 2}).state(cached_path=None).hosts
+        with scoped_state(ProcessJob({"hosts": 2}), cached_path=None) as state:
+            host_mesh = state.hosts
 
-        with gather_mount(host_mesh, os.path.join(base, "$SUBDIR"), mnt):
-            self.assertEqual(
-                sorted(os.listdir(os.path.join(mnt, "hosts_0"))), ["a.txt", "b.txt"]
-            )
-            self.assertEqual(
-                sorted(os.listdir(os.path.join(mnt, "hosts_1"))), ["c.txt", "d.txt"]
-            )
+            with gather_mount(host_mesh, os.path.join(base, "$SUBDIR"), mnt):
+                self.assertEqual(
+                    sorted(os.listdir(os.path.join(mnt, "hosts_0"))),
+                    ["a.txt", "b.txt"],
+                )
+                self.assertEqual(
+                    sorted(os.listdir(os.path.join(mnt, "hosts_1"))),
+                    ["c.txt", "d.txt"],
+                )
 
     def test_multi_host_cache_invalidation_append(self) -> None:
         """Appending to a remote file is visible after inotify invalidation fires."""
         from monarch._src.gather_mount.gather_mount import _NOTIFY_BATCH_S
         from monarch._src.job.process import ProcessJob
         from monarch.gather_mount import gather_mount
+        from scoped_state import scoped_state
 
         num_hosts = 2
         base = self._tmpdir()
@@ -380,33 +393,35 @@ class GatherMountProcessJobTest(unittest.TestCase):
             with open(p, "w") as f:
                 f.write(f"initial line host={i}\n")
 
-        host_mesh = ProcessJob({"hosts": num_hosts}).state(cached_path=None).hosts
+        with scoped_state(ProcessJob({"hosts": num_hosts}), cached_path=None) as state:
+            host_mesh = state.hosts
 
-        with gather_mount(host_mesh, os.path.join(base, "$SUBDIR"), mnt):
-            # Prime the cache.
-            for i in range(num_hosts):
-                content = open(os.path.join(mnt, f"hosts_{i}", "log.txt")).read()
-                self.assertIn(f"initial line host={i}", content)
+            with gather_mount(host_mesh, os.path.join(base, "$SUBDIR"), mnt):
+                # Prime the cache.
+                for i in range(num_hosts):
+                    content = open(os.path.join(mnt, f"hosts_{i}", "log.txt")).read()
+                    self.assertIn(f"initial line host={i}", content)
 
-            # Append to each host's log file.
-            time.sleep(0.05)  # ensure mtime advances
-            for i, p in enumerate(log_paths):
-                with open(p, "a") as f:
-                    f.write(f"appended line host={i}\n")
+                # Append to each host's log file.
+                time.sleep(0.05)  # ensure mtime advances
+                for i, p in enumerate(log_paths):
+                    with open(p, "a") as f:
+                        f.write(f"appended line host={i}\n")
 
-            # Wait for inotify batch window + notification round-trip.
-            time.sleep(_NOTIFY_BATCH_S * 4)
+                # Wait for inotify batch window + notification round-trip.
+                time.sleep(_NOTIFY_BATCH_S * 4)
 
-            for i in range(num_hosts):
-                content = open(os.path.join(mnt, f"hosts_{i}", "log.txt")).read()
-                self.assertIn(f"initial line host={i}", content)
-                self.assertIn(f"appended line host={i}", content)
+                for i in range(num_hosts):
+                    content = open(os.path.join(mnt, f"hosts_{i}", "log.txt")).read()
+                    self.assertIn(f"initial line host={i}", content)
+                    self.assertIn(f"appended line host={i}", content)
 
     def test_multi_host_cache_invalidation_replace(self) -> None:
         """Replacing a file is detected and the new (shorter) content is served."""
         from monarch._src.gather_mount.gather_mount import _NOTIFY_BATCH_S
         from monarch._src.job.process import ProcessJob
         from monarch.gather_mount import gather_mount
+        from scoped_state import scoped_state
 
         num_hosts = 2
         base = self._tmpdir()
@@ -422,30 +437,32 @@ class GatherMountProcessJobTest(unittest.TestCase):
             with open(p, "w") as f:
                 f.write(f"version1 host={i}\n")
 
-        host_mesh = ProcessJob({"hosts": num_hosts}).state(cached_path=None).hosts
+        with scoped_state(ProcessJob({"hosts": num_hosts}), cached_path=None) as state:
+            host_mesh = state.hosts
 
-        with gather_mount(host_mesh, os.path.join(base, "$SUBDIR"), mnt):
-            # Prime cache.
-            for i in range(num_hosts):
-                content = open(os.path.join(mnt, f"hosts_{i}", "state.txt")).read()
-                self.assertIn("version1", content)
+            with gather_mount(host_mesh, os.path.join(base, "$SUBDIR"), mnt):
+                # Prime cache.
+                for i in range(num_hosts):
+                    content = open(os.path.join(mnt, f"hosts_{i}", "state.txt")).read()
+                    self.assertIn("version1", content)
 
-            # Overwrite with a shorter string.
-            time.sleep(0.05)
-            for i, p in enumerate(file_paths):
-                with open(p, "w") as f:
-                    f.write(f"v2 h{i}\n")
+                # Overwrite with a shorter string.
+                time.sleep(0.05)
+                for i, p in enumerate(file_paths):
+                    with open(p, "w") as f:
+                        f.write(f"v2 h{i}\n")
 
-            time.sleep(_NOTIFY_BATCH_S * 4)
+                time.sleep(_NOTIFY_BATCH_S * 4)
 
-            for i in range(num_hosts):
-                content = open(os.path.join(mnt, f"hosts_{i}", "state.txt")).read()
-                self.assertEqual(content, f"v2 h{i}\n")
+                for i in range(num_hosts):
+                    content = open(os.path.join(mnt, f"hosts_{i}", "state.txt")).read()
+                    self.assertEqual(content, f"v2 h{i}\n")
 
     def test_multi_host_nested_dirs(self) -> None:
         """Deep sub-directories inside each host's root are traversable."""
         from monarch._src.job.process import ProcessJob
         from monarch.gather_mount import gather_mount
+        from scoped_state import scoped_state
 
         num_hosts = 2
         base = self._tmpdir()
@@ -458,11 +475,12 @@ class GatherMountProcessJobTest(unittest.TestCase):
             with open(os.path.join(sub, "model.pt"), "w") as f:
                 f.write(f"weights_host_{i}\n")
 
-        host_mesh = ProcessJob({"hosts": num_hosts}).state(cached_path=None).hosts
+        with scoped_state(ProcessJob({"hosts": num_hosts}), cached_path=None) as state:
+            host_mesh = state.hosts
 
-        with gather_mount(host_mesh, os.path.join(base, "$SUBDIR"), mnt):
-            for i in range(num_hosts):
-                path = os.path.join(
-                    mnt, f"hosts_{i}", "checkpoints", "step_100", "model.pt"
-                )
-                self.assertEqual(open(path).read(), f"weights_host_{i}\n")
+            with gather_mount(host_mesh, os.path.join(base, "$SUBDIR"), mnt):
+                for i in range(num_hosts):
+                    path = os.path.join(
+                        mnt, f"hosts_{i}", "checkpoints", "step_100", "model.pt"
+                    )
+                    self.assertEqual(open(path).read(), f"weights_host_{i}\n")

--- a/python/tests/test_host_mesh.py
+++ b/python/tests/test_host_mesh.py
@@ -154,15 +154,16 @@ def test_shutdown_host_mesh() -> None:
 async def test_host_mesh_context_manager() -> None:
     """Tests that the HostMesh can be used as a context manager and that it runs
     shutdown on exit"""
-    async with ProcessJob({"hosts": 2}).state(cached_path=None).hosts as hm:
-        pm = hm.spawn_procs(per_host={"gpus": 2})
-        am = pm.spawn("actor", RankActor)
-        await am.get_rank.choose()
-    # Ensure that other operations fail after shutdown.
-    with pytest.raises(RuntimeError, match="HostMesh has already been shut down"):
-        hm.spawn_procs(per_host={"gpus": 2})
-    with pytest.raises(RuntimeError, match="HostMesh has already been shut down"):
-        await hm.shutdown()
+    with scoped_state(ProcessJob({"hosts": 2}), cached_path=None) as state:
+        async with state.hosts as hm:
+            pm = hm.spawn_procs(per_host={"gpus": 2})
+            am = pm.spawn("actor", RankActor)
+            await am.get_rank.choose()
+        # Ensure that other operations fail after shutdown.
+        with pytest.raises(RuntimeError, match="HostMesh has already been shut down"):
+            hm.spawn_procs(per_host={"gpus": 2})
+        with pytest.raises(RuntimeError, match="HostMesh has already been shut down"):
+            await hm.shutdown()
 
 
 @pytest.mark.timeout(60)
@@ -194,31 +195,32 @@ def test_stop_and_reconnect() -> None:
         job = ProcessJob({"hosts": 2})
 
         # First connection: spawn actors, verify they work.
-        hm = job.state(cached_path=None).hosts
-        pm = hm.spawn_procs(per_host={"gpus": 1})
-        am = pm.spawn("actor", RankActor)
-        pids = am.get_pid.call().get()
-        assert len(pids) == 2
-        pids = [pid for _, pid in pids.items()]
+        with scoped_state(job, cached_path=None) as state:
+            hm = state.hosts
+            pm = hm.spawn_procs(per_host={"gpus": 1})
+            am = pm.spawn("actor", RankActor)
+            pids = am.get_pid.call().get()
+            assert len(pids) == 2
+            pids = [pid for _, pid in pids.items()]
 
-        # Stop: terminate user procs but keep workers alive.
-        hm.stop().get()
-        # Ensure that the procs are actually dead.
-        assert all(not is_process_running(pid) for pid in pids)
+            # Stop: terminate user procs but keep workers alive.
+            hm.stop().get()
+            # Ensure that the procs are actually dead.
+            assert all(not is_process_running(pid) for pid in pids)
 
-        # Sleep past the message delivery timeout to ensure that no errors
-        # surface from undeliverable messages to dead procs/actors.
-        time.sleep(7)
+            # Sleep past the message delivery timeout to ensure that no errors
+            # surface from undeliverable messages to dead procs/actors.
+            time.sleep(7)
 
-        # Second connection: reconnect to the same workers via state().
-        hm2 = job.state(cached_path=None).hosts
-        pm2 = hm2.spawn_procs(per_host={"gpus": 1})
-        am2 = pm2.spawn("actor", RankActor)
-        ranks2 = am2.get_rank.call().get()
-        assert len(ranks2) == 2
+            # Second connection: reconnect to the same workers via state().
+            hm2 = job.state(cached_path=None).hosts
+            pm2 = hm2.spawn_procs(per_host={"gpus": 1})
+            am2 = pm2.spawn("actor", RankActor)
+            ranks2 = am2.get_rank.call().get()
+            assert len(ranks2) == 2
 
-        # Shutdown: fully tear down and exit workers.
-        hm2.shutdown().get()
+            # Shutdown: fully tear down and exit workers.
+            hm2.shutdown().get()
 
 
 @pytest.mark.timeout(120)
@@ -234,33 +236,34 @@ def test_stop_only_drains_own_mesh_procs() -> None:
     job = ProcessJob({"hosts": 2})
 
     # First mesh: simulate the main process.
-    state1 = job.state(cached_path=None)
-    hm1 = state1.hosts
-    pm1 = hm1.spawn_procs(per_host={"gpus": 1}, name="proc1")
-    am1 = pm1.spawn("actor", RankActor)
-    pids1 = list(am1.get_pid.call().get().values())
-    assert len(pids1) == 2
+    with scoped_state(job, cached_path=None) as state1:
+        hm1 = state1.hosts
+        pm1 = hm1.spawn_procs(per_host={"gpus": 1}, name="proc1")
+        am1 = pm1.spawn("actor", RankActor)
+        pids1 = list(am1.get_pid.call().get().values())
+        assert len(pids1) == 2
 
-    # Second mesh: simulate the mount process reconnecting. This creates
-    # a new HostMesh with a different name via a second state() call.
-    state2 = job.state(cached_path=None)
-    hm2 = state2.hosts
-    pm2 = hm2.spawn_procs(per_host={"gpus": 1}, name="proc2")
-    am2 = pm2.spawn("actor", RankActor)
-    pids2 = list(am2.get_pid.call().get().values())
-    assert len(pids2) == 2
+        # Second mesh: simulate the mount process reconnecting. This
+        # creates a new HostMesh with a different name via a second
+        # state() call on the same job.
+        state2 = job.state(cached_path=None)
+        hm2 = state2.hosts
+        pm2 = hm2.spawn_procs(per_host={"gpus": 1}, name="proc2")
+        am2 = pm2.spawn("actor", RankActor)
+        pids2 = list(am2.get_pid.call().get().values())
+        assert len(pids2) == 2
 
-    # Stop the first mesh — should only drain its own procs.
-    hm1.stop().get()
+        # Stop the first mesh — should only drain its own procs.
+        hm1.stop().get()
 
-    # Procs from mesh1 should be stopped.
-    assert all(not is_process_running(pid) for pid in pids1)
+        # Procs from mesh1 should be stopped.
+        assert all(not is_process_running(pid) for pid in pids1)
 
-    # Procs from mesh2 should still be alive.
-    assert all(is_process_running(pid) for pid in pids2)
+        # Procs from mesh2 should still be alive.
+        assert all(is_process_running(pid) for pid in pids2)
 
-    # Clean up mesh2.
-    hm2.shutdown().get()
+        # Clean up mesh2.
+        hm2.shutdown().get()
 
 
 class PidActor(Actor):


### PR DESCRIPTION
Summary:

Tests that build a `ProcessJob` directly (`ProcessJob({...}).state(...).hosts`) and never wrap it in `scoped_state` leak both ends of the lifecycle: worker subprocesses (spawned with `start_new_session=True`) survive `Popen` reference drop, and the `/tmp/monarch_process_job_*/` tmpdir is only cleaned up inside `ProcessJob._kill`. Across a long pytest run this accumulates dozens of straggler workers and hundreds of tmpdirs — enough load to perturb the channel-ack flush race fixed in D102661335.

Wraps every `ProcessJob` test usage in `scoped_state` so worker shutdown and tmpdir cleanup are guaranteed. `test_proc_mesh.py::test_actor_spawn_does_not_block_on_proc_mesh_init` is left as-is (already plumbs its own `try/finally` with `job.kill()`; existing comment explains why `scoped_state` cannot be used). `test_cli_integration.py` is also left alone (manages its own lifecycle via the `monarch.tools.cli` subprocess).

Reviewed By: zdevito

Differential Revision: D102671781


