### PR TITLE
Fix two RwLock/DashMap deadlocks in actor teardown

### DIFF
--- a/hyperactor/src/introspect.rs
+++ b/hyperactor/src/introspect.rs
@@ -878,9 +878,16 @@ pub(crate) async fn serve_introspect(
                     }
                 }
             }
-            _ = status.wait_for(ActorStatus::is_terminal) => {
-                // Snapshot for post-mortem introspection before
-                // dropping our InstanceCell reference.
+            status_ref = status.wait_for(ActorStatus::is_terminal) => {
+                // Explicitly drop the Ref before calling live_actor_payload.
+                // wait_for returns a Ref that holds a read lock on the watch
+                // channel's RwLock<ActorStatus>. tokio select! uses a match
+                // internally, so the scrutinee (and its read lock) stays alive
+                // through the arm body. live_actor_payload also calls borrow(),
+                // and parking_lot's write-preferring RwLock blocks new readers
+                // once a writer is queued — causing a deadlock if InstanceState
+                // ::drop tries to write between wait_for and live_actor_payload.
+                drop(status_ref);
                 let snapshot = live_actor_payload(&cell);
                 cell.store_terminated_snapshot(snapshot);
                 break;

--- a/hyperactor/src/proc.rs
+++ b/hyperactor/src/proc.rs
@@ -1041,26 +1041,32 @@ impl Proc {
         actor_id: &ActorAddr,
         reason: String,
     ) -> Option<watch::Receiver<ActorStatus>> {
-        if let Some(entry) = self.state().instances.get(actor_id) {
-            match entry.value().upgrade() {
-                None => None, // the actor's cell has been dropped
-                Some(cell) => {
-                    tracing::info!("sending stop signal to {}", cell.actor_id());
-                    if let Err(err) = cell.signal(Signal::DrainAndStop(reason)) {
-                        tracing::error!(
-                            "failed to send stop signal to uid {}: {:?}",
-                            cell.uid(),
-                            err
-                        );
-                        None
-                    } else {
-                        Some(cell.status().clone())
-                    }
+        // Upgrade the weak ref and immediately drop the DashMap entry (read
+        // guard) before doing anything with `cell`. InstanceCellState::drop
+        // calls instances.remove(), which needs a write lock on the same shard.
+        // Holding the read guard while cell drops would self-deadlock.
+        let cell = match self.state().instances.get(actor_id) {
+            None => {
+                tracing::error!(subject = %self.proc_id().subject(), "no actor {} found", actor_id);
+                return None;
+            }
+            Some(entry) => entry.value().upgrade(),
+        }; // entry (shard read lock) dropped here
+        match cell {
+            None => None, // the actor's cell has been dropped
+            Some(cell) => {
+                tracing::info!("sending stop signal to {}", cell.actor_id());
+                if let Err(err) = cell.signal(Signal::DrainAndStop(reason)) {
+                    tracing::error!(
+                        "failed to send stop signal to uid {}: {:?}",
+                        cell.uid(),
+                        err
+                    );
+                    None
+                } else {
+                    Some(cell.status().clone())
                 }
             }
-        } else {
-            tracing::error!(subject = %self.proc_id().subject(), "no actor {} found", actor_id);
-            None
         }
     }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #3754

Zach: I wrote a script (see commit d55efadba497663a93b9da83fa551696997749bc) which runs one of the actor tests in a loop concurrently with a bunch of other tests until one gets stuck. It found two deadlocks, which claude fixed after I gave it the stack traces. After fixing both deadlocks I ran the test 10000 times without observing a new deadlock.

Claude (summary of deadlocks):

## Deadlock 1: watch::Sender write-lock vs. serve_introspect read-lock (hyperactor/src/introspect.rs)

tokio's watch::Receiver::wait_for returns a Ref<T> that holds the internal RwLock<ActorStatus> read lock. Because tokio select! expands to a match expression, the scrutinee (which wraps the Ref) stays alive through the entire arm body — even when the pattern is `_`. Inside that arm body, live_actor_payload calls cell.status().borrow(), which tries to acquire a second read lock on the same RwLock. If InstanceState::drop fires concurrently on another tokio worker and tries to write-lock the same RwLock via watch::Sender::send_if_modified, parking_lot's write-preferring RwLock sets WRITER_BIT. This blocks the new read attempt in live_actor_payload, while the write attempt waits for the existing Ref to be released. Since the Ref is not released until the arm body finishes, and the body cannot finish because its borrow() is blocked, the process deadlocks.

Fix: bind the result to a named variable and call drop() explicitly before invoking live_actor_payload, releasing the read lock before any new lock acquisition.

## Deadlock 2: DashMap shard self-deadlock in stop_actor (hyperactor/src/proc.rs)

stop_actor called self.state().instances.get(actor_id), which acquires a DashMap shard read lock held by the returned Ref (entry). It then called entry.value().upgrade() to get an Arc<InstanceCellState>. This Arc (cell) was held inside the if-let scope, meaning entry (and its read lock) was still alive when cell was dropped at the end of the match arm. If cell was the last strong reference to the InstanceCellState, dropping it fires InstanceCellState::drop, which calls instances.remove() to write-lock the same DashMap shard. parking_lot does not support lock reentrancy, so the thread blocks trying to acquire a write lock it can never get because it already holds the read lock. The process self-deadlocks on a single tokio worker thread; all other workers park with nothing to do.

Fix: upgrade the weak reference and immediately drop entry (the shard read guard) before using cell. Restructured as an early-return match so the guard scope is minimal and explicit.

Differential Revision: [D103722199](https://our.internmc.facebook.com/intern/diff/D103722199/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D103722199/)!