### PR TITLE
Fix ProcMesh.stop() hang and undeliverable poisoning when a peer dies (#3826)

### DIFF
--- a/hyperactor_mesh/src/host_mesh.rs
+++ b/hyperactor_mesh/src/host_mesh.rs
@@ -112,7 +112,6 @@ use crate::resource::GetRankStatus;
 use crate::resource::GetRankStatusClient;
 use crate::resource::RankedValues;
 use crate::resource::Status;
-use crate::resource::WaitRankStatusClient;
 use crate::transport::DEFAULT_TRANSPORT;
 
 /// Actor name for `ProcMeshController` when spawned as a named child.
@@ -1483,32 +1482,55 @@ impl HostMeshRef {
         procs: impl IntoIterator<Item = ProcAddr>,
         region: Region,
         reason: String,
+        // Snapshot of ranks the caller has already observed in a
+        // terminal status. Observation-only: by the monotonicity
+        // invariant on rank status those values are stable, so we
+        // pre-seed the wait accumulator with them and skip
+        // `wait_rank_status` for the corresponding host agents. `Stop`
+        // is always signalled to every proc.
+        known_terminal: std::collections::HashMap<usize, Status>,
     ) -> crate::Result<crate::StatusMesh> {
-        // Accumulator outputs full StatusMesh snapshots; seed with
-        // NotExist.
-        let mut proc_names = Vec::new();
         let num_ranks = region.num_ranks();
-        // Accumulator outputs full StatusMesh snapshots; seed with
-        // NotExist.
+        // Accumulator outputs full StatusMesh snapshots; pre-fill
+        // ranks the caller already observed as terminal so the wait
+        // can complete without overlay updates for them.
+        let seed = if known_terminal.is_empty() {
+            crate::StatusMesh::from_single(region.clone(), Status::NotExist)
+        } else {
+            let ranges: Vec<(std::ops::Range<usize>, Status)> = known_terminal
+                .iter()
+                .map(|(rank, status)| (*rank..rank + 1, status.clone()))
+                .collect();
+            crate::StatusMesh::from_ranges_with_default(region.clone(), Status::NotExist, ranges)
+                .map_err(|e| anyhow::anyhow!("invalid known_terminal entries: {:?}", e))?
+        };
         let (port, rx) = cx.mailbox().open_accum_port_opts(
-            crate::StatusMesh::from_single(region.clone(), Status::NotExist),
+            seed,
             StreamingReducerOpts {
                 max_update_interval: Some(Duration::from_millis(50)),
                 initial_update_interval: None,
             },
         );
-        for proc_id in procs.into_iter() {
-            let addr = proc_id.addr().clone();
-            // The name stored in HostAgent is not the same as the
-            // one stored in the ProcMesh. We instead take each proc id
-            // and map it to that particular agent.
-            let proc_resource_id = ResourceId::new(proc_id.uid().clone(), proc_id.label().cloned());
-            proc_names.push(proc_resource_id.clone());
 
-            // Note that we don't send 1 message per host agent, we send 1 message
-            // per proc.
-            let host = HostRef(addr);
-            host.mesh_agent()
+        // `procs` is in rank order, so the index in this vec is the
+        // create_rank — matching the keys in `known_terminal`.
+        let procs: Vec<ProcAddr> = procs.into_iter().collect();
+        let proc_names: Vec<ResourceId> = procs
+            .iter()
+            .map(|p| ResourceId::new(p.uid().clone(), p.label().cloned()))
+            .collect();
+
+        // Signal phase: send `Stop` to every host unconditionally.
+        // The signal sets the desired state; `return_undeliverable(false)`
+        // keeps a dead host agent's bounced envelope from being routed
+        // through the caller's supervisor. There is also no per-host
+        // short-circuit on `?`: every live host receives `Stop`
+        // regardless of sibling failures.
+        for (proc_id, proc_resource_id) in procs.iter().zip(proc_names.iter()) {
+            let host = HostRef(proc_id.addr().clone());
+            let mut stop_port = host.mesh_agent().port::<resource::Stop>();
+            stop_port.return_undeliverable(false);
+            stop_port
                 .send(
                     cx,
                     resource::Stop {
@@ -1519,16 +1541,38 @@ impl HostMeshRef {
                 .map_err(|e| {
                     crate::Error::SendingError(host.mesh_agent().actor_addr().clone(), Box::new(e))
                 })?;
-            host.mesh_agent()
-                .wait_rank_status(cx, proc_resource_id, Status::Stopped, port.bind())
-                .await
-                .map_err(|e| crate::Error::CallError(host.mesh_agent().actor_addr().clone(), e))?;
-
             tracing::info!(
                 name = "ProcMeshStatus",
                 %proc_id,
                 status = "Stop::Sent",
             );
+        }
+
+        // Observation phase: subscribe via `WaitRankStatus` only on
+        // hosts whose proc rank has not already been observed in a
+        // terminal state. A host can still die between building
+        // `known_terminal` and the send; `return_undeliverable(false)`
+        // suppresses the bounce so the wait's idle timeout is the
+        // only failure surface, matching the HM-3 in-band convention.
+        for (rank, (proc_id, proc_resource_id)) in procs.iter().zip(proc_names.iter()).enumerate() {
+            if known_terminal.contains_key(&rank) {
+                continue;
+            }
+            let host = HostRef(proc_id.addr().clone());
+            let mut wait_port = host.mesh_agent().port::<resource::WaitRankStatus>();
+            wait_port.return_undeliverable(false);
+            wait_port
+                .send(
+                    cx,
+                    resource::WaitRankStatus {
+                        id: proc_resource_id.clone(),
+                        min_status: Status::Stopped,
+                        reply: port.bind(),
+                    },
+                )
+                .map_err(|e| {
+                    crate::Error::SendingError(host.mesh_agent().actor_addr().clone(), Box::new(e))
+                })?;
         }
         tracing::info!(
             name = "HostMeshStatus",

--- a/hyperactor_mesh/src/mesh_controller.rs
+++ b/hyperactor_mesh/src/mesh_controller.rs
@@ -1219,10 +1219,33 @@ impl<A: Referable> Controlled for ActorMeshRef<A> {
             .next()
             .map(|p| p.extent().clone());
 
+        // Observation snapshot of ranks already observed in a
+        // terminal status. Monotonicity makes those values stable;
+        // `stop_actor_by_id` uses this to pre-seed its wait
+        // accumulator and to skip `WaitRankStatus` for the
+        // corresponding agents. `Stop` is still cast to every rank.
+        let known_terminal: HashMap<usize, resource::Status> = health_state
+            .statuses
+            .iter()
+            .filter(|(_, (status, _))| status.is_terminated())
+            .map(|(point, (status, _))| (point.rank(), status.clone()))
+            .collect();
+
+        if known_terminal.len() == health_state.statuses.len() && !health_state.statuses.is_empty()
+        {
+            // Every rank already observed terminal; nothing to signal
+            // and the observation would be trivially complete.
+            tracing::info!(
+                actor_mesh = %mesh_name,
+                "all ranks already terminated: skipping stop broadcast"
+            );
+            return Ok(());
+        }
+
         // Cannot use "ActorMesh::stop" as it tries to message the controller.
         let result = self
             .proc_mesh()
-            .stop_actor_by_id(cx, ActorMeshRef::id(self).clone(), reason)
+            .stop_actor_by_id(cx, ActorMeshRef::id(self).clone(), reason, known_terminal)
             .await;
 
         match result {
@@ -1261,7 +1284,7 @@ impl<A: Referable> Controlled for ActorMeshRef<A> {
 
     async fn cleanup_stop(&self, cx: &impl context::Actor, reason: String) -> anyhow::Result<()> {
         self.proc_mesh()
-            .stop_actor_by_id(cx, ActorMeshRef::id(self).clone(), reason)
+            .stop_actor_by_id(cx, ActorMeshRef::id(self).clone(), reason, HashMap::new())
             .await?;
         Ok(())
     }
@@ -1417,8 +1440,48 @@ impl Controlled for ProcMeshRef {
             send_subscriber_message(cx, subscriber, failure_message.clone());
         }
 
-        let names = self.proc_ids().collect::<Vec<hyperactor::ProcAddr>>();
+        // Build an observation snapshot of ranks already known to be
+        // in a terminal state (`Stopped`, `Failed`, or `Timeout`). By
+        // the monotonicity invariant on rank status, those values are
+        // stable; `stop_proc_mesh` will pre-seed the wait accumulator
+        // and skip `wait_rank_status` for them. The `Stop` signal
+        // itself is still sent to every proc — the signal and
+        // observation paths are independent. `Stopping` ranks are not
+        // included: their host agents are still expected to be alive
+        // and we want a fresh observation through to `Stopped`.
         let region = Ranked::region(self).clone();
+        let extent = region.extent();
+        let known_terminal: HashMap<usize, resource::Status> = self
+            .proc_refs()
+            .iter()
+            .filter_map(|proc_ref| {
+                let create_rank = proc_ref.create_rank();
+                let point = extent.point_of_rank(create_rank).ok()?;
+                let (status, _) = health_state.statuses.get(&point)?;
+                if status.is_terminated() {
+                    Some((create_rank, status.clone()))
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        if known_terminal.len() == self.proc_refs().len() {
+            // Every rank already observed terminal; nothing to signal
+            // and the observation would be trivially complete.
+            tracing::info!(
+                proc_mesh = %mesh_name,
+                "all ranks already terminated: skipping stop broadcast"
+            );
+            return Ok(());
+        }
+
+        let names: Vec<hyperactor::ProcAddr> = self
+            .proc_refs()
+            .iter()
+            .map(|p| p.proc_addr().clone())
+            .collect();
+
         let Some(hosts) = self.hosts() else {
             return Ok(());
         };
@@ -1428,13 +1491,13 @@ impl Controlled for ProcMeshRef {
         // ranks the host agents reported on; apply those too so health
         // state stays as accurate as we can make it.
         let max_rank = health_state.statuses.keys().map(|p| p.rank()).max();
-        let extent = health_state
+        let stored_extent = health_state
             .statuses
             .keys()
             .next()
             .map(|p| p.extent().clone());
         match hosts
-            .stop_proc_mesh(cx, self.id(), names, region, reason)
+            .stop_proc_mesh(cx, self.id(), names, region, reason, known_terminal)
             .await
         {
             Ok(statuses) => {
@@ -1447,7 +1510,7 @@ impl Controlled for ProcMeshRef {
                 Ok(())
             }
             Err(crate::Error::ProcMeshStopError { statuses }) => {
-                if let (Some(max_rank), Some(extent)) = (max_rank, extent) {
+                if let (Some(max_rank), Some(extent)) = (max_rank, stored_extent) {
                     for (rank, status) in statuses.materialized_iter(max_rank).enumerate() {
                         if let Ok(point) = extent.point_of_rank(rank) {
                             health_state
@@ -1468,7 +1531,7 @@ impl Controlled for ProcMeshRef {
         let region = Ranked::region(self).clone();
         if let Some(hosts) = self.hosts() {
             hosts
-                .stop_proc_mesh(cx, self.id(), names, region, reason)
+                .stop_proc_mesh(cx, self.id(), names, region, reason, HashMap::new())
                 .await?;
         }
         Ok(())
@@ -1793,6 +1856,90 @@ mod tests {
         }
 
         let _ = actor_hm.shutdown(instance).await;
+    }
+
+    /// Verify that `ProcMesh::stop()` returns promptly when one rank's host
+    /// process is already dead. Regression test for the case where the
+    /// controller's stop path coupled signal and observation: a dead host
+    /// caused `wait_rank_status` to bounce as undeliverable, which
+    /// short-circuited the per-host loop before the surviving rank ever
+    /// received `Stop`, leaving `stop()` hung.
+    ///
+    /// After the signal/observation split, `Stop` is signalled to every
+    /// host unconditionally with undeliverable bounces suppressed, and the
+    /// wait observation is pre-seeded with cached terminal statuses for
+    /// dead ranks. The call completes well under `PROC_STOP_MAX_IDLE`.
+    #[tokio::test]
+    #[cfg(fbcode_build)]
+    async fn test_proc_mesh_stop_with_a_dead_host() {
+        let config = hyperactor_config::global::lock();
+        let _poll = config.override_key(SUPERVISION_POLL_FREQUENCY, Duration::from_secs(1));
+        let _stop_idle =
+            config.override_key(crate::host_mesh::PROC_STOP_MAX_IDLE, Duration::from_secs(5));
+
+        let instance = testing::instance();
+        let mut hm = host_mesh_with_config(2).await;
+
+        let mut proc_mesh = hm
+            .spawn(instance, "test_stop", Extent::unity(), None, None)
+            .await
+            .unwrap();
+
+        // Spawn a TestActor mesh so the controller has cached `Running`
+        // for every rank before we kill one.
+        let _actor_mesh: ActorMesh<testactor::TestActor> = proc_mesh
+            .spawn(instance, "stop_test_actor", &())
+            .await
+            .unwrap();
+
+        // Give the controller time to populate per-rank `Running` via
+        // its supervision stream.
+        tokio::time::sleep(Duration::from_secs(2)).await;
+
+        // Kill one host process. Its proc agent dies with it.
+        let _ = hm.children[0].start_kill();
+        let _ = hm.children[0].wait().await;
+
+        // Wait for the controller's supervision poll to observe the
+        // dead host's rank in a terminal status (Failed via
+        // supervision-stream disconnect, or Timeout via the next
+        // poll). This is what populates `known_terminal` on the stop
+        // path. The orphan/keepalive timeout in the agent is configured
+        // long; we poll the controller's actor_states view (also
+        // backed by health_state via GetState) until at least one rank
+        // appears terminal.
+        let observation_deadline = tokio::time::Instant::now() + Duration::from_secs(30);
+        loop {
+            if let Ok(Some(states)) = proc_mesh.proc_states(instance, None).await
+                && states.values().any(|s| s.status.is_terminated())
+            {
+                break;
+            }
+            assert!(
+                tokio::time::Instant::now() < observation_deadline,
+                "controller did not observe dead rank in terminal status within 30s"
+            );
+            tokio::time::sleep(Duration::from_millis(500)).await;
+        }
+
+        // Stop must complete in bounded time. The original bug was an
+        // unbounded hang.
+        let start = tokio::time::Instant::now();
+        let stop_result = tokio::time::timeout(
+            Duration::from_secs(30),
+            proc_mesh.stop(instance, "dead-host stop test".to_string()),
+        )
+        .await;
+        let elapsed = start.elapsed();
+        tracing::info!(?elapsed, "proc_mesh.stop returned");
+        assert!(
+            stop_result.is_ok(),
+            "ProcMesh::stop hung when one rank's host was dead (elapsed {:?})",
+            elapsed,
+        );
+        stop_result
+            .unwrap()
+            .expect("ProcMesh::stop should succeed with cached-terminal partition");
     }
 
     #[test]

--- a/hyperactor_mesh/src/proc_mesh.rs
+++ b/hyperactor_mesh/src/proc_mesh.rs
@@ -110,6 +110,11 @@ impl ProcRef {
         &self.proc_id
     }
 
+    /// The rank this proc was assigned when its mesh was created.
+    pub(crate) fn create_rank(&self) -> usize {
+        self.create_rank
+    }
+
     pub(crate) fn actor_addr(&self, id: &ActorMeshId) -> ActorAddr {
         self.proc_id.actor_addr_uid(id.uid().clone())
     }
@@ -330,7 +335,7 @@ impl ProcMesh {
             .host_mesh
             .as_ref()
             .expect("ProcMesh always has a host mesh")
-            .stop_proc_mesh(cx, &self.id, procs, region, reason)
+            .stop_proc_mesh(cx, &self.id, procs, region, reason, HashMap::new())
             .await
             .map(|_| ())
             .map_err(anyhow::Error::from)
@@ -607,6 +612,11 @@ impl ProcMeshRef {
     /// Returns an iterator over the proc ids in this mesh.
     pub(crate) fn proc_ids(&self) -> impl Iterator<Item = ProcAddr> {
         self.ranks.iter().map(|proc_ref| proc_ref.proc_id.clone())
+    }
+
+    /// Returns the proc refs in this mesh in rank order.
+    pub(crate) fn proc_refs(&self) -> &[ProcRef] {
+        &self.ranks
     }
 
     /// Spawn an actor on all of the procs in this mesh, returning a
@@ -915,6 +925,12 @@ impl ProcMeshRef {
     }
 
     /// Send stop actors message to all mesh agents for a specific actor mesh id.
+    ///
+    /// `known_terminal` is a snapshot of ranks the caller has already observed
+    /// in a terminal status. It is *observation-only*: by the monotonicity
+    /// invariant on rank status, those ranks cannot transition back, so we
+    /// reuse the cached value instead of asking their (possibly dead) agents.
+    /// `Stop` is always signalled to every rank.
     #[hyperactor::instrument(fields(
         host_mesh = self.host_mesh_id().map(|id| id.to_string()),
         proc_mesh = self.id.to_string(),
@@ -925,10 +941,13 @@ impl ProcMeshRef {
         cx: &impl context::Actor,
         actor_mesh_id: ActorMeshId,
         reason: String,
+        known_terminal: HashMap<usize, Status>,
     ) -> crate::Result<ValueMesh<Status>> {
         tracing::info!(name = "ProcMeshStatus", status = "ActorMesh::Stop::Attempt");
         tracing::info!(name = "ActorMeshStatus", status = "Stop::Attempt");
-        let result = self.stop_actor_by_id_inner(cx, actor_mesh_id, reason).await;
+        let result = self
+            .stop_actor_by_id_inner(cx, actor_mesh_id, reason, known_terminal)
+            .await;
         match &result {
             Ok(_) => {
                 tracing::info!(name = "ProcMeshStatus", status = "ActorMesh::Stop::Success");
@@ -947,46 +966,82 @@ impl ProcMeshRef {
         cx: &impl context::Actor,
         actor_mesh_id: ActorMeshId,
         reason: String,
+        known_terminal: HashMap<usize, Status>,
     ) -> crate::Result<ValueMesh<Status>> {
         let region = self.region().clone();
         let agent_mesh = self.agent_mesh();
-        agent_mesh.cast(
-            cx,
-            resource::Stop {
-                id: actor_mesh_id.resource_id().clone(),
-                reason,
-            },
-        )?;
 
-        // Open an accum port that *receives overlays* and *emits full
-        // meshes*.
+        // Signal phase: send `Stop` to every rank unconditionally.
+        // The signal sets the desired state and is independent of
+        // observed health; the mailbox enqueues every send, and
+        // `return_undeliverable(false)` keeps a dead proc agent's
+        // bounced envelope from being routed through the caller's
+        // supervisor.
+        let stop_msg = resource::Stop {
+            id: actor_mesh_id.resource_id().clone(),
+            reason,
+        };
+        for (_, agent) in agent_mesh.iter() {
+            let mut stop_port = agent.port::<resource::Stop>();
+            stop_port.return_undeliverable(false);
+            stop_port
+                .send(cx, stop_msg.clone())
+                .map_err(|e| Error::SendingError(agent.actor_addr().clone(), Box::new(e)))?;
+        }
+
+        // Observation phase. Open an accum port that *receives
+        // overlays* and *emits full meshes*. Pre-fill ranks the
+        // caller has already observed in a terminal state — the
+        // monotonicity invariant on rank status means those values
+        // are stable, so the wait completes without re-asking those
+        // (possibly dead) agents.
         //
         // NOTE: Mailbox initializes the accumulator state via
         // `Default`, which is an *empty* ValueMesh (0 ranks). Our
         // Accumulator<ValueMesh<T>> implementation detects this on
         // the first update and replaces it with the caller-supplied
-        // template (the `self` passed into open_accum_port), which we
-        // seed here as "full NotExist over the target region".
+        // template (the `self` passed into open_accum_port).
+        let seed = if known_terminal.is_empty() {
+            crate::StatusMesh::from_single(region.clone(), Status::NotExist)
+        } else {
+            let ranges: Vec<(std::ops::Range<usize>, Status)> = known_terminal
+                .iter()
+                .map(|(rank, status)| (*rank..rank + 1, status.clone()))
+                .collect();
+            crate::StatusMesh::from_ranges_with_default(region.clone(), Status::NotExist, ranges)
+                .map_err(|e| {
+                    Error::Other(anyhow::anyhow!("invalid known_terminal entries: {:?}", e))
+                })?
+        };
         let (port, rx) = cx.mailbox().open_accum_port_opts(
-            // Initial state for the accumulator: full mesh seeded to
-            // NotExist.
-            crate::StatusMesh::from_single(region.clone(), Status::NotExist),
+            seed,
             StreamingReducerOpts {
                 max_update_interval: Some(Duration::from_millis(50)),
                 initial_update_interval: None,
             },
         );
-        // Use WaitRankStatus instead of GetRankStatus so agents defer
-        // their reply until the actor reaches terminal state, rather
-        // than replying immediately with Stopping.
-        agent_mesh.cast(
-            cx,
-            resource::WaitRankStatus {
-                id: actor_mesh_id.resource_id().clone(),
-                min_status: Status::Stopped,
-                reply: port.bind(),
-            },
-        )?;
+        // Subscribe via `WaitRankStatus` only on ranks whose terminal
+        // status we have not already cached. Agents defer their reply
+        // until the actor reaches terminal state, rather than replying
+        // immediately with `Stopping`. A rank can still die between
+        // building `known_terminal` and the send; `return_undeliverable(false)`
+        // suppresses the bounce so the timeout — not the caller's
+        // supervisor — is the only failure surface.
+        let wait_msg = resource::WaitRankStatus {
+            id: actor_mesh_id.resource_id().clone(),
+            min_status: Status::Stopped,
+            reply: port.bind(),
+        };
+        for (point, agent) in agent_mesh.iter() {
+            if known_terminal.contains_key(&point.rank()) {
+                continue;
+            }
+            let mut wait_port = agent.port::<resource::WaitRankStatus>();
+            wait_port.return_undeliverable(false);
+            wait_port
+                .send(cx, wait_msg.clone())
+                .map_err(|e| Error::SendingError(agent.actor_addr().clone(), Box::new(e)))?;
+        }
         let start_time = tokio::time::Instant::now();
 
         // Reuse actor spawn idle time.


### PR DESCRIPTION
Summary:

When one rank in a multi-process ProcMesh dies while peers are still active, calling `ProcMesh.stop()` — or stopping an `ActorMesh` whose underlying procs include a failed rank — hangs and pollutes the supervisor with undeliverables. The cause sits in the controller stop path, which previously entangled two concerns in a single broadcast: *signalling* the desired state change and *observing* the resulting status.

Per meriksen's review, the fix separates the two so that the observation result no longer depends on the signal.

**Signal phase.** `Stop` is broadcast to every rank unconditionally via a port configured with `return_undeliverable(false)`. Dead-rank delivery failures are dropped silently rather than bouncing back through the caller's supervisor. There is also no per-host short-circuit on `?`: every live rank receives `Stop` regardless of sibling failures.

**Observation phase.** The controller's monotonic cache of rank status — `Stopped`, `Failed`, and `Timeout` are terminal-and-stable — is captured as `known_terminal` at handler entry. The wait accumulator is pre-seeded with those slots, and only ranks not yet observed terminal receive a fresh `WaitRankStatus`. The wait completes as soon as the surviving ranks reach terminal state. `WaitRankStatus` sends also use `return_undeliverable(false)`, so a rank that dies between snapshot and message arrival cannot poison the supervisor either.

Concretely:

- `Controlled::handle_stop_request` for both `ProcMeshRef` and `ActorMeshRef` builds `known_terminal` from `health_state.statuses` filtered by `Status::is_terminated()`. If every rank is already terminal, both handlers early-return — this also addresses an AI-reviewer correctness gap on `ActorMeshRef::handle_stop_request`, where `GetRankStatus::wait` would otherwise idle out without ever receiving an overlay update.
- `HostMeshRef::stop_proc_mesh` and `ProcMeshRef::stop_actor_by_id` accept `known_terminal: HashMap<usize, Status>`. `Stop` is signalled to every rank/host. `WaitRankStatus` is filtered to ranks not in the snapshot, and the accumulator seed is built via `ValueMesh::from_ranges_with_default(region, NotExist, known_terminal)` so cached slots are pre-filled.
- `HostMeshRef::stop_proc_mesh` is restructured to send all `Stop`s first and only then issue the observation subscriptions. The previous serial per-host loop interleaved them, so a failure observing one host short-circuited `Stop` delivery to the surviving hosts.

`Stopping` ranks are not included in `known_terminal`: their host/proc agents are expected to be alive, and a fresh observation through to `Stopped` is what we want. Cleanup paths (`cleanup_stop`, the no-controller `ProcMesh::stop` fallback) pass an empty snapshot and behave as a pure broadcast.

Two small accessors are added: `ProcRef::create_rank()` and `ProcMeshRef::proc_refs()`.

**Race window.** A rank can still die after the snapshot is taken but before its agent processes the `WaitRankStatus`. For proc-only failures (host_agent alive), the host_agent's deferred-reply handler observes the transition independently and posts the overlay — the wait completes promptly regardless of the controller's blocked main loop. For full-host failures (host_agent dead with the proc), the wait's `PROC_STOP_MAX_IDLE` bound applies: missing ranks materialize as `Timeout`, which `proc_mesh.stop` accepts as terminating. The race is finite and never blocks the controller from making progress. A fuller fix — spawning the wait as a detached future so the controller keeps draining `State<T>` updates concurrently — is left for a follow-up.

Differential Revision: D103308259


