### PR TITLE
[monarch][rdma] fix find_cuda_segment boundary: bound by mr_size, not phys_size

### DIFF
--- a/monarch_rdma/src/backend/cuda_test_utils.rs
+++ b/monarch_rdma/src/backend/cuda_test_utils.rs
@@ -33,12 +33,36 @@ use crate::local_memory::KeepaliveLocalMemory;
 use crate::local_memory::RdmaLocalMemory;
 use crate::register_segment_scanner;
 
+/// One physical chunk mapped into an expandable segment's VA
+/// reservation. Owns a single `cuMemCreate` handle.
+#[derive(Debug)]
+struct MappedChunk {
+    offset: usize,
+    size: usize,
+    handle: u64,
+}
+
 #[derive(Debug)]
 struct CudaAllocationInner {
+    /// Start of the VA reservation; stable for the allocation's life.
     ptr: usize,
-    size: usize,
+    /// Total VA extent reserved; `mapped_size` grows up to this.
+    reserved_size: usize,
     device: i32,
-    handle: u64,
+    /// Driver-reported granularity; commit/expand sizes round up to
+    /// the next multiple.
+    granularity: usize,
+    state: Mutex<MappedState>,
+}
+
+#[derive(Debug)]
+struct MappedState {
+    /// Ordered chunks; each must be unmapped before the VA reservation
+    /// is freed.
+    chunks: Vec<MappedChunk>,
+    /// Sum of chunk sizes — what the scanner reports and what
+    /// `CudaAllocation::size` returns.
+    mapped_size: usize,
 }
 
 impl Drop for CudaAllocationInner {
@@ -47,9 +71,10 @@ impl Drop for CudaAllocationInner {
     }
 }
 
-/// A CUDA device allocation that keeps its backing memory alive via
-/// reference counting. When the last clone is dropped, the backing
-/// CUDA resources are released through [`CudaAllocator`].
+/// CUDA VMM allocation modelled on PyTorch's expandable segments:
+/// a large VA range reserved up front, with physical memory mapped
+/// in on demand via [`Self::expand`]. `ptr` is stable; `size()`
+/// grows. Refcounted; dropped on last clone.
 #[derive(Clone, Debug)]
 pub struct CudaAllocation {
     inner: Arc<CudaAllocationInner>,
@@ -60,12 +85,112 @@ impl CudaAllocation {
         self.inner.ptr
     }
 
+    /// Currently mapped extent. Use this — not [`Self::reserved_size`]
+    /// — to bounds-check buffer offsets; addresses past `ptr + size()`
+    /// are reserved but unmapped.
     pub fn size(&self) -> usize {
-        self.inner.size
+        self.inner.state.lock().unwrap().mapped_size
     }
-}
 
-impl CudaAllocation {
+    /// Total reserved VA extent. Always >= [`Self::size`].
+    pub fn reserved_size(&self) -> usize {
+        self.inner.reserved_size
+    }
+
+    /// Driver-reported allocation granularity. [`Self::expand`]
+    /// rounds `additional_size` up to a multiple of this.
+    pub fn granularity(&self) -> usize {
+        self.inner.granularity
+    }
+
+    /// Map another `additional_size` bytes (rounded up to a granularity
+    /// multiple) into the trailing reserved VA region and return the
+    /// new total mapped size. Errors if `additional_size` is zero or
+    /// the rounded total would exceed `reserved_size`.
+    ///
+    /// Scanner sees the same `ptr`, just a larger `size`.
+    pub fn expand(&self, additional_size: usize) -> Result<usize, anyhow::Error> {
+        anyhow::ensure!(
+            additional_size > 0,
+            "expand: additional_size must be positive (got 0)",
+        );
+        let granularity = self.inner.granularity;
+        let padded = additional_size.div_ceil(granularity) * granularity;
+
+        let mut state = self.inner.state.lock().unwrap();
+        let new_total = state
+            .mapped_size
+            .checked_add(padded)
+            .ok_or_else(|| anyhow::anyhow!("expand: mapped_size overflow"))?;
+        anyhow::ensure!(
+            new_total <= self.inner.reserved_size,
+            "expand: would map {} bytes past reservation ({} reserved, {} already mapped)",
+            padded,
+            self.inner.reserved_size,
+            state.mapped_size,
+        );
+
+        let offset = state.mapped_size;
+        let chunk_addr = self.inner.ptr + offset;
+
+        // SAFETY: [offset, offset + padded) is within the live VA
+        // reservation and currently unmapped (the inner `Arc` keeps
+        // the reservation alive past every chunk).
+        unsafe {
+            let _ctx_guard = crate::local_memory::set_ctx_for_ptr(self.inner.ptr)
+                .map_err(|e| anyhow::anyhow!("set CUDA context for expand: {e}"))?;
+
+            let mut prop: rdmaxcel_sys::CUmemAllocationProp = std::mem::zeroed();
+            prop.type_ = rdmaxcel_sys::CU_MEM_ALLOCATION_TYPE_PINNED;
+            prop.location.type_ = rdmaxcel_sys::CU_MEM_LOCATION_TYPE_DEVICE;
+            prop.location.id = self.inner.device;
+            prop.allocFlags.gpuDirectRDMACapable = 1;
+            prop.requestedHandleTypes = rdmaxcel_sys::CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR;
+
+            let mut handle: rdmaxcel_sys::CUmemGenericAllocationHandle = std::mem::zeroed();
+            let r = rdmaxcel_sys::rdmaxcel_cuMemCreate(&mut handle, padded, &prop, 0);
+            if r != rdmaxcel_sys::CUDA_SUCCESS {
+                anyhow::bail!("cuMemCreate (expand): {}", cuda_err(r));
+            }
+
+            let r = rdmaxcel_sys::rdmaxcel_cuMemMap(
+                chunk_addr as rdmaxcel_sys::CUdeviceptr,
+                padded,
+                0,
+                handle,
+                0,
+            );
+            if r != rdmaxcel_sys::CUDA_SUCCESS {
+                rdmaxcel_sys::rdmaxcel_cuMemRelease(handle);
+                anyhow::bail!("cuMemMap (expand): {}", cuda_err(r));
+            }
+
+            let mut access: rdmaxcel_sys::CUmemAccessDesc = std::mem::zeroed();
+            access.location.type_ = rdmaxcel_sys::CU_MEM_LOCATION_TYPE_DEVICE;
+            access.location.id = self.inner.device;
+            access.flags = rdmaxcel_sys::CU_MEM_ACCESS_FLAGS_PROT_READWRITE;
+            let r = rdmaxcel_sys::rdmaxcel_cuMemSetAccess(
+                chunk_addr as rdmaxcel_sys::CUdeviceptr,
+                padded,
+                &access,
+                1,
+            );
+            if r != rdmaxcel_sys::CUDA_SUCCESS {
+                rdmaxcel_sys::rdmaxcel_cuMemUnmap(chunk_addr as rdmaxcel_sys::CUdeviceptr, padded);
+                rdmaxcel_sys::rdmaxcel_cuMemRelease(handle);
+                anyhow::bail!("cuMemSetAccess (expand): {}", cuda_err(r));
+            }
+
+            state.chunks.push(MappedChunk {
+                offset,
+                size: padded,
+                handle,
+            });
+            state.mapped_size = new_total;
+        }
+        Ok(new_total)
+    }
+
     /// Try to free the backing CUDA memory. Returns `true` if the
     /// resources were released, or `false` if other clones still exist.
     pub fn try_free(self) -> bool {
@@ -113,10 +238,19 @@ impl CudaAllocator {
         })
     }
 
-    /// Allocate GPU memory on `device` of at least `size` bytes via the CUDA
-    /// VMM API. Returns the device pointer. Panics on failure, cleaning up
-    /// any partially-allocated resources.
-    pub fn allocate(&self, device: i32, size: usize) -> CudaAllocation {
+    /// Allocate an expandable CUDA segment on `device`: reserve
+    /// `reserved_size` bytes of VA and commit `initial_committed_size`
+    /// at offset 0. [`CudaAllocation::expand`] commits more later.
+    ///
+    /// Both sizes must be positive and round up to the device
+    /// granularity, with `initial_committed_size <= reserved_size`
+    /// after rounding. Panics on FFI failure.
+    pub fn allocate(
+        &self,
+        device: i32,
+        reserved_size: usize,
+        initial_committed_size: usize,
+    ) -> CudaAllocation {
         unsafe {
             // Context setup — shared primary context, nothing to roll back.
             let mut dev: rdmaxcel_sys::CUdevice = std::mem::zeroed();
@@ -142,29 +276,39 @@ impl CudaAllocator {
                 rdmaxcel_sys::CU_MEM_ALLOC_GRANULARITY_MINIMUM,
             ));
 
-            let padded = size.div_ceil(granularity) * granularity;
+            assert!(reserved_size > 0, "reserved_size must be positive");
+            assert!(
+                initial_committed_size > 0,
+                "initial_committed_size must be positive",
+            );
+            let padded_reserved = reserved_size.div_ceil(granularity) * granularity;
+            let padded_initial = initial_committed_size.div_ceil(granularity) * granularity;
+            assert!(
+                padded_initial <= padded_reserved,
+                "initial_committed_size {initial_committed_size} (padded {padded_initial}) > \
+                 reserved_size {reserved_size} (padded {padded_reserved})",
+            );
 
-            // From here each step acquires a resource; clean up predecessors
-            // before panicking if a later step fails.
-            let mut handle: rdmaxcel_sys::CUmemGenericAllocationHandle = std::mem::zeroed();
-            cu_check!(rdmaxcel_sys::rdmaxcel_cuMemCreate(
-                &mut handle,
-                padded,
-                &prop,
-                0
-            ));
-
+            // Reserve the full VA range up front so `expand` can
+            // contiguously fill in.
             let mut dptr: rdmaxcel_sys::CUdeviceptr = std::mem::zeroed();
-            let r = rdmaxcel_sys::rdmaxcel_cuMemAddressReserve(&mut dptr, padded, 0, 0, 0);
+            let r = rdmaxcel_sys::rdmaxcel_cuMemAddressReserve(&mut dptr, padded_reserved, 0, 0, 0);
             if r != rdmaxcel_sys::CUDA_SUCCESS {
-                rdmaxcel_sys::rdmaxcel_cuMemRelease(handle);
                 panic!("cuMemAddressReserve: {}", cuda_err(r));
             }
 
-            let r = rdmaxcel_sys::rdmaxcel_cuMemMap(dptr, padded, 0, handle, 0);
+            // Commit the initial chunk at offset 0.
+            let mut handle: rdmaxcel_sys::CUmemGenericAllocationHandle = std::mem::zeroed();
+            let r = rdmaxcel_sys::rdmaxcel_cuMemCreate(&mut handle, padded_initial, &prop, 0);
+            if r != rdmaxcel_sys::CUDA_SUCCESS {
+                rdmaxcel_sys::rdmaxcel_cuMemAddressFree(dptr, padded_reserved);
+                panic!("cuMemCreate: {}", cuda_err(r));
+            }
+
+            let r = rdmaxcel_sys::rdmaxcel_cuMemMap(dptr, padded_initial, 0, handle, 0);
             if r != rdmaxcel_sys::CUDA_SUCCESS {
                 rdmaxcel_sys::rdmaxcel_cuMemRelease(handle);
-                rdmaxcel_sys::rdmaxcel_cuMemAddressFree(dptr, padded);
+                rdmaxcel_sys::rdmaxcel_cuMemAddressFree(dptr, padded_reserved);
                 panic!("cuMemMap: {}", cuda_err(r));
             }
 
@@ -172,20 +316,28 @@ impl CudaAllocator {
             access.location.type_ = rdmaxcel_sys::CU_MEM_LOCATION_TYPE_DEVICE;
             access.location.id = device;
             access.flags = rdmaxcel_sys::CU_MEM_ACCESS_FLAGS_PROT_READWRITE;
-            let r = rdmaxcel_sys::rdmaxcel_cuMemSetAccess(dptr, padded, &access, 1);
+            let r = rdmaxcel_sys::rdmaxcel_cuMemSetAccess(dptr, padded_initial, &access, 1);
             if r != rdmaxcel_sys::CUDA_SUCCESS {
-                rdmaxcel_sys::rdmaxcel_cuMemUnmap(dptr, padded);
+                rdmaxcel_sys::rdmaxcel_cuMemUnmap(dptr, padded_initial);
                 rdmaxcel_sys::rdmaxcel_cuMemRelease(handle);
-                rdmaxcel_sys::rdmaxcel_cuMemAddressFree(dptr, padded);
+                rdmaxcel_sys::rdmaxcel_cuMemAddressFree(dptr, padded_reserved);
                 panic!("cuMemSetAccess: {}", cuda_err(r));
             }
 
             let ptr = dptr as usize;
             let inner = Arc::new(CudaAllocationInner {
                 ptr,
-                size: padded,
+                reserved_size: padded_reserved,
                 device,
-                handle,
+                granularity,
+                state: Mutex::new(MappedState {
+                    chunks: vec![MappedChunk {
+                        offset: 0,
+                        size: padded_initial,
+                        handle,
+                    }],
+                    mapped_size: padded_initial,
+                }),
             });
             self.allocations
                 .lock()
@@ -213,15 +365,21 @@ impl CudaAllocator {
         // SAFETY: inner.ptr is a valid CUDA device pointer from allocate.
         let _ctx_guard = unsafe { crate::local_memory::set_ctx_for_ptr(inner.ptr) }
             .expect("failed to set CUDA context for deallocation");
+
+        // Unmap each chunk individually (the unmapped portion of the
+        // reservation isn't safe to touch), then free the VA range.
+        let chunks = std::mem::take(&mut inner.state.lock().unwrap().chunks);
         unsafe {
-            cu_check!(rdmaxcel_sys::rdmaxcel_cuMemUnmap(
-                inner.ptr as rdmaxcel_sys::CUdeviceptr,
-                inner.size
-            ));
-            cu_check!(rdmaxcel_sys::rdmaxcel_cuMemRelease(inner.handle));
+            for chunk in chunks {
+                cu_check!(rdmaxcel_sys::rdmaxcel_cuMemUnmap(
+                    (inner.ptr + chunk.offset) as rdmaxcel_sys::CUdeviceptr,
+                    chunk.size,
+                ));
+                cu_check!(rdmaxcel_sys::rdmaxcel_cuMemRelease(chunk.handle));
+            }
             cu_check!(rdmaxcel_sys::rdmaxcel_cuMemAddressFree(
                 inner.ptr as rdmaxcel_sys::CUdeviceptr,
-                inner.size
+                inner.reserved_size,
             ));
         }
     }
@@ -257,12 +415,15 @@ pub unsafe extern "C" fn cuda_allocator_scanner(
         let Some(inner) = weak.upgrade() else {
             continue;
         };
+        // Report the *currently mapped* extent, not the reserved
+        // VA. Expandable segments grow this on each `expand` call.
+        let mapped_size = inner.state.lock().unwrap().mapped_size;
         if !out.is_null() && written < max {
             // SAFETY: caller guarantees `out` points to a buffer of at least `max` entries.
             unsafe {
                 *out.add(written) = rdmaxcel_sys::rdmaxcel_scanned_segment_t {
                     address: inner.ptr,
-                    size: inner.size,
+                    size: mapped_size,
                     device: inner.device,
                     is_expandable: 1,
                 };
@@ -283,7 +444,7 @@ pub unsafe extern "C" fn cuda_allocator_scanner(
 #[derive(Debug)]
 pub struct SenderActor {
     device: i32,
-    allocation: Option<CudaAllocation>,
+    allocations: Vec<CudaAllocation>,
 }
 
 impl Actor for SenderActor {}
@@ -296,7 +457,7 @@ impl RemoteSpawn for SenderActor {
         register_segment_scanner(Some(cuda_allocator_scanner));
         Ok(Self {
             device: device_id,
-            allocation: None,
+            allocations: Vec::new(),
         })
     }
 }
@@ -310,20 +471,34 @@ impl RemoteSpawn for SenderActor {
     Debug
 )]
 pub enum SenderMessage {
-    /// Allocate GPU memory for later registration.
+    /// Allocate an expandable segment and return its index for use
+    /// with `Register` and `Expand`.
     Allocate {
-        total_size: usize,
+        reserved_size: usize,
+        initial_committed_size: usize,
         #[reply]
-        reply: OncePortRef<()>,
+        reply: OncePortRef<usize>,
     },
-    /// Register sub-buffers from the previous allocation with the RDMA manager.
+    /// Commit another `additional_size` bytes into the segment at
+    /// `allocation_idx`; returns the new mapped extent.
+    Expand {
+        allocation_idx: usize,
+        additional_size: usize,
+        #[reply]
+        reply: OncePortRef<usize>,
+    },
+    /// Register sub-buffers carved out of allocation `allocation_idx`
+    /// with the RDMA manager. Each buffer's backing bytes are pre-
+    /// filled with `pattern` so reads return a known sequence.
     Register {
+        allocation_idx: usize,
         buffers: Vec<(usize, usize)>,
+        pattern: u8,
         rdma_manager: ActorRef<RdmaManagerActor>,
         #[reply]
         reply: OncePortRef<Vec<RdmaRemoteBuffer>>,
     },
-    FreeAllocation {
+    FreeAllocations {
         #[reply]
         reply: OncePortRef<()>,
     },
@@ -335,22 +510,53 @@ impl SenderMessageHandler for SenderActor {
     async fn allocate(
         &mut self,
         _cx: &Context<Self>,
-        total_size: usize,
-    ) -> Result<(), anyhow::Error> {
-        self.allocation = Some(CudaAllocator::get().allocate(self.device, total_size));
-        Ok(())
+        reserved_size: usize,
+        initial_committed_size: usize,
+    ) -> Result<usize, anyhow::Error> {
+        let idx = self.allocations.len();
+        self.allocations.push(CudaAllocator::get().allocate(
+            self.device,
+            reserved_size,
+            initial_committed_size,
+        ));
+        Ok(idx)
+    }
+
+    async fn expand(
+        &mut self,
+        _cx: &Context<Self>,
+        allocation_idx: usize,
+        additional_size: usize,
+    ) -> Result<usize, anyhow::Error> {
+        let alloc = self.allocations.get(allocation_idx).ok_or_else(|| {
+            anyhow::anyhow!(
+                "expand called with allocation_idx={allocation_idx} but only \
+                 {} allocations exist",
+                self.allocations.len()
+            )
+        })?;
+        alloc.expand(additional_size)
     }
 
     async fn register(
         &mut self,
         cx: &Context<Self>,
+        allocation_idx: usize,
         buffers: Vec<(usize, usize)>,
+        pattern: u8,
         rdma_manager: ActorRef<RdmaManagerActor>,
     ) -> Result<Vec<RdmaRemoteBuffer>, anyhow::Error> {
         let alloc = self
-            .allocation
-            .as_ref()
-            .ok_or_else(|| anyhow::anyhow!("register called before allocate"))?;
+            .allocations
+            .get(allocation_idx)
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "register called with allocation_idx={allocation_idx} but only \
+                     {} allocations exist",
+                    self.allocations.len()
+                )
+            })?
+            .clone();
 
         for (i, &(offset, size)) in buffers.iter().enumerate() {
             anyhow::ensure!(
@@ -371,14 +577,18 @@ impl SenderMessageHandler for SenderActor {
                 size,
                 Arc::new(alloc.clone()),
             ));
+            // Pre-fill so reads return a known sequence; write_at
+            // routes to the GPU path for CUDA-backed memory.
+            let fill = vec![pattern; size];
+            local.write_at(0, &fill)?;
             remotes.push(handle.request_buffer(cx, local).await?);
         }
 
         Ok(remotes)
     }
 
-    async fn free_allocation(&mut self, _cx: &Context<Self>) -> Result<(), anyhow::Error> {
-        if let Some(alloc) = self.allocation.take() {
+    async fn free_allocations(&mut self, _cx: &Context<Self>) -> Result<(), anyhow::Error> {
+        for alloc in self.allocations.drain(..) {
             alloc.try_free();
         }
         Ok(())
@@ -412,9 +622,22 @@ impl RemoteSpawn for ReceiverActor {
     Debug
 )]
 pub enum ReceiverMessage {
+    /// RDMA-read `size` bytes from `remote` and verify every byte of
+    /// the local destination equals `expected_pattern`. Catches both
+    /// WR-level failures and silent data corruption.
     ReadRemote {
         remote: RdmaRemoteBuffer,
         size: usize,
+        expected_pattern: u8,
+        timeout_secs: u64,
+        #[reply]
+        reply: OncePortRef<Result<(), String>>,
+    },
+    /// RDMA-write `size` bytes of `pattern` into `remote`.
+    WriteRemote {
+        remote: RdmaRemoteBuffer,
+        size: usize,
+        pattern: u8,
         timeout_secs: u64,
         #[reply]
         reply: OncePortRef<Result<(), String>>,
@@ -429,15 +652,55 @@ impl ReceiverMessageHandler for ReceiverActor {
         cx: &Context<Self>,
         remote: RdmaRemoteBuffer,
         size: usize,
+        expected_pattern: u8,
         timeout_secs: u64,
     ) -> Result<Result<(), String>, anyhow::Error> {
-        let buf: Box<[u8]> = vec![0u8; size].into_boxed_slice();
+        // Pre-fill with the bitwise-NOT of `expected_pattern` so an
+        // unwritten destination is distinguishable from a successful
+        // read.
+        let buf: Box<[u8]> = vec![!expected_pattern; size].into_boxed_slice();
+        let addr = buf.as_ptr() as usize;
+        let local: Arc<dyn RdmaLocalMemory> =
+            Arc::new(KeepaliveLocalMemory::new(addr, size, Arc::new(buf)));
+
+        let read_result = remote
+            .read_into_local(cx, Arc::clone(&local), timeout_secs)
+            .await
+            .map(|_| ())
+            .map_err(|e| e.to_string());
+        if let Err(e) = read_result {
+            return Ok(Err(e));
+        }
+
+        let mut got = vec![0u8; size];
+        if let Err(e) = local.read_at(0, &mut got) {
+            return Ok(Err(format!("post-read inspect failed: {e}")));
+        }
+        if let Some(idx) = got.iter().position(|&b| b != expected_pattern) {
+            return Ok(Err(format!(
+                "pattern mismatch at byte {idx}: expected 0x{expected_pattern:02x}, \
+                 got 0x{:02x}",
+                got[idx]
+            )));
+        }
+        Ok(Ok(()))
+    }
+
+    async fn write_remote(
+        &mut self,
+        cx: &Context<Self>,
+        remote: RdmaRemoteBuffer,
+        size: usize,
+        pattern: u8,
+        timeout_secs: u64,
+    ) -> Result<Result<(), String>, anyhow::Error> {
+        let buf: Box<[u8]> = vec![pattern; size].into_boxed_slice();
         let addr = buf.as_ptr() as usize;
         let local: Arc<dyn RdmaLocalMemory> =
             Arc::new(KeepaliveLocalMemory::new(addr, size, Arc::new(buf)));
 
         let result = remote
-            .read_into_local(cx, local, timeout_secs)
+            .write_from_local(cx, local, timeout_secs)
             .await
             .map(|_| ())
             .map_err(|e| e.to_string());

--- a/monarch_rdma/src/backend/ibverbs/manager_actor.rs
+++ b/monarch_rdma/src/backend/ibverbs/manager_actor.rs
@@ -145,6 +145,43 @@ pub enum IbvManagerLocalMessage {
     },
 }
 
+/// Look up `(addr, size)` in a slice of registered CUDA segments
+/// and return a view into the matching mkey.
+///
+/// Bounded by `mr_size` (what the mkey actually covers), NOT by
+/// `phys_size` (the scanner-reported extent). They diverge when
+/// `register_segments` hits `max_sge` and stops growing the binding.
+/// Returning a view based on `phys_size` would hand out an
+/// `(lkey, offset)` past the bound and the WR would fail with
+/// `IBV_WC_LOC_PROT_ERR`; bounding by `mr_size` makes the gap a
+/// miss so the caller falls back to per-buffer dmabuf.
+///
+/// Free function so the boundary can be unit-tested without an actor.
+pub(super) fn lookup_segment_for_address(
+    segments: &[rdmaxcel_sys::rdma_segment_info_t],
+    addr: usize,
+    size: usize,
+    id: usize,
+) -> Option<IbvMemoryRegionView> {
+    for segment in segments {
+        let start_addr = segment.phys_address;
+        let end_addr = start_addr + segment.mr_size;
+        if start_addr <= addr && addr + size <= end_addr {
+            let offset = addr - start_addr;
+            let rdma_addr = segment.mr_addr + offset;
+            return Some(IbvMemoryRegionView {
+                id,
+                virtual_addr: addr,
+                rdma_addr,
+                size,
+                lkey: segment.lkey,
+                rkey: segment.rkey,
+            });
+        }
+    }
+    None
+}
+
 /// Manages all ibverbs-specific RDMA resources and operations.
 ///
 /// This struct handles memory registration, queue pair management,
@@ -417,26 +454,10 @@ impl IbvManagerActor {
         pd: *mut rdmaxcel_sys::ibv_pd,
     ) -> Option<IbvMemoryRegionView> {
         let registered_segments = get_registered_cuda_segments(pd);
-        for segment in registered_segments {
-            let start_addr = segment.phys_address;
-            let end_addr = start_addr + segment.phys_size;
-            if start_addr <= addr && addr + size <= end_addr {
-                let offset = addr - start_addr;
-                let rdma_addr = segment.mr_addr + offset;
-
-                let mrv = IbvMemoryRegionView {
-                    id: self.mrv_id,
-                    virtual_addr: addr,
-                    rdma_addr,
-                    size,
-                    lkey: segment.lkey,
-                    rkey: segment.rkey,
-                };
-                self.mrv_id += 1;
-                return Some(mrv);
-            }
-        }
-        None
+        let id = self.mrv_id;
+        let mrv = lookup_segment_for_address(&registered_segments, addr, size, id)?;
+        self.mrv_id += 1;
+        Some(mrv)
     }
 
     fn register_mr_impl(
@@ -515,6 +536,7 @@ impl IbvManagerActor {
                             pds.as_mut_ptr(),
                             qps.as_mut_ptr(),
                             pds.len() as i32,
+                            self.config.max_sge_override,
                         );
                         // Only retry if register_segments succeeded
                         // If it fails (e.g., scanner returns 0 segments), we'll fall back to dmabuf

--- a/monarch_rdma/src/backend/ibverbs/mlx5dv_tests.rs
+++ b/monarch_rdma/src/backend/ibverbs/mlx5dv_tests.rs
@@ -8,6 +8,7 @@
 
 //! Tests for mlx5dv-specific functionality (indirect mkeys, segment scanning).
 
+use hyperactor::context as actor_context;
 use hyperactor_mesh::ActorMesh;
 use hyperactor_mesh::context;
 use hyperactor_mesh::host_mesh::HostMesh;
@@ -85,18 +86,23 @@ async fn test_indirect_mkey_read_at_large_offset() -> Result<(), anyhow::Error> 
     let sender = sender_mesh.values().next().unwrap().clone();
     let receiver = receiver_mesh.values().next().unwrap().clone();
 
-    sender.allocate(instance, SEGMENT_SIZE).await?;
+    const PATTERN: u8 = 0xa5;
+    let alloc_idx = sender
+        .allocate(instance, SEGMENT_SIZE, SEGMENT_SIZE)
+        .await?;
     let remotes = sender
         .register(
             instance,
+            alloc_idx,
             vec![(0, BUF0_SIZE), (BUF1_OFFSET, BUF1_SIZE)],
+            PATTERN,
             sender_rdma_ref,
         )
         .await?;
 
     // Read at offset 0 — should always work.
     let buf0_result = receiver
-        .read_remote(instance, remotes[0].clone(), BUF0_SIZE, 10)
+        .read_remote(instance, remotes[0].clone(), BUF0_SIZE, PATTERN, 10)
         .await?;
     assert!(
         buf0_result.is_ok(),
@@ -106,7 +112,7 @@ async fn test_indirect_mkey_read_at_large_offset() -> Result<(), anyhow::Error> 
 
     // Read at offset 0x66000000 (1.71 GB) — fails without the rdma-core fix.
     let buf1_result = receiver
-        .read_remote(instance, remotes[1].clone(), BUF1_SIZE, 10)
+        .read_remote(instance, remotes[1].clone(), BUF1_SIZE, PATTERN, 10)
         .await?;
     assert!(
         buf1_result.is_ok(),
@@ -116,7 +122,422 @@ async fn test_indirect_mkey_read_at_large_offset() -> Result<(), anyhow::Error> 
         buf1_result.unwrap_err()
     );
 
-    sender.free_allocation(instance).await?;
+    sender.free_allocations(instance).await?;
     let _ = host_mesh.shutdown(instance).await;
     Ok(())
+}
+
+/// Resolve the ibverbs `(lkey, rkey)` of a remote buffer. Async
+/// because the `IbvBuffer` is lazily fetched from the owning
+/// `IbvManagerActor`.
+async fn ibv_keys_of(
+    cx: &(impl actor_context::Actor + Send + Sync),
+    remote: &crate::RdmaRemoteBuffer,
+) -> Result<(u32, u32), anyhow::Error> {
+    let (_mgr, buf) = remote
+        .resolve_ibv(cx)
+        .await
+        .ok_or_else(|| anyhow::anyhow!("remote buffer has no ibverbs backend context"))??;
+    Ok((buf.lkey, buf.rkey))
+}
+
+/// Integration test for the successful indirect-mkey rebind path.
+///
+/// Allocates two segments S1 and S2 and registers a buffer in each
+/// (distinct mkeys). Then expands S1 and registers another buffer
+/// in S1's new chunk: the rebind must grow S1's existing mkey, so
+/// the new buffer shares S1's `(lkey, rkey)` and differs from S2's.
+/// Round-trips each buffer to confirm wire payload.
+///
+/// Hardware-gated: needs CUDA + mlx5dv.
+#[timed_test::async_timed_test(timeout_secs = 60)]
+async fn test_indirect_mkey_rebind_grows_existing_segment() -> Result<(), anyhow::Error> {
+    use crate::backend::ibverbs::primitives::mlx5dv_supported;
+
+    if !crate::is_cuda_available() {
+        panic!("SKIPPED: CUDA not available (required for GPU memory allocation)");
+    }
+    if !mlx5dv_supported() {
+        panic!("SKIPPED: mlx5dv not supported (required for indirect mkey rebinding)");
+    }
+
+    // Sized to leave plenty of room for granularity rounding while
+    // staying small enough to fit on a single GPU.
+    const RESERVED: usize = 1024 * 1024 * 1024; // 1 GiB VA per segment
+    const CHUNK: usize = 256 * 1024 * 1024; // 256 MiB committed per chunk
+    const BUF: usize = 8 * 1024 * 1024; // 8 MiB per registered buffer
+
+    let cx = context().await;
+    let instance = cx.actor_instance;
+    let mut host_mesh = HostMesh::local().await?;
+    let proc_mesh = host_mesh
+        .spawn(
+            instance,
+            "rebind_grow_procs",
+            hyperactor_mesh::extent!(procs = 2),
+            None,
+        )
+        .await?;
+
+    let sender_proc = proc_mesh.range("procs", 0..1).unwrap();
+    let receiver_proc = proc_mesh.range("procs", 1..2).unwrap();
+
+    let sender_rdma: ActorMesh<RdmaManagerActor> = sender_proc
+        .spawn_service(instance, "rdma_manager", &Some(IbvConfig::default()))
+        .await?;
+    let _receiver_rdma: ActorMesh<RdmaManagerActor> = receiver_proc
+        .spawn_service(instance, "rdma_manager", &Some(IbvConfig::default()))
+        .await?;
+    let sender_rdma_ref = sender_rdma.values().next().unwrap().clone();
+
+    let sender_mesh: ActorMesh<SenderActor> = sender_proc.spawn(instance, "sender", &0_i32).await?;
+    let receiver_mesh: ActorMesh<ReceiverActor> =
+        receiver_proc.spawn(instance, "receiver", &()).await?;
+    let sender = sender_mesh.values().next().unwrap().clone();
+    let receiver = receiver_mesh.values().next().unwrap().clone();
+
+    const PATTERN_A: u8 = 0xa1;
+    const PATTERN_B: u8 = 0xb1;
+    const PATTERN_C: u8 = 0xc1;
+    const PATTERN_OVERWRITE: u8 = 0x5a;
+
+    let s1 = sender.allocate(instance, RESERVED, CHUNK).await?;
+    let s2 = sender.allocate(instance, RESERVED, CHUNK).await?;
+
+    let buf_a = sender
+        .register(
+            instance,
+            s1,
+            vec![(0, BUF)],
+            PATTERN_A,
+            sender_rdma_ref.clone(),
+        )
+        .await?
+        .into_iter()
+        .next()
+        .expect("buf A");
+    let buf_b = sender
+        .register(
+            instance,
+            s2,
+            vec![(0, BUF)],
+            PATTERN_B,
+            sender_rdma_ref.clone(),
+        )
+        .await?
+        .into_iter()
+        .next()
+        .expect("buf B");
+
+    let (lkey_a, rkey_a) = ibv_keys_of(instance, &buf_a).await?;
+    let (lkey_b, rkey_b) = ibv_keys_of(instance, &buf_b).await?;
+    assert_ne!(
+        (lkey_a, rkey_a),
+        (lkey_b, rkey_b),
+        "buffers in distinct segments must have distinct (lkey, rkey)",
+    );
+
+    // Expand S1 in place; the next miss triggers a register_segments
+    // rebind that grows S1's mkey to cover both chunks.
+    sender.expand(instance, s1, CHUNK).await?;
+    let buf_c = sender
+        .register(instance, s1, vec![(CHUNK, BUF)], PATTERN_C, sender_rdma_ref)
+        .await?
+        .into_iter()
+        .next()
+        .expect("buf C");
+
+    let (lkey_c, rkey_c) = ibv_keys_of(instance, &buf_c).await?;
+    assert_eq!(
+        (lkey_c, rkey_c),
+        (lkey_a, rkey_a),
+        "buffer carved from a rebound expandable segment must share \
+         the segment's (lkey, rkey)",
+    );
+
+    // Each buffer was filled with its own pattern at registration;
+    // RDMA reads should return exactly those bytes.
+    for (label, buf, pattern) in [
+        ("A", &buf_a, PATTERN_A),
+        ("B", &buf_b, PATTERN_B),
+        ("C", &buf_c, PATTERN_C),
+    ] {
+        let result = receiver
+            .read_remote(instance, buf.clone(), BUF, pattern, 10)
+            .await?;
+        assert!(
+            result.is_ok(),
+            "RDMA read of buf {label} failed: {:?}",
+            result.unwrap_err()
+        );
+    }
+
+    // RDMA-write a fresh pattern, read back, confirm it landed.
+    for (label, buf) in [("A", &buf_a), ("B", &buf_b), ("C", &buf_c)] {
+        let write = receiver
+            .write_remote(instance, buf.clone(), BUF, PATTERN_OVERWRITE, 10)
+            .await?;
+        assert!(
+            write.is_ok(),
+            "RDMA write to buf {label} failed: {:?}",
+            write.unwrap_err()
+        );
+        let read = receiver
+            .read_remote(instance, buf.clone(), BUF, PATTERN_OVERWRITE, 10)
+            .await?;
+        assert!(
+            read.is_ok(),
+            "RDMA read-back of buf {label} after write failed: {:?}",
+            read.unwrap_err()
+        );
+    }
+
+    sender.free_allocations(instance).await?;
+    let _ = host_mesh.shutdown(instance).await;
+    Ok(())
+}
+
+/// Integration test for the rebind failure path. Forces the second
+/// `register_segments` call to fail with `RDMAXCEL_MKEY_REG_LIMIT`
+/// by setting `IbvConfig::max_sge_override = 1`, leaving the
+/// segment table in a `phys_size > mr_size` state. Subsequent
+/// buffer registrations whose addresses fall in the
+/// `[mr_size, phys_size)` gap must fall through to per-buffer
+/// dmabuf rather than reuse the indirect mkey at an offset past
+/// the bound.
+///
+/// Hardware-gated: needs CUDA + mlx5dv.
+#[timed_test::async_timed_test(timeout_secs = 60)]
+async fn test_indirect_mkey_rebind_falls_back_to_dmabuf_at_max_sge() -> Result<(), anyhow::Error> {
+    use crate::backend::ibverbs::primitives::mlx5dv_supported;
+
+    if !crate::is_cuda_available() {
+        panic!("SKIPPED: CUDA not available (required for GPU memory allocation)");
+    }
+    if !mlx5dv_supported() {
+        panic!("SKIPPED: mlx5dv not supported (required for indirect mkey rebinding)");
+    }
+
+    const RESERVED: usize = 1024 * 1024 * 1024;
+    const CHUNK: usize = 256 * 1024 * 1024;
+    const BUF: usize = 8 * 1024 * 1024;
+
+    let cx = context().await;
+    let instance = cx.actor_instance;
+    let mut host_mesh = HostMesh::local().await?;
+    let proc_mesh = host_mesh
+        .spawn(
+            instance,
+            "rebind_failover_procs",
+            hyperactor_mesh::extent!(procs = 2),
+            None,
+        )
+        .await?;
+
+    let sender_proc = proc_mesh.range("procs", 0..1).unwrap();
+    let receiver_proc = proc_mesh.range("procs", 1..2).unwrap();
+
+    let sender_config = IbvConfig {
+        max_sge_override: 1,
+        ..IbvConfig::default()
+    };
+    let sender_rdma: ActorMesh<RdmaManagerActor> = sender_proc
+        .spawn_service(instance, "rdma_manager", &Some(sender_config))
+        .await?;
+    let _receiver_rdma: ActorMesh<RdmaManagerActor> = receiver_proc
+        .spawn_service(instance, "rdma_manager", &Some(IbvConfig::default()))
+        .await?;
+    let sender_rdma_ref = sender_rdma.values().next().unwrap().clone();
+
+    let sender_mesh: ActorMesh<SenderActor> = sender_proc.spawn(instance, "sender", &0_i32).await?;
+    let receiver_mesh: ActorMesh<ReceiverActor> =
+        receiver_proc.spawn(instance, "receiver", &()).await?;
+    let sender = sender_mesh.values().next().unwrap().clone();
+    let receiver = receiver_mesh.values().next().unwrap().clone();
+
+    const PATTERN_A: u8 = 0xa1;
+    const PATTERN_B: u8 = 0xb1;
+    const PATTERN_C: u8 = 0xc1;
+    const PATTERN_OVERWRITE: u8 = 0x5a;
+
+    let seg = sender.allocate(instance, RESERVED, CHUNK).await?;
+
+    let buf_a = sender
+        .register(
+            instance,
+            seg,
+            vec![(0, BUF)],
+            PATTERN_A,
+            sender_rdma_ref.clone(),
+        )
+        .await?
+        .into_iter()
+        .next()
+        .expect("buf A");
+    let read_a = receiver
+        .read_remote(instance, buf_a.clone(), BUF, PATTERN_A, 10)
+        .await?;
+    assert!(
+        read_a.is_ok(),
+        "RDMA read of buf A (within initial chunk) failed: {:?}",
+        read_a.unwrap_err()
+    );
+
+    sender.expand(instance, seg, CHUNK).await?;
+
+    // Buf B's registration hits the max_sge cap, leaving the
+    // segment table with phys_size = 2*CHUNK but mr_size = CHUNK.
+    // Buf C is the registration whose lookup observes that gap.
+    let buf_b = sender
+        .register(
+            instance,
+            seg,
+            vec![(CHUNK, BUF)],
+            PATTERN_B,
+            sender_rdma_ref.clone(),
+        )
+        .await?
+        .into_iter()
+        .next()
+        .expect("buf B");
+    let buf_c = sender
+        .register(
+            instance,
+            seg,
+            vec![(CHUNK + BUF, BUF)],
+            PATTERN_C,
+            sender_rdma_ref,
+        )
+        .await?
+        .into_iter()
+        .next()
+        .expect("buf C");
+
+    // Buf B took the dmabuf path (the override forced
+    // register_segments to fail), so its lkey differs from buf A's
+    // indirect mkey — sanity check that the override took effect.
+    // Buf C lands at an address inside the [mr_size, phys_size) gap;
+    // it must also fall through to dmabuf and get a distinct lkey.
+    let (lkey_a, _) = ibv_keys_of(instance, &buf_a).await?;
+    let (lkey_b, _) = ibv_keys_of(instance, &buf_b).await?;
+    let (lkey_c, _) = ibv_keys_of(instance, &buf_c).await?;
+    assert_ne!(
+        lkey_a, lkey_b,
+        "buf B should be registered via the dmabuf fallback after \
+         register_segments hit the max_sge override and therefore have \
+         a different lkey from buf A's indirect mkey"
+    );
+    assert_ne!(
+        lkey_a, lkey_c,
+        "buf C lands in the [mr_size, phys_size) gap and must fall \
+         through to dmabuf; reusing buf A's indirect mkey here would \
+         hand the NIC a stale (lkey, offset) past the bound"
+    );
+
+    // Round-trip every buffer: read the registration pattern, write
+    // a fresh one, read it back. Even if the lkey check above
+    // somehow passed, a stale (lkey, offset) on buf C would fail at
+    // the NIC with LOC_PROT_ERR.
+    for (label, buf, pattern) in [
+        ("A", &buf_a, PATTERN_A),
+        ("B", &buf_b, PATTERN_B),
+        ("C", &buf_c, PATTERN_C),
+    ] {
+        let read = receiver
+            .read_remote(instance, buf.clone(), BUF, pattern, 10)
+            .await?;
+        assert!(
+            read.is_ok(),
+            "RDMA read of buf {label} failed: {:?}",
+            read.unwrap_err()
+        );
+        let write = receiver
+            .write_remote(instance, buf.clone(), BUF, PATTERN_OVERWRITE, 10)
+            .await?;
+        assert!(
+            write.is_ok(),
+            "RDMA write to buf {label} failed: {:?}",
+            write.unwrap_err()
+        );
+        let read_back = receiver
+            .read_remote(instance, buf.clone(), BUF, PATTERN_OVERWRITE, 10)
+            .await?;
+        assert!(
+            read_back.is_ok(),
+            "RDMA read-back of buf {label} after write failed: {:?}",
+            read_back.unwrap_err()
+        );
+    }
+
+    sender.free_allocations(instance).await?;
+    let _ = host_mesh.shutdown(instance).await;
+    Ok(())
+}
+
+/// Unit test for the `phys_size` vs `mr_size` boundary in
+/// `lookup_segment_for_address`. Drives the pure helper with a
+/// synthetic `rdma_segment_info_t` shaped like the post-`max_sge`
+/// state (`phys_size > mr_size`) and asserts addresses in the
+/// `[mr_size, phys_size)` gap miss while addresses inside `mr_size`
+/// hit.
+#[test]
+fn test_lookup_segment_respects_mr_size_when_scanner_reports_larger_phys_size() {
+    use rdmaxcel_sys::rdma_segment_info_t;
+
+    use crate::backend::ibverbs::manager_actor::lookup_segment_for_address;
+
+    // Scanner reports 64 MiB but only the first 16 MiB is bound
+    // (max_sge cap). `mr_addr` is the post-registration RDMA
+    // address and need not equal `phys_address`.
+    const PHYS_ADDR: usize = 0x1000_0000;
+    const PHYS_SIZE: usize = 64 * 1024 * 1024;
+    const MR_SIZE: usize = 16 * 1024 * 1024;
+    const MR_ADDR: usize = 0xdead_0000;
+    const LKEY: u32 = 0xabcd;
+    const RKEY: u32 = 0x1234;
+
+    let segment = rdma_segment_info_t {
+        phys_address: PHYS_ADDR,
+        phys_size: PHYS_SIZE,
+        device: 0,
+        is_expandable: 1,
+        lkey: LKEY,
+        rkey: RKEY,
+        mr_size: MR_SIZE,
+        mr_addr: MR_ADDR,
+    };
+    let segments = [segment];
+
+    // Inside the bound region: hit; rdma_addr is offset from the
+    // registered `mr_addr`, not the physical address.
+    let in_bound_addr = PHYS_ADDR + 4 * 1024 * 1024;
+    let in_bound = lookup_segment_for_address(&segments, in_bound_addr, 1024, 0)
+        .expect("in-bound address should hit the segment cache");
+    assert_eq!(in_bound.virtual_addr, in_bound_addr);
+    assert_eq!(in_bound.rdma_addr, MR_ADDR + 4 * 1024 * 1024);
+    assert_eq!(in_bound.lkey, LKEY);
+    assert_eq!(in_bound.rkey, RKEY);
+
+    // Inside the `[mr_size, phys_size)` gap: must miss so the
+    // caller falls through to dmabuf.
+    let in_gap_addr = PHYS_ADDR + MR_SIZE + 1024;
+    assert!(
+        lookup_segment_for_address(&segments, in_gap_addr, 1024, 0).is_none(),
+        "address in the [mr_size, phys_size) gap must not be reported \
+         as covered by the indirect mkey",
+    );
+
+    // Request straddling the mr_size boundary must miss.
+    let straddling_addr = PHYS_ADDR + MR_SIZE - 512;
+    assert!(
+        lookup_segment_for_address(&segments, straddling_addr, 4096, 0).is_none(),
+        "request straddling the mr_size boundary must miss",
+    );
+
+    // Past `phys_size`: out of range.
+    let past_end_addr = PHYS_ADDR + PHYS_SIZE + 1;
+    assert!(
+        lookup_segment_for_address(&segments, past_end_addr, 1, 0).is_none(),
+        "address past phys_size must miss",
+    );
 }

--- a/monarch_rdma/src/backend/ibverbs/primitives.rs
+++ b/monarch_rdma/src/backend/ibverbs/primitives.rs
@@ -169,6 +169,10 @@ pub struct IbvConfig {
     pub hw_init_delay_ms: u64,
     /// `qp_type` - The type of queue pair to create (Auto, Standard, or Mlx5dv).
     pub qp_type: IbvQpType,
+    /// Test-only override for `register_segments`'s `max_sge`. `<= 0`
+    /// (default) uses `ibv_query_device`; small positive values force
+    /// `RDMAXCEL_MKEY_REG_LIMIT` to exercise the dmabuf fallback.
+    pub max_sge_override: i32,
 }
 wirevalue::register_type!(IbvConfig);
 
@@ -198,6 +202,7 @@ impl Default for IbvConfig {
             use_gpu_direct: false, // nv_peermem enabled for cuda
             hw_init_delay_ms: 2,
             qp_type: IbvQpType::Auto,
+            max_sge_override: 0,
         };
         if crate::efa::is_efa_device() {
             crate::efa::apply_efa_defaults(&mut config);

--- a/monarch_rdma/src/backend/tcp/manager_actor.rs
+++ b/monarch_rdma/src/backend/tcp/manager_actor.rs
@@ -1578,7 +1578,7 @@ mod tests {
                     .ok_or_else(|| anyhow::anyhow!("tcp actor not local"))?,
             );
 
-            let alloc = CudaAllocator::get().allocate(device, buffer_size);
+            let alloc = CudaAllocator::get().allocate(device, buffer_size, buffer_size);
             let local_memory: Arc<dyn RdmaLocalMemory> = Arc::new(KeepaliveLocalMemory::new(
                 alloc.ptr(),
                 buffer_size,

--- a/monarch_rdma/tests/multi_pd_test.rs
+++ b/monarch_rdma/tests/multi_pd_test.rs
@@ -132,21 +132,29 @@ async fn test_multi_pd_segment_registration() -> Result<(), anyhow::Error> {
 
     // Both senders allocate first, so the scanner sees both segments before
     // either triggers registration.
-    sender_a.allocate(instance, BUF_SIZE).await?;
-    sender_b.allocate(instance, BUF_SIZE).await?;
+    let alloc_a = sender_a.allocate(instance, BUF_SIZE, BUF_SIZE).await?;
+    let alloc_b = sender_b.allocate(instance, BUF_SIZE, BUF_SIZE).await?;
 
     // Now register — each triggers segment scanning and gets its own PD
     // based on the NIC closest to its device.
+    const PATTERN_A: u8 = 0xa1;
+    const PATTERN_B: u8 = 0xb1;
     let remotes_a = sender_a
-        .register(instance, vec![(0, BUF_SIZE)], rdma_ref.clone())
+        .register(
+            instance,
+            alloc_a,
+            vec![(0, BUF_SIZE)],
+            PATTERN_A,
+            rdma_ref.clone(),
+        )
         .await?;
     let remotes_b = sender_b
-        .register(instance, vec![(0, BUF_SIZE)], rdma_ref)
+        .register(instance, alloc_b, vec![(0, BUF_SIZE)], PATTERN_B, rdma_ref)
         .await?;
 
     // Each receiver reads using a QP on the matching NIC/subnet.
     let result_a = receiver_a
-        .read_remote(instance, remotes_a[0].clone(), BUF_SIZE, 10)
+        .read_remote(instance, remotes_a[0].clone(), BUF_SIZE, PATTERN_A, 10)
         .await?;
     assert!(
         result_a.is_ok(),
@@ -157,7 +165,7 @@ async fn test_multi_pd_segment_registration() -> Result<(), anyhow::Error> {
     // On the base revision (address-only key), B's segment would never be
     // registered with the correct PD, causing this read to fail.
     let result_b = receiver_b
-        .read_remote(instance, remotes_b[0].clone(), BUF_SIZE, 10)
+        .read_remote(instance, remotes_b[0].clone(), BUF_SIZE, PATTERN_B, 10)
         .await?;
     assert!(
         result_b.is_ok(),
@@ -166,8 +174,8 @@ async fn test_multi_pd_segment_registration() -> Result<(), anyhow::Error> {
     );
 
     // Clean up allocations.
-    sender_a.free_allocation(instance).await?;
-    sender_b.free_allocation(instance).await?;
+    sender_a.free_allocations(instance).await?;
+    sender_b.free_allocations(instance).await?;
 
     let _ = host_mesh.shutdown(instance).await;
     Ok(())

--- a/rdmaxcel-sys/src/rdmaxcel.cpp
+++ b/rdmaxcel-sys/src/rdmaxcel.cpp
@@ -336,7 +336,8 @@ int compact_mrs(struct ibv_pd* pd, SegmentInfo& seg, int access_flags) {
 int register_segments(
     struct ibv_pd** pds,
     rdmaxcel_qp_t** qps,
-    int num_devices) {
+    int num_devices,
+    int32_t max_sge_override) {
   if (!pds || !qps || num_devices <= 0) {
     return RDMAXCEL_INVALID_PARAMS;
   }
@@ -378,7 +379,13 @@ int register_segments(
       if (ibv_query_device(pd->context, &dev_attr)) {
         return RDMAXCEL_QUERY_DEVICE_FAILED;
       }
-      max_sge = dev_attr.max_sge;
+      // Test-only override (see header).
+      if (max_sge_override > 0 &&
+          static_cast<uint32_t>(max_sge_override) < dev_attr.max_sge) {
+        max_sge = static_cast<uint32_t>(max_sge_override);
+      } else {
+        max_sge = dev_attr.max_sge;
+      }
       max_sge_cache[static_cast<void*>(pd)] = max_sge;
     }
 

--- a/rdmaxcel-sys/src/rdmaxcel.h
+++ b/rdmaxcel-sys/src/rdmaxcel.h
@@ -279,13 +279,16 @@ void rdmaxcel_qp_store_rts_timestamp(rdmaxcel_qp_t* qp, uint64_t value);
 completion_cache_t* rdmaxcel_qp_get_send_cache(rdmaxcel_qp_t* qp);
 completion_cache_t* rdmaxcel_qp_get_recv_cache(rdmaxcel_qp_t* qp);
 
-// Per-device segment registration.
-// pds and qps are parallel arrays indexed by CUDA device ordinal.
-// num_devices is the length of both arrays.
+// Per-device segment registration. pds and qps are parallel arrays
+// indexed by CUDA device ordinal; num_devices is their length.
+// max_sge_override > 0 replaces ibv_query_device(...).max_sge for
+// this call (test-only knob to force RDMAXCEL_MKEY_REG_LIMIT); pass
+// 0 in production.
 int register_segments(
     struct ibv_pd** pds,
     rdmaxcel_qp_t** qps,
-    int num_devices);
+    int num_devices,
+    int32_t max_sge_override);
 
 // Completion Cache Structures and Functions
 #define MAX_CACHED_COMPLETIONS 128


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #3773
* #3771
* __->__ #3769

`find_cuda_segment_for_address` previously bounded its lookup by `segment.phys_size` (the scanner-reported extent), but the indirect mkey only covers `segment.mr_size`. The two diverge when `register_segments` hits the device's `max_sge` cap and stops growing the binding while `scan_existing_segments` keeps lifting `phys_size`. Addresses in `[mr_size, phys_size)` were then handed back as cache hits, producing `(lkey, offset)` pairs the NIC rejects with `IBV_WC_LOC_PROT_ERR`. Switches the boundary to `mr_size` so gap addresses miss and the caller falls through to per-buffer dmabuf.

Walkthrough:

- Boundary changed to `mr_size` in `find_cuda_segment_for_address`. The lookup body is extracted into a free `lookup_segment_for_address` so it can be unit-tested without a real PD.
- `IbvConfig` gains a `max_sge_override: i32` field plumbed to a new `int32_t max_sge_override` parameter on the C `register_segments`. Tests set it to a small positive value to deterministically force `RDMAXCEL_MKEY_REG_LIMIT`.
- `CudaAllocator` / `CudaAllocation` reworked into PyTorch-`ExpandableSegment`-style: a large VA reservation up front and on-demand `expand` calls that mint fresh `cuMemCreate` handles and map them at the next offset. The reported `ptr` stays constant while the scanner-visible `size` grows, which is what drives `register_segments` down the rebind path.
- `SenderActor::Register` and `ReceiverActor::ReadRemote`/`WriteRemote` take caller-specified `pattern` / `expected_pattern` bytes; sender pre-fills via `RdmaLocalMemory::write_at`, receiver pre-fills the destination with `!expected_pattern` and verifies every byte equals `expected_pattern` after the read. Catches both WR-level failures and silent corruption.
- Tests:
  - `test_lookup_segment_respects_mr_size_when_scanner_reports_larger_phys_size` — pure unit test on the boundary helper with synthetic segment info.
  - `test_indirect_mkey_rebind_grows_existing_segment` — success path: distinct segments get distinct mkeys; expanding a segment and registering in the new chunk shares the same mkey after rebind.
  - `test_indirect_mkey_rebind_falls_back_to_dmabuf_at_max_sge` — failure path: with `max_sge_override = 1`, the second `register_segments` call returns `RDMAXCEL_MKEY_REG_LIMIT`, leaving `phys_size > mr_size`; subsequent registrations in the gap must fall through to dmabuf.

Differential Revision: [D103797452](https://our.internmc.facebook.com/intern/diff/D103797452/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D103797452/)!