### PR TITLE
[hyperactor] move labels into Uid

### DIFF
--- a/hyperactor/src/actor.rs
+++ b/hyperactor/src/actor.rs
@@ -286,18 +286,17 @@ pub trait RemoteSpawn: Actor + Referable + Binds<Self> {
     // TODO: consider making this 'private' -- by moving it into a non-public trait as in [`cap`].
     fn gspawn(
         proc: &Proc,
-        name: &str,
+        uid: crate::id::Uid,
         serialized_params: Data,
         environment: Flattrs,
     ) -> Pin<Box<dyn Future<Output = Result<ActorAddr, anyhow::Error>> + Send>> {
         let proc = proc.clone();
-        let name = name.to_string();
         Box::pin(async move {
             let params =
                 bincode::serde::decode_from_slice(&serialized_params, bincode::config::legacy())
                     .map(|(v, _)| v)?;
             let actor = Self::new(params, environment).await?;
-            let handle = proc.spawn(&name, actor)?;
+            let handle = proc.spawn_with_uid(uid, actor)?;
             // We return only the ActorAddr, not a typed ActorRef.
             // Callers that hold this ID can interact with the actor
             // only via the serialized/opaque messaging path, which

--- a/hyperactor/src/actor/remote.rs
+++ b/hyperactor/src/actor/remote.rs
@@ -18,6 +18,7 @@ use hyperactor_config::Flattrs;
 
 use crate::Actor;
 use crate::Data;
+use crate::id::Uid;
 use crate::proc::Proc;
 
 /// The offset of user-defined ports (i.e., arbitrarily bound).
@@ -67,7 +68,7 @@ pub struct SpawnableActor {
     /// Type-erased spawn function. This is the type's [`RemoteSpawn::gspawn`].
     pub gspawn: fn(
         &Proc,
-        &str,
+        Uid,
         Data,
         Flattrs,
     )
@@ -118,14 +119,14 @@ impl Remote {
             .map(|entry| **entry.name)
     }
 
-    /// Spawns the named actor with the provided sender, actor id,
+    /// Spawns the actor with the provided sender, actor uid,
     /// and serialized parameters. Returns an error if the actor is not
     /// registered, or if the actor's spawn fails.
     pub async fn gspawn(
         &self,
         proc: &Proc,
         actor_type: &str,
-        actor_name: &str,
+        actor_uid: Uid,
         params: Data,
         environment: Flattrs,
     ) -> Result<crate::ActorAddr, anyhow::Error> {
@@ -133,7 +134,7 @@ impl Remote {
             .by_name
             .get(actor_type)
             .ok_or_else(|| anyhow::anyhow!("actor type {} not registered", actor_type))?;
-        (entry.gspawn)(proc, actor_name, params, environment).await
+        (entry.gspawn)(proc, actor_uid, params, environment).await
     }
 }
 
@@ -149,6 +150,7 @@ mod tests {
     use crate::Context;
     use crate::Handler;
     use crate::RemoteSpawn;
+    use crate::id::Label;
 
     #[derive(Debug)]
     #[hyperactor::export(())]
@@ -220,7 +222,7 @@ mod tests {
             .gspawn(
                 &Proc::local(),
                 "hyperactor::actor::remote::tests::MyActor",
-                "actor",
+                Uid::instance_labeled(Label::new("actor").unwrap()),
                 bincode::serde::encode_to_vec(true, bincode::config::legacy()).unwrap(),
                 Flattrs::default(),
             )
@@ -231,7 +233,7 @@ mod tests {
             .gspawn(
                 &Proc::local(),
                 "hyperactor::actor::remote::tests::MyActor",
-                "actor",
+                Uid::instance_labeled(Label::new("actor").unwrap()),
                 bincode::serde::encode_to_vec(false, bincode::config::legacy()).unwrap(),
                 Flattrs::default(),
             )

--- a/hyperactor/src/addr.rs
+++ b/hyperactor/src/addr.rs
@@ -138,10 +138,7 @@ impl ProcAddr {
     /// The proc's label: the explicit metadata label for instances,
     /// or the singleton name for singletons.
     pub fn label(&self) -> Option<&Label> {
-        self.id.label().or_else(|| match self.id.uid() {
-            Uid::Singleton(label) => Some(label),
-            _ => None,
-        })
+        self.id.label()
     }
 
     /// Create a ProcAddr with a unique (random) uid and the given label.
@@ -164,6 +161,11 @@ impl ProcAddr {
         ActorAddr::new_from_name(self.clone(), name)
     }
 
+    /// Create an ActorAddr with the provided uid within this proc.
+    pub fn actor_ref_uid(&self, uid: Uid) -> ActorAddr {
+        ActorAddr::new_from_uid(self.clone(), uid)
+    }
+
     /// Compatibility alias for callers still using `actor_id` naming.
     pub fn actor_id(&self, name: impl AsRef<str>) -> ActorAddr {
         self.actor_ref(name)
@@ -184,10 +186,13 @@ impl ProcAddr {
                 .to_string()
         }
 
-        match (self.id.uid(), self.id.label()) {
-            (Uid::Singleton(label), _) => label.to_string(),
-            (uid @ Uid::Instance(_), Some(label)) => format!("{label}-{}", uid_no_brackets(uid)),
-            (uid @ Uid::Instance(_), None) => uid.to_string(),
+        match self.id.uid() {
+            Uid::Singleton(label) => label.to_string(),
+            Uid::Instance(uid, Some(label)) => {
+                let uid = Uid::Instance(*uid, None);
+                format!("{label}-{}", uid_no_brackets(&uid))
+            }
+            Uid::Instance(uid, None) => Uid::Instance(*uid, None).to_string(),
         }
     }
 }
@@ -200,7 +205,7 @@ pub(crate) fn parse_resource_name(s: &str) -> (Uid, Option<Label>) {
     fn parse_wrapped_instance_uid(s: &str) -> Option<u64> {
         let wrapped = format!("<{s}>");
         match Uid::from_str(&wrapped) {
-            Ok(Uid::Instance(uid)) => Some(uid),
+            Ok(Uid::Instance(uid, _)) => Some(uid),
             _ => None,
         }
     }
@@ -217,16 +222,16 @@ pub(crate) fn parse_resource_name(s: &str) -> (Uid, Option<Label>) {
     if let Some((label_part, uid_part)) = s.rsplit_once('-')
         && uid_part.len() >= 8
     {
-        if let (Ok(label), Ok(uid)) = (
+        if let (Ok(label), Ok(Uid::Instance(uid, _))) = (
             Label::new(label_part),
             Uid::from_str(&format!("<{uid_part}>")),
         ) {
-            return (uid, Some(label));
+            return (Uid::Instance(uid, Some(label.clone())), Some(label));
         }
         if let (Ok(label), Some(uid)) =
             (Label::new(label_part), parse_wrapped_instance_uid(uid_part))
         {
-            return (Uid::Instance(uid), Some(label));
+            return (Uid::Instance(uid, Some(label.clone())), Some(label));
         }
     }
 
@@ -234,8 +239,10 @@ pub(crate) fn parse_resource_name(s: &str) -> (Uid, Option<Label>) {
         if s.ends_with('>') {
             let label_part = &s[..open];
             let uid_part = &s[open..];
-            if let (Ok(uid), Ok(label)) = (Uid::from_str(uid_part), Label::new(label_part)) {
-                return (uid, Some(label));
+            if let (Ok(Uid::Instance(uid, _)), Ok(label)) =
+                (Uid::from_str(uid_part), Label::new(label_part))
+            {
+                return (Uid::Instance(uid, Some(label.clone())), Some(label));
             }
         }
     }
@@ -323,6 +330,12 @@ impl ActorAddr {
         Self::new(actor_id, proc_ref.location)
     }
 
+    /// Create an ActorAddr from a ProcAddr and actor uid.
+    pub fn new_from_uid(proc_ref: ProcAddr, uid: Uid) -> Self {
+        let actor_id = id::ActorId::new(uid, proc_ref.id.clone(), None);
+        Self::new(actor_id, proc_ref.location)
+    }
+
     /// Returns the actor id.
     pub fn id(&self) -> &ActorId {
         &self.id
@@ -346,10 +359,7 @@ impl ActorAddr {
     /// The actor's label: explicit metadata label for instances,
     /// or singleton name for singletons.
     pub fn label(&self) -> Option<&Label> {
-        self.id.label().or_else(|| match self.id.uid() {
-            Uid::Singleton(label) => Some(label),
-            _ => None,
-        })
+        self.id.label()
     }
 
     /// Reconstruct the parent ProcAddr (with location preserved).
@@ -915,7 +925,7 @@ mod tests {
     #[test]
     fn test_proc_ref_display() {
         let pid = ProcId::new(
-            Uid::Instance(0xabc123),
+            Uid::Instance(0xabc123, None),
             Some(Label::new("my-proc").unwrap()),
         );
         let loc: Location = ChannelAddr::Local(42).into();
@@ -926,7 +936,7 @@ mod tests {
     #[test]
     fn test_proc_ref_debug_with_label() {
         let pid = ProcId::new(
-            Uid::Instance(0xabc123),
+            Uid::Instance(0xabc123, None),
             Some(Label::new("my-proc").unwrap()),
         );
         let loc: Location = ChannelAddr::Local(42).into();
@@ -939,7 +949,7 @@ mod tests {
 
     #[test]
     fn test_proc_ref_debug_without_label() {
-        let pid = ProcId::new(Uid::Instance(0xabc123), None);
+        let pid = ProcId::new(Uid::Instance(0xabc123, None), None);
         let loc: Location = ChannelAddr::Local(42).into();
         let pref = ProcAddr::new(pid, loc);
         assert_eq!(
@@ -951,7 +961,7 @@ mod tests {
     #[test]
     fn test_proc_ref_fromstr_roundtrip() {
         let pid = ProcId::new(
-            Uid::Instance(0xabc123),
+            Uid::Instance(0xabc123, None),
             Some(Label::new("my-proc").unwrap()),
         );
         let loc: Location = ChannelAddr::Local(42).into();
@@ -965,11 +975,11 @@ mod tests {
     fn test_proc_ref_fromstr_tcp() {
         let parsed: ProcAddr = format!(
             "{}@tcp://127.0.0.1:8080",
-            ProcId::new(Uid::Instance(0xabc123), None)
+            ProcId::new(Uid::Instance(0xabc123, None), None)
         )
         .parse()
         .unwrap();
-        assert_eq!(*parsed.id().uid(), Uid::Instance(0xabc123));
+        assert_eq!(*parsed.id().uid(), Uid::Instance(0xabc123, None));
         assert_eq!(
             *parsed.location().addr(),
             "tcp:127.0.0.1:8080".parse::<ChannelAddr>().unwrap()
@@ -985,7 +995,7 @@ mod tests {
         );
         assert_eq!(*parsed.location().addr(), ChannelAddr::Local(0));
 
-        let expected_uid = Uid::Instance(0xabc123);
+        let expected_uid = Uid::Instance(0xabc123, None);
         let parsed: ProcAddr = format!("controller{}@tcp://[::1]:2345", expected_uid)
             .parse()
             .unwrap();
@@ -1002,7 +1012,7 @@ mod tests {
 
     #[test]
     fn test_proc_ref_fromstr_missing_separator() {
-        let err = ProcId::new(Uid::Instance(0xabc123), None)
+        let err = ProcId::new(Uid::Instance(0xabc123, None), None)
             .to_string()
             .parse::<ProcAddr>()
             .unwrap_err();
@@ -1018,9 +1028,9 @@ mod tests {
     #[test]
     fn test_actor_ref_display() {
         let aid = ActorId::new(
-            Uid::Instance(0xabc123),
+            Uid::Instance(0xabc123, None),
             ProcId::new(
-                Uid::Instance(0xdef456),
+                Uid::Instance(0xdef456, None),
                 Some(Label::new("my-proc").unwrap()),
             ),
             Some(Label::new("my-actor").unwrap()),
@@ -1033,9 +1043,9 @@ mod tests {
     #[test]
     fn test_actor_ref_debug_all_labels() {
         let aid = ActorId::new(
-            Uid::Instance(0xabc123),
+            Uid::Instance(0xabc123, None),
             ProcId::new(
-                Uid::Instance(0xdef456),
+                Uid::Instance(0xdef456, None),
                 Some(Label::new("my-proc").unwrap()),
             ),
             Some(Label::new("my-actor").unwrap()),
@@ -1051,8 +1061,8 @@ mod tests {
     #[test]
     fn test_actor_ref_debug_no_labels() {
         let aid = ActorId::new(
-            Uid::Instance(0xabc123),
-            ProcId::new(Uid::Instance(0xdef456), None),
+            Uid::Instance(0xabc123, None),
+            ProcId::new(Uid::Instance(0xdef456, None), None),
             None,
         );
         let loc: Location = ChannelAddr::Local(42).into();
@@ -1066,8 +1076,8 @@ mod tests {
     #[test]
     fn test_actor_ref_debug_actor_label_only() {
         let aid = ActorId::new(
-            Uid::Instance(0xabc123),
-            ProcId::new(Uid::Instance(0xdef456), None),
+            Uid::Instance(0xabc123, None),
+            ProcId::new(Uid::Instance(0xdef456, None), None),
             Some(Label::new("my-actor").unwrap()),
         );
         let loc: Location = ChannelAddr::Local(42).into();
@@ -1081,9 +1091,9 @@ mod tests {
     #[test]
     fn test_actor_ref_debug_proc_label_only() {
         let aid = ActorId::new(
-            Uid::Instance(0xabc123),
+            Uid::Instance(0xabc123, None),
             ProcId::new(
-                Uid::Instance(0xdef456),
+                Uid::Instance(0xdef456, None),
                 Some(Label::new("my-proc").unwrap()),
             ),
             None,
@@ -1099,9 +1109,9 @@ mod tests {
     #[test]
     fn test_actor_ref_fromstr_roundtrip() {
         let aid = ActorId::new(
-            Uid::Instance(0xabc123),
+            Uid::Instance(0xabc123, None),
             ProcId::new(
-                Uid::Instance(0xdef456),
+                Uid::Instance(0xdef456, None),
                 Some(Label::new("my-proc").unwrap()),
             ),
             Some(Label::new("my-actor").unwrap()),
@@ -1120,7 +1130,7 @@ mod tests {
 
     #[test]
     fn test_actor_ref_fromstr_examples() {
-        let expected_actor_uid = Uid::Instance(0xabc123);
+        let expected_actor_uid = Uid::Instance(0xabc123, None);
         let parsed: ActorAddr = format!("controller{}.local@inproc://0", expected_actor_uid)
             .parse()
             .unwrap();
@@ -1139,8 +1149,8 @@ mod tests {
     #[test]
     fn test_actor_ref_fromstr_missing_separator() {
         let err = ActorId::new(
-            Uid::Instance(0xabc123),
-            ProcId::new(Uid::Instance(0xdef456), None),
+            Uid::Instance(0xabc123, None),
+            ProcId::new(Uid::Instance(0xdef456, None), None),
             None,
         )
         .to_string()
@@ -1160,7 +1170,7 @@ mod tests {
         use std::collections::hash_map::DefaultHasher;
         use std::hash::Hasher;
 
-        let pid = ProcId::new(Uid::Instance(0x42), Some(Label::new("proc").unwrap()));
+        let pid = ProcId::new(Uid::Instance(0x42, None), Some(Label::new("proc").unwrap()));
         let loc: Location = ChannelAddr::Local(1).into();
         let a = ProcAddr::new(pid.clone(), loc.clone());
         let b = ProcAddr::new(pid, loc);
@@ -1176,7 +1186,7 @@ mod tests {
 
     #[test]
     fn test_proc_ref_neq_different_location() {
-        let pid = ProcId::new(Uid::Instance(0x42), Some(Label::new("proc").unwrap()));
+        let pid = ProcId::new(Uid::Instance(0x42, None), Some(Label::new("proc").unwrap()));
         let a = ProcAddr::new(pid.clone(), ChannelAddr::Local(1).into());
         let b = ProcAddr::new(pid, ChannelAddr::Local(2).into());
         assert_ne!(a, b);
@@ -1188,8 +1198,8 @@ mod tests {
         use std::hash::Hasher;
 
         let aid = ActorId::new(
-            Uid::Instance(0x42),
-            ProcId::new(Uid::Instance(0x99), Some(Label::new("proc").unwrap())),
+            Uid::Instance(0x42, None),
+            ProcId::new(Uid::Instance(0x99, None), Some(Label::new("proc").unwrap())),
             Some(Label::new("actor").unwrap()),
         );
         let loc: Location = ChannelAddr::Local(1).into();
@@ -1229,12 +1239,15 @@ mod tests {
             )
         );
         assert_eq!(
-            parse_resource_name(&format!("worker{}", Uid::Instance(0xabc123))),
-            (Uid::Instance(0xabc123), Some(Label::new("worker").unwrap()))
+            parse_resource_name(&format!("worker{}", Uid::Instance(0xabc123, None))),
+            (
+                Uid::Instance(0xabc123, Some(Label::new("worker").unwrap())),
+                Some(Label::new("worker").unwrap())
+            )
         );
         assert_eq!(
-            parse_resource_name(&Uid::Instance(0xabc123).to_string()),
-            (Uid::Instance(0xabc123), None)
+            parse_resource_name(&Uid::Instance(0xabc123, None).to_string()),
+            (Uid::Instance(0xabc123, None), None)
         );
         assert_eq!(
             parse_resource_name("dead"),
@@ -1248,7 +1261,10 @@ mod tests {
     #[test]
     fn test_proc_resource_name_uses_legacy_labeled_instance_format() {
         let proc_ref = ProcAddr::new(
-            ProcId::new(Uid::Instance(0xabc123), Some(Label::new("worker").unwrap())),
+            ProcId::new(
+                Uid::Instance(0xabc123, None),
+                Some(Label::new("worker").unwrap()),
+            ),
             ChannelAddr::Local(42).into(),
         );
 
@@ -1256,7 +1272,7 @@ mod tests {
             proc_ref.resource_name(),
             format!(
                 "worker-{}",
-                Uid::Instance(0xabc123)
+                Uid::Instance(0xabc123, None)
                     .to_string()
                     .trim_start_matches('<')
                     .trim_end_matches('>')
@@ -1286,7 +1302,7 @@ mod tests {
     #[test]
     fn test_proc_ref_serde_roundtrip() {
         let pid = ProcId::new(
-            Uid::Instance(0xabcdef),
+            Uid::Instance(0xabcdef, None),
             Some(Label::new("my-proc").unwrap()),
         );
         let loc: Location = ChannelAddr::Local(42).into();
@@ -1299,9 +1315,9 @@ mod tests {
     #[test]
     fn test_actor_ref_serde_roundtrip() {
         let aid = ActorId::new(
-            Uid::Instance(0xabcdef),
+            Uid::Instance(0xabcdef, None),
             ProcId::new(
-                Uid::Instance(0x123456),
+                Uid::Instance(0x123456, None),
                 Some(Label::new("my-proc").unwrap()),
             ),
             Some(Label::new("my-actor").unwrap()),
@@ -1317,7 +1333,7 @@ mod tests {
     fn test_proc_ref_with_metatls_location() {
         use crate::channel::TlsAddr;
 
-        let pid = ProcId::new(Uid::Instance(0x42), None);
+        let pid = ProcId::new(Uid::Instance(0x42, None), None);
         let loc: Location = ChannelAddr::MetaTls(TlsAddr::new("example.com", 443)).into();
         let pref = ProcAddr::new(pid, loc);
         let s = pref.to_string();
@@ -1329,9 +1345,9 @@ mod tests {
     #[test]
     fn test_port_ref_construction_and_accessors() {
         let aid = ActorId::new(
-            Uid::Instance(0xabc123),
+            Uid::Instance(0xabc123, None),
             ProcId::new(
-                Uid::Instance(0xdef456),
+                Uid::Instance(0xdef456, None),
                 Some(Label::new("my-proc").unwrap()),
             ),
             Some(Label::new("my-actor").unwrap()),
@@ -1347,9 +1363,9 @@ mod tests {
     #[test]
     fn test_port_ref_display() {
         let aid = ActorId::new(
-            Uid::Instance(0xabc123),
+            Uid::Instance(0xabc123, None),
             ProcId::new(
-                Uid::Instance(0xdef456),
+                Uid::Instance(0xdef456, None),
                 Some(Label::new("my-proc").unwrap()),
             ),
             Some(Label::new("my-actor").unwrap()),
@@ -1363,9 +1379,9 @@ mod tests {
     #[test]
     fn test_port_ref_debug_all_labels() {
         let aid = ActorId::new(
-            Uid::Instance(0xabc123),
+            Uid::Instance(0xabc123, None),
             ProcId::new(
-                Uid::Instance(0xdef456),
+                Uid::Instance(0xdef456, None),
                 Some(Label::new("my-proc").unwrap()),
             ),
             Some(Label::new("my-actor").unwrap()),
@@ -1382,8 +1398,8 @@ mod tests {
     #[test]
     fn test_port_ref_debug_no_labels() {
         let aid = ActorId::new(
-            Uid::Instance(0xabc123),
-            ProcId::new(Uid::Instance(0xdef456), None),
+            Uid::Instance(0xabc123, None),
+            ProcId::new(Uid::Instance(0xdef456, None), None),
             None,
         );
         let port_id = PortId::new(aid, Port::from(42));
@@ -1395,8 +1411,8 @@ mod tests {
     #[test]
     fn test_port_ref_debug_actor_label_only() {
         let aid = ActorId::new(
-            Uid::Instance(0xabc123),
-            ProcId::new(Uid::Instance(0xdef456), None),
+            Uid::Instance(0xabc123, None),
+            ProcId::new(Uid::Instance(0xdef456, None), None),
             Some(Label::new("my-actor").unwrap()),
         );
         let port_id = PortId::new(aid, Port::from(42));
@@ -1411,9 +1427,9 @@ mod tests {
     #[test]
     fn test_port_ref_debug_proc_label_only() {
         let aid = ActorId::new(
-            Uid::Instance(0xabc123),
+            Uid::Instance(0xabc123, None),
             ProcId::new(
-                Uid::Instance(0xdef456),
+                Uid::Instance(0xdef456, None),
                 Some(Label::new("my-proc").unwrap()),
             ),
             None,
@@ -1430,9 +1446,9 @@ mod tests {
     #[test]
     fn test_port_ref_fromstr_roundtrip() {
         let aid = ActorId::new(
-            Uid::Instance(0xabc123),
+            Uid::Instance(0xabc123, None),
             ProcId::new(
-                Uid::Instance(0xdef456),
+                Uid::Instance(0xdef456, None),
                 Some(Label::new("my-proc").unwrap()),
             ),
             Some(Label::new("my-actor").unwrap()),
@@ -1455,8 +1471,8 @@ mod tests {
 
     #[test]
     fn test_port_ref_fromstr_examples() {
-        let expected_actor_uid = Uid::Instance(0xabc123);
-        let expected_proc_uid = Uid::Instance(0xdef456);
+        let expected_actor_uid = Uid::Instance(0xabc123, None);
+        let expected_proc_uid = Uid::Instance(0xdef456, None);
         let parsed: PortAddr = format!(
             "{}.{}:42@tcp://[::1]:2345",
             expected_actor_uid, expected_proc_uid
@@ -1476,8 +1492,8 @@ mod tests {
     fn test_port_ref_fromstr_missing_separator() {
         let err = PortId::new(
             ActorId::new(
-                Uid::Instance(0xabc123),
-                ProcId::new(Uid::Instance(0xdef456), None),
+                Uid::Instance(0xabc123, None),
+                ProcId::new(Uid::Instance(0xdef456, None), None),
                 None,
             ),
             Port::from(42),
@@ -1543,8 +1559,8 @@ mod tests {
         use std::hash::Hasher;
 
         let aid = ActorId::new(
-            Uid::Instance(0x42),
-            ProcId::new(Uid::Instance(0x99), Some(Label::new("proc").unwrap())),
+            Uid::Instance(0x42, None),
+            ProcId::new(Uid::Instance(0x99, None), Some(Label::new("proc").unwrap())),
             Some(Label::new("actor").unwrap()),
         );
         let port_id = PortId::new(aid, Port::from(10));
@@ -1564,8 +1580,8 @@ mod tests {
     #[test]
     fn test_port_ref_neq_different_location() {
         let aid = ActorId::new(
-            Uid::Instance(0x42),
-            ProcId::new(Uid::Instance(0x99), Some(Label::new("proc").unwrap())),
+            Uid::Instance(0x42, None),
+            ProcId::new(Uid::Instance(0x99, None), Some(Label::new("proc").unwrap())),
             Some(Label::new("actor").unwrap()),
         );
         let port_id = PortId::new(aid, Port::from(10));
@@ -1577,9 +1593,9 @@ mod tests {
     #[test]
     fn test_port_ref_serde_roundtrip() {
         let aid = ActorId::new(
-            Uid::Instance(0xabcdef),
+            Uid::Instance(0xabcdef, None),
             ProcId::new(
-                Uid::Instance(0x123456),
+                Uid::Instance(0x123456, None),
                 Some(Label::new("my-proc").unwrap()),
             ),
             Some(Label::new("my-actor").unwrap()),

--- a/hyperactor/src/id.rs
+++ b/hyperactor/src/id.rs
@@ -30,7 +30,7 @@
 //! alphanumeric.
 //!
 //! [`Uid`] is either a singleton (identified by label) or an instance
-//! (identified by a random `u64`).
+//! (identified by a random `u64`, with an optional label for display).
 
 use std::cmp::Ordering;
 use std::fmt;
@@ -46,6 +46,7 @@ use crate::parse::id::ActorIdParts;
 use crate::parse::id::IdComponent;
 use crate::parse::id::PortIdParts;
 use crate::parse::id::ProcIdParts;
+use crate::parse::id::UidParts;
 use crate::port::Port;
 
 /// Maximum length of an RFC 1035 label.
@@ -188,18 +189,24 @@ impl<'de> Deserialize<'de> for Label {
     }
 }
 
-/// A unique identifier: either a labeled singleton or a random instance.
+/// A unique identifier.
+///
+/// Singleton labels are identity. Instance labels are supplemental metadata
+/// and do not participate in equality, hashing, or ordering.
 #[derive(Clone)]
 pub enum Uid {
     /// A singleton identified by label.
     Singleton(Label),
-    /// An instance identified by a random u64.
-    Instance(u64),
+    /// An instance identified by a random u64, with an optional display label.
+    Instance(u64, Option<Label>),
 }
 
 /// Errors that can occur when parsing a [`Uid`] from a string.
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 pub enum UidParseError {
+    /// Error parsing the uid syntax.
+    #[error("invalid uid syntax: {0}")]
+    InvalidSyntax(String),
     /// Error parsing the label component.
     #[error("invalid label: {0}")]
     InvalidLabel(#[from] LabelError),
@@ -211,12 +218,38 @@ pub enum UidParseError {
 impl Uid {
     /// Create a fresh instance with a random uid.
     pub fn instance() -> Self {
-        Uid::Instance(rand::random())
+        Uid::Instance(rand::random(), None)
+    }
+
+    /// Create a fresh instance with a random uid and display label.
+    pub fn instance_labeled(label: Label) -> Self {
+        Uid::Instance(rand::random(), Some(label))
     }
 
     /// Create a singleton with the given label.
     pub fn singleton(label: Label) -> Self {
         Uid::Singleton(label)
+    }
+
+    /// Returns the display label for this uid, if present.
+    ///
+    /// For singletons, the label is the identity. For instances, the label is
+    /// supplemental metadata.
+    pub fn label(&self) -> Option<&Label> {
+        match self {
+            Uid::Singleton(label) => Some(label),
+            Uid::Instance(_, label) => label.as_ref(),
+        }
+    }
+
+    /// Returns this uid with the provided instance label.
+    ///
+    /// Singleton labels are identity and are not replaced.
+    pub fn with_label(self, label: Option<Label>) -> Self {
+        match self {
+            Uid::Singleton(label) => Uid::Singleton(label),
+            Uid::Instance(uid, existing) => Uid::Instance(uid, label.or(existing)),
+        }
     }
 }
 
@@ -224,7 +257,7 @@ impl PartialEq for Uid {
     fn eq(&self, other: &Self) -> bool {
         match (self, other) {
             (Uid::Singleton(a), Uid::Singleton(b)) => a == b,
-            (Uid::Instance(a), Uid::Instance(b)) => a == b,
+            (Uid::Instance(a, _), Uid::Instance(b, _)) => a == b,
             _ => false,
         }
     }
@@ -237,7 +270,7 @@ impl Hash for Uid {
         std::mem::discriminant(self).hash(state);
         match self {
             Uid::Singleton(label) => label.hash(state),
-            Uid::Instance(uid) => uid.hash(state),
+            Uid::Instance(uid, _) => uid.hash(state),
         }
     }
 }
@@ -252,19 +285,23 @@ impl Ord for Uid {
     fn cmp(&self, other: &Self) -> Ordering {
         match (self, other) {
             (Uid::Singleton(a), Uid::Singleton(b)) => a.cmp(b),
-            (Uid::Singleton(_), Uid::Instance(_)) => Ordering::Less,
-            (Uid::Instance(_), Uid::Singleton(_)) => Ordering::Greater,
-            (Uid::Instance(a), Uid::Instance(b)) => a.cmp(b),
+            (Uid::Singleton(_), Uid::Instance(_, _)) => Ordering::Less,
+            (Uid::Instance(_, _), Uid::Singleton(_)) => Ordering::Greater,
+            (Uid::Instance(a, _), Uid::Instance(b, _)) => a.cmp(b),
         }
     }
 }
 
-/// Displays as `label` (singleton) or `<base58>` (instance).
+/// Displays as `label` (singleton), `label<base58>` (labeled instance), or
+/// `<base58>` (unlabeled instance).
 impl fmt::Debug for Uid {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Uid::Singleton(label) => write!(f, "Uid({})", label),
-            Uid::Instance(uid) => write!(f, "Uid(<{}>)", encode_base58_uid(*uid)),
+            Uid::Instance(uid, Some(label)) => {
+                write!(f, "Uid({}<{}>)", label, encode_base58_uid(*uid))
+            }
+            Uid::Instance(uid, None) => write!(f, "Uid(<{}>)", encode_base58_uid(*uid)),
         }
     }
 }
@@ -273,24 +310,21 @@ impl fmt::Display for Uid {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Uid::Singleton(label) => write!(f, "{label}"),
-            Uid::Instance(uid) => write!(f, "<{}>", encode_base58_uid(*uid)),
+            Uid::Instance(uid, Some(label)) => write!(f, "{}<{}>", label, encode_base58_uid(*uid)),
+            Uid::Instance(uid, None) => write!(f, "<{}>", encode_base58_uid(*uid)),
         }
     }
 }
 
-/// Parses `label` as singleton, `<base58>` as instance.
+/// Parses `label` as singleton, `<base58>` as an unlabeled instance, and
+/// `label<base58>` as a labeled instance.
 impl FromStr for Uid {
     type Err = UidParseError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        if let Some(inner) = s
-            .strip_prefix('<')
-            .and_then(|inner| inner.strip_suffix('>'))
-        {
-            let uid = parse_base58_uid(inner)?;
-            return Ok(Uid::Instance(uid));
-        }
-        Ok(Uid::Singleton(Label::new(s)?))
+        let parts = crate::parse::id::parse_uid(s)
+            .map_err(|err| UidParseError::InvalidSyntax(err.to_string()))?;
+        Self::try_from(parts)
     }
 }
 
@@ -324,16 +358,6 @@ fn parse_base58_uid(s: &str) -> Result<u64, UidParseError> {
             .ok_or_else(|| UidParseError::InvalidBase58(s.to_string()))?;
     }
     Ok(uid)
-}
-
-fn fmt_id_component(f: &mut fmt::Formatter<'_>, uid: &Uid, label: Option<&Label>) -> fmt::Result {
-    match uid {
-        Uid::Singleton(singleton) => write!(f, "{}", singleton),
-        Uid::Instance(uid) => match label {
-            Some(label) => write!(f, "{}<{}>", label, encode_base58_uid(*uid)),
-            None => write!(f, "<{}>", encode_base58_uid(*uid)),
-        },
-    }
 }
 
 impl Serialize for Uid {
@@ -374,33 +398,31 @@ pub enum IdParseError {
 
 /// Identifies a process in the actor system.
 ///
-/// Identity (Eq, Hash, Ord) is determined solely by `uid`; `label` is
-/// informational and excluded from comparisons.
+/// Identity (Eq, Hash, Ord) is determined by `uid`.
 #[derive(Clone, Serialize, Deserialize)]
 pub struct ProcId {
     uid: Uid,
-    label: Option<Label>,
 }
 
 impl ProcId {
     /// Create a new [`ProcId`].
     pub fn new(uid: Uid, label: Option<Label>) -> Self {
-        Self { uid, label }
+        Self {
+            uid: uid.with_label(label),
+        }
     }
 
     /// Create a singleton [`ProcId`] identified by the given label.
     pub fn singleton(label: Label) -> Self {
         Self {
-            uid: Uid::Singleton(label.clone()),
-            label: Some(label),
+            uid: Uid::Singleton(label),
         }
     }
 
     /// Create an instance [`ProcId`] with a random uid and the given label.
     pub fn instance(label: Label) -> Self {
         Self {
-            uid: Uid::instance(),
-            label: Some(label),
+            uid: Uid::instance_labeled(label),
         }
     }
 
@@ -411,7 +433,7 @@ impl ProcId {
 
     /// Returns the label.
     pub fn label(&self) -> Option<&Label> {
-        self.label.as_ref()
+        self.uid.label()
     }
 }
 
@@ -443,13 +465,13 @@ impl Ord for ProcId {
 
 impl fmt::Display for ProcId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt_id_component(f, &self.uid, self.label.as_ref())
+        fmt::Display::fmt(&self.uid, f)
     }
 }
 
 impl fmt::Debug for ProcId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match &self.label {
+        match self.label() {
             Some(label) => write!(f, "<'{}' {}>", label, self.uid),
             None => write!(f, "<{}>", self.uid),
         }
@@ -468,31 +490,27 @@ impl FromStr for ProcId {
 
 /// Identifies an actor within a process.
 ///
-/// Identity (Eq, Hash, Ord) is determined by `(proc_id, uid)`; `label` is
-/// informational and excluded from comparisons.
+/// Identity (Eq, Hash, Ord) is determined by `(proc_id, uid)`.
 #[derive(Clone, Serialize, Deserialize)]
 pub struct ActorId {
     uid: Uid,
     proc_id: ProcId,
-    label: Option<Label>,
 }
 
 impl ActorId {
     /// Create a new [`ActorId`].
     pub fn new(uid: Uid, proc_id: ProcId, label: Option<Label>) -> Self {
         Self {
-            uid,
+            uid: uid.with_label(label),
             proc_id,
-            label,
         }
     }
 
     /// Create a singleton [`ActorId`] identified by the given label.
     pub fn singleton(label: Label, proc_id: ProcId) -> Self {
         Self {
-            uid: Uid::Singleton(label.clone()),
+            uid: Uid::Singleton(label),
             proc_id,
-            label: Some(label),
         }
     }
 
@@ -501,16 +519,14 @@ impl ActorId {
         Self {
             uid: Uid::instance(),
             proc_id,
-            label: None,
         }
     }
 
     /// Create an instance [`ActorId`] with a random uid and the given label.
     pub fn instance_labeled(label: Label, proc_id: ProcId) -> Self {
         Self {
-            uid: Uid::instance(),
+            uid: Uid::instance_labeled(label),
             proc_id,
-            label: Some(label),
         }
     }
 
@@ -526,7 +542,7 @@ impl ActorId {
 
     /// Returns the label.
     pub fn label(&self) -> Option<&Label> {
-        self.label.as_ref()
+        self.uid.label()
     }
 }
 
@@ -561,14 +577,14 @@ impl Ord for ActorId {
 
 impl fmt::Display for ActorId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt_id_component(f, &self.uid, self.label.as_ref())?;
+        fmt::Display::fmt(&self.uid, f)?;
         write!(f, ".{}", self.proc_id)
     }
 }
 
 impl fmt::Debug for ActorId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match (&self.label, &self.proc_id.label) {
+        match (self.label(), self.proc_id.label()) {
             (Some(actor_label), Some(proc_label)) => {
                 write!(
                     f,
@@ -703,8 +719,8 @@ fn convert_id_component(component: IdComponent<'_>) -> Result<(Uid, Option<Label
             Ok((Uid::Singleton(label.clone()), Some(label)))
         }
         IdComponent::Instance { label, uid, .. } => {
-            let uid = Uid::Instance(parse_base58_uid(uid)?);
             let label = label.map(Label::new).transpose()?;
+            let uid = Uid::Instance(parse_base58_uid(uid)?, label.clone());
             Ok((uid, label))
         }
     }
@@ -715,7 +731,15 @@ impl TryFrom<ProcIdParts<'_>> for ProcId {
 
     fn try_from(parts: ProcIdParts<'_>) -> Result<Self, Self::Error> {
         let (uid, label) = convert_id_component(parts.component)?;
-        Ok(Self { uid, label })
+        Ok(Self::new(uid, label))
+    }
+}
+
+impl TryFrom<UidParts<'_>> for Uid {
+    type Error = UidParseError;
+
+    fn try_from(parts: UidParts<'_>) -> Result<Self, Self::Error> {
+        convert_id_component(parts.component).map(|(uid, _)| uid)
     }
 }
 
@@ -729,11 +753,7 @@ impl TryFrom<ActorIdParts<'_>> for ActorId {
             component: parts.proc_,
         })
         .map_err(IdParseError::InvalidActorProcUid)?;
-        Ok(Self {
-            uid,
-            proc_id,
-            label,
-        })
+        Ok(Self::new(uid, proc_id, label))
     }
 }
 
@@ -756,7 +776,7 @@ fn legacy_parse_id_component(s: &str) -> Result<(Uid, Option<Label>), UidParseEr
         .and_then(|inner| inner.strip_suffix('>'))
     {
         let uid = parse_base58_uid(inner)?;
-        return Ok((Uid::Instance(uid), None));
+        return Ok((Uid::Instance(uid, None), None));
     }
 
     if let Some(open) = s.find('<')
@@ -764,7 +784,7 @@ fn legacy_parse_id_component(s: &str) -> Result<(Uid, Option<Label>), UidParseEr
     {
         let label = Label::new(&s[..open])?;
         let uid = parse_base58_uid(&s[open + 1..s.len() - 1])?;
-        return Ok((Uid::Instance(uid), Some(label)));
+        return Ok((Uid::Instance(uid, Some(label.clone())), Some(label)));
     }
 
     let label = Label::new(s)?;
@@ -898,7 +918,7 @@ mod tests {
 
     #[test]
     fn test_instance_display_parse() {
-        let uid = Uid::Instance(0xd5d54d7201103869);
+        let uid = Uid::Instance(0xd5d54d7201103869, None);
         let s = uid.to_string();
         assert_eq!(s, format!("<{}>", encode_base58_uid(0xd5d54d7201103869)));
         let parsed: Uid = s.parse().unwrap();
@@ -906,9 +926,40 @@ mod tests {
     }
 
     #[test]
+    fn test_labeled_instance_display_parse() {
+        let label = Label::new("my-actor").unwrap();
+        let uid = Uid::Instance(0xd5d54d7201103869, Some(label.clone()));
+        let s = uid.to_string();
+        assert_eq!(
+            s,
+            format!("my-actor<{}>", encode_base58_uid(0xd5d54d7201103869))
+        );
+        let parsed: Uid = s.parse().unwrap();
+        assert_eq!(parsed, uid);
+        assert_eq!(parsed.label(), Some(&label));
+    }
+
+    #[test]
+    fn test_labeled_instance_identity_ignores_label() {
+        let a = Uid::Instance(0x42, Some(Label::new("alpha").unwrap()));
+        let b = Uid::Instance(0x42, Some(Label::new("beta").unwrap()));
+        assert_eq!(a, b);
+        assert_eq!(a.cmp(&b), Ordering::Equal);
+
+        use std::collections::hash_map::DefaultHasher;
+
+        let hash = |uid: &Uid| {
+            let mut h = DefaultHasher::new();
+            uid.hash(&mut h);
+            h.finish()
+        };
+        assert_eq!(hash(&a), hash(&b));
+    }
+
+    #[test]
     fn test_ordering_singleton_lt_instance() {
         let singleton = Uid::singleton(Label::new("zzz").unwrap());
-        let instance = Uid::Instance(0);
+        let instance = Uid::Instance(0, None);
         assert!(singleton < instance);
     }
 
@@ -921,8 +972,8 @@ mod tests {
 
     #[test]
     fn test_ordering_instances() {
-        let a = Uid::Instance(1);
-        let b = Uid::Instance(2);
+        let a = Uid::Instance(1, None);
+        let b = Uid::Instance(2, None);
         assert!(a < b);
     }
 
@@ -930,8 +981,8 @@ mod tests {
     fn test_uid_serde_roundtrip() {
         let uids = vec![
             Uid::singleton(Label::new("my-actor").unwrap()),
-            Uid::Instance(0xabcdef0123456789),
-            Uid::Instance(1),
+            Uid::Instance(0xabcdef0123456789, None),
+            Uid::Instance(1, None),
         ];
         for uid in uids {
             let json = serde_json::to_string(&uid).unwrap();
@@ -949,7 +1000,10 @@ mod tests {
         // Invalid base58.
         assert!("<0>".parse::<Uid>().is_err());
         // Missing closing delimiter.
-        assert!("<abc".parse::<Uid>().is_err());
+        assert_eq!(
+            "<abc".parse::<Uid>().unwrap_err().to_string(),
+            "invalid uid syntax: expected \">\", found end of input"
+        );
     }
 
     #[test]
@@ -962,12 +1016,12 @@ mod tests {
     #[test]
     fn test_short_hex_parse() {
         let parsed: Uid = "<2>".parse().unwrap();
-        assert_eq!(parsed, Uid::Instance(1));
+        assert_eq!(parsed, Uid::Instance(1, None));
     }
 
     #[test]
     fn test_proc_id_construction_and_accessors() {
-        let uid = Uid::Instance(0xabc);
+        let uid = Uid::Instance(0xabc, None);
         let label = Label::new("my-proc").unwrap();
         let pid = ProcId::new(uid.clone(), Some(label.clone()));
         assert_eq!(pid.uid(), &uid);
@@ -976,7 +1030,7 @@ mod tests {
 
     #[test]
     fn test_proc_id_eq_ignores_label() {
-        let uid = Uid::Instance(0x42);
+        let uid = Uid::Instance(0x42, None);
         let a = ProcId::new(uid.clone(), Some(Label::new("alpha").unwrap()));
         let b = ProcId::new(uid, Some(Label::new("beta").unwrap()));
         assert_eq!(a, b);
@@ -986,7 +1040,7 @@ mod tests {
     fn test_proc_id_hash_ignores_label() {
         use std::collections::hash_map::DefaultHasher;
 
-        let uid = Uid::Instance(0x42);
+        let uid = Uid::Instance(0x42, None);
         let a = ProcId::new(uid.clone(), Some(Label::new("alpha").unwrap()));
         let b = ProcId::new(uid, Some(Label::new("beta").unwrap()));
 
@@ -1000,15 +1054,15 @@ mod tests {
 
     #[test]
     fn test_proc_id_ord_ignores_label() {
-        let a = ProcId::new(Uid::Instance(1), Some(Label::new("zzz").unwrap()));
-        let b = ProcId::new(Uid::Instance(2), Some(Label::new("aaa").unwrap()));
+        let a = ProcId::new(Uid::Instance(1, None), Some(Label::new("zzz").unwrap()));
+        let b = ProcId::new(Uid::Instance(2, None), Some(Label::new("aaa").unwrap()));
         assert!(a < b);
     }
 
     #[test]
     fn test_proc_id_display() {
         let pid = ProcId::new(
-            Uid::Instance(0xd5d54d7201103869),
+            Uid::Instance(0xd5d54d7201103869, None),
             Some(Label::new("my-proc").unwrap()),
         );
         assert_eq!(
@@ -1026,15 +1080,18 @@ mod tests {
     #[test]
     fn test_proc_id_debug() {
         let pid = ProcId::new(
-            Uid::Instance(0xd5d54d7201103869),
+            Uid::Instance(0xd5d54d7201103869, None),
             Some(Label::new("my-proc").unwrap()),
         );
         assert_eq!(
             format!("{:?}", pid),
-            format!("<'my-proc' <{}>>", encode_base58_uid(0xd5d54d7201103869))
+            format!(
+                "<'my-proc' my-proc<{}>>",
+                encode_base58_uid(0xd5d54d7201103869)
+            )
         );
 
-        let pid_no_label = ProcId::new(Uid::Instance(0xd5d54d7201103869), None);
+        let pid_no_label = ProcId::new(Uid::Instance(0xd5d54d7201103869, None), None);
         assert_eq!(
             format!("{:?}", pid_no_label),
             format!("<<{}>>", encode_base58_uid(0xd5d54d7201103869))
@@ -1044,7 +1101,7 @@ mod tests {
     #[test]
     fn test_proc_id_fromstr_roundtrip() {
         let pid = ProcId::new(
-            Uid::Instance(0xd5d54d7201103869),
+            Uid::Instance(0xd5d54d7201103869, None),
             Some(Label::new("my-proc").unwrap()),
         );
         let s = pid.to_string();
@@ -1065,7 +1122,7 @@ mod tests {
 
     #[test]
     fn test_proc_id_fromstr_unlabeled_instance() {
-        let expected_uid = Uid::Instance(0xabc123);
+        let expected_uid = Uid::Instance(0xabc123, None);
         let parsed: ProcId = expected_uid.to_string().parse().unwrap();
         assert_eq!(parsed.uid(), &expected_uid);
         assert_eq!(parsed.label(), None);
@@ -1073,7 +1130,7 @@ mod tests {
 
     #[test]
     fn test_proc_id_fromstr_labeled_instance_with_underscore() {
-        let expected_uid = Uid::Instance(0xabc123);
+        let expected_uid = Uid::Instance(0xabc123, None);
         let parsed: ProcId = format!("proc_agent{}", expected_uid).parse().unwrap();
         assert_eq!(parsed.uid(), &expected_uid);
         assert_eq!(
@@ -1104,7 +1161,7 @@ mod tests {
     #[test]
     fn test_proc_id_serde_roundtrip() {
         let pid = ProcId::new(
-            Uid::Instance(0xabcdef),
+            Uid::Instance(0xabcdef, None),
             Some(Label::new("my-proc").unwrap()),
         );
         let json = serde_json::to_string(&pid).unwrap();
@@ -1112,7 +1169,7 @@ mod tests {
         assert_eq!(pid, parsed);
         assert_eq!(parsed.label().map(|l| l.as_str()), Some("my-proc"));
 
-        let pid_none = ProcId::new(Uid::Instance(0xabcdef), None);
+        let pid_none = ProcId::new(Uid::Instance(0xabcdef, None), None);
         let json_none = serde_json::to_string(&pid_none).unwrap();
         let parsed_none: ProcId = serde_json::from_str(&json_none).unwrap();
         assert_eq!(parsed_none.label(), None);
@@ -1130,7 +1187,7 @@ mod tests {
     fn test_proc_id_instance() {
         let label = Label::new("my-proc").unwrap();
         let pid = ProcId::instance(label.clone());
-        assert!(matches!(pid.uid(), Uid::Instance(_)));
+        assert!(matches!(pid.uid(), Uid::Instance(_, Some(_))));
         assert_eq!(pid.label(), Some(&label));
         let pid2 = ProcId::instance(label);
         assert_ne!(pid, pid2);
@@ -1150,7 +1207,7 @@ mod tests {
     fn test_actor_id_instance() {
         let proc_id = ProcId::singleton(Label::new("my-proc").unwrap());
         let aid = ActorId::instance(proc_id.clone());
-        assert!(matches!(aid.uid(), Uid::Instance(_)));
+        assert!(matches!(aid.uid(), Uid::Instance(_, None)));
         assert_eq!(aid.proc_id(), &proc_id);
         assert_eq!(aid.label(), None);
         let aid2 = ActorId::instance(proc_id);
@@ -1162,7 +1219,7 @@ mod tests {
         let label = Label::new("my-actor").unwrap();
         let proc_id = ProcId::singleton(Label::new("my-proc").unwrap());
         let aid = ActorId::instance_labeled(label.clone(), proc_id.clone());
-        assert!(matches!(aid.uid(), Uid::Instance(_)));
+        assert!(matches!(aid.uid(), Uid::Instance(_, Some(_))));
         assert_eq!(aid.proc_id(), &proc_id);
         assert_eq!(aid.label(), Some(&label));
         let aid2 = ActorId::instance_labeled(label, proc_id);
@@ -1171,8 +1228,11 @@ mod tests {
 
     #[test]
     fn test_actor_id_construction_and_accessors() {
-        let actor_uid = Uid::Instance(0xabc);
-        let proc_id = ProcId::new(Uid::Instance(0xdef), Some(Label::new("my-proc").unwrap()));
+        let actor_uid = Uid::Instance(0xabc, None);
+        let proc_id = ProcId::new(
+            Uid::Instance(0xdef, None),
+            Some(Label::new("my-proc").unwrap()),
+        );
         let label = Label::new("my-actor").unwrap();
         let aid = ActorId::new(actor_uid.clone(), proc_id.clone(), Some(label.clone()));
         assert_eq!(aid.uid(), &actor_uid);
@@ -1182,8 +1242,8 @@ mod tests {
 
     #[test]
     fn test_actor_id_eq_ignores_label() {
-        let actor_uid = Uid::Instance(0x42);
-        let proc_id = ProcId::new(Uid::Instance(0x99), Some(Label::new("proc").unwrap()));
+        let actor_uid = Uid::Instance(0x42, None);
+        let proc_id = ProcId::new(Uid::Instance(0x99, None), Some(Label::new("proc").unwrap()));
         let a = ActorId::new(
             actor_uid.clone(),
             proc_id.clone(),
@@ -1195,9 +1255,9 @@ mod tests {
 
     #[test]
     fn test_actor_id_neq_different_proc() {
-        let actor_uid = Uid::Instance(0x42);
-        let proc_a = ProcId::new(Uid::Instance(1), Some(Label::new("proc").unwrap()));
-        let proc_b = ProcId::new(Uid::Instance(2), Some(Label::new("proc").unwrap()));
+        let actor_uid = Uid::Instance(0x42, None);
+        let proc_a = ProcId::new(Uid::Instance(1, None), Some(Label::new("proc").unwrap()));
+        let proc_b = ProcId::new(Uid::Instance(2, None), Some(Label::new("proc").unwrap()));
         let a = ActorId::new(
             actor_uid.clone(),
             proc_a,
@@ -1211,8 +1271,8 @@ mod tests {
     fn test_actor_id_hash_ignores_label() {
         use std::collections::hash_map::DefaultHasher;
 
-        let actor_uid = Uid::Instance(0x42);
-        let proc_id = ProcId::new(Uid::Instance(0x99), Some(Label::new("proc").unwrap()));
+        let actor_uid = Uid::Instance(0x42, None);
+        let proc_id = ProcId::new(Uid::Instance(0x99, None), Some(Label::new("proc").unwrap()));
         let a = ActorId::new(
             actor_uid.clone(),
             proc_id.clone(),
@@ -1231,13 +1291,13 @@ mod tests {
     #[test]
     fn test_actor_id_ord_proc_first() {
         let a = ActorId::new(
-            Uid::Instance(0xff),
-            ProcId::new(Uid::Instance(1), Some(Label::new("p").unwrap())),
+            Uid::Instance(0xff, None),
+            ProcId::new(Uid::Instance(1, None), Some(Label::new("p").unwrap())),
             Some(Label::new("a").unwrap()),
         );
         let b = ActorId::new(
-            Uid::Instance(0x01),
-            ProcId::new(Uid::Instance(2), Some(Label::new("p").unwrap())),
+            Uid::Instance(0x01, None),
+            ProcId::new(Uid::Instance(2, None), Some(Label::new("p").unwrap())),
             Some(Label::new("a").unwrap()),
         );
         assert!(a < b, "proc_id should be compared first");
@@ -1245,22 +1305,26 @@ mod tests {
 
     #[test]
     fn test_actor_id_ord_then_uid() {
-        let proc_id = ProcId::new(Uid::Instance(1), Some(Label::new("p").unwrap()));
+        let proc_id = ProcId::new(Uid::Instance(1, None), Some(Label::new("p").unwrap()));
         let a = ActorId::new(
-            Uid::Instance(1),
+            Uid::Instance(1, None),
             proc_id.clone(),
             Some(Label::new("a").unwrap()),
         );
-        let b = ActorId::new(Uid::Instance(2), proc_id, Some(Label::new("a").unwrap()));
+        let b = ActorId::new(
+            Uid::Instance(2, None),
+            proc_id,
+            Some(Label::new("a").unwrap()),
+        );
         assert!(a < b);
     }
 
     #[test]
     fn test_actor_id_display() {
         let aid = ActorId::new(
-            Uid::Instance(0xabc123),
+            Uid::Instance(0xabc123, None),
             ProcId::new(
-                Uid::Instance(0xdef456),
+                Uid::Instance(0xdef456, None),
                 Some(Label::new("my-proc").unwrap()),
             ),
             Some(Label::new("my-actor").unwrap()),
@@ -1278,9 +1342,9 @@ mod tests {
     #[test]
     fn test_actor_id_debug() {
         let aid = ActorId::new(
-            Uid::Instance(0xabc123),
+            Uid::Instance(0xabc123, None),
             ProcId::new(
-                Uid::Instance(0xdef456),
+                Uid::Instance(0xdef456, None),
                 Some(Label::new("my-proc").unwrap()),
             ),
             Some(Label::new("my-actor").unwrap()),
@@ -1288,15 +1352,15 @@ mod tests {
         assert_eq!(
             format!("{:?}", aid),
             format!(
-                "<'my-actor.my-proc' <{}>.<{}>>",
+                "<'my-actor.my-proc' my-actor<{}>.my-proc<{}>>",
                 encode_base58_uid(0xabc123),
                 encode_base58_uid(0xdef456)
             )
         );
 
         let aid_no_labels = ActorId::new(
-            Uid::Instance(0xabc123),
-            ProcId::new(Uid::Instance(0xdef456), None),
+            Uid::Instance(0xabc123, None),
+            ProcId::new(Uid::Instance(0xdef456, None), None),
             None,
         );
         assert_eq!(
@@ -1312,9 +1376,9 @@ mod tests {
     #[test]
     fn test_actor_id_fromstr_roundtrip() {
         let aid = ActorId::new(
-            Uid::Instance(0xabc123),
+            Uid::Instance(0xabc123, None),
             ProcId::new(
-                Uid::Instance(0xdef456),
+                Uid::Instance(0xdef456, None),
                 Some(Label::new("my-proc").unwrap()),
             ),
             Some(Label::new("my-actor").unwrap()),
@@ -1349,7 +1413,7 @@ mod tests {
 
     #[test]
     fn test_actor_id_fromstr_mixed_examples() {
-        let proc_uid = Uid::Instance(0xabc123);
+        let proc_uid = Uid::Instance(0xabc123, None);
         let parsed: ActorId = format!("controller.some-proc-123{}", proc_uid)
             .parse()
             .unwrap();
@@ -1367,8 +1431,8 @@ mod tests {
             Some("some-proc-123")
         );
 
-        let expected_actor_uid = Uid::Instance(0xabc123);
-        let expected_proc_uid = Uid::Instance(0xdef456);
+        let expected_actor_uid = Uid::Instance(0xabc123, None);
+        let expected_proc_uid = Uid::Instance(0xdef456, None);
         let parsed: ActorId = format!("{}.{}", expected_actor_uid, expected_proc_uid)
             .parse()
             .unwrap();
@@ -1377,7 +1441,7 @@ mod tests {
         assert_eq!(parsed.label(), None);
         assert_eq!(parsed.proc_id().label(), None);
 
-        let expected_actor_uid = Uid::Instance(0xabc123);
+        let expected_actor_uid = Uid::Instance(0xabc123, None);
         let parsed: ActorId = format!("controller{}.local", expected_actor_uid)
             .parse()
             .unwrap();
@@ -1427,9 +1491,9 @@ mod tests {
     #[test]
     fn test_actor_id_serde_roundtrip() {
         let aid = ActorId::new(
-            Uid::Instance(0xabcdef),
+            Uid::Instance(0xabcdef, None),
             ProcId::new(
-                Uid::Instance(0x123456),
+                Uid::Instance(0x123456, None),
                 Some(Label::new("my-proc").unwrap()),
             ),
             Some(Label::new("my-actor").unwrap()),
@@ -1446,8 +1510,11 @@ mod tests {
 
     #[test]
     fn test_port_id_construction_and_accessors() {
-        let actor_uid = Uid::Instance(0xabc);
-        let proc_id = ProcId::new(Uid::Instance(0xdef), Some(Label::new("my-proc").unwrap()));
+        let actor_uid = Uid::Instance(0xabc, None);
+        let proc_id = ProcId::new(
+            Uid::Instance(0xdef, None),
+            Some(Label::new("my-proc").unwrap()),
+        );
         let actor_id = ActorId::new(
             actor_uid,
             proc_id.clone(),
@@ -1463,8 +1530,8 @@ mod tests {
     #[test]
     fn test_port_id_eq() {
         let actor_id = ActorId::new(
-            Uid::Instance(0x42),
-            ProcId::new(Uid::Instance(0x99), Some(Label::new("proc").unwrap())),
+            Uid::Instance(0x42, None),
+            ProcId::new(Uid::Instance(0x99, None), Some(Label::new("proc").unwrap())),
             Some(Label::new("actor").unwrap()),
         );
         let a = PortId::new(actor_id.clone(), Port::from(10));
@@ -1475,8 +1542,8 @@ mod tests {
     #[test]
     fn test_port_id_neq_different_port() {
         let actor_id = ActorId::new(
-            Uid::Instance(0x42),
-            ProcId::new(Uid::Instance(0x99), Some(Label::new("proc").unwrap())),
+            Uid::Instance(0x42, None),
+            ProcId::new(Uid::Instance(0x99, None), Some(Label::new("proc").unwrap())),
             Some(Label::new("actor").unwrap()),
         );
         let a = PortId::new(actor_id.clone(), Port::from(10));
@@ -1489,8 +1556,8 @@ mod tests {
         use std::collections::hash_map::DefaultHasher;
 
         let actor_id = ActorId::new(
-            Uid::Instance(0x42),
-            ProcId::new(Uid::Instance(0x99), Some(Label::new("proc").unwrap())),
+            Uid::Instance(0x42, None),
+            ProcId::new(Uid::Instance(0x99, None), Some(Label::new("proc").unwrap())),
             Some(Label::new("actor").unwrap()),
         );
         let a = PortId::new(actor_id.clone(), Port::from(10));
@@ -1506,8 +1573,8 @@ mod tests {
     #[test]
     fn test_port_id_ord() {
         let actor_id = ActorId::new(
-            Uid::Instance(0x42),
-            ProcId::new(Uid::Instance(0x99), Some(Label::new("proc").unwrap())),
+            Uid::Instance(0x42, None),
+            ProcId::new(Uid::Instance(0x99, None), Some(Label::new("proc").unwrap())),
             Some(Label::new("actor").unwrap()),
         );
         let a = PortId::new(actor_id.clone(), Port::from(1));
@@ -1519,16 +1586,16 @@ mod tests {
     fn test_port_id_ord_actor_first() {
         let a = PortId::new(
             ActorId::new(
-                Uid::Instance(0x01),
-                ProcId::new(Uid::Instance(1), Some(Label::new("p").unwrap())),
+                Uid::Instance(0x01, None),
+                ProcId::new(Uid::Instance(1, None), Some(Label::new("p").unwrap())),
                 Some(Label::new("a").unwrap()),
             ),
             Port::from(99),
         );
         let b = PortId::new(
             ActorId::new(
-                Uid::Instance(0x02),
-                ProcId::new(Uid::Instance(1), Some(Label::new("p").unwrap())),
+                Uid::Instance(0x02, None),
+                ProcId::new(Uid::Instance(1, None), Some(Label::new("p").unwrap())),
                 Some(Label::new("a").unwrap()),
             ),
             Port::from(1),
@@ -1539,9 +1606,9 @@ mod tests {
     #[test]
     fn test_port_id_display() {
         let aid = ActorId::new(
-            Uid::Instance(0xabc123),
+            Uid::Instance(0xabc123, None),
             ProcId::new(
-                Uid::Instance(0xdef456),
+                Uid::Instance(0xdef456, None),
                 Some(Label::new("my-proc").unwrap()),
             ),
             Some(Label::new("my-actor").unwrap()),
@@ -1570,7 +1637,7 @@ mod tests {
         );
         assert_eq!(parsed.port(), Port::from(0));
 
-        let expected_actor_uid = Uid::Instance(0xabc123);
+        let expected_actor_uid = Uid::Instance(0xabc123, None);
         let parsed: PortId = format!("controller{}.local:42", expected_actor_uid)
             .parse()
             .unwrap();
@@ -1585,8 +1652,8 @@ mod tests {
         );
         assert_eq!(parsed.port(), Port::from(42));
 
-        let expected_actor_uid = Uid::Instance(0xabc123);
-        let expected_proc_uid = Uid::Instance(0xdef456);
+        let expected_actor_uid = Uid::Instance(0xabc123, None);
+        let expected_proc_uid = Uid::Instance(0xdef456, None);
         let parsed: PortId = format!("{}.{}:7", expected_actor_uid, expected_proc_uid)
             .parse()
             .unwrap();
@@ -1598,9 +1665,9 @@ mod tests {
     #[test]
     fn test_port_id_debug_all_labels() {
         let aid = ActorId::new(
-            Uid::Instance(0xabc123),
+            Uid::Instance(0xabc123, None),
             ProcId::new(
-                Uid::Instance(0xdef456),
+                Uid::Instance(0xdef456, None),
                 Some(Label::new("my-proc").unwrap()),
             ),
             Some(Label::new("my-actor").unwrap()),
@@ -1619,8 +1686,8 @@ mod tests {
     #[test]
     fn test_port_id_debug_no_labels() {
         let aid = ActorId::new(
-            Uid::Instance(0xabc123),
-            ProcId::new(Uid::Instance(0xdef456), None),
+            Uid::Instance(0xabc123, None),
+            ProcId::new(Uid::Instance(0xdef456, None), None),
             None,
         );
         let pid = PortId::new(aid, Port::from(42));
@@ -1637,8 +1704,8 @@ mod tests {
     #[test]
     fn test_port_id_debug_actor_label_only() {
         let aid = ActorId::new(
-            Uid::Instance(0xabc123),
-            ProcId::new(Uid::Instance(0xdef456), None),
+            Uid::Instance(0xabc123, None),
+            ProcId::new(Uid::Instance(0xdef456, None), None),
             Some(Label::new("my-actor").unwrap()),
         );
         let pid = PortId::new(aid, Port::from(42));
@@ -1655,9 +1722,9 @@ mod tests {
     #[test]
     fn test_port_id_debug_proc_label_only() {
         let aid = ActorId::new(
-            Uid::Instance(0xabc123),
+            Uid::Instance(0xabc123, None),
             ProcId::new(
-                Uid::Instance(0xdef456),
+                Uid::Instance(0xdef456, None),
                 Some(Label::new("my-proc").unwrap()),
             ),
             None,
@@ -1676,9 +1743,9 @@ mod tests {
     #[test]
     fn test_port_id_fromstr_roundtrip() {
         let aid = ActorId::new(
-            Uid::Instance(0xabc123),
+            Uid::Instance(0xabc123, None),
             ProcId::new(
-                Uid::Instance(0xdef456),
+                Uid::Instance(0xdef456, None),
                 Some(Label::new("my-proc").unwrap()),
             ),
             Some(Label::new("my-actor").unwrap()),
@@ -1734,9 +1801,9 @@ mod tests {
     #[test]
     fn test_port_id_serde_roundtrip() {
         let aid = ActorId::new(
-            Uid::Instance(0xabcdef),
+            Uid::Instance(0xabcdef, None),
             ProcId::new(
-                Uid::Instance(0x123456),
+                Uid::Instance(0x123456, None),
                 Some(Label::new("my-proc").unwrap()),
             ),
             Some(Label::new("my-actor").unwrap()),

--- a/hyperactor/src/parse/id.rs
+++ b/hyperactor/src/parse/id.rs
@@ -32,6 +32,13 @@ pub(crate) enum IdComponent<'a> {
     },
 }
 
+/// A parsed uid.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct UidParts<'a> {
+    /// The uid component.
+    pub(crate) component: IdComponent<'a>,
+}
+
 /// A parsed proc id.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) struct ProcIdParts<'a> {
@@ -57,6 +64,13 @@ pub(crate) struct PortIdParts<'a> {
     pub(crate) port: &'a str,
 }
 
+pub(crate) fn parse_uid(input: &str) -> Result<UidParts<'_>, ParseError> {
+    let mut parser = Parser::new(input);
+    let parts = parse_uid_parts(&mut parser)?;
+    parser.finish()?;
+    Ok(parts)
+}
+
 pub(crate) fn parse_proc_id(input: &str) -> Result<ProcIdParts<'_>, ParseError> {
     let mut parser = Parser::new(input);
     let parts = parse_proc_id_parts(&mut parser)?;
@@ -76,6 +90,12 @@ pub(crate) fn parse_port_id(input: &str) -> Result<PortIdParts<'_>, ParseError> 
     let parts = parse_port_id_parts(&mut parser)?;
     parser.finish()?;
     Ok(parts)
+}
+
+pub(crate) fn parse_uid_parts<'a>(parser: &mut Parser<'a>) -> Result<UidParts<'a>, ParseError> {
+    Ok(UidParts {
+        component: parse_id_component(parser)?,
+    })
 }
 
 pub(crate) fn parse_proc_id_parts<'a>(
@@ -214,6 +234,39 @@ impl<'a> Parser<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_parse_uid_forms() {
+        assert_eq!(
+            parse_uid("local").unwrap(),
+            UidParts {
+                component: IdComponent::Singleton {
+                    label: "local",
+                    span: Span::new(0, 5),
+                },
+            }
+        );
+        assert_eq!(
+            parse_uid("controller<abc>").unwrap(),
+            UidParts {
+                component: IdComponent::Instance {
+                    label: Some("controller"),
+                    uid: "abc",
+                    span: Span::new(0, 15),
+                },
+            }
+        );
+        assert_eq!(
+            parse_uid("<abc>").unwrap(),
+            UidParts {
+                component: IdComponent::Instance {
+                    label: None,
+                    uid: "abc",
+                    span: Span::new(0, 5),
+                },
+            }
+        );
+    }
 
     #[test]
     fn test_parse_proc_id_forms() {

--- a/hyperactor/src/proc.rs
+++ b/hyperactor/src/proc.rs
@@ -740,6 +740,19 @@ impl Proc {
         self.spawn_inner(actor_id, actor, None)
     }
 
+    /// Spawn a root actor on this proc using an explicit uid.
+    ///
+    /// The uid must be unique among root actors on this proc. Instance labels,
+    /// if present, are descriptive only and do not affect uniqueness.
+    pub fn spawn_with_uid<A: Actor>(
+        &self,
+        uid: crate::id::Uid,
+        actor: A,
+    ) -> Result<ActorHandle<A>, anyhow::Error> {
+        let actor_id: ActorAddr = self.allocate_root_uid(uid)?;
+        self.spawn_inner(actor_id, actor, None)
+    }
+
     /// Common spawn logic for both root and child actors.
     #[hyperactor::instrument(fields(subject = actor_id.subject().to_string()))]
     fn spawn_inner<A: Actor>(
@@ -1272,6 +1285,16 @@ impl Proc {
     /// Uses `reserved_roots` to prevent races between concurrent callers.
     fn allocate_root_id(&self, name: &str) -> Result<ActorAddr, anyhow::Error> {
         let actor_ref = self.state().proc_id.actor_ref(name);
+        self.reserve_root(actor_ref, name)
+    }
+
+    /// Create a root allocation in the proc from an explicit uid.
+    fn allocate_root_uid(&self, uid: crate::id::Uid) -> Result<ActorAddr, anyhow::Error> {
+        let actor_ref = ActorAddr::new_from_uid(self.state().proc_id.clone(), uid.clone());
+        self.reserve_root(actor_ref, &uid.to_string())
+    }
+
+    fn reserve_root(&self, actor_ref: ActorAddr, name: &str) -> Result<ActorAddr, anyhow::Error> {
         let uid = actor_ref.uid().clone();
         if !self.state().reserved_roots.insert(uid) {
             anyhow::bail!("an actor with name '{}' has already been spawned", name)

--- a/hyperactor/src/proc.rs
+++ b/hyperactor/src/proc.rs
@@ -1290,8 +1290,9 @@ impl Proc {
 
     /// Create a root allocation in the proc from an explicit uid.
     fn allocate_root_uid(&self, uid: crate::id::Uid) -> Result<ActorAddr, anyhow::Error> {
-        let actor_ref = ActorAddr::new_from_uid(self.state().proc_id.clone(), uid.clone());
-        self.reserve_root(actor_ref, &uid.to_string())
+        let name = uid.to_string();
+        let actor_ref = ActorAddr::new_from_uid(self.state().proc_id.clone(), uid);
+        self.reserve_root(actor_ref, &name)
     }
 
     fn reserve_root(&self, actor_ref: ActorAddr, name: &str) -> Result<ActorAddr, anyhow::Error> {

--- a/hyperactor/src/remote.rs
+++ b/hyperactor/src/remote.rs
@@ -276,9 +276,9 @@ mod tests {
 
     fn make_actor_ref(actor_label: Option<&str>, proc_label: Option<&str>) -> ActorAddr {
         let aid = ActorId::new(
-            Uid::Instance(0xabc123),
+            Uid::Instance(0xabc123, None),
             ProcId::new(
-                Uid::Instance(0xdef456),
+                Uid::Instance(0xdef456, None),
                 proc_label.map(|l| Label::new(l).unwrap()),
             ),
             actor_label.map(|l| Label::new(l).unwrap()),
@@ -289,9 +289,9 @@ mod tests {
 
     fn make_port_ref(actor_label: Option<&str>, proc_label: Option<&str>) -> PortAddr {
         let aid = ActorId::new(
-            Uid::Instance(0xabc123),
+            Uid::Instance(0xabc123, None),
             ProcId::new(
-                Uid::Instance(0xdef456),
+                Uid::Instance(0xdef456, None),
                 proc_label.map(|l| Label::new(l).unwrap()),
             ),
             actor_label.map(|l| Label::new(l).unwrap()),

--- a/hyperactor_macros/src/lib.rs
+++ b/hyperactor_macros/src/lib.rs
@@ -2357,7 +2357,7 @@ pub fn uid(input: TokenStream) -> TokenStream {
     // Instance: bare hex
     match validate_hex_uid(&combined) {
         Ok(uid_val) => TokenStream::from(quote! {
-            hyperactor::id::Uid::Instance(#uid_val)
+            hyperactor::id::Uid::Instance(#uid_val, None)
         }),
         Err(e) => {
             let msg = format!("invalid uid: {e}");

--- a/hyperactor_macros/tests/basic.rs
+++ b/hyperactor_macros/tests/basic.rs
@@ -202,6 +202,6 @@ mod tests {
     #[test]
     fn test_uid_macro_instance() {
         let id = uid!(d5d54d7201103869);
-        assert_eq!(id, Uid::Instance(0xd5d54d7201103869));
+        assert_eq!(id, Uid::Instance(0xd5d54d7201103869, None));
     }
 }

--- a/hyperactor_mesh/src/bootstrap/mailbox.rs
+++ b/hyperactor_mesh/src/bootstrap/mailbox.rs
@@ -64,7 +64,7 @@ impl MailboxSender for LocalProcDialer {
         if addr == &self.local_addr
             // ...and only non-system procs on that address; the rest are directly
             // reachable through the backend address.
-            && matches!(proc_ref.uid(), Uid::Instance(_))
+            && matches!(proc_ref.uid(), Uid::Instance(_, _))
         {
             let key = proc_ref.resource_name();
             let senders = self.local_senders.read().unwrap();

--- a/hyperactor_mesh/src/mesh_id.rs
+++ b/hyperactor_mesh/src/mesh_id.rs
@@ -8,11 +8,10 @@
 
 //! Mesh identity types.
 //!
-//! [`ResourceId`] is the common control-plane identifier for mesh resources:
-//! a uid for identity and an optional label for human readability. The
-//! mesh-specific newtypes [`ActorMeshId`], [`ProcMeshId`], and [`HostMeshId`]
-//! provide type safety at mesh struct boundaries while converting freely to
-//! [`ResourceId`] for resource message plumbing.
+//! [`ResourceId`] is the common control-plane identifier for mesh resources.
+//! The mesh-specific newtypes [`ActorMeshId`], [`ProcMeshId`], and
+//! [`HostMeshId`] provide type safety at mesh struct boundaries while
+//! converting freely to [`ResourceId`] for resource message plumbing.
 //!
 //! # Where resource ids are used
 //!
@@ -24,9 +23,9 @@
 //! The same logical resource may be rendered into other name spaces:
 //!
 //! - The control-plane resource name is `ResourceId::to_string()`.
-//! - The runtime actor name is `ActorMeshId::actor_name()`, which is consumed
-//!   by `ProcRef::actor_id()` in `proc_mesh.rs` and by `ProcAgent` when it
-//!   calls `remote.gspawn(...)`.
+//! - The runtime actor id is carried as `ActorMeshId::uid()` by
+//!   `ProcRef::actor_id()` in `proc_mesh.rs` and by `ProcAgent` when it calls
+//!   `remote.gspawn(...)`.
 //! - The runtime proc name is `ResourceId::to_string()`, which is consumed by
 //!   `HostRef::named_proc()` in `host_mesh.rs` and by `HostAgent` when it
 //!   spawns a proc on a host.
@@ -38,13 +37,13 @@
 //! `ResourceId` has three externally visible string forms:
 //!
 //! - Singleton: `label`
-//! - Labeled instance: `label-<instance_uid>`
+//! - Labeled instance: `label-uid58`
 //! - Unlabeled instance: `<instance_uid>`
 //!
-//! Here `<instance_uid>` is the hexadecimal instance component produced by
-//! [`Uid::Instance`], without angle brackets. Parsing accepts the display
-//! forms above. For backwards compatibility, instance uids wrapped in angle
-//! brackets are also accepted when parsing.
+//! Here `uid58` is the base58 instance component produced by [`Uid::Instance`],
+//! without angle brackets. Parsing accepts the display forms above. For
+//! backwards compatibility, instance uids wrapped in angle brackets are also
+//! accepted when parsing.
 //!
 //! Identity is uid-only: labels are descriptive metadata and do not
 //! participate in `Eq`, `Hash`, or `Ord`.
@@ -76,46 +75,39 @@ pub enum ResourceIdParseError {
 
 /// Identifies a resource in the mesh system.
 ///
-/// Identity (Eq, Hash, Ord) is determined solely by `uid`; `label` is
-/// informational metadata excluded from comparisons.
+/// Identity (Eq, Hash, Ord) is determined by the underlying [`Uid`].
 #[derive(Clone, Serialize, Deserialize, Named)]
-pub struct ResourceId {
-    uid: Uid,
-    label: Option<Label>,
-}
+pub struct ResourceId(Uid);
 wirevalue::register_type!(ResourceId);
 
 impl ResourceId {
     /// Create a [`ResourceId`] with explicit uid and label.
     pub fn new(uid: Uid, label: Option<Label>) -> Self {
-        Self { uid, label }
+        Self(uid.with_label(label))
     }
 
     /// Create a singleton [`ResourceId`] identified by label.
     /// The label becomes the uid; no separate label metadata is stored.
     pub fn singleton(label: Label) -> Self {
-        Self {
-            uid: Uid::Singleton(label),
-            label: None,
-        }
+        Self(Uid::Singleton(label))
     }
 
     /// Create a unique [`ResourceId`] with a random uid and the given label.
     pub fn unique(label: Label) -> Self {
-        Self {
-            uid: Uid::instance(),
-            label: Some(label),
-        }
+        Self(Uid::instance_labeled(label))
     }
 
     /// Returns the uid.
     pub fn uid(&self) -> &Uid {
-        &self.uid
+        &self.0
     }
 
     /// Returns the explicit label metadata, if any.
     pub fn label(&self) -> Option<&Label> {
-        self.label.as_ref()
+        match &self.0 {
+            Uid::Singleton(_) => None,
+            Uid::Instance(_, label) => label.as_ref(),
+        }
     }
 
     /// Returns the human-facing label for this resource id.
@@ -123,18 +115,10 @@ impl ResourceId {
     /// This is the explicit label metadata for instances, or the singleton
     /// label embedded in the uid. Telemetry uses this for `given_name`.
     pub fn display_label(&self) -> Option<&Label> {
-        self.label.as_ref().or(match &self.uid {
-            Uid::Singleton(label) => Some(label),
-            _ => None,
-        })
+        self.0.label()
     }
 
-    /// Returns the actor-runtime name derived from this resource id.
-    ///
-    /// This is the name passed into `ProcAddr::actor_id(...)` and used when
-    /// `ProcAgent` spawns the actor process-local runtime object. Keep this
-    /// helper as the single mapping point from control-plane resource ids to
-    /// actor-runtime names.
+    /// Returns the legacy actor-runtime name derived from this resource id.
     pub fn actor_name(&self) -> String {
         self.to_string()
     }
@@ -142,7 +126,7 @@ impl ResourceId {
 
 impl PartialEq for ResourceId {
     fn eq(&self, other: &Self) -> bool {
-        self.uid == other.uid
+        self.0 == other.0
     }
 }
 
@@ -150,7 +134,7 @@ impl Eq for ResourceId {}
 
 impl Hash for ResourceId {
     fn hash<H: Hasher>(&self, state: &mut H) {
-        self.uid.hash(state);
+        self.0.hash(state);
     }
 }
 
@@ -162,12 +146,12 @@ impl PartialOrd for ResourceId {
 
 impl Ord for ResourceId {
     fn cmp(&self, other: &Self) -> Ordering {
-        self.uid.cmp(&other.uid)
+        self.0.cmp(&other.0)
     }
 }
 
 fn fmt_instance_uid(uid: u64) -> String {
-    Uid::Instance(uid)
+    Uid::Instance(uid, None)
         .to_string()
         .trim_start_matches('<')
         .trim_end_matches('>')
@@ -178,7 +162,7 @@ fn parse_instance_uid(s: &str) -> Result<u64, UidParseError> {
     let mut last_err = None;
     for candidate in [s.to_string(), format!("<{s}>")] {
         match Uid::from_str(&candidate) {
-            Ok(Uid::Instance(uid)) => return Ok(uid),
+            Ok(Uid::Instance(uid, _)) => return Ok(uid),
             Ok(Uid::Singleton(_)) => {}
             Err(err) => last_err = Some(err),
         }
@@ -190,7 +174,7 @@ fn parse_instance_uid(s: &str) -> Result<u64, UidParseError> {
 fn fmt_id_component(f: &mut fmt::Formatter<'_>, uid: &Uid, label: Option<&Label>) -> fmt::Result {
     match uid {
         Uid::Singleton(singleton) => write!(f, "{singleton}"),
-        Uid::Instance(uid) => match label {
+        Uid::Instance(uid, _) => match label {
             Some(label) => write!(f, "{label}-{}", fmt_instance_uid(*uid)),
             None => write!(f, "{}", fmt_instance_uid(*uid)),
         },
@@ -203,37 +187,37 @@ impl fmt::Display for ResourceId {
     /// This string is used for resource message keys, proc names on hosts,
     /// and telemetry `full_name`.
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt_id_component(f, &self.uid, self.label.as_ref())
+        fmt_id_component(f, &self.0, self.label())
     }
 }
 
 impl fmt::Debug for ResourceId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match (&self.uid, &self.label) {
+        match (&self.0, self.label()) {
             (Uid::Singleton(label), _) => write!(f, "<{label}>"),
-            (Uid::Instance(uid), Some(label)) => {
+            (Uid::Instance(uid, _), Some(label)) => {
                 write!(f, "<'{label}' {}>", fmt_instance_uid(*uid))
             }
-            (Uid::Instance(uid), None) => write!(f, "<{}>", fmt_instance_uid(*uid)),
+            (Uid::Instance(uid, _), None) => write!(f, "<{}>", fmt_instance_uid(*uid)),
         }
     }
 }
 
-fn parse_id_component(s: &str) -> Result<(Uid, Option<Label>), ResourceIdParseError> {
+fn parse_id_component(s: &str) -> Result<Uid, ResourceIdParseError> {
     if let Ok(uid) = parse_instance_uid(s) {
-        return Ok((Uid::Instance(uid), None));
+        return Ok(Uid::Instance(uid, None));
     }
 
     if let Some(split) = s.rfind('-') {
         let label_part = &s[..split];
         let uid_part = &s[split + 1..];
         if let (Ok(label), Ok(uid)) = (Label::new(label_part), parse_instance_uid(uid_part)) {
-            return Ok((Uid::Instance(uid), Some(label)));
+            return Ok(Uid::Instance(uid, Some(label)));
         }
     }
 
     let label = Label::new(s)?;
-    Ok((Uid::Singleton(label), None))
+    Ok(Uid::Singleton(label))
 }
 
 impl FromStr for ResourceId {
@@ -250,8 +234,7 @@ impl FromStr for ResourceId {
     /// For backwards compatibility, `<instance_uid>` may also be wrapped in
     /// angle brackets.
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let (uid, label) = parse_id_component(s)?;
-        Ok(Self { uid, label })
+        Ok(Self(parse_id_component(s)?))
     }
 }
 
@@ -384,20 +367,20 @@ mod tests {
     #[test]
     fn test_resource_id_unique() {
         let id = ResourceId::unique(Label::new("workers").unwrap());
-        assert!(matches!(id.uid(), Uid::Instance(_)));
+        assert!(matches!(id.uid(), Uid::Instance(_, Some(_))));
         assert_eq!(id.label().map(|l| l.as_str()), Some("workers"));
     }
 
     #[test]
     fn test_resource_id_unlabeled() {
-        let id = ResourceId::new(Uid::Instance(0xabcdef), None);
+        let id = ResourceId::new(Uid::Instance(0xabcdef, None), None);
         assert_eq!(id.to_string(), fmt_instance_uid(0xabcdef));
         assert_eq!(id.label(), None);
     }
 
     #[test]
     fn test_resource_id_eq_by_uid_only() {
-        let uid = Uid::Instance(0x42);
+        let uid = Uid::Instance(0x42, None);
         let a = ResourceId::new(uid.clone(), Some(Label::new("alpha").unwrap()));
         let b = ResourceId::new(uid, Some(Label::new("beta").unwrap()));
         assert_eq!(a, b);
@@ -405,14 +388,14 @@ mod tests {
 
     #[test]
     fn test_resource_id_neq_different_uid() {
-        let a = ResourceId::new(Uid::Instance(1), Some(Label::new("same").unwrap()));
-        let b = ResourceId::new(Uid::Instance(2), Some(Label::new("same").unwrap()));
+        let a = ResourceId::new(Uid::Instance(1, None), Some(Label::new("same").unwrap()));
+        let b = ResourceId::new(Uid::Instance(2, None), Some(Label::new("same").unwrap()));
         assert_ne!(a, b);
     }
 
     #[test]
     fn test_resource_id_hash_by_uid_only() {
-        let uid = Uid::Instance(0x42);
+        let uid = Uid::Instance(0x42, None);
         let a = ResourceId::new(uid.clone(), Some(Label::new("alpha").unwrap()));
         let b = ResourceId::new(uid, Some(Label::new("beta").unwrap()));
 
@@ -426,8 +409,8 @@ mod tests {
 
     #[test]
     fn test_resource_id_ord_by_uid_only() {
-        let a = ResourceId::new(Uid::Instance(1), Some(Label::new("zzz").unwrap()));
-        let b = ResourceId::new(Uid::Instance(2), Some(Label::new("aaa").unwrap()));
+        let a = ResourceId::new(Uid::Instance(1, None), Some(Label::new("zzz").unwrap()));
+        let b = ResourceId::new(Uid::Instance(2, None), Some(Label::new("aaa").unwrap()));
         assert!(a < b);
     }
 
@@ -440,7 +423,7 @@ mod tests {
     #[test]
     fn test_resource_id_display_labeled_instance() {
         let id = ResourceId::new(
-            Uid::Instance(0xd5d54d7201103869),
+            Uid::Instance(0xd5d54d7201103869, None),
             Some(Label::new("workers").unwrap()),
         );
         assert_eq!(
@@ -451,7 +434,7 @@ mod tests {
 
     #[test]
     fn test_resource_id_display_unlabeled_instance() {
-        let id = ResourceId::new(Uid::Instance(0xd5d54d7201103869), None);
+        let id = ResourceId::new(Uid::Instance(0xd5d54d7201103869, None), None);
         assert_eq!(id.to_string(), fmt_instance_uid(0xd5d54d7201103869));
     }
 
@@ -464,7 +447,7 @@ mod tests {
     #[test]
     fn test_resource_id_actor_name_labeled_instance() {
         let id = ResourceId::new(
-            Uid::Instance(0xd5d54d7201103869),
+            Uid::Instance(0xd5d54d7201103869, None),
             Some(Label::new("workers").unwrap()),
         );
         assert_eq!(
@@ -475,7 +458,7 @@ mod tests {
 
     #[test]
     fn test_resource_id_actor_name_unlabeled_instance() {
-        let id = ResourceId::new(Uid::Instance(0xd5d54d7201103869), None);
+        let id = ResourceId::new(Uid::Instance(0xd5d54d7201103869, None), None);
         assert_eq!(id.actor_name(), fmt_instance_uid(0xd5d54d7201103869));
     }
 
@@ -485,7 +468,7 @@ mod tests {
         assert_eq!(format!("{:?}", singleton), "<local>");
 
         let labeled = ResourceId::new(
-            Uid::Instance(0xd5d54d7201103869),
+            Uid::Instance(0xd5d54d7201103869, None),
             Some(Label::new("workers").unwrap()),
         );
         assert_eq!(
@@ -493,7 +476,7 @@ mod tests {
             format!("<'workers' {}>", fmt_instance_uid(0xd5d54d7201103869))
         );
 
-        let unlabeled = ResourceId::new(Uid::Instance(0xd5d54d7201103869), None);
+        let unlabeled = ResourceId::new(Uid::Instance(0xd5d54d7201103869, None), None);
         assert_eq!(
             format!("{:?}", unlabeled),
             format!("<{}>", fmt_instance_uid(0xd5d54d7201103869))
@@ -512,14 +495,17 @@ mod tests {
         let parsed: ResourceId = format!("workers-{}", fmt_instance_uid(0xd5d54d7201103869))
             .parse()
             .unwrap();
-        assert_eq!(*parsed.uid(), Uid::Instance(0xd5d54d7201103869));
+        assert_eq!(
+            *parsed.uid(),
+            Uid::Instance(0xd5d54d7201103869, Some(Label::new("workers").unwrap()))
+        );
         assert_eq!(parsed.label().map(|l| l.as_str()), Some("workers"));
     }
 
     #[test]
     fn test_resource_id_fromstr_unlabeled_instance() {
         let parsed: ResourceId = fmt_instance_uid(0xd5d54d7201103869).parse().unwrap();
-        assert_eq!(*parsed.uid(), Uid::Instance(0xd5d54d7201103869));
+        assert_eq!(*parsed.uid(), Uid::Instance(0xd5d54d7201103869, None));
         assert_eq!(parsed.label(), None);
     }
 
@@ -528,7 +514,10 @@ mod tests {
         let parsed: ResourceId = format!("my-service-{}", fmt_instance_uid(0xd5d54d7201103869))
             .parse()
             .unwrap();
-        assert_eq!(*parsed.uid(), Uid::Instance(0xd5d54d7201103869));
+        assert_eq!(
+            *parsed.uid(),
+            Uid::Instance(0xd5d54d7201103869, Some(Label::new("my-service").unwrap()))
+        );
         assert_eq!(parsed.label().map(|l| l.as_str()), Some("my-service"));
     }
 
@@ -537,15 +526,15 @@ mod tests {
         let cases = vec![
             ResourceId::singleton(Label::new("local").unwrap()),
             ResourceId::new(
-                Uid::Instance(0xd5d54d7201103869),
+                Uid::Instance(0xd5d54d7201103869, None),
                 Some(Label::new("workers").unwrap()),
             ),
-            ResourceId::new(Uid::Instance(0xd5d54d7201103869), None),
+            ResourceId::new(Uid::Instance(0xd5d54d7201103869, None), None),
             ResourceId::new(
-                Uid::Instance(0xd5d54d7201103869),
+                Uid::Instance(0xd5d54d7201103869, None),
                 Some(Label::new("my-service").unwrap()),
             ),
-            ResourceId::new(Uid::Instance(1), Some(Label::new("a").unwrap())),
+            ResourceId::new(Uid::Instance(1, None), Some(Label::new("a").unwrap())),
         ];
         for id in cases {
             let s = id.to_string();
@@ -559,10 +548,10 @@ mod tests {
         let cases = vec![
             ResourceId::singleton(Label::new("local").unwrap()),
             ResourceId::new(
-                Uid::Instance(0xabcdef),
+                Uid::Instance(0xabcdef, None),
                 Some(Label::new("workers").unwrap()),
             ),
-            ResourceId::new(Uid::Instance(0xabcdef), None),
+            ResourceId::new(Uid::Instance(0xabcdef, None), None),
         ];
         for id in cases {
             let json = serde_json::to_string(&id).unwrap();
@@ -583,17 +572,17 @@ mod tests {
         assert_eq!(*host.uid(), Uid::Singleton(Label::new("local").unwrap()));
 
         let proc_ = ProcMeshId::unique(Label::new("workers").unwrap());
-        assert!(matches!(proc_.uid(), Uid::Instance(_)));
+        assert!(matches!(proc_.uid(), Uid::Instance(_, Some(_))));
         assert_eq!(proc_.label().map(|l| l.as_str()), Some("workers"));
 
         let actor = ActorMeshId::unique(Label::new("trainers").unwrap());
-        assert!(matches!(actor.uid(), Uid::Instance(_)));
+        assert!(matches!(actor.uid(), Uid::Instance(_, Some(_))));
         assert_eq!(actor.label().map(|l| l.as_str()), Some("trainers"));
     }
 
     #[test]
     fn test_mesh_id_eq_by_uid_only() {
-        let uid = Uid::Instance(0x42);
+        let uid = Uid::Instance(0x42, None);
         let a = HostMeshId::new(uid.clone(), Some(Label::new("alpha").unwrap()));
         let b = HostMeshId::new(uid, Some(Label::new("beta").unwrap()));
         assert_eq!(a, b);
@@ -604,10 +593,10 @@ mod tests {
         let ids: Vec<HostMeshId> = vec![
             HostMeshId::singleton(Label::new("local").unwrap()),
             HostMeshId::new(
-                Uid::Instance(0xd5d54d7201103869),
+                Uid::Instance(0xd5d54d7201103869, None),
                 Some(Label::new("workers").unwrap()),
             ),
-            HostMeshId::new(Uid::Instance(0xd5d54d7201103869), None),
+            HostMeshId::new(Uid::Instance(0xd5d54d7201103869, None), None),
         ];
         for id in ids {
             let s = id.to_string();
@@ -632,8 +621,14 @@ mod tests {
 
     #[test]
     fn test_mesh_id_serde_transparent() {
-        let host = HostMeshId::new(Uid::Instance(0xabcdef), Some(Label::new("test").unwrap()));
-        let resource = ResourceId::new(Uid::Instance(0xabcdef), Some(Label::new("test").unwrap()));
+        let host = HostMeshId::new(
+            Uid::Instance(0xabcdef, None),
+            Some(Label::new("test").unwrap()),
+        );
+        let resource = ResourceId::new(
+            Uid::Instance(0xabcdef, None),
+            Some(Label::new("test").unwrap()),
+        );
 
         let host_json = serde_json::to_string(&host).unwrap();
         let resource_json = serde_json::to_string(&resource).unwrap();

--- a/hyperactor_mesh/src/proc_agent.rs
+++ b/hyperactor_mesh/src/proc_agent.rs
@@ -842,7 +842,7 @@ impl Handler<resource::CreateOrUpdate<ActorSpec>> for ProcAgent {
                     .gspawn(
                         &self.proc,
                         &actor_type,
-                        &create_or_update.id.actor_name(),
+                        create_or_update.id.uid().clone(),
                         params_data,
                         cx.headers().clone(),
                     )

--- a/hyperactor_mesh/src/proc_mesh.rs
+++ b/hyperactor_mesh/src/proc_mesh.rs
@@ -113,7 +113,7 @@ impl ProcRef {
     }
 
     pub(crate) fn actor_id(&self, id: &ActorMeshId) -> hyperactor_reference::ActorAddr {
-        self.proc_id.actor_id(id.actor_name())
+        self.proc_id.actor_ref_uid(id.uid().clone())
     }
 
     /// Generic bound: `A: Referable` - required because we return
@@ -165,8 +165,7 @@ impl ProcMesh {
             ranks
                 .first()
                 .expect("root mesh cannot be empty")
-                .actor_id(&comm_actor_name)
-                .into(),
+                .actor_id(&comm_actor_name),
         );
         let current_ref = ProcMeshRef::new(
             id.clone(),


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #3739
* #3738
* #3737
* #3736
* __->__ #3735

Redefine Uid so instance labels are stored with the uid, keep labels non-semantic for equality/hash/ordering, update ProcId/ActorId and mesh ResourceId wrappers to use the new shape, and pass Uid directly through remote gspawn/proc mesh spawn plumbing.

The motivation for this is that labels are always used and parsed in conjunction with Uids, and that we want to enforce the rule that singleton uid *not* carry a label (the label *is* the Uid in this case). This structure lets us capture this -- making labeled singletons unrepresentable in the system.

It also helps to reuse and simplify composition of Uids, and to make 'ResourceId' a pure presentation layer, which we may be able to fully get rid of.

Differential Revision: [D103561881](https://our.internmc.facebook.com/intern/diff/D103561881/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D103561881/)!