### PR TITLE
traced decorator (#3774)

### DIFF
--- a/python/monarch/_src/actor/telemetry/__init__.py
+++ b/python/monarch/_src/actor/telemetry/__init__.py
@@ -7,9 +7,11 @@
 # pyre-strict
 
 
+import functools
+import inspect
 import logging
 import warnings
-from typing import Optional, Sequence
+from typing import Callable, Optional, overload, Sequence, TypeVar
 
 import opentelemetry.metrics as metrics  # @manual=fbsource//third-party/pypi/opentelemetry-api:opentelemetry-api
 import opentelemetry.trace as trace  # @manual=fbsource//third-party/pypi/opentelemetry-api:opentelemetry-api
@@ -24,6 +26,7 @@ from monarch._rust_bindings.monarch_hyperactor.telemetry import (  # @manual=//m
 from opentelemetry.context import Context
 from opentelemetry.metrics import CallbackT
 from opentelemetry.util.types import Attributes
+from typing_extensions import ParamSpec
 
 
 def _current_actor_id() -> ActorAddr | None:
@@ -35,6 +38,65 @@ def _current_actor_id() -> ActorAddr | None:
 
 def span(name: str) -> PySpan:
     return PySpan(name, _current_actor_id())
+
+
+_P = ParamSpec("_P")
+_R = TypeVar("_R")
+
+
+@overload
+def traced(fn: Callable[_P, _R]) -> Callable[_P, _R]: ...
+
+
+@overload
+def traced(
+    *, name: str
+) -> Callable[[Callable[_P, _R]], Callable[_P, _R]]: ...  # pyre-ignore[34]
+
+
+def traced(
+    fn: Callable[_P, _R] | None = None, *, name: str | None = None
+) -> Callable[_P, _R] | Callable[[Callable[_P, _R]], Callable[_P, _R]]:
+    """Decorator that wraps a function in a telemetry span.
+
+    Works with both sync and async functions. The span is automatically
+    associated with the current actor context, if any. When no name is
+    provided, the function's ``__name__`` is used as the span name.
+
+    Usage::
+
+        @traced
+        async def do_work():
+            ...
+
+        @traced(name="custom_name")
+        def compute():
+            ...
+    """
+
+    def decorator(fn: Callable[_P, _R]) -> Callable[_P, _R]:
+        span_name: str = name if name is not None else fn.__name__
+
+        if inspect.iscoroutinefunction(fn):
+
+            @functools.wraps(fn)
+            async def async_wrapper(*args: _P.args, **kwargs: _P.kwargs) -> _R:
+                with span(span_name):
+                    return await fn(*args, **kwargs)  # type: ignore[misc]
+
+            return async_wrapper  # type: ignore[return-value]
+        else:
+
+            @functools.wraps(fn)
+            def sync_wrapper(*args: _P.args, **kwargs: _P.kwargs) -> _R:
+                with span(span_name):
+                    return fn(*args, **kwargs)
+
+            return sync_wrapper
+
+    if fn is not None:
+        return decorator(fn)
+    return decorator
 
 
 class TracingForwarder(logging.Handler):

--- a/python/monarch/actor/__init__.py
+++ b/python/monarch/actor/__init__.py
@@ -45,7 +45,7 @@ from monarch._src.actor.host_mesh import (
 )
 from monarch._src.actor.proc_mesh import get_or_spawn_controller, ProcMesh
 from monarch._src.actor.supervision import unhandled_fault_hook
-from monarch._src.actor.telemetry import span
+from monarch._src.actor.telemetry import span, traced
 
 __all__ = [
     "Accumulator",
@@ -83,4 +83,5 @@ __all__ = [
     "MeshFailure",
     "config",
     "span",
+    "traced",
 ]


### PR DESCRIPTION
Summary:

Add a convenience decorator so we can also add spans to functions with a decorator. Uses PySpan as the backend

Reviewed By: thedavekwon

Differential Revision: D103747675


