### PR TITLE
push RDMAAction parallelism into the Rust backends (#3687)

### DIFF
--- a/monarch_hyperactor/src/pytokio.rs
+++ b/monarch_hyperactor/src/pytokio.rs
@@ -817,6 +817,41 @@ impl PyShared {
         )
     }
 
+    /// Run the given `Shared`s concurrently and collect their
+    /// results.
+    ///
+    /// Returns a `Shared` resolving to a tuple with one entry per
+    /// input, in the same order. Each entry is either the resolved
+    /// value (on success) or the Python exception object the task
+    /// failed with -- exceptions are returned as values, not raised.
+    #[staticmethod]
+    #[pyo3(signature = (*tasks))]
+    fn gather(tasks: Vec<PyRef<'_, PyShared>>) -> PyResult<PyShared> {
+        let futures = tasks
+            .iter()
+            .map(|s| {
+                let mut t = s.task()?;
+                t.take_task()
+            })
+            .collect::<PyResult<Vec<_>>>()?;
+
+        let mut task = PyPythonTask::new(async move {
+            let results = futures::future::join_all(futures).await;
+            monarch_with_gil(|py| -> PyResult<Py<PyAny>> {
+                let items: Vec<Py<PyAny>> = results
+                    .into_iter()
+                    .map(|r| match r {
+                        Ok(v) => v,
+                        Err(err) => err.into_value(py).into_any(),
+                    })
+                    .collect();
+                Ok(PyTuple::new(py, items)?.into_any().unbind())
+            })
+            .await
+        })?;
+        task.spawn()
+    }
+
     /// Implement Python's `await` protocol for `Shared`.
     ///
     /// This delegates to `self.task()` (which returns a `PythonTask`

--- a/monarch_rdma/extension/lib.rs
+++ b/monarch_rdma/extension/lib.rs
@@ -18,6 +18,7 @@ use monarch_hyperactor::runtime::monarch_with_gil_blocking;
 use monarch_hyperactor::runtime::signal_safe_block_on;
 use monarch_rdma::RdmaManagerActor;
 use monarch_rdma::RdmaManagerMessageClient;
+use monarch_rdma::RdmaOpType;
 use monarch_rdma::RdmaRemoteBuffer;
 use monarch_rdma::ibverbs_supported;
 use monarch_rdma::local_memory::Keepalive;
@@ -181,6 +182,28 @@ impl PyLocalMemoryHandle {
     }
 }
 
+/// Python-visible mirror of [`RdmaOpType`] for [`PyRdmaBuffer::submit`].
+#[pyclass(
+    name = "_RdmaOpType",
+    module = "monarch._rust_bindings.rdma",
+    eq,
+    eq_int
+)]
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum PyRdmaOpType {
+    ReadInto,
+    WriteFrom,
+}
+
+impl From<PyRdmaOpType> for RdmaOpType {
+    fn from(op_type: PyRdmaOpType) -> Self {
+        match op_type {
+            PyRdmaOpType::ReadInto => RdmaOpType::ReadIntoLocal,
+            PyRdmaOpType::WriteFrom => RdmaOpType::WriteFromLocal,
+        }
+    }
+}
+
 #[pyclass(name = "_RdmaBuffer", module = "monarch._rust_bindings.rdma")]
 #[derive(Clone, Named)]
 struct PyRdmaBuffer {
@@ -235,6 +258,34 @@ impl PyRdmaBuffer {
         format!("<RdmaBuffer'{:?}'>", self.buffer)
     }
 
+    /// Submit a batch of `(op_type, local)` ops against this buffer.
+    /// `timeout` is in seconds and applies to the batch.
+    fn submit<'py>(
+        &self,
+        _py: Python<'py>,
+        ops: Vec<(PyRdmaOpType, PyLocalMemoryHandle)>,
+        client: PyInstance,
+        timeout: u64,
+    ) -> PyResult<PyPythonTask> {
+        let buffer = self.buffer.clone();
+        PyPythonTask::new(async move {
+            let rdma_ops: Vec<(RdmaOpType, Arc<dyn RdmaLocalMemory>)> = ops
+                .into_iter()
+                .map(|(op_type, handle)| {
+                    let local: Arc<dyn RdmaLocalMemory> = Arc::new(handle.inner);
+                    (op_type.into(), local)
+                })
+                .collect();
+
+            buffer
+                .submit(client.deref(), rdma_ops, timeout)
+                .await
+                .map_err(|e| PyException::new_err(format!("failed to submit batch: {}", e)))?;
+
+            Ok(())
+        })
+    }
+
     /// Reads from this remote RDMA buffer into a local memory region.
     ///
     /// # Arguments
@@ -243,23 +294,12 @@ impl PyRdmaBuffer {
     /// * `timeout` - Maximum time in seconds to wait for the operation
     fn read_into<'py>(
         &self,
-        _py: Python<'py>,
+        py: Python<'py>,
         dst: PyLocalMemoryHandle,
         client: PyInstance,
         timeout: u64,
     ) -> PyResult<PyPythonTask> {
-        let buffer = self.buffer.clone();
-
-        PyPythonTask::new(async move {
-            let local_memory: Arc<dyn RdmaLocalMemory> = Arc::new(dst.inner);
-
-            buffer
-                .read_into_local(client.deref(), local_memory, timeout)
-                .await
-                .map_err(|e| PyException::new_err(format!("failed to read into buffer: {}", e)))?;
-
-            Ok(())
-        })
+        self.submit(py, vec![(PyRdmaOpType::ReadInto, dst)], client, timeout)
     }
 
     /// Writes from a local memory region into this remote RDMA buffer.
@@ -270,23 +310,12 @@ impl PyRdmaBuffer {
     /// * `timeout` - Maximum time in seconds to wait for the operation
     fn write_from<'py>(
         &self,
-        _py: Python<'py>,
+        py: Python<'py>,
         src: PyLocalMemoryHandle,
         client: PyInstance,
         timeout: u64,
     ) -> PyResult<PyPythonTask> {
-        let buffer = self.buffer.clone();
-
-        PyPythonTask::new(async move {
-            let local_memory: Arc<dyn RdmaLocalMemory> = Arc::new(src.inner);
-
-            buffer
-                .write_from_local(client.deref(), local_memory, timeout)
-                .await
-                .map_err(|e| PyException::new_err(format!("failed to write from buffer: {}", e)))?;
-
-            Ok(())
-        })
+        self.submit(py, vec![(PyRdmaOpType::WriteFrom, src)], client, timeout)
     }
 
     fn size(&self) -> usize {
@@ -393,6 +422,7 @@ pub fn register_python_bindings(module: &Bound<'_, PyModule>) -> PyResult<()> {
     register_segment_scanner(Some(pytorch_segment_scanner));
 
     module.add_class::<PyLocalMemoryHandle>()?;
+    module.add_class::<PyRdmaOpType>()?;
     module.add_class::<PyRdmaBuffer>()?;
     module.add_class::<PyRdmaManager>()?;
     py_module_add_function!(

--- a/monarch_rdma/src/backend/ibverbs/ibv_manager_actor_tests.rs
+++ b/monarch_rdma/src/backend/ibverbs/ibv_manager_actor_tests.rs
@@ -15,13 +15,118 @@
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+    use std::sync::atomic::AtomicUsize;
+    use std::sync::atomic::Ordering;
+
+    use hyperactor::Proc;
+    use hyperactor::RemoteSpawn;
+    use hyperactor::channel::ChannelAddr;
+    use hyperactor::channel::ChannelTransport;
+    use hyperactor_config::Flattrs;
+
     use super::super::PollTarget;
+    use super::super::manager_actor::IbvBackend;
+    use super::super::manager_actor::IbvManagerActor;
     use super::super::manager_actor::IbvManagerMessageClient;
     use super::super::primitives::IbvQpType;
     use super::super::primitives::get_all_devices;
     use super::super::test_utils::IbvTestEnv;
     use super::super::test_utils::*;
+    use crate::IbvConfig;
+    use crate::RdmaManagerMessageClient;
+    use crate::RdmaOp;
+    use crate::RdmaOpType;
+    use crate::RdmaRemoteBuffer;
+    use crate::backend::RdmaBackend;
+    use crate::backend::cuda_test_utils::CudaAllocation;
+    use crate::backend::cuda_test_utils::CudaAllocator;
+    use crate::backend::cuda_test_utils::cuda_allocator_scanner;
+    use crate::local_memory::KeepaliveLocalMemory;
+    use crate::local_memory::RdmaLocalMemory;
+    use crate::rdma_components::register_segment_scanner;
     use crate::rdma_components::validate_execution_context;
+    use crate::rdma_manager_actor::RdmaManagerActor;
+
+    /// Allocate a single host-resident `KeepaliveLocalMemory` of `size`
+    /// bytes pre-filled with `pattern`. The backing `Vec<u8>` is moved
+    /// into the keepalive (`monarch_rdma::local_memory` provides
+    /// `Keepalive for Vec<u8>` already), so the address stays valid for
+    /// the lifetime of the returned handle.
+    fn alloc_cpu_local(size: usize, pattern: u8) -> Arc<dyn RdmaLocalMemory> {
+        let v = vec![pattern; size];
+        let addr = v.as_ptr() as usize;
+        Arc::new(KeepaliveLocalMemory::new(addr, size, Arc::new(v)))
+    }
+
+    fn alloc_cuda_local(
+        device: i32,
+        size: usize,
+        pattern: u8,
+        cuda_allocs: &mut Vec<CudaAllocation>,
+    ) -> Result<Arc<dyn RdmaLocalMemory>, anyhow::Error> {
+        let alloc = CudaAllocator::get().allocate(device, size);
+        cuda_allocs.push(alloc.clone());
+        let addr = alloc.ptr();
+        let mem = KeepaliveLocalMemory::new(addr, size, Arc::new(alloc));
+        let pattern_buf = vec![pattern; size];
+        mem.write_at(0, &pattern_buf)?;
+        Ok(Arc::new(mem))
+    }
+
+    fn cleanup_cuda_allocations(cuda_allocs: Vec<CudaAllocation>) {
+        assert!(
+            cuda_allocs.into_iter().all(|alloc| alloc.try_free()),
+            "failed to free all CUDA allocations",
+        );
+    }
+
+    /// Allocate `n` independent local-memory handles of `size` bytes
+    /// each, every one pre-filled with the caller-supplied per-buffer
+    /// pattern. `accel` is a `cpu:n` or `cuda:n` string; the index
+    /// matters only for CUDA (host allocations ignore it). CUDA
+    /// allocations are appended to `cuda_allocs` so the caller can
+    /// `try_free` them once every reference (including the keepalive
+    /// inside the returned handles) has been dropped.
+    fn alloc_locals_with_patterns(
+        accel: &str,
+        n: usize,
+        size: usize,
+        pattern_for_index: impl Fn(usize) -> u8,
+        cuda_allocs: &mut Vec<CudaAllocation>,
+    ) -> Result<Vec<Arc<dyn RdmaLocalMemory>>, anyhow::Error> {
+        let (kind, idx_str) = accel
+            .split_once(':')
+            .ok_or_else(|| anyhow::anyhow!("expected accel like 'cpu:0' or 'cuda:0'"))?;
+        let idx: i32 = idx_str.parse()?;
+        (0..n)
+            .map(|i| match kind {
+                "cpu" => Ok(alloc_cpu_local(size, pattern_for_index(i))),
+                "cuda" => alloc_cuda_local(idx, size, pattern_for_index(i), cuda_allocs),
+                _ => Err(anyhow::anyhow!("unknown accel kind: {}", kind)),
+            })
+            .collect()
+    }
+
+    /// Read the full `mem` and assert every byte equals `expected`.
+    fn assert_buffer_uniform(
+        mem: &Arc<dyn RdmaLocalMemory>,
+        expected: u8,
+    ) -> Result<(), anyhow::Error> {
+        let mut buf = vec![0u8; mem.size()];
+        mem.read_at(0, &mut buf)?;
+        for (i, b) in buf.iter().enumerate() {
+            if *b != expected {
+                return Err(anyhow::anyhow!(
+                    "byte {}: got {:#x}, expected {:#x}",
+                    i,
+                    b,
+                    expected,
+                ));
+            }
+        }
+        Ok(())
+    }
 
     #[timed_test::async_timed_test(timeout_secs = 60)]
     async fn test_rdma_read_loopback() -> Result<(), anyhow::Error> {
@@ -842,5 +947,221 @@ mod tests {
 
         println!("2GB RDMA write test completed successfully");
         Ok(())
+    }
+
+    /// Register the cuda allocator's segment scanner so the mlx5dv path
+    /// can find `CudaAllocation`-backed buffers without going through
+    /// dmabuf.
+    fn ensure_cuda_segment_scanner() {
+        static REGISTER: std::sync::Once = std::sync::Once::new();
+        REGISTER.call_once(|| {
+            register_segment_scanner(Some(cuda_allocator_scanner));
+        });
+    }
+
+    /// Spawn a `Proc` hosting one `RdmaManagerActor` targeting `accel`.
+    async fn spawn_rdma_manager_proc(
+        accel: &str,
+        proc_name: String,
+    ) -> Result<
+        (
+            Proc,
+            hyperactor::Instance<()>,
+            hyperactor::ActorHandle<RdmaManagerActor>,
+        ),
+        anyhow::Error,
+    > {
+        let config = IbvConfig::targeting(accel);
+        let proc = Proc::direct(ChannelAddr::any(ChannelTransport::Unix), proc_name)?;
+        let (instance, _) = proc.instance("client")?;
+        let actor = RdmaManagerActor::new(Some(config), Flattrs::default()).await?;
+        let handle = proc.spawn("rdma_manager", actor)?;
+        Ok((proc, instance, handle))
+    }
+
+    /// Tear down `procs` so MRs deregister before their backing storage
+    /// is freed. Otherwise `RdmaManagerActor::handle_supervision_event`
+    /// can call `std::process::exit(1)` after the test logic completes.
+    async fn destroy_procs(procs: Vec<Proc>) -> Result<(), anyhow::Error> {
+        let timeout = std::time::Duration::from_secs(10);
+        for mut proc in procs {
+            proc.destroy_and_wait::<()>(timeout, None, "test cleanup")
+                .await?;
+        }
+        Ok(())
+    }
+
+    /// `N` concurrent ops, half reads + half writes, each touching a
+    /// distinct `(local_i, remote_i)` pair. The read half (`N/2 = 32`)
+    /// exceeds `max_rd_atomic = 16`, exercising read-permit recycling.
+    async fn submit_parallel_rw_inner(accel: &str) -> Result<(), anyhow::Error> {
+        // 2MB matches CUDA's VMM allocation granularity, which is the
+        // minimum size `cuMemGetHandleForAddressRange(DMA_BUF_FD, ...)`
+        // accepts inside `register_mr_impl`'s dmabuf fallback.
+        const BSIZE: usize = 2 * 1024 * 1024;
+        const N: usize = 64;
+        assert!(
+            !get_all_devices().is_empty(),
+            "test requires RDMA devices to be available",
+        );
+
+        fn local_pattern(i: usize) -> u8 {
+            i as u8
+        }
+        fn remote_pattern(i: usize) -> u8 {
+            (i as u8).wrapping_add(0x80)
+        }
+
+        static COUNTER: AtomicUsize = AtomicUsize::new(0);
+        let id = COUNTER.fetch_add(1, Ordering::Relaxed);
+        let (proc_1, instance_1, _actor_1) =
+            spawn_rdma_manager_proc(accel, format!("rdma_submit_rw_{id}_a")).await?;
+        let (proc_2, instance_2, actor_2) =
+            spawn_rdma_manager_proc(accel, format!("rdma_submit_rw_{id}_b")).await?;
+
+        let mut cuda_allocs: Vec<CudaAllocation> = Vec::new();
+        let remote_locals =
+            alloc_locals_with_patterns(accel, N, BSIZE, remote_pattern, &mut cuda_allocs)?;
+        let mut remote_handles: Vec<RdmaRemoteBuffer> = Vec::with_capacity(N);
+        for mem in &remote_locals {
+            let h = actor_2.request_buffer(&instance_2, mem.clone()).await?;
+            remote_handles.push(h);
+        }
+
+        let local_mems =
+            alloc_locals_with_patterns(accel, N, BSIZE, local_pattern, &mut cuda_allocs)?;
+
+        let ops: Vec<RdmaOp> = (0..N)
+            .map(|i| RdmaOp {
+                op_type: if i % 2 == 0 {
+                    RdmaOpType::ReadIntoLocal
+                } else {
+                    RdmaOpType::WriteFromLocal
+                },
+                local: local_mems[i].clone(),
+                remote: remote_handles[i].clone(),
+            })
+            .collect();
+        let mut backend = IbvBackend(IbvManagerActor::local_handle(&instance_1).await?);
+        backend
+            .submit(&instance_1, ops, std::time::Duration::from_secs(30))
+            .await?;
+
+        for i in 0..N {
+            if i % 2 == 0 {
+                assert_buffer_uniform(&local_mems[i], remote_pattern(i))?;
+            } else {
+                assert_buffer_uniform(&remote_locals[i], local_pattern(i))?;
+            }
+        }
+
+        for h in &remote_handles {
+            h.drop_buffer(&instance_2).await?;
+        }
+        // Drop the backend (and its `ActorHandle<IbvManagerActor>`)
+        // before tearing down the procs so the actors can shut down.
+        drop(backend);
+        destroy_procs(vec![proc_1, proc_2]).await?;
+        drop(remote_locals);
+        drop(local_mems);
+        cleanup_cuda_allocations(cuda_allocs);
+        Ok(())
+    }
+
+    #[timed_test::async_timed_test(timeout_secs = 120)]
+    async fn test_submit_parallel_rw_cpu() -> Result<(), anyhow::Error> {
+        submit_parallel_rw_inner("cpu:0").await
+    }
+
+    #[timed_test::async_timed_test(timeout_secs = 120)]
+    async fn test_submit_parallel_rw_cuda() -> Result<(), anyhow::Error> {
+        assert!(crate::is_cuda_available(), "CUDA must be available");
+        ensure_cuda_segment_scanner();
+        submit_parallel_rw_inner("cuda:0").await
+    }
+
+    /// `N > max_rd_atomic` reads from one remote into `N` distinct
+    /// locals. Each local has a sentinel disjoint from `REMOTE_FILL`,
+    /// so any missed read surfaces as a surviving sentinel.
+    async fn submit_fanout_reads_inner(accel: &str) -> Result<(), anyhow::Error> {
+        // 2MB matches CUDA's VMM allocation granularity, which is the
+        // minimum size `cuMemGetHandleForAddressRange(DMA_BUF_FD, ...)`
+        // accepts inside `register_mr_impl`'s dmabuf fallback.
+        const BSIZE: usize = 2 * 1024 * 1024;
+        const N: usize = 64;
+        const REMOTE_FILL: u8 = 0x2A;
+        assert!(
+            !get_all_devices().is_empty(),
+            "test requires RDMA devices to be available",
+        );
+
+        // i*37+0x55 mod 256 cycles through all 256 values (gcd(37, 256) = 1);
+        // bump off REMOTE_FILL so a missed read can't masquerade as success.
+        fn local_sentinel(i: usize) -> u8 {
+            let v = ((i as u32).wrapping_mul(37).wrapping_add(0x55)) as u8;
+            if v == REMOTE_FILL {
+                v.wrapping_add(1)
+            } else {
+                v
+            }
+        }
+
+        static COUNTER: AtomicUsize = AtomicUsize::new(0);
+        let id = COUNTER.fetch_add(1, Ordering::Relaxed);
+        let (proc_1, instance_1, _actor_1) =
+            spawn_rdma_manager_proc(accel, format!("rdma_submit_fanout_{id}_a")).await?;
+        let (proc_2, instance_2, actor_2) =
+            spawn_rdma_manager_proc(accel, format!("rdma_submit_fanout_{id}_b")).await?;
+
+        let mut cuda_allocs: Vec<CudaAllocation> = Vec::new();
+        let remote_local =
+            alloc_locals_with_patterns(accel, 1, BSIZE, |_| REMOTE_FILL, &mut cuda_allocs)?
+                .into_iter()
+                .next()
+                .unwrap();
+        let remote_handle = actor_2
+            .request_buffer(&instance_2, remote_local.clone())
+            .await?;
+
+        let local_mems =
+            alloc_locals_with_patterns(accel, N, BSIZE, local_sentinel, &mut cuda_allocs)?;
+        let ops: Vec<RdmaOp> = local_mems
+            .iter()
+            .map(|m| RdmaOp {
+                op_type: RdmaOpType::ReadIntoLocal,
+                local: m.clone(),
+                remote: remote_handle.clone(),
+            })
+            .collect();
+        let mut backend = IbvBackend(IbvManagerActor::local_handle(&instance_1).await?);
+        backend
+            .submit(&instance_1, ops, std::time::Duration::from_secs(30))
+            .await?;
+
+        for mem in &local_mems {
+            assert_buffer_uniform(mem, REMOTE_FILL)?;
+        }
+
+        remote_handle.drop_buffer(&instance_2).await?;
+        // Drop the backend (and its `ActorHandle<IbvManagerActor>`)
+        // before tearing down the procs so the actors can shut down.
+        drop(backend);
+        destroy_procs(vec![proc_1, proc_2]).await?;
+        drop(remote_local);
+        drop(local_mems);
+        cleanup_cuda_allocations(cuda_allocs);
+        Ok(())
+    }
+
+    #[timed_test::async_timed_test(timeout_secs = 120)]
+    async fn test_submit_fanout_reads_cpu() -> Result<(), anyhow::Error> {
+        submit_fanout_reads_inner("cpu:0").await
+    }
+
+    #[timed_test::async_timed_test(timeout_secs = 120)]
+    async fn test_submit_fanout_reads_cuda() -> Result<(), anyhow::Error> {
+        assert!(crate::is_cuda_available(), "CUDA must be available");
+        ensure_cuda_segment_scanner();
+        submit_fanout_reads_inner("cuda:0").await
     }
 }

--- a/monarch_rdma/src/backend/ibverbs/manager_actor.rs
+++ b/monarch_rdma/src/backend/ibverbs/manager_actor.rs
@@ -37,6 +37,8 @@ use hyperactor::RefClient;
 use hyperactor::reference;
 use serde::Deserialize;
 use serde::Serialize;
+use tokio::sync::OwnedSemaphorePermit;
+use tokio::sync::Semaphore;
 use typeuri::Named;
 
 use super::IbvBuffer;
@@ -52,6 +54,7 @@ use super::primitives::resolve_qp_type;
 use super::queue_pair::IbvQueuePair;
 use super::queue_pair::PollCompletionError;
 use super::queue_pair::PollTarget;
+use super::queue_pair::wr_count_for_size;
 use crate::RdmaOp;
 use crate::RdmaOpType;
 use crate::RdmaTransportLevel;
@@ -127,7 +130,72 @@ pub enum IbvManagerMessage {
 }
 wirevalue::register_type!(IbvManagerMessage);
 
-/// Local-only messages for MR registration/deregistration.
+/// Per-QP send-queue flow control. Splits the QP's `max_send_wr`
+/// capacity into two independent pools: `max_rd_atomic` permits for
+/// RDMA-READs (NIC-level cap; over-posting trips `ENOMEM` from
+/// `ibv_post_send`) and the remainder for RDMA-WRITEs. Permits map
+/// 1:1 to send-queue WRs, so an op that posts N WRs claims N permits.
+#[derive(Debug)]
+pub struct QpFlowControl {
+    read_sem: Arc<Semaphore>,
+    write_sem: Arc<Semaphore>,
+    max_read_permits: u32,
+    max_write_permits: u32,
+}
+
+impl QpFlowControl {
+    fn new(config: &IbvConfig) -> Result<Self, anyhow::Error> {
+        let max_rd_atomic = config.max_rd_atomic as u32;
+        let max_send_wr = config.max_send_wr;
+        // `max_rd_atomic == 0` would deadlock any RDMA-READ op, and a QP
+        // whose `max_send_wr` does not exceed `max_rd_atomic` would give
+        // writes zero permits and deadlock any RDMA-WRITE op.
+        anyhow::ensure!(
+            max_rd_atomic > 0,
+            "max_rd_atomic must be > 0 (got {})",
+            max_rd_atomic,
+        );
+        anyhow::ensure!(
+            max_send_wr > max_rd_atomic,
+            "max_send_wr ({}) must exceed max_rd_atomic ({})",
+            max_send_wr,
+            max_rd_atomic,
+        );
+        let max_write_permits = max_send_wr - max_rd_atomic;
+        Ok(Self {
+            read_sem: Arc::new(Semaphore::new(max_rd_atomic as usize)),
+            write_sem: Arc::new(Semaphore::new(max_write_permits as usize)),
+            max_read_permits: max_rd_atomic,
+            max_write_permits,
+        })
+    }
+
+    /// Acquire `n` permits from the pool for `op_type`, one per WR the op
+    /// will post. Drop the returned guard to return them all. Errors if
+    /// `n` exceeds the pool's total capacity, since otherwise the await
+    /// would block forever waiting for permits that can never be released.
+    async fn acquire_many(
+        &self,
+        op_type: RdmaOpType,
+        n: u32,
+    ) -> Result<OwnedSemaphorePermit, anyhow::Error> {
+        let (sem, capacity) = match op_type {
+            RdmaOpType::ReadIntoLocal => (self.read_sem.clone(), self.max_read_permits),
+            RdmaOpType::WriteFromLocal => (self.write_sem.clone(), self.max_write_permits),
+        };
+        anyhow::ensure!(
+            n <= capacity,
+            "RDMA op of {} WRs exceeds {:?} pool capacity ({})",
+            n,
+            op_type,
+            capacity,
+        );
+        Ok(sem.acquire_many_owned(n).await?)
+    }
+}
+
+/// Local-only messages for MR registration/deregistration and fetching
+/// the per-QP flow-control semaphores.
 #[derive(Handler, HandleClient, Debug)]
 pub enum IbvManagerLocalMessage {
     /// Register a memory region, returning the MR view and device name.
@@ -142,6 +210,15 @@ pub enum IbvManagerLocalMessage {
         id: usize,
         #[reply]
         reply: OncePortHandle<Result<(), String>>,
+    },
+    /// Return the [`QpFlowControl`] for the given QP, or `None` if it
+    /// hasn't been created yet.
+    GetQpFlowControl {
+        local_device: String,
+        remote_actor_id: reference::ActorId,
+        remote_device: String,
+        #[reply]
+        reply: OncePortHandle<Option<Arc<QpFlowControl>>>,
     },
 }
 
@@ -160,6 +237,9 @@ pub struct IbvManagerActor {
 
     // Nested map: local_device -> (ActorId, remote_device) -> IbvQueuePair
     device_qps: HashMap<String, HashMap<(reference::ActorId, String), IbvQueuePair>>,
+
+    // Per-QP flow control, keyed identically to `device_qps`.
+    qp_flow_control: HashMap<String, HashMap<(reference::ActorId, String), Arc<QpFlowControl>>>,
 
     // Track QPs currently being created to prevent duplicate creation
     // Wrapped in Arc<Mutex> to allow safe concurrent access
@@ -313,6 +393,7 @@ impl IbvManagerActor {
         let actor = Self {
             owner: OnceLock::new(),
             device_qps: HashMap::new(),
+            qp_flow_control: HashMap::new(),
             pending_qp_creation: Arc::new(Mutex::new(HashSet::new())),
             device_domains: HashMap::new(),
             config,
@@ -899,11 +980,15 @@ impl IbvManagerMessageHandler for IbvManagerActor {
         let qp = IbvQueuePair::new(domain_context, domain_pd, self.config.clone())
             .map_err(|e| anyhow::anyhow!("could not create IbvQueuePair: {}", e))?;
 
-        // Insert the QP into the nested map structure
+        let flow_control = Arc::new(QpFlowControl::new(&self.config)?);
         self.device_qps
             .entry(self_device.clone())
             .or_insert_with(HashMap::new)
-            .insert(inner_key, qp);
+            .insert(inner_key.clone(), qp);
+        self.qp_flow_control
+            .entry(self_device.clone())
+            .or_insert_with(HashMap::new)
+            .insert(inner_key, flow_control);
 
         tracing::debug!(
             "successfully created a connection with {:?} for local device {} -> remote device {}",
@@ -1003,6 +1088,21 @@ impl IbvManagerLocalMessageHandler for IbvManagerActor {
         id: usize,
     ) -> Result<Result<(), String>, anyhow::Error> {
         Ok(self.deregister_mr_impl(id).map_err(|e| e.to_string()))
+    }
+
+    async fn get_qp_flow_control(
+        &mut self,
+        _cx: &Context<Self>,
+        local_device: String,
+        remote_actor_id: reference::ActorId,
+        remote_device: String,
+    ) -> Result<Option<Arc<QpFlowControl>>, anyhow::Error> {
+        let inner_key = (remote_actor_id, remote_device);
+        Ok(self
+            .qp_flow_control
+            .get(&local_device)
+            .and_then(|m| m.get(&inner_key))
+            .cloned())
     }
 }
 
@@ -1134,6 +1234,30 @@ impl IbvBackend {
                 .await?
                 .map_err(|e| anyhow::anyhow!(e))?;
 
+            // Hold one send-queue permit per WR `qp.put`/`qp.get` will post,
+            // until `wait_for_completion` drains all of their CQEs. A single
+            // op chunked into N WRs consumes N slots in the QP send queue
+            // (and N `max_rd_atomic` slots if it's an RDMA-READ), so we
+            // reserve N permits up front to avoid `ENOMEM` from
+            // `ibv_post_send` under concurrent submitters.
+            let flow_control = self
+                .get_qp_flow_control(
+                    cx,
+                    local_buffer.device_name.clone(),
+                    op.remote_manager.actor_id().clone(),
+                    op.remote_buffer.device_name.clone(),
+                )
+                .await?
+                .ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "QP flow control missing for {} -> {}",
+                        local_buffer.device_name,
+                        op.remote_buffer.device_name,
+                    )
+                })?;
+            let n_wrs = wr_count_for_size(local_buffer.size);
+            let _flow_guard = flow_control.acquire_many(op.op_type, n_wrs).await?;
+
             let wr_id = match op.op_type {
                 RdmaOpType::WriteFromLocal => qp.put(local_buffer.clone(), op.remote_buffer)?,
                 RdmaOpType::ReadIntoLocal => qp.get(local_buffer.clone(), op.remote_buffer)?,
@@ -1167,10 +1291,8 @@ impl IbvBackend {
 impl RdmaBackend for IbvBackend {
     type TransportInfo = ();
 
-    /// Submit a batch of RDMA operations.
-    ///
-    /// Resolves ibv ops, then executes each directly — registering/deregistering
-    /// MRs via actor messages, while performing QP put/get and CQ polling locally.
+    /// Submit a batch of RDMA ops, sharing one deadline across the
+    /// batch. Per-op flow control runs inside [`Self::execute_op`].
     async fn submit(
         &mut self,
         cx: &(impl hyperactor::context::Actor + Send + Sync),
@@ -1193,14 +1315,33 @@ impl RdmaBackend for IbvBackend {
         }
 
         let deadline = Instant::now() + timeout;
-        for op in ibv_ops {
+        let this = &*self;
+        let futs = ibv_ops.into_iter().map(|op| async move {
             let remaining = deadline.saturating_duration_since(Instant::now());
             if remaining.is_zero() {
                 return Err(anyhow::anyhow!("submit timed out"));
             }
-            self.execute_op(cx, op, remaining).await?;
+            this.execute_op(cx, op, remaining).await
+        });
+        // `join_all` (not `try_join_all`) so a sibling failure can't drop
+        // an in-flight `execute_op` mid-await, which would skip its
+        // `deregister_mr` cleanup and release a flow-control permit
+        // while the WR is still posted on the hardware.
+        let results = futures::future::join_all(futs).await;
+        let errors: Vec<anyhow::Error> = results.into_iter().filter_map(Result::err).collect();
+        if errors.is_empty() {
+            Ok(())
+        } else {
+            Err(anyhow::anyhow!(
+                "{} op(s) failed: {}",
+                errors.len(),
+                errors
+                    .iter()
+                    .map(|e| e.to_string())
+                    .collect::<Vec<_>>()
+                    .join("; "),
+            ))
         }
-        Ok(())
     }
 
     fn transport_level(&self) -> RdmaTransportLevel {

--- a/monarch_rdma/src/backend/ibverbs/queue_pair.rs
+++ b/monarch_rdma/src/backend/ibverbs/queue_pair.rs
@@ -15,6 +15,19 @@
 /// Maximum size for a single RDMA operation in bytes (1 GiB).
 const MAX_RDMA_MSG_SIZE: usize = 1024 * 1024 * 1024;
 
+/// Number of work requests `put`/`get` will post for an op of `size` bytes.
+/// Each WR consumes one slot in the QP send queue (and one `max_rd_atomic`
+/// slot if the op is an RDMA-READ), so callers that need to reserve send-queue
+/// capacity ahead of time should use this to size the reservation.
+pub(crate) fn wr_count_for_size(size: usize) -> u32 {
+    // A zero-byte op still posts no WRs; otherwise it's ceil(size / chunk).
+    if size == 0 {
+        0
+    } else {
+        size.div_ceil(MAX_RDMA_MSG_SIZE) as u32
+    }
+}
+
 use std::io::Error;
 use std::result::Result;
 use std::time::Duration;
@@ -250,7 +263,9 @@ impl IbvQueuePair {
                 &mut port_attr as *mut rdmaxcel_sys::ibv_port_attr as *mut _,
             );
             if errno != 0 {
-                let os_error = Error::last_os_error();
+                // ibv_query_port returns the errno value directly; reading
+                // the C global Error::last_os_error() can be stale.
+                let os_error = Error::from_raw_os_error(errno);
                 return Err(anyhow::anyhow!(
                     "Failed to query port attributes: {}",
                     os_error
@@ -295,7 +310,9 @@ impl IbvQueuePair {
                 &mut qp_init_attr,
             );
             if errno != 0 {
-                let os_error = Error::last_os_error();
+                // ibv_query_qp returns the errno value directly; reading
+                // the C global Error::last_os_error() can be stale.
+                let os_error = Error::from_raw_os_error(errno);
                 return Err(anyhow::anyhow!("failed to query QP state: {}", os_error));
             }
             Ok(qp_attr.qp_state)
@@ -337,7 +354,9 @@ impl IbvQueuePair {
 
             let errno = rdmaxcel_sys::ibv_modify_qp((*qp).ibv_qp, &mut qp_attr, mask.0 as i32);
             if errno != 0 {
-                let os_error = Error::last_os_error();
+                // ibv_modify_qp returns the errno value directly; reading
+                // the C global Error::last_os_error() can be stale.
+                let os_error = Error::from_raw_os_error(errno);
                 return Err(anyhow::anyhow!(
                     "failed to transition QP to INIT: {}",
                     os_error
@@ -382,7 +401,9 @@ impl IbvQueuePair {
 
             let errno = rdmaxcel_sys::ibv_modify_qp((*qp).ibv_qp, &mut qp_attr, mask.0 as i32);
             if errno != 0 {
-                let os_error = Error::last_os_error();
+                // ibv_modify_qp returns the errno value directly; reading
+                // the C global Error::last_os_error() can be stale.
+                let os_error = Error::from_raw_os_error(errno);
                 return Err(anyhow::anyhow!(
                     "failed to transition QP to RTR: {}",
                     os_error
@@ -409,7 +430,9 @@ impl IbvQueuePair {
 
             let errno = rdmaxcel_sys::ibv_modify_qp((*qp).ibv_qp, &mut qp_attr, mask.0 as i32);
             if errno != 0 {
-                let os_error = Error::last_os_error();
+                // ibv_modify_qp returns the errno value directly; reading
+                // the C global Error::last_os_error() can be stale.
+                let os_error = Error::from_raw_os_error(errno);
                 return Err(anyhow::anyhow!(
                     "failed to transition QP to RTS: {}",
                     os_error
@@ -793,7 +816,9 @@ impl IbvQueuePair {
             }
 
             if errno != 0 {
-                let os_error = Error::last_os_error();
+                // ibv_post_send returns the errno value directly; reading
+                // the C global Error::last_os_error() can be stale.
+                let os_error = Error::from_raw_os_error(errno);
                 return Err(anyhow::anyhow!("Failed to post send request: {}", os_error));
             }
             tracing::debug!(

--- a/monarch_rdma/src/rdma_components.rs
+++ b/monarch_rdma/src/rdma_components.rs
@@ -136,6 +136,29 @@ impl RdmaRemoteBuffer {
         .await
     }
 
+    /// Submit a batch of `(op_type, local)` ops against this buffer to
+    /// the chosen backend. `timeout` (seconds) applies to the whole
+    /// batch.
+    pub async fn submit(
+        &self,
+        client: &(impl context::Actor + Send + Sync),
+        ops: Vec<(RdmaOpType, Arc<dyn RdmaLocalMemory>)>,
+        timeout: u64,
+    ) -> Result<(), anyhow::Error> {
+        let mut backend = self.choose_backend(client).await?;
+        let rdma_ops = ops
+            .into_iter()
+            .map(|(op_type, local)| RdmaOp {
+                op_type,
+                local,
+                remote: self.clone(),
+            })
+            .collect();
+        backend
+            .submit(client, rdma_ops, Duration::from_secs(timeout))
+            .await
+    }
+
     /// Push data from local memory into this remote buffer (local->remote).
     pub async fn write_from_local(
         &self,
@@ -143,17 +166,7 @@ impl RdmaRemoteBuffer {
         local: Arc<dyn RdmaLocalMemory>,
         timeout: u64,
     ) -> Result<bool, anyhow::Error> {
-        let mut backend = self.choose_backend(client).await?;
-        backend
-            .submit(
-                client,
-                vec![RdmaOp {
-                    op_type: RdmaOpType::WriteFromLocal,
-                    local,
-                    remote: self.clone(),
-                }],
-                Duration::from_secs(timeout),
-            )
+        self.submit(client, vec![(RdmaOpType::WriteFromLocal, local)], timeout)
             .await?;
         Ok(true)
     }
@@ -165,17 +178,7 @@ impl RdmaRemoteBuffer {
         local: Arc<dyn RdmaLocalMemory>,
         timeout: u64,
     ) -> Result<bool, anyhow::Error> {
-        let mut backend = self.choose_backend(client).await?;
-        backend
-            .submit(
-                client,
-                vec![RdmaOp {
-                    op_type: RdmaOpType::ReadIntoLocal,
-                    local,
-                    remote: self.clone(),
-                }],
-                Duration::from_secs(timeout),
-            )
+        self.submit(client, vec![(RdmaOpType::ReadIntoLocal, local)], timeout)
             .await?;
         Ok(true)
     }

--- a/python/monarch/_rust_bindings/monarch_hyperactor/pytokio.pyi
+++ b/python/monarch/_rust_bindings/monarch_hyperactor/pytokio.pyi
@@ -14,12 +14,18 @@ from typing import (
     Generator,
     Generic,
     Optional,
+    overload,
     Sequence,
     Tuple,
     TypeVar,
 )
 
 T = TypeVar("T")
+T1 = TypeVar("T1")
+T2 = TypeVar("T2")
+T3 = TypeVar("T3")
+T4 = TypeVar("T4")
+T5 = TypeVar("T5")
 
 class PythonTask(Generic[T], Awaitable[T]):
     """
@@ -107,6 +113,50 @@ class Shared(Generic[T]):
         """
         Create a Shared that has already completed with the given value. It will return that
         value the first time poll is called.
+        """
+        ...
+
+    @overload
+    @staticmethod
+    def gather(__t1: "Shared[T1]", /) -> "Shared[tuple[T1 | BaseException]]": ...
+    @overload
+    @staticmethod
+    def gather(
+        __t1: "Shared[T1]", __t2: "Shared[T2]", /
+    ) -> "Shared[tuple[T1 | BaseException, T2 | BaseException]]": ...
+    @overload
+    @staticmethod
+    def gather(
+        __t1: "Shared[T1]", __t2: "Shared[T2]", __t3: "Shared[T3]", /
+    ) -> (
+        "Shared[tuple[T1 | BaseException, T2 | BaseException, T3 | BaseException]]"
+    ): ...
+    @overload
+    @staticmethod
+    def gather(
+        __t1: "Shared[T1]",
+        __t2: "Shared[T2]",
+        __t3: "Shared[T3]",
+        __t4: "Shared[T4]",
+        /,
+    ) -> "Shared[tuple[T1 | BaseException, T2 | BaseException, T3 | BaseException, T4 | BaseException]]": ...
+    @overload
+    @staticmethod
+    def gather(
+        __t1: "Shared[T1]",
+        __t2: "Shared[T2]",
+        __t3: "Shared[T3]",
+        __t4: "Shared[T4]",
+        __t5: "Shared[T5]",
+        /,
+    ) -> "Shared[tuple[T1 | BaseException, T2 | BaseException, T3 | BaseException, T4 | BaseException, T5 | BaseException]]": ...
+    @overload
+    @staticmethod
+    def gather(*tasks: "Shared[Any]") -> "Shared[tuple[Any, ...]]":
+        """
+        Run the given Shareds concurrently and return a tuple of their results in input order.
+        Each entry is either the resolved value or the exception object the corresponding task
+        failed with -- exceptions are returned as values, not raised.
         """
         ...
 

--- a/python/monarch/_rust_bindings/rdma.pyi
+++ b/python/monarch/_rust_bindings/rdma.pyi
@@ -5,9 +5,18 @@
 # LICENSE file in the root directory of this source tree.
 
 # pyre-strict
+import enum
 from typing import Any, final
 
 from monarch._rust_bindings.monarch_hyperactor.pytokio import PythonTask
+
+@final
+class _RdmaOpType(enum.IntEnum):
+    """Mirror of the Rust ``RdmaOpType`` enum, used to build mixed-op
+    batches for ``_RdmaBuffer.submit``."""
+
+    ReadInto = 0
+    WriteFrom = 1
 
 @final
 class _RdmaMemoryRegionView:
@@ -48,6 +57,12 @@ class _RdmaBuffer:
         cls, local: _LocalMemoryHandle, client: Any
     ) -> PythonTask[Any]: ...
     def drop(self, client: Any) -> PythonTask[None]: ...
+    def submit(
+        self,
+        ops: list[tuple[_RdmaOpType, _LocalMemoryHandle]],
+        client: Any,
+        timeout: int,
+    ) -> PythonTask[Any]: ...
     def read_into(
         self,
         dst: _LocalMemoryHandle,

--- a/python/monarch/_src/rdma/rdma.py
+++ b/python/monarch/_src/rdma/rdma.py
@@ -32,6 +32,7 @@ try:
         _LocalMemoryHandle,
         _RdmaBuffer,
         _RdmaManager,
+        _RdmaOpType,
         is_ibverbs_available as _is_ibverbs_available,
         rdma_supported as _rdma_supported,
     )
@@ -359,12 +360,55 @@ class RDMABuffer:
     def size(self) -> int:
         return self._buffer.size()
 
+    def _submit_impl(
+        self,
+        ops: "List[Tuple[_RdmaOpType, torch.Tensor | memoryview]]",
+        timeout: int,
+    ) -> "PythonTask[None]":
+        """
+        Build a PythonTask that submits a batch of ``(_RdmaOpType, local)``
+        ops to the underlying backend. Size checks run eagerly so errors
+        surface at task-construction time.
+
+        Intended to be called only from ``RDMAAction.submit``, which runs
+        intra-batch overlap detection; bypassing it cannot guarantee
+        safety against intra-batch data races.
+        """
+        prepared: List[Tuple[_RdmaOpType, _LocalMemoryHandle]] = []
+        for op_type, local in ops:
+            handle = _make_local_memory_handle(local)
+            if op_type == _RdmaOpType.ReadInto:
+                if self.size() > handle.size:
+                    raise ValueError(
+                        f"Destination tensor size ({handle.size}) must be >= RDMA buffer size ({self.size()})"
+                    )
+            elif op_type == _RdmaOpType.WriteFrom:
+                if handle.size > self.size():
+                    raise ValueError(
+                        f"Source tensor size ({handle.size}) must be <= RDMA buffer size ({self.size()})"
+                    )
+            else:
+                raise NotImplementedError(f"Unsupported RDMA op type: {op_type}")
+            prepared.append((op_type, handle))
+
+        client = context().actor_instance
+
+        async def submit_nonblocking() -> None:
+            await _ensure_init_rdma_manager()
+            await self._buffer.submit(
+                ops=prepared,
+                client=client,
+                timeout=timeout,
+            )
+
+        return PythonTask.from_coroutine(submit_nonblocking())
+
     def read_into(
         self,
         dst: "torch.Tensor | memoryview",
         *,
-        timeout: int = 3,
-    ) -> Future[Optional[int]]:
+        timeout: int = 60,
+    ) -> Future[None]:
         """
         Read data from the RDMABuffer into a destination tensor.
 
@@ -372,16 +416,12 @@ class RDMABuffer:
         Args:
             dst: Destination tensor or memoryview to read into.
         Keyword Args:
-            timeout (int, optional): Timeout in seconds for the operation. Defaults to 3s.
+            timeout (int, optional): Timeout in seconds for the operation. Defaults to 60s.
         Returns:
-            Future[Optional[int]]: A Monarch Future that can be awaited or called with .get() for blocking operation.
+            Future[None]: A Monarch Future that can be awaited or called with .get() for blocking operation.
 
         Raises:
             ValueError: If the destination tensor size is smaller than the RDMA buffer size.
-
-        Note:
-            Currently only CPU tensors are fully supported. GPU tensors will be temporarily
-            copied to CPU, which may impact performance.
         """
         handle = _make_local_memory_handle(dst)
 
@@ -392,15 +432,13 @@ class RDMABuffer:
 
         client = context().actor_instance
 
-        async def read_into_nonblocking() -> Optional[int]:
+        async def read_into_nonblocking() -> None:
             await _ensure_init_rdma_manager()
-
-            res = await self._buffer.read_into(
+            await self._buffer.read_into(
                 dst=handle,
                 client=client,
                 timeout=timeout,
             )
-            return res
 
         return Future(coro=read_into_nonblocking())
 
@@ -408,7 +446,7 @@ class RDMABuffer:
         self,
         src: "torch.Tensor | memoryview",
         *,
-        timeout: int = 3,
+        timeout: int = 60,
     ) -> Future[None]:
         """
         Write data from a source tensor into the RDMABuffer.
@@ -418,7 +456,7 @@ class RDMABuffer:
                                 Must be a contiguous tensor (including tensor views/slices).
                                 Either src or addr/size must be provided.
         Keyword Args:
-            timeout (int, optional): Timeout in seconds for the operation. Defaults to 3s.
+            timeout (int, optional): Timeout in seconds for the operation. Defaults to 60s.
 
         Returns:
             Future[None]: A Monarch Future object that can be awaited or called with .get()
@@ -426,29 +464,23 @@ class RDMABuffer:
 
         Raises:
             ValueError: If the source tensor size exceeds the RDMA buffer size.
-
-        Note:
-            Currently only CPU tensors are fully supported. GPU tensors will be temporarily
-            copied to CPU, which may impact performance.
         """
-
         handle = _make_local_memory_handle(src)
 
         if handle.size > self.size():
             raise ValueError(
                 f"Source tensor size ({handle.size}) must be <= RDMA buffer size ({self.size()})"
             )
+
         client = context().actor_instance
 
         async def write_from_nonblocking() -> None:
             await _ensure_init_rdma_manager()
-
-            res = await self._buffer.write_from(
+            await self._buffer.write_from(
                 src=handle,
                 client=client,
                 timeout=timeout,
             )
-            return res
 
         return Future(coro=write_from_nonblocking())
 
@@ -645,49 +677,46 @@ class RDMAAction:
         """
         raise NotImplementedError("Not yet supported")
 
-    def submit(self) -> Future[None]:
+    def submit(self, *, timeout: int = 60) -> Future[None]:
         """
-        Schedules the work (can be called multiple times to schedule the same work more than once).
-        Future completes when all the work is done.
+        Schedule the registered work.
 
-        Executes futures for each src actor independently and concurrently for optimal performance.
+        Ops are grouped by source ``RDMABuffer`` and submitted as one
+        batch per buffer; submits across buffers are awaited concurrently.
+        The Future resolves when all ops finish, or fails with the first
+        error. Safe to call more than once.
+
+        Keyword Args:
+            timeout (int, optional): Per-buffer batch timeout in seconds.
+                Defaults to 60s.
         """
+        ops_by_buffer: Dict[RDMABuffer, List[Tuple[_RdmaOpType, "LocalMemory"]]] = (
+            defaultdict(list)
+        )
+        for op, src, dst in self._instructs:
+            if op == self.RDMAOp.READ_INTO:
+                rdma_op = _RdmaOpType.ReadInto
+            elif op == self.RDMAOp.WRITE_FROM:
+                rdma_op = _RdmaOpType.WriteFrom
+            else:
+                raise NotImplementedError(f"Unknown RDMA operation: {op}")
+            ops_by_buffer[src].append((rdma_op, dst))
 
-        async def submit_all_work() -> None:
-            if not self._instructs:
-                return
+        async def run() -> None:
+            # Spawn before awaiting so per-buffer submits run concurrently.
+            shareds = [
+                buf._submit_impl(ops, timeout).spawn()
+                for buf, ops in ops_by_buffer.items()
+            ]
+            results = await Shared.gather(*shareds)
+            # Re-raise non-`Exception` `BaseException`s (e.g. `KeyboardInterrupt`,
+            # `SystemExit`) directly: `ExceptionGroup` only accepts `Exception`
+            # subclasses, so wrapping them would either drop them or fail.
+            for r in results:
+                if isinstance(r, BaseException) and not isinstance(r, Exception):
+                    raise r
+            errors = [r for r in results if isinstance(r, Exception)]
+            if errors:
+                raise ExceptionGroup("RDMAAction.submit failed", errors)
 
-            work = defaultdict(list)
-
-            # Group operations by owner for concurrent execution per owner
-            for op, src, dst in self._instructs:
-                if op == self.RDMAOp.READ_INTO:
-                    fut = src.read_into(dst)
-                elif op == self.RDMAOp.WRITE_FROM:
-                    fut = src.write_from(dst)
-                else:
-                    raise NotImplementedError(f"Unknown RDMA operation: {op}")
-                work[src.owner].append(fut)
-
-            # Create a list of tasks, one per owner, that wait for all that owner's futures sequentially
-            owner_tasks = []
-
-            for _, futures in work.items():
-                # Create a coroutine that processes all futures for a qp sequentially
-                async def process_owner_futures(owner_futures_list=futures):
-                    """Process all futures for a single qp sequentially"""
-                    for future in owner_futures_list:
-                        await future
-
-                # Convert to PythonTask for Monarch's native concurrency
-                owner_task = PythonTask.from_coroutine(process_owner_futures())
-                owner_tasks.append(owner_task)
-
-            # Spawn all owner tasks concurrently and collect their shared handles
-            shared_tasks = [task.spawn() for task in owner_tasks]
-
-            # Wait for all owner tasks to complete concurrently
-            for shared_task in shared_tasks:
-                await shared_task
-
-        return Future(coro=submit_all_work())
+        return Future(coro=run())

--- a/python/tests/test_rdma_action.py
+++ b/python/tests/test_rdma_action.py
@@ -1,0 +1,320 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-unsafe
+"""End-to-end tests for ``monarch.rdma.RDMAAction``."""
+
+import os
+
+# Required to enable RDMA support for CUDA tensors.
+os.environ.setdefault("PYTORCH_CUDA_ALLOC_CONF", "expandable_segments:True")
+
+import pytest  # noqa: E402
+import torch  # noqa: E402
+from monarch.actor import Actor, endpoint, this_host  # noqa: E402
+from monarch.rdma import RDMAAction, RDMABuffer  # noqa: E402
+from proc_mesh_test_utils import stop_all_proc_meshes  # noqa: E402, F401
+from rdma_test_utils import rdma_backends  # noqa: E402
+
+
+TIMEOUT = 60
+
+
+def _make_seed_tensor(seed: int, size: int, device: str) -> torch.Tensor:
+    generator = torch.Generator(device=device).manual_seed(seed)
+    return torch.rand(size, generator=generator, dtype=torch.float32, device=device)
+
+
+class BufferHost(Actor):
+    def __init__(
+        self, num_buffers: int, size: int, seed_base: int, device: str
+    ) -> None:
+        super().__init__()
+        self.device = device
+        self.tensors = [
+            _make_seed_tensor(seed_base + i, size, device) for i in range(num_buffers)
+        ]
+        self.buffers: list[RDMABuffer] = []
+
+    @endpoint
+    async def create_buffers(self) -> list[RDMABuffer]:
+        self.buffers = [RDMABuffer(t) for t in self.tensors]
+        return self.buffers
+
+    @endpoint
+    async def get_tensors(self) -> list[torch.Tensor]:
+        return list(self.tensors)
+
+
+class ActionClient(Actor):
+    def __init__(self, num_slots: int, size: int, device: str) -> None:
+        super().__init__()
+        self.device = device
+        self.slots = [
+            torch.zeros(size, dtype=torch.float32, device=device)
+            for _ in range(num_slots)
+        ]
+
+    @endpoint
+    async def get_slots(self) -> list[torch.Tensor]:
+        return list(self.slots)
+
+    @endpoint
+    async def submit_empty_is_noop(self) -> None:
+        await RDMAAction().submit(timeout=TIMEOUT)
+
+    @endpoint
+    async def read_all_with_submit(self, buffers: list[RDMABuffer]) -> None:
+        action = RDMAAction()
+        for i, buffer in enumerate(buffers):
+            action.read_into(buffer, self.slots[i])
+        await action.submit(timeout=TIMEOUT)
+
+    @endpoint
+    async def read_resubmit(
+        self, buffers: list[RDMABuffer]
+    ) -> tuple[list[torch.Tensor], list[torch.Tensor]]:
+        action = RDMAAction()
+        for i, buffer in enumerate(buffers):
+            action.read_into(buffer, self.slots[i])
+        await action.submit(timeout=TIMEOUT)
+        # Snapshot before zeroing so the second submit has something to fill in.
+        first = [s.clone() for s in self.slots[: len(buffers)]]
+        for slot in self.slots[: len(buffers)]:
+            slot.zero_()
+        await action.submit(timeout=TIMEOUT)
+        second = [s.clone() for s in self.slots[: len(buffers)]]
+        return first, second
+
+    @endpoint
+    async def write_from_seeded(
+        self, buffers: list[RDMABuffer], seeds: list[int]
+    ) -> None:
+        size = self.slots[0].numel()
+        for i, seed in enumerate(seeds):
+            self.slots[i] = _make_seed_tensor(seed, size, self.device)
+        action = RDMAAction()
+        for i, buffer in enumerate(buffers):
+            action.write_from(buffer, self.slots[i])
+        await action.submit(timeout=TIMEOUT)
+
+    @endpoint
+    async def mixed_read_write(
+        self,
+        read_buffers: list[RDMABuffer],
+        write_buffers: list[RDMABuffer],
+        write_seeds: list[int],
+    ) -> None:
+        size = self.slots[0].numel()
+        for i, seed in enumerate(write_seeds):
+            self.slots[len(read_buffers) + i] = _make_seed_tensor(
+                seed, size, self.device
+            )
+        action = RDMAAction()
+        for i, buffer in enumerate(read_buffers):
+            action.read_into(buffer, self.slots[i])
+        for i, buffer in enumerate(write_buffers):
+            action.write_from(buffer, self.slots[len(read_buffers) + i])
+        await action.submit(timeout=TIMEOUT)
+
+    @endpoint
+    async def submit_validates_size_eagerly(self, buffer: RDMABuffer) -> bool:
+        oversized = torch.zeros(
+            buffer.size() + 32, dtype=torch.uint8, device=self.device
+        )
+        action = RDMAAction()
+        try:
+            action.write_from(buffer, oversized)
+        except ValueError:
+            return True
+        return False
+
+
+async def _spawn_host_and_client(
+    *,
+    num_buffers: int,
+    size: int,
+    host_device: str,
+    client_device: str,
+    seed_base: int = 0,
+    num_slots: int | None = None,
+) -> tuple[BufferHost, ActionClient]:
+    host_proc = this_host().spawn_procs(per_host={"processes": 1})
+    client_proc = this_host().spawn_procs(per_host={"processes": 1})
+    host = host_proc.spawn(
+        "buffer_host", BufferHost, num_buffers, size, seed_base, host_device
+    )
+    client = client_proc.spawn(
+        "action_client",
+        ActionClient,
+        num_slots or num_buffers,
+        size,
+        client_device,
+    )
+    return host, client
+
+
+def _device_variants() -> list[tuple[str, str]]:
+    variants: list[tuple[str, str]] = [("cpu", "cpu")]
+    if torch.cuda.is_available():
+        variants.extend([("cuda", "cuda"), ("cpu", "cuda"), ("cuda", "cpu")])
+    return variants
+
+
+DEVICE_VARIANTS = _device_variants()
+DEVICE_IDS = [f"{h}->{c}" for h, c in DEVICE_VARIANTS]
+
+
+@rdma_backends
+@pytest.mark.parametrize(
+    ("host_device", "client_device"), DEVICE_VARIANTS, ids=DEVICE_IDS
+)
+async def test_submit_empty_action_is_noop(host_device, client_device) -> None:
+    _, client = await _spawn_host_and_client(
+        num_buffers=1, size=16, host_device=host_device, client_device=client_device
+    )
+    await client.submit_empty_is_noop.call_one()
+    # Empty submit must not touch client slots: they were initialized to zeros
+    # and should remain so after a no-op submit.
+    slots = await client.get_slots.call_one()
+    for i, slot in enumerate(slots):
+        assert torch.equal(slot, torch.zeros_like(slot)), (
+            f"slot {i} was mutated by an empty RDMAAction.submit"
+        )
+
+
+@rdma_backends
+@pytest.mark.parametrize(
+    ("host_device", "client_device"), DEVICE_VARIANTS, ids=DEVICE_IDS
+)
+async def test_submit_reads_all_buffers(host_device, client_device) -> None:
+    size = 64
+    num_buffers = 5
+    host, client = await _spawn_host_and_client(
+        num_buffers=num_buffers,
+        size=size,
+        host_device=host_device,
+        client_device=client_device,
+        seed_base=1000,
+    )
+    buffers = await host.create_buffers.call_one()
+    await client.read_all_with_submit.call_one(buffers)
+    host_tensors = await host.get_tensors.call_one()
+    client_tensors = await client.get_slots.call_one()
+    for i in range(num_buffers):
+        assert torch.equal(client_tensors[i], host_tensors[i]), (
+            f"slot {i} does not match source buffer bit-for-bit"
+        )
+
+
+@rdma_backends
+@pytest.mark.parametrize(
+    ("host_device", "client_device"), DEVICE_VARIANTS, ids=DEVICE_IDS
+)
+async def test_submit_can_be_called_twice(host_device, client_device) -> None:
+    size = 32
+    num_buffers = 3
+    host, client = await _spawn_host_and_client(
+        num_buffers=num_buffers,
+        size=size,
+        host_device=host_device,
+        client_device=client_device,
+        seed_base=2000,
+    )
+    buffers = await host.create_buffers.call_one()
+    first, second = await client.read_resubmit.call_one(buffers)
+    host_tensors = await host.get_tensors.call_one()
+    for i in range(num_buffers):
+        assert torch.equal(first[i], host_tensors[i]), (
+            f"first attempt slot {i} mismatch"
+        )
+        assert torch.equal(second[i], host_tensors[i]), (
+            f"second attempt slot {i} mismatch"
+        )
+
+
+@rdma_backends
+@pytest.mark.parametrize(
+    ("host_device", "client_device"), DEVICE_VARIANTS, ids=DEVICE_IDS
+)
+async def test_submit_writes_all_buffers(host_device, client_device) -> None:
+    size = 32
+    num_buffers = 4
+    host, client = await _spawn_host_and_client(
+        num_buffers=num_buffers,
+        size=size,
+        host_device=host_device,
+        client_device=client_device,
+        seed_base=3000,
+    )
+    buffers = await host.create_buffers.call_one()
+    seeds = [40, 41, 42, 43]
+    await client.write_from_seeded.call_one(buffers, seeds)
+    host_tensors = await host.get_tensors.call_one()
+    client_slots = await client.get_slots.call_one()
+    for i in range(num_buffers):
+        assert torch.equal(host_tensors[i], client_slots[i]), (
+            f"host buffer {i} does not match bytes the client wrote"
+        )
+
+
+@rdma_backends
+@pytest.mark.parametrize(
+    ("host_device", "client_device"), DEVICE_VARIANTS, ids=DEVICE_IDS
+)
+async def test_submit_mixes_reads_and_writes(host_device, client_device) -> None:
+    size = 32
+    num_reads = 2
+    num_writes = 2
+    host, client = await _spawn_host_and_client(
+        num_buffers=num_reads + num_writes,
+        size=size,
+        host_device=host_device,
+        client_device=client_device,
+        seed_base=4000,
+        num_slots=num_reads + num_writes,
+    )
+    buffers = await host.create_buffers.call_one()
+    host_before = await host.get_tensors.call_one()
+    write_seeds = [77, 78]
+
+    await client.mixed_read_write.call_one(
+        buffers[:num_reads], buffers[num_reads:], write_seeds
+    )
+
+    client_tensors = await client.get_slots.call_one()
+    for i in range(num_reads):
+        assert torch.equal(client_tensors[i], host_before[i]), (
+            f"read slot {i} did not capture the pre-action host bytes"
+        )
+
+    host_after = await host.get_tensors.call_one()
+    for i in range(num_reads):
+        assert torch.equal(host_after[i], host_before[i]), (
+            f"read-source buffer {i} was modified by the action"
+        )
+    for j in range(len(write_seeds)):
+        assert torch.equal(host_after[num_reads + j], client_tensors[num_reads + j]), (
+            f"write-target buffer {num_reads + j} mismatch"
+        )
+
+
+@rdma_backends
+@pytest.mark.parametrize(
+    ("host_device", "client_device"), DEVICE_VARIANTS, ids=DEVICE_IDS
+)
+async def test_submit_validation_errors_surface(host_device, client_device) -> None:
+    size = 32
+    host, client = await _spawn_host_and_client(
+        num_buffers=1,
+        size=size,
+        host_device=host_device,
+        client_device=client_device,
+        num_slots=2,
+    )
+    (buffer,) = await host.create_buffers.call_one()
+    caught = await client.submit_validates_size_eagerly.call_one(buffer)
+    assert caught, "Expected ValueError from RDMAAction.write_from size check"


### PR DESCRIPTION
Summary:

**Goal:** Parallelize RDMAAction operations within a single source buffer. Previously ops sharing a source buffer were dispatched sequentially through `RDMABuffer.read_into` / `write_from`, even though the RDMA backends can comfortably pipeline them.

**Design:**

- Push parallelism out of the Python `RDMAAction` layer and down into the Rust backends.
- New batched `RdmaRemoteBuffer::submit(client, ops, timeout)` dispatches a list of `(op_type, local_memory)` pairs concurrently on the chosen backend; both `IbvBackend` and `TcpBackend` run per-op work in parallel.
- Expose this to Python as `_RdmaBuffer.submit` plus a new `_RdmaOpType` enum, so callers can build mixed read/write batches in a single call.
- New `Shared.gather(*tasks)` pytokio API runs a group of `Shared`s concurrently and returns a `Shared` resolving to a tuple of values-or-exceptions in input order; typed via overloads so element types track the inputs.
- `RDMAAction.submit` becomes a thin wrapper: group ops by source buffer, fire one batched submit per buffer, `Shared.gather` the per-buffer results, and raise an `ExceptionGroup` if any failed.
- New `test_rdma_action.py` covers the public RDMAAction surface (empty / fan-out / mixed / re-submit / validation) across host & client devices and RDMA backends.

Differential Revision: D102533330


