### PR TITLE
Propagate config env to launched workers (#3776)

### DIFF
--- a/monarch_hyperactor/src/config.rs
+++ b/monarch_hyperactor/src/config.rs
@@ -18,6 +18,7 @@
 
 use std::collections::HashMap;
 use std::fmt::Debug;
+use std::sync::LazyLock;
 use std::time::Duration;
 
 use hyperactor::channel::BindSpec;
@@ -235,6 +236,37 @@ pub fn reset_config_to_defaults() -> PyResult<()> {
     // Set all config values to defaults, ignoring even environment variables.
     hyperactor_config::global::reset_to_defaults();
     Ok(())
+}
+
+static PROPAGATABLE_ENV_NAME_BY_KEY: LazyLock<HashMap<&'static str, String>> =
+    LazyLock::new(|| {
+        inventory::iter::<AttrKeyInfo>()
+            .filter_map(|info| {
+                let cfg_meta = info.meta.get(CONFIG)?;
+                if cfg_meta.propagate {
+                    Some((info.name, cfg_meta.env_name.clone()?))
+                } else {
+                    None
+                }
+            })
+            .collect()
+    });
+
+fn propagatable_config_env() -> HashMap<String, String> {
+    hyperactor_config::global::propagatable_attrs()
+        .iter()
+        .filter_map(|(name, value)| {
+            PROPAGATABLE_ENV_NAME_BY_KEY
+                .get(name)
+                .map(|env_name| (env_name.clone(), value.display()))
+        })
+        .collect()
+}
+
+/// Return env vars for the propagatable config snapshot.
+#[pyfunction]
+fn get_propagatable_config_env() -> PyResult<HashMap<String, String>> {
+    Ok(propagatable_config_env())
 }
 
 /// Map from the kwarg name passed to `monarch.configure(...)` to the
@@ -707,6 +739,13 @@ pub fn register_python_bindings(module: &Bound<'_, PyModule>) -> PyResult<()> {
     )?;
     module.add_function(reset)?;
 
+    let get_propagatable_config_env_fn = wrap_pyfunction!(get_propagatable_config_env, module)?;
+    get_propagatable_config_env_fn.setattr(
+        "__module__",
+        "monarch._rust_bindings.monarch_hyperactor.config",
+    )?;
+    module.add_function(get_propagatable_config_env_fn)?;
+
     let configure = wrap_pyfunction!(configure, module)?;
     configure.setattr(
         "__module__",
@@ -762,6 +801,40 @@ mod tests {
         ))
         attr TEST_NONZERO_USIZE: hyperactor_config::NonZeroUsize =
             hyperactor_config::NonZeroUsize::MIN;
+
+        @meta(CONFIG = ConfigAttr::new(
+            Some("TEST_PROCESS_LOCAL_CONFIG".to_string()),
+            Some("test_process_local_config".to_string()),
+        ).process_local())
+        attr TEST_PROCESS_LOCAL_CONFIG: bool = false;
+    }
+
+    #[test]
+    fn test_propagatable_config_env_exports_config_values() {
+        let _lock = hyperactor_config::global::lock();
+        hyperactor_config::global::reset_to_defaults();
+
+        let mut runtime = Attrs::new();
+        runtime[TOKIO_WORKER_THREADS] = Some(
+            hyperactor_config::NonZeroUsize::try_from(4).expect("test value should be non-zero"),
+        );
+        runtime[TEST_PROCESS_LOCAL_CONFIG] = true;
+        hyperactor_config::global::set(Source::Runtime, runtime);
+
+        let env = propagatable_config_env();
+        assert_eq!(
+            env.get("MONARCH_TOKIO_WORKER_THREADS").map(String::as_str),
+            Some("4")
+        );
+        assert_eq!(
+            env.get("MONARCH_ACTOR_QUEUE_DISPATCH").map(String::as_str),
+            Some("1")
+        );
+        assert!(
+            !env.contains_key("TEST_PROCESS_LOCAL_CONFIG"),
+            "process-local config values should not propagate"
+        );
+        hyperactor_config::global::reset_to_defaults();
     }
 
     #[test]

--- a/python/monarch/_rust_bindings/monarch_hyperactor/config.pyi
+++ b/python/monarch/_rust_bindings/monarch_hyperactor/config.pyi
@@ -39,6 +39,10 @@ def reset_config_to_defaults() -> None:
     """
     ...
 
+def get_propagatable_config_env() -> Dict[str, str]:
+    """Return env vars for the propagatable config snapshot."""
+    ...
+
 def configure(
     default_transport: ChannelTransport | str = ...,
     enable_log_forwarding: bool = ...,

--- a/python/monarch/_src/job/job.py
+++ b/python/monarch/_src/job/job.py
@@ -21,6 +21,7 @@ from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import Any, Dict, List, Literal, NamedTuple, Optional, Sequence
 
+from monarch._rust_bindings.monarch_hyperactor.config import get_propagatable_config_env
 from monarch._src.actor.bootstrap import attach_to_workers
 from monarch._src.job._batch_env import in_batch_job, MONARCH_BATCH_JOB_ENV
 from monarch._src.job._telemetry_query_client import QueryEngineClient
@@ -1001,7 +1002,7 @@ class LocalJob(JobTrait):
         stderr_log = os.path.join(log_dir, "stderr.log")
 
         # Create environment with the batch-mode marker set.
-        env = os.environ.copy()
+        env = {**get_propagatable_config_env(), **os.environ}
         env[MONARCH_BATCH_JOB_ENV] = "1"
 
         # Open log files
@@ -1188,7 +1189,13 @@ class SSHJob(LoginJob):
         addr = f"{self._scheme}://{host}:{self._port}"
         startup = f'from monarch.actor import run_worker_loop_forever; run_worker_loop_forever(address={repr(addr)}, ca="trust_all_connections")'
 
+        env_prefix = " ".join(
+            f"{key}={shlex.quote(value)}"
+            for key, value in get_propagatable_config_env().items()
+        )
         command = f"{shlex.quote(self._python_exe)} -c {shlex.quote(startup)}"
+        if env_prefix:
+            command = f"{env_prefix} {command}"
         proc = subprocess.Popen(
             ["ssh", *self._ssh_args, host, "-n", command],
             start_new_session=True,

--- a/python/monarch/_src/job/kubernetes.py
+++ b/python/monarch/_src/job/kubernetes.py
@@ -27,7 +27,10 @@ except ImportError:
     )
 
 from monarch._rust_bindings.monarch_hyperactor.channel import ChannelTransport
-from monarch._rust_bindings.monarch_hyperactor.config import configure
+from monarch._rust_bindings.monarch_hyperactor.config import (
+    configure,
+    get_propagatable_config_env,
+)
 from monarch._src.actor.bootstrap import attach_to_workers
 from monarch._src.job.job import JobState, JobTrait
 from monarch.actor import attach
@@ -441,12 +444,15 @@ class KubernetesJob(JobTrait):
                 requests=k8s_resources,
                 limits=k8s_resources,
             )
-        env = [client.V1EnvVar(name="MONARCH_PORT", value=str(port))]
+        worker_env = {**get_propagatable_config_env(), "MONARCH_PORT": str(port)}
         container = client.V1Container(
             name="worker",
             image=image_spec.image,
             command=["python", "-u", "-c", _WORKER_BOOTSTRAP_SCRIPT],
-            env=env,
+            env=[
+                client.V1EnvVar(name=key, value=value)
+                for key, value in worker_env.items()
+            ],
             resources=resources,
         )
         return client.V1PodTemplateSpec(

--- a/python/monarch/_src/job/process.py
+++ b/python/monarch/_src/job/process.py
@@ -18,6 +18,7 @@ import threading
 import time
 from typing import Callable, Dict, List, Optional, Union
 
+from monarch._rust_bindings.monarch_hyperactor.config import get_propagatable_config_env
 from monarch._src.actor.bootstrap import attach_to_workers
 from monarch._src.actor.future import Future
 from monarch._src.job.job import JobState, JobTrait, ProcessState
@@ -138,11 +139,16 @@ class ProcessJob(JobTrait):
         self._tmpdir = tempfile.mkdtemp(prefix="monarch_process_job_")
 
         try:
+            propagatable_config_env = get_propagatable_config_env()
             for mesh_name, count in self._meshes.items():
                 for i in range(count):
                     host_key = f"{mesh_name}_{i}"
                     addr = f"ipc://{self._tmpdir}/{host_key}"
-                    env = {**os.environ, "HYPERACTOR_PROCESS_NAME": host_key}
+                    env = {
+                        **propagatable_config_env,
+                        **os.environ,
+                        "HYPERACTOR_PROCESS_NAME": host_key,
+                    }
                     if self._env is not None:
                         env.update(self._env)
                     if _IN_PAR:

--- a/python/monarch/_src/job/slurm.py
+++ b/python/monarch/_src/job/slurm.py
@@ -15,7 +15,10 @@ import sys
 from typing import Any, Dict, FrozenSet, List, Optional, Sequence
 
 from monarch._rust_bindings.monarch_hyperactor.channel import ChannelTransport
-from monarch._rust_bindings.monarch_hyperactor.config import configure
+from monarch._rust_bindings.monarch_hyperactor.config import (
+    configure,
+    get_propagatable_config_env,
+)
 from monarch._src.actor.bootstrap import attach_to_workers
 from monarch._src.job._batch_env import in_batch_job
 from monarch._src.job._slurm_batch import _WORKER_BOOTSTRAP
@@ -203,6 +206,8 @@ class SlurmJob(JobTrait):
                 sbatch_directives.append(f"#SBATCH {arg}")
 
         batch_script = "\n".join(sbatch_directives)
+        for key, value in get_propagatable_config_env().items():
+            batch_script += f"\nexport {key}={shlex.quote(value)}"
         if client_script is None:
             # Workers only; an external controller attaches and manages the
             # lifetime. Shares _WORKER_BOOTSTRAP with the batch runner.
@@ -345,10 +350,9 @@ class SlurmJob(JobTrait):
         hostname_idx = 0
 
         for mesh_name, num_nodes in self._meshes.items():
-            mesh_hostnames = self._all_hostnames[
-                hostname_idx : hostname_idx + num_nodes
-            ]
-            hostname_idx += num_nodes
+            next_hostname_idx = hostname_idx + num_nodes
+            mesh_hostnames = self._all_hostnames[hostname_idx:next_hostname_idx]
+            hostname_idx = next_hostname_idx
 
             workers = [f"tcp://{hostname}:{self._port}" for hostname in mesh_hostnames]
             host_mesh = attach_to_workers(

--- a/python/monarch/_src/job/spmd.py
+++ b/python/monarch/_src/job/spmd.py
@@ -20,7 +20,10 @@ from datetime import datetime
 from typing import Any, Dict, List, Optional, Tuple
 
 from monarch._rust_bindings.monarch_hyperactor.channel import ChannelTransport
-from monarch._rust_bindings.monarch_hyperactor.config import configure
+from monarch._rust_bindings.monarch_hyperactor.config import (
+    configure,
+    get_propagatable_config_env,
+)
 from monarch._src.actor.bootstrap import attach_to_workers
 from monarch._src.actor.host_mesh import this_host
 from monarch._src.job.job import JobState, JobTrait
@@ -319,6 +322,7 @@ def serve(
 
     # Cache original entrypoints before modifying
     original_roles = []
+    role_env = get_propagatable_config_env()
     scheme = "metatls" if scheduler.startswith("mast") else "tcp"
     for role in appdef.roles:
         original_roles.append(
@@ -328,6 +332,7 @@ def serve(
             }
         )
 
+        role.env = {**role_env, **(role.env or {})}
         role.args = [
             "python",
             "-X",

--- a/python/tests/_src/job/test_kubernetes.py
+++ b/python/tests/_src/job/test_kubernetes.py
@@ -528,7 +528,14 @@ class TestCreate(unittest.TestCase):
 class TestBuildWorkerPodTemplate(unittest.TestCase):
     """Tests for KubernetesJob._build_worker_pod_template."""
 
-    def test_basic_pod_template(self) -> None:
+    @patch(
+        "monarch._src.job.kubernetes.get_propagatable_config_env",
+        return_value={
+            "MONARCH_TOKIO_WORKER_THREADS": "4",
+            "HYPERACTOR_EXECUTION_ID": "test-exec-id",
+        },
+    )
+    def test_basic_pod_template(self, mock_config_env: MagicMock) -> None:
         template = KubernetesJob._build_worker_pod_template(
             ImageSpec("myimage:latest"), port=26600
         )
@@ -539,14 +546,20 @@ class TestBuildWorkerPodTemplate(unittest.TestCase):
         self.assertEqual(
             container.command, ["python", "-u", "-c", _WORKER_BOOTSTRAP_SCRIPT]
         )
-        self.assertEqual(len(container.env), 1)
-        self.assertEqual(container.env[0].name, "MONARCH_PORT")
-        self.assertEqual(container.env[0].value, "26600")
+        env_dict = {e.name: e.value for e in container.env}
+        self.assertEqual(env_dict["MONARCH_PORT"], "26600")
+        self.assertEqual(env_dict["HYPERACTOR_EXECUTION_ID"], "test-exec-id")
+        self.assertEqual(env_dict["MONARCH_TOKIO_WORKER_THREADS"], "4")
         self.assertIsNone(container.resources)
 
-    def test_custom_port_in_env(self) -> None:
+    @patch(
+        "monarch._src.job.kubernetes.get_propagatable_config_env",
+        return_value={},
+    )
+    def test_custom_port_in_env(self, mock_config_env: MagicMock) -> None:
         template = KubernetesJob._build_worker_pod_template(ImageSpec("img"), port=9999)
-        self.assertEqual(template.spec.containers[0].env[0].value, "9999")
+        env_dict = {e.name: e.value for e in template.spec.containers[0].env}
+        self.assertEqual(env_dict["MONARCH_PORT"], "9999")
 
     def test_resources_set(self) -> None:
         template = KubernetesJob._build_worker_pod_template(


### PR DESCRIPTION
Summary:

Seed scheduler-launched Monarch worker processes with the current propagatable config env snapshot so startup-only declared settings such as `MONARCH_TOKIO_WORKER_THREADS` are available before worker initialization. The snapshot uses `propagatable_attrs()` and declared environment mappings, while existing user environment knobs continue to override framework-provided values.

Differential Revision: D103440896


