### PR TITLE
[monarch][rdma] adaptive PollSleepPolicy for completion polling

### DIFF
--- a/monarch_rdma/Cargo.toml
+++ b/monarch_rdma/Cargo.toml
@@ -10,6 +10,7 @@ license = "BSD-3-Clause"
 [dependencies]
 anyhow = "1.0.102"
 async-trait = "0.1.86"
+backoff = { version = "0.4.0", features = ["futures", "tokio"] }
 bytes = { version = "1.11.1", features = ["serde"] }
 dashmap = { version = "6.1.0", features = ["rayon", "serde"] }
 erased-serde = "0.4.10"

--- a/monarch_rdma/src/backend/ibverbs/manager_actor.rs
+++ b/monarch_rdma/src/backend/ibverbs/manager_actor.rs
@@ -25,6 +25,9 @@ use std::time::Instant;
 
 use anyhow::Result;
 use async_trait::async_trait;
+use backoff::ExponentialBackoff;
+use backoff::ExponentialBackoffBuilder;
+use backoff::backoff::Backoff;
 use futures::lock::Mutex;
 use hyperactor as reference;
 use hyperactor::Actor;
@@ -143,6 +146,69 @@ pub enum IbvManagerLocalMessage {
         #[reply]
         reply: OncePortHandle<Result<(), String>>,
     },
+}
+
+/// Adaptive wait between completion polls.
+///
+/// While the elapsed time since [`Self::yield_now`] was first called
+/// is below `yield_window`, the policy yields cooperatively
+/// (`tokio::task::yield_now`) — keeping latency tight when the WR
+/// completes shortly after being posted. `tokio::time::sleep` has a
+/// minimum resolution of ~1ms (the timer wheel tick), so even a
+/// `sleep(Duration::from_micros(100))` would block that long; `yield_now` is
+/// sub-millisecond and lets the next poll fire as soon as the runtime
+/// schedules us. Past `yield_window` the policy switches to an
+/// exponential backoff (1ms initial, doubling, capped at 10ms) so
+/// long-running operations don't keep the runtime spinning.
+///
+/// `yield_window` is read from
+/// [`crate::config::RDMA_CQ_BUSY_POLL_WINDOW`]. When it's `None`
+/// (the default) the policy disables the cutoff and only ever
+/// yields, never sleeps.
+struct PollSleepPolicy {
+    yield_window: Option<Duration>,
+    started_at: Option<Instant>,
+    backoff: Option<ExponentialBackoff>,
+}
+
+impl PollSleepPolicy {
+    fn new() -> Self {
+        let yield_window = hyperactor_config::global::get(crate::config::RDMA_CQ_BUSY_POLL_WINDOW);
+        Self {
+            yield_window,
+            started_at: None,
+            backoff: None,
+        }
+    }
+
+    /// Suspend the current task before the next poll. If no yield
+    /// window is configured (the default), always yields. Otherwise,
+    /// yields while within the window and then walks an exponential
+    /// backoff up to 10ms past it.
+    async fn yield_now(&mut self) {
+        let Some(window) = self.yield_window else {
+            tokio::task::yield_now().await;
+            return;
+        };
+        let started = *self.started_at.get_or_insert_with(Instant::now);
+        if started.elapsed() < window {
+            tokio::task::yield_now().await;
+            return;
+        }
+        let backoff = self.backoff.get_or_insert_with(|| {
+            ExponentialBackoffBuilder::new()
+                .with_initial_interval(Duration::from_millis(1))
+                .with_max_interval(Duration::from_millis(10))
+                .with_multiplier(2.0)
+                .with_randomization_factor(0.0)
+                .with_max_elapsed_time(None)
+                .build()
+        });
+        match backoff.next_backoff() {
+            Some(delay) => tokio::time::sleep(delay).await,
+            None => tokio::task::yield_now().await,
+        }
+    }
 }
 
 /// Look up `(addr, size)` in a slice of registered CUDA segments
@@ -1078,6 +1144,7 @@ impl IbvBackend {
 
         let mut remaining: std::collections::HashSet<u64> =
             expected_wr_ids.iter().copied().collect();
+        let mut poll_policy = PollSleepPolicy::new();
 
         while start_time.elapsed() < timeout {
             if remaining.is_empty() {
@@ -1093,7 +1160,7 @@ impl IbvBackend {
                     if remaining.is_empty() {
                         return Ok(());
                     }
-                    tokio::time::sleep(Duration::from_millis(1)).await;
+                    poll_policy.yield_now().await;
                 }
                 Err(e) => {
                     // When the returned error is WR_FLUSH_ERR, which is generally a

--- a/monarch_rdma/src/config.rs
+++ b/monarch_rdma/src/config.rs
@@ -8,6 +8,8 @@
 
 //! RDMA configuration attributes.
 
+use std::time::Duration;
+
 use hyperactor_config::CONFIG;
 use hyperactor_config::ConfigAttr;
 use hyperactor_config::attrs::declare_attrs;
@@ -53,4 +55,16 @@ declare_attrs! {
         Some("rdma_tcp_fallback_parallelism".to_string()),
     ))
     pub attr RDMA_TCP_FALLBACK_PARALLELISM: usize = 1;
+
+    /// Cooperative-yield window for the ibverbs CQ poll loop. While
+    /// the policy is within this window it calls
+    /// `tokio::task::yield_now` between polls; past it, polls fall
+    /// into an exponential backoff sleep (1ms initial, x2, capped at
+    /// 10ms). `None` (the default) disables the cutoff entirely:
+    /// the loop only ever yields, never sleeps.
+    @meta(CONFIG = ConfigAttr::new(
+        Some("MONARCH_RDMA_CQ_BUSY_POLL_WINDOW".to_string()),
+        Some("rdma_cq_busy_poll_window".to_string()),
+    ))
+    pub attr RDMA_CQ_BUSY_POLL_WINDOW: Option<Duration> = None;
 }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #3773
* __->__ #3771
* #3769

The completion-polling loop in `IbvBackend::wait_for_completion` previously slept a fixed 1ms between `poll_completion` calls. That set a hard lower bound on a hot path: any WR that wasn't already in the CQ on the first poll waited at least 1ms even if the next poll would have caught it microseconds later.

Replaces the fixed sleep with a `PollSleepPolicy` helper. While the elapsed time since the first poll is below a configurable yield window, the policy yields cooperatively via `tokio::task::yield_now` — keeping latency tight when completions land shortly after the WR is posted. Past the window it switches to an exponential backoff (1ms initial, x2 multiplier, capped at 10ms) so long-running operations don't keep the runtime spinning.

The yield window is exposed as a new config attr `RDMA_CQ_BUSY_POLL_WINDOW: Option<Duration>` (env `MONARCH_RDMA_CQ_BUSY_POLL_WINDOW`). The default is `None` — the policy disables the cutoff and only ever yields, never sleeps. Setting it to e.g. `Some(Duration::from_millis(5))` re-enables the 5ms cutoff for environments where unbounded yielding starves CPU clients.

**Benchmark results at this commit** (`multihost_rdma_benchmark.py`, `--cross-host`, c=1, `--procs-per-host 1`, `--sends-per-actor 20`, `--runs-per-config 3`, `--warmup 5`, ibverbs; median per-actor throughput in GB/s). Three settings of `RDMA_CQ_BUSY_POLL_WINDOW`: `Some(Duration::from_millis(1))`, `Some(Duration::from_millis(5))`, and the new default `None` (yield-only). Each cell shows absolute GB/s plus delta vs the baseline (the previous commit, which still uses the original fixed 1ms `tokio::time::sleep`) in parentheses as `(ΔGB/s, Δ%)`.

**GB200 / CPU client (cross-host):**

| Payload | Direction | Prev    | 1 ms                       | 5 ms                       | None                       |
|---------|-----------|-------|----------------------------|----------------------------|----------------------------|
| 16 MB   | Read      |  4.23 |  6.81 (+2.58,  +61%)       |  6.56 (+2.33,  +55%)       |  9.85 (+5.62, +133%)       |
| 16 MB   | Write     |  4.29 | 12.79 (+8.50, +198%)       | 11.67 (+7.38, +172%)       | 15.34 (+11.05, +258%)      |
| 64 MB   | Read      | 13.31 | 11.69 (−1.62,  −12%)       | 17.42 (+4.11,  +31%)       | 19.27 (+5.96,  +45%)       |
| 64 MB   | Write     | 20.84 | 16.67 (−4.17,  −20%)       | 25.35 (+4.51,  +22%)       | 29.21 (+8.37,  +40%)       |
| 256 MB  | Read      | 29.95 | 30.41 (+0.46,   +2%)       | 27.35 (−2.60,   −9%)       | 26.17 (−3.78,  −13%)       |
| 256 MB  | Write     | 32.33 | 33.70 (+1.37,   +4%)       | 29.98 (−2.35,   −7%)       | 31.29 (−1.04,   −3%)       |
| 512 MB  | Read      | 32.81 | 21.31 (−11.50, −35%)       | 26.59 (−6.22,  −19%)       | 28.77 (−4.04,  −12%)       |
| 512 MB  | Write     | 32.91 | 37.81 (+4.90,  +15%)       | 29.20 (−3.71,  −11%)       | 33.07 (+0.16,   +0%)       |

**GB200 / GPU client (cross-host):**

| Payload | Direction | Prev    | 1 ms                       | 5 ms                       | None                       |
|---------|-----------|-------|----------------------------|----------------------------|----------------------------|
| 16 MB   | Read      |  4.42 |  8.02 (+3.60,  +81%)       |  6.86 (+2.44,  +55%)       |  8.25 (+3.83,  +87%)       |
| 16 MB   | Write     |  4.72 | 12.77 (+8.05, +171%)       | 12.52 (+7.80, +165%)       | 16.20 (+11.48, +243%)      |
| 64 MB   | Read      | 14.15 | 13.63 (−0.52,   −4%)       | 20.81 (+6.66,  +47%)       | 19.07 (+4.92,  +35%)       |
| 64 MB   | Write     | 21.61 | 16.19 (−5.42,  −25%)       | 27.46 (+5.85,  +27%)       | 28.32 (+6.71,  +31%)       |
| 256 MB  | Read      | 25.42 | 19.88 (−5.54,  −22%)       | 20.96 (−4.46,  −18%)       | 27.35 (+1.93,   +8%)       |
| 256 MB  | Write     | 33.25 | 35.17 (+1.92,   +6%)       | 29.28 (−3.97,  −12%)       | 39.84 (+6.59,  +20%)       |
| 512 MB  | Read      | 31.73 | 22.46 (−9.27,  −29%)       | 30.41 (−1.32,   −4%)       | 31.61 (−0.12,   −0%)       |
| 512 MB  | Write     | 36.89 | 42.25 (+5.36,  +15%)       | 31.85 (−5.04,  −14%)       | 42.52 (+5.63,  +15%)       |

**Grandteton / CPU client (cross-host):**

| Payload | Direction | Prev    | 1 ms                       | 5 ms                       | None                       |
|---------|-----------|-------|----------------------------|----------------------------|----------------------------|
| 16 MB   | Read      |  4.52 |  8.14 (+3.62,  +80%)       |  6.66 (+2.14,  +47%)       |  6.88 (+2.36,  +52%)       |
| 16 MB   | Write     |  5.63 | 14.28 (+8.65, +154%)       |  9.73 (+4.10,  +73%)       | 10.31 (+4.68,  +83%)       |
| 64 MB   | Read      | 17.74 | 14.38 (−3.36,  −19%)       | 12.26 (−5.48,  −31%)       | 12.07 (−5.67,  −32%)       |
| 64 MB   | Write     | 20.98 | 15.60 (−5.38,  −26%)       | 15.87 (−5.11,  −24%)       | 12.56 (−8.42,  −40%)       |
| 256 MB  | Read      | 23.53 | 19.02 (−4.51,  −19%)       | 13.30 (−10.23, −43%)       | 15.75 (−7.78,  −33%)       |
| 256 MB  | Write     | 31.36 | 33.94 (+2.58,   +8%)       | 17.38 (−13.98, −45%)       | 19.97 (−11.39, −36%)       |
| 512 MB  | Read      | 26.07 | 21.24 (−4.83,  −19%)       | 13.06 (−13.01, −50%)       | 16.50 (−9.57,  −37%)       |
| 512 MB  | Write     | 34.26 | 23.31 (−10.95, −32%)       | 17.05 (−17.21, −50%)       | 21.38 (−12.88, −38%)       |

**Grandteton / GPU client (cross-host):**

| Payload | Direction | Prev    | 1 ms                       | 5 ms                       | None                       |
|---------|-----------|-------|----------------------------|----------------------------|----------------------------|
| 16 MB   | Read      |  5.33 | 10.31 (+4.98,  +93%)       | 10.40 (+5.07,  +95%)       | 10.22 (+4.89,  +92%)       |
| 16 MB   | Write     |  6.34 | 18.60 (+12.26, +193%)      | 17.97 (+11.63, +183%)      | 16.51 (+10.17, +160%)      |
| 64 MB   | Read      | 12.80 | 15.49 (+2.69,  +21%)       | 20.10 (+7.30,  +57%)       | 20.74 (+7.94,  +62%)       |
| 64 MB   | Write     | 24.83 | 17.70 (−7.13,  −29%)       | 31.43 (+6.60,  +27%)       | 32.62 (+7.79,  +31%)       |
| 256 MB  | Read      | 22.07 | 20.43 (−1.64,   −7%)       | 22.87 (+0.80,   +4%)       | 26.92 (+4.85,  +22%)       |
| 256 MB  | Write     | 37.84 | 36.57 (−1.27,   −3%)       | 32.74 (−5.10,  −13%)       | 40.93 (+3.09,   +8%)       |
| 512 MB  | Read      | 25.99 | 23.77 (−2.22,   −9%)       | 20.02 (−5.97,  −23%)       | 28.46 (+2.47,  +10%)       |
| 512 MB  | Write     | 39.22 | 41.99 (+2.77,   +7%)       | 32.31 (−6.91,  −18%)       | 43.16 (+3.94,  +10%)       |

The pattern: more yielding helps GPU and ≤64 MB transfers (where the previous fixed 1ms sleep was blocking past the actual completion), often by very large margins; the new `None` default outperforms the baseline on the GB200 slots and Grandteton/GPU. Grandteton/CPU is the inverse — `None` and `Some(5ms)` both lose to the baseline because unparked polling threads compete with other work on the same CPU cores. That's the motivation for keeping the cutoff configurable rather than hard-coding the new default.

Differential Revision: [D103797533](https://our.internmc.facebook.com/intern/diff/D103797533/)