### PR TITLE
deprecate Future.get() called from inside an active event loop

### DIFF
--- a/python/monarch/_src/actor/future.py
+++ b/python/monarch/_src/actor/future.py
@@ -7,6 +7,8 @@
 # pyre-strict
 
 import asyncio
+import logging
+import warnings
 from typing import (
     Any,
     cast,
@@ -23,6 +25,7 @@ from monarch._rust_bindings.monarch_hyperactor.pytokio import (
     PythonTask,
     Shared,
 )
+from monarch._src.actor.telemetry import log_with_tracing
 
 R = TypeVar("R")
 
@@ -104,6 +107,24 @@ class Future(Generic[R]):
         )
 
     def get(self, timeout: Optional[float] = None) -> R:
+        in_asyncio = asyncio._get_running_loop() is not None
+        in_tokio = is_tokio_thread()
+        if in_asyncio or in_tokio:
+            warnings.warn(
+                "Future.get() called from within an active event loop blocks it; "
+                "use 'await' instead. This will become a RuntimeError in monarch v0.6.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            # Forward the event directly to Rust tracing so we capture it in
+            # non-actor driver processes too, where no `TracingForwarder`
+            # handler is attached to the Python logging chain.
+            log_with_tracing(
+                logging.WARNING,
+                "Future.get() called from within an active event loop",
+                extra={"context": "asyncio" if in_asyncio else "tokio"},
+                stacklevel=2,
+            )
         match self._status:
             case _Unawaited(coro=coro):
                 try:

--- a/python/monarch/_src/actor/proc_mesh.py
+++ b/python/monarch/_src/actor/proc_mesh.py
@@ -41,7 +41,6 @@ from monarch._rust_bindings.monarch_hyperactor.proc_mesh import ProcMesh as HyPr
 from monarch._rust_bindings.monarch_hyperactor.pytokio import PythonTask, Shared
 from monarch._rust_bindings.monarch_hyperactor.shape import Region, Shape, Slice
 from monarch._rust_bindings.monarch_hyperactor.supervision import MeshFailure
-from monarch._rust_bindings.monarch_hyperactor.telemetry import forward_to_tracing
 from monarch._src.actor.actor_mesh import (
     _Actor,
     _create_endpoint_message,
@@ -63,6 +62,7 @@ from monarch._src.actor.endpoint import endpoint
 from monarch._src.actor.future import Future
 from monarch._src.actor.logging import LoggingManager
 from monarch._src.actor.shape import MeshTrait
+from monarch._src.actor.telemetry import log_with_tracing
 from monarch.tools.config.environment import CondaEnvironment
 from monarch.tools.config.workspace import Workspace
 from monarch.tools.utils import conda as conda_utils
@@ -101,38 +101,6 @@ _COMMON_CUDA_ENV_VARS: Tuple[str, ...] = (
 
 T = TypeVar("T")
 TActor = TypeVar("TActor", bound=Actor)
-
-
-def log_with_tracing(
-    level: int,
-    msg: object,
-    *args: object,
-    stack_info: bool = False,
-    stacklevel: int = 1,
-    extra: Dict[str, object] | None = None,
-    logger: logging.Logger | None = None,
-) -> None:
-    logger = logger or logging.getLogger(__name__)
-
-    fn, lno, func, sinfo = logger.findCaller(
-        stack_info=stack_info,
-        stacklevel=stacklevel + 1,
-    )
-
-    record = logger.makeRecord(
-        logger.name,
-        level,
-        fn,
-        lno,
-        msg,
-        args,
-        None,
-        func,
-        extra=extra,
-        sinfo=sinfo,
-    )
-    logger.handle(record)
-    forward_to_tracing(record)
 
 
 def _cuda_env_snapshot() -> Dict[str, Optional[str]]:

--- a/python/monarch/_src/actor/telemetry/__init__.py
+++ b/python/monarch/_src/actor/telemetry/__init__.py
@@ -11,7 +11,7 @@ import functools
 import inspect
 import logging
 import warnings
-from typing import Callable, Optional, overload, Sequence, TypeVar
+from typing import Callable, Dict, Optional, overload, Sequence, TypeVar
 
 import opentelemetry.metrics as metrics  # @manual=fbsource//third-party/pypi/opentelemetry-api:opentelemetry-api
 import opentelemetry.trace as trace  # @manual=fbsource//third-party/pypi/opentelemetry-api:opentelemetry-api
@@ -97,6 +97,47 @@ def traced(
     if fn is not None:
         return decorator(fn)
     return decorator
+
+
+def log_with_tracing(
+    level: int,
+    msg: object,
+    *args: object,
+    stack_info: bool = False,
+    stacklevel: int = 1,
+    extra: Dict[str, object] | None = None,
+    logger: logging.Logger | None = None,
+) -> None:
+    """Emit a log record through the normal `logging` handler chain and also
+    forward it directly to Rust tracing.
+
+    Use this in library code that must guarantee the event reaches the
+    tracing backend even when no `TracingForwarder` handler is attached to
+    the calling process's loggers (e.g., a non-actor driver process).
+    `stacklevel=1` attributes the record's pathname/lineno/funcName to the
+    immediate caller of `log_with_tracing`.
+    """
+    logger = logger or logging.getLogger(__name__)
+
+    fn, lno, func, sinfo = logger.findCaller(
+        stack_info=stack_info,
+        stacklevel=stacklevel + 1,
+    )
+
+    record = logger.makeRecord(
+        logger.name,
+        level,
+        fn,
+        lno,
+        msg,
+        args,
+        None,
+        func,
+        extra=extra,
+        sinfo=sinfo,
+    )
+    logger.handle(record)
+    forward_to_tracing(record)
 
 
 class TracingForwarder(logging.Handler):

--- a/python/tests/test_python_actors.py
+++ b/python/tests/test_python_actors.py
@@ -1813,6 +1813,25 @@ def test_context_propagated_through_python_task_spawn_blocking():
     p.stop().get()
 
 
+@pytest.mark.timeout(15)
+def test_future_get_inside_async_loop_warns():
+    """Calling Future.get() from inside an active asyncio loop is deprecated:
+    it blocks the surrounding loop. Verify a DeprecationWarning fires while
+    the call still completes for backward compatibility; this will become a
+    RuntimeError in monarch v0.6.
+    """
+
+    async def runner() -> int:
+        async def inner() -> int:
+            return 1
+
+        f: Future[int] = Future(coro=inner())
+        with pytest.warns(DeprecationWarning, match="event loop"):
+            return f.get()
+
+    assert asyncio.run(runner()) == 1
+
+
 class ActorWithCleanup(Actor):
     def __init__(self, counter: Counter) -> None:
         self.counter = counter


### PR DESCRIPTION
Summary:
Calling `Future.get()` from inside an active asyncio event loop or from a tokio thread blocks the surrounding loop until the underlying task completes. This is almost always a mistake — inside a coroutine, callers should `await` the Future instead — but it is not currently diagnosed, so the misuse silently degrades concurrency and (per the prior commit) used to deadlock interpreter shutdown if the worker never finished.

This commit adds an eager check at the top of `Future.get()` and emits a `DeprecationWarning` when an active event loop is detected. The call still completes (the underlying `coro.block_on()` runs as before), so existing callers are not broken. The warning message tells users to use `await` and notes that the behavior will become a `RuntimeError` in monarch v0.6.

Alongside the user-visible warning we forward a structured event through `log_with_tracing`, which dispatches a `LogRecord` through the standard Python `logging` handler chain and additionally calls `forward_to_tracing(record)` directly so the event reaches Rust tracing (and onward to OpenTelemetry) even when no `TracingForwarder` handler is attached. The direct forward matters because `TracingForwarder` is only installed in actor-process bootstraps and a few example `main()` bodies; non-actor driver processes have no such handler, so a plain `logger.warning` would only land on stderr and we would never see the call site in production telemetry. The event carries the loop context ("asyncio" or "tokio") in `extra` and uses `stacklevel=2`, so `pathname`/`lineno`/`funcName` point at the caller of `get()` rather than `get()` itself, which is exactly the information we need to identify production call sites that must migrate before the v0.6 flip.

To make `log_with_tracing` usable from `future.py` without a circular import (`proc_mesh.py` already imports `Future`), we relocate the helper from `monarch._src.actor.proc_mesh` to its natural home, `monarch._src.actor.telemetry`. The implementation is unchanged; the two existing call sites in `proc_mesh.py` migrate to the new import, and the orphaned `forward_to_tracing` import in `proc_mesh.py` goes away.

The follow-up commit replaces this warning with the actual `RuntimeError` raise; landing this commit first gives users one release of notice to migrate.

Reviewed By: mariusae

Differential Revision: D104448235


