### PR TITLE
add per-QP flow control to IbvBackend (#3686)

### DIFF
--- a/monarch_rdma/src/backend/ibverbs/ibv_manager_actor_tests.rs
+++ b/monarch_rdma/src/backend/ibverbs/ibv_manager_actor_tests.rs
@@ -15,13 +15,118 @@
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+    use std::sync::atomic::AtomicUsize;
+    use std::sync::atomic::Ordering;
+
+    use hyperactor::Proc;
+    use hyperactor::RemoteSpawn;
+    use hyperactor::channel::ChannelAddr;
+    use hyperactor::channel::ChannelTransport;
+    use hyperactor_config::Flattrs;
+
     use super::super::PollTarget;
+    use super::super::manager_actor::IbvBackend;
+    use super::super::manager_actor::IbvManagerActor;
     use super::super::manager_actor::IbvManagerMessageClient;
     use super::super::primitives::IbvQpType;
     use super::super::primitives::get_all_devices;
     use super::super::test_utils::IbvTestEnv;
     use super::super::test_utils::*;
+    use crate::IbvConfig;
+    use crate::RdmaManagerMessageClient;
+    use crate::RdmaOp;
+    use crate::RdmaOpType;
+    use crate::RdmaRemoteBuffer;
+    use crate::backend::RdmaBackend;
+    use crate::backend::cuda_test_utils::CudaAllocation;
+    use crate::backend::cuda_test_utils::CudaAllocator;
+    use crate::backend::cuda_test_utils::cuda_allocator_scanner;
+    use crate::local_memory::KeepaliveLocalMemory;
+    use crate::local_memory::RdmaLocalMemory;
+    use crate::rdma_components::register_segment_scanner;
     use crate::rdma_components::validate_execution_context;
+    use crate::rdma_manager_actor::RdmaManagerActor;
+
+    /// Allocate a single host-resident `KeepaliveLocalMemory` of `size`
+    /// bytes pre-filled with `pattern`. The backing `Vec<u8>` is moved
+    /// into the keepalive (`monarch_rdma::local_memory` provides
+    /// `Keepalive for Vec<u8>` already), so the address stays valid for
+    /// the lifetime of the returned handle.
+    fn alloc_cpu_local(size: usize, pattern: u8) -> Arc<dyn RdmaLocalMemory> {
+        let v = vec![pattern; size];
+        let addr = v.as_ptr() as usize;
+        Arc::new(KeepaliveLocalMemory::new(addr, size, Arc::new(v)))
+    }
+
+    fn alloc_cuda_local(
+        device: i32,
+        size: usize,
+        pattern: u8,
+        cuda_allocs: &mut Vec<CudaAllocation>,
+    ) -> Result<Arc<dyn RdmaLocalMemory>, anyhow::Error> {
+        let alloc = CudaAllocator::get().allocate(device, size);
+        cuda_allocs.push(alloc.clone());
+        let addr = alloc.ptr();
+        let mem = KeepaliveLocalMemory::new(addr, size, Arc::new(alloc));
+        let pattern_buf = vec![pattern; size];
+        mem.write_at(0, &pattern_buf)?;
+        Ok(Arc::new(mem))
+    }
+
+    fn cleanup_cuda_allocations(cuda_allocs: Vec<CudaAllocation>) {
+        assert!(
+            cuda_allocs.into_iter().all(|alloc| alloc.try_free()),
+            "failed to free all CUDA allocations",
+        );
+    }
+
+    /// Allocate `n` independent local-memory handles of `size` bytes
+    /// each, every one pre-filled with the caller-supplied per-buffer
+    /// pattern. `accel` is a `cpu:n` or `cuda:n` string; the index
+    /// matters only for CUDA (host allocations ignore it). CUDA
+    /// allocations are appended to `cuda_allocs` so the caller can
+    /// `try_free` them once every reference (including the keepalive
+    /// inside the returned handles) has been dropped.
+    fn alloc_locals_with_patterns(
+        accel: &str,
+        n: usize,
+        size: usize,
+        pattern_for_index: impl Fn(usize) -> u8,
+        cuda_allocs: &mut Vec<CudaAllocation>,
+    ) -> Result<Vec<Arc<dyn RdmaLocalMemory>>, anyhow::Error> {
+        let (kind, idx_str) = accel
+            .split_once(':')
+            .ok_or_else(|| anyhow::anyhow!("expected accel like 'cpu:0' or 'cuda:0'"))?;
+        let idx: i32 = idx_str.parse()?;
+        (0..n)
+            .map(|i| match kind {
+                "cpu" => Ok(alloc_cpu_local(size, pattern_for_index(i))),
+                "cuda" => alloc_cuda_local(idx, size, pattern_for_index(i), cuda_allocs),
+                _ => Err(anyhow::anyhow!("unknown accel kind: {}", kind)),
+            })
+            .collect()
+    }
+
+    /// Read the full `mem` and assert every byte equals `expected`.
+    fn assert_buffer_uniform(
+        mem: &Arc<dyn RdmaLocalMemory>,
+        expected: u8,
+    ) -> Result<(), anyhow::Error> {
+        let mut buf = vec![0u8; mem.size()];
+        mem.read_at(0, &mut buf)?;
+        for (i, b) in buf.iter().enumerate() {
+            if *b != expected {
+                return Err(anyhow::anyhow!(
+                    "byte {}: got {:#x}, expected {:#x}",
+                    i,
+                    b,
+                    expected,
+                ));
+            }
+        }
+        Ok(())
+    }
 
     #[timed_test::async_timed_test(timeout_secs = 60)]
     async fn test_rdma_read_loopback() -> Result<(), anyhow::Error> {
@@ -842,5 +947,221 @@ mod tests {
 
         println!("2GB RDMA write test completed successfully");
         Ok(())
+    }
+
+    /// Register the cuda allocator's segment scanner so the mlx5dv path
+    /// can find `CudaAllocation`-backed buffers without going through
+    /// dmabuf.
+    fn ensure_cuda_segment_scanner() {
+        static REGISTER: std::sync::Once = std::sync::Once::new();
+        REGISTER.call_once(|| {
+            register_segment_scanner(Some(cuda_allocator_scanner));
+        });
+    }
+
+    /// Spawn a `Proc` hosting one `RdmaManagerActor` targeting `accel`.
+    async fn spawn_rdma_manager_proc(
+        accel: &str,
+        proc_name: String,
+    ) -> Result<
+        (
+            Proc,
+            hyperactor::Instance<()>,
+            hyperactor::ActorHandle<RdmaManagerActor>,
+        ),
+        anyhow::Error,
+    > {
+        let config = IbvConfig::targeting(accel);
+        let proc = Proc::direct(ChannelAddr::any(ChannelTransport::Unix), proc_name)?;
+        let (instance, _) = proc.instance("client")?;
+        let actor = RdmaManagerActor::new(Some(config), Flattrs::default()).await?;
+        let handle = proc.spawn("rdma_manager", actor)?;
+        Ok((proc, instance, handle))
+    }
+
+    /// Tear down `procs` so MRs deregister before their backing storage
+    /// is freed. Otherwise `RdmaManagerActor::handle_supervision_event`
+    /// can call `std::process::exit(1)` after the test logic completes.
+    async fn destroy_procs(procs: Vec<Proc>) -> Result<(), anyhow::Error> {
+        let timeout = std::time::Duration::from_secs(10);
+        for mut proc in procs {
+            proc.destroy_and_wait::<()>(timeout, None, "test cleanup")
+                .await?;
+        }
+        Ok(())
+    }
+
+    /// `N` concurrent ops, half reads + half writes, each touching a
+    /// distinct `(local_i, remote_i)` pair. The read half (`N/2 = 32`)
+    /// exceeds `max_rd_atomic = 16`, exercising read-permit recycling.
+    async fn submit_parallel_rw_inner(accel: &str) -> Result<(), anyhow::Error> {
+        // 2MB matches CUDA's VMM allocation granularity, which is the
+        // minimum size `cuMemGetHandleForAddressRange(DMA_BUF_FD, ...)`
+        // accepts inside `register_mr_impl`'s dmabuf fallback.
+        const BSIZE: usize = 2 * 1024 * 1024;
+        const N: usize = 64;
+        assert!(
+            !get_all_devices().is_empty(),
+            "test requires RDMA devices to be available",
+        );
+
+        fn local_pattern(i: usize) -> u8 {
+            i as u8
+        }
+        fn remote_pattern(i: usize) -> u8 {
+            (i as u8).wrapping_add(0x80)
+        }
+
+        static COUNTER: AtomicUsize = AtomicUsize::new(0);
+        let id = COUNTER.fetch_add(1, Ordering::Relaxed);
+        let (proc_1, instance_1, _actor_1) =
+            spawn_rdma_manager_proc(accel, format!("rdma_submit_rw_{id}_a")).await?;
+        let (proc_2, instance_2, actor_2) =
+            spawn_rdma_manager_proc(accel, format!("rdma_submit_rw_{id}_b")).await?;
+
+        let mut cuda_allocs: Vec<CudaAllocation> = Vec::new();
+        let remote_locals =
+            alloc_locals_with_patterns(accel, N, BSIZE, remote_pattern, &mut cuda_allocs)?;
+        let mut remote_handles: Vec<RdmaRemoteBuffer> = Vec::with_capacity(N);
+        for mem in &remote_locals {
+            let h = actor_2.request_buffer(&instance_2, mem.clone()).await?;
+            remote_handles.push(h);
+        }
+
+        let local_mems =
+            alloc_locals_with_patterns(accel, N, BSIZE, local_pattern, &mut cuda_allocs)?;
+
+        let ops: Vec<RdmaOp> = (0..N)
+            .map(|i| RdmaOp {
+                op_type: if i % 2 == 0 {
+                    RdmaOpType::ReadIntoLocal
+                } else {
+                    RdmaOpType::WriteFromLocal
+                },
+                local: local_mems[i].clone(),
+                remote: remote_handles[i].clone(),
+            })
+            .collect();
+        let mut backend = IbvBackend(IbvManagerActor::local_handle(&instance_1).await?);
+        backend
+            .submit(&instance_1, ops, std::time::Duration::from_secs(30))
+            .await?;
+
+        for i in 0..N {
+            if i % 2 == 0 {
+                assert_buffer_uniform(&local_mems[i], remote_pattern(i))?;
+            } else {
+                assert_buffer_uniform(&remote_locals[i], local_pattern(i))?;
+            }
+        }
+
+        for h in &remote_handles {
+            h.drop_buffer(&instance_2).await?;
+        }
+        // Drop the backend (and its `ActorHandle<IbvManagerActor>`)
+        // before tearing down the procs so the actors can shut down.
+        drop(backend);
+        destroy_procs(vec![proc_1, proc_2]).await?;
+        drop(remote_locals);
+        drop(local_mems);
+        cleanup_cuda_allocations(cuda_allocs);
+        Ok(())
+    }
+
+    #[timed_test::async_timed_test(timeout_secs = 120)]
+    async fn test_submit_parallel_rw_cpu() -> Result<(), anyhow::Error> {
+        submit_parallel_rw_inner("cpu:0").await
+    }
+
+    #[timed_test::async_timed_test(timeout_secs = 120)]
+    async fn test_submit_parallel_rw_cuda() -> Result<(), anyhow::Error> {
+        assert!(crate::is_cuda_available(), "CUDA must be available");
+        ensure_cuda_segment_scanner();
+        submit_parallel_rw_inner("cuda:0").await
+    }
+
+    /// `N > max_rd_atomic` reads from one remote into `N` distinct
+    /// locals. Each local has a sentinel disjoint from `REMOTE_FILL`,
+    /// so any missed read surfaces as a surviving sentinel.
+    async fn submit_fanout_reads_inner(accel: &str) -> Result<(), anyhow::Error> {
+        // 2MB matches CUDA's VMM allocation granularity, which is the
+        // minimum size `cuMemGetHandleForAddressRange(DMA_BUF_FD, ...)`
+        // accepts inside `register_mr_impl`'s dmabuf fallback.
+        const BSIZE: usize = 2 * 1024 * 1024;
+        const N: usize = 64;
+        const REMOTE_FILL: u8 = 0x2A;
+        assert!(
+            !get_all_devices().is_empty(),
+            "test requires RDMA devices to be available",
+        );
+
+        // i*37+0x55 mod 256 cycles through all 256 values (gcd(37, 256) = 1);
+        // bump off REMOTE_FILL so a missed read can't masquerade as success.
+        fn local_sentinel(i: usize) -> u8 {
+            let v = ((i as u32).wrapping_mul(37).wrapping_add(0x55)) as u8;
+            if v == REMOTE_FILL {
+                v.wrapping_add(1)
+            } else {
+                v
+            }
+        }
+
+        static COUNTER: AtomicUsize = AtomicUsize::new(0);
+        let id = COUNTER.fetch_add(1, Ordering::Relaxed);
+        let (proc_1, instance_1, _actor_1) =
+            spawn_rdma_manager_proc(accel, format!("rdma_submit_fanout_{id}_a")).await?;
+        let (proc_2, instance_2, actor_2) =
+            spawn_rdma_manager_proc(accel, format!("rdma_submit_fanout_{id}_b")).await?;
+
+        let mut cuda_allocs: Vec<CudaAllocation> = Vec::new();
+        let remote_local =
+            alloc_locals_with_patterns(accel, 1, BSIZE, |_| REMOTE_FILL, &mut cuda_allocs)?
+                .into_iter()
+                .next()
+                .unwrap();
+        let remote_handle = actor_2
+            .request_buffer(&instance_2, remote_local.clone())
+            .await?;
+
+        let local_mems =
+            alloc_locals_with_patterns(accel, N, BSIZE, local_sentinel, &mut cuda_allocs)?;
+        let ops: Vec<RdmaOp> = local_mems
+            .iter()
+            .map(|m| RdmaOp {
+                op_type: RdmaOpType::ReadIntoLocal,
+                local: m.clone(),
+                remote: remote_handle.clone(),
+            })
+            .collect();
+        let mut backend = IbvBackend(IbvManagerActor::local_handle(&instance_1).await?);
+        backend
+            .submit(&instance_1, ops, std::time::Duration::from_secs(30))
+            .await?;
+
+        for mem in &local_mems {
+            assert_buffer_uniform(mem, REMOTE_FILL)?;
+        }
+
+        remote_handle.drop_buffer(&instance_2).await?;
+        // Drop the backend (and its `ActorHandle<IbvManagerActor>`)
+        // before tearing down the procs so the actors can shut down.
+        drop(backend);
+        destroy_procs(vec![proc_1, proc_2]).await?;
+        drop(remote_local);
+        drop(local_mems);
+        cleanup_cuda_allocations(cuda_allocs);
+        Ok(())
+    }
+
+    #[timed_test::async_timed_test(timeout_secs = 120)]
+    async fn test_submit_fanout_reads_cpu() -> Result<(), anyhow::Error> {
+        submit_fanout_reads_inner("cpu:0").await
+    }
+
+    #[timed_test::async_timed_test(timeout_secs = 120)]
+    async fn test_submit_fanout_reads_cuda() -> Result<(), anyhow::Error> {
+        assert!(crate::is_cuda_available(), "CUDA must be available");
+        ensure_cuda_segment_scanner();
+        submit_fanout_reads_inner("cuda:0").await
     }
 }

--- a/monarch_rdma/src/backend/ibverbs/manager_actor.rs
+++ b/monarch_rdma/src/backend/ibverbs/manager_actor.rs
@@ -37,6 +37,8 @@ use hyperactor::RefClient;
 use hyperactor::reference;
 use serde::Deserialize;
 use serde::Serialize;
+use tokio::sync::OwnedSemaphorePermit;
+use tokio::sync::Semaphore;
 use typeuri::Named;
 
 use super::IbvBuffer;
@@ -52,6 +54,7 @@ use super::primitives::resolve_qp_type;
 use super::queue_pair::IbvQueuePair;
 use super::queue_pair::PollCompletionError;
 use super::queue_pair::PollTarget;
+use super::queue_pair::wr_count_for_size;
 use crate::RdmaOp;
 use crate::RdmaOpType;
 use crate::RdmaTransportLevel;
@@ -127,7 +130,72 @@ pub enum IbvManagerMessage {
 }
 wirevalue::register_type!(IbvManagerMessage);
 
-/// Local-only messages for MR registration/deregistration.
+/// Per-QP send-queue flow control. Splits the QP's `max_send_wr`
+/// capacity into two independent pools: `max_rd_atomic` permits for
+/// RDMA-READs (NIC-level cap; over-posting trips `ENOMEM` from
+/// `ibv_post_send`) and the remainder for RDMA-WRITEs. Permits map
+/// 1:1 to send-queue WRs, so an op that posts N WRs claims N permits.
+#[derive(Debug)]
+pub struct QpFlowControl {
+    read_sem: Arc<Semaphore>,
+    write_sem: Arc<Semaphore>,
+    max_read_permits: u32,
+    max_write_permits: u32,
+}
+
+impl QpFlowControl {
+    fn new(config: &IbvConfig) -> Result<Self, anyhow::Error> {
+        let max_rd_atomic = config.max_rd_atomic as u32;
+        let max_send_wr = config.max_send_wr;
+        // `max_rd_atomic == 0` would deadlock any RDMA-READ op, and a QP
+        // whose `max_send_wr` does not exceed `max_rd_atomic` would give
+        // writes zero permits and deadlock any RDMA-WRITE op.
+        anyhow::ensure!(
+            max_rd_atomic > 0,
+            "max_rd_atomic must be > 0 (got {})",
+            max_rd_atomic,
+        );
+        anyhow::ensure!(
+            max_send_wr > max_rd_atomic,
+            "max_send_wr ({}) must exceed max_rd_atomic ({})",
+            max_send_wr,
+            max_rd_atomic,
+        );
+        let max_write_permits = max_send_wr - max_rd_atomic;
+        Ok(Self {
+            read_sem: Arc::new(Semaphore::new(max_rd_atomic as usize)),
+            write_sem: Arc::new(Semaphore::new(max_write_permits as usize)),
+            max_read_permits: max_rd_atomic,
+            max_write_permits,
+        })
+    }
+
+    /// Acquire `n` permits from the pool for `op_type`, one per WR the op
+    /// will post. Drop the returned guard to return them all. Errors if
+    /// `n` exceeds the pool's total capacity, since otherwise the await
+    /// would block forever waiting for permits that can never be released.
+    async fn acquire_many(
+        &self,
+        op_type: RdmaOpType,
+        n: u32,
+    ) -> Result<OwnedSemaphorePermit, anyhow::Error> {
+        let (sem, capacity) = match op_type {
+            RdmaOpType::ReadIntoLocal => (self.read_sem.clone(), self.max_read_permits),
+            RdmaOpType::WriteFromLocal => (self.write_sem.clone(), self.max_write_permits),
+        };
+        anyhow::ensure!(
+            n <= capacity,
+            "RDMA op of {} WRs exceeds {:?} pool capacity ({})",
+            n,
+            op_type,
+            capacity,
+        );
+        Ok(sem.acquire_many_owned(n).await?)
+    }
+}
+
+/// Local-only messages for MR registration/deregistration and fetching
+/// the per-QP flow-control semaphores.
 #[derive(Handler, HandleClient, Debug)]
 pub enum IbvManagerLocalMessage {
     /// Register a memory region, returning the MR view and device name.
@@ -142,6 +210,15 @@ pub enum IbvManagerLocalMessage {
         id: usize,
         #[reply]
         reply: OncePortHandle<Result<(), String>>,
+    },
+    /// Return the [`QpFlowControl`] for the given QP, or `None` if it
+    /// hasn't been created yet.
+    GetQpFlowControl {
+        local_device: String,
+        remote_actor_id: reference::ActorId,
+        remote_device: String,
+        #[reply]
+        reply: OncePortHandle<Option<Arc<QpFlowControl>>>,
     },
 }
 
@@ -160,6 +237,9 @@ pub struct IbvManagerActor {
 
     // Nested map: local_device -> (ActorId, remote_device) -> IbvQueuePair
     device_qps: HashMap<String, HashMap<(reference::ActorId, String), IbvQueuePair>>,
+
+    // Per-QP flow control, keyed identically to `device_qps`.
+    qp_flow_control: HashMap<String, HashMap<(reference::ActorId, String), Arc<QpFlowControl>>>,
 
     // Track QPs currently being created to prevent duplicate creation
     // Wrapped in Arc<Mutex> to allow safe concurrent access
@@ -313,6 +393,7 @@ impl IbvManagerActor {
         let actor = Self {
             owner: OnceLock::new(),
             device_qps: HashMap::new(),
+            qp_flow_control: HashMap::new(),
             pending_qp_creation: Arc::new(Mutex::new(HashSet::new())),
             device_domains: HashMap::new(),
             config,
@@ -899,11 +980,15 @@ impl IbvManagerMessageHandler for IbvManagerActor {
         let qp = IbvQueuePair::new(domain_context, domain_pd, self.config.clone())
             .map_err(|e| anyhow::anyhow!("could not create IbvQueuePair: {}", e))?;
 
-        // Insert the QP into the nested map structure
+        let flow_control = Arc::new(QpFlowControl::new(&self.config)?);
         self.device_qps
             .entry(self_device.clone())
             .or_insert_with(HashMap::new)
-            .insert(inner_key, qp);
+            .insert(inner_key.clone(), qp);
+        self.qp_flow_control
+            .entry(self_device.clone())
+            .or_insert_with(HashMap::new)
+            .insert(inner_key, flow_control);
 
         tracing::debug!(
             "successfully created a connection with {:?} for local device {} -> remote device {}",
@@ -1003,6 +1088,21 @@ impl IbvManagerLocalMessageHandler for IbvManagerActor {
         id: usize,
     ) -> Result<Result<(), String>, anyhow::Error> {
         Ok(self.deregister_mr_impl(id).map_err(|e| e.to_string()))
+    }
+
+    async fn get_qp_flow_control(
+        &mut self,
+        _cx: &Context<Self>,
+        local_device: String,
+        remote_actor_id: reference::ActorId,
+        remote_device: String,
+    ) -> Result<Option<Arc<QpFlowControl>>, anyhow::Error> {
+        let inner_key = (remote_actor_id, remote_device);
+        Ok(self
+            .qp_flow_control
+            .get(&local_device)
+            .and_then(|m| m.get(&inner_key))
+            .cloned())
     }
 }
 
@@ -1134,6 +1234,30 @@ impl IbvBackend {
                 .await?
                 .map_err(|e| anyhow::anyhow!(e))?;
 
+            // Hold one send-queue permit per WR `qp.put`/`qp.get` will post,
+            // until `wait_for_completion` drains all of their CQEs. A single
+            // op chunked into N WRs consumes N slots in the QP send queue
+            // (and N `max_rd_atomic` slots if it's an RDMA-READ), so we
+            // reserve N permits up front to avoid `ENOMEM` from
+            // `ibv_post_send` under concurrent submitters.
+            let flow_control = self
+                .get_qp_flow_control(
+                    cx,
+                    local_buffer.device_name.clone(),
+                    op.remote_manager.actor_id().clone(),
+                    op.remote_buffer.device_name.clone(),
+                )
+                .await?
+                .ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "QP flow control missing for {} -> {}",
+                        local_buffer.device_name,
+                        op.remote_buffer.device_name,
+                    )
+                })?;
+            let n_wrs = wr_count_for_size(local_buffer.size);
+            let _flow_guard = flow_control.acquire_many(op.op_type, n_wrs).await?;
+
             let wr_id = match op.op_type {
                 RdmaOpType::WriteFromLocal => qp.put(local_buffer.clone(), op.remote_buffer)?,
                 RdmaOpType::ReadIntoLocal => qp.get(local_buffer.clone(), op.remote_buffer)?,
@@ -1167,10 +1291,8 @@ impl IbvBackend {
 impl RdmaBackend for IbvBackend {
     type TransportInfo = ();
 
-    /// Submit a batch of RDMA operations.
-    ///
-    /// Resolves ibv ops, then executes each directly — registering/deregistering
-    /// MRs via actor messages, while performing QP put/get and CQ polling locally.
+    /// Submit a batch of RDMA ops, sharing one deadline across the
+    /// batch. Per-op flow control runs inside [`Self::execute_op`].
     async fn submit(
         &mut self,
         cx: &(impl hyperactor::context::Actor + Send + Sync),
@@ -1193,14 +1315,33 @@ impl RdmaBackend for IbvBackend {
         }
 
         let deadline = Instant::now() + timeout;
-        for op in ibv_ops {
+        let this = &*self;
+        let futs = ibv_ops.into_iter().map(|op| async move {
             let remaining = deadline.saturating_duration_since(Instant::now());
             if remaining.is_zero() {
                 return Err(anyhow::anyhow!("submit timed out"));
             }
-            self.execute_op(cx, op, remaining).await?;
+            this.execute_op(cx, op, remaining).await
+        });
+        // `join_all` (not `try_join_all`) so a sibling failure can't drop
+        // an in-flight `execute_op` mid-await, which would skip its
+        // `deregister_mr` cleanup and release a flow-control permit
+        // while the WR is still posted on the hardware.
+        let results = futures::future::join_all(futs).await;
+        let errors: Vec<anyhow::Error> = results.into_iter().filter_map(Result::err).collect();
+        if errors.is_empty() {
+            Ok(())
+        } else {
+            Err(anyhow::anyhow!(
+                "{} op(s) failed: {}",
+                errors.len(),
+                errors
+                    .iter()
+                    .map(|e| e.to_string())
+                    .collect::<Vec<_>>()
+                    .join("; "),
+            ))
         }
-        Ok(())
     }
 
     fn transport_level(&self) -> RdmaTransportLevel {

--- a/monarch_rdma/src/backend/ibverbs/queue_pair.rs
+++ b/monarch_rdma/src/backend/ibverbs/queue_pair.rs
@@ -15,6 +15,19 @@
 /// Maximum size for a single RDMA operation in bytes (1 GiB).
 const MAX_RDMA_MSG_SIZE: usize = 1024 * 1024 * 1024;
 
+/// Number of work requests `put`/`get` will post for an op of `size` bytes.
+/// Each WR consumes one slot in the QP send queue (and one `max_rd_atomic`
+/// slot if the op is an RDMA-READ), so callers that need to reserve send-queue
+/// capacity ahead of time should use this to size the reservation.
+pub(crate) fn wr_count_for_size(size: usize) -> u32 {
+    // A zero-byte op still posts no WRs; otherwise it's ceil(size / chunk).
+    if size == 0 {
+        0
+    } else {
+        size.div_ceil(MAX_RDMA_MSG_SIZE) as u32
+    }
+}
+
 use std::io::Error;
 use std::result::Result;
 use std::time::Duration;
@@ -250,7 +263,9 @@ impl IbvQueuePair {
                 &mut port_attr as *mut rdmaxcel_sys::ibv_port_attr as *mut _,
             );
             if errno != 0 {
-                let os_error = Error::last_os_error();
+                // ibv_query_port returns the errno value directly; reading
+                // the C global Error::last_os_error() can be stale.
+                let os_error = Error::from_raw_os_error(errno);
                 return Err(anyhow::anyhow!(
                     "Failed to query port attributes: {}",
                     os_error
@@ -295,7 +310,9 @@ impl IbvQueuePair {
                 &mut qp_init_attr,
             );
             if errno != 0 {
-                let os_error = Error::last_os_error();
+                // ibv_query_qp returns the errno value directly; reading
+                // the C global Error::last_os_error() can be stale.
+                let os_error = Error::from_raw_os_error(errno);
                 return Err(anyhow::anyhow!("failed to query QP state: {}", os_error));
             }
             Ok(qp_attr.qp_state)
@@ -337,7 +354,9 @@ impl IbvQueuePair {
 
             let errno = rdmaxcel_sys::ibv_modify_qp((*qp).ibv_qp, &mut qp_attr, mask.0 as i32);
             if errno != 0 {
-                let os_error = Error::last_os_error();
+                // ibv_modify_qp returns the errno value directly; reading
+                // the C global Error::last_os_error() can be stale.
+                let os_error = Error::from_raw_os_error(errno);
                 return Err(anyhow::anyhow!(
                     "failed to transition QP to INIT: {}",
                     os_error
@@ -382,7 +401,9 @@ impl IbvQueuePair {
 
             let errno = rdmaxcel_sys::ibv_modify_qp((*qp).ibv_qp, &mut qp_attr, mask.0 as i32);
             if errno != 0 {
-                let os_error = Error::last_os_error();
+                // ibv_modify_qp returns the errno value directly; reading
+                // the C global Error::last_os_error() can be stale.
+                let os_error = Error::from_raw_os_error(errno);
                 return Err(anyhow::anyhow!(
                     "failed to transition QP to RTR: {}",
                     os_error
@@ -409,7 +430,9 @@ impl IbvQueuePair {
 
             let errno = rdmaxcel_sys::ibv_modify_qp((*qp).ibv_qp, &mut qp_attr, mask.0 as i32);
             if errno != 0 {
-                let os_error = Error::last_os_error();
+                // ibv_modify_qp returns the errno value directly; reading
+                // the C global Error::last_os_error() can be stale.
+                let os_error = Error::from_raw_os_error(errno);
                 return Err(anyhow::anyhow!(
                     "failed to transition QP to RTS: {}",
                     os_error
@@ -793,7 +816,9 @@ impl IbvQueuePair {
             }
 
             if errno != 0 {
-                let os_error = Error::last_os_error();
+                // ibv_post_send returns the errno value directly; reading
+                // the C global Error::last_os_error() can be stale.
+                let os_error = Error::from_raw_os_error(errno);
                 return Err(anyhow::anyhow!("Failed to post send request: {}", os_error));
             }
             tracing::debug!(


### PR DESCRIPTION
Summary:

- Goal: let `IbvBackend::submit` run a batch of ops concurrently without over-posting the QP's send queue (over-posting trips `ENOMEM` from `ibv_post_send`).
- Add `QpFlowControl`: per-QP semaphores split into a read pool sized to `max_rd_atomic` (the NIC-level cap on outstanding RDMA-READs) and a write pool sized to the remainder of `max_send_wr`. Each `execute_op` acquires one permit before posting and holds it until the CQE drains.
- Switch `IbvBackend::submit` from a sequential per-op loop to concurrent execution via `futures::future::join_all`, aggregating per-op errors. The per-QP permits are the only backpressure.
- Fix six libibverbs call sites in `queue_pair.rs` to format errnos via `Error::from_raw_os_error(rc)` instead of `Error::last_os_error()` — those entry points return errno directly, and the C global was sometimes stale and masking real failures (e.g. `ENOMEM` reported as `EAGAIN`).
- Add `test_submit_parallel_rw_*` and `test_submit_fanout_reads_*` that drive `N > max_rd_atomic` ops through `IbvBackend::submit` to exercise read-permit recycling.

Differential Revision: D102724923


