### PR TITLE
wire IbvManagerActor onto QueuePairInitializer (#3814)

### DIFF
--- a/monarch_rdma/Cargo.toml
+++ b/monarch_rdma/Cargo.toml
@@ -14,7 +14,6 @@ backoff = { version = "0.4.0", features = ["futures", "tokio"] }
 bytes = { version = "1.11.1", features = ["serde"] }
 dashmap = { version = "6.1.0", features = ["rayon", "serde"] }
 erased-serde = "0.4.10"
-futures = { version = "0.3.31", features = ["async-await", "compat"] }
 hyperactor = { version = "0.0.0", path = "../hyperactor" }
 hyperactor_config = { version = "0.0.0", path = "../hyperactor_config" }
 hyperactor_mesh = { version = "0.0.0", path = "../hyperactor_mesh" }

--- a/monarch_rdma/examples/cuda_ping_pong/src/cuda_ping_pong.rs
+++ b/monarch_rdma/examples/cuda_ping_pong/src/cuda_ping_pong.rs
@@ -69,6 +69,7 @@ use hyperactor::OncePortRef;
 use hyperactor::RemoteSpawn;
 use hyperactor::Unbind;
 use hyperactor::channel::ChannelAddr;
+use hyperactor::context::Mailbox;
 use hyperactor::id::Label;
 use hyperactor::supervision::ActorSupervisionEvent;
 use hyperactor_config::Flattrs;
@@ -83,7 +84,7 @@ use monarch_rdma::IbvConfig;
 use monarch_rdma::RdmaManagerActor;
 use monarch_rdma::RdmaManagerMessageClient;
 use monarch_rdma::RdmaRemoteBuffer;
-use monarch_rdma::backend::ibverbs::manager_actor::IbvManagerMessageClient;
+use monarch_rdma::backend::ibverbs::manager_actor::IbvManagerLocalMessageClient;
 use monarch_rdma::cu_check;
 use monarch_rdma::local_memory::RdmaLocalMemory;
 use monarch_rdma::local_memory::UnsafeLocalMemory;
@@ -512,14 +513,25 @@ impl Handler<PerformPingPong> for CudaRdmaActor {
             .resolve_ibv()
             .ok_or_else(|| anyhow::anyhow!("ibverbs backend not found for remote buffer"))?;
 
-        let qp = local_ibv_manager
+        let local_ibv_manager_handle = local_ibv_manager
+            .downcast_handle(cx)
+            .ok_or_else(|| anyhow::anyhow!("local IbvManagerActor is not in this process"))?;
+        let (reply_handle, reply_rx) = cx
+            .mailbox()
+            .open_once_port::<Result<monarch_rdma::backend::ibverbs::queue_pair::IbvQueuePair, String>>();
+        local_ibv_manager_handle
             .request_queue_pair(
                 cx,
                 remote_ibv_manager.clone(),
                 local_ibv.device_name.clone(),
                 remote_ibv.device_name.clone(),
+                reply_handle,
             )
-            .await?
+            .await?;
+        let qp = reply_rx
+            .recv()
+            .await
+            .map_err(|e| anyhow::anyhow!("request_queue_pair reply channel closed: {e}"))?
             .map_err(|e| anyhow::anyhow!(e))?;
 
         unsafe {

--- a/monarch_rdma/src/backend/ibverbs/ibv_manager_actor_tests.rs
+++ b/monarch_rdma/src/backend/ibverbs/ibv_manager_actor_tests.rs
@@ -16,7 +16,7 @@
 #[cfg(test)]
 mod tests {
     use super::super::PollTarget;
-    use super::super::manager_actor::IbvManagerMessageClient;
+    use super::super::manager_actor::request_queue_pair;
     use super::super::primitives::IbvQpType;
     use super::super::primitives::get_all_devices;
     use super::super::test_utils::IbvTestEnv;
@@ -33,30 +33,19 @@ mod tests {
             return Ok(());
         }
         let env = IbvTestEnv::setup(BSIZE, "cpu:0", "cpu:0").await?;
-        let mut qp_1 = env
-            .ibv_actor_1
-            .request_queue_pair(
-                &env.client_1,
-                env.ibv_actor_2.clone(),
-                env.ibv_buffer_1.device_name.clone(),
-                env.ibv_buffer_2.device_name.clone(),
-            )
-            .await?
-            .map_err(|e| anyhow::anyhow!(e))?;
+        let mut qp_1 = request_queue_pair(
+            &env.ibv_handle_1,
+            &env.client_1,
+            env.ibv_actor_2.clone(),
+            env.ibv_buffer_1.device_name.clone(),
+            env.ibv_buffer_2.device_name.clone(),
+        )
+        .await?
+        .map_err(|e| anyhow::anyhow!(e))?;
         let wr_id = qp_1.put(env.ibv_buffer_1.clone(), env.ibv_buffer_2.clone())?;
 
         // Poll for completion
         wait_for_completion(&mut qp_1, PollTarget::Send, &wr_id, 2).await?;
-
-        env.ibv_actor_1
-            .release_queue_pair(
-                &env.client_1,
-                env.ibv_actor_2.clone(),
-                env.ibv_buffer_1.device_name.clone(),
-                env.ibv_buffer_2.device_name.clone(),
-                qp_1,
-            )
-            .await?;
 
         env.verify_buffers(BSIZE, 0).await?;
         Ok(())
@@ -72,29 +61,18 @@ mod tests {
             return Ok(());
         }
         let env = IbvTestEnv::setup(BSIZE, "cpu:0", "cpu:0").await?;
-        let mut qp_1 = env
-            .ibv_actor_1
-            .request_queue_pair(
-                &env.client_1,
-                env.ibv_actor_2.clone(),
-                env.ibv_buffer_1.device_name.clone(),
-                env.ibv_buffer_2.device_name.clone(),
-            )
-            .await?
-            .map_err(|e| anyhow::anyhow!(e))?;
+        let mut qp_1 = request_queue_pair(
+            &env.ibv_handle_1,
+            &env.client_1,
+            env.ibv_actor_2.clone(),
+            env.ibv_buffer_1.device_name.clone(),
+            env.ibv_buffer_2.device_name.clone(),
+        )
+        .await?
+        .map_err(|e| anyhow::anyhow!(e))?;
         let wr_id = qp_1.put(env.ibv_buffer_1.clone(), env.ibv_buffer_2.clone())?;
 
         wait_for_completion(&mut qp_1, PollTarget::Send, &wr_id, 2).await?;
-
-        env.ibv_actor_1
-            .release_queue_pair(
-                &env.client_1,
-                env.ibv_actor_2.clone(),
-                env.ibv_buffer_1.device_name.clone(),
-                env.ibv_buffer_2.device_name.clone(),
-                qp_1,
-            )
-            .await?;
 
         env.verify_buffers(BSIZE, 0).await?;
         Ok(())
@@ -112,16 +90,15 @@ mod tests {
             return Ok(());
         }
         let env = IbvTestEnv::setup(BSIZE, "cpu:0", "cpu:1").await?;
-        let mut qp_1 = env
-            .ibv_actor_1
-            .request_queue_pair(
-                &env.client_1,
-                env.ibv_actor_2.clone(),
-                env.ibv_buffer_1.device_name.clone(),
-                env.ibv_buffer_2.device_name.clone(),
-            )
-            .await?
-            .map_err(|e| anyhow::anyhow!(e))?;
+        let mut qp_1 = request_queue_pair(
+            &env.ibv_handle_1,
+            &env.client_1,
+            env.ibv_actor_2.clone(),
+            env.ibv_buffer_1.device_name.clone(),
+            env.ibv_buffer_2.device_name.clone(),
+        )
+        .await?
+        .map_err(|e| anyhow::anyhow!(e))?;
         let wr_id = qp_1.get(env.ibv_buffer_1.clone(), env.ibv_buffer_2.clone())?;
 
         // Poll for completion
@@ -143,16 +120,15 @@ mod tests {
             return Ok(());
         }
         let env = IbvTestEnv::setup(BSIZE, "cpu:0", "cpu:1").await?;
-        let mut qp_1 = env
-            .ibv_actor_1
-            .request_queue_pair(
-                &env.client_1,
-                env.ibv_actor_2.clone(),
-                env.ibv_buffer_1.device_name.clone(),
-                env.ibv_buffer_2.device_name.clone(),
-            )
-            .await?
-            .map_err(|e| anyhow::anyhow!(e))?;
+        let mut qp_1 = request_queue_pair(
+            &env.ibv_handle_1,
+            &env.client_1,
+            env.ibv_actor_2.clone(),
+            env.ibv_buffer_1.device_name.clone(),
+            env.ibv_buffer_2.device_name.clone(),
+        )
+        .await?
+        .map_err(|e| anyhow::anyhow!(e))?;
         let wr_id = qp_1.put(env.ibv_buffer_1.clone(), env.ibv_buffer_2.clone())?;
         wait_for_completion(&mut qp_1, PollTarget::Send, &wr_id, 2).await?;
 
@@ -172,26 +148,24 @@ mod tests {
             return Ok(());
         }
         let env = IbvTestEnv::setup(BSIZE, "cpu:0", "cpu:1").await?;
-        let mut qp_1 = env
-            .ibv_actor_1
-            .request_queue_pair(
-                &env.client_1,
-                env.ibv_actor_2.clone(),
-                env.ibv_buffer_1.device_name.clone(),
-                env.ibv_buffer_2.device_name.clone(),
-            )
-            .await?
-            .map_err(|e| anyhow::anyhow!(e))?;
-        let mut qp_2 = env
-            .ibv_actor_2
-            .request_queue_pair(
-                &env.client_2,
-                env.ibv_actor_1.clone(),
-                env.ibv_buffer_2.device_name.clone(),
-                env.ibv_buffer_1.device_name.clone(),
-            )
-            .await?
-            .map_err(|e| anyhow::anyhow!(e))?;
+        let mut qp_1 = request_queue_pair(
+            &env.ibv_handle_1,
+            &env.client_1,
+            env.ibv_actor_2.clone(),
+            env.ibv_buffer_1.device_name.clone(),
+            env.ibv_buffer_2.device_name.clone(),
+        )
+        .await?
+        .map_err(|e| anyhow::anyhow!(e))?;
+        let mut qp_2 = request_queue_pair(
+            &env.ibv_handle_2,
+            &env.client_2,
+            env.ibv_actor_1.clone(),
+            env.ibv_buffer_2.device_name.clone(),
+            env.ibv_buffer_1.device_name.clone(),
+        )
+        .await?
+        .map_err(|e| anyhow::anyhow!(e))?;
         qp_1.recv(env.ibv_buffer_1.clone(), env.ibv_buffer_2.clone())?;
         let wr_id = qp_2.put_with_recv(env.ibv_buffer_2.clone(), env.ibv_buffer_1.clone())?;
         wait_for_completion(&mut qp_2, PollTarget::Send, &wr_id, 5).await?;
@@ -214,16 +188,15 @@ mod tests {
             return Ok(());
         }
         let env = IbvTestEnv::setup(BSIZE, "cpu:0", "cpu:0").await?;
-        let mut qp_1 = env
-            .ibv_actor_1
-            .request_queue_pair(
-                &env.client_1,
-                env.ibv_actor_2.clone(),
-                env.ibv_buffer_1.device_name.clone(),
-                env.ibv_buffer_2.device_name.clone(),
-            )
-            .await?
-            .map_err(|e| anyhow::anyhow!(e))?;
+        let mut qp_1 = request_queue_pair(
+            &env.ibv_handle_1,
+            &env.client_1,
+            env.ibv_actor_2.clone(),
+            env.ibv_buffer_1.device_name.clone(),
+            env.ibv_buffer_2.device_name.clone(),
+        )
+        .await?
+        .map_err(|e| anyhow::anyhow!(e))?;
         let wr_id = qp_1.enqueue_put(env.ibv_buffer_1.clone(), env.ibv_buffer_2.clone())?;
         qp_1.ring_doorbell()?;
         // Poll for completion
@@ -247,16 +220,15 @@ mod tests {
             return Ok(());
         }
         let env = IbvTestEnv::setup(BSIZE, "cpu:0", "cpu:1").await?;
-        let mut qp_2 = env
-            .ibv_actor_2
-            .request_queue_pair(
-                &env.client_2,
-                env.ibv_actor_1.clone(),
-                env.ibv_buffer_2.device_name.clone(),
-                env.ibv_buffer_1.device_name.clone(),
-            )
-            .await?
-            .map_err(|e| anyhow::anyhow!(e))?;
+        let mut qp_2 = request_queue_pair(
+            &env.ibv_handle_2,
+            &env.client_2,
+            env.ibv_actor_1.clone(),
+            env.ibv_buffer_2.device_name.clone(),
+            env.ibv_buffer_1.device_name.clone(),
+        )
+        .await?
+        .map_err(|e| anyhow::anyhow!(e))?;
         let wr_id = qp_2.enqueue_get(env.ibv_buffer_2.clone(), env.ibv_buffer_1.clone())?;
         qp_2.ring_doorbell()?;
         // Poll for completion
@@ -339,16 +311,15 @@ mod tests {
             return Ok(());
         }
         let env = IbvTestEnv::setup(BSIZE, "cuda:0", "cuda:1").await?;
-        let mut qp_1 = env
-            .ibv_actor_1
-            .request_queue_pair(
-                &env.client_1,
-                env.ibv_actor_2.clone(),
-                env.ibv_buffer_1.device_name.clone(),
-                env.ibv_buffer_2.device_name.clone(),
-            )
-            .await?
-            .map_err(|e| anyhow::anyhow!(e))?;
+        let mut qp_1 = request_queue_pair(
+            &env.ibv_handle_1,
+            &env.client_1,
+            env.ibv_actor_2.clone(),
+            env.ibv_buffer_1.device_name.clone(),
+            env.ibv_buffer_2.device_name.clone(),
+        )
+        .await?
+        .map_err(|e| anyhow::anyhow!(e))?;
         qp_1.enqueue_put(env.ibv_buffer_1.clone(), env.ibv_buffer_2.clone())?;
         ring_db_gpu(&qp_1).await?;
         // Poll for completion
@@ -381,16 +352,15 @@ mod tests {
             return Ok(());
         }
         let env = IbvTestEnv::setup(BSIZE, "cuda:0", "cuda:1").await?;
-        let mut qp_1 = env
-            .ibv_actor_1
-            .request_queue_pair(
-                &env.client_1,
-                env.ibv_actor_2.clone(),
-                env.ibv_buffer_1.device_name.clone(),
-                env.ibv_buffer_2.device_name.clone(),
-            )
-            .await?
-            .map_err(|e| anyhow::anyhow!(e))?;
+        let mut qp_1 = request_queue_pair(
+            &env.ibv_handle_1,
+            &env.client_1,
+            env.ibv_actor_2.clone(),
+            env.ibv_buffer_1.device_name.clone(),
+            env.ibv_buffer_2.device_name.clone(),
+        )
+        .await?
+        .map_err(|e| anyhow::anyhow!(e))?;
         qp_1.enqueue_get(env.ibv_buffer_1.clone(), env.ibv_buffer_2.clone())?;
         ring_db_gpu(&qp_1).await?;
         // Poll for completion
@@ -422,26 +392,24 @@ mod tests {
             return Ok(());
         }
         let env = IbvTestEnv::setup(BSIZE, "cuda:0", "cuda:1").await?;
-        let mut qp_1 = env
-            .ibv_actor_1
-            .request_queue_pair(
-                &env.client_1,
-                env.ibv_actor_2.clone(),
-                env.ibv_buffer_1.device_name.clone(),
-                env.ibv_buffer_2.device_name.clone(),
-            )
-            .await?
-            .map_err(|e| anyhow::anyhow!(e))?;
-        let mut qp_2 = env
-            .ibv_actor_2
-            .request_queue_pair(
-                &env.client_2,
-                env.ibv_actor_1.clone(),
-                env.ibv_buffer_2.device_name.clone(),
-                env.ibv_buffer_1.device_name.clone(),
-            )
-            .await?
-            .map_err(|e| anyhow::anyhow!(e))?;
+        let mut qp_1 = request_queue_pair(
+            &env.ibv_handle_1,
+            &env.client_1,
+            env.ibv_actor_2.clone(),
+            env.ibv_buffer_1.device_name.clone(),
+            env.ibv_buffer_2.device_name.clone(),
+        )
+        .await?
+        .map_err(|e| anyhow::anyhow!(e))?;
+        let mut qp_2 = request_queue_pair(
+            &env.ibv_handle_2,
+            &env.client_2,
+            env.ibv_actor_1.clone(),
+            env.ibv_buffer_2.device_name.clone(),
+            env.ibv_buffer_1.device_name.clone(),
+        )
+        .await?
+        .map_err(|e| anyhow::anyhow!(e))?;
         recv_wqe_gpu(
             &mut qp_1,
             &env.ibv_buffer_1,
@@ -481,16 +449,15 @@ mod tests {
         }
         let env = IbvTestEnv::setup(BSIZE, "cuda:0", "cpu:1").await?;
         // Pre-initialize comms, and wait for hardware to transition to send state
-        let mut qp_1 = env
-            .ibv_actor_1
-            .request_queue_pair(
-                &env.client_1,
-                env.ibv_actor_2.clone(),
-                env.ibv_buffer_1.device_name.clone(),
-                env.ibv_buffer_2.device_name.clone(),
-            )
-            .await?
-            .map_err(|e| anyhow::anyhow!(e))?;
+        let mut qp_1 = request_queue_pair(
+            &env.ibv_handle_1,
+            &env.client_1,
+            env.ibv_actor_2.clone(),
+            env.ibv_buffer_1.device_name.clone(),
+            env.ibv_buffer_2.device_name.clone(),
+        )
+        .await?
+        .map_err(|e| anyhow::anyhow!(e))?;
         let wr_id = qp_1.put(env.ibv_buffer_1.clone(), env.ibv_buffer_2.clone())?;
 
         wait_for_completion(&mut qp_1, PollTarget::Send, &wr_id, 5).await?;
@@ -517,16 +484,15 @@ mod tests {
         }
         let env = IbvTestEnv::setup(BSIZE, "cuda:0", "cuda:1").await?;
         // Pre-initialize comms, and wait for hardware to transition to send state
-        let mut qp_1 = env
-            .ibv_actor_1
-            .request_queue_pair(
-                &env.client_1,
-                env.ibv_actor_2.clone(),
-                env.ibv_buffer_1.device_name.clone(),
-                env.ibv_buffer_2.device_name.clone(),
-            )
-            .await?
-            .map_err(|e| anyhow::anyhow!(e))?;
+        let mut qp_1 = request_queue_pair(
+            &env.ibv_handle_1,
+            &env.client_1,
+            env.ibv_actor_2.clone(),
+            env.ibv_buffer_1.device_name.clone(),
+            env.ibv_buffer_2.device_name.clone(),
+        )
+        .await?
+        .map_err(|e| anyhow::anyhow!(e))?;
         let wr_id = qp_1.put(env.ibv_buffer_1.clone(), env.ibv_buffer_2.clone())?;
 
         wait_for_completion(&mut qp_1, PollTarget::Send, &wr_id, 5).await?;
@@ -853,6 +819,88 @@ mod tests {
         env.cleanup().await?;
 
         println!("2GB RDMA write test completed successfully");
+        Ok(())
+    }
+
+    // ============================================================
+    // Wiring tests for IbvManagerActor's QP state machine.
+    // ============================================================
+
+    /// Two concurrent local `request_queue_pair` calls for the same
+    /// `(self_device, peer, other_device)` key must both succeed and
+    /// return the same QP; that QP must be usable for data-plane ops.
+    #[timed_test::async_timed_test(timeout_secs = 60)]
+    async fn test_concurrent_request_queue_pair_converges() -> Result<(), anyhow::Error> {
+        const BSIZE: usize = 32;
+        if get_all_devices().is_empty() {
+            panic!("Skipping test: RDMA devices not available");
+        }
+        let env = IbvTestEnv::setup(BSIZE, "cpu:0", "cpu:0").await?;
+        let self_device = env.ibv_buffer_1.device_name.clone();
+        let other_device = env.ibv_buffer_2.device_name.clone();
+
+        let (r1, r2) = tokio::join!(
+            request_queue_pair(
+                &env.ibv_handle_1,
+                &env.client_1,
+                env.ibv_actor_2.clone(),
+                self_device.clone(),
+                other_device.clone(),
+            ),
+            request_queue_pair(
+                &env.ibv_handle_1,
+                &env.client_1,
+                env.ibv_actor_2.clone(),
+                self_device.clone(),
+                other_device.clone(),
+            ),
+        );
+        let qp1 = r1?.map_err(|e| anyhow::anyhow!(e))?;
+        let mut qp2 = r2?.map_err(|e| anyhow::anyhow!(e))?;
+        assert_eq!(qp1.qp, qp2.qp);
+
+        let wr_id = qp2.put(env.ibv_buffer_1.clone(), env.ibv_buffer_2.clone())?;
+        wait_for_completion(&mut qp2, PollTarget::Send, &wr_id, 2).await?;
+        env.verify_buffers(BSIZE, 0).await?;
+        Ok(())
+    }
+
+    /// Two managers call `request_queue_pair` for each other at the
+    /// same time. Each side spawns a [`QueuePairInitializer`] and the
+    /// two initializers must rendezvous on the wire (peer endpoint +
+    /// `NotifyRts`) without either side deadlocking the other. The
+    /// resulting QP must be usable for a data-plane op.
+    #[timed_test::async_timed_test(timeout_secs = 60)]
+    async fn test_bidirectional_concurrent_request_queue_pair() -> Result<(), anyhow::Error> {
+        const BSIZE: usize = 32;
+        if get_all_devices().is_empty() {
+            panic!("Skipping test: RDMA devices not available");
+        }
+        let env = IbvTestEnv::setup(BSIZE, "cpu:0", "cpu:0").await?;
+        let dev_1 = env.ibv_buffer_1.device_name.clone();
+        let dev_2 = env.ibv_buffer_2.device_name.clone();
+
+        let (r_local, r_remote) = tokio::join!(
+            request_queue_pair(
+                &env.ibv_handle_1,
+                &env.client_1,
+                env.ibv_actor_2.clone(),
+                dev_1.clone(),
+                dev_2.clone(),
+            ),
+            request_queue_pair(
+                &env.ibv_handle_2,
+                &env.client_2,
+                env.ibv_actor_1.clone(),
+                dev_2.clone(),
+                dev_1.clone(),
+            ),
+        );
+        let mut qp1 = r_local?.map_err(|e| anyhow::anyhow!(e))?;
+        let _ = r_remote?.map_err(|e| anyhow::anyhow!(e))?;
+        let wr_id = qp1.put(env.ibv_buffer_1.clone(), env.ibv_buffer_2.clone())?;
+        wait_for_completion(&mut qp1, PollTarget::Send, &wr_id, 2).await?;
+        env.verify_buffers(BSIZE, 0).await?;
         Ok(())
     }
 }

--- a/monarch_rdma/src/backend/ibverbs/manager_actor.rs
+++ b/monarch_rdma/src/backend/ibverbs/manager_actor.rs
@@ -39,7 +39,9 @@ use hyperactor::Handler;
 use hyperactor::Instance;
 use hyperactor::OncePortHandle;
 use hyperactor::OncePortRef;
+use hyperactor::PortRef;
 use hyperactor::RefClient;
+use hyperactor::actor::Referable;
 use serde::Deserialize;
 use serde::Serialize;
 use typeuri::Named;
@@ -55,8 +57,11 @@ use super::primitives::ibverbs_supported;
 use super::primitives::mlx5dv_supported;
 use super::primitives::resolve_qp_type;
 use super::queue_pair::IbvQueuePair;
+use super::queue_pair::PeerInfo;
 use super::queue_pair::PollCompletionError;
 use super::queue_pair::PollTarget;
+use super::queue_pair::QpGuard;
+use super::queue_pair::QpKey;
 use crate::RdmaOp;
 use crate::RdmaOpType;
 use crate::RdmaTransportLevel;
@@ -117,6 +122,21 @@ pub enum IbvManagerMessage {
 }
 wirevalue::register_type!(IbvManagerMessage);
 
+/// Cross-proc message: peer asks for our endpoint, lazily creating
+/// the entry on our side if absent. Generic over the manager actor
+/// type so tests can swap in a mock. The handler impl on
+/// `IbvManagerActor` lands in a follow-up commit; this commit only
+/// defines the type so `QueuePairInitializer` can compile.
+#[derive(Debug, Serialize, Deserialize, Named)]
+#[serde(bound(serialize = "", deserialize = ""))]
+pub(super) struct EnsureQueuePair<A: Referable> {
+    pub(super) sender: ActorRef<A>,
+    pub(super) sender_device: String,
+    pub(super) receiver_device: String,
+    pub(super) reply: PortRef<PeerInfo>,
+}
+wirevalue::register_type!(EnsureQueuePair<IbvManagerActor>);
+
 /// Local-only messages for MR registration/deregistration.
 #[derive(Handler, HandleClient, Debug)]
 pub enum IbvManagerLocalMessage {
@@ -146,6 +166,27 @@ pub enum IbvManagerLocalMessage {
         #[reply]
         reply: OncePortHandle<Result<IbvBuffer, String>>,
     },
+}
+
+/// Local-only handshake-success report. The initializer sends this
+/// to its owning manager once both sides have reached RTS, handing
+/// over the freshly-connected [`QpGuard`]. Wired up in a follow-up
+/// commit; the [`Handler`] impl is `unreachable!` until then.
+#[derive(Debug)]
+pub(super) struct QpInitializerDone {
+    pub(super) qp_key: QpKey,
+    pub(super) qp: QpGuard,
+}
+
+/// Local-only handshake-failure report. The initializer sends this
+/// to its owning manager when the handshake aborted; the underlying
+/// QP has already been dropped on the initializer side. Wired up in
+/// a follow-up commit; the [`Handler`] impl is `unreachable!` until
+/// then.
+#[derive(Debug)]
+pub(super) struct QpInitializerFailed {
+    pub(super) qp_key: QpKey,
+    pub(super) error: String,
 }
 
 /// Adaptive wait between completion polls.
@@ -1098,6 +1139,32 @@ impl IbvManagerLocalMessageHandler for IbvManagerActor {
         };
         self.buffer_registrations.insert(remote_buf_id, buf.clone());
         Ok(Ok(buf))
+    }
+}
+
+#[async_trait]
+impl Handler<QpInitializerDone> for IbvManagerActor {
+    async fn handle(
+        &mut self,
+        _cx: &Context<Self>,
+        _msg: QpInitializerDone,
+    ) -> Result<(), anyhow::Error> {
+        unreachable!(
+            "IbvManagerActor does not yet spawn QueuePairInitializer; wired up in a follow-up commit"
+        )
+    }
+}
+
+#[async_trait]
+impl Handler<QpInitializerFailed> for IbvManagerActor {
+    async fn handle(
+        &mut self,
+        _cx: &Context<Self>,
+        _msg: QpInitializerFailed,
+    ) -> Result<(), anyhow::Error> {
+        unreachable!(
+            "IbvManagerActor does not yet spawn QueuePairInitializer; wired up in a follow-up commit"
+        )
     }
 }
 

--- a/monarch_rdma/src/backend/ibverbs/manager_actor.rs
+++ b/monarch_rdma/src/backend/ibverbs/manager_actor.rs
@@ -15,9 +15,25 @@
 //! - Queue pair creation and connection establishment
 //! - RDMA domain and protection domain management
 //! - Device selection and PCI-to-RDMA device mapping
+//!
+//! ## Queue-pair lifecycle
+//!
+//! Bringing up a queue pair to a peer is a two-sided handshake (each
+//! side has its own QP and must learn the other side's endpoint
+//! before transitioning `INIT → RTR → RTS`). Doing all of that in
+//! response to a single message would block our actor loop while
+//! awaiting peer RPCs, and the peer's symmetric request would block
+//! waiting for us — a deadlock.
+//!
+//! Instead, [`IbvManagerActor`] does only sync bookkeeping in the
+//! handler and offloads the handshake to a per-QP child actor,
+//! [`QueuePairInitializer`]. The store of QPs ([`Self::qps`]) is
+//! keyed by [`QpKey`] and holds a [`QpState`]: `Pending { info,
+//! initializer, waiters }` while the handshake runs, `Ready(qp)`
+//! once this side is RTS and has observed the peer's RTS, or
+//! `Failed(error)` as a tombstone after a fatal error.
 
 use std::collections::HashMap;
-use std::collections::HashSet;
 use std::sync::Arc;
 use std::sync::OnceLock;
 use std::time::Duration;
@@ -28,17 +44,14 @@ use async_trait::async_trait;
 use backoff::ExponentialBackoff;
 use backoff::ExponentialBackoffBuilder;
 use backoff::backoff::Backoff;
-use futures::lock::Mutex;
 use hyperactor::Actor;
 use hyperactor::ActorHandle;
-use hyperactor::ActorId;
 use hyperactor::ActorRef;
 use hyperactor::Context;
 use hyperactor::HandleClient;
 use hyperactor::Handler;
 use hyperactor::Instance;
 use hyperactor::OncePortHandle;
-use hyperactor::OncePortRef;
 use hyperactor::PortRef;
 use hyperactor::RefClient;
 use hyperactor::actor::Referable;
@@ -62,6 +75,8 @@ use super::queue_pair::PollCompletionError;
 use super::queue_pair::PollTarget;
 use super::queue_pair::QpGuard;
 use super::queue_pair::QpKey;
+use super::queue_pair::QueuePairInitializer;
+use super::queue_pair::destroy_qp;
 use crate::RdmaOp;
 use crate::RdmaOpType;
 use crate::RdmaTransportLevel;
@@ -73,60 +88,9 @@ use crate::rdma_manager_actor::RdmaManagerActor;
 use crate::rdma_manager_actor::get_rdmaxcel_error_message;
 use crate::validate_execution_context;
 
-/// Messages handled by [`IbvManagerActor`].
-#[derive(Handler, HandleClient, RefClient, Debug, Serialize, Deserialize, Named)]
-pub enum IbvManagerMessage {
-    /// Release a buffer registration by `remote_buf_id`. Fire-and-forget
-    /// (no reply port) to avoid blocking the caller during teardown.
-    ReleaseBuffer { remote_buf_id: usize },
-    RequestQueuePair {
-        other: ActorRef<IbvManagerActor>,
-        self_device: String,
-        other_device: String,
-        #[reply]
-        reply: OncePortRef<Result<IbvQueuePair, String>>,
-    },
-    Connect {
-        other: ActorRef<IbvManagerActor>,
-        self_device: String,
-        other_device: String,
-        endpoint: IbvQpInfo,
-    },
-    InitializeQP {
-        other: ActorRef<IbvManagerActor>,
-        self_device: String,
-        other_device: String,
-        #[reply]
-        reply: OncePortRef<bool>,
-    },
-    ConnectionInfo {
-        other: ActorRef<IbvManagerActor>,
-        self_device: String,
-        other_device: String,
-        #[reply]
-        reply: OncePortRef<IbvQpInfo>,
-    },
-    ReleaseQueuePair {
-        other: ActorRef<IbvManagerActor>,
-        self_device: String,
-        other_device: String,
-        qp: IbvQueuePair,
-    },
-    GetQpState {
-        other: ActorRef<IbvManagerActor>,
-        self_device: String,
-        other_device: String,
-        #[reply]
-        reply: OncePortRef<u32>,
-    },
-}
-wirevalue::register_type!(IbvManagerMessage);
-
 /// Cross-proc message: peer asks for our endpoint, lazily creating
 /// the entry on our side if absent. Generic over the manager actor
-/// type so tests can swap in a mock. The handler impl on
-/// `IbvManagerActor` lands in a follow-up commit; this commit only
-/// defines the type so `QueuePairInitializer` can compile.
+/// type so tests can swap in a mock.
 #[derive(Debug, Serialize, Deserialize, Named)]
 #[serde(bound(serialize = "", deserialize = ""))]
 pub(super) struct EnsureQueuePair<A: Referable> {
@@ -137,7 +101,48 @@ pub(super) struct EnsureQueuePair<A: Referable> {
 }
 wirevalue::register_type!(EnsureQueuePair<IbvManagerActor>);
 
-/// Local-only messages for MR registration/deregistration.
+/// Per-QpKey state in [`IbvManagerActor::qps`].
+///
+/// `Pending` covers the entire handshake (an initializer is running);
+/// `Ready` is the terminal usable state; `Failed` is a tombstone that
+/// records the error so subsequent `RequestQueuePair` / `EnsureQueuePair`
+/// calls for the same key surface the same error rather than retrying
+/// or hanging.
+///
+/// TODO: add recovery — allow retries via an explicit message or after
+/// a backoff. For now the entry stays `Failed` for the life of the
+/// manager.
+#[derive(Debug)]
+enum QpState {
+    Pending {
+        /// Local endpoint, captured when the QP was first created so
+        /// repeated `EnsureQueuePair` calls don't have to re-extract it.
+        info: IbvQpInfo,
+        /// Child actor driving the handshake. Stopped on
+        /// `QpInitializerDone`/`QpInitializerFailed`.
+        initializer: ActorHandle<QueuePairInitializer<IbvManagerActor>>,
+        /// Local `RequestQueuePair` callers waiting for the QP. Drained
+        /// to `Ok(qp.clone())` on `Ready`, or `Err(_)` on failure.
+        waiters: Vec<OncePortHandle<Result<IbvQueuePair, String>>>,
+    },
+    Ready(IbvQueuePair),
+    Failed(String),
+}
+
+/// Cross-proc messages handled by [`IbvManagerActor`].
+///
+/// `EnsureQueuePair` is defined as a separate top-level message
+/// because it's generic over the manager actor type to allow
+/// mocking in tests.
+#[derive(Handler, HandleClient, RefClient, Debug, Serialize, Deserialize, Named)]
+pub enum IbvManagerMessage {
+    /// Release a buffer registration by `remote_buf_id`. Fire-and-forget
+    /// (no reply port) to avoid blocking the caller during teardown.
+    ReleaseBuffer { remote_buf_id: usize },
+}
+wirevalue::register_type!(IbvManagerMessage);
+
+/// Local-only messages for [`IbvManagerActor`].
 #[derive(Handler, HandleClient, Debug)]
 pub enum IbvManagerLocalMessage {
     /// Register a memory region, returning the MR view and device name.
@@ -166,12 +171,26 @@ pub enum IbvManagerLocalMessage {
         #[reply]
         reply: OncePortHandle<Result<IbvBuffer, String>>,
     },
+    /// User-facing entry point: get a connected `IbvQueuePair` for
+    /// `(self_device, other actor's id, other_device)`. Lazily creates
+    /// the QP + initializer if absent; if a handshake is in flight,
+    /// the reply port is queued and answered when the QP becomes
+    /// `Ready` (or fails).
+    ///
+    /// No `#[reply]` because the handler may park `reply` on the
+    /// `Pending` entry and answer it later from [`QpInitializerDone`]/
+    /// [`QpInitializerFailed`].
+    RequestQueuePair {
+        other: ActorRef<IbvManagerActor>,
+        self_device: String,
+        other_device: String,
+        reply: OncePortHandle<Result<IbvQueuePair, String>>,
+    },
 }
 
 /// Local-only handshake-success report. The initializer sends this
 /// to its owning manager once both sides have reached RTS, handing
-/// over the freshly-connected [`QpGuard`]. Wired up in a follow-up
-/// commit; the [`Handler`] impl is `unreachable!` until then.
+/// over the freshly-connected [`QpGuard`].
 #[derive(Debug)]
 pub(super) struct QpInitializerDone {
     pub(super) qp_key: QpKey,
@@ -180,9 +199,7 @@ pub(super) struct QpInitializerDone {
 
 /// Local-only handshake-failure report. The initializer sends this
 /// to its owning manager when the handshake aborted; the underlying
-/// QP has already been dropped on the initializer side. Wired up in
-/// a follow-up commit; the [`Handler`] impl is `unreachable!` until
-/// then.
+/// QP has already been dropped on the initializer side.
 #[derive(Debug)]
 pub(super) struct QpInitializerFailed {
     pub(super) qp_key: QpKey,
@@ -297,34 +314,32 @@ pub(super) fn lookup_segment_for_address(
 #[hyperactor::export(
     handlers = [
         IbvManagerMessage,
+        EnsureQueuePair<IbvManagerActor>,
     ],
 )]
 pub struct IbvManagerActor {
     owner: OnceLock<ActorHandle<RdmaManagerActor>>,
 
-    // Nested map: local_device -> (ActorId, remote_device) -> IbvQueuePair
-    device_qps: HashMap<String, HashMap<(ActorId, String), IbvQueuePair>>,
+    /// Per-QP state, keyed from this manager's perspective. See [`QpKey`].
+    qps: HashMap<QpKey, QpState>,
 
-    // Track QPs currently being created to prevent duplicate creation
-    // Wrapped in Arc<Mutex> to allow safe concurrent access
-    pending_qp_creation: Arc<Mutex<HashSet<(String, ActorId, String)>>>,
-
-    // Map of RDMA device names to their domains and loopback QPs
-    // Created lazily when memory is registered for a specific device
+    /// Map of RDMA device names to their domains and loopback QPs.
+    /// Created lazily when memory is registered for a specific device.
     device_domains: HashMap<String, (IbvDomain, Option<IbvQueuePair>)>,
 
     config: IbvConfig,
 
     mlx5dv_enabled: bool,
 
-    // Map of unique IbvMemoryRegionView to ibv_mr*.  In case of cuda w/ pytorch its -1
-    // since its managed independently.  Only used for registration/deregistration purposes
+    /// Map of MR view id to ibv_mr*. CUDA segments register as `0`
+    /// since they're managed independently. Used only for
+    /// registration/deregistration bookkeeping.
     mr_map: HashMap<usize, usize>,
 
-    // Id for next mrv created
+    /// Id for next mrv created.
     mrv_id: usize,
 
-    // Map from buffer_id to registration details.
+    /// Map from buffer_id to registration details.
     buffer_registrations: HashMap<usize, IbvBuffer>,
 }
 
@@ -345,30 +360,32 @@ impl Actor for IbvManagerActor {
 
 impl Drop for IbvManagerActor {
     fn drop(&mut self) {
-        // Helper function to destroy QP resources
-        // We can't use Drop on IbvQueuePair because it derives Clone
-        // Note: rdmaxcel_qp_destroy handles destroying both the QP and its CQs internally,
-        // so we must NOT call ibv_destroy_cq separately (would cause double-free/SIGSEGV)
-        fn destroy_queue_pair(qp: &IbvQueuePair, _context: &str) {
-            unsafe {
-                if qp.qp != 0 {
-                    let rdmaxcel_qp = qp.qp as *mut rdmaxcel_sys::rdmaxcel_qp;
-                    rdmaxcel_sys::rdmaxcel_qp_destroy(rdmaxcel_qp);
+        // 1. Clean up QPs. `Pending` entries hold the qp via the
+        // initializer; signal the initializer to stop and let the
+        // runtime tear it down. `Failed` is a tombstone with no
+        // resources. Pending waiters won't be answered and their
+        // callers will observe the dropped reply ports as `Err(_)`.
+        for (_key, state) in self.qps.drain() {
+            match state {
+                QpState::Ready(_) => {
+                    // TODO(slurye): Proper cleanup of QPs. Currently there's no safe way to do this
+                    // because `IbvQueuePair` can have arbitrary clones and there's no way to guarantee
+                    // that none of them are still in use.
                 }
-            }
-        }
-
-        // 1. Clean up all queue pairs (both regular and loopback)
-        for (_device_name, device_map) in self.device_qps.drain() {
-            for ((actor_id, _remote_device), qp) in device_map {
-                destroy_queue_pair(&qp, &format!("actor {:?}", actor_id));
+                QpState::Pending { initializer, .. } => {
+                    let _ = initializer.drain_and_stop("IbvManagerActor dropped");
+                }
+                QpState::Failed(_) => {}
             }
         }
 
         // 2. Clean up device domains (which contain PDs and loopback QPs)
-        for (device_name, (domain, qp)) in self.device_domains.drain() {
+        for (_device_name, (domain, qp)) in self.device_domains.drain() {
             if let Some(qp) = qp {
-                destroy_queue_pair(&qp, &format!("loopback QP on device {}", device_name));
+                // SAFETY: `device_domains` is the only holder of
+                // these loopback QPs; we just drained it and the
+                // manager is being dropped, so no clones survive.
+                unsafe { destroy_qp(&qp) };
             }
             drop(domain);
         }
@@ -456,8 +473,7 @@ impl IbvManagerActor {
 
         let actor = Self {
             owner: OnceLock::new(),
-            device_qps: HashMap::new(),
-            pending_qp_creation: Arc::new(Mutex::new(HashSet::new())),
+            qps: HashMap::new(),
             device_domains: HashMap::new(),
             config,
             mlx5dv_enabled,
@@ -490,14 +506,15 @@ impl IbvManagerActor {
         // Create loopback QP for this domain if mlx5dv is supported (needed for segment registration)
         // For EFA, we don't need a loopback QP for segment scanning
         let qp = if mlx5dv_supported() && !crate::efa::is_efa_device() {
-            let mut qp = IbvQueuePair::new(domain.context, domain.pd, self.config.clone())
-                .map_err(|e| {
+            let mut qp = QpGuard::new(
+                IbvQueuePair::new(domain.context, domain.pd, self.config.clone()).map_err(|e| {
                     anyhow::anyhow!(
                         "could not create loopback QP for device {}: {}",
                         device_name,
                         e
                     )
-                })?;
+                })?,
+            );
 
             // Get connection info and connect to itself
             let endpoint = qp.get_qp_info().map_err(|e| {
@@ -517,6 +534,7 @@ impl IbvManagerActor {
             None
         };
 
+        let qp = qp.map(|qp| qp.into_inner());
         self.device_domains
             .insert(device_name.to_string(), (domain.clone(), qp.clone()));
         Ok((domain, qp))
@@ -729,183 +747,51 @@ impl IbvManagerActor {
         Ok(())
     }
 
-    async fn request_queue_pair_impl(
+    /// Lazy QP creation: if `qp_key` is absent, create the local
+    /// `IbvQueuePair`, capture its `IbvQpInfo`, and spawn a
+    /// `QueuePairInitializer` to drive the handshake. Returns the
+    /// `QpState` entry — either the freshly-inserted `Pending` one,
+    /// or the existing `Pending`/`Ready`/`Failed`.
+    fn ensure_queue_pair_impl(
         &mut self,
         cx: &Context<'_, Self>,
         other: ActorRef<IbvManagerActor>,
-        self_device: String,
-        other_device: String,
-    ) -> Result<IbvQueuePair, anyhow::Error> {
-        let self_ref: ActorRef<IbvManagerActor> = cx.bind();
-        let other_id = other.actor_addr().id().clone();
-
-        // Use the nested map structure: local_device -> (actor_id, remote_device) -> IbvQueuePair
-        let inner_key = (other_id.clone(), other_device.clone());
-
-        // Check if queue pair exists in map
-        let device_map: Option<&HashMap<(ActorId, String), IbvQueuePair>> =
-            self.device_qps.get(&self_device);
-        if let Some(device_map) = device_map {
-            if let Some(qp) = device_map.get(&inner_key) {
-                return Ok(qp.clone());
-            }
+        qp_key: &QpKey,
+    ) -> Result<&mut QpState, anyhow::Error> {
+        if !self.qps.contains_key(qp_key) {
+            let self_device = &qp_key.self_device;
+            let rdma_device = super::primitives::get_all_devices()
+                .into_iter()
+                .find(|d| d.name() == self_device)
+                .ok_or_else(|| anyhow::anyhow!("RDMA device '{}' not found", self_device))?;
+            let (domain, _) = self.get_or_create_device_domain(self_device, &rdma_device)?;
+            // Wrap the freshly-created QP in a `QpGuard` immediately
+            // so that any early-return path below (e.g. `get_qp_info`
+            // failing) destroys the underlying `rdmaxcel_qp_t` via
+            // the guard's `Drop` rather than leaking it.
+            let mut qp = QpGuard::new(
+                IbvQueuePair::new(domain.context, domain.pd, self.config.clone())
+                    .map_err(|e| anyhow::anyhow!("could not create IbvQueuePair: {}", e))?,
+            );
+            let info = qp
+                .get_qp_info()
+                .map_err(|e| anyhow::anyhow!("could not extract QP info: {}", e))?;
+            let initializer =
+                QueuePairInitializer::new(Instance::handle(cx), other, qp_key.clone(), qp)
+                    .spawn(cx)?;
+            self.qps.insert(
+                qp_key.clone(),
+                QpState::Pending {
+                    info,
+                    initializer,
+                    waiters: Vec::new(),
+                },
+            );
         }
-
-        // Try to acquire lock and mark as pending (hold lock only once!)
-        let pending_key = (self_device.clone(), other_id.clone(), other_device.clone());
-        let mut pending: futures::lock::MutexGuard<'_, HashSet<(String, ActorId, String)>> =
-            self.pending_qp_creation.lock().await;
-
-        if pending.contains(&pending_key) {
-            // Another task is creating this QP, release lock and wait
-            drop(pending);
-
-            // Loop checking device_qps until QP is created (no more locks needed)
-            // Timeout after 1 second
-            let start = Instant::now();
-            let timeout = Duration::from_secs(1);
-
-            loop {
-                tokio::time::sleep(Duration::from_micros(200)).await;
-
-                // Check if QP was created while we waited
-                let device_map: Option<&HashMap<(ActorId, String), IbvQueuePair>> =
-                    self.device_qps.get(&self_device);
-                if let Some(device_map) = device_map {
-                    if let Some(qp) = device_map.get(&inner_key) {
-                        return Ok(qp.clone());
-                    }
-                }
-
-                // Check for timeout
-                if start.elapsed() >= timeout {
-                    return Err(anyhow::anyhow!(
-                        "Timeout waiting for QP creation (device {} -> actor {} device {}). \
-                         Another task is creating it but hasn't completed in 1 second",
-                        self_device,
-                        other_id,
-                        other_device
-                    ));
-                }
-            }
-        } else {
-            // Not pending, add to set and proceed with creation
-            pending.insert(pending_key.clone());
-            drop(pending);
-            // Fall through to create QP
-        }
-
-        // Queue pair doesn't exist - need to create connection
-        let result = async {
-            let is_loopback =
-                other_id == *self_ref.actor_addr().id() && self_device == other_device;
-
-            if is_loopback {
-                // Loopback connection setup
-                self.initialize_qp(cx, other.clone(), self_device.clone(), other_device.clone())
-                    .await?;
-                let endpoint = self
-                    .connection_info(cx, other.clone(), other_device.clone(), self_device.clone())
-                    .await?;
-                self.connect(
-                    cx,
-                    other.clone(),
-                    self_device.clone(),
-                    other_device.clone(),
-                    endpoint,
-                )
-                .await?;
-            } else {
-                // Remote connection setup
-                self.initialize_qp(cx, other.clone(), self_device.clone(), other_device.clone())
-                    .await?;
-                other
-                    .initialize_qp(
-                        cx,
-                        self_ref.clone(),
-                        other_device.clone(),
-                        self_device.clone(),
-                    )
-                    .await?;
-                let other_endpoint: IbvQpInfo = other
-                    .connection_info(
-                        cx,
-                        self_ref.clone(),
-                        other_device.clone(),
-                        self_device.clone(),
-                    )
-                    .await?;
-                self.connect(
-                    cx,
-                    other.clone(),
-                    self_device.clone(),
-                    other_device.clone(),
-                    other_endpoint,
-                )
-                .await?;
-                let local_endpoint = self
-                    .connection_info(cx, other.clone(), self_device.clone(), other_device.clone())
-                    .await?;
-                other
-                    .connect(
-                        cx,
-                        self_ref.clone(),
-                        other_device.clone(),
-                        self_device.clone(),
-                        local_endpoint,
-                    )
-                    .await?;
-
-                // BARRIER: Ensure remote side has completed its connection and is ready
-                let remote_state = other
-                    .get_qp_state(
-                        cx,
-                        self_ref.clone(),
-                        other_device.clone(),
-                        self_device.clone(),
-                    )
-                    .await?;
-
-                if remote_state != rdmaxcel_sys::ibv_qp_state::IBV_QPS_RTS {
-                    return Err(anyhow::anyhow!(
-                        "Remote QP not in RTS state after connection setup. \
-                         Local is ready but remote is in state {}. \
-                         This indicates a synchronization issue in connection setup.",
-                        remote_state
-                    ));
-                }
-            }
-
-            // Now that connection is established, get and clone the queue pair
-            let device_map: Option<&HashMap<(ActorId, String), IbvQueuePair>> =
-                self.device_qps.get(&self_device);
-            if let Some(device_map) = device_map {
-                if let Some(qp) = device_map.get(&inner_key) {
-                    Ok(qp.clone())
-                } else {
-                    Err(anyhow::anyhow!(
-                        "Failed to create connection for actor {} on device {}",
-                        other_id,
-                        other_device
-                    ))
-                }
-            } else {
-                Err(anyhow::anyhow!(
-                    "Failed to create connection for actor {} on device {} - no device map",
-                    other_id,
-                    other_device
-                ))
-            }
-        }
-        .await;
-
-        // Always remove from pending set when done (success or failure)
-        let mut pending: futures::lock::MutexGuard<'_, HashSet<(String, ActorId, String)>> =
-            self.pending_qp_creation.lock().await;
-        pending.remove(&pending_key);
-        drop(pending);
-
-        result
+        Ok(self
+            .qps
+            .get_mut(qp_key)
+            .expect("entry just inserted or pre-existing"))
     }
 }
 
@@ -923,176 +809,58 @@ impl IbvManagerMessageHandler for IbvManagerActor {
         }
         Ok(())
     }
+}
 
-    async fn request_queue_pair(
+#[async_trait]
+impl Handler<EnsureQueuePair<IbvManagerActor>> for IbvManagerActor {
+    async fn handle(
         &mut self,
         cx: &Context<Self>,
-        other: ActorRef<IbvManagerActor>,
-        self_device: String,
-        other_device: String,
-    ) -> Result<Result<IbvQueuePair, String>, anyhow::Error> {
-        Ok(self
-            .request_queue_pair_impl(cx, other, self_device, other_device)
-            .await
-            .map_err(|e| e.to_string()))
-    }
-
-    async fn connect(
-        &mut self,
-        _cx: &Context<Self>,
-        other: ActorRef<IbvManagerActor>,
-        self_device: String,
-        other_device: String,
-        endpoint: IbvQpInfo,
+        msg: EnsureQueuePair<IbvManagerActor>,
     ) -> Result<(), anyhow::Error> {
-        tracing::debug!("connecting with {:?}", other);
-        let other_id = other.actor_addr().id().clone();
-
-        let inner_key = (other_id.clone(), other_device.clone());
-
-        let device_map: Option<&mut HashMap<(ActorId, String), IbvQueuePair>> =
-            self.device_qps.get_mut(&self_device);
-        if let Some(device_map) = device_map {
-            match device_map.get_mut(&inner_key) {
-                Some(qp) => {
-                    qp.connect(&endpoint).map_err(|e| {
-                        anyhow::anyhow!("could not connect to RDMA endpoint: {}", e)
-                    })?;
-                    Ok(())
-                }
-                None => Err(anyhow::anyhow!(
-                    "No connection found for actor {}",
-                    other_id
-                )),
+        let EnsureQueuePair {
+            sender,
+            sender_device,
+            receiver_device,
+            reply,
+        } = msg;
+        let qp_key = QpKey {
+            self_device: receiver_device,
+            other_id: sender.actor_addr().id().clone(),
+            other_device: sender_device,
+        };
+        let state = match self.ensure_queue_pair_impl(cx, sender, &qp_key) {
+            Ok(state) => state,
+            Err(e) => {
+                reply.send(cx, PeerInfo(Err(e.to_string())))?;
+                return Ok(());
             }
-        } else {
-            Err(anyhow::anyhow!(
-                "No device map found for device {}",
-                self_device
-            ))
-        }
-    }
-
-    async fn initialize_qp(
-        &mut self,
-        _cx: &Context<Self>,
-        other: ActorRef<IbvManagerActor>,
-        self_device: String,
-        other_device: String,
-    ) -> Result<bool, anyhow::Error> {
-        let other_id = other.actor_addr().id().clone();
-        let inner_key = (other_id.clone(), other_device.clone());
-
-        // Check if QP already exists in nested structure
-        let device_map: Option<&HashMap<(ActorId, String), IbvQueuePair>> =
-            self.device_qps.get(&self_device);
-        if let Some(device_map) = device_map {
-            if device_map.contains_key(&inner_key) {
-                return Ok(true);
+        };
+        match state {
+            QpState::Pending {
+                info, initializer, ..
+            } => {
+                let notify_rts = initializer.bind::<QueuePairInitializer<Self>>().port();
+                reply.send(cx, PeerInfo(Ok((info.clone(), notify_rts))))?;
+            }
+            QpState::Ready(_) => {
+                // `Ready` means a prior handshake completed and the
+                // initializer was stopped — we can't hand back an
+                // initializer ref. Reaching here represents a logic
+                // error (peer is asking us to redo a handshake we've
+                // already finished); surface it as `Err`.
+                reply.send(
+                    cx,
+                    PeerInfo(Err(format!(
+                        "EnsureQueuePair on already-Ready entry {qp_key:?}"
+                    ))),
+                )?;
+            }
+            QpState::Failed(error) => {
+                reply.send(cx, PeerInfo(Err(error.clone())))?;
             }
         }
-
-        // The domain is guaranteed to exist here: register_mr is always called before
-        // initialize_qp, either in execute_op or in register_remote_buffer at
-        // buffer-creation time, and register_mr always calls get_or_create_device_domain.
-        let (domain, _) = self.device_domains.get(&self_device).ok_or_else(|| {
-            anyhow::anyhow!(
-                "device domain for '{}' not found; register_mr must be called before initialize_qp",
-                self_device
-            )
-        })?;
-        let (domain_context, domain_pd) = (domain.context, domain.pd);
-
-        let qp = IbvQueuePair::new(domain_context, domain_pd, self.config.clone())
-            .map_err(|e| anyhow::anyhow!("could not create IbvQueuePair: {}", e))?;
-
-        // Insert the QP into the nested map structure
-        self.device_qps
-            .entry(self_device.clone())
-            .or_insert_with(HashMap::new)
-            .insert(inner_key, qp);
-
-        tracing::debug!(
-            "successfully created a connection with {:?} for local device {} -> remote device {}",
-            other,
-            self_device,
-            other_device
-        );
-
-        Ok(true)
-    }
-
-    async fn connection_info(
-        &mut self,
-        _cx: &Context<Self>,
-        other: ActorRef<IbvManagerActor>,
-        self_device: String,
-        other_device: String,
-    ) -> Result<IbvQpInfo, anyhow::Error> {
-        tracing::debug!("getting connection info with {:?}", other);
-        let other_id = other.actor_addr().id().clone();
-
-        let inner_key = (other_id.clone(), other_device.clone());
-
-        let device_map: Option<&mut HashMap<(ActorId, String), IbvQueuePair>> =
-            self.device_qps.get_mut(&self_device);
-        if let Some(device_map) = device_map {
-            match device_map.get_mut(&inner_key) {
-                Some(qp) => {
-                    let connection_info = qp.get_qp_info()?;
-                    Ok(connection_info)
-                }
-                None => Err(anyhow::anyhow!(
-                    "No connection found for actor {}",
-                    other_id
-                )),
-            }
-        } else {
-            Err(anyhow::anyhow!(
-                "No device map found for self device {}",
-                self_device
-            ))
-        }
-    }
-
-    async fn release_queue_pair(
-        &mut self,
-        _cx: &Context<Self>,
-        _other: ActorRef<IbvManagerActor>,
-        _self_device: String,
-        _other_device: String,
-        _qp: IbvQueuePair,
-    ) -> Result<(), anyhow::Error> {
         Ok(())
-    }
-
-    async fn get_qp_state(
-        &mut self,
-        _cx: &Context<Self>,
-        other: ActorRef<IbvManagerActor>,
-        self_device: String,
-        other_device: String,
-    ) -> Result<u32, anyhow::Error> {
-        let other_id = other.actor_addr().id().clone();
-        let inner_key = (other_id.clone(), other_device.clone());
-
-        let device_map: Option<&mut HashMap<(ActorId, String), IbvQueuePair>> =
-            self.device_qps.get_mut(&self_device);
-        if let Some(device_map) = device_map {
-            match device_map.get_mut(&inner_key) {
-                Some(qp) => qp.state(),
-                None => Err(anyhow::anyhow!(
-                    "No connection found for actor {} on device {}",
-                    other_id,
-                    other_device
-                )),
-            }
-        } else {
-            Err(anyhow::anyhow!(
-                "No device map found for self device {}",
-                self_device
-            ))
-        }
     }
 }
 
@@ -1140,18 +908,80 @@ impl IbvManagerLocalMessageHandler for IbvManagerActor {
         self.buffer_registrations.insert(remote_buf_id, buf.clone());
         Ok(Ok(buf))
     }
+
+    async fn request_queue_pair(
+        &mut self,
+        cx: &Context<Self>,
+        other: ActorRef<IbvManagerActor>,
+        self_device: String,
+        other_device: String,
+        reply: OncePortHandle<Result<IbvQueuePair, String>>,
+    ) -> Result<(), anyhow::Error> {
+        let qp_key = QpKey {
+            self_device,
+            other_id: other.actor_addr().id().clone(),
+            other_device,
+        };
+        let state = match self.ensure_queue_pair_impl(cx, other, &qp_key) {
+            Ok(state) => state,
+            Err(e) => {
+                reply.send(cx, Err(e.to_string()))?;
+                return Ok(());
+            }
+        };
+        match state {
+            QpState::Pending { waiters, .. } => waiters.push(reply),
+            QpState::Ready(qp) => reply.send(cx, Ok(qp.clone()))?,
+            QpState::Failed(error) => reply.send(cx, Err(error.clone()))?,
+        }
+        Ok(())
+    }
 }
 
 #[async_trait]
 impl Handler<QpInitializerDone> for IbvManagerActor {
     async fn handle(
         &mut self,
-        _cx: &Context<Self>,
-        _msg: QpInitializerDone,
+        cx: &Context<Self>,
+        msg: QpInitializerDone,
     ) -> Result<(), anyhow::Error> {
-        unreachable!(
-            "IbvManagerActor does not yet spawn QueuePairInitializer; wired up in a follow-up commit"
-        )
+        let QpInitializerDone { qp_key, qp } = msg;
+        let qp = qp.into_inner();
+        // Take the entry out, transition to Ready, drain waiters,
+        // then stop the initializer.
+        let initializer = match self.qps.remove(&qp_key) {
+            Some(QpState::Pending {
+                waiters,
+                initializer,
+                ..
+            }) => {
+                for w in waiters {
+                    let waiter_dbg = format!("{w:?}");
+                    if let Err(e) = w.send(cx, Ok(qp.clone())) {
+                        tracing::error!(
+                            "QpInitializerDone: failed to deliver to waiter {waiter_dbg} for {qp_key:?}: {e}"
+                        );
+                    }
+                }
+                initializer
+            }
+            other => {
+                unreachable!("QpInitializerDone received but state is {other:?}: {qp_key:?}")
+            }
+        };
+        self.qps.insert(qp_key.clone(), QpState::Ready(qp));
+        initializer.drain_and_stop("QpInitializerDone")?;
+        let status = initializer.await;
+        if status.is_failed() {
+            // The QP itself is already `Ready` and waiters have been
+            // drained, so a non-clean initializer shutdown is not
+            // user-visible — log and move on rather than crashing
+            // the manager.
+            tracing::error!(
+                "QueuePairInitializer for {qp_key:?} terminated with failure after Done: {status:?}"
+            );
+        }
+        Ok(())
     }
 }
 
@@ -1159,13 +989,66 @@ impl Handler<QpInitializerDone> for IbvManagerActor {
 impl Handler<QpInitializerFailed> for IbvManagerActor {
     async fn handle(
         &mut self,
-        _cx: &Context<Self>,
-        _msg: QpInitializerFailed,
+        cx: &Context<Self>,
+        msg: QpInitializerFailed,
     ) -> Result<(), anyhow::Error> {
-        unreachable!(
-            "IbvManagerActor does not yet spawn QueuePairInitializer; wired up in a follow-up commit"
-        )
+        let QpInitializerFailed { qp_key, error } = msg;
+        let initializer = match self.qps.remove(&qp_key) {
+            Some(QpState::Pending {
+                waiters,
+                initializer,
+                ..
+            }) => {
+                for w in waiters {
+                    let waiter_dbg = format!("{w:?}");
+                    if let Err(e) = w.send(cx, Err(error.clone())) {
+                        tracing::error!(
+                            "QpInitializerFailed: failed to deliver to waiter {waiter_dbg} for {qp_key:?}: {e}"
+                        );
+                    }
+                }
+                initializer
+            }
+            other => {
+                unreachable!("QpInitializerFailed received but state is {other:?}: {qp_key:?}")
+            }
+        };
+        // Tombstone the entry: subsequent `RequestQueuePair` calls
+        // for the same key surface the same error rather than
+        // retrying or hanging. TODO: add recovery.
+        self.qps.insert(qp_key.clone(), QpState::Failed(error));
+        initializer.drain_and_stop("QpInitializerFailed")?;
+        let status = initializer.await;
+        if status.is_failed() {
+            tracing::error!(
+                "QueuePairInitializer for {qp_key:?} terminated with failure after Failed: {status:?}"
+            );
+        }
+        Ok(())
     }
+}
+
+/// Free helper around [`IbvManagerLocalMessage::RequestQueuePair`] — opens
+/// a `OncePortHandle` for the reply, sends the message, and awaits the
+/// answer. Exists because `RequestQueuePair` doesn't use `#[reply]`
+/// (the handler may park the port until the QP becomes `Ready`), so
+/// the auto-derived client method only does fire-and-forget.
+pub(super) async fn request_queue_pair(
+    actor: &ActorHandle<IbvManagerActor>,
+    cx: &(impl hyperactor::context::Actor + Send + Sync),
+    other: ActorRef<IbvManagerActor>,
+    self_device: String,
+    other_device: String,
+) -> Result<Result<IbvQueuePair, String>, anyhow::Error> {
+    let (reply, rx) = cx
+        .mailbox()
+        .open_once_port::<Result<IbvQueuePair, String>>();
+    actor
+        .request_queue_pair(cx, other, self_device, other_device, reply)
+        .await?;
+    rx.recv()
+        .await
+        .map_err(|e| anyhow::anyhow!("request_queue_pair port closed: {e}"))
 }
 
 /// Wrapper around [`ActorHandle<IbvManagerActor>`] that moves the RDMA
@@ -1287,15 +1170,15 @@ impl IbvBackend {
         };
 
         let op_result = async {
-            let mut qp = self
-                .request_queue_pair(
-                    cx,
-                    op.remote_manager.clone(),
-                    local_buffer.device_name.clone(),
-                    op.remote_buffer.device_name.clone(),
-                )
-                .await?
-                .map_err(|e| anyhow::anyhow!(e))?;
+            let mut qp = request_queue_pair(
+                &self.0,
+                cx,
+                op.remote_manager.clone(),
+                local_buffer.device_name.clone(),
+                op.remote_buffer.device_name.clone(),
+            )
+            .await?
+            .map_err(|e| anyhow::anyhow!(e))?;
 
             let wr_id = match op.op_type {
                 RdmaOpType::WriteFromLocal => qp.put(local_buffer.clone(), op.remote_buffer)?,

--- a/monarch_rdma/src/backend/ibverbs/queue_pair.rs
+++ b/monarch_rdma/src/backend/ibverbs/queue_pair.rs
@@ -19,11 +19,28 @@ use std::io::Error;
 use std::result::Result;
 use std::time::Duration;
 
+use async_trait::async_trait;
+use hyperactor::Actor;
+use hyperactor::ActorHandle;
+use hyperactor::ActorId;
+use hyperactor::ActorRef;
+use hyperactor::Context;
+use hyperactor::Handler;
+use hyperactor::Instance;
+use hyperactor::PortRef;
+use hyperactor::actor::Binds;
+use hyperactor::actor::Referable;
+use hyperactor::actor::RemoteHandles;
+use hyperactor::mailbox::MessageEnvelope;
+use hyperactor::mailbox::Undeliverable;
 use serde::Deserialize;
 use serde::Serialize;
 use typeuri::Named;
 
 use super::IbvBuffer;
+use super::manager_actor::EnsureQueuePair;
+use super::manager_actor::QpInitializerDone;
+use super::manager_actor::QpInitializerFailed;
 use super::primitives::Gid;
 use super::primitives::IbvConfig;
 use super::primitives::IbvOperation;
@@ -1051,10 +1068,441 @@ impl IbvQueuePair {
     }
 }
 
+// =====================================================================
+// QueuePairInitializer
+// =====================================================================
+//
+// Drives one local `IbvQueuePair` through `INIT → RTR → RTS` off the
+// owning `IbvManagerActor`'s mailbox. Each peer spawns its own
+// initializer; the two converge by exchanging `NotifyRts` directly
+// after one round-trip through the peer's manager (`EnsureQueuePair`
+// → `PeerInfo`). A side declares itself "Ready" as soon as it
+// observes the peer's `NotifyRts`; it does not wait for the peer to
+// observe its own.
+//
+// Progress is tracked by two flags — `our_rts_sent` (we received
+// `PeerInfo`, connected, and sent our `NotifyRts`) and
+// `peer_rts_received` (we observed the peer's `NotifyRts`). When
+// both are true the handshake hands the qp to the manager via
+// [`QpInitializerDone`]. The `terminal` flag short-circuits any
+// further handler work after success or failure. The qp is held in
+// a `QpGuard` so any failure path (or aborted message delivery)
+// destroys it.
+
+/// Identifies a per-peer queue pair held by one
+/// [`super::manager_actor::IbvManagerActor`]. The same conceptual
+/// QP is referenced by two distinct keys, one from each side: each
+/// manager stores the local view (its own device, the peer's actor
+/// id, the peer's device).
+#[derive(Clone, Hash, Eq, PartialEq, Debug, Serialize, Deserialize, Named)]
+pub(super) struct QpKey {
+    pub(super) self_device: String,
+    pub(super) other_id: ActorId,
+    pub(super) other_device: String,
+}
+
+/// Cross-proc reply payload for [`EnsureQueuePair`]: peer's endpoint
+/// plus a `PortRef` to the peer initializer's `NotifyRts` port, or
+/// an error string from the peer side.
+#[derive(Debug, Serialize, Deserialize, Named)]
+pub(super) struct PeerInfo(pub(super) Result<(IbvQpInfo, PortRef<NotifyRts>), String>);
+wirevalue::register_type!(PeerInfo);
+
+/// Cross-proc fire-and-forget. Sent from one initializer to the peer
+/// initializer once we hit RTS. A queue pair can begin sending to
+/// its peer as soon as it receives this message.
+#[derive(Debug, Serialize, Deserialize, Named)]
+pub(super) struct NotifyRts;
+wirevalue::register_type!(NotifyRts);
+
+/// Local-only self-message fired by the timeout task. Triggers
+/// the initializer to abort the handshake.
+#[derive(Debug)]
+#[cfg_attr(not(test), allow(dead_code))]
+struct InitializationFailed;
+
+/// RAII wrapper that destroys the wrapped queue pair on drop.
+/// Use `into_inner` to extract the qp without destroying.
+#[derive(Debug)]
+pub(super) struct QpGuard {
+    qp: Option<IbvQueuePair>,
+}
+
+#[cfg_attr(not(test), allow(dead_code))]
+impl QpGuard {
+    fn new(qp: IbvQueuePair) -> Self {
+        Self { qp: Some(qp) }
+    }
+
+    /// Consume the guard and return the qp; suppresses Drop's destroy.
+    pub(super) fn into_inner(mut self) -> IbvQueuePair {
+        self.qp.take().expect("QpGuard already drained")
+    }
+
+    /// Delegates to [`IbvQueuePair::connect`].
+    pub(super) fn connect(&mut self, info: &IbvQpInfo) -> Result<(), anyhow::Error> {
+        self.qp
+            .as_mut()
+            .expect("QpGuard already drained")
+            .connect(info)
+    }
+
+    /// Delegates to [`IbvQueuePair::get_qp_info`].
+    pub(super) fn get_qp_info(&mut self) -> Result<IbvQpInfo, anyhow::Error> {
+        self.qp
+            .as_mut()
+            .expect("QpGuard already drained")
+            .get_qp_info()
+    }
+}
+
+impl Drop for QpGuard {
+    fn drop(&mut self) {
+        if let Some(qp) = self.qp.take() {
+            // SAFETY: `QpGuard` owns the `IbvQueuePair` and exposes
+            // no API that hands out a reference to it, so safe code
+            // cannot have cloned the underlying `rdmaxcel_qp_t`
+            // pointer out from under us. The only way to extract a
+            // live clone is `into_inner`, which consumes `self` and
+            // skips this `Drop`; reaching here means `into_inner`
+            // was never called.
+            unsafe { destroy_qp(&qp) };
+        }
+    }
+}
+
+/// Bundle of trait bounds for an actor type that can play the role
+/// of [`QueuePairInitializer`]'s owner/peer manager.
+#[cfg_attr(not(test), allow(dead_code))]
+pub(super) trait QpOwner:
+    Actor
+    + Referable
+    + Binds<Self>
+    + RemoteHandles<EnsureQueuePair<Self>>
+    + Handler<QpInitializerDone>
+    + Handler<QpInitializerFailed>
+{
+}
+
+impl<T> QpOwner for T where
+    T: Actor
+        + Referable
+        + Binds<T>
+        + RemoteHandles<EnsureQueuePair<T>>
+        + Handler<QpInitializerDone>
+        + Handler<QpInitializerFailed>
+{
+}
+
+/// Per-peer queue-pair handshake actor. See module docs.
+///
+/// Generic over the manager actor type `A` so tests can swap in a
+/// mock.
+#[derive(Debug)]
+#[hyperactor::export(handlers = [PeerInfo, NotifyRts])]
+#[cfg_attr(not(test), allow(dead_code))]
+pub(super) struct QueuePairInitializer<A: QpOwner> {
+    owner: ActorHandle<A>,
+    other: ActorRef<A>,
+    qp_key: QpKey,
+    /// Held until the handshake succeeds (handed to the manager
+    /// via [`QpInitializerDone`]) or fails (dropped here, which
+    /// destroys the qp via `QpGuard::drop`).
+    qp: Option<QpGuard>,
+    /// Per-side handshake budget pulled from
+    /// `RDMA_QP_INIT_TIMEOUT` at construction.
+    timeout: Duration,
+    /// Set in `Handler<PeerInfo>` after we connect the qp and send
+    /// our `NotifyRts` to the peer.
+    our_rts_sent: bool,
+    /// Set in `Handler<NotifyRts>` when the peer's `NotifyRts`
+    /// arrives.
+    peer_rts_received: bool,
+    /// Set by `done`/`fail` once a terminal report has been
+    /// dispatched to the owner. All further handler work
+    /// short-circuits.
+    terminal: bool,
+    /// Currently-armed timeout. `arm_timeout` aborts any prior one.
+    timeout_handle: Option<tokio::task::JoinHandle<()>>,
+}
+
+#[cfg_attr(not(test), allow(dead_code))]
+impl<A> QueuePairInitializer<A>
+where
+    A: QpOwner,
+{
+    pub(super) fn new(
+        owner: ActorHandle<A>,
+        other: ActorRef<A>,
+        qp_key: QpKey,
+        qp: IbvQueuePair,
+    ) -> Self {
+        let timeout = hyperactor_config::global::get(crate::config::RDMA_QP_INIT_TIMEOUT);
+        Self {
+            owner,
+            other,
+            qp_key,
+            qp: Some(QpGuard::new(qp)),
+            timeout,
+            our_rts_sent: false,
+            peer_rts_received: false,
+            terminal: false,
+            timeout_handle: None,
+        }
+    }
+
+    /// Arm a fresh `InitializationFailed` timer, aborting any prior one.
+    fn arm_timeout(&mut self, this: &Instance<Self>) {
+        if let Some(h) = self.timeout_handle.take() {
+            h.abort();
+        }
+        let self_handle: ActorHandle<Self> = this.handle();
+        let timeout = self.timeout;
+        let task = tokio::spawn(async move {
+            tokio::time::sleep(timeout).await;
+            if let Err(e) = self_handle.send(Instance::<Self>::self_client(), InitializationFailed)
+            {
+                tracing::error!(
+                    "QueuePairInitializer: failed to deliver timeout self-message: {e}"
+                );
+            }
+        });
+        self.timeout_handle = Some(task);
+    }
+
+    /// Transition to the terminal failed state, drop the qp guard
+    /// (destroying any qp held), and report failure to the owning
+    /// manager.
+    fn fail(&mut self, this: &Instance<Self>, error: String) -> Result<(), anyhow::Error> {
+        if let Some(h) = self.timeout_handle.take() {
+            h.abort();
+        }
+        self.qp = None;
+        self.terminal = true;
+        self.owner.send(
+            this,
+            QpInitializerFailed {
+                qp_key: self.qp_key.clone(),
+                error,
+            },
+        )?;
+        Ok(())
+    }
+
+    /// Transition to the terminal success state and hand the qp
+    /// guard to the owning manager via [`QpInitializerDone`].
+    fn done(&mut self, this: &Instance<Self>) -> Result<(), anyhow::Error> {
+        if let Some(h) = self.timeout_handle.take() {
+            h.abort();
+        }
+        let qp = self.qp.take().expect("qp present in done()");
+        self.terminal = true;
+        self.owner.send(
+            this,
+            QpInitializerDone {
+                qp_key: self.qp_key.clone(),
+                qp,
+            },
+        )?;
+        Ok(())
+    }
+
+    /// Connect our qp to the peer endpoint, then notify the peer
+    /// that we've reached RTS. Returns the failure string for
+    /// [`Self::fail`] on error.
+    fn connect_and_notify(
+        &mut self,
+        cx: &Context<Self>,
+        info: Result<(IbvQpInfo, PortRef<NotifyRts>), String>,
+    ) -> Result<(), String> {
+        let (peer_endpoint, peer_notify_rts) = info?;
+        self.qp
+            .as_mut()
+            .expect("qp present pre-terminal")
+            .connect(&peer_endpoint)
+            .map_err(|e| format!("QpGuard::connect failed: {e}"))?;
+        peer_notify_rts
+            .send(cx, NotifyRts)
+            .map_err(|e| format!("failed to send NotifyRts to peer: {e}"))?;
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl<A> Actor for QueuePairInitializer<A>
+where
+    A: QpOwner,
+{
+    async fn init(&mut self, this: &Instance<Self>) -> Result<(), anyhow::Error> {
+        // Send the QueuePairInitializer's PeerInfo actor port so that the reply
+        // is routed back to this actor's handler automatically.
+        let reply = this.bind::<Self>().port();
+        let sender = self.owner.bind();
+        let sender_device = self.qp_key.self_device.clone();
+        let receiver_device = self.qp_key.other_device.clone();
+        self.other.send(
+            this,
+            EnsureQueuePair {
+                sender,
+                sender_device,
+                receiver_device,
+                reply,
+            },
+        )?;
+
+        self.arm_timeout(this);
+        Ok(())
+    }
+
+    async fn cleanup(
+        &mut self,
+        _this: &Instance<Self>,
+        _err: Option<&hyperactor::actor::ActorError>,
+    ) -> Result<(), anyhow::Error> {
+        if let Some(h) = self.timeout_handle.take() {
+            h.abort();
+        }
+        Ok(())
+    }
+
+    async fn handle_undeliverable_message(
+        &mut self,
+        this: &Instance<Self>,
+        Undeliverable(envelope): Undeliverable<MessageEnvelope>,
+    ) -> Result<(), anyhow::Error> {
+        if self.terminal {
+            tracing::warn!(
+                "undeliverable message after handshake terminated: {}",
+                envelope.error_msg().unwrap_or_default()
+            );
+            return Ok(());
+        }
+        self.fail(this, envelope.error_msg().unwrap_or_default())
+    }
+}
+
+impl<A> Drop for QueuePairInitializer<A>
+where
+    A: QpOwner,
+{
+    fn drop(&mut self) {
+        if let Some(h) = self.timeout_handle.take() {
+            h.abort();
+        }
+    }
+}
+
+/// Destroy the underlying `rdmaxcel_qp_t`.
+///
+/// # Safety
+///
+/// `IbvQueuePair` derives [`Clone`] but the wrapped `rdmaxcel_qp_t`
+/// pointer is shared by all clones; this call frees that pointer. The
+/// caller must guarantee no remaining clones of `qp` are in use (no
+/// other code is reading from or posting to `qp.qp`, and no future
+/// code will), since accessing a freed `rdmaxcel_qp_t` is undefined
+/// behavior.
+pub(super) unsafe fn destroy_qp(qp: &IbvQueuePair) {
+    // SAFETY: The caller has guaranteed no other live clone of `qp`
+    // observes `qp.qp` (see this function's `# Safety` section). This
+    // is truly unsafe -- the current implementation does not properly
+    // track outstanding clones. An imminent change will fix this, but
+    // for now it isn't a regression.
+    unsafe {
+        if qp.qp != 0 {
+            let rdmaxcel_qp = qp.qp as *mut rdmaxcel_sys::rdmaxcel_qp;
+            rdmaxcel_sys::rdmaxcel_qp_destroy(rdmaxcel_qp);
+        }
+    }
+}
+
+#[async_trait]
+impl<A> Handler<PeerInfo> for QueuePairInitializer<A>
+where
+    A: QpOwner,
+{
+    async fn handle(&mut self, cx: &Context<Self>, msg: PeerInfo) -> Result<(), anyhow::Error> {
+        if self.terminal {
+            tracing::warn!("PeerInfo received after queue pair already terminal");
+            return Ok(());
+        }
+        debug_assert!(!self.our_rts_sent, "duplicate PeerInfo");
+        if let Err(e) = self.connect_and_notify(cx, msg.0) {
+            return self.fail(cx, e);
+        }
+        self.our_rts_sent = true;
+        if self.peer_rts_received {
+            return self.done(cx);
+        }
+        // Rearm the timeout for the remaining wait on the peer's
+        // `NotifyRts` so a hang past this point still surfaces as a
+        // failure.
+        self.arm_timeout(cx);
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl<A> Handler<NotifyRts> for QueuePairInitializer<A>
+where
+    A: QpOwner,
+{
+    async fn handle(&mut self, cx: &Context<Self>, _msg: NotifyRts) -> Result<(), anyhow::Error> {
+        if self.terminal {
+            tracing::warn!("NotifyRts received after queue pair already terminal");
+            return Ok(());
+        }
+        debug_assert!(!self.peer_rts_received, "duplicate NotifyRts");
+        self.peer_rts_received = true;
+        if self.our_rts_sent {
+            return self.done(cx);
+        }
+        // Rearm the timeout for the remaining wait on our own
+        // `PeerInfo` reply.
+        self.arm_timeout(cx);
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl<A> Handler<InitializationFailed> for QueuePairInitializer<A>
+where
+    A: QpOwner,
+{
+    async fn handle(
+        &mut self,
+        cx: &Context<Self>,
+        _msg: InitializationFailed,
+    ) -> Result<(), anyhow::Error> {
+        if self.terminal {
+            return Ok(());
+        }
+        self.fail(cx, "QP initialization timed out".into())
+    }
+}
+
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+    use std::sync::Mutex;
+    use std::time::Duration;
+    use std::time::Instant;
+
+    use anyhow::Result;
+    use async_trait::async_trait;
+    use hyperactor::Context;
+    use hyperactor::Handler;
+    use hyperactor::PortRef;
+    use hyperactor::mailbox::DeliveryError;
+    use hyperactor::mailbox::MessageEnvelope;
+    use hyperactor::mailbox::Undeliverable;
+    use hyperactor::port::Port;
+    use hyperactor::proc::Proc;
+    use hyperactor_config::Flattrs;
+
     use super::*;
     use crate::backend::ibverbs::domain::IbvDomain;
+    use crate::backend::ibverbs::manager_actor::EnsureQueuePair;
     use crate::backend::ibverbs::primitives::IbvConfig;
     use crate::backend::ibverbs::primitives::get_all_devices;
 
@@ -1114,5 +1562,351 @@ mod tests {
 
         assert!(server_qp.connect(&client_connection_info).is_ok());
         assert!(client_qp.connect(&server_connection_info).is_ok());
+    }
+
+    /// Outcomes recorded by [`MockManager`] for assertions.
+    #[derive(Default, Debug)]
+    struct MockState {
+        done: Vec<QpKey>,
+        failed: Vec<(QpKey, String)>,
+        /// Number of `NotifyRts` messages the mock received from the
+        /// initializer (i.e., how many times the initializer reached
+        /// the "we've hit RTS" point and sent us a notification).
+        notify_rts: usize,
+    }
+
+    /// Scripted reply for the next `EnsureQueuePair` the mock sees.
+    /// After a single reply the mock disarms back to `DropReply`.
+    #[derive(Debug)]
+    enum MockResponse {
+        /// Reply with `PeerInfo(Ok((info, mock_notify_rts_port)))`. The
+        /// caller must drive the initializer's `NotifyRts` port from
+        /// the test to reach `Succeeded`.
+        Success(IbvQpInfo),
+        /// Like `Success`, but the `PortRef<NotifyRts>` handed back is
+        /// attested to an unreachable address in the mock's own proc
+        /// so the initializer's `NotifyRts` send bounces back as
+        /// undeliverable.
+        SuccessWithBogusNotifyRts(IbvQpInfo),
+        Error(String),
+        DropReply,
+    }
+
+    /// Zero-initialized [`IbvQueuePair`]. `qp == 0` so `QpGuard::Drop`
+    /// is a no-op; tests using this must not exercise [`IbvQueuePair::connect`]
+    /// (it would deref a null pointer).
+    fn fake_qp() -> IbvQueuePair {
+        IbvQueuePair {
+            send_cq: 0,
+            recv_cq: 0,
+            qp: 0,
+            dv_qp: 0,
+            dv_send_cq: 0,
+            dv_recv_cq: 0,
+            context: 0,
+            config: IbvConfig::default(),
+            is_efa: false,
+        }
+    }
+
+    /// A real (loopback) `IbvQueuePair` and its `IbvQpInfo`. Returns
+    /// `None` when no RDMA device is present.
+    fn loopback_qp() -> Option<(IbvQueuePair, IbvQpInfo)> {
+        if get_all_devices().is_empty() {
+            return None;
+        }
+        let config = IbvConfig::default();
+        let domain = IbvDomain::new(config.device.clone()).ok()?;
+        let mut qp = IbvQueuePair::new(domain.context, domain.pd, config).ok()?;
+        let info = qp.get_qp_info().ok()?;
+        Some((qp, info))
+    }
+
+    #[derive(Debug)]
+    #[hyperactor::export(handlers = [EnsureQueuePair<MockManager>, NotifyRts])]
+    struct MockManager {
+        state: Arc<Mutex<MockState>>,
+        response: MockResponse,
+    }
+
+    #[async_trait]
+    impl Actor for MockManager {}
+
+    #[async_trait]
+    impl Handler<EnsureQueuePair<MockManager>> for MockManager {
+        async fn handle(
+            &mut self,
+            cx: &Context<Self>,
+            msg: EnsureQueuePair<MockManager>,
+        ) -> Result<()> {
+            let response = std::mem::replace(&mut self.response, MockResponse::DropReply);
+            match response {
+                MockResponse::Success(info) => {
+                    let notify_rts = cx.bind::<MockManager>().port::<NotifyRts>();
+                    msg.reply.send(cx, PeerInfo(Ok((info, notify_rts))))?;
+                }
+                MockResponse::SuccessWithBogusNotifyRts(info) => {
+                    let bogus = hyperactor::context::Mailbox::mailbox(cx)
+                        .actor_addr()
+                        .proc_addr()
+                        .actor_addr("bogus")
+                        .port_addr(Port::from(0u64));
+                    let notify_rts = PortRef::<NotifyRts>::attest(bogus);
+                    msg.reply.send(cx, PeerInfo(Ok((info, notify_rts))))?;
+                }
+                MockResponse::Error(e) => {
+                    msg.reply.send(cx, PeerInfo(Err(e)))?;
+                }
+                MockResponse::DropReply => {}
+            }
+            Ok(())
+        }
+    }
+
+    #[async_trait]
+    impl Handler<NotifyRts> for MockManager {
+        async fn handle(&mut self, _cx: &Context<Self>, _msg: NotifyRts) -> Result<()> {
+            self.state.lock().unwrap().notify_rts += 1;
+            Ok(())
+        }
+    }
+
+    #[async_trait]
+    impl Handler<QpInitializerDone> for MockManager {
+        async fn handle(&mut self, _cx: &Context<Self>, msg: QpInitializerDone) -> Result<()> {
+            let _ = msg.qp.into_inner();
+            self.state.lock().unwrap().done.push(msg.qp_key);
+            Ok(())
+        }
+    }
+
+    #[async_trait]
+    impl Handler<QpInitializerFailed> for MockManager {
+        async fn handle(&mut self, _cx: &Context<Self>, msg: QpInitializerFailed) -> Result<()> {
+            self.state
+                .lock()
+                .unwrap()
+                .failed
+                .push((msg.qp_key, msg.error));
+            Ok(())
+        }
+    }
+
+    struct Harness {
+        proc: Proc,
+        init_handle: ActorHandle<QueuePairInitializer<MockManager>>,
+        state: Arc<Mutex<MockState>>,
+        qp_key: QpKey,
+    }
+
+    impl Harness {
+        fn build(qp: IbvQueuePair, response: MockResponse) -> Result<Self> {
+            let proc = Proc::new();
+            let state = Arc::new(Mutex::new(MockState::default()));
+            let mock = MockManager {
+                state: state.clone(),
+                response,
+            };
+            let mock_handle = proc.spawn("mock", mock)?;
+            let mock_ref = mock_handle.bind::<MockManager>();
+            let qp_key = QpKey {
+                self_device: "mock0".into(),
+                other_id: mock_ref.actor_addr().id().clone(),
+                other_device: "mock0".into(),
+            };
+            let initializer = QueuePairInitializer::new(mock_handle, mock_ref, qp_key.clone(), qp);
+            let init_handle = proc.spawn("initializer", initializer)?;
+            // Bind well-known ports so PeerInfo/NotifyRts can route.
+            let _ = init_handle.bind::<QueuePairInitializer<MockManager>>();
+            Ok(Harness {
+                proc,
+                init_handle,
+                state,
+                qp_key,
+            })
+        }
+
+        async fn await_done(&self) -> QpKey {
+            let deadline = Instant::now() + Duration::from_secs(5);
+            loop {
+                if let Some(key) = self.state.lock().unwrap().done.first().cloned() {
+                    return key;
+                }
+                if Instant::now() >= deadline {
+                    panic!(
+                        "QpInitializerDone not delivered within 5s; state={:?}",
+                        self.state.lock().unwrap()
+                    );
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        }
+
+        async fn await_failed(&self) -> (QpKey, String) {
+            let deadline = Instant::now() + Duration::from_secs(5);
+            loop {
+                if let Some(entry) = self.state.lock().unwrap().failed.first().cloned() {
+                    return entry;
+                }
+                if Instant::now() >= deadline {
+                    panic!(
+                        "QpInitializerFailed was not delivered within 5s; state={:?}",
+                        self.state.lock().unwrap()
+                    );
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn test_peer_info_error_transitions_to_failed() {
+        let harness =
+            Harness::build(fake_qp(), MockResponse::Error("peer rejected".into())).unwrap();
+        let (key, error) = harness.await_failed().await;
+        assert_eq!(key, harness.qp_key);
+        assert_eq!(error, "peer rejected");
+        // No spurious done callbacks.
+        assert!(harness.state.lock().unwrap().done.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_initial_timeout_transitions_to_failed() {
+        // Drop the configured per-handshake budget to 200ms so the
+        // test doesn't sit on the default 30s.
+        let lock = hyperactor_config::global::lock();
+        let _guard = lock.override_key(
+            crate::config::RDMA_QP_INIT_TIMEOUT,
+            Duration::from_millis(200),
+        );
+
+        let harness = Harness::build(fake_qp(), MockResponse::DropReply).unwrap();
+        let (key, error) = harness.await_failed().await;
+        assert_eq!(key, harness.qp_key);
+        assert!(
+            error.contains("timed out"),
+            "expected timeout error, got {error}"
+        );
+    }
+
+    /// Real loopback handshake. The mock replies `Success`, the
+    /// initializer connects the qp to itself and sends `NotifyRts` to
+    /// the mock; the test then delivers `NotifyRts` directly to the
+    /// initializer's well-known port to drive it to success.
+    #[tokio::test]
+    async fn test_loopback_handshake_succeeds() -> Result<()> {
+        let Some((qp, info)) = loopback_qp() else {
+            panic!("Skipping test: RDMA devices not available");
+        };
+        let harness = Harness::build(qp, MockResponse::Success(info))?;
+
+        let (peer, _) = harness.proc.instance("peer")?;
+        harness.init_handle.send(&peer, NotifyRts)?;
+
+        let key = harness.await_done().await;
+        assert_eq!(key, harness.qp_key);
+        let state = harness.state.lock().unwrap();
+        assert!(state.failed.is_empty());
+        assert_eq!(
+            state.notify_rts, 1,
+            "initializer must send exactly one NotifyRts to the peer after qp.connect"
+        );
+        Ok(())
+    }
+
+    /// Real loopback `qp.connect` succeeds and the initializer
+    /// flips `our_rts_sent`, but the test never delivers `NotifyRts`
+    /// back to the initializer's port. The rearmed timer fires and
+    /// the handshake is reported as failed.
+    #[tokio::test]
+    async fn test_notify_rts_timeout_after_peer_info() -> Result<()> {
+        let Some((qp, info)) = loopback_qp() else {
+            panic!("Skipping test: RDMA devices not available");
+        };
+        let lock = hyperactor_config::global::lock();
+        let _guard = lock.override_key(
+            crate::config::RDMA_QP_INIT_TIMEOUT,
+            Duration::from_millis(200),
+        );
+
+        let harness = Harness::build(qp, MockResponse::Success(info))?;
+        let (key, error) = harness.await_failed().await;
+        assert_eq!(key, harness.qp_key);
+        assert!(
+            error.contains("timed out"),
+            "expected timeout error, got {error}"
+        );
+        // Receiving exactly one NotifyRts confirms the initializer
+        // ran `qp.connect` + sent NotifyRts to the peer and was
+        // waiting on the peer's `NotifyRts` when the rearmed timer
+        // fired.
+        assert_eq!(harness.state.lock().unwrap().notify_rts, 1);
+        Ok(())
+    }
+
+    fn fake_undeliverable(proc: &Proc, error: &str) -> Undeliverable<MessageEnvelope> {
+        let mut envelope = MessageEnvelope::serialize(
+            proc.proc_addr().actor_addr("test-sender"),
+            proc.proc_addr()
+                .actor_addr("test-dest")
+                .port_addr(Port::from(0u64)),
+            &0u64,
+            Flattrs::default(),
+        )
+        .unwrap();
+        envelope.set_error(DeliveryError::Mailbox(error.into()));
+        Undeliverable(envelope)
+    }
+
+    /// In an awaiting state, an undeliverable message returned to the
+    /// initializer trips `handle_undeliverable_message` into `fail()`,
+    /// which reports `QpInitializerFailed` to the owner with the
+    /// envelope's error message.
+    #[tokio::test]
+    async fn test_undeliverable_in_awaiting_transitions_to_failed() {
+        let harness = Harness::build(fake_qp(), MockResponse::DropReply).unwrap();
+        let undeliverable = fake_undeliverable(&harness.proc, "simulated bounce");
+        let (peer, _) = harness.proc.instance("peer").unwrap();
+        harness.init_handle.send(&peer, undeliverable).unwrap();
+        let (key, error) = harness.await_failed().await;
+        assert_eq!(key, harness.qp_key);
+        assert!(
+            error.contains("simulated bounce"),
+            "expected delivery error, got {error}"
+        );
+    }
+
+    /// `PeerInfo` carries a `PortRef<NotifyRts>` attested to a bogus
+    /// address; the initializer's send bounces back as undeliverable
+    /// after `our_rts_sent` is set, and `handle_undeliverable_message`
+    /// trips `fail()`.
+    #[tokio::test]
+    async fn test_notify_rts_undeliverable_transitions_to_failed() -> Result<()> {
+        let Some((qp, info)) = loopback_qp() else {
+            panic!("Skipping test: RDMA devices not available");
+        };
+        let harness = Harness::build(qp, MockResponse::SuccessWithBogusNotifyRts(info))?;
+        let (key, error) = harness.await_failed().await;
+        assert_eq!(key, harness.qp_key);
+        assert!(
+            error.contains("address not routable"),
+            "expected delivery error, got {error:?}"
+        );
+        Ok(())
+    }
+
+    /// Once the initializer is terminal, a late undeliverable is
+    /// just warn-logged and must not produce a second
+    /// `QpInitializerFailed` callback.
+    #[tokio::test]
+    async fn test_undeliverable_after_terminated_does_not_re_fail() {
+        let harness = Harness::build(fake_qp(), MockResponse::Error("first fail".into())).unwrap();
+        let _ = harness.await_failed().await;
+
+        let undeliverable = fake_undeliverable(&harness.proc, "late bounce");
+        let (peer, _) = harness.proc.instance("peer").unwrap();
+        harness.init_handle.send(&peer, undeliverable).unwrap();
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        assert_eq!(harness.state.lock().unwrap().failed.len(), 1);
     }
 }

--- a/monarch_rdma/src/backend/ibverbs/queue_pair.rs
+++ b/monarch_rdma/src/backend/ibverbs/queue_pair.rs
@@ -1118,7 +1118,6 @@ wirevalue::register_type!(NotifyRts);
 /// Local-only self-message fired by the timeout task. Triggers
 /// the initializer to abort the handshake.
 #[derive(Debug)]
-#[cfg_attr(not(test), allow(dead_code))]
 struct InitializationFailed;
 
 /// RAII wrapper that destroys the wrapped queue pair on drop.
@@ -1128,9 +1127,8 @@ pub(super) struct QpGuard {
     qp: Option<IbvQueuePair>,
 }
 
-#[cfg_attr(not(test), allow(dead_code))]
 impl QpGuard {
-    fn new(qp: IbvQueuePair) -> Self {
+    pub(super) fn new(qp: IbvQueuePair) -> Self {
         Self { qp: Some(qp) }
     }
 
@@ -1173,7 +1171,6 @@ impl Drop for QpGuard {
 
 /// Bundle of trait bounds for an actor type that can play the role
 /// of [`QueuePairInitializer`]'s owner/peer manager.
-#[cfg_attr(not(test), allow(dead_code))]
 pub(super) trait QpOwner:
     Actor
     + Referable
@@ -1200,7 +1197,6 @@ impl<T> QpOwner for T where
 /// mock.
 #[derive(Debug)]
 #[hyperactor::export(handlers = [PeerInfo, NotifyRts])]
-#[cfg_attr(not(test), allow(dead_code))]
 pub(super) struct QueuePairInitializer<A: QpOwner> {
     owner: ActorHandle<A>,
     other: ActorRef<A>,
@@ -1226,7 +1222,6 @@ pub(super) struct QueuePairInitializer<A: QpOwner> {
     timeout_handle: Option<tokio::task::JoinHandle<()>>,
 }
 
-#[cfg_attr(not(test), allow(dead_code))]
 impl<A> QueuePairInitializer<A>
 where
     A: QpOwner,
@@ -1235,14 +1230,14 @@ where
         owner: ActorHandle<A>,
         other: ActorRef<A>,
         qp_key: QpKey,
-        qp: IbvQueuePair,
+        qp: QpGuard,
     ) -> Self {
         let timeout = hyperactor_config::global::get(crate::config::RDMA_QP_INIT_TIMEOUT);
         Self {
             owner,
             other,
             qp_key,
-            qp: Some(QpGuard::new(qp)),
+            qp: Some(qp),
             timeout,
             our_rts_sent: false,
             peer_rts_received: false,
@@ -1611,13 +1606,13 @@ mod tests {
 
     /// A real (loopback) `IbvQueuePair` and its `IbvQpInfo`. Returns
     /// `None` when no RDMA device is present.
-    fn loopback_qp() -> Option<(IbvQueuePair, IbvQpInfo)> {
+    fn loopback_qp() -> Option<(QpGuard, IbvQpInfo)> {
         if get_all_devices().is_empty() {
             return None;
         }
         let config = IbvConfig::default();
         let domain = IbvDomain::new(config.device.clone()).ok()?;
-        let mut qp = IbvQueuePair::new(domain.context, domain.pd, config).ok()?;
+        let mut qp = QpGuard::new(IbvQueuePair::new(domain.context, domain.pd, config).ok()?);
         let info = qp.get_qp_info().ok()?;
         Some((qp, info))
     }
@@ -1700,7 +1695,7 @@ mod tests {
     }
 
     impl Harness {
-        fn build(qp: IbvQueuePair, response: MockResponse) -> Result<Self> {
+        fn build(qp: QpGuard, response: MockResponse) -> Result<Self> {
             let proc = Proc::new();
             let state = Arc::new(Mutex::new(MockState::default()));
             let mock = MockManager {
@@ -1761,8 +1756,11 @@ mod tests {
 
     #[tokio::test]
     async fn test_peer_info_error_transitions_to_failed() {
-        let harness =
-            Harness::build(fake_qp(), MockResponse::Error("peer rejected".into())).unwrap();
+        let harness = Harness::build(
+            QpGuard::new(fake_qp()),
+            MockResponse::Error("peer rejected".into()),
+        )
+        .unwrap();
         let (key, error) = harness.await_failed().await;
         assert_eq!(key, harness.qp_key);
         assert_eq!(error, "peer rejected");
@@ -1780,7 +1778,7 @@ mod tests {
             Duration::from_millis(200),
         );
 
-        let harness = Harness::build(fake_qp(), MockResponse::DropReply).unwrap();
+        let harness = Harness::build(QpGuard::new(fake_qp()), MockResponse::DropReply).unwrap();
         let (key, error) = harness.await_failed().await;
         assert_eq!(key, harness.qp_key);
         assert!(
@@ -1864,7 +1862,7 @@ mod tests {
     /// envelope's error message.
     #[tokio::test]
     async fn test_undeliverable_in_awaiting_transitions_to_failed() {
-        let harness = Harness::build(fake_qp(), MockResponse::DropReply).unwrap();
+        let harness = Harness::build(QpGuard::new(fake_qp()), MockResponse::DropReply).unwrap();
         let undeliverable = fake_undeliverable(&harness.proc, "simulated bounce");
         let (peer, _) = harness.proc.instance("peer").unwrap();
         harness.init_handle.send(&peer, undeliverable).unwrap();
@@ -1900,7 +1898,11 @@ mod tests {
     /// `QpInitializerFailed` callback.
     #[tokio::test]
     async fn test_undeliverable_after_terminated_does_not_re_fail() {
-        let harness = Harness::build(fake_qp(), MockResponse::Error("first fail".into())).unwrap();
+        let harness = Harness::build(
+            QpGuard::new(fake_qp()),
+            MockResponse::Error("first fail".into()),
+        )
+        .unwrap();
         let _ = harness.await_failed().await;
 
         let undeliverable = fake_undeliverable(&harness.proc, "late bounce");

--- a/monarch_rdma/src/backend/ibverbs/test_utils.rs
+++ b/monarch_rdma/src/backend/ibverbs/test_utils.rs
@@ -13,6 +13,7 @@ use std::time::Duration;
 use std::time::Instant;
 
 use hyperactor::Actor;
+use hyperactor::ActorHandle;
 use hyperactor::ActorRef;
 use hyperactor::Context;
 use hyperactor::HandleClient;
@@ -465,6 +466,11 @@ pub struct IbvTestEnv {
     pub actor_2: ActorRef<RdmaManagerActor>,
     pub ibv_actor_1: ActorRef<IbvManagerActor>,
     pub ibv_actor_2: ActorRef<IbvManagerActor>,
+    /// In-proc handles for the same actors as `ibv_actor_*`.
+    /// Tests that need to call local-only messages such as
+    /// `RequestQueuePair` go through these.
+    pub ibv_handle_1: ActorHandle<IbvManagerActor>,
+    pub ibv_handle_2: ActorHandle<IbvManagerActor>,
     pub rdma_handle_1: RdmaRemoteBuffer,
     pub rdma_handle_2: RdmaRemoteBuffer,
     pub local_memory_1: Arc<dyn RdmaLocalMemory>,
@@ -645,6 +651,14 @@ impl IbvTestEnv {
         let (ibv_actor_2, ibv_buffer_2) = rdma_handle_2
             .resolve_ibv()
             .ok_or_else(|| anyhow::anyhow!("ibverbs backend not found for buffer 2"))?;
+        let ibv_handle_1: ActorHandle<IbvManagerActor> =
+            ibv_actor_1
+                .downcast_handle(&instance_1)
+                .ok_or_else(|| anyhow::anyhow!("ibv_actor_1 is not in proc_1"))?;
+        let ibv_handle_2: ActorHandle<IbvManagerActor> =
+            ibv_actor_2
+                .downcast_handle(&instance_2)
+                .ok_or_else(|| anyhow::anyhow!("ibv_actor_2 is not in proc_2"))?;
 
         // Fill buffer1 with test data
         if parsed_accel1.0 == "cuda" {
@@ -674,6 +688,8 @@ impl IbvTestEnv {
             actor_2,
             ibv_actor_1,
             ibv_actor_2,
+            ibv_handle_1,
+            ibv_handle_2,
             rdma_handle_1,
             rdma_handle_2,
             local_memory_1,

--- a/monarch_rdma/src/config.rs
+++ b/monarch_rdma/src/config.rs
@@ -67,4 +67,16 @@ declare_attrs! {
         Some("rdma_cq_busy_poll_window".to_string()),
     ))
     pub attr RDMA_CQ_BUSY_POLL_WINDOW: Option<Duration> = None;
+
+    /// Per-side budget for the `QueuePairInitializer` handshake. The
+    /// timer arms once when we send `EnsureQueuePair` and is rearmed
+    /// after we hit RTS while still waiting for the peer's
+    /// `NotifyRts`. If it fires the entry is tombstoned with a
+    /// `qp_initializer_failed` so further `RequestQueuePair` calls
+    /// for the same key surface the same error rather than hanging.
+    @meta(CONFIG = ConfigAttr::new(
+        Some("MONARCH_RDMA_QP_INIT_TIMEOUT".to_string()),
+        Some("rdma_qp_init_timeout".to_string()),
+    ))
+    pub attr RDMA_QP_INIT_TIMEOUT: Duration = Duration::from_secs(30);
 }


### PR DESCRIPTION
Summary:

Rips out `IbvManagerActor`'s previous direct-handshake QP code and wires it onto `QueuePairInitializer` from the parent commit. This fixes three problems with the old design:

- **Deadlock on concurrent bidirectional initialization.** `RequestQueuePair` ran the handshake inline from the manager's handler, blocking on cross-proc RPCs to the peer manager. If the peer simultaneously issued `RequestQueuePair` to the manager, it would also block — classic deadlock. The handshake now runs in a per-QP child actor; the manager handler does only sync bookkeeping.
- **Race returning a half-initialized QP.** When node A's manager called `InitializeQP` on node B, node B inserted the QP into its qps map and replied without waiting to reach RTS itself. A subsequent `request_queue_pair` on node B would find that entry and hand back the QP before B's QP had advanced through INIT→RTR→RTS, so work posted from B could land on a not-yet-ready QP. With the initializer, the entry on each side stays `Pending` until the peer's `NotifyRts` message is received and the local QP has been observed as RTS, and only then transitions to `Ready` and answers waiters.
- **Useless pending-creation map.** `pending_qp_creation: Arc<Mutex<HashSet<(String, ActorId, String)>>>` was meant to coalesce concurrent `RequestQueuePair` invocations, but actor message handlers always run one at a time — two `RequestQueuePair` messages for the same key can never run concurrently in the first place, so the map's polling-and-locking dance protected against a scenario that couldn't happen. Coalescing now lives in the `Pending` entry itself: late callers append their reply ports to `waiters: Vec<OncePortHandle<_>>`, and all of them drain together in `QpInitializerDone` / `QpInitializerFailed`.

Concretely: the cross-proc `IbvManagerMessage::{RequestQueuePair,Connect,InitializeQP,ConnectionInfo,ReleaseQueuePair,GetQpState}` variants and their handlers go away; `qps` becomes a `HashMap<QpKey, QpState>` of `Pending { info, initializer, waiters } | Ready(qp) | Failed(error)`; a new local `IbvManagerLocalMessage::RequestQueuePair` (no `#[reply]` — the handler parks the port on `Pending.waiters`) replaces the old cross-proc variant; cross-proc peer-side handshake is now `Handler<EnsureQueuePair<IbvManagerActor>>`; the unused `futures` dep is dropped.

Differential Revision: D104605344


