### PR TITLE
Replace admin API HTTP walk with snapshot table SQL queries

### DIFF
--- a/python/monarch/_src/job/job.py
+++ b/python/monarch/_src/job/job.py
@@ -310,8 +310,9 @@ class TelemetryConfig:
         snapshot_interval_secs: Interval in seconds between periodic mesh
             introspection snapshots. Snapshots capture the mesh topology
             into the telemetry query surface. 0 disables periodic capture
-            (default). Snapshot table schemas are always pre-registered
-            regardless of this setting.
+            (default). When ``include_dashboard`` is True and this is 0,
+            it is automatically set to 30s because the dashboard requires
+            snapshot data for system actor filtering.
     """
 
     batch_size: int = 1000
@@ -319,6 +320,10 @@ class TelemetryConfig:
     include_dashboard: bool = False
     dashboard_port: int = 8265
     snapshot_interval_secs: float = 0  # 0 = disabled
+
+    def __post_init__(self) -> None:
+        if self.include_dashboard and self.snapshot_interval_secs <= 0:
+            self.snapshot_interval_secs = 30.0
 
 
 @dataclass

--- a/python/monarch/monarch_dashboard/server/admin_dag.py
+++ b/python/monarch/monarch_dashboard/server/admin_dag.py
@@ -4,31 +4,29 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-"""Build a DAG by walking the Mesh Admin API.
+"""Build a DAG from snapshot tables.
 
 This mirrors the TUI's tree hierarchy (Root → Host → Proc → Actor)
 rather than the telemetry SQL layer's 6-tier mesh hierarchy.  The
 result is a simpler, more readable graph.
 
-System actors are filtered using the ``system_children`` list and
-``is_system`` flag from the Admin API, plus a name-based heuristic
-for infrastructure actors that aren't flagged (e.g. telemetry, setup).
+Topology comes from the snapshot tables (``nodes``, ``children``,
+``host_nodes``, ``proc_nodes``, ``actor_nodes``), populated by
+periodic snapshot capture.  Messages and telemetry actor IDs come
+from the telemetry SQL tables (``messages``, ``actors``, ``meshes``).
+
+System actors are filtered using the ``is_system`` flag from the
+``actor_nodes`` / ``children`` snapshot tables, plus a name-based
+heuristic for infrastructure actors that aren't flagged.
 """
 
 import logging
-import os
 import re
-import urllib.parse
-from typing import Any, Dict, List, Optional, Set, Tuple
-
-import requests
+from typing import Any, Dict, List, Optional, Set
 
 from . import db
 
 logger = logging.getLogger(__name__)
-
-# Max walk depth: Root(0) -> Host(1) -> Proc(2) -> Actor(3).
-_MAX_TREE_DEPTH = 4
 
 # Known system/infrastructure actor name patterns.
 # These actors are spawned by Monarch internals, not by user code.
@@ -52,245 +50,178 @@ def _is_client_actor(ref: str) -> bool:
     return ref.endswith(",client[0]")
 
 
-def _get_admin_url() -> Optional[str]:
-    return os.environ.get("MONARCH_ADMIN_URL")
-
-
-def configure_tls(session: requests.Session) -> None:
-    """Configure TLS client certs on a requests session.
-
-    Mirrors the cert detection logic in Rust's ``try_tls_connector``
-    (``hyperactor/src/channel/net.rs``):
-
-    1. **OSS** — ``HYPERACTOR_TLS_CA``, ``HYPERACTOR_TLS_CERT``,
-       ``HYPERACTOR_TLS_KEY`` environment variables.
-    2. **Meta** — ``/var/facebook/rootcanal/ca.pem`` (CA),
-       ``/var/facebook/x509_identities/server.pem`` (cert + key).
-    3. **Fallback** — no TLS configuration (plain HTTP only).
-    """
-    # OSS: explicit env vars take priority.
-    ca = os.environ.get("HYPERACTOR_TLS_CA")
-    cert = os.environ.get("HYPERACTOR_TLS_CERT")
-    key = os.environ.get("HYPERACTOR_TLS_KEY")
-    if ca and os.path.isfile(ca):
-        session.verify = ca
-        if cert and key and os.path.isfile(cert) and os.path.isfile(key):
-            session.cert = (cert, key)
-        return
-
-    # Meta: well-known certificate paths.
-    meta_ca = "/var/facebook/rootcanal/ca.pem"
-    meta_cert = "/var/facebook/x509_identities/server.pem"
-    if os.path.isfile(meta_ca) and os.path.isfile(meta_cert):
-        session.verify = meta_ca
-        session.cert = (meta_cert, meta_cert)  # PEM contains both cert and key
-        return
-
-    # No certs found; HTTPS requests will fail and fall back to the
-    # telemetry SQL layer in build_admin_dag.
-    logger.debug("No TLS certs found for admin API; HTTPS will not work")
-
-
-def _fetch_node(
-    session: requests.Session, admin_url: str, ref: str
-) -> Optional[Dict[str, Any]]:
-    """Fetch a single node from the admin API."""
-    encoded = urllib.parse.quote(ref, safe="")
-    try:
-        resp = session.get(f"{admin_url}/v1/{encoded}", timeout=2.0)
-        if resp.status_code == 200:
-            return resp.json()
-    except Exception:
-        logger.debug("Failed to fetch admin node %s", ref, exc_info=True)
-    return None
-
-
-def _extract_status(props: Dict[str, Any]) -> str:
-    """Extract a status string from node properties.
-
-    Actors have an explicit ``actor_status`` field.  Procs derive status
-    from ``is_poisoned`` and ``failed_actor_count``.  Hosts derive status
-    from their child procs (resolved later — default to "idle" here).
-    """
-    # Actor: explicit status.
-    actor = props.get("Actor", {})
-    if isinstance(actor, dict) and "actor_status" in actor:
-        status = actor["actor_status"]
-        if isinstance(status, str):
-            return status.split(":")[0].strip().lower() if status else "unknown"
-
-    # Proc: derive from health fields.
-    proc = props.get("Proc", {})
-    if isinstance(proc, dict):
-        if proc.get("is_poisoned"):
-            return "failed"
-        if proc.get("failed_actor_count", 0) > 0:
-            return "stopping"
-        return "idle"
-
-    # Host: healthy by default (no failure fields on Host).
-    host = props.get("Host", {})
-    if isinstance(host, dict):
-        return "idle"
-
-    return "n/a"
-
-
-def _extract_is_system(props: Dict[str, Any]) -> bool:
-    """Check if a node is a system actor via the API flag."""
-    actor = props.get("Actor", {})
-    return isinstance(actor, dict) and actor.get("is_system", False)
-
-
-def _extract_system_children(props: Dict[str, Any]) -> Set[str]:
-    """Get system_children refs from Root/Host/Proc properties."""
-    result: Set[str] = set()
-    for variant_data in props.values():
-        if isinstance(variant_data, dict):
-            for sc in variant_data.get("system_children", []):
-                result.add(sc)
-    return result
-
-
-def _node_type(props: Dict[str, Any]) -> str:
-    for key in ("Root", "Host", "Proc", "Actor", "Error"):
-        if key in props:
-            return key.lower()
-    return "unknown"
-
-
 def _is_system_by_name(label: str) -> bool:
     """Heuristic: check if a node label looks like a system/infra actor."""
     return bool(_SYSTEM_NAME_PATTERNS.search(label))
 
 
-def _derive_label(payload: Dict[str, Any]) -> str:
-    """Derive a short display label from a node payload.
+def _derive_label(node_id: str, node_kind: str, addr: str = "") -> str:
+    """Derive a short display label from a snapshot node.
 
-    For hosts, extracts the IP:port from the ``addr`` property so
-    each host is visually distinguishable.  For procs and actors
-    the label is the name component of the identity string.
+    For hosts, uses the ``addr`` field so each host is visually
+    distinguishable.  For procs and actors, extracts the name
+    component from the node_id string.
     """
-    identity = payload.get("identity", "")
-    props = payload.get("properties", {})
-
-    # Host: use addr from properties (e.g. "tcp:10.0.1.2:26600").
-    host_props = props.get("Host", {})
-    if isinstance(host_props, dict) and "addr" in host_props:
-        addr = host_props["addr"]
-        # Strip "tcp:" prefix -> "10.0.1.2:26600"
+    if node_kind == "host" and addr:
+        # Strip transport prefix (e.g. "tcp:" or "metatls:") -> IP:port
         if ":" in addr:
             addr = addr.split(":", 1)[1]
         return addr
 
-    if "ActorId" in identity:
-        inner = identity.split("(", 1)[-1].rstrip(")")
-        parts = inner.split(",")
-        if len(parts) >= 3:
-            return f"{parts[1].strip()}[{parts[2].strip()}]"
-        return inner
-    if "ProcId" in identity:
-        inner = identity.split("(", 1)[-1].rstrip(")")
-        parts = inner.split(",")
-        if len(parts) >= 2:
-            return f"{parts[0].strip()}[{parts[1].strip()}]"
-        return inner
-    return identity.rsplit("/", 1)[-1].rsplit(",", 1)[-1] or identity
+    # node_id for actors/procs is the last comma-separated component
+    return node_id.rsplit(",", 1)[-1] or node_id
 
 
-def _resolve_mesh_names(nodes: List[Dict[str, Any]]) -> None:
-    try:
-        # Get the full name of all actors and their meshes.
-        rows = db._query(
-            "SELECT a.full_name, m.full_name AS mesh_full_name"
-            " FROM actors a"
-            " LEFT JOIN meshes m ON a.mesh_id = m.id"
-        )
-        if not rows:
-            return
+def _extract_status(
+    node_kind: str,
+    actor_status: str = "",
+    is_poisoned: bool = False,
+    failed_actor_count: int = 0,
+) -> str:
+    """Derive a status string from snapshot node fields."""
+    if node_kind == "actor" and actor_status:
+        return actor_status.split(":")[0].strip().lower()
+    if node_kind == "proc":
+        if is_poisoned:
+            return "failed"
+        if failed_actor_count > 0:
+            return "stopping"
+        return "idle"
+    if node_kind == "host":
+        return "idle"
+    return "n/a"
 
-        # Map actor full_name -> mesh full_name (includes unique suffix).
-        fname_to_mesh: Dict[str, str] = {}
-        for r in rows:
-            mname = r.get("mesh_full_name")
-            if mname:
-                fname_to_mesh[r["full_name"]] = mname
 
-        # Iterate over graph nodes and try to look up mesh names.
-        for n in nodes:
-            entity = n["entity_id"]
-            # Strip "host:" prefix — admin API uses it but telemetry doesn't.
-            bare = entity[5:] if entity.startswith("host:") else entity
-            # Direct match (actors, and host_agent actors).
-            if bare in fname_to_mesh:
-                n["mesh_name"] = fname_to_mesh[bare]
-                continue
-            # Procs: try appending proc_agent suffix.
-            agent_name = bare + ",proc_agent[0]"
-            if agent_name in fname_to_mesh:
-                n["mesh_name"] = fname_to_mesh[agent_name]
-
-    except Exception:
-        logger.debug("Could not resolve mesh names from telemetry", exc_info=True)
+_LATEST_SNAPSHOT_SQL = (
+    "SELECT snapshot_id FROM snapshots ORDER BY snapshot_ts DESC LIMIT 1"
+)
 
 
 def build_admin_dag(hide_system: bool = True) -> Dict[str, Any]:
-    """Walk the Admin API and build a DAG matching the TUI hierarchy.
+    """Build a 4-tier DAG (Host → Proc → Actor) from snapshot tables.
 
     Returns ``{"nodes": [...], "edges": [...]}``.
     """
-    admin_url = _get_admin_url()
-    if not admin_url:
+    try:
+        snap_row = db._query_one(_LATEST_SNAPSHOT_SQL)
+    except Exception:
+        logger.debug("Could not query snapshots table", exc_info=True)
         return {"nodes": [], "edges": []}
 
-    session = requests.Session()
-    configure_tls(session)
+    if not snap_row:
+        return {"nodes": [], "edges": []}
+
+    snap_id = snap_row["snapshot_id"]
+
+    # Load all snapshot data for the latest snapshot in bulk.
+    try:
+        all_nodes = db._query(
+            "SELECT node_id, node_kind FROM nodes WHERE snapshot_id = ?",
+            (snap_id,),
+        )
+        all_children = db._query(
+            "SELECT parent_id, child_id, is_system, child_sort_key"
+            " FROM children WHERE snapshot_id = ?"
+            " ORDER BY parent_id, child_sort_key",
+            (snap_id,),
+        )
+        host_rows = db._query(
+            "SELECT node_id, addr FROM host_nodes WHERE snapshot_id = ?",
+            (snap_id,),
+        )
+        proc_rows = db._query(
+            "SELECT node_id, proc_name, is_poisoned, failed_actor_count"
+            " FROM proc_nodes WHERE snapshot_id = ?",
+            (snap_id,),
+        )
+        actor_rows = db._query(
+            "SELECT node_id, actor_status, is_system"
+            " FROM actor_nodes WHERE snapshot_id = ?",
+            (snap_id,),
+        )
+    except Exception:
+        logger.debug("Could not load snapshot data", exc_info=True)
+        return {"nodes": [], "edges": []}
+
+    # Index snapshot data.
+    node_kinds: Dict[str, str] = {n["node_id"]: n["node_kind"] for n in all_nodes}
+    host_info: Dict[str, Dict] = {h["node_id"]: h for h in host_rows}
+    proc_info: Dict[str, Dict] = {p["node_id"]: p for p in proc_rows}
+    actor_info: Dict[str, Dict] = {a["node_id"]: a for a in actor_rows}
+
+    # Build parent → children map and system_children set per parent.
+    children_map: Dict[str, List[str]] = {}
+    system_children_map: Dict[str, Set[str]] = {}
+    for c in all_children:
+        parent = c["parent_id"]
+        child = c["child_id"]
+        children_map.setdefault(parent, []).append(child)
+        if c["is_system"]:
+            system_children_map.setdefault(parent, set()).add(child)
+
+    # BFS walk: Root → Host → Proc → Actor (same structure as old HTTP walk).
     nodes: List[Dict[str, Any]] = []
     edges: List[Dict[str, Any]] = []
     visited: Set[str] = set()
     ref_to_node_id: Dict[str, str] = {}
     controller_host_ref: Optional[str] = None
 
-    queue: List[Tuple[str, Optional[str], int]] = [("root", None, 0)]
+    queue: List[tuple] = [("root", None)]
 
     while queue:
-        ref, parent_ref, depth = queue.pop(0)
+        ref, parent_ref = queue.pop(0)
         if ref in visited:
             continue
         visited.add(ref)
 
-        payload = _fetch_node(session, admin_url, ref)
-        if payload is None:
+        ntype = node_kinds.get(ref)
+        if ntype is None:
             continue
 
-        props = payload.get("properties", {})
-        children_refs = payload.get("children", [])
-        ntype = _node_type(props)
+        child_refs = children_map.get(ref, [])
+        system_children = system_children_map.get(ref, set())
 
-        # Skip root node itself.
+        # Skip root node itself — just enqueue its children.
         if ntype == "root":
-            system_children = _extract_system_children(props) if hide_system else set()
-            for child_ref in children_refs:
+            for child_ref in child_refs:
                 if hide_system and child_ref in system_children:
                     continue
-                queue.append((child_ref, None, depth))
+                queue.append((child_ref, None))
             continue
 
-        # Filter system actors — both API flag and name heuristic.
-        # The root client actor is exempt: it is the user's entrypoint
-        # and the source of all user-visible messages.
-        label = _derive_label(payload)
+        # Derive label for this node.
+        if ntype == "host":
+            h = host_info.get(ref, {})
+            label = _derive_label(ref, ntype, addr=h.get("addr", ""))
+        else:
+            label = _derive_label(ref, ntype)
+
+        # Filter system actors — both snapshot is_system flag and name heuristic.
+        # The root client actor is exempt.
         if hide_system and not _is_client_actor(ref):
-            if _extract_is_system(props):
-                continue
-            if ntype == "actor" and _is_system_by_name(label):
-                continue
+            if ntype == "actor":
+                a = actor_info.get(ref, {})
+                if a.get("is_system", False):
+                    continue
+                if _is_system_by_name(label):
+                    continue
 
-        system_children = _extract_system_children(props) if hide_system else set()
-
+        # Build node data.
         tier_map = {"host": "host", "proc": "proc", "actor": "actor"}
         tier = tier_map.get(ntype, "actor")
-        status = _extract_status(props)
+
+        if ntype == "actor":
+            a = actor_info.get(ref, {})
+            status = _extract_status(ntype, actor_status=a.get("actor_status", ""))
+        elif ntype == "proc":
+            p = proc_info.get(ref, {})
+            status = _extract_status(
+                ntype,
+                is_poisoned=p.get("is_poisoned", False),
+                failed_actor_count=p.get("failed_actor_count", 0),
+            )
+        else:
+            status = _extract_status(ntype)
 
         node_id = f"{tier}-{ref}"
         ref_to_node_id[ref] = node_id
@@ -317,23 +248,20 @@ def build_admin_dag(hide_system: bool = True) -> Dict[str, Any]:
             )
 
         # Detect the controller host by looking for the root client
-        # actor (client[0]) in proc children. Every Monarch process
-        # has exactly one client actor on its local proc, so this is
-        # a stable identifier. This can be removed once the admin API
-        # and telemetry SQL endpoints converge into a single schema
-        # that exposes host roles directly.
-        if ntype == "proc" and any(c.endswith(",client[0]") for c in children_refs):
+        # actor (client[0]) in proc children. Only the controller
+        # process has this actor; worker procs do not.
+        if ntype == "proc" and any(c.endswith(",client[0]") for c in child_refs):
             controller_host_ref = parent_ref
 
-        if depth < _MAX_TREE_DEPTH:
-            for child_ref in children_refs:
-                if (
-                    hide_system
-                    and child_ref in system_children
-                    and not _is_client_actor(child_ref)
-                ):
-                    continue
-                queue.append((child_ref, ref, depth + 1))
+        # Enqueue children.
+        for child_ref in child_refs:
+            if (
+                hide_system
+                and child_ref in system_children
+                and not _is_client_actor(child_ref)
+            ):
+                continue
+            queue.append((child_ref, ref))
 
     # Tag the controller host with "(controller)" in its label.
     if controller_host_ref is not None:
@@ -363,12 +291,10 @@ def build_admin_dag(hide_system: bool = True) -> Dict[str, Any]:
     # Prune procs that have no actor children after system filtering.
     if hide_system:
         actor_node_ids = {n["id"] for n in nodes if n["tier"] == "actor"}
-        # Find which procs have at least one actor child via edges.
         procs_with_actors: Set[str] = set()
         for e in edges:
             if e["type"] == "hierarchy" and e["target_id"] in actor_node_ids:
                 procs_with_actors.add(e["source_id"])
-        # Remove procs with no actors and their edges.
         proc_node_ids = {n["id"] for n in nodes if n["tier"] == "proc"}
         empty_procs = proc_node_ids - procs_with_actors
         if empty_procs:
@@ -386,19 +312,40 @@ def build_admin_dag(hide_system: bool = True) -> Dict[str, Any]:
     return {"nodes": nodes, "edges": edges}
 
 
+def _resolve_mesh_names(nodes: List[Dict[str, Any]]) -> None:
+    try:
+        rows = db._query(
+            "SELECT a.full_name, m.full_name AS mesh_full_name"
+            " FROM actors a"
+            " LEFT JOIN meshes m ON a.mesh_id = m.id"
+        )
+        if not rows:
+            return
+
+        fname_to_mesh: Dict[str, str] = {}
+        for r in rows:
+            mname = r.get("mesh_full_name")
+            if mname:
+                fname_to_mesh[r["full_name"]] = mname
+
+        for n in nodes:
+            entity = n["entity_id"]
+            bare = entity[5:] if entity.startswith("host:") else entity
+            if bare in fname_to_mesh:
+                n["mesh_name"] = fname_to_mesh[bare]
+                continue
+            agent_name = bare + ",proc_agent[0]"
+            if agent_name in fname_to_mesh:
+                n["mesh_name"] = fname_to_mesh[agent_name]
+
+    except Exception:
+        logger.debug("Could not resolve mesh names from telemetry", exc_info=True)
+
+
 def _add_message_edges(
     nodes: List[Dict[str, Any]], edges: List[Dict[str, Any]]
 ) -> None:
-    """Overlay message edges from the telemetry SQL layer.
-
-    Matching strategy: both the admin API references (entity_id) and
-    the telemetry actor full_names use the same format:
-        unix:@HASH,PROC_NAME,ACTOR_NAME[RANK]
-
-    So we match telemetry full_name against admin entity_id directly.
-    For each telemetry actor, if its full_name is a substring of (or
-    equal to) an admin node's entity_id, that's a match.
-    """
+    """Overlay message edges from the telemetry SQL layer."""
     try:
         messages = db._query("SELECT DISTINCT from_actor_id, to_actor_id FROM messages")
         if not messages:
@@ -408,21 +355,14 @@ def _add_message_edges(
         if not actors:
             return
 
-        # Map telemetry actor numeric ID -> full_name.
         actor_id_to_name: Dict[int, str] = {a["id"]: a["full_name"] for a in actors}
 
-        # Build lookup: telemetry full_name -> admin node_id.
-        # Admin entity_ids are the full reference strings which contain
-        # the same actor identifier as the telemetry full_name.
-        # Strategy: for each admin actor node, its entity_id IS the same
-        # reference string as the telemetry full_name.
         entity_to_node_id: Dict[str, str] = {}
         for n in nodes:
             if n["tier"] == "actor":
                 entity_to_node_id[n["entity_id"]] = n["id"]
 
         def _match_node(telemetry_name: str) -> Optional[str]:
-            # Direct match: telemetry name == admin entity_id.
             return entity_to_node_id.get(telemetry_name)
 
         seen: Set[str] = set()

--- a/python/monarch/monarch_dashboard/server/routes.py
+++ b/python/monarch/monarch_dashboard/server/routes.py
@@ -11,7 +11,6 @@ actors, status events, messages, and sent messages.  Every handler returns
 JSON and uses standard HTTP status codes (200, 404).
 """
 
-import os
 from typing import Any
 
 from flask import Blueprint, jsonify, request
@@ -70,12 +69,13 @@ def summary():
 def dag():
     """Classified nodes and edges for the DAG visualization.
 
-    When the Mesh Admin API is available (MONARCH_ADMIN_URL env var),
-    uses the admin tree directly — same hierarchy as the TUI:
-    Host → Proc → Actor.  System actors are filtered using the admin
-    API's authoritative ``is_system`` flag and ``system_children``.
+    When snapshot tables are populated (periodic snapshot capture),
+    uses the 4-tier snapshot hierarchy — same structure as the TUI:
+    Host → Proc → Actor.  System actors are filtered using the
+    snapshot ``is_system`` flag and a name-based heuristic.
 
-    Falls back to the telemetry SQL layer if the admin API is unavailable.
+    Falls back to the telemetry SQL 6-tier hierarchy if snapshot
+    tables are empty.
 
     Optional: ?hide_system=true (default) to filter system actors.
     """
@@ -84,16 +84,14 @@ def dag():
     try:
 
         def _compute_dag():
-            # Prefer the admin API for a clean TUI-like hierarchy.
-            if os.environ.get("MONARCH_ADMIN_URL"):
-                result = build_admin_dag(hide_system=hide_system)
-                if result.get("nodes"):
-                    return _sanitize_for_js(
-                        {
-                            "nodes": result["nodes"],
-                            "edges": result["edges"],
-                        }
-                    )
+            result = build_admin_dag(hide_system=hide_system)
+            if result.get("nodes"):
+                return _sanitize_for_js(
+                    {
+                        "nodes": result["nodes"],
+                        "edges": result["edges"],
+                    }
+                )
 
             # Fallback: telemetry SQL layer.
             system_names = get_system_actor_names() if hide_system else set()

--- a/python/monarch/monarch_dashboard/server/system_actors.py
+++ b/python/monarch/monarch_dashboard/server/system_actors.py
@@ -4,160 +4,112 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-"""Discover system actors by walking the Mesh Admin API.
+"""Discover system actors from snapshot tables and name heuristics.
 
-The Mesh Admin API exposes ``system_children`` on Root/Host/Proc nodes
-and ``is_system`` on Actor nodes.  This module walks the admin tree and
-collects:
+System actor classification uses two complementary filters:
 
-  1. System actor ``full_name`` strings (actors with ``is_system: true``)
-  2. System proc/mesh names (references listed in ``system_children``)
+  1. **Snapshot flag** — the ``actor_nodes`` table (populated by periodic
+     snapshot capture) carries an ``is_system`` flag set by actors that
+     call ``set_system()`` in their ``init()`` (e.g. proc_agent, comm,
+     host_agent, mesh_admin).
+  2. **Name heuristic** — a regex catches infrastructure actors that do
+     *not* call ``set_system()`` but are still Monarch internals (e.g.
+     telemetry, setup, controller_controller).
 
-The dashboard uses these to prune entire system subtrees from the DAG,
-not just individual actors.  Results are cached with a TTL.
+Both filters are applied to the telemetry ``actors`` table, and results
+are unioned.  The root client actor (``client[0]``) is always excluded.
+
+Results are cached with a short TTL to avoid redundant queries.
 """
 
 import logging
-import os
+import re
 import time
-import urllib.parse
-from dataclasses import dataclass, field
-from typing import Optional, Set
-
-import requests
+from typing import Set
 
 logger = logging.getLogger(__name__)
 
+# Known system/infrastructure actor name patterns.
+# Applied to the leaf name (last comma-separated component of full_name),
+# matching the old admin_dag._derive_label behavior.
+_SYSTEM_NAME_PATTERNS = re.compile(
+    r"(telemetry|setup[-_]|SetupActor|comm[-_]|CommActor|"
+    r"logger[-_]|LoggerActor|log_client|MeshAdminAgent|HostAgent|ProcAgent|"
+    r"host_agent|proc_agent|mesh_admin|controller_controller|"
+    r"proc_mesh_controller|actor_mesh_controller)",
+    re.IGNORECASE,
+)
 
-@dataclass
-class SystemInfo:
-    """Collected system actor/mesh classification from the admin API."""
-
-    # Actor full_names that are system actors.
-    actor_names: Set[str] = field(default_factory=set)
-    # References (opaque strings) that appear in system_children.
-    system_refs: Set[str] = field(default_factory=set)
-
-
-# Cache.
-_cache: SystemInfo = SystemInfo()
+_cache: Set[str] = set()
 _cache_time: float = 0.0
 _CACHE_TTL_SECS = 10.0
 
+_LATEST_SNAPSHOT_SYSTEM_ACTORS_SQL = (
+    "SELECT a.node_id FROM actor_nodes a"
+    " INNER JOIN ("
+    "   SELECT snapshot_id FROM snapshots ORDER BY snapshot_ts DESC LIMIT 1"
+    " ) latest ON a.snapshot_id = latest.snapshot_id"
+    " WHERE a.is_system = true"
+)
 
-def _get_admin_url() -> Optional[str]:
-    """Read the admin URL from the environment (set by the host application)."""
-    return os.environ.get("MONARCH_ADMIN_URL")
-
-
-def _walk_admin_tree(admin_url: str) -> SystemInfo:
-    """Walk the admin API tree and collect system classification info."""
-    from .admin_dag import configure_tls
-
-    info = SystemInfo()
-    session = requests.Session()
-    configure_tls(session)
-    visited: Set[str] = set()
-    queue = ["root"]
-
-    while queue:
-        ref = queue.pop(0)
-        if ref in visited:
-            continue
-        visited.add(ref)
-
-        encoded = urllib.parse.quote(ref, safe="")
-        try:
-            resp = session.get(f"{admin_url}/v1/{encoded}", timeout=2.0)
-            if resp.status_code != 200:
-                continue
-            payload = resp.json()
-        except Exception:
-            logger.debug("Failed to fetch node %s", ref, exc_info=True)
-            continue
-
-        props = payload.get("properties", {})
-        children = payload.get("children", [])
-
-        for variant_name, variant_data in props.items():
-            if not isinstance(variant_data, dict):
-                continue
-
-            # Actor: check is_system flag.
-            if variant_name == "Actor" and variant_data.get("is_system"):
-                name = variant_data.get("full_name") or payload.get("identity", "")
-                if name:
-                    info.actor_names.add(name)
-
-            # Root/Host/Proc: collect system_children refs.
-            for sc in variant_data.get("system_children", []):
-                info.system_refs.add(sc)
-
-        # Queue children for traversal.
-        for child_ref in children:
-            queue.append(child_ref)
-
-    # Also resolve system refs to get their actor names.
-    for ref in info.system_refs:
-        if ref in visited:
-            continue
-        encoded = urllib.parse.quote(ref, safe="")
-        try:
-            resp = session.get(f"{admin_url}/v1/{encoded}", timeout=2.0)
-            if resp.status_code != 200:
-                continue
-            payload = resp.json()
-            props = payload.get("properties", {})
-            actor_data = props.get("Actor", {})
-            name = actor_data.get("full_name") or payload.get("identity", "")
-            if name:
-                info.actor_names.add(name)
-        except Exception:
-            logger.debug("Failed to resolve system ref %s", ref, exc_info=True)
-            continue
-
-    logger.debug(
-        "Admin API: %d system actors, %d system refs",
-        len(info.actor_names),
-        len(info.system_refs),
-    )
-    return info
+_ALL_TELEMETRY_ACTORS_SQL = "SELECT full_name FROM actors"
 
 
-def get_system_info() -> SystemInfo:
-    """Return system classification info, with caching.
+def get_system_actor_names() -> Set[str]:
+    """Return system actor names for DAG filtering.
 
-    Returns an empty SystemInfo if the admin URL is not configured or
-    unreachable.
+    Combines two filters:
+      1. ``is_system`` flag from snapshot ``actor_nodes`` table.
+      2. Name heuristic (``_SYSTEM_NAME_PATTERNS``) applied to the leaf
+         name of each actor in the telemetry ``actors`` table.
+
+    The root client actor (``client[0]``) is excluded — it is the
+    user's entrypoint and the source of all user-visible messages.
+
+    Returns an empty set if tables are not yet populated or queries fail.
     """
     global _cache, _cache_time
 
     now = time.monotonic()
-    if now - _cache_time < _CACHE_TTL_SECS and (
-        _cache.actor_names or _cache.system_refs
-    ):
+    if now - _cache_time < _CACHE_TTL_SECS and _cache:
         return _cache
 
-    admin_url = _get_admin_url()
-    if not admin_url:
-        return _cache
+    from . import db
 
+    names: Set[str] = set()
+
+    # Filter 1: actors with is_system=true from snapshot tables.
     try:
-        info = _walk_admin_tree(admin_url)
-        _cache = info
-        _cache_time = now
+        rows = db._query(_LATEST_SNAPSHOT_SYSTEM_ACTORS_SQL)
+        for r in rows:
+            names.add(r["node_id"])
     except Exception:
-        logger.warning("Failed to walk admin API for system actors", exc_info=True)
+        logger.debug("Could not query snapshot tables for system actors", exc_info=True)
+
+    # Filter 2: name heuristic on telemetry actors table.
+    try:
+        rows = db._query(_ALL_TELEMETRY_ACTORS_SQL)
+        for r in rows:
+            full_name = r["full_name"]
+            leaf = full_name.rsplit(",", 1)[-1]
+            if _SYSTEM_NAME_PATTERNS.search(leaf):
+                names.add(full_name)
+    except Exception:
+        logger.debug(
+            "Could not query telemetry actors for name heuristic", exc_info=True
+        )
+
+    # TODO(matthewzhang): Replace the snapshot + name heuristic approach
+    # with ``SELECT full_name FROM actors WHERE is_system = true`` once
+    # the ``is_system`` column on the telemetry ``actors`` table
+    # correctly classifies all system actors (including Python-spawned
+    # ones like setup, telemetry, controller_controller). See D102645433.
+
+    # Exclude the root client actor.
+    names = {n for n in names if not n.endswith(",client[0]")}
+
+    _cache = names
+    _cache_time = now
+    logger.debug("System actors: %d (snapshot + heuristic)", len(names))
 
     return _cache
-
-
-def get_system_actor_names() -> Set[str]:
-    """Convenience: return just the set of system actor full_names.
-
-    The root client actor (``client[0]``) is excluded even though the
-    admin API marks it ``is_system``.  It is the user's entrypoint and
-    the source of all user-visible messages; keeping it out of the
-    system set preserves message edge visibility in the DAG.
-    """
-    return {n for n in get_system_info().actor_names if not n.endswith(",client[0]")}


### PR DESCRIPTION
Summary:
Replace the dashboard's HTTP-based mesh admin API walk with SQL queries
against the snapshot tables (populated by periodic snapshot capture from
D100101207).

The old \`build_admin_dag()\` walked the admin API via HTTP to build a
4-tier DAG (Host → Proc → Actor), then overlaid messages and telemetry
actor IDs from the telemetry SQL tables. The new version produces the
exact same 4-tier DAG structure but sources the topology from snapshot
SQL tables (\`nodes\`, \`children\`, \`host_nodes\`, \`proc_nodes\`,
\`actor_nodes\`) instead of HTTP calls to the mesh admin API.

System actor filtering uses both the snapshot \`is_system\` flag and
the existing name-based heuristic (\`_SYSTEM_NAME_PATTERNS\`), applied
to the leaf name of each actor — identical behavior to the old path.
The \`client[0]\` exemption is preserved.

Changes:
- \`admin_dag.py\`: Rewritten to query snapshot tables via \`db._query()\`
  instead of walking the admin API via HTTP. Same 4-tier BFS structure,
  same filtering logic, same message edge overlay, same controller host
  detection, same empty proc pruning. Removes \`requests\` dependency,
  TLS configuration, and \`MONARCH_ADMIN_URL\` env var dependency.
- \`system_actors.py\`: Rewritten from ~120 lines of HTTP BFS walk to
  SQL queries: snapshot \`actor_nodes.is_system\` flag + name heuristic
  on telemetry \`actors\` table (leaf name regex). Removes \`requests\`
  dependency.
- \`routes.py\`: Same structure as before — prefers the 4-tier snapshot
  DAG (\`build_admin_dag\`), falls back to the 6-tier telemetry SQL DAG
  (\`db.get_dag_data\`) if snapshot tables are empty.
- \`job.py\`: \`TelemetryConfig.__post_init__\` now sets
  \`snapshot_interval_secs=30\` when \`include_dashboard=True\` and no
  interval was specified, ensuring snapshot tables are populated when
  the dashboard is running.
- \`BUCK\`: Remove \`requests\` dependency from \`admin_dag\` and
  \`system_actors\` targets.

Reviewed By: thedavekwon

Differential Revision: D102362229


