### PR TITLE
Do not assign seq for actor ports which bypass workq (#3832)

### DIFF
--- a/hyperactor/src/actor.rs
+++ b/hyperactor/src/actor.rs
@@ -232,6 +232,33 @@ pub trait Handler<M>: Actor {
     async fn handle(&mut self, cx: &Context<Self>, message: M) -> Result<(), anyhow::Error>;
 }
 
+/// Blanket Handler impls for bypass-workq message types. Since these messages
+/// bypass workq, they will never be sent to actor's handler.
+///
+/// These exist solely to lock the `Handler<M>` coherence slot for each bypass
+/// type, so no specific `impl Handler<BypassType> for SomeActor` can be written.
+/// The actual delivery for these types goes through dedicated channels set up
+/// in `Instance::new`, not through Handler. See the matching sender-side check
+/// in [crate::ordering::Sequencer::assign_seq] and the registry of bypass types
+/// in [crate::ordering::is_bypass_workq_type_id].
+#[async_trait]
+impl<A: Actor> Handler<Signal> for A {
+    async fn handle(&mut self, _cx: &Context<Self>, _message: Signal) -> Result<(), anyhow::Error> {
+        unimplemented!("signal handler should not be called directly")
+    }
+}
+
+#[async_trait]
+impl<A: Actor> Handler<crate::introspect::IntrospectMessage> for A {
+    async fn handle(
+        &mut self,
+        _cx: &Context<Self>,
+        _message: crate::introspect::IntrospectMessage,
+    ) -> Result<(), anyhow::Error> {
+        unimplemented!("introspect message handler should not be called directly")
+    }
+}
+
 /// This handler provides a default behavior when a message sent by
 /// the actor to another is returned due to delivery failure.
 #[async_trait]

--- a/hyperactor/src/ordering.rs
+++ b/hyperactor/src/ordering.rs
@@ -9,10 +9,13 @@
 //! This module contains utilities used to help messages are delivered in order
 //! for any given sender and receiver actor pair.
 
+use std::any::TypeId;
 use std::collections::HashMap;
+use std::collections::HashSet;
 use std::fmt;
 use std::ops::DerefMut;
 use std::sync::Arc;
+use std::sync::LazyLock;
 use std::sync::Mutex;
 
 use dashmap::DashMap;
@@ -27,6 +30,41 @@ use uuid::Uuid;
 
 use crate::ActorAddr;
 use crate::PortAddr;
+use crate::actor::Signal;
+use crate::introspect::IntrospectMessage;
+
+// Bypass-actor-workq registry: message types whose receivers are delivered via
+// dedicated channels rather than the actor's work queue.
+//
+// Types in this registry share two invariants that the framework must honor:
+//   1. Their actor port is pre-registered via `Ports::open_message_port` in
+//      `Instance::new`; `Ports::get` rejects them via `is_bypass_workq_type_id` so
+//      they can't accidentally be wired to the work queue.
+//   2. Their sender-side sequence numbers must NOT share the per-actor seq
+//      counter (`SeqKey::Actor`), because the work queue never observes them
+//      and would otherwise see seq gaps that buffer subsequent workq messages
+//      indefinitely. `Sequencer::assign_seq` uses `SeqKey::Port` for these.
+//
+// When adding a new bypass-channel actor-port message type, update both lists.
+// A future move to `inventory`-driven registration can collapse them.
+
+static BYPASS_TYPE_IDS: LazyLock<HashSet<TypeId>> =
+    LazyLock::new(|| HashSet::from([TypeId::of::<Signal>(), TypeId::of::<IntrospectMessage>()]));
+
+static BYPASS_ACTOR_PORTS: LazyLock<HashSet<u64>> =
+    LazyLock::new(|| HashSet::from([Signal::port(), IntrospectMessage::port()]));
+
+/// Returns true if `id` is the `TypeId` of a bypass-channel message type
+/// (i.e. one that must not be wired through `Ports::get`).
+pub(crate) fn is_bypass_workq_type_id(id: TypeId) -> bool {
+    BYPASS_TYPE_IDS.contains(&id)
+}
+
+/// Returns true if `port` is the actor-port index of a bypass-channel
+/// message type (i.e. the sequencer must use `SeqKey::Port` for it).
+pub(crate) fn is_bypass_workq_actor_port(port: u64) -> bool {
+    BYPASS_ACTOR_PORTS.contains(&port)
+}
 
 /// A client's re-ordering buffer state.
 struct BufferState<T> {
@@ -256,8 +294,11 @@ impl Sequencer {
     ///
     /// - Handler ports: share the same sequence scheme per actor (keyed by ActorAddr)
     /// - Non-handler ports: get individual sequence schemes (keyed by PortAddr)
+    /// - Bypass-workq actor ports: messages sent to these ports are delivered
+    ///   to their dedicated channels rather than the actor's work queue. As a
+    ///   result, they use the per-port counter instead.
     pub fn assign_seq(&self, port_id: &PortAddr) -> SeqInfo {
-        let key = if port_id.is_handler_port() {
+        let key = if port_id.is_handler_port() && !is_bypass_workq_actor_port(port_id.index()) {
             SeqKey::Actor(port_id.actor_addr().clone())
         } else {
             SeqKey::Port(port_id.clone())
@@ -564,5 +605,43 @@ mod tests {
         assert_eq!(get_seq(sequencer.assign_seq(&non_handler_port_1)), 2); // continues its own
         assert_eq!(get_seq(sequencer.assign_seq(&handler_port_1)), 3); // continues handler sequence
         assert_eq!(get_seq(sequencer.assign_seq(&non_handler_port_2)), 2); // continues its own
+    }
+
+    #[test]
+    fn bypass_registry_introspect_message() {
+        assert!(is_bypass_workq_type_id(TypeId::of::<IntrospectMessage>()));
+        assert!(is_bypass_workq_actor_port(IntrospectMessage::port()));
+    }
+
+    #[test]
+    fn bypass_registry_signal() {
+        assert!(is_bypass_workq_type_id(TypeId::of::<Signal>()));
+        assert!(is_bypass_workq_actor_port(Signal::port()));
+    }
+
+    #[test]
+    fn bypass_registry_lists_have_matching_lengths() {
+        // If this fails, BYPASS_TYPE_IDS and BYPASS_ACTOR_PORTS have drifted.
+        assert_eq!(BYPASS_TYPE_IDS.len(), BYPASS_ACTOR_PORTS.len());
+    }
+
+    #[test]
+    fn bypass_actor_port_uses_per_port_seq_counter() {
+        // Regression test for the seq-gap bug that caused pyspy 504s when
+        // ENABLE_DEST_ACTOR_REORDERING_BUFFER=true. A bypass-channel actor port
+        // (IntrospectMessage) must use SeqKey::Port so it doesn't share a counter
+        // with workq-bound messages to the same actor.
+        let sequencer = Sequencer::new(Uuid::now_v7());
+        let actor_ref: ActorAddr = test_actor_id("agent_0", "proc_agent");
+
+        let introspect_port = actor_ref.port_addr(Port::from(IntrospectMessage::port()));
+        let regular_actor_port = actor_ref.port_addr(Port::from(TestMsg1::port()));
+
+        // Both should start at seq=1 because their counters are independent.
+        assert_eq!(get_seq(sequencer.assign_seq(&introspect_port)), 1);
+        assert_eq!(get_seq(sequencer.assign_seq(&regular_actor_port)), 1);
+        // And continue independently.
+        assert_eq!(get_seq(sequencer.assign_seq(&introspect_port)), 2);
+        assert_eq!(get_seq(sequencer.assign_seq(&regular_actor_port)), 2);
     }
 }

--- a/hyperactor/src/proc.rs
+++ b/hyperactor/src/proc.rs
@@ -3403,17 +3403,14 @@ impl<A: Actor> HandlerPorts<A> {
         let key = TypeId::of::<M>();
         match self.ports.entry(key) {
             Entry::Vacant(entry) => {
-                // Runtime control-plane ports are provisioned directly,
-                // not through HandlerPorts.
-                assert_ne!(
-                    key,
-                    TypeId::of::<Signal>(),
-                    "cannot provision Signal port through `HandlerPorts::get`"
-                );
-                assert_ne!(
-                    key,
-                    TypeId::of::<IntrospectMessage>(),
-                    "cannot provision IntrospectMessage port through `HandlerPorts::get`"
+                // Runtime control-plane ports are provisioned directly, not
+                // through HandlerPorts, nor wired to the work queue. So they
+                // should never hit this code path.
+                assert!(
+                    !crate::ordering::is_bypass_workq_type_id(key),
+                    "cannot provision bypass-workq port {} through `Ports::get`; \
+                     it must be pre-registered via `open_message_port` in `Instance::new`",
+                    std::any::type_name::<M>()
                 );
 
                 let type_info = TypeInfo::get_by_typeid(key);

--- a/hyperactor_mesh/src/comm.rs
+++ b/hyperactor_mesh/src/comm.rs
@@ -900,7 +900,7 @@ mod tests {
                 hyperactor_config::Flattrs::new(),
                 TestMessage::Forward(payload.to_string()),
                 uuid::Uuid::new_v4(),
-                crate::ValueMesh::from_single(region, 0u64),
+                crate::ValueMesh::from_single(region, 1u64),
             )
             .unwrap();
             let frame = RoutingFrame::root(sel!(*), slice);


### PR DESCRIPTION
Summary:

When assigning seq number, by default, named message type's port, aka actor port, will share the same sequence group, because they are all sent to the actor's workq, and should be processed sequential there. However, we have 2 special types, whose messages are sent to their dedicate channels directly:

Signal

https://www.internalfb.com/code/fbsource/[cde3780c2f7f52d2f3dd9a4087295531166db2a7]/fbcode/monarch/hyperactor/src/proc.rs?lines=2199%2C2235

IntrospectMessage

https://www.internalfb.com/code/fbsource/[cde3780c2f7f52d2f3dd9a4087295531166db2a7]/fbcode/monarch/hyperactor/src/proc.rs?lines=1958-1965

As a result, these 2 message types should not share the actor workq's sequence group, because their messages will never been observed by workq.

This diff makes changes to they will use their own sequence group, scoped by their port id (i.e. `SeqKey::Port`).

# Alternatives

I considered this alternative:

Still share the same sequence group, but add a `BypassPortReceiver` for `open_message_port`. This `BypassPortReceiver` will put a `NOOP` message to `workq`, just to fill the seq gap.
 
This is actually not a bad idea. I picked this diff's implementation since this diff should be simpler to implement.

Reviewed By: mariusae

Differential Revision: D104835906


