### PR TITLE
[monarch][rdma] make resolve_ibv synchronous: ship IbvBuffer eagerly in RdmaRemoteBackendContext

### DIFF
--- a/monarch_rdma/examples/cuda_ping_pong/src/cuda_ping_pong.rs
+++ b/monarch_rdma/examples/cuda_ping_pong/src/cuda_ping_pong.rs
@@ -503,15 +503,13 @@ impl Handler<PerformPingPong> for CudaRdmaActor {
             cu_check!(rdmaxcel_sys::rdmaxcel_cuCtxSetCurrent(context));
         }
 
-        // Resolve IbvManagerActor refs and IbvBuffers from backends
+        // Extract IbvManagerActor refs and IbvBuffers from backends
         let (local_ibv_manager, local_ibv) = local_buffer
-            .resolve_ibv(cx)
-            .await
-            .ok_or_else(|| anyhow::anyhow!("ibverbs backend not found for local buffer"))??;
+            .resolve_ibv()
+            .ok_or_else(|| anyhow::anyhow!("ibverbs backend not found for local buffer"))?;
         let (remote_ibv_manager, remote_ibv) = remote_buffer
-            .resolve_ibv(cx)
-            .await
-            .ok_or_else(|| anyhow::anyhow!("ibverbs backend not found for remote buffer"))??;
+            .resolve_ibv()
+            .ok_or_else(|| anyhow::anyhow!("ibverbs backend not found for remote buffer"))?;
 
         let qp = local_ibv_manager
             .request_queue_pair(

--- a/monarch_rdma/src/backend.rs
+++ b/monarch_rdma/src/backend.rs
@@ -14,7 +14,6 @@ pub mod ibverbs;
 pub mod tcp;
 
 use std::fmt::Debug;
-use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::Result;
@@ -22,7 +21,6 @@ use async_trait::async_trait;
 use hyperactor as reference;
 use serde::Deserialize;
 use serde::Serialize;
-use tokio::sync::OnceCell;
 
 use crate::RdmaOp;
 use crate::RdmaTransportLevel;
@@ -31,50 +29,13 @@ use crate::RdmaTransportLevel;
 ///
 /// Each variant holds the information needed to perform RDMA operations
 /// using that backend on a particular buffer.
-///
-/// The [`OnceCell`] is lazily populated at runtime and excluded from
-/// serialization; deserializing produces an empty cell.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum RdmaRemoteBackendContext {
     Ibverbs(
         reference::ActorRef<ibverbs::manager_actor::IbvManagerActor>,
-        Arc<OnceCell<ibverbs::IbvBuffer>>,
+        ibverbs::IbvBuffer,
     ),
     Tcp(reference::ActorRef<tcp::manager_actor::TcpManagerActor>),
-}
-
-impl Serialize for RdmaRemoteBackendContext {
-    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        match self {
-            RdmaRemoteBackendContext::Ibverbs(actor_ref, _) => serializer
-                .serialize_newtype_variant("RdmaRemoteBackendContext", 0, "Ibverbs", actor_ref),
-            RdmaRemoteBackendContext::Tcp(actor_ref) => serializer.serialize_newtype_variant(
-                "RdmaRemoteBackendContext",
-                1,
-                "Tcp",
-                actor_ref,
-            ),
-        }
-    }
-}
-
-impl<'de> Deserialize<'de> for RdmaRemoteBackendContext {
-    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
-        #[derive(Deserialize)]
-        #[serde(rename = "RdmaRemoteBackendContext")]
-        enum Repr {
-            Ibverbs(reference::ActorRef<ibverbs::manager_actor::IbvManagerActor>),
-            Tcp(reference::ActorRef<tcp::manager_actor::TcpManagerActor>),
-        }
-
-        match Repr::deserialize(deserializer)? {
-            Repr::Ibverbs(actor_ref) => Ok(RdmaRemoteBackendContext::Ibverbs(
-                actor_ref,
-                Arc::new(OnceCell::new()),
-            )),
-            Repr::Tcp(actor_ref) => Ok(RdmaRemoteBackendContext::Tcp(actor_ref)),
-        }
-    }
 }
 
 /// Backend for executing RDMA operations over a specific transport.

--- a/monarch_rdma/src/backend/ibverbs/manager_actor.rs
+++ b/monarch_rdma/src/backend/ibverbs/manager_actor.rs
@@ -953,9 +953,8 @@ impl IbvManagerMessageHandler for IbvManagerActor {
         }
 
         // The domain is guaranteed to exist here: register_mr is always called before
-        // initialize_qp, either in execute_op (for the local actor) or in
-        // register_remote_buffer at buffer-creation time (for the remote actor),
-        // and register_mr always calls get_or_create_device_domain.
+        // initialize_qp, either in execute_op or in register_remote_buffer at
+        // buffer-creation time, and register_mr always calls get_or_create_device_domain.
         let (domain, _) = self.device_domains.get(&self_device).ok_or_else(|| {
             anyhow::anyhow!(
                 "device domain for '{}' not found; register_mr must be called before initialize_qp",

--- a/monarch_rdma/src/backend/ibverbs/manager_actor.rs
+++ b/monarch_rdma/src/backend/ibverbs/manager_actor.rs
@@ -59,33 +59,18 @@ use crate::RdmaOp;
 use crate::RdmaOpType;
 use crate::RdmaTransportLevel;
 use crate::backend::RdmaBackend;
+use crate::local_memory::RdmaLocalMemory;
 use crate::rdma_components::get_registered_cuda_segments;
 use crate::rdma_manager_actor::GetIbvActorRefClient;
 use crate::rdma_manager_actor::RdmaManagerActor;
-use crate::rdma_manager_actor::RdmaManagerMessageClient;
 use crate::rdma_manager_actor::get_rdmaxcel_error_message;
 use crate::validate_execution_context;
 
 /// Messages handled by [`IbvManagerActor`].
 #[derive(Handler, HandleClient, RefClient, Debug, Serialize, Deserialize, Named)]
 pub enum IbvManagerMessage {
-    /// Register the MR for a buffer identified by `remote_buf_id`. Resolves
-    /// the local memory via the parent [`RdmaManagerActor`]'s
-    /// `RequestLocalMemory`, registers it as an ibverbs MR, and returns
-    /// the resulting [`IbvBuffer`].
-    ///
-    /// Returns `None` if the buffer has already been released or does not
-    /// exist.
-    RequestBuffer {
-        remote_buf_id: usize,
-        #[reply]
-        reply: reference::OncePortRef<Option<IbvBuffer>>,
-    },
-    /// Release a buffer registration by `remote_buf_id`.
-    /// IMPORTANT: This needs to be fire-and-forget (no reply port)
-    /// to avoid a circular deadlock where RdmaManagerActor waits for
-    /// IbvManagerMessage::ReleaseBuffer while IbvManagerActor waits for
-    /// RdmaManagerMessage::RequestLocalMemory.
+    /// Release a buffer registration by `remote_buf_id`. Fire-and-forget
+    /// (no reply port) to avoid blocking the caller during teardown.
     ReleaseBuffer { remote_buf_id: usize },
     RequestQueuePair {
         other: reference::ActorRef<IbvManagerActor>,
@@ -145,6 +130,19 @@ pub enum IbvManagerLocalMessage {
         id: usize,
         #[reply]
         reply: OncePortHandle<Result<(), String>>,
+    },
+    /// Register a remote-facing buffer's MR and return its
+    /// [`IbvBuffer`]. Called by
+    /// [`crate::rdma_manager_actor::RdmaManagerActor::request_buffer`]
+    /// at buffer-creation time.
+    ///
+    /// The MR lives in [`IbvManagerActor::buffer_registrations`] and
+    /// is deregistered on [`IbvManagerMessage::ReleaseBuffer`].
+    RegisterRemoteBuffer {
+        remote_buf_id: usize,
+        local: Arc<dyn RdmaLocalMemory>,
+        #[reply]
+        reply: OncePortHandle<Result<IbvBuffer, String>>,
     },
 }
 
@@ -874,41 +872,6 @@ impl IbvManagerActor {
 #[async_trait]
 #[hyperactor::handle(IbvManagerMessage)]
 impl IbvManagerMessageHandler for IbvManagerActor {
-    async fn request_buffer(
-        &mut self,
-        cx: &Context<Self>,
-        remote_buf_id: usize,
-    ) -> Result<Option<IbvBuffer>, anyhow::Error> {
-        // If already registered, return it
-        if let Some(buf) = self.buffer_registrations.get(&remote_buf_id) {
-            return Ok(Some(buf.clone()));
-        }
-
-        // Resolve local memory from the parent RdmaManagerActor.
-        // Returns None if the buffer has already been released or does
-        // not exist.
-        let owner = self.owner.get().unwrap();
-        let mem = match owner.request_local_memory(cx, remote_buf_id).await? {
-            Some(mem) => mem,
-            None => return Ok(None),
-        };
-
-        let (mrv, device_name) = self.register_mr_impl(mem.addr(), mem.size())?;
-
-        let buf = IbvBuffer {
-            mr_id: mrv.id,
-            lkey: mrv.lkey,
-            rkey: mrv.rkey,
-            addr: mrv.rdma_addr,
-            size: mrv.size,
-            device_name,
-        };
-
-        self.buffer_registrations.insert(remote_buf_id, buf.clone());
-
-        Ok(Some(buf))
-    }
-
     async fn release_buffer(
         &mut self,
         _cx: &Context<Self>,
@@ -990,8 +953,9 @@ impl IbvManagerMessageHandler for IbvManagerActor {
         }
 
         // The domain is guaranteed to exist here: register_mr is always called before
-        // initialize_qp, either in execute_op (for the local actor) or via resolve_ibv
-        // (for the remote actor), and register_mr always calls get_or_create_device_domain.
+        // initialize_qp, either in execute_op (for the local actor) or in
+        // register_remote_buffer at buffer-creation time (for the remote actor),
+        // and register_mr always calls get_or_create_device_domain.
         let (domain, _) = self.device_domains.get(&self_device).ok_or_else(|| {
             anyhow::anyhow!(
                 "device domain for '{}' not found; register_mr must be called before initialize_qp",
@@ -1111,6 +1075,31 @@ impl IbvManagerLocalMessageHandler for IbvManagerActor {
         id: usize,
     ) -> Result<Result<(), String>, anyhow::Error> {
         Ok(self.deregister_mr_impl(id).map_err(|e| e.to_string()))
+    }
+
+    async fn register_remote_buffer(
+        &mut self,
+        _cx: &Context<Self>,
+        remote_buf_id: usize,
+        local: Arc<dyn RdmaLocalMemory>,
+    ) -> Result<Result<IbvBuffer, String>, anyhow::Error> {
+        if let Some(buf) = self.buffer_registrations.get(&remote_buf_id) {
+            return Ok(Ok(buf.clone()));
+        }
+        let (mrv, device_name) = match self.register_mr_impl(local.addr(), local.size()) {
+            Ok(v) => v,
+            Err(e) => return Ok(Err(e.to_string())),
+        };
+        let buf = IbvBuffer {
+            mr_id: mrv.id,
+            lkey: mrv.lkey,
+            rkey: mrv.rkey,
+            addr: mrv.rdma_addr,
+            size: mrv.size,
+            device_name,
+        };
+        self.buffer_registrations.insert(remote_buf_id, buf.clone());
+        Ok(Ok(buf))
     }
 }
 
@@ -1288,18 +1277,14 @@ impl RdmaBackend for IbvBackend {
     ) -> Result<(), anyhow::Error> {
         let mut ibv_ops = Vec::with_capacity(ops.len());
         for op in ops {
-            let (remote_ibv_mgr, remote_ibv_buffer): (
-                reference::ActorRef<IbvManagerActor>,
-                IbvBuffer,
-            ) = op.remote.resolve_ibv(cx).await.ok_or_else(|| {
+            let (remote_manager, remote_buffer) = op.remote.resolve_ibv().ok_or_else(|| {
                 anyhow::anyhow!("ibverbs backend not found for buffer: {:?}", op.remote)
-            })??;
-
+            })?;
             ibv_ops.push(IbvOp {
                 op_type: op.op_type,
                 local_memory: op.local.clone(),
-                remote_buffer: remote_ibv_buffer,
-                remote_manager: remote_ibv_mgr,
+                remote_buffer,
+                remote_manager,
             });
         }
 

--- a/monarch_rdma/src/backend/ibverbs/mlx5dv_tests.rs
+++ b/monarch_rdma/src/backend/ibverbs/mlx5dv_tests.rs
@@ -8,7 +8,6 @@
 
 //! Tests for mlx5dv-specific functionality (indirect mkeys, segment scanning).
 
-use hyperactor::context as actor_context;
 use hyperactor_mesh::ActorMesh;
 use hyperactor_mesh::context;
 use hyperactor_mesh::host_mesh::HostMesh;
@@ -127,17 +126,11 @@ async fn test_indirect_mkey_read_at_large_offset() -> Result<(), anyhow::Error> 
     Ok(())
 }
 
-/// Resolve the ibverbs `(lkey, rkey)` of a remote buffer. Async
-/// because the `IbvBuffer` is lazily fetched from the owning
-/// `IbvManagerActor`.
-async fn ibv_keys_of(
-    cx: &(impl actor_context::Actor + Send + Sync),
-    remote: &crate::RdmaRemoteBuffer,
-) -> Result<(u32, u32), anyhow::Error> {
+/// Extract the ibverbs `(lkey, rkey)` from a remote buffer.
+fn ibv_keys_of(remote: &crate::RdmaRemoteBuffer) -> Result<(u32, u32), anyhow::Error> {
     let (_mgr, buf) = remote
-        .resolve_ibv(cx)
-        .await
-        .ok_or_else(|| anyhow::anyhow!("remote buffer has no ibverbs backend context"))??;
+        .resolve_ibv()
+        .ok_or_else(|| anyhow::anyhow!("remote buffer has no ibverbs backend context"))?;
     Ok((buf.lkey, buf.rkey))
 }
 
@@ -229,8 +222,8 @@ async fn test_indirect_mkey_rebind_grows_existing_segment() -> Result<(), anyhow
         .next()
         .expect("buf B");
 
-    let (lkey_a, rkey_a) = ibv_keys_of(instance, &buf_a).await?;
-    let (lkey_b, rkey_b) = ibv_keys_of(instance, &buf_b).await?;
+    let (lkey_a, rkey_a) = ibv_keys_of(&buf_a)?;
+    let (lkey_b, rkey_b) = ibv_keys_of(&buf_b)?;
     assert_ne!(
         (lkey_a, rkey_a),
         (lkey_b, rkey_b),
@@ -247,7 +240,7 @@ async fn test_indirect_mkey_rebind_grows_existing_segment() -> Result<(), anyhow
         .next()
         .expect("buf C");
 
-    let (lkey_c, rkey_c) = ibv_keys_of(instance, &buf_c).await?;
+    let (lkey_c, rkey_c) = ibv_keys_of(&buf_c)?;
     assert_eq!(
         (lkey_c, rkey_c),
         (lkey_a, rkey_a),
@@ -418,9 +411,9 @@ async fn test_indirect_mkey_rebind_falls_back_to_dmabuf_at_max_sge() -> Result<(
     // indirect mkey — sanity check that the override took effect.
     // Buf C lands at an address inside the [mr_size, phys_size) gap;
     // it must also fall through to dmabuf and get a distinct lkey.
-    let (lkey_a, _) = ibv_keys_of(instance, &buf_a).await?;
-    let (lkey_b, _) = ibv_keys_of(instance, &buf_b).await?;
-    let (lkey_c, _) = ibv_keys_of(instance, &buf_c).await?;
+    let (lkey_a, _) = ibv_keys_of(&buf_a)?;
+    let (lkey_b, _) = ibv_keys_of(&buf_b)?;
+    let (lkey_c, _) = ibv_keys_of(&buf_c)?;
     assert_ne!(
         lkey_a, lkey_b,
         "buf B should be registered via the dmabuf fallback after \

--- a/monarch_rdma/src/backend/ibverbs/test_utils.rs
+++ b/monarch_rdma/src/backend/ibverbs/test_utils.rs
@@ -200,8 +200,7 @@ impl Handler<CudaActorMessage> for CudaActor {
                     (dptr as usize, padded_size)
                 };
 
-                // Register via RdmaManagerActor request_buffer; the ibverbs MR
-                // will be registered lazily by resolve_ibv().
+                // Register via RdmaManagerActor request_buffer.
                 let local_memory: Arc<dyn RdmaLocalMemory> =
                     Arc::new(UnsafeLocalMemory::new(dptr, padded_size));
                 let handle = rdma_actor
@@ -639,15 +638,12 @@ impl IbvTestEnv {
             cuda_actor_2 = Some(cuda_actor_ref_2);
         }
 
-        // Resolve ibverbs details lazily via resolve_ibv
         let (ibv_actor_1, ibv_buffer_1) = rdma_handle_1
-            .resolve_ibv(&instance_1)
-            .await
-            .ok_or_else(|| anyhow::anyhow!("ibverbs backend not found for buffer 1"))??;
+            .resolve_ibv()
+            .ok_or_else(|| anyhow::anyhow!("ibverbs backend not found for buffer 1"))?;
         let (ibv_actor_2, ibv_buffer_2) = rdma_handle_2
-            .resolve_ibv(&instance_2)
-            .await
-            .ok_or_else(|| anyhow::anyhow!("ibverbs backend not found for buffer 2"))??;
+            .resolve_ibv()
+            .ok_or_else(|| anyhow::anyhow!("ibverbs backend not found for buffer 2"))?;
 
         // Fill buffer1 with test data
         if parsed_accel1.0 == "cuda" {

--- a/monarch_rdma/src/rdma_components.rs
+++ b/monarch_rdma/src/rdma_components.rs
@@ -62,7 +62,6 @@ use crate::backend::RdmaRemoteBackendContext;
 use crate::backend::ibverbs::IbvBuffer;
 use crate::backend::ibverbs::manager_actor::IbvBackend;
 use crate::backend::ibverbs::manager_actor::IbvManagerActor;
-use crate::backend::ibverbs::manager_actor::IbvManagerMessageClient;
 use crate::backend::tcp::manager_actor::TcpBackend;
 use crate::backend::tcp::manager_actor::TcpManagerActor;
 use crate::local_memory::RdmaLocalMemory;
@@ -213,42 +212,18 @@ impl RdmaRemoteBuffer {
             .any(|b| matches!(b, RdmaRemoteBackendContext::Ibverbs(..)))
     }
 
-    /// Resolve the ibverbs backend context for this buffer.
+    /// Extract the ibverbs backend context for this buffer.
     ///
-    /// Returns `None` if the buffer has no ibverbs backend context (i.e.,
-    /// the remote side was created without ibverbs). Returns `Some(Err(...))`
-    /// if the context exists but lazy MR resolution fails. Returns
-    /// `Some(Ok(...))` on success.
-    pub async fn resolve_ibv(
-        &self,
-        client: &impl context::Actor,
-    ) -> Option<Result<(reference::ActorRef<IbvManagerActor>, IbvBuffer), anyhow::Error>> {
-        let (remote_ibv_mgr, remote_ibv_buf): (
-            &reference::ActorRef<IbvManagerActor>,
-            &Arc<tokio::sync::OnceCell<IbvBuffer>>,
-        ) = self.backends.iter().find_map(|b| match b {
-            RdmaRemoteBackendContext::Ibverbs(mgr, buf) => Some((mgr, buf)),
+    /// Returns `None` if the buffer has no ibverbs backend context
+    /// (i.e., the remote side was created without ibverbs).
+    pub fn resolve_ibv(&self) -> Option<(reference::ActorRef<IbvManagerActor>, IbvBuffer)> {
+        self.backends.iter().find_map(|b| match b {
+            RdmaRemoteBackendContext::Ibverbs(mgr, buf) => Some((mgr.clone(), buf.clone())),
             _ => None,
-        })?;
-
-        Some(
-            remote_ibv_buf
-                .get_or_try_init(async || {
-                    remote_ibv_mgr
-                        .request_buffer(client, self.id)
-                        .await?
-                        .ok_or_else(|| anyhow::anyhow!("buffer {} not found", self.id))
-                })
-                .await
-                .cloned()
-                .map(|buf| (remote_ibv_mgr.clone(), buf)),
-        )
+        })
     }
 
     /// Extract the TCP backend context from this buffer.
-    ///
-    /// Unlike [`resolve_ibv`], no lazy initialization is needed -- the
-    /// TCP backend only needs the remote actor ref and the buffer id.
     pub fn resolve_tcp(&self) -> Result<(ActorRef<TcpManagerActor>, usize), anyhow::Error> {
         self.backends
             .iter()

--- a/monarch_rdma/src/rdma_manager_actor.rs
+++ b/monarch_rdma/src/rdma_manager_actor.rs
@@ -42,11 +42,11 @@ use hyperactor::supervision::ActorSupervisionEvent;
 use hyperactor_config::Flattrs;
 use serde::Deserialize;
 use serde::Serialize;
-use tokio::sync::OnceCell;
 use typeuri::Named;
 
 use crate::backend::RdmaRemoteBackendContext;
 use crate::backend::ibverbs::manager_actor::IbvManagerActor;
+use crate::backend::ibverbs::manager_actor::IbvManagerLocalMessageClient;
 use crate::backend::ibverbs::manager_actor::IbvManagerMessageClient;
 use crate::backend::ibverbs::primitives::IbvConfig;
 use crate::backend::tcp::manager_actor::TcpManagerActor;
@@ -289,16 +289,21 @@ impl RdmaManagerMessageHandler for RdmaManagerActor {
         self.next_remote_buf_id += 1;
         let size = local.size();
 
-        self.buffers.insert(remote_buf_id, local);
-
         let mut backends = Vec::new();
 
         if let Some(ibv) = &self.ibverbs {
+            let ibv_buffer = ibv
+                .handle()
+                .register_remote_buffer(cx, remote_buf_id, local.clone())
+                .await?
+                .map_err(|e| anyhow::anyhow!(e))?;
             backends.push(RdmaRemoteBackendContext::Ibverbs(
                 ibv.handle().bind(),
-                Arc::new(OnceCell::new()),
+                ibv_buffer,
             ));
         }
+
+        self.buffers.insert(remote_buf_id, local);
 
         backends.push(RdmaRemoteBackendContext::Tcp(self.tcp.handle().bind()));
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #3773
* #3771
* #3769

Replaces the lazy `Arc<OnceCell<IbvBuffer>>` in `RdmaRemoteBackendContext::Ibverbs` with an inline `IbvBuffer` populated at buffer-creation time. Eliminates the cross-proc round-trip from `RdmaRemoteBuffer::resolve_ibv` on the data path.

Walkthrough:

- `RdmaRemoteBackendContext::Ibverbs` now carries `(ActorRef<IbvManagerActor>, IbvBuffer)`. The struct derives `Serialize`/`Deserialize` directly; the hand-written impls and the `OnceCell` indirection are gone.
- `RdmaManagerActor::request_buffer` now registers the MR eagerly via a new `IbvManagerLocalMessage::RegisterRemoteBuffer { remote_buf_id, local }` actor message. The handler installs the MR in `buffer_registrations` and returns the resulting `IbvBuffer`, which gets shipped inline in the returned `RdmaRemoteBuffer`. The old `IbvManagerMessage::RequestBuffer` (and its `request_buffer` handler) are removed.
- Makes `RdmaRemoteBuffer::resolve_ibv` synchronous: it now just extracts the `(ActorRef, IbvBuffer)` from the backend list, with no remote round-trip needed.
- `IbvBackend::submit`, `mlx5dv_tests::ibv_keys_of`, `test_utils::IbvTestEnv::setup`, and the `cuda_ping_pong` example updated to use the synchronous accessor.

**Benchmark results at this commit** (`multihost_rdma_benchmark.py`, `--cross-host`, c=1, `--procs-per-host 1`, `--sends-per-actor 20`, `--runs-per-config 3`, `--warmup 5`, ibverbs; median per-actor throughput in GB/s; both this commit and the previous-commit baseline run with the new default `RDMA_CQ_BUSY_POLL_WINDOW=None` so the comparison is apples-to-apples). Two deltas are reported per cell: **Δ vs prev** is `+/− GB/s (+/− %)` against the previous commit in the stack (D103797533, after switching to the new yield-only default but before this diff's eager-ship change). **Δ vs base** is against the stack base — the unchanged commit before D103797533 that still uses the original fixed 1ms `tokio::time::sleep` — i.e. the cumulative gain from both diffs.

**GB200 / CPU client:**

| Payload | Read GB/s | Δ vs prev          | Δ vs base           | Write GB/s | Δ vs prev          | Δ vs base           |
|---------|-----------|--------------------|---------------------|------------|--------------------|---------------------|
| 16 MB   |  9.14     | −0.71   (−7.2%)    |  +4.91 (+116.1%)    | 11.88      | −3.46  (−22.6%)    |  +7.59 (+176.9%)    |
| 64 MB   | 27.01     | +7.74  (+40.2%)    | +13.70 (+102.9%)    | 26.29      | −2.92  (−10.0%)    |  +5.45  (+26.2%)    |
| 256 MB  | 33.05     | +6.88  (+26.3%)    |  +3.10  (+10.4%)    | 33.00      | +1.71   (+5.5%)    |  +0.67   (+2.1%)    |
| 512 MB  | 33.06     | +4.29  (+14.9%)    |  +0.25   (+0.8%)    | 38.73      | +5.66  (+17.1%)    |  +5.82  (+17.7%)    |

**GB200 / GPU client:**

| Payload | Read GB/s | Δ vs prev          | Δ vs base           | Write GB/s | Δ vs prev          | Δ vs base           |
|---------|-----------|--------------------|---------------------|------------|--------------------|---------------------|
| 16 MB   | 14.90     | +6.65  (+80.6%)    | +10.48 (+237.1%)    | 16.93      | +0.73   (+4.5%)    | +12.21 (+258.7%)    |
| 64 MB   | 23.42     | +4.35  (+22.8%)    |  +9.27  (+65.5%)    | 28.48      | +0.16   (+0.6%)    |  +6.87  (+31.8%)    |
| 256 MB  | 29.84     | +2.49   (+9.1%)    |  +4.42  (+17.4%)    | 39.40      | −0.44   (−1.1%)    |  +6.15  (+18.5%)    |
| 512 MB  | 32.91     | +1.30   (+4.1%)    |  +1.18   (+3.7%)    | 42.92      | +0.40   (+0.9%)    |  +6.03  (+16.3%)    |

**Grandteton / CPU client:**

| Payload | Read GB/s | Δ vs prev          | Δ vs base           | Write GB/s | Δ vs prev          | Δ vs base           |
|---------|-----------|--------------------|---------------------|------------|--------------------|---------------------|
| 16 MB   |  9.89     | +3.01  (+43.7%)    |  +5.37 (+118.8%)    | 12.85      | +2.54  (+24.6%)    |  +7.22 (+128.2%)    |
| 64 MB   | 19.04     | +6.97  (+57.7%)    |  +1.30   (+7.3%)    | 25.08      | +12.52 (+99.7%)    |  +4.10  (+19.5%)    |
| 256 MB  | 25.71     | +9.96  (+63.2%)    |  +2.18   (+9.3%)    | 34.31      | +14.34 (+71.8%)    |  +2.95   (+9.4%)    |
| 512 MB  | 28.52     | +12.02 (+72.8%)    |  +2.45   (+9.4%)    | 38.58      | +17.20 (+80.5%)    |  +4.32  (+12.6%)    |

**Grandteton / GPU client:**

| Payload | Read GB/s | Δ vs prev          | Δ vs base           | Write GB/s | Δ vs prev          | Δ vs base           |
|---------|-----------|--------------------|---------------------|------------|--------------------|---------------------|
| 16 MB   | 15.14     | +4.92  (+48.1%)    |  +9.81 (+184.1%)    | 18.74      | +2.23  (+13.5%)    | +12.40 (+195.6%)    |
| 64 MB   | 23.98     | +3.24  (+15.6%)    | +11.18  (+87.3%)    | 33.82      | +1.20   (+3.7%)    |  +8.99  (+36.2%)    |
| 256 MB  | 28.30     | +1.38   (+5.1%)    |  +6.23  (+28.2%)    | 41.80      | +0.87   (+2.1%)    |  +3.96  (+10.5%)    |
| 512 MB  | 29.50     | +1.04   (+3.7%)    |  +3.51  (+13.5%)    | 43.73      | +0.57   (+1.3%)    |  +4.51  (+11.5%)    |


The fact that we see disproportionately large wins for reads is more a quirk of the benchmark than a real result. Every read in the benchmark sends the list of `RDMABuffer`s to an actor endpoint, which does one read and returns. Even though these `RDMABuffer`s refer to the same underlying memory on each endpoint call, they are distinct objects and therefore do not have `IbvBuffer` filled in yet. This requires a network roundtrip on *every* read, whereas the network roundtrip is only needed on the *first* write.

Differential Revision: [D103797546](https://our.internmc.facebook.com/intern/diff/D103797546/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D103797546/)!