### PR TITLE
Avoid SUN_LEN unix socket errors on longer paths (#3697)

### DIFF
--- a/hyperactor/src/id.rs
+++ b/hyperactor/src/id.rs
@@ -33,9 +33,12 @@
 //! (identified by a random `u64`, with an optional label for display).
 
 use std::cmp::Ordering;
+use std::collections::hash_map::DefaultHasher;
 use std::fmt;
 use std::hash::Hash;
 use std::hash::Hasher;
+use std::path::Path;
+use std::path::PathBuf;
 use std::str::FromStr;
 
 use enum_as_inner::EnumAsInner;
@@ -412,6 +415,44 @@ impl ProcId {
     /// Returns the label.
     pub fn label(&self) -> Option<&Label> {
         self.uid.label()
+    }
+
+    /// Returns a unique path for this proc in the given directory. This is stable
+    /// over the lifetime of the ProcId.
+    ///
+    /// The basename is `proc_id.pseudo_uid()` rendered in base58, which keeps the
+    /// path short and host-unique. Both ends of a local link compute the same
+    /// pseudo uid, so the path is consistent without coordination. The
+    /// returned [`PathBuf`] is the on-disk socket path, which callers may use to
+    /// pre-flight existence before dialing.
+    pub fn to_path_elem(&self, base_dir: &Path) -> PathBuf {
+        let pseudo_id = self.pseudo_uid();
+        let tag = match pseudo_id {
+            Uid::Singleton(label) => {
+                panic!("pseudo uid should never be a singleton, but got: {}", label)
+            }
+            Uid::Instance(uid, _) => encode_base58_uid(uid).to_string(),
+        };
+        base_dir.join(tag)
+    }
+
+    /// A `Uid` suitable as a short, host-unique identifier — for example,
+    /// as a basename in a filesystem path.
+    ///
+    /// For an instance proc, this is the proc's actual uid. For a singleton,
+    /// it is `Uid::Instance(hash(label))`, a stable value derived from the
+    /// singleton's name. Singletons are host-unique by name, so this remains
+    /// host-unique. We call it "pseudo" because in the singleton case it does
+    /// not match the proc's true uid.
+    pub fn pseudo_uid(&self) -> Uid {
+        match &self.uid {
+            Uid::Instance(_, _) => self.uid.clone(),
+            Uid::Singleton(label) => {
+                let mut h = DefaultHasher::new();
+                label.hash(&mut h);
+                Uid::Instance(h.finish(), None)
+            }
+        }
     }
 }
 
@@ -1192,6 +1233,42 @@ mod tests {
         assert_eq!(pid.label(), Some(&label));
         let pid2 = ProcId::instance(label);
         assert_ne!(pid, pid2);
+    }
+
+    #[test]
+    fn test_proc_id_pseudo_uid_instance_returns_real_uid() {
+        let uid = Uid::Instance(0xd5d54d7201103869, None);
+        let pid = ProcId::new(uid.clone(), Some(Label::new("my-proc").unwrap()));
+        assert_eq!(pid.pseudo_uid(), uid);
+    }
+
+    #[test]
+    fn test_proc_id_pseudo_uid_singleton_is_instance_form() {
+        let pid = ProcId::singleton(Label::new("my-proc").unwrap());
+        assert!(matches!(pid.pseudo_uid(), Uid::Instance(_, _)));
+    }
+
+    #[test]
+    fn test_proc_id_pseudo_uid_singleton_is_deterministic() {
+        let a = ProcId::singleton(Label::new("my-proc").unwrap());
+        let b = ProcId::singleton(Label::new("my-proc").unwrap());
+        assert_eq!(a.pseudo_uid(), b.pseudo_uid());
+    }
+
+    #[test]
+    fn test_proc_id_pseudo_uid_singleton_distinct_labels_differ() {
+        let a = ProcId::singleton(Label::new("alpha").unwrap());
+        let b = ProcId::singleton(Label::new("beta").unwrap());
+        assert_ne!(a.pseudo_uid(), b.pseudo_uid());
+    }
+
+    #[test]
+    fn test_proc_id_pseudo_uid_displays_as_short_base58() {
+        let pid = ProcId::singleton(Label::new("my-proc").unwrap());
+        let s = pid.pseudo_uid().to_string();
+        assert!(s.starts_with('<') && s.ends_with('>'), "got: {s}");
+        // base58 of u64 fits in 11 chars, plus the two delimiters.
+        assert!(s.len() <= 13, "expected short base58 form, got: {s}");
     }
 
     #[test]

--- a/hyperactor_mesh/src/bootstrap.rs
+++ b/hyperactor_mesh/src/bootstrap.rs
@@ -30,6 +30,7 @@ use std::sync::Weak;
 use std::time::Duration;
 use std::time::SystemTime;
 
+use anyhow::Context;
 use async_trait::async_trait;
 use base64::prelude::*;
 use futures::StreamExt;
@@ -473,12 +474,7 @@ impl Bootstrap {
                 }
 
                 let local_addr = proc_id.addr().clone();
-                // TODO provide a direct way to construct these
-                let serve_addr = format!(
-                    "unix:{}",
-                    socket_dir_path.join(proc_id.resource_name()).display()
-                );
-                let serve_addr = serve_addr.parse().unwrap();
+                let (serve_addr, _) = local_proc_addr(&socket_dir_path, proc_id.id())?;
 
                 // The following is a modified host::spawn_proc to support direct
                 // dialing between local procs: 1) we bind each proc to a deterministic
@@ -2288,6 +2284,26 @@ impl Write for Debug {
         }
         res
     }
+}
+
+/// Build the bind/dial [`ChannelAddr`] for a local proc within `socket_dir`.
+pub(crate) fn local_proc_addr(
+    socket_dir: &Path,
+    proc_id: &hyperactor::id::ProcId,
+) -> anyhow::Result<(ChannelAddr, PathBuf)> {
+    let path = proc_id.to_path_elem(socket_dir);
+    let addr = std::os::unix::net::SocketAddr::from_pathname(path.clone())
+        .with_context(|| {
+            format!(
+                "constructing unix socket address for proc {proc_id} \
+            at {} ({} bytes); path must fit within SUN_LEN \
+             (108 on Linux, 104 on macOS)",
+                path.display(),
+                path.as_os_str().len()
+            )
+        })?
+        .into();
+    Ok((addr, path))
 }
 
 /// Create a new runtime [`TempDir`]. The directory is created in

--- a/hyperactor_mesh/src/bootstrap/mailbox.rs
+++ b/hyperactor_mesh/src/bootstrap/mailbox.rs
@@ -14,6 +14,7 @@ use std::sync::RwLock;
 
 use async_trait::async_trait;
 use hyperactor::PortHandle;
+use hyperactor::Uid;
 use hyperactor::channel::ChannelAddr;
 use hyperactor::channel::ChannelError;
 use hyperactor::mailbox::DeliveryError;
@@ -29,7 +30,7 @@ pub(crate) struct LocalProcDialer {
     local_addr: ChannelAddr,
     socket_dir: PathBuf,
     backend_sender: MailboxClient,
-    local_senders: RwLock<HashMap<String, Result<MailboxClient, ChannelError>>>,
+    local_senders: RwLock<HashMap<Uid, Result<MailboxClient, ChannelError>>>,
 }
 
 impl LocalProcDialer {
@@ -65,7 +66,7 @@ impl MailboxSender for LocalProcDialer {
             // reachable through the backend address.
             && proc_ref.uid().is_instance()
         {
-            let key = proc_ref.resource_name();
+            let key = proc_ref.id().pseudo_uid();
             let senders = self.local_senders.read().unwrap();
             let senders = if senders.contains_key(&key) {
                 senders
@@ -73,17 +74,15 @@ impl MailboxSender for LocalProcDialer {
                 drop(senders);
                 let mut senders = self.local_senders.write().unwrap();
                 senders.entry(key.clone()).or_insert_with(|| {
-                    let socket_path = self.socket_dir.join(&key);
-                    if socket_path.exists() {
-                        let addr = format!("unix:{}", socket_path.display());
-                        let addr = addr.parse().unwrap();
-                        MailboxClient::dial(addr)
-                    } else {
-                        Err(ChannelError::InvalidAddress(format!(
+                    let (addr, path) = super::local_proc_addr(&self.socket_dir, proc_ref.id())
+                        .map_err(|e| ChannelError::InvalidAddress(e.to_string()))?;
+                    if !path.exists() {
+                        return Err(ChannelError::InvalidAddress(format!(
                             "unix socket path '{}' does not exist",
-                            socket_path.display()
-                        )))
+                            path.display()
+                        )));
                     }
+                    MailboxClient::dial(addr)
                 });
                 drop(senders);
                 self.local_senders.read().unwrap()
@@ -124,41 +123,27 @@ mod tests {
     use hyperactor_config::Flattrs;
 
     use super::*;
-    use crate::mesh_id::ResourceId;
+    use crate::bootstrap::local_proc_addr;
 
     #[tokio::test]
     async fn test_proc_dialer() {
         let dir = tempfile::tempdir().unwrap();
-        let first = ResourceId::unique(hyperactor::id::Label::new("first").unwrap());
-        let second = ResourceId::unique(hyperactor::id::Label::new("second").unwrap());
-        let third = ResourceId::unique(hyperactor::id::Label::new("third").unwrap());
-        let (_first_addr, mut first_rx) = channel::serve::<MessageEnvelope>(
-            format!("unix:{}/{}", dir.path().display(), first)
-                .parse()
-                .unwrap(),
-        )
-        .unwrap();
-        let (_second_addr, _second_rx) = channel::serve::<MessageEnvelope>(
-            format!("unix:{}/{}", dir.path().display(), second)
-                .parse()
-                .unwrap(),
-        )
-        .unwrap();
+        let local_addr: ChannelAddr = "tcp:3.4.5.6:123".parse().unwrap();
+        let first = hyperactor::ProcAddr::unique(local_addr.clone(), "first");
+        let second = hyperactor::ProcAddr::unique(local_addr.clone(), "second");
+        let third = hyperactor::ProcAddr::unique(local_addr.clone(), "third");
+        let (first_serve, _) = local_proc_addr(dir.path(), first.id()).unwrap();
+        let (_first_addr, mut first_rx) = channel::serve::<MessageEnvelope>(first_serve).unwrap();
+        let (second_serve, _) = local_proc_addr(dir.path(), second.id()).unwrap();
+        let (_second_addr, _second_rx) = channel::serve::<MessageEnvelope>(second_serve).unwrap();
         let (backend_addr, mut backend_rx) =
             channel::serve::<MessageEnvelope>(ChannelTransport::Unix.any()).unwrap();
 
-        // These proc names must match the socket file names on disk, so we
-        // construct the IDs directly rather than via test_proc_id.
-        let local_addr: ChannelAddr = "tcp:3.4.5.6:123".parse().unwrap();
-        let first_actor_id =
-            hyperactor::ProcAddr::from_resource_name(local_addr.clone(), first.to_string())
-                .actor_id("actor");
-        let second_actor_id =
-            hyperactor::ProcAddr::from_resource_name(local_addr.clone(), second.to_string())
-                .actor_id("actor");
-        let third_notexist_actor_id =
-            hyperactor::ProcAddr::from_resource_name(local_addr.clone(), third.to_string())
-                .actor_id("actor");
+        // The dialer derives the socket path from each proc's pseudo_uid, so
+        // both ends must share the same ProcId.
+        let first_actor_id = first.actor_id("actor");
+        let second_actor_id = second.actor_id("actor");
+        let third_notexist_actor_id = third.actor_id("actor");
         let proc_dialer = LocalProcDialer::new(
             local_addr.clone(),
             dir.path().to_owned(),


### PR DESCRIPTION
Summary:

The proc bootstrap path constructed a unix socket address by joining the runtime tempdir with `proc_id.resource_name()` and unwrapping the parse. When the resulting path exceeded `SUN_LEN` (108 bytes on Linux, 104 on macOS), `from_pathname` returned an error and the unwrap panicked the worker thread with `path must be shorter than SUN_LEN`.

This change funnels both the bind site (`Bootstrap::Proc`) and the dial site (`LocalProcDialer`) through a `local_proc_addr(socket_dir, proc_id)` helper that derives the basename from the proc's `pseudo_uid()`, rendered as base58. Both ends compute the same uid from the same `ProcId`, so binding and dialing agree without coordinating; the basename is bounded by `base58(u64)` (≤11 chars), so a long resource name no longer pushes the full path past `SUN_LEN`. The dialer keeps its existing existence pre-check and now caches senders by `Uid` instead of by resource-name string. Parse failures propagate through `anyhow::Result` instead of panicking.

`pseudo_uid()` is a new method on `id::ProcId`. For an `Instance` proc, it returns the proc's actual uid; for a `Singleton`, it returns `Uid::Instance(hash(label))` — a stable, host-unique value derived from the label. We call it "pseudo" because in the singleton case it does not match the proc's true uid. Singletons are host-unique by name, so the result remains host-unique.

`socket_dir` itself can still exceed `SUN_LEN` if `XDG_RUNTIME_DIR` is unusually long; callers will get a contextual error from the helper rather than a panic. Picking a shorter root dir is a separate follow-up.

Reviewed By: mariusae

Differential Revision: D103084036


