### PR TITLE
Fix cuda available on ROCm (#3740)

### DIFF
--- a/python/tests/test_tensor_engine.py
+++ b/python/tests/test_tensor_engine.py
@@ -21,8 +21,8 @@ needs_tensor_engine = pytest.mark.skipif(
     reason="tensor_engine was not built",
 )
 needs_cuda = pytest.mark.skipif(
-    not torch.cuda.is_available(),
-    reason="cross-rank tensor transport currently requires CUDA",
+    not torch.cuda.is_available() or torch.version.hip,
+    reason="cross-rank tensor transport requires CUDA+NCCL (not ROCm/HIP)",
 )
 
 


### PR DESCRIPTION
Summary:

On ROCm builds, `torch.cuda.is_available()` returns `True` because PyTorch maps HIP through the `torch.cuda` namespace. This means the `needs_cuda` skip decorator does not trigger on ROCm runners. However, the `test_proc_mesh_tensor_engine` test exercises cross-rank `to_mesh()` transport, which uses native CUDA/NCCL in Monarch's Rust tensor engine — not PyTorch's abstraction. Since ROCm runners have AMD GPUs (no NVIDIA devices), the Rust code fails with a `NoDevice` error.

Add a `torch.version.hip is not None` check to the `needs_cuda` skip condition so that this test is correctly skipped on ROCm builds.

Reviewed By: thedavekwon

Differential Revision: D103610336


