### PR TITLE
[hyperactor] return concrete addrs from parser

### DIFF
--- a/hyperactor/src/addr.rs
+++ b/hyperactor/src/addr.rs
@@ -46,9 +46,6 @@ use crate::id::PortId;
 use crate::id::ProcId;
 use crate::id::Uid;
 use crate::parse;
-use crate::parse::addr::ActorAddrParts;
-use crate::parse::addr::PortAddrParts;
-use crate::parse::addr::ProcAddrParts;
 use crate::port::Port;
 
 /// A network location, wrapping a [`ChannelAddr`].
@@ -300,8 +297,7 @@ impl FromStr for ProcAddr {
     type Err = AddrParseError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let parts = parse::addr::parse_proc_addr(s).map_err(|_| legacy_parse_proc_ref(s))?;
-        Self::try_from((s, parts))
+        parse::addr::parse_proc_addr(s).map_err(|_| legacy_parse_proc_ref(s))
     }
 }
 
@@ -463,8 +459,7 @@ impl FromStr for ActorAddr {
     type Err = AddrParseError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let parts = parse::addr::parse_actor_addr(s).map_err(|_| legacy_parse_actor_ref(s))?;
-        Self::try_from((s, parts))
+        parse::addr::parse_actor_addr(s).map_err(|_| legacy_parse_actor_ref(s))
     }
 }
 
@@ -623,8 +618,7 @@ impl FromStr for PortAddr {
     type Err = AddrParseError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let parts = parse::addr::parse_port_addr(s).map_err(|_| legacy_parse_port_ref(s))?;
-        Self::try_from((s, parts))
+        parse::addr::parse_port_addr(s).map_err(|_| legacy_parse_port_ref(s))
     }
 }
 
@@ -723,62 +717,7 @@ impl FromStr for Address {
     type Err = AddrParseError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match parse::addr::parse_address(s).map_err(|_| legacy_parse_reference(s))? {
-            parse::addr::AddressParts::Proc(parts) => {
-                Ok(Self::Proc(ProcAddr::try_from((s, parts))?))
-            }
-            parse::addr::AddressParts::Actor(parts) => {
-                Ok(Self::Actor(ActorAddr::try_from((s, parts))?))
-            }
-            parse::addr::AddressParts::Port(parts) => {
-                Ok(Self::Port(PortAddr::try_from((s, parts))?))
-            }
-        }
-    }
-}
-
-impl<'a> TryFrom<(&'a str, ProcAddrParts<'a>)> for ProcAddr {
-    type Error = AddrParseError;
-
-    fn try_from((_, parts): (&'a str, ProcAddrParts<'a>)) -> Result<Self, Self::Error> {
-        let location: Location = parts
-            .location
-            .parse()
-            .map_err(AddrParseError::InvalidLocation)?;
-        Ok(Self {
-            id: parts.id,
-            location,
-        })
-    }
-}
-
-impl<'a> TryFrom<(&'a str, ActorAddrParts<'a>)> for ActorAddr {
-    type Error = AddrParseError;
-
-    fn try_from((_, parts): (&'a str, ActorAddrParts<'a>)) -> Result<Self, Self::Error> {
-        let location: Location = parts
-            .location
-            .parse()
-            .map_err(AddrParseError::InvalidLocation)?;
-        Ok(Self {
-            id: parts.id,
-            location,
-        })
-    }
-}
-
-impl<'a> TryFrom<(&'a str, PortAddrParts<'a>)> for PortAddr {
-    type Error = AddrParseError;
-
-    fn try_from((_, parts): (&'a str, PortAddrParts<'a>)) -> Result<Self, Self::Error> {
-        let location: Location = parts
-            .location
-            .parse()
-            .map_err(AddrParseError::InvalidLocation)?;
-        Ok(Self {
-            id: parts.id,
-            location,
-        })
+        parse::addr::parse_address(s).map_err(|_| legacy_parse_reference(s))
     }
 }
 

--- a/hyperactor/src/parse/addr.rs
+++ b/hyperactor/src/parse/addr.rs
@@ -13,6 +13,11 @@
 //! keeps URL punctuation out of the Hyperactor lexer while still giving
 //! token-aware errors at the id/address boundary.
 
+use crate::addr::ActorAddr;
+use crate::addr::Address;
+use crate::addr::Location;
+use crate::addr::PortAddr;
+use crate::addr::ProcAddr;
 use crate::id::ActorId;
 use crate::id::PortId;
 use crate::id::ProcId;
@@ -25,82 +30,44 @@ use crate::parse::id::parse_uid;
 use crate::parse::lex::TokenKind;
 use crate::port::Port;
 
-/// A parsed proc address.
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub(crate) struct ProcAddrParts<'a> {
-    /// The proc id.
-    pub(crate) id: ProcId,
-    /// The raw location tail.
-    pub(crate) location: &'a str,
-}
-
-/// A parsed actor address.
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub(crate) struct ActorAddrParts<'a> {
-    /// The actor id.
-    pub(crate) id: ActorId,
-    /// The raw location tail.
-    pub(crate) location: &'a str,
-}
-
-/// A parsed port address.
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub(crate) struct PortAddrParts<'a> {
-    /// The port id.
-    pub(crate) id: PortId,
-    /// The raw location tail.
-    pub(crate) location: &'a str,
-}
-
-/// A parsed polymorphic address.
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub(crate) enum AddressParts<'a> {
-    /// A proc address.
-    Proc(ProcAddrParts<'a>),
-    /// An actor address.
-    Actor(ActorAddrParts<'a>),
-    /// A port address.
-    Port(PortAddrParts<'a>),
-}
-
-pub(crate) fn parse_proc_addr(input: &str) -> Result<ProcAddrParts<'_>, ParseError> {
+pub(crate) fn parse_proc_addr(input: &str) -> Result<ProcAddr, ParseError> {
     let mut parser = Parser::new(input);
     let id = parse_proc_id_with_parser(&mut parser)?;
     let location = parse_location(&mut parser)?;
-    Ok(ProcAddrParts { id, location })
+    Ok(ProcAddr::new(id, location))
 }
 
-pub(crate) fn parse_actor_addr(input: &str) -> Result<ActorAddrParts<'_>, ParseError> {
+pub(crate) fn parse_actor_addr(input: &str) -> Result<ActorAddr, ParseError> {
     let mut parser = Parser::new(input);
     let id = parse_actor_id_with_parser(&mut parser)?;
     let location = parse_location(&mut parser)?;
-    Ok(ActorAddrParts { id, location })
+    Ok(ActorAddr::new(id, location))
 }
 
-pub(crate) fn parse_port_addr(input: &str) -> Result<PortAddrParts<'_>, ParseError> {
+pub(crate) fn parse_port_addr(input: &str) -> Result<PortAddr, ParseError> {
     let mut parser = Parser::new(input);
     let id = parse_port_id_with_parser(&mut parser)?;
     let location = parse_location(&mut parser)?;
-    Ok(PortAddrParts { id, location })
+    Ok(PortAddr::new(id, location))
 }
 
-pub(crate) fn parse_address(input: &str) -> Result<AddressParts<'_>, ParseError> {
+pub(crate) fn parse_address(input: &str) -> Result<Address, ParseError> {
     let mut parser = Parser::new(input);
     let first = parse_uid(&mut parser)?;
     match parser.peek().kind {
-        TokenKind::At => Ok(AddressParts::Proc(ProcAddrParts {
-            id: ProcId::new(first, None),
-            location: parse_location(&mut parser)?,
-        })),
+        TokenKind::At => Ok(Address::Proc(ProcAddr::new(
+            ProcId::new(first, None),
+            parse_location(&mut parser)?,
+        ))),
         TokenKind::Dot => {
             parser.bump();
             let proc_id = parse_proc_id_with_parser(&mut parser)?;
             let actor = ActorId::new(first, proc_id, None);
             match parser.peek().kind {
-                TokenKind::At => Ok(AddressParts::Actor(ActorAddrParts {
-                    id: actor,
-                    location: parse_location(&mut parser)?,
-                })),
+                TokenKind::At => Ok(Address::Actor(ActorAddr::new(
+                    actor,
+                    parse_location(&mut parser)?,
+                ))),
                 TokenKind::Colon => {
                     parser.bump();
                     let port = parser.expect_text("decimal port")?;
@@ -111,10 +78,10 @@ pub(crate) fn parse_address(input: &str) -> Result<AddressParts<'_>, ParseError>
                         .text
                         .parse()
                         .map_err(|_| ParseError::invalid_port(port))?;
-                    Ok(AddressParts::Port(PortAddrParts {
-                        id: PortId::new(actor, Port::from(port)),
-                        location: parse_location(&mut parser)?,
-                    }))
+                    Ok(Address::Port(PortAddr::new(
+                        PortId::new(actor, Port::from(port)),
+                        parse_location(&mut parser)?,
+                    )))
                 }
                 _ => Err(ParseError::expected(parser.peek(), "\"@\" or \":\"")),
             }
@@ -123,15 +90,19 @@ pub(crate) fn parse_address(input: &str) -> Result<AddressParts<'_>, ParseError>
     }
 }
 
-fn parse_location<'a>(parser: &mut Parser<'a>) -> Result<&'a str, ParseError> {
+fn parse_location(parser: &mut Parser<'_>) -> Result<Location, ParseError> {
     let at = parser.expect_kind(TokenKind::At)?;
     let location = parser.rest();
     if location.is_empty() {
         return Err(ParseError::missing_location(at));
     }
-    let location = parser.take_rest();
+    let span = parser.rest_span();
+    let parsed = location
+        .parse()
+        .map_err(|err: anyhow::Error| ParseError::invalid_location(span, err.to_string()))?;
+    parser.take_rest();
     parser.finish()?;
-    Ok(location)
+    Ok(parsed)
 }
 
 #[cfg(test)]
@@ -142,38 +113,45 @@ mod tests {
     #[test]
     fn test_parse_proc_addr() {
         let parsed = parse_proc_addr("local@inproc://0").unwrap();
-        assert_eq!(parsed.id.to_string(), "local");
-        assert_eq!(parsed.location, "inproc://0");
+        assert_eq!(parsed.id().to_string(), "local");
+        assert_eq!(parsed.location().to_string(), "inproc://0");
     }
 
     #[test]
     fn test_parse_actor_addr() {
         let parsed = parse_actor_addr("controller.local@tcp://[::1]:2345").unwrap();
-        assert_eq!(parsed.id.to_string(), "controller.local");
-        assert_eq!(parsed.location, "tcp://[::1]:2345");
+        assert_eq!(parsed.id().to_string(), "controller.local");
+        assert_eq!(parsed.location().to_string(), "tcp://[::1]:2345");
     }
 
     #[test]
     fn test_parse_port_addr() {
         let parsed = parse_port_addr("controller.local:7@inproc://0").unwrap();
-        assert_eq!(parsed.id.to_string(), "controller.local:7");
-        assert_eq!(parsed.location, "inproc://0");
+        assert_eq!(parsed.id().to_string(), "controller.local:7");
+        assert_eq!(parsed.location().to_string(), "inproc://0");
     }
 
     #[test]
     fn test_parse_address_specificity() {
         assert!(matches!(
             parse_address("local@inproc://0").unwrap(),
-            AddressParts::Proc(_)
+            Address::Proc(_)
         ));
         assert!(matches!(
             parse_address("local.local@inproc://0").unwrap(),
-            AddressParts::Actor(_)
+            Address::Actor(_)
         ));
         assert!(matches!(
             parse_address("local.local:7@inproc://0").unwrap(),
-            AddressParts::Port(_)
+            Address::Port(_)
         ));
+    }
+
+    #[test]
+    fn test_parse_address_reports_invalid_location() {
+        let err = parse_address("local@tcp://").unwrap_err();
+        assert!(err.to_string().starts_with("invalid location: "));
+        assert_eq!(err.span, Span::new(6, 12));
     }
 
     #[test]

--- a/hyperactor/src/parse/error.rs
+++ b/hyperactor/src/parse/error.rs
@@ -72,6 +72,13 @@ impl ParseError {
             },
         }
     }
+
+    pub(crate) fn invalid_location(span: Span, error: impl Into<String>) -> Self {
+        Self {
+            span,
+            kind: ParseErrorKind::InvalidLocation(error.into()),
+        }
+    }
 }
 
 /// Shared parse error kinds.
@@ -87,6 +94,8 @@ pub(crate) enum ParseErrorKind {
     InvalidBase58Uid(String),
     /// A non-decimal port was encountered.
     InvalidPort(String),
+    /// A location failed semantic validation.
+    InvalidLocation(String),
 }
 
 impl fmt::Display for ParseError {
@@ -105,6 +114,7 @@ impl fmt::Display for ParseErrorKind {
             Self::InvalidLabel(error) => write!(f, "invalid label: {error}"),
             Self::InvalidBase58Uid(uid) => write!(f, "invalid base58 uid: {uid}"),
             Self::InvalidPort(port) => write!(f, "invalid port {port:?}"),
+            Self::InvalidLocation(error) => write!(f, "invalid location: {error}"),
         }
     }
 }

--- a/hyperactor/src/parse/id.rs
+++ b/hyperactor/src/parse/id.rs
@@ -19,6 +19,7 @@ use crate::id::ProcId;
 use crate::id::Uid;
 use crate::parse::error::ParseError;
 use crate::parse::lex::Lexer;
+use crate::parse::lex::Span;
 use crate::parse::lex::Token;
 use crate::parse::lex::TokenKind;
 use crate::port::Port;
@@ -206,6 +207,10 @@ impl<'a> Parser<'a> {
         &self.input[self.peek().span.start..]
     }
 
+    pub(crate) fn rest_span(&self) -> Span {
+        Span::new(self.peek().span.start, self.input.len())
+    }
+
     pub(crate) fn take_rest(&mut self) -> &'a str {
         let rest = self.rest();
         self.lookahead = Token::eof(self.input.len());
@@ -216,7 +221,6 @@ impl<'a> Parser<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::parse::lex::Span;
 
     #[test]
     fn test_parse_uid_forms() {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #3739
* #3738
* __->__ #3737
* #3736
* #3735

Move Location parsing into parse::addr so address parser entry points return concrete ProcAddr, ActorAddr, PortAddr, and Address values instead of intermediate Parts structs. Add span-aware invalid-location parse errors and remove the reparsing/conversion layer from addr.rs.

Differential Revision: [D103561879](https://our.internmc.facebook.com/intern/diff/D103561879/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D103561879/)!