### PR TITLE
Onboard ProcMeshController; orphan-cleanup for hard client exit (#3811)

### DIFF
--- a/hyperactor_mesh/src/host_mesh.rs
+++ b/hyperactor_mesh/src/host_mesh.rs
@@ -105,6 +105,7 @@ use crate::mesh_id::HostMeshId;
 use crate::mesh_id::ProcMeshId;
 use crate::mesh_id::ResourceId;
 use crate::proc_agent::ProcAgent;
+use crate::proc_mesh::ProcMeshRef;
 use crate::resource;
 use crate::resource::CreateOrUpdateClient;
 use crate::resource::GetRankStatus;
@@ -145,12 +146,12 @@ declare_attrs! {
 
 /// A reference to a single host.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Named, Serialize, Deserialize)]
-pub struct HostRef(ChannelAddr);
+pub struct HostRef(pub(crate) ChannelAddr);
 wirevalue::register_type!(HostRef);
 
 impl HostRef {
     /// The host mesh agent associated with this host.
-    fn mesh_agent(&self) -> ActorRef<HostAgent> {
+    pub(crate) fn mesh_agent(&self) -> ActorRef<HostAgent> {
         ActorRef::attest(
             self.service_proc()
                 .actor_addr(host_agent::HOST_MESH_AGENT_ACTOR_NAME),
@@ -1424,11 +1425,17 @@ impl HostMeshRef {
             }
         }
 
-        let mesh = ProcMesh::create(cx, proc_mesh_id, extent, self.clone(), procs).await;
-        if let Ok(ref mesh) = mesh {
+        let mut mesh = ProcMesh::create(cx, proc_mesh_id, extent, self.clone(), procs).await;
+        if let Ok(ref mut mesh) = mesh {
             // Spawn a unique mesh controller for each proc mesh, so the type of the
-            // mesh can be preserved.
-            let controller = ProcMeshController::new(mesh.deref().clone());
+            // mesh can be preserved. Procs reached a non-terminating state above,
+            // so seed the controller's per-rank statuses as Running.
+            let mesh_ref: ProcMeshRef = (**mesh).clone();
+            let region = ndslice::view::Ranked::region(&mesh_ref).clone();
+            let initial_statuses: crate::ValueMesh<resource::Status> =
+                std::iter::repeat_n(resource::Status::Running, region.num_ranks())
+                    .collect_mesh::<crate::ValueMesh<_>>(region)?;
+            let controller = ProcMeshController::new(mesh_ref, None, None, initial_statuses);
             // hyperactor::proc AI-3: controller name must include mesh
             // identity for proc-wide ActorAddr uniqueness.
             let controller_name = format!("{}_{}", PROC_MESH_CONTROLLER_NAME, mesh.id());
@@ -1442,7 +1449,8 @@ impl HostMeshRef {
             // Undeliverable). Without this, the controller's mailbox has no
             // port entries and messages (including introspection queries)
             // are returned as undeliverable.
-            let _: ActorRef<ProcMeshController> = controller_handle.bind();
+            let controller_ref: ActorRef<ProcMeshController> = controller_handle.bind();
+            mesh.set_controller(Some(controller_ref));
         }
         mesh
     }
@@ -1457,6 +1465,16 @@ impl HostMeshRef {
         &self.ranks
     }
 
+    /// Stop every proc in this proc mesh.
+    ///
+    /// On success returns the final per-rank `StatusMesh`, in which every
+    /// rank is guaranteed to be `is_terminated()` (`Stopped`, `Failed`, or
+    /// `Timeout`). Callers can apply these statuses to controller health
+    /// state so that subsequent `GetState` queries reflect reality.
+    ///
+    /// Returns `crate::Error::ProcMeshStopError` if any rank did not reach
+    /// a terminal state within `PROC_STOP_MAX_IDLE`; the error carries the
+    /// best-known per-rank statuses for the same purpose.
     #[hyperactor::instrument(fields(host_mesh=self.id.to_string(), proc_mesh=proc_mesh_id.to_string()))]
     pub(crate) async fn stop_proc_mesh(
         &self,
@@ -1465,7 +1483,7 @@ impl HostMeshRef {
         procs: impl IntoIterator<Item = ProcAddr>,
         region: Region,
         reason: String,
-    ) -> anyhow::Result<()> {
+    ) -> crate::Result<crate::StatusMesh> {
         // Accumulator outputs full StatusMesh snapshots; seed with
         // NotExist.
         let mut proc_names = Vec::new();
@@ -1490,16 +1508,21 @@ impl HostMeshRef {
             // Note that we don't send 1 message per host agent, we send 1 message
             // per proc.
             let host = HostRef(addr);
-            host.mesh_agent().send(
-                cx,
-                resource::Stop {
-                    id: proc_resource_id.clone(),
-                    reason: reason.clone(),
-                },
-            )?;
+            host.mesh_agent()
+                .send(
+                    cx,
+                    resource::Stop {
+                        id: proc_resource_id.clone(),
+                        reason: reason.clone(),
+                    },
+                )
+                .map_err(|e| {
+                    crate::Error::SendingError(host.mesh_agent().actor_addr().clone(), Box::new(e))
+                })?;
             host.mesh_agent()
                 .wait_rank_status(cx, proc_resource_id, Status::Stopped, port.bind())
-                .await?;
+                .await
+                .map_err(|e| crate::Error::CallError(host.mesh_agent().actor_addr().clone(), e))?;
 
             tracing::info!(
                 name = "ProcMeshStatus",
@@ -1532,18 +1555,22 @@ impl HostMeshRef {
             Ok(statuses) => {
                 let all_stopped = statuses.values().all(|s| s.is_terminated());
                 if !all_stopped {
+                    let legacy = mesh_to_rankedvalues_with_default(
+                        &statuses,
+                        Status::NotExist,
+                        Status::is_not_exist,
+                        num_ranks,
+                    );
                     tracing::error!(
                         name = "ProcMeshStatus",
                         status = "FailedToStop",
                         "failed to terminate proc mesh: {:?}",
                         statuses,
                     );
-                    return Err(anyhow::anyhow!(
-                        "failed to terminate proc mesh: {:?}",
-                        statuses,
-                    ));
+                    return Err(crate::Error::ProcMeshStopError { statuses: legacy });
                 }
                 tracing::info!(name = "ProcMeshStatus", status = "Stopped");
+                Ok(statuses)
             }
             Err(complete) => {
                 // Fill remaining ranks with a timeout status via the
@@ -1557,29 +1584,29 @@ impl HostMeshRef {
                 tracing::error!(
                     name = "ProcMeshStatus",
                     status = "StoppingTimeout",
-                    "failed to terminate proc mesh before timeout: {:?}",
-                    legacy,
-                );
-                return Err(anyhow::anyhow!(
                     "failed to terminate proc mesh {} before timeout: {:?}",
                     proc_mesh_id,
-                    legacy
-                ));
+                    legacy,
+                );
+                Err(crate::Error::ProcMeshStopError { statuses: legacy })
             }
         }
-        Ok(())
     }
 
     /// Get the state of all procs with Name in this host mesh.
     /// The procs iterator must be in rank order.
     /// The returned ValueMesh will have a non-empty inner state unless there
     /// was a timeout reaching the host mesh agent.
+    ///
+    /// If `keepalive` is `Some`, send `KeepaliveGetState` so the host agent
+    /// extends each proc's expiry time; otherwise send a plain `GetState`.
     #[allow(clippy::result_large_err)]
     pub(crate) async fn proc_states(
         &self,
         cx: &impl context::Actor,
         procs: impl IntoIterator<Item = ProcAddr>,
         region: Region,
+        keepalive: Option<std::time::SystemTime>,
     ) -> crate::Result<ValueMesh<resource::State<ProcState>>> {
         let (tx, mut rx) = cx.mailbox().open_port();
 
@@ -1604,17 +1631,26 @@ impl HostMeshRef {
             // can handle the error as it pleases. Set this so an undeliverable message doesn't cause
             // a supervision crash.
             send_port.return_undeliverable(false);
-            send_port
-                .send(
+            let get_state = resource::GetState {
+                id: proc_resource_id,
+                reply,
+            };
+            let send_result = if let Some(expires_after) = keepalive {
+                let mut keepalive_port = host.mesh_agent().port();
+                keepalive_port.return_undeliverable(false);
+                keepalive_port.send(
                     cx,
-                    resource::GetState {
-                        id: proc_resource_id,
-                        reply,
+                    resource::KeepaliveGetState {
+                        expires_after,
+                        get_state,
                     },
                 )
-                .map_err(|e| {
-                    crate::Error::CallError(host.mesh_agent().actor_addr().clone(), e.into())
-                })?;
+            } else {
+                send_port.send(cx, get_state)
+            };
+            send_result.map_err(|e| {
+                crate::Error::CallError(host.mesh_agent().actor_addr().clone(), e.into())
+            })?;
         }
 
         let mut states = Vec::with_capacity(num_ranks);

--- a/hyperactor_mesh/src/host_mesh/host_agent.rs
+++ b/hyperactor_mesh/src/host_mesh/host_agent.rs
@@ -37,6 +37,7 @@ use hyperactor::ProcAddr;
 use hyperactor::RefClient;
 use hyperactor::context;
 use hyperactor::mailbox::MailboxServerHandle;
+use hyperactor_config::Flattrs;
 use hyperactor_config::attrs::Attrs;
 use serde::Deserialize;
 use serde::Serialize;
@@ -174,6 +175,10 @@ pub(crate) struct ProcCreationState {
     pub(crate) rank: usize,
     pub(crate) host_mesh_id: Option<HostMeshId>,
     pub(crate) created: Result<(ProcAddr, ActorRef<ProcAgent>), HostError>,
+    /// "Owner is alive" deadline communicated by the controller via
+    /// `KeepaliveGetState`. The host's `SelfCheck` reaper compares against this
+    /// and tears down procs whose owner has stopped extending the keepalive.
+    pub(crate) expiry_time: Option<std::time::SystemTime>,
 }
 
 /// Actor name used when spawning the host mesh agent on the system proc.
@@ -268,6 +273,8 @@ impl fmt::Debug for DrainWorker {
         resource::CreateOrUpdate<ProcSpec>,
         resource::Stop,
         resource::GetState<ProcState>,
+        resource::KeepaliveGetState<ProcState>,
+        resource::StreamState<ProcState> { cast = true },
         resource::GetRankStatus { cast = true },
         resource::WaitRankStatus { cast = true },
         resource::List,
@@ -278,6 +285,7 @@ impl fmt::Debug for DrainWorker {
         PySpyDump,
         PySpyProfile,
         ConfigDump,
+        crate::proc_agent::SelfCheck,
     ]
 )]
 pub struct HostAgent {
@@ -622,6 +630,14 @@ impl Actor for HostAgent {
 
         self.proc_status_port = Some(this.port::<ProcStatusChanged>());
 
+        // Kick off the SelfCheck reaper if the orphan timeout is configured.
+        // The reaper walks `created` looking for procs whose owner stopped
+        // extending the keepalive and tears them down.
+        if let Some(delay) = hyperactor_config::global::get(crate::proc_agent::MESH_ORPHAN_TIMEOUT)
+        {
+            this.self_message_with_delay(crate::proc_agent::SelfCheck::default(), delay)?;
+        }
+
         Ok(())
     }
 }
@@ -689,6 +705,7 @@ impl Handler<resource::CreateOrUpdate<ProcSpec>> for HostAgent {
                 rank,
                 host_mesh_id: create_or_update.spec.host_mesh_id.clone(),
                 created,
+                expiry_time: None,
             },
         );
 
@@ -1150,7 +1167,17 @@ impl Handler<ShutdownHost> for HostAgent {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Named, Serialize, Deserialize)]
+#[derive(
+    Debug,
+    Clone,
+    PartialEq,
+    Eq,
+    Named,
+    Serialize,
+    Deserialize,
+    hyperactor::Bind,
+    hyperactor::Unbind
+)]
 pub struct ProcState {
     pub proc_id: ProcAddr,
     pub create_rank: usize,
@@ -1230,10 +1257,156 @@ impl Handler<resource::GetState<ProcState>> for HostAgent {
 }
 
 #[async_trait]
+impl Handler<crate::proc_agent::SelfCheck> for HostAgent {
+    async fn handle(
+        &mut self,
+        cx: &Context<Self>,
+        _: crate::proc_agent::SelfCheck,
+    ) -> anyhow::Result<()> {
+        // Walk procs and tear down any whose owner-supplied keepalive has
+        // lapsed. Mirrors the proc-agent reaper but at host scope: we
+        // address the same problem (a controller/client died abruptly)
+        // for proc-level cleanup so the host doesn't leak children.
+        let Some(duration) = hyperactor_config::global::get(crate::proc_agent::MESH_ORPHAN_TIMEOUT)
+        else {
+            return Ok(());
+        };
+        let now = std::time::SystemTime::now();
+        let timeout = hyperactor_config::global::get(hyperactor::config::PROCESS_EXIT_TIMEOUT);
+
+        let expired: Vec<ResourceId> = self
+            .created
+            .iter()
+            .filter_map(|(id, state)| {
+                let expiry = state.expiry_time?;
+                if now > expiry { Some(id.clone()) } else { None }
+            })
+            .collect();
+
+        if !expired.is_empty() {
+            tracing::info!(
+                "stopping {} orphaned procs past their keepalive expiry",
+                expired.len(),
+            );
+        }
+
+        for id in expired {
+            if let Some(ProcCreationState {
+                created: Ok((proc_id, _)),
+                ..
+            }) = self.created.get(&id)
+            {
+                let proc_id = proc_id.clone();
+                if let Some(host) = self.host() {
+                    host.request_stop(cx, &proc_id, timeout, "orphaned").await;
+                }
+                // Don't reap repeatedly while teardown is in flight.
+                if let Some(state) = self.created.get_mut(&id) {
+                    state.expiry_time = None;
+                }
+            }
+        }
+
+        cx.self_message_with_delay(crate::proc_agent::SelfCheck::default(), duration)?;
+        Ok(())
+    }
+}
+
+#[async_trait]
 impl Handler<resource::List> for HostAgent {
     async fn handle(&mut self, cx: &Context<Self>, list: resource::List) -> anyhow::Result<()> {
         list.reply
             .send(cx, self.created.keys().cloned().collect())?;
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl Handler<resource::KeepaliveGetState<ProcState>> for HostAgent {
+    async fn handle(
+        &mut self,
+        cx: &Context<Self>,
+        message: resource::KeepaliveGetState<ProcState>,
+    ) -> anyhow::Result<()> {
+        // Record the new expiry so the periodic SelfCheck reaper knows the
+        // owner is still alive. If the owner stops extending the keepalive
+        // (e.g. its process dies abruptly), the proc will be reaped past
+        // `expires_after`.
+        if let Some(state) = self.created.get_mut(&message.get_state.id) {
+            state.expiry_time = Some(message.expires_after);
+        }
+        <Self as Handler<resource::GetState<ProcState>>>::handle(self, cx, message.get_state).await
+    }
+}
+
+#[async_trait]
+impl Handler<resource::StreamState<ProcState>> for HostAgent {
+    async fn handle(
+        &mut self,
+        cx: &Context<Self>,
+        stream_state: resource::StreamState<ProcState>,
+    ) -> anyhow::Result<()> {
+        // TODO: register `subscriber` for ongoing updates. For now send the
+        // current state once so the controller has an initial snapshot.
+        let state = match self.created.get(&stream_state.id) {
+            Some(ProcCreationState {
+                rank,
+                created: Ok((proc_id, mesh_agent)),
+                ..
+            }) => {
+                let (raw_status, proc_status, bootstrap_command) = match self.host() {
+                    Some(host) => {
+                        let (status, proc_status) = host.proc_status(proc_id).await;
+                        (status, proc_status, host.bootstrap_command())
+                    }
+                    None => (resource::Status::Unknown, None, None),
+                };
+                let status = raw_status.clamp_min(self.min_proc_status());
+                resource::State {
+                    id: stream_state.id.clone(),
+                    status,
+                    state: Some(ProcState {
+                        proc_id: proc_id.clone(),
+                        create_rank: *rank,
+                        mesh_agent: mesh_agent.clone(),
+                        bootstrap_command,
+                        proc_status,
+                    }),
+                    generation: 0,
+                    timestamp: std::time::SystemTime::now(),
+                }
+            }
+            Some(ProcCreationState {
+                created: Err(e), ..
+            }) => resource::State {
+                id: stream_state.id.clone(),
+                status: resource::Status::Failed(e.to_string()),
+                state: None,
+                generation: 0,
+                timestamp: std::time::SystemTime::now(),
+            },
+            None => resource::State {
+                id: stream_state.id.clone(),
+                status: resource::Status::NotExist,
+                state: None,
+                generation: 0,
+                timestamp: std::time::SystemTime::now(),
+            },
+        };
+
+        let mut headers = Flattrs::new();
+        headers.set(crate::proc_agent::STREAM_STATE_SUBSCRIBER, true);
+        if let Err(e) = stream_state
+            .subscriber
+            .send_with_headers(cx, headers, state)
+        {
+            tracing::warn!(
+                actor = %cx.self_addr(),
+                "failed to send initial StreamState to {}: {}",
+                stream_state.subscriber.port_addr().actor_id(),
+                e,
+            );
+        }
         Ok(())
     }
 }

--- a/hyperactor_mesh/src/lib.rs
+++ b/hyperactor_mesh/src/lib.rs
@@ -197,6 +197,12 @@ pub enum Error {
     )]
     ActorStopError { statuses: RankedValues<Status> },
 
+    #[error(
+        "error stopping proc mesh: statuses: {}",
+        RankedValues::invert(statuses)
+    )]
+    ProcMeshStopError { statuses: RankedValues<Status> },
+
     #[error("error spawning actor: {0}")]
     SingletonActorSpawnError(anyhow::Error),
 

--- a/hyperactor_mesh/src/mesh_controller.rs
+++ b/hyperactor_mesh/src/mesh_controller.rs
@@ -80,6 +80,11 @@ declare_static_counter!(
     "actor.actor_mesh_controller.num_stalls"
 );
 
+declare_static_counter!(
+    PROC_MESH_CONTROLLER_SUPERVISION_STALLS,
+    "actor.proc_mesh_controller.num_stalls"
+);
+
 /// Aggregated health and subscriber bookkeeping for a single
 /// `ResourceController`. Tracks the most recently observed status of every
 /// rank in the controlled mesh, the latched unhealthy event (if any), the
@@ -1037,7 +1042,7 @@ impl<A: Referable> Controlled for ActorMeshRef<A> {
 
         // Actor-specific: first check if the proc mesh is dead before
         // trying to query their agents.
-        let proc_states = self.proc_mesh().proc_states(cx).await;
+        let proc_states = self.proc_mesh().proc_states(cx, None).await;
         if let Err(e) = proc_states {
             send_state_change(
                 cx,
@@ -1262,47 +1267,244 @@ impl<A: Referable> Controlled for ActorMeshRef<A> {
     }
 }
 
-#[derive(Debug)]
-#[hyperactor::export]
-pub(crate) struct ProcMeshController {
-    mesh: ProcMeshRef,
-}
+/// Controller for a proc mesh.
+pub(crate) type ProcMeshController = ResourceController<ProcMeshRef>;
 
-impl ProcMeshController {
-    /// Create a new proc controller based on the provided reference.
-    pub(crate) fn new(mesh: ProcMeshRef) -> Self {
-        Self { mesh }
-    }
-}
-
+/// `Controlled` implementation for a proc mesh.
 #[async_trait]
-impl Actor for ProcMeshController {
-    async fn init(&mut self, this: &Instance<Self>) -> Result<(), anyhow::Error> {
-        this.set_system();
+impl Controlled for ProcMeshRef {
+    type StateInner = crate::host_mesh::host_agent::ProcState;
+
+    fn stall_counter() -> &'static Counter<u64> {
+        &PROC_MESH_CONTROLLER_SUPERVISION_STALLS
+    }
+
+    fn id(&self) -> &ResourceId {
+        ProcMeshRef::id(self).resource_id()
+    }
+
+    fn region(&self) -> &ndslice::Region {
+        ndslice::view::Ranked::region(self)
+    }
+
+    fn subscribe_to_stream(
+        &self,
+        cx: &impl context::Actor,
+        subscriber: hyperactor::PortRef<resource::State<Self::StateInner>>,
+    ) -> anyhow::Result<()> {
+        // Send one StreamState per proc to its host agent.
+        for proc_id in self.proc_ids() {
+            let proc_resource_id = ResourceId::new(proc_id.uid().clone(), proc_id.label().cloned());
+            let host = crate::host_mesh::HostRef(proc_id.addr().clone());
+            host.mesh_agent().send(
+                cx,
+                resource::StreamState::<Self::StateInner> {
+                    id: proc_resource_id,
+                    subscriber: subscriber.clone(),
+                },
+            )?;
+        }
         Ok(())
     }
 
-    async fn cleanup(
-        &mut self,
-        this: &Instance<Self>,
-        _err: Option<&ActorError>,
-    ) -> Result<(), anyhow::Error> {
-        // Cannot use "ProcMesh::stop" as it's only defined on ProcMesh, not ProcMeshRef.
-        let names = self.mesh.proc_ids().collect::<Vec<hyperactor::ProcAddr>>();
-        let region = self.mesh.region().clone();
-        if let Some(hosts) = self.mesh.hosts() {
-            hosts
-                .stop_proc_mesh(
-                    this,
-                    self.mesh.id(),
-                    names,
-                    region,
-                    "proc mesh controller cleanup".to_string(),
-                )
-                .await
-        } else {
-            Ok(())
+    fn forward_wait_rank_status(
+        &self,
+        cx: &impl context::Actor,
+        msg: resource::WaitRankStatus,
+    ) -> anyhow::Result<()> {
+        for proc_id in self.proc_ids() {
+            let host = crate::host_mesh::HostRef(proc_id.addr().clone());
+            host.mesh_agent().send(cx, msg.clone())?;
         }
+        Ok(())
+    }
+
+    async fn poll_states(
+        &self,
+        cx: &impl context::Actor,
+        supervision_display_name: &str,
+        health_state: &mut HealthState,
+    ) -> PollResult {
+        let mesh_name = Controlled::id(self);
+
+        let proc_states = self.proc_states(cx, compute_keepalive()).await;
+        match proc_states {
+            Err(e) => {
+                send_state_change(
+                    cx,
+                    0,
+                    ActorSupervisionEvent::new(
+                        cx.instance().self_addr().clone(),
+                        Some(supervision_display_name.to_string()),
+                        ActorStatus::generic_failure(format!(
+                            "unable to query for proc states: {:?}",
+                            e
+                        )),
+                        None,
+                    ),
+                    mesh_name,
+                    false,
+                    health_state,
+                );
+                PollResult::Reschedule
+            }
+            Ok(None) => PollResult::Processed { did_notify: false },
+            Ok(Some(states)) => {
+                let did_notify =
+                    health_state.apply_updates_and_notify(&states, |state, health_state| {
+                        self.notify_proc_state_change(
+                            cx,
+                            supervision_display_name,
+                            state,
+                            health_state,
+                        )
+                    });
+                PollResult::Processed { did_notify }
+            }
+        }
+    }
+
+    fn process_state(
+        &self,
+        cx: &impl context::Actor,
+        state: resource::State<Self::StateInner>,
+        health_state: &mut HealthState,
+    ) -> bool {
+        let Ok(point) = Controlled::region(self).extent().point_of_rank(
+            state
+                .state
+                .as_ref()
+                .map(|s| s.create_rank)
+                .unwrap_or(usize::MAX),
+        ) else {
+            return false;
+        };
+        let changed = health_state.maybe_update(point, state.status.clone(), state.generation);
+        if !changed {
+            return false;
+        }
+        let display = Controlled::id(self).to_string();
+        self.notify_proc_state_change(cx, &display, state, health_state)
+    }
+
+    async fn handle_stop_request(
+        &self,
+        cx: &impl context::Actor,
+        _supervision_display_name: &str,
+        reason: String,
+        health_state: &mut HealthState,
+    ) -> anyhow::Result<()> {
+        let mesh_name = Controlled::id(self);
+        tracing::info!(
+            actor_id = %cx.instance().self_addr(),
+            proc_mesh = %mesh_name,
+            "ProcMeshController stopping proc mesh"
+        );
+        // Marker so subscribers know the mesh is being torn down on request.
+        let event = ActorSupervisionEvent::new(
+            cx.instance().self_addr().clone(),
+            None,
+            ActorStatus::Stopped("ProcMeshController received explicit stop request".to_string()),
+            None,
+        );
+        let failure_message = MeshFailure {
+            actor_mesh_name: Some(mesh_name.to_string()),
+            event,
+            crashed_ranks: vec![],
+        };
+        health_state.unhealthy_event = Some(Unhealthy::StreamClosed(failure_message.clone()));
+        for subscriber in health_state.subscribers.iter() {
+            send_subscriber_message(cx, subscriber, failure_message.clone());
+        }
+
+        let names = self.proc_ids().collect::<Vec<hyperactor::ProcAddr>>();
+        let region = Ranked::region(self).clone();
+        let Some(hosts) = self.hosts() else {
+            return Ok(());
+        };
+        // stop_proc_mesh waits for every rank to reach a terminating state
+        // before returning Ok, so we can apply its returned StatusMesh
+        // verbatim. On error we still got per-rank statuses for whatever
+        // ranks the host agents reported on; apply those too so health
+        // state stays as accurate as we can make it.
+        let max_rank = health_state.statuses.keys().map(|p| p.rank()).max();
+        let extent = health_state
+            .statuses
+            .keys()
+            .next()
+            .map(|p| p.extent().clone());
+        match hosts
+            .stop_proc_mesh(cx, self.id(), names, region, reason)
+            .await
+        {
+            Ok(statuses) => {
+                for (rank, status) in statuses.iter() {
+                    health_state
+                        .statuses
+                        .entry(rank)
+                        .and_modify(move |s| *s = (status, u64::MAX));
+                }
+                Ok(())
+            }
+            Err(crate::Error::ProcMeshStopError { statuses }) => {
+                if let (Some(max_rank), Some(extent)) = (max_rank, extent) {
+                    for (rank, status) in statuses.materialized_iter(max_rank).enumerate() {
+                        if let Ok(point) = extent.point_of_rank(rank) {
+                            health_state
+                                .statuses
+                                .entry(point)
+                                .and_modify(|s| *s = (status.clone(), u64::MAX));
+                        }
+                    }
+                }
+                Err(crate::Error::ProcMeshStopError { statuses }.into())
+            }
+            Err(e) => Err(e.into()),
+        }
+    }
+
+    async fn cleanup_stop(&self, cx: &impl context::Actor, reason: String) -> anyhow::Result<()> {
+        let names = self.proc_ids().collect::<Vec<hyperactor::ProcAddr>>();
+        let region = Ranked::region(self).clone();
+        if let Some(hosts) = self.hosts() {
+            hosts
+                .stop_proc_mesh(cx, self.id(), names, region, reason)
+                .await?;
+        }
+        Ok(())
+    }
+}
+
+impl ProcMeshRef {
+    /// Translate a polled or streamed `State<ProcState>` into a supervision
+    /// event on this proc-mesh controller. Returns `true` if a notification
+    /// was sent (which suppresses the heartbeat path).
+    fn notify_proc_state_change(
+        &self,
+        cx: &impl context::Actor,
+        supervision_display_name: &str,
+        state: resource::State<crate::host_mesh::host_agent::ProcState>,
+        health_state: &mut HealthState,
+    ) -> bool {
+        let create_rank = state.state.as_ref().map(|s| s.create_rank);
+        let actor_status = proc_status_to_actor_status(state.state.and_then(|s| s.proc_status));
+        let event = ActorSupervisionEvent::new(
+            cx.instance().self_addr().clone(),
+            Some(supervision_display_name.to_string()),
+            actor_status,
+            None,
+        );
+        let rank = create_rank
+            .and_then(|r| {
+                ndslice::view::Ranked::region(self)
+                    .extent()
+                    .point_of_rank(r)
+                    .ok()
+            })
+            .map(|p| p.rank())
+            .unwrap_or(0);
+        send_state_change(cx, rank, event, Controlled::id(self), true, health_state);
+        true
     }
 }
 

--- a/hyperactor_mesh/src/proc_agent.rs
+++ b/hyperactor_mesh/src/proc_agent.rs
@@ -85,7 +85,7 @@ declare_attrs! {
     /// Header tag for StreamState subscriber messages. When present on an
     /// undeliverable envelope, ProcAgent removes the dead subscriber instead
     /// of treating it as an error.
-    attr STREAM_STATE_SUBSCRIBER: bool;
+    pub(crate) attr STREAM_STATE_SUBSCRIBER: bool;
 }
 
 /// Deferred republish of introspect properties.
@@ -262,7 +262,7 @@ impl ActorInstanceState {
     Bind,
     Unbind
 )]
-struct SelfCheck {}
+pub(crate) struct SelfCheck {}
 
 /// A mesh agent is responsible for managing procs in a [`ProcMesh`].
 ///

--- a/hyperactor_mesh/src/proc_mesh.rs
+++ b/hyperactor_mesh/src/proc_mesh.rs
@@ -129,6 +129,7 @@ pub struct ProcMesh {
     #[allow(dead_code)]
     comm_actor_name: Option<ActorMeshId>,
     current_ref: ProcMeshRef,
+    controller: Option<ActorRef<crate::mesh_controller::ProcMeshController>>,
 }
 
 impl ProcMesh {
@@ -221,6 +222,7 @@ impl ProcMesh {
             id,
             comm_actor_name: Some(comm_actor_name.clone()),
             current_ref,
+            controller: None,
         };
 
         // CommActor satisfies `Actor + Referable`, so it can be
@@ -247,8 +249,79 @@ impl ProcMesh {
         Ok(proc_mesh)
     }
 
+    /// Set or clear the controller actor managing this mesh.
+    pub(crate) fn set_controller(
+        &mut self,
+        controller: Option<ActorRef<crate::mesh_controller::ProcMeshController>>,
+    ) {
+        self.controller = controller;
+    }
+
     /// Stop this mesh gracefully.
+    ///
+    /// If a `ProcMeshController` is present (owned meshes spawned from a host
+    /// mesh), the stop is delegated to the controller via `resource::Stop`;
+    /// the controller's handler awaits `HostMeshRef::stop_proc_mesh`, which
+    /// casts `Stop` + `WaitRankStatus{min_status: Stopped}` to the
+    /// HostAgents and waits up to `PROC_STOP_MAX_IDLE` for every proc to
+    /// reach `Stopped`. We then serialize behind that handler with a
+    /// `GetState` to read the final statuses out of the controller's
+    /// `health_state`.
     pub async fn stop(&mut self, cx: &impl context::Actor, reason: String) -> anyhow::Result<()> {
+        if let Some(controller) = self.controller.take() {
+            let id = self.id.resource_id().clone();
+            controller
+                .send(
+                    cx,
+                    resource::Stop {
+                        id: id.clone(),
+                        reason,
+                    },
+                )
+                .map_err(|e| {
+                    crate::Error::SendingError(controller.actor_addr().clone(), Box::new(e))
+                })?;
+
+            // The controller processes messages serially, so by the time it
+            // gets to this `GetState`, its `health_state.statuses` already
+            // reflects the outcome of `stop_proc_mesh` (Stopping, Stopped,
+            // Failed, or Timeout on `PROC_STOP_MAX_IDLE` exhaustion).
+            let (port, mut rx) = cx.mailbox().open_port();
+            controller
+                .send(
+                    cx,
+                    resource::GetState::<resource::mesh::State<()>> {
+                        id: id.clone(),
+                        reply: port.bind(),
+                    },
+                )
+                .map_err(|e| {
+                    crate::Error::SendingError(controller.actor_addr().clone(), Box::new(e))
+                })?;
+
+            let statuses = rx.recv().await?;
+            let Some(state) = &statuses.state else {
+                anyhow::bail!(
+                    "non-existent state in GetState reply from controller: {}",
+                    controller.actor_addr()
+                );
+            };
+            // `is_terminating` accepts Stopping, Stopped, Failed, and
+            // Timeout. The controller's Stop handler has already awaited
+            // (or timed out) the underlying HostAgent wait, so any rank
+            // still in Running here means the controller never processed
+            // the stop for that rank.
+            let all_stopped = state.statuses.values().all(|s| s.is_terminating());
+            if !all_stopped {
+                anyhow::bail!(
+                    "proc mesh {} not all procs reached terminating state after stop: {:?}",
+                    id,
+                    state.statuses,
+                );
+            }
+            return Ok(());
+        }
+
         let region = self.region.clone();
         let procs = self.current_ref.proc_ids().collect::<Vec<ProcAddr>>();
         // We use the proc mesh region rather than the host mesh region
@@ -259,6 +332,8 @@ impl ProcMesh {
             .expect("ProcMesh always has a host mesh")
             .stop_proc_mesh(cx, &self.id, procs, region, reason)
             .await
+            .map(|_| ())
+            .map_err(anyhow::Error::from)
     }
 
     #[cfg(test)]
@@ -515,12 +590,13 @@ impl ProcMeshRef {
     pub async fn proc_states(
         &self,
         cx: &impl context::Actor,
+        keepalive: Option<std::time::SystemTime>,
     ) -> crate::Result<Option<ValueMesh<resource::State<ProcState>>>> {
         let names = self.proc_ids().collect::<Vec<ProcAddr>>();
         if let Some(host_mesh) = &self.host_mesh {
             Ok(Some(
                 host_mesh
-                    .proc_states(cx, names, self.region.clone())
+                    .proc_states(cx, names, self.region.clone(), keepalive)
                     .await?,
             ))
         } else {

--- a/hyperactor_mesh/src/resource.rs
+++ b/hyperactor_mesh/src/resource.rs
@@ -312,6 +312,7 @@ pub struct State<S> {
     pub timestamp: std::time::SystemTime,
 }
 wirevalue::register_type!(State<ActorState>);
+wirevalue::register_type!(State<ProcState>);
 
 impl<S: Serialize> fmt::Display for State<S> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -491,6 +492,7 @@ pub struct StreamState<S> {
     pub subscriber: PortRef<State<S>>,
 }
 wirevalue::register_type!(StreamState<ActorState>);
+wirevalue::register_type!(StreamState<ProcState>);
 
 // Cannot derive Bind and Unbind for this generic, implement manually.
 impl<S> Unbind for StreamState<S>

--- a/python/tests/test_actor_error.py
+++ b/python/tests/test_actor_error.py
@@ -16,7 +16,8 @@ import re
 import subprocess
 import sys
 import time
-from typing import cast, IO, Optional
+from contextlib import contextmanager
+from typing import cast, Generator, IO, Optional
 
 import monarch.actor
 import pytest
@@ -461,6 +462,15 @@ async def test_exception_after_wait_unmonitored():
 """
 
 
+def is_process_running(pid: int) -> bool:
+    """Check if a process with the given PID is still running."""
+    try:
+        os.kill(pid, 0)  # Signal 0 doesn't kill, just checks if process exists
+        return True
+    except OSError:
+        return False
+
+
 # oss_skip: importlib not pulling resource correctly in git CI, needs to be revisited
 @pytest.mark.oss_skip
 def test_python_actor_process_cleanup():
@@ -514,14 +524,6 @@ def test_python_actor_process_cleanup():
     print("Waiting for child processes to be cleaned up...")
     cleanup_timeout = 120
     start_time = time.time()
-
-    def is_process_running(pid):
-        """Check if a process with the given PID is still running."""
-        try:
-            os.kill(pid, 0)  # Signal 0 doesn't kill, just checks if process exists
-            return True
-        except OSError:
-            return False
 
     still_running = set(child_pids)
 
@@ -1675,11 +1677,10 @@ def test_controller_controller_error():
         actor_1.fail_with_supervision_error.call_one().get()
 
     # Make sure the error message includes what originally happened.
-    with pytest.raises(
-        ActorError,
-        match="Simulated actor failure for supervision testing",
-    ):
+    with pytest.raises(ActorError) as error:
         get_or_spawn_controller("actor_1", ErrorActor).get()
+    error.match("Failure on actor_1")
+    error.match("Simulated actor failure for supervision testing")
 
     # Verify that the other actor is still reachable.
     # Note that we cannot spawn new actors on a proc mesh that has prior supervision
@@ -1787,3 +1788,76 @@ def test_unhandled_fault_hook_runs_atexit() -> None:
             f"file {marker_path} should have contents 'finalized' if the atexit handlers were run"
         )
     os.unlink(marker_path)
+
+
+def subprocess_with_hard_exit(
+    queue: multiprocessing.Queue, procs_ref: ProcMesh
+) -> None:
+    # The actors spawned in this process should exit themselves once the client
+    # is gone.
+    procs = this_host().spawn_procs({"gpus": 1})
+    actors = procs.spawn("error", ErrorActor)
+    actors_on_ref = procs_ref.spawn("error", ErrorActor)
+    # Ensure the procs and actors are spawned with a message.
+    pids = actors.get_pid.call().get()
+    pids = [pid for _, pid in pids]
+    pids_on_ref = actors_on_ref.get_pid.call().get()
+    pids_on_ref = [pid for _, pid in pids_on_ref]
+    # The pids owned by this client will be dead, but the pids on the referenced
+    # proc mesh should be alive. The actors will be gone.
+    queue.put(pids)
+    queue.put(pids_on_ref)
+    # Sleep for a long time so there is time to be interrupted.
+    time.sleep(120)
+
+
+@contextmanager
+def set_environment(**kwargs: str) -> Generator[None, None, None]:
+    try:
+        old = dict(os.environ)
+        new_keys = set(kwargs.keys()) - set(old.keys())
+        os.environ.update(kwargs)
+        yield
+    finally:
+        # Make sure to delete any new environments that were added
+        for k in new_keys:
+            del os.environ[k]
+        # Restore the old environment
+        os.environ.update(old)
+
+
+@pytest.mark.timeout(120)
+@isolate_in_subprocess
+def test_client_hard_exit_cleanup() -> None:
+    """Tests that actors and procs exit when client disconnects abruptly without running cleanup"""
+    with configured(mesh_orphan_timeout="10s"):
+        # Set the environment variable as well as the config to ensure the subprocess
+        # client gets the same value.
+        with set_environment(HYPERACTOR_MESH_ORPHAN_TIMEOUT="10s"):
+            # Start some procs from this client to ensure they are not killed if
+            # the subprocess client goes away.
+            procs = this_host().spawn_procs({"gpus": 1})
+            # Start a subprocess that will be a client, and kill the process.
+            # Ensure the process is new and not forked.
+            ctx = multiprocessing.get_context("spawn")
+            q = ctx.Queue()
+            p = ctx.Process(target=subprocess_with_hard_exit, args=(q, procs))
+            p.start()
+            # These pids should be gone because that client spawned the procs.
+            pids = q.get()
+            pids_on_ref = q.get()
+            # Make sure to terminate abnormally (SIGTERM), so we can test that this
+            # works even without any involvement from the user.
+            p.terminate()
+            # Ensure the processes exit after waiting for the timeout specified.
+            time.sleep(15)
+            processes_exist = [pid for pid in pids if is_process_running(pid)]
+            assert not processes_exist
+
+            ref_processes_exist = [
+                pid for pid in pids_on_ref if is_process_running(pid)
+            ]
+            assert ref_processes_exist
+
+            # There is currently no Python API to determine if the actors spawned
+            # by the subprocess are gone other than an undeliverable message.


### PR DESCRIPTION
Summary:

This is the second of two diffs that extend the ProcAgent self-kill to include procs. The first (https://github.com/meta-pytorch/monarch/issues/2198) lands the generic `ResourceController<T: Controlled>` and migrates `ActorMeshController`; this diff onboards `ProcMeshController` to it and lights up the proc-mesh polling/reaping path.

`impl Controlled for ProcMeshRef` lands here, the placeholder `ProcMeshController` struct is replaced with `pub(crate) type ProcMeshController = ResourceController<ProcMeshRef>`, and streamed/polled `State<ProcState>` flows through the same supervision loop the actor-mesh side already uses.

The functional change beyond the refactor: the proc-mesh controller now runs the periodic state poll (`HostAgent::KeepaliveGetState`) and a `SelfCheck` on each `HostAgent` reaps procs whose keepalive has lapsed past `MESH_ORPHAN_TIMEOUT`. When the client dies, the procs it started exit alongside its actors. `test_client_hard_exit_cleanup` covers this end-to-end: a subprocess client spawns its own procs, gets SIGTERM'd, and the orphan timeout cleans up the spawned procs while leaving procs owned by the surviving parent client untouched.

Walkthrough (ProcMesh::stop)

`ProcMesh::stop` now delegates to the controller when one is present, mirroring `ActorMesh::stop`: send `resource::Stop` to the controller, follow with `resource::GetState<resource::mesh::State<()>>`, and read the authoritative statuses out of `health_state` once the controller's serial handler has finished awaiting `HostMeshRef::stop_proc_mesh`. `is_terminating()` accepts `Stopping`, `Stopped`, `Failed`, and `Timeout`. `ProcMesh` has no `health_state` field, so `ProcMesh::stop` just propagates the error.

Walkthrough (HostAgent state plumbing)

`HostAgent` gains:
* `KeepaliveGetState<ProcState>` — same as `GetState`, but additionally extends the proc's `expiry_time` so `SelfCheck` knows the owner is still alive.
* `StreamState<ProcState>` — registers a subscriber that receives `State<ProcState>` on each state change, so the controller sees changes in real time without waiting for the next poll.
* `SelfCheck` — periodic self-message that walks `created`, finds procs whose `expiry_time` has lapsed, and sends `request_stop` to the host; gated on `MESH_ORPHAN_TIMEOUT > 0`.

`ProcCreationState` is refactored to centralise the (status, ProcState) derivation into `status()` and `to_state()`, so `GetState`, `StreamState`, `GetRankStatus`, `WaitRankStatus`, and `ProcStatusChanged` all share the same logic. `ProcState` derives `Bind`/`Unbind`. `STREAM_STATE_SUBSCRIBER` and `SelfCheck` become `pub(crate)` so `host_agent` can reuse them. `ProcMesh` gains a `controller` field with `set_controller`.

Reviewed By: mariusae

Differential Revision: D102638853


