### PR TITLE
Upload test result XML files as GHA artifacts (#3670)

### DIFF
--- a/.github/workflows/test-cpu-python-macos.yml
+++ b/.github/workflows/test-cpu-python-macos.yml
@@ -77,3 +77,11 @@ jobs:
           set -eux
           source scripts/common-setup-macos.sh
           run_test_groups
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results-cpu-python-macos-${{ github.sha }}
+          path: test-results/*.xml
+          if-no-files-found: ignore

--- a/.github/workflows/test-cpu-python.yml
+++ b/.github/workflows/test-cpu-python.yml
@@ -29,6 +29,7 @@ jobs:
       runner: ${{ inputs.runner }}
       submodules: recursive
       download-artifact: ${{ inputs.artifact-name }}
+      upload-artifact: test-results-cpu-python-${{ github.sha }}
       script: |
         # Source common setup functions
         source scripts/common-setup.sh
@@ -57,3 +58,5 @@ jobs:
         # Run CPU Python tests (excluding GPU/tensor engine tests)
         # TODO: Add appropriate test filters for CPU-only Python tests
         echo "CPU Python tests would run here - currently placeholder"
+
+        stage_test_artifacts

--- a/.github/workflows/test-cpu-rust-macos.yml
+++ b/.github/workflows/test-cpu-rust-macos.yml
@@ -69,3 +69,20 @@ jobs:
             --exclude monarch_extension \
             --exclude monarch_bench \
             --exclude monarch_conda
+
+      - name: Stage nextest results
+        if: always()
+        shell: bash
+        run: |
+          mkdir -p test-results
+          if [[ -f "${{ runner.temp }}/cargo-target/nextest/ci/junit.xml" ]]; then
+            cp -v "${{ runner.temp }}/cargo-target/nextest/ci/junit.xml" test-results/nextest-junit.xml
+          fi
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results-cpu-rust-macos-${{ github.sha }}
+          path: test-results/nextest-junit.xml
+          if-no-files-found: ignore

--- a/.github/workflows/test-cpu-rust.yml
+++ b/.github/workflows/test-cpu-rust.yml
@@ -29,6 +29,7 @@ jobs:
       runner: ${{ inputs.runner }}
       docker-image: ${{ inputs.docker-image }}
       submodules: recursive
+      upload-artifact: test-results-cpu-rust-${{ github.sha }}
       script: |
         # Source common setup functions
         source scripts/common-setup.sh
@@ -51,8 +52,11 @@ jobs:
 
         # Run CPU-safe Rust tests (no GPU hardware available)
         echo "Running CPU Rust tests..."
-        # Exclude crates that require GPU hardware, CUDA libraries, or
-        # torch C++ headers (libtorch) not available on CPU-only runners.
+        # Capture the test exit code so stage_test_artifacts still runs on
+        # failure (otherwise set -e would exit before any artifacts are
+        # uploaded). Exclude crates that require GPU hardware, CUDA libraries,
+        # or torch C++ headers (libtorch) not available on CPU-only runners.
+        rc=0
         timeout 12m cargo nextest run --workspace --profile ci \
           -E "$(cat .config/nextest-filter.txt)" \
           --exclude monarch_messages \
@@ -65,8 +69,11 @@ jobs:
           --exclude monarch_cpp_static_libs \
           --exclude monarch_extension \
           --exclude monarch_bench \
-          --exclude monarch_conda
+          --exclude monarch_conda || rc=$?
 
         echo "=== sccache stats ==="
         sccache --show-stats || true
         echo "=== end sccache stats ==="
+
+        stage_test_artifacts
+        exit $rc

--- a/.github/workflows/test-gpu-python.yml
+++ b/.github/workflows/test-gpu-python.yml
@@ -25,6 +25,7 @@ jobs:
       gpu-arch-version: ${{ matrix.gpu-arch-version }}
       submodules: recursive
       download-artifact: monarch-${{ matrix.name }}-${{ github.sha }}-py3.10
+      upload-artifact: test-results-gpu-python-${{ matrix.name }}-${{ github.sha }}
       script: |
         # Source common setup functions
         source scripts/common-setup.sh
@@ -61,8 +62,15 @@ jobs:
         # Each group runs separately with process cleanup in between
         pip install pytest-split
 
+        # run_test_groups disables errexit internally and leaks `set +e`,
+        # so capture its exit code before `stage_test_artifacts` runs;
+        # otherwise stage_test_artifacts's exit 0 masks a test failure.
         run_test_groups
+        rc=$?
 
         # TODO(meriksen): temporarily disabled to unblock lands while debugging
         # mock CUDA issues on the OSS setup
         # python python/tests/test_mock_cuda.py
+
+        stage_test_artifacts
+        exit $rc

--- a/.github/workflows/test-gpu-rust.yml
+++ b/.github/workflows/test-gpu-rust.yml
@@ -25,6 +25,7 @@ jobs:
       gpu-arch-version: ${{ matrix.gpu-arch-version }}
       submodules: recursive
       download-artifact: monarch-${{ matrix.name }}-${{ github.sha }}-py3.10
+      upload-artifact: test-results-gpu-rust-${{ matrix.name }}-${{ github.sha }}
       script: |
         # Source common setup functions
         source scripts/common-setup.sh
@@ -64,20 +65,25 @@ jobs:
         # * monarch_messages: monarch/target/debug/deps/monarch_messages-...:
         #   /lib64/libm.so.6: version `GLIBC_2.29' not found
         #   (required by /meta-pytorch/monarch/libtorch/lib/libtorch_cpu.so)
+        # Capture the test exit code so stage_test_artifacts still runs on
+        # failure (otherwise set -e would exit before any artifacts are
+        # uploaded).
+        rc=0
         timeout 12m cargo nextest run --workspace --profile ci \
           -E "$(cat .config/nextest-filter.txt)" \
           --exclude monarch_messages \
           --exclude monarch_tensor_worker \
           --exclude torch-sys-cuda \
           --exclude monarch_rdma \
-          --exclude torch-sys
+          --exclude torch-sys || rc=$?
 
         echo "=== sccache stats ==="
         sccache --show-stats || true
         echo "=== end sccache stats ==="
 
-        # Copy the test results to the expected location
-        # TODO: error in pytest-results-action, TypeError: results.testsuites.testsuite.testcase is not iterable
-        # Don't try to parse these results for now.
-        # mkdir -p "${RUNNER_TEST_RESULTS_DIR:-test-results}"
-        # cp target/nextest/ci/junit.xml "${RUNNER_TEST_RESULTS_DIR:-test-results}/junit.xml"
+        # NOTE: We deliberately do NOT copy nextest's junit.xml into
+        # RUNNER_TEST_RESULTS_DIR. pytest-results-action chokes on it with
+        # "TypeError: results.testsuites.testsuite.testcase is not iterable".
+        # stage_test_artifacts uploads it under a separate name instead.
+        stage_test_artifacts
+        exit $rc

--- a/scripts/common-setup-macos.sh
+++ b/scripts/common-setup-macos.sh
@@ -31,6 +31,8 @@ install_macos_rust_test_dependencies() {
 # between runs.
 run_test_groups() {
     set +e
+    local test_results_dir="${RUNNER_TEST_RESULTS_DIR:-test-results}"
+    mkdir -p "$test_results_dir"
     local FAILED_GROUPS=()
     local TEST_EXIT_CODE=0
     for GROUP in $(seq 1 10); do
@@ -44,6 +46,7 @@ run_test_groups() {
             --ignore-glob="**/meta/**" \
             --dist=no \
             --group="$GROUP" \
+            --junit-xml="$test_results_dir/test-results-$GROUP.xml" \
             --splits=10
         TEST_EXIT_CODE=$?
         if [[ $TEST_EXIT_CODE -eq 0 ]]; then

--- a/scripts/common-setup.sh
+++ b/scripts/common-setup.sh
@@ -332,3 +332,23 @@ run_test_groups() {
   fi
   set -e
 }
+
+# Stage JUnit XML test results into RUNNER_ARTIFACT_DIR so linux_job_v2.yml
+# uploads them as a workflow artifact (when the caller sets upload-artifact).
+# Picks up pytest XMLs from RUNNER_TEST_RESULTS_DIR and the cargo-nextest
+# junit.xml; safe to call from a workflow that only ran one of them.
+#
+# Removes any *.whl that download-artifact placed in RUNNER_ARTIFACT_DIR first,
+# so the test-results artifact doesn't re-upload the wheel under its own name.
+# (The build workflow uploaded the wheel under its own name; that artifact
+# remains separately downloadable on the GitHub run summary.)
+stage_test_artifacts() {
+  : "${RUNNER_ARTIFACT_DIR:?RUNNER_ARTIFACT_DIR must be set}"
+  rm -f "${RUNNER_ARTIFACT_DIR}"/*.whl
+  if [[ -d "${RUNNER_TEST_RESULTS_DIR:-test-results}" ]]; then
+    cp -v "${RUNNER_TEST_RESULTS_DIR:-test-results}"/*.xml "${RUNNER_ARTIFACT_DIR}/" 2>/dev/null || true
+  fi
+  if [[ -f target/nextest/ci/junit.xml ]]; then
+    cp -v target/nextest/ci/junit.xml "${RUNNER_ARTIFACT_DIR}/nextest-junit.xml"
+  fi
+}


### PR DESCRIPTION
Summary:

The Monarch GitHub Actions test workflows generate JUnit XML files (pytest, cargo-nextest), but they were discarded with the runner. `pmeier/pytest-results-action` consumed them in-place to render UI annotations, but no artifact was ever uploaded — so external consumers had nothing to fetch.

Each test workflow now uploads its JUnit XMLs as a separately downloadable GitHub artifact named `test-results-<workflow-id>-[<matrix.name>-]<sha>` (`cpu-python`, `cpu-rust`, `gpu-python`, `gpu-rust`, `cpu-python-macos`, `cpu-rust-macos`). The workflow-id segment is hardcoded per file rather than derived from `${{ github.job }}`: that expression resolves empty in the reusable-workflow caller context, which previously caused three workflows to collide on `test-results--<sha>`. Hardcoded names are also stable across PR / push to main / nightly / workflow_dispatch.

Linux workflows go through `pytorch/test-infra`'s `linux_job_v2.yml`, which uploads the contents of `RUNNER_ARTIFACT_DIR`. A new `stage_test_artifacts` helper in `scripts/common-setup.sh` first removes any `*.whl` that `download-artifact:` placed in `RUNNER_ARTIFACT_DIR` (so the wheel doesn't get re-uploaded under the test-results name — it's still separately downloadable from the build workflow's own artifact), then copies pytest XMLs from `RUNNER_TEST_RESULTS_DIR` and cargo-nextest's `target/nextest/ci/junit.xml` (renamed `nextest-junit.xml`) into `RUNNER_ARTIFACT_DIR`. Each linux test workflow sets `upload-artifact:` and ends its `script:` with `stage_test_artifacts`. The existing pmeier/pytest-results-action UI rendering is unaffected — that step reads from `RUNNER_TEST_RESULTS_DIR`, which we don't touch.

macOS workflows don't use `linux_job_v2.yml`, so they get an explicit `actions/upload-artifact@v4` step with `if: always()`, `if-no-files-found: ignore`, and a tight `path:` glob (XMLs only — no wheel-pollution risk). Two macOS gaps had to close: `run_test_groups` in `common-setup-macos.sh` now passes `--junit-xml` (it never emitted XMLs before), and the Rust workflow has a small staging step that copies nextest's `junit.xml` to `test-results/nextest-junit.xml` so the file inside the artifact has the same name as on linux.

Differential Revision: D102869250


