### PR TITLE
undeliverable: dest and RUST_MESSAGE_TYPE fallbacks (#3730)

### DIFF
--- a/hyperactor/src/mailbox.rs
+++ b/hyperactor/src/mailbox.rs
@@ -3732,8 +3732,18 @@ mod tests {
             unreachable!()
         };
         let msg_str = msg.to_string();
-        assert!(msg_str.contains("undeliverable message error"));
-        // Updated assertions for direct format
+        // UE-3 (top-line shape): with no operation context, the top
+        // line names the destination — `undeliverable message to
+        // {dest}`. The retired neutral `undeliverable message error`
+        // wording is no longer emitted.
+        assert!(
+            msg_str.contains("undeliverable message to"),
+            "expected destination-named top line, got:\n{msg_str}"
+        );
+        assert!(
+            !msg_str.contains("undeliverable message error"),
+            "retired neutral fallback must not appear, got:\n{msg_str}"
+        );
         assert!(msg_str.contains("sender:") && msg_str.contains("quux_0"));
         assert!(msg_str.contains("dest:") && msg_str.contains("corge_0"));
 

--- a/hyperactor/src/mailbox/undeliverable.rs
+++ b/hyperactor/src/mailbox/undeliverable.rs
@@ -18,14 +18,33 @@
 //! - **UE-2 (core diagnostics preserved).** The rendered text keeps
 //!   `sender`, `dest`, `message type`, `data_len`, and `error`.
 //!
-//! - **UE-3 (operation context names the top line).** When the
-//!   envelope carries operation-context headers, the top line names
-//!   that operation instead of falling back to the neutral
-//!   `"undeliverable message error"` prefix.
+//! - **UE-3 (top-line shape).** The top line names the operation when
+//!   the envelope carries `OPERATION_ENDPOINT`. Otherwise it names the
+//!   actual failing hop, derived from the variant of
+//!   `UndeliverableMessageError`:
+//!   - `DeliveryFailure` → `"undeliverable message to {dest}"`,
+//!     mirroring the abandonment-log surface in `mailbox.rs`.
+//!   - `ReturnFailure` → `"undeliverable return to original sender
+//!     {sender}"`. Sender/dest in this variant refer to the *original*
+//!     envelope, so headlining `dest` would misstate the failing hop;
+//!     the return-to-sender hop is the one that actually failed.
 //!
-//! - **UE-4 (neutral wording).** Top-line wording remains neutral
-//!   (`"undeliverable message for ..."`); presence of operation
-//!   context does not classify the envelope as request or reply.
+//!   Both shapes only relocate UE-2 stable rendered fields into the
+//!   headline; no unbounded surface is introduced.
+//!
+//! - **UE-4 (neutral wording).** Top-line wording is neutral re.
+//!   request/reply classification. The three shapes — `"undeliverable
+//!   message for {operation} ({adverb})"`, `"undeliverable message to
+//!   {dest}"`, and `"undeliverable return to original sender
+//!   {sender}"` — describe a bounce without claiming send-kind.
+//!
+//! - **UE-5 (message-type fallback).** When wirevalue type resolution
+//!   is unavailable (`envelope.data().typename()` returns `None`), the
+//!   `message type:` field falls back to the stamped
+//!   `RUST_MESSAGE_TYPE` header (planted at every send by the
+//!   `PortHandle`/`PortRef` paths in `mailbox.rs` / `ref_.rs`) before
+//!   rendering the literal `"unknown"`. `"unknown"` is reserved for
+//!   envelopes lacking both.
 
 use std::sync::OnceLock;
 
@@ -46,6 +65,7 @@ use crate::mailbox::PortReceiver;
 use crate::mailbox::UndeliverableMailboxSender;
 use crate::mailbox::headers::OPERATION_ADVERB;
 use crate::mailbox::headers::OPERATION_ENDPOINT;
+use crate::mailbox::headers::RUST_MESSAGE_TYPE;
 
 /// An undeliverable `M`-typed message (in practice `M` is
 /// [MessageEnvelope]).
@@ -153,9 +173,17 @@ pub enum UndeliverableMessageError {
 
 /// Compute the top-line prefix for a bounced envelope (UE-3, UE-4).
 ///
-/// When `OPERATION_ENDPOINT` is present, name the operation;
-/// otherwise fall back to a neutral prefix.
-fn undeliverable_prefix(envelope: &MessageEnvelope) -> String {
+/// When `OPERATION_ENDPOINT` is present, name the operation. Otherwise
+/// name the actual failing hop, which differs between the two variants:
+/// `DeliveryFailure` failed at `sender → dest`, while `ReturnFailure`
+/// failed at the return hop `system → original sender` (sender/dest
+/// in that variant still describe the original envelope, not the
+/// failing return).
+fn undeliverable_prefix(error: &UndeliverableMessageError) -> String {
+    let envelope = match error {
+        UndeliverableMessageError::DeliveryFailure { envelope }
+        | UndeliverableMessageError::ReturnFailure { envelope } => envelope,
+    };
     if let Some(endpoint) = envelope.headers().get(OPERATION_ENDPOINT) {
         let adverb = envelope
             .headers()
@@ -163,7 +191,17 @@ fn undeliverable_prefix(envelope: &MessageEnvelope) -> String {
             .unwrap_or_else(|| "?".to_string());
         return format!("undeliverable message for {} ({})", endpoint, adverb);
     }
-    "undeliverable message error".to_string()
+    match error {
+        UndeliverableMessageError::DeliveryFailure { .. } => {
+            format!("undeliverable message to {}", envelope.dest())
+        }
+        UndeliverableMessageError::ReturnFailure { .. } => {
+            format!(
+                "undeliverable return to original sender {}",
+                envelope.sender()
+            )
+        }
+    }
 }
 
 impl std::fmt::Display for UndeliverableMessageError {
@@ -189,15 +227,20 @@ impl std::fmt::Display for UndeliverableMessageError {
             ),
         };
 
-        writeln!(f, "{}:", undeliverable_prefix(envelope))?;
+        writeln!(f, "{}:", undeliverable_prefix(self))?;
         writeln!(f, "\tdescription: {}", description)?;
         writeln!(f, "\t{}: {}", sender_label, envelope.sender())?;
         writeln!(f, "\t{}: {}", dest_label, envelope.dest())?;
-        writeln!(
-            f,
-            "\tmessage type: {}",
-            envelope.data().typename().unwrap_or("unknown")
-        )?;
+        // UE-5: prefer the wirevalue-resolved typename; fall back to
+        // the static `RUST_MESSAGE_TYPE` stamped at send time before
+        // resorting to the literal "unknown".
+        let message_type = envelope
+            .data()
+            .typename()
+            .map(|s| s.to_string())
+            .or_else(|| envelope.headers().get(RUST_MESSAGE_TYPE))
+            .unwrap_or_else(|| "unknown".to_string());
+        writeln!(f, "\tmessage type: {}", message_type)?;
         writeln!(f, "\tdata_len: {}", envelope.data().len())?;
         writeln!(
             f,
@@ -332,19 +375,116 @@ mod tests {
         );
     }
 
-    /// UE-3 / UE-4: envelope with no operation context falls back to
-    /// the neutral prefix.
+    /// UE-3: `DeliveryFailure` with no operation context falls back to
+    /// naming the destination (the actual failing hop), mirroring the
+    /// abandonment-log surface in `mailbox.rs`.
     #[test]
-    fn test_ue3_no_context_neutral_prefix() {
+    fn test_ue3_delivery_failure_no_context_names_destination() {
         let envelope = make_envelope("payload", Flattrs::new());
+        let dest_str = envelope.dest().to_string();
+        let rendered = format!(
+            "{}",
+            UndeliverableMessageError::DeliveryFailure { envelope }
+        );
+
+        let expected_prefix = format!("undeliverable message to {}", dest_str);
+        assert!(
+            rendered.starts_with(&expected_prefix),
+            "UE-3: delivery failure no context → destination prefix `{expected_prefix}`, got:\n{rendered}"
+        );
+        // The retired neutral wording must not return.
+        assert!(
+            !rendered.contains("undeliverable message error"),
+            "UE-3: neutral fallback must not be re-introduced, got:\n{rendered}"
+        );
+    }
+
+    /// UE-3: `ReturnFailure` with no operation context names the
+    /// original sender, because in this variant `sender`/`dest` refer
+    /// to the original envelope and the actual failing hop is
+    /// `system → original sender`. Headlining `dest` here would
+    /// misstate the failure.
+    #[test]
+    fn test_ue3_return_failure_no_context_names_original_sender() {
+        let envelope = make_envelope("payload", Flattrs::new());
+        let sender_str = envelope.sender().to_string();
+        let dest_str = envelope.dest().to_string();
+        let rendered = format!("{}", UndeliverableMessageError::ReturnFailure { envelope });
+
+        let expected_prefix = format!("undeliverable return to original sender {}", sender_str);
+        assert!(
+            rendered.starts_with(&expected_prefix),
+            "UE-3: return failure no context → original-sender prefix `{expected_prefix}`, got:\n{rendered}"
+        );
+        // Must not headline the original destination — the failing hop
+        // is the return to the original sender, not the original
+        // delivery.
+        assert!(
+            !rendered.starts_with(&format!("undeliverable message to {}", dest_str)),
+            "UE-3: return failure must not headline the original destination, got:\n{rendered}"
+        );
+        // The retired neutral wording must not return.
+        assert!(
+            !rendered.contains("undeliverable message error"),
+            "UE-3: neutral fallback must not be re-introduced, got:\n{rendered}"
+        );
+    }
+
+    /// UE-5: when wirevalue type resolution is unavailable
+    /// (`typename()` is `None`), the formatter falls back to the
+    /// static `RUST_MESSAGE_TYPE` stamped at send time.
+    #[test]
+    fn test_ue5_message_type_falls_back_to_rust_message_type() {
+        // `Any::new_broken()` carries `BROKEN_TYPEHASH` (0), which is
+        // not in the wirevalue type registry, so `typename()` is None.
+        // Mirrors the `test_broken_any` pattern in wirevalue itself.
+        let sender = test_actor_id("ue_proc", "ue_sender");
+        let dest = test_port_id("ue_dest_proc", "ue_dest", 42);
+        let mut headers = Flattrs::new();
+        headers.set(RUST_MESSAGE_TYPE, "my::Foo".to_string());
+        let envelope = MessageEnvelope::new(sender, dest, wirevalue::Any::new_broken(), headers);
+        assert!(
+            envelope.data().typename().is_none(),
+            "test fixture invariant: broken Any must have no typename()"
+        );
+
         let rendered = format!(
             "{}",
             UndeliverableMessageError::DeliveryFailure { envelope }
         );
 
         assert!(
-            rendered.starts_with("undeliverable message error:"),
-            "UE-3: no context → neutral prefix, got:\n{rendered}"
+            rendered.contains("\tmessage type: my::Foo\n"),
+            "UE-5: must surface RUST_MESSAGE_TYPE when typename() is absent, got:\n{rendered}"
+        );
+        assert!(
+            !rendered.contains("\tmessage type: unknown"),
+            "UE-5: must not render \"unknown\" when RUST_MESSAGE_TYPE is present, got:\n{rendered}"
+        );
+    }
+
+    /// UE-5 (negative): when both `typename()` and `RUST_MESSAGE_TYPE`
+    /// are absent, the formatter falls all the way through to the
+    /// literal `"unknown"`.
+    #[test]
+    fn test_ue5_unknown_when_typename_and_rust_message_type_both_absent() {
+        let sender = test_actor_id("ue_proc", "ue_sender");
+        let dest = test_port_id("ue_dest_proc", "ue_dest", 42);
+        let envelope =
+            MessageEnvelope::new(sender, dest, wirevalue::Any::new_broken(), Flattrs::new());
+        assert!(
+            envelope.data().typename().is_none(),
+            "test fixture invariant: broken Any must have no typename()"
+        );
+
+        let rendered = format!(
+            "{}",
+            UndeliverableMessageError::DeliveryFailure { envelope }
+        );
+
+        assert!(
+            rendered.contains("\tmessage type: unknown\n"),
+            "UE-5: with no typename and no RUST_MESSAGE_TYPE, must render \"unknown\", got:\n{rendered}"
         );
     }
 }

--- a/python/tests/test_actor_error.py
+++ b/python/tests/test_actor_error.py
@@ -1049,8 +1049,16 @@ async def test_supervision_with_sending_error() -> None:
     # This would require Undeliverable to know about a specific return channel.
     assert "MeshFailure" in error_msg
     assert "RootClientActor" in error_msg
+    # Top line is one of:
+    #   `undeliverable message to {dest}` (DeliveryFailure, no
+    #     OPERATION_ENDPOINT — see UE-3 in
+    #     hyperactor/src/mailbox/undeliverable.rs).
+    #   `undeliverable message for {operation} ({adverb})`
+    #     (when OPERATION_ENDPOINT is present).
+    # Both are valid here: pending messages of mixed shapes flush back
+    # to the client when the receiver session breaks. Match either.
     assert re.search(
-        "undeliverable message error.*client.*",
+        r"undeliverable message (to|for) .*client",
         error_msg,
         flags=re.DOTALL,
     )


### PR DESCRIPTION
Summary:

this diff improves the undeliverable formatter for internal/control-plane failures where no OPERATION_ENDPOINT is present. instead of the neutral top line undeliverable message error, it now falls back to naming the failing hop destination, mirroring the existing abandonment-log surface. it also fills the message type field from the stamped RUST_MESSAGE_TYPE header on the same internal-send paths when the wire bytes don't carry a resolvable wirevalue type tag, so internal sends no longer collapse to unknown when the static Rust type was known at send time..

the motivating production case was a bounce to host_agent.service that rendered as a generic undeliverable with message type: unknown. after this change, the same class of failure surfaces as undeliverable message to <dest> with the static Rust message type populated, which makes bootstrap/control-plane triage much more direct without adding new stamp sites or expanding the OPERATION_* vocabulary.

Reviewed By: thedavekwon

Differential Revision: D103466076


