### PR TITLE
[hyperactor] rename raw ref_ layer to addr

### DIFF
--- a/hyperactor/src/actor.rs
+++ b/hyperactor/src/actor.rs
@@ -32,6 +32,7 @@ use tokio::task::JoinHandle;
 use typeuri::Named;
 
 use crate as hyperactor; // for macros
+use crate::ActorAddr;
 use crate::Data;
 use crate::Message;
 use crate::RemoteMessage;
@@ -49,7 +50,6 @@ use crate::proc::Instance;
 use crate::proc::InstanceCell;
 use crate::proc::Ports;
 use crate::proc::Proc;
-use crate::ref_;
 use crate::reference;
 use crate::supervision::ActorSupervisionEvent;
 
@@ -334,8 +334,8 @@ impl<A: Actor + Referable + Binds<Self> + Default> RemoteSpawn for A {
 /// with the ID of the actor being served.
 #[derive(Debug)]
 pub struct ActorError {
-    /// The ActorRef for the actor that generated this error.
-    pub actor_id: Box<ref_::ActorRef>,
+    /// The ActorAddr for the actor that generated this error.
+    pub actor_id: Box<ActorAddr>,
     /// The kind of error that occurred.
     pub kind: Box<ActorErrorKind>,
 }
@@ -405,7 +405,7 @@ impl ActorErrorKind {
 
 impl ActorError {
     /// Create a new actor server error with the provided id and kind.
-    pub(crate) fn new(actor_id: &ref_::ActorRef, kind: ActorErrorKind) -> Self {
+    pub(crate) fn new(actor_id: &ActorAddr, kind: ActorErrorKind) -> Self {
         Self {
             actor_id: Box::new(actor_id.clone()),
             kind: Box::new(kind),
@@ -611,7 +611,7 @@ impl fmt::Display for ActorStatus {
 /// detached from the underlying actor instance, and there is no longer
 /// any way to join it.
 ///
-/// Correspondingly, [`crate::ActorRef`]s refer to (possibly) remote
+/// Correspondingly, [`crate::ActorAddr`]s refer to (possibly) remote
 /// actors.
 pub struct ActorHandle<A: Actor> {
     cell: InstanceCell,
@@ -630,8 +630,8 @@ impl<A: Actor> ActorHandle<A> {
         &self.cell
     }
 
-    /// The [`ActorRef`] of the actor represented by this handle.
-    pub fn actor_id(&self) -> &ref_::ActorRef {
+    /// The [`ActorAddr`] of the actor represented by this handle.
+    pub fn actor_id(&self) -> &ActorAddr {
         self.cell.actor_id()
     }
 
@@ -790,6 +790,7 @@ mod tests {
     use super::*;
     use crate as hyperactor;
     use crate::Actor;
+    use crate::Address;
     use crate::OncePortHandle;
     use crate::config;
     use crate::context::Mailbox as _;
@@ -2098,7 +2099,7 @@ mod tests {
         let handle = proc.spawn::<EchoActor>("echo_qch", actor).unwrap();
 
         // Before registering, query_child returns None.
-        let test_ref: ref_::Reference =
+        let test_ref: Address =
             reference::Reference::Actor(test_proc_id("test").actor_id("child")).into();
         assert!(handle.cell().query_child(&test_ref).is_none());
 
@@ -2106,9 +2107,9 @@ mod tests {
         handle.cell().set_query_child_handler(|child_ref| {
             use crate::introspect::IntrospectRef;
             let identity = match child_ref {
-                ref_::Reference::Proc(p) => IntrospectRef::Proc(p.clone().into()),
-                ref_::Reference::Actor(a) => IntrospectRef::Actor(a.clone().into()),
-                ref_::Reference::Port(p) => IntrospectRef::Actor(p.actor_ref().into()),
+                Address::Proc(p) => IntrospectRef::Proc(p.clone().into()),
+                Address::Actor(a) => IntrospectRef::Actor(a.clone().into()),
+                Address::Port(p) => IntrospectRef::Actor(p.actor_ref().into()),
             };
             IntrospectResult {
                 identity,

--- a/hyperactor/src/addr.rs
+++ b/hyperactor/src/addr.rs
@@ -45,9 +45,9 @@ use crate::id::PortId;
 use crate::id::ProcId;
 use crate::id::Uid;
 use crate::parse;
-use crate::parse::ref_::ActorRefParts;
-use crate::parse::ref_::PortRefParts;
-use crate::parse::ref_::ProcRefParts;
+use crate::parse::addr::ActorAddrParts;
+use crate::parse::addr::PortAddrParts;
+use crate::parse::addr::ProcAddrParts;
 use crate::port::Port;
 
 /// A network location, wrapping a [`ChannelAddr`].
@@ -87,9 +87,9 @@ impl FromStr for Location {
     }
 }
 
-/// Errors that can occur when parsing a [`ProcRef`] or [`ActorRef`].
+/// Errors that can occur when parsing a [`ProcAddr`] or [`ActorAddr`].
 #[derive(Debug, thiserror::Error)]
-pub enum RefParseError {
+pub enum AddrParseError {
     /// The `@` separator between id and location is missing.
     #[error("missing '@' separator between id and location")]
     MissingSeparator,
@@ -103,13 +103,13 @@ pub enum RefParseError {
 
 /// A process identifier paired with a network location.
 #[derive(Clone, Serialize, Deserialize, typeuri::Named)]
-pub struct ProcRef {
+pub struct ProcAddr {
     id: ProcId,
     location: Location,
 }
 
-impl ProcRef {
-    /// Create a new [`ProcRef`].
+impl ProcAddr {
+    /// Create a new [`ProcAddr`].
     pub fn new(id: ProcId, location: Location) -> Self {
         Self { id, location }
     }
@@ -143,13 +143,13 @@ impl ProcRef {
         })
     }
 
-    /// Create a ProcRef with a unique (random) uid and the given label.
+    /// Create a ProcAddr with a unique (random) uid and the given label.
     pub fn unique(addr: ChannelAddr, base_name: impl AsRef<str>) -> Self {
         let label = Label::strip(base_name.as_ref());
         Self::new(id::ProcId::instance(label), Location::from(addr))
     }
 
-    /// Create a ProcRef by parsing a name string in ResourceId format.
+    /// Create a ProcAddr by parsing a name string in ResourceId format.
     ///
     /// Recognizes: `label` (singleton), `label<uid58>` (labeled instance),
     /// `<uid58>` (unlabeled instance). Falls back to singleton from stripped name.
@@ -158,9 +158,9 @@ impl ProcRef {
         Self::new(id::ProcId::new(uid, label), Location::from(addr))
     }
 
-    /// Create an ActorRef with the provided name within this proc.
-    pub fn actor_ref(&self, name: impl AsRef<str>) -> ActorRef {
-        ActorRef::new_from_name(self.clone(), name)
+    /// Create an ActorAddr with the provided name within this proc.
+    pub fn actor_ref(&self, name: impl AsRef<str>) -> ActorAddr {
+        ActorAddr::new_from_name(self.clone(), name)
     }
 
     /// A human-readable name for logging.
@@ -169,10 +169,7 @@ impl ProcRef {
     }
 
     /// The ResourceId text form: `label` (singleton), `label-uid58`
-    /// (labeled instance), or `<uid58>` (unlabeled instance). Labeled
-    /// instances match the `Display` output of `mesh_id::ResourceId` and
-    /// are suitable for use as filesystem path components. All forms
-    /// round-trip through `parse_resource_name`.
+    /// (labeled instance), or `<uid58>` (unlabeled instance).
     pub fn resource_name(&self) -> String {
         fn uid_no_brackets(uid: &Uid) -> String {
             uid.to_string()
@@ -180,6 +177,7 @@ impl ProcRef {
                 .trim_end_matches('>')
                 .to_string()
         }
+
         match (self.id.uid(), self.id.label()) {
             (Uid::Singleton(label), _) => label.to_string(),
             (uid @ Uid::Instance(_), Some(label)) => format!("{label}-{}", uid_no_brackets(uid)),
@@ -244,28 +242,28 @@ pub(crate) fn parse_resource_name(s: &str) -> (Uid, Option<Label>) {
     (Uid::Singleton(label.clone()), Some(label))
 }
 
-impl PartialEq for ProcRef {
+impl PartialEq for ProcAddr {
     fn eq(&self, other: &Self) -> bool {
         self.id == other.id && self.location == other.location
     }
 }
 
-impl Eq for ProcRef {}
+impl Eq for ProcAddr {}
 
-impl std::hash::Hash for ProcRef {
+impl std::hash::Hash for ProcAddr {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         self.id.hash(state);
         self.location.hash(state);
     }
 }
 
-impl PartialOrd for ProcRef {
+impl PartialOrd for ProcAddr {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
         Some(self.cmp(other))
     }
 }
 
-impl Ord for ProcRef {
+impl Ord for ProcAddr {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
         self.id
             .cmp(&other.id)
@@ -273,13 +271,13 @@ impl Ord for ProcRef {
     }
 }
 
-impl fmt::Display for ProcRef {
+impl fmt::Display for ProcAddr {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}@{}", self.id, self.location)
     }
 }
 
-impl fmt::Debug for ProcRef {
+impl fmt::Debug for ProcAddr {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self.id.label() {
             Some(label) => write!(f, "<'{}' {}@{}>", label, self.id, self.location),
@@ -288,44 +286,44 @@ impl fmt::Debug for ProcRef {
     }
 }
 
-impl FromStr for ProcRef {
-    type Err = RefParseError;
+impl FromStr for ProcAddr {
+    type Err = AddrParseError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let parts = parse::ref_::parse_proc_ref(s).map_err(|_| legacy_parse_proc_ref(s))?;
+        let parts = parse::addr::parse_proc_addr(s).map_err(|_| legacy_parse_proc_ref(s))?;
         Self::try_from((s, parts))
     }
 }
 
 /// An actor identifier paired with a network location.
 #[derive(Clone, Serialize, Deserialize, typeuri::Named)]
-pub struct ActorRef {
+pub struct ActorAddr {
     id: ActorId,
     location: Location,
 }
 
-hyperactor_config::impl_attrvalue!(ActorRef);
+hyperactor_config::impl_attrvalue!(ActorAddr);
 
-impl PartialEq<crate::reference::ActorId> for ActorRef {
+impl PartialEq<crate::reference::ActorId> for ActorAddr {
     fn eq(&self, other: &crate::reference::ActorId) -> bool {
         self == other.actor_ref()
     }
 }
 
-impl PartialEq<ActorRef> for crate::reference::ActorId {
-    fn eq(&self, other: &ActorRef) -> bool {
+impl PartialEq<ActorAddr> for crate::reference::ActorId {
+    fn eq(&self, other: &ActorAddr) -> bool {
         self.actor_ref() == other
     }
 }
 
-impl ActorRef {
-    /// Create a new [`ActorRef`].
+impl ActorAddr {
+    /// Create a new [`ActorAddr`].
     pub fn new(id: ActorId, location: Location) -> Self {
         Self { id, location }
     }
 
-    /// Create an ActorRef from a ProcRef and name string (parsed in ResourceId format).
-    pub fn new_from_name(proc_ref: ProcRef, name: impl AsRef<str>) -> Self {
+    /// Create an ActorAddr from a ProcAddr and name string (parsed in ResourceId format).
+    pub fn new_from_name(proc_ref: ProcAddr, name: impl AsRef<str>) -> Self {
         let (uid, label) = parse_resource_name(name.as_ref());
         let actor_id = id::ActorId::new(uid, proc_ref.id.clone(), label);
         Self::new(actor_id, proc_ref.location)
@@ -360,27 +358,27 @@ impl ActorRef {
         })
     }
 
-    /// Reconstruct the parent ProcRef (with location preserved).
-    pub fn proc_ref(&self) -> ProcRef {
-        ProcRef::new(self.id.proc_id().clone(), self.location.clone())
+    /// Reconstruct the parent ProcAddr (with location preserved).
+    pub fn proc_ref(&self) -> ProcAddr {
+        ProcAddr::new(self.id.proc_id().clone(), self.location.clone())
     }
 
-    /// Create a PortRef for a port on this actor.
-    pub fn port_ref(&self, port: Port) -> PortRef {
-        PortRef::new(
+    /// Create a PortAddr for a port on this actor.
+    pub fn port_ref(&self, port: Port) -> PortAddr {
+        PortAddr::new(
             id::PortId::new(self.id.clone(), port),
             self.location.clone(),
         )
     }
 
-    /// Create an ActorRef for a root actor on a proc.
-    pub fn root(proc_ref: ProcRef, label: impl Into<Label>) -> Self {
+    /// Create an ActorAddr for a root actor on a proc.
+    pub fn root(proc_ref: ProcAddr, label: impl Into<Label>) -> Self {
         let label = label.into();
         let actor_id = id::ActorId::singleton(label, proc_ref.id.clone());
         Self::new(actor_id, proc_ref.location)
     }
 
-    /// Create an ActorRef for a child actor with a random uid.
+    /// Create an ActorAddr for a child actor with a random uid.
     pub fn unique_child(&self) -> Self {
         let child_id = id::ActorId::instance(self.id.proc_id().clone());
         Self::new(child_id, self.location.clone())
@@ -397,28 +395,28 @@ impl ActorRef {
     }
 }
 
-impl PartialEq for ActorRef {
+impl PartialEq for ActorAddr {
     fn eq(&self, other: &Self) -> bool {
         self.id == other.id && self.location == other.location
     }
 }
 
-impl Eq for ActorRef {}
+impl Eq for ActorAddr {}
 
-impl std::hash::Hash for ActorRef {
+impl std::hash::Hash for ActorAddr {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         self.id.hash(state);
         self.location.hash(state);
     }
 }
 
-impl PartialOrd for ActorRef {
+impl PartialOrd for ActorAddr {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
         Some(self.cmp(other))
     }
 }
 
-impl Ord for ActorRef {
+impl Ord for ActorAddr {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
         self.id
             .cmp(&other.id)
@@ -426,13 +424,13 @@ impl Ord for ActorRef {
     }
 }
 
-impl fmt::Display for ActorRef {
+impl fmt::Display for ActorAddr {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}@{}", self.id, self.location)
     }
 }
 
-impl fmt::Debug for ActorRef {
+impl fmt::Debug for ActorAddr {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match (self.id.label(), self.id.proc_id().label()) {
             (Some(actor_label), Some(proc_label)) => {
@@ -455,24 +453,24 @@ impl fmt::Debug for ActorRef {
     }
 }
 
-impl FromStr for ActorRef {
-    type Err = RefParseError;
+impl FromStr for ActorAddr {
+    type Err = AddrParseError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let parts = parse::ref_::parse_actor_ref(s).map_err(|_| legacy_parse_actor_ref(s))?;
+        let parts = parse::addr::parse_actor_addr(s).map_err(|_| legacy_parse_actor_ref(s))?;
         Self::try_from((s, parts))
     }
 }
 
 /// A port identifier paired with a network location.
 #[derive(Clone, Serialize, Deserialize, typeuri::Named)]
-pub struct PortRef {
+pub struct PortAddr {
     id: PortId,
     location: Location,
 }
 
-impl PortRef {
-    /// Create a new [`PortRef`].
+impl PortAddr {
+    /// Create a new [`PortAddr`].
     pub fn new(id: PortId, location: Location) -> Self {
         Self { id, location }
     }
@@ -502,34 +500,34 @@ impl PortRef {
         self.id.port().as_u64()
     }
 
-    /// Reconstruct the parent ActorRef (with location preserved).
-    pub fn actor_ref(&self) -> ActorRef {
-        ActorRef::new(self.id.actor_id().clone(), self.location.clone())
+    /// Reconstruct the parent ActorAddr (with location preserved).
+    pub fn actor_ref(&self) -> ActorAddr {
+        ActorAddr::new(self.id.actor_id().clone(), self.location.clone())
     }
 }
 
-impl PartialEq for PortRef {
+impl PartialEq for PortAddr {
     fn eq(&self, other: &Self) -> bool {
         self.id == other.id && self.location == other.location
     }
 }
 
-impl Eq for PortRef {}
+impl Eq for PortAddr {}
 
-impl std::hash::Hash for PortRef {
+impl std::hash::Hash for PortAddr {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         self.id.hash(state);
         self.location.hash(state);
     }
 }
 
-impl PartialOrd for PortRef {
+impl PartialOrd for PortAddr {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
         Some(self.cmp(other))
     }
 }
 
-impl Ord for PortRef {
+impl Ord for PortAddr {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
         self.id
             .cmp(&other.id)
@@ -537,13 +535,13 @@ impl Ord for PortRef {
     }
 }
 
-impl fmt::Display for PortRef {
+impl fmt::Display for PortAddr {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}@{}", self.id, self.location)
     }
 }
 
-impl fmt::Debug for PortRef {
+impl fmt::Debug for PortAddr {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match (
             self.id.actor_id().label(),
@@ -569,11 +567,11 @@ impl fmt::Debug for PortRef {
     }
 }
 
-impl FromStr for PortRef {
-    type Err = RefParseError;
+impl FromStr for PortAddr {
+    type Err = AddrParseError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let parts = parse::ref_::parse_port_ref(s).map_err(|_| legacy_parse_port_ref(s))?;
+        let parts = parse::addr::parse_port_addr(s).map_err(|_| legacy_parse_port_ref(s))?;
         Self::try_from((s, parts))
     }
 }
@@ -584,16 +582,16 @@ impl FromStr for PortRef {
 /// [`DialMailboxRouter`]. Ordering is lexicographic by
 /// (proc, actor uid, port).
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
-pub enum Reference {
+pub enum Address {
     /// A process reference.
-    Proc(ProcRef),
+    Proc(ProcAddr),
     /// An actor reference.
-    Actor(ActorRef),
+    Actor(ActorAddr),
     /// A port reference.
-    Port(PortRef),
+    Port(PortAddr),
 }
 
-impl Reference {
+impl Address {
     /// Whether `self` is a prefix of `other`.
     ///
     /// - Proc is a prefix of any Actor or Port on the same proc.
@@ -611,7 +609,7 @@ impl Reference {
     }
 
     /// The proc ref of this reference.
-    pub fn proc_ref(&self) -> ProcRef {
+    pub fn proc_ref(&self) -> ProcAddr {
         match self {
             Self::Proc(p) => p.clone(),
             Self::Actor(a) => a.proc_ref(),
@@ -620,13 +618,13 @@ impl Reference {
     }
 }
 
-impl PartialOrd for Reference {
+impl PartialOrd for Address {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
         Some(self.cmp(other))
     }
 }
 
-impl Ord for Reference {
+impl Ord for Address {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
         // Order by: proc, then actor uid (None < Some), then port (None < Some).
         let proc_ord = self.proc_ref().cmp(&other.proc_ref());
@@ -659,7 +657,7 @@ impl Ord for Reference {
     }
 }
 
-impl fmt::Display for Reference {
+impl fmt::Display for Address {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Proc(p) => fmt::Display::fmt(p, f),
@@ -669,14 +667,14 @@ impl fmt::Display for Reference {
     }
 }
 
-impl FromStr for Reference {
-    type Err = RefParseError;
+impl FromStr for Address {
+    type Err = AddrParseError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match parse::ref_::parse_reference(s).map_err(|_| legacy_parse_reference(s))? {
-            parse::ref_::ReferenceParts::Proc(_) => Ok(Self::Proc(s.parse()?)),
-            parse::ref_::ReferenceParts::Actor(_) => Ok(Self::Actor(s.parse()?)),
-            parse::ref_::ReferenceParts::Port(_) => Ok(Self::Port(s.parse()?)),
+        match parse::addr::parse_address(s).map_err(|_| legacy_parse_reference(s))? {
+            parse::addr::AddressParts::Proc(_) => Ok(Self::Proc(s.parse()?)),
+            parse::addr::AddressParts::Actor(_) => Ok(Self::Actor(s.parse()?)),
+            parse::addr::AddressParts::Port(_) => Ok(Self::Port(s.parse()?)),
         }
     }
 }
@@ -685,61 +683,61 @@ fn id_text_from_ref_input<'a>(input: &'a str, location: &str) -> &'a str {
     &input[..input.len() - location.len() - 1]
 }
 
-impl<'a> TryFrom<(&'a str, ProcRefParts<'a>)> for ProcRef {
-    type Error = RefParseError;
+impl<'a> TryFrom<(&'a str, ProcAddrParts<'a>)> for ProcAddr {
+    type Error = AddrParseError;
 
-    fn try_from((input, parts): (&'a str, ProcRefParts<'a>)) -> Result<Self, Self::Error> {
+    fn try_from((input, parts): (&'a str, ProcAddrParts<'a>)) -> Result<Self, Self::Error> {
         let id_text = id_text_from_ref_input(input, parts.location);
         let id: ProcId = id_text.parse()?;
         let location: Location = parts
             .location
             .parse()
-            .map_err(RefParseError::InvalidLocation)?;
+            .map_err(AddrParseError::InvalidLocation)?;
         Ok(Self { id, location })
     }
 }
 
-impl<'a> TryFrom<(&'a str, ActorRefParts<'a>)> for ActorRef {
-    type Error = RefParseError;
+impl<'a> TryFrom<(&'a str, ActorAddrParts<'a>)> for ActorAddr {
+    type Error = AddrParseError;
 
-    fn try_from((input, parts): (&'a str, ActorRefParts<'a>)) -> Result<Self, Self::Error> {
+    fn try_from((input, parts): (&'a str, ActorAddrParts<'a>)) -> Result<Self, Self::Error> {
         let id_text = id_text_from_ref_input(input, parts.location);
         let id: ActorId = id_text.parse()?;
         let location: Location = parts
             .location
             .parse()
-            .map_err(RefParseError::InvalidLocation)?;
+            .map_err(AddrParseError::InvalidLocation)?;
         Ok(Self { id, location })
     }
 }
 
-impl<'a> TryFrom<(&'a str, PortRefParts<'a>)> for PortRef {
-    type Error = RefParseError;
+impl<'a> TryFrom<(&'a str, PortAddrParts<'a>)> for PortAddr {
+    type Error = AddrParseError;
 
-    fn try_from((input, parts): (&'a str, PortRefParts<'a>)) -> Result<Self, Self::Error> {
+    fn try_from((input, parts): (&'a str, PortAddrParts<'a>)) -> Result<Self, Self::Error> {
         let id_text = id_text_from_ref_input(input, parts.location);
         let id: PortId = id_text.parse()?;
         let location: Location = parts
             .location
             .parse()
-            .map_err(RefParseError::InvalidLocation)?;
+            .map_err(AddrParseError::InvalidLocation)?;
         Ok(Self { id, location })
     }
 }
 
-fn split_ref_input(s: &str) -> Result<(&str, &str), RefParseError> {
+fn split_ref_input(s: &str) -> Result<(&str, &str), AddrParseError> {
     let Some((id_text, location_text)) = s.split_once('@') else {
-        return Err(RefParseError::MissingSeparator);
+        return Err(AddrParseError::MissingSeparator);
     };
     Ok((id_text, location_text))
 }
 
-fn legacy_parse_proc_ref(s: &str) -> RefParseError {
+fn legacy_parse_proc_ref(s: &str) -> AddrParseError {
     let Ok((id_text, location_text)) = split_ref_input(s) else {
-        return RefParseError::MissingSeparator;
+        return AddrParseError::MissingSeparator;
     };
     if let Err(err) = id_text.parse::<ProcId>() {
-        return RefParseError::InvalidId(err);
+        return AddrParseError::InvalidId(err);
     }
     let location = if location_text.is_empty() {
         "@"
@@ -747,15 +745,15 @@ fn legacy_parse_proc_ref(s: &str) -> RefParseError {
         location_text
     };
     let err = location.parse::<Location>().unwrap_err();
-    RefParseError::InvalidLocation(err)
+    AddrParseError::InvalidLocation(err)
 }
 
-fn legacy_parse_actor_ref(s: &str) -> RefParseError {
+fn legacy_parse_actor_ref(s: &str) -> AddrParseError {
     let Ok((id_text, location_text)) = split_ref_input(s) else {
-        return RefParseError::MissingSeparator;
+        return AddrParseError::MissingSeparator;
     };
     if let Err(err) = id_text.parse::<ActorId>() {
-        return RefParseError::InvalidId(err);
+        return AddrParseError::InvalidId(err);
     }
     let location = if location_text.is_empty() {
         "@"
@@ -763,15 +761,15 @@ fn legacy_parse_actor_ref(s: &str) -> RefParseError {
         location_text
     };
     let err = location.parse::<Location>().unwrap_err();
-    RefParseError::InvalidLocation(err)
+    AddrParseError::InvalidLocation(err)
 }
 
-fn legacy_parse_port_ref(s: &str) -> RefParseError {
+fn legacy_parse_port_ref(s: &str) -> AddrParseError {
     let Ok((id_text, location_text)) = split_ref_input(s) else {
-        return RefParseError::MissingSeparator;
+        return AddrParseError::MissingSeparator;
     };
     if let Err(err) = id_text.parse::<PortId>() {
-        return RefParseError::InvalidId(err);
+        return AddrParseError::InvalidId(err);
     }
     let location = if location_text.is_empty() {
         "@"
@@ -779,12 +777,12 @@ fn legacy_parse_port_ref(s: &str) -> RefParseError {
         location_text
     };
     let err = location.parse::<Location>().unwrap_err();
-    RefParseError::InvalidLocation(err)
+    AddrParseError::InvalidLocation(err)
 }
 
-fn legacy_parse_reference(s: &str) -> RefParseError {
+fn legacy_parse_reference(s: &str) -> AddrParseError {
     let Ok((id_text, location_text)) = split_ref_input(s) else {
-        return RefParseError::MissingSeparator;
+        return AddrParseError::MissingSeparator;
     };
     let location = if location_text.is_empty() {
         "@"
@@ -793,7 +791,7 @@ fn legacy_parse_reference(s: &str) -> RefParseError {
     };
     let location_err = || {
         let err = location.parse::<Location>().unwrap_err();
-        RefParseError::InvalidLocation(err)
+        AddrParseError::InvalidLocation(err)
     };
 
     let port_result = id_text.parse::<PortId>();
@@ -810,29 +808,29 @@ fn legacy_parse_reference(s: &str) -> RefParseError {
     }
 
     if id_text.contains(':') {
-        return RefParseError::InvalidId(port_result.unwrap_err());
+        return AddrParseError::InvalidId(port_result.unwrap_err());
     }
     if id_text.contains('.') {
-        return RefParseError::InvalidId(actor_result.unwrap_err());
+        return AddrParseError::InvalidId(actor_result.unwrap_err());
     }
 
-    RefParseError::InvalidId(proc_result.unwrap_err())
+    AddrParseError::InvalidId(proc_result.unwrap_err())
 }
 
-impl From<ProcRef> for Reference {
-    fn from(p: ProcRef) -> Self {
+impl From<ProcAddr> for Address {
+    fn from(p: ProcAddr) -> Self {
         Self::Proc(p)
     }
 }
 
-impl From<ActorRef> for Reference {
-    fn from(a: ActorRef) -> Self {
+impl From<ActorAddr> for Address {
+    fn from(a: ActorAddr) -> Self {
         Self::Actor(a)
     }
 }
 
-impl From<PortRef> for Reference {
-    fn from(p: PortRef) -> Self {
+impl From<PortAddr> for Address {
+    fn from(p: PortAddr) -> Self {
         Self::Port(p)
     }
 }
@@ -876,7 +874,7 @@ mod tests {
             Some(Label::new("my-proc").unwrap()),
         );
         let loc: Location = ChannelAddr::Local(42).into();
-        let pref = ProcRef::new(pid, loc);
+        let pref = ProcAddr::new(pid, loc);
         assert_eq!(pref.to_string(), format!("{}@inproc://42", pref.id()));
     }
 
@@ -887,7 +885,7 @@ mod tests {
             Some(Label::new("my-proc").unwrap()),
         );
         let loc: Location = ChannelAddr::Local(42).into();
-        let pref = ProcRef::new(pid, loc);
+        let pref = ProcAddr::new(pid, loc);
         assert_eq!(
             format!("{:?}", pref),
             format!("<'my-proc' {}@inproc://42>", pref.id())
@@ -898,7 +896,7 @@ mod tests {
     fn test_proc_ref_debug_without_label() {
         let pid = ProcId::new(Uid::Instance(0xabc123), None);
         let loc: Location = ChannelAddr::Local(42).into();
-        let pref = ProcRef::new(pid, loc);
+        let pref = ProcAddr::new(pid, loc);
         assert_eq!(
             format!("{:?}", pref),
             format!("<{}@inproc://42>", pref.id())
@@ -912,15 +910,15 @@ mod tests {
             Some(Label::new("my-proc").unwrap()),
         );
         let loc: Location = ChannelAddr::Local(42).into();
-        let pref = ProcRef::new(pid, loc);
+        let pref = ProcAddr::new(pid, loc);
         let s = pref.to_string();
-        let parsed: ProcRef = s.parse().unwrap();
+        let parsed: ProcAddr = s.parse().unwrap();
         assert_eq!(pref, parsed);
     }
 
     #[test]
     fn test_proc_ref_fromstr_tcp() {
-        let parsed: ProcRef = format!(
+        let parsed: ProcAddr = format!(
             "{}@tcp://127.0.0.1:8080",
             ProcId::new(Uid::Instance(0xabc123), None)
         )
@@ -935,7 +933,7 @@ mod tests {
 
     #[test]
     fn test_proc_ref_fromstr_examples() {
-        let parsed: ProcRef = "local@inproc://0".parse().unwrap();
+        let parsed: ProcAddr = "local@inproc://0".parse().unwrap();
         assert_eq!(
             parsed.id().uid(),
             &Uid::singleton(Label::new("local").unwrap())
@@ -943,7 +941,7 @@ mod tests {
         assert_eq!(*parsed.location().addr(), ChannelAddr::Local(0));
 
         let expected_uid = Uid::Instance(0xabc123);
-        let parsed: ProcRef = format!("controller{}@tcp://[::1]:2345", expected_uid)
+        let parsed: ProcAddr = format!("controller{}@tcp://[::1]:2345", expected_uid)
             .parse()
             .unwrap();
         assert_eq!(parsed.id().uid(), &expected_uid);
@@ -961,15 +959,15 @@ mod tests {
     fn test_proc_ref_fromstr_missing_separator() {
         let err = ProcId::new(Uid::Instance(0xabc123), None)
             .to_string()
-            .parse::<ProcRef>()
+            .parse::<ProcAddr>()
             .unwrap_err();
-        assert!(matches!(err, RefParseError::MissingSeparator));
+        assert!(matches!(err, AddrParseError::MissingSeparator));
     }
 
     #[test]
     fn test_proc_ref_fromstr_invalid_location() {
-        let err = "local@tcp://".parse::<ProcRef>().unwrap_err();
-        assert!(matches!(err, RefParseError::InvalidLocation(_)));
+        let err = "local@tcp://".parse::<ProcAddr>().unwrap_err();
+        assert!(matches!(err, AddrParseError::InvalidLocation(_)));
     }
 
     #[test]
@@ -983,7 +981,7 @@ mod tests {
             Some(Label::new("my-actor").unwrap()),
         );
         let loc: Location = ChannelAddr::Local(42).into();
-        let aref = ActorRef::new(aid, loc);
+        let aref = ActorAddr::new(aid, loc);
         assert_eq!(aref.to_string(), format!("{}@inproc://42", aref.id()));
     }
 
@@ -998,7 +996,7 @@ mod tests {
             Some(Label::new("my-actor").unwrap()),
         );
         let loc: Location = ChannelAddr::Local(42).into();
-        let aref = ActorRef::new(aid, loc);
+        let aref = ActorAddr::new(aid, loc);
         assert_eq!(
             format!("{:?}", aref),
             format!("<'my-actor.my-proc' {}@inproc://42>", aref.id())
@@ -1013,7 +1011,7 @@ mod tests {
             None,
         );
         let loc: Location = ChannelAddr::Local(42).into();
-        let aref = ActorRef::new(aid, loc);
+        let aref = ActorAddr::new(aid, loc);
         assert_eq!(
             format!("{:?}", aref),
             format!("<{}@inproc://42>", aref.id())
@@ -1028,7 +1026,7 @@ mod tests {
             Some(Label::new("my-actor").unwrap()),
         );
         let loc: Location = ChannelAddr::Local(42).into();
-        let aref = ActorRef::new(aid, loc);
+        let aref = ActorAddr::new(aid, loc);
         assert_eq!(
             format!("{:?}", aref),
             format!("<'my-actor' {}@inproc://42>", aref.id())
@@ -1046,7 +1044,7 @@ mod tests {
             None,
         );
         let loc: Location = ChannelAddr::Local(42).into();
-        let aref = ActorRef::new(aid, loc);
+        let aref = ActorAddr::new(aid, loc);
         assert_eq!(
             format!("{:?}", aref),
             format!("<'.my-proc' {}@inproc://42>", aref.id())
@@ -1064,9 +1062,9 @@ mod tests {
             Some(Label::new("my-actor").unwrap()),
         );
         let loc: Location = ChannelAddr::Local(42).into();
-        let aref = ActorRef::new(aid, loc);
+        let aref = ActorAddr::new(aid, loc);
         let s = aref.to_string();
-        let parsed: ActorRef = s.parse().unwrap();
+        let parsed: ActorAddr = s.parse().unwrap();
         assert_eq!(aref, parsed);
         assert_eq!(parsed.id.label().map(|l| l.as_str()), Some("my-actor"));
         assert_eq!(
@@ -1078,7 +1076,7 @@ mod tests {
     #[test]
     fn test_actor_ref_fromstr_examples() {
         let expected_actor_uid = Uid::Instance(0xabc123);
-        let parsed: ActorRef = format!("controller{}.local@inproc://0", expected_actor_uid)
+        let parsed: ActorAddr = format!("controller{}.local@inproc://0", expected_actor_uid)
             .parse()
             .unwrap();
         assert_eq!(parsed.id().uid(), &expected_actor_uid);
@@ -1101,15 +1099,15 @@ mod tests {
             None,
         )
         .to_string()
-        .parse::<ActorRef>()
+        .parse::<ActorAddr>()
         .unwrap_err();
-        assert!(matches!(err, RefParseError::MissingSeparator));
+        assert!(matches!(err, AddrParseError::MissingSeparator));
     }
 
     #[test]
     fn test_actor_ref_fromstr_invalid_location() {
-        let err = "local.local@tcp://".parse::<ActorRef>().unwrap_err();
-        assert!(matches!(err, RefParseError::InvalidLocation(_)));
+        let err = "local.local@tcp://".parse::<ActorAddr>().unwrap_err();
+        assert!(matches!(err, AddrParseError::InvalidLocation(_)));
     }
 
     #[test]
@@ -1119,11 +1117,11 @@ mod tests {
 
         let pid = ProcId::new(Uid::Instance(0x42), Some(Label::new("proc").unwrap()));
         let loc: Location = ChannelAddr::Local(1).into();
-        let a = ProcRef::new(pid.clone(), loc.clone());
-        let b = ProcRef::new(pid, loc);
+        let a = ProcAddr::new(pid.clone(), loc.clone());
+        let b = ProcAddr::new(pid, loc);
         assert_eq!(a, b);
 
-        let hash = |r: &ProcRef| {
+        let hash = |r: &ProcAddr| {
             let mut h = DefaultHasher::new();
             r.hash(&mut h);
             h.finish()
@@ -1134,8 +1132,8 @@ mod tests {
     #[test]
     fn test_proc_ref_neq_different_location() {
         let pid = ProcId::new(Uid::Instance(0x42), Some(Label::new("proc").unwrap()));
-        let a = ProcRef::new(pid.clone(), ChannelAddr::Local(1).into());
-        let b = ProcRef::new(pid, ChannelAddr::Local(2).into());
+        let a = ProcAddr::new(pid.clone(), ChannelAddr::Local(1).into());
+        let b = ProcAddr::new(pid, ChannelAddr::Local(2).into());
         assert_ne!(a, b);
     }
 
@@ -1150,11 +1148,11 @@ mod tests {
             Some(Label::new("actor").unwrap()),
         );
         let loc: Location = ChannelAddr::Local(1).into();
-        let a = ActorRef::new(aid.clone(), loc.clone());
-        let b = ActorRef::new(aid, loc);
+        let a = ActorAddr::new(aid.clone(), loc.clone());
+        let b = ActorAddr::new(aid, loc);
         assert_eq!(a, b);
 
-        let hash = |r: &ActorRef| {
+        let hash = |r: &ActorAddr| {
             let mut h = DefaultHasher::new();
             r.hash(&mut h);
             h.finish()
@@ -1169,10 +1167,10 @@ mod tests {
             Some(Label::new("my-proc").unwrap()),
         );
         let loc: Location = ChannelAddr::Local(0).into();
-        let pref = ProcRef::new(pid, loc);
+        let pref = ProcAddr::new(pid, loc);
         let s = pref.to_string();
         assert_eq!(s, "my-proc@inproc://0");
-        let parsed: ProcRef = s.parse().unwrap();
+        let parsed: ProcAddr = s.parse().unwrap();
         assert_eq!(pref, parsed);
     }
 
@@ -1203,16 +1201,33 @@ mod tests {
     }
 
     #[test]
+    fn test_proc_resource_name_uses_legacy_labeled_instance_format() {
+        let proc_ref = ProcAddr::new(
+            ProcId::new(Uid::Instance(0xabc123), Some(Label::new("worker").unwrap())),
+            ChannelAddr::Local(42).into(),
+        );
+
+        assert_eq!(
+            proc_ref.resource_name(),
+            format!(
+                "worker-{}",
+                Uid::Instance(0xabc123)
+                    .to_string()
+                    .trim_start_matches('<')
+                    .trim_end_matches('>')
+            )
+        );
+    }
+
+    #[test]
     fn test_reference_prefix_relationships() {
-        let proc_ref = ProcRef::from_resource_name(ChannelAddr::Local(42), "service");
+        let proc_ref = ProcAddr::from_resource_name(ChannelAddr::Local(42), "service");
         let actor_ref = proc_ref.actor_ref("host_agent");
         let port_ref = actor_ref.port_ref(Port::from(7u64));
 
-        assert!(
-            Reference::Proc(proc_ref.clone()).is_prefix_of(&Reference::Actor(actor_ref.clone()))
-        );
-        assert!(Reference::Proc(proc_ref.clone()).is_prefix_of(&Reference::Port(port_ref.clone())));
-        assert!(Reference::Actor(actor_ref.clone()).is_prefix_of(&Reference::Port(port_ref)));
+        assert!(Address::Proc(proc_ref.clone()).is_prefix_of(&Address::Actor(actor_ref.clone())));
+        assert!(Address::Proc(proc_ref.clone()).is_prefix_of(&Address::Port(port_ref.clone())));
+        assert!(Address::Actor(actor_ref.clone()).is_prefix_of(&Address::Port(port_ref)));
     }
 
     #[test]
@@ -1230,9 +1245,9 @@ mod tests {
             Some(Label::new("my-proc").unwrap()),
         );
         let loc: Location = ChannelAddr::Local(42).into();
-        let pref = ProcRef::new(pid, loc);
+        let pref = ProcAddr::new(pid, loc);
         let json = serde_json::to_string(&pref).unwrap();
-        let parsed: ProcRef = serde_json::from_str(&json).unwrap();
+        let parsed: ProcAddr = serde_json::from_str(&json).unwrap();
         assert_eq!(pref, parsed);
     }
 
@@ -1247,9 +1262,9 @@ mod tests {
             Some(Label::new("my-actor").unwrap()),
         );
         let loc: Location = ChannelAddr::Local(42).into();
-        let aref = ActorRef::new(aid, loc);
+        let aref = ActorAddr::new(aid, loc);
         let json = serde_json::to_string(&aref).unwrap();
-        let parsed: ActorRef = serde_json::from_str(&json).unwrap();
+        let parsed: ActorAddr = serde_json::from_str(&json).unwrap();
         assert_eq!(aref, parsed);
     }
 
@@ -1259,10 +1274,10 @@ mod tests {
 
         let pid = ProcId::new(Uid::Instance(0x42), None);
         let loc: Location = ChannelAddr::MetaTls(TlsAddr::new("example.com", 443)).into();
-        let pref = ProcRef::new(pid, loc);
+        let pref = ProcAddr::new(pid, loc);
         let s = pref.to_string();
         assert_eq!(s, format!("{}@metatls://example.com:443", pref.id()));
-        let parsed: ProcRef = s.parse().unwrap();
+        let parsed: ProcAddr = s.parse().unwrap();
         assert_eq!(pref, parsed);
     }
 
@@ -1278,7 +1293,7 @@ mod tests {
         );
         let port_id = PortId::new(aid.clone(), Port::from(42));
         let loc: Location = ChannelAddr::Local(7).into();
-        let pref = PortRef::new(port_id.clone(), loc.clone());
+        let pref = PortAddr::new(port_id.clone(), loc.clone());
         assert_eq!(pref.id(), &port_id);
         assert_eq!(pref.location(), &loc);
         assert_eq!(pref.actor_id(), &aid);
@@ -1296,7 +1311,7 @@ mod tests {
         );
         let port_id = PortId::new(aid, Port::from(42));
         let loc: Location = ChannelAddr::Local(7).into();
-        let pref = PortRef::new(port_id, loc);
+        let pref = PortAddr::new(port_id, loc);
         assert_eq!(pref.to_string(), format!("{}@inproc://7", pref.id()));
     }
 
@@ -1312,7 +1327,7 @@ mod tests {
         );
         let port_id = PortId::new(aid, Port::from(42));
         let loc: Location = ChannelAddr::Local(7).into();
-        let pref = PortRef::new(port_id, loc);
+        let pref = PortAddr::new(port_id, loc);
         assert_eq!(
             format!("{:?}", pref),
             format!("<'my-actor.my-proc' {}@inproc://7>", pref.id())
@@ -1328,7 +1343,7 @@ mod tests {
         );
         let port_id = PortId::new(aid, Port::from(42));
         let loc: Location = ChannelAddr::Local(7).into();
-        let pref = PortRef::new(port_id, loc);
+        let pref = PortAddr::new(port_id, loc);
         assert_eq!(format!("{:?}", pref), format!("<{}@inproc://7>", pref.id()));
     }
 
@@ -1341,7 +1356,7 @@ mod tests {
         );
         let port_id = PortId::new(aid, Port::from(42));
         let loc: Location = ChannelAddr::Local(7).into();
-        let pref = PortRef::new(port_id, loc);
+        let pref = PortAddr::new(port_id, loc);
         assert_eq!(
             format!("{:?}", pref),
             format!("<'my-actor' {}@inproc://7>", pref.id())
@@ -1360,7 +1375,7 @@ mod tests {
         );
         let port_id = PortId::new(aid, Port::from(42));
         let loc: Location = ChannelAddr::Local(7).into();
-        let pref = PortRef::new(port_id, loc);
+        let pref = PortAddr::new(port_id, loc);
         assert_eq!(
             format!("{:?}", pref),
             format!("<'.my-proc' {}@inproc://7>", pref.id())
@@ -1379,9 +1394,9 @@ mod tests {
         );
         let port_id = PortId::new(aid, Port::from(42));
         let loc: Location = ChannelAddr::Local(7).into();
-        let pref = PortRef::new(port_id, loc);
+        let pref = PortAddr::new(port_id, loc);
         let s = pref.to_string();
-        let parsed: PortRef = s.parse().unwrap();
+        let parsed: PortAddr = s.parse().unwrap();
         assert_eq!(pref, parsed);
         assert_eq!(
             parsed.id.actor_id().label().map(|l| l.as_str()),
@@ -1397,7 +1412,7 @@ mod tests {
     fn test_port_ref_fromstr_examples() {
         let expected_actor_uid = Uid::Instance(0xabc123);
         let expected_proc_uid = Uid::Instance(0xdef456);
-        let parsed: PortRef = format!(
+        let parsed: PortAddr = format!(
             "{}.{}:42@tcp://[::1]:2345",
             expected_actor_uid, expected_proc_uid
         )
@@ -1423,57 +1438,57 @@ mod tests {
             Port::from(42),
         )
         .to_string()
-        .parse::<PortRef>()
+        .parse::<PortAddr>()
         .unwrap_err();
-        assert!(matches!(err, RefParseError::MissingSeparator));
+        assert!(matches!(err, AddrParseError::MissingSeparator));
     }
 
     #[test]
     fn test_port_ref_fromstr_invalid_location() {
-        let err = "local.local:7@tcp://".parse::<PortRef>().unwrap_err();
-        assert!(matches!(err, RefParseError::InvalidLocation(_)));
+        let err = "local.local:7@tcp://".parse::<PortAddr>().unwrap_err();
+        assert!(matches!(err, AddrParseError::InvalidLocation(_)));
     }
 
     #[test]
     fn test_reference_fromstr_specificity() {
-        let parsed: Reference = "local@inproc://0".parse().unwrap();
-        assert!(matches!(parsed, Reference::Proc(_)));
+        let parsed: Address = "local@inproc://0".parse().unwrap();
+        assert!(matches!(parsed, Address::Proc(_)));
 
-        let parsed: Reference = "local.local@inproc://0".parse().unwrap();
-        assert!(matches!(parsed, Reference::Actor(_)));
+        let parsed: Address = "local.local@inproc://0".parse().unwrap();
+        assert!(matches!(parsed, Address::Actor(_)));
 
-        let parsed: Reference = "local.local:7@inproc://0".parse().unwrap();
-        assert!(matches!(parsed, Reference::Port(_)));
+        let parsed: Address = "local.local:7@inproc://0".parse().unwrap();
+        assert!(matches!(parsed, Address::Port(_)));
     }
 
     #[test]
     fn test_reference_fromstr_rejects_malformed_specific_forms() {
         assert!(
             "local.local:not-a-port@inproc://0"
-                .parse::<Reference>()
+                .parse::<Address>()
                 .is_err()
         );
-        assert!("local.<bad!>@inproc://0".parse::<Reference>().is_err());
-        assert!("local@tcp://".parse::<Reference>().is_err());
+        assert!("local.<bad!>@inproc://0".parse::<Address>().is_err());
+        assert!("local@tcp://".parse::<Address>().is_err());
     }
 
     #[test]
     fn test_reference_fromstr_does_not_downcast_malformed_port_ref() {
         let err = "local.local:not-a-port@inproc://0"
-            .parse::<Reference>()
+            .parse::<Address>()
             .unwrap_err();
         assert!(matches!(
             err,
-            RefParseError::InvalidId(IdParseError::InvalidPort(_))
+            AddrParseError::InvalidId(IdParseError::InvalidPort(_))
         ));
     }
 
     #[test]
     fn test_reference_fromstr_does_not_downcast_malformed_actor_ref() {
-        let err = "local.<bad!>@inproc://0".parse::<Reference>().unwrap_err();
+        let err = "local.<bad!>@inproc://0".parse::<Address>().unwrap_err();
         assert!(matches!(
             err,
-            RefParseError::InvalidId(IdParseError::InvalidActorProcUid(_))
+            AddrParseError::InvalidId(IdParseError::InvalidActorProcUid(_))
         ));
     }
 
@@ -1489,11 +1504,11 @@ mod tests {
         );
         let port_id = PortId::new(aid, Port::from(10));
         let loc: Location = ChannelAddr::Local(1).into();
-        let a = PortRef::new(port_id.clone(), loc.clone());
-        let b = PortRef::new(port_id, loc);
+        let a = PortAddr::new(port_id.clone(), loc.clone());
+        let b = PortAddr::new(port_id, loc);
         assert_eq!(a, b);
 
-        let hash = |r: &PortRef| {
+        let hash = |r: &PortAddr| {
             let mut h = DefaultHasher::new();
             r.hash(&mut h);
             h.finish()
@@ -1509,8 +1524,8 @@ mod tests {
             Some(Label::new("actor").unwrap()),
         );
         let port_id = PortId::new(aid, Port::from(10));
-        let a = PortRef::new(port_id.clone(), ChannelAddr::Local(1).into());
-        let b = PortRef::new(port_id, ChannelAddr::Local(2).into());
+        let a = PortAddr::new(port_id.clone(), ChannelAddr::Local(1).into());
+        let b = PortAddr::new(port_id, ChannelAddr::Local(2).into());
         assert_ne!(a, b);
     }
 
@@ -1526,9 +1541,9 @@ mod tests {
         );
         let port_id = PortId::new(aid, Port::from(42));
         let loc: Location = ChannelAddr::Local(7).into();
-        let pref = PortRef::new(port_id, loc);
+        let pref = PortAddr::new(port_id, loc);
         let json = serde_json::to_string(&pref).unwrap();
-        let parsed: PortRef = serde_json::from_str(&json).unwrap();
+        let parsed: PortAddr = serde_json::from_str(&json).unwrap();
         assert_eq!(pref, parsed);
     }
 }

--- a/hyperactor/src/context.rs
+++ b/hyperactor/src/context.rs
@@ -25,7 +25,9 @@ use backoff::backoff::Backoff;
 use dashmap::DashSet;
 use hyperactor_config::Flattrs;
 
+use crate::ActorAddr;
 use crate::Instance;
+use crate::PortAddr;
 use crate::accum;
 use crate::accum::ErasedCommReducer;
 use crate::accum::ReducerMode;
@@ -36,7 +38,6 @@ use crate::mailbox::MailboxSender;
 use crate::mailbox::MessageEnvelope;
 use crate::ordering::SEQ_INFO;
 use crate::port::Port;
-use crate::ref_;
 use crate::time::Alarm;
 
 /// Policy for handling SEQ_INFO in message headers.
@@ -74,7 +75,7 @@ pub(crate) trait MailboxExt: Mailbox {
     /// All messages posted from actors should use this implementation.
     fn post(
         &self,
-        dest: ref_::PortRef,
+        dest: PortAddr,
         headers: Flattrs,
         data: wirevalue::Any,
         return_undeliverable: bool,
@@ -84,24 +85,24 @@ pub(crate) trait MailboxExt: Mailbox {
     /// Split a port, using a provided reducer spec, if provided.
     fn split(
         &self,
-        port_id: ref_::PortRef,
+        port_id: PortAddr,
         reducer_spec: Option<ReducerSpec>,
         reducer_mode: ReducerMode,
         return_undeliverable: bool,
-    ) -> anyhow::Result<ref_::PortRef>;
+    ) -> anyhow::Result<PortAddr>;
 }
 
 // Tracks mailboxes that have emitted a `CanSend::post` warning due to
 // missing an `Undeliverable<MessageEnvelope>` binding. In this
 // context, mailboxes are few and long-lived; unbounded growth is not
 // a realistic concern.
-static CAN_SEND_WARNED_MAILBOXES: OnceLock<DashSet<ref_::ActorRef>> = OnceLock::new();
+static CAN_SEND_WARNED_MAILBOXES: OnceLock<DashSet<ActorAddr>> = OnceLock::new();
 
 /// Only actors CanSend because they need a return port.
 impl<T: Actor + Send + Sync> MailboxExt for T {
     fn post(
         &self,
-        dest: ref_::PortRef,
+        dest: PortAddr,
         mut headers: Flattrs,
         data: wirevalue::Any,
         return_undeliverable: bool,
@@ -144,14 +145,14 @@ impl<T: Actor + Send + Sync> MailboxExt for T {
 
     fn split(
         &self,
-        port_id: ref_::PortRef,
+        port_id: PortAddr,
         reducer_spec: Option<ReducerSpec>,
         reducer_mode: ReducerMode,
         return_undeliverable: bool,
-    ) -> anyhow::Result<ref_::PortRef> {
+    ) -> anyhow::Result<PortAddr> {
         fn post(
             mailbox: &mailbox::Mailbox,
-            port_id: ref_::PortRef,
+            port_id: PortAddr,
             msg: wirevalue::Any,
             return_undeliverable: bool,
         ) {

--- a/hyperactor/src/host.rs
+++ b/hyperactor/src/host.rs
@@ -70,8 +70,11 @@ use tokio::task::JoinSet;
 
 use crate as hyperactor;
 use crate::Actor;
+use crate::ActorAddr;
 use crate::ActorHandle;
+use crate::Address;
 use crate::Proc;
+use crate::ProcAddr;
 use crate::actor::Binds;
 use crate::actor::Referable;
 use crate::channel;
@@ -93,7 +96,6 @@ use crate::mailbox::MailboxServer;
 use crate::mailbox::MailboxServerError;
 use crate::mailbox::MailboxServerHandle;
 use crate::mailbox::MessageEnvelope;
-use crate::ref_;
 use crate::reference;
 
 /// Name of the system service proc on a host — hosts the admin actor
@@ -213,15 +215,15 @@ pub enum HostError {
 
     /// Failures occuring while spawning a subprocess.
     #[error("proc '{0}' (command: {1}) failed to spawn process: {2}")]
-    ProcessSpawnFailure(ref_::ProcRef, String, #[source] std::io::Error),
+    ProcessSpawnFailure(ProcAddr, String, #[source] std::io::Error),
 
     /// Failures occuring while configuring a subprocess.
     #[error("proc '{0}' failed to configure process: {1}")]
-    ProcessConfigurationFailure(ref_::ProcRef, #[source] anyhow::Error),
+    ProcessConfigurationFailure(ProcAddr, #[source] anyhow::Error),
 
     /// Failures occuring while spawning a management actor in a proc.
     #[error("failed to spawn agent on proc '{0}': {1}")]
-    AgentSpawnFailure(ref_::ProcRef, #[source] anyhow::Error),
+    AgentSpawnFailure(ProcAddr, #[source] anyhow::Error),
 
     /// An input parameter was missing.
     #[error("parameter '{0}' missing: {1}")]
@@ -313,9 +315,8 @@ impl<M: ProcManager> Host<M> {
         // guaranteed by the ChannelAddr component, and the Name type's
         // '-' delimiter must not collide with a hash suffix.
         let service_proc_id =
-            reference::ProcId::from_resource_name(frontend_addr.clone(), SERVICE_PROC_NAME);
-        let local_proc_id =
-            reference::ProcId::from_resource_name(frontend_addr.clone(), LOCAL_PROC_NAME);
+            ProcAddr::from_resource_name(frontend_addr.clone(), SERVICE_PROC_NAME);
+        let local_proc_id = ProcAddr::from_resource_name(frontend_addr.clone(), LOCAL_PROC_NAME);
         let combined = router.fallback(dial_router.boxed());
         let service_proc = Proc::configured(service_proc_id.clone(), combined.clone());
         let local_proc = Proc::configured(local_proc_id.clone(), combined);
@@ -325,11 +326,11 @@ impl<M: ProcManager> Host<M> {
         // avoid a flush cycle: Proc.forwarder → MailboxRouter → Proc →
         // Proc.forwarder → …
         router.bind(
-            ref_::Reference::from(service_proc_id.proc_ref().clone()),
+            Address::from(service_proc_id.clone()),
             service_proc.muxer().clone(),
         );
         router.bind(
-            ref_::Reference::from(local_proc_id.proc_ref().clone()),
+            Address::from(local_proc_id.clone()),
             local_proc.muxer().clone(),
         );
 
@@ -418,12 +419,12 @@ impl<M: ProcManager> Host<M> {
         &mut self,
         name: String,
         config: M::Config,
-    ) -> Result<(ref_::ProcRef, reference::ActorRef<ManagerAgent<M>>), HostError> {
+    ) -> Result<(ProcAddr, reference::ActorRef<ManagerAgent<M>>), HostError> {
         if self.procs.contains(&name) {
             return Err(HostError::ProcExists(name));
         }
 
-        let proc_id = ref_::ProcRef::from_resource_name(self.frontend_addr.clone(), &name);
+        let proc_id = ProcAddr::from_resource_name(self.frontend_addr.clone(), &name);
         let handle = self
             .manager
             .spawn(proc_id.clone(), self.backend_addr.clone(), config)
@@ -444,7 +445,7 @@ impl<M: ProcManager> Host<M> {
         })?;
 
         self.dial_router
-            .bind(ref_::Reference::from(proc_id.clone()), ready.addr().clone());
+            .bind(Address::from(proc_id.clone()), ready.addr().clone());
         self.procs.insert(name.clone());
 
         Ok((proc_id, ready.agent_ref().clone()))
@@ -600,7 +601,7 @@ async fn duplex_accept_loop(
             duplex_tx.post(Host2Client::Bootstrap(assignment));
 
             router.bind(
-                ref_::Reference::from(proc_id.proc_ref().clone()),
+                Address::from(proc_id.proc_ref().clone()),
                 AttachSender(duplex_tx),
             );
 
@@ -615,7 +616,7 @@ async fn duplex_accept_loop(
                         let _ = handle.await;
                     }
                 }
-                cleanup_router.unbind(&ref_::Reference::from(proc_id.proc_ref().clone()));
+                cleanup_router.unbind(&Address::from(proc_id.proc_ref().clone()));
                 tracing::info!(
                     proc_id = proc_id.to_string(),
                     "attach connection closed, removed route"
@@ -809,10 +810,10 @@ pub trait SingleTerminate: Send + Sync {
     async fn terminate_proc(
         &self,
         cx: &impl context::Actor,
-        proc: &ref_::ProcRef,
+        proc: &ProcAddr,
         timeout: std::time::Duration,
         reason: &str,
-    ) -> Result<(Vec<ref_::ActorRef>, Vec<ref_::ActorRef>), anyhow::Error>;
+    ) -> Result<(Vec<ActorAddr>, Vec<ActorAddr>), anyhow::Error>;
 }
 
 /// Trait for managers that can terminate many child **units** in
@@ -887,8 +888,8 @@ impl<M: ProcManager + BulkTerminate> Host<M> {
         // Unbind procs from the router so if new procs are made with the same
         // names, they can use the same slot.
         for name in self.procs.drain() {
-            let proc_ref = ref_::ProcRef::from_resource_name(self.frontend_addr.clone(), &name);
-            self.dial_router.unbind(&ref_::Reference::from(proc_ref));
+            let proc_ref = ProcAddr::from_resource_name(self.frontend_addr.clone(), &name);
+            self.dial_router.unbind(&Address::from(proc_ref));
         }
         summary
     }
@@ -899,10 +900,10 @@ impl<M: ProcManager + SingleTerminate> SingleTerminate for Host<M> {
     async fn terminate_proc(
         &self,
         cx: &impl context::Actor,
-        proc: &ref_::ProcRef,
+        proc: &ProcAddr,
         timeout: Duration,
         reason: &str,
-    ) -> Result<(Vec<ref_::ActorRef>, Vec<ref_::ActorRef>), anyhow::Error> {
+    ) -> Result<(Vec<ActorAddr>, Vec<ActorAddr>), anyhow::Error> {
         self.manager.terminate_proc(cx, proc, timeout, reason).await
     }
 }
@@ -942,7 +943,7 @@ impl<'a, H: ProcHandle> ReadyProc<'a, H> {
     }
 
     /// The proc's logical identity.
-    pub fn proc_id(&self) -> &ref_::ProcRef {
+    pub fn proc_id(&self) -> &ProcAddr {
         self.handle.proc_id()
     }
 
@@ -1009,7 +1010,7 @@ pub trait ProcHandle: Clone + Send + Sync + 'static {
     type TerminalStatus: std::fmt::Debug + Clone + Send + Sync + 'static;
 
     /// The proc's logical identity on this host.
-    fn proc_id(&self) -> &ref_::ProcRef;
+    fn proc_id(&self) -> &ProcAddr;
 
     /// The proc's address (the one callers bind into the host
     /// router). May return `None` before `ready()` completes.
@@ -1090,7 +1091,7 @@ pub trait ProcManager {
     /// ref is returned.
     async fn spawn(
         &self,
-        proc_id: ref_::ProcRef,
+        proc_id: ProcAddr,
         forwarder_addr: ChannelAddr,
         config: Self::Config,
     ) -> Result<Self::Handle, HostError>;
@@ -1135,8 +1136,8 @@ pub enum LocalProcStatus {
 ///
 ///   No OS signals are sent or required.
 pub struct LocalProcManager<S> {
-    procs: Arc<Mutex<HashMap<ref_::ProcRef, Proc>>>,
-    stopping: Arc<Mutex<HashMap<ref_::ProcRef, tokio::sync::watch::Sender<LocalProcStatus>>>>,
+    procs: Arc<Mutex<HashMap<ProcAddr, Proc>>>,
+    stopping: Arc<Mutex<HashMap<ProcAddr, tokio::sync::watch::Sender<LocalProcStatus>>>>,
     spawn: S,
 }
 
@@ -1157,7 +1158,7 @@ impl<S> LocalProcManager<S> {
     /// Status transitions through `Stopping` -> `Stopped` and is
     /// observable via [`local_proc_status`] and [`watch`]. Idempotent:
     /// no-ops if the proc is already stopping or stopped.
-    pub async fn request_stop(&self, proc: &ref_::ProcRef, timeout: Duration, reason: &str) {
+    pub async fn request_stop(&self, proc: &ProcAddr, timeout: Duration, reason: &str) {
         {
             let guard = self.stopping.lock().await;
             if guard.contains_key(proc) {
@@ -1173,7 +1174,7 @@ impl<S> LocalProcManager<S> {
             }
         };
 
-        let proc_ref: ref_::ProcRef = proc_handle.proc_id().clone();
+        let proc_ref: ProcAddr = proc_handle.proc_id().clone();
         let (tx, _) = tokio::sync::watch::channel(LocalProcStatus::Stopping);
         self.stopping.lock().await.insert(proc_ref.clone(), tx);
 
@@ -1196,7 +1197,7 @@ impl<S> LocalProcManager<S> {
     /// [`request_stop`].
     ///
     /// Returns `None` if the proc was never stopped through this path.
-    pub async fn local_proc_status(&self, proc: &ref_::ProcRef) -> Option<LocalProcStatus> {
+    pub async fn local_proc_status(&self, proc: &ProcAddr) -> Option<LocalProcStatus> {
         self.stopping.lock().await.get(proc).map(|tx| *tx.borrow())
     }
 
@@ -1206,7 +1207,7 @@ impl<S> LocalProcManager<S> {
     /// Returns `None` if the proc was never stopped through this path.
     pub async fn watch(
         &self,
-        proc: &ref_::ProcRef,
+        proc: &ProcAddr,
     ) -> Option<tokio::sync::watch::Receiver<LocalProcStatus>> {
         self.stopping
             .lock()
@@ -1269,10 +1270,10 @@ where
     async fn terminate_proc(
         &self,
         _cx: &impl context::Actor,
-        proc: &ref_::ProcRef,
+        proc: &ProcAddr,
         timeout: std::time::Duration,
         reason: &str,
-    ) -> Result<(Vec<ref_::ActorRef>, Vec<ref_::ActorRef>), anyhow::Error> {
+    ) -> Result<(Vec<ActorAddr>, Vec<ActorAddr>), anyhow::Error> {
         // Snapshot procs so we don't hold the lock across awaits.
         let procs: Option<Proc> = {
             let mut guard = self.procs.lock().await;
@@ -1293,7 +1294,7 @@ where
 /// - its [`ProcId`] (logical identity on the host),
 /// - the proc's [`ChannelAddr`] (the address callers bind into the
 ///   host router), and
-/// - the [`ActorRef`] to the agent actor hosted in the proc.
+/// - the [`ActorAddr`] to the agent actor hosted in the proc.
 ///
 /// Unlike external handles, `LocalHandle` does **not** manage an OS
 /// child process. It provides a uniform surface (`proc_id()`,
@@ -1304,10 +1305,10 @@ where
 /// **Type parameter:** `A` is constrained by the `ProcHandle::Agent`
 /// bound (`Actor + Referable`).
 pub struct LocalHandle<A: Actor + Referable> {
-    proc_id: ref_::ProcRef,
+    proc_id: ProcAddr,
     addr: ChannelAddr,
     agent_ref: reference::ActorRef<A>,
-    procs: Arc<Mutex<HashMap<ref_::ProcRef, Proc>>>,
+    procs: Arc<Mutex<HashMap<ProcAddr, Proc>>>,
 }
 
 // Manual `Clone` to avoid requiring `A: Clone`.
@@ -1329,7 +1330,7 @@ impl<A: Actor + Referable> ProcHandle for LocalHandle<A> {
     type Agent = A;
     type TerminalStatus = ();
 
-    fn proc_id(&self) -> &ref_::ProcRef {
+    fn proc_id(&self) -> &ProcAddr {
         &self.proc_id
     }
 
@@ -1431,7 +1432,7 @@ where
     #[crate::instrument(fields(proc_id=proc_id.to_string(), addr=forwarder_addr.to_string()))]
     async fn spawn(
         &self,
-        proc_id: ref_::ProcRef,
+        proc_id: ProcAddr,
         forwarder_addr: ChannelAddr,
         _config: (),
     ) -> Result<Self::Handle, HostError> {
@@ -1484,7 +1485,7 @@ where
 /// protocol.
 pub struct ProcessProcManager<A> {
     program: std::path::PathBuf,
-    children: Arc<Mutex<HashMap<ref_::ProcRef, Child>>>,
+    children: Arc<Mutex<HashMap<ProcAddr, Child>>>,
     _phantom: PhantomData<A>,
 }
 
@@ -1535,7 +1536,7 @@ impl<A> Drop for ProcessProcManager<A> {
 /// typed remote reference).
 #[derive(Debug)]
 pub struct ProcessHandle<A: Actor + Referable> {
-    proc_id: ref_::ProcRef,
+    proc_id: ProcAddr,
     addr: ChannelAddr,
     agent_ref: reference::ActorRef<A>,
 }
@@ -1558,7 +1559,7 @@ impl<A: Actor + Referable> ProcHandle for ProcessHandle<A> {
     type Agent = A;
     type TerminalStatus = ();
 
-    fn proc_id(&self) -> &ref_::ProcRef {
+    fn proc_id(&self) -> &ProcAddr {
         &self.proc_id
     }
 
@@ -1612,7 +1613,7 @@ where
     #[crate::instrument(fields(proc_id=proc_id.to_string(), addr=forwarder_addr.to_string()))]
     async fn spawn(
         &self,
-        proc_id: ref_::ProcRef,
+        proc_id: ProcAddr,
         forwarder_addr: ChannelAddr,
         _config: (),
     ) -> Result<Self::Handle, HostError> {
@@ -1681,7 +1682,7 @@ where
         S: FnOnce(Proc) -> F,
         F: Future<Output = Result<ActorHandle<A>, anyhow::Error>>,
     {
-        let proc_id: ref_::ProcRef = Self::parse_env("HYPERACTOR_HOST_PROC_ID")?;
+        let proc_id: ProcAddr = Self::parse_env("HYPERACTOR_HOST_PROC_ID")?;
         let backend_addr: ChannelAddr = Self::parse_env("HYPERACTOR_HOST_BACKEND_ADDR")?;
         let callback_addr: ChannelAddr = Self::parse_env("HYPERACTOR_HOST_CALLBACK_ADDR")?;
         spawn_proc(proc_id, backend_addr, callback_addr, spawn).await
@@ -1705,7 +1706,7 @@ where
 /// the provided `callback_addr`.
 #[crate::instrument(fields(proc_id=proc_id.to_string(), addr=backend_addr.to_string(), callback_addr=callback_addr.to_string()))]
 pub async fn spawn_proc<A, S, F>(
-    proc_id: ref_::ProcRef,
+    proc_id: ProcAddr,
     backend_addr: ChannelAddr,
     callback_addr: ChannelAddr,
     spawn: S,
@@ -1746,26 +1747,26 @@ pub mod testing {
 
     use crate as hyperactor;
     use crate::Actor;
+    use crate::ActorAddr;
     use crate::Context;
     use crate::Handler;
-    use crate::reference;
-
+    use crate::reference::OncePortRef;
     /// Just a simple actor, available in both the bootstrap binary as well as
     /// hyperactor tests.
     #[derive(Debug, Default)]
-    #[hyperactor::export(handlers = [reference::OncePortRef<reference::ActorId>])]
+    #[hyperactor::export(handlers = [OncePortRef<ActorAddr>])]
     pub struct EchoActor;
 
     impl Actor for EchoActor {}
 
     #[async_trait]
-    impl Handler<reference::OncePortRef<reference::ActorId>> for EchoActor {
+    impl Handler<OncePortRef<ActorAddr>> for EchoActor {
         async fn handle(
             &mut self,
             cx: &Context<Self>,
-            reply: reference::OncePortRef<reference::ActorId>,
+            reply: OncePortRef<ActorAddr>,
         ) -> Result<(), anyhow::Error> {
-            reply.send(cx, reference::ActorId::from(cx.self_id().clone()))?;
+            reply.send(cx, cx.self_id().clone())?;
             Ok(())
         }
     }
@@ -1834,7 +1835,7 @@ mod tests {
         let (proc_id1, _ref) = host.spawn("proc1".to_string(), ()).await.unwrap();
         assert_eq!(
             proc_id1,
-            ref_::ProcRef::from_resource_name(host.addr().clone(), "proc1")
+            ProcAddr::from_resource_name(host.addr().clone(), "proc1")
         );
         assert!(procs.lock().await.contains_key(&proc_id1));
 
@@ -1973,7 +1974,7 @@ mod tests {
     async fn local_ready_and_wait_are_immediate() {
         // Build a LocalHandle directly.
         let addr = ChannelAddr::any(ChannelTransport::Local);
-        let proc_ref = ref_::ProcRef::from_resource_name(addr.clone(), "p");
+        let proc_ref = ProcAddr::from_resource_name(addr.clone(), "p");
         let actor_ref = proc_ref.actor_ref("host_agent");
         let agent_ref = reference::ActorRef::<()>::attest(actor_ref.into());
         let h = LocalHandle::<()> {
@@ -2006,7 +2007,7 @@ mod tests {
 
     #[derive(Debug, Clone)]
     struct TestHandle {
-        id: ref_::ProcRef,
+        id: ProcAddr,
         addr: ChannelAddr,
         agent: reference::ActorRef<()>,
         mode: ReadyMode,
@@ -2019,7 +2020,7 @@ mod tests {
         type Agent = ();
         type TerminalStatus = ();
 
-        fn proc_id(&self) -> &ref_::ProcRef {
+        fn proc_id(&self) -> &ProcAddr {
             &self.id
         }
 
@@ -2101,7 +2102,7 @@ mod tests {
 
         async fn spawn(
             &self,
-            proc_id: ref_::ProcRef,
+            proc_id: ProcAddr,
             forwarder_addr: ChannelAddr,
             _config: (),
         ) -> Result<Self::Handle, HostError> {
@@ -2445,21 +2446,20 @@ mod tests {
 
         let dial_router = DialMailboxRouter::new();
         dial_router.bind(
-            ref_::Reference::from(host.system_proc().proc_id().clone()),
+            Address::from(host.system_proc().proc_id().clone()),
             host.addr().clone(),
         );
         let client_addr = ChannelAddr::any(ChannelTransport::Unix);
         let (client_listen_addr, client_rx) = channel::serve(client_addr).unwrap();
-        let client_proc_id = reference::ProcId::from_resource_name(client_listen_addr, "client");
+        let client_proc_id = ProcAddr::from_resource_name(client_listen_addr, "client");
         let client_proc = Proc::configured(client_proc_id, dial_router.into_boxed());
         let _client_handle = client_proc.clone().serve(client_rx);
 
         let (client_inst, _h) = client_proc.instance("requester").unwrap();
-        let (reply_port, reply_handle) =
-            client_inst.mailbox().open_once_port::<reference::ActorId>();
+        let (reply_port, reply_handle) = client_inst.mailbox().open_once_port::<ActorAddr>();
         let reply_port = reply_port.bind();
         echo_ref
-            .port::<reference::OncePortRef<reference::ActorId>>()
+            .port::<reference::OncePortRef<ActorAddr>>()
             .send(&client_inst, reply_port)
             .unwrap();
         let _ = tokio::time::timeout(Duration::from_secs(5), reply_handle.recv())
@@ -2470,12 +2470,11 @@ mod tests {
         // Snapshot the client's outbound NetTx status before shutdown.
         let host_tx = channel::dial::<MessageEnvelope>(host.addr().clone()).unwrap();
         // Push one message so the lazy-connect kicks in.
-        let dummy_dest = reference::PortId::from(
-            host.system_proc()
-                .proc_id()
-                .actor_ref("noop")
-                .port_ref(crate::port::Port::from(0u64)),
-        );
+        let dummy_dest = host
+            .system_proc()
+            .proc_id()
+            .actor_ref("noop")
+            .port_ref(crate::port::Port::from(0u64));
         let envelope = MessageEnvelope::serialize(
             client_inst.self_id().clone(),
             dummy_dest,
@@ -2558,13 +2557,11 @@ mod tests {
             let system_proc_id = system_proc_id.clone();
             client_tasks.push(tokio::spawn(async move {
                 let dial_router = DialMailboxRouter::new();
-                dial_router.bind(ref_::Reference::from(system_proc_id.clone()), host_addr);
+                dial_router.bind(Address::from(system_proc_id.clone()), host_addr);
                 let client_addr = ChannelAddr::any(ChannelTransport::Unix);
                 let (client_listen_addr, client_rx) = channel::serve(client_addr).unwrap();
-                let client_proc_id = reference::ProcId::from_resource_name(
-                    client_listen_addr,
-                    format!("client-{}", ci),
-                );
+                let client_proc_id =
+                    ProcAddr::from_resource_name(client_listen_addr, format!("client-{}", ci));
                 let client_proc = Proc::configured(client_proc_id, dial_router.into_boxed());
                 let _client_handle = client_proc.clone().serve(client_rx);
 
@@ -2573,10 +2570,10 @@ mod tests {
                 for ri in 0..M_REQUESTS {
                     let (client_inst, _h) = client_proc.instance(&format!("req-{}", ri)).unwrap();
                     let (reply_port, reply_handle) =
-                        client_inst.mailbox().open_once_port::<reference::ActorId>();
+                        client_inst.mailbox().open_once_port::<ActorAddr>();
                     let reply_port = reply_port.bind();
                     echo_ref
-                        .port::<reference::OncePortRef<reference::ActorId>>()
+                        .port::<reference::OncePortRef<ActorAddr>>()
                         .send(&client_inst, reply_port)
                         .unwrap();
                     let received =
@@ -2635,12 +2632,11 @@ mod tests {
         let client_addr = ChannelAddr::any(ChannelTransport::Unix);
         let dial_router = DialMailboxRouter::new();
         dial_router.bind(
-            ref_::Reference::from(host.system_proc().proc_id().clone()),
+            Address::from(host.system_proc().proc_id().clone()),
             host.addr().clone(),
         );
         let (client_listen_addr, client_rx) = channel::serve(client_addr).unwrap();
-        let client_proc_id =
-            reference::ProcId::from_resource_name(client_listen_addr, "external-client");
+        let client_proc_id = ProcAddr::from_resource_name(client_listen_addr, "external-client");
         let client_proc = Proc::configured(client_proc_id, dial_router.into_boxed());
         let _client_handle = client_proc.clone().serve(client_rx);
 
@@ -2649,11 +2645,10 @@ mod tests {
         // Send a request to the echo actor on the host. The reply
         // travels back through the host's dial router → simplex dial
         // → client's frontend.
-        let (reply_port, reply_handle) =
-            client_inst.mailbox().open_once_port::<reference::ActorId>();
+        let (reply_port, reply_handle) = client_inst.mailbox().open_once_port::<ActorAddr>();
         let reply_port = reply_port.bind();
         echo_ref
-            .port::<reference::OncePortRef<reference::ActorId>>()
+            .port::<reference::OncePortRef<ActorAddr>>()
             .send(&client_inst, reply_port)
             .unwrap();
 

--- a/hyperactor/src/introspect.rs
+++ b/hyperactor/src/introspect.rs
@@ -131,8 +131,8 @@ use serde::Deserialize;
 use serde::Serialize;
 use typeuri::Named;
 
+use crate::Address;
 use crate::InstanceCell;
-use crate::ref_;
 use crate::reference;
 
 /// Typed reference to an introspectable entity.
@@ -581,7 +581,7 @@ impl ActorAttrsView {
 /// (with `NodeProperties`) lives in `hyperactor_mesh::introspect`.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Named)]
 pub struct IntrospectResult {
-    /// Reference identifying this node.
+    /// Address identifying this node.
     pub identity: IntrospectRef,
     /// JSON-serialized `Attrs` bag containing introspection attributes.
     pub attrs: String,
@@ -634,7 +634,7 @@ pub enum IntrospectMessage {
     },
     /// "Describe one of your children."
     QueryChild {
-        /// Reference identifying the child to describe.
+        /// Address identifying the child to describe.
         child_ref: reference::Reference,
         /// Reply port receiving the child's description.
         reply: reference::OncePortRef<IntrospectResult>,
@@ -906,7 +906,7 @@ pub(crate) async fn serve_introspect(
                 )
             }
             IntrospectMessage::QueryChild { child_ref, reply } => {
-                let child_ref_: ref_::Reference = child_ref.clone().into();
+                let child_ref_: Address = child_ref.clone().into();
                 let payload = cell.query_child(&child_ref_).unwrap_or_else(|| {
                     let mut error_attrs = hyperactor_config::Attrs::new();
                     error_attrs.set(ERROR_CODE, "not_found".to_string());

--- a/hyperactor/src/lib.rs
+++ b/hyperactor/src/lib.rs
@@ -62,6 +62,7 @@
 pub mod accum;
 pub mod actor;
 pub mod actor_local;
+pub mod addr;
 pub mod channel;
 pub mod config;
 pub mod context;
@@ -77,7 +78,6 @@ pub mod panic_handler;
 mod parse;
 pub mod port;
 pub mod proc;
-pub mod ref_;
 pub mod reference;
 pub mod remote;
 mod signal_handler;
@@ -113,6 +113,12 @@ pub use actor::HandlerInfo;
 pub use actor::RemoteHandles;
 pub use actor::RemoteSpawn;
 pub use actor_local::ActorLocal;
+pub use addr::ActorAddr;
+pub use addr::AddrParseError;
+pub use addr::Address;
+pub use addr::Location;
+pub use addr::PortAddr;
+pub use addr::ProcAddr;
 #[doc(inline)]
 pub use hyperactor_macros::Bind;
 #[doc(inline)]

--- a/hyperactor/src/mailbox.rs
+++ b/hyperactor/src/mailbox.rs
@@ -139,8 +139,12 @@ use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 use typeuri::Named;
 
+use crate::ActorAddr;
+use crate::Address;
 // for macros
+use crate::PortAddr;
 use crate::Proc;
+use crate::ProcAddr;
 use crate::accum::Accumulator;
 use crate::accum::ReducerSpec;
 use crate::accum::StreamingReducerOpts;
@@ -158,7 +162,6 @@ use crate::metrics;
 use crate::ordering::SEQ_INFO;
 use crate::ordering::SeqInfo;
 use crate::port::Port;
-use crate::ref_;
 use crate::reference;
 
 mod undeliverable;
@@ -229,10 +232,10 @@ pub enum DeliveryError {
 #[derive(Debug, Serialize, Deserialize, Clone, typeuri::Named)]
 pub struct MessageEnvelope {
     /// The sender of this message.
-    sender: ref_::ActorRef,
+    sender: ActorAddr,
 
     /// The destination of the message.
-    dest: ref_::PortRef,
+    dest: PortAddr,
 
     /// The serialized message.
     data: wirevalue::Any,
@@ -256,8 +259,8 @@ wirevalue::register_type!(MessageEnvelope);
 impl MessageEnvelope {
     /// Create a new envelope with the provided sender, destination, and message.
     pub fn new(
-        sender: impl Into<ref_::ActorRef>,
-        dest: impl Into<ref_::PortRef>,
+        sender: impl Into<ActorAddr>,
+        dest: impl Into<PortAddr>,
         data: wirevalue::Any,
         headers: Flattrs,
     ) -> Self {
@@ -276,19 +279,19 @@ impl MessageEnvelope {
     }
 
     /// Create a new envelope whose sender ID is unknown.
-    pub(crate) fn new_unknown(dest: impl Into<ref_::PortRef>, data: wirevalue::Any) -> Self {
+    pub(crate) fn new_unknown(dest: impl Into<PortAddr>, data: wirevalue::Any) -> Self {
         // Create a synthetic "unknown" actor ID for messages with no known sender
         let unknown_addr = ChannelAddr::any(ChannelTransport::Local);
-        let unknown_proc_ref = ref_::ProcRef::unique(unknown_addr, "unknown");
+        let unknown_proc_ref = ProcAddr::unique(unknown_addr, "unknown");
         let unknown_actor_ref =
-            ref_::ActorRef::root(unknown_proc_ref, crate::id::Label::strip("unknown"));
+            ActorAddr::root(unknown_proc_ref, crate::id::Label::strip("unknown"));
         Self::new(unknown_actor_ref, dest, data, Flattrs::new())
     }
 
     /// Construct a new serialized value by serializing the provided T-typed value.
     pub fn serialize<T: Serialize + Named>(
-        source: impl Into<ref_::ActorRef>,
-        dest: impl Into<ref_::PortRef>,
+        source: impl Into<ActorAddr>,
+        dest: impl Into<PortAddr>,
         value: &T,
         headers: Flattrs,
     ) -> Result<Self, wirevalue::Error> {
@@ -354,12 +357,12 @@ impl MessageEnvelope {
     }
 
     /// The message sender.
-    pub fn sender(&self) -> &ref_::ActorRef {
+    pub fn sender(&self) -> &ActorAddr {
         &self.sender
     }
 
     /// The destination of the message.
-    pub fn dest(&self) -> &ref_::PortRef {
+    pub fn dest(&self) -> &PortAddr {
         &self.dest
     }
 
@@ -382,7 +385,7 @@ impl MessageEnvelope {
     /// Change the sender on the envelope in case it was set incorrectly. This
     /// should only be used by CommActor since it is forwarding from another
     /// sender.
-    pub fn update_sender(&mut self, sender: impl Into<ref_::ActorRef>) {
+    pub fn update_sender(&mut self, sender: impl Into<ActorAddr>) {
         self.sender = sender.into();
     }
 
@@ -520,8 +523,8 @@ impl fmt::Display for MessageEnvelope {
 /// Metadata about a message sent via a MessageEnvelope.
 #[derive(Clone)]
 pub struct MessageMetadata {
-    sender: ref_::ActorRef,
-    dest: ref_::PortRef,
+    sender: ActorAddr,
+    dest: PortAddr,
     errors: Vec<DeliveryError>,
     headers: Flattrs,
     ttl: u8,
@@ -532,7 +535,7 @@ pub struct MessageMetadata {
 /// with the mailbox's actor id.
 #[derive(Debug)]
 pub struct MailboxError {
-    actor_id: ref_::ActorRef,
+    actor_id: ActorAddr,
     kind: MailboxErrorKind,
 }
 
@@ -547,28 +550,28 @@ pub enum MailboxErrorKind {
 
     /// The port associated with an operation was invalid.
     #[error("invalid port: {0}")]
-    InvalidPort(ref_::PortRef),
+    InvalidPort(PortAddr),
 
     /// There was no sender associated with the port.
     #[error("no sender for port: {0}")]
-    NoSenderForPort(ref_::PortRef),
+    NoSenderForPort(PortAddr),
 
     /// There was no local sender associated with the port.
     /// Returned by operations that require a local port.
     #[error("no local sender for port: {0}")]
-    NoLocalSenderForPort(ref_::PortRef),
+    NoLocalSenderForPort(PortAddr),
 
     /// The port was closed.
     #[error("{0}: port closed")]
-    PortClosed(ref_::PortRef),
+    PortClosed(PortAddr),
 
     /// An error occured during a send operation.
     #[error("send {0}: {1}")]
-    Send(ref_::PortRef, #[source] anyhow::Error),
+    Send(PortAddr, #[source] anyhow::Error),
 
     /// An error occured during a receive operation.
     #[error("recv {0}: {1}")]
-    Recv(ref_::PortRef, #[source] anyhow::Error),
+    Recv(PortAddr, #[source] anyhow::Error),
 
     /// There was a serialization failure.
     #[error("serialize: {0}")]
@@ -590,7 +593,7 @@ pub enum MailboxErrorKind {
 impl MailboxError {
     /// Create a new mailbox error associated with the provided actor
     /// id and of the given kind.
-    pub fn new(actor_id: impl Into<ref_::ActorRef>, kind: MailboxErrorKind) -> Self {
+    pub fn new(actor_id: impl Into<ActorAddr>, kind: MailboxErrorKind) -> Self {
         Self {
             actor_id: actor_id.into(),
             kind,
@@ -598,7 +601,7 @@ impl MailboxError {
     }
 
     /// The ID of the mailbox producing this error.
-    pub fn actor_id(&self) -> &ref_::ActorRef {
+    pub fn actor_id(&self) -> &ActorAddr {
         &self.actor_id
     }
 
@@ -627,23 +630,23 @@ impl std::error::Error for MailboxError {
 #[derive(Debug, Clone)]
 pub enum PortLocation {
     /// The port was bound: the location is its underlying bound ID.
-    Bound(ref_::PortRef),
+    Bound(PortAddr),
     /// The port was not bound: we provide the actor ID and the message type.
-    Unbound(ref_::ActorRef, &'static str),
+    Unbound(ActorAddr, &'static str),
 }
 
 impl PortLocation {
-    fn new_unbound<M: Message>(actor_id: ref_::ActorRef) -> Self {
+    fn new_unbound<M: Message>(actor_id: ActorAddr) -> Self {
         PortLocation::Unbound(actor_id, std::any::type_name::<M>())
     }
 
     #[allow(dead_code)]
-    fn new_unbound_type(actor_id: ref_::ActorRef, ty: &'static str) -> Self {
+    fn new_unbound_type(actor_id: ActorAddr, ty: &'static str) -> Self {
         PortLocation::Unbound(actor_id, ty)
     }
 
     /// The actor id of the location.
-    pub fn actor_id(&self) -> ref_::ActorRef {
+    pub fn actor_id(&self) -> ActorAddr {
         match self {
             PortLocation::Bound(port_ref) => port_ref.actor_ref(),
             PortLocation::Unbound(actor_ref, _) => actor_ref.clone(),
@@ -707,10 +710,7 @@ pub enum MailboxSenderErrorKind {
 
 impl MailboxSenderError {
     /// Create a new mailbox sender error to an unbound port.
-    pub fn new_unbound<M>(
-        actor_id: impl Into<ref_::ActorRef>,
-        kind: MailboxSenderErrorKind,
-    ) -> Self {
+    pub fn new_unbound<M>(actor_id: impl Into<ActorAddr>, kind: MailboxSenderErrorKind) -> Self {
         Self {
             location: Box::new(PortLocation::Unbound(
                 actor_id.into(),
@@ -722,7 +722,7 @@ impl MailboxSenderError {
 
     /// Create a new mailbox sender, manually providing the type.
     pub fn new_unbound_type(
-        actor_id: impl Into<ref_::ActorRef>,
+        actor_id: impl Into<ActorAddr>,
         kind: MailboxSenderErrorKind,
         ty: &'static str,
     ) -> Self {
@@ -733,7 +733,7 @@ impl MailboxSenderError {
     }
 
     /// Create a new mailbox sender error with the provided port ID and kind.
-    pub fn new_bound(port_id: impl Into<ref_::PortRef>, kind: MailboxSenderErrorKind) -> Self {
+    pub fn new_bound(port_id: impl Into<PortAddr>, kind: MailboxSenderErrorKind) -> Self {
         Self {
             location: Box::new(PortLocation::Bound(port_id.into())),
             kind: Box::new(kind),
@@ -1059,7 +1059,7 @@ pub trait MailboxServer: MailboxSender + Clone + Sized + 'static {
             static NEXT_RANK: AtomicUsize = AtomicUsize::new(0);
             let rank = NEXT_RANK.fetch_add(1, Ordering::Relaxed);
             let addr = ChannelAddr::any(ChannelTransport::Local);
-            let proc_id = ref_::ProcRef::unique(addr, format!("mailbox_server_{}", rank));
+            let proc_id = ProcAddr::unique(addr, format!("mailbox_server_{}", rank));
             // Use this mailbox server as the forwarder, so we can use it to
             // return message back to the sender.
             let proc = Proc::configured(proc_id, BoxedMailboxSender::new(server));
@@ -1330,7 +1330,7 @@ impl MailboxSender for MailboxClient {
     }
 }
 
-/// Wrapper to turn `PortRef` into a `Sink`.
+/// Wrapper to turn `PortAddr` into a `Sink`.
 pub struct PortSink<C: context::Actor, M: RemoteMessage> {
     cx: C,
     port: reference::PortRef<M>,
@@ -1373,14 +1373,14 @@ pub struct Mailbox {
 impl Mailbox {
     /// Create a new mailbox associated with the provided actor ID, using the provided
     /// forwarder for external destinations.
-    pub fn new(actor_id: impl Into<ref_::ActorRef>, forwarder: BoxedMailboxSender) -> Self {
+    pub fn new(actor_id: impl Into<ActorAddr>, forwarder: BoxedMailboxSender) -> Self {
         Self {
             inner: Arc::new(State::new(actor_id.into(), forwarder)),
         }
     }
 
     /// Create a new detached mailbox associated with the provided actor ID.
-    pub fn new_detached(actor_id: impl Into<ref_::ActorRef>) -> Self {
+    pub fn new_detached(actor_id: impl Into<ActorAddr>) -> Self {
         Self {
             inner: Arc::new(State::new(
                 actor_id.into(),
@@ -1390,7 +1390,7 @@ impl Mailbox {
     }
 
     /// The actor id associated with this mailbox.
-    pub fn actor_id(&self) -> &ref_::ActorRef {
+    pub fn actor_id(&self) -> &ActorAddr {
         &self.inner.actor_id
     }
 
@@ -1649,7 +1649,7 @@ impl Mailbox {
         }
     }
 
-    pub(crate) fn bind_untyped(&self, port_id: &ref_::PortRef, sender: UntypedUnboundedSender) {
+    pub(crate) fn bind_untyped(&self, port_id: &PortAddr, sender: UntypedUnboundedSender) {
         assert_eq!(
             port_id.actor_ref(),
             *self.actor_id(),
@@ -1865,13 +1865,13 @@ pub struct PortHandle<M: Message> {
     mailbox: Mailbox,
     port_index: u64,
     sender: UnboundedPortSender<M>,
-    // We would like this to be a Arc<RwLock<Option<PortRef<M>>>>, but we cannot
-    // write down the type PortRef<M> (M: Message), even though we cannot
+    // We would like this to be a Arc<RwLock<Option<PortAddr<M>>>>, but we cannot
+    // write down the type PortAddr<M> (M: Message), even though we cannot
     // legally construct such a value without M: RemoteMessage. We could consider
-    // making PortRef<M> valid for M: Message, but constructible only for
+    // making PortAddr<M> valid for M: Message, but constructible only for
     // M: RemoteMessage, but the guarantees offered by the impossibilty of even
     // writing down the type are appealing.
-    bound: Arc<RwLock<Option<ref_::PortRef>>>,
+    bound: Arc<RwLock<Option<PortAddr>>>,
     // Typehash of an optional reducer. When it's defined, we include it in port
     /// references to optionally enable incremental accumulation.
     reducer_spec: Option<ReducerSpec>,
@@ -1923,7 +1923,7 @@ impl<M: Message> PortHandle<M> {
         let bound_guard = self.bound.read().unwrap();
         if let Some(bound_port) = bound_guard.as_ref() {
             let sequencer = cx.instance().sequencer();
-            let bound_ref: crate::ref_::PortRef = bound_port.clone();
+            let bound_ref: PortAddr = bound_port.clone();
             let seq_info = sequencer.assign_seq(&bound_ref);
             headers.set(SEQ_INFO, seq_info);
         } else {
@@ -2032,7 +2032,7 @@ impl<M: Message> fmt::Display for PortHandle<M> {
 pub struct OncePortHandle<M: Message> {
     mailbox: Mailbox,
     port_index: u64,
-    port_id: ref_::PortRef,
+    port_id: PortAddr,
     sender: oneshot::Sender<M>,
     reducer_spec: Option<ReducerSpec>,
 }
@@ -2040,7 +2040,7 @@ pub struct OncePortHandle<M: Message> {
 impl<M: Message> OncePortHandle<M> {
     /// This port's ID.
     // TODO: make value
-    pub fn port_id(&self) -> &ref_::PortRef {
+    pub fn port_id(&self) -> &PortAddr {
         &self.port_id
     }
 
@@ -2092,7 +2092,7 @@ impl<M: Message> fmt::Display for OncePortHandle<M> {
 #[derive(Debug)]
 pub struct PortReceiver<M> {
     receiver: mpsc::UnboundedReceiver<M>,
-    port_id: ref_::PortRef,
+    port_id: PortAddr,
     /// When multiple messages are put in channel, only receive the latest one
     /// if coalesce is true. Other messages will be discarded.
     coalesce: bool,
@@ -2104,7 +2104,7 @@ pub struct PortReceiver<M> {
 impl<M> PortReceiver<M> {
     fn new(
         receiver: mpsc::UnboundedReceiver<M>,
-        port_id: ref_::PortRef,
+        port_id: PortAddr,
         coalesce: bool,
         mailbox: Mailbox,
     ) -> Self {
@@ -2172,7 +2172,7 @@ impl<M> PortReceiver<M> {
         self.port_id.index()
     }
 
-    fn actor_id(&self) -> ref_::ActorRef {
+    fn actor_id(&self) -> ActorAddr {
         self.port_id.actor_ref()
     }
 }
@@ -2197,7 +2197,7 @@ impl<M> Stream for PortReceiver<M> {
 /// A receiver of M-typed messages from [`OncePort`]s.
 pub struct OncePortReceiver<M> {
     receiver: Option<oneshot::Receiver<M>>,
-    port_id: ref_::PortRef,
+    port_id: PortAddr,
 
     /// Mailbox is used to remove the port from service when the receiver
     /// is dropped.
@@ -2224,7 +2224,7 @@ impl<M> OncePortReceiver<M> {
         self.port_id.index()
     }
 
-    fn actor_id(&self) -> ref_::ActorRef {
+    fn actor_id(&self) -> ActorAddr {
         self.port_id.actor_ref()
     }
 }
@@ -2316,13 +2316,13 @@ impl<M: Message> Debug for UnboundedPortSender<M> {
 
 struct UnboundedSender<M: Message> {
     sender: UnboundedPortSender<M>,
-    port_id: ref_::PortRef,
+    port_id: PortAddr,
 }
 
 impl<M: Message> UnboundedSender<M> {
     /// Create a new UnboundedSender encapsulating the provided
     /// sender.
-    fn new(sender: UnboundedPortSender<M>, port_id: ref_::PortRef) -> Self {
+    fn new(sender: UnboundedPortSender<M>, port_id: PortAddr) -> Self {
         Self { sender, port_id }
     }
 
@@ -2393,13 +2393,13 @@ impl<M: RemoteMessage> SerializedSender for UnboundedSender<M> {
 #[derive(Debug)]
 struct OnceSender<M: Message> {
     sender: Arc<Mutex<Option<oneshot::Sender<M>>>>,
-    port_id: ref_::PortRef,
+    port_id: PortAddr,
 }
 
 impl<M: Message> OnceSender<M> {
     /// Create a new OnceSender encapsulating the provided one-shot
     /// sender.
-    fn new(sender: oneshot::Sender<M>, port_id: ref_::PortRef) -> Self {
+    fn new(sender: oneshot::Sender<M>, port_id: PortAddr) -> Self {
         Self {
             sender: Arc::new(Mutex::new(Some(sender))),
             port_id,
@@ -2474,7 +2474,7 @@ impl<M: RemoteMessage> SerializedSender for OnceSender<M> {
 pub(crate) struct UntypedUnboundedSender {
     pub(crate) sender:
         Box<dyn Fn(wirevalue::Any) -> Result<bool, (wirevalue::Any, anyhow::Error)> + Send + Sync>,
-    pub(crate) port_id: ref_::PortRef,
+    pub(crate) port_id: PortAddr,
 }
 
 impl SerializedSender for UntypedUnboundedSender {
@@ -2501,7 +2501,7 @@ impl SerializedSender for UntypedUnboundedSender {
 /// State is the internal state of the mailbox.
 struct State {
     /// The ID of the mailbox owner.
-    actor_id: ref_::ActorRef,
+    actor_id: ActorAddr,
 
     // insert if it's serializable; otherwise don't.
     /// The set of active ports in the mailbox. All currently
@@ -2521,7 +2521,7 @@ struct State {
 
 impl State {
     /// Create a new state with the provided owning ActorId.
-    fn new(actor_id: ref_::ActorRef, forwarder: BoxedMailboxSender) -> Self {
+    fn new(actor_id: ActorAddr, forwarder: BoxedMailboxSender) -> Self {
         Self {
             actor_id,
             ports: DashMap::new(),
@@ -2557,7 +2557,7 @@ impl fmt::Debug for State {
 /// different underlying senders.
 #[derive(Clone)]
 pub struct MailboxMuxer {
-    mailboxes: Arc<DashMap<ref_::ActorRef, Box<dyn MailboxSender + Send + Sync>>>,
+    mailboxes: Arc<DashMap<ActorAddr, Box<dyn MailboxSender + Send + Sync>>>,
 }
 
 impl Default for MailboxMuxer {
@@ -2580,7 +2580,7 @@ impl MailboxMuxer {
     /// the caller must [`MailboxMuxer::unbind`] it first.
     pub fn bind(
         &self,
-        actor_id: impl Into<ref_::ActorRef>,
+        actor_id: impl Into<ActorAddr>,
         sender: impl MailboxSender + 'static,
     ) -> bool {
         let actor_id = actor_id.into();
@@ -2602,12 +2602,12 @@ impl MailboxMuxer {
     /// unbinding, the muxer will no longer be able to send messages to
     /// that actor.
     #[allow(dead_code)]
-    pub(crate) fn unbind(&self, actor_id: &ref_::ActorRef) {
+    pub(crate) fn unbind(&self, actor_id: &ActorAddr) {
         self.mailboxes.remove(actor_id);
     }
 
     /// Returns a list of all actors bound to this muxer. Useful in debugging.
-    pub fn bound_actors(&self) -> Vec<ref_::ActorRef> {
+    pub fn bound_actors(&self) -> Vec<ActorAddr> {
         self.mailboxes.iter().map(|e| e.key().clone()).collect()
     }
 }
@@ -2651,7 +2651,7 @@ impl MailboxSender for MailboxMuxer {
 /// nearest prefix.
 #[derive(Clone)]
 pub struct MailboxRouter {
-    entries: Arc<RwLock<BTreeMap<ref_::Reference, Arc<dyn MailboxSender + Send + Sync>>>>,
+    entries: Arc<RwLock<BTreeMap<Address, Arc<dyn MailboxSender + Send + Sync>>>>,
 }
 
 impl Default for MailboxRouter {
@@ -2687,7 +2687,7 @@ impl MailboxRouter {
     /// Bind the provided sender to the given reference. The destination
     /// is treated as a prefix to which messages can be routed, and
     /// messages are routed to their longest matching prefix.
-    pub fn bind(&self, dest: impl Into<ref_::Reference>, sender: impl MailboxSender + 'static) {
+    pub fn bind(&self, dest: impl Into<Address>, sender: impl MailboxSender + 'static) {
         let dest = dest.into();
         let mut w = self.entries.write().unwrap();
         w.insert(dest, Arc::new(sender));
@@ -2696,13 +2696,13 @@ impl MailboxRouter {
     /// Remove the binding for the given reference. Only the exact
     /// point is removed; other bindings under the same prefix are
     /// unaffected.
-    pub fn unbind(&self, dest: &ref_::Reference) {
+    pub fn unbind(&self, dest: &Address) {
         let mut w = self.entries.write().unwrap();
         w.remove(dest);
     }
 
-    fn sender(&self, actor_ref: &ref_::ActorRef) -> Option<Arc<dyn MailboxSender + Send + Sync>> {
-        let reference = ref_::Reference::from(actor_ref.clone());
+    fn sender(&self, actor_ref: &ActorAddr) -> Option<Arc<dyn MailboxSender + Send + Sync>> {
+        let reference = Address::from(actor_ref.clone());
         match self
             .entries
             .read()
@@ -2790,9 +2790,7 @@ impl MailboxSender for FallbackMailboxRouter {
 /// the granularity of each entry. Possibly the router should allow weak references
 /// on a per-entry basis.
 #[derive(Debug, Clone)]
-pub struct WeakMailboxRouter(
-    Weak<RwLock<BTreeMap<ref_::Reference, Arc<dyn MailboxSender + Send + Sync>>>>,
-);
+pub struct WeakMailboxRouter(Weak<RwLock<BTreeMap<Address, Arc<dyn MailboxSender + Send + Sync>>>>);
 
 impl WeakMailboxRouter {
     /// Upgrade the weak router to a strong reference router.
@@ -2840,7 +2838,7 @@ impl MailboxSender for WeakMailboxRouter {
 /// sender, if present.
 #[derive(Clone)]
 pub struct DialMailboxRouter {
-    address_book: Arc<RwLock<BTreeMap<ref_::Reference, ChannelAddr>>>,
+    address_book: Arc<RwLock<BTreeMap<Address, ChannelAddr>>>,
     sender_cache: Arc<DashMap<ChannelAddr, Arc<MailboxClient>>>,
 
     // The default sender, to which messages for unknown recipients
@@ -2890,12 +2888,12 @@ impl DialMailboxRouter {
         }
     }
 
-    /// Binds a [`Reference`] to a [`ChannelAddr`], replacing any
+    /// Binds a [`Address`] to a [`ChannelAddr`], replacing any
     /// existing binding.
     ///
     /// If the address changes, the old sender is evicted from the
     /// cache to ensure fresh routing on next use.
-    pub fn bind(&self, dest: impl Into<ref_::Reference>, addr: ChannelAddr) {
+    pub fn bind(&self, dest: impl Into<Address>, addr: ChannelAddr) {
         let dest = dest.into();
         if let Ok(mut w) = self.address_book.write() {
             if let Some(old_addr) = w.insert(dest.clone(), addr.clone())
@@ -2914,9 +2912,9 @@ impl DialMailboxRouter {
     ///
     /// Also evicts any corresponding cached senders to prevent reuse
     /// of stale connections.
-    pub fn unbind(&self, dest: &ref_::Reference) {
+    pub fn unbind(&self, dest: &Address) {
         if let Ok(mut w) = self.address_book.write() {
-            let to_remove: Vec<(ref_::Reference, ChannelAddr)> = w
+            let to_remove: Vec<(Address, ChannelAddr)> = w
                 .range(dest..)
                 .take_while(|(key, _)| dest.is_prefix_of(key))
                 .map(|(key, addr)| (key.clone(), addr.clone()))
@@ -2933,13 +2931,13 @@ impl DialMailboxRouter {
     }
 
     /// Lookup an actor's channel in the router's address bok.
-    pub fn lookup_addr(&self, actor_ref: &ref_::ActorRef) -> Option<ChannelAddr> {
+    pub fn lookup_addr(&self, actor_ref: &ActorAddr) -> Option<ChannelAddr> {
         let address_book = self.address_book.read().unwrap();
-        let reference = ref_::Reference::from(actor_ref.clone());
+        let reference = Address::from(actor_ref.clone());
         let found = address_book.lower_bound(Excluded(&reference)).prev();
 
         // First try to look up the address in our address book; failing that,
-        // extract the address from the ProcRef (all procs are direct-addressed now).
+        // extract the address from the ProcAddr (all procs are direct-addressed now).
         if let Some((key, addr)) = found
             && key.is_prefix_of(&reference)
         {
@@ -2956,9 +2954,9 @@ impl DialMailboxRouter {
 
     /// Return all covering prefixes of this router. That is, all references that are not
     /// prefixed by another reference in the routing table
-    pub fn prefixes(&self) -> BTreeSet<ref_::Reference> {
+    pub fn prefixes(&self) -> BTreeSet<Address> {
         let addrs = self.address_book.read().unwrap();
-        let mut prefixes: BTreeSet<ref_::Reference> = BTreeSet::new();
+        let mut prefixes: BTreeSet<Address> = BTreeSet::new();
         for (reference, _) in addrs.iter() {
             match prefixes.lower_bound(Excluded(reference)).peek_prev() {
                 Some(candidate) if candidate.is_prefix_of(reference) => (),
@@ -2974,7 +2972,7 @@ impl DialMailboxRouter {
     fn dial(
         &self,
         addr: &ChannelAddr,
-        actor_ref: &ref_::ActorRef,
+        actor_ref: &ActorAddr,
     ) -> Result<Arc<MailboxClient>, MailboxSenderError> {
         // Get the sender. Create it if needed. Do not send the
         // messages inside this block so we do not hold onto the
@@ -3073,12 +3071,12 @@ mod tests {
     use crate::testing::ids::test_port_id;
     use crate::testing::ids::test_proc_id;
 
-    fn test_proc_ref(name: &str) -> ref_::Reference {
-        ref_::Reference::Proc(test_proc_id(name).into())
+    fn test_proc_ref(name: &str) -> Address {
+        Address::Proc(test_proc_id(name).into())
     }
 
-    fn test_actor_ref(proc_name: &str, actor_name: &str) -> ref_::Reference {
-        ref_::Reference::Actor(test_actor_id(proc_name, actor_name).into())
+    fn test_actor_ref(proc_name: &str, actor_name: &str) -> Address {
+        Address::Actor(test_actor_id(proc_name, actor_name).into())
     }
 
     #[test]
@@ -3351,12 +3349,12 @@ mod tests {
         // Bind a direct address -- we should use its bound address!
         // The actor must be on unix:@4 so that after unbinding, the prefix
         // route for world1_1 (unix!@3) is the fallback, not world1_1/actor1 (unix!@4).
-        let direct_actor_ref: ref_::ActorRef =
+        let direct_actor_ref: ActorAddr =
             reference::ProcId::from_resource_name("unix:@4".parse().unwrap(), "my_proc")
                 .actor_id("my_actor")
                 .into();
         router.bind(
-            ref_::Reference::Actor(direct_actor_ref.clone()),
+            Address::Actor(direct_actor_ref.clone()),
             "unix:@5".parse().unwrap(),
         );
 
@@ -3442,9 +3440,9 @@ mod tests {
                 .label()
                 .is_some_and(|l| l.as_str().starts_with("world0"))
             {
-                world0_router.bind(ref_::Reference::from(mbox.actor_id().clone()), addr);
+                world0_router.bind(Address::from(mbox.actor_id().clone()), addr);
             } else {
-                world1_router.bind(ref_::Reference::from(mbox.actor_id().clone()), addr);
+                world1_router.bind(Address::from(mbox.actor_id().clone()), addr);
             }
         }
 
@@ -3616,7 +3614,7 @@ mod tests {
         fn create_receiver<M>(coalesce: bool) -> (mpsc::UnboundedSender<M>, PortReceiver<M>) {
             // Create dummy state and port_id to create PortReceiver. They are
             // not used in the test.
-            let dummy_actor_ref: ref_::ActorRef = test_actor_id("world_0", "actor").into();
+            let dummy_actor_ref: ActorAddr = test_actor_id("world_0", "actor").into();
             let dummy_state = State::new(
                 dummy_actor_ref.clone(),
                 BOXED_PANICKING_MAILBOX_SENDER.clone(),
@@ -4102,7 +4100,7 @@ mod tests {
                 .expect("receiver should not be closed");
 
         // Verify the undeliverable message has the correct destination
-        let split_port_ref: ref_::PortRef = split_port_id.into();
+        let split_port_ref: PortAddr = split_port_id.into();
         assert_eq!(undeliverable.0.dest(), &split_port_ref);
 
         // Verify no additional messages arrived at the original receiver
@@ -4120,7 +4118,7 @@ mod tests {
         let router = DialMailboxRouter::new();
         router.bind(test_proc_ref("world0"), "unix!@1".parse().unwrap());
 
-        let prefixes: Vec<ref_::Reference> = router.prefixes().into_iter().collect();
+        let prefixes: Vec<Address> = router.prefixes().into_iter().collect();
         assert_eq!(prefixes.len(), 1);
         assert_eq!(prefixes[0], test_proc_ref("world0"));
     }
@@ -4132,7 +4130,7 @@ mod tests {
         router.bind(test_proc_ref("world1"), "unix!@2".parse().unwrap());
         router.bind(test_proc_ref("world2"), "unix!@3".parse().unwrap());
 
-        let mut prefixes: Vec<ref_::Reference> = router.prefixes().into_iter().collect();
+        let mut prefixes: Vec<Address> = router.prefixes().into_iter().collect();
         prefixes.sort();
 
         let mut expected = vec![
@@ -4155,7 +4153,7 @@ mod tests {
         router.bind(test_proc_ref("world1"), "unix!@4".parse().unwrap());
         router.bind(test_proc_ref("world1_0"), "unix!@5".parse().unwrap());
 
-        let mut prefixes: Vec<ref_::Reference> = router.prefixes().into_iter().collect();
+        let mut prefixes: Vec<Address> = router.prefixes().into_iter().collect();
         prefixes.sort();
 
         let mut expected = vec![
@@ -4187,7 +4185,7 @@ mod tests {
             "unix!@6".parse().unwrap(),
         );
 
-        let mut prefixes: Vec<ref_::Reference> = router.prefixes().into_iter().collect();
+        let mut prefixes: Vec<Address> = router.prefixes().into_iter().collect();
         prefixes.sort();
 
         // Covering prefixes:
@@ -4215,7 +4213,7 @@ mod tests {
         router.bind(test_proc_ref("world0_1"), "unix!@2".parse().unwrap());
         router.bind(test_proc_ref("world0_2"), "unix!@3".parse().unwrap());
 
-        let mut prefixes: Vec<ref_::Reference> = router.prefixes().into_iter().collect();
+        let mut prefixes: Vec<Address> = router.prefixes().into_iter().collect();
         prefixes.sort();
 
         // All should be covering prefixes since none is a prefix of another

--- a/hyperactor/src/mailbox/mailbox_admin_message.rs
+++ b/hyperactor/src/mailbox/mailbox_admin_message.rs
@@ -12,9 +12,9 @@ use serde::Serialize;
 pub use crate as hyperactor;
 use crate::HandleClient;
 use crate::Handler;
+use crate::ProcAddr;
 use crate::RefClient;
 use crate::mailbox::ChannelAddr;
-use crate::reference;
 
 /// Messages relating to mailbox administration.
 #[derive(
@@ -32,7 +32,7 @@ pub enum MailboxAdminMessage {
     /// An address update.
     UpdateAddress {
         /// The ID of the proc.
-        proc_id: reference::ProcId,
+        proc_id: ProcAddr,
 
         /// The address at which it listens.
         addr: ChannelAddr,

--- a/hyperactor/src/ordering.rs
+++ b/hyperactor/src/ordering.rs
@@ -25,7 +25,8 @@ use tokio::sync::mpsc::error::SendError;
 use typeuri::Named;
 use uuid::Uuid;
 
-use crate::ref_;
+use crate::ActorAddr;
+use crate::PortAddr;
 
 /// A client's re-ordering buffer state.
 struct BufferState<T> {
@@ -179,9 +180,9 @@ impl<T> OrderedSender<T> {
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
 enum SeqKey {
     /// Shared sequence for all actor ports of an actor
-    Actor(ref_::ActorRef),
+    Actor(ActorAddr),
     /// Individual sequence for a specific non-actor port
-    Port(ref_::PortRef),
+    Port(PortAddr),
 }
 
 /// A message's sequencer number infomation.
@@ -255,7 +256,7 @@ impl Sequencer {
     ///
     /// - Actor ports: share the same sequence scheme per actor (keyed by ActorId)
     /// - Non-actor ports: get individual sequence schemes (keyed by PortId)
-    pub fn assign_seq(&self, port_id: &ref_::PortRef) -> SeqInfo {
+    pub fn assign_seq(&self, port_id: &PortAddr) -> SeqInfo {
         let key = if port_id.is_actor_port() {
             SeqKey::Actor(port_id.actor_ref().clone())
         } else {
@@ -475,7 +476,7 @@ mod tests {
             last_seqs: Arc::new(Mutex::new(HashMap::new())),
         };
 
-        let actor_ref: crate::ref_::ActorRef = test_actor_id("test_0", "test").into();
+        let actor_ref: ActorAddr = test_actor_id("test_0", "test").into();
         let port_ref = actor_ref.port_ref(Port::from(1));
 
         // Modify original sequencer
@@ -495,18 +496,18 @@ mod tests {
             last_seqs: Arc::new(Mutex::new(HashMap::new())),
         };
 
-        let actor_ref: crate::ref_::ActorRef = test_actor_id("worker_0", "worker").into();
+        let actor_ref: ActorAddr = test_actor_id("worker_0", "worker").into();
         // Two different actor ports for the same actor (using Named::port())
         let actor_port_1 = actor_ref.port_ref(Port::from(TestMsg1::port()));
         let actor_port_2 = actor_ref.port_ref(Port::from(TestMsg2::port()));
 
-        // Actor ports should share a sequence (keyed by ActorRef)
+        // Actor ports should share a sequence (keyed by ActorAddr)
         assert_eq!(get_seq(sequencer.assign_seq(&actor_port_1)), 1);
         assert_eq!(get_seq(sequencer.assign_seq(&actor_port_2)), 2); // continues from 1
         assert_eq!(get_seq(sequencer.assign_seq(&actor_port_1)), 3);
 
         // Actor ports from a different actor get their own shared sequence
-        let actor_ref_2: crate::ref_::ActorRef = test_actor_id("worker_1", "worker").into();
+        let actor_ref_2: ActorAddr = test_actor_id("worker_1", "worker").into();
         let actor_port_3 = actor_ref_2.port_ref(Port::from(TestMsg1::port()));
         assert_eq!(get_seq(sequencer.assign_seq(&actor_port_3)), 1); // independent from actor_ref
     }
@@ -518,14 +519,14 @@ mod tests {
             last_seqs: Arc::new(Mutex::new(HashMap::new())),
         };
 
-        let actor_ref_0: crate::ref_::ActorRef = test_actor_id("worker_0", "worker").into();
-        let actor_ref_1: crate::ref_::ActorRef = test_actor_id("worker_1", "worker").into();
+        let actor_ref_0: ActorAddr = test_actor_id("worker_0", "worker").into();
+        let actor_ref_1: ActorAddr = test_actor_id("worker_1", "worker").into();
 
         // Non-actor ports from the same actor (without ACTOR_PORT_BIT)
         let port_1 = actor_ref_0.port_ref(Port::from(1));
         let port_2 = actor_ref_0.port_ref(Port::from(2));
 
-        // Non-actor ports should have independent sequences (keyed by PortRef)
+        // Non-actor ports should have independent sequences (keyed by PortAddr)
         assert_eq!(get_seq(sequencer.assign_seq(&port_1)), 1);
         assert_eq!(get_seq(sequencer.assign_seq(&port_2)), 1); // independent, starts at 1
         assert_eq!(get_seq(sequencer.assign_seq(&port_1)), 2);
@@ -545,7 +546,7 @@ mod tests {
             last_seqs: Arc::new(Mutex::new(HashMap::new())),
         };
 
-        let actor_ref: crate::ref_::ActorRef = test_actor_id("worker_0", "worker").into();
+        let actor_ref: ActorAddr = test_actor_id("worker_0", "worker").into();
 
         // Actor ports (share sequence per actor)
         let actor_port_1 = actor_ref.port_ref(Port::from(TestMsg1::port()));

--- a/hyperactor/src/parse/addr.rs
+++ b/hyperactor/src/parse/addr.rs
@@ -1,0 +1,249 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+//! Recursive-descent parsing for Hyperactor addresses.
+//!
+//! These parsers compose on top of the shared id parser and then treat the
+//! location tail after `@` as opaque input for `Location::from_str`. That
+//! keeps URL punctuation out of the Hyperactor lexer while still giving
+//! token-aware errors at the id/address boundary.
+
+use crate::parse::error::ParseError;
+use crate::parse::id::ActorIdParts;
+use crate::parse::id::Parser;
+use crate::parse::id::PortIdParts;
+use crate::parse::id::ProcIdParts;
+use crate::parse::id::parse_actor_id_parts;
+use crate::parse::id::parse_id_component;
+use crate::parse::id::parse_port_id_parts;
+use crate::parse::id::parse_proc_id_parts;
+use crate::parse::lex::TokenKind;
+
+/// A parsed proc address.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct ProcAddrParts<'a> {
+    /// The proc id.
+    pub(crate) id: ProcIdParts<'a>,
+    /// The raw location tail.
+    pub(crate) location: &'a str,
+}
+
+/// A parsed actor address.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct ActorAddrParts<'a> {
+    /// The actor id.
+    pub(crate) id: ActorIdParts<'a>,
+    /// The raw location tail.
+    pub(crate) location: &'a str,
+}
+
+/// A parsed port address.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct PortAddrParts<'a> {
+    /// The port id.
+    pub(crate) id: PortIdParts<'a>,
+    /// The raw location tail.
+    pub(crate) location: &'a str,
+}
+
+/// A parsed polymorphic address.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum AddressParts<'a> {
+    /// A proc address.
+    Proc(ProcAddrParts<'a>),
+    /// An actor address.
+    Actor(ActorAddrParts<'a>),
+    /// A port address.
+    Port(PortAddrParts<'a>),
+}
+
+pub(crate) fn parse_proc_addr(input: &str) -> Result<ProcAddrParts<'_>, ParseError> {
+    let mut parser = Parser::new(input);
+    let id = parse_proc_id_parts(&mut parser)?;
+    let location = parse_location(&mut parser)?;
+    Ok(ProcAddrParts { id, location })
+}
+
+pub(crate) fn parse_actor_addr(input: &str) -> Result<ActorAddrParts<'_>, ParseError> {
+    let mut parser = Parser::new(input);
+    let id = parse_actor_id_parts(&mut parser)?;
+    let location = parse_location(&mut parser)?;
+    Ok(ActorAddrParts { id, location })
+}
+
+pub(crate) fn parse_port_addr(input: &str) -> Result<PortAddrParts<'_>, ParseError> {
+    let mut parser = Parser::new(input);
+    let id = parse_port_id_parts(&mut parser)?;
+    let location = parse_location(&mut parser)?;
+    Ok(PortAddrParts { id, location })
+}
+
+pub(crate) fn parse_address(input: &str) -> Result<AddressParts<'_>, ParseError> {
+    let mut parser = Parser::new(input);
+    let first = parse_id_component(&mut parser)?;
+    match parser.peek().kind {
+        TokenKind::At => Ok(AddressParts::Proc(ProcAddrParts {
+            id: ProcIdParts { component: first },
+            location: parse_location(&mut parser)?,
+        })),
+        TokenKind::Dot => {
+            parser.bump();
+            let proc_ = parse_id_component(&mut parser)?;
+            let actor = ActorIdParts {
+                actor: first,
+                proc_,
+            };
+            match parser.peek().kind {
+                TokenKind::At => Ok(AddressParts::Actor(ActorAddrParts {
+                    id: actor,
+                    location: parse_location(&mut parser)?,
+                })),
+                TokenKind::Colon => {
+                    parser.bump();
+                    let port = parser.expect_text("decimal port")?;
+                    if !port.text.bytes().all(|ch| ch.is_ascii_digit()) {
+                        return Err(ParseError::invalid_port(port));
+                    }
+                    Ok(AddressParts::Port(PortAddrParts {
+                        id: PortIdParts {
+                            actor,
+                            port: port.text,
+                        },
+                        location: parse_location(&mut parser)?,
+                    }))
+                }
+                _ => Err(ParseError::expected(parser.peek(), "\"@\" or \":\"")),
+            }
+        }
+        _ => Err(ParseError::expected(parser.peek(), "\"@\" or \".\"")),
+    }
+}
+
+fn parse_location<'a>(parser: &mut Parser<'a>) -> Result<&'a str, ParseError> {
+    let at = parser.expect_kind(TokenKind::At)?;
+    let location = parser.rest();
+    if location.is_empty() {
+        return Err(ParseError::missing_location(at));
+    }
+    let location = parser.take_rest();
+    parser.finish()?;
+    Ok(location)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::parse::id::IdComponent;
+    use crate::parse::lex::Span;
+
+    #[test]
+    fn test_parse_proc_addr() {
+        assert_eq!(
+            parse_proc_addr("local@inproc://0").unwrap(),
+            ProcAddrParts {
+                id: ProcIdParts {
+                    component: IdComponent::Singleton {
+                        label: "local",
+                        span: Span::new(0, 5),
+                    },
+                },
+                location: "inproc://0",
+            }
+        );
+    }
+
+    #[test]
+    fn test_parse_actor_addr() {
+        assert_eq!(
+            parse_actor_addr("controller.local@tcp://[::1]:2345").unwrap(),
+            ActorAddrParts {
+                id: ActorIdParts {
+                    actor: IdComponent::Singleton {
+                        label: "controller",
+                        span: Span::new(0, 10),
+                    },
+                    proc_: IdComponent::Singleton {
+                        label: "local",
+                        span: Span::new(11, 16),
+                    },
+                },
+                location: "tcp://[::1]:2345",
+            }
+        );
+    }
+
+    #[test]
+    fn test_parse_port_addr() {
+        assert_eq!(
+            parse_port_addr("controller.local:7@inproc://0").unwrap(),
+            PortAddrParts {
+                id: PortIdParts {
+                    actor: ActorIdParts {
+                        actor: IdComponent::Singleton {
+                            label: "controller",
+                            span: Span::new(0, 10),
+                        },
+                        proc_: IdComponent::Singleton {
+                            label: "local",
+                            span: Span::new(11, 16),
+                        },
+                    },
+                    port: "7",
+                },
+                location: "inproc://0",
+            }
+        );
+    }
+
+    #[test]
+    fn test_parse_address_specificity() {
+        assert!(matches!(
+            parse_address("local@inproc://0").unwrap(),
+            AddressParts::Proc(_)
+        ));
+        assert!(matches!(
+            parse_address("local.local@inproc://0").unwrap(),
+            AddressParts::Actor(_)
+        ));
+        assert!(matches!(
+            parse_address("local.local:7@inproc://0").unwrap(),
+            AddressParts::Port(_)
+        ));
+    }
+
+    #[test]
+    fn test_parse_address_reports_missing_separator() {
+        let err = parse_address("local").unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "expected \"@\" or \".\", found end of input"
+        );
+        assert_eq!(err.span, Span::new(5, 5));
+    }
+
+    #[test]
+    fn test_parse_address_reports_missing_location() {
+        let err = parse_address("local@").unwrap_err();
+        assert_eq!(err.to_string(), "expected location, found end of input");
+        assert_eq!(err.span, Span::new(5, 6));
+    }
+
+    #[test]
+    fn test_parse_address_does_not_downcast_malformed_port_addr() {
+        let err = parse_address("local.local:not-a-port@inproc://0").unwrap_err();
+        assert_eq!(err.to_string(), "invalid port \"not-a-port\"");
+        assert_eq!(err.span, Span::new(12, 22));
+    }
+
+    #[test]
+    fn test_parse_address_does_not_downcast_malformed_actor_addr() {
+        let err = parse_address("local.@inproc://0").unwrap_err();
+        assert_eq!(err.to_string(), "expected \"label\" or \"<\", found \"@\"");
+        assert_eq!(err.span, Span::new(6, 7));
+    }
+}

--- a/hyperactor/src/parse/mod.rs
+++ b/hyperactor/src/parse/mod.rs
@@ -8,7 +8,7 @@
 
 //! Shared parser infrastructure for Hyperactor ids and refs.
 
+pub(crate) mod addr;
 pub(crate) mod error;
 pub(crate) mod id;
 pub(crate) mod lex;
-pub(crate) mod ref_;

--- a/hyperactor/src/proc.rs
+++ b/hyperactor/src/proc.rs
@@ -133,8 +133,12 @@ use wirevalue::TypeInfo;
 
 use crate as hyperactor;
 use crate::Actor;
+use crate::ActorAddr;
+use crate::Address;
 use crate::Handler;
 use crate::Message;
+use crate::PortAddr;
+use crate::ProcAddr;
 use crate::RemoteMessage;
 use crate::actor::ActorError;
 use crate::actor::ActorErrorKind;
@@ -329,7 +333,6 @@ use crate::ordering::SeqInfo;
 use crate::ordering::Sequencer;
 use crate::ordering::ordered_channel;
 use crate::panic_handler;
-use crate::ref_;
 use crate::reference;
 use crate::supervision::ActorSupervisionEvent;
 
@@ -358,7 +361,7 @@ impl fmt::Debug for Proc {
 struct ProcState {
     /// The proc's id. This should be globally unique, but is not (yet)
     /// for local-only procs.
-    proc_id: ref_::ProcRef,
+    proc_id: ProcAddr,
 
     /// A muxer instance that has entries for every actor managed by
     /// the proc.
@@ -373,7 +376,7 @@ struct ProcState {
     reserved_roots: DashSet<crate::id::Uid>,
 
     /// All actor instances in this proc.
-    instances: DashMap<ref_::ActorRef, WeakInstanceCell>,
+    instances: DashMap<ActorAddr, WeakInstanceCell>,
 
     /// Proc-level queue-pressure accounting (PD-6 through PD-9).
     /// Runtime-driven — updated from `account_enqueue` /
@@ -385,7 +388,7 @@ struct ProcState {
     /// Populated by the introspect task just before it exits on
     /// terminal status. Bounded by
     /// [`config::TERMINATED_SNAPSHOT_RETENTION`].
-    terminated_snapshots: DashMap<ref_::ActorRef, crate::introspect::IntrospectResult>,
+    terminated_snapshots: DashMap<ActorAddr, crate::introspect::IntrospectResult>,
 
     /// Used by root actors to send events to the actor coordinating
     /// supervision of root actors in this proc.
@@ -393,7 +396,7 @@ struct ProcState {
 
     /// The actor ID of the supervision coordinator, if it lives on this proc.
     /// Used to ensure the coordinator is shut down last during proc teardown.
-    supervision_coordinator_actor_id: OnceLock<ref_::ActorRef>,
+    supervision_coordinator_actor_id: OnceLock<ActorAddr>,
 
     /// Handle to the mailbox server task, if this proc was created with
     /// `Proc::direct()` or had `serve()` called on it. Used to
@@ -434,7 +437,7 @@ pub struct ActorInstance<A: Actor> {
 
 impl Proc {
     /// Create a pre-configured proc with the given proc id and forwarder.
-    pub fn configured(proc_id: impl Into<ref_::ProcRef>, forwarder: BoxedMailboxSender) -> Self {
+    pub fn configured(proc_id: impl Into<ProcAddr>, forwarder: BoxedMailboxSender) -> Self {
         let proc_id = proc_id.into();
         tracing::info!(
             subject = %proc_id.subject(),
@@ -461,7 +464,7 @@ impl Proc {
     /// Create a new direct-addressed proc.
     pub fn direct(addr: ChannelAddr, name: String) -> Result<Self, ChannelError> {
         let (addr, rx) = channel::serve(addr)?;
-        let proc_id = ref_::ProcRef::from_resource_name(addr, name);
+        let proc_id = ProcAddr::from_resource_name(addr, name);
         let proc = Self::configured(proc_id, DialMailboxRouter::new().into_boxed());
         let handle = proc.clone().serve(rx);
         *proc.inner.mailbox_server_handle.lock().unwrap() = Some(handle);
@@ -542,7 +545,7 @@ impl Proc {
         &self,
         port: PortHandle<ActorSupervisionEvent>,
     ) -> Result<(), anyhow::Error> {
-        let actor_ref: ref_::ActorRef = port.location().actor_id();
+        let actor_ref: ActorAddr = port.location().actor_id();
         self.state()
             .supervision_coordinator_port
             .set(port)
@@ -553,7 +556,7 @@ impl Proc {
 
     /// The actor ID of the supervision coordinator, if one is set and
     /// lives on this proc.
-    pub fn supervision_coordinator_actor_id(&self) -> Option<&ref_::ActorRef> {
+    pub fn supervision_coordinator_actor_id(&self) -> Option<&ActorAddr> {
         self.state().supervision_coordinator_actor_id.get()
     }
 
@@ -606,12 +609,12 @@ impl Proc {
     pub fn local() -> Self {
         let rank = NEXT_LOCAL_RANK.fetch_add(1, Ordering::Relaxed);
         let addr = ChannelAddr::any(ChannelTransport::Local);
-        let proc_id = ref_::ProcRef::unique(addr, format!("local_{}", rank));
+        let proc_id = ProcAddr::unique(addr, format!("local_{}", rank));
         Proc::configured(proc_id, BoxedMailboxSender::new(PanickingMailboxSender))
     }
 
     /// The proc's ID.
-    pub fn proc_id(&self) -> &ref_::ProcRef {
+    pub fn proc_id(&self) -> &ProcAddr {
         &self.state().proc_id
     }
 
@@ -637,25 +640,25 @@ impl Proc {
         static RUNTIME_PROC: OnceLock<Proc> = OnceLock::new();
         RUNTIME_PROC.get_or_init(|| {
             let addr = ChannelAddr::any(ChannelTransport::Local);
-            let proc_id = ref_::ProcRef::unique(addr, "hyperactor_runtime");
+            let proc_id = ProcAddr::unique(addr, "hyperactor_runtime");
             Proc::configured(proc_id, BoxedMailboxSender::new(PanickingMailboxSender))
         })
     }
 
     /// Attach a mailbox to the proc with the provided root name.
     pub fn attach(&self, name: &str) -> Result<Mailbox, anyhow::Error> {
-        let actor_id: ref_::ActorRef = self.allocate_root_id(name)?;
+        let actor_id: ActorAddr = self.allocate_root_id(name)?;
         Ok(self.bind_mailbox(actor_id))
     }
 
     /// Attach a mailbox to the proc as a child actor.
-    pub fn attach_child(&self, parent_id: &ref_::ActorRef) -> Result<Mailbox, anyhow::Error> {
-        let actor_id: ref_::ActorRef = self.allocate_child_id(parent_id)?;
+    pub fn attach_child(&self, parent_id: &ActorAddr) -> Result<Mailbox, anyhow::Error> {
+        let actor_id: ActorAddr = self.allocate_child_id(parent_id)?;
         Ok(self.bind_mailbox(actor_id))
     }
 
     /// Bind a mailbox to the proc.
-    fn bind_mailbox(&self, actor_id: ref_::ActorRef) -> Mailbox {
+    fn bind_mailbox(&self, actor_id: ActorAddr) -> Mailbox {
         let mbox = Mailbox::new(actor_id, BoxedMailboxSender::new(self.downgrade()));
 
         // TODO: T210748165 tie the muxer entry to the lifecycle of the mailbox held
@@ -664,7 +667,7 @@ impl Proc {
         mbox
     }
 
-    /// Attach a mailbox to the proc with the provided root name, and bind an [`ActorRef`].
+    /// Attach a mailbox to the proc with the provided root name, and bind an [`ActorAddr`].
     /// This is intended only for testing, and will be replaced by simpled utilities.
     pub fn attach_actor<R, M>(
         &self,
@@ -683,7 +686,7 @@ impl Proc {
     /// Spawn a named (root) actor on this proc. The name of the actor must be
     /// unique.
     pub fn spawn<A: Actor>(&self, name: &str, actor: A) -> Result<ActorHandle<A>, anyhow::Error> {
-        let actor_id: ref_::ActorRef = self.allocate_root_id(name)?;
+        let actor_id: ActorAddr = self.allocate_root_id(name)?;
         self.spawn_inner(actor_id, actor, None)
     }
 
@@ -691,7 +694,7 @@ impl Proc {
     #[hyperactor::instrument(fields(subject = actor_id.subject().to_string()))]
     fn spawn_inner<A: Actor>(
         &self,
-        actor_id: ref_::ActorRef,
+        actor_id: ActorAddr,
         actor: A,
         parent: Option<InstanceCell>,
     ) -> Result<ActorHandle<A>, anyhow::Error> {
@@ -704,7 +707,7 @@ impl Proc {
     /// runtime — unlike [`actor_instance`], it never calls
     /// `tokio::spawn`.
     pub fn instance(&self, name: &str) -> Result<(Instance<()>, ActorHandle<()>), anyhow::Error> {
-        let actor_id: ref_::ActorRef = self.allocate_root_id(name)?;
+        let actor_id: ActorAddr = self.allocate_root_id(name)?;
         let (instance, _receivers) = Instance::new(self.clone(), actor_id, false, None);
         let handle = ActorHandle::new(instance.inner.cell.clone(), instance.inner.ports.clone());
         instance.change_status(ActorStatus::Client);
@@ -727,7 +730,7 @@ impl Proc {
         &self,
         name: &str,
     ) -> Result<(Instance<()>, ActorHandle<()>), anyhow::Error> {
-        let actor_id: ref_::ActorRef = self.allocate_root_id(name)?;
+        let actor_id: ActorAddr = self.allocate_root_id(name)?;
         let (instance, receivers) = Instance::new(self.clone(), actor_id, false, None);
         let handle = ActorHandle::new(instance.inner.cell.clone(), instance.inner.ports.clone());
         instance.change_status(ActorStatus::Client);
@@ -745,7 +748,7 @@ impl Proc {
     /// launch child actors, etc. The actor itself does not handle any
     /// messages unless driven by the caller.
     pub fn actor_instance<A: Actor>(&self, name: &str) -> Result<ActorInstance<A>, anyhow::Error> {
-        let actor_id: ref_::ActorRef = self.allocate_root_id(name)?;
+        let actor_id: ActorAddr = self.allocate_root_id(name)?;
         let span = tracing::debug_span!(
             "actor_instance",
             subject = %actor_id.subject(),
@@ -808,7 +811,7 @@ impl Proc {
     }
 
     /// Look up an instance by ActorId.
-    pub fn get_instance(&self, actor_id: &ref_::ActorRef) -> Option<InstanceCell> {
+    pub fn get_instance(&self, actor_id: &ActorAddr) -> Option<InstanceCell> {
         self.state()
             .instances
             .get(actor_id)
@@ -823,7 +826,7 @@ impl Proc {
     /// with concurrent writes. Prefer `all_instance_keys()` with a
     /// post-filter if this becomes a hot path. Currently unused in
     /// production code.
-    pub fn root_actor_ids(&self) -> Vec<ref_::ActorRef> {
+    pub fn root_actor_ids(&self) -> Vec<ActorAddr> {
         self.state()
             .instances
             .iter()
@@ -840,7 +843,7 @@ impl Proc {
     /// actors whose `InstanceCell` has been dropped and actors that
     /// have stopped or failed but whose Arc is still held (e.g. by
     /// the introspect task during teardown).
-    pub fn all_actor_ids(&self) -> Vec<ref_::ActorRef> {
+    pub fn all_actor_ids(&self) -> Vec<ActorAddr> {
         self.state()
             .instances
             .iter()
@@ -865,7 +868,7 @@ impl Proc {
     /// whose `WeakInstanceCell` no longer upgrades. Callers should
     /// tolerate stale entries (e.g. by handling "not found" on
     /// subsequent per-actor lookups).
-    pub fn all_instance_keys(&self) -> Vec<ref_::ActorRef> {
+    pub fn all_instance_keys(&self) -> Vec<ActorAddr> {
         self.state()
             .instances
             .iter()
@@ -876,7 +879,7 @@ impl Proc {
     /// Look up a terminated actor's snapshot by ID.
     pub fn terminated_snapshot(
         &self,
-        actor_id: &ref_::ActorRef,
+        actor_id: &ActorAddr,
     ) -> Option<crate::introspect::IntrospectResult> {
         self.state()
             .terminated_snapshots
@@ -885,7 +888,7 @@ impl Proc {
     }
 
     /// Return all terminated actor IDs currently retained.
-    pub fn all_terminated_actor_ids(&self) -> Vec<ref_::ActorRef> {
+    pub fn all_terminated_actor_ids(&self) -> Vec<ActorAddr> {
         self.state()
             .terminated_snapshots
             .iter()
@@ -944,9 +947,9 @@ impl Proc {
     /// `None`.
     pub fn abort_root_actor(
         &self,
-        root: &ref_::ActorRef,
+        root: &ActorAddr,
         this_handle: Option<&JoinHandle<()>>,
-    ) -> Option<impl Future<Output = ref_::ActorRef>> {
+    ) -> Option<impl Future<Output = ActorAddr>> {
         self.state()
             .instances
             .get(root)
@@ -985,7 +988,7 @@ impl Proc {
     /// returning a status observer if successful.
     pub fn stop_actor(
         &self,
-        actor_id: &ref_::ActorRef,
+        actor_id: &ActorAddr,
         reason: String,
     ) -> Option<watch::Receiver<ActorStatus>> {
         if let Some(entry) = self.state().instances.get(actor_id) {
@@ -1023,7 +1026,7 @@ impl Proc {
         timeout: Duration,
         cx: Option<&Context<'_, A>>,
         reason: &str,
-    ) -> Result<(Vec<ref_::ActorRef>, Vec<ref_::ActorRef>), anyhow::Error> {
+    ) -> Result<(Vec<ActorAddr>, Vec<ActorAddr>), anyhow::Error> {
         self.destroy_and_wait_except_current::<A>(timeout, cx, false, reason)
             .await
     }
@@ -1044,7 +1047,7 @@ impl Proc {
         cx: Option<&Context<'_, A>>,
         except_current: bool,
         reason: &str,
-    ) -> Result<(Vec<ref_::ActorRef>, Vec<ref_::ActorRef>), anyhow::Error> {
+    ) -> Result<(Vec<ActorAddr>, Vec<ActorAddr>), anyhow::Error> {
         tracing::debug!("proc stopping");
 
         let (this_handle, this_actor_id) = cx.map_or((None, None), |cx| {
@@ -1213,7 +1216,7 @@ impl Proc {
     /// Create a root allocation in the proc.
     ///
     /// Uses `reserved_roots` to prevent races between concurrent callers.
-    fn allocate_root_id(&self, name: &str) -> Result<ref_::ActorRef, anyhow::Error> {
+    fn allocate_root_id(&self, name: &str) -> Result<ActorAddr, anyhow::Error> {
         let actor_ref = self.state().proc_id.actor_ref(name);
         let uid = actor_ref.uid().clone();
         if !self.state().reserved_roots.insert(uid) {
@@ -1226,8 +1229,8 @@ impl Proc {
     #[hyperactor::instrument]
     pub(crate) fn allocate_child_id(
         &self,
-        parent_id: &ref_::ActorRef,
-    ) -> Result<ref_::ActorRef, anyhow::Error> {
+        parent_id: &ActorAddr,
+    ) -> Result<ActorAddr, anyhow::Error> {
         assert_eq!(parent_id.proc_ref(), self.state().proc_id);
         Ok(parent_id.unique_child())
     }
@@ -1235,17 +1238,17 @@ impl Proc {
     /// Allocate an actor ID with a custom name on this proc.
     pub(crate) fn allocate_named_child_id(
         &self,
-        parent_id: &ref_::ActorRef,
+        parent_id: &ActorAddr,
         name: &str,
-    ) -> Result<ref_::ActorRef, anyhow::Error> {
+    ) -> Result<ActorAddr, anyhow::Error> {
         assert_eq!(parent_id.proc_ref(), self.state().proc_id);
         let proc_id = self.state().proc_id.id().clone();
-        let (_uid, label) = crate::ref_::parse_resource_name(name);
+        let (_uid, label) = crate::addr::parse_resource_name(name);
         let actor_id = match label {
             Some(label) => crate::id::ActorId::instance_labeled(label, proc_id),
             None => crate::id::ActorId::instance(proc_id),
         };
-        Ok(ref_::ActorRef::new(
+        Ok(ActorAddr::new(
             actor_id,
             self.state().proc_id.location().clone(),
         ))
@@ -1456,7 +1459,7 @@ struct InstanceState<A: Actor> {
 }
 
 impl<A: Actor> InstanceState<A> {
-    fn self_id(&self) -> &ref_::ActorRef {
+    fn self_id(&self) -> &ActorAddr {
         self.mailbox.actor_id()
     }
 }
@@ -1502,7 +1505,7 @@ impl<A: Actor> Instance<A> {
     /// Create a new actor instance in Created state.
     fn new(
         proc: Proc,
-        actor_id: ref_::ActorRef,
+        actor_id: ActorAddr,
         detached: bool,
         parent: Option<InstanceCell>,
     ) -> (Self, InstanceReceivers<A>) {
@@ -1649,7 +1652,7 @@ impl<A: Actor> Instance<A> {
     }
 
     /// This instance's actor ID.
-    pub fn self_id(&self) -> &ref_::ActorRef {
+    pub fn self_id(&self) -> &ActorAddr {
         self.inner.self_id()
     }
 
@@ -1754,7 +1757,7 @@ impl<A: Actor> Instance<A> {
     /// procs that have no independent `ProcAgent`.
     pub fn set_query_child_handler(
         &self,
-        handler: impl (Fn(&crate::ref_::Reference) -> IntrospectResult) + Send + Sync + 'static,
+        handler: impl (Fn(&Address) -> IntrospectResult) + Send + Sync + 'static,
     ) {
         self.inner.cell.set_query_child_handler(handler);
     }
@@ -1802,13 +1805,8 @@ impl<A: Actor> Instance<A> {
     }
 
     /// Send a message to the actor running on the proc.
-    pub fn post(
-        &self,
-        port_id: impl Into<ref_::PortRef>,
-        headers: Flattrs,
-        message: wirevalue::Any,
-    ) {
-        let port_id: ref_::PortRef = port_id.into();
+    pub fn post(&self, port_id: impl Into<PortAddr>, headers: Flattrs, message: wirevalue::Any) {
+        let port_id: PortAddr = port_id.into();
         <Self as context::MailboxExt>::post(
             self,
             port_id,
@@ -1827,7 +1825,7 @@ impl<A: Actor> Instance<A> {
     #[doc(hidden)]
     pub fn post_with_external_seq_info(
         &self,
-        port_id: impl Into<ref_::PortRef>,
+        port_id: impl Into<PortAddr>,
         headers: Flattrs,
         message: wirevalue::Any,
     ) {
@@ -2566,7 +2564,7 @@ impl fmt::Debug for InstanceCell {
 
 struct InstanceCellState {
     /// The actor's id.
-    actor_id: ref_::ActorRef,
+    actor_id: ActorAddr,
 
     /// Actor info contains the actor's type information.
     actor_type: ActorType,
@@ -2637,8 +2635,7 @@ struct InstanceCellState {
     /// `None` means `QueryChild` returns a "not_found" error.
     ///
     /// See S7 in `introspect` module doc.
-    query_child_handler:
-        RwLock<Option<Box<dyn (Fn(&crate::ref_::Reference) -> IntrospectResult) + Send + Sync>>>,
+    query_child_handler: RwLock<Option<Box<dyn (Fn(&Address) -> IntrospectResult) + Send + Sync>>>,
 
     /// The supervision event for this actor's failure, if any.
     /// See FI-1, FI-2 in `introspect` module doc.
@@ -2683,11 +2680,11 @@ impl InstanceCellState {
 ///    newest-first (descending `occurred_at`), preserving the
 ///    earliest failures which are closest to the root cause.
 fn select_eviction_candidates(
-    entries: &[(ref_::ActorRef, Option<String>)],
+    entries: &[(ActorAddr, Option<String>)],
     excess: usize,
-) -> Vec<ref_::ActorRef> {
-    let mut clean: Vec<&ref_::ActorRef> = Vec::new();
-    let mut failed: Vec<(&ref_::ActorRef, &str)> = Vec::new();
+) -> Vec<ActorAddr> {
+    let mut clean: Vec<&ActorAddr> = Vec::new();
+    let mut failed: Vec<(&ActorAddr, &str)> = Vec::new();
     for (id, occurred_at) in entries {
         match occurred_at {
             Some(ts) => failed.push((id, ts.as_str())),
@@ -2695,7 +2692,7 @@ fn select_eviction_candidates(
         }
     }
 
-    let mut to_remove: Vec<ref_::ActorRef> = Vec::new();
+    let mut to_remove: Vec<ActorAddr> = Vec::new();
     let mut remaining = excess;
 
     // Evict cleanly-stopped first.
@@ -2722,7 +2719,7 @@ impl InstanceCell {
     /// Creates a new instance cell with the provided internal state. If a parent
     /// is provided, it is linked to this cell.
     fn new(
-        actor_id: ref_::ActorRef,
+        actor_id: ActorAddr,
         actor_type: ActorType,
         proc: Proc,
         actor_loop: Option<(PortHandle<Signal>, PortHandle<ActorSupervisionEvent>)>,
@@ -2768,7 +2765,7 @@ impl InstanceCell {
     }
 
     /// The actor's ID.
-    pub fn actor_id(&self) -> &ref_::ActorRef {
+    pub fn actor_id(&self) -> &ActorAddr {
         &self.inner.actor_id
     }
 
@@ -2919,7 +2916,7 @@ impl InstanceCell {
     }
 
     /// Returns the ActorIds of this instance's direct children.
-    pub fn child_actor_ids(&self) -> Vec<ref_::ActorRef> {
+    pub fn child_actor_ids(&self) -> Vec<ActorAddr> {
         self.inner
             .children
             .iter()
@@ -3006,13 +3003,13 @@ impl InstanceCell {
     /// Capture cloned `Proc` references, not `&mut self`.
     pub fn set_query_child_handler(
         &self,
-        handler: impl (Fn(&crate::ref_::Reference) -> IntrospectResult) + Send + Sync + 'static,
+        handler: impl (Fn(&Address) -> IntrospectResult) + Send + Sync + 'static,
     ) {
         *self.inner.query_child_handler.write().unwrap() = Some(Box::new(handler));
     }
 
     /// Invoke the registered QueryChild handler, if any.
-    pub fn query_child(&self, child_ref: &crate::ref_::Reference) -> Option<IntrospectResult> {
+    pub fn query_child(&self, child_ref: &Address) -> Option<IntrospectResult> {
         let guard = self.inner.query_child_handler.read().unwrap();
         guard.as_ref().map(|handler| handler(child_ref))
     }
@@ -3440,6 +3437,7 @@ mod tests {
         }
     }
 
+    #[allow(clippy::await_holding_invalid_type)]
     #[tracing_test::traced_test]
     #[async_timed_test(timeout_secs = 30)]
     async fn test_spawn_actor() {
@@ -3670,6 +3668,7 @@ mod tests {
         );
     }
 
+    #[allow(clippy::await_holding_invalid_type)]
     #[tracing_test::traced_test]
     #[async_timed_test(timeout_secs = 30)]
     async fn test_spawn_child() {
@@ -4142,6 +4141,7 @@ mod tests {
 
         #[async_trait]
         impl Handler<Arc<(Barrier, Barrier)>> for LoggingActor {
+            #[allow(clippy::await_holding_invalid_type)]
             async fn handle(
                 &mut self,
                 _cx: &crate::Context<Self>,
@@ -4270,7 +4270,7 @@ mod tests {
     /// have stored the snapshot by the time `handle.await` returns.
     async fn wait_for_terminated_snapshot(
         proc: &Proc,
-        actor_id: &ref_::ActorRef,
+        actor_id: &ActorAddr,
     ) -> crate::introspect::IntrospectResult {
         // Yield to let the introspect task run, then poll. Use a
         // combination of yields (for fast paths) and sleeps (to

--- a/hyperactor/src/reference.rs
+++ b/hyperactor/src/reference.rs
@@ -50,6 +50,7 @@ use crate::accum::ReducerMode;
 use crate::accum::ReducerSpec;
 use crate::accum::StreamingReducerOpts;
 use crate::actor::Referable;
+use crate::addr;
 use crate::channel::ChannelAddr;
 use crate::context;
 use crate::context::MailboxExt;
@@ -61,7 +62,6 @@ use crate::mailbox::PortSink;
 use crate::message::Bind;
 use crate::message::Bindings;
 use crate::message::Unbind;
-use crate::ref_;
 
 pub mod lex;
 pub mod name;
@@ -232,13 +232,13 @@ impl FromStr for Reference {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         // References use the ref_:: format: "id@location".
         // Try most specific first: Port (has `:` in id), Actor (has `.`), Proc.
-        if let Ok(port_ref) = s.parse::<ref_::PortRef>() {
+        if let Ok(port_ref) = s.parse::<addr::PortAddr>() {
             return Ok(Self::Port(PortId(port_ref)));
         }
-        if let Ok(actor_ref) = s.parse::<ref_::ActorRef>() {
+        if let Ok(actor_ref) = s.parse::<addr::ActorAddr>() {
             return Ok(Self::Actor(ActorId(actor_ref)));
         }
-        if let Ok(proc_ref) = s.parse::<ref_::ProcRef>() {
+        if let Ok(proc_ref) = s.parse::<addr::ProcAddr>() {
             return Ok(Self::Proc(ProcId(proc_ref)));
         }
         Err(ReferenceParsingError::Unexpected(format!(
@@ -363,15 +363,15 @@ fn parse_resource_name(s: &str) -> (Uid, Option<Label>) {
     typeuri::Named
 )]
 #[serde(transparent)]
-pub struct ProcId(ref_::ProcRef);
+pub struct ProcId(addr::ProcAddr);
 
 impl ProcId {
     /// Create a ProcId with a unique (random) uid and the given label.
     pub fn unique(addr: ChannelAddr, base_name: impl AsRef<str>) -> Self {
         let label = Label::strip(base_name.as_ref());
-        Self(ref_::ProcRef::new(
+        Self(addr::ProcAddr::new(
             crate::id::ProcId::instance(label),
-            ref_::Location::from(addr),
+            addr::Location::from(addr),
         ))
     }
 
@@ -386,14 +386,14 @@ impl ProcId {
     pub fn from_resource_name(addr: ChannelAddr, name: impl AsRef<str>) -> Self {
         let s = name.as_ref();
         let (uid, label) = parse_resource_name(s);
-        Self(ref_::ProcRef::new(
+        Self(addr::ProcAddr::new(
             crate::id::ProcId::new(uid, label),
-            ref_::Location::from(addr),
+            addr::Location::from(addr),
         ))
     }
 
-    /// Wrap an existing [`ref_::ProcRef`].
-    pub fn from_proc_ref(proc_ref: ref_::ProcRef) -> Self {
+    /// Wrap an existing [`addr::ProcAddr`].
+    pub fn from_proc_ref(proc_ref: addr::ProcAddr) -> Self {
         Self(proc_ref)
     }
 
@@ -413,7 +413,7 @@ impl ProcId {
     }
 
     /// The underlying process reference.
-    pub fn proc_ref(&self) -> &ref_::ProcRef {
+    pub fn proc_ref(&self) -> &addr::ProcAddr {
         &self.0
     }
 
@@ -464,21 +464,21 @@ impl fmt::Display for ProcId {
     }
 }
 
-impl From<ProcId> for ref_::ProcRef {
+impl From<ProcId> for addr::ProcAddr {
     fn from(p: ProcId) -> Self {
         p.0
     }
 }
 
-impl From<ref_::ProcRef> for ProcId {
-    fn from(p: ref_::ProcRef) -> Self {
+impl From<addr::ProcAddr> for ProcId {
+    fn from(p: addr::ProcAddr) -> Self {
         Self(p)
     }
 }
 
 impl std::ops::Deref for ProcId {
-    type Target = ref_::ProcRef;
-    fn deref(&self) -> &ref_::ProcRef {
+    type Target = addr::ProcAddr;
+    fn deref(&self) -> &addr::ProcAddr {
         &self.0
     }
 }
@@ -495,7 +495,7 @@ impl FromStr for ProcId {
             }
         }
 
-        let proc_ref: ref_::ProcRef = s
+        let proc_ref: addr::ProcAddr = s
             .parse()
             .map_err(|e| ReferenceParsingError::Unexpected(format!("{}", e)))?;
         Ok(Self(proc_ref))
@@ -517,7 +517,7 @@ impl FromStr for ProcId {
     typeuri::Named
 )]
 #[serde(transparent)]
-pub struct ActorId(ref_::ActorRef);
+pub struct ActorId(addr::ActorAddr);
 
 hyperactor_config::impl_attrvalue!(ActorId);
 
@@ -530,35 +530,35 @@ impl ActorId {
         let s = name.as_ref();
         let (uid, label) = parse_resource_name(s);
         let actor_id = crate::id::ActorId::new(uid, proc_id.0.id().clone(), label);
-        Self(ref_::ActorRef::new(actor_id, proc_id.0.location().clone()))
+        Self(addr::ActorAddr::new(actor_id, proc_id.0.location().clone()))
     }
 
     /// Create a new port ID with the provided port for this actor.
     pub fn port_id(&self, port: u64) -> PortId {
         let port_id = crate::id::PortId::new(self.0.id().clone(), crate::port::Port::from(port));
-        PortId(ref_::PortRef::new(port_id, self.0.location().clone()))
+        PortId(addr::PortAddr::new(port_id, self.0.location().clone()))
     }
 
     /// Create a child actor ID with a random uid.
     pub fn unique_child_id(&self) -> Self {
         let child = crate::id::ActorId::instance(self.0.id().proc_id().clone());
-        Self(ref_::ActorRef::new(child, self.0.location().clone()))
+        Self(addr::ActorAddr::new(child, self.0.location().clone()))
     }
 
     /// Return the root actor ID for the provided proc and label.
     pub fn root(proc_id: ProcId, label: Label) -> Self {
         let actor_id = crate::id::ActorId::singleton(label, proc_id.0.id().clone());
-        Self(ref_::ActorRef::new(actor_id, proc_id.0.location().clone()))
+        Self(addr::ActorAddr::new(actor_id, proc_id.0.location().clone()))
     }
 
-    /// Wrap an existing [`ref_::ActorRef`].
-    pub fn from_actor_ref(actor_ref: ref_::ActorRef) -> Self {
+    /// Wrap an existing [`addr::ActorAddr`].
+    pub fn from_actor_ref(actor_ref: addr::ActorAddr) -> Self {
         Self(actor_ref)
     }
 
     /// The proc ID of this actor ID.
     pub fn proc_id(&self) -> ProcId {
-        ProcId(ref_::ProcRef::new(
+        ProcId(addr::ProcAddr::new(
             self.0.id().proc_id().clone(),
             self.0.location().clone(),
         ))
@@ -570,7 +570,7 @@ impl ActorId {
     }
 
     /// The underlying actor reference.
-    pub fn actor_ref(&self) -> &ref_::ActorRef {
+    pub fn actor_ref(&self) -> &addr::ActorAddr {
         &self.0
     }
 
@@ -624,28 +624,28 @@ impl FromStr for ActorId {
     type Err = ReferenceParsingError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let actor_ref: ref_::ActorRef = s
+        let actor_ref: addr::ActorAddr = s
             .parse()
             .map_err(|e| ReferenceParsingError::Unexpected(format!("{}", e)))?;
         Ok(Self(actor_ref))
     }
 }
 
-impl From<ActorId> for ref_::ActorRef {
+impl From<ActorId> for addr::ActorAddr {
     fn from(a: ActorId) -> Self {
         a.0
     }
 }
 
-impl From<ref_::ActorRef> for ActorId {
-    fn from(a: ref_::ActorRef) -> Self {
+impl From<addr::ActorAddr> for ActorId {
+    fn from(a: addr::ActorAddr) -> Self {
         Self(a)
     }
 }
 
 impl std::ops::Deref for ActorId {
-    type Target = ref_::ActorRef;
-    fn deref(&self) -> &ref_::ActorRef {
+    type Target = addr::ActorAddr;
+    fn deref(&self) -> &addr::ActorAddr {
         &self.0
     }
 }
@@ -817,19 +817,19 @@ impl<A: Referable> Hash for ActorRef<A> {
     typeuri::Named
 )]
 #[serde(transparent)]
-pub struct PortId(ref_::PortRef);
+pub struct PortId(addr::PortAddr);
 
 impl PortId {
     /// Create a new port ID.
     pub fn new(actor_id: ActorId, port: u64) -> Self {
         let port_id =
             crate::id::PortId::new(actor_id.0.id().clone(), crate::port::Port::from(port));
-        Self(ref_::PortRef::new(port_id, actor_id.0.location().clone()))
+        Self(addr::PortAddr::new(port_id, actor_id.0.location().clone()))
     }
 
     /// The ID of the port's owning actor.
     pub fn actor_id(&self) -> ActorId {
-        ActorId(ref_::ActorRef::new(
+        ActorId(addr::ActorAddr::new(
             self.0.id().actor_id().clone(),
             self.0.location().clone(),
         ))
@@ -906,7 +906,7 @@ impl FromStr for PortId {
     type Err = ReferenceParsingError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let port_ref: ref_::PortRef = s
+        let port_ref: addr::PortAddr = s
             .parse()
             .map_err(|e| ReferenceParsingError::Unexpected(format!("{}", e)))?;
         Ok(Self(port_ref))
@@ -919,42 +919,42 @@ impl fmt::Display for PortId {
     }
 }
 
-impl From<PortId> for ref_::PortRef {
+impl From<PortId> for addr::PortAddr {
     fn from(p: PortId) -> Self {
         p.0
     }
 }
 
-impl From<ref_::PortRef> for PortId {
-    fn from(p: ref_::PortRef) -> Self {
+impl From<addr::PortAddr> for PortId {
+    fn from(p: addr::PortAddr) -> Self {
         Self(p)
     }
 }
 
 impl std::ops::Deref for PortId {
-    type Target = ref_::PortRef;
-    fn deref(&self) -> &ref_::PortRef {
+    type Target = addr::PortAddr;
+    fn deref(&self) -> &addr::PortAddr {
         &self.0
     }
 }
 
-// Also bridge Reference <-> ref_::Reference.
-impl From<Reference> for ref_::Reference {
+// Also bridge Reference <-> addr::Address.
+impl From<Reference> for addr::Address {
     fn from(r: Reference) -> Self {
         match r {
-            Reference::Proc(p) => ref_::Reference::Proc(p.0),
-            Reference::Actor(a) => ref_::Reference::Actor(a.0),
-            Reference::Port(p) => ref_::Reference::Port(p.0),
+            Reference::Proc(p) => addr::Address::Proc(p.0),
+            Reference::Actor(a) => addr::Address::Actor(a.0),
+            Reference::Port(p) => addr::Address::Port(p.0),
         }
     }
 }
 
-impl From<ref_::Reference> for Reference {
-    fn from(r: ref_::Reference) -> Self {
+impl From<addr::Address> for Reference {
+    fn from(r: addr::Address) -> Self {
         match r {
-            ref_::Reference::Proc(p) => Reference::Proc(ProcId(p)),
-            ref_::Reference::Actor(a) => Reference::Actor(ActorId(a)),
-            ref_::Reference::Port(p) => Reference::Port(PortId(p)),
+            addr::Address::Proc(p) => Reference::Proc(ProcId(p)),
+            addr::Address::Actor(a) => Reference::Actor(ActorId(a)),
+            addr::Address::Port(p) => Reference::Port(PortId(p)),
         }
     }
 }
@@ -1373,6 +1373,7 @@ mod tests {
     use super::*;
     // for macros
     use crate::Proc;
+    use crate::addr;
     use crate::context::Mailbox as _;
     use crate::id::Label;
     use crate::id::ProcId as RawProcId;
@@ -1380,7 +1381,6 @@ mod tests {
     use crate::mailbox::PortLocation;
     use crate::ordering::SEQ_INFO;
     use crate::ordering::SeqInfo;
-    use crate::ref_;
 
     #[test]
     fn test_reference_parse() {
@@ -1495,9 +1495,9 @@ mod tests {
     #[test]
     fn test_proc_id_display_roundtrip_labeled_instance() {
         let addr = "tcp:[::1]:1234".parse::<ChannelAddr>().unwrap();
-        let proc_id = ProcId::from_proc_ref(ref_::ProcRef::new(
+        let proc_id = ProcId::from_proc_ref(addr::ProcAddr::new(
             RawProcId::new(Uid::Instance(0x123), Some(Label::new("worker").unwrap())),
-            ref_::Location::from(addr),
+            addr::Location::from(addr),
         ));
         let s = proc_id.to_string();
         assert_eq!(s, "worker<62>@tcp://[::1]:1234");
@@ -1507,9 +1507,9 @@ mod tests {
     #[test]
     fn test_proc_id_display_roundtrip_unlabeled_instance() {
         let addr = "tcp:[::1]:1234".parse::<ChannelAddr>().unwrap();
-        let proc_id = ProcId::from_proc_ref(ref_::ProcRef::new(
+        let proc_id = ProcId::from_proc_ref(addr::ProcAddr::new(
             RawProcId::new(Uid::Instance(0x123), None),
-            ref_::Location::from(addr),
+            addr::Location::from(addr),
         ));
         let s = proc_id.to_string();
         assert_eq!(s, "<62>@tcp://[::1]:1234");

--- a/hyperactor/src/remote.rs
+++ b/hyperactor/src/remote.rs
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-//! Remote references: typed wrappers around [`ActorRef`] or [`PortRef`] for type-safe message sending.
+//! Remote references: typed wrappers around [`ActorAddr`] or [`PortAddr`] for type-safe message sending.
 
 use std::fmt;
 use std::marker::PhantomData;
@@ -16,14 +16,14 @@ use serde::Deserialize;
 use serde::Serialize;
 use typeuri::Named;
 
+use crate::ActorAddr;
+use crate::AddrParseError;
+use crate::Location;
+use crate::PortAddr;
 use crate::actor::Referable;
 use crate::id::ActorId;
 use crate::id::Label;
 use crate::mailbox::RemoteMessage;
-use crate::ref_::ActorRef;
-use crate::ref_::Location;
-use crate::ref_::PortRef;
-use crate::ref_::RefParseError;
 
 /// Marker trait: `Remote<T>` can send message `M` when `T: Accepts<M>`.
 ///
@@ -36,8 +36,8 @@ impl<M: RemoteMessage> Accepts<M> for M {}
 /// The inner reference: either an actor or a port.
 #[derive(Clone, Serialize, Deserialize, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub(crate) enum RemoteRef {
-    Actor(ActorRef),
-    Port(PortRef),
+    Actor(ActorAddr),
+    Port(PortAddr),
 }
 
 impl RemoteRef {
@@ -67,7 +67,7 @@ impl fmt::Display for RemoteRef {
     }
 }
 
-/// A typed remote actor reference, wrapping an [`ActorRef`] or [`PortRef`]
+/// A typed remote actor reference, wrapping an [`ActorAddr`] or [`PortAddr`]
 /// with a type parameter for type-safe message sending.
 #[derive(Clone, Serialize, Deserialize, typeuri::Named)]
 pub struct Remote<A: Named> {
@@ -77,16 +77,16 @@ pub struct Remote<A: Named> {
 }
 
 impl<A: Named> Remote<A> {
-    /// Create a new [`Remote`] reference from an [`ActorRef`].
-    pub fn new(actor_ref: ActorRef) -> Self {
+    /// Create a new [`Remote`] reference from an [`ActorAddr`].
+    pub fn new(actor_ref: ActorAddr) -> Self {
         Self {
             inner: RemoteRef::Actor(actor_ref),
             _phantom: PhantomData,
         }
     }
 
-    /// Create a new [`Remote`] reference from a [`PortRef`].
-    pub fn from_port(port_ref: PortRef) -> Self {
+    /// Create a new [`Remote`] reference from a [`PortAddr`].
+    pub fn from_port(port_ref: PortAddr) -> Self {
         Self {
             inner: RemoteRef::Port(port_ref),
             _phantom: PhantomData,
@@ -226,16 +226,16 @@ impl<A: Named> fmt::Debug for Remote<A> {
 }
 
 impl<A: Named> FromStr for Remote<A> {
-    type Err = RefParseError;
+    type Err = AddrParseError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let at = s.find('@').ok_or(RefParseError::MissingSeparator)?;
+        let at = s.find('@').ok_or(AddrParseError::MissingSeparator)?;
         let id_part = &s[..at];
         if id_part.contains(':') {
-            let port_ref: PortRef = s.parse()?;
+            let port_ref: PortAddr = s.parse()?;
             Ok(Self::from_port(port_ref))
         } else {
-            let actor_ref: ActorRef = s.parse()?;
+            let actor_ref: ActorAddr = s.parse()?;
             Ok(Self::new(actor_ref))
         }
     }
@@ -274,7 +274,7 @@ mod tests {
     impl Accepts<Ping> for TestActor {}
     impl Accepts<Pong> for TestActor {}
 
-    fn make_actor_ref(actor_label: Option<&str>, proc_label: Option<&str>) -> ActorRef {
+    fn make_actor_ref(actor_label: Option<&str>, proc_label: Option<&str>) -> ActorAddr {
         let aid = ActorId::new(
             Uid::Instance(0xabc123),
             ProcId::new(
@@ -284,10 +284,10 @@ mod tests {
             actor_label.map(|l| Label::new(l).unwrap()),
         );
         let loc: Location = ChannelAddr::Local(42).into();
-        ActorRef::new(aid, loc)
+        ActorAddr::new(aid, loc)
     }
 
-    fn make_port_ref(actor_label: Option<&str>, proc_label: Option<&str>) -> PortRef {
+    fn make_port_ref(actor_label: Option<&str>, proc_label: Option<&str>) -> PortAddr {
         let aid = ActorId::new(
             Uid::Instance(0xabc123),
             ProcId::new(
@@ -298,7 +298,7 @@ mod tests {
         );
         let port_id = PortId::new(aid, Port::from(42));
         let loc: Location = ChannelAddr::Local(7).into();
-        PortRef::new(port_id, loc)
+        PortAddr::new(port_id, loc)
     }
 
     fn make_remote<A: Named>() -> Remote<A> {

--- a/hyperactor/src/spawn.rs
+++ b/hyperactor/src/spawn.rs
@@ -10,14 +10,14 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 
+use crate::ActorAddr;
 use crate::actor::Actor;
 use crate::actor::ActorHandle;
 use crate::mailbox::BoxedMailboxSender;
-use crate::ref_;
 
 #[derive(Debug)]
 struct LocalSpawnerState {
-    root: ref_::ActorRef,
+    root: ActorAddr,
     sender: BoxedMailboxSender,
 }
 
@@ -25,7 +25,7 @@ struct LocalSpawnerState {
 pub(crate) struct LocalSpawner(Option<Arc<LocalSpawnerState>>);
 
 impl LocalSpawner {
-    pub(crate) fn new(root: ref_::ActorRef, sender: BoxedMailboxSender) -> Self {
+    pub(crate) fn new(root: ActorAddr, sender: BoxedMailboxSender) -> Self {
         Self(Some(Arc::new(LocalSpawnerState { root, sender })))
     }
 

--- a/hyperactor/src/subject.rs
+++ b/hyperactor/src/subject.rs
@@ -18,6 +18,9 @@
 
 use std::fmt;
 
+use crate::ActorAddr;
+use crate::ProcAddr;
+
 /// Identifies the entity a log message pertains to.
 ///
 /// Used as a tracing span field via `%actor_id.subject()`.
@@ -64,13 +67,13 @@ impl AsSubject for crate::reference::ProcId {
     }
 }
 
-impl AsSubject for crate::ref_::ActorRef {
+impl AsSubject for ActorAddr {
     fn subject(&self) -> Subject<'_> {
         Subject::actor(self)
     }
 }
 
-impl AsSubject for crate::ref_::ProcRef {
+impl AsSubject for ProcAddr {
     fn subject(&self) -> Subject<'_> {
         Subject::proc(self)
     }

--- a/hyperactor_mesh/src/bootstrap.rs
+++ b/hyperactor_mesh/src/bootstrap.rs
@@ -35,7 +35,9 @@ use base64::prelude::*;
 use futures::StreamExt;
 use futures::stream;
 use humantime::format_duration;
+use hyperactor::ActorAddr;
 use hyperactor::ActorHandle;
+use hyperactor::ProcAddr;
 use hyperactor::channel;
 use hyperactor::channel::ChannelAddr;
 use hyperactor::channel::ChannelError;
@@ -53,7 +55,6 @@ use hyperactor::mailbox::MailboxClient;
 use hyperactor::mailbox::MailboxServer;
 use hyperactor::mailbox::MailboxServerHandle;
 use hyperactor::proc::Proc;
-use hyperactor::ref_;
 use hyperactor::reference as hyperactor_reference;
 use hyperactor_config::CONFIG;
 use hyperactor_config::ConfigAttr;
@@ -736,7 +737,7 @@ impl std::error::Error for ReadyError {}
 #[derive(Clone)]
 pub struct BootstrapProcHandle {
     /// Logical identity of the proc in the mesh.
-    proc_id: ref_::ProcRef,
+    proc_id: ProcAddr,
 
     /// Live lifecycle snapshot (see [`ProcStatus`]). Kept in a mutex
     /// so [`BootstrapProcHandle::status`] can return a synchronous
@@ -804,7 +805,7 @@ impl BootstrapProcHandle {
     /// This is the canonical entry point used by
     /// `BootstrapProcManager` when it launches a proc into a new
     /// process.
-    pub(crate) fn new(proc_id: ref_::ProcRef, launcher: Weak<dyn ProcLauncher>) -> Self {
+    pub(crate) fn new(proc_id: ProcAddr, launcher: Weak<dyn ProcLauncher>) -> Self {
         let (tx, rx) = watch::channel(ProcStatus::Starting);
         Self {
             proc_id,
@@ -819,7 +820,7 @@ impl BootstrapProcHandle {
 
     /// Return the logical proc identity in the mesh.
     #[inline]
-    pub fn proc_id(&self) -> &ref_::ProcRef {
+    pub fn proc_id(&self) -> &ProcAddr {
         &self.proc_id
     }
 
@@ -1228,7 +1229,7 @@ impl hyperactor::host::ProcHandle for BootstrapProcHandle {
     type TerminalStatus = ProcStatus;
 
     #[inline]
-    fn proc_id(&self) -> &ref_::ProcRef {
+    fn proc_id(&self) -> &ProcAddr {
         &self.proc_id
     }
 
@@ -1611,7 +1612,7 @@ pub struct BootstrapProcManager {
     /// Async registry of running children, keyed by [`ProcId`]. Holds
     /// [`BootstrapProcHandle`]s so callers can query or monitor
     /// status.
-    children: Arc<tokio::sync::Mutex<HashMap<ref_::ProcRef, BootstrapProcHandle>>>,
+    children: Arc<tokio::sync::Mutex<HashMap<ProcAddr, BootstrapProcHandle>>>,
 
     /// FileMonitor that aggregates logs from all children. None if
     /// file monitor creation failed.
@@ -1709,7 +1710,7 @@ impl BootstrapProcManager {
     ///
     /// Returns `None` if the manager has no record of the proc (e.g.
     /// never spawned here, or entry already removed).
-    pub async fn status(&self, proc_id: &ref_::ProcRef) -> Option<ProcStatus> {
+    pub async fn status(&self, proc_id: &ProcAddr) -> Option<ProcStatus> {
         self.children.lock().await.get(proc_id).map(|h| h.status())
     }
 
@@ -1717,7 +1718,7 @@ impl BootstrapProcManager {
     /// if the proc is known to this manager.
     pub async fn watch(
         &self,
-        proc_id: &ref_::ProcRef,
+        proc_id: &ProcAddr,
     ) -> Option<tokio::sync::watch::Receiver<ProcStatus>> {
         self.children.lock().await.get(proc_id).map(|h| h.watch())
     }
@@ -1731,7 +1732,7 @@ impl BootstrapProcManager {
     pub(crate) async fn request_stop(
         &self,
         cx: &impl context::Actor,
-        proc: &ref_::ProcRef,
+        proc: &ProcAddr,
         timeout: Duration,
         reason: &str,
     ) {
@@ -1766,7 +1767,7 @@ impl BootstrapProcManager {
 
     fn spawn_exit_monitor(
         &self,
-        proc_id: ref_::ProcRef,
+        proc_id: ProcAddr,
         handle: BootstrapProcHandle,
         exit_rx: tokio::sync::oneshot::Receiver<ProcExitResult>,
     ) {
@@ -1919,7 +1920,7 @@ impl ProcManager for BootstrapProcManager {
     #[hyperactor::instrument(fields(proc_id=proc_id.to_string(), addr=backend_addr.to_string()))]
     async fn spawn(
         &self,
-        proc_id: ref_::ProcRef,
+        proc_id: ProcAddr,
         backend_addr: ChannelAddr,
         config: BootstrapProcConfig,
     ) -> Result<Self::Handle, HostError> {
@@ -2082,10 +2083,10 @@ impl hyperactor::host::SingleTerminate for BootstrapProcManager {
     async fn terminate_proc(
         &self,
         cx: &impl context::Actor,
-        proc: &ref_::ProcRef,
+        proc: &ProcAddr,
         timeout: Duration,
         reason: &str,
-    ) -> Result<(Vec<ref_::ActorRef>, Vec<ref_::ActorRef>), anyhow::Error> {
+    ) -> Result<(Vec<ActorAddr>, Vec<ActorAddr>), anyhow::Error> {
         // Snapshot to avoid holding the lock across awaits.
         let proc_handle: Option<BootstrapProcHandle> = {
             let mut guard = self.children.lock().await;
@@ -2451,7 +2452,7 @@ mod tests {
             BoxedMailboxSender::new(router.clone()),
         );
         proc.clone().serve(proc_rx);
-        let proc_ref: hyperactor::ref_::ProcRef = test_proc_id("client_0").into();
+        let proc_ref: ProcAddr = test_proc_id("client_0").into();
         router.bind(proc_ref, proc_addr.clone());
         let (client, _handle) = proc.instance("client").unwrap();
 
@@ -2563,7 +2564,7 @@ mod tests {
         // ensuring tests only exercise status transitions and not
         // actual process lifecycle.
         fn handle_for_test() -> BootstrapProcHandle {
-            let proc_id: hyperactor::ref_::ProcRef = test_proc_id("0").into();
+            let proc_id: ProcAddr = test_proc_id("0").into();
             let launcher: Arc<dyn ProcLauncher> = Arc::new(TestProcLauncher);
             BootstrapProcHandle::new(proc_id, Arc::downgrade(&launcher))
         }

--- a/hyperactor_mesh/src/host_mesh.rs
+++ b/hyperactor_mesh/src/host_mesh.rs
@@ -6,6 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#![allow(clippy::result_large_err)]
+
 use hyperactor::Actor;
 use hyperactor::Handler;
 use hyperactor::accum::StreamingReducerOpts;
@@ -44,6 +46,7 @@ use ndslice::view::Ranked;
 use ndslice::view::RegionParseError;
 use serde::Deserialize;
 use serde::Serialize;
+use tracing::Instrument;
 use typeuri::Named;
 
 use crate::Bootstrap;
@@ -64,7 +67,6 @@ use crate::mesh_id::HostMeshId;
 use crate::mesh_id::ProcMeshId;
 use crate::mesh_id::ResourceId;
 use crate::proc_agent::ProcAgent;
-use crate::proc_mesh::ProcRef;
 use crate::resource;
 use crate::resource::CreateOrUpdateClient;
 use crate::resource::GetRankStatus;
@@ -123,7 +125,7 @@ impl HostRef {
 
     /// The ProcId for the proc with name `name` on this host.
     fn named_proc(&self, id: &ResourceId) -> hyperactor_reference::ProcId {
-        hyperactor_reference::ProcId::from_proc_ref(hyperactor::ref_::ProcRef::new(
+        hyperactor_reference::ProcId::from_proc_ref(hyperactor::addr::ProcAddr::new(
             hyperactor::id::ProcId::new(id.uid().clone(), id.label().cloned()),
             self.0.clone().into(),
         ))
@@ -695,31 +697,28 @@ impl Drop for HostMeshShutdownGuard {
         // Best-effort only when a Tokio runtime is available.
         if let Ok(handle) = tokio::runtime::Handle::try_current() {
             let mesh_id = self.0.id.clone();
+            let span = tracing::info_span!(
+                "hostmesh_drop_cleanup",
+                host_mesh = %mesh_id,
+                hosts = hosts.len(),
+            );
 
-            handle.spawn(async move {
-                let span = tracing::info_span!(
-                    "hostmesh_drop_cleanup",
-                    host_mesh = %mesh_id,
-                    hosts = hosts.len(),
-                );
-                let _g = span.enter();
-
-                // Spin up a tiny ephemeral proc+instance to get an
-                // Actor context.
-                match hyperactor::Proc::direct(
-                    ChannelTransport::Unix.any(),
-                    "hostmesh-drop".to_string(),
-                )
-                {
-                    Err(e) => {
-                        tracing::warn!(
-                            error = %e,
-                            "failed to construct ephemeral Proc for drop-cleanup; \
-                             relying on PDEATHSIG/manager Drop"
-                        );
-                    }
-                    Ok(proc) => {
-                        match proc.instance("drop") {
+            handle.spawn(
+                async move {
+                    // Spin up a tiny ephemeral proc+instance to get an
+                    // Actor context.
+                    match hyperactor::Proc::direct(
+                        ChannelTransport::Unix.any(),
+                        "hostmesh-drop".to_string(),
+                    ) {
+                        Err(e) => {
+                            tracing::warn!(
+                                error = %e,
+                                "failed to construct ephemeral Proc for drop-cleanup; \
+                                 relying on PDEATHSIG/manager Drop"
+                            );
+                        }
+                        Ok(proc) => match proc.instance("drop") {
                             Err(e) => {
                                 tracing::warn!(
                                     error = %e,
@@ -752,10 +751,11 @@ impl Drop for HostMeshShutdownGuard {
                                     "hostmesh drop-cleanup summary"
                                 );
                             }
-                        }
+                        },
                     }
                 }
-            });
+                .instrument(span),
+            );
         } else {
             // No runtime here; PDEATHSIG and manager Drop remain the
             // last-resort safety net.
@@ -1154,7 +1154,7 @@ impl HostMeshRef {
                     %proc_id,
                     rank = create_rank,
                 );
-                procs.push(ProcRef::new(
+                procs.push(crate::proc_mesh::ProcRef::new(
                     proc_id,
                     create_rank,
                     // TODO: specify or retrieve from state instead, to avoid attestation.

--- a/hyperactor_mesh/src/host_mesh/host_agent.rs
+++ b/hyperactor_mesh/src/host_mesh/host_agent.rs
@@ -24,12 +24,14 @@ use async_trait::async_trait;
 use enum_as_inner::EnumAsInner;
 use hyperactor::Actor;
 use hyperactor::ActorHandle;
+use hyperactor::Address;
 use hyperactor::Context;
 use hyperactor::HandleClient;
 use hyperactor::Handler;
 use hyperactor::Instance;
 use hyperactor::PortHandle;
 use hyperactor::Proc;
+use hyperactor::ProcAddr;
 use hyperactor::RefClient;
 use hyperactor::context;
 use hyperactor::host::Host;
@@ -39,7 +41,6 @@ use hyperactor::host::LocalProcManager;
 use hyperactor::host::SERVICE_PROC_NAME;
 use hyperactor::host::SingleTerminate;
 use hyperactor::mailbox::MailboxServerHandle;
-use hyperactor::ref_;
 use hyperactor::reference as hyperactor_reference;
 use hyperactor_config::attrs::Attrs;
 use serde::Deserialize;
@@ -120,7 +121,7 @@ impl HostAgentMode {
     async fn request_stop(
         &self,
         cx: &impl context::Actor,
-        proc: &ref_::ProcRef,
+        proc: &ProcAddr,
         timeout: Duration,
         reason: &str,
     ) {
@@ -140,7 +141,7 @@ impl HostAgentMode {
     /// that need process-level detail such as PIDs or exit codes.
     async fn proc_status(
         &self,
-        proc_id: &ref_::ProcRef,
+        proc_id: &ProcAddr,
     ) -> (resource::Status, Option<bootstrap::ProcStatus>) {
         match self {
             HostAgentMode::Process { host, .. } => match host.manager().status(proc_id).await {
@@ -171,8 +172,7 @@ impl HostAgentMode {
 pub(crate) struct ProcCreationState {
     pub(crate) rank: usize,
     pub(crate) host_mesh_id: Option<HostMeshId>,
-    pub(crate) created:
-        Result<(ref_::ProcRef, hyperactor_reference::ActorRef<ProcAgent>), HostError>,
+    pub(crate) created: Result<(ProcAddr, hyperactor_reference::ActorRef<ProcAgent>), HostError>,
 }
 
 /// Actor name used when spawning the host mesh agent on the system proc.
@@ -519,7 +519,7 @@ impl Actor for HostAgent {
             use hyperactor::introspect::IntrospectResult;
 
             let proc = match child_ref {
-                hyperactor::ref_::Reference::Proc(proc_ref) => {
+                Address::Proc(proc_ref) => {
                     if *proc_ref == *system_proc.proc_id() {
                         Some((&system_proc, SERVICE_PROC_NAME))
                     } else if *proc_ref == *local_proc.proc_id() {
@@ -610,13 +610,13 @@ impl Actor for HostAgent {
                         format!("child {} not found", child_ref),
                     );
                     let identity = match child_ref {
-                        hyperactor::ref_::Reference::Proc(p) => {
+                        Address::Proc(p) => {
                             hyperactor::introspect::IntrospectRef::Proc(p.clone().into())
                         }
-                        hyperactor::ref_::Reference::Actor(a) => {
+                        Address::Actor(a) => {
                             hyperactor::introspect::IntrospectRef::Actor(a.clone().into())
                         }
-                        hyperactor::ref_::Reference::Port(p) => {
+                        Address::Port(p) => {
                             hyperactor::introspect::IntrospectRef::Actor(p.actor_ref().into())
                         }
                     };
@@ -969,7 +969,7 @@ impl HostAgent {
 
     /// Start a bridge task that watches a proc's status channel and sends
     /// `ProcStatusChanged` to self on each change. At most one bridge per proc.
-    async fn start_watch_bridge(&mut self, id: &ResourceId, proc_id: &ref_::ProcRef) {
+    async fn start_watch_bridge(&mut self, id: &ResourceId, proc_id: &ProcAddr) {
         if self.watching.contains(id) {
             return;
         }

--- a/hyperactor_mesh/src/logging.rs
+++ b/hyperactor_mesh/src/logging.rs
@@ -1462,6 +1462,7 @@ mod tests {
     use std::sync::Arc;
     use std::sync::Mutex;
 
+    use hyperactor::ProcAddr;
     use hyperactor::RemoteSpawn;
     use hyperactor::channel;
     use hyperactor::channel::ChannelAddr;
@@ -1598,7 +1599,7 @@ mod tests {
             BoxedMailboxSender::new(router.clone()),
         );
         proc.clone().serve(client_rx);
-        let proc_ref: hyperactor::ref_::ProcRef = test_proc_id("client_0").into();
+        let proc_ref: ProcAddr = test_proc_id("client_0").into();
         router.bind(proc_ref, proc_addr.clone());
         let (client, _handle) = proc.instance("client").unwrap();
 

--- a/hyperactor_mesh/src/proc_agent.rs
+++ b/hyperactor_mesh/src/proc_agent.rs
@@ -20,6 +20,7 @@ use std::time::Duration;
 use async_trait::async_trait;
 use hyperactor::Actor;
 use hyperactor::ActorHandle;
+use hyperactor::Address;
 use hyperactor::Bind;
 use hyperactor::Context;
 use hyperactor::Data;
@@ -253,7 +254,7 @@ struct SelfCheck {}
 /// events to the *currently active* mesh.
 ///
 /// Without exporting this handler, `ActorSupervisionEvent` cannot be
-/// addressed via `ActorRef`/`PortRef` across processes, and the
+/// addressed via `ActorAddr`/`PortAddr` across processes, and the
 /// global-root-client undeliverable → supervision pipeline would
 /// degrade to log-only behavior (events become undeliverable again or
 /// are dropped).
@@ -491,7 +492,7 @@ impl Actor for ProcAgent {
         this.set_query_child_handler(move |child_ref| {
             use hyperactor::introspect::IntrospectResult;
 
-            if let hyperactor::ref_::Reference::Actor(actor_ref) = child_ref {
+            if let Address::Actor(actor_ref) = child_ref {
                 if let Some(snapshot) = proc.terminated_snapshot(actor_ref) {
                     return snapshot;
                 }
@@ -501,10 +502,10 @@ impl Actor for ProcAgent {
             // admin/TUI must be computed from live proc state at query
             // time, not solely from cached published_properties.
             // Therefore a direct proc.spawn() actor must appear on the
-            // next QueryChild(Reference::Proc) response without an
+            // next QueryChild(Address::Proc) response without an
             // extra publish event. See
             // test_query_child_proc_returns_live_children.
-            if let hyperactor::ref_::Reference::Proc(proc_ref) = child_ref {
+            if let Address::Proc(proc_ref) = child_ref {
                 if *proc_ref == *proc.proc_id() {
                     let (mut children, mut system_children) = collect_live_children(&proc);
 
@@ -618,13 +619,13 @@ impl Actor for ProcAgent {
                     format!("child {} not found", child_ref),
                 );
                 let identity = match child_ref {
-                    hyperactor::ref_::Reference::Proc(p) => {
+                    Address::Proc(p) => {
                         hyperactor::introspect::IntrospectRef::Proc(p.clone().into())
                     }
-                    hyperactor::ref_::Reference::Actor(a) => {
+                    Address::Actor(a) => {
                         hyperactor::introspect::IntrospectRef::Actor(a.clone().into())
                     }
-                    hyperactor::ref_::Reference::Port(p) => {
+                    Address::Port(p) => {
                         hyperactor::introspect::IntrospectRef::Actor(p.actor_ref().into())
                     }
                 };
@@ -1210,7 +1211,7 @@ mod tests {
     struct ExtraActor;
     impl hyperactor::Actor for ExtraActor {}
     hyperactor::remote!(ExtraActor);
-    // Verifies that QueryChild(Reference::Proc) on a ProcAgent returns
+    // Verifies that QueryChild(Address::Proc) on a ProcAgent returns
     // a live IntrospectResult whose children reflect actors spawned
     // directly on the proc — i.e. via proc.spawn(), which bypasses the
     // gspawn message handler and therefore never triggers
@@ -1326,7 +1327,7 @@ mod tests {
 
     // Exercises S12 (see introspect module doc): introspection must
     // not impair actor liveness. Rapidly spawns and stops
-    // actors while concurrently querying QueryChild(Reference::Proc).
+    // actors while concurrently querying QueryChild(Address::Proc).
     // The spawn/stop loop must complete within the timeout and the
     // iteration count must match -- if DashMap convoy starvation
     // blocks the proc, the timeout fires and the test fails.

--- a/monarch_hyperactor/src/endpoint.rs
+++ b/monarch_hyperactor/src/endpoint.rs
@@ -11,6 +11,7 @@ use std::sync::Arc;
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
 
+use hyperactor::ActorAddr;
 use hyperactor::Instance;
 use hyperactor::accum::Accumulator;
 use hyperactor::accum::CommReducer;
@@ -18,7 +19,6 @@ use hyperactor::accum::ReducerFactory;
 use hyperactor::accum::ReducerSpec;
 use hyperactor::mailbox::OncePortReceiver;
 use hyperactor::mailbox::PortReceiver;
-use hyperactor::ref_::ActorRef;
 use hyperactor_mesh::sel;
 use hyperactor_mesh::value_mesh::ValueOverlay;
 use hyperactor_mesh::value_mesh::rle;
@@ -219,7 +219,7 @@ pub(crate) struct SpanGuard {
 }
 
 impl SpanGuard {
-    fn actor_endpoint(name: &'static str, actor_id: &ActorRef, mesh: &str, method: &str) -> Self {
+    fn actor_endpoint(name: &'static str, actor_id: &ActorAddr, mesh: &str, method: &str) -> Self {
         Self {
             id: hyperactor_telemetry::start_user_span(
                 name,
@@ -244,7 +244,7 @@ impl SpanGuard {
         }
     }
 
-    fn remote(name: &'static str, actor_id: &ActorRef, call_name: &str) -> Self {
+    fn remote(name: &'static str, actor_id: &ActorAddr, call_name: &str) -> Self {
         Self {
             id: hyperactor_telemetry::start_user_span(
                 name,
@@ -634,7 +634,7 @@ pub(crate) trait Endpoint {
     /// for Remote) and route the slice to an actor-specific track. The adverb is the span name,
     /// so no formatting happens at the call site and the sink formats only when
     /// it renders the slice.
-    fn enter_endpoint_span(&self, adverb: EndpointAdverb, actor_id: &ActorRef) -> SpanGuard;
+    fn enter_endpoint_span(&self, adverb: EndpointAdverb, actor_id: &ActorAddr) -> SpanGuard;
 
     fn get_current_instance(&self, py: Python<'_>) -> PyResult<Instance<PythonActor>> {
         let context = get_context(py).call0()?;
@@ -952,7 +952,7 @@ impl Endpoint for ActorEndpoint {
         Some(format!("{}.{}()", self.mesh_name, self.method.name()))
     }
 
-    fn enter_endpoint_span(&self, adverb: EndpointAdverb, actor_id: &ActorRef) -> SpanGuard {
+    fn enter_endpoint_span(&self, adverb: EndpointAdverb, actor_id: &ActorAddr) -> SpanGuard {
         let mesh = self.mesh_name.as_str();
         let method = self.method.name();
         SpanGuard::actor_endpoint(adverb.as_str(), actor_id, mesh, method)
@@ -1217,7 +1217,7 @@ impl Endpoint for Remote {
         None // Remote endpoints don't have qualified names
     }
 
-    fn enter_endpoint_span(&self, adverb: EndpointAdverb, actor_id: &ActorRef) -> SpanGuard {
+    fn enter_endpoint_span(&self, adverb: EndpointAdverb, actor_id: &ActorAddr) -> SpanGuard {
         let call_name = Python::attach(|py| {
             self.inner
                 .call_method0(py, "_call_name")
@@ -1468,6 +1468,7 @@ impl Accumulator for PythonResponseMessageAccumulator {
 
 #[cfg(test)]
 mod tests {
+    use hyperactor::ActorAddr;
     use hyperactor::mailbox::headers::OPERATION_ADVERB;
     use hyperactor::mailbox::headers::OPERATION_ENDPOINT;
 
@@ -1504,7 +1505,7 @@ mod tests {
         fn get_qualified_name(&self) -> Option<String> {
             self.qualified_name.clone()
         }
-        fn enter_endpoint_span(&self, _adverb: EndpointAdverb, _actor_id: &ActorRef) -> SpanGuard {
+        fn enter_endpoint_span(&self, _adverb: EndpointAdverb, _actor_id: &ActorAddr) -> SpanGuard {
             unreachable!()
         }
     }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #3718
* #3717
* #3716
* #3715
* #3714
* #3713
* __->__ #3712
* #3630
* #3629
* #3628
* #3627
* #3626

Free the `ref_` namespace by mechanically renaming the raw `id@location` layer from `ref_` to `addr`. This moves the raw module and parser, renames raw `*Ref` types to `*Addr`, updates raw call sites across hyperactor and hyperactor_mesh, and retargets `reference` internals to wrap `addr::*` while preserving the typed `reference` capability surface.

Differential Revision: [D102664681](https://our.internmc.facebook.com/intern/diff/D102664681/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D102664681/)!