### PR TITLE
Bump rust-toolchain to 1.95 (#3758)

### DIFF
--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,3 +1,3 @@
-# @rustc_version: rustc 1.94.0-nightly (fe98ddcfc 2026-01-17)
+# @rustc_version: rustc 1.95.0-nightly (3a70d0349 2026-02-27)
 [toolchain]
-channel = "nightly-2026-01-18"
+channel = "nightly-2026-02-28"


### PR DESCRIPTION
Summary:

bumping rust nightly compiler pin to 1.95

Reviewed By: zdevito

Differential Revision: D103763044


