### PR TITLE
lints (#3772)

### DIFF
--- a/hyperactor/src/mailbox.rs
+++ b/hyperactor/src/mailbox.rs
@@ -3300,7 +3300,7 @@ mod tests {
         let mbox = Mailbox::new_detached(test_actor_id("0", "test"));
         let port_index = mbox.allocate_port();
         let port_id = mbox.actor_addr().port_addr(Port::from(port_index));
-        let port = crate::PortRef::attest(port_id.clone().into());
+        let port = crate::PortRef::attest(port_id.clone());
         let (return_handle, mut return_receiver) =
             crate::mailbox::undeliverable::new_undeliverable_port();
         let (sender, receiver) = mpsc::unbounded_channel::<u64>();

--- a/hyperactor_mesh/src/host.rs
+++ b/hyperactor_mesh/src/host.rs
@@ -2503,7 +2503,7 @@ mod tests {
                 let client_proc = Proc::configured(client_proc_id, dial_router.into_boxed());
                 let _client_handle = client_proc.clone().serve(client_rx);
 
-                let echo_ref = ActorRef::<EchoActor>::attest(echo_actor_id.into());
+                let echo_ref = ActorRef::<EchoActor>::attest(echo_actor_id);
 
                 for ri in 0..M_REQUESTS {
                     let (client_inst, _h) = client_proc.instance(&format!("req-{}", ri)).unwrap();

--- a/monarch_extension/src/client.rs
+++ b/monarch_extension/src/client.rs
@@ -413,7 +413,7 @@ impl ClientActor {
             reference::ActorRef::<ControllerActor>::attest(reference::ActorAddr::from(
                 &controller_id,
             ))
-            .attach(&instance, reference::ActorRef::attest(actor_id.into()))
+            .attach(&instance, reference::ActorRef::attest(actor_id))
             .await
             .map_err(|err| PyRuntimeError::new_err(err.to_string()))
         })?

--- a/monarch_extension/src/mesh_controller.rs
+++ b/monarch_extension/src/mesh_controller.rs
@@ -781,7 +781,7 @@ impl MeshControllerActor {
     ) -> anyhow::Result<()> {
         if matches!(action, DebuggerAction::Paused()) {
             self.debugger_paused
-                .push_back(reference::ActorRef::attest(debugger_actor_id.into()));
+                .push_back(reference::ActorRef::attest(debugger_actor_id));
         } else {
             let debugger_actor = self
                 .debugger_active

--- a/monarch_hyperactor/src/actor.rs
+++ b/monarch_hyperactor/src/actor.rs
@@ -1795,7 +1795,7 @@ mod tests {
             builder_params: Some(wirevalue::Any::serialize(&"abcdefg12345".to_string()).unwrap()),
         };
         let port_ref = hyperactor::PortRef::<PythonMessage>::attest_reducible(
-            test_port_id("world_0", "client", 123).into(),
+            test_port_id("world_0", "client", 123),
             Some(reducer_spec),
             StreamingReducerOpts::default(),
         );


### PR DESCRIPTION
Summary:

lints, glorious lints.

___

overriding_review_checks_triggers_an_audit_and_retroactive_review
Oncall Short Name: monarch_kubernetes_aws

Reviewed By: thedavekwon

Differential Revision: D103922278


