### PR TITLE
Fix artifact name collision in test-cpu-rust CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,14 +51,6 @@ jobs:
     if: ${{ !startsWith(github.ref, 'refs/tags/ciflow/rocm/') }}
     uses: ./.github/workflows/test-cpu-rust.yml
 
-  test-cpu-rust-arm64:
-    name: Test CPU Rust (ARM64)
-    if: ${{ !startsWith(github.ref, 'refs/tags/ciflow/rocm/') }}
-    uses: ./.github/workflows/test-cpu-rust.yml
-    with:
-      runner: linux.arm64.2xlarge
-      docker-image: 'pytorch/manylinuxaarch64-builder:cuda12.8'
-
   test-gpu-rust:
     name: Test GPU Rust
     needs: build-gpu
@@ -76,7 +68,7 @@ jobs:
   status-check:
     name: Status Check
     runs-on: ubuntu-latest
-    needs: [test-cpu-python, test-gpu-python, test-cpu-rust, test-cpu-rust-arm64, test-gpu-rust]
+    needs: [test-cpu-python, test-gpu-python, test-cpu-rust, test-gpu-rust]
     if: always()
     steps:
       # Fail if any job failed or was cancelled; skipped jobs are OK

--- a/.github/workflows/test-cpu-rust.yml
+++ b/.github/workflows/test-cpu-rust.yml
@@ -2,34 +2,31 @@ name: Test CPU Rust
 
 on:
   workflow_call:
-    inputs:
-      python-version:
-        description: 'Python version to test with'
-        type: string
-        default: '3.10'
-      runner:
-        description: 'Linux runner to use for the test'
-        type: string
-        default: 'linux.4xlarge'
-      docker-image:
-        description: 'Docker image to use (default lets test-infra auto-select)'
-        type: string
-        default: 'pytorch/almalinux-builder'
 
 concurrency:
-  group: test-cpu-rust-${{ inputs.runner }}-${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.run_number || github.ref }}
+  group: test-cpu-rust-${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.run_number || github.ref }}
   cancel-in-progress: true
 
 jobs:
   test-cpu-rust:
-    name: Test CPU Rust
+    name: Test CPU Rust (${{ matrix.name }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: x86_64
+            runner: linux.4xlarge
+            docker-image: pytorch/almalinux-builder
+          - name: arm64
+            runner: linux.arm64.2xlarge
+            docker-image: pytorch/manylinuxaarch64-builder:cuda12.8
     uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
     with:
       timeout: 120
-      runner: ${{ inputs.runner }}
-      docker-image: ${{ inputs.docker-image }}
+      runner: ${{ matrix.runner }}
+      docker-image: ${{ matrix.docker-image }}
       submodules: recursive
-      upload-artifact: test-results-cpu-rust-${{ github.sha }}
+      upload-artifact: test-results-cpu-rust-${{ matrix.name }}-${{ github.sha }}
       script: |
         # Source common setup functions
         source scripts/common-setup.sh


### PR DESCRIPTION
Summary: The test-cpu-rust.yml workflow was invoked twice from ci.yml (x86_64 and arm64), but its `upload-artifact:` value was hardcoded to `test-results-cpu-rust-${{ github.sha }}` with no per-runner differentiator. Both jobs called CreateArtifact with the same name on the same SHA, so the second to upload hit a 409 Conflict ("an artifact with this name already exists on the workflow run") at the "Upload artifacts to Github if any" step from pytorch/test-infras linux_job_v2.yml. The collision was introduced by D102869250 / #3670 (2026-04-30), which added artifact uploads but did not account for ci.yml calling the same workflow twice.

Fix: restructure test-cpu-rust.yml to hold an inline strategy.matrix with x86_64 and arm64 entries (each supplying `runner` and `docker-image`), mirroring the pattern test-gpu-rust.yml uses. The artifact name now includes `${{ matrix.name }}`, producing `test-results-cpu-rust-x86_64-<sha>` and `test-results-cpu-rust-arm64-<sha>`. ci.yml two `test-cpu-rust` jobs collapse into one matrix-driven job, and `test-cpu-rust-arm64` is removed from `status-check.needs`.

Test Plan:

Reviewers:

Subscribers:

Tasks:

Tags: