### PR TITLE
drop `use hyperactor as reference` alias (#3785)

### DIFF
--- a/monarch_rdma/examples/cuda_ping_pong/src/cuda_ping_pong.rs
+++ b/monarch_rdma/examples/cuda_ping_pong/src/cuda_ping_pong.rs
@@ -59,12 +59,13 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use clap::Arg;
 use clap::Command as ClapCommand;
-use hyperactor as reference;
 use hyperactor::Actor;
+use hyperactor::ActorRef;
 use hyperactor::Bind;
 use hyperactor::Context;
 use hyperactor::Handler;
 use hyperactor::Instance;
+use hyperactor::OncePortRef;
 use hyperactor::RemoteSpawn;
 use hyperactor::Unbind;
 use hyperactor::channel::ChannelAddr;
@@ -265,7 +266,7 @@ pub struct CudaRdmaActor {
     // RDMA buffer handle for the CUDA memory
     rdma_buffer_handle: Option<RdmaRemoteBuffer>,
     // Reference to the RDMA manager actor
-    rdma_manager: reference::ActorRef<RdmaManagerActor>,
+    rdma_manager: ActorRef<RdmaManagerActor>,
 }
 
 #[async_trait]
@@ -286,7 +287,7 @@ impl Actor for CudaRdmaActor {
 
 #[async_trait]
 impl RemoteSpawn for CudaRdmaActor {
-    type Params = (reference::ActorRef<RdmaManagerActor>, usize, usize);
+    type Params = (ActorRef<RdmaManagerActor>, usize, usize);
 
     async fn new(params: Self::Params, _environment: Flattrs) -> Result<Self, anyhow::Error> {
         let (rdma_manager, device_id, buffer_size) = params;
@@ -386,21 +387,21 @@ impl RemoteSpawn for CudaRdmaActor {
 
 // Message to initialize the buffer with data
 #[derive(Debug, Serialize, Deserialize, Named, Clone)]
-struct InitializeBuffer(pub u8, pub reference::OncePortRef<bool>);
+struct InitializeBuffer(pub u8, pub OncePortRef<bool>);
 
 // Message to perform an RDMA ping-pong operation with another actor
 #[derive(Debug, Serialize, Deserialize, Named, Clone)]
 struct PerformPingPong(
-    pub reference::ActorRef<CudaRdmaActor>,
+    pub ActorRef<CudaRdmaActor>,
     pub RdmaRemoteBuffer,
     pub i32,
     pub i32,
-    pub reference::OncePortRef<bool>,
+    pub OncePortRef<bool>,
 );
 
 // Message to verify the buffer contents
 #[derive(Debug, Serialize, Deserialize, Named, Clone)]
-struct VerifyBuffer(pub Box<[u8]>, pub reference::OncePortRef<bool>);
+struct VerifyBuffer(pub Box<[u8]>, pub OncePortRef<bool>);
 
 #[async_trait]
 impl Handler<InitializeBuffer> for CudaRdmaActor {
@@ -657,7 +658,7 @@ impl Handler<VerifyBuffer> for CudaRdmaActor {
 
 // Message to get the buffer handle from an actor
 #[derive(Debug, Serialize, Deserialize, Named, Clone, Bind, Unbind)]
-struct GetBufferHandle(#[binding(include)] pub reference::OncePortRef<RdmaRemoteBuffer>);
+struct GetBufferHandle(#[binding(include)] pub OncePortRef<RdmaRemoteBuffer>);
 
 #[async_trait]
 impl Handler<GetBufferHandle> for CudaRdmaActor {

--- a/monarch_rdma/examples/parameter_server/src/parameter_server.rs
+++ b/monarch_rdma/examples/parameter_server/src/parameter_server.rs
@@ -57,12 +57,14 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use hyperactor as reference;
 use hyperactor::Actor;
+use hyperactor::ActorRef;
 use hyperactor::Bind;
 use hyperactor::Context;
 use hyperactor::Handler;
 use hyperactor::Instance;
+use hyperactor::OncePortRef;
+use hyperactor::PortRef;
 use hyperactor::RemoteSpawn;
 use hyperactor::Unbind;
 use hyperactor::channel::ChannelTransport;
@@ -107,7 +109,7 @@ pub struct ParameterServerActor {
     grad_buffer_data: Box<[Box<[u8]>]>,
     weights_handle: Option<RdmaRemoteBuffer>,
     grad_buffer_handles: HashMap<usize, RdmaRemoteBuffer>,
-    owner_ref: reference::ActorRef<RdmaManagerActor>,
+    owner_ref: ActorRef<RdmaManagerActor>,
 }
 
 #[async_trait]
@@ -130,7 +132,7 @@ impl Actor for ParameterServerActor {
 
 #[async_trait]
 impl RemoteSpawn for ParameterServerActor {
-    type Params = (reference::ActorRef<RdmaManagerActor>, usize);
+    type Params = (ActorRef<RdmaManagerActor>, usize);
 
     async fn new(_params: Self::Params, _environment: Flattrs) -> Result<Self, anyhow::Error> {
         let (owner_ref, worker_world_size) = _params;
@@ -151,17 +153,17 @@ impl RemoteSpawn for ParameterServerActor {
 }
 
 // Message to get handles to the parameter server's weights and gradient buffers.
-// - reference::OncePortRef<(RdmaRemoteBuffer, RdmaRemoteBuffer)>: OncePortRef to the parameter server's weights and gradient buffers.
+// - OncePortRef<(RdmaRemoteBuffer, RdmaRemoteBuffer)>: OncePortRef to the parameter server's weights and gradient buffers.
 #[derive(Debug, Serialize, Deserialize, Named, Clone)]
 struct PsGetBuffers(
     pub usize,
-    pub reference::OncePortRef<(RdmaRemoteBuffer, RdmaRemoteBuffer)>,
+    pub OncePortRef<(RdmaRemoteBuffer, RdmaRemoteBuffer)>,
 );
 
 // Message to update the parameter server's weights with its current gradient buffer.
-// - reference::OncePortRef<bool>: OncePortRef used primarily for workload synchronization.
+// - OncePortRef<bool>: OncePortRef used primarily for workload synchronization.
 #[derive(Debug, Serialize, Deserialize, Named, Clone)]
-struct PsUpdate(pub reference::OncePortRef<bool>);
+struct PsUpdate(pub OncePortRef<bool>);
 
 // Message to log actors' weights and gradients.
 #[derive(Debug, Serialize, Deserialize, Named, Clone, Bind, Unbind)]
@@ -302,21 +304,21 @@ impl RemoteSpawn for WorkerActor {
 // This message is sent to workers to establish their connection with the parameter server
 // and obtain handles to the shared weights and gradient buffers.
 #[derive(Debug, Serialize, Deserialize, Named, Clone, Bind, Unbind)]
-pub struct WorkerInit(pub reference::ActorRef<ParameterServerActor>);
+pub struct WorkerInit(pub ActorRef<ParameterServerActor>);
 
 // Message to signal the worker to update its gradients and transmit them to the server.
-// The reference::PortRef<bool> is used to notify the main process when the operation completes.
+// The PortRef<bool> is used to notify the main process when the operation completes.
 // - Workers compute local gradients (weights + 1)
 // - Workers write these gradients to their assigned buffer on the parameter server using RDMA
 #[derive(Debug, Serialize, Deserialize, Named, Clone, Bind, Unbind)]
-pub struct WorkerStep(#[binding(include)] reference::PortRef<bool>);
+pub struct WorkerStep(#[binding(include)] PortRef<bool>);
 
 // Message to signal the worker to pull updated weights from the parameter server.
-// The reference::PortRef<bool> is used to notify the main process when the operation completes.
+// The PortRef<bool> is used to notify the main process when the operation completes.
 // - Workers read the updated weights from the parameter server using RDMA
 // - This happens after the parameter server has applied all gradients to update the weights
 #[derive(Debug, Serialize, Deserialize, Named, Clone, Bind, Unbind)]
-pub struct WorkerUpdate(#[binding(include)] reference::PortRef<bool>);
+pub struct WorkerUpdate(#[binding(include)] PortRef<bool>);
 
 #[async_trait]
 impl Handler<WorkerInit> for WorkerActor {

--- a/monarch_rdma/src/backend.rs
+++ b/monarch_rdma/src/backend.rs
@@ -18,7 +18,7 @@ use std::time::Duration;
 
 use anyhow::Result;
 use async_trait::async_trait;
-use hyperactor as reference;
+use hyperactor::ActorRef;
 use serde::Deserialize;
 use serde::Serialize;
 
@@ -32,10 +32,10 @@ use crate::RdmaTransportLevel;
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum RdmaRemoteBackendContext {
     Ibverbs(
-        reference::ActorRef<ibverbs::manager_actor::IbvManagerActor>,
+        ActorRef<ibverbs::manager_actor::IbvManagerActor>,
         ibverbs::IbvBuffer,
     ),
-    Tcp(reference::ActorRef<tcp::manager_actor::TcpManagerActor>),
+    Tcp(ActorRef<tcp::manager_actor::TcpManagerActor>),
 }
 
 /// Backend for executing RDMA operations over a specific transport.

--- a/monarch_rdma/src/backend/ibverbs.rs
+++ b/monarch_rdma/src/backend/ibverbs.rs
@@ -10,7 +10,7 @@
 
 use std::sync::Arc;
 
-use hyperactor as reference;
+use hyperactor::ActorRef;
 use serde::Deserialize;
 use serde::Serialize;
 use typeuri::Named;
@@ -56,5 +56,5 @@ pub struct IbvOp {
     pub op_type: RdmaOpType,
     pub local_memory: Arc<dyn RdmaLocalMemory>,
     pub remote_buffer: IbvBuffer,
-    pub remote_manager: reference::ActorRef<IbvManagerActor>,
+    pub remote_manager: ActorRef<IbvManagerActor>,
 }

--- a/monarch_rdma/src/backend/ibverbs/manager_actor.rs
+++ b/monarch_rdma/src/backend/ibverbs/manager_actor.rs
@@ -29,14 +29,16 @@ use backoff::ExponentialBackoff;
 use backoff::ExponentialBackoffBuilder;
 use backoff::backoff::Backoff;
 use futures::lock::Mutex;
-use hyperactor as reference;
 use hyperactor::Actor;
 use hyperactor::ActorHandle;
+use hyperactor::ActorId;
+use hyperactor::ActorRef;
 use hyperactor::Context;
 use hyperactor::HandleClient;
 use hyperactor::Handler;
 use hyperactor::Instance;
 use hyperactor::OncePortHandle;
+use hyperactor::OncePortRef;
 use hyperactor::RefClient;
 use serde::Deserialize;
 use serde::Serialize;
@@ -73,44 +75,44 @@ pub enum IbvManagerMessage {
     /// (no reply port) to avoid blocking the caller during teardown.
     ReleaseBuffer { remote_buf_id: usize },
     RequestQueuePair {
-        other: reference::ActorRef<IbvManagerActor>,
+        other: ActorRef<IbvManagerActor>,
         self_device: String,
         other_device: String,
         #[reply]
-        reply: reference::OncePortRef<Result<IbvQueuePair, String>>,
+        reply: OncePortRef<Result<IbvQueuePair, String>>,
     },
     Connect {
-        other: reference::ActorRef<IbvManagerActor>,
+        other: ActorRef<IbvManagerActor>,
         self_device: String,
         other_device: String,
         endpoint: IbvQpInfo,
     },
     InitializeQP {
-        other: reference::ActorRef<IbvManagerActor>,
+        other: ActorRef<IbvManagerActor>,
         self_device: String,
         other_device: String,
         #[reply]
-        reply: reference::OncePortRef<bool>,
+        reply: OncePortRef<bool>,
     },
     ConnectionInfo {
-        other: reference::ActorRef<IbvManagerActor>,
+        other: ActorRef<IbvManagerActor>,
         self_device: String,
         other_device: String,
         #[reply]
-        reply: reference::OncePortRef<IbvQpInfo>,
+        reply: OncePortRef<IbvQpInfo>,
     },
     ReleaseQueuePair {
-        other: reference::ActorRef<IbvManagerActor>,
+        other: ActorRef<IbvManagerActor>,
         self_device: String,
         other_device: String,
         qp: IbvQueuePair,
     },
     GetQpState {
-        other: reference::ActorRef<IbvManagerActor>,
+        other: ActorRef<IbvManagerActor>,
         self_device: String,
         other_device: String,
         #[reply]
-        reply: reference::OncePortRef<u32>,
+        reply: OncePortRef<u32>,
     },
 }
 wirevalue::register_type!(IbvManagerMessage);
@@ -260,11 +262,11 @@ pub struct IbvManagerActor {
     owner: OnceLock<ActorHandle<RdmaManagerActor>>,
 
     // Nested map: local_device -> (ActorId, remote_device) -> IbvQueuePair
-    device_qps: HashMap<String, HashMap<(reference::ActorId, String), IbvQueuePair>>,
+    device_qps: HashMap<String, HashMap<(ActorId, String), IbvQueuePair>>,
 
     // Track QPs currently being created to prevent duplicate creation
     // Wrapped in Arc<Mutex> to allow safe concurrent access
-    pending_qp_creation: Arc<Mutex<HashSet<(String, reference::ActorId, String)>>>,
+    pending_qp_creation: Arc<Mutex<HashSet<(String, ActorId, String)>>>,
 
     // Map of RDMA device names to their domains and loopback QPs
     // Created lazily when memory is registered for a specific device
@@ -372,7 +374,7 @@ impl IbvManagerActor {
         client: &(impl hyperactor::context::Actor + Send + Sync),
     ) -> Result<ActorHandle<Self>, anyhow::Error> {
         let rdma_handle = RdmaManagerActor::local_handle(client);
-        let ibv_ref: reference::ActorRef<IbvManagerActor> = rdma_handle
+        let ibv_ref: ActorRef<IbvManagerActor> = rdma_handle
             .get_ibv_actor_ref(client)
             .await?
             .ok_or_else(|| anyhow::anyhow!("local RdmaManagerActor has no ibverbs backend"))?;
@@ -689,18 +691,18 @@ impl IbvManagerActor {
     async fn request_queue_pair_impl(
         &mut self,
         cx: &Context<'_, Self>,
-        other: reference::ActorRef<IbvManagerActor>,
+        other: ActorRef<IbvManagerActor>,
         self_device: String,
         other_device: String,
     ) -> Result<IbvQueuePair, anyhow::Error> {
-        let self_ref: reference::ActorRef<IbvManagerActor> = cx.bind();
+        let self_ref: ActorRef<IbvManagerActor> = cx.bind();
         let other_id = other.actor_addr().id().clone();
 
         // Use the nested map structure: local_device -> (actor_id, remote_device) -> IbvQueuePair
         let inner_key = (other_id.clone(), other_device.clone());
 
         // Check if queue pair exists in map
-        let device_map: Option<&HashMap<(reference::ActorId, String), IbvQueuePair>> =
+        let device_map: Option<&HashMap<(ActorId, String), IbvQueuePair>> =
             self.device_qps.get(&self_device);
         if let Some(device_map) = device_map {
             if let Some(qp) = device_map.get(&inner_key) {
@@ -710,10 +712,8 @@ impl IbvManagerActor {
 
         // Try to acquire lock and mark as pending (hold lock only once!)
         let pending_key = (self_device.clone(), other_id.clone(), other_device.clone());
-        let mut pending: futures::lock::MutexGuard<
-            '_,
-            HashSet<(String, reference::ActorId, String)>,
-        > = self.pending_qp_creation.lock().await;
+        let mut pending: futures::lock::MutexGuard<'_, HashSet<(String, ActorId, String)>> =
+            self.pending_qp_creation.lock().await;
 
         if pending.contains(&pending_key) {
             // Another task is creating this QP, release lock and wait
@@ -728,7 +728,7 @@ impl IbvManagerActor {
                 tokio::time::sleep(Duration::from_micros(200)).await;
 
                 // Check if QP was created while we waited
-                let device_map: Option<&HashMap<(reference::ActorId, String), IbvQueuePair>> =
+                let device_map: Option<&HashMap<(ActorId, String), IbvQueuePair>> =
                     self.device_qps.get(&self_device);
                 if let Some(device_map) = device_map {
                     if let Some(qp) = device_map.get(&inner_key) {
@@ -836,7 +836,7 @@ impl IbvManagerActor {
             }
 
             // Now that connection is established, get and clone the queue pair
-            let device_map: Option<&HashMap<(reference::ActorId, String), IbvQueuePair>> =
+            let device_map: Option<&HashMap<(ActorId, String), IbvQueuePair>> =
                 self.device_qps.get(&self_device);
             if let Some(device_map) = device_map {
                 if let Some(qp) = device_map.get(&inner_key) {
@@ -859,10 +859,8 @@ impl IbvManagerActor {
         .await;
 
         // Always remove from pending set when done (success or failure)
-        let mut pending: futures::lock::MutexGuard<
-            '_,
-            HashSet<(String, reference::ActorId, String)>,
-        > = self.pending_qp_creation.lock().await;
+        let mut pending: futures::lock::MutexGuard<'_, HashSet<(String, ActorId, String)>> =
+            self.pending_qp_creation.lock().await;
         pending.remove(&pending_key);
         drop(pending);
 
@@ -888,7 +886,7 @@ impl IbvManagerMessageHandler for IbvManagerActor {
     async fn request_queue_pair(
         &mut self,
         cx: &Context<Self>,
-        other: reference::ActorRef<IbvManagerActor>,
+        other: ActorRef<IbvManagerActor>,
         self_device: String,
         other_device: String,
     ) -> Result<Result<IbvQueuePair, String>, anyhow::Error> {
@@ -901,7 +899,7 @@ impl IbvManagerMessageHandler for IbvManagerActor {
     async fn connect(
         &mut self,
         _cx: &Context<Self>,
-        other: reference::ActorRef<IbvManagerActor>,
+        other: ActorRef<IbvManagerActor>,
         self_device: String,
         other_device: String,
         endpoint: IbvQpInfo,
@@ -911,7 +909,7 @@ impl IbvManagerMessageHandler for IbvManagerActor {
 
         let inner_key = (other_id.clone(), other_device.clone());
 
-        let device_map: Option<&mut HashMap<(reference::ActorId, String), IbvQueuePair>> =
+        let device_map: Option<&mut HashMap<(ActorId, String), IbvQueuePair>> =
             self.device_qps.get_mut(&self_device);
         if let Some(device_map) = device_map {
             match device_map.get_mut(&inner_key) {
@@ -937,7 +935,7 @@ impl IbvManagerMessageHandler for IbvManagerActor {
     async fn initialize_qp(
         &mut self,
         _cx: &Context<Self>,
-        other: reference::ActorRef<IbvManagerActor>,
+        other: ActorRef<IbvManagerActor>,
         self_device: String,
         other_device: String,
     ) -> Result<bool, anyhow::Error> {
@@ -945,7 +943,7 @@ impl IbvManagerMessageHandler for IbvManagerActor {
         let inner_key = (other_id.clone(), other_device.clone());
 
         // Check if QP already exists in nested structure
-        let device_map: Option<&HashMap<(reference::ActorId, String), IbvQueuePair>> =
+        let device_map: Option<&HashMap<(ActorId, String), IbvQueuePair>> =
             self.device_qps.get(&self_device);
         if let Some(device_map) = device_map {
             if device_map.contains_key(&inner_key) {
@@ -986,7 +984,7 @@ impl IbvManagerMessageHandler for IbvManagerActor {
     async fn connection_info(
         &mut self,
         _cx: &Context<Self>,
-        other: reference::ActorRef<IbvManagerActor>,
+        other: ActorRef<IbvManagerActor>,
         self_device: String,
         other_device: String,
     ) -> Result<IbvQpInfo, anyhow::Error> {
@@ -995,7 +993,7 @@ impl IbvManagerMessageHandler for IbvManagerActor {
 
         let inner_key = (other_id.clone(), other_device.clone());
 
-        let device_map: Option<&mut HashMap<(reference::ActorId, String), IbvQueuePair>> =
+        let device_map: Option<&mut HashMap<(ActorId, String), IbvQueuePair>> =
             self.device_qps.get_mut(&self_device);
         if let Some(device_map) = device_map {
             match device_map.get_mut(&inner_key) {
@@ -1019,7 +1017,7 @@ impl IbvManagerMessageHandler for IbvManagerActor {
     async fn release_queue_pair(
         &mut self,
         _cx: &Context<Self>,
-        _other: reference::ActorRef<IbvManagerActor>,
+        _other: ActorRef<IbvManagerActor>,
         _self_device: String,
         _other_device: String,
         _qp: IbvQueuePair,
@@ -1030,14 +1028,14 @@ impl IbvManagerMessageHandler for IbvManagerActor {
     async fn get_qp_state(
         &mut self,
         _cx: &Context<Self>,
-        other: reference::ActorRef<IbvManagerActor>,
+        other: ActorRef<IbvManagerActor>,
         self_device: String,
         other_device: String,
     ) -> Result<u32, anyhow::Error> {
         let other_id = other.actor_addr().id().clone();
         let inner_key = (other_id.clone(), other_device.clone());
 
-        let device_map: Option<&mut HashMap<(reference::ActorId, String), IbvQueuePair>> =
+        let device_map: Option<&mut HashMap<(ActorId, String), IbvQueuePair>> =
             self.device_qps.get_mut(&self_device);
         if let Some(device_map) = device_map {
             match device_map.get_mut(&inner_key) {

--- a/monarch_rdma/src/backend/ibverbs/test_utils.rs
+++ b/monarch_rdma/src/backend/ibverbs/test_utils.rs
@@ -12,12 +12,13 @@ use std::sync::atomic::Ordering;
 use std::time::Duration;
 use std::time::Instant;
 
-use hyperactor as reference;
 use hyperactor::Actor;
+use hyperactor::ActorRef;
 use hyperactor::Context;
 use hyperactor::HandleClient;
 use hyperactor::Handler;
 use hyperactor::Instance;
+use hyperactor::OncePortRef;
 use hyperactor::Proc;
 use hyperactor::RefClient;
 use hyperactor::RemoteSpawn;
@@ -94,23 +95,23 @@ impl RemoteSpawn for CudaActor {
 pub enum CudaActorMessage {
     CreateBuffer {
         size: usize,
-        rdma_actor: reference::ActorRef<RdmaManagerActor>,
+        rdma_actor: ActorRef<RdmaManagerActor>,
         #[reply]
-        reply: reference::OncePortRef<(RdmaRemoteBuffer, usize)>,
+        reply: OncePortRef<(RdmaRemoteBuffer, usize)>,
     },
     FillBuffer {
         device_ptr: usize,
         size: usize,
         value: u8,
         #[reply]
-        reply: reference::OncePortRef<()>,
+        reply: OncePortRef<()>,
     },
     VerifyBuffer {
         cpu_buffer_ptr: usize,
         device_ptr: usize,
         size: usize,
         #[reply]
-        reply: reference::OncePortRef<()>,
+        reply: OncePortRef<()>,
     },
 }
 
@@ -460,18 +461,18 @@ pub struct IbvTestEnv {
     buffer_2: Buffer,
     pub client_1: Instance<()>,
     pub client_2: Instance<()>,
-    pub actor_1: reference::ActorRef<RdmaManagerActor>,
-    pub actor_2: reference::ActorRef<RdmaManagerActor>,
-    pub ibv_actor_1: reference::ActorRef<IbvManagerActor>,
-    pub ibv_actor_2: reference::ActorRef<IbvManagerActor>,
+    pub actor_1: ActorRef<RdmaManagerActor>,
+    pub actor_2: ActorRef<RdmaManagerActor>,
+    pub ibv_actor_1: ActorRef<IbvManagerActor>,
+    pub ibv_actor_2: ActorRef<IbvManagerActor>,
     pub rdma_handle_1: RdmaRemoteBuffer,
     pub rdma_handle_2: RdmaRemoteBuffer,
     pub local_memory_1: Arc<dyn RdmaLocalMemory>,
     pub local_memory_2: Arc<dyn RdmaLocalMemory>,
     pub ibv_buffer_1: IbvBuffer,
     pub ibv_buffer_2: IbvBuffer,
-    cuda_actor_1: Option<reference::ActorRef<CudaActor>>,
-    cuda_actor_2: Option<reference::ActorRef<CudaActor>>,
+    cuda_actor_1: Option<ActorRef<CudaActor>>,
+    cuda_actor_2: Option<ActorRef<CudaActor>>,
     device_ptr_1: Option<usize>,
     device_ptr_2: Option<usize>,
 }
@@ -547,11 +548,11 @@ impl IbvTestEnv {
 
         let rdma_actor_1 = RdmaManagerActor::new(Some(config1), Flattrs::default()).await?;
         let rdma_actor_handle_1 = proc_1.spawn("rdma_manager", rdma_actor_1)?;
-        let actor_1: reference::ActorRef<RdmaManagerActor> = rdma_actor_handle_1.bind();
+        let actor_1: ActorRef<RdmaManagerActor> = rdma_actor_handle_1.bind();
 
         let rdma_actor_2 = RdmaManagerActor::new(Some(config2), Flattrs::default()).await?;
         let rdma_actor_handle_2 = proc_2.spawn("rdma_manager", rdma_actor_2)?;
-        let actor_2: reference::ActorRef<RdmaManagerActor> = rdma_actor_handle_2.bind();
+        let actor_2: ActorRef<RdmaManagerActor> = rdma_actor_handle_2.bind();
 
         let mut buf_vec = Vec::new();
         let mut cuda_actor_1 = None;
@@ -584,7 +585,7 @@ impl IbvTestEnv {
             // CUDA case - spawn CudaActor on the same proc
             let cuda_actor = CudaActor::new(parsed_accel1.1 as i32, Flattrs::default()).await?;
             let cuda_handle = proc_1.spawn("cuda_init", cuda_actor)?;
-            let cuda_actor_ref_1: reference::ActorRef<CudaActor> = cuda_handle.bind();
+            let cuda_actor_ref_1: ActorRef<CudaActor> = cuda_handle.bind();
 
             let (rdma_buf, dev_ptr) = cuda_actor_ref_1
                 .create_buffer(&instance_1, buffer_size, actor_1.clone())
@@ -621,7 +622,7 @@ impl IbvTestEnv {
             // CUDA case - spawn CudaActor on the same proc
             let cuda_actor = CudaActor::new(parsed_accel2.1 as i32, Flattrs::default()).await?;
             let cuda_handle = proc_2.spawn("cuda_init", cuda_actor)?;
-            let cuda_actor_ref_2: reference::ActorRef<CudaActor> = cuda_handle.bind();
+            let cuda_actor_ref_2: ActorRef<CudaActor> = cuda_handle.bind();
 
             let (rdma_buf, dev_ptr) = cuda_actor_ref_2
                 .create_buffer(&instance_2, buffer_size, actor_2.clone())

--- a/monarch_rdma/src/backend/tcp/manager_actor.rs
+++ b/monarch_rdma/src/backend/tcp/manager_actor.rs
@@ -23,9 +23,9 @@ use async_trait::async_trait;
 use bytes::Bytes;
 use bytes::BytesMut;
 use dashmap::DashMap;
-use hyperactor as reference;
 use hyperactor::Actor;
 use hyperactor::ActorHandle;
+use hyperactor::ActorRef;
 use hyperactor::Context;
 use hyperactor::HandleClient;
 use hyperactor::Handler;
@@ -364,8 +364,7 @@ impl TcpManagerActor {
         client: &(impl context::Actor + Send + Sync),
     ) -> Result<ActorHandle<Self>, anyhow::Error> {
         let rdma_handle = RdmaManagerActor::local_handle(client);
-        let tcp_ref: reference::ActorRef<TcpManagerActor> =
-            rdma_handle.get_tcp_actor_ref(client).await?;
+        let tcp_ref: ActorRef<TcpManagerActor> = rdma_handle.get_tcp_actor_ref(client).await?;
         tcp_ref
             .downcast_handle(client)
             .ok_or_else(|| anyhow::anyhow!("TcpManagerActor is not in the local process"))

--- a/monarch_rdma/src/rdma_components.rs
+++ b/monarch_rdma/src/rdma_components.rs
@@ -46,7 +46,6 @@ use std::result::Result;
 use std::sync::Arc;
 use std::time::Duration;
 
-use hyperactor as reference;
 use hyperactor::ActorRef;
 use hyperactor::context;
 use serde::Deserialize;
@@ -75,7 +74,7 @@ use crate::local_memory::RdmaLocalMemory;
 pub struct RdmaRemoteBuffer {
     pub id: usize,
     pub size: usize,
-    pub owner: reference::ActorRef<RdmaManagerActor>,
+    pub owner: ActorRef<RdmaManagerActor>,
     pub backends: Vec<RdmaRemoteBackendContext>,
 }
 wirevalue::register_type!(RdmaRemoteBuffer);
@@ -216,7 +215,7 @@ impl RdmaRemoteBuffer {
     ///
     /// Returns `None` if the buffer has no ibverbs backend context
     /// (i.e., the remote side was created without ibverbs).
-    pub fn resolve_ibv(&self) -> Option<(reference::ActorRef<IbvManagerActor>, IbvBuffer)> {
+    pub fn resolve_ibv(&self) -> Option<(ActorRef<IbvManagerActor>, IbvBuffer)> {
         self.backends.iter().find_map(|b| match b {
             RdmaRemoteBackendContext::Ibverbs(mgr, buf) => Some((mgr.clone(), buf.clone())),
             _ => None,

--- a/monarch_rdma/src/rdma_manager_actor.rs
+++ b/monarch_rdma/src/rdma_manager_actor.rs
@@ -27,14 +27,15 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use hyperactor as reference;
 use hyperactor::Actor;
 use hyperactor::ActorHandle;
+use hyperactor::ActorRef;
 use hyperactor::Context;
 use hyperactor::HandleClient;
 use hyperactor::Handler;
 use hyperactor::Instance;
 use hyperactor::OncePortHandle;
+use hyperactor::OncePortRef;
 use hyperactor::RefClient;
 use hyperactor::RemoteSpawn;
 use hyperactor::context;
@@ -100,7 +101,7 @@ wirevalue::register_type!(ReleaseBuffer);
 #[derive(Handler, HandleClient, RefClient, Debug, Serialize, Deserialize, Named)]
 pub struct GetIbvActorRef {
     #[reply]
-    pub reply: reference::OncePortRef<Option<reference::ActorRef<IbvManagerActor>>>,
+    pub reply: OncePortRef<Option<ActorRef<IbvManagerActor>>>,
 }
 wirevalue::register_type!(GetIbvActorRef);
 
@@ -109,7 +110,7 @@ wirevalue::register_type!(GetIbvActorRef);
 #[derive(Handler, HandleClient, RefClient, Debug, Serialize, Deserialize, Named)]
 pub struct GetTcpActorRef {
     #[reply]
-    pub reply: reference::OncePortRef<reference::ActorRef<TcpManagerActor>>,
+    pub reply: OncePortRef<ActorRef<TcpManagerActor>>,
 }
 wirevalue::register_type!(GetTcpActorRef);
 
@@ -162,7 +163,7 @@ impl RdmaManagerActor {
     /// Construct an [`ActorHandle`] for the [`RdmaManagerActor`] co-located
     /// with the caller.
     pub fn local_handle(client: &impl context::Actor) -> ActorHandle<Self> {
-        let actor_ref = reference::ActorRef::attest(
+        let actor_ref = ActorRef::attest(
             client
                 .mailbox()
                 .actor_addr()
@@ -249,7 +250,7 @@ impl GetIbvActorRefHandler for RdmaManagerActor {
     async fn get_ibv_actor_ref(
         &mut self,
         _cx: &Context<Self>,
-    ) -> Result<Option<reference::ActorRef<IbvManagerActor>>, anyhow::Error> {
+    ) -> Result<Option<ActorRef<IbvManagerActor>>, anyhow::Error> {
         Ok(self.ibverbs.as_ref().map(|ibv| ibv.handle().bind()))
     }
 }
@@ -260,7 +261,7 @@ impl GetTcpActorRefHandler for RdmaManagerActor {
     async fn get_tcp_actor_ref(
         &mut self,
         _cx: &Context<Self>,
-    ) -> Result<reference::ActorRef<TcpManagerActor>, anyhow::Error> {
+    ) -> Result<ActorRef<TcpManagerActor>, anyhow::Error> {
         Ok(self.tcp.handle().bind())
     }
 }


### PR DESCRIPTION
Summary:

Removes the `use hyperactor as reference;` alias from every file in `monarch_rdma/`.

Reviewed By: dulinriley

Differential Revision: D104113770


