### PR TITLE
hyperactor: separate export from spawnable registration

### DIFF
--- a/docs/source/books/hyperactor-book/src/actors/binds.md
+++ b/docs/source/books/hyperactor-book/src/actors/binds.md
@@ -14,10 +14,8 @@ In most cases, you do not implement this trait manually. Instead, the `#[export]
 
 For example:
 ```rust
-#[hyperactor::export(
-    spawn = true,
-    handlers = [ShoppingList],
-)]
+#[hyperactor::spawnable]
+#[hyperactor::export(ShoppingList)]
 struct ShoppingListActor;
 ```
 Expands to:

--- a/docs/source/books/hyperactor-book/src/actors/index.md
+++ b/docs/source/books/hyperactor-book/src/actors/index.md
@@ -9,7 +9,7 @@ This chapter introduces the actor system in hyperactor. We'll cover:
 - The [`Actor`](./actor.md) trait and its lifecycle hooks
 - The [`Handler`](./handler.md) trait for defining message-handling behavior
 - The [`RemoteSpawn`](./remote_spawn.md) trait for enabling remote spawning
-- The [remote actor registry](./remote.md) for registering remotable-spawnable actors via `remote!` and spawning them by global type name
+- The [remote actor registry](./remote.md) for registering remotable-spawnable actors via `#[spawnable]` or `register_spawnable!(...)` and spawning them by global type name
 - The [`Referable`](./referable.md) marker trait for remotely referencable types
 - The [`Binds`](./binds.md) trait for wiring exported ports to reference types
 - The [`RemoteHandles`](./remote_handles.md) trait for associating message types with a reference

--- a/docs/source/books/hyperactor-book/src/actors/remote.md
+++ b/docs/source/books/hyperactor-book/src/actors/remote.md
@@ -1,15 +1,16 @@
 # Remote Registry
 
-The `hyperactor::actor::remote` module provides the process-local registry for remote-spawnable actors. It is the counterpart to `RemoteSpawn`: given actor types that implement `RemoteSpawn` and are registered with `remote!`, this module discovers them at runtime and allows actors to be spawned by their global type name. The implementation uses the [`inventory`](https://docs.rs/inventory/0.3.21/inventory/index.html) crate to collect registrations contributed from any crate linked into the application.
+The `hyperactor::actor::remote` module provides the process-local registry for remote-spawnable actors. It is the counterpart to `RemoteSpawn`: given actor types that implement `RemoteSpawn` and are registered with `#[spawnable]` or `register_spawnable!(...)`, this module discovers them at runtime and allows actors to be spawned by their global type name. The implementation uses the [`inventory`](https://docs.rs/inventory/0.3.21/inventory/index.html) crate to collect registrations contributed from any crate linked into the application.
 
-## Registration model and the `remote!` macro
+## Registration model and spawnable registration
 
-Remote-spawnable actors are registered using the `remote!` macro. Given an actor type that implements [`RemoteSpawn`](./remote_spawn.md) and `Named`, `remote!(MyActor)` arranges for a `SpawnableActor` record to be submitted to a global registry using the [`inventory`](https://docs.rs/inventory/0.3.21/inventory/index.html) crate.
+Remote-spawnable actors are registered using either the `#[spawnable]` attribute or the `register_spawnable!` macro. Given an actor type that implements [`RemoteSpawn`](./remote_spawn.md) and `Named`, either form arranges for a `SpawnableActor` record to be submitted to a global registry using the [`inventory`](https://docs.rs/inventory/0.3.21/inventory/index.html) crate.
 
 In idiomatic use:
 ```rust
 #[derive(Debug)]
-#[hyperactor::export(handlers = [()])]
+#[hyperactor::spawnable]
+#[hyperactor::export(())]
 struct MyActor;
 
 impl Actor for MyActor {}
@@ -26,11 +27,9 @@ impl RemoteSpawn for MyActor {
         }
     }
 }
-
-remote!(MyActor);
 ```
 
-Conceptually, the `remote!` invocation expands to something like:
+Conceptually, the generated registration expands to something like:
 ```rust
 static MY_ACTOR_NAME: std::sync::LazyLock<&'static str> =
     std::sync::LazyLock::new(|| <MyActor as hyperactor::data::Named>::typename());
@@ -43,7 +42,7 @@ inventory::submit! {
     }
 }
 ```
-The real macro uses `paste!` to synthesize the `MY_ACTOR_NAME` identifier and the crate-local paths, but the effect is the same:
+The real expansion uses crate-local paths and an anonymous const wrapper, but the effect is the same:
 - compute a **global type name** for `MyActor` via `Named::typename()`,
 - build a `SpawnableActor` record that points at `MyActor`s `RemoteSpawn` implementation, and
 - submit that record into the inventory of `SpawnableActor` entries.
@@ -52,7 +51,7 @@ At runtime, the `Remote` registry (described below) discovers all such submissio
 
 ## `SpawnableActor`: registration records
 
-A `SpawnableActor` is the type-erased registration record produced by `remote!`. Each remotely spawnable actor type contributes exactly one of these records to the process. The registry discovers them at runtime and uses them to look up actors by global type name and to invoke their type-erased constructor.
+A `SpawnableActor` is the type-erased registration record produced by `#[spawnable]` or `register_spawnable!(...)`. Each remotely spawnable actor type contributes exactly one of these records to the process. The registry discovers them at runtime and uses them to look up actors by global type name and to invoke their type-erased constructor.
 ```rust
 #[derive(Debug)]
 pub struct SpawnableActor {
@@ -72,17 +71,17 @@ pub struct SpawnableActor {
 - `gspawn` is the type-erased entry point for constructing the actor on a remote `Proc`. It is backed by the actor's `RemoteSpawn::gspawn` implementation and handles deserializing parameters and invoking `RemoteSpawn::new(...).await`.
 - `get_type_id` returns the actor's `TypeId`, allowing the registry to map a concrete Rust type back to it's registration entry.
 
-Users never construct a `SpawnableActor` manually; these records are generated automatically by the `remote!` macro.
+Users never construct a `SpawnableActor` manually; these records are generated automatically by `#[spawnable]` or `register_spawnable!(...)`.
 
-The reason `remote!(MyActor)` works is that it only requires `MyActor: RemoteSpawn`. You can provide that either with an explicit `impl RemoteSpawn for MyActor`, or you get it for free from the blanket `impl<A: Actor + Referable + Binds<Self> + Default> RemoteSpawn for A`.
+The reason `#[spawnable]` and `register_spawnable!(MyActor)` work is that they only require `MyActor: RemoteSpawn`. You can provide that either with an explicit `impl RemoteSpawn for MyActor`, or you get it for free from the blanket `impl<A: Actor + Referable + Binds<Self> + Default> RemoteSpawn for A`.
 
 > **Note:** `Referable` itself only requires `Named`, not `Send + Sync`. The `Actor` trait already provides `Send`, but `Sync` must be added explicitly at call sites that require it.
 
-In both cases, `remote!` can safely plug `<MyActor as RemoteSpawn>::gspawn` into the `SpawnableActor` record it generates.
+In both cases, the registration step can safely plug `<MyActor as RemoteSpawn>::gspawn` into the `SpawnableActor` record it generates.
 
 ## The `Remote` registry
 
-The `Remote` type is the process-local registry of remote-spawnable actors. It is built from all `SpawnableActor` records submitted via `remote!` and exposed through two lookups: by global type name and by `TypeId`.
+The `Remote` type is the process-local registry of remote-spawnable actors. It is built from all `SpawnableActor` records submitted via `#[spawnable]` and `register_spawnable!(...)` and exposed through two lookups: by global type name and by `TypeId`.
 ```rust
 #[derive(Debug)]
 pub struct Remote {
@@ -140,7 +139,7 @@ impl Remote {
 ```
 `name_of` resolves a concrete `A: RemoteSpawn` to its registered global type name string.
 
-Given a concrete `A: Actor`, `name_of` returns the string name that was registered via `remote!`. This is used by caller-side APIs that *start from a Rust type* and need to put a string type name on the wire for a remote spawn request.
+Given a concrete `A: Actor`, `name_of` returns the string name that was registered by `#[spawnable]` or `register_spawnable!(...)`. This is used by caller-side APIs that *start from a Rust type* and need to put a string type name on the wire for a remote spawn request.
 
 For example, `spawn_with_name_inner`  constructs an `ActorSpec` by first resolving the type `A` to its global name:
 ```rust
@@ -213,7 +212,7 @@ to look up the corresponding `SpawnableActor` by `actor_type` and invoke its `gs
 ## Putting it together
 
 Remote spawning in hyperactor involves two complementary pieces:
-1. **Type-level registration** Each `A: RemoteSpawn` contributes a `SpawnableActor` record when the user writes `remote!(A)`. These records are collected at runtime by `Remote::collect()`.
+1. **Type-level registration** Each `A: RemoteSpawn` contributes a `SpawnableActor` record when the user writes `#[spawnable]` on a concrete actor declaration or `register_spawnable!(A)` for a concrete instantiation. These records are collected at runtime by `Remote::collect()`.
 2. **Data-level spawn requests** Higher-level code starts from a concrete actor type (e.g. `A: RemoteSpawn`), uses `Remote::name_of::<A>()` to obtain it's global type name, serializes `A::Params`, and sends a request containing those two pieces of data.
 
 On the receiving side, a management component reconstructs the actor by calling:

--- a/docs/source/books/hyperactor-book/src/macros/export.md
+++ b/docs/source/books/hyperactor-book/src/macros/export.md
@@ -1,6 +1,6 @@
 # `#[export]`
 
-The `#[hyperactor::export]` macro turns a regular `Actor` implementation into a remotely spawnable actor, registering its type information, `spawn` function, and supported message handlers for discovery and use across processes or runtimes.
+The `#[hyperactor::export]` macro turns a regular `Actor` implementation into a remotely addressable actor by generating its type information and supported message handlers.
 
 It also supports message casting (broadcasting to multiple actors) by specifying `cast = true` for individual handlers.
 
@@ -9,10 +9,8 @@ It also supports message casting (broadcasting to multiple actors) by specifying
 When applied to an actor type like this:
 
 ```rust
-#[hyperactor::export(
-    spawn = true,
-    handlers = [ShoppingList],
-)]
+#[hyperactor::spawnable]
+#[hyperactor::export(ShoppingList)]
 struct ShoppingListActor(HashSet<String>);
 ```
 The macro expands to include:
@@ -20,12 +18,12 @@ The macro expands to include:
  - A `Binds<Self>` implementation that registers supported message types
  - Implementations of `RemoteHandles<T>` for each type in the `handlers = [...]` list
  - A `Referable` marker implementation
- - If `spawn = true`, the actor's `RemoteSpawn` implementation is registered in the remote actor inventory.
 
 This enables the actor to be:
- - Spawned dynamically by name
  - Routed to via typed messages
  - Reflected on at runtime (for diagnostics, tools, and orchestration)
+
+To make a concrete actor remotely spawnable, add `#[hyperactor::spawnable]`. For generic instantiations, use `hyperactor::register_spawnable!(MyActor<u64>);`.
 
 ## Casting Messages
 
@@ -69,7 +67,7 @@ impl Named for ShoppingListActor {
 
 > **Note:** The `Referable` trait itself only requires `Named`. It does not automatically provide `Send` or `Sync` bounds. If your actor needs to be passed across threads or stored in shared contexts, those bounds will be enforced at the specific call sites that require them.
 
-If `spawn = true`, the macro also emits:
+If the actor is marked `#[hyperactor::spawnable]`, that attribute emits:
 ```rust
 impl RemoteSpawn for ShoppingListActor {}
 ```
@@ -87,9 +85,8 @@ This allows the actor to be discovered and spawned by name at runtime.
 
 ## Summary
 
-The `#[export]` macro makes an actor remotely visible, spawnable, and routable by declaring:
+The `#[export]` macro makes an actor remotely visible and routable by declaring:
  - What messages it handles
  - How to bind those messages
  - What its globally unique name is
- - (Optionally) how to spawn it dynamically
  - (Optionally) which messages support multicast (broadcasting)

--- a/docs/source/books/hyperactor-mesh-book/src/meshes/proc-mesh-and-agent.md
+++ b/docs/source/books/hyperactor-mesh-book/src/meshes/proc-mesh-and-agent.md
@@ -21,7 +21,7 @@ To anchor that discussion, here is the essential shape of the agent:
 ```rust
 pub struct ProcAgent {
     proc: Proc, // local actor runtime
-    remote: Remote,  // registry of SpawnableActor entries (built from RemoteSpawn + remote!(...))
+    remote: Remote,  // registry of SpawnableActor entries (built from RemoteSpawn + spawnable registration)
     state: State, // v0/v1 bootstrapping mode
     actor_states: HashMap<Name, ActorInstanceState>, // per-actor spawn results & metadata
     record_supervision_events: bool,
@@ -29,7 +29,7 @@ pub struct ProcAgent {
 }
 ```
 - **`proc: Proc`** The proc-local runtime into which new actors will be installed
-- **`remote: Remote`** A snapshot of the process-local registry of `SpawnableActor` entries (populated from `RemoteSpawn` impls via `remote!(A)`). This is the bridge between *global type names* and the actual constructors used by `Remote::gspawn`.
+- **`remote: Remote`** A snapshot of the process-local registry of `SpawnableActor` entries (populated from `RemoteSpawn` impls via `#[spawnable]` or `register_spawnable!(A)`). This is the bridge between *global type names* and the actual constructors used by `Remote::gspawn`.
 - **`actor_states`** The agent's bookkeeping: for each actor name in the mesh, what happened when this proc tried to spawn it.
 
 The sections that follow walk the spawn flow end-to-end. Additional responsibilities (status, supervision, teardown) will be documented after the spawn discussion.
@@ -70,7 +70,7 @@ impl ProcMeshRef {
       A::Params: RemoteMessage,
   {
       let remote = Remote::collect();
-        // `RemoteSpawn` + `remote!(A)` ensure that `A` has a
+        // `RemoteSpawn` + spawnable registration ensure that `A` has a
         // `SpawnableActor` entry in this registry, so
         // `name_of::<A>()` can resolve its global type name.
       let actor_type = remote
@@ -107,11 +107,11 @@ What this does, step by step:
        .to_string();
    ```
    This is the point where the *type-level* contract kicks in:
-   - elsewhere, the user has written `remote!(MyActor)` for each `A: RemoteSpawn`,
+   - elsewhere, the user has marked each concrete actor as `#[spawnable]` or called `register_spawnable!(MyActor)`,
    - that registration adds a `SpawnableActor` entry to the `Remote` registry,
    - `Remote::name_of::<A>()` looks up that entry and reads its **global type name**.
 
-   If `A` was never registered with `remote!(A)`, this call fails with `ActorTypeNotRegistered`, and the spawn never leaves the caller's process.
+   If `A` was never registered with `#[spawnable]` or `register_spawnable!(A)`, this call fails with `ActorTypeNotRegistered`, and the spawn never leaves the caller's process.
 
 2. **Serialize the spawn parameters**
    ```rust
@@ -235,7 +235,7 @@ self.actor_states.insert(
 This is the core of v1 spawning. The agent:
 - unpacks the `ActorSpec` (type name + parameter bytes), and
 - passes those pieces into `remote.gspawn(...)` to construct the local actor.
-- `actor_type: String` – the logical type name registered by `remote!(A)`, computed in `ProcMeshRef::spawn_with_name_inner` via `remote.name_of::<A>()`, and used by `Remote::gspawn` on each proc to find the right constructor.
+- `actor_type: String` – the logical type name registered by `#[spawnable]` or `register_spawnable!(A)`, computed in `ProcMeshRef::spawn_with_name_inner` via `remote.name_of::<A>()`, and used by `Remote::gspawn` on each proc to find the right constructor.
 - `params_data: Data` A raw byte buffer containing serialized `A::Params` (via `bincode::serialize`).
 - `self.remote.gspawn(...)` This method looks up the `SpawnableActor` entry for `actor_type` in the local `Remote` registry then invoks:
 ```rust

--- a/hyperactor/src/actor/remote.rs
+++ b/hyperactor/src/actor/remote.rs
@@ -33,27 +33,29 @@ pub const USER_PORT_OFFSET: u64 = 1024;
 /// ```ignore
 /// struct MyActor { ... }
 ///
-/// remote!(MyActor);
+/// register_spawnable!(MyActor);
 /// ```
 #[macro_export]
-macro_rules! remote {
+macro_rules! register_spawnable {
     ($actor:ty) => {
-        $crate::internal_macro_support::paste! {
-            static [<$actor:snake:upper _NAME>]: std::sync::LazyLock<&'static str> =
-              std::sync::LazyLock::new(|| <$actor as $crate::internal_macro_support::typeuri::Named>::typename());
+        const _: () = {
+            static NAME: std::sync::LazyLock<&'static str> = std::sync::LazyLock::new(|| {
+                <$actor as $crate::internal_macro_support::typeuri::Named>::typename()
+            });
+
             $crate::internal_macro_support::inventory::submit! {
                 $crate::actor::remote::SpawnableActor {
-                    name: &[<$actor:snake:upper _NAME>],
+                    name: &NAME,
                     gspawn: <$actor as $crate::actor::RemoteSpawn>::gspawn,
                     get_type_id: <$actor as $crate::actor::RemoteSpawn>::get_type_id,
                 }
             }
-        }
+        };
     };
 }
 
 /// A type-erased actor registration entry. These are constructed via
-/// [`crate::remote`].
+/// [`crate::register_spawnable`].
 #[derive(Debug)]
 pub struct SpawnableActor {
     /// A URI that globally identifies an actor. It is an error to register
@@ -81,7 +83,7 @@ pub struct SpawnableActor {
 inventory::collect!(SpawnableActor);
 
 /// Registry of actors linked into this image and registered by way of
-/// [`crate::remote`].
+/// [`crate::register_spawnable`].
 #[derive(Debug)]
 pub struct Remote {
     by_name: HashMap<&'static str, &'static SpawnableActor>,
@@ -151,7 +153,7 @@ mod tests {
     use crate::RemoteSpawn;
 
     #[derive(Debug)]
-    #[hyperactor::export(handlers = [()])]
+    #[hyperactor::export(())]
     struct MyActor;
 
     #[async_trait]
@@ -177,7 +179,24 @@ mod tests {
         }
     }
 
-    remote!(MyActor);
+    register_spawnable!(MyActor);
+
+    #[derive(Debug, Default)]
+    #[hyperactor::export(())]
+    struct GenericActor<T>(std::marker::PhantomData<T>);
+
+    #[async_trait]
+    impl<T: Send + 'static> Actor for GenericActor<T> {}
+
+    #[async_trait]
+    impl<T: Send + Sync + 'static> Handler<()> for GenericActor<T> {
+        async fn handle(&mut self, _cx: &Context<Self>, _message: ()) -> anyhow::Result<()> {
+            unimplemented!()
+        }
+    }
+
+    register_spawnable!(GenericActor<u64>);
+    register_spawnable!(GenericActor<bool>);
 
     #[tokio::test]
     async fn test_registry() {
@@ -185,6 +204,18 @@ mod tests {
         assert_matches!(
             remote.name_of::<MyActor>(),
             Some("hyperactor::actor::remote::tests::MyActor")
+        );
+        assert_matches!(
+            remote.name_of::<GenericActor<u64>>(),
+            Some("hyperactor::actor::remote::tests::GenericActor<u64>")
+        );
+        assert_matches!(
+            remote.name_of::<GenericActor<bool>>(),
+            Some("hyperactor::actor::remote::tests::GenericActor<bool>")
+        );
+        assert_ne!(
+            <GenericActor<u64> as typeuri::Named>::typename(),
+            <GenericActor<bool> as typeuri::Named>::typename()
         );
 
         let _ = remote

--- a/hyperactor/src/lib.rs
+++ b/hyperactor/src/lib.rs
@@ -135,6 +135,8 @@ pub use hyperactor_macros::instrument_infallible;
 pub use hyperactor_macros::observe_async;
 pub use hyperactor_macros::observe_result;
 #[doc(inline)]
+pub use hyperactor_macros::spawnable;
+#[doc(inline)]
 pub use hyperactor_macros::uid;
 pub use hyperactor_telemetry::declare_static_counter;
 pub use hyperactor_telemetry::declare_static_gauge;

--- a/hyperactor/src/testing/pingpong.rs
+++ b/hyperactor/src/testing/pingpong.rs
@@ -38,7 +38,8 @@ wirevalue::register_type!(PingPongMessage);
 
 /// A PingPong actor that can play the PingPong game by sending messages around.
 #[derive(Debug)]
-#[hyperactor::export(spawn = true, handlers = [PingPongMessage])]
+#[hyperactor::export(PingPongMessage)]
+#[hyperactor::spawnable]
 pub struct PingPongActor {
     /// A port to send undeliverable messages to.
     undeliverable_port_ref: Option<reference::PortRef<Undeliverable<MessageEnvelope>>>,

--- a/hyperactor_macros/Cargo.toml
+++ b/hyperactor_macros/Cargo.toml
@@ -35,4 +35,3 @@ timed_test = { version = "0.0.0", path = "../timed_test" }
 tokio = { version = "1.37.0", features = ["full", "test-util", "tracing"] }
 tracing = { version = "0.1.41", features = ["attributes", "valuable"] }
 typeuri = { version = "0.0.0", path = "../typeuri" }
-wirevalue = { version = "0.0.0", path = "../wirevalue" }

--- a/hyperactor_macros/src/lib.rs
+++ b/hyperactor_macros/src/lib.rs
@@ -37,6 +37,7 @@ use syn::ItemImpl;
 use syn::Lit;
 use syn::Token;
 use syn::Type;
+use syn::WherePredicate;
 use syn::bracketed;
 use syn::parse::Parse;
 use syn::parse::ParseStream;
@@ -560,12 +561,8 @@ fn parse_messages(input: DeriveInput) -> Result<Vec<Message>, syn::Error> {
 ///
 /// // Define an actor.
 /// #[derive(Debug)]
-/// #[hyperactor::export(
-///     spawn = true,
-///     handlers = [
-///         ShoppingList,
-///     ],
-/// )]
+/// #[hyperactor::export(ShoppingList)]
+/// #[hyperactor::spawnable]
 /// struct ShoppingListActor(HashSet<String>);
 ///
 /// #[async_trait]
@@ -1288,15 +1285,104 @@ impl HandlerSpec {
     }
 }
 
+fn named_impl(data_type_name: &Ident, generics: &syn::Generics) -> proc_macro2::TokenStream {
+    let generics_with_bounds = generics_with_named_bounds(generics);
+    let type_params: Vec<_> = generics.type_params().collect();
+    let has_generics = !type_params.is_empty();
+
+    let (impl_generics_with_bounds, _, _) = generics_with_bounds.split_for_impl();
+    let (_, ty_generics, where_clause) = generics.split_for_impl();
+
+    let (typename_impl, typehash_impl) = if has_generics {
+        let placeholders = vec!["{}"; type_params.len()].join(", ");
+        let placeholders_format_string = format!("<{}>", placeholders);
+        let format_string = quote! {
+            concat!(
+                std::module_path!(),
+                "::",
+                stringify!(#data_type_name),
+                #placeholders_format_string
+            )
+        };
+        let type_param_idents: Vec<_> = type_params.iter().map(|param| &param.ident).collect();
+        (
+            quote! {
+                typeuri::intern_typename!(Self, #format_string, #(#type_param_idents),*)
+            },
+            quote! {
+                typeuri::cityhasher::hash(Self::typename())
+            },
+        )
+    } else {
+        (
+            quote! {
+                concat!(std::module_path!(), "::", stringify!(#data_type_name))
+            },
+            quote! {
+                static TYPEHASH: std::sync::LazyLock<u64> = std::sync::LazyLock::new(|| {
+                    typeuri::cityhasher::hash(<#data_type_name as typeuri::Named>::typename())
+                });
+                *TYPEHASH
+            },
+        )
+    };
+
+    quote! {
+        impl #impl_generics_with_bounds typeuri::Named for #data_type_name #ty_generics #where_clause {
+            fn typename() -> &'static str {
+                #typename_impl
+            }
+
+            fn typehash() -> u64 {
+                #typehash_impl
+            }
+        }
+    }
+}
+
+fn generics_with_named_bounds(generics: &syn::Generics) -> syn::Generics {
+    let mut generics = generics.clone();
+    for param in generics.type_params_mut() {
+        param.bounds.push(syn::parse_quote!(typeuri::Named));
+    }
+    generics
+}
+
+fn generics_with_predicates(
+    generics: &syn::Generics,
+    predicates: impl IntoIterator<Item = WherePredicate>,
+) -> syn::Generics {
+    let mut generics = generics.clone();
+    generics.make_where_clause().predicates.extend(predicates);
+    generics
+}
+
 /// Attribute Struct for [`fn export`] macro.
 struct ExportAttr {
-    spawn: bool,
     handlers: Vec<HandlerSpec>,
 }
 
 impl Parse for ExportAttr {
     fn parse(input: ParseStream) -> syn::Result<Self> {
-        let mut spawn = false;
+        if input.is_empty() {
+            return Ok(Self {
+                handlers: Vec::new(),
+            });
+        }
+
+        let compatibility_form = {
+            let fork = input.fork();
+            fork.parse::<Ident>().is_ok() && fork.parse::<Token![=]>().is_ok()
+        };
+
+        if !compatibility_form {
+            let handlers = input
+                .parse_terminated(HandlerSpec::parse, Token![,])?
+                .into_iter()
+                .collect();
+            return Ok(Self { handlers });
+        }
+
         let mut handlers: Vec<HandlerSpec> = vec![];
 
         while !input.is_empty() {
@@ -1305,17 +1391,10 @@ impl Parse for ExportAttr {
 
             if key == "spawn" {
                 let expr: Expr = input.parse()?;
-                if let Expr::Lit(ExprLit {
-                    lit: Lit::Bool(b), ..
-                }) = expr
-                {
-                    spawn = b.value;
-                } else {
-                    return Err(syn::Error::new_spanned(
-                        expr,
-                        "expected boolean for `spawn`",
-                    ));
-                }
+                return Err(syn::Error::new_spanned(
+                    expr,
+                    "`spawn = true` is no longer supported; use `#[spawnable]` on concrete actor declarations or `hyperactor::register_spawnable!(ConcreteType)` for generic instantiations",
+                ));
             } else if key == "handlers" {
                 let content;
                 bracketed!(content in input);
@@ -1324,7 +1403,7 @@ impl Parse for ExportAttr {
             } else {
                 return Err(syn::Error::new_spanned(
                     key,
-                    "unexpected key in `#[export(...)]`. Only supports `spawn` and `handlers`",
+                    "unexpected key in `#[export(...)]`. Use direct handler lists, or the compatibility key `handlers`",
                 ));
             }
 
@@ -1332,7 +1411,7 @@ impl Parse for ExportAttr {
             let _ = input.parse::<Token![,]>();
         }
 
-        Ok(ExportAttr { spawn, handlers })
+        Ok(ExportAttr { handlers })
     }
 }
 
@@ -1341,89 +1420,144 @@ impl Parse for ExportAttr {
 /// the actor ([`hyperaxtor::ActorRef`]). Only messages that implement
 /// [`hyperactor::RemoteMessage`] may be exported.
 ///
-/// Additionally, an exported actor may be remotely spawned,
-/// indicated by `spawn = true`. Such actors must also ensure that
-/// their parameter type implements [`hyperactor::RemoteMessage`].
-///
 /// # Example
 ///
-/// In the following example, `MyActor` can be spawned remotely. It also has
-/// exports handlers for two message types, `MyMessage` and `MyOtherMessage`.
-/// Consequently, `ActorRef`s of the actor's type may dispatch messages of these
-/// types.
+/// In the following example, `MyActor` exports handlers for two message types,
+/// `MyMessage` and `MyOtherMessage`. Consequently, `ActorRef`s of the actor's
+/// type may dispatch messages of these types.
 ///
 /// ```ignore
-/// #[export(
-///     spawn = true,
-///     handlers = [
-///         MyMessage,
-///         MyOtherMessage,
-///     ],
-/// )]
+/// #[export(MyMessage, MyOtherMessage)]
 /// struct MyActor {}
 /// ```
 #[proc_macro_attribute]
 pub fn export(attr: TokenStream, item: TokenStream) -> TokenStream {
     let input: DeriveInput = parse_macro_input!(item as DeriveInput);
     let data_type_name = &input.ident;
-    let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
+    let (_, ty_generics, _) = input.generics.split_for_impl();
+    let named_generics = generics_with_named_bounds(&input.generics);
+    let (named_impl_generics, named_ty_generics, named_where_clause) =
+        named_generics.split_for_impl();
 
-    let ExportAttr { spawn, handlers } = parse_macro_input!(attr as ExportAttr);
-    let tys = HandlerSpec::add_indexed(handlers);
+    let ExportAttr { handlers } = parse_macro_input!(attr as ExportAttr);
 
     let mut handles = Vec::new();
     let mut bindings = Vec::new();
-    let mut type_registrations = Vec::new();
+    let mut bind_predicates = Vec::new();
+    let actor_ty: Type = syn::parse_quote!(#data_type_name #ty_generics);
 
-    for ty in &tys {
+    for HandlerSpec { ty, cast } in &handlers {
+        let message_generics = generics_with_predicates(
+            &named_generics,
+            [syn::parse_quote!(#ty: hyperactor::RemoteMessage)],
+        );
+        let (message_impl_generics, message_ty_generics, message_where_clause) =
+            message_generics.split_for_impl();
         handles.push(quote! {
-            impl #impl_generics hyperactor::actor::RemoteHandles<#ty> for #data_type_name #ty_generics #where_clause {}
-            impl #impl_generics hyperactor::remote::Accepts<#ty> for #data_type_name #ty_generics #where_clause {}
+            impl #message_impl_generics hyperactor::actor::RemoteHandles<#ty>
+                for #data_type_name #message_ty_generics #message_where_clause {}
+            impl #message_impl_generics hyperactor::remote::Accepts<#ty>
+                for #data_type_name #message_ty_generics #message_where_clause {}
         });
         bindings.push(quote! {
             ports.bind::<#ty>();
         });
-        type_registrations.push(quote! {
-            wirevalue::register_type!(#ty);
-        });
+        bind_predicates.push(syn::parse_quote!(#ty: hyperactor::RemoteMessage));
+        bind_predicates.push(syn::parse_quote!(#actor_ty: hyperactor::Handler<#ty>));
+
+        if *cast {
+            let indexed_ty: Type =
+                syn::parse_quote!(hyperactor::message::IndexedErasedUnbound<#ty>);
+            let indexed_generics = generics_with_predicates(
+                &named_generics,
+                [
+                    syn::parse_quote!(#ty: hyperactor::message::Castable),
+                    syn::parse_quote!(#indexed_ty: hyperactor::RemoteMessage),
+                ],
+            );
+            let (indexed_impl_generics, indexed_ty_generics, indexed_where_clause) =
+                indexed_generics.split_for_impl();
+            handles.push(quote! {
+                impl #indexed_impl_generics hyperactor::actor::RemoteHandles<#indexed_ty>
+                    for #data_type_name #indexed_ty_generics #indexed_where_clause {}
+                impl #indexed_impl_generics hyperactor::remote::Accepts<#indexed_ty>
+                    for #data_type_name #indexed_ty_generics #indexed_where_clause {}
+            });
+            bindings.push(quote! {
+                ports.bind::<#indexed_ty>();
+            });
+            bind_predicates.push(syn::parse_quote!(#ty: hyperactor::message::Castable));
+            bind_predicates.push(syn::parse_quote!(#indexed_ty: hyperactor::RemoteMessage));
+        }
     }
 
-    let mut expanded = quote! {
+    let bind_generics = generics_with_predicates(&named_generics, bind_predicates);
+    let (bind_impl_generics, bind_ty_generics, bind_where_clause) = bind_generics.split_for_impl();
+    let named_impl = named_impl(data_type_name, &input.generics);
+
+    let expanded = quote! {
         #input
 
-        impl #impl_generics hyperactor::actor::Referable for #data_type_name #ty_generics #where_clause {}
+        impl #named_impl_generics hyperactor::actor::Referable for #data_type_name #named_ty_generics #named_where_clause {}
 
         #(#handles)*
 
-        #(#type_registrations)*
-
         // Always export the `Signal` type.
-        impl #impl_generics hyperactor::actor::RemoteHandles<hyperactor::actor::Signal> for #data_type_name #ty_generics #where_clause {}
-        impl #impl_generics hyperactor::remote::Accepts<hyperactor::actor::Signal> for #data_type_name #ty_generics #where_clause {}
+        impl #named_impl_generics hyperactor::actor::RemoteHandles<hyperactor::actor::Signal> for #data_type_name #named_ty_generics #named_where_clause {}
+        impl #named_impl_generics hyperactor::remote::Accepts<hyperactor::actor::Signal> for #data_type_name #named_ty_generics #named_where_clause {}
 
         // Always export the `IntrospectMessage` type.
-        impl #impl_generics hyperactor::actor::RemoteHandles<hyperactor::introspect::IntrospectMessage> for #data_type_name #ty_generics #where_clause {}
-        impl #impl_generics hyperactor::remote::Accepts<hyperactor::introspect::IntrospectMessage> for #data_type_name #ty_generics #where_clause {}
+        impl #named_impl_generics hyperactor::actor::RemoteHandles<hyperactor::introspect::IntrospectMessage> for #data_type_name #named_ty_generics #named_where_clause {}
+        impl #named_impl_generics hyperactor::remote::Accepts<hyperactor::introspect::IntrospectMessage> for #data_type_name #named_ty_generics #named_where_clause {}
 
-        impl #impl_generics hyperactor::actor::Binds<#data_type_name #ty_generics> for #data_type_name #ty_generics #where_clause {
+        impl #bind_impl_generics hyperactor::actor::Binds<#data_type_name #bind_ty_generics> for #data_type_name #bind_ty_generics #bind_where_clause {
             fn bind(ports: &hyperactor::proc::Ports<Self>) {
                 #(#bindings)*
             }
         }
 
-        // TODO: just use Named derive directly here.
-        impl #impl_generics typeuri::Named for #data_type_name #ty_generics #where_clause {
-            fn typename() -> &'static str { concat!(std::module_path!(), "::", stringify!(#data_type_name #ty_generics)) }
-        }
+        #named_impl
     };
 
-    if spawn {
-        expanded.extend(quote! {
-            hyperactor::remote!(#data_type_name);
-        });
+    TokenStream::from(expanded)
+}
+
+/// Marks a concrete actor declaration as remotely spawnable.
+///
+/// When combined with `#[export(...)]`, place `#[spawnable]` below `#[export]`.
+#[proc_macro_attribute]
+pub fn spawnable(attr: TokenStream, item: TokenStream) -> TokenStream {
+    if !attr.is_empty() {
+        return syn::Error::new(Span::call_site(), "`#[spawnable]` does not take arguments")
+            .to_compile_error()
+            .into();
     }
 
-    TokenStream::from(expanded)
+    let input: DeriveInput = parse_macro_input!(item as DeriveInput);
+    if !matches!(input.data, Data::Struct(_)) {
+        return syn::Error::new(
+            input.span(),
+            "`#[spawnable]` only supports struct actor declarations",
+        )
+        .to_compile_error()
+        .into();
+    }
+
+    if !input.generics.params.is_empty() {
+        return syn::Error::new(
+            input.generics.span(),
+            "generic actor families cannot use `#[spawnable]`; use `hyperactor::register_spawnable!(ConcreteType)` instead",
+        )
+        .to_compile_error()
+        .into();
+    }
+
+    let data_type_name = &input.ident;
+    quote! {
+        #input
+        hyperactor::register_spawnable!(#data_type_name);
+    }
+    .into()
 }
 
 /// Represents the full input to [`fn behavior`].

--- a/hyperactor_macros/tests/export.rs
+++ b/hyperactor_macros/tests/export.rs
@@ -6,6 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+use std::fmt::Debug;
+
 use async_trait::async_trait;
 use hyperactor::Actor;
 use hyperactor::Bind;
@@ -20,12 +22,10 @@ use typeuri::Named;
 
 #[derive(Debug)]
 #[hyperactor::export(
-    handlers = [
-        TestMessage { cast = true },
-        () { cast = true },
-        MyGeneric<()> { cast = true },
-        u64,
-    ],
+    TestMessage { cast = true },
+    () { cast = true },
+    MyGeneric<()> { cast = true },
+    u64,
 )]
 struct TestActor {
     // Forward the received message to this port, so it can be inspected by
@@ -40,6 +40,48 @@ impl TestActor {
 }
 
 impl Actor for TestActor {}
+
+#[derive(Debug)]
+#[hyperactor::export(GenericMessage<T>)]
+struct GenericActor<T> {
+    forward_port: reference::PortRef<String>,
+    _marker: std::marker::PhantomData<T>,
+}
+
+impl<T> GenericActor<T> {
+    fn new(forward_port: reference::PortRef<String>) -> Self {
+        Self {
+            forward_port,
+            _marker: std::marker::PhantomData,
+        }
+    }
+}
+
+impl<T> Actor for GenericActor<T>
+where
+    T: Debug + Send + Sync + Serialize + Named + 'static,
+    for<'de> T: Deserialize<'de>,
+{
+}
+
+#[derive(Debug, PartialEq, Serialize, Deserialize, Bind, Unbind, Named)]
+struct GenericMessage<T>(T);
+
+#[async_trait]
+impl<T> Handler<GenericMessage<T>> for GenericActor<T>
+where
+    T: Debug + Send + Sync + Serialize + Named + 'static,
+    for<'de> T: Deserialize<'de>,
+{
+    async fn handle(
+        &mut self,
+        cx: &Context<Self>,
+        GenericMessage(message): GenericMessage<T>,
+    ) -> anyhow::Result<()> {
+        self.forward_port.send(cx, format!("{message:?}"))?;
+        Ok(())
+    }
+}
 
 #[derive(Debug, PartialEq, Serialize, Deserialize, Named, Bind, Unbind)]
 struct TestMessage(String);
@@ -227,5 +269,30 @@ mod tests {
         assert_eq!(rx.recv().await.unwrap(), "()");
         assert_eq!(rx.recv().await.unwrap(), "bar");
         assert_eq!(rx.recv().await.unwrap(), "MyGeneric<()>");
+    }
+
+    #[async_timed_test(timeout_secs = 30)]
+    async fn test_generic_export() {
+        let proc = Proc::local();
+        let (client, _) = proc.instance("client").unwrap();
+        let (tx, mut rx) = client.open_port();
+        let actor_handle = proc
+            .spawn("generic", GenericActor::<u64>::new(tx.bind()))
+            .unwrap();
+
+        actor_handle.bind::<GenericActor<u64>>();
+
+        let port_id = actor_handle
+            .actor_id()
+            .port_ref(Port::from(GenericMessage::<u64>::port()));
+        let port_ref: reference::PortRef<GenericMessage<u64>> =
+            reference::PortRef::attest(port_id.into());
+        port_ref.send(&client, GenericMessage(42)).unwrap();
+        assert_eq!(rx.recv().await.unwrap(), "42");
+
+        assert_ne!(
+            <GenericActor<u64> as Named>::typename(),
+            <GenericActor<String> as Named>::typename()
+        );
     }
 }

--- a/hyperactor_mesh/benches/bench_actor.rs
+++ b/hyperactor_mesh/benches/bench_actor.rs
@@ -31,12 +31,8 @@ pub struct BenchMessage {
 }
 
 #[derive(Debug)]
-#[hyperactor::export(
-    spawn = true,
-    handlers = [
-        BenchMessage { cast = true },
-    ],
-)]
+#[hyperactor::export(BenchMessage { cast = true })]
+#[hyperactor::spawnable]
 pub struct BenchActor {
     processing_time: Duration,
 }

--- a/hyperactor_mesh/examples/dining_philosophers.rs
+++ b/hyperactor_mesh/examples/dining_philosophers.rs
@@ -59,12 +59,8 @@ enum ChopstickStatus {
 }
 
 #[derive(Debug)]
-#[hyperactor::export(
-    spawn = true,
-    handlers = [
-        PhilosopherMessage { cast = true },
-    ],
-)]
+#[hyperactor::export(PhilosopherMessage { cast = true })]
+#[hyperactor::spawnable]
 struct PhilosopherActor {
     /// Status of left and right chopsticks
     chopsticks: (ChopstickStatus, ChopstickStatus),

--- a/hyperactor_mesh/examples/sieve.rs
+++ b/hyperactor_mesh/examples/sieve.rs
@@ -75,12 +75,8 @@ pub struct SieveParams {
 /// Filters candidates divisible by `prime`. Forwards survivors to
 /// `next`. Spawns a new child when a new prime is discovered.
 #[derive(Debug)]
-#[hyperactor::export(
-        spawn = true,
-        handlers = [
-          NextNumber,
-        ],
-    )]
+#[hyperactor::export(NextNumber)]
+#[hyperactor::spawnable]
 pub struct SieveActor {
     /// Prime used for filtering.
     prime: u64,

--- a/hyperactor_mesh/examples/test_bench.rs
+++ b/hyperactor_mesh/examples/test_bench.rs
@@ -34,12 +34,8 @@ use serde::Serialize;
 use typeuri::Named;
 
 #[derive(Default, Debug)]
-#[hyperactor::export(
-    spawn = true,
-    handlers = [
-        TestMessage { cast = true },
-    ],
-)]
+#[hyperactor::export(TestMessage { cast = true })]
+#[hyperactor::spawnable]
 struct TestActor {}
 
 impl Actor for TestActor {}

--- a/hyperactor_mesh/src/comm.rs
+++ b/hyperactor_mesh/src/comm.rs
@@ -99,15 +99,13 @@ struct ReceiveState {
 /// and result accumulation.
 #[derive(Debug, Default)]
 #[hyperactor::export(
-    spawn = true,
-    handlers = [
-        CommMeshConfig,
-        CastMessage,
-        ForwardMessage,
-        CastMessageV1,
-        ForwardMessageV1,
-    ],
+    CommMeshConfig,
+    CastMessage,
+    ForwardMessage,
+    CastMessageV1,
+    ForwardMessageV1
 )]
+#[hyperactor::spawnable]
 pub struct CommActor {
     /// Sequence numbers are maintained for each (actor mesh id, sender).
     send_seq: HashMap<(ActorMeshId, hyperactor_reference::ActorId), usize>,
@@ -689,12 +687,8 @@ pub mod test_utils {
     }
 
     #[derive(Debug)]
-    #[hyperactor::export(
-        spawn = true,
-        handlers = [
-            TestMessage { cast = true },
-        ],
-    )]
+    #[hyperactor::export(TestMessage { cast = true })]
+    #[hyperactor::spawnable]
     pub struct TestActor {
         // Forward the received message to this port, so it can be inspected by
         // the unit test.

--- a/hyperactor_mesh/src/logging.rs
+++ b/hyperactor_mesh/src/logging.rs
@@ -982,10 +982,8 @@ pub enum LogForwardMessage {
 }
 
 /// A log forwarder that receives the log from its parent process and forward it back to the client
-#[hyperactor::export(
-    spawn = true,
-    handlers = [LogForwardMessage {cast = true}],
-)]
+#[hyperactor::export(LogForwardMessage { cast = true })]
+#[hyperactor::spawnable]
 pub struct LogForwardActor {
     rx: ChannelRx<LogMessage>,
     flush_tx: Arc<Mutex<ChannelTx<LogMessage>>>,
@@ -1166,10 +1164,8 @@ fn deserialize_message_lines(serialized_message: &wirevalue::Any) -> Result<Vec<
 
 /// A client to receive logs from remote processes
 #[derive(Debug)]
-#[hyperactor::export(
-    spawn = true,
-    handlers = [LogMessage, LogClientMessage],
-)]
+#[hyperactor::export(LogMessage, LogClientMessage)]
+#[hyperactor::spawnable]
 pub struct LogClientActor {
     aggregate_window_sec: Option<u64>,
     aggregators: HashMap<OutputTarget, Aggregator>,

--- a/hyperactor_mesh/src/proc_agent.rs
+++ b/hyperactor_mesh/src/proc_agent.rs
@@ -1204,7 +1204,7 @@ mod tests {
     #[hyperactor::export(handlers = [])]
     struct ExtraActor;
     impl hyperactor::Actor for ExtraActor {}
-    hyperactor::remote!(ExtraActor);
+    hyperactor::register_spawnable!(ExtraActor);
     // Verifies that QueryChild(Reference::Proc) on a ProcAgent returns
     // a live IntrospectResult whose children reflect actors spawned
     // directly on the proc — i.e. via proc.spawn(), which bypasses the

--- a/hyperactor_mesh/src/proc_mesh.rs
+++ b/hyperactor_mesh/src/proc_mesh.rs
@@ -658,7 +658,7 @@ impl ProcMeshRef {
         C::A: Handler<MeshFailure>,
     {
         let remote = Remote::collect();
-        // `RemoteSpawn` + `remote!(A)` ensure that `A` has a
+        // `RemoteSpawn` + `register_spawnable!(A)` ensure that `A` has a
         // `SpawnableActor` entry in this registry, so
         // `name_of::<A>()` can resolve its global type name.
         let actor_type = remote

--- a/hyperactor_mesh/src/test_utils.rs
+++ b/hyperactor_mesh/src/test_utils.rs
@@ -24,12 +24,8 @@ use crate::host_mesh::HostMesh;
 pub struct EmptyMessage();
 
 #[derive(Debug, PartialEq, Default)]
-#[hyperactor::export(
-    spawn = true,
-    handlers = [
-        EmptyMessage { cast = true },
-    ],
-)]
+#[hyperactor::export(EmptyMessage { cast = true })]
+#[hyperactor::spawnable]
 pub struct EmptyActor();
 
 impl Actor for EmptyActor {}

--- a/hyperactor_mesh/src/testactor.rs
+++ b/hyperactor_mesh/src/testactor.rs
@@ -56,17 +56,15 @@ use crate::testing;
 /// A simple test actor used by various unit tests.
 #[derive(Default, Debug)]
 #[hyperactor::export(
-    spawn = true,
-    handlers = [
-        () { cast = true },
-        GetActorId { cast = true },
-        GetCastInfo { cast = true },
-        CauseSupervisionEvent { cast = true },
-        Forward,
-        GetConfigAttrs { cast = true },
-        SetConfigAttrs { cast = true },
-    ]
+    () { cast = true },
+    GetActorId { cast = true },
+    GetCastInfo { cast = true },
+    CauseSupervisionEvent { cast = true },
+    Forward,
+    GetConfigAttrs { cast = true },
+    SetConfigAttrs { cast = true },
 )]
+#[hyperactor::spawnable]
 pub struct TestActor;
 
 impl Actor for TestActor {}
@@ -149,10 +147,8 @@ impl Handler<CauseSupervisionEvent> for TestActor {
 /// A test actor that handles supervision events.
 /// It should be the parent of TestActor who can panic or cause a SIGSEGV.
 #[derive(Default, Debug)]
-#[hyperactor::export(
-    spawn = true,
-    handlers = [ActorSupervisionEvent],
-)]
+#[hyperactor::export(ActorSupervisionEvent)]
+#[hyperactor::spawnable]
 pub struct TestActorWithSupervisionHandling;
 
 #[async_trait]
@@ -182,10 +178,8 @@ impl Handler<ActorSupervisionEvent> for TestActorWithSupervisionHandling {
 /// A test actor that sleeps when it receives a Duration message.
 /// Used for testing timeout and abort behavior.
 #[derive(Default, Debug)]
-#[hyperactor::export(
-    spawn = true,
-    handlers = [std::time::Duration],
-)]
+#[hyperactor::export(std::time::Duration)]
+#[hyperactor::spawnable]
 pub struct SleepActor;
 
 impl Actor for SleepActor {}
@@ -267,7 +261,8 @@ impl Handler<GetCastInfo> for TestActor {
 }
 
 #[derive(Debug)]
-#[hyperactor::export(spawn = true)]
+#[hyperactor::export]
+#[hyperactor::spawnable]
 pub struct FailingCreateTestActor;
 
 #[async_trait]
@@ -332,13 +327,11 @@ pub struct NextSupervisionFailure(pub hyperactor_reference::PortRef<Option<MeshF
 /// The supervision events are sent back to "supervisor".
 #[derive(Debug)]
 #[hyperactor::export(
-    spawn = true,
-    handlers = [
-        CauseSupervisionEvent { cast = true },
-        MeshFailure { cast = true },
-        NextSupervisionFailure { cast = true },
-    ]
+    CauseSupervisionEvent { cast = true },
+    MeshFailure { cast = true },
+    NextSupervisionFailure { cast = true },
 )]
+#[hyperactor::spawnable]
 pub struct WrapperActor {
     proc_mesh: ProcMeshRef,
     // Needs to be a mesh so we own this actor and have a controller for it.

--- a/hyperactor_mesh/test/hyperactor_mesh_proxy_test.rs
+++ b/hyperactor_mesh/test/hyperactor_mesh_proxy_test.rs
@@ -56,12 +56,8 @@ struct Args {
 // -- TestActor
 
 #[derive(Debug)]
-#[hyperactor::export(
-    spawn = true,
-    handlers = [
-        Echo,
-    ],
-)]
+#[hyperactor::export(Echo)]
+#[hyperactor::spawnable]
 pub struct TestActor;
 
 impl Actor for TestActor {}
@@ -89,12 +85,8 @@ impl Handler<Echo> for TestActor {
 
 // -- ProxyActor
 
-#[hyperactor::export(
-    spawn = true,
-    handlers = [
-        Echo,
-    ],
-)]
+#[hyperactor::export(Echo)]
+#[hyperactor::spawnable]
 pub struct ProxyActor {
     exe_path: String,
     host_mesh: Option<HostMesh>,

--- a/monarch_hyperactor/src/actor.rs
+++ b/monarch_hyperactor/src/actor.rs
@@ -545,12 +545,12 @@ pub enum PythonActorDispatchMode {
 /// An actor for which message handlers are implemented in Python.
 #[derive(Debug)]
 #[hyperactor::export(
-    spawn = true,
     handlers = [
         PythonMessage { cast = true },
         MeshFailure { cast = true },
     ],
 )]
+#[hyperactor::spawnable]
 pub struct PythonActor {
     /// The Python object that we delegate message handling to.
     actor: Py<PyAny>,

--- a/monarch_hyperactor/src/code_sync/auto_reload.rs
+++ b/monarch_hyperactor/src/code_sync/auto_reload.rs
@@ -38,7 +38,8 @@ wirevalue::register_type!(AutoReloadParams);
 
 /// Simple Rust Actor that wraps the Python AutoReloader class via pyo3
 #[derive(Debug)]
-#[hyperactor::export(spawn = true, handlers = [AutoReloadMessage])]
+#[hyperactor::export(handlers = [AutoReloadMessage])]
+#[hyperactor::spawnable]
 pub struct AutoReloadActor {
     state: Result<(Arc<Py<PyAny>>, Py<PyAny>), SerializablePyErr>,
 }

--- a/monarch_hyperactor/src/code_sync/conda_sync.rs
+++ b/monarch_hyperactor/src/code_sync/conda_sync.rs
@@ -66,7 +66,8 @@ pub struct CondaSyncParams {}
 wirevalue::register_type!(CondaSyncParams);
 
 #[derive(Debug, Default)]
-#[hyperactor::export(spawn = true, handlers = [CondaSyncMessage { cast = true }])]
+#[hyperactor::export(handlers = [CondaSyncMessage { cast = true }])]
+#[hyperactor::spawnable]
 pub struct CondaSyncActor {}
 
 impl Actor for CondaSyncActor {}

--- a/monarch_hyperactor/src/code_sync/manager.rs
+++ b/monarch_hyperactor/src/code_sync/manager.rs
@@ -176,12 +176,12 @@ wirevalue::register_type!(CodeSyncManagerParams);
 
 #[derive(Debug)]
 #[hyperactor::export(
-    spawn = true,
     handlers = [
         CodeSyncMessage { cast = true },
         SetActorMeshMessage { cast = true }
     ],
 )]
+#[hyperactor::spawnable]
 pub struct CodeSyncManager {
     rsync: OnceCell<ActorHandle<RsyncActor>>,
     auto_reload: OnceCell<ActorHandle<AutoReloadActor>>,

--- a/monarch_hyperactor/src/code_sync/rsync.rs
+++ b/monarch_hyperactor/src/code_sync/rsync.rs
@@ -336,7 +336,8 @@ pub struct RsyncMessage {
 wirevalue::register_type!(RsyncMessage);
 
 #[derive(Debug, Default)]
-#[hyperactor::export(spawn = true, handlers = [RsyncMessage { cast = true }])]
+#[hyperactor::export(handlers = [RsyncMessage { cast = true }])]
+#[hyperactor::spawnable]
 pub struct RsyncActor {
     //workspace: WorkspaceLocation,
 }

--- a/monarch_hyperactor/src/local_state_broker.rs
+++ b/monarch_hyperactor/src/local_state_broker.rs
@@ -30,7 +30,8 @@ pub enum LocalStateBrokerMessage {
 }
 
 #[derive(Debug, Default)]
-#[hyperactor::export(spawn = true)]
+#[hyperactor::export]
+#[hyperactor::spawnable]
 pub struct LocalStateBrokerActor {
     states: HashMap<usize, LocalState>,
     ports: HashMap<usize, OncePortHandle<LocalState>>,

--- a/monarch_hyperactor/src/logging.rs
+++ b/monarch_hyperactor/src/logging.rs
@@ -68,7 +68,8 @@ pub enum LoggerRuntimeMessage {
 
 /// Simple Rust actor that invokes python logger APIs. It needs a python runtime.
 #[derive(Debug)]
-#[hyperactor::export(spawn = true, handlers = [LoggerRuntimeMessage {cast = true}])]
+#[hyperactor::export(handlers = [LoggerRuntimeMessage {cast = true}])]
+#[hyperactor::spawnable]
 pub struct LoggerRuntimeActor {
     logger: Arc<Py<PyAny>>,
 }

--- a/monarch_introspection_snapshot/test/snapshot_integration_test.rs
+++ b/monarch_introspection_snapshot/test/snapshot_integration_test.rs
@@ -49,7 +49,8 @@ use ndslice::view::Ranked;
 // requirement for at least one handler.
 
 #[derive(Default, Debug)]
-#[hyperactor::export(spawn = true, handlers = [()])]
+#[hyperactor::spawnable]
+#[hyperactor::export(handlers = [()])]
 struct SnapshotTestActor;
 
 impl Actor for SnapshotTestActor {}

--- a/monarch_rdma/examples/cuda_ping_pong/Cargo.toml
+++ b/monarch_rdma/examples/cuda_ping_pong/Cargo.toml
@@ -37,4 +37,3 @@ tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }
 tracing = { version = "0.1.41", features = ["attributes", "valuable"] }
 tracing-subscriber = { version = "0.3.23", features = ["chrono", "env-filter", "json", "local-time", "parking_lot", "registry"] }
 typeuri = { version = "0.0.0", path = "../../../typeuri" }
-wirevalue = { version = "0.0.0", path = "../../../wirevalue" }

--- a/monarch_rdma/examples/cuda_ping_pong/src/cuda_ping_pong.rs
+++ b/monarch_rdma/examples/cuda_ping_pong/src/cuda_ping_pong.rs
@@ -247,8 +247,8 @@ impl CliConfig {
 
 // CUDA RDMA Actor
 #[derive(Debug)]
+#[hyperactor::spawnable]
 #[hyperactor::export(
-    spawn = true,
     handlers = [
         InitializeBuffer,
         PerformPingPong,

--- a/monarch_rdma/examples/parameter_server/Cargo.toml
+++ b/monarch_rdma/examples/parameter_server/Cargo.toml
@@ -34,7 +34,6 @@ tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }
 tracing = { version = "0.1.41", features = ["attributes", "valuable"] }
 tracing-subscriber = { version = "0.3.23", features = ["chrono", "env-filter", "json", "local-time", "parking_lot", "registry"] }
 typeuri = { version = "0.0.0", path = "../../../typeuri" }
-wirevalue = { version = "0.0.0", path = "../../../wirevalue" }
 
 [dev-dependencies]
 timed_test = { version = "0.0.0", path = "../../../timed_test" }

--- a/monarch_rdma/examples/parameter_server/src/parameter_server.rs
+++ b/monarch_rdma/examples/parameter_server/src/parameter_server.rs
@@ -94,8 +94,8 @@ const BUFFER_SIZE: usize = 8;
 
 // Parameter Server Actor
 #[derive(Debug)]
+#[hyperactor::spawnable]
 #[hyperactor::export(
-    spawn = true,
     handlers = [
         PsGetBuffers,
         PsUpdate,
@@ -249,8 +249,8 @@ impl Handler<Log> for ParameterServerActor {
 
 // Worker Actor
 #[derive(Debug)]
+#[hyperactor::spawnable]
 #[hyperactor::export(
-    spawn = true,
     handlers = [
         WorkerInit { cast = true },
         WorkerStep { cast = true },

--- a/monarch_rdma/src/backend/ibverbs/mlx5dv_tests.rs
+++ b/monarch_rdma/src/backend/ibverbs/mlx5dv_tests.rs
@@ -45,7 +45,8 @@ use crate::register_segment_scanner;
 /// request. Allocate and register are separate messages so that multiple senders
 /// can allocate first (making all segments visible to the scanner) before any
 /// of them trigger registration.
-#[hyperactor::export(spawn = true, handlers = [SenderMessage])]
+#[hyperactor::export(handlers = [SenderMessage])]
+#[hyperactor::spawnable]
 #[derive(Debug)]
 struct SenderActor {
     device: i32,
@@ -162,7 +163,8 @@ impl SenderMessageHandler for SenderActor {
 
 /// Runs in the receiver's child process. Allocates a CPU buffer and performs
 /// an RDMA read from the sender's GPU memory.
-#[hyperactor::export(spawn = true, handlers = [ReceiverMessage])]
+#[hyperactor::export(handlers = [ReceiverMessage])]
+#[hyperactor::spawnable]
 #[derive(Debug)]
 struct ReceiverActor;
 

--- a/monarch_rdma/src/backend/ibverbs/test_utils.rs
+++ b/monarch_rdma/src/backend/ibverbs/test_utils.rs
@@ -45,11 +45,11 @@ unsafe impl Sync for SendSyncCudaContext {}
 /// Actor responsible for CUDA initialization and buffer management within its own process context.
 /// This is important because you preform CUDA operations within the same process as the RDMA operations.
 #[hyperactor::export(
-    spawn = true,
     handlers = [
         CudaActorMessage,
     ],
 )]
+#[hyperactor::spawnable]
 #[derive(Debug)]
 pub struct CudaActor {
     device: Option<i32>,

--- a/monarch_rdma/src/rdma_manager_actor.rs
+++ b/monarch_rdma/src/rdma_manager_actor.rs
@@ -144,13 +144,13 @@ impl<A: Actor> RdmaBackendActor<A> {
 
 #[derive(Debug)]
 #[hyperactor::export(
-    spawn = true,
     handlers = [
         GetIbvActorRef,
         GetTcpActorRef,
         ReleaseBuffer,
     ],
 )]
+#[hyperactor::spawnable]
 pub struct RdmaManagerActor {
     next_remote_buf_id: usize,
     buffers: HashMap<usize, Arc<dyn RdmaLocalMemory>>,

--- a/monarch_tensor_worker/src/lib.rs
+++ b/monarch_tensor_worker/src/lib.rs
@@ -142,8 +142,8 @@ enum Recording {
 ///
 /// See [`WorkerMessage`] for what it can do!
 #[derive(Debug)]
+#[hyperactor::spawnable]
 #[hyperactor::export(
-    spawn = true,
     handlers = [
         WorkerMessage {cast = true},
         AssignRankMessage {cast = true},


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #3685

Split actor export semantics from concrete spawn registration and make generic actors exportable.

Examples:
`#[hyperactor::export(Ping)]`
`#[hyperactor::spawnable]`
`struct MyActor;`

`#[hyperactor::export(MessageEnvelope<T>)]`
`struct MyActor<T>;`
`hyperactor::register_spawnable!(MyActor<u64>);`

This change adds direct-list `#[export(...)]` parsing, a concrete-only `#[spawnable]` attribute macro, generic-aware actor naming, generic handler bounds in generated `Binds` impls, and `register_spawnable!` support for concrete generic instantiations. It also removes handler auto-registration from `#[export]` and migrates existing `spawn = true` call sites to the split API.

Differential Revision: [D103051277](https://our.internmc.facebook.com/intern/diff/D103051277/)