### PR TITLE
[hyperactor] move hyperactor_mesh typed refs off hyperactor::reference

### DIFF
--- a/hyperactor_mesh/src/actor_mesh.rs
+++ b/hyperactor_mesh/src/actor_mesh.rs
@@ -21,6 +21,8 @@ use std::sync::OnceLock as OnceCell;
 use std::time::Duration;
 
 use hyperactor::ActorLocal;
+use hyperactor::ActorRef;
+use hyperactor::PortRef;
 use hyperactor::RemoteHandles;
 use hyperactor::RemoteMessage;
 use hyperactor::actor::ActorStatus;
@@ -30,7 +32,6 @@ use hyperactor::mailbox::PortReceiver;
 use hyperactor::message::Castable;
 use hyperactor::message::IndexedErasedUnbound;
 use hyperactor::message::Unbound;
-use hyperactor::reference as hyperactor_reference;
 use hyperactor::supervision::ActorSupervisionEvent;
 use hyperactor_config::CONFIG;
 use hyperactor_config::ConfigAttr;
@@ -86,7 +87,7 @@ declare_attrs! {
 /// An ActorMesh is a collection of ranked A-typed actors.
 ///
 /// Bound note: `A: Referable` because the mesh stores/returns
-/// `hyperactor_reference::ActorRef<A>`, which is only defined for `A: Referable`.
+/// `ActorRef<A>`, which is only defined for `A: Referable`.
 #[derive(Debug)]
 pub struct ActorMesh<A: Referable> {
     proc_mesh: ProcMeshRef,
@@ -97,16 +98,15 @@ pub struct ActorMesh<A: Referable> {
     /// supervision events via subscribing.
     /// It may not be present for some types of actors, typically system actors
     /// such as ProcAgent or CommActor.
-    controller: Option<hyperactor_reference::ActorRef<ActorMeshController<A>>>,
+    controller: Option<ActorRef<ActorMeshController<A>>>,
 }
 
-// `A: Referable` for the same reason as the struct: the mesh holds
-// `hyperactor_reference::ActorRef<A>`.
+// `A: Referable` for the same reason as the struct: the mesh holds `ActorRef<A>`.
 impl<A: Referable> ActorMesh<A> {
     pub(crate) fn new(
         proc_mesh: ProcMeshRef,
         id: ActorMeshId,
-        controller: Option<hyperactor_reference::ActorRef<ActorMeshController<A>>>,
+        controller: Option<ActorRef<ActorMeshController<A>>>,
     ) -> Self {
         let current_ref = ActorMeshRef::with_page_size(
             id.clone(),
@@ -127,10 +127,7 @@ impl<A: Referable> ActorMesh<A> {
         &self.id
     }
 
-    pub(crate) fn set_controller(
-        &mut self,
-        controller: Option<hyperactor_reference::ActorRef<ActorMeshController<A>>>,
-    ) {
+    pub(crate) fn set_controller(&mut self, controller: Option<ActorRef<ActorMeshController<A>>>) {
         self.controller = controller.clone();
         self.current_ref.set_controller(controller);
     }
@@ -264,7 +261,7 @@ const DEFAULT_PAGE: usize = 1024;
 
 /// A lazily materialized page of ActorRefs.
 struct Page<A: Referable> {
-    slots: Box<[OnceCell<hyperactor_reference::ActorRef<A>>]>,
+    slots: Box<[OnceCell<ActorRef<A>>]>,
 }
 
 impl<A: Referable> Page<A> {
@@ -396,7 +393,7 @@ pub struct ActorMeshRef<A: Referable> {
     /// not be stopped. If Some, the actor mesh may still be stopped, and the
     /// next_supervision_event function can be used to alert that the mesh has
     /// stopped.
-    controller: Option<hyperactor_reference::ActorRef<ActorMeshController<A>>>,
+    controller: Option<ActorRef<ActorMeshController<A>>>,
 
     /// Recorded health issues with the mesh, to quickly consult before sending
     /// out any casted messages. This is a locally updated copy of the authoritative
@@ -409,7 +406,7 @@ pub struct ActorMeshRef<A: Referable> {
     receiver: ActorLocal<
         Arc<
             tokio::sync::Mutex<(
-                hyperactor_reference::PortRef<Option<MeshFailure>>,
+                PortRef<Option<MeshFailure>>,
                 watch::Receiver<MessageOrFailure<Option<MeshFailure>>>,
             )>,
         >,
@@ -420,7 +417,7 @@ pub struct ActorMeshRef<A: Referable> {
     /// - The `Vec` holds slots for multiple pages.
     /// - Each slot is itself a `OnceCell<Box<Page<A>>>`, so that each
     ///   page can be initialized on demand.
-    /// - A `Page<A>` is a boxed slice of `OnceCell<hyperactor_reference::ActorRef<A>>`,
+    /// - A `Page<A>` is a boxed slice of `OnceCell<ActorRef<A>>`,
     ///   i.e. the actual storage for actor references within that
     ///   page.
     pages: OnceCell<Vec<OnceCell<Box<Page<A>>>>>,
@@ -561,7 +558,7 @@ impl<A: Referable> ActorMeshRef<A> {
         cx: &impl context::Actor,
         message: M,
         sel: Selection,
-        root_comm_actor: &hyperactor_reference::ActorRef<CommActor>,
+        root_comm_actor: &ActorRef<CommActor>,
         caller_headers: &Flattrs,
     ) -> crate::Result<()>
     where
@@ -626,7 +623,7 @@ impl<A: Referable> ActorMeshRef<A> {
     pub(crate) fn new(
         id: ActorMeshId,
         proc_mesh: ProcMeshRef,
-        controller: Option<hyperactor_reference::ActorRef<ActorMeshController<A>>>,
+        controller: Option<ActorRef<ActorMeshController<A>>>,
     ) -> Self {
         Self::with_page_size(id, proc_mesh, DEFAULT_PAGE, controller)
     }
@@ -639,7 +636,7 @@ impl<A: Referable> ActorMeshRef<A> {
         id: ActorMeshId,
         proc_mesh: ProcMeshRef,
         page_size: usize,
-        controller: Option<hyperactor_reference::ActorRef<ActorMeshController<A>>>,
+        controller: Option<ActorRef<ActorMeshController<A>>>,
     ) -> Self {
         Self {
             proc_mesh,
@@ -661,14 +658,11 @@ impl<A: Referable> ActorMeshRef<A> {
         view::Ranked::region(&self.proc_mesh).num_ranks()
     }
 
-    pub fn controller(&self) -> &Option<hyperactor_reference::ActorRef<ActorMeshController<A>>> {
+    pub fn controller(&self) -> &Option<ActorRef<ActorMeshController<A>>> {
         &self.controller
     }
 
-    fn set_controller(
-        &mut self,
-        controller: Option<hyperactor_reference::ActorRef<ActorMeshController<A>>>,
-    ) {
+    fn set_controller(&mut self, controller: Option<ActorRef<ActorMeshController<A>>>) {
         self.controller = controller;
     }
 
@@ -678,7 +672,7 @@ impl<A: Referable> ActorMeshRef<A> {
             .get_or_init(|| (0..n).map(|_| OnceCell::new()).collect())
     }
 
-    fn materialize(&self, rank: usize) -> Option<&hyperactor_reference::ActorRef<A>> {
+    fn materialize(&self, rank: usize) -> Option<&ActorRef<A>> {
         let len = self.len();
         if rank >= len {
             return None;
@@ -715,10 +709,10 @@ impl<A: Referable> ActorMeshRef<A> {
     }
 
     fn init_supervision_receiver(
-        controller: &hyperactor_reference::ActorRef<ActorMeshController<A>>,
+        controller: &ActorRef<ActorMeshController<A>>,
         cx: &impl context::Actor,
     ) -> (
-        hyperactor_reference::PortRef<Option<MeshFailure>>,
+        PortRef<Option<MeshFailure>>,
         watch::Receiver<MessageOrFailure<Option<MeshFailure>>>,
     ) {
         let (tx, rx) = cx.mailbox().open_port();
@@ -939,7 +933,7 @@ impl<'de, A: Referable> Deserialize<'de> for ActorMeshRef<A> {
         let (proc_mesh, id, controller) = <(
             ProcMeshRef,
             ActorMeshId,
-            Option<hyperactor_reference::ActorRef<ActorMeshController<A>>>,
+            Option<ActorRef<ActorMeshController<A>>>,
         )>::deserialize(deserializer)?;
         Ok(ActorMeshRef::with_page_size(
             id,
@@ -951,7 +945,7 @@ impl<'de, A: Referable> Deserialize<'de> for ActorMeshRef<A> {
 }
 
 impl<A: Referable> view::Ranked for ActorMeshRef<A> {
-    type Item = hyperactor_reference::ActorRef<A>;
+    type Item = ActorRef<A>;
 
     #[inline]
     fn region(&self) -> &Region {

--- a/hyperactor_mesh/src/casting.rs
+++ b/hyperactor_mesh/src/casting.rs
@@ -10,6 +10,7 @@
 
 use std::collections::BTreeSet;
 
+use hyperactor::ActorRef;
 use hyperactor::RemoteHandles;
 use hyperactor::RemoteMessage;
 use hyperactor::actor::Referable;
@@ -20,7 +21,6 @@ use hyperactor::mailbox::MessageEnvelope;
 use hyperactor::mailbox::Undeliverable;
 use hyperactor::message::Castable;
 use hyperactor::message::IndexedErasedUnbound;
-use hyperactor::reference as hyperactor_reference;
 use hyperactor_config::Flattrs;
 use hyperactor_config::attrs::declare_attrs;
 use ndslice::Selection;
@@ -81,7 +81,7 @@ pub fn update_undeliverable_envelope_for_casting(
 pub(crate) fn actor_mesh_cast<A, M>(
     cx: &impl context::Actor,
     actor_mesh_id: ActorMeshId,
-    comm_actor_ref: &hyperactor_reference::ActorRef<CommActor>,
+    comm_actor_ref: &ActorRef<CommActor>,
     selection_of_root: Selection,
     root_mesh_shape: &Shape,
     cast_mesh_shape: &Shape,
@@ -163,7 +163,7 @@ where
 pub(crate) fn cast_to_sliced_mesh<A, M>(
     cx: &impl context::Actor,
     actor_mesh_id: ActorMeshId,
-    comm_actor_ref: &hyperactor_reference::ActorRef<CommActor>,
+    comm_actor_ref: &ActorRef<CommActor>,
     sel_of_sliced: &Selection,
     message: M,
     sliced_shape: &Shape,

--- a/hyperactor_mesh/src/connect.rs
+++ b/hyperactor_mesh/src/connect.rs
@@ -47,6 +47,8 @@ use futures::future;
 use futures::stream::FusedStream;
 use futures::task::Context;
 use futures::task::Poll;
+use hyperactor::OncePortRef;
+use hyperactor::PortRef;
 use hyperactor::context;
 use hyperactor::mailbox::OncePortReceiver;
 use hyperactor::mailbox::PortReceiver;
@@ -55,7 +57,7 @@ use hyperactor::mailbox::open_port;
 use hyperactor::message::Bind;
 use hyperactor::message::Bindings;
 use hyperactor::message::Unbind;
-use hyperactor::reference as hyperactor_reference;
+use hyperactor::reference::ActorId;
 use pin_project::pin_project;
 use pin_project::pinned_drop;
 use serde::Deserialize;
@@ -85,18 +87,18 @@ struct OwnedReadHalfStream {
 
 /// Wrap a `PortReceiver<IoMsg>` as a `AsyncRead`.
 pub struct OwnedReadHalf {
-    peer: hyperactor_reference::ActorId,
+    peer: ActorId,
     inner: StreamReader<OwnedReadHalfStream, Cursor<Vec<u8>>>,
 }
 
 /// Wrap a `PortRef<IoMsg>` as a `AsyncWrite`.
 #[pin_project(PinnedDrop)]
 pub struct OwnedWriteHalf<C: context::Actor> {
-    peer: hyperactor_reference::ActorId,
+    peer: ActorId,
     #[pin]
     caps: C,
     #[pin]
-    port: hyperactor_reference::PortRef<Io>,
+    port: PortRef<Io>,
     #[pin]
     shutdown: bool,
 }
@@ -115,13 +117,13 @@ impl<C: context::Actor> ActorConnection<C> {
         (self.reader, self.writer)
     }
 
-    pub fn peer(&self) -> &hyperactor_reference::ActorId {
+    pub fn peer(&self) -> &ActorId {
         self.reader.peer()
     }
 }
 
 impl OwnedReadHalf {
-    fn new(peer: hyperactor_reference::ActorId, port: PortReceiver<Io>) -> Self {
+    fn new(peer: ActorId, port: PortReceiver<Io>) -> Self {
         Self {
             peer,
             inner: StreamReader::new(OwnedReadHalfStream {
@@ -131,7 +133,7 @@ impl OwnedReadHalf {
         }
     }
 
-    pub fn peer(&self) -> &hyperactor_reference::ActorId {
+    pub fn peer(&self) -> &ActorId {
         &self.peer
     }
 
@@ -144,11 +146,7 @@ impl OwnedReadHalf {
 }
 
 impl<C: context::Actor> OwnedWriteHalf<C> {
-    fn new(
-        peer: hyperactor_reference::ActorId,
-        caps: C,
-        port: hyperactor_reference::PortRef<Io>,
-    ) -> Self {
+    fn new(peer: ActorId, caps: C, port: PortRef<Io>) -> Self {
         Self {
             peer,
             caps,
@@ -157,7 +155,7 @@ impl<C: context::Actor> OwnedWriteHalf<C> {
         }
     }
 
-    pub fn peer(&self) -> &hyperactor_reference::ActorId {
+    pub fn peer(&self) -> &ActorId {
         &self.peer
     }
 
@@ -316,20 +314,17 @@ impl<C: context::Actor> ConnectionCompleter<C> {
 #[derive(Debug, Serialize, Deserialize, Named, Clone)]
 pub struct Connect {
     /// The ID of the client initiating the connection.
-    id: hyperactor_reference::ActorId,
-    conn: hyperactor_reference::PortRef<Io>,
+    id: ActorId,
+    conn: PortRef<Io>,
     /// The port the server can use to complete the connection.
-    return_conn: hyperactor_reference::OncePortRef<Accept>,
+    return_conn: OncePortRef<Accept>,
 }
 wirevalue::register_type!(Connect);
 
 impl Connect {
     /// Allocate a new `Connect` message and return the associated `ConnectionCompleter` that can be used
     /// to finish setting up the connection.
-    pub fn allocate<C: context::Actor>(
-        id: hyperactor_reference::ActorId,
-        caps: C,
-    ) -> (Self, ConnectionCompleter<C>) {
+    pub fn allocate<C: context::Actor>(id: ActorId, caps: C) -> (Self, ConnectionCompleter<C>) {
         let (conn_tx, conn_rx) = open_port::<Io>(&caps);
         let (return_tx, return_rx) = open_once_port::<Accept>(&caps);
         (
@@ -352,9 +347,9 @@ impl Connect {
 #[derive(Debug, Serialize, Deserialize, Named, Clone)]
 struct Accept {
     /// The ID of the server that accepted the connection.
-    id: hyperactor_reference::ActorId,
+    id: ActorId,
     /// The port the client will use to send data over the connection to the server.
-    conn: hyperactor_reference::PortRef<Io>,
+    conn: PortRef<Io>,
 }
 wirevalue::register_type!(Accept);
 
@@ -376,7 +371,7 @@ impl Unbind for Connect {
 /// return `AsyncRead` and `AsyncWrite` streams that can be used to communicate with the other side.
 pub async fn accept<C: context::Actor>(
     caps: C,
-    self_id: hyperactor_reference::ActorId,
+    self_id: ActorId,
     message: Connect,
 ) -> Result<ActorConnection<C>> {
     let (tx, rx) = open_port::<Io>(&caps);

--- a/hyperactor_mesh/src/global_context.rs
+++ b/hyperactor_mesh/src/global_context.rs
@@ -59,6 +59,7 @@ use hyperactor::ActorHandle;
 use hyperactor::Context;
 use hyperactor::Handler;
 use hyperactor::Instance;
+use hyperactor::PortRef;
 use hyperactor::actor::ActorError;
 use hyperactor::actor::ActorErrorKind;
 use hyperactor::actor::ActorStatus;
@@ -72,7 +73,6 @@ use hyperactor::mailbox::PortReceiver;
 use hyperactor::mailbox::Undeliverable;
 use hyperactor::proc::Proc;
 use hyperactor::proc::WorkCell;
-use hyperactor::reference as hyperactor_reference;
 use hyperactor::supervision::ActorSupervisionEvent;
 use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
@@ -100,13 +100,12 @@ use crate::transport::default_bind_spec;
 ///
 /// Uses `PortRef` (not `PortHandle`) because the sink target
 /// (`ProcAgent`) runs in a remote worker process.
-static GLOBAL_SUPERVISION_SINK: OnceLock<
-    RwLock<Option<hyperactor_reference::PortRef<ActorSupervisionEvent>>>,
-> = OnceLock::new();
+static GLOBAL_SUPERVISION_SINK: OnceLock<RwLock<Option<PortRef<ActorSupervisionEvent>>>> =
+    OnceLock::new();
 
 /// Returns the lazily-initialized container that holds the current
 /// process-global supervision sink.
-fn sink_cell() -> &'static RwLock<Option<hyperactor_reference::PortRef<ActorSupervisionEvent>>> {
+fn sink_cell() -> &'static RwLock<Option<PortRef<ActorSupervisionEvent>>> {
     GLOBAL_SUPERVISION_SINK.get_or_init(|| RwLock::new(None))
 }
 
@@ -126,8 +125,8 @@ fn sink_cell() -> &'static RwLock<Option<hyperactor_reference::PortRef<ActorSupe
 /// destination [`ProcAgent`] may live in a different
 /// process/rank.
 pub(crate) fn set_global_supervision_sink(
-    sink: hyperactor_reference::PortRef<ActorSupervisionEvent>,
-) -> Option<hyperactor_reference::PortRef<ActorSupervisionEvent>> {
+    sink: PortRef<ActorSupervisionEvent>,
+) -> Option<PortRef<ActorSupervisionEvent>> {
     let cell = sink_cell();
     let mut guard = cell.write().unwrap();
     let prev = guard.take();
@@ -146,7 +145,7 @@ pub(crate) fn set_global_supervision_sink(
 /// Cloning a [`PortRef`] is cheap.
 ///
 /// Used only by the process-global root client.
-fn get_global_supervision_sink() -> Option<hyperactor_reference::PortRef<ActorSupervisionEvent>> {
+fn get_global_supervision_sink() -> Option<PortRef<ActorSupervisionEvent>> {
     sink_cell().read().unwrap().clone()
 }
 
@@ -512,7 +511,6 @@ pub fn try_this_host() -> Option<&'static HostMeshRef> {
 mod tests {
     use std::time::Duration;
 
-    use hyperactor::reference as hyperactor_reference;
     use hyperactor::testing::ids::test_actor_id;
     use hyperactor_config::Flattrs;
     use ndslice::view::Extent;
@@ -537,16 +535,14 @@ mod tests {
     ) {
         let env = MessageEnvelope::new(
             client.self_id().clone(),
-            hyperactor_reference::PortId::new(dest_actor, 0),
+            hyperactor::reference::PortId::new(dest_actor, 0),
             wirevalue::Any::serialize(&0u64).unwrap(),
             Flattrs::new(),
         );
         // Target the global root client's well-known Undeliverable port.
-        let client_actor_id: hyperactor_reference::ActorId = client.self_id().clone().into();
+        let client_actor_id: hyperactor::reference::ActorId = client.self_id().clone().into();
         let undeliverable_port =
-            hyperactor_reference::PortRef::<Undeliverable<MessageEnvelope>>::attest_message_port(
-                &client_actor_id,
-            );
+            PortRef::<Undeliverable<MessageEnvelope>>::attest_message_port(&client_actor_id);
         undeliverable_port
             .send(client, Undeliverable(env))
             .expect("inject_undeliverable: send failed");

--- a/hyperactor_mesh/src/lib.rs
+++ b/hyperactor_mesh/src/lib.rs
@@ -74,9 +74,11 @@ pub use global_context::context;
 pub use global_context::this_host;
 pub use global_context::this_proc;
 pub use host_mesh::HostMeshRef;
+use hyperactor::ActorRef;
 use hyperactor::host::HostError;
 use hyperactor::mailbox::MailboxSenderError;
-use hyperactor::reference as hyperactor_reference;
+use hyperactor::reference::ActorId;
+use hyperactor::reference::ProcId;
 pub use hyperactor_mesh_macros::sel;
 pub use mesh::Mesh;
 // Re-exported for internal test binaries that don't have ndslice as a direct dependency
@@ -142,7 +144,7 @@ pub enum Error {
     UnroutableMesh(),
 
     #[error("error while calling actor {0}: {1}")]
-    CallError(hyperactor_reference::ActorId, anyhow::Error),
+    CallError(ActorId, anyhow::Error),
 
     #[error("actor not registered for type {0}")]
     ActorTypeNotRegistered(String),
@@ -152,13 +154,13 @@ pub enum Error {
     GspawnError(mesh_id::ActorMeshId, String),
 
     #[error("error while sending message to actor {0}: {1}")]
-    SendingError(hyperactor_reference::ActorId, Box<MailboxSenderError>),
+    SendingError(ActorId, Box<MailboxSenderError>),
 
     #[error("error while casting message to {0}: {1}")]
     CastingError(mesh_id::ActorMeshId, anyhow::Error),
 
     #[error("error configuring host mesh agent {0}: {1}")]
-    HostMeshAgentConfigurationError(hyperactor_reference::ActorId, String),
+    HostMeshAgentConfigurationError(ActorId, String),
 
     #[error(
         "error creating proc (host rank {host_rank}) on host mesh agent {mesh_agent}, state: {state}"
@@ -166,7 +168,7 @@ pub enum Error {
     ProcCreationError {
         state: Box<resource::State<ProcState>>,
         host_rank: usize,
-        mesh_agent: hyperactor_reference::ActorRef<HostAgent>,
+        mesh_agent: ActorRef<HostAgent>,
     },
 
     #[error(
@@ -194,7 +196,7 @@ pub enum Error {
     ControllerActorSpawnError(mesh_id::ResourceId, anyhow::Error),
 
     #[error("proc {0} must be direct-addressable")]
-    RankedProc(hyperactor_reference::ProcId),
+    RankedProc(ProcId),
 
     #[error("{0}")]
     Supervision(Box<MeshFailure>),

--- a/hyperactor_mesh/src/mesh_controller.rs
+++ b/hyperactor_mesh/src/mesh_controller.rs
@@ -16,6 +16,7 @@ use hyperactor::Bind;
 use hyperactor::Context;
 use hyperactor::Handler;
 use hyperactor::Instance;
+use hyperactor::PortRef;
 use hyperactor::Unbind;
 use hyperactor::actor::ActorError;
 use hyperactor::actor::ActorErrorKind;
@@ -26,7 +27,7 @@ use hyperactor::context;
 use hyperactor::kv_pairs;
 use hyperactor::mailbox::MessageEnvelope;
 use hyperactor::mailbox::Undeliverable;
-use hyperactor::reference as hyperactor_reference;
+use hyperactor::reference::ProcId;
 use hyperactor::supervision::ActorSupervisionEvent;
 use hyperactor_config::CONFIG;
 use hyperactor_config::ConfigAttr;
@@ -86,15 +87,15 @@ struct HealthState {
     unhealthy_event: Option<Unhealthy>,
     crashed_ranks: HashMap<usize, ActorSupervisionEvent>,
     // The unique owner of this actor.
-    owner: Option<hyperactor_reference::PortRef<MeshFailure>>,
+    owner: Option<PortRef<MeshFailure>>,
     /// A set of subscribers to send messages to when events are encountered.
-    subscribers: HashSet<hyperactor_reference::PortRef<Option<MeshFailure>>>,
+    subscribers: HashSet<PortRef<Option<MeshFailure>>>,
 }
 
 impl HealthState {
     fn new(
         statuses: HashMap<Point, resource::Status>,
-        owner: Option<hyperactor_reference::PortRef<MeshFailure>>,
+        owner: Option<PortRef<MeshFailure>>,
     ) -> Self {
         Self {
             statuses: statuses
@@ -139,16 +140,16 @@ impl HealthState {
 /// the listener that the controller is still alive. Make sure to filter such events
 /// out as not useful.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Named, Bind, Unbind)]
-pub struct Subscribe(pub hyperactor_reference::PortRef<Option<MeshFailure>>);
+pub struct Subscribe(pub PortRef<Option<MeshFailure>>);
 
 /// Unsubscribe me to future updates about a mesh. Should be the same port used in
 /// the Subscribe message.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Named, Bind, Unbind)]
-pub struct Unsubscribe(pub hyperactor_reference::PortRef<Option<MeshFailure>>);
+pub struct Unsubscribe(pub PortRef<Option<MeshFailure>>);
 
 /// Query the number of active supervision subscribers on this controller.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Named, Bind, Unbind)]
-pub struct GetSubscriberCount(#[binding(include)] pub hyperactor_reference::PortRef<usize>);
+pub struct GetSubscriberCount(#[binding(include)] pub PortRef<usize>);
 
 /// Check state of the actors in the mesh. This is used as a self message to
 /// periodically check.
@@ -197,7 +198,7 @@ impl<A: Referable> ActorMeshController<A> {
     pub(crate) fn new(
         mesh: ActorMeshRef<A>,
         supervision_display_name: Option<String>,
-        port: Option<hyperactor_reference::PortRef<MeshFailure>>,
+        port: Option<PortRef<MeshFailure>>,
         initial_statuses: ValueMesh<resource::Status>,
     ) -> Self {
         let supervision_display_name =
@@ -243,7 +244,7 @@ declare_attrs! {
 
 fn send_subscriber_message(
     cx: &impl context::Actor,
-    subscriber: &hyperactor_reference::PortRef<Option<MeshFailure>>,
+    subscriber: &PortRef<Option<MeshFailure>>,
     message: MeshFailure,
 ) {
     let mut headers = Flattrs::new();
@@ -307,7 +308,10 @@ impl<A: Referable> Actor for ActorMeshController<A> {
                 // but the longer-term fix is to clarify whether that
                 // bind path should be idempotent and eliminate the
                 // need for attestation here.
-                subscriber: hyperactor_reference::PortRef::<resource::State<ActorState>>::attest_message_port(&this.self_id().clone().into()).unsplit(),
+                subscriber: PortRef::<resource::State<ActorState>>::attest_message_port(
+                    &this.self_id().clone().into(),
+                )
+                .unsplit(),
             },
         )?;
 
@@ -348,8 +352,7 @@ impl<A: Referable> Actor for ActorMeshController<A> {
             // NOTE: The only part of the port that is used for equality checks is
             // the port id, so create a new one just for the comparison.
             let dest_port_id = envelope.0.dest().clone();
-            let port =
-                hyperactor_reference::PortRef::<Option<MeshFailure>>::attest(dest_port_id.into());
+            let port = PortRef::<Option<MeshFailure>>::attest(dest_port_id.into());
             let did_exist = self.health_state.subscribers.remove(&port);
             if did_exist {
                 tracing::debug!(
@@ -1011,10 +1014,7 @@ impl Actor for ProcMeshController {
         _err: Option<&ActorError>,
     ) -> Result<(), anyhow::Error> {
         // Cannot use "ProcMesh::stop" as it's only defined on ProcMesh, not ProcMeshRef.
-        let names = self
-            .mesh
-            .proc_ids()
-            .collect::<Vec<hyperactor_reference::ProcId>>();
+        let names = self.mesh.proc_ids().collect::<Vec<ProcId>>();
         let region = self.mesh.region().clone();
         if let Some(hosts) = self.mesh.hosts() {
             hosts

--- a/hyperactor_mesh/src/resource.rs
+++ b/hyperactor_mesh/src/resource.rs
@@ -27,6 +27,7 @@ use enum_as_inner::EnumAsInner;
 use hyperactor::Bind;
 use hyperactor::HandleClient;
 use hyperactor::Handler;
+use hyperactor::PortRef;
 use hyperactor::RefClient;
 use hyperactor::RemoteMessage;
 use hyperactor::Unbind;
@@ -34,7 +35,6 @@ use hyperactor::mailbox::PortReceiver;
 use hyperactor::message::Bind;
 use hyperactor::message::Bindings;
 use hyperactor::message::Unbind;
-use hyperactor::reference as hyperactor_reference;
 use hyperactor_config::attrs::Attrs;
 use ndslice::Region;
 use ndslice::ViewExt;
@@ -212,7 +212,7 @@ pub struct GetRankStatus {
     pub id: ResourceId,
     /// Sparse status updates (overlays) from a rank.
     #[binding(include)]
-    pub reply: hyperactor_reference::PortRef<StatusOverlay>,
+    pub reply: PortRef<StatusOverlay>,
 }
 
 /// Like [`GetRankStatus`], but the handler defers its reply until the
@@ -239,7 +239,7 @@ pub struct WaitRankStatus {
     pub min_status: Status,
     /// Sparse status updates (overlays) from a rank.
     #[binding(include)]
-    pub reply: hyperactor_reference::PortRef<StatusOverlay>,
+    pub reply: PortRef<StatusOverlay>,
 }
 
 impl GetRankStatus {
@@ -397,7 +397,7 @@ pub struct GetState<S> {
     pub id: ResourceId,
     /// A reply containing the state.
     #[reply]
-    pub reply: hyperactor_reference::PortRef<State<S>>,
+    pub reply: PortRef<State<S>>,
 }
 wirevalue::register_type!(GetState<ProcState>);
 wirevalue::register_type!(GetState<ActorState>);
@@ -488,7 +488,7 @@ pub struct StreamState<S> {
     /// The resource identifier.
     pub id: ResourceId,
     /// A streaming port that will receive state updates.
-    pub subscriber: hyperactor_reference::PortRef<State<S>>,
+    pub subscriber: PortRef<State<S>>,
 }
 wirevalue::register_type!(StreamState<ActorState>);
 
@@ -530,7 +530,7 @@ where
 pub struct List {
     /// List of resource names managed by this controller.
     #[reply]
-    pub reply: hyperactor_reference::PortRef<Vec<ResourceId>>,
+    pub reply: PortRef<Vec<ResourceId>>,
 }
 wirevalue::register_type!(List);
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #3704
* #3703
* #3702
* __->__ #3701
* #3700
* #3699
* #3698
* #3630
* #3629
* #3628
* #3627
* #3626

Start removing `hyperactor::reference` by importing typed capability refs directly in `hyperactor_mesh`. Keep legacy `reference::*Id` uses explicit where the code still depends on the compatibility layer so this change stays mechanical and limited to typed-ref paths.

Differential Revision: [D102822048](https://our.internmc.facebook.com/intern/diff/D102822048/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D102822048/)!