### PR TITLE
[hyperactor] derive enum inner helpers for ids and addrs

### DIFF
--- a/hyperactor/src/addr.rs
+++ b/hyperactor/src/addr.rs
@@ -33,6 +33,7 @@
 use std::fmt;
 use std::str::FromStr;
 
+use enum_as_inner::EnumAsInner;
 use serde::Deserialize;
 use serde::Serialize;
 
@@ -388,7 +389,7 @@ impl ActorAddr {
 
     /// Whether this is a root actor (singleton uid).
     pub fn is_root(&self) -> bool {
-        matches!(self.id.uid(), Uid::Singleton(_))
+        self.id.uid().is_singleton()
     }
 
     /// A human-readable name for logging.
@@ -627,7 +628,7 @@ impl FromStr for PortAddr {
 /// Used for prefix-based routing in [`MailboxRouter`] and
 /// [`DialMailboxRouter`]. Ordering is lexicographic by
 /// (proc, actor uid, port).
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, EnumAsInner, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum Addr {
     /// A process reference.
     Proc(ProcAddr),
@@ -1454,13 +1455,13 @@ mod tests {
     #[test]
     fn test_reference_fromstr_specificity() {
         let parsed: Addr = "local@inproc://0".parse().unwrap();
-        assert!(matches!(parsed, Addr::Proc(_)));
+        assert!(parsed.is_proc());
 
         let parsed: Addr = "local.local@inproc://0".parse().unwrap();
-        assert!(matches!(parsed, Addr::Actor(_)));
+        assert!(parsed.is_actor());
 
         let parsed: Addr = "local.local:7@inproc://0".parse().unwrap();
-        assert!(matches!(parsed, Addr::Port(_)));
+        assert!(parsed.is_port());
     }
 
     #[test]

--- a/hyperactor/src/id.rs
+++ b/hyperactor/src/id.rs
@@ -38,6 +38,7 @@ use std::hash::Hash;
 use std::hash::Hasher;
 use std::str::FromStr;
 
+use enum_as_inner::EnumAsInner;
 use serde::Deserialize;
 use serde::Serialize;
 use smol_str::SmolStr;
@@ -191,7 +192,7 @@ impl<'de> Deserialize<'de> for Label {
 ///
 /// Singleton labels are identity. Instance labels are supplemental metadata
 /// and do not participate in equality, hashing, or ordering.
-#[derive(Clone)]
+#[derive(Clone, EnumAsInner)]
 pub enum Uid {
     /// A singleton identified by label.
     Singleton(Label),
@@ -688,7 +689,17 @@ impl FromStr for PortId {
 }
 
 /// A Hyperactor id.
-#[derive(Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+#[derive(
+    Clone,
+    EnumAsInner,
+    PartialEq,
+    Eq,
+    Hash,
+    PartialOrd,
+    Ord,
+    Serialize,
+    Deserialize
+)]
 pub enum Id {
     /// A process id.
     Proc(ProcId),
@@ -1177,7 +1188,7 @@ mod tests {
     fn test_proc_id_instance() {
         let label = Label::new("my-proc").unwrap();
         let pid = ProcId::instance(label.clone());
-        assert!(matches!(pid.uid(), Uid::Instance(_, Some(_))));
+        assert!(pid.uid().is_instance());
         assert_eq!(pid.label(), Some(&label));
         let pid2 = ProcId::instance(label);
         assert_ne!(pid, pid2);
@@ -1197,7 +1208,7 @@ mod tests {
     fn test_actor_id_instance() {
         let proc_id = ProcId::singleton(Label::new("my-proc").unwrap());
         let aid = ActorId::instance(proc_id.clone());
-        assert!(matches!(aid.uid(), Uid::Instance(_, None)));
+        assert!(aid.uid().is_instance());
         assert_eq!(aid.proc_id(), &proc_id);
         assert_eq!(aid.label(), None);
         let aid2 = ActorId::instance(proc_id);
@@ -1209,7 +1220,7 @@ mod tests {
         let label = Label::new("my-actor").unwrap();
         let proc_id = ProcId::singleton(Label::new("my-proc").unwrap());
         let aid = ActorId::instance_labeled(label.clone(), proc_id.clone());
-        assert!(matches!(aid.uid(), Uid::Instance(_, Some(_))));
+        assert!(aid.uid().is_instance());
         assert_eq!(aid.proc_id(), &proc_id);
         assert_eq!(aid.label(), Some(&label));
         let aid2 = ActorId::instance_labeled(label, proc_id);

--- a/hyperactor/src/parse/addr.rs
+++ b/hyperactor/src/parse/addr.rs
@@ -97,18 +97,9 @@ mod tests {
 
     #[test]
     fn test_parse_addr_specificity() {
-        assert!(matches!(
-            parse_addr("local@inproc://0").unwrap(),
-            Addr::Proc(_)
-        ));
-        assert!(matches!(
-            parse_addr("local.local@inproc://0").unwrap(),
-            Addr::Actor(_)
-        ));
-        assert!(matches!(
-            parse_addr("local.local:7@inproc://0").unwrap(),
-            Addr::Port(_)
-        ));
+        assert!(parse_addr("local@inproc://0").unwrap().is_proc());
+        assert!(parse_addr("local.local@inproc://0").unwrap().is_actor());
+        assert!(parse_addr("local.local:7@inproc://0").unwrap().is_port());
     }
 
     #[test]

--- a/hyperactor/src/parse/id.rs
+++ b/hyperactor/src/parse/id.rs
@@ -296,15 +296,9 @@ mod tests {
 
     #[test]
     fn test_parse_id_specificity() {
-        assert!(matches!(parse_id("local").unwrap(), Id::Proc(_)));
-        assert!(matches!(
-            parse_id("controller.local").unwrap(),
-            Id::Actor(_)
-        ));
-        assert!(matches!(
-            parse_id("controller.local:7").unwrap(),
-            Id::Port(_)
-        ));
+        assert!(parse_id("local").unwrap().is_proc());
+        assert!(parse_id("controller.local").unwrap().is_actor());
+        assert!(parse_id("controller.local:7").unwrap().is_port());
     }
 
     #[test]

--- a/hyperactor_mesh/src/bootstrap/mailbox.rs
+++ b/hyperactor_mesh/src/bootstrap/mailbox.rs
@@ -16,7 +16,6 @@ use async_trait::async_trait;
 use hyperactor::PortHandle;
 use hyperactor::channel::ChannelAddr;
 use hyperactor::channel::ChannelError;
-use hyperactor::id::Uid;
 use hyperactor::mailbox::DeliveryError;
 use hyperactor::mailbox::MailboxClient;
 use hyperactor::mailbox::MailboxSender;
@@ -64,7 +63,7 @@ impl MailboxSender for LocalProcDialer {
         if addr == &self.local_addr
             // ...and only non-system procs on that address; the rest are directly
             // reachable through the backend address.
-            && matches!(proc_ref.uid(), Uid::Instance(_, _))
+            && proc_ref.uid().is_instance()
         {
             let key = proc_ref.resource_name();
             let senders = self.local_senders.read().unwrap();

--- a/hyperactor_mesh/src/mesh_admin.rs
+++ b/hyperactor_mesh/src/mesh_admin.rs
@@ -357,7 +357,6 @@ use hyperactor::Handler;
 use hyperactor::Instance;
 use hyperactor::RefClient;
 use hyperactor::channel::try_tls_acceptor;
-use hyperactor::id::Uid;
 use hyperactor::introspect::IntrospectMessage;
 use hyperactor::introspect::IntrospectResult;
 use hyperactor::introspect::IntrospectView;
@@ -2259,8 +2258,10 @@ impl ResolvedProcHandler {
 /// the probe (CFG-4).
 fn route_proc_handler(raw_proc_reference: &str) -> Result<ResolvedProcHandler, ApiError> {
     let (_proc_reference, proc_id) = parse_proc_reference(raw_proc_reference)?;
-    let is_service =
-        matches!(proc_id.uid(), Uid::Singleton(label) if label.as_str() == SERVICE_PROC_NAME);
+    let is_service = proc_id
+        .uid()
+        .as_singleton()
+        .is_some_and(|label| label.as_str() == SERVICE_PROC_NAME);
     if is_service {
         let agent_id = proc_id.actor_id(HOST_MESH_AGENT_ACTOR_NAME);
         Ok(ResolvedProcHandler::Host(

--- a/hyperactor_mesh/src/mesh_id.rs
+++ b/hyperactor_mesh/src/mesh_id.rs
@@ -367,7 +367,7 @@ mod tests {
     #[test]
     fn test_resource_id_unique() {
         let id = ResourceId::unique(Label::new("workers").unwrap());
-        assert!(matches!(id.uid(), Uid::Instance(_, Some(_))));
+        assert!(id.uid().is_instance());
         assert_eq!(id.label().map(|l| l.as_str()), Some("workers"));
     }
 
@@ -572,11 +572,11 @@ mod tests {
         assert_eq!(*host.uid(), Uid::Singleton(Label::new("local").unwrap()));
 
         let proc_ = ProcMeshId::unique(Label::new("workers").unwrap());
-        assert!(matches!(proc_.uid(), Uid::Instance(_, Some(_))));
+        assert!(proc_.uid().is_instance());
         assert_eq!(proc_.label().map(|l| l.as_str()), Some("workers"));
 
         let actor = ActorMeshId::unique(Label::new("trainers").unwrap());
-        assert!(matches!(actor.uid(), Uid::Instance(_, Some(_))));
+        assert!(actor.uid().is_instance());
         assert_eq!(actor.label().map(|l| l.as_str()), Some("trainers"));
     }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #3739
* #3738
* #3737
* #3736
* #3735

Derive `EnumAsInner` for `Uid`, `Id`, and `Addr`, and replace simple boolean `matches!` checks with generated `is_*` and `as_*` helpers. This keeps variant tests for ids and addresses consistent and avoids open-coded pattern checks where no data is being bound.

Differential Revision: [D103562588](https://our.internmc.facebook.com/intern/diff/D103562588/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D103562588/)!