### PR TITLE
bump test_concurrent_send_to_same_target wrapper to 120s (#3793)

### DIFF
--- a/monarch_rdma/src/backend/ibverbs/ibv_manager_actor_tests.rs
+++ b/monarch_rdma/src/backend/ibverbs/ibv_manager_actor_tests.rs
@@ -635,7 +635,11 @@ mod tests {
         Ok(())
     }
 
-    #[timed_test::async_timed_test(timeout_secs = 30)]
+    // Wrapper is intentionally generous: under full-suite parallel
+    // load, `IbvTestEnv::setup` (proc spawn + CUDA ctx + buffer
+    // registration) alone takes >30s, while the actual concurrent
+    // reads are tens to hundreds of ms.
+    #[timed_test::async_timed_test(timeout_secs = 120)]
     async fn test_concurrent_send_to_same_target() -> Result<(), anyhow::Error> {
         const BSIZE: usize = 2 * 1024 * 1024;
         let devices = get_all_devices();


### PR DESCRIPTION
Summary:

When running many tests at once, `IbvTestEnv::setup` (proc spawn + CUDA ctx + buffer registration) alone takes >30s, while the test's actual concurrent `read_into_local` calls run in tens to hundreds of ms. The 30s wrapper is causing flaky timeouts and is not a meaningful bound on the test's work. Bumping to 120s makes the test pass reliably under load. The slowness reproduces on master and is independent of any in-flight RDMA stack work.

Differential Revision: D104255552


