### PR TITLE
[hyperactor] export true id/addr/ref names

### DIFF
--- a/hyperactor/src/actor.rs
+++ b/hyperactor/src/actor.rs
@@ -99,7 +99,7 @@ pub trait Actor: Sized + Send + 'static {
     }
 
     /// Spawn a named child actor. Same supervision semantics as
-    /// `spawn`, but the child gets `name` in its ActorId.
+    /// `spawn`, but the child gets `name` in its ActorAddr.
     fn spawn_with_name(
         self,
         cx: &impl context::Actor,
@@ -151,7 +151,7 @@ pub trait Actor: Sized + Send + 'static {
     }
 
     /// If overridden, we will use this name in place of the
-    /// ActorId for talking about this actor in supervision error
+    /// ActorAddr for talking about this actor in supervision error
     /// messages.
     fn display_name(&self) -> Option<String> {
         None
@@ -261,14 +261,14 @@ where
 /// - `Actor`: only actors may be remotely spawned.
 /// - `Referable`: marks the type as eligible for typed remote
 ///   references (`ActorRef<A>`); required because remote spawn
-///   ultimately hands back an `ActorId` that higher-level APIs may
+///   ultimately hands back an `ActorAddr` that higher-level APIs may
 ///   re-type as `ActorRef<A>`.
 /// - `Binds<Self>`: lets the runtime wire this actor's message ports
 ///   when it is spawned (the blanket impl calls `handle.bind::<Self>()`).
 ///
 /// `gspawn` is a type-erased entry point used by the remote
 /// spawn/registry machinery. It takes serialized params and returns
-/// the new actor's `ActorId`; application code shouldn't call it
+/// the new actor's `ActorAddr`; application code shouldn't call it
 /// directly.
 #[async_trait]
 pub trait RemoteSpawn: Actor + Referable + Binds<Self> {
@@ -298,7 +298,7 @@ pub trait RemoteSpawn: Actor + Referable + Binds<Self> {
                     .map(|(v, _)| v)?;
             let actor = Self::new(params, environment).await?;
             let handle = proc.spawn(&name, actor)?;
-            // We return only the ActorId, not a typed ActorRef.
+            // We return only the ActorAddr, not a typed ActorRef.
             // Callers that hold this ID can interact with the actor
             // only via the serialized/opaque messaging path, which
             // makes it safe to export across process boundaries.
@@ -1577,7 +1577,7 @@ mod tests {
         let handle = proc.spawn::<EchoActor>("echo_introspect", actor).unwrap();
 
         let (reply_port, reply_rx) = client.open_once_port::<IntrospectResult>();
-        PortRef::<IntrospectMessage>::attest_message_port(&handle.actor_id().clone().into())
+        PortRef::<IntrospectMessage>::attest_message_port(&handle.actor_id().clone())
             .send(
                 &client,
                 IntrospectMessage::Query {
@@ -1590,7 +1590,7 @@ mod tests {
 
         assert_eq!(
             payload.identity,
-            crate::introspect::IntrospectRef::Actor(handle.actor_id().clone().into())
+            crate::introspect::IntrospectRef::Actor(handle.actor_id().clone())
         );
         assert_valid_attrs(&payload);
         assert_has_attr(&payload, "status");
@@ -1800,7 +1800,7 @@ mod tests {
             .unwrap();
 
         let (reply_port, reply_rx) = client.open_once_port::<IntrospectResult>();
-        PortRef::<IntrospectMessage>::attest_message_port(&handle.actor_id().clone().into())
+        PortRef::<IntrospectMessage>::attest_message_port(&handle.actor_id().clone())
             .send(
                 &client,
                 IntrospectMessage::Query {
@@ -1841,7 +1841,7 @@ mod tests {
 
         // Query the child — supervisor should be the parent.
         let (reply_port, reply_rx) = client.open_once_port::<IntrospectResult>();
-        PortRef::<IntrospectMessage>::attest_message_port(&child_handle.actor_id().clone().into())
+        PortRef::<IntrospectMessage>::attest_message_port(&child_handle.actor_id().clone())
             .send(
                 &client,
                 IntrospectMessage::Query {
@@ -1854,7 +1854,7 @@ mod tests {
 
         assert_eq!(
             child_payload.identity,
-            crate::introspect::IntrospectRef::Actor(child_handle.actor_id().clone().into()),
+            crate::introspect::IntrospectRef::Actor(child_handle.actor_id().clone()),
         );
         // Verify it has actor attrs (status present).
         assert!(
@@ -1864,13 +1864,13 @@ mod tests {
         assert_eq!(
             child_payload.parent,
             Some(crate::introspect::IntrospectRef::Actor(
-                parent_handle.actor_id().clone().into()
+                parent_handle.actor_id().clone()
             )),
         );
 
         // Query the parent — children should include the child.
         let (reply_port, reply_rx) = client.open_once_port::<IntrospectResult>();
-        PortRef::<IntrospectMessage>::attest_message_port(&parent_handle.actor_id().clone().into())
+        PortRef::<IntrospectMessage>::attest_message_port(&parent_handle.actor_id().clone())
             .send(
                 &client,
                 IntrospectMessage::Query {
@@ -1886,7 +1886,7 @@ mod tests {
             parent_payload
                 .children
                 .contains(&crate::introspect::IntrospectRef::Actor(
-                    child_handle.actor_id().clone().into()
+                    child_handle.actor_id().clone()
                 )),
         );
 
@@ -1916,7 +1916,7 @@ mod tests {
             .unwrap();
 
         let (reply_port, reply_rx) = client.open_once_port::<IntrospectResult>();
-        PortRef::<IntrospectMessage>::attest_message_port(&handle.actor_id().clone().into())
+        PortRef::<IntrospectMessage>::attest_message_port(&handle.actor_id().clone())
             .send(
                 &client,
                 IntrospectMessage::Query {
@@ -1951,7 +1951,7 @@ mod tests {
         let _ = rx.recv().await.unwrap();
 
         let (reply_port, reply_rx) = client.open_once_port::<IntrospectResult>();
-        PortRef::<IntrospectMessage>::attest_message_port(&handle.actor_id().clone().into())
+        PortRef::<IntrospectMessage>::attest_message_port(&handle.actor_id().clone())
             .send(
                 &client,
                 IntrospectMessage::Query {
@@ -1990,7 +1990,7 @@ mod tests {
 
         // First introspect query.
         let (reply_port, reply_rx) = client.open_once_port::<IntrospectResult>();
-        PortRef::<IntrospectMessage>::attest_message_port(&handle.actor_id().clone().into())
+        PortRef::<IntrospectMessage>::attest_message_port(&handle.actor_id().clone())
             .send(
                 &client,
                 IntrospectMessage::Query {
@@ -2003,7 +2003,7 @@ mod tests {
 
         // Second introspect query.
         let (reply_port2, reply_rx2) = client.open_once_port::<IntrospectResult>();
-        PortRef::<IntrospectMessage>::attest_message_port(&handle.actor_id().clone().into())
+        PortRef::<IntrospectMessage>::attest_message_port(&handle.actor_id().clone())
             .send(
                 &client,
                 IntrospectMessage::Query {
@@ -2174,7 +2174,7 @@ mod tests {
 
         // Send introspect query via the dedicated introspect port.
         let (reply_port, reply_rx) = client.open_once_port::<IntrospectResult>();
-        PortRef::<IntrospectMessage>::attest_message_port(&handle.actor_id().clone().into())
+        PortRef::<IntrospectMessage>::attest_message_port(&handle.actor_id().clone())
             .send(
                 &client,
                 IntrospectMessage::Query {
@@ -2219,7 +2219,7 @@ mod tests {
 
         // First introspect query.
         let (reply_port1, reply_rx1) = client.open_once_port::<IntrospectResult>();
-        PortRef::<IntrospectMessage>::attest_message_port(&handle.actor_id().clone().into())
+        PortRef::<IntrospectMessage>::attest_message_port(&handle.actor_id().clone())
             .send(
                 &client,
                 IntrospectMessage::Query {

--- a/hyperactor/src/host.rs
+++ b/hyperactor/src/host.rs
@@ -1729,8 +1729,9 @@ where
     // and call back.
     let (proc_addr, proc_rx) = channel::serve(ChannelAddr::any(backend_transport))?;
     proc.clone().serve(proc_rx);
+    let agent_ref: ActorRef<A> = agent_handle.bind::<A>();
     channel::dial::<(ChannelAddr, ActorRef<A>)>(callback_addr)?
-        .send((proc_addr, agent_handle.bind::<A>()))
+        .send((proc_addr, agent_ref))
         .await
         .map_err(ChannelError::from)?;
 

--- a/hyperactor/src/introspect.rs
+++ b/hyperactor/src/introspect.rs
@@ -775,7 +775,7 @@ pub fn live_actor_payload(cell: &InstanceCell) -> IntrospectResult {
     let children: Vec<IntrospectRef> = cell
         .child_actor_ids()
         .into_iter()
-        .map(|a| IntrospectRef::Actor(a.into()))
+        .map(IntrospectRef::Actor)
         .collect();
 
     let events = cell.recording().tail();
@@ -799,7 +799,7 @@ pub fn live_actor_payload(cell: &InstanceCell) -> IntrospectResult {
 
     let supervisor = cell
         .parent()
-        .map(|p| IntrospectRef::Actor(p.actor_id().clone().into()));
+        .map(|p| IntrospectRef::Actor(p.actor_id().clone()));
 
     // FI-3: failure_info is computed from the same status value as
     // actor_status, ensuring they agree on whether the actor failed.
@@ -829,7 +829,7 @@ pub fn live_actor_payload(cell: &InstanceCell) -> IntrospectResult {
     let attrs = build_actor_attrs(cell, &snap);
 
     IntrospectResult {
-        identity: IntrospectRef::Actor(actor_id.clone().into()),
+        identity: IntrospectRef::Actor(actor_id.clone()),
         attrs,
         children,
         parent: supervisor,
@@ -897,12 +897,12 @@ pub(crate) async fn serve_introspect(
                             let children: Vec<IntrospectRef> =
                                 published.get(CHILDREN).cloned().unwrap_or_default();
                             IntrospectResult {
-                                identity: IntrospectRef::Actor(cell.actor_id().clone().into()),
+                                identity: IntrospectRef::Actor(cell.actor_id().clone()),
                                 attrs: attrs_json,
                                 children,
                                 parent: cell
                                     .parent()
-                                    .map(|p| IntrospectRef::Actor(p.actor_id().clone().into())),
+                                    .map(|p| IntrospectRef::Actor(p.actor_id().clone())),
                                 as_of: SystemTime::now(),
                             }
                         }
@@ -917,7 +917,7 @@ pub(crate) async fn serve_introspect(
                 )
             }
             IntrospectMessage::QueryChild { child_ref, reply } => {
-                let child_ref_: Address = child_ref.clone().into();
+                let child_ref_: Address = child_ref.clone();
                 let payload = cell.query_child(&child_ref_).unwrap_or_else(|| {
                     let mut error_attrs = hyperactor_config::Attrs::new();
                     error_attrs.set(ERROR_CODE, "not_found".to_string());

--- a/hyperactor/src/lib.rs
+++ b/hyperactor/src/lib.rs
@@ -114,16 +114,11 @@ pub use actor::RemoteHandles;
 pub use actor::RemoteSpawn;
 pub use actor_local::ActorLocal;
 pub use addr::ActorAddr;
-pub use addr::ActorAddr as ActorId;
 pub use addr::AddrParseError;
-pub use addr::AddrParseError as ReferenceParsingError;
 pub use addr::Address;
-pub use addr::Address as Reference;
 pub use addr::Location;
 pub use addr::PortAddr;
-pub use addr::PortAddr as PortId;
 pub use addr::ProcAddr;
-pub use addr::ProcAddr as ProcId;
 #[doc(inline)]
 pub use hyperactor_macros::Bind;
 #[doc(inline)]
@@ -154,10 +149,10 @@ pub use hyperactor_telemetry::declare_static_histogram;
 pub use hyperactor_telemetry::declare_static_timer;
 pub use hyperactor_telemetry::key_value;
 pub use hyperactor_telemetry::kv_pairs;
-pub use id::ActorId as RawActorId;
+pub use id::ActorId;
 pub use id::Label;
-pub use id::PortId as RawPortId;
-pub use id::ProcId as RawProcId;
+pub use id::PortId;
+pub use id::ProcId;
 pub use id::Uid;
 #[doc(inline)]
 pub use init::initialize;

--- a/hyperactor/src/mailbox.rs
+++ b/hyperactor/src/mailbox.rs
@@ -12,7 +12,7 @@
 //! An actor can open one or more typed _ports_ in the mailbox; messages
 //! are in turn delivered to specific ports.
 //!
-//! Mailboxes are associated with an [`ActorId`] (given by `actor_id`
+//! Mailboxes are associated with an [`ActorAddr`] (given by `actor_id`
 //! in the following example):
 //!
 //! ```
@@ -59,9 +59,9 @@
 //! Mailboxes allow delivery of serialized messages to named ports:
 //!
 //! 1) Ports restrict message types to (serializable) [`Message`]s.
-//! 2) Each [`Port`] is associated with a [`PortId`] which globally names the port.
+//! 2) Each [`Port`] is associated with a [`PortAddr`] which globally names the port.
 //! 3) [`Mailbox`] provides interfaces to deliver serialized
-//!    messages to ports named by their [`PortId`].
+//!    messages to ports named by their [`PortAddr`].
 //!
 //! While this complicates the interface somewhat, it allows the
 //! implementation to avoid a serialization roundtrip when passing
@@ -2519,7 +2519,7 @@ struct State {
 }
 
 impl State {
-    /// Create a new state with the provided owning ActorId.
+    /// Create a new state with the provided owning ActorAddr.
     fn new(actor_id: ActorAddr, forwarder: BoxedMailboxSender) -> Self {
         Self {
             actor_id,
@@ -3071,11 +3071,11 @@ mod tests {
     use crate::testing::ids::test_proc_id;
 
     fn test_proc_ref(name: &str) -> Address {
-        Address::Proc(test_proc_id(name).into())
+        Address::Proc(test_proc_id(name))
     }
 
     fn test_actor_ref(proc_name: &str, actor_name: &str) -> Address {
-        Address::Actor(test_actor_id(proc_name, actor_name).into())
+        Address::Actor(test_actor_id(proc_name, actor_name))
     }
 
     #[test]
@@ -3085,7 +3085,7 @@ mod tests {
             test_actor_id("myworld_2", "myactor"),
             MailboxErrorKind::Closed,
         );
-        // ActorId display is now "actor_uid.proc_uid@location"
+        // ActorAddr display is now "actor_uid.proc_uid@location"
         let err_str = format!("{err}");
         assert!(
             err_str.contains("mailbox closed"),
@@ -3612,7 +3612,7 @@ mod tests {
         fn create_receiver<M>(coalesce: bool) -> (mpsc::UnboundedSender<M>, PortReceiver<M>) {
             // Create dummy state and port_id to create PortReceiver. They are
             // not used in the test.
-            let dummy_actor_ref: ActorAddr = test_actor_id("world_0", "actor").into();
+            let dummy_actor_ref: ActorAddr = test_actor_id("world_0", "actor");
             let dummy_state = State::new(
                 dummy_actor_ref.clone(),
                 BOXED_PANICKING_MAILBOX_SENDER.clone(),
@@ -4098,7 +4098,7 @@ mod tests {
                 .expect("receiver should not be closed");
 
         // Verify the undeliverable message has the correct destination
-        let split_port_ref: PortAddr = split_port_id.into();
+        let split_port_ref: PortAddr = split_port_id;
         assert_eq!(undeliverable.0.dest(), &split_port_ref);
 
         // Verify no additional messages arrived at the original receiver

--- a/hyperactor/src/mailbox/headers.rs
+++ b/hyperactor/src/mailbox/headers.rs
@@ -28,7 +28,7 @@ declare_attrs! {
     /// The rust type of the message.
     pub attr RUST_MESSAGE_TYPE: String;
 
-    /// Hashed ActorId of the message sender, injected in post_unchecked().
+    /// Hashed ActorAddr of the message sender, injected in post_unchecked().
     pub attr SENDER_ACTOR_ID_HASH: u64;
 
     /// Telemetry message ID for correlating lifecycle events, injected in post_unchecked().

--- a/hyperactor/src/ordering.rs
+++ b/hyperactor/src/ordering.rs
@@ -254,8 +254,8 @@ impl Sequencer {
     /// Assign the next seq for a port, mutate the sequencer with the new seq,
     /// and return the new seq.
     ///
-    /// - Actor ports: share the same sequence scheme per actor (keyed by ActorId)
-    /// - Non-actor ports: get individual sequence schemes (keyed by PortId)
+    /// - Actor ports: share the same sequence scheme per actor (keyed by ActorAddr)
+    /// - Non-actor ports: get individual sequence schemes (keyed by PortAddr)
     pub fn assign_seq(&self, port_id: &PortAddr) -> SeqInfo {
         let key = if port_id.is_actor_port() {
             SeqKey::Actor(port_id.actor_ref().clone())
@@ -476,7 +476,7 @@ mod tests {
             last_seqs: Arc::new(Mutex::new(HashMap::new())),
         };
 
-        let actor_ref: ActorAddr = test_actor_id("test_0", "test").into();
+        let actor_ref: ActorAddr = test_actor_id("test_0", "test");
         let port_ref = actor_ref.port_ref(Port::from(1));
 
         // Modify original sequencer
@@ -496,7 +496,7 @@ mod tests {
             last_seqs: Arc::new(Mutex::new(HashMap::new())),
         };
 
-        let actor_ref: ActorAddr = test_actor_id("worker_0", "worker").into();
+        let actor_ref: ActorAddr = test_actor_id("worker_0", "worker");
         // Two different actor ports for the same actor (using Named::port())
         let actor_port_1 = actor_ref.port_ref(Port::from(TestMsg1::port()));
         let actor_port_2 = actor_ref.port_ref(Port::from(TestMsg2::port()));
@@ -507,7 +507,7 @@ mod tests {
         assert_eq!(get_seq(sequencer.assign_seq(&actor_port_1)), 3);
 
         // Actor ports from a different actor get their own shared sequence
-        let actor_ref_2: ActorAddr = test_actor_id("worker_1", "worker").into();
+        let actor_ref_2: ActorAddr = test_actor_id("worker_1", "worker");
         let actor_port_3 = actor_ref_2.port_ref(Port::from(TestMsg1::port()));
         assert_eq!(get_seq(sequencer.assign_seq(&actor_port_3)), 1); // independent from actor_ref
     }
@@ -519,8 +519,8 @@ mod tests {
             last_seqs: Arc::new(Mutex::new(HashMap::new())),
         };
 
-        let actor_ref_0: ActorAddr = test_actor_id("worker_0", "worker").into();
-        let actor_ref_1: ActorAddr = test_actor_id("worker_1", "worker").into();
+        let actor_ref_0: ActorAddr = test_actor_id("worker_0", "worker");
+        let actor_ref_1: ActorAddr = test_actor_id("worker_1", "worker");
 
         // Non-actor ports from the same actor (without ACTOR_PORT_BIT)
         let port_1 = actor_ref_0.port_ref(Port::from(1));
@@ -546,7 +546,7 @@ mod tests {
             last_seqs: Arc::new(Mutex::new(HashMap::new())),
         };
 
-        let actor_ref: ActorAddr = test_actor_id("worker_0", "worker").into();
+        let actor_ref: ActorAddr = test_actor_id("worker_0", "worker");
 
         // Actor ports (share sequence per actor)
         let actor_port_1 = actor_ref.port_ref(Port::from(TestMsg1::port()));

--- a/hyperactor/src/proc.rs
+++ b/hyperactor/src/proc.rs
@@ -3347,6 +3347,7 @@ mod tests {
     use crate::Handler;
     use crate::OncePortRef;
     use crate::PortRef;
+    use crate::port::Port;
     use crate::testing::proc_supervison::ProcSupervisionCoordinator;
     use crate::testing::process_assertion::assert_termination;
 
@@ -3557,9 +3558,7 @@ mod tests {
         let sender = test_actor_id("sender", "client");
 
         // Same ProcId, same addr: route locally; the forwarder must not see it.
-        let local_dest = proc_local
-            .actor_id("worker")
-            .port_ref(crate::port::Port::from(1234));
+        let local_dest = proc_local.actor_id("worker").port_ref(Port::from(1234));
         proc.post(
             MessageEnvelope::new(
                 sender.clone(),
@@ -3572,9 +3571,7 @@ mod tests {
         assert_eq!(forwarded.load(Ordering::SeqCst), 0);
 
         // Same ProcId, different addr: must forward to reach the remote proc.
-        let remote_dest = proc_remote
-            .actor_id("worker")
-            .port_ref(crate::port::Port::from(1234));
+        let remote_dest = proc_remote.actor_id("worker").port_ref(Port::from(1234));
         proc.post(
             MessageEnvelope::new(
                 sender,

--- a/hyperactor/src/testing/ids.rs
+++ b/hyperactor/src/testing/ids.rs
@@ -17,7 +17,7 @@ use crate::ProcAddr;
 use crate::channel::ChannelAddr;
 use crate::channel::ChannelTransport;
 
-/// Create a test `ProcId` with a local channel address and name `"test_{name}"`.
+/// Create a test `ProcAddr` with a local channel address and name `"test_{name}"`.
 pub fn test_proc_id(name: &str) -> ProcAddr {
     ProcAddr::from_resource_name(
         ChannelAddr::any(ChannelTransport::Local),
@@ -25,17 +25,17 @@ pub fn test_proc_id(name: &str) -> ProcAddr {
     )
 }
 
-/// Create a test `ProcId` with a custom address and name `"test_{name}"`.
+/// Create a test `ProcAddr` with a custom address and name `"test_{name}"`.
 pub fn test_proc_id_with_addr(addr: ChannelAddr, name: &str) -> ProcAddr {
     ProcAddr::from_resource_name(addr, format!("test_{name}"))
 }
 
-/// Create a test `ActorId`.
+/// Create a test `ActorAddr`.
 pub fn test_actor_id(proc_name: &str, actor_name: &str) -> ActorAddr {
     test_proc_id(proc_name).actor_ref(actor_name)
 }
 
-/// Create a test `PortId`.
+/// Create a test `PortAddr`.
 pub fn test_port_id(proc_name: &str, actor_name: &str, port: u64) -> PortAddr {
     test_actor_id(proc_name, actor_name).port_ref(port.into())
 }

--- a/hyperactor_mesh/src/bootstrap.rs
+++ b/hyperactor_mesh/src/bootstrap.rs
@@ -39,7 +39,6 @@ use hyperactor::ActorAddr;
 use hyperactor::ActorHandle;
 use hyperactor::ActorRef;
 use hyperactor::ProcAddr;
-use hyperactor::ProcId;
 use hyperactor::channel;
 use hyperactor::channel::ChannelAddr;
 use hyperactor::channel::ChannelError;
@@ -311,8 +310,8 @@ pub async fn host(
 pub enum Bootstrap {
     /// Bootstrap as a "v1" proc
     Proc {
-        /// The ProcId of the proc to be bootstrapped.
-        proc_id: ProcId,
+        /// The ProcAddr of the proc to be bootstrapped.
+        proc_id: ProcAddr,
         /// The backend address to which messages are forwarded.
         /// See [`hyperactor::host`] for channel topology details.
         backend_addr: ChannelAddr,
@@ -490,7 +489,7 @@ impl Bootstrap {
 
                 let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<i32>();
                 let agent_handle = ProcAgent::boot_v1(proc.clone(), Some(shutdown_tx))
-                    .map_err(|e| HostError::AgentSpawnFailure(proc_id.into(), e))?;
+                    .map_err(|e| HostError::AgentSpawnFailure(proc_id, e))?;
 
                 let span = entered.exit();
 
@@ -708,7 +707,7 @@ impl std::error::Error for ReadyError {}
 /// terminate the process.
 ///
 /// What it pairs together:
-/// - the **logical proc identity** (`ProcId`)
+/// - the **logical proc identity** (`ProcAddr`)
 /// - the **live status surface** ([`ProcStatus`]), available both as
 ///   a synchronous snapshot (`status()`) and as an async stream via a
 ///   `tokio::sync::watch` channel (`watch()` / `changed()`)
@@ -1172,7 +1171,7 @@ impl BootstrapProcHandle {
         let _ = self.mark_stopping();
 
         if let Some(launcher) = self.launcher.upgrade() {
-            let ref_proc_id: ProcId = self.proc_id.clone();
+            let ref_proc_id: ProcAddr = self.proc_id.clone();
             if let Err(e) = launcher.terminate(&ref_proc_id, timeout).await {
                 tracing::warn!(
                     proc_id = %self.proc_id,
@@ -1337,7 +1336,7 @@ impl hyperactor::host::ProcHandle for BootstrapProcHandle {
 
         // Delegate to launcher for SIGTERM/SIGKILL escalation.
         tracing::info!(proc_id = %self.proc_id, ?timeout, "terminate(): delegating to launcher");
-        let ref_proc_id: ProcId = self.proc_id.clone();
+        let ref_proc_id: ProcAddr = self.proc_id.clone();
         if let Some(launcher) = self.launcher.upgrade() {
             if let Err(e) = launcher.terminate(&ref_proc_id, timeout).await {
                 tracing::warn!(proc_id = %self.proc_id, error=%e, "terminate(): launcher termination failed");
@@ -1389,7 +1388,7 @@ impl hyperactor::host::ProcHandle for BootstrapProcHandle {
 
         // Delegate to launcher for kill.
         tracing::info!(proc_id = %self.proc_id, "kill(): delegating to launcher");
-        let ref_proc_id: ProcId = self.proc_id.clone();
+        let ref_proc_id: ProcAddr = self.proc_id.clone();
         if let Some(launcher) = self.launcher.upgrade() {
             if let Err(e) = launcher.kill(&ref_proc_id).await {
                 tracing::warn!(proc_id = %self.proc_id, error=%e, "kill(): launcher kill failed");
@@ -1581,7 +1580,7 @@ impl FromStr for LauncherKind {
 ///   [`ProcStatus`],
 /// - providing status/query APIs over the set of active procs.
 ///
-/// It maintains an async registry mapping [`ProcId`] →
+/// It maintains an async registry mapping [`ProcAddr`] →
 /// [`BootstrapProcHandle`] for lifecycle queries and exit
 /// observation.
 ///
@@ -1606,7 +1605,7 @@ pub struct BootstrapProcManager {
     /// The command specification used to bootstrap new processes.
     command: BootstrapCommand,
 
-    /// Async registry of running children, keyed by [`ProcId`]. Holds
+    /// Async registry of running children, keyed by [`ProcAddr`]. Holds
     /// [`BootstrapProcHandle`]s so callers can query or monitor
     /// status.
     children: Arc<tokio::sync::Mutex<HashMap<ProcAddr, BootstrapProcHandle>>>,
@@ -1697,7 +1696,7 @@ impl BootstrapProcManager {
         self.socket_dir.path()
     }
 
-    /// Return the current [`ProcStatus`] for the given [`ProcId`], if
+    /// Return the current [`ProcStatus`] for the given [`ProcAddr`], if
     /// the proc is known to this manager.
     ///
     /// This queries the live [`BootstrapProcHandle`] stored in the
@@ -1933,7 +1932,7 @@ impl ProcManager for BootstrapProcManager {
         let need_stdio = enable_forwarding || enable_file_capture || tail_size > 0;
 
         let mode = Bootstrap::Proc {
-            proc_id: proc_id.clone().into(),
+            proc_id: proc_id.clone(),
             backend_addr,
             callback_addr,
             socket_dir_path: self.socket_dir.path().to_owned(),
@@ -1947,7 +1946,7 @@ impl ProcManager for BootstrapProcManager {
 
         let opts = LaunchOptions {
             bootstrap_payload,
-            process_name: format_process_name(&proc_id.clone().into()),
+            process_name: format_process_name(&proc_id.clone()),
             command: config
                 .bootstrap_command
                 .as_ref()
@@ -1965,7 +1964,7 @@ impl ProcManager for BootstrapProcManager {
 
         // Launch via the configured launcher backend.
         tracing::info!(proc_id = %proc_id, "launching proc with opts={opts:?}");
-        let ref_proc_id: ProcId = proc_id.clone();
+        let ref_proc_id: ProcAddr = proc_id.clone();
         let launch_result = self
             .launcher()
             .launch(&ref_proc_id, opts.clone())
@@ -2447,7 +2446,7 @@ mod tests {
             BoxedMailboxSender::new(router.clone()),
         );
         proc.clone().serve(proc_rx);
-        let proc_ref: ProcAddr = test_proc_id("client_0").into();
+        let proc_ref: ProcAddr = test_proc_id("client_0");
         router.bind(proc_ref, proc_addr.clone());
         let (client, _handle) = proc.instance("client").unwrap();
 
@@ -2508,7 +2507,7 @@ mod tests {
 
         use async_trait::async_trait;
         use hyperactor::ActorRef;
-        use hyperactor::ProcId;
+        use hyperactor::ProcAddr;
         use hyperactor::host::ProcHandle;
         use hyperactor::testing::ids::test_proc_id;
 
@@ -2531,7 +2530,7 @@ mod tests {
         impl ProcLauncher for TestProcLauncher {
             async fn launch(
                 &self,
-                _proc_id: &ProcId,
+                _proc_id: &ProcAddr,
                 _opts: LaunchOptions,
             ) -> Result<LaunchResult, ProcLauncherError> {
                 panic!("TestProcLauncher::launch should not be called in unit tests");
@@ -2539,13 +2538,13 @@ mod tests {
 
             async fn terminate(
                 &self,
-                _proc_id: &ProcId,
+                _proc_id: &ProcAddr,
                 _timeout: Duration,
             ) -> Result<(), ProcLauncherError> {
                 panic!("TestProcLauncher::terminate should not be called in unit tests");
             }
 
-            async fn kill(&self, _proc_id: &ProcId) -> Result<(), ProcLauncherError> {
+            async fn kill(&self, _proc_id: &ProcAddr) -> Result<(), ProcLauncherError> {
                 panic!("TestProcLauncher::kill should not be called in unit tests");
             }
         }
@@ -2557,7 +2556,7 @@ mod tests {
         // ensuring tests only exercise status transitions and not
         // actual process lifecycle.
         fn handle_for_test() -> BootstrapProcHandle {
-            let proc_id: ProcAddr = test_proc_id("0").into();
+            let proc_id: ProcAddr = test_proc_id("0");
             let launcher: Arc<dyn ProcLauncher> = Arc::new(TestProcLauncher);
             BootstrapProcHandle::new(proc_id, Arc::downgrade(&launcher))
         }
@@ -2648,7 +2647,7 @@ mod tests {
             let t0 = std::time::SystemTime::now();
             assert!(h.mark_running(t0));
             // Build a consistent AgentRef for Ready using the
-            // handle's ProcId.
+            // handle's ProcAddr.
             let proc_id = <BootstrapProcHandle as ProcHandle>::proc_id(&h);
             let actor_id = proc_id.actor_ref(crate::proc_agent::PROC_AGENT_ACTOR_NAME);
             let agent_ref: ActorRef<ProcAgent> = ActorRef::attest(actor_id);
@@ -2666,7 +2665,7 @@ mod tests {
             let t0 = std::time::SystemTime::now();
             assert!(h.mark_running(t0));
             // Build a consistent AgentRef for Ready using the
-            // handle's ProcId.
+            // handle's ProcAddr.
             let proc_id = <BootstrapProcHandle as ProcHandle>::proc_id(&h);
             let actor_id = proc_id.actor_ref(crate::proc_agent::PROC_AGENT_ACTOR_NAME);
             let agent: ActorRef<ProcAgent> = ActorRef::attest(actor_id);
@@ -2706,7 +2705,7 @@ mod tests {
     impl crate::proc_launcher::ProcLauncher for TestLauncher {
         async fn launch(
             &self,
-            _proc_id: &ProcId,
+            _proc_id: &ProcAddr,
             _opts: crate::proc_launcher::LaunchOptions,
         ) -> Result<crate::proc_launcher::LaunchResult, crate::proc_launcher::ProcLauncherError>
         {
@@ -2715,7 +2714,7 @@ mod tests {
 
         async fn terminate(
             &self,
-            _proc_id: &ProcId,
+            _proc_id: &ProcAddr,
             _timeout: std::time::Duration,
         ) -> Result<(), crate::proc_launcher::ProcLauncherError> {
             panic!("TestLauncher::terminate should not be called in unit tests");
@@ -2723,16 +2722,16 @@ mod tests {
 
         async fn kill(
             &self,
-            _proc_id: &ProcId,
+            _proc_id: &ProcAddr,
         ) -> Result<(), crate::proc_launcher::ProcLauncherError> {
             panic!("TestLauncher::kill should not be called in unit tests");
         }
     }
 
-    fn test_handle(proc_id: ProcId) -> BootstrapProcHandle {
+    fn test_handle(proc_id: ProcAddr) -> BootstrapProcHandle {
         let launcher: std::sync::Arc<dyn crate::proc_launcher::ProcLauncher> =
             std::sync::Arc::new(TestLauncher);
-        BootstrapProcHandle::new(proc_id.into(), std::sync::Arc::downgrade(&launcher))
+        BootstrapProcHandle::new(proc_id, std::sync::Arc::downgrade(&launcher))
     }
 
     #[tokio::test]
@@ -2957,7 +2956,7 @@ mod tests {
         }
     }
 
-    /// Create a ProcId and a host **backend_addr** channel that the
+    /// Create a ProcAddr and a host **backend_addr** channel that the
     /// bootstrap child proc will dial to attach its mailbox to the
     /// host.
     ///
@@ -2969,7 +2968,7 @@ mod tests {
     async fn make_proc_id_and_backend_addr(
         instance: &hyperactor::Instance<()>,
         _tag: &str,
-    ) -> (ProcId, ChannelAddr) {
+    ) -> (ProcAddr, ChannelAddr) {
         // Serve a Unix channel as the "backend_addr" and hook it into
         // this test proc.
         let (backend_addr, rx) = channel::serve(ChannelAddr::any(ChannelTransport::Unix)).unwrap();
@@ -2997,7 +2996,7 @@ mod tests {
         let (proc_id, backend_addr) = make_proc_id_and_backend_addr(&instance, "t_term").await;
         let handle = mgr
             .spawn(
-                proc_id.clone().into(),
+                proc_id.clone(),
                 backend_addr.clone(),
                 BootstrapProcConfig {
                     create_rank: 0,
@@ -3068,7 +3067,7 @@ mod tests {
         // Launch the child bootstrap process.
         let handle = mgr
             .spawn(
-                proc_id.clone().into(),
+                proc_id.clone(),
                 backend_addr.clone(),
                 BootstrapProcConfig {
                     create_rank: 0,
@@ -3169,7 +3168,7 @@ mod tests {
     impl ProcLauncher for DummyLauncher {
         async fn launch(
             &self,
-            _proc_id: &ProcId,
+            _proc_id: &ProcAddr,
             _opts: LaunchOptions,
         ) -> Result<LaunchResult, ProcLauncherError> {
             let (tx, rx) = tokio::sync::oneshot::channel();
@@ -3188,13 +3187,13 @@ mod tests {
 
         async fn terminate(
             &self,
-            _proc_id: &ProcId,
+            _proc_id: &ProcAddr,
             _timeout: Duration,
         ) -> Result<(), ProcLauncherError> {
             Ok(())
         }
 
-        async fn kill(&self, _proc_id: &ProcId) -> Result<(), ProcLauncherError> {
+        async fn kill(&self, _proc_id: &ProcAddr) -> Result<(), ProcLauncherError> {
             Ok(())
         }
     }

--- a/hyperactor_mesh/src/bootstrap/mailbox.rs
+++ b/hyperactor_mesh/src/bootstrap/mailbox.rs
@@ -116,7 +116,6 @@ mod tests {
 
     use std::assert_matches::assert_matches;
 
-    use hyperactor as hyperactor_reference;
     use hyperactor::Mailbox;
     use hyperactor::channel::ChannelAddr;
     use hyperactor::channel::ChannelTransport;
@@ -153,15 +152,13 @@ mod tests {
         // construct the IDs directly rather than via test_proc_id.
         let local_addr: ChannelAddr = "tcp:3.4.5.6:123".parse().unwrap();
         let first_actor_id =
-            hyperactor_reference::ProcId::from_resource_name(local_addr.clone(), first.to_string())
+            hyperactor::ProcAddr::from_resource_name(local_addr.clone(), first.to_string())
                 .actor_id("actor");
-        let second_actor_id = hyperactor_reference::ProcId::from_resource_name(
-            local_addr.clone(),
-            second.to_string(),
-        )
-        .actor_id("actor");
+        let second_actor_id =
+            hyperactor::ProcAddr::from_resource_name(local_addr.clone(), second.to_string())
+                .actor_id("actor");
         let third_notexist_actor_id =
-            hyperactor_reference::ProcId::from_resource_name(local_addr.clone(), third.to_string())
+            hyperactor::ProcAddr::from_resource_name(local_addr.clone(), third.to_string())
                 .actor_id("actor");
         let proc_dialer = LocalProcDialer::new(
             local_addr.clone(),
@@ -211,7 +208,7 @@ mod tests {
 
         // System proc on the host (name must be exactly "system"):
         let system_actor_id =
-            hyperactor_reference::ProcId::from_resource_name(local_addr.clone(), "system")
+            hyperactor::ProcAddr::from_resource_name(local_addr.clone(), "system")
                 .actor_id("actor");
         let envelope = MessageEnvelope::new(
             second_actor_id.clone(),

--- a/hyperactor_mesh/src/comm.rs
+++ b/hyperactor_mesh/src/comm.rs
@@ -22,7 +22,7 @@ use std::fmt::Debug;
 use anyhow::Result;
 use async_trait::async_trait;
 use hyperactor::Actor;
-use hyperactor::ActorId;
+use hyperactor::ActorAddr;
 use hyperactor::ActorRef;
 use hyperactor::Context;
 use hyperactor::Handler;
@@ -114,9 +114,9 @@ struct ReceiveState {
 )]
 pub struct CommActor {
     /// Sequence numbers are maintained for each (actor mesh id, sender).
-    send_seq: HashMap<(ActorMeshId, ActorId), usize>,
+    send_seq: HashMap<(ActorMeshId, ActorAddr), usize>,
     /// Each sender is a unique stream.
-    recv_state: HashMap<(ActorMeshId, ActorId), ReceiveState>,
+    recv_state: HashMap<(ActorMeshId, ActorAddr), ReceiveState>,
 
     /// The comm actor's mesh configuration, or buffered messages if not yet configured.
     mesh_config: MeshConfigState,
@@ -282,7 +282,7 @@ impl CommActor {
         config: &CommMeshConfig,
         deliver_here: bool,
         next_steps: HashMap<usize, Vec<RoutingFrame>>,
-        sender: ActorId,
+        sender: ActorAddr,
         mut message: CastMessageEnvelope,
         seq: usize,
         last_seqs: &mut HashMap<usize, usize>,
@@ -460,7 +460,7 @@ impl Handler<CastMessage> for CommActor {
 
         let fwd_message = ForwardMessage {
             dests: vec![frame],
-            sender: cx.self_id().clone().into(),
+            sender: cx.self_id().clone(),
             message: cast_message.message,
             seq: *seq,
             last_seq,
@@ -641,7 +641,7 @@ pub mod test_utils {
     use anyhow::Result;
     use async_trait::async_trait;
     use hyperactor::Actor;
-    use hyperactor::ActorId;
+    use hyperactor::ActorAddr;
     use hyperactor::Bind;
     use hyperactor::Context;
     use hyperactor::Handler;
@@ -655,7 +655,7 @@ pub mod test_utils {
 
     #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Named)]
     pub struct MyReply {
-        pub sender: ActorId,
+        pub sender: ActorAddr,
         pub value: u64,
     }
 
@@ -840,7 +840,7 @@ mod tests {
             let shape = ndslice::Shape::new(vec!["rank".to_string()], slice.clone()).unwrap();
             let envelope = multicast::CastMessageEnvelope::new::<TestActor, TestMessage>(
                 actor_mesh_id,
-                client.self_id().clone().into(),
+                client.self_id().clone(),
                 shape,
                 hyperactor_config::Flattrs::new(),
                 TestMessage::Forward(payload.to_string()),
@@ -869,7 +869,7 @@ mod tests {
             let shape = ndslice::Shape::new(vec!["rank".to_string()], slice.clone()).unwrap();
             let envelope = multicast::CastMessageEnvelope::new::<TestActor, TestMessage>(
                 actor_mesh_id,
-                client.self_id().clone().into(),
+                client.self_id().clone(),
                 shape,
                 hyperactor_config::Flattrs::new(),
                 TestMessage::Forward(payload.to_string()),
@@ -879,7 +879,7 @@ mod tests {
             let last_seq = next_seq;
             next_seq += 1;
             multicast::ForwardMessage {
-                sender: client.self_id().clone().into(),
+                sender: client.self_id().clone(),
                 dests: vec![frame],
                 seq: next_seq,
                 last_seq,
@@ -899,7 +899,7 @@ mod tests {
             let slice = Slice::new_row_major(vec![1]);
             let region = Region::new(vec!["rank".to_string()], slice.clone());
             let cast_msg = multicast::CastMessageV1::new::<TestActor, TestMessage>(
-                client.self_id().clone().into(),
+                client.self_id().clone(),
                 actor_mesh_id,
                 region.clone(),
                 hyperactor_config::Flattrs::new(),
@@ -917,13 +917,13 @@ mod tests {
         .await;
     }
 
-    use hyperactor::ActorId;
+    use hyperactor::ActorAddr;
     use hyperactor::ActorRef;
     use hyperactor::Index;
     use hyperactor::OncePortRef;
-    use hyperactor::PortId;
+    use hyperactor::PortAddr;
     use hyperactor::PortRef;
-    use hyperactor::ProcId;
+    use hyperactor::ProcAddr;
     use hyperactor::accum::Accumulator;
     use hyperactor::accum::ReducerSpec;
     use hyperactor::context;
@@ -950,8 +950,8 @@ mod tests {
     use crate::testing;
 
     // Helper to look up the rank for a given actor ID using the rank_lookup table.
-    fn lookup_rank(actor_id: &ActorId, rank_lookup: &HashMap<ProcId, usize>) -> usize {
-        let proc_id = actor_id.proc_id();
+    fn lookup_rank(actor_id: &ActorAddr, rank_lookup: &HashMap<ProcAddr, usize>) -> usize {
+        let proc_id = actor_id.proc_ref();
         *rank_lookup
             .get(&proc_id)
             .unwrap_or_else(|| panic!("proc rank not found for {}", proc_id))
@@ -971,11 +971,11 @@ mod tests {
 
     // The relationship between original ports and split ports. The elements in
     // the tuple are (original port, split port, deliver_here).
-    static SPLIT_PORT_TREE: OnceLock<Mutex<Vec<Edge<PortId>>>> = OnceLock::new();
+    static SPLIT_PORT_TREE: OnceLock<Mutex<Vec<Edge<PortAddr>>>> = OnceLock::new();
 
     // Collect the relationships between original ports and split ports into
     // SPLIT_PORT_TREE. This is used by tests to verify that ports are split as expected.
-    pub(crate) fn collect_split_port(original: &PortId, split: &PortId, deliver_here: bool) {
+    pub(crate) fn collect_split_port(original: &PortAddr, split: &PortAddr, deliver_here: bool) {
         let mutex = SPLIT_PORT_TREE.get_or_init(|| Mutex::new(vec![]));
         let mut tree = mutex.lock().unwrap();
 
@@ -991,7 +991,7 @@ mod tests {
     // tree so it will only contain the cast we want to check.
     fn clear_collected_tree() {
         if let Some(tree) = SPLIT_PORT_TREE.get() {
-            let mut tree: std::sync::MutexGuard<'_, Vec<Edge<PortId>>> = tree.lock().unwrap();
+            let mut tree: std::sync::MutexGuard<'_, Vec<Edge<PortAddr>>> = tree.lock().unwrap();
             tree.clear();
         }
     }
@@ -1105,14 +1105,14 @@ mod tests {
     //     2 -> 0, 2
     //     3 -> 0, 2, 3
     fn get_ranks(
-        paths: PathToLeaves<PortId>,
-        client_reply: &PortId,
-        rank_lookup: &HashMap<ProcId, usize>,
+        paths: PathToLeaves<PortAddr>,
+        client_reply: &PortAddr,
+        rank_lookup: &HashMap<ProcAddr, usize>,
     ) -> PathToLeaves<Index> {
         let ranks = paths
             .0
             .into_iter()
-            .map(|(dst, mut path): (PortId, Vec<PortId>)| {
+            .map(|(dst, mut path): (PortAddr, Vec<PortAddr>)| {
                 let first = path.remove(0);
                 // The first PortId is the client's reply port.
                 assert_eq!(&first, client_reply);
@@ -1121,7 +1121,7 @@ mod tests {
                 assert!(dst.actor_id().label().unwrap().as_str().contains("comm"));
                 let actor_path = path
                     .into_iter()
-                    .map(|p: PortId| {
+                    .map(|p: PortAddr| {
                         assert!(p.actor_id().label().unwrap().as_str().contains("comm"));
                         let actor_ref = p.actor_ref();
                         lookup_rank(&actor_ref, rank_lookup)
@@ -1159,7 +1159,7 @@ mod tests {
         extent: &Extent,
         reply_port_ref1: &PortRef<u64>,
         reply_port_ref2: &PortRef<MyReply>,
-        rank_lookup: &HashMap<ProcId, usize>,
+        rank_lookup: &HashMap<ProcAddr, usize>,
     ) {
         // Get the paths used in casting
         let sel_paths = PathToLeaves(
@@ -1222,7 +1222,7 @@ mod tests {
         // be received in the same order as they were sent out.
         {
             let n = 100;
-            let mut expected2: HashMap<ActorId, Vec<MyReply>> = hashmap! {};
+            let mut expected2: HashMap<ActorAddr, Vec<MyReply>> = hashmap! {};
             for (i, (dest_actor, (_reply_to1, reply_to2))) in
                 ranks.iter().zip(reply_tos.iter()).enumerate()
             {
@@ -1245,7 +1245,7 @@ mod tests {
                 );
             }
 
-            let mut received2: HashMap<ActorId, Vec<MyReply>> = hashmap! {};
+            let mut received2: HashMap<ActorAddr, Vec<MyReply>> = hashmap! {};
 
             for _ in 0..(n * ranks.len()) {
                 let my_reply = reply2_rx.recv().await.unwrap();
@@ -1412,7 +1412,7 @@ mod tests {
             .iter()
             .enumerate()
             .map(|(i, r)| (r.proc_id().clone(), i))
-            .collect::<HashMap<ProcId, usize>>();
+            .collect::<HashMap<ProcAddr, usize>>();
 
         // v1 always uses sel!(*) when casting to a mesh.
         let selection = sel!(*);

--- a/hyperactor_mesh/src/comm/multicast.rs
+++ b/hyperactor_mesh/src/comm/multicast.rs
@@ -9,7 +9,7 @@
 //! The comm actor that provides message casting and result accumulation.
 
 use hyperactor::Actor;
-use hyperactor::ActorId;
+use hyperactor::ActorAddr;
 use hyperactor::Context;
 use hyperactor::RemoteHandles;
 use hyperactor::RemoteMessage;
@@ -40,7 +40,7 @@ use crate::mesh_id::ActorMeshId;
 pub(crate) trait CastEnvelope {
     fn dest_port(&self) -> &DestinationPort;
     fn headers(&self) -> &Flattrs;
-    fn sender(&self) -> &ActorId;
+    fn sender(&self) -> &ActorAddr;
     fn cast_point(&self, config: &CommMeshConfig) -> anyhow::Result<Point>;
     fn data(&self) -> &ErasedUnbound;
     fn data_mut(&mut self) -> &mut ErasedUnbound;
@@ -66,7 +66,7 @@ pub struct CastMessageEnvelope {
     /// The end-to-end message headers.
     headers: Flattrs,
     /// The sender of this message.
-    sender: ActorId,
+    sender: ActorAddr,
     /// The destination port of the message. It could match multiple actors with
     /// rank wildcard.
     dest_port: DestinationPort,
@@ -78,7 +78,7 @@ pub struct CastMessageEnvelope {
 wirevalue::register_type!(CastMessageEnvelope);
 
 impl CastEnvelope for CastMessageEnvelope {
-    fn sender(&self) -> &ActorId {
+    fn sender(&self) -> &ActorAddr {
         &self.sender
     }
 
@@ -114,7 +114,7 @@ impl CastMessageEnvelope {
     /// Create a new CastMessageEnvelope.
     pub fn new<A, M>(
         actor_mesh_id: ActorMeshId,
-        sender: ActorId,
+        sender: ActorAddr,
         shape: Shape,
         headers: Flattrs,
         message: M,
@@ -140,7 +140,7 @@ impl CastMessageEnvelope {
     /// with the destination actors reply to the client actor directly.
     pub fn from_serialized(
         actor_mesh_id: ActorMeshId,
-        sender: ActorId,
+        sender: ActorAddr,
         dest_port: DestinationPort,
         shape: Shape,
         headers: Flattrs,
@@ -196,7 +196,7 @@ impl CastMessageEnvelope {
     /// The unique key used to indicate the stream to which to deliver this message.
     /// Concretely, the comm actors along the path should use this key to manage
     /// sequence numbers and reorder buffers.
-    pub(crate) fn stream_key(&self) -> (ActorMeshId, ActorId) {
+    pub(crate) fn stream_key(&self) -> (ActorMeshId, ActorAddr) {
         (self.actor_mesh_id.clone(), self.sender.clone())
     }
 }
@@ -256,7 +256,7 @@ wirevalue::register_type!(CastMessage);
 #[derive(Serialize, Deserialize, Debug, Clone, Named)]
 pub(crate) struct ForwardMessage {
     /// The comm actor who originally casted the message.
-    pub(crate) sender: ActorId,
+    pub(crate) sender: ActorAddr,
     /// The destination of the message.
     pub(crate) dests: Vec<RoutingFrame>,
     /// The sequence number of this message.
@@ -274,7 +274,7 @@ pub(crate) struct CastMessageV1 {
     /// The additional end-to-end message headers.
     pub(super) headers: Flattrs,
     /// The client who sent this message.
-    pub(super) sender: ActorId,
+    pub(super) sender: ActorAddr,
     /// The client-assigned session id of this message.
     pub(super) session_id: Uuid,
     /// The client-assigned sequence numbers of this message.
@@ -289,7 +289,7 @@ pub(crate) struct CastMessageV1 {
 }
 
 impl CastEnvelope for CastMessageV1 {
-    fn sender(&self) -> &ActorId {
+    fn sender(&self) -> &ActorAddr {
         &self.sender
     }
 
@@ -320,7 +320,7 @@ impl CastMessageV1 {
     /// Create a new CastMessageEnvelope.
     #[allow(unused)]
     pub(crate) fn new<A, M>(
-        sender: ActorId,
+        sender: ActorAddr,
         dest_mesh: &ActorMeshId,
         dest_region: Region,
         headers: Flattrs,
@@ -358,13 +358,13 @@ pub(super) struct ForwardMessageV1 {
 
 declare_attrs! {
     /// Used inside headers to store the originating sender of a cast.
-    pub attr CAST_ORIGINATING_SENDER: ActorId;
+    pub attr CAST_ORIGINATING_SENDER: ActorAddr;
 
     /// The point in the casted region that this message was sent to.
     pub attr CAST_POINT: Point;
 }
 
-pub fn set_cast_info_on_headers(headers: &mut Flattrs, cast_point: Point, sender: ActorId) {
+pub fn set_cast_info_on_headers(headers: &mut Flattrs, cast_point: Point, sender: ActorAddr) {
     // Pre-set the telemetry sender hash to the originating actor,
     // so post_unchecked() does not overwrite it with the comm actor.
     // TODO: consider merging SENDER_ACTOR_ID_HASH and
@@ -383,7 +383,7 @@ pub trait CastInfo {
     /// we represent it as the only member of a 0-dimensonal cast shape,
     /// which is the same as a singleton.
     fn cast_point(&self) -> Point;
-    fn sender(&self) -> ActorId;
+    fn sender(&self) -> ActorAddr;
 }
 
 impl<A: Actor> CastInfo for Context<'_, A> {
@@ -394,7 +394,7 @@ impl<A: Actor> CastInfo for Context<'_, A> {
         }
     }
 
-    fn sender(&self) -> ActorId {
+    fn sender(&self) -> ActorAddr {
         self.headers()
             .get(CAST_ORIGINATING_SENDER)
             .expect("has sender header")

--- a/hyperactor_mesh/src/connect.rs
+++ b/hyperactor_mesh/src/connect.rs
@@ -47,7 +47,7 @@ use futures::future;
 use futures::stream::FusedStream;
 use futures::task::Context;
 use futures::task::Poll;
-use hyperactor::ActorId;
+use hyperactor::ActorAddr;
 use hyperactor::OncePortRef;
 use hyperactor::PortRef;
 use hyperactor::context;
@@ -87,14 +87,14 @@ struct OwnedReadHalfStream {
 
 /// Wrap a `PortReceiver<IoMsg>` as a `AsyncRead`.
 pub struct OwnedReadHalf {
-    peer: ActorId,
+    peer: ActorAddr,
     inner: StreamReader<OwnedReadHalfStream, Cursor<Vec<u8>>>,
 }
 
 /// Wrap a `PortRef<IoMsg>` as a `AsyncWrite`.
 #[pin_project(PinnedDrop)]
 pub struct OwnedWriteHalf<C: context::Actor> {
-    peer: ActorId,
+    peer: ActorAddr,
     #[pin]
     caps: C,
     #[pin]
@@ -117,13 +117,13 @@ impl<C: context::Actor> ActorConnection<C> {
         (self.reader, self.writer)
     }
 
-    pub fn peer(&self) -> &ActorId {
+    pub fn peer(&self) -> &ActorAddr {
         self.reader.peer()
     }
 }
 
 impl OwnedReadHalf {
-    fn new(peer: ActorId, port: PortReceiver<Io>) -> Self {
+    fn new(peer: ActorAddr, port: PortReceiver<Io>) -> Self {
         Self {
             peer,
             inner: StreamReader::new(OwnedReadHalfStream {
@@ -133,7 +133,7 @@ impl OwnedReadHalf {
         }
     }
 
-    pub fn peer(&self) -> &ActorId {
+    pub fn peer(&self) -> &ActorAddr {
         &self.peer
     }
 
@@ -146,7 +146,7 @@ impl OwnedReadHalf {
 }
 
 impl<C: context::Actor> OwnedWriteHalf<C> {
-    fn new(peer: ActorId, caps: C, port: PortRef<Io>) -> Self {
+    fn new(peer: ActorAddr, caps: C, port: PortRef<Io>) -> Self {
         Self {
             peer,
             caps,
@@ -155,7 +155,7 @@ impl<C: context::Actor> OwnedWriteHalf<C> {
         }
     }
 
-    pub fn peer(&self) -> &ActorId {
+    pub fn peer(&self) -> &ActorAddr {
         &self.peer
     }
 
@@ -314,7 +314,7 @@ impl<C: context::Actor> ConnectionCompleter<C> {
 #[derive(Debug, Serialize, Deserialize, Named, Clone)]
 pub struct Connect {
     /// The ID of the client initiating the connection.
-    id: ActorId,
+    id: ActorAddr,
     conn: PortRef<Io>,
     /// The port the server can use to complete the connection.
     return_conn: OncePortRef<Accept>,
@@ -324,7 +324,7 @@ wirevalue::register_type!(Connect);
 impl Connect {
     /// Allocate a new `Connect` message and return the associated `ConnectionCompleter` that can be used
     /// to finish setting up the connection.
-    pub fn allocate<C: context::Actor>(id: ActorId, caps: C) -> (Self, ConnectionCompleter<C>) {
+    pub fn allocate<C: context::Actor>(id: ActorAddr, caps: C) -> (Self, ConnectionCompleter<C>) {
         let (conn_tx, conn_rx) = open_port::<Io>(&caps);
         let (return_tx, return_rx) = open_once_port::<Accept>(&caps);
         (
@@ -347,7 +347,7 @@ impl Connect {
 #[derive(Debug, Serialize, Deserialize, Named, Clone)]
 struct Accept {
     /// The ID of the server that accepted the connection.
-    id: ActorId,
+    id: ActorAddr,
     /// The port the client will use to send data over the connection to the server.
     conn: PortRef<Io>,
 }
@@ -371,7 +371,7 @@ impl Unbind for Connect {
 /// return `AsyncRead` and `AsyncWrite` streams that can be used to communicate with the other side.
 pub async fn accept<C: context::Actor>(
     caps: C,
-    self_id: ActorId,
+    self_id: ActorAddr,
     message: Connect,
 ) -> Result<ActorConnection<C>> {
     let (tx, rx) = open_port::<Io>(&caps);
@@ -414,7 +414,7 @@ mod tests {
             cx: &Context<Self>,
             message: Connect,
         ) -> Result<(), anyhow::Error> {
-            let (mut rd, mut wr) = accept(cx, cx.self_id().clone().into(), message)
+            let (mut rd, mut wr) = accept(cx, cx.self_id().clone(), message)
                 .await?
                 .into_split();
             tokio::io::copy(&mut rd, &mut wr).await?;
@@ -427,7 +427,7 @@ mod tests {
     async fn test_simple_connection() -> Result<()> {
         let proc = Proc::local();
         let (client, _) = proc.instance("client")?;
-        let (connect, completer) = Connect::allocate(client.self_id().clone().into(), client);
+        let (connect, completer) = Connect::allocate(client.self_id().clone(), client);
         let actor = proc.spawn("actor", EchoActor {})?;
         actor.send(&completer.caps, connect)?;
         let (mut rd, mut wr) = completer.complete().await?.into_split();
@@ -454,14 +454,10 @@ mod tests {
         let (client, _client_handle) = proc.instance("client")?;
 
         let (connect, completer) =
-            Connect::allocate(client.self_id().clone().into(), client.clone_for_py());
-        let (mut rd, _) = accept(
-            client.clone_for_py(),
-            client.self_id().clone().into(),
-            connect,
-        )
-        .await?
-        .into_split();
+            Connect::allocate(client.self_id().clone(), client.clone_for_py());
+        let (mut rd, _) = accept(client.clone_for_py(), client.self_id().clone(), connect)
+            .await?
+            .into_split();
         let (_, mut wr) = completer.complete().await?.into_split();
 
         // Write some data
@@ -485,14 +481,10 @@ mod tests {
         let (client, _client_handle) = proc.instance("client")?;
 
         let (connect, completer) =
-            Connect::allocate(client.self_id().clone().into(), client.clone_for_py());
-        let (mut rd, _) = accept(
-            client.clone_for_py(),
-            client.self_id().clone().into(),
-            connect,
-        )
-        .await?
-        .into_split();
+            Connect::allocate(client.self_id().clone(), client.clone_for_py());
+        let (mut rd, _) = accept(client.clone_for_py(), client.self_id().clone(), connect)
+            .await?
+            .into_split();
         let (_, mut wr) = completer.complete().await?.into_split();
 
         // Write some data

--- a/hyperactor_mesh/src/global_context.rs
+++ b/hyperactor_mesh/src/global_context.rs
@@ -396,7 +396,7 @@ async fn bootstrap_host() -> GlobalState {
     let proc_mesh = ProcMeshRef::new_singleton(
         ProcMeshId::singleton(Label::new("local").unwrap()),
         ProcRef::new(
-            local_proc_agent.actor_id().proc_ref().into(),
+            local_proc_agent.actor_id().proc_ref(),
             0,
             local_proc_agent.bind(),
         ),
@@ -531,7 +531,7 @@ mod tests {
     /// sink is shared across tests running in the same process).
     fn inject_undeliverable(
         client: &'static Instance<GlobalClientActor>,
-        dest_actor: hyperactor::ActorId,
+        dest_actor: hyperactor::ActorAddr,
     ) {
         let env = MessageEnvelope::new(
             client.self_id().clone(),
@@ -540,7 +540,7 @@ mod tests {
             Flattrs::new(),
         );
         // Target the global root client's well-known Undeliverable port.
-        let client_actor_id: hyperactor::ActorId = client.self_id().clone();
+        let client_actor_id: hyperactor::ActorAddr = client.self_id().clone();
         let undeliverable_port =
             PortRef::<Undeliverable<MessageEnvelope>>::attest_message_port(&client_actor_id);
         undeliverable_port

--- a/hyperactor_mesh/src/host_mesh.rs
+++ b/hyperactor_mesh/src/host_mesh.rs
@@ -35,8 +35,8 @@ use std::str::FromStr;
 use std::sync::Arc;
 use std::time::Duration;
 
-use hyperactor::ActorId;
-use hyperactor::ProcId;
+use hyperactor::ActorAddr;
+use hyperactor::ProcAddr;
 use hyperactor::channel::ChannelAddr;
 use hyperactor::context;
 use ndslice::Extent;
@@ -125,17 +125,17 @@ impl HostRef {
         )
     }
 
-    /// The ProcId for the proc with name `name` on this host.
-    fn named_proc(&self, id: &ResourceId) -> ProcId {
-        ProcId::new(
+    /// The ProcAddr for the proc with name `name` on this host.
+    fn named_proc(&self, id: &ResourceId) -> ProcAddr {
+        ProcAddr::new(
             hyperactor::id::ProcId::new(id.uid().clone(), id.label().cloned()),
             self.0.clone().into(),
         )
     }
 
     /// The service proc on this host.
-    fn service_proc(&self) -> ProcId {
-        ProcId::from_resource_name(self.0.clone(), SERVICE_PROC_NAME)
+    fn service_proc(&self) -> ProcAddr {
+        ProcAddr::from_resource_name(self.0.clone(), SERVICE_PROC_NAME)
     }
 
     /// Request an orderly teardown of this host and all procs it
@@ -1261,7 +1261,7 @@ impl HostMeshRef {
             // mesh can be preserved.
             let controller = ProcMeshController::new(mesh.deref().clone());
             // hyperactor::proc AI-3: controller name must include mesh
-            // identity for proc-wide ActorId uniqueness.
+            // identity for proc-wide ActorAddr uniqueness.
             let controller_name = format!("{}_{}", PROC_MESH_CONTROLLER_NAME, mesh.id());
             let controller_handle =
                 controller
@@ -1293,7 +1293,7 @@ impl HostMeshRef {
         &self,
         cx: &impl hyperactor::context::Actor,
         proc_mesh_id: &ProcMeshId,
-        procs: impl IntoIterator<Item = ProcId>,
+        procs: impl IntoIterator<Item = ProcAddr>,
         region: Region,
         reason: String,
     ) -> anyhow::Result<()> {
@@ -1409,13 +1409,13 @@ impl HostMeshRef {
     pub(crate) async fn proc_states(
         &self,
         cx: &impl context::Actor,
-        procs: impl IntoIterator<Item = ProcId>,
+        procs: impl IntoIterator<Item = ProcAddr>,
         region: Region,
     ) -> crate::Result<ValueMesh<resource::State<ProcState>>> {
         let (tx, mut rx) = cx.mailbox().open_port();
 
         let mut num_ranks = 0;
-        let procs: Vec<ProcId> = procs.into_iter().collect();
+        let procs: Vec<ProcAddr> = procs.into_iter().collect();
         let mut proc_names = Vec::new();
         for proc_id in procs.iter() {
             num_ranks += 1;
@@ -1510,15 +1510,15 @@ impl HostMeshRef {
     }
 }
 
-/// An ordered set of host entries, deduplicated by `HostAgent` `ActorId`
+/// An ordered set of host entries, deduplicated by `HostAgent` `ActorAddr`
 /// in first-seen order.
 ///
-/// Insertion is idempotent by construction — SA-3 (dedup by ActorId)
+/// Insertion is idempotent by construction — SA-3 (dedup by ActorAddr)
 /// is a property of this type, not a comment on careful control flow.
 /// First-seen order is preserved: the first occurrence of a given
-/// ActorId wins; subsequent duplicates are silently dropped.
+/// ActorAddr wins; subsequent duplicates are silently dropped.
 struct HostSet {
-    seen: HashSet<ActorId>,
+    seen: HashSet<ActorAddr>,
     entries: Vec<(String, ActorRef<HostAgent>)>,
 }
 
@@ -1530,7 +1530,7 @@ impl HostSet {
         }
     }
 
-    /// Insert a host entry. No-op if `ActorId` already present (SA-3).
+    /// Insert a host entry. No-op if `ActorAddr` already present (SA-3).
     /// First-seen order is preserved.
     fn insert(&mut self, addr: String, agent_ref: ActorRef<HostAgent>) {
         if self.seen.insert(agent_ref.actor_id().clone()) {
@@ -1551,7 +1551,7 @@ impl HostSet {
 }
 
 /// Ordered union of hosts from meshes and optional client host
-/// entries, deduplicated by `HostAgent` `ActorId` in first-seen
+/// entries, deduplicated by `HostAgent` `ActorAddr` in first-seen
 /// order.
 ///
 /// SA-3 dedup and SA-6 client-host merge are structural properties
@@ -1619,7 +1619,7 @@ pub async fn spawn_admin(
         crate::mesh_admin::MESH_ADMIN_ACTOR_NAME,
         crate::mesh_admin::MeshAdminAgent::new(
             hosts,
-            Some(root_client_id.into()),
+            Some(root_client_id),
             admin_addr,
             telemetry_url,
         ),
@@ -2023,7 +2023,7 @@ mod tests {
     }
 
     /// SA-3: `HostSet::insert` is idempotent — inserting the same
-    /// `ActorId` twice does not add a duplicate entry, and first-seen
+    /// `ActorAddr` twice does not add a duplicate entry, and first-seen
     /// order is preserved. This is a structural property of `HostSet`,
     /// not an invariant on `aggregate_hosts` control flow.
     #[test]
@@ -2044,7 +2044,7 @@ mod tests {
         assert_eq!(
             result.len(),
             2,
-            "SA-3: duplicate ActorId must not add entry"
+            "SA-3: duplicate ActorAddr must not add entry"
         );
         assert_eq!(
             result[0].0,

--- a/hyperactor_mesh/src/host_mesh/host_agent.rs
+++ b/hyperactor_mesh/src/host_mesh/host_agent.rs
@@ -448,18 +448,16 @@ impl HostAgent {
         // local appear as regular children; 's' in the TUI toggles
         // actor visibility, not proc visibility.
         children.push(hyperactor::introspect::IntrospectRef::Proc(
-            host.system_proc().proc_id().clone().into(),
+            host.system_proc().proc_id().clone(),
         ));
         children.push(hyperactor::introspect::IntrospectRef::Proc(
-            host.local_proc().proc_id().clone().into(),
+            host.local_proc().proc_id().clone(),
         ));
 
         // User procs.
         for state in self.created.values() {
             if let Ok((proc_id, _agent_ref)) = &state.created {
-                children.push(hyperactor::introspect::IntrospectRef::Proc(
-                    proc_id.clone().into(),
-                ));
+                children.push(hyperactor::introspect::IntrospectRef::Proc(proc_id.clone()));
             }
         }
 
@@ -552,10 +550,9 @@ impl Actor for HostAgent {
                     let mut system_actors: Vec<crate::introspect::NodeRef> = Vec::new();
                     for id in all_keys {
                         if proc.get_instance(&id).is_some_and(|cell| cell.is_system()) {
-                            system_actors
-                                .push(crate::introspect::NodeRef::Actor(id.clone().into()));
+                            system_actors.push(crate::introspect::NodeRef::Actor(id.clone()));
                         }
-                        actors.push(hyperactor::introspect::IntrospectRef::Actor(id.into()));
+                        actors.push(hyperactor::introspect::IntrospectRef::Actor(id));
                     }
                     let mut attrs = hyperactor_config::Attrs::new();
                     attrs.set(crate::introspect::NODE_TYPE, "proc".to_string());
@@ -592,12 +589,12 @@ impl Actor for HostAgent {
 
                     IntrospectResult {
                         identity: hyperactor::introspect::IntrospectRef::Proc(
-                            proc.proc_id().clone().into(),
+                            proc.proc_id().clone(),
                         ),
                         attrs: attrs_json,
                         children: actors,
                         parent: Some(hyperactor::introspect::IntrospectRef::Actor(
-                            self_id.clone().into(),
+                            self_id.clone(),
                         )),
                         as_of: std::time::SystemTime::now(),
                     }
@@ -610,14 +607,12 @@ impl Actor for HostAgent {
                         format!("child {} not found", child_ref),
                     );
                     let identity = match child_ref {
-                        Address::Proc(p) => {
-                            hyperactor::introspect::IntrospectRef::Proc(p.clone().into())
-                        }
+                        Address::Proc(p) => hyperactor::introspect::IntrospectRef::Proc(p.clone()),
                         Address::Actor(a) => {
-                            hyperactor::introspect::IntrospectRef::Actor(a.clone().into())
+                            hyperactor::introspect::IntrospectRef::Actor(a.clone())
                         }
                         Address::Port(p) => {
-                            hyperactor::introspect::IntrospectRef::Actor(p.actor_ref().into())
+                            hyperactor::introspect::IntrospectRef::Actor(p.actor_ref())
                         }
                     };
                     IntrospectResult {
@@ -1167,7 +1162,7 @@ impl Handler<ShutdownHost> for HostAgent {
 
 #[derive(Debug, Clone, PartialEq, Eq, Named, Serialize, Deserialize)]
 pub struct ProcState {
-    pub proc_id: hyperactor_reference::ProcId,
+    pub proc_id: hyperactor_reference::ProcAddr,
     pub create_rank: usize,
     pub mesh_agent: hyperactor_reference::ActorRef<ProcAgent>,
     pub bootstrap_command: Option<BootstrapCommand>,
@@ -1200,7 +1195,7 @@ impl Handler<resource::GetState<ProcState>> for HostAgent {
                     id: get_state.id.clone(),
                     status,
                     state: Some(ProcState {
-                        proc_id: proc_id.clone().into(),
+                        proc_id: proc_id.clone(),
                         create_rank: *rank,
                         mesh_agent: mesh_agent.clone(),
                         bootstrap_command,
@@ -1434,8 +1429,8 @@ mod tests {
                 }),
                 ..
             } if id == resource_id
-              && proc_id == hyperactor_reference::ProcId::from_resource_name(host_addr.clone(), id.to_string())
-              && mesh_agent == hyperactor_reference::ActorRef::attest(hyperactor_reference::ProcId::from_resource_name(host_addr.clone(), id.to_string()).actor_id(crate::proc_agent::PROC_AGENT_ACTOR_NAME)) && bootstrap_command == Some(BootstrapCommand::test())
+              && proc_id == hyperactor_reference::ProcAddr::from_resource_name(host_addr.clone(), id.to_string())
+              && mesh_agent == hyperactor_reference::ActorRef::attest(hyperactor_reference::ProcAddr::from_resource_name(host_addr.clone(), id.to_string()).actor_id(crate::proc_agent::PROC_AGENT_ACTOR_NAME)) && bootstrap_command == Some(BootstrapCommand::test())
               && mesh_agent == proc_status_mesh_agent
         );
     }
@@ -1831,7 +1826,7 @@ mod tests {
         // The host_agent has now processed messages on the service
         // proc. Query the service proc's introspection.
         let agent_ref = system_proc.proc_id().actor_ref(HOST_MESH_AGENT_ACTOR_NAME);
-        let agent_id: hyperactor_reference::ActorId = agent_ref.into();
+        let agent_id: hyperactor_reference::ActorAddr = agent_ref;
         let port =
             hyperactor_reference::PortRef::<IntrospectMessage>::attest_message_port(&agent_id);
 
@@ -1843,9 +1838,7 @@ mod tests {
             port.send(
                 &client,
                 IntrospectMessage::QueryChild {
-                    child_ref: hyperactor_reference::Reference::Proc(
-                        system_proc.proc_id().clone().into(),
-                    ),
+                    child_ref: hyperactor_reference::Address::Proc(system_proc.proc_id().clone()),
                     reply: reply_port.bind(),
                 },
             )

--- a/hyperactor_mesh/src/introspect.rs
+++ b/hyperactor_mesh/src/introspect.rs
@@ -67,13 +67,13 @@
 //!
 //! These govern the HTTP DTO layer in [`dto`].
 //!
-//! - **HB-1 (typed-internal, string-external):** `NodeRef`, `ActorId`,
-//!   `ProcId`, and `SystemTime` are typed Rust values internally. At the
+//! - **HB-1 (typed-internal, string-external):** `NodeRef`, `ActorAddr`,
+//!   `ProcAddr`, and `SystemTime` are typed Rust values internally. At the
 //!   HTTP JSON boundary, [`dto::NodePayloadDto`],
 //!   [`dto::NodePropertiesDto`], and [`dto::FailureInfoDto`] encode them
 //!   as canonical strings.
 //! - **HB-2 (round-trip):** The HTTP string forms round-trip through the
-//!   internal typed parsers (`NodeRef::from_str`, `ActorId::from_str`,
+//!   internal typed parsers (`NodeRef::from_str`, `ActorAddr::from_str`,
 //!   `humantime::parse_rfc3339`). Timestamps are formatted at
 //!   millisecond precision; sub-millisecond values are truncated at
 //!   the boundary.
@@ -220,7 +220,7 @@
 //!   contract.
 //!
 //! v1 contract notes:
-//! - The current py-spy bridge expects a ProcId-form reference and
+//! - The current py-spy bridge expects a ProcAddr-form reference and
 //!   rejects other forms as `bad_request`. This may be broadened in
 //!   future versions.
 //! - If `worker.send()` fails after the reply port has moved into
@@ -827,11 +827,11 @@ pub enum NodeRef {
     #[serde(rename = "root")]
     Root,
     /// A host in the mesh, identified by its `HostAgent` actor ID.
-    Host(hyperactor::ActorId),
+    Host(hyperactor::ActorAddr),
     /// A proc running on a host.
-    Proc(hyperactor::ProcId),
+    Proc(hyperactor::ProcAddr),
     /// An actor instance within a proc.
-    Actor(hyperactor::ActorId),
+    Actor(hyperactor::ActorAddr),
 }
 
 hyperactor_config::impl_attrvalue!(NodeRef);
@@ -853,11 +853,11 @@ pub enum NodeRefParseError {
     #[error("empty reference string")]
     Empty,
     #[error("invalid host reference: {0}")]
-    InvalidHost(hyperactor::ReferenceParsingError),
+    InvalidHost(hyperactor::AddrParseError),
     #[error("port references are not valid node references")]
     PortNotAllowed,
     #[error(transparent)]
-    Reference(#[from] hyperactor::ReferenceParsingError),
+    Reference(#[from] hyperactor::AddrParseError),
 }
 
 impl FromStr for NodeRef {
@@ -871,15 +871,15 @@ impl FromStr for NodeRef {
             return Ok(Self::Root);
         }
         if let Some(rest) = s.strip_prefix("host:") {
-            let actor_id: hyperactor::ActorId =
+            let actor_id: hyperactor::ActorAddr =
                 rest.parse().map_err(NodeRefParseError::InvalidHost)?;
             return Ok(Self::Host(actor_id));
         }
-        let r: hyperactor::Reference = s.parse()?;
+        let r: hyperactor::Address = s.parse()?;
         match r {
-            hyperactor::Reference::Proc(id) => Ok(Self::Proc(id)),
-            hyperactor::Reference::Actor(id) => Ok(Self::Actor(id)),
-            hyperactor::Reference::Port(_) => Err(NodeRefParseError::PortNotAllowed),
+            hyperactor::Address::Proc(id) => Ok(Self::Proc(id)),
+            hyperactor::Address::Actor(id) => Ok(Self::Actor(id)),
+            hyperactor::Address::Port(_) => Err(NodeRefParseError::PortNotAllowed),
         }
     }
 }
@@ -976,7 +976,7 @@ pub struct FailureInfo {
     /// Error message describing the failure.
     pub error_message: String,
     /// Actor that caused the failure (root cause).
-    pub root_cause_actor: hyperactor::ActorId,
+    pub root_cause_actor: hyperactor::ActorAddr,
     /// Display name of the root-cause actor, if available.
     pub root_cause_name: Option<String>,
     /// When the failure occurred.
@@ -1254,10 +1254,10 @@ mod tests {
     }
 
     fn test_actor_ref(proc_name: &str, actor_name: &str) -> NodeRef {
-        use hyperactor::ProcId;
+        use hyperactor::ProcAddr;
         use hyperactor::channel::ChannelAddr;
         NodeRef::Actor(
-            ProcId::from_resource_name(ChannelAddr::Local(0), proc_name).actor_id(actor_name),
+            ProcAddr::from_resource_name(ChannelAddr::Local(0), proc_name).actor_id(actor_name),
         )
     }
 
@@ -1649,7 +1649,7 @@ mod tests {
     /// SC-3: real payloads validate against the generated schema.
     #[test]
     fn test_payloads_validate_against_schema() {
-        use hyperactor::ProcId;
+        use hyperactor::ProcAddr;
         use hyperactor::channel::ChannelAddr;
 
         let schema = schemars::schema_for!(dto::NodePayloadDto);
@@ -1657,7 +1657,7 @@ mod tests {
         let compiled = jsonschema::JSONSchema::compile(&schema_value).expect("schema must compile");
 
         let epoch = std::time::UNIX_EPOCH;
-        let proc_id = ProcId::from_resource_name(ChannelAddr::Local(0), "worker");
+        let proc_id = ProcAddr::from_resource_name(ChannelAddr::Local(0), "worker");
         let actor_id = proc_id.actor_id("actor");
 
         let samples = [

--- a/hyperactor_mesh/src/introspect/dto.rs
+++ b/hyperactor_mesh/src/introspect/dto.rs
@@ -15,8 +15,8 @@
 //!
 //! ## Invariants
 //!
-//! - **HB-1 (typed-internal, string-external):** `NodeRef`, `ActorId`,
-//!   `ProcId`, and `SystemTime` are encoded as canonical strings in the
+//! - **HB-1 (typed-internal, string-external):** `NodeRef`, `ActorAddr`,
+//!   `ProcAddr`, and `SystemTime` are encoded as canonical strings in the
 //!   DTO types.
 //! - **HB-2 (round-trip):** `NodePayload → NodePayloadDto → NodePayload`
 //!   is lossless for values representable in the wire format.
@@ -462,15 +462,18 @@ mod tests {
 
     // Test fixtures
 
-    fn test_proc_id() -> hyperactor::ProcId {
-        hyperactor::ProcId::from_resource_name(hyperactor::channel::ChannelAddr::Local(0), "worker")
+    fn test_proc_id() -> hyperactor::ProcAddr {
+        hyperactor::ProcAddr::from_resource_name(
+            hyperactor::channel::ChannelAddr::Local(0),
+            "worker",
+        )
     }
 
-    fn test_actor_id() -> hyperactor::ActorId {
+    fn test_actor_id() -> hyperactor::ActorAddr {
         test_proc_id().actor_id("actor")
     }
 
-    fn test_host_actor_id() -> hyperactor::ActorId {
+    fn test_host_actor_id() -> hyperactor::ActorAddr {
         test_proc_id().actor_id("host_agent")
     }
 
@@ -686,7 +689,7 @@ mod tests {
         assert!(root["system_children"].as_array().unwrap().is_empty());
     }
 
-    /// HB-1: Actor variant with failure — ActorId, SystemTime, and
+    /// HB-1: Actor variant with failure — ActorAddr, SystemTime, and
     /// nested FailureInfo fields all serialize as strings.
     #[test]
     fn test_json_shape_actor_with_failure() {

--- a/hyperactor_mesh/src/lib.rs
+++ b/hyperactor_mesh/src/lib.rs
@@ -74,9 +74,9 @@ pub use global_context::context;
 pub use global_context::this_host;
 pub use global_context::this_proc;
 pub use host_mesh::HostMeshRef;
-use hyperactor::ActorId;
+use hyperactor::ActorAddr;
 use hyperactor::ActorRef;
-use hyperactor::ProcId;
+use hyperactor::ProcAddr;
 use hyperactor::host::HostError;
 use hyperactor::mailbox::MailboxSenderError;
 pub use hyperactor_mesh_macros::sel;
@@ -144,7 +144,7 @@ pub enum Error {
     UnroutableMesh(),
 
     #[error("error while calling actor {0}: {1}")]
-    CallError(ActorId, anyhow::Error),
+    CallError(ActorAddr, anyhow::Error),
 
     #[error("actor not registered for type {0}")]
     ActorTypeNotRegistered(String),
@@ -154,13 +154,13 @@ pub enum Error {
     GspawnError(mesh_id::ActorMeshId, String),
 
     #[error("error while sending message to actor {0}: {1}")]
-    SendingError(ActorId, Box<MailboxSenderError>),
+    SendingError(ActorAddr, Box<MailboxSenderError>),
 
     #[error("error while casting message to {0}: {1}")]
     CastingError(mesh_id::ActorMeshId, anyhow::Error),
 
     #[error("error configuring host mesh agent {0}: {1}")]
-    HostMeshAgentConfigurationError(ActorId, String),
+    HostMeshAgentConfigurationError(ActorAddr, String),
 
     #[error(
         "error creating proc (host rank {host_rank}) on host mesh agent {mesh_agent}, state: {state}"
@@ -196,7 +196,7 @@ pub enum Error {
     ControllerActorSpawnError(mesh_id::ResourceId, anyhow::Error),
 
     #[error("proc {0} must be direct-addressable")]
-    RankedProc(ProcId),
+    RankedProc(ProcAddr),
 
     #[error("{0}")]
     Supervision(Box<MeshFailure>),

--- a/hyperactor_mesh/src/logging.rs
+++ b/hyperactor_mesh/src/logging.rs
@@ -28,7 +28,7 @@ use hyperactor::HandleClient;
 use hyperactor::Handler;
 use hyperactor::Instance;
 use hyperactor::OncePortRef;
-use hyperactor::ProcId;
+use hyperactor::ProcAddr;
 use hyperactor::RefClient;
 use hyperactor::Unbind;
 use hyperactor::channel;
@@ -287,7 +287,7 @@ pub enum LogMessage {
     Log {
         /// The hostname of the process that generated the log
         hostname: String,
-        /// String representation of the ProcId that generated the log
+        /// String representation of the ProcAddr that generated the log
         proc_id: String,
         /// The target output stream (stdout or stderr)
         output_target: OutputTarget,
@@ -368,7 +368,7 @@ pub struct LocalLogSender {
 }
 
 impl LocalLogSender {
-    fn new(log_channel: ChannelAddr, proc_id: &ProcId) -> Result<Self, anyhow::Error> {
+    fn new(log_channel: ChannelAddr, proc_id: &ProcAddr) -> Result<Self, anyhow::Error> {
         let tx = channel::dial::<LogMessage>(log_channel)?;
         let status = tx.status().clone();
 
@@ -850,7 +850,7 @@ impl StreamFwder {
         target: OutputTarget,
         max_buffer_size: usize,
         log_channel: Option<ChannelAddr>,
-        proc_id: &ProcId,
+        proc_id: &ProcAddr,
         local_rank: usize,
     ) -> Self {
         let prefix = match hyperactor_config::global::get(PREFIX_WITH_RANK) {
@@ -879,7 +879,7 @@ impl StreamFwder {
         target: OutputTarget,
         max_buffer_size: usize,
         log_channel: Option<ChannelAddr>,
-        proc_id: &ProcId,
+        proc_id: &ProcAddr,
         prefix: Option<String>,
     ) -> Self {
         // Sanity: when there is no file sink, no log forwarding, and
@@ -1598,7 +1598,7 @@ mod tests {
             BoxedMailboxSender::new(router.clone()),
         );
         proc.clone().serve(client_rx);
-        let proc_ref: ProcAddr = test_proc_id("client_0").into();
+        let proc_ref: ProcAddr = test_proc_id("client_0");
         router.bind(proc_ref, proc_addr.clone());
         let (client, _handle) = proc.instance("client").unwrap();
 

--- a/hyperactor_mesh/src/mesh_admin.rs
+++ b/hyperactor_mesh/src/mesh_admin.rs
@@ -112,7 +112,7 @@
 //!
 //! **Routable** — an entity is routable if the system can address it
 //! via the routing layer and successfully deliver a message to it
-//! using a `Reference` / `ActorId` (i.e., there exists a live mailbox
+//! using a `Address` / `ActorAddr` (i.e., there exists a live mailbox
 //! sender reachable through normal routing). Practical test: "can I
 //! send `IntrospectMessage::Query` to it and get a reply?"
 //!
@@ -134,10 +134,10 @@
 //!
 //! A proc is not directly introspected; actors are. Tooling
 //! synthesizes proc-level nodes by grouping introspectable actors by
-//! `ProcId`.
+//! `ProcAddr`.
 //!
 //! A proc is visible iff there exists at least one actor on that proc
-//! whose `ActorId` is deliverable via the routing layer (i.e., the
+//! whose `ActorAddr` is deliverable via the routing layer (i.e., the
 //! actor has a bound mailbox sender reachable through normal routing)
 //! and responds to `IntrospectMessage`.
 //!
@@ -202,7 +202,7 @@
 //! When a proc reference is resolved, the returned `NodePayload`
 //! satisfies:
 //!
-//! - **SP-1 (identity):** The identity matches the ProcId reference
+//! - **SP-1 (identity):** The identity matches the ProcAddr reference
 //!   from the parent's children list.
 //! - **SP-2 (properties):** The properties are `NodeProperties::Proc`.
 //! - **SP-3 (parent):** The parent is `NodeRef::Host(actor_id)`.
@@ -248,14 +248,14 @@
 //!
 //! Let **A** denote the aggregated host set (the union of hosts
 //! from all meshes passed to [`host_mesh::spawn_admin`],
-//! deduplicated by `HostAgent` `ActorId` — see SA-3), and let
+//! deduplicated by `HostAgent` `ActorAddr` — see SA-3), and let
 //! **C** denote the process-global singleton client host mesh in
 //! the caller process (whose local proc hosts the root client
 //! actor).
 //!
 //! - **CH-1 (deduplication):** When C ∈ A, the client host appears
 //!   exactly once in the admin host list (deduplicated by `HostAgent`
-//!   `ActorId` identity). When C ∉ A, `spawn_admin` includes C
+//!   `ActorAddr` identity). When C ∉ A, `spawn_admin` includes C
 //!   alongside A's hosts so the admin introspects C as a normal host
 //!   subtree, not as a standalone proc.
 //!
@@ -282,7 +282,7 @@
 //! **Mechanism:** [`host_mesh::spawn_admin`] aggregates hosts from
 //! all input meshes (SA-3), reads C from the caller process (via
 //! `try_this_host()`), merges it with the aggregated set (SA-6),
-//! deduplicates by `HostAgent` `ActorId`, and spawns the
+//! deduplicates by `HostAgent` `ActorAddr`, and spawns the
 //! `MeshAdminAgent` on the caller's local proc via
 //! `cx.instance().proc().spawn(...)`. Placement now follows the
 //! caller context rather than mesh topology.
@@ -298,7 +298,7 @@
 //!   least one host.
 //! - **SA-3 (host-agent identity dedup):** The admin host set is
 //!   the ordered union of host agents from all input meshes,
-//!   deduplicated by `HostAgent` `ActorId` in first-seen order.
+//!   deduplicated by `HostAgent` `ActorAddr` in first-seen order.
 //! - **SA-4 (single-mesh degeneracy):** `spawn_admin([mesh], ...)`
 //!   is behaviorally equivalent to the former `mesh.spawn_admin(...)`.
 //!   Established by existing single-mesh integration tests (e.g.
@@ -392,13 +392,12 @@ use crate::pyspy::ValidatedProfileRequest;
 /// Encapsulates open_once_port + send + timeout + error handling.
 async fn query_introspect(
     cx: &hyperactor::Context<'_, MeshAdminAgent>,
-    actor_id: &hyperactor_reference::ActorId,
+    actor_id: &hyperactor::ActorAddr,
     view: hyperactor::introspect::IntrospectView,
     timeout: Duration,
     err_ctx: &str,
 ) -> Result<IntrospectResult, anyhow::Error> {
-    let introspect_port =
-        hyperactor_reference::PortRef::<IntrospectMessage>::attest_message_port(actor_id);
+    let introspect_port = hyperactor::PortRef::<IntrospectMessage>::attest_message_port(actor_id);
     let (reply_handle, reply_rx) = open_once_port::<IntrospectResult>(cx);
     let mut reply_ref = reply_handle.bind();
     reply_ref.return_undeliverable(false);
@@ -418,13 +417,12 @@ async fn query_introspect(
 /// Send an `IntrospectMessage::QueryChild` to an actor.
 async fn query_child_introspect(
     cx: &hyperactor::Context<'_, MeshAdminAgent>,
-    actor_id: &hyperactor_reference::ActorId,
-    child_ref: hyperactor_reference::Reference,
+    actor_id: &hyperactor::ActorAddr,
+    child_ref: hyperactor::Address,
     timeout: Duration,
     err_ctx: &str,
 ) -> Result<IntrospectResult, anyhow::Error> {
-    let introspect_port =
-        hyperactor_reference::PortRef::<IntrospectMessage>::attest_message_port(actor_id);
+    let introspect_port = hyperactor::PortRef::<IntrospectMessage>::attest_message_port(actor_id);
     let (reply_handle, reply_rx) = open_once_port::<IntrospectResult>(cx);
     let mut reply_ref = reply_handle.bind();
     reply_ref.return_undeliverable(false);
@@ -565,8 +563,8 @@ wirevalue::register_type!(ResolveReferenceResponse);
 /// `NodePayload`.
 ///
 /// This is the primary “navigation” request used by the admin HTTP
-/// bridge: the caller provides a reference (e.g. `"root"`, a `ProcId`
-/// string, or an `ActorId` string) and the `MeshAdminAgent` returns a
+/// bridge: the caller provides a reference (e.g. `"root"`, a `ProcAddr`
+/// string, or an `ActorAddr` string) and the `MeshAdminAgent` returns a
 /// uniformly shaped `NodePayload` plus child references to continue
 /// walking the topology.
 ///
@@ -594,7 +592,7 @@ pub enum ResolveReferenceMessage {
     /// On success the reply contains `payload=Some(..), error=None`; on failure
     /// it contains `payload=None, error=Some(..)`.
     Resolve {
-        /// Reference string from the HTTP path, parsed into a typed
+        /// Address string from the HTTP path, parsed into a typed
         /// `NodeRef` at the resolve boundary.
         reference_string: String,
         /// Reply port receiving the resolution result.
@@ -622,28 +620,28 @@ pub struct MeshAdminAgent {
     /// fan out our target admin queries.
     hosts: HashMap<String, hyperactor_reference::ActorRef<HostAgent>>,
 
-    /// Reverse index: `HostAgent` `ActorId` → host address
+    /// Reverse index: `HostAgent` `ActorAddr` → host address
     /// string.
     ///
     /// The host agent itself is an actor that can appear in multiple
     /// places (e.g., as a host node and as a child actor under a
     /// system proc). This index lets reference resolution treat that
-    /// `ActorId` as a *Host* node (via `resolve_host_node`) rather
+    /// `ActorAddr` as a *Host* node (via `resolve_host_node`) rather
     /// than a generic *Actor* node, avoiding cycles / dropped nodes
     /// in clients like the TUI.
-    host_agents_by_actor_id: HashMap<hyperactor_reference::ActorId, String>,
+    host_agents_by_actor_id: HashMap<hyperactor::ActorAddr, String>,
 
-    /// `ActorId` of the process-global root client (`client[0]` on
+    /// `ActorAddr` of the process-global root client (`client[0]` on
     /// the singleton Host's `local_proc`), exposed as a first-class
     /// child of the root node. Routable and introspectable via the
     /// blanket `Handler<IntrospectMessage>`.
-    root_client_actor_id: Option<hyperactor_reference::ActorId>,
+    root_client_actor_id: Option<hyperactor::ActorAddr>,
 
-    /// This agent's own `ActorId`, captured during `init`. Used to
+    /// This agent's own `ActorAddr`, captured during `init`. Used to
     /// include the admin proc as a visible node in the introspection
     /// tree (the principle: "if you can send it a message, you can
     /// introspect it").
-    self_actor_id: Option<hyperactor_reference::ActorId>,
+    self_actor_id: Option<hyperactor::ActorAddr>,
 
     // -- HTTP server address fields --
     //
@@ -685,13 +683,13 @@ pub struct MeshAdminAgent {
 
 impl MeshAdminAgent {
     /// Construct a `MeshAdminAgent` from a list of `(host_addr,
-    /// host_agent_ref)` pairs and an optional root client `ActorId`.
+    /// host_agent_ref)` pairs and an optional root client `ActorAddr`.
     ///
     /// Builds both:
     /// - `hosts`: the forward map used to route admin queries to the
     ///   correct `HostAgent`, and
     /// - `host_agents_by_actor_id`: a reverse index used during
-    ///   reference resolution to recognize host-agent `ActorId`s and
+    ///   reference resolution to recognize host-agent `ActorAddr`s and
     ///   resolve them as `NodeProperties::Host` rather than as
     ///   generic actors.
     ///
@@ -703,11 +701,11 @@ impl MeshAdminAgent {
     /// during `init()` after the server socket is bound.
     pub fn new(
         hosts: Vec<(String, hyperactor_reference::ActorRef<HostAgent>)>,
-        root_client_actor_id: Option<hyperactor_reference::ActorId>,
+        root_client_actor_id: Option<hyperactor::ActorAddr>,
         admin_addr: Option<std::net::SocketAddr>,
         telemetry_url: Option<String>,
     ) -> Self {
-        let host_agents_by_actor_id: HashMap<hyperactor_reference::ActorId, String> = hosts
+        let host_agents_by_actor_id: HashMap<hyperactor::ActorAddr, String> = hosts
             .iter()
             .map(|(addr, agent_ref)| (agent_ref.actor_id().clone(), addr.clone()))
             .collect();
@@ -756,9 +754,9 @@ impl std::fmt::Debug for MeshAdminAgent {
 /// host, so `host` always derives from `url` at construction.
 #[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct AdminInfo {
-    /// Stringified `ActorId` of the `MeshAdminAgent`.
+    /// Stringified `ActorAddr` of the `MeshAdminAgent`.
     pub actor_id: String,
-    /// Stringified `ProcId` of the proc hosting `MeshAdminAgent`.
+    /// Stringified `ProcAddr` of the proc hosting `MeshAdminAgent`.
     pub proc_id: String,
     /// Hostname the admin HTTP server bound on (derived from `url`).
     pub host: String,
@@ -798,7 +796,7 @@ impl AdminInfo {
 /// resolution happens inside the actor message loop (with access to
 /// actor messaging, timeouts, and indices).
 struct BridgeState {
-    /// Reference to the `MeshAdminAgent` actor that performs
+    /// Address to the `MeshAdminAgent` actor that performs
     /// reference resolution.
     admin_ref: hyperactor_reference::ActorRef<MeshAdminAgent>,
     /// Dedicated client mailbox on system_proc for HTTP bridge reply
@@ -929,7 +927,7 @@ impl Actor for MeshAdminAgent {
         // as soon as the admin is reachable.
         this.bind::<Self>();
         this.set_system();
-        self.self_actor_id = Some(this.self_id().clone().into());
+        self.self_actor_id = Some(this.self_id().clone());
 
         let bind_addr = match self.admin_addr_override {
             Some(addr) => addr,
@@ -1185,7 +1183,7 @@ impl MeshAdminAgent {
     ///
     /// The root client is no longer standalone: spawn_admin registers
     /// C (the bootstrap host) as a normal host entry (A/C invariant).
-    fn standalone_proc_actors(&self) -> impl Iterator<Item = &hyperactor_reference::ActorId> {
+    fn standalone_proc_actors(&self) -> impl Iterator<Item = &hyperactor::ActorAddr> {
         std::iter::empty()
     }
 
@@ -1193,14 +1191,14 @@ impl MeshAdminAgent {
     /// actor on that proc. Returns `None` for host-managed procs.
     fn standalone_proc_anchor(
         &self,
-        proc_id: &hyperactor_reference::ProcId,
-    ) -> Option<&hyperactor_reference::ActorId> {
+        proc_id: &hyperactor_reference::ProcAddr,
+    ) -> Option<&hyperactor::ActorAddr> {
         self.standalone_proc_actors()
             .find(|actor_id| actor_id.proc_id() == *proc_id)
     }
 
     /// Returns true if `actor_id` lives on a standalone proc.
-    fn is_standalone_proc_actor(&self, actor_id: &hyperactor_reference::ActorId) -> bool {
+    fn is_standalone_proc_actor(&self, actor_id: &hyperactor::ActorAddr) -> bool {
         self.standalone_proc_actors()
             .any(|a| a.proc_id() == actor_id.proc_id())
     }
@@ -1248,7 +1246,7 @@ impl MeshAdminAgent {
     async fn resolve_host_node(
         &self,
         cx: &Context<'_, Self>,
-        actor_id: &hyperactor_reference::ActorId,
+        actor_id: &hyperactor::ActorAddr,
     ) -> Result<NodePayload, anyhow::Error> {
         let result = query_introspect(
             cx,
@@ -1265,20 +1263,20 @@ impl MeshAdminAgent {
         ))
     }
 
-    /// Resolve a `ProcId` reference into a proc-level `NodePayload`.
+    /// Resolve a `ProcAddr` reference into a proc-level `NodePayload`.
     ///
     /// First tries `IntrospectMessage::QueryChild` against the owning
     /// `HostAgent` (which recognizes service and local procs). If
     /// that returns an error payload, falls back to `ProcAgent` for
     /// user procs by querying
-    /// `QueryChild(hyperactor_reference::Reference::Proc(proc_id))`
+    /// `QueryChild(hyperactor::Address::Proc(proc_id))`
     /// on `<proc_id>/proc_agent[0]`.
     ///
     /// See PA-1 in module doc.
     async fn resolve_proc_node(
         &self,
         cx: &Context<'_, Self>,
-        proc_id: &hyperactor_reference::ProcId,
+        proc_id: &hyperactor_reference::ProcAddr,
     ) -> Result<NodePayload, anyhow::Error> {
         let host_addr = proc_id.addr().to_string();
 
@@ -1291,7 +1289,7 @@ impl MeshAdminAgent {
         let result = query_child_introspect(
             cx,
             agent.actor_id(),
-            hyperactor_reference::Reference::Proc(proc_id.clone()),
+            hyperactor::Address::Proc(proc_id.clone()),
             hyperactor_config::global::get(crate::config::MESH_ADMIN_QUERY_CHILD_TIMEOUT),
             "querying proc details",
         )
@@ -1314,7 +1312,7 @@ impl MeshAdminAgent {
         let result = query_child_introspect(
             cx,
             &mesh_agent_id,
-            hyperactor_reference::Reference::Proc(proc_id.clone()),
+            hyperactor::Address::Proc(proc_id.clone()),
             hyperactor_config::global::get(crate::config::MESH_ADMIN_RESOLVE_ACTOR_TIMEOUT),
             "querying proc mesh agent",
         )
@@ -1343,7 +1341,7 @@ impl MeshAdminAgent {
     async fn resolve_standalone_proc_node(
         &self,
         cx: &Context<'_, Self>,
-        proc_id: &hyperactor_reference::ProcId,
+        proc_id: &hyperactor_reference::ProcAddr,
     ) -> Result<NodePayload, anyhow::Error> {
         let actor_id = self
             .standalone_proc_anchor(proc_id)
@@ -1437,7 +1435,7 @@ impl MeshAdminAgent {
         })
     }
 
-    /// Resolve a non-host-agent `ActorId` reference into an
+    /// Resolve a non-host-agent `ActorAddr` reference into an
     /// actor-level `NodePayload`.
     ///
     /// Sends `IntrospectMessage::Query` directly to the target actor
@@ -1449,11 +1447,11 @@ impl MeshAdminAgent {
     /// The resolver sets `parent` based on the actor's position
     /// in the topology: if the actor lives in a system proc, the
     /// parent is the system proc ref; otherwise it's the proc's
-    /// `ProcId` string.
+    /// `ProcAddr` string.
     async fn resolve_actor_node(
         &self,
         cx: &Context<'_, Self>,
-        actor_id: &hyperactor_reference::ActorId,
+        actor_id: &hyperactor::ActorAddr,
     ) -> Result<NodePayload, anyhow::Error> {
         // Self-resolution: we cannot send IntrospectMessage to our
         // own actor loop while handling a resolve request (deadlock).
@@ -1478,7 +1476,7 @@ impl MeshAdminAgent {
             let terminated = query_child_introspect(
                 cx,
                 &mesh_agent_id,
-                hyperactor_reference::Reference::Actor(actor_id.clone()),
+                hyperactor::Address::Actor(actor_id.clone()),
                 hyperactor_config::global::get(crate::config::MESH_ADMIN_QUERY_CHILD_TIMEOUT),
                 "querying terminated snapshot",
             )
@@ -1768,7 +1766,7 @@ pub fn build_openapi_spec() -> serde_json::Value {
         "info": {
             "title": "Monarch Mesh Admin API",
             "version": "1.0.0",
-            "description": "Reference-walking introspection API for a Monarch actor mesh. See the Admin Gateway Pattern RFC."
+            "description": "Address-walking introspection API for a Monarch actor mesh. See the Admin Gateway Pattern RFC."
         },
         "paths": {
             "/v1/root": {
@@ -1797,7 +1795,7 @@ pub fn build_openapi_spec() -> serde_json::Value {
                     "responses": {
                         "200": success_payload,
                         "400": error_response("Bad request (malformed reference)"),
-                        "404": error_response("Reference not found"),
+                        "404": error_response("Address not found"),
                         "500": error_response("Internal error"),
                         "503": error_response("Service unavailable (at capacity, retry with backoff)"),
                         "504": error_response("Gateway timeout (downstream host unresponsive)")
@@ -1866,7 +1864,7 @@ pub fn build_openapi_spec() -> serde_json::Value {
                         "name": "proc_reference",
                         "in": "path",
                         "required": true,
-                        "description": "URL-encoded proc reference (ProcId)",
+                        "description": "URL-encoded proc reference (ProcAddr)",
                         "schema": { "type": "string" }
                     }],
                     "responses": {
@@ -1911,7 +1909,7 @@ pub fn build_openapi_spec() -> serde_json::Value {
                         "name": "proc_reference",
                         "in": "path",
                         "required": true,
-                        "description": "URL-encoded proc reference (ProcId)",
+                        "description": "URL-encoded proc reference (ProcAddr)",
                         "schema": { "type": "string" }
                     }],
                     "responses": {
@@ -1968,7 +1966,7 @@ pub fn build_openapi_spec() -> serde_json::Value {
                         "name": "proc_reference",
                         "in": "path",
                         "required": true,
-                        "description": "URL-encoded proc reference (ProcId)",
+                        "description": "URL-encoded proc reference (ProcAddr)",
                         "schema": { "type": "string" }
                     }],
                     "responses": {
@@ -2022,7 +2020,7 @@ pub fn build_openapi_spec() -> serde_json::Value {
                         "name": "proc_reference",
                         "in": "path",
                         "required": true,
-                        "description": "URL-encoded proc reference (ProcId)",
+                        "description": "URL-encoded proc reference (ProcAddr)",
                         "schema": { "type": "string" }
                     }],
                     "requestBody": {
@@ -2058,8 +2056,8 @@ async fn serve_openapi() -> Result<axum::response::Json<serde_json::Value>, ApiE
 }
 
 /// Validate and parse a raw proc reference path segment into a
-/// decoded reference string and `ProcId`. Extracted for testability.
-fn parse_proc_reference(raw: &str) -> Result<(String, hyperactor_reference::ProcId), ApiError> {
+/// decoded reference string and `ProcAddr`. Extracted for testability.
+fn parse_proc_reference(raw: &str) -> Result<(String, hyperactor_reference::ProcAddr), ApiError> {
     let trimmed = raw.trim_start_matches('/');
     if trimmed.is_empty() {
         return Err(ApiError::bad_request("empty proc reference", None));
@@ -2072,7 +2070,7 @@ fn parse_proc_reference(raw: &str) -> Result<(String, hyperactor_reference::Proc
                 None,
             )
         })?;
-    let proc_id: hyperactor_reference::ProcId = decoded
+    let proc_id: hyperactor_reference::ProcAddr = decoded
         .parse()
         .map_err(|e| ApiError::bad_request(format!("invalid proc reference: {}", e), None))?;
     Ok((decoded, proc_id))
@@ -2087,9 +2085,9 @@ fn parse_proc_reference(raw: &str) -> Result<(String, hyperactor_reference::Proc
 /// infrastructure problem, not an absent actor.
 async fn probe_actor(
     cx: &Instance<()>,
-    agent_id: &hyperactor_reference::ActorId,
+    agent_id: &hyperactor::ActorAddr,
 ) -> Result<bool, ApiError> {
-    let port = hyperactor_reference::PortRef::<IntrospectMessage>::attest_message_port(agent_id);
+    let port = hyperactor::PortRef::<IntrospectMessage>::attest_message_port(agent_id);
     let (handle, rx) = open_once_port::<IntrospectResult>(cx);
     port.send(
         cx,
@@ -2144,7 +2142,7 @@ enum ResolvedProcHandler {
 }
 
 impl ResolvedProcHandler {
-    fn agent_id(&self) -> hyperactor_reference::ActorId {
+    fn agent_id(&self) -> hyperactor::ActorAddr {
         match self {
             Self::Host(r) => r.actor_id().clone(),
             Self::Proc(r) => r.actor_id().clone(),
@@ -2855,11 +2853,11 @@ async fn tree_dump(
 /// `HostAgent`'s children list:
 ///
 /// - System proc ref `"[system] unix:@hash,service"` → `"service"`
-/// - ProcAgent ActorId `"unix:@hash,my_proc,agent[0]"` →
+/// - ProcAgent ActorAddr `"unix:@hash,my_proc,agent[0]"` →
 ///   `"my_proc"`
-/// - Bare ProcId `"unix:@hash,my_proc"` → `"my_proc"`
+/// - Bare ProcAddr `"unix:@hash,my_proc"` → `"my_proc"`
 ///
-/// Note: `ActorId::Display` for `ProcId` uses commas as
+/// Note: `ActorAddr::Display` for `ProcAddr` uses commas as
 /// separators (`proc_id,actor_name[idx]`), not slashes.
 fn derive_tree_label(node_ref: &crate::introspect::NodeRef) -> String {
     match node_ref {
@@ -3295,7 +3293,7 @@ mod tests {
     // End-to-end smoke test for MeshAdminAgent::resolve that walks
     // the reference tree: root → host → system proc → host-agent
     // cross-reference. Verifies the reverse index routes the
-    // HostAgent ActorId to NodeProperties::Host (not Actor),
+    // HostAgent ActorAddr to NodeProperties::Host (not Actor),
     // preventing the TUI's cycle detection from dropping that node.
     #[tokio::test]
     async fn test_resolve_reference_tree_walk() {
@@ -3487,10 +3485,8 @@ mod tests {
                 .await
                 .unwrap();
         let host_addr = host.addr().clone();
-        let system_proc_id: hyperactor_reference::ProcId =
-            host.system_proc().proc_id().clone().into();
-        let local_proc_id: hyperactor_reference::ProcId =
-            host.local_proc().proc_id().clone().into();
+        let system_proc_id: hyperactor_reference::ProcAddr = host.system_proc().proc_id().clone();
+        let local_proc_id: hyperactor_reference::ProcAddr = host.local_proc().proc_id().clone();
         let system_proc = host.system_proc().clone();
         let host_agent_handle = system_proc
             .spawn(
@@ -3592,14 +3588,13 @@ mod tests {
     fn test_build_root_payload_with_root_client() {
         let addr1: SocketAddr = "127.0.0.1:9001".parse().unwrap();
         let proc1 =
-            hyperactor_reference::ProcId::from_resource_name(ChannelAddr::Tcp(addr1), "host1");
-        let actor_id1 =
-            hyperactor_reference::ActorId::root(proc1, Label::new("mesh_agent").unwrap());
+            hyperactor_reference::ProcAddr::from_resource_name(ChannelAddr::Tcp(addr1), "host1");
+        let actor_id1 = hyperactor::ActorAddr::root(proc1, Label::new("mesh_agent").unwrap());
         let ref1: hyperactor_reference::ActorRef<HostAgent> =
             hyperactor_reference::ActorRef::attest(actor_id1.clone());
 
         let client_proc_id =
-            hyperactor_reference::ProcId::from_resource_name(ChannelAddr::Tcp(addr1), "local");
+            hyperactor_reference::ProcAddr::from_resource_name(ChannelAddr::Tcp(addr1), "local");
         let client_actor_id = client_proc_id.actor_id("client");
 
         let agent = MeshAdminAgent::new(
@@ -3666,7 +3661,7 @@ mod tests {
         let host_addr_str = host_addr.to_string();
 
         // Spawn MeshAdminAgent on a dedicated test proc with the root
-        // client ActorId. NOTE: Does not conform to SA-5 (caller-local
+        // client ActorAddr. NOTE: Does not conform to SA-5 (caller-local
         // placement). Production uses host_mesh::spawn_admin().
         // White-box test of root-client visibility, not placement.
         let admin_proc =
@@ -3711,7 +3706,7 @@ mod tests {
             .await
             .unwrap();
         let host_node = host_resp.0.unwrap();
-        let local_proc_node_ref = crate::introspect::NodeRef::Proc(local_proc_id.clone().into());
+        let local_proc_node_ref = crate::introspect::NodeRef::Proc(local_proc_id.clone());
         assert!(
             host_node.children.contains(&local_proc_node_ref),
             "host children {:?} should contain local proc {:?}",
@@ -3983,7 +3978,7 @@ mod tests {
         );
 
         // -- 6. Verify host children contain the system proc --
-        let expected_system_ref = crate::introspect::NodeRef::Proc(system_proc_id.clone().into());
+        let expected_system_ref = crate::introspect::NodeRef::Proc(system_proc_id.clone());
         assert!(
             host_node.children.contains(&expected_system_ref),
             "host children {:?} should contain the system proc ref {:?}",
@@ -4283,7 +4278,7 @@ mod tests {
 
         // Resolve the user proc via MeshAdminAgent. HostMeshAgent
         // returns Error for QueryChild → fallback to proc_agent[0]
-        // QueryChild(Reference::Proc) → live NodeProperties::Proc.
+        // QueryChild(Address::Proc) → live NodeProperties::Proc.
         let user_proc_ref = user_proc.proc_id().to_string();
         let resp = admin_ref
             .resolve(&client, user_proc_ref.clone())
@@ -4342,7 +4337,7 @@ mod tests {
     //
     // Tests for the v1 proc-reference strictness contract (see
     // introspect module doc): the py-spy bridge accepts only
-    // ProcId-form references and rejects other forms as bad_request.
+    // ProcAddr-form references and rejects other forms as bad_request.
 
     #[test]
     fn pyspy_parse_empty_reference() {
@@ -4371,7 +4366,7 @@ mod tests {
 
     #[test]
     fn pyspy_parse_invalid_proc_id() {
-        // v1 contract: non-ProcId reference → bad_request.
+        // v1 contract: non-ProcAddr reference → bad_request.
         let err = parse_proc_reference("not-a-valid-proc-id").unwrap_err();
         assert_eq!(err.code, "bad_request");
         assert!(err.message.contains("invalid proc reference"));
@@ -4379,7 +4374,7 @@ mod tests {
 
     #[test]
     fn pyspy_parse_valid_proc_reference() {
-        // v1 contract: valid ProcId → accepted.
+        // v1 contract: valid ProcAddr → accepted.
         let addr: SocketAddr = "127.0.0.1:9000".parse().unwrap();
         let proc_id = test_proc_id_with_addr(ChannelAddr::Tcp(addr), "myproc");
         let proc_id_str = proc_id.to_string();
@@ -4403,11 +4398,11 @@ mod tests {
     /// PS-12: service proc routes to HostAgent.
     #[test]
     fn route_proc_handler_service_proc_yields_host() {
-        use hyperactor::ProcId;
+        use hyperactor::ProcAddr;
         let addr: SocketAddr = "127.0.0.1:9000".parse().unwrap();
-        // Use ProcId::from_resource_name directly — test_proc_id_with_addr
+        // Use ProcAddr::from_resource_name directly — test_proc_id_with_addr
         // prepends "test_" which would not match SERVICE_PROC_NAME.
-        let proc_id = ProcId::from_resource_name(ChannelAddr::Tcp(addr), SERVICE_PROC_NAME);
+        let proc_id = ProcAddr::from_resource_name(ChannelAddr::Tcp(addr), SERVICE_PROC_NAME);
         let handler = route_proc_handler(&proc_id.to_string()).unwrap();
         assert!(
             matches!(handler, ResolvedProcHandler::Host(_)),
@@ -4430,10 +4425,10 @@ mod tests {
     /// PS-12: a labeled instance named "service" is still a normal proc.
     #[test]
     fn route_proc_handler_service_instance_yields_proc() {
-        use hyperactor::ProcId;
+        use hyperactor::ProcAddr;
         let addr: SocketAddr = "127.0.0.1:9000".parse().unwrap();
         let proc_id =
-            ProcId::from_resource_name(ChannelAddr::Tcp(addr), "service-deadbeefdeadbeef");
+            ProcAddr::from_resource_name(ChannelAddr::Tcp(addr), "service-deadbeefdeadbeef");
         let handler = route_proc_handler(&proc_id.to_string()).unwrap();
         assert!(
             matches!(handler, ResolvedProcHandler::Proc(_)),

--- a/hyperactor_mesh/src/mesh_admin_skill.md
+++ b/hyperactor_mesh/src/mesh_admin_skill.md
@@ -104,7 +104,7 @@ Most endpoints are read-only (`GET`). Three endpoints accept `POST`:
 
 - `GET {base}/v1/pyspy/{proc_reference}`
   Requests a py-spy stack dump from the process hosting
-  `{proc_reference}`. The reference must be a valid ProcId
+  `{proc_reference}`. The reference must be a valid ProcAddr
   (percent-encoded in the URL path). Requires py-spy in the
   target environment and ptrace permissions.
 
@@ -141,7 +141,7 @@ Most endpoints are read-only (`GET`). Three endpoints accept `POST`:
   - 503 — py-spy not available on target host
   - 504 — py-spy record subprocess timed out
 
-  Agent note: `{encoded_proc_ref}` is the percent-encoded ProcId
+  Agent note: `{encoded_proc_ref}` is the percent-encoded ProcAddr
   string for the target process. If you save the
   returned SVG on a remote host for browser viewing, tell the user
   the remote file path, the serving port, the exact `ssh -L`
@@ -156,7 +156,7 @@ Most endpoints are read-only (`GET`). Three endpoints accept `POST`:
 - `GET {base}/v1/config/{proc_reference}`
   Returns the effective CONFIG-marked configuration entries from the
   process hosting `{proc_reference}`. The reference must be a valid
-  ProcId (percent-encoded in the URL path).
+  ProcAddr (percent-encoded in the URL path).
 
   Success returns a `ConfigDumpResult` JSON object:
   ```json
@@ -219,7 +219,7 @@ Most endpoints are read-only (`GET`). Three endpoints accept `POST`:
 - `POST {base}/v1/pyspy_dump/{proc_reference}`
   Captures a py-spy stack dump from the process hosting
   `{proc_reference}` and persists the result in the telemetry
-  store. The reference must be a valid ProcId (percent-encoded
+  store. The reference must be a valid ProcAddr (percent-encoded
   in the URL path). Requires `telemetry_url` to be configured.
 
   The endpoint performs two steps:
@@ -307,8 +307,8 @@ Always round-trip references exactly as returned in `children`.
 Common examples include:
 
 - `root` — synthetic entrypoint
-- Actor references (`ActorId`)
-- Proc references (`ProcId`)
+- Actor references (`ActorAddr`)
+- Proc references (`ProcAddr`)
 
 ## Examples
 

--- a/hyperactor_mesh/src/mesh_controller.rs
+++ b/hyperactor_mesh/src/mesh_controller.rs
@@ -17,7 +17,7 @@ use hyperactor::Context;
 use hyperactor::Handler;
 use hyperactor::Instance;
 use hyperactor::PortRef;
-use hyperactor::ProcId;
+use hyperactor::ProcAddr;
 use hyperactor::Unbind;
 use hyperactor::actor::ActorError;
 use hyperactor::actor::ActorErrorKind;
@@ -309,7 +309,7 @@ impl<A: Referable> Actor for ActorMeshController<A> {
                 // bind path should be idempotent and eliminate the
                 // need for attestation here.
                 subscriber: PortRef::<resource::State<ActorState>>::attest_message_port(
-                    &this.self_id().clone().into(),
+                    &this.self_id().clone(),
                 )
                 .unsplit(),
             },
@@ -352,7 +352,7 @@ impl<A: Referable> Actor for ActorMeshController<A> {
             // NOTE: The only part of the port that is used for equality checks is
             // the port id, so create a new one just for the comparison.
             let dest_port_id = envelope.0.dest().clone();
-            let port = PortRef::<Option<MeshFailure>>::attest(dest_port_id.into());
+            let port = PortRef::<Option<MeshFailure>>::attest(dest_port_id);
             let did_exist = self.health_state.subscribers.remove(&port);
             if did_exist {
                 tracing::debug!(
@@ -1014,7 +1014,7 @@ impl Actor for ProcMeshController {
         _err: Option<&ActorError>,
     ) -> Result<(), anyhow::Error> {
         // Cannot use "ProcMesh::stop" as it's only defined on ProcMesh, not ProcMeshRef.
-        let names = self.mesh.proc_ids().collect::<Vec<ProcId>>();
+        let names = self.mesh.proc_ids().collect::<Vec<ProcAddr>>();
         let region = self.mesh.region().clone();
         if let Some(hosts) = self.mesh.hosts() {
             hosts

--- a/hyperactor_mesh/src/mesh_id.rs
+++ b/hyperactor_mesh/src/mesh_id.rs
@@ -131,7 +131,7 @@ impl ResourceId {
 
     /// Returns the actor-runtime name derived from this resource id.
     ///
-    /// This is the name passed into `ProcId::actor_id(...)` and used when
+    /// This is the name passed into `ProcAddr::actor_id(...)` and used when
     /// `ProcAgent` spawns the actor process-local runtime object. Keep this
     /// helper as the single mapping point from control-plane resource ids to
     /// actor-runtime names.

--- a/hyperactor_mesh/src/proc_agent.rs
+++ b/hyperactor_mesh/src/proc_agent.rs
@@ -104,9 +104,9 @@ fn collect_live_children(
     for id in all_keys {
         if let Some(cell) = proc.get_instance(&id) {
             if cell.is_system() {
-                system_children.push(crate::introspect::NodeRef::Actor(id.clone().into()));
+                system_children.push(crate::introspect::NodeRef::Actor(id.clone()));
             }
-            children.push(hyperactor::introspect::IntrospectRef::Actor(id.into()));
+            children.push(hyperactor::introspect::IntrospectRef::Actor(id));
         }
     }
     (children, system_children)
@@ -116,7 +116,7 @@ fn collect_live_children(
 #[derive(Debug)]
 struct ActorInstanceState {
     create_rank: usize,
-    spawn: Result<hyperactor_reference::ActorId, anyhow::Error>,
+    spawn: Result<hyperactor_reference::ActorAddr, anyhow::Error>,
     /// True once a stop signal has been sent. This does *not* mean the actor
     /// has reached a terminal state — that is determined by observing
     /// supervision events.
@@ -370,7 +370,7 @@ impl ProcAgent {
 
     /// Send a stop signal to an actor on this proc. This is fire-and-forget;
     /// it does not wait for the actor to reach terminal status.
-    fn stop_actor_by_id(&self, actor_id: &hyperactor_reference::ActorId, reason: &str) {
+    fn stop_actor_by_id(&self, actor_id: &hyperactor_reference::ActorAddr, reason: &str) {
         tracing::info!(
             name = "StopActor",
             %actor_id,
@@ -390,8 +390,8 @@ impl ProcAgent {
         // TUI can filter/gray without per-child fetches.
         let mut stopped_children: Vec<crate::introspect::NodeRef> = Vec::new();
         for id in self.proc.all_terminated_actor_ids() {
-            let child_ref = hyperactor::introspect::IntrospectRef::Actor(id.clone().into());
-            let node_ref = crate::introspect::NodeRef::Actor(id.clone().into());
+            let child_ref = hyperactor::introspect::IntrospectRef::Actor(id.clone());
+            let node_ref = crate::introspect::NodeRef::Actor(id.clone());
             stopped_children.push(node_ref.clone());
             if let Some(snapshot) = self.proc.terminated_snapshot(&id) {
                 let snapshot_attrs: hyperactor_config::Attrs =
@@ -509,9 +509,8 @@ impl Actor for ProcAgent {
 
                     let mut stopped_children: Vec<crate::introspect::NodeRef> = Vec::new();
                     for id in proc.all_terminated_actor_ids() {
-                        let child_ref =
-                            hyperactor::introspect::IntrospectRef::Actor(id.clone().into());
-                        let node_ref = crate::introspect::NodeRef::Actor(id.clone().into());
+                        let child_ref = hyperactor::introspect::IntrospectRef::Actor(id.clone());
+                        let node_ref = crate::introspect::NodeRef::Actor(id.clone());
                         stopped_children.push(node_ref.clone());
                         if let Some(snapshot) = proc.terminated_snapshot(&id) {
                             let snapshot_attrs: hyperactor_config::Attrs =
@@ -598,9 +597,7 @@ impl Actor for ProcAgent {
                         serde_json::to_string(&attrs).unwrap_or_else(|_| "{}".to_string());
 
                     return IntrospectResult {
-                        identity: hyperactor::introspect::IntrospectRef::Proc(
-                            proc_ref.clone().into(),
-                        ),
+                        identity: hyperactor::introspect::IntrospectRef::Proc(proc_ref.clone()),
                         attrs: attrs_json,
                         children,
                         parent: None,
@@ -617,15 +614,9 @@ impl Actor for ProcAgent {
                     format!("child {} not found", child_ref),
                 );
                 let identity = match child_ref {
-                    Address::Proc(p) => {
-                        hyperactor::introspect::IntrospectRef::Proc(p.clone().into())
-                    }
-                    Address::Actor(a) => {
-                        hyperactor::introspect::IntrospectRef::Actor(a.clone().into())
-                    }
-                    Address::Port(p) => {
-                        hyperactor::introspect::IntrospectRef::Actor(p.actor_ref().into())
-                    }
+                    Address::Proc(p) => hyperactor::introspect::IntrospectRef::Proc(p.clone()),
+                    Address::Actor(a) => hyperactor::introspect::IntrospectRef::Actor(a.clone()),
+                    Address::Port(p) => hyperactor::introspect::IntrospectRef::Actor(p.actor_ref()),
                 };
                 IntrospectResult {
                     identity,
@@ -649,7 +640,7 @@ impl Actor for ProcAgent {
         envelope: Undeliverable<MessageEnvelope>,
     ) -> Result<(), anyhow::Error> {
         if let Some(true) = envelope.0.headers().get(STREAM_STATE_SUBSCRIBER) {
-            let dest_port_id: hyperactor_reference::PortId = envelope.0.dest().clone().into();
+            let dest_port_id: hyperactor_reference::PortAddr = envelope.0.dest().clone();
             let port = PortRef::<resource::State<ActorState>>::attest(dest_port_id);
             // Remove this subscriber from whichever actor instance holds it.
             for instance in self.actor_states.values_mut() {
@@ -796,7 +787,7 @@ wirevalue::register_type!(ActorSpec);
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Named, Bind, Unbind)]
 pub struct ActorState {
     /// The actor's ID.
-    pub actor_id: hyperactor_reference::ActorId,
+    pub actor_id: hyperactor_reference::ActorAddr,
     /// The rank of the proc that created the actor. This is before any slicing.
     pub create_rank: usize,
     // TODO status: ActorStatus,
@@ -908,7 +899,7 @@ impl Handler<resource::StopAll> for ProcAgent {
         self.stopping_all = true;
 
         // Send stop signals to all actors that haven't been stopped yet.
-        let to_stop: Vec<hyperactor_reference::ActorId> = self
+        let to_stop: Vec<hyperactor_reference::ActorAddr> = self
             .actor_states
             .values_mut()
             .filter_map(|state| {
@@ -1161,7 +1152,7 @@ impl Handler<SelfCheck> for ProcAgent {
         let now = std::time::SystemTime::now();
 
         // Collect expired actors before mutating, since stop_actor borrows &mut self.
-        let expired: Vec<(ResourceId, hyperactor_reference::ActorId)> = self
+        let expired: Vec<(ResourceId, hyperactor_reference::ActorAddr)> = self
             .actor_states
             .iter()
             .filter_map(|(id, state)| {
@@ -1246,8 +1237,8 @@ mod tests {
         let client_proc = Proc::direct(ChannelTransport::Unix.any(), "client".to_string()).unwrap();
         let (client, _client_handle) = client_proc.instance("client").unwrap();
 
-        let agent_id: hyperactor_reference::ActorId =
-            proc.proc_id().actor_ref(PROC_AGENT_ACTOR_NAME).into();
+        let agent_id: hyperactor_reference::ActorAddr =
+            proc.proc_id().actor_ref(PROC_AGENT_ACTOR_NAME);
         let port = PortRef::<IntrospectMessage>::attest_message_port(&agent_id);
 
         // Helper: send QueryChild(Proc) and return the payload with a
@@ -1257,7 +1248,7 @@ mod tests {
             port.send(
                 client,
                 IntrospectMessage::QueryChild {
-                    child_ref: hyperactor_reference::Reference::Proc(proc.proc_id().clone().into()),
+                    child_ref: hyperactor_reference::Address::Proc(proc.proc_id().clone()),
                     reply: reply_port.bind(),
                 },
             )
@@ -1354,8 +1345,8 @@ mod tests {
         let client_proc = Proc::direct(ChannelTransport::Unix.any(), "client".to_string()).unwrap();
         let (client, _client_handle) = client_proc.instance("client").unwrap();
 
-        let agent_id: hyperactor_reference::ActorId =
-            proc.proc_id().actor_ref(PROC_AGENT_ACTOR_NAME).into();
+        let agent_id: hyperactor_reference::ActorAddr =
+            proc.proc_id().actor_ref(PROC_AGENT_ACTOR_NAME);
         let port = PortRef::<IntrospectMessage>::attest_message_port(&agent_id);
 
         // Concurrent query task: send QueryChild(Proc) every 10ms.
@@ -1373,9 +1364,7 @@ mod tests {
                     .send(
                         &query_client,
                         IntrospectMessage::QueryChild {
-                            child_ref: hyperactor_reference::Reference::Proc(
-                                query_proc_id.clone().into(),
-                            ),
+                            child_ref: hyperactor_reference::Address::Proc(query_proc_id.clone()),
                             reply: reply_port.bind(),
                         },
                     )
@@ -1436,7 +1425,7 @@ mod tests {
         port.send(
             &client,
             IntrospectMessage::QueryChild {
-                child_ref: hyperactor_reference::Reference::Proc(proc.proc_id().clone().into()),
+                child_ref: hyperactor_reference::Address::Proc(proc.proc_id().clone()),
                 reply: reply_port.bind(),
             },
         )
@@ -1681,8 +1670,8 @@ mod tests {
 
         // QueryChild(Proc) — same aggregation logic as mesh-admin
         // resolution.
-        let agent_id: hyperactor_reference::ActorId =
-            proc.proc_id().actor_ref(PROC_AGENT_ACTOR_NAME).into();
+        let agent_id: hyperactor_reference::ActorAddr =
+            proc.proc_id().actor_ref(PROC_AGENT_ACTOR_NAME);
         let port = PortRef::<IntrospectMessage>::attest_message_port(&agent_id);
 
         // Poll until queue stats are non-zero.
@@ -1692,7 +1681,7 @@ mod tests {
             port.send(
                 &client,
                 IntrospectMessage::QueryChild {
-                    child_ref: hyperactor_reference::Reference::Proc(proc.proc_id().clone().into()),
+                    child_ref: hyperactor_reference::Address::Proc(proc.proc_id().clone()),
                     reply: reply_port.bind(),
                 },
             )

--- a/hyperactor_mesh/src/proc_launcher.rs
+++ b/hyperactor_mesh/src/proc_launcher.rs
@@ -277,12 +277,12 @@ pub struct LaunchOptions {
 /// include a friendly identifier in logs, crash reports, etc.
 ///
 /// Format:
-/// - `ProcId(_, name)` → `<name> @ <host_process_name>`
+/// - `ProcAddr(_, name)` → `<name> @ <host_process_name>`
 ///
 /// The host identity is taken from the current process's
 /// `HYPERACTOR_PROCESS_NAME`, falling back to the machine hostname.
 /// This groups procs under their host process in traces and logs.
-pub fn format_process_name(proc_id: &hyperactor_reference::ProcId) -> String {
+pub fn format_process_name(proc_id: &hyperactor::ProcAddr) -> String {
     let who = proc_id
         .label()
         .map(|l| l.as_str().to_string())
@@ -343,7 +343,7 @@ pub trait ProcLauncher: Send + Sync + 'static {
     /// (pipes vs inherit, log streaming, etc.).
     async fn launch(
         &self,
-        proc_id: &hyperactor_reference::ProcId,
+        proc_id: &hyperactor::ProcAddr,
         opts: LaunchOptions,
     ) -> Result<LaunchResult, ProcLauncherError>;
 
@@ -361,7 +361,7 @@ pub trait ProcLauncher: Send + Sync + 'static {
     /// (agent-first) termination cannot be applied or fails.
     async fn terminate(
         &self,
-        proc_id: &hyperactor_reference::ProcId,
+        proc_id: &hyperactor::ProcAddr,
         timeout: Duration,
     ) -> Result<(), ProcLauncherError>;
 
@@ -387,5 +387,5 @@ pub trait ProcLauncher: Send + Sync + 'static {
     /// Idempotent behavior is preferred: killing an already-dead proc
     /// should not be treated as an error unless the backend cannot
     /// determine state.
-    async fn kill(&self, proc_id: &hyperactor_reference::ProcId) -> Result<(), ProcLauncherError>;
+    async fn kill(&self, proc_id: &hyperactor::ProcAddr) -> Result<(), ProcLauncherError>;
 }

--- a/hyperactor_mesh/src/proc_launcher/native.rs
+++ b/hyperactor_mesh/src/proc_launcher/native.rs
@@ -41,7 +41,7 @@
 //! to the child via environment variables:
 //! - [`BOOTSTRAP_MODE_ENV`] carries an env-safe encoding of [`Bootstrap`].
 //! - [`PROCESS_NAME_ENV`] carries a diagnostic name derived from the
-//!   [`ProcId`] and hostname (useful for logs/`ps`/systemd).
+//!   [`ProcAddr`] and hostname (useful for logs/`ps`/systemd).
 //! - [`BOOTSTRAP_LOG_CHANNEL`] is optionally set when the manager
 //!   provisions a mesh log-forwarding channel in [`LaunchOptions`].
 //!
@@ -128,7 +128,7 @@ pub(crate) struct NativeProcLauncher {
     /// removed by the exit-monitor task after `wait()` completes.
     /// Missing entries are treated as idempotent success (already
     /// exited / unknown).
-    pid_table: Arc<Mutex<HashMap<hyperactor_reference::ProcId, u32>>>,
+    pid_table: Arc<Mutex<HashMap<hyperactor::ProcAddr, u32>>>,
 }
 
 impl NativeProcLauncher {
@@ -314,7 +314,7 @@ impl ProcLauncher for NativeProcLauncher {
     )]
     async fn launch(
         &self,
-        proc_id: &hyperactor_reference::ProcId,
+        proc_id: &hyperactor::ProcAddr,
         opts: LaunchOptions,
     ) -> Result<LaunchResult, ProcLauncherError> {
         // Apply NUMA/CPU binding if requested.
@@ -478,7 +478,7 @@ impl ProcLauncher for NativeProcLauncher {
     ///   channel when the proc actually terminates.
     async fn terminate(
         &self,
-        proc_id: &hyperactor_reference::ProcId,
+        proc_id: &hyperactor::ProcAddr,
         timeout: Duration,
     ) -> Result<(), ProcLauncherError> {
         let pid = {
@@ -558,7 +558,7 @@ impl ProcLauncher for NativeProcLauncher {
     /// - We do not remove `proc_id` from `pid_table` here; the
     ///   exit-monitor task spawned in `launch` removes it once the
     ///   child actually exits.
-    async fn kill(&self, proc_id: &hyperactor_reference::ProcId) -> Result<(), ProcLauncherError> {
+    async fn kill(&self, proc_id: &hyperactor::ProcAddr) -> Result<(), ProcLauncherError> {
         let pid = {
             let table = self.pid_table.lock().expect("pid_table mutex poisoned");
             table.get(proc_id).copied()
@@ -605,7 +605,7 @@ impl Drop for NativeProcLauncher {
     fn drop(&mut self) {
         // Collect PIDs while holding the lock, then release before killing.
         // This avoids holding the lock during syscalls.
-        let pids: Vec<(hyperactor_reference::ProcId, u32)> = {
+        let pids: Vec<(hyperactor::ProcAddr, u32)> = {
             let table = self.pid_table.lock().expect("pid_table mutex poisoned");
             table.iter().map(|(k, v)| (k.clone(), *v)).collect()
         };
@@ -816,7 +816,7 @@ mod tests {
                 exit_on_shutdown: false,
             };
             let proc_id =
-                hyperactor_reference::ProcId::from_resource_name(any_unix_addr(), "stdio-captured");
+                hyperactor::ProcAddr::from_resource_name(any_unix_addr(), "stdio-captured");
             let opts = LaunchOptions {
                 command: with_sh(script),
                 bootstrap_payload: bootstrap.to_env_safe_string().unwrap(),
@@ -855,10 +855,8 @@ mod tests {
                 config: None,
                 exit_on_shutdown: false,
             };
-            let proc_id = hyperactor_reference::ProcId::from_resource_name(
-                any_unix_addr(),
-                "stdio-inherited",
-            );
+            let proc_id =
+                hyperactor::ProcAddr::from_resource_name(any_unix_addr(), "stdio-inherited");
             let opts = LaunchOptions {
                 command: with_sh(script),
                 bootstrap_payload: bootstrap.to_env_safe_string().unwrap(),
@@ -901,7 +899,7 @@ mod tests {
             config: None,
             exit_on_shutdown: false,
         };
-        let proc_id = hyperactor_reference::ProcId::from_resource_name(any_unix_addr(), "exit-7");
+        let proc_id = hyperactor::ProcAddr::from_resource_name(any_unix_addr(), "exit-7");
         let opts = LaunchOptions {
             command: with_sh("exit 7"),
             bootstrap_payload: bootstrap.to_env_safe_string().unwrap(),
@@ -945,7 +943,7 @@ mod tests {
             config: None,
             exit_on_shutdown: false,
         };
-        let proc_id = hyperactor_reference::ProcId::from_resource_name(any_unix_addr(), "killed");
+        let proc_id = hyperactor::ProcAddr::from_resource_name(any_unix_addr(), "killed");
         let opts = LaunchOptions {
             command: with_sh("sleep 30"),
             bootstrap_payload: bootstrap.to_env_safe_string().unwrap(),
@@ -1022,8 +1020,7 @@ mod tests {
             config: None,
             exit_on_shutdown: false,
         };
-        let proc_id =
-            hyperactor_reference::ProcId::from_resource_name(any_unix_addr(), "term-escalate");
+        let proc_id = hyperactor::ProcAddr::from_resource_name(any_unix_addr(), "term-escalate");
         let opts = LaunchOptions {
             command: with_sh(script),
             bootstrap_payload: bootstrap.to_env_safe_string().unwrap(),
@@ -1117,7 +1114,7 @@ while True:
             exit_on_shutdown: false,
         };
         let proc_id =
-            hyperactor_reference::ProcId::from_resource_name(any_unix_addr(), "drop-cleanup-test");
+            hyperactor::ProcAddr::from_resource_name(any_unix_addr(), "drop-cleanup-test");
         let opts = LaunchOptions {
             command,
             bootstrap_payload: bootstrap.to_env_safe_string().unwrap(),

--- a/hyperactor_mesh/src/proc_launcher/systemd.rs
+++ b/hyperactor_mesh/src/proc_launcher/systemd.rs
@@ -147,8 +147,8 @@ fn is_unit_gone(e: &zbus::Error) -> bool {
 /// it), we log a warning and recover the guard anyway. This ensures
 /// cleanup can proceed even after a panic.
 fn units_lock_recover(
-    units: &std::sync::Mutex<HashMap<hyperactor_reference::ProcId, String>>,
-) -> MutexGuard<'_, HashMap<hyperactor_reference::ProcId, String>> {
+    units: &std::sync::Mutex<HashMap<hyperactor::ProcAddr, String>>,
+) -> MutexGuard<'_, HashMap<hyperactor::ProcAddr, String>> {
     units.lock().unwrap_or_else(|p| {
         tracing::warn!("mutex was poisoned, recovering");
         p.into_inner()
@@ -262,8 +262,8 @@ fn is_terminal(active: &str, sub: &str) -> bool {
 /// Log exit, remove proc from units map, and send result on channel.
 fn send_and_cleanup(
     kind: ProcExitKind,
-    proc_id: &hyperactor_reference::ProcId,
-    units: &std::sync::Mutex<HashMap<hyperactor_reference::ProcId, String>>,
+    proc_id: &hyperactor::ProcAddr,
+    units: &std::sync::Mutex<HashMap<hyperactor::ProcAddr, String>>,
     exit_tx: oneshot::Sender<ProcExitResult>,
 ) {
     tracing::debug!(?kind, "exit_observed");
@@ -396,8 +396,8 @@ fn map_exit_from_result(result: &str, status: i32, active: &str, sub: &str) -> P
 /// 7. Sends the result on `exit_tx`
 async fn monitor_exit(
     conn: Connection,
-    units: Arc<std::sync::Mutex<HashMap<hyperactor_reference::ProcId, String>>>,
-    proc_id: hyperactor_reference::ProcId,
+    units: Arc<std::sync::Mutex<HashMap<hyperactor::ProcAddr, String>>>,
+    proc_id: hyperactor::ProcAddr,
     handle: SystemdUnitHandle,
     exit_tx: oneshot::Sender<ProcExitResult>,
 ) {
@@ -655,7 +655,7 @@ pub(crate) struct SystemdProcLauncher {
     /// handshake until the first launch/terminate/kill operation.
     conn: tokio::sync::OnceCell<Connection>,
 
-    /// ProcId → unit name mapping for management operations.
+    /// ProcAddr → unit name mapping for management operations.
     ///
     /// - `terminate`/`kill` use this to find the unit name.
     /// - The exit monitor removes the entry once it observes
@@ -664,7 +664,7 @@ pub(crate) struct SystemdProcLauncher {
     ///
     /// Uses `std::sync::Mutex` (not tokio) so Drop can synchronously
     /// acquire the lock.
-    units: Arc<std::sync::Mutex<HashMap<hyperactor_reference::ProcId, String>>>,
+    units: Arc<std::sync::Mutex<HashMap<hyperactor::ProcAddr, String>>>,
 }
 
 impl SystemdProcLauncher {
@@ -698,20 +698,20 @@ impl SystemdProcLauncher {
     /// `proc_id`.
     ///
     /// systemd unit names are picky about allowed characters.
-    /// `ProcId::to_string()` can contain characters that are
+    /// `ProcAddr::to_string()` can contain characters that are
     /// awkward/invalid in a unit name, so we **hex-encode** the UTF-8
     /// bytes of that string and embed it in a `monarch-<hex>.service`
     /// name.
     ///
     /// Properties:
-    /// - **Stable**: the same `ProcId` always yields the same unit
+    /// - **Stable**: the same `ProcAddr` always yields the same unit
     ///   name.
-    /// - **Bijective**: different `ProcId` strings yield different
+    /// - **Bijective**: different `ProcAddr` strings yield different
     ///   unit names (hex encoding is collision-free on bytes).
     /// - **Systemd-safe**: output contains only ASCII hex digits plus
     ///   `-` and `.service`.
-    pub(crate) fn unit_name(proc_id: &hyperactor_reference::ProcId) -> String {
-        // Hex-encode the ProcId string to ensure only valid systemd
+    pub(crate) fn unit_name(proc_id: &hyperactor::ProcAddr) -> String {
+        // Hex-encode the ProcAddr string to ensure only valid systemd
         // unit name characters. This is bijective (collision-free)
         // and stable.
         let s = proc_id.to_string();
@@ -780,7 +780,7 @@ impl SystemdProcLauncher {
 
     /// Build the properties for `StartTransientUnit`.
     fn build_unit_props<'a>(
-        proc_id: &hyperactor_reference::ProcId,
+        proc_id: &hyperactor::ProcAddr,
         exec_start: Vec<(String, Vec<String>, bool)>,
         env_kv: Vec<String>,
     ) -> Vec<(&'a str, Value<'a>)> {
@@ -807,7 +807,7 @@ impl SystemdProcLauncher {
     /// Shared implementation for terminate/kill via systemd StopUnit.
     async fn stop_unit_impl(
         &self,
-        proc_id: &hyperactor_reference::ProcId,
+        proc_id: &hyperactor::ProcAddr,
         op: StopOp,
     ) -> Result<(), ProcLauncherError> {
         let unit = match self.units.lock().unwrap().get(proc_id).cloned() {
@@ -908,7 +908,7 @@ impl ProcLauncher for SystemdProcLauncher {
     )]
     async fn launch(
         &self,
-        proc_id: &hyperactor_reference::ProcId,
+        proc_id: &hyperactor::ProcAddr,
         opts: LaunchOptions,
     ) -> Result<LaunchResult, ProcLauncherError> {
         let unit = Self::unit_name(proc_id);
@@ -989,7 +989,7 @@ impl ProcLauncher for SystemdProcLauncher {
     ///   from the `units` map when observed.
     async fn terminate(
         &self,
-        proc_id: &hyperactor_reference::ProcId,
+        proc_id: &hyperactor::ProcAddr,
         timeout: Duration,
     ) -> Result<(), ProcLauncherError> {
         self.stop_unit_impl(proc_id, StopOp::Terminate { timeout })
@@ -1010,7 +1010,7 @@ impl ProcLauncher for SystemdProcLauncher {
     /// - The exit monitor is responsible for observing the final exit
     ///   status (Exited vs Signaled) and for removing the proc from
     ///   the `units` map.
-    async fn kill(&self, proc_id: &hyperactor_reference::ProcId) -> Result<(), ProcLauncherError> {
+    async fn kill(&self, proc_id: &hyperactor::ProcAddr) -> Result<(), ProcLauncherError> {
         self.stop_unit_impl(proc_id, StopOp::Kill).await
     }
 }
@@ -1024,7 +1024,7 @@ impl Drop for SystemdProcLauncher {
         // Note: This cleanup is best-effort. If the process is
         // terminating, the spawned cleanup thread may not complete
         // before the process exits.
-        let units: Vec<(hyperactor_reference::ProcId, String)> = {
+        let units: Vec<(hyperactor::ProcAddr, String)> = {
             let mut guard = units_lock_recover(&self.units);
             guard.drain().collect()
         };
@@ -1190,7 +1190,7 @@ mod tests {
 
         let launcher = SystemdProcLauncher::new();
 
-        let proc_id = hyperactor_reference::ProcId::from_resource_name(any_unix_addr(), "env-vars");
+        let proc_id = hyperactor::ProcAddr::from_resource_name(any_unix_addr(), "env-vars");
         // The bootstrap payload content doesn't matter for this test.
         let bootstrap = Bootstrap::Host {
             addr: any_unix_addr(),
@@ -1299,7 +1299,7 @@ mod tests {
             config: None,
             exit_on_shutdown: false,
         };
-        let proc_id = hyperactor_reference::ProcId::from_resource_name(any_unix_addr(), "exit-7");
+        let proc_id = hyperactor::ProcAddr::from_resource_name(any_unix_addr(), "exit-7");
         let opts = LaunchOptions {
             command: with_sh("exit 7"),
             bootstrap_payload: bootstrap.to_env_safe_string().unwrap(),
@@ -1346,7 +1346,7 @@ mod tests {
             config: None,
             exit_on_shutdown: false,
         };
-        let proc_id = hyperactor_reference::ProcId::from_resource_name(any_unix_addr(), "killed");
+        let proc_id = hyperactor::ProcAddr::from_resource_name(any_unix_addr(), "killed");
         let opts = LaunchOptions {
             command: with_sh("sleep 30"),
             bootstrap_payload: bootstrap.to_env_safe_string().unwrap(),
@@ -1413,8 +1413,7 @@ mod tests {
             config: None,
             exit_on_shutdown: false,
         };
-        let proc_id =
-            hyperactor_reference::ProcId::from_resource_name(any_unix_addr(), "terminated");
+        let proc_id = hyperactor::ProcAddr::from_resource_name(any_unix_addr(), "terminated");
         let opts = LaunchOptions {
             command: with_sh("sleep 30"),
             bootstrap_payload: bootstrap.to_env_safe_string().unwrap(),
@@ -1458,8 +1457,7 @@ mod tests {
 
         let launcher = SystemdProcLauncher::new();
 
-        let unknown_proc_id =
-            hyperactor_reference::ProcId::from_resource_name(any_unix_addr(), "unknown");
+        let unknown_proc_id = hyperactor::ProcAddr::from_resource_name(any_unix_addr(), "unknown");
 
         let result = launcher
             .terminate(&unknown_proc_id, Duration::from_secs(1))
@@ -1481,8 +1479,7 @@ mod tests {
 
         let launcher = SystemdProcLauncher::new();
 
-        let unknown_proc_id =
-            hyperactor_reference::ProcId::from_resource_name(any_unix_addr(), "unknown");
+        let unknown_proc_id = hyperactor::ProcAddr::from_resource_name(any_unix_addr(), "unknown");
 
         let result = launcher.kill(&unknown_proc_id).await;
 
@@ -1592,7 +1589,7 @@ mod tests {
             exit_on_shutdown: false,
         };
         let proc_id =
-            hyperactor_reference::ProcId::from_resource_name(any_unix_addr(), "drop-cleanup-test");
+            hyperactor::ProcAddr::from_resource_name(any_unix_addr(), "drop-cleanup-test");
 
         let exit_rx;
 
@@ -1691,8 +1688,7 @@ mod tests {
 
         let launcher = SystemdProcLauncher::new();
 
-        let proc_id =
-            hyperactor_reference::ProcId::from_resource_name(any_unix_addr(), "long-running");
+        let proc_id = hyperactor::ProcAddr::from_resource_name(any_unix_addr(), "long-running");
         // The bootstrap payload content doesn't matter for this test.
         let bootstrap = Bootstrap::Host {
             addr: any_unix_addr(),

--- a/hyperactor_mesh/src/proc_mesh.rs
+++ b/hyperactor_mesh/src/proc_mesh.rs
@@ -87,7 +87,7 @@ pub const COMM_ACTOR_NAME: &str = "comm";
 /// A reference to a single [`hyperactor::Proc`].
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct ProcRef {
-    proc_id: hyperactor_reference::ProcId,
+    proc_id: hyperactor_reference::ProcAddr,
     /// The rank of this proc at creation.
     create_rank: usize,
     /// The agent managing this proc.
@@ -97,7 +97,7 @@ pub struct ProcRef {
 impl ProcRef {
     /// Create a new proc ref from the provided id, create rank and agent.
     pub fn new(
-        proc_id: hyperactor_reference::ProcId,
+        proc_id: hyperactor_reference::ProcAddr,
         create_rank: usize,
         agent: hyperactor_reference::ActorRef<ProcAgent>,
     ) -> Self {
@@ -108,11 +108,11 @@ impl ProcRef {
         }
     }
 
-    pub fn proc_id(&self) -> &hyperactor_reference::ProcId {
+    pub fn proc_id(&self) -> &hyperactor_reference::ProcAddr {
         &self.proc_id
     }
 
-    pub(crate) fn actor_id(&self, id: &ActorMeshId) -> hyperactor_reference::ActorId {
+    pub(crate) fn actor_id(&self, id: &ActorMeshId) -> hyperactor_reference::ActorAddr {
         self.proc_id.actor_id(id.actor_name())
     }
 
@@ -259,7 +259,7 @@ impl ProcMesh {
         let procs = self
             .current_ref
             .proc_ids()
-            .collect::<Vec<hyperactor_reference::ProcId>>();
+            .collect::<Vec<hyperactor_reference::ProcAddr>>();
         // We use the proc mesh region rather than the host mesh region
         // because the host agent stores one entry per proc, not per host.
         self.current_ref
@@ -485,7 +485,7 @@ impl ProcMeshRef {
                         resource::State {
                             id: id.resource_id().clone(),
                             status: resource::Status::Timeout(timeout),
-                            // We don't know the ActorId that used to live on this rank.
+                            // We don't know the ActorAddr that used to live on this rank.
                             // But we do know the mesh agent id, so we'll use that.
                             // Use u64::MAX so this synthetic state always wins
                             // last-writer-wins ordering against real streamed updates.
@@ -527,7 +527,7 @@ impl ProcMeshRef {
     ) -> crate::Result<Option<ValueMesh<resource::State<ProcState>>>> {
         let names = self
             .proc_ids()
-            .collect::<Vec<hyperactor_reference::ProcId>>();
+            .collect::<Vec<hyperactor_reference::ProcAddr>>();
         if let Some(host_mesh) = &self.host_mesh {
             Ok(Some(
                 host_mesh
@@ -540,7 +540,7 @@ impl ProcMeshRef {
     }
 
     /// Returns an iterator over the proc ids in this mesh.
-    pub(crate) fn proc_ids(&self) -> impl Iterator<Item = hyperactor_reference::ProcId> {
+    pub(crate) fn proc_ids(&self) -> impl Iterator<Item = hyperactor_reference::ProcAddr> {
         self.ranks.iter().map(|proc_ref| proc_ref.proc_id.clone())
     }
 
@@ -778,7 +778,7 @@ impl ProcMeshRef {
                 statuses,
             );
             // hyperactor::proc AI-3: controller name must include mesh
-            // identity for proc-wide ActorId uniqueness. A fixed base name alone
+            // identity for proc-wide ActorAddr uniqueness. A fixed base name alone
             // collides across parents because pid allocation is
             // parent-scoped.
             let controller_name = format!(

--- a/hyperactor_mesh/src/supervision.rs
+++ b/hyperactor_mesh/src/supervision.rs
@@ -113,14 +113,13 @@ mod tests {
     //! "with mesh name" and "without mesh name" rendered output is
     //! locked down and any regression surfaces here.
     //!
-    //! The `assert_eq!` literals capture the `ActorId::Display`
+    //! The `assert_eq!` literals capture the `ActorAddr::Display`
     //! output of the checkout the tests were generated against. If
     //! the identifier encoding changes (e.g. a reference-stack
     //! refactor lands in the same tree), the literals need to be
     //! regenerated on the new baseline — the mesh-name-rendering
     //! behavior this module tests is independent of the id format.
 
-    use hyperactor as reference;
     use hyperactor::actor::ActorErrorKind;
     use hyperactor::actor::ActorStatus;
     use hyperactor::channel::ChannelAddr;
@@ -128,7 +127,7 @@ mod tests {
     use super::*;
 
     fn test_event(name: &str, display_name: Option<String>) -> ActorSupervisionEvent {
-        let proc_id = reference::ProcId::from_resource_name(ChannelAddr::Local(0), "test_proc");
+        let proc_id = hyperactor::ProcAddr::from_resource_name(ChannelAddr::Local(0), "test_proc");
         ActorSupervisionEvent::new(
             proc_id.actor_id(name),
             display_name,
@@ -201,7 +200,8 @@ mod tests {
     // (`hyperactor_mesh/src/global_context.rs:278`): display_name =
     // None, actor_status = generic_failure("message not delivered: ...").
     fn undeliverable_synthesized_event() -> ActorSupervisionEvent {
-        let proc_id = reference::ProcId::from_resource_name(ChannelAddr::Local(0), "worker_proc");
+        let proc_id =
+            hyperactor::ProcAddr::from_resource_name(ChannelAddr::Local(0), "worker_proc");
         ActorSupervisionEvent::new(
             proc_id.actor_id("dead_actor"),
             None, // synthesized site has no PythonActor context; display_name stays None
@@ -255,7 +255,7 @@ mod tests {
         // Note: the inner event here has `display_name = None` (the
         // synthesis site at `global_context.rs` has no PythonActor
         // context to populate it), so the inner actor mention
-        // renders via raw `ActorId` text. That is a separate concern
+        // renders via raw `ActorAddr` text. That is a separate concern
         // from mesh-name plumbing.
     }
 
@@ -277,7 +277,7 @@ mod tests {
     fn proof_direct_actor_handled_panic() {
         let panicked_event = {
             let proc_id =
-                reference::ProcId::from_resource_name(ChannelAddr::Local(0), "worker_proc");
+                hyperactor::ProcAddr::from_resource_name(ChannelAddr::Local(0), "worker_proc");
             ActorSupervisionEvent::new(
                 proc_id.actor_id("philosopher_1"),
                 // `Proc::stop_actor` populates this via
@@ -326,7 +326,7 @@ mod tests {
     fn proof_controller_unreachable() {
         let controller_timeout_event = {
             let proc_id =
-                reference::ProcId::from_resource_name(ChannelAddr::Local(0), "controller_proc");
+                hyperactor::ProcAddr::from_resource_name(ChannelAddr::Local(0), "controller_proc");
             ActorSupervisionEvent::new(
                 proc_id.actor_id("training_controller"),
                 None,

--- a/hyperactor_mesh/src/testactor.rs
+++ b/hyperactor_mesh/src/testactor.rs
@@ -74,8 +74,7 @@ impl Actor for TestActor {}
 /// A message that returns the recipient actor's id and cast message's seq info.
 #[derive(Debug, Clone, Named, Bind, Unbind, Serialize, Deserialize)]
 pub struct GetActorId(
-    #[binding(include)]
-    pub  hyperactor_reference::PortRef<(hyperactor_reference::ActorId, Option<SeqInfo>)>,
+    #[binding(include)] pub hyperactor::PortRef<(hyperactor::ActorAddr, Option<SeqInfo>)>,
 );
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -130,7 +129,7 @@ impl Handler<GetActorId> for TestActor {
         GetActorId(reply): GetActorId,
     ) -> Result<(), anyhow::Error> {
         let seq_info = cx.headers().get(SEQ_INFO);
-        reply.send(cx, (cx.self_id().clone().into(), seq_info))?;
+        reply.send(cx, (cx.self_id().clone(), seq_info))?;
         Ok(())
     }
 }
@@ -207,8 +206,8 @@ impl Handler<std::time::Duration> for SleepActor {
 /// 'visited' list.
 #[derive(Debug, Clone, Named, Bind, Unbind, Serialize, Deserialize)]
 pub struct Forward {
-    pub to_visit: VecDeque<hyperactor_reference::PortRef<Forward>>,
-    pub visited: Vec<hyperactor_reference::PortRef<Forward>>,
+    pub to_visit: VecDeque<hyperactor::PortRef<Forward>>,
+    pub visited: Vec<hyperactor::PortRef<Forward>>,
 }
 
 #[async_trait]
@@ -247,10 +246,10 @@ impl Handler<Forward> for TestActor {
 pub struct GetCastInfo {
     /// Originating actor, point, sender.
     #[reply]
-    pub cast_info: hyperactor_reference::PortRef<(
+    pub cast_info: hyperactor::PortRef<(
         Point,
         hyperactor_reference::ActorRef<TestActor>,
-        hyperactor_reference::ActorId,
+        hyperactor::ActorAddr,
     )>,
 }
 
@@ -303,7 +302,7 @@ impl Handler<SetConfigAttrs> for TestActor {
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, Named, Bind, Unbind)]
-pub struct GetConfigAttrs(pub hyperactor_reference::PortRef<Vec<u8>>);
+pub struct GetConfigAttrs(pub hyperactor::PortRef<Vec<u8>>);
 
 #[async_trait]
 impl Handler<GetConfigAttrs> for TestActor {
@@ -325,7 +324,7 @@ impl Handler<GetConfigAttrs> for TestActor {
 /// Replies with None if no supervision event is encountered within a timeout
 /// (10 seconds).
 #[derive(Clone, Debug, Serialize, Deserialize, Named, Bind, Unbind)]
-pub struct NextSupervisionFailure(pub hyperactor_reference::PortRef<Option<MeshFailure>>);
+pub struct NextSupervisionFailure(pub hyperactor::PortRef<Option<MeshFailure>>);
 
 /// A small wrapper to handle supervision messages so they don't
 /// need to reach the client. This just wraps and forwards all messages to TestActor.
@@ -343,17 +342,13 @@ pub struct WrapperActor {
     proc_mesh: ProcMeshRef,
     // Needs to be a mesh so we own this actor and have a controller for it.
     mesh: Option<ActorMesh<TestActor>>,
-    supervisor: hyperactor_reference::PortRef<MeshFailure>,
+    supervisor: hyperactor::PortRef<MeshFailure>,
     test_name: ActorMeshId,
 }
 
 #[async_trait]
 impl hyperactor::RemoteSpawn for WrapperActor {
-    type Params = (
-        ProcMeshRef,
-        hyperactor_reference::PortRef<MeshFailure>,
-        ActorMeshId,
-    );
+    type Params = (ProcMeshRef, hyperactor::PortRef<MeshFailure>, ActorMeshId);
 
     async fn new(
         (proc_mesh, supervisor, test_name): Self::Params,
@@ -477,8 +472,7 @@ pub async fn assert_casting_correctness(
         .values()
         .map(|actor_ref| actor_ref.actor_id().clone())
         .collect::<Vec<_>>();
-    let mut expected: HashMap<&hyperactor_reference::ActorId, Option<SeqInfo>> = match expected_seqs
-    {
+    let mut expected: HashMap<&hyperactor::ActorAddr, Option<SeqInfo>> = match expected_seqs {
         None => expected_actor_ids
             .iter()
             .map(|actor_id| (actor_id, None))

--- a/hyperactor_mesh/src/testdata/admin_info_schema.json
+++ b/hyperactor_mesh/src/testdata/admin_info_schema.json
@@ -4,7 +4,7 @@
   "description": "Self-identification payload returned by `GET /v1/admin`.\n\nConstruct via [`AdminInfo::new`]. AI-1, AI-2, AI-3 are live\ninvariants. The relationship between `host` and `url` is a\nconstructor guarantee — `AdminInfo::new()` rejects URLs with no\nhost, so `host` always derives from `url` at construction.",
   "properties": {
     "actor_id": {
-      "description": "Stringified `ActorId` of the `MeshAdminAgent`.",
+      "description": "Stringified `ActorAddr` of the `MeshAdminAgent`.",
       "type": "string"
     },
     "host": {
@@ -12,7 +12,7 @@
       "type": "string"
     },
     "proc_id": {
-      "description": "Stringified `ProcId` of the proc hosting `MeshAdminAgent`.",
+      "description": "Stringified `ProcAddr` of the proc hosting `MeshAdminAgent`.",
       "type": "string"
     },
     "url": {

--- a/hyperactor_mesh/src/testdata/openapi.json
+++ b/hyperactor_mesh/src/testdata/openapi.json
@@ -6,7 +6,7 @@
         "description": "Self-identification payload returned by `GET /v1/admin`.\n\nConstruct via [`AdminInfo::new`]. AI-1, AI-2, AI-3 are live\ninvariants. The relationship between `host` and `url` is a\nconstructor guarantee — `AdminInfo::new()` rejects URLs with no\nhost, so `host` always derives from `url` at construction.",
         "properties": {
           "actor_id": {
-            "description": "Stringified `ActorId` of the `MeshAdminAgent`.",
+            "description": "Stringified `ActorAddr` of the `MeshAdminAgent`.",
             "type": "string"
           },
           "host": {
@@ -14,7 +14,7 @@
             "type": "string"
           },
           "proc_id": {
-            "description": "Stringified `ProcId` of the proc hosting `MeshAdminAgent`.",
+            "description": "Stringified `ProcAddr` of the proc hosting `MeshAdminAgent`.",
             "type": "string"
           },
           "url": {
@@ -785,7 +785,7 @@
     }
   },
   "info": {
-    "description": "Reference-walking introspection API for a Monarch actor mesh. See the Admin Gateway Pattern RFC.",
+    "description": "Address-walking introspection API for a Monarch actor mesh. See the Admin Gateway Pattern RFC.",
     "title": "Monarch Mesh Admin API",
     "version": "1.0.0"
   },
@@ -816,7 +816,7 @@
         "operationId": "getConfig",
         "parameters": [
           {
-            "description": "URL-encoded proc reference (ProcId)",
+            "description": "URL-encoded proc reference (ProcAddr)",
             "in": "path",
             "name": "proc_reference",
             "required": true,
@@ -910,7 +910,7 @@
         "operationId": "getPyspy",
         "parameters": [
           {
-            "description": "URL-encoded proc reference (ProcId)",
+            "description": "URL-encoded proc reference (ProcAddr)",
             "in": "path",
             "name": "proc_reference",
             "required": true,
@@ -980,7 +980,7 @@
         "operationId": "pyspyDumpAndStore",
         "parameters": [
           {
-            "description": "URL-encoded proc reference (ProcId)",
+            "description": "URL-encoded proc reference (ProcAddr)",
             "in": "path",
             "name": "proc_reference",
             "required": true,
@@ -1050,7 +1050,7 @@
         "operationId": "pyspyProfileSvg",
         "parameters": [
           {
-            "description": "URL-encoded proc reference (ProcId)",
+            "description": "URL-encoded proc reference (ProcAddr)",
             "in": "path",
             "name": "proc_reference",
             "required": true,
@@ -1346,7 +1346,7 @@
                 }
               }
             },
-            "description": "Reference not found"
+            "description": "Address not found"
           },
           "500": {
             "content": {

--- a/hyperactor_mesh_admin_tui/src/actions.rs
+++ b/hyperactor_mesh_admin_tui/src/actions.rs
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-use hyperactor::ProcId;
+use hyperactor::ProcAddr;
 use hyperactor_mesh::introspect::NodeRef;
 
 /// Result of handling a key event.
@@ -23,7 +23,7 @@ pub(crate) enum KeyResult {
     /// Start the self-diagnostic suite against the attached mesh.
     RunDiagnostics,
     /// Fetch a py-spy stack dump for the given proc.
-    RunPySpy(ProcId),
+    RunPySpy(ProcAddr),
     /// Fetch the config dump for the given proc.
-    RunConfig(ProcId),
+    RunConfig(ProcAddr),
 }

--- a/hyperactor_mesh_admin_tui/src/app.rs
+++ b/hyperactor_mesh_admin_tui/src/app.rs
@@ -199,7 +199,7 @@ impl App {
     /// Fetch a single node payload from the admin API.
     ///
     /// `reference` is the opaque identifier used by the server (e.g.
-    /// `"root"`, a `ProcId` string, or an `ActorId` string). The
+    /// `"root"`, a `ProcAddr` string, or an `ActorAddr` string). The
     /// reference is URL-encoded and requested from `GET
     /// /v1/{reference}`. Returns a parsed `NodePayload` on success,
     /// or a human-readable error string on failure.
@@ -609,7 +609,7 @@ impl App {
     /// - Proc selected → proc's own reference.
     /// - Actor selected → owning proc from `detail.parent`.
     /// - Root/Host selected → `None` (PY-4).
-    pub(crate) fn pyspy_proc_ref(&self) -> Option<hyperactor::ProcId> {
+    pub(crate) fn pyspy_proc_ref(&self) -> Option<hyperactor::ProcAddr> {
         let rows = self.visible_rows();
         let row = rows.get(&self.cursor)?;
         match (&row.node.node_type, &row.node.reference) {
@@ -654,11 +654,11 @@ impl App {
     ///
     /// Calls `set_job` which drops any prior variant and its receiver,
     /// cancelling any in-flight fetch (PY-1/PY-2).
-    pub(crate) fn start_pyspy(&mut self, proc_id: hyperactor::ProcId) {
+    pub(crate) fn start_pyspy(&mut self, proc_id: hyperactor::ProcAddr) {
         let proc_ref = proc_id.to_string();
         let short = proc_id
             .label()
-            .map(|l| l.as_str().to_string())
+            .map(|l: &hyperactor::id::Label| l.as_str().to_string())
             .unwrap_or_else(|| proc_id.id().to_string());
         let scheme = self.theme.scheme; // ColorScheme: Copy
         let client = self.client.clone();
@@ -713,11 +713,11 @@ impl App {
     ///
     /// Calls `set_job` which drops any prior variant and its receiver,
     /// cancelling any in-flight fetch (CFG-1/CFG-2).
-    pub(crate) fn start_config(&mut self, proc_id: hyperactor::ProcId) {
+    pub(crate) fn start_config(&mut self, proc_id: hyperactor::ProcAddr) {
         let proc_ref = proc_id.to_string();
         let short = proc_id
             .label()
-            .map(|l| l.as_str().to_string())
+            .map(|l: &hyperactor::id::Label| l.as_str().to_string())
             .unwrap_or_else(|| proc_id.id().to_string());
         let scheme = self.theme.scheme; // ColorScheme: Copy
         let client = self.client.clone();

--- a/hyperactor_telemetry/Cargo.toml
+++ b/hyperactor_telemetry/Cargo.toml
@@ -36,7 +36,6 @@ tracing-core = { version = "0.1.33", features = ["valuable"] }
 tracing-glog = { version = "0.4.1", features = ["ansi", "tracing-log"] }
 tracing-perfetto-sdk-schema = "0.13.1"
 tracing-subscriber = { version = "0.3.23", features = ["chrono", "env-filter", "json", "local-time", "parking_lot", "registry"] }
-urlencoding = "2.1.0"
 whoami = "1.5"
 
 [dev-dependencies]

--- a/hyperactor_telemetry/src/lib.rs
+++ b/hyperactor_telemetry/src/lib.rs
@@ -419,7 +419,7 @@ enum EntityEventState {
 /// This is passed to EntityEventDispatcher implementations when an actor is spawned.
 #[derive(Debug, Clone)]
 pub struct ActorEvent {
-    /// Unique identifier for this actor (hashed from ActorId)
+    /// Unique identifier for this actor (hashed from ActorAddr)
     pub id: u64,
     /// Timestamp when the actor was created
     pub timestamp: SystemTime,
@@ -499,7 +499,7 @@ pub fn notify_actor_status_changed(event: ActorStatusEvent) {
 #[derive(Debug, Clone)]
 pub struct SentMessageEvent {
     pub timestamp: SystemTime,
-    /// Hash of the sending actor's [`ActorId`].
+    /// Hash of the sending actor's [`ActorAddr`].
     pub sender_actor_id: u64,
     /// Hash of the target actor mesh's name.
     pub actor_mesh_id: u64,
@@ -526,9 +526,9 @@ pub struct MessageEvent {
     pub timestamp: SystemTime,
     /// Unique identifier for this received message.
     pub id: u64,
-    /// Hash of sender's ActorId.
+    /// Hash of sender's ActorAddr.
     pub from_actor_id: u64,
-    /// Hash of receiver's ActorId.
+    /// Hash of receiver's ActorAddr.
     pub to_actor_id: u64,
     /// Endpoint name if this message targets a specific actor endpoint
     pub endpoint: Option<String>,

--- a/monarch_distributed_telemetry/src/database_scanner.rs
+++ b/monarch_distributed_telemetry/src/database_scanner.rs
@@ -386,7 +386,7 @@ impl DatabaseScanner {
         let instance: Instance<PythonActor> = py_instance.clone_for_py();
 
         // Build destination PortRef once
-        let dest_port_id: reference::PortId = dest.clone().into();
+        let dest_port_id: reference::PortAddr = dest.clone().into();
         let dest_ref: reference::PortRef<QueryResponse> =
             reference::PortRef::attest(dest_port_id.into());
 

--- a/monarch_distributed_telemetry/src/entity_dispatcher.rs
+++ b/monarch_distributed_telemetry/src/entity_dispatcher.rs
@@ -111,9 +111,9 @@ pub struct Message {
     pub id: u64,
     /// Timestamp in microseconds since Unix epoch
     pub timestamp_us: i64,
-    /// Hash of sender's ActorId
+    /// Hash of sender's ActorAddr
     pub from_actor_id: u64,
-    /// Hash of receiver's ActorId
+    /// Hash of receiver's ActorAddr
     pub to_actor_id: u64,
     /// Message handler type name
     pub endpoint: Option<String>,

--- a/monarch_extension/src/client.rs
+++ b/monarch_extension/src/client.rs
@@ -11,7 +11,7 @@ use std::sync::Arc;
 use hyperactor as reference;
 use monarch_hyperactor::ndslice::PySlice;
 use monarch_hyperactor::proc::InstanceWrapper;
-use monarch_hyperactor::proc::PyActorId;
+use monarch_hyperactor::proc::PyActorAddr;
 use monarch_hyperactor::proc::PyProc;
 use monarch_hyperactor::proc::PySerialized;
 use monarch_hyperactor::runtime::monarch_with_gil_blocking;
@@ -116,7 +116,7 @@ impl PyError {
         seq: Seq,
         caused_by_seq: Seq,
         backtrace: String,
-        actor_id: &PyActorId,
+        actor_id: &PyActorAddr,
     ) -> PyResult<(Self, PyException)> {
         Ok((
             Self,
@@ -138,7 +138,7 @@ impl PyError {
         py: Python<'_>,
         seq: Seq,
         caused_by_seq: Seq,
-        actor_id: &PyActorId,
+        actor_id: &PyActorAddr,
         backtrace: String,
     ) -> PyResult<Py<PyAny>> {
         let initializer = PyClassInitializer::from(PyException {
@@ -166,7 +166,7 @@ impl PyError {
     }
 
     #[getter]
-    fn actor_id(self_: PyRef<Self>) -> PyActorId {
+    fn actor_id(self_: PyRef<Self>) -> PyActorAddr {
         self_
             .as_ref()
             .inner
@@ -264,7 +264,7 @@ impl PyFailure {
     fn new(
         backtrace: String,
         address: String,
-        actor_id: &PyActorId,
+        actor_id: &PyActorAddr,
     ) -> PyResult<(Self, PyException)> {
         Ok((
             Self,
@@ -281,7 +281,7 @@ impl PyFailure {
     #[staticmethod]
     fn new_for_unit_test(
         py: Python<'_>,
-        actor_id: &PyActorId,
+        actor_id: &PyActorAddr,
         backtrace: String,
     ) -> PyResult<Py<PyAny>> {
         let initializer = PyClassInitializer::from(PyException {
@@ -296,7 +296,7 @@ impl PyFailure {
     }
 
     #[getter]
-    fn actor_id(self_: PyRef<Self>) -> PyActorId {
+    fn actor_id(self_: PyRef<Self>) -> PyActorAddr {
         self_
             .as_ref()
             .inner
@@ -325,7 +325,7 @@ impl PyFailure {
     module = "monarch._rust_bindings.monarch_extension.client"
 )]
 pub struct DebuggerMessage {
-    debugger_actor_id: PyActorId,
+    debugger_actor_id: PyActorAddr,
     action: DebuggerAction,
 }
 
@@ -333,7 +333,7 @@ pub struct DebuggerMessage {
 impl DebuggerMessage {
     #[new]
     #[pyo3(signature = (*, debugger_actor_id, action))]
-    pub fn new(debugger_actor_id: PyActorId, action: DebuggerAction) -> PyResult<Self> {
+    pub fn new(debugger_actor_id: PyActorAddr, action: DebuggerAction) -> PyResult<Self> {
         Ok(Self {
             debugger_actor_id,
             action,
@@ -356,7 +356,7 @@ impl ClientActor {
     }
 
     #[staticmethod]
-    fn new_with_parent(_proc: &PyProc, _parent: &PyActorId) -> PyResult<Self> {
+    fn new_with_parent(_proc: &PyProc, _parent: &PyActorAddr) -> PyResult<Self> {
         // XXX:
         unimplemented!("this is not a valid thing to do!");
         // Ok(Self {
@@ -369,13 +369,13 @@ impl ClientActor {
 
     /// Send a message to any actor that can receive the corresponding serialized
     /// message.
-    fn send(&self, actor_id: &PyActorId, message: &PySerialized) -> PyResult<()> {
+    fn send(&self, actor_id: &PyActorAddr, message: &PySerialized) -> PyResult<()> {
         self.instance.blocking_lock().send(actor_id, message)
     }
 
     fn send_obj(
         &self,
-        controller: &PyActorId,
+        controller: &PyActorAddr,
         ranks: PyRanks,
         message: Bound<'_, PyAny>,
     ) -> PyResult<()> {
@@ -401,7 +401,7 @@ impl ClientActor {
     }
 
     /// Attach the client to a controller actor. This will block until the controller responds.
-    fn attach(&mut self, py: Python, controller_id: PyActorId) -> PyResult<()> {
+    fn attach(&mut self, py: Python, controller_id: PyActorAddr) -> PyResult<()> {
         let instance_wrapper = self.instance.blocking_lock();
         let actor_id = instance_wrapper.actor_id().clone();
         let (instance, _handler) = instance_wrapper
@@ -410,16 +410,16 @@ impl ClientActor {
             .map_err(|err| PyRuntimeError::new_err(err.to_string()))?;
 
         signal_safe_block_on(py, async move {
-            reference::ActorRef::<ControllerActor>::attest(
-                reference::ActorId::from(&controller_id).into(),
-            )
+            reference::ActorRef::<ControllerActor>::attest(reference::ActorAddr::from(
+                &controller_id,
+            ))
             .attach(&instance, reference::ActorRef::attest(actor_id.into()))
             .await
             .map_err(|err| PyRuntimeError::new_err(err.to_string()))
         })?
     }
 
-    fn drop_refs(&self, py: Python, controller_id: PyActorId, refs: Vec<Ref>) -> PyResult<()> {
+    fn drop_refs(&self, py: Python, controller_id: PyActorAddr, refs: Vec<Ref>) -> PyResult<()> {
         let instance_wrapper = self.instance.blocking_lock();
         let (instance, _handler) = instance_wrapper
             .instance()
@@ -427,9 +427,9 @@ impl ClientActor {
             .map_err(|err| PyRuntimeError::new_err(err.to_string()))?;
 
         signal_safe_block_on(py, async move {
-            reference::ActorRef::<ControllerActor>::attest(
-                reference::ActorId::from(&controller_id).into(),
-            )
+            reference::ActorRef::<ControllerActor>::attest(reference::ActorAddr::from(
+                &controller_id,
+            ))
             .drop_refs(&instance, refs)
             .await
             .map_err(|err| PyRuntimeError::new_err(err.to_string()))
@@ -502,9 +502,9 @@ impl ClientActor {
         PyList::new(py, messages)
     }
 
-    fn actor_id(&self) -> PyResult<PyActorId> {
+    fn actor_id(&self) -> PyResult<PyActorAddr> {
         let instance = self.instance.blocking_lock();
-        Ok(PyActorId::from(instance.actor_id().clone()))
+        Ok(PyActorAddr::from(instance.actor_id().clone()))
     }
 }
 

--- a/monarch_extension/src/convert.rs
+++ b/monarch_extension/src/convert.rs
@@ -11,7 +11,7 @@ use std::sync::OnceLock;
 
 use hyperactor as reference;
 use monarch_hyperactor::ndslice::PySlice;
-use monarch_hyperactor::proc::PyActorId;
+use monarch_hyperactor::proc::PyActorAddr;
 use monarch_messages::controller::Seq;
 use monarch_messages::worker;
 use monarch_messages::worker::ArgsKwargs;
@@ -180,13 +180,13 @@ impl<'a> MessageParser<'a> {
     fn parse_error_reason(
         &self,
         name: &str,
-    ) -> PyResult<Option<(Option<reference::ActorId>, String)>> {
+    ) -> PyResult<Option<(Option<reference::ActorAddr>, String)>> {
         let err = self.attr(name)?;
         if err.is_none() {
             return Ok(None);
         }
         if let Ok(actor_source_id) = err.getattr("source_actor_id") {
-            let actor_id: PyActorId = actor_source_id.extract()?;
+            let actor_id: PyActorAddr = actor_source_id.extract()?;
             return Ok(Some((
                 Some(actor_id.into()),
                 err.getattr("message")?.extract()?,

--- a/monarch_extension/src/mesh_controller.rs
+++ b/monarch_extension/src/mesh_controller.rs
@@ -103,7 +103,7 @@ impl _Controller {
         let proc_mesh = py_proc_mesh.downcast::<PyProcMesh>()?.borrow().mesh_ref()?;
 
         // Build rank map from proc ids to ranks.
-        let rank_map: HashMap<reference::ProcId, usize> = proc_mesh
+        let rank_map: HashMap<reference::ProcAddr, usize> = proc_mesh
             .iter()
             .map(|(point, proc)| (proc.proc_id().clone(), point.rank()))
             .collect();
@@ -156,7 +156,7 @@ impl _Controller {
         accumulate: bool,
     ) -> PyResult<()> {
         let response_port: Option<PortInfo> = response_port.map(|(port, ranks)| PortInfo {
-            port: reference::PortRef::attest(reference::PortId::from(port).into()),
+            port: reference::PortRef::attest(reference::PortAddr::from(port)),
             ranks: ranks.into(),
             accumulate,
         });
@@ -195,7 +195,7 @@ impl _Controller {
             .send(
                 instance.deref(),
                 ClientToControllerMessage::SyncAtExit {
-                    port: reference::PortRef::attest(reference::PortId::from(port).into()),
+                    port: reference::PortRef::attest(reference::PortAddr::from(port)),
                 },
             )
             .map_err(to_py_error)
@@ -731,13 +731,13 @@ struct MeshControllerActor {
     id: usize,
     debugger_active: Option<reference::ActorRef<DebuggerActor>>,
     debugger_paused: VecDeque<reference::ActorRef<DebuggerActor>>,
-    rank_map: HashMap<reference::ProcId, usize>,
+    rank_map: HashMap<reference::ProcAddr, usize>,
 }
 
 struct MeshControllerActorParams {
     proc_mesh_ref: ProcMeshRef,
     id: usize,
-    rank_map: HashMap<reference::ProcId, usize>,
+    rank_map: HashMap<reference::ProcAddr, usize>,
 }
 
 impl MeshControllerActor {
@@ -776,7 +776,7 @@ impl MeshControllerActor {
     async fn handle_debug(
         &mut self,
         this: &Context<'_, Self>,
-        debugger_actor_id: reference::ActorId,
+        debugger_actor_id: reference::ActorAddr,
         action: DebuggerAction,
     ) -> anyhow::Result<()> {
         if matches!(action, DebuggerAction::Paused()) {
@@ -889,7 +889,7 @@ impl Debug for MeshControllerActor {
 }
 
 impl MeshControllerActor {
-    fn rank_of_worker(&self, actor_id: &reference::ActorId) -> usize {
+    fn rank_of_worker(&self, actor_id: &reference::ActorAddr) -> usize {
         *self
             .rank_map
             .get(&actor_id.proc_id())

--- a/monarch_hyperactor/src/actor.rs
+++ b/monarch_hyperactor/src/actor.rs
@@ -75,7 +75,7 @@ use crate::metrics::ENDPOINT_ACTOR_ERROR;
 use crate::metrics::ENDPOINT_ACTOR_LATENCY_US_HISTOGRAM;
 use crate::metrics::ENDPOINT_ACTOR_PANIC;
 use crate::pickle::pickle_to_part;
-use crate::proc::PyActorId;
+use crate::proc::PyActorAddr;
 use crate::pympsc;
 use crate::pytokio::PythonTask;
 use crate::runtime::get_proc_runtime;
@@ -523,7 +523,7 @@ impl PythonActorHandle {
         Ok(())
     }
 
-    fn bind(&self) -> PyActorId {
+    fn bind(&self) -> PyActorAddr {
         self.inner.bind::<PythonActor>().into_actor_id().into()
     }
 }
@@ -1794,7 +1794,7 @@ mod tests {
             typehash: 123,
             builder_params: Some(wirevalue::Any::serialize(&"abcdefg12345".to_string()).unwrap()),
         };
-        let port_ref = reference::PortRef::<PythonMessage>::attest_reducible(
+        let port_ref = hyperactor::PortRef::<PythonMessage>::attest_reducible(
             test_port_id("world_0", "client", 123).into(),
             Some(reducer_spec),
             StreamingReducerOpts::default(),

--- a/monarch_hyperactor/src/actor_mesh.rs
+++ b/monarch_hyperactor/src/actor_mesh.rs
@@ -17,7 +17,6 @@ use async_trait::async_trait;
 use futures::future;
 use futures::future::FutureExt;
 use futures::future::Shared;
-use hyperactor as reference;
 use hyperactor::Instance;
 use hyperactor::supervision::ActorSupervisionEvent;
 use hyperactor_mesh::actor_mesh::ActorMesh;
@@ -46,7 +45,7 @@ use crate::actor::PythonMessage;
 use crate::actor::PythonMessageKind;
 use crate::context::PyInstance;
 use crate::pickle::PendingMessage;
-use crate::proc::PyActorId;
+use crate::proc::PyActorAddr;
 use crate::pytokio::PyPythonTask;
 use crate::runtime::get_tokio_runtime;
 use crate::runtime::monarch_with_gil;
@@ -719,12 +718,12 @@ impl ActorMeshProtocol for ActorMeshRef<PythonActor> {
 
 #[pymethods]
 impl PythonActorMeshImpl {
-    fn get(&self, rank: usize) -> PyResult<Option<PyActorId>> {
+    fn get(&self, rank: usize) -> PyResult<Option<PyActorAddr>> {
         Ok(self
             .mesh_ref()
             .get(rank)
-            .map(|r| reference::ActorRef::into_actor_id(r.clone()))
-            .map(PyActorId::from))
+            .map(|r| hyperactor::ActorRef::into_actor_id(r.clone()))
+            .map(PyActorAddr::from))
     }
 
     fn __repr__(&self) -> String {
@@ -758,8 +757,8 @@ impl PyActorSupervisionEvent {
     }
 
     #[getter]
-    pub(crate) fn actor_id(&self) -> PyResult<PyActorId> {
-        Ok(PyActorId::from(self.inner.actor_id.clone()))
+    pub(crate) fn actor_id(&self) -> PyResult<PyActorAddr> {
+        Ok(PyActorAddr::from(self.inner.actor_id.clone()))
     }
 
     #[getter]

--- a/monarch_hyperactor/src/context.rs
+++ b/monarch_hyperactor/src/context.rs
@@ -17,7 +17,7 @@ use pyo3::prelude::*;
 use crate::actor::PythonActor;
 use crate::actor::root_client_actor;
 use crate::mailbox::PyMailbox;
-use crate::proc::PyActorId;
+use crate::proc::PyActorAddr;
 use crate::runtime;
 use crate::shape::PyPoint;
 
@@ -78,8 +78,8 @@ impl PyInstance {
     }
 
     #[getter]
-    pub fn actor_id(&self) -> PyActorId {
-        let actor_id: hyperactor::ActorId = self.inner.self_id().clone();
+    pub fn actor_id(&self) -> PyActorAddr {
+        let actor_id: hyperactor::ActorAddr = self.inner.self_id().clone();
         actor_id.into()
     }
 

--- a/monarch_hyperactor/src/local_state_broker.rs
+++ b/monarch_hyperactor/src/local_state_broker.rs
@@ -9,7 +9,6 @@
 use std::collections::HashMap;
 
 use async_trait::async_trait;
-use hyperactor as reference;
 use hyperactor::Actor;
 use hyperactor::ActorHandle;
 use hyperactor::Context;
@@ -88,8 +87,8 @@ impl BrokerId {
 
         let broker_name = format!("{:?}", self);
         let actor_id = cx.proc().proc_id().actor_id(&self.0);
-        let actor_ref: reference::ActorRef<LocalStateBrokerActor> =
-            reference::ActorRef::attest(actor_id.into());
+        let actor_ref: hyperactor::ActorRef<LocalStateBrokerActor> =
+            hyperactor::ActorRef::attest(actor_id);
 
         let mut delay_ms = 1;
         loop {

--- a/monarch_hyperactor/src/logging.rs
+++ b/monarch_hyperactor/src/logging.rs
@@ -45,7 +45,7 @@ use serde::Serialize;
 use typeuri::Named;
 
 use crate::context::PyInstance;
-use crate::proc::PyActorId;
+use crate::proc::PyActorAddr;
 use crate::proc_mesh::PyProcMesh;
 use crate::pytokio::PyPythonTask;
 use crate::runtime::monarch_with_gil;
@@ -547,7 +547,7 @@ fn log_endpoint_exception<'py>(
     py: Python<'py>,
     e: Py<PyAny>,
     endpoint: Py<PyAny>,
-    actor_id: PyActorId,
+    actor_id: PyActorAddr,
 ) {
     let pyerr = PyErr::from_value(e.into_bound(py));
     let exception_str = format_traceback(py, &pyerr);

--- a/monarch_hyperactor/src/mailbox.rs
+++ b/monarch_hyperactor/src/mailbox.rs
@@ -12,7 +12,6 @@ use std::hash::Hasher;
 use std::ops::Deref;
 use std::sync::Arc;
 
-use hyperactor as reference;
 use hyperactor::Mailbox;
 use hyperactor::OncePortHandle;
 use hyperactor::PortHandle;
@@ -46,7 +45,7 @@ use typeuri::Named;
 use crate::actor::PythonMessage;
 use crate::actor::PythonMessageKind;
 use crate::context::PyInstance;
-use crate::proc::PyActorId;
+use crate::proc::PyActorAddr;
 use crate::pytokio::PyPythonTask;
 use crate::pytokio::PythonTask;
 use crate::runtime::monarch_with_gil;
@@ -115,7 +114,7 @@ impl PyMailbox {
         PyTuple::new(py, vec![handle.into_any(), receiver.into_any()])
     }
 
-    pub(super) fn post(&self, dest: &PyActorId, message: &PythonMessage) -> PyResult<()> {
+    pub(super) fn post(&self, dest: &PyActorAddr, message: &PythonMessage) -> PyResult<()> {
         let port_id = dest.inner.port_ref(PythonMessage::port().into());
         let message = wirevalue::Any::serialize(message).map_err(|err| {
             PyRuntimeError::new_err(format!(
@@ -138,9 +137,9 @@ impl PyMailbox {
     }
 
     #[getter]
-    pub(super) fn actor_id(&self) -> PyActorId {
-        PyActorId {
-            inner: self.inner.actor_id().clone().into(),
+    pub(super) fn actor_id(&self) -> PyActorAddr {
+        PyActorAddr {
+            inner: self.inner.actor_id().clone(),
         }
     }
 
@@ -156,16 +155,16 @@ impl PyMailbox {
 )]
 #[derive(Clone)]
 pub struct PyPortId {
-    inner: reference::PortId,
+    inner: hyperactor::PortAddr,
 }
 
-impl From<reference::PortId> for PyPortId {
-    fn from(port_id: reference::PortId) -> Self {
+impl From<hyperactor::PortAddr> for PyPortId {
+    fn from(port_id: hyperactor::PortAddr) -> Self {
         Self { inner: port_id }
     }
 }
 
-impl From<PyPortId> for reference::PortId {
+impl From<PyPortId> for hyperactor::PortAddr {
     fn from(port_id: PyPortId) -> Self {
         port_id.inner
     }
@@ -181,7 +180,7 @@ impl From<Mailbox> for PyMailbox {
 impl PyPortId {
     #[new]
     #[pyo3(signature = (*, actor_id, port))]
-    fn new(actor_id: &PyActorId, port: u64) -> Self {
+    fn new(actor_id: &PyActorAddr, port: u64) -> Self {
         Self {
             inner: actor_id.inner.port_ref(port.into()),
         }
@@ -197,8 +196,8 @@ impl PyPortId {
     }
 
     #[getter]
-    fn actor_id(&self) -> PyActorId {
-        PyActorId {
+    fn actor_id(&self) -> PyActorAddr {
+        PyActorAddr {
             inner: self.inner.actor_ref(),
         }
     }
@@ -274,7 +273,7 @@ impl PythonPortHandle {
     module = "monarch._rust_bindings.monarch_hyperactor.mailbox"
 )]
 pub struct PythonPortRef {
-    pub(crate) inner: reference::PortRef<PythonMessage>,
+    pub(crate) inner: hyperactor::PortRef<PythonMessage>,
 }
 
 #[pymethods]
@@ -282,7 +281,7 @@ impl PythonPortRef {
     #[new]
     fn new(port: PyPortId) -> Self {
         Self {
-            inner: reference::PortRef::attest(port.inner.into()),
+            inner: hyperactor::PortRef::attest(port.inner),
         }
     }
     fn __reduce__<'py>(
@@ -319,8 +318,8 @@ impl PythonPortRef {
     }
 }
 
-impl From<reference::PortRef<PythonMessage>> for PythonPortRef {
-    fn from(port_ref: reference::PortRef<PythonMessage>) -> Self {
+impl From<hyperactor::PortRef<PythonMessage>> for PythonPortRef {
+    fn from(port_ref: hyperactor::PortRef<PythonMessage>) -> Self {
         Self { inner: port_ref }
     }
 }
@@ -398,14 +397,14 @@ impl PythonUndeliverableMessageEnvelope {
         ))
     }
 
-    fn sender(&self) -> PyResult<PyActorId> {
-        Ok(PyActorId {
-            inner: self.inner()?.0.sender().clone().into(),
+    fn sender(&self) -> PyResult<PyActorAddr> {
+        Ok(PyActorAddr {
+            inner: self.inner()?.0.sender().clone(),
         })
     }
 
     fn dest(&self) -> PyResult<PyPortId> {
-        let port_id: hyperactor::PortId = self.inner()?.0.dest().clone();
+        let port_id: hyperactor::PortAddr = self.inner()?.0.dest().clone();
         Ok(port_id.into())
     }
 
@@ -454,7 +453,7 @@ impl PythonOncePortHandle {
     module = "monarch._rust_bindings.monarch_hyperactor.mailbox"
 )]
 pub struct PythonOncePortRef {
-    pub(crate) inner: Option<reference::OncePortRef<PythonMessage>>,
+    pub(crate) inner: Option<hyperactor::OncePortRef<PythonMessage>>,
 }
 
 #[pymethods]
@@ -462,7 +461,7 @@ impl PythonOncePortRef {
     #[new]
     fn new(port: Option<PyPortId>) -> Self {
         Self {
-            inner: port.map(|port| reference::PortRef::attest(port.inner.into()).into_once()),
+            inner: port.map(|port| hyperactor::PortRef::attest(port.inner).into_once()),
         }
     }
     fn __reduce__<'py>(
@@ -471,7 +470,7 @@ impl PythonOncePortRef {
         let id: Option<PyPortId> = (*slf.borrow())
             .inner
             .as_ref()
-            .map(|x: &reference::OncePortRef<PythonMessage>| x.port_id().clone().into());
+            .map(|x: &hyperactor::OncePortRef<PythonMessage>| x.port_id().clone().into());
         Ok((slf.get_type(), (id,)))
     }
 
@@ -479,7 +478,7 @@ impl PythonOncePortRef {
         let Some(port_ref) = self.inner.take() else {
             return Err(PyErr::new::<PyValueError, _>("OncePortRef is already used"));
         };
-        let port_ref: reference::OncePortRef<PythonMessage> = port_ref;
+        let port_ref: hyperactor::OncePortRef<PythonMessage> = port_ref;
         port_ref
             .send(instance.deref(), message)
             .map_err(|err| PyErr::new::<PyEOFError, _>(format!("Port closed: {}", err)))?;
@@ -489,7 +488,7 @@ impl PythonOncePortRef {
     fn __repr__(&self) -> String {
         self.inner.as_ref().map_or(
             "OncePortRef is already used".to_string(),
-            |r: &reference::OncePortRef<PythonMessage>| r.to_string(),
+            |r: &hyperactor::OncePortRef<PythonMessage>| r.to_string(),
         )
     }
 
@@ -511,8 +510,8 @@ impl PythonOncePortRef {
     }
 }
 
-impl From<reference::OncePortRef<PythonMessage>> for PythonOncePortRef {
-    fn from(port_ref: reference::OncePortRef<PythonMessage>) -> Self {
+impl From<hyperactor::OncePortRef<PythonMessage>> for PythonOncePortRef {
+    fn from(port_ref: hyperactor::OncePortRef<PythonMessage>) -> Self {
         Self {
             inner: Some(port_ref),
         }
@@ -590,7 +589,7 @@ impl EitherPortRef {
         match self {
             EitherPortRef::Unbounded(port_ref) => port_ref.inner.get_return_undeliverable(),
             EitherPortRef::Once(once_port_ref) => once_port_ref.inner.as_ref().is_some_and(
-                |r: &reference::OncePortRef<PythonMessage>| r.get_return_undeliverable(),
+                |r: &hyperactor::OncePortRef<PythonMessage>| r.get_return_undeliverable(),
             ),
         }
     }

--- a/monarch_hyperactor/src/proc.rs
+++ b/monarch_hyperactor/src/proc.rs
@@ -12,7 +12,6 @@ use std::hash::Hasher;
 use std::time::Duration;
 
 use anyhow::Result;
-use hyperactor as reference;
 use hyperactor::RemoteMessage;
 use hyperactor::actor::Signal;
 use hyperactor::channel::ChannelAddr;
@@ -138,28 +137,28 @@ impl PyProc {
 
 #[pyclass(
     frozen,
-    name = "ActorId",
+    name = "ActorAddr",
     module = "monarch._rust_bindings.monarch_hyperactor.proc"
 )]
 #[derive(Clone)]
-pub struct PyActorId {
-    pub(super) inner: reference::ActorId,
+pub struct PyActorAddr {
+    pub(super) inner: hyperactor::ActorAddr,
 }
 
-impl From<reference::ActorId> for PyActorId {
-    fn from(actor_id: reference::ActorId) -> Self {
+impl From<hyperactor::ActorAddr> for PyActorAddr {
+    fn from(actor_id: hyperactor::ActorAddr) -> Self {
         Self { inner: actor_id }
     }
 }
 
-impl From<PyActorId> for reference::ActorId {
-    fn from(val: PyActorId) -> Self {
+impl From<PyActorAddr> for hyperactor::ActorAddr {
+    fn from(val: PyActorAddr) -> Self {
         val.inner
     }
 }
 
 #[pymethods]
-impl PyActorId {
+impl PyActorAddr {
     #[new]
     #[pyo3(signature = (*, addr, proc_name, actor_name))]
     fn new(addr: &str, proc_name: &str, actor_name: &str) -> PyResult<Self> {
@@ -167,7 +166,7 @@ impl PyActorId {
             PyValueError::new_err(format!("Failed to parse channel address '{}': {}", addr, e))
         })?;
         Ok(Self {
-            inner: reference::ProcId::from_resource_name(addr, proc_name).actor_id(actor_name),
+            inner: hyperactor::ProcAddr::from_resource_name(addr, proc_name).actor_id(actor_name),
         })
     }
 
@@ -251,7 +250,7 @@ impl PyActorId {
     }
 
     fn __eq__(&self, other: &Bound<'_, PyAny>) -> PyResult<bool> {
-        if let Ok(other) = other.extract::<PyActorId>() {
+        if let Ok(other) = other.extract::<PyActorAddr>() {
             Ok(self.inner == other.inner)
         } else {
             Ok(false)
@@ -263,13 +262,13 @@ impl PyActorId {
     }
 }
 
-impl From<&PyActorId> for reference::ActorId {
-    fn from(actor_id: &PyActorId) -> Self {
+impl From<&PyActorAddr> for hyperactor::ActorAddr {
+    fn from(actor_id: &PyActorAddr) -> Self {
         actor_id.inner.clone()
     }
 }
 
-impl std::fmt::Debug for PyActorId {
+impl std::fmt::Debug for PyActorAddr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         self.inner.fmt(f)
     }
@@ -329,7 +328,7 @@ pub struct InstanceWrapper<M: RemoteMessage> {
     message_receiver: PortReceiver<M>,
     signal_receiver: PortReceiver<Signal>,
     status: InstanceStatus,
-    actor_id: reference::ActorId,
+    actor_id: hyperactor::ActorAddr,
 }
 
 impl<M: RemoteMessage> InstanceWrapper<M> {
@@ -340,7 +339,7 @@ impl<M: RemoteMessage> InstanceWrapper<M> {
 
         let (_signal_port, signal_receiver) = instance.bind_actor_port::<Signal>();
 
-        let actor_id = instance.self_id().clone().into();
+        let actor_id = instance.self_id().clone();
 
         Ok(Self {
             instance,
@@ -353,7 +352,7 @@ impl<M: RemoteMessage> InstanceWrapper<M> {
 
     /// Send a message to any actor. It is the responsibility of the caller to ensure the right
     /// payload accepted by the target actor has been serialized and provided to this function.
-    pub fn send(&self, actor_id: &PyActorId, message: &PySerialized) -> PyResult<()> {
+    pub fn send(&self, actor_id: &PyActorAddr, message: &PySerialized) -> PyResult<()> {
         hyperactor::internal_macro_support::tracing::debug!(
             name = "py_send_message",
             actor_id = hyperactor::internal_macro_support::tracing::field::display(self.actor_id()),
@@ -455,14 +454,14 @@ impl<M: RemoteMessage> InstanceWrapper<M> {
         &self.instance
     }
 
-    pub fn actor_id(&self) -> &reference::ActorId {
+    pub fn actor_id(&self) -> &hyperactor::ActorAddr {
         &self.actor_id
     }
 }
 
 pub fn register_python_bindings(hyperactor_mod: &Bound<'_, PyModule>) -> PyResult<()> {
     hyperactor_mod.add_class::<PyProc>()?;
-    hyperactor_mod.add_class::<PyActorId>()?;
+    hyperactor_mod.add_class::<PyActorAddr>()?;
     hyperactor_mod.add_class::<PySerialized>()?;
     Ok(())
 }

--- a/monarch_hyperactor/src/proc_launcher.rs
+++ b/monarch_hyperactor/src/proc_launcher.rs
@@ -21,7 +21,6 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use async_trait::async_trait;
-use hyperactor as reference;
 use hyperactor::ActorHandle;
 use hyperactor::Instance;
 use hyperactor::Mailbox;
@@ -567,7 +566,7 @@ pub struct ActorProcLauncher {
     ///
     /// Not used for correctness; used for diagnostics and sanity
     /// checks.
-    active_procs: Arc<Mutex<HashSet<reference::ProcId>>>,
+    active_procs: Arc<Mutex<HashSet<hyperactor::ProcAddr>>>,
 }
 
 impl ActorProcLauncher {
@@ -621,7 +620,7 @@ impl ProcLauncher for ActorProcLauncher {
     ///   resolves to `ProcExitKind::Failed` with a decode error reason.
     async fn launch(
         &self,
-        proc_id: &reference::ProcId,
+        proc_id: &hyperactor::ProcAddr,
         opts: LaunchOptions,
     ) -> Result<LaunchResult, ProcLauncherError> {
         let (exit_port, exit_port_rx) = self.mailbox.open_once_port::<PythonMessage>();
@@ -704,13 +703,14 @@ impl ProcLauncher for ActorProcLauncher {
             .send(&self.instance, message)
             .map_err(|e| ProcLauncherError::Other(format!("send to spawner failed: {e}")))?;
 
-        let mut active_procs: tokio::sync::MutexGuard<'_, HashSet<reference::ProcId>> =
+        let mut active_procs: tokio::sync::MutexGuard<'_, HashSet<hyperactor::ProcAddr>> =
             self.active_procs.lock().await;
         active_procs.insert(proc_id.clone());
         drop(active_procs);
 
         let (exit_tx, exit_rx) = oneshot::channel();
-        let active_procs: Arc<Mutex<HashSet<reference::ProcId>>> = Arc::clone(&self.active_procs);
+        let active_procs: Arc<Mutex<HashSet<hyperactor::ProcAddr>>> =
+            Arc::clone(&self.active_procs);
         let proc_id_clone = proc_id.clone();
 
         tokio::spawn(async move {
@@ -758,7 +758,7 @@ impl ProcLauncher for ActorProcLauncher {
     /// - send the message to the spawner actor.
     async fn terminate(
         &self,
-        proc_id: &reference::ProcId,
+        proc_id: &hyperactor::ProcAddr,
         timeout: Duration,
     ) -> Result<(), ProcLauncherError> {
         let pickled = Python::attach(|py| -> Result<Vec<u8>, ProcLauncherError> {
@@ -801,7 +801,7 @@ impl ProcLauncher for ActorProcLauncher {
     /// Returns `ProcLauncherError::Kill` if we fail to:
     /// - import/serialize the request via `cloudpickle`, or
     /// - send the message to the spawner actor.
-    async fn kill(&self, proc_id: &reference::ProcId) -> Result<(), ProcLauncherError> {
+    async fn kill(&self, proc_id: &hyperactor::ProcAddr) -> Result<(), ProcLauncherError> {
         let pickled = Python::attach(|py| -> Result<Vec<u8>, ProcLauncherError> {
             let cloudpickle =
                 import_cloudpickle(py).map_err(|e| ProcLauncherError::Kill(format!("{e}")))?;

--- a/monarch_hyperactor/src/runtime.rs
+++ b/monarch_hyperactor/src/runtime.rs
@@ -16,7 +16,6 @@ use std::sync::atomic::Ordering;
 use std::time::Duration;
 
 use anyhow::Result;
-use hyperactor as reference;
 use hyperactor::Proc;
 use hyperactor::channel::ChannelAddr;
 use hyperactor::channel::ChannelTransport;
@@ -89,7 +88,7 @@ pub(crate) fn get_proc_runtime() -> &'static Proc {
     static RUNTIME_PROC: OnceLock<Proc> = OnceLock::new();
     RUNTIME_PROC.get_or_init(|| {
         let addr = ChannelAddr::any(ChannelTransport::Local);
-        let proc_id = reference::ProcId::unique(addr, "monarch_hyperactor_runtime");
+        let proc_id = hyperactor::ProcAddr::unique(addr, "monarch_hyperactor_runtime");
         Proc::configured(proc_id, BoxedMailboxSender::new(PanickingMailboxSender))
     })
 }

--- a/monarch_hyperactor/src/telemetry.rs
+++ b/monarch_hyperactor/src/telemetry.rs
@@ -18,7 +18,7 @@ use opentelemetry::metrics;
 use pyo3::prelude::*;
 use pyo3::types::PyTraceback;
 
-use crate::proc::PyActorId;
+use crate::proc::PyActorAddr;
 
 /// Get the current span ID from the active span
 #[pyfunction]
@@ -254,7 +254,7 @@ struct PySpan {
 impl PySpan {
     #[new]
     #[pyo3(signature = (name, actor_id = None))]
-    fn new(name: &str, actor_id: Option<&PyActorId>) -> Self {
+    fn new(name: &str, actor_id: Option<&PyActorAddr>) -> Self {
         let mut fields = vec![("name", FieldValue::Str(name.to_string()))];
         if let Some(actor_id) = actor_id {
             fields.push(("actor_id", FieldValue::Str(actor_id.inner.to_string())));

--- a/monarch_introspection_snapshot/src/schema.rs
+++ b/monarch_introspection_snapshot/src/schema.rs
@@ -17,7 +17,7 @@
 //! Typed in Rust, canonical string IDs in SQL, numeric time in SQL.
 //! ID columns (`node_id`, `parent_id`, `child_id`,
 //! `failure_root_cause_actor`) are opaque strings derived from typed
-//! refs (`NodeRef`, `ActorId`, `ProcId`) at the conversion boundary.
+//! refs (`NodeRef`, `ActorAddr`, `ProcAddr`) at the conversion boundary.
 //! Timestamps are `i64` microseconds since epoch. Queries should
 //! treat ID columns as opaque join keys — do not parse them in SQL.
 //!
@@ -249,7 +249,7 @@ pub struct ActorFailureRow {
     pub node_id: String,
     /// Human-readable error message.
     pub failure_error_message: String,
-    /// Opaque `ActorId.to_string()` of the root-cause actor — do not
+    /// Opaque `ActorAddr.to_string()` of the root-cause actor — do not
     /// parse in SQL.
     pub failure_root_cause_actor: String,
     /// Display name of the root-cause actor. Nullable —

--- a/monarch_introspection_snapshot/src/service.rs
+++ b/monarch_introspection_snapshot/src/service.rs
@@ -428,7 +428,7 @@ mod tests {
     use std::collections::HashMap;
     use std::time::SystemTime;
 
-    use hyperactor::ProcId;
+    use hyperactor::ProcAddr;
     use hyperactor::channel::ChannelAddr;
     use hyperactor_mesh::host_mesh::host_agent::HOST_MESH_AGENT_ACTOR_NAME;
     use hyperactor_mesh::introspect::NodeProperties;
@@ -444,8 +444,8 @@ mod tests {
     /// and as the `actor_type` string in test fixtures.
     const ACTOR_TYPE: &str = "test_actor";
 
-    fn test_proc_id() -> ProcId {
-        ProcId::from_resource_name(ChannelAddr::Local(0), PROC_NAME)
+    fn test_proc_id() -> ProcAddr {
+        ProcAddr::from_resource_name(ChannelAddr::Local(0), PROC_NAME)
     }
 
     /// Build a stub resolver backed by a `HashMap`.

--- a/monarch_messages/src/client.rs
+++ b/monarch_messages/src/client.rs
@@ -93,8 +93,8 @@ pub enum ClientMessage {
 
     /// Notify the client of a debugger event.
     DebuggerMessage {
-        /// The actor id of the debugger.
-        debugger_actor_id: reference::ActorId,
+        /// The actor address of the debugger.
+        debugger_actor_id: reference::ActorAddr,
         /// The action to take.
         action: DebuggerAction,
     },

--- a/monarch_messages/src/controller.rs
+++ b/monarch_messages/src/controller.rs
@@ -127,9 +127,9 @@ pub struct WorkerError {
     /// The message and/or stack trace of the error.
     pub backtrace: String,
 
-    /// Actor id of the worker that had the error.
+    /// Actor address of the worker that had the error.
     // TODO: arguably at this level we only care about the rank
-    pub worker_actor_id: reference::ActorId,
+    pub worker_actor_id: reference::ActorAddr,
 }
 
 /// Device operation failures.
@@ -142,9 +142,9 @@ pub struct DeviceFailure {
     /// Address of the device that had the error.
     pub address: String,
 
-    /// Actor id of the worker that had the error.
+    /// Actor address of the worker that had the error.
     // TODO: arguably at this level we only care about the rank
-    pub actor_id: reference::ActorId,
+    pub actor_id: reference::ActorAddr,
 }
 
 /// Controller messages. These define the contract that the controller has with the client
@@ -205,7 +205,7 @@ pub enum ControllerMessage {
     // TODO: T212094401 take a ActorRef
     Status {
         seq: Seq,
-        worker_actor_id: reference::ActorId,
+        worker_actor_id: reference::ActorAddr,
         controller: bool,
     },
 
@@ -230,7 +230,7 @@ pub enum ControllerMessage {
 
     /// Debugger message sent from a debugger to be forwarded back to the client.
     DebuggerMessage {
-        debugger_actor_id: reference::ActorId,
+        debugger_actor_id: reference::ActorAddr,
         action: DebuggerAction,
     },
 }

--- a/monarch_messages/src/worker.rs
+++ b/monarch_messages/src/worker.rs
@@ -858,7 +858,7 @@ pub enum WorkerMessage {
         /// - error message or stacktrace
         ///
         /// The worker process will be stopped if the error is provided.
-        error: Option<(Option<reference::ActorId>, String)>,
+        error: Option<(Option<reference::ActorAddr>, String)>,
     },
 
     /// Defines (part of) a new recording on the worker. This is a list of commands

--- a/monarch_rdma/src/backend/ibverbs/manager_actor.rs
+++ b/monarch_rdma/src/backend/ibverbs/manager_actor.rs
@@ -608,7 +608,7 @@ impl IbvManagerActor {
         other_device: String,
     ) -> Result<IbvQueuePair, anyhow::Error> {
         let self_ref: reference::ActorRef<IbvManagerActor> = cx.bind();
-        let other_id = other.actor_id().clone();
+        let other_id = other.actor_id().id().clone();
 
         // Use the nested map structure: local_device -> (actor_id, remote_device) -> IbvQueuePair
         let inner_key = (other_id.clone(), other_device.clone());
@@ -670,7 +670,7 @@ impl IbvManagerActor {
 
         // Queue pair doesn't exist - need to create connection
         let result = async {
-            let is_loopback = other_id == *self_ref.actor_id() && self_device == other_device;
+            let is_loopback = other_id == *self_ref.actor_id().id() && self_device == other_device;
 
             if is_loopback {
                 // Loopback connection setup
@@ -855,7 +855,7 @@ impl IbvManagerMessageHandler for IbvManagerActor {
         endpoint: IbvQpInfo,
     ) -> Result<(), anyhow::Error> {
         tracing::debug!("connecting with {:?}", other);
-        let other_id = other.actor_id().clone();
+        let other_id = other.actor_id().id().clone();
 
         let inner_key = (other_id.clone(), other_device.clone());
 
@@ -889,7 +889,7 @@ impl IbvManagerMessageHandler for IbvManagerActor {
         self_device: String,
         other_device: String,
     ) -> Result<bool, anyhow::Error> {
-        let other_id = other.actor_id().clone();
+        let other_id = other.actor_id().id().clone();
         let inner_key = (other_id.clone(), other_device.clone());
 
         // Check if QP already exists in nested structure
@@ -939,7 +939,7 @@ impl IbvManagerMessageHandler for IbvManagerActor {
         other_device: String,
     ) -> Result<IbvQpInfo, anyhow::Error> {
         tracing::debug!("getting connection info with {:?}", other);
-        let other_id = other.actor_id().clone();
+        let other_id = other.actor_id().id().clone();
 
         let inner_key = (other_id.clone(), other_device.clone());
 
@@ -982,7 +982,7 @@ impl IbvManagerMessageHandler for IbvManagerActor {
         self_device: String,
         other_device: String,
     ) -> Result<u32, anyhow::Error> {
-        let other_id = other.actor_id().clone();
+        let other_id = other.actor_id().id().clone();
         let inner_key = (other_id.clone(), other_device.clone());
 
         let device_map: Option<&mut HashMap<(reference::ActorId, String), IbvQueuePair>> =

--- a/monarch_tensor_worker/src/lib.rs
+++ b/monarch_tensor_worker/src/lib.rs
@@ -598,7 +598,7 @@ impl WorkerMessageHandler for WorkerActor {
             &self.controller_actor,
             cx,
             seq.next(),
-            cx.self_id().clone().into(),
+            cx.self_id().clone(),
             controller,
         )
         .await?;
@@ -714,7 +714,7 @@ impl WorkerMessageHandler for WorkerActor {
     async fn exit(
         &mut self,
         cx: &hyperactor::Context<Self>,
-        error: Option<(Option<reference::ActorId>, String)>,
+        error: Option<(Option<reference::ActorAddr>, String)>,
     ) -> Result<()> {
         for (_, stream) in self.streams.drain() {
             stream.drain_and_stop("tensor worker exit cleanup")?;
@@ -740,7 +740,7 @@ impl WorkerMessageHandler for WorkerActor {
                     actor_id,
                     reason
                 );
-                if *cx.self_id() == actor_id {
+                if cx.self_id() == &actor_id {
                     self_error_exit_code
                 } else {
                     peer_error_exit_code
@@ -792,7 +792,7 @@ impl WorkerMessageHandler for WorkerActor {
             .send_value(
                 cx,
                 seq,
-                cx.self_id().clone().into(),
+                cx.self_id().clone(),
                 mutates,
                 function,
                 args_kwargs,

--- a/monarch_tensor_worker/src/stream.rs
+++ b/monarch_tensor_worker/src/stream.rs
@@ -205,7 +205,7 @@ pub enum StreamMessage {
 
     SendValue {
         seq: Seq,
-        worker_actor_id: reference::ActorId,
+        worker_actor_id: reference::ActorAddr,
         mutates: Vec<Ref>,
         function: Option<ResolvableFunction>,
         args_kwargs: ArgsKwargs,
@@ -504,9 +504,9 @@ impl Actor for StreamActor {
                 .cloned()
                 .unwrap_or_else(|| Label::new("stream").unwrap());
             root_actor_id
-                .set(reference::ActorId::root(
-                    cx.self_id().proc_ref(),
+                .set(reference::ActorId::singleton(
                     root_label,
+                    cx.self_id().proc_ref().id().clone(),
                 ))
                 .ok()
         });
@@ -647,7 +647,7 @@ impl StreamActor {
                 if self.active_recording.is_none() {
                     let worker_error = WorkerError {
                         backtrace: format!("{e}"),
-                        worker_actor_id: cx.self_id().clone().into(),
+                        worker_actor_id: cx.self_id().clone(),
                     };
                     tracing::info!("Propagating remote function error to client: {worker_error}");
                     self.controller_actor
@@ -1454,7 +1454,7 @@ impl StreamMessageHandler for StreamActor {
         &mut self,
         cx: &Context<Self>,
         seq: Seq,
-        worker_actor_id: reference::ActorId,
+        worker_actor_id: reference::ActorAddr,
         mutates: Vec<Ref>,
         function: Option<ResolvableFunction>,
         args_kwargs: ArgsKwargs,
@@ -1797,7 +1797,7 @@ impl StreamMessageHandler for StreamActor {
                             seq,
                             WorkerError {
                                 backtrace: format!("recording failed: {}", &seq_err),
-                                worker_actor_id: cx.self_id().clone().into(),
+                                worker_actor_id: cx.self_id().clone(),
                             },
                         )
                         .await?;
@@ -2101,7 +2101,7 @@ mod tests {
             .send_value(
                 cx,
                 seq,
-                stream_actor.actor_id().clone().into(),
+                stream_actor.actor_id().clone(),
                 Vec::new(),
                 None,
                 ArgsKwargs::from_wire_values(

--- a/python/monarch/_rust_bindings/monarch_extension/client.pyi
+++ b/python/monarch/_rust_bindings/monarch_extension/client.pyi
@@ -9,7 +9,7 @@
 from typing import Any, ClassVar, Dict, final, List, NamedTuple, Union
 
 from monarch._rust_bindings.monarch_extension.tensor_worker import Ref
-from monarch._rust_bindings.monarch_hyperactor.proc import ActorId, Proc, Serialized
+from monarch._rust_bindings.monarch_hyperactor.proc import ActorAddr, Proc, Serialized
 from monarch._rust_bindings.monarch_hyperactor.shape import Slice as NDSlice
 from monarch._rust_bindings.monarch_messages.debugger import DebuggerActionType
 
@@ -38,8 +38,8 @@ class Error(Exception):
         ...
 
     @property
-    def actor_id(self) -> ActorId:
-        """The actor id of the worker where the error occured."""
+    def actor_id(self) -> ActorAddr:
+        """The actor address of the worker where the error occured."""
         ...
 
     @property
@@ -49,7 +49,7 @@ class Error(Exception):
 
     @staticmethod
     def new_for_unit_test(
-        seq: int, caused_by_seq: int, actor_id: ActorId, backtrace: str
+        seq: int, caused_by_seq: int, actor_id: ActorAddr, backtrace: str
     ) -> "Error": ...
 
 @final
@@ -61,8 +61,8 @@ class Failure(Exception):
     """
 
     @property
-    def actor_id(self) -> ActorId:
-        """The actor id of the worker where the failure occured."""
+    def actor_id(self) -> ActorAddr:
+        """The actor address of the worker where the failure occured."""
         ...
 
     @property
@@ -76,7 +76,7 @@ class Failure(Exception):
         ...
 
     @staticmethod
-    def new_for_unit_test(actor_id: ActorId) -> "Failure": ...
+    def new_for_unit_test(actor_id: ActorAddr) -> "Failure": ...
 
 @final
 class WorkerResponse:
@@ -153,45 +153,45 @@ class ClientActor:
 
     def __init__(self, proc: Proc, actor_name: str) -> None: ...
     @staticmethod
-    def new_with_parent(proc: Proc, parent_id: ActorId) -> ClientActor:
+    def new_with_parent(proc: Proc, parent_id: ActorAddr) -> ClientActor:
         """
         Create a new client actor with the given parent id. This is used to create
         a client actor that is a child of another client actor.
         """
         ...
 
-    def attach(self, controller_id: ActorId) -> None:
+    def attach(self, controller_id: ActorAddr) -> None:
         """Attach the client to the given controller.
 
         Arguments:
-        - `controller_id`: The actor id of the controller to attach to.
+        - `controller_id`: The actor address of the controller to attach to.
         """
         ...
 
-    def send(self, actor_id: ActorId, message: Serialized) -> None:
-        """Send a message to the actor with the given actor id.
+    def send(self, actor_id: ActorAddr, message: Serialized) -> None:
+        """Send a message to the actor with the given actor address.
 
         Arguments:
-        - `actor_id`: The actor id of the actor to send the message to.
+        - `actor_id`: The actor address of the actor to send the message to.
         - `message`: The message to send.
         """
         ...
 
     def send_obj(
         self,
-        controller: ActorId,
+        controller: ActorAddr,
         ranks: Union[NDSlice | List[NDSlice]],
         message: NamedTuple,
     ) -> None:
         """Send a worker message to the controller actor
 
         Arguments:
-        - `actor_id`: The actor id of the actor to send the message to.
+        - `actor_id`: The actor address of the actor to send the message to.
         - `message`: The monarch
         """
         ...
 
-    def drop_refs(self, controller_id: ActorId, refs: List[Ref]) -> None:
+    def drop_refs(self, controller_id: ActorAddr, refs: List[Ref]) -> None:
         """
         Mark references as never being used again
         """
@@ -217,8 +217,8 @@ class ClientActor:
         ...
 
     @property
-    def actor_id(self) -> ActorId:
-        """The actor id of the actor."""
+    def actor_id(self) -> ActorAddr:
+        """The actor address of the actor."""
         ...
 
 @final
@@ -228,11 +228,11 @@ class DebuggerMessage:
     """
 
     def __init__(
-        self, *, debugger_actor_id: ActorId, action: DebuggerActionType
+        self, *, debugger_actor_id: ActorAddr, action: DebuggerActionType
     ) -> None: ...
     @property
-    def debugger_actor_id(self) -> ActorId:
-        """Get the actor id of the debugger actor."""
+    def debugger_actor_id(self) -> ActorAddr:
+        """Get the actor address of the debugger actor."""
         ...
 
     @property

--- a/python/monarch/_rust_bindings/monarch_extension/mesh_controller.pyi
+++ b/python/monarch/_rust_bindings/monarch_extension/mesh_controller.pyi
@@ -12,7 +12,7 @@ from typing import List, NamedTuple, Sequence, Tuple, Union
 from monarch._rust_bindings.monarch_extension import client
 from monarch._rust_bindings.monarch_hyperactor.context import Instance
 from monarch._rust_bindings.monarch_hyperactor.mailbox import PortId
-from monarch._rust_bindings.monarch_hyperactor.proc import ActorId
+from monarch._rust_bindings.monarch_hyperactor.proc import ActorAddr
 from monarch._rust_bindings.monarch_hyperactor.proc_mesh import ProcMesh
 from monarch._rust_bindings.monarch_hyperactor.shape import Slice as NDSlice
 

--- a/python/monarch/_rust_bindings/monarch_hyperactor/actor.pyi
+++ b/python/monarch/_rust_bindings/monarch_hyperactor/actor.pyi
@@ -24,7 +24,7 @@ from typing import (
 from monarch._rust_bindings.monarch_hyperactor.buffers import Buffer, FrozenBuffer
 from monarch._rust_bindings.monarch_hyperactor.mailbox import OncePortRef, PortRef
 from monarch._rust_bindings.monarch_hyperactor.pickle import PicklingState
-from monarch._rust_bindings.monarch_hyperactor.proc import ActorId, Proc, Serialized
+from monarch._rust_bindings.monarch_hyperactor.proc import ActorAddr, Proc, Serialized
 
 class PythonMessageKind:
     @classmethod
@@ -168,9 +168,9 @@ class PythonActorHandle:
         """
         ...
 
-    def bind(self) -> ActorId:
+    def bind(self) -> ActorAddr:
         """
-        Bind this actor. The returned actor id can be used to reach the actor externally.
+        Bind this actor. The returned actor address can be used to reach the actor externally.
         """
         ...
 

--- a/python/monarch/_rust_bindings/monarch_hyperactor/actor_mesh.pyi
+++ b/python/monarch/_rust_bindings/monarch_hyperactor/actor_mesh.pyi
@@ -11,7 +11,7 @@ from typing import final, Protocol
 from monarch._rust_bindings.monarch_hyperactor.actor import PythonMessage
 from monarch._rust_bindings.monarch_hyperactor.context import Instance
 from monarch._rust_bindings.monarch_hyperactor.pickle import PendingMessage
-from monarch._rust_bindings.monarch_hyperactor.proc import ActorId
+from monarch._rust_bindings.monarch_hyperactor.proc import ActorAddr
 from monarch._rust_bindings.monarch_hyperactor.pytokio import PythonTask
 from monarch._rust_bindings.monarch_hyperactor.shape import Region
 from typing_extensions import Self
@@ -53,9 +53,9 @@ class PythonActorMesh(ActorMeshProtocol):
 @final
 class ActorSupervisionEvent:
     @property
-    def actor_id(self) -> ActorId:
+    def actor_id(self) -> ActorAddr:
         """
-        The actor id of the actor.
+        The actor address of the actor.
         """
         ...
 

--- a/python/monarch/_rust_bindings/monarch_hyperactor/logging.pyi
+++ b/python/monarch/_rust_bindings/monarch_hyperactor/logging.pyi
@@ -8,7 +8,7 @@
 
 from typing import final, TYPE_CHECKING
 
-from monarch._rust_bindings.monarch_hyperactor.proc import ActorId
+from monarch._rust_bindings.monarch_hyperactor.proc import ActorAddr
 from monarch._rust_bindings.monarch_hyperactor.proc_mesh import ProcMesh
 from monarch._rust_bindings.monarch_hyperactor.pytokio import PythonTask
 
@@ -33,4 +33,6 @@ class LoggingMeshClient:
     ) -> None: ...
     def flush(self, instance: Instance) -> PythonTask[None]: ...
 
-def log_endpoint_exception(e: Exception, endpoint: str, actor_id: ActorId) -> None: ...
+def log_endpoint_exception(
+    e: Exception, endpoint: str, actor_id: ActorAddr
+) -> None: ...

--- a/python/monarch/_rust_bindings/monarch_hyperactor/mailbox.pyi
+++ b/python/monarch/_rust_bindings/monarch_hyperactor/mailbox.pyi
@@ -10,12 +10,12 @@ from typing import final, Protocol
 
 from monarch._rust_bindings.monarch_hyperactor.actor import PythonMessage
 from monarch._rust_bindings.monarch_hyperactor.context import Instance
-from monarch._rust_bindings.monarch_hyperactor.proc import ActorId
+from monarch._rust_bindings.monarch_hyperactor.proc import ActorAddr
 from monarch._rust_bindings.monarch_hyperactor.pytokio import PythonTask
 
 @final
 class PortId:
-    def __init__(self, *, actor_id: ActorId, port: int) -> None:
+    def __init__(self, *, actor_id: ActorAddr, port: int) -> None:
         """
         Create a new port id given an actor id and a port index.
         """
@@ -24,7 +24,7 @@ class PortId:
     def __hash__(self) -> int: ...
     def __eq__(self, other: object) -> bool: ...
     @property
-    def actor_id(self) -> ActorId:
+    def actor_id(self) -> ActorAddr:
         """
         The ID of the actor that owns the port.
         """
@@ -166,7 +166,7 @@ class Mailbox:
         """Open a accum port."""
         ...
 
-    def post(self, dest: ActorId, message: PythonMessage) -> None:
+    def post(self, dest: ActorAddr, message: PythonMessage) -> None:
         """
         Post a message to the provided destination. If the destination is an actor id,
         the message is sent to the default handler for `PythonMessage` on the actor.
@@ -175,7 +175,7 @@ class Mailbox:
         ...
 
     @property
-    def actor_id(self) -> ActorId: ...
+    def actor_id(self) -> ActorAddr: ...
 
 class Accumulator(Protocol):
     """
@@ -222,9 +222,9 @@ class UndeliverableMessageEnvelope:
     """
 
     def __repr__(self) -> str: ...
-    def sender(self) -> ActorId:
+    def sender(self) -> ActorAddr:
         """
-        The actor id of the sender.
+        The actor address of the sender.
         """
         ...
 

--- a/python/monarch/_rust_bindings/monarch_hyperactor/proc.pyi
+++ b/python/monarch/_rust_bindings/monarch_hyperactor/proc.pyi
@@ -22,7 +22,7 @@ def init_proc(
     Helper function to bootstrap a new Proc.
 
     Arguments:
-    - `proc_id`: String representation of the ProcId eg. `"worker<2MuAHeDjLCEd>@tcp://[::1]:2345"`
+    - `proc_id`: String representation of the ProcAddr eg. `"worker<2MuAHeDjLCEd>@tcp://[::1]:2345"`
     - `bootstrap_addr`: String representation of the channel address of the system
         actor. eg. `"tcp![::1]:2345"`
     - `timeout`: Number of seconds to wait to successfully connect to the system.
@@ -41,9 +41,9 @@ class Serialized:
     ...
 
 @final
-class ActorId:
+class ActorAddr:
     """
-    A python wrapper around hyperactor ActorId. It represents a unique reference
+    A python wrapper around hyperactor ActorAddr. It represents a unique reference
     for an actor.
 
     Arguments:
@@ -93,21 +93,21 @@ class ActorId:
 
     @property
     def proc_id(self) -> str:
-        """String representation of the ProcId in Rust-compatible `proc@location` form."""
+        """String representation of the ProcAddr in Rust-compatible `proc@location` form."""
         ...
 
     @property
     def is_root(self) -> bool:
-        """Whether this actor id names a singleton root actor."""
+        """Whether this actor address names a singleton root actor."""
         ...
 
     @staticmethod
-    def from_string(actor_id_str: str) -> ActorId:
+    def from_string(actor_addr_str: str) -> ActorAddr:
         """
-        Create an ActorId from a string representation.
+        Create an ActorAddr from a string representation.
 
         Arguments:
-        - `actor_id_str`: String representation of the actor id.
+        - `actor_addr_str`: String representation of the actor address.
         """
         ...
 

--- a/python/monarch/_src/actor/actor_mesh.py
+++ b/python/monarch/_src/actor/actor_mesh.py
@@ -65,7 +65,7 @@ from monarch._rust_bindings.monarch_hyperactor.pickle import (
     pickle,
     PicklingState,
 )
-from monarch._rust_bindings.monarch_hyperactor.proc import ActorId
+from monarch._rust_bindings.monarch_hyperactor.proc import ActorAddr
 from monarch._rust_bindings.monarch_hyperactor.pytokio import PythonTask, Shared
 from monarch._rust_bindings.monarch_hyperactor.shape import Point as HyPoint, Shape
 from monarch._rust_bindings.monarch_hyperactor.supervision import (
@@ -165,7 +165,7 @@ class Instance(abc.ABC):
         return self.actor_id.proc_id
 
     @abstractproperty
-    def actor_id(self) -> ActorId:
+    def actor_id(self) -> ActorAddr:
         """
         The actor_id of the current actor.
         """

--- a/python/monarch/_src/actor/debugger/pdb_wrapper.py
+++ b/python/monarch/_src/actor/debugger/pdb_wrapper.py
@@ -18,7 +18,7 @@ from dataclasses import dataclass
 from types import FrameType, TracebackType
 from typing import Any, Dict, Generator, Optional, TYPE_CHECKING
 
-from monarch._rust_bindings.monarch_hyperactor.proc import ActorId
+from monarch._rust_bindings.monarch_hyperactor.proc import ActorAddr
 from monarch._src.actor.sync_state import fake_sync_state
 
 if TYPE_CHECKING:
@@ -46,7 +46,7 @@ class PdbWrapper(pdb.Pdb):
         self,
         rank: int,
         coords: Dict[str, int],
-        actor_id: ActorId,
+        actor_id: ActorAddr,
         controller: "DebugController",
         header: str | None = None,
     ) -> None:

--- a/python/monarch/common/invocation.py
+++ b/python/monarch/common/invocation.py
@@ -9,7 +9,7 @@ import traceback
 from typing import Any, List, Optional, Tuple
 
 from monarch._rust_bindings.monarch_hyperactor.proc import (  # @manual=//monarch/monarch_extension:monarch_extension
-    ActorId,
+    ActorAddr,
 )
 
 
@@ -26,7 +26,7 @@ class DeviceException(Exception):
         self,
         exception: Exception,
         frames: List[traceback.FrameSummary],
-        source_actor_id: ActorId,
+        source_actor_id: ActorAddr,
         message: str,
     ):
         self.exception = exception
@@ -61,7 +61,7 @@ class RemoteException(Exception):
         controller_frame_index: Optional[int],
         controller_frames: Optional[List[traceback.FrameSummary]],
         worker_frames: List[traceback.FrameSummary],
-        source_actor_id: ActorId,
+        source_actor_id: ActorAddr,
         message="A remote function has failed asynchronously.",
     ):
         self.exception = exception

--- a/python/monarch/controller/controller.py
+++ b/python/monarch/controller/controller.py
@@ -11,10 +11,10 @@ from collections import deque
 from typing import Generator, List, NamedTuple, Optional, Sequence, Tuple, Union
 
 from monarch._rust_bindings.monarch_extension.client import (  # @manual=//monarch/monarch_extension:monarch_extension
-    DebuggerMessage,
+    DebuggerMessage as RustDebuggerMessage,
 )
 from monarch._rust_bindings.monarch_hyperactor.proc import (  # @manual=//monarch/monarch_extension:monarch_extension
-    ActorId,
+    ActorAddr,
 )
 from monarch._src.actor.shape import NDSlice
 from monarch.common import messages
@@ -75,7 +75,7 @@ class Controller:
         for rank, value in self._backend.recvready(timeout):
             yield from self._handle_message(rank, value)
 
-    def drain_and_stop(self) -> List[MessageResult | LogMessage | DebuggerMessage]:
+    def drain_and_stop(self) -> List[MessageResult | LogMessage | RustDebuggerMessage]:
         messages = []
         while self._messages:
             messages.append(self._messages.popleft())
@@ -136,7 +136,7 @@ class Controller:
             error=DeviceException(
                 exception,
                 worker_frames,
-                ActorId(addr="local:0", proc_name="unknown", actor_name="unknown"),
+                ActorAddr(addr="local:0", proc_name="unknown", actor_name="unknown"),
                 message="A worker experienced an internal error.",
             ),
         )
@@ -153,7 +153,7 @@ class Controller:
             error=DeviceException(
                 exception=exception,
                 frames=frames,
-                source_actor_id=ActorId(
+                source_actor_id=ActorAddr(
                     addr="local:0", proc_name="unknown", actor_name="unknown"
                 ),
                 message="A remote generator failed.",

--- a/python/monarch/controller/history.py
+++ b/python/monarch/controller/history.py
@@ -9,7 +9,7 @@ from collections import deque
 from typing import Generator, Sequence, TYPE_CHECKING
 
 from monarch._rust_bindings.monarch_hyperactor.proc import (  # @manual=//monarch/monarch_extension:monarch_extension
-    ActorId,
+    ActorAddr,
 )
 from monarch.common.controller_api import MessageResult
 from monarch.common.invocation import Invocation, RemoteException, Seq
@@ -56,7 +56,7 @@ class History:
             traceback_index,
             None,
             worker_frames,
-            ActorId(addr="local:0", proc_name="unknown", actor_name="unknown"),
+            ActorAddr(addr="local:0", proc_name="unknown", actor_name="unknown"),
         )
         worklist = deque((invocation,))
         while worklist:

--- a/python/monarch/controller/rust_backend/controller.py
+++ b/python/monarch/controller/rust_backend/controller.py
@@ -22,7 +22,7 @@ from monarch._rust_bindings.monarch_extension.client import (  # @manual=//monar
     ClientActor,
 )
 from monarch._rust_bindings.monarch_hyperactor.proc import (  # @manual=//monarch/monarch_extension:monarch_extension
-    ActorId,
+    ActorAddr,
     Proc,
 )
 from monarch._rust_bindings.monarch_messages.debugger import DebuggerAction
@@ -42,7 +42,7 @@ class RustController:
         self,
         proc: Proc,
         client_actor: ClientActor,
-        controller_id: ActorId,
+        controller_id: ActorAddr,
         worker_world_name: str,
     ) -> None:
         self._controller_actor = controller_id
@@ -58,7 +58,7 @@ class RustController:
         self._non_debugger_pending_messages: deque[
             Optional[client.LogMessage | client.WorkerResponse]
         ] = deque()
-        self._pending_debugger_sessions: deque[ActorId] = deque()
+        self._pending_debugger_sessions: deque[ActorAddr] = deque()
 
     def send(
         self,

--- a/python/monarch/mesh_controller.py
+++ b/python/monarch/mesh_controller.py
@@ -47,7 +47,7 @@ from monarch._rust_bindings.monarch_hyperactor.pickle import (
     PicklingState,
 )
 from monarch._rust_bindings.monarch_hyperactor.proc import (  # @manual=//monarch/monarch_extension:monarch_extension
-    ActorId,
+    ActorAddr,
 )
 from monarch._src.actor.actor_mesh import Channel
 from monarch._src.actor.shape import NDSlice
@@ -70,7 +70,7 @@ from monarch.common.client import Client
 from monarch.common.controller_api import LogMessage, MessageResult
 from monarch.common.device_mesh import DeviceMesh
 from monarch.common.future import Future as OldFuture
-from monarch.common.invocation import DeviceException, RemoteException
+from monarch.common.invocation import DeviceException
 
 logger: Logger = logging.getLogger(__name__)
 
@@ -191,7 +191,7 @@ class WriteWrapper:
 class Controller(_Controller):
     def __init__(self, instance: Instance, workers: "HyProcMesh") -> None:
         super().__init__()
-        self._pending_debugger_sessions: deque[ActorId] = deque()
+        self._pending_debugger_sessions: deque[ActorAddr] = deque()
 
     def node(
         self,
@@ -334,7 +334,9 @@ class MeshClient(Client):
     def shutdown(
         self,
         destroy_pg: bool = True,
-        error_reason: Optional[RemoteException | DeviceException | Exception] = None,
+        error_reason: Optional[
+            Union["RemoteException", DeviceException, Exception]
+        ] = None,
     ):
         # return
         if self.has_shutdown:

--- a/python/monarch/monarch_dashboard/server/admin_dag.py
+++ b/python/monarch/monarch_dashboard/server/admin_dag.py
@@ -38,6 +38,10 @@ _SYSTEM_NAME_PATTERNS = re.compile(
     re.IGNORECASE,
 )
 
+_DISPLAY_ID_COMPONENT_RE = re.compile(
+    r"^(?:(?P<label>[^<]+)<(?P<uid>[^>]+)>|<(?P<anon_uid>[^>]+)>)$"
+)
+
 
 def _is_client_actor(ref: str) -> bool:
     """The root client actor (client[0]) is the user's entrypoint.
@@ -55,6 +59,16 @@ def _is_system_by_name(label: str) -> bool:
     return bool(_SYSTEM_NAME_PATTERNS.search(label))
 
 
+def _format_display_id_component(component: str) -> str:
+    """Format a canonical Hyperactor id component for display."""
+    match = _DISPLAY_ID_COMPONENT_RE.fullmatch(component.strip())
+    if not match:
+        return component
+    label = match.group("label")
+    uid = match.group("uid") or match.group("anon_uid") or component
+    return f"{label}[{uid}]" if label else uid
+
+
 def _derive_label(node_id: str, node_kind: str, addr: str = "") -> str:
     """Derive a short display label from a snapshot node.
 
@@ -68,7 +82,30 @@ def _derive_label(node_id: str, node_kind: str, addr: str = "") -> str:
             addr = addr.split(":", 1)[1]
         return addr
 
-    # node_id for actors/procs is the last comma-separated component
+    # Compatibility with older snapshot rows that stored tuple-like ids.
+    if node_kind == "actor" and "(" in node_id and node_id.endswith(")"):
+        inner = node_id.split("(", 1)[-1].rstrip(")")
+        parts = inner.split(",")
+        if len(parts) >= 3:
+            return f"{parts[1].strip()}[{parts[2].strip()}]"
+        return inner
+
+    if node_kind == "proc" and "(" in node_id and node_id.endswith(")"):
+        inner = node_id.split("(", 1)[-1].rstrip(")")
+        parts = inner.split(",")
+        if len(parts) >= 2:
+            return f"{parts[0].strip()}[{parts[1].strip()}]"
+        return inner
+
+    if node_kind == "actor":
+        actor_id = node_id.rsplit("@", 1)[0]
+        actor_component = actor_id.split(".", 1)[0]
+        return _format_display_id_component(actor_component)
+
+    if node_kind == "proc":
+        proc_id = node_id.rsplit("@", 1)[0]
+        return _format_display_id_component(proc_id)
+
     return node_id.rsplit(",", 1)[-1] or node_id
 
 

--- a/python/monarch/rust_backend_mesh.py
+++ b/python/monarch/rust_backend_mesh.py
@@ -8,22 +8,18 @@
 import logging
 import time
 from logging import Logger
-from typing import Any, Callable, Optional, Protocol
+from typing import Any, Optional, Protocol
 
 from monarch._rust_bindings.monarch_extension.client import (  # @manual=//monarch/monarch_extension:monarch_extension
     ClientActor,
 )
 from monarch._rust_bindings.monarch_hyperactor.proc import (  # @manual=//monarch/monarch_extension:monarch_extension
-    ActorId,
+    ActorAddr,
     init_proc,
     Proc,
 )
-from monarch._src.actor.shape import NDSlice
-from monarch.common.client import Client
-from monarch.common.device_mesh import DeviceMesh, DeviceMeshStatus
-from monarch.common.invocation import DeviceException, RemoteException
+from monarch.common.device_mesh import DeviceMesh
 from monarch.common.mast import MastJob
-from monarch.controller.rust_backend.controller import RustController
 
 TORCHX_MAST_TASK_GROUP_NAME = "script"
 
@@ -31,7 +27,7 @@ logger: Logger = logging.getLogger(__name__)
 
 # A world tuple contains a worker world name and a controller actor id
 # The pair forms a functional world that can be used to create a device mesh
-MeshWorld = tuple[str, ActorId]
+MeshWorld = tuple[str, ActorAddr]
 
 # Taken from //monarch/controller/src/bootstrap.rs
 WORLD_WORKER_LABEL = "world.monarch.meta.com/worker"

--- a/python/monarch/simulator/mock_controller.py
+++ b/python/monarch/simulator/mock_controller.py
@@ -20,7 +20,7 @@ from typing import (
 
 import torch
 from monarch._rust_bindings.monarch_hyperactor.proc import (  # @manual=//monarch/monarch_extension:monarch_extension
-    ActorId,
+    ActorAddr,
 )
 from monarch._src.actor.shape import iter_ranks, NDSlice, Slices as Ranks
 from monarch.common import messages
@@ -74,7 +74,7 @@ class History:
             traceback_index,
             None,
             worker_frames,
-            ActorId(addr="local:0", proc_name="unknown", actor_name="unknown"),
+            ActorAddr(addr="local:0", proc_name="unknown", actor_name="unknown"),
         )
         worklist = deque((invocation,))
         while worklist:

--- a/python/monarch/simulator/simulator.py
+++ b/python/monarch/simulator/simulator.py
@@ -40,7 +40,7 @@ from typing import (
 import numpy as np
 import torch
 from monarch._rust_bindings.monarch_hyperactor.proc import (  # @manual=//monarch/monarch_extension:monarch_extension
-    ActorId,
+    ActorAddr,
 )
 from monarch._src.actor.shape import iter_ranks, NDSlice
 from monarch.common import messages
@@ -177,10 +177,9 @@ class Simulator:
             cuda_device_count = torch.cuda.device_count()
             if cuda_device_count > 0 and torch.cuda.is_available():
                 # Try a small CUDA operation and sync to verify CUDA actually works
-                test_tensor = torch.zeros(1, device="cuda")
+                torch.zeros(1, device="cuda")
                 # Force synchronization to catch any deferred CUDA errors
                 torch.cuda.synchronize()
-                del test_tensor
                 use_real_profiler = True
         except Exception:
             pass
@@ -919,7 +918,7 @@ class SimulatorController(MockController):
                     error=DeviceException(
                         e,
                         traceback.extract_tb(e.__traceback__),
-                        ActorId(
+                        ActorAddr(
                             addr="local:0", proc_name="unknown", actor_name="unknown"
                         ),
                         message="Simulator has an internal error.",

--- a/python/tests/_monarch/test_hyperactor.py
+++ b/python/tests/_monarch/test_hyperactor.py
@@ -22,7 +22,7 @@ from monarch._rust_bindings.monarch_hyperactor.pickle import (
     PendingMessage,
     pickle as monarch_pickle,
 )
-from monarch._rust_bindings.monarch_hyperactor.proc import ActorId
+from monarch._rust_bindings.monarch_hyperactor.proc import ActorAddr
 from monarch._rust_bindings.monarch_hyperactor.proc_mesh import ProcMesh
 from monarch._rust_bindings.monarch_hyperactor.pytokio import PythonTask, Shared
 from monarch._rust_bindings.monarch_hyperactor.shape import Extent
@@ -70,7 +70,7 @@ def test_import() -> None:
 
 
 def test_actor_id() -> None:
-    actor_id = ActorId(addr="local:0", proc_name="test", actor_name="actor")
+    actor_id = ActorAddr(addr="local:0", proc_name="test", actor_name="actor")
     assert actor_id.uid == "actor"
     assert actor_id.pid == actor_id.uid
     assert actor_id.label == "actor"
@@ -78,7 +78,7 @@ def test_actor_id() -> None:
     assert actor_id.proc_id == "test@inproc://0"
     assert actor_id.is_root is True
     assert str(actor_id) == "actor.test@inproc://0"
-    assert ActorId.from_string(str(actor_id)) == actor_id
+    assert ActorAddr.from_string(str(actor_id)) == actor_id
 
 
 def test_no_hang_on_shutdown() -> None:

--- a/python/tests/test_distributed_telemetry.py
+++ b/python/tests/test_distributed_telemetry.py
@@ -16,7 +16,7 @@ from typing import cast
 import monarch.distributed_telemetry.actor as telemetry_actor
 import pytest
 from isolate_in_subprocess import isolate_in_subprocess
-from monarch._rust_bindings.monarch_hyperactor.proc import ActorId
+from monarch._rust_bindings.monarch_hyperactor.proc import ActorAddr
 from monarch._src.actor.actor_mesh import Actor, ActorMesh
 from monarch._src.actor.endpoint import endpoint
 from monarch._src.actor.proc_mesh import (
@@ -696,7 +696,7 @@ def test_sent_messages_table(
     All send paths (call, call_one, broadcast, choose) go through
     cast_with_selection in actor_mesh.rs, which calls notify_sent_message
     with a SentMessageEvent containing:
-      - sender_actor_id: hash of the sending actor's ActorId
+      - sender_actor_id: hash of the sending actor's ActorAddr
       - actor_mesh_id: hash of the target actor mesh name
       - view_json: serialized ndslice::Region of the current view
       - shape_json: serialized ndslice::Shape (converted from the Region)
@@ -1358,7 +1358,7 @@ def test_store_pyspy_dump_with_child_proc_ref(cleanup_callbacks) -> None:
 
         coordinator_proc_id = engine._actor.get_proc_id.call_one().get()
 
-        # Discover child proc_ids by parsing canonical ActorId strings for
+        # Discover child proc_refs by parsing canonical ActorAddr strings for
         # ProcAgent actors. display_name is reserved for user-facing names,
         # so the canonical full_name is the stable source of system actor
         # identity.
@@ -1367,7 +1367,7 @@ def test_store_pyspy_dump_with_child_proc_ref(cleanup_callbacks) -> None:
         child_proc_refs = [
             actor_id.proc_id
             for row in proc_agent_names
-            if (actor_id := ActorId.from_string(row)).label
+            if (actor_id := ActorAddr.from_string(row)).label
             in {"proc_agent", "_proc_agent"}
             and actor_id.proc_id != coordinator_proc_id
         ]

--- a/python/tests/test_future.py
+++ b/python/tests/test_future.py
@@ -10,7 +10,7 @@ from typing import Callable
 
 import pytest
 from monarch._rust_bindings.monarch_hyperactor.proc import (  # @manual=//monarch/monarch_extension:monarch_extension
-    ActorId,
+    ActorAddr,
 )
 from monarch.common import future
 from monarch.common.client import Client
@@ -69,7 +69,7 @@ class TestFuture:
             None,
             [],
             [],
-            ActorId(addr="local:0", proc_name="unknown", actor_name="unknown"),
+            ActorAddr(addr="local:0", proc_name="unknown", actor_name="unknown"),
         )
 
         the_messages = [(1, lambda: None), (2, lambda: f._set_result(re))]

--- a/python/tests/test_python_actors.py
+++ b/python/tests/test_python_actors.py
@@ -40,7 +40,7 @@ from monarch._rust_bindings.monarch_hyperactor.mailbox import (
     PortRef,
     UndeliverableMessageEnvelope,
 )
-from monarch._rust_bindings.monarch_hyperactor.proc import ActorId
+from monarch._rust_bindings.monarch_hyperactor.proc import ActorAddr
 from monarch._rust_bindings.monarch_hyperactor.pytokio import PythonTask, Shared
 from monarch._src.actor.actor_mesh import ActorMesh, Channel, context, Port
 from monarch._src.actor.future import Future
@@ -1262,7 +1262,7 @@ class UndeliverableMessageSender(Actor):
     def send_undeliverable(self) -> None:
         actor_instance = context().actor_instance
         port_id = PortId(
-            actor_id=ActorId(addr="local:0", proc_name="bogus", actor_name="bogus"),
+            actor_id=ActorAddr(addr="local:0", proc_name="bogus", actor_name="bogus"),
             port=1234,
         )
         port_ref = PortRef(port_id)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #3704
* #3703
* #3702
* #3701
* #3700
* #3699
* #3698
* #3630
* #3629
* #3628
* #3627
* #3626

Remove the remaining root-level `hyperactor` type renames so the crate exports the real `addr`, `id`, and `ref_` names directly, and retarget downstream users to those true names. This is a mechanical rename only.

Differential Revision: [D102822047](https://our.internmc.facebook.com/intern/diff/D102822047/)