### PR TITLE
[monarch] remove vestigial hyperactor_reference imports

### DIFF
--- a/hyperactor_mesh/src/host_mesh/host_agent.rs
+++ b/hyperactor_mesh/src/host_mesh/host_agent.rs
@@ -22,15 +22,16 @@ use std::sync::OnceLock;
 
 use async_trait::async_trait;
 use enum_as_inner::EnumAsInner;
-use hyperactor as hyperactor_reference;
 use hyperactor::Actor;
 use hyperactor::ActorHandle;
+use hyperactor::ActorRef;
 use hyperactor::Addr;
 use hyperactor::Context;
 use hyperactor::HandleClient;
 use hyperactor::Handler;
 use hyperactor::Instance;
 use hyperactor::PortHandle;
+use hyperactor::PortRef;
 use hyperactor::Proc;
 use hyperactor::ProcAddr;
 use hyperactor::RefClient;
@@ -172,7 +173,7 @@ impl HostAgentMode {
 pub(crate) struct ProcCreationState {
     pub(crate) rank: usize,
     pub(crate) host_mesh_id: Option<HostMeshId>,
-    pub(crate) created: Result<(ProcAddr, hyperactor_reference::ActorRef<ProcAgent>), HostError>,
+    pub(crate) created: Result<(ProcAddr, ActorRef<ProcAgent>), HostError>,
 }
 
 /// Actor name used when spawning the host mesh agent on the system proc.
@@ -206,7 +207,7 @@ struct ProcStatusChanged {
 /// Not exported — delivered locally via PortHandle (no serialization).
 struct DrainComplete {
     host: HostAgentMode,
-    ack: hyperactor_reference::PortRef<()>,
+    ack: PortRef<()>,
 }
 
 /// Child actor whose only job is to run `host.terminate_children()` in
@@ -218,7 +219,7 @@ struct DrainWorker {
     host: Option<HostAgentMode>,
     timeout: Duration,
     max_in_flight: usize,
-    ack: Option<hyperactor_reference::PortRef<()>>,
+    ack: Option<PortRef<()>>,
     done_notify: PortHandle<DrainComplete>,
 }
 
@@ -285,14 +286,8 @@ pub struct HostAgent {
     /// Pending `WaitRankStatus` waiters, keyed by resource name.
     /// Each entry is `(min_status, rank, reply_port)`. Only touched
     /// from `&mut self` handlers.
-    pending_proc_waiters: HashMap<
-        ResourceId,
-        Vec<(
-            resource::Status,
-            usize,
-            hyperactor_reference::PortRef<crate::StatusOverlay>,
-        )>,
-    >,
+    pending_proc_waiters:
+        HashMap<ResourceId, Vec<(resource::Status, usize, PortRef<crate::StatusOverlay>)>>,
     /// Procs that already have an active bridge task watching their status.
     watching: HashSet<ResourceId>,
     /// Port handle for sending `ProcStatusChanged` to self. Set in `init()`.
@@ -1157,9 +1152,9 @@ impl Handler<ShutdownHost> for HostAgent {
 
 #[derive(Debug, Clone, PartialEq, Eq, Named, Serialize, Deserialize)]
 pub struct ProcState {
-    pub proc_id: hyperactor_reference::ProcAddr,
+    pub proc_id: ProcAddr,
     pub create_rank: usize,
-    pub mesh_agent: hyperactor_reference::ActorRef<ProcAgent>,
+    pub mesh_agent: ActorRef<ProcAgent>,
     pub bootstrap_command: Option<BootstrapCommand>,
     pub proc_status: Option<bootstrap::ProcStatus>,
 }
@@ -1258,7 +1253,7 @@ impl Handler<resource::List> for HostAgent {
 pub struct SetClientConfig {
     pub attrs: Attrs,
     #[reply]
-    pub done: hyperactor_reference::PortRef<()>,
+    pub done: PortRef<()>,
 }
 wirevalue::register_type!(SetClientConfig);
 
@@ -1358,6 +1353,7 @@ impl Handler<ConfigDump> for HostAgent {
 mod tests {
     use std::assert_matches;
 
+    use hyperactor::ActorAddr;
     use hyperactor::Proc;
     use hyperactor::channel::ChannelTransport;
     use hyperactor::id::Label;
@@ -1426,7 +1422,7 @@ mod tests {
                 ..
             } if id == resource_id
               && proc_id == id.proc_addr(host_addr.clone())
-              && mesh_agent == hyperactor_reference::ActorRef::attest(id.proc_addr(host_addr.clone()).actor_addr(crate::proc_agent::PROC_AGENT_ACTOR_NAME)) && bootstrap_command == Some(BootstrapCommand::test())
+              && mesh_agent == ActorRef::attest(id.proc_addr(host_addr.clone()).actor_addr(crate::proc_agent::PROC_AGENT_ACTOR_NAME)) && bootstrap_command == Some(BootstrapCommand::test())
               && mesh_agent == proc_status_mesh_agent
         );
     }
@@ -1772,7 +1768,6 @@ mod tests {
     #[tokio::test]
     #[cfg(fbcode_build)]
     async fn test_service_proc_query_child_has_queue_stats() {
-        use hyperactor as hyperactor_reference;
         use hyperactor::actor::ActorStatus;
         use hyperactor::introspect::IntrospectMessage;
         use hyperactor::introspect::IntrospectResult;
@@ -1824,9 +1819,8 @@ mod tests {
         let agent_ref = system_proc
             .proc_addr()
             .actor_addr(HOST_MESH_AGENT_ACTOR_NAME);
-        let agent_id: hyperactor_reference::ActorAddr = agent_ref;
-        let port =
-            hyperactor_reference::PortRef::<IntrospectMessage>::attest_message_port(&agent_id);
+        let agent_id: ActorAddr = agent_ref;
+        let port = PortRef::<IntrospectMessage>::attest_message_port(&agent_id);
 
         // Poll until we see non-zero watermark (evidence of queue
         // traffic since startup).
@@ -1836,7 +1830,7 @@ mod tests {
             port.send(
                 &client,
                 IntrospectMessage::QueryChild {
-                    child_ref: hyperactor_reference::Addr::Proc(system_proc.proc_addr().clone()),
+                    child_ref: Addr::Proc(system_proc.proc_addr().clone()),
                     reply: reply_port.bind(),
                 },
             )

--- a/hyperactor_mesh/src/mesh_admin.rs
+++ b/hyperactor_mesh/src/mesh_admin.rs
@@ -348,13 +348,15 @@ use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use axum::routing::get;
 use axum::routing::post;
-use hyperactor as hyperactor_reference;
 use hyperactor::Actor;
 use hyperactor::ActorHandle;
+use hyperactor::ActorRef;
 use hyperactor::Context;
 use hyperactor::HandleClient;
 use hyperactor::Handler;
 use hyperactor::Instance;
+use hyperactor::OncePortRef;
+use hyperactor::ProcAddr;
 use hyperactor::RefClient;
 use hyperactor::channel::try_tls_acceptor;
 use hyperactor::introspect::IntrospectMessage;
@@ -547,7 +549,7 @@ pub enum MeshAdminMessage {
     /// The reply contains `None` if the server hasn't started yet.
     GetAdminAddr {
         #[reply]
-        reply: hyperactor_reference::OncePortRef<MeshAdminAddrResponse>,
+        reply: OncePortRef<MeshAdminAddrResponse>,
     },
 }
 wirevalue::register_type!(MeshAdminMessage);
@@ -596,7 +598,7 @@ pub enum ResolveReferenceMessage {
         reference_string: String,
         /// Reply port receiving the resolution result.
         #[reply]
-        reply: hyperactor_reference::OncePortRef<ResolveReferenceResponse>,
+        reply: OncePortRef<ResolveReferenceResponse>,
     },
 }
 wirevalue::register_type!(ResolveReferenceMessage);
@@ -604,7 +606,7 @@ wirevalue::register_type!(ResolveReferenceMessage);
 /// Actor that serves a mesh-level admin HTTP endpoint.
 ///
 /// `MeshAdminAgent` is the mesh-wide aggregation point for
-/// introspection: it holds `hyperactor_reference::ActorRef<HostAgent>` handles for each
+/// introspection: it holds `ActorRef<HostAgent>` handles for each
 /// host, and answers admin queries by forwarding targeted requests to
 /// the appropriate host agent and assembling a uniform `NodePayload`
 /// response for the client.
@@ -617,7 +619,7 @@ wirevalue::register_type!(ResolveReferenceMessage);
 pub struct MeshAdminAgent {
     /// Map of host address string → `HostAgent` reference used to
     /// fan out our target admin queries.
-    hosts: HashMap<String, hyperactor_reference::ActorRef<HostAgent>>,
+    hosts: HashMap<String, ActorRef<HostAgent>>,
 
     /// Reverse index: `HostAgent` `ActorAddr` → host address
     /// string.
@@ -699,7 +701,7 @@ impl MeshAdminAgent {
     /// The HTTP listen address is initialized to `None` and populated
     /// during `init()` after the server socket is bound.
     pub fn new(
-        hosts: Vec<(String, hyperactor_reference::ActorRef<HostAgent>)>,
+        hosts: Vec<(String, ActorRef<HostAgent>)>,
         root_client_actor_id: Option<hyperactor::ActorAddr>,
         admin_addr: Option<std::net::SocketAddr>,
         telemetry_url: Option<String>,
@@ -797,7 +799,7 @@ impl AdminInfo {
 struct BridgeState {
     /// Addr to the `MeshAdminAgent` actor that performs
     /// reference resolution.
-    admin_ref: hyperactor_reference::ActorRef<MeshAdminAgent>,
+    admin_ref: ActorRef<MeshAdminAgent>,
     /// Dedicated client mailbox on system_proc for HTTP bridge reply
     /// ports. Using a separate `Instance<()>` avoids sharing the
     /// actor's own mailbox with the HTTP bridge and ensures the
@@ -993,7 +995,7 @@ impl Actor for MeshAdminAgent {
             .clone()
             .unwrap_or_else(|| "unknown".to_string());
         let bridge_state = Arc::new(BridgeState {
-            admin_ref: hyperactor_reference::ActorRef::attest(this.self_addr().clone()),
+            admin_ref: ActorRef::attest(this.self_addr().clone()),
             bridge_cx,
             resolve_semaphore: tokio::sync::Semaphore::new(hyperactor_config::global::get(
                 crate::config::MESH_ADMIN_MAX_CONCURRENT_RESOLVES,
@@ -1188,10 +1190,7 @@ impl MeshAdminAgent {
 
     /// If `proc_id` belongs to a standalone proc, return the anchor
     /// actor on that proc. Returns `None` for host-managed procs.
-    fn standalone_proc_anchor(
-        &self,
-        proc_id: &hyperactor_reference::ProcAddr,
-    ) -> Option<&hyperactor::ActorAddr> {
+    fn standalone_proc_anchor(&self, proc_id: &ProcAddr) -> Option<&hyperactor::ActorAddr> {
         self.standalone_proc_actors()
             .find(|actor_id| actor_id.proc_addr() == *proc_id)
     }
@@ -1275,7 +1274,7 @@ impl MeshAdminAgent {
     async fn resolve_proc_node(
         &self,
         cx: &Context<'_, Self>,
-        proc_id: &hyperactor_reference::ProcAddr,
+        proc_id: &ProcAddr,
     ) -> Result<NodePayload, anyhow::Error> {
         let host_addr = proc_id.addr().to_string();
 
@@ -1340,7 +1339,7 @@ impl MeshAdminAgent {
     async fn resolve_standalone_proc_node(
         &self,
         cx: &Context<'_, Self>,
-        proc_id: &hyperactor_reference::ProcAddr,
+        proc_id: &ProcAddr,
     ) -> Result<NodePayload, anyhow::Error> {
         let actor_id = self
             .standalone_proc_anchor(proc_id)
@@ -2056,7 +2055,7 @@ async fn serve_openapi() -> Result<axum::response::Json<serde_json::Value>, ApiE
 
 /// Validate and parse a raw proc reference path segment into a
 /// decoded reference string and `ProcAddr`. Extracted for testability.
-fn parse_proc_reference(raw: &str) -> Result<(String, hyperactor_reference::ProcAddr), ApiError> {
+fn parse_proc_reference(raw: &str) -> Result<(String, ProcAddr), ApiError> {
     let trimmed = raw.trim_start_matches('/');
     if trimmed.is_empty() {
         return Err(ApiError::bad_request("empty proc reference", None));
@@ -2069,7 +2068,7 @@ fn parse_proc_reference(raw: &str) -> Result<(String, hyperactor_reference::Proc
                 None,
             )
         })?;
-    let proc_id: hyperactor_reference::ProcAddr = decoded
+    let proc_id: ProcAddr = decoded
         .parse()
         .map_err(|e| ApiError::bad_request(format!("invalid proc reference: {}", e), None))?;
     Ok((decoded, proc_id))
@@ -2136,8 +2135,8 @@ async fn probe_actor(
 /// minting point is `route_proc_handler` via `ActorRef::attest`.
 /// After minting, all sends go through typed `ActorRef::send`.
 enum ResolvedProcHandler {
-    Host(hyperactor_reference::ActorRef<HostAgent>),
-    Proc(hyperactor_reference::ActorRef<ProcAgent>),
+    Host(ActorRef<HostAgent>),
+    Proc(ActorRef<ProcAgent>),
 }
 
 impl ResolvedProcHandler {
@@ -2264,14 +2263,10 @@ fn route_proc_handler(raw_proc_reference: &str) -> Result<ResolvedProcHandler, A
         .is_some_and(|label| label.as_str() == SERVICE_PROC_NAME);
     if is_service {
         let agent_id = proc_id.actor_addr(HOST_MESH_AGENT_ACTOR_NAME);
-        Ok(ResolvedProcHandler::Host(
-            hyperactor_reference::ActorRef::attest(agent_id),
-        ))
+        Ok(ResolvedProcHandler::Host(ActorRef::attest(agent_id)))
     } else {
         let agent_id = proc_id.actor_addr(PROC_AGENT_ACTOR_NAME);
-        Ok(ResolvedProcHandler::Proc(
-            hyperactor_reference::ActorRef::attest(agent_id),
-        ))
+        Ok(ResolvedProcHandler::Proc(ActorRef::attest(agent_id)))
     }
 }
 
@@ -3241,10 +3236,8 @@ mod tests {
         let actor_id1 = proc1.actor_addr("mesh_agent");
         let actor_id2 = proc2.actor_addr("mesh_agent");
 
-        let ref1: hyperactor_reference::ActorRef<HostAgent> =
-            hyperactor_reference::ActorRef::attest(actor_id1.clone());
-        let ref2: hyperactor_reference::ActorRef<HostAgent> =
-            hyperactor_reference::ActorRef::attest(actor_id2.clone());
+        let ref1: ActorRef<HostAgent> = ActorRef::attest(actor_id1.clone());
+        let ref2: ActorRef<HostAgent> = ActorRef::attest(actor_id2.clone());
 
         let agent = MeshAdminAgent::new(
             vec![("host_a".to_string(), ref1), ("host_b".to_string(), ref2)],
@@ -3326,7 +3319,7 @@ mod tests {
                 HostAgent::new(HostAgentMode::Local(host)),
             )
             .unwrap();
-        let host_agent_ref: hyperactor_reference::ActorRef<HostAgent> = host_agent_handle.bind();
+        let host_agent_ref: ActorRef<HostAgent> = host_agent_handle.bind();
         let host_addr_str = host_addr.to_string();
 
         // -- 2. Spawn MeshAdminAgent on a dedicated test proc --
@@ -3349,7 +3342,7 @@ mod tests {
                 ),
             )
             .unwrap();
-        let admin_ref: hyperactor_reference::ActorRef<MeshAdminAgent> = admin_handle.bind();
+        let admin_ref: ActorRef<MeshAdminAgent> = admin_handle.bind();
 
         // -- 3. Create a bare client instance for sending messages --
         // Only a mailbox is needed for reply ports — no actor message
@@ -3487,8 +3480,8 @@ mod tests {
                 .await
                 .unwrap();
         let host_addr = host.addr().clone();
-        let system_proc_id: hyperactor_reference::ProcAddr = host.system_proc().proc_addr().clone();
-        let local_proc_id: hyperactor_reference::ProcAddr = host.local_proc().proc_addr().clone();
+        let system_proc_id: ProcAddr = host.system_proc().proc_addr().clone();
+        let local_proc_id: ProcAddr = host.local_proc().proc_addr().clone();
         let system_proc = host.system_proc().clone();
         let host_agent_handle = system_proc
             .spawn(
@@ -3496,7 +3489,7 @@ mod tests {
                 HostAgent::new(HostAgentMode::Local(host)),
             )
             .unwrap();
-        let host_agent_ref: hyperactor_reference::ActorRef<HostAgent> = host_agent_handle.bind();
+        let host_agent_ref: ActorRef<HostAgent> = host_agent_handle.bind();
         let host_addr_str = host_addr.to_string();
 
         // Spawn MeshAdminAgent on a dedicated test proc.
@@ -3516,7 +3509,7 @@ mod tests {
                 ),
             )
             .unwrap();
-        let admin_ref: hyperactor_reference::ActorRef<MeshAdminAgent> = admin_handle.bind();
+        let admin_ref: ActorRef<MeshAdminAgent> = admin_handle.bind();
 
         // Create a bare client instance for sending messages.
         let client_proc = Proc::direct(ChannelTransport::Unix.any(), "client".to_string()).unwrap();
@@ -3591,8 +3584,7 @@ mod tests {
         let addr1: SocketAddr = "127.0.0.1:9001".parse().unwrap();
         let proc1 = ResourceId::proc_addr_from_name(ChannelAddr::Tcp(addr1), "host1");
         let actor_id1 = hyperactor::ActorAddr::root(proc1, Label::new("mesh_agent").unwrap());
-        let ref1: hyperactor_reference::ActorRef<HostAgent> =
-            hyperactor_reference::ActorRef::attest(actor_id1.clone());
+        let ref1: ActorRef<HostAgent> = ActorRef::attest(actor_id1.clone());
 
         let client_proc_id = ResourceId::proc_addr_from_name(ChannelAddr::Tcp(addr1), "local");
         let client_actor_id = client_proc_id.actor_addr("client");
@@ -3647,8 +3639,7 @@ mod tests {
         let local_proc = host.local_proc();
         let local_proc_id = local_proc.proc_addr().clone();
         let root_client_handle = local_proc.spawn("client", TestIntrospectableActor).unwrap();
-        let root_client_ref: hyperactor_reference::ActorRef<TestIntrospectableActor> =
-            root_client_handle.bind();
+        let root_client_ref: ActorRef<TestIntrospectableActor> = root_client_handle.bind();
         let root_client_actor_id = root_client_ref.actor_addr().clone();
 
         let host_agent_handle = system_proc
@@ -3657,7 +3648,7 @@ mod tests {
                 HostAgent::new(HostAgentMode::Local(host)),
             )
             .unwrap();
-        let host_agent_ref: hyperactor_reference::ActorRef<HostAgent> = host_agent_handle.bind();
+        let host_agent_ref: ActorRef<HostAgent> = host_agent_handle.bind();
         let host_addr_str = host_addr.to_string();
 
         // Spawn MeshAdminAgent on a dedicated test proc with the root
@@ -3679,7 +3670,7 @@ mod tests {
                 ),
             )
             .unwrap();
-        let admin_ref: hyperactor_reference::ActorRef<MeshAdminAgent> = admin_handle.bind();
+        let admin_ref: ActorRef<MeshAdminAgent> = admin_handle.bind();
 
         // Client for sending messages.
         let client_proc =
@@ -3814,7 +3805,7 @@ mod tests {
                 HostAgent::new(HostAgentMode::Local(host)),
             )
             .unwrap();
-        let host_agent_ref: hyperactor_reference::ActorRef<HostAgent> = host_agent_handle.bind();
+        let host_agent_ref: ActorRef<HostAgent> = host_agent_handle.bind();
         let host_addr_str = host_addr.to_string();
 
         // Spawn MeshAdminAgent on a dedicated test proc.
@@ -3834,7 +3825,7 @@ mod tests {
                 ),
             )
             .unwrap();
-        let admin_ref: hyperactor_reference::ActorRef<MeshAdminAgent> = admin_handle.bind();
+        let admin_ref: ActorRef<MeshAdminAgent> = admin_handle.bind();
 
         let client_proc = Proc::direct(ChannelTransport::Unix.any(), "client".to_string()).unwrap();
         let (client, _handle) = client_proc.instance("client").unwrap();
@@ -3918,7 +3909,7 @@ mod tests {
                 HostAgent::new(HostAgentMode::Local(host)),
             )
             .unwrap();
-        let host_agent_ref: hyperactor_reference::ActorRef<HostAgent> = host_agent_handle.bind();
+        let host_agent_ref: ActorRef<HostAgent> = host_agent_handle.bind();
         let host_addr_str = host_addr.to_string();
 
         // -- 2. Spawn MeshAdminAgent on a dedicated test proc --
@@ -3939,7 +3930,7 @@ mod tests {
                 ),
             )
             .unwrap();
-        let admin_ref: hyperactor_reference::ActorRef<MeshAdminAgent> = admin_handle.bind();
+        let admin_ref: ActorRef<MeshAdminAgent> = admin_handle.bind();
 
         // -- 3. Create a bare client instance for sending messages --
         let client_proc = Proc::direct(ChannelTransport::Unix.any(), "client".to_string()).unwrap();
@@ -4240,7 +4231,7 @@ mod tests {
                 HostAgent::new(HostAgentMode::Local(host)),
             )
             .unwrap();
-        let host_agent_ref: hyperactor_reference::ActorRef<HostAgent> = host_agent_handle.bind();
+        let host_agent_ref: ActorRef<HostAgent> = host_agent_handle.bind();
 
         // User proc: own ephemeral Unix socket, own ProcAgent.
         let user_proc =
@@ -4271,7 +4262,7 @@ mod tests {
                 ),
             )
             .unwrap();
-        let admin_ref: hyperactor_reference::ActorRef<MeshAdminAgent> = admin_handle.bind();
+        let admin_ref: ActorRef<MeshAdminAgent> = admin_handle.bind();
 
         let client_proc = Proc::direct(ChannelTransport::Unix.any(), "client".to_string()).unwrap();
         let (client, _client_handle) = client_proc.instance("client").unwrap();

--- a/hyperactor_mesh/src/proc_agent.rs
+++ b/hyperactor_mesh/src/proc_agent.rs
@@ -18,8 +18,8 @@ use std::collections::HashMap;
 use std::time::Duration;
 
 use async_trait::async_trait;
-use hyperactor as hyperactor_reference;
 use hyperactor::Actor;
+use hyperactor::ActorAddr;
 use hyperactor::ActorHandle;
 use hyperactor::Addr;
 use hyperactor::Bind;
@@ -27,6 +27,7 @@ use hyperactor::Context;
 use hyperactor::Data;
 use hyperactor::Handler;
 use hyperactor::Instance;
+use hyperactor::PortAddr;
 use hyperactor::PortHandle;
 use hyperactor::PortRef;
 use hyperactor::Unbind;
@@ -139,7 +140,7 @@ fn collect_live_children(
 #[derive(Debug)]
 struct ActorInstanceState {
     create_rank: usize,
-    spawn: Result<hyperactor_reference::ActorAddr, anyhow::Error>,
+    spawn: Result<ActorAddr, anyhow::Error>,
     /// True once a stop signal has been sent. This does *not* mean the actor
     /// has reached a terminal state — that is determined by observing
     /// supervision events.
@@ -393,7 +394,7 @@ impl ProcAgent {
 
     /// Send a stop signal to an actor on this proc. This is fire-and-forget;
     /// it does not wait for the actor to reach terminal status.
-    fn stop_actor_by_id(&self, actor_id: &hyperactor_reference::ActorAddr, reason: &str) {
+    fn stop_actor_by_id(&self, actor_id: &ActorAddr, reason: &str) {
         tracing::info!(
             name = "StopActor",
             %actor_id,
@@ -679,7 +680,7 @@ impl Actor for ProcAgent {
         envelope: Undeliverable<MessageEnvelope>,
     ) -> Result<(), anyhow::Error> {
         if let Some(true) = envelope.0.headers().get(STREAM_STATE_SUBSCRIBER) {
-            let dest_port_id: hyperactor_reference::PortAddr = envelope.0.dest().clone();
+            let dest_port_id: PortAddr = envelope.0.dest().clone();
             let port = PortRef::<resource::State<ActorState>>::attest(dest_port_id);
             // Remove this subscriber from whichever actor instance holds it.
             for instance in self.actor_states.values_mut() {
@@ -857,7 +858,7 @@ wirevalue::register_type!(ActorSpec);
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Named, Bind, Unbind)]
 pub struct ActorState {
     /// The actor's ID.
-    pub actor_id: hyperactor_reference::ActorAddr,
+    pub actor_id: ActorAddr,
     /// The rank of the proc that created the actor. This is before any slicing.
     pub create_rank: usize,
     // TODO status: ActorStatus,
@@ -969,7 +970,7 @@ impl Handler<resource::StopAll> for ProcAgent {
         self.stopping_all = true;
 
         // Send stop signals to all actors that haven't been stopped yet.
-        let to_stop: Vec<hyperactor_reference::ActorAddr> = self
+        let to_stop: Vec<ActorAddr> = self
             .actor_states
             .values_mut()
             .filter_map(|state| {
@@ -1222,7 +1223,7 @@ impl Handler<SelfCheck> for ProcAgent {
         let now = std::time::SystemTime::now();
 
         // Collect expired actors before mutating, since stop_actor borrows &mut self.
-        let expired: Vec<(ResourceId, hyperactor_reference::ActorAddr)> = self
+        let expired: Vec<(ResourceId, ActorAddr)> = self
             .actor_states
             .iter()
             .filter_map(|(id, state)| {
@@ -1286,7 +1287,6 @@ mod tests {
     // mesh_admin::tests::test_proc_children_reflect_directly_spawned_actors.
     #[tokio::test]
     async fn test_query_child_proc_returns_live_children() {
-        use hyperactor as hyperactor_reference;
         use hyperactor::Proc;
         use hyperactor::actor::ActorStatus;
         use hyperactor::channel::ChannelTransport;
@@ -1307,8 +1307,7 @@ mod tests {
         let client_proc = Proc::direct(ChannelTransport::Unix.any(), "client".to_string()).unwrap();
         let (client, _client_handle) = client_proc.instance("client").unwrap();
 
-        let agent_id: hyperactor_reference::ActorAddr =
-            proc.proc_addr().actor_addr(PROC_AGENT_ACTOR_NAME);
+        let agent_id: ActorAddr = proc.proc_addr().actor_addr(PROC_AGENT_ACTOR_NAME);
         let port = PortRef::<IntrospectMessage>::attest_message_port(&agent_id);
 
         // Helper: send QueryChild(Proc) and return the payload with a
@@ -1318,7 +1317,7 @@ mod tests {
             port.send(
                 client,
                 IntrospectMessage::QueryChild {
-                    child_ref: hyperactor_reference::Addr::Proc(proc.proc_addr().clone()),
+                    child_ref: Addr::Proc(proc.proc_addr().clone()),
                     reply: reply_port.bind(),
                 },
             )
@@ -1396,7 +1395,6 @@ mod tests {
         use std::sync::atomic::AtomicUsize;
         use std::sync::atomic::Ordering;
 
-        use hyperactor as hyperactor_reference;
         use hyperactor::Proc;
         use hyperactor::actor::ActorStatus;
         use hyperactor::channel::ChannelTransport;
@@ -1415,8 +1413,7 @@ mod tests {
         let client_proc = Proc::direct(ChannelTransport::Unix.any(), "client".to_string()).unwrap();
         let (client, _client_handle) = client_proc.instance("client").unwrap();
 
-        let agent_id: hyperactor_reference::ActorAddr =
-            proc.proc_addr().actor_addr(PROC_AGENT_ACTOR_NAME);
+        let agent_id: ActorAddr = proc.proc_addr().actor_addr(PROC_AGENT_ACTOR_NAME);
         let port = PortRef::<IntrospectMessage>::attest_message_port(&agent_id);
 
         // Concurrent query task: send QueryChild(Proc) every 10ms.
@@ -1434,7 +1431,7 @@ mod tests {
                     .send(
                         &query_client,
                         IntrospectMessage::QueryChild {
-                            child_ref: hyperactor_reference::Addr::Proc(query_proc_id.clone()),
+                            child_ref: Addr::Proc(query_proc_id.clone()),
                             reply: reply_port.bind(),
                         },
                     )
@@ -1495,7 +1492,7 @@ mod tests {
         port.send(
             &client,
             IntrospectMessage::QueryChild {
-                child_ref: hyperactor_reference::Addr::Proc(proc.proc_addr().clone()),
+                child_ref: Addr::Proc(proc.proc_addr().clone()),
                 reply: reply_port.bind(),
             },
         )
@@ -1700,7 +1697,6 @@ mod tests {
     // not backlog history.
     #[tokio::test]
     async fn test_query_child_proc_queue_depth_under_pressure() {
-        use hyperactor as hyperactor_reference;
         use hyperactor::Proc;
         use hyperactor::actor::ActorStatus;
         use hyperactor::channel::ChannelTransport;
@@ -1740,8 +1736,7 @@ mod tests {
 
         // QueryChild(Proc) — same aggregation logic as mesh-admin
         // resolution.
-        let agent_id: hyperactor_reference::ActorAddr =
-            proc.proc_addr().actor_addr(PROC_AGENT_ACTOR_NAME);
+        let agent_id: ActorAddr = proc.proc_addr().actor_addr(PROC_AGENT_ACTOR_NAME);
         let port = PortRef::<IntrospectMessage>::attest_message_port(&agent_id);
 
         // Poll until queue stats are non-zero.
@@ -1751,7 +1746,7 @@ mod tests {
             port.send(
                 &client,
                 IntrospectMessage::QueryChild {
-                    child_ref: hyperactor_reference::Addr::Proc(proc.proc_addr().clone()),
+                    child_ref: Addr::Proc(proc.proc_addr().clone()),
                     reply: reply_port.bind(),
                 },
             )

--- a/hyperactor_mesh/src/proc_launcher.rs
+++ b/hyperactor_mesh/src/proc_launcher.rs
@@ -46,7 +46,6 @@ use std::fmt;
 use std::time::Duration;
 
 use async_trait::async_trait;
-use hyperactor as hyperactor_reference;
 use hyperactor::channel::ChannelAddr;
 use serde::Deserialize;
 use serde::Serialize;

--- a/hyperactor_mesh/src/proc_launcher/native.rs
+++ b/hyperactor_mesh/src/proc_launcher/native.rs
@@ -82,7 +82,6 @@ use std::time::Duration;
 use std::time::SystemTime;
 
 use async_trait::async_trait;
-use hyperactor as hyperactor_reference;
 use tokio::sync::oneshot;
 use tracing::Instrument;
 

--- a/hyperactor_mesh/src/proc_launcher/systemd.rs
+++ b/hyperactor_mesh/src/proc_launcher/systemd.rs
@@ -71,7 +71,6 @@ use std::time::Duration;
 
 use async_trait::async_trait;
 use futures::StreamExt;
-use hyperactor as hyperactor_reference;
 use hyperactor::channel::ChannelAddr;
 use tokio::sync::oneshot;
 use tracing::Instrument;

--- a/hyperactor_mesh/src/proc_mesh.rs
+++ b/hyperactor_mesh/src/proc_mesh.rs
@@ -15,9 +15,11 @@ use std::ops::Deref;
 use std::sync::Arc;
 use std::time::Duration;
 
-use hyperactor as hyperactor_reference;
 use hyperactor::Actor;
+use hyperactor::ActorAddr;
+use hyperactor::ActorRef;
 use hyperactor::Handler;
+use hyperactor::ProcAddr;
 use hyperactor::RemoteMessage;
 use hyperactor::RemoteSpawn;
 use hyperactor::accum::StreamingReducerOpts;
@@ -87,20 +89,16 @@ pub const COMM_ACTOR_NAME: &str = "comm";
 /// A reference to a single [`hyperactor::Proc`].
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct ProcRef {
-    proc_id: hyperactor_reference::ProcAddr,
+    proc_id: ProcAddr,
     /// The rank of this proc at creation.
     create_rank: usize,
     /// The agent managing this proc.
-    agent: hyperactor_reference::ActorRef<ProcAgent>,
+    agent: ActorRef<ProcAgent>,
 }
 
 impl ProcRef {
     /// Create a new proc ref from the provided id, create rank and agent.
-    pub fn new(
-        proc_id: hyperactor_reference::ProcAddr,
-        create_rank: usize,
-        agent: hyperactor_reference::ActorRef<ProcAgent>,
-    ) -> Self {
+    pub fn new(proc_id: ProcAddr, create_rank: usize, agent: ActorRef<ProcAgent>) -> Self {
         Self {
             proc_id,
             create_rank,
@@ -108,21 +106,18 @@ impl ProcRef {
         }
     }
 
-    pub fn proc_addr(&self) -> &hyperactor_reference::ProcAddr {
+    pub fn proc_addr(&self) -> &ProcAddr {
         &self.proc_id
     }
 
-    pub(crate) fn actor_addr(&self, id: &ActorMeshId) -> hyperactor_reference::ActorAddr {
+    pub(crate) fn actor_addr(&self, id: &ActorMeshId) -> ActorAddr {
         self.proc_id.actor_addr_uid(id.uid().clone())
     }
 
     /// Generic bound: `A: Referable` - required because we return
     /// an `ActorRef<A>`.
-    pub(crate) fn attest<A: Referable>(
-        &self,
-        id: &ActorMeshId,
-    ) -> hyperactor_reference::ActorRef<A> {
-        hyperactor_reference::ActorRef::attest(self.actor_addr(id))
+    pub(crate) fn attest<A: Referable>(&self, id: &ActorMeshId) -> ActorRef<A> {
+        ActorRef::attest(self.actor_addr(id))
     }
 }
 
@@ -161,7 +156,7 @@ impl ProcMesh {
             );
         }
 
-        let root_comm_actor = hyperactor_reference::ActorRef::attest(
+        let root_comm_actor = ActorRef::attest(
             ranks
                 .first()
                 .expect("root mesh cannot be empty")
@@ -255,10 +250,7 @@ impl ProcMesh {
     /// Stop this mesh gracefully.
     pub async fn stop(&mut self, cx: &impl context::Actor, reason: String) -> anyhow::Result<()> {
         let region = self.region.clone();
-        let procs = self
-            .current_ref
-            .proc_ids()
-            .collect::<Vec<hyperactor_reference::ProcAddr>>();
+        let procs = self.current_ref.proc_ids().collect::<Vec<ProcAddr>>();
         // We use the proc mesh region rather than the host mesh region
         // because the host agent stores one entry per proc, not per host.
         self.current_ref
@@ -320,7 +312,7 @@ pub struct ProcMeshRef {
     // should be removed after we remove the v0 code.
     // v0 casting requires root mesh rank 0 as the 1st hop, so we need to provide
     // it here. For v1, this can be removed since v1 can use any rank.
-    pub(crate) root_comm_actor: Option<hyperactor_reference::ActorRef<CommActor>>,
+    pub(crate) root_comm_actor: Option<ActorRef<CommActor>>,
 }
 wirevalue::register_type!(ProcMeshRef);
 
@@ -333,7 +325,7 @@ impl ProcMeshRef {
         ranks: Arc<Vec<ProcRef>>,
         host_mesh: Option<HostMeshRef>,
         root_region: Option<Region>,
-        root_comm_actor: Option<hyperactor_reference::ActorRef<CommActor>>,
+        root_comm_actor: Option<ActorRef<CommActor>>,
     ) -> crate::Result<Self> {
         if region.num_ranks() != ranks.len() {
             return Err(crate::Error::InvalidRankCardinality {
@@ -365,7 +357,7 @@ impl ProcMeshRef {
         }
     }
 
-    pub(crate) fn root_comm_actor(&self) -> Option<&hyperactor_reference::ActorRef<CommActor>> {
+    pub(crate) fn root_comm_actor(&self) -> Option<&ActorRef<CommActor>> {
         self.root_comm_actor.as_ref()
     }
 
@@ -524,9 +516,7 @@ impl ProcMeshRef {
         &self,
         cx: &impl context::Actor,
     ) -> crate::Result<Option<ValueMesh<resource::State<ProcState>>>> {
-        let names = self
-            .proc_ids()
-            .collect::<Vec<hyperactor_reference::ProcAddr>>();
+        let names = self.proc_ids().collect::<Vec<ProcAddr>>();
         if let Some(host_mesh) = &self.host_mesh {
             Ok(Some(
                 host_mesh
@@ -539,7 +529,7 @@ impl ProcMeshRef {
     }
 
     /// Returns an iterator over the proc ids in this mesh.
-    pub(crate) fn proc_ids(&self) -> impl Iterator<Item = hyperactor_reference::ProcAddr> {
+    pub(crate) fn proc_ids(&self) -> impl Iterator<Item = ProcAddr> {
         self.ranks.iter().map(|proc_ref| proc_ref.proc_id.clone())
     }
 

--- a/hyperactor_mesh/src/pyspy.rs
+++ b/hyperactor_mesh/src/pyspy.rs
@@ -11,11 +11,11 @@
 //! See PS-* and PP-* invariants in `introspect` module doc.
 
 use async_trait::async_trait;
-use hyperactor as hyperactor_reference;
 use hyperactor::Actor;
 use hyperactor::Context;
 use hyperactor::HandleClient;
 use hyperactor::Handler;
+use hyperactor::OncePortRef;
 use hyperactor::RefClient;
 use serde::Deserialize;
 use serde::Serialize;
@@ -439,7 +439,7 @@ pub struct PySpyDump {
     pub opts: PySpyOpts,
     /// Reply port for the result.
     #[reply]
-    pub result: hyperactor_reference::OncePortRef<PySpyResult>,
+    pub result: OncePortRef<PySpyResult>,
 }
 wirevalue::register_type!(PySpyDump);
 
@@ -456,7 +456,7 @@ pub struct PySpyProfile {
     pub request: ValidatedProfileRequest,
     /// Reply port for the result.
     #[reply]
-    pub result: hyperactor_reference::OncePortRef<PySpyProfileResult>,
+    pub result: OncePortRef<PySpyProfileResult>,
 }
 wirevalue::register_type!(PySpyProfile);
 

--- a/hyperactor_mesh/src/testactor.rs
+++ b/hyperactor_mesh/src/testactor.rs
@@ -19,8 +19,8 @@ use std::ops::Deref;
 use std::time::Duration;
 
 use async_trait::async_trait;
-use hyperactor as hyperactor_reference;
 use hyperactor::Actor;
+use hyperactor::ActorRef;
 use hyperactor::Bind;
 use hyperactor::Context;
 use hyperactor::Handler;
@@ -240,11 +240,7 @@ impl Handler<Forward> for TestActor {
 pub struct GetCastInfo {
     /// Originating actor, point, sender.
     #[reply]
-    pub cast_info: hyperactor::PortRef<(
-        Point,
-        hyperactor_reference::ActorRef<TestActor>,
-        hyperactor::ActorAddr,
-    )>,
+    pub cast_info: hyperactor::PortRef<(Point, ActorRef<TestActor>, hyperactor::ActorAddr)>,
 }
 
 #[async_trait]

--- a/monarch_introspection_snapshot/src/service.rs
+++ b/monarch_introspection_snapshot/src/service.rs
@@ -124,8 +124,8 @@ use std::time::Duration;
 use std::time::Instant;
 
 use async_trait::async_trait;
-use hyperactor as hyperactor_reference;
 use hyperactor::Actor;
+use hyperactor::ActorRef;
 use hyperactor::Context;
 use hyperactor::Handler;
 use hyperactor::Instance;
@@ -321,7 +321,7 @@ pub struct SnapshotCaptureActor {
     service: SnapshotService,
     /// Typed admin actor reference used to resolve `NodeRef`s during
     /// capture.
-    admin_ref: hyperactor_reference::ActorRef<MeshAdminAgent>,
+    admin_ref: ActorRef<MeshAdminAgent>,
     /// Delay between periodic capture ticks after the initial
     /// immediate fire.
     interval: Duration,
@@ -367,7 +367,7 @@ impl SnapshotCaptureActor {
     /// start it.
     pub fn new(
         table_store: TableStore,
-        admin_ref: hyperactor_reference::ActorRef<MeshAdminAgent>,
+        admin_ref: ActorRef<MeshAdminAgent>,
         interval: Duration,
     ) -> Self {
         Self {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #3809

Remove leftover `use hyperactor as hyperactor_reference` aliases and import the referenced hyperactor types directly in Monarch Rust code.

Differential Revision: [D104465140](https://our.internmc.facebook.com/intern/diff/D104465140/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D104465140/)!