### PR TITLE
[monarch] touch files to verify extended CI label exclusions

### DIFF
--- a/hyperactor/src/lib.rs
+++ b/hyperactor/src/lib.rs
@@ -205,7 +205,7 @@ mod private {
     /// [Sealed trait pattern](https://rust-lang.github.io/api-guidelines/future-proofing.html#sealed-traits-protect-against-downstream-implementations-c-sealed).
     pub trait Sealed {}
 
-    // These two implement context capabilities:
+    // These two implement context capabilities (ci: verify extended label exclusions):
     impl<A: crate::Actor> Sealed for crate::proc::Instance<A> {}
     impl<A: crate::Actor> Sealed for &crate::proc::Instance<A> {}
     impl<A: crate::Actor> Sealed for crate::proc::Context<'_, A> {}

--- a/python/tests/test_coalescing.py
+++ b/python/tests/test_coalescing.py
@@ -44,6 +44,11 @@ def testing_context():
         yield
 
 
+# Sandcastle's overall timeout is 600s per test; set a tighter bound so timeouts
+# are counted as failures rather than silently burning the 3h job timeout.
+pytestmark = pytest.mark.timeout(120)
+
+
 class BackendType(Enum):
     PY = "py"
     RS = "rs"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #3844

Touch hyperactor (broad dep), monarch_tensor_worker, test_torchtitan, test_paft_manager, and monarch_rdma_benchmark to force BTD to select those tests. The parent commit marks them extended; this verifies they are excluded from diff CI.

Differential Revision: [D104890696](https://our.internmc.facebook.com/intern/diff/D104890696/)