### PR TITLE
Sanitize HostMesh labels from user-supplied names

### DIFF
--- a/monarch_hyperactor/src/bootstrap.rs
+++ b/monarch_hyperactor/src/bootstrap.rs
@@ -20,7 +20,6 @@ use pyo3::Bound;
 use pyo3::PyAny;
 use pyo3::PyResult;
 use pyo3::Python;
-use pyo3::exceptions::PyException;
 use pyo3::exceptions::PyRuntimeError;
 use pyo3::pyfunction;
 use pyo3::types::PyAnyMethods;
@@ -124,9 +123,11 @@ pub fn attach_to_workers<'py>(
         .map(|x| x.borrow_mut().take_task())
         .collect::<PyResult<Vec<_>>>()?;
 
-    let name = HostMeshId::unique(
-        Label::new(name.unwrap_or("hosts")).map_err(|e| PyException::new_err(e.to_string()))?,
-    );
+    // `Label::strip` (vs. `Label::new`) sanitizes user-supplied names — lowercases,
+    // drops illegal characters, falls back to "nil" if empty. Callers pass names
+    // derived from experiment / job names that may contain uppercase or punctuation;
+    // rejecting them surfaces as an opaque PyException far from the input site.
+    let name = HostMeshId::unique(Label::strip(name.unwrap_or("hosts")));
     let instance = instance.clone();
     PyPythonTask::new(async move {
         let results = try_join_all(tasks).await?;


### PR DESCRIPTION
Summary: Hyperactor's `Label::new` enforces a strict charset (`[a-z0-9_-]`, leading lowercase letter, ≤63 chars) — anything outside that returns `LabelError::InvalidChar`. That's the right invariant for a stable identifier, but it makes `attach_to_workers` brittle when the `name` argument is derived from a user-facing experiment or job name.

Differential Revision: D103099136


