### PR TITLE
[hyperactor] return concrete ids from parser

### DIFF
--- a/hyperactor/src/addr.rs
+++ b/hyperactor/src/addr.rs
@@ -179,18 +179,15 @@ impl ProcAddr {
     /// The ResourceId text form: `label` (singleton), `label-uid58`
     /// (labeled instance), or `<uid58>` (unlabeled instance).
     pub fn resource_name(&self) -> String {
-        fn uid_no_brackets(uid: &Uid) -> String {
-            uid.to_string()
-                .trim_start_matches('<')
-                .trim_end_matches('>')
-                .to_string()
-        }
-
         match self.id.uid() {
             Uid::Singleton(label) => label.to_string(),
-            Uid::Instance(uid, Some(label)) => {
-                let uid = Uid::Instance(*uid, None);
-                format!("{label}-{}", uid_no_brackets(&uid))
+            Uid::Instance(_, Some(label)) => {
+                let uid = self
+                    .id
+                    .uid()
+                    .instance_uid_base58()
+                    .expect("instance uid should have base58 text");
+                format!("{label}-{uid}")
             }
             Uid::Instance(uid, None) => Uid::Instance(*uid, None).to_string(),
         }
@@ -727,56 +724,61 @@ impl FromStr for Address {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match parse::addr::parse_address(s).map_err(|_| legacy_parse_reference(s))? {
-            parse::addr::AddressParts::Proc(_) => Ok(Self::Proc(s.parse()?)),
-            parse::addr::AddressParts::Actor(_) => Ok(Self::Actor(s.parse()?)),
-            parse::addr::AddressParts::Port(_) => Ok(Self::Port(s.parse()?)),
+            parse::addr::AddressParts::Proc(parts) => {
+                Ok(Self::Proc(ProcAddr::try_from((s, parts))?))
+            }
+            parse::addr::AddressParts::Actor(parts) => {
+                Ok(Self::Actor(ActorAddr::try_from((s, parts))?))
+            }
+            parse::addr::AddressParts::Port(parts) => {
+                Ok(Self::Port(PortAddr::try_from((s, parts))?))
+            }
         }
     }
-}
-
-fn id_text_from_ref_input<'a>(input: &'a str, location: &str) -> &'a str {
-    &input[..input.len() - location.len() - 1]
 }
 
 impl<'a> TryFrom<(&'a str, ProcAddrParts<'a>)> for ProcAddr {
     type Error = AddrParseError;
 
-    fn try_from((input, parts): (&'a str, ProcAddrParts<'a>)) -> Result<Self, Self::Error> {
-        let id_text = id_text_from_ref_input(input, parts.location);
-        let id: ProcId = id_text.parse()?;
+    fn try_from((_, parts): (&'a str, ProcAddrParts<'a>)) -> Result<Self, Self::Error> {
         let location: Location = parts
             .location
             .parse()
             .map_err(AddrParseError::InvalidLocation)?;
-        Ok(Self { id, location })
+        Ok(Self {
+            id: parts.id,
+            location,
+        })
     }
 }
 
 impl<'a> TryFrom<(&'a str, ActorAddrParts<'a>)> for ActorAddr {
     type Error = AddrParseError;
 
-    fn try_from((input, parts): (&'a str, ActorAddrParts<'a>)) -> Result<Self, Self::Error> {
-        let id_text = id_text_from_ref_input(input, parts.location);
-        let id: ActorId = id_text.parse()?;
+    fn try_from((_, parts): (&'a str, ActorAddrParts<'a>)) -> Result<Self, Self::Error> {
         let location: Location = parts
             .location
             .parse()
             .map_err(AddrParseError::InvalidLocation)?;
-        Ok(Self { id, location })
+        Ok(Self {
+            id: parts.id,
+            location,
+        })
     }
 }
 
 impl<'a> TryFrom<(&'a str, PortAddrParts<'a>)> for PortAddr {
     type Error = AddrParseError;
 
-    fn try_from((input, parts): (&'a str, PortAddrParts<'a>)) -> Result<Self, Self::Error> {
-        let id_text = id_text_from_ref_input(input, parts.location);
-        let id: PortId = id_text.parse()?;
+    fn try_from((_, parts): (&'a str, PortAddrParts<'a>)) -> Result<Self, Self::Error> {
         let location: Location = parts
             .location
             .parse()
             .map_err(AddrParseError::InvalidLocation)?;
-        Ok(Self { id, location })
+        Ok(Self {
+            id: parts.id,
+            location,
+        })
     }
 }
 

--- a/hyperactor/src/id.rs
+++ b/hyperactor/src/id.rs
@@ -42,18 +42,11 @@ use serde::Deserialize;
 use serde::Serialize;
 use smol_str::SmolStr;
 
-use crate::parse::id::ActorIdParts;
-use crate::parse::id::IdComponent;
-use crate::parse::id::PortIdParts;
-use crate::parse::id::ProcIdParts;
-use crate::parse::id::UidParts;
+use crate::parse::id::encode_base58_uid;
 use crate::port::Port;
 
 /// Maximum length of an RFC 1035 label.
 const MAX_LABEL_LEN: usize = 63;
-
-/// Flickr base58 alphabet.
-const BASE58_FLICKR: &[u8; 58] = b"123456789abcdefghijkmnopqrstuvwxyzABCDEFGHJKLMNPQRSTUVWXYZ";
 
 /// An RFC 1035-style label: 1–63 chars, lowercase ASCII alphanumeric plus `-`
 /// or `_`,
@@ -242,6 +235,14 @@ impl Uid {
         }
     }
 
+    /// Returns the raw base58 uid for instances, without display delimiters.
+    pub fn instance_uid_base58(&self) -> Option<String> {
+        match self {
+            Uid::Singleton(_) => None,
+            Uid::Instance(uid, _) => Some(encode_base58_uid(*uid)),
+        }
+    }
+
     /// Returns this uid with the provided instance label.
     ///
     /// Singleton labels are identity and are not replaced.
@@ -322,42 +323,13 @@ impl FromStr for Uid {
     type Err = UidParseError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let parts = crate::parse::id::parse_uid(s)
-            .map_err(|err| UidParseError::InvalidSyntax(err.to_string()))?;
-        Self::try_from(parts)
+        crate::parse::id::parse_uid_str(s)
+            .map_err(|err| UidParseError::InvalidSyntax(err.to_string()))
     }
-}
-
-fn encode_base58_uid(mut uid: u64) -> String {
-    if uid == 0 {
-        return "1".to_string();
-    }
-
-    let mut digits = Vec::new();
-    while uid > 0 {
-        digits.push(BASE58_FLICKR[(uid % 58) as usize] as char);
-        uid /= 58;
-    }
-    digits.iter().rev().collect()
 }
 
 fn parse_base58_uid(s: &str) -> Result<u64, UidParseError> {
-    if s.is_empty() {
-        return Err(UidParseError::InvalidBase58(s.to_string()));
-    }
-
-    let mut uid = 0u64;
-    for ch in s.bytes() {
-        let digit = BASE58_FLICKR
-            .iter()
-            .position(|candidate| *candidate == ch)
-            .ok_or_else(|| UidParseError::InvalidBase58(s.to_string()))? as u64;
-        uid = uid
-            .checked_mul(58)
-            .and_then(|value| value.checked_add(digit))
-            .ok_or_else(|| UidParseError::InvalidBase58(s.to_string()))?;
-    }
-    Ok(uid)
+    crate::parse::id::decode_base58_uid(s).map_err(|_| UidParseError::InvalidBase58(s.to_string()))
 }
 
 impl Serialize for Uid {
@@ -482,9 +454,9 @@ impl FromStr for ProcId {
     type Err = IdParseError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let parts = crate::parse::id::parse_proc_id(s)
-            .map_err(|_| legacy_parse_id_component(s).unwrap_err())?;
-        Self::try_from(parts).map_err(IdParseError::InvalidProcId)
+        crate::parse::id::parse_proc_id(s).map_err(|err| {
+            IdParseError::InvalidProcId(UidParseError::InvalidSyntax(err.to_string()))
+        })
     }
 }
 
@@ -609,8 +581,7 @@ impl FromStr for ActorId {
     type Err = IdParseError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let parts = crate::parse::id::parse_actor_id(s).map_err(|_| legacy_parse_actor_id(s))?;
-        Self::try_from(parts)
+        crate::parse::id::parse_actor_id(s).map_err(|_| legacy_parse_actor_id(s))
     }
 }
 
@@ -707,66 +678,7 @@ impl FromStr for PortId {
     type Err = IdParseError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let parts = crate::parse::id::parse_port_id(s).map_err(|_| legacy_port_parse_error(s))?;
-        Self::try_from(parts)
-    }
-}
-
-fn convert_id_component(component: IdComponent<'_>) -> Result<(Uid, Option<Label>), UidParseError> {
-    match component {
-        IdComponent::Singleton { label, .. } => {
-            let label = Label::new(label)?;
-            Ok((Uid::Singleton(label.clone()), Some(label)))
-        }
-        IdComponent::Instance { label, uid, .. } => {
-            let label = label.map(Label::new).transpose()?;
-            let uid = Uid::Instance(parse_base58_uid(uid)?, label.clone());
-            Ok((uid, label))
-        }
-    }
-}
-
-impl TryFrom<ProcIdParts<'_>> for ProcId {
-    type Error = UidParseError;
-
-    fn try_from(parts: ProcIdParts<'_>) -> Result<Self, Self::Error> {
-        let (uid, label) = convert_id_component(parts.component)?;
-        Ok(Self::new(uid, label))
-    }
-}
-
-impl TryFrom<UidParts<'_>> for Uid {
-    type Error = UidParseError;
-
-    fn try_from(parts: UidParts<'_>) -> Result<Self, Self::Error> {
-        convert_id_component(parts.component).map(|(uid, _)| uid)
-    }
-}
-
-impl TryFrom<ActorIdParts<'_>> for ActorId {
-    type Error = IdParseError;
-
-    fn try_from(parts: ActorIdParts<'_>) -> Result<Self, Self::Error> {
-        let (uid, label) =
-            convert_id_component(parts.actor).map_err(IdParseError::InvalidActorUid)?;
-        let proc_id = ProcId::try_from(ProcIdParts {
-            component: parts.proc_,
-        })
-        .map_err(IdParseError::InvalidActorProcUid)?;
-        Ok(Self::new(uid, proc_id, label))
-    }
-}
-
-impl TryFrom<PortIdParts<'_>> for PortId {
-    type Error = IdParseError;
-
-    fn try_from(parts: PortIdParts<'_>) -> Result<Self, Self::Error> {
-        let actor_id = ActorId::try_from(parts.actor)?;
-        let port = parts
-            .port
-            .parse()
-            .map_err(|_| IdParseError::InvalidPort(parts.port.to_string()))?;
-        Ok(Self { actor_id, port })
+        crate::parse::id::parse_port_id(s).map_err(|_| legacy_port_parse_error(s))
     }
 }
 
@@ -921,8 +833,18 @@ mod tests {
         let uid = Uid::Instance(0xd5d54d7201103869, None);
         let s = uid.to_string();
         assert_eq!(s, format!("<{}>", encode_base58_uid(0xd5d54d7201103869)));
+        assert_eq!(
+            uid.instance_uid_base58(),
+            Some(encode_base58_uid(0xd5d54d7201103869))
+        );
         let parsed: Uid = s.parse().unwrap();
         assert_eq!(uid, parsed);
+    }
+
+    #[test]
+    fn test_singleton_has_no_instance_base58() {
+        let uid = Uid::singleton(Label::new("my-actor").unwrap());
+        assert_eq!(uid.instance_uid_base58(), None);
     }
 
     #[test]
@@ -1143,18 +1065,18 @@ mod tests {
     fn test_proc_id_fromstr_errors_are_stable() {
         assert_eq!(
             "".parse::<ProcId>().unwrap_err().to_string(),
-            "invalid proc id: invalid label: label must not be empty"
+            "invalid proc id: invalid uid syntax: expected \"label\" or \"<\", found end of input"
         );
         assert_eq!(
             "controller<2MuAHeDjLCEd"
                 .parse::<ProcId>()
                 .unwrap_err()
                 .to_string(),
-            "invalid proc id: invalid label: label contains invalid character '<'"
+            "invalid proc id: invalid uid syntax: expected \">\", found end of input"
         );
         assert_eq!(
             "controller@tcp".parse::<ProcId>().unwrap_err().to_string(),
-            "invalid proc id: invalid label: label contains invalid character '@'"
+            "invalid proc id: invalid uid syntax: expected end of input, found \"@\""
         );
     }
 

--- a/hyperactor/src/parse/addr.rs
+++ b/hyperactor/src/parse/addr.rs
@@ -13,46 +13,47 @@
 //! keeps URL punctuation out of the Hyperactor lexer while still giving
 //! token-aware errors at the id/address boundary.
 
+use crate::id::ActorId;
+use crate::id::PortId;
+use crate::id::ProcId;
 use crate::parse::error::ParseError;
-use crate::parse::id::ActorIdParts;
 use crate::parse::id::Parser;
-use crate::parse::id::PortIdParts;
-use crate::parse::id::ProcIdParts;
-use crate::parse::id::parse_actor_id_parts;
-use crate::parse::id::parse_id_component;
-use crate::parse::id::parse_port_id_parts;
-use crate::parse::id::parse_proc_id_parts;
+use crate::parse::id::parse_actor_id_with_parser;
+use crate::parse::id::parse_port_id_with_parser;
+use crate::parse::id::parse_proc_id_with_parser;
+use crate::parse::id::parse_uid;
 use crate::parse::lex::TokenKind;
+use crate::port::Port;
 
 /// A parsed proc address.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) struct ProcAddrParts<'a> {
     /// The proc id.
-    pub(crate) id: ProcIdParts<'a>,
+    pub(crate) id: ProcId,
     /// The raw location tail.
     pub(crate) location: &'a str,
 }
 
 /// A parsed actor address.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) struct ActorAddrParts<'a> {
     /// The actor id.
-    pub(crate) id: ActorIdParts<'a>,
+    pub(crate) id: ActorId,
     /// The raw location tail.
     pub(crate) location: &'a str,
 }
 
 /// A parsed port address.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) struct PortAddrParts<'a> {
     /// The port id.
-    pub(crate) id: PortIdParts<'a>,
+    pub(crate) id: PortId,
     /// The raw location tail.
     pub(crate) location: &'a str,
 }
 
 /// A parsed polymorphic address.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) enum AddressParts<'a> {
     /// A proc address.
     Proc(ProcAddrParts<'a>),
@@ -64,40 +65,37 @@ pub(crate) enum AddressParts<'a> {
 
 pub(crate) fn parse_proc_addr(input: &str) -> Result<ProcAddrParts<'_>, ParseError> {
     let mut parser = Parser::new(input);
-    let id = parse_proc_id_parts(&mut parser)?;
+    let id = parse_proc_id_with_parser(&mut parser)?;
     let location = parse_location(&mut parser)?;
     Ok(ProcAddrParts { id, location })
 }
 
 pub(crate) fn parse_actor_addr(input: &str) -> Result<ActorAddrParts<'_>, ParseError> {
     let mut parser = Parser::new(input);
-    let id = parse_actor_id_parts(&mut parser)?;
+    let id = parse_actor_id_with_parser(&mut parser)?;
     let location = parse_location(&mut parser)?;
     Ok(ActorAddrParts { id, location })
 }
 
 pub(crate) fn parse_port_addr(input: &str) -> Result<PortAddrParts<'_>, ParseError> {
     let mut parser = Parser::new(input);
-    let id = parse_port_id_parts(&mut parser)?;
+    let id = parse_port_id_with_parser(&mut parser)?;
     let location = parse_location(&mut parser)?;
     Ok(PortAddrParts { id, location })
 }
 
 pub(crate) fn parse_address(input: &str) -> Result<AddressParts<'_>, ParseError> {
     let mut parser = Parser::new(input);
-    let first = parse_id_component(&mut parser)?;
+    let first = parse_uid(&mut parser)?;
     match parser.peek().kind {
         TokenKind::At => Ok(AddressParts::Proc(ProcAddrParts {
-            id: ProcIdParts { component: first },
+            id: ProcId::new(first, None),
             location: parse_location(&mut parser)?,
         })),
         TokenKind::Dot => {
             parser.bump();
-            let proc_ = parse_id_component(&mut parser)?;
-            let actor = ActorIdParts {
-                actor: first,
-                proc_,
-            };
+            let proc_id = parse_proc_id_with_parser(&mut parser)?;
+            let actor = ActorId::new(first, proc_id, None);
             match parser.peek().kind {
                 TokenKind::At => Ok(AddressParts::Actor(ActorAddrParts {
                     id: actor,
@@ -109,11 +107,12 @@ pub(crate) fn parse_address(input: &str) -> Result<AddressParts<'_>, ParseError>
                     if !port.text.bytes().all(|ch| ch.is_ascii_digit()) {
                         return Err(ParseError::invalid_port(port));
                     }
+                    let port: u64 = port
+                        .text
+                        .parse()
+                        .map_err(|_| ParseError::invalid_port(port))?;
                     Ok(AddressParts::Port(PortAddrParts {
-                        id: PortIdParts {
-                            actor,
-                            port: port.text,
-                        },
+                        id: PortId::new(actor, Port::from(port)),
                         location: parse_location(&mut parser)?,
                     }))
                 }
@@ -138,66 +137,27 @@ fn parse_location<'a>(parser: &mut Parser<'a>) -> Result<&'a str, ParseError> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::parse::id::IdComponent;
     use crate::parse::lex::Span;
 
     #[test]
     fn test_parse_proc_addr() {
-        assert_eq!(
-            parse_proc_addr("local@inproc://0").unwrap(),
-            ProcAddrParts {
-                id: ProcIdParts {
-                    component: IdComponent::Singleton {
-                        label: "local",
-                        span: Span::new(0, 5),
-                    },
-                },
-                location: "inproc://0",
-            }
-        );
+        let parsed = parse_proc_addr("local@inproc://0").unwrap();
+        assert_eq!(parsed.id.to_string(), "local");
+        assert_eq!(parsed.location, "inproc://0");
     }
 
     #[test]
     fn test_parse_actor_addr() {
-        assert_eq!(
-            parse_actor_addr("controller.local@tcp://[::1]:2345").unwrap(),
-            ActorAddrParts {
-                id: ActorIdParts {
-                    actor: IdComponent::Singleton {
-                        label: "controller",
-                        span: Span::new(0, 10),
-                    },
-                    proc_: IdComponent::Singleton {
-                        label: "local",
-                        span: Span::new(11, 16),
-                    },
-                },
-                location: "tcp://[::1]:2345",
-            }
-        );
+        let parsed = parse_actor_addr("controller.local@tcp://[::1]:2345").unwrap();
+        assert_eq!(parsed.id.to_string(), "controller.local");
+        assert_eq!(parsed.location, "tcp://[::1]:2345");
     }
 
     #[test]
     fn test_parse_port_addr() {
-        assert_eq!(
-            parse_port_addr("controller.local:7@inproc://0").unwrap(),
-            PortAddrParts {
-                id: PortIdParts {
-                    actor: ActorIdParts {
-                        actor: IdComponent::Singleton {
-                            label: "controller",
-                            span: Span::new(0, 10),
-                        },
-                        proc_: IdComponent::Singleton {
-                            label: "local",
-                            span: Span::new(11, 16),
-                        },
-                    },
-                    port: "7",
-                },
-                location: "inproc://0",
-            }
-        );
+        let parsed = parse_port_addr("controller.local:7@inproc://0").unwrap();
+        assert_eq!(parsed.id.to_string(), "controller.local:7");
+        assert_eq!(parsed.location, "inproc://0");
     }
 
     #[test]

--- a/hyperactor/src/parse/error.rs
+++ b/hyperactor/src/parse/error.rs
@@ -49,6 +49,20 @@ impl ParseError {
         }
     }
 
+    pub(crate) fn invalid_label(span: Span, error: impl Into<String>) -> Self {
+        Self {
+            span,
+            kind: ParseErrorKind::InvalidLabel(error.into()),
+        }
+    }
+
+    pub(crate) fn invalid_base58_uid(token: Token<'_>) -> Self {
+        Self {
+            span: token.span,
+            kind: ParseErrorKind::InvalidBase58Uid(token.text.to_string()),
+        }
+    }
+
     pub(crate) fn missing_location(at: Token<'_>) -> Self {
         Self {
             span: at.span,
@@ -67,6 +81,10 @@ pub(crate) enum ParseErrorKind {
     Expected { expected: String, found: String },
     /// Input remained after a full parse.
     TrailingInput { found: String },
+    /// A label failed semantic validation.
+    InvalidLabel(String),
+    /// A base58 uid failed semantic validation.
+    InvalidBase58Uid(String),
     /// A non-decimal port was encountered.
     InvalidPort(String),
 }
@@ -84,6 +102,8 @@ impl fmt::Display for ParseErrorKind {
                 write!(f, "expected {expected}, found {found}")
             }
             Self::TrailingInput { found } => write!(f, "expected end of input, found {found}"),
+            Self::InvalidLabel(error) => write!(f, "invalid label: {error}"),
+            Self::InvalidBase58Uid(uid) => write!(f, "invalid base58 uid: {uid}"),
             Self::InvalidPort(port) => write!(f, "invalid port {port:?}"),
         }
     }

--- a/hyperactor/src/parse/id.rs
+++ b/hyperactor/src/parse/id.rs
@@ -8,162 +8,144 @@
 
 //! Recursive-descent parsing for Hyperactor ids.
 //!
-//! This module parses only the id grammar. It does not validate labels,
-//! base58 uid text, or decimal ports beyond the structural checks that are
-//! needed to distinguish grammar productions. Semantic validation happens when
-//! the parsed parts are converted into concrete `id` types.
+//! This module parses the id grammar and performs semantic validation for
+//! labels, base58 uids, and decimal ports while token spans are still
+//! available.
 
+use crate::id::ActorId;
+use crate::id::Label;
+use crate::id::PortId;
+use crate::id::ProcId;
+use crate::id::Uid;
 use crate::parse::error::ParseError;
 use crate::parse::lex::Lexer;
-use crate::parse::lex::Span;
 use crate::parse::lex::Token;
 use crate::parse::lex::TokenKind;
+use crate::port::Port;
 
-/// A parsed id component.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub(crate) enum IdComponent<'a> {
-    /// A singleton label.
-    Singleton { label: &'a str, span: Span },
-    /// An instance uid, optionally labeled.
-    Instance {
-        label: Option<&'a str>,
-        uid: &'a str,
-        span: Span,
-    },
-}
+/// Flickr base58 alphabet.
+const BASE58_FLICKR: &[u8; 58] = b"123456789abcdefghijkmnopqrstuvwxyzABCDEFGHJKLMNPQRSTUVWXYZ";
 
-/// A parsed uid.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub(crate) struct UidParts<'a> {
-    /// The uid component.
-    pub(crate) component: IdComponent<'a>,
-}
-
-/// A parsed proc id.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub(crate) struct ProcIdParts<'a> {
-    /// The proc id component.
-    pub(crate) component: IdComponent<'a>,
-}
-
-/// A parsed actor id.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub(crate) struct ActorIdParts<'a> {
-    /// The actor id component.
-    pub(crate) actor: IdComponent<'a>,
-    /// The process id component.
-    pub(crate) proc_: IdComponent<'a>,
-}
-
-/// A parsed port id.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub(crate) struct PortIdParts<'a> {
-    /// The parsed actor id.
-    pub(crate) actor: ActorIdParts<'a>,
-    /// The raw decimal port text.
-    pub(crate) port: &'a str,
-}
-
-pub(crate) fn parse_uid(input: &str) -> Result<UidParts<'_>, ParseError> {
+pub(crate) fn parse_uid_str(input: &str) -> Result<Uid, ParseError> {
     let mut parser = Parser::new(input);
-    let parts = parse_uid_parts(&mut parser)?;
+    let uid = parse_uid(&mut parser)?;
     parser.finish()?;
-    Ok(parts)
+    Ok(uid)
 }
 
-pub(crate) fn parse_proc_id(input: &str) -> Result<ProcIdParts<'_>, ParseError> {
+pub(crate) fn parse_proc_id(input: &str) -> Result<ProcId, ParseError> {
     let mut parser = Parser::new(input);
-    let parts = parse_proc_id_parts(&mut parser)?;
+    let id = parse_proc_id_with_parser(&mut parser)?;
     parser.finish()?;
-    Ok(parts)
+    Ok(id)
 }
 
-pub(crate) fn parse_actor_id(input: &str) -> Result<ActorIdParts<'_>, ParseError> {
+pub(crate) fn parse_actor_id(input: &str) -> Result<ActorId, ParseError> {
     let mut parser = Parser::new(input);
-    let parts = parse_actor_id_parts(&mut parser)?;
+    let id = parse_actor_id_with_parser(&mut parser)?;
     parser.finish()?;
-    Ok(parts)
+    Ok(id)
 }
 
-pub(crate) fn parse_port_id(input: &str) -> Result<PortIdParts<'_>, ParseError> {
+pub(crate) fn parse_port_id(input: &str) -> Result<PortId, ParseError> {
     let mut parser = Parser::new(input);
-    let parts = parse_port_id_parts(&mut parser)?;
+    let id = parse_port_id_with_parser(&mut parser)?;
     parser.finish()?;
-    Ok(parts)
+    Ok(id)
 }
 
-pub(crate) fn parse_uid_parts<'a>(parser: &mut Parser<'a>) -> Result<UidParts<'a>, ParseError> {
-    Ok(UidParts {
-        component: parse_id_component(parser)?,
-    })
+pub(crate) fn parse_uid(parser: &mut Parser<'_>) -> Result<Uid, ParseError> {
+    parse_id_component(parser)
 }
 
-pub(crate) fn parse_proc_id_parts<'a>(
-    parser: &mut Parser<'a>,
-) -> Result<ProcIdParts<'a>, ParseError> {
-    Ok(ProcIdParts {
-        component: parse_id_component(parser)?,
-    })
+pub(crate) fn parse_proc_id_with_parser(parser: &mut Parser<'_>) -> Result<ProcId, ParseError> {
+    Ok(ProcId::new(parse_uid(parser)?, None))
 }
 
-pub(crate) fn parse_actor_id_parts<'a>(
-    parser: &mut Parser<'a>,
-) -> Result<ActorIdParts<'a>, ParseError> {
-    let actor = parse_id_component(parser)?;
+pub(crate) fn parse_actor_id_with_parser(parser: &mut Parser<'_>) -> Result<ActorId, ParseError> {
+    let actor = parse_uid(parser)?;
     parser.expect_kind(TokenKind::Dot)?;
-    let proc_ = parse_id_component(parser)?;
-    Ok(ActorIdParts { actor, proc_ })
+    let proc_id = parse_proc_id_with_parser(parser)?;
+    Ok(ActorId::new(actor, proc_id, None))
 }
 
-pub(crate) fn parse_port_id_parts<'a>(
-    parser: &mut Parser<'a>,
-) -> Result<PortIdParts<'a>, ParseError> {
-    let actor = parse_actor_id_parts(parser)?;
+pub(crate) fn parse_port_id_with_parser(parser: &mut Parser<'_>) -> Result<PortId, ParseError> {
+    let actor_id = parse_actor_id_with_parser(parser)?;
     parser.expect_kind(TokenKind::Colon)?;
     let port = parser.expect_text("decimal port")?;
     if !port.text.bytes().all(|ch| ch.is_ascii_digit()) {
         return Err(ParseError::invalid_port(port));
     }
-    Ok(PortIdParts {
-        actor,
-        port: port.text,
-    })
+    let port: u64 = port
+        .text
+        .parse()
+        .map_err(|_| ParseError::invalid_port(port))?;
+    Ok(PortId::new(actor_id, Port::from(port)))
 }
 
-pub(crate) fn parse_id_component<'a>(
-    parser: &mut Parser<'a>,
-) -> Result<IdComponent<'a>, ParseError> {
+pub(crate) fn parse_id_component(parser: &mut Parser<'_>) -> Result<Uid, ParseError> {
     match parser.peek().kind {
         TokenKind::Text => {
             let label = parser.bump();
             if parser.peek().kind == TokenKind::LessThan {
                 parser.bump();
                 let uid = parser.expect_text("uid text")?;
-                let end = parser.expect_kind(TokenKind::GreaterThan)?;
-                Ok(IdComponent::Instance {
-                    label: Some(label.text),
-                    uid: uid.text,
-                    span: Span::new(label.span.start, end.span.end),
-                })
+                parser.expect_kind(TokenKind::GreaterThan)?;
+                let label = parse_label(label)?;
+                let uid = parse_base58_uid(uid)?;
+                Ok(Uid::Instance(uid, Some(label)))
             } else {
-                Ok(IdComponent::Singleton {
-                    label: label.text,
-                    span: label.span,
-                })
+                Ok(Uid::Singleton(parse_label(label)?))
             }
         }
         TokenKind::LessThan => {
-            let start = parser.bump();
+            parser.bump();
             let uid = parser.expect_text("uid text")?;
-            let end = parser.expect_kind(TokenKind::GreaterThan)?;
-            Ok(IdComponent::Instance {
-                label: None,
-                uid: uid.text,
-                span: Span::new(start.span.start, end.span.end),
-            })
+            parser.expect_kind(TokenKind::GreaterThan)?;
+            Ok(Uid::Instance(parse_base58_uid(uid)?, None))
         }
         _ => Err(ParseError::expected(parser.bump(), "\"label\" or \"<\"")),
     }
+}
+
+fn parse_label(token: Token<'_>) -> Result<Label, ParseError> {
+    Label::new(token.text).map_err(|err| ParseError::invalid_label(token.span, err.to_string()))
+}
+
+fn parse_base58_uid(token: Token<'_>) -> Result<u64, ParseError> {
+    decode_base58_uid(token.text).map_err(|_| ParseError::invalid_base58_uid(token))
+}
+
+pub(crate) fn encode_base58_uid(mut uid: u64) -> String {
+    if uid == 0 {
+        return "1".to_string();
+    }
+
+    let mut digits = Vec::new();
+    while uid > 0 {
+        digits.push(BASE58_FLICKR[(uid % 58) as usize] as char);
+        uid /= 58;
+    }
+    digits.iter().rev().collect()
+}
+
+pub(crate) fn decode_base58_uid(s: &str) -> Result<u64, ()> {
+    if s.is_empty() {
+        return Err(());
+    }
+
+    let mut uid = 0u64;
+    for ch in s.bytes() {
+        let digit = BASE58_FLICKR
+            .iter()
+            .position(|candidate| *candidate == ch)
+            .ok_or(())? as u64;
+        uid = uid
+            .checked_mul(58)
+            .and_then(|value| value.checked_add(digit))
+            .ok_or(())?;
+    }
+    Ok(uid)
 }
 
 pub(crate) struct Parser<'a> {
@@ -234,122 +216,63 @@ impl<'a> Parser<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::parse::lex::Span;
 
     #[test]
     fn test_parse_uid_forms() {
+        assert_eq!(parse_uid_str("local").unwrap().to_string(), "local");
         assert_eq!(
-            parse_uid("local").unwrap(),
-            UidParts {
-                component: IdComponent::Singleton {
-                    label: "local",
-                    span: Span::new(0, 5),
-                },
-            }
+            parse_uid_str("controller<2>").unwrap().to_string(),
+            "controller<2>"
         );
-        assert_eq!(
-            parse_uid("controller<abc>").unwrap(),
-            UidParts {
-                component: IdComponent::Instance {
-                    label: Some("controller"),
-                    uid: "abc",
-                    span: Span::new(0, 15),
-                },
-            }
-        );
-        assert_eq!(
-            parse_uid("<abc>").unwrap(),
-            UidParts {
-                component: IdComponent::Instance {
-                    label: None,
-                    uid: "abc",
-                    span: Span::new(0, 5),
-                },
-            }
-        );
+        assert_eq!(parse_uid_str("<2>").unwrap().to_string(), "<2>");
     }
 
     #[test]
     fn test_parse_proc_id_forms() {
+        assert_eq!(parse_proc_id("local").unwrap().to_string(), "local");
         assert_eq!(
-            parse_proc_id("local").unwrap(),
-            ProcIdParts {
-                component: IdComponent::Singleton {
-                    label: "local",
-                    span: Span::new(0, 5),
-                },
-            }
+            parse_proc_id("controller<2>").unwrap().to_string(),
+            "controller<2>"
         );
-        assert_eq!(
-            parse_proc_id("controller<abc>").unwrap(),
-            ProcIdParts {
-                component: IdComponent::Instance {
-                    label: Some("controller"),
-                    uid: "abc",
-                    span: Span::new(0, 15),
-                },
-            }
-        );
-        assert_eq!(
-            parse_proc_id("<abc>").unwrap(),
-            ProcIdParts {
-                component: IdComponent::Instance {
-                    label: None,
-                    uid: "abc",
-                    span: Span::new(0, 5),
-                },
-            }
-        );
+        assert_eq!(parse_proc_id("<2>").unwrap().to_string(), "<2>");
     }
 
     #[test]
     fn test_parse_actor_id_forms() {
         assert_eq!(
-            parse_actor_id("controller.local").unwrap(),
-            ActorIdParts {
-                actor: IdComponent::Singleton {
-                    label: "controller",
-                    span: Span::new(0, 10),
-                },
-                proc_: IdComponent::Singleton {
-                    label: "local",
-                    span: Span::new(11, 16),
-                },
-            }
+            parse_actor_id("controller.local").unwrap().to_string(),
+            "controller.local"
         );
         assert_eq!(
-            parse_actor_id("controller<abc>.local").unwrap(),
-            ActorIdParts {
-                actor: IdComponent::Instance {
-                    label: Some("controller"),
-                    uid: "abc",
-                    span: Span::new(0, 15),
-                },
-                proc_: IdComponent::Singleton {
-                    label: "local",
-                    span: Span::new(16, 21),
-                },
-            }
+            parse_actor_id("controller<2>.local").unwrap().to_string(),
+            "controller<2>.local"
         );
     }
 
     #[test]
     fn test_parse_port_id_form() {
         assert_eq!(
-            parse_port_id("controller.local:7").unwrap(),
-            PortIdParts {
-                actor: ActorIdParts {
-                    actor: IdComponent::Singleton {
-                        label: "controller",
-                        span: Span::new(0, 10),
-                    },
-                    proc_: IdComponent::Singleton {
-                        label: "local",
-                        span: Span::new(11, 16),
-                    },
-                },
-                port: "7",
-            }
+            parse_port_id("controller.local:7").unwrap().to_string(),
+            "controller.local:7"
         );
+    }
+
+    #[test]
+    fn test_parse_uid_reports_invalid_base58_span() {
+        let err = parse_uid_str("controller<0>").unwrap_err();
+        assert_eq!(err.to_string(), "invalid base58 uid: 0");
+        assert_eq!(err.span, Span::new(11, 12));
+    }
+
+    #[test]
+    fn test_parse_uid_reports_invalid_label_span() {
+        let err = parse_uid_str("Controller<2>").unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "invalid label: label must start with a lowercase letter"
+        );
+        assert_eq!(err.span, Span::new(0, 10));
     }
 
     #[test]
@@ -386,20 +309,8 @@ mod tests {
     #[test]
     fn test_parser_rest_tracks_location_boundary() {
         let mut parser = Parser::new("controller.local@inproc://0");
-        let actor = parse_actor_id_parts(&mut parser).unwrap();
-        assert_eq!(
-            actor,
-            ActorIdParts {
-                actor: IdComponent::Singleton {
-                    label: "controller",
-                    span: Span::new(0, 10),
-                },
-                proc_: IdComponent::Singleton {
-                    label: "local",
-                    span: Span::new(11, 16),
-                },
-            }
-        );
+        let actor = parse_actor_id_with_parser(&mut parser).unwrap();
+        assert_eq!(actor.to_string(), "controller.local");
         assert_eq!(parser.rest(), "@inproc://0");
     }
 }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #3739
* #3738
* #3737
* __->__ #3736
* #3735

Move label validation and base58 uid decoding into the id parser so parser entry points return concrete Uid, ProcId, ActorId, and PortId values with span-aware ParseError diagnostics. Update address parsing to carry concrete ids instead of reparsing id text.

Differential Revision: [D103561880](https://our.internmc.facebook.com/intern/diff/D103561880/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D103561880/)!