### PR TITLE
Remove dead code orphaned by D102655612

### DIFF
--- a/python/monarch/_src/tools/commands.py
+++ b/python/monarch/_src/tools/commands.py
@@ -6,10 +6,8 @@
 
 # pyre-strict
 
-import argparse
 import asyncio
 import getpass
-import inspect
 import logging
 import os
 import subprocess
@@ -18,7 +16,7 @@ import tempfile
 import time
 from datetime import datetime, timedelta
 from pathlib import Path
-from typing import Any, Callable, Mapping, Optional, Union
+from typing import Any, Mapping, Optional, Union
 
 from monarch.tools.colors import CYAN, ENDC
 from monarch.tools.config import (  # @manual=//monarch/python/monarch/tools/config/meta:defaults
@@ -30,8 +28,6 @@ from monarch.tools.utils import MONARCH_HOME
 from torchx.runner import Runner  # @manual=//torchx/runner:lib_core
 from torchx.specs import AppDef, AppDryRunInfo, AppState, CfgVal, parse_app_handle
 from torchx.specs.api import is_terminal
-from torchx.specs.builders import parse_args
-from torchx.util.types import decode, decode_optional
 
 logger: logging.Logger = logging.getLogger(__name__)
 
@@ -48,52 +44,6 @@ def torchx_runner() -> Runner:
     # so that server handle is short (e.g. slurm:///job-id)
     _EMPTY_NS = ""
     return Runner(_EMPTY_NS, defaults.scheduler_factories())
-
-
-def component_args_from_cli(
-    component_fn: Callable[..., AppDef], component_args: list[str]
-) -> dict[str, Any]:
-    """Parses component function's arguments from 'argname=argvalue' strings.
-
-    Returns: component arguments kwarg-ified.
-    """
-
-    cli_fied_component_args = []
-    for arg in component_args:
-        argname = arg.split("=")[0]
-        # torchx auto-generates an argparse parser for component function based
-        # type-hints and docstring as if the component was a CLI itself so we have to
-        # CLI arg-ify the component arguments by adding a "-" for
-        # single-char argnames (short arg) and "--" for multi-char (long arg)
-        cli_fied_component_args.append(f"-{arg}" if len(argname) == 1 else f"--{arg}")
-
-    parsed_args: argparse.Namespace = parse_args(component_fn, cli_fied_component_args)
-
-    # TODO kiuk@ logic below needs to move into torchx.specs.builders.parse_args()
-    #  which is copied from torchx.specs.builders.materialize_appdef()
-    #  parse_args() returns all the component parameters parsed from cli inputs
-    #  as a string. Additional parameter type matching needs to be done (as below)
-    #  to turn the CLI inputs to component function arguments.
-    component_kwargs = {}
-
-    parameters = inspect.signature(component_fn).parameters
-    for param_name, parameter in parameters.items():
-        arg_value = getattr(parsed_args, param_name)
-        parameter_type = parameter.annotation
-        parameter_type = decode_optional(parameter_type)
-        arg_value = decode(arg_value, parameter_type)
-        if parameter.kind == inspect.Parameter.VAR_POSITIONAL:
-            raise TypeError(
-                f"component fn param `{param_name}` is a '*arg' which is not supported; consider changing the type to a list"
-            )
-        elif parameter.kind == inspect.Parameter.VAR_KEYWORD:
-            raise TypeError(
-                f"component fn param `{param_name}` is a '**kwargs' which is not supported; consider changing the type to a dict or explicitly declare the params"
-            )
-        else:
-            component_kwargs[param_name] = arg_value
-
-    return component_kwargs
 
 
 def create(
@@ -418,16 +368,6 @@ def kill_and_confirm(
     raise Exception(
         f"Server {server_handle} did not reach a terminal state within {timeout_after_kill} seconds after kill",
     )
-
-
-def bounce(server_handle: str) -> None:
-    """(re)starts the server's processes without tearing down the server's job."""
-    raise NotImplementedError("`bounce` is not yet implemented")
-
-
-def stop(server_handle: str) -> None:
-    """Stops the server's unix processes without tearing down the server's job."""
-    raise NotImplementedError("`stop` is not yet implemented")
 
 
 def debug(host: str, port: int) -> None:

--- a/python/monarch/tools/commands.py
+++ b/python/monarch/tools/commands.py
@@ -6,8 +6,6 @@
 
 from monarch._src.tools.commands import (
     apply_job,
-    bounce,
-    component_args_from_cli,
     context_create,
     context_ls,
     context_rm,
@@ -23,14 +21,11 @@ from monarch._src.tools.commands import (
     load_current_job,
     MONARCH_DIR,
     server_ready,
-    stop,
     torchx_runner,
 )
 
 __all__ = [
     "apply_job",
-    "bounce",
-    "component_args_from_cli",
     "context_create",
     "context_ls",
     "context_rm",
@@ -46,6 +41,5 @@ __all__ = [
     "load_current_job",
     "MONARCH_DIR",
     "server_ready",
-    "stop",
     "torchx_runner",
 ]

--- a/python/tests/_src/tools/test_commands.py
+++ b/python/tests/_src/tools/test_commands.py
@@ -15,7 +15,7 @@ from unittest import mock
 from unittest.mock import MagicMock
 
 from monarch._src.tools import commands
-from monarch._src.tools.commands import component_args_from_cli, server_ready
+from monarch._src.tools.commands import server_ready
 from monarch.tools.config import Config
 from monarch.tools.config.workspace import Workspace
 from monarch.tools.mesh_spec import MeshSpec, ServerSpec
@@ -35,16 +35,6 @@ def _appdef() -> AppDef:
 
 
 class TestCommands(unittest.TestCase):
-    def test_component_args_from_cli(self) -> None:
-        def fn(h: str, num_hosts: int) -> AppDef:
-            return AppDef("_unused_", roles=[Role("_unused_", "_unused_")])
-
-        args = component_args_from_cli(fn, ["h=gpu.medium", "num_hosts=4"])
-
-        # should be able to call the component function with **args as kwargs
-        self.assertIsNotNone(fn(**args))
-        self.assertDictEqual({"h": "gpu.medium", "num_hosts": 4}, args)
-
     def test_create_dryrun(self) -> None:
         scheduler = "slurm"
         config = Config(

--- a/python/tests/tools/test_cli.py
+++ b/python/tests/tools/test_cli.py
@@ -6,12 +6,9 @@
 
 # pyre-strict
 
-import os
 import unittest
 
 from monarch.tools.cli import get_parser, main
-
-_CURRENT_WORKING_DIR: str = os.getcwd()
 
 
 class TestCli(unittest.TestCase):
@@ -19,112 +16,6 @@ class TestCli(unittest.TestCase):
         with self.assertRaises(SystemExit) as cm:
             main(["--help"])
             self.assertEqual(cm.exception.code, 0)
-
-    # ── Original CLI tests (create, info, kill, bounce, stop) ──────────
-    # These tests are for the old CLI subcommands that were replaced by
-    # serve/exec/use/kill.  Commented out until the old commands are
-    # either restored as aliases or the tests are migrated.
-
-    # @mock.patch(
-    #     # prevent images from actually being pulled during tests
-    #     "torchx.schedulers.local_scheduler.ImageProvider.fetch",
-    #     return_value=_CURRENT_WORKING_DIR,
-    # )
-    # def test_create_dryrun_default(self, _) -> None:  # type: ignore[no-untyped-def]
-    #     # use local_cwd as a representative scheduler to run the test with
-    #     main(
-    #         [
-    #             "create",
-    #             "-s=local_cwd",
-    #             "--dryrun",
-    #             "-arg=image=_DUMMY_IMAGE:0",
-    #         ]
-    #     )
-
-    # @mock.patch("monarch.tools.cli.info")
-    # def test_info(self, mock_cmd_info: mock.MagicMock) -> None:
-    #     job_name = "imaginary-test-job"
-    #     mock_cmd_info.return_value = ServerSpec(
-    #         name=job_name,
-    #         scheduler="slurm",
-    #         state=AppState.RUNNING,
-    #         meshes=[
-    #             MeshSpec(name="trainer", num_hosts=4, host_type="gpu.medium", gpus=2),
-    #             MeshSpec(name="generator", num_hosts=16, host_type="gpu.small", gpus=1),
-    #         ],
-    #     )
-    #     with capture_stdout() as buf:
-    #         main(["info", f"slurm:///{job_name}"])
-    #         out = buf.getvalue()
-    #         expected = """
-    # {
-    #   "name": "imaginary-test-job",
-    #   "server_handle": "slurm:///imaginary-test-job",
-    #   "state": "RUNNING",
-    #   "meshes": {
-    #     "trainer": {
-    #       "host_type": "gpu.medium",
-    #       "hosts": 4,
-    #       "gpus": 2,
-    #       "hostnames": []
-    #     },
-    #     "generator": {
-    #       "host_type": "gpu.small",
-    #       "hosts": 16,
-    #       "gpus": 1,
-    #       "hostnames": []
-    #     }
-    #   }
-    # }
-    # """
-    #         self.assertEqual(
-    #             expected.strip("\n"),
-    #             json.dumps(json.loads(out), indent=2),
-    #         )
-
-    # @mock.patch("monarch.tools.cli.kill")
-    # def test_kill(self, mock_cmd_kill: mock.MagicMock) -> None:
-    #     handle = "slurm:///test-job-id"
-    #     main(["kill", handle])
-    #     mock_cmd_kill.assert_called_once_with(handle)
-
-    # def test_config_from_cli_args(self) -> None:
-    #     parser = get_parser()
-    #     args = parser.parse_args(
-    #         [
-    #             "create",
-    #             "--scheduler=slurm",
-    #             "-cfg=partition=test",
-    #             "-cfg=mail-user=foo@bar.com,mail-type=FAIL",
-    #             "--dryrun",
-    #             "--workspace=/mnt/users/foo",
-    #         ]
-    #     )
-    #
-    #     config = config_from_cli_args(args)
-    #     self.assertEqual(
-    #         Config(
-    #             scheduler="slurm",
-    #             scheduler_args={
-    #                 "partition": "test",
-    #                 "mail-user": "foo@bar.com",
-    #                 "mail-type": "FAIL",
-    #             },
-    #             dryrun=True,
-    #             workspace=Workspace(dirs={"/mnt/users/foo": ""}),
-    #         ),
-    #         config,
-    #     )
-
-    # def test_bounce(self) -> None:
-    #     with self.assertRaises(NotImplementedError):
-    #         main(["bounce", "slurm:///test-job-id"])
-
-    # def test_stop(self) -> None:
-    #     with self.assertRaises(NotImplementedError):
-    #         main(["stop", "slurm:///test-job-id"])
-
-    # ── New CLI tests (serve, exec, use, rank targeting) ──────────────
 
     def test_apply_module_path(self) -> None:
         parser = get_parser()


### PR DESCRIPTION
Summary:
D102655612 deleted the old `CreateCmd`, `InfoCmd`, `OldKillCmd`, `BounceCmd`, and `StopCmd` classes from `tools/cli.py`. Those were the only production callers of three helpers in `monarch._src.tools.commands`, which are now dead:

- `bounce()` and `stop()` — `NotImplementedError` stubs with no callers anywhere.
- `component_args_from_cli()` — CLI arg-ifier whose only remaining caller was its own unit test.

This change deletes those three functions, drops the now-unused `argparse`, `inspect`, `Callable`, `parse_args`, `decode`, and `decode_optional` imports, prunes the corresponding entries from the `monarch.tools.commands` re-export shim and `__all__`, removes the obsolete `test_component_args_from_cli` test, and clears a ~100-line block of commented-out CLI tests in `test_cli.py` that referenced subcommands that no longer exist (along with the now-orphaned `os` import and `_CURRENT_WORKING_DIR` constant).

The other helpers the old CLI used to import (`torchx_runner`, `info`, `kill`, `create`, `Config`, `defaults`) all retain live callers in examples, benches, or `_src/tools/commands.py` itself and are left alone.

Differential Revision: D103001536


