### PR TITLE
pass missing per_rank_bootstrap to host_mesh.spawn

### DIFF
--- a/monarch_rdma/src/backend/ibverbs/mlx5dv_tests.rs
+++ b/monarch_rdma/src/backend/ibverbs/mlx5dv_tests.rs
@@ -170,6 +170,7 @@ async fn test_indirect_mkey_rebind_grows_existing_segment() -> Result<(), anyhow
             "rebind_grow_procs",
             hyperactor_mesh::extent!(procs = 2),
             None,
+            None,
         )
         .await?;
 
@@ -324,6 +325,7 @@ async fn test_indirect_mkey_rebind_falls_back_to_dmabuf_at_max_sge() -> Result<(
             instance,
             "rebind_failover_procs",
             hyperactor_mesh::extent!(procs = 2),
+            None,
             None,
         )
         .await?;


### PR DESCRIPTION
Summary: The two `HostMesh::spawn` calls in `mlx5dv_tests.rs` were stuck on the previous four-arg signature. The current signature in `hyperactor_mesh::host_mesh::HostMesh::spawn` takes a fifth argument, `per_rank_bootstrap: Option<Box<PerRankBootstrapFn>>`, so the file no longer compiled — passing `None` for both `proc_bind` and `per_rank_bootstrap` matches the previous behavior.

Differential Revision: D104306915


