### PR TITLE
[hyperactor] add deferred stop handling to actor lifecycle

### DIFF
--- a/hyperactor/src/actor.rs
+++ b/hyperactor/src/actor.rs
@@ -47,13 +47,32 @@ use crate::mailbox::UndeliverableMessageError;
 use crate::message::Castable;
 use crate::message::IndexedErasedUnbound;
 use crate::proc::Context;
+use crate::proc::HandlerPorts;
 use crate::proc::Instance;
 use crate::proc::InstanceCell;
-use crate::proc::Ports;
 use crate::proc::Proc;
 use crate::supervision::ActorSupervisionEvent;
 
 pub mod remote;
+
+/// The shutdown mode requested for an actor.
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Serialize,
+    Deserialize,
+    PartialEq,
+    Eq,
+    typeuri::Named
+)]
+pub enum StopMode {
+    /// Stop without draining ordinary queued work first.
+    Stop,
+    /// Stop after draining already accepted ordinary queued work.
+    DrainAndStop,
+}
+wirevalue::register_type!(StopMode);
 
 /// An Actor is an independent, asynchronous thread of execution. Each
 /// actor instance has a mailbox, whose messages are delivered through
@@ -71,6 +90,27 @@ pub trait Actor: Sized + Send + 'static {
     async fn init(&mut self, _this: &Instance<Self>) -> Result<(), anyhow::Error> {
         // Default implementation: no init.
         Ok(())
+    }
+
+    /// Handle a stop request from the runtime.
+    ///
+    /// The default implementation closes handler ingress and then
+    /// either exits immediately or queues an exit after already
+    /// accepted handler work drains. Actors that need to coordinate
+    /// asynchronous shutdown work can override this method and call
+    /// `Instance::exit()` / `Instance::exit_after_drain()` later,
+    /// once they are ready to terminate.
+    async fn handle_stop(
+        &mut self,
+        this: &Instance<Self>,
+        mode: StopMode,
+        reason: &str,
+    ) -> Result<(), anyhow::Error> {
+        this.close();
+        match mode {
+            StopMode::Stop => this.exit(reason).map_err(anyhow::Error::from),
+            StopMode::DrainAndStop => this.exit_after_drain(reason).map_err(anyhow::Error::from),
+        }
     }
 
     /// Cleanup things used by this actor before shutting down. Notably this function
@@ -178,7 +218,7 @@ impl Actor for () {}
 impl Referable for () {}
 
 impl Binds<()> for () {
-    fn bind(_ports: &Ports<Self>) {
+    fn bind(_ports: &HandlerPorts<Self>) {
         // Binds no ports.
     }
 }
@@ -458,13 +498,16 @@ pub enum Signal {
     /// Stop the actor immediately.
     Stop(String),
 
+    /// Exit the actor loop with the provided stop reason.
+    ExitRequested(String),
+
     /// The direct child with the given uid was stopped.
     ChildStopped(crate::id::Uid),
 
-    /// Abort the actor. This will exit the actor loop with an error,
+    /// Kill the actor. This will exit the actor loop with an error,
     /// causing a supervision event to propagate up the supervision
     /// hierarchy.
-    Abort(String),
+    Kill(String),
 }
 wirevalue::register_type!(Signal);
 
@@ -473,8 +516,9 @@ impl fmt::Display for Signal {
         match self {
             Signal::DrainAndStop(reason) => write!(f, "DrainAndStop({})", reason),
             Signal::Stop(reason) => write!(f, "Stop({})", reason),
+            Signal::ExitRequested(reason) => write!(f, "ExitRequested({})", reason),
             Signal::ChildStopped(uid) => write!(f, "ChildStopped({})", uid),
-            Signal::Abort(reason) => write!(f, "Abort({})", reason),
+            Signal::Kill(reason) => write!(f, "Kill({})", reason),
         }
     }
 }
@@ -615,12 +659,12 @@ impl fmt::Display for ActorStatus {
 /// actors.
 pub struct ActorHandle<A: Actor> {
     cell: InstanceCell,
-    ports: Arc<Ports<A>>,
+    ports: Arc<HandlerPorts<A>>,
 }
 
 /// A handle to a running (local) actor.
 impl<A: Actor> ActorHandle<A> {
-    pub(crate) fn new(cell: InstanceCell, ports: Arc<Ports<A>>) -> Self {
+    pub(crate) fn new(cell: InstanceCell, ports: Arc<HandlerPorts<A>>) -> Self {
         Self { cell, ports }
     }
 
@@ -639,6 +683,19 @@ impl<A: Actor> ActorHandle<A> {
     pub fn drain_and_stop(&self, reason: &str) -> Result<(), ActorError> {
         tracing::info!("ActorHandle::drain_and_stop called: {}", self.actor_id());
         self.cell.signal(Signal::DrainAndStop(reason.to_string()))
+    }
+
+    /// Signal the actor to stop without draining ordinary queued
+    /// work first.
+    pub fn stop(&self, reason: &str) -> Result<(), ActorError> {
+        tracing::info!("ActorHandle::stop called: {}", self.actor_id());
+        self.cell.signal(Signal::Stop(reason.to_string()))
+    }
+
+    /// Signal the actor to terminate immediately.
+    pub fn kill(&self, reason: &str) -> Result<(), ActorError> {
+        tracing::info!("ActorHandle::kill called: {}", self.actor_id());
+        self.cell.signal(Signal::Kill(reason.to_string()))
     }
 
     /// A watch that observes the lifecycle state of the actor.
@@ -730,7 +787,7 @@ pub trait Referable: Named {}
 /// reference type.
 pub trait Binds<A: Actor>: Referable {
     /// Bind ports in this actor.
-    fn bind(ports: &Ports<A>);
+    fn bind(ports: &HandlerPorts<A>);
 }
 
 /// Handles is a marker trait specifying that message type [`M`]
@@ -1194,11 +1251,14 @@ mod tests {
 
         // Create a non-actor port using open_enqueue_port
         let non_actor_tx_clone = non_actor_tx.clone();
-        let non_actor_port_handle = client.mailbox().open_enqueue_port(move |headers, _m: ()| {
-            let seq_info = headers.get(SEQ_INFO);
-            non_actor_tx_clone.send(seq_info).unwrap();
-            Ok(())
-        });
+        let non_actor_port_handle =
+            client
+                .mailbox()
+                .open_enqueue_port(move |headers: Flattrs, _m: ()| {
+                    let seq_info = headers.get(SEQ_INFO);
+                    non_actor_tx_clone.send(seq_info).unwrap();
+                    Ok(())
+                });
 
         // Bind the port to get a port ID
         non_actor_port_handle.bind();

--- a/hyperactor/src/mailbox.rs
+++ b/hyperactor/src/mailbox.rs
@@ -116,6 +116,7 @@ use std::sync::LazyLock;
 use std::sync::Mutex;
 use std::sync::RwLock;
 use std::sync::Weak;
+use std::sync::atomic::AtomicBool;
 use std::sync::atomic::AtomicU64;
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
@@ -1494,6 +1495,28 @@ impl Mailbox {
         }
     }
 
+    /// Open a runtime-dispatched handler port that accepts M-typed
+    /// messages using the provided enqueue function.
+    pub(crate) fn open_handler_enqueue_port<M: Message>(
+        &self,
+        enqueue: impl Fn(Flattrs, M) -> Result<(), anyhow::Error> + Send + Sync + 'static,
+    ) -> (PortHandle<M>, Arc<dyn HandlerPortControl>) {
+        let port_index = self.inner.allocate_port();
+        let enqueue = Arc::new(enqueue);
+        let sender = Arc::new(HandlerPortSender::new(UnboundedPortSender::Func(enqueue)));
+        (
+            PortHandle {
+                mailbox: self.clone(),
+                port_index,
+                sender: UnboundedPortSender::Handler(sender.clone()),
+                bound: Arc::new(RwLock::new(None)),
+                reducer_spec: None,
+                streaming_opts: StreamingReducerOpts::default(),
+            },
+            sender,
+        )
+    }
+
     /// Open a new one-shot port that accepts M-typed messages. The
     /// returned port may be used to send a single message; ditto the
     /// receiver may receive a single message.
@@ -1924,7 +1947,6 @@ impl<M: Message> PortHandle<M> {
                 MailboxSenderErrorKind::Mailbox(err),
             ));
         }
-
         let mut headers = Flattrs::new();
 
         crate::mailbox::headers::set_send_timestamp(&mut headers);
@@ -1959,7 +1981,7 @@ impl<M: Message> PortHandle<M> {
         self.sender.send(headers, message).map_err(|err| {
             MailboxSenderError::new_unbound::<M>(
                 self.mailbox.actor_id().clone(),
-                MailboxSenderErrorKind::Other(err),
+                classify_sender_error(err),
             )
         })
     }
@@ -2299,12 +2321,30 @@ trait SerializedSender: Send + Sync {
     ) -> Result<SerializedSendDisposition, SerializedSendFailure>;
 }
 
+pub(crate) trait HandlerPortControl: Send + Sync {
+    fn close_for_drain(&self);
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error("handler port closed")]
+struct HandlerPortClosedError;
+
+fn classify_sender_error(err: anyhow::Error) -> MailboxSenderErrorKind {
+    if err.is::<HandlerPortClosedError>() {
+        MailboxSenderErrorKind::Closed
+    } else {
+        MailboxSenderErrorKind::Other(err)
+    }
+}
+
 /// A sender to an M-typed unbounded port.
 enum UnboundedPortSender<M: Message> {
     /// Send directly to the mpsc queue.
     Mpsc(mpsc::UnboundedSender<M>),
     /// Use the provided function to enqueue the item.
     Func(Arc<dyn Fn(Flattrs, M) -> Result<(), anyhow::Error> + Send + Sync>),
+    /// A runtime-dispatched handler port that can be closed during drain.
+    Handler(Arc<HandlerPortSender<M>>),
 }
 
 impl<M: Message> UnboundedPortSender<M> {
@@ -2312,6 +2352,7 @@ impl<M: Message> UnboundedPortSender<M> {
         match self {
             Self::Mpsc(sender) => sender.send(message).map_err(anyhow::Error::from),
             Self::Func(func) => func(headers, message),
+            Self::Handler(sender) => sender.send(headers, message),
         }
     }
 }
@@ -2323,6 +2364,7 @@ impl<M: Message> Clone for UnboundedPortSender<M> {
         match self {
             Self::Mpsc(sender) => Self::Mpsc(sender.clone()),
             Self::Func(func) => Self::Func(func.clone()),
+            Self::Handler(sender) => Self::Handler(sender.clone()),
         }
     }
 }
@@ -2335,7 +2377,38 @@ impl<M: Message> Debug for UnboundedPortSender<M> {
                 .debug_tuple("UnboundedPortSender::Func")
                 .field(&"..")
                 .finish(),
+            Self::Handler(_) => f
+                .debug_tuple("UnboundedPortSender::Handler")
+                .field(&"..")
+                .finish(),
         }
+    }
+}
+
+struct HandlerPortSender<M: Message> {
+    sender: UnboundedPortSender<M>,
+    closed: AtomicBool,
+}
+
+impl<M: Message> HandlerPortSender<M> {
+    fn new(sender: UnboundedPortSender<M>) -> Self {
+        Self {
+            sender,
+            closed: AtomicBool::new(false),
+        }
+    }
+
+    fn send(&self, headers: Flattrs, message: M) -> Result<(), anyhow::Error> {
+        if self.closed.load(Ordering::SeqCst) {
+            return Err(HandlerPortClosedError.into());
+        }
+        self.sender.send(headers, message)
+    }
+}
+
+impl<M: Message> HandlerPortControl for HandlerPortSender<M> {
+    fn close_for_drain(&self) {
+        self.closed.store(true, Ordering::SeqCst);
     }
 }
 
@@ -2354,7 +2427,7 @@ impl<M: Message> UnboundedSender<M> {
     #[allow(dead_code)]
     fn send(&self, headers: Flattrs, message: M) -> Result<(), MailboxSenderError> {
         self.sender.send(headers, message).map_err(|err| {
-            MailboxSenderError::new_bound(self.port_id.clone(), MailboxSenderErrorKind::Other(err))
+            MailboxSenderError::new_bound(self.port_id.clone(), classify_sender_error(err))
         })
     }
 }
@@ -2387,33 +2460,23 @@ impl<M: RemoteMessage> SerializedSender for UnboundedSender<M> {
         // to provide type indexing, specifically in `IndexedErasedUnbound` which is used to
         // support port aggregation.
         match serialized.deserialized_unchecked() {
-            Ok(message) => {
-                match &self.sender {
-                    UnboundedPortSender::Mpsc(sender) => {
-                        sender
-                            .send(message)
-                            .map_err(anyhow::Error::from)
-                            .map_err(|_| SerializedSendFailure::Dead {
-                                data: serialized,
-                                headers,
-                            })?;
-                    }
-                    UnboundedPortSender::Func(func) => {
-                        func(headers.clone(), message).map_err(|err| {
-                            SerializedSendFailure::Error(SerializedSendError {
-                                data: serialized,
-                                error: MailboxSenderError::new_bound(
-                                    self.port_id.clone(),
-                                    MailboxSenderErrorKind::Other(err),
-                                ),
-                                headers,
-                            })
-                        })?;
-                    }
+            Ok(message) => match self.sender.send(headers.clone(), message) {
+                Ok(()) => Ok(SerializedSendDisposition::Delivered),
+                Err(_) if matches!(&self.sender, UnboundedPortSender::Mpsc(_)) => {
+                    Err(SerializedSendFailure::Dead {
+                        data: serialized,
+                        headers,
+                    })
                 }
-
-                Ok(SerializedSendDisposition::Delivered)
-            }
+                Err(err) => Err(SerializedSendFailure::Error(SerializedSendError {
+                    data: serialized,
+                    error: MailboxSenderError::new_bound(
+                        self.port_id.clone(),
+                        classify_sender_error(err),
+                    ),
+                    headers,
+                })),
+            },
             Err(err) => Err(SerializedSendFailure::Error(SerializedSendError {
                 data: serialized,
                 error: MailboxSenderError::new_bound(
@@ -3300,7 +3363,7 @@ mod tests {
         let mbox = Mailbox::new_detached(test_actor_id("0", "test"));
         let port_index = mbox.allocate_port();
         let port_id = mbox.actor_id().port_ref(Port::from(port_index));
-        let port = crate::PortRef::attest(port_id.clone().into());
+        let port = crate::PortRef::attest(port_id.clone());
         let (return_handle, mut return_receiver) =
             crate::mailbox::undeliverable::new_undeliverable_port();
         let (sender, receiver) = mpsc::unbounded_channel::<u64>();

--- a/hyperactor/src/proc.rs
+++ b/hyperactor/src/proc.rs
@@ -51,7 +51,7 @@
 //! - **PD-5a:** Per-actor queue depth counts work items enqueued for
 //!   handler execution but not yet received from `work_rx`.
 //! - **PD-5b:** Queue depth is incremented exactly once on every
-//!   enqueue into the actor work queue (in `Ports::get`).
+//!   enqueue into the actor work queue (in `HandlerPorts::get`).
 //! - **PD-5c:** Queue depth is decremented exactly once on every
 //!   dequeue from `work_rx` (in the actor `run` loop).
 //! - **PD-5d:** Queue depth is intended to be non-negative; tests
@@ -152,6 +152,7 @@ use crate::actor::HandlerInfo;
 use crate::actor::Referable;
 use crate::actor::RemoteHandles;
 use crate::actor::Signal;
+use crate::actor::StopMode;
 use crate::actor_local::ActorLocalStorage;
 use crate::channel;
 use crate::channel::ChannelAddr;
@@ -165,6 +166,7 @@ use crate::introspect::IntrospectResult;
 use crate::mailbox::BoxedMailboxSender;
 use crate::mailbox::DeliveryError;
 use crate::mailbox::DialMailboxRouter;
+use crate::mailbox::HandlerPortControl;
 use crate::mailbox::IntoBoxedMailboxSender as _;
 use crate::mailbox::Mailbox;
 use crate::mailbox::MailboxClient;
@@ -434,7 +436,7 @@ struct ProcState {
     /// Proc-level queue-pressure accounting (PD-6 through PD-9).
     /// Runtime-driven — updated from `account_enqueue` /
     /// `account_dequeue`, not from publish-time sampling.
-    /// `Arc`-wrapped so `Ports<A>` enqueue closures can share it.
+    /// `Arc`-wrapped so `HandlerPorts<A>` enqueue closures can share it.
     queue_stats: Arc<ProcQueueStats>,
 
     /// Snapshots of terminated actors for post-mortem introspection.
@@ -1497,7 +1499,7 @@ struct InstanceState<A: Actor> {
     /// The mailbox associated with the actor.
     mailbox: Mailbox,
 
-    ports: Arc<Ports<A>>,
+    ports: Arc<HandlerPorts<A>>,
 
     /// A watch for communicating the actor's state.
     status_tx: watch::Sender<ActorStatus>,
@@ -1571,7 +1573,7 @@ impl<A: Actor> Instance<A> {
         );
         let queue_depth = Arc::new(AtomicU64::new(0));
         let proc_stats = Arc::clone(&proc.state().queue_stats);
-        let ports: Arc<Ports<A>> = Arc::new(Ports::new(
+        let ports: Arc<HandlerPorts<A>> = Arc::new(HandlerPorts::new(
             mailbox.clone(),
             work_tx,
             Arc::clone(&queue_depth),
@@ -1587,8 +1589,10 @@ impl<A: Actor> Instance<A> {
         let actor_loop_ports = if detached {
             None
         } else {
-            let (signal_port, signal_receiver) = ports.open_message_port().unwrap();
-            let (supervision_port, supervision_receiver) = mailbox.open_port();
+            let (signal_port, signal_receiver) = mailbox.open_port::<Signal>();
+            signal_port.bind_actor_port();
+            let (supervision_port, supervision_receiver) =
+                mailbox.open_port::<ActorSupervisionEvent>();
             Some((
                 (signal_port, supervision_port),
                 (signal_receiver, supervision_receiver),
@@ -1598,14 +1602,12 @@ impl<A: Actor> Instance<A> {
         let (actor_loop, actor_loop_receivers) = actor_loop_ports.unzip();
 
         // Introspect port: a separate channel handled by a dedicated
-        // tokio task (not the actor's message loop). Pre-registered
-        // so Ports::get finds the Occupied entry and skips WorkCell
-        // creation. bind_actor_port() registers in the mailbox
+        // tokio task (not the actor's message loop). bind_actor_port()
+        // registers in the mailbox
         // dispatch table at IntrospectMessage::port().
         //
         // Exercises S3, S4, S9 (see introspect module doc).
-        let (introspect_port, introspect_receiver) =
-            ports.open_message_port::<IntrospectMessage>().unwrap();
+        let (introspect_port, introspect_receiver) = mailbox.open_port::<IntrospectMessage>();
         introspect_port.bind_actor_port();
 
         let cell = InstanceCell::new(
@@ -1823,19 +1825,69 @@ impl<A: Actor> Instance<A> {
             reason,
             "Instance::stop called",
         );
+        self.inner.cell.signal(Signal::Stop(reason.to_string()))
+    }
+
+    /// Signal the actor to drain current ordinary work and then stop.
+    pub fn drain_and_stop(&self, reason: &str) -> Result<(), ActorError> {
+        tracing::info!(
+            actor_id = %self.inner.cell.actor_id(),
+            reason,
+            "Instance::drain_and_stop called",
+        );
         self.inner
             .cell
             .signal(Signal::DrainAndStop(reason.to_string()))
     }
 
-    /// Signal the actor to abort with a provided reason.
+    /// Signal the actor to terminate immediately with a provided reason.
+    pub fn kill(&self, reason: &str) -> Result<(), ActorError> {
+        tracing::info!(
+            actor_id = %self.inner.cell.actor_id(),
+            reason,
+            "Instance::kill called",
+        );
+        self.inner.cell.signal(Signal::Kill(reason.to_string()))
+    }
+
+    /// Backward-compatible alias for `kill()`.
     pub fn abort(&self, reason: &str) -> Result<(), ActorError> {
         tracing::info!(
             actor_id = %self.inner.cell.actor_id(),
             reason,
             "Instance::abort called",
         );
-        self.inner.cell.signal(Signal::Abort(reason.to_string()))
+        self.kill(reason)
+    }
+
+    /// Close handler ingress for this actor.
+    pub fn close(&self) {
+        self.inner.ports.close_handler_ports_for_drain();
+    }
+
+    /// Request immediate actor exit with the provided stop reason.
+    pub fn exit(&self, reason: &str) -> Result<(), ActorError> {
+        self.inner
+            .cell
+            .signal(Signal::ExitRequested(reason.to_string()))
+    }
+
+    /// Queue an internal exit request after already accepted handler work.
+    ///
+    /// This is intentionally a small runtime special case for now.
+    /// The long-term goal is to make "exit after drain" fall out of
+    /// ordinary self-messaging semantics rather than requiring a
+    /// dedicated internal path here.
+    pub fn exit_after_drain(&self, reason: &str) -> Result<(), ActorError> {
+        let this = self.clone_for_py();
+        let reason = reason.to_string();
+        let work = WorkCell::new(move |_actor: &mut A, _instance: &Instance<A>| {
+            Box::pin(async move {
+                this.exit(&reason).map_err(anyhow::Error::from)?;
+                Ok(())
+            })
+        });
+        self.enqueue_runtime_work(work)
     }
 
     /// Open a new port that accepts M-typed messages. The returned
@@ -1851,6 +1903,12 @@ impl<A: Actor> Instance<A> {
     /// receiver may receive a single message.
     pub fn open_once_port<M: Message>(&self) -> (OncePortHandle<M>, OncePortReceiver<M>) {
         self.inner.mailbox.open_once_port()
+    }
+
+    /// Return this actor's runtime signal port.
+    #[doc(hidden)]
+    pub fn signal_port(&self) -> PortHandle<Signal> {
+        self.inner.cell.signal_port()
     }
 
     /// Get the per-instance local storage.
@@ -1891,6 +1949,29 @@ impl<A: Actor> Instance<A> {
             true,
             context::SeqInfoPolicy::AllowExternal,
         )
+    }
+
+    fn enqueue_runtime_work(&self, work: WorkCell<A>) -> Result<(), ActorError> {
+        let actor_id_str = self.self_id().to_string();
+        account_enqueue(
+            &self.inner.cell.inner.queue_depth,
+            &self.inner.proc.state().queue_stats,
+            &actor_id_str,
+        );
+        let result = self
+            .inner
+            .ports
+            .workq
+            .direct_send(work)
+            .map_err(anyhow::Error::from);
+        if result.is_err() {
+            account_cancel_enqueue(
+                &self.inner.cell.inner.queue_depth,
+                &self.inner.proc.state().queue_stats,
+                &actor_id_str,
+            );
+        }
+        result.map_err(|err| ActorError::new(self.self_id(), ActorErrorKind::processing(err)))
     }
 
     /// Return a static client instance that can be used to send
@@ -2183,13 +2264,43 @@ impl<A: Actor> Instance<A> {
             .init(self)
             .await
             .map_err(|err| ActorError::new(self.self_id(), ActorErrorKind::init(err)))?;
-        let need_drain;
-        let stop_reason;
         let actor_id_str = self.self_id().to_string();
-        'messages: loop {
-            self.change_status(ActorStatus::Idle);
+        let stop_reason = 'messages: loop {
+            if !self.is_stopping() {
+                self.change_status(ActorStatus::Idle);
+            }
             let metric_pairs = hyperactor_telemetry::kv_pairs!("actor_id" => actor_id_str.clone());
             tokio::select! {
+                biased;
+                signal = signal_receiver.recv() => {
+                    let signal = signal.map_err(ActorError::from);
+                    tracing::debug!("Received signal {signal:?}");
+                    match signal? {
+                        Signal::Stop(reason) => {
+                            self.change_status(ActorStatus::Stopping);
+                            actor
+                                .handle_stop(self, StopMode::Stop, &reason)
+                                .await
+                                .map_err(|err| ActorError::new(self.self_id(), ActorErrorKind::processing(err)))?;
+                        },
+                        Signal::DrainAndStop(reason) => {
+                            self.change_status(ActorStatus::Stopping);
+                            actor
+                                .handle_stop(self, StopMode::DrainAndStop, &reason)
+                                .await
+                                .map_err(|err| ActorError::new(self.self_id(), ActorErrorKind::processing(err)))?;
+                        },
+                        Signal::ChildStopped(uid) => {
+                            assert!(self.inner.cell.get_child(&uid).is_none());
+                        },
+                        Signal::ExitRequested(reason) => {
+                            break 'messages reason;
+                        }
+                        Signal::Kill(reason) => {
+                            return Err(ActorError { actor_id: Box::new(self.self_id().clone()), kind: Box::new(ActorErrorKind::Aborted(reason)) });
+                        }
+                    }
+                }
                 work = work_rx.recv() => {
                     ACTOR_MESSAGES_RECEIVED.add(1, metric_pairs);
                     account_dequeue(&self.inner.cell.inner.queue_depth, &self.inner.proc.state().queue_stats, &actor_id_str);
@@ -2206,28 +2317,6 @@ impl<A: Actor> Instance<A> {
                         });
                     }
                 }
-                signal = signal_receiver.recv() => {
-                    let signal = signal.map_err(ActorError::from);
-                    tracing::debug!("Received signal {signal:?}");
-                    match signal? {
-                        Signal::Stop(reason) => {
-                            need_drain = false;
-                            stop_reason = reason;
-                            break 'messages;
-                        },
-                        Signal::DrainAndStop(reason) => {
-                            need_drain = true;
-                            stop_reason = reason;
-                            break 'messages;
-                        },
-                        Signal::ChildStopped(uid) => {
-                            assert!(self.inner.cell.get_child(&uid).is_none());
-                        },
-                        Signal::Abort(reason) => {
-                            return Err(ActorError { actor_id: Box::new(self.self_id().clone()), kind: Box::new(ActorErrorKind::Aborted(reason)) });
-                        }
-                    }
-                }
                 Ok(supervision_event) = supervision_event_receiver.recv() => {
                     self.handle_supervision_event(actor, supervision_event).await?;
                 }
@@ -2237,48 +2326,7 @@ impl<A: Actor> Instance<A> {
                 .inner
                 .num_processed_messages
                 .fetch_add(1, Ordering::SeqCst);
-        }
-
-        if need_drain {
-            let mut supervision_events_drained = 0;
-            for supervision_event in supervision_event_receiver.drain() {
-                self.handle_supervision_event(actor, supervision_event)
-                    .await?;
-                supervision_events_drained += 1;
-            }
-
-            let mut n = 0;
-            while let Ok(work) = work_rx.try_recv() {
-                // PD-5c: drained work items must also be accounted.
-                account_dequeue(
-                    &self.inner.cell.inner.queue_depth,
-                    &self.inner.proc.state().queue_stats,
-                    &actor_id_str,
-                );
-                if let Err(err) = work.handle(actor, self).await {
-                    return Err(ActorError::new(
-                        self.self_id(),
-                        ActorErrorKind::processing(err),
-                    ));
-                }
-                for supervision_event in supervision_event_receiver.drain() {
-                    self.handle_supervision_event(actor, supervision_event)
-                        .await?;
-                    supervision_events_drained += 1;
-                }
-                n += 1;
-            }
-            for supervision_event in supervision_event_receiver.drain() {
-                self.handle_supervision_event(actor, supervision_event)
-                    .await?;
-                supervision_events_drained += 1;
-            }
-            tracing::debug!(
-                "drained {} messages and {} supervision events",
-                n,
-                supervision_events_drained
-            );
-        }
+        };
         tracing::debug!(
             actor_id = %self.self_id(),
             reason = stop_reason,
@@ -2664,7 +2712,7 @@ struct InstanceCellState {
     /// Both are updated together by `account_enqueue` /
     /// `account_dequeue`.
     ///
-    /// Shared with `Ports<A>`: incremented at enqueue in the send
+    /// Shared with `HandlerPorts<A>`: incremented at enqueue in the send
     /// path, decremented when the actor loop receives from `work_rx`.
     queue_depth: Arc<AtomicU64>,
 
@@ -2700,8 +2748,8 @@ struct InstanceCellState {
     /// `Instance::set_system()`.
     is_system: AtomicBool,
 
-    /// A type-erased reference to Ports<A>, which allows us to recover
-    /// an ActorHandle<A> by downcasting.
+    /// A type-erased reference to HandlerPorts<A>, which allows us to
+    /// recover an ActorHandle<A> by downcasting.
     ports: Arc<dyn Any + Send + Sync>,
 }
 
@@ -2843,6 +2891,14 @@ impl InstanceCell {
     /// `None` for actors that stopped cleanly or are still running.
     pub fn supervision_event(&self) -> Option<crate::supervision::ActorSupervisionEvent> {
         self.inner.supervision_event.lock().unwrap().clone()
+    }
+
+    fn signal_port(&self) -> PortHandle<Signal> {
+        self.inner
+            .actor_loop
+            .as_ref()
+            .map(|(signal_port, _)| signal_port.clone())
+            .unwrap_or_else(|| panic!("{} has no runtime signal port", self.actor_id()))
     }
 
     /// Send a signal to the actor.
@@ -3117,20 +3173,16 @@ impl InstanceCell {
 
     /// This is temporary so that we can share binding code between handle and instance.
     /// We should find some (better) way to consolidate the two.
-    pub(crate) fn bind<A: Actor, R: Binds<A>>(&self, ports: &Ports<A>) -> ActorRef<R> {
+    pub(crate) fn bind<A: Actor, R: Binds<A>>(&self, ports: &HandlerPorts<A>) -> ActorRef<R> {
         <R as Binds<A>>::bind(ports);
-        // Signal: pre-registered via open_message_port() in
-        // Instance::new(), handled by the actor loop's select!.
-        // Ports::bind() here reuses the existing handle.
+        // Signal: registered directly in Instance::new() and handled
+        // by the actor loop's select!.
         //
         // Undeliverable: dispatched through the work queue to the
         // actor's Handler<Undeliverable<MessageEnvelope>>.
         //
-        // IntrospectMessage: pre-registered via open_message_port()
-        // in Instance::new(), handled by a dedicated introspect task.
-        // NOT bound here — its port is registered via
-        // bind_actor_port() directly.
-        ports.bind::<Signal>();
+        // IntrospectMessage: registered directly in Instance::new()
+        // and handled by a dedicated introspect task.
         ports.bind::<Undeliverable<MessageEnvelope>>();
         // TODO: consider sharing `ports.bound` directly.
         for entry in ports.bound.iter() {
@@ -3143,7 +3195,9 @@ impl InstanceCell {
 
     /// Attempt to downcast this cell to a concrete actor handle.
     pub(crate) fn downcast_handle<A: Actor>(&self) -> Option<ActorHandle<A>> {
-        let ports = Arc::clone(&self.inner.ports).downcast::<Ports<A>>().ok()?;
+        let ports = Arc::clone(&self.inner.ports)
+            .downcast::<HandlerPorts<A>>()
+            .ok()?;
         Some(ActorHandle::new(self.clone(), ports))
     }
 
@@ -3211,12 +3265,14 @@ impl WeakInstanceCell {
     }
 }
 
-/// A polymorphic dictionary that stores ports for an actor's handlers.
+/// A polymorphic dictionary that stores runtime-dispatched handler ports.
 /// The interface memoizes the ports so that they are reused. We do not
 /// (yet) support stable identifiers across multiple instances of the same
 /// actor.
-pub struct Ports<A: Actor> {
+pub struct HandlerPorts<A: Actor> {
     ports: DashMap<TypeId, Box<dyn Any + Send + Sync + 'static>>,
+    controls: DashMap<TypeId, Arc<dyn HandlerPortControl>>,
+    closed_for_drain: AtomicBool,
     bound: DashMap<u64, &'static str>,
     mailbox: Mailbox,
     workq: OrderedSender<WorkCell<A>>,
@@ -3226,7 +3282,7 @@ pub struct Ports<A: Actor> {
     proc_stats: Arc<ProcQueueStats>,
 }
 
-impl<A: Actor> Ports<A> {
+impl<A: Actor> HandlerPorts<A> {
     fn new(
         mailbox: Mailbox,
         workq: OrderedSender<WorkCell<A>>,
@@ -3235,6 +3291,8 @@ impl<A: Actor> Ports<A> {
     ) -> Self {
         Self {
             ports: DashMap::new(),
+            controls: DashMap::new(),
+            closed_for_drain: AtomicBool::new(false),
             bound: DashMap::new(),
             mailbox,
             workq,
@@ -3251,16 +3309,17 @@ impl<A: Actor> Ports<A> {
         let key = TypeId::of::<M>();
         match self.ports.entry(key) {
             Entry::Vacant(entry) => {
-                // Some special case hackery, but it keeps the rest of the code (relatively) simple.
+                // Runtime control-plane ports are provisioned directly,
+                // not through HandlerPorts.
                 assert_ne!(
                     key,
                     TypeId::of::<Signal>(),
-                    "cannot provision Signal port through `Ports::get`"
+                    "cannot provision Signal port through `HandlerPorts::get`"
                 );
                 assert_ne!(
                     key,
                     TypeId::of::<IntrospectMessage>(),
-                    "cannot provision IntrospectMessage port through `Ports::get`"
+                    "cannot provision IntrospectMessage port through `HandlerPorts::get`"
                 );
 
                 let type_info = TypeInfo::get_by_typeid(key);
@@ -3268,7 +3327,7 @@ impl<A: Actor> Ports<A> {
                 let actor_id = self.mailbox.actor_id().to_string();
                 let enqueue_depth = Arc::clone(&self.queue_depth);
                 let enqueue_proc_stats = Arc::clone(&self.proc_stats);
-                let port = self.mailbox.open_enqueue_port(move |headers, msg: M| {
+                let enqueue = move |headers: Flattrs, msg: M| {
                     let seq_info = headers.get(SEQ_INFO);
 
                     let work = WorkCell::new(move |actor: &mut A, instance: &Instance<A>| {
@@ -3296,7 +3355,7 @@ impl<A: Actor> Ports<A> {
                                 workq.send(session_id, seq, work).map_err(|e| match e {
                                     OrderedSenderError::InvalidZeroSeq(_) => {
                                         let error_msg = format!(
-                                             "in enqueue func for {}, got seq 0 for message type {}",
+                                            "in enqueue func for {}, got seq 0 for message type {}",
                                             actor_id,
                                             std::any::type_name::<M>(),
                                         );
@@ -3315,7 +3374,7 @@ impl<A: Actor> Ports<A> {
                                     "in enqueue func for {}, buffering is enabled, but SEQ_INFO is not set for message type {}",
                                     actor_id,
                                     std::any::type_name::<M>(),
-                                    );
+                                );
                                 tracing::error!(error_msg);
                                 Err(anyhow::anyhow!(error_msg))
                             }
@@ -3327,8 +3386,13 @@ impl<A: Actor> Ports<A> {
                         account_cancel_enqueue(&enqueue_depth, &enqueue_proc_stats, &actor_id);
                     }
                     result
-                });
+                };
+                let (port, control) = self.mailbox.open_handler_enqueue_port(enqueue);
+                if self.closed_for_drain.load(Ordering::Relaxed) {
+                    control.close_for_drain();
+                }
                 entry.insert(Box::new(port.clone()));
+                self.controls.insert(key, control);
                 port
             }
             Entry::Occupied(entry) => {
@@ -3338,16 +3402,10 @@ impl<A: Actor> Ports<A> {
         }
     }
 
-    /// Open a (typed) message port as in [`get`], but return a port receiver instead of dispatching
-    /// the underlying handler.
-    pub(crate) fn open_message_port<M: Message>(&self) -> Option<(PortHandle<M>, PortReceiver<M>)> {
-        match self.ports.entry(TypeId::of::<M>()) {
-            Entry::Vacant(entry) => {
-                let (port, receiver) = self.mailbox.open_port();
-                entry.insert(Box::new(port.clone()));
-                Some((port, receiver))
-            }
-            Entry::Occupied(_) => None,
+    pub(crate) fn close_handler_ports_for_drain(&self) {
+        self.closed_for_drain.store(true, Ordering::Relaxed);
+        for entry in self.controls.iter() {
+            entry.value().close_for_drain();
         }
     }
 
@@ -3807,6 +3865,98 @@ mod tests {
             assert!(actor.send(&client, TestActorMessage::Noop()).is_err());
             assert_matches!(actor.await, ActorStatus::Stopped(reason) if reason == "parent stopping");
         }
+    }
+
+    #[derive(Debug)]
+    struct DeferredStopActor {
+        stop_started: Arc<tokio::sync::Notify>,
+        release_stop: Arc<tokio::sync::Notify>,
+    }
+
+    #[async_trait]
+    impl Actor for DeferredStopActor {
+        async fn handle_stop(
+            &mut self,
+            this: &Instance<Self>,
+            mode: StopMode,
+            reason: &str,
+        ) -> Result<(), anyhow::Error> {
+            let this = this.clone_for_py();
+            let release_stop = Arc::clone(&self.release_stop);
+            let reason = reason.to_string();
+            this.close();
+            self.stop_started.notify_one();
+            tokio::spawn(async move {
+                release_stop.notified().await;
+                match mode {
+                    StopMode::Stop => this.exit(&reason).unwrap(),
+                    StopMode::DrainAndStop => this.exit_after_drain(&reason).unwrap(),
+                }
+            });
+            Ok(())
+        }
+    }
+
+    #[async_trait]
+    impl Handler<()> for DeferredStopActor {
+        async fn handle(&mut self, _cx: &crate::Context<Self>, _message: ()) -> anyhow::Result<()> {
+            Ok(())
+        }
+    }
+
+    #[async_timed_test(timeout_secs = 30)]
+    async fn test_handle_stop_can_defer_exit() {
+        let proc = Proc::local();
+        let stop_started = Arc::new(tokio::sync::Notify::new());
+        let release_stop = Arc::new(tokio::sync::Notify::new());
+        let handle = proc
+            .spawn(
+                "deferred_stop",
+                DeferredStopActor {
+                    stop_started: Arc::clone(&stop_started),
+                    release_stop: Arc::clone(&release_stop),
+                },
+            )
+            .unwrap();
+
+        let mut status = handle.status();
+        handle.stop("test").unwrap();
+        stop_started.notified().await;
+        status
+            .wait_for(|state| matches!(state, ActorStatus::Stopping))
+            .await
+            .unwrap();
+
+        release_stop.notify_one();
+        assert_matches!(handle.await, ActorStatus::Stopped(reason) if reason == "test");
+    }
+
+    #[async_timed_test(timeout_secs = 30)]
+    async fn test_drain_and_stop_closes_handler_ingress() {
+        let proc = Proc::local();
+        let (client, _) = proc.instance("client").unwrap();
+        let stop_started = Arc::new(tokio::sync::Notify::new());
+        let release_stop = Arc::new(tokio::sync::Notify::new());
+        let handle = proc
+            .spawn(
+                "deferred_drain_stop",
+                DeferredStopActor {
+                    stop_started: Arc::clone(&stop_started),
+                    release_stop: Arc::clone(&release_stop),
+                },
+            )
+            .unwrap();
+
+        handle.drain_and_stop("test").unwrap();
+        stop_started.notified().await;
+
+        // Drain closes runtime-dispatched handler ingress, so new
+        // sends to the actor's handler port are rejected.
+        let err = handle.send(&client, ()).unwrap_err();
+        assert_matches!(err.kind(), crate::mailbox::MailboxSenderErrorKind::Closed);
+
+        release_stop.notify_one();
+        assert_matches!(handle.await, ActorStatus::Stopped(reason) if reason == "test");
     }
 
     #[async_timed_test(timeout_secs = 30)]

--- a/hyperactor_macros/src/lib.rs
+++ b/hyperactor_macros/src/lib.rs
@@ -1511,7 +1511,7 @@ pub fn export(attr: TokenStream, item: TokenStream) -> TokenStream {
         impl #named_impl_generics hyperactor::remote::Accepts<hyperactor::introspect::IntrospectMessage> for #data_type_name #named_ty_generics #named_where_clause {}
 
         impl #bind_impl_generics hyperactor::actor::Binds<#data_type_name #bind_ty_generics> for #data_type_name #bind_ty_generics #bind_where_clause {
-            fn bind(ports: &hyperactor::proc::Ports<Self>) {
+            fn bind(ports: &hyperactor::proc::HandlerPorts<Self>) {
                 #(#bindings)*
             }
         }
@@ -1709,7 +1709,7 @@ pub fn behavior(input: TokenStream) -> TokenStream {
             A: hyperactor::Actor #(+ hyperactor::Handler<#tys>)*,
             #where_clause
         {
-            fn bind(ports: &hyperactor::proc::Ports<A>) {
+            fn bind(ports: &hyperactor::proc::HandlerPorts<A>) {
                 #(
                     ports.bind::<#tys>();
                 )*

--- a/monarch_hyperactor/src/actor.rs
+++ b/monarch_hyperactor/src/actor.rs
@@ -710,8 +710,7 @@ impl PythonActor {
         // (matching GlobalClientActor::fresh_instance).
         instance.set_system();
 
-        // Bind to ensure the Signal and Undeliverable<MessageEnvelope> ports
-        // are bound.
+        // Bind to ensure the Undeliverable<MessageEnvelope> port is bound.
         let _client_ref = handle.bind::<PythonActor>();
 
         get_tokio_runtime().spawn(async move {
@@ -780,8 +779,9 @@ impl PythonActor {
                                 need_drain = matches!(signal, Signal::DrainAndStop(_));
                                 break None;
                             },
+                            Ok(Signal::ExitRequested(_)) => {}
                             Ok(Signal::ChildStopped(_)) => {},
-                            Ok(Signal::Abort(reason)) => {
+                            Ok(Signal::Kill(reason)) => {
                                 break Some(ActorError { actor_id: Box::new(instance.self_id().clone()), kind: Box::new(ActorErrorKind::Aborted(reason)) })
                             },
                             Err(err) => break Some(err),
@@ -897,7 +897,7 @@ impl Actor for PythonActor {
             // Create an error port that converts PythonMessage to an abort signal.
             // This allows Python to send errors that trigger actor supervision.
             let error_port: hyperactor::PortHandle<PythonMessage> =
-                this.port::<Signal>().contramap(|msg: PythonMessage| {
+                this.signal_port().contramap(|msg: PythonMessage| {
                     monarch_with_gil_blocking(|py| {
                         let err = match msg.kind {
                             PythonMessageKind::Exception { .. } => {
@@ -917,7 +917,7 @@ impl Actor for PythonActor {
                                 SerializablePyErr::from(py, &py_err)
                             }
                         };
-                        Signal::Abort(err.to_string())
+                        Signal::Kill(err.to_string())
                     })
                 });
 
@@ -1584,7 +1584,7 @@ async fn handle_async_endpoint_panic(
             })
             .0;
         panic_sender
-            .send(&client, Signal::Abort(panic.to_string()))
+            .send(&client, Signal::Kill(panic.to_string()))
             .expect("Unable to send panic message");
     }
 
@@ -1795,7 +1795,7 @@ mod tests {
             builder_params: Some(wirevalue::Any::serialize(&"abcdefg12345".to_string()).unwrap()),
         };
         let port_ref = hyperactor::PortRef::<PythonMessage>::attest_reducible(
-            test_port_id("world_0", "client", 123).into(),
+            test_port_id("world_0", "client", 123),
             Some(reducer_spec),
             StreamingReducerOpts::default(),
         );


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)

Add the first lifecycle/shutdown refactor in `hyperactor` to support more flexible actor participation in stopping. The immediate goal is to let actors coordinate asynchronous shutdown work, which we need for features such as remote supervision. This change introduces `StopMode` and `Actor::handle_stop`, adds `Instance::{stop,drain_and_stop,kill,exit}`, lets deferred stop handlers wake the runtime back up to exit, and closes ordinary mailbox ingress during `drain_and_stop` while leaving control-plane ports available. This is also the path toward replacing `cleanup` with the new stop-handling mechanism, though `cleanup` remains in place for now.

The overall goal of this stack is to break 'shutdown' into a simple set of operations, and then letting the actor participate in shutdown (with a default implementation that behaves like it does now). By making shutdown "not special", we'll also be able to simplify the run loop, since shutdown behavior is now policy, rather than implementation.

Differential Revision: [D103678247](https://our.internmc.facebook.com/intern/diff/D103678247/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D103678247/)!