### PR TITLE
Add cuda_tensor buffer_type to rdma_pingpong (#3799)

### DIFF
--- a/examples/rdma_pingpong/README.md
+++ b/examples/rdma_pingpong/README.md
@@ -1,0 +1,71 @@
+# RDMA Pingpong
+
+A two-node RDMA pingpong example that exchanges buffers between actors via `RDMABuffer` and reports per-iteration bandwidth. Supports `slurm`, `mast`, and `k8s` backends via the `--backend` flag.
+
+## Slurm
+
+```bash
+python rdma_pingpong.py \
+  --backend=slurm \
+  --data_size_mb=1000 \
+  --num_iterations=3
+```
+
+## Kubernetes
+
+### Prerequisites
+
+- A Kubernetes cluster with the [Monarch CRD and operator](https://github.com/meta-pytorch/monarch-kubernetes/) installed
+- `kubectl` configured to access the cluster
+- The `monarch-tests` namespace created:
+  ```bash
+  kubectl create namespace monarch-tests
+  ```
+- Worker nodes that expose an `rdma/ib` device plugin and `nvidia.com/gpu` resources
+
+### 1. Apply RBAC + driver pod
+
+```bash
+kubectl apply -f kubernetes_provision.yaml
+```
+
+### 2. Wait for the driver to be Ready
+
+The driver `pip install`s `fire` and `xxhash` on startup; wait for its readiness probe:
+
+```bash
+kubectl -n monarch-tests wait --for=condition=Ready \
+  pod/rdma-pingpong-driver --timeout=5m
+```
+
+### 3. Copy the script into the driver
+
+```bash
+kubectl -n monarch-tests cp rdma_pingpong.py \
+  rdma-pingpong-driver:/tmp/rdma_pingpong.py
+```
+
+### 4. Launch
+
+Worker pods provisioned by the MonarchMesh operator use the same image as the driver:
+
+```bash
+kubectl -n monarch-tests exec -it rdma-pingpong-driver -- \
+  python -u /tmp/rdma_pingpong.py \
+    --backend=k8s \
+    --data_size_mb=1000 \
+    --num_iterations=3
+```
+
+### 5. Cleanup
+
+```bash
+kubectl -n monarch-tests delete monarchmesh workers
+kubectl delete -f kubernetes_provision.yaml
+```
+
+### Notes on cross-host fabric
+
+The k8s backend attaches a hard `requiredDuringSchedulingIgnoredDuringExecution` pod anti-affinity keyed on the operator's `monarch.pytorch.org/mesh-name=workers` label with `topologyKey: kubernetes.io/hostname`. This forces the two replicas onto distinct nodes so the pingpong actually exercises the cross-host RDMA fabric instead of a same-HCA loopback path.
+
+Requesting `rdma/ib: 1` only guarantees each pod gets an IB device; it does NOT guarantee the two pods can reach each other over IB. On clusters with multiple isolated IB fabrics, add a required `pod_affinity` term keyed on your provider's fabric label so the two replicas land on the same fabric. Without it, the example will fail.

--- a/examples/rdma_pingpong/kubernetes_provision.yaml
+++ b/examples/rdma_pingpong/kubernetes_provision.yaml
@@ -1,0 +1,62 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: rdma-pingpong-driver
+  namespace: monarch-tests
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: rdma-pingpong-driver
+  namespace: monarch-tests
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["monarch.pytorch.org"]
+    resources: ["monarchmeshes"]
+    verbs: ["create", "get", "patch", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: rdma-pingpong-driver
+  namespace: monarch-tests
+subjects:
+  - kind: ServiceAccount
+    name: rdma-pingpong-driver
+    namespace: monarch-tests
+roleRef:
+  kind: Role
+  name: rdma-pingpong-driver
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: rdma-pingpong-driver
+  namespace: monarch-tests
+spec:
+  serviceAccountName: rdma-pingpong-driver
+  restartPolicy: Never
+  containers:
+    - name: driver
+      image: ghcr.io/meta-pytorch/monarch:latest
+      command: ["/bin/sh", "-c"]
+      args:
+        - |
+          pip install --quiet --break-system-packages fire xxhash && \
+          sleep infinity
+      readinessProbe:
+        exec:
+          command: ["python", "-c", "import fire, xxhash, monarch"]
+        initialDelaySeconds: 5
+        periodSeconds: 3
+        timeoutSeconds: 3
+        failureThreshold: 60

--- a/examples/rdma_pingpong/rdma_pingpong.py
+++ b/examples/rdma_pingpong/rdma_pingpong.py
@@ -26,15 +26,16 @@ def _checksum(buf: bytes) -> str:
 class PingPongActor(Actor):
     """Actor that participates in RDMA pingpong."""
 
-    def __init__(self, size_bytes: int, buffer_type: str = "tensor"):
+    def __init__(self, size_bytes: int, buffer_type: str = "cpu_tensor"):
         self.hostname = socket.gethostname()
         self.size_bytes = size_bytes
         self.buffer_type = buffer_type
 
-        if buffer_type == "tensor":
+        if buffer_type in ("cpu_tensor", "cuda_tensor"):
             n = size_bytes // 4
-            self.data = torch.rand(n, dtype=torch.float32)
-            self.recv_buf = torch.zeros(n, dtype=torch.float32)
+            device = "cuda" if buffer_type == "cuda_tensor" else "cpu"
+            self.data = torch.rand(n, dtype=torch.float32, device=device)
+            self.recv_buf = torch.zeros(n, dtype=torch.float32, device=device)
         elif buffer_type == "bytearray":
             self.data = bytearray(os.urandom(size_bytes))
             self.recv_buf = bytearray(size_bytes)
@@ -58,7 +59,7 @@ class PingPongActor(Actor):
 
     @endpoint
     async def get_buffer(self) -> RDMABuffer:
-        if self.buffer_type == "tensor":
+        if self.buffer_type in ("cpu_tensor", "cuda_tensor"):
             return RDMABuffer(self.data.view(torch.uint8).flatten())
         else:
             return RDMABuffer(memoryview(self.data))
@@ -66,7 +67,7 @@ class PingPongActor(Actor):
     @endpoint
     async def read_from(self, peer_buf: RDMABuffer) -> float:
         """Read peer's data into recv_buf, return elapsed seconds."""
-        if self.buffer_type == "tensor":
+        if self.buffer_type in ("cpu_tensor", "cuda_tensor"):
             self.recv_buf.zero_()
             local = self.recv_buf.view(torch.uint8).flatten()
         elif self.buffer_type == "bytearray":
@@ -86,8 +87,10 @@ class PingPongActor(Actor):
     @endpoint
     async def checksum(self, which: str = "data") -> str:
         buf = self.data if which == "data" else self.recv_buf
-        if self.buffer_type == "tensor":
-            raw = buf.numpy().tobytes()
+        if self.buffer_type in ("cpu_tensor", "cuda_tensor"):
+            # .cpu() is a no-op on CPU tensors, required for cuda_tensor
+            # since numpy doesn't accept CUDA storage.
+            raw = buf.cpu().numpy().tobytes()
         else:
             raw = bytes(buf)
         return _checksum(raw)
@@ -104,16 +107,16 @@ def main(
     rm_attribution: str = "msl_infra_pytorch_dev",
     k8s_namespace: str = "monarch-tests",
     k8s_image: str = "ghcr.io/meta-pytorch/monarch:latest",
-    buffer_type: str = "tensor",
+    buffer_type: str = "cpu_tensor",
 ):
     """RDMA Pingpong: transfer data between two nodes via RDMABuffer."""
     sys.stdout.reconfigure(line_buffering=True)
     size = data_size_mb * 1024 * 1024
 
-    if buffer_type not in ("tensor", "bytearray", "memoryview"):
+    if buffer_type not in ("cpu_tensor", "cuda_tensor", "bytearray", "memoryview"):
         raise ValueError(
             f"Unknown buffer_type: {buffer_type!r}; "
-            "choose from 'tensor', 'bytearray', 'memoryview'"
+            "choose from 'cpu_tensor', 'cuda_tensor', 'bytearray', 'memoryview'"
         )
 
     if backend == "mast":

--- a/examples/rdma_pingpong/rdma_pingpong.py
+++ b/examples/rdma_pingpong/rdma_pingpong.py
@@ -102,6 +102,8 @@ def main(
     hpc_job_oncall: str = "monarch",
     hpc_cluster_uuid: str = "MastGenAICluster",
     rm_attribution: str = "msl_infra_pytorch_dev",
+    k8s_namespace: str = "monarch-tests",
+    k8s_image: str = "ghcr.io/meta-pytorch/monarch:latest",
     buffer_type: str = "tensor",
 ):
     """RDMA Pingpong: transfer data between two nodes via RDMABuffer."""
@@ -130,6 +132,65 @@ def main(
             default_transport=ChannelTransport.MetaTlsWithIpV6,
         )
         job.add_mesh("workers", 2)
+    elif backend == "k8s":
+        from kubernetes.client import (
+            V1Affinity,
+            V1Container,
+            V1EnvVar,
+            V1LabelSelector,
+            V1LabelSelectorRequirement,
+            V1PodAffinityTerm,
+            V1PodAntiAffinity,
+            V1PodSpec,
+            V1ResourceRequirements,
+        )
+        from monarch._src.job.kubernetes import _WORKER_BOOTSTRAP_SCRIPT
+        from monarch.job.kubernetes import KubernetesJob
+
+        # Hard anti-affinity on the operator's per-mesh label forces the two
+        # replicas onto distinct nodes, so RDMA pingpong actually exercises
+        # the cross-host fabric instead of a same-HCA loopback path.
+        #
+        # NOTE: requesting "rdma/ib": 1 only guarantees each pod gets an IB
+        # device; it does NOT guarantee the two pods can reach each other
+        # over IB. On clusters with multiple isolated IB fabrics, add a
+        # required pod_affinity term keyed on your provider's fabric label
+        # so the two replicas land on the same fabric. Without it, the example will fail.
+        worker_resources = {"nvidia.com/gpu": "1", "rdma/ib": "1"}
+        pod_spec = V1PodSpec(
+            affinity=V1Affinity(
+                pod_anti_affinity=V1PodAntiAffinity(
+                    required_during_scheduling_ignored_during_execution=[
+                        V1PodAffinityTerm(
+                            topology_key="kubernetes.io/hostname",
+                            label_selector=V1LabelSelector(
+                                match_expressions=[
+                                    V1LabelSelectorRequirement(
+                                        key="monarch.pytorch.org/mesh-name",
+                                        operator="In",
+                                        values=["workers"],
+                                    ),
+                                ],
+                            ),
+                        ),
+                    ],
+                ),
+            ),
+            containers=[
+                V1Container(
+                    name="worker",
+                    image=k8s_image,
+                    command=["python", "-u", "-c", _WORKER_BOOTSTRAP_SCRIPT],
+                    env=[V1EnvVar(name="MONARCH_PORT", value="26600")],
+                    resources=V1ResourceRequirements(
+                        requests=worker_resources,
+                        limits=worker_resources,
+                    ),
+                ),
+            ],
+        )
+        job = KubernetesJob(namespace=k8s_namespace)
+        job.add_mesh("workers", num_replicas=2, pod_spec=pod_spec)
     else:
         from monarch.job import SlurmJob
 


### PR DESCRIPTION
Summary:

Adds a fourth buffer_type "cuda_tensor" alongside the existing "tensor", "bytearray", and "memoryview" options in examples/rdma_pingpong.py. The new mode allocates the source and receive tensors on a CUDA device, so the example exercises GPUDirect RDMA on pods that already request nvidia.com/gpu and rdma/ib. The previous "tensor" mode allocated on CPU regardless, leaving the GPU idle and silently routing RDMA reads through host memory.

Also rename tensor to cpu_tensor for better clarity.

Reviewed By: cpuhrsch

Differential Revision: D104327229
