### PR TITLE
Log seq of dropped messages in multi-stream writer

### DIFF
--- a/hyperactor/src/channel/net.rs
+++ b/hyperactor/src/channel/net.rs
@@ -419,6 +419,13 @@ pub(crate) fn spawn_unordered<M: RemoteMessage>(links: Vec<impl Link + 'static>)
                                     };
                                     let framed = queued.message.clone().framed();
                                     stream.write(framed).drive().await.map_err(|e| {
+                                        tracing::warn!(
+                                            seq,
+                                            %dest,
+                                            stream = i,
+                                            error = %e,
+                                            "multi-stream writer dropped message on write failure",
+                                        );
                                         session::SendLoopError::Io(e.into())
                                     })?;
                                     queued.sent_at = Some(tokio::time::Instant::now());


### PR DESCRIPTION
Summary:
When a multi-stream writer fails to send a message (e.g. connection drops mid-write), the message is consumed from the shared MPMC queue but never inserted into the unacked map — it is permanently lost. Previously this happened silently, making it impossible to diagnose sequence gaps or watermark stalls from logs.

Add a `tracing::warn!` that logs the seq number, destination, stream index, and error when a write failure causes a message to be dropped.

Differential Revision: D103428587


