### PR TITLE
[hyperactor_mesh] assert mesh tests do not leak child processes

### DIFF
--- a/hyperactor_mesh/src/actor_mesh.rs
+++ b/hyperactor_mesh/src/actor_mesh.rs
@@ -993,6 +993,7 @@ mod tests {
     use ndslice::ViewExt;
     use ndslice::extent;
     use ndslice::view::Ranked;
+    use timed_test::assert_no_process_leak;
     use timed_test::async_timed_test;
     use tokio::time::Duration;
 
@@ -1208,8 +1209,9 @@ mod tests {
         let _ = hm.shutdown(instance).await;
     }
 
-    #[async_timed_test(timeout_secs = 30)]
     #[cfg(fbcode_build)]
+    #[assert_no_process_leak]
+    #[async_timed_test(timeout_secs = 30)]
     async fn test_actor_states_with_process_exit() {
         hyperactor_telemetry::initialize_logging_for_test();
 
@@ -1423,8 +1425,9 @@ mod tests {
     ///
     /// This is the V1 version of the test from
     /// hyperactor_multiprocess/src/proc_actor.rs::test_undeliverable_message_return.
-    #[async_timed_test(timeout_secs = 60)]
     #[cfg(fbcode_build)]
+    #[assert_no_process_leak]
+    #[async_timed_test(timeout_secs = 60)]
     async fn test_undeliverable_message_return() {
         use hyperactor::mailbox::MessageEnvelope;
         use hyperactor::mailbox::Undeliverable;

--- a/hyperactor_mesh/src/host_mesh.rs
+++ b/hyperactor_mesh/src/host_mesh.rs
@@ -1724,6 +1724,7 @@ mod tests {
     use hyperactor_config::attrs::Attrs;
     use ndslice::ViewExt;
     use ndslice::extent;
+    use timed_test::assert_no_process_leak;
     use tokio::process::Command;
 
     use super::*;
@@ -1880,8 +1881,9 @@ mod tests {
         );
     }
 
-    #[tokio::test]
     #[cfg(fbcode_build)]
+    #[assert_no_process_leak]
+    #[tokio::test]
     async fn test_halting_proc_allocation() {
         let config = hyperactor_config::global::lock();
         let _guard1 = config.override_key(PROC_SPAWN_MAX_IDLE, Duration::from_secs(20));

--- a/hyperactor_mesh/src/mesh_controller.rs
+++ b/hyperactor_mesh/src/mesh_controller.rs
@@ -1042,6 +1042,7 @@ mod tests {
     use hyperactor::id::Label;
     use ndslice::Extent;
     use ndslice::ViewExt;
+    use timed_test::assert_no_process_leak;
 
     use super::SUPERVISION_POLL_FREQUENCY;
     use super::proc_status_to_actor_status;
@@ -1212,8 +1213,9 @@ mod tests {
     /// and then kills the controller's host process uncleanly.
     /// The agents on the surviving proc mesh detect the expired keepalive
     /// and stop the actors.
-    #[tokio::test]
     #[cfg(fbcode_build)]
+    #[assert_no_process_leak]
+    #[tokio::test]
     async fn test_orphaned_actors_cleaned_up_on_controller_crash() {
         let config = hyperactor_config::global::lock();
         let _orphan = config.override_key(MESH_ORPHAN_TIMEOUT, Duration::from_secs(2));

--- a/hyperactor_mesh/src/proc_mesh.rs
+++ b/hyperactor_mesh/src/proc_mesh.rs
@@ -1031,6 +1031,7 @@ fn python_class_from_supervision_name(sdn: &str) -> Option<String> {
 mod tests {
     use hyperactor::Instance;
     use ndslice::extent;
+    use timed_test::assert_no_process_leak;
     use timed_test::async_timed_test;
 
     use crate::resource::RankedValues;
@@ -1038,8 +1039,9 @@ mod tests {
     use crate::testactor;
     use crate::testing;
 
-    #[async_timed_test(timeout_secs = 30)]
     #[cfg(fbcode_build)]
+    #[assert_no_process_leak]
+    #[async_timed_test(timeout_secs = 30)]
     async fn test_spawn_actor() {
         hyperactor_telemetry::initialize_logging(hyperactor_telemetry::DefaultTelemetryClock {});
 
@@ -1056,8 +1058,9 @@ mod tests {
         let _ = hm.shutdown(instance).await;
     }
 
-    #[tokio::test]
     #[cfg(fbcode_build)]
+    #[assert_no_process_leak]
+    #[tokio::test]
     async fn test_failing_spawn_actor() {
         hyperactor_telemetry::initialize_logging(hyperactor_telemetry::DefaultTelemetryClock {});
 

--- a/hyperactor_mesh/src/testing.rs
+++ b/hyperactor_mesh/src/testing.rs
@@ -10,7 +10,15 @@
 
 //! This module contains common testing utilities.
 
+use std::collections::BTreeMap;
+use std::collections::BTreeSet;
+use std::path::Path;
+use std::sync::Arc;
+use std::sync::Mutex;
 use std::sync::OnceLock;
+use std::sync::atomic::AtomicBool;
+use std::sync::atomic::Ordering;
+use std::time::Duration;
 
 use async_trait::async_trait;
 use hyperactor::Actor;
@@ -35,6 +43,141 @@ use crate::HostMeshRef;
 use crate::host_mesh::HostMesh;
 use crate::host_mesh::HostMeshShutdownGuard;
 use crate::supervision::MeshFailure;
+
+/// Guard that fails the test if it leaves new child processes behind.
+pub struct ChildProcessGuard {
+    baseline: BTreeSet<u32>,
+    observed: Arc<Mutex<BTreeSet<u32>>>,
+    stop_monitor: Arc<AtomicBool>,
+    monitor: Option<std::thread::JoinHandle<()>>,
+}
+
+impl ChildProcessGuard {
+    pub fn new() -> Self {
+        let root_pid = std::process::id();
+        let baseline: BTreeSet<u32> = current_descendant_processes(root_pid)
+            .keys()
+            .copied()
+            .collect();
+        let observed = Arc::new(Mutex::new(BTreeSet::new()));
+        let stop_monitor = Arc::new(AtomicBool::new(false));
+        let monitor_observed = Arc::clone(&observed);
+        let monitor_stop = Arc::clone(&stop_monitor);
+        let monitor_baseline = baseline.clone();
+        let monitor = std::thread::spawn(move || {
+            while !monitor_stop.load(Ordering::Acquire) {
+                record_new_descendants(root_pid, &monitor_baseline, &monitor_observed);
+                std::thread::sleep(Duration::from_millis(50));
+            }
+            record_new_descendants(root_pid, &monitor_baseline, &monitor_observed);
+        });
+
+        Self {
+            baseline,
+            observed,
+            stop_monitor,
+            monitor: Some(monitor),
+        }
+    }
+}
+
+impl Drop for ChildProcessGuard {
+    fn drop(&mut self) {
+        self.stop_monitor.store(true, Ordering::Release);
+        if let Some(monitor) = self.monitor.take() {
+            let _ = monitor.join();
+        }
+
+        record_new_descendants(std::process::id(), &self.baseline, &self.observed);
+        let leaked: BTreeMap<_, _> = self
+            .observed
+            .lock()
+            .expect("child process guard monitor should not panic")
+            .iter()
+            .filter_map(|pid| process_name(*pid).map(|name| (*pid, name)))
+            .collect();
+        if leaked.is_empty() {
+            return;
+        }
+
+        let message = format!("test leaked child processes: {:?}", leaked);
+        if std::thread::panicking() {
+            eprintln!("{message}");
+        } else {
+            panic!("{message}");
+        }
+    }
+}
+
+fn record_new_descendants(
+    root_pid: u32,
+    baseline: &BTreeSet<u32>,
+    observed: &Arc<Mutex<BTreeSet<u32>>>,
+) {
+    let descendants = current_descendant_processes(root_pid);
+    let mut observed = observed
+        .lock()
+        .expect("child process guard monitor should not panic");
+    observed.extend(
+        descendants
+            .keys()
+            .copied()
+            .filter(|pid| !baseline.contains(pid)),
+    );
+}
+
+fn current_descendant_processes(root_pid: u32) -> BTreeMap<u32, String> {
+    let mut descendants = BTreeSet::new();
+    let mut pending = current_child_processes(root_pid);
+    while let Some(pid) = pending.pop_first() {
+        if descendants.insert(pid) {
+            pending.extend(current_child_processes(pid));
+        }
+    }
+
+    descendants
+        .into_iter()
+        .filter_map(|pid| process_name(pid).map(|name| (pid, name)))
+        .collect()
+}
+
+fn current_child_processes(pid: u32) -> BTreeSet<u32> {
+    let mut children = BTreeSet::new();
+    let tasks_path = Path::new("/proc").join(pid.to_string()).join("task");
+    let Ok(tasks) = std::fs::read_dir(tasks_path) else {
+        return children;
+    };
+    for task in tasks.flatten() {
+        let path = task.path().join("children");
+        let Ok(contents) = std::fs::read_to_string(path) else {
+            continue;
+        };
+        children.extend(
+            contents
+                .split_whitespace()
+                .map(|pid| pid.parse::<u32>().expect("child pid should parse")),
+        );
+    }
+
+    children
+}
+
+fn process_name(pid: u32) -> Option<String> {
+    let proc_dir = Path::new("/proc").join(pid.to_string());
+    let cmdline = std::fs::read(proc_dir.join("cmdline")).ok()?;
+    let cmdline = cmdline
+        .split(|byte| *byte == 0)
+        .filter(|arg| !arg.is_empty())
+        .map(|arg| String::from_utf8_lossy(arg))
+        .collect::<Vec<_>>()
+        .join(" ");
+    if !cmdline.is_empty() {
+        return Some(cmdline);
+    }
+    std::fs::read_to_string(proc_dir.join("comm"))
+        .ok()
+        .map(|comm| comm.trim().to_string())
+}
 
 #[derive(Debug)]
 pub struct TestRootClient {

--- a/timed_test/src/lib.rs
+++ b/timed_test/src/lib.rs
@@ -13,6 +13,7 @@ use syn::ItemFn;
 use syn::Lit;
 use syn::MetaNameValue;
 use syn::parse_macro_input;
+use syn::parse_quote;
 
 /// A test macro that wraps tokio::test and adds a configurable timeout.
 ///
@@ -116,4 +117,24 @@ pub fn async_timed_test(attr: TokenStream, input: TokenStream) -> TokenStream {
     };
 
     output.into()
+}
+
+/// Wrap a test body with a Linux child process leak guard.
+///
+/// The crate using this macro must define
+/// `crate::testing::ChildProcessGuard` on Linux.
+#[proc_macro_attribute]
+pub fn assert_no_process_leak(attr: TokenStream, input: TokenStream) -> TokenStream {
+    if !attr.is_empty() {
+        return quote!(compile_error!("assert_no_process_leak does not accept arguments");).into();
+    }
+
+    let mut input_fn = parse_macro_input!(input as ItemFn);
+    let fn_block = input_fn.block;
+    input_fn.block = Box::new(parse_quote!({
+        #[cfg(target_os = "linux")]
+        let _child_process_guard = crate::testing::ChildProcessGuard::new();
+        #fn_block
+    }));
+    quote!(#input_fn).into()
 }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #3729
* #3728

Add a test-only ChildProcessGuard that snapshots existing descendants, monitors newly spawned descendants during the test, and fails on drop if any observed new process remains alive. Add an assert_no_process_leak test attribute and apply it to the subprocess-heavy hyperactor mesh tests.

Differential Revision: [D103450391](https://our.internmc.facebook.com/intern/diff/D103450391/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D103450391/)!