### PR TITLE
[hyperactor] retarget typed capability uses to ref_

### DIFF
--- a/hyperactor/src/actor.rs
+++ b/hyperactor/src/actor.rs
@@ -33,6 +33,7 @@ use typeuri::Named;
 
 use crate as hyperactor; // for macros
 use crate::ActorAddr;
+use crate::ActorRef;
 use crate::Data;
 use crate::Message;
 use crate::RemoteMessage;
@@ -669,7 +670,7 @@ impl<A: Actor> ActorHandle<A> {
 
     /// TEMPORARY: bind...
     /// TODO: we shoudl also have a default binding(?)
-    pub fn bind<R: Binds<A>>(&self) -> reference::ActorRef<R> {
+    pub fn bind<R: Binds<A>>(&self) -> ActorRef<R> {
         self.cell.bind(self.ports.as_ref())
     }
 }
@@ -790,8 +791,10 @@ mod tests {
     use super::*;
     use crate as hyperactor;
     use crate::Actor;
+    use crate::ActorRef;
     use crate::Address;
     use crate::OncePortHandle;
+    use crate::PortRef;
     use crate::config;
     use crate::context::Mailbox as _;
     use crate::introspect::IntrospectMessage;
@@ -809,7 +812,7 @@ mod tests {
     use crate::testing::proc_supervison::ProcSupervisionCoordinator; // for macros
 
     #[derive(Debug)]
-    struct EchoActor(reference::PortRef<u64>);
+    struct EchoActor(PortRef<u64>);
 
     #[async_trait]
     impl Actor for EchoActor {}
@@ -1031,7 +1034,7 @@ mod tests {
         test.sync().await;
         assert_eq!(test.get_values(), (123u64, "foo".to_string()));
 
-        let myref: reference::ActorRef<MultiActor> = test.handle.bind();
+        let myref: ActorRef<MultiActor> = test.handle.bind();
 
         myref.port().send(&test.client, 321u64).unwrap();
         test.sync().await;
@@ -1051,7 +1054,7 @@ mod tests {
 
         hyperactor::behavior!(MyActorBehavior, u64, String);
 
-        let myref: reference::ActorRef<MyActorBehavior> = test.handle.bind();
+        let myref: ActorRef<MyActorBehavior> = test.handle.bind();
         myref.port().send(&test.client, "biz".to_string()).unwrap();
         myref.port().send(&test.client, 999u64).unwrap();
 
@@ -1083,7 +1086,7 @@ mod tests {
     // Returning the sequence number assigned to the message.
     #[derive(Debug)]
     #[hyperactor::export(handlers = [String, Callback])]
-    struct GetSeqActor(reference::PortRef<(String, SeqInfo)>);
+    struct GetSeqActor(PortRef<(String, SeqInfo)>);
 
     #[async_trait]
     impl Actor for GetSeqActor {}
@@ -1107,7 +1110,7 @@ mod tests {
     // handler will reply that port with its own callback port. Then sender can
     // send the string message through this callback port.
     #[derive(Clone, Debug, Serialize, Deserialize, Named)]
-    struct Callback(reference::PortRef<reference::PortRef<String>>);
+    struct Callback(PortRef<PortRef<String>>);
 
     #[async_trait]
     impl Handler<Callback> for GetSeqActor {
@@ -1139,7 +1142,7 @@ mod tests {
             ("unbound".to_string(), SeqInfo::Direct)
         );
 
-        let actor_ref: reference::ActorRef<GetSeqActor> = actor_handle.bind();
+        let actor_ref: ActorRef<GetSeqActor> = actor_handle.bind();
 
         let session_id = client.sequencer().session_id();
         let mut expected_seq = 0;
@@ -1188,7 +1191,7 @@ mod tests {
         let (non_actor_tx, mut non_actor_rx) = mpsc::unbounded_channel::<Option<SeqInfo>>();
 
         let actor_handle = proc.spawn("get_seq", GetSeqActor(actor_tx.bind())).unwrap();
-        let actor_ref: reference::ActorRef<GetSeqActor> = actor_handle.bind();
+        let actor_ref: ActorRef<GetSeqActor> = actor_handle.bind();
 
         // Create a non-actor port using open_enqueue_port
         let non_actor_tx_clone = non_actor_tx.clone();
@@ -1265,7 +1268,7 @@ mod tests {
         let (tx, mut rx) = client1.open_port();
 
         let actor_handle = proc.spawn("get_seq", GetSeqActor(tx.bind())).unwrap();
-        let actor_ref: reference::ActorRef<GetSeqActor> = actor_handle.bind();
+        let actor_ref: ActorRef<GetSeqActor> = actor_handle.bind();
 
         // Each client should have a different session_id
         let session_id_1 = client1.sequencer().session_id();
@@ -1374,7 +1377,7 @@ mod tests {
         let (tx, mut rx) = client.open_port();
 
         let actor_handle = proc.spawn("get_seq", GetSeqActor(tx.bind())).unwrap();
-        let actor_ref: reference::ActorRef<GetSeqActor> = actor_handle.bind();
+        let actor_ref: ActorRef<GetSeqActor> = actor_handle.bind();
 
         let (callback_tx, mut callback_rx) = client.open_port();
         // Client sends the 1st message
@@ -1462,7 +1465,7 @@ mod tests {
         let (tx, mut rx) = client.open_port();
 
         let handle = local_proc.spawn("get_seq", GetSeqActor(tx.bind())).unwrap();
-        let actor_ref: reference::ActorRef<GetSeqActor> = handle.bind();
+        let actor_ref: ActorRef<GetSeqActor> = handle.bind();
 
         let remote_proc = Proc::configured(
             test_proc_id("remote_0"),
@@ -1575,17 +1578,15 @@ mod tests {
         let handle = proc.spawn::<EchoActor>("echo_introspect", actor).unwrap();
 
         let (reply_port, reply_rx) = client.open_once_port::<IntrospectResult>();
-        reference::PortRef::<IntrospectMessage>::attest_message_port(
-            &handle.actor_id().clone().into(),
-        )
-        .send(
-            &client,
-            IntrospectMessage::Query {
-                view: IntrospectView::Actor,
-                reply: reply_port.bind(),
-            },
-        )
-        .unwrap();
+        PortRef::<IntrospectMessage>::attest_message_port(&handle.actor_id().clone().into())
+            .send(
+                &client,
+                IntrospectMessage::Query {
+                    view: IntrospectView::Actor,
+                    reply: reply_port.bind(),
+                },
+            )
+            .unwrap();
         let payload = reply_rx.recv().await.unwrap();
 
         assert_eq!(
@@ -1752,17 +1753,15 @@ mod tests {
 
         let child_ref = reference::Reference::Actor(test_proc_id("nonexistent").actor_id("child"));
         let (reply_port, reply_rx) = client.open_once_port::<IntrospectResult>();
-        reference::PortRef::<IntrospectMessage>::attest_message_port(
-            &handle.actor_id().clone().into(),
-        )
-        .send(
-            &client,
-            IntrospectMessage::QueryChild {
-                child_ref,
-                reply: reply_port.bind(),
-            },
-        )
-        .unwrap();
+        PortRef::<IntrospectMessage>::attest_message_port(&handle.actor_id().clone().into())
+            .send(
+                &client,
+                IntrospectMessage::QueryChild {
+                    child_ref,
+                    reply: reply_port.bind(),
+                },
+            )
+            .unwrap();
         let payload = reply_rx.recv().await.unwrap();
 
         assert_eq!(
@@ -1802,17 +1801,15 @@ mod tests {
             .unwrap();
 
         let (reply_port, reply_rx) = client.open_once_port::<IntrospectResult>();
-        reference::PortRef::<IntrospectMessage>::attest_message_port(
-            &handle.actor_id().clone().into(),
-        )
-        .send(
-            &client,
-            IntrospectMessage::Query {
-                view: IntrospectView::Actor,
-                reply: reply_port.bind(),
-            },
-        )
-        .unwrap();
+        PortRef::<IntrospectMessage>::attest_message_port(&handle.actor_id().clone().into())
+            .send(
+                &client,
+                IntrospectMessage::Query {
+                    view: IntrospectView::Actor,
+                    reply: reply_port.bind(),
+                },
+            )
+            .unwrap();
         let payload = reply_rx.recv().await.unwrap();
 
         // The runtime task returns actor attrs (with status), NOT
@@ -1845,17 +1842,15 @@ mod tests {
 
         // Query the child — supervisor should be the parent.
         let (reply_port, reply_rx) = client.open_once_port::<IntrospectResult>();
-        reference::PortRef::<IntrospectMessage>::attest_message_port(
-            &child_handle.actor_id().clone().into(),
-        )
-        .send(
-            &client,
-            IntrospectMessage::Query {
-                view: IntrospectView::Actor,
-                reply: reply_port.bind(),
-            },
-        )
-        .unwrap();
+        PortRef::<IntrospectMessage>::attest_message_port(&child_handle.actor_id().clone().into())
+            .send(
+                &client,
+                IntrospectMessage::Query {
+                    view: IntrospectView::Actor,
+                    reply: reply_port.bind(),
+                },
+            )
+            .unwrap();
         let child_payload = reply_rx.recv().await.unwrap();
 
         assert_eq!(
@@ -1876,17 +1871,15 @@ mod tests {
 
         // Query the parent — children should include the child.
         let (reply_port, reply_rx) = client.open_once_port::<IntrospectResult>();
-        reference::PortRef::<IntrospectMessage>::attest_message_port(
-            &parent_handle.actor_id().clone().into(),
-        )
-        .send(
-            &client,
-            IntrospectMessage::Query {
-                view: IntrospectView::Actor,
-                reply: reply_port.bind(),
-            },
-        )
-        .unwrap();
+        PortRef::<IntrospectMessage>::attest_message_port(&parent_handle.actor_id().clone().into())
+            .send(
+                &client,
+                IntrospectMessage::Query {
+                    view: IntrospectView::Actor,
+                    reply: reply_port.bind(),
+                },
+            )
+            .unwrap();
         let parent_payload = reply_rx.recv().await.unwrap();
 
         assert!(parent_payload.parent.is_none());
@@ -1924,17 +1917,15 @@ mod tests {
             .unwrap();
 
         let (reply_port, reply_rx) = client.open_once_port::<IntrospectResult>();
-        reference::PortRef::<IntrospectMessage>::attest_message_port(
-            &handle.actor_id().clone().into(),
-        )
-        .send(
-            &client,
-            IntrospectMessage::Query {
-                view: IntrospectView::Actor,
-                reply: reply_port.bind(),
-            },
-        )
-        .unwrap();
+        PortRef::<IntrospectMessage>::attest_message_port(&handle.actor_id().clone().into())
+            .send(
+                &client,
+                IntrospectMessage::Query {
+                    view: IntrospectView::Actor,
+                    reply: reply_port.bind(),
+                },
+            )
+            .unwrap();
         let payload = reply_rx.recv().await.unwrap();
 
         assert_status(&payload, "idle");
@@ -1961,17 +1952,15 @@ mod tests {
         let _ = rx.recv().await.unwrap();
 
         let (reply_port, reply_rx) = client.open_once_port::<IntrospectResult>();
-        reference::PortRef::<IntrospectMessage>::attest_message_port(
-            &handle.actor_id().clone().into(),
-        )
-        .send(
-            &client,
-            IntrospectMessage::Query {
-                view: IntrospectView::Actor,
-                reply: reply_port.bind(),
-            },
-        )
-        .unwrap();
+        PortRef::<IntrospectMessage>::attest_message_port(&handle.actor_id().clone().into())
+            .send(
+                &client,
+                IntrospectMessage::Query {
+                    view: IntrospectView::Actor,
+                    reply: reply_port.bind(),
+                },
+            )
+            .unwrap();
         let payload = reply_rx.recv().await.unwrap();
 
         assert_status(&payload, "idle");
@@ -2002,32 +1991,28 @@ mod tests {
 
         // First introspect query.
         let (reply_port, reply_rx) = client.open_once_port::<IntrospectResult>();
-        reference::PortRef::<IntrospectMessage>::attest_message_port(
-            &handle.actor_id().clone().into(),
-        )
-        .send(
-            &client,
-            IntrospectMessage::Query {
-                view: IntrospectView::Actor,
-                reply: reply_port.bind(),
-            },
-        )
-        .unwrap();
+        PortRef::<IntrospectMessage>::attest_message_port(&handle.actor_id().clone().into())
+            .send(
+                &client,
+                IntrospectMessage::Query {
+                    view: IntrospectView::Actor,
+                    reply: reply_port.bind(),
+                },
+            )
+            .unwrap();
         let payload1 = reply_rx.recv().await.unwrap();
 
         // Second introspect query.
         let (reply_port2, reply_rx2) = client.open_once_port::<IntrospectResult>();
-        reference::PortRef::<IntrospectMessage>::attest_message_port(
-            &handle.actor_id().clone().into(),
-        )
-        .send(
-            &client,
-            IntrospectMessage::Query {
-                view: IntrospectView::Actor,
-                reply: reply_port2.bind(),
-            },
-        )
-        .unwrap();
+        PortRef::<IntrospectMessage>::attest_message_port(&handle.actor_id().clone().into())
+            .send(
+                &client,
+                IntrospectMessage::Query {
+                    view: IntrospectView::Actor,
+                    reply: reply_port2.bind(),
+                },
+            )
+            .unwrap();
         let payload2 = reply_rx2.recv().await.unwrap();
 
         // Neither should show IntrospectMessage as the handler.
@@ -2191,17 +2176,15 @@ mod tests {
 
         // Send introspect query via the dedicated introspect port.
         let (reply_port, reply_rx) = client.open_once_port::<IntrospectResult>();
-        reference::PortRef::<IntrospectMessage>::attest_message_port(
-            &handle.actor_id().clone().into(),
-        )
-        .send(
-            &client,
-            IntrospectMessage::Query {
-                view: IntrospectView::Actor,
-                reply: reply_port.bind(),
-            },
-        )
-        .unwrap();
+        PortRef::<IntrospectMessage>::attest_message_port(&handle.actor_id().clone().into())
+            .send(
+                &client,
+                IntrospectMessage::Query {
+                    view: IntrospectView::Actor,
+                    reply: reply_port.bind(),
+                },
+            )
+            .unwrap();
 
         // Must not hang — the introspect task runs independently.
         let payload = tokio::time::timeout(Duration::from_secs(5), reply_rx.recv())
@@ -2238,17 +2221,15 @@ mod tests {
 
         // First introspect query.
         let (reply_port1, reply_rx1) = client.open_once_port::<IntrospectResult>();
-        reference::PortRef::<IntrospectMessage>::attest_message_port(
-            &handle.actor_id().clone().into(),
-        )
-        .send(
-            &client,
-            IntrospectMessage::Query {
-                view: IntrospectView::Actor,
-                reply: reply_port1.bind(),
-            },
-        )
-        .unwrap();
+        PortRef::<IntrospectMessage>::attest_message_port(&handle.actor_id().clone().into())
+            .send(
+                &client,
+                IntrospectMessage::Query {
+                    view: IntrospectView::Actor,
+                    reply: reply_port1.bind(),
+                },
+            )
+            .unwrap();
         let payload1 = reply_rx1.recv().await.unwrap();
 
         // Second introspect query.
@@ -2292,7 +2273,7 @@ mod tests {
         let actor_id: reference::ActorId = handle.actor_id().clone().into();
 
         let (reply_port, reply_rx) = bridge.open_once_port::<IntrospectResult>();
-        reference::PortRef::<IntrospectMessage>::attest_message_port(&actor_id)
+        PortRef::<IntrospectMessage>::attest_message_port(&actor_id)
             .send(
                 &bridge,
                 IntrospectMessage::Query {
@@ -2331,7 +2312,7 @@ mod tests {
         let mailbox_id: reference::ActorId = mailbox_handle.actor_id().clone().into();
 
         let (reply_port, reply_rx) = client.open_once_port::<IntrospectResult>();
-        reference::PortRef::<IntrospectMessage>::attest_message_port(&mailbox_id)
+        PortRef::<IntrospectMessage>::attest_message_port(&mailbox_id)
             .send(
                 &client,
                 IntrospectMessage::Query {

--- a/hyperactor/src/host.rs
+++ b/hyperactor/src/host.rs
@@ -72,6 +72,7 @@ use crate as hyperactor;
 use crate::Actor;
 use crate::ActorAddr;
 use crate::ActorHandle;
+use crate::ActorRef;
 use crate::Address;
 use crate::Proc;
 use crate::ProcAddr;
@@ -419,7 +420,7 @@ impl<M: ProcManager> Host<M> {
         &mut self,
         name: String,
         config: M::Config,
-    ) -> Result<(ProcAddr, reference::ActorRef<ManagerAgent<M>>), HostError> {
+    ) -> Result<(ProcAddr, ActorRef<ManagerAgent<M>>), HostError> {
         if self.procs.contains(&name) {
             return Err(HostError::ProcExists(name));
         }
@@ -918,7 +919,7 @@ impl<M: ProcManager + SingleTerminate> SingleTerminate for Host<M> {
 pub struct ReadyProc<'a, H: ProcHandle> {
     handle: &'a H,
     addr: ChannelAddr,
-    agent_ref: reference::ActorRef<H::Agent>,
+    agent_ref: ActorRef<H::Agent>,
 }
 
 impl<'a, H: ProcHandle> ReadyProc<'a, H> {
@@ -953,7 +954,7 @@ impl<'a, H: ProcHandle> ReadyProc<'a, H> {
     }
 
     /// The agent actor reference (guaranteed available after ready).
-    pub fn agent_ref(&self) -> &reference::ActorRef<H::Agent> {
+    pub fn agent_ref(&self) -> &ActorRef<H::Agent> {
         &self.agent_ref
     }
 }
@@ -1026,7 +1027,7 @@ pub trait ProcHandle: Clone + Send + Sync + 'static {
     ///
     /// **Prefer [`ready_proc()`]** for type-safe access that
     /// guarantees availability at compile time.
-    fn agent_ref(&self) -> Option<reference::ActorRef<Self::Agent>>;
+    fn agent_ref(&self) -> Option<ActorRef<Self::Agent>>;
 
     /// Resolves when the proc becomes Ready. Multi-waiter,
     /// non-consuming.
@@ -1307,7 +1308,7 @@ where
 pub struct LocalHandle<A: Actor + Referable> {
     proc_id: ProcAddr,
     addr: ChannelAddr,
-    agent_ref: reference::ActorRef<A>,
+    agent_ref: ActorRef<A>,
     procs: Arc<Mutex<HashMap<ProcAddr, Proc>>>,
 }
 
@@ -1338,7 +1339,7 @@ impl<A: Actor + Referable> ProcHandle for LocalHandle<A> {
         Some(self.addr.clone())
     }
 
-    fn agent_ref(&self) -> Option<reference::ActorRef<Self::Agent>> {
+    fn agent_ref(&self) -> Option<ActorRef<Self::Agent>> {
         Some(self.agent_ref.clone())
     }
 
@@ -1538,7 +1539,7 @@ impl<A> Drop for ProcessProcManager<A> {
 pub struct ProcessHandle<A: Actor + Referable> {
     proc_id: ProcAddr,
     addr: ChannelAddr,
-    agent_ref: reference::ActorRef<A>,
+    agent_ref: ActorRef<A>,
 }
 
 // Manual `Clone` to avoid requiring `A: Clone`.
@@ -1567,7 +1568,7 @@ impl<A: Actor + Referable> ProcHandle for ProcessHandle<A> {
         Some(self.addr.clone())
     }
 
-    fn agent_ref(&self) -> Option<reference::ActorRef<Self::Agent>> {
+    fn agent_ref(&self) -> Option<ActorRef<Self::Agent>> {
         Some(self.agent_ref.clone())
     }
 
@@ -1732,7 +1733,7 @@ where
     // and call back.
     let (proc_addr, proc_rx) = channel::serve(ChannelAddr::any(backend_transport))?;
     proc.clone().serve(proc_rx);
-    channel::dial(callback_addr)?
+    channel::dial::<(ChannelAddr, ActorRef<A>)>(callback_addr)?
         .send((proc_addr, agent_handle.bind::<A>()))
         .await
         .map_err(ChannelError::from)?;
@@ -1750,7 +1751,8 @@ pub mod testing {
     use crate::ActorAddr;
     use crate::Context;
     use crate::Handler;
-    use crate::reference::OncePortRef;
+    use crate::OncePortRef;
+
     /// Just a simple actor, available in both the bootstrap binary as well as
     /// hyperactor tests.
     #[derive(Debug, Default)]
@@ -1976,7 +1978,7 @@ mod tests {
         let addr = ChannelAddr::any(ChannelTransport::Local);
         let proc_ref = ProcAddr::from_resource_name(addr.clone(), "p");
         let actor_ref = proc_ref.actor_ref("host_agent");
-        let agent_ref = reference::ActorRef::<()>::attest(actor_ref.into());
+        let agent_ref = ActorRef::<()>::attest(actor_ref.into());
         let h = LocalHandle::<()> {
             proc_id: proc_ref,
             addr,
@@ -2009,7 +2011,7 @@ mod tests {
     struct TestHandle {
         id: ProcAddr,
         addr: ChannelAddr,
-        agent: reference::ActorRef<()>,
+        agent: ActorRef<()>,
         mode: ReadyMode,
         omit_addr: bool,
         omit_agent: bool,
@@ -2032,7 +2034,7 @@ mod tests {
             }
         }
 
-        fn agent_ref(&self) -> Option<reference::ActorRef<Self::Agent>> {
+        fn agent_ref(&self) -> Option<ActorRef<Self::Agent>> {
             if self.omit_agent {
                 None
             } else {
@@ -2106,7 +2108,7 @@ mod tests {
             forwarder_addr: ChannelAddr,
             _config: (),
         ) -> Result<Self::Handle, HostError> {
-            let agent = reference::ActorRef::<()>::attest(proc_id.actor_ref("host_agent").into());
+            let agent = ActorRef::<()>::attest(proc_id.actor_ref("host_agent").into());
             Ok(TestHandle {
                 id: proc_id,
                 addr: forwarder_addr,

--- a/hyperactor/src/introspect.rs
+++ b/hyperactor/src/introspect.rs
@@ -133,6 +133,7 @@ use typeuri::Named;
 
 use crate::Address;
 use crate::InstanceCell;
+use crate::OncePortRef;
 use crate::reference;
 
 /// Typed reference to an introspectable entity.
@@ -630,14 +631,14 @@ pub enum IntrospectMessage {
         /// View context - Entity or Actor.
         view: IntrospectView,
         /// Reply port receiving the actor's self-description.
-        reply: reference::OncePortRef<IntrospectResult>,
+        reply: OncePortRef<IntrospectResult>,
     },
     /// "Describe one of your children."
     QueryChild {
         /// Address identifying the child to describe.
         child_ref: reference::Reference,
         /// Reply port receiving the child's description.
-        reply: reference::OncePortRef<IntrospectResult>,
+        reply: OncePortRef<IntrospectResult>,
     },
 }
 wirevalue::register_type!(IntrospectMessage);

--- a/hyperactor/src/mailbox.rs
+++ b/hyperactor/src/mailbox.rs
@@ -142,7 +142,9 @@ use typeuri::Named;
 use crate::ActorAddr;
 use crate::Address;
 // for macros
+use crate::OncePortRef;
 use crate::PortAddr;
+use crate::PortRef;
 use crate::Proc;
 use crate::ProcAddr;
 use crate::accum::Accumulator;
@@ -804,7 +806,7 @@ pub trait PortSender: MailboxSender {
     /// Deliver a message to the provided port.
     fn serialize_and_send<M: RemoteMessage>(
         &self,
-        port: &reference::PortRef<M>,
+        port: &PortRef<M>,
         message: M,
         return_handle: PortHandle<Undeliverable<MessageEnvelope>>,
     ) -> Result<(), MailboxSenderError> {
@@ -826,7 +828,7 @@ pub trait PortSender: MailboxSender {
     /// which is not reusable.
     fn serialize_and_send_once<M: RemoteMessage>(
         &self,
-        once_port: reference::OncePortRef<M>,
+        once_port: OncePortRef<M>,
         message: M,
         return_handle: PortHandle<Undeliverable<MessageEnvelope>>,
     ) -> Result<(), MailboxSenderError> {
@@ -1077,9 +1079,7 @@ pub trait MailboxServer: MailboxSender + Clone + Sized + 'static {
                 ));
                 let sender_id: reference::ActorId = envelope.sender().clone().into();
                 let return_port =
-                    reference::PortRef::<Undeliverable<MessageEnvelope>>::attest_message_port(
-                        &sender_id,
-                    );
+                    PortRef::<Undeliverable<MessageEnvelope>>::attest_message_port(&sender_id);
                 return_port.send_serialized(
                     &client,
                     Flattrs::new(),
@@ -1333,12 +1333,12 @@ impl MailboxSender for MailboxClient {
 /// Wrapper to turn `PortAddr` into a `Sink`.
 pub struct PortSink<C: context::Actor, M: RemoteMessage> {
     cx: C,
-    port: reference::PortRef<M>,
+    port: PortRef<M>,
 }
 
 impl<C: context::Actor, M: RemoteMessage> PortSink<C, M> {
     /// Create new PortSink
-    pub fn new(cx: C, port: reference::PortRef<M>) -> Self {
+    pub fn new(cx: C, port: PortRef<M>) -> Self {
         Self { cx, port }
     }
 }
@@ -1596,7 +1596,7 @@ impl Mailbox {
         self.inner.allocate_port()
     }
 
-    fn bind<M: RemoteMessage>(&self, handle: &PortHandle<M>) -> reference::PortRef<M> {
+    fn bind<M: RemoteMessage>(&self, handle: &PortHandle<M>) -> PortRef<M> {
         assert_eq!(
             handle.mailbox.actor_id(),
             self.actor_id(),
@@ -1616,7 +1616,7 @@ impl Mailbox {
             Entry::Occupied(_entry) => {}
         }
 
-        reference::PortRef::attest(port_ref.into())
+        PortRef::attest(port_ref.into())
     }
 
     fn bind_to_actor_port<M: RemoteMessage>(&self, handle: &PortHandle<M>) {
@@ -1973,14 +1973,14 @@ impl<M: Message> PortHandle<M> {
 
 impl<M: RemoteMessage> PortHandle<M> {
     /// Bind this port, making it accessible to remote actors.
-    pub fn bind(&self) -> reference::PortRef<M> {
+    pub fn bind(&self) -> PortRef<M> {
         let port_ref = {
             let mut guard = self.bound.write().unwrap();
             guard
                 .get_or_insert_with(|| self.mailbox.bind(self).port_id().clone().into())
                 .clone()
         };
-        reference::PortRef::attest_reducible(
+        PortRef::attest_reducible(
             port_ref.into(),
             self.reducer_spec.clone(),
             self.streaming_opts.clone(),
@@ -2073,11 +2073,11 @@ impl<M: RemoteMessage> OncePortHandle<M> {
     /// a remote actor. The remote actor can then use the
     /// ref to send a message to the port. Creating a ref also
     /// binds the port, so that it is remotely writable.
-    pub fn bind(self) -> reference::OncePortRef<M> {
+    pub fn bind(self) -> OncePortRef<M> {
         let port_id: reference::PortId = self.port_id().clone().into();
         let reducer_spec = self.reducer_spec.clone();
         self.mailbox.clone().bind_once(self);
-        reference::OncePortRef::attest_reducible(port_id, reducer_spec)
+        OncePortRef::attest_reducible(port_id, reducer_spec)
     }
 }
 
@@ -3292,7 +3292,7 @@ mod tests {
         let mbox2 = Mailbox::new_detached(test_actor_id("world1_1", "actor0"));
         let mbox3 = Mailbox::new_detached(test_actor_id("world1_1", "actor1"));
 
-        let comms: Vec<(reference::OncePortRef<u64>, OncePortReceiver<u64>)> =
+        let comms: Vec<(OncePortRef<u64>, OncePortReceiver<u64>)> =
             [&mbox0, &mbox1, &mbox2, &mbox3]
                 .into_iter()
                 .map(|mbox| {

--- a/hyperactor/src/message.rs
+++ b/hyperactor/src/message.rs
@@ -39,12 +39,12 @@ use serde::de::DeserializeOwned;
 use typeuri::Named;
 
 // for macros
+use crate::ActorRef;
 use crate::Mailbox;
 use crate::RemoteHandles;
 use crate::RemoteMessage;
 use crate::actor::Referable;
 use crate::context;
-use crate::reference;
 
 /// An object `T` that is [`Unbind`] can extract a set of parameters from itself,
 /// and store in [`Bindings`]. The extracted parameters in [`Bindings`] can be
@@ -243,7 +243,7 @@ impl<M: Bind> IndexedErasedUnbound<M> {
     /// Used in unit tests to bind CastBlobT<M> to the given actor. Do not use in
     /// production.
     pub fn bind_for_test_only<A, C>(
-        actor_ref: reference::ActorRef<A>,
+        actor_ref: ActorRef<A>,
         cx: C,
         mailbox: Mailbox,
     ) -> anyhow::Result<()>
@@ -333,7 +333,9 @@ mod tests {
     use super::*;
     use crate as hyperactor; // for macros
     use crate::Bind;
+    use crate::PortRef;
     use crate::Unbind;
+    use crate::UnboundPort;
     use crate::accum::ReducerSpec;
     use crate::accum::StreamingReducerOpts;
     use crate::testing::ids::test_port_id;
@@ -357,15 +359,15 @@ mod tests {
         arg0: bool,
         arg1: u32,
         #[binding(include)]
-        reply0: reference::PortRef<String>,
+        reply0: PortRef<String>,
         #[binding(include)]
-        reply1: reference::PortRef<MyReply>,
+        reply1: PortRef<MyReply>,
     }
 
     #[test]
     fn test_castable() {
-        let original_port0 = reference::PortRef::attest(test_port_id("world_0", "actor", 123));
-        let original_port1 = reference::PortRef::attest_reducible(
+        let original_port0 = PortRef::attest(test_port_id("world_0", "actor", 123));
+        let original_port1 = PortRef::attest_reducible(
             test_port_id("world_1", "actor1", 456),
             Some(ReducerSpec {
                 typehash: 123,
@@ -391,18 +393,12 @@ mod tests {
                 bindings: Bindings(
                     [
                         (
-                            reference::UnboundPort::typehash(),
-                            wirevalue::Any::serialize(&reference::UnboundPort::from(
-                                &original_port0
-                            ))
-                            .unwrap(),
+                            UnboundPort::typehash(),
+                            wirevalue::Any::serialize(&UnboundPort::from(&original_port0)).unwrap(),
                         ),
                         (
-                            reference::UnboundPort::typehash(),
-                            wirevalue::Any::serialize(&reference::UnboundPort::from(
-                                &original_port1
-                            ))
-                            .unwrap(),
+                            UnboundPort::typehash(),
+                            wirevalue::Any::serialize(&UnboundPort::from(&original_port1)).unwrap(),
                         ),
                     ]
                     .into_iter()
@@ -419,15 +415,15 @@ mod tests {
 
         let mut new_ports = vec![&new_port_id0, &new_port_id1].into_iter();
         erased
-            .visit_mut::<reference::UnboundPort>(|b| {
+            .visit_mut::<UnboundPort>(|b| {
                 let port = new_ports.next().unwrap();
                 b.update(port.clone());
                 Ok(())
             })
             .unwrap();
 
-        let new_port0 = reference::PortRef::<String>::attest(new_port_id0);
-        let new_port1 = reference::PortRef::<MyReply>::attest_reducible(
+        let new_port0 = PortRef::<String>::attest(new_port_id0);
+        let new_port1 = PortRef::<MyReply>::attest_reducible(
             new_port_id1,
             Some(ReducerSpec {
                 typehash: 123,
@@ -438,12 +434,12 @@ mod tests {
         let new_bindings = Bindings(
             [
                 (
-                    reference::UnboundPort::typehash(),
-                    wirevalue::Any::serialize(&reference::UnboundPort::from(&new_port0)).unwrap(),
+                    UnboundPort::typehash(),
+                    wirevalue::Any::serialize(&UnboundPort::from(&new_port0)).unwrap(),
                 ),
                 (
-                    reference::UnboundPort::typehash(),
-                    wirevalue::Any::serialize(&reference::UnboundPort::from(&new_port1)).unwrap(),
+                    UnboundPort::typehash(),
+                    wirevalue::Any::serialize(&UnboundPort::from(&new_port1)).unwrap(),
                 ),
             ]
             .into_iter()

--- a/hyperactor/src/proc.rs
+++ b/hyperactor/src/proc.rs
@@ -134,6 +134,7 @@ use wirevalue::TypeInfo;
 use crate as hyperactor;
 use crate::Actor;
 use crate::ActorAddr;
+use crate::ActorRef;
 use crate::Address;
 use crate::Handler;
 use crate::Message;
@@ -178,6 +179,9 @@ use crate::mailbox::Undeliverable;
 use crate::metrics::ACTOR_MESSAGE_HANDLER_DURATION;
 use crate::metrics::ACTOR_MESSAGE_QUEUE_SIZE;
 use crate::metrics::ACTOR_MESSAGES_RECEIVED;
+use crate::reference::ActorId;
+use crate::reference::PortId;
+use crate::reference::ProcId;
 use crate::subject::AsSubject as _;
 
 /// Returns current epoch-millis from wall clock. Used by
@@ -333,7 +337,6 @@ use crate::ordering::SeqInfo;
 use crate::ordering::Sequencer;
 use crate::ordering::ordered_channel;
 use crate::panic_handler;
-use crate::reference;
 use crate::supervision::ActorSupervisionEvent;
 
 /// This is used to mint new local ranks for [`Proc::local`].
@@ -495,14 +498,14 @@ impl Proc {
         // `return_undeliverable` closes the hazard path in case the
         // envelope ever escapes into the forwarder: it should be
         // dropped, not bounced to the fake sender.
-        let signal_actor_id = reference::ActorId::root(
-            reference::ProcId::from_resource_name(
+        let signal_actor_id = ActorId::root(
+            ProcId::from_resource_name(
                 ChannelAddr::any(channel::ChannelTransport::Local),
                 "attach",
             ),
             crate::id::Label::strip("attach"),
         );
-        let signal_port = reference::PortId::new(signal_actor_id.clone(), 0);
+        let signal_port = PortId::new(signal_actor_id.clone(), 0);
         let mut envelope = MessageEnvelope::serialize(
             signal_actor_id,
             signal_port,
@@ -672,14 +675,14 @@ impl Proc {
     pub fn attach_actor<R, M>(
         &self,
         name: &str,
-    ) -> Result<(Instance<()>, reference::ActorRef<R>, PortReceiver<M>), anyhow::Error>
+    ) -> Result<(Instance<()>, ActorRef<R>, PortReceiver<M>), anyhow::Error>
     where
         M: RemoteMessage,
         R: Referable + RemoteHandles<M>,
     {
         let (instance, _handle) = self.instance(name)?;
         let (_handle, rx) = instance.bind_actor_port::<M>();
-        let actor_ref = reference::ActorRef::attest(instance.self_id().clone().into());
+        let actor_ref = ActorRef::attest(instance.self_id().clone().into());
         Ok((instance, actor_ref, rx))
     }
 
@@ -1201,7 +1204,7 @@ impl Proc {
     ///   `ActorRef<R>`.
     pub fn resolve_actor_ref<R: Actor + Referable>(
         &self,
-        actor_ref: &reference::ActorRef<R>,
+        actor_ref: &ActorRef<R>,
     ) -> Option<ActorHandle<R>> {
         let cell = self.inner.instances.get(actor_ref.actor_id())?.upgrade()?;
         // An actor whose status is terminal has stopped processing
@@ -2413,7 +2416,7 @@ impl<A: Actor> Instance<A> {
     }
 
     /// The owning actor ref.
-    pub fn bind<R: Binds<A>>(&self) -> reference::ActorRef<R> {
+    pub fn bind<R: Binds<A>>(&self) -> ActorRef<R> {
         self.inner.cell.bind(self.inner.ports.as_ref())
     }
 
@@ -3063,7 +3066,7 @@ impl InstanceCell {
 
     /// This is temporary so that we can share binding code between handle and instance.
     /// We should find some (better) way to consolidate the two.
-    pub(crate) fn bind<A: Actor, R: Binds<A>>(&self, ports: &Ports<A>) -> reference::ActorRef<R> {
+    pub(crate) fn bind<A: Actor, R: Binds<A>>(&self, ports: &Ports<A>) -> ActorRef<R> {
         <R as Binds<A>>::bind(ports);
         // Signal: pre-registered via open_message_port() in
         // Instance::new(), handled by the actor loop's select!.
@@ -3084,7 +3087,7 @@ impl InstanceCell {
                 .exported_named_ports
                 .insert(*entry.key(), entry.value());
         }
-        reference::ActorRef::attest(self.actor_id().clone().into())
+        ActorRef::attest(self.actor_id().clone().into())
     }
 
     /// Attempt to downcast this cell to a concrete actor handle.
@@ -3341,6 +3344,8 @@ mod tests {
     use crate as hyperactor;
     use crate::HandleClient;
     use crate::Handler;
+    use crate::OncePortRef;
+    use crate::PortRef;
     use crate::testing::proc_supervison::ProcSupervisionCoordinator;
     use crate::testing::process_assertion::assert_termination;
 
@@ -3585,10 +3590,7 @@ mod tests {
 
     #[derive(Handler, HandleClient, Debug)]
     enum LookupTestMessage {
-        ActorExists(
-            reference::ActorRef<TestActor>,
-            #[reply] reference::OncePortRef<bool>,
-        ),
+        ActorExists(ActorRef<TestActor>, #[reply] OncePortRef<bool>),
     }
 
     #[async_trait]
@@ -3597,7 +3599,7 @@ mod tests {
         async fn actor_exists(
             &mut self,
             cx: &crate::Context<Self>,
-            actor_ref: reference::ActorRef<TestActor>,
+            actor_ref: ActorRef<TestActor>,
         ) -> Result<bool, anyhow::Error> {
             Ok(actor_ref.downcast_handle(cx).is_some())
         }
@@ -3626,7 +3628,7 @@ mod tests {
             !lookup_actor
                 .actor_exists(
                     &client,
-                    reference::ActorRef::attest(target_actor.actor_id().unique_child().into())
+                    ActorRef::attest(target_actor.actor_id().unique_child().into())
                 )
                 .await
                 .unwrap()
@@ -3636,7 +3638,7 @@ mod tests {
             !lookup_actor
                 .actor_exists(
                     &client,
-                    reference::ActorRef::attest(lookup_actor.actor_id().clone().into())
+                    ActorRef::attest(lookup_actor.actor_id().clone().into())
                 )
                 .await
                 .unwrap()
@@ -4011,11 +4013,11 @@ mod tests {
         impl Actor for TestActor {}
 
         #[async_trait]
-        impl Handler<(String, reference::PortRef<String>)> for TestActor {
+        impl Handler<(String, PortRef<String>)> for TestActor {
             async fn handle(
                 &mut self,
                 cx: &crate::Context<Self>,
-                (message, port): (String, reference::PortRef<String>),
+                (message, port): (String, PortRef<String>),
             ) -> anyhow::Result<()> {
                 port.send(cx, message)?;
                 Ok(())
@@ -4529,7 +4531,7 @@ mod tests {
         let (_client, _client_handle) = proc.instance("client").unwrap();
 
         let handle = proc.spawn::<TestActor>("target", TestActor).unwrap();
-        let actor_ref: reference::ActorRef<TestActor> = handle.bind();
+        let actor_ref: ActorRef<TestActor> = handle.bind();
 
         // Actor is live — resolve should succeed.
         assert!(
@@ -4814,7 +4816,7 @@ mod tests {
         let proc = Proc::local();
         let (client, _) = proc.instance("client").unwrap();
         let handle = proc.spawn("qd_test", TestActor).unwrap();
-        let actor_ref: crate::reference::ActorRef<TestActor> = handle.bind();
+        let actor_ref: crate::ActorRef<TestActor> = handle.bind();
         let actor_id = actor_ref.actor_id().clone();
 
         // Before any message: queue depth should be 0.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #3725
* #3724
* #3723
* #3722
* __->__ #3721
* #3720
* #3719
* #3630
* #3629
* #3628
* #3627
* #3626

Move the core hyperactor crate off `reference` for typed capability names. Retarget `ActorRef`, `PortRef`, `OncePortRef`, and `UnboundPort` call sites to the new `ref_` layer, while leaving the remaining `reference::*Id` and `reference::Reference` adapter surface in place for the later semantic cleanup.

Differential Revision: [D102664680](https://our.internmc.facebook.com/intern/diff/D102664680/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D102664680/)!