### PR TITLE
Fix re-entrant tracing on_close

### DIFF
--- a/hyperactor_telemetry/src/trace_dispatcher.rs
+++ b/hyperactor_telemetry/src/trace_dispatcher.rs
@@ -206,6 +206,18 @@ struct WorkerHandle {
     join_handle: Option<JoinHandle<()>>,
 }
 
+thread_local! {
+    static IN_SEND: Cell<bool> = const { Cell::new(false) };
+}
+
+struct InSendGuard;
+
+impl Drop for InSendGuard {
+    fn drop(&mut self) {
+        IN_SEND.with(|f| f.set(false));
+    }
+}
+
 impl TraceEventDispatcher {
     /// Create a new trace event dispatcher with the given sinks.
     /// Uses a bounded channel (capacity QUEUE_CAPACITY) to ensure telemetry never blocks
@@ -287,6 +299,15 @@ impl TraceEventDispatcher {
     }
 
     fn send_event(&self, event: TraceEvent) {
+        // Re-entrancy guard. A `Layer` callback may emit `tracing` events
+        // through code it touches—notably std's mpmc channel, which is itself
+        // instrumented—and those events loop back through this subscriber.
+        // Without this guard, the recursion exhausts the stack and SIGSEGVs.
+        if IN_SEND.with(|f| f.replace(true)) {
+            return;
+        }
+        let _reset = InSendGuard;
+
         if let Some(sender) = &self.sender {
             if let Err(mpsc::TrySendError::Full(_)) = sender.try_send(event) {
                 let dropped = self.dropped_events.fetch_add(1, Ordering::Relaxed) + 1;
@@ -591,5 +612,67 @@ impl Drop for WorkerHandle {
                 eprintln!("[telemetry] worker thread panicked: {:?}", e);
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use std::sync::Mutex;
+
+    use super::*;
+
+    #[derive(Default)]
+    struct RecordingSink {
+        events: Arc<Mutex<Vec<TraceEvent>>>,
+    }
+
+    impl TraceEventSink for RecordingSink {
+        fn consume(&mut self, event: &TraceEvent) -> Result<(), anyhow::Error> {
+            self.events.lock().unwrap().push(event.clone());
+            Ok(())
+        }
+
+        fn flush(&mut self) -> Result<(), anyhow::Error> {
+            Ok(())
+        }
+    }
+
+    fn span_close(id: u64) -> TraceEvent {
+        TraceEvent::SpanClose {
+            id,
+            timestamp: SystemTime::now(),
+        }
+    }
+
+    #[test]
+    fn send_event_delivers_repeatedly() {
+        let sink = RecordingSink::default();
+        let recorded = Arc::clone(&sink.events);
+        let dispatcher = TraceEventDispatcher::new(vec![Box::new(sink)]);
+
+        dispatcher.send_event(span_close(1));
+        dispatcher.send_event(span_close(2));
+        dispatcher.send_event(span_close(3));
+
+        drop(dispatcher);
+        assert_eq!(recorded.lock().unwrap().len(), 3);
+    }
+
+    #[test]
+    fn send_event_drops_on_reentrance() {
+        let sink = RecordingSink::default();
+        let recorded = Arc::clone(&sink.events);
+        let dispatcher = TraceEventDispatcher::new(vec![Box::new(sink)]);
+
+        // Simulate that this thread is already inside `send_event`. The nested
+        // call must short-circuit; otherwise a `Layer` callback that re-enters
+        // the subscriber would recurse without bound.
+        IN_SEND.with(|f| f.set(true));
+        dispatcher.send_event(span_close(1));
+        IN_SEND.with(|f| f.set(false));
+
+        drop(dispatcher);
+        assert!(recorded.lock().unwrap().is_empty());
     }
 }


### PR DESCRIPTION
Summary:
A training run crashed with SIGSEGV from unbounded recursion in `TraceEventDispatcher`. The repeating cycle was `Layered::try_close` → `sharded_slab::DataInner::clear` → `CloseGuard::drop` → `Layered::try_close`, terminating at `SyncSender::try_send` once the stack was exhausted (folly's `GuardPageAllocator` caught the guard-page hit).

`TraceEventDispatcher::send_event` runs inside every `Layer` callback (`on_new_span`, `on_enter`, `on_exit`, `on_event`, `on_close`). The send goes through `std::sync::mpsc::SyncSender`, which is backed by `std::sync::mpmc::array::Channel`. That path emits `tracing` instrumentation under the toolchain's `tracing_unstable` flag, and those nested events loop back through the same `Layered` subscriber, re-entering `send_event` synchronously on the application thread. Each cycle consumes a few stack frames; eventually the thread walks off the end.

This change adds a thread-local `Cell<bool>` re-entrancy guard at the entry of `send_event`. A nested call on the same thread short-circuits. An RAII `InSendGuard` clears the flag on every exit path (normal return, panic-unwind, early return on a full channel). All five `Layer` callbacks route through `send_event`, so guarding there covers them with one change.

We considered replacing the channel with a non-instrumented implementation (e.g., `crossbeam_channel`). That would remove today's known trigger, but the layer would remain fragile to future callback work that touches `tracing`-instrumented code. The guard is structural protection.

Reviewed By: thedavekwon

Differential Revision: D102851742


