### PR TITLE
[hyperactor] store typed refs as addr::* and finish mesh cleanup

### DIFF
--- a/hyper/src/commands/list.rs
+++ b/hyper/src/commands/list.rs
@@ -38,7 +38,8 @@ impl ListCommand {
         // Codify obtaining a proc's agent in `hyperactor_mesh` somewhere.
         let agent: reference::ActorRef<HostAgent> = reference::ActorRef::attest(
             reference::ProcId::from_resource_name(host, SERVICE_PROC_NAME)
-                .actor_id(HOST_MESH_AGENT_ACTOR_NAME),
+                .actor_id(HOST_MESH_AGENT_ACTOR_NAME)
+                .into(),
         );
 
         let resources = agent.list(&client).await?;

--- a/hyper/src/commands/show.rs
+++ b/hyper/src/commands/show.rs
@@ -32,7 +32,8 @@ impl ShowCommand {
                 // Codify obtaining a proc's agent in `hyperactor_mesh` somewhere.
                 let agent: reference::ActorRef<HostAgent> = reference::ActorRef::attest(
                     reference::ProcId::from_resource_name(host, SERVICE_PROC_NAME)
-                        .actor_id(HOST_MESH_AGENT_ACTOR_NAME),
+                        .actor_id(HOST_MESH_AGENT_ACTOR_NAME)
+                        .into(),
                 );
 
                 let state = agent.get_state(&client, proc.parse().unwrap()).await?;

--- a/hyperactor/src/actor.rs
+++ b/hyperactor/src/actor.rs
@@ -310,7 +310,7 @@ pub trait RemoteSpawn: Actor + Referable + Binds<Self> {
             //
             // This will be replaced by a proper export/registry
             // mechanism.
-            Ok(handle.bind::<Self>().actor_id)
+            Ok(handle.bind::<Self>().into_actor_id())
         })
     }
 

--- a/hyperactor/src/host.rs
+++ b/hyperactor/src/host.rs
@@ -1978,7 +1978,7 @@ mod tests {
         let addr = ChannelAddr::any(ChannelTransport::Local);
         let proc_ref = ProcAddr::from_resource_name(addr.clone(), "p");
         let actor_ref = proc_ref.actor_ref("host_agent");
-        let agent_ref = ActorRef::<()>::attest(actor_ref.into());
+        let agent_ref = ActorRef::<()>::attest(actor_ref);
         let h = LocalHandle::<()> {
             proc_id: proc_ref,
             addr,
@@ -2108,7 +2108,7 @@ mod tests {
             forwarder_addr: ChannelAddr,
             _config: (),
         ) -> Result<Self::Handle, HostError> {
-            let agent = ActorRef::<()>::attest(proc_id.actor_ref("host_agent").into());
+            let agent = ActorRef::<()>::attest(proc_id.actor_ref("host_agent"));
             Ok(TestHandle {
                 id: proc_id,
                 addr: forwarder_addr,
@@ -2300,7 +2300,7 @@ mod tests {
         // host's service proc.
         let bogus_actor = host.system_proc().proc_id().actor_ref("no-such-actor");
         let bogus_port = bogus_actor.port_ref(crate::port::Port::from(0u64));
-        let bogus_dest = reference::PortRef::<String>::attest(reference::PortId::from(bogus_port));
+        let bogus_dest = reference::PortRef::<String>::attest(bogus_port);
 
         let (trigger_inst, _h) = remote_proc.instance("trigger").unwrap();
         collector_ref
@@ -2348,7 +2348,7 @@ mod tests {
         // attached remote proc.
         let bogus_actor = remote_proc.proc_id().actor_ref("ghost-actor");
         let bogus_port = bogus_actor.port_ref(crate::port::Port::from(0u64));
-        let bogus_dest = reference::PortRef::<String>::attest(reference::PortId::from(bogus_port));
+        let bogus_dest = reference::PortRef::<String>::attest(bogus_port);
 
         let (trigger_inst, _h) = host.system_proc().instance("trigger").unwrap();
         collector_ref
@@ -2567,7 +2567,7 @@ mod tests {
                 let client_proc = Proc::configured(client_proc_id, dial_router.into_boxed());
                 let _client_handle = client_proc.clone().serve(client_rx);
 
-                let echo_ref = reference::ActorRef::<EchoActor>::attest(echo_actor_id);
+                let echo_ref = reference::ActorRef::<EchoActor>::attest(echo_actor_id.into());
 
                 for ri in 0..M_REQUESTS {
                     let (client_inst, _h) = client_proc.instance(&format!("req-{}", ri)).unwrap();

--- a/hyperactor/src/mailbox.rs
+++ b/hyperactor/src/mailbox.rs
@@ -1616,7 +1616,7 @@ impl Mailbox {
             Entry::Occupied(_entry) => {}
         }
 
-        PortRef::attest(port_ref.into())
+        PortRef::attest(port_ref)
     }
 
     fn bind_to_actor_port<M: RemoteMessage>(&self, handle: &PortHandle<M>) {
@@ -1977,11 +1977,11 @@ impl<M: RemoteMessage> PortHandle<M> {
         let port_ref = {
             let mut guard = self.bound.write().unwrap();
             guard
-                .get_or_insert_with(|| self.mailbox.bind(self).port_id().clone().into())
+                .get_or_insert_with(|| self.mailbox.bind(self).into_port_addr())
                 .clone()
         };
         PortRef::attest_reducible(
-            port_ref.into(),
+            port_ref,
             self.reducer_spec.clone(),
             self.streaming_opts.clone(),
         )
@@ -2077,7 +2077,7 @@ impl<M: RemoteMessage> OncePortHandle<M> {
         let port_id: reference::PortId = self.port_id().clone().into();
         let reducer_spec = self.reducer_spec.clone();
         self.mailbox.clone().bind_once(self);
-        OncePortRef::attest_reducible(port_id, reducer_spec)
+        OncePortRef::attest_reducible(port_id.into(), reducer_spec)
     }
 }
 
@@ -3216,7 +3216,7 @@ mod tests {
         };
 
         assert_matches!(err.kind(), MailboxSenderErrorKind::Closed);
-        assert_matches!(err.location(), PortLocation::Bound(bound) if *bound == **port.port_id());
+        assert_matches!(err.location(), PortLocation::Bound(bound) if *bound == *port.port_addr());
     }
 
     #[tokio::test]

--- a/hyperactor/src/message.rs
+++ b/hyperactor/src/message.rs
@@ -366,9 +366,9 @@ mod tests {
 
     #[test]
     fn test_castable() {
-        let original_port0 = PortRef::attest(test_port_id("world_0", "actor", 123));
+        let original_port0 = PortRef::attest(test_port_id("world_0", "actor", 123).into());
         let original_port1 = PortRef::attest_reducible(
-            test_port_id("world_1", "actor1", 456),
+            test_port_id("world_1", "actor1", 456).into(),
             Some(ReducerSpec {
                 typehash: 123,
                 builder_params: None,
@@ -409,22 +409,22 @@ mod tests {
 
         // Modify the port in the erased
         let new_port_id0 = test_port_id("world_0", "comm", 680);
-        assert_ne!(&new_port_id0, original_port0.port_id());
+        assert_ne!(&new_port_id0, &original_port0.port_id());
         let new_port_id1 = test_port_id("world_1", "comm", 257);
-        assert_ne!(&new_port_id1, original_port1.port_id());
+        assert_ne!(&new_port_id1, &original_port1.port_id());
 
         let mut new_ports = vec![&new_port_id0, &new_port_id1].into_iter();
         erased
             .visit_mut::<UnboundPort>(|b| {
                 let port = new_ports.next().unwrap();
-                b.update(port.clone());
+                b.update(port.clone().into());
                 Ok(())
             })
             .unwrap();
 
-        let new_port0 = PortRef::<String>::attest(new_port_id0);
+        let new_port0 = PortRef::<String>::attest(new_port_id0.into());
         let new_port1 = PortRef::<MyReply>::attest_reducible(
-            new_port_id1,
+            new_port_id1.into(),
             Some(ReducerSpec {
                 typehash: 123,
                 builder_params: None,

--- a/hyperactor/src/proc.rs
+++ b/hyperactor/src/proc.rs
@@ -682,7 +682,7 @@ impl Proc {
     {
         let (instance, _handle) = self.instance(name)?;
         let (_handle, rx) = instance.bind_actor_port::<M>();
-        let actor_ref = ActorRef::attest(instance.self_id().clone().into());
+        let actor_ref = ActorRef::attest(instance.self_id().clone());
         Ok((instance, actor_ref, rx))
     }
 
@@ -1206,7 +1206,11 @@ impl Proc {
         &self,
         actor_ref: &ActorRef<R>,
     ) -> Option<ActorHandle<R>> {
-        let cell = self.inner.instances.get(actor_ref.actor_id())?.upgrade()?;
+        let cell = self
+            .inner
+            .instances
+            .get(actor_ref.actor_addr())?
+            .upgrade()?;
         // An actor whose status is terminal has stopped processing
         // messages even if its InstanceCell Arc is still alive (e.g.
         // held by the introspect task during teardown).
@@ -3087,7 +3091,7 @@ impl InstanceCell {
                 .exported_named_ports
                 .insert(*entry.key(), entry.value());
         }
-        ActorRef::attest(self.actor_id().clone().into())
+        ActorRef::attest(self.actor_id().clone())
     }
 
     /// Attempt to downcast this cell to a concrete actor handle.
@@ -3628,7 +3632,7 @@ mod tests {
             !lookup_actor
                 .actor_exists(
                     &client,
-                    ActorRef::attest(target_actor.actor_id().unique_child().into())
+                    ActorRef::attest(target_actor.actor_id().unique_child())
                 )
                 .await
                 .unwrap()
@@ -3636,10 +3640,7 @@ mod tests {
         // A wrongly-typed actor ref should also not obtain.
         assert!(
             !lookup_actor
-                .actor_exists(
-                    &client,
-                    ActorRef::attest(lookup_actor.actor_id().clone().into())
-                )
+                .actor_exists(&client, ActorRef::attest(lookup_actor.actor_id().clone()))
                 .await
                 .unwrap()
         );

--- a/hyperactor/src/ref_.rs
+++ b/hyperactor/src/ref_.rs
@@ -23,7 +23,9 @@ use serde::Serializer;
 use typeuri::Named;
 
 use crate::Actor;
+use crate::ActorAddr;
 use crate::ActorHandle;
+use crate::PortAddr;
 use crate::RemoteHandles;
 use crate::RemoteMessage;
 use crate::accum::ReducerSpec;
@@ -37,13 +39,12 @@ use crate::mailbox::PortSink;
 use crate::message::Bind;
 use crate::message::Bindings;
 use crate::message::Unbind;
-use crate::reference::ActorId;
-use crate::reference::PortId;
+use crate::port::Port;
 
 /// ActorRefs are typed references to actors.
 #[derive(typeuri::Named)]
 pub struct ActorRef<A: Referable> {
-    pub(crate) actor_id: ActorId,
+    pub(crate) actor_addr: ActorAddr,
     // fn() -> A so that the struct remains Send
     phantom: PhantomData<fn() -> A>,
 }
@@ -54,7 +55,7 @@ impl<A: Referable> ActorRef<A> {
     where
         A: RemoteHandles<M>,
     {
-        PortRef::attest(self.actor_id.port_id(<M as Named>::port()))
+        PortRef::attest(self.actor_addr.port_ref(Port::from(<M as Named>::port())))
     }
 
     /// Send an [`M`]-typed message to the referenced actor.
@@ -87,21 +88,31 @@ impl<A: Referable> ActorRef<A> {
     /// typed reference.  This is usually invoked to provide a guarantee
     /// that an externally-provided actor ID (e.g., through a command
     /// line argument) is a valid reference.
-    pub fn attest(actor_id: ActorId) -> Self {
+    pub fn attest(actor_addr: ActorAddr) -> Self {
         Self {
-            actor_id,
+            actor_addr,
             phantom: PhantomData,
         }
     }
 
+    /// The actor address corresponding with this reference.
+    pub fn actor_addr(&self) -> &ActorAddr {
+        &self.actor_addr
+    }
+
+    /// Convert this actor reference into its corresponding actor address.
+    pub fn into_actor_addr(self) -> ActorAddr {
+        self.actor_addr
+    }
+
     /// The actor ID corresponding with this reference.
-    pub fn actor_id(&self) -> &ActorId {
-        &self.actor_id
+    pub fn actor_id(&self) -> crate::reference::ActorId {
+        self.actor_addr.clone().into()
     }
 
     /// Convert this actor reference into its corresponding actor ID.
-    pub fn into_actor_id(self) -> ActorId {
-        self.actor_id
+    pub fn into_actor_id(self) -> crate::reference::ActorId {
+        self.actor_addr.into()
     }
 
     /// Attempt to downcast this reference into a (local) actor handle.
@@ -122,7 +133,7 @@ impl<A: Referable> Serialize for ActorRef<A> {
         S: Serializer,
     {
         // Serialize only the fields that don't depend on A
-        self.actor_id().serialize(serializer)
+        self.actor_addr.serialize(serializer)
     }
 }
 
@@ -132,9 +143,9 @@ impl<'de, A: Referable> Deserialize<'de> for ActorRef<A> {
     where
         D: Deserializer<'de>,
     {
-        let actor_id = <ActorId>::deserialize(deserializer)?;
+        let actor_addr = <ActorAddr>::deserialize(deserializer)?;
         Ok(ActorRef {
-            actor_id,
+            actor_addr,
             phantom: PhantomData,
         })
     }
@@ -144,7 +155,7 @@ impl<'de, A: Referable> Deserialize<'de> for ActorRef<A> {
 impl<A: Referable> fmt::Debug for ActorRef<A> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("ActorRef")
-            .field("actor_id", &self.actor_id)
+            .field("actor_addr", &self.actor_addr)
             .field("type", &std::any::type_name::<A>())
             .finish()
     }
@@ -152,7 +163,7 @@ impl<A: Referable> fmt::Debug for ActorRef<A> {
 
 impl<A: Referable> fmt::Display for ActorRef<A> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt::Display::fmt(&self.actor_id, f)?;
+        fmt::Display::fmt(&self.actor_addr, f)?;
         write!(f, "<{}>", std::any::type_name::<A>())
     }
 }
@@ -161,7 +172,7 @@ impl<A: Referable> fmt::Display for ActorRef<A> {
 impl<A: Referable> Clone for ActorRef<A> {
     fn clone(&self) -> Self {
         Self {
-            actor_id: self.actor_id.clone(),
+            actor_addr: self.actor_addr.clone(),
             phantom: PhantomData,
         }
     }
@@ -169,7 +180,7 @@ impl<A: Referable> Clone for ActorRef<A> {
 
 impl<A: Referable> PartialEq for ActorRef<A> {
     fn eq(&self, other: &Self) -> bool {
-        self.actor_id == other.actor_id
+        self.actor_addr == other.actor_addr
     }
 }
 
@@ -183,13 +194,13 @@ impl<A: Referable> PartialOrd for ActorRef<A> {
 
 impl<A: Referable> Ord for ActorRef<A> {
     fn cmp(&self, other: &Self) -> Ordering {
-        self.actor_id.cmp(&other.actor_id)
+        self.actor_addr.cmp(&other.actor_addr)
     }
 }
 
 impl<A: Referable> Hash for ActorRef<A> {
     fn hash<H: Hasher>(&self, state: &mut H) {
-        self.actor_id.hash(state);
+        self.actor_addr.hash(state);
     }
 }
 
@@ -198,7 +209,7 @@ impl<A: Referable> Hash for ActorRef<A> {
 #[derive(Debug, Serialize, Deserialize, Derivative, typeuri::Named)]
 #[derivative(PartialEq, Eq, PartialOrd, Hash, Ord)]
 pub struct PortRef<M> {
-    port_id: PortId,
+    port_addr: PortAddr,
     #[derivative(
         PartialEq = "ignore",
         PartialOrd = "ignore",
@@ -227,9 +238,9 @@ pub struct PortRef<M> {
 impl<M: RemoteMessage> PortRef<M> {
     /// The caller attests that the provided PortId can be
     /// converted to a reachable, typed port reference.
-    pub fn attest(port_id: PortId) -> Self {
+    pub fn attest(port_addr: PortAddr) -> Self {
         Self {
-            port_id,
+            port_addr,
             reducer_spec: None,
             streaming_opts: StreamingReducerOpts::default(),
             phantom: PhantomData,
@@ -241,12 +252,12 @@ impl<M: RemoteMessage> PortRef<M> {
     /// The caller attests that the provided PortId can be
     /// converted to a reachable, typed port reference.
     pub fn attest_reducible(
-        port_id: PortId,
+        port_addr: PortAddr,
         reducer_spec: Option<ReducerSpec>,
         streaming_opts: StreamingReducerOpts,
     ) -> Self {
         Self {
-            port_id,
+            port_addr,
             reducer_spec,
             streaming_opts,
             phantom: PhantomData,
@@ -263,8 +274,8 @@ impl<M: RemoteMessage> PortRef<M> {
 
     /// The caller attests that the provided PortId can be
     /// converted to a reachable, typed port reference.
-    pub fn attest_message_port(actor: &ActorId) -> Self {
-        PortRef::<M>::attest(actor.port_id(<M as Named>::port()))
+    pub fn attest_message_port(actor: &crate::reference::ActorId) -> Self {
+        PortRef::<M>::attest(actor.actor_ref().port_ref(Port::from(<M as Named>::port())))
     }
 
     /// The typehash of this port's reducer, if any. Reducers
@@ -273,14 +284,24 @@ impl<M: RemoteMessage> PortRef<M> {
         &self.reducer_spec
     }
 
+    /// This port's address.
+    pub fn port_addr(&self) -> &PortAddr {
+        &self.port_addr
+    }
+
+    /// Convert this PortRef into its corresponding port address.
+    pub fn into_port_addr(self) -> PortAddr {
+        self.port_addr
+    }
+
     /// This port's ID.
-    pub fn port_id(&self) -> &PortId {
-        &self.port_id
+    pub fn port_id(&self) -> crate::reference::PortId {
+        self.port_addr.clone().into()
     }
 
     /// Convert this PortRef into its corresponding port id.
-    pub fn into_port_id(self) -> PortId {
-        self.port_id
+    pub fn into_port_id(self) -> crate::reference::PortId {
+        self.port_addr.into()
     }
 
     /// coerce it into OncePortRef so we can send messages to this port from
@@ -288,7 +309,7 @@ impl<M: RemoteMessage> PortRef<M> {
     pub fn into_once(self) -> OncePortRef<M> {
         let return_undeliverable = self.return_undeliverable;
         let unsplit = self.unsplit;
-        let mut once = OncePortRef::attest(self.into_port_id());
+        let mut once = OncePortRef::attest(self.into_port_addr());
         once.return_undeliverable = return_undeliverable;
         once.unsplit = unsplit;
         once
@@ -311,7 +332,7 @@ impl<M: RemoteMessage> PortRef<M> {
     ) -> Result<(), MailboxSenderError> {
         let serialized = wirevalue::Any::serialize(&message).map_err(|err| {
             MailboxSenderError::new_bound(
-                self.port_id.clone(),
+                self.port_addr.clone(),
                 MailboxSenderErrorKind::Serialize(err.into()),
             )
         })?;
@@ -330,7 +351,7 @@ impl<M: RemoteMessage> PortRef<M> {
         crate::mailbox::headers::set_send_timestamp(&mut headers);
         crate::mailbox::headers::set_rust_message_type::<M>(&mut headers);
         cx.post(
-            self.port_id.clone().into(),
+            self.port_addr.clone(),
             headers,
             message,
             self.return_undeliverable,
@@ -359,7 +380,7 @@ impl<M: RemoteMessage> PortRef<M> {
 impl<M: RemoteMessage> Clone for PortRef<M> {
     fn clone(&self) -> Self {
         Self {
-            port_id: self.port_id.clone(),
+            port_addr: self.port_addr.clone(),
             reducer_spec: self.reducer_spec.clone(),
             streaming_opts: self.streaming_opts.clone(),
             phantom: PhantomData,
@@ -371,7 +392,7 @@ impl<M: RemoteMessage> Clone for PortRef<M> {
 
 impl<M: RemoteMessage> fmt::Display for PortRef<M> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt::Display::fmt(&self.port_id, f)
+        fmt::Display::fmt(&self.port_addr, f)
     }
 }
 
@@ -387,7 +408,7 @@ pub enum UnboundPortKind {
 /// The parameters extracted from [`PortRef`] to [`Bindings`].
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, typeuri::Named)]
 pub struct UnboundPort(
-    pub PortId,
+    pub PortAddr,
     pub Option<ReducerSpec>,
     pub bool, // return_undeliverable
     pub UnboundPortKind,
@@ -397,15 +418,15 @@ wirevalue::register_type!(UnboundPort);
 
 impl UnboundPort {
     /// Update the port id of this binding.
-    pub fn update(&mut self, port_id: PortId) {
-        self.0 = port_id;
+    pub fn update(&mut self, port_addr: PortAddr) {
+        self.0 = port_addr;
     }
 }
 
 impl<M: RemoteMessage> From<&PortRef<M>> for UnboundPort {
     fn from(port_ref: &PortRef<M>) -> Self {
         UnboundPort(
-            port_ref.port_id.clone(),
+            port_ref.port_addr.clone(),
             port_ref.reducer_spec.clone(),
             port_ref.return_undeliverable,
             UnboundPortKind::Streaming(Some(port_ref.streaming_opts.clone())),
@@ -422,9 +443,9 @@ impl<M: RemoteMessage> Unbind for PortRef<M> {
 
 impl<M: RemoteMessage> Bind for PortRef<M> {
     fn bind(&mut self, bindings: &mut Bindings) -> anyhow::Result<()> {
-        let UnboundPort(port_id, reducer_spec, return_undeliverable, port_kind, unsplit) =
+        let UnboundPort(port_addr, reducer_spec, return_undeliverable, port_kind, unsplit) =
             bindings.try_pop_front::<UnboundPort>()?;
-        self.port_id = port_id;
+        self.port_addr = port_addr;
         self.reducer_spec = reducer_spec;
         self.return_undeliverable = return_undeliverable;
         self.unsplit = unsplit;
@@ -443,7 +464,7 @@ impl<M: RemoteMessage> Bind for PortRef<M> {
 /// a message to this port.
 #[derive(Debug, Serialize, Deserialize, PartialEq)]
 pub struct OncePortRef<M> {
-    port_id: PortId,
+    port_addr: PortAddr,
     reducer_spec: Option<ReducerSpec>,
     return_undeliverable: bool,
     unsplit: bool,
@@ -451,9 +472,9 @@ pub struct OncePortRef<M> {
 }
 
 impl<M: RemoteMessage> OncePortRef<M> {
-    pub(crate) fn attest(port_id: PortId) -> Self {
+    pub(crate) fn attest(port_addr: PortAddr) -> Self {
         Self {
-            port_id,
+            port_addr,
             reducer_spec: None,
             return_undeliverable: true,
             unsplit: false,
@@ -463,9 +484,9 @@ impl<M: RemoteMessage> OncePortRef<M> {
 
     /// The caller attests that the provided PortId can be
     /// converted to a reachable, typed once port reference.
-    pub fn attest_reducible(port_id: PortId, reducer_spec: Option<ReducerSpec>) -> Self {
+    pub fn attest_reducible(port_addr: PortAddr, reducer_spec: Option<ReducerSpec>) -> Self {
         Self {
-            port_id,
+            port_addr,
             reducer_spec,
             return_undeliverable: true,
             unsplit: false,
@@ -484,14 +505,24 @@ impl<M: RemoteMessage> OncePortRef<M> {
         &self.reducer_spec
     }
 
+    /// This port's address.
+    pub fn port_addr(&self) -> &PortAddr {
+        &self.port_addr
+    }
+
+    /// Convert this OncePortRef into its corresponding port address.
+    pub fn into_port_addr(self) -> PortAddr {
+        self.port_addr
+    }
+
     /// This port's ID.
-    pub fn port_id(&self) -> &PortId {
-        &self.port_id
+    pub fn port_id(&self) -> crate::reference::PortId {
+        self.port_addr.clone().into()
     }
 
     /// Convert this PortRef into its corresponding port id.
-    pub fn into_port_id(self) -> PortId {
-        self.port_id
+    pub fn into_port_id(self) -> crate::reference::PortId {
+        self.port_addr.into()
     }
 
     /// Send a message to this port, provided a sending capability, such as
@@ -511,12 +542,12 @@ impl<M: RemoteMessage> OncePortRef<M> {
         crate::mailbox::headers::set_send_timestamp(&mut headers);
         let serialized = wirevalue::Any::serialize(&message).map_err(|err| {
             MailboxSenderError::new_bound(
-                self.port_id.clone(),
+                self.port_addr.clone(),
                 MailboxSenderErrorKind::Serialize(err.into()),
             )
         })?;
         cx.post(
-            self.port_id.clone().into(),
+            self.port_addr.clone(),
             headers,
             serialized,
             self.return_undeliverable,
@@ -541,7 +572,7 @@ impl<M: RemoteMessage> OncePortRef<M> {
 impl<M: RemoteMessage> Clone for OncePortRef<M> {
     fn clone(&self) -> Self {
         Self {
-            port_id: self.port_id.clone(),
+            port_addr: self.port_addr.clone(),
             reducer_spec: self.reducer_spec.clone(),
             return_undeliverable: self.return_undeliverable,
             unsplit: self.unsplit,
@@ -552,7 +583,7 @@ impl<M: RemoteMessage> Clone for OncePortRef<M> {
 
 impl<M: RemoteMessage> fmt::Display for OncePortRef<M> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt::Display::fmt(&self.port_id, f)
+        fmt::Display::fmt(&self.port_addr, f)
     }
 }
 
@@ -565,7 +596,7 @@ impl<M: RemoteMessage> Named for OncePortRef<M> {
 impl<M: RemoteMessage> From<&OncePortRef<M>> for UnboundPort {
     fn from(port_ref: &OncePortRef<M>) -> Self {
         UnboundPort(
-            port_ref.port_id.clone(),
+            port_ref.port_addr.clone(),
             port_ref.reducer_spec.clone(),
             true, // return_undeliverable
             UnboundPortKind::Once,
@@ -582,11 +613,11 @@ impl<M: RemoteMessage> Unbind for OncePortRef<M> {
 
 impl<M: RemoteMessage> Bind for OncePortRef<M> {
     fn bind(&mut self, bindings: &mut Bindings) -> anyhow::Result<()> {
-        let UnboundPort(port_id, reducer_spec, _return_undeliverable, port_kind, unsplit) =
+        let UnboundPort(port_addr, reducer_spec, _return_undeliverable, port_kind, unsplit) =
             bindings.try_pop_front::<UnboundPort>()?;
         match port_kind {
             UnboundPortKind::Once => {
-                self.port_id = port_id;
+                self.port_addr = port_addr;
                 self.reducer_spec = reducer_spec;
                 self.unsplit = unsplit;
                 Ok(())

--- a/hyperactor/src/reference.rs
+++ b/hyperactor/src/reference.rs
@@ -593,13 +593,13 @@ impl fmt::Display for ActorId {
 }
 impl<A: Referable> From<ActorRef<A>> for ActorId {
     fn from(actor_ref: ActorRef<A>) -> Self {
-        actor_ref.actor_id.clone()
+        actor_ref.into_actor_addr().into()
     }
 }
 
-impl<'a, A: Referable> From<&'a ActorRef<A>> for &'a ActorId {
-    fn from(actor_ref: &'a ActorRef<A>) -> Self {
-        &actor_ref.actor_id
+impl<A: Referable> From<&ActorRef<A>> for ActorId {
+    fn from(actor_ref: &ActorRef<A>) -> Self {
+        actor_ref.actor_addr().clone().into()
     }
 }
 
@@ -967,7 +967,7 @@ mod tests {
             _ => panic!("port_handle should be bound"),
         };
         assert!(port_ref_val.is_actor_port());
-        let port_ref = PortRef::attest(port_ref_val.clone().into());
+        let port_ref = PortRef::attest(port_ref_val.clone());
 
         port_handle.send(&client, ()).unwrap();
         let SeqInfo::Session {
@@ -1059,7 +1059,7 @@ mod tests {
         assert_eq!(seq1, 1);
         assert_eq!(session_id, client.sequencer().session_id());
 
-        let port_ref = PortRef::attest(port_ref_val.clone().into());
+        let port_ref = PortRef::attest(port_ref_val.clone());
         port_ref.send(&client, ()).unwrap();
         let SeqInfo::Session { seq: seq2, .. } = rx
             .try_recv()

--- a/hyperactor_macros/tests/castable.rs
+++ b/hyperactor_macros/tests/castable.rs
@@ -113,8 +113,8 @@ mod tests {
     fn test_named_struct() {
         let port_id2 = test_port_id("world_0", "comm", 2);
         let port_id4 = test_port_id("world_1", "worker", 4);
-        let port2 = reference::PortRef::attest(port_id2.clone());
-        let port4 = reference::PortRef::attest(port_id4.clone());
+        let port2 = reference::PortRef::attest(port_id2.clone().into());
+        let port4 = reference::PortRef::attest(port_id4.clone().into());
         let my_struct = MyNamedStruct {
             field0: 11,
             field1: MyReply("hello".to_string()),
@@ -132,8 +132,8 @@ mod tests {
     fn test_unnamed_struct() {
         let port_id2 = test_port_id("world_0", "comm", 2);
         let port_id4 = test_port_id("world_1", "worker", 4);
-        let port2 = reference::PortRef::attest(port_id2.clone());
-        let port4 = reference::PortRef::attest(port_id4.clone());
+        let port2 = reference::PortRef::attest(port_id2.clone().into());
+        let port4 = reference::PortRef::attest(port_id4.clone().into());
         let my_struct = MyUnamedStruct(
             11,
             MyReply("hello".to_string()),
@@ -151,8 +151,8 @@ mod tests {
     fn test_named_enum() {
         let port_id2 = test_port_id("world_0", "comm", 2);
         let port_id4 = test_port_id("world_1", "worker", 4);
-        let port2 = reference::PortRef::attest(port_id2.clone());
-        let port4 = reference::PortRef::attest(port_id4.clone());
+        let port2 = reference::PortRef::attest(port_id2.clone().into());
+        let port4 = reference::PortRef::attest(port_id4.clone().into());
         let my_enum = MyEnum::Struct {
             field0: 11,
             field1: MyReply("hello".to_string()),
@@ -170,8 +170,8 @@ mod tests {
     fn test_unnamed_enum() {
         let port_id2 = test_port_id("world_0", "comm", 2);
         let port_id4 = test_port_id("world_1", "worker", 4);
-        let port2 = reference::PortRef::attest(port_id2.clone());
-        let port4 = reference::PortRef::attest(port_id4.clone());
+        let port2 = reference::PortRef::attest(port_id2.clone().into());
+        let port4 = reference::PortRef::attest(port_id4.clone().into());
         let my_enum = MyEnum::Tuple(
             11,
             MyReply("hello".to_string()),
@@ -196,8 +196,8 @@ mod tests {
     fn test_my_generic_struct() {
         let port_id2 = test_port_id("world_0", "comm", 2);
         let port_id4 = test_port_id("world_1", "worker", 4);
-        let port2: reference::PortRef<()> = reference::PortRef::attest(port_id2.clone());
-        let port4: reference::PortRef<()> = reference::PortRef::attest(port_id4.clone());
+        let port2: reference::PortRef<()> = reference::PortRef::attest(port_id2.clone().into());
+        let port4: reference::PortRef<()> = reference::PortRef::attest(port_id4.clone().into());
         let my_struct = MyGenericStruct(port2.clone(), &11, port4.clone());
         let mut bindings = Bindings::default();
         port2.unbind(&mut bindings).unwrap();
@@ -208,8 +208,8 @@ mod tests {
     fn test_my_generic_enum() {
         let port_id2 = test_port_id("world_0", "comm", 2);
         let port_id4 = test_port_id("world_1", "worker", 4);
-        let port2: reference::PortRef<()> = reference::PortRef::attest(port_id2.clone());
-        let port4: reference::PortRef<()> = reference::PortRef::attest(port_id4.clone());
+        let port2: reference::PortRef<()> = reference::PortRef::attest(port_id2.clone().into());
+        let port4: reference::PortRef<()> = reference::PortRef::attest(port_id4.clone().into());
         let my_enum = MyGenericEnum::Tuple(port2.clone(), &11, port4.clone());
         let mut bindings = Bindings::default();
         port2.unbind(&mut bindings).unwrap();

--- a/hyperactor_mesh/src/bootstrap.rs
+++ b/hyperactor_mesh/src/bootstrap.rs
@@ -37,6 +37,7 @@ use futures::stream;
 use humantime::format_duration;
 use hyperactor::ActorAddr;
 use hyperactor::ActorHandle;
+use hyperactor::ActorRef;
 use hyperactor::ProcAddr;
 use hyperactor::channel;
 use hyperactor::channel::ChannelAddr;
@@ -55,7 +56,7 @@ use hyperactor::mailbox::MailboxClient;
 use hyperactor::mailbox::MailboxServer;
 use hyperactor::mailbox::MailboxServerHandle;
 use hyperactor::proc::Proc;
-use hyperactor::reference as hyperactor_reference;
+use hyperactor::reference::ProcId;
 use hyperactor_config::CONFIG;
 use hyperactor_config::ConfigAttr;
 use hyperactor_config::attrs::Attrs;
@@ -311,7 +312,7 @@ pub enum Bootstrap {
     /// Bootstrap as a "v1" proc
     Proc {
         /// The ProcId of the proc to be bootstrapped.
-        proc_id: hyperactor_reference::ProcId,
+        proc_id: ProcId,
         /// The backend address to which messages are forwarded.
         /// See [`hyperactor::host`] for channel topology details.
         backend_addr: ChannelAddr,
@@ -600,7 +601,7 @@ pub enum ProcStatus {
     Ready {
         started_at: SystemTime,
         addr: ChannelAddr,
-        agent: hyperactor_reference::ActorRef<ProcAgent>,
+        agent: ActorRef<ProcAgent>,
     },
     /// A stop has been requested (SIGTERM, graceful shutdown, etc.),
     /// but the OS process has not yet fully exited. (Proc-level:
@@ -938,11 +939,7 @@ impl BootstrapProcHandle {
     /// `Running`), or `false` if the current state did not allow
     /// moving to `Ready`. In the latter case the state is left
     /// unchanged and a warning is logged.
-    pub(crate) fn mark_ready(
-        &self,
-        addr: ChannelAddr,
-        agent: hyperactor_reference::ActorRef<ProcAgent>,
-    ) -> bool {
+    pub(crate) fn mark_ready(&self, addr: ChannelAddr, agent: ActorRef<ProcAgent>) -> bool {
         tracing::info!(proc_id = %self.proc_id, %addr, "{} ready at {}", self.proc_id, addr);
         self.transition(|st| match st {
             ProcStatus::Starting => {
@@ -1175,7 +1172,7 @@ impl BootstrapProcHandle {
         let _ = self.mark_stopping();
 
         if let Some(launcher) = self.launcher.upgrade() {
-            let ref_proc_id: hyperactor_reference::ProcId = self.proc_id.clone().into();
+            let ref_proc_id: ProcId = self.proc_id.clone().into();
             if let Err(e) = launcher.terminate(&ref_proc_id, timeout).await {
                 tracing::warn!(
                     proc_id = %self.proc_id,
@@ -1195,7 +1192,7 @@ impl BootstrapProcHandle {
     async fn send_stop_all(
         &self,
         cx: &impl context::Actor,
-        agent: hyperactor_reference::ActorRef<ProcAgent>,
+        agent: ActorRef<ProcAgent>,
         timeout: Duration,
         reason: &str,
     ) -> anyhow::Result<ProcStatus> {
@@ -1242,7 +1239,7 @@ impl hyperactor::host::ProcHandle for BootstrapProcHandle {
     }
 
     #[inline]
-    fn agent_ref(&self) -> Option<hyperactor_reference::ActorRef<Self::Agent>> {
+    fn agent_ref(&self) -> Option<ActorRef<Self::Agent>> {
         match &*self.status.lock().expect("status mutex poisoned") {
             ProcStatus::Ready { agent, .. } => Some(agent.clone()),
             _ => None,
@@ -1340,7 +1337,7 @@ impl hyperactor::host::ProcHandle for BootstrapProcHandle {
 
         // Delegate to launcher for SIGTERM/SIGKILL escalation.
         tracing::info!(proc_id = %self.proc_id, ?timeout, "terminate(): delegating to launcher");
-        let ref_proc_id: hyperactor_reference::ProcId = self.proc_id.clone().into();
+        let ref_proc_id: ProcId = self.proc_id.clone().into();
         if let Some(launcher) = self.launcher.upgrade() {
             if let Err(e) = launcher.terminate(&ref_proc_id, timeout).await {
                 tracing::warn!(proc_id = %self.proc_id, error=%e, "terminate(): launcher termination failed");
@@ -1392,7 +1389,7 @@ impl hyperactor::host::ProcHandle for BootstrapProcHandle {
 
         // Delegate to launcher for kill.
         tracing::info!(proc_id = %self.proc_id, "kill(): delegating to launcher");
-        let ref_proc_id: hyperactor_reference::ProcId = self.proc_id.clone().into();
+        let ref_proc_id: ProcId = self.proc_id.clone().into();
         if let Some(launcher) = self.launcher.upgrade() {
             if let Err(e) = launcher.kill(&ref_proc_id).await {
                 tracing::warn!(proc_id = %self.proc_id, error=%e, "kill(): launcher kill failed");
@@ -1924,10 +1921,9 @@ impl ProcManager for BootstrapProcManager {
         backend_addr: ChannelAddr,
         config: BootstrapProcConfig,
     ) -> Result<Self::Handle, HostError> {
-        let (callback_addr, mut callback_rx) =
-            channel::serve::<(ChannelAddr, hyperactor_reference::ActorRef<ProcAgent>)>(
-                ChannelAddr::any(ChannelTransport::Unix),
-            )?;
+        let (callback_addr, mut callback_rx) = channel::serve::<(ChannelAddr, ActorRef<ProcAgent>)>(
+            ChannelAddr::any(ChannelTransport::Unix),
+        )?;
 
         // Decide whether we need to capture stdio.
         let overrides = &config.client_config_override;
@@ -1969,7 +1965,7 @@ impl ProcManager for BootstrapProcManager {
 
         // Launch via the configured launcher backend.
         tracing::info!(proc_id = %proc_id, "launching proc with opts={opts:?}");
-        let ref_proc_id: hyperactor_reference::ProcId = proc_id.clone().into();
+        let ref_proc_id: ProcId = proc_id.clone().into();
         let launch_result = self
             .launcher()
             .launch(&ref_proc_id, opts.clone())
@@ -2316,7 +2312,6 @@ mod tests {
     use hyperactor::channel::ChannelTransport;
     use hyperactor::channel::TcpMode;
     use hyperactor::host::ProcHandle;
-    use hyperactor::reference as hyperactor_reference;
     use hyperactor::testing::ids::test_proc_id;
     use hyperactor::testing::ids::test_proc_id_with_addr;
     use hyperactor_config::Flattrs;
@@ -2468,7 +2463,7 @@ mod tests {
         // Spawn the log client and disable aggregation (immediate
         // print + tap push).
         let log_client_actor = LogClientActor::new((), Flattrs::default()).await.unwrap();
-        let log_client: hyperactor_reference::ActorRef<LogClientActor> =
+        let log_client: ActorRef<LogClientActor> =
             proc.spawn("log_client", log_client_actor).unwrap().bind();
         log_client.set_aggregate(&client, None).await.unwrap();
 
@@ -2477,7 +2472,7 @@ mod tests {
         let log_forwarder_actor = LogForwardActor::new(log_client.clone(), Flattrs::default())
             .await
             .unwrap();
-        let _log_forwarder: hyperactor_reference::ActorRef<LogForwardActor> = proc
+        let _log_forwarder: ActorRef<LogForwardActor> = proc
             .spawn("log_forwarder", log_forwarder_actor)
             .unwrap()
             .bind();
@@ -2512,8 +2507,9 @@ mod tests {
         use std::time::Duration;
 
         use async_trait::async_trait;
+        use hyperactor::ActorRef;
         use hyperactor::host::ProcHandle;
-        use hyperactor::reference as hyperactor_reference;
+        use hyperactor::reference::ProcId;
         use hyperactor::testing::ids::test_proc_id;
 
         use super::super::*;
@@ -2535,7 +2531,7 @@ mod tests {
         impl ProcLauncher for TestProcLauncher {
             async fn launch(
                 &self,
-                _proc_id: &hyperactor_reference::ProcId,
+                _proc_id: &ProcId,
                 _opts: LaunchOptions,
             ) -> Result<LaunchResult, ProcLauncherError> {
                 panic!("TestProcLauncher::launch should not be called in unit tests");
@@ -2543,16 +2539,13 @@ mod tests {
 
             async fn terminate(
                 &self,
-                _proc_id: &hyperactor_reference::ProcId,
+                _proc_id: &ProcId,
                 _timeout: Duration,
             ) -> Result<(), ProcLauncherError> {
                 panic!("TestProcLauncher::terminate should not be called in unit tests");
             }
 
-            async fn kill(
-                &self,
-                _proc_id: &hyperactor_reference::ProcId,
-            ) -> Result<(), ProcLauncherError> {
+            async fn kill(&self, _proc_id: &ProcId) -> Result<(), ProcLauncherError> {
                 panic!("TestProcLauncher::kill should not be called in unit tests");
             }
         }
@@ -2657,11 +2650,8 @@ mod tests {
             // Build a consistent AgentRef for Ready using the
             // handle's ProcId.
             let proc_id = <BootstrapProcHandle as ProcHandle>::proc_id(&h);
-            let actor_id = proc_id
-                .actor_ref(crate::proc_agent::PROC_AGENT_ACTOR_NAME)
-                .into();
-            let agent_ref: hyperactor_reference::ActorRef<ProcAgent> =
-                hyperactor_reference::ActorRef::attest(actor_id);
+            let actor_id = proc_id.actor_ref(crate::proc_agent::PROC_AGENT_ACTOR_NAME);
+            let agent_ref: ActorRef<ProcAgent> = ActorRef::attest(actor_id);
             // Ready -> Stopping -> Stopped should be legal.
             assert!(h.mark_ready(addr, agent_ref));
             assert!(h.mark_stopping());
@@ -2678,11 +2668,8 @@ mod tests {
             // Build a consistent AgentRef for Ready using the
             // handle's ProcId.
             let proc_id = <BootstrapProcHandle as ProcHandle>::proc_id(&h);
-            let actor_id = proc_id
-                .actor_ref(crate::proc_agent::PROC_AGENT_ACTOR_NAME)
-                .into();
-            let agent: hyperactor_reference::ActorRef<ProcAgent> =
-                hyperactor_reference::ActorRef::attest(actor_id);
+            let actor_id = proc_id.actor_ref(crate::proc_agent::PROC_AGENT_ACTOR_NAME);
+            let agent: ActorRef<ProcAgent> = ActorRef::attest(actor_id);
             // Running -> Ready
             assert!(h.mark_ready(addr, agent));
             // Ready -> Killed
@@ -2719,7 +2706,7 @@ mod tests {
     impl crate::proc_launcher::ProcLauncher for TestLauncher {
         async fn launch(
             &self,
-            _proc_id: &hyperactor_reference::ProcId,
+            _proc_id: &ProcId,
             _opts: crate::proc_launcher::LaunchOptions,
         ) -> Result<crate::proc_launcher::LaunchResult, crate::proc_launcher::ProcLauncherError>
         {
@@ -2728,7 +2715,7 @@ mod tests {
 
         async fn terminate(
             &self,
-            _proc_id: &hyperactor_reference::ProcId,
+            _proc_id: &ProcId,
             _timeout: std::time::Duration,
         ) -> Result<(), crate::proc_launcher::ProcLauncherError> {
             panic!("TestLauncher::terminate should not be called in unit tests");
@@ -2736,13 +2723,13 @@ mod tests {
 
         async fn kill(
             &self,
-            _proc_id: &hyperactor_reference::ProcId,
+            _proc_id: &ProcId,
         ) -> Result<(), crate::proc_launcher::ProcLauncherError> {
             panic!("TestLauncher::kill should not be called in unit tests");
         }
     }
 
-    fn test_handle(proc_id: hyperactor_reference::ProcId) -> BootstrapProcHandle {
+    fn test_handle(proc_id: ProcId) -> BootstrapProcHandle {
         let launcher: std::sync::Arc<dyn crate::proc_launcher::ProcLauncher> =
             std::sync::Arc::new(TestLauncher);
         BootstrapProcHandle::new(proc_id.into(), std::sync::Arc::downgrade(&launcher))
@@ -2813,11 +2800,8 @@ mod tests {
         let started_at = std::time::SystemTime::now();
         assert!(handle.mark_running(started_at));
 
-        let actor_id = proc_id
-            .actor_ref(crate::proc_agent::PROC_AGENT_ACTOR_NAME)
-            .into();
-        let agent_ref: hyperactor_reference::ActorRef<ProcAgent> =
-            hyperactor_reference::ActorRef::attest(actor_id);
+        let actor_id = proc_id.actor_ref(crate::proc_agent::PROC_AGENT_ACTOR_NAME);
+        let agent_ref: ActorRef<ProcAgent> = ActorRef::attest(actor_id);
 
         // Pick any addr to carry in Ready (what the child would have
         // called back with).
@@ -2859,9 +2843,10 @@ mod tests {
     fn display_ready_includes_addr() {
         let started_at = std::time::SystemTime::now() - Duration::from_secs(5);
         let addr = ChannelAddr::any(ChannelTransport::Unix);
-        let agent = hyperactor_reference::ActorRef::attest(
+        let agent = ActorRef::attest(
             test_proc_id_with_addr(addr.clone(), "proc")
-                .actor_id(crate::proc_agent::PROC_AGENT_ACTOR_NAME),
+                .actor_id(crate::proc_agent::PROC_AGENT_ACTOR_NAME)
+                .into(),
         );
 
         let st = ProcStatus::Ready {
@@ -2896,9 +2881,10 @@ mod tests {
             ProcStatus::Ready {
                 started_at: std::time::SystemTime::now(),
                 addr: ChannelAddr::any(ChannelTransport::Unix),
-                agent: hyperactor_reference::ActorRef::attest(
+                agent: ActorRef::attest(
                     test_proc_id_with_addr(ChannelAddr::any(ChannelTransport::Unix), "x")
-                        .actor_id(crate::proc_agent::PROC_AGENT_ACTOR_NAME),
+                        .actor_id(crate::proc_agent::PROC_AGENT_ACTOR_NAME)
+                        .into(),
                 ),
             },
             ProcStatus::Killed {
@@ -2927,12 +2913,8 @@ mod tests {
 
         // Synthesize Ready data
         let addr = ChannelAddr::any(ChannelTransport::Unix);
-        let agent: hyperactor_reference::ActorRef<ProcAgent> =
-            hyperactor_reference::ActorRef::attest(
-                proc_id
-                    .actor_ref(crate::proc_agent::PROC_AGENT_ACTOR_NAME)
-                    .into(),
-            );
+        let agent: ActorRef<ProcAgent> =
+            ActorRef::attest(proc_id.actor_ref(crate::proc_agent::PROC_AGENT_ACTOR_NAME));
         assert!(handle.mark_ready(addr, agent));
 
         // Call the trait method (not ready_inner).
@@ -2989,7 +2971,7 @@ mod tests {
     async fn make_proc_id_and_backend_addr(
         instance: &hyperactor::Instance<()>,
         _tag: &str,
-    ) -> (hyperactor_reference::ProcId, ChannelAddr) {
+    ) -> (ProcId, ChannelAddr) {
         // Serve a Unix channel as the "backend_addr" and hook it into
         // this test proc.
         let (backend_addr, rx) = channel::serve(ChannelAddr::any(ChannelTransport::Unix)).unwrap();
@@ -3189,7 +3171,7 @@ mod tests {
     impl ProcLauncher for DummyLauncher {
         async fn launch(
             &self,
-            _proc_id: &hyperactor_reference::ProcId,
+            _proc_id: &ProcId,
             _opts: LaunchOptions,
         ) -> Result<LaunchResult, ProcLauncherError> {
             let (tx, rx) = tokio::sync::oneshot::channel();
@@ -3208,16 +3190,13 @@ mod tests {
 
         async fn terminate(
             &self,
-            _proc_id: &hyperactor_reference::ProcId,
+            _proc_id: &ProcId,
             _timeout: Duration,
         ) -> Result<(), ProcLauncherError> {
             Ok(())
         }
 
-        async fn kill(
-            &self,
-            _proc_id: &hyperactor_reference::ProcId,
-        ) -> Result<(), ProcLauncherError> {
+        async fn kill(&self, _proc_id: &ProcId) -> Result<(), ProcLauncherError> {
             Ok(())
         }
     }

--- a/hyperactor_mesh/src/comm.rs
+++ b/hyperactor_mesh/src/comm.rs
@@ -22,10 +22,14 @@ use std::fmt::Debug;
 use anyhow::Result;
 use async_trait::async_trait;
 use hyperactor::Actor;
+use hyperactor::ActorRef;
 use hyperactor::Context;
 use hyperactor::Handler;
 use hyperactor::Instance;
+use hyperactor::PortRef;
 use hyperactor::RemoteMessage;
+use hyperactor::UnboundPort;
+use hyperactor::UnboundPortKind;
 use hyperactor::accum::ReducerMode;
 use hyperactor::mailbox::DeliveryError;
 use hyperactor::mailbox::MailboxSender;
@@ -36,7 +40,7 @@ use hyperactor::mailbox::monitored_return_handle;
 use hyperactor::message::ErasedUnbound;
 use hyperactor::ordering::SEQ_INFO;
 use hyperactor::ordering::SeqInfo;
-use hyperactor::reference as hyperactor_reference;
+use hyperactor::reference::ActorId;
 use hyperactor_config::CONFIG;
 use hyperactor_config::ConfigAttr;
 use hyperactor_config::Flattrs;
@@ -110,9 +114,9 @@ struct ReceiveState {
 )]
 pub struct CommActor {
     /// Sequence numbers are maintained for each (actor mesh id, sender).
-    send_seq: HashMap<(ActorMeshId, hyperactor_reference::ActorId), usize>,
+    send_seq: HashMap<(ActorMeshId, ActorId), usize>,
     /// Each sender is a unique stream.
-    recv_state: HashMap<(ActorMeshId, hyperactor_reference::ActorId), ReceiveState>,
+    recv_state: HashMap<(ActorMeshId, ActorId), ReceiveState>,
 
     /// The comm actor's mesh configuration, or buffered messages if not yet configured.
     mesh_config: MeshConfigState,
@@ -145,21 +149,18 @@ pub struct CommMeshConfig {
     /// The rank of this comm actor on the root mesh.
     rank: usize,
     /// Key is the rank of the peer on the root mesh. Value is the peer's comm actor.
-    peers: HashMap<usize, hyperactor_reference::ActorRef<CommActor>>,
+    peers: HashMap<usize, ActorRef<CommActor>>,
 }
 wirevalue::register_type!(CommMeshConfig);
 
 impl CommMeshConfig {
     /// Create a new mesh configuration with the given rank and peer mapping.
-    pub fn new(
-        rank: usize,
-        peers: HashMap<usize, hyperactor_reference::ActorRef<CommActor>>,
-    ) -> Self {
+    pub fn new(rank: usize, peers: HashMap<usize, ActorRef<CommActor>>) -> Self {
         Self { rank, peers }
     }
 
     /// Return the peer comm actor for the given rank.
-    fn peer_for_rank(&self, rank: usize) -> Result<hyperactor_reference::ActorRef<CommActor>> {
+    fn peer_for_rank(&self, rank: usize) -> Result<ActorRef<CommActor>> {
         self.peers
             .get(&rank)
             .cloned()
@@ -192,7 +193,7 @@ impl Actor for CommActor {
             message_envelope.deserialized::<ForwardMessage>()
         {
             let sender = message.sender();
-            let return_port = hyperactor_reference::PortRef::attest_message_port(sender);
+            let return_port = PortRef::attest_message_port(sender);
             message_envelope.set_error(DeliveryError::Multicast(format!(
                 "comm actor {} failed to forward the cast message; returning to origin {}",
                 cx.self_id(),
@@ -222,7 +223,7 @@ impl Actor for CommActor {
 
         // 2. Case delivery failure at a "deliver here" step.
         if let Some(sender) = message_envelope.headers().get(CAST_ORIGINATING_SENDER) {
-            let return_port = hyperactor_reference::PortRef::attest_message_port(&sender);
+            let return_port = PortRef::attest_message_port(&sender);
             message_envelope.set_error(DeliveryError::Multicast(format!(
                 "comm actor {} failed to deliver the cast message to the dest \
                 actor; returning to origin {}",
@@ -281,7 +282,7 @@ impl CommActor {
         config: &CommMeshConfig,
         deliver_here: bool,
         next_steps: HashMap<usize, Vec<RoutingFrame>>,
-        sender: hyperactor_reference::ActorId,
+        sender: ActorId,
         mut message: CastMessageEnvelope,
         seq: usize,
         last_seqs: &mut HashMap<usize, usize>,
@@ -358,22 +359,16 @@ fn split_ports(
     // Split ports, if any, and update message with new ports. In this
     // way, children actors will reply to this comm actor's ports, instead
     // of to the original ports provided by parent.
-    data.visit_mut::<hyperactor_reference::UnboundPort>(
-        |hyperactor_reference::UnboundPort(
-            port_id,
-            reducer_spec,
-            return_undeliverable,
-            kind,
-            unsplit,
-        )| {
+    data.visit_mut::<UnboundPort>(
+        |UnboundPort(port_id, reducer_spec, return_undeliverable, kind, unsplit)| {
             if *unsplit {
                 return Ok(());
             }
             let reducer_mode = match kind {
-                hyperactor_reference::UnboundPortKind::Streaming(opts) => {
+                UnboundPortKind::Streaming(opts) => {
                     ReducerMode::Streaming(opts.clone().unwrap_or_default())
                 }
-                hyperactor_reference::UnboundPortKind::Once if reducer_spec.is_none() => {
+                UnboundPortKind::Once if reducer_spec.is_none() => {
                     // We can only split OncePorts that have reducers.
                     // Pass this through -- if it is used multiple times,
                     // it will cause a delivery error downstream.
@@ -382,7 +377,7 @@ fn split_ports(
                     // unicast and broadcast messages.
                     return Ok(());
                 }
-                hyperactor_reference::UnboundPortKind::Once => {
+                UnboundPortKind::Once => {
                     // Compute peer count for OncePort splitting. This is the number of
                     // destinations the message will be delivered to, so that the split
                     // port can correctly accumulate responses.
@@ -391,7 +386,7 @@ fn split_ports(
                 }
             };
 
-            let split = port_id.split(
+            let split = hyperactor::reference::PortId::from(port_id.clone()).split(
                 cx,
                 reducer_spec.clone(),
                 reducer_mode,
@@ -399,9 +394,13 @@ fn split_ports(
             )?;
 
             #[cfg(test)]
-            tests::collect_split_port(port_id, &split, deliver_here);
+            tests::collect_split_port(
+                &hyperactor::reference::PortId::from(port_id.clone()),
+                &split,
+                deliver_here,
+            );
 
-            *port_id = split;
+            *port_id = split.into();
             Ok(())
         },
     )
@@ -649,8 +648,9 @@ pub mod test_utils {
     use hyperactor::Bind;
     use hyperactor::Context;
     use hyperactor::Handler;
+    use hyperactor::PortRef;
     use hyperactor::Unbind;
-    use hyperactor::reference as hyperactor_reference;
+    use hyperactor::reference::ActorId;
     use serde::Deserialize;
     use serde::Serialize;
     use typeuri::Named;
@@ -659,7 +659,7 @@ pub mod test_utils {
 
     #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Named)]
     pub struct MyReply {
-        pub sender: hyperactor_reference::ActorId,
+        pub sender: ActorId,
         pub value: u64,
     }
 
@@ -671,20 +671,20 @@ pub mod test_utils {
             // Intentionally not including 0. As a result, this port will not be
             // split.
             // #[binding(include)]
-            reply_to0: hyperactor_reference::PortRef<String>,
+            reply_to0: PortRef<String>,
             #[binding(include)]
-            reply_to1: hyperactor_reference::PortRef<u64>,
+            reply_to1: PortRef<u64>,
             #[binding(include)]
-            reply_to2: hyperactor_reference::PortRef<MyReply>,
+            reply_to2: PortRef<MyReply>,
         },
         CastAndReplyOnce {
             arg: String,
             #[binding(include)]
-            reply_to: hyperactor::reference::OncePortRef<u64>,
+            reply_to: hyperactor::OncePortRef<u64>,
         },
         CastWithUnsplitPort {
             #[binding(include)]
-            reply_to: hyperactor_reference::PortRef<u64>,
+            reply_to: PortRef<u64>,
         },
     }
 
@@ -698,12 +698,12 @@ pub mod test_utils {
     pub struct TestActor {
         // Forward the received message to this port, so it can be inspected by
         // the unit test.
-        forward_port: hyperactor_reference::PortRef<TestMessage>,
+        forward_port: PortRef<TestMessage>,
     }
 
     #[derive(Debug, Clone, Named, Serialize, Deserialize)]
     pub struct TestActorParams {
-        pub forward_port: hyperactor_reference::PortRef<TestMessage>,
+        pub forward_port: PortRef<TestMessage>,
     }
 
     #[async_trait]
@@ -761,7 +761,7 @@ mod tests {
         (
             hyperactor::ActorHandle<()>,
             hyperactor::ActorHandle<TestActor>,
-            hyperactor_reference::ActorRef<TestActor>,
+            ActorRef<TestActor>,
         ),
     ) {
         use hyperactor::Proc;
@@ -781,7 +781,7 @@ mod tests {
             .await
             .unwrap();
         let test_handle = proc.spawn(&actor_name, test_actor).unwrap();
-        let test_ref: hyperactor_reference::ActorRef<TestActor> = test_handle.bind::<TestActor>();
+        let test_ref: ActorRef<TestActor> = test_handle.bind::<TestActor>();
 
         let comm_handle = proc.spawn("comm", CommActor::default()).unwrap();
 
@@ -921,13 +921,19 @@ mod tests {
         .await;
     }
 
+    use hyperactor::ActorRef;
+    use hyperactor::OncePortRef;
+    use hyperactor::PortRef;
     use hyperactor::accum::Accumulator;
     use hyperactor::accum::ReducerSpec;
     use hyperactor::context;
     use hyperactor::context::Mailbox;
     use hyperactor::mailbox::PortReceiver;
     use hyperactor::mailbox::open_port;
-    use hyperactor::reference as hyperactor_reference;
+    use hyperactor::reference::ActorId;
+    use hyperactor::reference::Index;
+    use hyperactor::reference::PortId;
+    use hyperactor::reference::ProcId;
     use hyperactor_config;
     use hyperactor_mesh_macros::sel;
     use maplit::btreemap;
@@ -950,7 +956,7 @@ mod tests {
     // Helper to look up the rank for a given actor ID using the rank_lookup table.
     fn lookup_rank(
         actor_id: &hyperactor::reference::ActorId,
-        rank_lookup: &HashMap<hyperactor_reference::ProcId, usize>,
+        rank_lookup: &HashMap<ProcId, usize>,
     ) -> usize {
         let proc_id = actor_id.proc_id();
         *rank_lookup
@@ -972,16 +978,11 @@ mod tests {
 
     // The relationship between original ports and split ports. The elements in
     // the tuple are (original port, split port, deliver_here).
-    static SPLIT_PORT_TREE: OnceLock<Mutex<Vec<Edge<hyperactor_reference::PortId>>>> =
-        OnceLock::new();
+    static SPLIT_PORT_TREE: OnceLock<Mutex<Vec<Edge<PortId>>>> = OnceLock::new();
 
     // Collect the relationships between original ports and split ports into
     // SPLIT_PORT_TREE. This is used by tests to verify that ports are split as expected.
-    pub(crate) fn collect_split_port(
-        original: &hyperactor_reference::PortId,
-        split: &hyperactor_reference::PortId,
-        deliver_here: bool,
-    ) {
+    pub(crate) fn collect_split_port(original: &PortId, split: &PortId, deliver_here: bool) {
         let mutex = SPLIT_PORT_TREE.get_or_init(|| Mutex::new(vec![]));
         let mut tree = mutex.lock().unwrap();
 
@@ -1111,10 +1112,10 @@ mod tests {
     //     2 -> 0, 2
     //     3 -> 0, 2, 3
     fn get_ranks(
-        paths: PathToLeaves<hyperactor_reference::PortId>,
-        client_reply: &hyperactor_reference::PortId,
-        rank_lookup: &HashMap<hyperactor_reference::ProcId, usize>,
-    ) -> PathToLeaves<hyperactor_reference::Index> {
+        paths: PathToLeaves<PortId>,
+        client_reply: &PortId,
+        rank_lookup: &HashMap<ProcId, usize>,
+    ) -> PathToLeaves<Index> {
         let ranks = paths
             .0
             .into_iter()
@@ -1161,9 +1162,9 @@ mod tests {
     fn verify_split_port_paths(
         selection: &Selection,
         extent: &Extent,
-        reply_port_ref1: &hyperactor_reference::PortRef<u64>,
-        reply_port_ref2: &hyperactor_reference::PortRef<MyReply>,
-        rank_lookup: &HashMap<hyperactor_reference::ProcId, usize>,
+        reply_port_ref1: &PortRef<u64>,
+        reply_port_ref2: &PortRef<MyReply>,
+        rank_lookup: &HashMap<ProcId, usize>,
     ) {
         // Get the paths used in casting
         let sel_paths = PathToLeaves(
@@ -1182,10 +1183,18 @@ mod tests {
             let (reply1, reply2): (BTreeMap<_, _>, BTreeMap<_, _>) = build_paths(&edges)
                 .0
                 .into_iter()
-                .partition(|(_dst, path)| &path[0] == reply_port_ref1.port_id());
+                .partition(|(_dst, path)| path[0] == reply_port_ref1.port_id());
             (
-                get_ranks(PathToLeaves(reply1), reply_port_ref1.port_id(), rank_lookup),
-                get_ranks(PathToLeaves(reply2), reply_port_ref2.port_id(), rank_lookup),
+                get_ranks(
+                    PathToLeaves(reply1),
+                    &reply_port_ref1.port_id(),
+                    rank_lookup,
+                ),
+                get_ranks(
+                    PathToLeaves(reply2),
+                    &reply_port_ref2.port_id(),
+                    rank_lookup,
+                ),
             )
         };
 
@@ -1195,14 +1204,11 @@ mod tests {
     }
 
     async fn execute_cast_and_reply(
-        ranks: Vec<hyperactor_reference::ActorRef<TestActor>>,
+        ranks: Vec<ActorRef<TestActor>>,
         instance: &impl context::Actor,
         mut reply1_rx: PortReceiver<u64>,
         mut reply2_rx: PortReceiver<MyReply>,
-        reply_tos: Vec<(
-            hyperactor_reference::PortRef<u64>,
-            hyperactor_reference::PortRef<MyReply>,
-        )>,
+        reply_tos: Vec<(PortRef<u64>, PortRef<MyReply>)>,
     ) {
         // Reply from each dest actor. The replies should be received by client.
         {
@@ -1229,7 +1235,7 @@ mod tests {
         // be received in the same order as they were sent out.
         {
             let n = 100;
-            let mut expected2: HashMap<hyperactor_reference::ActorId, Vec<MyReply>> = hashmap! {};
+            let mut expected2: HashMap<ActorId, Vec<MyReply>> = hashmap! {};
             for (i, (dest_actor, (_reply_to1, reply_to2))) in
                 ranks.iter().zip(reply_tos.iter()).enumerate()
             {
@@ -1252,7 +1258,7 @@ mod tests {
                 );
             }
 
-            let mut received2: HashMap<hyperactor_reference::ActorId, Vec<MyReply>> = hashmap! {};
+            let mut received2: HashMap<ActorId, Vec<MyReply>> = hashmap! {};
 
             for _ in 0..(n * ranks.len()) {
                 let my_reply = reply2_rx.recv().await.unwrap();
@@ -1284,13 +1290,10 @@ mod tests {
     }
 
     async fn execute_cast_and_accum(
-        ranks: Vec<hyperactor_reference::ActorRef<TestActor>>,
+        ranks: Vec<ActorRef<TestActor>>,
         instance: &impl context::Actor,
         mut reply1_rx: PortReceiver<u64>,
-        reply_tos: Vec<(
-            hyperactor_reference::PortRef<u64>,
-            hyperactor_reference::PortRef<MyReply>,
-        )>,
+        reply_tos: Vec<(PortRef<u64>, PortRef<MyReply>)>,
     ) {
         // Now send multiple replies from the dest actors. They should all be
         // received by client. Replies sent from the same dest actor should
@@ -1320,10 +1323,7 @@ mod tests {
         actor_mesh_ref: crate::ActorMeshRef<TestActor>,
         reply1_rx: PortReceiver<u64>,
         reply2_rx: PortReceiver<MyReply>,
-        reply_tos: Vec<(
-            hyperactor_reference::PortRef<u64>,
-            hyperactor_reference::PortRef<MyReply>,
-        )>,
+        reply_tos: Vec<(PortRef<u64>, PortRef<MyReply>)>,
         // Keep the host mesh alive so comm actors aren't shut down.
         host_mesh: HostMesh,
     }
@@ -1425,7 +1425,7 @@ mod tests {
             .iter()
             .enumerate()
             .map(|(i, r)| (r.proc_id().clone(), i))
-            .collect::<HashMap<hyperactor_reference::ProcId, usize>>();
+            .collect::<HashMap<ProcId, usize>>();
 
         // v1 always uses sel!(*) when casting to a mesh.
         let selection = sel!(*);
@@ -1522,8 +1522,8 @@ mod tests {
     struct OncePortMeshSetupV1 {
         instance: &'static Instance<testing::TestRootClient>,
         reply_rx: hyperactor::mailbox::OncePortReceiver<u64>,
-        reply_tos: Vec<hyperactor::reference::OncePortRef<u64>>,
-        _reply_port_ref: hyperactor::reference::OncePortRef<u64>,
+        reply_tos: Vec<OncePortRef<u64>>,
+        _reply_port_ref: OncePortRef<u64>,
         host_mesh: HostMesh,
     }
 

--- a/hyperactor_mesh/src/comm/multicast.rs
+++ b/hyperactor_mesh/src/comm/multicast.rs
@@ -16,7 +16,7 @@ use hyperactor::actor::Referable;
 use hyperactor::message::Castable;
 use hyperactor::message::ErasedUnbound;
 use hyperactor::message::IndexedErasedUnbound;
-use hyperactor::reference as hyperactor_reference;
+use hyperactor::reference::ActorId;
 use hyperactor_config::Flattrs;
 use hyperactor_config::attrs::declare_attrs;
 use ndslice::Extent;
@@ -40,7 +40,7 @@ use crate::mesh_id::ActorMeshId;
 pub(crate) trait CastEnvelope {
     fn dest_port(&self) -> &DestinationPort;
     fn headers(&self) -> &Flattrs;
-    fn sender(&self) -> &hyperactor_reference::ActorId;
+    fn sender(&self) -> &ActorId;
     fn cast_point(&self, config: &CommMeshConfig) -> anyhow::Result<Point>;
     fn data(&self) -> &ErasedUnbound;
     fn data_mut(&mut self) -> &mut ErasedUnbound;
@@ -66,7 +66,7 @@ pub struct CastMessageEnvelope {
     /// The end-to-end message headers.
     headers: Flattrs,
     /// The sender of this message.
-    sender: hyperactor_reference::ActorId,
+    sender: ActorId,
     /// The destination port of the message. It could match multiple actors with
     /// rank wildcard.
     dest_port: DestinationPort,
@@ -78,7 +78,7 @@ pub struct CastMessageEnvelope {
 wirevalue::register_type!(CastMessageEnvelope);
 
 impl CastEnvelope for CastMessageEnvelope {
-    fn sender(&self) -> &hyperactor_reference::ActorId {
+    fn sender(&self) -> &ActorId {
         &self.sender
     }
 
@@ -114,7 +114,7 @@ impl CastMessageEnvelope {
     /// Create a new CastMessageEnvelope.
     pub fn new<A, M>(
         actor_mesh_id: ActorMeshId,
-        sender: hyperactor_reference::ActorId,
+        sender: ActorId,
         shape: Shape,
         headers: Flattrs,
         message: M,
@@ -140,7 +140,7 @@ impl CastMessageEnvelope {
     /// with the destination actors reply to the client actor directly.
     pub fn from_serialized(
         actor_mesh_id: ActorMeshId,
-        sender: hyperactor_reference::ActorId,
+        sender: ActorId,
         dest_port: DestinationPort,
         shape: Shape,
         headers: Flattrs,
@@ -196,7 +196,7 @@ impl CastMessageEnvelope {
     /// The unique key used to indicate the stream to which to deliver this message.
     /// Concretely, the comm actors along the path should use this key to manage
     /// sequence numbers and reorder buffers.
-    pub(crate) fn stream_key(&self) -> (ActorMeshId, hyperactor_reference::ActorId) {
+    pub(crate) fn stream_key(&self) -> (ActorMeshId, ActorId) {
         (self.actor_mesh_id.clone(), self.sender.clone())
     }
 }
@@ -256,7 +256,7 @@ wirevalue::register_type!(CastMessage);
 #[derive(Serialize, Deserialize, Debug, Clone, Named)]
 pub(crate) struct ForwardMessage {
     /// The comm actor who originally casted the message.
-    pub(crate) sender: hyperactor_reference::ActorId,
+    pub(crate) sender: ActorId,
     /// The destination of the message.
     pub(crate) dests: Vec<RoutingFrame>,
     /// The sequence number of this message.
@@ -274,7 +274,7 @@ pub(crate) struct CastMessageV1 {
     /// The additional end-to-end message headers.
     pub(super) headers: Flattrs,
     /// The client who sent this message.
-    pub(super) sender: hyperactor_reference::ActorId,
+    pub(super) sender: ActorId,
     /// The client-assigned session id of this message.
     pub(super) session_id: Uuid,
     /// The client-assigned sequence numbers of this message.
@@ -289,7 +289,7 @@ pub(crate) struct CastMessageV1 {
 }
 
 impl CastEnvelope for CastMessageV1 {
-    fn sender(&self) -> &hyperactor_reference::ActorId {
+    fn sender(&self) -> &ActorId {
         &self.sender
     }
 
@@ -320,7 +320,7 @@ impl CastMessageV1 {
     /// Create a new CastMessageEnvelope.
     #[allow(unused)]
     pub(crate) fn new<A, M>(
-        sender: hyperactor_reference::ActorId,
+        sender: ActorId,
         dest_mesh: &ActorMeshId,
         dest_region: Region,
         headers: Flattrs,
@@ -358,17 +358,13 @@ pub(super) struct ForwardMessageV1 {
 
 declare_attrs! {
     /// Used inside headers to store the originating sender of a cast.
-    pub attr CAST_ORIGINATING_SENDER: hyperactor_reference::ActorId;
+    pub attr CAST_ORIGINATING_SENDER: ActorId;
 
     /// The point in the casted region that this message was sent to.
     pub attr CAST_POINT: Point;
 }
 
-pub fn set_cast_info_on_headers(
-    headers: &mut Flattrs,
-    cast_point: Point,
-    sender: hyperactor_reference::ActorId,
-) {
+pub fn set_cast_info_on_headers(headers: &mut Flattrs, cast_point: Point, sender: ActorId) {
     // Pre-set the telemetry sender hash to the originating actor,
     // so post_unchecked() does not overwrite it with the comm actor.
     // TODO: consider merging SENDER_ACTOR_ID_HASH and
@@ -387,7 +383,7 @@ pub trait CastInfo {
     /// we represent it as the only member of a 0-dimensonal cast shape,
     /// which is the same as a singleton.
     fn cast_point(&self) -> Point;
-    fn sender(&self) -> hyperactor_reference::ActorId;
+    fn sender(&self) -> ActorId;
 }
 
 impl<A: Actor> CastInfo for Context<'_, A> {
@@ -398,7 +394,7 @@ impl<A: Actor> CastInfo for Context<'_, A> {
         }
     }
 
-    fn sender(&self) -> hyperactor_reference::ActorId {
+    fn sender(&self) -> ActorId {
         self.headers()
             .get(CAST_ORIGINATING_SENDER)
             .expect("has sender header")

--- a/hyperactor_mesh/src/host_mesh.rs
+++ b/hyperactor_mesh/src/host_mesh.rs
@@ -9,6 +9,7 @@
 #![allow(clippy::result_large_err)]
 
 use hyperactor::Actor;
+use hyperactor::ActorRef;
 use hyperactor::Handler;
 use hyperactor::accum::StreamingReducerOpts;
 use hyperactor::channel::ChannelTransport;
@@ -36,7 +37,8 @@ use std::time::Duration;
 
 use hyperactor::channel::ChannelAddr;
 use hyperactor::context;
-use hyperactor::reference as hyperactor_reference;
+use hyperactor::reference::ActorId;
+use hyperactor::reference::ProcId;
 use ndslice::Extent;
 use ndslice::Region;
 use ndslice::ViewExt;
@@ -116,24 +118,25 @@ wirevalue::register_type!(HostRef);
 
 impl HostRef {
     /// The host mesh agent associated with this host.
-    fn mesh_agent(&self) -> hyperactor_reference::ActorRef<HostAgent> {
-        hyperactor_reference::ActorRef::attest(
+    fn mesh_agent(&self) -> ActorRef<HostAgent> {
+        ActorRef::attest(
             self.service_proc()
-                .actor_id(host_agent::HOST_MESH_AGENT_ACTOR_NAME),
+                .actor_id(host_agent::HOST_MESH_AGENT_ACTOR_NAME)
+                .into(),
         )
     }
 
     /// The ProcId for the proc with name `name` on this host.
-    fn named_proc(&self, id: &ResourceId) -> hyperactor_reference::ProcId {
-        hyperactor_reference::ProcId::from_proc_ref(hyperactor::addr::ProcAddr::new(
+    fn named_proc(&self, id: &ResourceId) -> ProcId {
+        ProcId::from_proc_ref(hyperactor::addr::ProcAddr::new(
             hyperactor::id::ProcId::new(id.uid().clone(), id.label().cloned()),
             self.0.clone().into(),
         ))
     }
 
     /// The service proc on this host.
-    fn service_proc(&self) -> hyperactor_reference::ProcId {
-        hyperactor_reference::ProcId::from_resource_name(self.0.clone(), SERVICE_PROC_NAME)
+    fn service_proc(&self) -> ProcId {
+        ProcId::from_resource_name(self.0.clone(), SERVICE_PROC_NAME)
     }
 
     /// Request an orderly teardown of this host and all procs it
@@ -194,10 +197,10 @@ impl HostRef {
     }
 }
 
-impl TryFrom<hyperactor_reference::ActorRef<HostAgent>> for HostRef {
+impl TryFrom<ActorRef<HostAgent>> for HostRef {
     type Error = crate::Error;
 
-    fn try_from(value: hyperactor_reference::ActorRef<HostAgent>) -> Result<Self, crate::Error> {
+    fn try_from(value: ActorRef<HostAgent>) -> Result<Self, crate::Error> {
         let proc_id = value.actor_id().proc_id();
         Ok(HostRef(proc_id.addr().clone()))
     }
@@ -264,7 +267,7 @@ impl HostMesh {
         for (rank, host) in self.current_ref.hosts().iter().enumerate() {
             let actor = host.mesh_agent();
             hyperactor_telemetry::notify_actor_created(hyperactor_telemetry::ActorEvent {
-                id: hyperactor_telemetry::hash_to_u64(actor.actor_id()),
+                id: hyperactor_telemetry::hash_to_u64(&actor.actor_id()),
                 timestamp: now,
                 mesh_id: mesh_id_hash,
                 rank: rank as u64,
@@ -870,7 +873,7 @@ impl HostMeshRef {
     /// Create a new HostMeshRef from an arbitrary set of host mesh agents.
     pub fn from_host_agents(
         id: HostMeshId,
-        agents: Vec<hyperactor_reference::ActorRef<HostAgent>>,
+        agents: Vec<ActorRef<HostAgent>>,
     ) -> crate::Result<Self> {
         Ok(Self {
             id,
@@ -886,10 +889,7 @@ impl HostMeshRef {
     }
 
     /// Create a unit HostMeshRef from a host mesh agent.
-    pub fn from_host_agent(
-        id: HostMeshId,
-        agent: hyperactor_reference::ActorRef<HostAgent>,
-    ) -> crate::Result<Self> {
+    pub fn from_host_agent(id: HostMeshId, agent: ActorRef<HostAgent>) -> crate::Result<Self> {
         Ok(Self {
             id,
             region: Extent::unity().into(),
@@ -910,7 +910,7 @@ impl HostMeshRef {
     /// Returns the host entries as `(addr_string, ActorRef<HostAgent>)` pairs.
     /// Used by `MeshAdminAgent::effective_hosts()` to merge C into the
     /// admin's host list (see CH-1 in mesh_admin module doc).
-    pub(crate) fn host_entries(&self) -> Vec<(String, hyperactor_reference::ActorRef<HostAgent>)> {
+    pub(crate) fn host_entries(&self) -> Vec<(String, ActorRef<HostAgent>)> {
         self.ranks
             .iter()
             .map(|h| (h.0.to_string(), h.mesh_agent()))
@@ -1158,9 +1158,10 @@ impl HostMeshRef {
                     proc_id,
                     create_rank,
                     // TODO: specify or retrieve from state instead, to avoid attestation.
-                    hyperactor_reference::ActorRef::attest(
+                    ActorRef::attest(
                         host.named_proc(&proc_name)
-                            .actor_id(crate::proc_agent::PROC_AGENT_ACTOR_NAME),
+                            .actor_id(crate::proc_agent::PROC_AGENT_ACTOR_NAME)
+                            .into(),
                     ),
                 ));
             }
@@ -1274,7 +1275,7 @@ impl HostMeshRef {
             // Undeliverable). Without this, the controller's mailbox has no
             // port entries and messages (including introspection queries)
             // are returned as undeliverable.
-            let _: hyperactor::reference::ActorRef<ProcMeshController> = controller_handle.bind();
+            let _: ActorRef<ProcMeshController> = controller_handle.bind();
         }
         mesh
     }
@@ -1294,7 +1295,7 @@ impl HostMeshRef {
         &self,
         cx: &impl hyperactor::context::Actor,
         proc_mesh_id: &ProcMeshId,
-        procs: impl IntoIterator<Item = hyperactor_reference::ProcId>,
+        procs: impl IntoIterator<Item = ProcId>,
         region: Region,
         reason: String,
     ) -> anyhow::Result<()> {
@@ -1410,13 +1411,13 @@ impl HostMeshRef {
     pub(crate) async fn proc_states(
         &self,
         cx: &impl context::Actor,
-        procs: impl IntoIterator<Item = hyperactor_reference::ProcId>,
+        procs: impl IntoIterator<Item = ProcId>,
         region: Region,
     ) -> crate::Result<ValueMesh<resource::State<ProcState>>> {
         let (tx, mut rx) = cx.mailbox().open_port();
 
         let mut num_ranks = 0;
-        let procs: Vec<hyperactor_reference::ProcId> = procs.into_iter().collect();
+        let procs: Vec<ProcId> = procs.into_iter().collect();
         let mut proc_names = Vec::new();
         for proc_id in procs.iter() {
             num_ranks += 1;
@@ -1519,8 +1520,8 @@ impl HostMeshRef {
 /// First-seen order is preserved: the first occurrence of a given
 /// ActorId wins; subsequent duplicates are silently dropped.
 struct HostSet {
-    seen: HashSet<hyperactor_reference::ActorId>,
-    entries: Vec<(String, hyperactor_reference::ActorRef<HostAgent>)>,
+    seen: HashSet<ActorId>,
+    entries: Vec<(String, ActorRef<HostAgent>)>,
 }
 
 impl HostSet {
@@ -1533,8 +1534,8 @@ impl HostSet {
 
     /// Insert a host entry. No-op if `ActorId` already present (SA-3).
     /// First-seen order is preserved.
-    fn insert(&mut self, addr: String, agent_ref: hyperactor_reference::ActorRef<HostAgent>) {
-        if self.seen.insert(agent_ref.actor_id().clone()) {
+    fn insert(&mut self, addr: String, agent_ref: ActorRef<HostAgent>) {
+        if self.seen.insert(agent_ref.actor_id()) {
             self.entries.push((addr, agent_ref));
         }
     }
@@ -1546,7 +1547,7 @@ impl HostSet {
         }
     }
 
-    fn into_vec(self) -> Vec<(String, hyperactor_reference::ActorRef<HostAgent>)> {
+    fn into_vec(self) -> Vec<(String, ActorRef<HostAgent>)> {
         self.entries
     }
 }
@@ -1559,8 +1560,8 @@ impl HostSet {
 /// of [`HostSet`], not invariants on this function's control flow.
 fn aggregate_hosts(
     meshes: &[impl AsRef<HostMeshRef>],
-    client_host_entries: Option<Vec<(String, hyperactor_reference::ActorRef<HostAgent>)>>,
-) -> Vec<(String, hyperactor_reference::ActorRef<HostAgent>)> {
+    client_host_entries: Option<Vec<(String, ActorRef<HostAgent>)>>,
+) -> Vec<(String, ActorRef<HostAgent>)> {
     let mut set = HostSet::new();
 
     // SA-3: dedup across all mesh hosts in first-seen order.
@@ -1596,7 +1597,7 @@ pub async fn spawn_admin(
     cx: &impl hyperactor::context::Actor,
     admin_addr: Option<std::net::SocketAddr>,
     telemetry_url: Option<String>,
-) -> anyhow::Result<hyperactor_reference::ActorRef<MeshAdminAgent>> {
+) -> anyhow::Result<ActorRef<MeshAdminAgent>> {
     let meshes: Vec<_> = meshes.into_iter().collect();
     anyhow::ensure!(!meshes.is_empty(), "at least one mesh is required (SA-1)");
     for (i, mesh) in meshes.iter().enumerate() {

--- a/hyperactor_mesh/src/host_mesh/host_agent.rs
+++ b/hyperactor_mesh/src/host_mesh/host_agent.rs
@@ -1435,7 +1435,7 @@ mod tests {
                 ..
             } if id == resource_id
               && proc_id == hyperactor_reference::ProcId::from_resource_name(host_addr.clone(), id.to_string())
-              && mesh_agent == hyperactor_reference::ActorRef::attest(hyperactor_reference::ProcId::from_resource_name(host_addr.clone(), id.to_string()).actor_id(crate::proc_agent::PROC_AGENT_ACTOR_NAME)) && bootstrap_command == Some(BootstrapCommand::test())
+              && mesh_agent == hyperactor_reference::ActorRef::attest(hyperactor_reference::ProcId::from_resource_name(host_addr.clone(), id.to_string()).actor_id(crate::proc_agent::PROC_AGENT_ACTOR_NAME).into()) && bootstrap_command == Some(BootstrapCommand::test())
               && mesh_agent == proc_status_mesh_agent
         );
     }

--- a/hyperactor_mesh/src/logging.rs
+++ b/hyperactor_mesh/src/logging.rs
@@ -21,11 +21,13 @@ use chrono::DateTime;
 use chrono::Local;
 use hostname;
 use hyperactor::Actor;
+use hyperactor::ActorRef;
 use hyperactor::Bind;
 use hyperactor::Context;
 use hyperactor::HandleClient;
 use hyperactor::Handler;
 use hyperactor::Instance;
+use hyperactor::OncePortRef;
 use hyperactor::RefClient;
 use hyperactor::Unbind;
 use hyperactor::channel;
@@ -36,7 +38,7 @@ use hyperactor::channel::ChannelTx;
 use hyperactor::channel::Rx;
 use hyperactor::channel::Tx;
 use hyperactor::channel::TxStatus;
-use hyperactor::reference as hyperactor_reference;
+use hyperactor::reference::ProcId;
 use hyperactor_config::CONFIG;
 use hyperactor_config::ConfigAttr;
 use hyperactor_config::Flattrs;
@@ -323,9 +325,9 @@ pub enum LogClientMessage {
         /// Expect these many procs to ack the flush message.
         expected_procs: usize,
         /// Return once we have received the acks from all the procs
-        reply: hyperactor_reference::OncePortRef<()>,
+        reply: OncePortRef<()>,
         /// Return to the caller the current flush version
-        version: hyperactor_reference::OncePortRef<u64>,
+        version: OncePortRef<u64>,
     },
 }
 
@@ -366,10 +368,7 @@ pub struct LocalLogSender {
 }
 
 impl LocalLogSender {
-    fn new(
-        log_channel: ChannelAddr,
-        proc_id: &hyperactor_reference::ProcId,
-    ) -> Result<Self, anyhow::Error> {
+    fn new(log_channel: ChannelAddr, proc_id: &ProcId) -> Result<Self, anyhow::Error> {
         let tx = channel::dial::<LogMessage>(log_channel)?;
         let status = tx.status().clone();
 
@@ -851,7 +850,7 @@ impl StreamFwder {
         target: OutputTarget,
         max_buffer_size: usize,
         log_channel: Option<ChannelAddr>,
-        proc_id: &hyperactor_reference::ProcId,
+        proc_id: &ProcId,
         local_rank: usize,
     ) -> Self {
         let prefix = match hyperactor_config::global::get(PREFIX_WITH_RANK) {
@@ -880,7 +879,7 @@ impl StreamFwder {
         target: OutputTarget,
         max_buffer_size: usize,
         log_channel: Option<ChannelAddr>,
-        proc_id: &hyperactor_reference::ProcId,
+        proc_id: &ProcId,
         prefix: Option<String>,
     ) -> Self {
         // Sanity: when there is no file sink, no log forwarding, and
@@ -990,7 +989,7 @@ pub struct LogForwardActor {
     rx: ChannelRx<LogMessage>,
     flush_tx: Arc<Mutex<ChannelTx<LogMessage>>>,
     next_flush_deadline: SystemTime,
-    logging_client_ref: hyperactor_reference::ActorRef<LogClientActor>,
+    logging_client_ref: ActorRef<LogClientActor>,
     stream_to_client: bool,
 }
 
@@ -1012,7 +1011,7 @@ impl Actor for LogForwardActor {
 
 #[async_trait]
 impl hyperactor::RemoteSpawn for LogForwardActor {
-    type Params = hyperactor_reference::ActorRef<LogClientActor>;
+    type Params = ActorRef<LogClientActor>;
 
     async fn new(logging_client_ref: Self::Params, _environment: Flattrs) -> Result<Self> {
         let log_channel: ChannelAddr = match std::env::var(BOOTSTRAP_LOG_CHANNEL) {
@@ -1178,7 +1177,7 @@ pub struct LogClientActor {
 
     // For flush sync barrier
     current_flush_version: u64,
-    current_flush_port: Option<hyperactor_reference::OncePortRef<()>>,
+    current_flush_port: Option<OncePortRef<()>>,
     current_unflushed_procs: usize,
 }
 
@@ -1390,8 +1389,8 @@ impl LogClientMessageHandler for LogClientActor {
         &mut self,
         cx: &Context<Self>,
         expected_procs_flushed: usize,
-        reply: hyperactor_reference::OncePortRef<()>,
-        version: hyperactor_reference::OncePortRef<u64>,
+        reply: OncePortRef<()>,
+        version: OncePortRef<u64>,
     ) -> Result<(), anyhow::Error> {
         if self.current_unflushed_procs > 0 || self.current_flush_port.is_some() {
             tracing::warn!(
@@ -1610,12 +1609,12 @@ mod tests {
             std::env::set_var(BOOTSTRAP_LOG_CHANNEL, log_channel.to_string());
         }
         let log_client_actor = LogClientActor::new((), Flattrs::default()).await.unwrap();
-        let log_client: hyperactor_reference::ActorRef<LogClientActor> =
+        let log_client: ActorRef<LogClientActor> =
             proc.spawn("log_client", log_client_actor).unwrap().bind();
         let log_forwarder_actor = LogForwardActor::new(log_client.clone(), Flattrs::default())
             .await
             .unwrap();
-        let log_forwarder: hyperactor_reference::ActorRef<LogForwardActor> = proc
+        let log_forwarder: ActorRef<LogForwardActor> = proc
             .spawn("log_forwarder", log_forwarder_actor)
             .unwrap()
             .bind();

--- a/hyperactor_mesh/src/mesh_admin.rs
+++ b/hyperactor_mesh/src/mesh_admin.rs
@@ -996,7 +996,7 @@ impl Actor for MeshAdminAgent {
             .clone()
             .unwrap_or_else(|| "unknown".to_string());
         let bridge_state = Arc::new(BridgeState {
-            admin_ref: hyperactor_reference::ActorRef::attest(this.self_id().clone().into()),
+            admin_ref: hyperactor_reference::ActorRef::attest(this.self_id().clone()),
             bridge_cx,
             resolve_semaphore: tokio::sync::Semaphore::new(hyperactor_config::global::get(
                 crate::config::MESH_ADMIN_MAX_CONCURRENT_RESOLVES,
@@ -1290,7 +1290,7 @@ impl MeshAdminAgent {
         // Try the host agent's QueryChild first.
         let result = query_child_introspect(
             cx,
-            agent.actor_id(),
+            &agent.actor_id(),
             hyperactor_reference::Reference::Proc(proc_id.clone()),
             hyperactor_config::global::get(crate::config::MESH_ADMIN_QUERY_CHILD_TIMEOUT),
             "querying proc details",
@@ -2144,7 +2144,7 @@ enum ResolvedProcHandler {
 }
 
 impl ResolvedProcHandler {
-    fn agent_id(&self) -> &hyperactor_reference::ActorId {
+    fn agent_id(&self) -> hyperactor_reference::ActorId {
         match self {
             Self::Host(r) => r.actor_id(),
             Self::Proc(r) => r.actor_id(),
@@ -2266,12 +2266,12 @@ fn route_proc_handler(raw_proc_reference: &str) -> Result<ResolvedProcHandler, A
     if is_service {
         let agent_id = proc_id.actor_id(HOST_MESH_AGENT_ACTOR_NAME);
         Ok(ResolvedProcHandler::Host(
-            hyperactor_reference::ActorRef::attest(agent_id),
+            hyperactor_reference::ActorRef::attest(agent_id.into()),
         ))
     } else {
         let agent_id = proc_id.actor_id(PROC_AGENT_ACTOR_NAME);
         Ok(ResolvedProcHandler::Proc(
-            hyperactor_reference::ActorRef::attest(agent_id),
+            hyperactor_reference::ActorRef::attest(agent_id.into()),
         ))
     }
 }
@@ -2283,7 +2283,7 @@ async fn resolve_proc_handler(
 ) -> Result<ResolvedProcHandler, ApiError> {
     let handler = route_proc_handler(raw_proc_reference)?;
     let cx = &state.bridge_cx;
-    if !probe_actor(cx, handler.agent_id()).await? {
+    if !probe_actor(cx, &handler.agent_id()).await? {
         return Err(ApiError::not_found(
             format!(
                 "proc does not have a reachable handler ({})",
@@ -3242,9 +3242,9 @@ mod tests {
         let actor_id2 = proc2.actor_id("mesh_agent");
 
         let ref1: hyperactor_reference::ActorRef<HostAgent> =
-            hyperactor_reference::ActorRef::attest(actor_id1.clone());
+            hyperactor_reference::ActorRef::attest(actor_id1.clone().into());
         let ref2: hyperactor_reference::ActorRef<HostAgent> =
-            hyperactor_reference::ActorRef::attest(actor_id2.clone());
+            hyperactor_reference::ActorRef::attest(actor_id2.clone().into());
 
         let agent = MeshAdminAgent::new(
             vec![("host_a".to_string(), ref1), ("host_b".to_string(), ref2)],
@@ -3596,7 +3596,7 @@ mod tests {
         let actor_id1 =
             hyperactor_reference::ActorId::root(proc1, Label::new("mesh_agent").unwrap());
         let ref1: hyperactor_reference::ActorRef<HostAgent> =
-            hyperactor_reference::ActorRef::attest(actor_id1.clone());
+            hyperactor_reference::ActorRef::attest(actor_id1.clone().into());
 
         let client_proc_id =
             hyperactor_reference::ProcId::from_resource_name(ChannelAddr::Tcp(addr1), "local");

--- a/hyperactor_mesh/src/proc_agent.rs
+++ b/hyperactor_mesh/src/proc_agent.rs
@@ -27,6 +27,7 @@ use hyperactor::Data;
 use hyperactor::Handler;
 use hyperactor::Instance;
 use hyperactor::PortHandle;
+use hyperactor::PortRef;
 use hyperactor::Unbind;
 use hyperactor::actor::handle_undeliverable_message;
 use hyperactor::actor::remote::Remote;
@@ -125,7 +126,7 @@ struct ActorInstanceState {
     supervision_event: Option<ActorSupervisionEvent>,
     /// Streaming subscribers that receive `State<ActorState>` on every
     /// state change. Dead subscribers are removed via undeliverable handling.
-    subscribers: Vec<hyperactor_reference::PortRef<resource::State<ActorState>>>,
+    subscribers: Vec<PortRef<resource::State<ActorState>>>,
     /// The time at which the actor should be considered expired if no further
     /// keepalive is received. `None` meaning it will never expire.
     expiry_time: Option<std::time::SystemTime>,
@@ -136,10 +137,7 @@ struct ActorInstanceState {
     /// Pending `WaitRankStatus` callers: each entry is the minimum
     /// status threshold and the reply port to send once the threshold
     /// is met.
-    pending_wait_status: Vec<(
-        resource::Status,
-        hyperactor_reference::PortRef<crate::StatusOverlay>,
-    )>,
+    pending_wait_status: Vec<(resource::Status, PortRef<crate::StatusOverlay>)>,
 }
 
 impl ActorInstanceState {
@@ -652,8 +650,7 @@ impl Actor for ProcAgent {
     ) -> Result<(), anyhow::Error> {
         if let Some(true) = envelope.0.headers().get(STREAM_STATE_SUBSCRIBER) {
             let dest_port_id: hyperactor_reference::PortId = envelope.0.dest().clone().into();
-            let port =
-                hyperactor_reference::PortRef::<resource::State<ActorState>>::attest(dest_port_id);
+            let port = PortRef::<resource::State<ActorState>>::attest(dest_port_id.into());
             // Remove this subscriber from whichever actor instance holds it.
             for instance in self.actor_states.values_mut() {
                 instance.subscribers.retain(|s| s != &port);
@@ -1203,6 +1200,8 @@ impl Handler<SelfCheck> for ProcAgent {
 mod tests {
     use std::sync::Arc;
 
+    use hyperactor::ActorRef;
+
     use super::*;
 
     // A no-op actor used to test direct proc-level spawning.
@@ -1249,8 +1248,7 @@ mod tests {
 
         let agent_id: hyperactor_reference::ActorId =
             proc.proc_id().actor_ref(PROC_AGENT_ACTOR_NAME).into();
-        let port =
-            hyperactor_reference::PortRef::<IntrospectMessage>::attest_message_port(&agent_id);
+        let port = PortRef::<IntrospectMessage>::attest_message_port(&agent_id);
 
         // Helper: send QueryChild(Proc) and return the payload with a
         // timeout so a misrouted reply fails fast rather than hanging.
@@ -1358,8 +1356,7 @@ mod tests {
 
         let agent_id: hyperactor_reference::ActorId =
             proc.proc_id().actor_ref(PROC_AGENT_ACTOR_NAME).into();
-        let port =
-            hyperactor_reference::PortRef::<IntrospectMessage>::attest_message_port(&agent_id);
+        let port = PortRef::<IntrospectMessage>::attest_message_port(&agent_id);
 
         // Concurrent query task: send QueryChild(Proc) every 10ms.
         let query_client_proc =
@@ -1477,7 +1474,7 @@ mod tests {
             .unwrap();
 
         let (client, _client_handle) = proc.instance("client").unwrap();
-        let agent_ref: hyperactor_reference::ActorRef<ProcAgent> = agent_handle.bind();
+        let agent_ref: ActorRef<ProcAgent> = agent_handle.bind();
 
         let actor_type = hyperactor::actor::remote::Remote::collect()
             .name_of::<ExtraActor>()
@@ -1686,8 +1683,7 @@ mod tests {
         // resolution.
         let agent_id: hyperactor_reference::ActorId =
             proc.proc_id().actor_ref(PROC_AGENT_ACTOR_NAME).into();
-        let port =
-            hyperactor_reference::PortRef::<IntrospectMessage>::attest_message_port(&agent_id);
+        let port = PortRef::<IntrospectMessage>::attest_message_port(&agent_id);
 
         // Poll until queue stats are non-zero.
         let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(5);

--- a/hyperactor_mesh/src/proc_mesh.rs
+++ b/hyperactor_mesh/src/proc_mesh.rs
@@ -122,7 +122,7 @@ impl ProcRef {
         &self,
         id: &ActorMeshId,
     ) -> hyperactor_reference::ActorRef<A> {
-        hyperactor_reference::ActorRef::attest(self.actor_id(id))
+        hyperactor_reference::ActorRef::attest(self.actor_id(id).into())
     }
 }
 
@@ -165,7 +165,8 @@ impl ProcMesh {
             ranks
                 .first()
                 .expect("root mesh cannot be empty")
-                .actor_id(&comm_actor_name),
+                .actor_id(&comm_actor_name)
+                .into(),
         );
         let current_ref = ProcMeshRef::new(
             id.clone(),
@@ -212,7 +213,7 @@ impl ProcMesh {
                 let actor_id = rank.agent.actor_id();
 
                 hyperactor_telemetry::notify_actor_created(hyperactor_telemetry::ActorEvent {
-                    id: hyperactor_telemetry::hash_to_u64(actor_id),
+                    id: hyperactor_telemetry::hash_to_u64(&actor_id),
                     timestamp: now,
                     mesh_id: mesh_id_hash,
                     rank: rank.create_rank as u64,

--- a/monarch_distributed_telemetry/src/database_scanner.rs
+++ b/monarch_distributed_telemetry/src/database_scanner.rs
@@ -387,7 +387,8 @@ impl DatabaseScanner {
 
         // Build destination PortRef once
         let dest_port_id: reference::PortId = dest.clone().into();
-        let dest_ref: reference::PortRef<QueryResponse> = reference::PortRef::attest(dest_port_id);
+        let dest_ref: reference::PortRef<QueryResponse> =
+            reference::PortRef::attest(dest_port_id.into());
 
         // Execute scan, streaming batches directly to destination
         self.execute_scan_streaming(

--- a/monarch_extension/src/client.rs
+++ b/monarch_extension/src/client.rs
@@ -410,10 +410,12 @@ impl ClientActor {
             .map_err(|err| PyRuntimeError::new_err(err.to_string()))?;
 
         signal_safe_block_on(py, async move {
-            reference::ActorRef::<ControllerActor>::attest((&controller_id).into())
-                .attach(&instance, reference::ActorRef::attest(actor_id))
-                .await
-                .map_err(|err| PyRuntimeError::new_err(err.to_string()))
+            reference::ActorRef::<ControllerActor>::attest(
+                reference::ActorId::from(&controller_id).into(),
+            )
+            .attach(&instance, reference::ActorRef::attest(actor_id.into()))
+            .await
+            .map_err(|err| PyRuntimeError::new_err(err.to_string()))
         })?
     }
 
@@ -425,10 +427,12 @@ impl ClientActor {
             .map_err(|err| PyRuntimeError::new_err(err.to_string()))?;
 
         signal_safe_block_on(py, async move {
-            reference::ActorRef::<ControllerActor>::attest((&controller_id).into())
-                .drop_refs(&instance, refs)
-                .await
-                .map_err(|err| PyRuntimeError::new_err(err.to_string()))
+            reference::ActorRef::<ControllerActor>::attest(
+                reference::ActorId::from(&controller_id).into(),
+            )
+            .drop_refs(&instance, refs)
+            .await
+            .map_err(|err| PyRuntimeError::new_err(err.to_string()))
         })?
     }
 

--- a/monarch_extension/src/mesh_controller.rs
+++ b/monarch_extension/src/mesh_controller.rs
@@ -156,7 +156,7 @@ impl _Controller {
         accumulate: bool,
     ) -> PyResult<()> {
         let response_port: Option<PortInfo> = response_port.map(|(port, ranks)| PortInfo {
-            port: reference::PortRef::attest(port.into()),
+            port: reference::PortRef::attest(reference::PortId::from(port).into()),
             ranks: ranks.into(),
             accumulate,
         });
@@ -195,7 +195,7 @@ impl _Controller {
             .send(
                 instance.deref(),
                 ClientToControllerMessage::SyncAtExit {
-                    port: reference::PortRef::attest(port.into()),
+                    port: reference::PortRef::attest(reference::PortId::from(port).into()),
                 },
             )
             .map_err(to_py_error)
@@ -781,7 +781,7 @@ impl MeshControllerActor {
     ) -> anyhow::Result<()> {
         if matches!(action, DebuggerAction::Paused()) {
             self.debugger_paused
-                .push_back(reference::ActorRef::attest(debugger_actor_id));
+                .push_back(reference::ActorRef::attest(debugger_actor_id.into()));
         } else {
             let debugger_actor = self
                 .debugger_active

--- a/monarch_hyperactor/src/actor.rs
+++ b/monarch_hyperactor/src/actor.rs
@@ -1795,7 +1795,7 @@ mod tests {
             builder_params: Some(wirevalue::Any::serialize(&"abcdefg12345".to_string()).unwrap()),
         };
         let port_ref = reference::PortRef::<PythonMessage>::attest_reducible(
-            test_port_id("world_0", "client", 123),
+            test_port_id("world_0", "client", 123).into(),
             Some(reducer_spec),
             StreamingReducerOpts::default(),
         );
@@ -1860,7 +1860,10 @@ mod tests {
         // A ProcCreationError
         let mesh_agent: hyperactor::reference::ActorRef<hyperactor_mesh::host_mesh::HostAgent> =
             hyperactor::reference::ActorRef::attest(
-                test_port_id("hello_0", "actor", 0).actor_id().clone(),
+                test_port_id("hello_0", "actor", 0)
+                    .actor_id()
+                    .clone()
+                    .into(),
             );
         let expected_prefix = format!(
             "error creating proc (host rank 0) on host mesh agent {}",

--- a/monarch_hyperactor/src/code_sync/manager.rs
+++ b/monarch_hyperactor/src/code_sync/manager.rs
@@ -376,7 +376,7 @@ impl Handler<SetActorMeshMessage> for CodeSyncManager {
         let mesh = self.self_mesh.get_or_init(|| msg.actor_mesh);
         self.rank.get_or_init(|| {
             mesh.iter()
-                .find(|(_, actor)| actor.actor_id() == cx.self_id())
+                .find(|(_, actor)| *actor.actor_id() == *cx.self_id())
                 .unwrap()
                 .0
                 .rank()

--- a/monarch_hyperactor/src/local_state_broker.rs
+++ b/monarch_hyperactor/src/local_state_broker.rs
@@ -89,7 +89,7 @@ impl BrokerId {
         let broker_name = format!("{:?}", self);
         let actor_id = reference::ActorId::new(cx.proc().proc_id().clone().into(), self.0.clone());
         let actor_ref: reference::ActorRef<LocalStateBrokerActor> =
-            reference::ActorRef::attest(actor_id);
+            reference::ActorRef::attest(actor_id.into());
 
         let mut delay_ms = 1;
         loop {

--- a/monarch_hyperactor/src/mailbox.rs
+++ b/monarch_hyperactor/src/mailbox.rs
@@ -282,7 +282,7 @@ impl PythonPortRef {
     #[new]
     fn new(port: PyPortId) -> Self {
         Self {
-            inner: reference::PortRef::attest(port.into()),
+            inner: reference::PortRef::attest(port.inner.into()),
         }
     }
     fn __reduce__<'py>(
@@ -462,7 +462,7 @@ impl PythonOncePortRef {
     #[new]
     fn new(port: Option<PyPortId>) -> Self {
         Self {
-            inner: port.map(|port| reference::PortRef::attest(port.inner).into_once()),
+            inner: port.map(|port| reference::PortRef::attest(port.inner.into()).into_once()),
         }
     }
     fn __reduce__<'py>(

--- a/monarch_rdma/src/rdma_manager_actor.rs
+++ b/monarch_rdma/src/rdma_manager_actor.rs
@@ -164,7 +164,7 @@ impl RdmaManagerActor {
     pub fn local_handle(client: &impl context::Actor) -> ActorHandle<Self> {
         let proc_id = client.mailbox().actor_id().proc_ref().into();
         let actor_ref =
-            reference::ActorRef::attest(reference::ActorId::new(proc_id, "rdma_manager"));
+            reference::ActorRef::attest(reference::ActorId::new(proc_id, "rdma_manager").into());
         actor_ref
             .downcast_handle(client)
             .expect("RdmaManagerActor is not in the local process")


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #3711
* #3710
* __->__ #3709
* #3708
* #3707
* #3706
* #3705
* #3630
* #3629
* #3628
* #3627
* #3626

Store `ActorRef`, `PortRef`, and `OncePortRef` as addr types internally, add addr accessors, and update `hyperactor_mesh` typed-ref call sites so typed capabilities stop routing through `hyperactor::reference`.

Differential Revision: [D102822045](https://our.internmc.facebook.com/intern/diff/D102822045/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D102822045/)!