### PR TITLE
Add flow events to show rpc correlation (#3731)

### DIFF
--- a/monarch_hyperactor/src/actor.rs
+++ b/monarch_hyperactor/src/actor.rs
@@ -158,9 +158,11 @@ pub struct AccumulatedResponses(ValueOverlay<PythonResponseMessage>);
 #[pyclass(module = "monarch._rust_bindings.monarch_hyperactor.actor")]
 #[derive(Clone, Debug, Serialize, Deserialize, Named, PartialEq)]
 pub enum PythonMessageKind {
+    #[pyo3(constructor = (name, response_port, correlation_id=None))]
     CallMethod {
         name: MethodSpecifier,
         response_port: Option<EitherPortRef>,
+        correlation_id: Option<u64>,
     },
     Result {
         rank: Option<usize>,
@@ -304,6 +306,7 @@ struct ResolvedCallMethod {
     /// Implements PortProtocol
     /// Concretely either a Port, DroppingPort, or LocalPort
     response_port: ResponsePort,
+    correlation_id: Option<u64>,
 }
 
 enum ResponsePort {
@@ -336,6 +339,8 @@ pub struct QueuedMessage {
     pub local_state: Py<PyAny>,
     #[pyo3(get)]
     pub response_port: Py<PyAny>,
+    #[pyo3(get)]
+    pub correlation_id: Option<u64>,
 }
 
 impl PythonMessage {
@@ -404,6 +409,7 @@ impl PythonMessage {
                         },
                         local_state,
                         response_port,
+                        correlation_id: None,
                     })
                 })
                 .await
@@ -411,6 +417,7 @@ impl PythonMessage {
             PythonMessageKind::CallMethod {
                 name,
                 response_port,
+                correlation_id,
             } => {
                 let method_name = name.name().to_string();
                 let response_port = response_port.map_or(ResponsePort::Dropping, |port_ref| {
@@ -448,6 +455,7 @@ impl PythonMessage {
                     },
                     local_state: None,
                     response_port,
+                    correlation_id,
                 })
             }
             _ => {
@@ -672,6 +680,7 @@ impl PythonActor {
             PythonMessageKind::CallMethod {
                 name: MethodSpecifier::Init {},
                 response_port: None,
+                correlation_id: None,
             },
             init_frozen_buffer,
         );
@@ -1281,6 +1290,9 @@ impl PythonActor {
                 inst.into_pyobject(py).unwrap().into()
             });
 
+            let correlation_id_py = resolved
+                .correlation_id
+                .map_or_else(|| py.None(), |id| id.into_pyobject(py).unwrap().into());
             let awaitable = self.actor.call_method(
                 py,
                 "handle",
@@ -1295,6 +1307,7 @@ impl PythonActor {
                         .local_state
                         .unwrap_or_else(|| PyList::empty(py).unbind().into()),
                     resolved.response_port.into_py_any(py)?,
+                    correlation_id_py,
                 ),
                 None,
             )?;
@@ -1347,6 +1360,7 @@ impl PythonActor {
                     .local_state
                     .unwrap_or_else(|| PyList::empty(py).unbind().into()),
                 response_port: resolved.response_port.into_py_any(py)?,
+                correlation_id: resolved.correlation_id,
             })
         })
         .await?;
@@ -1805,6 +1819,7 @@ mod tests {
                     name: "test".to_string(),
                 },
                 response_port: Some(EitherPortRef::Unbounded(port_ref.clone().into())),
+                correlation_id: None,
             },
             message: Part::from(vec![1, 2, 3]),
         };
@@ -1828,6 +1843,7 @@ mod tests {
                     name: "test".to_string(),
                 },
                 response_port: None,
+                correlation_id: None,
             },
             ..message
         };

--- a/monarch_hyperactor/src/endpoint.rs
+++ b/monarch_hyperactor/src/endpoint.rs
@@ -100,6 +100,7 @@ pub(crate) enum EndpointAdverb {
     CallOne,
     Choose,
     Stream,
+    Broadcast,
 }
 
 impl EndpointAdverb {
@@ -109,6 +110,7 @@ impl EndpointAdverb {
             Self::CallOne => "call_one",
             Self::Choose => "choose",
             Self::Stream => "stream",
+            Self::Broadcast => "broadcast",
         }
     }
 }
@@ -145,8 +147,8 @@ impl RecordEndpointGuard {
             EndpointAdverb::Choose => {
                 ENDPOINT_CHOOSE_THROUGHPUT.add(1, attributes);
             }
-            EndpointAdverb::Stream => {
-                // Throughput already recorded once at stream creation in py_stream_collector
+            EndpointAdverb::Stream | EndpointAdverb::Broadcast => {
+                // Throughput already recorded at the call site
             }
         }
 
@@ -187,6 +189,7 @@ impl Drop for RecordEndpointGuard {
             EndpointAdverb::Stream => {
                 ENDPOINT_STREAM_LATENCY_US_HISTOGRAM.record(duration_us as f64, attributes);
             }
+            EndpointAdverb::Broadcast => {}
         }
 
         if self.error_occurred.get() {
@@ -203,6 +206,7 @@ impl Drop for RecordEndpointGuard {
                 EndpointAdverb::Stream => {
                     ENDPOINT_STREAM_ERROR.add(1, attributes);
                 }
+                EndpointAdverb::Broadcast => {}
             }
         }
     }
@@ -219,7 +223,13 @@ pub(crate) struct SpanGuard {
 }
 
 impl SpanGuard {
-    fn actor_endpoint(name: &'static str, actor_id: &ActorAddr, mesh: &str, method: &str) -> Self {
+    fn actor_endpoint(
+        name: &'static str,
+        actor_id: &ActorAddr,
+        mesh: &str,
+        method: &str,
+        correlation_id: u64,
+    ) -> Self {
         Self {
             id: hyperactor_telemetry::start_user_span(
                 name,
@@ -239,12 +249,21 @@ impl SpanGuard {
                         "method",
                         hyperactor_telemetry::trace_dispatcher::FieldValue::Str(method.to_string()),
                     ),
+                    (
+                        "correlation_id",
+                        hyperactor_telemetry::trace_dispatcher::FieldValue::U64(correlation_id),
+                    ),
                 ],
             ),
         }
     }
 
-    fn remote(name: &'static str, actor_id: &ActorAddr, call_name: &str) -> Self {
+    fn remote(
+        name: &'static str,
+        actor_id: &ActorAddr,
+        call_name: &str,
+        correlation_id: u64,
+    ) -> Self {
         Self {
             id: hyperactor_telemetry::start_user_span(
                 name,
@@ -261,6 +280,10 @@ impl SpanGuard {
                         hyperactor_telemetry::trace_dispatcher::FieldValue::Str(
                             call_name.to_string(),
                         ),
+                    ),
+                    (
+                        "correlation_id",
+                        hyperactor_telemetry::trace_dispatcher::FieldValue::U64(correlation_id),
                     ),
                 ],
             ),
@@ -579,6 +602,7 @@ pub(crate) trait Endpoint {
         port_ref: Option<EitherPortRef>,
         selection: Selection,
         instance: &Instance<PythonActor>,
+        correlation_id: Option<u64>,
     ) -> PyResult<()>;
 
     /// Like `send_message` but stamps `caller_headers` onto the
@@ -594,8 +618,17 @@ pub(crate) trait Endpoint {
         selection: Selection,
         instance: &Instance<PythonActor>,
         _caller_headers: hyperactor_config::Flattrs,
+        correlation_id: Option<u64>,
     ) -> PyResult<()> {
-        self.send_message(py, args, kwargs, port_ref, selection, instance)
+        self.send_message(
+            py,
+            args,
+            kwargs,
+            port_ref,
+            selection,
+            instance,
+            correlation_id,
+        )
     }
 
     /// Build the operation-context envelope headers to stamp on an
@@ -607,12 +640,7 @@ pub(crate) trait Endpoint {
         &self,
         adverb: EndpointAdverb,
     ) -> hyperactor_config::Flattrs {
-        let adverb_str = match adverb {
-            EndpointAdverb::Call => "call",
-            EndpointAdverb::CallOne => "call_one",
-            EndpointAdverb::Choose => "choose",
-            EndpointAdverb::Stream => "stream",
-        };
+        let adverb_str = adverb.as_str();
         let attrs = crate::operation_context::build_operation_context_attrs(
             self.get_qualified_name(),
             Some(adverb_str),
@@ -634,7 +662,12 @@ pub(crate) trait Endpoint {
     /// for Remote) and route the slice to an actor-specific track. The adverb is the span name,
     /// so no formatting happens at the call site and the sink formats only when
     /// it renders the slice.
-    fn enter_endpoint_span(&self, adverb: EndpointAdverb, actor_id: &ActorAddr) -> SpanGuard;
+    fn enter_endpoint_span(
+        &self,
+        adverb: EndpointAdverb,
+        actor_id: &ActorAddr,
+        correlation_id: u64,
+    ) -> SpanGuard;
 
     fn get_current_instance(&self, py: Python<'_>) -> PyResult<Instance<PythonActor>> {
         let context = get_context(py).call0()?;
@@ -668,7 +701,9 @@ pub(crate) trait Endpoint {
         kwargs: Option<&Bound<'py, PyDict>>,
     ) -> PyResult<Py<PyAny>> {
         let instance = self.get_current_instance(py)?;
-        let span_guard = self.enter_endpoint_span(EndpointAdverb::Call, instance.self_id());
+        let correlation_id: u64 = fastrand::u64(..);
+        let span_guard =
+            self.enter_endpoint_span(EndpointAdverb::Call, instance.self_id(), correlation_id);
 
         let extent = self.get_extent(py)?;
         let method_name = self.get_method_name().to_string();
@@ -686,6 +721,7 @@ pub(crate) trait Endpoint {
             sel!(*),
             &instance,
             caller_headers,
+            Some(correlation_id),
         )?;
 
         let instance_for_task = instance.clone_for_py();
@@ -714,7 +750,9 @@ pub(crate) trait Endpoint {
         kwargs: Option<&Bound<'py, PyDict>>,
     ) -> PyResult<Py<PyAny>> {
         let instance = self.get_current_instance(py)?;
-        let span_guard = self.enter_endpoint_span(EndpointAdverb::Choose, instance.self_id());
+        let correlation_id: u64 = fastrand::u64(..);
+        let span_guard =
+            self.enter_endpoint_span(EndpointAdverb::Choose, instance.self_id(), correlation_id);
         let (port_ref, receiver) = self.open_response_port(&instance);
 
         let caller_headers = self.build_operation_context_headers(EndpointAdverb::Choose);
@@ -726,6 +764,7 @@ pub(crate) trait Endpoint {
             sel!(?),
             &instance,
             caller_headers,
+            Some(correlation_id),
         )?;
 
         let task = value_collector(
@@ -758,7 +797,9 @@ pub(crate) trait Endpoint {
         }
 
         let instance = self.get_current_instance(py)?;
-        let span_guard = self.enter_endpoint_span(EndpointAdverb::CallOne, instance.self_id());
+        let correlation_id: u64 = fastrand::u64(..);
+        let span_guard =
+            self.enter_endpoint_span(EndpointAdverb::CallOne, instance.self_id(), correlation_id);
         let (port_ref, receiver) = self.open_response_port(&instance);
 
         let caller_headers = self.build_operation_context_headers(EndpointAdverb::CallOne);
@@ -770,6 +811,7 @@ pub(crate) trait Endpoint {
             sel!(*),
             &instance,
             caller_headers,
+            Some(correlation_id),
         )?;
 
         let task = value_collector(
@@ -798,6 +840,7 @@ pub(crate) trait Endpoint {
         let instance = self.get_current_instance(py)?;
         let (port_ref, receiver) = self.open_response_port(&instance);
 
+        let correlation_id: u64 = fastrand::u64(..);
         let caller_headers = self.build_operation_context_headers(EndpointAdverb::Stream);
         self.send_message_with_headers(
             py,
@@ -807,6 +850,7 @@ pub(crate) trait Endpoint {
             sel!(*),
             &instance,
             caller_headers,
+            Some(correlation_id),
         )?;
 
         let actor_count = extent.num_ranks();
@@ -843,12 +887,27 @@ pub(crate) trait Endpoint {
         kwargs: Option<&Bound<'py, PyDict>>,
     ) -> PyResult<()> {
         let instance = self.get_current_instance(py)?;
+        let correlation_id: u64 = fastrand::u64(..);
+        let _span_guard = self.enter_endpoint_span(
+            EndpointAdverb::Broadcast,
+            instance.self_id(),
+            correlation_id,
+        );
+
         let method_name = self.get_method_name();
         let attributes = hyperactor_telemetry::kv_pairs!(
             "method" => method_name.to_string()
         );
 
-        match self.send_message(py, args, kwargs, None, sel!(*), &instance) {
+        match self.send_message(
+            py,
+            args,
+            kwargs,
+            None,
+            sel!(*),
+            &instance,
+            Some(correlation_id),
+        ) {
             Ok(()) => {
                 ENDPOINT_BROADCAST_THROUGHPUT.add(1, attributes);
                 Ok(())
@@ -882,6 +941,7 @@ impl ActorEndpoint {
         args: &Bound<'py, PyTuple>,
         kwargs: Option<&Bound<'py, PyDict>>,
         port_ref: Option<EitherPortRef>,
+        correlation_id: Option<u64>,
     ) -> PyResult<PendingMessage> {
         let port_ref_py: Py<PyAny> = match port_ref {
             Some(pr) => pr.clone().into_pyobject(py)?.unbind(),
@@ -901,6 +961,7 @@ impl ActorEndpoint {
             self.proc_mesh
                 .as_ref()
                 .map_or_else(|| py.None(), |p| p.clone_ref(py)),
+            correlation_id,
         ))?;
         let mut pending: PyRefMut<'_, PendingMessage> = result.extract()?;
         pending.take()
@@ -924,8 +985,9 @@ impl Endpoint for ActorEndpoint {
         port_ref: Option<EitherPortRef>,
         selection: Selection,
         instance: &Instance<PythonActor>,
+        correlation_id: Option<u64>,
     ) -> PyResult<()> {
-        let message = self.create_message(py, args, kwargs, port_ref)?;
+        let message = self.create_message(py, args, kwargs, port_ref, correlation_id)?;
         self.inner.cast_unresolved(message, selection, instance)
     }
 
@@ -938,8 +1000,9 @@ impl Endpoint for ActorEndpoint {
         selection: Selection,
         instance: &Instance<PythonActor>,
         caller_headers: hyperactor_config::Flattrs,
+        correlation_id: Option<u64>,
     ) -> PyResult<()> {
-        let message = self.create_message(py, args, kwargs, port_ref)?;
+        let message = self.create_message(py, args, kwargs, port_ref, correlation_id)?;
         self.inner
             .cast_unresolved_with_headers(message, selection, instance, caller_headers)
     }
@@ -952,10 +1015,15 @@ impl Endpoint for ActorEndpoint {
         Some(format!("{}.{}()", self.mesh_name, self.method.name()))
     }
 
-    fn enter_endpoint_span(&self, adverb: EndpointAdverb, actor_id: &ActorAddr) -> SpanGuard {
+    fn enter_endpoint_span(
+        &self,
+        adverb: EndpointAdverb,
+        actor_id: &ActorAddr,
+        correlation_id: u64,
+    ) -> SpanGuard {
         let mesh = self.mesh_name.as_str();
         let method = self.method.name();
-        SpanGuard::actor_endpoint(adverb.as_str(), actor_id, mesh, method)
+        SpanGuard::actor_endpoint(adverb.as_str(), actor_id, mesh, method, correlation_id)
     }
 }
 
@@ -1150,7 +1218,16 @@ impl ActorEndpoint {
     ) -> PyResult<()> {
         let instance = self.get_current_instance(py)?;
         let sel = to_hy_sel(selection)?;
-        self.send_message(py, args, Some(kwargs), port, sel, &instance)
+        let correlation_id: u64 = fastrand::u64(..);
+        self.send_message(
+            py,
+            args,
+            Some(kwargs),
+            port,
+            sel,
+            &instance,
+            Some(correlation_id),
+        )
     }
 }
 
@@ -1185,6 +1262,7 @@ impl Endpoint for Remote {
         port_ref: Option<EitherPortRef>,
         selection: Selection,
         _instance: &Instance<PythonActor>,
+        _correlation_id: Option<u64>,
     ) -> PyResult<()> {
         let send_kwargs = PyDict::new(py);
         match port_ref {
@@ -1217,7 +1295,12 @@ impl Endpoint for Remote {
         None // Remote endpoints don't have qualified names
     }
 
-    fn enter_endpoint_span(&self, adverb: EndpointAdverb, actor_id: &ActorAddr) -> SpanGuard {
+    fn enter_endpoint_span(
+        &self,
+        adverb: EndpointAdverb,
+        actor_id: &ActorAddr,
+        correlation_id: u64,
+    ) -> SpanGuard {
         let call_name = Python::attach(|py| {
             self.inner
                 .call_method0(py, "_call_name")
@@ -1225,7 +1308,7 @@ impl Endpoint for Remote {
                 .and_then(|v| v.extract::<String>(py).ok())
         });
         let call_name = call_name.as_deref().unwrap_or("");
-        SpanGuard::remote(adverb.as_str(), actor_id, call_name)
+        SpanGuard::remote(adverb.as_str(), actor_id, call_name, correlation_id)
     }
 }
 
@@ -1496,6 +1579,7 @@ mod tests {
             _port_ref: Option<EitherPortRef>,
             _selection: Selection,
             _instance: &Instance<PythonActor>,
+            _correlation_id: Option<u64>,
         ) -> PyResult<()> {
             unreachable!()
         }
@@ -1505,7 +1589,12 @@ mod tests {
         fn get_qualified_name(&self) -> Option<String> {
             self.qualified_name.clone()
         }
-        fn enter_endpoint_span(&self, _adverb: EndpointAdverb, _actor_id: &ActorAddr) -> SpanGuard {
+        fn enter_endpoint_span(
+            &self,
+            _adverb: EndpointAdverb,
+            _actor_id: &ActorAddr,
+            _correlation_id: u64,
+        ) -> SpanGuard {
             unreachable!()
         }
     }

--- a/monarch_hyperactor/src/proc_launcher.rs
+++ b/monarch_hyperactor/src/proc_launcher.rs
@@ -695,6 +695,7 @@ impl ProcLauncher for ActorProcLauncher {
                     name: "launch".into(),
                 },
                 response_port: Some(EitherPortRef::Once(PythonOncePortRef::from(bound_port))),
+                correlation_id: None,
             },
             message: pickled_args.into(),
         };
@@ -779,6 +780,7 @@ impl ProcLauncher for ActorProcLauncher {
                     name: "terminate".into(),
                 },
                 response_port: None,
+                correlation_id: None,
             },
             message: pickled.into(),
         };
@@ -820,6 +822,7 @@ impl ProcLauncher for ActorProcLauncher {
                     name: "kill".into(),
                 },
                 response_port: None,
+                correlation_id: None,
             },
             message: pickled.into(),
         };

--- a/monarch_hyperactor/src/proc_launcher_probe.rs
+++ b/monarch_hyperactor/src/proc_launcher_probe.rs
@@ -124,6 +124,7 @@ pub(crate) fn probe_exit_port_via_mesh(
             name: method_name.clone(),
         },
         response_port: Some(EitherPortRef::Once(PythonOncePortRef::from(bound_port))),
+        correlation_id: None,
     };
 
     // Create a PendingMessage using py_new which takes PyRefMut

--- a/monarch_hyperactor/src/telemetry.rs
+++ b/monarch_hyperactor/src/telemetry.rs
@@ -253,11 +253,14 @@ struct PySpan {
 #[pymethods]
 impl PySpan {
     #[new]
-    #[pyo3(signature = (name, actor_id = None))]
-    fn new(name: &str, actor_id: Option<&PyActorAddr>) -> Self {
+    #[pyo3(signature = (name, actor_id = None, correlation_id = None))]
+    fn new(name: &str, actor_id: Option<&PyActorAddr>, correlation_id: Option<u64>) -> Self {
         let mut fields = vec![("name", FieldValue::Str(name.to_string()))];
         if let Some(actor_id) = actor_id {
             fields.push(("actor_id", FieldValue::Str(actor_id.inner.to_string())));
+        }
+        if let Some(cid) = correlation_id {
+            fields.push(("correlation_id", FieldValue::U64(cid)));
         }
         let id = start_user_span("python_user_span", USER_TELEMETRY_PREFIX, fields);
 

--- a/monarch_perfetto_trace/src/local.rs
+++ b/monarch_perfetto_trace/src/local.rs
@@ -21,6 +21,8 @@
 //! │   └── latest -> {execution_id}/   # symlink to most recent
 //! ```
 
+use std::collections::HashMap;
+use std::collections::HashSet;
 use std::fs;
 use std::io::Read;
 use std::io::Write;
@@ -34,7 +36,9 @@ use prost::Message;
 use tracing::info;
 use tracing_perfetto_sdk_schema::Trace;
 use tracing_perfetto_sdk_schema::TracePacket;
+use tracing_perfetto_sdk_schema::TrackEvent;
 use tracing_perfetto_sdk_schema::trace_packet::Data;
+use tracing_perfetto_sdk_schema::track_event::Type as TrackEventType;
 
 use crate::Sink;
 
@@ -314,9 +318,130 @@ pub fn merge_to_file(
     let edir = execution_dir(&tdir, Some(&exec_id))?;
     info!("Reading from execution: {}", edir.display());
 
+    let mut buffer = VecSink::default();
+    merge_traces_from_dir(&edir, &mut buffer)?;
+    inject_correlation_flows(&mut buffer.packets);
+
     let mut sink = Collector::new(output);
-    merge_traces_from_dir(&edir, &mut sink)?;
+    for packet in buffer.packets {
+        sink.consume(packet);
+    }
     sink.flush()?;
 
     Ok(exec_id)
+}
+
+/// Collects packets into a Vec for post-processing before writing.
+#[derive(Default)]
+struct VecSink {
+    packets: Vec<TracePacket>,
+}
+
+impl Sink for VecSink {
+    fn consume(&mut self, packet: TracePacket) {
+        self.packets.push(packet);
+    }
+}
+
+const CORRELATION_ID_ANNOTATION: &str = "correlation_id";
+
+fn build_annotation_name_table(packets: &[TracePacket]) -> HashMap<u64, String> {
+    let mut table = HashMap::new();
+    for packet in packets {
+        if let Some(ref interned) = packet.interned_data {
+            for dan in &interned.debug_annotation_names {
+                if let (Some(iid), Some(name)) = (dan.iid, &dan.name) {
+                    table.insert(iid, name.clone());
+                }
+            }
+        }
+    }
+    table
+}
+
+fn get_annotation_u64(
+    te: &TrackEvent,
+    name: &str,
+    interned_names: &HashMap<u64, String>,
+) -> Option<u64> {
+    te.debug_annotations.iter().find_map(|ann| {
+        let matches = match &ann.name_field {
+            Some(tracing_perfetto_sdk_schema::debug_annotation::NameField::Name(n)) => n == name,
+            Some(tracing_perfetto_sdk_schema::debug_annotation::NameField::NameIid(iid)) => {
+                interned_names.get(iid).is_some_and(|n| n == name)
+            }
+            _ => false,
+        };
+        if matches {
+            match &ann.value {
+                Some(tracing_perfetto_sdk_schema::debug_annotation::Value::IntValue(v)) => {
+                    Some(*v as u64)
+                }
+                _ => None,
+            }
+        } else {
+            None
+        }
+    })
+}
+
+fn is_slice_begin(te: &TrackEvent) -> bool {
+    te.r#type == Some(TrackEventType::SliceBegin as i32)
+}
+
+/// Scans merged trace packets for correlation_id annotations and injects
+/// Perfetto flow events to draw arrows from sender to receiver spans.
+///
+/// A "sender" is a SliceBegin with a correlation_id that appears exactly
+/// once for that ID (the endpoint span). All other SliceBegins sharing
+/// that correlation_id are "receivers".
+///
+/// Pass 1: count how many receivers exist per correlation_id.
+/// Pass 2: stamp `flow_ids` on senders (one per receiver) and
+///          `terminating_flow_ids` on receivers (sequential offset).
+fn inject_correlation_flows(packets: &mut [TracePacket]) {
+    let interned_names = build_annotation_name_table(packets);
+
+    let mut counts: HashMap<u64, usize> = HashMap::new();
+    let mut sender_cids: HashSet<u64> = HashSet::new();
+
+    for packet in packets.iter() {
+        let Some(Data::TrackEvent(te)) = &packet.data else {
+            continue;
+        };
+        if !is_slice_begin(te) {
+            continue;
+        }
+        let Some(cid) = get_annotation_u64(te, CORRELATION_ID_ANNOTATION, &interned_names) else {
+            continue;
+        };
+        *counts.entry(cid).or_insert(0) += 1;
+    }
+
+    let mut receiver_counters: HashMap<u64, u64> = HashMap::new();
+
+    for packet in packets.iter_mut() {
+        let Some(Data::TrackEvent(te)) = &mut packet.data else {
+            continue;
+        };
+        if !is_slice_begin(te) {
+            continue;
+        }
+        let Some(cid) = get_annotation_u64(te, CORRELATION_ID_ANNOTATION, &interned_names) else {
+            continue;
+        };
+
+        let total = match counts.get(&cid) {
+            Some(&n) if n > 1 => n - 1,
+            _ => continue,
+        };
+
+        if sender_cids.insert(cid) {
+            te.flow_ids = (0..total).map(|i| cid.wrapping_add(i as u64)).collect();
+        } else {
+            let idx = receiver_counters.entry(cid).or_insert(0);
+            te.terminating_flow_ids = vec![cid.wrapping_add(*idx)];
+            *idx += 1;
+        }
+    }
 }

--- a/python/monarch/_rust_bindings/monarch_hyperactor/actor.pyi
+++ b/python/monarch/_rust_bindings/monarch_hyperactor/actor.pyi
@@ -55,12 +55,17 @@ class Exception(PythonMessageKind):
 
 class CallMethod(PythonMessageKind):
     def __init__(
-        self, name: MethodSpecifier, response_port: PortRef | OncePortRef | None
+        self,
+        name: MethodSpecifier,
+        response_port: PortRef | OncePortRef | None,
+        correlation_id: int | None = None,
     ) -> None: ...
     @property
     def name(self) -> MethodSpecifier: ...
     @property
     def response_port(self) -> PortRef | OncePortRef | None: ...
+    @property
+    def correlation_id(self) -> int | None: ...
 
 class MethodSpecifier:
     @classmethod
@@ -202,6 +207,7 @@ class Actor(Protocol):
         panic_flag: PanicFlag,
         local_state: List[Any],
         response_port: PortProtocol[Any],
+        correlation_id: int | None = None,
     ) -> None: ...
 
 @final
@@ -234,4 +240,9 @@ class QueuedMessage:
     @property
     def response_port(self) -> PortProtocol[Any]:
         """The response port for this message."""
+        ...
+
+    @property
+    def correlation_id(self) -> int | None:
+        """The correlation ID for RPC flow tracing."""
         ...

--- a/python/monarch/_rust_bindings/monarch_hyperactor/telemetry.pyi
+++ b/python/monarch/_rust_bindings/monarch_hyperactor/telemetry.pyi
@@ -69,6 +69,7 @@ class PySpan:
         self,
         name: str,
         actor_id: ActorAddr | None = None,
+        correlation_id: int | None = None,
     ) -> None:
         """
         Create a new PySpan.
@@ -76,6 +77,7 @@ class PySpan:
         Args:
         - name (str): The name of the span.
         - actor_id (ActorAddr | None, optional): The actor whose Perfetto track should own the span.
+        - correlation_id (int | None, optional): The correlation ID for RPC flow tracing.
         """
         ...
 

--- a/python/monarch/_src/actor/actor_mesh.py
+++ b/python/monarch/_src/actor/actor_mesh.py
@@ -641,6 +641,7 @@ def _create_endpoint_message(
     kwargs: Dict[str, Any],
     port_ref: "Optional[PortRef | OncePortRef]",
     proc_mesh: "Optional[ProcMesh]",
+    correlation_id: int | None = None,
 ) -> PendingMessage:
     """
     Create a PythonMessage for sending to an actor endpoint.
@@ -657,7 +658,9 @@ def _create_endpoint_message(
     )
     objects = pickling_state.tensor_engine_references()
     if not objects:
-        message_kind = PythonMessageKind.CallMethod(method_name, port_ref)
+        message_kind = PythonMessageKind.CallMethod(
+            method_name, port_ref, correlation_id
+        )
     else:
         message_kind = create_actor_message_kind(
             method_name, proc_mesh, objects, port_ref
@@ -1189,6 +1192,7 @@ class _Actor:
         panic_flag: PanicFlag,
         local_state: List[Any],
         response_port: "PortProtocol[Any]",
+        correlation_id: int | None = None,
     ) -> None:
         MESSAGES_HANDLED.add(1)
 
@@ -1278,7 +1282,7 @@ class _Actor:
 
             if is_coro:
                 if should_instrument:
-                    with span(method_name):
+                    with span(method_name, correlation_id):
                         result = await the_method(*args, **kwargs)
                 else:
                     result = await the_method(*args, **kwargs)
@@ -1286,7 +1290,7 @@ class _Actor:
             else:
                 with fake_sync_state():
                     if should_instrument:
-                        with span(method_name):
+                        with span(method_name, correlation_id):
                             result = the_method(*args, **kwargs)
                     else:
                         result = the_method(*args, **kwargs)
@@ -1465,6 +1469,7 @@ class _Actor:
             panic_flag,  # pyre-ignore[6]: QueuePanicFlag implements PanicFlag protocol
             msg.local_state,
             msg.response_port,
+            msg.correlation_id,
         )
         # If a panic was signaled, re-raise it after handle() has cleaned up
         if panic_flag.panic_exception is not None:

--- a/python/monarch/_src/actor/telemetry/__init__.py
+++ b/python/monarch/_src/actor/telemetry/__init__.py
@@ -33,8 +33,8 @@ def _current_actor_id() -> ActorAddr | None:
     return None if ctx is None else ctx.actor_instance.actor_id
 
 
-def span(name: str) -> PySpan:
-    return PySpan(name, _current_actor_id())
+def span(name: str, correlation_id: int | None = None) -> PySpan:
+    return PySpan(name, _current_actor_id(), correlation_id)
 
 
 class TracingForwarder(logging.Handler):

--- a/python/tests/_monarch/test_actor_mesh.py
+++ b/python/tests/_monarch/test_actor_mesh.py
@@ -82,6 +82,7 @@ class MyActor:
         panic_flag: PanicFlag,
         local_state: Iterable[Any],
         response_port: "PortProtocol[Any]",
+        correlation_id: int | None = None,
     ) -> None:
         match method:
             case MethodSpecifier.Init():

--- a/python/tests/_monarch/test_hyperactor.py
+++ b/python/tests/_monarch/test_hyperactor.py
@@ -44,6 +44,7 @@ class MyActor:
         panic_flag: PanicFlag,
         local_state: Iterable[Any],
         response_port: "PortProtocol[Any]",
+        correlation_id: int | None = None,
     ) -> None:
         match method:
             case MethodSpecifier.Init():

--- a/python/tests/_monarch/test_mailbox.py
+++ b/python/tests/_monarch/test_mailbox.py
@@ -180,6 +180,7 @@ class MyActor:
         panic_flag: PanicFlag,
         local_state: Iterable[Any],
         response_port: "PortProtocol[Any]",
+        correlation_id: int | None = None,
     ) -> None:
         match method:
             case MethodSpecifier.Init():


### PR DESCRIPTION
Summary:

We have caller side spans that start when an endpoint is called to the time a response is received, as well as receiver side spans for just the execution of the user defined endpoint. Now we can correlate a caller with the invocation

Collision probabilities with random u64s is 1% @ 610 million samples, and 50% at 5.06 billion which is acceptable for just a flow arrow being incorrect

Differential Revision: D103471987


