### PR TITLE
Enable `enable_log_forwarding` in kubernetes_grpo example

### DIFF
--- a/docs/source/examples/grpo/kubernetes_grpo.py
+++ b/docs/source/examples/grpo/kubernetes_grpo.py
@@ -167,6 +167,7 @@ monarch.configure(
     actor_spawn_max_idle="10m",
     get_proc_state_max_idle="10m",
     supervision_watchdog_timeout="10m",
+    enable_log_forwarding=True,
 )
 
 # %%


### PR DESCRIPTION
Summary: we also need to setup the monarch configure

Reviewed By: dulinriley, shayne-fletcher

Differential Revision: D103700464


