### PR TITLE
Fix clap dependency (#3688)

### DIFF
--- a/hyperactor_mesh/Cargo.toml
+++ b/hyperactor_mesh/Cargo.toml
@@ -62,7 +62,7 @@ zbus = { version = "5.14.0", features = ["async-executor", "async-fs", "async-io
 
 [dev-dependencies]
 buck-resources = "1"
-clap = { version = "4.6.0", features = ["derive", "env", "string", "unicode", "wrap_help"] }
+clap = { version = "4.6.0", features = ["derive"] }
 criterion = { version = "0.5.1", features = ["async_tokio", "csv_output"] }
 inventory = "0.3.24"
 jsonschema = "0.17.0"


### PR DESCRIPTION
Summary:


hyperactor_mesh fails to compile in oss because of dining_philosophers needs clap
ghstack-source-id: 373466077
exported-using-ghexport

Reviewed By: dulinriley

Differential Revision: D102659777
