### PR TITLE
Configure nextest to retry

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -3,6 +3,8 @@
 fail-fast = false
 # Cap parallelism to reduce contention-induced timeouts on shared CI runners.
 test-threads = 4
+# Retry failures to distinguish flaky tests from genuine breakage.
+retries = 2
 
 [profile.ci.junit]
 path = "junit.xml"


### PR DESCRIPTION
Summary: Our rust tests fail from timeouts but not deterministically and pass in isolation, so failures are mostly from contention

Differential Revision: D103682938


