### PR TITLE
Fix tokio runtime block with SIGINT (#3801)

### DIFF
--- a/monarch_extension/src/lib.rs
+++ b/monarch_extension/src/lib.rs
@@ -77,8 +77,7 @@ pub fn mod_init(module: &Bound<'_, PyModule>) -> PyResult<()> {
     )?;
 
     monarch_hyperactor::runtime::initialize(module.py())?;
-    let runtime = monarch_hyperactor::runtime::get_tokio_runtime();
-    ::hyperactor::initialize(runtime.handle().clone());
+    ::hyperactor::initialize(monarch_hyperactor::runtime::get_tokio_runtime());
     monarch_hyperactor::buffers::register_python_bindings(&get_or_add_new_module(
         module,
         "monarch_hyperactor.buffers",

--- a/monarch_hyperactor/src/runtime.rs
+++ b/monarch_hyperactor/src/runtime.rs
@@ -8,9 +8,8 @@
 
 use std::future::Future;
 use std::pin::Pin;
+use std::sync::Mutex;
 use std::sync::OnceLock;
-use std::sync::RwLock;
-use std::sync::RwLockReadGuard;
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
 use std::time::Duration;
@@ -29,57 +28,70 @@ use pyo3::exceptions::PyRuntimeError;
 use pyo3::prelude::*;
 use pyo3::types::PyAnyMethods;
 use pyo3_async_runtimes::TaskLocals;
+use tokio::runtime::Handle;
 use tokio::task;
 
-// this must be a RwLock and only return a guard for reading the runtime.
-// Otherwise multiple threads can deadlock fighting for the Runtime object if they hold it
-// while blocking on something.
-static INSTANCE: std::sync::LazyLock<RwLock<Option<tokio::runtime::Runtime>>> =
-    std::sync::LazyLock::new(|| RwLock::new(None));
+/// Global tokio runtime container.
+///
+/// `handle` is cheap to clone and is what callers receive from
+/// `get_tokio_runtime()`. Holding a `Handle` does not lock anything, so
+/// concurrent block_on calls from different threads do not contend.
+///
+/// `runtime` exists only so the atexit handler can take ownership and
+/// call `shutdown_timeout`. Under normal operation nothing locks it; the
+/// mutex is uncontended at shutdown.
+struct GlobalRuntime {
+    handle: Handle,
+    runtime: Mutex<Option<tokio::runtime::Runtime>>,
+}
 
-pub fn get_tokio_runtime<'l>() -> std::sync::MappedRwLockReadGuard<'l, tokio::runtime::Runtime> {
-    // First try to get a read lock and check if runtime exists
-    {
-        let read_guard = INSTANCE.read().unwrap();
-        if read_guard.is_some() {
-            return RwLockReadGuard::map(read_guard, |lock: &Option<tokio::runtime::Runtime>| {
-                lock.as_ref().unwrap()
-            });
+static INSTANCE: OnceLock<GlobalRuntime> = OnceLock::new();
+
+fn global_runtime() -> &'static GlobalRuntime {
+    INSTANCE.get_or_init(|| {
+        let runtime = tokio::runtime::Builder::new_multi_thread()
+            .thread_name_fn(|| {
+                static ATOMIC_ID: AtomicUsize = AtomicUsize::new(0);
+                let id = ATOMIC_ID.fetch_add(1, Ordering::SeqCst);
+                format!("monarch-pytokio-worker-{}", id)
+            })
+            .enable_all()
+            .build()
+            .unwrap();
+        let handle = runtime.handle().clone();
+        GlobalRuntime {
+            handle,
+            runtime: Mutex::new(Some(runtime)),
         }
-        // Drop the read lock by letting it go out of scope
-    }
-
-    // Runtime doesn't exist, upgrade to write lock to initialize
-    let mut write_guard = INSTANCE.write().unwrap();
-    if write_guard.is_none() {
-        *write_guard = Some(
-            tokio::runtime::Builder::new_multi_thread()
-                .thread_name_fn(|| {
-                    static ATOMIC_ID: AtomicUsize = AtomicUsize::new(0);
-                    let id = ATOMIC_ID.fetch_add(1, Ordering::SeqCst);
-                    format!("monarch-pytokio-worker-{}", id)
-                })
-                .enable_all()
-                .build()
-                .unwrap(),
-        );
-    }
-
-    // Downgrade write lock to read lock and return the reference
-    let read_guard = std::sync::RwLockWriteGuard::downgrade(write_guard);
-    RwLockReadGuard::map(read_guard, |lock: &Option<tokio::runtime::Runtime>| {
-        lock.as_ref().unwrap()
     })
 }
 
+pub fn get_tokio_runtime() -> Handle {
+    global_runtime().handle.clone()
+}
+
+/// atexit handler that tears down the global Tokio runtime.
+///
+/// Callers obtain a cloned `Handle` from `get_tokio_runtime()` rather
+/// than a guard, so the `runtime` mutex is uncontended at shutdown. We
+/// can take ownership of the `Runtime` and call `shutdown_timeout`
+/// directly. If a worker thread is still inside `Handle::block_on` on a
+/// future that never resolves (e.g. a non-main thread that cannot
+/// observe SIGINT), `shutdown_timeout` aborts spawned tasks and returns
+/// after at most one second; the stuck worker is then a daemon thread
+/// that CPython kills on interpreter exit.
 #[pyfunction]
 pub fn shutdown_tokio_runtime(py: Python<'_>) {
     // Called from Python's atexit, which holds the GIL. Release it so tokio
     // worker threads can acquire it to complete their Python work.
     py.detach(|| {
-        if let Some(x) = INSTANCE.write().unwrap().take() {
-            x.shutdown_timeout(Duration::from_secs(1));
-        }
+        let Some(global) = INSTANCE.get() else {
+            return;
+        };
+        let Some(rt) = global.runtime.lock().unwrap().take() else {
+            return;
+        };
+        rt.shutdown_timeout(Duration::from_secs(1));
     });
 }
 


### PR DESCRIPTION
Summary:

Pressing Ctrl-C on a Monarch process can hang indefinitely until SIGKILL when **any** non-main thread is parked inside `signal_safe_block_on`. The user-visible symptom looks like "SIGINT is ignored," but the signal is actually delivered and Python raises `KeyboardInterrupt` on the main thread — the program just cannot finish exiting. Two compounding causes:

1. **Worker thread cannot leave `block_on()` on its own.** The non-main branch of `signal_safe_block_on` (`runtime.rs`) is a plain `runtime.block_on(future)` with no signal-checking `tokio::select!` and no cancellation hook. Per the existing comment, `PyErr_CheckSignals` is a no-op off the main thread, so the worker has no path out until its future naturally resolves. This fires for any non-main thread that enters `signal_safe_block_on` — directly via `PyPythonTask.block_on()` / `PyShared.block_on()` from worker code, indirectly via `Future.get()`, or via anything else routing through `signal_safe_block_on` off the main thread. The asyncio event-loop thread set up by `create_task_locals` (`actor.rs`) is one common instance, but it is incidental: the same hang reproduces on a plain `threading.Thread` with no asyncio loop involved.

2. **Interpreter shutdown deadlocks against that worker.** `get_tokio_runtime()` previously returned a `MappedRwLockReadGuard` over a global `RwLock<Option<Runtime>>`, and `signal_safe_block_on` held that read guard for the entire duration of `runtime.block_on(...)`. The atexit handler `shutdown_tokio_runtime` took `INSTANCE.write().unwrap().take()` — that write call blocked waiting for the still-held read guard. CPython only forcibly stops daemon threads *after* atexit completes, so even though every Monarch-owned Python thread is already `daemon=True` (e.g. the `create_task_locals` asyncio loop in `actor.rs`, the `event_loop.py` thread, the `logging.py` stdout/stderr pumps), interpreter shutdown still hung in atexit and the process had to be SIGKILLed.

This commit addresses (2) by removing the user-level lock around the runtime entirely. The previous `RwLock` existed solely so atexit could `take()` the `Runtime` to call `shutdown_timeout(self)`; the read-guard requirement on the hot path was a downstream consequence of that, not the goal. We now keep the `Runtime` in a `OnceLock<GlobalRuntime>` where `GlobalRuntime` holds a cloned `Handle` for hot-path access and a `Mutex<Option<Runtime>>` used only by atexit. `get_tokio_runtime()` returns `Handle::clone()` with no lock held; `shutdown_tokio_runtime` takes the runtime out of the (uncontended) mutex and calls `shutdown_timeout` directly. No `try_write` / leak fallback is needed.

**Why handing out a `Handle` is safe.** A `Handle` is a small struct of `Arc`s pointing at the scheduler, IO/timer drivers, and blocking-pool spawner; cloning it is `Arc::clone` × a few, cheaper than traversing `RwLock` reader state. The runtime does use synchronization internally — the inject queue, driver poll loops, parking primitives — but those critical sections live entirely inside tokio's own machinery, never span a user `.await`, and produce contention but not deadlock. The original "this must be a `RwLock`" comment in this file was guarding against a *user-level* lock held *across* `block_on(future)` (the classic `Mutex<Runtime>` deadlock); with `Handle` there is no user-level lock on the hot path at all. The scheduler internals are identical to what the previous `RwLockReadGuard<Runtime>` design was driving — the `RwLock` layer only enforced the shutdown invariant, it did not add sharing safety.

**Hazard: `Handle::block_on` after the runtime is dropped.** With the old design the read guard kept the `Runtime` alive for as long as any caller was inside `block_on`. With this design, atexit can run `shutdown_timeout` while a wedged non-main worker is still inside `Handle::block_on(future)`. After `shutdown_timeout` returns (≤1s), the `Runtime` is dropped: spawned tasks are aborted, timers and IO drivers stop ticking, and the future may never make further progress. The worker is then a parked Python daemon thread that CPython kills during interpreter shutdown. End state matches the previous `try_write`+leak path, and the user-visible bug (atexit hang on Ctrl-C) is resolved either way — but the runtime-drop-during-`block_on` window is new and should be acknowledged in review.

Cause (1) remains — a worker thread can still spend an arbitrary amount of time in `block_on()` before the process exits — but the program no longer hangs forever in atexit, which was the actual blocker for Ctrl-C.

Reviewed By: mariusae

Differential Revision: D104446546


