### PR TITLE
host_mesh: attach fails closed on config-push errors

### DIFF
--- a/hyperactor/src/mailbox.rs
+++ b/hyperactor/src/mailbox.rs
@@ -3732,8 +3732,18 @@ mod tests {
             unreachable!()
         };
         let msg_str = msg.to_string();
-        assert!(msg_str.contains("undeliverable message error"));
-        // Updated assertions for direct format
+        // UE-3 (top-line shape): with no operation context, the top
+        // line names the destination — `undeliverable message to
+        // {dest}`. The retired neutral `undeliverable message error`
+        // wording is no longer emitted.
+        assert!(
+            msg_str.contains("undeliverable message to"),
+            "expected destination-named top line, got:\n{msg_str}"
+        );
+        assert!(
+            !msg_str.contains("undeliverable message error"),
+            "retired neutral fallback must not appear, got:\n{msg_str}"
+        );
         assert!(msg_str.contains("sender:") && msg_str.contains("quux_0"));
         assert!(msg_str.contains("dest:") && msg_str.contains("corge_0"));
 

--- a/hyperactor/src/mailbox/undeliverable.rs
+++ b/hyperactor/src/mailbox/undeliverable.rs
@@ -18,14 +18,33 @@
 //! - **UE-2 (core diagnostics preserved).** The rendered text keeps
 //!   `sender`, `dest`, `message type`, `data_len`, and `error`.
 //!
-//! - **UE-3 (operation context names the top line).** When the
-//!   envelope carries operation-context headers, the top line names
-//!   that operation instead of falling back to the neutral
-//!   `"undeliverable message error"` prefix.
+//! - **UE-3 (top-line shape).** The top line names the operation when
+//!   the envelope carries `OPERATION_ENDPOINT`. Otherwise it names the
+//!   actual failing hop, derived from the variant of
+//!   `UndeliverableMessageError`:
+//!   - `DeliveryFailure` → `"undeliverable message to {dest}"`,
+//!     mirroring the abandonment-log surface in `mailbox.rs`.
+//!   - `ReturnFailure` → `"undeliverable return to original sender
+//!     {sender}"`. Sender/dest in this variant refer to the *original*
+//!     envelope, so headlining `dest` would misstate the failing hop;
+//!     the return-to-sender hop is the one that actually failed.
 //!
-//! - **UE-4 (neutral wording).** Top-line wording remains neutral
-//!   (`"undeliverable message for ..."`); presence of operation
-//!   context does not classify the envelope as request or reply.
+//!   Both shapes only relocate UE-2 stable rendered fields into the
+//!   headline; no unbounded surface is introduced.
+//!
+//! - **UE-4 (neutral wording).** Top-line wording is neutral re.
+//!   request/reply classification. The three shapes — `"undeliverable
+//!   message for {operation} ({adverb})"`, `"undeliverable message to
+//!   {dest}"`, and `"undeliverable return to original sender
+//!   {sender}"` — describe a bounce without claiming send-kind.
+//!
+//! - **UE-5 (message-type fallback).** When wirevalue type resolution
+//!   is unavailable (`envelope.data().typename()` returns `None`), the
+//!   `message type:` field falls back to the stamped
+//!   `RUST_MESSAGE_TYPE` header (planted at every send by the
+//!   `PortHandle`/`PortRef` paths in `mailbox.rs` / `ref_.rs`) before
+//!   rendering the literal `"unknown"`. `"unknown"` is reserved for
+//!   envelopes lacking both.
 
 use std::sync::OnceLock;
 
@@ -46,6 +65,7 @@ use crate::mailbox::PortReceiver;
 use crate::mailbox::UndeliverableMailboxSender;
 use crate::mailbox::headers::OPERATION_ADVERB;
 use crate::mailbox::headers::OPERATION_ENDPOINT;
+use crate::mailbox::headers::RUST_MESSAGE_TYPE;
 
 /// An undeliverable `M`-typed message (in practice `M` is
 /// [MessageEnvelope]).
@@ -153,9 +173,17 @@ pub enum UndeliverableMessageError {
 
 /// Compute the top-line prefix for a bounced envelope (UE-3, UE-4).
 ///
-/// When `OPERATION_ENDPOINT` is present, name the operation;
-/// otherwise fall back to a neutral prefix.
-fn undeliverable_prefix(envelope: &MessageEnvelope) -> String {
+/// When `OPERATION_ENDPOINT` is present, name the operation. Otherwise
+/// name the actual failing hop, which differs between the two variants:
+/// `DeliveryFailure` failed at `sender → dest`, while `ReturnFailure`
+/// failed at the return hop `system → original sender` (sender/dest
+/// in that variant still describe the original envelope, not the
+/// failing return).
+fn undeliverable_prefix(error: &UndeliverableMessageError) -> String {
+    let envelope = match error {
+        UndeliverableMessageError::DeliveryFailure { envelope }
+        | UndeliverableMessageError::ReturnFailure { envelope } => envelope,
+    };
     if let Some(endpoint) = envelope.headers().get(OPERATION_ENDPOINT) {
         let adverb = envelope
             .headers()
@@ -163,7 +191,17 @@ fn undeliverable_prefix(envelope: &MessageEnvelope) -> String {
             .unwrap_or_else(|| "?".to_string());
         return format!("undeliverable message for {} ({})", endpoint, adverb);
     }
-    "undeliverable message error".to_string()
+    match error {
+        UndeliverableMessageError::DeliveryFailure { .. } => {
+            format!("undeliverable message to {}", envelope.dest())
+        }
+        UndeliverableMessageError::ReturnFailure { .. } => {
+            format!(
+                "undeliverable return to original sender {}",
+                envelope.sender()
+            )
+        }
+    }
 }
 
 impl std::fmt::Display for UndeliverableMessageError {
@@ -189,15 +227,20 @@ impl std::fmt::Display for UndeliverableMessageError {
             ),
         };
 
-        writeln!(f, "{}:", undeliverable_prefix(envelope))?;
+        writeln!(f, "{}:", undeliverable_prefix(self))?;
         writeln!(f, "\tdescription: {}", description)?;
         writeln!(f, "\t{}: {}", sender_label, envelope.sender())?;
         writeln!(f, "\t{}: {}", dest_label, envelope.dest())?;
-        writeln!(
-            f,
-            "\tmessage type: {}",
-            envelope.data().typename().unwrap_or("unknown")
-        )?;
+        // UE-5: prefer the wirevalue-resolved typename; fall back to
+        // the static `RUST_MESSAGE_TYPE` stamped at send time before
+        // resorting to the literal "unknown".
+        let message_type = envelope
+            .data()
+            .typename()
+            .map(|s| s.to_string())
+            .or_else(|| envelope.headers().get(RUST_MESSAGE_TYPE))
+            .unwrap_or_else(|| "unknown".to_string());
+        writeln!(f, "\tmessage type: {}", message_type)?;
         writeln!(f, "\tdata_len: {}", envelope.data().len())?;
         writeln!(
             f,
@@ -332,19 +375,116 @@ mod tests {
         );
     }
 
-    /// UE-3 / UE-4: envelope with no operation context falls back to
-    /// the neutral prefix.
+    /// UE-3: `DeliveryFailure` with no operation context falls back to
+    /// naming the destination (the actual failing hop), mirroring the
+    /// abandonment-log surface in `mailbox.rs`.
     #[test]
-    fn test_ue3_no_context_neutral_prefix() {
+    fn test_ue3_delivery_failure_no_context_names_destination() {
         let envelope = make_envelope("payload", Flattrs::new());
+        let dest_str = envelope.dest().to_string();
+        let rendered = format!(
+            "{}",
+            UndeliverableMessageError::DeliveryFailure { envelope }
+        );
+
+        let expected_prefix = format!("undeliverable message to {}", dest_str);
+        assert!(
+            rendered.starts_with(&expected_prefix),
+            "UE-3: delivery failure no context → destination prefix `{expected_prefix}`, got:\n{rendered}"
+        );
+        // The retired neutral wording must not return.
+        assert!(
+            !rendered.contains("undeliverable message error"),
+            "UE-3: neutral fallback must not be re-introduced, got:\n{rendered}"
+        );
+    }
+
+    /// UE-3: `ReturnFailure` with no operation context names the
+    /// original sender, because in this variant `sender`/`dest` refer
+    /// to the original envelope and the actual failing hop is
+    /// `system → original sender`. Headlining `dest` here would
+    /// misstate the failure.
+    #[test]
+    fn test_ue3_return_failure_no_context_names_original_sender() {
+        let envelope = make_envelope("payload", Flattrs::new());
+        let sender_str = envelope.sender().to_string();
+        let dest_str = envelope.dest().to_string();
+        let rendered = format!("{}", UndeliverableMessageError::ReturnFailure { envelope });
+
+        let expected_prefix = format!("undeliverable return to original sender {}", sender_str);
+        assert!(
+            rendered.starts_with(&expected_prefix),
+            "UE-3: return failure no context → original-sender prefix `{expected_prefix}`, got:\n{rendered}"
+        );
+        // Must not headline the original destination — the failing hop
+        // is the return to the original sender, not the original
+        // delivery.
+        assert!(
+            !rendered.starts_with(&format!("undeliverable message to {}", dest_str)),
+            "UE-3: return failure must not headline the original destination, got:\n{rendered}"
+        );
+        // The retired neutral wording must not return.
+        assert!(
+            !rendered.contains("undeliverable message error"),
+            "UE-3: neutral fallback must not be re-introduced, got:\n{rendered}"
+        );
+    }
+
+    /// UE-5: when wirevalue type resolution is unavailable
+    /// (`typename()` is `None`), the formatter falls back to the
+    /// static `RUST_MESSAGE_TYPE` stamped at send time.
+    #[test]
+    fn test_ue5_message_type_falls_back_to_rust_message_type() {
+        // `Any::new_broken()` carries `BROKEN_TYPEHASH` (0), which is
+        // not in the wirevalue type registry, so `typename()` is None.
+        // Mirrors the `test_broken_any` pattern in wirevalue itself.
+        let sender = test_actor_id("ue_proc", "ue_sender");
+        let dest = test_port_id("ue_dest_proc", "ue_dest", 42);
+        let mut headers = Flattrs::new();
+        headers.set(RUST_MESSAGE_TYPE, "my::Foo".to_string());
+        let envelope = MessageEnvelope::new(sender, dest, wirevalue::Any::new_broken(), headers);
+        assert!(
+            envelope.data().typename().is_none(),
+            "test fixture invariant: broken Any must have no typename()"
+        );
+
         let rendered = format!(
             "{}",
             UndeliverableMessageError::DeliveryFailure { envelope }
         );
 
         assert!(
-            rendered.starts_with("undeliverable message error:"),
-            "UE-3: no context → neutral prefix, got:\n{rendered}"
+            rendered.contains("\tmessage type: my::Foo\n"),
+            "UE-5: must surface RUST_MESSAGE_TYPE when typename() is absent, got:\n{rendered}"
+        );
+        assert!(
+            !rendered.contains("\tmessage type: unknown"),
+            "UE-5: must not render \"unknown\" when RUST_MESSAGE_TYPE is present, got:\n{rendered}"
+        );
+    }
+
+    /// UE-5 (negative): when both `typename()` and `RUST_MESSAGE_TYPE`
+    /// are absent, the formatter falls all the way through to the
+    /// literal `"unknown"`.
+    #[test]
+    fn test_ue5_unknown_when_typename_and_rust_message_type_both_absent() {
+        let sender = test_actor_id("ue_proc", "ue_sender");
+        let dest = test_port_id("ue_dest_proc", "ue_dest", 42);
+        let envelope =
+            MessageEnvelope::new(sender, dest, wirevalue::Any::new_broken(), Flattrs::new());
+        assert!(
+            envelope.data().typename().is_none(),
+            "test fixture invariant: broken Any must have no typename()"
+        );
+
+        let rendered = format!(
+            "{}",
+            UndeliverableMessageError::DeliveryFailure { envelope }
+        );
+
+        assert!(
+            rendered.contains("\tmessage type: unknown\n"),
+            "UE-5: with no typename and no RUST_MESSAGE_TYPE, must render \"unknown\", got:\n{rendered}"
         );
     }
 }

--- a/hyperactor_mesh/src/host_mesh.rs
+++ b/hyperactor_mesh/src/host_mesh.rs
@@ -6,6 +6,43 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+//! Host-mesh attach and lifecycle.
+//!
+//! ## Host-mesh invariants (HM-*)
+//!
+//! These are the load-bearing semantic contracts of `HostMesh::attach()`
+//! and `HostMeshRef::push_config()`. They describe what callers may
+//! rely on; they do not pin specific mechanisms (the current
+//! implementation chooses a particular send path, error taxonomy, and
+//! timeout shape — those are not invariants and may evolve).
+//!
+//! - **HM-1 (attach-config-complete).** If `HostMesh::attach()` returns
+//!   `Ok`, every attached host has installed the client's propagatable
+//!   config snapshot.
+//!
+//! - **HM-2 (attach-config-fails-closed).** If config push fails on
+//!   any attached host, `HostMesh::attach()` returns `Err`. It must
+//!   not return a partially-configured mesh as success.
+//!
+//! - **HM-3 (in-band-request-failure-surface).** Attach-time
+//!   config-push *request* failure must surface through `attach()` /
+//!   `push_config()` as a structured error. It must not bypass that
+//!   result path by returning the outbound request on the caller's
+//!   `Undeliverable<MessageEnvelope>` channel. The invariant names a
+//!   specific prohibited bypass; what a caller chooses to do with the
+//!   returned `Err` (escalate, retry, abort) is outside scope.
+//!   Cross-cutting: depends on hyperactor undeliverable semantics in
+//!   `hyperactor::reference` and `hyperactor::actor`; the invariant
+//!   still belongs here because the attach contract is owned here.
+//!
+//! - **HM-4 (host-scoped-error-reporting).** Config-push failure
+//!   reported from `push_config()` identifies the failing host(s)
+//!   individually, so callers can act per-host. The contract commits
+//!   to per-host *identity*; the failure-mode taxonomy carried
+//!   alongside it (the `ConfigPushFailure` variant set) is
+//!   implementation detail and may evolve without changing the
+//!   contract.
+
 #![allow(clippy::result_large_err)]
 
 use hyperactor::Actor;
@@ -62,7 +99,6 @@ pub use crate::host_mesh::host_agent::HostAgent;
 use crate::host_mesh::host_agent::HostAgentMode;
 use crate::host_mesh::host_agent::ProcManagerSpawnFn;
 use crate::host_mesh::host_agent::ProcState;
-use crate::host_mesh::host_agent::SetClientConfigClient;
 use crate::host_mesh::host_agent::ShutdownHostClient;
 use crate::mesh_controller::ProcMeshController;
 use crate::mesh_id::HostMeshId;
@@ -216,6 +252,116 @@ impl FromStr for HostRef {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         Ok(HostRef(ChannelAddr::from_str(s)?))
+    }
+}
+
+/// Per-host failure modes for the attach-time config push.
+///
+/// **Implementation detail of [`ConfigPushError`].** The variant
+/// taxonomy is *not* part of HM-4 or any other invariant — HM-4
+/// commits to per-host *identity* in the error, not to a specific
+/// menu of failure subtypes. The variant set may grow, shrink, or be
+/// reshaped without changing the contract; tests should not pin to a
+/// specific variant unless the fixture deterministically guarantees
+/// it.
+#[derive(Debug, thiserror::Error)]
+pub enum ConfigPushFailure {
+    /// Synchronous send failure (e.g. the request port refused the
+    /// post). The error is preserved for triage.
+    #[error("send failed: {0}")]
+    SendFailed(#[source] Box<hyperactor::mailbox::MailboxSenderError>),
+
+    /// The awaited reply did not arrive within
+    /// `MESH_ATTACH_CONFIG_TIMEOUT`. With request-bounce suppression
+    /// (HM-3 mechanism), this is the dominant failure mode for an
+    /// unreachable host: the channel-side `BrokenLink` is logged at
+    /// debug from `MailboxClient`'s buffer task; the contract surface
+    /// is just "did not reply in time".
+    #[error("reply timed out after MESH_ATTACH_CONFIG_TIMEOUT")]
+    ReplyTimedOut,
+
+    /// The reply receiver closed before any value arrived (sender
+    /// side dropped, or the local mailbox tore down).
+    #[error("reply channel closed before reply")]
+    ReplyChannelClosed,
+}
+
+/// Aggregated `attach()` config-push failure surface — one entry per
+/// host that didn't acknowledge installation.
+///
+/// HM-4: per-host identity is preserved so callers can act per-host.
+/// The host-identity key is `HostRef` (the iteration unit in
+/// `push_config()`); the per-host cause is a `ConfigPushFailure`
+/// (taxonomy is implementation-detail; see the type's doc).
+#[derive(Debug)]
+pub struct ConfigPushError {
+    /// One entry per host whose config push didn't succeed.
+    pub failures: Vec<(HostRef, ConfigPushFailure)>,
+}
+
+impl std::fmt::Display for ConfigPushError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "config push failed during attach on {} host(s):",
+            self.failures.len()
+        )?;
+        for (host, failure) in &self.failures {
+            write!(f, "\n  - {}: {}", host, failure)?;
+        }
+        Ok(())
+    }
+}
+
+impl std::error::Error for ConfigPushError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        // Per-host causes are surfaced through `Display`. A single
+        // top-level `source()` would arbitrarily pick one host's
+        // cause and obscure the others.
+        None
+    }
+}
+
+/// Push the propagatable client config to a single host, awaiting
+/// the host's installation acknowledgement.
+///
+/// HM-3 mechanism: the outbound request envelope is constructed
+/// manually (rather than via the `RefClient`-derived
+/// `set_client_config` shortcut) so the per-call
+/// `return_undeliverable(false)` setter can suppress the request
+/// bounce. With suppression, the only failure surface is the awaited
+/// reply path — exactly what `push_config()` wants in-band.
+async fn push_config_to_host(
+    cx: &impl context::Actor,
+    host: &HostRef,
+    attrs: hyperactor_config::attrs::Attrs,
+    per_host_timeout: Duration,
+) -> Result<(), ConfigPushFailure> {
+    use crate::host_mesh::host_agent::SetClientConfig;
+
+    let (reply_handle, mut reply_receiver) = hyperactor::mailbox::open_port::<()>(cx);
+    let reply_ref = reply_handle.bind();
+    let msg = SetClientConfig {
+        attrs,
+        done: reply_ref,
+    };
+
+    let mut request_port = host.mesh_agent().port::<SetClientConfig>();
+    // HM-3: bypass the default `return_undeliverable: true` from
+    // `PortRef::attest`. Without this, a transient session failure
+    // (e.g. "never connected") would bounce the request back through
+    // the caller's `Undeliverable<MessageEnvelope>` handler — the
+    // exact bypass HM-3 prohibits.
+    request_port.return_undeliverable(false);
+
+    if let Err(send_err) = request_port.send(cx, msg) {
+        return Err(ConfigPushFailure::SendFailed(Box::new(send_err)));
+    }
+
+    match tokio::time::timeout(per_host_timeout, reply_receiver.recv()).await {
+        Ok(Ok(())) => Ok(()),
+        Ok(Err(_recv_err)) => Err(ConfigPushFailure::ReplyChannelClosed),
+        Err(_elapsed) => Err(ConfigPushFailure::ReplyTimedOut),
     }
 }
 
@@ -471,10 +617,13 @@ impl HostMesh {
     /// 1. Wraps the provided addresses into a `HostMeshRef`.
     /// 2. Snapshots `propagatable_attrs()` from the client's global config.
     /// 3. Pushes the config to each host agent as `Source::ClientOverride`,
-    ///    with a barrier to confirm installation.
+    ///    awaiting per-host installation acknowledgement.
     /// 4. Returns the owned `HostMesh`.
     ///
-    /// After this returns, host agents have the client's config.
+    /// HM-1 / HM-2 / HM-3 / HM-4 (see module docs): if config push
+    /// fails on any host, this returns `Err`. A successful return
+    /// means every attached host installed the propagatable config
+    /// snapshot.
     pub async fn attach(
         cx: &impl context::Actor,
         id: HostMeshId,
@@ -482,7 +631,7 @@ impl HostMesh {
     ) -> crate::Result<Self> {
         let mesh_ref = HostMeshRef::from_hosts(id, addresses);
         let config = hyperactor_config::global::propagatable_attrs();
-        mesh_ref.push_config(cx, config).await;
+        mesh_ref.push_config(cx, config).await?;
         Ok(Self::take(mesh_ref))
     }
 
@@ -921,58 +1070,57 @@ impl HostMeshRef {
     /// Each host installs the attrs as `Source::ClientOverride`.
     /// Idempotent: sending the same attrs twice replaces the layer.
     ///
-    /// Sends request-reply to each host and barriers on all replies.
-    /// Best-effort: on timeout or error, logs a warning and continues.
-    /// Timeout controlled by `MESH_ATTACH_CONFIG_TIMEOUT` (default 10s).
+    /// Implements HM-1, HM-2, HM-3, and HM-4 (see module docs):
+    /// returns `Err(ConfigPushError)` if any host's push didn't
+    /// succeed, naming each failing host individually. The outbound
+    /// request envelope is sent with `return_undeliverable: false` to
+    /// keep failure in-band on the awaited reply (HM-3 mechanism);
+    /// per-host wait is bounded by `MESH_ATTACH_CONFIG_TIMEOUT`.
     pub(crate) async fn push_config(
         &self,
         cx: &impl context::Actor,
         attrs: hyperactor_config::attrs::Attrs,
-    ) {
+    ) -> Result<(), ConfigPushError> {
         let timeout = hyperactor_config::global::get(crate::config::MESH_ATTACH_CONFIG_TIMEOUT);
         let hosts: Vec<_> = self.values().collect();
-        let num_hosts = hosts.len();
 
-        let barrier = futures::future::join_all(hosts.into_iter().map(|host| {
+        let per_host = hosts.into_iter().map(|host| {
             let attrs = attrs.clone();
-            let agent_id = host.mesh_agent().actor_id().clone();
             async move {
-                match host.mesh_agent().set_client_config(cx, attrs).await {
-                    Ok(()) => {
-                        tracing::debug!(host = %agent_id, "host agent config installed");
-                        true
-                    }
-                    Err(e) => {
-                        tracing::warn!(
-                            host = %agent_id,
-                            error = %e,
-                            "failed to push client config to host agent, \
-                             continuing without it",
-                        );
-                        false
-                    }
+                (
+                    host.clone(),
+                    push_config_to_host(cx, &host, attrs, timeout).await,
+                )
+            }
+        });
+
+        let results = futures::future::join_all(per_host).await;
+
+        let mut failures = Vec::new();
+        let mut success = 0_usize;
+        for (host, outcome) in results {
+            match outcome {
+                Ok(()) => {
+                    success += 1;
+                    tracing::debug!(host = %host, "host agent config installed");
+                }
+                Err(failure) => {
+                    tracing::warn!(host = %host, error = %failure, "config push failed");
+                    failures.push((host, failure));
                 }
             }
-        }));
+        }
 
-        match tokio::time::timeout(timeout, barrier).await {
-            Ok(results) => {
-                let success = results.iter().filter(|&&r| r).count();
-                let failed = num_hosts - success;
-                tracing::info!(
-                    success = success,
-                    failed = failed,
-                    "push_config barrier complete",
-                );
-            }
-            Err(_) => {
-                tracing::warn!(
-                    num_hosts = num_hosts,
-                    timeout_secs = timeout.as_secs(),
-                    "push_config barrier timed out, some hosts may not \
-                     have received client config",
-                );
-            }
+        if failures.is_empty() {
+            tracing::info!(success, "push_config complete");
+            Ok(())
+        } else {
+            tracing::info!(
+                success,
+                failed = failures.len(),
+                "push_config complete with failures",
+            );
+            Err(ConfigPushError { failures })
         }
     }
 
@@ -2004,7 +2152,74 @@ mod tests {
         let _ = hm.shutdown(instance).await;
     }
 
-    // ---- SA-* invariant tests ----
+    // ---- HM-* invariant tests ----
+    //
+    // HM-1 (attach-config-complete) is covered by
+    // `test_client_config_override` above: a successful end-to-end
+    // attach + per-host config-override observation.
+    //
+    // The tests below cover HM-2, HM-3, and HM-4 in a single fixture
+    // — `attach()` against a host address with no listener. Because
+    // `testing::TestRootClient::handle::<MeshFailure>` panics on any
+    // supervision event, a passing test is itself the HM-3
+    // observation: no `Undeliverable<MessageEnvelope>` reached the
+    // root client (had the bounce escaped, the test would panic).
+
+    /// HM-2 / HM-3 / HM-4: `attach()` against an unreachable host
+    /// returns a structured `Err` that names the failing host, and
+    /// the calling actor stays alive (no supervision crash from a
+    /// bounce on the request path).
+    #[tokio::test]
+    async fn test_attach_fails_closed_on_unreachable_host() {
+        let config = hyperactor_config::global::lock();
+        // Tighten the per-host timeout so the test doesn't sit on
+        // the 10 s default.
+        let _guard = config.override_key(
+            crate::config::MESH_ATTACH_CONFIG_TIMEOUT,
+            Duration::from_millis(500),
+        );
+
+        let instance = testing::instance();
+
+        // `free_localhost_addr` binds a TCP port and immediately
+        // drops the listener. SO_REUSEADDR + no further bind means
+        // sends to this address never connect — exactly the
+        // production-shape failure mode.
+        let unreachable = free_localhost_addr();
+
+        let id = HostMeshId::unique(Label::new("hm_test").unwrap());
+        let result = HostMesh::attach(instance, id, vec![unreachable.clone()]).await;
+
+        // HM-2: attach returns Err on any failed config push.
+        let err = match result {
+            Ok(_) => panic!("HM-2: attach must fail when a host is unreachable"),
+            Err(e) => e,
+        };
+
+        // HM-4: the structured error names the failing host.
+        let push_err = match err {
+            crate::Error::ConfigPushFailed(e) => e,
+            other => panic!("expected ConfigPushFailed, got: {other:?}"),
+        };
+        assert_eq!(push_err.failures.len(), 1);
+        let (failed_host, _failure) = &push_err.failures[0];
+        assert_eq!(
+            failed_host,
+            &HostRef(unreachable),
+            "HM-4: failure entry must identify the unreachable host"
+        );
+        // Intentionally do NOT pin the `_failure` variant — the
+        // contract commits to per-host identity, not to a specific
+        // failure-mode subtype (see ConfigPushFailure's doc).
+
+        // HM-3: the test process getting here without panicking is
+        // itself the assertion. `TestRootClient::handle::<MeshFailure>`
+        // panics on supervision events; if the request bounce had
+        // escaped through `Undeliverable<MessageEnvelope>`, the
+        // root-client's default `handle_undeliverable_message` would
+        // bail with `UndeliverableMessageError::DeliveryFailure`,
+        // supervision would fire, and we wouldn't be here.
+    }
 
     #[tokio::test]
     async fn test_sa1_empty_mesh_set_rejected() {

--- a/hyperactor_mesh/src/host_mesh/host_agent.rs
+++ b/hyperactor_mesh/src/host_mesh/host_agent.rs
@@ -1256,8 +1256,9 @@ impl Handler<resource::List> for HostAgent {
 /// the layer wholesale.
 ///
 /// Request-reply: the reply acts as a barrier confirming the config
-/// is installed. The caller should await with a timeout and treat
-/// timeout as best-effort (log warning, continue).
+/// is installed. The fatal-on-failure / best-effort policy is the
+/// caller's contract, not this message's; for the canonical
+/// attach-time contract see the HM-* invariants in `host_mesh.rs`.
 #[derive(Debug, Named, Handler, RefClient, HandleClient, Serialize, Deserialize)]
 pub struct SetClientConfig {
     pub attrs: Attrs,

--- a/hyperactor_mesh/src/lib.rs
+++ b/hyperactor_mesh/src/lib.rs
@@ -164,6 +164,12 @@ pub enum Error {
     #[error("error configuring host mesh agent {0}: {1}")]
     HostMeshAgentConfigurationError(ActorAddr, String),
 
+    /// HM-2 / HM-3 / HM-4: structured per-host failure from
+    /// `HostMeshRef::push_config()`. See the HM-* invariant block in
+    /// `host_mesh.rs` for the contract this surfaces.
+    #[error(transparent)]
+    ConfigPushFailed(#[from] crate::host_mesh::ConfigPushError),
+
     #[error(
         "error creating proc (host rank {host_rank}) on host mesh agent {mesh_agent}, state: {state}"
     )]

--- a/python/tests/test_actor_error.py
+++ b/python/tests/test_actor_error.py
@@ -1049,8 +1049,16 @@ async def test_supervision_with_sending_error() -> None:
     # This would require Undeliverable to know about a specific return channel.
     assert "MeshFailure" in error_msg
     assert "RootClientActor" in error_msg
+    # Top line is one of:
+    #   `undeliverable message to {dest}` (DeliveryFailure, no
+    #     OPERATION_ENDPOINT — see UE-3 in
+    #     hyperactor/src/mailbox/undeliverable.rs).
+    #   `undeliverable message for {operation} ({adverb})`
+    #     (when OPERATION_ENDPOINT is present).
+    # Both are valid here: pending messages of mixed shapes flush back
+    # to the client when the receiver session breaks. Match either.
     assert re.search(
-        "undeliverable message error.*client.*",
+        r"undeliverable message (to|for) .*client",
         error_msg,
         flags=re.DOTALL,
     )

--- a/python/tests/test_python_actors.py
+++ b/python/tests/test_python_actors.py
@@ -1440,6 +1440,37 @@ def test_simple_bootstrap():
             proc.wait()
 
 
+@isolate_in_subprocess
+def test_attach_fails_closed_on_unreachable_host():
+    """`attach_to_workers(...)` against an unreachable host raises a
+    Python exception whose message names the failing host. See HM-* in
+    `host_mesh.rs` for the underlying contract."""
+    # Tighten the per-host config-push timeout so the test doesn't
+    # wait the 10 s default.
+    with configured(mesh_attach_config_timeout="500ms"):
+        with TemporaryDirectory() as d:
+            unreachable = f"ipc://{d}/never_bound"
+
+            hosts = attach_to_workers(ca="trust_all_connections", workers=[unreachable])
+
+            with pytest.raises(Exception) as excinfo:
+                hosts.initialized.get()
+
+            msg = str(excinfo.value)
+
+            assert "attach failed: config push failed during attach" in msg, (
+                f"expected attach-time config-push failure shape, got: {msg}"
+            )
+
+            # `ipc://...` normalizes to `unix:...` in
+            # `ChannelAddr::Display`; match on the stable path
+            # component so the assertion isn't tied to scheme spelling.
+            expected_path = f"{d}/never_bound"
+            assert expected_path in msg, (
+                f"unreachable host path must appear in error, got: {msg}"
+            )
+
+
 @parametrize_config(actor_queue_dispatch={True, False})
 @isolate_in_subprocess
 def test_config_propagates_to_host_agent():


### PR DESCRIPTION
Summary:
this fixes a production attach failure where the root client could crash while pushing client config to host agents during HostMesh::attach().

the parent diff improves how undeliverable failures are rendered; this diff fixes the underlying attach-time failure path so config push fails through attach() itself.

before this diff, push_config() only handled failure on the awaited reply path. the outbound SetClientConfig request still used the default return_undeliverable: true, so a host-agent session failure during bring-up could return the request on the caller’s Undeliverable<MessageEnvelope> channel and bypass the attach() / push_config() result path entirely.

this change makes the failure surface explicit and fail-closed. HostMeshRef::push_config() now returns structured per-host failure, HostMesh::attach() propagates that error, and the outbound SetClientConfig request is sent with undeliverable bounce suppressed so attach-time config-push request failure stays on the attach() / push_config() error path. callers may still choose to escalate that returned error through supervision, but they now do so from a structured internal error rather than from an out-of-band undeliverable bounce. the module docs now register the HM-* invariants for attach-time config completeness, fail-closed behavior, in-band request-failure surfacing, and host- scoped error reporting.

for the motivating production case, the failure now surfaces as a normal Python exception from host_mesh.attach(...), with an inner error of the form:

  config push failed during attach on 1 host(s):
    - metatls:2401:db00:19ac:9945:face:0:3a:0:26600: reply timed out after MESH_ATTACH_CONFIG_TIMEOUT

the traceback now points at the user’s host_mesh.attach(...) call, which is the natural failure site for this operation, rather than at supervision handling of an out-of-band undeliverable request.

Differential Revision: D103496536


