### PR TITLE
[hyperactor] add Instance::gspawn for registered child actors

### DIFF
--- a/hyperactor/src/actor.rs
+++ b/hyperactor/src/actor.rs
@@ -299,7 +299,7 @@ where
 /// - `Binds<Self>`: lets the runtime wire this actor's handler ports
 ///   when it is spawned (the blanket impl calls `handle.bind::<Self>()`).
 ///
-/// `gspawn` is a type-erased entry point used by the remote
+/// `gspawn_root_bind` is a type-erased entry point used by the remote
 /// spawn/registry machinery. It takes serialized params and returns
 /// the new actor's `ActorAddr`; application code shouldn't call it
 /// directly.
@@ -313,11 +313,11 @@ pub trait RemoteSpawn: Actor + Referable + Binds<Self> {
     /// to pass in additional context that may be useful.
     async fn new(params: Self::Params, environment: Flattrs) -> anyhow::Result<Self>;
 
-    /// A type-erased entry point to spawn this actor. This is
+    /// A type-erased entry point to spawn this actor as a root. This is
     /// primarily used by hyperactor's remote actor registration
     /// mechanism.
     // TODO: consider making this 'private' -- by moving it into a non-public trait as in [`cap`].
-    fn gspawn(
+    fn gspawn_root_bind(
         proc: &Proc,
         uid: crate::id::Uid,
         serialized_params: Data,
@@ -342,6 +342,29 @@ pub trait RemoteSpawn: Actor + Referable + Binds<Self> {
             // This will be replaced by a proper export/registry
             // mechanism.
             Ok(handle.bind::<Self>().into_actor_id())
+        })
+    }
+
+    /// A type-erased entry point to spawn this actor as a child.
+    ///
+    /// The returned handle is lifecycle-only; callers that know the concrete
+    /// actor type can recover a typed handle with [`AnyActorHandle::downcast`].
+    fn gspawn_child(
+        proc: &Proc,
+        parent: InstanceCell,
+        uid: crate::id::Uid,
+        serialized_params: Data,
+        environment: Flattrs,
+    ) -> Pin<Box<dyn Future<Output = Result<AnyActorHandle, anyhow::Error>> + Send>> {
+        let proc = proc.clone();
+        Box::pin(async move {
+            let params =
+                bincode::serde::decode_from_slice(&serialized_params, bincode::config::legacy())
+                    .map(|(v, _)| v)?;
+            let actor = Self::new(params, environment).await?;
+            let handle = proc.spawn_child_with_uid(parent, uid, actor)?;
+            handle.bind::<Self>();
+            Ok(handle.into_any())
         })
     }
 
@@ -720,6 +743,89 @@ impl<A: Actor> ActorHandle<A> {
     /// TODO: we shoudl also have a default binding(?)
     pub fn bind<R: Binds<A>>(&self) -> ActorRef<R> {
         self.cell.bind(self.ports.as_ref())
+    }
+
+    /// Erase this handle's actor type, preserving only lifecycle access.
+    pub fn into_any(self) -> AnyActorHandle {
+        AnyActorHandle { cell: self.cell }
+    }
+}
+
+/// A type-erased handle to a running actor whose concrete type is erased.
+///
+/// This handle intentionally does not expose typed messaging or binding APIs.
+/// Use [`AnyActorHandle::downcast`] to recover a typed [`ActorHandle`] when the
+/// concrete actor type is known.
+pub struct AnyActorHandle {
+    cell: InstanceCell,
+}
+
+impl AnyActorHandle {
+    /// The [`ActorAddr`] of the actor represented by this handle.
+    pub fn actor_id(&self) -> &ActorAddr {
+        self.cell.actor_id()
+    }
+
+    /// Signal the actor to drain its current messages and then stop.
+    pub fn drain_and_stop(&self, reason: &str) -> Result<(), ActorError> {
+        self.cell.signal(Signal::DrainAndStop(reason.to_string()))
+    }
+
+    /// Signal the actor to stop without draining ordinary queued work first.
+    pub fn stop(&self, reason: &str) -> Result<(), ActorError> {
+        self.cell.signal(Signal::Stop(reason.to_string()))
+    }
+
+    /// Signal the actor to terminate immediately.
+    pub fn kill(&self, reason: &str) -> Result<(), ActorError> {
+        self.cell.signal(Signal::Kill(reason.to_string()))
+    }
+
+    /// A watch that observes the lifecycle state of the actor.
+    pub fn status(&self) -> watch::Receiver<ActorStatus> {
+        self.cell.status().clone()
+    }
+
+    /// Attempt to recover a typed actor handle.
+    pub fn downcast<A: Actor>(&self) -> Option<ActorHandle<A>> {
+        self.cell.downcast_handle()
+    }
+}
+
+/// IntoFuture allows users to await the handle to join it. The future
+/// resolves when the actor itself has stopped processing messages.
+/// The future resolves to the actor's final status.
+impl IntoFuture for AnyActorHandle {
+    type Output = ActorStatus;
+    type IntoFuture = BoxFuture<'static, Self::Output>;
+
+    fn into_future(self) -> Self::IntoFuture {
+        let future = async move {
+            let mut status_receiver = self.cell.status().clone();
+            let result = status_receiver.wait_for(ActorStatus::is_terminal).await;
+            match result {
+                Err(_) => ActorStatus::Unknown,
+                Ok(status) => status.clone(),
+            }
+        };
+
+        future.boxed()
+    }
+}
+
+impl Debug for AnyActorHandle {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+        f.debug_struct("AnyActorHandle")
+            .field("cell", &"..")
+            .finish()
+    }
+}
+
+impl Clone for AnyActorHandle {
+    fn clone(&self) -> Self {
+        Self {
+            cell: self.cell.clone(),
+        }
     }
 }
 

--- a/hyperactor/src/actor/remote.rs
+++ b/hyperactor/src/actor/remote.rs
@@ -17,8 +17,10 @@ use std::sync::LazyLock;
 use hyperactor_config::Flattrs;
 
 use crate::Actor;
+use crate::AnyActorHandle;
 use crate::Data;
 use crate::id::Uid;
+use crate::proc::InstanceCell;
 use crate::proc::Proc;
 
 /// The offset of user-defined ports (i.e., arbitrarily bound).
@@ -46,7 +48,8 @@ macro_rules! register_spawnable {
             $crate::internal_macro_support::inventory::submit! {
                 $crate::actor::remote::SpawnableActor {
                     name: &NAME,
-                    gspawn: <$actor as $crate::actor::RemoteSpawn>::gspawn,
+                    gspawn_root_bind: <$actor as $crate::actor::RemoteSpawn>::gspawn_root_bind,
+                    gspawn_child: <$actor as $crate::actor::RemoteSpawn>::gspawn_child,
                     get_type_id: <$actor as $crate::actor::RemoteSpawn>::get_type_id,
                 }
             }
@@ -65,14 +68,27 @@ pub struct SpawnableActor {
     /// implementation, which can not yet be `const`.
     pub name: &'static LazyLock<&'static str>,
 
-    /// Type-erased spawn function. This is the type's [`RemoteSpawn::gspawn`].
-    pub gspawn: fn(
+    /// Type-erased root spawn function. This is the type's
+    /// [`RemoteSpawn::gspawn_root_bind`].
+    pub gspawn_root_bind: fn(
         &Proc,
         Uid,
         Data,
         Flattrs,
-    )
-        -> Pin<Box<dyn Future<Output = Result<crate::ActorAddr, anyhow::Error>> + Send>>,
+    ) -> Pin<
+        Box<dyn Future<Output = Result<crate::ActorAddr, anyhow::Error>> + Send>,
+    >,
+
+    /// Type-erased child spawn function. This is the type's
+    /// [`RemoteSpawn::gspawn_child`].
+    pub gspawn_child:
+        fn(
+            &Proc,
+            InstanceCell,
+            Uid,
+            Data,
+            Flattrs,
+        ) -> Pin<Box<dyn Future<Output = Result<AnyActorHandle, anyhow::Error>> + Send>>,
 
     /// A function to retrieve the type id of the actor itself. This is
     /// used to translate a concrete type to a global name.
@@ -112,6 +128,12 @@ impl Remote {
         }
     }
 
+    /// Return the process-wide remote spawn registry.
+    pub fn global() -> &'static Self {
+        static REMOTE: LazyLock<Remote> = LazyLock::new(Remote::collect);
+        &REMOTE
+    }
+
     /// Returns the name of the provided actor, if registered.
     pub fn name_of<A: Actor>(&self) -> Option<&'static str> {
         self.by_type_id
@@ -134,7 +156,25 @@ impl Remote {
             .by_name
             .get(actor_type)
             .ok_or_else(|| anyhow::anyhow!("actor type {} not registered", actor_type))?;
-        (entry.gspawn)(proc, actor_uid, params, environment).await
+        (entry.gspawn_root_bind)(proc, actor_uid, params, environment).await
+    }
+
+    /// Spawns the actor as a child of the provided parent. Returns an
+    /// erased lifecycle handle.
+    pub async fn gspawn_child(
+        &self,
+        proc: &Proc,
+        parent: InstanceCell,
+        actor_type: &str,
+        actor_uid: Uid,
+        params: Data,
+        environment: Flattrs,
+    ) -> Result<AnyActorHandle, anyhow::Error> {
+        let entry = self
+            .by_name
+            .get(actor_type)
+            .ok_or_else(|| anyhow::anyhow!("actor type {} not registered", actor_type))?;
+        (entry.gspawn_child)(proc, parent, actor_uid, params, environment).await
     }
 }
 
@@ -241,5 +281,77 @@ mod tests {
             .unwrap_err();
 
         assert_eq!(err.to_string().as_str(), "some failure");
+    }
+
+    #[tokio::test]
+    async fn test_instance_gspawn_child_returns_erased_handle() {
+        let proc = Proc::local();
+        let (parent, _parent_handle) = proc.instance("parent").unwrap();
+
+        let child = parent
+            .gspawn(
+                "hyperactor::actor::remote::tests::MyActor",
+                bincode::serde::encode_to_vec(true, bincode::config::legacy()).unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert!(!child.actor_id().is_root());
+        assert!(child.downcast::<MyActor>().is_some());
+        assert!(child.downcast::<GenericActor<u64>>().is_none());
+
+        child.stop("test").unwrap();
+        child.await;
+    }
+
+    #[tokio::test]
+    async fn test_instance_gspawn_uid_uses_explicit_uid() {
+        let proc = Proc::local();
+        let (parent, _parent_handle) = proc.instance("parent").unwrap();
+        let uid = Uid::instance_labeled(Label::new("child").unwrap());
+
+        let child = parent
+            .gspawn_uid(
+                "hyperactor::actor::remote::tests::MyActor",
+                uid.clone(),
+                bincode::serde::encode_to_vec(true, bincode::config::legacy()).unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(child.actor_id().uid(), &uid);
+
+        child.stop("test").unwrap();
+        child.await;
+    }
+
+    #[tokio::test]
+    async fn test_instance_gspawn_uid_rejects_duplicate_uid() {
+        let proc = Proc::local();
+        let (parent, _parent_handle) = proc.instance("parent").unwrap();
+        let uid = Uid::instance_labeled(Label::new("child").unwrap());
+
+        let child = parent
+            .gspawn_uid(
+                "hyperactor::actor::remote::tests::MyActor",
+                uid.clone(),
+                bincode::serde::encode_to_vec(true, bincode::config::legacy()).unwrap(),
+            )
+            .await
+            .unwrap();
+
+        let err = parent
+            .gspawn_uid(
+                "hyperactor::actor::remote::tests::MyActor",
+                uid,
+                bincode::serde::encode_to_vec(true, bincode::config::legacy()).unwrap(),
+            )
+            .await
+            .unwrap_err();
+
+        assert!(err.to_string().contains("has already been spawned"));
+
+        child.stop("test").unwrap();
+        child.await;
     }
 }

--- a/hyperactor/src/lib.rs
+++ b/hyperactor/src/lib.rs
@@ -107,6 +107,7 @@ pub mod internal_macro_support {
 
 pub use actor::Actor;
 pub use actor::ActorHandle;
+pub use actor::AnyActorHandle;
 pub use actor::Handler;
 pub use actor::HandlerInfo;
 pub use actor::RemoteHandles;

--- a/hyperactor/src/proc.rs
+++ b/hyperactor/src/proc.rs
@@ -138,6 +138,7 @@ use crate::Actor;
 use crate::ActorAddr;
 use crate::ActorRef;
 use crate::Addr;
+use crate::Data;
 use crate::Handler;
 use crate::Message;
 use crate::PortAddr;
@@ -147,6 +148,7 @@ use crate::actor::ActorError;
 use crate::actor::ActorErrorKind;
 use crate::actor::ActorHandle;
 use crate::actor::ActorStatus;
+use crate::actor::AnyActorHandle;
 use crate::actor::Binds;
 use crate::actor::HandlerInfo;
 use crate::actor::Referable;
@@ -993,6 +995,17 @@ impl Proc {
         self.spawn_inner(actor_id, actor, Some(parent))
     }
 
+    /// Spawn a child actor from the provided parent using an explicit uid.
+    pub(crate) fn spawn_child_with_uid<A: Actor>(
+        &self,
+        parent: InstanceCell,
+        uid: crate::id::Uid,
+        actor: A,
+    ) -> Result<ActorHandle<A>, anyhow::Error> {
+        let actor_id = self.ensure_child_uid(parent.actor_id(), uid)?;
+        self.spawn_inner(actor_id, actor, Some(parent))
+    }
+
     /// Spawn a named child actor. Same as `spawn_child` but the child
     /// gets a descriptive name instead of inheriting the parent's.
     /// Supervision linkage to parent is preserved.
@@ -1318,6 +1331,21 @@ impl Proc {
     ) -> Result<ActorAddr, anyhow::Error> {
         assert_eq!(parent_id.proc_ref(), self.state().proc_id);
         Ok(parent_id.unique_child())
+    }
+
+    /// Ensure that the requested child uid is available in this proc.
+    fn ensure_child_uid(
+        &self,
+        parent_id: &ActorAddr,
+        uid: crate::id::Uid,
+    ) -> Result<ActorAddr, anyhow::Error> {
+        assert_eq!(parent_id.proc_ref(), self.state().proc_id);
+        let actor_id = crate::id::ActorId::new(uid, self.state().proc_id.id().clone(), None);
+        let actor_addr = ActorAddr::new(actor_id, self.state().proc_id.location().clone());
+        if self.state().instances.contains_key(&actor_addr) {
+            anyhow::bail!("an actor with id {} has already been spawned", actor_addr);
+        }
+        Ok(actor_addr)
     }
 
     /// Allocate an actor ID with a custom name on this proc.
@@ -2527,6 +2555,37 @@ impl<A: Actor> Instance<A> {
     /// Create a new direct child instance.
     pub fn child(&self) -> anyhow::Result<(Instance<()>, ActorHandle<()>)> {
         self.inner.proc.child_instance(self.inner.cell.clone())
+    }
+
+    /// Spawn a registered actor as this instance's child.
+    ///
+    /// The actor type is resolved through the remote spawn registry. The child
+    /// receives an empty environment.
+    pub async fn gspawn(&self, actor_type: &str, params: Data) -> anyhow::Result<AnyActorHandle> {
+        self.gspawn_uid(actor_type, crate::id::Uid::instance(), params)
+            .await
+    }
+
+    /// Spawn a registered actor as this instance's child using an explicit uid.
+    ///
+    /// The actor type is resolved through the remote spawn registry. The child
+    /// receives an empty environment.
+    pub async fn gspawn_uid(
+        &self,
+        actor_type: &str,
+        uid: crate::id::Uid,
+        params: Data,
+    ) -> anyhow::Result<AnyActorHandle> {
+        crate::actor::remote::Remote::global()
+            .gspawn_child(
+                &self.inner.proc,
+                self.inner.cell.clone(),
+                actor_type,
+                uid,
+                params,
+                Flattrs::default(),
+            )
+            .await
     }
 
     /// Return a handler port handle representing the actor's message


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #3800
* #3768
* #3767
* #3766
* #3765
* #3764
* #3763
* #3762
* #3761
* __->__ #3760
* #3745
* #3744
* #3743
* #3742

Add `Instance::gspawn` and `Instance::gspawn_uid` so an actor instance can spawn a registered actor as a true supervised child through the remote spawn registry. The supporting changes make that API useful across type boundaries: root registry spawning is renamed to `gspawn_root_bind`, child spawning returns an `AnyActorHandle` that preserves lifecycle operations and supports downcasting, and child spawns use an empty environment. This keeps the main API centered on child supervision while leaving erased handler-port access for a later layer.

Differential Revision: [D103862675](https://our.internmc.facebook.com/intern/diff/D103862675/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D103862675/)!