### PR TITLE
[monarch_hyperactor] honor exit requests in Python actor loop

### DIFF
--- a/monarch_hyperactor/src/actor.rs
+++ b/monarch_hyperactor/src/actor.rs
@@ -779,7 +779,7 @@ impl PythonActor {
                                 need_drain = matches!(signal, Signal::DrainAndStop(_));
                                 break None;
                             },
-                            Ok(Signal::ExitRequested(_)) => {}
+                            Ok(Signal::ExitRequested(_)) => break None,
                             Ok(Signal::ChildStopped(_)) => {},
                             Ok(Signal::Kill(reason)) => {
                                 break Some(ActorError { actor_id: Box::new(instance.self_addr().clone()), kind: Box::new(ActorErrorKind::Aborted(reason)) })


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #3800
* #3768
* #3767
* #3766
* #3765
* #3764
* #3763
* #3762
* #3761
* #3760
* #3745
* #3744
* #3743
* #3742

The root client PythonActor uses a custom signal loop rather than the standard Hyperactor actor loop. That loop handled Stop and DrainAndStop by breaking out, but ignored ExitRequested, so Instance::exit() and Instance::exit_after_drain() did not stop the actor. Treat ExitRequested as a clean loop exit so Python actors honor the same exit API.

Differential Revision: [D104333648](https://our.internmc.facebook.com/intern/diff/D104333648/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D104333648/)!