### PR TITLE
Set the right starting seq number in assert_buffered_and_replayed (#3836)

### DIFF
--- a/hyperactor_mesh/src/comm.rs
+++ b/hyperactor_mesh/src/comm.rs
@@ -900,7 +900,7 @@ mod tests {
                 hyperactor_config::Flattrs::new(),
                 TestMessage::Forward(payload.to_string()),
                 uuid::Uuid::new_v4(),
-                crate::ValueMesh::from_single(region, 0u64),
+                crate::ValueMesh::from_single(region, 1u64),
             )
             .unwrap();
             let frame = RoutingFrame::root(sel!(*), slice);


### PR DESCRIPTION
Summary:

Surprise, surprise, sequence number is 1 indexed!

https://www.internalfb.com/code/fbsource/[ecdee6d2c09ddd1860c9b55c47757118e8f1048d]/fbcode/monarch/hyperactor/src/ordering.rs?lines=154-156

The reason this test is still passing with 0 is because the actor-side reordering buffer has not been enabled yet. I will enable it in D104596919, and it would fail there.

This diff is just to clean this up first, so it will pollute D104596919's change history.

Reviewed By: thedavekwon

Differential Revision: D104855276


